### PR TITLE
MSA decode path improvements

### DIFF
--- a/flashinfer/msa_ops/_common.py
+++ b/flashinfer/msa_ops/_common.py
@@ -29,7 +29,7 @@ _compile_cache: dict = {}
 def _q_offset_tensor(
     q_offset,
     cu_seqlens_q: torch.Tensor,
-    cu_seqlens_k: torch.Tensor,
+    k_len_or_cu: torch.Tensor,
     device,
     k_is_lengths: bool = False,
 ) -> torch.Tensor:
@@ -39,12 +39,12 @@ def _q_offset_tensor(
     semantics). When ``q_offset`` is None, queries are right-aligned to the end
     of the KV sequence: ``q_offset[b] = seqlen_k[b] - seqlen_q[b]``.
 
-    ``k_is_lengths`` says ``cu_seqlens_k`` already holds per-request lengths
-    rather than a prefix sum (the paged paths pass ``seqused_k`` straight
-    through), which skips differencing it back apart."""
+    ``k_len_or_cu`` is per-request lengths ``(B,)`` when ``k_is_lengths`` (the
+    paged paths pass ``seqused_k`` straight through), else a ``(B+1,)`` prefix
+    sum to difference back apart."""
     if q_offset is None:
         seqlens_k = (
-            cu_seqlens_k if k_is_lengths else (cu_seqlens_k[1:] - cu_seqlens_k[:-1])
+            k_len_or_cu if k_is_lengths else (k_len_or_cu[1:] - k_len_or_cu[:-1])
         )
         return (seqlens_k - (cu_seqlens_q[1:] - cu_seqlens_q[:-1])).to(torch.int32)
     return _q_offset_explicit(q_offset, cu_seqlens_q.numel() - 1, device)

--- a/flashinfer/msa_ops/_common.py
+++ b/flashinfer/msa_ops/_common.py
@@ -44,9 +44,7 @@ def _q_offset_tensor(
     through), which skips differencing it back apart."""
     if q_offset is None:
         seqlens_k = (
-            cu_seqlens_k
-            if k_is_lengths
-            else (cu_seqlens_k[1:] - cu_seqlens_k[:-1])
+            cu_seqlens_k if k_is_lengths else (cu_seqlens_k[1:] - cu_seqlens_k[:-1])
         )
         return (seqlens_k - (cu_seqlens_q[1:] - cu_seqlens_q[:-1])).to(torch.int32)
     return _q_offset_explicit(q_offset, cu_seqlens_q.numel() - 1, device)

--- a/flashinfer/msa_ops/_common.py
+++ b/flashinfer/msa_ops/_common.py
@@ -31,17 +31,24 @@ def _q_offset_tensor(
     cu_seqlens_q: torch.Tensor,
     cu_seqlens_k: torch.Tensor,
     device,
+    k_is_lengths: bool = False,
 ) -> torch.Tensor:
     """Build the per-batch causal offset tensor the kernels consume.
 
     A query's global position is ``q_offset[b] + local_index`` (MSA q_offset
     semantics). When ``q_offset`` is None, queries are right-aligned to the end
-    of the KV sequence: ``q_offset[b] = seqlen_k[b] - seqlen_q[b]``."""
+    of the KV sequence: ``q_offset[b] = seqlen_k[b] - seqlen_q[b]``.
+
+    ``k_is_lengths`` says ``cu_seqlens_k`` already holds per-request lengths
+    rather than a prefix sum (the paged paths pass ``seqused_k`` straight
+    through), which skips differencing it back apart."""
     if q_offset is None:
-        return (
-            (cu_seqlens_k[1:] - cu_seqlens_k[:-1])
-            - (cu_seqlens_q[1:] - cu_seqlens_q[:-1])
-        ).to(torch.int32)
+        seqlens_k = (
+            cu_seqlens_k
+            if k_is_lengths
+            else (cu_seqlens_k[1:] - cu_seqlens_k[:-1])
+        )
+        return (seqlens_k - (cu_seqlens_q[1:] - cu_seqlens_q[:-1])).to(torch.int32)
     return _q_offset_explicit(q_offset, cu_seqlens_q.numel() - 1, device)
 
 

--- a/flashinfer/msa_ops/cute_dsl/proxy_score_fp4_sm12x.py
+++ b/flashinfer/msa_ops/cute_dsl/proxy_score_fp4_sm12x.py
@@ -179,8 +179,15 @@ class MsaProxyScoreFp4MmaSm12x:
 
         q_start = mCuQ[batch_idx]
         seqlen_q = mCuQ[batch_idx + 1] - q_start
-        k_start = mCuK[batch_idx]
-        seqlen_k = mCuK[batch_idx + 1] - k_start
+        if cutlass.const_expr(self._paged):
+            # mCuK holds per-request lengths on the paged path:
+            # page_table supplies every KV address, so there is
+            # no base offset to add.
+            k_start = cutlass.Int32(0)
+            seqlen_k = mCuK[batch_idx]
+        else:
+            k_start = mCuK[batch_idx]
+            seqlen_k = mCuK[batch_idx + 1] - k_start
         num_kv_blocks = cute.ceil_div(seqlen_k, self._N)
         group_size = mQ.shape[1] // mK.shape[1]
         kv_head = qo_head // group_size
@@ -724,8 +731,15 @@ class MsaProxyScoreFp4MmaDecodePackedSm12x(MsaProxyScoreFp4MmaSm12x):
 
         q_start = mCuQ[batch_idx]
         seqlen_q = mCuQ[batch_idx + 1] - q_start
-        k_start = mCuK[batch_idx]
-        seqlen_k = mCuK[batch_idx + 1] - k_start
+        if cutlass.const_expr(self._paged):
+            # mCuK holds per-request lengths on the paged path:
+            # page_table supplies every KV address, so there is
+            # no base offset to add.
+            k_start = cutlass.Int32(0)
+            seqlen_k = mCuK[batch_idx]
+        else:
+            k_start = mCuK[batch_idx]
+            seqlen_k = mCuK[batch_idx + 1] - k_start
         num_kv_blocks = cute.ceil_div(seqlen_k, self._N)
         num_qo_heads = mQ.shape[1]
 

--- a/flashinfer/msa_ops/cute_dsl/proxy_score_sm12x.py
+++ b/flashinfer/msa_ops/cute_dsl/proxy_score_sm12x.py
@@ -149,8 +149,15 @@ class MsaProxyScoreSm12x:
 
         q_start = mCuQ[batch_idx]
         seqlen_q = mCuQ[batch_idx + 1] - q_start
-        k_start = mCuK[batch_idx]
-        seqlen_k = mCuK[batch_idx + 1] - k_start
+        if cutlass.const_expr(self._paged):
+            # mCuK holds per-request lengths on the paged path:
+            # page_table supplies every KV address, so there is
+            # no base offset to add.
+            k_start = cutlass.Int32(0)
+            seqlen_k = mCuK[batch_idx]
+        else:
+            k_start = mCuK[batch_idx]
+            seqlen_k = mCuK[batch_idx + 1] - k_start
         num_kv_blocks = cute.ceil_div(seqlen_k, self._n_block_size)
         group_size = mQ.shape[1] // mK.shape[1]
         kv_head = qo_head // group_size
@@ -541,8 +548,15 @@ class MsaProxyScoreDecodePackedSm12x(MsaProxyScoreSm12x):
 
         q_start = mCuQ[batch_idx]
         seqlen_q = mCuQ[batch_idx + 1] - q_start
-        k_start = mCuK[batch_idx]
-        seqlen_k = mCuK[batch_idx + 1] - k_start
+        if cutlass.const_expr(self._paged):
+            # mCuK holds per-request lengths on the paged path:
+            # page_table supplies every KV address, so there is
+            # no base offset to add.
+            k_start = cutlass.Int32(0)
+            seqlen_k = mCuK[batch_idx]
+        else:
+            k_start = mCuK[batch_idx]
+            seqlen_k = mCuK[batch_idx + 1] - k_start
         num_kv_blocks = cute.ceil_div(seqlen_k, self._n_block_size)
 
         sQ_layout = self._make_sq_layout()
@@ -887,8 +901,15 @@ class MsaProxyScoreDecodeStreamSm12x:
         tile, qi, kv_head = cute.arch.block_idx()
 
         G = self._G
-        k_start = mCuK[qi]
-        seqlen_k = mCuK[qi + 1] - k_start
+        if cutlass.const_expr(self._paged):
+            # mCuK holds per-request lengths on the paged path:
+            # page_table supplies every KV address, so there is
+            # no base offset to add.
+            k_start = cutlass.Int32(0)
+            seqlen_k = mCuK[qi]
+        else:
+            k_start = mCuK[qi]
+            seqlen_k = mCuK[qi + 1] - k_start
         if cutlass.const_expr(self._is_causal and not self._qoff_default):
             col_limit = cutlass.min(mQOffset[qi] + 1, seqlen_k)
         else:

--- a/flashinfer/msa_ops/cute_dsl/sparse_decode_sm12x.py
+++ b/flashinfer/msa_ops/cute_dsl/sparse_decode_sm12x.py
@@ -110,7 +110,7 @@ class SparseDecodeForwardSm12x:
         mSplitCounts: cute.Tensor,  # (total_q, Hkv) int32 (dummy if fused)
         mOut: cute.Tensor,  # (total_q, Hq, d) final output (dummy if not fused)
         mLseOut: cute.Tensor,  # (total_q, Hq) f32 natural-log LSE (dummy if not fused)
-        mCuK: cute.Tensor,  # (B + 1,) int32
+        mCuK: cute.Tensor,  # flat: (B+1,) prefix sum; paged: (B,) lengths
         mQOffset: cute.Tensor,  # (B,) int32 causal offset (MSA q_offset)
         softmax_scale: cutlass.Float32,
         out_scale: cutlass.Float32,  # fused: output value scale (v_global_scale)
@@ -312,8 +312,14 @@ class SparseDecodeForwardSm12x:
         if chunk_start < cnt:
             batch_idx = qi // seqlen_q
             tok_in_req = qi - batch_idx * seqlen_q
