### PR TITLE
fix(cake_kda): support non-aligned recurrent prefill head counts

### DIFF
--- a/csrc/kda/flashkda_binding_common.cuh
+++ b/csrc/kda/flashkda_binding_common.cuh
@@ -40,18 +40,23 @@ constexpr size_t kTensorMapCount = 6;
 constexpr size_t kTensorMapAlignment = 64;
 static_assert(sizeof(CUtensorMap) == 128);
 constexpr size_t kDescriptorStorageBytes = kTensorMapCount * sizeof(CUtensorMap);
-constexpr int64_t kBetaTmaMinHeads = 8;
+constexpr int64_t kBetaTmaHeadsPerBox = 8;
+
+inline int64_t RoundUpBetaTmaHeads(int64_t num_heads) {
+  return (num_heads / kBetaTmaHeadsPerBox +
+          static_cast<int64_t>(num_heads % kBetaTmaHeadsPerBox != 0)) *
+         kBetaTmaHeadsPerBox;
+}
 
 static __global__ void PackBetaForTmaKernel(const __nv_bfloat16* beta, __nv_bfloat16* beta_tma,
-                                            int64_t token_count, int64_t padded_token_count,
-                                            int32_t num_heads) {
+                                            int64_t token_count, int64_t padded_elements,
+                                            int64_t num_heads, int64_t padded_num_heads) {
   const int64_t linear_index = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
-  const int64_t padded_elements = padded_token_count * kBetaTmaMinHeads;
   if (linear_index >= padded_elements) {
     return;
   }
-  const int64_t token_index = linear_index / kBetaTmaMinHeads;
-  const int32_t head_index = static_cast<int32_t>(linear_index % kBetaTmaMinHeads);
+  const int64_t token_index = linear_index / padded_num_heads;
+  const int64_t head_index = linear_index % padded_num_heads;
   __nv_bfloat16 value = __float2bfloat16(0.0f);
   if (token_index < token_count && head_index < num_heads) {
     value = beta[token_index * num_heads + head_index];
@@ -228,14 +233,14 @@ inline int64_t CheckCommonInputs(const TensorView& q, const TensorView& k, const
   TVM_FFI_ICHECK(beta.ndim() >= 2 && beta.size(beta.ndim() - 1) == num_heads &&
                  beta.numel() == token_count * num_heads)
       << "beta must match flattened [tokens, H]";
-  const int64_t beta_tma_heads = std::max<int64_t>(num_heads, 8);
+  const int64_t beta_tma_heads = RoundUpBetaTmaHeads(num_heads);
   TVM_FFI_ICHECK(beta_tma.ndim() >= 2 && beta_tma.size(beta_tma.ndim() - 1) == beta_tma_heads &&
                  beta_tma.numel() % beta_tma_heads == 0 &&
                  beta_tma.numel() / beta_tma_heads >= std::max<int64_t>(token_count, 32))
-      << "beta_tma must have at least [max(tokens, 32), max(H, 8)] "
+      << "beta_tma must have at least [max(tokens, 32), round_up(H, 8)] "
          "storage";
   CheckNoPartialOverlapOrExactAlias(beta, "beta", beta_tma, "beta_tma");
-  if (num_heads < kBetaTmaMinHeads) {
+  if (beta_tma_heads != num_heads) {
     CheckNoOverlap(beta_tma, "beta_tma", q, "q");
     CheckNoOverlap(beta_tma, "beta_tma", k, "k");
     CheckNoOverlap(beta_tma, "beta_tma", v, "v");
@@ -314,23 +319,22 @@ inline int64_t CheckCommonInputs(const TensorView& q, const TensorView& k, const
 
 inline void PackBetaForTmaIfNeeded(const TensorView& beta, const TensorView& beta_tma,
                                    int64_t num_heads, cudaStream_t stream) {
-  // Full chunks TMA-load an eight-head beta box.  Only H<8 requires a
-  // materialized row-padded source; H>=8 aliases beta whenever a full chunk
-  // exists, while shorter inputs stay entirely on the direct-load tail path.
-  if (num_heads >= kBetaTmaMinHeads) {
+  // Full chunks TMA-load an eight-head beta box, so any partial final group
+  // needs a materialized row padded to the next eight-head boundary.
+  const int64_t padded_num_heads = beta_tma.size(beta_tma.ndim() - 1);
+  if (padded_num_heads == num_heads) {
     return;
   }
   const int64_t token_count = beta.numel() / num_heads;
-  const int64_t padded_token_count = beta_tma.numel() / kBetaTmaMinHeads;
-  const int64_t padded_elements = padded_token_count * kBetaTmaMinHeads;
+  const int64_t padded_elements = beta_tma.numel();
   constexpr int32_t kThreads = 256;
-  const int64_t blocks_i64 = (padded_elements + kThreads - 1) / kThreads;
+  const int64_t blocks_i64 = (padded_elements - 1) / kThreads + 1;
   TVM_FFI_ICHECK(blocks_i64 > 0 && blocks_i64 <= std::numeric_limits<uint32_t>::max())
       << "beta TMA pack grid.x is out of range: " << blocks_i64;
   PackBetaForTmaKernel<<<static_cast<uint32_t>(blocks_i64), kThreads, 0, stream>>>(
       reinterpret_cast<const __nv_bfloat16*>(beta.data_ptr()),
-      reinterpret_cast<__nv_bfloat16*>(beta_tma.data_ptr()), token_count, padded_token_count,
-      static_cast<int32_t>(num_heads));
+      reinterpret_cast<__nv_bfloat16*>(beta_tma.data_ptr()), token_count, padded_elements,
+      num_heads, padded_num_heads);
   CheckCuda(cudaGetLastError(), "PackBetaForTmaKernel launch");
 }
 

--- a/docs/api/kda_prefill.rst
+++ b/docs/api/kda_prefill.rst
@@ -108,5 +108,7 @@ stream.
 When an explicit workspace is used with ``initial_state=None`` and
 ``output_final_state=True``, the returned final state is workspace-owned
 stable scratch. Otherwise an explicitly supplied ``initial_state`` is updated
-directly in place by the frozen kernel. The small-head ``H < 8`` path captures
-the beta copy into workspace-owned padded storage before the frozen launch.
+directly in place by the frozen kernel. Head counts that are not divisible by
+eight capture the beta copy into workspace-owned storage padded to the next
+eight-head boundary before the frozen launch. The public beta and state shapes
+keep the caller's original head count.

--- a/flashinfer/kda_prefill.py
+++ b/flashinfer/kda_prefill.py
@@ -35,7 +35,7 @@ if TYPE_CHECKING:
     from .jit.flash_kda import FlashKDATarget, FlashKDAVariant
 
 _FLASH_KDA_HEAD_DIM = 128
-_FLASH_KDA_BETA_TMA_MIN_HEADS = 8
+_FLASH_KDA_BETA_TMA_HEADS_PER_BOX = 8
 _FLASH_KDA_SUPPORTED_COMPUTE_CAPABILITIES = {(10, 0), (10, 3)}
 _FLASH_KDA_DESCRIPTOR_STORAGE_BYTES = 6 * 128
 _flash_kda_tensor_cache: dict[tuple, torch.Tensor] = {}
@@ -381,7 +381,11 @@ def _beta_tma_source(
     total_tokens = batch_size * seq_len
     beta_flat = beta.reshape(total_tokens, num_heads)
     padded_tokens = max(total_tokens, 32)
-    padded_heads = max(num_heads, _FLASH_KDA_BETA_TMA_MIN_HEADS)
+    padded_heads = (
+        (num_heads + _FLASH_KDA_BETA_TMA_HEADS_PER_BOX - 1)
+        // _FLASH_KDA_BETA_TMA_HEADS_PER_BOX
+        * _FLASH_KDA_BETA_TMA_HEADS_PER_BOX
+    )
     if padded_tokens == total_tokens and padded_heads == num_heads:
         return beta_flat
     shape = (padded_tokens, padded_heads)

--- a/tests/jit/test_flash_kda_jit.py
+++ b/tests/jit/test_flash_kda_jit.py
@@ -190,6 +190,10 @@ def test_flash_kda_descriptor_workspace_contract():
     assert "major == 10 && (minor == 0 || minor == 3)" in common_text
     assert "CheckFlashKDATarget" in common_text
     assert "PackBetaForTmaKernel" in common_text
+    assert "RoundUpBetaTmaHeads(num_heads)" in common_text
+    assert "padded_num_heads == num_heads" in common_text
+    assert "linear_index / padded_num_heads" in common_text
+    assert "linear_index % padded_num_heads" in common_text
     assert (
         'CheckNoPartialOverlapOrExactAlias(beta, "beta", beta_tma, "beta_tma")'
         in common_text

--- a/tests/kda/test_recurrent_kda_prefill.py
+++ b/tests/kda/test_recurrent_kda_prefill.py
@@ -280,7 +280,12 @@ def test_multi_token_gqa_stays_on_existing_backend(cuda_device, monkeypatch):
 
 @pytest.mark.parametrize(
     ("packed", "num_heads", "expected_variant"),
-    [(False, 64, "m64"), (True, 64, "m128"), (True, 2, "m128")],
+    [
+        (False, 64, "m64"),
+        (True, 64, "m128"),
+        (True, 2, "m128"),
+        (False, 12, "m128"),
+    ],
 )
 @pytest.mark.parametrize(
     ("compute_capability", "expected_target"),
@@ -339,7 +344,7 @@ def test_frozen_route_and_ffi_abi(
     assert args[4].data_ptr() == inputs["beta"].data_ptr()
     assert args[5].shape == (
         max(inputs["q"].numel() // (num_heads * 128), 32),
-        max(num_heads, 8),
+        (num_heads + 7) // 8 * 8,
     )
     assert args[8].dtype == torch.int64
     assert args[9].dtype == torch.int32
@@ -353,7 +358,7 @@ def test_frozen_route_and_ffi_abi(
     assert math.isclose(args[18], 128**-0.5)
     assert args[19] == -5.0
     assert args[20] == int(torch.cuda.current_stream(cuda_device).cuda_stream)
-    if num_heads < 8:
+    if num_heads % 8 != 0:
         assert args[5].data_ptr() != inputs["beta"].data_ptr()
 
 
@@ -776,6 +781,81 @@ def test_frozen_prefill_h6_full_tma_chunk_matches_reference(flash_kda_device):
     )
 
 
+@pytest.mark.parametrize("seq_len", [32, 33])
+def test_frozen_prefill_h12_tma_chunks_match_reference(flash_kda_device, seq_len):
+    inputs = _make_inputs(
+        seq_lens=[seq_len],
+        num_heads=12,
+        packed=False,
+        initial_state=True,
+        seed=2012 + seq_len,
+    )
+    reference_inputs = {
+        **inputs,
+        "initial_state": inputs["initial_state"].clone(),
+    }
+    expected_output, expected_state = _reference(reference_inputs)
+    output = torch.empty_like(inputs["q"])
+
+    actual_output, actual_state = recurrent_kda(
+        **_strict_prefill_kwargs(inputs),
+        output=output,
+        output_final_state=True,
+    )
+
+    assert actual_output.data_ptr() == output.data_ptr()
+    assert actual_state is inputs["initial_state"]
+    torch.testing.assert_close(
+        actual_output.float(),
+        expected_output.float(),
+        atol=1e-2,
+        rtol=1e-2,
+    )
+    torch.testing.assert_close(
+        actual_state.float(),
+        expected_state.float(),
+        atol=1e-2,
+        rtol=1e-2,
+    )
+
+
+def test_frozen_prefill_h12_packed_matches_reference(flash_kda_device):
+    inputs = _make_inputs(
+        seq_lens=[32, 3],
+        num_heads=12,
+        packed=True,
+        initial_state=True,
+        seed=2047,
+    )
+    reference_inputs = {
+        **inputs,
+        "initial_state": inputs["initial_state"].clone(),
+    }
+    expected_output, expected_state = _reference(reference_inputs)
+    output = torch.empty_like(inputs["q"])
+
+    actual_output, actual_state = recurrent_kda(
+        **_strict_prefill_kwargs(inputs),
+        output=output,
+        output_final_state=True,
+    )
+
+    assert actual_output.data_ptr() == output.data_ptr()
+    assert actual_state is inputs["initial_state"]
+    torch.testing.assert_close(
+        actual_output.float(),
+        expected_output.float(),
+        atol=1e-2,
+        rtol=1e-2,
+    )
+    torch.testing.assert_close(
+        actual_state.float(),
+        expected_state.float(),
+        atol=1e-2,
+        rtol=1e-2,
+    )
+
+
 def test_frozen_prefill_m64_matches_reference(flash_kda_device):
     inputs = _make_inputs(
         seq_lens=[2],
@@ -898,13 +978,16 @@ def test_frozen_prefill_cuda_graph_capture_and_replay(
     )
 
 
-def test_frozen_prefill_h6_full_chunk_graph_refreshes_beta(flash_kda_device):
+@pytest.mark.parametrize("num_heads", [6, 12])
+def test_frozen_prefill_non_aligned_heads_graph_refreshes_beta(
+    flash_kda_device, num_heads
+):
     inputs = _make_inputs(
         seq_lens=[32],
-        num_heads=6,
+        num_heads=num_heads,
         packed=False,
         initial_state=True,
-        seed=2033,
+        seed=2033 + num_heads,
     )
     initial_state_seed = inputs["initial_state"].clone()
     output = torch.empty_like(inputs["q"])


### PR DESCRIPTION
Follow-up to merged #4262 and #4313.

## What changed

- pad the beta-only TMA source to `round_up(H, 8)` instead of only padding `H < 8`;
- teach the beta pack kernel and binding validation to use the dynamic padded-head stride;
- retain the caller-visible `H`, state shape, launch grid, and frozen M64/M128 CUDA bodies unchanged;
- add H=12 eager, packed, full-chunk-plus-tail, final-state, and CUDA graph replay coverage.

The frozen kernels load beta in 8-head TMA boxes. For H=12, the original BF16 row stride is 24 bytes and `cuTensorMapEncodeTiled` rejects it. Padding the descriptor source to 16 heads gives a 32-byte row stride; heads 12–15 are padding only and are never assigned CTAs.

This generalizes the fix to every positive head count that is not divisible by eight, while aligned head counts retain the existing zero-copy beta path.

## Correctness

Both runs used the public `flashinfer.recurrent_kda` facade and compared BF16 output plus the complete final state against the PyTorch reference with `atol=rtol=1e-2`.

| GPU | Compute capability | CUDA | Result |
| --- | --- | --- | --- |
| NVIDIA B200 | 10.0 | 12.9 | `62 passed, 0 skipped, 0 failed` |
| NVIDIA GB300 | 10.3 | 12.9 | `62 passed, 0 skipped, 0 failed` |

The test gate runs:

```text
tests/jit/test_flash_kda_jit.py
tests/kda/test_recurrent_kda_prefill.py
```

H=12 coverage includes fixed T=32, fixed T=33 (one full TMA chunk plus the direct-load tail), packed sequence lengths `[32, 3]`, in-place initial/final state, and CUDA graph replay after beta is changed. The JIT contract test also verifies that the frozen generated M64/M128 bodies remain unchanged.

`pre-commit run --files <changed files>` passes.

## Performance

The H=12 path was benchmarked through the public `flashinfer.recurrent_kda` facade with fallback forbidden. Speedup is the official FlashKDA raw GPU span divided by this PR's public-API GPU span. The baseline is the same official FlashKDA source used for #4262: [`MoonshotAI/FlashKDA@d2ff19a`](https://github.com/MoonshotAI/FlashKDA/commit/d2ff19a6a0c82f39f796f637ebd1c36090b1268f), with CUTLASS `5c149f5`.

Measurements use strict CUPTI first-to-last correlated compute-kernel span, cold L2, no CUDA Graph, and two independent 128-sample blocks in symmetric ABCCBA order. The PR span includes both the beta pack and frozen M128 recurrence kernels. All six benchmark shapes passed output and complete-final-state correctness against the official peer with BF16 `atol=rtol=1e-2`.

| H=12 shape | SM100 / B200: PR / baseline | Speedup | SM103 / GB300: PR / baseline | Speedup |
| --- | ---: | ---: | ---: | ---: |
| packed `[512] x 32` | 136.159 / 240.239 us | **1.7644x** | 128.264 / 233.496 us | **1.8204x** |
| packed `[128] x 8` | 23.760 / 46.448 us | **1.9549x** | 25.712 / 52.904 us | **2.0576x** |
| fixed `[512]` | 46.184 / 76.383 us | **1.6539x** | 47.712 / 82.240 us | **1.7237x** |
| fixed `[8192]` | 514.197 / 814.435 us | **1.5839x** | 487.161 / 779.426 us | **1.5999x** |
| mixed `[1300, 547, 2048, 963, 271, 3063]` | 208.647 / 351.550 us | **1.6849x** | 198.216 / 340.913 us | **1.7199x** |
| uniform `[1024] x 8` | 82.080 / 162.703 us | **1.9823x** | 78.440 / 162.505 us | **2.0717x** |
| **Six-shape geometric mean** | | **1.7645x** | | **1.8238x** |

| Comparison | Result |
| --- | --- |
| FlashInfer upstream main at H=12 | `unsupported / N/A` |

Upstream main fails before kernel launch with `cuTensorMapEncodeTiled failed for beta_tma with CUresult=1`, so there is no valid upstream H=12 timing or speedup claim. This PR leaves the frozen compute kernel unchanged; it adds the required beta packing only for non-8-aligned head counts.

Related to #4254.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved beta padding for head counts that are not divisible by eight.
  - Ensured packed inputs correctly handle larger, non-aligned head counts.
  - Added validation for padded storage requirements.

- **Documentation**
  - Clarified beta padding behavior and public tensor shapes.

- **Tests**
  - Expanded coverage for 12-head inputs, varied sequence lengths, chunk boundaries, packed inputs, and CUDA graph updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->