### PR TITLE
docs: document tinygemm2 escape hatch and MonoMoE scratchpad

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -539,6 +539,7 @@ match what the code uses today; values are strings unless noted.
 | `FLASHINFER_NO_DOWNLOAD` | unset | `flashinfer/jit/cubin_loader.py` | Hard-fail if a cubin is missing locally instead of attempting to download. Useful in CI / locked-down environments. |
 | `FLASHINFER_DSL_FMHA_LOCAL_DIR` | unset | `flashinfer/attention/cute_dsl/fmha.py` | Path to a local checkout of the CuTe-DSL FMHA kernel sources. The loader checks here before downloading. |
 | `FLASHINFER_LOGGING_LEVEL` | `INFO` | `flashinfer/artifacts.py`, `flashinfer/jit/core.py` | Python logging level for the artifacts/cubin loader and the JIT compiler (`DEBUG`/`INFO`/`WARNING`/`ERROR`). Distinct from `FLASHINFER_LOGLEVEL`. |
+| `FLASHINFER_DISABLE_TINYGEMM2_SM100` | `0` | `flashinfer/gemm/routergemm.py` | Set to `1` to disable the generated SM100/SM103 `tinygemm2` backend and force the dispatcher to fall back to the legacy implementation. Useful as an escape hatch when debugging backend-selection or kernel issues on Blackwell systems. |
 
 ##### API Dump / Logging Extensions
 

--- a/flashinfer/fused_moe/monomoe.py
+++ b/flashinfer/fused_moe/monomoe.py
@@ -95,6 +95,17 @@ def alloc_scratchpad(device: torch.device) -> torch.Tensor:
     see docs/design_docs/monomoe_kernel.md §2/§4); afterwards the kernel
     self-maintains them, so allocate once and reuse the same tensor for every
     :func:`mono_moe` invocation.
+
+    Parameters
+    ----------
+    device : torch.device
+        The CUDA device on which to allocate the scratchpad.
+
+    Returns
+    -------
+    torch.Tensor
+        A zero-initialized 1-D ``uint8`` tensor containing
+        :func:`get_scratchpad_size_bytes` bytes on ``device``.
     """
     nbytes = get_scratchpad_size_bytes()
     return torch.zeros(nbytes, dtype=torch.uint8, device=device)


### PR DESCRIPTION
## Description

- Document `FLASHINFER_DISABLE_TINYGEMM2_SM100` and its legacy-backend fallback behavior.
- Restore the structured `Parameters` and `Returns` sections for `flashinfer.fused_moe.alloc_scratchpad`.
- Keep `fused_kda_decode` unchanged because its arguments are already documented; the checker parser fix is handled separately.

## Related Issues

- Nightly FlashInfer documentation check findings from 2026-08-07.

## Pull Request Checklist

### Pre-commit Checks

- [x] Ran `pre-commit run --files flashinfer/fused_moe/monomoe.py`; all hooks passed.

## Tests

- [x] Documentation checker: `Docstring Completeness 0 fail`, `Args Consistency 0 fail` with the parser fix.
- [x] Cross-source checker: all five checks report 0 failures.

## Reviewer Notes

The KDA finding was a checker false positive caused by multiline Google-style `name:` entries. No KDA source change is needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Documented an environment variable for disabling the SM100/SM103 tinygemm2 backend and falling back to the legacy implementation.
  * Expanded documentation for scratchpad allocation parameters and return values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->