### PR TITLE
test: Add sharding support to scripts/task_run_unit_tests.sh

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,0 +1,2 @@
+# Pytest plugins required for the repository's test semantics.
+pytest-timeout

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,1 @@
+"""Repository automation modules."""

--- a/scripts/rebuild_test_duration_estimates.py
+++ b/scripts/rebuild_test_duration_estimates.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+"""Reconstruct and refresh deterministic pytest duration estimates from JUnit runs."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from scripts.test_sharding.models import Plan
+from scripts.test_sharding.observations import (
+    EstimateRefresh,
+    ObservedCase,
+    refresh_estimates,
+)
+from scripts.test_sharding.scanner import (
+    scan_cleaned_artifact_dirs,
+    scan_observation_inputs,
+    write_scan_outputs,
+)
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    for command, help_text in (
+        ("scan", "write reviewable observations without modifying estimates"),
+        ("refresh", "scan observations and update local estimate files"),
+    ):
+        child = subparsers.add_parser(command, help=help_text)
+        child.add_argument(
+            "inputs",
+            type=Path,
+            nargs="*",
+            help="runner JUnit directories or XML files defining the observation window",
+        )
+        child.add_argument(
+            "--cleaned-artifact-dir",
+            type=Path,
+            action="append",
+            default=[],
+            help=(
+                "directory containing GitLab-cleaned ZIP artifacts and sibling "
+                "job logs; may be repeated"
+            ),
+        )
+        child.add_argument(
+            "--reconstruction-manifest",
+            type=Path,
+            help=(
+                "compatible runner manifest used to restore node IDs truncated "
+                "in cleaned artifacts"
+            ),
+        )
+        child.add_argument(
+            "--output-dir",
+            type=Path,
+            default=Path.cwd(),
+            help="directory for observed CSV and JSON review artifacts",
+        )
+        if command == "refresh":
+            child.add_argument(
+                "--duration-file",
+                type=Path,
+                default=REPO_ROOT
+                / "tests"
+                / "data"
+                / "unit_test_duration_estimates.csv.gz",
+            )
+            child.add_argument(
+                "--overhead-file",
+                type=Path,
+                default=REPO_ROOT
+                / "tests"
+                / "data"
+                / "unit_test_overhead_estimates.csv",
+            )
+            child.add_argument(
+                "--summary-file",
+                type=Path,
+                default=REPO_ROOT
+                / "tests"
+                / "data"
+                / "unit_test_duration_estimates_summary.csv",
+            )
+            child.add_argument(
+                "--prune",
+                action="store_true",
+                help="remove obsolete nodes proven absent by a complete collection manifest",
+            )
+            child.add_argument(
+                "--complete-collection-manifest",
+                type=Path,
+                help="manifest proving a complete, unsampled tests/ collection for --prune",
+            )
+    return parser
+
+
+def _prune_scope(manifest_path: Path) -> set[str]:
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    if manifest.get("selection", {}).get("sanity_test"):
+        raise ValueError("a sampled manifest cannot authorize pruning")
+    test_path = (REPO_ROOT / Path(manifest["test_path"])).resolve()
+    if test_path != (REPO_ROOT / "tests").resolve():
+        raise ValueError("pruning requires a complete collection rooted at tests/")
+    plan = Plan.from_dict(manifest["plan"])
+    return {node.nodeid for node in plan.nodes}
+
+
+def _validate_inputs(args: argparse.Namespace) -> None:
+    if not args.inputs and not args.cleaned_artifact_dir:
+        raise ValueError("provide runner JUnit inputs or --cleaned-artifact-dir")
+    if args.cleaned_artifact_dir and args.reconstruction_manifest is None:
+        raise ValueError("--cleaned-artifact-dir requires --reconstruction-manifest")
+    if args.reconstruction_manifest is not None and not args.cleaned_artifact_dir:
+        raise ValueError("--reconstruction-manifest requires --cleaned-artifact-dir")
+
+
+def _scan_inputs(args: argparse.Namespace):
+    observations, overheads, diagnostics = scan_observation_inputs(args.inputs)
+    if args.cleaned_artifact_dir:
+        artifact_observations, artifact_overheads, artifact_diagnostics = (
+            scan_cleaned_artifact_dirs(
+                args.cleaned_artifact_dir,
+                args.reconstruction_manifest,
+            )
+        )
+        observations.extend(artifact_observations)
+        overheads.extend(artifact_overheads)
+        diagnostics.extend(artifact_diagnostics)
+    return observations, overheads, diagnostics
+
+
+def _refresh_scope(
+    args: argparse.Namespace, observations: list[ObservedCase]
+) -> tuple[set[str] | None, str | None]:
+    if args.prune:
+        if args.complete_collection_manifest is None:
+            raise ValueError("--prune requires --complete-collection-manifest")
+        profiles = {observation.profile for observation in observations}
+        if len(profiles) != 1:
+            raise ValueError(
+                "--prune requires observations from exactly one timing profile"
+            )
+        return _prune_scope(args.complete_collection_manifest), profiles.pop()
+    if args.complete_collection_manifest is not None:
+        raise ValueError("--complete-collection-manifest is only valid with --prune")
+    return None, None
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    _validate_inputs(args)
+    observations, overheads, diagnostics = _scan_inputs(args)
+    write_scan_outputs(args.output_dir, observations, overheads, diagnostics)
+    for diagnostic in diagnostics:
+        print(f"WARNING: {diagnostic}", file=sys.stderr)
+    print(
+        f"Scanned {len(observations)} testcase observations and "
+        f"{len(overheads)} batch overhead observations"
+    )
+    if args.command == "scan":
+        return 0
+    if not observations:
+        raise ValueError(
+            "refresh requires at least one eligible real testcase observation"
+        )
+    keep_nodeids, prune_profile = _refresh_scope(args, observations)
+    refresh_estimates(
+        observations,
+        overheads,
+        EstimateRefresh(
+            duration_file=args.duration_file,
+            overhead_file=args.overhead_file,
+            summary_file=args.summary_file,
+            keep_nodeids=keep_nodeids,
+            prune_profile=prune_profile,
+        ),
+    )
+    print(f"Updated {args.duration_file}")
+    print(f"Updated {args.overhead_file}")
+    print(f"Updated {args.summary_file}")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except (OSError, ValueError, KeyError, json.JSONDecodeError) as error:
+        print(f"ERROR: {error}", file=sys.stderr)
+        raise SystemExit(3) from None

--- a/scripts/task_run_unit_tests.sh
+++ b/scripts/task_run_unit_tests.sh
@@ -1,143 +1,183 @@
 #!/bin/bash
 
 set -eo pipefail
+exec 2>&1
 
-export PARALLEL_TESTS=true  # Enable parallel test execution for unit tests (auto-discovery mode)
+printf -v UNIT_TEST_RUN_STARTED_AT '%(%s)T' -1
+UNIT_TEST_RUN_STARTED_SECONDS=${SECONDS}
 
-# Get the directory where this script is located
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RUNNER="${SCRIPT_DIR}/unit_test_runner.py"
+SUMMARY_PRINTED=false
+CURRENT_PHASE="preflight"
+LAST_ERROR_COMMAND=""
 
-# Source common test functions
-# shellcheck disable=SC1091  # File exists, checked separately
-source "${SCRIPT_DIR}/test_utils.sh"
-
-# nvshmem4py-cu12 pins cuda-python<=12.9; letting pip resolve its deps on a
-# cu13 container downgrades cuda-python/cuda-bindings and makes the next
-# requirements resolution evict CUDA torch (aarch64 backtracks to the CPU-only
-# wheel -> "Torch not compiled with CUDA enabled"). Install only if missing,
-# and --no-deps: the image already ships the right-flavor cuda-python and
-# nvidia-nvshmem libraries.
-# TODO: Remove once CI container ships with nvshmem4py pre-installed.
-python -c "import nvshmem.core" 2>/dev/null || pip install --no-deps nvshmem4py-cu12
-
-# Find and filter test files based on pytest.ini exclusions
-find_test_files() {
-    SEARCH_DIR="${TEST_PATH:-tests/}"
-
-    if [ -n "$TEST_PATH" ]; then
-        if [ ! -d "${SEARCH_DIR}" ]; then
-            echo "ERROR: TEST_PATH '${SEARCH_DIR}' does not exist or is not a directory."
-            echo "Available test directories:"
-            find tests/ -maxdepth 1 -type d | sort | tail -n +2 | sed 's/^/  /'
-            exit 1
-        fi
-        echo "🎯 TEST_PATH set: scoping test discovery to ${SEARCH_DIR}"
-        echo ""
-    fi
-
-    echo "Reading pytest.ini for excluded directories..."
-    EXCLUDED_DIRS=""
-    if [ -f "./pytest.ini" ]; then
-        # Extract norecursedirs from pytest.ini and convert to array
-        NORECURSEDIRS=$(grep "^norecursedirs" ./pytest.ini | sed 's/norecursedirs\s*=\s*//' | sed 's/#.*//')
-        if [ -n "$NORECURSEDIRS" ]; then
-            EXCLUDED_DIRS=$(echo "$NORECURSEDIRS" | tr ',' ' ' | tr -s ' ')
-            echo "⚠️  WARNING: Excluding directories from pytest.ini: $EXCLUDED_DIRS"
-            echo ""
-        fi
-    fi
-
-    echo "Finding all test_*.py files in ${SEARCH_DIR} directory..."
-
-    # Find all test_*.py files
-    ALL_TEST_FILES=$(find "${SEARCH_DIR}" -name "test_*.py" -type f | sort)
-
-    # Filter out excluded files based on directory exclusions
-    TEST_FILES=""
-    for test_file in $ALL_TEST_FILES; do
-        exclude_file=false
-        test_dir=$(dirname "$test_file")
-
-        for excluded_dir in $EXCLUDED_DIRS; do
-            excluded_dir=$(echo "$excluded_dir" | xargs)  # trim whitespace
-            if [ -n "$excluded_dir" ]; then
-                # Check if this file's directory should be excluded
-                if [[ "$test_dir" == *"/$excluded_dir" ]] || [[ "$test_dir" == "tests/$excluded_dir" ]] || [[ "$test_dir" == *"/$excluded_dir/"* ]]; then
-                    exclude_file=true
-                    break
-                fi
-            fi
-        done
-
-        if [ "$exclude_file" = false ]; then
-            TEST_FILES="$TEST_FILES $test_file"
-        fi
-    done
-
-    # Clean up whitespace
-    TEST_FILES=$(echo "$TEST_FILES" | xargs)
-
-    if [ -z "$TEST_FILES" ]; then
-        echo "No test files found in ${SEARCH_DIR} directory (after exclusions)"
-        exit 1
-    fi
-
-    echo "Found test files:"
-    for test_file in $TEST_FILES; do
-        echo "  $test_file"
-    done
-    echo ""
+record_error_command() {
+    LAST_ERROR_COMMAND=${BASH_COMMAND}
 }
 
-# Main execution
-main() {
-    # Parse command line arguments
-    parse_args "$@"
-
-    # Print test mode banner
-    print_test_mode_banner
-
-    # Install and verify (includes precompiled kernels)
-    install_and_verify
-
-    # apply dependency overrides after installation since pip may overwrite
-    source "${SCRIPT_DIR}/setup_test_env.sh"
-
-    # tests/moe_ep needs the EP runtime stack (nvidia-nccl >= 2.30.7 + nccl4py,
-    # nvshmem4py, DeepGEMM) and a --no-build-isolation FlashInfer install so the
-    # build hook's NCCL floor upgrade isn't lost in a throwaway PEP 517 env.
-    # Without it the split-path tests fail validate_arch_for_backend on
-    # Blackwell (NCCL 2.28.9 from the torch pin) and the deep_gemm multirank
-    # file exits 5 (module-level importorskip collects nothing).
-    # The ~25-min trtllm fused-MoE JIT prewarm stays off (FI_EP_PREWARM
-    # defaults to 0); the torchrun-only tests that would need it auto-skip
-    # here (no WORLD_SIZE).
-    #
-    # build_flashinfer_ep_pytorch.sh pins cuda-bindings==13.2.0 (a cu13 package)
-    # and is designed for the nvcr.io/nvidia/pytorch:26.05 base image. On cu12
-    # CI images that ship CUDA 12.x torch, that pin conflicts with the image's
-    # cuda-python~=12.x and breaks nccl.ep's CUDA-major consistency check.
-    # cu12 CI images already have nccl4py pre-installed as a base dependency of
-    # flashinfer-python, so EP is available (or unavailable due to the cu12/cu13
-    # libnccl_ep mismatch — in either case the tests handle it via auto-skip).
-    _cuda_major=$(python -c \
-        'import torch; v=torch.version.cuda; print(v.split(".")[0] if v else "0")' \
-        2>/dev/null || echo 0)
-    if [ "$DRY_RUN" != "true" ] && [[ "${TEST_PATH:-}" == *moe_ep* ]] && [ "${_cuda_major}" -ge 13 ]; then
-        FI_SRC="$(pwd)" bash docker/install/build_flashinfer_ep_pytorch.sh
-    fi
-
-    # Find test files (unique to unit tests - auto-discovery)
-    find_test_files
-
-    # Execute tests or dry run
-    if [ "$DRY_RUN" == "true" ]; then
-        execute_dry_run "$TEST_FILES"
+format_elapsed() {
+    local total_seconds=$1
+    local hours=$((total_seconds / 3600))
+    local minutes=$(((total_seconds % 3600) / 60))
+    local seconds=$((total_seconds % 60))
+    if [ "${hours}" -gt 0 ]; then
+        printf '%dh%02dm%02ds' "${hours}" "${minutes}" "${seconds}"
+    elif [ "${minutes}" -gt 0 ]; then
+        printf '%dm%02ds' "${minutes}" "${seconds}"
     else
-        execute_tests "$TEST_FILES"
+        printf '%ds' "${seconds}"
+    fi
+}
+
+print_fallback_summary() {
+    local shell_status=$?
+    if [ "$#" -gt 0 ]; then
+        shell_status=$1
+    fi
+    if [ "${SUMMARY_PRINTED}" = "true" ]; then
+        return
+    fi
+    local started_at_iso
+    local ended_at_iso
+    TZ=UTC printf -v started_at_iso '%(%Y-%m-%dT%H:%M:%SZ)T' "${UNIT_TEST_RUN_STARTED_AT}"
+    TZ=UTC printf -v ended_at_iso '%(%Y-%m-%dT%H:%M:%SZ)T' -1
+    local elapsed_seconds=$((SECONDS - UNIT_TEST_RUN_STARTED_SECONDS))
+    echo "=========================================="
+    echo "TEST SUMMARY"
+    echo "=========================================="
+    echo "Start time: ${started_at_iso}"
+    echo "End time: ${ended_at_iso}"
+    echo "Time elapsed: $(format_elapsed "${elapsed_seconds}")"
+    echo "Scope: unavailable"
+    echo "Planned nodes: unavailable"
+    echo "Finalized nodes: unavailable"
+    echo ""
+    echo "STOP CAUSE"
+    echo "  phase=${CURRENT_PHASE} shell_exit_code=${shell_status} command=${LAST_ERROR_COMMAND:-unknown}"
+    echo ""
+    echo "TEST RUN RESOURCE SUMMARY"
+    echo "  No finalized source data."
+    echo "=========================================="
+    echo "Result: status=preflight-setup-or-abnormal-error python_exit_code=unavailable shell_exit_code=${shell_status}"
+    echo "=========================================="
+}
+
+handle_signal() {
+    local signal_name=$1
+    local signal_status=$2
+    CURRENT_PHASE="signal"
+    LAST_ERROR_COMMAND="received ${signal_name}"
+    print_fallback_summary "${signal_status}"
+    SUMMARY_PRINTED=true
+    exit "${signal_status}"
+}
+
+trap record_error_command ERR
+trap print_fallback_summary EXIT
+trap 'handle_signal SIGINT 130' INT
+trap 'handle_signal SIGTERM 143' TERM
+
+# Help must not prepare the environment, install dependencies, or collect tests.
+for arg in "$@"; do
+    if [ "$arg" = "--help" ] || [ "$arg" = "-h" ]; then
+        exec python "${RUNNER}" run --help
+    fi
+done
+
+if [ -n "${PYTEST_FILE_TIMEOUT_SECONDS+x}" ]; then
+    echo "ERROR: PYTEST_FILE_TIMEOUT_SECONDS is obsolete; use UNIT_TEST_TIMEOUT_SECONDS or --unit-timeout-seconds." >&2
+    exit 3
+fi
+if [ -n "${PYTEST_FILE_TIMEOUT_KILL_AFTER_SECONDS+x}" ]; then
+    echo "ERROR: PYTEST_FILE_TIMEOUT_KILL_AFTER_SECONDS is obsolete; use UNIT_TEST_TIMEOUT_GRACE_SECONDS or --timeout-grace-seconds." >&2
+    exit 3
+fi
+
+# The old shared helper randomized this value while being sourced. The sharding
+# manifest freezes sampling, so establish the documented deterministic default.
+: "${SAMPLE_OFFSET:=0}"
+export SAMPLE_OFFSET
+export PARALLEL_TESTS=true
+
+# shellcheck disable=SC1091
+source "${SCRIPT_DIR}/test_utils.sh"
+
+main() {
+    CURRENT_PHASE="argument-preflight"
+    local runner_settings_output
+    local -a runner_settings
+    if runner_settings_output=$(python "${RUNNER}" __shell-settings "$@"); then
+        :
+    else
+        local preflight_exit_code=$?
+        printf '%s\n' "${runner_settings_output}"
+        return "${preflight_exit_code}"
+    fi
+    mapfile -t runner_settings <<< "${runner_settings_output}"
+    local operation="${runner_settings[0]}"
+    TEST_PATH="${runner_settings[1]}"
+
+    export JUNIT_DIR SAMPLE_RATE SAMPLE_OFFSET TEST_PATH
+
+    if [ "$operation" = "plan" ]; then
+        echo "🔍 DRY RUN MODE - collecting and writing a deterministic plan only"
+    else
+        CURRENT_PHASE="dependency-setup"
+        echo "📋 DETERMINISTIC SHARD MODE - finalized batches resume automatically"
+
+        # nvshmem4py-cu12 pins cuda-python<=12.9. The CI image already carries
+        # compatible cuda-python and NVIDIA NVSHMEM libraries, so avoid allowing
+        # pip to replace the CUDA flavor while filling this one missing module.
+        python -c "import nvshmem.core" 2>/dev/null || pip install --no-deps nvshmem4py-cu12
+
+        install_and_verify
+
+        # Apply dependency overrides after installation since pip may overwrite
+        # the versions established by the CI image.
+        # shellcheck disable=SC1091
+        source "${SCRIPT_DIR}/setup_test_env.sh"
+
+        # tests/moe_ep needs its additional runtime stack only on CUDA 13 images.
+        local cuda_major
+        cuda_major=$(python -c \
+            'import torch; v=torch.version.cuda; print(v.split(".")[0] if v else "0")' \
+            2>/dev/null || echo 0)
+        if [[ "${TEST_PATH:-}" == *moe_ep* ]] && [ "${cuda_major}" -ge 13 ]; then
+            FI_SRC="$(pwd)" bash docker/install/build_flashinfer_ep_pytorch.sh
+        fi
     fi
 
-    exit "$EXIT_CODE"
+    # test_utils.sh defines the obsolete variables for its legacy callers. They
+    # are deliberately not forwarded to the replacement runner.
+    unset PYTEST_FILE_TIMEOUT_SECONDS PYTEST_FILE_TIMEOUT_KILL_AFTER_SECONDS
+
+    CURRENT_PHASE="python-runner"
+    local runner_exit_code
+    if python "${RUNNER}" "${operation}" "$@" \
+        --wrapper-started-at "${UNIT_TEST_RUN_STARTED_AT}"; then
+        runner_exit_code=0
+    else
+        runner_exit_code=$?
+    fi
+
+    case "${runner_exit_code}" in
+        0|1|2|3) ;;
+        *)
+            echo "ERROR: UNIT TEST RUNNER ABNORMAL EXIT: exit_code=${runner_exit_code} wrapper_exit_code=unchanged"
+            return "${runner_exit_code}"
+            ;;
+    esac
+
+    SUMMARY_PRINTED=true
+    case "${runner_exit_code}" in
+        0|2)
+            return 0
+            ;;
+        *)
+            return "${runner_exit_code}"
+            ;;
+    esac
 }
 
 main "$@"

--- a/scripts/test_sharding/__init__.py
+++ b/scripts/test_sharding/__init__.py
@@ -1,0 +1,5 @@
+"""Deterministic and resumable pytest sharding support."""
+
+from .models import ALGORITHM_VERSION, SCHEMA_VERSION
+
+__all__ = ["ALGORITHM_VERSION", "SCHEMA_VERSION"]

--- a/scripts/test_sharding/estimates.py
+++ b/scripts/test_sharding/estimates.py
@@ -1,0 +1,335 @@
+from __future__ import annotations
+
+import csv
+import gzip
+import math
+from collections import defaultdict
+from dataclasses import dataclass
+from pathlib import Path
+from statistics import fmean, median
+from typing import Iterable
+
+from .models import base_function_for_nodeid, source_file_for_nodeid
+
+
+PREFERRED_FALLBACK_PROFILES = frozenset({"sm103-cuda12", "sm103-cuda13"})
+MIN_AGGREGATE_COVERAGE = 0.8
+
+
+@dataclass(frozen=True)
+class DurationEstimate:
+    profile: str
+    nodeid: str
+    estimated_seconds: float
+    sample_count: int
+
+
+@dataclass(frozen=True)
+class OverheadEstimate:
+    profile: str
+    source_file: str
+    process_startup_seconds: float
+    source_warmup_seconds: float
+    sample_count: int
+
+
+@dataclass(frozen=True)
+class DurationLookup:
+    seconds: float
+    source: str
+
+
+@dataclass(frozen=True)
+class DurationCoverage:
+    function_totals: dict[str, int]
+    source_totals: dict[str, int]
+    function_observed: dict[tuple[str, str], int]
+    source_observed: dict[tuple[str, str], int]
+
+    def sufficient(
+        self,
+        profile: str,
+        key: str,
+        level: str,
+    ) -> bool:
+        if level == "function":
+            observed = self.function_observed.get((profile, key), 0)
+            population = self.function_totals.get(key, 0)
+        elif level == "source":
+            observed = self.source_observed.get((profile, key), 0)
+            population = self.source_totals.get(key, 0)
+        else:
+            raise ValueError(f"unknown aggregate level: {level}")
+        return population > 0 and observed / population >= MIN_AGGREGATE_COVERAGE
+
+
+def nearest_rank_p90(values: Iterable[float]) -> float:
+    ordered = sorted(values)
+    if not ordered:
+        raise ValueError("p90 requires at least one value")
+    return ordered[max(0, math.ceil(0.9 * len(ordered)) - 1)]
+
+
+class EstimateBook:
+    def __init__(
+        self,
+        durations: Iterable[DurationEstimate] = (),
+        overheads: Iterable[OverheadEstimate] = (),
+    ) -> None:
+        self.durations = tuple(durations)
+        self.overheads = tuple(overheads)
+        self._exact = {
+            (estimate.profile, estimate.nodeid): estimate for estimate in self.durations
+        }
+        self._first_by_node: dict[str, DurationEstimate] = {}
+        for estimate in self.durations:
+            self._first_by_node.setdefault(estimate.nodeid, estimate)
+        self._by_node: dict[str, list[DurationEstimate]] = defaultdict(list)
+        self._overhead = {
+            (estimate.profile, estimate.source_file): estimate
+            for estimate in self.overheads
+        }
+        self._first_overhead_by_source: dict[str, OverheadEstimate] = {}
+        for overhead_estimate in self.overheads:
+            self._first_overhead_by_source.setdefault(
+                overhead_estimate.source_file, overhead_estimate
+            )
+        self._overhead_profiles = frozenset(
+            estimate.profile for estimate in self.overheads
+        )
+        overhead_seconds = [
+            estimate.process_startup_seconds + estimate.source_warmup_seconds
+            for estimate in self.overheads
+        ]
+        # Each row predicts one source file, so sample_count must not bias the
+        # default toward a few heavily sampled files.
+        self._default_overhead_seconds = (
+            median(overhead_seconds) if overhead_seconds else 0.0
+        )
+        self._function: dict[tuple[str, str], list[float]] = defaultdict(list)
+        self._source: dict[tuple[str, str], list[float]] = defaultdict(list)
+        self._suite: dict[str, list[float]] = defaultdict(list)
+        for estimate in self.durations:
+            self._by_node[estimate.nodeid].append(estimate)
+            key = (estimate.profile, base_function_for_nodeid(estimate.nodeid))
+            self._function[key].append(estimate.estimated_seconds)
+            source_key = (estimate.profile, source_file_for_nodeid(estimate.nodeid))
+            self._source[source_key].append(estimate.estimated_seconds)
+            self._suite[estimate.profile].append(estimate.estimated_seconds)
+        self._function_p90 = {
+            key: nearest_rank_p90(values) for key, values in self._function.items()
+        }
+        self._source_p90 = {
+            key: nearest_rank_p90(values) for key, values in self._source.items()
+        }
+        self._suite_mean = {key: fmean(values) for key, values in self._suite.items()}
+        self._duration_profiles = frozenset(self._suite_mean)
+
+    @staticmethod
+    def _fallback_profiles(
+        profile: str, available_profiles: frozenset[str]
+    ) -> frozenset[str]:
+        alternatives = available_profiles - {profile}
+        preferred = alternatives & PREFERRED_FALLBACK_PROFILES
+        if profile not in available_profiles and preferred:
+            return preferred
+        return alternatives
+
+    @classmethod
+    def from_files(
+        cls, duration_path: Path | None = None, overhead_path: Path | None = None
+    ) -> "EstimateBook":
+        durations: list[DurationEstimate] = []
+        if duration_path is not None and duration_path.exists():
+            opener = gzip.open if duration_path.suffix == ".gz" else open
+            with opener(duration_path, "rt", newline="", encoding="utf-8") as stream:
+                for row in csv.DictReader(stream):
+                    durations.append(
+                        DurationEstimate(
+                            profile=row.get("profile", ""),
+                            nodeid=row["nodeid"],
+                            estimated_seconds=float(row["estimated_seconds"]),
+                            sample_count=int(row.get("sample_count") or 1),
+                        )
+                    )
+        overheads: list[OverheadEstimate] = []
+        if overhead_path is not None and overhead_path.exists():
+            overhead_opener = gzip.open if overhead_path.suffix == ".gz" else open
+            with overhead_opener(
+                overhead_path, "rt", newline="", encoding="utf-8"
+            ) as stream:
+                for row in csv.DictReader(stream):
+                    overheads.append(
+                        OverheadEstimate(
+                            profile=row.get("profile", ""),
+                            source_file=row["source_file"],
+                            process_startup_seconds=float(
+                                row["process_startup_seconds"]
+                            ),
+                            source_warmup_seconds=float(row["source_warmup_seconds"]),
+                            sample_count=int(row.get("sample_count") or 1),
+                        )
+                    )
+        return cls(durations, overheads)
+
+    def lookup_runtime(
+        self, nodeid: str, default_case_seconds: float
+    ) -> DurationLookup:
+        """Use the first exact row, ignoring profile, or the configured default."""
+
+        exact = self._first_by_node.get(nodeid)
+        if exact is not None:
+            return DurationLookup(exact.estimated_seconds, "provided")
+        return DurationLookup(default_case_seconds, "default-case")
+
+    def overhead_ms_runtime(
+        self, source_file: str, default_source_overhead_seconds: float
+    ) -> int:
+        """Use the first exact source row, ignoring profile, or the default."""
+
+        exact = self._first_overhead_by_source.get(source_file)
+        seconds = (
+            exact.process_startup_seconds + exact.source_warmup_seconds
+            if exact is not None
+            else default_source_overhead_seconds
+        )
+        return max(0, round(seconds * 1000))
+
+    def lookup(
+        self,
+        nodeid: str,
+        profile: str,
+        unknown_floor_seconds: float,
+        *,
+        coverage: DurationCoverage | None = None,
+    ) -> DurationLookup:
+        exact = self._exact.get((profile, nodeid))
+        if exact is not None:
+            return DurationLookup(exact.estimated_seconds, "exact-current-profile")
+
+        fallback_profiles = self._fallback_profiles(profile, self._duration_profiles)
+        exact_other = [
+            item.estimated_seconds
+            for item in self._by_node.get(nodeid, ())
+            if item.profile in fallback_profiles
+        ]
+        if exact_other:
+            return DurationLookup(max(exact_other), "exact-other-profile")
+
+        function = base_function_for_nodeid(nodeid)
+        source = source_file_for_nodeid(nodeid)
+        current_levels = (
+            (
+                self._function_p90.get((profile, function)),
+                function,
+                "function",
+                "function-current-profile",
+            ),
+            (
+                self._source_p90.get((profile, source)),
+                source,
+                "source",
+                "source-current-profile",
+            ),
+        )
+        for value, key, level, current_name in current_levels:
+            if value is not None and (
+                coverage is None or coverage.sufficient(profile, key, level)
+            ):
+                return DurationLookup(max(unknown_floor_seconds, value), current_name)
+        suite_mean = self._suite_mean.get(profile)
+        if suite_mean is not None:
+            return DurationLookup(
+                max(unknown_floor_seconds, suite_mean),
+                "suite-mean-current-profile",
+            )
+        other_levels = (
+            (
+                [
+                    (other_profile, value)
+                    for (
+                        other_profile,
+                        other_function,
+                    ), value in self._function_p90.items()
+                    if other_profile in fallback_profiles and other_function == function
+                ],
+                function,
+                "function",
+                "function-other-profile",
+            ),
+            (
+                [
+                    (other_profile, value)
+                    for (other_profile, other_source), value in self._source_p90.items()
+                    if other_profile in fallback_profiles and other_source == source
+                ],
+                source,
+                "source",
+                "source-other-profile",
+            ),
+        )
+        for candidates, key, level, other_name in other_levels:
+            covered = [
+                value
+                for other_profile, value in candidates
+                if coverage is None or coverage.sufficient(other_profile, key, level)
+            ]
+            if covered:
+                return DurationLookup(
+                    max(unknown_floor_seconds, max(covered)), other_name
+                )
+        other_suite_means = [
+            value
+            for other_profile, value in self._suite_mean.items()
+            if other_profile in fallback_profiles
+        ]
+        if other_suite_means:
+            return DurationLookup(
+                max(unknown_floor_seconds, max(other_suite_means)),
+                "suite-mean-other-profile",
+            )
+        return DurationLookup(unknown_floor_seconds, "unknown-floor")
+
+    def coverage(self, nodeids: Iterable[str]) -> DurationCoverage:
+        function_totals: dict[str, int] = defaultdict(int)
+        source_totals: dict[str, int] = defaultdict(int)
+        function_observed: dict[tuple[str, str], int] = defaultdict(int)
+        source_observed: dict[tuple[str, str], int] = defaultdict(int)
+        for nodeid in nodeids:
+            function = base_function_for_nodeid(nodeid)
+            source = source_file_for_nodeid(nodeid)
+            function_totals[function] += 1
+            source_totals[source] += 1
+            for observed_profile in {
+                estimate.profile for estimate in self._by_node.get(nodeid, ())
+            }:
+                function_observed[(observed_profile, function)] += 1
+                source_observed[(observed_profile, source)] += 1
+        return DurationCoverage(
+            dict(function_totals),
+            dict(source_totals),
+            dict(function_observed),
+            dict(source_observed),
+        )
+
+    def overhead_ms(self, source_file: str, profile: str) -> int:
+        exact = self._overhead.get((profile, source_file))
+        if exact is None:
+            fallback_profiles = self._fallback_profiles(
+                profile, self._overhead_profiles
+            )
+            alternatives = [
+                value
+                for (other_profile, source), value in self._overhead.items()
+                if source == source_file and other_profile in fallback_profiles
+            ]
+            if not alternatives:
+                seconds = self._default_overhead_seconds
+            else:
+                seconds = max(
+                    item.process_startup_seconds + item.source_warmup_seconds
+                    for item in alternatives
+                )
+        else:
+            seconds = exact.process_startup_seconds + exact.source_warmup_seconds
+        return max(0, round(seconds * 1000))

--- a/scripts/test_sharding/io.py
+++ b/scripts/test_sharding/io.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+import xml.etree.ElementTree as ET
+from pathlib import Path
+from typing import Any
+
+
+def atomic_write_bytes(path: Path, content: bytes) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    descriptor, temporary_name = tempfile.mkstemp(
+        dir=path.parent,
+        prefix=f".{path.name}.",
+        suffix=".tmp",
+    )
+    temporary = Path(temporary_name)
+    try:
+        with os.fdopen(descriptor, "wb") as stream:
+            stream.write(content)
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.replace(temporary, path)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def atomic_write_text(path: Path, content: str) -> None:
+    atomic_write_bytes(path, content.encode("utf-8"))
+
+
+def atomic_write_json(path: Path, value: Any) -> None:
+    atomic_write_text(
+        path, json.dumps(value, sort_keys=True, separators=(",", ":")) + "\n"
+    )
+
+
+def atomic_write_xml(path: Path, root: ET.Element) -> None:
+    ET.indent(root, space="  ")
+    content = ET.tostring(root, encoding="utf-8", xml_declaration=True)
+    atomic_write_bytes(path, content + b"\n")

--- a/scripts/test_sharding/junit.py
+++ b/scripts/test_sharding/junit.py
@@ -1,0 +1,243 @@
+from __future__ import annotations
+
+import json
+import xml.etree.ElementTree as ET
+from collections import Counter
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Sequence
+
+from .io import atomic_write_xml
+from .models import base_function_for_nodeid, source_file_for_nodeid
+
+
+@dataclass(frozen=True)
+class TestCaseResult:
+    nodeid: str
+    source_file: str
+    base_function: str
+    outcome: str
+    seconds: float
+    synthetic: bool
+    diagnostic: str
+
+
+@dataclass(frozen=True)
+class BatchValidation:
+    valid: bool
+    cases: tuple[TestCaseResult, ...]
+    diagnostics: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class SyntheticBatchMetadata:
+    policy: str
+    batch_id: str
+    unit_id: str
+    shard_index: int
+    attempt_id: str
+    profile: str
+
+
+def test_suites(root: ET.Element) -> list[ET.Element]:
+    if root.tag == "testsuite":
+        return [root]
+    if root.tag == "testsuites":
+        return list(root.findall("./testsuite"))
+    return []
+
+
+def element_properties(element: ET.Element) -> dict[str, str]:
+    return {
+        prop.attrib.get("name", ""): prop.attrib.get("value", "")
+        for prop in element.findall("./properties/property")
+    }
+
+
+def testcase_outcome(testcase: ET.Element) -> str:
+    if testcase.find("./failure") is not None or testcase.find("./error") is not None:
+        return "failed"
+    if testcase.find("./skipped") is not None:
+        return "skipped"
+    return "passed"
+
+
+def validate_batch_xml(path: Path, expected_nodeids: Sequence[str]) -> BatchValidation:
+    diagnostics: list[str] = []
+    try:
+        root = ET.parse(path).getroot()
+    except (OSError, ET.ParseError) as error:
+        return BatchValidation(False, (), (f"malformed JUnit XML: {error}",))
+    suites = test_suites(root)
+    if not suites:
+        return BatchValidation(False, (), (f"unexpected JUnit root {root.tag!r}",))
+    cases: list[TestCaseResult] = []
+    seen: list[str] = []
+    for suite in suites:
+        for testcase in suite.findall("./testcase"):
+            properties = element_properties(testcase)
+            nodeid = properties.get("pytest_nodeid")
+            if not nodeid:
+                diagnostics.append("testcase is missing pytest_nodeid property")
+                continue
+            seen.append(nodeid)
+            try:
+                seconds = float(testcase.attrib.get("time", "0") or 0)
+            except ValueError:
+                diagnostics.append(f"testcase {nodeid} has invalid time")
+                seconds = 0.0
+            cases.append(
+                TestCaseResult(
+                    nodeid=nodeid,
+                    source_file=source_file_for_nodeid(nodeid),
+                    base_function=base_function_for_nodeid(nodeid),
+                    outcome=testcase_outcome(testcase),
+                    seconds=seconds,
+                    synthetic=properties.get("synthetic") == "true",
+                    diagnostic=_testcase_diagnostic(testcase),
+                )
+            )
+    expected = set(expected_nodeids)
+    counts = Counter(seen)
+    actual = set(counts)
+    duplicates = sorted(nodeid for nodeid, count in counts.items() if count > 1)
+    missing = sorted(expected - actual)
+    unexpected = sorted(actual - expected)
+    if missing:
+        diagnostics.append("missing planned nodes: " + ", ".join(missing[:5]))
+    if unexpected:
+        diagnostics.append("unexpected nodes: " + ", ".join(unexpected[:5]))
+    if duplicates:
+        diagnostics.append("duplicate nodes: " + ", ".join(duplicates[:5]))
+    return BatchValidation(not diagnostics, tuple(cases), tuple(diagnostics))
+
+
+def _testcase_diagnostic(testcase: ET.Element) -> str:
+    result = testcase.find("./failure")
+    if result is None:
+        result = testcase.find("./error")
+    if result is None:
+        return ""
+    message = result.attrib.get("message", "").strip()
+    detail = (result.text or "").strip()
+    if message and detail and message not in detail:
+        return f"{message}\n{detail}"
+    return detail or message
+
+
+def finalized_batch_outcomes(
+    path: Path, expected_nodeids: Sequence[str]
+) -> tuple[Counter[str], tuple[str, ...]]:
+    validation = validate_batch_xml(path, expected_nodeids)
+    if not validation.valid:
+        return Counter(), validation.diagnostics
+
+    recorded: dict[str, str] = {}
+    result_path = path.with_name(f"{path.stem}.results.json")
+    try:
+        value = json.loads(result_path.read_text(encoding="utf-8"))
+        results = value.get("results", [])
+        if isinstance(results, list):
+            for result in results:
+                if not isinstance(result, dict):
+                    continue
+                nodeid = result.get("nodeid")
+                outcome = result.get("outcome")
+                if isinstance(nodeid, str) and isinstance(outcome, str):
+                    recorded[nodeid] = (
+                        outcome
+                        if outcome in {"passed", "failed", "skipped", "unknown"}
+                        else "unknown"
+                    )
+    except (OSError, AttributeError, json.JSONDecodeError):
+        pass
+
+    return (
+        Counter(recorded.get(case.nodeid, case.outcome) for case in validation.cases),
+        (),
+    )
+
+
+def _add_properties(element: ET.Element, values: dict[str, str]) -> None:
+    properties = element.find("./properties")
+    if properties is None:
+        properties = ET.Element("properties")
+        element.insert(0, properties)
+    existing = element_properties(element)
+    for name, value in values.items():
+        if name not in existing:
+            ET.SubElement(properties, "property", name=name, value=value)
+
+
+def annotate_batch_xml(path: Path, values: dict[str, str]) -> None:
+    root = ET.parse(path).getroot()
+    for suite in test_suites(root):
+        _add_properties(suite, values)
+    if root.tag == "testsuite":
+        wrapper = ET.Element("testsuites", root.attrib)
+        wrapper.append(root)
+        root = wrapper
+    atomic_write_xml(path, root)
+
+
+def create_synthetic_batch_xml(
+    path: Path,
+    nodeids: Sequence[str],
+    metadata: SyntheticBatchMetadata,
+) -> None:
+    policy = metadata.policy
+    if policy not in {"skip", "fail"}:
+        raise ValueError("synthetic policy must be skip or fail")
+    suite = ET.Element(
+        "testsuite",
+        name=metadata.batch_id,
+        tests=str(len(nodeids)),
+        failures=str(len(nodeids) if policy == "fail" else 0),
+        errors="0",
+        skipped=str(len(nodeids) if policy == "skip" else 0),
+        time="0",
+    )
+    _add_properties(
+        suite,
+        {
+            "batch_id": metadata.batch_id,
+            "unit_id": metadata.unit_id,
+            "shard_index": str(metadata.shard_index),
+            "attempt_id": metadata.attempt_id,
+            "timing_profile": metadata.profile,
+            "synthetic": "true",
+        },
+    )
+    for nodeid in nodeids:
+        testcase = ET.SubElement(
+            suite,
+            "testcase",
+            classname=source_file_for_nodeid(nodeid).replace("/", "."),
+            name=nodeid.split("::")[-1],
+            time="0",
+        )
+        _add_properties(
+            testcase,
+            {
+                "pytest_nodeid": nodeid,
+                "synthetic": "true",
+                "timeout_policy": policy,
+            },
+        )
+        result_tag = "skipped" if policy == "skip" else "failure"
+        result = ET.SubElement(
+            testcase,
+            result_tag,
+            message="not executed due to timeout",
+        )
+        result.text = "not executed due to timeout"
+    root = ET.Element(
+        "testsuites",
+        tests=str(len(nodeids)),
+        failures=str(len(nodeids) if policy == "fail" else 0),
+        errors="0",
+        skipped=str(len(nodeids) if policy == "skip" else 0),
+        time="0",
+    )
+    root.append(suite)
+    atomic_write_xml(path, root)

--- a/scripts/test_sharding/models.py
+++ b/scripts/test_sharding/models.py
@@ -1,0 +1,346 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+SCHEMA_VERSION = 4
+ALGORITHM_VERSION = "lpt-ms-v4"
+DEFAULT_CHECKPOINT_SECONDS = 1_000_000
+DEFAULT_TARGET_UNIT_SECONDS = 1_000_000
+RUNTIME_TIMING_PROFILE = "unprofiled"
+
+
+def source_file_for_nodeid(nodeid: str) -> str:
+    return nodeid.split("::", 1)[0]
+
+
+def base_function_for_nodeid(nodeid: str) -> str:
+    parts = nodeid.split("::")
+    if len(parts) == 1:
+        return nodeid
+    parts[-1] = parts[-1].split("[", 1)[0]
+    return "::".join(parts)
+
+
+@dataclass(frozen=True)
+class CollectedNode:
+    nodeid: str
+    source_file: str
+    base_function: str
+    order: int
+    shard_group: str | None = None
+    solo: bool = False
+    long_running: bool = False
+
+    @classmethod
+    def from_nodeid(
+        cls,
+        nodeid: str,
+        order: int,
+        shard_group: str | None = None,
+        *,
+        solo: bool = False,
+        long_running: bool = False,
+    ) -> "CollectedNode":
+        return cls(
+            nodeid=nodeid,
+            source_file=source_file_for_nodeid(nodeid),
+            base_function=base_function_for_nodeid(nodeid),
+            order=order,
+            shard_group=shard_group,
+            solo=solo,
+            long_running=long_running,
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "nodeid": self.nodeid,
+            "source_file": self.source_file,
+            "base_function": self.base_function,
+            "order": self.order,
+            "shard_group": self.shard_group,
+            "solo": self.solo,
+            "long_running": self.long_running,
+        }
+
+
+@dataclass(frozen=True)
+class PlanningOptions:
+    checkpoint_seconds: int = DEFAULT_CHECKPOINT_SECONDS
+    target_unit_seconds: int = DEFAULT_TARGET_UNIT_SECONDS
+    default_case_seconds: int = 1
+    default_source_overhead_seconds: int = 30
+    shard_count: int = 1
+
+    def __post_init__(self) -> None:
+        if self.checkpoint_seconds <= 0:
+            raise ValueError("checkpoint_seconds must be positive")
+        if self.target_unit_seconds <= 0:
+            raise ValueError("target_unit_seconds must be positive")
+        if self.default_case_seconds <= 0:
+            raise ValueError("default_case_seconds must be positive")
+        if self.default_source_overhead_seconds < 0:
+            raise ValueError("default_source_overhead_seconds must be nonnegative")
+        if self.shard_count <= 0:
+            raise ValueError("shard_count must be positive")
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "checkpoint_seconds": self.checkpoint_seconds,
+            "target_unit_seconds": self.target_unit_seconds,
+            "default_case_seconds": self.default_case_seconds,
+            "default_source_overhead_seconds": self.default_source_overhead_seconds,
+            "shard_count": self.shard_count,
+        }
+
+
+@dataclass(frozen=True)
+class Batch:
+    id: str
+    source_file: str
+    nodeids: tuple[str, ...]
+    estimated_ms: int
+    overhead_ms: int
+    oversized: bool
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "source_file": self.source_file,
+            "nodeids": list(self.nodeids),
+            "estimated_ms": self.estimated_ms,
+            "overhead_ms": self.overhead_ms,
+            "oversized": self.oversized,
+        }
+
+    @classmethod
+    def from_dict(cls, value: dict[str, Any]) -> "Batch":
+        return cls(
+            id=value["id"],
+            source_file=value["source_file"],
+            nodeids=tuple(value["nodeids"]),
+            estimated_ms=int(value["estimated_ms"]),
+            overhead_ms=int(value["overhead_ms"]),
+            oversized=bool(value["oversized"]),
+        )
+
+
+@dataclass(frozen=True)
+class Unit:
+    id: str
+    batches: tuple[Batch, ...]
+    estimated_ms: int
+    oversized: bool
+    shard_index: int = -1
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "batches": [batch.to_dict() for batch in self.batches],
+            "estimated_ms": self.estimated_ms,
+            "oversized": self.oversized,
+            "shard_index": self.shard_index,
+        }
+
+    @classmethod
+    def from_dict(cls, value: dict[str, Any]) -> "Unit":
+        return cls(
+            id=value["id"],
+            batches=tuple(Batch.from_dict(batch) for batch in value["batches"]),
+            estimated_ms=int(value["estimated_ms"]),
+            oversized=bool(value["oversized"]),
+            shard_index=int(value["shard_index"]),
+        )
+
+
+@dataclass(frozen=True)
+class Plan:
+    options: PlanningOptions
+    nodes: tuple[CollectedNode, ...]
+    units: tuple[Unit, ...]
+    fallback_counts: dict[str, int] = field(default_factory=dict)
+    fallback_sources: dict[str, str] = field(default_factory=dict)
+
+    def fallback_index_groups(self) -> dict[str, list[int]]:
+        nodeids = [node.nodeid for node in self.nodes]
+        node_indexes = {nodeid: index for index, nodeid in enumerate(nodeids)}
+        if len(node_indexes) != len(nodeids):
+            raise ValueError("plan contains duplicate node IDs")
+        fallback_groups: dict[str, list[int]] = {}
+        for nodeid, source in self.fallback_sources.items():
+            fallback_groups.setdefault(source, []).append(node_indexes[nodeid])
+        return {
+            source: sorted(indexes)
+            for source, indexes in sorted(fallback_groups.items())
+        }
+
+    def to_dict(self) -> dict[str, Any]:
+        nodeids = [node.nodeid for node in self.nodes]
+        node_indexes = {nodeid: index for index, nodeid in enumerate(nodeids)}
+        if len(node_indexes) != len(nodeids):
+            raise ValueError("plan contains duplicate node IDs")
+        source_file_groups: dict[str, list[int]] = {}
+        for index, node in enumerate(self.nodes):
+            source_file_groups.setdefault(node.source_file, []).append(index)
+        shard_groups = {
+            str(index): node.shard_group
+            for index, node in enumerate(self.nodes)
+            if node.shard_group is not None
+        }
+        solo_sources = sorted(
+            {node.source_file for node in self.nodes if node.solo},
+            key=lambda value: value.encode("utf-8"),
+        )
+        long_running_sources = sorted(
+            {node.source_file for node in self.nodes if node.long_running},
+            key=lambda value: value.encode("utf-8"),
+        )
+        return {
+            "schema_version": SCHEMA_VERSION,
+            "algorithm_version": ALGORITHM_VERSION,
+            "options": self.options.to_dict(),
+            "nodeids": nodeids,
+            "source_files": [
+                {"path": path, "node_indexes": indexes}
+                for path, indexes in sorted(source_file_groups.items())
+            ],
+            "shard_groups": shard_groups,
+            "solo_sources": solo_sources,
+            "long_running_sources": long_running_sources,
+            "units": [
+                {
+                    "id": unit.id,
+                    "batches": [
+                        {
+                            "id": batch.id,
+                            "node_indexes": [
+                                node_indexes[nodeid] for nodeid in batch.nodeids
+                            ],
+                            "estimated_ms": batch.estimated_ms,
+                            "overhead_ms": batch.overhead_ms,
+                            "oversized": batch.oversized,
+                        }
+                        for batch in unit.batches
+                    ],
+                    "estimated_ms": unit.estimated_ms,
+                    "oversized": unit.oversized,
+                    "shard_index": unit.shard_index,
+                }
+                for unit in self.units
+            ],
+            "fallback_counts": dict(sorted(self.fallback_counts.items())),
+            "fallbacks": [
+                {
+                    "source": source,
+                    "node_indexes": indexes,
+                }
+                for source, indexes in self.fallback_index_groups().items()
+            ],
+        }
+
+    @classmethod
+    def from_dict(cls, value: dict[str, Any]) -> "Plan":
+        option_value = value["options"]
+        options = PlanningOptions(
+            checkpoint_seconds=int(option_value["checkpoint_seconds"]),
+            target_unit_seconds=int(option_value["target_unit_seconds"]),
+            default_case_seconds=int(
+                option_value.get(
+                    "default_case_seconds", option_value.get("unknown_case_seconds", 1)
+                )
+            ),
+            default_source_overhead_seconds=int(
+                option_value.get("default_source_overhead_seconds", 30)
+            ),
+            shard_count=int(option_value["shard_count"]),
+        )
+        if "nodeids" not in value:
+            return cls(
+                options=options,
+                nodes=tuple(
+                    CollectedNode(
+                        nodeid=node["nodeid"],
+                        source_file=node["source_file"],
+                        base_function=node["base_function"],
+                        order=int(node["order"]),
+                        shard_group=node.get("shard_group"),
+                        solo=bool(node.get("solo", False)),
+                        long_running=bool(node.get("long_running", False)),
+                    )
+                    for node in value["nodes"]
+                ),
+                units=tuple(Unit.from_dict(unit) for unit in value["units"]),
+                fallback_counts={
+                    str(name): int(count)
+                    for name, count in value.get("fallback_counts", {}).items()
+                },
+                fallback_sources={
+                    str(nodeid): str(source)
+                    for nodeid, source in value.get("fallback_sources", {}).items()
+                },
+            )
+        nodeids = tuple(str(nodeid) for nodeid in value["nodeids"])
+        shard_groups = {
+            int(index): str(group)
+            for index, group in value.get("shard_groups", {}).items()
+        }
+        source_files = {
+            int(index): str(group["path"])
+            for group in value.get("source_files", [])
+            for index in group["node_indexes"]
+        }
+        solo_sources = {str(source) for source in value.get("solo_sources", [])}
+        long_running_sources = {
+            str(source) for source in value.get("long_running_sources", [])
+        }
+        nodes = tuple(
+            CollectedNode(
+                nodeid,
+                source_files.get(index, source_file_for_nodeid(nodeid)),
+                base_function_for_nodeid(nodeid),
+                index,
+                shard_groups.get(index),
+                source_files.get(index, source_file_for_nodeid(nodeid)) in solo_sources,
+                source_files.get(index, source_file_for_nodeid(nodeid))
+                in long_running_sources,
+            )
+            for index, nodeid in enumerate(nodeids)
+        )
+        units = tuple(
+            Unit(
+                id=unit["id"],
+                batches=tuple(
+                    Batch(
+                        id=batch["id"],
+                        source_file=nodes[int(batch["node_indexes"][0])].source_file,
+                        nodeids=tuple(
+                            nodeids[int(index)] for index in batch["node_indexes"]
+                        ),
+                        estimated_ms=int(batch["estimated_ms"]),
+                        overhead_ms=int(batch["overhead_ms"]),
+                        oversized=bool(batch["oversized"]),
+                    )
+                    for batch in unit["batches"]
+                ),
+                estimated_ms=int(unit["estimated_ms"]),
+                oversized=bool(unit["oversized"]),
+                shard_index=int(unit["shard_index"]),
+            )
+            for unit in value["units"]
+        )
+        fallback_sources = {
+            nodeids[int(index)]: str(group["source"])
+            for group in value.get("fallbacks", [])
+            for index in group["node_indexes"]
+        }
+        return cls(
+            options=options,
+            nodes=nodes,
+            units=units,
+            fallback_counts={
+                str(name): int(count)
+                for name, count in value.get("fallback_counts", {}).items()
+            },
+            fallback_sources=fallback_sources,
+        )

--- a/scripts/test_sharding/observations.py
+++ b/scripts/test_sharding/observations.py
@@ -1,0 +1,264 @@
+from __future__ import annotations
+
+import csv
+import gzip
+import io
+import statistics
+from collections import defaultdict
+from contextlib import suppress
+from dataclasses import dataclass, replace
+from pathlib import Path
+from typing import Iterable
+
+from .estimates import (
+    DurationEstimate,
+    EstimateBook,
+    OverheadEstimate,
+    nearest_rank_p90,
+)
+from .io import atomic_write_bytes, atomic_write_text
+from .models import base_function_for_nodeid, source_file_for_nodeid
+
+
+@dataclass(frozen=True)
+class ObservedCase:
+    profile: str
+    nodeid: str
+    source_file: str
+    base_function: str
+    outcome: str
+    seconds: float
+    adjusted_seconds: float
+    synthetic: bool
+    run_id: str
+    batch_id: str
+    first_in_batch: bool
+
+
+@dataclass(frozen=True)
+class EstimateRefresh:
+    duration_file: Path
+    overhead_file: Path
+    summary_file: Path
+    keep_nodeids: set[str] | None = None
+    prune_profile: str | None = None
+
+
+@dataclass(frozen=True)
+class ObservedOverhead:
+    profile: str
+    source_file: str
+    process_startup_seconds: float
+    source_warmup_seconds: float
+    run_id: str
+    batch_id: str
+
+
+def _format_seconds(value: float) -> str:
+    formatted = f"{value:.6f}".rstrip("0").rstrip(".")
+    return formatted or "0"
+
+
+def adjust_first_case_warmup(
+    observations: Iterable[ObservedCase],
+) -> tuple[list[ObservedCase], dict[tuple[str, str], float]]:
+    values = list(observations)
+    siblings: dict[tuple[str, str], list[float]] = defaultdict(list)
+    for item in values:
+        siblings[(item.profile, item.base_function)].append(item.seconds)
+    adjusted: list[ObservedCase] = []
+    warmup: dict[tuple[str, str], float] = defaultdict(float)
+    for item in values:
+        peers = list(siblings[(item.profile, item.base_function)])
+        with suppress(ValueError):
+            peers.remove(item.seconds)
+        if item.first_in_batch and len(peers) >= 10:
+            median = statistics.median(peers)
+            if median > 0 and item.seconds >= 10 * median:
+                adjusted.append(replace(item, adjusted_seconds=median))
+                warmup[(item.run_id, item.batch_id)] += item.seconds - median
+                continue
+        adjusted.append(replace(item, adjusted_seconds=item.seconds))
+    return adjusted, dict(warmup)
+
+
+def _write_duration_file(path: Path, rows: Iterable[DurationEstimate]) -> None:
+    stream = io.StringIO(newline="")
+    writer = csv.writer(stream, lineterminator="\n")
+    writer.writerow(["profile", "nodeid", "estimated_seconds", "sample_count"])
+    for row in sorted(
+        rows, key=lambda item: (item.profile.encode(), item.nodeid.encode())
+    ):
+        writer.writerow(
+            [
+                row.profile,
+                row.nodeid,
+                _format_seconds(row.estimated_seconds),
+                row.sample_count,
+            ]
+        )
+    buffer = io.BytesIO()
+    with gzip.GzipFile(
+        filename="", mode="wb", fileobj=buffer, compresslevel=9, mtime=0
+    ) as compressed:
+        compressed.write(stream.getvalue().encode("utf-8"))
+    atomic_write_bytes(path, buffer.getvalue())
+
+
+def _write_overhead_file(path: Path, rows: Iterable[OverheadEstimate]) -> None:
+    stream = io.StringIO(newline="")
+    writer = csv.writer(stream, lineterminator="\n")
+    writer.writerow(
+        [
+            "profile",
+            "source_file",
+            "process_startup_seconds",
+            "source_warmup_seconds",
+            "sample_count",
+        ]
+    )
+    for row in sorted(
+        rows, key=lambda item: (item.profile.encode(), item.source_file.encode())
+    ):
+        writer.writerow(
+            [
+                row.profile,
+                row.source_file,
+                _format_seconds(row.process_startup_seconds),
+                _format_seconds(row.source_warmup_seconds),
+                row.sample_count,
+            ]
+        )
+    atomic_write_text(path, stream.getvalue())
+
+
+def _write_summary(path: Path, rows: Iterable[DurationEstimate]) -> None:
+    aggregate: dict[tuple[str, str, str], list[float]] = defaultdict(list)
+    for row in rows:
+        aggregate[
+            (
+                row.profile,
+                source_file_for_nodeid(row.nodeid),
+                base_function_for_nodeid(row.nodeid),
+            )
+        ].append(row.estimated_seconds)
+    stream = io.StringIO(newline="")
+    writer = csv.writer(stream, lineterminator="\n")
+    writer.writerow(
+        [
+            "profile",
+            "source_file",
+            "base_function",
+            "node_count",
+            "total_estimated_seconds",
+            "p90_estimated_seconds",
+        ]
+    )
+    for key, estimates in sorted(
+        aggregate.items(), key=lambda item: tuple(value.encode() for value in item[0])
+    ):
+        writer.writerow(
+            [
+                *key,
+                len(estimates),
+                _format_seconds(sum(estimates)),
+                _format_seconds(nearest_rank_p90(estimates)),
+            ]
+        )
+    atomic_write_text(path, stream.getvalue())
+
+
+def refresh_estimates(
+    observations: Iterable[ObservedCase],
+    overhead_observations: Iterable[ObservedOverhead],
+    request: EstimateRefresh,
+) -> tuple[list[DurationEstimate], list[OverheadEstimate]]:
+    duration_file = request.duration_file
+    overhead_file = request.overhead_file
+    summary_file = request.summary_file
+    book = EstimateBook.from_files(duration_file, overhead_file)
+    existing = {(row.profile, row.nodeid): row for row in book.durations}
+    eligible: dict[tuple[str, str], list[ObservedCase]] = defaultdict(list)
+    for observation in observations:
+        if not observation.synthetic and observation.outcome in {"passed", "failed"}:
+            eligible[(observation.profile, observation.nodeid)].append(observation)
+    updated = dict(existing)
+    for duration_key, duration_samples in eligible.items():
+        old_duration = existing.get(duration_key)
+        passing = [
+            sample.adjusted_seconds
+            for sample in duration_samples
+            if sample.outcome == "passed"
+        ]
+        failing = [
+            sample.adjusted_seconds
+            for sample in duration_samples
+            if sample.outcome == "failed"
+        ]
+        candidates: list[float] = []
+        if passing:
+            passing_candidate = 1.2 * nearest_rank_p90(passing)
+            candidates.append(
+                max(0.9 * old_duration.estimated_seconds, passing_candidate)
+                if old_duration is not None
+                else passing_candidate
+            )
+        if failing:
+            failure_candidate = 1.2 * nearest_rank_p90(failing)
+            candidates.append(
+                max(old_duration.estimated_seconds, failure_candidate)
+                if old_duration is not None
+                else failure_candidate
+            )
+        estimate = max(candidates)
+        updated[duration_key] = DurationEstimate(
+            profile=duration_key[0],
+            nodeid=duration_key[1],
+            estimated_seconds=estimate,
+            sample_count=(old_duration.sample_count if old_duration is not None else 0)
+            + len(duration_samples),
+        )
+    if request.keep_nodeids is not None and request.prune_profile is not None:
+        updated = {
+            key: row
+            for key, row in updated.items()
+            if key[0] != request.prune_profile or key[1] in request.keep_nodeids
+        }
+
+    overhead_existing = {(row.profile, row.source_file): row for row in book.overheads}
+    grouped_overheads: dict[tuple[str, str], list[ObservedOverhead]] = defaultdict(list)
+    for overhead_observation in overhead_observations:
+        grouped_overheads[
+            (overhead_observation.profile, overhead_observation.source_file)
+        ].append(overhead_observation)
+    overhead_updated = dict(overhead_existing)
+    for overhead_key, overhead_samples in grouped_overheads.items():
+        old_overhead = overhead_existing.get(overhead_key)
+        startup_candidate = 1.2 * nearest_rank_p90(
+            sample.process_startup_seconds for sample in overhead_samples
+        )
+        warmup_candidate = 1.2 * nearest_rank_p90(
+            sample.source_warmup_seconds for sample in overhead_samples
+        )
+        if old_overhead is not None:
+            startup_candidate = max(
+                0.9 * old_overhead.process_startup_seconds, startup_candidate
+            )
+            warmup_candidate = max(
+                0.9 * old_overhead.source_warmup_seconds, warmup_candidate
+            )
+        overhead_updated[overhead_key] = OverheadEstimate(
+            profile=overhead_key[0],
+            source_file=overhead_key[1],
+            process_startup_seconds=startup_candidate,
+            source_warmup_seconds=warmup_candidate,
+            sample_count=(old_overhead.sample_count if old_overhead is not None else 0)
+            + len(overhead_samples),
+        )
+
+    duration_rows = list(updated.values())
+    overhead_rows = list(overhead_updated.values())
+    _write_duration_file(duration_file, duration_rows)
+    _write_overhead_file(overhead_file, overhead_rows)
+    _write_summary(summary_file, duration_rows)
+    return duration_rows, overhead_rows

--- a/scripts/test_sharding/planner.py
+++ b/scripts/test_sharding/planner.py
@@ -1,0 +1,524 @@
+from __future__ import annotations
+
+import hashlib
+import heapq
+import math
+from collections import Counter, defaultdict
+from dataclasses import dataclass, replace
+from typing import Callable, Iterable, Mapping, Sequence, TypedDict, TypeVar
+
+from .estimates import EstimateBook
+from .models import ALGORITHM_VERSION, Batch, CollectedNode, Plan, PlanningOptions, Unit
+
+
+class CapacityMetrics(TypedDict):
+    configured_workers_by_shard: dict[str, int]
+    estimated_shard_load_ms: dict[str, int]
+    estimated_worker_load_ms: dict[str, list[int]]
+    estimated_makespan_ms: int
+    total_estimated_load_ms: int
+    total_estimated_overhead_ms: int
+    estimated_overhead_by_source_ms: dict[str, int]
+    deadline_seconds: int
+    required_workers_by_shard: dict[str, int | None]
+    required_total_worker_slots: int | None
+
+
+@dataclass(frozen=True)
+class _AtomicItem:
+    id: str
+    nodes: tuple[CollectedNode, ...]
+    estimated_ms: int
+
+
+@dataclass(frozen=True)
+class _UnitGroup:
+    id: str
+    units: tuple[Unit, ...]
+    estimated_ms: int
+
+
+_MIN_WORK_TO_OVERHEAD_RATIO = 15
+_MAX_BATCHES_PER_TARGET_UNIT = 4  # to reduce pytest overhead
+_MIN_AFFINITY_IMPROVEMENT_PERCENT = 5
+
+
+def _stable_id(kind: str, nodeids: Iterable[str]) -> str:
+    digest = hashlib.sha256()
+    digest.update(kind.encode())
+    digest.update(b"\0")
+    digest.update(ALGORITHM_VERSION.encode())
+    for nodeid in sorted(nodeids, key=lambda value: value.encode("utf-8")):
+        digest.update(b"\0")
+        digest.update(nodeid.encode("utf-8"))
+    return f"{kind}-{digest.hexdigest()[:16]}"
+
+
+T = TypeVar("T")
+
+
+def _lpt_bins(
+    items: Sequence[T],
+    count: int,
+    duration: Callable[[T], int],
+    stable_id: Callable[[T], str],
+) -> list[list[T]]:
+    bins: list[list[T]] = [[] for _ in range(count)]
+    loads = [(0, index) for index in range(count)]
+    heapq.heapify(loads)
+    ordered = sorted(
+        items,
+        key=lambda item: (-duration(item), stable_id(item).encode("utf-8")),
+    )
+    for item in ordered:
+        load, index = heapq.heappop(loads)
+        bins[index].append(item)
+        heapq.heappush(loads, (load + duration(item), index))
+    return bins
+
+
+def _pack_with_soft_target(
+    items: Sequence[T],
+    target_ms: int,
+    duration: Callable[[T], int],
+    stable_id: Callable[[T], str],
+) -> list[list[T]]:
+    if not items:
+        return []
+    oversized = [item for item in items if duration(item) > target_ms]
+    regular = [item for item in items if duration(item) <= target_ms]
+    result = [
+        [item] for item in sorted(oversized, key=lambda item: stable_id(item).encode())
+    ]
+    if not regular:
+        return result
+    count = max(1, math.ceil(sum(duration(item) for item in regular) / target_ms))
+    attempts: dict[int, list[list[T]]] = {}
+
+    def try_count(candidate: int) -> list[list[T]]:
+        if candidate not in attempts:
+            attempts[candidate] = _lpt_bins(regular, candidate, duration, stable_id)
+        return attempts[candidate]
+
+    def fits(candidate: int) -> bool:
+        return all(
+            sum(duration(item) for item in group) <= target_ms
+            for group in try_count(candidate)
+        )
+
+    if fits(count):
+        return result + try_count(count)
+
+    lower = count
+    upper = min(len(regular), max(lower + 1, lower * 2))
+    while upper < len(regular) and not fits(upper):
+        lower = upper
+        upper = min(len(regular), upper * 2)
+    while lower + 1 < upper:
+        middle = (lower + upper) // 2
+        if fits(middle):
+            upper = middle
+        else:
+            lower = middle
+    return result + try_count(upper)
+
+
+def _unit_source(unit: Unit) -> str:
+    sources = {batch.source_file for batch in unit.batches}
+    if len(sources) != 1:
+        raise ValueError(f"unit {unit.id} crosses source files")
+    return sources.pop()
+
+
+def source_affine_unit_bins(
+    units: Sequence[Unit],
+    count: int,
+) -> list[list[Unit]]:
+    """Balance units, splitting sources only for a material makespan improvement."""
+
+    if count <= 0:
+        raise ValueError("count must be positive")
+    if not units:
+        return [[] for _ in range(count)]
+    by_source: dict[str, list[Unit]] = defaultdict(list)
+    for unit in units:
+        by_source[_unit_source(unit)].append(unit)
+    whole_groups = [
+        _UnitGroup(
+            id=source,
+            units=tuple(
+                sorted(by_source[source], key=lambda unit: unit.id.encode("utf-8"))
+            ),
+            estimated_ms=sum(unit.estimated_ms for unit in by_source[source]),
+        )
+        for source in sorted(by_source, key=lambda value: value.encode("utf-8"))
+    ]
+    whole_bins = _lpt_bins(
+        whole_groups,
+        count,
+        lambda group: group.estimated_ms,
+        lambda group: group.id,
+    )
+    fair_share = max(
+        1,
+        math.ceil(sum(unit.estimated_ms for unit in units) / count),
+    )
+    split_groups: list[_UnitGroup] = []
+    for source in sorted(by_source, key=lambda value: value.encode("utf-8")):
+        source_units = by_source[source]
+        source_load = sum(unit.estimated_ms for unit in source_units)
+        chunk_count = min(count, max(1, math.ceil(source_load / fair_share)))
+        chunks = _lpt_bins(
+            source_units,
+            chunk_count,
+            lambda unit: unit.estimated_ms,
+            lambda unit: unit.id,
+        )
+        for index, chunk in enumerate(chunks):
+            if not chunk:
+                continue
+            ordered = tuple(sorted(chunk, key=lambda unit: unit.id.encode("utf-8")))
+            split_groups.append(
+                _UnitGroup(
+                    id=f"{source}\0{index:04d}",
+                    units=ordered,
+                    estimated_ms=sum(unit.estimated_ms for unit in ordered),
+                )
+            )
+    split_bins = _lpt_bins(
+        split_groups,
+        count,
+        lambda group: group.estimated_ms,
+        lambda group: group.id,
+    )
+    whole_makespan = max(
+        (sum(group.estimated_ms for group in group_bin) for group_bin in whole_bins),
+        default=0,
+    )
+    split_makespan = max(
+        (sum(group.estimated_ms for group in group_bin) for group_bin in split_bins),
+        default=0,
+    )
+    materially_better = split_makespan * 100 <= whole_makespan * (
+        100 - _MIN_AFFINITY_IMPROVEMENT_PERCENT
+    )
+    group_bins = split_bins if materially_better else whole_bins
+    return [
+        [unit for group in group_bin for unit in group.units]
+        for group_bin in group_bins
+    ]
+
+
+def _atomic_items(
+    nodes: Sequence[CollectedNode], estimates: dict[str, int]
+) -> list[_AtomicItem]:
+    groups: dict[str, list[CollectedNode]] = defaultdict(list)
+    for node in nodes:
+        group_key = (
+            f"group:{node.source_file}:{node.shard_group}"
+            if node.shard_group is not None
+            else f"node:{node.nodeid}"
+        )
+        groups[group_key].append(node)
+    items = []
+    for key, members in groups.items():
+        ordered = tuple(sorted(members, key=lambda item: item.order))
+        items.append(
+            _AtomicItem(
+                id=key,
+                nodes=ordered,
+                estimated_ms=sum(estimates[node.nodeid] for node in ordered),
+            )
+        )
+    return items
+
+
+def build_plan(
+    collected_nodes: Sequence[CollectedNode],
+    estimate_book: EstimateBook,
+    options: PlanningOptions,
+) -> Plan:
+    nodes = tuple(sorted(collected_nodes, key=lambda node: node.order))
+    if len({node.nodeid for node in nodes}) != len(nodes):
+        raise ValueError("collection contains duplicate node IDs")
+    duration_ms: dict[str, int] = {}
+    fallback_counts: Counter[str] = Counter()
+    fallback_sources: dict[str, str] = {}
+    for node in nodes:
+        lookup = estimate_book.lookup_runtime(
+            node.nodeid,
+            options.default_case_seconds,
+        )
+        duration_ms[node.nodeid] = max(1, round(lookup.seconds * 1000))
+        fallback_counts[lookup.source] += 1
+        if lookup.source != "provided":
+            fallback_sources[node.nodeid] = lookup.source
+
+    source_nodes: dict[str, list[CollectedNode]] = defaultdict(list)
+    for node in nodes:
+        source_nodes[node.source_file].append(node)
+
+    batches: list[Batch] = []
+    solo_sources = {node.source_file for node in nodes if node.solo}
+    for source_file in sorted(source_nodes, key=lambda value: value.encode("utf-8")):
+        overhead_ms = estimate_book.overhead_ms_runtime(
+            source_file, options.default_source_overhead_seconds
+        )
+        baseline_capacity = max(1, options.checkpoint_seconds * 1000 - overhead_ms)
+        unit_capacity = max(1, options.target_unit_seconds * 1000 - overhead_ms)
+        overhead_aware_capacity = min(
+            unit_capacity,
+            _MIN_WORK_TO_OVERHEAD_RATIO * overhead_ms,
+        )
+        item_capacity = max(baseline_capacity, overhead_aware_capacity)
+        if source_file in solo_sources:
+            batch_nodes = tuple(
+                sorted(source_nodes[source_file], key=lambda node: node.order)
+            )
+            nodeids = tuple(node.nodeid for node in batch_nodes)
+            item_ms = sum(duration_ms[nodeid] for nodeid in nodeids)
+            batches.append(
+                Batch(
+                    id=_stable_id("batch", nodeids),
+                    source_file=source_file,
+                    nodeids=nodeids,
+                    estimated_ms=overhead_ms + item_ms,
+                    overhead_ms=overhead_ms,
+                    oversized=item_ms > item_capacity,
+                )
+            )
+            continue
+        atomic = _atomic_items(source_nodes[source_file], duration_ms)
+        item_bins = _pack_with_soft_target(
+            atomic,
+            item_capacity,
+            lambda item: item.estimated_ms,
+            lambda item: item.id,
+        )
+        target_unit_count = max(
+            1,
+            math.ceil(sum(item.estimated_ms for item in atomic) / unit_capacity),
+        )
+        process_count_cap = target_unit_count * _MAX_BATCHES_PER_TARGET_UNIT
+        if len(item_bins) > process_count_cap:
+            item_bins = _lpt_bins(
+                atomic,
+                min(process_count_cap, len(atomic)),
+                lambda item: item.estimated_ms,
+                lambda item: item.id,
+            )
+        for item_bin in item_bins:
+            batch_nodes = tuple(
+                sorted(
+                    (node for item in item_bin for node in item.nodes),
+                    key=lambda node: node.order,
+                )
+            )
+            nodeids = tuple(node.nodeid for node in batch_nodes)
+            item_ms = sum(duration_ms[nodeid] for nodeid in nodeids)
+            batches.append(
+                Batch(
+                    id=_stable_id("batch", nodeids),
+                    source_file=source_file,
+                    nodeids=nodeids,
+                    estimated_ms=overhead_ms + item_ms,
+                    overhead_ms=overhead_ms,
+                    oversized=item_ms > item_capacity,
+                )
+            )
+
+    batches_by_source: dict[str, list[Batch]] = defaultdict(list)
+    for batch in batches:
+        batches_by_source[batch.source_file].append(batch)
+    unit_bins: list[list[Batch]] = []
+    for source_file in sorted(
+        batches_by_source, key=lambda value: value.encode("utf-8")
+    ):
+        source_batches = batches_by_source[source_file]
+        if source_file in solo_sources:
+            unit_bins.extend(
+                [batch]
+                for batch in sorted(
+                    source_batches, key=lambda batch: batch.id.encode("utf-8")
+                )
+            )
+            continue
+        unit_bins.extend(
+            _pack_with_soft_target(
+                source_batches,
+                options.target_unit_seconds * 1000,
+                lambda batch: batch.estimated_ms,
+                lambda batch: batch.id,
+            )
+        )
+    units = []
+    for batch_bin in unit_bins:
+        ordered_batches = tuple(sorted(batch_bin, key=lambda batch: batch.id.encode()))
+        unit_nodeids = [nodeid for batch in ordered_batches for nodeid in batch.nodeids]
+        estimate = sum(batch.estimated_ms for batch in ordered_batches)
+        units.append(
+            Unit(
+                id=_stable_id("unit", unit_nodeids),
+                batches=ordered_batches,
+                estimated_ms=estimate,
+                oversized=estimate > options.target_unit_seconds * 1000,
+            )
+        )
+
+    shard_bins = source_affine_unit_bins(units, options.shard_count)
+    shard_for_unit = {
+        unit.id: shard_index
+        for shard_index, shard_units in enumerate(shard_bins)
+        for unit in shard_units
+    }
+    assigned = tuple(
+        replace(unit, shard_index=shard_for_unit[unit.id])
+        for unit in sorted(units, key=lambda item: item.id.encode("utf-8"))
+    )
+    plan = Plan(
+        options,
+        nodes,
+        assigned,
+        dict(fallback_counts),
+        fallback_sources,
+    )
+    errors = validate_plan(plan)
+    if errors:
+        raise ValueError("invalid plan: " + "; ".join(errors))
+    return plan
+
+
+def _estimated_worker_loads(
+    units: Sequence[Unit],
+    workers: int,
+    solo_sources: frozenset[str],
+) -> list[int]:
+    if workers <= 0:
+        raise ValueError("workers must be positive")
+    solo_units = [unit for unit in units if _unit_is_solo(unit, solo_sources)]
+    regular_units = [unit for unit in units if not _unit_is_solo(unit, solo_sources)]
+    # Workers start with source-affine queues but steal whole units after
+    # draining their own queue, so LPT is the appropriate steady-state model.
+    bins = _lpt_bins(
+        regular_units,
+        workers,
+        lambda unit: unit.estimated_ms,
+        lambda unit: unit.id,
+    )
+    exclusive_ms = sum(unit.estimated_ms for unit in solo_units)
+    return [
+        exclusive_ms + sum(unit.estimated_ms for unit in worker_units)
+        for worker_units in bins
+    ]
+
+
+def _unit_is_solo(unit: Unit, solo_sources: frozenset[str]) -> bool:
+    return any(batch.source_file in solo_sources for batch in unit.batches)
+
+
+def capacity_metrics(
+    plan: Plan,
+    workers_by_shard: Mapping[int, int] | None = None,
+    *,
+    deadline_seconds: int = 0,
+) -> CapacityMetrics:
+    """Return deterministic load, makespan, and deadline-capacity estimates."""
+
+    configured = workers_by_shard or {}
+    shard_loads: dict[str, int] = {}
+    worker_loads: dict[str, list[int]] = {}
+    makespans: list[int] = []
+    required_by_shard: dict[str, int | None] = {}
+    deadline_ms = deadline_seconds * 1000
+    solo_sources = frozenset(node.source_file for node in plan.nodes if node.solo)
+    for shard_index in range(plan.options.shard_count):
+        units = [unit for unit in plan.units if unit.shard_index == shard_index]
+        load = sum(unit.estimated_ms for unit in units)
+        shard_loads[str(shard_index)] = load
+        workers = max(1, int(configured.get(shard_index, 1)))
+        loads = _estimated_worker_loads(units, workers, solo_sources)
+        worker_loads[str(shard_index)] = loads
+        makespans.append(max(loads, default=0))
+        if deadline_ms <= 0:
+            required_by_shard[str(shard_index)] = None
+        elif not units:
+            required_by_shard[str(shard_index)] = 0
+        else:
+            regular_count = sum(not _unit_is_solo(unit, solo_sources) for unit in units)
+            required_by_shard[str(shard_index)] = next(
+                (
+                    candidate
+                    for candidate in range(1, max(1, regular_count) + 1)
+                    if max(
+                        _estimated_worker_loads(units, candidate, solo_sources),
+                        default=0,
+                    )
+                    <= deadline_ms
+                ),
+                None,
+            )
+    required_values = list(required_by_shard.values())
+    required_total = (
+        sum(value for value in required_values if value is not None)
+        if deadline_ms > 0 and all(value is not None for value in required_values)
+        else None
+    )
+    overhead_by_source: dict[str, int] = defaultdict(int)
+    for unit in plan.units:
+        for batch in unit.batches:
+            overhead_by_source[batch.source_file] += batch.overhead_ms
+    return {
+        "configured_workers_by_shard": {
+            str(index): max(1, int(configured.get(index, 1)))
+            for index in range(plan.options.shard_count)
+        },
+        "estimated_shard_load_ms": shard_loads,
+        "estimated_worker_load_ms": worker_loads,
+        "estimated_makespan_ms": max(makespans, default=0),
+        "total_estimated_load_ms": sum(shard_loads.values()),
+        "total_estimated_overhead_ms": sum(
+            batch.overhead_ms for unit in plan.units for batch in unit.batches
+        ),
+        "estimated_overhead_by_source_ms": dict(sorted(overhead_by_source.items())),
+        "deadline_seconds": deadline_seconds,
+        "required_workers_by_shard": required_by_shard,
+        "required_total_worker_slots": required_total,
+    }
+
+
+def validate_plan(plan: Plan) -> list[str]:
+    errors: list[str] = []
+    expected = [node.nodeid for node in plan.nodes]
+    assigned = [
+        nodeid
+        for unit in plan.units
+        for batch in unit.batches
+        for nodeid in batch.nodeids
+    ]
+    duplicates = sorted(
+        nodeid for nodeid, count in Counter(assigned).items() if count > 1
+    )
+    missing = sorted(set(expected) - set(assigned))
+    extra = sorted(set(assigned) - set(expected))
+    if duplicates:
+        errors.append(f"duplicate nodes: {duplicates[:5]}")
+    if missing:
+        errors.append(f"missing nodes: {missing[:5]}")
+    if extra:
+        errors.append(f"unexpected nodes: {extra[:5]}")
+    sources_by_nodeid = {node.nodeid: node.source_file for node in plan.nodes}
+    for unit in plan.units:
+        if not 0 <= unit.shard_index < plan.options.shard_count:
+            errors.append(f"unit {unit.id} has invalid shard {unit.shard_index}")
+        unit_sources = {batch.source_file for batch in unit.batches}
+        if len(unit_sources) > 1:
+            errors.append(f"unit {unit.id} crosses source files")
+        for batch in unit.batches:
+            sources = {
+                sources_by_nodeid.get(nodeid, batch.source_file)
+                for nodeid in batch.nodeids
+                if nodeid in sources_by_nodeid
+            } or {batch.source_file}
+            if sources != {batch.source_file}:
+                errors.append(f"batch {batch.id} crosses source files")
+    return errors

--- a/scripts/test_sharding/processes.py
+++ b/scripts/test_sharding/processes.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import os
+import signal
+import subprocess
+import time
+from typing import Any
+
+
+def _process_group_exists(process_group: int) -> bool:
+    try:
+        os.killpg(process_group, 0)
+    except ProcessLookupError:
+        return False
+    return True
+
+
+def terminate_process_group(
+    process: subprocess.Popen[Any], grace_seconds: float
+) -> str:
+    process_group = process.pid
+    prior_returncode = process.poll()
+    try:
+        os.killpg(process_group, signal.SIGTERM)
+    except ProcessLookupError:
+        process.poll()
+        return (
+            f"exit-{prior_returncode}"
+            if prior_returncode is not None
+            else "already-exited"
+        )
+
+    deadline = time.monotonic() + max(0.0, grace_seconds)
+    while True:
+        process.poll()
+        if not _process_group_exists(process_group):
+            process.wait()
+            return "SIGTERM"
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            break
+        time.sleep(min(0.05, remaining))
+
+    try:
+        os.killpg(process_group, signal.SIGKILL)
+    except ProcessLookupError:
+        process.wait()
+        return "SIGTERM"
+    process.wait()
+    return "SIGKILL"

--- a/scripts/test_sharding/progress.py
+++ b/scripts/test_sharding/progress.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import json
+from typing import Any
+
+
+PYTEST_EVENT_PREFIX = "@@flashinfer-pytest-event@@ "
+
+
+def encode_pytest_event(event: str, **fields: Any) -> str:
+    return PYTEST_EVENT_PREFIX + json.dumps(
+        {"event": event, **fields}, sort_keys=True, separators=(",", ":")
+    )
+
+
+def decode_pytest_event(line: str) -> dict[str, Any] | None:
+    position = line.find(PYTEST_EVENT_PREFIX)
+    if position < 0:
+        return None
+    try:
+        value = json.loads(line[position + len(PYTEST_EVENT_PREFIX) :])
+    except json.JSONDecodeError:
+        return None
+    return value if isinstance(value, dict) else None

--- a/scripts/test_sharding/pytest_plugin.py
+++ b/scripts/test_sharding/pytest_plugin.py
@@ -1,0 +1,264 @@
+"""Pytest plugin used by the sharding runner.
+
+The plugin communicates through JSON files so the coordinator never has to parse
+pytest's terminal output and never passes hundreds of thousands of node IDs on a
+command line.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from .io import atomic_write_json
+from .models import CollectedNode
+from .progress import encode_pytest_event
+
+
+def _emit_progress(event: str, **fields: Any) -> None:
+    stream = sys.__stdout__
+    stream.write(encode_pytest_event(event, **fields) + "\n")
+    stream.flush()
+
+
+def pytest_addoption(parser: pytest.Parser) -> None:
+    group = parser.getgroup("flashinfer-sharding")
+    group.addoption("--flashinfer-collection-json", metavar="PATH")
+    group.addoption("--flashinfer-node-file", metavar="PATH")
+    group.addoption("--flashinfer-result-json", metavar="PATH")
+    group.addoption("--flashinfer-telemetry-json", metavar="PATH")
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    config.addinivalue_line(
+        "markers",
+        "shard_group(name): keep marked nodes from one source in one pytest batch",
+    )
+    config.addinivalue_line(
+        "markers",
+        "solo: run every node from this source without overlapping another local unit",
+    )
+    config.addinivalue_line(
+        "markers",
+        "long_running: dispatch every unit from this source before normal work",
+    )
+    config._flashinfer_sharding = {  # type: ignore[attr-defined]
+        "session_start": time.time(),
+        "collection_complete": None,
+        "first_case_start": None,
+        "report_complete": None,
+        "nodes": {},
+    }
+
+
+def _marker_name(item: pytest.Item) -> str | None:
+    marker = item.get_closest_marker("shard_group")
+    if marker is None:
+        return None
+    if len(marker.args) != 1 or marker.kwargs or not isinstance(marker.args[0], str):
+        raise pytest.UsageError("shard_group requires exactly one string argument")
+    if not marker.args[0]:
+        raise pytest.UsageError("shard_group name must not be empty")
+    return marker.args[0]
+
+
+def pytest_collection_modifyitems(
+    config: pytest.Config, items: list[pytest.Item]
+) -> None:
+    solo_sources = {
+        Path(str(item.path)).resolve()
+        for item in items
+        if item.get_closest_marker("solo") is not None
+    }
+    long_running_sources = {
+        Path(str(item.path)).resolve()
+        for item in items
+        if item.get_closest_marker("long_running") is not None
+    }
+    collected = []
+    for order, item in enumerate(items):
+        node = CollectedNode.from_nodeid(item.nodeid, order, _marker_name(item))
+        item_path = Path(str(item.path)).resolve()
+        try:
+            source_file = item_path.relative_to(Path.cwd().resolve()).as_posix()
+        except ValueError:
+            source_file = str(item_path)
+        collected.append(
+            CollectedNode(
+                nodeid=node.nodeid,
+                source_file=source_file,
+                base_function=node.base_function,
+                order=node.order,
+                shard_group=node.shard_group,
+                solo=item_path in solo_sources,
+                long_running=item_path in long_running_sources,
+            )
+        )
+    collection_path = config.getoption("--flashinfer-collection-json")
+    if collection_path:
+        atomic_write_json(
+            Path(collection_path),
+            {"schema_version": 1, "nodes": [node.to_dict() for node in collected]},
+        )
+
+    selection_path = config.getoption("--flashinfer-node-file")
+    if selection_path:
+        try:
+            selected_data = json.loads(Path(selection_path).read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as error:
+            raise pytest.UsageError(
+                f"cannot read node selection {selection_path}: {error}"
+            ) from error
+        if not isinstance(selected_data, list) or not all(
+            isinstance(nodeid, str) for nodeid in selected_data
+        ):
+            raise pytest.UsageError("node selection must be a JSON array of node IDs")
+        selected = set(selected_data)
+        available = {item.nodeid for item in items}
+        missing = sorted(selected - available)
+        if missing:
+            raise pytest.UsageError(
+                "selected node IDs were not collected: " + ", ".join(missing[:5])
+            )
+        keep = [item for item in items if item.nodeid in selected]
+        deselected = [item for item in items if item.nodeid not in selected]
+        if deselected:
+            config.hook.pytest_deselected(items=deselected)
+        items[:] = keep
+
+    for item in items:
+        item.user_properties.append(("pytest_nodeid", item.nodeid))
+
+
+def pytest_collection_finish(session: pytest.Session) -> None:
+    state = session.config._flashinfer_sharding  # type: ignore[attr-defined]
+    state["collection_complete"] = time.time()
+
+
+def pytest_runtest_logstart(nodeid: str, location: tuple[str, int | None, str]) -> None:
+    del location
+    record = _REPORTS.setdefault(
+        nodeid,
+        {"nodeid": nodeid, "setup": 0.0, "call": 0.0, "teardown": 0.0},
+    )
+    record["started_at"] = time.time()
+    _emit_progress("start", nodeid=nodeid, started_at=record["started_at"])
+
+
+def pytest_runtest_logfinish(
+    nodeid: str, location: tuple[str, int | None, str]
+) -> None:
+    del location
+    record = _REPORTS.setdefault(
+        nodeid,
+        {"nodeid": nodeid, "setup": 0.0, "call": 0.0, "teardown": 0.0},
+    )
+    record["finished_at"] = time.time()
+    _emit_progress(
+        "finish",
+        nodeid=nodeid,
+        outcome=_final_outcome(record),
+        duration_seconds=sum(
+            float(record.get(phase, 0.0)) for phase in ("setup", "call", "teardown")
+        ),
+        finished_at=record["finished_at"],
+    )
+
+
+@pytest.hookimpl(tryfirst=True)
+def pytest_runtest_setup(item: pytest.Item) -> None:
+    state = item.config._flashinfer_sharding  # type: ignore[attr-defined]
+    if state["first_case_start"] is None:
+        state["first_case_start"] = time.time()
+
+
+def pytest_runtest_logreport(report: pytest.TestReport) -> None:
+    config = getattr(report, "config", None)
+    del config
+    # TestReport does not expose Config. The per-process recorder is attached to
+    # the plugin module by pytest_runtest_makereport below.
+    record = _REPORTS.setdefault(
+        report.nodeid,
+        {"nodeid": report.nodeid, "setup": 0.0, "call": 0.0, "teardown": 0.0},
+    )
+    record[report.when] = float(report.duration)
+    record[f"{report.when}_outcome"] = report.outcome
+    if report.failed:
+        diagnostic = str(report.longrepr)
+        prior_diagnostic = str(record.get("longrepr", ""))
+        record["longrepr"] = (
+            f"{prior_diagnostic}\n\n[{report.when} failure]\n{diagnostic}"
+            if prior_diagnostic
+            else diagnostic
+        )
+        encoded = diagnostic.encode("utf-8")
+        truncated = len(encoded) > 32 * 1024
+        if truncated:
+            diagnostic = encoded[: 32 * 1024].decode("utf-8", errors="replace")
+        _emit_progress(
+            "failure",
+            nodeid=report.nodeid,
+            phase=report.when,
+            diagnostic=diagnostic,
+            diagnostic_truncated=truncated,
+        )
+
+
+_REPORTS: dict[str, dict[str, Any]] = {}
+
+
+def _final_outcome(record: dict[str, Any]) -> str:
+    outcomes = [
+        record.get(f"{phase}_outcome") for phase in ("setup", "call", "teardown")
+    ]
+    if "failed" in outcomes:
+        return "failed"
+    if "skipped" in outcomes:
+        return "skipped"
+    if record.get("call_outcome") == "passed":
+        return "passed"
+    return "unknown"
+
+
+def pytest_sessionfinish(
+    session: pytest.Session, exitstatus: int | pytest.ExitCode
+) -> None:
+    now = time.time()
+    state = session.config._flashinfer_sharding  # type: ignore[attr-defined]
+    state["report_complete"] = now
+    result_path = session.config.getoption("--flashinfer-result-json")
+    if result_path:
+        results = []
+        for nodeid in sorted(_REPORTS, key=lambda value: value.encode("utf-8")):
+            record = dict(_REPORTS[nodeid])
+            record["outcome"] = _final_outcome(record)
+            results.append(record)
+        atomic_write_json(
+            Path(result_path),
+            {
+                "schema_version": 1,
+                "exitstatus": int(exitstatus),
+                "results": results,
+            },
+        )
+    telemetry_path = session.config.getoption("--flashinfer-telemetry-json")
+    if telemetry_path:
+        atomic_write_json(
+            Path(telemetry_path),
+            {
+                "schema_version": 1,
+                "process_id": os.getpid(),
+                "session_start": state["session_start"],
+                "collection_complete": state["collection_complete"],
+                "first_case_start": state["first_case_start"],
+                "report_complete": state["report_complete"],
+                "process_exit": now,
+            },
+        )
+    _REPORTS.clear()

--- a/scripts/test_sharding/runner.py
+++ b/scripts/test_sharding/runner.py
@@ -1,0 +1,1552 @@
+from __future__ import annotations
+
+import json
+import os
+import queue
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+from collections import Counter
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from .estimates import EstimateBook
+from .io import atomic_write_json
+from .junit import (
+    SyntheticBatchMetadata,
+    create_synthetic_batch_xml,
+    finalized_batch_outcomes,
+    validate_batch_xml,
+)
+from .models import RUNTIME_TIMING_PROFILE, CollectedNode, Plan, PlanningOptions, Unit
+from .planner import build_plan, capacity_metrics, source_affine_unit_bins
+from .processes import terminate_process_group
+from .state import (
+    AttemptRecord,
+    AttemptSettings,
+    ManifestBuild,
+    RunnerStateError,
+    active_attempt_collection_timeout,
+    attempts_dir,
+    build_manifest,
+    claims_dir,
+    collection_fingerprint,
+    create_or_join_attempt,
+    lease_is_live,
+    lease_value,
+    list_attempts,
+    load_attempt,
+    load_manifest,
+    recover_unit_elapsed,
+    sha256_file,
+    source_git_sha_from_env,
+    state_lock,
+    units_dir,
+    verify_manifest,
+    write_unit_elapsed,
+    write_manifest,
+)
+from .summary import (
+    RunSummary,
+    batch_is_final,
+    batch_xml_path,
+    exit_code_for_summary,
+    exit_code_for_shard,
+    publish_summary,
+    publish_summary_under_lock,
+)
+from .workers import BatchExecutionRequest, execute_batch, write_console
+
+
+_COLLECTION_HEARTBEAT_SECONDS = 30.0
+_LEASE_HEARTBEAT_SECONDS = 10.0
+_LEASE_CLOSE_SECONDS = 2.0
+_CONTROLLER_PROGRESS_SECONDS = 60.0
+
+
+def _timestamp() -> str:
+    return datetime.now(timezone.utc).astimezone().isoformat(timespec="seconds")
+
+
+@dataclass(frozen=True)
+class DeadlineClock:
+    started_at: float
+    limit_seconds: int
+
+    @classmethod
+    def from_attempt(cls, attempt: AttemptRecord) -> DeadlineClock:
+        return cls(
+            started_at=float(attempt["started_at"]),
+            limit_seconds=int(attempt["settings"]["deadline_seconds"]),
+        )
+
+    def status_fields(self) -> str:
+        elapsed = max(0.0, time.time() - self.started_at)
+        limit = f"{self.limit_seconds}s" if self.limit_seconds > 0 else "disabled"
+        return f"deadline_elapsed={elapsed:.1f}s deadline={limit}"
+
+
+class CollectionTimeoutError(RunnerStateError):
+    def __init__(self, termination_signal: str, elapsed_seconds: float) -> None:
+        super().__init__("pytest collection exceeded the remaining attempt deadline")
+        self.termination_signal = termination_signal
+        self.elapsed_seconds = elapsed_seconds
+        self.result_scope = "current-process"
+        self.finalized_nodes = 0
+        self.passed = 0
+        self.failed = 0
+        self.skipped = 0
+        self.pending_nodes: int | None = None
+        self.deadline_clock: DeadlineClock | None = None
+
+    def record_existing_results(self, summary: RunSummary) -> None:
+        outcomes = summary["outcomes"]
+        self.result_scope = "suite"
+        self.finalized_nodes = int(summary["finalized_nodes"])
+        self.passed = int(outcomes.get("passed", 0))
+        self.failed = int(outcomes.get("failed", 0))
+        self.skipped = int(outcomes.get("skipped", 0))
+        self.pending_nodes = len(summary["pending_nodes"])
+
+    def record_deadline_clock(self, deadline_clock: DeadlineClock) -> None:
+        self.deadline_clock = deadline_clock
+
+
+@dataclass(frozen=True)
+class SelectionSettings:
+    test_path: Path
+    sanity_test: bool
+    sample_rate: int
+    sample_offset: int
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "sanity_test": self.sanity_test,
+            "sample_rate": self.sample_rate,
+            "sample_offset": self.sample_offset,
+        }
+
+
+def _reject_runner_path_collisions(junit_dir: Path, *, include_attempts: bool) -> None:
+    runner_paths = [
+        junit_dir / "test_timings.csv",
+        junit_dir / "memory_summary.csv",
+        junit_dir / "run-summary.json",
+        claims_dir(junit_dir),
+        units_dir(junit_dir),
+        junit_dir / "shards",
+    ]
+    if include_attempts:
+        runner_paths.append(attempts_dir(junit_dir))
+    collisions = [path for path in runner_paths if path.exists()]
+    if collisions:
+        raise RunnerStateError(
+            "new run would collide with runner-owned paths: "
+            + ", ".join(str(path) for path in collisions[:5])
+        )
+
+
+@dataclass(frozen=True)
+class ExecutionSettings:
+    workers: int
+    shard_index: int
+    attempt: AttemptSettings
+    monitor_memory: bool = True
+    memory_interval: float = 2.0
+    pytest_command_prefix: tuple[str, ...] = ()
+    timing_profile: str = RUNTIME_TIMING_PROFILE
+
+
+@dataclass(frozen=True)
+class ManifestPreparation:
+    repo_root: Path
+    junit_dir: Path
+    selection: SelectionSettings
+    planning: PlanningOptions
+    collection_timeout_seconds: float | None = None
+    collection_grace_seconds: float = 5.0
+    attempt_settings: AttemptSettings | None = None
+    operation_started_at: float | None = None
+    pytest_command_prefix: tuple[str, ...] = ()
+    duration_estimates: Path | None = None
+    overhead_estimates: Path | None = None
+
+
+def _report_shard_status(
+    summary: RunSummary,
+    shard_index: int,
+    *,
+    state: str,
+    deadline_clock: DeadlineClock,
+    reason: str | None = None,
+) -> None:
+    shard = summary["shards"][str(shard_index)]
+    outcomes = shard["outcomes"]
+    reason_field = f" reason={reason}" if reason else ""
+    print(
+        f"RUNNER STATUS: shard={shard_index} state={state}{reason_field} "
+        f"finalized={shard['finalized_nodes']}/{shard['planned_nodes']} "
+        f"passed={outcomes.get('passed', 0)} failed={outcomes.get('failed', 0)} "
+        f"skipped={outcomes.get('skipped', 0)} pending={shard['pending_nodes']} "
+        f"suite_complete={str(summary['complete']).lower()} "
+        f"{deadline_clock.status_fields()}",
+        flush=True,
+    )
+
+
+def _estimate_checksums(
+    duration: Path | None, overhead: Path | None
+) -> dict[str, str | None]:
+    for label, path in (("duration", duration), ("overhead", overhead)):
+        if path is not None and not path.is_file():
+            raise RunnerStateError(f"{label} estimate file does not exist: {path}")
+    return {
+        "duration": sha256_file(duration) if duration is not None else None,
+        "overhead": sha256_file(overhead) if overhead is not None else None,
+    }
+
+
+def _wait_for_collection(
+    process: subprocess.Popen[Any],
+    *,
+    test_path: Path,
+    timeout_seconds: float | None,
+    grace_seconds: float,
+) -> None:
+    started_at = time.monotonic()
+    deadline = started_at + timeout_seconds if timeout_seconds is not None else None
+    while process.poll() is None:
+        remaining = None if deadline is None else deadline - time.monotonic()
+        if remaining is not None and remaining <= 0:
+            termination_signal = terminate_process_group(process, grace_seconds)
+            raise CollectionTimeoutError(
+                termination_signal, time.monotonic() - started_at
+            )
+        wait_seconds = _COLLECTION_HEARTBEAT_SECONDS
+        if remaining is not None:
+            wait_seconds = min(wait_seconds, remaining)
+        try:
+            process.wait(timeout=max(0.001, wait_seconds))
+        except subprocess.TimeoutExpired:
+            if deadline is not None and time.monotonic() >= deadline:
+                termination_signal = terminate_process_group(process, grace_seconds)
+                raise CollectionTimeoutError(
+                    termination_signal, time.monotonic() - started_at
+                ) from None
+            print(
+                "RUNNER HEARTBEAT: state=collecting "
+                f"elapsed={time.monotonic() - started_at:.1f}s "
+                f"collected=unknown test_path={test_path}",
+                flush=True,
+            )
+
+
+def _collect_nodes(
+    repo_root: Path,
+    test_path: Path,
+    timeout_seconds: float | None,
+    grace_seconds: float,
+) -> list[dict[str, Any]]:
+    with tempfile.TemporaryDirectory(prefix="flashinfer-test-collection-") as directory:
+        output = Path(directory) / "collection.json"
+        log_path = Path(directory) / "collection.log"
+        env = os.environ.copy()
+        pythonpath = env.get("PYTHONPATH")
+        env["PYTHONPATH"] = (
+            f"{repo_root}{os.pathsep}{pythonpath}" if pythonpath else str(repo_root)
+        )
+        command = [
+            sys.executable,
+            "-m",
+            "pytest",
+            "--collect-only",
+            "-q",
+            "-q",
+            "--continue-on-collection-errors",
+            "-p",
+            "scripts.test_sharding.pytest_plugin",
+            f"--flashinfer-collection-json={output}",
+            str(test_path),
+        ]
+        with log_path.open("wb") as log:
+            process = subprocess.Popen(
+                command,
+                cwd=repo_root,
+                env=env,
+                stdout=log,
+                stderr=subprocess.STDOUT,
+                start_new_session=True,
+            )
+            _wait_for_collection(
+                process,
+                test_path=test_path,
+                timeout_seconds=timeout_seconds,
+                grace_seconds=grace_seconds,
+            )
+        if process.returncode != 0 or not output.exists():
+            diagnostic = log_path.read_text(encoding="utf-8", errors="replace")[-20000:]
+            raise RunnerStateError(
+                f"pytest collection failed with exit code {process.returncode}:\n{diagnostic}"
+            )
+        try:
+            value = json.loads(output.read_text(encoding="utf-8"))
+            nodes = value["nodes"]
+        except (OSError, KeyError, TypeError, json.JSONDecodeError) as error:
+            raise RunnerStateError(f"invalid collection metadata: {error}") from error
+        if not nodes:
+            raise RunnerStateError(f"pytest collected no tests below {test_path}")
+        return nodes
+
+
+def _validate_selection(selection: SelectionSettings) -> None:
+    if not selection.test_path.exists():
+        raise RunnerStateError(f"test path does not exist: {selection.test_path}")
+    if selection.sample_rate <= 0:
+        raise RunnerStateError("SAMPLE_RATE must be positive")
+    if not 0 <= selection.sample_offset < selection.sample_rate:
+        raise RunnerStateError("SAMPLE_OFFSET must be in [0, SAMPLE_RATE)")
+
+
+def _selected_nodes(
+    raw_nodes: list[dict[str, Any]],
+    selection: SelectionSettings,
+) -> list[CollectedNode]:
+    if selection.sanity_test:
+        raw_nodes = [
+            node
+            for index, node in enumerate(raw_nodes)
+            if index % selection.sample_rate == selection.sample_offset
+        ]
+        if not raw_nodes:
+            raise RunnerStateError("sanity sampling selected no tests")
+    return [
+        CollectedNode(
+            nodeid=node["nodeid"],
+            source_file=node["source_file"],
+            base_function=node["base_function"],
+            order=int(node["order"]),
+            shard_group=node.get("shard_group"),
+            solo=bool(node.get("solo", False)),
+            long_running=bool(node.get("long_running", False)),
+        )
+        for node in raw_nodes
+    ]
+
+
+def _verify_collection(manifest: dict[str, Any], nodes: list[CollectedNode]) -> None:
+    current = collection_fingerprint(nodes)
+    saved = manifest.get("collection_fingerprint")
+    if saved != current:
+        raise RunnerStateError(
+            "existing run is incompatible; use a different --junit-dir:\n  "
+            f"collection_fingerprint: saved={saved!r}, current={current!r}"
+        )
+
+
+def _write_new_manifest(
+    *,
+    request: ManifestPreparation,
+    source_git_sha: str | None,
+    nodes: list[CollectedNode],
+    manifest: dict[str, Any],
+    plan: Plan,
+) -> tuple[dict[str, Any], Plan, bool]:
+    with state_lock(request.junit_dir):
+        concurrent = load_manifest(request.junit_dir)
+        if concurrent is not None:
+            verify_manifest(
+                concurrent,
+                source_git_sha=source_git_sha,
+                test_path=request.selection.test_path,
+                selection=request.selection.to_dict(),
+                planning_options=request.planning.to_dict(),
+                pytest_command_prefix=request.pytest_command_prefix,
+                estimate_files=_estimate_checksums(
+                    request.duration_estimates, request.overhead_estimates
+                ),
+            )
+            _verify_collection(concurrent, nodes)
+            return concurrent, Plan.from_dict(concurrent["plan"]), False
+        _reject_runner_path_collisions(
+            request.junit_dir,
+            include_attempts=request.attempt_settings is None,
+        )
+        write_manifest(request.junit_dir, manifest)
+    return manifest, plan, True
+
+
+def prepare_manifest(
+    request: ManifestPreparation,
+) -> tuple[dict[str, Any], Plan, bool]:
+    repo_root = request.repo_root
+    junit_dir = request.junit_dir
+    selection = request.selection
+    planning = request.planning
+    collection_timeout_seconds = request.collection_timeout_seconds
+    attempt_settings = request.attempt_settings
+    operation_started_at = request.operation_started_at
+    test_path = selection.test_path
+    _validate_selection(selection)
+    junit_dir.mkdir(parents=True, exist_ok=True)
+    source_git_sha = source_git_sha_from_env()
+    selection_value = selection.to_dict()
+    estimate_files = _estimate_checksums(
+        request.duration_estimates, request.overhead_estimates
+    )
+    existing = load_manifest(junit_dir)
+    existing_plan: Plan | None = None
+    if existing is not None:
+        verify_manifest(
+            existing,
+            source_git_sha=source_git_sha,
+            test_path=test_path,
+            selection=selection_value,
+            planning_options=planning.to_dict(),
+            pytest_command_prefix=request.pytest_command_prefix,
+            estimate_files=estimate_files,
+        )
+        existing_plan = Plan.from_dict(existing["plan"])
+    if existing is None:
+        _reject_runner_path_collisions(
+            junit_dir, include_attempts=attempt_settings is None
+        )
+    attempts = list_attempts(junit_dir)
+    active_attempt = bool(attempts and not (attempts[-1] / "closed.json").exists())
+    outputs_complete = bool(
+        existing_plan is not None
+        and all(
+            batch_is_final(junit_dir, unit, batch)
+            for unit in existing_plan.units
+            for batch in unit.batches
+        )
+    )
+    deadline_clock = (
+        DeadlineClock(
+            started_at=(
+                time.time() if operation_started_at is None else operation_started_at
+            ),
+            limit_seconds=attempt_settings.deadline_seconds,
+        )
+        if attempt_settings is not None
+        else None
+    )
+    if attempt_settings is not None and (
+        existing is None or not outputs_complete or active_attempt
+    ):
+        _, attempt = create_or_join_attempt(
+            junit_dir,
+            attempt_settings,
+            started_at=(
+                time.time() if operation_started_at is None else operation_started_at
+            ),
+        )
+        deadline_clock = DeadlineClock.from_attempt(attempt)
+    collection_timeout_seconds = active_attempt_collection_timeout(
+        junit_dir, collection_timeout_seconds
+    )
+    if existing is not None:
+        assert existing_plan is not None
+        return existing, existing_plan, False
+    try:
+        raw_nodes = _collect_nodes(
+            repo_root,
+            test_path,
+            collection_timeout_seconds,
+            request.collection_grace_seconds,
+        )
+    except CollectionTimeoutError as error:
+        if existing_plan is not None:
+            error.record_existing_results(publish_summary(junit_dir, existing_plan))
+        if deadline_clock is not None:
+            error.record_deadline_clock(deadline_clock)
+        raise
+    nodes = _selected_nodes(raw_nodes, selection)
+    estimates = EstimateBook.from_files(
+        request.duration_estimates,
+        request.overhead_estimates,
+    )
+    plan = build_plan(nodes, estimates, planning)
+    manifest = build_manifest(
+        ManifestBuild(
+            repo_root=repo_root,
+            test_path=test_path,
+            source_git_sha=source_git_sha,
+            plan=plan,
+            selection=selection_value,
+            estimate_files=estimate_files,
+            pytest_command_prefix=request.pytest_command_prefix,
+        )
+    )
+    return _write_new_manifest(
+        request=request,
+        source_git_sha=source_git_sha,
+        nodes=nodes,
+        manifest=manifest,
+        plan=plan,
+    )
+
+
+def plan_description(plan: Plan, *, workers: int = 1, deadline_seconds: int = 0) -> str:
+    metrics = capacity_metrics(
+        plan,
+        {index: workers for index in range(plan.options.shard_count)},
+        deadline_seconds=deadline_seconds,
+    )
+    shard_loads = metrics["estimated_shard_load_ms"]
+    batch_count = 0
+    for unit in plan.units:
+        batch_count += len(unit.batches)
+    lines = [
+        f"Collected nodes: {len(plan.nodes)}",
+        f"Checkpoint batches: {batch_count}",
+        f"Logical units: {len(plan.units)}",
+        f"External shards: {plan.options.shard_count}",
+        "Oversized: "
+        f"{sum(batch.oversized for unit in plan.units for batch in unit.batches)} batches, "
+        f"{sum(unit.oversized for unit in plan.units)} units",
+    ]
+    for index in range(plan.options.shard_count):
+        load = shard_loads[str(index)]
+        lines.append(f"  shard {index}: {load / 1000:.1f}s estimated")
+    lines.append(
+        f"Estimated makespan at {workers} worker(s) per shard: "
+        f"{metrics['estimated_makespan_ms'] / 1000:.1f}s"
+    )
+    if deadline_seconds > 0:
+        required = metrics["required_total_worker_slots"]
+        lines.append(
+            "Required worker slots for deadline: "
+            + (str(required) if required is not None else "not feasible")
+        )
+        lines.append(
+            "Required workers by shard: "
+            + ", ".join(
+                f"{index}={value if value is not None else 'not feasible'}"
+                for index, value in metrics["required_workers_by_shard"].items()
+            )
+        )
+    lines.append(
+        f"Estimated process/warm-up overhead: "
+        f"{metrics['total_estimated_overhead_ms'] / 1000:.1f}s"
+    )
+    lines.append(
+        "Fallbacks: "
+        + ", ".join(
+            f"{name}={count}" for name, count in sorted(plan.fallback_counts.items())
+        )
+    )
+    return "\n".join(lines)
+
+
+def visible_devices() -> list[str | None]:
+    configured = os.environ.get("CUDA_VISIBLE_DEVICES")
+    if configured is not None:
+        values = [value.strip() for value in configured.split(",") if value.strip()]
+        if not values or values == ["-1"]:
+            return [None]
+        return values
+    try:
+        result = subprocess.run(
+            ["nvidia-smi", "-L"],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return [None]
+    count = sum(line.startswith("GPU ") for line in result.stdout.splitlines())
+    return [str(index) for index in range(count)] if count else [None]
+
+
+def _synthesize_batch(
+    junit_dir: Path,
+    unit: Unit,
+    batch: Any,
+    metadata: SyntheticBatchMetadata,
+) -> None:
+    output = batch_xml_path(junit_dir, unit, batch)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    if output.exists() and batch_is_final(junit_dir, unit, batch):
+        return
+    create_synthetic_batch_xml(
+        output,
+        batch.nodeids,
+        metadata,
+    )
+    atomic_write_json(
+        output.with_name(f"{batch.id}.meta.json"),
+        {
+            "attempt_id": metadata.attempt_id,
+            "batch_id": batch.id,
+            "unit_id": unit.id,
+            "shard_index": unit.shard_index,
+            "synthetic": True,
+            "timeout_policy": metadata.policy,
+        },
+    )
+
+
+def _completed_node_count(junit_dir: Path, plan: Plan) -> int:
+    """Count batches whose final XML and last-written metadata marker are visible."""
+
+    completed = 0
+    for unit in plan.units:
+        for batch in unit.batches:
+            xml_path = batch_xml_path(junit_dir, unit, batch)
+            metadata_path = xml_path.with_name(f"{batch.id}.meta.json")
+            if xml_path.exists() and metadata_path.exists():
+                completed += len(batch.nodeids)
+    return completed
+
+
+def _live_attempt_leases(attempt_path: Path) -> list[Path]:
+    root = attempt_path / "leases"
+    if not root.exists():
+        return []
+    return [path for path in root.glob("*.json") if lease_is_live(path)]
+
+
+def _attempt_is_eligible(
+    attempt_path: Path,
+    plan: Plan,
+    summary: RunSummary,
+    *,
+    explicit_fan_in: bool = False,
+) -> bool:
+    attempt = load_attempt(attempt_path)
+    deadline_at = attempt.get("deadline_at")
+    deadline_reached = deadline_at is not None and time.time() >= deadline_at
+    done_shards = len(list((attempt_path / "shards").glob("shard-*.done.json")))
+    all_shards_done = done_shards >= plan.options.shard_count
+    return (
+        explicit_fan_in
+        or deadline_reached
+        or all_shards_done
+        or bool(summary["complete"])
+    )
+
+
+def _attempt_infrastructure_errors(attempt_path: Path) -> list[str]:
+    errors: list[str] = []
+    for marker in sorted((attempt_path / "shards").glob("shard-*.done.json")):
+        try:
+            value = json.loads(marker.read_text(encoding="utf-8"))
+            if not isinstance(value, dict):
+                raise TypeError("completion marker is not an object")
+            marker_errors = value.get("infrastructure_errors", [])
+            if not isinstance(marker_errors, list):
+                raise TypeError("infrastructure_errors is not a list")
+            errors.extend(f"{marker.stem}: {error}" for error in marker_errors)
+        except (OSError, TypeError, json.JSONDecodeError) as error:
+            errors.append(f"{marker.stem}: invalid shard completion marker: {error}")
+    return errors
+
+
+def finalize_attempt(
+    *,
+    junit_dir: Path,
+    plan: Plan,
+    attempt_path: Path,
+    explicit_fan_in: bool = False,
+) -> RunSummary:
+    with state_lock(junit_dir):
+        closed_path = attempt_path / "closed.json"
+        if closed_path.exists():
+            return publish_summary_under_lock(junit_dir, plan)
+        attempt = load_attempt(attempt_path)
+        summary = publish_summary_under_lock(junit_dir, plan)
+        if not _attempt_is_eligible(
+            attempt_path,
+            plan,
+            summary,
+            explicit_fan_in=explicit_fan_in,
+        ) or _live_attempt_leases(attempt_path):
+            return summary
+        policy = attempt["settings"]["timeout_policy"]
+        deadline_at = attempt.get("deadline_at")
+        deadline_reached = deadline_at is not None and time.time() >= deadline_at
+        infrastructure_errors = _attempt_infrastructure_errors(attempt_path)
+        if (
+            policy in {"skip", "fail"}
+            and (deadline_reached or explicit_fan_in)
+            and not infrastructure_errors
+            and not summary["complete"]
+        ):
+            for unit in plan.units:
+                for batch in unit.batches:
+                    if not batch_is_final(junit_dir, unit, batch):
+                        _synthesize_batch(
+                            junit_dir,
+                            unit,
+                            batch,
+                            SyntheticBatchMetadata(
+                                policy=policy,
+                                batch_id=batch.id,
+                                unit_id=unit.id,
+                                shard_index=unit.shard_index,
+                                attempt_id=attempt["id"],
+                                profile=RUNTIME_TIMING_PROFILE,
+                            ),
+                        )
+            summary = publish_summary_under_lock(junit_dir, plan)
+        closure = {
+            "ended_at": time.time(),
+            "complete": summary["complete"],
+            "timeout_policy": policy,
+            "infrastructure_error": bool(infrastructure_errors),
+            "infrastructure_errors": infrastructure_errors,
+            "pending_nodes": len(summary["pending_nodes"]),
+            "reason": (
+                "deadline"
+                if deadline_reached
+                else "explicit-fan-in"
+                if explicit_fan_in
+                else "all-work-finished"
+            ),
+        }
+        atomic_write_json(closed_path, closure)
+    return publish_summary(junit_dir, plan)
+
+
+class _LeaseHeartbeat:
+    def __init__(self, attempt: AttemptRecord, shard_index: int) -> None:
+        self.attempt = attempt
+        self.shard_index = shard_index
+        self.paths: dict[Path, str] = {}
+        self.lock = threading.Lock()
+        self.stop = threading.Event()
+        self.failed = threading.Event()
+        self.failure: Exception | None = None
+        self.thread = threading.Thread(target=self._run, daemon=True)
+        self.started = False
+
+    def add(self, path: Path, worker: str) -> None:
+        self.raise_if_failed()
+        with self.lock:
+            self.paths[path] = worker
+        self._renew(path, worker)
+        self.raise_if_failed()
+
+    def remove(self, path: Path) -> None:
+        with self.lock:
+            worker = self.paths.pop(path, None)
+        try:
+            path.unlink(missing_ok=True)
+        except OSError:
+            if worker is not None:
+                with self.lock:
+                    self.paths[path] = worker
+            raise
+
+    def _renew(self, path: Path, worker: str) -> None:
+        atomic_write_json(
+            path,
+            lease_value(
+                attempt_id=self.attempt["id"],
+                shard_index=self.shard_index,
+                worker=worker,
+            ),
+        )
+
+    def _run(self) -> None:
+        while not self.stop.wait(_LEASE_HEARTBEAT_SECONDS):
+            try:
+                with self.lock:
+                    for path, worker in self.paths.items():
+                        self._renew(path, worker)
+            except Exception as error:
+                with self.lock:
+                    self.failure = error
+                self.failed.set()
+                self.stop.set()
+                return
+
+    def raise_if_failed(self) -> None:
+        if not self.failed.is_set():
+            return
+        with self.lock:
+            failure = self.failure
+        raise RunnerStateError(f"lease heartbeat failed: {failure}") from failure
+
+    def start(self) -> None:
+        self.thread.start()
+        self.started = True
+
+    def close(self) -> None:
+        self.stop.set()
+        if self.started:
+            self.thread.join(timeout=_LEASE_CLOSE_SECONDS)
+            if self.thread.is_alive():
+                raise RunnerStateError(
+                    "lease heartbeat did not stop within "
+                    f"{_LEASE_CLOSE_SECONDS:g} seconds"
+                )
+        with self.lock:
+            paths = list(self.paths)
+            self.paths.clear()
+        errors: list[str] = []
+        for path in paths:
+            try:
+                path.unlink(missing_ok=True)
+            except OSError as error:
+                errors.append(f"cannot remove lease {path}: {error}")
+        try:
+            self.raise_if_failed()
+        except RunnerStateError as error:
+            errors.append(str(error))
+        if errors:
+            raise RunnerStateError("; ".join(errors))
+
+
+@dataclass(frozen=True)
+class _UnitTimer:
+    prior_elapsed: float
+    started_monotonic: float
+
+    def elapsed(self) -> float:
+        return self.prior_elapsed + (time.monotonic() - self.started_monotonic)
+
+
+def _next_worker_unit(
+    work_by_worker: list[queue.Queue[Unit]],
+    worker_index: int,
+) -> tuple[queue.Queue[Unit], Unit]:
+    preferred = work_by_worker[worker_index]
+    try:
+        return preferred, preferred.get_nowait()
+    except queue.Empty:
+        pass
+    donors = sorted(
+        (
+            (work.qsize(), index, work)
+            for index, work in enumerate(work_by_worker)
+            if index != worker_index
+        ),
+        key=lambda item: (-item[0], item[1]),
+    )
+    for _, _, work in donors:
+        try:
+            return work, work.get_nowait()
+        except queue.Empty:
+            continue
+    raise queue.Empty
+
+
+@dataclass
+class _ShardProgress:
+    shard_index: int
+    planned: int
+    finalized: int
+    outcomes: Counter[str]
+    synthetic: int = 0
+    finalized_this_invocation: int = 0
+    lock: threading.Lock = field(default_factory=threading.Lock)
+    stop: threading.Event = field(default_factory=threading.Event)
+    thread: threading.Thread | None = None
+
+    def start(self) -> None:
+        self.thread = threading.Thread(
+            target=self._run,
+            name=f"shard-{self.shard_index}-progress",
+            daemon=True,
+        )
+        self.thread.start()
+        self.report()
+
+    def close(self) -> None:
+        self.stop.set()
+        if self.thread is not None:
+            self.thread.join(timeout=2)
+        self.report()
+
+    def _run(self) -> None:
+        while not self.stop.wait(_CONTROLLER_PROGRESS_SECONDS):
+            self.report()
+
+    def record(self, outcomes: Counter[str], *, synthetic: int = 0) -> None:
+        count = sum(outcomes.values())
+        with self.lock:
+            self.finalized += count
+            self.finalized_this_invocation += count
+            self.outcomes.update(outcomes)
+            self.synthetic += synthetic
+        self.report()
+
+    def report(self) -> None:
+        with self.lock:
+            finalized = self.finalized
+            current = self.finalized_this_invocation
+            outcomes = Counter(self.outcomes)
+            synthetic = self.synthetic
+        write_console(
+            f"PROGRESS shard={self.shard_index} finalized={finalized}/{self.planned} "
+            f"finalized_this_invocation={current} passed={outcomes['passed']} "
+            f"failed={outcomes['failed']} skipped={outcomes['skipped']} "
+            f"unknown={outcomes['unknown']} pending={max(0, self.planned - finalized)} "
+            f"synthetic={synthetic}"
+        )
+
+
+@dataclass
+class _ShardExecutor:
+    repo_root: Path
+    junit_dir: Path
+    plan: Plan
+    execution: ExecutionSettings
+    attempt_path: Path
+    attempt: AttemptRecord
+    devices: list[str | None]
+    heartbeat: _LeaseHeartbeat
+    solo_sources: frozenset[str]
+    long_running_sources: frozenset[str]
+    progress: _ShardProgress
+    long_work_by_worker: list[queue.Queue[Unit]] = field(default_factory=list)
+    normal_work_by_worker: list[queue.Queue[Unit]] = field(default_factory=list)
+    solo_units: list[Unit] = field(default_factory=list)
+    non_solo_units: list[Unit] = field(default_factory=list)
+    all_non_solo_units: list[Unit] = field(default_factory=list)
+    infrastructure_errors: list[str] = field(default_factory=list)
+    interruption_reasons: set[str] = field(default_factory=set)
+    errors_lock: threading.Lock = field(default_factory=threading.Lock)
+    stop_workers: threading.Event = field(default_factory=threading.Event)
+
+    def add_units(self, units: list[Unit]) -> None:
+        self.all_non_solo_units = [
+            unit for unit in units if not self._unit_is_solo(unit)
+        ]
+        pending = []
+        for unit in units:
+            timed_out = (self.attempt_path / "timed-out" / f"{unit.id}.json").exists()
+            if not timed_out and any(
+                not batch_is_final(self.junit_dir, unit, batch)
+                for batch in unit.batches
+            ):
+                pending.append(unit)
+        self.solo_units = sorted(
+            (unit for unit in pending if self._unit_is_solo(unit)),
+            key=lambda item: (-item.estimated_ms, item.id.encode("utf-8")),
+        )
+        self.non_solo_units = [unit for unit in pending if not self._unit_is_solo(unit)]
+        self.long_work_by_worker = []
+        self.normal_work_by_worker = []
+        for worker_units in source_affine_unit_bins(
+            self.non_solo_units, self.execution.workers
+        ):
+            long_work: queue.Queue[Unit] = queue.Queue()
+            normal_work: queue.Queue[Unit] = queue.Queue()
+            for unit in sorted(
+                worker_units,
+                key=lambda item: (-item.estimated_ms, item.id.encode("utf-8")),
+            ):
+                target = long_work if self._unit_is_long_running(unit) else normal_work
+                target.put(unit)
+            self.long_work_by_worker.append(long_work)
+            self.normal_work_by_worker.append(normal_work)
+
+    def run(self) -> None:
+        self.progress.start()
+        try:
+            with ThreadPoolExecutor(
+                max_workers=self.execution.workers,
+                thread_name_prefix="test-worker",
+            ) as executor:
+                futures = {
+                    executor.submit(self._worker, index): index
+                    for index in range(self.execution.workers)
+                }
+                for future in as_completed(futures):
+                    index = futures[future]
+                    try:
+                        future.result()
+                    except Exception as error:
+                        self.stop_workers.set()
+                        self._record_infrastructure_error(
+                            f"worker-{index}: {type(error).__name__}: {error}"
+                        )
+            if self.stop_workers.is_set() or not self._non_solo_finalized():
+                return
+            self._run_solo_phase()
+        finally:
+            self.progress.close()
+
+    def _record_infrastructure_error(self, diagnostic: str) -> None:
+        with self.errors_lock:
+            self.infrastructure_errors.append(diagnostic)
+
+    def _worker(self, index: int) -> None:
+        started = time.monotonic()
+        stats: Counter[str] = Counter()
+        device = self.devices[index]
+        write_console(
+            f"WORKER START worker={index} time={_timestamp()} "
+            f"device={device if device is not None else 'unassigned'}"
+        )
+        try:
+            while not self.stop_workers.is_set():
+                try:
+                    try:
+                        work, unit = _next_worker_unit(self.long_work_by_worker, index)
+                    except queue.Empty:
+                        work, unit = _next_worker_unit(
+                            self.normal_work_by_worker, index
+                        )
+                except queue.Empty:
+                    return
+                before = {
+                    batch.id
+                    for batch in unit.batches
+                    if batch_is_final(self.junit_dir, unit, batch)
+                }
+                pending_nodes = sum(
+                    len(batch.nodeids)
+                    for batch in unit.batches
+                    if batch.id not in before
+                )
+                self._report_worker_task(index, unit, pending_nodes, solo=False)
+                try:
+                    self._execute_unit(index, unit, solo=False)
+                    stats.update(self._new_unit_outcomes(unit, before))
+                finally:
+                    work.task_done()
+        finally:
+            self._report_worker_end(index, started, stats, solo=False)
+
+    def _run_solo_phase(self) -> None:
+        if not self.solo_units:
+            return
+        started = time.monotonic()
+        stats: Counter[str] = Counter()
+        write_console(
+            f"WORKER START worker=solo-0 time={_timestamp()} device=all-visible-gpus"
+        )
+        try:
+            for unit in self.solo_units:
+                if self.stop_workers.is_set():
+                    return
+                before = {
+                    batch.id
+                    for batch in unit.batches
+                    if batch_is_final(self.junit_dir, unit, batch)
+                }
+                pending_nodes = sum(
+                    len(batch.nodeids)
+                    for batch in unit.batches
+                    if batch.id not in before
+                )
+                self._report_worker_task("solo-0", unit, pending_nodes, solo=True)
+                self._execute_unit(0, unit, solo=True)
+                stats.update(self._new_unit_outcomes(unit, before))
+        finally:
+            self._report_worker_end("solo-0", started, stats, solo=True)
+
+    def _report_worker_task(
+        self, worker: int | str, unit: Unit, node_count: int, *, solo: bool
+    ) -> None:
+        source = unit.batches[0].source_file if unit.batches else "unknown"
+        first_node = unit.batches[0].nodeids[0] if unit.batches else "unknown"
+        write_console(
+            f"WORKER TASK worker={worker} time={_timestamp()} solo={str(solo).lower()} "
+            f"source={source} unit={unit.id} nodes={node_count} first_node={first_node}"
+        )
+
+    def _report_worker_end(
+        self,
+        worker: int | str,
+        started: float,
+        outcomes: Counter[str],
+        *,
+        solo: bool,
+    ) -> None:
+        handled = sum(outcomes.values())
+        write_console(
+            f"WORKER END worker={worker} time={_timestamp()} solo={str(solo).lower()} "
+            f"elapsed={time.monotonic() - started:.3f}s handled={handled} "
+            f"passed={outcomes['passed']} failed={outcomes['failed']} "
+            f"skipped={outcomes['skipped']} unknown={outcomes['unknown']}"
+        )
+
+    def _new_unit_outcomes(
+        self, unit: Unit, previously_final: set[str]
+    ) -> Counter[str]:
+        outcomes: Counter[str] = Counter()
+        for batch in unit.batches:
+            if batch.id in previously_final or not batch_is_final(
+                self.junit_dir, unit, batch
+            ):
+                continue
+            batch_outcomes, _ = finalized_batch_outcomes(
+                batch_xml_path(self.junit_dir, unit, batch), batch.nodeids
+            )
+            outcomes.update(batch_outcomes)
+        return outcomes
+
+    def _unit_is_solo(self, unit: Unit) -> bool:
+        return any(batch.source_file in self.solo_sources for batch in unit.batches)
+
+    def _unit_is_long_running(self, unit: Unit) -> bool:
+        return any(
+            batch.source_file in self.long_running_sources for batch in unit.batches
+        )
+
+    def _non_solo_finalized(self) -> bool:
+        return all(
+            batch_is_final(self.junit_dir, unit, batch)
+            for unit in self.all_non_solo_units
+            for batch in unit.batches
+        )
+
+    def _execute_unit(self, worker_index: int, unit: Unit, *, solo: bool) -> None:
+        claim_path = claims_dir(self.junit_dir) / f"{unit.id}.json"
+        prior_elapsed = recover_unit_elapsed(
+            self.attempt_path,
+            unit.id,
+            stale_claim_path=claim_path,
+        )
+        self.heartbeat.add(claim_path, f"worker-{worker_index}:{unit.id}")
+        timer = _UnitTimer(prior_elapsed, time.monotonic())
+        write_unit_elapsed(
+            self.attempt_path,
+            unit.id,
+            elapsed_seconds=prior_elapsed,
+            active_started_at=time.time(),
+        )
+        try:
+            completed = self._execute_unit_batches(worker_index, unit, timer, solo=solo)
+            if completed:
+                self._report_unit_complete(worker_index, unit)
+        finally:
+            write_unit_elapsed(
+                self.attempt_path,
+                unit.id,
+                elapsed_seconds=timer.elapsed(),
+                active_started_at=None,
+            )
+            self.heartbeat.remove(claim_path)
+
+    def _execute_unit_batches(
+        self,
+        worker_index: int,
+        unit: Unit,
+        timer: _UnitTimer,
+        *,
+        solo: bool,
+    ) -> bool:
+        for batch_position, batch in enumerate(unit.batches):
+            if batch_is_final(self.junit_dir, unit, batch):
+                continue
+            remaining, timeout_reason = self._remaining_budget(timer)
+            if remaining is not None and remaining <= 0:
+                status = "timeout"
+            else:
+                result = execute_batch(
+                    BatchExecutionRequest(
+                        repo_root=self.repo_root,
+                        junit_dir=self.junit_dir,
+                        unit=unit,
+                        batch=batch,
+                        attempt_id=self.attempt["id"],
+                        profile=self.execution.timing_profile,
+                        timeout_seconds=remaining,
+                        timeout_reason=timeout_reason,
+                        grace_seconds=self.execution.attempt.timeout_grace_seconds,
+                        worker_index=worker_index,
+                        device=None if solo else self.devices[worker_index],
+                        monitor_memory=self.execution.monitor_memory,
+                        memory_interval=self.execution.memory_interval,
+                        pytest_command_prefix=self.execution.pytest_command_prefix,
+                        abort_event=self.heartbeat.failed,
+                    )
+                )
+                self.heartbeat.raise_if_failed()
+                status = result.status
+            if status == "infrastructure":
+                diagnostic = (
+                    f"source={batch.source_file} batch={batch.id} "
+                    f"nodes={len(batch.nodeids)} first_node={batch.nodeids[0]} "
+                    f"cause={result.diagnostic}"
+                )
+                write_console(f"ERROR: {diagnostic}")
+                self._record_infrastructure_error(diagnostic)
+            if status == "finalized":
+                self._record_batch_progress(unit, batch)
+                continue
+            if status == "infrastructure":
+                return False
+            completed = self._handle_timeout(
+                unit,
+                batch_position,
+                timer,
+                timeout_reason or "timeout",
+            )
+            if completed:
+                return True
+            return False
+        return True
+
+    def _record_batch_progress(self, unit: Unit, batch: Any) -> None:
+        path = batch_xml_path(self.junit_dir, unit, batch)
+        outcomes, diagnostics = finalized_batch_outcomes(path, batch.nodeids)
+        if diagnostics:
+            raise RunnerStateError(
+                f"cannot record progress for {batch.source_file} {batch.id}: "
+                + "; ".join(diagnostics)
+            )
+        validation = validate_batch_xml(path, batch.nodeids)
+        self.progress.record(
+            outcomes,
+            synthetic=sum(case.synthetic for case in validation.cases),
+        )
+
+    def _report_unit_complete(self, worker_index: int, unit: Unit) -> None:
+        outcomes: Counter[str] = Counter()
+        for batch in unit.batches:
+            path = batch_xml_path(self.junit_dir, unit, batch)
+            batch_outcomes, diagnostics = finalized_batch_outcomes(path, batch.nodeids)
+            if diagnostics:
+                raise RunnerStateError(
+                    f"completed unit {unit.id} has invalid batch {batch.id}: "
+                    + "; ".join(diagnostics)
+                )
+            outcomes.update(batch_outcomes)
+        completed_nodes = _completed_node_count(self.junit_dir, self.plan)
+        write_console(
+            f"PYTEST UNIT COMPLETE worker={worker_index} unit={unit.id} "
+            f"finalized={sum(outcomes.values())} "
+            f"passed={outcomes['passed']} failed={outcomes['failed']} "
+            f"skipped={outcomes['skipped']} unknown={outcomes['unknown']} "
+            f"completed_nodes={completed_nodes}/{len(self.plan.nodes)}"
+        )
+
+    def _remaining_budget(self, timer: _UnitTimer) -> tuple[float | None, str | None]:
+        limits: list[tuple[float, str]] = []
+        unit_timeout = self.execution.attempt.unit_timeout_seconds
+        if unit_timeout > 0:
+            limits.append((unit_timeout - timer.elapsed(), "unit-timeout"))
+        deadline_at = self.attempt.get("deadline_at")
+        if deadline_at is not None:
+            limits.append((deadline_at - time.time(), "attempt-deadline"))
+        return min(limits, key=lambda value: value[0]) if limits else (None, None)
+
+    def _handle_timeout(
+        self,
+        unit: Unit,
+        batch_position: int,
+        timer: _UnitTimer,
+        reason: str,
+    ) -> bool:
+        with self.errors_lock:
+            self.interruption_reasons.add(reason)
+        timeout = self.execution.attempt.unit_timeout_seconds
+        unit_timeout = timeout > 0 and timer.elapsed() >= timeout
+        deadline_at = self.attempt.get("deadline_at")
+        deadline_timeout = deadline_at is not None and time.time() >= deadline_at
+        if not unit_timeout or deadline_timeout:
+            return False
+        policy = self.execution.attempt.timeout_policy
+        atomic_write_json(
+            self.attempt_path / "timed-out" / f"{unit.id}.json",
+            {
+                "unit_id": unit.id,
+                "timed_out_at": time.time(),
+                "elapsed_seconds": timer.elapsed(),
+                "timeout_policy": policy,
+            },
+        )
+        if policy not in {"skip", "fail"}:
+            return False
+        for pending in unit.batches[batch_position:]:
+            if not batch_is_final(self.junit_dir, unit, pending):
+                _synthesize_batch(
+                    self.junit_dir,
+                    unit,
+                    pending,
+                    SyntheticBatchMetadata(
+                        policy=policy,
+                        batch_id=pending.id,
+                        unit_id=unit.id,
+                        shard_index=unit.shard_index,
+                        attempt_id=self.attempt["id"],
+                        profile=self.execution.timing_profile,
+                    ),
+                )
+                self._record_batch_progress(unit, pending)
+        return True
+
+
+def _claim_shard_leases(
+    junit_dir: Path,
+    attempt_path: Path,
+    attempt: AttemptRecord,
+    execution: ExecutionSettings,
+) -> _LeaseHeartbeat:
+    lease_root = attempt_path / "leases"
+    lease_root.mkdir(parents=True, exist_ok=True)
+    process_lease = lease_root / f"shard-{execution.shard_index:04d}.json"
+    with state_lock(junit_dir):
+        if lease_is_live(process_lease):
+            raise RunnerStateError(
+                f"external shard {execution.shard_index} already has a live owner"
+            )
+        atomic_write_json(
+            process_lease,
+            lease_value(
+                attempt_id=attempt["id"],
+                shard_index=execution.shard_index,
+                worker="coordinator",
+            ),
+        )
+    heartbeat = _LeaseHeartbeat(attempt, execution.shard_index)
+    worker_leases = [
+        lease_root / f"shard-{execution.shard_index:04d}-worker-{index:03d}.json"
+        for index in range(execution.workers)
+    ]
+    try:
+        heartbeat.add(process_lease, "coordinator")
+        for index, path in enumerate(worker_leases):
+            heartbeat.add(path, f"worker-{index}")
+        heartbeat.start()
+    except Exception as error:
+        try:
+            heartbeat.close()
+        except Exception as cleanup_error:
+            raise RunnerStateError(
+                f"cannot claim shard leases: {error}; "
+                f"lease rollback also failed: {cleanup_error}"
+            ) from error
+        raise
+    return heartbeat
+
+
+def _existing_shard_result(
+    *,
+    junit_dir: Path,
+    plan: Plan,
+    execution: ExecutionSettings,
+    attempt_path: Path,
+    deadline_clock: DeadlineClock,
+) -> int | None:
+    shard_done = (
+        attempt_path / "shards" / f"shard-{execution.shard_index:04d}.done.json"
+    )
+    if not shard_done.exists():
+        return None
+    summary = finalize_attempt(
+        junit_dir=junit_dir,
+        plan=plan,
+        attempt_path=attempt_path,
+    )
+    shard_summary = summary["shards"][str(execution.shard_index)]
+    _report_shard_status(
+        summary,
+        execution.shard_index,
+        state="completed" if shard_summary["complete"] else "incomplete",
+        deadline_clock=deadline_clock,
+    )
+    return exit_code_for_shard(summary, execution.shard_index)
+
+
+def _report_shard_result(
+    shard_executor: _ShardExecutor,
+    deadline_clock: DeadlineClock,
+) -> int:
+    junit_dir = shard_executor.junit_dir
+    plan = shard_executor.plan
+    execution = shard_executor.execution
+    attempt_path = shard_executor.attempt_path
+    summary = finalize_attempt(
+        junit_dir=junit_dir,
+        plan=plan,
+        attempt_path=attempt_path,
+    )
+    if shard_executor.infrastructure_errors:
+        for error in shard_executor.infrastructure_errors:
+            print(f"ERROR: {error}")
+        _report_shard_status(
+            summary,
+            execution.shard_index,
+            state="failed",
+            deadline_clock=deadline_clock,
+            reason="infrastructure-error",
+        )
+        return 3
+    shard_summary = summary["shards"][str(execution.shard_index)]
+    if shard_summary["complete"]:
+        state, reason = "completed", None
+    elif shard_executor.interruption_reasons:
+        state = "interrupted"
+        reason = ",".join(sorted(shard_executor.interruption_reasons))
+    else:
+        state, reason = "incomplete", None
+    _report_shard_status(
+        summary,
+        execution.shard_index,
+        state=state,
+        deadline_clock=deadline_clock,
+        reason=reason,
+    )
+    return exit_code_for_shard(summary, execution.shard_index)
+
+
+def execute_shard(
+    *,
+    repo_root: Path,
+    junit_dir: Path,
+    plan: Plan,
+    execution: ExecutionSettings,
+    operation_started_at: float,
+) -> int:
+    if not 0 <= execution.shard_index < plan.options.shard_count:
+        raise RunnerStateError(
+            f"shard index {execution.shard_index} is outside [0, {plan.options.shard_count})"
+        )
+    initial_summary = publish_summary(junit_dir, plan)
+    deadline_clock = DeadlineClock(
+        started_at=operation_started_at,
+        limit_seconds=execution.attempt.deadline_seconds,
+    )
+    if initial_summary["complete"]:
+        attempts = list_attempts(junit_dir)
+        if attempts and not (attempts[-1] / "closed.json").exists():
+            deadline_clock = DeadlineClock.from_attempt(load_attempt(attempts[-1]))
+            initial_summary = finalize_attempt(
+                junit_dir=junit_dir,
+                plan=plan,
+                attempt_path=attempts[-1],
+            )
+        _report_shard_status(
+            initial_summary,
+            execution.shard_index,
+            state="completed",
+            deadline_clock=deadline_clock,
+        )
+        return exit_code_for_shard(initial_summary, execution.shard_index)
+    devices = visible_devices()
+    if execution.workers <= 0:
+        raise RunnerStateError("workers must be positive")
+    if execution.workers > len(devices):
+        raise RunnerStateError(
+            f"requested {execution.workers} workers but only {len(devices)} visible GPU slot(s)"
+        )
+    attempt_path, attempt = create_or_join_attempt(
+        junit_dir, execution.attempt, started_at=operation_started_at
+    )
+    deadline_clock = DeadlineClock.from_attempt(attempt)
+    existing_result = _existing_shard_result(
+        junit_dir=junit_dir,
+        plan=plan,
+        execution=execution,
+        attempt_path=attempt_path,
+        deadline_clock=deadline_clock,
+    )
+    if existing_result is not None:
+        return existing_result
+    lease_heartbeat = _claim_shard_leases(junit_dir, attempt_path, attempt, execution)
+    shard_executor: _ShardExecutor | None = None
+
+    try:
+        atomic_write_json(
+            attempt_path
+            / "shards"
+            / f"shard-{execution.shard_index:04d}.settings.json",
+            {
+                "shard_index": execution.shard_index,
+                "workers": execution.workers,
+                "recorded_at": time.time(),
+            },
+        )
+
+        shard_units = sorted(
+            (unit for unit in plan.units if unit.shard_index == execution.shard_index),
+            key=lambda unit: (-unit.estimated_ms, unit.id.encode("utf-8")),
+        )
+        shard_executor = _ShardExecutor(
+            repo_root=repo_root,
+            junit_dir=junit_dir,
+            plan=plan,
+            execution=execution,
+            attempt_path=attempt_path,
+            attempt=attempt,
+            devices=devices,
+            heartbeat=lease_heartbeat,
+            solo_sources=frozenset(
+                node.source_file for node in plan.nodes if node.solo
+            ),
+            long_running_sources=frozenset(
+                node.source_file for node in plan.nodes if node.long_running
+            ),
+            progress=_ShardProgress(
+                shard_index=execution.shard_index,
+                planned=initial_summary["shards"][str(execution.shard_index)][
+                    "planned_nodes"
+                ],
+                finalized=initial_summary["shards"][str(execution.shard_index)][
+                    "finalized_nodes"
+                ],
+                outcomes=Counter(
+                    initial_summary["shards"][str(execution.shard_index)]["outcomes"]
+                ),
+                synthetic=sum(
+                    int(row["synthetic"])
+                    for row in initial_summary["sources"]
+                    if int(row["shard_index"]) == execution.shard_index
+                ),
+            ),
+        )
+        shard_executor.add_units(shard_units)
+        shard_executor.run()
+    finally:
+        primary_error = sys.exc_info()[1]
+        try:
+            lease_heartbeat.close()
+        except Exception as cleanup_error:
+            if shard_executor is not None:
+                shard_executor._record_infrastructure_error(str(cleanup_error))
+            if primary_error is not None:
+                print(f"ERROR: lease cleanup also failed: {cleanup_error}", flush=True)
+            elif shard_executor is None:
+                raise
+
+    assert shard_executor is not None
+
+    shard_done = (
+        attempt_path / "shards" / f"shard-{execution.shard_index:04d}.done.json"
+    )
+    atomic_write_json(
+        shard_done,
+        {
+            "finished_at": time.time(),
+            "infrastructure_errors": shard_executor.infrastructure_errors,
+        },
+    )
+    return _report_shard_result(
+        shard_executor,
+        deadline_clock,
+    )
+
+
+def finalize_latest(junit_dir: Path, plan: Plan, *, wait: bool = True) -> int:
+    attempts = list_attempts(junit_dir)
+    if not attempts:
+        return exit_code_for_summary(publish_summary(junit_dir, plan))
+    attempt_path = attempts[-1]
+    if wait and not (attempt_path / "closed.json").exists():
+        attempt = load_attempt(attempt_path)
+        grace = int(attempt["settings"]["timeout_grace_seconds"])
+        wait_until = time.time() + grace + 31
+        while _live_attempt_leases(attempt_path) and time.time() < wait_until:
+            time.sleep(1)
+    summary = finalize_attempt(
+        junit_dir=junit_dir,
+        plan=plan,
+        attempt_path=attempt_path,
+        explicit_fan_in=True,
+    )
+    if _live_attempt_leases(attempt_path):
+        raise RunnerStateError("cannot finalize while worker leases are still live")
+    return exit_code_for_summary(summary)

--- a/scripts/test_sharding/runner.py
+++ b/scripts/test_sharding/runner.py
@@ -68,6 +68,18 @@ _LEASE_HEARTBEAT_SECONDS = 10.0
 _LEASE_CLOSE_SECONDS = 2.0
 _CONTROLLER_PROGRESS_SECONDS = 60.0
 
+# The SM90 pull-style and SM100 MegaMoE drops both import vendored modules such
+# as ``common`` as top-level packages, so they cannot be imported by one pytest
+# collection process. Keep the smaller SM90 family isolated for now. Long term,
+# namespace both vendored trees and use package-relative imports; once they can
+# coexist in ``sys.modules``, remove this collection partition.
+_COLLECTION_ISOLATION_GROUPS = (
+    (
+        "sm90-pull-style-cutedsl-megakernel",
+        ("test_moe_ep_sm90_pull_*_mega_multirank.py",),
+    ),
+)
+
 
 def _timestamp() -> str:
     return datetime.now(timezone.utc).astimezone().isoformat(timespec="seconds")
@@ -246,61 +258,165 @@ def _wait_for_collection(
             )
 
 
+def _isolated_collection_groups(test_path: Path) -> list[tuple[str, list[Path]]]:
+    groups = []
+    for name, patterns in _COLLECTION_ISOLATION_GROUPS:
+        matches: set[Path] = set()
+        for pattern in patterns:
+            if test_path.is_file():
+                if test_path.match(pattern):
+                    matches.add(test_path)
+            else:
+                matches.update(
+                    path for path in test_path.rglob(pattern) if path.is_file()
+                )
+        if matches:
+            groups.append(
+                (name, sorted(matches, key=lambda path: str(path).encode("utf-8")))
+            )
+    return groups
+
+
+def _collect_partition(
+    repo_root: Path,
+    test_path: Path,
+    targets: list[Path],
+    ignored_paths: list[Path],
+    timeout_seconds: float | None,
+    grace_seconds: float,
+    directory: Path,
+    partition_index: int,
+    partition_name: str,
+    *,
+    allow_empty: bool,
+) -> list[dict[str, Any]]:
+    output = directory / f"collection-{partition_index:02d}.json"
+    log_path = directory / f"collection-{partition_index:02d}.log"
+    env = os.environ.copy()
+    pythonpath = env.get("PYTHONPATH")
+    env["PYTHONPATH"] = (
+        f"{repo_root}{os.pathsep}{pythonpath}" if pythonpath else str(repo_root)
+    )
+    command = [
+        sys.executable,
+        "-m",
+        "pytest",
+        "--collect-only",
+        "-q",
+        "-q",
+        "--continue-on-collection-errors",
+        "-p",
+        "scripts.test_sharding.pytest_plugin",
+        f"--flashinfer-collection-json={output}",
+        *(f"--ignore={path}" for path in ignored_paths),
+        *(str(path) for path in targets),
+    ]
+    with log_path.open("wb") as log:
+        process = subprocess.Popen(
+            command,
+            cwd=repo_root,
+            env=env,
+            stdout=log,
+            stderr=subprocess.STDOUT,
+            start_new_session=True,
+        )
+        _wait_for_collection(
+            process,
+            test_path=test_path,
+            timeout_seconds=timeout_seconds,
+            grace_seconds=grace_seconds,
+        )
+    if allow_empty and process.returncode == 5:
+        return []
+    if process.returncode != 0 or not output.exists():
+        diagnostic = log_path.read_text(encoding="utf-8", errors="replace")[-20000:]
+        raise RunnerStateError(
+            f"pytest collection failed for {partition_name} "
+            f"with exit code {process.returncode}:\n{diagnostic}"
+        )
+    try:
+        value = json.loads(output.read_text(encoding="utf-8"))
+        nodes = value["nodes"]
+    except (OSError, KeyError, TypeError, json.JSONDecodeError) as error:
+        raise RunnerStateError(
+            f"invalid collection metadata for {partition_name}: {error}"
+        ) from error
+    if not nodes and not allow_empty:
+        raise RunnerStateError(f"pytest collected no tests for {partition_name}")
+    return nodes
+
+
 def _collect_nodes(
     repo_root: Path,
     test_path: Path,
     timeout_seconds: float | None,
     grace_seconds: float,
 ) -> list[dict[str, Any]]:
-    with tempfile.TemporaryDirectory(prefix="flashinfer-test-collection-") as directory:
-        output = Path(directory) / "collection.json"
-        log_path = Path(directory) / "collection.log"
-        env = os.environ.copy()
-        pythonpath = env.get("PYTHONPATH")
-        env["PYTHONPATH"] = (
-            f"{repo_root}{os.pathsep}{pythonpath}" if pythonpath else str(repo_root)
-        )
-        command = [
-            sys.executable,
-            "-m",
-            "pytest",
-            "--collect-only",
-            "-q",
-            "-q",
-            "--continue-on-collection-errors",
-            "-p",
-            "scripts.test_sharding.pytest_plugin",
-            f"--flashinfer-collection-json={output}",
-            str(test_path),
-        ]
-        with log_path.open("wb") as log:
-            process = subprocess.Popen(
-                command,
-                cwd=repo_root,
-                env=env,
-                stdout=log,
-                stderr=subprocess.STDOUT,
-                start_new_session=True,
-            )
-            _wait_for_collection(
-                process,
-                test_path=test_path,
-                timeout_seconds=timeout_seconds,
-                grace_seconds=grace_seconds,
-            )
-        if process.returncode != 0 or not output.exists():
-            diagnostic = log_path.read_text(encoding="utf-8", errors="replace")[-20000:]
-            raise RunnerStateError(
-                f"pytest collection failed with exit code {process.returncode}:\n{diagnostic}"
-            )
-        try:
-            value = json.loads(output.read_text(encoding="utf-8"))
-            nodes = value["nodes"]
-        except (OSError, KeyError, TypeError, json.JSONDecodeError) as error:
-            raise RunnerStateError(f"invalid collection metadata: {error}") from error
-        if not nodes:
-            raise RunnerStateError(f"pytest collected no tests below {test_path}")
-        return nodes
+    started_at = time.monotonic()
+    isolated_groups = _isolated_collection_groups(test_path)
+    isolated_paths = [path for _, paths in isolated_groups for path in paths]
+
+    def remaining_timeout() -> float | None:
+        if timeout_seconds is None:
+            return None
+        return max(0.0, timeout_seconds - (time.monotonic() - started_at))
+
+    try:
+        with tempfile.TemporaryDirectory(
+            prefix="flashinfer-test-collection-"
+        ) as temporary_directory:
+            directory = Path(temporary_directory)
+            partitions = []
+            if test_path not in isolated_paths:
+                partitions.append(
+                    _collect_partition(
+                        repo_root,
+                        test_path,
+                        [test_path],
+                        isolated_paths,
+                        remaining_timeout(),
+                        grace_seconds,
+                        directory,
+                        0,
+                        "primary test scope",
+                        allow_empty=bool(isolated_paths),
+                    )
+                )
+            for partition_index, (name, paths) in enumerate(isolated_groups, start=1):
+                partitions.append(
+                    _collect_partition(
+                        repo_root,
+                        test_path,
+                        paths,
+                        [],
+                        remaining_timeout(),
+                        grace_seconds,
+                        directory,
+                        partition_index,
+                        name,
+                        allow_empty=False,
+                    )
+                )
+    except CollectionTimeoutError as error:
+        error.elapsed_seconds = time.monotonic() - started_at
+        raise
+
+    nodes = []
+    seen_nodeids = set()
+    for partition in partitions:
+        for node in partition:
+            nodeid = node["nodeid"]
+            if nodeid in seen_nodeids:
+                raise RunnerStateError(
+                    f"duplicate pytest node ID across collection partitions: {nodeid}"
+                )
+            seen_nodeids.add(nodeid)
+            merged = dict(node)
+            merged["order"] = len(nodes)
+            nodes.append(merged)
+    if not nodes:
+        raise RunnerStateError(f"pytest collected no tests below {test_path}")
+    return nodes
 
 
 def _validate_selection(selection: SelectionSettings) -> None:

--- a/scripts/test_sharding/scanner.py
+++ b/scripts/test_sharding/scanner.py
@@ -1,0 +1,819 @@
+from __future__ import annotations
+
+import bisect
+import csv
+import hashlib
+import io
+import json
+import re
+import xml.etree.ElementTree as ET
+import zipfile
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Iterable
+
+from .io import atomic_write_json, atomic_write_text
+from .junit import element_properties, test_suites, testcase_outcome
+from .models import (
+    Batch,
+    CollectedNode,
+    Plan,
+    RUNTIME_TIMING_PROFILE,
+    Unit,
+    base_function_for_nodeid,
+    source_file_for_nodeid,
+)
+from .observations import (
+    ObservedCase,
+    ObservedOverhead,
+    adjust_first_case_warmup,
+)
+from .state import manifest_path
+from .summary import batch_xml_path
+
+
+def _run_identity(manifest_path: Path) -> str:
+    return hashlib.sha256(manifest_path.read_bytes()).hexdigest()
+
+
+def _load_run(run_dir: Path) -> tuple[dict[str, Any], Plan, str]:
+    path = manifest_path(run_dir)
+    if not path.exists():
+        raise ValueError(f"no sharding manifest below {run_dir}")
+    manifest = json.loads(path.read_text(encoding="utf-8"))
+    return manifest, Plan.from_dict(manifest["plan"]), _run_identity(path)
+
+
+@dataclass
+class _RunScanContext:
+    profile: str
+    node_metadata: dict[str, CollectedNode]
+    run_id: str
+    seen: set[tuple[str, str, str]]
+    diagnostics: list[str]
+
+
+def _parse_batch_suite(
+    suite: ET.Element,
+    expected_batch: Batch,
+    context: _RunScanContext,
+) -> list[ObservedCase]:
+    found: list[str] = []
+    observations: list[ObservedCase] = []
+    for index, testcase in enumerate(suite.findall("./testcase")):
+        properties = element_properties(testcase)
+        nodeid = properties.get("pytest_nodeid")
+        if nodeid is None:
+            context.diagnostics.append(
+                f"{expected_batch.id}: testcase lacks pytest_nodeid"
+            )
+            continue
+        found.append(nodeid)
+        if nodeid not in context.node_metadata:
+            context.diagnostics.append(f"{expected_batch.id}: unknown node {nodeid}")
+            continue
+        key = (context.run_id, expected_batch.id, nodeid)
+        if key in context.seen:
+            context.diagnostics.append(f"{expected_batch.id}: duplicate node {nodeid}")
+            continue
+        context.seen.add(key)
+        try:
+            seconds = float(testcase.attrib.get("time", "0") or 0)
+        except ValueError:
+            context.diagnostics.append(
+                f"{expected_batch.id}: invalid time for {nodeid}"
+            )
+            continue
+        metadata = context.node_metadata[nodeid]
+        synthetic = properties.get("synthetic") == "true"
+        if synthetic:
+            continue
+        observations.append(
+            ObservedCase(
+                profile=context.profile,
+                nodeid=nodeid,
+                source_file=metadata.source_file,
+                base_function=metadata.base_function,
+                outcome=testcase_outcome(testcase),
+                seconds=seconds,
+                adjusted_seconds=seconds,
+                synthetic=False,
+                run_id=context.run_id,
+                batch_id=expected_batch.id,
+                first_in_batch=index == 0,
+            )
+        )
+    expected = set(expected_batch.nodeids)
+    actual = set(found)
+    if expected != actual:
+        missing = sorted(expected - actual)
+        extra = sorted(actual - expected)
+        context.diagnostics.append(
+            f"{expected_batch.id}: coverage mismatch missing={missing[:5]} extra={extra[:5]}"
+        )
+    return observations
+
+
+def _read_suites(path: Path, diagnostics: list[str]) -> list[ET.Element]:
+    try:
+        root = ET.parse(path).getroot()
+    except (OSError, ET.ParseError) as error:
+        diagnostics.append(f"{path}: malformed XML: {error}")
+        return []
+    suites = test_suites(root)
+    if suites:
+        return suites
+    diagnostics.append(f"{path}: unexpected root {root.tag!r}")
+    return []
+
+
+def _overhead_for_batch(
+    run_dir: Path,
+    run_id: str,
+    plan: Plan,
+    unit: Unit,
+    batch: Batch,
+    profile: str,
+) -> ObservedOverhead | None:
+    xml_path = batch_xml_path(run_dir, unit, batch)
+    telemetry_path = xml_path.with_name(f"{batch.id}.telemetry.json")
+    try:
+        telemetry = json.loads(telemetry_path.read_text(encoding="utf-8"))
+        launch = float(telemetry["process_launch"])
+        collection = float(telemetry["collection_complete"])
+        first_case = float(telemetry.get("first_case_start") or collection)
+        report = float(telemetry.get("report_complete") or telemetry["process_exit"])
+        process_exit = float(telemetry["process_exit"])
+    except (OSError, KeyError, TypeError, ValueError, json.JSONDecodeError):
+        return None
+    startup = max(0.0, collection - launch) + max(0.0, process_exit - report)
+    warmup = max(0.0, first_case - collection)
+    return ObservedOverhead(
+        profile=profile,
+        source_file=batch.source_file,
+        process_startup_seconds=startup,
+        source_warmup_seconds=warmup,
+        run_id=run_id,
+        batch_id=batch.id,
+    )
+
+
+def _scan_run(
+    run_dir: Path,
+    selected_xml: set[Path] | None = None,
+) -> tuple[list[ObservedCase], list[ObservedOverhead], list[str]]:
+    _, plan, run_id = _load_run(run_dir)
+    observations: list[ObservedCase] = []
+    overheads: list[ObservedOverhead] = []
+    diagnostics: list[str] = []
+    seen: set[tuple[str, str, str]] = set()
+    node_metadata = {node.nodeid: node for node in plan.nodes}
+    context = _RunScanContext(
+        profile=RUNTIME_TIMING_PROFILE,
+        node_metadata=node_metadata,
+        run_id=run_id,
+        seen=seen,
+        diagnostics=diagnostics,
+    )
+    for unit in plan.units:
+        for batch in unit.batches:
+            raw = batch_xml_path(run_dir, unit, batch)
+            if not raw.exists() or (
+                selected_xml is not None and raw.resolve() not in selected_xml
+            ):
+                continue
+            suites = _read_suites(raw, diagnostics)
+            batch_profile = RUNTIME_TIMING_PROFILE
+            for suite in suites:
+                batch_profile = (
+                    element_properties(suite).get("timing_profile")
+                    or RUNTIME_TIMING_PROFILE
+                )
+                context.profile = batch_profile
+                observations.extend(
+                    _parse_batch_suite(
+                        suite,
+                        batch,
+                        context,
+                    )
+                )
+            overhead = _overhead_for_batch(
+                run_dir, run_id, plan, unit, batch, batch_profile
+            )
+            if overhead is not None:
+                overheads.append(overhead)
+    adjusted, warmup_excess = adjust_first_case_warmup(observations)
+    overheads = [
+        ObservedOverhead(
+            profile=item.profile,
+            source_file=item.source_file,
+            process_startup_seconds=item.process_startup_seconds,
+            source_warmup_seconds=item.source_warmup_seconds
+            + warmup_excess.get((item.run_id, item.batch_id), 0.0),
+            run_id=item.run_id,
+            batch_id=item.batch_id,
+        )
+        for item in overheads
+    ]
+    adjusted.sort(
+        key=lambda item: (item.profile.encode(), item.nodeid.encode(), item.run_id)
+    )
+    overheads.sort(
+        key=lambda item: (
+            item.profile.encode(),
+            item.source_file.encode(),
+            item.run_id,
+            item.batch_id,
+        )
+    )
+    return adjusted, overheads, diagnostics
+
+
+def _find_run_dir(path: Path) -> Path | None:
+    candidates = [path] if path.is_dir() else [path.parent, *path.parents]
+    for candidate in candidates:
+        if manifest_path(candidate).exists():
+            return candidate
+    return None
+
+
+def _register_observation_input(
+    run_dirs: dict[Path, set[Path] | None],
+    supplied: Path,
+    diagnostics: list[str],
+) -> None:
+    path = supplied.resolve()
+    run_dir = _find_run_dir(path)
+    if run_dir is None:
+        diagnostics.append(f"{path}: no containing sharding manifest")
+    elif path.is_dir():
+        run_dirs[run_dir] = None
+    elif run_dir not in run_dirs or run_dirs[run_dir] is not None:
+        selected = run_dirs.setdefault(run_dir, set())
+        assert selected is not None
+        selected.add(path)
+
+
+def scan_observation_inputs(
+    inputs: Iterable[Path],
+) -> tuple[list[ObservedCase], list[ObservedOverhead], list[str]]:
+    run_dirs: dict[Path, set[Path] | None] = {}
+    diagnostics: list[str] = []
+    for supplied in inputs:
+        _register_observation_input(run_dirs, supplied, diagnostics)
+    observations: list[ObservedCase] = []
+    overheads: list[ObservedOverhead] = []
+    seen_cases: set[tuple[str, str, str]] = set()
+    seen_overheads: set[tuple[str, str]] = set()
+    for run_dir in sorted(run_dirs, key=lambda value: str(value).encode("utf-8")):
+        try:
+            cases, batch_overheads, run_diagnostics = _scan_run(
+                run_dir, run_dirs[run_dir]
+            )
+        except (
+            OSError,
+            ValueError,
+            KeyError,
+            TypeError,
+            json.JSONDecodeError,
+        ) as error:
+            diagnostics.append(f"{run_dir}: {error}")
+            continue
+        for case in cases:
+            case_key = (case.run_id, case.batch_id, case.nodeid)
+            if case_key in seen_cases:
+                diagnostics.append(
+                    f"{run_dir}: duplicate supplied observation {case.batch_id}:{case.nodeid}"
+                )
+            else:
+                seen_cases.add(case_key)
+                observations.append(case)
+        for overhead in batch_overheads:
+            overhead_key = (overhead.run_id, overhead.batch_id)
+            if overhead_key not in seen_overheads:
+                seen_overheads.add(overhead_key)
+                overheads.append(overhead)
+        diagnostics.extend(run_diagnostics)
+    return observations, overheads, diagnostics
+
+
+_PYTEST_RESULT = re.compile(
+    r"PYTEST RESULT worker=\d+ batch=(?P<batch>\S+) "
+    r"outcome=(?P<outcome>\S+) duration=(?P<seconds>[0-9.]+)s "
+    r"node=(?P<nodeid>.+?)\s*$"
+)
+
+
+@dataclass(frozen=True)
+class _ArtifactObservationKey:
+    run_id: str
+    profile: str
+    batch_id: str
+    nodeid: str
+
+
+def _artifact_run_identity(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as source:
+        while chunk := source.read(1024 * 1024):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _artifact_suites(
+    content: bytes,
+    *,
+    label: str,
+    diagnostics: list[str],
+) -> list[ET.Element]:
+    try:
+        root = ET.fromstring(content)
+    except ET.ParseError as error:
+        diagnostics.append(f"{label}: malformed XML: {error}")
+        return []
+    suites = test_suites(root)
+    if suites:
+        return suites
+    diagnostics.append(f"{label}: unexpected root {root.tag!r}")
+    return []
+
+
+def _artifact_case(
+    testcase: ET.Element,
+    key: _ArtifactObservationKey,
+    first_in_batch: bool,
+) -> ObservedCase | None:
+    properties = element_properties(testcase)
+    if properties.get("synthetic") == "true":
+        return None
+    try:
+        seconds = float(testcase.attrib.get("time", "0") or 0)
+    except ValueError:
+        return None
+    return ObservedCase(
+        profile=key.profile,
+        nodeid=key.nodeid,
+        source_file=source_file_for_nodeid(key.nodeid),
+        base_function=base_function_for_nodeid(key.nodeid),
+        outcome=testcase_outcome(testcase),
+        seconds=seconds,
+        adjusted_seconds=seconds,
+        synthetic=False,
+        run_id=key.run_id,
+        batch_id=key.batch_id,
+        first_in_batch=first_in_batch,
+    )
+
+
+@dataclass(frozen=True)
+class _ArtifactIndex:
+    sorted_nodeids: tuple[str, ...]
+    batches: dict[str, Batch]
+
+    @classmethod
+    def from_manifest(cls, path: Path) -> _ArtifactIndex:
+        manifest = json.loads(path.read_text(encoding="utf-8"))
+        plan = Plan.from_dict(manifest["plan"])
+        return cls(
+            sorted_nodeids=tuple(
+                sorted(
+                    (node.nodeid for node in plan.nodes),
+                    key=lambda value: value.encode("utf-8"),
+                )
+            ),
+            batches={batch.id: batch for unit in plan.units for batch in unit.batches},
+        )
+
+
+@dataclass
+class _ArchiveOmissions:
+    ambiguous: int = 0
+    unknown: int = 0
+    invalid: int = 0
+
+
+@dataclass
+class _ArchiveContext:
+    path: Path
+    run_id: str
+    profiles: set[str] = field(default_factory=set)
+    omissions: _ArchiveOmissions = field(default_factory=_ArchiveOmissions)
+
+
+@dataclass
+class _CleanedArtifactScan:
+    index: _ArtifactIndex
+    observations: list[ObservedCase] = field(default_factory=list)
+    diagnostics: list[str] = field(default_factory=list)
+    seen: set[_ArtifactObservationKey] = field(default_factory=set)
+    xml_resolution: dict[_ArtifactObservationKey, str] = field(default_factory=dict)
+    prefix_conflicts: set[_ArtifactObservationKey] = field(default_factory=set)
+    job_metadata: dict[Path, tuple[str, str]] = field(default_factory=dict)
+
+    def scan_archive(self, archive_path: Path) -> None:
+        context = _ArchiveContext(
+            path=archive_path,
+            run_id=_artifact_run_identity(archive_path),
+        )
+        try:
+            archive = zipfile.ZipFile(archive_path)
+        except (OSError, zipfile.BadZipFile) as error:
+            self.diagnostics.append(f"{archive_path}: unreadable ZIP: {error}")
+            return
+        with archive:
+            members = sorted(
+                (name for name in archive.namelist() if name.endswith(".xml")),
+                key=lambda value: value.encode("utf-8"),
+            )
+            for member in members:
+                self._scan_archive_member(
+                    archive,
+                    member,
+                    context,
+                )
+        self._record_archive_metadata(
+            archive_path,
+            context.run_id,
+            context.profiles,
+            context.omissions,
+        )
+
+    def _scan_archive_member(
+        self,
+        archive: zipfile.ZipFile,
+        member: str,
+        context: _ArchiveContext,
+    ) -> None:
+        label = f"{context.path}:{member}"
+        try:
+            content = archive.read(member)
+        except (KeyError, OSError, RuntimeError, zipfile.BadZipFile) as error:
+            self.diagnostics.append(f"{label}: unreadable ZIP member: {error}")
+            return
+        for suite in _artifact_suites(
+            content,
+            label=label,
+            diagnostics=self.diagnostics,
+        ):
+            self._scan_suite(
+                suite,
+                label,
+                context.run_id,
+                context.profiles,
+                context.omissions,
+            )
+
+    def _scan_suite(
+        self,
+        suite: ET.Element,
+        label: str,
+        run_id: str,
+        profiles: set[str],
+        omissions: _ArchiveOmissions,
+    ) -> None:
+        properties = element_properties(suite)
+        profile = properties.get("timing_profile", "")
+        batch_id = properties.get("batch_id", "")
+        if not profile or not batch_id:
+            self.diagnostics.append(f"{label}: suite lacks timing_profile or batch_id")
+            return
+        profiles.add(profile)
+        if properties.get("synthetic") == "true":
+            return
+        testcases = list(suite.findall("./testcase"))
+        exact_nodeids = self._exact_batch_nodeids(batch_id, testcases)
+        for position, testcase in enumerate(testcases):
+            nodeid, resolution = self._resolve_nodeid(
+                testcase,
+                exact_nodeids[position] if exact_nodeids is not None else None,
+            )
+            if nodeid is None:
+                if resolution == "ambiguous":
+                    omissions.ambiguous += 1
+                else:
+                    omissions.unknown += 1
+                continue
+            key = _ArtifactObservationKey(
+                run_id=run_id,
+                profile=profile,
+                batch_id=batch_id,
+                nodeid=nodeid,
+            )
+            observation = _artifact_case(
+                testcase,
+                key,
+                position == 0,
+            )
+            if observation is None:
+                omissions.invalid += 1
+                continue
+            self._add_observation(observation, resolution)
+
+    def _exact_batch_nodeids(
+        self,
+        batch_id: str,
+        testcases: list[ET.Element],
+    ) -> tuple[str, ...] | None:
+        expected = self.index.batches.get(batch_id)
+        if expected is None or len(expected.nodeids) != len(testcases):
+            return None
+        if all(
+            (prefix := element_properties(testcase).get("pytest_nodeid", ""))
+            and nodeid.startswith(prefix)
+            for testcase, nodeid in zip(testcases, expected.nodeids, strict=True)
+        ):
+            return expected.nodeids
+        return None
+
+    def _resolve_nodeid(
+        self,
+        testcase: ET.Element,
+        exact_nodeid: str | None,
+    ) -> tuple[str | None, str]:
+        if exact_nodeid is not None:
+            return exact_nodeid, "batch"
+        prefix = element_properties(testcase).get("pytest_nodeid", "")
+        if not prefix:
+            return None, "unknown"
+        lower = bisect.bisect_left(self.index.sorted_nodeids, prefix)
+        upper = bisect.bisect_left(self.index.sorted_nodeids, prefix + chr(0x10FFFF))
+        testcase_name = testcase.attrib.get("name", "")
+        candidates = [
+            candidate
+            for candidate in self.index.sorted_nodeids[lower:upper]
+            if candidate.rsplit("::", 1)[-1].startswith(testcase_name)
+        ]
+        if len(candidates) == 1:
+            return candidates[0], "prefix"
+        return None, "ambiguous" if candidates else "unknown"
+
+    def _add_observation(
+        self,
+        observation: ObservedCase,
+        resolution: str,
+    ) -> None:
+        key = _ArtifactObservationKey(
+            run_id=observation.run_id,
+            profile=observation.profile,
+            batch_id=observation.batch_id,
+            nodeid=observation.nodeid,
+        )
+        if key not in self.seen:
+            self.seen.add(key)
+            self.xml_resolution[key] = resolution
+            self.observations.append(observation)
+        elif self.xml_resolution.get(key) == "prefix" or resolution == "prefix":
+            self.prefix_conflicts.add(key)
+
+    def _record_archive_metadata(
+        self,
+        archive_path: Path,
+        run_id: str,
+        profiles: set[str],
+        omissions: _ArchiveOmissions,
+    ) -> None:
+        if len(profiles) == 1:
+            self.job_metadata[archive_path.with_suffix("")] = (
+                next(iter(profiles)),
+                run_id,
+            )
+        elif profiles:
+            self.diagnostics.append(
+                f"{archive_path}: inconsistent timing profiles {sorted(profiles)}; "
+                "sibling log omitted"
+            )
+        labels = (
+            (
+                omissions.ambiguous,
+                "ambiguous testcase node IDs after attribute truncation",
+            ),
+            (
+                omissions.unknown,
+                "testcase node IDs absent from the reconstruction manifest",
+            ),
+            (
+                omissions.invalid,
+                "testcases with invalid or synthetic timing data",
+            ),
+        )
+        for count, label in labels:
+            if count:
+                self.diagnostics.append(f"{archive_path}: omitted {count} {label}")
+
+    def remove_prefix_conflicts(self) -> None:
+        by_profile_node: dict[tuple[str, str], list[_ArtifactObservationKey]] = {}
+        for key in self.xml_resolution:
+            by_profile_node.setdefault((key.profile, key.nodeid), []).append(key)
+        for keys in by_profile_node.values():
+            if len({key.batch_id for key in keys}) > 1:
+                batch_verified = {
+                    key for key in keys if self.xml_resolution[key] == "batch"
+                }
+                self.prefix_conflicts.update(set(keys) - batch_verified)
+        if not self.prefix_conflicts:
+            return
+        conflicts = self.prefix_conflicts
+        self.observations = [
+            observation
+            for observation in self.observations
+            if _ArtifactObservationKey(
+                run_id=observation.run_id,
+                profile=observation.profile,
+                batch_id=observation.batch_id,
+                nodeid=observation.nodeid,
+            )
+            not in conflicts
+        ]
+        self.seen.difference_update(conflicts)
+        self.diagnostics.append(
+            "cleaned artifacts: omitted "
+            f"{len(conflicts)} prefix-resolved observations that collided within "
+            "a batch or mapped one node ID into different batches"
+        )
+
+    def scan_log(self, log_path: Path) -> None:
+        metadata = self.job_metadata.get(log_path.with_suffix(""))
+        if metadata is None:
+            self.diagnostics.append(
+                f"{log_path}: no sibling ZIP with one timing profile; log omitted"
+            )
+            return
+        profile, run_id = metadata
+        try:
+            lines = log_path.read_text(encoding="utf-8", errors="replace").splitlines()
+        except OSError as error:
+            self.diagnostics.append(f"{log_path}: unreadable log: {error}")
+            return
+        for line in lines:
+            self._add_log_line(line, profile, run_id)
+
+    def _add_log_line(self, line: str, profile: str, run_id: str) -> None:
+        match = _PYTEST_RESULT.search(line)
+        if match is None:
+            return
+        key = _ArtifactObservationKey(
+            run_id=run_id,
+            profile=profile,
+            batch_id=match.group("batch"),
+            nodeid=match.group("nodeid"),
+        )
+        if key in self.seen:
+            return
+        try:
+            seconds = float(match.group("seconds"))
+        except ValueError:
+            return
+        self.seen.add(key)
+        self.observations.append(
+            ObservedCase(
+                profile=profile,
+                nodeid=key.nodeid,
+                source_file=source_file_for_nodeid(key.nodeid),
+                base_function=base_function_for_nodeid(key.nodeid),
+                outcome=match.group("outcome"),
+                seconds=seconds,
+                adjusted_seconds=seconds,
+                synthetic=False,
+                run_id=run_id,
+                batch_id=key.batch_id,
+                first_in_batch=False,
+            )
+        )
+
+
+def _discover_cleaned_artifacts(
+    artifact_dirs: Iterable[Path],
+) -> tuple[list[Path], list[Path], list[str]]:
+    directories = sorted(
+        {path.resolve() for path in artifact_dirs},
+        key=lambda value: str(value).encode("utf-8"),
+    )
+    zip_paths: list[Path] = []
+    log_paths: list[Path] = []
+    diagnostics: list[str] = []
+    for directory in directories:
+        if not directory.is_dir():
+            diagnostics.append(f"{directory}: cleaned artifact path is not a directory")
+            continue
+        zip_paths.extend(directory.glob("*.zip"))
+        log_paths.extend(directory.glob("*.log"))
+    return (
+        sorted(set(zip_paths), key=lambda value: str(value).encode("utf-8")),
+        sorted(set(log_paths), key=lambda value: str(value).encode("utf-8")),
+        diagnostics,
+    )
+
+
+def scan_cleaned_artifact_dirs(
+    artifact_dirs: Iterable[Path],
+    reconstruction_manifest: Path,
+) -> tuple[list[ObservedCase], list[ObservedOverhead], list[str]]:
+    """Recover observations from GitLab-cleaned ZIPs and sibling job logs.
+
+    The GitLab cleaner truncates XML attributes, including long pytest node
+    IDs. A compatible reconstruction manifest restores exact IDs when the
+    deterministic batch hash and testcase order agree. For batches from a
+    different source revision, only uniquely resolvable combinations of the
+    node-ID and testcase-name prefixes are accepted. Sibling logs supply exact
+    failed/skipped node IDs, including results from batches that never
+    finalized their XML.
+    """
+
+    index = _ArtifactIndex.from_manifest(reconstruction_manifest)
+    zip_paths, log_paths, diagnostics = _discover_cleaned_artifacts(artifact_dirs)
+    scan = _CleanedArtifactScan(index=index, diagnostics=diagnostics)
+    for archive_path in zip_paths:
+        scan.scan_archive(archive_path)
+    scan.remove_prefix_conflicts()
+    for log_path in log_paths:
+        scan.scan_log(log_path)
+    scan.observations.sort(
+        key=lambda item: (
+            item.profile.encode(),
+            item.nodeid.encode(),
+            item.run_id,
+            item.batch_id,
+        )
+    )
+    return scan.observations, [], scan.diagnostics
+
+
+def write_scan_outputs(
+    output_dir: Path,
+    observations: Iterable[ObservedCase],
+    overheads: Iterable[ObservedOverhead],
+    diagnostics: list[str],
+) -> None:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    duration_stream = io.StringIO(newline="")
+    writer = csv.writer(duration_stream, lineterminator="\n")
+    writer.writerow(
+        [
+            "profile",
+            "nodeid",
+            "source_file",
+            "base_function",
+            "outcome",
+            "wall_clock_seconds",
+            "adjusted_seconds",
+            "run_id",
+            "batch_id",
+            "first_in_batch",
+        ]
+    )
+    observation_list = list(observations)
+    for observation in observation_list:
+        writer.writerow(
+            [
+                observation.profile,
+                observation.nodeid,
+                observation.source_file,
+                observation.base_function,
+                observation.outcome,
+                f"{observation.seconds:.6f}",
+                f"{observation.adjusted_seconds:.6f}",
+                observation.run_id,
+                observation.batch_id,
+                str(observation.first_in_batch).lower(),
+            ]
+        )
+    atomic_write_text(
+        output_dir / "observed_test_durations.csv", duration_stream.getvalue()
+    )
+
+    overhead_stream = io.StringIO(newline="")
+    overhead_writer = csv.writer(overhead_stream, lineterminator="\n")
+    overhead_writer.writerow(
+        [
+            "profile",
+            "source_file",
+            "process_startup_seconds",
+            "source_warmup_seconds",
+            "run_id",
+            "batch_id",
+        ]
+    )
+    overhead_list = list(overheads)
+    for overhead in overhead_list:
+        overhead_writer.writerow(
+            [
+                overhead.profile,
+                overhead.source_file,
+                f"{overhead.process_startup_seconds:.6f}",
+                f"{overhead.source_warmup_seconds:.6f}",
+                overhead.run_id,
+                overhead.batch_id,
+            ]
+        )
+    atomic_write_text(
+        output_dir / "observed_batch_overheads.csv", overhead_stream.getvalue()
+    )
+    atomic_write_json(
+        output_dir / "duration_refresh_summary.json",
+        {
+            "schema_version": 1,
+            "observations": len(observation_list),
+            "overhead_observations": len(overhead_list),
+            "diagnostics": diagnostics,
+        },
+    )

--- a/scripts/test_sharding/state.py
+++ b/scripts/test_sharding/state.py
@@ -1,0 +1,438 @@
+from __future__ import annotations
+
+import fcntl
+import hashlib
+import json
+import os
+import socket
+import tempfile
+import time
+from contextlib import contextmanager
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterator, Sequence, TypedDict
+
+from .io import atomic_write_json
+from .models import ALGORITHM_VERSION, SCHEMA_VERSION, CollectedNode, Plan
+
+
+class RunnerStateError(RuntimeError):
+    pass
+
+
+_LOCK_MARKER = "flashinfer-unit-test-runner-lock-v1\n"
+
+
+def _publish_runner_lock(lock_path: Path) -> None:
+    """Publish a complete lock marker without exposing an empty lock file."""
+
+    if os.path.lexists(lock_path):
+        return
+
+    file_descriptor, temporary_name = tempfile.mkstemp(
+        dir=lock_path.parent, prefix=".lock-"
+    )
+    temporary_path = Path(temporary_name)
+    try:
+        with os.fdopen(file_descriptor, "w", encoding="utf-8") as stream:
+            stream.write(_LOCK_MARKER)
+            stream.flush()
+            os.fsync(stream.fileno())
+        try:
+            os.link(temporary_path, lock_path)
+        except FileExistsError:
+            pass
+        except OSError as error:
+            raise RunnerStateError(
+                f"cannot create runner-owned lock path {lock_path}: {error}"
+            ) from error
+    finally:
+        temporary_path.unlink(missing_ok=True)
+
+
+@contextmanager
+def state_lock(junit_dir: Path) -> Iterator[None]:
+    junit_dir.mkdir(parents=True, exist_ok=True)
+    lock_path = junit_dir / "lock"
+    _publish_runner_lock(lock_path)
+    try:
+        stream = lock_path.open("r+")
+    except OSError as error:
+        raise RunnerStateError(
+            f"cannot open runner-owned lock path {lock_path}: {error}"
+        ) from error
+    with stream:
+        fcntl.flock(stream.fileno(), fcntl.LOCK_EX)
+        try:
+            stream.seek(0)
+            marker = stream.read()
+            if marker != _LOCK_MARKER:
+                raise RunnerStateError(
+                    f"runner-owned lock path has foreign content: {lock_path}"
+                )
+            yield
+        finally:
+            fcntl.flock(stream.fileno(), fcntl.LOCK_UN)
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        while chunk := stream.read(1024 * 1024):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _normalize_source_git_sha(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+    normalized = value.strip()
+    return normalized or None
+
+
+def source_git_sha_from_env() -> str | None:
+    """Return the optional CI archive identity used to validate resume."""
+
+    return _normalize_source_git_sha(os.environ.get("SOURCE_GIT_SHA"))
+
+
+def collection_fingerprint(plan_or_nodes: Plan | Sequence[CollectedNode]) -> str:
+    digest = hashlib.sha256()
+    nodes = plan_or_nodes.nodes if isinstance(plan_or_nodes, Plan) else plan_or_nodes
+    for node in nodes:
+        digest.update(
+            json.dumps(node.to_dict(), sort_keys=True, separators=(",", ":")).encode(
+                "utf-8"
+            )
+        )
+        digest.update(b"\0")
+    return digest.hexdigest()
+
+
+def _unit_elapsed_path(attempt_path: Path, unit_id: str) -> Path:
+    return attempt_path / "unit-elapsed" / f"{unit_id}.json"
+
+
+def write_unit_elapsed(
+    attempt_path: Path,
+    unit_id: str,
+    *,
+    elapsed_seconds: float,
+    active_started_at: float | None,
+) -> None:
+    atomic_write_json(
+        _unit_elapsed_path(attempt_path, unit_id),
+        {
+            "active_started_at": active_started_at,
+            "elapsed_seconds": max(0.0, elapsed_seconds),
+        },
+    )
+
+
+def recover_unit_elapsed(
+    attempt_path: Path,
+    unit_id: str,
+    *,
+    stale_claim_path: Path,
+    now: float | None = None,
+) -> float:
+    """Recover an attempt's unit budget, bounded by its last claim lease."""
+
+    path = _unit_elapsed_path(attempt_path, unit_id)
+    if not path.exists():
+        return 0.0
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+        elapsed = float(value.get("elapsed_seconds", 0.0))
+        active_started_at = value.get("active_started_at")
+        active_started_at = (
+            float(active_started_at) if active_started_at is not None else None
+        )
+    except (OSError, TypeError, ValueError, json.JSONDecodeError) as error:
+        raise RunnerStateError(f"invalid unit elapsed state {path}: {error}") from error
+    if active_started_at is not None:
+        current = time.time() if now is None else now
+        try:
+            claim = json.loads(stale_claim_path.read_text(encoding="utf-8"))
+            cutoff = min(current, float(claim["expires_at"]))
+        except (OSError, KeyError, TypeError, ValueError, json.JSONDecodeError):
+            cutoff = active_started_at
+        elapsed += max(0.0, cutoff - active_started_at)
+        write_unit_elapsed(
+            attempt_path,
+            unit_id,
+            elapsed_seconds=elapsed,
+            active_started_at=None,
+        )
+    return elapsed
+
+
+def manifest_path(junit_dir: Path) -> Path:
+    return junit_dir / "manifest.json"
+
+
+def claims_dir(junit_dir: Path) -> Path:
+    return junit_dir / "claims"
+
+
+def units_dir(junit_dir: Path) -> Path:
+    return junit_dir / "units"
+
+
+def load_manifest(junit_dir: Path) -> dict[str, Any] | None:
+    path = manifest_path(junit_dir)
+    if not path.exists():
+        return None
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise RunnerStateError(
+            f"cannot read runner manifest {path}: {error}"
+        ) from error
+
+
+def write_manifest(junit_dir: Path, manifest: dict[str, Any]) -> None:
+    atomic_write_json(manifest_path(junit_dir), manifest)
+
+
+@dataclass(frozen=True)
+class ManifestBuild:
+    repo_root: Path
+    test_path: Path
+    source_git_sha: str | None
+    plan: Plan
+    selection: dict[str, Any]
+    estimate_files: dict[str, str | None]
+    pytest_command_prefix: tuple[str, ...] = ()
+
+
+def build_manifest(request: ManifestBuild) -> dict[str, Any]:
+    repo_root = request.repo_root
+    test_path = request.test_path
+    plan = request.plan
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "algorithm_version": ALGORITHM_VERSION,
+        "created_at": time.time(),
+        "repository_root": str(repo_root.resolve()),
+        "source_git_sha": request.source_git_sha,
+        "collection_fingerprint": collection_fingerprint(plan),
+        "test_path": str(test_path.resolve()),
+        "selection": request.selection,
+        "pytest_command_prefix": list(request.pytest_command_prefix),
+        "estimate_files": request.estimate_files,
+        "plan": plan.to_dict(),
+    }
+
+
+def verify_manifest(
+    manifest: dict[str, Any],
+    *,
+    source_git_sha: str | None,
+    test_path: Path,
+    selection: dict[str, Any],
+    planning_options: dict[str, Any],
+    pytest_command_prefix: tuple[str, ...] = (),
+    estimate_files: dict[str, str | None] | None = None,
+) -> None:
+    mismatches: list[str] = []
+    checks = {
+        "schema_version": (manifest.get("schema_version"), SCHEMA_VERSION),
+        "algorithm_version": (
+            manifest.get("algorithm_version"),
+            ALGORITHM_VERSION,
+        ),
+        "test_path": (manifest.get("test_path"), str(test_path.resolve())),
+        "selection": (manifest.get("selection"), selection),
+        "pytest_command_prefix": (
+            tuple(manifest.get("pytest_command_prefix", ())),
+            pytest_command_prefix,
+        ),
+        "planning_options": (
+            manifest.get("plan", {}).get("options"),
+            planning_options,
+        ),
+    }
+    if estimate_files is not None:
+        checks["estimate_files"] = (manifest.get("estimate_files"), estimate_files)
+    for name, (saved, current) in checks.items():
+        if saved != current:
+            mismatches.append(f"{name}: saved={saved!r}, current={current!r}")
+    saved_source_git_sha = _normalize_source_git_sha(manifest.get("source_git_sha"))
+    current_source_git_sha = _normalize_source_git_sha(source_git_sha)
+    if (
+        saved_source_git_sha is not None
+        and current_source_git_sha is not None
+        and saved_source_git_sha != current_source_git_sha
+    ):
+        mismatches.append(
+            "source_git_sha: "
+            f"saved={saved_source_git_sha!r}, current={current_source_git_sha!r}"
+        )
+    if mismatches:
+        raise RunnerStateError(
+            "existing run is incompatible; use a different --junit-dir:\n  "
+            + "\n  ".join(mismatches)
+        )
+
+
+class AttemptSettingsRecord(TypedDict):
+    deadline_seconds: int
+    unit_timeout_seconds: int
+    timeout_grace_seconds: int
+    timeout_policy: str
+
+
+class AttemptRecord(TypedDict):
+    schema_version: int
+    id: str
+    started_at: float
+    deadline_at: float | None
+    settings: AttemptSettingsRecord
+
+
+@dataclass(frozen=True)
+class AttemptSettings:
+    deadline_seconds: int
+    unit_timeout_seconds: int
+    timeout_grace_seconds: int
+    timeout_policy: str
+
+    def to_dict(self) -> AttemptSettingsRecord:
+        return {
+            "deadline_seconds": self.deadline_seconds,
+            "unit_timeout_seconds": self.unit_timeout_seconds,
+            "timeout_grace_seconds": self.timeout_grace_seconds,
+            "timeout_policy": self.timeout_policy,
+        }
+
+
+def attempts_dir(junit_dir: Path) -> Path:
+    return junit_dir / "attempts"
+
+
+def _attempt_number(path: Path) -> int:
+    try:
+        return int(path.name.split("-", 1)[1])
+    except (IndexError, ValueError):
+        return -1
+
+
+def _attempt_paths(junit_dir: Path, *, require_complete: bool) -> list[Path]:
+    root = attempts_dir(junit_dir)
+    if not root.exists():
+        return []
+    if not root.is_dir():
+        raise RunnerStateError(f"runner-owned attempts path is not a directory: {root}")
+    entries = list(root.iterdir())
+    invalid = {
+        path
+        for path in entries
+        if not path.is_dir()
+        or _attempt_number(path) < 0
+        or path.name != f"attempt-{_attempt_number(path):04d}"
+    }
+    incomplete = [path for path in entries if not (path / "attempt.json").is_file()]
+    if require_complete:
+        invalid.update(incomplete)
+    if invalid:
+        raise RunnerStateError(
+            "runner-owned attempts path contains invalid entries: "
+            + ", ".join(str(path) for path in sorted(invalid)[:5])
+        )
+    return sorted(
+        (path for path in entries if path not in incomplete), key=_attempt_number
+    )
+
+
+def list_attempts(junit_dir: Path) -> list[Path]:
+    return _attempt_paths(junit_dir, require_complete=False)
+
+
+def load_attempt(path: Path) -> AttemptRecord:
+    return json.loads((path / "attempt.json").read_text(encoding="utf-8"))
+
+
+def active_attempt_collection_timeout(
+    junit_dir: Path,
+    requested_timeout: float | None,
+    *,
+    now: float | None = None,
+) -> float | None:
+    """Cap re-collection by the shared deadline of an active attempt."""
+
+    attempts = list_attempts(junit_dir)
+    if not attempts or (attempts[-1] / "closed.json").exists():
+        return requested_timeout
+    attempt = load_attempt(attempts[-1])
+    deadline_at = attempt.get("deadline_at")
+    if deadline_at is None:
+        return requested_timeout
+    remaining = max(0.001, float(deadline_at) - (time.time() if now is None else now))
+    return remaining if requested_timeout is None else min(requested_timeout, remaining)
+
+
+def create_or_join_attempt(
+    junit_dir: Path,
+    settings: AttemptSettings,
+    *,
+    started_at: float,
+) -> tuple[Path, AttemptRecord]:
+    with state_lock(junit_dir):
+        attempts_root_exists = attempts_dir(junit_dir).exists()
+        attempts = _attempt_paths(junit_dir, require_complete=True)
+        if attempts_root_exists and not attempts:
+            raise RunnerStateError(
+                "runner-owned attempts path is empty: " + str(attempts_dir(junit_dir))
+            )
+        if attempts and not (attempts[-1] / "closed.json").exists():
+            path = attempts[-1]
+            active_attempt = load_attempt(path)
+            saved_settings = active_attempt["settings"]
+            if saved_settings != settings.to_dict():
+                raise RunnerStateError(
+                    "active attempt settings differ: "
+                    f"saved={saved_settings!r}, current={settings.to_dict()!r}"
+                )
+            return path, active_attempt
+        number = _attempt_number(attempts[-1]) + 1 if attempts else 1
+        attempt_id = f"attempt-{number:04d}"
+        path = attempts_dir(junit_dir) / attempt_id
+        path.mkdir(parents=True, exist_ok=False)
+        deadline_at = (
+            started_at + settings.deadline_seconds
+            if settings.deadline_seconds > 0
+            else None
+        )
+        new_attempt: AttemptRecord = {
+            "schema_version": SCHEMA_VERSION,
+            "id": attempt_id,
+            "started_at": started_at,
+            "deadline_at": deadline_at,
+            "settings": settings.to_dict(),
+        }
+        atomic_write_json(path / "attempt.json", new_attempt)
+        return path, new_attempt
+
+
+def lease_is_live(path: Path, now: float | None = None) -> bool:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+        return float(value["expires_at"]) > (time.time() if now is None else now)
+    except (OSError, KeyError, TypeError, ValueError, json.JSONDecodeError):
+        return False
+
+
+def lease_value(
+    *, attempt_id: str, shard_index: int, worker: str, ttl_seconds: int = 30
+) -> dict[str, Any]:
+    now = time.time()
+    return {
+        "attempt_id": attempt_id,
+        "shard_index": shard_index,
+        "worker": worker,
+        "host": socket.gethostname(),
+        "pid": os.getpid(),
+        "renewed_at": now,
+        "expires_at": now + ttl_seconds,
+    }

--- a/scripts/test_sharding/summary.py
+++ b/scripts/test_sharding/summary.py
@@ -1,0 +1,850 @@
+from __future__ import annotations
+
+import csv
+import io
+import json
+from collections import Counter, defaultdict
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, TypedDict, cast
+
+from .io import atomic_write_json, atomic_write_text
+from .junit import validate_batch_xml
+from .models import Batch, Plan, Unit
+from .planner import CapacityMetrics, capacity_metrics
+from .state import AttemptRecord, list_attempts, load_attempt, state_lock
+
+
+TIMING_HEADER = [
+    "nodeid",
+    "source_file",
+    "base_function",
+    "outcome",
+    "setup_seconds",
+    "call_seconds",
+    "teardown_seconds",
+    "wall_clock_seconds",
+    "synthetic",
+    "batch_id",
+    "unit_id",
+    "shard_index",
+    "attempt_id",
+]
+_TERMINAL_SEPARATOR = "=" * 42
+
+
+class AttemptSummary(AttemptRecord, total=False):
+    unit_timeout_events: list[dict[str, Any]]
+    closed: bool
+    closure: dict[str, Any]
+
+
+class ShardSummary(TypedDict):
+    complete: bool
+    planned_nodes: int
+    finalized_nodes: int
+    pending_nodes: int
+    outcomes: dict[str, int]
+
+
+class FallbackSummary(TypedDict):
+    source: str
+    node_indexes: list[int]
+
+
+class FailedNodeSummary(TypedDict):
+    shard_index: int
+    source_file: str
+    nodeid: str
+    diagnostic: str
+    batch_id: str
+    unit_id: str
+    log_path: str
+    results_path: str
+    junit_path: str
+    synthetic: bool
+
+
+class SourceSummary(TypedDict):
+    shard_index: int
+    source_file: str
+    planned_nodes: int
+    finalized_nodes: int
+    pending_nodes: int
+    passed: int
+    failed: int
+    skipped: int
+    unknown: int
+    synthetic: int
+    process_seconds: float
+    max_host_rss_mib: float
+    max_gpu_memory_mib: float
+    memory_samples: int
+    partial_resources: bool
+    status: str
+
+
+class RunSummary(TypedDict):
+    schema_version: int
+    complete: bool
+    planned_nodes: int
+    finalized_nodes: int
+    pending_nodes: list[str]
+    outcomes: dict[str, int]
+    shards: dict[str, ShardSummary]
+    synthetic: int
+    fallback_counts: dict[str, int]
+    fallback_node_table: str
+    fallbacks: list[FallbackSummary]
+    oversized_batches: int
+    oversized_units: int
+    estimated_shard_load_ms: dict[str, int]
+    estimated_makespan_ms: int
+    estimated_total_overhead_ms: int
+    capacity: CapacityMetrics
+    attempts: list[AttemptSummary]
+    infrastructure_errors: list[str]
+    shard_infrastructure_errors: dict[str, list[str]]
+    failed_nodes: list[FailedNodeSummary]
+    sources: list[SourceSummary]
+
+
+def batch_directory(junit_dir: Path, unit: Unit) -> Path:
+    return (
+        junit_dir
+        / "shards"
+        / f"shard-{unit.shard_index:04d}"
+        / "units"
+        / unit.id
+        / "batches"
+    )
+
+
+def batch_xml_path(junit_dir: Path, unit: Unit, batch: Batch) -> Path:
+    return batch_directory(junit_dir, unit) / f"{batch.id}.xml"
+
+
+def batch_is_final(junit_dir: Path, unit: Unit, batch: Batch) -> bool:
+    path = batch_xml_path(junit_dir, unit, batch)
+    return path.exists() and validate_batch_xml(path, batch.nodeids).valid
+
+
+def _sidecar(path: Path, suffix: str) -> Path:
+    return path.with_name(path.stem + suffix)
+
+
+def _attempt_for_batch(path: Path) -> str:
+    try:
+        value = json.loads(_sidecar(path, ".meta.json").read_text(encoding="utf-8"))
+        return str(value.get("attempt_id", ""))
+    except (OSError, json.JSONDecodeError):
+        return ""
+
+
+def _phase_results(path: Path) -> dict[str, dict[str, Any]]:
+    try:
+        value = json.loads(_sidecar(path, ".results.json").read_text(encoding="utf-8"))
+        return {item["nodeid"]: item for item in value.get("results", [])}
+    except (OSError, KeyError, TypeError, json.JSONDecodeError):
+        return {}
+
+
+def _memory_samples(path: Path) -> list[dict[str, float]]:
+    sample_path = _sidecar(path, ".memory.csv")
+    if not sample_path.exists():
+        return []
+    samples: list[dict[str, float]] = []
+    try:
+        with sample_path.open(newline="", encoding="utf-8") as stream:
+            for row in csv.DictReader(stream):
+                samples.append(
+                    {
+                        "timestamp": float(row["timestamp"]),
+                        "host_rss_mib": float(row["host_rss_mib"]),
+                        "gpu_memory_mib": float(row["gpu_memory_mib"]),
+                    }
+                )
+    except (OSError, KeyError, TypeError, ValueError):
+        return []
+    return samples
+
+
+def _json_sidecar(path: Path, suffix: str) -> dict[str, Any]:
+    try:
+        value = json.loads(_sidecar(path, suffix).read_text(encoding="utf-8"))
+        return value if isinstance(value, dict) else {}
+    except (OSError, json.JSONDecodeError):
+        return {}
+
+
+def _max_memory(samples: list[dict[str, float]]) -> tuple[float, float]:
+    if not samples:
+        return 0.0, 0.0
+    return (
+        max(sample["host_rss_mib"] for sample in samples),
+        max(sample["gpu_memory_mib"] for sample in samples),
+    )
+
+
+@dataclass
+class _SummaryScan:
+    rows: list[dict[str, Any]] = field(default_factory=list)
+    outcomes: Counter[str] = field(default_factory=Counter)
+    shard_outcomes: dict[int, Counter[str]] = field(default_factory=dict)
+    shard_planned: Counter[int] = field(default_factory=Counter)
+    shard_pending: Counter[int] = field(default_factory=Counter)
+    shard_finalized: Counter[int] = field(default_factory=Counter)
+    pending: list[str] = field(default_factory=list)
+    synthetic_count: int = 0
+    batch_memory: dict[str, tuple[float, float]] = field(default_factory=dict)
+    node_memory: dict[str, tuple[float, float]] = field(default_factory=dict)
+    unit_memory: dict[str, list[tuple[float, float]]] = field(
+        default_factory=lambda: defaultdict(list)
+    )
+    shard_memory: dict[int, list[tuple[float, float]]] = field(
+        default_factory=lambda: defaultdict(list)
+    )
+
+    @classmethod
+    def for_plan(cls, plan: Plan) -> _SummaryScan:
+        return cls(
+            shard_outcomes={
+                index: Counter() for index in range(plan.options.shard_count)
+            }
+        )
+
+
+def _record_pending(scan: _SummaryScan, unit: Unit, batch: Batch) -> None:
+    scan.pending.extend(batch.nodeids)
+    scan.shard_pending[unit.shard_index] += len(batch.nodeids)
+
+
+def _case_memory(
+    samples: list[dict[str, float]], phase: dict[str, Any]
+) -> tuple[float, float]:
+    started_at = phase.get("started_at")
+    finished_at = phase.get("finished_at")
+    if started_at is None or finished_at is None:
+        return 0.0, 0.0
+    return _max_memory(
+        [
+            sample
+            for sample in samples
+            if float(started_at) <= sample["timestamp"] <= float(finished_at)
+        ]
+    )
+
+
+def _record_final_batch(
+    scan: _SummaryScan,
+    *,
+    unit: Unit,
+    batch: Batch,
+    path: Path,
+) -> None:
+    validation = validate_batch_xml(path, batch.nodeids)
+    if not validation.valid:
+        _record_pending(scan, unit, batch)
+        return
+    attempt_id = _attempt_for_batch(path)
+    phases = _phase_results(path)
+    samples = _memory_samples(path)
+    memory = _max_memory(samples)
+    scan.batch_memory[batch.id] = memory
+    scan.unit_memory[unit.id].append(memory)
+    scan.shard_memory[unit.shard_index].append(memory)
+    for case in validation.cases:
+        phase = phases.get(case.nodeid, {})
+        scan.node_memory[case.nodeid] = _case_memory(samples, phase)
+        scan.outcomes[case.outcome] += 1
+        scan.shard_outcomes[unit.shard_index][case.outcome] += 1
+        scan.shard_finalized[unit.shard_index] += 1
+        scan.synthetic_count += int(case.synthetic)
+        scan.rows.append(
+            {
+                "nodeid": case.nodeid,
+                "source_file": case.source_file,
+                "base_function": case.base_function,
+                "outcome": case.outcome,
+                "setup_seconds": phase.get("setup", 0.0),
+                "call_seconds": phase.get("call", case.seconds),
+                "teardown_seconds": phase.get("teardown", 0.0),
+                "wall_clock_seconds": case.seconds,
+                "synthetic": str(case.synthetic).lower(),
+                "batch_id": batch.id,
+                "unit_id": unit.id,
+                "shard_index": unit.shard_index,
+                "attempt_id": attempt_id,
+            }
+        )
+
+
+def _scan_batches(junit_dir: Path, plan: Plan) -> _SummaryScan:
+    scan = _SummaryScan.for_plan(plan)
+
+    for unit in plan.units:
+        for batch in unit.batches:
+            scan.shard_planned[unit.shard_index] += len(batch.nodeids)
+            path = batch_xml_path(junit_dir, unit, batch)
+            if not path.exists():
+                _record_pending(scan, unit, batch)
+                continue
+            _record_final_batch(scan, unit=unit, batch=batch, path=path)
+    scan.rows.sort(key=lambda row: row["nodeid"].encode("utf-8"))
+    for outcome in ("passed", "failed", "skipped"):
+        scan.outcomes.setdefault(outcome, 0)
+        for shard in scan.shard_outcomes.values():
+            shard.setdefault(outcome, 0)
+    return scan
+
+
+def _write_timing_csv(junit_dir: Path, rows: list[dict[str, Any]]) -> None:
+    timing_stream = io.StringIO(newline="")
+    writer = csv.DictWriter(
+        timing_stream, fieldnames=TIMING_HEADER, lineterminator="\n"
+    )
+    writer.writeheader()
+    writer.writerows(rows)
+    atomic_write_text(junit_dir / "test_timings.csv", timing_stream.getvalue())
+
+
+def _write_memory_csv(junit_dir: Path, scan: _SummaryScan) -> None:
+    memory_stream = io.StringIO(newline="")
+    memory_writer = csv.writer(memory_stream, lineterminator="\n")
+    memory_writer.writerow(["level", "id", "max_host_rss_mib", "max_gpu_memory_mib"])
+    for nodeid, memory in sorted(scan.node_memory.items()):
+        memory_writer.writerow(["node", nodeid, f"{memory[0]:.3f}", f"{memory[1]:.3f}"])
+    for batch_id, memory in sorted(scan.batch_memory.items()):
+        memory_writer.writerow(
+            ["batch", batch_id, f"{memory[0]:.3f}", f"{memory[1]:.3f}"]
+        )
+    for unit_id, memories in sorted(scan.unit_memory.items()):
+        memory_writer.writerow(
+            [
+                "unit",
+                unit_id,
+                f"{max(value[0] for value in memories):.3f}",
+                f"{max(value[1] for value in memories):.3f}",
+            ]
+        )
+    for shard_index, memories in sorted(scan.shard_memory.items()):
+        memory_writer.writerow(
+            [
+                "shard",
+                shard_index,
+                f"{max(value[0] for value in memories):.3f}",
+                f"{max(value[1] for value in memories):.3f}",
+            ]
+        )
+    atomic_write_text(junit_dir / "memory_summary.csv", memory_stream.getvalue())
+
+
+SOURCE_HEADER = [
+    "shard_index",
+    "source_file",
+    "status",
+    "planned_nodes",
+    "finalized_nodes",
+    "pending_nodes",
+    "passed",
+    "failed",
+    "skipped",
+    "unknown",
+    "synthetic",
+    "process_seconds",
+    "max_host_rss_mib",
+    "max_gpu_memory_mib",
+    "memory_samples",
+    "partial_resources",
+]
+
+
+def _source_status(row: SourceSummary) -> str:
+    if row["failed"]:
+        return "failed"
+    if row["finalized_nodes"] == 0:
+        return "no result"
+    if row["pending_nodes"]:
+        return "incomplete"
+    if row["unknown"]:
+        return "unknown"
+    return "passed"
+
+
+def _source_and_failure_summaries(
+    junit_dir: Path, plan: Plan
+) -> tuple[list[SourceSummary], list[FailedNodeSummary]]:
+    by_source: dict[tuple[int, str], SourceSummary] = {}
+    failed_nodes: list[FailedNodeSummary] = []
+    for unit in plan.units:
+        for batch in unit.batches:
+            key = (unit.shard_index, batch.source_file)
+            row = by_source.setdefault(
+                key,
+                {
+                    "shard_index": unit.shard_index,
+                    "source_file": batch.source_file,
+                    "planned_nodes": 0,
+                    "finalized_nodes": 0,
+                    "pending_nodes": 0,
+                    "passed": 0,
+                    "failed": 0,
+                    "skipped": 0,
+                    "unknown": 0,
+                    "synthetic": 0,
+                    "process_seconds": 0.0,
+                    "max_host_rss_mib": 0.0,
+                    "max_gpu_memory_mib": 0.0,
+                    "memory_samples": 0,
+                    "partial_resources": False,
+                    "status": "",
+                },
+            )
+            row["planned_nodes"] += len(batch.nodeids)
+            path = batch_xml_path(junit_dir, unit, batch)
+            validation = (
+                validate_batch_xml(path, batch.nodeids) if path.exists() else None
+            )
+            if validation is None or not validation.valid:
+                row["pending_nodes"] += len(batch.nodeids)
+                row["partial_resources"] = True
+                continue
+            phases = _phase_results(path)
+            meta = _json_sidecar(path, ".meta.json")
+            telemetry = _json_sidecar(path, ".telemetry.json")
+            samples = _memory_samples(path)
+            memory = _max_memory(samples)
+            row["max_host_rss_mib"] = max(row["max_host_rss_mib"], memory[0])
+            row["max_gpu_memory_mib"] = max(row["max_gpu_memory_mib"], memory[1])
+            row["memory_samples"] += len(samples)
+            launched = telemetry.get("process_launch", meta.get("launched_at"))
+            exited = telemetry.get("process_exit", meta.get("exited_at"))
+            try:
+                row["process_seconds"] += max(0.0, float(exited) - float(launched))
+            except (TypeError, ValueError):
+                if not bool(meta.get("synthetic", False)):
+                    row["partial_resources"] = True
+            if not bool(meta.get("synthetic", False)) and (
+                not bool(meta.get("monitor_memory", True)) or not samples
+            ):
+                row["partial_resources"] = True
+            for case in validation.cases:
+                phase = phases.get(case.nodeid, {})
+                outcome = str(phase.get("outcome", case.outcome))
+                if outcome not in {"passed", "failed", "skipped", "unknown"}:
+                    outcome = "unknown"
+                row["finalized_nodes"] += 1
+                cast(dict[str, Any], row)[outcome] += 1
+                row["synthetic"] += int(case.synthetic)
+                if outcome == "failed":
+                    failed_nodes.append(
+                        {
+                            "shard_index": unit.shard_index,
+                            "source_file": batch.source_file,
+                            "nodeid": case.nodeid,
+                            "diagnostic": str(
+                                phase.get("longrepr")
+                                or case.diagnostic
+                                or "pytest failure"
+                            ),
+                            "batch_id": batch.id,
+                            "unit_id": unit.id,
+                            "log_path": str(_sidecar(path, ".log")),
+                            "results_path": str(_sidecar(path, ".results.json")),
+                            "junit_path": str(path),
+                            "synthetic": case.synthetic,
+                        }
+                    )
+    rows: list[SourceSummary] = []
+    for key in sorted(by_source, key=lambda item: (item[0], item[1].encode("utf-8"))):
+        row = by_source[key]
+        row["status"] = _source_status(row)
+        row["process_seconds"] = round(float(row["process_seconds"]), 6)
+        row["max_host_rss_mib"] = round(float(row["max_host_rss_mib"]), 3)
+        row["max_gpu_memory_mib"] = round(float(row["max_gpu_memory_mib"]), 3)
+        rows.append(row)
+    failed_nodes.sort(
+        key=lambda item: (item["shard_index"], item["nodeid"].encode("utf-8"))
+    )
+    return rows, failed_nodes
+
+
+def _write_source_csv(junit_dir: Path, rows: list[SourceSummary]) -> None:
+    stream = io.StringIO(newline="")
+    writer = csv.DictWriter(stream, fieldnames=SOURCE_HEADER, lineterminator="\n")
+    writer.writeheader()
+    writer.writerows(
+        {name: cast(dict[str, Any], row)[name] for name in SOURCE_HEADER}
+        for row in rows
+    )
+    atomic_write_text(junit_dir / "source_summary.csv", stream.getvalue())
+
+
+def _attempt_history(junit_dir: Path) -> tuple[list[AttemptSummary], list[Path]]:
+    attempts: list[AttemptSummary] = []
+    attempt_paths = list_attempts(junit_dir)
+    for path in attempt_paths:
+        attempt = cast(AttemptSummary, load_attempt(path))
+        timeout_events = []
+        for event_path in sorted((path / "timed-out").glob("*.json")):
+            try:
+                timeout_events.append(
+                    json.loads(event_path.read_text(encoding="utf-8"))
+                )
+            except (OSError, json.JSONDecodeError):
+                timeout_events.append({"path": str(event_path), "malformed": True})
+        attempt["unit_timeout_events"] = timeout_events
+        closed_path = path / "closed.json"
+        attempt["closed"] = closed_path.exists()
+        if closed_path.exists():
+            try:
+                attempt["closure"] = json.loads(closed_path.read_text(encoding="utf-8"))
+            except (OSError, json.JSONDecodeError):
+                attempt["closure"] = {"malformed": True}
+        attempts.append(attempt)
+    return attempts, attempt_paths
+
+
+def _capacity_for_latest_attempt(
+    plan: Plan, attempt_paths: list[Path]
+) -> CapacityMetrics:
+    workers_by_shard: dict[int, int] = {}
+    deadline_seconds = 0
+    if attempt_paths:
+        latest_path = attempt_paths[-1]
+        latest_attempt = load_attempt(latest_path)
+        deadline_seconds = int(latest_attempt["settings"]["deadline_seconds"])
+        for settings_path in (latest_path / "shards").glob("shard-*.settings.json"):
+            try:
+                settings = json.loads(settings_path.read_text(encoding="utf-8"))
+                workers_by_shard[int(settings["shard_index"])] = int(
+                    settings["workers"]
+                )
+            except (OSError, KeyError, TypeError, ValueError, json.JSONDecodeError):
+                continue
+    return capacity_metrics(
+        plan,
+        workers_by_shard,
+        deadline_seconds=deadline_seconds,
+    )
+
+
+def _latest_shard_infrastructure_errors(
+    attempt_paths: list[Path], shard_count: int
+) -> dict[str, list[str]]:
+    errors_by_shard: dict[str, list[str]] = {
+        str(index): [] for index in range(shard_count)
+    }
+    if not attempt_paths:
+        return errors_by_shard
+    for marker in sorted((attempt_paths[-1] / "shards").glob("shard-*.done.json")):
+        try:
+            shard_index = int(marker.name.removeprefix("shard-").split(".", 1)[0])
+        except ValueError:
+            continue
+        key = str(shard_index)
+        if key not in errors_by_shard:
+            continue
+        try:
+            value = json.loads(marker.read_text(encoding="utf-8"))
+            marker_errors = value.get("infrastructure_errors", [])
+            if not isinstance(marker_errors, list):
+                raise TypeError("infrastructure_errors is not a list")
+            errors_by_shard[key].extend(str(error) for error in marker_errors)
+        except (OSError, AttributeError, TypeError, json.JSONDecodeError) as error:
+            errors_by_shard[key].append(
+                f"invalid shard completion marker {marker}: {error}"
+            )
+    return errors_by_shard
+
+
+def publish_summary_under_lock(junit_dir: Path, plan: Plan) -> RunSummary:
+    """Publish derived artifacts while the caller owns ``state_lock(junit_dir)``."""
+
+    scan = _scan_batches(junit_dir, plan)
+    _write_timing_csv(junit_dir, scan.rows)
+    _write_memory_csv(junit_dir, scan)
+    sources, failed_nodes = _source_and_failure_summaries(junit_dir, plan)
+    _write_source_csv(junit_dir, sources)
+    attempts, attempt_paths = _attempt_history(junit_dir)
+    shard_infrastructure_errors = _latest_shard_infrastructure_errors(
+        attempt_paths, plan.options.shard_count
+    )
+    capacity = _capacity_for_latest_attempt(plan, attempt_paths)
+    summary: RunSummary = {
+        "schema_version": 3,
+        "complete": not scan.pending,
+        "planned_nodes": len(plan.nodes),
+        "finalized_nodes": len(scan.rows),
+        "pending_nodes": sorted(scan.pending, key=lambda value: value.encode("utf-8")),
+        "outcomes": dict(sorted(scan.outcomes.items())),
+        "shards": {
+            str(index): {
+                "complete": scan.shard_pending[index] == 0,
+                "planned_nodes": scan.shard_planned[index],
+                "finalized_nodes": scan.shard_finalized[index],
+                "pending_nodes": scan.shard_pending[index],
+                "outcomes": dict(sorted(scan.shard_outcomes[index].items())),
+            }
+            for index in range(plan.options.shard_count)
+        },
+        "synthetic": scan.synthetic_count,
+        "fallback_counts": dict(sorted(plan.fallback_counts.items())),
+        "fallback_node_table": "manifest.json#/plan/nodeids",
+        "fallbacks": [
+            {"source": source, "node_indexes": indexes}
+            for source, indexes in plan.fallback_index_groups().items()
+        ],
+        "oversized_batches": sum(
+            batch.oversized for unit in plan.units for batch in unit.batches
+        ),
+        "oversized_units": sum(unit.oversized for unit in plan.units),
+        "estimated_shard_load_ms": capacity["estimated_shard_load_ms"],
+        "estimated_makespan_ms": capacity["estimated_makespan_ms"],
+        "estimated_total_overhead_ms": capacity["total_estimated_overhead_ms"],
+        "capacity": capacity,
+        "attempts": attempts,
+        "infrastructure_errors": [
+            f"shard-{index}: {error}"
+            for index, errors in shard_infrastructure_errors.items()
+            for error in errors
+        ],
+        "shard_infrastructure_errors": shard_infrastructure_errors,
+        "failed_nodes": failed_nodes,
+        "sources": sources,
+    }
+    atomic_write_json(junit_dir / "run-summary.json", summary)
+    return summary
+
+
+def publish_summary(junit_dir: Path, plan: Plan) -> RunSummary:
+    """Regenerate all derived artifacts from one serialized batch snapshot."""
+
+    with state_lock(junit_dir):
+        return publish_summary_under_lock(junit_dir, plan)
+
+
+def exit_code_for_summary(summary: RunSummary) -> int:
+    if summary["infrastructure_errors"]:
+        return 3
+    if summary["outcomes"].get("failed", 0):
+        return 1
+    return 2 if not summary["complete"] else 0
+
+
+def exit_code_for_shard(summary: RunSummary, shard_index: int) -> int:
+    if summary["shard_infrastructure_errors"].get(str(shard_index), []):
+        return 3
+    shard = summary["shards"][str(shard_index)]
+    if shard["outcomes"].get("failed", 0):
+        return 1
+    return 2 if not shard["complete"] else 0
+
+
+def _format_duration(seconds: float) -> str:
+    total = max(0, round(seconds))
+    hours, remainder = divmod(total, 3600)
+    minutes, secs = divmod(remainder, 60)
+    if hours:
+        return f"{hours}h{minutes:02d}m{secs:02d}s"
+    if minutes:
+        return f"{minutes}m{secs:02d}s"
+    return f"{seconds:.1f}s"
+
+
+def _format_timestamp(timestamp: float) -> str:
+    return (
+        datetime.fromtimestamp(timestamp, tz=timezone.utc)
+        .isoformat(timespec="seconds")
+        .replace("+00:00", "Z")
+    )
+
+
+def _format_test_elapsed(seconds: float) -> str:
+    total = max(0, int(seconds))
+    hours, remainder = divmod(total, 3600)
+    minutes, secs = divmod(remainder, 60)
+    if hours:
+        return f"{hours}h{minutes:02d}m{secs:02d}s"
+    if minutes:
+        return f"{minutes}m{secs:02d}s"
+    return f"{secs}s"
+
+
+def _format_memory(mib: float) -> str:
+    return f"{mib / 1024:.1f} GiB" if mib >= 1024 else f"{mib:.0f} MiB"
+
+
+def _top_source_lines(
+    rows: list[SourceSummary], field: str, *, limit: int = 10
+) -> list[str]:
+    ordered = sorted(
+        rows,
+        key=lambda row: (
+            -float(cast(dict[str, Any], row)[field]),
+            row["source_file"].encode("utf-8"),
+        ),
+    )[:limit]
+    lines = []
+    for index, row in enumerate(ordered, 1):
+        partial = " (partial)" if row["partial_resources"] else ""
+        lines.append(
+            f"  {index:2d}. {row['source_file']} - "
+            f"duration {_format_duration(float(row['process_seconds']))}, "
+            f"peak RSS {_format_memory(float(row['max_host_rss_mib']))}, "
+            f"peak GPU {_format_memory(float(row['max_gpu_memory_mib']))}, "
+            f"samples {row['memory_samples']}{partial}"
+        )
+    return lines or ["  No finalized source data."]
+
+
+def _failure_detail_lines(
+    failed_nodes: list[FailedNodeSummary], diagnostic_limit: int
+) -> list[str]:
+    if not failed_nodes:
+        return []
+    lines = [_TERMINAL_SEPARATOR, "FAILED TEST NODES", _TERMINAL_SEPARATOR]
+    for failure in failed_nodes:
+        diagnostic = str(failure["diagnostic"])
+        encoded = diagnostic.encode("utf-8")
+        truncated = len(encoded) > diagnostic_limit
+        if truncated:
+            diagnostic = encoded[:diagnostic_limit].decode("utf-8", errors="replace")
+        lines.extend(
+            [
+                f"  - {failure['source_file']} :: {failure['nodeid']}",
+                "    " + diagnostic.replace("\n", "\n    "),
+            ]
+        )
+        if truncated:
+            lines.append(f"    [diagnostic truncated at {diagnostic_limit} bytes]")
+        lines.extend(
+            [
+                f"    log: {failure['log_path']}",
+                f"    results: {failure['results_path']}",
+                f"    junit: {failure['junit_path']}",
+            ]
+        )
+    return lines
+
+
+def terminal_summary_lines(
+    summary: RunSummary | None,
+    *,
+    shard_index: int | None,
+    runner_exit_code: int,
+    shell_exit_code: int | None = None,
+    status: str,
+    test_started_at: float,
+    test_ended_at: float,
+    cause: str | None = None,
+    diagnostic_limit: int = 32 * 1024,
+) -> list[str]:
+    lines = [
+        _TERMINAL_SEPARATOR,
+        "TEST SUMMARY",
+        _TERMINAL_SEPARATOR,
+        f"Start time: {_format_timestamp(test_started_at)}",
+        f"End time: {_format_timestamp(test_ended_at)}",
+        f"Time elapsed: {_format_test_elapsed(test_ended_at - test_started_at)}",
+    ]
+    if summary is None:
+        lines.extend(
+            [
+                "Scope: unavailable",
+                "Planned nodes: unavailable",
+                "Finalized nodes: unavailable",
+            ]
+        )
+        failed_nodes: list[FailedNodeSummary] = []
+        sources: list[SourceSummary] = []
+        infrastructure_errors: list[str] = []
+    else:
+        if shard_index is None:
+            outcomes = summary["outcomes"]
+            sources = summary["sources"]
+            failed_nodes = summary["failed_nodes"]
+            scope_lines = [
+                "Scope: shared run",
+                f"Planned nodes: {summary['planned_nodes']}",
+                f"Finalized nodes: {summary['finalized_nodes']}",
+            ]
+            pending_count = len(summary["pending_nodes"])
+            infrastructure_errors = summary["infrastructure_errors"]
+        else:
+            shard = summary["shards"][str(shard_index)]
+            outcomes = shard["outcomes"]
+            sources = [
+                row for row in summary["sources"] if row["shard_index"] == shard_index
+            ]
+            failed_nodes = [
+                row
+                for row in summary["failed_nodes"]
+                if row["shard_index"] == shard_index
+            ]
+            scope_lines = [
+                f"Shard: {shard_index}",
+                f"Planned nodes: {shard['planned_nodes']}",
+                f"Finalized nodes: {shard['finalized_nodes']}",
+            ]
+            pending_count = shard["pending_nodes"]
+            infrastructure_errors = summary["shard_infrastructure_errors"].get(
+                str(shard_index), []
+            )
+        source_statuses = Counter(row["status"] for row in sources)
+        synthetic = sum(int(row["synthetic"]) for row in sources)
+        lines.extend(
+            [
+                *scope_lines,
+                f"Passed: {outcomes.get('passed', 0)}",
+                f"Failed: {outcomes.get('failed', 0)}",
+                f"Skipped: {outcomes.get('skipped', 0)}",
+                f"Unknown: {outcomes.get('unknown', 0)}",
+                f"Pending: {pending_count}",
+                f"Synthetic: {synthetic}",
+                f"Source files: passed={source_statuses['passed']} "
+                f"failed={source_statuses['failed']} "
+                f"incomplete={source_statuses['incomplete']} "
+                f"unknown={source_statuses['unknown']} "
+                f"no-result={source_statuses['no result']}",
+            ]
+        )
+        if shard_index is not None:
+            lines.append(
+                f"Shared run: finalized={summary['finalized_nodes']}/{summary['planned_nodes']} "
+                f"pending={len(summary['pending_nodes'])}"
+            )
+    if cause:
+        lines.extend(["", "STOP CAUSE", f"  {cause}"])
+    if infrastructure_errors:
+        lines.extend(["", "INFRASTRUCTURE ERRORS"])
+        lines.extend(f"  - {error}" for error in infrastructure_errors)
+    if failed_nodes:
+        failed_sources = sorted(
+            {failure["source_file"] for failure in failed_nodes},
+            key=lambda source: source.encode("utf-8"),
+        )
+        lines.extend(["", "Failed test files:"])
+        lines.extend(f"  - {source}" for source in failed_sources)
+    lines.extend(
+        ["", "TEST RUN RESOURCE SUMMARY", "Top 10 longest-running source files:"]
+    )
+    lines.extend(_top_source_lines(sources, "process_seconds"))
+    lines.append("Top 10 highest host RSS source files:")
+    lines.extend(_top_source_lines(sources, "max_host_rss_mib"))
+    lines.append("Top 10 highest GPU memory source files:")
+    lines.extend(_top_source_lines(sources, "max_gpu_memory_mib"))
+    lines.extend(
+        [
+            _TERMINAL_SEPARATOR,
+            f"Result: status={status} python_exit_code={runner_exit_code} "
+            + (
+                f"shell_exit_code={shell_exit_code}"
+                if shell_exit_code is not None
+                else "shell_exit_code=pending"
+            ),
+            _TERMINAL_SEPARATOR,
+        ]
+    )
+    return [*_failure_detail_lines(failed_nodes, diagnostic_limit), *lines]

--- a/scripts/test_sharding/summary.py
+++ b/scripts/test_sharding/summary.py
@@ -713,7 +713,7 @@ def _failure_detail_lines(
             diagnostic = encoded[:diagnostic_limit].decode("utf-8", errors="replace")
         lines.extend(
             [
-                f"  - {failure['source_file']} :: {failure['nodeid']}",
+                f"  - {failure['nodeid']}",
                 "    " + diagnostic.replace("\n", "\n    "),
             ]
         )

--- a/scripts/test_sharding/workers.py
+++ b/scripts/test_sharding/workers.py
@@ -1,0 +1,618 @@
+from __future__ import annotations
+
+import csv
+import io
+import json
+import os
+import subprocess
+import sys
+import threading
+import time
+from collections import Counter
+from contextlib import suppress
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TextIO
+
+from .io import atomic_write_json, atomic_write_text
+from .junit import annotate_batch_xml, validate_batch_xml
+from .models import Batch, Unit
+from .processes import terminate_process_group
+from .progress import PYTEST_EVENT_PREFIX, decode_pytest_event
+from .summary import batch_directory, batch_xml_path
+
+
+@dataclass(frozen=True)
+class BatchExecution:
+    status: str
+    diagnostic: str = ""
+
+
+@dataclass(frozen=True)
+class BatchExecutionRequest:
+    repo_root: Path
+    junit_dir: Path
+    unit: Unit
+    batch: Batch
+    attempt_id: str
+    profile: str
+    timeout_seconds: float | None
+    timeout_reason: str | None
+    grace_seconds: int
+    worker_index: int
+    device: str | None
+    monitor_memory: bool
+    memory_interval: float
+    pytest_command_prefix: tuple[str, ...] = ()
+    abort_event: threading.Event | None = None
+
+
+@dataclass
+class _BatchProgress:
+    completed: int = 0
+    current_nodeid: str | None = None
+    current_started_at: float | None = None
+    last_function: str | None = None
+    outcomes: Counter[str] = field(default_factory=Counter)
+    _lock: threading.Lock = field(default_factory=threading.Lock, repr=False)
+
+    def start(self, nodeid: str, started_at: float) -> tuple[str, bool]:
+        function = nodeid.split("[", 1)[0]
+        with self._lock:
+            self.current_nodeid = nodeid
+            self.current_started_at = started_at
+            should_print = function != self.last_function
+            if should_print:
+                self.last_function = function
+        return function, should_print
+
+    def finish(self, nodeid: str, outcome: str) -> None:
+        with self._lock:
+            self.completed += 1
+            self.outcomes[outcome] += 1
+            if self.current_nodeid == nodeid:
+                self.current_nodeid = None
+                self.current_started_at = None
+
+    def current(self) -> tuple[str | None, float | None, int]:
+        with self._lock:
+            return self.current_nodeid, self.current_started_at, self.completed
+
+    def totals(self) -> tuple[int, Counter[str]]:
+        with self._lock:
+            return self.completed, Counter(self.outcomes)
+
+
+_CONSOLE_LOCK = threading.Lock()
+_OUTPUT_DRAIN_SECONDS = 5.0
+
+
+def write_console(message: str) -> None:
+    with _CONSOLE_LOCK:
+        print(message, flush=True)
+
+
+@dataclass
+class _OutputDrainState:
+    error: str = ""
+    console_enabled: bool = True
+
+    def emit(self, message: str) -> None:
+        with _CONSOLE_LOCK:
+            if self.console_enabled:
+                print(message, flush=True)
+
+    def disable_console(self) -> None:
+        with _CONSOLE_LOCK:
+            self.console_enabled = False
+
+
+def _descendant_pids(root_pid: int) -> set[int]:
+    pids = {root_pid}
+    changed = True
+    while changed:
+        changed = False
+        for status_path in Path("/proc").glob("[0-9]*/status"):
+            try:
+                content = status_path.read_text(encoding="utf-8")
+                pid = int(status_path.parent.name)
+                parent_line = next(
+                    line for line in content.splitlines() if line.startswith("PPid:")
+                )
+                parent = int(parent_line.split()[1])
+            except (OSError, StopIteration, ValueError):
+                continue
+            if parent in pids and pid not in pids:
+                pids.add(pid)
+                changed = True
+    return pids
+
+
+def _rss_mib(pids: set[int]) -> float:
+    total_kib = 0
+    for pid in pids:
+        try:
+            for line in (
+                Path(f"/proc/{pid}/status").read_text(encoding="utf-8").splitlines()
+            ):
+                if line.startswith("VmRSS:"):
+                    total_kib += int(line.split()[1])
+                    break
+        except (OSError, ValueError):
+            pass
+    return total_kib / 1024
+
+
+def _gpu_mib(pids: set[int]) -> float:
+    try:
+        result = subprocess.run(
+            [
+                "nvidia-smi",
+                "--query-compute-apps=pid,used_memory",
+                "--format=csv,noheader,nounits",
+            ],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return 0.0
+    total = 0.0
+    for line in result.stdout.splitlines():
+        try:
+            pid_text, memory_text = line.split(",", 1)
+            if int(pid_text.strip()) in pids:
+                total += float(memory_text.strip())
+        except ValueError:
+            continue
+    return total
+
+
+def _monitor_memory(
+    pid: int,
+    stop: threading.Event,
+    samples: list[tuple[float, float, float]],
+    interval: float,
+) -> None:
+    while not stop.is_set():
+        pids = _descendant_pids(pid)
+        samples.append((time.time(), _rss_mib(pids), _gpu_mib(pids)))
+        stop.wait(interval)
+
+
+def _forward_pytest_output(
+    stream: TextIO,
+    log: TextIO,
+    progress: _BatchProgress,
+    *,
+    worker_index: int,
+    batch_id: str,
+    source_file: str,
+    log_path: Path,
+    junit_path: Path,
+    results_path: Path,
+    drain_state: _OutputDrainState | None = None,
+) -> None:
+    state = drain_state or _OutputDrainState()
+    for line in stream:
+        event = decode_pytest_event(line)
+        if event is None:
+            log.write(line)
+            log.flush()
+            continue
+        leading_output = line.split(PYTEST_EVENT_PREFIX, 1)[0]
+        if leading_output:
+            log.write(leading_output)
+            log.flush()
+        nodeid = str(event.get("nodeid", ""))
+        if event.get("event") == "start":
+            function, should_print = progress.start(
+                nodeid, float(event.get("started_at", time.time()))
+            )
+            if should_print:
+                state.emit(
+                    f"PYTEST START worker={worker_index} batch={batch_id} "
+                    f"function={function} node={nodeid}"
+                )
+        elif event.get("event") == "finish":
+            outcome = str(event.get("outcome", "unknown"))
+            duration = float(event.get("duration_seconds", 0.0))
+            progress.finish(nodeid, outcome)
+            if outcome in {"failed", "unknown"}:
+                state.emit(
+                    f"PYTEST RESULT worker={worker_index} batch={batch_id} "
+                    f"outcome={outcome} duration={duration:.3f}s node={nodeid}"
+                )
+        elif event.get("event") == "failure":
+            diagnostic = str(event.get("diagnostic", "pytest failure"))
+            state.emit(
+                "PYTEST FAILURE "
+                f"worker={worker_index} source={source_file} node={nodeid} "
+                f"phase={event.get('phase', 'unknown')}\n{diagnostic}"
+            )
+            if bool(event.get("diagnostic_truncated", False)):
+                state.emit("[diagnostic truncated at 32768 bytes]")
+            state.emit(
+                f"PYTEST FAILURE ARTIFACTS log={log_path} "
+                f"results={results_path} junit={junit_path}"
+            )
+
+
+def _drain_pytest_output(
+    stream: TextIO,
+    log: TextIO,
+    progress: _BatchProgress,
+    state: _OutputDrainState,
+    *,
+    worker_index: int,
+    batch_id: str,
+    source_file: str,
+    log_path: Path,
+    junit_path: Path,
+    results_path: Path,
+) -> None:
+    try:
+        _forward_pytest_output(
+            stream,
+            log,
+            progress,
+            worker_index=worker_index,
+            batch_id=batch_id,
+            source_file=source_file,
+            log_path=log_path,
+            junit_path=junit_path,
+            results_path=results_path,
+            drain_state=state,
+        )
+    except Exception as error:
+        state.error = f"{type(error).__name__}: {error}"
+    finally:
+        stream.close()
+
+
+def _temporary(path: Path) -> Path:
+    return path.with_name(f".{path.name}.{os.getpid()}.{threading.get_ident()}.tmp")
+
+
+def _discard_temporary_artifacts(*paths: Path) -> None:
+    for path in paths:
+        path.unlink(missing_ok=True)
+
+
+@dataclass(frozen=True)
+class _BatchArtifacts:
+    final_xml: Path
+    selection: Path
+    temporary_xml: Path
+    temporary_results: Path
+    temporary_telemetry: Path
+    log: Path
+
+    @property
+    def final_results(self) -> Path:
+        return self.final_xml.with_name(f"{self.final_xml.stem}.results.json")
+
+    @property
+    def temporary(self) -> tuple[Path, ...]:
+        return (
+            self.temporary_xml,
+            self.temporary_results,
+            self.temporary_telemetry,
+            self.selection,
+        )
+
+
+@dataclass(frozen=True)
+class _ProcessOutcome:
+    returncode: int
+    launched_at: float
+    exited_at: float
+    timed_out: bool
+    aborted: bool
+    termination_signal: str
+    output_error: str
+    samples: tuple[tuple[float, float, float], ...]
+    progress: _BatchProgress
+
+
+def _batch_artifacts(request: BatchExecutionRequest) -> _BatchArtifacts:
+    directory = batch_directory(request.junit_dir, request.unit)
+    directory.mkdir(parents=True, exist_ok=True)
+    final_xml = batch_xml_path(request.junit_dir, request.unit, request.batch)
+    batch_id = request.batch.id
+    return _BatchArtifacts(
+        final_xml=final_xml,
+        selection=_temporary(directory / f"{batch_id}.selection.json"),
+        temporary_xml=_temporary(final_xml),
+        temporary_results=_temporary(directory / f"{batch_id}.results.json"),
+        temporary_telemetry=_temporary(directory / f"{batch_id}.telemetry.json"),
+        log=directory / f"{batch_id}.log",
+    )
+
+
+def _pytest_command(
+    request: BatchExecutionRequest, artifacts: _BatchArtifacts
+) -> list[str]:
+    return [
+        *request.pytest_command_prefix,
+        sys.executable,
+        "-m",
+        "pytest",
+        "--continue-on-collection-errors",
+        "-p",
+        "scripts.test_sharding.pytest_plugin",
+        f"--flashinfer-node-file={artifacts.selection}",
+        f"--flashinfer-result-json={artifacts.temporary_results}",
+        f"--flashinfer-telemetry-json={artifacts.temporary_telemetry}",
+        f"--junitxml={artifacts.temporary_xml}",
+        request.batch.source_file,
+    ]
+
+
+def _pytest_environment(request: BatchExecutionRequest) -> dict[str, str]:
+    env = os.environ.copy()
+    pythonpath = env.get("PYTHONPATH")
+    env["PYTHONPATH"] = (
+        f"{request.repo_root}{os.pathsep}{pythonpath}"
+        if pythonpath
+        else str(request.repo_root)
+    )
+    if request.device is not None:
+        env["CUDA_VISIBLE_DEVICES"] = request.device
+    return env
+
+
+def _run_pytest(
+    request: BatchExecutionRequest,
+    artifacts: _BatchArtifacts,
+    command: list[str],
+) -> _ProcessOutcome:
+    launched_at = time.time()
+    samples: list[tuple[float, float, float]] = []
+    stop_monitor = threading.Event()
+    monitor: threading.Thread | None = None
+    termination_signal = ""
+    progress = _BatchProgress()
+    timed_out = False
+    aborted = False
+    exited_at: float | None = None
+    output_errors: list[str] = []
+    with artifacts.log.open("a", encoding="utf-8") as log:
+        log.write(f"command: {' '.join(command)}\n")
+        log.flush()
+        process = subprocess.Popen(
+            command,
+            cwd=request.repo_root,
+            env=_pytest_environment(request),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            start_new_session=True,
+            text=True,
+            bufsize=1,
+            errors="replace",
+        )
+        assert process.stdout is not None
+        drain_state = _OutputDrainState()
+        output_thread = threading.Thread(
+            target=_drain_pytest_output,
+            args=(process.stdout, log, progress, drain_state),
+            kwargs={
+                "worker_index": request.worker_index,
+                "batch_id": request.batch.id,
+                "source_file": request.batch.source_file,
+                "log_path": artifacts.log,
+                "junit_path": artifacts.final_xml,
+                "results_path": artifacts.final_results,
+            },
+            daemon=True,
+        )
+        output_thread.start()
+        if request.monitor_memory:
+            monitor = threading.Thread(
+                target=_monitor_memory,
+                args=(process.pid, stop_monitor, samples, request.memory_interval),
+                daemon=True,
+            )
+            monitor.start()
+        try:
+            timeout_at = (
+                time.monotonic() + request.timeout_seconds
+                if request.timeout_seconds is not None
+                else None
+            )
+            while process.poll() is None:
+                if request.abort_event is not None and request.abort_event.is_set():
+                    aborted = True
+                    termination_signal = terminate_process_group(
+                        process, request.grace_seconds
+                    )
+                    break
+                remaining = (
+                    timeout_at - time.monotonic() if timeout_at is not None else None
+                )
+                if remaining is not None and remaining <= 0:
+                    timed_out = True
+                    termination_signal = terminate_process_group(
+                        process, request.grace_seconds
+                    )
+                    break
+                wait_seconds = 0.25 if remaining is None else min(0.25, remaining)
+                with suppress(subprocess.TimeoutExpired):
+                    process.wait(timeout=wait_seconds)
+            process.wait()
+            exited_at = time.time()
+            if not timed_out and not aborted:
+                try:
+                    terminate_process_group(process, request.grace_seconds)
+                except OSError as error:
+                    output_errors.append(
+                        "cannot clean residual pytest process group: "
+                        f"{type(error).__name__}: {error}"
+                    )
+        finally:
+            stop_monitor.set()
+            if monitor is not None:
+                monitor.join(timeout=max(1.0, request.memory_interval + 1))
+            output_thread.join(timeout=_OUTPUT_DRAIN_SECONDS)
+            if output_thread.is_alive():
+                drain_state.disable_console()
+                output_errors.append(
+                    f"pytest output did not reach EOF within {_OUTPUT_DRAIN_SECONDS:g} "
+                    "seconds after process exit; a descendant may still hold stdout; "
+                    f"log={artifacts.log}"
+                )
+            elif drain_state.error:
+                output_errors.append(
+                    f"pytest output reader failed: {drain_state.error}; "
+                    f"log={artifacts.log}"
+                )
+    return _ProcessOutcome(
+        returncode=int(process.returncode),
+        launched_at=launched_at,
+        exited_at=exited_at if exited_at is not None else time.time(),
+        timed_out=timed_out,
+        aborted=aborted,
+        termination_signal=termination_signal,
+        output_error="; ".join(output_errors),
+        samples=tuple(samples),
+        progress=progress,
+    )
+
+
+def _memory_csv(samples: tuple[tuple[float, float, float], ...]) -> str:
+    memory_stream = io.StringIO(newline="")
+    memory_writer = csv.writer(memory_stream, lineterminator="\n")
+    memory_writer.writerow(["timestamp", "host_rss_mib", "gpu_memory_mib"])
+    for timestamp, rss_mib, gpu_mib in samples:
+        memory_writer.writerow([f"{timestamp:.6f}", f"{rss_mib:.3f}", f"{gpu_mib:.3f}"])
+    return memory_stream.getvalue()
+
+
+def _timeout_result(
+    request: BatchExecutionRequest,
+    artifacts: _BatchArtifacts,
+    outcome: _ProcessOutcome,
+) -> BatchExecution:
+    active_nodeid, _, _ = outcome.progress.current()
+    completed, outcomes = outcome.progress.totals()
+    write_console(
+        f"PYTEST KILLED worker={request.worker_index} batch={request.batch.id} "
+        f"source={request.batch.source_file} "
+        f"reason={request.timeout_reason or 'timeout'} "
+        f"signal={outcome.termination_signal} "
+        f"completed_in_batch={completed} passed={outcomes['passed']} "
+        f"failed={outcomes['failed']} skipped={outcomes['skipped']} "
+        f"node={active_nodeid or 'unknown'} log={artifacts.log}"
+    )
+    _discard_temporary_artifacts(*artifacts.temporary)
+    return BatchExecution("timeout", "pytest batch exceeded its time budget")
+
+
+def _promote_batch_artifacts(
+    request: BatchExecutionRequest,
+    artifacts: _BatchArtifacts,
+    outcome: _ProcessOutcome,
+) -> None:
+    batch = request.batch
+    unit = request.unit
+    annotate_batch_xml(
+        artifacts.temporary_xml,
+        {
+            "batch_id": batch.id,
+            "unit_id": unit.id,
+            "shard_index": str(unit.shard_index),
+            "attempt_id": request.attempt_id,
+            "timing_profile": request.profile,
+            "synthetic": "false",
+        },
+    )
+    if artifacts.temporary_telemetry.exists():
+        try:
+            telemetry = json.loads(
+                artifacts.temporary_telemetry.read_text(encoding="utf-8")
+            )
+        except (OSError, json.JSONDecodeError):
+            telemetry = {}
+        telemetry.update(
+            {
+                "process_launch": outcome.launched_at,
+                "process_exit": outcome.exited_at,
+                "batch_id": batch.id,
+            }
+        )
+        atomic_write_json(artifacts.temporary_telemetry, telemetry)
+    os.replace(artifacts.temporary_xml, artifacts.final_xml)
+    if artifacts.temporary_results.exists():
+        os.replace(artifacts.temporary_results, artifacts.final_results)
+    if artifacts.temporary_telemetry.exists():
+        os.replace(
+            artifacts.temporary_telemetry,
+            artifacts.final_xml.with_name(f"{batch.id}.telemetry.json"),
+        )
+    atomic_write_text(
+        artifacts.final_xml.with_name(f"{batch.id}.memory.csv"),
+        _memory_csv(outcome.samples),
+    )
+    atomic_write_json(
+        artifacts.final_xml.with_name(f"{batch.id}.meta.json"),
+        {
+            "attempt_id": request.attempt_id,
+            "batch_id": batch.id,
+            "unit_id": unit.id,
+            "shard_index": unit.shard_index,
+            "pytest_exit_code": outcome.returncode,
+            "launched_at": outcome.launched_at,
+            "exited_at": outcome.exited_at,
+            "synthetic": False,
+            "monitor_memory": request.monitor_memory,
+        },
+    )
+    artifacts.selection.unlink(missing_ok=True)
+
+
+def execute_batch(request: BatchExecutionRequest) -> BatchExecution:
+    artifacts = _batch_artifacts(request)
+    atomic_write_json(artifacts.selection, list(request.batch.nodeids))
+    outcome = _run_pytest(request, artifacts, _pytest_command(request, artifacts))
+    if outcome.output_error:
+        _discard_temporary_artifacts(*artifacts.temporary)
+        return BatchExecution("infrastructure", outcome.output_error)
+    if outcome.aborted:
+        _discard_temporary_artifacts(*artifacts.temporary)
+        return BatchExecution(
+            "infrastructure",
+            "pytest stopped because the runner lease heartbeat failed; "
+            f"log={artifacts.log}",
+        )
+    if outcome.timed_out:
+        return _timeout_result(request, artifacts, outcome)
+    if outcome.returncode not in {0, 1}:
+        _discard_temporary_artifacts(*artifacts.temporary)
+        return BatchExecution(
+            "infrastructure",
+            f"pytest exited with infrastructure exit code {outcome.returncode}; "
+            f"log={artifacts.log}",
+        )
+    if not artifacts.temporary_xml.exists():
+        _discard_temporary_artifacts(*artifacts.temporary)
+        return BatchExecution(
+            "infrastructure",
+            f"pytest did not produce JUnit XML; log={artifacts.log}",
+        )
+    validation = validate_batch_xml(artifacts.temporary_xml, request.batch.nodeids)
+    if not validation.valid:
+        _discard_temporary_artifacts(*artifacts.temporary)
+        return BatchExecution(
+            "infrastructure",
+            "; ".join(validation.diagnostics) + f"; log={artifacts.log}",
+        )
+    _promote_batch_artifacts(request, artifacts, outcome)
+    outcomes = Counter(case.outcome for case in validation.cases)
+    write_console(
+        f"PYTEST BATCH COMPLETE worker={request.worker_index} "
+        f"batch={request.batch.id} finalized={len(validation.cases)} "
+        f"passed={outcomes['passed']} failed={outcomes['failed']} "
+        f"skipped={outcomes['skipped']}"
+    )
+    return BatchExecution("finalized")

--- a/scripts/test_utils.sh
+++ b/scripts/test_utils.sh
@@ -54,6 +54,7 @@ fi
 : "${MEMORY_MONITOR_LOG_INTERVAL:=0}"  # Emit periodic samples to the CI log when >0
 : "${PYTEST_FILE_TIMEOUT_SECONDS:=7200}"  # Per-test-file timeout; 0 disables
 : "${PYTEST_FILE_TIMEOUT_KILL_AFTER_SECONDS:=300}"  # Grace period before SIGKILL after timeout
+: "${UNIT_TEST_REQUIRE_PRECOMPILED_KERNELS:=false}"  # Fail setup when CI artifacts are absent
 
 # Randomize starting offset (0 to SAMPLE_RATE-1) for sampling variety
 if [ -z "${SAMPLE_OFFSET:-}" ]; then
@@ -187,7 +188,21 @@ install_precompiled_kernels() {
         return
     fi
 
+    case "${UNIT_TEST_REQUIRE_PRECOMPILED_KERNELS}" in
+        true|false) ;;
+        *)
+            echo "ERROR: UNIT_TEST_REQUIRE_PRECOMPILED_KERNELS must be true or false, got '${UNIT_TEST_REQUIRE_PRECOMPILED_KERNELS}'." >&2
+            return 2
+            ;;
+    esac
+
+    if [ "${UNIT_TEST_REQUIRE_PRECOMPILED_KERNELS}" = "true" ] && [ -z "${JIT_ARCH:-}" ]; then
+        echo "ERROR: UNIT_TEST_REQUIRE_PRECOMPILED_KERNELS=true requires JIT_ARCH." >&2
+        return 1
+    fi
+
     JIT_ARCH_EFFECTIVE=""
+    local missing_artifacts=false
     # Map CUDA_VERSION to CUDA_STREAM for artifact lookup
     if [[ "${CUDA_VERSION}" == cu* ]]; then
         CUDA_STREAM="${CUDA_VERSION}"
@@ -233,16 +248,32 @@ install_precompiled_kernels() {
             echo "Installing flashinfer-cubin from ${DIST_CUBIN_DIR} ..."
             pip install -q "${DIST_CUBIN_DIR}"/*.whl
         else
-            echo "ERROR: flashinfer-cubin wheel not found in ${DIST_CUBIN_DIR}. Ensure the CI build stage produced the artifact." >&2
+            missing_artifacts=true
+            if [ "${UNIT_TEST_REQUIRE_PRECOMPILED_KERNELS}" = "true" ]; then
+                echo "ERROR: flashinfer-cubin wheel not found in ${DIST_CUBIN_DIR}. Ensure the CI build stage produced the artifact." >&2
+            else
+                echo "WARNING: flashinfer-cubin wheel not found in ${DIST_CUBIN_DIR}; tests will use JIT compilation." >&2
+            fi
         fi
 
         if [ -d "${DIST_JIT_CACHE_DIR}" ] && ls "${DIST_JIT_CACHE_DIR}"/*.whl >/dev/null 2>&1; then
             echo "Installing flashinfer-jit-cache from ${DIST_JIT_CACHE_DIR} ..."
             pip install -q "${DIST_JIT_CACHE_DIR}"/*.whl
         else
-            echo "ERROR: flashinfer-jit-cache wheel not found in ${DIST_JIT_CACHE_DIR} for ${CUDA_VERSION}. Ensure the CI build stage produced the artifact." >&2
+            missing_artifacts=true
+            if [ "${UNIT_TEST_REQUIRE_PRECOMPILED_KERNELS}" = "true" ]; then
+                echo "ERROR: flashinfer-jit-cache wheel not found in ${DIST_JIT_CACHE_DIR} for ${CUDA_VERSION}. Ensure the CI build stage produced the artifact." >&2
+            else
+                echo "WARNING: flashinfer-jit-cache wheel not found in ${DIST_JIT_CACHE_DIR} for ${CUDA_VERSION}; tests will use JIT compilation." >&2
+            fi
         fi
         echo ""
+    else
+        echo "WARNING: JIT_ARCH is unset; skipping precompiled kernel artifact lookup and using JIT compilation." >&2
+    fi
+
+    if [ "${missing_artifacts}" = "true" ] && [ "${UNIT_TEST_REQUIRE_PRECOMPILED_KERNELS}" = "true" ]; then
+        return 1
     fi
 }
 
@@ -257,6 +288,8 @@ install_and_verify() {
 
         # Sync dependencies from the branch's requirements.txt
         pip install -r requirements.txt
+        pip install -r requirements-test.txt
+        python -c "import pytest_timeout"
 
         # Install nvidia-cutlass-dsl with the correct CUDA extra to avoid
         # version skew between libs-base and libs-cu13.

--- a/scripts/unit_test_runner.py
+++ b/scripts/unit_test_runner.py
@@ -1,0 +1,598 @@
+#!/usr/bin/env python3
+"""Deterministic, duration-balanced, resumable pytest coordinator."""
+
+from __future__ import annotations
+
+import argparse
+import math
+import os
+import shlex
+import sys
+import time
+import traceback
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from scripts.test_sharding.models import (
+    DEFAULT_CHECKPOINT_SECONDS,
+    DEFAULT_TARGET_UNIT_SECONDS,
+    Plan,
+    PlanningOptions,
+)
+from scripts.test_sharding.runner import (
+    CollectionTimeoutError,
+    DeadlineClock,
+    ExecutionSettings,
+    ManifestPreparation,
+    SelectionSettings,
+    execute_shard,
+    finalize_latest,
+    plan_description,
+    prepare_manifest,
+    visible_devices,
+)
+from scripts.test_sharding.planner import capacity_metrics
+from scripts.test_sharding.state import (
+    AttemptSettings,
+    RunnerStateError,
+    load_manifest,
+)
+from scripts.test_sharding.summary import (
+    exit_code_for_summary,
+    publish_summary,
+    terminal_summary_lines,
+)
+
+
+EXIT_HELP = (
+    "exit codes: 0=complete without failures; "
+    "1=complete with real or synthetic failures; "
+    "2=incomplete and resumable; "
+    "3=configuration, manifest, collection, or infrastructure error"
+)
+DEFAULT_DEADLINE_SECONDS = 0
+DEFAULT_UNIT_TIMEOUT_SECONDS = 0
+
+
+def _env_int(name: str, default: int) -> int:
+    value = os.environ.get(name)
+    return int(value) if value is not None else default
+
+
+def _env_positive_float(name: str, default: float) -> float:
+    value = float(os.environ.get(name, str(default)))
+    if not math.isfinite(value) or value <= 0:
+        raise ValueError(f"{name} must be a positive finite number")
+    return value
+
+
+def _pytest_command_prefix() -> tuple[str, ...]:
+    try:
+        return tuple(shlex.split(os.environ.get("PYTEST_COMMAND_PREFIX", "")))
+    except ValueError as error:
+        raise RunnerStateError(f"invalid PYTEST_COMMAND_PREFIX: {error}") from error
+
+
+def _configure_output() -> None:
+    for stream in (sys.stdout, sys.stderr):
+        reconfigure = getattr(stream, "reconfigure", None)
+        if reconfigure is not None:
+            reconfigure(line_buffering=True)
+
+
+def _test_started_at(
+    operation_started_at: float, wrapper_started_at: float | None
+) -> float:
+    if wrapper_started_at is None:
+        return operation_started_at
+    if not math.isfinite(wrapper_started_at) or not (
+        0 < wrapper_started_at <= operation_started_at
+    ):
+        return operation_started_at
+    return wrapper_started_at
+
+
+def _positive(value: str) -> int:
+    parsed = int(value)
+    if parsed <= 0:
+        raise argparse.ArgumentTypeError("must be positive")
+    return parsed
+
+
+def _nonnegative(value: str) -> int:
+    parsed = int(value)
+    if parsed < 0:
+        raise argparse.ArgumentTypeError("must be nonnegative")
+    return parsed
+
+
+def _timeout_policy(value: str) -> str:
+    if value not in {"resume", "skip", "fail"}:
+        raise argparse.ArgumentTypeError("must be one of: resume, skip, fail")
+    return value
+
+
+def _auto_timing_profile() -> str:
+    """Label result telemetry without using the label for runtime planning."""
+
+    cuda = "unknown"
+    gpu = "unknown"
+    try:
+        import torch
+
+        if torch.version.cuda:
+            cuda = torch.version.cuda.split(".", 1)[0]
+        if torch.cuda.is_available():
+            major, minor = torch.cuda.get_device_capability(0)
+            name = torch.cuda.get_device_name(0).lower()
+            gpu = next(
+                (
+                    model
+                    for model in ("b100", "b200", "h100", "h200", "a100", "l40")
+                    if model in name
+                ),
+                f"sm{major}{minor}",
+            )
+    except Exception:
+        pass
+    return f"{gpu}-cuda{cuda}"
+
+
+def _add_common(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="used by task_run_unit_tests.sh to select plan-only mode",
+    )
+    parser.add_argument(
+        "--wrapper-started-at",
+        type=float,
+        help=(
+            "Unix start timestamp injected by the shell entry point for "
+            "elapsed-time reporting"
+        ),
+    )
+    parser.add_argument(
+        "--junit-dir",
+        type=Path,
+        default=Path(os.environ.get("JUNIT_DIR", "./junit")),
+        help="shared result and persistent state directory (JUNIT_DIR)",
+    )
+    parser.add_argument(
+        "--target-unit-seconds",
+        type=_positive,
+        default=os.environ.get("UNIT_TEST_TARGET_SECONDS", DEFAULT_TARGET_UNIT_SECONDS),
+        help="soft logical-unit target (UNIT_TEST_TARGET_SECONDS)",
+    )
+    parser.add_argument(
+        "--checkpoint-seconds",
+        type=_positive,
+        default=os.environ.get(
+            "UNIT_TEST_CHECKPOINT_SECONDS", DEFAULT_CHECKPOINT_SECONDS
+        ),
+        help="source-local checkpoint target (UNIT_TEST_CHECKPOINT_SECONDS)",
+    )
+    parser.add_argument(
+        "--default-case-seconds",
+        type=_positive,
+        default=os.environ.get("UNIT_TEST_DEFAULT_CASE_SECONDS", 1),
+        help="default estimate for a node missing timing data (UNIT_TEST_DEFAULT_CASE_SECONDS)",
+    )
+    parser.add_argument(
+        "--default-source-overhead-seconds",
+        type=_nonnegative,
+        default=os.environ.get("UNIT_TEST_DEFAULT_SOURCE_OVERHEAD_SECONDS", 30),
+        help="default per-source process overhead (UNIT_TEST_DEFAULT_SOURCE_OVERHEAD_SECONDS)",
+    )
+    parser.add_argument(
+        "--duration-estimates",
+        type=Path,
+        default=(
+            Path(os.environ["UNIT_TEST_DURATION_ESTIMATES"])
+            if os.environ.get("UNIT_TEST_DURATION_ESTIMATES")
+            else None
+        ),
+        help="optional per-node duration CSV or CSV.gz (UNIT_TEST_DURATION_ESTIMATES)",
+    )
+    parser.add_argument(
+        "--overhead-estimates",
+        type=Path,
+        default=(
+            Path(os.environ["UNIT_TEST_OVERHEAD_ESTIMATES"])
+            if os.environ.get("UNIT_TEST_OVERHEAD_ESTIMATES")
+            else None
+        ),
+        help="optional per-source overhead CSV or CSV.gz (UNIT_TEST_OVERHEAD_ESTIMATES)",
+    )
+    parser.add_argument(
+        "--shard-count",
+        type=_positive,
+        default=os.environ.get("UNIT_TEST_SHARD_COUNT", 1),
+        help="number of deterministic external shards (UNIT_TEST_SHARD_COUNT)",
+    )
+    parser.add_argument(
+        "--shard-index",
+        type=_nonnegative,
+        default=os.environ.get("UNIT_TEST_SHARD_INDEX", 0),
+        help="zero-based external shard (UNIT_TEST_SHARD_INDEX)",
+    )
+    parser.add_argument(
+        "--test-path",
+        type=Path,
+        default=Path(os.environ.get("TEST_PATH") or "tests/"),
+        help="pytest collection scope (TEST_PATH)",
+    )
+    parser.add_argument(
+        "--sanity-test",
+        action="store_true",
+        help=(
+            "globally select every SAMPLE_RATE-th collected node using a zero-based "
+            "SAMPLE_OFFSET (defaults: SAMPLE_RATE=5, SAMPLE_OFFSET=0)"
+        ),
+    )
+    parser.add_argument(
+        "--workers",
+        type=_positive,
+        default=os.environ.get("UNIT_TEST_WORKERS", max(1, len(visible_devices()))),
+        help="local workers, at most visible GPU count (UNIT_TEST_WORKERS)",
+    )
+    parser.add_argument(
+        "--unit-timeout-seconds",
+        type=_nonnegative,
+        default=os.environ.get(
+            "UNIT_TEST_TIMEOUT_SECONDS", DEFAULT_UNIT_TIMEOUT_SECONDS
+        ),
+        help="cumulative unit timeout; 0 disables (UNIT_TEST_TIMEOUT_SECONDS)",
+    )
+    parser.add_argument(
+        "--timeout-grace-seconds",
+        type=_nonnegative,
+        default=os.environ.get("UNIT_TEST_TIMEOUT_GRACE_SECONDS", 300),
+        help="SIGTERM-to-SIGKILL grace (UNIT_TEST_TIMEOUT_GRACE_SECONDS)",
+    )
+    parser.add_argument(
+        "--timeout-policy",
+        type=_timeout_policy,
+        choices=("resume", "skip", "fail"),
+        default=os.environ.get("UNIT_TEST_TIMEOUT_POLICY", "resume"),
+        help="handling for unexecuted nodes (UNIT_TEST_TIMEOUT_POLICY)",
+    )
+    parser.add_argument(
+        "--deadline-seconds",
+        type=_nonnegative,
+        default=os.environ.get("UNIT_TEST_DEADLINE_SECONDS", DEFAULT_DEADLINE_SECONDS),
+        help="shared attempt deadline; 0 disables (UNIT_TEST_DEADLINE_SECONDS)",
+    )
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        epilog=EXIT_HELP,
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    for command, help_text in (
+        ("run", "create/resume a run and execute one external shard"),
+        ("plan", "create/verify a plan without executing tests"),
+    ):
+        child = subparsers.add_parser(
+            command,
+            help=help_text,
+            epilog=EXIT_HELP,
+            formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+        )
+        _add_common(child)
+    for command, help_text in (
+        ("finalize", "idempotently close the latest attempt and regenerate artifacts"),
+        ("summarize", "regenerate derived artifacts from authoritative batch XML"),
+    ):
+        child = subparsers.add_parser(
+            command,
+            help=help_text,
+            epilog=EXIT_HELP,
+            formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+        )
+        child.add_argument(
+            "--junit-dir",
+            type=Path,
+            default=Path(os.environ.get("JUNIT_DIR", "./junit")),
+            help="shared result and persistent state directory (JUNIT_DIR)",
+        )
+    return parser
+
+
+def _shell_settings(argv: list[str]) -> int:
+    operation = "plan" if "--dry-run" in argv else "run"
+    parser = _parser()
+    args = parser.parse_args([operation, *argv])
+    try:
+        sample_rate = _env_int("SAMPLE_RATE", 5)
+        sample_offset = _env_int("SAMPLE_OFFSET", 0)
+        if sample_rate <= 0:
+            raise ValueError("SAMPLE_RATE must be positive")
+        if not 0 <= sample_offset < sample_rate:
+            raise ValueError("SAMPLE_OFFSET must be in [0, SAMPLE_RATE)")
+        _pytest_command_prefix()
+        _env_positive_float("MEMORY_MONITOR_INTERVAL", 2)
+    except (RunnerStateError, ValueError) as error:
+        parser.error(str(error))
+    print(operation)
+    print(args.test_path)
+    return 0
+
+
+def _load_frozen_plan(junit_dir: Path) -> Plan:
+    manifest = load_manifest(junit_dir)
+    if manifest is None:
+        raise RunnerStateError(f"no runner manifest in {junit_dir}")
+    return Plan.from_dict(manifest["plan"])
+
+
+def _execute_command(args: argparse.Namespace, operation_started_at: float) -> int:
+    junit_dir = args.junit_dir.resolve()
+    if args.command in {"finalize", "summarize"}:
+        plan = _load_frozen_plan(junit_dir)
+        if args.command == "finalize":
+            return finalize_latest(junit_dir, plan)
+        return exit_code_for_summary(publish_summary(junit_dir, plan))
+
+    if "PYTEST_FILE_TIMEOUT_SECONDS" in os.environ:
+        raise RunnerStateError(
+            "PYTEST_FILE_TIMEOUT_SECONDS is obsolete; use UNIT_TEST_TIMEOUT_SECONDS "
+            "or --unit-timeout-seconds"
+        )
+    if "PYTEST_FILE_TIMEOUT_KILL_AFTER_SECONDS" in os.environ:
+        raise RunnerStateError(
+            "PYTEST_FILE_TIMEOUT_KILL_AFTER_SECONDS is obsolete; use "
+            "UNIT_TEST_TIMEOUT_GRACE_SECONDS or --timeout-grace-seconds"
+        )
+
+    pytest_command_prefix = _pytest_command_prefix()
+    planning = PlanningOptions(
+        checkpoint_seconds=args.checkpoint_seconds,
+        target_unit_seconds=args.target_unit_seconds,
+        default_case_seconds=args.default_case_seconds,
+        default_source_overhead_seconds=args.default_source_overhead_seconds,
+        shard_count=args.shard_count,
+    )
+    sample_rate = _env_int("SAMPLE_RATE", 5)
+    sample_offset = _env_int("SAMPLE_OFFSET", 0)
+    selection = SelectionSettings(
+        test_path=args.test_path.resolve(),
+        sanity_test=args.sanity_test,
+        sample_rate=sample_rate,
+        sample_offset=sample_offset,
+    )
+    collection_timeout = (
+        max(0.001, args.deadline_seconds - (time.time() - operation_started_at))
+        if args.deadline_seconds > 0
+        else None
+    )
+    attempt = AttemptSettings(
+        deadline_seconds=args.deadline_seconds,
+        unit_timeout_seconds=args.unit_timeout_seconds,
+        timeout_grace_seconds=args.timeout_grace_seconds,
+        timeout_policy=args.timeout_policy,
+    )
+    print(
+        f"RUNNER STATUS: state=collecting command={args.command} "
+        f"test_path={selection.test_path}",
+        flush=True,
+    )
+    _, plan, created = prepare_manifest(
+        ManifestPreparation(
+            repo_root=REPO_ROOT,
+            junit_dir=junit_dir,
+            selection=selection,
+            planning=planning,
+            collection_timeout_seconds=collection_timeout,
+            collection_grace_seconds=args.timeout_grace_seconds,
+            attempt_settings=attempt if args.command == "run" else None,
+            operation_started_at=operation_started_at,
+            pytest_command_prefix=pytest_command_prefix,
+            duration_estimates=(
+                args.duration_estimates.resolve()
+                if args.duration_estimates is not None
+                else None
+            ),
+            overhead_estimates=(
+                args.overhead_estimates.resolve()
+                if args.overhead_estimates is not None
+                else None
+            ),
+        )
+    )
+    print(("Created" if created else "Using") + f" plan in {junit_dir}", flush=True)
+    print(
+        plan_description(
+            plan,
+            workers=args.workers,
+            deadline_seconds=args.deadline_seconds,
+        ),
+        flush=True,
+    )
+    print(
+        f"RUNNER STATUS: state=plan-ready nodes={len(plan.nodes)} "
+        f"units={len(plan.units)} shards={plan.options.shard_count}",
+        flush=True,
+    )
+    capacity = capacity_metrics(
+        plan,
+        {index: args.workers for index in range(plan.options.shard_count)},
+        deadline_seconds=args.deadline_seconds,
+    )
+    if (
+        args.deadline_seconds > 0
+        and capacity["estimated_makespan_ms"] > args.deadline_seconds * 1000
+    ):
+        print(
+            "WARNING: estimated per-shard load exceeds the attempt deadline at "
+            f"{args.workers} local worker(s); configure more workers/shards or expect resume",
+        )
+    if args.unit_timeout_seconds > 0:
+        over_timeout = [
+            batch
+            for unit in plan.units
+            for batch in unit.batches
+            if batch.estimated_ms > args.unit_timeout_seconds * 1000
+        ]
+        if over_timeout:
+            print(
+                f"WARNING: {len(over_timeout)} atomic/checkpoint batch(es) are estimated "
+                "to exceed the unit timeout",
+            )
+    if args.command == "plan":
+        return 0
+    execution = ExecutionSettings(
+        workers=args.workers,
+        shard_index=args.shard_index,
+        attempt=attempt,
+        monitor_memory=os.environ.get("MONITOR_TEST_MEMORY", "true").lower()
+        not in {"0", "false", "no"},
+        memory_interval=_env_positive_float("MEMORY_MONITOR_INTERVAL", 2),
+        pytest_command_prefix=pytest_command_prefix,
+        timing_profile=_auto_timing_profile(),
+    )
+    return execute_shard(
+        repo_root=REPO_ROOT,
+        junit_dir=junit_dir,
+        plan=plan,
+        execution=execution,
+        operation_started_at=operation_started_at,
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    _configure_output()
+    arguments = list(sys.argv[1:] if argv is None else argv)
+    if arguments[:1] == ["__shell-settings"]:
+        return _shell_settings(arguments[1:])
+    operation_started_at = time.time()
+    test_started_at = operation_started_at
+    deadline_clock = DeadlineClock(
+        started_at=operation_started_at,
+        limit_seconds=0,
+    )
+    args: argparse.Namespace | None = None
+    cause: str | None = None
+    try:
+        args = _parser().parse_args(arguments)
+        test_started_at = _test_started_at(
+            operation_started_at, getattr(args, "wrapper_started_at", None)
+        )
+        deadline_clock = DeadlineClock(
+            started_at=operation_started_at,
+            limit_seconds=getattr(args, "deadline_seconds", 0),
+        )
+        result = _execute_command(args, operation_started_at)
+    except CollectionTimeoutError as error:
+        pending = "unknown" if error.pending_nodes is None else str(error.pending_nodes)
+        deadline_fields = (
+            error.deadline_clock.status_fields()
+            if error.deadline_clock is not None
+            else deadline_clock.status_fields()
+        )
+        cause = str(error)
+        print(f"ERROR: {error}")
+        print(
+            "PYTEST KILLED phase=collection reason=attempt-deadline "
+            f"signal={error.termination_signal} "
+            f"elapsed={error.elapsed_seconds:.1f}s scope={error.result_scope} "
+            f"finalized={error.finalized_nodes} passed={error.passed} "
+            f"failed={error.failed} skipped={error.skipped} "
+            f"pending={pending} node=unknown",
+            flush=True,
+        )
+        print(
+            "RUNNER STATUS: state=killed phase=collection "
+            "reason=attempt-deadline "
+            f"signal={error.termination_signal} scope={error.result_scope} "
+            f"finalized={error.finalized_nodes} passed={error.passed} "
+            f"failed={error.failed} skipped={error.skipped} pending={pending} "
+            f"{deadline_fields}",
+            flush=True,
+        )
+        result = 3
+    except (RunnerStateError, ValueError, OSError) as error:
+        cause = f"{type(error).__name__}: {error}"
+        print(f"ERROR: {cause}")
+        print(
+            "RUNNER STATUS: state=failed "
+            "reason=configuration-or-infrastructure-error "
+            f"{deadline_clock.status_fields()}",
+            flush=True,
+        )
+        result = 3
+    except Exception as error:
+        cause = f"{type(error).__name__}: {error}"
+        print(f"ERROR: unexpected runner error: {cause}")
+        traceback.print_exc(file=sys.stdout)
+        print(
+            "RUNNER STATUS: state=failed reason=unexpected-infrastructure-error "
+            f"{deadline_clock.status_fields()}",
+            flush=True,
+        )
+        result = 3
+    summary = None
+    shard_index = None
+    if args is not None and hasattr(args, "junit_dir"):
+        try:
+            manifest = load_manifest(args.junit_dir.resolve())
+            if manifest is not None:
+                plan = Plan.from_dict(manifest["plan"])
+                summary = publish_summary(args.junit_dir.resolve(), plan)
+                shard_index = (
+                    None
+                    if getattr(args, "command", "") in {"finalize", "summarize"}
+                    else int(getattr(args, "shard_index", 0))
+                )
+        except Exception as summary_error:
+            detail = f"summary publication failed: {summary_error}"
+            cause = f"{cause}; {detail}" if cause else detail
+            print(f"ERROR: {detail}")
+            result = 3
+    status = {
+        0: "complete-without-failures"
+        if getattr(args, "command", "") != "plan"
+        else "plan-ready",
+        1: "complete-with-failures",
+        2: "incomplete-and-resumable",
+        3: "configuration-collection-or-infrastructure-error",
+    }.get(result, "abnormal-exit")
+    if cause is None:
+        if result == 0:
+            cause = (
+                "deterministic plan was written successfully"
+                if getattr(args, "command", "") == "plan"
+                else "requested test operation completed without failures"
+            )
+        elif result == 1:
+            cause = (
+                "one or more test nodes failed; failure status takes precedence "
+                "over incomplete work"
+            )
+        elif result == 2:
+            cause = "planned test nodes remain pending; run again to resume"
+        elif result == 3:
+            cause = "the current operation stopped because of an infrastructure error"
+    for line in terminal_summary_lines(
+        summary,
+        shard_index=shard_index,
+        runner_exit_code=result,
+        shell_exit_code=0 if result in {0, 2} else result,
+        status=status,
+        test_started_at=test_started_at,
+        test_ended_at=time.time(),
+        cause=cause,
+    ):
+        print(line)
+    return result
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/unit_test_runner.py
+++ b/scripts/unit_test_runner.py
@@ -55,7 +55,7 @@ EXIT_HELP = (
     "3=configuration, manifest, collection, or infrastructure error"
 )
 DEFAULT_DEADLINE_SECONDS = 0
-DEFAULT_UNIT_TIMEOUT_SECONDS = 0
+DEFAULT_UNIT_TIMEOUT_SECONDS = 2 * 60 * 60
 
 
 def _env_int(name: str, default: int) -> int:
@@ -258,7 +258,7 @@ def _add_common(parser: argparse.ArgumentParser) -> None:
         "--timeout-policy",
         type=_timeout_policy,
         choices=("resume", "skip", "fail"),
-        default=os.environ.get("UNIT_TEST_TIMEOUT_POLICY", "resume"),
+        default=os.environ.get("UNIT_TEST_TIMEOUT_POLICY", "fail"),
         help="handling for unexecuted nodes (UNIT_TEST_TIMEOUT_POLICY)",
     )
     parser.add_argument(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -171,6 +171,10 @@ def pytest_configure(config):
     config.addinivalue_line(
         "markers", "solo: run this whole test file alone (memory-heavy)"
     )
+    config.addinivalue_line(
+        "markers",
+        "shard_group(name): keep marked nodes from one source in one pytest batch",
+    )
 
 
 def pytest_collection_modifyitems(config, items):

--- a/tests/test_sharding/conftest.py
+++ b/tests/test_sharding/conftest.py
@@ -1,0 +1,11 @@
+"""Keep runner-module imports local to the sharding infrastructure tests."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))

--- a/tests/test_sharding/test_estimate_refresh.py
+++ b/tests/test_sharding/test_estimate_refresh.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+import csv
+import gzip
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts.rebuild_test_duration_estimates import _prune_scope
+from scripts.test_sharding.models import CollectedNode, Plan, PlanningOptions
+from scripts.test_sharding.observations import (
+    EstimateRefresh,
+    ObservedCase,
+    adjust_first_case_warmup,
+    refresh_estimates,
+)
+
+
+def _observation(
+    nodeid: str,
+    seconds: float,
+    *,
+    outcome: str = "passed",
+    first: bool = False,
+) -> ObservedCase:
+    return ObservedCase(
+        profile="profile",
+        nodeid=nodeid,
+        source_file="tests/test_sample.py",
+        base_function="tests/test_sample.py::test_case",
+        outcome=outcome,
+        seconds=seconds,
+        adjusted_seconds=seconds,
+        synthetic=False,
+        run_id="run",
+        batch_id="batch",
+        first_in_batch=first,
+    )
+
+
+def test_first_case_outlier_is_reclassified_as_source_warmup() -> None:
+    observations = [
+        _observation("tests/test_sample.py::test_case[slow]", 20, first=True)
+    ]
+    observations.extend(
+        _observation(f"tests/test_sample.py::test_case[{index}]", 1)
+        for index in range(10)
+    )
+
+    adjusted, warmup = adjust_first_case_warmup(observations)
+
+    slow = next(item for item in adjusted if item.first_in_batch)
+    assert slow.adjusted_seconds == 1
+    assert warmup[("run", "batch")] == 19
+
+
+def test_refresh_is_byte_reproducible_and_decreases_gradually(tmp_path: Path) -> None:
+    duration_file = tmp_path / "estimates.csv.gz"
+    with gzip.open(duration_file, "wt", newline="", encoding="utf-8") as stream:
+        writer = csv.writer(stream)
+        writer.writerow(["profile", "nodeid", "estimated_seconds", "sample_count"])
+        writer.writerow(
+            ["profile", "tests/test_sample.py::test_case[pass]", "100", "2"]
+        )
+        writer.writerow(
+            ["profile", "tests/test_sample.py::test_case[fail]", "100", "2"]
+        )
+    overhead_file = tmp_path / "overhead.csv"
+    overhead_file.write_text(
+        "profile,source_file,process_startup_seconds,source_warmup_seconds,sample_count\n",
+        encoding="utf-8",
+    )
+    summary_file = tmp_path / "summary.csv"
+    observations = [
+        _observation("tests/test_sample.py::test_case[pass]", 50),
+        _observation("tests/test_sample.py::test_case[fail]", 200, outcome="failed"),
+        _observation("tests/test_sample.py::test_case[new]", 10),
+    ]
+
+    refresh_estimates(
+        observations,
+        [],
+        EstimateRefresh(
+            duration_file=duration_file,
+            overhead_file=overhead_file,
+            summary_file=summary_file,
+        ),
+    )
+    first_bytes = duration_file.read_bytes()
+    with gzip.open(duration_file, "rt", newline="", encoding="utf-8") as stream:
+        rows = {row["nodeid"]: row for row in csv.DictReader(stream)}
+
+    assert (
+        float(rows["tests/test_sample.py::test_case[pass]"]["estimated_seconds"]) == 90
+    )
+    assert (
+        float(rows["tests/test_sample.py::test_case[fail]"]["estimated_seconds"]) == 240
+    )
+    assert (
+        float(rows["tests/test_sample.py::test_case[new]"]["estimated_seconds"]) == 12
+    )
+
+    # Refreshing an identical starting file with identical observations is
+    # byte-for-byte stable, including the gzip header timestamp.
+    second_file = tmp_path / "second.csv.gz"
+    with gzip.open(second_file, "wt", newline="", encoding="utf-8") as stream:
+        writer = csv.writer(stream)
+        writer.writerow(["profile", "nodeid", "estimated_seconds", "sample_count"])
+        writer.writerow(
+            ["profile", "tests/test_sample.py::test_case[pass]", "100", "2"]
+        )
+        writer.writerow(
+            ["profile", "tests/test_sample.py::test_case[fail]", "100", "2"]
+        )
+    refresh_estimates(
+        observations,
+        [],
+        EstimateRefresh(
+            duration_file=second_file,
+            overhead_file=tmp_path / "second-overhead.csv",
+            summary_file=tmp_path / "second-summary.csv",
+        ),
+    )
+    assert second_file.read_bytes() == first_bytes
+
+
+def test_prune_scope_resolves_test_path_from_repository_root(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    node = CollectedNode.from_nodeid("tests/test_sample.py::test_case", 0)
+    manifest = tmp_path / "manifest.json"
+    manifest.write_text(
+        json.dumps(
+            {
+                "selection": {"sanity_test": False},
+                "test_path": "tests",
+                "plan": Plan(
+                    options=PlanningOptions(), nodes=(node,), units=()
+                ).to_dict(),
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(tmp_path)
+
+    assert _prune_scope(manifest) == {node.nodeid}

--- a/tests/test_sharding/test_io.py
+++ b/tests/test_sharding/test_io.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import os
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+import pytest
+
+from scripts.test_sharding import io
+
+
+def test_concurrent_atomic_writes_use_distinct_temporary_files(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    destination = tmp_path / "state.json"
+    replace_barrier = threading.Barrier(2)
+    real_replace = os.replace
+
+    def synchronized_replace(source: Path, target: Path) -> None:
+        replace_barrier.wait(timeout=5)
+        real_replace(source, target)
+
+    monkeypatch.setattr(io.os, "replace", synchronized_replace)
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        futures = [
+            executor.submit(io.atomic_write_bytes, destination, content)
+            for content in (b"first", b"second")
+        ]
+        for future in futures:
+            future.result(timeout=5)
+
+    assert destination.read_bytes() in {b"first", b"second"}

--- a/tests/test_sharding/test_junit.py
+++ b/tests/test_sharding/test_junit.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+import json
+import xml.etree.ElementTree as ET
+from collections import Counter
+from pathlib import Path
+
+from scripts.test_sharding.junit import (
+    SyntheticBatchMetadata,
+    annotate_batch_xml,
+    create_synthetic_batch_xml,
+    finalized_batch_outcomes,
+    validate_batch_xml,
+)
+
+
+def _write_batch(path: Path, nodeid: str, *, failed: bool = False) -> None:
+    failure = '<failure message="boom">details</failure>' if failed else ""
+    path.write_text(
+        f"""<?xml version="1.0" encoding="utf-8"?>
+<testsuites name="pytest tests"><testsuite name="pytest" tests="1" failures="{int(failed)}" errors="0" skipped="0" time="1.25">
+  <testcase classname="sample" name="case" time="1.25"><properties><property name="pytest_nodeid" value="{nodeid}"/></properties>{failure}</testcase>
+</testsuite></testsuites>
+""",
+        encoding="utf-8",
+    )
+
+
+def test_batch_is_final_only_when_exact_node_coverage_matches(tmp_path: Path) -> None:
+    report = tmp_path / "batch.xml"
+    _write_batch(report, "tests/test_sample.py::test_case")
+
+    valid = validate_batch_xml(report, ["tests/test_sample.py::test_case"])
+    missing = validate_batch_xml(report, ["tests/test_sample.py::test_other"])
+
+    assert valid.valid is True
+    assert valid.cases[0].outcome == "passed"
+    assert valid.cases[0].seconds == 1.25
+    assert missing.valid is False
+    assert "missing" in missing.diagnostics[0]
+
+
+def test_finalized_batch_outcomes_preserve_unknown_plugin_results(
+    tmp_path: Path,
+) -> None:
+    report = tmp_path / "batch.xml"
+    nodeid = "tests/test_sample.py::test_case"
+    _write_batch(report, nodeid)
+    report.with_name("batch.results.json").write_text(
+        json.dumps(
+            {
+                "results": [
+                    {
+                        "nodeid": nodeid,
+                        "outcome": "unknown",
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    outcomes, diagnostics = finalized_batch_outcomes(report, [nodeid])
+
+    assert diagnostics == ()
+    assert outcomes == Counter({"unknown": 1})
+
+
+def test_synthetic_timeout_report_is_self_describing(tmp_path: Path) -> None:
+    output = tmp_path / "synthetic.xml"
+    nodes = ["tests/test_sample.py::test_a", "tests/test_sample.py::test_b"]
+
+    create_synthetic_batch_xml(
+        output,
+        nodes,
+        SyntheticBatchMetadata(
+            policy="skip",
+            batch_id="batch-1",
+            unit_id="unit-1",
+            shard_index=0,
+            attempt_id="attempt-1",
+            profile="profile",
+        ),
+    )
+
+    validation = validate_batch_xml(output, nodes)
+    assert validation.valid is True
+    assert [case.outcome for case in validation.cases] == ["skipped", "skipped"]
+    root = ET.parse(output).getroot()
+    testcase_properties = {
+        prop.attrib["name"]: prop.attrib["value"]
+        for prop in root.findall(".//testcase/properties/property")
+    }
+    assert testcase_properties["synthetic"] == "true"
+
+
+def test_annotation_normalizes_a_bare_testsuite_root(tmp_path: Path) -> None:
+    report = tmp_path / "batch.xml"
+    report.write_text(
+        """<?xml version="1.0" encoding="utf-8"?>
+<testsuite name="pytest" tests="1" failures="0" errors="0" skipped="0" time="1">
+  <testcase classname="sample" name="case" time="1"><properties><property name="pytest_nodeid" value="tests/test_sample.py::test_case"/></properties></testcase>
+</testsuite>
+""",
+        encoding="utf-8",
+    )
+
+    annotate_batch_xml(report, {"batch_id": "batch-1"})
+
+    root = ET.parse(report).getroot()
+    assert root.tag == "testsuites"
+    assert root.find("./testsuite") is not None
+    properties = {
+        prop.attrib["name"]: prop.attrib["value"]
+        for prop in root.findall("./testsuite/properties/property")
+    }
+    assert properties["batch_id"] == "batch-1"

--- a/tests/test_sharding/test_observation_scan.py
+++ b/tests/test_sharding/test_observation_scan.py
@@ -1,0 +1,322 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import zipfile
+
+from scripts.test_sharding.estimates import DurationEstimate, EstimateBook
+from scripts.test_sharding.models import CollectedNode, PlanningOptions
+from scripts.test_sharding.planner import build_plan
+from scripts.test_sharding.scanner import (
+    scan_cleaned_artifact_dirs,
+    scan_observation_inputs,
+)
+from scripts.test_sharding.summary import batch_xml_path
+
+
+def _planning(**values: int) -> PlanningOptions:
+    return PlanningOptions(default_source_overhead_seconds=0, **values)
+
+
+def test_scanner_reads_authoritative_batch_xml(
+    tmp_path: Path,
+) -> None:
+    nodes = [
+        CollectedNode.from_nodeid("tests/test_sample.py::test_case[0]", 0),
+        CollectedNode.from_nodeid("tests/test_sample.py::test_case[1]", 1),
+    ]
+    estimates = EstimateBook(
+        [DurationEstimate("profile", node.nodeid, 1, 1) for node in nodes]
+    )
+    plan = build_plan(
+        nodes,
+        estimates,
+        _planning(
+            checkpoint_seconds=10,
+            target_unit_seconds=10,
+            default_case_seconds=5,
+            shard_count=1,
+        ),
+    )
+    run_dir = tmp_path / "junit"
+    manifest_path = run_dir / "manifest.json"
+    manifest_path.parent.mkdir(parents=True)
+    manifest_path.write_text(
+        json.dumps(
+            {
+                "source_git_sha": "run-identity",
+                "selection": {"sanity_test": False},
+                "test_path": "tests",
+                "plan": plan.to_dict(),
+            }
+        ),
+        encoding="utf-8",
+    )
+    unit = plan.units[0]
+    batch = unit.batches[0]
+    raw = batch_xml_path(run_dir, unit, batch)
+    raw.parent.mkdir(parents=True)
+    testcases = "".join(
+        f'<testcase classname="sample" name="case" time="{index + 1}"><properties>'
+        f'<property name="pytest_nodeid" value="{node.nodeid}"/>'
+        "</properties></testcase>"
+        for index, node in enumerate(nodes)
+    )
+    raw.write_text(
+        f'<testsuites><testsuite name="{batch.id}" tests="2" failures="0" '
+        f'errors="0" skipped="0" time="3"><properties><property name="batch_id" '
+        f'value="{batch.id}"/><property name="timing_profile" '
+        f'value="artifact-profile"/></properties>{testcases}</testsuite></testsuites>',
+        encoding="utf-8",
+    )
+    raw.with_name(f"{batch.id}.meta.json").write_text(
+        json.dumps({"attempt_id": "attempt-1"}), encoding="utf-8"
+    )
+    raw.with_name(f"{batch.id}.telemetry.json").write_text(
+        json.dumps(
+            {
+                "process_launch": 1,
+                "collection_complete": 2,
+                "first_case_start": 2.5,
+                "process_exit": 6,
+            }
+        ),
+        encoding="utf-8",
+    )
+    observations, overheads, diagnostics = scan_observation_inputs([run_dir])
+
+    assert diagnostics == []
+    assert [item.nodeid for item in observations] == [node.nodeid for node in nodes]
+    assert {item.profile for item in observations} == {"artifact-profile"}
+    assert [item.seconds for item in observations] == [1, 2]
+    assert len(overheads) == 1
+    assert overheads[0].profile == "artifact-profile"
+    assert overheads[0].process_startup_seconds == 1
+    assert overheads[0].source_warmup_seconds == 0.5
+
+
+def test_scanner_recovers_cleaned_gitlab_artifacts(
+    tmp_path: Path,
+) -> None:
+    long_node = (
+        "tests/test_sample.py::test_case[" + "parameter-value-" * 10 + "complete]"
+    )
+    log_only_node = "tests/test_log_only.py::test_failure[value]"
+    nodes = [
+        CollectedNode.from_nodeid(long_node, 0),
+        CollectedNode.from_nodeid(log_only_node, 1),
+    ]
+    estimates = EstimateBook(
+        [DurationEstimate("planning-profile", node.nodeid, 1, 1) for node in nodes]
+    )
+    plan = build_plan(
+        nodes,
+        estimates,
+        _planning(
+            checkpoint_seconds=10,
+            target_unit_seconds=10,
+            default_case_seconds=5,
+            shard_count=1,
+        ),
+    )
+    manifest_path = tmp_path / "manifest.json"
+    manifest_path.write_text(
+        json.dumps({"plan": plan.to_dict()}),
+        encoding="utf-8",
+    )
+    batch = next(
+        batch
+        for unit in plan.units
+        for batch in unit.batches
+        if long_node in batch.nodeids
+    )
+    artifact_dir = tmp_path / "artifacts"
+    artifact_dir.mkdir()
+    archive_path = artifact_dir / "job.zip"
+    truncated_node = long_node[:100]
+    xml = (
+        '<testsuites><testsuite name="pytest" tests="1" failures="0" '
+        'errors="0" skipped="0" time="2.5"><properties>'
+        f'<property name="batch_id" value="{batch.id}"/>'
+        '<property name="timing_profile" value="artifact-profile"/>'
+        '<property name="synthetic" value="false"/>'
+        "</properties>"
+        '<testcase classname="sample" name="truncated" time="2.5">'
+        "<properties>"
+        f'<property name="pytest_nodeid" value="{truncated_node}"/>'
+        "</properties></testcase></testsuite></testsuites>"
+    )
+    with zipfile.ZipFile(archive_path, "w") as archive:
+        archive.writestr("report/unit/batches/batch.xml", xml)
+    (artifact_dir / "job.log").write_text(
+        "PYTEST RESULT worker=0 batch=batch-incomplete outcome=failed "
+        f"duration=3.250s node={log_only_node}\n",
+        encoding="utf-8",
+    )
+
+    observations, overheads, diagnostics = scan_cleaned_artifact_dirs(
+        [artifact_dir],
+        manifest_path,
+    )
+
+    assert overheads == []
+    assert diagnostics == []
+    by_node = {item.nodeid: item for item in observations}
+    assert set(by_node) == {long_node, log_only_node}
+    assert by_node[long_node].profile == "artifact-profile"
+    assert by_node[long_node].seconds == 2.5
+    assert by_node[long_node].outcome == "passed"
+    assert by_node[log_only_node].seconds == 3.25
+    assert by_node[log_only_node].outcome == "failed"
+
+
+def test_scanner_omits_ambiguous_truncated_artifact_nodeids(
+    tmp_path: Path,
+) -> None:
+    shared_prefix = "tests/test_sample.py::test_case[" + "x" * 80
+    nodes = [
+        CollectedNode.from_nodeid(f"{shared_prefix}-one]", 0),
+        CollectedNode.from_nodeid(f"{shared_prefix}-two]", 1),
+    ]
+    plan = build_plan(
+        nodes,
+        EstimateBook(),
+        _planning(
+            checkpoint_seconds=10,
+            target_unit_seconds=10,
+            default_case_seconds=5,
+            shard_count=1,
+        ),
+    )
+    manifest_path = tmp_path / "manifest.json"
+    manifest_path.write_text(
+        json.dumps({"plan": plan.to_dict()}),
+        encoding="utf-8",
+    )
+    artifact_dir = tmp_path / "artifacts"
+    artifact_dir.mkdir()
+    xml = (
+        '<testsuites><testsuite name="pytest" tests="1" failures="0" '
+        'errors="0" skipped="0" time="1"><properties>'
+        '<property name="batch_id" value="batch-from-another-plan"/>'
+        '<property name="timing_profile" value="artifact-profile"/>'
+        "</properties>"
+        '<testcase classname="sample" name="test_case[" time="1">'
+        "<properties>"
+        f'<property name="pytest_nodeid" value="{shared_prefix}"/>'
+        "</properties></testcase></testsuite></testsuites>"
+    )
+    with zipfile.ZipFile(artifact_dir / "job.zip", "w") as archive:
+        archive.writestr("report/unit/batches/batch.xml", xml)
+
+    observations, overheads, diagnostics = scan_cleaned_artifact_dirs(
+        [artifact_dir],
+        manifest_path,
+    )
+
+    assert observations == []
+    assert overheads == []
+    assert len(diagnostics) == 1
+    assert "omitted 1 ambiguous testcase" in diagnostics[0]
+
+
+def test_scanner_combines_nodeid_and_testcase_name_prefixes(
+    tmp_path: Path,
+) -> None:
+    source = "tests/" + "long_directory/" * 8 + "test_sample.py"
+    selected = f"{source}::test_case[alpha-parameter]"
+    nodes = [
+        CollectedNode.from_nodeid(selected, 0),
+        CollectedNode.from_nodeid(f"{source}::test_case[beta-parameter]", 1),
+    ]
+    plan = build_plan(
+        nodes,
+        EstimateBook(),
+        _planning(
+            checkpoint_seconds=10,
+            target_unit_seconds=10,
+            default_case_seconds=5,
+            shard_count=1,
+        ),
+    )
+    manifest_path = tmp_path / "manifest.json"
+    manifest_path.write_text(
+        json.dumps({"plan": plan.to_dict()}),
+        encoding="utf-8",
+    )
+    artifact_dir = tmp_path / "artifacts"
+    artifact_dir.mkdir()
+    xml = (
+        '<testsuites><testsuite name="pytest" tests="1" failures="0" '
+        'errors="0" skipped="0" time="1"><properties>'
+        '<property name="batch_id" value="batch-from-another-plan"/>'
+        '<property name="timing_profile" value="artifact-profile"/>'
+        "</properties>"
+        '<testcase classname="sample" name="test_case[alpha" time="1">'
+        "<properties>"
+        f'<property name="pytest_nodeid" value="{source[:100]}"/>'
+        "</properties></testcase></testsuite></testsuites>"
+    )
+    with zipfile.ZipFile(artifact_dir / "job.zip", "w") as archive:
+        archive.writestr("report/unit/batches/batch.xml", xml)
+
+    observations, overheads, diagnostics = scan_cleaned_artifact_dirs(
+        [artifact_dir],
+        manifest_path,
+    )
+
+    assert overheads == []
+    assert diagnostics == []
+    assert [item.nodeid for item in observations] == [selected]
+
+
+def test_scanner_omits_prefix_resolution_collisions_across_batches(
+    tmp_path: Path,
+) -> None:
+    nodeid = "tests/test_sample.py::test_case[" + "x" * 100 + "]"
+    node = CollectedNode.from_nodeid(nodeid, 0)
+    plan = build_plan(
+        [node],
+        EstimateBook(),
+        _planning(
+            checkpoint_seconds=10,
+            target_unit_seconds=10,
+            default_case_seconds=5,
+            shard_count=1,
+        ),
+    )
+    manifest_path = tmp_path / "manifest.json"
+    manifest_path.write_text(
+        json.dumps({"plan": plan.to_dict()}),
+        encoding="utf-8",
+    )
+    artifact_dir = tmp_path / "artifacts"
+    artifact_dir.mkdir()
+    prefix = nodeid[:100]
+
+    def xml(batch_id: str) -> str:
+        return (
+            '<testsuites><testsuite name="pytest" tests="1" failures="0" '
+            'errors="0" skipped="0" time="1"><properties>'
+            f'<property name="batch_id" value="{batch_id}"/>'
+            '<property name="timing_profile" value="artifact-profile"/>'
+            "</properties>"
+            '<testcase classname="sample" name="test_case[" time="1">'
+            "<properties>"
+            f'<property name="pytest_nodeid" value="{prefix}"/>'
+            "</properties></testcase></testsuite></testsuites>"
+        )
+
+    with zipfile.ZipFile(artifact_dir / "job.zip", "w") as archive:
+        archive.writestr("report/batch-one.xml", xml("batch-from-old-plan-one"))
+        archive.writestr("report/batch-two.xml", xml("batch-from-old-plan-two"))
+
+    observations, overheads, diagnostics = scan_cleaned_artifact_dirs(
+        [artifact_dir],
+        manifest_path,
+    )
+
+    assert observations == []
+    assert overheads == []
+    assert len(diagnostics) == 1
+    assert "omitted 2 prefix-resolved observations" in diagnostics[0]

--- a/tests/test_sharding/test_planner.py
+++ b/tests/test_sharding/test_planner.py
@@ -1,0 +1,625 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts.test_sharding import planner
+from scripts.test_sharding.estimates import (
+    DurationEstimate,
+    DurationLookup,
+    EstimateBook,
+    OverheadEstimate,
+)
+from scripts.test_sharding.models import CollectedNode, Plan, PlanningOptions
+from scripts.test_sharding.planner import build_plan, capacity_metrics, validate_plan
+
+
+def _planning(**values: int) -> PlanningOptions:
+    return PlanningOptions(default_source_overhead_seconds=0, **values)
+
+
+def _node(
+    nodeid: str,
+    order: int,
+    *,
+    shard_group: str | None = None,
+    solo: bool = False,
+) -> CollectedNode:
+    return CollectedNode.from_nodeid(
+        nodeid,
+        order=order,
+        shard_group=shard_group,
+        solo=solo,
+    )
+
+
+def test_plan_is_reproducible_and_covers_each_node_once(tmp_path: Path) -> None:
+    nodes = [
+        _node("tests/a/test_alpha.py::test_a[0]", 0),
+        _node("tests/a/test_alpha.py::test_a[1]", 1),
+        _node("tests/a/test_alpha.py::test_b", 2),
+        _node("tests/b/test_beta.py::TestBeta::test_c", 3),
+    ]
+    estimates = EstimateBook(
+        [
+            DurationEstimate("b100-cu13", node.nodeid, seconds, 1)
+            for node, seconds in zip(nodes, [4.0, 3.0, 2.0, 1.0], strict=True)
+        ]
+    )
+    options = _planning(
+        checkpoint_seconds=5,
+        target_unit_seconds=7,
+        default_case_seconds=5,
+        shard_count=2,
+    )
+
+    first = build_plan(nodes, estimates, options)
+    second = build_plan(list(reversed(nodes)), estimates, options)
+
+    assert first.to_dict() == second.to_dict()
+    assert validate_plan(first) == []
+    assert sorted(
+        nodeid
+        for unit in first.units
+        for batch in unit.batches
+        for nodeid in batch.nodeids
+    ) == sorted(node.nodeid for node in nodes)
+    assert json.dumps(
+        first.to_dict(), sort_keys=True, separators=(",", ":")
+    ) == json.dumps(second.to_dict(), sort_keys=True, separators=(",", ":"))
+
+
+def test_runtime_defaults_are_one_second_per_case_and_thirty_per_source() -> None:
+    node = _node("tests/test_sample.py::test_case", 0)
+
+    plan = build_plan([node], EstimateBook(), PlanningOptions())
+
+    batch = plan.units[0].batches[0]
+    assert batch.overhead_ms == 30_000
+    assert batch.estimated_ms == 31_000
+    assert plan.fallback_counts == {"default-case": 1}
+
+
+def test_shard_group_is_atomic_even_when_it_exceeds_checkpoint() -> None:
+    nodes = [
+        _node("tests/test_grouped.py::test_grouped[0]", 0, shard_group="compile"),
+        _node("tests/test_grouped.py::test_grouped[1]", 1, shard_group="compile"),
+        _node("tests/test_grouped.py::test_other", 2),
+    ]
+    estimates = EstimateBook(
+        [DurationEstimate("profile", node.nodeid, 4.0, 1) for node in nodes]
+    )
+    plan = build_plan(
+        nodes,
+        estimates,
+        _planning(
+            checkpoint_seconds=5,
+            target_unit_seconds=10,
+            default_case_seconds=5,
+            shard_count=1,
+        ),
+    )
+
+    grouped_batches = [
+        batch
+        for unit in plan.units
+        for batch in unit.batches
+        if "tests/test_grouped.py::test_grouped[0]" in batch.nodeids
+    ]
+    assert len(grouped_batches) == 1
+    assert grouped_batches[0].nodeids == (
+        "tests/test_grouped.py::test_grouped[0]",
+        "tests/test_grouped.py::test_grouped[1]",
+    )
+    assert grouped_batches[0].oversized is True
+
+
+def test_solo_source_is_one_batch_and_one_logical_unit() -> None:
+    nodes = [
+        _node("tests/test_solo.py::test_case[0]", 0, solo=True),
+        _node("tests/test_solo.py::test_case[1]", 1, solo=True),
+        _node("tests/test_regular.py::test_case", 2),
+    ]
+    plan = build_plan(
+        nodes,
+        EstimateBook(
+            [DurationEstimate("profile", node.nodeid, 4.0, 1) for node in nodes]
+        ),
+        _planning(
+            checkpoint_seconds=5,
+            target_unit_seconds=20,
+            shard_count=1,
+        ),
+    )
+
+    solo_units = [
+        unit
+        for unit in plan.units
+        if any(batch.source_file == "tests/test_solo.py" for batch in unit.batches)
+    ]
+    assert len(solo_units) == 1
+    assert len(solo_units[0].batches) == 1
+    assert solo_units[0].batches[0].nodeids == (
+        "tests/test_solo.py::test_case[0]",
+        "tests/test_solo.py::test_case[1]",
+    )
+    assert Plan.from_dict(plan.to_dict()) == plan
+
+
+def test_capacity_metrics_account_for_solo_exclusivity() -> None:
+    nodes = [
+        _node("tests/test_solo.py::test_case", 0, solo=True),
+        _node("tests/test_regular_a.py::test_case", 1),
+        _node("tests/test_regular_b.py::test_case", 2),
+    ]
+    plan = build_plan(
+        nodes,
+        EstimateBook(
+            [
+                DurationEstimate("profile", nodes[0].nodeid, 10.0, 1),
+                DurationEstimate("profile", nodes[1].nodeid, 8.0, 1),
+                DurationEstimate("profile", nodes[2].nodeid, 8.0, 1),
+            ]
+        ),
+        _planning(
+            checkpoint_seconds=5,
+            target_unit_seconds=5,
+            shard_count=1,
+        ),
+    )
+
+    metrics = capacity_metrics(plan, {0: 2}, deadline_seconds=18)
+
+    assert metrics["total_estimated_load_ms"] == 26000
+    assert metrics["estimated_worker_load_ms"] == {"0": [18000, 18000]}
+    assert metrics["estimated_makespan_ms"] == 18000
+    assert metrics["required_workers_by_shard"] == {"0": 2}
+    assert capacity_metrics(plan, deadline_seconds=17)["required_workers_by_shard"] == {
+        "0": None
+    }
+
+
+def test_unknown_duration_uses_documented_fallback_order_and_floor() -> None:
+    book = EstimateBook(
+        [
+            DurationEstimate("current", "tests/test_x.py::test_known[a]", 1.0, 2),
+            DurationEstimate("current", "tests/test_x.py::test_known[b]", 9.0, 2),
+            DurationEstimate("other", "tests/test_x.py::test_new", 7.0, 3),
+        ]
+    )
+
+    exact_other = book.lookup(
+        "tests/test_x.py::test_new", "current", unknown_floor_seconds=5
+    )
+    same_function = book.lookup(
+        "tests/test_x.py::test_known[c]", "current", unknown_floor_seconds=5
+    )
+    suite_history = book.lookup(
+        "tests/new/test_none.py::test_none", "current", unknown_floor_seconds=5
+    )
+    no_history = EstimateBook().lookup(
+        "tests/new/test_none.py::test_none", "current", unknown_floor_seconds=5
+    )
+
+    assert exact_other.seconds == 7.0
+    assert exact_other.source == "exact-other-profile"
+    assert same_function.seconds == 9.0
+    assert same_function.source == "function-current-profile"
+    assert suite_history.seconds == 5.0
+    assert suite_history.source == "suite-mean-current-profile"
+    assert no_history.seconds == 5.0
+    assert no_history.source == "unknown-floor"
+
+
+def test_sparse_function_and_source_history_uses_profile_mean() -> None:
+    durations = [
+        DurationEstimate("current", "tests/test_x.py::test_case[a]", 1.0, 1),
+        DurationEstimate("current", "tests/test_x.py::test_case[b]", 9.0, 1),
+        *[
+            DurationEstimate(
+                "current",
+                f"tests/other/test_case_{index}.py::test_case",
+                1.0,
+                1,
+            )
+            for index in range(8)
+        ],
+    ]
+    book = EstimateBook(durations)
+    collected = [
+        "tests/test_x.py::test_case[a]",
+        "tests/test_x.py::test_case[b]",
+        *[f"tests/test_x.py::test_case[{index}]" for index in range(8)],
+        *[f"tests/other/test_case_{index}.py::test_case" for index in range(10)],
+    ]
+
+    lookup = book.lookup(
+        "tests/test_x.py::test_case[missing]",
+        "current",
+        unknown_floor_seconds=1,
+        coverage=book.coverage(collected),
+    )
+
+    assert lookup == DurationLookup(1.8, "suite-mean-current-profile")
+
+
+def test_well_covered_function_history_keeps_conservative_p90() -> None:
+    book = EstimateBook(
+        [
+            DurationEstimate(
+                "current",
+                f"tests/test_x.py::test_case[{index}]",
+                float(index + 1),
+                1,
+            )
+            for index in range(9)
+        ]
+    )
+
+    lookup = book.lookup(
+        "tests/test_x.py::test_case[missing]",
+        "current",
+        unknown_floor_seconds=1,
+        coverage=book.coverage(
+            [
+                *[f"tests/test_x.py::test_case[{index}]" for index in range(9)],
+                "tests/test_x.py::test_case[missing]",
+            ]
+        ),
+    )
+
+    assert lookup == DurationLookup(9.0, "function-current-profile")
+
+
+def test_unknown_profile_prefers_b300_duration_fallbacks() -> None:
+    known_node = "tests/test_x.py::test_case[known]"
+    book = EstimateBook(
+        [
+            DurationEstimate("sm103-cuda12", known_node, 4.0, 1),
+            DurationEstimate("sm103-cuda13", known_node, 6.0, 1),
+            DurationEstimate("unrelated-profile", known_node, 100.0, 1),
+        ]
+    )
+
+    exact = book.lookup(known_node, "new-profile", unknown_floor_seconds=5)
+    same_function = book.lookup(
+        "tests/test_x.py::test_case[new]",
+        "new-profile",
+        unknown_floor_seconds=5,
+    )
+
+    assert exact == DurationLookup(6.0, "exact-other-profile")
+    assert same_function == DurationLookup(6.0, "function-other-profile")
+
+
+def test_unknown_profile_prefers_b300_overhead_fallbacks() -> None:
+    source_file = "tests/test_x.py"
+    book = EstimateBook(
+        overheads=[
+            OverheadEstimate("sm103-cuda12", source_file, 3.0, 2.0, 1),
+            OverheadEstimate("sm103-cuda13", source_file, 5.0, 3.0, 1),
+            OverheadEstimate("unrelated-profile", source_file, 50.0, 50.0, 1),
+        ]
+    )
+
+    assert book.overhead_ms(source_file, "new-profile") == 8000
+
+
+def test_missing_source_overhead_uses_overall_median() -> None:
+    book = EstimateBook(
+        overheads=[
+            OverheadEstimate("current", "tests/test_a.py", 1.0, 2.0, 1),
+            OverheadEstimate("current", "tests/test_b.py", 2.0, 5.0, 10),
+            OverheadEstimate("current", "tests/test_c.py", 8.0, 12.0, 100),
+            OverheadEstimate("other", "tests/test_d.py", 50.0, 50.0, 1),
+        ]
+    )
+
+    assert book.overhead_ms("tests/test_new.py", "current") == 13500
+
+
+def test_missing_profile_overhead_uses_overall_median() -> None:
+    book = EstimateBook(
+        overheads=[
+            OverheadEstimate("sm103-cuda12", "tests/test_a.py", 1.0, 3.0, 1),
+            OverheadEstimate("sm103-cuda13", "tests/test_b.py", 4.0, 6.0, 1),
+            OverheadEstimate("unrelated-profile", "tests/test_c.py", 50.0, 50.0, 1),
+        ]
+    )
+
+    assert book.overhead_ms("tests/test_new.py", "new-profile") == 10000
+
+
+def test_b300_preference_only_applies_when_target_profile_is_absent() -> None:
+    requested_node = "tests/test_x.py::test_case[requested]"
+    book = EstimateBook(
+        [
+            DurationEstimate(
+                "target-profile",
+                "tests/test_x.py::test_case[existing]",
+                1.0,
+                1,
+            ),
+            DurationEstimate("sm103-cuda13", requested_node, 6.0, 1),
+            DurationEstimate("unrelated-profile", requested_node, 100.0, 1),
+        ]
+    )
+
+    lookup = book.lookup(
+        requested_node,
+        "target-profile",
+        unknown_floor_seconds=5,
+    )
+
+    assert lookup == DurationLookup(100.0, "exact-other-profile")
+
+
+def test_unknown_profile_uses_available_history_when_b300_is_absent() -> None:
+    requested_node = "tests/test_x.py::test_case[requested]"
+    book = EstimateBook([DurationEstimate("available-profile", requested_node, 7.0, 1)])
+
+    lookup = book.lookup(
+        requested_node,
+        "new-profile",
+        unknown_floor_seconds=5,
+    )
+
+    assert lookup == DurationLookup(7.0, "exact-other-profile")
+
+
+def test_plan_records_each_fallback_source_and_worker_aware_capacity() -> None:
+    nodes = [
+        _node("tests/test_x.py::test_known[a]", 0),
+        _node("tests/test_x.py::test_new", 1),
+    ]
+    book = EstimateBook([DurationEstimate("profile", nodes[0].nodeid, 4.0, 1)])
+    plan = build_plan(
+        nodes,
+        book,
+        _planning(
+            checkpoint_seconds=5,
+            target_unit_seconds=5,
+            default_case_seconds=2,
+            shard_count=1,
+        ),
+    )
+
+    assert plan.fallback_sources == {"tests/test_x.py::test_new": "default-case"}
+    one_worker = capacity_metrics(plan, {0: 1}, deadline_seconds=5)
+    two_workers = capacity_metrics(plan, {0: 2}, deadline_seconds=5)
+    assert one_worker["total_estimated_load_ms"] == 6000
+    assert two_workers["estimated_makespan_ms"] < one_worker["estimated_makespan_ms"]
+    assert one_worker["required_workers_by_shard"] == {"0": 2}
+
+
+def test_high_overhead_source_expands_checkpoint_to_avoid_process_churn() -> None:
+    nodes = [
+        _node(f"tests/test_expensive.py::test_case[{index}]", index)
+        for index in range(100)
+    ]
+    plan = build_plan(
+        nodes,
+        EstimateBook(
+            [DurationEstimate("profile", node.nodeid, 1.0, 1) for node in nodes],
+            [
+                OverheadEstimate(
+                    "profile",
+                    "tests/test_expensive.py",
+                    process_startup_seconds=5.0,
+                    source_warmup_seconds=5.0,
+                    sample_count=1,
+                )
+            ],
+        ),
+        _planning(
+            checkpoint_seconds=20,
+            target_unit_seconds=1000,
+            shard_count=1,
+        ),
+    )
+
+    batches = [batch for unit in plan.units for batch in unit.batches]
+    assert len(batches) == 1
+    assert batches[0].estimated_ms == 110_000
+
+
+def test_source_process_count_is_capped_when_overhead_is_unknown() -> None:
+    nodes = [
+        _node(f"tests/test_many.py::test_case[{index}]", index) for index in range(100)
+    ]
+    plan = build_plan(
+        nodes,
+        EstimateBook(
+            [DurationEstimate("profile", node.nodeid, 1.0, 1) for node in nodes]
+        ),
+        _planning(
+            checkpoint_seconds=1,
+            target_unit_seconds=100,
+            shard_count=1,
+        ),
+    )
+
+    batches = [batch for unit in plan.units for batch in unit.batches]
+    assert len(batches) == planner._MAX_BATCHES_PER_TARGET_UNIT
+    assert all(len(batch.nodeids) == 25 for batch in batches)
+
+
+def test_source_affinity_avoids_split_without_material_makespan_gain() -> None:
+    durations = {
+        "tests/test_c.py": (4.0, 4.0),
+        "tests/test_b.py": (2.0, 2.0),
+        "tests/test_a.py": (1.0, 1.0),
+    }
+    nodes = []
+    estimates = []
+    for source, seconds_values in durations.items():
+        for seconds in seconds_values:
+            node = _node(
+                f"{source}::test_case[{len(nodes)}]",
+                len(nodes),
+            )
+            nodes.append(node)
+            estimates.append(DurationEstimate("profile", node.nodeid, seconds, 1))
+    plan = build_plan(
+        nodes,
+        EstimateBook(estimates),
+        _planning(
+            checkpoint_seconds=1,
+            target_unit_seconds=4,
+            shard_count=2,
+        ),
+    )
+
+    c_shards = {
+        unit.shard_index
+        for unit in plan.units
+        if unit.batches[0].source_file == "tests/test_c.py"
+    }
+    assert len(c_shards) == 1
+    assert max(capacity_metrics(plan)["estimated_shard_load_ms"].values()) == 8000
+
+
+def test_source_affinity_keeps_balanced_sources_on_one_external_shard() -> None:
+    nodes = [
+        *[_node(f"tests/test_a.py::test_case[{index}]", index) for index in range(4)],
+        _node("tests/test_b.py::test_case", 4),
+        _node("tests/test_c.py::test_case", 5),
+    ]
+    estimates = EstimateBook(
+        [
+            DurationEstimate(
+                "profile",
+                node.nodeid,
+                6.0 if node.source_file == "tests/test_a.py" else 12.0,
+                1,
+            )
+            for node in nodes
+        ]
+    )
+
+    plan = build_plan(
+        nodes,
+        estimates,
+        _planning(
+            checkpoint_seconds=5,
+            target_unit_seconds=6,
+            shard_count=2,
+        ),
+    )
+
+    shards_by_source: dict[str, set[int]] = {}
+    for unit in plan.units:
+        sources = {batch.source_file for batch in unit.batches}
+        assert len(sources) == 1
+        shards_by_source.setdefault(sources.pop(), set()).add(unit.shard_index)
+    assert shards_by_source["tests/test_a.py"] in ({0}, {1})
+    shard_loads = capacity_metrics(plan)["estimated_shard_load_ms"]
+    assert sorted(shard_loads.values()) == [24_000, 24_000]
+
+
+def test_source_affinity_splits_source_that_exceeds_one_shard_share() -> None:
+    nodes = [
+        *[_node(f"tests/test_a.py::test_case[{index}]", index) for index in range(6)],
+        _node("tests/test_b.py::test_case", 6),
+        _node("tests/test_c.py::test_case", 7),
+    ]
+    plan = build_plan(
+        nodes,
+        EstimateBook(
+            [
+                DurationEstimate(
+                    "profile",
+                    node.nodeid,
+                    6.0 if node.source_file == "tests/test_a.py" else 12.0,
+                    1,
+                )
+                for node in nodes
+            ]
+        ),
+        _planning(
+            checkpoint_seconds=5,
+            target_unit_seconds=6,
+            shard_count=2,
+        ),
+    )
+
+    a_shards = {
+        unit.shard_index
+        for unit in plan.units
+        if unit.batches[0].source_file == "tests/test_a.py"
+    }
+    assert a_shards == {0, 1}
+
+
+def test_soft_target_search_does_not_retry_every_intermediate_bin_count(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls = 0
+    original = planner._lpt_bins
+
+    def counted(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(planner, "_lpt_bins", counted)
+
+    bins = planner._pack_with_soft_target(
+        list(range(64)),
+        100,
+        lambda _item: 51,
+        str,
+    )
+
+    assert len(bins) == 64
+    assert calls <= 8
+
+
+def test_plan_serialization_stores_each_nodeid_once() -> None:
+    nodes = [
+        _node("tests/test_x.py::test_known[a-very-long-parameter]", 0),
+        _node("tests/test_x.py::test_new[another-very-long-parameter]", 1),
+    ]
+    book = EstimateBook([DurationEstimate("profile", nodes[0].nodeid, 1.0, 1)])
+    plan = build_plan(
+        nodes,
+        book,
+        _planning(
+            checkpoint_seconds=5,
+            target_unit_seconds=5,
+            default_case_seconds=2,
+            shard_count=1,
+        ),
+    )
+
+    serialized = plan.to_dict()
+    encoded = json.dumps(serialized, sort_keys=True, separators=(",", ":"))
+
+    assert Plan.from_dict(serialized) == plan
+    assert serialized["schema_version"] == 4
+    assert serialized["nodeids"] == [node.nodeid for node in nodes]
+    assert "nodes" not in serialized
+    assert "batch_ids" not in encoded
+    assert all(encoded.count(node.nodeid) == 1 for node in nodes)
+
+
+def test_plan_reader_accepts_schema_one_manifests() -> None:
+    nodes = [_node("tests/test_x.py::test_case", 0)]
+    plan = build_plan(
+        nodes,
+        EstimateBook([DurationEstimate("profile", nodes[0].nodeid, 1.0, 1)]),
+        _planning(),
+    )
+    legacy = {
+        "schema_version": 1,
+        "algorithm_version": "lpt-ms-v2",
+        "options": plan.options.to_dict(),
+        "nodes": [node.to_dict() for node in plan.nodes],
+        "units": [unit.to_dict() for unit in plan.units],
+        "fallback_counts": plan.fallback_counts,
+        "fallback_sources": plan.fallback_sources,
+    }
+
+    assert Plan.from_dict(legacy) == plan

--- a/tests/test_sharding/test_processes.py
+++ b/tests/test_sharding/test_processes.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import os
+import signal
+import subprocess
+import sys
+import time
+from contextlib import suppress
+
+from scripts.test_sharding.processes import terminate_process_group
+
+
+def _spawn_process_group() -> subprocess.Popen[str]:
+    return subprocess.Popen(
+        [
+            sys.executable,
+            "-c",
+            (
+                "import os, signal, subprocess, sys, time; "
+                "signal.signal(signal.SIGTERM, lambda *_: sys.exit(0)); "
+                "child = subprocess.Popen([sys.executable, '-c', "
+                "'import signal,time; signal.signal(signal.SIGTERM, signal.SIG_IGN); "
+                'print("ready", flush=True); time.sleep(30)\'], '
+                "stdout=subprocess.PIPE, text=True); "
+                "child.stdout.readline(); "
+                "print(child.pid, flush=True); "
+                "time.sleep(30)"
+            ),
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        start_new_session=True,
+        text=True,
+    )
+
+
+def _child_pid(process: subprocess.Popen[str]) -> int:
+    assert process.stdout is not None
+    return int(process.stdout.readline().strip())
+
+
+def _kill_if_alive(pid: int) -> None:
+    with suppress(ProcessLookupError):
+        os.kill(pid, signal.SIGKILL)
+
+
+def test_termination_grace_applies_to_descendants_after_leader_exits() -> None:
+    process = _spawn_process_group()
+    child_pid = _child_pid(process)
+    started = time.monotonic()
+    try:
+        termination_signal = terminate_process_group(process, grace_seconds=0.25)
+    finally:
+        _kill_if_alive(child_pid)
+        _kill_if_alive(process.pid)
+        process.wait(timeout=5)
+
+    elapsed = time.monotonic() - started
+    assert elapsed >= 0.20
+    assert elapsed < 2
+    assert termination_signal == "SIGKILL"
+
+
+def test_termination_cleans_group_after_leader_already_exited() -> None:
+    process = _spawn_process_group()
+    child_pid = _child_pid(process)
+    os.kill(process.pid, signal.SIGTERM)
+    process.wait(timeout=5)
+    try:
+        termination_signal = terminate_process_group(process, grace_seconds=0.05)
+    finally:
+        _kill_if_alive(child_pid)
+
+    assert termination_signal == "SIGKILL"

--- a/tests/test_sharding/test_pytest_plugin.py
+++ b/tests/test_sharding/test_pytest_plugin.py
@@ -1,0 +1,168 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+from scripts.test_sharding.progress import decode_pytest_event
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _pytest(tmp_path: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(REPO_ROOT)
+    return subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pytest",
+            "-q",
+            "-p",
+            "scripts.test_sharding.pytest_plugin",
+            *args,
+        ],
+        cwd=tmp_path,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def test_plugin_collects_groups_and_selects_exact_nodeids(tmp_path: Path) -> None:
+    test_file = tmp_path / "test_sample.py"
+    test_file.write_text(
+        """\
+import pytest
+
+@pytest.mark.shard_group("shared-compile")
+@pytest.mark.parametrize("value", [1, 2])
+def test_grouped(value):
+    assert value > 0
+
+def test_unselected():
+    raise AssertionError("must not execute")
+""",
+        encoding="utf-8",
+    )
+    collection_path = tmp_path / "collection.json"
+
+    collected = _pytest(
+        tmp_path,
+        "--collect-only",
+        f"--flashinfer-collection-json={collection_path}",
+        str(test_file),
+    )
+
+    assert collected.returncode == 0, collected.stdout + collected.stderr
+    collection = json.loads(collection_path.read_text(encoding="utf-8"))
+    grouped = [item for item in collection["nodes"] if "test_grouped" in item["nodeid"]]
+    assert len(grouped) == 2
+    assert {item["shard_group"] for item in grouped} == {"shared-compile"}
+
+    selected_node = grouped[1]["nodeid"]
+    selection_path = tmp_path / "selection.json"
+    selection_path.write_text(json.dumps([selected_node]), encoding="utf-8")
+    junit_path = tmp_path / "batch.xml"
+    executed = _pytest(
+        tmp_path,
+        f"--flashinfer-node-file={selection_path}",
+        f"--junitxml={junit_path}",
+        str(test_file),
+    )
+
+    assert executed.returncode == 0, executed.stdout + executed.stderr
+    testcases = ET.parse(junit_path).getroot().findall(".//testcase")
+    assert len(testcases) == 1
+    properties = {
+        prop.attrib["name"]: prop.attrib.get("value", "")
+        for prop in testcases[0].findall("./properties/property")
+    }
+    assert properties["pytest_nodeid"] == selected_node
+
+
+def test_plugin_promotes_solo_and_long_running_markers_to_their_sources(
+    tmp_path: Path,
+) -> None:
+    solo_file = tmp_path / "test_solo.py"
+    solo_file.write_text(
+        """\
+import pytest
+
+@pytest.mark.solo
+def test_marked():
+    pass
+
+def test_same_source():
+    pass
+""",
+        encoding="utf-8",
+    )
+    long_file = tmp_path / "test_long.py"
+    long_file.write_text(
+        """\
+import pytest
+
+@pytest.mark.long_running
+def test_marked():
+    pass
+
+def test_same_source():
+    pass
+""",
+        encoding="utf-8",
+    )
+    collection_path = tmp_path / "collection.json"
+
+    collected = _pytest(
+        tmp_path,
+        "--strict-markers",
+        "--collect-only",
+        f"--flashinfer-collection-json={collection_path}",
+        str(solo_file),
+        str(long_file),
+    )
+
+    assert collected.returncode == 0, collected.stdout + collected.stderr
+    collection = json.loads(collection_path.read_text(encoding="utf-8"))
+    solo_nodes = [
+        node for node in collection["nodes"] if "test_solo.py::" in node["nodeid"]
+    ]
+    long_nodes = [
+        node for node in collection["nodes"] if "test_long.py::" in node["nodeid"]
+    ]
+    assert len(solo_nodes) == 2
+    assert len(long_nodes) == 2
+    assert all(node["solo"] is True for node in solo_nodes)
+    assert all(node["long_running"] is False for node in solo_nodes)
+    assert all(node["long_running"] is True for node in long_nodes)
+    assert all(node["solo"] is False for node in long_nodes)
+    assert "PytestUnknownMarkWarning" not in collected.stdout + collected.stderr
+
+
+def test_plugin_emits_detailed_failure_event_as_soon_as_report_is_available(
+    tmp_path: Path,
+) -> None:
+    test_file = tmp_path / "test_failure.py"
+    test_file.write_text(
+        "def test_failure():\n    assert 1 == 2, 'specific failure detail'\n",
+        encoding="utf-8",
+    )
+
+    result = _pytest(tmp_path, str(test_file))
+
+    assert result.returncode == 1
+    events = [
+        event
+        for line in result.stdout.splitlines()
+        if (event := decode_pytest_event(line)) is not None
+    ]
+    failure = next(event for event in events if event["event"] == "failure")
+    assert failure["nodeid"].endswith("test_failure.py::test_failure")
+    assert failure["phase"] == "call"
+    assert "specific failure detail" in failure["diagnostic"]

--- a/tests/test_sharding/test_runner_cli.py
+++ b/tests/test_sharding/test_runner_cli.py
@@ -505,6 +505,64 @@ def test_slow_collection_reports_a_live_heartbeat(
     assert f"test_path={suite}" in output
 
 
+def test_collection_isolates_sm90_pull_multirank_modules(tmp_path: Path) -> None:
+    suite = tmp_path / "suite"
+    suite.mkdir()
+    sm100 = suite / "sm100"
+    sm100.mkdir()
+    (sm100 / "common.py").write_text("BACKEND = 'sm100'\n", encoding="utf-8")
+    sm90 = suite / "sm90"
+    sm90.mkdir()
+    (sm90 / "common.py").write_text("BACKEND = 'sm90'\n", encoding="utf-8")
+    (suite / "test_aaa_sm100.py").write_text(
+        """\
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent / "sm100"))
+import common
+
+assert common.BACKEND == "sm100"
+
+def test_sm100():
+    pass
+""",
+        encoding="utf-8",
+    )
+    isolated = suite / "test_moe_ep_sm90_pull_fp8_mega_multirank.py"
+    isolated.write_text(
+        """\
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent / "sm90"))
+import common
+
+if common.BACKEND != "sm90":
+    raise RuntimeError("SM100 and SM90 common modules cannot share one process")
+
+def test_sm90():
+    pass
+""",
+        encoding="utf-8",
+    )
+
+    nodes = runner._collect_nodes(REPO_ROOT, suite, 15, 0)
+
+    assert [node["nodeid"] for node in nodes] == [
+        "test_aaa_sm100.py::test_sm100",
+        f"{isolated.name}::test_sm90",
+    ]
+    assert [node["order"] for node in nodes] == [0, 1]
+
+    isolated_nodes = runner._collect_nodes(REPO_ROOT, isolated, 15, 0)
+
+    assert [node["nodeid"] for node in isolated_nodes] == [
+        f"{isolated.name}::test_sm90"
+    ]
+    assert [node["order"] for node in isolated_nodes] == [0]
+
+
 def test_collection_termination_uses_configured_grace(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_sharding/test_runner_cli.py
+++ b/tests/test_sharding/test_runner_cli.py
@@ -84,11 +84,12 @@ def test_worker_unit_stealing_drains_queued_units_exactly_once() -> None:
     assert all(work.unfinished_tasks == 0 for work in work_by_worker)
 
 
-def test_compatibility_defaults_use_file_sized_units_without_time_limits(
+def test_compatibility_defaults_use_file_sized_units_with_failure_timeout(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.delenv("UNIT_TEST_DEADLINE_SECONDS", raising=False)
     monkeypatch.delenv("UNIT_TEST_TIMEOUT_SECONDS", raising=False)
+    monkeypatch.delenv("UNIT_TEST_TIMEOUT_POLICY", raising=False)
     monkeypatch.delenv("UNIT_TEST_DEFAULT_CASE_SECONDS", raising=False)
     monkeypatch.delenv("UNIT_TEST_DEFAULT_SOURCE_OVERHEAD_SECONDS", raising=False)
     monkeypatch.delenv("UNIT_TEST_DURATION_ESTIMATES", raising=False)
@@ -100,7 +101,8 @@ def test_compatibility_defaults_use_file_sized_units_without_time_limits(
     args = unit_test_runner._parser().parse_args(["run"])
 
     assert args.deadline_seconds == 0
-    assert args.unit_timeout_seconds == 0
+    assert args.unit_timeout_seconds == 7_200
+    assert args.timeout_policy == "fail"
     assert args.default_case_seconds == 1
     assert args.default_source_overhead_seconds == 30
     assert args.duration_estimates is None

--- a/tests/test_sharding/test_runner_cli.py
+++ b/tests/test_sharding/test_runner_cli.py
@@ -1,0 +1,1623 @@
+from __future__ import annotations
+
+import json
+import os
+import queue
+import select
+import shlex
+import subprocess
+import sys
+import threading
+import time
+import xml.etree.ElementTree as ET
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+import pytest
+
+from scripts import unit_test_runner
+from scripts.test_sharding import runner
+from scripts.test_sharding.models import (
+    Batch,
+    CollectedNode,
+    Plan,
+    PlanningOptions,
+    Unit,
+)
+from scripts.test_sharding.state import AttemptSettings
+from scripts.test_sharding.workers import BatchExecution
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+RUNNER = REPO_ROOT / "scripts" / "unit_test_runner.py"
+
+
+def _queue_test_unit(identifier: str) -> Unit:
+    return Unit(
+        id=identifier,
+        batches=(),
+        estimated_ms=1,
+        oversized=False,
+    )
+
+
+def test_worker_unit_selection_prefers_local_queue_before_stealing() -> None:
+    work_by_worker = [queue.Queue() for _ in range(2)]
+    work_by_worker[0].put(_queue_test_unit("donor"))
+    work_by_worker[1].put(_queue_test_unit("local"))
+
+    local_queue, local_unit = runner._next_worker_unit(work_by_worker, 1)
+
+    assert local_queue is work_by_worker[1]
+    assert local_unit.id == "local"
+
+    donor_queue, donor_unit = runner._next_worker_unit(work_by_worker, 1)
+
+    assert donor_queue is work_by_worker[0]
+    assert donor_unit.id == "donor"
+
+
+def test_worker_unit_stealing_drains_queued_units_exactly_once() -> None:
+    work_by_worker = [queue.Queue() for _ in range(4)]
+    expected = [f"unit-{index}" for index in range(40)]
+    for index, identifier in enumerate(expected):
+        work_by_worker[index % 2].put(_queue_test_unit(identifier))
+
+    def drain(worker_index: int) -> list[str]:
+        completed = []
+        while True:
+            try:
+                work, unit = runner._next_worker_unit(work_by_worker, worker_index)
+            except queue.Empty:
+                return completed
+            completed.append(unit.id)
+            work.task_done()
+
+    with ThreadPoolExecutor(max_workers=4) as executor:
+        completed = [
+            identifier
+            for worker_units in executor.map(drain, range(4))
+            for identifier in worker_units
+        ]
+
+    assert sorted(completed) == sorted(expected)
+    assert all(work.unfinished_tasks == 0 for work in work_by_worker)
+
+
+def test_compatibility_defaults_use_file_sized_units_without_time_limits(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("UNIT_TEST_DEADLINE_SECONDS", raising=False)
+    monkeypatch.delenv("UNIT_TEST_TIMEOUT_SECONDS", raising=False)
+    monkeypatch.delenv("UNIT_TEST_DEFAULT_CASE_SECONDS", raising=False)
+    monkeypatch.delenv("UNIT_TEST_DEFAULT_SOURCE_OVERHEAD_SECONDS", raising=False)
+    monkeypatch.delenv("UNIT_TEST_DURATION_ESTIMATES", raising=False)
+    monkeypatch.delenv("UNIT_TEST_OVERHEAD_ESTIMATES", raising=False)
+    monkeypatch.delenv("UNIT_TEST_SHARD_COUNT", raising=False)
+    monkeypatch.delenv("UNIT_TEST_CHECKPOINT_SECONDS", raising=False)
+    monkeypatch.delenv("UNIT_TEST_TARGET_SECONDS", raising=False)
+
+    args = unit_test_runner._parser().parse_args(["run"])
+
+    assert args.deadline_seconds == 0
+    assert args.unit_timeout_seconds == 0
+    assert args.default_case_seconds == 1
+    assert args.default_source_overhead_seconds == 30
+    assert args.duration_estimates is None
+    assert args.overhead_estimates is None
+    assert args.shard_count == 1
+    assert args.checkpoint_seconds == 1_000_000
+    assert args.target_unit_seconds == 1_000_000
+    assert PlanningOptions().checkpoint_seconds == 1_000_000
+    assert PlanningOptions().target_unit_seconds == 1_000_000
+
+
+def test_shard_count_precedence_is_cli_then_environment_then_one(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("UNIT_TEST_SHARD_COUNT", raising=False)
+    assert unit_test_runner._parser().parse_args(["run"]).shard_count == 1
+
+    monkeypatch.setenv("UNIT_TEST_SHARD_COUNT", "4")
+    assert unit_test_runner._parser().parse_args(["run"]).shard_count == 4
+    assert (
+        unit_test_runner._parser().parse_args(["run", "--shard-count", "2"]).shard_count
+        == 2
+    )
+
+
+def test_explicit_zero_deadline_is_disabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("UNIT_TEST_DEADLINE_SECONDS", "60")
+
+    args = unit_test_runner._parser().parse_args(["run", "--deadline-seconds", "0"])
+
+    assert args.deadline_seconds == 0
+    clock = runner.DeadlineClock(started_at=100.0, limit_seconds=args.deadline_seconds)
+    assert clock.status_fields().endswith("deadline=disabled")
+
+
+def test_empty_test_path_environment_uses_default_suite(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("TEST_PATH", "")
+
+    args = unit_test_runner._parser().parse_args(["run"])
+
+    assert args.test_path == Path("tests/")
+
+
+@pytest.mark.parametrize(
+    ("name", "value"),
+    [
+        ("UNIT_TEST_CHECKPOINT_SECONDS", "0"),
+        ("UNIT_TEST_SHARD_COUNT", "0"),
+        ("UNIT_TEST_WORKERS", "0"),
+        ("UNIT_TEST_DEADLINE_SECONDS", "-1"),
+        ("UNIT_TEST_TIMEOUT_POLICY", "bogus"),
+    ],
+)
+def test_invalid_cli_environment_defaults_fail_argument_preflight(
+    monkeypatch: pytest.MonkeyPatch,
+    name: str,
+    value: str,
+) -> None:
+    monkeypatch.setenv(name, value)
+
+    with pytest.raises(SystemExit) as exit_info:
+        unit_test_runner._parser().parse_args(["run"])
+
+    assert exit_info.value.code == 2
+
+
+@pytest.mark.parametrize(
+    ("name", "value"),
+    [
+        ("SAMPLE_RATE", "0"),
+        ("SAMPLE_OFFSET", "5"),
+        ("PYTEST_COMMAND_PREFIX", "'unterminated"),
+        ("MEMORY_MONITOR_INTERVAL", "invalid"),
+        ("MEMORY_MONITOR_INTERVAL", "0"),
+        ("MEMORY_MONITOR_INTERVAL", "-1"),
+        ("MEMORY_MONITOR_INTERVAL", "nan"),
+        ("MEMORY_MONITOR_INTERVAL", "inf"),
+    ],
+)
+def test_invalid_runtime_environment_fails_shell_settings_preflight(
+    monkeypatch: pytest.MonkeyPatch,
+    name: str,
+    value: str,
+) -> None:
+    monkeypatch.setenv(name, value)
+
+    with pytest.raises(SystemExit) as exit_info:
+        unit_test_runner._shell_settings(["--dry-run"])
+
+    assert exit_info.value.code == 2
+
+
+def test_help_defines_global_zero_based_sanity_sampling(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    with pytest.raises(SystemExit) as exit_info:
+        unit_test_runner._parser().parse_args(["run", "--help"])
+
+    assert exit_info.value.code == 0
+    help_text = capsys.readouterr().out
+    assert "globally select every SAMPLE_RATE-th collected node" in help_text
+    assert "SAMPLE_RATE=5, SAMPLE_OFFSET=0" in help_text
+
+
+def test_help_reports_effective_argument_defaults(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setenv("UNIT_TEST_TARGET_SECONDS", "123")
+    monkeypatch.setenv("UNIT_TEST_DURATION_ESTIMATES", "/tmp/durations.csv.gz")
+    monkeypatch.setenv("UNIT_TEST_OVERHEAD_ESTIMATES", "/tmp/overheads.csv")
+
+    with pytest.raises(SystemExit) as exit_info:
+        unit_test_runner._parser().parse_args(["run", "--help"])
+
+    assert exit_info.value.code == 0
+    help_text = " ".join(capsys.readouterr().out.split())
+    assert (
+        "soft logical-unit target (UNIT_TEST_TARGET_SECONDS) (default: 123)"
+        in help_text
+    )
+    assert "optional per-node duration CSV or CSV.gz" in help_text
+    assert "default estimate for a node missing timing data" in help_text
+    assert "default per-source process overhead" in help_text
+    assert "--dry-run" in help_text
+    assert "--wrapper-started-at" in help_text
+    assert "--timing-profile" not in help_text
+    assert "--unknown-case-seconds" not in help_text
+    assert "exit codes: 0=complete without failures;" in help_text
+    assert "(default: /tmp/durations.csv.gz)" in help_text
+    assert "(default: /tmp/overheads.csv)" in help_text
+
+
+def test_pytest_command_prefix_wraps_batches_and_is_frozen_in_manifest(
+    tmp_path: Path,
+) -> None:
+    suite = tmp_path / "suite"
+    suite.mkdir()
+    (suite / "test_sample.py").write_text("def test_passes(): pass\n", encoding="utf-8")
+    record = tmp_path / "prefix-arguments.json"
+    wrapper = tmp_path / "prefix wrapper.py"
+    wrapper.write_text(
+        """\
+import json
+import os
+import sys
+from pathlib import Path
+
+Path(os.environ["PREFIX_RECORD"]).write_text(
+    json.dumps(sys.argv[1:]), encoding="utf-8"
+)
+os.execv(sys.argv[1], sys.argv[1:])
+""",
+        encoding="utf-8",
+    )
+    prefix = shlex.join([sys.executable, str(wrapper)])
+    environment = {
+        "PREFIX_RECORD": str(record),
+        "PYTEST_COMMAND_PREFIX": prefix,
+    }
+
+    created = _run(tmp_path, "run", suite, env_override=environment)
+
+    assert created.returncode == 0, created.stdout + created.stderr
+    forwarded = json.loads(record.read_text(encoding="utf-8"))
+    assert forwarded[:3] == [sys.executable, "-m", "pytest"]
+    manifest = json.loads(
+        (tmp_path / "junit" / "manifest.json").read_text(encoding="utf-8")
+    )
+    assert manifest["pytest_command_prefix"] == [sys.executable, str(wrapper)]
+
+    changed = _run(
+        tmp_path,
+        "run",
+        suite,
+        env_override={
+            **environment,
+            "PYTEST_COMMAND_PREFIX": shlex.join([sys.executable, "-u", str(wrapper)]),
+        },
+    )
+
+    assert changed.returncode == 3
+    assert "pytest_command_prefix" in changed.stdout
+
+
+def _run(
+    tmp_path: Path,
+    command: str,
+    test_path: Path,
+    *extra: str,
+    env_override: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(REPO_ROOT)
+    env.update(env_override or {})
+    return subprocess.run(
+        [
+            sys.executable,
+            str(RUNNER),
+            command,
+            "--junit-dir",
+            str(tmp_path / "junit"),
+            "--test-path",
+            str(test_path),
+            "--default-case-seconds",
+            "1",
+            "--default-source-overhead-seconds",
+            "0",
+            "--checkpoint-seconds",
+            "1",
+            "--target-unit-seconds",
+            "1",
+            "--workers",
+            "1",
+            "--timeout-grace-seconds",
+            "0",
+            "--deadline-seconds",
+            "120",
+            *extra,
+        ],
+        cwd=REPO_ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+        timeout=120,
+    )
+
+
+def test_cli_summary_uses_scoped_shell_invocation_start_time(tmp_path: Path) -> None:
+    suite = tmp_path / "suite"
+    suite.mkdir()
+    (suite / "test_sample.py").write_text("def test_case(): pass\n", encoding="utf-8")
+
+    result = _run(
+        tmp_path,
+        "plan",
+        suite,
+        "--wrapper-started-at",
+        "1700000000",
+    )
+
+    assert result.returncode == 0, result.stdout
+    assert "Start time: 2023-11-14T22:13:20Z" in result.stdout
+    assert "End time: " in result.stdout
+    assert "Time elapsed: " in result.stdout
+
+
+def test_cli_summary_ignores_unscoped_start_time_environment(tmp_path: Path) -> None:
+    suite = tmp_path / "suite"
+    suite.mkdir()
+    (suite / "test_sample.py").write_text("def test_case(): pass\n", encoding="utf-8")
+
+    result = _run(
+        tmp_path,
+        "plan",
+        suite,
+        env_override={"UNIT_TEST_RUN_STARTED_AT": "1700000000"},
+    )
+
+    assert result.returncode == 0, result.stdout
+    assert "Start time: 2023-11-14T22:13:20Z" not in result.stdout
+
+
+def test_optional_timing_files_use_first_matching_rows(tmp_path: Path) -> None:
+    suite = tmp_path / "suite"
+    suite.mkdir()
+    source = suite / "test_sample.py"
+    source.write_text("def test_case(): pass\n", encoding="utf-8")
+    nodeid = f"{source.name}::test_case"
+    source_file = str(source.resolve())
+    duration = tmp_path / "durations.csv"
+    duration.write_text(
+        f"nodeid,estimated_seconds\n{nodeid},7\n{nodeid},99\n",
+        encoding="utf-8",
+    )
+    overhead = tmp_path / "overheads.csv"
+    overhead.write_text(
+        "source_file,process_startup_seconds,source_warmup_seconds\n"
+        f"{source_file},3,7\n"
+        f"{source_file},99,99\n",
+        encoding="utf-8",
+    )
+
+    result = _run(
+        tmp_path,
+        "plan",
+        suite,
+        "--duration-estimates",
+        str(duration),
+        "--overhead-estimates",
+        str(overhead),
+    )
+
+    assert result.returncode == 0, result.stdout
+    manifest = json.loads(
+        (tmp_path / "junit" / "manifest.json").read_text(encoding="utf-8")
+    )
+    batch = manifest["plan"]["units"][0]["batches"][0]
+    assert batch["estimated_ms"] == 17_000
+    assert set(manifest["estimate_files"]) == {"duration", "overhead"}
+
+
+def test_manifest_freezes_timing_content_not_input_path(tmp_path: Path) -> None:
+    suite = tmp_path / "suite"
+    suite.mkdir()
+    (suite / "test_sample.py").write_text("def test_case(): pass\n", encoding="utf-8")
+    content = "nodeid,estimated_seconds\ntest_sample.py::test_case,7\n"
+    first = tmp_path / "first.csv"
+    second = tmp_path / "second.csv"
+    first.write_text(content, encoding="utf-8")
+    second.write_text(content, encoding="utf-8")
+
+    created = _run(tmp_path, "plan", suite, "--duration-estimates", str(first))
+    reused = _run(tmp_path, "plan", suite, "--duration-estimates", str(second))
+    second.write_text(content.replace(",7", ",8"), encoding="utf-8")
+    changed = _run(tmp_path, "plan", suite, "--duration-estimates", str(second))
+
+    assert created.returncode == 0, created.stdout
+    assert reused.returncode == 0, reused.stdout
+    assert "Using plan" in reused.stdout
+    assert changed.returncode == 3
+    assert "estimate_files" in changed.stdout
+
+
+def test_run_streams_current_pytest_node_before_it_finishes(tmp_path: Path) -> None:
+    suite = tmp_path / "suite"
+    suite.mkdir()
+    (suite / "test_slow.py").write_text(
+        "import time\ndef test_slow():\n    time.sleep(2)\n", encoding="utf-8"
+    )
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(REPO_ROOT)
+    process = subprocess.Popen(
+        [
+            sys.executable,
+            str(RUNNER),
+            "run",
+            "--junit-dir",
+            str(tmp_path / "junit"),
+            "--test-path",
+            str(suite),
+            "--default-case-seconds",
+            "1",
+            "--checkpoint-seconds",
+            "1",
+            "--target-unit-seconds",
+            "1",
+            "--workers",
+            "1",
+            "--timeout-grace-seconds",
+            "0",
+            "--deadline-seconds",
+            "120",
+        ],
+        cwd=REPO_ROOT,
+        env=env,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+    )
+    assert process.stdout is not None
+    captured: list[str] = []
+    saw_running_node = False
+    read_deadline = time.monotonic() + 15
+    while process.poll() is None and time.monotonic() < read_deadline:
+        readable, _, _ = select.select([process.stdout], [], [], 0.1)
+        if not readable:
+            continue
+        line = process.stdout.readline()
+        captured.append(line)
+        if "PYTEST START" in line and "test_slow.py::test_slow" in line:
+            saw_running_node = process.poll() is None
+            break
+    remainder, _ = process.communicate(timeout=120)
+    captured.append(remainder)
+
+    assert process.returncode == 0, "".join(captured)
+    assert saw_running_node, "".join(captured)
+
+
+def test_slow_collection_reports_a_live_heartbeat(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    suite = tmp_path / "suite"
+    suite.mkdir()
+    (suite / "conftest.py").write_text(
+        "import time\ntime.sleep(0.3)\n", encoding="utf-8"
+    )
+    (suite / "test_sample.py").write_text("def test_passes(): pass\n", encoding="utf-8")
+    monkeypatch.setattr(runner, "_COLLECTION_HEARTBEAT_SECONDS", 0.05)
+
+    nodes = runner._collect_nodes(REPO_ROOT, suite, 5, 5)
+
+    assert len(nodes) == 1
+    output = capsys.readouterr().out
+    assert "RUNNER HEARTBEAT: state=collecting" in output
+    assert f"test_path={suite}" in output
+
+
+def test_collection_termination_uses_configured_grace(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    class RunningProcess:
+        def poll(self) -> None:
+            return None
+
+    grace_values: list[float] = []
+
+    def terminate(_process, grace_seconds: float) -> str:
+        grace_values.append(grace_seconds)
+        return "SIGTERM"
+
+    monkeypatch.setattr(runner, "terminate_process_group", terminate)
+
+    with pytest.raises(runner.CollectionTimeoutError):
+        runner._wait_for_collection(
+            RunningProcess(),  # type: ignore[arg-type]
+            test_path=tmp_path,
+            timeout_seconds=0,
+            grace_seconds=17,
+        )
+
+    assert grace_values == [17]
+
+
+def test_final_status_reports_elapsed_against_deadline(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    summary = {
+        "complete": True,
+        "shards": {
+            "0": {
+                "finalized_nodes": 2,
+                "planned_nodes": 2,
+                "outcomes": {"passed": 1, "failed": 0, "skipped": 1},
+                "pending_nodes": 0,
+            }
+        },
+    }
+    monkeypatch.setattr(runner.time, "time", lambda: 135.5)
+
+    runner._report_shard_status(
+        summary,
+        0,
+        state="completed",
+        deadline_clock=runner.DeadlineClock(started_at=100.0, limit_seconds=120),
+    )
+
+    output = capsys.readouterr().out
+    assert "RUNNER STATUS: shard=0 state=completed" in output
+    assert "deadline_elapsed=35.5s deadline=120s" in output
+
+
+@pytest.mark.parametrize("timeout_policy", ["skip", "fail"])
+def test_worker_exception_is_reported_as_infrastructure_error(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    timeout_policy: str,
+) -> None:
+    node = CollectedNode.from_nodeid("tests/test_sample.py::test_case", 0)
+    batch = Batch(
+        id="batch-1",
+        source_file=node.source_file,
+        nodeids=(node.nodeid,),
+        estimated_ms=1000,
+        overhead_ms=0,
+        oversized=False,
+    )
+    unit = Unit(
+        id="unit-1",
+        batches=(batch,),
+        estimated_ms=1000,
+        oversized=False,
+        shard_index=0,
+    )
+    plan = Plan(
+        options=PlanningOptions(),
+        nodes=(node,),
+        units=(unit,),
+    )
+    execution = runner.ExecutionSettings(
+        workers=1,
+        shard_index=0,
+        attempt=AttemptSettings(
+            deadline_seconds=0,
+            unit_timeout_seconds=0,
+            timeout_grace_seconds=0,
+            timeout_policy=timeout_policy,
+        ),
+        monitor_memory=False,
+    )
+    monkeypatch.setattr(runner, "visible_devices", lambda: [None])
+
+    def fail_batch(_request):
+        raise OSError("cannot start pytest")
+
+    monkeypatch.setattr(runner, "execute_batch", fail_batch)
+
+    result = runner.execute_shard(
+        repo_root=REPO_ROOT,
+        junit_dir=tmp_path / "junit",
+        plan=plan,
+        execution=execution,
+        operation_started_at=time.time(),
+    )
+
+    assert result == 3
+    done = json.loads(
+        (
+            tmp_path
+            / "junit"
+            / "attempts"
+            / "attempt-0001"
+            / "shards"
+            / "shard-0000.done.json"
+        ).read_text(encoding="utf-8")
+    )
+    assert any(
+        "cannot start pytest" in error for error in done["infrastructure_errors"]
+    )
+    assert not list((tmp_path / "junit").glob("shards/*/units/*/batches/*.xml"))
+    summary = json.loads(
+        (tmp_path / "junit" / "run-summary.json").read_text(encoding="utf-8")
+    )
+    assert summary["complete"] is False
+    closure = summary["attempts"][0]["closure"]
+    assert closure["infrastructure_error"] is True
+    assert closure["infrastructure_errors"]
+
+
+def test_setup_error_is_not_masked_when_lease_cleanup_also_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    node = CollectedNode.from_nodeid("tests/test_sample.py::test_case", 0)
+    batch = Batch(
+        id="batch-1",
+        source_file=node.source_file,
+        nodeids=(node.nodeid,),
+        estimated_ms=1000,
+        overhead_ms=0,
+        oversized=False,
+    )
+    plan = Plan(
+        options=PlanningOptions(),
+        nodes=(node,),
+        units=(
+            Unit(
+                id="unit-1",
+                batches=(batch,),
+                estimated_ms=1000,
+                oversized=False,
+                shard_index=0,
+            ),
+        ),
+    )
+    execution = runner.ExecutionSettings(
+        workers=1,
+        shard_index=0,
+        attempt=AttemptSettings(
+            deadline_seconds=0,
+            unit_timeout_seconds=0,
+            timeout_grace_seconds=0,
+            timeout_policy="resume",
+        ),
+        monitor_memory=False,
+    )
+    monkeypatch.setattr(runner, "visible_devices", lambda: [None])
+    original_write = runner.atomic_write_json
+
+    def fail_settings(path: Path, value) -> None:
+        if path.name.endswith(".settings.json"):
+            raise OSError("cannot write shard settings")
+        original_write(path, value)
+
+    class FailingLeases:
+        def close(self) -> None:
+            raise runner.RunnerStateError("cannot close shard leases")
+
+    monkeypatch.setattr(runner, "atomic_write_json", fail_settings)
+    monkeypatch.setattr(
+        runner,
+        "_claim_shard_leases",
+        lambda *_args, **_kwargs: FailingLeases(),
+    )
+
+    with pytest.raises(OSError, match="cannot write shard settings"):
+        runner.execute_shard(
+            repo_root=REPO_ROOT,
+            junit_dir=tmp_path / "junit",
+            plan=plan,
+            execution=execution,
+            operation_started_at=time.time(),
+        )
+
+    assert "cannot close shard leases" in capsys.readouterr().out
+
+
+def test_partial_shard_lease_claim_is_rolled_back(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    node = CollectedNode.from_nodeid("tests/test_sample.py::test_case", 0)
+    batch = Batch(
+        id="batch-1",
+        source_file=node.source_file,
+        nodeids=(node.nodeid,),
+        estimated_ms=1000,
+        overhead_ms=0,
+        oversized=False,
+    )
+    plan = Plan(
+        options=PlanningOptions(),
+        nodes=(node,),
+        units=(
+            Unit(
+                id="unit-1",
+                batches=(batch,),
+                estimated_ms=1000,
+                oversized=False,
+                shard_index=0,
+            ),
+        ),
+    )
+    execution = runner.ExecutionSettings(
+        workers=1,
+        shard_index=0,
+        attempt=AttemptSettings(
+            deadline_seconds=0,
+            unit_timeout_seconds=0,
+            timeout_grace_seconds=0,
+            timeout_policy="resume",
+        ),
+        monitor_memory=False,
+    )
+    monkeypatch.setattr(runner, "visible_devices", lambda: [None])
+    original_add = runner._LeaseHeartbeat.add
+
+    def fail_worker_lease(
+        heartbeat: runner._LeaseHeartbeat, path: Path, worker: str
+    ) -> None:
+        if worker == "worker-0":
+            raise OSError("cannot create worker lease")
+        original_add(heartbeat, path, worker)
+
+    monkeypatch.setattr(runner._LeaseHeartbeat, "add", fail_worker_lease)
+
+    with pytest.raises(OSError, match="cannot create worker lease"):
+        runner.execute_shard(
+            repo_root=REPO_ROOT,
+            junit_dir=tmp_path / "junit",
+            plan=plan,
+            execution=execution,
+            operation_started_at=time.time(),
+        )
+
+    leases = tmp_path / "junit" / "attempts" / "attempt-0001" / "leases"
+    assert list(leases.glob("*.json")) == []
+
+
+def test_heartbeat_close_is_bounded_when_storage_write_is_stuck(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    attempt = {
+        "id": "attempt-1",
+        "started_at": time.time(),
+        "deadline_at": None,
+        "settings": {
+            "deadline_seconds": 0,
+            "unit_timeout_seconds": 0,
+            "timeout_grace_seconds": 0,
+            "timeout_policy": "resume",
+        },
+    }
+    heartbeat = runner._LeaseHeartbeat(attempt, 0)  # type: ignore[arg-type]
+    lease = tmp_path / "lease.json"
+    heartbeat.add(lease, "coordinator")
+    entered = threading.Event()
+    release = threading.Event()
+    original_renew = heartbeat._renew
+
+    def block_background_write(path: Path, worker: str) -> None:
+        if threading.current_thread() is heartbeat.thread:
+            entered.set()
+            release.wait(timeout=5)
+            return
+        original_renew(path, worker)
+
+    monkeypatch.setattr(heartbeat, "_renew", block_background_write)
+    monkeypatch.setattr(runner, "_LEASE_HEARTBEAT_SECONDS", 0.01)
+    monkeypatch.setattr(runner, "_LEASE_CLOSE_SECONDS", 0.05)
+    heartbeat.start()
+    assert entered.wait(timeout=2)
+    started = time.monotonic()
+    try:
+        with pytest.raises(runner.RunnerStateError, match="did not stop"):
+            heartbeat.close()
+    finally:
+        release.set()
+        heartbeat.thread.join(timeout=2)
+        lease.unlink(missing_ok=True)
+
+    assert time.monotonic() - started < 0.5
+
+
+def test_heartbeat_close_attempts_every_lease_removal(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    attempt = {
+        "id": "attempt-1",
+        "started_at": time.time(),
+        "deadline_at": None,
+        "settings": {
+            "deadline_seconds": 0,
+            "unit_timeout_seconds": 0,
+            "timeout_grace_seconds": 0,
+            "timeout_policy": "resume",
+        },
+    }
+    heartbeat = runner._LeaseHeartbeat(attempt, 0)  # type: ignore[arg-type]
+    first = tmp_path / "first.json"
+    second = tmp_path / "second.json"
+    heartbeat.add(first, "first")
+    heartbeat.add(second, "second")
+    original_unlink = Path.unlink
+
+    def fail_first(path: Path, *, missing_ok: bool = False) -> None:
+        if path == first:
+            raise OSError("first lease is busy")
+        original_unlink(path, missing_ok=missing_ok)
+
+    monkeypatch.setattr(Path, "unlink", fail_first)
+    try:
+        with pytest.raises(runner.RunnerStateError, match="first lease is busy"):
+            heartbeat.close()
+        assert not second.exists()
+    finally:
+        original_unlink(first, missing_ok=True)
+
+
+def test_lease_heartbeat_failure_aborts_work_and_is_reported(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    node = CollectedNode.from_nodeid("tests/test_sample.py::test_case", 0)
+    batch = Batch(
+        id="batch-1",
+        source_file=node.source_file,
+        nodeids=(node.nodeid,),
+        estimated_ms=1000,
+        overhead_ms=0,
+        oversized=False,
+    )
+    unit = Unit(
+        id="unit-1",
+        batches=(batch,),
+        estimated_ms=1000,
+        oversized=False,
+        shard_index=0,
+    )
+    plan = Plan(
+        options=PlanningOptions(),
+        nodes=(node,),
+        units=(unit,),
+    )
+    execution = runner.ExecutionSettings(
+        workers=1,
+        shard_index=0,
+        attempt=AttemptSettings(
+            deadline_seconds=0,
+            unit_timeout_seconds=0,
+            timeout_grace_seconds=0,
+            timeout_policy="fail",
+        ),
+        monitor_memory=False,
+    )
+    monkeypatch.setattr(runner, "visible_devices", lambda: [None])
+    monkeypatch.setattr(runner, "_LEASE_HEARTBEAT_SECONDS", 0.01)
+    original_renew = runner._LeaseHeartbeat._renew
+
+    def fail_background_renewal(
+        heartbeat: runner._LeaseHeartbeat, path: Path, worker: str
+    ) -> None:
+        if threading.current_thread() is heartbeat.thread:
+            raise OSError("lease storage unavailable")
+        original_renew(heartbeat, path, worker)
+
+    def wait_for_abort(request) -> BatchExecution:
+        assert request.abort_event is not None
+        assert request.abort_event.wait(timeout=5)
+        return BatchExecution("infrastructure", "aborted by runner")
+
+    monkeypatch.setattr(runner._LeaseHeartbeat, "_renew", fail_background_renewal)
+    monkeypatch.setattr(runner, "execute_batch", wait_for_abort)
+
+    result = runner.execute_shard(
+        repo_root=REPO_ROOT,
+        junit_dir=tmp_path / "junit",
+        plan=plan,
+        execution=execution,
+        operation_started_at=time.time(),
+    )
+
+    assert result == 3
+    done = json.loads(
+        (
+            tmp_path
+            / "junit"
+            / "attempts"
+            / "attempt-0001"
+            / "shards"
+            / "shard-0000.done.json"
+        ).read_text(encoding="utf-8")
+    )
+    assert any(
+        "lease heartbeat failed: lease storage unavailable" in error
+        for error in done["infrastructure_errors"]
+    )
+    assert not list((tmp_path / "junit").glob("shards/*/units/*/batches/*.xml"))
+
+
+def test_collection_deadline_reports_that_pytest_was_killed(tmp_path: Path) -> None:
+    suite = tmp_path / "suite"
+    suite.mkdir()
+    (suite / "conftest.py").write_text("import time\ntime.sleep(5)\n", encoding="utf-8")
+    (suite / "test_sample.py").write_text("def test_passes(): pass\n", encoding="utf-8")
+
+    result = _run(tmp_path, "run", suite, "--deadline-seconds", "1")
+
+    assert result.returncode == 3, result.stdout + result.stderr
+    combined = result.stdout + result.stderr
+    assert "PYTEST KILLED phase=collection reason=attempt-deadline" in combined
+    assert "RUNNER STATUS: state=killed phase=collection" in combined
+    assert "signal=SIGKILL" in combined
+    assert "deadline_elapsed=" in combined
+    assert "deadline=1s" in combined
+
+
+def test_plan_run_and_completed_reuse_publish_resumable_artifacts(
+    tmp_path: Path,
+) -> None:
+    suite = tmp_path / "suite"
+    suite.mkdir()
+    (suite / "conftest.py").write_text(
+        """\
+import os
+import time
+
+if os.environ.get("SLOW_COLLECTION"):
+    time.sleep(5)
+""",
+        encoding="utf-8",
+    )
+    (suite / "test_sample.py").write_text(
+        """\
+def test_passes():
+    pass
+
+def test_fails():
+    assert False, "intentional"
+""",
+        encoding="utf-8",
+    )
+
+    planned = _run(tmp_path, "plan", suite)
+    assert planned.returncode == 0, planned.stdout + planned.stderr
+    manifest_path = tmp_path / "junit" / "manifest.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    planned_nodes = manifest["plan"]["nodeids"]
+    assert len(planned_nodes) == 2
+
+    executed = _run(
+        tmp_path,
+        "run",
+        suite,
+        "--unit-timeout-seconds",
+        "60",
+        "--timeout-grace-seconds",
+        "0",
+    )
+    assert executed.returncode == 1, executed.stdout + executed.stderr
+    failure_detail_at = executed.stdout.index("FAILED TEST NODES")
+    summary_at = executed.stdout.index("TEST SUMMARY")
+    assert failure_detail_at < summary_at
+    assert "test_sample.py::test_fails" in executed.stdout[:summary_at]
+    assert "intentional" in executed.stdout[:summary_at]
+    summary_output = executed.stdout[summary_at:]
+    assert f"Failed test files:\n  - {suite / 'test_sample.py'}" in summary_output
+    assert "test_sample.py::test_fails" not in summary_output
+    assert "intentional" not in summary_output
+    assert "Top 10 longest-running source files:" in executed.stdout
+    assert "Top 10 highest host RSS source files:" in executed.stdout
+    assert "Top 10 highest GPU memory source files:" in executed.stdout
+    assert "RUNNER STATUS: shard=0 state=completed" in executed.stdout
+    assert "finalized=2/2 passed=1 failed=1 skipped=0 pending=0" in executed.stdout
+    summary = json.loads(
+        (tmp_path / "junit" / "run-summary.json").read_text(encoding="utf-8")
+    )
+    assert summary["complete"] is True
+    assert summary["failed_nodes"][0]["nodeid"] == "test_sample.py::test_fails"
+    assert "intentional" in summary["failed_nodes"][0]["diagnostic"]
+    assert summary["outcomes"] == {"failed": 1, "passed": 1, "skipped": 0}
+    assert summary["shards"]["0"] == {
+        "complete": True,
+        "finalized_nodes": 2,
+        "outcomes": {"failed": 1, "passed": 1, "skipped": 0},
+        "pending_nodes": 0,
+        "planned_nodes": 2,
+    }
+    assert summary["fallback_counts"] == {"default-case": 2}
+    assert summary["fallbacks"] == [{"node_indexes": [0, 1], "source": "default-case"}]
+    assert summary["capacity"]["estimated_makespan_ms"] > 0
+    assert not list((tmp_path / "junit").glob("unit-*.xml"))
+    batch_xml = sorted(
+        (tmp_path / "junit").glob("shards/shard-0000/units/*/batches/batch-*.xml")
+    )
+    planned_batches = sum(len(unit["batches"]) for unit in manifest["plan"]["units"])
+    assert len(batch_xml) == planned_batches
+    assert all(ET.parse(path).getroot().tag == "testsuites" for path in batch_xml)
+    assert not (tmp_path / "junit" / ".state").exists()
+
+    # A completed run must use its frozen plan without repeating collection.
+    repeated = _run(
+        tmp_path,
+        "run",
+        suite,
+        "--unit-timeout-seconds",
+        "60",
+        "--timeout-grace-seconds",
+        "0",
+        "--deadline-seconds",
+        "1",
+        env_override={"SLOW_COLLECTION": "1"},
+    )
+    assert repeated.returncode == 1
+    assert "Using plan" in repeated.stdout
+    assert "RUNNER STATUS: shard=0 state=completed" in repeated.stdout
+    assert "finalized=2/2 passed=1 failed=1 skipped=0 pending=0" in repeated.stdout
+    assert "PYTEST KILLED phase=collection" not in repeated.stdout + repeated.stderr
+    assert len(list((tmp_path / "junit" / "attempts").glob("attempt-*"))) == 1
+
+
+def test_unit_progress_omits_skipped_results_and_reports_all_outcomes(
+    tmp_path: Path,
+) -> None:
+    suite = tmp_path / "suite"
+    suite.mkdir()
+    (suite / "test_sample.py").write_text(
+        """\
+import pytest
+
+def test_passes():
+    pass
+
+def test_fails():
+    assert False, "intentional"
+
+def test_skips():
+    pytest.skip("intentional")
+""",
+        encoding="utf-8",
+    )
+
+    result = _run(
+        tmp_path,
+        "run",
+        suite,
+        "--checkpoint-seconds",
+        "100",
+        "--target-unit-seconds",
+        "100",
+    )
+
+    assert result.returncode == 1, result.stdout + result.stderr
+    assert "PYTEST RESULT" in result.stdout
+    assert "outcome=failed" in result.stdout
+    assert not any(
+        "PYTEST RESULT" in line and "outcome=skipped" in line
+        for line in result.stdout.splitlines()
+    )
+    unit_lines = [
+        line
+        for line in result.stdout.splitlines()
+        if line.startswith("PYTEST UNIT COMPLETE")
+    ]
+    assert len(unit_lines) == 1
+    assert (
+        "finalized=3 passed=1 failed=1 skipped=1 unknown=0 completed_nodes=3/3"
+    ) in unit_lines[0]
+
+
+def test_completed_node_progress_observes_finalized_batches_from_every_shard(
+    tmp_path: Path,
+) -> None:
+    nodes = tuple(
+        CollectedNode.from_nodeid(f"tests/test_{index}.py::test_case", index)
+        for index in range(2)
+    )
+    units = tuple(
+        Unit(
+            id=f"unit-{index}",
+            batches=(
+                Batch(
+                    id=f"batch-{index}",
+                    source_file=node.source_file,
+                    nodeids=(node.nodeid,),
+                    estimated_ms=1000,
+                    overhead_ms=0,
+                    oversized=False,
+                ),
+            ),
+            estimated_ms=1000,
+            oversized=False,
+            shard_index=index,
+        )
+        for index, node in enumerate(nodes)
+    )
+    plan = Plan(
+        options=PlanningOptions(shard_count=2),
+        nodes=nodes,
+        units=units,
+    )
+    metadata = runner.SyntheticBatchMetadata(
+        policy="skip",
+        batch_id=units[0].batches[0].id,
+        unit_id=units[0].id,
+        shard_index=0,
+        attempt_id="attempt-1",
+        profile="synthetic",
+    )
+
+    assert runner._completed_node_count(tmp_path / "junit", plan) == 0
+    runner._synthesize_batch(
+        tmp_path / "junit", units[0], units[0].batches[0], metadata
+    )
+    assert runner._completed_node_count(tmp_path / "junit", plan) == 1
+    runner._synthesize_batch(
+        tmp_path / "junit",
+        units[1],
+        units[1].batches[0],
+        runner.SyntheticBatchMetadata(
+            policy="fail",
+            batch_id=units[1].batches[0].id,
+            unit_id=units[1].id,
+            shard_index=1,
+            attempt_id="attempt-1",
+            profile="synthetic",
+        ),
+    )
+    assert runner._completed_node_count(tmp_path / "junit", plan) == 2
+
+
+def test_solo_source_runs_exclusively_with_full_gpu_visibility(
+    tmp_path: Path,
+) -> None:
+    suite = tmp_path / "suite"
+    suite.mkdir()
+    state = tmp_path / "solo-state"
+    state.mkdir()
+    (suite / "test_solo.py").write_text(
+        """\
+import os
+import time
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.solo
+
+@pytest.fixture(scope="module", autouse=True)
+def exclusive_source():
+    state = Path(os.environ["SOLO_STATE"])
+    solo = state / "solo-active"
+    regular = state / "regular-active"
+    assert not regular.exists(), "regular batch overlapped solo setup"
+    solo.write_text("active", encoding="utf-8")
+    (state / "solo-devices").write_text(
+        os.environ.get("CUDA_VISIBLE_DEVICES", ""), encoding="utf-8"
+    )
+    time.sleep(1)
+    yield
+    time.sleep(1)
+    assert not regular.exists(), "regular batch overlapped solo teardown"
+    solo.unlink()
+
+def test_solo_one():
+    pass
+
+def test_solo_two():
+    pass
+""",
+        encoding="utf-8",
+    )
+    (suite / "test_regular.py").write_text(
+        """\
+import os
+import time
+from pathlib import Path
+
+def test_regular():
+    state = Path(os.environ["SOLO_STATE"])
+    solo = state / "solo-active"
+    regular = state / "regular-active"
+    assert not solo.exists(), "solo batch overlapped regular setup"
+    regular.write_text("active", encoding="utf-8")
+    (state / "regular-devices").write_text(
+        os.environ.get("CUDA_VISIBLE_DEVICES", ""), encoding="utf-8"
+    )
+    try:
+        time.sleep(2)
+        assert not solo.exists(), "solo batch overlapped regular execution"
+    finally:
+        regular.unlink()
+""",
+        encoding="utf-8",
+    )
+
+    result = _run(
+        tmp_path,
+        "run",
+        suite,
+        "--workers",
+        "2",
+        env_override={
+            "CUDA_VISIBLE_DEVICES": "0,1",
+            "SOLO_STATE": str(state),
+        },
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert (state / "solo-devices").read_text(encoding="utf-8") == "0,1"
+    assert (state / "regular-devices").read_text(encoding="utf-8") in {"0", "1"}
+
+
+def test_long_running_dispatches_first_and_solo_runs_after_non_solo_finalized(
+    tmp_path: Path,
+) -> None:
+    suite = tmp_path / "suite"
+    suite.mkdir()
+    state = tmp_path / "phase-state"
+    state.mkdir()
+    for name in ("a", "b"):
+        (suite / f"test_long_{name}.py").write_text(
+            f"""\
+import os
+import time
+from pathlib import Path
+import pytest
+
+pytestmark = pytest.mark.long_running
+
+def test_long_{name}():
+    state = Path(os.environ["PHASE_STATE"])
+    (state / "long-{name}-started").write_text("1", encoding="utf-8")
+    time.sleep(0.5)
+    (state / "long-{name}-done").write_text("1", encoding="utf-8")
+""",
+            encoding="utf-8",
+        )
+    (suite / "test_normal.py").write_text(
+        """\
+import os
+from pathlib import Path
+
+def test_normal():
+    state = Path(os.environ["PHASE_STATE"])
+    assert (state / "long-a-started").exists()
+    assert (state / "long-b-started").exists()
+    (state / "normal-done").write_text("1", encoding="utf-8")
+""",
+        encoding="utf-8",
+    )
+    (suite / "test_solo.py").write_text(
+        """\
+import os
+from pathlib import Path
+import pytest
+
+pytestmark = pytest.mark.solo
+
+def test_solo():
+    state = Path(os.environ["PHASE_STATE"])
+    assert (state / "long-a-done").exists()
+    assert (state / "long-b-done").exists()
+    assert (state / "normal-done").exists()
+""",
+        encoding="utf-8",
+    )
+
+    result = _run(
+        tmp_path,
+        "run",
+        suite,
+        "--workers",
+        "2",
+        env_override={
+            "CUDA_VISIBLE_DEVICES": "0,1",
+            "PHASE_STATE": str(state),
+        },
+    )
+
+    assert result.returncode == 0, result.stdout
+    assert "WORKER START worker=0" in result.stdout
+    assert "WORKER TASK worker=0" in result.stdout
+    assert "WORKER END worker=0" in result.stdout
+    assert "PROGRESS shard=0 finalized=4/4" in result.stdout
+    assert "PYTEST RUNNING" not in result.stdout
+
+
+def test_pending_non_solo_work_blocks_the_solo_phase(tmp_path: Path) -> None:
+    suite = tmp_path / "suite"
+    suite.mkdir()
+    solo_started = tmp_path / "solo-started"
+    (suite / "test_regular.py").write_text(
+        "import time\ndef test_regular(): time.sleep(5)\n",
+        encoding="utf-8",
+    )
+    (suite / "test_solo.py").write_text(
+        f"""\
+from pathlib import Path
+import pytest
+
+pytestmark = pytest.mark.solo
+
+def test_solo():
+    Path({str(solo_started)!r}).write_text("started", encoding="utf-8")
+""",
+        encoding="utf-8",
+    )
+
+    result = _run(
+        tmp_path,
+        "run",
+        suite,
+        "--unit-timeout-seconds",
+        "1",
+        "--timeout-grace-seconds",
+        "0",
+        "--timeout-policy",
+        "resume",
+    )
+
+    assert result.returncode == 2, result.stdout
+    assert not solo_started.exists()
+    assert "WORKER TASK worker=solo-0" not in result.stdout
+    assert "Pending: 2" in result.stdout
+
+
+def test_run_records_the_shared_attempt_before_pytest_collection(
+    tmp_path: Path,
+) -> None:
+    suite = tmp_path / "suite"
+    suite.mkdir()
+    (suite / "conftest.py").write_text(
+        """\
+import os
+from pathlib import Path
+
+attempts = Path(os.environ["ATTEMPT_PROBE"]) / "attempts"
+assert list(attempts.glob("attempt-*/attempt.json")), "attempt was not reserved"
+""",
+        encoding="utf-8",
+    )
+    (suite / "test_sample.py").write_text("def test_passes(): pass\n", encoding="utf-8")
+
+    result = _run(
+        tmp_path,
+        "run",
+        suite,
+        "--unit-timeout-seconds",
+        "5",
+        env_override={"ATTEMPT_PROBE": str(tmp_path / "junit")},
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_manifest_compares_source_git_sha_only_when_both_values_are_available(
+    tmp_path: Path,
+) -> None:
+    suite = tmp_path / "suite"
+    suite.mkdir()
+    (suite / "test_sample.py").write_text("def test_passes(): pass\n", encoding="utf-8")
+
+    created = _run(
+        tmp_path,
+        "plan",
+        suite,
+        env_override={"SOURCE_GIT_SHA": "source-a"},
+    )
+    mismatch = _run(
+        tmp_path,
+        "plan",
+        suite,
+        env_override={"SOURCE_GIT_SHA": "source-b"},
+    )
+    unavailable = _run(
+        tmp_path,
+        "plan",
+        suite,
+        env_override={"SOURCE_GIT_SHA": ""},
+    )
+
+    assert created.returncode == 0, created.stdout + created.stderr
+    manifest = json.loads(
+        (tmp_path / "junit" / "manifest.json").read_text(encoding="utf-8")
+    )
+    assert manifest["source_git_sha"] == "source-a"
+    assert mismatch.returncode == 3
+    assert "source_git_sha" in mismatch.stdout
+    assert unavailable.returncode == 0, unavailable.stdout + unavailable.stderr
+
+
+@pytest.mark.parametrize(
+    ("policy", "expected_code", "outcome"),
+    [("skip", 0, "skipped"), ("fail", 1, "failed")],
+)
+def test_terminal_timeout_policies_synthesize_junit(
+    tmp_path: Path,
+    policy: str,
+    expected_code: int,
+    outcome: str,
+) -> None:
+    suite = tmp_path / "suite"
+    suite.mkdir()
+    (suite / "test_slow.py").write_text(
+        "import time\ndef test_slow():\n    time.sleep(5)\n",
+        encoding="utf-8",
+    )
+
+    result = _run(
+        tmp_path,
+        "run",
+        suite,
+        "--unit-timeout-seconds",
+        "1",
+        "--timeout-grace-seconds",
+        "0",
+        "--timeout-policy",
+        policy,
+    )
+
+    assert result.returncode == expected_code, result.stdout + result.stderr
+    summary = json.loads(
+        (tmp_path / "junit" / "run-summary.json").read_text(encoding="utf-8")
+    )
+    assert summary["complete"] is True
+    assert summary["synthetic"] == 1
+    assert summary["outcomes"][outcome] == 1
+    expected_counts = (
+        "passed=0 failed=1 skipped=0 unknown=0"
+        if policy == "fail"
+        else "passed=0 failed=0 skipped=1 unknown=0"
+    )
+    assert expected_counts in result.stdout
+    assert "completed_nodes=1/1" in result.stdout
+    assert len(summary["attempts"][0]["unit_timeout_events"]) == 1
+    assert summary["attempts"][0]["unit_timeout_events"][0]["timeout_policy"] == policy
+
+
+def test_timeout_policy_resume_starts_a_new_attempt_without_fake_results(
+    tmp_path: Path,
+) -> None:
+    suite = tmp_path / "suite"
+    suite.mkdir()
+    (suite / "test_slow.py").write_text(
+        "import time\ndef test_slow():\n    time.sleep(5)\n",
+        encoding="utf-8",
+    )
+    options = (
+        "--unit-timeout-seconds",
+        "2",
+        "--timeout-grace-seconds",
+        "0",
+        "--timeout-policy",
+        "resume",
+    )
+
+    first = _run(tmp_path, "run", suite, *options)
+    second = _run(tmp_path, "run", suite, *options)
+
+    assert first.returncode == 2, first.stdout + first.stderr
+    assert second.returncode == 2, second.stdout + second.stderr
+    assert "PYTEST KILLED" in first.stdout
+    assert "node=test_slow.py::test_slow" in first.stdout
+    assert "RUNNER STATUS: shard=0 state=interrupted" in first.stdout
+    assert "reason=unit-timeout" in first.stdout
+    assert not list((tmp_path / "junit").glob("unit-*.xml"))
+    attempts = list((tmp_path / "junit" / "attempts").glob("attempt-*"))
+    assert len(attempts) == 2
+
+
+def test_timed_out_shard_is_not_retried_inside_the_same_attempt(
+    tmp_path: Path,
+) -> None:
+    suite = tmp_path / "suite"
+    suite.mkdir()
+    (suite / "test_slow.py").write_text(
+        "import time\ndef test_slow():\n    time.sleep(5)\n",
+        encoding="utf-8",
+    )
+    options = (
+        "--shard-count",
+        "2",
+        "--shard-index",
+        "0",
+        "--unit-timeout-seconds",
+        "1",
+        "--timeout-grace-seconds",
+        "0",
+        "--timeout-policy",
+        "resume",
+    )
+
+    first = _run(tmp_path, "run", suite, *options)
+    repeated = _run(tmp_path, "run", suite, *options)
+
+    assert first.returncode == 2, first.stdout + first.stderr
+    assert repeated.returncode == 2, repeated.stdout + repeated.stderr
+    attempts = list((tmp_path / "junit" / "attempts").glob("attempt-*"))
+    assert len(attempts) == 1
+    logs = list((tmp_path / "junit" / "shards" / "shard-0000").glob("**/*.log"))
+    assert len(logs) == 1
+    assert logs[0].read_text(encoding="utf-8").count("command:") == 1
+
+
+def test_existing_manifest_skips_environment_dependent_recollection(
+    tmp_path: Path,
+) -> None:
+    suite = tmp_path / "suite"
+    suite.mkdir()
+    (suite / "test_dynamic.py").write_text(
+        """\
+import os
+import pytest
+
+@pytest.mark.parametrize("value", range(int(os.environ["DYNAMIC_CASES"])))
+def test_dynamic(value):
+    pass
+""",
+        encoding="utf-8",
+    )
+
+    first = _run(
+        tmp_path,
+        "plan",
+        suite,
+        env_override={"DYNAMIC_CASES": "1"},
+    )
+    changed = _run(
+        tmp_path,
+        "plan",
+        suite,
+        env_override={"DYNAMIC_CASES": "2"},
+    )
+
+    assert first.returncode == 0, first.stdout + first.stderr
+    assert changed.returncode == 0, changed.stdout + changed.stderr
+    assert "Using plan" in changed.stdout
+    manifest = json.loads(
+        (tmp_path / "junit" / "manifest.json").read_text(encoding="utf-8")
+    )
+    assert len(manifest["plan"]["nodeids"]) == 1
+
+
+def test_finalize_fan_in_closes_an_attempt_after_all_leases_are_gone(
+    tmp_path: Path,
+) -> None:
+    suite = tmp_path / "suite"
+    suite.mkdir()
+    (suite / "test_one.py").write_text("def test_one(): pass\n", encoding="utf-8")
+    (suite / "test_two.py").write_text("def test_two(): pass\n", encoding="utf-8")
+    partial = _run(
+        tmp_path,
+        "run",
+        suite,
+        "--shard-count",
+        "2",
+        "--shard-index",
+        "0",
+        "--timeout-policy",
+        "skip",
+        "--deadline-seconds",
+        "0",
+    )
+    finalize_env = os.environ.copy()
+    finalize_env["PYTHONPATH"] = str(REPO_ROOT)
+    finalized = subprocess.run(
+        [
+            sys.executable,
+            str(RUNNER),
+            "finalize",
+            "--junit-dir",
+            str(tmp_path / "junit"),
+        ],
+        cwd=REPO_ROOT,
+        env=finalize_env,
+        text=True,
+        capture_output=True,
+        check=False,
+        timeout=30,
+    )
+
+    assert partial.returncode == 0, partial.stdout + partial.stderr
+    assert "Shared run: finalized=1/2 pending=1" in partial.stdout
+    assert finalized.returncode == 0, finalized.stdout + finalized.stderr
+    assert "Scope: shared run" in finalized.stdout
+    assert "Finalized nodes: 2" in finalized.stdout
+    attempt = tmp_path / "junit" / "attempts" / "attempt-0001"
+    closure = json.loads((attempt / "closed.json").read_text(encoding="utf-8"))
+    assert closure["reason"] == "explicit-fan-in"
+    summary = json.loads(
+        (tmp_path / "junit" / "run-summary.json").read_text(encoding="utf-8")
+    )
+    assert summary["complete"] is True
+    assert summary["synthetic"] == 1

--- a/tests/test_sharding/test_shell_entrypoint.py
+++ b/tests/test_sharding/test_shell_entrypoint.py
@@ -1,0 +1,241 @@
+from __future__ import annotations
+
+import os
+import signal
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+@pytest.mark.parametrize(
+    ("python_code", "shell_code"),
+    [(0, 0), (1, 1), (2, 0), (3, 3)],
+)
+def test_shell_maps_runner_codes_and_leaves_summary_last(
+    tmp_path: Path, python_code: int, shell_code: int
+) -> None:
+    scripts = tmp_path / "scripts"
+    scripts.mkdir()
+    entrypoint = scripts / "task_run_unit_tests.sh"
+    shutil.copy(REPO_ROOT / "scripts" / "task_run_unit_tests.sh", entrypoint)
+    (scripts / "test_utils.sh").write_text("", encoding="utf-8")
+    (scripts / "unit_test_runner.py").write_text(
+        """\
+import os
+import sys
+
+if sys.argv[1] == "__shell-settings":
+    print("plan")
+    print("tests/")
+    raise SystemExit(0)
+
+code = int(os.environ["FAKE_RUNNER_CODE"])
+print("==========================================")
+print("TEST SUMMARY")
+print("==========================================")
+print(f"Result: status=fake python_exit_code={code} shell_exit_code={0 if code in {0, 2} else code}")
+print("==========================================")
+raise SystemExit(code)
+""",
+        encoding="utf-8",
+    )
+    env = os.environ.copy()
+    env["FAKE_RUNNER_CODE"] = str(python_code)
+
+    result = subprocess.run(
+        ["bash", str(entrypoint), "--dry-run"],
+        cwd=tmp_path,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == shell_code
+    assert result.stderr == ""
+    assert result.stdout.count("TEST SUMMARY") == 1
+    assert result.stdout.rstrip().endswith("==========================================")
+
+
+def test_shell_start_time_cannot_be_overridden_by_caller(tmp_path: Path) -> None:
+    scripts = tmp_path / "scripts"
+    scripts.mkdir()
+    entrypoint = scripts / "task_run_unit_tests.sh"
+    shutil.copy(REPO_ROOT / "scripts" / "task_run_unit_tests.sh", entrypoint)
+    (scripts / "test_utils.sh").write_text("", encoding="utf-8")
+    (scripts / "unit_test_runner.py").write_text(
+        """\
+import sys
+
+if sys.argv[1] == "__shell-settings":
+    print("plan")
+    print("tests/")
+    raise SystemExit(0)
+
+starts = [
+    sys.argv[index + 1]
+    for index, argument in enumerate(sys.argv)
+    if argument == "--wrapper-started-at"
+]
+print(f"EFFECTIVE WRAPPER START: {starts[-1]}")
+print("==========================================")
+print("TEST SUMMARY")
+print("==========================================")
+raise SystemExit(0)
+""",
+        encoding="utf-8",
+    )
+
+    result = subprocess.run(
+        ["bash", str(entrypoint), "--dry-run", "--wrapper-started-at", "1"],
+        cwd=tmp_path,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stdout
+    effective = next(
+        line for line in result.stdout.splitlines() if line.startswith("EFFECTIVE ")
+    )
+    assert float(effective.rsplit(" ", 1)[1]) > 1
+
+
+def test_shell_prints_fallback_summary_for_argument_preflight_error(
+    tmp_path: Path,
+) -> None:
+    scripts = tmp_path / "scripts"
+    scripts.mkdir()
+    entrypoint = scripts / "task_run_unit_tests.sh"
+    shutil.copy(REPO_ROOT / "scripts" / "task_run_unit_tests.sh", entrypoint)
+    (scripts / "test_utils.sh").write_text("", encoding="utf-8")
+    (scripts / "unit_test_runner.py").write_text(
+        "import sys\nprint('ERROR: bad option')\nraise SystemExit(3)\n",
+        encoding="utf-8",
+    )
+
+    result = subprocess.run(
+        ["bash", str(entrypoint), "--dry-run"],
+        cwd=tmp_path,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 3
+    assert result.stderr == ""
+    assert "ERROR: bad option" in result.stdout
+    assert result.stdout.count("TEST SUMMARY") == 1
+    assert "Start time: " in result.stdout
+    assert "End time: " in result.stdout
+    assert "Time elapsed: " in result.stdout
+    assert "phase=argument-preflight" in result.stdout
+    assert result.stdout.rstrip().endswith("==========================================")
+
+
+def test_shell_prints_fallback_summary_for_dependency_setup_failure(
+    tmp_path: Path,
+) -> None:
+    scripts = tmp_path / "scripts"
+    scripts.mkdir()
+    entrypoint = scripts / "task_run_unit_tests.sh"
+    shutil.copy(REPO_ROOT / "scripts" / "task_run_unit_tests.sh", entrypoint)
+    (scripts / "test_utils.sh").write_text(
+        "install_and_verify() { return 17; }\n", encoding="utf-8"
+    )
+    (scripts / "unit_test_runner.py").write_text(
+        "import sys\n"
+        "if sys.argv[1] == '__shell-settings': print('run\\ntests/'); raise SystemExit(0)\n"
+        "raise AssertionError('runner must not start')\n",
+        encoding="utf-8",
+    )
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    (fake_bin / "pip").write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    (fake_bin / "pip").chmod(0o755)
+    env = os.environ.copy()
+    env["PATH"] = f"{fake_bin}{os.pathsep}{env['PATH']}"
+
+    result = subprocess.run(
+        ["bash", str(entrypoint)],
+        cwd=tmp_path,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 17
+    assert result.stderr == ""
+    assert result.stdout.count("TEST SUMMARY") == 1
+    assert "phase=dependency-setup" in result.stdout
+
+
+def test_shell_preserves_abnormal_runner_exit_and_prints_fallback_summary(
+    tmp_path: Path,
+) -> None:
+    scripts = tmp_path / "scripts"
+    scripts.mkdir()
+    entrypoint = scripts / "task_run_unit_tests.sh"
+    shutil.copy(REPO_ROOT / "scripts" / "task_run_unit_tests.sh", entrypoint)
+    (scripts / "test_utils.sh").write_text("", encoding="utf-8")
+    (scripts / "unit_test_runner.py").write_text(
+        "import sys\n"
+        "if sys.argv[1] == '__shell-settings': print('plan\\ntests/'); raise SystemExit(0)\n"
+        "print('runner crashed without a summary')\n"
+        "raise SystemExit(9)\n",
+        encoding="utf-8",
+    )
+
+    result = subprocess.run(
+        ["bash", str(entrypoint), "--dry-run"],
+        cwd=tmp_path,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 9
+    assert result.stdout.count("TEST SUMMARY") == 1
+    assert "UNIT TEST RUNNER ABNORMAL EXIT" in result.stdout
+    assert "phase=python-runner" in result.stdout
+
+
+def test_shell_prints_fallback_summary_for_catchable_signal(tmp_path: Path) -> None:
+    scripts = tmp_path / "scripts"
+    scripts.mkdir()
+    entrypoint = scripts / "task_run_unit_tests.sh"
+    shutil.copy(REPO_ROOT / "scripts" / "task_run_unit_tests.sh", entrypoint)
+    (scripts / "test_utils.sh").write_text("", encoding="utf-8")
+    (scripts / "unit_test_runner.py").write_text(
+        "import sys, time\n"
+        "if sys.argv[1] == '__shell-settings': print('plan\\ntests/'); raise SystemExit(0)\n"
+        "print('runner-started', flush=True)\n"
+        "time.sleep(0.2)\n",
+        encoding="utf-8",
+    )
+    process = subprocess.Popen(
+        ["bash", str(entrypoint), "--dry-run"],
+        cwd=tmp_path,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    assert process.stdout is not None
+    prefix = process.stdout.readline()
+    while "runner-started" not in prefix:
+        prefix += process.stdout.readline()
+    process.send_signal(signal.SIGTERM)
+    stdout, stderr = process.communicate(timeout=5)
+    output = prefix + stdout
+
+    assert process.returncode == 143
+    assert stderr == ""
+    assert output.count("TEST SUMMARY") == 1
+    assert "received SIGTERM" in output
+    assert output.rstrip().endswith("==========================================")

--- a/tests/test_sharding/test_shell_entrypoint.py
+++ b/tests/test_sharding/test_shell_entrypoint.py
@@ -4,12 +4,169 @@ import os
 import signal
 import shutil
 import subprocess
+import sys
 from pathlib import Path
 
 import pytest
 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_pytest_timeout_plugin_enforces_marked_deadline(tmp_path: Path) -> None:
+    test_file = tmp_path / "test_timeout.py"
+    test_file.write_text(
+        """\
+import time
+import pytest
+
+@pytest.mark.timeout(0.05)
+def test_hangs():
+    time.sleep(1)
+""",
+        encoding="utf-8",
+    )
+
+    result = subprocess.run(
+        [sys.executable, "-m", "pytest", "-q", str(test_file)],
+        cwd=tmp_path,
+        text=True,
+        capture_output=True,
+        check=False,
+        timeout=10,
+    )
+
+    output = result.stdout + result.stderr
+    assert result.returncode == 1, output
+    assert "Timeout" in output
+
+
+@pytest.mark.parametrize(
+    ("required", "expected_code", "expected_level"),
+    [("false", 0, "WARNING"), ("true", 1, "ERROR")],
+)
+def test_missing_precompiled_kernels_follow_explicit_policy(
+    tmp_path: Path, required: str, expected_code: int, expected_level: str
+) -> None:
+    work = tmp_path / "work"
+    work.mkdir()
+    env = os.environ.copy()
+    env.update(
+        {
+            "JUNIT_DIR": str(tmp_path / "junit"),
+            "MAX_JOBS": "1",
+            "PIP_CONSTRAINT": os.devnull,
+            "UNIT_TEST_REQUIRE_PRECOMPILED_KERNELS": required,
+        }
+    )
+    result = subprocess.run(
+        [
+            "bash",
+            "-c",
+            'source "$1"; DRY_RUN=false; CUDA_VERSION=cu129; '
+            "JIT_ARCH=9.0a; install_precompiled_kernels",
+            "bash",
+            str(REPO_ROOT / "scripts" / "test_utils.sh"),
+        ],
+        cwd=work,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    output = result.stdout + result.stderr
+    assert result.returncode == expected_code, output
+    assert f"{expected_level}: flashinfer-cubin wheel not found" in output
+    assert f"{expected_level}: flashinfer-jit-cache wheel not found" in output
+
+
+@pytest.mark.parametrize(
+    ("required", "jit_arch", "expected_code", "expected_message"),
+    [
+        (
+            "sometimes",
+            "9.0a",
+            2,
+            "UNIT_TEST_REQUIRE_PRECOMPILED_KERNELS must be true or false",
+        ),
+        (
+            "true",
+            "",
+            1,
+            "UNIT_TEST_REQUIRE_PRECOMPILED_KERNELS=true requires JIT_ARCH",
+        ),
+    ],
+)
+def test_precompiled_kernel_policy_rejects_invalid_configuration(
+    tmp_path: Path,
+    required: str,
+    jit_arch: str,
+    expected_code: int,
+    expected_message: str,
+) -> None:
+    env = os.environ.copy()
+    env.update(
+        {
+            "JIT_ARCH": jit_arch,
+            "JUNIT_DIR": str(tmp_path / "junit"),
+            "MAX_JOBS": "1",
+            "PIP_CONSTRAINT": os.devnull,
+            "UNIT_TEST_REQUIRE_PRECOMPILED_KERNELS": required,
+        }
+    )
+    result = subprocess.run(
+        [
+            "bash",
+            "-c",
+            'source "$1"; DRY_RUN=false; CUDA_VERSION=cu129; '
+            "install_precompiled_kernels",
+            "bash",
+            str(REPO_ROOT / "scripts" / "test_utils.sh"),
+        ],
+        cwd=tmp_path,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    output = result.stdout + result.stderr
+    assert result.returncode == expected_code, output
+    assert expected_message in output
+
+
+def test_optional_precompiled_policy_warns_without_jit_arch(tmp_path: Path) -> None:
+    env = os.environ.copy()
+    env.update(
+        {
+            "JIT_ARCH": "",
+            "JUNIT_DIR": str(tmp_path / "junit"),
+            "MAX_JOBS": "1",
+            "PIP_CONSTRAINT": os.devnull,
+            "UNIT_TEST_REQUIRE_PRECOMPILED_KERNELS": "false",
+        }
+    )
+    result = subprocess.run(
+        [
+            "bash",
+            "-c",
+            'source "$1"; DRY_RUN=false; CUDA_VERSION=cu129; '
+            "install_precompiled_kernels",
+            "bash",
+            str(REPO_ROOT / "scripts" / "test_utils.sh"),
+        ],
+        cwd=tmp_path,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    output = result.stdout + result.stderr
+    assert result.returncode == 0, output
+    assert "JIT_ARCH is unset" in output
+    assert "using JIT compilation" in output
 
 
 @pytest.mark.parametrize(

--- a/tests/test_sharding/test_state.py
+++ b/tests/test_sharding/test_state.py
@@ -1,0 +1,170 @@
+from __future__ import annotations
+
+import json
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from scripts.test_sharding.models import Plan, PlanningOptions
+from scripts.test_sharding.state import (
+    AttemptSettings,
+    ManifestBuild,
+    RunnerStateError,
+    active_attempt_collection_timeout,
+    build_manifest,
+    create_or_join_attempt,
+    recover_unit_elapsed,
+    source_git_sha_from_env,
+    state_lock,
+    verify_manifest,
+    write_unit_elapsed,
+)
+
+
+def test_unit_elapsed_recovers_only_the_stale_claim_window(tmp_path: Path) -> None:
+    attempt_path = tmp_path / "attempt-0001"
+    claim_path = tmp_path / "claim.json"
+    write_unit_elapsed(
+        attempt_path,
+        "unit-a",
+        elapsed_seconds=12.0,
+        active_started_at=100.0,
+    )
+    claim_path.write_text(json.dumps({"expires_at": 130.0}), encoding="utf-8")
+
+    elapsed = recover_unit_elapsed(
+        attempt_path,
+        "unit-a",
+        stale_claim_path=claim_path,
+        now=200.0,
+    )
+
+    assert elapsed == 42.0
+    saved = json.loads(
+        (attempt_path / "unit-elapsed" / "unit-a.json").read_text(encoding="utf-8")
+    )
+    assert saved == {"active_started_at": None, "elapsed_seconds": 42.0}
+
+
+def _manifest(tmp_path: Path, source_git_sha: str | None) -> dict[str, Any]:
+    test_path = tmp_path / "tests"
+    plan = Plan(options=PlanningOptions(), nodes=(), units=())
+    return build_manifest(
+        ManifestBuild(
+            repo_root=tmp_path,
+            test_path=test_path,
+            source_git_sha=source_git_sha,
+            plan=plan,
+            selection={"sanity_test": False},
+            estimate_files={"duration": None, "overhead": None},
+        )
+    )
+
+
+def test_source_git_sha_from_env_normalizes_missing_and_blank_values(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("SOURCE_GIT_SHA", raising=False)
+    assert source_git_sha_from_env() is None
+
+    monkeypatch.setenv("SOURCE_GIT_SHA", "  ")
+    assert source_git_sha_from_env() is None
+
+    monkeypatch.setenv("SOURCE_GIT_SHA", " abc123 \n")
+    assert source_git_sha_from_env() == "abc123"
+
+
+def test_manifest_rejects_different_available_source_git_shas(
+    tmp_path: Path,
+) -> None:
+    manifest = _manifest(tmp_path, "saved-sha")
+    verify_manifest(
+        manifest,
+        source_git_sha="saved-sha",
+        test_path=tmp_path / "tests",
+        selection={"sanity_test": False},
+        planning_options=PlanningOptions().to_dict(),
+    )
+
+    with pytest.raises(RunnerStateError, match="source_git_sha"):
+        verify_manifest(
+            manifest,
+            source_git_sha="current-sha",
+            test_path=tmp_path / "tests",
+            selection={"sanity_test": False},
+            planning_options=PlanningOptions().to_dict(),
+        )
+
+
+@pytest.mark.parametrize(
+    ("saved_sha", "current_sha"),
+    [(None, "current-sha"), ("saved-sha", None), (None, None)],
+)
+def test_manifest_assumes_source_matches_when_either_sha_is_unavailable(
+    tmp_path: Path,
+    saved_sha: str | None,
+    current_sha: str | None,
+) -> None:
+    manifest = _manifest(tmp_path, saved_sha)
+
+    verify_manifest(
+        manifest,
+        source_git_sha=current_sha,
+        test_path=tmp_path / "tests",
+        selection={"sanity_test": False},
+        planning_options=PlanningOptions().to_dict(),
+    )
+
+
+def test_collection_timeout_uses_active_attempt_absolute_deadline(
+    tmp_path: Path,
+) -> None:
+    attempt = tmp_path / "attempts" / "attempt-0001"
+    attempt.mkdir(parents=True)
+    (attempt / "attempt.json").write_text(
+        json.dumps({"deadline_at": 125.0}), encoding="utf-8"
+    )
+
+    assert active_attempt_collection_timeout(tmp_path, 100.0, now=100.0) == 25.0
+    assert active_attempt_collection_timeout(tmp_path, 10.0, now=100.0) == 10.0
+    assert active_attempt_collection_timeout(tmp_path, None, now=100.0) == 25.0
+
+
+def test_state_lock_rejects_foreign_lock_file(tmp_path: Path) -> None:
+    (tmp_path / "lock").write_text("foreign\n", encoding="utf-8")
+
+    with pytest.raises(RunnerStateError, match="lock"), state_lock(tmp_path):
+        pass
+
+
+def test_state_lock_supports_simultaneous_first_start(tmp_path: Path) -> None:
+    worker_count = 8
+    start = threading.Barrier(worker_count)
+
+    def acquire_lock() -> None:
+        start.wait()
+        with state_lock(tmp_path):
+            pass
+
+    with ThreadPoolExecutor(max_workers=worker_count) as executor:
+        futures = [executor.submit(acquire_lock) for _ in range(worker_count)]
+        for future in futures:
+            future.result()
+
+
+def test_create_attempt_rejects_empty_reserved_attempts_directory(
+    tmp_path: Path,
+) -> None:
+    (tmp_path / "attempts").mkdir()
+    settings = AttemptSettings(
+        deadline_seconds=60,
+        unit_timeout_seconds=30,
+        timeout_grace_seconds=5,
+        timeout_policy="resume",
+    )
+
+    with pytest.raises(RunnerStateError, match="attempts"):
+        create_or_join_attempt(tmp_path, settings, started_at=100.0)

--- a/tests/test_sharding/test_summary.py
+++ b/tests/test_sharding/test_summary.py
@@ -1,0 +1,322 @@
+from __future__ import annotations
+
+import csv
+import json
+import threading
+from collections.abc import Iterator
+from concurrent.futures import ThreadPoolExecutor
+from contextlib import contextmanager
+from pathlib import Path
+
+import pytest
+
+from scripts.test_sharding import summary as summary_module
+from scripts.test_sharding.models import (
+    Batch,
+    CollectedNode,
+    Plan,
+    PlanningOptions,
+    Unit,
+)
+from scripts.test_sharding.state import state_lock
+from scripts.test_sharding.summary import (
+    batch_xml_path,
+    exit_code_for_shard,
+    exit_code_for_summary,
+    terminal_summary_lines,
+)
+
+
+def test_summary_publication_waits_for_the_state_lock(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    plan = Plan(
+        options=PlanningOptions(),
+        nodes=(),
+        units=(),
+    )
+    lock_attempted = threading.Event()
+
+    @contextmanager
+    def observed_state_lock(junit_dir: Path) -> Iterator[None]:
+        lock_attempted.set()
+        with state_lock(junit_dir):
+            yield
+
+    monkeypatch.setattr(summary_module, "state_lock", observed_state_lock)
+    executor = ThreadPoolExecutor(max_workers=1)
+    try:
+        with state_lock(tmp_path):
+            future = executor.submit(summary_module.publish_summary, tmp_path, plan)
+            assert lock_attempted.wait(timeout=5)
+            assert not future.done()
+        summary = future.result(timeout=5)
+    finally:
+        executor.shutdown()
+
+    assert summary["complete"] is True
+    assert summary["schema_version"] == 3
+
+
+def test_failure_exit_code_wins_over_incomplete() -> None:
+    summary = {
+        "infrastructure_errors": [],
+        "outcomes": {"failed": 1},
+        "complete": False,
+    }
+
+    assert exit_code_for_summary(summary) == 1  # type: ignore[arg-type]
+
+
+def _summary_plan() -> Plan:
+    nodes = tuple(
+        CollectedNode.from_nodeid(f"tests/test_sample.py::test_case_{index}", index)
+        for index in range(2)
+    )
+    units = []
+    for index, node in enumerate(nodes):
+        batch = Batch(
+            id=f"batch-{index}",
+            source_file=node.source_file,
+            nodeids=(node.nodeid,),
+            estimated_ms=1000,
+            overhead_ms=0,
+            oversized=False,
+        )
+        units.append(
+            Unit(
+                id=f"unit-{index}",
+                batches=(batch,),
+                estimated_ms=1000,
+                oversized=False,
+                shard_index=0,
+            )
+        )
+    return Plan(options=PlanningOptions(), nodes=nodes, units=tuple(units))
+
+
+def _write_final_batch(
+    junit_dir: Path,
+    unit: Unit,
+    *,
+    failed: bool,
+    launched_at: float,
+    exited_at: float,
+    rss_mib: float,
+    gpu_mib: float,
+    monitor_memory: bool,
+) -> None:
+    batch = unit.batches[0]
+    path = batch_xml_path(junit_dir, unit, batch)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    failure = (
+        '<failure message="boom">detailed pytest failure</failure>' if failed else ""
+    )
+    path.write_text(
+        '<testsuites><testsuite><testcase time="1">'
+        f'<properties><property name="pytest_nodeid" value="{batch.nodeids[0]}"/>'
+        "</properties>"
+        f"{failure}</testcase></testsuite></testsuites>",
+        encoding="utf-8",
+    )
+    path.with_name(f"{batch.id}.results.json").write_text(
+        json.dumps(
+            {
+                "results": [
+                    {
+                        "nodeid": batch.nodeids[0],
+                        "outcome": "failed" if failed else "passed",
+                        "longrepr": "detailed pytest failure" if failed else "",
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    path.with_name(f"{batch.id}.meta.json").write_text(
+        json.dumps(
+            {
+                "attempt_id": "attempt-1",
+                "launched_at": launched_at,
+                "exited_at": exited_at,
+                "synthetic": False,
+                "monitor_memory": monitor_memory,
+            }
+        ),
+        encoding="utf-8",
+    )
+    path.with_name(f"{batch.id}.memory.csv").write_text(
+        f"timestamp,host_rss_mib,gpu_memory_mib\n1,{rss_mib},{gpu_mib}\n",
+        encoding="utf-8",
+    )
+
+
+def test_source_summary_aggregates_local_resources_and_failed_diagnostics(
+    tmp_path: Path,
+) -> None:
+    plan = _summary_plan()
+    _write_final_batch(
+        tmp_path,
+        plan.units[0],
+        failed=False,
+        launched_at=10,
+        exited_at=12,
+        rss_mib=100,
+        gpu_mib=900,
+        monitor_memory=True,
+    )
+    _write_final_batch(
+        tmp_path,
+        plan.units[1],
+        failed=True,
+        launched_at=20,
+        exited_at=25,
+        rss_mib=300,
+        gpu_mib=400,
+        monitor_memory=False,
+    )
+
+    summary = summary_module.publish_summary(tmp_path, plan)
+
+    source = summary["sources"][0]
+    assert source == {
+        "shard_index": 0,
+        "source_file": "tests/test_sample.py",
+        "planned_nodes": 2,
+        "finalized_nodes": 2,
+        "pending_nodes": 0,
+        "passed": 1,
+        "failed": 1,
+        "skipped": 0,
+        "unknown": 0,
+        "synthetic": 0,
+        "process_seconds": 7.0,
+        "max_host_rss_mib": 300.0,
+        "max_gpu_memory_mib": 900.0,
+        "memory_samples": 2,
+        "partial_resources": True,
+        "status": "failed",
+    }
+    failure = summary["failed_nodes"][0]
+    assert failure["nodeid"].endswith("::test_case_1")
+    assert failure["diagnostic"] == "detailed pytest failure"
+    assert failure["results_path"].endswith("batch-1.results.json")
+    with (tmp_path / "source_summary.csv").open(newline="", encoding="utf-8") as stream:
+        csv_row = next(csv.DictReader(stream))
+    assert csv_row["status"] == "failed"
+    assert csv_row["partial_resources"] == "True"
+
+    terminal = "\n".join(
+        terminal_summary_lines(
+            summary,
+            shard_index=0,
+            runner_exit_code=1,
+            status="complete-with-failures",
+            test_started_at=100.0,
+            test_ended_at=101.0,
+            cause="pytest failure",
+            diagnostic_limit=8,
+        )
+    )
+    assert "[diagnostic truncated at 8 bytes]" in terminal
+    assert "results:" in terminal
+    assert "tests/test_sample.py :: tests/test_sample.py::test_case_1" in terminal
+
+
+def test_terminal_summary_lists_detailed_failures_before_deduplicated_files(
+    tmp_path: Path,
+) -> None:
+    plan = _summary_plan()
+    for index, unit in enumerate(plan.units):
+        _write_final_batch(
+            tmp_path,
+            unit,
+            failed=True,
+            launched_at=10 + index,
+            exited_at=11 + index,
+            rss_mib=100,
+            gpu_mib=200,
+            monitor_memory=True,
+        )
+    summary = summary_module.publish_summary(tmp_path, plan)
+
+    terminal_lines = terminal_summary_lines(
+        summary,
+        shard_index=0,
+        runner_exit_code=1,
+        status="complete-with-failures",
+        test_started_at=100.0,
+        test_ended_at=101.0,
+    )
+    summary_at = terminal_lines.index("TEST SUMMARY")
+    detail_output = "\n".join(terminal_lines[:summary_at])
+    summary_output = "\n".join(terminal_lines[summary_at:])
+
+    assert detail_output.count("tests/test_sample.py::test_case_") == 2
+    assert detail_output.count("detailed pytest failure") == 2
+    assert "Failed test files:" not in detail_output
+    assert summary_output.count("  - tests/test_sample.py") == 1
+    assert "tests/test_sample.py::test_case_" not in summary_output
+    assert "detailed pytest failure" not in summary_output
+
+
+def test_terminal_summary_skips_failure_sections_when_no_test_failed(
+    tmp_path: Path,
+) -> None:
+    plan = _summary_plan()
+    for index, unit in enumerate(plan.units):
+        _write_final_batch(
+            tmp_path,
+            unit,
+            failed=False,
+            launched_at=10 + index,
+            exited_at=11 + index,
+            rss_mib=100,
+            gpu_mib=200,
+            monitor_memory=True,
+        )
+    summary = summary_module.publish_summary(tmp_path, plan)
+
+    terminal = "\n".join(
+        terminal_summary_lines(
+            summary,
+            shard_index=0,
+            runner_exit_code=0,
+            status="complete-without-failures",
+            test_started_at=100.0,
+            test_ended_at=101.0,
+        )
+    )
+
+    assert "FAILED TEST NODES" not in terminal
+    assert "Failed test files:" not in terminal
+
+
+def test_terminal_summary_reports_test_times() -> None:
+    terminal = "\n".join(
+        terminal_summary_lines(
+            None,
+            shard_index=None,
+            runner_exit_code=3,
+            status="configuration-collection-or-infrastructure-error",
+            test_started_at=1_700_000_000.0,
+            test_ended_at=1_700_000_005.25,
+        )
+    )
+
+    assert "Start time: 2023-11-14T22:13:20Z" in terminal
+    assert "End time: 2023-11-14T22:13:25Z" in terminal
+    assert "Time elapsed: 5s" in terminal
+
+
+def test_shard_exit_code_ignores_other_shard_infrastructure_errors() -> None:
+    summary = {
+        "shards": {
+            "0": {"complete": True, "outcomes": {}},
+            "1": {"complete": False, "outcomes": {}},
+        },
+        "shard_infrastructure_errors": {"0": [], "1": ["gpu disappeared"]},
+    }
+
+    assert exit_code_for_shard(summary, 0) == 0  # type: ignore[arg-type]
+    assert exit_code_for_shard(summary, 1) == 3  # type: ignore[arg-type]

--- a/tests/test_sharding/test_summary.py
+++ b/tests/test_sharding/test_summary.py
@@ -220,7 +220,7 @@ def test_source_summary_aggregates_local_resources_and_failed_diagnostics(
     )
     assert "[diagnostic truncated at 8 bytes]" in terminal
     assert "results:" in terminal
-    assert "tests/test_sample.py :: tests/test_sample.py::test_case_1" in terminal
+    assert "  - tests/test_sample.py::test_case_1" in terminal
 
 
 def test_terminal_summary_lists_detailed_failures_before_deduplicated_files(

--- a/tests/test_sharding/test_workers.py
+++ b/tests/test_sharding/test_workers.py
@@ -1,0 +1,273 @@
+from __future__ import annotations
+
+import os
+import signal
+import time
+from contextlib import suppress
+from io import StringIO
+from pathlib import Path
+
+import pytest
+
+from scripts.test_sharding import workers as workers_module
+from scripts.test_sharding.models import Batch, Unit
+from scripts.test_sharding.progress import encode_pytest_event
+from scripts.test_sharding.workers import (
+    BatchExecutionRequest,
+    _BatchProgress,
+    _forward_pytest_output,
+    execute_batch,
+)
+
+
+def test_abnormal_pytest_exit_does_not_finalize_batch(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    fake_pythonpath = tmp_path / "fake-pythonpath"
+    pytest_package = fake_pythonpath / "pytest"
+    pytest_package.mkdir(parents=True)
+    (pytest_package / "__init__.py").write_text("", encoding="utf-8")
+    (pytest_package / "__main__.py").write_text(
+        """\
+import json
+import sys
+from pathlib import Path
+from xml.sax.saxutils import quoteattr
+
+arguments = sys.argv[1:]
+selection = next(value.split("=", 1)[1] for value in arguments if value.startswith("--flashinfer-node-file="))
+xml_path = Path(next(value.split("=", 1)[1] for value in arguments if value.startswith("--junitxml=")))
+nodeid = json.loads(Path(selection).read_text(encoding="utf-8"))[0]
+xml_path.write_text(
+    "<testsuites><testsuite tests=\\"1\\"><testcase name=\\"case\\" time=\\"0\\">"
+    "<properties><property name=\\"pytest_nodeid\\" value=" + quoteattr(nodeid) + "/>"
+    "</properties></testcase></testsuite></testsuites>",
+    encoding="utf-8",
+)
+raise SystemExit(3)
+""",
+        encoding="utf-8",
+    )
+    existing_pythonpath = os.environ.get("PYTHONPATH")
+    monkeypatch.setenv(
+        "PYTHONPATH",
+        (
+            f"{fake_pythonpath}{os.pathsep}{existing_pythonpath}"
+            if existing_pythonpath
+            else str(fake_pythonpath)
+        ),
+    )
+    nodeid = "tests/test_sample.py::test_case"
+    batch = Batch(
+        id="batch-1",
+        source_file="tests/test_sample.py",
+        nodeids=(nodeid,),
+        estimated_ms=1000,
+        overhead_ms=0,
+        oversized=False,
+    )
+    unit = Unit(
+        id="unit-1",
+        batches=(batch,),
+        estimated_ms=1000,
+        oversized=False,
+        shard_index=0,
+    )
+
+    result = execute_batch(
+        BatchExecutionRequest(
+            repo_root=Path(__file__).resolve().parents[2],
+            junit_dir=tmp_path / "junit",
+            unit=unit,
+            batch=batch,
+            attempt_id="attempt-1",
+            profile="synthetic",
+            timeout_seconds=10,
+            timeout_reason=None,
+            grace_seconds=0,
+            worker_index=0,
+            device=None,
+            monitor_memory=False,
+            memory_interval=1,
+        )
+    )
+
+    assert result.status == "infrastructure"
+    assert "exit code 3" in result.diagnostic
+    assert not list((tmp_path / "junit").glob("shards/*/units/*/batches/*.xml"))
+
+
+def test_failure_event_is_printed_with_source_node_diagnostic_and_artifacts(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    stream = StringIO(
+        encode_pytest_event(
+            "failure",
+            nodeid="tests/test_sample.py::test_case",
+            phase="call",
+            diagnostic="assert expected == actual",
+            diagnostic_truncated=False,
+        )
+        + "\n"
+    )
+    log = StringIO()
+
+    _forward_pytest_output(
+        stream,
+        log,
+        _BatchProgress(),
+        worker_index=2,
+        batch_id="batch-1",
+        source_file="tests/test_sample.py",
+        log_path=tmp_path / "batch.log",
+        results_path=tmp_path / "batch.results.json",
+        junit_path=tmp_path / "batch.xml",
+    )
+
+    output = capsys.readouterr().out
+    assert "source=tests/test_sample.py" in output
+    assert "node=tests/test_sample.py::test_case" in output
+    assert "assert expected == actual" in output
+    assert f"results={tmp_path / 'batch.results.json'}" in output
+    assert f"junit={tmp_path / 'batch.xml'}" in output
+
+
+def _fake_batch_request(tmp_path: Path) -> BatchExecutionRequest:
+    nodeid = "tests/test_sample.py::test_case"
+    batch = Batch(
+        id="batch-1",
+        source_file="tests/test_sample.py",
+        nodeids=(nodeid,),
+        estimated_ms=1000,
+        overhead_ms=0,
+        oversized=False,
+    )
+    unit = Unit(
+        id="unit-1",
+        batches=(batch,),
+        estimated_ms=1000,
+        oversized=False,
+        shard_index=0,
+    )
+    return BatchExecutionRequest(
+        repo_root=Path(__file__).resolve().parents[2],
+        junit_dir=tmp_path / "junit",
+        unit=unit,
+        batch=batch,
+        attempt_id="attempt-1",
+        profile="synthetic",
+        timeout_seconds=10,
+        timeout_reason=None,
+        grace_seconds=0,
+        worker_index=0,
+        device=None,
+        monitor_memory=False,
+        memory_interval=1,
+    )
+
+
+def _install_fake_pytest(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, source: str
+) -> None:
+    fake_pythonpath = tmp_path / "fake-pythonpath"
+    pytest_package = fake_pythonpath / "pytest"
+    pytest_package.mkdir(parents=True)
+    (pytest_package / "__init__.py").write_text("", encoding="utf-8")
+    (pytest_package / "__main__.py").write_text(source, encoding="utf-8")
+    existing_pythonpath = os.environ.get("PYTHONPATH")
+    monkeypatch.setenv(
+        "PYTHONPATH",
+        (
+            f"{fake_pythonpath}{os.pathsep}{existing_pythonpath}"
+            if existing_pythonpath
+            else str(fake_pythonpath)
+        ),
+    )
+
+
+def test_inherited_stdout_cannot_block_batch_completion(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    child_pid_path = tmp_path / "escaped-child.pid"
+    monkeypatch.setenv("ESCAPED_CHILD_PID_FILE", str(child_pid_path))
+    monkeypatch.setattr(workers_module, "_OUTPUT_DRAIN_SECONDS", 0.05, raising=False)
+    _install_fake_pytest(
+        tmp_path,
+        monkeypatch,
+        """\
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from xml.sax.saxutils import quoteattr
+
+arguments = sys.argv[1:]
+selection = next(value.split("=", 1)[1] for value in arguments if value.startswith("--flashinfer-node-file="))
+xml_path = Path(next(value.split("=", 1)[1] for value in arguments if value.startswith("--junitxml=")))
+nodeid = json.loads(Path(selection).read_text(encoding="utf-8"))[0]
+child = subprocess.Popen(
+    [sys.executable, "-c", "import time; time.sleep(30)"],
+    start_new_session=True,
+)
+Path(os.environ["ESCAPED_CHILD_PID_FILE"]).write_text(str(child.pid), encoding="utf-8")
+xml_path.write_text(
+    "<testsuites><testsuite tests=\\"1\\"><testcase name=\\"case\\" time=\\"0\\">"
+    "<properties><property name=\\"pytest_nodeid\\" value=" + quoteattr(nodeid) + "/>"
+    "</properties></testcase></testsuite></testsuites>",
+    encoding="utf-8",
+)
+""",
+    )
+    started = time.monotonic()
+    child_pid: int | None = None
+    try:
+        result = execute_batch(_fake_batch_request(tmp_path))
+        child_pid = int(child_pid_path.read_text(encoding="utf-8"))
+    finally:
+        if child_pid is None and child_pid_path.exists():
+            child_pid = int(child_pid_path.read_text(encoding="utf-8"))
+        if child_pid is not None:
+            with suppress(ProcessLookupError):
+                os.kill(child_pid, signal.SIGKILL)
+
+    assert time.monotonic() - started < 3
+    assert result.status == "infrastructure"
+    assert "output did not reach EOF" in result.diagnostic
+
+
+def test_output_reader_failure_is_an_infrastructure_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _install_fake_pytest(
+        tmp_path,
+        monkeypatch,
+        """\
+import json
+import sys
+from pathlib import Path
+from xml.sax.saxutils import quoteattr
+
+arguments = sys.argv[1:]
+selection = next(value.split("=", 1)[1] for value in arguments if value.startswith("--flashinfer-node-file="))
+xml_path = Path(next(value.split("=", 1)[1] for value in arguments if value.startswith("--junitxml=")))
+nodeid = json.loads(Path(selection).read_text(encoding="utf-8"))[0]
+print(
+    '@@flashinfer-pytest-event@@ ' + json.dumps(
+        {"event": "start", "nodeid": nodeid, "started_at": "not-a-time"}
+    ),
+    flush=True,
+)
+xml_path.write_text(
+    "<testsuites><testsuite tests=\\"1\\"><testcase name=\\"case\\" time=\\"0\\">"
+    "<properties><property name=\\"pytest_nodeid\\" value=" + quoteattr(nodeid) + "/>"
+    "</properties></testcase></testsuite></testsuites>",
+    encoding="utf-8",
+)
+""",
+    )
+
+    result = execute_batch(_fake_batch_request(tmp_path))
+
+    assert result.status == "infrastructure"
+    assert "pytest output reader failed" in result.diagnostic

--- a/tests/trace/template_registry.py
+++ b/tests/trace/template_registry.py
@@ -82,6 +82,7 @@ _TRACE_REGISTRATION_MODULES = (
     "flashinfer.sampling",
     "flashinfer.sparse",
     "flashinfer.topk",
+    "flashinfer.topk_varlen.topk_varlen",
     "flashinfer.xqa",
 )
 

--- a/tests/trace/template_registry.py
+++ b/tests/trace/template_registry.py
@@ -1,0 +1,122 @@
+# Copyright (c) 2025 by FlashInfer team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Deterministic discovery of APIs registered with trace templates.
+
+Pytest first collects the complete suite to build the sharding manifest, then
+collects one source file per worker process.  A source file must therefore
+produce the same parametrized node IDs regardless of modules imported by other
+tests.  Import every registration module here, filter out unrelated registry
+state, and sort the result by stable API identity.
+
+Keep ``_TRACE_REGISTRATION_MODULES`` synchronized with modules containing
+``@flashinfer_api(trace=...)``.  ``test_template_registry.py`` enforces this
+inventory.
+"""
+
+from __future__ import annotations
+
+import importlib
+from typing import Any, Callable
+
+TraceRegistryEntry = tuple[Callable[..., Any], Any, str]
+
+
+_TRACE_REGISTRATION_MODULES = (
+    "flashinfer.activation",
+    "flashinfer.attention._core",
+    "flashinfer.attention.prims_ts.decode",
+    "flashinfer.attention.prims_ts.mla_decode",
+    "flashinfer.cascade",
+    "flashinfer.comm.allreduce",
+    "flashinfer.comm.dcp_alltoall",
+    "flashinfer.concat_ops",
+    "flashinfer.cudnn.decode",
+    "flashinfer.cudnn.prefill",
+    "flashinfer.cute_dsl.add_rmsnorm_fp4quant",
+    "flashinfer.cute_dsl.attention.wrappers.batch_mla",
+    "flashinfer.cute_dsl.attention.wrappers.batch_prefill",
+    "flashinfer.cute_dsl.rmsnorm_fp4quant",
+    "flashinfer.decode",
+    "flashinfer.fused_moe.core",
+    "flashinfer.fused_moe.cute_dsl.b12x_moe",
+    "flashinfer.fused_moe.cute_dsl.fused_moe",
+    "flashinfer.fused_moe.fused_routing_dsv3",
+    "flashinfer.fused_moe.hash_topk",
+    "flashinfer.fused_moe.monomoe",
+    "flashinfer.fused_moe.prepare",
+    "flashinfer.gdn_decode",
+    "flashinfer.gdn_prefill",
+    "flashinfer.gemm.gemm_base",
+    "flashinfer.gemm.gemm_bf16_fp4",
+    "flashinfer.gemm.gemm_svdquant",
+    "flashinfer.gemm.kernels.grouped_gemm_masked_blackwell",
+    "flashinfer.gemm.routergemm",
+    "flashinfer.kda",
+    "flashinfer.kda_decode",
+    "flashinfer.mamba.selective_state_update",
+    "flashinfer.mhc",
+    "flashinfer.mla._core",
+    "flashinfer.msa_ops.proxy_score",
+    "flashinfer.msa_ops.sparse_decode",
+    "flashinfer.msa_ops.sparse_prefill",
+    "flashinfer.norm",
+    "flashinfer.nvfp4_attention_sm120",
+    "flashinfer.page",
+    "flashinfer.pod",
+    "flashinfer.prefill",
+    "flashinfer.quantization.fp4_quantization",
+    "flashinfer.quantization.fp8_quantization",
+    "flashinfer.rope",
+    "flashinfer.sampling",
+    "flashinfer.sparse",
+    "flashinfer.topk",
+    "flashinfer.xqa",
+)
+
+
+def trace_registry_entry_key(entry: TraceRegistryEntry) -> tuple[str, str, str]:
+    func, _, label = entry
+    return func.__module__, func.__qualname__, label
+
+
+def collect_registered_trace_templates() -> list[TraceRegistryEntry]:
+    """Return available trace registrations in deterministic order.
+
+    Optional backends are allowed to be unavailable.  An entry is included
+    only when its defining module imports successfully in this process, so a
+    partially imported optional module cannot leak state from earlier pytest
+    collection.
+    """
+
+    available_modules: set[str] = set()
+    for module_name in _TRACE_REGISTRATION_MODULES:
+        try:
+            importlib.import_module(module_name)
+        except ImportError:
+            continue
+        available_modules.add(module_name)
+
+    from flashinfer.api_logging import _TRACE_REGISTRY
+
+    entries = [
+        entry for entry in _TRACE_REGISTRY if entry[0].__module__ in available_modules
+    ]
+    keys = [trace_registry_entry_key(entry) for entry in entries]
+    if len(keys) != len(set(keys)):
+        raise RuntimeError(
+            "duplicate trace-template registration identities prevent "
+            "deterministic pytest parameter IDs"
+        )
+    return sorted(entries, key=trace_registry_entry_key)

--- a/tests/trace/test_fi_trace_template_consistency.py
+++ b/tests/trace/test_fi_trace_template_consistency.py
@@ -31,10 +31,11 @@ Two levels of checking
 
 How to add a new template
 --------------------------
-When you add ``@flashinfer_api(trace=my_trace)`` to a function, ensure its
-module is imported by the collector below and optionally add a targeted
-end-to-end test. See the docstring in ``flashinfer/trace/templates/__init__.py``
-for the full how-to guide.
+When you add ``@flashinfer_api(trace=my_trace)`` to the first traced function
+in a module, add that module to ``_TRACE_REGISTRATION_MODULES`` in
+``tests.trace.template_registry``.  Add a targeted end-to-end test when the
+generic checks are insufficient.  See the docstring in
+``flashinfer/trace/templates/__init__.py`` for the full how-to guide.
 """
 
 import ast
@@ -46,6 +47,7 @@ import pytest
 import torch
 
 from flashinfer.trace.template import Const, Scalar, Tensor, TraceTemplate, Var
+from tests.trace.template_registry import collect_registered_trace_templates
 
 # ---------------------------------------------------------------------------
 # Structural checker utilities
@@ -305,44 +307,24 @@ def assert_fi_trace_complete(
 
 
 # ---------------------------------------------------------------------------
-# Auto-discovery via _TRACE_REGISTRY
+# Deterministic auto-discovery via _TRACE_REGISTRY
 #
 # @flashinfer_api(trace=...) automatically registers every (func, template)
-# pair in flashinfer.api_logging._TRACE_REGISTRY at decoration time.
-# We just need to import the modules that contain the decorated functions to
-# trigger those decorators, then read the registry.
+# pair in flashinfer.api_logging._TRACE_REGISTRY at decoration time.  The
+# shared collector imports the complete module inventory and returns a stable
+# snapshot, independent of modules imported by earlier pytest files.
 #
-# To add a new kernel: no changes needed here — simply add
-# @flashinfer_api(trace=my_template) to your function and the tests will
-# pick it up automatically.
+# To add a new kernel, add @flashinfer_api(trace=my_template) to the function.
+# If it lives in a new registration module, add that module to
+# tests.trace.template_registry._TRACE_REGISTRATION_MODULES; the inventory
+# regression test reports omissions.
 # ---------------------------------------------------------------------------
 
 
 def _collect_template_func_pairs() -> List[Tuple[Callable, TraceTemplate, str]]:
-    """
-    Return all (func, template, label) pairs by reading _TRACE_REGISTRY.
+    """Return all available (func, template, label) triples."""
 
-    Imports are done lazily here so that missing GPU drivers don't prevent
-    the structural tests from running.
-    """
-    # Trigger @flashinfer_api decorators by importing all modules that use them.
-    import flashinfer.decode  # BatchDecodeWithPagedKVCacheWrapper
-    import flashinfer.attention.prims_ts.decode  # PrimTS FMHA decode APIs
-    import flashinfer.attention.prims_ts.mla_decode  # PrimTS MLA decode APIs
-    import flashinfer.fused_moe  # trtllm_fp8_block_scale_moe
-    import flashinfer.gdn_decode  # gated_delta_rule_decode, gated_delta_rule_mtp
-    import flashinfer.gdn_prefill  # chunk_gated_delta_rule
-    import flashinfer.gemm  # mm_bf16, mm_fp8, mm_mxfp8, mm_fp4
-    import flashinfer.kda_decode  # recurrent_kda
-    import flashinfer.mla  # BatchMLAPagedAttentionWrapper
-    import flashinfer.msa_ops  # msa_proxy_score, msa_sparse_attention, decode
-    import flashinfer.norm  # rmsnorm, fused_add_rmsnorm
-    import flashinfer.prefill  # BatchPrefillWithPagedKVCacheWrapper, Ragged
-    import flashinfer.sampling  # noqa: F401  # top_k_sampling_from_probs, etc.
-
-    from flashinfer.api_logging import _TRACE_REGISTRY
-
-    return list(_TRACE_REGISTRY)
+    return collect_registered_trace_templates()
 
 
 _ALL_PAIRS = _collect_template_func_pairs()

--- a/tests/trace/test_template_init.py
+++ b/tests/trace/test_template_init.py
@@ -39,6 +39,7 @@ import pytest
 import torch
 
 from flashinfer.trace.template import TraceTemplate, Var
+from tests.trace.template_registry import collect_registered_trace_templates
 
 # ---------------------------------------------------------------------------
 # Auto-discovery (imports the modules to populate _TRACE_REGISTRY).
@@ -46,47 +47,9 @@ from flashinfer.trace.template import TraceTemplate, Var
 
 
 def _collect_pairs() -> List[Tuple[Callable, TraceTemplate, str]]:
-    """Discover (func, template, label) triples by importing every module
-    that decorates a function with ``@flashinfer_api(trace=...)``.
+    """Return all available (func, template, label) triples."""
 
-    Each import is wrapped individually because some submodules require
-    optional dependencies (e.g. ``cuda.tile`` for ``comm.allreduce``) that
-    may not be installed in the current environment — we still want to
-    test whatever templates are available.
-    """
-    import contextlib
-    import importlib
-
-    _MODULES = [
-        "flashinfer.activation",
-        "flashinfer.cascade",
-        "flashinfer.comm.allreduce",
-        "flashinfer.comm.dcp_alltoall",
-        "flashinfer.decode",
-        "flashinfer.fused_moe",
-        "flashinfer.gdn_decode",
-        "flashinfer.gdn_prefill",
-        "flashinfer.gemm",
-        "flashinfer.mamba",
-        "flashinfer.mla",
-        "flashinfer.msa_ops",
-        "flashinfer.norm",
-        "flashinfer.page",
-        "flashinfer.prefill",
-        "flashinfer.quantization.fp4_quantization",
-        "flashinfer.quantization.fp8_quantization",
-        "flashinfer.rope",
-        "flashinfer.sampling",
-        "flashinfer.xqa",
-    ]
-    for mod in _MODULES:
-        # Optional dependency missing → skip; whatever's available will still test.
-        with contextlib.suppress(ImportError):
-            importlib.import_module(mod)
-
-    from flashinfer.api_logging import _TRACE_REGISTRY
-
-    return list(_TRACE_REGISTRY)
+    return collect_registered_trace_templates()
 
 
 _ALL_PAIRS = _collect_pairs()

--- a/tests/trace/test_template_registry.py
+++ b/tests/trace/test_template_registry.py
@@ -1,0 +1,145 @@
+# Copyright (c) 2025 by FlashInfer team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import ast
+import importlib
+import os
+from pathlib import Path
+import subprocess
+import sys
+
+from tests.trace.template_registry import (
+    _TRACE_REGISTRATION_MODULES,
+    collect_registered_trace_templates,
+    trace_registry_entry_key,
+)
+
+
+def _uses_trace_decorator(node: ast.AST) -> bool:
+    if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+        return False
+    for decorator in node.decorator_list:
+        if not isinstance(decorator, ast.Call):
+            continue
+        name = getattr(
+            decorator.func,
+            "id",
+            getattr(decorator.func, "attr", None),
+        )
+        if name == "flashinfer_api" and any(
+            keyword.arg == "trace" for keyword in decorator.keywords
+        ):
+            return True
+    return False
+
+
+def _registration_modules_from_source() -> set[str]:
+    package_root = Path(__file__).parents[2] / "flashinfer"
+    modules: set[str] = set()
+    for path in package_root.rglob("*.py"):
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        if not any(_uses_trace_decorator(node) for node in ast.walk(tree)):
+            continue
+        relative = path.relative_to(package_root.parent).with_suffix("")
+        parts = relative.parts[:-1] if relative.name == "__init__" else relative.parts
+        modules.add(".".join(parts))
+    return modules
+
+
+def test_registration_module_inventory_is_complete():
+    assert set(_TRACE_REGISTRATION_MODULES) == _registration_modules_from_source()
+
+
+def test_registered_template_discovery_is_import_order_independent():
+    from flashinfer.api_logging import _TRACE_REGISTRY
+
+    expected = collect_registered_trace_templates()
+    original_registry = list(_TRACE_REGISTRY)
+    try:
+        _TRACE_REGISTRY.reverse()
+        actual = collect_registered_trace_templates()
+    finally:
+        _TRACE_REGISTRY[:] = original_registry
+
+    assert [trace_registry_entry_key(entry) for entry in actual] == [
+        trace_registry_entry_key(entry) for entry in expected
+    ]
+
+
+def test_formerly_order_dependent_templates_are_discovered():
+    labels = {label for _, _, label in collect_registered_trace_templates()}
+    assert "concat_mla_k" in labels
+
+    optional_labels = {
+        "flashinfer.comm.allreduce": "allreduce_fusion",
+        "flashinfer.comm.dcp_alltoall": "decode_cp_a2a_alltoall",
+        "flashinfer.cute_dsl.attention.wrappers.batch_mla": ("cute_dsl_batch_mla_run"),
+        "flashinfer.cute_dsl.attention.wrappers.batch_prefill": (
+            "cute_dsl_batch_prefill_run"
+        ),
+    }
+    for module_name, label in optional_labels.items():
+        try:
+            importlib.import_module(module_name)
+        except ImportError:
+            continue
+        assert label in labels
+
+
+def _collect_parametrized_nodeids(
+    *,
+    workspace: Path,
+    preimport_concat: bool,
+) -> set[str]:
+    imports = "import flashinfer.concat_ops\n" if preimport_concat else ""
+    script = (
+        imports
+        + "import pytest\n"
+        + "raise SystemExit(pytest.main([\n"
+        + "    '--collect-only', '-q', '--color=no',\n"
+        + "    'tests/trace/test_fi_trace_template_consistency.py',\n"
+        + "    'tests/trace/test_template_init.py',\n"
+        + "]))\n"
+    )
+    env = os.environ.copy()
+    env.pop("PYTEST_ADDOPTS", None)
+    env["FLASHINFER_WORKSPACE_BASE"] = str(workspace)
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=Path(__file__).parents[2],
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    return {
+        line
+        for line in result.stdout.splitlines()
+        if line.startswith("tests/trace/") and "::" in line
+    }
+
+
+def test_parametrized_nodeids_do_not_depend_on_prior_imports(tmp_path):
+    isolated = _collect_parametrized_nodeids(
+        workspace=tmp_path / "isolated",
+        preimport_concat=False,
+    )
+    preimported = _collect_parametrized_nodeids(
+        workspace=tmp_path / "preimported",
+        preimport_concat=True,
+    )
+
+    assert isolated
+    assert preimported == isolated


### PR DESCRIPTION
## 📌 Description

Allow PyTest to run in shards optionally. The jobs in each shard are allocated to make the shards in balanced load. The output JUnit XML remains in a compatible format.

## 🔍 Related Issues

Various, including [PR#3936](https://github.com/flashinfer-ai/flashinfer/issues/3936)

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [X] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [X] I have installed the hooks with `pre-commit install`.
- [X] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [X] Tests have been added or updated as needed.
- [X] All tests are passing (`unittest`, etc.).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a deterministic, duration-balanced test runner with planning, sharding, resumable attempts, deadlines, and coordinated workers.
  - Added source-aware, solo, long-running, and GPU-capable scheduling with resource monitoring.
  - Added detailed progress, summaries, diagnostics, timing data, capacity metrics, and standardized statuses.
  - Added artifact scanning and runtime/overhead estimate refresh tools.
- **Reliability**
  - Improved validation, state recovery, timeout handling, artifact safety, and infrastructure-error reporting.
  - Added legacy manifest compatibility and clearer command-line validation.
- **Tests**
  - Expanded coverage for sharding, recovery, reporting, process cleanup, and deterministic trace-template discovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->