### PR TITLE
Mirror nightly release to flashinfer-ai/whl repo

### DIFF
--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -1,5 +1,9 @@
 name: Nightly Release
 
+env:
+  NIGHTLY_RELEASE_REPOSITORY: flashinfer-ai/whl
+  LEGACY_NIGHTLY_RELEASE_REPOSITORY: flashinfer-ai/flashinfer
+
 on:
   schedule:
     # Run at 00:00 UTC every day
@@ -206,25 +210,52 @@ jobs:
     needs: [setup, build-flashinfer-python, build-flashinfer-cubin, build-flashinfer-jit-cache]
     runs-on: ubuntu-latest
     permissions:
+      actions: read
       contents: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Create GitHub Release (empty first)
+      # Temporary dual-write during the transition to flashinfer-ai/whl.
+      - name: Create legacy nightly release in flashinfer repository (empty first)
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           TAG="${{ needs.setup.outputs.release_tag }}"
 
-          # Delete existing release and tag if they exist
-          if gh release view "$TAG" &>/dev/null; then
+          if gh release view "$TAG" --repo "${LEGACY_NIGHTLY_RELEASE_REPOSITORY}" &>/dev/null; then
             echo "Deleting existing release: $TAG"
-            gh release delete "$TAG" --yes --cleanup-tag
+            gh release delete "$TAG" \
+              --repo "${LEGACY_NIGHTLY_RELEASE_REPOSITORY}" \
+              --yes \
+              --cleanup-tag
+          fi
+
+          gh release create "$TAG" \
+            --repo "${LEGACY_NIGHTLY_RELEASE_REPOSITORY}" \
+            --title "Nightly Release v${{ needs.setup.outputs.version }}-${{ needs.setup.outputs.dev_suffix }}" \
+            --notes "Automated nightly build for version ${{ needs.setup.outputs.version }} (dev${{ needs.setup.outputs.dev_suffix }})" \
+            --prerelease
+
+      - name: Create nightly release in wheel repository (empty first)
+        env:
+          # Requires contents: write access to NIGHTLY_RELEASE_REPOSITORY.
+          GH_TOKEN: ${{ secrets.WHL_TOKEN }}
+        run: |
+          TAG="${{ needs.setup.outputs.release_tag }}"
+
+          # Delete existing release and tag if they exist
+          if gh release view "$TAG" --repo "${NIGHTLY_RELEASE_REPOSITORY}" &>/dev/null; then
+            echo "Deleting existing release: $TAG"
+            gh release delete "$TAG" \
+              --repo "${NIGHTLY_RELEASE_REPOSITORY}" \
+              --yes \
+              --cleanup-tag
           fi
 
           # Create new release without assets first
           gh release create "$TAG" \
+            --repo "${NIGHTLY_RELEASE_REPOSITORY}" \
             --title "Nightly Release v${{ needs.setup.outputs.version }}-${{ needs.setup.outputs.dev_suffix }}" \
             --notes "Automated nightly build for version ${{ needs.setup.outputs.version }} (dev${{ needs.setup.outputs.dev_suffix }})" \
             --prerelease
@@ -235,11 +266,17 @@ jobs:
           name: flashinfer-python-dist
           path: dist-python/
 
-      - name: Upload flashinfer-python to release
+      - name: Upload flashinfer-python to both releases
         env:
           GH_TOKEN: ${{ github.token }}
+          WHL_TOKEN: ${{ secrets.WHL_TOKEN }}
         run: |
-          gh release upload "${{ needs.setup.outputs.release_tag }}" dist-python/* --clobber
+          gh release upload "${{ needs.setup.outputs.release_tag }}" dist-python/* \
+            --repo "${LEGACY_NIGHTLY_RELEASE_REPOSITORY}" \
+            --clobber
+          GH_TOKEN="${WHL_TOKEN}" gh release upload "${{ needs.setup.outputs.release_tag }}" dist-python/* \
+            --repo "${NIGHTLY_RELEASE_REPOSITORY}" \
+            --clobber
 
       - name: Download flashinfer-cubin artifact
         uses: actions/download-artifact@v4
@@ -247,15 +284,22 @@ jobs:
           name: flashinfer-cubin-wheel
           path: dist-cubin/
 
-      - name: Upload flashinfer-cubin to release
+      - name: Upload flashinfer-cubin to both releases
         env:
           GH_TOKEN: ${{ github.token }}
+          WHL_TOKEN: ${{ secrets.WHL_TOKEN }}
         run: |
-          gh release upload "${{ needs.setup.outputs.release_tag }}" dist-cubin/* --clobber
+          gh release upload "${{ needs.setup.outputs.release_tag }}" dist-cubin/* \
+            --repo "${LEGACY_NIGHTLY_RELEASE_REPOSITORY}" \
+            --clobber
+          GH_TOKEN="${WHL_TOKEN}" gh release upload "${{ needs.setup.outputs.release_tag }}" dist-cubin/* \
+            --repo "${NIGHTLY_RELEASE_REPOSITORY}" \
+            --clobber
 
-      - name: Upload flashinfer-jit-cache wheels to release (one at a time to avoid OOM)
+      - name: Upload flashinfer-jit-cache wheels to both releases (one at a time to avoid OOM)
         env:
           GH_TOKEN: ${{ github.token }}
+          WHL_TOKEN: ${{ secrets.WHL_TOKEN }}
         run: |
           # Upload jit-cache wheels one at a time to avoid OOM
           # Each wheel can be several GB, so we download, upload, delete, repeat
@@ -274,8 +318,13 @@ jobs:
 
               # Upload to release
               if [ -n "$(ls -A dist-jit-cache/)" ]; then
-                gh release upload "${{ needs.setup.outputs.release_tag }}" dist-jit-cache/* --clobber
-                echo "✅ Uploaded ${ARTIFACT_NAME}"
+                gh release upload "${{ needs.setup.outputs.release_tag }}" dist-jit-cache/* \
+                  --repo "${LEGACY_NIGHTLY_RELEASE_REPOSITORY}" \
+                  --clobber
+                GH_TOKEN="${WHL_TOKEN}" gh release upload "${{ needs.setup.outputs.release_tag }}" dist-jit-cache/* \
+                  --repo "${NIGHTLY_RELEASE_REPOSITORY}" \
+                  --clobber
+                echo "✅ Uploaded ${ARTIFACT_NAME} to both release repositories"
               fi
 
               # Clean up to save disk space before next iteration
@@ -425,6 +474,7 @@ jobs:
           python3 scripts/update_whl_index.py \
             --dist-dir dist \
             --output-dir flashinfer-whl \
+            --base-url "https://github.com/${NIGHTLY_RELEASE_REPOSITORY}/releases/download" \
             --release-tag "${{ needs.setup.outputs.release_tag }}" \
             --nightly
 


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->
In order to help clean up our main releases page, this will start mirroring nightly builds over to the https://github.com/flashinfer-ai/whl repo.

Once we have a few uploaded there, we can update the nightly wheel index to pull from the new location and disable the legacy one so that only tagged/numbered releases will display there.

## 🔍 Related Issues

<!-- Link any related issues here -->

https://github.com/flashinfer-ai/flashinfer/issues/3854

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved nightly release publishing by separating legacy and wheel distributions.
  - Nightly releases now include Python packages, compiled artifacts, and JIT caches in both distribution channels.
  - Updated the wheel index to provide accurate download links for nightly wheel packages.
  - Nightly prereleases are now created consistently across both repositories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->