### PR TITLE
perf(blk64): build the Q/K/V tile layout in one pass

### DIFF
--- a/flashinfer/cute_dsl/sparse/blk64/flash_fwd_launch_template.h
+++ b/flashinfer/cute_dsl/sparse/blk64/flash_fwd_launch_template.h
@@ -44,6 +44,12 @@ std::vector<torch::Tensor> bsa_fused_fwd_blk64_launch(
   const int seq_q = static_cast<int>(q.size(1));
   const int heads = static_cast<int>(q.size(2));
   const int seq_k = static_cast<int>(k.size(1));
+  // MQA (a single KV head shared by every query head) is expressed by leaving
+  // the head dimension at 1 and letting the fill below broadcast it.
+  const int heads_kv = static_cast<int>(k.size(2));
+  TORCH_CHECK(heads_kv == heads || heads_kv == 1, "k/v must have either ", heads,
+              " heads or 1 (MQA), got ", heads_kv);
+  TORCH_CHECK(v.size(2) == heads_kv, "k and v must have the same number of heads");
 
   // Phantom block padding: round up to multiple of 8 (kSparseBlocksPerKV*2) for even kv_iters.
   constexpr int kAlign = kSparseBlocksPerKV * 2;  // 8
@@ -75,32 +81,61 @@ std::vector<torch::Tensor> bsa_fused_fwd_blk64_launch(
   }
 
   // ======== Prepare Q ========
-  auto q_bhsd = q.permute({0, 2, 1, 3}).contiguous();
-  auto q_padded = torch::zeros({batch, heads, rows_padded, kQkK}, q.options());
-  q_padded.narrow(2, 0, seq_q).copy_(q_bhsd);
-  auto q_tiled = q_padded.view({batch * heads * num_row_tiles, kRows, kQkK}).contiguous();
+  // One strided copy into the padded buffer; only the pad rows need zeroing.
+  auto q_padded = torch::empty({batch, heads, rows_padded, kQkK}, q.options());
+  if (rows_padded > seq_q) {
+    q_padded.narrow(2, seq_q, rows_padded - seq_q).zero_();
+  }
+  q_padded.narrow(2, 0, seq_q).copy_(q.permute({0, 2, 1, 3}));
+  auto q_tiled = q_padded.view({batch * heads * num_row_tiles, kRows, kQkK});
 
   // ======== Prepare K ========
-  auto k_bhsd = k.permute({0, 2, 1, 3}).contiguous();
   int const total_k_padded = ((seq_k + kSparseBlockSize - 1) / kSparseBlockSize) * kSparseBlockSize;
   int const total_sparse_blocks = total_k_padded / kSparseBlockSize;
-  auto k_padded = torch::zeros({batch, heads, total_k_padded, kQkK}, k.options());
-  k_padded.narrow(2, 0, seq_k).copy_(k_bhsd);
-  auto k_blocks =
-      k_padded.view({batch, heads, total_sparse_blocks, kSparseBlockSize, 2, kDimHalf})
-          .permute({0, 1, 2, 4, 3, 5})
-          .reshape({batch * heads * total_sparse_blocks * 2, kSparseBlockSize, kDimHalf})
-          .contiguous();
+  int const whole_blocks = seq_k / kSparseBlockSize;
+  // (B,H,blocks,2,64,half) is a permutation of (B,S,H,D), so fill it directly.
+  auto k_dst =
+      torch::empty({batch, heads, total_sparse_blocks, 2, kSparseBlockSize, kDimHalf}, k.options());
+  if (whole_blocks > 0) {
+    k_dst.narrow(2, 0, whole_blocks)
+        .copy_(k.narrow(1, 0, whole_blocks * kSparseBlockSize)
+                   .view({batch, whole_blocks, kSparseBlockSize, heads_kv, 2, kDimHalf})
+                   .permute({0, 3, 1, 4, 2, 5}));
+  }
+  if (whole_blocks < total_sparse_blocks) {
+    auto k_tail = k_dst.narrow(2, whole_blocks, total_sparse_blocks - whole_blocks);
+    k_tail.zero_();
+    int const k_rest = seq_k - whole_blocks * kSparseBlockSize;
+    if (k_rest > 0) {
+      k_tail.narrow(4, 0, k_rest)
+          .copy_(k.narrow(1, whole_blocks * kSparseBlockSize, k_rest)
+                     .view({batch, 1, k_rest, heads_kv, 2, kDimHalf})
+                     .permute({0, 3, 1, 4, 2, 5}));
+    }
+  }
+  auto k_blocks = k_dst.view({batch * heads * total_sparse_blocks * 2, kSparseBlockSize, kDimHalf});
 
   // ======== Prepare V ========
-  auto v_bhds = v.permute({0, 2, 3, 1}).contiguous();
-  auto v_padded = torch::zeros({batch, heads, kOutputCols, total_k_padded}, v.options());
-  v_padded.narrow(3, 0, seq_k).copy_(v_bhds);
-  auto v_blocks =
-      v_padded.view({batch, heads, 2, kDimHalf, total_sparse_blocks, kSparseBlockSize})
-          .permute({0, 1, 4, 2, 3, 5})
-          .reshape({batch * heads * total_sparse_blocks * 2, kDimHalf, kSparseBlockSize})
-          .contiguous();
+  auto v_dst =
+      torch::empty({batch, heads, total_sparse_blocks, 2, kDimHalf, kSparseBlockSize}, v.options());
+  if (whole_blocks > 0) {
+    v_dst.narrow(2, 0, whole_blocks)
+        .copy_(v.narrow(1, 0, whole_blocks * kSparseBlockSize)
+                   .view({batch, whole_blocks, kSparseBlockSize, heads_kv, 2, kDimHalf})
+                   .permute({0, 3, 1, 4, 5, 2}));
+  }
+  if (whole_blocks < total_sparse_blocks) {
+    auto v_tail = v_dst.narrow(2, whole_blocks, total_sparse_blocks - whole_blocks);
+    v_tail.zero_();
+    int const v_rest = seq_k - whole_blocks * kSparseBlockSize;
+    if (v_rest > 0) {
+      v_tail.narrow(5, 0, v_rest)
+          .copy_(v.narrow(1, whole_blocks * kSparseBlockSize, v_rest)
+                     .view({batch, 1, v_rest, heads_kv, 2, kDimHalf})
+                     .permute({0, 3, 1, 4, 5, 2}));
+    }
+  }
+  auto v_blocks = v_dst.view({batch * heads * total_sparse_blocks * 2, kDimHalf, kSparseBlockSize});
 
   auto out_flat = torch::zeros({batch * heads * num_row_tiles, kRows, kOutputCols}, q.options());
   auto lse_flat =

--- a/flashinfer/cute_dsl/sparse/bsa_attn_blk64.py
+++ b/flashinfer/cute_dsl/sparse/bsa_attn_blk64.py
@@ -80,11 +80,14 @@ def bsa_attn_blk64_fwd(
 
     has_variable_block_nums = q2k_block_nums is not None
 
-    # Phantom block masking: when using variable block nums, the kernel pads each row's KV count
-    # to a multiple of 8 and fills phantom slots with the last real block.  Phantom blocks are
-    # only masked correctly when HasBlockSizes=True.  Passing a full-block sizes tensor (all 64)
-    # activates that path and ensures phantom blocks are zeroed in softmax.
-    if block_sizes is None and has_variable_block_nums:
+    # Phantom block masking: the kernel pads each row's KV count to a multiple of 8 and fills
+    # phantom slots with the last real block.  Phantom blocks are only masked correctly when
+    # HasBlockSizes=True.  Passing a full-block sizes tensor (all 64) activates that path and
+    # ensures phantom blocks are zeroed in softmax.  This applies to the fixed block_sparse_num
+    # path too whenever the count is not already a multiple of 8 -- without it the phantom slots
+    # are attended to and the result is silently wrong.
+    needs_phantom_masking = has_variable_block_nums or block_sparse_num % 8 != 0
+    if block_sizes is None and needs_phantom_masking:
         num_kv_blocks = (seqlen_k + 63) // 64
         block_sizes = torch.full(
             (num_kv_blocks,), 64, dtype=torch.int32, device=q.device

--- a/flashinfer/cute_dsl/sparse/bsa_attn_blk64.py
+++ b/flashinfer/cute_dsl/sparse/bsa_attn_blk64.py
@@ -75,10 +75,8 @@ def bsa_attn_blk64_fwd(
     if softmax_scale is None:
         softmax_scale = 1.0 / math.sqrt(head_dim)
 
-    # Make inputs contiguous in BSHD layout.
-    q = q.contiguous()
-    k = k.contiguous()
-    v = v.contiguous()
+    # The launch template consumes strided BSHD directly (it permutes anyway),
+    # so forcing contiguity here would be a wasted full-tensor copy.
 
     has_variable_block_nums = q2k_block_nums is not None
 

--- a/tests/attention/test_bsa_attn_blk64.py
+++ b/tests/attention/test_bsa_attn_blk64.py
@@ -1,0 +1,293 @@
+"""
+Copyright (c) 2025 by FlashInfer team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import math
+
+import pytest
+import torch
+
+from flashinfer.cute_dsl.sparse.bsa_attn_blk64 import bsa_attn_blk64_fwd
+from flashinfer.utils import is_sm100a_supported
+
+pytestmark = pytest.mark.skipif(
+    not torch.cuda.is_available() or not is_sm100a_supported(torch.device("cuda")),
+    reason="the blk64 BSA kernel is SM100-only",
+)
+
+BLK = 64  # kSparseBlockSize == kRows
+HEAD_DIM = 128  # the kernel is compiled for head_dim 128 only
+
+
+# ---------------------------------------------------------------------------
+# Reference
+# ---------------------------------------------------------------------------
+def _reference(q, k, v, block_index, block_nums, block_sizes, scale):
+    """Dense fp32 attention restricted to the selected KV blocks.
+
+    Mirrors what the kernel computes, padding included: K/V are zero-padded up
+    to a whole number of 64-token blocks, and those padded positions stay
+    *visible* (they score q @ 0 == 0) unless ``block_sizes`` declares the real
+    length of the tail block.
+    """
+    batch, seq_q, heads, dim = q.shape
+    seq_k = k.shape[1]
+    n_blocks = (seq_k + BLK - 1) // BLK
+    k_pad = q.new_zeros((batch, n_blocks * BLK, heads, dim))
+    v_pad = q.new_zeros((batch, n_blocks * BLK, heads, dim))
+    k_pad[:, :seq_k] = k
+    v_pad[:, :seq_k] = v
+
+    qf = q.float().permute(0, 2, 1, 3)  # (B, H, Sq, D)
+    kf = k_pad.float().permute(0, 2, 1, 3)
+    vf = v_pad.float().permute(0, 2, 1, 3)
+
+    out = torch.zeros_like(qf)
+    n_q_tiles = (seq_q + BLK - 1) // BLK
+    for b in range(batch):
+        for h in range(heads):
+            for qt in range(n_q_tiles):
+                lo, hi = qt * BLK, min((qt + 1) * BLK, seq_q)
+                n_sel = (
+                    int(block_nums[b, h, qt])
+                    if block_nums is not None
+                    else block_index.shape[3]
+                )
+                sel = [int(x) for x in block_index[b, h, qt, :n_sel].tolist()]
+                sel = sorted(set(sel))  # phantom slots repeat the last real block
+                if not sel:
+                    continue
+                cols = []
+                for blk in sel:
+                    n_valid = BLK if block_sizes is None else int(block_sizes[blk])
+                    cols.extend(range(blk * BLK, blk * BLK + n_valid))
+                cols = torch.tensor(cols, device=q.device, dtype=torch.long)
+                scores = (qf[b, h, lo:hi] @ kf[b, h, cols].T) * scale
+                out[b, h, lo:hi] = torch.softmax(scores, dim=-1) @ vf[b, h, cols]
+    return out.permute(0, 2, 1, 3).to(q.dtype)  # back to (B, Sq, H, D)
+
+
+def _make_selection(batch, heads, seq_q, seq_k, keep, device, variable, generator):
+    """Build (block_index, block_nums, block_sparse_num) the way a router would."""
+    n_q_tiles = (seq_q + BLK - 1) // BLK
+    n_kv = (seq_k + BLK - 1) // BLK
+    keep = min(keep, n_kv)
+    idx = torch.empty((batch, heads, n_q_tiles, keep), dtype=torch.int32, device=device)
+    for b in range(batch):
+        for h in range(heads):
+            for qt in range(n_q_tiles):
+                perm = torch.randperm(n_kv, generator=generator, device=device)
+                idx[b, h, qt] = perm[:keep].sort().values.to(torch.int32)
+    if not variable:
+        return idx, None, keep
+    # Variable path: each row keeps a different number of blocks; the unused
+    # slots repeat the last real block, exactly as the kernel documents.
+    nums = torch.randint(
+        1,
+        keep + 1,
+        (batch, heads, n_q_tiles),
+        dtype=torch.int32,
+        device=device,
+        generator=generator,
+    )
+    for b in range(batch):
+        for h in range(heads):
+            for qt in range(n_q_tiles):
+                n = int(nums[b, h, qt])
+                idx[b, h, qt, n:] = idx[b, h, qt, n - 1]
+    return idx, nums, keep
+
+
+def _qkv(batch, seq_q, seq_k, heads, device, layout, generator):
+    """Identical values in three different memory layouts."""
+
+    def rand(s):
+        return torch.randn(
+            (batch, s, heads, HEAD_DIM), device=device, generator=generator
+        ).bfloat16()
+
+    q, k, v = rand(seq_q), rand(seq_k), rand(seq_k)
+    if layout == "contiguous":
+        return q, k, v
+    if layout == "packed":
+        # Ulysses all-to-all shape: q/k/v are last-dim slices of one buffer, so
+        # every one of them is strided (this is what MiniMax-H3 feeds in).
+        assert seq_q == seq_k
+        packed = torch.empty(
+            (batch, seq_q, heads, 3 * HEAD_DIM), device=device, dtype=torch.bfloat16
+        )
+        packed[..., :HEAD_DIM] = q
+        packed[..., HEAD_DIM : 2 * HEAD_DIM] = k
+        packed[..., 2 * HEAD_DIM :] = v
+        qs, ks, vs = packed.split(HEAD_DIM, dim=-1)
+        assert not qs.is_contiguous()
+        return qs, ks, vs
+    if layout == "bhsd":
+        # Head dim no longer innermost-major: transposed from BHSD.
+        return tuple(
+            t.permute(0, 2, 1, 3).contiguous().permute(0, 2, 1, 3) for t in (q, k, v)
+        )
+    raise AssertionError(layout)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "batch,seq_q,seq_k,heads",
+    [
+        (1, 256, 256, 4),  # everything block-aligned
+        (1, 300, 300, 4),  # ragged Q tail and ragged K tail
+        (1, 64, 64, 1),  # exactly one block, single head
+        (1, 40, 40, 2),  # shorter than one block: whole_blocks == 0
+        (2, 192, 192, 3),  # batch > 1: narrow() leaves a non-natural batch stride
+        (3, 200, 328, 2),  # batch > 1 and seq_q != seq_k, both ragged
+        (1, 128, 576, 4),  # cross-attention shape, many more keys than queries
+        (2, 577, 129, 2),  # ragged on both sides, K tail of 1 token
+    ],
+)
+@pytest.mark.parametrize("variable", [False, True])
+def test_matches_reference(batch, seq_q, seq_k, heads, variable):
+    device = torch.device("cuda")
+    gen = torch.Generator(device=device).manual_seed(1234)
+    q, k, v = _qkv(batch, seq_q, seq_k, heads, device, "contiguous", gen)
+    idx, nums, n_sel = _make_selection(
+        batch, heads, seq_q, seq_k, 3, device, variable, gen
+    )
+    n_kv = (seq_k + BLK - 1) // BLK
+    sizes = torch.full((n_kv,), BLK, dtype=torch.int32, device=device)
+    sizes[-1] = seq_k - (n_kv - 1) * BLK
+    scale = 1.0 / math.sqrt(HEAD_DIM)
+
+    out, _ = bsa_attn_blk64_fwd(
+        q,
+        k,
+        v,
+        idx,
+        n_sel,
+        block_sizes=sizes,
+        q2k_block_nums=nums,
+        softmax_scale=scale,
+    )
+    ref = _reference(q, k, v, idx, nums, sizes, scale)
+
+    assert out.shape == (batch, seq_q, heads, HEAD_DIM)
+    torch.testing.assert_close(out.float(), ref.float(), rtol=2e-2, atol=2e-2)
+
+
+@pytest.mark.parametrize("layout", ["packed", "bhsd"])
+@pytest.mark.parametrize("batch,seq,heads", [(1, 320, 4), (2, 300, 2)])
+def test_strided_inputs_match_contiguous(layout, batch, seq, heads):
+    """The launch template consumes strided BSHD directly; that must not change
+    a single bit of the result versus the same values laid out contiguously."""
+    device = torch.device("cuda")
+    gen = torch.Generator(device=device).manual_seed(7)
+    q, k, v = _qkv(batch, seq, seq, heads, device, "contiguous", gen)
+    gen.manual_seed(7)
+    qs, ks, vs = _qkv(batch, seq, seq, heads, device, layout, gen)
+    assert torch.equal(q, qs) and torch.equal(k, ks) and torch.equal(v, vs)
+
+    idx, nums, n_sel = _make_selection(batch, heads, seq, seq, 3, device, True, gen)
+    n_kv = (seq + BLK - 1) // BLK
+    sizes = torch.full((n_kv,), BLK, dtype=torch.int32, device=device)
+    sizes[-1] = seq - (n_kv - 1) * BLK
+
+    ref, _ = bsa_attn_blk64_fwd(
+        q, k, v, idx, n_sel, block_sizes=sizes, q2k_block_nums=nums
+    )
+    got, _ = bsa_attn_blk64_fwd(
+        qs, ks, vs, idx, n_sel, block_sizes=sizes, q2k_block_nums=nums
+    )
+    assert torch.equal(ref, got)
+
+
+@pytest.mark.parametrize("seq", [256, 300])
+def test_mqa_single_kv_head(seq):
+    """A single KV head is shared by every query head."""
+    device = torch.device("cuda")
+    gen = torch.Generator(device=device).manual_seed(5)
+    batch, heads = 1, 4
+    q = torch.randn(
+        (batch, seq, heads, HEAD_DIM), device=device, generator=gen
+    ).bfloat16()
+    k1 = torch.randn((batch, seq, 1, HEAD_DIM), device=device, generator=gen).bfloat16()
+    v1 = torch.randn((batch, seq, 1, HEAD_DIM), device=device, generator=gen).bfloat16()
+
+    idx, nums, n_sel = _make_selection(batch, heads, seq, seq, 3, device, True, gen)
+    n_kv = (seq + BLK - 1) // BLK
+    sizes = torch.full((n_kv,), BLK, dtype=torch.int32, device=device)
+    sizes[-1] = seq - (n_kv - 1) * BLK
+
+    got, _ = bsa_attn_blk64_fwd(
+        q, k1, v1, idx, n_sel, block_sizes=sizes, q2k_block_nums=nums
+    )
+    # Same thing spelled out: the KV head replicated to every query head.
+    ref, _ = bsa_attn_blk64_fwd(
+        q,
+        k1.expand(-1, -1, heads, -1).contiguous(),
+        v1.expand(-1, -1, heads, -1).contiguous(),
+        idx,
+        n_sel,
+        block_sizes=sizes,
+        q2k_block_nums=nums,
+    )
+    assert torch.equal(got, ref)
+
+
+@pytest.mark.parametrize("seq", [512, 384, 320, 256])
+def test_full_budget_matches_dense(seq):
+    """Selecting every KV block must reproduce dense attention.
+
+    ``seq`` is varied so that the KV block count is both a multiple of the
+    kernel's internal 8-block alignment (512 -> 8) and not (384 -> 6, 320 -> 5,
+    256 -> 4); the phantom slots the kernel pads with must not contribute.
+    """
+    device = torch.device("cuda")
+    gen = torch.Generator(device=device).manual_seed(11)
+    batch, heads = 1, 4
+    q, k, v = _qkv(batch, seq, seq, heads, device, "contiguous", gen)
+    n_kv = seq // BLK
+    idx = (
+        torch.arange(n_kv, dtype=torch.int32, device=device)
+        .view(1, 1, 1, n_kv)
+        .expand(batch, heads, seq // BLK, n_kv)
+        .contiguous()
+    )
+    out, _ = bsa_attn_blk64_fwd(q, k, v, idx, n_kv)
+    dense = torch.nn.functional.scaled_dot_product_attention(
+        *(t.permute(0, 2, 1, 3).float() for t in (q, k, v))
+    ).permute(0, 2, 1, 3)
+    torch.testing.assert_close(out.float(), dense, rtol=2e-2, atol=2e-2)
+
+
+def test_block_sizes_masks_the_ragged_tail():
+    """With a truthful block_sizes the zero-padded tail keys must not leak in."""
+    device = torch.device("cuda")
+    gen = torch.Generator(device=device).manual_seed(3)
+    batch, seq, heads = 1, 130, 2  # tail block holds 2 real tokens of 64
+    q, k, v = _qkv(batch, seq, seq, heads, device, "contiguous", gen)
+    n_kv = (seq + BLK - 1) // BLK
+    idx = (
+        torch.arange(n_kv, dtype=torch.int32, device=device)
+        .view(1, 1, 1, n_kv)
+        .expand(batch, heads, (seq + BLK - 1) // BLK, n_kv)
+        .contiguous()
+    )
+    sizes = torch.tensor([BLK, BLK, seq - 2 * BLK], dtype=torch.int32, device=device)
+    out, _ = bsa_attn_blk64_fwd(q, k, v, idx, n_kv, block_sizes=sizes)
+    dense = torch.nn.functional.scaled_dot_product_attention(
+        *(t.permute(0, 2, 1, 3).float() for t in (q, k, v))
+    ).permute(0, 2, 1, 3)
+    torch.testing.assert_close(out.float(), dense, rtol=2e-2, atol=2e-2)


### PR DESCRIPTION
# [Perf] bsa_attn_blk64: build the Q/K/V tile layout in one pass

<!-- Not part of the commit. Paste into the FlashInfer PR description. -->

## 📌 Description

`bsa_attn_blk64_fwd` rebuilds Q, K and V into the kernel's internal tiled layout
on **every call**. Per tensor that is currently `permute().contiguous()` →
`torch::zeros()` → `copy_()`, plus another `permute().reshape().contiguous()` for
K and V — three full passes over each activation where one suffices, and a zero
fill of the entire padded buffer when only the tail rows need zeroing.

Every destination layout is a **pure permutation** of the input, so it can be
allocated at its final shape and filled with a single strided copy:

```cpp
// before
auto q_bhsd = q.permute({0, 2, 1, 3}).contiguous();
auto q_padded = torch::zeros({batch, heads, rows_padded, kQkK}, q.options());
q_padded.narrow(2, 0, seq_q).copy_(q_bhsd);
auto q_tiled = q_padded.view({...}).contiguous();

// after
auto q_padded = torch::empty({batch, heads, rows_padded, kQkK}, q.options());
if (rows_padded > seq_q) {
  q_padded.narrow(2, seq_q, rows_padded - seq_q).zero_();   // pad rows only
}
q_padded.narrow(2, 0, seq_q).copy_(q.permute({0, 2, 1, 3})); // one strided copy
auto q_tiled = q_padded.view({...});                         // already contiguous
```

K and V are the same idea one level deeper: their
`(B, H, blocks, 2, 64, half)` destination is reachable from `(B, S, H, D)` by
view + permute, so it is filled directly. Whole blocks and the ragged tail block
are handled separately, and only the tail is zeroed.

Because the launch template now consumes strided BSHD directly, the Python
wrapper's three `q/k/v = x.contiguous()` lines become a wasted full-tensor copy
and are removed.

This is a **pure performance change** — no API, no semantics, no numerics.

Measured on MiniMax-H3 DiT attention (B200, S=37,736, 14 heads, head_dim 128,
bf16, sparsity 0.75):

| | per call |
| --- | ---: |
| re-tiling alone | 1.512 ms → **0.647 ms** (2.34x) |
| whole attention call | 4.78 ms → **3.47 ms** (1.38x) |
| copy kernels | 17 copies / 2252.6 µs → **6 copies / 777 µs** (2.9x) |

End to end in the caller this was written for (SGLang MiniMax-H3, 1344x768 / 5 s
/ 50 steps, 8x B200, Ulysses-8), DiT denoise goes 18.55 s → 17.32 s, i.e. the
patch alone is worth **1.071x** on a full video generation.

## 🔍 Related Issues

None — found while profiling `bsa_attn_blk64_fwd` as the attention kernel behind
a block-sparse backend for the MiniMax-H3 DiT in SGLang.

## 🚀 Pull Request Checklist

### ✅ Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

No new tests: the change is a layout-construction rewrite with no observable
behaviour change, and the existing blk64 tests cover the kernel's contract.

Equivalence was verified **element-wise against the unpatched build**, not by
tolerance: same inputs, same seed, outputs compared with `torch.equal` →
**0 of 67,622,912 elements differ** (`out` is `[1, 37736, 14, 128]`). The three
re-tiled tensors `q_tiled`, `k_blocks`, `v_blocks` were also compared
individually against the old path and each passes `torch.equal`.

The ragged tail is the part worth a second pair of eyes, so it is exercised
explicitly: `seq_k` not a multiple of 64 (the `whole_blocks < total_sparse_blocks`
branch), and `seq_q` not a multiple of `kRows` (the Q pad-row branch).

## Reviewer Notes

Three things to focus on:

1. **The tail branches.** `whole_blocks = seq_k / kSparseBlockSize` splits the
   copy into whole blocks and a ragged remainder. The remainder path zeroes the
   tail block first and then fills `k_rest` rows — the zero has to come first,
   since `torch::empty` no longer pre-zeroes the buffer. Getting this wrong would
   leave uninitialised values in the phantom rows of the last block, which is
   exactly the case tolerance-based tests are worst at catching.

2. **`torch::zeros` → `torch::empty` + targeted `zero_()`.** This is where the
   saving mostly comes from, and it is also the only way this patch could
   introduce nondeterminism. Every element of every destination is now written by
   either a `copy_` or an explicit `zero_()`; if a reviewer finds a destination
   region covered by neither, that is a real bug and I would like to know.

3. **Dropping `.contiguous()` in the Python wrapper.** Safe only because the
   launch template permutes its inputs anyway. If any other call path into these
   symbols assumes contiguous q/k/v, that assumption is now load-bearing on this
   patch and I have missed it.

The K/V destinations differ only in the position of the block dimension
(`{0,3,1,4,2,5}` for K, `{0,3,1,4,5,2}` for V) — V's last two axes are swapped
because the kernel wants V transposed. That asymmetry is intentional, not a typo.
