### PR TITLE
fix(test): Produce summary after unit test is completed

### DIFF
--- a/scripts/setup_test_env.sh
+++ b/scripts/setup_test_env.sh
@@ -22,18 +22,23 @@ REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 if [ -z "${PIP_CONSTRAINT:-}" ]; then
   _torch_pin=$(python -c "import torch; print('torch=='+torch.__version__.split('+')[0])" 2>/dev/null || true)
   if [ -n "${_torch_pin}" ]; then
-    _constraint_file=$(mktemp /tmp/ci-torch-constraint.XXXXXX.txt)
+    _constraint_file=$(mktemp /tmp/ci-torch-constraint.XXXXXX.txt) || return $?
     echo "${_torch_pin}" > "${_constraint_file}"
+    _constraint_write_status=$?
+    if [ "${_constraint_write_status}" -ne 0 ]; then
+      rm -f "${_constraint_file}"
+      return "${_constraint_write_status}"
+    fi
     export PIP_CONSTRAINT="${_constraint_file}"
     echo "Pinning for all pip installs in this job: ${_torch_pin}"
-    unset _constraint_file
+    unset _constraint_file _constraint_write_status
   fi
   unset _torch_pin
 fi
 
 # Source the environment override file if it exists
 if [ -f "${REPO_ROOT}/ci/setup_python.env" ]; then
-  source "${REPO_ROOT}/ci/setup_python.env"
+  source "${REPO_ROOT}/ci/setup_python.env" || return $?
 fi
 
 # Override TVM-FFI if specified
@@ -41,7 +46,7 @@ if [ -n "${TVM_FFI_REF:-}" ]; then
   echo "========================================"
   echo "Overriding TVM-FFI with ref: ${TVM_FFI_REF}"
   echo "========================================"
-  pip install --force-reinstall "git+https://github.com/apache/tvm-ffi.git@${TVM_FFI_REF}"
+  pip install --force-reinstall "git+https://github.com/apache/tvm-ffi.git@${TVM_FFI_REF}" || return $?
   echo "TVM-FFI override complete."
   echo ""
 fi
@@ -60,7 +65,7 @@ if [ -n "${CUTLASS_DSL_VERSION:-}" ]; then
   echo "========================================"
   # Clean uninstall old packages first (recommended by NVIDIA docs)
   pip uninstall nvidia-cutlass-dsl nvidia-cutlass-dsl-libs-base nvidia-cutlass-dsl-libs-cu12 nvidia-cutlass-dsl-libs-cu13 -y 2>/dev/null || true
-  pip install "${CUTLASS_DSL_PKG}"
+  pip install "${CUTLASS_DSL_PKG}" || return $?
   echo "nvidia-cutlass-dsl override complete."
   echo ""
 fi

--- a/scripts/task_run_unit_tests.sh
+++ b/scripts/task_run_unit_tests.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -eo pipefail
+set -o pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 RUNNER="${SCRIPT_DIR}/unit_test_runner.py"
@@ -28,13 +28,17 @@ export SAMPLE_OFFSET
 export PARALLEL_TESTS=true
 
 # shellcheck disable=SC1091
-source "${SCRIPT_DIR}/test_utils.sh"
+source "${SCRIPT_DIR}/test_utils.sh" || exit $?
 
 main() {
     local runner_settings_output
     local -a runner_settings
     runner_settings_output=$(python "${RUNNER}" __shell-settings "$@")
-    mapfile -t runner_settings <<< "${runner_settings_output}"
+    local runner_settings_exit_code=$?
+    if [ "${runner_settings_exit_code}" -ne 0 ]; then
+        return "${runner_settings_exit_code}"
+    fi
+    mapfile -t runner_settings <<< "${runner_settings_output}" || return $?
     local operation="${runner_settings[0]}"
     TEST_PATH="${runner_settings[1]}"
 
@@ -48,14 +52,16 @@ main() {
         # nvshmem4py-cu12 pins cuda-python<=12.9. The CI image already carries
         # compatible cuda-python and NVIDIA NVSHMEM libraries, so avoid allowing
         # pip to replace the CUDA flavor while filling this one missing module.
-        python -c "import nvshmem.core" 2>/dev/null || pip install --no-deps nvshmem4py-cu12
+        if ! python -c "import nvshmem.core" 2>/dev/null; then
+            pip install --no-deps nvshmem4py-cu12 || return $?
+        fi
 
-        install_and_verify
+        install_and_verify || return $?
 
         # Apply dependency overrides after installation since pip may overwrite
         # the versions established by the CI image.
         # shellcheck disable=SC1091
-        source "${SCRIPT_DIR}/setup_test_env.sh"
+        source "${SCRIPT_DIR}/setup_test_env.sh" || return $?
 
         # tests/moe_ep needs its additional runtime stack only on CUDA 13 images.
         local cuda_major
@@ -63,7 +69,7 @@ main() {
             'import torch; v=torch.version.cuda; print(v.split(".")[0] if v else "0")' \
             2>/dev/null || echo 0)
         if [[ "${TEST_PATH:-}" == *moe_ep* ]] && [ "${cuda_major}" -ge 13 ]; then
-            FI_SRC="$(pwd)" bash docker/install/build_flashinfer_ep_pytorch.sh
+            FI_SRC="$(pwd)" bash docker/install/build_flashinfer_ep_pytorch.sh || return $?
         fi
     fi
 
@@ -73,6 +79,7 @@ main() {
 
     local runner_exit_code
     local runner_status
+    local wrapper_exit_code
     if python "${RUNNER}" "${operation}" "$@"; then
         runner_exit_code=0
     else
@@ -82,15 +89,19 @@ main() {
     case "${runner_exit_code}" in
         0)
             runner_status="complete-without-failures"
+            wrapper_exit_code=0
             ;;
         1)
             runner_status="complete-with-failures"
+            wrapper_exit_code=1
             ;;
         2)
             runner_status="incomplete-and-resumable"
+            wrapper_exit_code=0
             ;;
         3)
             runner_status="configuration-collection-or-infrastructure-error"
+            wrapper_exit_code=3
             ;;
         *)
             echo "UNIT TEST RUNNER ABNORMAL EXIT: exit_code=${runner_exit_code} wrapper_exit_code=unchanged" >&2
@@ -98,8 +109,8 @@ main() {
             ;;
     esac
 
-    echo "UNIT TEST RUNNER RESULT: exit_code=${runner_exit_code} status=${runner_status} wrapper_exit_code=0"
-    return 0
+    echo "UNIT TEST RUNNER RESULT: exit_code=${runner_exit_code} status=${runner_status} wrapper_exit_code=${wrapper_exit_code}"
+    return "${wrapper_exit_code}"
 }
 
 main "$@"

--- a/scripts/test_sharding/junit.py
+++ b/scripts/test_sharding/junit.py
@@ -11,12 +11,17 @@ from .io import atomic_write_xml
 from .models import base_function_for_nodeid, source_file_for_nodeid
 
 
+_MAX_FAILURE_REASON_CHARS = 500
+_TRUNCATION_SUFFIX = "... [truncated; see JUnit XML]"
+
+
 @dataclass(frozen=True)
 class TestCaseResult:
     nodeid: str
     source_file: str
     base_function: str
     outcome: str
+    failure_reason: str | None
     seconds: float
     synthetic: bool
 
@@ -61,6 +66,43 @@ def testcase_outcome(testcase: ET.Element) -> str:
     return "passed"
 
 
+def _normalized_reason(value: str | None) -> str:
+    return " ".join((value or "").split())
+
+
+def _bounded_reason(value: str) -> str:
+    if len(value) <= _MAX_FAILURE_REASON_CHARS:
+        return value
+    prefix_length = _MAX_FAILURE_REASON_CHARS - len(_TRUNCATION_SUFFIX)
+    return value[:prefix_length].rstrip() + _TRUNCATION_SUFFIX
+
+
+def testcase_failure_reason(testcase: ET.Element) -> str | None:
+    result = testcase.find("./failure")
+    if result is None:
+        result = testcase.find("./error")
+    if result is None:
+        return None
+
+    message = _normalized_reason(result.attrib.get("message"))
+    if message:
+        return _bounded_reason(message)
+
+    raw_lines = [
+        line.strip()
+        for value in result.itertext()
+        for line in value.splitlines()
+        if line.strip()
+    ]
+    if not raw_lines:
+        return None
+    pytest_errors = [
+        _normalized_reason(line[1:]) for line in raw_lines if line.startswith("E ")
+    ]
+    reason = pytest_errors[-1] if pytest_errors else _normalized_reason(raw_lines[-1])
+    return _bounded_reason(reason) if reason else None
+
+
 def validate_batch_xml(path: Path, expected_nodeids: Sequence[str]) -> BatchValidation:
     diagnostics: list[str] = []
     try:
@@ -91,6 +133,7 @@ def validate_batch_xml(path: Path, expected_nodeids: Sequence[str]) -> BatchVali
                     source_file=source_file_for_nodeid(nodeid),
                     base_function=base_function_for_nodeid(nodeid),
                     outcome=testcase_outcome(testcase),
+                    failure_reason=testcase_failure_reason(testcase),
                     seconds=seconds,
                     synthetic=properties.get("synthetic") == "true",
                 )

--- a/scripts/test_sharding/models.py
+++ b/scripts/test_sharding/models.py
@@ -30,6 +30,7 @@ class CollectedNode:
     order: int
     shard_group: str | None = None
     solo: bool = False
+    long_running: bool = False
 
     @classmethod
     def from_nodeid(
@@ -39,6 +40,7 @@ class CollectedNode:
         shard_group: str | None = None,
         *,
         solo: bool = False,
+        long_running: bool = False,
     ) -> "CollectedNode":
         return cls(
             nodeid=nodeid,
@@ -47,6 +49,7 @@ class CollectedNode:
             order=order,
             shard_group=shard_group,
             solo=solo,
+            long_running=long_running,
         )
 
     def to_dict(self) -> dict[str, Any]:
@@ -57,6 +60,7 @@ class CollectedNode:
             "order": self.order,
             "shard_group": self.shard_group,
             "solo": self.solo,
+            "long_running": self.long_running,
         }
 
 
@@ -185,6 +189,10 @@ class Plan:
             {node.source_file for node in self.nodes if node.solo},
             key=lambda value: value.encode("utf-8"),
         )
+        long_running_sources = sorted(
+            {node.source_file for node in self.nodes if node.long_running},
+            key=lambda value: value.encode("utf-8"),
+        )
         return {
             "schema_version": SCHEMA_VERSION,
             "algorithm_version": ALGORITHM_VERSION,
@@ -196,6 +204,7 @@ class Plan:
             ],
             "shard_groups": shard_groups,
             "solo_sources": solo_sources,
+            "long_running_sources": long_running_sources,
             "units": [
                 {
                     "id": unit.id,
@@ -248,6 +257,7 @@ class Plan:
                         order=int(node["order"]),
                         shard_group=node.get("shard_group"),
                         solo=bool(node.get("solo", False)),
+                        long_running=bool(node.get("long_running", False)),
                     )
                     for node in value["nodes"]
                 ),
@@ -272,14 +282,24 @@ class Plan:
             for index in group["node_indexes"]
         }
         solo_sources = {str(source) for source in value.get("solo_sources", [])}
+        long_running_sources = {
+            str(source) for source in value.get("long_running_sources", [])
+        }
         nodes = tuple(
             CollectedNode(
-                nodeid,
-                source_files.get(index, source_file_for_nodeid(nodeid)),
-                base_function_for_nodeid(nodeid),
-                index,
-                shard_groups.get(index),
-                source_files.get(index, source_file_for_nodeid(nodeid)) in solo_sources,
+                nodeid=nodeid,
+                source_file=source_files.get(index, source_file_for_nodeid(nodeid)),
+                base_function=base_function_for_nodeid(nodeid),
+                order=index,
+                shard_group=shard_groups.get(index),
+                solo=(
+                    source_files.get(index, source_file_for_nodeid(nodeid))
+                    in solo_sources
+                ),
+                long_running=(
+                    source_files.get(index, source_file_for_nodeid(nodeid))
+                    in long_running_sources
+                ),
             )
             for index, nodeid in enumerate(nodeids)
         )

--- a/scripts/test_sharding/pytest_plugin.py
+++ b/scripts/test_sharding/pytest_plugin.py
@@ -44,6 +44,10 @@ def pytest_configure(config: pytest.Config) -> None:
         "markers",
         "solo: run every node from this source without overlapping another local unit",
     )
