### PR TITLE
fix(build): avoid package installs from build hooks

### DIFF
--- a/build_backend.py
+++ b/build_backend.py
@@ -109,10 +109,9 @@ def _in_isolated_build_env() -> bool:
 
     pip's isolated build envs live in a ``pip-build-env-*`` temp dir injected
     on sys.path; uv's ephemeral build envs live under a ``builds-v0`` cache
-    dir. In such an env, wheels installed by this hook (nixl-cu13) vanish
-    when the build finishes and never reach the user's target environment —
-    and the env usually has no ``pip`` module at all, so the installs fail
-    outright. The moe_ep build path therefore needs --no-build-isolation.
+    dir. Such an environment cannot inspect runtime distributions installed in
+    the user's target environment. The moe_ep build path therefore needs
+    --no-build-isolation when it consumes target-environment dependencies.
     """
     markers = ("pip-build-env-", f"{os.sep}builds-v0{os.sep}")
     paths = [sys.prefix, *sys.path]
@@ -246,9 +245,9 @@ def _build_nixl_ep() -> None:
         wheel_lib_dir = _find_nixl_wheel_lib_dir()
         if wheel_lib_dir is None:
             raise RuntimeError(
-                "The NIXL-EP build requires the nixl-cu13 wheel (the build "
-                "hook normally pre-installs it; see _ensure_nixl_wheel).\n"
-                "Run: uv pip install --no-deps 'nixl-cu13>=1.3.1'\n"
+                "The NIXL-EP build requires the nixl-cu13 wheel. Declare "
+                "nixl-cu13>=1.3.1 in package metadata or the owning "
+                "environment manager before building.\n"
                 "Or set BUILD_NIXL_EP_HERMETIC=1 to build the full NIXL tree."
             )
         setup_args += [
@@ -282,7 +281,7 @@ def _build_nixl_ep() -> None:
 
     # We do NOT stage the base NIXL libraries (libnixl.so, libnixl_capi.so,
     # libserdes.so, etc.) — they come from the `nixl-cu13` pip wheel installed
-    # by _install_nvep_runtime_wheels(). The runtime loader in
+    # by the owning package or environment manager. The runtime loader in
     # flashinfer/moe_ep/backends/split/comm/nixl_ep/__init__.py ctypes-preloads them via the wheel's
     # site-packages path before loading nixl_ep_cpp.so. This keeps the
     # FlashInfer wheel small.
@@ -463,7 +462,7 @@ def _build_nccl_ep() -> None:
     dst = _moe_ep_pkg / "backends" / "split" / "comm" / "nccl_ep" / "_libs"
     dst.mkdir(parents=True, exist_ok=True)
     # We do NOT stage libnccl.so.2 — it comes from the `nvidia-nccl-cu13`
-    # pip wheel installed by _install_nvep_runtime_wheels(). The runtime
+    # pip wheel installed by the owning package or environment manager. The runtime
     # loader in flashinfer/moe_ep/backends/split/comm/nccl_ep/__init__.py ctypes-preloads it
     # via the wheel's site-packages path before loading libnccl_ep.so.
     # This keeps the FlashInfer wheel ~200 MB smaller.
@@ -523,75 +522,6 @@ def _fix_rpaths() -> None:
             print(f"[BUILD_NVEP] WARNING: patchelf failed on {so.name}: {err}")
 
 
-def _ensure_nixl_wheel() -> None:
-    """Pre-install the nixl-cu* wheel the NIXL-EP build links against.
-
-    The default (non-hermetic) NIXL-EP build links nixl_ep_cpp.so against the
-    libnixl.so shipped by the `nixl-cu13` pip wheel. Since the EP build now
-    runs by default on `pip install .`, install that wheel up front instead of
-    requiring users to pre-install it. `--no-deps` for the same reason as
-    _install_nvep_runtime_wheels: the wheel's transitive constraints downgrade
-    torch. Best-effort: on failure the _nixl_buildable probe reports the
-    missing wheel and the backend is gated as usual (skip or hard error).
-    """
-    if _find_nixl_wheel_lib_dir() is not None:
-        return
-    cuda_major = _detect_cuda_major()
-    wheel = f"nixl-cu{cuda_major}>=1.3.1"
-    print(f"[BUILD_NVEP] pre-installing NIXL wheel --no-deps: {wheel}")
-
-    uv_bin = shutil.which("uv")
-    if uv_bin:
-        cmd = [uv_bin, "pip", "install", "--python", sys.executable, "--no-deps", wheel]
-    else:
-        cmd = [sys.executable, "-m", "pip", "install", "--no-deps", wheel]
-    print(f"[BUILD_NVEP] $ {' '.join(cmd)}")
-    try:
-        subprocess.run(cmd, check=True)
-    except (subprocess.CalledProcessError, FileNotFoundError) as e:
-        print(
-            f"[BUILD_NVEP] WARNING: could not pre-install {wheel} ({e}); "
-            "the NIXL-EP pre-flight probe will decide whether to skip or fail."
-        )
-
-
-def _ensure_nccl_floor() -> None:
-    """Best-effort upgrade of nvidia-nccl-cu13 to the B200 EP floor (>=2.30.7).
-
-    Deliberately NOT a base dependency: torch's cu13 wheels pin
-    nvidia-nccl-cu13 EXACTLY (e.g. ==2.29.7), so declaring a >=2.30.7 floor
-    in package metadata makes pip's resolver evict torch — on aarch64 it
-    backtracks to the CPU-only torch wheel. Installing here with --no-deps
-    (mirroring the nixl-cu13 pattern) upgrades the wheel without ever
-    entering the resolver. Failures only warn: torch's own NCCL is
-    sufficient everywhere except NCCL-EP group-create on B200, and
-    moe_ep/_validators.py enforces the floor at runtime with an actionable
-    error where it actually matters.
-    """
-    cuda_major = _detect_cuda_major()
-    if cuda_major < 13:
-        return  # EP is CUDA-13-only; nothing to upgrade on cu12 hosts.
-    wheel = "nvidia-nccl-cu13>=2.30.7"
-    print(f"[BUILD_NVEP] ensuring NCCL-EP floor --no-deps: {wheel}")
-
-    uv_bin = shutil.which("uv")
-    if uv_bin:
-        cmd = [uv_bin, "pip", "install", "--python", sys.executable, "--no-deps", wheel]
-    else:
-        cmd = [sys.executable, "-m", "pip", "install", "--no-deps", wheel]
-    print(f"[BUILD_NVEP] $ {' '.join(cmd)}")
-    try:
-        subprocess.run(cmd, check=True)
-    except (subprocess.CalledProcessError, FileNotFoundError) as e:
-        print(
-            f"[BUILD_NVEP] WARNING: could not install {wheel} ({e}). "
-            "NCCL-EP on B200 needs NCCL >= 2.30.7 (group-create fails on "
-            "older releases); the runtime validator will raise there. "
-            "Install manually if needed: pip install --no-deps "
-            f"'{wheel}'"
-        )
-
-
 def _nixl_buildable() -> tuple[bool, str]:
     """Probe for hard NIXL-EP build-time deps. Returns (ok, reason_if_not).
 
