### PR TITLE
fix: honor sparse MLA KV page strides

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -576,7 +576,7 @@ Used by `flashinfer.trace` / `fi_trace`.
 
 | Variable | Default | Read in | Effect |
 |----------|---------|---------|--------|
-| `FLASHINFER_VALIDATE_INPUTS` | `0` | `flashinfer/mla/_core.py` (MLA wrapper) | Non-zero / non-empty value enables defensive input validation inside the MLA wrapper. Adds host-side overhead; intended for debugging. |
+| `FLASHINFER_VALIDATE_INPUTS` | `0` | `flashinfer/mla/_core.py` (MLA wrapper) | Non-zero / non-empty value enables defensive input validation inside the MLA wrapper. Device-synchronizing checks are skipped during CUDA Graph capture. Adds host-side overhead; intended for debugging. |
 | `FLASHINFER_AUTOTUNER_LOAD_FROM_FILE` | `0` | `flashinfer/autotuner/autotuner.py` | `1` loads previously serialized autotune results from disk instead of re-running the search. |
 | `FLASHINFER_DIST_AWARE_AUTOTUNE` | `0` | `flashinfer/fused_moe/da_config.py` | `1` enables experimental distribution-aware autotune and kernel dispatch (TRT-LLM MoE only). |
 | `FLASHINFER_DA_DISTRIBUTIONS` | built-in distribution catalog | `flashinfer/fused_moe/da_config.py` | Comma-separated training distributions used by the experimental TRT-LLM distribution-aware MoE autotuner. |

--- a/benchmarks/bench_dsv4_hca_trtllm_vs_dkg.py
+++ b/benchmarks/bench_dsv4_hca_trtllm_vs_dkg.py
@@ -450,6 +450,8 @@ def make_trtllm_runners(inputs: HcaInputs) -> BackendRunners:
             inputs.workspace,
             counters,
             inputs.sparse_indices,
+            inputs.sparse_indices,
+            False,
             inputs.seq_lens,
             inputs.sparse_topk_lens,
             softmax_scale,

