### PR TITLE
fix(moe_ep): let the host framework pin the CUDA device via Bootstrap

### DIFF
--- a/flashinfer/moe_ep/config.py
+++ b/flashinfer/moe_ep/config.py
@@ -88,6 +88,14 @@ class BootstrapConfig:
     rank: int
     stream: int = 0  # int representation of a cudaStream_t; 0 = default stream
     auto_bootstrap: bool = True
+    # CUDA device ordinal to bind for this rank. None = derive from the
+    # LOCAL_RANK env var, falling back to ``rank`` (torchrun convention).
+    # Host frameworks that already bound their worker's device (possibly
+    # under a remapped CUDA_VISIBLE_DEVICES, where the derived ordinal would
+    # point at the wrong or a nonexistent GPU) should pass
+    # ``torch.cuda.current_device()``. Keyword-only so it does not shift the
+    # positional binding of the pre-existing fields below.
+    device: Optional[int] = field(default=None, kw_only=True)
     nccl_comm: Optional[int] = (
         None  # int representation of ncclComm_t; None = derive from PG
     )
@@ -105,6 +113,8 @@ class BootstrapConfig:
             raise ValueError(f"world_size must be positive, got {self.world_size}")
         if not (0 <= self.rank < self.world_size):
             raise ValueError(f"rank {self.rank} not in [0, {self.world_size})")
+        if self.device is not None and self.device < 0:
+            raise ValueError(f"device must be non-negative, got {self.device}")
 
 
 @dataclass(frozen=True)

--- a/flashinfer/moe_ep/core/runtime/bootstrap.py
+++ b/flashinfer/moe_ep/core/runtime/bootstrap.py
@@ -51,17 +51,31 @@ def _launched_via_torchrun() -> bool:
     return "RANK" in os.environ and "WORLD_SIZE" in os.environ
 
 
+def _resolve_local_device(bootstrap: BootstrapConfig) -> int:
+    """CUDA device ordinal for this rank.
+
+    ``bootstrap.device`` wins when set (host frameworks pass the device they
+    already bound); otherwise fall back to the LOCAL_RANK env var and then
+    ``bootstrap.rank`` (torchrun convention).
+    """
+    if bootstrap.device is not None:
+        return bootstrap.device
+    return int(os.environ.get("LOCAL_RANK", str(bootstrap.rank)))
+
+
 def _ensure_cuda_device(bootstrap: BootstrapConfig) -> None:
     import torch
 
     if not torch.cuda.is_available():
         return
-    local_rank = int(os.environ.get("LOCAL_RANK", str(bootstrap.rank)))
-    torch.cuda.set_device(local_rank)
+    torch.cuda.set_device(_resolve_local_device(bootstrap))
 
 
 def ensure_moe_ep_cuda_device(bootstrap: BootstrapConfig) -> None:
-    """Bind the current process to ``LOCAL_RANK`` before any CUDA allocations."""
+    """Bind the process to this rank's device before any CUDA allocations.
+
+    See :func:`_resolve_local_device` for how the device is chosen.
+    """
     _ensure_cuda_device(bootstrap)
 
 
@@ -79,8 +93,7 @@ def _ensure_torch_dist(bootstrap: BootstrapConfig) -> bool:
     _ensure_cuda_device(bootstrap)
 
     if "RANK" in os.environ and "WORLD_SIZE" in os.environ:
-        local_rank = int(os.environ.get("LOCAL_RANK", str(bootstrap.rank)))
-        device = torch.device(f"cuda:{local_rank}")
+        device = torch.device(f"cuda:{_resolve_local_device(bootstrap)}")
         dist.init_process_group(backend="nccl", device_id=device)
     elif bootstrap.world_size == 1:
         dist.init_process_group(
@@ -134,9 +147,9 @@ def _init_nvshmem_after_dist(bootstrap: BootstrapConfig) -> bool:
     pg = bootstrap_comm_group(bootstrap)
     rank, world_size = bootstrap_ep_rank_world(bootstrap)
 
-    local_rank = int(os.environ.get("LOCAL_RANK", str(bootstrap.rank)))
-    torch.cuda.set_device(local_rank)
-    dev = Device(local_rank)
+    local_device = _resolve_local_device(bootstrap)
+    torch.cuda.set_device(local_device)
+    dev = Device(local_device)
     dev.set_current()
 
     uid = nvshmem.core.get_unique_id(empty=(rank != 0))

--- a/tests/moe_ep/test_constraints.py
+++ b/tests/moe_ep/test_constraints.py
@@ -365,3 +365,31 @@ def test_nixl_ep_capacity_below_world_size_rejected():
         validate_fleet_params(
             _split(num_experts=8), backend="nixl_ep", world_size=4, topology_capacity=2
         )
+
+
+# ------------------------------------------------------------------ bootstrap device
+
+
+def test_bootstrap_device_resolution_prefers_explicit_device(monkeypatch):
+    """A host framework's explicit device wins over LOCAL_RANK and rank."""
+    from flashinfer.moe_ep.core.runtime.bootstrap import _resolve_local_device
+
+    monkeypatch.setenv("LOCAL_RANK", "5")
+    bootstrap = BootstrapConfig(world_size=8, rank=3, device=0)
+    assert _resolve_local_device(bootstrap) == 0
+
+
+def test_bootstrap_device_resolution_env_then_rank(monkeypatch):
+    """Without an explicit device: LOCAL_RANK env, then rank (torchrun)."""
+    from flashinfer.moe_ep.core.runtime.bootstrap import _resolve_local_device
+
+    monkeypatch.setenv("LOCAL_RANK", "5")
+    assert _resolve_local_device(BootstrapConfig(world_size=8, rank=3)) == 5
+
+    monkeypatch.delenv("LOCAL_RANK")
+    assert _resolve_local_device(BootstrapConfig(world_size=8, rank=3)) == 3
+
+
+def test_bootstrap_rejects_negative_device():
+    with pytest.raises(ValueError, match="device"):
+        BootstrapConfig(world_size=8, rank=3, device=-1)


### PR DESCRIPTION
The moe_ep runtime derives its CUDA device from the environment (LOCAL_RANK, falling back to bootstrap.rank) and rebinds unconditionally in _ensure_cuda_device, _ensure_torch_dist, and _init_nvshmem_after_dist. Host frameworks like vLLM bind each worker's device themselves, often under a remapped CUDA_VISIBLE_DEVICES where the derived ordinal points at the wrong or a nonexistent GPU; the rebind then launches weight transforms against another device's pointers
(CUDA_ERROR_ILLEGAL_ADDRESS in deep_gemm transform_sf during load).

Add BootstrapConfig.device: when set, all three bind sites use it verbatim; when None, behavior is unchanged (LOCAL_RANK then rank, torchrun convention). Hosts pass torch.cuda.current_device() and no longer need to mutate LOCAL_RANK to steer the library.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for explicitly selecting the CUDA device used during bootstrap.
  - Device selection now follows a predictable priority: configured device, local environment setting, then process rank.
  - Invalid negative device values are rejected with a clear validation error.

- **Bug Fixes**
  - Improved consistency between CUDA, NCCL, and NVSHMEM device selection during initialization.

- **Tests**
  - Added coverage for device-selection precedence and invalid device configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->