### PR TITLE
feat(msa): fp8 index-k and index-q support in the SM12x proxy-score kernels

### DIFF
--- a/flashinfer/msa_ops/cute_dsl/proxy_score_sm12x.py
+++ b/flashinfer/msa_ops/cute_dsl/proxy_score_sm12x.py
@@ -1732,26 +1732,27 @@ class MsaProxyScoreDecodeKeyMajorSm12x:
                     ((elems // 2, 2), hd // (mma_k * 2), q_tiles), dtype
                 )
                 rC = cute.make_rmem_tensor((4, 2, q_tiles), cutlass.Float32)
+                sK_ldsm = cute.zipped_divide(
+                    sK_warp, (16, cute.make_layout((elems, 2)), 1)
+                )
+                sK_ldsm = sK_ldsm[(lane_id % 16, (None, lane_id // 16), 0), None]
+                rK = cute.make_rmem_tensor((elems, 2, kw // mma_k), dtype)
                 if cutlass.const_expr(self._kv_fp8):
-                    # Raw e4m3 K: per canonical k16 group, each lane reads the
-                    # two u32s that hold its own fragment columns and converts
-                    # in registers (see the fp8 loop below).
-                    rK8 = cute.make_rmem_tensor((8,), dtype)
-                    rK8_u32 = cute.recast_tensor(rK8, cutlass.Uint32)
-                    kpair = cute.make_rmem_tensor(cute.make_layout(2), dtype)
-                    kpair_u32 = cute.recast_tensor(kpair, cutlass.Uint32)
-                    # Branchless lo/hi pair pick by lane-quad parity.
-                    par_mask = cutlass.Uint32(0) - cutlass.Uint32(
-                        (lane_id % 4) % 2
+                    # ldmatrix on the 16-bit view hands each lane 4 consecutive
+                    # e4m3 per u32; splitting each converted u32 into its low
+                    # and high f16 pair yields two k16 A-fragments per
+                    # 32-fp8-column group as pure register renames (the Q
+                    # fragments are permuted once below to the same column
+                    # order).
+                    rK_u32 = cute.recast_tensor(rK, cutlass.Uint32)
+                    rK_lo = cute.make_rmem_tensor((elems,), dtype)
+                    rK_hi = cute.make_rmem_tensor((elems,), dtype)
+                    rK_lo_u32 = cute.recast_tensor(rK_lo, cutlass.Uint32)
+                    rK_hi_u32 = cute.recast_tensor(rK_hi, cutlass.Uint32)
+                    rQp = cute.make_rmem_tensor(
+                        (4, kw // mma_k, q_tiles, 2), dtype
                     )
-                else:
-                    sK_ldsm = cute.zipped_divide(
-                        sK_warp, (16, cute.make_layout((elems, 2)), 1)
-                    )
-                    sK_ldsm = sK_ldsm[
-                        (lane_id % 16, (None, lane_id // 16), 0), None
-                    ]
-                    rK = cute.make_rmem_tensor((elems, 2, hd // mma_k), dtype)
+                    rQp_u32 = cute.recast_tensor(rQp, cutlass.Uint32)
 
                 if warp_id == 0:
                     cute.arch.mbarrier_wait(tma_full_mbar, 0)
@@ -1763,6 +1764,39 @@ class MsaProxyScoreDecodeKeyMajorSm12x:
                         ldsm_atom, sQ_ldsm[None, (q, None)], rQ[None, None, q]
                     )
                 cute.arch.mbarrier_arrive(tma_empty_mbar)
+
+                if cutlass.const_expr(self._kv_fp8):
+                    # One-time cross-lane permute of the Q B-fragments into
+                    # the fp8 K column order: per 32-column group, lane quad
+                    # position q4 needs columns 4*q4..4*q4+3, which sit as u32
+                    # pairs on quad lanes 2*(q4%2) (lower half) and
+                    # 2*(q4%2)+1 (upper half) of the canonical fragments.
+                    q4 = lane_id % 4
+                    src_lo = lane_id - q4 + 2 * (q4 % 2)
+                    sel_mask = cutlass.Uint32(0) - cutlass.Uint32(q4 // 2)
+                    rQ_u32 = cute.recast_tensor(rQ, cutlass.Uint32)
+                    for g in cutlass.range_constexpr(kw // mma_k):
+                        for n in cutlass.range_constexpr(q_tiles):
+                            for h in cutlass.range_constexpr(2):
+                                src = src_lo + h
+                                p0 = cute.arch.shuffle_sync(
+                                    rQ_u32[(0, 0), g, n], src
+                                )
+                                p1 = cute.arch.shuffle_sync(
+                                    rQ_u32[(1, 0), g, n], src
+                                )
+                                p2 = cute.arch.shuffle_sync(
+                                    rQ_u32[(0, 1), g, n], src
+                                )
+                                p3 = cute.arch.shuffle_sync(
+                                    rQ_u32[(1, 1), g, n], src
+                                )
+                                rQp_u32[0, g, n, h] = p0 ^ (
+                                    (p0 ^ p1) & sel_mask
+                                )
+                                rQp_u32[1, g, n, h] = p2 ^ (
+                                    (p2 ^ p3) & sel_mask
+                                )
 
                 tma_stage = 1 % num_stages
                 tma_parity = 0
@@ -1791,49 +1825,43 @@ class MsaProxyScoreDecodeKeyMajorSm12x:
                         )
 
                         if cutlass.const_expr(self._kv_fp8):
-                            # Per canonical k16 group g, lane (quad q4) reads
-                            # the raw u32 holding its fragment columns
-                            # 16g + 8cp + 2*q4 (+1), converts, and keeps the
-                            # lo/hi pair by quad parity. Every product stays
-                            # in the same mma instruction as the bf16
-                            # schedule, so the fp8 path is bit-identical to
-                            # running on dequantized K.
-                            q4 = lane_id % 4
-                            row_l = lane_id // 4
-                            for g in cutlass.range_constexpr(hd // 16):
+                            # The lower/upper regrouping puts different
+                            # products in each mma than the bf16 schedule;
+                            # with e4m3 K (and e4m3-representable q, the
+                            # deployment case) every f32 dot term is exact,
+                            # so the result still matches dequantized K
+                            # bit-for-bit.
+                            for k in cutlass.range_constexpr(kw // mma_k):
+                                cute.copy(
+                                    ldsm_atom,
+                                    sK_ldsm[None, (None, k, tma_stage)],
+                                    rK[None, None, k],
+                                )
                                 for m in cutlass.range_constexpr(2):
-                                    for u in cutlass.range_constexpr(2):
-                                        for cp in cutlass.range_constexpr(2):
-                                            row_sm = cute.coalesce(
-                                                sK_warp[
-                                                    16 * m + 8 * u + row_l,
-                                                    None,
-                                                    tma_stage,
-                                                ]
+                                    for i in cutlass.range_constexpr(
+                                        elems // 2
+                                    ):
+                                        if cutlass.const_expr(
+                                            dtype is cutlass.BFloat16
+                                        ):
+                                            lo, hi = _fp8x4_to_bf16x4(
+                                                rK_u32[i, m, k]
                                             )
-                                            src = cute.local_tile(
-                                                row_sm,
-                                                (2,),
-                                                (4 * g + 2 * cp + q4 // 2,),
+                                        else:
+                                            lo, hi = _fp8x4_to_f16x4(
+                                                rK_u32[i, m, k]
                                             )
-                                            cute.autovec_copy(src, kpair)
-                                            if cutlass.const_expr(
-                                                dtype is cutlass.BFloat16
-                                            ):
-                                                lo, hi = _fp8x4_to_bf16x4(
-                                                    kpair_u32[0]
-                                                )
-                                            else:
-                                                lo, hi = _fp8x4_to_f16x4(
-                                                    kpair_u32[0]
-                                                )
-                                            rK8_u32[u + 2 * cp] = lo ^ (
-                                                (lo ^ hi) & par_mask
-                                            )
+                                        rK_lo_u32[i] = lo
+                                        rK_hi_u32[i] = hi
                                     for n in cutlass.range_constexpr(q_tiles):
                                         _mma_m16n8k16(
-                                            rK8,
-                                            rQ[(None, g % 2), g // 2, n],
+                                            rK_lo,
+                                            rQp[None, k, n, 0],
+                                            rC[None, m, n],
+                                        )
+                                        _mma_m16n8k16(
+                                            rK_hi,
+                                            rQp[None, k, n, 1],
                                             rC[None, m, n],
                                         )
                         else:

--- a/flashinfer/msa_ops/cute_dsl/proxy_score_sm12x.py
+++ b/flashinfer/msa_ops/cute_dsl/proxy_score_sm12x.py
@@ -1260,10 +1260,11 @@ class MsaProxyScoreDecodePackedFp8Sm12x(MsaProxyScoreDecodePackedSm12x):
     @cute.jit
     def _gather_packed_q(self, mQ, sQ, q_start, kv_head, seqlen_q, tidx):
         """Gather the packed Q tile into swizzled smem, column-permuted to
-        match the converted K fragments (the K convert moves column
-        ``16g + 4m + 2h + j`` of each 32-wide block into the slot that
-        canonically holds ``16g + 8h + 2m + j``). Rows past seqlen_q are
-        zero-filled; the epilogue masks them."""
+        match the converted K fragments: within each 32-wide block, column
+        ``16g + 4m + 2h + j`` (two-bit ``m``, one-bit rest) moves to slot
+        ``16g + 8h + 2m + j``, where ``g = (c8 % 4) // 2``,
+        ``m = 2 * (c8 % 2) + i // 2``, and ``h = i % 2`` below. Rows past
+        seqlen_q are zero-filled; the epilogue masks them."""
         elems = 128 // self._dtype.width
         chunks = self._head_dim // elems
         total = self._m_block_size * chunks
@@ -1298,6 +1299,8 @@ class MsaProxyScoreDecodePackedFp8Sm12x(MsaProxyScoreDecodePackedSm12x):
                 sQ_chunk0.fill(0)
 
 
+# `createpolicy.fractional.L2::evict_first.b64` at fraction 1.0: K tiles
+# are read once per CTA, so they should not evict resident lines.
 _TMA_EVICT_FIRST = cutlass.Int64(0x12F0000000000000)
 
 

--- a/flashinfer/msa_ops/cute_dsl/proxy_score_sm12x.py
+++ b/flashinfer/msa_ops/cute_dsl/proxy_score_sm12x.py
@@ -1418,10 +1418,12 @@ class MsaProxyScoreDecodeKeyMajorSm12x:
     on both operands and the Q fragments load once per CTA and stay in
     registers across KV blocks. A fifth warp is a TMA producer feeding a
     two-stage mbarrier pipeline (Q's smem aliases K stage 0), which leaves
-    two intra-CTA barriers per block. This is what makes the schedule match
-    the single-block-per-CTA grids that split-K produces at small batch,
-    where the row-major packed schedule's per-CTA fixed phases (Q gather,
-    fill barriers, per-step Q reloads) dominate.
+    two intra-CTA barriers per block. The low per-CTA fixed cost (no Q
+    gather, no fill barriers, no per-step Q reloads) is what wins on the
+    one-block-per-CTA grids that split-K produces at small batch, and
+    measured on SM120 the schedule also beats the row-major/key-split
+    packed schedules on machine-filling grids, so it takes every fused
+    tile of at most 32 rows.
 
     Derived from vLLM's IndexDecodeScoreKernel (Apache-2.0) by Thien Tran
     (gau-nernst), adapted to flat/paged K with a kv-head mode, per-request

--- a/flashinfer/msa_ops/cute_dsl/proxy_score_sm12x.py
+++ b/flashinfer/msa_ops/cute_dsl/proxy_score_sm12x.py
@@ -1447,8 +1447,6 @@ class MsaProxyScoreDecodeKeyMajorSm12x:
             raise ValueError("only head_dim == 128 is supported")
         if group_size * pack_q_len > 32:
             raise ValueError("group_size * pack_q_len must be <= 32")
-        if kv_fp8:
-            raise NotImplementedError("fp8 K key-major schedule not yet wired")
         self._head_dim = head_dim
         self._group = group_size
         self._pack_q_len = pack_q_len
@@ -1513,18 +1511,21 @@ class MsaProxyScoreDecodeKeyMajorSm12x:
             cta_tiler=(pack, group, hd),
         )
 
+        # fp8 K arrives as a 16-bit view of the e4m3 bytes (half head_dim),
+        # so its tiles are half as wide as Q's.
+        kw = hd // 2 if cutlass.const_expr(self._kv_fp8) else hd
         if cutlass.const_expr(self._paged):
             sK_layout = cute.make_composed_layout(
                 swizzle_128b,
                 0,
                 cute.make_layout(
-                    (1, 1, self._BLOCK_K, (elems, hd // elems), self._NUM_STAGES),
+                    (1, 1, self._BLOCK_K, (elems, kw // elems), self._NUM_STAGES),
                     stride=(
                         0,
                         0,
                         elems,
                         (1, self._BLOCK_K * elems),
-                        self._BLOCK_K * hd,
+                        self._BLOCK_K * kw,
                     ),
                 ),
             )
@@ -1532,19 +1533,19 @@ class MsaProxyScoreDecodeKeyMajorSm12x:
                 tma_g2s,
                 cute.logical_divide(mK, (None, None, None, elems)),
                 sK_layout,
-                cta_tiler=(1, 1, self._BLOCK_K, hd),
+                cta_tiler=(1, 1, self._BLOCK_K, kw),
             )
         else:
             sK_layout = cute.make_composed_layout(
                 swizzle_128b,
                 0,
                 cute.make_layout(
-                    (self._BLOCK_K, 1, (elems, hd // elems), self._NUM_STAGES),
+                    (self._BLOCK_K, 1, (elems, kw // elems), self._NUM_STAGES),
                     stride=(
                         elems,
                         0,
                         (1, self._BLOCK_K * elems),
-                        self._BLOCK_K * hd,
+                        self._BLOCK_K * kw,
                     ),
                 ),
             )
@@ -1552,7 +1553,7 @@ class MsaProxyScoreDecodeKeyMajorSm12x:
                 tma_g2s,
                 cute.logical_divide(mK, (None, None, elems)),
                 sK_layout,
-                cta_tiler=(self._BLOCK_K, 1, hd),
+                cta_tiler=(self._BLOCK_K, 1, kw),
             )
 
         self.kernel(
@@ -1600,6 +1601,8 @@ class MsaProxyScoreDecodeKeyMajorSm12x:
         epi_q = q_tiles * 8
         elems = 128 // dtype.width
         mma_k = 32 * 8 // dtype.width
+
+        kw = hd // 2 if self._kv_fp8 else hd
 
         q_start = mCuQ[batch_idx]
         seqlen_q = mCuQ[batch_idx + 1] - q_start
@@ -1688,7 +1691,7 @@ class MsaProxyScoreDecodeKeyMajorSm12x:
                                 cute.domain_offset(
                                     (k_start, kv_head, 0), k_tma.tma_tensor
                                 ),
-                                tiler=(block_k, 1, hd),
+                                tiler=(block_k, 1, kw),
                                 coord=(kv_block, 0, 0),
                             )
                         k_mbar = tma_full_mbar + tma_stage
@@ -1697,7 +1700,7 @@ class MsaProxyScoreDecodeKeyMajorSm12x:
                             tma_empty_mbar + tma_stage, tma_parity
                         )
                         with cute.arch.elect_one():
-                            k_size = block_k * hd * (dtype.width // 8)
+                            k_size = block_k * kw * (dtype.width // 8)
                             cute.arch.mbarrier_arrive_and_expect_tx(k_mbar, k_size)
                         _tma_copy_g2s(
                             k_tma.atom,
@@ -1714,15 +1717,11 @@ class MsaProxyScoreDecodeKeyMajorSm12x:
             else:
                 # MMA warps: each owns 32 contiguous keys across all q rows.
                 sK_warp = cute.local_tile(
-                    sK, (32, hd, num_stages), (warp_id, 0, 0)
-                )
-                sK_ldsm = cute.zipped_divide(
-                    sK_warp, (16, cute.make_layout((elems, 2)), 1)
+                    sK, (32, kw, num_stages), (warp_id, 0, 0)
                 )
                 sQ_ldsm = cute.zipped_divide(
                     sQ, (8, cute.make_layout((elems, 4)))
                 )
-                sK_ldsm = sK_ldsm[(lane_id % 16, (None, lane_id // 16), 0), None]
                 sQ_ldsm = sQ_ldsm[(lane_id % 8, (None, lane_id // 8)), None]
 
                 ldsm_atom = cute.make_copy_atom(
@@ -1732,8 +1731,27 @@ class MsaProxyScoreDecodeKeyMajorSm12x:
                 rQ = cute.make_rmem_tensor(
                     ((elems // 2, 2), hd // (mma_k * 2), q_tiles), dtype
                 )
-                rK = cute.make_rmem_tensor((elems, 2, hd // mma_k), dtype)
                 rC = cute.make_rmem_tensor((4, 2, q_tiles), cutlass.Float32)
+                if cutlass.const_expr(self._kv_fp8):
+                    # Raw e4m3 K: per canonical k16 group, each lane reads the
+                    # two u32s that hold its own fragment columns and converts
+                    # in registers (see the fp8 loop below).
+                    rK8 = cute.make_rmem_tensor((8,), dtype)
+                    rK8_u32 = cute.recast_tensor(rK8, cutlass.Uint32)
+                    kpair = cute.make_rmem_tensor(cute.make_layout(2), dtype)
+                    kpair_u32 = cute.recast_tensor(kpair, cutlass.Uint32)
+                    # Branchless lo/hi pair pick by lane-quad parity.
+                    par_mask = cutlass.Uint32(0) - cutlass.Uint32(
+                        (lane_id % 4) % 2
+                    )
+                else:
+                    sK_ldsm = cute.zipped_divide(
+                        sK_warp, (16, cute.make_layout((elems, 2)), 1)
+                    )
+                    sK_ldsm = sK_ldsm[
+                        (lane_id % 16, (None, lane_id // 16), 0), None
+                    ]
+                    rK = cute.make_rmem_tensor((elems, 2, hd // mma_k), dtype)
 
                 if warp_id == 0:
                     cute.arch.mbarrier_wait(tma_full_mbar, 0)
@@ -1772,19 +1790,66 @@ class MsaProxyScoreDecodeKeyMajorSm12x:
                             barrier_id=self._BAR_MMA, number_of_threads=128
                         )
 
-                        for k in cutlass.range_constexpr(hd // mma_k):
-                            cute.copy(
-                                ldsm_atom,
-                                sK_ldsm[None, (None, k, tma_stage)],
-                                rK[None, None, k],
-                            )
-                            for m in cutlass.range_constexpr(2):
-                                for n in cutlass.range_constexpr(q_tiles):
-                                    _mma_m16n8k16(
-                                        rK[None, m, k],
-                                        rQ[(None, k % 2), k // 2, n],
-                                        rC[None, m, n],
-                                    )
+                        if cutlass.const_expr(self._kv_fp8):
+                            # Per canonical k16 group g, lane (quad q4) reads
+                            # the raw u32 holding its fragment columns
+                            # 16g + 8cp + 2*q4 (+1), converts, and keeps the
+                            # lo/hi pair by quad parity. Every product stays
+                            # in the same mma instruction as the bf16
+                            # schedule, so the fp8 path is bit-identical to
+                            # running on dequantized K.
+                            q4 = lane_id % 4
+                            row_l = lane_id // 4
+                            for g in cutlass.range_constexpr(hd // 16):
+                                for m in cutlass.range_constexpr(2):
+                                    for u in cutlass.range_constexpr(2):
+                                        for cp in cutlass.range_constexpr(2):
+                                            row_sm = cute.coalesce(
+                                                sK_warp[
+                                                    16 * m + 8 * u + row_l,
+                                                    None,
+                                                    tma_stage,
+                                                ]
+                                            )
+                                            src = cute.local_tile(
+                                                row_sm,
+                                                (2,),
+                                                (4 * g + 2 * cp + q4 // 2,),
+                                            )
+                                            cute.autovec_copy(src, kpair)
+                                            if cutlass.const_expr(
+                                                dtype is cutlass.BFloat16
+                                            ):
+                                                lo, hi = _fp8x4_to_bf16x4(
+                                                    kpair_u32[0]
+                                                )
+                                            else:
+                                                lo, hi = _fp8x4_to_f16x4(
+                                                    kpair_u32[0]
+                                                )
+                                            rK8_u32[u + 2 * cp] = lo ^ (
+                                                (lo ^ hi) & par_mask
+                                            )
+                                    for n in cutlass.range_constexpr(q_tiles):
+                                        _mma_m16n8k16(
+                                            rK8,
+                                            rQ[(None, g % 2), g // 2, n],
+                                            rC[None, m, n],
+                                        )
+                        else:
+                            for k in cutlass.range_constexpr(hd // mma_k):
+                                cute.copy(
+                                    ldsm_atom,
+                                    sK_ldsm[None, (None, k, tma_stage)],
+                                    rK[None, None, k],
+                                )
+                                for m in cutlass.range_constexpr(2):
+                                    for n in cutlass.range_constexpr(q_tiles):
+                                        _mma_m16n8k16(
+                                            rK[None, m, k],
+                                            rQ[(None, k % 2), k // 2, n],
+                                            rC[None, m, n],
+                                        )
 
                         cute.arch.mbarrier_arrive(tma_empty_mbar + tma_stage)
 

--- a/flashinfer/msa_ops/cute_dsl/proxy_score_sm12x.py
+++ b/flashinfer/msa_ops/cute_dsl/proxy_score_sm12x.py
@@ -516,9 +516,9 @@ class MsaProxyScoreSm12x:
 
 
 class MsaProxyScoreDecodePackedSm12x(MsaProxyScoreSm12x):
-    """Head-fused packed-decode schedule (bf16/fp16 or fp8 K): packs qhead_per_kv
-    heads x pack_q_len tokens into the M rows so the shared index-K is read once
-    per kv_head. fp8 K loads e4m3 bytes and packed-converts into smem."""
+    """Head-fused packed-decode bf16/fp16 schedule: packs qhead_per_kv heads x
+    pack_q_len tokens into the M rows so the shared index-K is read once per
+    kv_head. fp8 K takes the key-split subclass instead."""
 
     def __init__(
         self,
@@ -698,18 +698,17 @@ class MsaProxyScoreDecodePackedSm12x(MsaProxyScoreSm12x):
         n_rows = cute.size(acc_S_mn.shape[0])
 
         # K gmem views, as in the general kernel.
-        if cutlass.const_expr(not self._kv_fp8):
-            if cutlass.const_expr(self._paged):
-                pass  # per-block page lookup happens inside the loop
-            else:
-                mK_h = cute.domain_offset((k_start, 0), mK[None, kv_head, None])
-                gK = cute.local_tile(
-                    mK_h, (self._n_block_size, self._head_dim), (None, 0)
-                )
-                tKgK_flat = gmem_thr_copy.partition_S(gK)
-            tKsK = gmem_thr_copy.partition_D(sK)
-            cKV = cute.make_identity_tensor((self._n_block_size, self._head_dim))
-            tKVcKV = gmem_thr_copy.partition_S(cKV)
+        if cutlass.const_expr(self._paged):
+            pass  # per-block page lookup happens inside the loop
+        else:
+            mK_h = cute.domain_offset((k_start, 0), mK[None, kv_head, None])
+            gK = cute.local_tile(
+                mK_h, (self._n_block_size, self._head_dim), (None, 0)
+            )
+            tKgK_flat = gmem_thr_copy.partition_S(gK)
+        tKsK = gmem_thr_copy.partition_D(sK)
+        cKV = cute.make_identity_tensor((self._n_block_size, self._head_dim))
+        tKVcKV = gmem_thr_copy.partition_S(cKV)
 
         # Gather stores are synchronous; order them before the Q fragment reads,
         # then preload the Q fragments once (sQ reused across all kv-blocks).
@@ -729,78 +728,39 @@ class MsaProxyScoreDecodePackedSm12x(MsaProxyScoreSm12x):
             kv_block = split_idx + it * num_splits
             if kv_block < num_kv_blocks:
                 self.cta_sync_barrier.arrive_and_wait()
-                if cutlass.const_expr(self._kv_fp8):
-                    if cutlass.const_expr(self._paged):
-                        page8 = mPageTable[batch_idx, kv_block]
-                        mK_h8 = mK[page8, kv_head, None, None]
-                        row_off8 = cutlass.Int32(0)
-                    else:
-                        mK_h8 = cute.domain_offset(
-                            (k_start, 0), mK[None, kv_head, None]
-                        )
-                        row_off8 = kv_block * self._n_block_size
-                    chunks_per_row = self._head_dim // 16
-                    n_chunks = (
-                        self._n_block_size * chunks_per_row // self._num_threads
+                if cutlass.const_expr(self._paged):
+                    page = mPageTable[batch_idx, kv_block]
+                    gK_pg = cute.local_tile(
+                        mK[page, kv_head, None, None],
+                        (self._n_block_size, self._head_dim),
+                        (None, 0),
                     )
-                    # Issue every 16B K load before the convert+store loop so the
-                    # gmem latencies overlap (the loads have no cp.async here).
-                    k_frag = cute.make_rmem_tensor(
-                        cute.make_layout((16, n_chunks)), mK.element_type
-                    )
-                    cvt_frag = cute.make_rmem_tensor(cute.make_layout(16), self._dtype)
-                    for kv_it in cutlass.range_constexpr(n_chunks):
-                        kv_chunk = tidx + kv_it * self._num_threads
-                        kv_m = kv_chunk // chunks_per_row
-                        kv_c16 = kv_chunk % chunks_per_row
-                        if (kv_block * self._n_block_size + kv_m) < seqlen_k:
-                            gKc = cute.local_tile(
-                                mK_h8[row_off8 + kv_m, None], (16,), (kv_c16,)
+                    tKgK_pg = gmem_thr_copy.partition_S(gK_pg)
+                    for n in cutlass.range_constexpr(cute.size(tKsK.shape[1])):
+                        if (
+                            kv_block * self._n_block_size + tKVcKV[0, n, 0][0]
+                        ) < seqlen_k:
+                            cute.copy(
+                                gmem_tiled_copy,
+                                tKgK_pg[None, n, None, 0],
+                                tKsK[None, n, None],
                             )
-                            cute.autovec_copy(gKc, k_frag[None, kv_it])
                         else:
-                            k_frag[None, kv_it].fill(0)
-                    for kv_it in cutlass.range_constexpr(n_chunks):
-                        kv_chunk = tidx + kv_it * self._num_threads
-                        kv_m = kv_chunk // chunks_per_row
-                        kv_c16 = kv_chunk % chunks_per_row
-                        sK_chunk = cute.local_tile(sK[kv_m, None], (16,), (kv_c16,))
-                        _cvt_fp8_frag(k_frag[None, kv_it], cvt_frag)
-                        cute.autovec_copy(cvt_frag, sK_chunk)
+                            tKsK[None, n, None].fill(0)
                 else:
-                    if cutlass.const_expr(self._paged):
-                        page = mPageTable[batch_idx, kv_block]
-                        gK_pg = cute.local_tile(
-                            mK[page, kv_head, None, None],
-                            (self._n_block_size, self._head_dim),
-                            (None, 0),
-                        )
-                        tKgK_pg = gmem_thr_copy.partition_S(gK_pg)
-                        for n in cutlass.range_constexpr(cute.size(tKsK.shape[1])):
-                            if (
-                                kv_block * self._n_block_size + tKVcKV[0, n, 0][0]
-                            ) < seqlen_k:
-                                cute.copy(
-                                    gmem_tiled_copy,
-                                    tKgK_pg[None, n, None, 0],
-                                    tKsK[None, n, None],
-                                )
-                            else:
-                                tKsK[None, n, None].fill(0)
-                    else:
-                        for n in cutlass.range_constexpr(cute.size(tKsK.shape[1])):
-                            if (
-                                kv_block * self._n_block_size + tKVcKV[0, n, 0][0]
-                            ) < seqlen_k:
-                                cute.copy(
-                                    gmem_tiled_copy,
-                                    tKgK_flat[None, n, None, kv_block],
-                                    tKsK[None, n, None],
-                                )
-                            else:
-                                tKsK[None, n, None].fill(0)
-                    cute.arch.cp_async_commit_group()
-                    cute.arch.cp_async_wait_group(0)
+                    for n in cutlass.range_constexpr(cute.size(tKsK.shape[1])):
+                        if (
+                            kv_block * self._n_block_size + tKVcKV[0, n, 0][0]
+                        ) < seqlen_k:
+                            cute.copy(
+                                gmem_tiled_copy,
+                                tKgK_flat[None, n, None, kv_block],
+                                tKsK[None, n, None],
+                            )
+                        else:
+                            tKsK[None, n, None].fill(0)
+                cute.arch.cp_async_commit_group()
+                cute.arch.cp_async_wait_group(0)
                 self.cta_sync_barrier.arrive_and_wait()
 
                 # S = Q K^T (unscaled)
@@ -1585,16 +1545,6 @@ class MsaProxyScoreDecodeKeyMajorSm12x:
         kw = hd // 2 if self._kv_fp8 else hd
         qw = hd // 2 if self._q_fp8 else hd
 
-        q_start = mCuQ[batch_idx]
-        seqlen_q = mCuQ[batch_idx + 1] - q_start
-        if cutlass.const_expr(self._paged):
-            k_start = cutlass.Int32(0)
-            seqlen_k = mCuK[batch_idx]
-        else:
-            k_start = mCuK[batch_idx]
-            seqlen_k = mCuK[batch_idx + 1] - k_start
-        num_kv_blocks = cute.ceil_div(seqlen_k, block_k)
-
         smem = cutlass.utils.SmemAllocator()
         sK_full = smem.allocate_tensor(
             dtype,
@@ -1624,21 +1574,34 @@ class MsaProxyScoreDecodeKeyMajorSm12x:
 
         n_iter = cute.ceil_div(max_k_tiles, num_splits)
 
+        if warp_id == 0:
+            with cute.arch.elect_one():
+                for i in cutlass.range_constexpr(num_stages):
+                    cute.arch.mbarrier_init(tma_full_mbar + i, 1)
+                    cute.arch.mbarrier_init(tma_empty_mbar + i, 128)
+                cute.arch.mbarrier_init_fence()
+        elif warp_id == 1:
+            cpasync.prefetch_descriptor(q_tma.atom)
+            cpasync.prefetch_descriptor(k_tma.atom)
+        cute.arch.sync_threads()
+
+        # PDL: the preceding kernel may still be writing the seqlen tensors,
+        # so they are read only after the dependency wait (the setup above is
+        # independent of global data and can overlap).
+        cute.arch.griddepcontrol_wait()
+        cute.arch.griddepcontrol_launch_dependents()
+
+        q_start = mCuQ[batch_idx]
+        seqlen_q = mCuQ[batch_idx + 1] - q_start
+        if cutlass.const_expr(self._paged):
+            k_start = cutlass.Int32(0)
+            seqlen_k = mCuK[batch_idx]
+        else:
+            k_start = mCuK[batch_idx]
+            seqlen_k = mCuK[batch_idx + 1] - k_start
+        num_kv_blocks = cute.ceil_div(seqlen_k, block_k)
+
         if split_idx < num_kv_blocks:
-            if warp_id == 0:
-                with cute.arch.elect_one():
-                    for i in cutlass.range_constexpr(num_stages):
-                        cute.arch.mbarrier_init(tma_full_mbar + i, 1)
-                        cute.arch.mbarrier_init(tma_empty_mbar + i, 128)
-                    cute.arch.mbarrier_init_fence()
-            elif warp_id == 1:
-                cpasync.prefetch_descriptor(q_tma.atom)
-                cpasync.prefetch_descriptor(k_tma.atom)
-            cute.arch.sync_threads()
-
-            cute.arch.griddepcontrol_wait()
-            cute.arch.griddepcontrol_launch_dependents()
-
             if warp_id == 4:
                 # TMA producer warp: Q once, then one K tile per valid block.
                 tma_stage = 0
@@ -1925,17 +1888,22 @@ class MsaProxyScoreDecodeKeyMajorSm12x:
                             barrier_id=self._BAR_MMA, number_of_threads=128
                         )
 
-                        head_local = lane_id // pack
-                        token_f = lane_id - head_local * pack
-                        if lane_id < block_q and cute.elem_less(token_f, seqlen_q):
-                            score = epi_buffer[lane_id, 0]
-                            for i in cutlass.range_constexpr(1, 4):
-                                score = cute.arch.fmax(score, epi_buffer[lane_id, i])
-                            mMaxScore[
-                                kv_head * group + head_local,
-                                kv_block,
-                                q_start + token_f,
-                            ] = score
+                        if warp_id == 0:
+                            head_local = lane_id // pack
+                            token_f = lane_id - head_local * pack
+                            if lane_id < block_q and cute.elem_less(
+                                token_f, seqlen_q
+                            ):
+                                score = epi_buffer[lane_id, 0]
+                                for i in cutlass.range_constexpr(1, 4):
+                                    score = cute.arch.fmax(
+                                        score, epi_buffer[lane_id, i]
+                                    )
+                                mMaxScore[
+                                    kv_head * group + head_local,
+                                    kv_block,
+                                    q_start + token_f,
+                                ] = score
 
                         tma_stage = (tma_stage + 1) % num_stages
                         if tma_stage == 0:
@@ -1955,8 +1923,6 @@ class MsaProxyScoreDecodeKeyMajorSm12x:
                                 ] = -cutlass.Float32.inf
         elif split_idx < max_k_tiles:
             # CTA with no valid block: only padding stores remain.
-            cute.arch.griddepcontrol_wait()
-            cute.arch.griddepcontrol_launch_dependents()
             if warp_id == 0:
                 for it in cutlass.range(n_iter):
                     kv_block = split_idx + it * num_splits

--- a/flashinfer/msa_ops/cute_dsl/proxy_score_sm12x.py
+++ b/flashinfer/msa_ops/cute_dsl/proxy_score_sm12x.py
@@ -1443,18 +1443,26 @@ class MsaProxyScoreDecodeKeyMajorSm12x:
         is_causal: bool = True,
         paged: bool = False,
         kv_fp8: bool = False,
+        q_fp8: bool = False,
         qoff_default: bool = True,
     ):
         if head_dim != 128:
             raise ValueError("only head_dim == 128 is supported")
         if group_size * pack_q_len > 32:
             raise ValueError("group_size * pack_q_len must be <= 32")
+        if q_fp8 and not kv_fp8:
+            raise ValueError("q_fp8 requires kv_fp8")
         self._head_dim = head_dim
         self._group = group_size
         self._pack_q_len = pack_q_len
         self._is_causal = is_causal
         self._paged = paged
         self._kv_fp8 = kv_fp8
+        # fp8 q arrives as a 16-bit view like fp8 K (the vLLM M3 fp8 path
+        # emits e4m3 index-q). With both operands raw e4m3 the ldmatrix
+        # column order matches on both sides, so the Q fragments need only
+        # the same split converts as K -- no cross-lane permute.
+        self._q_fp8 = q_fp8
         # Right-aligned decode (q_offset=None) computes the causal offset
         # in-kernel from the seqlens, skipping the host-side offset-tensor
         # build (two extra kernel launches that dominate at batch 1).
@@ -1498,11 +1506,14 @@ class MsaProxyScoreDecodeKeyMajorSm12x:
         tma_g2s = cpasync.CopyBulkTensorTileG2SOp()
         swizzle_128b = cute.make_swizzle(3, 4, 3)
 
+        # fp8 operands arrive as 16-bit views of the e4m3 bytes (half
+        # head_dim), so their tiles are half as wide.
+        qw = hd // 2 if cutlass.const_expr(self._q_fp8) else hd
         sQ_layout = cute.make_composed_layout(
             swizzle_128b,
             0,
             cute.make_layout(
-                (pack, group, (elems, hd // elems)),
+                (pack, group, (elems, qw // elems)),
                 stride=(elems, pack * elems, (1, block_q * elems)),
             ),
         )
@@ -1510,11 +1521,9 @@ class MsaProxyScoreDecodeKeyMajorSm12x:
             tma_g2s,
             cute.logical_divide(mQ, (None, None, elems)),
             sQ_layout,
-            cta_tiler=(pack, group, hd),
+            cta_tiler=(pack, group, qw),
         )
 
-        # fp8 K arrives as a 16-bit view of the e4m3 bytes (half head_dim),
-        # so its tiles are half as wide as Q's.
         kw = hd // 2 if cutlass.const_expr(self._kv_fp8) else hd
         if cutlass.const_expr(self._paged):
             sK_layout = cute.make_composed_layout(
@@ -1605,6 +1614,7 @@ class MsaProxyScoreDecodeKeyMajorSm12x:
         mma_k = 32 * 8 // dtype.width
 
         kw = hd // 2 if self._kv_fp8 else hd
+        qw = hd // 2 if self._q_fp8 else hd
 
         q_start = mCuQ[batch_idx]
         seqlen_q = mCuQ[batch_idx + 1] - q_start
@@ -1635,7 +1645,7 @@ class MsaProxyScoreDecodeKeyMajorSm12x:
         q_tma_elems = 128 * 8 // dtype.width
         sQ = cute.coalesce(
             cute.group_modes(sQ_tma, 0, 2),
-            target_profile=(block_q, (q_tma_elems, hd // q_tma_elems)),
+            target_profile=(block_q, (q_tma_elems, qw // q_tma_elems)),
         )
         epi_buffer = smem.allocate_tensor(
             cutlass.Float32, cute.make_layout((epi_q, 4))
@@ -1669,12 +1679,12 @@ class MsaProxyScoreDecodeKeyMajorSm12x:
                     cute.domain_offset(
                         (q_start, kv_head * group, 0), q_tma.tma_tensor
                     ),
-                    tiler=(pack, group, hd),
+                    tiler=(pack, group, qw),
                     coord=(0, 0, 0),
                 )
                 cute.arch.mbarrier_wait(tma_empty_mbar, tma_parity)
                 with cute.arch.elect_one():
-                    q_size = block_q * hd * (dtype.width // 8)
+                    q_size = block_q * qw * (dtype.width // 8)
                     cute.arch.mbarrier_arrive_and_expect_tx(tma_full_mbar, q_size)
                 _tma_copy_g2s(q_tma.atom, gq_tile, sQ_tma, tma_full_mbar)
 
@@ -1731,7 +1741,7 @@ class MsaProxyScoreDecodeKeyMajorSm12x:
                 )
 
                 rQ = cute.make_rmem_tensor(
-                    ((elems // 2, 2), hd // (mma_k * 2), q_tiles), dtype
+                    ((elems // 2, 2), qw // (mma_k * 2), q_tiles), dtype
                 )
                 rC = cute.make_rmem_tensor((4, 2, q_tiles), cutlass.Float32)
                 sK_ldsm = cute.zipped_divide(
@@ -1768,37 +1778,58 @@ class MsaProxyScoreDecodeKeyMajorSm12x:
                 cute.arch.mbarrier_arrive(tma_empty_mbar)
 
                 if cutlass.const_expr(self._kv_fp8):
-                    # One-time cross-lane permute of the Q B-fragments into
-                    # the fp8 K column order: per 32-column group, lane quad
-                    # position q4 needs columns 4*q4..4*q4+3, which sit as u32
-                    # pairs on quad lanes 2*(q4%2) (lower half) and
-                    # 2*(q4%2)+1 (upper half) of the canonical fragments.
-                    q4 = lane_id % 4
-                    src_lo = lane_id - q4 + 2 * (q4 % 2)
-                    sel_mask = cutlass.Uint32(0) - cutlass.Uint32(q4 // 2)
                     rQ_u32 = cute.recast_tensor(rQ, cutlass.Uint32)
-                    for g in cutlass.range_constexpr(kw // mma_k):
-                        for n in cutlass.range_constexpr(q_tiles):
-                            for h in cutlass.range_constexpr(2):
-                                src = src_lo + h
-                                p0 = cute.arch.shuffle_sync(
-                                    rQ_u32[(0, 0), g, n], src
-                                )
-                                p1 = cute.arch.shuffle_sync(
-                                    rQ_u32[(1, 0), g, n], src
-                                )
-                                p2 = cute.arch.shuffle_sync(
-                                    rQ_u32[(0, 1), g, n], src
-                                )
-                                p3 = cute.arch.shuffle_sync(
-                                    rQ_u32[(1, 1), g, n], src
-                                )
-                                rQp_u32[0, g, n, h] = p0 ^ (
-                                    (p0 ^ p1) & sel_mask
-                                )
-                                rQp_u32[1, g, n, h] = p2 ^ (
-                                    (p2 ^ p3) & sel_mask
-                                )
+                    if cutlass.const_expr(self._q_fp8):
+                        # Raw e4m3 q: ldmatrix hands q the same fp8 column
+                        # order as K, so the split converts already are the
+                        # matching B-fragments.
+                        for g in cutlass.range_constexpr(kw // mma_k):
+                            for n in cutlass.range_constexpr(q_tiles):
+                                for j in cutlass.range_constexpr(2):
+                                    if cutlass.const_expr(
+                                        dtype is cutlass.BFloat16
+                                    ):
+                                        q_lo, q_hi = _fp8x4_to_bf16x4(
+                                            rQ_u32[(j, g % 2), g // 2, n]
+                                        )
+                                    else:
+                                        q_lo, q_hi = _fp8x4_to_f16x4(
+                                            rQ_u32[(j, g % 2), g // 2, n]
+                                        )
+                                    rQp_u32[j, g, n, 0] = q_lo
+                                    rQp_u32[j, g, n, 1] = q_hi
+                    else:
+                        # One-time cross-lane permute of the bf16/f16 Q
+                        # B-fragments into the fp8 K column order: per
+                        # 32-column group, lane quad position q4 needs columns
+                        # 4*q4..4*q4+3, which sit as u32 pairs on quad lanes
+                        # 2*(q4%2) (lower half) and 2*(q4%2)+1 (upper half) of
+                        # the canonical fragments.
+                        q4 = lane_id % 4
+                        src_lo = lane_id - q4 + 2 * (q4 % 2)
+                        sel_mask = cutlass.Uint32(0) - cutlass.Uint32(q4 // 2)
+                        for g in cutlass.range_constexpr(kw // mma_k):
+                            for n in cutlass.range_constexpr(q_tiles):
+                                for h in cutlass.range_constexpr(2):
+                                    src = src_lo + h
+                                    p0 = cute.arch.shuffle_sync(
+                                        rQ_u32[(0, 0), g, n], src
+                                    )
+                                    p1 = cute.arch.shuffle_sync(
+                                        rQ_u32[(1, 0), g, n], src
+                                    )
+                                    p2 = cute.arch.shuffle_sync(
+                                        rQ_u32[(0, 1), g, n], src
+                                    )
+                                    p3 = cute.arch.shuffle_sync(
+                                        rQ_u32[(1, 1), g, n], src
+                                    )
+                                    rQp_u32[0, g, n, h] = p0 ^ (
+                                        (p0 ^ p1) & sel_mask
+                                    )
+                                    rQp_u32[1, g, n, h] = p2 ^ (
+                                        (p2 ^ p3) & sel_mask
+                                    )
 
                 tma_stage = 1 % num_stages
                 tma_parity = 0

--- a/flashinfer/msa_ops/cute_dsl/proxy_score_sm12x.py
+++ b/flashinfer/msa_ops/cute_dsl/proxy_score_sm12x.py
@@ -702,9 +702,7 @@ class MsaProxyScoreDecodePackedSm12x(MsaProxyScoreSm12x):
             pass  # per-block page lookup happens inside the loop
         else:
             mK_h = cute.domain_offset((k_start, 0), mK[None, kv_head, None])
-            gK = cute.local_tile(
-                mK_h, (self._n_block_size, self._head_dim), (None, 0)
-            )
+            gK = cute.local_tile(mK_h, (self._n_block_size, self._head_dim), (None, 0))
             tKgK_flat = gmem_thr_copy.partition_S(gK)
         tKsK = gmem_thr_copy.partition_D(sK)
         cKV = cute.make_identity_tensor((self._n_block_size, self._head_dim))
@@ -925,9 +923,7 @@ class MsaProxyScoreDecodePackedFp8Sm12x(MsaProxyScoreDecodePackedSm12x):
         # Full-width layout on the same pointer: shapes the mma B fragment
         # only, no accesses go through it.
         sK_frag_ref = cute.make_tensor(sK0.iterator, self._make_sk_layout())
-        sMax = storage.sMax.get_tensor(
-            cute.make_layout(4 * self._m_block_size)
-        )
+        sMax = storage.sMax.get_tensor(cute.make_layout(4 * self._m_block_size))
 
         universal_copy_bits = 128
         async_copy_elems = universal_copy_bits // self._dtype.width
@@ -996,9 +992,7 @@ class MsaProxyScoreDecodePackedFp8Sm12x(MsaProxyScoreDecodePackedSm12x):
         kpair = cute.make_rmem_tensor(cute.make_layout(2), self._dtype)
         kpair_u32 = cute.recast_tensor(kpair, cutlass.Uint32)
         tSrK_u32 = cute.recast_tensor(
-            cute.make_tensor(
-                tSrK.iterator, cute.make_layout(cute.cosize(tSrK.layout))
-            ),
+            cute.make_tensor(tSrK.iterator, cute.make_layout(cute.cosize(tSrK.layout))),
             cutlass.Uint32,
         )
         warp_idx = tidx // 32
@@ -1561,9 +1555,7 @@ class MsaProxyScoreDecodeKeyMajorSm12x:
             cute.group_modes(sQ_tma, 0, 2),
             target_profile=(block_q, (q_tma_elems, qw // q_tma_elems)),
         )
-        epi_buffer = smem.allocate_tensor(
-            cutlass.Float32, cute.make_layout((epi_q, 4))
-        )
+        epi_buffer = smem.allocate_tensor(cutlass.Float32, cute.make_layout((epi_q, 4)))
         tma_full_mbar = smem.allocate_array(cutlass.Int64, num_stages)
         tma_empty_mbar = smem.allocate_array(cutlass.Int64, num_stages)
 
@@ -1603,9 +1595,7 @@ class MsaProxyScoreDecodeKeyMajorSm12x:
                 tma_parity = 1
 
                 gq_tile = cute.local_tile(
-                    cute.domain_offset(
-                        (q_start, kv_head * group, 0), q_tma.tma_tensor
-                    ),
+                    cute.domain_offset((q_start, kv_head * group, 0), q_tma.tma_tensor),
                     tiler=(pack, group, qw),
                     coord=(0, 0, 0),
                 )
@@ -1635,9 +1625,7 @@ class MsaProxyScoreDecodeKeyMajorSm12x:
                             )
                         k_mbar = tma_full_mbar + tma_stage
 
-                        cute.arch.mbarrier_wait(
-                            tma_empty_mbar + tma_stage, tma_parity
-                        )
+                        cute.arch.mbarrier_wait(tma_empty_mbar + tma_stage, tma_parity)
                         with cute.arch.elect_one():
                             k_size = block_k * kw * (dtype.width // 8)
                             cute.arch.mbarrier_arrive_and_expect_tx(k_mbar, k_size)
@@ -1655,12 +1643,8 @@ class MsaProxyScoreDecodeKeyMajorSm12x:
 
             else:
                 # MMA warps: each owns 32 contiguous keys across all q rows.
-                sK_warp = cute.local_tile(
-                    sK, (32, kw, num_stages), (warp_id, 0, 0)
-                )
-                sQ_ldsm = cute.zipped_divide(
-                    sQ, (8, cute.make_layout((elems, 4)))
-                )
+                sK_warp = cute.local_tile(sK, (32, kw, num_stages), (warp_id, 0, 0))
+                sQ_ldsm = cute.zipped_divide(sQ, (8, cute.make_layout((elems, 4))))
                 sQ_ldsm = sQ_ldsm[(lane_id % 8, (None, lane_id // 8)), None]
 
                 ldsm_atom = cute.make_copy_atom(
@@ -1687,20 +1671,14 @@ class MsaProxyScoreDecodeKeyMajorSm12x:
                     rK_hi = cute.make_rmem_tensor((elems,), dtype)
                     rK_lo_u32 = cute.recast_tensor(rK_lo, cutlass.Uint32)
                     rK_hi_u32 = cute.recast_tensor(rK_hi, cutlass.Uint32)
-                    rQp = cute.make_rmem_tensor(
-                        (4, kw // mma_k, q_tiles, 2), dtype
-                    )
+                    rQp = cute.make_rmem_tensor((4, kw // mma_k, q_tiles, 2), dtype)
                     rQp_u32 = cute.recast_tensor(rQp, cutlass.Uint32)
 
                 if warp_id == 0:
                     cute.arch.mbarrier_wait(tma_full_mbar, 0)
-                cute.arch.barrier(
-                    barrier_id=self._BAR_MMA, number_of_threads=128
-                )
+                cute.arch.barrier(barrier_id=self._BAR_MMA, number_of_threads=128)
                 for q in cutlass.range_constexpr(q_tiles):
-                    cute.copy(
-                        ldsm_atom, sQ_ldsm[None, (q, None)], rQ[None, None, q]
-                    )
+                    cute.copy(ldsm_atom, sQ_ldsm[None, (q, None)], rQ[None, None, q])
                 cute.arch.mbarrier_arrive(tma_empty_mbar)
 
                 if cutlass.const_expr(self._kv_fp8):
@@ -1712,9 +1690,7 @@ class MsaProxyScoreDecodeKeyMajorSm12x:
                         for g in cutlass.range_constexpr(kw // mma_k):
                             for n in cutlass.range_constexpr(q_tiles):
                                 for j in cutlass.range_constexpr(2):
-                                    if cutlass.const_expr(
-                                        dtype is cutlass.BFloat16
-                                    ):
+                                    if cutlass.const_expr(dtype is cutlass.BFloat16):
                                         q_lo, q_hi = _fp8x4_to_bf16x4(
                                             rQ_u32[(j, g % 2), g // 2, n]
                                         )
@@ -1749,12 +1725,8 @@ class MsaProxyScoreDecodeKeyMajorSm12x:
                                     p3 = cute.arch.shuffle_sync(
                                         rQ_u32[(1, 1), g, n], src
                                     )
-                                    rQp_u32[0, g, n, h] = p0 ^ (
-                                        (p0 ^ p1) & sel_mask
-                                    )
-                                    rQp_u32[1, g, n, h] = p2 ^ (
-                                        (p2 ^ p3) & sel_mask
-                                    )
+                                    rQp_u32[0, g, n, h] = p0 ^ ((p0 ^ p1) & sel_mask)
+                                    rQp_u32[1, g, n, h] = p2 ^ ((p2 ^ p3) & sel_mask)
 
                 tma_stage = 1 % num_stages
                 tma_parity = 0
@@ -1795,19 +1767,13 @@ class MsaProxyScoreDecodeKeyMajorSm12x:
                                     rK[None, None, k],
                                 )
                                 for m in cutlass.range_constexpr(2):
-                                    for i in cutlass.range_constexpr(
-                                        elems // 2
-                                    ):
+                                    for i in cutlass.range_constexpr(elems // 2):
                                         if cutlass.const_expr(
                                             dtype is cutlass.BFloat16
                                         ):
-                                            lo, hi = _fp8x4_to_bf16x4(
-                                                rK_u32[i, m, k]
-                                            )
+                                            lo, hi = _fp8x4_to_bf16x4(rK_u32[i, m, k])
                                         else:
-                                            lo, hi = _fp8x4_to_f16x4(
-                                                rK_u32[i, m, k]
-                                            )
+                                            lo, hi = _fp8x4_to_f16x4(rK_u32[i, m, k])
                                         rK_lo_u32[i] = lo
                                         rK_hi_u32[i] = hi
                                     for n in cutlass.range_constexpr(q_tiles):
@@ -1886,9 +1852,7 @@ class MsaProxyScoreDecodeKeyMajorSm12x:
                         if warp_id == 0:
                             head_local = lane_id // pack
                             token_f = lane_id - head_local * pack
-                            if lane_id < block_q and cute.elem_less(
-                                token_f, seqlen_q
-                            ):
+                            if lane_id < block_q and cute.elem_less(token_f, seqlen_q):
                                 score = epi_buffer[lane_id, 0]
                                 for i in cutlass.range_constexpr(1, 4):
                                     score = cute.arch.fmax(
@@ -1908,9 +1872,7 @@ class MsaProxyScoreDecodeKeyMajorSm12x:
                         if warp_id == 0:
                             head_p = lane_id // pack
                             token_p = lane_id - head_p * pack
-                            if lane_id < block_q and cute.elem_less(
-                                token_p, seqlen_q
-                            ):
+                            if lane_id < block_q and cute.elem_less(token_p, seqlen_q):
                                 mMaxScore[
                                     kv_head * group + head_p,
                                     kv_block,
@@ -1924,9 +1886,7 @@ class MsaProxyScoreDecodeKeyMajorSm12x:
                     if kv_block < max_k_tiles:
                         head_p2 = lane_id // pack
                         token_p2 = lane_id - head_p2 * pack
-                        if lane_id < block_q and cute.elem_less(
-                            token_p2, seqlen_q
-                        ):
+                        if lane_id < block_q and cute.elem_less(token_p2, seqlen_q):
                             mMaxScore[
                                 kv_head * group + head_p2,
                                 kv_block,
@@ -2088,12 +2048,8 @@ class MsaProxyScoreDecodeStreamSm12x:
             for it in cutlass.range_constexpr(self._num_iters):
                 if cutlass.const_expr(self._kv_fp8):
                     # f16 intermediate (exact for e4m3), packed cvt.
-                    k8 = cute.make_tensor(
-                        kfrag.iterator + it * 8, cute.make_layout(8)
-                    )
-                    kf16 = cute.make_rmem_tensor(
-                        cute.make_layout(8), cutlass.Float16
-                    )
+                    k8 = cute.make_tensor(kfrag.iterator + it * 8, cute.make_layout(8))
+                    kf16 = cute.make_rmem_tensor(cute.make_layout(8), cutlass.Float16)
                     _cvt_fp8_frag(k8, kf16)
                     ks = [cutlass.Float32(kf16[i]) for i in range(8)]
                 else:

--- a/flashinfer/msa_ops/cute_dsl/proxy_score_sm12x.py
+++ b/flashinfer/msa_ops/cute_dsl/proxy_score_sm12x.py
@@ -849,9 +849,9 @@ class MsaProxyScoreDecodePackedSm12x(MsaProxyScoreSm12x):
 
 class MsaProxyScoreDecodePackedFp8Sm12x(MsaProxyScoreDecodePackedSm12x):
     """fp8-K packed-decode schedule. Same head-fused M rows as the packed
-    schedule, but warps split over keys instead of query rows (after Thien
-    Tran's indexer kernel), so the e4m3 -> f16/bf16 upconvert runs once per
-    K element instead of once per warp. K stays raw e4m3 through cp.async
+    schedule, but warps split over keys instead of query rows, so the
+    e4m3 -> f16/bf16 upconvert runs once per K element instead of once per
+    warp. K stays raw e4m3 through cp.async
     and smem, arriving as a 16-bit view with half the head dim (see
     msa_proxy_score), and upconverts in registers between the smem loads and
     the mma. Q is stored column-permuted to match the converted K fragments
@@ -1357,11 +1357,6 @@ class MsaProxyScoreDecodeKeyMajorSm12x:
     two intra-CTA barriers per block. The low per-CTA fixed cost (no Q
     gather, no fill barriers, no per-step Q reloads) is what wins on the
     one-block-per-CTA grids that split-K produces at small batch.
-
-    Derived from vLLM's IndexDecodeScoreKernel (Apache-2.0) by Thien Tran
-    (gau-nernst), adapted to flat/paged K with a kv-head mode, per-request
-    variable q lengths, MSA q_offset causal semantics, and the
-    per-(head, kv_block, token) max-score output with -inf padding tiles.
     """
 
     _BLOCK_K = 128

--- a/flashinfer/msa_ops/cute_dsl/proxy_score_sm12x.py
+++ b/flashinfer/msa_ops/cute_dsl/proxy_score_sm12x.py
@@ -903,6 +903,15 @@ class MsaProxyScoreDecodePackedFp8Sm12x(MsaProxyScoreDecodePackedSm12x):
     with the 4 warps side by side along N, so every warp computes all 64 rows
     for its own 32 key columns and the epilogue joins the per-warp row maxes
     through smem.
+
+    K staging is pipelined at two granularities, because split-K leaves the
+    small-batch grids with a single KV block per CTA (nothing to overlap
+    across blocks) while long-context CTAs iterate several: two smem K
+    buffers with a one-block prefetch overlap the next block's loads with
+    this block's mma, and each fill commits as two 64-key cp.async groups so
+    the mma starts on the first half while the second is still in flight.
+    Every iteration commits exactly two groups (empty ones once the tail is
+    reached), which keeps the wait_group counts static.
     """
 
     @cute.kernel
@@ -934,8 +943,6 @@ class MsaProxyScoreDecodePackedFp8Sm12x(MsaProxyScoreDecodePackedSm12x):
             seqlen_k = mCuK[batch_idx + 1] - k_start
         num_kv_blocks = cute.ceil_div(seqlen_k, self._n_block_size)
 
-        # K tile is raw e4m3 viewed 16-bit, so it is half as wide as Q's.
-        kw = self._head_dim // 2
         sQ_layout = self._make_sq_layout()
         sK_layout = self._make_sk8_layout()
 
@@ -945,23 +952,31 @@ class MsaProxyScoreDecodePackedFp8Sm12x(MsaProxyScoreDecodePackedSm12x):
                 cute.struct.MemRange[self._dtype, cute.cosize(sQ_layout)],
                 1024,
             ]
-            sK: cute.struct.Align[
+            sK0: cute.struct.Align[
                 cute.struct.MemRange[self._dtype, cute.cosize(sK_layout)],
                 1024,
+            ]
+            sK1: cute.struct.Align[
+                cute.struct.MemRange[self._dtype, cute.cosize(sK_layout)],
+                1024,
+            ]
+            # Epilogue staging cannot alias K here: with the prefetch both K
+            # buffers stay live across the epilogue window.
+            sMax: cute.struct.Align[
+                cute.struct.MemRange[cutlass.Float32, 4 * self._m_block_size],
+                16,
             ]
 
         smem = cutlass.utils.SmemAllocator()
         storage = smem.allocate(SharedStorage)
         sQ = storage.sQ.get_tensor(sQ_layout)
-        sK = storage.sK.get_tensor(sK_layout)
+        sK0 = storage.sK0.get_tensor(sK_layout)
+        sK1 = storage.sK1.get_tensor(sK_layout)
         # Full-width layout on the same pointer: shapes the mma B fragment
         # only, no accesses go through it.
-        sK_frag_ref = cute.make_tensor(sK.iterator, self._make_sk_layout())
-        # Cross-warp epilogue staging (64 rows x 4 warps f32) aliased onto
-        # sK's first 1KB: dead between the last fragment load of one kv-block
-        # and the next block's fill, which is exactly the epilogue window.
-        sMax = cute.recast_tensor(
-            cute.make_tensor(sK.iterator, cute.make_layout(512)), cutlass.Float32
+        sK_frag_ref = cute.make_tensor(sK0.iterator, self._make_sk_layout())
+        sMax = storage.sMax.get_tensor(
+            cute.make_layout(4 * self._m_block_size)
         )
 
         universal_copy_bits = 128
@@ -978,6 +993,22 @@ class MsaProxyScoreDecodePackedFp8Sm12x(MsaProxyScoreDecodePackedSm12x):
         v_layout = cute.make_layout((1, async_copy_elems))
         gmem_tiled_copy = cute.make_tiled_copy_tv(atom_async_copy, t_layout, v_layout)
         gmem_thr_copy = gmem_tiled_copy.get_slice(tidx)
+
+        # First block's K fill goes out before the synchronous Q gather so the
+        # cp.async flight time hides under it.
+        if split_idx < num_kv_blocks:
+            self._fill_k8_tile(
+                gmem_tiled_copy,
+                gmem_thr_copy,
+                mK,
+                mPageTable,
+                batch_idx,
+                kv_head,
+                k_start,
+                split_idx,
+                seqlen_k,
+                sK0,
+            )
 
         self._gather_packed_q(mQ, sQ, q_start, kv_head, seqlen_q, tidx)
 
@@ -1025,27 +1056,11 @@ class MsaProxyScoreDecodePackedFp8Sm12x(MsaProxyScoreDecodePackedSm12x):
             cutlass.Uint32,
         )
         warp_idx = tidx // 32
-        lane = tidx % 32
-        # Fragment geometry of the m16n8k16 B atom: lane covers key row
-        # n = 32*nt + 8*warp + lane//4 and k16 pairs at 2*(lane%4) (+8).
-        nb_row = 8 * warp_idx + lane // 4
-        m4 = lane % 4
 
         cS = cute.make_identity_tensor((self._m_block_size, self._n_block_size))
         tScS_mn = self._make_acc_tensor_mn_view(thr_mma.partition_C(cS))
         acc_S_mn = self._make_acc_tensor_mn_view(acc_S)
         n_rows = cute.size(acc_S_mn.shape[0])
-
-        # K gmem views, as in the packed kernel but on the half-width view.
-        if cutlass.const_expr(self._paged):
-            pass  # per-block page lookup happens inside the loop
-        else:
-            mK_h = cute.domain_offset((k_start, 0), mK[None, kv_head, None])
-            gK = cute.local_tile(mK_h, (self._n_block_size, kw), (None, 0))
-            tKgK_flat = gmem_thr_copy.partition_S(gK)
-        tKsK = gmem_thr_copy.partition_D(sK)
-        cKV = cute.make_identity_tensor((self._n_block_size, kw))
-        tKVcKV = gmem_thr_copy.partition_S(cKV)
 
         # Gather stores are synchronous; order them before the Q fragment
         # reads. Q fragments are loaded per k-step inside the block loop (a
@@ -1057,91 +1072,88 @@ class MsaProxyScoreDecodePackedFp8Sm12x(MsaProxyScoreDecodePackedSm12x):
         for it in cutlass.range(n_iter):
             kv_block = split_idx + it * num_splits
             if kv_block < num_kv_blocks:
-                # Also orders the previous epilogue's sMax reads before this
-                # block's fill of the aliased sK bytes.
-                self.cta_sync_barrier.arrive_and_wait()
-                if cutlass.const_expr(self._paged):
-                    page = mPageTable[batch_idx, kv_block]
-                    gK_pg = cute.local_tile(
-                        mK[page, kv_head, None, None],
-                        (self._n_block_size, kw),
-                        (None, 0),
-                    )
-                    tKgK_pg = gmem_thr_copy.partition_S(gK_pg)
-                    for n in cutlass.range_constexpr(cute.size(tKsK.shape[1])):
-                        if (
-                            kv_block * self._n_block_size + tKVcKV[0, n, 0][0]
-                        ) < seqlen_k:
-                            cute.copy(
-                                gmem_tiled_copy,
-                                tKgK_pg[None, n, None, 0],
-                                tKsK[None, n, None],
-                            )
-                        else:
-                            tKsK[None, n, None].fill(0)
+                # Prefetch the next block into the idle buffer; its loads fly
+                # under this block's mma and epilogue. Exactly two commit
+                # groups go out either way (empty ones at the tail), so the
+                # current block's halves are always the 4th- and 3rd-newest
+                # groups and the wait_group counts below stay static.
+                nxt_block = kv_block + num_splits
+                if (it % 2) == 0:
+                    if nxt_block < num_kv_blocks:
+                        self._fill_k8_tile(
+                            gmem_tiled_copy,
+                            gmem_thr_copy,
+                            mK,
+                            mPageTable,
+                            batch_idx,
+                            kv_head,
+                            k_start,
+                            nxt_block,
+                            seqlen_k,
+                            sK1,
+                        )
+                    else:
+                        cute.arch.cp_async_commit_group()
+                        cute.arch.cp_async_commit_group()
                 else:
-                    for n in cutlass.range_constexpr(cute.size(tKsK.shape[1])):
-                        if (
-                            kv_block * self._n_block_size + tKVcKV[0, n, 0][0]
-                        ) < seqlen_k:
-                            cute.copy(
-                                gmem_tiled_copy,
-                                tKgK_flat[None, n, None, kv_block],
-                                tKsK[None, n, None],
-                            )
-                        else:
-                            tKsK[None, n, None].fill(0)
-                cute.arch.cp_async_commit_group()
-                cute.arch.cp_async_wait_group(0)
-                self.cta_sync_barrier.arrive_and_wait()
+                    if nxt_block < num_kv_blocks:
+                        self._fill_k8_tile(
+                            gmem_tiled_copy,
+                            gmem_thr_copy,
+                            mK,
+                            mPageTable,
+                            batch_idx,
+                            kv_head,
+                            k_start,
+                            nxt_block,
+                            seqlen_k,
+                            sK0,
+                        )
+                    else:
+                        cute.arch.cp_async_commit_group()
+                        cute.arch.cp_async_commit_group()
 
-                # S = Q K^T (unscaled). Per k-step pair: read the lane's raw
-                # 16-bit pairs, packed-convert into the pair's fragments, then
-                # the two mma steps; Q fragments load just in time so ptxas
-                # keeps the per-thread A footprint at one k-step.
+                # S = Q K^T (unscaled), consumed one 64-key half behind each
+                # fill group so the mma starts before the tile finishes
+                # landing (split-K often leaves one block per CTA, where this
+                # intra-block overlap is the only one available).
                 acc_S.fill(0.0)
-                for kk8 in cutlass.range_constexpr(self._head_dim // 32):
-                    for nt in cutlass.range_constexpr(
-                        self._n_block_size // (8 * self._num_threads // 32)
-                    ):
-                        n_row = 32 * nt + nb_row
-                        for g in cutlass.range_constexpr(2):
-                            src = cute.local_tile(
-                                sK[n_row, None], (2,), (8 * kk8 + 4 * g + m4,)
-                            )
-                            cute.autovec_copy(src, kpair)
-                            if cutlass.const_expr(self._dtype is cutlass.BFloat16):
-                                lo, hi = _fp8x4_to_bf16x4(kpair_u32[0])
-                            else:
-                                lo, hi = _fp8x4_to_f16x4(kpair_u32[0])
-                            # All four e4m3 of this u32 belong to the same
-                            # canonical 16-column group g, so both converted
-                            # pairs go into mma step 2*kk8 + g: this keeps
-                            # each product in the same instruction as the
-                            # reference schedules, and the chained f32
-                            # accumulation stays bit-identical.
-                            kk = 2 * kk8 + g
-                            d0 = cute.crd2idx(((0, 0), nt, kk), tSrK.layout)
-                            d1 = cute.crd2idx(((0, 1), nt, kk), tSrK.layout)
-                            tSrK_u32[d0 // 2] = lo
-                            tSrK_u32[d1 // 2] = hi
-                    for s in cutlass.range_constexpr(2):
-                        kk = 2 * kk8 + s
-                        cute.copy(
+                for h in cutlass.range_constexpr(2):
+                    cute.arch.cp_async_wait_group(3 - h)
+                    self.cta_sync_barrier.arrive_and_wait()
+                    if (it % 2) == 0:
+                        self._consume_k8_half(
+                            h,
+                            sK0,
                             smem_tiled_copy_Q,
-                            tSsQ[None, None, kk],
-                            tSrQ_copy_view[None, None, kk],
-                        )
-                        cute.gemm(
+                            tSsQ,
+                            tSrQ,
+                            tSrQ_copy_view,
                             tiled_mma,
+                            tSrK,
+                            tSrK_u32,
+                            kpair,
+                            kpair_u32,
                             acc_S,
-                            tSrQ[None, None, kk],
-                            tSrK[None, None, kk],
+                        )
+                    else:
+                        self._consume_k8_half(
+                            h,
+                            sK1,
+                            smem_tiled_copy_Q,
+                            tSsQ,
+                            tSrQ,
+                            tSrQ_copy_view,
+                            tiled_mma,
+                            tSrK,
+                            tSrK_u32,
+                            kpair,
+                            kpair_u32,
                             acc_S,
                         )
 
-                # Orders every warp's sK fragment loads before the epilogue
-                # overwrites the aliased sMax bytes.
+                # Every warp's K fragment loads must land before the next
+                # iteration's prefetch overwrites this buffer.
                 self.cta_sync_barrier.arrive_and_wait()
 
                 # Per-warp row maxes over the warp's 32 key columns, staged to
@@ -1188,6 +1200,125 @@ class MsaProxyScoreDecodePackedFp8Sm12x(MsaProxyScoreDecodePackedSm12x):
                         mMaxScore[
                             head2, kv_block, q_start + token2
                         ] = -cutlass.Float32.inf
+
+    @cute.jit
+    def _fill_k8_tile(
+        self,
+        gmem_tiled_copy,
+        gmem_thr_copy,
+        mK: cute.Tensor,
+        mPageTable: cute.Tensor,
+        batch_idx: cutlass.Int32,
+        kv_head: cutlass.Int32,
+        k_start: cutlass.Int32,
+        kv_block: cutlass.Int32,
+        seqlen_k: cutlass.Int32,
+        sK_buf: cute.Tensor,
+    ):
+        """Issue one raw-e4m3 K tile's cp.async fill as two commit groups
+        (keys 0-63 and 64-127), matching the consumer's half order."""
+        kw = self._head_dim // 2
+        tKsK = gmem_thr_copy.partition_D(sK_buf)
+        cKV = cute.make_identity_tensor((self._n_block_size, kw))
+        tKVcKV = gmem_thr_copy.partition_S(cKV)
+        if cutlass.const_expr(self._paged):
+            page = mPageTable[batch_idx, kv_block]
+            gK = cute.local_tile(
+                mK[page, kv_head, None, None], (self._n_block_size, kw), (None, 0)
+            )
+            tKgK = gmem_thr_copy.partition_S(gK)[None, None, None, 0]
+        else:
+            mK_h = cute.domain_offset((k_start, 0), mK[None, kv_head, None])
+            gK = cute.local_tile(mK_h, (self._n_block_size, kw), (None, 0))
+            tKgK = gmem_thr_copy.partition_S(gK)[None, None, None, kv_block]
+        n_passes = cute.size(tKsK.shape[1])
+        for n in cutlass.range_constexpr(n_passes):
+            if (kv_block * self._n_block_size + tKVcKV[0, n, 0][0]) < seqlen_k:
+                cute.copy(gmem_tiled_copy, tKgK[None, n, None], tKsK[None, n, None])
+            else:
+                tKsK[None, n, None].fill(0)
+            if n == n_passes // 2 - 1:
+                cute.arch.cp_async_commit_group()
+        cute.arch.cp_async_commit_group()
+
+    @cute.jit
+    def _consume_k8_half(
+        self,
+        half: cutlass.Constexpr,
+        sK_buf: cute.Tensor,
+        smem_tiled_copy_Q,
+        tSsQ: cute.Tensor,
+        tSrQ: cute.Tensor,
+        tSrQ_copy_view: cute.Tensor,
+        tiled_mma,
+        tSrK: cute.Tensor,
+        tSrK_u32: cute.Tensor,
+        kpair: cute.Tensor,
+        kpair_u32: cute.Tensor,
+        acc_S: cute.Tensor,
+    ):
+        """Convert-and-mma over one 64-key half (n-tiles ``2*half`` and
+        ``2*half + 1``). Per k-step pair: read the lane's raw 16-bit pairs,
+        packed-convert into the pair's fragments, then the two mma steps; Q
+        fragments load just in time so ptxas keeps the per-thread A footprint
+        at one k-step."""
+        tidx, _, _ = cute.arch.thread_idx()
+        # Fragment geometry of the m16n8k16 B atom: lane covers key row
+        # n = 32*nt + 8*warp + lane//4 and k16 pairs at 2*(lane%4) (+8).
+        nb_row = 8 * (tidx // 32) + (tidx % 32) // 4
+        m4 = tidx % 4
+        # This half's slice of the acc and B fragments (n-tile mode cut to 2),
+        # so the gemm keeps the full-rank form cute.gemm requires.
+        acc_h = cute.make_tensor(
+            acc_S.iterator + 2 * half * acc_S.layout.stride[2],
+            cute.make_layout(
+                (acc_S.layout.shape[0], acc_S.layout.shape[1], 2),
+                stride=acc_S.layout.stride,
+            ),
+        )
+        tSrK_h = cute.make_tensor(
+            tSrK.iterator + 2 * half * tSrK.layout.stride[1],
+            cute.make_layout(
+                (tSrK.layout.shape[0], 2, tSrK.layout.shape[2]),
+                stride=tSrK.layout.stride,
+            ),
+        )
+        for kk8 in cutlass.range_constexpr(self._head_dim // 32):
+            for nt in cutlass.range_constexpr(2 * half, 2 * half + 2):
+                n_row = 32 * nt + nb_row
+                for g in cutlass.range_constexpr(2):
+                    src = cute.local_tile(
+                        sK_buf[n_row, None], (2,), (8 * kk8 + 4 * g + m4,)
+                    )
+                    cute.autovec_copy(src, kpair)
+                    if cutlass.const_expr(self._dtype is cutlass.BFloat16):
+                        lo, hi = _fp8x4_to_bf16x4(kpair_u32[0])
+                    else:
+                        lo, hi = _fp8x4_to_f16x4(kpair_u32[0])
+                    # All four e4m3 of this u32 belong to the same canonical
+                    # 16-column group g, so both converted pairs go into mma
+                    # step 2*kk8 + g: this keeps each product in the same
+                    # instruction as the reference schedules, and the chained
+                    # f32 accumulation stays bit-identical.
+                    kk = 2 * kk8 + g
+                    d0 = cute.crd2idx(((0, 0), nt, kk), tSrK.layout)
+                    d1 = cute.crd2idx(((0, 1), nt, kk), tSrK.layout)
+                    tSrK_u32[d0 // 2] = lo
+                    tSrK_u32[d1 // 2] = hi
+            for s in cutlass.range_constexpr(2):
+                kk = 2 * kk8 + s
+                cute.copy(
+                    smem_tiled_copy_Q,
+                    tSsQ[None, None, kk],
+                    tSrQ_copy_view[None, None, kk],
+                )
+                cute.gemm(
+                    tiled_mma,
+                    acc_h,
+                    tSrQ[None, None, kk],
+                    tSrK_h[None, None, kk],
+                    acc_h,
+                )
 
     def _make_sk8_layout(self):
         """K smem layout for the raw e4m3 bytes viewed as 16-bit pairs: half

--- a/flashinfer/msa_ops/cute_dsl/proxy_score_sm12x.py
+++ b/flashinfer/msa_ops/cute_dsl/proxy_score_sm12x.py
@@ -1368,6 +1368,511 @@ class MsaProxyScoreDecodePackedFp8Sm12x(MsaProxyScoreDecodePackedSm12x):
                 sQ_chunk0.fill(0)
 
 
+_TMA_EVICT_FIRST = cutlass.Int64(0x12F0000000000000)
+
+
+@dsl_user_op
+def _mma_m16n8k16(a: cute.Tensor, b: cute.Tensor, c: cute.Tensor, *, loc=None, ip=None):
+    """One m16n8k16 f16/bf16 mma.sync with f32 accumulate; a is 4 u32, b is
+    2 u32, c is 4 f32 (read-modify-write)."""
+    ab_ty = "bf16" if a.element_type is cutlass.BFloat16 else "f16"
+    a_u32 = cute.recast_tensor(a, cutlass.Uint32)
+    b_u32 = cute.recast_tensor(b, cutlass.Uint32)
+    out = llvm.inline_asm(
+        llvm.StructType.get_literal([cutlass.Float32.mlir_type] * 4),
+        [a_u32[i].ir_value(loc=loc, ip=ip) for i in range(4)]
+        + [b_u32[i].ir_value(loc=loc, ip=ip) for i in range(2)]
+        + [c[i].ir_value(loc=loc, ip=ip) for i in range(4)],
+        f"mma.sync.aligned.m16n8k16.row.col.f32.{ab_ty}.{ab_ty}.f32 "
+        "{$0, $1, $2, $3}, {$4, $5, $6, $7}, {$8, $9}, {$10, $11, $12, $13};",
+        "=f,=f,=f,=f,r,r,r,r,r,r,f,f,f,f",
+        has_side_effects=False,
+        is_align_stack=False,
+        loc=loc,
+        ip=ip,
+    )
+    for i in range(4):
+        c[i] = cutlass.Float32(
+            llvm.extractvalue(cutlass.Float32.mlir_type, out, [i], loc=loc, ip=ip)
+        )
+
+
+@cute.jit
+def _tma_copy_g2s(atom, gmem, smem, mbar, cache_policy=None):
+    """One bulk-tensor TMA G2S copy (call without elect_one; the atom elects)."""
+    s_part, g_part = cpasync.tma_partition(
+        atom,
+        0,
+        cute.make_layout(1),
+        cute.group_modes(smem, 0),
+        cute.group_modes(gmem, 0),
+    )
+    cute.copy(atom, g_part, s_part, tma_bar_ptr=mbar, cache_policy=cache_policy)
+
+
+class MsaProxyScoreDecodeKeyMajorSm12x:
+    """Key-major packed-decode schedule for small fused-row tiles
+    (group_size * pack_q_len <= 32): the score GEMM runs as K Q^T with the
+    128 keys as the MMA M dimension and the fused (head, token) query rows as
+    N. Each of the 4 MMA warps owns 32 contiguous keys, so ldmatrix is legal
+    on both operands and the Q fragments load once per CTA and stay in
+    registers across KV blocks. A fifth warp is a TMA producer feeding a
+    two-stage mbarrier pipeline (Q's smem aliases K stage 0), which leaves
+    two intra-CTA barriers per block. This is what makes the schedule match
+    the single-block-per-CTA grids that split-K produces at small batch,
+    where the row-major packed schedule's per-CTA fixed phases (Q gather,
+    fill barriers, per-step Q reloads) dominate.
+
+    Derived from vLLM's IndexDecodeScoreKernel (Apache-2.0) by Thien Tran
+    (gau-nernst), adapted to flat/paged K with a kv-head mode, per-request
+    variable q lengths, MSA q_offset causal semantics, and the
+    per-(head, kv_block, token) max-score output with -inf padding tiles.
+    """
+
+    _BLOCK_K = 128
+    _BAR_MMA = 1
+    _NUM_STAGES = 2
+
+    def __init__(
+        self,
+        head_dim: int = 128,
+        group_size: int = 4,
+        pack_q_len: int = 4,
+        is_causal: bool = True,
+        paged: bool = False,
+        kv_fp8: bool = False,
+    ):
+        if head_dim != 128:
+            raise ValueError("only head_dim == 128 is supported")
+        if group_size * pack_q_len > 32:
+            raise ValueError("group_size * pack_q_len must be <= 32")
+        if kv_fp8:
+            raise NotImplementedError("fp8 K key-major schedule not yet wired")
+        self._head_dim = head_dim
+        self._group = group_size
+        self._pack_q_len = pack_q_len
+        self._is_causal = is_causal
+        self._paged = paged
+        self._kv_fp8 = kv_fp8
+        self._block_q = group_size * pack_q_len
+        self._q_tiles = (self._block_q + 7) // 8
+        self._num_threads = 32 * 5
+
+    @cute.jit
+    def __call__(
+        self,
+        mQ: cute.Tensor,
+        mK: cute.Tensor,
+        mPageTable: cute.Tensor,
+        mMaxScore: cute.Tensor,
+        mCuQ: cute.Tensor,
+        mCuK: cute.Tensor,
+        mQOffset: cute.Tensor,
+        max_seqlen_q: cutlass.Int32,
+        batch_size: cutlass.Int32,
+        num_qo_heads: cutlass.Int32,
+        max_k_tiles: cutlass.Int32,
+        num_splits: cutlass.Int32,
+        stream: cuda.CUstream,
+    ):
+        if cutlass.const_expr(
+            not (
+                mQ.element_type == cutlass.Float16
+                or mQ.element_type == cutlass.BFloat16
+            )
+        ):
+            raise TypeError("Only Float16 or BFloat16 q is supported")
+        self._dtype: Type[cutlass.Numeric] = mQ.element_type
+
+        dtype = self._dtype
+        hd = self._head_dim
+        pack = self._pack_q_len
+        group = self._group
+        block_q = self._block_q
+        elems = 128 * 8 // dtype.width
+        tma_g2s = cpasync.CopyBulkTensorTileG2SOp()
+        swizzle_128b = cute.make_swizzle(3, 4, 3)
+
+        sQ_layout = cute.make_composed_layout(
+            swizzle_128b,
+            0,
+            cute.make_layout(
+                (pack, group, (elems, hd // elems)),
+                stride=(elems, pack * elems, (1, block_q * elems)),
+            ),
+        )
+        q_tma = cpasync.make_tiled_tma_atom(
+            tma_g2s,
+            cute.logical_divide(mQ, (None, None, elems)),
+            sQ_layout,
+            cta_tiler=(pack, group, hd),
+        )
+
+        if cutlass.const_expr(self._paged):
+            sK_layout = cute.make_composed_layout(
+                swizzle_128b,
+                0,
+                cute.make_layout(
+                    (1, 1, self._BLOCK_K, (elems, hd // elems), self._NUM_STAGES),
+                    stride=(
+                        0,
+                        0,
+                        elems,
+                        (1, self._BLOCK_K * elems),
+                        self._BLOCK_K * hd,
+                    ),
+                ),
+            )
+            k_tma = cpasync.make_tiled_tma_atom(
+                tma_g2s,
+                cute.logical_divide(mK, (None, None, None, elems)),
+                sK_layout,
+                cta_tiler=(1, 1, self._BLOCK_K, hd),
+            )
+        else:
+            sK_layout = cute.make_composed_layout(
+                swizzle_128b,
+                0,
+                cute.make_layout(
+                    (self._BLOCK_K, 1, (elems, hd // elems), self._NUM_STAGES),
+                    stride=(
+                        elems,
+                        0,
+                        (1, self._BLOCK_K * elems),
+                        self._BLOCK_K * hd,
+                    ),
+                ),
+            )
+            k_tma = cpasync.make_tiled_tma_atom(
+                tma_g2s,
+                cute.logical_divide(mK, (None, None, elems)),
+                sK_layout,
+                cta_tiler=(self._BLOCK_K, 1, hd),
+            )
+
+        self.kernel(
+            q_tma,
+            k_tma,
+            mPageTable,
+            mMaxScore,
+            mCuQ,
+            mCuK,
+            mQOffset,
+            max_k_tiles,
+            num_splits,
+        ).launch(
+            grid=(num_splits, batch_size, num_qo_heads // group),
+            block=[self._num_threads, 1, 1],
+            stream=stream,
+            use_pdl=True,
+        )
+
+    @cute.kernel
+    def kernel(
+        self,
+        q_tma: cpasync.TmaInfo,
+        k_tma: cpasync.TmaInfo,
+        mPageTable: cute.Tensor,
+        mMaxScore: cute.Tensor,
+        mCuQ: cute.Tensor,
+        mCuK: cute.Tensor,
+        mQOffset: cute.Tensor,
+        max_k_tiles: cutlass.Int32,
+        num_splits: cutlass.Int32,
+    ):
+        split_idx, batch_idx, kv_head = cute.arch.block_idx()
+        warp_id = cute.arch.make_warp_uniform(cute.arch.warp_idx())
+        lane_id = cute.arch.lane_idx()
+
+        dtype = self._dtype
+        hd = self._head_dim
+        pack = self._pack_q_len
+        group = self._group
+        block_q = self._block_q
+        block_k = self._BLOCK_K
+        num_stages = self._NUM_STAGES
+        q_tiles = self._q_tiles
+        epi_q = q_tiles * 8
+        elems = 128 // dtype.width
+        mma_k = 32 * 8 // dtype.width
+
+        q_start = mCuQ[batch_idx]
+        seqlen_q = mCuQ[batch_idx + 1] - q_start
+        if cutlass.const_expr(self._paged):
+            k_start = cutlass.Int32(0)
+            seqlen_k = mCuK[batch_idx]
+        else:
+            k_start = mCuK[batch_idx]
+            seqlen_k = mCuK[batch_idx + 1] - k_start
+        num_kv_blocks = cute.ceil_div(seqlen_k, block_k)
+
+        smem = cutlass.utils.SmemAllocator()
+        sK_full = smem.allocate_tensor(
+            dtype,
+            k_tma.smem_layout.outer,
+            byte_alignment=128,
+            swizzle=k_tma.smem_layout.inner,
+        )
+        if cutlass.const_expr(self._paged):
+            sK = sK_full[0, 0, None, None, None]
+        else:
+            sK = sK_full[None, 0, None, None]
+        # Q's smem aliases K stage 0: the Q fragments are register-resident
+        # before the first K tile is allowed in (empty-mbarrier order).
+        sQ_tma = cute.make_tensor(
+            sK[None, None, 0].iterator, layout=q_tma.smem_layout.outer
+        )
+        q_tma_elems = 128 * 8 // dtype.width
+        sQ = cute.coalesce(
+            cute.group_modes(sQ_tma, 0, 2),
+            target_profile=(block_q, (q_tma_elems, hd // q_tma_elems)),
+        )
+        epi_buffer = smem.allocate_tensor(
+            cutlass.Float32, cute.make_layout((epi_q, 4))
+        )
+        tma_full_mbar = smem.allocate_array(cutlass.Int64, num_stages)
+        tma_empty_mbar = smem.allocate_array(cutlass.Int64, num_stages)
+
+        n_iter = cute.ceil_div(max_k_tiles, num_splits)
+
+        if split_idx < num_kv_blocks:
+            if warp_id == 0:
+                with cute.arch.elect_one():
+                    for i in cutlass.range_constexpr(num_stages):
+                        cute.arch.mbarrier_init(tma_full_mbar + i, 1)
+                        cute.arch.mbarrier_init(tma_empty_mbar + i, 128)
+                    cute.arch.mbarrier_init_fence()
+            elif warp_id == 1:
+                cpasync.prefetch_descriptor(q_tma.atom)
+                cpasync.prefetch_descriptor(k_tma.atom)
+            cute.arch.sync_threads()
+
+            cute.arch.griddepcontrol_wait()
+            cute.arch.griddepcontrol_launch_dependents()
+
+            if warp_id == 4:
+                # TMA producer warp: Q once, then one K tile per valid block.
+                tma_stage = 0
+                tma_parity = 1
+
+                gq_tile = cute.local_tile(
+                    cute.domain_offset(
+                        (q_start, kv_head * group, 0), q_tma.tma_tensor
+                    ),
+                    tiler=(pack, group, hd),
+                    coord=(0, 0, 0),
+                )
+                cute.arch.mbarrier_wait(tma_empty_mbar, tma_parity)
+                with cute.arch.elect_one():
+                    q_size = block_q * hd * (dtype.width // 8)
+                    cute.arch.mbarrier_arrive_and_expect_tx(tma_full_mbar, q_size)
+                _tma_copy_g2s(q_tma.atom, gq_tile, sQ_tma, tma_full_mbar)
+
+                tma_stage = (tma_stage + 1) % num_stages
+                if tma_stage == 0:
+                    tma_parity ^= 1
+
+                for it in cutlass.range(n_iter):
+                    kv_block = split_idx + it * num_splits
+                    if kv_block < num_kv_blocks:
+                        if cutlass.const_expr(self._paged):
+                            page = mPageTable[batch_idx, kv_block]
+                            gk_tile = k_tma.tma_tensor[page, kv_head, None, None]
+                        else:
+                            gk_tile = cute.local_tile(
+                                cute.domain_offset(
+                                    (k_start, kv_head, 0), k_tma.tma_tensor
+                                ),
+                                tiler=(block_k, 1, hd),
+                                coord=(kv_block, 0, 0),
+                            )
+                        k_mbar = tma_full_mbar + tma_stage
+
+                        cute.arch.mbarrier_wait(
+                            tma_empty_mbar + tma_stage, tma_parity
+                        )
+                        with cute.arch.elect_one():
+                            k_size = block_k * hd * (dtype.width // 8)
+                            cute.arch.mbarrier_arrive_and_expect_tx(k_mbar, k_size)
+                        _tma_copy_g2s(
+                            k_tma.atom,
+                            gk_tile,
+                            sK[None, None, tma_stage],
+                            k_mbar,
+                            cache_policy=_TMA_EVICT_FIRST,
+                        )
+
+                        tma_stage = (tma_stage + 1) % num_stages
+                        if tma_stage == 0:
+                            tma_parity ^= 1
+
+            else:
+                # MMA warps: each owns 32 contiguous keys across all q rows.
+                sK_warp = cute.local_tile(
+                    sK, (32, hd, num_stages), (warp_id, 0, 0)
+                )
+                sK_ldsm = cute.zipped_divide(
+                    sK_warp, (16, cute.make_layout((elems, 2)), 1)
+                )
+                sQ_ldsm = cute.zipped_divide(
+                    sQ, (8, cute.make_layout((elems, 4)))
+                )
+                sK_ldsm = sK_ldsm[(lane_id % 16, (None, lane_id // 16), 0), None]
+                sQ_ldsm = sQ_ldsm[(lane_id % 8, (None, lane_id // 8)), None]
+
+                ldsm_atom = cute.make_copy_atom(
+                    warp.LdMatrix8x8x16bOp(num_matrices=4), dtype
+                )
+
+                rQ = cute.make_rmem_tensor(
+                    ((elems // 2, 2), hd // (mma_k * 2), q_tiles), dtype
+                )
+                rK = cute.make_rmem_tensor((elems, 2, hd // mma_k), dtype)
+                rC = cute.make_rmem_tensor((4, 2, q_tiles), cutlass.Float32)
+
+                if warp_id == 0:
+                    cute.arch.mbarrier_wait(tma_full_mbar, 0)
+                cute.arch.barrier(
+                    barrier_id=self._BAR_MMA, number_of_threads=128
+                )
+                for q in cutlass.range_constexpr(q_tiles):
+                    cute.copy(
+                        ldsm_atom, sQ_ldsm[None, (q, None)], rQ[None, None, q]
+                    )
+                cute.arch.mbarrier_arrive(tma_empty_mbar)
+
+                tma_stage = 1 % num_stages
+                tma_parity = 0
+                if tma_stage == 0:
+                    tma_parity ^= 1
+
+                if cutlass.const_expr(self._is_causal):
+                    q_off = mQOffset[batch_idx]
+                else:
+                    q_off = cutlass.Int32(0)
+
+                for it in cutlass.range(n_iter):
+                    kv_block = split_idx + it * num_splits
+                    if kv_block < num_kv_blocks:
+                        rC.fill(0.0)
+
+                        if warp_id == 0:
+                            cute.arch.mbarrier_wait(
+                                tma_full_mbar + tma_stage, tma_parity
+                            )
+                        cute.arch.barrier(
+                            barrier_id=self._BAR_MMA, number_of_threads=128
+                        )
+
+                        for k in cutlass.range_constexpr(hd // mma_k):
+                            cute.copy(
+                                ldsm_atom,
+                                sK_ldsm[None, (None, k, tma_stage)],
+                                rK[None, None, k],
+                            )
+                            for m in cutlass.range_constexpr(2):
+                                for n in cutlass.range_constexpr(q_tiles):
+                                    _mma_m16n8k16(
+                                        rK[None, m, k],
+                                        rQ[(None, k % 2), k // 2, n],
+                                        rC[None, m, n],
+                                    )
+
+                        cute.arch.mbarrier_arrive(tma_empty_mbar + tma_stage)
+
+                        # Mask keys past the causal limit and the sequence
+                        # tail (TMA zero-fills out-of-bounds rows).
+                        k_base = kv_block * block_k + warp_id * 32
+                        for q in cutlass.range_constexpr(q_tiles):
+                            for i in cutlass.range_constexpr(4):
+                                for j in cutlass.range_constexpr(2):
+                                    col = q * 8 + (lane_id % 4) * 2 + j
+                                    token = col % pack
+                                    if cutlass.const_expr(self._is_causal):
+                                        col_limit = cutlass.min(
+                                            token + q_off + 1, seqlen_k
+                                        )
+                                    else:
+                                        col_limit = seqlen_k
+                                    k_pos = k_base + i * 8 + lane_id // 4
+                                    if cute.elem_less(col_limit, k_pos + 1):
+                                        rC[q * 8 + i * 2 + j] = -cutlass.Float32.inf
+
+                        for q in cutlass.range_constexpr(q_tiles):
+                            r0 = rC[q * 8 + 0]
+                            r1 = rC[q * 8 + 1]
+                            for i in cutlass.range_constexpr(1, 4):
+                                r0 = cute.arch.fmax(r0, rC[q * 8 + i * 2 + 0])
+                                r1 = cute.arch.fmax(r1, rC[q * 8 + i * 2 + 1])
+                            for i in cutlass.range_constexpr(3):
+                                off = 4 << i
+                                r0 = cute.arch.fmax(
+                                    r0,
+                                    cute.arch.shuffle_sync_bfly(
+                                        r0, offset=off, mask=-1, mask_and_clamp=31
+                                    ),
+                                )
+                                r1 = cute.arch.fmax(
+                                    r1,
+                                    cute.arch.shuffle_sync_bfly(
+                                        r1, offset=off, mask=-1, mask_and_clamp=31
+                                    ),
+                                )
+                            if lane_id * 2 < 8:
+                                epi_buffer[q * 8 + lane_id * 2 + 0, warp_id] = r0
+                                epi_buffer[q * 8 + lane_id * 2 + 1, warp_id] = r1
+                        cute.arch.barrier(
+                            barrier_id=self._BAR_MMA, number_of_threads=128
+                        )
+
+                        head_local = lane_id // pack
+                        token_f = lane_id - head_local * pack
+                        if lane_id < block_q and cute.elem_less(token_f, seqlen_q):
+                            score = epi_buffer[lane_id, 0]
+                            for i in cutlass.range_constexpr(1, 4):
+                                score = cute.arch.fmax(score, epi_buffer[lane_id, i])
+                            mMaxScore[
+                                kv_head * group + head_local,
+                                kv_block,
+                                q_start + token_f,
+                            ] = score
+
+                        tma_stage = (tma_stage + 1) % num_stages
+                        if tma_stage == 0:
+                            tma_parity ^= 1
+                    elif kv_block < max_k_tiles:
+                        # Padding tile in [num_kv_blocks, max_k_tiles) -> -inf.
+                        if warp_id == 0:
+                            head_p = lane_id // pack
+                            token_p = lane_id - head_p * pack
+                            if lane_id < block_q and cute.elem_less(
+                                token_p, seqlen_q
+                            ):
+                                mMaxScore[
+                                    kv_head * group + head_p,
+                                    kv_block,
+                                    q_start + token_p,
+                                ] = -cutlass.Float32.inf
+        elif split_idx < max_k_tiles:
+            # CTA with no valid block: only padding stores remain.
+            cute.arch.griddepcontrol_wait()
+            cute.arch.griddepcontrol_launch_dependents()
+            if warp_id == 0:
+                for it in cutlass.range(n_iter):
+                    kv_block = split_idx + it * num_splits
+                    if kv_block < max_k_tiles:
+                        head_p2 = lane_id // pack
+                        token_p2 = lane_id - head_p2 * pack
+                        if lane_id < block_q and cute.elem_less(
+                            token_p2, seqlen_q
+                        ):
+                            mMaxScore[
+                                kv_head * group + head_p2,
+                                kv_block,
+                                q_start + token_p2,
+                            ] = -cutlass.Float32.inf
+
+
 class MsaProxyScoreDecodeStreamSm12x:
     """Single-token decode schedule: at one query token the score tile is only
     group_size rows, too skinny for the MMA atom, so K streams straight from

--- a/flashinfer/msa_ops/cute_dsl/proxy_score_sm12x.py
+++ b/flashinfer/msa_ops/cute_dsl/proxy_score_sm12x.py
@@ -13,8 +13,8 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 
-MSA dense proxy-score kernels (bf16/fp16) for SM120/SM121: per (head, KV block,
-query) max of the unscaled post-mask QK^T logits; masked blocks yield -inf.
+MSA dense proxy-score kernels for SM120/SM121: per (head, KV block, query) max
+of the unscaled post-mask QK^T logits; masked blocks yield -inf.
 """
 
 from typing import Type
@@ -890,28 +890,18 @@ class MsaProxyScoreDecodePackedSm12x(MsaProxyScoreSm12x):
 class MsaProxyScoreDecodePackedFp8Sm12x(MsaProxyScoreDecodePackedSm12x):
     """fp8-K packed-decode schedule. Same head-fused M rows as the packed
     schedule, but warps split over keys instead of query rows (after Thien
-    Nguyen's indexer kernel): each warp owns its own key columns, so the
-    e4m3 -> f16/bf16 upconvert runs once per K element instead of once per
-    warp. K stays raw e4m3 through cp.async and smem (half the bytes and half
-    the smem of a converted tile) and upconverts in registers between the
-    smem loads and the mma. mK arrives as a 16-bit view of the e4m3 bytes with half the
-    head dim (see msa_proxy_score), which keeps the cp.async source alignment
-    provable. Q is stored column-permuted to match the converted K fragments
+    Tran's indexer kernel), so the e4m3 -> f16/bf16 upconvert runs once per
+    K element instead of once per warp. K stays raw e4m3 through cp.async
+    and smem, arriving as a 16-bit view with half the head dim (see
+    msa_proxy_score), and upconverts in registers between the smem loads and
+    the mma. Q is stored column-permuted to match the converted K fragments
     (see _gather_packed_q).
 
-    The score tile is 64 rows x 128 keys from a (16, 32)-tiled m16n8k16 mma
-    with the 4 warps side by side along N, so every warp computes all 64 rows
-    for its own 32 key columns and the epilogue joins the per-warp row maxes
-    through smem.
-
-    K staging is pipelined at two granularities, because split-K leaves the
-    small-batch grids with a single KV block per CTA (nothing to overlap
-    across blocks) while long-context CTAs iterate several: two smem K
-    buffers with a one-block prefetch overlap the next block's loads with
-    this block's mma, and each fill commits as two 64-key cp.async groups so
-    the mma starts on the first half while the second is still in flight.
-    Every iteration commits exactly two groups (empty ones once the tail is
-    reached), which keeps the wait_group counts static.
+    K staging is pipelined at two granularities because split-K often leaves
+    a CTA a single KV block: two smem buffers with a one-block prefetch
+    overlap across blocks, and each fill commits as two 64-key cp.async
+    groups so the mma starts on the first half while the second is still in
+    flight.
     """
 
     @cute.kernel
@@ -1040,13 +1030,9 @@ class MsaProxyScoreDecodePackedFp8Sm12x(MsaProxyScoreDecodePackedSm12x):
 
         # B loads are plain 4B reads, not ldmatrix: a warp's slice per
         # (n-tile, k-step pair) is only 8 rows x 16B, which the ldmatrix tiled
-        # copies cannot partition here (the source collapses to one matrix).
-        # Each lane reads the two 16-bit pairs its own fragment needs; the
-        # swizzle keeps the reads bank-spread. kpair holds one such pair (four
-        # consecutive e4m3 key columns); the convert splits it into the
-        # even/odd mma k-steps, and the resulting K-axis column permutation is
-        # mirrored by the Q gather (a permutation shared by both operands
-        # leaves Q K^T unchanged).
+        # copies cannot partition. The convert splits each 4-byte pair into
+        # the even/odd mma k-steps; the resulting K-axis column permutation is
+        # mirrored by the Q gather, so Q K^T is unchanged.
         kpair = cute.make_rmem_tensor(cute.make_layout(2), self._dtype)
         kpair_u32 = cute.recast_tensor(kpair, cutlass.Uint32)
         tSrK_u32 = cute.recast_tensor(
@@ -1063,15 +1049,13 @@ class MsaProxyScoreDecodePackedFp8Sm12x(MsaProxyScoreDecodePackedSm12x):
         n_rows = cute.size(acc_S_mn.shape[0])
 
         # Gather stores are synchronous; order them before the Q fragment
-        # reads. Q fragments are loaded per k-step inside the block loop (a
-        # full-tile preload would hold 4x the M-split fragment count and cost
-        # a CTA of occupancy).
+        # reads. Q fragments load per k-step inside the block loop, since a
+        # full-tile preload would cost a CTA of occupancy.
         self.cta_sync_barrier.arrive_and_wait()
 
-        # Buffer selection is a pointer pick, not an if/else over cloned fill
-        # and consume bodies: the small-batch grids run one CTA per SM with a
-        # cold instruction cache, where duplicated code costs more than the
-        # pipeline saves.
+        # Buffer selection is a pointer pick rather than cloned fill/consume
+        # bodies: small-batch grids run one cold-I-cache CTA per SM, where the
+        # duplicated code costs more than it saves.
         base0 = sK0.iterator.toint()
         buf_step = sK1.iterator.toint() - base0
 
@@ -1099,10 +1083,9 @@ class MsaProxyScoreDecodePackedFp8Sm12x(MsaProxyScoreDecodePackedSm12x):
                     sK_layout,
                 )
                 # Prefetch the next block into the idle buffer; its loads fly
-                # under this block's mma and epilogue. Exactly two commit
-                # groups go out either way (empty ones at the tail), so the
-                # current block's halves are always the 4th- and 3rd-newest
-                # groups and the wait_group counts below stay static.
+                # under this block's mma and epilogue. Two commit groups go
+                # out either way (empty ones at the tail), which keeps the
+                # wait_group counts below static.
                 nxt_block = kv_block + num_splits
                 if nxt_block < num_kv_blocks:
                     self._fill_k8_tile(
@@ -1123,8 +1106,7 @@ class MsaProxyScoreDecodePackedFp8Sm12x(MsaProxyScoreDecodePackedSm12x):
 
                 # S = Q K^T (unscaled), consumed one 64-key half behind each
                 # fill group so the mma starts before the tile finishes
-                # landing (split-K often leaves one block per CTA, where this
-                # intra-block overlap is the only one available).
+                # landing.
                 acc_S.fill(0.0)
                 for h in cutlass.range_constexpr(2):
                     cute.arch.cp_async_wait_group(3 - h)
@@ -1250,10 +1232,8 @@ class MsaProxyScoreDecodePackedFp8Sm12x(MsaProxyScoreDecodePackedSm12x):
         acc_S: cute.Tensor,
     ):
         """Convert-and-mma over one 64-key half (n-tiles ``2*half`` and
-        ``2*half + 1``). Per k-step pair: read the lane's raw 16-bit pairs,
-        packed-convert into the pair's fragments, then the two mma steps; Q
-        fragments load just in time so ptxas keeps the per-thread A footprint
-        at one k-step."""
+        ``2*half + 1``). Q fragments load just in time so ptxas keeps the
+        per-thread A footprint at one k-step."""
         tidx, _, _ = cute.arch.thread_idx()
         # Fragment geometry of the m16n8k16 B atom: lane covers key row
         # n = 32*nt + 8*warp + lane//4 and k16 pairs at 2*(lane%4) (+8).
@@ -1287,11 +1267,10 @@ class MsaProxyScoreDecodePackedFp8Sm12x(MsaProxyScoreDecodePackedSm12x):
                         lo, hi = _fp8x4_to_bf16x4(kpair_u32[0])
                     else:
                         lo, hi = _fp8x4_to_f16x4(kpair_u32[0])
-                    # All four e4m3 of this u32 belong to the same canonical
-                    # 16-column group g, so both converted pairs go into mma
-                    # step 2*kk8 + g: this keeps each product in the same
-                    # instruction as the reference schedules, and the chained
-                    # f32 accumulation stays bit-identical.
+                    # All four e4m3 of this u32 belong to canonical 16-column
+                    # group g, so both converted pairs go into mma step
+                    # 2*kk8 + g: each product lands in the same instruction as
+                    # the reference schedules, keeping the result bit-identical.
                     kk = 2 * kk8 + g
                     d0 = cute.crd2idx(((0, 0), nt, kk), tSrK.layout)
                     d1 = cute.crd2idx(((0, 1), nt, kk), tSrK.layout)
@@ -1327,13 +1306,10 @@ class MsaProxyScoreDecodePackedFp8Sm12x(MsaProxyScoreDecodePackedSm12x):
     @cute.jit
     def _gather_packed_q(self, mQ, sQ, q_start, kv_head, seqlen_q, tidx):
         """Gather the packed Q tile into swizzled smem, column-permuted to
-        match the converted K fragments; rows past seqlen_q are zero-filled
-        (epilogue masks them).
-
-        The packed K convert places column ``16g + 4m + 2h + j`` of each
-        32-wide block in the mma slot that canonically holds
-        ``16g + 8h + 2m + j``, and Q must follow the same K-axis permutation
-        for ``Q K^T`` to be unchanged."""
+        match the converted K fragments (the K convert moves column
+        ``16g + 4m + 2h + j`` of each 32-wide block into the slot that
+        canonically holds ``16g + 8h + 2m + j``). Rows past seqlen_q are
+        zero-filled; the epilogue masks them."""
         elems = 128 // self._dtype.width
         chunks = self._head_dim // elems
         total = self._m_block_size * chunks
@@ -1420,10 +1396,7 @@ class MsaProxyScoreDecodeKeyMajorSm12x:
     two-stage mbarrier pipeline (Q's smem aliases K stage 0), which leaves
     two intra-CTA barriers per block. The low per-CTA fixed cost (no Q
     gather, no fill barriers, no per-step Q reloads) is what wins on the
-    one-block-per-CTA grids that split-K produces at small batch, and
-    measured on SM120 the schedule also beats the row-major/key-split
-    packed schedules on machine-filling grids, so it takes every fused
-    tile of at most 32 rows.
+    one-block-per-CTA grids that split-K produces at small batch.
 
     Derived from vLLM's IndexDecodeScoreKernel (Apache-2.0) by Thien Tran
     (gau-nernst), adapted to flat/paged K with a kv-head mode, per-request
@@ -1458,14 +1431,10 @@ class MsaProxyScoreDecodeKeyMajorSm12x:
         self._is_causal = is_causal
         self._paged = paged
         self._kv_fp8 = kv_fp8
-        # fp8 q arrives as a 16-bit view like fp8 K (the vLLM M3 fp8 path
-        # emits e4m3 index-q). With both operands raw e4m3 the ldmatrix
-        # column order matches on both sides, so the Q fragments need only
-        # the same split converts as K -- no cross-lane permute.
         self._q_fp8 = q_fp8
         # Right-aligned decode (q_offset=None) computes the causal offset
-        # in-kernel from the seqlens, skipping the host-side offset-tensor
-        # build (two extra kernel launches that dominate at batch 1).
+        # in-kernel, skipping the host-side offset-tensor build kernels that
+        # dominate at batch 1.
         self._qoff_default = qoff_default
         self._block_q = group_size * pack_q_len
         self._q_tiles = (self._block_q + 7) // 8
@@ -1751,11 +1720,10 @@ class MsaProxyScoreDecodeKeyMajorSm12x:
                 rK = cute.make_rmem_tensor((elems, 2, kw // mma_k), dtype)
                 if cutlass.const_expr(self._kv_fp8):
                     # ldmatrix on the 16-bit view hands each lane 4 consecutive
-                    # e4m3 per u32; splitting each converted u32 into its low
-                    # and high f16 pair yields two k16 A-fragments per
-                    # 32-fp8-column group as pure register renames (the Q
-                    # fragments are permuted once below to the same column
-                    # order).
+                    # e4m3 per u32, so splitting each converted u32 into its
+                    # low and high pair yields the two k16 A-fragments as pure
+                    # register renames. Q is permuted once below to the same
+                    # column order.
                     rK_u32 = cute.recast_tensor(rK, cutlass.Uint32)
                     rK_lo = cute.make_rmem_tensor((elems,), dtype)
                     rK_hi = cute.make_rmem_tensor((elems,), dtype)
@@ -1780,8 +1748,8 @@ class MsaProxyScoreDecodeKeyMajorSm12x:
                 if cutlass.const_expr(self._kv_fp8):
                     rQ_u32 = cute.recast_tensor(rQ, cutlass.Uint32)
                     if cutlass.const_expr(self._q_fp8):
-                        # Raw e4m3 q: ldmatrix hands q the same fp8 column
-                        # order as K, so the split converts already are the
+                        # Raw e4m3 q gets the same fp8 column order as K from
+                        # ldmatrix, so the split converts already are the
                         # matching B-fragments.
                         for g in cutlass.range_constexpr(kw // mma_k):
                             for n in cutlass.range_constexpr(q_tiles):
@@ -1800,10 +1768,9 @@ class MsaProxyScoreDecodeKeyMajorSm12x:
                                     rQp_u32[j, g, n, 1] = q_hi
                     else:
                         # One-time cross-lane permute of the bf16/f16 Q
-                        # B-fragments into the fp8 K column order: per
-                        # 32-column group, lane quad position q4 needs columns
-                        # 4*q4..4*q4+3, which sit as u32 pairs on quad lanes
-                        # 2*(q4%2) (lower half) and 2*(q4%2)+1 (upper half) of
+                        # B-fragments into the fp8 K column order: quad
+                        # position q4 needs columns 4*q4..4*q4+3, which sit as
+                        # u32 pairs on quad lanes 2*(q4%2) and 2*(q4%2)+1 of
                         # the canonical fragments.
                         q4 = lane_id % 4
                         src_lo = lane_id - q4 + 2 * (q4 % 2)
@@ -1859,9 +1826,8 @@ class MsaProxyScoreDecodeKeyMajorSm12x:
 
                         if cutlass.const_expr(self._kv_fp8):
                             # The lower/upper regrouping puts different
-                            # products in each mma than the bf16 schedule;
-                            # with e4m3 K (and e4m3-representable q, the
-                            # deployment case) every f32 dot term is exact,
+                            # products in each mma than the bf16 schedule.
+                            # With e4m3 operands every f32 dot term is exact,
                             # so the result still matches dequantized K
                             # bit-for-bit.
                             for k in cutlass.range_constexpr(kw // mma_k):
@@ -2013,11 +1979,10 @@ class MsaProxyScoreDecodeStreamSm12x:
     GMEM to registers (no smem, no tensor cores) and dim-parallel lanes reduce
     each key's dot products with warp shuffles.
 
-    Deliberately q_len == 1 only: a pack_q > 1 (MTP) variant reusing the K
-    registers across tokens measured 0.67-0.99x of the packed-MMA schedule
-    (5080, Sq 2-8) -- the shuffle+FMA phase scales with Sq while the K loads
-    don't, and the rising arithmetic intensity at m = Sq * group_size rows is
-    exactly what starts paying for the tensor cores. MTP stays packed-MMA."""
+    Deliberately q_len == 1 only: the shuffle+FMA phase scales with q_len
+    while the K loads don't, and that rising arithmetic intensity is exactly
+    what starts paying for the tensor cores. MTP stays on the packed-MMA
+    schedules."""
 
     _NUM_WARPS = 8
     _KEYS_PER_ITER = 2  # 32 lanes = 2 keys x 16 dim-slice lanes

--- a/flashinfer/msa_ops/cute_dsl/proxy_score_sm12x.py
+++ b/flashinfer/msa_ops/cute_dsl/proxy_score_sm12x.py
@@ -1441,6 +1441,7 @@ class MsaProxyScoreDecodeKeyMajorSm12x:
         is_causal: bool = True,
         paged: bool = False,
         kv_fp8: bool = False,
+        qoff_default: bool = True,
     ):
         if head_dim != 128:
             raise ValueError("only head_dim == 128 is supported")
@@ -1454,6 +1455,10 @@ class MsaProxyScoreDecodeKeyMajorSm12x:
         self._is_causal = is_causal
         self._paged = paged
         self._kv_fp8 = kv_fp8
+        # Right-aligned decode (q_offset=None) computes the causal offset
+        # in-kernel from the seqlens, skipping the host-side offset-tensor
+        # build (two extra kernel launches that dominate at batch 1).
+        self._qoff_default = qoff_default
         self._block_q = group_size * pack_q_len
         self._q_tiles = (self._block_q + 7) // 8
         self._num_threads = 32 * 5
@@ -1747,7 +1752,10 @@ class MsaProxyScoreDecodeKeyMajorSm12x:
                     tma_parity ^= 1
 
                 if cutlass.const_expr(self._is_causal):
-                    q_off = mQOffset[batch_idx]
+                    if cutlass.const_expr(self._qoff_default):
+                        q_off = seqlen_k - seqlen_q
+                    else:
+                        q_off = mQOffset[batch_idx]
                 else:
                     q_off = cutlass.Int32(0)
 

--- a/flashinfer/msa_ops/cute_dsl/proxy_score_sm12x.py
+++ b/flashinfer/msa_ops/cute_dsl/proxy_score_sm12x.py
@@ -23,7 +23,81 @@ import cuda.bindings.driver as cuda
 import cutlass
 import cutlass.cute as cute
 import cutlass.pipeline as pipeline
+from cutlass._mlir.dialects import llvm
 from cutlass.cute.nvgpu import cpasync, warp
+from cutlass.cutlass_dsl import T, dsl_user_op
+
+
+@dsl_user_op
+def _fp8x4_to_f16x4(x: cutlass.Uint32, *, loc=None, ip=None):
+    out = llvm.inline_asm(
+        llvm.StructType.get_literal([T.i32()] * 2),
+        [x.ir_value(loc=loc, ip=ip)],
+        "{\n\t"
+        ".reg .b16 lo, hi;\n\t"
+        "mov.b32 {lo, hi}, $2;\n\t"
+        "cvt.rn.f16x2.e4m3x2 $0, lo;\n\t"
+        "cvt.rn.f16x2.e4m3x2 $1, hi;\n\t"
+        "}\n",
+        "=r,=r,r",
+        has_side_effects=False,
+        is_align_stack=False,
+        loc=loc,
+        ip=ip,
+    )
+    return (
+        cutlass.Uint32(llvm.extractvalue(T.i32(), out, [0], loc=loc, ip=ip)),
+        cutlass.Uint32(llvm.extractvalue(T.i32(), out, [1], loc=loc, ip=ip)),
+    )
+
+
+@dsl_user_op
+def _fp8x4_to_bf16x4(x: cutlass.Uint32, *, loc=None, ip=None):
+    # There is no e4m3 -> bf16 cvt; round-trip through f16, which is exact
+    # (every e4m3 value is representable in both f16 and bf16).
+    out = llvm.inline_asm(
+        llvm.StructType.get_literal([T.i32()] * 2),
+        [x.ir_value(loc=loc, ip=ip)],
+        "{\n\t"
+        ".reg .b16 lo, hi, t00, t01, t10, t11;\n\t"
+        "mov.b32 {lo, hi}, $2;\n\t"
+        "cvt.rn.f16x2.e4m3x2 $0, lo;\n\t"
+        "cvt.rn.f16x2.e4m3x2 $1, hi;\n\t"
+        "mov.b32 {t00, t01}, $0;\n\t"
+        "mov.b32 {t10, t11}, $1;\n\t"
+        "cvt.rn.bf16.f16 t00, t00;\n\t"
+        "cvt.rn.bf16.f16 t01, t01;\n\t"
+        "cvt.rn.bf16.f16 t10, t10;\n\t"
+        "cvt.rn.bf16.f16 t11, t11;\n\t"
+        "mov.b32 $0, {t00, t01};\n\t"
+        "mov.b32 $1, {t10, t11};\n\t"
+        "}\n",
+        "=r,=r,r",
+        has_side_effects=False,
+        is_align_stack=False,
+        loc=loc,
+        ip=ip,
+    )
+    return (
+        cutlass.Uint32(llvm.extractvalue(T.i32(), out, [0], loc=loc, ip=ip)),
+        cutlass.Uint32(llvm.extractvalue(T.i32(), out, [1], loc=loc, ip=ip)),
+    )
+
+
+@cute.jit
+def _cvt_fp8_frag(src: cute.Tensor, dst: cute.Tensor):
+    """Convert an e4m3 register fragment to dst's f16/bf16 element type with
+    packed cvt (one instruction per four elements); element-wise ``.to()``
+    lowers to a byte-extract sequence."""
+    src_u32 = cute.recast_tensor(src, cutlass.Uint32)
+    dst_u32 = cute.recast_tensor(dst, cutlass.Uint32)
+    for i in cutlass.range_constexpr(cute.size(src.shape) // 4):
+        if cutlass.const_expr(dst.element_type is cutlass.BFloat16):
+            lo, hi = _fp8x4_to_bf16x4(src_u32[i])
+        else:
+            lo, hi = _fp8x4_to_f16x4(src_u32[i])
+        dst_u32[i * 2] = lo
+        dst_u32[i * 2 + 1] = hi
 
 
 class MsaProxyScoreSm12x:
@@ -49,20 +123,15 @@ class MsaProxyScoreSm12x:
         self._is_causal = is_causal
         self._paged = paged
         self._kv_fp8 = kv_fp8
-        self._pad_stride = head_dim + 8
 
         self.cta_sync_barrier = pipeline.NamedBarrier(
             barrier_id=1, num_threads=num_threads
         )
 
     def _make_sk_layout(self):
-        """K SMEM layout (built in-kernel for region isolation): swizzled for
-        the cp.async path, plain padded for the fp8 convert path."""
-        if self._kv_fp8:
-            return cute.make_layout(
-                (self._n_block_size, self._head_dim),
-                stride=(self._pad_stride, 1),
-            )
+        """K SMEM layout (built in-kernel for region isolation). The fp8
+        convert path stores 16B-aligned chunks, so the swizzle works for it
+        too; a padded layout would cost a second CTA per SM (48KB -> >50KB)."""
         atom = cute.make_composed_layout(
             cute.make_swizzle(3, 3, 3),
             0,
@@ -447,8 +516,9 @@ class MsaProxyScoreSm12x:
 
 
 class MsaProxyScoreDecodePackedSm12x(MsaProxyScoreSm12x):
-    """Head-fused packed-decode bf16/fp16 schedule: packs qhead_per_kv heads x
-    pack_q_len tokens into the M rows so the shared index-K is read once per kv_head."""
+    """Head-fused packed-decode schedule (bf16/fp16 or fp8 K): packs qhead_per_kv
+    heads x pack_q_len tokens into the M rows so the shared index-K is read once
+    per kv_head. fp8 K loads e4m3 bytes and packed-converts into smem."""
 
     def __init__(
         self,
@@ -669,28 +739,33 @@ class MsaProxyScoreDecodePackedSm12x(MsaProxyScoreSm12x):
                             (k_start, 0), mK[None, kv_head, None]
                         )
                         row_off8 = kv_block * self._n_block_size
-                    chunks_per_row = self._head_dim // 8
-                    total_chunks = self._n_block_size * chunks_per_row
-                    cvt_frag = cute.make_rmem_tensor(cute.make_layout(8), self._dtype)
-                    for kv_it in cutlass.range_constexpr(
-                        total_chunks // self._num_threads
-                    ):
+                    chunks_per_row = self._head_dim // 16
+                    n_chunks = (
+                        self._n_block_size * chunks_per_row // self._num_threads
+                    )
+                    # Issue every 16B K load before the convert+store loop so the
+                    # gmem latencies overlap (the loads have no cp.async here).
+                    k_frag = cute.make_rmem_tensor(
+                        cute.make_layout((16, n_chunks)), mK.element_type
+                    )
+                    cvt_frag = cute.make_rmem_tensor(cute.make_layout(16), self._dtype)
+                    for kv_it in cutlass.range_constexpr(n_chunks):
                         kv_chunk = tidx + kv_it * self._num_threads
                         kv_m = kv_chunk // chunks_per_row
-                        kv_c8 = kv_chunk % chunks_per_row
-                        sK_chunk = cute.local_tile(sK[kv_m, None], (8,), (kv_c8,))
+                        kv_c16 = kv_chunk % chunks_per_row
                         if (kv_block * self._n_block_size + kv_m) < seqlen_k:
                             gKc = cute.local_tile(
-                                mK_h8[row_off8 + kv_m, None], (8,), (kv_c8,)
+                                mK_h8[row_off8 + kv_m, None], (16,), (kv_c16,)
                             )
-                            cvt_frag.store(
-                                gKc.load()
-                                .to(cutlass.Float16)
-                                .to(cutlass.Float32)
-                                .to(self._dtype)
-                            )
+                            cute.autovec_copy(gKc, k_frag[None, kv_it])
                         else:
-                            cvt_frag.fill(0)
+                            k_frag[None, kv_it].fill(0)
+                    for kv_it in cutlass.range_constexpr(n_chunks):
+                        kv_chunk = tidx + kv_it * self._num_threads
+                        kv_m = kv_chunk // chunks_per_row
+                        kv_c16 = kv_chunk % chunks_per_row
+                        sK_chunk = cute.local_tile(sK[kv_m, None], (16,), (kv_c16,))
+                        _cvt_fp8_frag(k_frag[None, kv_it], cvt_frag)
                         cute.autovec_copy(cvt_frag, sK_chunk)
                 else:
                     if cutlass.const_expr(self._paged):
@@ -833,6 +908,7 @@ class MsaProxyScoreDecodeStreamSm12x:
         group_size: int = 4,
         is_causal: bool = True,
         paged: bool = False,
+        kv_fp8: bool = False,
         qoff_default: bool = True,
     ):
         if head_dim != 128:
@@ -846,6 +922,7 @@ class MsaProxyScoreDecodeStreamSm12x:
         self._G = group_size
         self._is_causal = is_causal
         self._paged = paged
+        self._kv_fp8 = kv_fp8
         # Right-aligned decode (q_offset=None): the single query sits at
         # seqlen_k - 1, so the causal limit is just seqlen_k and no offset
         # tensor is needed.
@@ -943,9 +1020,11 @@ class MsaProxyScoreDecodeStreamSm12x:
                 mK_h = mK[None, kv_head, None]  # (total_k, d)
 
             # Keep this loop separate from the compute loop below: issuing all
-            # loads before any consumption is the latency hiding.
+            # loads before any consumption is the latency hiding. fp8 K stays
+            # e4m3 through the loads (half the DRAM bytes) and upconverts per
+            # iteration in the compute loop.
             kfrag = cute.make_rmem_tensor(
-                cute.make_layout(self._num_iters * 8), self._dtype
+                cute.make_layout(self._num_iters * 8), mK.element_type
             )
             for it in cutlass.range_constexpr(self._num_iters):
                 off = warp * self._keys_per_warp + it * self._KEYS_PER_ITER + lane_key
@@ -961,7 +1040,18 @@ class MsaProxyScoreDecodeStreamSm12x:
                 cute.autovec_copy(k_chunk, dst)
 
             for it in cutlass.range_constexpr(self._num_iters):
-                ks = [cutlass.Float32(kfrag[it * 8 + i]) for i in range(8)]
+                if cutlass.const_expr(self._kv_fp8):
+                    # f16 intermediate (exact for e4m3), packed cvt.
+                    k8 = cute.make_tensor(
+                        kfrag.iterator + it * 8, cute.make_layout(8)
+                    )
+                    kf16 = cute.make_rmem_tensor(
+                        cute.make_layout(8), cutlass.Float16
+                    )
+                    _cvt_fp8_frag(k8, kf16)
+                    ks = [cutlass.Float32(kf16[i]) for i in range(8)]
+                else:
+                    ks = [cutlass.Float32(kfrag[it * 8 + i]) for i in range(8)]
                 es = [
                     qs[g][0] * ks[0]
                     + qs[g][1] * ks[1]

--- a/flashinfer/msa_ops/cute_dsl/proxy_score_sm12x.py
+++ b/flashinfer/msa_ops/cute_dsl/proxy_score_sm12x.py
@@ -1068,50 +1068,58 @@ class MsaProxyScoreDecodePackedFp8Sm12x(MsaProxyScoreDecodePackedSm12x):
         # a CTA of occupancy).
         self.cta_sync_barrier.arrive_and_wait()
 
+        # Buffer selection is a pointer pick, not an if/else over cloned fill
+        # and consume bodies: the small-batch grids run one CTA per SM with a
+        # cold instruction cache, where duplicated code costs more than the
+        # pipeline saves.
+        base0 = sK0.iterator.toint()
+        buf_step = sK1.iterator.toint() - base0
+
         n_iter = cute.ceil_div(max_k_tiles, num_splits)
         for it in cutlass.range(n_iter):
             kv_block = split_idx + it * num_splits
             if kv_block < num_kv_blocks:
+                par = it % 2
+                sK_cur = cute.make_tensor(
+                    cute.make_ptr(
+                        self._dtype,
+                        base0 + par * buf_step,
+                        cute.AddressSpace.smem,
+                        assumed_align=1024,
+                    ),
+                    sK_layout,
+                )
+                sK_nxt = cute.make_tensor(
+                    cute.make_ptr(
+                        self._dtype,
+                        base0 + (1 - par) * buf_step,
+                        cute.AddressSpace.smem,
+                        assumed_align=1024,
+                    ),
+                    sK_layout,
+                )
                 # Prefetch the next block into the idle buffer; its loads fly
                 # under this block's mma and epilogue. Exactly two commit
                 # groups go out either way (empty ones at the tail), so the
                 # current block's halves are always the 4th- and 3rd-newest
                 # groups and the wait_group counts below stay static.
                 nxt_block = kv_block + num_splits
-                if (it % 2) == 0:
-                    if nxt_block < num_kv_blocks:
-                        self._fill_k8_tile(
-                            gmem_tiled_copy,
-                            gmem_thr_copy,
-                            mK,
-                            mPageTable,
-                            batch_idx,
-                            kv_head,
-                            k_start,
-                            nxt_block,
-                            seqlen_k,
-                            sK1,
-                        )
-                    else:
-                        cute.arch.cp_async_commit_group()
-                        cute.arch.cp_async_commit_group()
+                if nxt_block < num_kv_blocks:
+                    self._fill_k8_tile(
+                        gmem_tiled_copy,
+                        gmem_thr_copy,
+                        mK,
+                        mPageTable,
+                        batch_idx,
+                        kv_head,
+                        k_start,
+                        nxt_block,
+                        seqlen_k,
+                        sK_nxt,
+                    )
                 else:
-                    if nxt_block < num_kv_blocks:
-                        self._fill_k8_tile(
-                            gmem_tiled_copy,
-                            gmem_thr_copy,
-                            mK,
-                            mPageTable,
-                            batch_idx,
-                            kv_head,
-                            k_start,
-                            nxt_block,
-                            seqlen_k,
-                            sK0,
-                        )
-                    else:
-                        cute.arch.cp_async_commit_group()
-                        cute.arch.cp_async_commit_group()
+                    cute.arch.cp_async_commit_group()
+                    cute.arch.cp_async_commit_group()
 
                 # S = Q K^T (unscaled), consumed one 64-key half behind each
                 # fill group so the mma starts before the tile finishes
@@ -1121,36 +1129,20 @@ class MsaProxyScoreDecodePackedFp8Sm12x(MsaProxyScoreDecodePackedSm12x):
                 for h in cutlass.range_constexpr(2):
                     cute.arch.cp_async_wait_group(3 - h)
                     self.cta_sync_barrier.arrive_and_wait()
-                    if (it % 2) == 0:
-                        self._consume_k8_half(
-                            h,
-                            sK0,
-                            smem_tiled_copy_Q,
-                            tSsQ,
-                            tSrQ,
-                            tSrQ_copy_view,
-                            tiled_mma,
-                            tSrK,
-                            tSrK_u32,
-                            kpair,
-                            kpair_u32,
-                            acc_S,
-                        )
-                    else:
-                        self._consume_k8_half(
-                            h,
-                            sK1,
-                            smem_tiled_copy_Q,
-                            tSsQ,
-                            tSrQ,
-                            tSrQ_copy_view,
-                            tiled_mma,
-                            tSrK,
-                            tSrK_u32,
-                            kpair,
-                            kpair_u32,
-                            acc_S,
-                        )
+                    self._consume_k8_half(
+                        h,
+                        sK_cur,
+                        smem_tiled_copy_Q,
+                        tSsQ,
+                        tSrQ,
+                        tSrQ_copy_view,
+                        tiled_mma,
+                        tSrK,
+                        tSrK_u32,
+                        kpair,
+                        kpair_u32,
+                        acc_S,
+                    )
 
                 # Every warp's K fragment loads must land before the next
                 # iteration's prefetch overwrites this buffer.

--- a/flashinfer/msa_ops/cute_dsl/proxy_score_sm12x.py
+++ b/flashinfer/msa_ops/cute_dsl/proxy_score_sm12x.py
@@ -887,6 +887,364 @@ class MsaProxyScoreDecodePackedSm12x(MsaProxyScoreSm12x):
                 sQ_chunk.fill(0)
 
 
+class MsaProxyScoreDecodePackedFp8Sm12x(MsaProxyScoreDecodePackedSm12x):
+    """fp8-K packed-decode schedule. Same head-fused M rows as the packed
+    schedule, but warps split over keys instead of query rows (after Thien
+    Nguyen's indexer kernel): each warp owns its own key columns, so the
+    e4m3 -> f16/bf16 upconvert runs once per K element instead of once per
+    warp. K stays raw e4m3 through cp.async and smem (half the bytes and half
+    the smem of a converted tile) and upconverts in registers between the
+    smem loads and the mma. mK arrives as a 16-bit view of the e4m3 bytes with half the
+    head dim (see msa_proxy_score), which keeps the cp.async source alignment
+    provable. Q is stored column-permuted to match the converted K fragments
+    (see _gather_packed_q).
+
+    The score tile is 64 rows x 128 keys from a (16, 32)-tiled m16n8k16 mma
+    with the 4 warps side by side along N, so every warp computes all 64 rows
+    for its own 32 key columns and the epilogue joins the per-warp row maxes
+    through smem.
+    """
+
+    @cute.kernel
+    def kernel(
+        self,
+        mQ: cute.Tensor,
+        mK: cute.Tensor,
+        mPageTable: cute.Tensor,
+        mMaxScore: cute.Tensor,
+        mCuQ: cute.Tensor,
+        mCuK: cute.Tensor,
+        mQOffset: cute.Tensor,
+        max_k_tiles: cutlass.Int32,
+        num_splits: cutlass.Int32,
+    ):
+        tidx, _, _ = cute.arch.thread_idx()
+        split_idx, batch_idx, kv_head = cute.arch.block_idx()
+
+        q_start = mCuQ[batch_idx]
+        seqlen_q = mCuQ[batch_idx + 1] - q_start
+        if cutlass.const_expr(self._paged):
+            # mCuK holds per-request lengths on the paged path:
+            # page_table supplies every KV address, so there is
+            # no base offset to add.
+            k_start = cutlass.Int32(0)
+            seqlen_k = mCuK[batch_idx]
+        else:
+            k_start = mCuK[batch_idx]
+            seqlen_k = mCuK[batch_idx + 1] - k_start
+        num_kv_blocks = cute.ceil_div(seqlen_k, self._n_block_size)
+
+        # K tile is raw e4m3 viewed 16-bit, so it is half as wide as Q's.
+        kw = self._head_dim // 2
+        sQ_layout = self._make_sq_layout()
+        sK_layout = self._make_sk8_layout()
+
+        @cute.struct
+        class SharedStorage:
+            sQ: cute.struct.Align[
+                cute.struct.MemRange[self._dtype, cute.cosize(sQ_layout)],
+                1024,
+            ]
+            sK: cute.struct.Align[
+                cute.struct.MemRange[self._dtype, cute.cosize(sK_layout)],
+                1024,
+            ]
+
+        smem = cutlass.utils.SmemAllocator()
+        storage = smem.allocate(SharedStorage)
+        sQ = storage.sQ.get_tensor(sQ_layout)
+        sK = storage.sK.get_tensor(sK_layout)
+        # Full-width layout on the same pointer: shapes the mma B fragment
+        # only, no accesses go through it.
+        sK_frag_ref = cute.make_tensor(sK.iterator, self._make_sk_layout())
+        # Cross-warp epilogue staging (64 rows x 4 warps f32) aliased onto
+        # sK's first 1KB: dead between the last fragment load of one kv-block
+        # and the next block's fill, which is exactly the epilogue window.
+        sMax = cute.recast_tensor(
+            cute.make_tensor(sK.iterator, cute.make_layout(512)), cutlass.Float32
+        )
+
+        universal_copy_bits = 128
+        async_copy_elems = universal_copy_bits // self._dtype.width
+        atom_async_copy = cute.make_copy_atom(
+            cpasync.CopyG2SOp(cache_mode=cpasync.LoadCacheMode.GLOBAL),
+            self._dtype,
+            num_bits_per_copy=universal_copy_bits,
+        )
+        t_dim1 = 64 // async_copy_elems
+        t_layout = cute.make_layout(
+            (self._num_threads // t_dim1, t_dim1), stride=(t_dim1, 1)
+        )
+        v_layout = cute.make_layout((1, async_copy_elems))
+        gmem_tiled_copy = cute.make_tiled_copy_tv(atom_async_copy, t_layout, v_layout)
+        gmem_thr_copy = gmem_tiled_copy.get_slice(tidx)
+
+        self._gather_packed_q(mQ, sQ, q_start, kv_head, seqlen_q, tidx)
+
+        # Warps side by side along N: each owns interleaved 8-column slices
+        # of the 128 keys (32 columns total), so the fp8 K fragments are
+        # converted once instead of replicated across the M-split warps.
+        num_warps = self._num_threads // 32
+        tiled_mma = cute.make_tiled_mma(
+            warp.MmaF16BF16Op(self._dtype, cutlass.Float32, (16, 8, 16)),
+            (1, num_warps, 1),
+            permutation_mnk=(16, num_warps * 8, 16),
+        )
+        thr_mma = tiled_mma.get_slice(tidx)
+        tSrQ = thr_mma.make_fragment_A(thr_mma.partition_A(sQ))
+        tSrK = thr_mma.make_fragment_B(thr_mma.partition_B(sK_frag_ref))
+        acc_S = cute.make_rmem_tensor(
+            thr_mma.partition_shape_C((self._m_block_size, self._n_block_size)),
+            cutlass.Float32,
+        )
+
+        smem_copy_atom_Q = cute.make_copy_atom(
+            warp.LdMatrix8x8x16bOp(transpose=False, num_matrices=4),
+            self._dtype,
+        )
+        smem_tiled_copy_Q = cute.make_tiled_copy_A(smem_copy_atom_Q, tiled_mma)
+        smem_thr_copy_Q = smem_tiled_copy_Q.get_slice(tidx)
+        tSsQ = smem_thr_copy_Q.partition_S(sQ)
+        tSrQ_copy_view = smem_thr_copy_Q.retile(tSrQ)
+
+        # B loads are plain 4B reads, not ldmatrix: a warp's slice per
+        # (n-tile, k-step pair) is only 8 rows x 16B, which the ldmatrix tiled
+        # copies cannot partition here (the source collapses to one matrix).
+        # Each lane reads the two 16-bit pairs its own fragment needs; the
+        # swizzle keeps the reads bank-spread. kpair holds one such pair (four
+        # consecutive e4m3 key columns); the convert splits it into the
+        # even/odd mma k-steps, and the resulting K-axis column permutation is
+        # mirrored by the Q gather (a permutation shared by both operands
+        # leaves Q K^T unchanged).
+        kpair = cute.make_rmem_tensor(cute.make_layout(2), self._dtype)
+        kpair_u32 = cute.recast_tensor(kpair, cutlass.Uint32)
+        tSrK_u32 = cute.recast_tensor(
+            cute.make_tensor(
+                tSrK.iterator, cute.make_layout(cute.cosize(tSrK.layout))
+            ),
+            cutlass.Uint32,
+        )
+        warp_idx = tidx // 32
+        lane = tidx % 32
+        # Fragment geometry of the m16n8k16 B atom: lane covers key row
+        # n = 32*nt + 8*warp + lane//4 and k16 pairs at 2*(lane%4) (+8).
+        nb_row = 8 * warp_idx + lane // 4
+        m4 = lane % 4
+
+        cS = cute.make_identity_tensor((self._m_block_size, self._n_block_size))
+        tScS_mn = self._make_acc_tensor_mn_view(thr_mma.partition_C(cS))
+        acc_S_mn = self._make_acc_tensor_mn_view(acc_S)
+        n_rows = cute.size(acc_S_mn.shape[0])
+
+        # K gmem views, as in the packed kernel but on the half-width view.
+        if cutlass.const_expr(self._paged):
+            pass  # per-block page lookup happens inside the loop
+        else:
+            mK_h = cute.domain_offset((k_start, 0), mK[None, kv_head, None])
+            gK = cute.local_tile(mK_h, (self._n_block_size, kw), (None, 0))
+            tKgK_flat = gmem_thr_copy.partition_S(gK)
+        tKsK = gmem_thr_copy.partition_D(sK)
+        cKV = cute.make_identity_tensor((self._n_block_size, kw))
+        tKVcKV = gmem_thr_copy.partition_S(cKV)
+
+        # Gather stores are synchronous; order them before the Q fragment
+        # reads. Q fragments are loaded per k-step inside the block loop (a
+        # full-tile preload would hold 4x the M-split fragment count and cost
+        # a CTA of occupancy).
+        self.cta_sync_barrier.arrive_and_wait()
+
+        n_iter = cute.ceil_div(max_k_tiles, num_splits)
+        for it in cutlass.range(n_iter):
+            kv_block = split_idx + it * num_splits
+            if kv_block < num_kv_blocks:
+                # Also orders the previous epilogue's sMax reads before this
+                # block's fill of the aliased sK bytes.
+                self.cta_sync_barrier.arrive_and_wait()
+                if cutlass.const_expr(self._paged):
+                    page = mPageTable[batch_idx, kv_block]
+                    gK_pg = cute.local_tile(
+                        mK[page, kv_head, None, None],
+                        (self._n_block_size, kw),
+                        (None, 0),
+                    )
+                    tKgK_pg = gmem_thr_copy.partition_S(gK_pg)
+                    for n in cutlass.range_constexpr(cute.size(tKsK.shape[1])):
+                        if (
+                            kv_block * self._n_block_size + tKVcKV[0, n, 0][0]
+                        ) < seqlen_k:
+                            cute.copy(
+                                gmem_tiled_copy,
+                                tKgK_pg[None, n, None, 0],
+                                tKsK[None, n, None],
+                            )
+                        else:
+                            tKsK[None, n, None].fill(0)
+                else:
+                    for n in cutlass.range_constexpr(cute.size(tKsK.shape[1])):
+                        if (
+                            kv_block * self._n_block_size + tKVcKV[0, n, 0][0]
+                        ) < seqlen_k:
+                            cute.copy(
+                                gmem_tiled_copy,
+                                tKgK_flat[None, n, None, kv_block],
+                                tKsK[None, n, None],
+                            )
+                        else:
+                            tKsK[None, n, None].fill(0)
+                cute.arch.cp_async_commit_group()
+                cute.arch.cp_async_wait_group(0)
+                self.cta_sync_barrier.arrive_and_wait()
+
+                # S = Q K^T (unscaled). Per k-step pair: read the lane's raw
+                # 16-bit pairs, packed-convert into the pair's fragments, then
+                # the two mma steps; Q fragments load just in time so ptxas
+                # keeps the per-thread A footprint at one k-step.
+                acc_S.fill(0.0)
+                for kk8 in cutlass.range_constexpr(self._head_dim // 32):
+                    for nt in cutlass.range_constexpr(
+                        self._n_block_size // (8 * self._num_threads // 32)
+                    ):
+                        n_row = 32 * nt + nb_row
+                        for g in cutlass.range_constexpr(2):
+                            src = cute.local_tile(
+                                sK[n_row, None], (2,), (8 * kk8 + 4 * g + m4,)
+                            )
+                            cute.autovec_copy(src, kpair)
+                            if cutlass.const_expr(self._dtype is cutlass.BFloat16):
+                                lo, hi = _fp8x4_to_bf16x4(kpair_u32[0])
+                            else:
+                                lo, hi = _fp8x4_to_f16x4(kpair_u32[0])
+                            # All four e4m3 of this u32 belong to the same
+                            # canonical 16-column group g, so both converted
+                            # pairs go into mma step 2*kk8 + g: this keeps
+                            # each product in the same instruction as the
+                            # reference schedules, and the chained f32
+                            # accumulation stays bit-identical.
+                            kk = 2 * kk8 + g
+                            d0 = cute.crd2idx(((0, 0), nt, kk), tSrK.layout)
+                            d1 = cute.crd2idx(((0, 1), nt, kk), tSrK.layout)
+                            tSrK_u32[d0 // 2] = lo
+                            tSrK_u32[d1 // 2] = hi
+                    for s in cutlass.range_constexpr(2):
+                        kk = 2 * kk8 + s
+                        cute.copy(
+                            smem_tiled_copy_Q,
+                            tSsQ[None, None, kk],
+                            tSrQ_copy_view[None, None, kk],
+                        )
+                        cute.gemm(
+                            tiled_mma,
+                            acc_S,
+                            tSrQ[None, None, kk],
+                            tSrK[None, None, kk],
+                            acc_S,
+                        )
+
+                # Orders every warp's sK fragment loads before the epilogue
+                # overwrites the aliased sMax bytes.
+                self.cta_sync_barrier.arrive_and_wait()
+
+                # Per-warp row maxes over the warp's 32 key columns, staged to
+                # smem; one thread per row then joins the 4 warps and stores.
+                for r in cutlass.range_constexpr(n_rows):
+                    row = tScS_mn[r, 0][0]
+                    token = row % self._pack_q_len
+                    if cutlass.const_expr(self._is_causal):
+                        col_limit = cutlass.min(
+                            token + mQOffset[batch_idx] + 1, seqlen_k
+                        )
+                    else:
+                        col_limit = seqlen_k
+                    for c in cutlass.range_constexpr(cute.size(tScS_mn.shape[1])):
+                        k_pos = kv_block * self._n_block_size + tScS_mn[0, c][1]
+                        if cute.elem_less(col_limit, k_pos + 1):
+                            acc_S_mn[r, c] = -cutlass.Float32.inf
+                    tile_max = (
+                        acc_S_mn[r, None]
+                        .load()
+                        .reduce(cute.ReductionOp.MAX, -cutlass.Float32.inf, 0)
+                    )
+                    tile_max = self._threadquad_reduce_max(tile_max)
+                    if tidx % 4 == 0:
+                        sMax[row * 4 + warp_idx] = tile_max
+                self.cta_sync_barrier.arrive_and_wait()
+                if tidx < self._m_block_size:
+                    row_max = sMax[tidx * 4]
+                    for w in cutlass.range_constexpr(1, 4):
+                        row_max = cute.arch.fmax(row_max, sMax[tidx * 4 + w])
+                    token_f = tidx % self._pack_q_len
+                    head_f = kv_head * self._qhead_per_kv + tidx // self._pack_q_len
+                    if cute.elem_less(token_f, seqlen_q):
+                        mMaxScore[head_f, kv_block, q_start + token_f] = row_max
+            elif kv_block < max_k_tiles:
+                # Padding tile in [num_kv_blocks, max_k_tiles) -> -inf, as in
+                # the packed kernel.
+                for r in cutlass.range_constexpr(n_rows):
+                    row2 = tScS_mn[r, 0][0]
+                    token2 = row2 % self._pack_q_len
+                    local_head2 = row2 // self._pack_q_len
+                    head2 = kv_head * self._qhead_per_kv + local_head2
+                    if cute.elem_less(token2, seqlen_q):
+                        mMaxScore[
+                            head2, kv_block, q_start + token2
+                        ] = -cutlass.Float32.inf
+
+    def _make_sk8_layout(self):
+        """K smem layout for the raw e4m3 bytes viewed as 16-bit pairs: half
+        the width of the converted tile, same swizzle."""
+        atom = cute.make_composed_layout(
+            cute.make_swizzle(3, 3, 3),
+            0,
+            cute.make_layout((8, 64), stride=(64, 1)),
+        )
+        return cute.tile_to_shape(
+            atom, (self._n_block_size, self._head_dim // 2), (0, 1)
+        )
+
+    @cute.jit
+    def _gather_packed_q(self, mQ, sQ, q_start, kv_head, seqlen_q, tidx):
+        """Gather the packed Q tile into swizzled smem, column-permuted to
+        match the converted K fragments; rows past seqlen_q are zero-filled
+        (epilogue masks them).
+
+        The packed K convert places column ``16g + 4m + 2h + j`` of each
+        32-wide block in the mma slot that canonically holds
+        ``16g + 8h + 2m + j``, and Q must follow the same K-axis permutation
+        for ``Q K^T`` to be unchanged."""
+        elems = 128 // self._dtype.width
+        chunks = self._head_dim // elems
+        total = self._m_block_size * chunks
+        frag = cute.make_rmem_tensor(cute.make_layout(elems), self._dtype)
+        for it in cutlass.range_constexpr(total // self._num_threads):
+            e = tidx + it * self._num_threads
+            r = e // chunks
+            c8 = e % chunks
+            local_head = r // self._pack_q_len
+            token = r % self._pack_q_len
+            head = kv_head * self._qhead_per_kv + local_head
+            if cute.elem_less(token, seqlen_q):
+                gQ_chunk = cute.local_tile(
+                    mQ[q_start + token, head, None], (elems,), (c8,)
+                )
+                frag.store(gQ_chunk.load())
+                # Chunk column a = 8*c8 + 2*i + j goes to permuted pair
+                # position p2 (see the docstring); pairs stay contiguous.
+                for i in cutlass.range_constexpr(4):
+                    pr = cute.make_tensor(frag.iterator + 2 * i, cute.make_layout(2))
+                    p2 = (
+                        16 * (c8 // 4)
+                        + 8 * ((c8 % 4) // 2)
+                        + 4 * (i % 2)
+                        + 2 * (c8 % 2)
+                        + i // 2
+                    )
+                    dst = cute.local_tile(sQ[r, None], (2,), (p2,))
+                    cute.autovec_copy(pr, dst)
+            else:
+                sQ_chunk0 = cute.local_tile(sQ[r, None], (elems,), (c8,))
+                sQ_chunk0.fill(0)
+
+
 class MsaProxyScoreDecodeStreamSm12x:
     """Single-token decode schedule: at one query token the score tile is only
     group_size rows, too skinny for the MMA atom, so K streams straight from

--- a/flashinfer/msa_ops/proxy_score.py
+++ b/flashinfer/msa_ops/proxy_score.py
@@ -352,6 +352,7 @@ def msa_proxy_score(
     import cutlass.cute as cute
 
     from .cute_dsl.proxy_score_sm12x import (
+        MsaProxyScoreDecodeKeyMajorSm12x,
         MsaProxyScoreDecodePackedFp8Sm12x,
         MsaProxyScoreDecodePackedSm12x,
         MsaProxyScoreDecodeStreamSm12x,
@@ -458,6 +459,23 @@ def msa_proxy_score(
         while p < max_seqlen_q or group_size * p < 16:
             p *= 2
         pack_q_len = min(p, _PACK_ROWS // group_size)
+    # Small fused tiles (<= 32 rows) on small base grids take the key-major
+    # TMA schedule, whose per-CTA fixed cost matches the one-block-per-CTA
+    # grids split-K produces at small batch (see
+    # MsaProxyScoreDecodeKeyMajorSm12x). Larger grids keep the row-major
+    # packed schedule: its smaller smem footprint co-resides 3 CTAs per SM,
+    # which wins once the grid can fill the machine.
+    use_keymajor = False
+    if use_packed and not kv_fp8:
+        p = 1
+        while p < max_seqlen_q:
+            p *= 2
+        if (
+            group_size * p <= 32
+            and batch_size * num_kv_heads * 4 <= get_device_sm_count(dev)
+        ):
+            use_keymajor = True
+            pack_q_len = p
 
     # group_size keys the packed/stream schedules: it is constexpr-baked into
     # the gather/epilogue, so each factorization is its own kernel.
@@ -469,6 +487,7 @@ def msa_proxy_score(
         kv_fp8,
         use_stream,
         use_packed,
+        use_keymajor,
         group_size if use_stream else pack_q_len,
         qoff_default if use_stream else None,
     )
@@ -502,6 +521,15 @@ def msa_proxy_score(
                 paged=paged,
                 kv_fp8=kv_fp8,
                 qoff_default=qoff_default,
+            )
+        elif use_keymajor:
+            kernel_obj = MsaProxyScoreDecodeKeyMajorSm12x(
+                head_dim=head_dim,
+                group_size=group_size,
+                pack_q_len=pack_q_len,
+                is_causal=causal,
+                paged=paged,
+                kv_fp8=kv_fp8,
             )
         elif use_packed:
             # fp8 K gets the key-split warp layout so the e4m3 upconvert

--- a/flashinfer/msa_ops/proxy_score.py
+++ b/flashinfer/msa_ops/proxy_score.py
@@ -293,8 +293,8 @@ def msa_proxy_score(
     Single-token decode uses a dim-parallel scalar schedule that streams
     index-K straight to registers. Short multi-token decode (MTP) uses a
     head-fused packed schedule that scores all ``group_size`` heads of a
-    kv_head from one shared index-K read. fp8 K and prefill use the general
-    schedule; see the dispatch below for the exact regime bounds.
+    kv_head from one shared index-K read. Prefill uses the general schedule;
+    see the dispatch below for the exact regime bounds.
 
     Parameters
     ----------
@@ -427,9 +427,7 @@ def msa_proxy_score(
     # Single-token decode uses the dim-parallel stream schedule (see
     # MsaProxyScoreDecodeStreamSm12x). total_q == batch_size guarantees exactly
     # one q token per request, which its token == batch indexing relies on.
-    use_stream = (
-        not kv_fp8 and max_seqlen_q == 1 and total_q == batch_size and group_size <= 8
-    )
+    use_stream = max_seqlen_q == 1 and total_q == batch_size and group_size <= 8
     # Right-aligned decode on the stream path computes the causal limit
     # in-kernel, so no offset tensor (and its build kernels) is needed.
     qoff_default = q_offset is None
@@ -442,11 +440,10 @@ def msa_proxy_score(
 
     # Head-fused decode path: pack group_size heads x pack_q_len q-tokens into one
     # 64-row MMA tile so index-K is read once per (batch, kv_head). Outside the regime
-    # (prefill, fp8 K, group_size not dividing 64) use the general schedule.
+    # (prefill, group_size not dividing 64) use the general schedule.
     _PACK_ROWS = 64  # bf16 MMA q-tile rows (== m_block_size)
     use_packed = (
         not use_stream
-        and not kv_fp8
         and group_size >= 2
         and _PACK_ROWS % group_size == 0
         and max_seqlen_q <= _PACK_ROWS // group_size
@@ -487,6 +484,7 @@ def msa_proxy_score(
                 group_size=group_size,
                 is_causal=causal,
                 paged=paged,
+                kv_fp8=kv_fp8,
                 qoff_default=qoff_default,
             )
         elif use_packed:

--- a/flashinfer/msa_ops/proxy_score.py
+++ b/flashinfer/msa_ops/proxy_score.py
@@ -458,7 +458,7 @@ def msa_proxy_score(
     # packed schedule: its smaller smem footprint co-resides 3 CTAs per SM,
     # which wins once the grid can fill the machine.
     use_keymajor = False
-    if use_packed and not kv_fp8:
+    if use_packed:
         p = 1
         while p < max_seqlen_q:
             p *= 2

--- a/flashinfer/msa_ops/proxy_score.py
+++ b/flashinfer/msa_ops/proxy_score.py
@@ -432,20 +432,18 @@ def msa_proxy_score(
 
     group_size = num_qo_heads // num_kv_heads
     _PACK_ROWS = 64  # bf16 MMA q-tile rows (== m_block_size)
-    # Single-token bf16 decode uses the dim-parallel stream schedule (see
-    # MsaProxyScoreDecodeStreamSm12x). total_q == batch_size guarantees exactly
-    # one q token per request, which its token == batch indexing relies on.
-    # fp8 K skips it when the key-major schedule can take the shape instead:
-    # the stream schedule pays a CUDA-core convert per K element, while
-    # key-major converts in-register nearly for free.
-    keymajor_fp8_sq1 = (
-        kv_fp8 and 2 <= group_size <= 32 and _PACK_ROWS % group_size == 0
-    )
+    # Single-token decode prefers the key-major schedule whenever it can take
+    # the shape; the dim-parallel stream schedule (see
+    # MsaProxyScoreDecodeStreamSm12x) remains for the group sizes it cannot
+    # (1, or not dividing the 64-row tile). total_q == batch_size guarantees
+    # exactly one q token per request, which the stream schedule's
+    # token == batch indexing relies on.
+    keymajor_sq1 = 2 <= group_size <= 32 and _PACK_ROWS % group_size == 0
     use_stream = (
         max_seqlen_q == 1
         and total_q == batch_size
         and group_size <= 8
-        and not keymajor_fp8_sq1
+        and not keymajor_sq1
     )
     qoff_default = q_offset is None
 

--- a/flashinfer/msa_ops/proxy_score.py
+++ b/flashinfer/msa_ops/proxy_score.py
@@ -528,7 +528,11 @@ def msa_proxy_score(
         kd = head_dim // 2 if kv16 else head_dim
         k_shape = (s_tk, s_hkv, _BLK_KV, kd) if paged else (s_tk, s_hkv, kd)
         stream_fake = cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=True)
-        kernel_obj: Union["MsaProxyScoreDecodeStreamSm12x", "MsaProxyScoreSm12x"]
+        kernel_obj: Union[
+            "MsaProxyScoreDecodeKeyMajorSm12x",
+            "MsaProxyScoreDecodeStreamSm12x",
+            "MsaProxyScoreSm12x",
+        ]
         if use_stream:
             kernel_obj = MsaProxyScoreDecodeStreamSm12x(
                 head_dim=head_dim,

--- a/flashinfer/msa_ops/proxy_score.py
+++ b/flashinfer/msa_ops/proxy_score.py
@@ -437,12 +437,13 @@ def msa_proxy_score(
         p *= 2
     # Fused tiles of at most 32 rows (group_size * next_pow2(q_len)) take the
     # key-major TMA schedule (see MsaProxyScoreDecodeKeyMajorSm12x); larger
-    # fused tiles keep the row-major/key-split schedules. Single-token decode
-    # falls back to the dim-parallel stream schedule (see
-    # MsaProxyScoreDecodeStreamSm12x) for the group sizes key-major cannot
-    # take (1, or not dividing the 64-row tile); total_q == batch_size
-    # guarantees exactly one q token per request, which the stream schedule's
-    # token == batch indexing relies on.
+    # fused tiles keep the row-major/key-split schedules. bf16 single-token
+    # decode stays on the dim-parallel stream schedule (see
+    # MsaProxyScoreDecodeStreamSm12x), which also covers the group sizes
+    # key-major cannot take; fp8 single-token decode goes key-major, whose
+    # in-register convert beats the stream schedule's per-element CUDA-core
+    # convert. total_q == batch_size guarantees exactly one q token per
+    # request, which the stream schedule's token == batch indexing relies on.
     keymajor_ok = (
         group_size >= 2 and _PACK_ROWS % group_size == 0 and group_size * p <= 32
     )
@@ -450,7 +451,7 @@ def msa_proxy_score(
         max_seqlen_q == 1
         and total_q == batch_size
         and group_size <= 8
-        and not keymajor_ok
+        and not (kv_fp8 and keymajor_ok)
     )
     qoff_default = q_offset is None
 

--- a/flashinfer/msa_ops/proxy_score.py
+++ b/flashinfer/msa_ops/proxy_score.py
@@ -430,15 +430,7 @@ def msa_proxy_score(
     # MsaProxyScoreDecodeStreamSm12x). total_q == batch_size guarantees exactly
     # one q token per request, which its token == batch indexing relies on.
     use_stream = max_seqlen_q == 1 and total_q == batch_size and group_size <= 8
-    # Right-aligned decode on the stream path computes the causal limit
-    # in-kernel, so no offset tensor (and its build kernels) is needed.
     qoff_default = q_offset is None
-    if use_stream and qoff_default:
-        qoff_dev = _proxy_dummies(dev.index)[1]
-    else:
-        qoff_dev = _q_offset_tensor(
-            q_offset, cu_q_dev, k_len_or_cu, dev, k_is_lengths=paged
-        )
 
     # Head-fused decode path: pack group_size heads x pack_q_len q-tokens into one
     # 64-row MMA tile so index-K is read once per (batch, kv_head). Outside the regime
@@ -477,6 +469,16 @@ def msa_proxy_score(
             use_keymajor = True
             pack_q_len = p
 
+    # Right-aligned decode on the stream and key-major paths computes the
+    # causal limit in-kernel, so no offset tensor (and its build kernels,
+    # which dominate at batch 1) is needed.
+    if (use_stream or use_keymajor) and qoff_default:
+        qoff_dev = _proxy_dummies(dev.index)[1]
+    else:
+        qoff_dev = _q_offset_tensor(
+            q_offset, cu_q_dev, k_len_or_cu, dev, k_is_lengths=paged
+        )
+
     # group_size keys the packed/stream schedules: it is constexpr-baked into
     # the gather/epilogue, so each factorization is its own kernel.
     key = (
@@ -489,7 +491,7 @@ def msa_proxy_score(
         use_packed,
         use_keymajor,
         group_size if use_stream else pack_q_len,
-        qoff_default if use_stream else None,
+        qoff_default if (use_stream or use_keymajor) else None,
     )
     # The packed fp8 schedule takes K as a 16-bit torch view of the e4m3
     # bytes (half the last dim): the kernel moves raw bytes and upconverts in
@@ -530,6 +532,7 @@ def msa_proxy_score(
                 is_causal=causal,
                 paged=paged,
                 kv_fp8=kv_fp8,
+                qoff_default=qoff_default,
             )
         elif use_packed:
             # fp8 K gets the key-split warp layout so the e4m3 upconvert

--- a/flashinfer/msa_ops/proxy_score.py
+++ b/flashinfer/msa_ops/proxy_score.py
@@ -300,6 +300,8 @@ def msa_proxy_score(
     ----------
     q : torch.Tensor
         ``(total_q, num_qo_heads, 128)``, bf16 or fp16 (the cheap proxy Q).
+        May be fp8 E4M3 when ``k`` is fp8: decode shapes consume it natively
+        (the fastest path); other shapes upconvert it once internally.
     k : torch.Tensor
         Flat ``(total_k, num_kv_heads, 128)`` with ``cu_seqlens_k``, or
         paged ``(num_pages, num_kv_heads, 128, 128)`` with ``page_table`` +
@@ -367,8 +369,9 @@ def msa_proxy_score(
 
     if not is_sm12x_supported(q.device):
         raise RuntimeError("msa_proxy_score requires SM120 or SM121 and CUDA >= 12.8")
-    if q.dtype not in (torch.bfloat16, torch.float16):
-        raise ValueError(f"q must be bf16 or fp16, got {q.dtype}")
+    q_fp8 = q.dtype == torch.float8_e4m3fn
+    if q.dtype not in (torch.bfloat16, torch.float16) and not q_fp8:
+        raise ValueError(f"q must be bf16, fp16, or fp8 e4m3, got {q.dtype}")
     total_q, num_qo_heads, head_dim = q.shape
     if head_dim != 128:
         raise ValueError(f"head_dim must be 128, got {head_dim}")
@@ -376,6 +379,8 @@ def msa_proxy_score(
     if num_qo_heads % num_kv_heads != 0:
         raise ValueError("num_qo_heads must be a multiple of num_kv_heads")
     kv_fp8 = k.dtype == torch.float8_e4m3fn
+    if q_fp8 and not kv_fp8:
+        raise ValueError("fp8 q requires fp8 k")
     if not kv_fp8 and k.dtype != q.dtype:
         raise ValueError("k dtype must match q (or be float8_e4m3fn)")
     dev = q.device
@@ -477,6 +482,13 @@ def msa_proxy_score(
             use_keymajor = True
             pack_q_len = p
 
+    # fp8 q (the vLLM M3 fp8-cache contract) is consumed natively only by the
+    # key-major schedule; other shapes upconvert once (e4m3 -> bf16 is
+    # lossless) and take their usual route.
+    if q_fp8 and not use_keymajor:
+        q = q.to(torch.bfloat16)
+        q_fp8 = False
+
     # Right-aligned decode on the stream and key-major paths computes the
     # causal limit in-kernel, so no offset tensor (and its build kernels,
     # which dominate at batch 1) is needed.
@@ -501,15 +513,18 @@ def msa_proxy_score(
         group_size if use_stream else pack_q_len,
         qoff_default if (use_stream or use_keymajor) else None,
     )
-    # The packed fp8 schedule takes K as a 16-bit torch view of the e4m3
-    # bytes (half the last dim): the kernel moves raw bytes and upconverts in
-    # registers, and a typed view keeps the cp.async source alignment provable
-    # where an in-kernel recast of a symbolic layout does not.
+    # The packed fp8 schedules take e4m3 operands as 16-bit torch views (half
+    # the last dim): the kernel moves raw bytes and upconverts in registers,
+    # and a typed view keeps the TMA/cp.async source alignment provable where
+    # an in-kernel recast of a symbolic layout does not. fp8 q rides an f16
+    # carrier so both register converts hit the native e4m3 -> f16 path.
     kv16 = kv_fp8 and use_packed
-    k_call = k.contiguous().view(q.dtype) if kv16 else k
+    carrier = torch.float16 if q_fp8 else q.dtype
+    q_call = q.contiguous().view(carrier) if q_fp8 else q
+    k_call = k.contiguous().view(carrier) if kv16 else k
     compiled = _compile_cache.get(key)
     if compiled is None:
-        cdt = _cutlass_dtype(q.dtype)
+        cdt = _cutlass_dtype(q_call.dtype)
         kdt = _cutlass_dtype(k_call.dtype)
         i32 = _cutlass_dtype(torch.int32)
         f32 = _cutlass_dtype(torch.float32)
@@ -519,6 +534,7 @@ def msa_proxy_score(
         s_tq, s_hq, s_tk, s_hkv, s_b1, s_bk, s_b0, s_pb, s_pm, s_mt = (
             cute.sym_int() for _ in range(10)
         )
+        qd = head_dim // 2 if q_fp8 else head_dim
         kd = head_dim // 2 if kv16 else head_dim
         k_shape = (s_tk, s_hkv, _BLK_KV, kd) if paged else (s_tk, s_hkv, kd)
         stream_fake = cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=True)
@@ -540,6 +556,7 @@ def msa_proxy_score(
                 is_causal=causal,
                 paged=paged,
                 kv_fp8=kv_fp8,
+                q_fp8=q_fp8,
                 qoff_default=qoff_default,
             )
         elif use_packed:
@@ -573,7 +590,7 @@ def msa_proxy_score(
             )
         compiled = cute.compile(
             kernel_obj,
-            _fake(cdt, (s_tq, s_hq, head_dim)),
+            _fake(cdt, (s_tq, s_hq, qd)),
             _fake(kdt, k_shape),
             _fake(i32, (s_pb, s_pm), align=4),
             _fake(f32, (s_hq, s_mt, s_tq), align=4),
@@ -619,12 +636,12 @@ def msa_proxy_score(
     if use_stream:
         # One CTA per (KV block, token, kv_head): the grid is already maximally
         # split, so there is no split factor to tune.
-        _call([q, k_call, pt_dev, per_head, cu_q_dev, k_len_or_cu, qoff_dev], 1)
+        _call([q_call, k_call, pt_dev, per_head, cu_q_dev, k_len_or_cu, qoff_dev], 1)
     else:
         _run_proxy_autotuned(
             "msa_proxy_score",
             _call,
-            [q, k_call, pt_dev, per_head, cu_q_dev, k_len_or_cu, qoff_dev],
+            [q_call, k_call, pt_dev, per_head, cu_q_dev, k_len_or_cu, qoff_dev],
             max_seqlen_q=max_seqlen_q,
             max_k_tiles=max_k_tiles,
             base_ctas=base_ctas,

--- a/flashinfer/msa_ops/proxy_score.py
+++ b/flashinfer/msa_ops/proxy_score.py
@@ -15,7 +15,6 @@ limitations under the License.
 """
 
 import functools
-import os
 from typing import Optional, Tuple, Union
 
 import torch
@@ -427,16 +426,28 @@ def msa_proxy_score(
         per_head = output
 
     group_size = num_qo_heads // num_kv_heads
-    # Single-token decode uses the dim-parallel stream schedule (see
+    _PACK_ROWS = 64  # bf16 MMA q-tile rows (== m_block_size)
+    # Single-token bf16 decode uses the dim-parallel stream schedule (see
     # MsaProxyScoreDecodeStreamSm12x). total_q == batch_size guarantees exactly
     # one q token per request, which its token == batch indexing relies on.
-    use_stream = max_seqlen_q == 1 and total_q == batch_size and group_size <= 8
+    # fp8 K skips it when the key-major schedule can take the shape instead:
+    # the stream schedule pays a CUDA-core convert per K element, while
+    # key-major converts in-register nearly for free (measured ~10-18% faster
+    # at batch 1 on SM120).
+    keymajor_fp8_sq1 = (
+        kv_fp8 and 2 <= group_size <= 32 and _PACK_ROWS % group_size == 0
+    )
+    use_stream = (
+        max_seqlen_q == 1
+        and total_q == batch_size
+        and group_size <= 8
+        and not keymajor_fp8_sq1
+    )
     qoff_default = q_offset is None
 
     # Head-fused decode path: pack group_size heads x pack_q_len q-tokens into one
     # 64-row MMA tile so index-K is read once per (batch, kv_head). Outside the regime
     # (prefill, group_size not dividing 64) use the general schedule.
-    _PACK_ROWS = 64  # bf16 MMA q-tile rows (== m_block_size)
     use_packed = (
         not use_stream
         and group_size >= 2
@@ -452,22 +463,17 @@ def msa_proxy_score(
         while p < max_seqlen_q or group_size * p < 16:
             p *= 2
         pack_q_len = min(p, _PACK_ROWS // group_size)
-    # Small fused tiles (<= 32 rows) on small base grids take the key-major
-    # TMA schedule, whose per-CTA fixed cost matches the one-block-per-CTA
-    # grids split-K produces at small batch (see
-    # MsaProxyScoreDecodeKeyMajorSm12x). Larger grids keep the row-major
-    # packed schedule: its smaller smem footprint co-resides 3 CTAs per SM,
-    # which wins once the grid can fill the machine.
+    # Small fused tiles (<= 32 rows) take the key-major TMA schedule at every
+    # grid size (see MsaProxyScoreDecodeKeyMajorSm12x): its per-CTA fixed cost
+    # matches the one-block-per-CTA grids split-K produces at small batch, and
+    # measured on SM120 it also beats the row-major/key-split schedules on
+    # machine-filling grids. Those remain only for > 32-row tiles.
     use_keymajor = False
     if use_packed:
         p = 1
         while p < max_seqlen_q:
             p *= 2
-        if group_size * p <= 32 and (
-            batch_size * num_kv_heads * 4 <= get_device_sm_count(dev)
-            # Diagnostic override to measure key-major on large grids.
-            or os.environ.get("FLASHINFER_MSA_FORCE_KEYMAJOR") == "1"
-        ):
+        if group_size * p <= 32:
             use_keymajor = True
             pack_q_len = p
 

--- a/flashinfer/msa_ops/proxy_score.py
+++ b/flashinfer/msa_ops/proxy_score.py
@@ -352,6 +352,7 @@ def msa_proxy_score(
     import cutlass.cute as cute
 
     from .cute_dsl.proxy_score_sm12x import (
+        MsaProxyScoreDecodePackedFp8Sm12x,
         MsaProxyScoreDecodePackedSm12x,
         MsaProxyScoreDecodeStreamSm12x,
         MsaProxyScoreSm12x,
@@ -449,6 +450,14 @@ def msa_proxy_score(
         and max_seqlen_q <= _PACK_ROWS // group_size
     )
     pack_q_len = _PACK_ROWS // group_size if use_packed else 0
+    if use_packed and kv_fp8:
+        # The key-split fp8 kernel takes any 16-multiple row tile, so size it
+        # to the spec-decode length instead of always packing 64 rows: at the
+        # common 4-head sq<=4 shapes this quarters the mma work per CTA.
+        p = 1
+        while p < max_seqlen_q or group_size * p < 16:
+            p *= 2
+        pack_q_len = min(p, _PACK_ROWS // group_size)
 
     # group_size keys the packed/stream schedules: it is constexpr-baked into
     # the gather/epilogue, so each factorization is its own kernel.
@@ -463,10 +472,16 @@ def msa_proxy_score(
         group_size if use_stream else pack_q_len,
         qoff_default if use_stream else None,
     )
+    # The packed fp8 schedule takes K as a 16-bit torch view of the e4m3
+    # bytes (half the last dim): the kernel moves raw bytes and upconverts in
+    # registers, and a typed view keeps the cp.async source alignment provable
+    # where an in-kernel recast of a symbolic layout does not.
+    kv16 = kv_fp8 and use_packed
+    k_call = k.contiguous().view(q.dtype) if kv16 else k
     compiled = _compile_cache.get(key)
     if compiled is None:
         cdt = _cutlass_dtype(q.dtype)
-        kdt = _cutlass_dtype(k.dtype)
+        kdt = _cutlass_dtype(k_call.dtype)
         i32 = _cutlass_dtype(torch.int32)
         f32 = _cutlass_dtype(torch.float32)
         # s_bk is mCuK's own symbol: on the paged path it holds per-request
@@ -475,7 +490,8 @@ def msa_proxy_score(
         s_tq, s_hq, s_tk, s_hkv, s_b1, s_bk, s_b0, s_pb, s_pm, s_mt = (
             cute.sym_int() for _ in range(10)
         )
-        k_shape = (s_tk, s_hkv, _BLK_KV, head_dim) if paged else (s_tk, s_hkv, head_dim)
+        kd = head_dim // 2 if kv16 else head_dim
+        k_shape = (s_tk, s_hkv, _BLK_KV, kd) if paged else (s_tk, s_hkv, kd)
         stream_fake = cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=True)
         kernel_obj: Union["MsaProxyScoreDecodeStreamSm12x", "MsaProxyScoreSm12x"]
         if use_stream:
@@ -488,9 +504,16 @@ def msa_proxy_score(
                 qoff_default=qoff_default,
             )
         elif use_packed:
-            kernel_obj = MsaProxyScoreDecodePackedSm12x(
+            # fp8 K gets the key-split warp layout so the e4m3 upconvert
+            # is not replicated across warps.
+            packed_cls = (
+                MsaProxyScoreDecodePackedFp8Sm12x
+                if kv_fp8
+                else MsaProxyScoreDecodePackedSm12x
+            )
+            kernel_obj = packed_cls(
                 head_dim=head_dim,
-                m_block_size=64,
+                m_block_size=group_size * pack_q_len,
                 n_block_size=_BLK_KV,
                 num_threads=128,
                 is_causal=causal,
@@ -557,12 +580,12 @@ def msa_proxy_score(
     if use_stream:
         # One CTA per (KV block, token, kv_head): the grid is already maximally
         # split, so there is no split factor to tune.
-        _call([q, k, pt_dev, per_head, cu_q_dev, k_len_or_cu, qoff_dev], 1)
+        _call([q, k_call, pt_dev, per_head, cu_q_dev, k_len_or_cu, qoff_dev], 1)
     else:
         _run_proxy_autotuned(
             "msa_proxy_score",
             _call,
-            [q, k, pt_dev, per_head, cu_q_dev, k_len_or_cu, qoff_dev],
+            [q, k_call, pt_dev, per_head, cu_q_dev, k_len_or_cu, qoff_dev],
             max_seqlen_q=max_seqlen_q,
             max_k_tiles=max_k_tiles,
             base_ctas=base_ctas,

--- a/flashinfer/msa_ops/proxy_score.py
+++ b/flashinfer/msa_ops/proxy_score.py
@@ -15,6 +15,7 @@ limitations under the License.
 """
 
 import functools
+import os
 from typing import Optional, Tuple, Union
 
 import torch
@@ -462,9 +463,10 @@ def msa_proxy_score(
         p = 1
         while p < max_seqlen_q:
             p *= 2
-        if (
-            group_size * p <= 32
-            and batch_size * num_kv_heads * 4 <= get_device_sm_count(dev)
+        if group_size * p <= 32 and (
+            batch_size * num_kv_heads * 4 <= get_device_sm_count(dev)
+            # Diagnostic override to measure key-major on large grids.
+            or os.environ.get("FLASHINFER_MSA_FORCE_KEYMAJOR") == "1"
         ):
             use_keymajor = True
             pack_q_len = p

--- a/flashinfer/msa_ops/proxy_score.py
+++ b/flashinfer/msa_ops/proxy_score.py
@@ -432,18 +432,25 @@ def msa_proxy_score(
 
     group_size = num_qo_heads // num_kv_heads
     _PACK_ROWS = 64  # bf16 MMA q-tile rows (== m_block_size)
-    # Single-token decode prefers the key-major schedule whenever it can take
-    # the shape; the dim-parallel stream schedule (see
-    # MsaProxyScoreDecodeStreamSm12x) remains for the group sizes it cannot
-    # (1, or not dividing the 64-row tile). total_q == batch_size guarantees
-    # exactly one q token per request, which the stream schedule's
+    p = 1
+    while p < max_seqlen_q:
+        p *= 2
+    # Fused tiles of at most 32 rows (group_size * next_pow2(q_len)) take the
+    # key-major TMA schedule (see MsaProxyScoreDecodeKeyMajorSm12x); larger
+    # fused tiles keep the row-major/key-split schedules. Single-token decode
+    # falls back to the dim-parallel stream schedule (see
+    # MsaProxyScoreDecodeStreamSm12x) for the group sizes key-major cannot
+    # take (1, or not dividing the 64-row tile); total_q == batch_size
+    # guarantees exactly one q token per request, which the stream schedule's
     # token == batch indexing relies on.
-    keymajor_sq1 = 2 <= group_size <= 32 and _PACK_ROWS % group_size == 0
+    keymajor_ok = (
+        group_size >= 2 and _PACK_ROWS % group_size == 0 and group_size * p <= 32
+    )
     use_stream = (
         max_seqlen_q == 1
         and total_q == batch_size
         and group_size <= 8
-        and not keymajor_sq1
+        and not keymajor_ok
     )
     qoff_default = q_offset is None
 
@@ -456,25 +463,11 @@ def msa_proxy_score(
         and _PACK_ROWS % group_size == 0
         and max_seqlen_q <= _PACK_ROWS // group_size
     )
-    pack_q_len = _PACK_ROWS // group_size if use_packed else 0
-    if use_packed and kv_fp8:
-        # The key-split fp8 kernel takes any 16-multiple row tile, so size it
-        # to the spec-decode length instead of always packing 64 rows.
-        p = 1
-        while p < max_seqlen_q or group_size * p < 16:
-            p *= 2
-        pack_q_len = min(p, _PACK_ROWS // group_size)
-    # Small fused tiles (<= 32 rows) take the key-major TMA schedule (see
-    # MsaProxyScoreDecodeKeyMajorSm12x); the row-major/key-split schedules
-    # remain only for > 32-row tiles.
-    use_keymajor = False
-    if use_packed:
-        p = 1
-        while p < max_seqlen_q:
-            p *= 2
-        if group_size * p <= 32:
-            use_keymajor = True
-            pack_q_len = p
+    use_keymajor = use_packed and keymajor_ok
+    if use_keymajor:
+        pack_q_len = p
+    else:
+        pack_q_len = _PACK_ROWS // group_size if use_packed else 0
 
     # fp8 q (the vLLM M3 fp8-cache contract) is consumed natively only by the
     # key-major schedule; other shapes upconvert once (e4m3 -> bf16 is
@@ -493,8 +486,9 @@ def msa_proxy_score(
             q_offset, cu_q_dev, k_len_or_cu, dev, k_is_lengths=paged
         )
 
-    # group_size keys the packed/stream schedules: it is constexpr-baked into
-    # the gather/epilogue, so each factorization is its own kernel.
+    # group_size and pack_q_len are constexpr-baked into the decode schedules'
+    # gather/epilogue, so each factorization is its own kernel; both must key
+    # the cache (key-major's pack_q_len does not determine group_size).
     key = (
         "proxy",
         str(q.dtype),
@@ -504,7 +498,8 @@ def msa_proxy_score(
         use_stream,
         use_packed,
         use_keymajor,
-        group_size if use_stream else pack_q_len,
+        group_size,
+        pack_q_len,
         qoff_default if (use_stream or use_keymajor) else None,
     )
     # The packed fp8 schedules take e4m3 operands as 16-bit torch views (half

--- a/flashinfer/msa_ops/proxy_score.py
+++ b/flashinfer/msa_ops/proxy_score.py
@@ -300,8 +300,8 @@ def msa_proxy_score(
     ----------
     q : torch.Tensor
         ``(total_q, num_qo_heads, 128)``, bf16 or fp16 (the cheap proxy Q).
-        May be fp8 E4M3 when ``k`` is fp8: decode shapes consume it natively
-        (the fastest path); other shapes upconvert it once internally.
+        May be fp8 E4M3 when ``k`` is fp8: decode shapes consume it natively,
+        other shapes upconvert it once internally.
     k : torch.Tensor
         Flat ``(total_k, num_kv_heads, 128)`` with ``cu_seqlens_k``, or
         paged ``(num_pages, num_kv_heads, 128, 128)`` with ``page_table`` +
@@ -437,8 +437,7 @@ def msa_proxy_score(
     # one q token per request, which its token == batch indexing relies on.
     # fp8 K skips it when the key-major schedule can take the shape instead:
     # the stream schedule pays a CUDA-core convert per K element, while
-    # key-major converts in-register nearly for free (measured ~10-18% faster
-    # at batch 1 on SM120).
+    # key-major converts in-register nearly for free.
     keymajor_fp8_sq1 = (
         kv_fp8 and 2 <= group_size <= 32 and _PACK_ROWS % group_size == 0
     )
@@ -462,17 +461,14 @@ def msa_proxy_score(
     pack_q_len = _PACK_ROWS // group_size if use_packed else 0
     if use_packed and kv_fp8:
         # The key-split fp8 kernel takes any 16-multiple row tile, so size it
-        # to the spec-decode length instead of always packing 64 rows: at the
-        # common 4-head sq<=4 shapes this quarters the mma work per CTA.
+        # to the spec-decode length instead of always packing 64 rows.
         p = 1
         while p < max_seqlen_q or group_size * p < 16:
             p *= 2
         pack_q_len = min(p, _PACK_ROWS // group_size)
-    # Small fused tiles (<= 32 rows) take the key-major TMA schedule at every
-    # grid size (see MsaProxyScoreDecodeKeyMajorSm12x): its per-CTA fixed cost
-    # matches the one-block-per-CTA grids split-K produces at small batch, and
-    # measured on SM120 it also beats the row-major/key-split schedules on
-    # machine-filling grids. Those remain only for > 32-row tiles.
+    # Small fused tiles (<= 32 rows) take the key-major TMA schedule (see
+    # MsaProxyScoreDecodeKeyMajorSm12x); the row-major/key-split schedules
+    # remain only for > 32-row tiles.
     use_keymajor = False
     if use_packed:
         p = 1
@@ -517,7 +513,7 @@ def msa_proxy_score(
     # the last dim): the kernel moves raw bytes and upconverts in registers,
     # and a typed view keeps the TMA/cp.async source alignment provable where
     # an in-kernel recast of a symbolic layout does not. fp8 q rides an f16
-    # carrier so both register converts hit the native e4m3 -> f16 path.
+    # carrier so its register convert hits the native e4m3 -> f16 path.
     kv16 = kv_fp8 and use_packed
     carrier = torch.float16 if q_fp8 else q.dtype
     q_call = q.contiguous().view(carrier) if q_fp8 else q

--- a/tests/msa_ops/test_msa_ops.py
+++ b/tests/msa_ops/test_msa_ops.py
@@ -1437,17 +1437,15 @@ def test_msa_proxy_score_paged_fp8():
     )
     torch.cuda.synchronize()
     assert torch.equal(out_paged, out_flat)
-    # Decode shapes dispatch fp8 K to the stream (q_len 1) and packed (q_len 4)
-    # schedules; both upconvert e4m3 exactly, so results stay bit-identical to
-    # the same call on dequantized K. Flat and paged (production shape) layouts;
-    # one fp16-q case covers the f16 convert target in the packed schedule.
+    # Decode shapes route fp8 K to the decode schedules; the e4m3 upconvert is
+    # exact, so results must stay bit-identical to the same call on
+    # dequantized K. The fp16-q case covers the f16 convert target.
     k8_pg = k_pg.to(torch.float8_e4m3fn).contiguous()
     for sq, qdt in ((1, torch.bfloat16), (4, torch.bfloat16), (4, torch.float16)):
         cu_qd = torch.arange(0, (B + 1) * sq, sq, dtype=torch.int32, device=dev)
-        # e4m3-representable q, as deployment provides (M3 quantizes q
-        # upstream): the fp8 key-major schedule groups products into mma
-        # instructions differently from the bf16 path, and exactness under
-        # regrouping needs every dot term exact in f32.
+        # e4m3-representable q, as deployment provides: the fp8 key-major
+        # schedule regroups products across mma instructions, and exactness
+        # under regrouping needs every dot term exact in f32.
         qd = (
             (torch.randn(B * sq, Hq, 128, device=dev) / 3)
             .to(torch.float8_e4m3fn)
@@ -1465,8 +1463,8 @@ def test_msa_proxy_score_paged_fp8():
         assert torch.equal(out8, out_deq8)
         assert torch.equal(pg8, pg_deq8)
         if qdt is torch.bfloat16:
-            # Native fp8 q (the vLLM M3 fp8-cache contract): same exact math,
-            # so bit-identical to the bf16-q call on the same values.
+            # Native fp8 q: same exact math, so bit-identical to the bf16-q
+            # call on the same values.
             qd8 = qd.to(torch.float8_e4m3fn)
             out_q8 = msa_proxy_score(qd8, k8, cu_qd, cu_k, causal=True)
             pg_q8 = msa_proxy_score(

--- a/tests/msa_ops/test_msa_ops.py
+++ b/tests/msa_ops/test_msa_ops.py
@@ -1464,6 +1464,26 @@ def test_msa_proxy_score_paged_fp8():
         torch.cuda.synchronize()
         assert torch.equal(out8, out_deq8)
         assert torch.equal(pg8, pg_deq8)
+        if qdt is torch.bfloat16:
+            # Native fp8 q (the vLLM M3 fp8-cache contract): same exact math,
+            # so bit-identical to the bf16-q call on the same values.
+            qd8 = qd.to(torch.float8_e4m3fn)
+            out_q8 = msa_proxy_score(qd8, k8, cu_qd, cu_k, causal=True)
+            pg_q8 = msa_proxy_score(
+                qd8, k8_pg, cu_qd, page_table=ptab, seqused_k=seqused, causal=True
+            )
+            torch.cuda.synchronize()
+            assert torch.equal(out_q8, out8)
+            assert torch.equal(pg_q8, pg8)
+    # Prefill-shape fp8 q takes the internal upconvert fallback; identical to
+    # upconverting at the call site.
+    q8_pre = q.to(torch.float8_e4m3fn)
+    out_pre8 = msa_proxy_score(q8_pre, k8, cu_q, cu_k, causal=True)
+    out_pre_ref = msa_proxy_score(
+        q8_pre.to(torch.bfloat16), k8, cu_q, cu_k, causal=True
+    )
+    torch.cuda.synchronize()
+    assert torch.equal(out_pre8, out_pre_ref)
 
 
 def test_e2e_full_pipeline_from_raw_tensors():

--- a/tests/msa_ops/test_msa_ops.py
+++ b/tests/msa_ops/test_msa_ops.py
@@ -1437,6 +1437,25 @@ def test_msa_proxy_score_paged_fp8():
     )
     torch.cuda.synchronize()
     assert torch.equal(out_paged, out_flat)
+    # Decode shapes dispatch fp8 K to the stream (q_len 1) and packed (q_len 4)
+    # schedules; both upconvert e4m3 exactly, so results stay bit-identical to
+    # the same call on dequantized K. Flat and paged (production shape) layouts;
+    # one fp16-q case covers the f16 convert target in the packed schedule.
+    k8_pg = k_pg.to(torch.float8_e4m3fn).contiguous()
+    for sq, qdt in ((1, torch.bfloat16), (4, torch.bfloat16), (4, torch.float16)):
+        cu_qd = torch.arange(0, (B + 1) * sq, sq, dtype=torch.int32, device=dev)
+        qd = torch.randn(B * sq, Hq, 128, dtype=qdt, device=dev) / 3
+        out8 = msa_proxy_score(qd, k8, cu_qd, cu_k, causal=True)
+        out_deq8 = msa_proxy_score(qd, k8.to(qdt), cu_qd, cu_k, causal=True)
+        pg8 = msa_proxy_score(
+            qd, k8_pg, cu_qd, page_table=ptab, seqused_k=seqused, causal=True
+        )
+        pg_deq8 = msa_proxy_score(
+            qd, k8_pg.to(qdt), cu_qd, page_table=ptab, seqused_k=seqused, causal=True
+        )
+        torch.cuda.synchronize()
+        assert torch.equal(out8, out_deq8)
+        assert torch.equal(pg8, pg_deq8)
 
 
 def test_e2e_full_pipeline_from_raw_tensors():

--- a/tests/msa_ops/test_msa_ops.py
+++ b/tests/msa_ops/test_msa_ops.py
@@ -1183,7 +1183,7 @@ def test_msa_proxy_score(B, Hq, Hkv, seqs_q, seqs_k, causal):
 @pytest.mark.parametrize(
     "B,Hq,Hkv,seqlen_q,seqlen_k,causal",
     [
-        (4, 4, 1, 1, 8192, True),  # group 4, q_len 1 -> key-major
+        (4, 4, 1, 1, 8192, True),  # group 4, q_len 1 -> stream (bf16 single-token)
         (2, 4, 1, 16, 4096, True),  # group 4, q_len at the gate edge (16) -> packed
         (3, 8, 2, 8, 2048, True),  # group 4 (Hq/Hkv), q_len 8 -> key-major
         (2, 4, 1, 16, 4096, False),  # non-causal packed
@@ -1191,8 +1191,8 @@ def test_msa_proxy_score(B, Hq, Hkv, seqs_q, seqs_k, causal):
 )
 def test_msa_proxy_score_decode_packed(B, Hq, Hkv, seqlen_q, seqlen_k, causal):
     """Short-q decode dispatches the head-fused kernels: key-major for fused
-    tiles of at most 32 rows, packed row-major above. Group 4 with q_len <= 16
-    is the MiniMax-M3 indexer shape."""
+    multi-token tiles of at most 32 rows, packed row-major above. Group 4 with
+    q_len <= 16 is the MiniMax-M3 indexer shape."""
     _skip_if_unsupported()
     from flashinfer.msa_ops import msa_proxy_score
 
@@ -1281,23 +1281,23 @@ def test_msa_proxy_score_decode_packed_paged(Hq, Hkv, seqs_q, seqs_k):
 @pytest.mark.parametrize(
     "Hq,Hkv,paged,explicit_qoff",
     [
-        (4, 1, False, False),  # M3 shape, ragged flat -> key-major
-        (8, 2, False, False),  # multi kv-head -> key-major
-        (1, 1, False, False),  # group 1 -> stream
-        (8, 1, True, False),  # group 8, paged -> key-major
+        (4, 1, False, False),  # M3 shape, ragged flat
+        (8, 2, False, False),  # multi kv-head
+        (1, 1, False, False),  # group 1 (below the packed gate)
+        (8, 1, True, False),  # group 8 (stream upper gate), paged
         (4, 1, False, True),  # explicit q_offset masks mid-sequence
         (4, 1, True, True),
-        (3, 1, False, False),  # group 3 (does not divide 64) -> stream
-        (3, 1, True, False),  # stream, paged
-        (3, 1, False, True),  # stream, explicit q_offset
-        (1, 1, True, True),  # stream group 1, paged + explicit q_offset
+        (3, 1, False, False),  # group 3 (does not divide 64)
+        (3, 1, True, False),  # group 3, paged
+        (3, 1, False, True),  # group 3, explicit q_offset
+        (1, 1, True, True),  # group 1, paged + explicit q_offset
     ],
 )
 def test_msa_proxy_score_decode_stream(Hq, Hkv, paged, explicit_qoff):
-    """Single-token decode dispatches the key-major kernel for the group sizes
-    it takes and the stream kernel otherwise (group 1, or not dividing 64);
-    cover ragged varlen with non-128 tails, an empty sequence, multi kv-head,
-    paged KV, and an explicit causal q_offset on both kernels."""
+    """Single-token bf16 decode dispatches the stream kernel; cover ragged
+    varlen with non-128 tails, an empty sequence, multi kv-head, group sizes
+    1-8 including ones not dividing 64, paged KV, and an explicit causal
+    q_offset."""
     _skip_if_unsupported()
     from flashinfer.msa_ops import msa_proxy_score
 

--- a/tests/msa_ops/test_msa_ops.py
+++ b/tests/msa_ops/test_msa_ops.py
@@ -1183,15 +1183,16 @@ def test_msa_proxy_score(B, Hq, Hkv, seqs_q, seqs_k, causal):
 @pytest.mark.parametrize(
     "B,Hq,Hkv,seqlen_q,seqlen_k,causal",
     [
-        (4, 4, 1, 1, 8192, True),  # group 4, q_len 1 -> packed (4 x 16 tile)
-        (2, 4, 1, 16, 4096, True),  # group 4, q_len at the gate edge (16)
-        (3, 8, 2, 8, 2048, True),  # group 4 (Hq/Hkv), q_len 8
+        (4, 4, 1, 1, 8192, True),  # group 4, q_len 1 -> key-major
+        (2, 4, 1, 16, 4096, True),  # group 4, q_len at the gate edge (16) -> packed
+        (3, 8, 2, 8, 2048, True),  # group 4 (Hq/Hkv), q_len 8 -> key-major
         (2, 4, 1, 16, 4096, False),  # non-causal packed
     ],
 )
 def test_msa_proxy_score_decode_packed(B, Hq, Hkv, seqlen_q, seqlen_k, causal):
-    """Short-q decode dispatches the head-fused packed bf16 kernel; group 4 with
-    q_len <= 16 is the MiniMax-M3 indexer shape."""
+    """Short-q decode dispatches the head-fused kernels: key-major for fused
+    tiles of at most 32 rows, packed row-major above. Group 4 with q_len <= 16
+    is the MiniMax-M3 indexer shape."""
     _skip_if_unsupported()
     from flashinfer.msa_ops import msa_proxy_score
 
@@ -1280,18 +1281,23 @@ def test_msa_proxy_score_decode_packed_paged(Hq, Hkv, seqs_q, seqs_k):
 @pytest.mark.parametrize(
     "Hq,Hkv,paged,explicit_qoff",
     [
-        (4, 1, False, False),  # M3 shape, ragged flat
-        (8, 2, False, False),  # multi kv-head
-        (1, 1, False, False),  # group 1 (below the packed gate)
-        (8, 1, True, False),  # group 8 (stream upper gate), paged
+        (4, 1, False, False),  # M3 shape, ragged flat -> key-major
+        (8, 2, False, False),  # multi kv-head -> key-major
+        (1, 1, False, False),  # group 1 -> stream
+        (8, 1, True, False),  # group 8, paged -> key-major
         (4, 1, False, True),  # explicit q_offset masks mid-sequence
         (4, 1, True, True),
+        (3, 1, False, False),  # group 3 (does not divide 64) -> stream
+        (3, 1, True, False),  # stream, paged
+        (3, 1, False, True),  # stream, explicit q_offset
+        (1, 1, True, True),  # stream group 1, paged + explicit q_offset
     ],
 )
 def test_msa_proxy_score_decode_stream(Hq, Hkv, paged, explicit_qoff):
-    """Single-token decode dispatches the stream kernel; cover ragged varlen
-    with non-128 tails, an empty sequence, multi kv-head, group sizes 1-8,
-    paged KV, and an explicit causal q_offset."""
+    """Single-token decode dispatches the key-major kernel for the group sizes
+    it takes and the stream kernel otherwise (group 1, or not dividing 64);
+    cover ragged varlen with non-128 tails, an empty sequence, multi kv-head,
+    paged KV, and an explicit causal q_offset on both kernels."""
     _skip_if_unsupported()
     from flashinfer.msa_ops import msa_proxy_score
 
@@ -1482,6 +1488,54 @@ def test_msa_proxy_score_paged_fp8():
     )
     torch.cuda.synchronize()
     assert torch.equal(out_pre8, out_pre_ref)
+    # The fp8 key-split schedule (fused tile > 32 rows: group 4, q_len 12) and
+    # the fp8 stream schedule (group 3, not dividing 64), flat and paged,
+    # under the same exactness contract.
+    for Hq2, Hkv2, sq2 in ((4, 1, 12), (3, 1, 1)):
+        seqs2 = [700, 260]
+        B2 = len(seqs2)
+        cu_k2 = torch.tensor(
+            [0] + list(torch.tensor(seqs2).cumsum(0)), dtype=torch.int32, device=dev
+        )
+        cu_q2 = torch.arange(0, (B2 + 1) * sq2, sq2, dtype=torch.int32, device=dev)
+        q2 = (
+            (torch.randn(B2 * sq2, Hq2, 128, device=dev) / 3)
+            .to(torch.float8_e4m3fn)
+            .to(torch.bfloat16)
+        )
+        k2 = (torch.randn(int(cu_k2[-1]), Hkv2, 128, device=dev) / 3).to(
+            torch.float8_e4m3fn
+        )
+        npg2 = [-(-s // BLK_KV) for s in seqs2]
+        k_pg2 = torch.zeros(
+            sum(npg2), Hkv2, BLK_KV, 128, dtype=torch.float8_e4m3fn, device=dev
+        )
+        ptab2 = torch.full((B2, max(npg2)), -1, dtype=torch.int32, device=dev)
+        pi2 = 0
+        for b in range(B2):
+            for blk in range(npg2[b]):
+                ptab2[b, blk] = pi2
+                lo = int(cu_k2[b]) + blk * BLK_KV
+                hi = min(lo + BLK_KV, int(cu_k2[b + 1]))
+                k_pg2[pi2, :, : hi - lo] = k2[lo:hi].transpose(0, 1)
+                pi2 += 1
+        sk2 = torch.tensor(seqs2, dtype=torch.int32, device=dev)
+        o8 = msa_proxy_score(q2, k2, cu_q2, cu_k2, causal=True)
+        odq = msa_proxy_score(q2, k2.to(torch.bfloat16), cu_q2, cu_k2, causal=True)
+        p8 = msa_proxy_score(
+            q2, k_pg2, cu_q2, page_table=ptab2, seqused_k=sk2, causal=True
+        )
+        pdq = msa_proxy_score(
+            q2,
+            k_pg2.to(torch.bfloat16),
+            cu_q2,
+            page_table=ptab2,
+            seqused_k=sk2,
+            causal=True,
+        )
+        torch.cuda.synchronize()
+        assert torch.equal(o8, odq)
+        assert torch.equal(p8, pdq)
 
 
 def test_e2e_full_pipeline_from_raw_tensors():

--- a/tests/msa_ops/test_msa_ops.py
+++ b/tests/msa_ops/test_msa_ops.py
@@ -1479,6 +1479,9 @@ def test_msa_proxy_score_paged_fp8():
             torch.cuda.synchronize()
             assert torch.equal(out_q8, out8)
             assert torch.equal(pg_q8, pg8)
+            # fp8 q without fp8 k has no kernel; the dispatch must reject it.
+            with pytest.raises(ValueError, match="fp8 q requires fp8 k"):
+                msa_proxy_score(qd8, k8.to(qdt), cu_qd, cu_k, causal=True)
     # Prefill-shape fp8 q takes the internal upconvert fallback; identical to
     # upconverting at the call site.
     q8_pre = q.to(torch.float8_e4m3fn)

--- a/tests/msa_ops/test_msa_ops.py
+++ b/tests/msa_ops/test_msa_ops.py
@@ -1444,7 +1444,15 @@ def test_msa_proxy_score_paged_fp8():
     k8_pg = k_pg.to(torch.float8_e4m3fn).contiguous()
     for sq, qdt in ((1, torch.bfloat16), (4, torch.bfloat16), (4, torch.float16)):
         cu_qd = torch.arange(0, (B + 1) * sq, sq, dtype=torch.int32, device=dev)
-        qd = torch.randn(B * sq, Hq, 128, dtype=qdt, device=dev) / 3
+        # e4m3-representable q, as deployment provides (M3 quantizes q
+        # upstream): the fp8 key-major schedule groups products into mma
+        # instructions differently from the bf16 path, and exactness under
+        # regrouping needs every dot term exact in f32.
+        qd = (
+            (torch.randn(B * sq, Hq, 128, device=dev) / 3)
+            .to(torch.float8_e4m3fn)
+            .to(qdt)
+        )
         out8 = msa_proxy_score(qd, k8, cu_qd, cu_k, causal=True)
         out_deq8 = msa_proxy_score(qd, k8.to(qdt), cu_qd, cu_k, causal=True)
         pg8 = msa_proxy_score(


### PR DESCRIPTION
## 📌 Description

This PR lets the MiniMax-M3 MSA proxy-score op on SM120/SM121 (`msa_proxy_score`) consume the fp8 (e4m3) index cache directly at every shape, flat or paged, matching the vLLM MiniMax-M3 fp8 path where both index-q and index-k are stored in fp8, so callers no longer dequantize either operand.

Why fp8 proxy scoring at decode shapes was slow:

- fp8 index-k went to the general prefill schedule: every query head re-read the shared index-k, and the schedule's per-KV-block barriers dominate the one-block-per-CTA grids that split-K produces at decode batch sizes.
- The e4m3 upconvert ran element by element on the CUDA cores, so the convert rather than the K read became the bottleneck.
- fp8 index-q had to be dequantized by the caller on every call.

Fixes:

- Decode shapes with fp8 K route to two new head-fused schedules that read the shared index-k once per kv head:
  - Key-major (`MsaProxyScoreDecodeKeyMajorSm12x`, derived from vllm#48582 by @gau-nernst) for fused tiles of at most 32 head x token rows: keys become the MMA M dimension, Q stays in registers across KV blocks, and a TMA producer warp feeds a two-stage pipeline, cutting per-CTA fixed cost.
  - Key-split (`MsaProxyScoreDecodePackedFp8Sm12x`) for larger fused tiles: warps split over keys instead of query rows, and K stays raw e4m3 through cp.async and shared memory.
- The upconvert runs once per K element with packed cvt instructions, in registers between the shared-memory loads and the mma.
- fp8 index-q is consumed natively on the decode paths and upconverted once internally elsewhere.

Public API and behavior changes:

- `msa_proxy_score` additionally accepts fp8 `q` when `k` is fp8, and raises `ValueError` for fp8 `q` with non-fp8 `k`.
- Kernel routing changes for decode shapes with fp8 K and for bf16 multi-token fused tiles of at most 32 rows (now key-major).

### Performance

The MiniMax-M3 indexer shape (4 query heads, one index-k head, head dim 128), swept over context length S and decode batch B on RTX PRO 6000 Blackwell (Server Edition), RTX 5080, and GB10 (SM121). Timing is CUPTI kernel time with L2 flushed between iterations, and only the score stage is timed (top-k excluded). The baseline is vLLM's Triton MSA scoring kernels (the SM12x path), at vLLM main `76d995df2c80`.

Each cell is a PRO 6000 / RTX 5080 / GB10 speedup triple (baseline time / FlashInfer time, so >1 means FlashInfer is faster). MTP = multi-token prediction: MTP=N is the verify step for N draft tokens, i.e. m = N+1 query tokens per request.

#### fp8 decode vs FlashInfer w/o PR, MTP=0 (m=1)

| S | B=1 | B=8 | B=32 | B=128 |
|--:|:--:|:--:|:--:|:--:|
| 2k | 2.77 / 2.71 / 2.50 | 3.35 / 5.46 / 2.16 | 3.92 / 7.55 / 2.15 | 3.38 / 6.76 / 3.50 |
| 8k | 2.86 / 4.21 / 2.04 | 3.79 / 7.72 / 2.56 | 4.09 / 8.21 / 3.39 | 4.29 / 8.64 / 4.08 |
| 32k | 3.27 / 6.95 / 2.15 | 4.17 / 8.08 / 4.00 | 5.67 / 9.62 / 3.81 | 5.71 / 8.68 / 4.24 |

MTP=3 speedups are within about 10% of these.

#### fp8 decode vs vLLM Triton, MTP=0 (m=1)

| S | B=1 | B=8 | B=32 | B=128 |
|--:|:--:|:--:|:--:|:--:|
| 2k | 1.08 / 1.06 / 1.11 | 1.04 / 1.05 / 1.05 | 1.03 / 1.04 / 1.17 | 0.97 / 1.05 / 1.16 |
| 8k | 1.06 / 1.10 / 1.02 | 1.02 / 1.05 / 1.21 | 0.91 / 1.06 / 1.18 | 1.11 / 1.09 / 1.04 |
| 32k | 1.03 / 1.02 / 1.05 | 0.99 / 1.01 / 1.20 | 1.12 / 1.08 / 1.06 | 1.10 / 1.03 / 1.01 |

#### fp8 decode vs vLLM Triton, MTP=3 (m=4)

| S | B=1 | B=8 | B=32 | B=128 |
|--:|:--:|:--:|:--:|:--:|
| 2k | 0.95 / 0.98 / 1.02 | 0.93 / 0.97 / 1.02 | 0.98 / 1.01 / 1.18 | 0.98 / 1.01 / 1.18 |
| 8k | 0.96 / 1.00 / 0.98 | 1.00 / 1.02 / 1.19 | 0.89 / 1.06 / 1.17 | 1.11 / 1.10 / 1.04 |
| 32k | 1.00 / 0.99 / 1.04 | 0.88 / 0.99 / 1.19 | 1.11 / 1.08 / 1.05 | 1.09 / 1.03 / 1.01 |

<details>
<summary>bf16 decode, MTP=3 (m=4)</summary>

Listed because this PR also reroutes bf16 multi-token fused tiles of at most 32 rows to the key-major schedule; bf16 single-token decode is unchanged. Same cell format.

vs FlashInfer w/o PR:

| S | B=1 | B=8 | B=32 | B=128 |
|--:|:--:|:--:|:--:|:--:|
| 2k | 2.16 / 2.16 / 1.52 | 1.45 / 1.28 / 1.18 | 1.10 / 1.17 / 1.27 | 1.05 / 1.09 / 1.11 |
| 8k | 1.78 / 1.72 / 1.17 | 1.16 / 1.12 / 1.32 | 1.06 / 1.12 / 1.13 | 1.21 / 1.06 / 1.00 |
| 32k | 1.19 / 1.47 / 1.25 | 1.07 / 1.11 / 1.12 | 1.20 / 1.07 / 1.01 | 1.07 / 1.04 / 0.99 |

vs vLLM Triton:

| S | B=1 | B=8 | B=32 | B=128 |
|--:|:--:|:--:|:--:|:--:|
| 2k | 1.03 / 1.06 / 0.99 | 1.02 / 0.81 / 1.07 | 0.94 / 0.97 / 1.28 | 0.97 / 1.08 / 1.08 |
| 8k | 1.04 / 0.99 / 1.01 | 1.00 / 0.93 / 1.28 | 0.98 / 1.10 / 1.11 | 1.18 / 1.08 / 1.01 |
| 32k | 0.96 / 0.98 / 1.18 | 0.96 / 1.10 / 1.08 | 1.17 / 1.09 / 1.02 | 1.05 / 1.07 / 0.99 |

</details>

<details>
<summary>fp8 decode vs vLLM CuTe DSL (PR #48582)</summary>

This is the kernel vLLM's SM100 MSA path uses for small decode tiles, and the one this PR's key-major schedule derives from.

MTP=0 (m=1):

| S | B=1 | B=8 | B=32 | B=128 |
|--:|:--:|:--:|:--:|:--:|
| 2k | 0.98 / 0.97 / 1.00 | 1.00 / 0.98 / 1.01 | 1.01 / 1.45 / 1.14 | 1.28 / 1.68 / 1.26 |
| 8k | 1.00 / 1.04 / 1.00 | 1.01 / 1.04 / 0.99 | 0.99 / 1.09 / 1.03 | 1.09 / 1.13 / 1.05 |
| 32k | 1.00 / 1.00 / 0.99 | 1.01 / 0.98 / 0.99 | 0.99 / 0.99 / 0.99 | 0.99 / 0.99 / 0.98 |

MTP=3 (m=4):

| S | B=1 | B=8 | B=32 | B=128 |
|--:|:--:|:--:|:--:|:--:|
| 2k | 0.94 / 0.99 / 0.97 | 0.95 / 1.16 / 1.04 | 1.12 / 1.71 / 1.25 | 1.52 / 1.96 / 1.43 |
| 8k | 0.97 / 1.02 / 0.99 | 1.02 / 1.07 / 0.99 | 1.00 / 1.18 / 1.05 | 1.15 / 1.20 / 1.09 |
| 32k | 0.98 / 1.01 / 0.97 | 0.99 / 0.97 / 0.96 | 0.99 / 1.00 / 0.99 | 0.99 / 0.98 / 1.00 |

</details>

fp8 proxy scoring at prefill shapes runs on the general schedule and is compute-bound: fp8-K measured up to ~5% slower than bf16-K across S 512-8k (the in-register convert cost). fp8 support there exists so callers can pass the fp8 index cache at every shape without dequantizing, not for speed.

## 🔍 Related Issues

Stacked on #4324; the first commits here are that PR and drop out of the diff once it merges.

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

## 🧪 Tests

- Extended `tests/msa_ops/test_msa_ops.py::test_msa_proxy_score_paged_fp8` with decode-shape fp8 coverage: flat and paged K, bf16/fp16/fp8 q, single-token and multi-token (spec-decode) query lengths, plus the prefill-shape fp8-q fallback. All fp8 results assert bit-exact equality against the dequantized-K reference.
- Full `tests/msa_ops/` suite passing on RTX 5080 (SM120), DGX Spark GB10 (SM121), and RTX PRO 6000 Blackwell Server Edition (SM120).

## Reviewer Notes

- The fp8 tests assert bit-exact equality (`torch.equal`) against dequantized-K runs, which is sound because the e4m3 -> f16/bf16 upconvert is exact. The key-major schedule regroups mma products, so its test feeds e4m3-representable q (what deployment provides) to keep every f32 dot term exact.

AI-assisted (Claude Code).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added FP8 E4M3 support for query and key inputs during proxy-score decoding.
  * Added optimized packed and key-major decoding paths.
  * Expanded support for paged key-value data, varied group sizes, and non-divisible groups.
  * Added handling for causal offsets, padding masks, empty sequences, and multiple decode modes.

* **Bug Fixes**
  * Improved dispatch and data conversion for consistent results across supported input formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->