### PR TITLE
fix: correct trtllm-gen reduction indexing for FMHA decode at long q_len

### DIFF
--- a/csrc/fmhaReduction.cu
+++ b/csrc/fmhaReduction.cu
@@ -66,9 +66,8 @@ __global__ void __launch_bounds__(NumThreadsPerCta, 2)
   int32_t const warpGrpThreadIdx{static_cast<int32_t>(threadIdx.x)};
 
   // The seqOffsetQ in token units (cumSeqLensQ is already token-relative).
-  int32_t const seqOffsetQ{params.ptrCumSeqLensQ == nullptr
-                               ? batchIdx * params.mMaxSeqLenQ
-                               : params.ptrCumSeqLensQ[batchIdx]};
+  int32_t const seqOffsetQ{params.ptrCumSeqLensQ == nullptr ? batchIdx * params.mMaxSeqLenQ
+                                                            : params.ptrCumSeqLensQ[batchIdx]};
   // The seqLenQ.
   int32_t const seqLenQ{params.ptrCumSeqLensQ == nullptr
                             ? params.mMaxSeqLenQ

--- a/csrc/fmhaReduction.cu
+++ b/csrc/fmhaReduction.cu
@@ -67,7 +67,7 @@ __global__ void __launch_bounds__(NumThreadsPerCta, 2)
 
   // The seqOffsetQ in token units (cumSeqLensQ is already token-relative).
   int32_t const seqOffsetQ{params.ptrCumSeqLensQ == nullptr
-                               ? batchIdx * params.mMaxNumCtasQ * params.mNumTokensPerCtaQ
+                               ? batchIdx * params.mMaxSeqLenQ
                                : params.ptrCumSeqLensQ[batchIdx]};
   // The seqLenQ.
   int32_t const seqLenQ{params.ptrCumSeqLensQ == nullptr
@@ -83,6 +83,9 @@ __global__ void __launch_bounds__(NumThreadsPerCta, 2)
     return;
   }
 
+  // The last tokenQ index (relative to the request) processed by this CTA.
+  int32_t const lastTokenIdxQ{ctaIdxQ * params.mNumTokensPerCtaQ + numValidTokens - 1};
+
   // The actual number of seqLenKv. Block-sparse attention uses per-KV-head sequence lengths
   // laid out as [numHeadsKv, batchSize].
   int32_t seqLenKv;
@@ -93,7 +96,7 @@ __global__ void __launch_bounds__(NumThreadsPerCta, 2)
     seqLenKv = params.ptrSeqLensKv[batchIdx];
   }
   // Consider the causal-mask speculative decoding.
