### PR TITLE
fix: Force fa3 backend in DeepSeek MLA benchmark to avoid missing SM120 kernel (closes #4336)

### DIFF
--- a/benchmarks/bench_deepseek_mla.py
+++ b/benchmarks/bench_deepseek_mla.py
@@ -81,4 +81,4 @@ if __name__ == "__main__":
     for seq_len in [1024, 2048, 8192]:
         for batch_size in [64, 128, 768]:
             for num_heads in [64, 128]:
-                bench_deepseek_mla_decode(batch_size, seq_len, num_heads, "auto")
+                bench_deepseek_mla_decode(batch_size, seq_len, num_heads, "fa3")


### PR DESCRIPTION
## What
The benchmark script `benchmarks/bench_deepseek_mla.py` uses the generic `"auto"` backend selection, which on SM120 (GB10) can dispatch to a sparse MLA decode kernel that lacks the required (32, 256) top-k instance. This causes a crash (missing kernel error) when using DeepSeek-V4-Flash-0731 drafts in DSPark.

## Fix
Change the backend from `"auto"` to `"fa3"` in the benchmark loop. The FA3 backend provides the required kernel instances for SM120 and is the recommended backend for DeepSeek-V4-Flash-0731. This minimal fix ensures the benchmark runs without kernel dispatch issues on this hardware.

Closes #4336

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated the DeepSeek MLA benchmark to use the FA3 backend explicitly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->