@@ -627,164 +557,11 @@ def _nixl_buildable() -> tuple[bool, str]:
     if not _flag("BUILD_NIXL_EP_HERMETIC"):
         if _find_nixl_wheel_lib_dir() is None:
             return False, (
-                "nixl pip wheel not importable (or libnixl.so missing); install with "
-                "`uv pip install --no-deps 'nixl-cu13>=1.3.1'` "
-                "or set BUILD_NIXL_EP_HERMETIC=1 to build the full NIXL tree"
+                f"nixl-cu{_detect_cuda_major()}>=1.3.1 is not importable or "
+                "does not contain libnixl.so; "
+                "set BUILD_NIXL_EP_HERMETIC=1 to build the full NIXL tree"
             )
     return True, ""
-
-
-def _install_nvep_runtime_wheels(built_nixl: bool) -> None:
-    """Install the NIXL runtime wheel with --no-deps when NIXL-EP was built.
-
-    The wheel supplies the BASE libraries (libnixl.so + siblings) that the
-    nixl_ep_cpp.so plugin dynamically loads at runtime. We do NOT stage the
-    base libs into the FlashInfer package tree — relying on the pip wheel
-    keeps the wheel small and avoids the duplication. (NCCL-EP's libnccl
-    comes from torch's own nvidia-nccl-cu13 pin; see _ensure_nccl_floor.)
-
-    The wheel carries transitive constraints (e.g. an nvidia-nccl-cu12 pin via
-    the `nixl` meta-package) that conflict with a recent torch and force a
-    downgrade when resolved normally. SGLang's Dockerfile mirrors this with
-    `pip install nixl nixl-cu13 --no-deps`; we do the same.
-
-    Two pip backends are tried, in order:
-      1. `uv pip install` — works in venvs created by `uv venv` (which have
-         no pip module). This is the path most users hit.
-      2. `python -m pip install` — for venvs with pip seeded.
-
-    Gated on what was ACTUALLY built (not what was requested), so `pip list`
-    stays honest when the backend was skipped due to missing build-time deps
-    in best-effort mode.
-
-    This step is FATAL on failure. Since we no longer stage the base libs, a
-    half-installed env where the wheel failed to install would leave the EP
-    plugin unable to load at runtime. Better to fail loudly at install time.
-    """
-    cuda_major = _detect_cuda_major()
-    wheels: list[str] = []
-    if built_nixl:
-        wheels.append(f"nixl-cu{cuda_major}>=1.3.1")
-    if not wheels:
-        return
-
-    print(f"[BUILD_NVEP] installing runtime wheels --no-deps: {' '.join(wheels)}")
-
-    # Prefer uv (works in a uv-created venv that has no pip module).
-    uv_bin = shutil.which("uv")
-    if uv_bin:
-        cmd = [
-            uv_bin,
-            "pip",
-            "install",
-            "--python",
-            sys.executable,
-            "--no-deps",
-            *wheels,
-        ]
-        print(f"[BUILD_NVEP] $ {' '.join(cmd)}")
-        subprocess.run(cmd, check=True)
-        return
-
-    # Fall back to python -m pip (requires pip in the venv).
-    cmd = [sys.executable, "-m", "pip", "install", "--no-deps", *wheels]
-    print(f"[BUILD_NVEP] $ {' '.join(cmd)}")
-    try:
-        subprocess.run(cmd, check=True)
-    except subprocess.CalledProcessError as e:
-        raise RuntimeError(
-            "Failed to install moe_ep runtime wheels and `uv` is not on "
-            "PATH. Either install uv (https://docs.astral.sh/uv/) so the "
-            "build hook can use `uv pip install`, or `--seed` your venv so "
-            "it has a pip module. The wheels we tried to install: "
-            f"{wheels}"
-        ) from e
-
-
-def _install_cuda_tile_compile_deps() -> None:
-    """Install cuda-tile's compile chain with ``--no-deps`` to dodge libcudart.so.13.
-
-    Background: ``cuda-tile[tileiras]>=1.4.0`` transitively pulls
-    ``cuda-toolkit[nvcc,nvvm,tileiras]<13.4,>=13.2``, which in turn pulls
-    ``nvidia-cuda-runtime==13.3.*`` (libcudart.so.13). That conflicts at
-    *cudnn import* time with ``nvidia-cuda-runtime-cu12`` (libcudart.so.12)
-    shipped by torch — cudnn's helper raises ``Multiple libcudart libraries
-    found: libcudart.so.12 and libcudart.so.13`` and every cudnn_decode /
-    cudnn_prefill test in the suite fails.
-
-    To work around this we drop the ``[tileiras]`` extra from
-    ``requirements.txt`` and instead install the compile-side wheels here
-    with ``--no-deps``. The chain (nvcc + tileiras + nvvm + nvjitlink + crt)
-    doesn't need libcudart at *compile* time — nvcc emits PTX/cubin; cubins
-    run against whatever libcudart torch ships (cu12) at *test* time. So
-    skipping the transitive ``nvidia-cuda-runtime`` (cu13) install is safe.
-
-    Mirrors ``_install_nvep_runtime_wheels`` for the uv-first / pip-fallback
-    path.
-
-    Best-effort — PEP 517 build isolation limits what we can install here.
-    When ``pip install`` runs without ``--no-build-isolation`` (the default),
-    pip creates a **clean isolated build environment** that contains only the
-    declared build dependencies (such as ``setuptools`` and ``packaging``) and
-    does *not* include ``pip`` itself or ``uv``.  As a result, we cannot invoke
-    ``pip install`` from within that environment to resolve the
-    ``nvidia-cuda-runtime`` version conflict described above.
-
-    In such isolated builds (e.g. the AOT Build Import workflow) the compile
-    chain is already present on flashinfer-ci images, so we *warn and continue*
-    instead of blocking the build.  A clean PyPI install on a system that lacks
-    both ``uv`` and the compile chain will surface a clear ``ImportError`` the
-    first time the user calls a cuTile kernel — a better failure mode than
-    aborting the install entirely.
-    """
-    wheels = [
-        "nvidia-cuda-nvcc<13.4,>=13.2",
-        "nvidia-cuda-tileiras<13.4,>=13.2",
-        "nvidia-nvvm<13.4,>=13.2",
-        "nvidia-nvjitlink<14,>=13.3",
-        "nvidia-cuda-crt<13.4,>=13.2",
-    ]
-    print(f"[BUILD] cuda-tile compile deps (--no-deps): {' '.join(wheels)}", flush=True)
-
-    uv_bin = shutil.which("uv")
-    if uv_bin:
-        cmd = [
-            uv_bin,
-            "pip",
-            "install",
-            "--python",
-            sys.executable,
-            "--no-deps",
-            *wheels,
-        ]
-        print(f"[BUILD] $ {' '.join(cmd)}", flush=True)
-        try:
-            subprocess.run(cmd, check=True)
-        except subprocess.CalledProcessError as e:
-            print(
-                f"[BUILD] WARNING: uv pip install of cuda-tile compile deps "
-                f"failed ({e}); continuing — wheels may already be present.",
-                flush=True,
-            )
-        return
-
-    cmd = [sys.executable, "-m", "pip", "install", "--no-deps", *wheels]
-    print(f"[BUILD] $ {' '.join(cmd)}", flush=True)
-    try:
-        subprocess.run(cmd, check=True)
-    except (subprocess.CalledProcessError, FileNotFoundError) as e:
-        # PEP 517 isolated build envs (the default when ``pip install -e .`` is
-        # invoked without ``--no-build-isolation``) have no ``pip`` module and
-        # no ``uv``. Don't block the build — log and continue. The compile
-        # chain is preinstalled in flashinfer-ci images, and a clean PyPI
-        # install would surface a clear ImportError at first cuTile use.
-        print(
-            f"[BUILD] WARNING: could not install cuda-tile compile deps "
-            f"(no `uv` on PATH and no `pip` module in this venv: {e}). "
-            f"Skipping — install these wheels manually if cuTile JIT compile "
-            f"fails at runtime: {wheels}",
-            flush=True,
-        )
 
 
 def _gate_backend(name: str, requested: bool, probe) -> bool:
