### PR TITLE
fix: optimize and correct SM120 NVFP4 paged prefill

### DIFF
--- a/include/flashinfer/attention/prefill.cuh
+++ b/include/flashinfer/attention/prefill.cuh
@@ -2626,7 +2626,7 @@ cudaError_t SinglePrefillWithKVCacheDispatched(Params params, typename Params::D
     // path is active, so NUM_MMA_KV is chosen to keep base+staging within the
     // occupancy budget. NOTE: single-prefill doesn't use the repack, but the
     // staging buffer still lives in SharedStorageQKVO, so it must be accounted.
-    constexpr bool kUseRepack = (sizeof(DTypeKV) == 1) && !is_fp4_type_v<DTypeKV> &&
+    constexpr bool kUseRepack = ((sizeof(DTypeKV) == 1) || is_fp4_type_v<DTypeKV>) &&
                                 (HEAD_DIM_VO != 64) && (HEAD_DIM_VO <= 256) && (CTA_TILE_Q > 16);
     constexpr bool kKVShared = !is_fp4_type_v<DTypeKV> && (HEAD_DIM_VO / 16 > 16) &&
                                ((HEAD_DIM_VO / 16) % NUM_WARPS_KV == 0) &&
@@ -4258,7 +4258,7 @@ cudaError_t BatchPrefillWithRaggedKVCacheDispatched(Params params, typename Para
   // staging buffer (sized max(HEAD_DIM_QK, HEAD_DIM_VO)) when the FP8 repack path
   // is active, so NUM_MMA_KV is chosen to keep base+staging within the occupancy
   // budget (otherwise the staging silently drops blocks/SM at large head dims).
-  constexpr bool kUseRepack = (sizeof(DTypeKV) == 1) && !is_fp4_type_v<DTypeKV> &&
+  constexpr bool kUseRepack = ((sizeof(DTypeKV) == 1) || is_fp4_type_v<DTypeKV>) &&
                               (HEAD_DIM_VO != 64) && (HEAD_DIM_VO <= 256) && (CTA_TILE_Q > 16);
   // Matches KernelTraits::USE_KV_SHARED_SMEM: at large head dims K and V
   // time-share one smem buffer, so the occupancy budget counts the K/V
@@ -4276,6 +4276,9 @@ cudaError_t BatchPrefillWithRaggedKVCacheDispatched(Params params, typename Para
       (kUseRepack ? ((HEAD_DIM_QK > HEAD_DIM_VO ? HEAD_DIM_QK : HEAD_DIM_VO) * 16 * NUM_WARPS_KV *
                      sizeof(DTypeQ))
                   : 0u) +
+      (is_fp4_type_v<DTypeKV>
+           ? ((HEAD_DIM_QK + HEAD_DIM_VO) * 16 * NUM_WARPS_KV / NVFP4_SF_VEC_SIZE)
+           : 0u) +
       (kVOSplitDispatch ? (CTA_TILE_Q * NUM_WARPS_KV * 16 * sizeof(DTypeQ)) : 0u);
   constexpr uint32_t kVOSplitFixedSmem =
       kVOSplitDispatch ? (NUM_WARPS_KV * CTA_TILE_Q * 8u + 2048u) : 0u;
@@ -4458,7 +4461,7 @@ cudaError_t BatchPrefillWithPagedKVCacheDispatched(Params params, typename Param
   // staging buffer (sized max(HEAD_DIM_QK, HEAD_DIM_VO)) when the FP8 repack path
   // is active, so NUM_MMA_KV is chosen to keep base+staging within the occupancy
   // budget (otherwise the staging silently drops blocks/SM at large head dims).
-  constexpr bool kUseRepack = (sizeof(DTypeKV) == 1) && !is_fp4_type_v<DTypeKV> &&
+  constexpr bool kUseRepack = ((sizeof(DTypeKV) == 1) || is_fp4_type_v<DTypeKV>) &&
                               (HEAD_DIM_VO != 64) && (HEAD_DIM_VO <= 256) && (CTA_TILE_Q > 16);
   // Matches KernelTraits::USE_KV_SHARED_SMEM: K/V share one smem buffer for bf16/fp16 at every
   // tile and for FP8 only at CTA_TILE_Q=32 (not NVFP4), so the occupancy budget counts the K/V
@@ -4475,6 +4478,9 @@ cudaError_t BatchPrefillWithPagedKVCacheDispatched(Params params, typename Param
       (kUseRepack ? ((HEAD_DIM_QK > HEAD_DIM_VO ? HEAD_DIM_QK : HEAD_DIM_VO) * 16 * NUM_WARPS_KV *
                      sizeof(DTypeQ))
                   : 0u) +
+      (is_fp4_type_v<DTypeKV>
+           ? ((HEAD_DIM_QK + HEAD_DIM_VO) * 16 * NUM_WARPS_KV / NVFP4_SF_VEC_SIZE)
+           : 0u) +
       (kVOSplitDispatch ? (CTA_TILE_Q * NUM_WARPS_KV * 16 * sizeof(DTypeQ)) : 0u);
   constexpr uint32_t kVOSplitFixedSmem =
       kVOSplitDispatch ? (NUM_WARPS_KV * CTA_TILE_Q * 8u + 2048u) : 0u;

--- a/include/flashinfer/attention/prefill.cuh
+++ b/include/flashinfer/attention/prefill.cuh
@@ -108,11 +108,11 @@ struct KVScaleFactorSmem<DTypeKV, CTA_TILE_KV, HEAD_DIM_QK, HEAD_DIM_VO, true> {
   alignas(16) uint8_t v_sf_smem[CTA_TILE_KV * HEAD_DIM_VO / NVFP4_SF_VEC_SIZE];
 };
 
-// BF16/FP16 staging buffer for the FP8 "repack" path (compute_qk REPACK_BF16). Empty base
+// BF16/FP16 staging buffer for the FP8/NVFP4 "repack" path (compute_qk REPACK_BF16). Empty base
 // (0 bytes via EBO) when unused; same smem rationale as KVScaleFactorSmem above.
 template <typename DTypeQ, typename DTypeKV, uint32_t CTA_TILE_Q, uint32_t CTA_TILE_KV,
           uint32_t HEAD_DIM_QK, uint32_t HEAD_DIM_VO,
-          bool = ((sizeof(DTypeKV) == 1) && !is_fp4_type_v<DTypeKV> && (HEAD_DIM_VO != 64) &&
+          bool = (((sizeof(DTypeKV) == 1) || is_fp4_type_v<DTypeKV>) && (HEAD_DIM_VO != 64) &&
                   (HEAD_DIM_VO <= 256) && (CTA_TILE_Q > 16))>
 struct KVRepackSmem {};
 template <typename DTypeQ, typename DTypeKV, uint32_t CTA_TILE_Q, uint32_t CTA_TILE_KV,
@@ -172,7 +172,7 @@ struct SharedStorageQKVO
     };
     alignas(16) DTypeO smem_o[CTA_TILE_Q * HEAD_DIM_VO];
   };
-  static constexpr bool USE_KV_REPACK = (sizeof(DTypeKV) == 1) && !is_fp4_type_v<DTypeKV> &&
+  static constexpr bool USE_KV_REPACK = ((sizeof(DTypeKV) == 1) || is_fp4_type_v<DTypeKV>) &&
                                         (HEAD_DIM_VO != 64) && (HEAD_DIM_VO <= 256) &&
                                         (CTA_TILE_Q > 16);
   static constexpr bool VO_SPLIT_SMEM = kVOSplit;
@@ -291,7 +291,7 @@ struct KernelTraits {
   using DTypeQKAccum = DTypeQKAccum_;
   using IdType = IdType_;
   using AttentionVariant = AttentionVariant_;
-  static constexpr bool USE_KV_REPACK = (sizeof(DTypeKV_) == 1) && !is_fp4_type_v<DTypeKV_> &&
+  static constexpr bool USE_KV_REPACK = ((sizeof(DTypeKV_) == 1) || is_fp4_type_v<DTypeKV_>) &&
                                         (HEAD_DIM_VO != 64) && (HEAD_DIM_VO <= 256) &&
                                         (CTA_TILE_Q > 16);  // CTA16 = decode/short-q -> in-loop
   // b128 columns per KV row in the FP8 (packed) and BF16 (repacked) layouts.
@@ -1122,6 +1122,112 @@ __device__ __forceinline__ void repack_fp8_tile_to_bf16(typename KTraits::DTypeK
     // so it must be 16-byte aligned (DTypeQ alone only guarantees 2B alignment).
     alignas(16) DTypeQ conv[16];
     vec_cast<DTypeQ, DTypeKV>::template cast<16>(conv, (DTypeKV*)&packed);
+    dst[get_permuted_offset<SWIZZLE, BF16_COLS>(row, 2 * col)] = *(b128_t*)&conv[0];
+    dst[get_permuted_offset<SWIZZLE, BF16_COLS>(row, 2 * col + 1)] = *(b128_t*)&conv[8];
+  }
+}
+
+// Amortized NVFP4 repack: convert packed FP4 + per-block scales in smem to scaled BF16 in the
+// staging buffer.  Each thread reads b128 chunks of packed FP4 and the corresponding
+// per-block UE4M3 scale factors, converts FP4→BF16 using cvt.rn.bf16x2.e2m1x2 (the same
+// intrinsic used by vec_cast in vec_dtypes.cuh), applies scale via __hmul2, and writes
+// native 16-bit BF16.  Afterwards the QK/PV MMAs use the standard 16-bit ldmatrix path
+// (no per-fragment cross-lane swizzle or __hmul2).
+// Numerically identical to the in-loop dequant.
+//
+// Layout (sizeof(__nv_fp4x2_e2m1)==1):
+//   FP4_COLS  = HEAD_DIM / upcast_size<DTypeKV>() = HEAD_DIM / 16  (b128 slots per FP4 row)
+//   BF16_COLS = HEAD_DIM / upcast_size<DTypeQ>()  = HEAD_DIM / 8   (b128 slots per BF16 row)
+//   SF_COLS   = HEAD_DIM / NVFP4_SF_VEC_SIZE      = HEAD_DIM / 16  (SF bytes per row)
+//   FP4_COLS == SF_COLS,  BF16_COLS == 2 * FP4_COLS
+//   Each FP4 b128 holds 16 bytes of __nv_fp4x2_e2m1, but only the lower 8 bytes
+//   (8 fp4x2 = 16 fp4 values = 1 SF group) are valid from load_64b_async.
+//   The upper 8 bytes are zero-padded and must NOT be converted.
+//   One FP4 b128 (8 valid fp4x2) → 2 BF16 b128 (16 bf16 values).
+//   One SF byte per FP4 b128.
+template <typename KTraits, uint32_t HEAD_DIM>
+__device__ __forceinline__ void repack_fp4_tile_to_bf16(typename KTraits::DTypeKV* smem_fp4,
+                                                        uint8_t* sf_smem,
+                                                        typename KTraits::DTypeQ* smem_bf16,
+                                                        uint32_t thread_id) {
+  using DTypeKV = typename KTraits::DTypeKV;
+  using DTypeQ = typename KTraits::DTypeQ;
+  static_assert(is_fp4_type_v<DTypeKV>, "repack_fp4_tile_to_bf16 requires FP4 KV dtype");
+  static_assert(sizeof(DTypeKV) == 1, "__nv_fp4x2_e2m1 must be 1 byte");
+  static_assert(sizeof(b128_t) == 16, "b128_t must be 16 bytes");
+  constexpr SwizzleMode SWIZZLE = KTraits::SWIZZLE_MODE_KV;
+  constexpr uint32_t NUM_THREADS = KTraits::NUM_THREADS;
+  constexpr uint32_t CTA_TILE_KV = KTraits::CTA_TILE_KV;
+  // upcast_size<DTypeKV>() = 16 (16 fp4x2 per b128), upcast_size<DTypeQ>() = 8 (8 bf16 per b128).
+  constexpr uint32_t FP4_COLS = HEAD_DIM / upcast_size<DTypeKV>();
+  constexpr uint32_t BF16_COLS = HEAD_DIM / upcast_size<DTypeQ>();
+  constexpr uint32_t SF_COLS = HEAD_DIM / NVFP4_SF_VEC_SIZE;
+  static_assert(SF_COLS == FP4_COLS, "SF_COLS must equal FP4_COLS for NVFP4");
+  static_assert(BF16_COLS == 2 * FP4_COLS, "BF16_COLS must be 2*FP4_COLS for NVFP4");
+  constexpr uint32_t NUM_B128 = CTA_TILE_KV * FP4_COLS;
+
+  b128_t* src = (b128_t*)smem_fp4;
+  b128_t* dst = (b128_t*)smem_bf16;
+#pragma unroll
+  for (uint32_t idx = thread_id; idx < NUM_B128; idx += NUM_THREADS) {
+    uint32_t row = idx / FP4_COLS, col = idx % FP4_COLS;
+    b128_t packed = src[get_permuted_offset<SWIZZLE, FP4_COLS>(row, col)];
+
+    // 1 SF byte per FP4 b128 (8 valid fp4x2 = 16 fp4 values per SF).
+    __nv_fp8_e4m3 sf;
+    sf.__x = sf_smem[row * SF_COLS + col];
+    DTypeQ bf16_sf = static_cast<DTypeQ>(sf);
+    using packed2_t = std::conditional_t<std::is_same_v<DTypeQ, half>, half2, __nv_bfloat162>;
+    packed2_t scale{bf16_sf, bf16_sf};
+
+    // Only the lower 8 bytes of the FP4 b128 are valid (from load_64b_async).
+    // Convert 8 valid fp4x2 bytes → 16 bf16 values, applying the per-block scale.
+    // We use the same cvt.rn.bf16x2.e2m1x2 intrinsic as vec_cast<DTypeQ, DTypeKV>
+    // in vec_dtypes.cuh, but read contiguous bytes (fp4_bytes[i]) rather than
+    // stride-2 fragment-swizzled layout.
+    uint8_t* fp4_bytes = (uint8_t*)&packed;
+    alignas(16) DTypeQ conv[16];
+
+#pragma unroll
+    for (uint32_t i = 0; i < 8; ++i) {
+      uint32_t y;
+#if (defined __CUDACC_VER_MAJOR__) && (defined __CUDACC_VER_MINOR__) && \
+    ((__CUDACC_VER_MAJOR__ > 13) || ((__CUDACC_VER_MAJOR__ == 13) && (__CUDACC_VER_MINOR__ >= 2)))
+      asm volatile(
+          "{\n"
+          ".reg .b8 fp4_byte;\n"
+          "mov.b32 {fp4_byte, _, _, _}, %1;\n"
+          "cvt.rn.bf16x2.e2m1x2 %0, fp4_byte;\n"
+          "}"
+          : "=r"(y)
+          : "r"(uint32_t(fp4_bytes[i])));
+#else
+      // Fallback: convert e2m1 → fp16 → bf16 when cvt.rn.bf16x2.e2m1x2 is unavailable
+      uint32_t fp16x2;
+      asm volatile(
+          "{\n"
+          ".reg .b8 fp4_byte;\n"
+          "mov.b32 {fp4_byte, _, _, _}, %1;\n"
+          "cvt.rn.f16x2.e2m1x2 %0, fp4_byte;\n"
+          "}"
+          : "=r"(fp16x2)
+          : "r"(uint32_t(fp4_bytes[i])));
+      __half2 h2 = reinterpret_cast<__half2&>(fp16x2);
+      __nv_bfloat162 bf16x2 = __float22bfloat162_rn(__half22float2(h2));
+      y = reinterpret_cast<uint32_t&>(bf16x2);
+#endif
+      // y always contains BF16 bits.  Convert to DTypeQ before multiply.
+      __nv_bfloat162 bf16x2_in = reinterpret_cast<__nv_bfloat162&>(const_cast<uint32_t&>(y));
+      packed2_t vals;
+      if constexpr (std::is_same_v<DTypeQ, half>) {
+        vals = __float22half2_rn(__bfloat1622float2(bf16x2_in));
+      } else {
+        vals = bf16x2_in;
+      }
+      *(packed2_t*)&conv[i * 2] = __hmul2(vals, scale);
+    }
+
+    // Write 2 BF16 b128 slots: first 8 bf16 at col 2*col, next 8 bf16 at col 2*col+1.
     dst[get_permuted_offset<SWIZZLE, BF16_COLS>(row, 2 * col)] = *(b128_t*)&conv[0];
     dst[get_permuted_offset<SWIZZLE, BF16_COLS>(row, 2 * col + 1)] = *(b128_t*)&conv[8];
   }
@@ -3000,10 +3106,18 @@ __global__ __launch_bounds__(KTraits::NUM_THREADS) void BatchPrefillWithRaggedKV
                                          16 * KTraits::NUM_MMA_D_QK),
               lane_idx, kv_rope_base, rope_freq, s_frag);
         } else if constexpr (KTraits::USE_KV_REPACK) {
-          // Dequantize FP8 K -> BF16 staging smem (shuffle-free), then read native 16-bit.
-          repack_fp8_tile_to_bf16<KTraits, KTraits::HEAD_DIM_QK>(smem_storage.k_smem,
-                                                                 smem_storage.kv_smem_repack_ptr(),
-                                                                 warp_idx * WARP_SIZE + lane_idx);
+          if constexpr (is_fp4_type_v<DTypeKV>) {
+            // Dequantize NVFP4 K -> BF16 staging smem with per-block scale (shuffle-free),
+            // then read native 16-bit.
+            repack_fp4_tile_to_bf16<KTraits, KTraits::HEAD_DIM_QK>(
+                smem_storage.k_smem, smem_storage.k_sf_smem_ptr(),
+                smem_storage.kv_smem_repack_ptr(), warp_idx * WARP_SIZE + lane_idx);
+          } else {
+            // Dequantize FP8 K -> BF16 staging smem (shuffle-free), then read native 16-bit.
+            repack_fp8_tile_to_bf16<KTraits, KTraits::HEAD_DIM_QK>(
+                smem_storage.k_smem, smem_storage.kv_smem_repack_ptr(),
+                warp_idx * WARP_SIZE + lane_idx);
+          }
           block.sync();
           compute_qk<KTraits, /*REPACK_BF16=*/true>(
               &qo_smem, &q_smem_offset_r, &k_smem_bf16, &k_smem_offset_r_bf16,
@@ -3063,10 +3177,18 @@ __global__ __launch_bounds__(KTraits::NUM_THREADS) void BatchPrefillWithRaggedKV
           vosplit_compute_pv<KTraits>(&smem_storage, o_frag, o_scale, warp_vo_base,
                                       get_warp_idx_q<KTraits>(tid.y), lane_idx);
         } else if constexpr (KTraits::USE_KV_REPACK) {
-          // Dequantize FP8 V -> BF16 staging smem (shuffle-free), then read native 16-bit.
-          repack_fp8_tile_to_bf16<KTraits, KTraits::HEAD_DIM_VO>(smem_storage.v_smem,
-                                                                 smem_storage.kv_smem_repack_ptr(),
-                                                                 warp_idx * WARP_SIZE + lane_idx);
+          if constexpr (is_fp4_type_v<DTypeKV>) {
+            // Dequantize NVFP4 V -> BF16 staging smem with per-block scale (shuffle-free),
+            // then read native 16-bit.
+            repack_fp4_tile_to_bf16<KTraits, KTraits::HEAD_DIM_VO>(
+                smem_storage.v_smem, smem_storage.v_sf_smem_ptr(),
+                smem_storage.kv_smem_repack_ptr(), warp_idx * WARP_SIZE + lane_idx);
+          } else {
+            // Dequantize FP8 V -> BF16 staging smem (shuffle-free), then read native 16-bit.
+            repack_fp8_tile_to_bf16<KTraits, KTraits::HEAD_DIM_VO>(
+                smem_storage.v_smem, smem_storage.kv_smem_repack_ptr(),
+                warp_idx * WARP_SIZE + lane_idx);
+          }
           block.sync();
           compute_sfm_v<KTraits, /*REPACK_BF16=*/true>(
               &v_smem_bf16, &v_smem_offset_r_bf16,
@@ -3863,10 +3985,18 @@ __device__ __forceinline__ void BatchPrefillWithPagedKVCacheDevice(
                                          16 * KTraits::NUM_MMA_D_QK),
               lane_idx, kv_rope_base, rope_freq, s_frag);
         } else if constexpr (KTraits::USE_KV_REPACK) {
-          // Dequantize FP8 K -> BF16 staging smem (shuffle-free), then read native 16-bit.
-          repack_fp8_tile_to_bf16<KTraits, KTraits::HEAD_DIM_QK>(smem_storage.k_smem,
-                                                                 smem_storage.kv_smem_repack_ptr(),
-                                                                 warp_idx * WARP_SIZE + lane_idx);
+          if constexpr (is_fp4_type_v<DTypeKV>) {
+            // Dequantize NVFP4 K -> BF16 staging smem with per-block scale (shuffle-free),
+            // then read native 16-bit.
+            repack_fp4_tile_to_bf16<KTraits, KTraits::HEAD_DIM_QK>(
+                smem_storage.k_smem, smem_storage.k_sf_smem_ptr(),
+                smem_storage.kv_smem_repack_ptr(), warp_idx * WARP_SIZE + lane_idx);
+          } else {
+            // Dequantize FP8 K -> BF16 staging smem (shuffle-free), then read native 16-bit.
+            repack_fp8_tile_to_bf16<KTraits, KTraits::HEAD_DIM_QK>(
+                smem_storage.k_smem, smem_storage.kv_smem_repack_ptr(),
+                warp_idx * WARP_SIZE + lane_idx);
+          }
           block.sync();
           compute_qk<KTraits, /*REPACK_BF16=*/true>(
               &qo_smem, &q_smem_offset_r, &k_smem_bf16, &k_smem_offset_r_bf16,
@@ -3953,10 +4083,18 @@ __device__ __forceinline__ void BatchPrefillWithPagedKVCacheDevice(
           vosplit_compute_pv<KTraits>(&smem_storage, o_frag, o_scale, warp_vo_base,
                                       get_warp_idx_q<KTraits>(tid.y), lane_idx);
         } else if constexpr (KTraits::USE_KV_REPACK) {
-          // Dequantize FP8 V -> BF16 staging smem (shuffle-free), then read native 16-bit.
-          repack_fp8_tile_to_bf16<KTraits, KTraits::HEAD_DIM_VO>(smem_storage.v_smem,
-                                                                 smem_storage.kv_smem_repack_ptr(),
-                                                                 warp_idx * WARP_SIZE + lane_idx);
+          if constexpr (is_fp4_type_v<DTypeKV>) {
+            // Dequantize NVFP4 V -> BF16 staging smem with per-block scale (shuffle-free),
+            // then read native 16-bit.
+            repack_fp4_tile_to_bf16<KTraits, KTraits::HEAD_DIM_VO>(
+                smem_storage.v_smem, smem_storage.v_sf_smem_ptr(),
+                smem_storage.kv_smem_repack_ptr(), warp_idx * WARP_SIZE + lane_idx);
+          } else {
+            // Dequantize FP8 V -> BF16 staging smem (shuffle-free), then read native 16-bit.
+            repack_fp8_tile_to_bf16<KTraits, KTraits::HEAD_DIM_VO>(
+                smem_storage.v_smem, smem_storage.kv_smem_repack_ptr(),
+                warp_idx * WARP_SIZE + lane_idx);
+          }
           block.sync();
           compute_sfm_v<KTraits, /*REPACK_BF16=*/true>(
               &v_smem_bf16, &v_smem_offset_r_bf16,

--- a/include/flashinfer/attention/prefill.cuh
+++ b/include/flashinfer/attention/prefill.cuh
@@ -108,11 +108,11 @@ struct KVScaleFactorSmem<DTypeKV, CTA_TILE_KV, HEAD_DIM_QK, HEAD_DIM_VO, true> {
   alignas(16) uint8_t v_sf_smem[CTA_TILE_KV * HEAD_DIM_VO / NVFP4_SF_VEC_SIZE];
 };
 
-// BF16/FP16 staging buffer for the FP8 "repack" path (compute_qk REPACK_BF16). Empty base
+// BF16/FP16 staging buffer for the FP8/NVFP4 "repack" path (compute_qk REPACK_BF16). Empty base
 // (0 bytes via EBO) when unused; same smem rationale as KVScaleFactorSmem above.
 template <typename DTypeQ, typename DTypeKV, uint32_t CTA_TILE_Q, uint32_t CTA_TILE_KV,
           uint32_t HEAD_DIM_QK, uint32_t HEAD_DIM_VO,
-          bool = ((sizeof(DTypeKV) == 1) && !is_fp4_type_v<DTypeKV> && (HEAD_DIM_VO != 64) &&
+          bool = (((sizeof(DTypeKV) == 1) || is_fp4_type_v<DTypeKV>) && (HEAD_DIM_VO != 64) &&
                   (HEAD_DIM_VO <= 256) && (CTA_TILE_Q > 16))>
 struct KVRepackSmem {};
 template <typename DTypeQ, typename DTypeKV, uint32_t CTA_TILE_Q, uint32_t CTA_TILE_KV,
@@ -172,7 +172,7 @@ struct SharedStorageQKVO
     };
     alignas(16) DTypeO smem_o[CTA_TILE_Q * HEAD_DIM_VO];
   };
-  static constexpr bool USE_KV_REPACK = (sizeof(DTypeKV) == 1) && !is_fp4_type_v<DTypeKV> &&
+  static constexpr bool USE_KV_REPACK = ((sizeof(DTypeKV) == 1) || is_fp4_type_v<DTypeKV>) &&
                                         (HEAD_DIM_VO != 64) && (HEAD_DIM_VO <= 256) &&
                                         (CTA_TILE_Q > 16);
   static constexpr bool VO_SPLIT_SMEM = kVOSplit;
@@ -291,7 +291,7 @@ struct KernelTraits {
   using DTypeQKAccum = DTypeQKAccum_;
   using IdType = IdType_;
   using AttentionVariant = AttentionVariant_;
-  static constexpr bool USE_KV_REPACK = (sizeof(DTypeKV_) == 1) && !is_fp4_type_v<DTypeKV_> &&
+  static constexpr bool USE_KV_REPACK = ((sizeof(DTypeKV_) == 1) || is_fp4_type_v<DTypeKV_>) &&
                                         (HEAD_DIM_VO != 64) && (HEAD_DIM_VO <= 256) &&
                                         (CTA_TILE_Q > 16);  // CTA16 = decode/short-q -> in-loop
   // b128 columns per KV row in the FP8 (packed) and BF16 (repacked) layouts.
@@ -1170,6 +1170,112 @@ __device__ __forceinline__ void repack_fp8_tile_to_bf16(typename KTraits::DTypeK
     // so it must be 16-byte aligned (DTypeQ alone only guarantees 2B alignment).
     alignas(16) DTypeQ conv[16];
     vec_cast<DTypeQ, DTypeKV>::template cast<16>(conv, (DTypeKV*)&packed);
+    dst[get_permuted_offset<SWIZZLE, BF16_COLS>(row, 2 * col)] = *(b128_t*)&conv[0];
+    dst[get_permuted_offset<SWIZZLE, BF16_COLS>(row, 2 * col + 1)] = *(b128_t*)&conv[8];
+  }
+}
+
+// Amortized NVFP4 repack: convert packed FP4 + per-block scales in smem to scaled BF16 in the
+// staging buffer.  Each thread reads b128 chunks of packed FP4 and the corresponding
+// per-block UE4M3 scale factors, converts FP4→BF16 using cvt.rn.bf16x2.e2m1x2 (the same
+// intrinsic used by vec_cast in vec_dtypes.cuh), applies scale via __hmul2, and writes
+// native 16-bit BF16.  Afterwards the QK/PV MMAs use the standard 16-bit ldmatrix path
+// (no per-fragment cross-lane swizzle or __hmul2).
+// Numerically identical to the in-loop dequant.
+//
+// Layout (sizeof(__nv_fp4x2_e2m1)==1):
+//   FP4_COLS  = HEAD_DIM / upcast_size<DTypeKV>() = HEAD_DIM / 16  (b128 slots per FP4 row)
+//   BF16_COLS = HEAD_DIM / upcast_size<DTypeQ>()  = HEAD_DIM / 8   (b128 slots per BF16 row)
+//   SF_COLS   = HEAD_DIM / NVFP4_SF_VEC_SIZE      = HEAD_DIM / 16  (SF bytes per row)
+//   FP4_COLS == SF_COLS,  BF16_COLS == 2 * FP4_COLS
+//   Each FP4 b128 holds 16 bytes of __nv_fp4x2_e2m1, but only the lower 8 bytes
+//   (8 fp4x2 = 16 fp4 values = 1 SF group) are valid from load_64b_async.
+//   The upper 8 bytes are zero-padded and must NOT be converted.
+//   One FP4 b128 (8 valid fp4x2) → 2 BF16 b128 (16 bf16 values).
+//   One SF byte per FP4 b128.
+template <typename KTraits, uint32_t HEAD_DIM>
+__device__ __forceinline__ void repack_fp4_tile_to_bf16(typename KTraits::DTypeKV* smem_fp4,
+                                                        uint8_t* sf_smem,
+                                                        typename KTraits::DTypeQ* smem_bf16,
+                                                        uint32_t thread_id) {
+  using DTypeKV = typename KTraits::DTypeKV;
+  using DTypeQ = typename KTraits::DTypeQ;
+  static_assert(is_fp4_type_v<DTypeKV>, "repack_fp4_tile_to_bf16 requires FP4 KV dtype");
+  static_assert(sizeof(DTypeKV) == 1, "__nv_fp4x2_e2m1 must be 1 byte");
+  static_assert(sizeof(b128_t) == 16, "b128_t must be 16 bytes");
+  constexpr SwizzleMode SWIZZLE = KTraits::SWIZZLE_MODE_KV;
+  constexpr uint32_t NUM_THREADS = KTraits::NUM_THREADS;
+  constexpr uint32_t CTA_TILE_KV = KTraits::CTA_TILE_KV;
+  // upcast_size<DTypeKV>() = 16 (16 fp4x2 per b128), upcast_size<DTypeQ>() = 8 (8 bf16 per b128).
+  constexpr uint32_t FP4_COLS = HEAD_DIM / upcast_size<DTypeKV>();
+  constexpr uint32_t BF16_COLS = HEAD_DIM / upcast_size<DTypeQ>();
+  constexpr uint32_t SF_COLS = HEAD_DIM / NVFP4_SF_VEC_SIZE;
+  static_assert(SF_COLS == FP4_COLS, "SF_COLS must equal FP4_COLS for NVFP4");
+  static_assert(BF16_COLS == 2 * FP4_COLS, "BF16_COLS must be 2*FP4_COLS for NVFP4");
+  constexpr uint32_t NUM_B128 = CTA_TILE_KV * FP4_COLS;
+
+  b128_t* src = (b128_t*)smem_fp4;
+  b128_t* dst = (b128_t*)smem_bf16;
+#pragma unroll
+  for (uint32_t idx = thread_id; idx < NUM_B128; idx += NUM_THREADS) {
+    uint32_t row = idx / FP4_COLS, col = idx % FP4_COLS;
+    b128_t packed = src[get_permuted_offset<SWIZZLE, FP4_COLS>(row, col)];
+
+    // 1 SF byte per FP4 b128 (8 valid fp4x2 = 16 fp4 values per SF).
+    __nv_fp8_e4m3 sf;
+    sf.__x = sf_smem[row * SF_COLS + col];
+    DTypeQ bf16_sf = static_cast<DTypeQ>(sf);
+    using packed2_t = std::conditional_t<std::is_same_v<DTypeQ, half>, half2, __nv_bfloat162>;
+    packed2_t scale{bf16_sf, bf16_sf};
+
+    // Only the lower 8 bytes of the FP4 b128 are valid (from load_64b_async).
+    // Convert 8 valid fp4x2 bytes → 16 bf16 values, applying the per-block scale.
+    // We use the same cvt.rn.bf16x2.e2m1x2 intrinsic as vec_cast<DTypeQ, DTypeKV>
+    // in vec_dtypes.cuh, but read contiguous bytes (fp4_bytes[i]) rather than
+    // stride-2 fragment-swizzled layout.
+    uint8_t* fp4_bytes = (uint8_t*)&packed;
+    alignas(16) DTypeQ conv[16];
+
+#pragma unroll
+    for (uint32_t i = 0; i < 8; ++i) {
+      uint32_t y;
+#if (defined __CUDACC_VER_MAJOR__) && (defined __CUDACC_VER_MINOR__) && \
+    ((__CUDACC_VER_MAJOR__ > 13) || ((__CUDACC_VER_MAJOR__ == 13) && (__CUDACC_VER_MINOR__ >= 2)))
+      asm volatile(
+          "{\n"
+          ".reg .b8 fp4_byte;\n"
+          "mov.b32 {fp4_byte, _, _, _}, %1;\n"
+          "cvt.rn.bf16x2.e2m1x2 %0, fp4_byte;\n"
+          "}"
+          : "=r"(y)
+          : "r"(uint32_t(fp4_bytes[i])));
+#else
+      // Fallback: convert e2m1 → fp16 → bf16 when cvt.rn.bf16x2.e2m1x2 is unavailable
+      uint32_t fp16x2;
+      asm volatile(
+          "{\n"
+          ".reg .b8 fp4_byte;\n"
+          "mov.b32 {fp4_byte, _, _, _}, %1;\n"
+          "cvt.rn.f16x2.e2m1x2 %0, fp4_byte;\n"
+          "}"
+          : "=r"(fp16x2)
+          : "r"(uint32_t(fp4_bytes[i])));
+      __half2 h2 = reinterpret_cast<__half2&>(fp16x2);
+      __nv_bfloat162 bf16x2 = __float22bfloat162_rn(__half22float2(h2));
+      y = reinterpret_cast<uint32_t&>(bf16x2);
+#endif
+      // y always contains BF16 bits.  Convert to DTypeQ before multiply.
+      __nv_bfloat162 bf16x2_in = reinterpret_cast<__nv_bfloat162&>(const_cast<uint32_t&>(y));
+      packed2_t vals;
+      if constexpr (std::is_same_v<DTypeQ, half>) {
+        vals = __float22half2_rn(__bfloat1622float2(bf16x2_in));
+      } else {
+        vals = bf16x2_in;
+      }
+      *(packed2_t*)&conv[i * 2] = __hmul2(vals, scale);
+    }
+
+    // Write 2 BF16 b128 slots: first 8 bf16 at col 2*col, next 8 bf16 at col 2*col+1.
     dst[get_permuted_offset<SWIZZLE, BF16_COLS>(row, 2 * col)] = *(b128_t*)&conv[0];
     dst[get_permuted_offset<SWIZZLE, BF16_COLS>(row, 2 * col + 1)] = *(b128_t*)&conv[8];
   }
@@ -2576,7 +2682,7 @@ cudaError_t SinglePrefillWithKVCacheDispatched(Params params, typename Params::D
     // path is active, so NUM_MMA_KV is chosen to keep base+staging within the
     // occupancy budget. NOTE: single-prefill doesn't use the repack, but the
     // staging buffer still lives in SharedStorageQKVO, so it must be accounted.
-    constexpr bool kUseRepack = (sizeof(DTypeKV) == 1) && !is_fp4_type_v<DTypeKV> &&
+    constexpr bool kUseRepack = ((sizeof(DTypeKV) == 1) || is_fp4_type_v<DTypeKV>) &&
                                 (HEAD_DIM_VO != 64) && (HEAD_DIM_VO <= 256) && (CTA_TILE_Q > 16);
     constexpr bool kKVShared = !is_fp4_type_v<DTypeKV> && (HEAD_DIM_VO / 16 > 16) &&
                                ((HEAD_DIM_VO / 16) % NUM_WARPS_KV == 0) &&
@@ -3056,10 +3162,18 @@ __global__ __launch_bounds__(KTraits::NUM_THREADS) void BatchPrefillWithRaggedKV
                                          16 * KTraits::NUM_MMA_D_QK),
               lane_idx, kv_rope_base, rope_freq, s_frag);
         } else if constexpr (KTraits::USE_KV_REPACK) {
-          // Dequantize FP8 K -> BF16 staging smem (shuffle-free), then read native 16-bit.
-          repack_fp8_tile_to_bf16<KTraits, KTraits::HEAD_DIM_QK>(smem_storage.k_smem,
-                                                                 smem_storage.kv_smem_repack_ptr(),
-                                                                 warp_idx * WARP_SIZE + lane_idx);
+          if constexpr (is_fp4_type_v<DTypeKV>) {
+            // Dequantize NVFP4 K -> BF16 staging smem with per-block scale (shuffle-free),
+            // then read native 16-bit.
+            repack_fp4_tile_to_bf16<KTraits, KTraits::HEAD_DIM_QK>(
+                smem_storage.k_smem, smem_storage.k_sf_smem_ptr(),
+                smem_storage.kv_smem_repack_ptr(), warp_idx * WARP_SIZE + lane_idx);
+          } else {
+            // Dequantize FP8 K -> BF16 staging smem (shuffle-free), then read native 16-bit.
+            repack_fp8_tile_to_bf16<KTraits, KTraits::HEAD_DIM_QK>(
+                smem_storage.k_smem, smem_storage.kv_smem_repack_ptr(),
+                warp_idx * WARP_SIZE + lane_idx);
+          }
           block.sync();
           compute_qk<KTraits, /*REPACK_BF16=*/true>(
               &qo_smem, &q_smem_offset_r, &k_smem_bf16, &k_smem_offset_r_bf16,
@@ -3119,10 +3233,18 @@ __global__ __launch_bounds__(KTraits::NUM_THREADS) void BatchPrefillWithRaggedKV
           vosplit_compute_pv<KTraits>(&smem_storage, o_frag, o_scale, warp_vo_base,
                                       get_warp_idx_q<KTraits>(tid.y), lane_idx);
         } else if constexpr (KTraits::USE_KV_REPACK) {
-          // Dequantize FP8 V -> BF16 staging smem (shuffle-free), then read native 16-bit.
-          repack_fp8_tile_to_bf16<KTraits, KTraits::HEAD_DIM_VO>(smem_storage.v_smem,
-                                                                 smem_storage.kv_smem_repack_ptr(),
-                                                                 warp_idx * WARP_SIZE + lane_idx);
+          if constexpr (is_fp4_type_v<DTypeKV>) {
+            // Dequantize NVFP4 V -> BF16 staging smem with per-block scale (shuffle-free),
+            // then read native 16-bit.
+            repack_fp4_tile_to_bf16<KTraits, KTraits::HEAD_DIM_VO>(
+                smem_storage.v_smem, smem_storage.v_sf_smem_ptr(),
+                smem_storage.kv_smem_repack_ptr(), warp_idx * WARP_SIZE + lane_idx);
+          } else {
+            // Dequantize FP8 V -> BF16 staging smem (shuffle-free), then read native 16-bit.
+            repack_fp8_tile_to_bf16<KTraits, KTraits::HEAD_DIM_VO>(
+                smem_storage.v_smem, smem_storage.kv_smem_repack_ptr(),
+                warp_idx * WARP_SIZE + lane_idx);
+          }
           block.sync();
           compute_sfm_v<KTraits, /*REPACK_BF16=*/true>(
               &v_smem_bf16, &v_smem_offset_r_bf16,
@@ -3932,10 +4054,18 @@ __device__ __forceinline__ void BatchPrefillWithPagedKVCacheDevice(
                                          16 * KTraits::NUM_MMA_D_QK),
               lane_idx, kv_rope_base, rope_freq, s_frag);
         } else if constexpr (KTraits::USE_KV_REPACK) {
-          // Dequantize FP8 K -> BF16 staging smem (shuffle-free), then read native 16-bit.
-          repack_fp8_tile_to_bf16<KTraits, KTraits::HEAD_DIM_QK>(smem_storage.k_smem,
-                                                                 smem_storage.kv_smem_repack_ptr(),
-                                                                 warp_idx * WARP_SIZE + lane_idx);
+          if constexpr (is_fp4_type_v<DTypeKV>) {
+            // Dequantize NVFP4 K -> BF16 staging smem with per-block scale (shuffle-free),
+            // then read native 16-bit.
+            repack_fp4_tile_to_bf16<KTraits, KTraits::HEAD_DIM_QK>(
+                smem_storage.k_smem, smem_storage.k_sf_smem_ptr(),
+                smem_storage.kv_smem_repack_ptr(), warp_idx * WARP_SIZE + lane_idx);
+          } else {
+            // Dequantize FP8 K -> BF16 staging smem (shuffle-free), then read native 16-bit.
+            repack_fp8_tile_to_bf16<KTraits, KTraits::HEAD_DIM_QK>(
+                smem_storage.k_smem, smem_storage.kv_smem_repack_ptr(),
+                warp_idx * WARP_SIZE + lane_idx);
+          }
           block.sync();
           compute_qk<KTraits, /*REPACK_BF16=*/true>(
               &qo_smem, &q_smem_offset_r, &k_smem_bf16, &k_smem_offset_r_bf16,
@@ -4022,10 +4152,18 @@ __device__ __forceinline__ void BatchPrefillWithPagedKVCacheDevice(
           vosplit_compute_pv<KTraits>(&smem_storage, o_frag, o_scale, warp_vo_base,
                                       get_warp_idx_q<KTraits>(tid.y), lane_idx);
         } else if constexpr (KTraits::USE_KV_REPACK) {
-          // Dequantize FP8 V -> BF16 staging smem (shuffle-free), then read native 16-bit.
-          repack_fp8_tile_to_bf16<KTraits, KTraits::HEAD_DIM_VO>(smem_storage.v_smem,
-                                                                 smem_storage.kv_smem_repack_ptr(),
-                                                                 warp_idx * WARP_SIZE + lane_idx);
+          if constexpr (is_fp4_type_v<DTypeKV>) {
+            // Dequantize NVFP4 V -> BF16 staging smem with per-block scale (shuffle-free),
+            // then read native 16-bit.
+            repack_fp4_tile_to_bf16<KTraits, KTraits::HEAD_DIM_VO>(
+                smem_storage.v_smem, smem_storage.v_sf_smem_ptr(),
+                smem_storage.kv_smem_repack_ptr(), warp_idx * WARP_SIZE + lane_idx);
+          } else {
+            // Dequantize FP8 V -> BF16 staging smem (shuffle-free), then read native 16-bit.
+            repack_fp8_tile_to_bf16<KTraits, KTraits::HEAD_DIM_VO>(
+                smem_storage.v_smem, smem_storage.kv_smem_repack_ptr(),
+                warp_idx * WARP_SIZE + lane_idx);
+          }
           block.sync();
           compute_sfm_v<KTraits, /*REPACK_BF16=*/true>(
               &v_smem_bf16, &v_smem_offset_r_bf16,
@@ -4186,10 +4324,10 @@ cudaError_t BatchPrefillWithRaggedKVCacheDispatched(Params params, typename Para
                                               cudaDevAttrMaxSharedMemoryPerBlockOptin, dev_id));
   // we expect each sm execute two threadblocks
   // Per-NUM_MMA_KV K/V shared-memory cost, including the single BF16 repack
-  // staging buffer (sized max(HEAD_DIM_QK, HEAD_DIM_VO)) when the FP8 repack path
+  // staging buffer (sized max(HEAD_DIM_QK, HEAD_DIM_VO)) when the FP8/NVFP4 repack path
   // is active, so NUM_MMA_KV is chosen to keep base+staging within the occupancy
   // budget (otherwise the staging silently drops blocks/SM at large head dims).
-  constexpr bool kUseRepack = (sizeof(DTypeKV) == 1) && !is_fp4_type_v<DTypeKV> &&
+  constexpr bool kUseRepack = ((sizeof(DTypeKV) == 1) || is_fp4_type_v<DTypeKV>) &&
                               (HEAD_DIM_VO != 64) && (HEAD_DIM_VO <= 256) && (CTA_TILE_Q > 16);
   // Matches KernelTraits::USE_KV_SHARED_SMEM: at large head dims K and V
   // time-share one smem buffer, so the occupancy budget counts the K/V
@@ -4207,6 +4345,9 @@ cudaError_t BatchPrefillWithRaggedKVCacheDispatched(Params params, typename Para
       (kUseRepack ? ((HEAD_DIM_QK > HEAD_DIM_VO ? HEAD_DIM_QK : HEAD_DIM_VO) * 16 * NUM_WARPS_KV *
                      sizeof(DTypeQ))
                   : 0u) +
+      (is_fp4_type_v<DTypeKV>
+           ? ((HEAD_DIM_QK + HEAD_DIM_VO) * 16 * NUM_WARPS_KV / NVFP4_SF_VEC_SIZE)
+           : 0u) +
       (kVOSplitDispatch ? (CTA_TILE_Q * NUM_WARPS_KV * 16 * sizeof(DTypeQ)) : 0u);
   constexpr uint32_t kVOSplitFixedSmem =
       kVOSplitDispatch ? (NUM_WARPS_KV * CTA_TILE_Q * 8u + 2048u) : 0u;
@@ -4386,10 +4527,10 @@ cudaError_t BatchPrefillWithPagedKVCacheDispatched(Params params, typename Param
                                               cudaDevAttrMaxSharedMemoryPerBlockOptin, dev_id));
   // we expect each sm execute two threadblocks
   // Per-NUM_MMA_KV K/V shared-memory cost, including the single BF16 repack
-  // staging buffer (sized max(HEAD_DIM_QK, HEAD_DIM_VO)) when the FP8 repack path
+  // staging buffer (sized max(HEAD_DIM_QK, HEAD_DIM_VO)) when the FP8/NVFP4 repack path
   // is active, so NUM_MMA_KV is chosen to keep base+staging within the occupancy
   // budget (otherwise the staging silently drops blocks/SM at large head dims).
-  constexpr bool kUseRepack = (sizeof(DTypeKV) == 1) && !is_fp4_type_v<DTypeKV> &&
+  constexpr bool kUseRepack = ((sizeof(DTypeKV) == 1) || is_fp4_type_v<DTypeKV>) &&
                               (HEAD_DIM_VO != 64) && (HEAD_DIM_VO <= 256) && (CTA_TILE_Q > 16);
   // Matches KernelTraits::USE_KV_SHARED_SMEM: K/V share one smem buffer for bf16/fp16 at every
   // tile and for FP8 only at CTA_TILE_Q=32 (not NVFP4), so the occupancy budget counts the K/V
@@ -4406,6 +4547,9 @@ cudaError_t BatchPrefillWithPagedKVCacheDispatched(Params params, typename Param
       (kUseRepack ? ((HEAD_DIM_QK > HEAD_DIM_VO ? HEAD_DIM_QK : HEAD_DIM_VO) * 16 * NUM_WARPS_KV *
                      sizeof(DTypeQ))
                   : 0u) +
+      (is_fp4_type_v<DTypeKV>
+           ? ((HEAD_DIM_QK + HEAD_DIM_VO) * 16 * NUM_WARPS_KV / NVFP4_SF_VEC_SIZE)
+           : 0u) +
       (kVOSplitDispatch ? (CTA_TILE_Q * NUM_WARPS_KV * 16 * sizeof(DTypeQ)) : 0u);
   constexpr uint32_t kVOSplitFixedSmem =
       kVOSplitDispatch ? (NUM_WARPS_KV * CTA_TILE_Q * 8u + 2048u) : 0u;

--- a/include/flashinfer/fastdiv.cuh
+++ b/include/flashinfer/fastdiv.cuh
@@ -47,18 +47,19 @@ struct uint_fastdiv {
 #else
 // CUDA 13+ path: cuda::fast_mod_div was removed. Fall back to plain division.
 struct uint_fastdiv {
-  __host__ __device__ uint_fastdiv() : d_(0) {}
+  __host__ __device__ uint_fastdiv() : impl_(1), d_(0) {}
 
-  __host__ __device__ uint_fastdiv(uint32_t d) : d_(d ? d : 1) {}
+  __host__ __device__ uint_fastdiv(uint32_t d) : impl_(d ? d : 1), d_(d) {}
 
   __host__ __device__ __forceinline__ operator unsigned int() const { return d_; }
 
   __host__ __device__ __forceinline__ void divmod(uint32_t n, uint32_t& q, uint32_t& r) const {
-    q = n / d_;
-    r = n % d_;
+    q = n / impl_;
+    r = n - q * d_;
   }
 
  private:
+  uint32_t impl_;
   uint32_t d_;
 };
 #endif

--- a/include/flashinfer/fastdiv.cuh
+++ b/include/flashinfer/fastdiv.cuh
@@ -16,13 +16,18 @@
 #ifndef FLASHINFER_FASTDIV_CUH_
 #define FLASHINFER_FASTDIV_CUH_
 #include <cstdint>
+
+// CUDA 12 and earlier: cuda::fast_mod_div is available in <cuda/cmath>.
+// CUDA 13+ renamed it to cub::detail::fast_div_mod (internal header).
+// We use the public CUDA 12 API when available and fall back to plain division otherwise.
+#if (__CUDACC_VER_MAJOR__ < 13)
 #include <cuda/cmath>
+#endif
 
 namespace flashinfer {
 
-// API-compatible wrapper around cuda::fast_mod_div<uint32_t>.
-// Preserves the default constructor, implicit conversions, and divmod()
-// method expected by existing call sites throughout the attention kernels.
+#if (__CUDACC_VER_MAJOR__ < 13)
+// CUDA 12 path: use cuda::fast_mod_div for hardware-accelerated division.
 struct uint_fastdiv {
   __host__ __device__ uint_fastdiv() : impl_(1), d_(0) {}
 
@@ -39,6 +44,25 @@ struct uint_fastdiv {
   cuda::fast_mod_div<uint32_t> impl_;
   uint32_t d_;
 };
+#else
+// CUDA 13+ path: cuda::fast_mod_div was removed. Fall back to plain division.
+struct uint_fastdiv {
+  __host__ __device__ uint_fastdiv() : impl_(1), d_(0) {}
+
+  __host__ __device__ uint_fastdiv(uint32_t d) : impl_(d ? d : 1), d_(d) {}
+
+  __host__ __device__ __forceinline__ operator unsigned int() const { return d_; }
+
+  __host__ __device__ __forceinline__ void divmod(uint32_t n, uint32_t& q, uint32_t& r) const {
+    q = n / impl_;
+    r = n - q * d_;
+  }
+
+ private:
+  uint32_t impl_;
+  uint32_t d_;
+};
+#endif
 
 __host__ __device__ __forceinline__ uint32_t operator/(const uint32_t n,
                                                        const uint_fastdiv& divisor) {

--- a/include/flashinfer/fastdiv.cuh
+++ b/include/flashinfer/fastdiv.cuh
@@ -16,13 +16,18 @@
 #ifndef FLASHINFER_FASTDIV_CUH_
 #define FLASHINFER_FASTDIV_CUH_
 #include <cstdint>
+
+// CUDA 12 and earlier: cuda::fast_mod_div is available in <cuda/cmath>.
+// CUDA 13+ renamed it to cub::detail::fast_div_mod (internal header).
+// We use the public CUDA 12 API when available and fall back to plain division otherwise.
+#if (__CUDACC_VER_MAJOR__ < 13)
 #include <cuda/cmath>
+#endif
 
 namespace flashinfer {
 
-// API-compatible wrapper around cuda::fast_mod_div<uint32_t>.
-// Preserves the default constructor, implicit conversions, and divmod()
-// method expected by existing call sites throughout the attention kernels.
+#if (__CUDACC_VER_MAJOR__ < 13)
+// CUDA 12 path: use cuda::fast_mod_div for hardware-accelerated division.
 struct uint_fastdiv {
   __host__ __device__ uint_fastdiv() : impl_(1), d_(0) {}
 
@@ -39,6 +44,24 @@ struct uint_fastdiv {
   cuda::fast_mod_div<uint32_t> impl_;
   uint32_t d_;
 };
+#else
+// CUDA 13+ path: cuda::fast_mod_div was removed. Fall back to plain division.
+struct uint_fastdiv {
+  __host__ __device__ uint_fastdiv() : d_(0) {}
+
+  __host__ __device__ uint_fastdiv(uint32_t d) : d_(d ? d : 1) {}
+
+  __host__ __device__ __forceinline__ operator unsigned int() const { return d_; }
+
+  __host__ __device__ __forceinline__ void divmod(uint32_t n, uint32_t& q, uint32_t& r) const {
+    q = n / d_;
+    r = n % d_;
+  }
+
+ private:
+  uint32_t d_;
+};
+#endif
 
 __host__ __device__ __forceinline__ uint32_t operator/(const uint32_t n,
                                                        const uint_fastdiv& divisor) {

--- a/tests/attention/test_batch_prefill_kernels.py
+++ b/tests/attention/test_batch_prefill_kernels.py
@@ -2317,6 +2317,30 @@ def test_single_prefill_torch_compile_cuda_graph():
     )
 
 
+def test_batch_prefill_with_paged_kv_cache_nvfp4_repack_boundary():
+    """Deterministic boundary test for the NVFP4 repack path.
+
+    Exercises the repack_fp4_tile_to_bf16 code path with small dimensions
+    where CTA_TILE_Q > 16 triggers the repack. Verifies correctness against
+    reference dequantized KV cache.
+    """
+    # Conditions that trigger repack path:
+    # - is_fp4_type_v<DTypeKV>: NVFP4 KV cache
+    # - HEAD_DIM_VO != 64 and HEAD_DIM_VO <= 256: head_dim=128
+    # - CTA_TILE_Q > 16: qo_len=64 ensures large enough tiles
+    test_batch_prefill_with_paged_kv_cache_nvfp4(
+        batch_size=2,
+        kv_len=64,
+        qo_len=64,
+        page_size=16,
+        num_kv_heads=4,
+        num_qo_heads=4,
+        head_dim=128,
+        causal=False,
+        q_dtype=torch.bfloat16,
+    )
+
+
 # Regression tests for the finite mask sentinel bugs #4267/#4450/#4451/#4452:
 # masked logits are IEEE -inf, so any finite logit must win over masked positions
 # and fully masked rows must yield zero output with LSE = -inf.

--- a/tests/attention/test_batch_prefill_kernels.py
+++ b/tests/attention/test_batch_prefill_kernels.py
@@ -1819,3 +1819,27 @@ def test_single_prefill_torch_compile_cuda_graph():
     assert result.returncode == 0 and "PASS" in result.stdout, (
         f"Test failed:\nstdout: {result.stdout[-500:]}\nstderr: {result.stderr[-500:]}"
     )
+
+
+def test_batch_prefill_with_paged_kv_cache_nvfp4_repack_boundary():
+    """Deterministic boundary test for the NVFP4 repack path.
+
+    Exercises the repack_fp4_tile_to_bf16 code path with small dimensions
+    where CTA_TILE_Q > 16 triggers the repack. Verifies correctness against
+    reference dequantized KV cache.
+    """
+    # Conditions that trigger repack path:
+    # - is_fp4_type_v<DTypeKV>: NVFP4 KV cache
+    # - HEAD_DIM_VO != 64 and HEAD_DIM_VO <= 256: head_dim=128
+    # - CTA_TILE_Q > 16: qo_len=64 ensures large enough tiles
+    test_batch_prefill_with_paged_kv_cache_nvfp4(
+        batch_size=2,
+        kv_len=64,
+        qo_len=64,
+        page_size=16,
+        num_kv_heads=4,
+        num_qo_heads=4,
+        head_dim=128,
+        causal=False,
+        q_dtype=torch.bfloat16,
+    )

--- a/tests/test_fastdiv.py
+++ b/tests/test_fastdiv.py
@@ -1,0 +1,75 @@
+# SPDX-FileCopyrightText: (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import pathlib
+
+import pytest
+import torch
+from torch.utils.cpp_extension import load_inline
+
+
+_REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+_FLASHINFER_INCLUDE = str(_REPO_ROOT / "include")
+
+
+_CPP_SOURCE = r"""
+torch::Tensor test_uint_fastdiv();
+"""
+
+_CUDA_SOURCE = r"""
+#include <torch/extension.h>
+
+#include <flashinfer/fastdiv.cuh>
+
+__global__ void uint_fastdiv_kernel(uint32_t* output) {
+  const uint32_t n = 7;
+  flashinfer::uint_fastdiv default_divisor;
+  flashinfer::uint_fastdiv zero_divisor(0);
+  flashinfer::uint_fastdiv three_divisor(3);
+
+  if (threadIdx.x == 0) {
+    uint32_t q, r;
+    default_divisor.divmod(n, q, r);
+    output[0] = q;
+    output[1] = r;
+    zero_divisor.divmod(n, q, r);
+    output[2] = q;
+    output[3] = r;
+    three_divisor.divmod(n, q, r);
+    output[4] = q;
+    output[5] = r;
+    output[6] = static_cast<unsigned int>(default_divisor);
+    output[7] = static_cast<unsigned int>(zero_divisor);
+    output[8] = static_cast<unsigned int>(three_divisor);
+  }
+}
+
+torch::Tensor test_uint_fastdiv() {
+  auto output = torch::empty({9}, torch::dtype(torch::kUInt32).device(torch::kCUDA));
+  uint_fastdiv_kernel<<<1, 1>>>(output.data_ptr<uint32_t>());
+  return output;
+}
+"""
+
+
+@pytest.fixture(scope="module")
+def fastdiv_module():
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is required")
+    major, minor = torch.cuda.get_device_capability()
+    gencode = f"-gencode=arch=compute_{major}{minor},code=sm_{major}{minor}"
+    return load_inline(
+        name="test_uint_fastdiv",
+        cpp_sources=[_CPP_SOURCE],
+        cuda_sources=[_CUDA_SOURCE],
+        extra_include_paths=[_FLASHINFER_INCLUDE],
+        extra_cuda_cflags=[gencode],
+        functions=["test_uint_fastdiv"],
+        verbose=False,
+    )
+
+
+def test_uint_fastdiv_zero_divisor_invariant(fastdiv_module):
+    output = fastdiv_module.test_uint_fastdiv()
+    expected = torch.tensor([7, 7, 7, 7, 2, 1, 0, 0, 3], device="cuda", dtype=torch.uint32)
+    torch.testing.assert_close(output, expected, rtol=0, atol=0)

--- a/tests/test_fastdiv.py
+++ b/tests/test_fastdiv.py
@@ -1,0 +1,79 @@
+# SPDX-FileCopyrightText: (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import pathlib
+
+import pytest
+import torch
+from torch.utils.cpp_extension import load_inline
+
+
+_REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+_FLASHINFER_INCLUDE = str(_REPO_ROOT / "include")
+
+
+_CPP_SOURCE = r"""
+torch::Tensor test_uint_fastdiv();
+"""
+
+_CUDA_SOURCE = r"""
+#include <torch/extension.h>
+
+#include <flashinfer/fastdiv.cuh>
+
+__global__ void uint_fastdiv_kernel(uint32_t* output) {
+  const uint32_t n = 7;
+  flashinfer::uint_fastdiv default_divisor;
+  flashinfer::uint_fastdiv zero_divisor(0);
+  flashinfer::uint_fastdiv three_divisor(3);
+
+  if (threadIdx.x == 0) {
+    uint32_t q, r;
+    default_divisor.divmod(n, q, r);
+    output[0] = q;
+    output[1] = r;
+    zero_divisor.divmod(n, q, r);
+    output[2] = q;
+    output[3] = r;
+    three_divisor.divmod(n, q, r);
+    output[4] = q;
+    output[5] = r;
+    output[6] = static_cast<unsigned int>(default_divisor);
+    output[7] = static_cast<unsigned int>(zero_divisor);
+    output[8] = static_cast<unsigned int>(three_divisor);
+    output[9] = n / three_divisor;
+    output[10] = n % three_divisor;
+  }
+}
+
+torch::Tensor test_uint_fastdiv() {
+  auto output = torch::empty({11}, torch::dtype(torch::kUInt32).device(torch::kCUDA));
+  uint_fastdiv_kernel<<<1, 1>>>(output.data_ptr<uint32_t>());
+  return output;
+}
+"""
+
+
+@pytest.fixture(scope="module")
+def fastdiv_module():
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is required")
+    major, minor = torch.cuda.get_device_capability()
+    gencode = f"-gencode=arch=compute_{major}{minor},code=sm_{major}{minor}"
+    return load_inline(
+        name="test_uint_fastdiv",
+        cpp_sources=[_CPP_SOURCE],
+        cuda_sources=[_CUDA_SOURCE],
+        extra_include_paths=[_FLASHINFER_INCLUDE],
+        extra_cuda_cflags=[gencode],
+        functions=["test_uint_fastdiv"],
+        verbose=False,
+    )
+
+
+def test_uint_fastdiv_zero_divisor_invariant(fastdiv_module):
+    output = fastdiv_module.test_uint_fastdiv()
+    expected = torch.tensor(
+        [7, 7, 7, 7, 2, 1, 0, 0, 3, 2, 1], device="cuda", dtype=torch.uint32
+    )
+    torch.testing.assert_close(output, expected, rtol=0, atol=0)

--- a/tests/test_fastdiv.py
+++ b/tests/test_fastdiv.py
@@ -41,11 +41,13 @@ __global__ void uint_fastdiv_kernel(uint32_t* output) {
     output[6] = static_cast<unsigned int>(default_divisor);
     output[7] = static_cast<unsigned int>(zero_divisor);
     output[8] = static_cast<unsigned int>(three_divisor);
+    output[9] = n / three_divisor;
+    output[10] = n % three_divisor;
   }
 }
 
 torch::Tensor test_uint_fastdiv() {
-  auto output = torch::empty({9}, torch::dtype(torch::kUInt32).device(torch::kCUDA));
+  auto output = torch::empty({11}, torch::dtype(torch::kUInt32).device(torch::kCUDA));
   uint_fastdiv_kernel<<<1, 1>>>(output.data_ptr<uint32_t>());
   return output;
 }
@@ -71,5 +73,7 @@ def fastdiv_module():
 
 def test_uint_fastdiv_zero_divisor_invariant(fastdiv_module):
     output = fastdiv_module.test_uint_fastdiv()
-    expected = torch.tensor([7, 7, 7, 7, 2, 1, 0, 0, 3], device="cuda", dtype=torch.uint32)
+    expected = torch.tensor(
+        [7, 7, 7, 7, 2, 1, 0, 0, 3, 2, 1], device="cuda", dtype=torch.uint32
+    )
     torch.testing.assert_close(output, expected, rtol=0, atol=0)


### PR DESCRIPTION
## 📌 Description

This PR fixes the SM120 NVFP4 paged causal prefill regression tracked in #4269.

The paged-prefill path dequantizes packed NVFP4 KV values inline for BF16-oriented MMA. This change adds an amortized NVFP4-to-BF16 repack path following the existing FP8 repack design, so conversion and scale application happen once per tile instead of inside every MMA iteration.

The initial repack implementation reinterpreted BF16 bit patterns as FP16 values when DTypeQ was half. The PTX conversion produces BF16 bits, so the implementation now explicitly converts BF16 to DTypeQ before applying the scale.

## 🔍 Related Issues

Fixes #4269

## 🚀 Pull Request Checklist

### ✅ Pre-commit Checks

- [x] Pre-commit hooks have been installed in the CUDA 13 development environment.
- [x] Hooks have been installed.
- [x] `pre-commit run --all-files` has been run successfully.

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] Final previously failing FP16 NVFP4 case passes on CT102.
- [x] Full paged NVFP4 selection passes: 39/39.
- [x] Representative paged-prefill regression passes.
- [x] `git diff --check` passes.

## Reviewer Notes

### Changes

- Add NVFP4 repack dispatch for paged and ragged prefill K/V paths.
- Convert only the eight valid packed FP4 bytes loaded by `load_64b_async`.
- Apply the per-block scale factor during repack.
- Convert BF16 results correctly to FP16 or retain BF16 according to DTypeQ.
- Preserve existing FP8 and non-FP4 paths.
- Add a deterministic NVFP4 repack boundary test.
- Add the CUDA 13 `uint_fastdiv` compatibility fallback.

### Validation environment

- CT102
- CUDA 13.0.88
- 2x NVIDIA RTX PRO 4000 Blackwell
- SM120

### Performance

Matched CUDA-event benchmark after warmup, 60 iterations per case, on CT102:

- Workload: BF16 Q, HND, causal paged prefill; batch=4, KV length=2048, QO length=128, page size=16, Q heads=32, KV heads=8, head dimension=128.
- Parent baseline (commit `51920591`, with only the independent CUDA 13 `fastdiv.cuh` compatibility fix applied): median **0.2999 ms**.
- This PR: median **0.2888 ms**.
- Result: **3.7% lower kernel-run latency** for this workload.

A shorter 256-token KV case was within noise, so the result above is reported as the representative long-KV case rather than extrapolating a larger gain. No large serving benchmark was run while SGLang owned the GPUs; SGLang was paused only for this controlled benchmark and restarted afterward. The PR is open for review pending maintainer review and broader CI validation.

## Review follow-up

- Account for NVFP4 repack staging and scale-factor shared memory in all launch-sizing paths.
- Restore CUDA 13 uint_fastdiv zero-divisor/default-constructor parity with the CUDA 12 implementation.
- Add a CUDA test covering default, zero, and nonzero divisors.
- Revalidated on SM120: uint_fastdiv parity passed; NVFP4 boundary and previously failing FP16 case passed.
- pre-commit run --all-files passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for NVFP4 key/value cache repacking in BF16 and FP16 prefill workflows, including single, ragged, and paged attention.
  * Added compatibility for CUDA 13 with built-in fast division and modulo operations.

* **Bug Fixes**
  * Preserved existing FP8 processing while improving FP4 data handling across supported prefill paths.

* **Tests**
  * Added coverage for NVFP4 paged-prefill boundary scenarios and CUDA fast division behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->