### PR TITLE
fix(comm): keep fd_exchange importable on Python 3.10/3.11

### DIFF
--- a/flashinfer/comm/fd_exchange.py
+++ b/flashinfer/comm/fd_exchange.py
@@ -25,6 +25,10 @@ plus the low-level SCM_RIGHTS send/recv primitives shared by connectionless
 (SOCK_DGRAM) callers.
 """
 
+# PEP 563: ``_fd_ancillary`` annotates ``array.array[int]``, which is only
+# subscriptable on Python 3.12+; lazy annotations keep 3.10/3.11 importable.
+from __future__ import annotations
+
 import array
 import contextlib
 import logging

--- a/tests/comm/test_fd_exchange.py
+++ b/tests/comm/test_fd_exchange.py
@@ -231,6 +231,13 @@ def test_fd_ancillary_extract_roundtrip() -> None:
     assert _extract_fd([(socket.SOL_SOCKET, socket.SCM_RIGHTS, buf.tobytes())]) == 7
 
 
+def test_fd_ancillary_annotation_is_not_evaluated() -> None:
+    """``array.array[int]`` is only subscriptable on Python 3.12+, so evaluating
+    this annotation would break ``import flashinfer.comm`` on 3.10/3.11.
+    """
+    assert isinstance(_fd_ancillary.__annotations__["return"], str)
+
+
 def test_extract_fd_ignores_unrelated_control_messages() -> None:
     assert _extract_fd([]) is None
     wrong = array.array("i", [123]).tobytes()


### PR DESCRIPTION
## 📌 Description

`flashinfer/comm/fd_exchange.py` annotates `_fd_ancillary` with `array.array[int]`:

```python
def _fd_ancillary(fd: int) -> tuple[tuple[int, int, array.array[int]]]:
```

`array.array` only became subscriptable (PEP 585 `__class_getitem__`) in Python 3.12.
Since the annotation is evaluated at function-definition time, importing this module
raises on older interpreters:

```
TypeError: type 'array.array' is not subscriptable
```

Both Python 3.10 and 3.11 are inside the range declared in `pyproject.toml`
(`requires-python = ">=3.10,<4.0"`), so this is a genuine support-matrix break rather
than a user misconfiguration.

The blast radius is larger than the helper itself: `flashinfer/comm/mnnvl.py` imports
`fd_exchange` at module scope, so `import flashinfer.comm` fails outright on 3.10/3.11.
Downstream packages that touch `flashinfer.comm` during their own initialization
therefore fail to import at all — we hit this in TensorRT-LLM CI, where the Python 3.10
package-sanity job could no longer run `import tensorrt_llm` after upgrading to 0.6.16.

**Fix:** add `from __future__ import annotations` (PEP 563) so the annotation stays a
string and is never subscripted at runtime. No behavior change on 3.12+.

Scope check: `array.array[` occurs exactly once in the repository, so this one file is
the whole problem.

## 🔍 Related Issues

Introduced by #3701, which added `fd_exchange.py`. Present in every release from
`v0.6.16rc1` onward (`v0.6.16`, `v0.6.16.post1`, `v0.6.16.post2`, `v0.6.17rc1`–`rc3`)
and on `main`; `v0.6.15` predates the file and is unaffected.

## 🚀 Pull Request Checklist

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

Added `test_fd_ancillary_annotation_is_not_evaluated`, which asserts the return
annotation stays a `str`. Verified it is a real regression guard: it fails on the
unpatched tree and passes with the fix.

```
tests/comm/test_fd_exchange.py .................  16 passed
tests/comm/test_fd_exchange.py::test_fd_ancillary_annotation_is_not_evaluated
    without fix -> FAILED
    with fix    -> PASSED
```

Language-level behavior confirmed on a 3.11 interpreter:

```
python:3.11 without `from __future__ import annotations`
    -> TypeError: type 'array.array' is not subscriptable
python:3.11 with `from __future__ import annotations`
    -> OK
```

## Reviewer Notes

The test asserts on `__annotations__` rather than importing under an older interpreter,
because the failure is interpreter-version dependent and cannot be reproduced in-process
on 3.12. If CI does not already exercise the minimum supported Python, running the
`tests/comm` suite once on 3.10 would catch this class of regression directly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with Python 3.10 and 3.11 by preventing import errors related to type annotations.

* **Tests**
  * Added regression coverage to verify compatibility across supported Python versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->