+    config.addinivalue_line(
+        "markers",
+        "long_running: front-load every node from this source in the worker queues",
+    )
     config._flashinfer_sharding = {  # type: ignore[attr-defined]
         "session_start": time.time(),
         "collection_complete": None,
@@ -72,6 +76,11 @@ def pytest_collection_modifyitems(
         for item in items
         if item.get_closest_marker("solo") is not None
     }
+    long_running_sources = {
+        Path(str(item.path)).resolve()
+        for item in items
+        if item.get_closest_marker("long_running") is not None
+    }
     collected = []
     for order, item in enumerate(items):
         node = CollectedNode.from_nodeid(item.nodeid, order, _marker_name(item))
@@ -88,13 +97,14 @@ def pytest_collection_modifyitems(
                 order=node.order,
                 shard_group=node.shard_group,
                 solo=item_path in solo_sources,
+                long_running=item_path in long_running_sources,
             )
         )
     collection_path = config.getoption("--flashinfer-collection-json")
     if collection_path:
         atomic_write_json(
             Path(collection_path),
-            {"schema_version": 1, "nodes": [node.to_dict() for node in collected]},
+            {"schema_version": 2, "nodes": [node.to_dict() for node in collected]},
         )
 
     selection_path = config.getoption("--flashinfer-node-file")

--- a/scripts/test_sharding/runner.py
+++ b/scripts/test_sharding/runner.py
@@ -345,6 +345,7 @@ def _selected_nodes(
             order=int(node["order"]),
             shard_group=node.get("shard_group"),
             solo=bool(node.get("solo", False)),
+            long_running=bool(node.get("long_running", False)),
         )
         for node in raw_nodes
     ]
@@ -793,39 +794,6 @@ class _UnitTimer:
         return self.prior_elapsed + (time.monotonic() - self.started_monotonic)
 
 