@@ -827,15 +604,12 @@ def _build_nvep_if_enabled() -> None:
 
     if _BUILD_NIXL_EP and _in_isolated_build_env():
         print(
-            "[BUILD_NVEP] WARNING: PEP 517 build isolation detected. Wheels "
-            "installed by this hook (nixl-cu13) land in the throwaway build "
-            "env — the NIXL-EP build will most likely be skipped, and even "
-            "if it succeeds its runtime wheel will NOT persist into the "
-            "target environment. To enable NIXL-EP when installing from "
-            "source, disable isolation:\n"
+            "[BUILD_NVEP] WARNING: PEP 517 build isolation detected. The "
+            "build backend cannot inspect nixl-cu13 from the target "
+            "environment, so the NIXL-EP build will most likely be skipped. "
+            "Declare its dependencies before building and disable isolation:\n"
             "    pip install --no-build-isolation .\n"
-            "If NIXL-EP libs were still staged, install the runtime wheel "
-            "manually afterwards: pip install --no-deps 'nixl-cu13>=1.3.1'.",
+            "The build backend never installs into the target environment.",
             flush=True,
         )
 
@@ -848,15 +622,6 @@ def _build_nvep_if_enabled() -> None:
             "[BUILD_NVEP] NCCL-EP is provided by the nccl4py wheel (>=0.3.1), "
             "a base dependency of flashinfer-python; no in-tree build."
         )