-  seqLenKv = seqLenKv - ((params.mMaxSeqLenQ - 1) - ctaIdxQ);
+  seqLenKv = seqLenKv - ((params.mMaxSeqLenQ - 1) - lastTokenIdxQ);
   // Consider sparseAttnTopK and variable sparse MLA topK lengths.
   if (supportsVarSparseMlaTopKLens) {
     seqLenKv = params.ptrSparseMlaTopKLens[seqOffsetQ + ctaIdxQ * params.mNumTokensPerCtaQ];

--- a/tests/attention/test_trtllm_gen_attention_decode.py
+++ b/tests/attention/test_trtllm_gen_attention_decode.py
@@ -1642,6 +1642,130 @@ def test_trtllm_batch_decode_head_dim_512(
     )
 
 
+def test_trtllm_batch_decode_reduction_indexing():
+    """Regression coverage for packed-Q offsets and causal KV tile extent."""
+    compute_capability = get_compute_capability(torch.device(GPU_DEVICE))
+    if compute_capability[0] != 10:
+        pytest.skip("trtllm-gen backend requires SM100 or SM103 GPUs.")
+
+    q_len_per_req = 6
+    page_size = 16
+    num_qo_heads = 8
+    num_kv_heads = 1
+    head_dim = 512
+    dtype = torch.bfloat16
+
+    # The first case isolates the packed Q/O request offset. The second uses
+    # variable sequence lengths so the long request raises mMaxNumCtasKv while
+    # the short request crosses a 128-token KV-tile boundary. Zero Q/K and a
+    # tile-coded V make a missing reduction contribution deterministic.
+    cases = (
+        ("packed_qo_offset", [4096, 4096, 4096, 4096], False),
+        ("causal_kv_extent", [2052, 8192], True),
+    )
+
+    for case_name, seq_len_values, use_tile_coded_v in cases:
+        batch_size = len(seq_len_values)
+        max_seq_len = max(seq_len_values)
+        max_pages = (max_seq_len + page_size - 1) // page_size
+        seq_lens = torch.tensor(seq_len_values, dtype=torch.int32)
+        q_lens = torch.full((batch_size,), q_len_per_req, dtype=torch.int32)
+        page_table = torch.arange(
+            batch_size * max_pages, dtype=torch.int32, device=GPU_DEVICE
+        ).view(batch_size, max_pages)
+
+        if use_tile_coded_v:
+            query = torch.zeros(
+                batch_size * q_len_per_req,
+                num_qo_heads,
+                head_dim,
+                dtype=dtype,
+                device=GPU_DEVICE,
+            )
+            kv_cache = torch.zeros(
+                batch_size * max_pages,
+                2,
+                num_kv_heads,
+                page_size,
+                head_dim,
+                dtype=dtype,
+                device=GPU_DEVICE,
+            )
+            tile_values = (
+                torch.arange(max_pages * page_size, device=GPU_DEVICE)
+                .div(128, rounding_mode="floor")
+                .to(dtype)
+                .view(max_pages, page_size, 1)
+            )
+            for request_idx in range(batch_size):
+                page_start = request_idx * max_pages
+                kv_cache[page_start : page_start + max_pages, 1, 0] = tile_values
+        else:
+            torch.manual_seed(1234)
+            query_one = (
+                torch.randn(
+                    q_len_per_req,
+                    num_qo_heads,
+                    head_dim,
+                    dtype=dtype,
+                    device=GPU_DEVICE,
+                )
+                / 4
+            )
+            query = query_one.repeat(batch_size, 1, 1).contiguous()
+            kv_one = (
+                torch.randn(
+                    max_pages,
+                    2,
+                    num_kv_heads,
+                    page_size,
+                    head_dim,
+                    dtype=dtype,
+                    device=GPU_DEVICE,
+                )
+                / 4
+            )
+            kv_cache = kv_one.repeat(batch_size, 1, 1, 1, 1).contiguous()
+
+        output_ref = sdpa_paged_reference(
+            query,
+            kv_cache,
+            q_lens,
+            seq_lens,
+            page_table,
+            page_size,
+            num_qo_heads,
+            num_kv_heads,
+            head_dim,
+            "HND",
+            -1,
+        )
+        workspace_buffer = torch.zeros(
+            256 * 1024 * 1024, dtype=torch.int8, device=GPU_DEVICE
+        )
+        output = flashinfer.decode.trtllm_batch_decode_with_kv_cache(
+            query=query,
+            kv_cache=kv_cache,
+            workspace_buffer=workspace_buffer,
+            block_tables=page_table,
+            seq_lens=seq_lens.to(GPU_DEVICE),
+            max_seq_len=max_seq_len,
+            bmm1_scale=head_dim**-0.5,
+            bmm2_scale=1.0,
+            window_left=-1,
+            kv_layout="HND",
+            backend="trtllm-gen",
+            q_len_per_req=q_len_per_req,
+        )
+
+        try:
+            torch.testing.assert_close(
+                output.float(), output_ref.float(), rtol=0.0, atol=1e-3
+            )
+        except AssertionError as error:
+            raise AssertionError(f"{case_name} failed: {error}") from error
+
+
 def make_query_non_contiguous(
     q: torch.Tensor, num_qo_heads: int, head_dim: int
 ) -> torch.Tensor:


### PR DESCRIPTION
## 📌 Description

Fix two trtllm-gen reduction indexing errors in multi-token batch decode:

- Index Q/O by the packed request offset.
- Derive causal KV extent from the CTA's last valid query token.

Thanks to @Dymasik for discovering the bug and providing the original patch.

### Observed vLLM failure

With Gemma 4 31B, MTP `num_speculative_tokens=5` (`q_len_per_req=6`), a ~26k-token context, and batch size greater than one, requests after the first receive corrupted attention output. This produces incorrect logits at the first speculative verification step; affected generations repeat one token, never emit EOS, and run to `max_tokens`. At batch size 4, about 94% of requests were affected and throughput dropped from 6.05 to 0.41 req/s. Batch size 1 remains correct.

### Standalone Python reproduction

This requires one SM100/SM103 GPU and no model weights. Identical queries and KV caches are used for every request, then compared with a PyTorch reference. The failure begins at `q_len_per_req >= 5`; `q_len_per_req=4` is included as a passing control.

```python
import torch
from flashinfer.decode import trtllm_batch_decode_with_kv_cache

DEV, DTYPE = "cuda", torch.bfloat16
HEAD_DIM, NUM_QO, NUM_KV, PAGE = 512, 8, 1, 16


def build(num_reqs, q_len, seq_len):
    torch.manual_seed(1234)
    pages = (seq_len + PAGE - 1) // PAGE
    kv_one = (
        torch.randn(
            pages, 2, NUM_KV, PAGE, HEAD_DIM, dtype=DTYPE, device=DEV
        )
        / 4
    )
    kv_cache = kv_one.repeat(num_reqs, 1, 1, 1, 1).contiguous()
    block_tables = (
        torch.arange(num_reqs * pages, dtype=torch.int32, device=DEV)
        .view(num_reqs, pages)
        .contiguous()
    )
    seq_lens = torch.full(
        (num_reqs,), seq_len, dtype=torch.int32, device=DEV
    )
    q_one = (
        torch.randn(q_len, NUM_QO, HEAD_DIM, dtype=DTYPE, device=DEV) / 4
    )
    query = q_one.repeat(num_reqs, 1, 1).contiguous()
    return query, kv_cache, block_tables, seq_lens


def reference(num_reqs, q_len, seq_len):
    query, kv_cache, block_tables, _ = build(num_reqs, q_len, seq_len)
    group = NUM_QO // NUM_KV
    pos = torch.arange(seq_len, device=DEV)
    qpos = seq_len - q_len + torch.arange(q_len, device=DEV)
    mask = pos[None, :] > qpos[:, None]
    out = torch.empty(
        num_reqs,
        q_len,
        NUM_QO,
        HEAD_DIM,
        dtype=torch.float32,
        device=DEV,
    )
    for r in range(num_reqs):
        g = kv_cache[block_tables[r].long()].float()
        k = g[:, 0].permute(1, 0, 2, 3).reshape(NUM_KV, -1, HEAD_DIM)[
            :, :seq_len
        ]
        v = g[:, 1].permute(1, 0, 2, 3).reshape(NUM_KV, -1, HEAD_DIM)[
            :, :seq_len
        ]
        k = k.repeat_interleave(group, 0)
        v = v.repeat_interleave(group, 0)
        q = query[r * q_len : (r + 1) * q_len].float().transpose(0, 1)
        scores = torch.bmm(q, k.transpose(1, 2)) * HEAD_DIM**-0.5
        scores = scores.masked_fill(mask[None], float("-inf"))
        out[r] = torch.bmm(torch.softmax(scores, -1), v).transpose(0, 1)
    return out


def kernel(num_reqs, q_len, seq_len, workspace):
    query, kv_cache, block_tables, seq_lens = build(
        num_reqs, q_len, seq_len
    )
    return trtllm_batch_decode_with_kv_cache(
        query=query,
        kv_cache=kv_cache,
        workspace_buffer=workspace,
        block_tables=block_tables,
        seq_lens=seq_lens,
        max_seq_len=seq_len,
        bmm1_scale=HEAD_DIM**-0.5,
        bmm2_scale=1.0,
        window_left=-1,
        kv_layout="HND",
        backend="trtllm-gen",
        q_len_per_req=q_len,
    ).view(num_reqs, q_len, NUM_QO, HEAD_DIM).float()


print(
    f"{'seq_len':>8} {'q_len':>6} {'batch':>6} {'call':>5}  "
    "max abs error per request"
)
for seq_len, q_len, batch in [
    (26121, 6, 4),
    (26121, 5, 4),
    (26121, 4, 4),
]:
    ref = reference(batch, q_len, seq_len)
    # vLLM reuses one global workspace across layers and steps.
    workspace = torch.zeros(
        256 * 1024 * 1024, dtype=torch.int8, device=DEV
    )
    for call in range(2):
        got = kernel(batch, q_len, seq_len, workspace)
        errors = [
            (got[r] - ref[r]).abs().max().item() for r in range(batch)
        ]
        formatted = ", ".join(
            "nan" if value != value else f"{value:.4f}"
            for value in errors
        )
        print(
            f"{seq_len:>8} {q_len:>6} {batch:>6} {call:>5}  "
            f"{formatted}"
        )
```

On the unpatched build, request 0 stays correct while requests 1-3 fail for `q_len_per_req=5` and 6, with errors ranging from ~5e-3 to NaN. `q_len_per_req=4` stays correct. With this patch, all three configurations match the reference (maximum error <= 1e-4).

### Unit-test coverage

`test_trtllm_batch_decode_reduction_indexing` uses `q_len_per_req=6` and covers both fixes in one SM100/SM103 test:

- `packed_qo_offset`: four 4096-token requests with identical Q/K/V detect the padded per-request Q/O offset. Reverting only the first fix causes 24.1% mismatched elements and NaNs.
- `causal_kv_extent`: variable sequence lengths `[2052, 8192]`, zero Q/K, and 128-token-tile-coded V deterministically expose a missing reduction contribution. Reverting only the second fix causes 8.3% mismatched elements with maximum absolute error 0.03125.

The test passes when both fixes are present.

## 🔍 Related Issues

N/A

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

Validated on B300: the targeted regression test passes with both fixes and fails independently when either fix is reverted. Ruff format/check also pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved attention reduction indexing for variable-length and packed sequences.
  * Corrected causal key/value length adjustments to use the final token processed by each block.

* **Tests**
  * Added regression coverage for batch decode reduction indexing on supported hardware.
  * Validates packed offsets and causal tile handling against a reference implementation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->