### PR TITLE
Accept unpacked pre-routed topk in fp8 block-scale and bf16 MoE

### DIFF
--- a/csrc/trtllm_fused_moe_kernel_launcher.cu
+++ b/csrc/trtllm_fused_moe_kernel_launcher.cu
@@ -277,8 +277,10 @@ class FusedMoeLauncher {
                    const Optional<TensorView>& output1_scales_gate_scalar,
                    const TensorView& gemm2_weights,
                    const Optional<TensorView>& output2_scales_scalar,
-                   const Optional<TensorView>& per_token_scales)
-      : routing_logits(routing_logits),
+                   const Optional<TensorView>& per_token_scales,
+                   RoutingInputMode routing_input_mode = RoutingInputMode::FromLogits)
+      : routing_input_mode_(routing_input_mode),
+        routing_logits(routing_logits),
         routing_bias(routing_bias),
         hidden_states(hidden_states),
         gemm1_weights(gemm1_weights),
@@ -326,6 +328,28 @@ class FusedMoeLauncher {
           << "routing_logits must be float or bfloat16.";
     }
   }
+
+  // Empty placeholder tensors may still carry a non-null data_ptr.
+  static bool has_precomputed(TensorView const& tensor) {
+    return tensor.ndim() == 2 && tensor.size(0) > 0;
+  }
+
+  static btg::Dtype expert_weights_dtype(TensorView const& weights) {
+    return weights.dtype() == dl_float32 ? btg::Dtype::Fp32 : btg::Dtype::Bfloat16;
+  }
+
+  bool is_unpacked_routing() const {
+    return routing_input_mode_ == RoutingInputMode::UnpackedPrecomputed;
+  }
+
+  int32_t* unpacked_expert_ids(TensorView const& indices) const {
+    return is_unpacked_routing() ? static_cast<int32_t*>(const_cast<void*>(indices.data_ptr()))
+                                 : nullptr;
+  }
+
+  virtual int32_t* precomputed_expert_ids() const { return nullptr; }
+
+  RoutingInputMode routing_input_mode_;
 
   // Routing bias [num_experts]
   void check_routing_bias_shape() const {
@@ -644,8 +668,7 @@ class FusedMoeLauncher {
     tensorrt_llm::kernels::trtllmgen_moe::Routing::Runner routing_runner(tile_tokens_dim);
     cudaStream_t routing_stream = get_stream(hidden_states.device());
 
-    // This base class only supports Mode 1 (FromLogits) - compute routing from logits
-    int32_t* expert_ids_param = nullptr;
+    int32_t* expert_ids_param = precomputed_expert_ids();
 
     int16_t* replay_ptr = nullptr;
     if (routing_replay_out.has_value()) {
@@ -763,10 +786,11 @@ class Bf16MoeLauncher : public FusedMoeLauncher {
                   TensorView const& gemm1_weights, TensorView const& gemm2_weights,
                   Optional<TensorView> const& gemm1_bias, Optional<TensorView> const& gemm1_alpha,
                   Optional<TensorView> const& gemm1_beta,
-                  Optional<TensorView> const& gemm1_clamp_limit)
+                  Optional<TensorView> const& gemm1_clamp_limit,
+                  RoutingInputMode routing_input_mode)
       : FusedMoeLauncher(routing_logits, routing_bias, hidden_states, gemm1_weights, gemm1_bias,
                          Optional<TensorView>(), Optional<TensorView>(), gemm2_weights,
-                         Optional<TensorView>(), Optional<TensorView>()),
+                         Optional<TensorView>(), Optional<TensorView>(), routing_input_mode),
         expert_indices(expert_indices),
         expert_weights(expert_weights),
         gemm1_alpha(gemm1_alpha),
@@ -784,15 +808,25 @@ class Bf16MoeLauncher : public FusedMoeLauncher {
 
   void check_routing() const override {
     FusedMoeLauncher::check_routing_common();
-    if (expert_indices.ndim() == 2 && expert_indices.size(0) > 0) {
-      // Pre-computed routing: expert_indices is a packed tensor
-      // Format: (expert_id << 16) | (weight_bf16.view(int16))
+    if (has_precomputed(expert_indices)) {
       TVM_FFI_ICHECK_EQ(expert_indices.ndim(), 2) << "expert_indices must be 2D.";
       TVM_FFI_ICHECK_EQ(expert_indices.size(0), hidden_states.size(0))
           << "expert_indices and hidden_states must have same number of tokens.";
       TVM_FFI_ICHECK_EQ(expert_indices.size(1), args->top_k)
           << "expert_indices dim1 must match top_k.";
       TVM_FFI_ICHECK_EQ(expert_indices.dtype(), dl_int32) << "expert_indices must be int32.";
+    }
+    if (is_unpacked_routing()) {
+      TVM_FFI_ICHECK(has_precomputed(expert_indices))
+          << "expert_indices must be a 2D [num_tokens, top_k] tensor for unpacked precomputed "
+             "routing.";
+      TVM_FFI_ICHECK(expert_weights.dtype() == dl_bfloat16 || expert_weights.dtype() == dl_float32)
+          << "expert_weights must be bfloat16 or float32 for unpacked precomputed routing.";
+      TVM_FFI_ICHECK_EQ(expert_weights.ndim(), 2) << "expert_weights must be 2D.";
+      TVM_FFI_ICHECK_EQ(expert_weights.size(0), hidden_states.size(0))
+          << "expert_weights and hidden_states must have same number of tokens.";
+      TVM_FFI_ICHECK_EQ(expert_weights.size(1), args->top_k)
+          << "expert_weights dim1 must match top_k.";
     }
 
     // TODO n_group, topk_group validation?
@@ -814,15 +848,17 @@ class Bf16MoeLauncher : public FusedMoeLauncher {
     mRoutingLogitsDtype =
         routing_logits_dtype == dl_float32 ? btg::Dtype::Fp32 : btg::Dtype::Bfloat16;
 
-    // Check ndim==2 and size>0 because empty placeholder tensors may have non-null data_ptr
-    bool has_precomputed_indices = expert_indices.ndim() == 2 && expert_indices.size(0) > 0;
+    bool has_precomputed_indices = has_precomputed(expert_indices);
     if (has_precomputed_indices) {
       // Use expert_indices directly
       workspace.routing_expert_indexes =
           static_cast<int*>(const_cast<void*>(expert_indices.data_ptr()));
     }
-    bool has_precomputed_weights = expert_weights.ndim() == 2 && expert_weights.size(0) > 0;
+    bool has_precomputed_weights = has_precomputed(expert_weights);
     if (has_precomputed_weights) {
+      if (is_unpacked_routing()) {
+        args->mDtypeExpW = expert_weights_dtype(expert_weights);
+      }
       workspace.expert_weights = const_cast<void*>(expert_weights.data_ptr());
     } else {
       // Allocate the routing-output buffer as bf16 to match the kernel's output
@@ -834,6 +870,8 @@ class Bf16MoeLauncher : public FusedMoeLauncher {
       workspace.expert_weights = FusedMoeLauncher::expert_weights.data_ptr();
     }
   }
+
+  int32_t* precomputed_expert_ids() const override { return unpacked_expert_ids(expert_indices); }
 
   void check_moe() const override {
     FusedMoeLauncher::check_moe_common();
@@ -1240,10 +1278,10 @@ class Fp8BlockScaleLauncher : public FusedMoeLauncher {
                         Optional<TensorView> const& gemm1_clamp_limit,
                         TensorView const& gemm2_weights, TensorView const& gemm2_weights_scale,
                         TensorView const& expert_indices, TensorView const& expert_weights,
-                        Fp8QuantizationType quantization_type)
+                        Fp8QuantizationType quantization_type, RoutingInputMode routing_input_mode)
       : FusedMoeLauncher(routing_logits, routing_bias, hidden_states, gemm1_weights, gemm1_bias,
                          Optional<TensorView>(), Optional<TensorView>(), gemm2_weights,
-                         Optional<TensorView>(), Optional<TensorView>()),
+                         Optional<TensorView>(), Optional<TensorView>(), routing_input_mode),
         hidden_states_scale(hidden_states_scale),
         gemm1_weights_scale(gemm1_weights_scale),
         gemm1_alpha(gemm1_alpha),
@@ -1286,16 +1324,25 @@ class Fp8BlockScaleLauncher : public FusedMoeLauncher {
   }
 
   void check_routing() const override {
-    // Check ndim==2 and size>0 because empty placeholder tensors may have non-null data_ptr
-    if (expert_indices.ndim() == 2 && expert_indices.size(0) > 0) {
-      // Pre-computed routing: expert_indices is a packed tensor
-      // Format: (expert_id << 16) | (weight_bf16.view(int16))
+    if (has_precomputed(expert_indices)) {
       TVM_FFI_ICHECK_EQ(expert_indices.ndim(), 2) << "expert_indices must be 2D.";
       TVM_FFI_ICHECK_EQ(expert_indices.size(0), hidden_states.size(0))
           << "expert_indices and hidden_states must have same number of tokens.";
       TVM_FFI_ICHECK_EQ(expert_indices.size(1), args->top_k)
           << "expert_indices dim1 must match top_k.";
       TVM_FFI_ICHECK_EQ(expert_indices.dtype(), dl_int32) << "expert_indices must be int32.";
+    }
+    if (is_unpacked_routing()) {
+      TVM_FFI_ICHECK(has_precomputed(expert_indices))
+          << "expert_indices must be a 2D [num_tokens, top_k] tensor for unpacked precomputed "
+             "routing.";
+      TVM_FFI_ICHECK(expert_weights.dtype() == dl_bfloat16 || expert_weights.dtype() == dl_float32)
+          << "expert_weights must be bfloat16 or float32 for unpacked precomputed routing.";
+      TVM_FFI_ICHECK_EQ(expert_weights.ndim(), 2) << "expert_weights must be 2D.";
+      TVM_FFI_ICHECK_EQ(expert_weights.size(0), hidden_states.size(0))
+          << "expert_weights and hidden_states must have same number of tokens.";
+      TVM_FFI_ICHECK_EQ(expert_weights.size(1), args->top_k)
+          << "expert_weights dim1 must match top_k.";
     }
 
     FusedMoeLauncher::check_routing_common();
@@ -1363,8 +1410,7 @@ class Fp8BlockScaleLauncher : public FusedMoeLauncher {
     }
 
     args->mUseDeepSeekFp8 = quantization_type == Fp8QuantizationType::DeepSeekFp8;
-    // Check ndim==2 and size>0 because empty placeholder tensors may have non-null data_ptr
-    bool has_precomputed_indices = expert_indices.ndim() == 2 && expert_indices.size(0) > 0;
+    bool has_precomputed_indices = has_precomputed(expert_indices);
     if (has_precomputed_indices) {
       // Use expert_indices directly
       workspace.routing_expert_indexes =
@@ -1384,8 +1430,7 @@ class Fp8BlockScaleLauncher : public FusedMoeLauncher {
     mRoutingLogitsDtype =
         routing_logits_dtype == dl_float32 ? btg::Dtype::Fp32 : btg::Dtype::Bfloat16;
 
-    // Check ndim==2 and size>0 because empty placeholder tensors may have non-null data_ptr
-    bool has_precomputed_weights = expert_weights.ndim() == 2 && expert_weights.size(0) > 0;
+    bool has_precomputed_weights = has_precomputed(expert_weights);
     if (!has_precomputed_weights) {
       // Allocate the routing-output buffer as bf16 to match the kernel's output
       // (always Bfloat16, never the logits dtype); a fp32 alloc would mislabel
@@ -1395,9 +1440,14 @@ class Fp8BlockScaleLauncher : public FusedMoeLauncher {
                                                       dl_bfloat16, hidden_states.device());
       workspace.expert_weights = FusedMoeLauncher::expert_weights.data_ptr();
     } else {
+      if (is_unpacked_routing()) {
+        args->mDtypeExpW = expert_weights_dtype(expert_weights);
+      }
       workspace.expert_weights = const_cast<void*>(expert_weights.data_ptr());
     }
   }
+
+  int32_t* precomputed_expert_ids() const override { return unpacked_expert_ids(expert_indices); }
 
   void check_moe() const override {
     FusedMoeLauncher::check_moe_common();
@@ -1574,11 +1624,9 @@ class Fp8BlockScaleLauncher : public FusedMoeLauncher {
     cudaStream_t routing_stream = get_stream(hidden_states.device());
     tensorrt_llm::kernels::trtllmgen_moe::Routing::Runner routing_runner(tile_tokens_dim);
 
-    // Check ndim==2 and size>0 because empty placeholder tensors may have non-null data_ptr
-    bool use_precomputed = expert_indices.ndim() == 2 && expert_indices.size(0) > 0;
+    bool use_precomputed = has_precomputed(expert_indices);
     // When using pre-computed routing, pass nullptr as routing_logits to tell the
     // routing runner to use the pre-computed expert indices from workspace.routing_expert_indexes
-    // FP8 only supports Mode 1 (FromLogits) and Mode 2 (PackedPrecomputed), so expertIds is nullptr
     int16_t* replay_ptr = nullptr;
     if (routing_replay_out.has_value()) {
       replay_ptr = reinterpret_cast<int16_t*>(routing_replay_out.value().data_ptr());
@@ -1593,7 +1641,7 @@ class Fp8BlockScaleLauncher : public FusedMoeLauncher {
         static_cast<int*>(total_num_padded_tokens.data_ptr()),
         static_cast<int*>(expanded_idx_to_permuted_idx.data_ptr()),
         workspace.permuted_idx_to_expanded_idx,
-        static_cast<int*>(permuted_idx_to_token_idx.data_ptr()), nullptr /*expertIds*/,
+        static_cast<int*>(permuted_idx_to_token_idx.data_ptr()), precomputed_expert_ids(),
         workspace.expert_weights, static_cast<int*>(num_tokens_per_expert.data_ptr()),
         static_cast<int*>(cta_idx_xy_to_batch_idx.data_ptr()),
         static_cast<int*>(cta_idx_xy_to_mn_limit.data_ptr()),
@@ -1914,8 +1962,7 @@ class FP4BlockScaleLauncher : public FusedMoeLauncher {
       TensorView const& topk_weights)
       : FusedMoeLauncher(routing_logits, routing_bias, hidden_states, gemm1_weights, gemm1_bias,
                          output1_scales_scalar, output1_scales_gate_scalar, gemm2_weights,
-                         output2_scales_scalar, per_token_scales),
-        routing_input_mode_(routing_input_mode),
+                         output2_scales_scalar, per_token_scales, routing_input_mode),
         hidden_states_scale(hidden_states_scale),
         gemm1_weights_scale(gemm1_weights_scale),
         gemm1_alpha(gemm1_alpha),
@@ -2144,7 +2191,6 @@ class FP4BlockScaleLauncher : public FusedMoeLauncher {
   }
 
  private:
-  RoutingInputMode routing_input_mode_;
   Optional<TensorView> hidden_states_scale;
   TensorView gemm1_weights_scale;
   Optional<TensorView> gemm1_alpha;
@@ -2279,17 +2325,18 @@ class FP4BlockScaleLauncher : public FusedMoeLauncher {
 };
 
 Array<Tensor> trtllm_bf16_moe(
-    Optional<TensorView> const& routing_logits, Optional<TensorView> const& routing_bias,
-    TensorView const& expert_indices, TensorView const& expert_weights,
-    TensorView const& hidden_states, TensorView const& gemm1_weights,
-    TensorView const& gemm2_weights, Optional<TensorView> const& gemm1_lora_delta,
-    Optional<TensorView> const& gemm1_alpha, Optional<TensorView> const& gemm1_beta,
-    Optional<TensorView> const& gemm1_clamp_limit, TensorView output, int64_t num_experts,
-    int64_t top_k, Optional<int64_t> n_group, Optional<int64_t> topk_group,
-    int64_t intermediate_size, int64_t local_expert_offset, int64_t local_num_experts,
-    Optional<double> routed_scaling_factor, int64_t routing_method_type, bool use_shuffled_weight,
-    int64_t weight_layout, bool do_finalize, bool enable_pdl, Array<int64_t> moe_tactic,
-    int64_t activation_type, bool norm_topk_prob, Optional<TensorView> routing_replay_out) {
+    int64_t routing_input_mode, Optional<TensorView> const& routing_logits,
+    Optional<TensorView> const& routing_bias, TensorView const& expert_indices,
+    TensorView const& expert_weights, TensorView const& hidden_states,
+    TensorView const& gemm1_weights, TensorView const& gemm2_weights,
+    Optional<TensorView> const& gemm1_lora_delta, Optional<TensorView> const& gemm1_alpha,
+    Optional<TensorView> const& gemm1_beta, Optional<TensorView> const& gemm1_clamp_limit,
+    TensorView output, int64_t num_experts, int64_t top_k, Optional<int64_t> n_group,
+    Optional<int64_t> topk_group, int64_t intermediate_size, int64_t local_expert_offset,
+    int64_t local_num_experts, Optional<double> routed_scaling_factor, int64_t routing_method_type,
+    bool use_shuffled_weight, int64_t weight_layout, bool do_finalize, bool enable_pdl,
+    Array<int64_t> moe_tactic, int64_t activation_type, bool norm_topk_prob,
+    Optional<TensorView> routing_replay_out) {
   // Just some basic type validation first and leave more checks to the launcher
   if (routing_logits.has_value()) {
     TVM_FFI_ICHECK(routing_logits.value().dtype() == dl_float32 ||
@@ -2346,7 +2393,8 @@ Array<Tensor> trtllm_bf16_moe(
     // Create and initialize launcher for this tile size
     auto launcher = std::make_unique<Bf16MoeLauncher>(
         routing_logits, routing_bias, expert_indices, expert_weights, hidden_states, gemm1_weights,
-        gemm2_weights, gemm1_lora_delta, gemm1_alpha, gemm1_beta, gemm1_clamp_limit);
+        gemm2_weights, gemm1_lora_delta, gemm1_alpha, gemm1_beta, gemm1_clamp_limit,
+        static_cast<RoutingInputMode>(routing_input_mode));
     launcher->init(std::move(args), curr_tile_N, routing_method_type, use_shuffled_weight,
                    weight_layout, activation, static_cast<int64_t>(gemm1_bias_type_enum),
                    norm_topk_prob);
@@ -2563,18 +2611,18 @@ Array<Tensor> trtllm_fp8_per_tensor_scale_routed_moe(
 }
 
 Array<Tensor> trtllm_fp8_block_scale_moe(
-    Optional<TensorView> routing_logits, TensorView expert_indices, TensorView expert_weights,
-    Optional<TensorView> routing_bias, TensorView hidden_states, TensorView hidden_states_scale,
-    TensorView gemm1_weights, TensorView gemm1_weights_scale, Optional<TensorView> gemm1_lora_delta,
-    Optional<TensorView> gemm1_alpha, Optional<TensorView> gemm1_beta,
-    Optional<TensorView> gemm1_clamp_limit, TensorView gemm2_weights,
-    TensorView gemm2_weights_scale, TensorView output, int64_t num_experts, int64_t top_k,
-    Optional<int64_t> num_fused_shared_experts, Optional<int64_t> n_group,
-    Optional<int64_t> topk_group, int64_t intermediate_size, int64_t local_expert_offset,
-    int64_t local_num_experts, Optional<double> routed_scaling_factor, int64_t routing_method_type,
-    bool use_shuffled_weight, int64_t weight_layout, bool do_finalize, bool enable_pdl,
-    Array<int64_t> config_index, Fp8QuantizationType quantization_type, int64_t act_type,
-    bool norm_topk_prob, Optional<TensorView> routing_replay_out) {
+    int64_t routing_input_mode, Optional<TensorView> routing_logits, TensorView expert_indices,
+    TensorView expert_weights, Optional<TensorView> routing_bias, TensorView hidden_states,
+    TensorView hidden_states_scale, TensorView gemm1_weights, TensorView gemm1_weights_scale,
+    Optional<TensorView> gemm1_lora_delta, Optional<TensorView> gemm1_alpha,
+    Optional<TensorView> gemm1_beta, Optional<TensorView> gemm1_clamp_limit,
+    TensorView gemm2_weights, TensorView gemm2_weights_scale, TensorView output,
+    int64_t num_experts, int64_t top_k, Optional<int64_t> num_fused_shared_experts,
+    Optional<int64_t> n_group, Optional<int64_t> topk_group, int64_t intermediate_size,
+    int64_t local_expert_offset, int64_t local_num_experts, Optional<double> routed_scaling_factor,
+    int64_t routing_method_type, bool use_shuffled_weight, int64_t weight_layout, bool do_finalize,
+    bool enable_pdl, Array<int64_t> config_index, Fp8QuantizationType quantization_type,
+    int64_t act_type, bool norm_topk_prob, Optional<TensorView> routing_replay_out) {
   auto activation_type = validateAndCastActivationType(act_type);
   validateFp8BlockScaleGemm1ActivationParams(gemm1_alpha, gemm1_beta, gemm1_clamp_limit,
                                              quantization_type, activation_type);
@@ -2686,7 +2734,8 @@ Array<Tensor> trtllm_fp8_block_scale_moe(
     auto launcher = std::make_unique<Fp8BlockScaleLauncher>(
         routing_logits, routing_bias, hidden_states, hidden_states_scale, gemm1_weights,
         gemm1_weights_scale, gemm1_lora_delta, gemm1_alpha, gemm1_beta, gemm1_clamp_limit,
-        gemm2_weights, gemm2_weights_scale, expert_indices, expert_weights, quantization_type);
+        gemm2_weights, gemm2_weights_scale, expert_indices, expert_weights, quantization_type,
+        static_cast<RoutingInputMode>(routing_input_mode));
     launcher->init(std::move(args), curr_tile_N, routing_method_type, use_shuffled_weight,
                    weight_layout, activation_type, static_cast<int64_t>(gemm1_bias_type_enum),
                    norm_topk_prob);

--- a/flashinfer/fused_moe/core.py
+++ b/flashinfer/fused_moe/core.py
@@ -1668,6 +1668,7 @@ def _get_trtllm_moe_sm100_module_impl(enable_rubin: bool):
             if self.dtype_weights == DtypeTrtllmGen.Bfloat16:
                 # BF16 operations
                 moe_op.trtllm_bf16_moe(
+                    kwargs["routing_input_mode"],
                     routing_logits,
                     kwargs["routing_bias"],
                     topk_ids,
@@ -1712,6 +1713,7 @@ def _get_trtllm_moe_sm100_module_impl(enable_rubin: bool):
                 ):
                     # FP8 block scale
                     moe_op.trtllm_fp8_block_scale_moe(
+                        kwargs["routing_input_mode"],
                         routing_logits,
                         topk_ids,
                         topk_weights,
@@ -1886,6 +1888,7 @@ def _get_trtllm_moe_sm100_module_impl(enable_rubin: bool):
         mutates_args=("routing_replay_out",),
     )
     def trtllm_bf16_moe_op(
+        routing_input_mode: int,
         routing_logits: Optional[torch.Tensor],
         routing_bias: Optional[torch.Tensor],
         topk_ids: Optional[torch.Tensor],
@@ -1995,6 +1998,7 @@ def _get_trtllm_moe_sm100_module_impl(enable_rubin: bool):
         tuning_config = moe_runner._make_tuning_config(
             moe_inputs,
             tune_max_num_tokens=tune_max_num_tokens,
+            routing_input_mode=RoutingInputMode(routing_input_mode),
             use_cuda_graph=True,
             use_cold_l2_cache=True,
         )
@@ -2005,6 +2009,7 @@ def _get_trtllm_moe_sm100_module_impl(enable_rubin: bool):
             tuning_config,
             moe_inputs.to_list(),
             routing_bias=routing_bias,
+            routing_input_mode=routing_input_mode,
             gemm1_weights=gemm1_weights,
             gemm2_weights=gemm2_weights,
             gemm1_alpha=gemm1_alpha,
@@ -2026,6 +2031,7 @@ def _get_trtllm_moe_sm100_module_impl(enable_rubin: bool):
 
         # Call the C++ function with the selected tactic
         intermediate_output = moe_op.trtllm_bf16_moe(
+            routing_input_mode,
             routing_logits,
             routing_bias,
             topk_ids,
@@ -2063,6 +2069,7 @@ def _get_trtllm_moe_sm100_module_impl(enable_rubin: bool):
 
     @register_fake_op("flashinfer::trtllm_bf16_moe")
     def _fake_trtllm_bf16_moe(
+        routing_input_mode: int,
         routing_logits: Optional[torch.Tensor],
         routing_bias: Optional[torch.Tensor],
         topk_ids: Optional[torch.Tensor],
@@ -2473,6 +2480,7 @@ def _get_trtllm_moe_sm100_module_impl(enable_rubin: bool):
         mutates_args=("routing_replay_out",),
     )
     def trtllm_fp8_block_scale_moe_op(
+        routing_input_mode: int,
         routing_logits: Optional[torch.Tensor],
         topk_ids: Optional[torch.Tensor],
         expert_weights: Optional[torch.Tensor],
@@ -2603,6 +2611,7 @@ def _get_trtllm_moe_sm100_module_impl(enable_rubin: bool):
         tuning_config = moe_runner._make_tuning_config(
             moe_inputs,
             tune_max_num_tokens=tune_max_num_tokens,
+            routing_input_mode=RoutingInputMode(routing_input_mode),
             use_cuda_graph=True,
             use_cold_l2_cache=True,
         )
@@ -2612,6 +2621,7 @@ def _get_trtllm_moe_sm100_module_impl(enable_rubin: bool):
             [moe_runner],
             tuning_config,
             moe_inputs.to_list(),
+            routing_input_mode=routing_input_mode,
             routing_bias=routing_bias,
             gemm1_weights=gemm1_weights,
             gemm1_weights_scale=gemm1_weights_scale,
@@ -2636,6 +2646,7 @@ def _get_trtllm_moe_sm100_module_impl(enable_rubin: bool):
         _nfse = num_fused_shared_experts if num_fused_shared_experts is not None else 0
         # Call the C++ function for block scale MoE
         intermediate_output = moe_op.trtllm_fp8_block_scale_moe(
+            routing_input_mode,
             routing_logits,
             topk_ids,
             expert_weights,
@@ -2677,6 +2688,7 @@ def _get_trtllm_moe_sm100_module_impl(enable_rubin: bool):
 
     @register_fake_op("flashinfer::trtllm_fp8_block_scale_moe")
     def _fake_trtllm_fp8_block_scale_moe(
+        routing_input_mode: int,
         routing_logits: Optional[torch.Tensor],
         topk_ids: Optional[torch.Tensor],
         expert_weights: Optional[torch.Tensor],
@@ -2864,6 +2876,7 @@ def _get_trtllm_moe_sm100_module_impl(enable_rubin: bool):
         tuning_config = moe_runner._make_tuning_config(
             moe_inputs,
             tune_max_num_tokens=tune_max_num_tokens,
+            routing_input_mode=RoutingInputMode(routing_input_mode),
             use_cold_l2_cache=True,
             use_cuda_graph=True,
         )
@@ -3448,6 +3461,7 @@ def trtllm_bf16_moe(
         hidden_states.device,
     )
     result = get_trtllm_moe_sm100_module().trtllm_bf16_moe(
+        RoutingInputMode.FromLogits,
         routing_logits,
         routing_bias,
         None,  # topk_ids
@@ -3488,9 +3502,19 @@ def trtllm_bf16_moe(
         return result
 
 
+def _split_precomputed_routing(
+    topk_ids: Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]],
+) -> Tuple[torch.Tensor, Optional[torch.Tensor], "RoutingInputMode"]:
+    """Split a routed-MoE ``topk_ids`` argument into its kernel-level inputs."""
+    if isinstance(topk_ids, tuple):
+        topk_ids_tensor, topk_weights = topk_ids
+        return topk_ids_tensor, topk_weights, RoutingInputMode.UnpackedPrecomputed
+    return topk_ids, None, RoutingInputMode.PackedPrecomputed
+
+
 @flashinfer_api(trace=trtllm_bf16_routed_moe_trace)
 def trtllm_bf16_routed_moe(
-    topk_ids: torch.Tensor,
+    topk_ids: Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]],
     hidden_states: torch.Tensor,
     gemm1_weights: torch.Tensor,
     gemm2_weights: torch.Tensor,
@@ -3518,15 +3542,17 @@ def trtllm_bf16_routed_moe(
 ) -> Union[torch.Tensor, List[torch.Tensor]]:
     r"""Pre-routed BF16 MoE operation with autotuning support.
 
-    Like :func:`trtllm_bf16_moe`, but takes a pre-computed ``topk_ids`` tensor
-    (the packed ``(expert_id, weight)`` representation produced by an upstream
-    routing kernel) instead of routing logits.
+    Like :func:`trtllm_bf16_moe`, but takes pre-computed routing instead of
+    routing logits, either as a packed ``topk_ids`` tensor or as a
+    ``(topk_ids, topk_weights)`` pair.
 
     Parameters
     ----------
-    topk_ids : torch.Tensor
+    topk_ids : torch.Tensor or Tuple[torch.Tensor, torch.Tensor]
         ``[seq_len, top_k]`` int32 tensor of packed expert indices and
         weights.  Format ``(expert_id << 16) | (weight_bf16.view(int16))``.
+        Alternatively a ``(topk_ids, topk_weights)`` pair of plain ``int32``
+        indices and ``bfloat16`` or ``float32`` weights.
     hidden_states : torch.Tensor
         ``[seq_len, hidden_size]`` tensor of input hidden states, ``bfloat16``.
     gemm1_weights : torch.Tensor
@@ -3650,11 +3676,14 @@ def trtllm_bf16_routed_moe(
         local_num_experts,
         hidden_states.device,
     )
+    topk_ids_tensor, topk_weights, routing_mode = _split_precomputed_routing(topk_ids)
+
     result = get_trtllm_moe_sm100_module().trtllm_bf16_moe(
+        routing_mode,
         None,
         None,
-        topk_ids,
-        None,
+        topk_ids_tensor,
+        topk_weights,
         hidden_states,
         gemm1_weights,
         gemm2_weights,
@@ -4174,6 +4203,7 @@ def trtllm_fp8_block_scale_moe(
         gemm1_clamp_limit,
     )
     result = get_trtllm_moe_sm100_module().trtllm_fp8_block_scale_moe(
+        RoutingInputMode.FromLogits,
         routing_logits,
         None,  # topk_ids - will be computed from routing_logits
         None,  # expert_weights - will be computed from routing_logits
@@ -4221,7 +4251,7 @@ def trtllm_fp8_block_scale_moe(
 
 @flashinfer_api(trace=trtllm_fp8_block_scale_routed_moe_trace)
 def trtllm_fp8_block_scale_routed_moe(
-    topk_ids: torch.Tensor,
+    topk_ids: Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]],
     routing_bias: Optional[torch.Tensor],
     hidden_states: torch.Tensor,
     hidden_states_scale: torch.Tensor,
@@ -4253,16 +4283,19 @@ def trtllm_fp8_block_scale_routed_moe(
 ) -> Union[List[torch.Tensor], torch.Tensor]:
     r"""Pre-routed FP8 block-scaled MoE operation.
 
-    Like :func:`trtllm_fp8_block_scale_moe`, but consumes a pre-computed packed
-    ``(expert_id, weight)`` tensor instead of routing logits.  Use this entry
+    Like :func:`trtllm_fp8_block_scale_moe`, but consumes pre-computed routing
+    instead of routing logits, either as a packed ``(expert_id, weight)``
+    tensor or as a ``(topk_ids, topk_weights)`` pair.  Use this entry
     point for CUDA-graph capture (avoids the CPU-GPU sync from logits
     processing) or distributed MoE where routing happens elsewhere.
 
     Parameters
     ----------
-    topk_ids : torch.Tensor
+    topk_ids : torch.Tensor or Tuple[torch.Tensor, torch.Tensor]
         ``[seq_len, top_k]`` int32 tensor of packed expert indices and weights
         with format ``(expert_id << 16) | (weight_bf16.view(int16))``.
+        Alternatively a ``(topk_ids, topk_weights)`` pair of plain ``int32``
+        indices and ``bfloat16`` or ``float32`` weights.
     routing_bias : Optional[torch.Tensor]
         ``[num_experts]`` tensor of routing bias, ``bfloat16`` or
         ``float32``.  May be ``None``.
@@ -4391,10 +4424,13 @@ def trtllm_fp8_block_scale_routed_moe(
         gemm1_beta,
         gemm1_clamp_limit,
     )
+    topk_ids_tensor, topk_weights, routing_mode = _split_precomputed_routing(topk_ids)
+
     result = get_trtllm_moe_sm100_module().trtllm_fp8_block_scale_moe(
+        routing_mode,
         None,  # routing_logits
-        topk_ids,
-        None,  # expert_weights
+        topk_ids_tensor,
+        topk_weights,
         routing_bias,
         hidden_states,
         hidden_states_scale,
@@ -4832,16 +4868,7 @@ def trtllm_fp4_block_scale_routed_moe(
         Return shape depends on ``do_finalize`` and ``gemm1_lora_delta``;
         see :func:`trtllm_bf16_routed_moe` for the table.
     """
-    # Determine routing mode based on input format
-    if isinstance(topk_ids, tuple):
-        # Unpacked format: (topk_ids, topk_weights)
-        topk_ids_tensor, topk_weights = topk_ids
-        routing_mode = RoutingInputMode.UnpackedPrecomputed
-    else:
-        # Packed format: single tensor with ``(expert_id << 16) | weight``
-        topk_ids_tensor = topk_ids
-        topk_weights = None
-        routing_mode = RoutingInputMode.PackedPrecomputed
+    topk_ids_tensor, topk_weights, routing_mode = _split_precomputed_routing(topk_ids)
 
     # The kernel folds dequantScaleAb into scaleC and applies it to the bias
     # when the input is Fp8 or NvFp4 and DeepSeekFp8 is not used (see trtllm-gen

--- a/tests/moe/test_trtllm_gen_fused_moe.py
+++ b/tests/moe/test_trtllm_gen_fused_moe.py
@@ -1855,6 +1855,16 @@ def test_fp8_block_scale_routed_activation_type_relu2_smoke():
     expert_weights = expert_weights_full.view(num_tokens, num_experts)[
         torch.arange(num_tokens, device=device).unsqueeze(1), topk_ids
     ].to(torch.bfloat16)
+    # expert_weights_full is bfloat16, so redo the reference softmax in fp32 to
+    # get routing weights that are not bfloat16-representable.
+    topk_values, topk_idx = torch.topk(routing_logits, k=top_k, dim=-1)
+    scores_fp32 = torch.zeros(
+        (num_tokens, num_experts), device=device, dtype=torch.float32
+    )
+    scores_fp32.scatter_(-1, topk_idx, torch.softmax(topk_values.float(), dim=-1))
+    expert_weights_fp32 = scores_fp32[
+        torch.arange(num_tokens, device=device).unsqueeze(1), topk_ids
+    ].contiguous()
     packed_topk_ids = pack_topk_for_routed_moe(topk_ids, expert_weights)
 
     output_routed = trtllm_fp8_block_scale_routed_moe(
@@ -1885,6 +1895,37 @@ def test_fp8_block_scale_routed_activation_type_relu2_smoke():
     close = torch.isclose(output_ref, output_routed, atol=1e-2, rtol=1e-2)
     mismatch_pct = (~close).float().mean().item() * 100
     assert mismatch_pct < 10, f"Mismatch percentage is {mismatch_pct:.2f}%"
+
+    for weights in (expert_weights, expert_weights_fp32):
+        output_unpacked = trtllm_fp8_block_scale_routed_moe(
+            topk_ids=(topk_ids, weights),
+            routing_bias=None,
+            hidden_states=quant_inputs["hidden_states"],
+            hidden_states_scale=quant_inputs["hidden_states_scale"],
+            gemm1_weights=quant_weights["gemm1_weights"],
+            gemm1_weights_scale=quant_weights["gemm1_scales"],
+            gemm2_weights=quant_weights["gemm2_weights"],
+            gemm2_weights_scale=quant_weights["gemm2_scales"],
+            num_experts=num_experts,
+            top_k=top_k,
+            n_group=None,
+            topk_group=None,
+            intermediate_size=intermediate_size,
+            local_expert_offset=0,
+            local_num_experts=num_experts,
+            routed_scaling_factor=None,
+            routing_method_type=routing_method_type.value,
+            use_shuffled_weight=True,
+            weight_layout=WeightLayout.MajorK.value,
+            enable_pdl=True,
+            fp8_quantization_type=fp8_quantization_type,
+            activation_type=activation_type,
+        ).to(torch.float)
+        close = torch.isclose(output_ref, output_unpacked, atol=1e-2, rtol=1e-2)
+        mismatch_pct = (~close).float().mean().item() * 100
+        assert mismatch_pct < 10, (
+            f"{weights.dtype} unpacked mismatch percentage is {mismatch_pct:.2f}%"
+        )
 
 
 def test_fp8_block_scale_moe_swiglu_oa_activation_param_validation():


### PR DESCRIPTION
`trtllm_fp8_block_scale_routed_moe` and `trtllm_bf16_routed_moe` only take the packed `(expert_id << 16) | bf16(weight)` form, which truncates the fp32 routing weights callers already have. However FP4 already handles this.

#3763 gave the FP4 path`(topk_ids, topk_weights)` form; this does the same for the FP8 block-scale and BF16 runners.

And unified support in https://github.com/flashinfer-ai/flashinfer/pull/4104

Now fp32 weights reach the combine as fp32.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added logits-based, packed precomputed, and unpacked precomputed routing for BF16, FP8, and FP4 Mixture-of-Experts operations.
  - Routed APIs now accept packed expert IDs or separate expert IDs and weights.
  - Precomputed routing supports FP32 and BF16 expert weights where applicable.

- **Bug Fixes**
  - Improved validation and handling of unpacked routing inputs.

- **Tests**
  - Added FP8 routing coverage for multiple expert-weight formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->