-        # torch's cu13 wheels pin nvidia-nccl-cu13 exactly (< the B200 EP
-        # floor), so upgrade it out-of-band; best-effort by design.
-        _ensure_nccl_floor()
-
-    # The default (non-hermetic) NIXL-EP build links against the nixl-cu13
-    # wheel's libnixl.so — install it up front so plain `pip install .` works
-    # without a manual pre-install step.
-    if _BUILD_NIXL_EP and not _flag("BUILD_NIXL_EP_HERMETIC"):
-        _ensure_nixl_wheel()
 
     # Pre-flight gating — probe the NIXL-EP build-time deps (NCCL-EP needs none).
     will_build_nixl = _gate_backend("NIXL-EP", _BUILD_NIXL_EP, _nixl_buildable)
@@ -902,8 +667,6 @@ def _build_nvep_if_enabled() -> None:
     if built_nixl:
         with _time_phase("_fix_rpaths"):
             _fix_rpaths()
-        with _time_phase("_install_nvep_runtime_wheels"):
-            _install_nvep_runtime_wheels(built_nixl=built_nixl)
 
     print(
         f"[BUILD_NVEP] total build phase wall time: "
@@ -1004,7 +767,6 @@ def _create_data_dir(use_symlinks=True):
 
 def _prepare_for_wheel():
     # For wheel, copy actual files instead of symlinks so they are included in the wheel
-    _install_cuda_tile_compile_deps()
     _build_nvep_if_enabled()
     if _data_dir.exists():
         shutil.rmtree(_data_dir)
@@ -1022,7 +784,6 @@ def _prepare_for_wheel():
 
 def _prepare_for_editable():
     # For editable install, use symlinks so changes are reflected immediately
-    _install_cuda_tile_compile_deps()
     _build_nvep_if_enabled()
     if _data_dir.exists():
         shutil.rmtree(_data_dir)

--- a/docker/Dockerfile.flashinfer-nvep
+++ b/docker/Dockerfile.flashinfer-nvep
@@ -132,13 +132,11 @@ RUN uv pip install --python ${VENV}/bin/python \
 #
 # --no-deps is mandatory: nvidia-nccl-cu13's transitive constraints would
 # downgrade torch, and nixl-cu13 transitively pulls nvidia-nccl-cu12 which
-# conflicts with the cu13 wheel above. Build_backend._install_nvep_runtime_wheels
-# also does this install during the BUILD_NVEP step; this explicit line in
-# the Dockerfile is the documented dep declaration. Both calls are
-# idempotent — the second one no-ops if the >= constraint is already met.
+# conflicts with the cu13 wheel above. The build backend consumes these
+# dependencies but never installs them.
 RUN uv pip install --python ${VENV}/bin/python --no-deps \
-        'nixl-cu13>=1.0.1' \
-        'nvidia-nccl-cu13>=2.30.4'
+        'nixl-cu13>=1.3.1' \
+        'nvidia-nccl-cu13>=2.30.7'
 
 # Build & install FlashInfer + moe_ep backends.
 # --no-build-isolation tells uv to use the target venv (above) for the build

--- a/docker/install/build_flashinfer_ep_pytorch.sh
+++ b/docker/install/build_flashinfer_ep_pytorch.sh
@@ -75,9 +75,6 @@ PIP_CONSTRAINT="" python -m pip install --no-cache-dir \
 echo "== build & install FlashInfer (NCCL-EP + Mega path) =="
 # The EP backends are ON by default now: NCCL-EP needs no build step (nccl4py
 # is a base dependency of flashinfer-python), so only NIXL-EP is opted out.
-# PIP_CONSTRAINT= so the build hook's --no-deps NCCL floor upgrade
-# (_ensure_nccl_floor, nvidia-nccl-cu13>=2.30.7) isn't blocked by the base
-# image's constraint file — a no-op here since 2.30.7 is already pinned above.
 cd "${FI_SRC}"
 # --no-build-isolation makes pyproject's [build-system] requires OUR job:
 # setuptools>=77 (PEP 639 SPDX `license = "Apache-2.0"`), packaging>=24, and
@@ -92,8 +89,7 @@ PIP_CONSTRAINT="" BUILD_NIXL_EP=0 \
 
 # The full-dep editable install above lets pip's resolver downgrade
 # nvidia-nccl-<cuXX> to torch's exact pin (2.28.9 on the 26.05 image), undoing
-# the 2.30.7 pin from the top of this script — and _ensure_nccl_floor runs at
-# build time, before that final resolution. Re-assert the pin last.
+# the 2.30.7 pin from the top of this script. Re-assert the pin last.
 PIP_CONSTRAINT="" pip install --no-cache-dir --no-deps \
     "nvidia-nccl-${CU}==${NCCL_VERSION}"
 

--- a/docs/design_docs/moe_ep_runbook.md
+++ b/docs/design_docs/moe_ep_runbook.md
@@ -82,8 +82,7 @@ sm_90+.
 
 **1. Build with NIXL-EP enabled.** Build deps: `meson`, `ninja`, `pkg-config`,
 `nvcc`, UCX (`pkg-config --exists ucx`), `libibverbs-dev`. The build hook
-pre-installs the `nixl-cu13` wheel it links against (`_ensure_nixl_wheel`), so
-no manual NIXL install is needed.
+requires the `nixl-cu13` wheel it links against to be installed beforehand.
 
 **UCX caveat:** the UCX found via pkg-config must ship the *device API*
 (`ucp/api/device/ucp_device_impl.h`) — NGC images' HPC-X UCX and Ubuntu's apt

--- a/flashinfer/cutile/cutile_common.py
+++ b/flashinfer/cutile/cutile_common.py
@@ -80,11 +80,8 @@ def is_cuda_tile_available() -> bool:
     + ``FileNotFoundError: 'tileiras' compiler not found`` cascade when the
     compiler is absent, which Python-module-only probes would miss.
 
-    This is needed because in CI's ``pip install -e . -v`` path (PEP 517
-    isolation), our build-backend's ``_install_cuda_tile_compile_deps()`` hook
-    cannot install ``nvidia-cuda-tileiras`` into the target env (the build venv
-    has no ``pip`` module to call). On cu12x CI images that don't pre-install
-    tileiras, this skip-guard prevents cuTile tests from crashing mid-JIT.
+    On cu12x CI images that don't provide ``nvidia-cuda-tileiras``, this
+    skip-guard prevents cuTile tests from crashing mid-JIT.
     """
     if importlib.util.find_spec("cuda.tile.tune") is None:
         return False

--- a/flashinfer/moe_ep/backends/split/comm/nixl_ep/__init__.py
+++ b/flashinfer/moe_ep/backends/split/comm/nixl_ep/__init__.py
@@ -5,8 +5,7 @@ Two pieces matter for import-time success:
 1. The base NIXL runtime libraries (``libnixl.so``, ``libnixl_capi.so``,
    ``libnixl_common.so``, ``libserdes.so``, etc.) — *not* shipped inside this
    package. They're expected to come from the ``nixl-cu13`` pip wheel,
-   installed automatically by the default ``pip install .`` build (see
-   ``build_backend._ensure_nixl_wheel`` / ``_install_nvep_runtime_wheels``).
+   installed before building FlashInfer.
 
 2. The EP torch extension, ``nixl_ep_cpp*.so`` — built in-tree from
    ``3rdparty/nixl/examples/device/ep`` and staged into ``_libs/`` here.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,8 +32,8 @@ cu13 = ["nvidia-cutlass-dsl[cu13]>=4.5.0"]
 # default (best-effort) on `pip install .` — see the moe_ep section at the top
 # of build_backend.py. libnccl comes from torch's own nvidia-nccl-cu13 pin;
 # the >=2.30.7 B200 floor is enforced at runtime (moe_ep/core/validation/
-# common.py) and upgraded --no-deps by the build hook on source installs. Opt
-# out of the native build with BUILD_NVEP=0 (or BUILD_NIXL_EP=0 / BUILD_NCCL_EP=0).
+# common.py). Opt out of the native build with BUILD_NVEP=0 (or
+# BUILD_NIXL_EP=0 / BUILD_NCCL_EP=0).
 nvep = []
 
 [project.scripts]

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,9 +9,8 @@ click
 # EXACTLY (e.g. ==2.29.7), so any floor here (>=2.30.7 for B200 EP) makes the
 # resolver evict torch — on aarch64 it backtracks all the way to the CPU-only
 # torch 2.10.0 wheel. torch supplies libnccl; the >=2.30.7 B200 floor is
-# enforced at runtime in flashinfer/moe_ep/core/validation/common.py, and the
-# build hook installs the newer wheel --no-deps on source installs
-# (build_backend.py).
+# enforced at runtime in flashinfer/moe_ep/core/validation/common.py. Source
+# environments that enable NCCL-EP must provide a compatible wheel.
 #
 # The same base-deps-must-not-force-a-CUDA-major rule applies to cuda-python:
 # a >=13.0 floor bulldozes CUDA-12 environments (pip reports e.g.

--- a/scripts/build_in_container.sh
+++ b/scripts/build_in_container.sh
@@ -116,7 +116,7 @@ uv pip install --python "${VENV}/bin/python" \
 # plugin loads libnixl.so from it at first use. (NCCL-EP's base libnccl.so.2 +
 # libnccl_ep.so come from the nccl4py wheel installed below.)
 uv pip install --python "${VENV}/bin/python" --no-deps \
-    "nixl-cu13>=1.0.1"
+    "nixl-cu13>=1.3.1"
 
 # FlashInfer runtime deps (incl. the moe_ep deps, now part of the base
 # dependencies), installed explicitly here (WITH their own deps) so the

--- a/tests/test_build_backend.py
+++ b/tests/test_build_backend.py
@@ -1,0 +1,23 @@
+from unittest import mock
+
+import build_backend
+
+
+def test_build_hooks_do_not_invoke_package_installers():
+    with (
+        mock.patch.object(build_backend, "_build_nvep_if_enabled"),
+        mock.patch.object(build_backend, "_create_data_dir"),
+        mock.patch.object(build_backend, "_data_dir") as data_dir,
+        mock.patch.object(build_backend.subprocess, "run") as run,
+    ):
+        data_dir.exists.return_value = False
+        build_backend._prepare_for_editable()
+    run.assert_not_called()
+
+    with (
+        mock.patch.object(build_backend, "_BUILD_NCCL_EP", True),
+        mock.patch.object(build_backend, "_BUILD_NIXL_EP", False),
+        mock.patch.object(build_backend.subprocess, "run") as run,
+    ):
+        build_backend._build_nvep_if_enabled()
+    run.assert_not_called()


### PR DESCRIPTION
## 📌 Description

Build backend hooks currently invoke uv or pip to install the cuTile compiler chain and MoE EP runtime wheels. This mutates an environment owned by the build frontend, does not reliably affect the target environment under PEP 517 isolation, and can deadlock environment managers that already hold their transaction lock.

This PR:

- removes nested package installation from wheel and editable build hooks;
- keeps NIXL-EP best-effort and explicit opt-in behavior through the existing dependency probe;
- leaves the Blackwell NCCL floor with the existing runtime validator and makes the reference Docker environment pin explicit;
- updates stale build and runtime guidance; and
- adds a focused regression test that build hooks do not invoke package installers.

Build and runtime dependencies remain the responsibility of package metadata or the owning environment. The build backend still compiles native components and reports missing prerequisites normally.

## 🔍 Related Issues

None.

## 🚀 Pull Request Checklist

### ✅ Pre-commit Checks

- [x] Ran all repository hooks with `prek run --all-files`.

## 🧪 Tests

- [x] `python -m pytest tests/test_build_backend.py -q`
- [x] Isolated `python -m build` produced both sdist and wheel
- [x] Locked workspace installation completed without nested installer activity

## Reviewer Notes

The NCCL floor is intentionally not added to base dependencies because CUDA 13 PyTorch wheels pin `nvidia-nccl-cu13` exactly. Environments enabling NCCL-EP on Blackwell must provide `nvidia-nccl-cu13>=2.30.7`; the reference Docker and container setup do so explicitly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Build and installation workflows now rely on preinstalled NIXL and NCCL runtime wheels.
  * Updated minimum runtime versions for NIXL and NCCL dependencies.

* **Documentation**
  * Clarified that required runtime wheels must be installed before building.
  * Updated setup guidance and dependency notes to reflect the revised workflow.

* **Tests**
  * Added coverage confirming builds do not install runtime packages automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->