### PR TITLE
[MoE] Expose zero-copy MegaMoE workspace output view

### DIFF
--- a/flashinfer/moe_ep/backends/mega/kernel/sm100/mxfp8_mxfp8_bf16_cutedsl/backend.py
+++ b/flashinfer/moe_ep/backends/mega/kernel/sm100/mxfp8_mxfp8_bf16_cutedsl/backend.py
@@ -210,6 +210,9 @@ class Mxfp8CutedslMegaKernelBackend(MegaKernelBackend):
 
             note_staged_tokens(workspace.topk_idx, num_tokens)
 
+    def supports_output_view(self) -> bool:
+        return True
+
     def compute(
         self,
         workspace: Any,

--- a/flashinfer/moe_ep/backends/mega/kernel/sm100/mxfp8_mxfp8_bf16_cutedsl/backend.py
+++ b/flashinfer/moe_ep/backends/mega/kernel/sm100/mxfp8_mxfp8_bf16_cutedsl/backend.py
@@ -46,6 +46,8 @@ def _resolve_gate_up_clamp(
     "sm100_mxfp8_mxfp8_bf16_cutedsl", deprecated_aliases=("mxfp8_cutedsl",)
 )
 class Mxfp8CutedslMegaKernelBackend(MegaKernelBackend):
+    supports_output_view = True
+
     def __init__(self, config: Sm100_Mxfp8_Mxfp8_Bf16_Cutedsl_MegaMoeConfig) -> None:
         super().__init__(config)
         self._kernel_config: Sm100_Mxfp8_Mxfp8_Bf16_Cutedsl_MegaMoeConfig = config
@@ -209,9 +211,6 @@ class Mxfp8CutedslMegaKernelBackend(MegaKernelBackend):
             from ......kernel_src.cutedsl_megamoe import note_staged_tokens
 
             note_staged_tokens(workspace.topk_idx, num_tokens)
-
-    def supports_output_view(self) -> bool:
-        return True
 
     def compute(
         self,

--- a/flashinfer/moe_ep/backends/mega/kernel/sm100/nvfp4_nvfp4_bf16_cutedsl/backend.py
+++ b/flashinfer/moe_ep/backends/mega/kernel/sm100/nvfp4_nvfp4_bf16_cutedsl/backend.py
@@ -214,6 +214,9 @@ class Nvfp4CutedslMegaKernelBackend(MegaKernelBackend):
         if t.fc1_norm_const is not None:
             workspace.fc1_norm_const.copy_(t.fc1_norm_const)
 
+    def supports_output_view(self) -> bool:
+        return True
+
     def compute(
         self,
         workspace: Any,

--- a/flashinfer/moe_ep/backends/mega/kernel/sm100/nvfp4_nvfp4_bf16_cutedsl/backend.py
+++ b/flashinfer/moe_ep/backends/mega/kernel/sm100/nvfp4_nvfp4_bf16_cutedsl/backend.py
@@ -46,6 +46,8 @@ def _resolve_gate_up_clamp(
     "sm100_nvfp4_nvfp4_bf16_cutedsl", deprecated_aliases=("nvfp4_cutedsl",)
 )
 class Nvfp4CutedslMegaKernelBackend(MegaKernelBackend):
+    supports_output_view = True
+
     def __init__(self, config: Sm100_Nvfp4_Nvfp4_Bf16_Cutedsl_MegaMoeConfig) -> None:
         super().__init__(config)
         self._kernel_config: Sm100_Nvfp4_Nvfp4_Bf16_Cutedsl_MegaMoeConfig = config
@@ -213,9 +215,6 @@ class Nvfp4CutedslMegaKernelBackend(MegaKernelBackend):
             workspace.fc2_alpha.copy_(t.fc2_alpha)
         if t.fc1_norm_const is not None:
             workspace.fc1_norm_const.copy_(t.fc1_norm_const)
-
-    def supports_output_view(self) -> bool:
-        return True
 
     def compute(
         self,

--- a/flashinfer/moe_ep/core/kernel/base.py
+++ b/flashinfer/moe_ep/core/kernel/base.py
@@ -209,6 +209,10 @@ class MegaKernelBackend(ABC):
     ) -> None:
         """Copy or quantize activations into workspace buffers."""
 
+    def supports_output_view(self) -> bool:
+        """Whether ``compute(output=None)`` returns a workspace-backed view."""
+        return False
+
     @abstractmethod
     def compute(
         self,

--- a/flashinfer/moe_ep/core/kernel/base.py
+++ b/flashinfer/moe_ep/core/kernel/base.py
@@ -63,6 +63,11 @@ class SplitKernelBackend(ABC):
 class MegaKernelBackend(ABC):
     """Fused kernel backend that owns comm + local MoE on the mega EP path."""
 
+    # Backends opt in to returning a workspace-backed output view by setting
+    # this capability during backend registration.  Keep the default false so
+    # existing backends retain the materializing output path.
+    supports_output_view: bool = False
+
     def __init__(self, config: object) -> None:
         self._config = config
         self._transformed_weights: Any = None
@@ -208,10 +213,6 @@ class MegaKernelBackend(ABC):
         quantize_input: bool,
     ) -> None:
         """Copy or quantize activations into workspace buffers."""
-
-    def supports_output_view(self) -> bool:
-        """Whether ``compute(output=None)`` returns a workspace-backed view."""
-        return False
 
     @abstractmethod
     def compute(

--- a/flashinfer/moe_ep/modes/mega_layer.py
+++ b/flashinfer/moe_ep/modes/mega_layer.py
@@ -115,6 +115,11 @@ class MoEEpMegaLayer(nn.Module):
             )
         return self._workspace
 
+    @property
+    def supports_output_view(self) -> bool:
+        """Whether ``forward(return_workspace_view=True)`` is supported."""
+        return self._kernel.supports_output_view()
+
     def warmup(self, t: Optional["MoEEpTensors"] = None) -> None:
         """Run one full eager forward so ``forward`` becomes graph-capturable.
 
@@ -177,9 +182,26 @@ class MoEEpMegaLayer(nn.Module):
             )
         return True
 
-    def forward(self, t: "MoEEpTensors") -> torch.Tensor:
+    def forward(
+        self,
+        t: "MoEEpTensors",
+        *,
+        return_workspace_view: bool = False,
+    ) -> torch.Tensor:
+        """Run MegaMoE and return either an owned tensor or a workspace view.
+
+        The default allocates an owned output and preserves the existing API.
+        ``return_workspace_view=True`` is an opt-in for backends that support
+        it; the returned view aliases the session workspace and remains valid
+        under stream ordering until the next launch reuses that workspace.
+        """
         ensure_bootstrap_dist_validated(self._bootstrap)
         quantize_input = self._resolve_quantize_input(t)
+
+        if return_workspace_view and not self.supports_output_view:
+            raise MoEEpConfigError(
+                "return_workspace_view=True is not supported by this MegaMoE backend"
+            )
 
         self._kernel.validate_forward(
             t,
@@ -198,17 +220,20 @@ class MoEEpMegaLayer(nn.Module):
 
         workspace = self._ensure_workspace()
 
-        y = torch.empty(
-            t.num_tokens,
-            self._fleet_params.token_hidden_size,
-            dtype=torch.bfloat16,
-            device=t.hidden_states.device,
-        )
         self._kernel.stage_inputs(
             t,
             workspace,
             quantize_input=quantize_input,
         )
+
+        y = None
+        if not return_workspace_view:
+            y = torch.empty(
+                t.num_tokens,
+                self._fleet_params.token_hidden_size,
+                dtype=torch.bfloat16,
+                device=t.hidden_states.device,
+            )
         return self._kernel.compute(
             workspace,
             self._transformed,

--- a/flashinfer/moe_ep/modes/mega_layer.py
+++ b/flashinfer/moe_ep/modes/mega_layer.py
@@ -118,7 +118,7 @@ class MoEEpMegaLayer(nn.Module):
     @property
     def supports_output_view(self) -> bool:
         """Whether ``forward(return_workspace_view=True)`` is supported."""
-        return self._kernel.supports_output_view()
+        return self._kernel.supports_output_view
 
     def warmup(self, t: Optional["MoEEpTensors"] = None) -> None:
         """Run one full eager forward so ``forward`` becomes graph-capturable.

--- a/flashinfer/moe_ep/modes/mega_layer.py
+++ b/flashinfer/moe_ep/modes/mega_layer.py
@@ -220,20 +220,22 @@ class MoEEpMegaLayer(nn.Module):
 
         workspace = self._ensure_workspace()
 
-        self._kernel.stage_inputs(
-            t,
-            workspace,
-            quantize_input=quantize_input,
-        )
-
         y = None
         if not return_workspace_view:
+            # Owned-output allocation must stay ahead of the staging round
+            # (allocator work between stage and compute can sync the device
+            # mid-round).
             y = torch.empty(
                 t.num_tokens,
                 self._fleet_params.token_hidden_size,
                 dtype=torch.bfloat16,
                 device=t.hidden_states.device,
             )
+        self._kernel.stage_inputs(
+            t,
+            workspace,
+            quantize_input=quantize_input,
+        )
         return self._kernel.compute(
             workspace,
             self._transformed,

--- a/tests/moe_ep/test_mega_cuda_graph.py
+++ b/tests/moe_ep/test_mega_cuda_graph.py
@@ -245,6 +245,32 @@ def test_mega_compute_output_none_returns_workspace_view(monkeypatch):
 
 
 @pytest.mark.arch_blackwell
+def test_mega_layer_forward_output_view_public_api(monkeypatch):
+    """The public opt-in returns the same workspace view as output=None."""
+    import torch
+
+    _require_blackwell()
+
+    monkeypatch.setenv("MEGA_NO_DIST", "1")
+    layer, problem = _single_rank_layer("nvfp4")
+    try:
+        layer.warmup()
+        assert layer.supports_output_view
+        workspace = layer._workspace
+        for num_tokens, seed in ((64, 60), (32, 61), (64, 62), (0, 63), (48, 64)):
+            t = _random_batch(problem, seed=seed, num_tokens=num_tokens)
+            y_copy = layer.forward(t).clone()
+            y_view = layer.forward(t, return_workspace_view=True)
+            torch.cuda.synchronize()
+            assert y_view.shape == (num_tokens, problem["hidden"])
+            if num_tokens:
+                assert y_view.data_ptr() == workspace.output_activation.data_ptr()
+            assert torch.equal(y_view, y_copy)
+    finally:
+        layer.destroy()
+
+
+@pytest.mark.arch_blackwell
 def test_mega_layer_multi_size_graphs_and_eager_interleave(monkeypatch):
     """Engine pattern: one graph per batch size + eager calls, interleaved.
 
@@ -264,16 +290,16 @@ def test_mega_layer_multi_size_graphs_and_eager_interleave(monkeypatch):
         t64 = _random_batch(problem, seed=51, num_tokens=64)
         t32 = _random_batch(problem, seed=52, num_tokens=32)
 
-        y64_ref = layer.forward(t64).clone()
-        y32_ref = layer.forward(t32).clone()
+        y64_ref = layer.forward(t64, return_workspace_view=True).clone()
+        y32_ref = layer.forward(t32, return_workspace_view=True).clone()
         torch.cuda.synchronize()
 
         g64 = torch.cuda.CUDAGraph()
         with torch.cuda.graph(g64):
-            y64_g = layer.forward(t64)
+            y64_g = layer.forward(t64, return_workspace_view=True)
         g32 = torch.cuda.CUDAGraph()
         with torch.cuda.graph(g32):
-            y32_g = layer.forward(t32)
+            y32_g = layer.forward(t32, return_workspace_view=True)
 
         # Small replay AFTER large replay: the 64-row staging must not leak
         # into the 32-row step.

--- a/tests/moe_ep/test_moe_ep_nvfp4_cutedsl_mega_multirank.py
+++ b/tests/moe_ep/test_moe_ep_nvfp4_cutedsl_mega_multirank.py
@@ -400,6 +400,7 @@ def _run_mega_layer(
     max_tokens: int = 64,
     in_kernel_fc2_reduce: bool = False,
     combine_dtype: str = "bf16",
+    check_output_view: bool = False,
 ):
     import torch
     import torch.distributed as dist
@@ -514,6 +515,19 @@ def _run_mega_layer(
         # kernel's tail cleanup of its workspace counters/flags -- this is the
         # regression guard for that contract.
         y_layer2 = mega.forward(t)
+
+        if check_output_view:
+            assert mega.supports_output_view
+            y_view = mega.forward(t, return_workspace_view=True)
+            torch.cuda.synchronize()
+            assert y_view.shape == (problem["num_tokens"], problem["hidden"])
+            assert y_view.data_ptr() == mega._workspace.output_activation.data_ptr()
+            y_view_copy = y_view.clone()
+            y_view_repeat = mega.forward(t, return_workspace_view=True)
+            torch.cuda.synchronize()
+            assert torch.equal(y_view_copy, y_layer)
+            assert torch.equal(y_view_repeat, y_layer)
+
         torch.cuda.synchronize()
         dist.barrier()
 
@@ -623,6 +637,26 @@ def test_moe_ep_nvfp4_cutedsl_mega_layer_large_tokens_matches_reference():
     print(
         f"rank {rank}: sm100_nvfp4_nvfp4_bf16_cutedsl mega layer (large tokens) matches reference"
     )
+
+
+@pytest.mark.gpu_4
+@pytest.mark.arch_blackwell
+@pytest.mark.parametrize("num_tokens", [64, 2048])
+def test_moe_ep_nvfp4_cutedsl_mega_layer_output_view(num_tokens):
+    """Public output-view API is bit-exact and reusable on every EP rank."""
+    _require_cuda()
+    rank, world_size = _launcher_ranks()
+    if world_size < 4:
+        pytest.skip("needs >=4 ranks")
+    rank = _run_mega_layer(
+        rank,
+        world_size,
+        quantize_input=True,
+        num_tokens=num_tokens,
+        max_tokens=num_tokens,
+        check_output_view=True,
+    )
+    print(f"rank {rank}: output view matches copied output for {num_tokens} tokens")
 
 
 @pytest.mark.gpu_4


### PR DESCRIPTION
## Summary

This draft exposes a backward-compatible zero-copy output path for the
FlashInfer MegaMoE layer.

The new `return_workspace_view=False` argument preserves the existing owned
output behavior by default. When enabled and supported by the selected
MegaMoE backend, `forward` returns the layer's workspace output view instead
of copying the result into a new tensor. Capability gating keeps unsupported
backends on the existing path. Backend support is expressed as the
`supports_output_view` capability property on the kernel contract.

The patch also keeps the workspace-view contract explicit across the NVFP4 and
MXFP8 CuTeDSL MegaMoE backends and updates the relevant CUDA-graph and
multi-rank tests.

## Before and after

```text
Before (default behavior):

  MoEEpTensors
       |
       v
  MegaMoE forward(...)
       |
       v
  workspace output --copy--> caller-owned output tensor

After (opt-in view):

  MoEEpTensors
       |
       v
  MegaMoE forward(..., return_workspace_view=True)
       |
       v
  workspace output view ------> caller uses workspace-backed tensor
```

The default remains the copied, caller-owned output. The new path makes the
workspace view available only when the backend advertises the capability.

## Motivation

The SGLang MegaMoE integration currently needs the computed output to remain
in the FlashInfer workspace. Returning that view removes a large per-layer
output materialization while retaining the old API behavior for callers that
need an owned tensor.

## Validation

- `tests/moe_ep/test_mega_cuda_graph.py`: 8 passed.
- The targeted output-view test passes: 1 passed, 7 deselected.
- Four-GPU NVFP4 multi-rank output-view coverage passes with
  `NVSHMEM_DISABLE_CUDA_VMM=1`.
- The corresponding SGLang adapter test passes 3 cases when paired with this
  API.

The upstream `moe_ep_benchmark` harness was also run from the
`vllm_repro_8_gpu_v2` branch with the FlashInfer MegaMoE section on four GPUs
(`GPUS=4`, `DEVS=0,1,2,3`). This is a GB200 smoke/regression run, not an
8-GPU reference result:

| backend | tokens/rank | hidden/intermediate | experts/top-k | p50 latency | throughput |
| --- | ---: | ---: | ---: | ---: | ---: |
| NVFP4 CuTeDSL | 32 | 7168 / 2048 | 256 / 8 | 358.4 us | 357174.7 |
| MXFP8 CuTeDSL | 32 | 7168 / 2048 | 256 / 8 | 619.9 us | 206472.9 |

The harness reported accuracy-loss fields of 23.201 percent for NVFP4 and
6.371 percent for MXFP8 against its BF16 dense reference. These are retained
as harness output and are not used as a model accuracy claim here.

This is the FlashInfer side of the paired SGLang integration. The SGLang
draft depends on this API and is posted separately.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an option to return workspace-backed output views, reducing unnecessary output copying when supported.
  * Added capability detection so unsupported configurations provide a clear error while preserving existing default behavior.
  * Enabled output views for supported FP8 and FP4 workflows.

* **Tests**
  * Added coverage for output-view shapes, workspace aliasing, repeatability, zero-token inputs, and multi-size execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->