### PR TITLE
feat(attention): add staged FP8 D256 PrimTS context schedule

### DIFF
--- a/benchmarks/routines/attention.py
+++ b/benchmarks/routines/attention.py
@@ -166,7 +166,7 @@ def _validate_prims_ts_context_samples(
     total_expected_sq = 0.0
     max_abs_error = 0.0
     if out.dtype == torch.float8_e4m3fn:
-        rtol, atol, relative_l2_limit = 5e-2, 1.3e-1, 1e-1
+        rtol, atol, relative_l2_limit = 5e-2, 2.5e-1, 1e-1
     else:
         rtol, atol, relative_l2_limit = 1e-1, 3e-2, 5e-2
     sample_points = _context_reference_sample_points(qo_indptr_host, num_qo_heads)
@@ -207,6 +207,8 @@ def _validate_prims_ts_context_samples(
         q_vector = q[q_begin + query_idx, query_head].float()
         probabilities = torch.softmax(torch.mv(k_matrix, q_vector) * sm_scale, dim=0)
         expected = torch.matmul(probabilities, v_matrix) * output_scale
+        if out.dtype == torch.float8_e4m3fn:
+            expected = expected.to(out.dtype).float()
         actual = out[q_begin + query_idx, query_head].float()
         difference = actual - expected
         sample_max_abs = float(difference.abs().max().item())

--- a/benchmarks/routines/attention.py
+++ b/benchmarks/routines/attention.py
@@ -166,7 +166,7 @@ def _validate_prims_ts_context_samples(
     total_expected_sq = 0.0
     max_abs_error = 0.0
     if out.dtype == torch.float8_e4m3fn:
-        rtol, atol, relative_l2_limit = 5e-2, 2.5e-1, 1e-1
+        rtol, atol, relative_l2_limit = 5e-2, 1.3e-1, 1e-1
     else:
         rtol, atol, relative_l2_limit = 1e-1, 3e-2, 5e-2
     sample_points = _context_reference_sample_points(qo_indptr_host, num_qo_heads)

--- a/benchmarks/test_flashinfer_benchmark.py
+++ b/benchmarks/test_flashinfer_benchmark.py
@@ -141,6 +141,32 @@ def test_prims_ts_backend_is_blackwell_only(routine):
     )
 
 
+def test_prims_ts_context_fp8_sample_oracle_quantizes_reference():
+    reference = torch.tensor([1e-3, 1.1e-3, 2.5e-3, 4e-3])
+    out = reference.to(torch.float8_e4m3fn).reshape(1, 1, -1)
+    unquantized_relative_l2 = torch.linalg.vector_norm(out.float() - reference) / (
+        torch.linalg.vector_norm(reference)
+    )
+    assert unquantized_relative_l2 > 1e-1
+
+    sample_count, max_abs_error = attention_routine._validate_prims_ts_context_samples(
+        q=torch.zeros(1, 1, 1),
+        k=torch.zeros(1, 1, 1),
+        v=reference.reshape(1, 1, -1),
+        out=out,
+        qo_indptr=torch.tensor([0, 1], dtype=torch.int32),
+        kv_indptr=torch.tensor([0, 1], dtype=torch.int32),
+        num_qo_heads=1,
+        num_kv_heads=1,
+        sm_scale=1.0,
+        output_scale=1.0,
+        causal=False,
+    )
+
+    assert sample_count == 1
+    assert max_abs_error == 0.0
+
+
 @pytest.mark.parametrize(
     ("backend", "out_dtype", "message"),
     [

--- a/benchmarks/test_flashinfer_benchmark.py
+++ b/benchmarks/test_flashinfer_benchmark.py
@@ -141,32 +141,6 @@ def test_prims_ts_backend_is_blackwell_only(routine):
     )
 
 
-def test_prims_ts_context_fp8_sample_oracle_quantizes_reference():
-    reference = torch.tensor([1e-3, 1.1e-3, 2.5e-3, 4e-3])
-    out = reference.to(torch.float8_e4m3fn).reshape(1, 1, -1)
-    unquantized_relative_l2 = torch.linalg.vector_norm(out.float() - reference) / (
-        torch.linalg.vector_norm(reference)
-    )
-    assert unquantized_relative_l2 > 1e-1
-
-    sample_count, max_abs_error = attention_routine._validate_prims_ts_context_samples(
-        q=torch.zeros(1, 1, 1),
-        k=torch.zeros(1, 1, 1),
-        v=reference.reshape(1, 1, -1),
-        out=out,
-        qo_indptr=torch.tensor([0, 1], dtype=torch.int32),
-        kv_indptr=torch.tensor([0, 1], dtype=torch.int32),
-        num_qo_heads=1,
-        num_kv_heads=1,
-        sm_scale=1.0,
-        output_scale=1.0,
-        causal=False,
-    )
-
-    assert sample_count == 1
-    assert max_abs_error == 0.0
-
-
 @pytest.mark.parametrize(
     ("backend", "out_dtype", "message"),
     [

--- a/flashinfer/attention/prims_ts/context.py
+++ b/flashinfer/attention/prims_ts/context.py
@@ -460,6 +460,18 @@ def _uses_heavy_first_static_causal_raster(
     return mask_type == "causal" and window_left < 0 and not has_q_offset
 
 
+def _use_staged_d256_schedule(capability: tuple[int, int]) -> bool:
+    """Select the explicit split-D schedule on the architecture it benefits.
+
+    The explicit schedule cuts D256 FP8 dynamic SMEM from about 232 KiB to
+    131 KiB. On SM100, however, NCU shows higher L1TEX scoreboard latency than
+    the generic schedule; SM103 removes that regression while retaining the
+    additional SMEM headroom.
+    """
+
+    return capability == (10, 3)
+
+
 def _paged_context_uses_clc_scheduler(
     *,
     is_persistent: bool,
@@ -1010,6 +1022,9 @@ def _get_compiled_context(
     input_dtype = dtype_map[q_dtype_key]
     output_dtype = dtype_map[output_dtype_key]
     is_causal = mask_type == "causal"
+    with torch.cuda.device(device_index):
+        capability = torch.cuda.get_device_capability(device_index)
+    enable_staged_head_dim = _use_staged_d256_schedule(capability)
     # Construct the scheduler-independent topology first. Immutable
     # single-instance domains can use the lower-overhead static persistent
     # queue; paired or live-ragged domains are reconstructed with CLC.
@@ -1031,6 +1046,7 @@ def _get_compiled_context(
         window_size_left=window_left if window_left > 0 else 0,
         h_r=num_qo_heads // num_kv_heads,
         enable_skip_correction=True,
+        enable_staged_head_dim=enable_staged_head_dim,
         causal_single_kv_tile=causal_single_kv_tile,
     )
     with torch.cuda.device(device_index):
@@ -1072,6 +1088,7 @@ def _get_compiled_context(
             window_size_left=window_left if window_left > 0 else 0,
             h_r=num_qo_heads // num_kv_heads,
             enable_skip_correction=True,
+            enable_staged_head_dim=enable_staged_head_dim,
             causal_single_kv_tile=causal_single_kv_tile,
         )
     elif not is_persistent:
@@ -1088,6 +1105,7 @@ def _get_compiled_context(
             window_size_left=window_left if window_left > 0 else 0,
             h_r=num_qo_heads // num_kv_heads,
             enable_skip_correction=True,
+            enable_staged_head_dim=enable_staged_head_dim,
             causal_single_kv_tile=causal_single_kv_tile,
         )
     fmha.cfg.has_varlen = packed
@@ -1210,6 +1228,7 @@ def _get_compiled_context(
             ("clc_dynamic_persistent" if fmha.is_clc_dynamic else "static_persistent"),
         ),
         ("pairing", "head" if head_paired else "query"),
+        ("head_dim_schedule", "staged" if fmha.cfg.staged_head_dim else "generic"),
         ("uniform_packed_lengths", uniform_packed_lengths),
         ("causal_single_kv_tile", causal_single_kv_tile),
         ("packed_dense_k_mask", packed_dense_k_mask),

--- a/flashinfer/attention/prims_ts/context.py
+++ b/flashinfer/attention/prims_ts/context.py
@@ -1025,6 +1025,7 @@ def _get_compiled_context(
     with torch.cuda.device(device_index):
         capability = torch.cuda.get_device_capability(device_index)
     enable_staged_head_dim = _use_staged_d256_schedule(capability)
+    enable_ldtm_stat = capability == (10, 3)
     # Construct the scheduler-independent topology first. Immutable
     # single-instance domains can use the lower-overhead static persistent
     # queue; paired or live-ragged domains are reconstructed with CLC.
@@ -1047,6 +1048,7 @@ def _get_compiled_context(
         h_r=num_qo_heads // num_kv_heads,
         enable_skip_correction=True,
         enable_staged_head_dim=enable_staged_head_dim,
+        enable_ldtm_stat=enable_ldtm_stat,
         causal_single_kv_tile=causal_single_kv_tile,
     )
     with torch.cuda.device(device_index):
@@ -1089,6 +1091,7 @@ def _get_compiled_context(
             h_r=num_qo_heads // num_kv_heads,
             enable_skip_correction=True,
             enable_staged_head_dim=enable_staged_head_dim,
+            enable_ldtm_stat=enable_ldtm_stat,
             causal_single_kv_tile=causal_single_kv_tile,
         )
     elif not is_persistent:
@@ -1106,6 +1109,7 @@ def _get_compiled_context(
             h_r=num_qo_heads // num_kv_heads,
             enable_skip_correction=True,
             enable_staged_head_dim=enable_staged_head_dim,
+            enable_ldtm_stat=enable_ldtm_stat,
             causal_single_kv_tile=causal_single_kv_tile,
         )
     fmha.cfg.has_varlen = packed
@@ -1229,6 +1233,7 @@ def _get_compiled_context(
         ),
         ("pairing", "head" if head_paired else "query"),
         ("head_dim_schedule", "staged" if fmha.cfg.staged_head_dim else "generic"),
+        ("ldtm_stat", fmha.cfg.use_ldtm_stat),
         ("uniform_packed_lengths", uniform_packed_lengths),
         ("causal_single_kv_tile", causal_single_kv_tile),
         ("packed_dense_k_mask", packed_dense_k_mask),

--- a/flashinfer/attention/prims_ts/kernels/fmha_context/fmha_kernel.py
+++ b/flashinfer/attention/prims_ts/kernels/fmha_context/fmha_kernel.py
@@ -178,14 +178,18 @@ from .fmha_resources import (
 )
 from .fmha_tasks import (
     PackedContextWorkQueue,
+    create_correction_epilogue_task_staged_head_dim,
     create_correction_task,
     create_epilogue_task,
     create_load_task,
+    create_load_task_staged_head_dim,
     create_mma_task,
+    create_mma_task_staged_head_dim,
     create_padding_task,
     create_page_offsets_task,
     create_scheduler_task,
     create_softmax_task,
+    create_softmax_task_staged_head_dim,
 )
 
 
@@ -831,7 +835,7 @@ def build_context_task_manager(
     smem_o_1_pipeline_cfg = PipelineConfig.create_async_async_pipeline_cfg(
         num_stages=1,
         producer_group=correction_group,
-        consumer_group=epilogue_group,
+        consumer_group=(correction_group if cfg.staged_head_dim else epilogue_group),
         cta_layout_vmnk=cluster_shape_vmnk,
     )
     # S0-S1 sequence barrier: PipelineAsync, 1 stage.
@@ -1038,6 +1042,7 @@ def build_context_task_manager(
     )
 
     single_qkv_instance = cfg.single_qkv_instance
+    staged_o_fast_path = single_qkv_instance and cfg.staged_head_dim
     tmem_sp1: TmemSPResource | None = None
     tmem_vec1: TmemStatsResource | None = None
     smem_o_1: SmemOResource | None = None
@@ -1090,6 +1095,21 @@ def build_context_task_manager(
             pipeline_config=tmem_stats_done_1_pipeline_cfg,
             name="tmem_stats_done_1",
         )
+    elif staged_o_fast_path:
+        smem_o_1 = SmemOResource(
+            pipeline_config=smem_o_1_pipeline_cfg,
+            cfg=cfg,
+            stage_idx=1,
+            tmem_vec_resource=tmem_vec0,
+            name="smem_o_1",
+        )
+        gmem_o_1 = GmemOResource(
+            tma_o_desc=tma_o_desc,
+            cum_seqlen_q=cum_seqlen_q,
+            cfg=cfg,
+            stage_idx=1,
+            name="gmem_o_1",
+        )
 
     tmem_o_kwargs = tmem_o_extra_kwargs or {}
     tmem_o = TmemOResource(
@@ -1098,7 +1118,7 @@ def build_context_task_manager(
         tmem_o0_offset=cfg.tmem_o0_offset,
         tmem_o1_offset=cfg.tmem_o1_offset,
         tmem_vec0_resource=tmem_vec0,
-        tmem_vec1_resource=tmem_vec1,
+        tmem_vec1_resource=tmem_vec0 if staged_o_fast_path else tmem_vec1,
         name="tmem_o",
         **tmem_o_kwargs,
     )
@@ -1128,39 +1148,71 @@ def build_context_task_manager(
         # The non-split single-instance schedule performs every QK/PV pair
         # inside its loop; it has no separate HEAD QK or TAIL PV iteration.
         mma_domain_kwargs = domain_n_kwargs
-    load_task = create_load_task(
-        gmem_qkv,
-        smem_q,
-        smem_kv,
-        work_queue,
-        smem_page_offsets_kv=smem_page_offsets_kv,
-        smem_page_offsets_v=smem_page_offsets_v,
-        **domain_n_kwargs,
-    )
-    mma_task = create_mma_task(
-        smem_q,
-        smem_kv,
-        tmem_sp0,
-        tmem_sp1,
-        tmem_p0,
-        tmem_o,
-        tmem_stats_done_0,
-        tmem_stats_done_1,
-        work_queue,
-        **mma_domain_kwargs,
-    )
+    if cfg.staged_head_dim:
+        if tmem_p0 is None:
+            raise ValueError("staged-head-dim scheduling requires a P handoff")
+        load_task = create_load_task_staged_head_dim(
+            gmem_qkv,
+            smem_q,
+            smem_kv,
+            work_queue,
+            **domain_n_minus_1_kwargs,
+        )
+        mma_task = create_mma_task_staged_head_dim(
+            smem_q,
+            smem_kv,
+            tmem_sp0,
+            tmem_o,
+            tmem_stats_done_0,
+            tmem_p0,
+            work_queue,
+            **domain_n_minus_1_kwargs,
+        )
+    else:
+        load_task = create_load_task(
+            gmem_qkv,
+            smem_q,
+            smem_kv,
+            work_queue,
+            smem_page_offsets_kv=smem_page_offsets_kv,
+            smem_page_offsets_v=smem_page_offsets_v,
+            **domain_n_kwargs,
+        )
+        mma_task = create_mma_task(
+            smem_q,
+            smem_kv,
+            tmem_sp0,
+            tmem_sp1,
+            tmem_p0,
+            tmem_o,
+            tmem_stats_done_0,
+            tmem_stats_done_1,
+            work_queue,
+            **mma_domain_kwargs,
+        )
 
     # Causal query-paired moves masked/invalid K iterations from LOOP to TAIL
     # with no runtime branch. SP resources derive mask selection from cfg.
-    softmax0_task = create_softmax_task(
-        0,
-        tmem_sp0,
-        tmem_vec0,
-        tmem_p0,
-        s0s1_seq,
-        work_queue,
-        **softmax0_domain_kwargs,
-    )
+    if cfg.staged_head_dim:
+        if tmem_p0 is None:
+            raise ValueError("staged-head-dim softmax requires a P handoff")
+        softmax0_task = create_softmax_task_staged_head_dim(
+            tmem_sp0,
+            tmem_vec0,
+            tmem_p0,
+            work_queue,
+            **softmax0_domain_kwargs,
+        )
+    else:
+        softmax0_task = create_softmax_task(
+            0,
+            tmem_sp0,
+            tmem_vec0,
+            tmem_p0,
+            s0s1_seq,
+            work_queue,
+            **softmax0_domain_kwargs,
+        )
     softmax1_task: Task | None = None
     if not single_qkv_instance:
         if tmem_sp1 is None or tmem_vec1 is None:
@@ -1174,19 +1226,34 @@ def build_context_task_manager(
             work_queue,
             **softmax1_domain_kwargs,
         )
-    correction_task = create_correction_task(
-        tmem_vec0,
-        tmem_vec1,
-        tmem_o,
-        smem_o_0,
-        smem_o_1,
-        gmem_o_0,
-        gmem_o_1,
-        tmem_stats_done_0,
-        tmem_stats_done_1,
-        work_queue,
-        **domain_n_minus_1_kwargs,
-    )
+    if cfg.staged_head_dim:
+        if smem_o_1 is None or gmem_o_1 is None:
+            raise ValueError("staged-head-dim output requires two O resources")
+        correction_task = create_correction_epilogue_task_staged_head_dim(
+            tmem_vec0,
+            tmem_o,
+            smem_o_0,
+            smem_o_1,
+            gmem_o_0,
+            gmem_o_1,
+            tmem_stats_done_0,
+            work_queue,
+            **domain_n_minus_1_kwargs,
+        )
+    else:
+        correction_task = create_correction_task(
+            tmem_vec0,
+            tmem_vec1,
+            tmem_o,
+            smem_o_0,
+            smem_o_1,
+            gmem_o_0,
+            gmem_o_1,
+            tmem_stats_done_0,
+            tmem_stats_done_1,
+            work_queue,
+            **domain_n_minus_1_kwargs,
+        )
     epilogue_task: Task | None = None
     freed_epilogue_task: Task | None = None
     if cfg.fuse_epilogue_into_correction:
@@ -1259,7 +1326,11 @@ def build_context_task_manager(
         task_list.append(scheduler_task)
     task_list.append(auxiliary_task)
 
-    if single_qkv_instance:
+    if cfg.staged_head_dim:
+        if tmem_p0 is None:
+            raise ValueError("staged-head-dim resource graph requires P handoff")
+        tmem_o_dependencies = scheduler_deps(tmem_sp0, tmem_p0)
+    elif single_qkv_instance:
         tmem_o_source = tmem_p0 if tmem_p0 is not None else tmem_sp0
         tmem_o_dependencies = scheduler_deps(tmem_o_source)
     else:
@@ -1293,6 +1364,15 @@ def build_context_task_manager(
         resource_dependency_graph[tmem_stats_done_0] = [tmem_vec0]
     if tmem_p0 is not None:
         resource_dependency_graph[tmem_p0] = scheduler_deps(tmem_sp0)
+    if staged_o_fast_path:
+        if smem_o_1 is None or gmem_o_1 is None:
+            raise ValueError("staged-output resource graph requires O stage 1")
+        resource_dependency_graph.update(
+            {
+                smem_o_1: scheduler_deps(tmem_vec0, tmem_o),
+                gmem_o_1: scheduler_deps(smem_o_1),
+            }
+        )
     if not single_qkv_instance:
         resource_dependency_graph.update(
             {
@@ -1355,7 +1435,20 @@ def build_context_task_manager(
         add_smem_resource(tmem_stats_done_1)
     if work_queue is not None and work_queue.pipeline_config is not None:
         add_smem_resource(work_queue)
-    if single_qkv_instance:
+    if staged_o_fast_path:
+        if smem_o_1 is None or gmem_o_1 is None:
+            raise ValueError("staged-output allocator requires O stage 1")
+        add_smem_resource(smem_o_0)
+        add_smem_resource(smem_o_1)
+        add_smem_resource(gmem_o_0)
+        add_smem_resource(gmem_o_1)
+        smem_allocator.add_alias_group(
+            [
+                [smem_o_0._alloc, smem_o_1._alloc],
+                [gmem_o_0._alloc, gmem_o_1._alloc],
+            ]
+        )
+    elif single_qkv_instance:
         add_smem_resource(smem_o_0)
         add_smem_resource(gmem_o_0)
         smem_allocator.add_alias_group(
@@ -1463,7 +1556,11 @@ def build_context_task_manager(
         exhaustive_deadlock_race_check=exhaustive_deadlock_race_check,
     )
 
-    if single_qkv_instance:
+    if staged_o_fast_path:
+        if smem_o_1 is None:
+            raise ValueError("staged-output TMEM resources require O stage 1")
+        tmem_resources = [tmem_sp0, tmem_vec0, tmem_o, smem_o_0, smem_o_1]
+    elif single_qkv_instance:
         tmem_resources = [tmem_sp0, tmem_vec0, tmem_o, smem_o_0]
     else:
         tmem_resources = [
@@ -1519,7 +1616,9 @@ def _context_pipeline_stage_counts(
         "tmem_p": cfg.mma_softmax_stage if cfg.has_tmem_p_pipeline else 0,
         "tmem_vec": cfg.softmax_corr_stage * cfg.num_qkv_instances,
         "tmem_o": cfg.mma_corr_stage,
-        "smem_o": cfg.num_qkv_instances,
+        "smem_o": (
+            cfg.num_head_dim_stages if cfg.staged_head_dim else cfg.num_qkv_instances
+        ),
         "s0s1_seq": 0 if cfg.single_qkv_instance else 1,
         "tmem_stats_done": 0 if cfg.stats_via_smem else cfg.num_qkv_instances,
         "work_queue": 1 if is_clc_dynamic else 0,
@@ -1615,6 +1714,15 @@ def _configure_pipeline_stages(cfg: FmhaConfig, *, is_clc_dynamic: bool) -> None
     """Set topology- and capacity-derived context pipeline stage counts."""
     cfg.q_stage = cfg.num_qkv_instances
     cfg.kv_stage = 3
+    if cfg.staged_head_dim:
+        cfg.q_stage = 1
+        cfg.kv_stage = 2 * cfg.num_head_dim_stages
+        cfg.has_tmem_p_pipeline = True
+        cfg.stage_scoped_tmem_stats = True
+        cfg.mma_softmax_stage = 2
+        cfg.softmax_corr_stage = 1
+        cfg.mma_corr_stage = 1
+        return
     cfg.has_tmem_p_pipeline = _should_use_tmem_p_pipeline(cfg)
     cfg.stage_scoped_tmem_stats = cfg.has_tmem_p_pipeline
     cfg.mma_softmax_stage = 2 if cfg.has_tmem_p_pipeline else 1
@@ -1693,6 +1801,7 @@ def _configure_early_tile_sum_policy(
 
 def _configure_smem_shapes(cfg: FmhaConfig) -> None:
     """Derive per-stage SMEM element counts from the configured tile shapes."""
+    q_head_dim = cfg.head_dim if cfg.staged_head_dim else cfg.qk_mma_tiler[2]
     kv_head_dim = (
         cfg.head_dim_per_stage_kv if cfg.stage_kv_by_head_dim else cfg.qk_mma_tiler[2]
     )
@@ -1701,7 +1810,7 @@ def _configure_smem_shapes(cfg: FmhaConfig) -> None:
     )
     cfg.sQ_shape = (
         cfg.q_stage,
-        cfg.qk_mma_tiler[0] * cfg.qk_mma_tiler[2],
+        cfg.qk_mma_tiler[0] * q_head_dim,
     )
     cfg.sK_shape = (
         cfg.kv_stage,
@@ -1712,14 +1821,20 @@ def _configure_smem_shapes(cfg: FmhaConfig) -> None:
 
 def _validate_tmem_columns(cfg: FmhaConfig) -> None:
     """Reject tile shapes that exceed the selected context TMEM layout."""
-    sp_tmem_cols = cfg.num_qkv_instances * cfg.qk_mma_tiler[1] * cfg.mma_softmax_stage
     o_tmem_cols = cfg.epi_tile[1]
-    stats_tmem_cols = 0
-    if cfg.single_qkv_instance and not cfg.stage_scoped_tmem_stats:
-        stats_tmem_cols = cfg.tmem_stats_cols
-    required_tmem_cols = (
-        sp_tmem_cols + cfg.num_qkv_instances * o_tmem_cols + stats_tmem_cols
-    )
+    if cfg.staged_head_dim:
+        sp_tmem_cols = cfg.qk_mma_tiler[1] * cfg.mma_softmax_stage
+        required_tmem_cols = sp_tmem_cols + cfg.num_head_dim_stages * cfg.epi_tile[1]
+    else:
+        sp_tmem_cols = (
+            cfg.num_qkv_instances * cfg.qk_mma_tiler[1] * cfg.mma_softmax_stage
+        )
+        stats_tmem_cols = 0
+        if cfg.single_qkv_instance and not cfg.stage_scoped_tmem_stats:
+            stats_tmem_cols = cfg.tmem_stats_cols
+        required_tmem_cols = (
+            sp_tmem_cols + cfg.num_qkv_instances * o_tmem_cols + stats_tmem_cols
+        )
     if required_tmem_cols > cfg.tmem_alloc_cols:
         raise ValueError(
             f"head dimension {o_tmem_cols} requires {required_tmem_cols} "
@@ -1730,6 +1845,13 @@ def _validate_tmem_columns(cfg: FmhaConfig) -> None:
 
 def _configure_single_instance_tmem_layout(cfg: FmhaConfig) -> None:
     """Select the one-S/P, one-O TMEM layout used for d>128 context FMHA."""
+    if cfg.staged_head_dim:
+        cfg.tmem_s0_offset = 0
+        cfg.tmem_p0_offset = cfg.tmem_x_load_s
+        cfg.tmem_vec0_offset = 0
+        cfg.tmem_o0_offset = cfg.mma_softmax_stage * cfg.qk_mma_tiler[1]
+        cfg.tmem_o1_offset = cfg.tmem_o0_offset + cfg.head_dim_per_stage_kv
+        return
     cfg.tmem_o0_offset = 0
     cfg.tmem_s0_offset = cfg.epi_tile[1]
     cfg.tmem_p0_offset = cfg.tmem_s0_offset + cfg.tmem_x_load_s
@@ -1774,6 +1896,94 @@ def _configure_head_dim_staging(cfg: FmhaConfig) -> None:
     cfg.stage_o_by_head_dim = True
     # Stage K, V, and O as 128-wide head-dimension slices so the d>128 K/V
     # pipeline can run deeper without exceeding Blackwell's SMEM budget.
+
+
+def _configure_staged_head_dim_tilers(
+    cfg: FmhaConfig,
+    *,
+    mma_tiler_mn: tuple[int, int],
+    d: int,
+) -> None:
+    """Configure the explicit full-Q, split-D schedule for D256."""
+    if d != 256:
+        raise ValueError(f"staged-head-dim FMHA requires D=256, got D={d}")
+    cfg.staged_head_dim = True
+    cfg.num_qkv_instances = 1
+    cfg.head_dim = d
+    cfg.head_dim_per_stage_kv = 128
+    cfg.num_head_dim_stages = d // cfg.head_dim_per_stage_kv
+    cfg.num_head_dim_stages_k = cfg.num_head_dim_stages
+    cfg.num_head_dim_stages_v = cfg.num_head_dim_stages
+    cfg.num_o_head_dim_stages = cfg.num_head_dim_stages
+    cfg.stage_kv_by_head_dim = True
+    cfg.stage_o_by_head_dim = True
+
+    mma_tiler = (*mma_tiler_mn, cfg.head_dim_per_stage_kv)
+    cfg.qk_mma_tiler = mma_tiler
+    cfg.pv_mma_tiler = (mma_tiler[0], cfg.head_dim_per_stage_kv, mma_tiler[1])
+    cfg.epi_tile = cfg.pv_mma_tiler[:2]
+
+    cfg.softmax0_warp_ids = (0, 1, 2, 3)
+    cfg.softmax1_warp_ids = ()
+    cfg.correction_warp_ids = (4, 5, 6, 7)
+    cfg.mma_warp_id = 8
+    cfg.load_warp_id = 11
+    # Fused output frees warp 9 for scheduler/padding participation.
+    cfg.epilogue_warp_id = 9
+    cfg.empty_warp_id = 10
+    cfg.block_warps = 12
+    cfg.num_regs_softmax = 200
+    cfg.num_regs_correction = 128
+    cfg.num_regs_other = 32
+
+
+def _configure_staged_head_dim_tma_copy_metadata(
+    cfg: FmhaConfig,
+    *,
+    q_dtype: type,
+    k_dtype: type,
+    o_dtype: type,
+) -> None:
+    """Derive full-Q and 128-wide K/V/O TMA copy granularities."""
+    kv_tma_bits = cfg.qk_mma_tiler[2] * k_dtype.width
+    if kv_tma_bits % 1024 != 0:
+        raise ValueError(
+            "FMHA TS requires a 128-byte aligned K/V inner dimension, "
+            f"got {kv_tma_bits // 8} bytes"
+        )
+    cfg.tma_copy_qkv_iters = kv_tma_bits // 1024
+    cfg.tma_copy_kv_iters = cfg.tma_copy_qkv_iters
+
+    q_tma_bits = cfg.head_dim * q_dtype.width
+    if q_tma_bits % 1024 != 0:
+        raise ValueError(
+            "FMHA TS requires a 128-byte aligned Q inner dimension, "
+            f"got {q_tma_bits // 8} bytes"
+        )
+    cfg.tma_copy_q_iters = q_tma_bits // 1024
+    cfg.q_tile_m = cfg.qk_mma_tiler[0]
+    cfg.tma_copy_q_granu_inner = cfg.head_dim // cfg.tma_copy_q_iters
+    cfg.tma_copy_q_elements = cfg.sQ_shape[1]
+    cfg.tma_copy_q_granu_elems = cfg.tma_copy_q_elements // cfg.tma_copy_q_iters
+    cfg.tma_copy_q_bytes = cfg.tma_copy_q_elements * q_dtype.width // 8
+
+    cfg.seq_tile_n = cfg.qk_mma_tiler[1]
+    cfg.kv_tile_n = cfg.qk_mma_tiler[1]
+    cfg.tma_copy_kv_granu_inner = cfg.qk_mma_tiler[2] // cfg.tma_copy_qkv_iters
+    cfg.tma_copy_kv_stage_iters = (
+        cfg.head_dim_per_stage_kv // cfg.tma_copy_kv_granu_inner
+    )
+    cfg.tma_copy_kv_elements = cfg.sK_shape[1]
+    cfg.tma_copy_kv_granu_elems = (
+        cfg.tma_copy_kv_elements // cfg.tma_copy_kv_stage_iters
+    )
+    cfg.tma_copy_kv_bytes = cfg.tma_copy_kv_elements * k_dtype.width // 8
+
+    cfg.tma_copy_o_iters = (cfg.epi_tile[1] * o_dtype.width) // 1024
+    cfg.tma_copy_o_granu_inner = cfg.epi_tile[1] // cfg.tma_copy_o_iters
+    cfg.tma_copy_o_stage_iters = cfg.head_dim_per_stage_kv // cfg.tma_copy_o_granu_inner
+    cfg.tma_copy_o_elements = cfg.epi_tile[0] * cfg.head_dim_per_stage_kv
+    cfg.tma_copy_o_granu_elems = cfg.tma_copy_o_elements // cfg.tma_copy_o_stage_iters
 
 
 def _configure_head_paired_tilers(
@@ -2230,6 +2440,10 @@ class FmhaTs:
         grouped-query attention with an even repeat count.
     enable_skip_correction : bool, optional
         Enable skip-correction for softmax rescaling (default: True).
+    enable_staged_head_dim : bool, optional
+        Enable the explicit full-Q, split-D schedule for eligible D256
+        specializations (default: True). The public context planner disables
+        it on architectures where the generic schedule is faster.
     causal_single_kv_tile : bool, optional
         Use the fixed causal one-K/V-tile task domains. The context runner
         enables this only for query-paired, fixed-length inputs whose K/V
@@ -2252,6 +2466,7 @@ class FmhaTs:
         window_size_left: int = 0,
         h_r: int = 1,
         enable_skip_correction: bool = True,
+        enable_staged_head_dim: bool = True,
         use_paged_kv: bool = False,
         num_tokens_per_page: int = 32,
         max_num_pages_per_seq_kv: int = 1,
@@ -2338,6 +2553,46 @@ class FmhaTs:
         balance_causal_workload = balance_causal_workload or (
             is_causal and is_clc_dynamic and not cfg.single_qkv_instance
         )
+
+        # Keep paged D256 on MR2's page-window-aware schedule. The explicit
+        # staged path below uses a K-ahead/V-delayed producer and is selected
+        # only where K/V coordinates are contiguous.
+        if (
+            enable_staged_head_dim
+            and d == 256
+            and q_dtype.width == 8
+            and k_dtype.width == 8
+            and v_dtype.width == 8
+            and not head_paired
+            and not use_paged_kv
+        ):
+            cfg.stats_via_smem = False
+            cfg.fuse_epilogue_into_correction = True
+            _configure_staged_head_dim_tilers(
+                cfg,
+                mma_tiler_mn=mma_tiler_mn,
+                d=d,
+            )
+            _configure_pipeline_stages(cfg, is_clc_dynamic=is_clc_dynamic)
+            _configure_single_instance_tmem_layout(cfg)
+            _configure_smem_shapes(cfg)
+            _validate_tmem_columns(cfg)
+            _configure_staged_head_dim_tma_copy_metadata(
+                cfg,
+                q_dtype=q_dtype,
+                k_dtype=k_dtype,
+                o_dtype=o_dtype,
+            )
+            _configure_common_launch_flags(
+                cfg,
+                d=d,
+                h_r=h_r,
+                is_causal=is_causal,
+                balance_causal_workload=balance_causal_workload,
+                window_size_left=window_size_left,
+            )
+            _configure_early_tile_sum_policy(cfg, is_persistent=is_persistent)
+            return
 
         if head_paired:
             _configure_head_paired_tilers(cfg, mma_tiler_mn=mma_tiler_mn, d=d)
@@ -2477,7 +2732,7 @@ class FmhaTs:
             if cutlass.const_expr(cfg.use_paged_kv)
             else cuda.TensorMapL2Promotion.none
         )
-        if cutlass.const_expr(cfg.head_paired):
+        if cutlass.const_expr(cfg.head_paired or cfg.staged_head_dim):
             inner_dim_size = cfg.qk_mma_tiler[2] * cfg.q_dtype.width // 8
             tma_qkv_swizzle = cuda.TensorMapSwizzle.none
             if cutlass.const_expr(inner_dim_size % 128 == 0):

--- a/flashinfer/attention/prims_ts/kernels/fmha_context/fmha_kernel.py
+++ b/flashinfer/attention/prims_ts/kernels/fmha_context/fmha_kernel.py
@@ -2444,6 +2444,9 @@ class FmhaTs:
         Enable the explicit full-Q, split-D schedule for eligible D256
         specializations (default: True). The public context planner disables
         it on architectures where the generic schedule is faster.
+    enable_ldtm_stat : bool, optional
+        Enable the SM103 fused TMEM load and score row-max reduction for the
+        explicit D256 schedule (default: False).
     causal_single_kv_tile : bool, optional
         Use the fixed causal one-K/V-tile task domains. The context runner
         enables this only for query-paired, fixed-length inputs whose K/V
@@ -2467,6 +2470,7 @@ class FmhaTs:
         h_r: int = 1,
         enable_skip_correction: bool = True,
         enable_staged_head_dim: bool = True,
+        enable_ldtm_stat: bool = False,
         use_paged_kv: bool = False,
         num_tokens_per_page: int = 32,
         max_num_pages_per_seq_kv: int = 1,
@@ -2573,6 +2577,7 @@ class FmhaTs:
                 mma_tiler_mn=mma_tiler_mn,
                 d=d,
             )
+            cfg.use_ldtm_stat = enable_ldtm_stat
             _configure_pipeline_stages(cfg, is_clc_dynamic=is_clc_dynamic)
             _configure_single_instance_tmem_layout(cfg)
             _configure_smem_shapes(cfg)

--- a/flashinfer/attention/prims_ts/kernels/fmha_context/fmha_kernel.py
+++ b/flashinfer/attention/prims_ts/kernels/fmha_context/fmha_kernel.py
@@ -178,18 +178,14 @@ from .fmha_resources import (
 )
 from .fmha_tasks import (
     PackedContextWorkQueue,
-    create_correction_epilogue_task_staged_head_dim,
     create_correction_task,
     create_epilogue_task,
     create_load_task,
-    create_load_task_staged_head_dim,
     create_mma_task,
-    create_mma_task_staged_head_dim,
     create_padding_task,
     create_page_offsets_task,
     create_scheduler_task,
     create_softmax_task,
-    create_softmax_task_staged_head_dim,
 )
 
 
@@ -1148,71 +1144,42 @@ def build_context_task_manager(
         # The non-split single-instance schedule performs every QK/PV pair
         # inside its loop; it has no separate HEAD QK or TAIL PV iteration.
         mma_domain_kwargs = domain_n_kwargs
-    if cfg.staged_head_dim:
-        if tmem_p0 is None:
-            raise ValueError("staged-head-dim scheduling requires a P handoff")
-        load_task = create_load_task_staged_head_dim(
-            gmem_qkv,
-            smem_q,
-            smem_kv,
-            work_queue,
-            **domain_n_minus_1_kwargs,
-        )
-        mma_task = create_mma_task_staged_head_dim(
-            smem_q,
-            smem_kv,
-            tmem_sp0,
-            tmem_o,
-            tmem_stats_done_0,
-            tmem_p0,
-            work_queue,
-            **domain_n_minus_1_kwargs,
-        )
-    else:
-        load_task = create_load_task(
-            gmem_qkv,
-            smem_q,
-            smem_kv,
-            work_queue,
-            smem_page_offsets_kv=smem_page_offsets_kv,
-            smem_page_offsets_v=smem_page_offsets_v,
-            **domain_n_kwargs,
-        )
-        mma_task = create_mma_task(
-            smem_q,
-            smem_kv,
-            tmem_sp0,
-            tmem_sp1,
-            tmem_p0,
-            tmem_o,
-            tmem_stats_done_0,
-            tmem_stats_done_1,
-            work_queue,
-            **mma_domain_kwargs,
-        )
+    load_domain_kwargs = (
+        domain_n_minus_1_kwargs if cfg.staged_head_dim else domain_n_kwargs
+    )
+    load_task = create_load_task(
+        gmem_qkv,
+        smem_q,
+        smem_kv,
+        work_queue,
+        smem_page_offsets_kv=smem_page_offsets_kv,
+        smem_page_offsets_v=smem_page_offsets_v,
+        **load_domain_kwargs,
+    )
+    mma_task = create_mma_task(
+        smem_q,
+        smem_kv,
+        tmem_sp0,
+        tmem_sp1,
+        tmem_p0,
+        tmem_o,
+        tmem_stats_done_0,
+        tmem_stats_done_1,
+        work_queue,
+        **mma_domain_kwargs,
+    )
 
     # Causal query-paired moves masked/invalid K iterations from LOOP to TAIL
     # with no runtime branch. SP resources derive mask selection from cfg.
-    if cfg.staged_head_dim:
-        if tmem_p0 is None:
-            raise ValueError("staged-head-dim softmax requires a P handoff")
-        softmax0_task = create_softmax_task_staged_head_dim(
-            tmem_sp0,
-            tmem_vec0,
-            tmem_p0,
-            work_queue,
-            **softmax0_domain_kwargs,
-        )
-    else:
-        softmax0_task = create_softmax_task(
-            0,
-            tmem_sp0,
-            tmem_vec0,
-            tmem_p0,
-            s0s1_seq,
-            work_queue,
-            **softmax0_domain_kwargs,
-        )
+    softmax0_task = create_softmax_task(
+        0,
+        tmem_sp0,
+        tmem_vec0,
+        tmem_p0,
+        s0s1_seq,
+        work_queue,
+        **softmax0_domain_kwargs,
+    )
     softmax1_task: Task | None = None
     if not single_qkv_instance:
         if tmem_sp1 is None or tmem_vec1 is None:
@@ -1226,34 +1193,19 @@ def build_context_task_manager(
             work_queue,
             **softmax1_domain_kwargs,
         )
-    if cfg.staged_head_dim:
-        if smem_o_1 is None or gmem_o_1 is None:
-            raise ValueError("staged-head-dim output requires two O resources")
-        correction_task = create_correction_epilogue_task_staged_head_dim(
-            tmem_vec0,
-            tmem_o,
-            smem_o_0,
-            smem_o_1,
-            gmem_o_0,
-            gmem_o_1,
-            tmem_stats_done_0,
-            work_queue,
-            **domain_n_minus_1_kwargs,
-        )
-    else:
-        correction_task = create_correction_task(
-            tmem_vec0,
-            tmem_vec1,
-            tmem_o,
-            smem_o_0,
-            smem_o_1,
-            gmem_o_0,
-            gmem_o_1,
-            tmem_stats_done_0,
-            tmem_stats_done_1,
-            work_queue,
-            **domain_n_minus_1_kwargs,
-        )
+    correction_task = create_correction_task(
+        tmem_vec0,
+        tmem_vec1,
+        tmem_o,
+        smem_o_0,
+        smem_o_1,
+        gmem_o_0,
+        gmem_o_1,
+        tmem_stats_done_0,
+        tmem_stats_done_1,
+        work_queue,
+        **domain_n_minus_1_kwargs,
+    )
     epilogue_task: Task | None = None
     freed_epilogue_task: Task | None = None
     if cfg.fuse_epilogue_into_correction:

--- a/flashinfer/attention/prims_ts/kernels/fmha_context/fmha_resources.py
+++ b/flashinfer/attention/prims_ts/kernels/fmha_context/fmha_resources.py
@@ -278,6 +278,8 @@ class FmhaConfig:
     # Explicit D256 schedule: Q remains resident as one full-D tile while
     # QK, K/V staging, PV, and O use two 128-wide head-dimension slices.
     staged_head_dim: bool = False
+    # SM103 fused TMEM load + row-max reduction for unmasked score tiles.
+    use_ldtm_stat: bool = False
     head_dim: int = 128
     num_head_dim_stages: int = 1
 
@@ -2543,6 +2545,36 @@ class TmemSPResource(MemoryResource):
         return s_data
 
     @cute.jit
+    def _load_s_chunks_with_row_max(
+        self, stage_info: StageInfo
+    ) -> tuple[SoftmaxChunks, SoftmaxScalar]:
+        """Load one score tile and use SM103 LDTM.STAT for its row maximum."""
+        tmem_s_addr = self.tmem_s_addr_cached + self._stage_col_offset(stage_info)
+        tmem_x = self.cfg.tmem_x_load_s
+        num_chunks = self.cfg.qk_mma_tiler[1] // tmem_x
+        loaded_values, tile_row_max = prims.tcgen05_ld_red(
+            "32x32b",
+            prims.make_tmem_ptr(tmem_s_addr, self.cfg.qk_acc_dtype),
+            prims.ReductionKind.MAX,
+            num=self.cfg.qk_mma_tiler[1],
+        )
+        # tcgen05 load-reduce results are asynchronous until the LOAD wait
+        # completes.
+        prims.tcgen05_wait(prims.Tcgen05Wait.LOAD)
+        cute.arch.fence_view_async_tmem_load()
+
+        s_data = []
+        for chunk_idx in cutlass.range_constexpr(num_chunks):
+            chunk_values = tuple(
+                loaded_values[chunk_idx * tmem_x + elem_idx]
+                for elem_idx in range(tmem_x)
+            )
+            s_data.append(
+                cutlass.Vector.from_elements(chunk_values, self.cfg.qk_acc_dtype)
+            )
+        return s_data, tile_row_max
+
+    @cute.jit
     def _reduce_row_max(
         self,
         s_data: SoftmaxChunks,
@@ -3030,6 +3062,15 @@ class TmemSPResource(MemoryResource):
         row_max: SoftmaxScalar,
     ) -> tuple[SoftmaxScalar, SoftmaxScalar]:
         """Main K-loop stage: load S from TMEM and compute unmasked row_max."""
+        if cutlass.const_expr(self.cfg.use_ldtm_stat):
+            old_row_max = row_max
+            s_data, tile_row_max = self._load_s_chunks_with_row_max(stage_info)
+            _tmem_sp_sdata[id(self)] = s_data
+            row_max = cute.math.max(row_max, tile_row_max, ftz=True)
+            row_max_safe = row_max
+            if row_max == -Float32.inf:
+                row_max_safe = Float32(0.0)
+            return old_row_max, row_max_safe
         s_data = self._load_s_chunks(stage_info)
         return self._reduce_row_max(s_data, row_max)
 
@@ -4408,7 +4449,9 @@ class TmemOResource(MemoryResource):
     ) -> None:
         """Rescale one 128-wide O half in TMEM."""
         tmem_o_addr = self.tmem_o_addr_base_cached + tmem_o_offset
-        tmem_x = 16
+        # x32 halves issue count within the correction warp's register budget;
+        # x64 was benchmarked but not retained.
+        tmem_x = 32
         for i in cutlass.range_constexpr(self.cfg.cta_tiler[2] // tmem_x):
             tmem_ptr = cutlass.inttoptr(
                 tmem_o_addr + i * tmem_x,

--- a/flashinfer/attention/prims_ts/kernels/fmha_context/fmha_resources.py
+++ b/flashinfer/attention/prims_ts/kernels/fmha_context/fmha_resources.py
@@ -2964,7 +2964,9 @@ class TmemSPResource(MemoryResource):
         packed_words: tuple[Any, ...] = ()
         local_sum_pair_0 = (Float32(0.0), Float32(0.0))
         local_sum_pair_1 = (Float32(0.0), Float32(0.0))
-        use_two_sum_pairs = not self.cfg.stage_kv_by_head_dim
+        use_two_sum_pairs = True  # staged D256: enable four independent sum chains
+        if cutlass.const_expr(self.cfg.use_ldtm_stat):
+            cute.nvgpu.sched_res_busy_xu64()
         for flat_idx in cutlass.range_constexpr(0, num_values, 2):
             if cutlass.const_expr(flat_idx >= 8):
                 delayed_idx = flat_idx - 8
@@ -2993,7 +2995,12 @@ class TmemSPResource(MemoryResource):
                         ftz=False,
                     )
 
+            if cutlass.const_expr(self.cfg.use_ldtm_stat):
+                # cfence prevents ptxas from regrouping the latency-hiding cadence.
+                cute.nvgpu.cfence()
             p0 = cute.math.exp2(fma_values[flat_idx], fastmath=True)
+            if cutlass.const_expr(self.cfg.use_ldtm_stat):
+                cute.nvgpu.cfence()
             if cutlass.const_expr(flat_idx + 8 < num_values):
                 future_idx = flat_idx + 8
                 chunk_idx = future_idx // tmem_x
@@ -3009,8 +3016,14 @@ class TmemSPResource(MemoryResource):
                     ftz=False,
                 )
                 fma_values += (fma_pair[0], fma_pair[1])
+            if cutlass.const_expr(self.cfg.use_ldtm_stat):
+                cute.nvgpu.cfence()
             p1 = cute.math.exp2(fma_values[flat_idx + 1], fastmath=True)
+            if cutlass.const_expr(self.cfg.use_ldtm_stat):
+                cute.nvgpu.cfence()
             p_values += (p0, p1)
+        if cutlass.const_expr(self.cfg.use_ldtm_stat):
+            cute.nvgpu.reset_sched_res_busy_xu64()
 
         for delayed_idx in cutlass.range_constexpr(num_values - 8, num_values, 2):
             if cutlass.const_expr(delayed_idx % 4 == 0):
@@ -4900,6 +4913,7 @@ class GmemOResource(MemoryResource):
         seq_coord_q: Int32,
         head_dim_stage_idx: cutlass.Constexpr[int] = 0,
         correction_fused: cutlass.Constexpr[bool] = False,
+        wait_after_write: cutlass.Constexpr[bool] = True,
     ) -> None:
         """TMA store O from SMEM to GMEM.
 
@@ -4967,5 +4981,7 @@ class GmemOResource(MemoryResource):
             # Q tile coordinates. Keep commit paired with an actual store.
             if should_store:
                 prims.cp_async_bulk_commit_group()
-                if cutlass.const_expr(self.cfg.gmem_o_store_wait_after_write):
+                if cutlass.const_expr(
+                    self.cfg.gmem_o_store_wait_after_write and wait_after_write
+                ):
                     prims.cp_async_bulk_wait_group(0, read=True)

--- a/flashinfer/attention/prims_ts/kernels/fmha_context/fmha_resources.py
+++ b/flashinfer/attention/prims_ts/kernels/fmha_context/fmha_resources.py
@@ -65,6 +65,7 @@ from typing import Any, Optional, TypeAlias
 import cutlass
 import cutlass.cute as cute
 from cutlass import Float32, Int32
+from cutlass._mlir import ir
 from ..tensor_map import transform_ragged_coords
 
 from cutlass.experimental.task_scheduling.enums import WorkAttr
@@ -104,6 +105,34 @@ SoftmaxRowSumContribution: TypeAlias = SoftmaxChunks | SoftmaxScalar
 # Stored at module level (not on self) to avoid adding a non-dynamic-expression
 # field to the dataclass, which breaks the framework's scf.if handling.
 _tmem_sp_sdata: dict[int, list] = {}
+
+
+@dsl_user_op
+def _tcgen05_ld_red_x128_max_f32(
+    tmem_addr: Int32,
+    *,
+    loc: ir.Location | None = None,
+    ip: ir.InsertionPoint | None = None,
+) -> tuple[cutlass.Vector, Float32]:
+    """Load 128 FP32 TMEM columns and compute their per-row maximum.
+
+    Public CUTLASS DSL 4.7 lacks a typed ``tcgen05.ld.red`` Python binding, so
+    use its public ``nvvm.inline_ptx`` wrapper, as the CTM operation does.
+    """
+    num_values = 128
+    data_operands = ", ".join(f"{{$w{i}}}" for i in range(num_values))
+    outputs = cute.arch.inline_ptx(
+        (
+            "tcgen05.ld.red.sync.aligned.32x32b.x128.max.f32 "
+            f"{{{data_operands}}}, {{$w{num_values}}}, [{{$r0}}];"
+        ),
+        write_only_types=[Int32] * (num_values + 1),
+        read_only_args=[tmem_addr],
+        loc=loc,
+        ip=ip,
+    )
+    values = tuple(output.bitcast(Float32, loc=loc, ip=ip) for output in outputs)
+    return cutlass.Vector.from_elements(values[:num_values], Float32), values[-1]
 
 
 @cute.jit
@@ -2552,12 +2581,7 @@ class TmemSPResource(MemoryResource):
         tmem_s_addr = self.tmem_s_addr_cached + self._stage_col_offset(stage_info)
         tmem_x = self.cfg.tmem_x_load_s
         num_chunks = self.cfg.qk_mma_tiler[1] // tmem_x
-        loaded_values, tile_row_max = prims.tcgen05_ld_red(
-            "32x32b",
-            prims.make_tmem_ptr(tmem_s_addr, self.cfg.qk_acc_dtype),
-            prims.ReductionKind.MAX,
-            num=self.cfg.qk_mma_tiler[1],
-        )
+        loaded_values, tile_row_max = _tcgen05_ld_red_x128_max_f32(Int32(tmem_s_addr))
         # tcgen05 load-reduce results are asynchronous until the LOAD wait
         # completes.
         prims.tcgen05_wait(prims.Tcgen05Wait.LOAD)

--- a/flashinfer/attention/prims_ts/kernels/fmha_context/fmha_resources.py
+++ b/flashinfer/attention/prims_ts/kernels/fmha_context/fmha_resources.py
@@ -2965,8 +2965,6 @@ class TmemSPResource(MemoryResource):
         local_sum_pair_0 = (Float32(0.0), Float32(0.0))
         local_sum_pair_1 = (Float32(0.0), Float32(0.0))
         use_two_sum_pairs = True  # staged D256: enable four independent sum chains
-        if cutlass.const_expr(self.cfg.use_ldtm_stat):
-            cute.nvgpu.sched_res_busy_xu64()
         for flat_idx in cutlass.range_constexpr(0, num_values, 2):
             if cutlass.const_expr(flat_idx >= 8):
                 delayed_idx = flat_idx - 8
@@ -2995,12 +2993,7 @@ class TmemSPResource(MemoryResource):
                         ftz=False,
                     )
 
-            if cutlass.const_expr(self.cfg.use_ldtm_stat):
-                # cfence prevents ptxas from regrouping the latency-hiding cadence.
-                cute.nvgpu.cfence()
             p0 = cute.math.exp2(fma_values[flat_idx], fastmath=True)
-            if cutlass.const_expr(self.cfg.use_ldtm_stat):
-                cute.nvgpu.cfence()
             if cutlass.const_expr(flat_idx + 8 < num_values):
                 future_idx = flat_idx + 8
                 chunk_idx = future_idx // tmem_x
@@ -3016,14 +3009,8 @@ class TmemSPResource(MemoryResource):
                     ftz=False,
                 )
                 fma_values += (fma_pair[0], fma_pair[1])
-            if cutlass.const_expr(self.cfg.use_ldtm_stat):
-                cute.nvgpu.cfence()
             p1 = cute.math.exp2(fma_values[flat_idx + 1], fastmath=True)
-            if cutlass.const_expr(self.cfg.use_ldtm_stat):
-                cute.nvgpu.cfence()
             p_values += (p0, p1)
-        if cutlass.const_expr(self.cfg.use_ldtm_stat):
-            cute.nvgpu.reset_sched_res_busy_xu64()
 
         for delayed_idx in cutlass.range_constexpr(num_values - 8, num_values, 2):
             if cutlass.const_expr(delayed_idx % 4 == 0):

--- a/flashinfer/attention/prims_ts/kernels/fmha_context/fmha_resources.py
+++ b/flashinfer/attention/prims_ts/kernels/fmha_context/fmha_resources.py
@@ -194,6 +194,8 @@ class FmhaConfig:
 
     # TMA copy granularity
     tma_copy_qkv_iters: int = 1
+    tma_copy_q_iters: int = 1
+    tma_copy_kv_iters: int = 1
     tma_copy_q_granu_inner: int = 128
     tma_copy_q_elements: int = 0
     tma_copy_q_granu_elems: int = 0
@@ -273,6 +275,11 @@ class FmhaConfig:
     # This enables the grouped-query/sliding-window context flavor while
     # reusing the unified FMHA context implementation.
     head_paired: bool = False
+    # Explicit D256 schedule: Q remains resident as one full-D tile while
+    # QK, K/V staging, PV, and O use two 128-wide head-dimension slices.
+    staged_head_dim: bool = False
+    head_dim: int = 128
+    num_head_dim_stages: int = 1
 
     # Concrete kernel policy derived from paired geometry and V dtype.  The
     # resource consumes this flag directly so the row-sum algorithm and the
@@ -1140,12 +1147,16 @@ class SmemQResource(MemoryResource):
         inst_idx 0 = Q0, inst_idx 1 = Q1.
         Uses seq_coord_q from producer variables (forwarded from GmemQKV).
         """
+        q_peer_idx = inst_idx
+        if cutlass.const_expr(self.cfg.staged_head_dim):
+            q_peer_idx = 0
         q_head_coord = (
             head_coord * self.cfg.work_tile_q_heads
-            + inst_idx * self.cfg.peer_q_head_stride
+            + q_peer_idx * self.cfg.peer_q_head_stride
         )
         q_seq_offset = (
-            seq_coord_q + inst_idx * self.cfg.peer_q_seq_tile_stride * self.cfg.q_tile_m
+            seq_coord_q
+            + q_peer_idx * self.cfg.peer_q_seq_tile_stride * self.cfg.q_tile_m
         )
         q_seq_extent = Int32(0)
         if cutlass.const_expr(self.cfg.has_varlen):
@@ -1154,8 +1165,11 @@ class SmemQResource(MemoryResource):
         d_granu_inner = self.cfg.tma_copy_q_granu_inner
 
         sQ_curr = self.sQ_array.subview(stage_info.stage_idx * smem_stage_elements)
+        tma_copy_q_iters = self.cfg.tma_copy_qkv_iters
+        if cutlass.const_expr(self.cfg.staged_head_dim):
+            tma_copy_q_iters = self.cfg.tma_copy_q_iters
         if prims.elect_sync():
-            for i in cutlass.range_constexpr(self.cfg.tma_copy_qkv_iters):
+            for i in cutlass.range_constexpr(tma_copy_q_iters):
                 d_offset = i * d_granu_inner
                 q_coords = (d_offset, q_head_coord, q_seq_offset, batch_coord)
                 if cutlass.const_expr(self.cfg.has_varlen):
@@ -1180,7 +1194,11 @@ class SmemQResource(MemoryResource):
         Q is consumed twice in HEAD without an intervening ConsumerRelease,
         which would otherwise advance consumer_state.
         """
-        sQ_curr = self.sQ_array.subview(inst_idx * self.cfg.tma_copy_q_elements)
+        if cutlass.const_expr(self.cfg.staged_head_dim):
+            slice_elements = self.cfg.qk_mma_tiler[0] * self.cfg.qk_mma_tiler[2]
+            sQ_curr = self.sQ_array.subview(inst_idx * slice_elements)
+        else:
+            sQ_curr = self.sQ_array.subview(inst_idx * self.cfg.tma_copy_q_elements)
         leading_byte_offset, stride_byte_offset = _qk_smem_desc_offsets(self.cfg)
         return prims.Tcgen05SmemDesc.build(
             sQ_curr,
@@ -1501,6 +1519,8 @@ class SmemKVResource(MemoryResource):
     cfg: Constexpr[FmhaConfig] = field(init=False, default=None)
     _alloc: Constexpr[Optional[SmemAllocation]] = field(init=False, default=None)
     desc_k_base: Constexpr[TaskLocalVariable] = TaskLocalVariable.uninitialized()
+    desc_k0_base: Constexpr[TaskLocalVariable] = TaskLocalVariable.uninitialized()
+    desc_k1_base: Constexpr[TaskLocalVariable] = TaskLocalVariable.uninitialized()
     desc_v_base: Constexpr[TaskLocalVariable] = TaskLocalVariable.uninitialized()
 
     def __init__(
@@ -1534,6 +1554,16 @@ class SmemKVResource(MemoryResource):
             dtype=cutlass.Int64,
             default=cutlass.Int64(0),
             docs="SMEM descriptor base for the current K tile.",
+        )
+        self.desc_k0_base = TaskLocalVariable(
+            dtype=cutlass.Int64,
+            default=cutlass.Int64(0),
+            docs="SMEM descriptor base for staged-D K stage 0.",
+        )
+        self.desc_k1_base = TaskLocalVariable(
+            dtype=cutlass.Int64,
+            default=cutlass.Int64(0),
+            docs="SMEM descriptor base for staged-D K stage 1.",
         )
         self.desc_v_base = TaskLocalVariable(
             dtype=cutlass.Int64,
@@ -1580,6 +1610,7 @@ class SmemKVResource(MemoryResource):
         tma_desc: cutlass.Pointer | None,
         is_v: cutlass.Constexpr[bool] = False,
         tile_offset: cutlass.Constexpr[int] = 0,
+        use_loop_end: cutlass.Constexpr[bool] = False,
         head_dim_stage_idx: cutlass.Constexpr[int] = 0,
         cached_page_ids: cutlass.Array | None = None,
         *,
@@ -1589,9 +1620,10 @@ class SmemKVResource(MemoryResource):
         kv_tile_start: Int32,
     ) -> None:
         """Issue TMA bulk-copy for one K or V tile."""
-        seq_offset = (
-            kv_tile_start + stage_info.loop_offset + tile_offset
-        ) * self.cfg.kv_tile_n
+        loop_offset = stage_info.loop_offset + tile_offset
+        if cutlass.const_expr(use_loop_end):
+            loop_offset = stage_info.loop_end
+        seq_offset = (kv_tile_start + loop_offset) * self.cfg.kv_tile_n
         smem_stage_elements = self.cfg.tma_copy_kv_elements
         sK_curr = self.sK_array.subview(stage_info.stage_idx * smem_stage_elements)
 
@@ -1603,7 +1635,7 @@ class SmemKVResource(MemoryResource):
             # the contiguous path: two d-halves (tma_copy_kv_granu_elems each)
             # with page fragments concatenated along the seq axis inside each
             # d-half.
-            tile_idx = kv_tile_start + stage_info.loop_offset + tile_offset
+            tile_idx = kv_tile_start + loop_offset
             pages_per_tile = self.cfg.kv_tile_n // self.cfg.num_tokens_per_page
             d_granu_inner = self.cfg.tma_copy_kv_granu_inner
             page_d_elems = self.cfg.num_tokens_per_page * d_granu_inner
@@ -1731,6 +1763,30 @@ class SmemKVResource(MemoryResource):
 
     @producer_work
     @cute.jit
+    def k_load_next(
+        self,
+        stage_info: StageInfo,
+        *,
+        head_dim_stage_idx: cutlass.Constexpr[int] = 0,
+        kv_head_coord: Int32,
+        batch_coord: Int32,
+        cuseqlen_k: Int32,
+        kv_tile_start: Int32,
+    ) -> None:
+        """Load K(i+1) for the explicit staged-D overlap."""
+        self._tma_load(
+            stage_info,
+            self.tma_k_desc,
+            tile_offset=1,
+            head_dim_stage_idx=head_dim_stage_idx,
+            kv_head_coord=kv_head_coord,
+            batch_coord=batch_coord,
+            cuseqlen_k=cuseqlen_k,
+            kv_tile_start=kv_tile_start,
+        )
+
+    @producer_work
+    @cute.jit
     def v_load(
         self,
         stage_info: StageInfo,
@@ -1784,6 +1840,31 @@ class SmemKVResource(MemoryResource):
 
     @producer_work
     @cute.jit
+    def v_load_tail(
+        self,
+        stage_info: StageInfo,
+        *,
+        head_dim_stage_idx: cutlass.Constexpr[int] = 0,
+        kv_head_coord: Int32,
+        batch_coord: Int32,
+        cuseqlen_k: Int32,
+        kv_tile_start: Int32,
+    ) -> None:
+        """Load the final V tile after the staged-D K-prefetch loop."""
+        self._tma_load(
+            stage_info,
+            self.tma_v_desc,
+            True,
+            use_loop_end=True,
+            head_dim_stage_idx=head_dim_stage_idx,
+            kv_head_coord=kv_head_coord,
+            batch_coord=batch_coord,
+            cuseqlen_k=cuseqlen_k,
+            kv_tile_start=kv_tile_start,
+        )
+
+    @producer_work
+    @cute.jit
     def v_load_stage_cached(
         self,
         stage_info: StageInfo,
@@ -1814,6 +1895,11 @@ class SmemKVResource(MemoryResource):
     @cute.jit
     def k_desc(self, stage_info: StageInfo) -> prims.Tcgen05SmemDesc:
         """Build K SMEM descriptor (K-major layout for QK MMA) -> desc_k_base."""
+        return self._build_k_descriptor(stage_info)
+
+    @cute.jit
+    def _build_k_descriptor(self, stage_info: StageInfo) -> prims.Tcgen05SmemDesc:
+        """Build a K SMEM descriptor for the current pipeline stage."""
         smem_stage_elements = self.cfg.tma_copy_kv_elements
         sK_curr = self.sK_array.subview(stage_info.stage_idx * smem_stage_elements)
         leading_byte_offset, stride_byte_offset = _qk_smem_desc_offsets(self.cfg)
@@ -1824,6 +1910,18 @@ class SmemKVResource(MemoryResource):
             layout=_qkv_smem_layout(self.cfg),
         )
         return desc_k_base
+
+    @consumer_work(returns=desc_k0_base)
+    @cute.jit
+    def k0_desc(self, stage_info: StageInfo) -> prims.Tcgen05SmemDesc:
+        """Build staged-D K-stage 0 descriptor."""
+        return self._build_k_descriptor(stage_info)
+
+    @consumer_work(returns=desc_k1_base)
+    @cute.jit
+    def k1_desc(self, stage_info: StageInfo) -> prims.Tcgen05SmemDesc:
+        """Build staged-D K-stage 1 descriptor."""
+        return self._build_k_descriptor(stage_info)
 
     @consumer_work(returns=desc_v_base)
     @cute.jit
@@ -2167,6 +2265,106 @@ class TmemSPResource(MemoryResource):
     def p_read(self, stage_info: StageInfo) -> None:
         """P-read sync: no-op. SP handle held from QK, consumed by softmax."""
         pass
+
+    @producer_work
+    @cute.jit
+    def qk_mma_staged_pair(
+        self,
+        stage_info: StageInfo,
+        *,
+        desc_q0_base: prims.Tcgen05SmemDesc,
+        desc_k0_base: prims.Tcgen05SmemDesc,
+        desc_q1_base: prims.Tcgen05SmemDesc,
+        desc_k1_base: prims.Tcgen05SmemDesc,
+    ) -> None:
+        """Issue both 128-wide D stages as one QK pipeline transaction."""
+        self._issue_qk_mma_staged(
+            stage_info,
+            desc_q0_base,
+            desc_k0_base,
+            Boolean(False),
+        )
+        self._issue_qk_mma_staged(
+            stage_info,
+            desc_q1_base,
+            desc_k1_base,
+            Boolean(True),
+        )
+
+    @cute.jit
+    def _issue_qk_mma_staged(
+        self,
+        stage_info: StageInfo,
+        desc_q_base: prims.Tcgen05SmemDesc,
+        desc_k_base: prims.Tcgen05SmemDesc,
+        scale_d: Boolean,
+    ) -> None:
+        """Issue one 128-wide QK half into the selected S/P stage."""
+        tmem_ptr_s = self.tmem_ptr_s_cached.subview(self._stage_col_offset(stage_info))
+
+        if cutlass.const_expr(self.cfg.q_dtype.width == 8):
+            mma_kind = prims.Tcgen05MMAKind.F8F6F4
+            ab_format = cutlass.Float16
+        else:
+            mma_kind = prims.Tcgen05MMAKind.F16
+            if cutlass.const_expr(self.cfg.q_dtype == cutlass.BFloat16):
+                ab_format = cutlass.BFloat16
+            else:
+                ab_format = cutlass.Float16
+
+        idesc_qk = prims.Tcgen05InstrDesc.build(
+            c_dtype=cutlass.Float32,
+            a_dtype=ab_format,
+            b_dtype=ab_format,
+            n_dim=self.cfg.qk_mma_tiler[1],
+            m_dim=self.cfg.qk_mma_tiler[0],
+        )
+
+        k_dim_per_mma = 16
+        if cutlass.const_expr(self.cfg.q_dtype.width != 16):
+            k_dim_per_mma = 32
+        num_kphases_qk = self.cfg.qk_mma_tiler[2] // k_dim_per_mma
+        inc_bytes_qk = k_dim_per_mma * self.cfg.q_dtype.width // 8
+
+        if cutlass.const_expr(self.cfg.tma_copy_qkv_iters == 1):
+            extra_bytes_qk = inc_bytes_qk * (num_kphases_qk // 2)
+        else:
+            extra_bytes_qk = self.cfg.tma_copy_kv_bytes // self.cfg.tma_copy_qkv_iters
+
+        desc_q_base_ = freeze_smem_descriptor(desc_q_base)
+        desc_k_base_ = freeze_smem_descriptor(desc_k_base)
+
+        for k_idx in cutlass.range_constexpr(num_kphases_qk // 2):
+            increment = (inc_bytes_qk * k_idx) >> 4
+            dq = desc_q_base_ + increment
+            dk = desc_k_base_ + increment
+            mma_scale_d = Boolean(True)
+            if cutlass.const_expr(k_idx == 0):
+                mma_scale_d = scale_d
+            if prims.elect_sync():
+                prims.tcgen05_mma(
+                    mma_kind,
+                    prims.CTAGroup.CTA_1,
+                    tmem_ptr_s,
+                    dq,
+                    dk,
+                    idesc_qk,
+                    mma_scale_d,
+                )
+        for k_idx in cutlass.range_constexpr(num_kphases_qk // 2):
+            increment = (inc_bytes_qk * k_idx + extra_bytes_qk) >> 4
+            dq = desc_q_base_ + increment
+            dk = desc_k_base_ + increment
+            if prims.elect_sync():
+                prims.tcgen05_mma(
+                    mma_kind,
+                    prims.CTAGroup.CTA_1,
+                    tmem_ptr_s,
+                    dq,
+                    dk,
+                    idesc_qk,
+                    Boolean(True),
+                )
 
     @cute.jit
     def _init_function_state(self, stage_info: StageInfo) -> None:
@@ -4049,6 +4247,135 @@ class TmemOResource(MemoryResource):
                             )
                         scale_d_stage = True
 
+    @producer_work
+    @cute.jit
+    def pv_mma_staged_o0_pipe(
+        self,
+        stage_info: StageInfo,
+        *,
+        desc_v_base: prims.Tcgen05SmemDesc,
+        tmem_p_base: TmemAddr,
+    ) -> None:
+        """Accumulate the loop-carried P/V tile into O's first D half."""
+        self._issue_pv_mma_staged(
+            desc_v_base,
+            self.tmem_o0_offset,
+            tmem_p_base,
+            Boolean(stage_info.loop_offset > 0),
+        )
+
+    @producer_work
+    @cute.jit
+    def pv_mma_staged_o1_pipe(
+        self,
+        stage_info: StageInfo,
+        *,
+        desc_v_base: prims.Tcgen05SmemDesc,
+        tmem_p_base: TmemAddr,
+    ) -> None:
+        """Accumulate the loop-carried P/V tile into O's second D half."""
+        self._issue_pv_mma_staged(
+            desc_v_base,
+            self.tmem_o1_offset,
+            tmem_p_base,
+            Boolean(stage_info.loop_offset > 0),
+        )
+
+    @producer_work
+    @cute.jit
+    def pv_mma_staged_o0_tail(
+        self,
+        stage_info: StageInfo,
+        *,
+        desc_v_base: prims.Tcgen05SmemDesc,
+        tmem_p_base: TmemAddr,
+    ) -> None:
+        """Accumulate the final P/V tile into O's first D half."""
+        self._issue_pv_mma_staged(
+            desc_v_base,
+            self.tmem_o0_offset,
+            tmem_p_base,
+            Boolean(stage_info.loop_end > 0),
+        )
+
+    @producer_work
+    @cute.jit
+    def pv_mma_staged_o1_tail(
+        self,
+        stage_info: StageInfo,
+        *,
+        desc_v_base: prims.Tcgen05SmemDesc,
+        tmem_p_base: TmemAddr,
+    ) -> None:
+        """Accumulate the final P/V tile into O's second D half."""
+        self._issue_pv_mma_staged(
+            desc_v_base,
+            self.tmem_o1_offset,
+            tmem_p_base,
+            Boolean(stage_info.loop_end > 0),
+        )
+
+    @cute.jit
+    def _issue_pv_mma_staged(
+        self,
+        desc_v_base: prims.Tcgen05SmemDesc,
+        tmem_o_offset: int,
+        tmem_p_base: TmemAddr,
+        scale_d: Boolean,
+    ) -> None:
+        """Issue one staged-D PV MMA into the selected 128-wide O half."""
+        tmem_ptr_raw = self.tmem_ptr_raw_cached
+
+        if cutlass.const_expr(self.cfg.v_dtype.width == 8):
+            mma_kind = prims.Tcgen05MMAKind.F8F6F4
+            ab_format = cutlass.Float16
+        else:
+            mma_kind = prims.Tcgen05MMAKind.F16
+            if cutlass.const_expr(self.cfg.v_dtype == cutlass.BFloat16):
+                ab_format = cutlass.BFloat16
+            else:
+                ab_format = cutlass.Float16
+
+        idesc_pv = prims.Tcgen05InstrDesc.build(
+            c_dtype=cutlass.Float32,
+            a_dtype=ab_format,
+            b_dtype=ab_format,
+            n_dim=self.cfg.pv_mma_tiler[1],
+            m_dim=self.cfg.pv_mma_tiler[0],
+            b_major=1,
+        )
+
+        k_dim_per_mma = 16
+        if cutlass.const_expr(self.cfg.v_dtype.width != 16):
+            k_dim_per_mma = 32
+        num_kphases_pv = self.cfg.pv_mma_tiler[2] // k_dim_per_mma
+        inc_tmem_p = (
+            k_dim_per_mma * self.cfg.v_dtype.width // self.cfg.qk_acc_dtype.width
+        )
+        inc_bytes_v = (
+            k_dim_per_mma
+            * (self.cfg.pv_mma_tiler[1] // self.cfg.tma_copy_kv_iters)
+            * self.cfg.v_dtype.width
+            // 8
+        )
+
+        tmem_ptr_o = tmem_ptr_raw.subview(tmem_o_offset)
+        desc_v_base_ = freeze_smem_descriptor(desc_v_base)
+        for k_idx in cutlass.range_constexpr(num_kphases_pv):
+            dp = tmem_ptr_raw.subview(tmem_p_base + k_idx * inc_tmem_p)
+            dv = desc_v_base_ + ((inc_bytes_v * k_idx) >> 4)
+            if prims.elect_sync():
+                prims.tcgen05_mma(
+                    mma_kind,
+                    prims.CTAGroup.CTA_1,
+                    tmem_ptr_o,
+                    dp,
+                    dv,
+                    idesc_pv,
+                    scale_d,
+                )
+            scale_d = Boolean(True)
+
     @consumer_work
     @cute.jit
     def correct(
@@ -4072,6 +4399,49 @@ class TmemOResource(MemoryResource):
             inst_idx=inst_idx,
             is_tail=is_tail,
         )
+
+    @cute.jit
+    def _rescale_staged_o(
+        self,
+        tmem_o_offset: Constexpr[int],
+        scale: SoftmaxScalar,
+    ) -> None:
+        """Rescale one 128-wide O half in TMEM."""
+        tmem_o_addr = self.tmem_o_addr_base_cached + tmem_o_offset
+        tmem_x = 16
+        for i in cutlass.range_constexpr(self.cfg.cta_tiler[2] // tmem_x):
+            tmem_ptr = cutlass.inttoptr(
+                tmem_o_addr + i * tmem_x,
+                mem_space=6,
+                dtype=self.cfg.pv_acc_dtype,
+            )
+            o_vec = prims.tcgen05_ld("32x32b", tmem_ptr, num=tmem_x)
+            o_scaled = o_vec * cutlass.vector.full_like(o_vec, scale)
+            prims.tcgen05_st("32x32b", tmem_ptr, o_scaled)
+
+    @consumer_work
+    @cute.jit
+    def correct_staged_pair(
+        self,
+        stage_info: StageInfo,
+        *,
+        vec_old_max: SoftmaxScalar,
+        vec_new_max: SoftmaxScalar,
+        vec_scale: SoftmaxScalar,
+    ) -> None:
+        """Rescale both D256 O halves under one correction synchronization."""
+        should_rescale = Boolean(True)
+        if cutlass.const_expr(self.cfg.enable_skip_correction):
+            vote_ballot_cnt = cute.arch.vote_ballot_sync(vec_old_max != vec_new_max)
+            should_rescale = vote_ballot_cnt != Int32(0)
+
+        prims.tcgen05_fence("after")
+        if should_rescale:
+            self._rescale_staged_o(self.tmem_o0_offset, vec_scale)
+            self._rescale_staged_o(self.tmem_o1_offset, vec_scale)
+            prims.tcgen05_wait(kind=prims.Tcgen05Wait.STORE)
+        prims.tcgen05_fence("before")
+        _ = stage_info
 
     @cute.jit
     def _correct_impl(

--- a/flashinfer/attention/prims_ts/kernels/fmha_context/fmha_tasks.py
+++ b/flashinfer/attention/prims_ts/kernels/fmha_context/fmha_tasks.py
@@ -644,6 +644,120 @@ def create_load_task(
     )
 
 
+def create_load_task_staged_head_dim(
+    gmem_qkv: GmemQKVResource,
+    smem_q: SmemQResource,
+    smem_kv: SmemKVResource,
+    work_queue: WorkQueue | None,
+    task_class: type[Task] = Task,
+    **task_kwargs: Any,
+) -> Task:
+    """Create the explicit D256 full-Q, split-K/V TMA task."""
+    loop_start, loop_end, loop_step = _captured_loop_bounds(task_class, task_kwargs)
+    skip_work_tile_if = _packed_context_skip_predicate(work_queue)
+    src = _src_resources(gmem_qkv, work_queue=work_queue)
+
+    @schedule
+    def load_schedule(
+        gqkv: GmemQKVResource,
+        sq: SmemQResource,
+        skv: SmemKVResource,
+        wq: WorkQueue | None = None,
+    ) -> None:
+        sq.init_load_state()
+        skv.init_load_state()
+        with _work_tile_schedule_loop(wq, skip_if=skip_work_tile_if):
+            (
+                _seq_coord,
+                head_coord,
+                kv_head_coord,
+                _head_coord_kv,
+                batch_coord,
+                seq_coord_q,
+                cuseqlen_q,
+                cuseqlen_k,
+                seqlen_q,
+                _seqlen_k,
+                kv_tile_start,
+            ) = gqkv.compute_coords()
+            sq.acquire()
+            sq.tma_load(
+                seq_coord_q=seq_coord_q,
+                head_coord=head_coord,
+                batch_coord=batch_coord,
+                cuseqlen_q=cuseqlen_q,
+                seqlen_q=seqlen_q,
+                inst_idx=0,
+            )
+            sq.commit()
+
+            for head_dim_stage_idx in range(smem_kv.cfg.num_head_dim_stages):
+                skv.try_acquire()
+                skv.acquire()
+                skv.k_load(
+                    kv_head_coord=kv_head_coord,
+                    batch_coord=batch_coord,
+                    cuseqlen_k=cuseqlen_k,
+                    kv_tile_start=kv_tile_start,
+                    head_dim_stage_idx=head_dim_stage_idx,
+                )
+                skv.commit()
+
+            with domain_loop(loop_start, loop_end, loop_step):
+                for head_dim_stage_idx in range(smem_kv.cfg.num_head_dim_stages):
+                    skv.try_acquire()
+                    skv.acquire()
+                    skv.k_load_next(
+                        kv_head_coord=kv_head_coord,
+                        batch_coord=batch_coord,
+                        cuseqlen_k=cuseqlen_k,
+                        kv_tile_start=kv_tile_start,
+                        head_dim_stage_idx=head_dim_stage_idx,
+                    )
+                    skv.commit()
+                for head_dim_stage_idx in range(smem_kv.cfg.num_head_dim_stages):
+                    skv.try_acquire()
+                    skv.acquire()
+                    skv.v_load(
+                        kv_head_coord=kv_head_coord,
+                        batch_coord=batch_coord,
+                        cuseqlen_k=cuseqlen_k,
+                        kv_tile_start=kv_tile_start,
+                        head_dim_stage_idx=head_dim_stage_idx,
+                    )
+                    skv.commit()
+
+            for head_dim_stage_idx in range(smem_kv.cfg.num_head_dim_stages):
+                skv.try_acquire()
+                skv.acquire()
+                skv.v_load_tail(
+                    kv_head_coord=kv_head_coord,
+                    batch_coord=batch_coord,
+                    cuseqlen_k=cuseqlen_k,
+                    kv_tile_start=kv_tile_start,
+                    head_dim_stage_idx=head_dim_stage_idx,
+                )
+                skv.commit()
+
+    captured_schedule = _schedule_with_work_queue(
+        load_schedule,
+        gmem_qkv,
+        smem_q,
+        smem_kv,
+        work_queue=work_queue,
+    )
+    return task_class(
+        src_resources=src,
+        dst_resources=[smem_q, smem_kv],
+        warp_idx=smem_kv.cfg.load_warp_id,
+        num_warps=1,
+        schedule=captured_schedule,
+        num_registers=smem_kv.cfg.num_regs_other,
+        name="LoadTaskStagedD",
+        **task_kwargs,
+    )
+
+
 def create_mma_task(
     smem_q: SmemQResource,
     smem_kv: SmemKVResource,
@@ -1043,6 +1157,149 @@ def create_mma_task(
         num_warps=1,
         schedule=captured_schedule,
         name="MmaTask",
+        num_registers=smem_q.cfg.num_regs_other,
+        **task_kwargs,
+    )
+
+
+def create_mma_task_staged_head_dim(
+    smem_q: SmemQResource,
+    smem_kv: SmemKVResource,
+    tmem_sp: TmemSPResource,
+    tmem_o: TmemOResource,
+    tmem_vec_done: TmemStatsDoneResource,
+    tmem_p_ready: TmemPResource,
+    work_queue: WorkQueue | None,
+    task_class: type[Task] = Task,
+    **task_kwargs: Any,
+) -> Task:
+    """Create the explicit D256 QK/PV overlap task."""
+    loop_start, loop_end, loop_step = _captured_loop_bounds(task_class, task_kwargs)
+    skip_work_tile_if = _packed_context_skip_predicate(work_queue)
+    src = _src_resources(smem_q, smem_kv, tmem_p_ready, work_queue=work_queue)
+
+    @schedule
+    def mma_schedule(
+        sq: SmemQResource,
+        skv: SmemKVResource,
+        sp: TmemSPResource,
+        to: TmemOResource,
+        vd: TmemStatsDoneResource,
+        pr: TmemPResource,
+        wq: WorkQueue | None = None,
+    ) -> None:
+        sq.init_descriptor_state()
+        skv.init_descriptor_state()
+        sp.init_mma_state()
+        to.init_mma_state()
+        with _work_tile_schedule_loop(wq, skip_if=skip_work_tile_if):
+            sp.init_mma_work_tile_state()
+            to.init_mma_work_tile_state()
+
+            sq.wait()
+            desc_q0_base = sq.q0_desc(inst_idx=0)
+            skv.wait()
+            desc_k0_base = skv.k0_desc()
+            vd.acquire()
+            sp.acquire()
+            desc_q1_base = sq.q1_desc(inst_idx=1)
+            skv.wait()
+            desc_k1_base = skv.k1_desc()
+            sp.qk_mma_staged_pair(
+                desc_q0_base=desc_q0_base,
+                desc_k0_base=desc_k0_base,
+                desc_q1_base=desc_q1_base,
+                desc_k1_base=desc_k1_base,
+            )
+            sp.commit()
+            vd.commit()
+            skv.release()
+            skv.release()
+
+            with domain_loop(loop_start, loop_end, loop_step):
+                skv.wait()
+                desc_k0_base = skv.k0_desc()
+                skv.wait()
+                desc_k1_base = skv.k1_desc()
+                vd.acquire()
+                sp.acquire()
+                sp.qk_mma_staged_pair(
+                    desc_q0_base=desc_q0_base,
+                    desc_k0_base=desc_k0_base,
+                    desc_q1_base=desc_q1_base,
+                    desc_k1_base=desc_k1_base,
+                )
+                sp.commit()
+                vd.commit()
+                skv.release()
+                skv.release()
+
+                pr.wait()
+                tmem_p_base = pr.p_base()
+                skv.wait()
+                desc_v_base = skv.v_desc()
+                to.acquire()
+                to.pv_mma_staged_o0_pipe(
+                    desc_v_base=desc_v_base,
+                    tmem_p_base=tmem_p_base,
+                )
+                skv.release()
+                skv.wait()
+                desc_v_base = skv.v_desc()
+                to.pv_mma_staged_o1_pipe(
+                    desc_v_base=desc_v_base,
+                    tmem_p_base=tmem_p_base,
+                )
+                to.commit()
+                skv.release()
+                pr.release()
+
+            pr.wait()
+            tmem_p_base = pr.p_base()
+            skv.wait()
+            desc_v_base = skv.v_desc()
+            to.acquire()
+            to.pv_mma_staged_o0_tail(
+                desc_v_base=desc_v_base,
+                tmem_p_base=tmem_p_base,
+            )
+            skv.release()
+            skv.wait()
+            desc_v_base = skv.v_desc()
+            to.pv_mma_staged_o1_tail(
+                desc_v_base=desc_v_base,
+                tmem_p_base=tmem_p_base,
+            )
+            to.commit()
+            skv.release()
+            pr.release()
+
+            sq.release()
+            vd.acquire()
+            sp.acquire()
+            sp.commit()
+            vd.commit()
+            # Keep both two-stage S/P cursors aligned across persistent tiles.
+            pr.wait()
+            pr.release()
+
+    captured_schedule = _schedule_with_work_queue(
+        mma_schedule,
+        smem_q,
+        smem_kv,
+        tmem_sp,
+        tmem_o,
+        tmem_vec_done,
+        tmem_p_ready,
+        work_queue=work_queue,
+    )
+    return task_class(
+        src_resources=src,
+        dst_resources=[tmem_sp, tmem_o, tmem_vec_done],
+        warp_idx=smem_q.cfg.mma_warp_id,
+        num_warps=1,
+        schedule=captured_schedule,
+        name="MmaTaskStagedD",
         num_registers=smem_q.cfg.num_regs_other,
         **task_kwargs,
     )
@@ -1805,6 +2062,161 @@ def create_softmax_task(
     )
 
 
+def create_softmax_task_staged_head_dim(
+    tmem_sp: TmemSPResource,
+    tmem_vec: TmemStatsResource,
+    tmem_p_ready: TmemPResource,
+    work_queue: WorkQueue | None,
+    task_class: type[Task] = Task,
+    **task_kwargs: Any,
+) -> Task:
+    """Create the single softmax warpgroup for the explicit D256 schedule."""
+    loop_start, loop_end, loop_step = _captured_loop_bounds(task_class, task_kwargs)
+    skip_work_tile_if = _packed_context_skip_predicate(work_queue)
+    src = _src_resources(tmem_sp, work_queue=work_queue)
+
+    @schedule
+    def softmax_schedule(
+        sp: TmemSPResource,
+        vec: TmemStatsResource,
+        pr: TmemPResource,
+        wq: WorkQueue | None = None,
+    ) -> None:
+        p_chunk = sp.init_softmax_state()
+        scale_softmax_log2 = sp.load_scale_softmax_log2()
+        vec.init_store_state()
+        with _work_tile_schedule_loop(wq, skip_if=skip_work_tile_if):
+            old_row_max, row_max, row_sum, q_offset = sp.init_softmax_work_tile_state()
+            vec.init_store_work_tile_state()
+            if tmem_sp.uses_varlen_q_offset_cache:
+                q_offset = sp.cache_q_offset()
+            if tmem_sp.uses_packed_dense_k_mask:
+                seqlen_k = sp.cache_seqlen_k()
+            vec.acquire()
+            with domain_loop(loop_start, loop_end, loop_step):
+                sp.wait()
+                if tmem_sp.uses_left_window_loop_mask:
+                    old_row_max, row_max = sp.left_masked_row_max(
+                        row_max=row_max,
+                        q_offset=q_offset,
+                    )
+                elif tmem_sp.uses_varlen_loop_right_mask:
+                    old_row_max, row_max = sp.right_masked_row_max(
+                        row_max=row_max,
+                        q_offset=q_offset,
+                        section=FmhaStage.Loop,
+                    )
+                elif tmem_sp.uses_query_paired_q_offset_loop_mask:
+                    old_row_max, row_max = sp.loop_masked_row_max(
+                        row_max=row_max,
+                        q_offset=q_offset,
+                    )
+                elif tmem_sp.uses_fixed_dense_k_tail_mask:
+                    old_row_max, row_max = sp.fixed_dense_k_tail_masked_row_max(
+                        row_max=row_max,
+                    )
+                elif tmem_sp.uses_packed_dense_k_mask:
+                    old_row_max, row_max = sp.packed_dense_k_masked_row_max(
+                        row_max=row_max,
+                        seqlen_k=seqlen_k,
+                        section=FmhaStage.Loop,
+                    )
+                else:
+                    old_row_max, row_max = sp.compute_row_max(row_max=row_max)
+                vec.store_vec(
+                    old_row_max=old_row_max,
+                    row_max=row_max,
+                    row_sum=row_sum,
+                )
+                vec.commit()
+                pr.acquire()
+                p_chunk = sp.exp2_p(
+                    row_max=row_max,
+                    scale_softmax_log2=scale_softmax_log2,
+                )
+                pr.commit()
+                sp.release()
+                row_sum = sp.softmax_aux_reduce(
+                    old_row_max=old_row_max,
+                    row_max=row_max,
+                    row_sum=row_sum,
+                    p_chunk=p_chunk,
+                    scale_softmax_log2=scale_softmax_log2,
+                )
+                vec.acquire()
+
+            if tmem_sp.cfg.is_causal:
+                sp.wait()
+                old_row_max, row_max = sp.masked_row_max(
+                    row_max=row_max,
+                    q_offset=q_offset,
+                )
+                vec.store_vec(
+                    old_row_max=old_row_max,
+                    row_max=row_max,
+                    row_sum=row_sum,
+                )
+                vec.commit()
+                pr.acquire()
+                p_chunk = sp.masked_exp2_p(
+                    row_max=row_max,
+                    scale_softmax_log2=scale_softmax_log2,
+                )
+                pr.commit()
+                sp.release()
+                row_sum = sp.softmax_aux_reduce(
+                    old_row_max=old_row_max,
+                    row_max=row_max,
+                    row_sum=row_sum,
+                    p_chunk=p_chunk,
+                    scale_softmax_log2=scale_softmax_log2,
+                )
+                sp.wait()
+                sp.release()
+                pr.acquire()
+                pr.commit()
+                old_row_max = sp.softmax_aux_identity(row_max=row_max)
+                vec.acquire()
+                vec.store_vec(
+                    old_row_max=old_row_max,
+                    row_max=row_max,
+                    row_sum=row_sum,
+                    final_stats=True,
+                )
+                vec.commit()
+            else:
+                sp.wait()
+                sp.release()
+                pr.acquire()
+                pr.commit()
+                old_row_max = sp.softmax_aux_identity(row_max=row_max)
+                vec.store_vec(
+                    old_row_max=old_row_max,
+                    row_max=row_max,
+                    row_sum=row_sum,
+                    final_stats=True,
+                )
+                vec.commit()
+
+    captured_schedule = _schedule_with_work_queue(
+        softmax_schedule,
+        tmem_sp,
+        tmem_vec,
+        tmem_p_ready,
+        work_queue=work_queue,
+    )
+    return task_class(
+        src_resources=src,
+        dst_resources=[tmem_vec, tmem_p_ready],
+        warp_idx=tmem_sp.cfg.softmax0_warp_ids[0],
+        num_warps=4,
+        schedule=captured_schedule,
+        num_registers=tmem_sp.cfg.num_regs_softmax,
+        name="SoftmaxTaskStagedD",
+        **task_kwargs,
+    )
+
+
 def create_correction_task(
     tmem_vec0: TmemStatsResource,
     tmem_vec1: TmemStatsResource | None,
@@ -2088,6 +2500,147 @@ def create_correction_task(
     if smem_o_0.cfg.single_qkv_instance:
         return _create_single_instance_task()
     return _create_paired_task()
+
+
+def create_correction_epilogue_task_staged_head_dim(
+    tmem_vec0: TmemStatsResource,
+    tmem_o: TmemOResource,
+    smem_o_0: SmemOResource,
+    smem_o_1: SmemOResource,
+    gmem_o_0: GmemOResource,
+    gmem_o_1: GmemOResource,
+    tmem_vec_done_0: TmemStatsDoneResource,
+    work_queue: WorkQueue | None,
+    task_class: type[Task] = Task,
+    **task_kwargs: Any,
+) -> Task:
+    """Fuse D256 correction, normalization, and both 128-wide O stores."""
+    loop_start, loop_end, loop_step = _captured_loop_bounds(task_class, task_kwargs)
+    skip_work_tile_if = _packed_context_skip_predicate(work_queue)
+    src = _src_resources(
+        tmem_vec0,
+        tmem_o,
+        smem_o_0,
+        smem_o_1,
+        tmem_vec_done_0,
+        work_queue=work_queue,
+    )
+
+    @schedule
+    def correction_epilogue_schedule(
+        v0: TmemStatsResource,
+        to: TmemOResource,
+        so0: SmemOResource,
+        so1: SmemOResource,
+        go0: GmemOResource,
+        go1: GmemOResource,
+        vd0: TmemStatsDoneResource,
+        wq: WorkQueue | None = None,
+    ) -> None:
+        v0.init_read_state()
+        scale_softmax_log2 = v0.load_scale_softmax_log2()
+        output_scale = v0.load_output_scale()
+        to.init_correction_state()
+        so0.init_store_state()
+        so1.init_store_state()
+        go0.init_store_state()
+        go1.init_store_state()
+        with _work_tile_schedule_loop(wq, skip_if=skip_work_tile_if):
+            v0.init_read_work_tile_state()
+            to.init_correction_work_tile_state()
+            so0.init_store_work_tile_state()
+            so1.init_store_work_tile_state()
+
+            # The first online-softmax record initializes O and needs no rescale.
+            v0.wait()
+            v0.release()
+            vd0.wait()
+            vd0.release()
+
+            with domain_loop(loop_start, loop_end, loop_step):
+                v0.wait()
+                vec_old_max, vec_new_max, _, vec_scale = v0.read_vec(
+                    scale_softmax_log2=scale_softmax_log2,
+                )
+                vd0.wait()
+                vd0.release()
+                to.wait()
+                to.correct_staged_pair(
+                    vec_old_max=vec_old_max,
+                    vec_new_max=vec_new_max,
+                    vec_scale=vec_scale,
+                )
+                v0.release()
+                to.release()
+
+            v0.wait()
+            _, _, vec_row_sum, vec_scale = v0.read_vec(
+                scale_softmax_log2=scale_softmax_log2,
+                final_stats=True,
+            )
+            vd0.wait()
+            vd0.release()
+            v0.release()
+            to.wait()
+
+            so0.acquire()
+            so0.store_o(
+                vec_row_sum=vec_row_sum,
+                vec_scale=vec_scale,
+                output_scale=output_scale,
+            )
+            so0.commit()
+            so0.wait()
+            head_coord, batch_coord, seq_coord_q = so0.compute_output_coords()
+            go0.tma_store(
+                head_coord=head_coord,
+                batch_coord=batch_coord,
+                seq_coord_q=seq_coord_q,
+                head_dim_stage_idx=0,
+                correction_fused=True,
+            )
+            so0.release()
+
+            so1.acquire()
+            so1.store_o(
+                vec_row_sum=vec_row_sum,
+                vec_scale=vec_scale,
+                output_scale=output_scale,
+            )
+            so1.commit()
+            so1.wait()
+            head_coord, batch_coord, seq_coord_q = so1.compute_output_coords()
+            go1.tma_store(
+                head_coord=head_coord,
+                batch_coord=batch_coord,
+                seq_coord_q=seq_coord_q,
+                head_dim_stage_idx=1,
+                correction_fused=True,
+            )
+            so1.release()
+            to.release()
+
+    captured_schedule = _schedule_with_work_queue(
+        correction_epilogue_schedule,
+        tmem_vec0,
+        tmem_o,
+        smem_o_0,
+        smem_o_1,
+        gmem_o_0,
+        gmem_o_1,
+        tmem_vec_done_0,
+        work_queue=work_queue,
+    )
+    return task_class(
+        src_resources=src,
+        dst_resources=[smem_o_0, smem_o_1, gmem_o_0, gmem_o_1],
+        warp_idx=tmem_o.cfg.correction_warp_ids[0],
+        num_warps=4,
+        schedule=captured_schedule,
+        num_registers=tmem_o.cfg.num_regs_correction,
+        name="CorrectionEpilogueTaskStagedD",
+        **task_kwargs,
+    )
 
 
 def create_epilogue_task(

--- a/flashinfer/attention/prims_ts/kernels/fmha_context/fmha_tasks.py
+++ b/flashinfer/attention/prims_ts/kernels/fmha_context/fmha_tasks.py
@@ -2562,6 +2562,7 @@ def create_correction_epilogue_task_staged_head_dim(
                 vec_old_max, vec_new_max, _, vec_scale = v0.read_vec(
                     scale_softmax_log2=scale_softmax_log2,
                 )
+                v0.release()
                 vd0.wait()
                 vd0.release()
                 to.wait()
@@ -2570,7 +2571,6 @@ def create_correction_epilogue_task_staged_head_dim(
                     vec_new_max=vec_new_max,
                     vec_scale=vec_scale,
                 )
-                v0.release()
                 to.release()
 
             v0.wait()
@@ -2598,8 +2598,8 @@ def create_correction_epilogue_task_staged_head_dim(
                 seq_coord_q=seq_coord_q,
                 head_dim_stage_idx=0,
                 correction_fused=True,
+                wait_after_write=False,
             )
-            so0.release()
 
             so1.acquire()
             so1.store_o(
@@ -2617,6 +2617,9 @@ def create_correction_epilogue_task_staged_head_dim(
                 head_dim_stage_idx=1,
                 correction_fused=True,
             )
+            # go1's wait drains both committed TMA groups. Keep both staging
+            # buffers owned until neither store can read from them.
+            so0.release()
             so1.release()
             to.release()
 

--- a/flashinfer/attention/prims_ts/kernels/fmha_context/fmha_tasks.py
+++ b/flashinfer/attention/prims_ts/kernels/fmha_context/fmha_tasks.py
@@ -187,12 +187,24 @@ def create_load_task(
     smem_page_offsets_v: SmemPageOffsetsKvResource | None = None,
     **task_kwargs: Any,
 ) -> Task:
-    """Create the one-warp TMA load task.
+    """Create the one-warp TMA load task for the configured topology.
 
     When ``smem_page_offsets_kv`` is provided, each K/V TMA load consumes page
     IDs prefetched by the auxiliary warp through the ordinary asynchronous
     page-offset pipeline.
     """
+    if smem_q.cfg.staged_head_dim:
+        if smem_page_offsets_kv is not None or smem_page_offsets_v is not None:
+            raise ValueError("staged-head-dim context does not use page offsets")
+        return _create_load_task_staged_head_dim(
+            gmem_qkv,
+            smem_q,
+            smem_kv,
+            work_queue,
+            task_class=task_class,
+            **task_kwargs,
+        )
+
     loop_start, loop_end, loop_step = _captured_loop_bounds(task_class, task_kwargs)
     skip_work_tile_if = _packed_context_skip_predicate(work_queue)
     src = _src_resources(gmem_qkv, work_queue=work_queue)
@@ -644,7 +656,7 @@ def create_load_task(
     )
 
 
-def create_load_task_staged_head_dim(
+def _create_load_task_staged_head_dim(
     gmem_qkv: GmemQKVResource,
     smem_q: SmemQResource,
     smem_kv: SmemKVResource,
@@ -771,7 +783,22 @@ def create_mma_task(
     task_class: type[Task] = Task,
     **task_kwargs: Any,
 ) -> Task:
-    """Create the one-warp MMA compute task."""
+    """Create the one-warp MMA compute task for the configured topology."""
+    if smem_q.cfg.staged_head_dim:
+        if tmem_p0 is None:
+            raise ValueError("staged-head-dim MMA requires a P handoff")
+        return _create_mma_task_staged_head_dim(
+            smem_q,
+            smem_kv,
+            tmem_sp0,
+            tmem_o,
+            tmem_vec_done_0,
+            tmem_p0,
+            work_queue,
+            task_class=task_class,
+            **task_kwargs,
+        )
+
     loop_start, loop_end, loop_step = _captured_loop_bounds(task_class, task_kwargs)
     skip_work_tile_if = _packed_context_skip_predicate(work_queue)
     src = _src_resources(smem_q, smem_kv, work_queue=work_queue)
@@ -1162,7 +1189,7 @@ def create_mma_task(
     )
 
 
-def create_mma_task_staged_head_dim(
+def _create_mma_task_staged_head_dim(
     smem_q: SmemQResource,
     smem_kv: SmemKVResource,
     tmem_sp: TmemSPResource,
@@ -1323,6 +1350,10 @@ def create_softmax_task(
     Args:
         task_class: Task subclass used to instantiate the softmax schedule.
     """
+    if tmem_sp.cfg.staged_head_dim:
+        if index != 0 or tmem_p is None or s0s1_seq is not None:
+            raise ValueError("staged-head-dim softmax requires index 0 and a P handoff")
+
     loop_start, loop_end, loop_step = _captured_loop_bounds(task_class, task_kwargs)
     skip_work_tile_if = _packed_context_skip_predicate(work_queue)
 
@@ -1592,7 +1623,11 @@ def create_softmax_task(
                 num_warps=4,
                 schedule=captured_schedule,
                 num_registers=tmem_sp.cfg.num_regs_softmax,
-                name=f"Softmax{index}Task",
+                name=(
+                    "SoftmaxTaskStagedD"
+                    if tmem_sp.cfg.staged_head_dim
+                    else f"Softmax{index}Task"
+                ),
                 **task_kwargs,
             )
 
@@ -2062,161 +2097,6 @@ def create_softmax_task(
     )
 
 
-def create_softmax_task_staged_head_dim(
-    tmem_sp: TmemSPResource,
-    tmem_vec: TmemStatsResource,
-    tmem_p_ready: TmemPResource,
-    work_queue: WorkQueue | None,
-    task_class: type[Task] = Task,
-    **task_kwargs: Any,
-) -> Task:
-    """Create the single softmax warpgroup for the explicit D256 schedule."""
-    loop_start, loop_end, loop_step = _captured_loop_bounds(task_class, task_kwargs)
-    skip_work_tile_if = _packed_context_skip_predicate(work_queue)
-    src = _src_resources(tmem_sp, work_queue=work_queue)
-
-    @schedule
-    def softmax_schedule(
-        sp: TmemSPResource,
-        vec: TmemStatsResource,
-        pr: TmemPResource,
-        wq: WorkQueue | None = None,
-    ) -> None:
-        p_chunk = sp.init_softmax_state()
-        scale_softmax_log2 = sp.load_scale_softmax_log2()
-        vec.init_store_state()
-        with _work_tile_schedule_loop(wq, skip_if=skip_work_tile_if):
-            old_row_max, row_max, row_sum, q_offset = sp.init_softmax_work_tile_state()
-            vec.init_store_work_tile_state()
-            if tmem_sp.uses_varlen_q_offset_cache:
-                q_offset = sp.cache_q_offset()
-            if tmem_sp.uses_packed_dense_k_mask:
-                seqlen_k = sp.cache_seqlen_k()
-            vec.acquire()
-            with domain_loop(loop_start, loop_end, loop_step):
-                sp.wait()
-                if tmem_sp.uses_left_window_loop_mask:
-                    old_row_max, row_max = sp.left_masked_row_max(
-                        row_max=row_max,
-                        q_offset=q_offset,
-                    )
-                elif tmem_sp.uses_varlen_loop_right_mask:
-                    old_row_max, row_max = sp.right_masked_row_max(
-                        row_max=row_max,
-                        q_offset=q_offset,
-                        section=FmhaStage.Loop,
-                    )
-                elif tmem_sp.uses_query_paired_q_offset_loop_mask:
-                    old_row_max, row_max = sp.loop_masked_row_max(
-                        row_max=row_max,
-                        q_offset=q_offset,
-                    )
-                elif tmem_sp.uses_fixed_dense_k_tail_mask:
-                    old_row_max, row_max = sp.fixed_dense_k_tail_masked_row_max(
-                        row_max=row_max,
-                    )
-                elif tmem_sp.uses_packed_dense_k_mask:
-                    old_row_max, row_max = sp.packed_dense_k_masked_row_max(
-                        row_max=row_max,
-                        seqlen_k=seqlen_k,
-                        section=FmhaStage.Loop,
-                    )
-                else:
-                    old_row_max, row_max = sp.compute_row_max(row_max=row_max)
-                vec.store_vec(
-                    old_row_max=old_row_max,
-                    row_max=row_max,
-                    row_sum=row_sum,
-                )
-                vec.commit()
-                pr.acquire()
-                p_chunk = sp.exp2_p(
-                    row_max=row_max,
-                    scale_softmax_log2=scale_softmax_log2,
-                )
-                pr.commit()
-                sp.release()
-                row_sum = sp.softmax_aux_reduce(
-                    old_row_max=old_row_max,
-                    row_max=row_max,
-                    row_sum=row_sum,
-                    p_chunk=p_chunk,
-                    scale_softmax_log2=scale_softmax_log2,
-                )
-                vec.acquire()
-
-            if tmem_sp.cfg.is_causal:
-                sp.wait()
-                old_row_max, row_max = sp.masked_row_max(
-                    row_max=row_max,
-                    q_offset=q_offset,
-                )
-                vec.store_vec(
-                    old_row_max=old_row_max,
-                    row_max=row_max,
-                    row_sum=row_sum,
-                )
-                vec.commit()
-                pr.acquire()
-                p_chunk = sp.masked_exp2_p(
-                    row_max=row_max,
-                    scale_softmax_log2=scale_softmax_log2,
-                )
-                pr.commit()
-                sp.release()
-                row_sum = sp.softmax_aux_reduce(
-                    old_row_max=old_row_max,
-                    row_max=row_max,
-                    row_sum=row_sum,
-                    p_chunk=p_chunk,
-                    scale_softmax_log2=scale_softmax_log2,
-                )
-                sp.wait()
-                sp.release()
-                pr.acquire()
-                pr.commit()
-                old_row_max = sp.softmax_aux_identity(row_max=row_max)
-                vec.acquire()
-                vec.store_vec(
-                    old_row_max=old_row_max,
-                    row_max=row_max,
-                    row_sum=row_sum,
-                    final_stats=True,
-                )
-                vec.commit()
-            else:
-                sp.wait()
-                sp.release()
-                pr.acquire()
-                pr.commit()
-                old_row_max = sp.softmax_aux_identity(row_max=row_max)
-                vec.store_vec(
-                    old_row_max=old_row_max,
-                    row_max=row_max,
-                    row_sum=row_sum,
-                    final_stats=True,
-                )
-                vec.commit()
-
-    captured_schedule = _schedule_with_work_queue(
-        softmax_schedule,
-        tmem_sp,
-        tmem_vec,
-        tmem_p_ready,
-        work_queue=work_queue,
-    )
-    return task_class(
-        src_resources=src,
-        dst_resources=[tmem_vec, tmem_p_ready],
-        warp_idx=tmem_sp.cfg.softmax0_warp_ids[0],
-        num_warps=4,
-        schedule=captured_schedule,
-        num_registers=tmem_sp.cfg.num_regs_softmax,
-        name="SoftmaxTaskStagedD",
-        **task_kwargs,
-    )
-
-
 def create_correction_task(
     tmem_vec0: TmemStatsResource,
     tmem_vec1: TmemStatsResource | None,
@@ -2231,7 +2111,23 @@ def create_correction_task(
     task_class: type[Task] = Task,
     **task_kwargs: Any,
 ) -> Task:
-    """Create the four-warp Correction task (warps 8-11)."""
+    """Create the four-warp correction task for the configured topology."""
+    if smem_o_0.cfg.staged_head_dim:
+        if smem_o_1 is None or gmem_o_1 is None:
+            raise ValueError("staged-head-dim output requires two O resources")
+        return _create_correction_epilogue_task_staged_head_dim(
+            tmem_vec0,
+            tmem_o,
+            smem_o_0,
+            smem_o_1,
+            gmem_o_0,
+            gmem_o_1,
+            tmem_vec_done_0,
+            work_queue,
+            task_class=task_class,
+            **task_kwargs,
+        )
+
     loop_start, loop_end, loop_step = _captured_loop_bounds(task_class, task_kwargs)
     skip_work_tile_if = _packed_context_skip_predicate(work_queue)
 
@@ -2502,7 +2398,7 @@ def create_correction_task(
     return _create_paired_task()
 
 
-def create_correction_epilogue_task_staged_head_dim(
+def _create_correction_epilogue_task_staged_head_dim(
     tmem_vec0: TmemStatsResource,
     tmem_o: TmemOResource,
     smem_o_0: SmemOResource,

--- a/tests/attention/test_attention_ts_context.py
+++ b/tests/attention/test_attention_ts_context.py
@@ -789,10 +789,11 @@ def test_attention_ts_context_d256_pipeline_policy_is_semantic_and_capacity_safe
     assert cfg.stage_kv_by_head_dim is True
     assert cfg.has_tmem_p_pipeline is True
     assert cfg.kv_stage >= cadence_stages
-    # Persistent D256 must keep correction statistics in the compact SMEM
-    # ring. Sharing its S/P TMEM columns is racy when producer latency varies
-    # across work tiles (most visibly for causal paged KV).
-    assert cfg.stats_via_smem is True
+    expected_staged = input_dtype == Float8E4M3FN and not use_paged_kv
+    assert cfg.staged_head_dim is expected_staged
+    # The generic persistent topology keeps correction statistics in SMEM.
+    # The staged topology uses a dedicated TMEM handoff instead.
+    assert cfg.stats_via_smem is not expected_staged
     assert cfg.mma_corr_stage == 1
     assert cfg.stages_page_offsets_in_smem is use_paged_kv
 
@@ -805,6 +806,89 @@ def test_attention_ts_context_d256_pipeline_policy_is_semantic_and_capacity_safe
         assert cfg.page_table_window_entries % pages_per_tile == 0
     else:
         assert cfg.page_offset_pipeline_stage_counts == ()
+
+
+@pytest.mark.parametrize(
+    "output_dtype",
+    (Float8E4M3FN, BFloat16, Float16),
+    ids=("fp8", "bf16", "fp16"),
+)
+def test_attention_ts_context_d256_contiguous_uses_explicit_staged_schedule(
+    output_dtype,
+):
+    """Contiguous D256 lowers to the full-Q, two-slice task topology."""
+
+    cfg = FmhaTs(
+        in_dtype=Float8E4M3FN,
+        out_dtype=output_dtype,
+        d=256,
+        is_persistent=True,
+        use_paged_kv=False,
+    ).cfg
+
+    assert cfg.staged_head_dim is True
+    assert cfg.qk_mma_tiler == (128, 128, 128)
+    assert cfg.pv_mma_tiler == (128, 128, 128)
+    assert cfg.sQ_shape == (1, 128 * 256)
+    assert cfg.sK_shape == (4, 128 * 128)
+    assert cfg.num_head_dim_stages == 2
+    assert cfg.kv_stage == 4
+    assert cfg.mma_softmax_stage == 2
+    assert cfg.softmax_corr_stage == 1
+    assert cfg.mma_corr_stage == 1
+    assert (cfg.tmem_s0_offset, cfg.tmem_p0_offset) == (0, 32)
+    assert (cfg.tmem_o0_offset, cfg.tmem_o1_offset) == (256, 384)
+    assert cfg.softmax0_warp_ids == (0, 1, 2, 3)
+    assert cfg.correction_warp_ids == (4, 5, 6, 7)
+    assert (cfg.mma_warp_id, cfg.epilogue_warp_id, cfg.empty_warp_id) == (8, 9, 10)
+    assert cfg.load_warp_id == 11
+    assert (cfg.num_regs_softmax, cfg.num_regs_correction, cfg.num_regs_other) == (
+        200,
+        128,
+        32,
+    )
+
+
+@pytest.mark.parametrize("is_clc_dynamic", (False, True), ids=("static", "clc"))
+def test_attention_ts_context_d256_staged_task_graph_is_safe(
+    is_clc_dynamic: bool,
+):
+    """The explicit D256 schedule validates with static and CLC queues."""
+
+    cfg = FmhaTs(
+        in_dtype=Float8E4M3FN,
+        out_dtype=Float8E4M3FN,
+        d=256,
+        is_persistent=True,
+        is_clc_dynamic=is_clc_dynamic,
+    ).cfg
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", UserWarning)
+        task_manager, _, _, _, work_queue, _ = build_fmha_task_manager(
+            cfg,
+            tile_sched_params=None,
+            tma_q_desc=None,
+            tma_k_desc=None,
+            tma_v_desc=None,
+            tma_o_desc=None,
+            cum_seqlen_q=None,
+            cum_seqlen_k=None,
+            num_kv_tiles=4,
+            is_persistent=True,
+            is_clc_dynamic=is_clc_dynamic,
+            exhaustive_deadlock_race_check=True,
+        )
+
+    tasks = {task.name: task for task in task_manager.tasks}
+    assert tasks["SoftmaxTaskStagedD"].warp_idx == 0
+    assert tasks["CorrectionEpilogueTaskStagedD"].warp_idx == 4
+    assert tasks["MmaTaskStagedD"].warp_idx == 8
+    assert tasks["LoadTaskStagedD"].warp_idx == 11
+    assert tasks["PaddingTask"].warp_idx == 10
+    scheduler_name = "SchedulerTask" if is_clc_dynamic else "EpiloguePaddingTask"
+    assert tasks[scheduler_name].warp_idx == 9
+    assert work_queue is not None
 
 
 @pytest.mark.parametrize(
@@ -870,6 +954,22 @@ def test_attention_ts_context_heavy_first_static_raster_policy(
         )
         is expected
     )
+
+
+@pytest.mark.parametrize(
+    ("capability", "expected"),
+    (
+        pytest.param((10, 0), False, id="sm100"),
+        pytest.param((10, 3), True, id="sm103"),
+    ),
+)
+def test_attention_ts_context_staged_d256_policy_is_arch_specific(
+    capability: tuple[int, int],
+    expected: bool,
+):
+    """The explicit schedule avoids its measured SM100 scoreboard regression."""
+
+    assert context_module._use_staged_d256_schedule(capability) is expected
 
 
 @pytest.mark.parametrize(
@@ -2107,6 +2207,53 @@ def test_attention_ts_context_d256_bf16_fixed_dense_static_runtime():
     for _ in range(2):
         output = wrapper.run(case.q, case.k, case.v)
         _assert_context_correct(output, case)
+
+
+@pytest.mark.arch_blackwell
+@_REQUIRES_CONTEXT_GPU
+@pytest.mark.parametrize(
+    ("q_length", "kv_length", "num_qo_heads", "seed"),
+    (
+        pytest.param(129, 257, 8, 2026072701, id="partial-tail"),
+        pytest.param(512, 512, 32, 2026072702, id="target-shape"),
+    ),
+)
+def test_attention_ts_context_d256_fp8_fixed_dense_runtime(
+    q_length: int,
+    kv_length: int,
+    num_qo_heads: int,
+    seed: int,
+):
+    """The explicit D256 schedule matches an E4M3-quantized output oracle."""
+
+    case = _make_context_case(
+        q_lengths=(q_length,),
+        k_lengths=(kv_length,),
+        num_qo_heads=num_qo_heads,
+        num_kv_heads=2,
+        head_dim=256,
+        qkv_dtype=_FP8,
+        packed=False,
+        mask_type="dense",
+        output_dtype=_FP8,
+        device="cuda",
+        seed=seed,
+    )
+    wrapper = BatchPrefillTSWrapper()
+    _plan_wrapper(wrapper, case)
+    policy = dict(wrapper._policy)
+    assert policy["scheduler"] == "static_persistent"
+    capability = torch.cuda.get_device_capability(case.q.device)
+    expected_schedule = "staged" if capability == (10, 3) else "generic"
+    assert policy["head_dim_schedule"] == expected_schedule
+
+    output = wrapper.run(case.q, case.k, case.v)
+    expected = _context_reference(case).to(_FP8).float()
+    assert torch.isfinite(output.float()).all()
+    torch.testing.assert_close(output.float(), expected, rtol=5e-2, atol=2.5e-1)
+    denominator = torch.linalg.vector_norm(expected).clamp_min(1e-6)
+    relative_l2 = torch.linalg.vector_norm(output.float() - expected) / denominator
+    assert float(relative_l2) <= 1e-1
 
 
 @pytest.mark.arch_blackwell

--- a/tests/attention/test_attention_ts_context.py
+++ b/tests/attention/test_attention_ts_context.py
@@ -2214,17 +2214,16 @@ def test_attention_ts_context_d256_bf16_fixed_dense_static_runtime():
 @pytest.mark.arch_blackwell
 @_REQUIRES_CONTEXT_GPU
 @pytest.mark.parametrize(
-    ("q_length", "kv_length", "num_qo_heads", "seed"),
+    ("q_length", "kv_length", "num_qo_heads"),
     (
-        pytest.param(129, 257, 8, 2026072701, id="partial-tail"),
-        pytest.param(512, 512, 32, 2026072702, id="target-shape"),
+        pytest.param(129, 257, 8, id="partial-tail"),
+        pytest.param(512, 512, 32, id="target-shape"),
     ),
 )
 def test_attention_ts_context_d256_fp8_fixed_dense_runtime(
     q_length: int,
     kv_length: int,
     num_qo_heads: int,
-    seed: int,
 ):
     """The explicit D256 schedule matches an E4M3-quantized output oracle."""
 
@@ -2239,7 +2238,7 @@ def test_attention_ts_context_d256_fp8_fixed_dense_runtime(
         mask_type="dense",
         output_dtype=_FP8,
         device="cuda",
-        seed=seed,
+        seed=2026072701,
     )
     wrapper = BatchPrefillTSWrapper()
     _plan_wrapper(wrapper, case)
@@ -2252,11 +2251,7 @@ def test_attention_ts_context_d256_fp8_fixed_dense_runtime(
 
     output = wrapper.run(case.q, case.k, case.v)
     expected = _context_reference(case).to(_FP8).float()
-    assert torch.isfinite(output.float()).all()
-    torch.testing.assert_close(output.float(), expected, rtol=5e-2, atol=2.5e-1)
-    denominator = torch.linalg.vector_norm(expected).clamp_min(1e-6)
-    relative_l2 = torch.linalg.vector_norm(output.float() - expected) / denominator
-    assert float(relative_l2) <= 1e-1
+    _assert_context_correct(output, case, expected=expected)
 
 
 @pytest.mark.arch_blackwell

--- a/tests/attention/test_attention_ts_context.py
+++ b/tests/attention/test_attention_ts_context.py
@@ -824,9 +824,11 @@ def test_attention_ts_context_d256_contiguous_uses_explicit_staged_schedule(
         d=256,
         is_persistent=True,
         use_paged_kv=False,
+        enable_ldtm_stat=True,
     ).cfg
 
     assert cfg.staged_head_dim is True
+    assert cfg.use_ldtm_stat is True
     assert cfg.qk_mma_tiler == (128, 128, 128)
     assert cfg.pv_mma_tiler == (128, 128, 128)
     assert cfg.sQ_shape == (1, 128 * 256)
@@ -2246,6 +2248,7 @@ def test_attention_ts_context_d256_fp8_fixed_dense_runtime(
     capability = torch.cuda.get_device_capability(case.q.device)
     expected_schedule = "staged" if capability == (10, 3) else "generic"
     assert policy["head_dim_schedule"] == expected_schedule
+    assert policy["ldtm_stat"] is (capability == (10, 3))
 
     output = wrapper.run(case.q, case.k, case.v)
     expected = _context_reference(case).to(_FP8).float()


### PR DESCRIPTION
## Summary

- Add a staged head-dimension schedule for SM103 FP8 context attention with head dimension 256.
- Use x128 LDTM.STAT and x32 correction paths, then refine pipeline and instruction overlap.
- Replace the internal load-reduce dependency with a public PTX implementation compatible with public CUDA Toolkit 13.3 and CUTLASS DSL 4.7.
- Consolidate staged D256 task factories and add focused accuracy and capacity-policy coverage.

## Dependency

This draft is stacked on the PrimTS baseline from GitLab MR2 (`perkzz/mr2` at `7602f88d1f219119d69acdb928b92caf4ad8580e`). Until that baseline lands and this branch is rebased, the GitHub comparison against `main` also contains the dependency commits.

The local, uncommitted paged-KV follow-up is intentionally not included in this branch push.

## Validation

- Ruff lint and formatting checks.
- Focused D256 pipeline, task-graph, and capacity-policy tests.
- FP8 D256 context accuracy and performance testing on B300 during development.