-            k_start = mCuK[batch_idx]
-            seqlen_k = mCuK[batch_idx + 1] - k_start
+            if cutlass.const_expr(self._paged):
+                # mCuK holds per-request lengths, not a prefix sum: page_table
+                # supplies every KV address, so there is no base offset to add.
+                k_start = cutlass.Int32(0)
+                seqlen_k = mCuK[batch_idx]
+            else:
+                k_start = mCuK[batch_idx]
+                seqlen_k = mCuK[batch_idx + 1] - k_start
 
             n_buf = 2 if cutlass.const_expr(self._pipeline) else 1
             sQ_layout = cute.make_layout(
@@ -863,8 +869,13 @@ class SparseDecodeForwardSm12x:
 
         batch_idx = qi // seqlen_q
         tok_in_req = qi - batch_idx * seqlen_q
-        k_start = mCuK[batch_idx]
-        seqlen_k = mCuK[batch_idx + 1] - k_start
+        if cutlass.const_expr(self._paged):
+            # Per-request lengths, not a prefix sum; see the split kernel above.
+            k_start = cutlass.Int32(0)
+            seqlen_k = mCuK[batch_idx]
+        else:
+            k_start = mCuK[batch_idx]
+            seqlen_k = mCuK[batch_idx + 1] - k_start
 
         # Valid-block count, as in the split kernel above.
         cnt = cutlass.Int32(0)

--- a/flashinfer/msa_ops/cute_dsl/topk_select_countrank_sm12x.py
+++ b/flashinfer/msa_ops/cute_dsl/topk_select_countrank_sm12x.py
@@ -100,7 +100,17 @@ class TopKSelectCountRankSm12x:
         cnt = st.cnt.get_tensor(cute.make_layout(1))
 
         if cutlass.const_expr(self._per_token_nvp):
-            nvp = mNumValidPages[q]
+            # Per-token counts arrive on device, so nothing on the host bounds
+            # them (reading them would sync). Clamp to the score tensor's own
+            # block extent, which is also the `score` staging bound because the
+            # host only dispatches here when max_k_tiles fits _MAX_BLOCKS: an
+            # out-of-range entry would otherwise read mScore past its end,
+            # overrun smem, and emit block indices the attend kernel cannot
+            # address. An over-large count degrades to the full block range.
+            cap = cutlass.min(
+                cutlass.Int32(mScore.shape[1]), cutlass.Int32(_MAX_BLOCKS)
+            )
+            nvp = cutlass.max(cutlass.Int32(0), cutlass.min(mNumValidPages[q], cap))
         else:
             nvp = num_valid_pages
 

--- a/flashinfer/msa_ops/cute_dsl/topk_select_countrank_sm12x.py
+++ b/flashinfer/msa_ops/cute_dsl/topk_select_countrank_sm12x.py
@@ -35,16 +35,21 @@ _SENTINEL = 0x7FFFFFFF  # INT32_MAX: empty slots sort to the tail, unlike -1
 class TopKSelectCountRankSm12x:
     """O(N^2) count-rank top-K selection for small candidate counts."""
 
-    def __init__(self, topk: int):
+    def __init__(self, topk: int, per_token_nvp: bool = False):
         if topk != 16:
             raise ValueError(f"topk must be 16, got {topk}")
         self._topk = topk
+        # Per-token valid-page counts: each query token carries its own causal
+        # KV extent, so the forced local window and the ranked middle range are
+        # token-relative instead of batch-uniform.
+        self._per_token_nvp = per_token_nvp
 
     @cute.jit
     def __call__(
         self,
         mMaxScore: cute.Tensor,  # (H, P, S) f32  (P = max_k_tiles)
         mOut: cute.Tensor,  # (S, H, topk) int32
+        mNumValidPages: cute.Tensor,  # (S,) int32; dummy when not per-token
         num_valid_pages: cutlass.Int32,
         force_begin: cutlass.Int32,
         force_end: cutlass.Int32,
@@ -53,7 +58,9 @@ class TopKSelectCountRankSm12x:
         stream: cuda.CUstream,
     ):
         mBits = cute.recast_tensor(mMaxScore, cutlass.Uint32)
-        self.kernel(mBits, mOut, num_valid_pages, force_begin, force_end).launch(
+        self.kernel(
+            mBits, mOut, mNumValidPages, num_valid_pages, force_begin, force_end
+        ).launch(
             grid=(total_qo_len, num_qo_heads, 1),
             block=(_NTHREADS, 1, 1),
             stream=stream,
@@ -72,6 +79,7 @@ class TopKSelectCountRankSm12x:
         self,
         mScore: cute.Tensor,  # (H, P, S) f32 recast to u32 bits
         mOut: cute.Tensor,  # (S, H, topk) int32
+        mNumValidPages: cute.Tensor,  # (S,) int32
         num_valid_pages: cutlass.Int32,
         force_begin: cutlass.Int32,
         force_end: cutlass.Int32,
@@ -91,10 +99,21 @@ class TopKSelectCountRankSm12x:
         sel = st.sel.get_tensor(cute.make_layout(16))
         cnt = st.cnt.get_tensor(cute.make_layout(1))
 
-        nvp = num_valid_pages
-        mid_lo = force_begin
-        mid_hi = num_valid_pages - force_end
-        n_forced = force_begin + force_end
+        if cutlass.const_expr(self._per_token_nvp):
+            nvp = mNumValidPages[q]
+        else:
+            nvp = num_valid_pages
+
+        # Per-token nvp can be smaller than the forced region (a token whose
+        # causal extent is shorter than the local window), which the host-side
+        # scalar check cannot rule out. Shrink the forced region to fit rather
+        # than emitting negative block indices.
+        fb = cutlass.min(force_begin, nvp)
+        fe = cutlass.min(force_end, nvp - fb)
+
+        mid_lo = fb
+        mid_hi = nvp - fe
+        n_forced = fb + fe
         target = cutlass.Int32(self._topk) - n_forced
 
         # Stage the middle scores' radix keys in SMEM: the rank loop rereads each
@@ -109,13 +128,13 @@ class TopKSelectCountRankSm12x:
         if tid == 0:
             w = cutlass.Int32(0)
             i = cutlass.Int32(0)
-            while i < force_begin:
+            while i < fb:
                 sel[w] = i
                 w += 1
                 i += 1
             j = cutlass.Int32(0)
-            while j < force_end:
-                sel[w] = (nvp - force_end) + j
+            while j < fe:
+                sel[w] = mid_hi + j
                 w += 1
                 j += 1
             k = w

--- a/flashinfer/msa_ops/cute_dsl/topk_select_radix_sm12x.py
+++ b/flashinfer/msa_ops/cute_dsl/topk_select_radix_sm12x.py
@@ -53,16 +53,19 @@ def _atomic_add_i32(a, ptr: cute.Pointer) -> cutlass.Int32:
 class TopKSelectRadixSm12x:
     """Multi-stage MSD radix top-K selection over per-block proxy scores."""
 
-    def __init__(self, topk: int):
+    def __init__(self, topk: int, per_token_nvp: bool = False):
         if topk != 16:
             raise ValueError(f"topk must be 16, got {topk}")
         self._topk = topk
+        # See TopKSelectCountRankSm12x: per-token causal KV extents.
+        self._per_token_nvp = per_token_nvp
 
     @cute.jit
     def __call__(
         self,
         mMaxScore: cute.Tensor,  # (H, P, S) f32  (P = max_k_tiles)
         mOut: cute.Tensor,  # (S, H, topk) int32
+        mNumValidPages: cute.Tensor,  # (S,) int32; dummy when not per-token
         num_valid_pages: cutlass.Int32,
         force_begin: cutlass.Int32,
         force_end: cutlass.Int32,
@@ -71,7 +74,9 @@ class TopKSelectRadixSm12x:
         stream: cuda.CUstream,
     ):
         mBits = cute.recast_tensor(mMaxScore, cutlass.Uint32)
-        self.kernel(mBits, mOut, num_valid_pages, force_begin, force_end).launch(
+        self.kernel(
+            mBits, mOut, mNumValidPages, num_valid_pages, force_begin, force_end
+        ).launch(
             grid=(total_qo_len, num_qo_heads, 1),
             block=(_KTHREADS, 1, 1),
             stream=stream,
@@ -90,6 +95,7 @@ class TopKSelectRadixSm12x:
         self,
         mBits: cute.Tensor,  # (H, P, S) uint32, raw bits of max_score
         mOut: cute.Tensor,  # (S, H, topk) int32
+        mNumValidPages: cute.Tensor,  # (S,) int32
         num_valid_pages: cutlass.Int32,
         force_begin: cutlass.Int32,
         force_end: cutlass.Int32,
@@ -126,10 +132,19 @@ class TopKSelectRadixSm12x:
         #   [5] done: selection complete, remaining stages no-op
         #   [6] need: slots still to fill this stage (target - found)
 
-        nvp = num_valid_pages
-        mid_lo = force_begin
-        mid_hi = num_valid_pages - force_end
-        n_forced = force_begin + force_end
+        if cutlass.const_expr(self._per_token_nvp):
+            nvp = mNumValidPages[q]
+        else:
+            nvp = num_valid_pages
+
+        # Shrink the forced region to fit a token whose causal extent is
+        # shorter than it; see TopKSelectCountRankSm12x.
+        fb = cutlass.min(force_begin, nvp)
+        fe = cutlass.min(force_end, nvp - fb)
+
+        mid_lo = fb
+        mid_hi = nvp - fe
+        n_forced = fb + fe
         target = cutlass.Int32(self._topk) - n_forced
 
         n_groups = _NUM_BINS // _GROUP
@@ -138,13 +153,13 @@ class TopKSelectRadixSm12x:
         if tid == 0:
             w = cutlass.Int32(0)
             i = cutlass.Int32(0)
-            while i < force_begin:
+            while i < fb:
                 sel[w] = i
                 w += 1
                 i += 1
             j = cutlass.Int32(0)
-            while j < force_end:
-                sel[w] = (nvp - force_end) + j
+            while j < fe:
+                sel[w] = mid_hi + j
                 w += 1
                 j += 1
             k = w

--- a/flashinfer/msa_ops/cute_dsl/topk_select_radix_sm12x.py
+++ b/flashinfer/msa_ops/cute_dsl/topk_select_radix_sm12x.py
@@ -133,7 +133,14 @@ class TopKSelectRadixSm12x:
         #   [6] need: slots still to fill this stage (target - found)
 
         if cutlass.const_expr(self._per_token_nvp):
-            nvp = mNumValidPages[q]
+            # Clamp the device-side count to the score tensor's own block extent;
+            # see TopKSelectCountRankSm12x. Nothing on the host bounds it, and an
+            # out-of-range entry would read mBits past its end and emit block
+            # indices the attend kernel cannot address.
+            nvp = cutlass.max(
+                cutlass.Int32(0),
+                cutlass.min(mNumValidPages[q], cutlass.Int32(mBits.shape[1])),
+            )
         else:
             nvp = num_valid_pages
 

--- a/flashinfer/msa_ops/proxy_score.py
+++ b/flashinfer/msa_ops/proxy_score.py
@@ -32,9 +32,14 @@ from ._common import _BLK_KV
 _SF_VEC_SIZE = 16
 
 
-def _resolve_proxy_dims(cu_seqlens_q, cu_k, max_seqlen_q, max_k_tiles, output):
+def _resolve_proxy_dims(
+    cu_seqlens_q, cu_k, max_seqlen_q, max_k_tiles, output, k_is_lengths=False
+):
     """Resolve grid dims ``(max_seqlen_q, max_k_tiles)`` as Python ints; deriving
-    them reads ``cu_seqlens`` on host, so under CUDA-graph capture we raise."""
+    them reads ``cu_seqlens`` on host, so under CUDA-graph capture we raise.
+
+    ``k_is_lengths`` says ``cu_k`` holds per-request lengths rather than a
+    prefix sum (the paged path)."""
     if max_k_tiles is None and output is not None:
         max_k_tiles = int(output.shape[1])
     if max_seqlen_q is not None and max_k_tiles is not None:
@@ -50,7 +55,7 @@ def _resolve_proxy_dims(cu_seqlens_q, cu_k, max_seqlen_q, max_k_tiles, output):
         max_seqlen_q = int((cu_q_cpu[1:] - cu_q_cpu[:-1]).max().item())
     if max_k_tiles is None:
         cu_k_cpu = cu_k.cpu()
-        seqlens_k = cu_k_cpu[1:] - cu_k_cpu[:-1]
+        seqlens_k = cu_k_cpu if k_is_lengths else (cu_k_cpu[1:] - cu_k_cpu[:-1])
         max_k_tiles = int((seqlens_k.max().item() + _BLK_KV - 1) // _BLK_KV)
     return max_seqlen_q, max_k_tiles
 
@@ -382,8 +387,12 @@ def msa_proxy_score(
                 f"paged k must be (num_pages, num_kv_heads, {_BLK_KV}, {head_dim})"
             )
         batch_size = seqused_k.numel()
-        cu_k = torch.zeros(batch_size + 1, dtype=torch.int32, device=dev)
-        cu_k[1:] = seqused_k.to(dev).cumsum(0)
+        # Paged addressing comes entirely from page_table, so the kernel needs
+        # only each request's length. Pass seqused_k through instead of building
+        # a prefix sum (zeros + cumsum + slice-copy on every call) for the
+        # kernel to difference back apart; `paged` tells it which form this is.
+        cu_k = seqused_k if seqused_k.device == dev else seqused_k.to(dev)
+        cu_k = cu_k.contiguous()
         pt_dev = page_table.contiguous()
     else:
         if cu_seqlens_k is None:
@@ -396,7 +405,7 @@ def msa_proxy_score(
 
     cu_q_dev = cu_seqlens_q.to(dev)
     max_seqlen_q, max_k_tiles = _resolve_proxy_dims(
-        cu_seqlens_q, cu_k, max_seqlen_q, max_k_tiles, output
+        cu_seqlens_q, cu_k, max_seqlen_q, max_k_tiles, output, k_is_lengths=paged
     )
 
     per_head_shape = (num_qo_heads, max_k_tiles, total_q)
@@ -427,7 +436,7 @@ def msa_proxy_score(
     if use_stream and qoff_default:
         qoff_dev = _proxy_dummies(dev.index)[1]
     else:
-        qoff_dev = _q_offset_tensor(q_offset, cu_q_dev, cu_k, dev)
+        qoff_dev = _q_offset_tensor(q_offset, cu_q_dev, cu_k, dev, k_is_lengths=paged)
 
     # Head-fused decode path: pack group_size heads x pack_q_len q-tokens into one
     # 64-row MMA tile so index-K is read once per (batch, kv_head). Outside the regime
@@ -461,8 +470,11 @@ def msa_proxy_score(
         kdt = _cutlass_dtype(k.dtype)
         i32 = _cutlass_dtype(torch.int32)
         f32 = _cutlass_dtype(torch.float32)
-        s_tq, s_hq, s_tk, s_hkv, s_b1, s_b0, s_pb, s_pm, s_mt = (
-            cute.sym_int() for _ in range(9)
+        # s_bk is mCuK's own symbol: on the paged path it holds per-request
+        # lengths (batch entries), not a prefix sum (batch + 1), so it must not
+        # share mCuQ's dim or the compiled signature rejects the call.
+        s_tq, s_hq, s_tk, s_hkv, s_b1, s_bk, s_b0, s_pb, s_pm, s_mt = (
+            cute.sym_int() for _ in range(10)
         )
         k_shape = (s_tk, s_hkv, _BLK_KV, head_dim) if paged else (s_tk, s_hkv, head_dim)
         stream_fake = cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=True)
@@ -503,8 +515,8 @@ def msa_proxy_score(
             _fake(kdt, k_shape),
             _fake(i32, (s_pb, s_pm), align=4),
             _fake(f32, (s_hq, s_mt, s_tq), align=4),
-            _fake(i32, (s_b1,), align=4),
-            _fake(i32, (s_b1,), align=4),
+            _fake(i32, (s_b1,), align=4),  # mCuQ
+            _fake(i32, (s_bk,), align=4),  # mCuK (lengths when paged)
             _fake(i32, (s_b0,), align=4),
             cutlass.Int32(1),
             cutlass.Int32(1),
@@ -715,8 +727,12 @@ def msa_proxy_score_fp4(
                 f"paged k_fp4 must be (num_pages, num_kv_heads, {_BLK_KV}, {hd2})"
             )
         batch_size = seqused_k.numel()
-        cu_k = torch.zeros(batch_size + 1, dtype=torch.int32, device=dev)
-        cu_k[1:] = seqused_k.to(dev).cumsum(0)
+        # Paged addressing comes entirely from page_table, so the kernel needs
+        # only each request's length. Pass seqused_k through instead of building
+        # a prefix sum (zeros + cumsum + slice-copy on every call) for the
+        # kernel to difference back apart; `paged` tells it which form this is.
+        cu_k = seqused_k if seqused_k.device == dev else seqused_k.to(dev)
+        cu_k = cu_k.contiguous()
         pt_dev = page_table.contiguous()
     else:
         if cu_seqlens_k is None:
@@ -728,9 +744,9 @@ def msa_proxy_score_fp4(
         batch_size = cu_k.numel() - 1
 
     cu_q_dev = cu_seqlens_q.to(dev)
-    qoff_dev = _q_offset_tensor(q_offset, cu_q_dev, cu_k, dev)
+    qoff_dev = _q_offset_tensor(q_offset, cu_q_dev, cu_k, dev, k_is_lengths=paged)
     max_seqlen_q, max_k_tiles = _resolve_proxy_dims(
-        cu_seqlens_q, cu_k, max_seqlen_q, max_k_tiles, output
+        cu_seqlens_q, cu_k, max_seqlen_q, max_k_tiles, output, k_is_lengths=paged
     )
 
     per_head_shape = (num_qo_heads, max_k_tiles, total_q)
@@ -774,13 +790,16 @@ def msa_proxy_score_fp4(
             s_tk,
             s_hkv,
             s_b1,
+            # mCuK's own symbol: per-request lengths (batch) when paged, a
+            # prefix sum (batch + 1) when flat, so it cannot share mCuQ's dim.
+            s_bk,
             s_b0,
             s_pb,
             s_pm,
             s_mt,
             s_qsf,
             s_ksf,
-        ) = (cute.sym_int() for _ in range(11))
+        ) = (cute.sym_int() for _ in range(12))
         if paged:
             k_shape: tuple = (s_tk, s_hkv, _BLK_KV, hd2)
         else:
@@ -809,8 +828,8 @@ def msa_proxy_score_fp4(
             _fake(u8, (s_ksf,), align=4),
             _fake(i32, (s_pb, s_pm), align=4),
             _fake(f32, (s_hq, s_mt, s_tq), align=4),
-            _fake(i32, (s_b1,), align=4),
-            _fake(i32, (s_b1,), align=4),
+            _fake(i32, (s_b1,), align=4),  # mCuQ
+            _fake(i32, (s_bk,), align=4),  # mCuK (lengths when paged)
             _fake(i32, (s_b0,), align=4),
             cutlass.Float32(1.0),
             cutlass.Float32(1.0),

--- a/flashinfer/msa_ops/proxy_score.py
+++ b/flashinfer/msa_ops/proxy_score.py
@@ -33,13 +33,13 @@ _SF_VEC_SIZE = 16
 
 
 def _resolve_proxy_dims(
-    cu_seqlens_q, cu_k, max_seqlen_q, max_k_tiles, output, k_is_lengths=False
+    cu_seqlens_q, k_len_or_cu, max_seqlen_q, max_k_tiles, output, k_is_lengths=False
 ):
     """Resolve grid dims ``(max_seqlen_q, max_k_tiles)`` as Python ints; deriving
     them reads ``cu_seqlens`` on host, so under CUDA-graph capture we raise.
 
-    ``k_is_lengths`` says ``cu_k`` holds per-request lengths rather than a
-    prefix sum (the paged path)."""
+    ``k_len_or_cu`` is per-request lengths when ``k_is_lengths`` (the paged
+    path), else a prefix sum."""
     if max_k_tiles is None and output is not None:
         max_k_tiles = int(output.shape[1])
     if max_seqlen_q is not None and max_k_tiles is not None:
@@ -54,8 +54,8 @@ def _resolve_proxy_dims(
         cu_q_cpu = cu_seqlens_q.cpu()
         max_seqlen_q = int((cu_q_cpu[1:] - cu_q_cpu[:-1]).max().item())
     if max_k_tiles is None:
-        cu_k_cpu = cu_k.cpu()
-        seqlens_k = cu_k_cpu if k_is_lengths else (cu_k_cpu[1:] - cu_k_cpu[:-1])
+        k_cpu = k_len_or_cu.cpu()
+        seqlens_k = k_cpu if k_is_lengths else (k_cpu[1:] - k_cpu[:-1])
         max_k_tiles = int((seqlens_k.max().item() + _BLK_KV - 1) // _BLK_KV)
     return max_seqlen_q, max_k_tiles
 
@@ -391,21 +391,21 @@ def msa_proxy_score(
         # only each request's length. Pass seqused_k through instead of building
         # a prefix sum (zeros + cumsum + slice-copy on every call) for the
         # kernel to difference back apart; `paged` tells it which form this is.
-        cu_k = seqused_k if seqused_k.device == dev else seqused_k.to(dev)
-        cu_k = cu_k.contiguous()
+        k_len_or_cu = seqused_k if seqused_k.device == dev else seqused_k.to(dev)
+        k_len_or_cu = k_len_or_cu.contiguous()
         pt_dev = page_table.contiguous()
     else:
         if cu_seqlens_k is None:
             raise ValueError("flat proxy requires cu_seqlens_k")
         if k.ndim != 3:
             raise ValueError("flat k must be (total_k, num_kv_heads, head_dim)")
-        cu_k = cu_seqlens_k.to(dev)
+        k_len_or_cu = cu_seqlens_k.to(dev)
         pt_dev = _proxy_dummies(dev.index)[0]
-        batch_size = cu_k.numel() - 1
+        batch_size = k_len_or_cu.numel() - 1
 
     cu_q_dev = cu_seqlens_q.to(dev)
     max_seqlen_q, max_k_tiles = _resolve_proxy_dims(
-        cu_seqlens_q, cu_k, max_seqlen_q, max_k_tiles, output, k_is_lengths=paged
+        cu_seqlens_q, k_len_or_cu, max_seqlen_q, max_k_tiles, output, k_is_lengths=paged
     )
 
     per_head_shape = (num_qo_heads, max_k_tiles, total_q)
@@ -436,7 +436,9 @@ def msa_proxy_score(
     if use_stream and qoff_default:
         qoff_dev = _proxy_dummies(dev.index)[1]
     else:
-        qoff_dev = _q_offset_tensor(q_offset, cu_q_dev, cu_k, dev, k_is_lengths=paged)
+        qoff_dev = _q_offset_tensor(
+            q_offset, cu_q_dev, k_len_or_cu, dev, k_is_lengths=paged
+        )
 
     # Head-fused decode path: pack group_size heads x pack_q_len q-tokens into one
     # 64-row MMA tile so index-K is read once per (batch, kv_head). Outside the regime
@@ -557,12 +559,12 @@ def msa_proxy_score(
     if use_stream:
         # One CTA per (KV block, token, kv_head): the grid is already maximally
         # split, so there is no split factor to tune.
-        _call([q, k, pt_dev, per_head, cu_q_dev, cu_k, qoff_dev], 1)
+        _call([q, k, pt_dev, per_head, cu_q_dev, k_len_or_cu, qoff_dev], 1)
     else:
         _run_proxy_autotuned(
             "msa_proxy_score",
             _call,
-            [q, k, pt_dev, per_head, cu_q_dev, cu_k, qoff_dev],
+            [q, k, pt_dev, per_head, cu_q_dev, k_len_or_cu, qoff_dev],
             max_seqlen_q=max_seqlen_q,
             max_k_tiles=max_k_tiles,
             base_ctas=base_ctas,
@@ -731,22 +733,24 @@ def msa_proxy_score_fp4(
         # only each request's length. Pass seqused_k through instead of building
         # a prefix sum (zeros + cumsum + slice-copy on every call) for the
         # kernel to difference back apart; `paged` tells it which form this is.
-        cu_k = seqused_k if seqused_k.device == dev else seqused_k.to(dev)
-        cu_k = cu_k.contiguous()
+        k_len_or_cu = seqused_k if seqused_k.device == dev else seqused_k.to(dev)
+        k_len_or_cu = k_len_or_cu.contiguous()
         pt_dev = page_table.contiguous()
     else:
         if cu_seqlens_k is None:
             raise ValueError("flat proxy requires cu_seqlens_k")
         if k_fp4.ndim != 3:
             raise ValueError("flat k_fp4 must be (total_k, num_kv_heads, 64)")
-        cu_k = cu_seqlens_k.to(dev)
+        k_len_or_cu = cu_seqlens_k.to(dev)
         pt_dev = torch.zeros((1, 1), dtype=torch.int32, device=dev)
-        batch_size = cu_k.numel() - 1
+        batch_size = k_len_or_cu.numel() - 1
 
     cu_q_dev = cu_seqlens_q.to(dev)
-    qoff_dev = _q_offset_tensor(q_offset, cu_q_dev, cu_k, dev, k_is_lengths=paged)
+    qoff_dev = _q_offset_tensor(
+        q_offset, cu_q_dev, k_len_or_cu, dev, k_is_lengths=paged
+    )
     max_seqlen_q, max_k_tiles = _resolve_proxy_dims(
-        cu_seqlens_q, cu_k, max_seqlen_q, max_k_tiles, output, k_is_lengths=paged
+        cu_seqlens_q, k_len_or_cu, max_seqlen_q, max_k_tiles, output, k_is_lengths=paged
     )
 
     per_head_shape = (num_qo_heads, max_k_tiles, total_q)
@@ -868,7 +872,17 @@ def msa_proxy_score_fp4(
     _run_proxy_autotuned(
         "msa_proxy_score_fp4",
         _call,
-        [q_fp4, k_fp4, q_scale, k_scale, pt_dev, per_head, cu_q_dev, cu_k, qoff_dev],
+        [
+            q_fp4,
+            k_fp4,
+            q_scale,
+            k_scale,
+            pt_dev,
+            per_head,
+            cu_q_dev,
+            k_len_or_cu,
+            qoff_dev,
+        ],
         max_seqlen_q=max_seqlen_q,
         max_k_tiles=max_k_tiles,
         base_ctas=base_ctas,

--- a/flashinfer/msa_ops/sparse_decode.py
+++ b/flashinfer/msa_ops/sparse_decode.py
@@ -346,8 +346,8 @@ def msa_sparse_decode_attention(
         # seqused_k directly instead of building a prefix sum (a zeros + cumsum
         # + slice-copy on every decode call) just for the kernel to difference
         # it back apart. The kernel reads this as lengths when `paged`.
-        cu_k = seqused_k if seqused_k.device == dev else seqused_k.to(dev)
-        cu_k = cu_k.contiguous()
+        k_len_or_cu = seqused_k if seqused_k.device == dev else seqused_k.to(dev)
+        k_len_or_cu = k_len_or_cu.contiguous()
         pt_dev = page_table.contiguous()
     else:
         if cu_seqlens_k is None:
@@ -358,7 +358,7 @@ def msa_sparse_decode_attention(
             raise ValueError("cu_seqlens_k must have batch_size + 1 entries")
         if k.ndim != 3:
             raise ValueError("flat k/v must be (total_k, num_kv_heads, head_dim)")
-        cu_k = cu_seqlens_k.to(dev)
+        k_len_or_cu = cu_seqlens_k.to(dev)
         pt_dev = _dummy_tensors(dev.index)[0]
 
     # v mirrors k (same layout/dtype for bf16/fp16, fp8, and packed NVFP4); the
@@ -539,7 +539,7 @@ def msa_sparse_decode_attention(
         split_counts,
         out_buf,
         lse_buf,
-        cu_k,
+        k_len_or_cu,
         qoff_dev,
         float(softmax_scale),
         float(v_global_scale) if v_global_scale is not None else 1.0,

--- a/flashinfer/msa_ops/sparse_decode.py
+++ b/flashinfer/msa_ops/sparse_decode.py
@@ -341,8 +341,13 @@ def msa_sparse_decode_attention(
             raise ValueError(
                 f"paged k/v must be (num_pages, num_kv_heads, 128, {kv_last})"
             )
-        cu_k = torch.zeros(batch_size + 1, dtype=torch.int32, device=dev)
-        cu_k[1:] = seqused_k.to(dev).cumsum(0)
+        # Paged addressing comes entirely from page_table, so the kernel never
+        # needs a KV base offset -- only each request's length. Hand it
+        # seqused_k directly instead of building a prefix sum (a zeros + cumsum
+        # + slice-copy on every decode call) just for the kernel to difference
+        # it back apart. The kernel reads this as lengths when `paged`.
+        cu_k = seqused_k if seqused_k.device == dev else seqused_k.to(dev)
+        cu_k = cu_k.contiguous()
         pt_dev = page_table.contiguous()
     else:
         if cu_seqlens_k is None:

--- a/flashinfer/msa_ops/sparse_topk_select.py
+++ b/flashinfer/msa_ops/sparse_topk_select.py
@@ -23,9 +23,6 @@ from ..api_logging import flashinfer_api
 from ..utils import is_sm12x_supported
 
 
-_topk_compile_cache: dict = {}
-
-
 @functools.cache
 def _dummy_nvp(device_index: int) -> torch.Tensor:
     """Signature filler for the scalar-``num_valid_pages`` path, which never
@@ -33,16 +30,15 @@ def _dummy_nvp(device_index: int) -> torch.Tensor:
     return torch.zeros(1, dtype=torch.int32, device=torch.device("cuda", device_index))
 
 
-def _get_compiled_topk(topk: int, small: bool, per_token_nvp: bool = False):
+@functools.cache
+def _get_compiled_topk(topk: int, small: bool, per_token_nvp: bool):
     """``small`` picks the O(N^2) count-rank kernel, else the radix kernel; the
-    two give identical selections only on distinct-score inputs (ties may differ)."""
+    two give identical selections only on distinct-score inputs (ties may differ).
+
+    No default on ``per_token_nvp``: it keys the cache, and a call that omitted
+    it would compile a second copy of an identical kernel."""
     import cutlass
     import cutlass.cute as cute
-
-    key = (topk, small, per_token_nvp)
-    compiled = _topk_compile_cache.get(key)
-    if compiled is not None:
-        return compiled
 
     if small:
         from .cute_dsl.topk_select_countrank_sm12x import (
@@ -76,7 +72,6 @@ def _get_compiled_topk(topk: int, small: bool, per_token_nvp: bool = False):
         stream_fake,
         options="--enable-tvm-ffi",
     )
-    _topk_compile_cache[key] = compiled
     return compiled
 
 

--- a/flashinfer/msa_ops/sparse_topk_select.py
+++ b/flashinfer/msa_ops/sparse_topk_select.py
@@ -118,6 +118,9 @@ def msa_topk_select(
         kernel launches per call and is easy to get wrong.  ``force_end_blocks``
         then denotes each token's own trailing local window, and no selected
         index can exceed that token's extent, so no masking pass is needed.
+        Entries are clamped in-kernel to ``[0, max_k_tiles]`` (checking them on
+        the host would sync), so an over-large count degrades to the full block
+        range rather than reading out of bounds.
     output : torch.Tensor, optional
         Pre-allocated output tensor of shape
         ``(total_qo_len, num_qo_heads, topk)``, dtype int32.  Allocated
@@ -180,9 +183,12 @@ def msa_topk_select(
         if num_valid_pages.device != max_score.device:
             raise ValueError("num_valid_pages must be on max_score's device")
         # Values stay on device (reading them would force a sync, which is
-        # illegal under CUDA graph capture), so the per-token forced-region fit
-        # is clamped in-kernel instead of checked here. Entries must still be in
-        # (0, max_k_tiles]; the caller owns that invariant.
+        # illegal under CUDA graph capture), so both the max_k_tiles bound and
+        # the per-token forced-region fit are clamped in-kernel instead of
+        # checked here. Unchecked, an out-of-range entry reads max_score out of
+        # bounds and emits block indices the attend kernel cannot address --
+        # reachable in practice, since callers derive the count and max_k_tiles
+        # from different metadata.
         nvp_dev = num_valid_pages
         nvp_scalar = 0
         # Cannot dispatch on the runtime values without a sync, so bound by the

--- a/flashinfer/msa_ops/sparse_topk_select.py
+++ b/flashinfer/msa_ops/sparse_topk_select.py
@@ -167,7 +167,7 @@ def msa_topk_select(
             f"{force_end_blocks}) must be <= topk ({topk})"
         )
 
-    if per_token_nvp:
+    if isinstance(num_valid_pages, torch.Tensor):
         if num_valid_pages.dtype != torch.int32 or num_valid_pages.ndim != 1:
             raise ValueError("num_valid_pages tensor must be 1D int32")
         if num_valid_pages.numel() != total_qo_len:

--- a/flashinfer/msa_ops/sparse_topk_select.py
+++ b/flashinfer/msa_ops/sparse_topk_select.py
@@ -14,7 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from typing import Optional
+import functools
+from typing import Optional, Union
 
 import torch
 
@@ -25,13 +26,20 @@ from ..utils import is_sm12x_supported
 _topk_compile_cache: dict = {}
 
 
-def _get_compiled_topk(topk: int, small: bool):
+@functools.cache
+def _dummy_nvp(device_index: int) -> torch.Tensor:
+    """Signature filler for the scalar-``num_valid_pages`` path, which never
+    reads it; cached so repeat calls do not launch a fill kernel."""
+    return torch.zeros(1, dtype=torch.int32, device=torch.device("cuda", device_index))
+
+
+def _get_compiled_topk(topk: int, small: bool, per_token_nvp: bool = False):
     """``small`` picks the O(N^2) count-rank kernel, else the radix kernel; the
     two give identical selections only on distinct-score inputs (ties may differ)."""
     import cutlass
     import cutlass.cute as cute
 
-    key = (topk, small)
+    key = (topk, small, per_token_nvp)
     compiled = _topk_compile_cache.get(key)
     if compiled is not None:
         return compiled
@@ -44,7 +52,7 @@ def _get_compiled_topk(topk: int, small: bool):
         from .cute_dsl.topk_select_radix_sm12x import (  # type: ignore[assignment,no-redef]
             TopKSelectRadixSm12x as _TopKKernel,
         )
-    kernel_obj = _TopKKernel(topk=topk)
+    kernel_obj = _TopKKernel(topk=topk, per_token_nvp=per_token_nvp)
 
     def fk(dtype, ndim, align):
         return cute.runtime.make_fake_compact_tensor(
@@ -59,7 +67,8 @@ def _get_compiled_topk(topk: int, small: bool):
         kernel_obj,
         fk(cutlass.Float32, 3, 4),  # max_score (H, P, S)
         fk(cutlass.Int32, 3, 4),  # out (S, H, topk)
-        cutlass.Int32(1),  # num_valid_pages
+        fk(cutlass.Int32, 1, 4),  # num_valid_pages tensor (S,)
+        cutlass.Int32(1),  # num_valid_pages scalar
         cutlass.Int32(0),  # force_begin
         cutlass.Int32(0),  # force_end
         cutlass.Int32(1),  # total_qo_len
@@ -75,7 +84,7 @@ def _get_compiled_topk(topk: int, small: bool):
 def msa_topk_select(
     max_score: torch.Tensor,
     topk: int,
-    num_valid_pages: Optional[int] = None,
+    num_valid_pages: Optional[Union[int, torch.Tensor]] = None,
     output: Optional[torch.Tensor] = None,
     force_begin_blocks: int = 0,
     force_end_blocks: int = 0,
@@ -96,10 +105,19 @@ def msa_topk_select(
         set to ``-inf`` by the caller.
     topk : int
         Number of KV blocks to select per (query token, head).  Must be 16.
-    num_valid_pages : int, optional
+    num_valid_pages : int or torch.Tensor, optional
         Actual number of valid KV pages (``<= max_k_tiles``).  Indices
         ``>= num_valid_pages`` are replaced with -1 and sorted to the tail.
         Defaults to ``max_k_tiles`` (disables clamping).
+
+        May instead be an int32 tensor of shape ``(total_qo_len,)`` giving each
+        query token its own valid-page count.  Callers whose tokens have
+        differing causal KV extents (decode batches, chunked prefill) want this:
+        with a batch-wide scalar the only way to recover per-token semantics is
+        to post-process the output on the host side, which costs several extra
+        kernel launches per call and is easy to get wrong.  ``force_end_blocks``
+        then denotes each token's own trailing local window, and no selected
+        index can exceed that token's extent, so no masking pass is needed.
     output : torch.Tensor, optional
         Pre-allocated output tensor of shape
         ``(total_qo_len, num_qo_heads, topk)``, dtype int32.  Allocated
@@ -132,19 +150,15 @@ def msa_topk_select(
     if topk != 16:
         raise ValueError(f"topk must be 16, got {topk}")
 
+    from .cute_dsl.topk_select_countrank_sm12x import _MAX_BLOCKS
+
     num_qo_heads, max_k_tiles, total_qo_len = max_score.shape
 
     if num_valid_pages is None:
         num_valid_pages = max_k_tiles
 
-    # Input guards (the radix kernel does not clamp internally): an out-of-range
-    # num_valid_pages reads max_score out of bounds, and oversized forced regions
-    # overrun the kernel's fixed forced-index buffer or underflow to negative blocks.
-    if not 0 < num_valid_pages <= max_k_tiles:
-        raise ValueError(
-            f"num_valid_pages must be in (0, max_k_tiles={max_k_tiles}], "
-            f"got {num_valid_pages}"
-        )
+    per_token_nvp = isinstance(num_valid_pages, torch.Tensor)
+
     if force_begin_blocks < 0 or force_end_blocks < 0:
         raise ValueError("force_begin_blocks / force_end_blocks must be >= 0")
     if force_begin_blocks + force_end_blocks > topk:
@@ -152,11 +166,50 @@ def msa_topk_select(
             f"force_begin_blocks + force_end_blocks ({force_begin_blocks} + "
             f"{force_end_blocks}) must be <= topk ({topk})"
         )
-    if force_begin_blocks + force_end_blocks > num_valid_pages:
-        raise ValueError(
-            f"force_begin_blocks + force_end_blocks ({force_begin_blocks} + "
-            f"{force_end_blocks}) must be <= num_valid_pages ({num_valid_pages})"
-        )
+
+    if per_token_nvp:
+        if num_valid_pages.dtype != torch.int32 or num_valid_pages.ndim != 1:
+            raise ValueError("num_valid_pages tensor must be 1D int32")
+        if num_valid_pages.numel() != total_qo_len:
+            raise ValueError(
+                f"num_valid_pages tensor must have total_qo_len ({total_qo_len}) "
+                f"entries, got {num_valid_pages.numel()}"
+            )
+        if not num_valid_pages.is_contiguous():
+            raise ValueError("num_valid_pages tensor must be contiguous")
+        if num_valid_pages.device != max_score.device:
+            raise ValueError("num_valid_pages must be on max_score's device")
+        # Values stay on device (reading them would force a sync, which is
+        # illegal under CUDA graph capture), so the per-token forced-region fit
+        # is clamped in-kernel instead of checked here. Entries must still be in
+        # (0, max_k_tiles]; the caller owns that invariant.
+        nvp_dev = num_valid_pages
+        nvp_scalar = 0
+        # Cannot dispatch on the runtime values without a sync, so bound by the
+        # allocated tile count. Conservative: picks radix when max_k_tiles
+        # exceeds the SMEM cap even if every token is actually shorter.
+        small = int(max_k_tiles) <= _MAX_BLOCKS
+    else:
+        # Input guards (the radix kernel does not clamp internally): an
+        # out-of-range num_valid_pages reads max_score out of bounds, and
+        # oversized forced regions overrun the kernel's fixed forced-index
+        # buffer or underflow to negative blocks.
+        if not 0 < num_valid_pages <= max_k_tiles:
+            raise ValueError(
+                f"num_valid_pages must be in (0, max_k_tiles={max_k_tiles}], "
+                f"got {num_valid_pages}"
+            )
+        if force_begin_blocks + force_end_blocks > num_valid_pages:
+            raise ValueError(
+                f"force_begin_blocks + force_end_blocks ({force_begin_blocks} + "
+                f"{force_end_blocks}) must be <= num_valid_pages ({num_valid_pages})"
+            )
+        nvp_dev = _dummy_nvp(max_score.device.index)
+        nvp_scalar = int(num_valid_pages)
+        # Dispatch on the runtime valid-page count: the count-rank kernel only
+        # ever touches blocks below num_valid_pages, regardless of the allocated
+        # score dimension.
+        small = nvp_scalar <= _MAX_BLOCKS
 
     if output is None:
         output = torch.empty(
@@ -173,16 +226,11 @@ def msa_topk_select(
         if output.dtype != torch.int32:
             raise ValueError(f"output must be int32, got {output.dtype}")
 
-    from .cute_dsl.topk_select_countrank_sm12x import _MAX_BLOCKS
-
-    # Dispatch on the runtime valid-page count: the count-rank kernel only ever
-    # touches blocks below num_valid_pages, regardless of the allocated score
-    # dimension.
-    small = int(num_valid_pages) <= _MAX_BLOCKS
-    _get_compiled_topk(topk, small)(
+    _get_compiled_topk(topk, small, per_token_nvp)(
         max_score,
         output,
-        int(num_valid_pages),
+        nvp_dev,
+        nvp_scalar,
         int(force_begin_blocks),
         int(force_end_blocks),
         int(total_qo_len),

--- a/tests/msa_ops/test_msa_ops.py
+++ b/tests/msa_ops/test_msa_ops.py
@@ -1645,10 +1645,13 @@ def test_msa_topk_select_countrank_matches_radix_on_nan():
     score = torch.randn(H, P, S, device=dev, dtype=torch.float32)
     score[0, 5, :] = float("nan")
     score[1, 40, ::3] = float("nan")
+    # Scalar num_valid_pages path: the per-token tensor is a signature filler
+    # the kernel does not read.
+    nvp_unused = torch.zeros(1, dtype=torch.int32, device=dev)
     outs = []
     for small in (True, False, True):
         out = torch.empty(S, H, topk, dtype=torch.int32, device=dev)
-        _get_compiled_topk(topk, small)(score, out, P, 0, 0, S, H)
+        _get_compiled_topk(topk, small)(score, out, nvp_unused, P, 0, 0, S, H)
         outs.append(out.cpu())
     assert torch.equal(outs[0], outs[2]), "count-rank nondeterministic on NaN"
     assert torch.equal(outs[0], outs[1]), "count-rank != radix on NaN scores"

--- a/tests/msa_ops/test_msa_ops.py
+++ b/tests/msa_ops/test_msa_ops.py
@@ -1713,7 +1713,7 @@ def test_msa_topk_select_countrank_matches_radix_on_nan():
     outs = []
     for small in (True, False, True):
         out = torch.empty(S, H, topk, dtype=torch.int32, device=dev)
-        _get_compiled_topk(topk, small)(score, out, nvp_unused, P, 0, 0, S, H)
+        _get_compiled_topk(topk, small, False)(score, out, nvp_unused, P, 0, 0, S, H)
         outs.append(out.cpu())
     assert torch.equal(outs[0], outs[2]), "count-rank nondeterministic on NaN"
     assert torch.equal(outs[0], outs[1]), "count-rank != radix on NaN scores"

--- a/tests/msa_ops/test_msa_ops.py
+++ b/tests/msa_ops/test_msa_ops.py
@@ -1216,6 +1216,68 @@ def test_msa_proxy_score_decode_packed(B, Hq, Hkv, seqlen_q, seqlen_k, causal):
 
 
 @pytest.mark.parametrize(
+    "Hq,Hkv,seqs_q,seqs_k",
+    [
+        (4, 1, [8, 3, 1], [2048, 300, 1280]),  # group 4, mixed q lens, ragged tail
+        (8, 2, [2, 2], [1024, 640]),  # group 4 (Hq/Hkv), multi kv-head
+    ],
+)
+def test_msa_proxy_score_decode_packed_paged(Hq, Hkv, seqs_q, seqs_k):
+    """Paged KV on the packed decode schedule (flat-only elsewhere).
+
+    ``seqused_k`` reaches the kernel as per-request lengths rather than a prefix
+    sum, so only a heterogeneous batch separates the two derivations. Paged must
+    also stay bit-identical to flat, page permutation and ragged tail included.
+    """
+    _skip_if_unsupported()
+    from flashinfer.msa_ops import msa_proxy_score
+
+    torch.manual_seed(180 + Hq)
+    dev = "cuda"
+    B = len(seqs_k)
+    cu_q = torch.tensor(
+        [0] + list(torch.tensor(seqs_q).cumsum(0)), dtype=torch.int32, device=dev
+    )
+    cu_k = torch.tensor(
+        [0] + list(torch.tensor(seqs_k).cumsum(0)), dtype=torch.int32, device=dev
+    )
+    total_q, total_k = int(cu_q[-1]), int(cu_k[-1])
+    q = torch.randn(total_q, Hq, 128, dtype=torch.bfloat16, device=dev) / 3
+    k = torch.randn(total_k, Hkv, 128, dtype=torch.bfloat16, device=dev) / 3
+
+    out_flat = msa_proxy_score(q, k, cu_q, cu_k, causal=True)
+    torch.cuda.synchronize()
+    ref = _ref_proxy_score(
+        q.cpu(), k.cpu(), cu_q.cpu(), cu_k.cpu(), True, out_flat.shape[1]
+    )
+    got = out_flat.cpu()
+    assert ((got == float("-inf")) == (ref == float("-inf"))).all(), "-inf pattern"
+    fin = ref != float("-inf")
+    assert (got[fin] - ref[fin]).abs().max().item() < 1e-2
+
+    # The same K behind a shuffled page table must reproduce it bit-identically.
+    npg = [-(-s // BLK_KV) for s in seqs_k]
+    perm = torch.randperm(sum(npg))
+    k_pg = torch.zeros(sum(npg), Hkv, BLK_KV, 128, dtype=torch.bfloat16, device=dev)
+    ptab = torch.full((B, max(npg)), -1, dtype=torch.int32, device=dev)
+    pi = 0
+    for b in range(B):
+        for blk in range(npg[b]):
+            pg = int(perm[pi])
+            pi += 1
+            ptab[b, blk] = pg
+            lo = int(cu_k[b]) + blk * BLK_KV
+            hi = min(lo + BLK_KV, int(cu_k[b + 1]))
+            k_pg[pg, :, : hi - lo] = k[lo:hi].transpose(0, 1)
+    seqused = torch.tensor(seqs_k, dtype=torch.int32, device=dev)
+    out_paged = msa_proxy_score(
+        q, k_pg, cu_q, page_table=ptab, seqused_k=seqused, causal=True
+    )
+    torch.cuda.synchronize()
+    assert torch.equal(out_paged, out_flat)
+
+
+@pytest.mark.parametrize(
     "Hq,Hkv,paged,explicit_qoff",
     [
         (4, 1, False, False),  # M3 shape, ragged flat

--- a/tests/msa_ops/test_msa_topk_per_token.py
+++ b/tests/msa_ops/test_msa_topk_per_token.py
@@ -151,9 +151,8 @@ def test_per_token_is_cuda_graph_safe():
     g = torch.cuda.CUDAGraph()
     s = torch.cuda.Stream()
     s.wait_stream(torch.cuda.current_stream())
-    with torch.cuda.stream(s):
-        with torch.cuda.graph(g):
-            run()
+    with torch.cuda.stream(s), torch.cuda.graph(g):
+        run()
     torch.cuda.current_stream().wait_stream(s)
 
     eager = msa_topk_select(

--- a/tests/msa_ops/test_msa_topk_per_token.py
+++ b/tests/msa_ops/test_msa_topk_per_token.py
@@ -90,6 +90,39 @@ def test_per_token_output_contract(P):
             assert (row[len(valid) :] == -1).all(), f"token {s} head {h} mid-array -1"
 
 
+@pytest.mark.parametrize("P", [24, 160])
+def test_per_token_out_of_range_is_clamped(P):
+    """Entries outside ``[0, max_k_tiles]`` must be clamped in-kernel.
+
+    Nothing on the host bounds the tensor's values (checking them would sync),
+    and callers derive the count and ``max_k_tiles`` from different metadata, so
+    a too-large entry is reachable. Unclamped it reads ``max_score`` out of
+    bounds -- and on the count-rank path overruns the smem staging buffer -- and
+    emits block indices the attend kernel cannot address.
+    """
+    H, S = 2, 6
+    fb, fe = 1, 2
+    max_score = _distinct_scores(H, P, S, seed=41 + P)
+    raw = [P + 1, 2 * P, 2**31 - 1, 0, -5, P]
+    nvp = torch.tensor(raw, dtype=torch.int32, device="cuda")
+
+    got = msa_topk_select(
+        max_score, TOPK, num_valid_pages=nvp, force_begin_blocks=fb, force_end_blocks=fe
+    ).cpu()
+    # Every over-range entry must behave exactly like a full-extent one.
+    full = msa_topk_select(
+        max_score, TOPK, num_valid_pages=P, force_begin_blocks=fb, force_end_blocks=fe
+    ).cpu()
+
+    for s, v in enumerate(raw):
+        if min(max(v, 0), P) == 0:
+            assert (got[s] == -1).all(), f"token {s}: empty extent must be all -1"
+        else:
+            torch.testing.assert_close(
+                got[s], full[s], msg=f"token {s} (nvp={v}) not clamped to {P}"
+            )
+
+
 def test_per_token_forces_each_tokens_own_local_window():
     """``force_end_blocks`` must denote each token's own trailing blocks, which
     is the property a batch-wide scalar cannot express."""

--- a/tests/msa_ops/test_msa_topk_per_token.py
+++ b/tests/msa_ops/test_msa_topk_per_token.py
@@ -1,0 +1,164 @@
+"""Per-token ``num_valid_pages`` for ``msa_topk_select``.
+
+Callers whose query tokens have differing causal KV extents (decode batches,
+chunked prefill) previously had to recover per-token semantics on the host with
+a scatter + mask + sort. These tests pin the in-kernel behaviour that replaces
+that: per-token clamping, a per-token trailing local window, and the output
+contract (ascending, ``-1`` tail-padded).
+"""
+
+import pytest
+import torch
+
+from flashinfer.msa_ops import msa_topk_select
+from flashinfer.utils import is_sm12x_supported
+
+pytestmark = pytest.mark.skipif(
+    not torch.cuda.is_available() or not is_sm12x_supported(torch.device("cuda")),
+    reason="msa_ops requires SM120/SM121",
+)
+
+TOPK = 16
+
+
+def _distinct_scores(H, P, S, seed):
+    """A permutation, so no two blocks tie: count-rank and radix agree only on
+    distinct inputs, and these tests compare across that dispatch boundary."""
+    g = torch.Generator(device="cuda").manual_seed(seed)
+    flat = torch.randperm(H * P * S, generator=g, device="cuda").to(torch.float32)
+    return flat.reshape(H, P, S).contiguous()
+
+
+@pytest.mark.parametrize("P", [24, 160])
+@pytest.mark.parametrize("fb,fe", [(0, 0), (0, 1), (1, 1), (2, 3)])
+def test_per_token_matches_scalar_per_token(P, fb, fe):
+    """A per-token tensor must equal invoking the scalar path once per token.
+
+    At P=160 the tensor call dispatches to radix (bounded by max_k_tiles) while
+    most single-token reference calls dispatch to count-rank, so this also
+    cross-checks the two kernels against each other.
+    """
+    H, S = 2, 12
+    max_score = _distinct_scores(H, P, S, seed=7 + P + fb * 10 + fe)
+    g = torch.Generator(device="cuda").manual_seed(3)
+    nvp = torch.randint(
+        max(fb + fe, 1), P + 1, (S,), generator=g, device="cuda", dtype=torch.int32
+    )
+
+    got = msa_topk_select(
+        max_score, TOPK, num_valid_pages=nvp, force_begin_blocks=fb, force_end_blocks=fe
+    )
+    assert got.shape == (S, H, TOPK)
+
+    for s in range(S):
+        ref = msa_topk_select(
+            max_score[:, :, s : s + 1].contiguous(),
+            TOPK,
+            num_valid_pages=int(nvp[s]),
+            force_begin_blocks=fb,
+            force_end_blocks=fe,
+        )
+        torch.testing.assert_close(got[s : s + 1], ref, msg=f"token {s} differs")
+
+
+@pytest.mark.parametrize("P", [24, 160])
+def test_per_token_output_contract(P):
+    """Every token, including ones shorter than the forced region, must yield
+    ascending in-range indices with ``-1`` only as a tail pad."""
+    H, S = 2, 64
+    fb, fe = 1, 2
+    max_score = _distinct_scores(H, P, S, seed=11 + P)
+    # Deliberately include extents below fb+fe: the scalar API rejects those,
+    # so only the in-kernel clamp can handle them.
+    g = torch.Generator(device="cuda").manual_seed(5)
+    nvp = torch.randint(1, P + 1, (S,), generator=g, device="cuda", dtype=torch.int32)
+
+    out = msa_topk_select(
+        max_score, TOPK, num_valid_pages=nvp, force_begin_blocks=fb, force_end_blocks=fe
+    ).cpu()
+    nvp_c = nvp.cpu()
+
+    for s in range(S):
+        n = int(nvp_c[s])
+        for h in range(H):
+            row = out[s, h]
+            valid = row[row >= 0]
+            assert len(valid) == min(TOPK, n), f"token {s} head {h}: {row.tolist()}"
+            assert (valid < n).all(), f"token {s} head {h} exceeds extent {n}"
+            assert (valid[1:] > valid[:-1]).all(), f"token {s} head {h} not ascending"
+            # -1 must be a pure tail pad, never a hole.
+            assert (row[len(valid) :] == -1).all(), f"token {s} head {h} mid-array -1"
+
+
+def test_per_token_forces_each_tokens_own_local_window():
+    """``force_end_blocks`` must denote each token's own trailing blocks, which
+    is the property a batch-wide scalar cannot express."""
+    H, S, P = 1, 8, 40
+    fe = 2
+    max_score = _distinct_scores(H, P, S, seed=23)
+    nvp = torch.arange(4, 4 + S, device="cuda", dtype=torch.int32)
+
+    out = msa_topk_select(
+        max_score, TOPK, num_valid_pages=nvp, force_begin_blocks=0, force_end_blocks=fe
+    ).cpu()
+
+    for s in range(S):
+        n = int(nvp[s])
+        sel = set(out[s, 0].tolist())
+        for j in range(n - fe, n):
+            assert j in sel, f"token {s}: local block {j} not forced (extent {n})"
+
+
+def test_per_token_input_guards():
+    H, P, S = 2, 32, 4
+    max_score = torch.randn(H, P, S, device="cuda", dtype=torch.float32)
+
+    with pytest.raises(ValueError, match="1D int32"):
+        msa_topk_select(
+            max_score,
+            TOPK,
+            num_valid_pages=torch.ones(S, device="cuda", dtype=torch.int64),
+        )
+    with pytest.raises(ValueError, match="total_qo_len"):
+        msa_topk_select(
+            max_score,
+            TOPK,
+            num_valid_pages=torch.ones(S + 1, device="cuda", dtype=torch.int32),
+        )
+
+
+def test_per_token_is_cuda_graph_safe():
+    """The whole point of moving these bounds in-kernel is to stop the caller
+    doing host-side repair; that only pays off if the call captures."""
+    H, P, S = 2, 32, 8
+    max_score = _distinct_scores(H, P, S, seed=31)
+    nvp = torch.randint(1, P + 1, (S,), device="cuda", dtype=torch.int32)
+    out = torch.empty((S, H, TOPK), dtype=torch.int32, device="cuda")
+
+    def run():
+        msa_topk_select(
+            max_score,
+            TOPK,
+            num_valid_pages=nvp,
+            force_begin_blocks=0,
+            force_end_blocks=1,
+            output=out,
+        )
+
+    run()  # warm the compile cache outside capture
+    torch.cuda.synchronize()
+
+    g = torch.cuda.CUDAGraph()
+    s = torch.cuda.Stream()
+    s.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(s):
+        with torch.cuda.graph(g):
+            run()
+    torch.cuda.current_stream().wait_stream(s)
+
+    eager = msa_topk_select(
+        max_score, TOPK, num_valid_pages=nvp, force_begin_blocks=0, force_end_blocks=1
+    )
+    g.replay()
+    torch.cuda.synchronize()
+    torch.testing.assert_close(out, eager)

--- a/tests/msa_ops/test_proxy_fp4.py
+++ b/tests/msa_ops/test_proxy_fp4.py
@@ -178,6 +178,132 @@ def test_proxy_fp4_selection_overlap_vs_bf16():
     assert mean_overlap > 0.8, f"mean topk overlap {mean_overlap} too low"
 
 
+def _paged_fp4_k(k, seqs_k, Hkv):
+    """Scatter a flat varlen K into shuffled pages and quantize page-major, so
+    the SF row order matches the paged kernel's ``(page*Hkv + kv_head)*128 +
+    token``. A ragged final page keeps its zero-filled tail.
+
+    Returns ``(k_pg, k_pg_scale, inv_k, page_table, per-request dequantized K)``.
+    """
+    from flashinfer import nvfp4_quantize
+
+    dev = k.device
+    npg = [-(-s // BLK_KV) for s in seqs_k]
+    total_pages = sum(npg)
+    perm = torch.randperm(total_pages)
+    k_pg_bf16 = torch.zeros(
+        total_pages, Hkv, BLK_KV, 128, dtype=torch.bfloat16, device=dev
+    )
+    ptab = torch.full((len(seqs_k), max(npg)), -1, dtype=torch.int32, device=dev)
+    base, pi = 0, 0
+    for b, sk in enumerate(seqs_k):
+        for blk in range(npg[b]):
+            pg = int(perm[pi])
+            pi += 1
+            ptab[b, blk] = pg
+            lo = base + blk * BLK_KV
+            hi = min(lo + BLK_KV, base + sk)
+            k_pg_bf16[pg, :, : hi - lo] = k[lo:hi].transpose(0, 1)
+        base += sk
+    gsf_k = (448.0 * 6.0) / k.float().abs().max()
+    inv_k = 1.0 / float(gsf_k)
+    kq, ksf = nvfp4_quantize(
+        k_pg_bf16.reshape(-1, 128), gsf_k.reshape(1).to(dev), sf_vec_size=16
+    )
+    k_pg = kq.view(torch.uint8).reshape(total_pages, Hkv, BLK_KV, 64)
+    k_pg_scale = ksf.view(torch.uint8).reshape(-1)
+
+    # Dequantize page-major, then gather each request's logical K for the oracle.
+    pg_deq = (
+        _dequant_128x4(
+            k_pg.reshape(-1, 64).cpu(),
+            k_pg_scale.cpu(),
+            1.0,
+            total_pages * Hkv * BLK_KV,
+        )
+        .reshape(total_pages, Hkv, BLK_KV, 128)
+        .to(torch.bfloat16)
+    )
+    k_deqs = []
+    for b, sk in enumerate(seqs_k):
+        rows = torch.empty(sk, Hkv, 128, dtype=torch.bfloat16)
+        for blk in range(npg[b]):
+            lo, hi = blk * BLK_KV, min((blk + 1) * BLK_KV, sk)
+            rows[lo:hi] = pg_deq[int(ptab[b, blk])].transpose(0, 1)[: hi - lo]
+        k_deqs.append(rows)
+    return k_pg, k_pg_scale, inv_k, ptab, k_deqs
+
+
+@pytest.mark.parametrize(
+    "Hq,Hkv,seqs_q",
+    [
+        (8, 2, [160, 33, 96]),  # q_len > 32 at group 4 -> general fp4-MMA schedule
+        (32, 2, [8, 3, 1]),  # q_len <= 8 at group 16 -> packed decode schedule
+    ],
+)
+def test_proxy_fp4_paged_varlen(Hq, Hkv, seqs_q):
+    """Paged fp4 over a heterogeneous batch.
+
+    ``seqused_k`` reaches the kernel as per-request lengths rather than a prefix
+    sum; at batch 1 the two forms are indistinguishable, so only B >= 2 with
+    distinct lengths separates them. Covers both fp4 schedules, a ragged final
+    page, and (unlike the B=1 paged tests) multi-kv-head SF row indexing.
+    """
+    _skip_if_unsupported()
+    from flashinfer.msa_ops import msa_proxy_score_fp4
+    from flashinfer.msa_ops.proxy_score import _quantize_qk_to_nvfp4
+
+    torch.manual_seed(99 + Hq)
+    dev = "cuda"
+    group_size = Hq // Hkv
+    seqs_k = [1024, 300, 1536]
+    cu_q = torch.tensor(
+        [0] + list(torch.tensor(seqs_q).cumsum(0)), dtype=torch.int32, device=dev
+    )
+    total_q, total_k = int(cu_q[-1]), sum(seqs_k)
+    seqused = torch.tensor(seqs_k, dtype=torch.int32, device=dev)
+
+    q = torch.randn(total_q, Hq, 128, dtype=torch.bfloat16, device=dev) * 2
+    k = torch.randn(total_k, Hkv, 128, dtype=torch.bfloat16, device=dev) * 2
+    q_fp4, q_scale, inv_q = _quantize_qk_to_nvfp4(q)
+    k_pg, k_pg_scale, inv_k, ptab, k_deqs = _paged_fp4_k(k, seqs_k, Hkv)
+
+    out = msa_proxy_score_fp4(
+        q_fp4,
+        k_pg,
+        q_scale,
+        k_pg_scale,
+        inv_q,
+        inv_k,
+        cu_q,
+        page_table=ptab,
+        seqused_k=seqused,
+        causal=True,
+    )
+    torch.cuda.synchronize()
+    mkt = max(-(-s // BLK_KV) for s in seqs_k)
+    assert out.shape == (Hq, mkt, total_q)
+
+    q_deq = (
+        _dequant_128x4(
+            q_fp4.reshape(-1, 64).cpu(), q_scale.cpu(), inv_q * inv_k, total_q * Hq
+        )
+        .reshape(total_q, Hq, 128)
+        .to(torch.bfloat16)
+    )
+    # Blocks past a request's own extent stay -inf, so build the padded oracle.
+    ref = torch.full((Hq, mkt, total_q), -float("inf"), dtype=torch.float32)
+    for b, sk in enumerate(seqs_k):
+        qlo, qhi = int(cu_q[b]), int(cu_q[b + 1])
+        sub = _ref_proxy_fp4(q_deq[qlo:qhi], k_deqs[b], qhi - qlo, sk, group_size, True)
+        ref[:, : sub.shape[1], qlo:qhi] = sub
+    got = out.float().cpu()
+    finite = torch.isfinite(ref)
+    assert (torch.isfinite(got) == finite).all(), "finite/-inf mask mismatch"
+    rel = ((got[finite] - ref[finite]).abs() / ref[finite].abs().clamp_min(1.0)).max()
+    assert rel < 5e-2, f"paged varlen max rel err {rel}"
+
+
 def test_proxy_fp4_paged():
     """group_size 4 dispatches the general, non-packed fp4-MMA schedule."""
     _skip_if_unsupported()


### PR DESCRIPTION

<!-- .github/pull_request_template.md -->

## 📌 Description
Two independent changes to the SM120/SM121 MSA ops, both aimed at per-call overhead on the decode path -- 

1. Paged paths rebuilt a prefix sum they did not need 
`msa_proxy_score`, `msa_proxy_score_fp4` and `msa_sparse_decode_attention` each did this on every paged call:
```
cu_k = torch.zeros(batch_size + 1, dtype=torch.int32, device=dev)
cu_k[1:] = seqused_k.to(dev).cumsum(0)
```
so the kernel could do `seqlen_k = mCuK[b + 1] - mCuK[b]` and recover a number the caller already had in `seqused_k`.

On the paged path `page_table` supplies every KV address, so `k_start` is dead — it is read only in the flat branches (`sparse_decode_sm12x.py` lines 470/474/ 633/637/648, and the equivalents in the proxy kernels). Only `seqlen_k` is used, for masking.

The fix passes `seqused_k` straight through and takes the length directly under a `const_expr` paged branch, so there is no runtime cost to the distinction:

```python
if cutlass.const_expr(self._paged):
    k_start = cutlass.Int32(0)
    seqlen_k = mCuK[batch_idx]
else:
    k_start = mCuK[batch_idx]
    seqlen_k = mCuK[batch_idx + 1] - k_start
```
2. `msa_topk_select` takes only batch-wide scalars
.`num_valid_pages` and `force_end_blocks` were ints, so a caller whose query tokens have differing causal KV extents — any decode batch, any chunked prefill — could not express per-token semantics. The only recourse was to post-process on the host. vLLM's MiniMax-M3 integration does exactly that: bias each token's local window with a `scatter_` of `FLT_MAX`, then repair the output with a comparison, a `masked_fill_` and a `sort`.

`num_valid_pages` may now be an int32 tensor of shape `(total_qo_len,)`. The kernel then clamps each token's candidate range to its own extent and forces that token's own trailing `force_end_blocks`, which is what the scatter was emulating. Consequences:

* no selected index can exceed its token's extent, so no masking pass
* the ascending, `-1`-tail-padded contract holds by construction, so no sort
* the forced region is clamped in-kernel against `nvp`, so tokens shorter than the local window are handled instead of underflowing to negative blocks

Dispatch between the count-rank and radix kernels bounds by `max_k_tiles` on this path rather than the valid-page count: reading the tensor on the host would sync the stream, which is illegal under CUDA graph capture.

### Measurements
RTX PRO 6000 Blackwell Server Edition (SM120), MiniMax-M3 per-GPU TP4 indexer geometry (`num_idx_heads` 1, `head_dim` 128, page 128, topk 16, `init_blocks` 0, `local_blocks` 1), context 8192, heterogeneous per-request extents.

Indexer selection (proxy score + top-k), kernel launches and eager wall time per call: 

| batch | launches before | after | before | after |
|-------|-----------------|-------|--------|-------|
| 1 | 27 | 7 | 341.1 us | 107.1 us |
| 4 | 27 | 7 | 337.8 us | 107.1 us |
| 16 | 27 | 7 | 334.8 us | 106.1 us |
| 64 | 27 | 7 | 337.9 us | 108.9 us |

Paged sparse decode: **7 -\> 2** launches per call
Selections are identical to the host-side sequence they replace, verified per-token across the batch.

### End-to-end
vLLM serving MiniMax-M3 NVFP4 on 4x RTX PRO 6000, TP4, ISL 8192 / OSL 1024. . Requires the matching vLLM-side change to use FI backend for MSA

| conc | TPOT Triton | TPOT FlashInfer | ΔTPOT | TTFT Triton | TTFT FlashInfer | ΔTTFT |
|------|-------------|-----------------|-------|-------------|-----------------|-------|
| 1 | 9.28 ms | 9.38 ms | +1.1% | 1030.1 ms | 977.4 ms | −5.1% |
| 4 | 16.17 ms | 16.16 ms | −0.1% | 1229.7 ms | 1171.6 ms | −4.7% |
| 16 | 38.99 ms | 38.24 ms | −1.9% | 2023.9 ms | 1938.4 ms | −4.2% |
| 64 | 112.68 ms | **109.63 ms** | **−2.7%** | 4699.7 ms | **4460.5 ms** | **−5.1%** |

Before these changes the FlashInfer backend was a **+16.7% TPOT regression at concurrency 1 and aborted outright at 4 and 16** with an illegal memory access.

### Tests
New `tests/msa_ops/test_msa_topk_per_token.py`:

* per-token tensor equals invoking the scalar path once per token, across `force_begin`/`force_end` combinations and at both `max_k_tiles` values that straddle the count-rank/radix dispatch boundary (so it cross-checks the two kernels against each other on distinct-score inputs)
* output contract for every token, including extents shorter than the forced region — which the scalar API rejects, so only the in-kernel clamp handles it
* `force_end_blocks` forces each token's _own_ trailing blocks
* input guards
* CUDA-graph capture safety

The existing `tests/msa_ops/` suite passes (63 passed after fixing one test that called the private `_get_compiled_topk` positionally).
## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added per-token valid-page counts for top-k page selection, including input validation and bounded results.
  - Improved paged KV-cache handling with direct per-request sequence lengths.
  - Added variable-length paged FP4 decoding for general and packed execution modes.

- **Bug Fixes**
  - Corrected sequence lengths, offsets, and page boundaries across paged and flat cache paths.
  - Improved forced-region clamping for variable-length requests.

- **Tests**
  - Added coverage for heterogeneous sequences, ragged pages, validation, bounded output, and CUDA Graph compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->