--- a/csrc/trtllm_fmha_kernel_launcher.cu
+++ b/csrc/trtllm_fmha_kernel_launcher.cu
@@ -37,6 +37,65 @@ using tvm::ffi::Variant;
 
 namespace flashinfer {
 
+namespace {
+
+constexpr int32_t kDsv4SparseMlaSlidingWindowTopK = 128;
+
+__global__ void RemapDsv4SparseMlaIndicesKernel(int32_t const* input, int32_t* output,
+                                                int64_t num_indices, int32_t sparse_mla_top_k,
+                                                int32_t primary_page_size,
+                                                int64_t primary_page_coordinate_stride,
+                                                int32_t sliding_page_size,
+                                                int64_t sliding_page_coordinate_stride) {
+  for (int64_t offset = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+       offset < num_indices; offset += static_cast<int64_t>(gridDim.x) * blockDim.x) {
+    int32_t const index = input[offset];
+    if (index < 0) {
+      output[offset] = index;
+      continue;
+    }
+
+    bool const use_sliding_pool = offset % sparse_mla_top_k < kDsv4SparseMlaSlidingWindowTopK;
+    int32_t const page_size = use_sliding_pool ? sliding_page_size : primary_page_size;
+    int64_t const page_coordinate_stride =
+        use_sliding_pool ? sliding_page_coordinate_stride : primary_page_coordinate_stride;
+    int64_t const page = index / page_size;
+    int64_t const token = index % page_size;
+    output[offset] = static_cast<int32_t>(page * page_coordinate_stride + token);
+  }
+}
+
+struct Dsv4SparseMlaPoolLayout {
+  int32_t page_size;
+  int64_t page_coordinate_stride;
+  bool needs_index_remap;
+};
+
+Dsv4SparseMlaPoolLayout GetDsv4SparseMlaPoolLayout(char const* pool_name, int64_t num_pages,
+                                                   int64_t page_size, int64_t page_stride,
+                                                   int64_t token_stride, int64_t head_dim) {
+  TVM_FFI_ICHECK(num_pages > 0) << pool_name << " must contain at least one page";
+  TVM_FFI_ICHECK(page_size > 0 && page_size <= INT_MAX)
+      << pool_name << " page size must be in [1, INT_MAX]";
+  TVM_FFI_ICHECK(page_stride > 0) << pool_name << " page stride must be positive";
+  TVM_FFI_ICHECK_EQ(token_stride, head_dim)
+      << pool_name << " token stride must equal the head dimension";
+  TVM_FFI_ICHECK((page_stride % token_stride) == 0)
+      << pool_name << " page stride must be divisible by the token stride";
+
+  int64_t const page_coordinate_stride = page_stride / token_stride;
+  int64_t const max_coordinate = INT_MAX - 1;
+  if (num_pages > 1) {
+    TVM_FFI_ICHECK(page_coordinate_stride <= (max_coordinate - page_size + 1) / (num_pages - 1))
+        << pool_name << " encoded page coordinate exceeds int32 range";
+  }
+
+  return {static_cast<int32_t>(page_size), page_coordinate_stride,
+          page_coordinate_stride != page_size};
+}
+
+}  // namespace
+
 enum class TllmPagedAttentionMode {
   Context,
   ForGen,
@@ -909,8 +968,9 @@ void trtllm_ragged_attention(
 void trtllm_paged_attention_decode_sparse_mla_dsv4(
     TensorView out, TensorView query, TensorView primary_kv_cache,
     TensorView sliding_window_kv_cache, TensorView workspace_buffer,
-    TensorView multi_ctas_kv_counter_buffer, TensorView sparse_indices, TensorView seq_lens,
-    TensorView sparse_mla_top_k_lens, Variant<double, ffi::Tensor> bmm1_scale,
+    TensorView multi_ctas_kv_counter_buffer, TensorView sparse_indices,
+    TensorView remapped_sparse_indices, bool sparse_indices_are_storage_offsets,
+    TensorView seq_lens, TensorView sparse_mla_top_k_lens, Variant<double, ffi::Tensor> bmm1_scale,
     Variant<double, ffi::Tensor> bmm2_scale, int64_t batch_size, int64_t max_q_len,
     int64_t sm_count, bool enable_pdl, int64_t workspace_size, Optional<TensorView> attention_sinks,
     Optional<TensorView> cum_seq_lens_q) {
@@ -925,6 +985,8 @@ void trtllm_paged_attention_decode_sparse_mla_dsv4(
       << "sliding_window_kv_cache must have HND shape [pages, heads, page_size, D]";
   TVM_FFI_ICHECK_EQ(sparse_indices.ndim(), 2)
       << "sparse_indices must have flattened shape [sumQ, topK]";
+  TVM_FFI_ICHECK_EQ(remapped_sparse_indices.ndim(), 2)
+      << "remapped_sparse_indices must have flattened shape [sumQ, topK]";
   TVM_FFI_ICHECK_EQ(seq_lens.ndim(), 1);
   TVM_FFI_ICHECK_EQ(sparse_mla_top_k_lens.ndim(), 1)
       << "sparse_mla_top_k_lens must have flattened shape [sumQ]";
@@ -948,6 +1010,8 @@ void trtllm_paged_attention_decode_sparse_mla_dsv4(
       << "sliding_window_kv_cache must have one KV head";
   TVM_FFI_ICHECK_EQ(seq_lens.size(0), batch_size);
   TVM_FFI_ICHECK_EQ(sparse_indices.size(0), sum_seq_q);
+  TVM_FFI_ICHECK_EQ(remapped_sparse_indices.size(0), sum_seq_q);
+  TVM_FFI_ICHECK_EQ(remapped_sparse_indices.size(1), sparse_indices.size(1));
   TVM_FFI_ICHECK_EQ(sparse_mla_top_k_lens.size(0), sum_seq_q);
   if (is_varlen_q) {
     TVM_FFI_ICHECK_EQ(cum_seq_lens_q.value().ndim(), 1);
@@ -973,16 +1037,69 @@ void trtllm_paged_attention_decode_sparse_mla_dsv4(
   TVM_FFI_ICHECK_EQ(head_dim_o, 512);
 
   int const sparse_mla_top_k = sparse_indices.size(-1);
+  TVM_FFI_ICHECK(sparse_mla_top_k >= kDsv4SparseMlaSlidingWindowTopK)
+      << "sparse topK must include 128 sliding-window entries";
   TVM_FFI_ICHECK((sparse_mla_top_k % 4) == 0) << "sparse topK must be a multiple of 4";
-  int const physical_page_size = primary_kv_cache.size(-2);
+  TVM_FFI_ICHECK_EQ(sparse_indices.dtype(), dl_int32) << "sparse_indices must be int32";
+  TVM_FFI_ICHECK(sparse_indices.IsContiguous()) << "sparse_indices must be contiguous";
+  TVM_FFI_ICHECK_EQ(remapped_sparse_indices.dtype(), dl_int32)
+      << "remapped_sparse_indices must be int32";
+  TVM_FFI_ICHECK(remapped_sparse_indices.IsContiguous())
+      << "remapped_sparse_indices must be contiguous";
+  TVM_FFI_ICHECK_EQ(primary_kv_cache.stride(-1), 1)
+      << "primary_kv_cache head dimension must be contiguous";
+  TVM_FFI_ICHECK_EQ(sliding_window_kv_cache.stride(-1), 1)
+      << "sliding_window_kv_cache head dimension must be contiguous";
+  TVM_FFI_ICHECK(reinterpret_cast<std::uintptr_t>(primary_kv_cache.data_ptr()) % 16 == 0)
+      << "primary_kv_cache must be 16-byte aligned for TMA";
+  TVM_FFI_ICHECK(reinterpret_cast<std::uintptr_t>(sliding_window_kv_cache.data_ptr()) % 16 == 0)
+      << "sliding_window_kv_cache must be 16-byte aligned for TMA";
+
   int const sparse_page_size = 1;
   int const stride_idx_factor = is_4bit(kv_data_type) ? 2 : 1;
+  TVM_FFI_ICHECK(primary_kv_cache.stride(0) <=
+                 std::numeric_limits<int64_t>::max() / stride_idx_factor);
+  TVM_FFI_ICHECK(primary_kv_cache.stride(-2) <=
+                 std::numeric_limits<int64_t>::max() / stride_idx_factor);
+  TVM_FFI_ICHECK(sliding_window_kv_cache.stride(0) <=
+                 std::numeric_limits<int64_t>::max() / stride_idx_factor);
+  TVM_FFI_ICHECK(sliding_window_kv_cache.stride(-2) <=
+                 std::numeric_limits<int64_t>::max() / stride_idx_factor);
+  auto const primary_layout = GetDsv4SparseMlaPoolLayout(
+      "primary_kv_cache", primary_kv_cache.size(0), primary_kv_cache.size(-2),
+      primary_kv_cache.stride(0) * stride_idx_factor,
+      primary_kv_cache.stride(-2) * stride_idx_factor, head_dim_k);
+  auto const sliding_layout = GetDsv4SparseMlaPoolLayout(
+      "sliding_window_kv_cache", sliding_window_kv_cache.size(0), sliding_window_kv_cache.size(-2),
+      sliding_window_kv_cache.stride(0) * stride_idx_factor,
+      sliding_window_kv_cache.stride(-2) * stride_idx_factor, head_dim_sw);
+
   int const kv_stride_keys_values = primary_kv_cache.stride(-2) * stride_idx_factor;
   int const kv_stride_heads = primary_kv_cache.stride(-3) * stride_idx_factor;
   int const sparse_kv_stride_batch = kv_stride_keys_values;
   int const q_stride_tokens = query.stride(0);
   int const q_stride_heads = query.stride(1);
-  int const sparse_num_pages_in_mem_pool = primary_kv_cache.size(0) * physical_page_size;
+  int const sparse_num_pages_in_mem_pool = primary_kv_cache.size(0) * primary_kv_cache.size(-2);
+
+  int* sparse_indices_ptr = static_cast<int*>(sparse_indices.data_ptr());
+  bool const needs_index_remap =
+      !sparse_indices_are_storage_offsets &&
+      (primary_layout.needs_index_remap || sliding_layout.needs_index_remap);
+  auto const stream = get_stream(query.device());
+  if (needs_index_remap && sparse_indices.numel() > 0) {
+    int64_t const num_sparse_indices = sparse_indices.numel();
+    sparse_indices_ptr = static_cast<int*>(remapped_sparse_indices.data_ptr());
+
+    constexpr int32_t threads = 256;
+    int32_t const blocks = static_cast<int32_t>(
+        std::min<int64_t>(ceil_div(num_sparse_indices, static_cast<int64_t>(threads)), 65535));
+    RemapDsv4SparseMlaIndicesKernel<<<blocks, threads, 0, stream>>>(
+        static_cast<int32_t const*>(sparse_indices.data_ptr()), sparse_indices_ptr,
+        num_sparse_indices, sparse_mla_top_k, primary_layout.page_size,
+        primary_layout.page_coordinate_stride, sliding_layout.page_size,
+        sliding_layout.page_coordinate_stride);
+    FLASHINFER_CUDA_CHECK(cudaGetLastError());
+  }
 
   float* attention_sinks_ptr = nullptr;
   if (attention_sinks.has_value()) {
@@ -1011,13 +1128,12 @@ void trtllm_paged_attention_decode_sparse_mla_dsv4(
                               ? static_cast<float*>(maybe_bmm2_scale_tensor.value().data_ptr())
                               : nullptr;
 
-  auto const stream = get_stream(query.device());
   trtllm_paged_attention_launcher(
       out.data_ptr(), /*out_scale_factor=*/nullptr, query.data_ptr(), primary_kv_cache.data_ptr(),
       primary_kv_cache.data_ptr(), workspace_buffer.data_ptr(),
       multi_ctas_kv_counter_buffer.data_ptr(),
       multi_ctas_kv_counter_buffer.numel() * get_element_size(multi_ctas_kv_counter_buffer),
-      static_cast<int*>(sparse_indices.data_ptr()), /*k_block_scales_ptr=*/nullptr,
+      sparse_indices_ptr, /*k_block_scales_ptr=*/nullptr,
       /*v_block_scales_ptr=*/nullptr, static_cast<int*>(seq_lens.data_ptr()), cum_seq_lens_q_ptr,
       /*cum_seq_lens_kv=*/nullptr, attention_sinks_ptr, /*lse=*/nullptr, q_data_type, kv_data_type,
       o_data_type, TllmPagedAttentionMode::ForGen, batch_size, max_q_len,

--- a/csrc/trtllm_fmha_kernel_launcher.cu
+++ b/csrc/trtllm_fmha_kernel_launcher.cu
@@ -1046,6 +1046,10 @@ void trtllm_paged_attention_decode_sparse_mla_dsv4(
       << "remapped_sparse_indices must be int32";
   TVM_FFI_ICHECK(remapped_sparse_indices.IsContiguous())
       << "remapped_sparse_indices must be contiguous";
+  TVM_FFI_ICHECK_EQ(remapped_sparse_indices.device().device_type, query.device().device_type)
+      << "remapped_sparse_indices must be on the same device as query";
+  TVM_FFI_ICHECK_EQ(remapped_sparse_indices.device().device_id, query.device().device_id)
+      << "remapped_sparse_indices must be on the same device as query";
   TVM_FFI_ICHECK_EQ(primary_kv_cache.stride(-1), 1)
       << "primary_kv_cache head dimension must be contiguous";
   TVM_FFI_ICHECK_EQ(sliding_window_kv_cache.stride(-1), 1)

--- a/flashinfer/mla/_core.py
+++ b/flashinfer/mla/_core.py
@@ -1647,7 +1647,8 @@ def trtllm_batch_decode_sparse_mla_dsv4(
         Optional INT32 output buffer matching ``sparse_indices``. TRTLLM-GEN
         uses it when either KV pool has a strided page layout. Passing a stable
         buffer avoids an allocation in serving and CUDA graph paths. Concurrent
-        calls must use distinct buffers.
+        calls must use distinct buffers. The buffer must not share storage
+        with ``sparse_indices`` when remapping is required.
     sparse_indices_are_storage_offsets : Optional[bool]
         Encoding of ``sparse_indices`` for strided TRTLLM-GEN KV pools. Set to
         ``False`` for logical flattened token indices or ``True`` for indices
@@ -1939,6 +1940,15 @@ def trtllm_batch_decode_sparse_mla_dsv4(
         )
         if not remapped_sparse_indices_buffer.is_contiguous():
             raise ValueError("remapped_sparse_indices_buffer must be contiguous")
+        if (
+            needs_index_remap
+            and remapped_sparse_indices_buffer.untyped_storage().data_ptr()
+            == sparse_indices.untyped_storage().data_ptr()
+        ):
+            raise ValueError(
+                "remapped_sparse_indices_buffer must not share storage with "
+                "sparse_indices"
+            )
     elif needs_index_remap:
         remapped_sparse_indices_buffer = torch.empty_like(sparse_indices)
     else:

--- a/flashinfer/mla/_core.py
+++ b/flashinfer/mla/_core.py
@@ -812,8 +812,14 @@ def _normalize_dsv4_topk_lens(
     return topk_lens
 
 
-def _validate_dsv4_sync_checks() -> bool:
-    return os.environ.get("FLASHINFER_VALIDATE_INPUTS", "0") not in ("0", "")
+def _validate_dsv4_sync_checks(device: torch.device) -> bool:
+    if os.environ.get("FLASHINFER_VALIDATE_INPUTS", "0") in ("0", ""):
+        return False
+    if device.type == "cuda":
+        with torch.cuda.device(device):
+            if torch.cuda.is_current_stream_capturing():
+                return False
+    return True
 
 
 def _check_dsv4_sparse_mla_inputs(
@@ -998,7 +1004,7 @@ def _check_dsv4_sparse_mla_inputs(
         query.device,
         cum_seq_lens_q,
     )
-    if _validate_dsv4_sync_checks() and normalized_sparse_lens.numel() > 0:
+    if _validate_dsv4_sync_checks(query.device) and normalized_sparse_lens.numel() > 0:
         sparse_topk_capacity = sparse_indices.size(-1)
         invalid_sparse_lens = torch.logical_or(
             normalized_sparse_lens < 128,
@@ -1911,7 +1917,7 @@ def trtllm_batch_decode_sparse_mla_dsv4(
         q_lens = seq_lens.new_full((batch_size,), q_len_per_request)
     else:
         q_lens = cum_seq_lens_q[1:] - cum_seq_lens_q[:-1]
-    if _validate_dsv4_sync_checks() and torch.any(seq_lens < q_lens).item():
+    if _validate_dsv4_sync_checks(query.device) and torch.any(seq_lens < q_lens).item():
         raise ValueError(
             "seq_lens must be greater than or equal to the per-request query "
             "lengths so TRTLLM-GEN can derive the SWA-128 valid window"

--- a/flashinfer/mla/_core.py
+++ b/flashinfer/mla/_core.py
@@ -1511,6 +1511,8 @@ def trtllm_batch_decode_sparse_mla_dsv4(
     hca_is_causal: bool = True,
     hca_use_persistent: bool = False,
     hca_sparse_indices_format: Optional[Literal["compressed-page-aligned"]] = None,
+    remapped_sparse_indices_buffer: Optional[torch.Tensor] = None,
+    sparse_indices_are_storage_offsets: Optional[bool] = None,
 ) -> torch.Tensor:
     r"""Decode DeepSeek V4 sparse MLA.
 
@@ -1641,8 +1643,27 @@ def trtllm_batch_decode_sparse_mla_dsv4(
         with
         :func:`convert_compressed_page_aligned_sparse_indices_to_hca_metadata`
         and reuse the returned metadata through the explicit HCA arguments.
+    remapped_sparse_indices_buffer : Optional[torch.Tensor]
+        Optional INT32 output buffer matching ``sparse_indices``. TRTLLM-GEN
+        uses it when either KV pool has a strided page layout. Passing a stable
+        buffer avoids an allocation in serving and CUDA graph paths. Concurrent
+        calls must use distinct buffers.
+    sparse_indices_are_storage_offsets : Optional[bool]
+        Encoding of ``sparse_indices`` for strided TRTLLM-GEN KV pools. Set to
+        ``False`` for logical flattened token indices or ``True`` for indices
+        already adjusted to storage-row offsets. Strided pools require an
+        explicit value to prevent accidental double remapping.
     """
     backend = _resolve_dsv4_sparse_mla_backend(query.device, backend)
+
+    if backend != "trtllm-gen" and (
+        remapped_sparse_indices_buffer is not None
+        or sparse_indices_are_storage_offsets is not None
+    ):
+        raise ValueError(
+            f"backend={backend!r} does not accept remapped_sparse_indices_buffer "
+            "or sparse_indices_are_storage_offsets"
+        )
 
     if backend == "cute-dsl":
         if not hca_is_causal:
@@ -1898,6 +1919,30 @@ def trtllm_batch_decode_sparse_mla_dsv4(
     primary_kv_cache = compressed_kv_cache
     sparse_indices = sparse_indices.reshape(query_flat.size(0), -1).contiguous()
     sparse_topk_lens = sparse_topk_lens.contiguous()
+    has_strided_pages = any(
+        kv_cache.stride(-2) != kv_cache.size(-1)
+        or kv_cache.stride(0) != kv_cache.size(-2) * kv_cache.stride(-2)
+        for kv_cache in (primary_kv_cache, swa_kv_cache)
+    )
+    if has_strided_pages and sparse_indices_are_storage_offsets is None:
+        raise ValueError(
+            "sparse_indices_are_storage_offsets must be set for strided KV pools"
+        )
+    needs_index_remap = has_strided_pages and not sparse_indices_are_storage_offsets
+    if remapped_sparse_indices_buffer is not None:
+        check_shape_dtype_device(
+            remapped_sparse_indices_buffer,
+            tuple(sparse_indices.shape),
+            torch.int32,
+            query.device,
+            "remapped_sparse_indices_buffer",
+        )
+        if not remapped_sparse_indices_buffer.is_contiguous():
+            raise ValueError("remapped_sparse_indices_buffer must be contiguous")
+    elif needs_index_remap:
+        remapped_sparse_indices_buffer = torch.empty_like(sparse_indices)
+    else:
+        remapped_sparse_indices_buffer = sparse_indices
 
     op = get_trtllm_gen_fmha_module()
     run_func = getattr(op, "trtllm_paged_attention_decode_sparse_mla_dsv4", None)
@@ -1921,6 +1966,8 @@ def trtllm_batch_decode_sparse_mla_dsv4(
         workspace_buffer,
         multi_ctas_kv_counter_buffer,
         sparse_indices,
+        remapped_sparse_indices_buffer,
+        sparse_indices_are_storage_offsets is True,
         seq_lens.contiguous(),
         sparse_topk_lens,
         bmm1_scale,

--- a/tests/attention/test_cute_dsl_hca_dsv4.py
+++ b/tests/attention/test_cute_dsl_hca_dsv4.py
@@ -215,6 +215,32 @@ def test_dsv4_backend_resolution_is_explicit(monkeypatch):
         mla_core._resolve_dsv4_sparse_mla_backend(torch.device("cpu"), "cute-dsl")
 
 
+@pytest.mark.parametrize(
+    ("backend", "compute_capability"),
+    (("cute-dsl", (10, 0)), ("sparse", (12, 0))),
+)
+@pytest.mark.parametrize(
+    "remap_arg",
+    ("remapped_sparse_indices_buffer", "sparse_indices_are_storage_offsets"),
+)
+def test_non_trtllm_dsv4_backends_reject_index_remapping_args(
+    monkeypatch, backend, compute_capability, remap_arg
+):
+    args = _cpu_hca_inputs()
+    args["backend"] = backend
+    args[remap_arg] = (
+        torch.empty((1, 128), dtype=torch.int32)
+        if remap_arg == "remapped_sparse_indices_buffer"
+        else False
+    )
+    monkeypatch.setattr(
+        mla_core, "get_compute_capability", lambda _device: compute_capability
+    )
+
+    with pytest.raises(ValueError, match=f"backend='{backend}' does not accept"):
+        trtllm_batch_decode_sparse_mla_dsv4(**args)
+
+
 def test_dsv4_backend_neutral_alias_is_backward_compatible():
     assert batch_decode_sparse_mla_dsv4 is trtllm_batch_decode_sparse_mla_dsv4
     assert (

--- a/tests/attention/test_trtllm_gen_sparse_mla_dsv4.py
+++ b/tests/attention/test_trtllm_gen_sparse_mla_dsv4.py
@@ -1040,8 +1040,9 @@ def test_trtllm_gen_sparse_mla_dsv4_strided_pages(
 
 
 @torch.inference_mode()
-def test_trtllm_gen_sparse_mla_dsv4_strided_pages_cuda_graph() -> None:
+def test_trtllm_gen_sparse_mla_dsv4_strided_pages_cuda_graph(monkeypatch) -> None:
     _skip_unless_sm100_or_sm103()
+    monkeypatch.setenv("FLASHINFER_VALIDATE_INPUTS", "1")
     p = RawTestParamForDecode(
         b=2,
         h_q=64,

--- a/tests/attention/test_trtllm_gen_sparse_mla_dsv4.py
+++ b/tests/attention/test_trtllm_gen_sparse_mla_dsv4.py
@@ -698,6 +698,8 @@ def run_flashinfer_decode(
     swa_page_stride_padding_elements: int = 0,
     compressed_page_stride_padding_elements: int = 0,
     sparse_indices_are_storage_offsets: bool | None = None,
+    remapped_sparse_indices_buffer: torch.Tensor | None = None,
+    out: torch.Tensor | None = None,
 ) -> torch.Tensor:
     assert t.decode is not None
     swa_indices = testcase.kv_scope.indices_in_kvcache[testcase.valid_q].contiguous()
@@ -773,6 +775,9 @@ def run_flashinfer_decode(
             cum_seq_lens_q=cum_seq_lens_q,
             max_q_len=max_q_len,
             enable_pdl=False,
+            backend="trtllm-gen",
+            out=out,
+            remapped_sparse_indices_buffer=remapped_sparse_indices_buffer,
             sparse_indices_are_storage_offsets=sparse_indices_are_storage_offsets,
         )
     except RuntimeError as err:
@@ -882,10 +887,15 @@ def test_trtllm_gen_sparse_mla_dsv4(p: TestParam) -> None:
 
 
 @pytest.mark.parametrize("kv_layout", ("HND", "NHD"))
+@pytest.mark.parametrize(
+    "dtype", (torch.bfloat16, torch.float8_e4m3fn), ids=("bf16", "fp8")
+)
 @pytest.mark.parametrize("sparse_indices_are_storage_offsets", (False, True))
 @torch.inference_mode()
 def test_trtllm_gen_sparse_mla_dsv4_strided_pages(
-    kv_layout: KVLayout, sparse_indices_are_storage_offsets: bool
+    kv_layout: KVLayout,
+    dtype: torch.dtype,
+    sparse_indices_are_storage_offsets: bool,
 ) -> None:
     _skip_unless_sm100_or_sm103()
     p = RawTestParamForDecode(
@@ -901,14 +911,23 @@ def test_trtllm_gen_sparse_mla_dsv4_strided_pages(
         block_size=SWA_PAGE_SIZE,
         extra_block_size=C4_PAGE_SIZE,
         seed=TEST_SEED_BASE + len(TESTCASES),
-        dtype=torch.bfloat16,
+        dtype=dtype,
         kv_layout=kv_layout,
         sparse_case="swa128+topk4x",
     ).to_test_param()
     testcase = generate_testcase_for_decode(p)
-    testcase.kv_scope.indices_in_kvcache[0, 0] = -1
+    testcase.kv_scope.indices_in_kvcache[0, 0, 0] = -1
     assert testcase.extra_kv_scope is not None
-    testcase.extra_kv_scope.indices_in_kvcache[0, 0] = -1
+    testcase.extra_kv_scope.indices_in_kvcache[0, 0, 0] = -1
+    assert testcase.extra_kv_scope.topk_length is not None
+    for batch_idx, topk_len in enumerate(
+        testcase.extra_kv_scope.topk_length[:, 0].tolist()
+    ):
+        testcase.extra_kv_scope.indices_in_kvcache[batch_idx, 0, topk_len:] = -1
+    assert torch.any(testcase.kv_scope.indices_in_kvcache >= p.decode.block_size)
+    assert torch.any(
+        testcase.extra_kv_scope.indices_in_kvcache >= p.decode.extra_block_size
+    )
     out_ans = run_flashinfer_decode(
         p,
         testcase,
@@ -917,4 +936,100 @@ def test_trtllm_gen_sparse_mla_dsv4_strided_pages(
         sparse_indices_are_storage_offsets=sparse_indices_are_storage_offsets,
     )
     out_ref, _ = ref_sparse_attn_decode(p, testcase)
+    _assert_close(out_ans, out_ref, p.dtype)
+
+
+@torch.inference_mode()
+def test_trtllm_gen_sparse_mla_dsv4_strided_pages_cuda_graph() -> None:
+    _skip_unless_sm100_or_sm103()
+    p = RawTestParamForDecode(
+        b=2,
+        h_q=64,
+        s_q=3,
+        h_kv=1,
+        s_kv=512,
+        is_varlen=True,
+        topk=DSV4_SWA_TOPK,
+        extra_s_k=1024,
+        extra_topk=_c4_topk(64),
+        block_size=SWA_PAGE_SIZE,
+        extra_block_size=C4_PAGE_SIZE,
+        seed=TEST_SEED_BASE + len(TESTCASES) + 1,
+        dtype=torch.bfloat16,
+        kv_layout="HND",
+        sparse_case="swa128+topk4x",
+    ).to_test_param()
+    testcase = generate_testcase_for_decode(p)
+    assert p.decode is not None
+    assert p.decode.extra_topk is not None
+    num_queries = int(testcase.valid_q.sum().item())
+    remapped_sparse_indices_buffer = torch.empty(
+        (num_queries, DSV4_SWA_TOPK + p.decode.extra_topk),
+        dtype=torch.int32,
+        device="cuda:0",
+    )
+    out = torch.empty(
+        (num_queries, p.h_q, p.d_v),
+        dtype=torch.bfloat16,
+        device="cuda:0",
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="sparse_indices_are_storage_offsets must be set for strided KV pools",
+    ):
+        run_flashinfer_decode(
+            p,
+            testcase,
+            swa_page_stride_padding_elements=512,
+            compressed_page_stride_padding_elements=1024,
+        )
+
+    run_flashinfer_decode(
+        p,
+        testcase,
+        swa_page_stride_padding_elements=512,
+        compressed_page_stride_padding_elements=1024,
+        sparse_indices_are_storage_offsets=False,
+        remapped_sparse_indices_buffer=remapped_sparse_indices_buffer,
+        out=out,
+    )
+    assert testcase.extra_kv_scope is not None
+    expected_indices = torch.cat(
+        (
+            testcase.kv_scope.indices_in_kvcache[testcase.valid_q],
+            testcase.extra_kv_scope.indices_in_kvcache[testcase.valid_q],
+        ),
+        dim=-1,
+    ).contiguous()
+    for indices, page_size, padding in (
+        (expected_indices[:, :DSV4_SWA_TOPK], SWA_PAGE_SIZE, 512),
+        (expected_indices[:, DSV4_SWA_TOPK:], C4_PAGE_SIZE, 1024),
+    ):
+        valid = indices >= 0
+        page_span = page_size + padding // DSV4_HEAD_DIM
+        indices[valid] = (
+            torch.div(indices[valid], page_size, rounding_mode="floor") * page_span
+            + indices[valid] % page_size
+        )
+    torch.testing.assert_close(remapped_sparse_indices_buffer, expected_indices)
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        out_ans = run_flashinfer_decode(
+            p,
+            testcase,
+            swa_page_stride_padding_elements=512,
+            compressed_page_stride_padding_elements=1024,
+            sparse_indices_are_storage_offsets=False,
+            remapped_sparse_indices_buffer=remapped_sparse_indices_buffer,
+            out=out,
+        )
+    out.zero_()
+    graph.replay()
+    torch.cuda.synchronize()
+
+    assert out_ans.data_ptr() == out.data_ptr()
+    out_ref, _ = ref_sparse_attn_decode(p, testcase)
+    out_ref = out_ref[testcase.valid_q]
     _assert_close(out_ans, out_ref, p.dtype)

--- a/tests/attention/test_trtllm_gen_sparse_mla_dsv4.py
+++ b/tests/attention/test_trtllm_gen_sparse_mla_dsv4.py
@@ -6,6 +6,7 @@ import pytest
 import torch
 
 from flashinfer.mla import trtllm_batch_decode_sparse_mla_dsv4
+from flashinfer.mla._core import get_trtllm_gen_fmha_module
 from flashinfer.utils import get_compute_capability
 
 
@@ -871,6 +872,95 @@ def _skip_unless_sm100_or_sm103() -> None:
         pytest.skip(
             "TRTLLM-GEN DeepSeek V4 sparse MLA requires SM100/SM103, "
             f"got SM{compute_capability[0]}{compute_capability[1]}"
+        )
+
+
+def _strided_validation_pool(page_size: int, padding: int) -> torch.Tensor:
+    num_pages = 2
+    page_stride = page_size * DSV4_HEAD_DIM + padding
+    backing = torch.empty(
+        (num_pages - 1) * page_stride + page_size * DSV4_HEAD_DIM,
+        dtype=torch.bfloat16,
+        device="cuda",
+    )
+    return torch.as_strided(
+        backing,
+        (num_pages, 1, page_size, DSV4_HEAD_DIM),
+        (page_stride, page_size * DSV4_HEAD_DIM, DSV4_HEAD_DIM, 1),
+    )
+
+
+@torch.inference_mode()
+def test_trtllm_gen_sparse_mla_rejects_remap_buffer_on_other_device() -> None:
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is required for TRTLLM-GEN FFI validation")
+
+    query = torch.empty((1, 8, DSV4_HEAD_DIM), dtype=torch.bfloat16, device="cuda")
+    sparse_indices = torch.zeros((1, DSV4_SWA_TOPK), dtype=torch.int32, device="cuda")
+    op = get_trtllm_gen_fmha_module()
+    with pytest.raises(RuntimeError, match="same device as query"):
+        op.trtllm_paged_attention_decode_sparse_mla_dsv4(
+            torch.empty_like(query),
+            query,
+            _strided_validation_pool(C4_PAGE_SIZE, 1024),
+            _strided_validation_pool(SWA_PAGE_SIZE, 512),
+            torch.empty(1, dtype=torch.uint8, device="cuda"),
+            torch.zeros(1, dtype=torch.int32, device="cuda"),
+            sparse_indices,
+            torch.empty(sparse_indices.shape, dtype=torch.int32, device="cpu"),
+            False,
+            torch.tensor([SWA_PAGE_SIZE], dtype=torch.int32, device="cuda"),
+            torch.tensor([DSV4_SWA_TOPK], dtype=torch.int32, device="cuda"),
+            1.0,
+            1.0,
+            1,
+            1,
+            1,
+            False,
+            1,
+            None,
+            None,
+        )
+
+
+@pytest.mark.parametrize(
+    "remap_storage_offset", (0, 1), ids=("exact-alias", "shifted-overlap")
+)
+@torch.inference_mode()
+def test_trtllm_gen_sparse_mla_rejects_aliasing_remap_buffer(
+    monkeypatch, remap_storage_offset: int
+) -> None:
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is required for TRTLLM-GEN input validation")
+    monkeypatch.setattr(
+        "flashinfer.mla._core.get_compute_capability", lambda _device: (10, 0)
+    )
+
+    index_storage = torch.zeros(
+        DSV4_SWA_TOPK + remap_storage_offset, dtype=torch.int32, device="cuda"
+    )
+    sparse_indices = index_storage[:DSV4_SWA_TOPK].view(1, DSV4_SWA_TOPK)
+    remapped_sparse_indices = index_storage[
+        remap_storage_offset : remap_storage_offset + DSV4_SWA_TOPK
+    ].view(1, DSV4_SWA_TOPK)
+    with pytest.raises(ValueError, match="must not share storage"):
+        trtllm_batch_decode_sparse_mla_dsv4(
+            query=torch.empty(
+                (1, 1, 8, DSV4_HEAD_DIM), dtype=torch.bfloat16, device="cuda"
+            ),
+            swa_kv_cache=_strided_validation_pool(SWA_PAGE_SIZE, 512),
+            workspace_buffer=torch.empty(1, dtype=torch.uint8, device="cuda"),
+            sparse_indices=sparse_indices,
+            compressed_kv_cache=_strided_validation_pool(C4_PAGE_SIZE, 1024),
+            sparse_topk_lens=torch.tensor(
+                [DSV4_SWA_TOPK], dtype=torch.int32, device="cuda"
+            ),
+            seq_lens=torch.tensor([SWA_PAGE_SIZE], dtype=torch.int32, device="cuda"),
+            bmm1_scale=1.0,
+            bmm2_scale=1.0,
+            backend="trtllm-gen",
+            remapped_sparse_indices_buffer=remapped_sparse_indices,
+            sparse_indices_are_storage_offsets=False,
         )
 
 

--- a/tests/attention/test_trtllm_gen_sparse_mla_dsv4.py
+++ b/tests/attention/test_trtllm_gen_sparse_mla_dsv4.py
@@ -162,10 +162,29 @@ class KVScope:
     indices_in_kvcache: torch.Tensor
     topk_length: torch.Tensor | None
 
-    def get_kvcache_for_flashinfer(self, kv_layout: KVLayout) -> torch.Tensor:
+    def get_kvcache_for_flashinfer(
+        self, kv_layout: KVLayout, page_stride_padding_elements: int = 0
+    ) -> torch.Tensor:
         if kv_layout == "HND":
-            return self.blocked_k.transpose(1, 2).contiguous()
-        return self.blocked_k.contiguous()
+            kv_cache = self.blocked_k.transpose(1, 2).contiguous()
+        else:
+            kv_cache = self.blocked_k.contiguous()
+        if page_stride_padding_elements == 0:
+            return kv_cache
+
+        strides = list(kv_cache.stride())
+        strides[0] += page_stride_padding_elements
+        storage_size = 1 + sum(
+            (size - 1) * stride
+            for size, stride in zip(kv_cache.shape, strides, strict=True)
+        )
+        backing = torch.full(
+            (storage_size,),
+            7.0,
+            dtype=kv_cache.dtype,
+            device=kv_cache.device,
+        )
+        return torch.as_strided(backing, kv_cache.shape, strides).copy_(kv_cache)
 
 
 @dataclasses.dataclass
@@ -672,13 +691,23 @@ def _scale_for_flashinfer(t: TestParam, value: float) -> float | torch.Tensor:
     return value
 
 
-def run_flashinfer_decode(t: TestParam, testcase: TestcaseForDecode) -> torch.Tensor:
+def run_flashinfer_decode(
+    t: TestParam,
+    testcase: TestcaseForDecode,
+    *,
+    swa_page_stride_padding_elements: int = 0,
+    compressed_page_stride_padding_elements: int = 0,
+    sparse_indices_are_storage_offsets: bool | None = None,
+) -> torch.Tensor:
     assert t.decode is not None
     swa_indices = testcase.kv_scope.indices_in_kvcache[testcase.valid_q].contiguous()
+    swa_kv_cache = testcase.kv_scope.get_kvcache_for_flashinfer(
+        t.kv_layout, swa_page_stride_padding_elements
+    )
     if testcase.extra_kv_scope is not None:
         assert testcase.extra_kv_scope.topk_length is not None
         compressed_kv_cache = testcase.extra_kv_scope.get_kvcache_for_flashinfer(
-            t.kv_layout
+            t.kv_layout, compressed_page_stride_padding_elements
         )
         compressed_indices = testcase.extra_kv_scope.indices_in_kvcache[
             testcase.valid_q
@@ -690,10 +719,35 @@ def run_flashinfer_decode(t: TestParam, testcase: TestcaseForDecode) -> torch.Te
             + DSV4_SWA_TOPK
         ).contiguous()
     else:
-        compressed_kv_cache = testcase.kv_scope.get_kvcache_for_flashinfer(t.kv_layout)
+        compressed_kv_cache = swa_kv_cache
         compressed_indices = swa_indices.new_empty((swa_indices.size(0), 0))
         sparse_topk_lens = swa_indices.new_full((swa_indices.size(0),), DSV4_SWA_TOPK)
     sparse_indices = torch.cat((swa_indices, compressed_indices), dim=-1).contiguous()
+    if sparse_indices_are_storage_offsets:
+        sparse_indices = sparse_indices.clone()
+        segments = [
+            (
+                sparse_indices[:, :DSV4_SWA_TOPK],
+                t.decode.block_size,
+                swa_page_stride_padding_elements,
+            )
+        ]
+        if compressed_indices.numel() > 0:
+            assert t.decode.extra_block_size is not None
+            segments.append(
+                (
+                    sparse_indices[:, DSV4_SWA_TOPK:],
+                    t.decode.extra_block_size,
+                    compressed_page_stride_padding_elements,
+                )
+            )
+        for indices, page_size, padding in segments:
+            valid = indices >= 0
+            page_span = page_size + padding // DSV4_HEAD_DIM
+            indices[valid] = (
+                torch.div(indices[valid], page_size, rounding_mode="floor") * page_span
+                + indices[valid] % page_size
+            )
     if t.decode.is_varlen:
         query = testcase.q[testcase.valid_q].contiguous()
         cum_seq_lens_q = _make_cum_seq_lens(testcase.q_lens)
@@ -706,7 +760,7 @@ def run_flashinfer_decode(t: TestParam, testcase: TestcaseForDecode) -> torch.Te
     try:
         return trtllm_batch_decode_sparse_mla_dsv4(
             query=query,
-            swa_kv_cache=testcase.kv_scope.get_kvcache_for_flashinfer(t.kv_layout),
+            swa_kv_cache=swa_kv_cache,
             workspace_buffer=testcase.workspace_buffer,
             sparse_indices=sparse_indices,
             compressed_kv_cache=compressed_kv_cache,
@@ -719,6 +773,7 @@ def run_flashinfer_decode(t: TestParam, testcase: TestcaseForDecode) -> torch.Te
             cum_seq_lens_q=cum_seq_lens_q,
             max_q_len=max_q_len,
             enable_pdl=False,
+            sparse_indices_are_storage_offsets=sparse_indices_are_storage_offsets,
         )
     except RuntimeError as err:
         err_msg = str(err)
@@ -823,4 +878,43 @@ def test_trtllm_gen_sparse_mla_dsv4(p: TestParam) -> None:
     out_ref, _ = ref_sparse_attn_decode(p, testcase)
     if p.decode is not None and p.decode.is_varlen:
         out_ref = out_ref[testcase.valid_q]
+    _assert_close(out_ans, out_ref, p.dtype)
+
+
+@pytest.mark.parametrize("kv_layout", ("HND", "NHD"))
+@pytest.mark.parametrize("sparse_indices_are_storage_offsets", (False, True))
+@torch.inference_mode()
+def test_trtllm_gen_sparse_mla_dsv4_strided_pages(
+    kv_layout: KVLayout, sparse_indices_are_storage_offsets: bool
+) -> None:
+    _skip_unless_sm100_or_sm103()
+    p = RawTestParamForDecode(
+        b=2,
+        h_q=64,
+        s_q=1,
+        h_kv=1,
+        s_kv=512,
+        is_varlen=False,
+        topk=DSV4_SWA_TOPK,
+        extra_s_k=1024,
+        extra_topk=_c4_topk(64),
+        block_size=SWA_PAGE_SIZE,
+        extra_block_size=C4_PAGE_SIZE,
+        seed=TEST_SEED_BASE + len(TESTCASES),
+        dtype=torch.bfloat16,
+        kv_layout=kv_layout,
+        sparse_case="swa128+topk4x",
+    ).to_test_param()
+    testcase = generate_testcase_for_decode(p)
+    testcase.kv_scope.indices_in_kvcache[0, 0] = -1
+    assert testcase.extra_kv_scope is not None
+    testcase.extra_kv_scope.indices_in_kvcache[0, 0] = -1
+    out_ans = run_flashinfer_decode(
+        p,
+        testcase,
+        swa_page_stride_padding_elements=512,
+        compressed_page_stride_padding_elements=1024,
+        sparse_indices_are_storage_offsets=sparse_indices_are_storage_offsets,
+    )
+    out_ref, _ = ref_sparse_attn_decode(p, testcase)
     _assert_close(out_ans, out_ref, p.dtype)

--- a/tests/attention/test_trtllm_gen_sparse_mla_dsv4.py
+++ b/tests/attention/test_trtllm_gen_sparse_mla_dsv4.py
@@ -692,6 +692,19 @@ def _scale_for_flashinfer(t: TestParam, value: float) -> float | torch.Tensor:
     return value
 
 
+def _remap_indices_to_storage_offsets(
+    indices: torch.Tensor, page_size: int, padding: int
+) -> torch.Tensor:
+    remapped = indices.clone()
+    valid = remapped >= 0
+    page_span = page_size + padding // DSV4_HEAD_DIM
+    remapped[valid] = (
+        torch.div(remapped[valid], page_size, rounding_mode="floor") * page_span
+        + remapped[valid] % page_size
+    )
+    return remapped
+
+
 def run_flashinfer_decode(
     t: TestParam,
     testcase: TestcaseForDecode,
@@ -745,11 +758,8 @@ def run_flashinfer_decode(
                 )
             )
         for indices, page_size, padding in segments:
-            valid = indices >= 0
-            page_span = page_size + padding // DSV4_HEAD_DIM
-            indices[valid] = (
-                torch.div(indices[valid], page_size, rounding_mode="floor") * page_span
-                + indices[valid] % page_size
+            indices.copy_(
+                _remap_indices_to_storage_offsets(indices, page_size, padding)
             )
     if t.decode.is_varlen:
         query = testcase.q[testcase.valid_q].contiguous()
@@ -1052,6 +1062,9 @@ def test_trtllm_gen_sparse_mla_dsv4_strided_pages_cuda_graph() -> None:
     testcase = generate_testcase_for_decode(p)
     assert p.decode is not None
     assert p.decode.extra_topk is not None
+    assert p.decode.extra_block_size is not None
+    assert testcase.extra_kv_scope is not None
+    assert testcase.extra_kv_scope.topk_length is not None
     num_queries = int(testcase.valid_q.sum().item())
     remapped_sparse_indices_buffer = torch.empty(
         (num_queries, DSV4_SWA_TOPK + p.decode.extra_topk),
@@ -1075,51 +1088,110 @@ def test_trtllm_gen_sparse_mla_dsv4_strided_pages_cuda_graph() -> None:
             compressed_page_stride_padding_elements=1024,
         )
 
-    run_flashinfer_decode(
-        p,
-        testcase,
-        swa_page_stride_padding_elements=512,
-        compressed_page_stride_padding_elements=1024,
-        sparse_indices_are_storage_offsets=False,
-        remapped_sparse_indices_buffer=remapped_sparse_indices_buffer,
-        out=out,
+    swa_indices = testcase.kv_scope.indices_in_kvcache[testcase.valid_q].contiguous()
+    compressed_indices = testcase.extra_kv_scope.indices_in_kvcache[
+        testcase.valid_q
+    ].contiguous()
+    sparse_indices = torch.cat((swa_indices, compressed_indices), dim=-1).contiguous()
+    swa_kv_cache = testcase.kv_scope.get_kvcache_for_flashinfer(p.kv_layout, 512)
+    compressed_kv_cache = testcase.extra_kv_scope.get_kvcache_for_flashinfer(
+        p.kv_layout, 1024
     )
-    assert testcase.extra_kv_scope is not None
+    sparse_topk_lens = (
+        _topk_length_for_flashinfer(
+            testcase.extra_kv_scope.topk_length, testcase.valid_q
+        )
+        + DSV4_SWA_TOPK
+    ).contiguous()
+    query = testcase.q[testcase.valid_q].contiguous()
+    cum_seq_lens_q = _make_cum_seq_lens(testcase.q_lens)
+    bmm1_scale = _scale_for_flashinfer(p, testcase.sm_scale)
+    bmm2_scale = _scale_for_flashinfer(p, 1.0)
+
+    out_ans = trtllm_batch_decode_sparse_mla_dsv4(
+        query=query,
+        swa_kv_cache=swa_kv_cache,
+        workspace_buffer=testcase.workspace_buffer,
+        sparse_indices=sparse_indices,
+        compressed_kv_cache=compressed_kv_cache,
+        sparse_topk_lens=sparse_topk_lens,
+        seq_lens=testcase.kv_scope.cache_seqlens,
+        bmm1_scale=bmm1_scale,
+        bmm2_scale=bmm2_scale,
+        sinks=testcase.attn_sink,
+        kv_layout=p.kv_layout,
+        cum_seq_lens_q=cum_seq_lens_q,
+        max_q_len=p.s_q,
+        enable_pdl=False,
+        backend="trtllm-gen",
+        out=out,
+        remapped_sparse_indices_buffer=remapped_sparse_indices_buffer,
+        sparse_indices_are_storage_offsets=False,
+    )
     expected_indices = torch.cat(
         (
-            testcase.kv_scope.indices_in_kvcache[testcase.valid_q],
-            testcase.extra_kv_scope.indices_in_kvcache[testcase.valid_q],
+            _remap_indices_to_storage_offsets(swa_indices, SWA_PAGE_SIZE, 512),
+            _remap_indices_to_storage_offsets(compressed_indices, C4_PAGE_SIZE, 1024),
         ),
         dim=-1,
-    ).contiguous()
-    for indices, page_size, padding in (
-        (expected_indices[:, :DSV4_SWA_TOPK], SWA_PAGE_SIZE, 512),
-        (expected_indices[:, DSV4_SWA_TOPK:], C4_PAGE_SIZE, 1024),
-    ):
-        valid = indices >= 0
-        page_span = page_size + padding // DSV4_HEAD_DIM
-        indices[valid] = (
-            torch.div(indices[valid], page_size, rounding_mode="floor") * page_span
-            + indices[valid] % page_size
-        )
+    )
     torch.testing.assert_close(remapped_sparse_indices_buffer, expected_indices)
+    out_ref, _ = ref_sparse_attn_decode(p, testcase)
+    out_ref = out_ref[testcase.valid_q]
+    _assert_close(out_ans, out_ref, p.dtype)
+    torch.cuda.synchronize()
 
     graph = torch.cuda.CUDAGraph()
     with torch.cuda.graph(graph):
-        out_ans = run_flashinfer_decode(
-            p,
-            testcase,
-            swa_page_stride_padding_elements=512,
-            compressed_page_stride_padding_elements=1024,
+        out_ans = trtllm_batch_decode_sparse_mla_dsv4(
+            query=query,
+            swa_kv_cache=swa_kv_cache,
+            workspace_buffer=testcase.workspace_buffer,
+            sparse_indices=sparse_indices,
+            compressed_kv_cache=compressed_kv_cache,
+            sparse_topk_lens=sparse_topk_lens,
+            seq_lens=testcase.kv_scope.cache_seqlens,
+            bmm1_scale=bmm1_scale,
+            bmm2_scale=bmm2_scale,
+            sinks=testcase.attn_sink,
+            kv_layout=p.kv_layout,
+            cum_seq_lens_q=cum_seq_lens_q,
+            max_q_len=p.s_q,
+            enable_pdl=False,
+            backend="trtllm-gen",
+            out=out,
             sparse_indices_are_storage_offsets=False,
             remapped_sparse_indices_buffer=remapped_sparse_indices_buffer,
-            out=out,
         )
+
+    mutated_sparse_indices = sparse_indices.clone()
+    mutated_sparse_indices[mutated_sparse_indices >= 0] = 0
+    assert not torch.equal(sparse_indices, mutated_sparse_indices)
+    sparse_indices.copy_(mutated_sparse_indices)
+    testcase.kv_scope.indices_in_kvcache[testcase.valid_q] = sparse_indices[
+        :, :DSV4_SWA_TOPK
+    ]
+    testcase.extra_kv_scope.indices_in_kvcache[testcase.valid_q] = sparse_indices[
+        :, DSV4_SWA_TOPK:
+    ]
     out.zero_()
+    remapped_sparse_indices_buffer.fill_(-2)
     graph.replay()
     torch.cuda.synchronize()
 
     assert out_ans.data_ptr() == out.data_ptr()
+    expected_indices = torch.cat(
+        (
+            _remap_indices_to_storage_offsets(
+                sparse_indices[:, :DSV4_SWA_TOPK], SWA_PAGE_SIZE, 512
+            ),
+            _remap_indices_to_storage_offsets(
+                sparse_indices[:, DSV4_SWA_TOPK:], C4_PAGE_SIZE, 1024
+            ),
+        ),
+        dim=-1,
+    )
+    torch.testing.assert_close(remapped_sparse_indices_buffer, expected_indices)
     out_ref, _ = ref_sparse_attn_decode(p, testcase)
     out_ref = out_ref[testcase.valid_q]
     _assert_close(out_ans, out_ref, p.dtype)


### PR DESCRIPTION
## 📌 Description

Fix TRTLLM-GEN sparse MLA reads from strided KV pools on SM100/SM103.

TRTLLM-GEN cubins consume flat TMA row coordinates. For logical token indices, the launcher now remaps each page/token pair using the pool's actual page stride. Sliding-window and compressed pools use independent layouts. Tight layouts and pre-remapped storage offsets skip the remap.

Strided callers must set `sparse_indices_are_storage_offsets`: `False` for logical token indices, `True` for storage-row offsets. An optional caller-owned remap buffer avoids allocation and supports CUDA Graph capture.

## 🔍 Related Issues

Fixes #3856.

Downstream reproduction: https://github.com/vllm-project/vllm/issues/47783

Temporary downstream workaround: https://github.com/vllm-project/vllm/pull/47493

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

Local validation after rebase onto `4927c0e1`:

- `339 passed, 108 skipped` across TRTLLM-GEN sparse MLA, SM120 sparse MLA, and CuTe DSL HCA tests.
- Fresh isolated TRTLLM-GEN JIT compile/load passed on SM120.
- BF16 and FP8 remap checks passed under Compute Sanitizer with zero errors, including negative indices and cross-page access.
- Regression tests cover remap-buffer device validation and storage-alias rejection.
- `pre-commit run --all-files` passed.

Affected-path tests cover BF16/FP8, HND/NHD, logical/pre-remapped indices, independently padded pools, negative and inactive entries, varlen queries, and CUDA Graph capture with caller-owned storage.

Target validation remains: run `pytest -q tests/attention/test_trtllm_gen_sparse_mla_dsv4.py` on B200/GB200 (SM100) or B300/GB300 (SM103), then measure remap overhead. Local RTX 5070 Ti is SM120, so all 103 affected TRTLLM-GEN cases skip before attention launch. End-to-end numerical results and performance on target hardware are not proven yet.

Current vLLM pre-remaps indices. Its FlashInfer version bump must pass `sparse_indices_are_storage_offsets=True`, or remove the workaround and pass `False`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved DeepSeek V4 sparse attention support for remapped indices and strided KV-cache layouts.
  * Added validation for index formats, cache layouts, alignment, and device compatibility.
  * Preserved correct results during CUDA Graph replay when sparse indices change.

* **Bug Fixes**
  * Fixed handling of logical sparse indices and storage-offset indices in TRTLLM decoding.
  * Improved validation behavior during CUDA Graph capture.

* **Tests**
  * Added coverage for index remapping and unsupported options across attention backends.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->