### PR TITLE
feat(moe): support GeGLU and SiTU in W4A16

### DIFF
--- a/flashinfer/fused_moe/cute_dsl/blackwell/moe_w4a16.py
+++ b/flashinfer/fused_moe/cute_dsl/blackwell/moe_w4a16.py
@@ -23,6 +23,7 @@ from flashinfer.fused_moe.cute_dsl.moe_utils import (
     moe_sort,
     moe_unpermute,
     normalize_cute_dsl_moe_activation_type,
+    validate_cute_dsl_moe_situ_config,
 )
 from flashinfer.tllm_enums import (
     ActivationType,
@@ -128,6 +129,8 @@ def _get_compiled_kernel(
     swiglu_alpha: float,
     swiglu_beta: float,
     swiglu_limit: float,
+    situ_beta: Optional[float],
+    situ_linear_beta: Optional[float],
     use_fused_finalize: bool,
     enable_pdl: bool,
     use_clc_scheduler: bool,
@@ -146,6 +149,8 @@ def _get_compiled_kernel(
         swiglu_alpha,
         swiglu_beta,
         swiglu_limit,
+        situ_beta,
+        situ_linear_beta,
         use_fused_finalize,
         enable_pdl,
         use_clc_scheduler,
@@ -170,6 +175,8 @@ def _get_compiled_kernel(
             swiglu_alpha=swiglu_alpha,
             swiglu_beta=swiglu_beta,
             swiglu_limit=swiglu_limit,
+            situ_beta=situ_beta,
+            situ_linear_beta=situ_linear_beta,
             use_fused_finalize=use_fused_finalize,
             enable_pdl=enable_pdl,
             use_clc_scheduler=use_clc_scheduler,
@@ -214,6 +221,8 @@ def _run_grouped_gemm(
     swiglu_alpha: float,
     swiglu_beta: float,
     swiglu_limit: float,
+    situ_beta: Optional[float],
+    situ_linear_beta: Optional[float],
     use_fused_finalize: bool,
     permuted_idx_to_expanded_idx: Optional[torch.Tensor],
     token_final_scales: Optional[torch.Tensor],
@@ -332,6 +341,8 @@ def _run_grouped_gemm(
         swiglu_alpha,
         swiglu_beta,
         swiglu_limit,
+        situ_beta,
+        situ_linear_beta,
         use_fused_finalize,
         enable_pdl,
         use_clc_scheduler,
@@ -379,6 +390,8 @@ def launch_w4a16_moe(
     swiglu_alpha: float = DEFAULT_SWIGLU_ALPHA,
     swiglu_beta: float = DEFAULT_SWIGLU_BETA,
     swiglu_limit: float = DEFAULT_SWIGLU_LIMIT,
+    situ_beta: Optional[float] = None,
+    situ_linear_beta: Optional[float] = None,
     tactic: Optional[W4A16MoeTactic] = None,
     workspace_cache: Optional[Dict[Tuple, _W4A16Workspace]] = None,
 ) -> torch.Tensor:
@@ -386,6 +399,7 @@ def launch_w4a16_moe(
     top_k = int(token_selected_experts.size(1))
     intermediate_size = int(w2_weight.size(2)) * 2
     activation_type, gated = normalize_cute_dsl_moe_activation_type(activation_type)
+    validate_cute_dsl_moe_situ_config(activation_type, situ_beta, situ_linear_beta)
     gemm1_output_size = intermediate_size * (2 if gated else 1)
     if int(w1_weight.size(1)) != gemm1_output_size:
         raise ValueError(
@@ -462,6 +476,8 @@ def launch_w4a16_moe(
         swiglu_alpha=swiglu_alpha,
         swiglu_beta=swiglu_beta,
         swiglu_limit=swiglu_limit,
+        situ_beta=situ_beta,
+        situ_linear_beta=situ_linear_beta,
         use_fused_finalize=False,
         permuted_idx_to_expanded_idx=None,
         token_final_scales=None,
@@ -485,6 +501,8 @@ def launch_w4a16_moe(
         swiglu_alpha=DEFAULT_SWIGLU_ALPHA,
         swiglu_beta=DEFAULT_SWIGLU_BETA,
         swiglu_limit=DEFAULT_SWIGLU_LIMIT,
+        situ_beta=None,
+        situ_linear_beta=None,
         use_fused_finalize=use_fused_finalize,
         permuted_idx_to_expanded_idx=(
             permuted_idx_to_expanded_idx if use_fused_finalize else None

--- a/flashinfer/fused_moe/cute_dsl/blackwell/moe_w4a16_kernel.py
+++ b/flashinfer/fused_moe/cute_dsl/blackwell/moe_w4a16_kernel.py
@@ -1983,7 +1983,10 @@ class Sm100W4A16GroupedGemmKernel:
                                 (gate[i], gate[i + 1]),
                                 (gated_alpha_f32, gated_alpha_f32),
                             )
-                            if cutlass.const_expr(self.situ_beta is not None):
+                            if cutlass.const_expr(
+                                self.activation_type == ActivationType.Swiglu.value
+                                and self.situ_beta is not None
+                            ):
                                 situ_beta = cutlass.Float32(self.situ_beta)
                                 situ_gate_pair = (
                                     situ_f32(gate_pair[0], situ_beta, fastmath=True),
@@ -2016,7 +2019,9 @@ class Sm100W4A16GroupedGemmKernel:
                                         gelu_tanh_f32(gate_pair[1], fastmath=True),
                                     ),
                                 )
-                            else:
+                            elif cutlass.const_expr(
+                                self.activation_type == ActivationType.Swiglu.value
+                            ):
                                 if cutlass.const_expr(self.parameterized_swiglu):
                                     gate_pair = (
                                         fmin(gate_pair[0], swiglu_limit, nan=True),

--- a/flashinfer/fused_moe/cute_dsl/blackwell/moe_w4a16_kernel.py
+++ b/flashinfer/fused_moe/cute_dsl/blackwell/moe_w4a16_kernel.py
@@ -55,12 +55,16 @@ from flashinfer.tllm_enums import (
     DEFAULT_SWIGLU_LIMIT,
 )
 
+from ..moe_utils import validate_cute_dsl_moe_situ_config
 from .moe_w4a16_utils import decode_nvfp4_fragment_to_bf16
 from .utils import (
     blk_reduce_bf16,
     fmin,
+    gelu_tanh_f32,
     griddepcontrol_launch_dependents,
     griddepcontrol_wait,
+    situ_f32,
+    tanh_f32,
 )
 
 
@@ -84,6 +88,8 @@ class Sm100W4A16GroupedGemmKernel:
         swiglu_alpha: float,
         swiglu_beta: float,
         swiglu_limit: float,
+        situ_beta: Optional[float],
+        situ_linear_beta: Optional[float],
         use_fused_finalize: bool,
         enable_pdl: bool,
         use_clc_scheduler: bool,
@@ -99,6 +105,7 @@ class Sm100W4A16GroupedGemmKernel:
         if activation_type not in (
             None,
             ActivationType.Swiglu.value,
+            ActivationType.GegluTanh.value,
             ActivationType.Relu2.value,
         ):
             raise ValueError(
@@ -108,10 +115,23 @@ class Sm100W4A16GroupedGemmKernel:
         self.use_clc_scheduler = use_clc_scheduler
         self.raster_along_m = raster_along_m
         self.transform_fragment_size = transform_fragment_size
-        self.gated = activation_type == ActivationType.Swiglu.value
+        if activation_type is None:
+            if situ_beta is not None or situ_linear_beta is not None:
+                raise ValueError("SiTU parameters require an activation")
+        else:
+            validate_cute_dsl_moe_situ_config(
+                ActivationType(activation_type), situ_beta, situ_linear_beta
+            )
+        self.activation_type = activation_type
+        self.gated = activation_type in (
+            ActivationType.Swiglu.value,
+            ActivationType.GegluTanh.value,
+        )
         self.swiglu_alpha = swiglu_alpha
         self.swiglu_beta = swiglu_beta
         self.swiglu_limit = swiglu_limit
+        self.situ_beta = situ_beta
+        self.situ_linear_beta = situ_linear_beta
         self.parameterized_swiglu = (
             swiglu_alpha != DEFAULT_SWIGLU_ALPHA
             or swiglu_beta != DEFAULT_SWIGLU_BETA
@@ -1963,47 +1983,81 @@ class Sm100W4A16GroupedGemmKernel:
                                 (gate[i], gate[i + 1]),
                                 (gated_alpha_f32, gated_alpha_f32),
                             )
-                            if cutlass.const_expr(self.parameterized_swiglu):
-                                gate_pair = (
-                                    fmin(gate_pair[0], swiglu_limit, nan=True),
-                                    fmin(gate_pair[1], swiglu_limit, nan=True),
+                            if cutlass.const_expr(self.situ_beta is not None):
+                                situ_beta = cutlass.Float32(self.situ_beta)
+                                situ_gate_pair = (
+                                    situ_f32(gate_pair[0], situ_beta, fastmath=True),
+                                    situ_f32(gate_pair[1], situ_beta, fastmath=True),
                                 )
-                                up_pair = (
-                                    -fmin(
-                                        -fmin(up_pair[0], swiglu_limit, nan=True),
-                                        swiglu_limit,
-                                        nan=True,
+                                if cutlass.const_expr(
+                                    self.situ_linear_beta is not None
+                                ):
+                                    linear_beta = cutlass.Float32(self.situ_linear_beta)
+                                    up_pair = (
+                                        linear_beta
+                                        * tanh_f32(
+                                            up_pair[0] / linear_beta, fastmath=True
+                                        ),
+                                        linear_beta
+                                        * tanh_f32(
+                                            up_pair[1] / linear_beta, fastmath=True
+                                        ),
+                                    )
+                                result = cute.arch.mul_packed_f32x2(
+                                    up_pair, situ_gate_pair
+                                )
+                            elif cutlass.const_expr(
+                                self.activation_type == ActivationType.GegluTanh.value
+                            ):
+                                result = cute.arch.mul_packed_f32x2(
+                                    up_pair,
+                                    (
+                                        gelu_tanh_f32(gate_pair[0], fastmath=True),
+                                        gelu_tanh_f32(gate_pair[1], fastmath=True),
                                     ),
-                                    -fmin(
-                                        -fmin(up_pair[1], swiglu_limit, nan=True),
-                                        swiglu_limit,
-                                        nan=True,
+                                )
+                            else:
+                                if cutlass.const_expr(self.parameterized_swiglu):
+                                    gate_pair = (
+                                        fmin(gate_pair[0], swiglu_limit, nan=True),
+                                        fmin(gate_pair[1], swiglu_limit, nan=True),
+                                    )
+                                    up_pair = (
+                                        -fmin(
+                                            -fmin(up_pair[0], swiglu_limit, nan=True),
+                                            swiglu_limit,
+                                            nan=True,
+                                        ),
+                                        -fmin(
+                                            -fmin(up_pair[1], swiglu_limit, nan=True),
+                                            swiglu_limit,
+                                            nan=True,
+                                        ),
+                                    )
+                                gate_log2e = cute.arch.mul_packed_f32x2(
+                                    gate_pair,
+                                    (
+                                        neg_swiglu_alpha_log2_e,
+                                        neg_swiglu_alpha_log2_e,
                                     ),
                                 )
-                            gate_log2e = cute.arch.mul_packed_f32x2(
-                                gate_pair,
-                                (
-                                    neg_swiglu_alpha_log2_e,
-                                    neg_swiglu_alpha_log2_e,
-                                ),
-                            )
-                            sigmoid = cute.arch.add_packed_f32x2(
-                                (
-                                    cute.math.exp2(gate_log2e[0], fastmath=True),
-                                    cute.math.exp2(gate_log2e[1], fastmath=True),
-                                ),
-                                (1.0, 1.0),
-                            )
-                            sigmoid = (
-                                cute.arch.rcp_approx(sigmoid[0]),
-                                cute.arch.rcp_approx(sigmoid[1]),
-                            )
-                            silu = cute.arch.mul_packed_f32x2(gate_pair, sigmoid)
-                            if cutlass.const_expr(self.parameterized_swiglu):
-                                up_pair = cute.arch.add_packed_f32x2(
-                                    up_pair, (swiglu_beta, swiglu_beta)
+                                sigmoid = cute.arch.add_packed_f32x2(
+                                    (
+                                        cute.math.exp2(gate_log2e[0], fastmath=True),
+                                        cute.math.exp2(gate_log2e[1], fastmath=True),
+                                    ),
+                                    (1.0, 1.0),
                                 )
-                            result = cute.arch.mul_packed_f32x2(up_pair, silu)
+                                sigmoid = (
+                                    cute.arch.rcp_approx(sigmoid[0]),
+                                    cute.arch.rcp_approx(sigmoid[1]),
+                                )
+                                silu = cute.arch.mul_packed_f32x2(gate_pair, sigmoid)
+                                if cutlass.const_expr(self.parameterized_swiglu):
+                                    up_pair = cute.arch.add_packed_f32x2(
+                                        up_pair, (swiglu_beta, swiglu_beta)
+                                    )
+                                result = cute.arch.mul_packed_f32x2(up_pair, silu)
 
                             coord_0 = up_coords[i]
                             coord_1 = up_coords[i + 1]

--- a/flashinfer/fused_moe/cute_dsl/fused_moe.py
+++ b/flashinfer/fused_moe/cute_dsl/fused_moe.py
@@ -632,8 +632,6 @@ class CuteDslMoEWrapper:
                 self._main_event = torch.cuda.Event()
                 self._memset_event = torch.cuda.Event()
         elif quant_mode == "w4a16":
-            if situ_beta is not None or situ_linear_beta is not None:
-                raise ValueError("SiTU is not supported when quant_mode='w4a16'")
             self._w4a16_runner = CuteDslFusedMoEW4A16Runner(
                 num_experts=num_experts,
                 top_k=top_k,
@@ -646,6 +644,8 @@ class CuteDslMoEWrapper:
                 swiglu_alpha=swiglu_alpha,
                 swiglu_beta=swiglu_beta,
                 swiglu_limit=swiglu_limit,
+                situ_beta=situ_beta,
+                situ_linear_beta=situ_linear_beta,
             )
         else:
             raise ValueError(
@@ -847,7 +847,10 @@ class CuteDslMoEWrapper:
                 w2_alpha,
                 moe_output,
             ]
-            op_name = f"CuteDslMoEWrapper::run::W4A16::{self.activation_type.name}"
+            activation_name = (
+                "Situ" if self.situ_beta is not None else self.activation_type.name
+            )
+            op_name = f"CuteDslMoEWrapper::run::W4A16::{activation_name}"
 
         if runner is None:
             raise RuntimeError(f"{self.quant_mode} runner was not initialized")
@@ -1128,8 +1131,6 @@ def cute_dsl_fused_moe_nvfp4(
         activation_name = "Situ" if situ_beta is not None else activation.name
         op_name = f"CuteDslFusedMoE::run_moe_nvfp4::{activation_name}"
     elif quant_mode == "w4a16":
-        if situ_beta is not None or situ_linear_beta is not None:
-            raise ValueError("SiTU is not supported when quant_mode='w4a16'")
         if (
             x_sf is not None
             or fc2_input_scale is not None
@@ -1151,6 +1152,8 @@ def cute_dsl_fused_moe_nvfp4(
             swiglu_alpha=swiglu_alpha,
             swiglu_beta=swiglu_beta,
             swiglu_limit=swiglu_limit,
+            situ_beta=situ_beta,
+            situ_linear_beta=situ_linear_beta,
         )
         inputs = [
             x,
@@ -1164,7 +1167,8 @@ def cute_dsl_fused_moe_nvfp4(
             w2_alpha,
             moe_output,
         ]
-        op_name = f"CuteDslFusedMoE::run_moe_w4a16::{activation.name}"
+        activation_name = "Situ" if situ_beta is not None else activation.name
+        op_name = f"CuteDslFusedMoE::run_moe_w4a16::{activation_name}"
     else:
         raise ValueError(
             f"quant_mode must be 'nvfp4'/'w4a4' or 'w4a16' (got {quant_mode!r})."

--- a/flashinfer/fused_moe/cute_dsl/fused_moe.py
+++ b/flashinfer/fused_moe/cute_dsl/fused_moe.py
@@ -824,7 +824,7 @@ class CuteDslMoEWrapper:
                 "Situ" if self.situ_beta is not None else self.activation_type.name
             )
             op_name = f"CuteDslMoEWrapper::run::{activation_name}"
-        else:
+        elif self.quant_mode == "w4a16":
             if (
                 x_sf is not None
                 or fc2_input_scale is not None
@@ -851,6 +851,8 @@ class CuteDslMoEWrapper:
                 "Situ" if self.situ_beta is not None else self.activation_type.name
             )
             op_name = f"CuteDslMoEWrapper::run::W4A16::{activation_name}"
+        else:
+            raise RuntimeError(f"Unexpected quant_mode {self.quant_mode!r}")
 
         if runner is None:
             raise RuntimeError(f"{self.quant_mode} runner was not initialized")
@@ -863,18 +865,24 @@ class CuteDslMoEWrapper:
             runner.tuning_config,
             inputs,
         )
-        runner_kwargs = {}
-        if self.quant_mode != "w4a16":
+        if self.quant_mode in ("nvfp4", "w4a4"):
             # Timed tactic runs retain the default async path; only this
             # selected-tactic execution is single-stream while tuning.
-            runner_kwargs["use_async_memset"] = not tuner.is_tuning_mode
+            runner_kwargs = {"use_async_memset": not tuner.is_tuning_mode}
+        elif self.quant_mode == "w4a16":
+            runner_kwargs = {}
+        else:
+            raise RuntimeError(f"Unexpected quant_mode {self.quant_mode!r}")
         return runner(inputs, tactic=best_tactic, **runner_kwargs)
 
     def get_valid_tactics(self) -> list:
         """Return list of valid tactics for this MoE configuration."""
-        return (
-            list(W4A16_MOE_TACTICS) if self.quant_mode == "w4a16" else ALL_MOE_TACTICS
-        )
+        if self.quant_mode in ("nvfp4", "w4a4"):
+            return ALL_MOE_TACTICS
+        elif self.quant_mode == "w4a16":
+            return list(W4A16_MOE_TACTICS)
+        else:
+            raise RuntimeError(f"Unexpected quant_mode {self.quant_mode!r}")
 
 
 # =============================================================================
@@ -1181,9 +1189,15 @@ def cute_dsl_fused_moe_nvfp4(
         inputs,
         aux_stream=aux_stream,
     )
-    runner_kwargs = {"aux_stream": aux_stream}
-    if quant_mode != "w4a16":
-        runner_kwargs["use_async_memset"] = not tuner.is_tuning_mode
+    if quant_mode in ("nvfp4", "w4a4"):
+        runner_kwargs = {
+            "aux_stream": aux_stream,
+            "use_async_memset": not tuner.is_tuning_mode,
+        }
+    elif quant_mode == "w4a16":
+        runner_kwargs = {"aux_stream": aux_stream}
+    else:
+        raise RuntimeError(f"Unexpected quant_mode {quant_mode!r}")
     return runner(inputs, tactic=best_tactic, **runner_kwargs)
 
 

--- a/flashinfer/fused_moe/cute_dsl/tuner.py
+++ b/flashinfer/fused_moe/cute_dsl/tuner.py
@@ -757,8 +757,11 @@ class CuteDslFusedMoEW4A16Runner(TunableRunner):
         swiglu_alpha: float = DEFAULT_SWIGLU_ALPHA,
         swiglu_beta: float = DEFAULT_SWIGLU_BETA,
         swiglu_limit: float = DEFAULT_SWIGLU_LIMIT,
+        situ_beta: Optional[float] = None,
+        situ_linear_beta: Optional[float] = None,
     ):
         activation_type, _ = normalize_cute_dsl_moe_activation_type(activation_type)
+        validate_cute_dsl_moe_situ_config(activation_type, situ_beta, situ_linear_beta)
         if output_dtype != torch.bfloat16:
             raise ValueError("W4A16 only supports BF16 output")
         self.num_experts = num_experts
@@ -772,6 +775,8 @@ class CuteDslFusedMoEW4A16Runner(TunableRunner):
         self.swiglu_alpha = swiglu_alpha
         self.swiglu_beta = swiglu_beta
         self.swiglu_limit = swiglu_limit
+        self.situ_beta = situ_beta
+        self.situ_linear_beta = situ_linear_beta
         self._workspace_cache: Dict[Tuple, Any] = {}
 
         # Match production EP routing density while retaining seeded load
@@ -841,6 +846,8 @@ class CuteDslFusedMoEW4A16Runner(TunableRunner):
                 self.swiglu_alpha,
                 self.swiglu_beta,
                 self.swiglu_limit,
+                self.situ_beta,
+                self.situ_linear_beta,
             )
         )
 
@@ -857,6 +864,8 @@ class CuteDslFusedMoEW4A16Runner(TunableRunner):
             self.swiglu_alpha,
             self.swiglu_beta,
             self.swiglu_limit,
+            self.situ_beta,
+            self.situ_linear_beta,
         )
 
     def get_valid_tactics(  # type: ignore[override]
@@ -968,6 +977,8 @@ class CuteDslFusedMoEW4A16Runner(TunableRunner):
             swiglu_alpha=self.swiglu_alpha,
             swiglu_beta=self.swiglu_beta,
             swiglu_limit=self.swiglu_limit,
+            situ_beta=self.situ_beta,
+            situ_linear_beta=self.situ_linear_beta,
             tactic=None if tactic is None or tactic == -1 else tactic,
             workspace_cache=self._workspace_cache,
         )

--- a/tests/moe/test_cute_dsl_fused_moe.py
+++ b/tests/moe/test_cute_dsl_fused_moe.py
@@ -159,21 +159,30 @@ def test_invalid_situ_config(activation_type, situ_beta, situ_linear_beta, error
         validate_cute_dsl_moe_situ_config(activation_type, situ_beta, situ_linear_beta)
 
 
-def test_situ_changes_autotuner_cache_key():
-    from flashinfer.fused_moe.cute_dsl.tuner import CuteDslFusedMoENvfp4Runner
+@pytest.mark.parametrize("quant_mode", _MOE_QUANT_MODES)
+def test_situ_changes_autotuner_cache_key(quant_mode: str):
+    from flashinfer.fused_moe.cute_dsl.tuner import (
+        CuteDslFusedMoENvfp4Runner,
+        CuteDslFusedMoEW4A16Runner,
+    )
 
     kwargs = {
-        "forward_impl": lambda *args, **kwargs: None,
         "num_experts": 8,
         "top_k": 2,
         "num_local_experts": 8,
     }
-    swiglu_runner = CuteDslFusedMoENvfp4Runner(**kwargs)
-    situ_runner = CuteDslFusedMoENvfp4Runner(**kwargs, situ_beta=1.0)
-    situ_beta_runner = CuteDslFusedMoENvfp4Runner(**kwargs, situ_beta=2.0)
-    situ_linear_runner = CuteDslFusedMoENvfp4Runner(
-        **kwargs, situ_beta=1.0, situ_linear_beta=1.5
-    )
+    if quant_mode == "w4a4":
+        runner_cls = CuteDslFusedMoENvfp4Runner
+        kwargs["forward_impl"] = lambda *args, **kwargs: None
+    elif quant_mode == "w4a16":
+        runner_cls = CuteDslFusedMoEW4A16Runner
+    else:
+        raise ValueError(f"Unsupported test quant_mode {quant_mode!r}")
+
+    swiglu_runner = runner_cls(**kwargs)
+    situ_runner = runner_cls(**kwargs, situ_beta=1.0)
+    situ_beta_runner = runner_cls(**kwargs, situ_beta=2.0)
+    situ_linear_runner = runner_cls(**kwargs, situ_beta=1.0, situ_linear_beta=1.5)
     runners = [swiglu_runner, situ_runner, situ_beta_runner, situ_linear_runner]
     assert len({hash(runner) for runner in runners}) == len(runners)
     assert len({runner.get_cache_key_extras([]) for runner in runners}) == len(runners)
@@ -1230,6 +1239,8 @@ class TestCuteDslMoeW4A16:
             swiglu_alpha=DEFAULT_SWIGLU_ALPHA,
             swiglu_beta=DEFAULT_SWIGLU_BETA,
             swiglu_limit=DEFAULT_SWIGLU_LIMIT,
+            situ_beta=None,
+            situ_linear_beta=None,
             use_fused_finalize=False,
             permuted_idx_to_expanded_idx=None,
             token_final_scales=None,
@@ -1595,9 +1606,11 @@ class TestCuteDslFusedMoeFunctional:
             f"Only {percent_within * 100:.2f}% within tolerance (atol={atol:.4f})"
         )
 
-    @pytest.mark.parametrize("use_per_token_activation", [False, True])
-    def test_geglu_tanh_accuracy(self, use_per_token_activation: bool):
-        """Accuracy test for tanh-approximate GeGLU in both scaling modes."""
+    @pytest.mark.parametrize(
+        "quant_mode,use_per_token_activation", _MOE_QUANT_MODE_CASES
+    )
+    def test_geglu_tanh_accuracy(self, quant_mode: str, use_per_token_activation: bool):
+        """Accuracy test for tanh-approximate GeGLU across quantization modes."""
         from flashinfer import cute_dsl_fused_moe_nvfp4
 
         activation_type = ActivationType.GegluTanh
@@ -1614,31 +1627,27 @@ class TestCuteDslFusedMoeFunctional:
             gated=True,
             use_per_token_activation=use_per_token_activation,
         )
+        api_inputs, reference_inputs = _prepare_moe_quant_mode_inputs(
+            tensors, quant_mode
+        )
 
         result = cute_dsl_fused_moe_nvfp4(
-            x=tensors["x"],
-            x_sf=tensors["x_sf"],
             token_selected_experts=tensors["token_selected_experts"],
             token_final_scales=tensors["token_final_scales"],
             w1_weight=tensors["w1_weight"],
             w1_weight_sf=tensors["w1_weight_sf"],
             w1_alpha=tensors["w1_alpha"],
-            fc2_input_scale=tensors["fc2_input_scale"],
             w2_weight=tensors["w2_weight"],
             w2_weight_sf=tensors["w2_weight_sf"],
             w2_alpha=tensors["w2_alpha"],
             num_experts=num_experts,
             top_k=top_k,
             activation_type=activation_type,
-            per_token_scale=tensors["x_per_token_scale"],
+            quant_mode=quant_mode,
+            **api_inputs,
         )
 
         ref_output = compute_reference_moe_fp4(
-            hidden_states=tensors["x_ref"].float().cuda(),
-            gemm1_weights=tensors["w1_weight_bf16"].float().cuda(),
-            gemm2_weights=tensors["w2_weight_bf16"].float().cuda(),
-            gemm1_alpha=tensors["w1_alpha"],
-            gemm2_alpha=tensors["w2_alpha"],
             token_selected_experts=tensors["token_selected_experts"],
             token_final_scales=tensors["token_final_scales"],
             num_tokens=num_tokens,
@@ -1646,17 +1655,11 @@ class TestCuteDslFusedMoeFunctional:
             top_k=top_k,
             hidden_size=hidden_size,
             intermediate_size=intermediate_size,
-            fc2_input_scale=tensors["fc2_input_scale"],
             activation_type=activation_type,
-            use_per_token_activation=use_per_token_activation,
+            **reference_inputs,
         )
 
         swiglu_ref_output = compute_reference_moe_fp4(
-            hidden_states=tensors["x_ref"].float().cuda(),
-            gemm1_weights=tensors["w1_weight_bf16"].float().cuda(),
-            gemm2_weights=tensors["w2_weight_bf16"].float().cuda(),
-            gemm1_alpha=tensors["w1_alpha"],
-            gemm2_alpha=tensors["w2_alpha"],
             token_selected_experts=tensors["token_selected_experts"],
             token_final_scales=tensors["token_final_scales"],
             num_tokens=num_tokens,
@@ -1664,9 +1667,8 @@ class TestCuteDslFusedMoeFunctional:
             top_k=top_k,
             hidden_size=hidden_size,
             intermediate_size=intermediate_size,
-            fc2_input_scale=tensors["fc2_input_scale"],
             activation_type=ActivationType.Swiglu,
-            use_per_token_activation=use_per_token_activation,
+            **reference_inputs,
         )
 
         passed, percent_within, atol = check_accuracy(result, ref_output)
@@ -1680,7 +1682,9 @@ class TestCuteDslFusedMoeFunctional:
             f"than SwiGLU reference ({swiglu_error:.4f})"
         )
 
-    @pytest.mark.parametrize("use_per_token_activation", [False, True])
+    @pytest.mark.parametrize(
+        "quant_mode,use_per_token_activation", _MOE_QUANT_MODE_CASES
+    )
     @pytest.mark.parametrize(
         "situ_beta,situ_linear_beta",
         [(1.75, None), (0.8, 1.5)],
@@ -1688,6 +1692,7 @@ class TestCuteDslFusedMoeFunctional:
     )
     def test_situ_accuracy(
         self,
+        quant_mode: str,
         use_per_token_activation: bool,
         situ_beta: float,
         situ_linear_beta: float | None,
@@ -1708,16 +1713,16 @@ class TestCuteDslFusedMoeFunctional:
             gated=True,
             use_per_token_activation=use_per_token_activation,
         )
+        api_inputs, reference_inputs = _prepare_moe_quant_mode_inputs(
+            tensors, quant_mode
+        )
 
         result = cute_dsl_fused_moe_nvfp4(
-            x=tensors["x"],
-            x_sf=tensors["x_sf"],
             token_selected_experts=tensors["token_selected_experts"],
             token_final_scales=tensors["token_final_scales"],
             w1_weight=tensors["w1_weight"],
             w1_weight_sf=tensors["w1_weight_sf"],
             w1_alpha=tensors["w1_alpha"],
-            fc2_input_scale=tensors["fc2_input_scale"],
             w2_weight=tensors["w2_weight"],
             w2_weight_sf=tensors["w2_weight_sf"],
             w2_alpha=tensors["w2_alpha"],
@@ -1726,15 +1731,11 @@ class TestCuteDslFusedMoeFunctional:
             activation_type=ActivationType.Swiglu,
             situ_beta=situ_beta,
             situ_linear_beta=situ_linear_beta,
-            per_token_scale=tensors["x_per_token_scale"],
+            quant_mode=quant_mode,
+            **api_inputs,
         )
 
         ref_output = compute_reference_moe_fp4(
-            hidden_states=tensors["x_ref"].float().cuda(),
-            gemm1_weights=tensors["w1_weight_bf16"].float().cuda(),
-            gemm2_weights=tensors["w2_weight_bf16"].float().cuda(),
-            gemm1_alpha=tensors["w1_alpha"],
-            gemm2_alpha=tensors["w2_alpha"],
             token_selected_experts=tensors["token_selected_experts"],
             token_final_scales=tensors["token_final_scales"],
             num_tokens=num_tokens,
@@ -1742,19 +1743,13 @@ class TestCuteDslFusedMoeFunctional:
             top_k=top_k,
             hidden_size=hidden_size,
             intermediate_size=intermediate_size,
-            fc2_input_scale=tensors["fc2_input_scale"],
             activation_type=ActivationType.Swiglu,
             situ_beta=situ_beta,
             situ_linear_beta=situ_linear_beta,
-            use_per_token_activation=use_per_token_activation,
+            **reference_inputs,
         )
 
         swiglu_ref_output = compute_reference_moe_fp4(
-            hidden_states=tensors["x_ref"].float().cuda(),
-            gemm1_weights=tensors["w1_weight_bf16"].float().cuda(),
-            gemm2_weights=tensors["w2_weight_bf16"].float().cuda(),
-            gemm1_alpha=tensors["w1_alpha"],
-            gemm2_alpha=tensors["w2_alpha"],
             token_selected_experts=tensors["token_selected_experts"],
             token_final_scales=tensors["token_final_scales"],
             num_tokens=num_tokens,
@@ -1762,9 +1757,8 @@ class TestCuteDslFusedMoeFunctional:
             top_k=top_k,
             hidden_size=hidden_size,
             intermediate_size=intermediate_size,
-            fc2_input_scale=tensors["fc2_input_scale"],
             activation_type=ActivationType.Swiglu,
-            use_per_token_activation=use_per_token_activation,
+            **reference_inputs,
         )
 
         passed, percent_within, atol = check_accuracy(result, ref_output)
@@ -2162,23 +2156,14 @@ class TestCuteDslMoEWrapper:
             f"CUDA graph accuracy: {percent_within * 100:.2f}% (atol={atol:.4f})"
         )
 
+    @pytest.mark.parametrize("quant_mode", _MOE_QUANT_MODES)
     @pytest.mark.parametrize(
-        "activation_type,situ_beta,situ_linear_beta,quant_mode",
+        "activation_type,situ_beta,situ_linear_beta",
         [
-            (ActivationType.Swiglu, None, None, "w4a4"),
-            (ActivationType.Swiglu, 1.0, 1.5, "w4a4"),
-            (ActivationType.GegluTanh, None, None, "w4a4"),
-            (ActivationType.Relu2, None, None, "w4a4"),
-            (ActivationType.Swiglu, None, None, "w4a16"),
-            (ActivationType.Relu2, None, None, "w4a16"),
-        ],
-        ids=[
-            "w4a4-swiglu",
-            "w4a4-situ",
-            "w4a4-geglu-tanh",
-            "w4a4-relu2",
-            "w4a16-swiglu",
-            "w4a16-relu2",
+            pytest.param(ActivationType.Swiglu, None, None, id="swiglu"),
+            pytest.param(ActivationType.Swiglu, 1.0, 1.5, id="situ"),
+            pytest.param(ActivationType.GegluTanh, None, None, id="geglu-tanh"),
+            pytest.param(ActivationType.Relu2, None, None, id="relu2"),
         ],
     )
     def test_wrapper_with_autotune(


### PR DESCRIPTION
## 📌 Description

@humansand

- Extend CuTe DSL W4A16 fused MoE with tanh-approximate GeGLU and SiTU.
- Reuse the activation math and validation introduced for W4A4 in #4009:
  - GeGLU-tanh: `up * GELU(gate, approximate="tanh")`.
  - SiTU: `ActivationType.Swiglu` plus `situ_beta`, with optional `situ_linear_beta` for the up-branch clamp.
- Apply each expert's W1 alpha before activation, matching the existing W4A4 contract.
- Include both SiTU parameters in autotuner and compiled-kernel cache identities.
- Keep activation in GEMM1; GEMM2 routing-weight reduction and fused finalize are unchanged.
- Extend existing Cartesian tests across W4A4 per-tensor, W4A4 per-token, and W4A16 modes; no new standalone test functions are added.

## 🔍 Related Issues

- https://github.com/flashinfer-ai/flashinfer/pull/4009
- https://github.com/flashinfer-ai/flashinfer/pull/4048

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see the [pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

B200 source-only validation with `lmsysorg/sglang:nightly-dev-cu13-20260806-ae5f8c94`:

- `pre-commit run --all-files` — passed.
- GeGLU/SiTU functional and cache-key matrix — 11 passed.
- W4A16 GeGLU/SiTU wrapper-autotune rows — 2 passed, 6 deselected.
- `moe_utils is_aot: False`; editable-install data links resolved inside the synced source checkout.

## Reviewer Notes

- SiTU intentionally remains `ActivationType.Swiglu` plus its beta parameters, matching #4009.
- Scope follows #4009's functional and wrapper APIs; the unified `CuteDslNvfp4Runner` activation configuration is unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for SiLU-in-the-unit (SiTU) parameters in W4A16 mixture-of-experts execution.
  * Added GeGLU-Tanh activation support for applicable gated operations.
  * Improved tuning and cache handling for activation and quantization configurations.

* **Bug Fixes**
  * Corrected activation parameter handling across wrapper and functional execution paths.

* **Tests**
  * Expanded accuracy and autotuning coverage across W4A4 and W4A16 modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->