-@dataclass
-class _ExecutionGate:
-    condition: threading.Condition = field(default_factory=threading.Condition)
-    regular_active: int = 0
-    solo_active: bool = False
-    solo_waiting: int = 0
-
-    def acquire(self, *, solo: bool) -> None:
-        with self.condition:
-            if solo:
-                self.solo_waiting += 1
-                try:
-                    self.condition.wait_for(
-                        lambda: not self.solo_active and self.regular_active == 0
-                    )
-                    self.solo_active = True
-                finally:
-                    self.solo_waiting -= 1
-                return
-            self.condition.wait_for(
-                lambda: not self.solo_active and self.solo_waiting == 0
-            )
-            self.regular_active += 1
-
-    def release(self, *, solo: bool) -> None:
-        with self.condition:
-            if solo:
-                self.solo_active = False
-            else:
-                self.regular_active -= 1
-            self.condition.notify_all()
-
-
 def _next_worker_unit(
     work_by_worker: list[queue.Queue[Unit]],
     worker_index: int,
@@ -851,6 +819,17 @@ def _next_worker_unit(
     raise queue.Empty
 
 
+def _next_prioritized_worker_unit(
+    long_work_by_worker: list[queue.Queue[Unit]],
+    regular_work_by_worker: list[queue.Queue[Unit]],
+    worker_index: int,
+) -> tuple[queue.Queue[Unit], Unit]:
+    try:
+        return _next_worker_unit(long_work_by_worker, worker_index)
+    except queue.Empty:
+        return _next_worker_unit(regular_work_by_worker, worker_index)
+
+
 @dataclass
 class _ShardExecutor:
     repo_root: Path
@@ -862,12 +841,26 @@ class _ShardExecutor:
     devices: list[str | None]
     heartbeat: _LeaseHeartbeat
     solo_sources: frozenset[str]
-    work_by_worker: list[queue.Queue[Unit]] = field(default_factory=list)
-    execution_gate: _ExecutionGate = field(default_factory=_ExecutionGate)
+    long_running_sources: frozenset[str]
+    long_work_by_worker: list[queue.Queue[Unit]] = field(default_factory=list)
+    regular_work_by_worker: list[queue.Queue[Unit]] = field(default_factory=list)
+    solo_units: list[Unit] = field(default_factory=list)
     infrastructure_errors: list[str] = field(default_factory=list)
     interruption_reasons: set[str] = field(default_factory=set)
     errors_lock: threading.Lock = field(default_factory=threading.Lock)
     stop_workers: threading.Event = field(default_factory=threading.Event)
+
+    def _worker_queues(self, units: list[Unit]) -> list[queue.Queue[Unit]]:
+        queues = []
+        for worker_units in source_affine_unit_bins(units, self.execution.workers):
+            work: queue.Queue[Unit] = queue.Queue()
+            for unit in sorted(
+                worker_units,
+                key=lambda item: (-item.estimated_ms, item.id.encode("utf-8")),
+            ):
+                work.put(unit)
+            queues.append(work)
+        return queues
 
     def add_units(self, units: list[Unit]) -> None:
         pending = []
@@ -878,15 +871,19 @@ class _ShardExecutor:
                 for batch in unit.batches
             ):
                 pending.append(unit)
-        self.work_by_worker = []
-        for worker_units in source_affine_unit_bins(pending, self.execution.workers):
-            work: queue.Queue[Unit] = queue.Queue()
-            for unit in sorted(
-                worker_units,
-                key=lambda item: (-item.estimated_ms, item.id.encode("utf-8")),
-            ):
-                work.put(unit)
-            self.work_by_worker.append(work)
+        self.solo_units = sorted(
+            (unit for unit in pending if self._unit_is_solo(unit)),
+            key=lambda item: (-item.estimated_ms, item.id.encode("utf-8")),
+        )
+        regular_units = [unit for unit in pending if not self._unit_is_solo(unit)]
+        long_units = [
+            unit for unit in regular_units if self._unit_is_long_running(unit)
+        ]
+        normal_units = [
+            unit for unit in regular_units if not self._unit_is_long_running(unit)
+        ]
+        self.long_work_by_worker = self._worker_queues(long_units)
+        self.regular_work_by_worker = self._worker_queues(normal_units)
 
     def run(self) -> None:
         with ThreadPoolExecutor(
@@ -906,6 +903,17 @@ class _ShardExecutor:
                     self._record_infrastructure_error(
                         f"worker-{index}: {type(error).__name__}: {error}"
                     )
+        if self.stop_workers.is_set():
+            return
+        for unit in self.solo_units:
+            try:
+                self._execute_unit(0, unit, solo=True)
+            except Exception as error:
+                self.stop_workers.set()
+                self._record_infrastructure_error(
+                    f"solo-worker: {type(error).__name__}: {error}"
+                )
+                return
 
     def _record_infrastructure_error(self, diagnostic: str) -> None:
         with self.errors_lock:
@@ -914,19 +922,25 @@ class _ShardExecutor:
     def _worker(self, index: int) -> None:
         while not self.stop_workers.is_set():
             try:
-                work, unit = _next_worker_unit(self.work_by_worker, index)
+                work, unit = _next_prioritized_worker_unit(
+                    self.long_work_by_worker,
+                    self.regular_work_by_worker,
+                    index,
+                )
             except queue.Empty:
                 return
-            solo = self._unit_is_solo(unit)
-            self.execution_gate.acquire(solo=solo)
             try:
-                self._execute_unit(index, unit, solo=solo)
+                self._execute_unit(index, unit, solo=False)
             finally:
-                self.execution_gate.release(solo=solo)
                 work.task_done()
 
     def _unit_is_solo(self, unit: Unit) -> bool:
         return any(batch.source_file in self.solo_sources for batch in unit.batches)
+
+    def _unit_is_long_running(self, unit: Unit) -> bool:
+        return any(
+            batch.source_file in self.long_running_sources for batch in unit.batches
+        )
 
     def _execute_unit(self, worker_index: int, unit: Unit, *, solo: bool) -> None:
         claim_path = claims_dir(self.junit_dir) / f"{unit.id}.json"
@@ -1290,6 +1304,9 @@ def execute_shard(
         devices=devices,
         heartbeat=leases.heartbeat,
         solo_sources=frozenset(node.source_file for node in plan.nodes if node.solo),
+        long_running_sources=frozenset(
+            node.source_file for node in plan.nodes if node.long_running
+        ),
     )
     shard_executor.add_units(shard_units)
     try:

--- a/scripts/test_sharding/runner.py
+++ b/scripts/test_sharding/runner.py
@@ -1271,6 +1271,7 @@ def execute_shard(
         {
             "shard_index": execution.shard_index,
             "workers": execution.workers,
+            "monitor_memory": execution.monitor_memory,
             "recorded_at": time.time(),
         },
     )

--- a/scripts/test_sharding/runner.py
+++ b/scripts/test_sharding/runner.py
@@ -54,6 +54,7 @@ from .summary import (
     batch_is_final,
     batch_xml_path,
     exit_code_for_summary,
+    format_test_run_summary,
     publish_summary,
     publish_summary_under_lock,
 )
@@ -127,6 +128,7 @@ def _reject_runner_path_collisions(junit_dir: Path, *, include_attempts: bool) -
     runner_paths = [
         junit_dir / "test_timings.csv",
         junit_dir / "memory_summary.csv",
+        junit_dir / "source_summary.csv",
         junit_dir / "run-summary.json",
         claims_dir(junit_dir),
         units_dir(junit_dir),
@@ -184,6 +186,26 @@ def _report_shard_status(
         f"{deadline_clock.status_fields()}",
         flush=True,
     )
+
+
+def _report_shard_terminal(
+    junit_dir: Path,
+    plan: Plan,
+    summary: RunSummary,
+    shard_index: int,
+    *,
+    state: str,
+    deadline_clock: DeadlineClock,
+    reason: str | None = None,
+) -> None:
+    _report_shard_status(
+        summary,
+        shard_index,
+        state=state,
+        deadline_clock=deadline_clock,
+        reason=reason,
+    )
+    write_console(format_test_run_summary(junit_dir, plan, shard_index=shard_index))
 
 
 def _estimate_paths(repo_root: Path) -> tuple[Path, Path]:
@@ -1130,7 +1152,9 @@ def _existing_shard_result(
         attempt_path=attempt_path,
     )
     shard_summary = summary["shards"][str(execution.shard_index)]
-    _report_shard_status(
+    _report_shard_terminal(
+        junit_dir,
+        plan,
         summary,
         execution.shard_index,
         state="completed" if shard_summary["complete"] else "incomplete",
@@ -1155,7 +1179,9 @@ def _report_shard_result(
     if shard_executor.infrastructure_errors:
         for error in shard_executor.infrastructure_errors:
             print(f"ERROR: {error}", file=sys.stderr)
-        _report_shard_status(
+        _report_shard_terminal(
+            junit_dir,
+            plan,
             summary,
             execution.shard_index,
             state="failed",
@@ -1171,7 +1197,9 @@ def _report_shard_result(
         reason = ",".join(sorted(shard_executor.interruption_reasons))
     else:
         state, reason = "incomplete", None
-    _report_shard_status(
+    _report_shard_terminal(
+        junit_dir,
+        plan,
         summary,
         execution.shard_index,
         state=state,
@@ -1207,7 +1235,9 @@ def execute_shard(
                 plan=plan,
                 attempt_path=attempts[-1],
             )
-        _report_shard_status(
+        _report_shard_terminal(
+            junit_dir,
+            plan,
             initial_summary,
             execution.shard_index,
             state="completed",

--- a/scripts/test_sharding/summary.py
+++ b/scripts/test_sharding/summary.py
@@ -122,6 +122,13 @@ class _SourceSummary:
         return "passed"
 
 
+@dataclass(frozen=True)
+class _FailedNode:
+    nodeid: str
+    reason: str
+    shard_index: int
+
+
 def batch_directory(junit_dir: Path, unit: Unit) -> Path:
     return units_dir(junit_dir) / unit.id / "batches"
 
@@ -139,12 +146,20 @@ def _sidecar(path: Path, suffix: str) -> Path:
     return path.with_name(path.stem + suffix)
 
 
-def _attempt_for_batch(path: Path) -> str:
+def _json_object(path: Path) -> dict[str, Any] | None:
     try:
-        value = json.loads(_sidecar(path, ".meta.json").read_text(encoding="utf-8"))
-        return str(value.get("attempt_id", ""))
+        value = json.loads(path.read_text(encoding="utf-8"))
+        return value if isinstance(value, dict) else None
     except (OSError, json.JSONDecodeError):
-        return ""
+        return None
+
+
+def _batch_metadata(path: Path) -> dict[str, Any]:
+    return _json_object(_sidecar(path, ".meta.json")) or {}
+
+
+def _attempt_for_batch(metadata: dict[str, Any]) -> str:
+    return str(metadata.get("attempt_id", ""))
 
 
 def _phase_results(path: Path) -> dict[str, dict[str, Any]]:
@@ -175,15 +190,19 @@ def _memory_samples(path: Path) -> list[dict[str, float]]:
     return samples
 
 
-def _process_seconds(path: Path) -> float | None:
+def _process_seconds(metadata: dict[str, Any]) -> float | None:
     try:
-        value = json.loads(_sidecar(path, ".meta.json").read_text(encoding="utf-8"))
-        launched_at = float(value["launched_at"])
-        exited_at = float(value["exited_at"])
-    except (OSError, KeyError, TypeError, ValueError, json.JSONDecodeError):
+        launched_at = float(metadata["launched_at"])
+        exited_at = float(metadata["exited_at"])
+    except (KeyError, TypeError, ValueError):
         return None
     duration = exited_at - launched_at
     return duration if math.isfinite(duration) and duration >= 0 else None
+
+
+def _batch_memory_monitoring(metadata: dict[str, Any]) -> bool:
+    configured = metadata.get("monitor_memory")
+    return configured if isinstance(configured, bool) else True
 
 
 def _max_memory(samples: list[dict[str, float]]) -> tuple[float, float]:
@@ -214,6 +233,7 @@ class _SummaryScan:
         default_factory=lambda: defaultdict(list)
     )
     sources: dict[tuple[int, str], _SourceSummary] = field(default_factory=dict)
+    failed_nodes: list[_FailedNode] = field(default_factory=list)
 
     @classmethod
     def for_plan(cls, plan: Plan) -> _SummaryScan:
@@ -278,13 +298,14 @@ def _record_final_batch(
     if not validation.valid:
         _record_pending(scan, unit, batch)
         return
-    attempt_id = _attempt_for_batch(path)
+    metadata = _batch_metadata(path)
+    attempt_id = _attempt_for_batch(metadata)
     phases = _phase_results(path)
     samples = _memory_samples(path)
     memory = _max_memory(samples)
     source = scan.sources[(unit.shard_index, batch.source_file)]
     source.finalized_nodes += len(validation.cases)
-    duration = _process_seconds(path)
+    duration = _process_seconds(metadata)
     if duration is None:
         source.partial_resources = True
     else:
@@ -294,7 +315,7 @@ def _record_final_batch(
         source.max_host_rss_mib = max(source.max_host_rss_mib, memory[0])
         source.max_gpu_memory_mib = max(source.max_gpu_memory_mib, memory[1])
         source.memory_samples += len(samples)
-    else:
+    elif _batch_memory_monitoring(metadata):
         source.partial_resources = True
     scan.batch_memory[batch.id] = memory
     scan.unit_memory[unit.id].append(memory)
@@ -308,6 +329,16 @@ def _record_final_batch(
         scan.shard_outcomes[unit.shard_index][outcome] += 1
         scan.shard_finalized[unit.shard_index] += 1
         scan.synthetic_count += int(case.synthetic)
+        if outcome == "failed":
+            scan.failed_nodes.append(
+                _FailedNode(
+                    nodeid=case.nodeid,
+                    reason=(
+                        case.failure_reason or "failure reason unavailable in JUnit XML"
+                    ),
+                    shard_index=unit.shard_index,
+                )
+            )
         scan.rows.append(
             {
                 "nodeid": case.nodeid,
@@ -339,6 +370,9 @@ def _scan_batches(junit_dir: Path, plan: Plan) -> _SummaryScan:
                 continue
             _record_final_batch(scan, unit=unit, batch=batch, path=path)
     scan.rows.sort(key=lambda row: row["nodeid"].encode("utf-8"))
+    scan.failed_nodes.sort(
+        key=lambda failed: (failed.nodeid.encode("utf-8"), failed.shard_index)
+    )
     for outcome in ("passed", "failed", "skipped"):
         scan.outcomes.setdefault(outcome, 0)
         for shard in scan.shard_outcomes.values():
@@ -459,6 +493,99 @@ def _merged_sources(
     return sorted(merged.values(), key=lambda item: item.source_file.encode("utf-8"))
 
 
+def _memory_monitoring_by_shard(
+    junit_dir: Path,
+    plan: Plan,
+) -> dict[int, str]:
+    observed: dict[int, set[bool]] = defaultdict(set)
+    unknown: set[int] = set()
+    for attempt_path in list_attempts(junit_dir):
+        for shard_index in range(plan.options.shard_count):
+            settings_path = (
+                attempt_path / "shards" / f"shard-{shard_index:04d}.settings.json"
+            )
+            if not settings_path.exists():
+                continue
+            settings = _json_object(settings_path)
+            if settings is None:
+                unknown.add(shard_index)
+                continue
+            monitor_memory = settings.get("monitor_memory")
+            if isinstance(monitor_memory, bool):
+                observed[shard_index].add(monitor_memory)
+            elif "monitor_memory" not in settings:
+                observed[shard_index].add(True)
+            else:
+                unknown.add(shard_index)
+
+    for unit in plan.units:
+        for batch in unit.batches:
+            path = batch_xml_path(junit_dir, unit, batch)
+            if not path.exists():
+                continue
+            metadata_path = _sidecar(path, ".meta.json")
+            metadata = _json_object(metadata_path)
+            if metadata is None:
+                unknown.add(unit.shard_index)
+                continue
+            if metadata.get("synthetic") is True:
+                continue
+            configured = metadata.get("monitor_memory")
+            if isinstance(configured, bool):
+                observed[unit.shard_index].add(configured)
+            elif "monitor_memory" not in metadata:
+                observed[unit.shard_index].add(True)
+            else:
+                unknown.add(unit.shard_index)
+
+    states: dict[int, str] = {}
+    for shard_index in range(plan.options.shard_count):
+        values = observed[shard_index]
+        if shard_index in unknown:
+            states[shard_index] = "unknown"
+        elif values == {False}:
+            states[shard_index] = "disabled"
+        elif values == {True}:
+            states[shard_index] = "enabled"
+        elif values:
+            states[shard_index] = "mixed"
+        else:
+            states[shard_index] = "unknown"
+    return states
+
+
+def _memory_monitoring_message(
+    junit_dir: Path,
+    plan: Plan,
+    shard_index: int | None,
+) -> str | None:
+    states = _memory_monitoring_by_shard(junit_dir, plan)
+    selected = (
+        [shard_index]
+        if shard_index is not None
+        else list(range(plan.options.shard_count))
+    )
+    disabled = [index for index in selected if states[index] == "disabled"]
+    mixed = [index for index in selected if states[index] == "mixed"]
+    unknown = [index for index in selected if states[index] == "unknown"]
+    if unknown:
+        return (
+            "Memory monitoring: mixed or unknown (shards: "
+            + ", ".join(str(index) for index in sorted({*disabled, *mixed, *unknown}))
+            + ")"
+        )
+    if disabled and len(disabled) == len(selected):
+        return "Memory monitoring: disabled"
+    affected = sorted({*disabled, *mixed})
+    if affected:
+        return (
+            "Memory monitoring: partially disabled (shards: "
+            + ", ".join(str(index) for index in affected)
+            + ")"
+        )
+    return None
+
+
 def _format_duration(seconds: float) -> str:
     total = max(0, int(round(seconds)))
     hours, remainder = divmod(total, 3600)
@@ -497,7 +624,13 @@ def format_test_run_summary(
 ) -> str:
     """Render node outcomes and source-level resources from finalized batch data."""
 
-    sources = _merged_sources(_scan_batches(junit_dir, plan), shard_index)
+    scan = _scan_batches(junit_dir, plan)
+    sources = _merged_sources(scan, shard_index)
+    failed_nodes = [
+        failed
+        for failed in scan.failed_nodes
+        if shard_index is None or failed.shard_index == shard_index
+    ]
     outcomes: Counter[str] = Counter()
     for source in sources:
         outcomes.update(source.outcomes)
@@ -510,14 +643,25 @@ def format_test_run_summary(
         separator,
         title,
         separator,
-        f"Total test files: {len(sources)}",
-        f"Total test nodes: {sum(source.planned_nodes for source in sources)}",
-        f"Passed: {outcomes['passed']}",
-        f"Failed: {outcomes['failed']}",
-        f"Skipped: {outcomes['skipped']}",
-        f"Unknown: {outcomes['unknown']}",
-        f"No result: {pending_nodes}",
     ]
+    if failed_nodes:
+        lines.append("Failed test nodes:")
+        lines.extend(
+            f"  {index}. {failed.nodeid} - {failed.reason}"
+            for index, failed in enumerate(failed_nodes, start=1)
+        )
+        lines.append("")
+    lines.extend(
+        [
+            f"Total test files: {len(sources)}",
+            f"Total test nodes: {sum(source.planned_nodes for source in sources)}",
+            f"Passed: {outcomes['passed']}",
+            f"Failed: {outcomes['failed']}",
+            f"Skipped: {outcomes['skipped']}",
+            f"Unknown: {outcomes['unknown']}",
+            f"No result: {pending_nodes}",
+        ]
+    )
     failed = [source for source in sources if source.outcomes["failed"]]
     if failed:
         lines.extend(["", "Failed test files:"])
@@ -536,6 +680,9 @@ def format_test_run_summary(
         )
 
     lines.extend(["", separator, "TEST RUN RESOURCE SUMMARY", separator])
+    monitoring_message = _memory_monitoring_message(junit_dir, plan, shard_index)
+    if monitoring_message is not None:
+        lines.append(monitoring_message)
     duration_sources = [source for source in sources if source.has_process_timing]
     memory_sources = [source for source in sources if source.memory_samples]
     if not duration_sources and not memory_sources:

--- a/scripts/test_sharding/summary.py
+++ b/scripts/test_sharding/summary.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import csv
 import io
 import json
+import math
 from collections import Counter, defaultdict
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -29,6 +30,24 @@ TIMING_HEADER = [
     "unit_id",
     "shard_index",
     "attempt_id",
+]
+
+SOURCE_SUMMARY_HEADER = [
+    "shard_index",
+    "source_file",
+    "status",
+    "planned_nodes",
+    "finalized_nodes",
+    "passed",
+    "failed",
+    "skipped",
+    "unknown",
+    "pending_nodes",
+    "process_seconds",
+    "max_host_rss_mib",
+    "max_gpu_memory_mib",
+    "memory_samples",
+    "partial_resources",
 ]
 
 
@@ -71,6 +90,36 @@ class RunSummary(TypedDict):
     capacity: CapacityMetrics
     attempts: list[AttemptSummary]
     infrastructure_errors: list[str]
+
+
+@dataclass
+class _SourceSummary:
+    shard_index: int
+    source_file: str
+    planned_nodes: int = 0
+    finalized_nodes: int = 0
+    pending_nodes: int = 0
+    outcomes: Counter[str] = field(default_factory=Counter)
+    process_seconds: float = 0.0
+    has_process_timing: bool = False
+    max_host_rss_mib: float = 0.0
+    max_gpu_memory_mib: float = 0.0
+    memory_samples: int = 0
+    partial_resources: bool = False
+
+    @property
+    def status(self) -> str:
+        if self.pending_nodes:
+            if self.outcomes["failed"]:
+                return "failed-partial"
+            if self.outcomes["unknown"]:
+                return "unknown-partial"
+            return "no-result"
+        if self.outcomes["failed"]:
+            return "failed"
+        if self.outcomes["unknown"]:
+            return "unknown"
+        return "passed"
 
 
 def batch_directory(junit_dir: Path, unit: Unit) -> Path:
@@ -126,6 +175,17 @@ def _memory_samples(path: Path) -> list[dict[str, float]]:
     return samples
 
 
+def _process_seconds(path: Path) -> float | None:
+    try:
+        value = json.loads(_sidecar(path, ".meta.json").read_text(encoding="utf-8"))
+        launched_at = float(value["launched_at"])
+        exited_at = float(value["exited_at"])
+    except (OSError, KeyError, TypeError, ValueError, json.JSONDecodeError):
+        return None
+    duration = exited_at - launched_at
+    return duration if math.isfinite(duration) and duration >= 0 else None
+
+
 def _max_memory(samples: list[dict[str, float]]) -> tuple[float, float]:
     if not samples:
         return 0.0, 0.0
@@ -153,19 +213,35 @@ class _SummaryScan:
     shard_memory: dict[int, list[tuple[float, float]]] = field(
         default_factory=lambda: defaultdict(list)
     )
+    sources: dict[tuple[int, str], _SourceSummary] = field(default_factory=dict)
 
     @classmethod
     def for_plan(cls, plan: Plan) -> _SummaryScan:
-        return cls(
+        scan = cls(
             shard_outcomes={
                 index: Counter() for index in range(plan.options.shard_count)
             }
         )
+        for unit in plan.units:
+            for batch in unit.batches:
+                key = (unit.shard_index, batch.source_file)
+                source = scan.sources.setdefault(
+                    key,
+                    _SourceSummary(
+                        shard_index=unit.shard_index,
+                        source_file=batch.source_file,
+                    ),
+                )
+                source.planned_nodes += len(batch.nodeids)
+        return scan
 
 
 def _record_pending(scan: _SummaryScan, unit: Unit, batch: Batch) -> None:
     scan.pending.extend(batch.nodeids)
     scan.shard_pending[unit.shard_index] += len(batch.nodeids)
+    source = scan.sources[(unit.shard_index, batch.source_file)]
+    source.pending_nodes += len(batch.nodeids)
+    source.partial_resources = True
 
 
 def _case_memory(
@@ -184,6 +260,13 @@ def _case_memory(
     )
 
 
+def _recorded_outcome(phase: dict[str, Any], fallback: str) -> str:
+    outcome = phase.get("outcome")
+    return (
+        outcome if outcome in {"passed", "failed", "skipped", "unknown"} else fallback
+    )
+
+
 def _record_final_batch(
     scan: _SummaryScan,
     *,
@@ -199,14 +282,30 @@ def _record_final_batch(
     phases = _phase_results(path)
     samples = _memory_samples(path)
     memory = _max_memory(samples)
+    source = scan.sources[(unit.shard_index, batch.source_file)]
+    source.finalized_nodes += len(validation.cases)
+    duration = _process_seconds(path)
+    if duration is None:
+        source.partial_resources = True
+    else:
+        source.process_seconds += duration
+        source.has_process_timing = True
+    if samples:
+        source.max_host_rss_mib = max(source.max_host_rss_mib, memory[0])
+        source.max_gpu_memory_mib = max(source.max_gpu_memory_mib, memory[1])
+        source.memory_samples += len(samples)
+    else:
+        source.partial_resources = True
     scan.batch_memory[batch.id] = memory
     scan.unit_memory[unit.id].append(memory)
     scan.shard_memory[unit.shard_index].append(memory)
     for case in validation.cases:
         phase = phases.get(case.nodeid, {})
+        outcome = _recorded_outcome(phase, case.outcome)
         scan.node_memory[case.nodeid] = _case_memory(samples, phase)
-        scan.outcomes[case.outcome] += 1
-        scan.shard_outcomes[unit.shard_index][case.outcome] += 1
+        source.outcomes[outcome] += 1
+        scan.outcomes[outcome] += 1
+        scan.shard_outcomes[unit.shard_index][outcome] += 1
         scan.shard_finalized[unit.shard_index] += 1
         scan.synthetic_count += int(case.synthetic)
         scan.rows.append(
@@ -214,7 +313,7 @@ def _record_final_batch(
                 "nodeid": case.nodeid,
                 "source_file": case.source_file,
                 "base_function": case.base_function,
-                "outcome": case.outcome,
+                "outcome": outcome,
                 "setup_seconds": phase.get("setup", 0.0),
                 "call_seconds": phase.get("call", case.seconds),
                 "teardown_seconds": phase.get("teardown", 0.0),
@@ -288,6 +387,187 @@ def _write_memory_csv(junit_dir: Path, scan: _SummaryScan) -> None:
     atomic_write_text(junit_dir / "memory_summary.csv", memory_stream.getvalue())
 
 
+def _source_csv_rows(scan: _SummaryScan) -> list[dict[str, Any]]:
+    rows = []
+    for source in sorted(
+        scan.sources.values(),
+        key=lambda item: (item.shard_index, item.source_file.encode("utf-8")),
+    ):
+        rows.append(
+            {
+                "shard_index": source.shard_index,
+                "source_file": source.source_file,
+                "status": source.status,
+                "planned_nodes": source.planned_nodes,
+                "finalized_nodes": source.finalized_nodes,
+                "passed": source.outcomes["passed"],
+                "failed": source.outcomes["failed"],
+                "skipped": source.outcomes["skipped"],
+                "unknown": source.outcomes["unknown"],
+                "pending_nodes": source.pending_nodes,
+                "process_seconds": f"{source.process_seconds:.6f}",
+                "max_host_rss_mib": f"{source.max_host_rss_mib:.3f}",
+                "max_gpu_memory_mib": f"{source.max_gpu_memory_mib:.3f}",
+                "memory_samples": source.memory_samples,
+                "partial_resources": str(source.partial_resources).lower(),
+            }
+        )
+    return rows
+
+
+def _write_source_csv(junit_dir: Path, scan: _SummaryScan) -> None:
+    source_stream = io.StringIO(newline="")
+    writer = csv.DictWriter(
+        source_stream, fieldnames=SOURCE_SUMMARY_HEADER, lineterminator="\n"
+    )
+    writer.writeheader()
+    writer.writerows(_source_csv_rows(scan))
+    atomic_write_text(junit_dir / "source_summary.csv", source_stream.getvalue())
+
+
+def _merged_sources(
+    scan: _SummaryScan,
+    shard_index: int | None,
+) -> list[_SourceSummary]:
+    selected = [
+        source
+        for source in scan.sources.values()
+        if shard_index is None or source.shard_index == shard_index
+    ]
+    if shard_index is not None:
+        return sorted(selected, key=lambda item: item.source_file.encode("utf-8"))
+    merged: dict[str, _SourceSummary] = {}
+    for source in selected:
+        target = merged.setdefault(
+            source.source_file,
+            _SourceSummary(shard_index=-1, source_file=source.source_file),
+        )
+        target.planned_nodes += source.planned_nodes
+        target.finalized_nodes += source.finalized_nodes
+        target.pending_nodes += source.pending_nodes
+        target.outcomes.update(source.outcomes)
+        target.process_seconds += source.process_seconds
+        target.has_process_timing = (
+            target.has_process_timing or source.has_process_timing
+        )
+        target.max_host_rss_mib = max(target.max_host_rss_mib, source.max_host_rss_mib)
+        target.max_gpu_memory_mib = max(
+            target.max_gpu_memory_mib, source.max_gpu_memory_mib
+        )
+        target.memory_samples += source.memory_samples
+        target.partial_resources = target.partial_resources or source.partial_resources
+    return sorted(merged.values(), key=lambda item: item.source_file.encode("utf-8"))
+
+
+def _format_duration(seconds: float) -> str:
+    total = max(0, int(round(seconds)))
+    hours, remainder = divmod(total, 3600)
+    minutes, seconds = divmod(remainder, 60)
+    if hours:
+        return f"{hours}h{minutes:02d}m{seconds:02d}s"
+    if minutes:
+        return f"{minutes}m{seconds:02d}s"
+    return f"{seconds}s"
+
+
+def _format_mib(mib: float) -> str:
+    if mib >= 1024 * 1024:
+        return f"{mib / (1024 * 1024):.1f} TiB"
+    if mib >= 1024:
+        return f"{mib / 1024:.1f} GiB"
+    return f"{int(round(mib))} MiB"
+
+
+def _format_resource_row(rank: int, source: _SourceSummary) -> str:
+    suffix = " (partial)" if source.partial_resources else ""
+    return (
+        f"  {rank:2d}. {source.source_file} - "
+        f"duration {_format_duration(source.process_seconds)}, "
+        f"peak RSS {_format_mib(source.max_host_rss_mib)}, "
+        f"peak GPU {_format_mib(source.max_gpu_memory_mib)}, "
+        f"samples {source.memory_samples}{suffix}"
+    )
+
+
+def format_test_run_summary(
+    junit_dir: Path,
+    plan: Plan,
+    *,
+    shard_index: int | None = None,
+) -> str:
+    """Render node outcomes and source-level resources from finalized batch data."""
+
+    sources = _merged_sources(_scan_batches(junit_dir, plan), shard_index)
+    outcomes: Counter[str] = Counter()
+    for source in sources:
+        outcomes.update(source.outcomes)
+    pending_nodes = sum(source.pending_nodes for source in sources)
+    separator = "=" * 42
+    title = (
+        "TEST SUMMARY" if shard_index is None else f"TEST SUMMARY - SHARD {shard_index}"
+    )
+    lines = [
+        separator,
+        title,
+        separator,
+        f"Total test files: {len(sources)}",
+        f"Total test nodes: {sum(source.planned_nodes for source in sources)}",
+        f"Passed: {outcomes['passed']}",
+        f"Failed: {outcomes['failed']}",
+        f"Skipped: {outcomes['skipped']}",
+        f"Unknown: {outcomes['unknown']}",
+        f"No result: {pending_nodes}",
+    ]
+    failed = [source for source in sources if source.outcomes["failed"]]
+    if failed:
+        lines.extend(["", "Failed test files:"])
+        lines.extend(
+            f"  - {source.source_file} - "
+            f"{source.outcomes['failed']}/{source.planned_nodes} failed"
+            for source in failed
+        )
+    pending = [source for source in sources if source.pending_nodes]
+    if pending:
+        lines.extend(["", "Test files with no result:"])
+        lines.extend(
+            f"  - {source.source_file} - "
+            f"{source.pending_nodes}/{source.planned_nodes} pending"
+            for source in pending
+        )
+
+    lines.extend(["", separator, "TEST RUN RESOURCE SUMMARY", separator])
+    duration_sources = [source for source in sources if source.has_process_timing]
+    memory_sources = [source for source in sources if source.memory_samples]
+    if not duration_sources and not memory_sources:
+        lines.append("No resource reports found for test-run resource summary.")
+        return "\n".join(lines)
+    rankings = (
+        ("Top 10 longest-running test files:", duration_sources, "process_seconds"),
+        ("Top 10 highest host RSS test files:", memory_sources, "max_host_rss_mib"),
+        (
+            "Top 10 highest GPU memory test files:",
+            memory_sources,
+            "max_gpu_memory_mib",
+        ),
+    )
+    for title, candidates, attribute in rankings:
+        if not candidates:
+            continue
+        lines.extend([title])
+        ranked = sorted(
+            candidates,
+            key=lambda source: (
+                -float(getattr(source, attribute)),
+                source.source_file.encode("utf-8"),
+            ),
+        )[:10]
+        lines.extend(
+            _format_resource_row(rank, source)
+            for rank, source in enumerate(ranked, start=1)
+        )
+    return "\n".join(lines)
+
+
 def _attempt_history(junit_dir: Path) -> tuple[list[AttemptSummary], list[Path]]:
     attempts: list[AttemptSummary] = []
     attempt_paths = list_attempts(junit_dir)
@@ -353,6 +633,7 @@ def publish_summary_under_lock(junit_dir: Path, plan: Plan) -> RunSummary:
     scan = _scan_batches(junit_dir, plan)
     _write_timing_csv(junit_dir, scan.rows)
     _write_memory_csv(junit_dir, scan)
+    _write_source_csv(junit_dir, scan)
     attempts, attempt_paths = _attempt_history(junit_dir)
     capacity = _capacity_for_latest_attempt(plan, attempt_paths)
     summary: RunSummary = {

--- a/scripts/test_sharding/workers.py
+++ b/scripts/test_sharding/workers.py
@@ -497,6 +497,7 @@ def _promote_batch_artifacts(
             "pytest_exit_code": outcome.returncode,
             "launched_at": outcome.launched_at,
             "exited_at": outcome.exited_at,
+            "monitor_memory": request.monitor_memory,
             "synthetic": False,
         },
     )

--- a/scripts/test_utils.sh
+++ b/scripts/test_utils.sh
@@ -239,6 +239,7 @@ install_precompiled_kernels() {
             pip install -q "${DIST_CUBIN_DIR}"/*.whl || return $?
         else
             echo "ERROR: flashinfer-cubin wheel not found in ${DIST_CUBIN_DIR}. Ensure the CI build stage produced the artifact." >&2
+            return 1
         fi
 
         if [ -d "${DIST_JIT_CACHE_DIR}" ] && ls "${DIST_JIT_CACHE_DIR}"/*.whl >/dev/null 2>&1; then
@@ -246,6 +247,7 @@ install_precompiled_kernels() {
             pip install -q "${DIST_JIT_CACHE_DIR}"/*.whl || return $?
         else
             echo "ERROR: flashinfer-jit-cache wheel not found in ${DIST_JIT_CACHE_DIR} for ${CUDA_VERSION}. Ensure the CI build stage produced the artifact." >&2
+            return 1
         fi
         echo ""
     fi

--- a/scripts/test_utils.sh
+++ b/scripts/test_utils.sh
@@ -37,11 +37,16 @@ export MAX_JOBS
 if [ -z "${PIP_CONSTRAINT:-}" ]; then
     _torch_pin=$(python -c "import torch; print('torch=='+torch.__version__.split('+')[0])" 2>/dev/null || true)
     if [ -n "${_torch_pin}" ]; then
-        _constraint_file=$(mktemp /tmp/ci-torch-constraint.XXXXXX.txt)
+        _constraint_file=$(mktemp /tmp/ci-torch-constraint.XXXXXX.txt) || return $?
         echo "${_torch_pin}" > "${_constraint_file}"
+        _constraint_write_status=$?
+        if [ "${_constraint_write_status}" -ne 0 ]; then
+            rm -f "${_constraint_file}"
+            return "${_constraint_write_status}"
+        fi
         export PIP_CONSTRAINT="${_constraint_file}"
         echo "Pinning for all pip installs in this job: ${_torch_pin}"
-        unset _constraint_file
+        unset _constraint_file _constraint_write_status
     fi
     unset _torch_pin
 fi
@@ -231,14 +236,14 @@ install_precompiled_kernels() {
 
         if [ -d "${DIST_CUBIN_DIR}" ] && ls "${DIST_CUBIN_DIR}"/*.whl >/dev/null 2>&1; then
             echo "Installing flashinfer-cubin from ${DIST_CUBIN_DIR} ..."
-            pip install -q "${DIST_CUBIN_DIR}"/*.whl
+            pip install -q "${DIST_CUBIN_DIR}"/*.whl || return $?
         else
             echo "ERROR: flashinfer-cubin wheel not found in ${DIST_CUBIN_DIR}. Ensure the CI build stage produced the artifact." >&2
         fi
 
         if [ -d "${DIST_JIT_CACHE_DIR}" ] && ls "${DIST_JIT_CACHE_DIR}"/*.whl >/dev/null 2>&1; then
             echo "Installing flashinfer-jit-cache from ${DIST_JIT_CACHE_DIR} ..."
-            pip install -q "${DIST_JIT_CACHE_DIR}"/*.whl
+            pip install -q "${DIST_JIT_CACHE_DIR}"/*.whl || return $?
         else
             echo "ERROR: flashinfer-jit-cache wheel not found in ${DIST_JIT_CACHE_DIR} for ${CUDA_VERSION}. Ensure the CI build stage produced the artifact." >&2
         fi
@@ -253,24 +258,24 @@ install_and_verify() {
         echo ""
 
         # Install precompiled kernels if enabled
-        install_precompiled_kernels
+        install_precompiled_kernels || return $?
 
         # Sync dependencies from the branch's requirements.txt
-        pip install -r requirements.txt
+        pip install -r requirements.txt || return $?
 
         # Install nvidia-cutlass-dsl with the correct CUDA extra to avoid
         # version skew between libs-base and libs-cu13.
         if [[ "${CUDA_VERSION}" == *"cu13"* ]]; then
-            pip install --upgrade "nvidia-cutlass-dsl[cu13]>=4.5.0"
+            pip install --upgrade "nvidia-cutlass-dsl[cu13]>=4.5.0" || return $?
         fi
 
         # Install local python sources
-        pip install -e . -v --no-deps
+        pip install -e . -v --no-deps || return $?
         echo ""
 
         # Verify installation
         echo "Verifying installation..."
-        (cd /tmp && python -m flashinfer show-config)
+        (cd /tmp && python -m flashinfer show-config) || return $?
         echo ""
     fi
 }

--- a/scripts/unit_test_runner.py
+++ b/scripts/unit_test_runner.py
@@ -40,7 +40,11 @@ from scripts.test_sharding.state import (
     RunnerStateError,
     load_manifest,
 )
-from scripts.test_sharding.summary import exit_code_for_summary, publish_summary
+from scripts.test_sharding.summary import (
+    exit_code_for_summary,
+    format_test_run_summary,
+    publish_summary,
+)
 
 
 EXIT_HELP = (
@@ -410,13 +414,25 @@ def _execute_command(args: argparse.Namespace, operation_started_at: float) -> i
         memory_interval=_env_positive_float("MEMORY_MONITOR_INTERVAL", 2),
         pytest_command_prefix=pytest_command_prefix,
     )
-    return execute_shard(
-        repo_root=REPO_ROOT,
-        junit_dir=junit_dir,
-        plan=plan,
-        execution=execution,
-        operation_started_at=operation_started_at,
-    )
+    try:
+        return execute_shard(
+            repo_root=REPO_ROOT,
+            junit_dir=junit_dir,
+            plan=plan,
+            execution=execution,
+            operation_started_at=operation_started_at,
+        )
+    except (RunnerStateError, ValueError, OSError):
+        report_shard = (
+            args.shard_index
+            if 0 <= args.shard_index < plan.options.shard_count
+            else None
+        )
+        print(
+            format_test_run_summary(junit_dir, plan, shard_index=report_shard),
+            flush=True,
+        )
+        raise
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/tests/test_sharding/test_junit.py
+++ b/tests/test_sharding/test_junit.py
@@ -66,6 +66,54 @@ def test_finalized_batch_outcomes_preserve_unknown_plugin_results(
     assert outcomes == Counter({"unknown": 1})
 
 
+def test_batch_validation_extracts_concise_failure_reasons(tmp_path: Path) -> None:
+    report = tmp_path / "batch.xml"
+    nodes = [
+        "tests/test_sample.py::test_failure",
+        "tests/test_sample.py::test_error",
+    ]
+    report.write_text(
+        """<?xml version="1.0" encoding="utf-8"?>
+<testsuites><testsuite name="pytest" tests="2" failures="1" errors="1">
+  <testcase classname="sample" name="failure"><properties><property name="pytest_nodeid" value="tests/test_sample.py::test_failure"/></properties><failure message="  AssertionError:   values differ  ">ignored traceback</failure></testcase>
+  <testcase classname="sample" name="error"><properties><property name="pytest_nodeid" value="tests/test_sample.py::test_error"/></properties><error>first traceback line
+E   RuntimeError: device unavailable
+tests/test_sample.py:12: RuntimeError
+</error></testcase>
+</testsuite></testsuites>
+""",
+        encoding="utf-8",
+    )
+
+    validation = validate_batch_xml(report, nodes)
+
+    assert validation.valid is True
+    assert [case.failure_reason for case in validation.cases] == [
+        "AssertionError: values differ",
+        "RuntimeError: device unavailable",
+    ]
+
+
+def test_batch_validation_bounds_long_failure_reasons(tmp_path: Path) -> None:
+    report = tmp_path / "batch.xml"
+    nodeid = "tests/test_sample.py::test_failure"
+    report.write_text(
+        "<testsuites><testsuite>"
+        '<testcase><properties><property name="pytest_nodeid" '
+        f'value="{nodeid}"/></properties><failure message="'
+        f"{'x' * 1000}"
+        '"/></testcase></testsuite></testsuites>',
+        encoding="utf-8",
+    )
+
+    validation = validate_batch_xml(report, [nodeid])
+
+    reason = validation.cases[0].failure_reason
+    assert reason is not None
+    assert len(reason) == 500
+    assert reason.endswith("... [truncated; see JUnit XML]")
+
+
 def test_synthetic_timeout_report_is_self_describing(tmp_path: Path) -> None:
     output = tmp_path / "synthetic.xml"
     nodes = ["tests/test_sample.py::test_a", "tests/test_sample.py::test_b"]

--- a/tests/test_sharding/test_planner.py
+++ b/tests/test_sharding/test_planner.py
@@ -22,12 +22,14 @@ def _node(
     *,
     shard_group: str | None = None,
     solo: bool = False,
+    long_running: bool = False,
 ) -> CollectedNode:
     return CollectedNode.from_nodeid(
         nodeid,
         order=order,
         shard_group=shard_group,
         solo=solo,
+        long_running=long_running,
     )
 
 
@@ -576,8 +578,16 @@ def test_soft_target_search_does_not_retry_every_intermediate_bin_count(
 
 def test_plan_serialization_stores_each_nodeid_once() -> None:
     nodes = [
-        _node("tests/test_x.py::test_known[a-very-long-parameter]", 0),
-        _node("tests/test_x.py::test_new[another-very-long-parameter]", 1),
+        _node(
+            "tests/test_x.py::test_known[a-very-long-parameter]",
+            0,
+            long_running=True,
+        ),
+        _node(
+            "tests/test_x.py::test_new[another-very-long-parameter]",
+            1,
+            long_running=True,
+        ),
     ]
     book = EstimateBook([DurationEstimate("profile", nodes[0].nodeid, 1.0, 1)])
     plan = build_plan(
@@ -598,6 +608,7 @@ def test_plan_serialization_stores_each_nodeid_once() -> None:
     assert Plan.from_dict(serialized) == plan
     assert serialized["schema_version"] == 3
     assert serialized["nodeids"] == [node.nodeid for node in nodes]
+    assert serialized["long_running_sources"] == ["tests/test_x.py"]
     assert "nodes" not in serialized
     assert "batch_ids" not in encoded
     assert all(encoded.count(node.nodeid) == 1 for node in nodes)

--- a/tests/test_sharding/test_pytest_plugin.py
+++ b/tests/test_sharding/test_pytest_plugin.py
@@ -114,3 +114,35 @@ def test_same_source():
     assert len(collection["nodes"]) == 2
     assert all(node["solo"] is True for node in collection["nodes"])
     assert "PytestUnknownMarkWarning" not in collected.stdout + collected.stderr
+
+
+def test_plugin_marks_every_node_from_a_long_running_source(tmp_path: Path) -> None:
+    test_file = tmp_path / "test_long.py"
+    test_file.write_text(
+        """\
+import pytest
+
+@pytest.mark.long_running
+def test_marked():
+    pass
+
+def test_same_source():
+    pass
+""",
+        encoding="utf-8",
+    )
+    collection_path = tmp_path / "collection.json"
+
+    collected = _pytest(
+        tmp_path,
+        "--strict-markers",
+        "--collect-only",
+        f"--flashinfer-collection-json={collection_path}",
+        str(test_file),
+    )
+
+    assert collected.returncode == 0, collected.stdout + collected.stderr
+    collection = json.loads(collection_path.read_text(encoding="utf-8"))
+    assert len(collection["nodes"]) == 2
+    assert all(node["long_running"] is True for node in collection["nodes"])
+    assert "PytestUnknownMarkWarning" not in collected.stdout + collected.stderr

--- a/tests/test_sharding/test_runner_cli.py
+++ b/tests/test_sharding/test_runner_cli.py
@@ -697,6 +697,12 @@ def test_fails():
     assert executed.returncode == 1, executed.stdout + executed.stderr
     assert "RUNNER STATUS: shard=0 state=completed" in executed.stdout
     assert "finalized=2/2 passed=1 failed=1 skipped=0 pending=0" in executed.stdout
+    assert executed.stdout.count("TEST SUMMARY - SHARD 0") == 1
+    assert "Total test files: 1" in executed.stdout
+    assert "Total test nodes: 2" in executed.stdout
+    assert "Passed: 1" in executed.stdout
+    assert "Failed: 1" in executed.stdout
+    assert f"  - {suite / 'test_sample.py'} - 1/2 failed" in executed.stdout
     summary = json.loads(
         (tmp_path / "junit" / "run-summary.json").read_text(encoding="utf-8")
     )
@@ -732,6 +738,35 @@ def test_fails():
     )
     assert repeated.returncode == 1
     assert len(list((tmp_path / "junit" / "attempts").glob("attempt-*"))) == 1
+
+
+def test_post_collection_setup_failure_prints_the_test_summary(tmp_path: Path) -> None:
+    suite = tmp_path / "suite"
+    suite.mkdir()
+    (suite / "test_sample.py").write_text("def test_passes(): pass\n", encoding="utf-8")
+
+    result = _run(tmp_path, "run", suite, "--workers", "999")
+
+    assert result.returncode == 3
+    assert result.stdout.count("TEST SUMMARY - SHARD 0") == 1
+    assert "Total test files: 1" in result.stdout
+    assert "Total test nodes: 1" in result.stdout
+    assert "No result: 1" in result.stdout
+
+
+def test_invalid_shard_index_prints_an_unscoped_test_summary(tmp_path: Path) -> None:
+    suite = tmp_path / "suite"
+    suite.mkdir()
+    (suite / "test_sample.py").write_text("def test_passes(): pass\n", encoding="utf-8")
+
+    result = _run(tmp_path, "run", suite, "--shard-index", "999")
+
+    assert result.returncode == 3
+    assert "TEST SUMMARY\n" in result.stdout
+    assert "TEST SUMMARY - SHARD 999" not in result.stdout
+    assert "Total test files: 1" in result.stdout
+    assert "Total test nodes: 1" in result.stdout
+    assert "No result: 1" in result.stdout
 
 
 def test_unit_progress_omits_skipped_results_and_reports_all_outcomes(
@@ -1065,6 +1100,11 @@ def test_timeout_policy_resume_starts_a_new_attempt_without_fake_results(
     assert "node=test_slow.py::test_slow" in first.stdout
     assert "RUNNER STATUS: shard=0 state=interrupted" in first.stdout
     assert "reason=unit-timeout" in first.stdout
+    assert first.stdout.count("TEST SUMMARY - SHARD 0") == 1
+    assert "Total test files: 1" in first.stdout
+    assert "Total test nodes: 1" in first.stdout
+    assert "No result: 1" in first.stdout
+    assert f"  - {suite / 'test_slow.py'} - 1/1 pending" in first.stdout
     assert not list((tmp_path / "junit").glob("unit-*.xml"))
     attempts = list((tmp_path / "junit" / "attempts").glob("attempt-*"))
     assert len(attempts) == 2

--- a/tests/test_sharding/test_runner_cli.py
+++ b/tests/test_sharding/test_runner_cli.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import csv
 import json
 import os
 import queue
@@ -769,6 +770,42 @@ def test_invalid_shard_index_prints_an_unscoped_test_summary(tmp_path: Path) -> 
     assert "No result: 1" in result.stdout
 
 
+def test_disabled_memory_monitoring_is_persisted_and_reported(tmp_path: Path) -> None:
+    suite = tmp_path / "suite"
+    suite.mkdir()
+    (suite / "test_sample.py").write_text("def test_passes(): pass\n", encoding="utf-8")
+
+    result = _run(
+        tmp_path,
+        "run",
+        suite,
+        env_override={"MONITOR_TEST_MEMORY": "0"},
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "Memory monitoring: disabled" in result.stdout
+    assert "samples 0 (partial)" not in result.stdout
+    [metadata_path] = list((tmp_path / "junit").glob("units/*/batches/*.meta.json"))
+    metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+    assert metadata["monitor_memory"] is False
+    settings = json.loads(
+        (
+            tmp_path
+            / "junit"
+            / "attempts"
+            / "attempt-0001"
+            / "shards"
+            / "shard-0000.settings.json"
+        ).read_text(encoding="utf-8")
+    )
+    assert settings["monitor_memory"] is False
+    with (tmp_path / "junit" / "source_summary.csv").open(
+        newline="", encoding="utf-8"
+    ) as stream:
+        [source] = list(csv.DictReader(stream))
+    assert source["partial_resources"] == "false"
+
+
 def test_unit_progress_omits_skipped_results_and_reports_all_outcomes(
     tmp_path: Path,
 ) -> None:
@@ -1053,6 +1090,7 @@ def test_terminal_timeout_policies_synthesize_junit(
         "0",
         "--timeout-policy",
         policy,
+        env_override={"MONITOR_TEST_MEMORY": "false"},
     )
 
     assert result.returncode == expected_code, result.stdout + result.stderr
@@ -1068,6 +1106,7 @@ def test_terminal_timeout_policies_synthesize_junit(
         else "passed=0 failed=0 skipped=1 unknown=0"
     )
     assert expected_counts in result.stdout
+    assert "Memory monitoring: disabled" in result.stdout
     assert "completed_nodes=1/1" in result.stdout
     assert len(summary["attempts"][0]["unit_timeout_events"]) == 1
     assert summary["attempts"][0]["unit_timeout_events"][0]["timeout_policy"] == policy

--- a/tests/test_sharding/test_runner_cli.py
+++ b/tests/test_sharding/test_runner_cli.py
@@ -88,6 +88,33 @@ def test_worker_unit_stealing_drains_queued_units_exactly_once() -> None:
     assert all(work.unfinished_tasks == 0 for work in work_by_worker)
 
 
+def test_worker_steals_queued_long_unit_before_local_normal_unit() -> None:
+    long_work_by_worker = [queue.Queue() for _ in range(2)]
+    regular_work_by_worker = [queue.Queue() for _ in range(2)]
+    long_work_by_worker[0].put(_queue_test_unit("remote-long"))
+    regular_work_by_worker[1].put(_queue_test_unit("local-normal"))
+
+    long_queue, long_unit = runner._next_prioritized_worker_unit(
+        long_work_by_worker,
+        regular_work_by_worker,
+        1,
+    )
+
+    assert long_queue is long_work_by_worker[0]
+    assert long_unit.id == "remote-long"
+    long_queue.task_done()
+
+    normal_queue, normal_unit = runner._next_prioritized_worker_unit(
+        long_work_by_worker,
+        regular_work_by_worker,
+        1,
+    )
+
+    assert normal_queue is regular_work_by_worker[1]
+    assert normal_unit.id == "local-normal"
+    normal_queue.task_done()
+
+
 def test_compatibility_defaults_use_file_sized_units_without_time_limits(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -931,7 +958,7 @@ from pathlib import Path
 
 import pytest
 
-pytestmark = pytest.mark.solo
+pytestmark = [pytest.mark.solo, pytest.mark.long_running]
 
 @pytest.fixture(scope="module", autouse=True)
 def exclusive_source():
@@ -996,6 +1023,86 @@ def test_regular():
     assert result.returncode == 0, result.stdout + result.stderr
     assert (state / "solo-devices").read_text(encoding="utf-8") == "0,1"
     assert (state / "regular-devices").read_text(encoding="utf-8") in {"0", "1"}
+
+
+def test_long_running_sources_start_before_normal_work_and_solo_runs_last(
+    tmp_path: Path,
+) -> None:
+    suite = tmp_path / "suite"
+    suite.mkdir()
+    state = tmp_path / "schedule-state"
+    state.mkdir()
+    order = state / "order.txt"
+
+    for name, other in (("long-a", "long-b"), ("long-b", "long-a")):
+        (suite / f"test_{name.replace('-', '_')}.py").write_text(
+            f'''\
+import os
+import time
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.long_running
+
+def test_case():
+    state = Path(os.environ["SCHEDULE_STATE"])
+    with (state / "order.txt").open("a", encoding="utf-8") as stream:
+        stream.write("{name}\\n")
+    (state / "{name}.started").write_text("started", encoding="utf-8")
+    deadline = time.monotonic() + 10
+    while not (state / "{other}.started").exists():
+        assert time.monotonic() < deadline, "other long-running unit did not start"
+        time.sleep(0.01)
+''',
+            encoding="utf-8",
+        )
+
+    (suite / "test_normal.py").write_text(
+        """\
+import os
+from pathlib import Path
+
+def test_case():
+    state = Path(os.environ["SCHEDULE_STATE"])
+    with (state / "order.txt").open("a", encoding="utf-8") as stream:
+        stream.write("normal\\n")
+""",
+        encoding="utf-8",
+    )
+    (suite / "test_solo.py").write_text(
+        """\
+import os
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.solo
+
+def test_case():
+    state = Path(os.environ["SCHEDULE_STATE"])
+    with (state / "order.txt").open("a", encoding="utf-8") as stream:
+        stream.write("solo\\n")
+""",
+        encoding="utf-8",
+    )
+
+    result = _run(
+        tmp_path,
+        "run",
+        suite,
+        "--workers",
+        "2",
+        env_override={
+            "CUDA_VISIBLE_DEVICES": "0,1",
+            "SCHEDULE_STATE": str(state),
+        },
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    observed = order.read_text(encoding="utf-8").splitlines()
+    assert set(observed[:2]) == {"long-a", "long-b"}
+    assert observed[2:] == ["normal", "solo"]
 
 
 def test_run_records_the_shared_attempt_before_pytest_collection(

--- a/tests/test_sharding/test_summary.py
+++ b/tests/test_sharding/test_summary.py
@@ -7,6 +7,7 @@ from collections.abc import Iterator
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
 from pathlib import Path
+from xml.sax.saxutils import quoteattr
 
 import pytest
 
@@ -31,6 +32,8 @@ def _write_final_batch(
     launched_at: float,
     exited_at: float,
     memory: list[tuple[float, float, float]],
+    monitor_memory: bool | None = True,
+    failure_reasons: dict[str, str] | None = None,
 ) -> None:
     path = batch_xml_path(junit_dir, unit, batch)
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -38,7 +41,7 @@ def _write_final_batch(
     for nodeid in batch.nodeids:
         outcome = outcomes[nodeid]
         result = (
-            '<failure message="failed"/>'
+            f"<failure message={quoteattr((failure_reasons or {}).get(nodeid, 'failed'))}/>"
             if outcome == "failed"
             else '<skipped message="skipped"/>'
             if outcome == "skipped"
@@ -54,14 +57,15 @@ def _write_final_batch(
         f'{len(batch.nodeids)}">{"".join(testcases)}</testsuite></testsuites>',
         encoding="utf-8",
     )
+    metadata = {
+        "attempt_id": "attempt-1",
+        "launched_at": launched_at,
+        "exited_at": exited_at,
+    }
+    if monitor_memory is not None:
+        metadata["monitor_memory"] = monitor_memory
     path.with_name(f"{batch.id}.meta.json").write_text(
-        json.dumps(
-            {
-                "attempt_id": "attempt-1",
-                "launched_at": launched_at,
-                "exited_at": exited_at,
-            }
-        ),
+        json.dumps(metadata),
         encoding="utf-8",
     )
     path.with_name(f"{batch.id}.results.json").write_text(
@@ -181,6 +185,12 @@ def test_console_summary_counts_nodes_and_aggregates_failed_files(
         launched_at=20,
         exited_at=143,
         memory=[(21, 2048, 4096)],
+        failure_reasons={
+            alpha_second_batch.nodeids[0]: (
+                "AssertionError: quantized output element mismatch: "
+                "64/256 elements differ"
+            )
+        },
     )
     _write_final_batch(
         tmp_path,
@@ -206,6 +216,13 @@ def test_console_summary_counts_nodes_and_aggregates_failed_files(
     assert "Skipped: 1" in report
     assert "Unknown: 1" in report
     assert "No result: 2" in report
+    assert (
+        "Failed test nodes:\n"
+        "  1. tests/test_alpha.py::test_case[1] - "
+        "AssertionError: quantized output element mismatch: "
+        "64/256 elements differ" in report
+    )
+    assert report.index("Failed test nodes:") < report.index("Total test files:")
     assert "  - tests/test_alpha.py - 1/3 failed" in report
     assert "  - tests/test_alpha.py - 1/3 pending" in report
     assert "  - tests/test_beta.py - 1/1 pending" in report
@@ -314,3 +331,235 @@ def test_global_summary_merges_a_source_split_across_shards(tmp_path: Path) -> N
         ("0", "tests/test_split.py"),
         ("1", "tests/test_split.py"),
     ]
+
+
+def test_failed_nodes_are_all_numbered_in_nodeid_order_and_scoped_to_shard(
+    tmp_path: Path,
+) -> None:
+    nodes = tuple(
+        CollectedNode.from_nodeid(f"tests/test_failed.py::test_case[{index}]", index)
+        for index in (1, 0)
+    )
+    units = []
+    for shard_index, node in enumerate(nodes):
+        batch = Batch(
+            id=f"batch-failed-{shard_index}",
+            source_file=node.source_file,
+            nodeids=(node.nodeid,),
+            estimated_ms=1000,
+            overhead_ms=0,
+            oversized=False,
+        )
+        unit = Unit(
+            id=f"unit-failed-{shard_index}",
+            batches=(batch,),
+            estimated_ms=1000,
+            oversized=False,
+            shard_index=shard_index,
+        )
+        units.append(unit)
+        _write_final_batch(
+            tmp_path,
+            unit,
+            batch,
+            {node.nodeid: "failed"},
+            launched_at=10,
+            exited_at=20,
+            memory=[],
+            failure_reasons={node.nodeid: f"reason {node.order}"},
+        )
+    plan = Plan(
+        options=PlanningOptions(profile="synthetic", shard_count=2),
+        nodes=nodes,
+        units=tuple(units),
+    )
+
+    global_report = summary_module.format_test_run_summary(tmp_path, plan)
+    shard_report = summary_module.format_test_run_summary(tmp_path, plan, shard_index=0)
+
+    first = "  1. tests/test_failed.py::test_case[0] - reason 0"
+    second = "  2. tests/test_failed.py::test_case[1] - reason 1"
+    assert first in global_report
+    assert second in global_report
+    assert global_report.index(first) < global_report.index(second)
+    assert "  1. tests/test_failed.py::test_case[1] - reason 1" in shard_report
+    assert "test_case[0] - reason 0" not in shard_report
+
+
+def test_disabled_memory_monitoring_is_reported_and_not_partial(
+    tmp_path: Path,
+) -> None:
+    node = CollectedNode.from_nodeid("tests/test_nomem.py::test_case", 0)
+    batch = Batch(
+        id="batch-nomem",
+        source_file=node.source_file,
+        nodeids=(node.nodeid,),
+        estimated_ms=1000,
+        overhead_ms=0,
+        oversized=False,
+    )
+    unit = Unit(
+        id="unit-nomem",
+        batches=(batch,),
+        estimated_ms=1000,
+        oversized=False,
+        shard_index=0,
+    )
+    plan = Plan(
+        options=PlanningOptions(profile="synthetic"),
+        nodes=(node,),
+        units=(unit,),
+    )
+    _write_final_batch(
+        tmp_path,
+        unit,
+        batch,
+        {node.nodeid: "passed"},
+        launched_at=10,
+        exited_at=25,
+        memory=[],
+        monitor_memory=False,
+    )
+
+    report = summary_module.format_test_run_summary(tmp_path, plan, shard_index=0)
+
+    assert "Memory monitoring: disabled" in report
+    assert (
+        "tests/test_nomem.py - duration 15s, peak RSS 0 MiB, "
+        "peak GPU 0 MiB, samples 0" in report
+    )
+    assert "samples 0 (partial)" not in report
+
+    summary_module.publish_summary(tmp_path, plan)
+    with (tmp_path / "source_summary.csv").open(newline="", encoding="utf-8") as stream:
+        [row] = list(csv.DictReader(stream))
+    assert row["partial_resources"] == "false"
+
+
+def test_legacy_batch_without_monitoring_metadata_is_conservatively_partial(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    node = CollectedNode.from_nodeid("tests/test_legacy.py::test_case", 0)
+    batch = Batch(
+        id="batch-legacy",
+        source_file=node.source_file,
+        nodeids=(node.nodeid,),
+        estimated_ms=1000,
+        overhead_ms=0,
+        oversized=False,
+    )
+    unit = Unit(
+        id="unit-legacy",
+        batches=(batch,),
+        estimated_ms=1000,
+        oversized=False,
+        shard_index=0,
+    )
+    plan = Plan(
+        options=PlanningOptions(profile="synthetic"),
+        nodes=(node,),
+        units=(unit,),
+    )
+    _write_final_batch(
+        tmp_path,
+        unit,
+        batch,
+        {node.nodeid: "passed"},
+        launched_at=10,
+        exited_at=25,
+        memory=[],
+        monitor_memory=None,
+    )
+
+    monkeypatch.setenv("MONITOR_TEST_MEMORY", "0")
+    disabled_environment = summary_module.format_test_run_summary(
+        tmp_path, plan, shard_index=0
+    )
+    monkeypatch.setenv("MONITOR_TEST_MEMORY", "true")
+    enabled_environment = summary_module.format_test_run_summary(
+        tmp_path, plan, shard_index=0
+    )
+
+    assert disabled_environment == enabled_environment
+    assert "Memory monitoring: disabled" not in disabled_environment
+    assert "samples 0 (partial)" in disabled_environment
+
+
+@pytest.mark.parametrize("attempt_values", [(False, True), (True, False)])
+def test_resumed_attempts_report_mixed_memory_monitoring_deterministically(
+    tmp_path: Path,
+    attempt_values: tuple[bool, bool],
+) -> None:
+    node = CollectedNode.from_nodeid("tests/test_pending.py::test_case", 0)
+    batch = Batch(
+        id="batch-pending",
+        source_file=node.source_file,
+        nodeids=(node.nodeid,),
+        estimated_ms=1000,
+        overhead_ms=0,
+        oversized=False,
+    )
+    plan = Plan(
+        options=PlanningOptions(profile="synthetic"),
+        nodes=(node,),
+        units=(
+            Unit(
+                id="unit-pending",
+                batches=(batch,),
+                estimated_ms=1000,
+                oversized=False,
+                shard_index=0,
+            ),
+        ),
+    )
+    for number, monitor_memory in enumerate(attempt_values, start=1):
+        attempt = tmp_path / "attempts" / f"attempt-{number:04d}"
+        shard_settings = attempt / "shards" / "shard-0000.settings.json"
+        shard_settings.parent.mkdir(parents=True)
+        (attempt / "attempt.json").write_text("{}", encoding="utf-8")
+        shard_settings.write_text(
+            json.dumps({"monitor_memory": monitor_memory}), encoding="utf-8"
+        )
+
+    report = summary_module.format_test_run_summary(tmp_path, plan, shard_index=0)
+
+    assert "Memory monitoring: partially disabled (shards: 0)" in report
+
+
+def test_malformed_memory_monitoring_settings_are_reported_as_unknown(
+    tmp_path: Path,
+) -> None:
+    plan = Plan(
+        options=PlanningOptions(profile="synthetic"),
+        nodes=(),
+        units=(),
+    )
+    attempt = tmp_path / "attempts" / "attempt-0001"
+    settings = attempt / "shards" / "shard-0000.settings.json"
+    settings.parent.mkdir(parents=True)
+    (attempt / "attempt.json").write_text("{}", encoding="utf-8")
+    settings.write_text("[]", encoding="utf-8")
+
+    report = summary_module.format_test_run_summary(tmp_path, plan, shard_index=0)
+
+    assert "Memory monitoring: mixed or unknown (shards: 0)" in report
+
+
+def test_no_monitoring_evidence_is_environment_independent(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    plan = _summary_plan()
+
+    monkeypatch.setenv("MONITOR_TEST_MEMORY", "0")
+    disabled_environment = summary_module.format_test_run_summary(
+        tmp_path, plan, shard_index=0
+    )
+    monkeypatch.setenv("MONITOR_TEST_MEMORY", "true")
+    enabled_environment = summary_module.format_test_run_summary(
+        tmp_path, plan, shard_index=0
+    )
+
+    assert disabled_environment == enabled_environment
+    assert "Memory monitoring: mixed or unknown (shards: 0)" in disabled_environment

--- a/tests/test_sharding/test_summary.py
+++ b/tests/test_sharding/test_summary.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import csv
+import json
 import threading
 from collections.abc import Iterator
 from concurrent.futures import ThreadPoolExecutor
@@ -9,8 +11,118 @@ from pathlib import Path
 import pytest
 
 from scripts.test_sharding import summary as summary_module
-from scripts.test_sharding.models import Plan, PlanningOptions
+from scripts.test_sharding.models import (
+    Batch,
+    CollectedNode,
+    Plan,
+    PlanningOptions,
+    Unit,
+)
 from scripts.test_sharding.state import state_lock
+from scripts.test_sharding.summary import batch_xml_path
+
+
+def _write_final_batch(
+    junit_dir: Path,
+    unit: Unit,
+    batch: Batch,
+    outcomes: dict[str, str],
+    *,
+    launched_at: float,
+    exited_at: float,
+    memory: list[tuple[float, float, float]],
+) -> None:
+    path = batch_xml_path(junit_dir, unit, batch)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    testcases = []
+    for nodeid in batch.nodeids:
+        outcome = outcomes[nodeid]
+        result = (
+            '<failure message="failed"/>'
+            if outcome == "failed"
+            else '<skipped message="skipped"/>'
+            if outcome == "skipped"
+            else ""
+        )
+        testcases.append(
+            '<testcase classname="sample" name="case" time="1">'
+            f'<properties><property name="pytest_nodeid" value="{nodeid}"/>'
+            f"</properties>{result}</testcase>"
+        )
+    path.write_text(
+        '<testsuites><testsuite name="pytest" tests="'
+        f'{len(batch.nodeids)}">{"".join(testcases)}</testsuite></testsuites>',
+        encoding="utf-8",
+    )
+    path.with_name(f"{batch.id}.meta.json").write_text(
+        json.dumps(
+            {
+                "attempt_id": "attempt-1",
+                "launched_at": launched_at,
+                "exited_at": exited_at,
+            }
+        ),
+        encoding="utf-8",
+    )
+    path.with_name(f"{batch.id}.results.json").write_text(
+        json.dumps(
+            {
+                "results": [
+                    {"nodeid": nodeid, "outcome": outcomes[nodeid]}
+                    for nodeid in batch.nodeids
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    with path.with_name(f"{batch.id}.memory.csv").open(
+        "w", newline="", encoding="utf-8"
+    ) as stream:
+        writer = csv.writer(stream)
+        writer.writerow(["timestamp", "host_rss_mib", "gpu_memory_mib"])
+        writer.writerows(memory)
+
+
+def _summary_plan() -> Plan:
+    alpha_nodes = tuple(
+        CollectedNode.from_nodeid(f"tests/test_alpha.py::test_case[{index}]", index)
+        for index in range(3)
+    )
+    beta_node = CollectedNode.from_nodeid("tests/test_beta.py::test_pending", 3)
+    gamma_nodes = tuple(
+        CollectedNode.from_nodeid(f"tests/test_gamma.py::test_case[{index}]", index + 4)
+        for index in range(3)
+    )
+
+    def unit(identifier: str, nodes: tuple[CollectedNode, ...]) -> Unit:
+        batch = Batch(
+            id=f"batch-{identifier}",
+            source_file=nodes[0].source_file,
+            nodeids=tuple(node.nodeid for node in nodes),
+            estimated_ms=1000,
+            overhead_ms=0,
+            oversized=False,
+        )
+        return Unit(
+            id=f"unit-{identifier}",
+            batches=(batch,),
+            estimated_ms=1000,
+            oversized=False,
+            shard_index=0,
+        )
+
+    nodes = (*alpha_nodes, beta_node, *gamma_nodes)
+    return Plan(
+        options=PlanningOptions(profile="synthetic"),
+        nodes=nodes,
+        units=(
+            unit("alpha-0", alpha_nodes[:1]),
+            unit("alpha-1", alpha_nodes[1:2]),
+            unit("alpha-2", alpha_nodes[2:]),
+            unit("beta", (beta_node,)),
+            unit("gamma", gamma_nodes),
+        ),
+    )
 
 
 def test_summary_publication_waits_for_the_state_lock(
@@ -42,3 +154,163 @@ def test_summary_publication_waits_for_the_state_lock(
 
     assert summary["complete"] is True
     assert summary["schema_version"] == 2
+
+
+def test_console_summary_counts_nodes_and_aggregates_failed_files(
+    tmp_path: Path,
+) -> None:
+    plan = _summary_plan()
+    alpha_first_unit, alpha_second_unit, _, _, gamma_unit = plan.units
+    alpha_first_batch = alpha_first_unit.batches[0]
+    alpha_second_batch = alpha_second_unit.batches[0]
+    gamma_batch = gamma_unit.batches[0]
+    _write_final_batch(
+        tmp_path,
+        alpha_first_unit,
+        alpha_first_batch,
+        {alpha_first_batch.nodeids[0]: "passed"},
+        launched_at=10,
+        exited_at=3610,
+        memory=[(11, 1024, 2048)],
+    )
+    _write_final_batch(
+        tmp_path,
+        alpha_second_unit,
+        alpha_second_batch,
+        {alpha_second_batch.nodeids[0]: "failed"},
+        launched_at=20,
+        exited_at=143,
+        memory=[(21, 2048, 4096)],
+    )
+    _write_final_batch(
+        tmp_path,
+        gamma_unit,
+        gamma_batch,
+        {
+            gamma_batch.nodeids[0]: "passed",
+            gamma_batch.nodeids[1]: "skipped",
+            gamma_batch.nodeids[2]: "unknown",
+        },
+        launched_at=20,
+        exited_at=80,
+        memory=[],
+    )
+
+    report = summary_module.format_test_run_summary(tmp_path, plan, shard_index=0)
+
+    assert "TEST SUMMARY - SHARD 0" in report
+    assert "Total test files: 3" in report
+    assert "Total test nodes: 7" in report
+    assert "Passed: 2" in report
+    assert "Failed: 1" in report
+    assert "Skipped: 1" in report
+    assert "Unknown: 1" in report
+    assert "No result: 2" in report
+    assert "  - tests/test_alpha.py - 1/3 failed" in report
+    assert "  - tests/test_alpha.py - 1/3 pending" in report
+    assert "  - tests/test_beta.py - 1/1 pending" in report
+    assert "Top 10 longest-running test files:" in report
+    assert (
+        "tests/test_alpha.py - duration 1h02m03s, peak RSS 2.0 GiB, "
+        "peak GPU 4.0 GiB, samples 2" in report
+    )
+    longest_section = report.split("Top 10 longest-running test files:", 1)[1].split(
+        "Top 10 highest host RSS test files:", 1
+    )[0]
+    host_rss_section = report.split("Top 10 highest host RSS test files:", 1)[1]
+    assert "tests/test_gamma.py" in longest_section
+    assert "tests/test_gamma.py" not in host_rss_section
+
+    summary_module.publish_summary(tmp_path, plan)
+    with (tmp_path / "source_summary.csv").open(newline="", encoding="utf-8") as stream:
+        rows = {row["source_file"]: row for row in csv.DictReader(stream)}
+    assert rows["tests/test_alpha.py"]["status"] == "failed-partial"
+    assert rows["tests/test_alpha.py"]["finalized_nodes"] == "2"
+    assert rows["tests/test_alpha.py"]["pending_nodes"] == "1"
+
+
+def test_publish_summary_writes_shard_source_csv(tmp_path: Path) -> None:
+    plan = _summary_plan()
+
+    summary_module.publish_summary(tmp_path, plan)
+
+    with (tmp_path / "source_summary.csv").open(newline="", encoding="utf-8") as stream:
+        rows = list(csv.DictReader(stream))
+    assert [row["source_file"] for row in rows] == [
+        "tests/test_alpha.py",
+        "tests/test_beta.py",
+        "tests/test_gamma.py",
+    ]
+    assert rows[0]["shard_index"] == "0"
+    assert rows[0]["planned_nodes"] == "3"
+    assert rows[1]["pending_nodes"] == "1"
+
+
+def test_global_summary_merges_a_source_split_across_shards(tmp_path: Path) -> None:
+    nodes = tuple(
+        CollectedNode.from_nodeid(f"tests/test_split.py::test_case[{index}]", index)
+        for index in range(2)
+    )
+    units = []
+    for shard_index, node in enumerate(nodes):
+        batch = Batch(
+            id=f"batch-{shard_index}",
+            source_file=node.source_file,
+            nodeids=(node.nodeid,),
+            estimated_ms=1000,
+            overhead_ms=0,
+            oversized=False,
+        )
+        units.append(
+            Unit(
+                id=f"unit-{shard_index}",
+                batches=(batch,),
+                estimated_ms=1000,
+                oversized=False,
+                shard_index=shard_index,
+            )
+        )
+    plan = Plan(
+        options=PlanningOptions(profile="synthetic", shard_count=2),
+        nodes=nodes,
+        units=tuple(units),
+    )
+    _write_final_batch(
+        tmp_path,
+        units[0],
+        units[0].batches[0],
+        {nodes[0].nodeid: "failed"},
+        launched_at=10,
+        exited_at=40,
+        memory=[(11, 100, 200)],
+    )
+    _write_final_batch(
+        tmp_path,
+        units[1],
+        units[1].batches[0],
+        {nodes[1].nodeid: "passed"},
+        launched_at=20,
+        exited_at=80,
+        memory=[(21, 300, 150)],
+    )
+
+    report = summary_module.format_test_run_summary(tmp_path, plan)
+
+    assert "TEST SUMMARY\n" in report
+    assert "Total test files: 1" in report
+    assert "Total test nodes: 2" in report
+    assert "Passed: 1" in report
+    assert "Failed: 1" in report
+    assert "  - tests/test_split.py - 1/2 failed" in report
+    assert (
+        "tests/test_split.py - duration 1m30s, peak RSS 300 MiB, "
+        "peak GPU 200 MiB, samples 2" in report
+    )
+
+    summary_module.publish_summary(tmp_path, plan)
+    with (tmp_path / "source_summary.csv").open(newline="", encoding="utf-8") as stream:
+        rows = list(csv.DictReader(stream))
+    assert [(row["shard_index"], row["source_file"]) for row in rows] == [
+        ("0", "tests/test_split.py"),
+        ("1", "tests/test_split.py"),
+    ]

--- a/tests/test_sharding/test_task_run_unit_tests_shell.py
+++ b/tests/test_sharding/test_task_run_unit_tests_shell.py
@@ -111,6 +111,7 @@ def test_wrapper_does_not_enable_bash_errexit() -> None:
 
     assert "set -e" not in source
     assert "set -eo" not in source
+    assert "set -o errexit" not in source
 
 
 @pytest.mark.parametrize(

--- a/tests/test_sharding/test_task_run_unit_tests_shell.py
+++ b/tests/test_sharding/test_task_run_unit_tests_shell.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "task_run_unit_tests.sh"
+
+
+def _run_wrapper(
+    tmp_path: Path, **environment: str
+) -> subprocess.CompletedProcess[str]:
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    python = fake_bin / "python"
+    python.write_text(
+        """\
+#!/bin/bash
+if [ "${2:-}" = "__shell-settings" ]; then
+    settings_rc="${SHELL_SETTINGS_RC:-0}"
+    if [ "${settings_rc}" -ne 0 ]; then
+        echo "fake argparse error" >&2
+        exit "${settings_rc}"
+    fi
+    printf '%s\\n%s\\n' "${RUNNER_OPERATION:-plan}" "tests/"
+    exit 0
+fi
+if [ "${1:-}" = "-c" ]; then
+    exit "${PYTHON_IMPORT_RC:-0}"
+fi
+if [ -n "${RUNNER_SIGNAL:-}" ]; then
+    kill -s "${RUNNER_SIGNAL}" "$$"
+fi
+exit "${RUNNER_RC:-0}"
+""",
+        encoding="utf-8",
+    )
+    python.chmod(0o755)
+    pip = fake_bin / "pip"
+    pip.write_text('#!/bin/bash\nexit "${PIP_RC:-0}"\n', encoding="utf-8")
+    pip.chmod(0o755)
+    env = os.environ.copy()
+    for name in (
+        "PIP_RC",
+        "PYTEST_FILE_TIMEOUT_KILL_AFTER_SECONDS",
+        "PYTEST_FILE_TIMEOUT_SECONDS",
+        "PYTHON_IMPORT_RC",
+        "RUNNER_OPERATION",
+        "RUNNER_RC",
+        "RUNNER_SIGNAL",
+        "SHELL_SETTINGS_RC",
+    ):
+        env.pop(name, None)
+    env.update(environment)
+    env["PATH"] = f"{fake_bin}{os.pathsep}{env['PATH']}"
+    env["PIP_CONSTRAINT"] = str(tmp_path / "unused-constraint.txt")
+    return subprocess.run(
+        [str(SCRIPT), "--dry-run"],
+        cwd=REPO_ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+        timeout=30,
+    )
+
+
+@pytest.mark.parametrize(
+    ("runner_code", "runner_status"),
+    [
+        (0, "complete-without-failures"),
+        (1, "complete-with-failures"),
+        (2, "incomplete-and-resumable"),
+        (3, "configuration-collection-or-infrastructure-error"),
+    ],
+)
+def test_semantic_runner_codes_are_reported_but_not_propagated(
+    tmp_path: Path, runner_code: int, runner_status: str
+) -> None:
+    result = _run_wrapper(tmp_path, RUNNER_RC=str(runner_code))
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert (
+        f"UNIT TEST RUNNER RESULT: exit_code={runner_code} "
+        f"status={runner_status} wrapper_exit_code=0"
+    ) in result.stdout
+
+
+@pytest.mark.parametrize(
+    ("signal", "returncode"),
+    [("TERM", 143), ("KILL", 137)],
+)
+def test_runner_signal_exit_remains_nonzero(
+    tmp_path: Path, signal: str, returncode: int
+) -> None:
+    result = _run_wrapper(tmp_path, RUNNER_SIGNAL=signal)
+
+    assert result.returncode == returncode
+    assert (
+        f"UNIT TEST RUNNER ABNORMAL EXIT: exit_code={returncode} "
+        "wrapper_exit_code=unchanged"
+    ) in result.stderr
+
+
+def test_argparse_failure_before_runner_execution_remains_nonzero(
+    tmp_path: Path,
+) -> None:
+    result = _run_wrapper(tmp_path, SHELL_SETTINGS_RC="2")
+
+    assert result.returncode == 2
+    assert "fake argparse error" in result.stderr
+    assert "UNIT TEST RUNNER RESULT" not in result.stdout
+
+
+def test_dependency_failure_before_runner_execution_remains_nonzero(
+    tmp_path: Path,
+) -> None:
+    result = _run_wrapper(
+        tmp_path,
+        RUNNER_OPERATION="run",
+        PYTHON_IMPORT_RC="1",
+        PIP_RC="47",
+    )
+
+    assert result.returncode == 47
+    assert "UNIT TEST RUNNER RESULT" not in result.stdout
+
+
+def test_obsolete_environment_failure_remains_nonzero(tmp_path: Path) -> None:
+    result = _run_wrapper(tmp_path, PYTEST_FILE_TIMEOUT_SECONDS="10")
+
+    assert result.returncode == 3
+    assert "PYTEST_FILE_TIMEOUT_SECONDS is obsolete" in result.stderr
+    assert "UNIT TEST RUNNER RESULT" not in result.stdout

--- a/tests/test_sharding/test_task_run_unit_tests_shell.py
+++ b/tests/test_sharding/test_task_run_unit_tests_shell.py
@@ -30,6 +30,7 @@ if [ "${2:-}" = "__shell-settings" ]; then
     exit 0
 fi
 if [ "${1:-}" = "-c" ]; then
+    printf '%s' "${PYTHON_IMPORT_OUTPUT:-}"
     exit "${PYTHON_IMPORT_RC:-0}"
 fi
 if [ -n "${RUNNER_SIGNAL:-}" ]; then
@@ -43,12 +44,26 @@ exit "${RUNNER_RC:-0}"
     pip = fake_bin / "pip"
     pip.write_text('#!/bin/bash\nexit "${PIP_RC:-0}"\n', encoding="utf-8")
     pip.chmod(0o755)
+    mktemp = fake_bin / "mktemp"
+    mktemp.write_text(
+        """\
+#!/bin/bash
+if [ "${MKTEMP_RC:-0}" -ne 0 ]; then
+    exit "${MKTEMP_RC}"
+fi
+exec /usr/bin/mktemp "$@"
+""",
+        encoding="utf-8",
+    )
+    mktemp.chmod(0o755)
     env = os.environ.copy()
     for name in (
         "PIP_RC",
+        "MKTEMP_RC",
         "PYTEST_FILE_TIMEOUT_KILL_AFTER_SECONDS",
         "PYTEST_FILE_TIMEOUT_SECONDS",
         "PYTHON_IMPORT_RC",
+        "PYTHON_IMPORT_OUTPUT",
         "RUNNER_OPERATION",
         "RUNNER_RC",
         "RUNNER_SIGNAL",
@@ -57,7 +72,8 @@ exit "${RUNNER_RC:-0}"
         env.pop(name, None)
     env.update(environment)
     env["PATH"] = f"{fake_bin}{os.pathsep}{env['PATH']}"
-    env["PIP_CONSTRAINT"] = str(tmp_path / "unused-constraint.txt")
+    if "PIP_CONSTRAINT" not in environment:
+        env["PIP_CONSTRAINT"] = str(tmp_path / "unused-constraint.txt")
     return subprocess.run(
         [str(SCRIPT), "--dry-run"],
         cwd=REPO_ROOT,
@@ -70,24 +86,31 @@ exit "${RUNNER_RC:-0}"
 
 
 @pytest.mark.parametrize(
-    ("runner_code", "runner_status"),
+    ("runner_code", "runner_status", "wrapper_code"),
     [
-        (0, "complete-without-failures"),
-        (1, "complete-with-failures"),
-        (2, "incomplete-and-resumable"),
-        (3, "configuration-collection-or-infrastructure-error"),
+        (0, "complete-without-failures", 0),
+        (1, "complete-with-failures", 1),
+        (2, "incomplete-and-resumable", 0),
+        (3, "configuration-collection-or-infrastructure-error", 3),
     ],
 )
-def test_semantic_runner_codes_are_reported_but_not_propagated(
-    tmp_path: Path, runner_code: int, runner_status: str
+def test_semantic_runner_codes_use_the_ci_exit_contract(
+    tmp_path: Path, runner_code: int, runner_status: str, wrapper_code: int
 ) -> None:
     result = _run_wrapper(tmp_path, RUNNER_RC=str(runner_code))
 
-    assert result.returncode == 0, result.stdout + result.stderr
+    assert result.returncode == wrapper_code, result.stdout + result.stderr
     assert (
         f"UNIT TEST RUNNER RESULT: exit_code={runner_code} "
-        f"status={runner_status} wrapper_exit_code=0"
+        f"status={runner_status} wrapper_exit_code={wrapper_code}"
     ) in result.stdout
+
+
+def test_wrapper_does_not_enable_bash_errexit() -> None:
+    source = SCRIPT.read_text(encoding="utf-8")
+
+    assert "set -e" not in source
+    assert "set -eo" not in source
 
 
 @pytest.mark.parametrize(
@@ -127,6 +150,32 @@ def test_dependency_failure_before_runner_execution_remains_nonzero(
     )
 
     assert result.returncode == 47
+    assert "UNIT TEST RUNNER RESULT" not in result.stdout
+
+
+def test_installation_failure_remains_nonzero_without_errexit(tmp_path: Path) -> None:
+    result = _run_wrapper(
+        tmp_path,
+        RUNNER_OPERATION="run",
+        PYTHON_IMPORT_RC="0",
+        PIP_RC="41",
+    )
+
+    assert result.returncode == 41
+    assert "UNIT TEST RUNNER RESULT" not in result.stdout
+
+
+def test_constraint_file_creation_failure_remains_nonzero_without_errexit(
+    tmp_path: Path,
+) -> None:
+    result = _run_wrapper(
+        tmp_path,
+        PIP_CONSTRAINT="",
+        PYTHON_IMPORT_OUTPUT="torch==2.8.0",
+        MKTEMP_RC="42",
+    )
+
+    assert result.returncode == 42
     assert "UNIT TEST RUNNER RESULT" not in result.stdout
 
 


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->
Produce a summary report when task_run_unit_tests.sh completes the tests. Restore the old behavior before PR#4141.

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [X] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [X] I have installed the hooks with `pre-commit install`.
- [X] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [X] Tests have been added or updated as needed.
- [X] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added detailed test-run summaries with counts, outcomes, pending tests, durations, and memory usage.
  - Added per-source CSV summaries, including results aggregated across shards.
  - Added concise, normalized failure reasons to test results.
  - Long-running tests are prioritized, while solo tests run on a dedicated worker.

- **Bug Fixes**
  - Execution and setup failures now report summaries and propagate accurate exit statuses.
  - Improved reporting for invalid, interrupted, and incomplete runs.
  - Memory-monitoring status is clearly reported when disabled, unavailable, or inconsistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->