### PR TITLE
fix(rope): guard rotary_dim <= head_dim to prevent silent cross-head corruption

### DIFF
--- a/flashinfer/rope.py
+++ b/flashinfer/rope.py
@@ -512,6 +512,10 @@ def apply_rope_inplace(
     """
     if rotary_dim is None:
         rotary_dim = q.size(-1)
+    if rotary_dim > q.size(-1):
+        raise ValueError(
+            f"head_dim ({q.size(-1)}) must be >= rotary_dim ({rotary_dim})"
+        )
     _apply_rope(
         q, k, q, k, indptr, offsets, rotary_dim, interleave, rope_scale, rope_theta
     )
@@ -571,6 +575,10 @@ def apply_rope_pos_ids_inplace(
     """
     if rotary_dim is None:
         rotary_dim = q.size(-1)
+    if rotary_dim > q.size(-1):
+        raise ValueError(
+            f"head_dim ({q.size(-1)}) must be >= rotary_dim ({rotary_dim})"
+        )
     _apply_rope_pos_ids(
         q, k, q, k, pos_ids, rotary_dim, interleave, rope_scale, rope_theta
     )
@@ -668,6 +676,10 @@ def apply_llama31_rope_inplace(
     """
     if rotary_dim is None:
         rotary_dim = q.size(-1)
+    if rotary_dim > q.size(-1):
+        raise ValueError(
+            f"head_dim ({q.size(-1)}) must be >= rotary_dim ({rotary_dim})"
+        )
     _apply_llama31_rope(
         q,
         k,
@@ -748,6 +760,10 @@ def apply_llama31_rope_pos_ids_inplace(
     """
     if rotary_dim is None:
         rotary_dim = q.size(-1)
+    if rotary_dim > q.size(-1):
+        raise ValueError(
+            f"head_dim ({q.size(-1)}) must be >= rotary_dim ({rotary_dim})"
+        )
     _apply_llama31_rope_pos_ids(
         q,
         k,

--- a/flashinfer/rope.py
+++ b/flashinfer/rope.py
@@ -512,9 +512,9 @@ def apply_rope_inplace(
     """
     if rotary_dim is None:
         rotary_dim = q.size(-1)
-    if rotary_dim > q.size(-1):
+    if rotary_dim > min(q.size(-1), k.size(-1)):
         raise ValueError(
-            f"head_dim ({q.size(-1)}) must be >= rotary_dim ({rotary_dim})"
+            f"head_dim (q={q.size(-1)}, k={k.size(-1)}) must be >= rotary_dim ({rotary_dim})"
         )
     _apply_rope(
         q, k, q, k, indptr, offsets, rotary_dim, interleave, rope_scale, rope_theta
@@ -575,9 +575,9 @@ def apply_rope_pos_ids_inplace(
     """
     if rotary_dim is None:
         rotary_dim = q.size(-1)
-    if rotary_dim > q.size(-1):
+    if rotary_dim > min(q.size(-1), k.size(-1)):
         raise ValueError(
-            f"head_dim ({q.size(-1)}) must be >= rotary_dim ({rotary_dim})"
+            f"head_dim (q={q.size(-1)}, k={k.size(-1)}) must be >= rotary_dim ({rotary_dim})"
         )
     _apply_rope_pos_ids(
         q, k, q, k, pos_ids, rotary_dim, interleave, rope_scale, rope_theta
@@ -676,9 +676,9 @@ def apply_llama31_rope_inplace(
     """
     if rotary_dim is None:
         rotary_dim = q.size(-1)
-    if rotary_dim > q.size(-1):
+    if rotary_dim > min(q.size(-1), k.size(-1)):
         raise ValueError(
-            f"head_dim ({q.size(-1)}) must be >= rotary_dim ({rotary_dim})"
+            f"head_dim (q={q.size(-1)}, k={k.size(-1)}) must be >= rotary_dim ({rotary_dim})"
         )
     _apply_llama31_rope(
         q,
@@ -760,9 +760,9 @@ def apply_llama31_rope_pos_ids_inplace(
     """
     if rotary_dim is None:
         rotary_dim = q.size(-1)
-    if rotary_dim > q.size(-1):
+    if rotary_dim > min(q.size(-1), k.size(-1)):
         raise ValueError(
-            f"head_dim ({q.size(-1)}) must be >= rotary_dim ({rotary_dim})"
+            f"head_dim (q={q.size(-1)}, k={k.size(-1)}) must be >= rotary_dim ({rotary_dim})"
         )
     _apply_llama31_rope_pos_ids(
         q,

--- a/include/flashinfer/pos_enc.cuh
+++ b/include/flashinfer/pos_enc.cuh
@@ -1394,6 +1394,15 @@ cudaError_t BatchQKApplyRotaryPosIds(
     size_t q_stride_n, size_t q_stride_h, size_t k_stride_n, size_t k_stride_h,
     size_t q_rope_stride_n, size_t q_rope_stride_h, size_t k_rope_stride_n, size_t k_rope_stride_h,
     bool interleave, float rope_scale, float rope_theta, cudaStream_t stream = nullptr) {
+  // Fail fast on rotary_dim > head_dim: the RoPE kernel reads x + rotary_dim/2,
+  // which would land past this head's data in the next head/token — silent
+  // cross-head corruption (no crash/NaN, just wrong attention output downstream).
+  if (head_dim < rotary_dim) {
+    std::ostringstream err_msg;
+    err_msg << "head_dim (" << head_dim << ") must be >= rotary_dim (" << rotary_dim << ")";
+    FLASHINFER_ERROR(err_msg.str());
+  }
+
   float rope_rcp_scale = 1.0f / rope_scale;
   float rope_rcp_theta = 1.0f / rope_theta;
   float smooth_a = 0.f;
@@ -1467,6 +1476,15 @@ cudaError_t BatchQKApplyRotary(DType* q, DType* k, DType* q_rope, DType* k_rope,
                                size_t q_rope_stride_n, size_t q_rope_stride_h,
                                size_t k_rope_stride_n, size_t k_rope_stride_h, bool interleave,
                                float rope_scale, float rope_theta, cudaStream_t stream = nullptr) {
+  // Fail fast on rotary_dim > head_dim: the RoPE kernel reads x + rotary_dim/2,
+  // which would land past this head's data in the next head/token — silent
+  // cross-head corruption (no crash/NaN, just wrong attention output downstream).
+  if (head_dim < rotary_dim) {
+    std::ostringstream err_msg;
+    err_msg << "head_dim (" << head_dim << ") must be >= rotary_dim (" << rotary_dim << ")";
+    FLASHINFER_ERROR(err_msg.str());
+  }
+
   float rope_rcp_scale = 1.0f / rope_scale;
   float rope_rcp_theta = 1.0f / rope_theta;
   float smooth_a = 0.f;
@@ -1518,6 +1536,15 @@ cudaError_t BatchQKApplyRotaryInPlace(DType* __restrict__ q, DType* __restrict__
                                       size_t q_stride_n, size_t q_stride_h, size_t k_stride_n,
                                       size_t k_stride_h, bool interleave, float rope_scale,
                                       float rope_theta, cudaStream_t stream = nullptr) {
+  // Fail fast on rotary_dim > head_dim: the RoPE kernel reads x + rotary_dim/2,
+  // which would land past this head's data in the next head/token — silent
+  // cross-head corruption (no crash/NaN, just wrong attention output downstream).
+  if (head_dim < rotary_dim) {
+    std::ostringstream err_msg;
+    err_msg << "head_dim (" << head_dim << ") must be >= rotary_dim (" << rotary_dim << ")";
+    FLASHINFER_ERROR(err_msg.str());
+  }
+
   return BatchQKApplyRotary<DType, IdType>(
       q, k, q, k, indptr, offsets, batch_size, num_qo_heads, num_kv_heads, rotary_dim, head_dim,
       q_stride_n, q_stride_h, k_stride_n, k_stride_h, q_stride_n, q_stride_h, k_stride_n,
@@ -1533,6 +1560,15 @@ cudaError_t BatchQKApplyLlama31Rotary(
     size_t k_rope_stride_h, bool interleave, float rope_scale, float rope_theta,
     float low_freq_factor, float high_freq_factor, float old_context_length,
     cudaStream_t stream = nullptr) {
+  // Fail fast on rotary_dim > head_dim: the RoPE kernel reads x + rotary_dim/2,
+  // which would land past this head's data in the next head/token — silent
+  // cross-head corruption (no crash/NaN, just wrong attention output downstream).
+  if (head_dim < rotary_dim) {
+    std::ostringstream err_msg;
+    err_msg << "head_dim (" << head_dim << ") must be >= rotary_dim (" << rotary_dim << ")";
+    FLASHINFER_ERROR(err_msg.str());
+  }
+
   float rope_rcp_scale = 1.0f / rope_scale;
   float rope_rcp_theta = 1.0f / rope_theta;
   float smooth_a = old_context_length / (2 * M_PI * high_freq_factor - 2 * M_PI * low_freq_factor);
@@ -1584,6 +1620,15 @@ cudaError_t BatchQKApplyLlama31RotaryPosIds(
     size_t q_rope_stride_n, size_t q_rope_stride_h, size_t k_rope_stride_n, size_t k_rope_stride_h,
     bool interleave, float rope_scale, float rope_theta, float low_freq_factor,
     float high_freq_factor, float old_context_length, cudaStream_t stream = nullptr) {
+  // Fail fast on rotary_dim > head_dim: the RoPE kernel reads x + rotary_dim/2,
+  // which would land past this head's data in the next head/token — silent
+  // cross-head corruption (no crash/NaN, just wrong attention output downstream).
+  if (head_dim < rotary_dim) {
+    std::ostringstream err_msg;
+    err_msg << "head_dim (" << head_dim << ") must be >= rotary_dim (" << rotary_dim << ")";
+    FLASHINFER_ERROR(err_msg.str());
+  }
+
   float rope_rcp_scale = 1.0f / rope_scale;
   float rope_rcp_theta = 1.0f / rope_theta;
   float smooth_a = old_context_length / (2 * M_PI * high_freq_factor - 2 * M_PI * low_freq_factor);

--- a/tests/test_rope_rotary_dim_bound.py
+++ b/tests/test_rope_rotary_dim_bound.py
@@ -1,0 +1,80 @@
+"""
+Regression test for the ``rotary_dim <= head_dim`` guard in the RoPE launchers.
+
+When ``rotary_dim > head_dim`` the RoPE kernel reads past the current head's data
+(``x + rotary_dim/2``) into the next head/token, producing silently wrong attention
+output (no crash, no NaN).  The Python wrappers now raise ``ValueError`` before any
+kernel/JIT work; this test exercises that guard for every public RoPE entry point.
+
+The bad-path assertions run without a GPU because the guard fires pre-kernel.  The
+happy path (``rotary_dim == head_dim``) drives the kernel and therefore needs CUDA.
+"""
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+import flashinfer  # noqa: E402
+
+HEAD_DIM = 64
+
+
+def _rope_inputs(device, dtype=torch.float16):
+    """Minimal q/k/indptr/offsets/pos_ids tensors for head_dim=HEAD_DIM."""
+    nnz, nq, nk = 2, 2, 2
+    q = torch.zeros((nnz, nq, HEAD_DIM), dtype=dtype, device=device)
+    k = torch.zeros((nnz, nk, HEAD_DIM), dtype=dtype, device=device)
+    indptr = torch.tensor([0, nnz], dtype=torch.int32, device=device)
+    offsets = torch.zeros((nnz,), dtype=torch.int32, device=device)
+    pos_ids = torch.arange(nnz, dtype=torch.int32, device=device)
+    return q, k, indptr, offsets, pos_ids
+
+
+def _call_apply_rope_inplace(rotary_dim, device):
+    q, k, indptr, offsets, _ = _rope_inputs(device)
+    flashinfer.apply_rope_inplace(q, k, indptr, offsets, rotary_dim=rotary_dim)
+
+
+def _call_apply_rope_pos_ids_inplace(rotary_dim, device):
+    q, k, _, _, pos_ids = _rope_inputs(device)
+    flashinfer.apply_rope_pos_ids_inplace(q, k, pos_ids, rotary_dim=rotary_dim)
+
+
+def _call_apply_llama31_rope_inplace(rotary_dim, device):
+    q, k, indptr, offsets, _ = _rope_inputs(device)
+    flashinfer.apply_llama31_rope_inplace(q, k, indptr, offsets, rotary_dim=rotary_dim)
+
+
+def _call_apply_llama31_rope_pos_ids_inplace(rotary_dim, device):
+    q, k, _, _, pos_ids = _rope_inputs(device)
+    flashinfer.apply_llama31_rope_pos_ids_inplace(q, k, pos_ids, rotary_dim=rotary_dim)
+
+
+WRAPPERS = [
+    ("apply_rope_inplace", _call_apply_rope_inplace),
+    ("apply_rope_pos_ids_inplace", _call_apply_rope_pos_ids_inplace),
+    ("apply_llama31_rope_inplace", _call_apply_llama31_rope_inplace),
+    ("apply_llama31_rope_pos_ids_inplace", _call_apply_llama31_rope_pos_ids_inplace),
+]
+WRAPPER_IDS = [name for name, _ in WRAPPERS]
+
+
+@pytest.mark.parametrize("rotary_dim", [128, 192])
+@pytest.mark.parametrize("name,caller", WRAPPERS, ids=WRAPPER_IDS)
+def test_rotary_dim_exceeds_head_dim_raises(name, caller, rotary_dim):
+    # The guard fires before any kernel/JIT work, so this runs without a GPU.
+    with pytest.raises(ValueError, match=r"head_dim .* must be >= rotary_dim"):
+        caller(rotary_dim, device="cpu")
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available(), reason="needs GPU for kernel"
+)
+@pytest.mark.parametrize("name,caller", WRAPPERS, ids=WRAPPER_IDS)
+def test_rotary_dim_equal_head_dim_does_not_raise_bound(name, caller):
+    # rotary_dim == head_dim: the bound guard must NOT fire. The kernel itself
+    # needs a CUDA tensor to run, hence the skip above.
+    try:
+        caller(HEAD_DIM, device="cuda")
+    except ValueError as e:
+        pytest.fail(f"bound guard fired for {name} with rotary_dim==head_dim: {e}")

--- a/tests/test_rope_rotary_dim_bound.py
+++ b/tests/test_rope_rotary_dim_bound.py
@@ -67,9 +67,7 @@ def test_rotary_dim_exceeds_head_dim_raises(name, caller, rotary_dim):
         caller(rotary_dim, device="cpu")
 
 
-@pytest.mark.skipif(
-    not torch.cuda.is_available(), reason="needs GPU for kernel"
-)
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="needs GPU for kernel")
 @pytest.mark.parametrize("name,caller", WRAPPERS, ids=WRAPPER_IDS)
 def test_rotary_dim_equal_head_dim_does_not_raise_bound(name, caller):
     # rotary_dim == head_dim: the bound guard must NOT fire. The kernel itself
@@ -78,3 +76,57 @@ def test_rotary_dim_equal_head_dim_does_not_raise_bound(name, caller):
         caller(HEAD_DIM, device="cuda")
     except ValueError as e:
         pytest.fail(f"bound guard fired for {name} with rotary_dim==head_dim: {e}")
+
+
+def _mismatched_rope_inputs(device, dtype=torch.float16):
+    """q.head_dim=128, k.head_dim=64: the bound guard must consider min(q, k),
+    not just q, or the K path reads past one K head (silent cross-head corruption)."""
+    nnz, nq, nk = 2, 2, 2
+    q = torch.zeros((nnz, nq, 128), dtype=dtype, device=device)
+    k = torch.zeros((nnz, nk, 64), dtype=dtype, device=device)
+    indptr = torch.tensor([0, nnz], dtype=torch.int32, device=device)
+    offsets = torch.zeros((nnz,), dtype=torch.int32, device=device)
+    pos_ids = torch.arange(nnz, dtype=torch.int32, device=device)
+    return q, k, indptr, offsets, pos_ids
+
+
+def _call_mismatched_apply_rope_inplace(device):
+    q, k, indptr, offsets, _ = _mismatched_rope_inputs(device)
+    flashinfer.apply_rope_inplace(q, k, indptr, offsets, rotary_dim=128)
+
+
+def _call_mismatched_apply_rope_pos_ids_inplace(device):
+    q, k, _, _, pos_ids = _mismatched_rope_inputs(device)
+    flashinfer.apply_rope_pos_ids_inplace(q, k, pos_ids, rotary_dim=128)
+
+
+def _call_mismatched_apply_llama31_rope_inplace(device):
+    q, k, indptr, offsets, _ = _mismatched_rope_inputs(device)
+    flashinfer.apply_llama31_rope_inplace(q, k, indptr, offsets, rotary_dim=128)
+
+
+def _call_mismatched_apply_llama31_rope_pos_ids_inplace(device):
+    q, k, _, _, pos_ids = _mismatched_rope_inputs(device)
+    flashinfer.apply_llama31_rope_pos_ids_inplace(q, k, pos_ids, rotary_dim=128)
+
+
+MISMATCHED_WRAPPERS = [
+    ("apply_rope_inplace", _call_mismatched_apply_rope_inplace),
+    ("apply_rope_pos_ids_inplace", _call_mismatched_apply_rope_pos_ids_inplace),
+    ("apply_llama31_rope_inplace", _call_mismatched_apply_llama31_rope_inplace),
+    (
+        "apply_llama31_rope_pos_ids_inplace",
+        _call_mismatched_apply_llama31_rope_pos_ids_inplace,
+    ),
+]
+MISMATCHED_IDS = [name for name, _ in MISMATCHED_WRAPPERS]
+
+
+@pytest.mark.parametrize("name,caller", MISMATCHED_WRAPPERS, ids=MISMATCHED_IDS)
+def test_rotary_dim_exceeds_k_head_dim_raises_on_mismatched_qk(name, caller):
+    # [P1] lazypool: the bound guard previously checked q only, so q.head_dim=128,
+    # k.head_dim=64, rotary_dim=128 passed the guard and the K path read past one
+    # K head (the stated silent cross-head corruption). The guard must consider
+    # min(q, k). Runs without a GPU because the guard fires pre-kernel.
+    with pytest.raises(ValueError, match=r"head_dim .* must be >= rotary_dim"):
+        caller(device="cpu")


### PR DESCRIPTION
## 📌 Description

Adds a `head_dim < rotary_dim` guard to the 5 RoPE launchers that were missing it, mirroring the guard already present in `BatchQKApplyRotaryPosIdsCosSinCache` (`include/flashinfer/pos_enc.cuh:1301`).

**Why this matters:** the RoPE kernel `vec_apply_llama_rope` (`pos_enc.cuh:107-126`) computes `x + rotary_dim/2` with no bounds check. When `rotary_dim > head_dim` (a misconfiguration that is easy to hit when porting partial-RoPE configs between HF and vLLM — e.g. `rotary_dim=192` on a `head_dim=128` tensor), the offset reads past the current head's data into the adjacent head/token. The result is **silent cross-head corruption**: no crash, no NaN — just wrong attention output downstream, which is far harder to diagnose than a clear error.

Only 1 of the 6 RoPE launchers (`BatchQKApplyRotaryPosIdsCosSinCache`) currently guards this. This PR propagates that exact guard to the 5 siblings:

- `BatchQKApplyRotaryPosIds`
- `BatchQKApplyRotary`
- `BatchQKApplyRotaryInPlace`
- `BatchQKApplyLlama31Rotary`
- `BatchQKApplyLlama31RotaryPosIds`

The C++ guard is mirrored byte-for-byte from the existing one (`FLASHINFER_ERROR` + `std::ostringstream`, same message wording), placed at the top of each launcher body before any kernel dispatch. A matching host-side `ValueError` is also added to the 4 public Python wrappers in `flashinfer/rope.py` so Python callers get a clear error before any JIT/kernel launch.

## 🔍 Related Issues

Refs #4312 (the prefill `head_dim` validation PR) — same class of "validate head_dim/rotary_dim at the launch boundary" fix; this covers the RoPE side that #4312 does not touch. No filed issue exists for the RoPE `rotary_dim` gap specifically — the corruption is silent, so it tends to be attributed to model weights/config rather than the kernel.

## 🚀 Pull Request Checklist

### ✅ Pre-commit Checks

- [x] `ruff check` passes on the changed Python files (`flashinfer/rope.py`, `tests/test_rope_rotary_dim_bound.py`); `pos_enc.cuh` is C++ (out of ruff scope).
- [ ] Full `pre-commit run --all-files` (mypy / codespell / clang-format) deferred to CI — no local toolchain for the CUDA/mypy parts.

> Note: I am not on the `ci-users` team, so public CI will not auto-trigger — requesting `run-ci` (or `@flashinfer-bot run`) for the GPU test matrix.

## 🧪 Tests

- [x] Tests added: `tests/test_rope_rotary_dim_bound.py` — parametrized over all 4 public Python wrappers; the bad-path (`rotary_dim` 128/192 with `head_dim=64`) asserts `ValueError` (runs without a GPU — the Python guard fires pre-kernel); the happy-path (`rotary_dim == head_dim == 64`) is `skipif(not torch.cuda.is_available())` since it drives the kernel.
- [x] `python3 -m py_compile` passes on the changed files.

## Reviewer Notes

- The guard is mechanical and byte-identical to the existing `BatchQKApplyRotaryPosIdsCosSinCache` guard (`pos_enc.cuh:1301`), so review should be short — it is "propagate the guard the team already wrote to the 5 launchers that missed it."
- `BatchQKApplyRotaryInPlace` delegates to `BatchQKApplyRotary`, so the guard on the latter already covers the in-place path; I added it to the in-place entry too as defense-in-depth at the public boundary. Happy to drop that one if you would prefer a single source of truth.
- The C++ guards are a backstop for direct TVM-FFI / JAX callers; the Python guards cover the common Python-API path. Both layers mirror each other.
- Pre-empting the "this is just user error" concern: agreed that `rotary_dim > head_dim` is a caller misconfiguration, but the cost of a host-side bounds check (one comparison per launch) is negligible, and the alternative — silently wrong attention output attributed to model weights — is materially worse for users debugging partial-RoPE setups. The existing `BatchQKApplyRotaryPosIdsCosSinCache` guard (line 1301) already encodes this judgment; this PR just makes it consistent across the RoPE surface.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to rotary position embedding operations to reject configurations where `rotary_dim` exceeds the query or key head dimension.
  * Errors are now reported before processing begins, preventing invalid execution and improving clarity.
  * Valid configurations where `rotary_dim` equals the head dimension continue to work as expected.

* **Tests**
  * Added regression coverage for invalid, boundary, and mismatched query/key head-dimension configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->