### PR TITLE
fix(gemm): never free workspace storage that captured CUDA graphs may reference

### DIFF
--- a/flashinfer/gemm/gemm_base.py
+++ b/flashinfer/gemm/gemm_base.py
@@ -65,6 +65,8 @@ from .kernels.utils import (
     _select_sm100_mm_fp4_cute_dsl_tactic,
 )
 from ..utils import (
+    _cache_buf,
+    _retired_cache_buf,
     get_device_index,
     get_device_sm_count,
     get_native_fp4_dtype,
@@ -124,6 +126,33 @@ from ..utils import (
 )
 
 DEFAULT_WORKSPACE_SIZE = 32 * 1024 * 1024
+
+
+def _grow_workspace(workspace: torch.Tensor, workspace_size: int) -> torch.Tensor:
+    """Grow a workspace tensor without freeing its current storage.
+
+    ``resize_()`` reallocates and frees the old device buffer, but the old
+    address may already be baked into a captured CUDA graph as a kernel
+    argument; replaying such a graph after the free faults with a GPU MMU
+    fault (Xid 31). Long-lived cached buffers are therefore retired (kept
+    alive) rather than freed; short-lived tensors (autotuner profiling
+    scratch) are freed normally unless a capture is in progress.
+    """
+    if workspace.numel() >= workspace_size:
+        return workspace
+    new_workspace = torch.empty(
+        workspace_size, dtype=workspace.dtype, device=workspace.device
+    )
+    retire = torch.cuda.is_current_stream_capturing()
+    for key, buf in _cache_buf.items():
+        if buf is workspace:
+            _cache_buf[key] = new_workspace
+            retire = True
+            break
+    if retire:
+        _retired_cache_buf.append(workspace)
+    return new_workspace
+
 
 # sizeof(cublasLtMatmulAlgo_t) = uint64_t[8] = 64 bytes.
 # Shared by cuBLAS FP8, cuBLASLt BF16, and any other cuBLASLt-based runners.
@@ -2898,7 +2927,7 @@ def execute_cudnn_gemm_fp4_graph(
 
     workspace_size = _get_cudnn_workspace_size(graph, plan_index)
     if workspace_buffer.numel() < workspace_size:
-        workspace_buffer.resize_(workspace_size)
+        workspace_buffer = _grow_workspace(workspace_buffer, workspace_size)
 
     stream = torch.cuda.current_stream(a.device)
 
@@ -3133,7 +3162,7 @@ def execute_cudnn_gemm_fp4_graph_override_shape(
         override_strides,
     )
     if workspace.numel() < workspace_size:
-        workspace.resize_(workspace_size)
+        workspace = _grow_workspace(workspace, workspace_size)
 
     if plan_index < 0:
         graph.execute(
@@ -3217,7 +3246,7 @@ def execute_cudnn_gemm_mxfp8_graph(
     workspace_size = _get_cudnn_workspace_size(graph, plan_index)
 
     if workspace_buffer.numel() < workspace_size:
-        workspace_buffer.resize_(workspace_size)
+        workspace_buffer = _grow_workspace(workspace_buffer, workspace_size)
 
     stream = torch.cuda.current_stream(a.device)
 
@@ -3440,7 +3469,7 @@ def execute_cudnn_gemm_mxfp8_graph_override_shape(
         override_strides,
     )
     if workspace.numel() < workspace_size:
-        workspace.resize_(workspace_size)
+        workspace = _grow_workspace(workspace, workspace_size)
 
     if plan_index < 0:
         graph.execute(
@@ -3559,7 +3588,7 @@ def execute_cudnn_gemm_fp8_graph(
 
     workspace_size = _get_cudnn_workspace_size(graph, plan_index)
     if workspace.numel() < workspace_size:
-        workspace.resize_(workspace_size)
+        workspace = _grow_workspace(workspace, workspace_size)
 
     if plan_index < 0:
         graph.execute(variant_pack, workspace, handle=cudnn_handle)
@@ -3698,7 +3727,7 @@ def execute_cudnn_gemm_fp8_graph_override_shape(
         override_strides,
     )
     if workspace.numel() < workspace_size:
-        workspace.resize_(workspace_size)
+        workspace = _grow_workspace(workspace, workspace_size)
 
     if plan_index < 0:
         graph.execute(
@@ -3993,7 +4022,7 @@ def execute_cudnn_gemm_bf16_graph(graph, a, b, bias, c_final, workspace, tactic=
 
     workspace_size = _get_cudnn_workspace_size(graph, plan_index)
     if workspace.numel() < workspace_size:
-        workspace.resize_(workspace_size)
+        workspace = _grow_workspace(workspace, workspace_size)
 
     if plan_index < 0:
         graph.execute(variant_pack, workspace, handle=cudnn_handle)
@@ -4169,7 +4198,7 @@ def execute_cudnn_gemm_bf16_graph_override_shape(
         override_strides,
     )
     if workspace.numel() < workspace_size:
-        workspace.resize_(workspace_size)
+        workspace = _grow_workspace(workspace, workspace_size)
 
     if plan_index < 0:
         graph.execute(

--- a/flashinfer/gemm/gemm_bf16_fp4_cudnn.py
+++ b/flashinfer/gemm/gemm_bf16_fp4_cudnn.py
@@ -23,6 +23,7 @@ from ..fused_moe.utils import (
 from ..utils import _get_cache_buf, get_native_fp4_dtype
 
 from .gemm_base import (
+    _grow_workspace,
     CUDNN_AVAILABLE,
     DEFAULT_WORKSPACE_SIZE,
     UIDs,
@@ -268,7 +269,7 @@ def execute_cudnn_bf16_fp4_graph(
 
     workspace_size = _get_cudnn_workspace_size(graph, plan_index)
     if workspace_buffer.numel() < workspace_size:
-        workspace_buffer.resize_(workspace_size)
+        workspace_buffer = _grow_workspace(workspace_buffer, workspace_size)
 
     stream = torch.cuda.current_stream(a.device)
     handle = _get_cudnn_handle(a.device, stream)
@@ -331,7 +332,7 @@ def execute_cudnn_bf16_fp4_graph_override_shape(
         override_strides,
     )
     if workspace_buffer.numel() < workspace_size:
-        workspace_buffer.resize_(workspace_size)
+        workspace_buffer = _grow_workspace(workspace_buffer, workspace_size)
 
     if plan_index < 0:
         graph.execute(

--- a/flashinfer/utils.py
+++ b/flashinfer/utils.py
@@ -224,6 +224,11 @@ def get_alibi_slopes(
 SINGLE_KERNEL_TMP_SIZE = 32 * 1024 * 1024
 
 _cache_buf: Dict[Tuple[str, torch.device], torch.Tensor] = {}
+# Buffers replaced by a larger allocation. A captured CUDA graph may hold the
+# old buffer's device address as a baked kernel argument, so its storage must
+# outlive any graph that references it; freeing it makes replay fault with a
+# GPU MMU fault (Xid 31). Growth per key is monotone, so this stays small.
+_retired_cache_buf: list = []
 
 
 def _get_cache_buf(
@@ -232,6 +237,8 @@ def _get_cache_buf(
     key = (name, device)
     buf = _cache_buf.get(key)
     if buf is None or buf.size(0) < bytes:
+        if buf is not None:
+            _retired_cache_buf.append(buf)
         if zero_init:
             buf = torch.zeros(bytes, dtype=torch.uint8, device=device)
         else:

--- a/tests/gemm/test_workspace_graph_safety.py
+++ b/tests/gemm/test_workspace_graph_safety.py
@@ -11,7 +11,7 @@ unsafe growth behavior without needing a GPU fault.
 import pytest
 import torch
 
-from flashinfer.utils import _cache_buf, _get_cache_buf
+from flashinfer.utils import _cache_buf, _get_cache_buf, get_compute_capability
 
 SMALL = 8 * 1024 * 1024
 LARGE = 16 * 1024 * 1024
@@ -47,9 +47,7 @@ def test_cache_buf_growth_keeps_graph_referenced_storage_alive():
     assert grown.size(0) >= LARGE
     del buf
 
-    probes = [
-        torch.zeros(SMALL, dtype=torch.uint8, device=device) for _ in range(3)
-    ]
+    probes = [torch.zeros(SMALL, dtype=torch.uint8, device=device) for _ in range(3)]
     graph.replay()
     torch.cuda.synchronize()
     for probe in probes:
@@ -70,6 +68,7 @@ def test_cudnn_fp8_gemm_workspace_growth_preserves_baked_pointer():
     the GEMM result must still be correct.
     """
     cudnn = pytest.importorskip("cudnn")
+    from flashinfer import bmm_fp8
     from flashinfer.gemm.gemm_base import (
         _cudnn_gemm_fp8,
         _get_cudnn_workspace_size,
@@ -78,6 +77,11 @@ def test_cudnn_fp8_gemm_workspace_growth_preserves_baked_pointer():
     )
 
     device = torch.device("cuda:0")
+    major, minor = get_compute_capability(device)
+    if not bmm_fp8.is_backend_supported("cudnn", major * 10 + minor):
+        pytest.skip(
+            f"cuDNN fp8 GEMM not supported on sm{major}{minor}; skipping fp8 graph test"
+        )
     b, m, n, k = 1, 48, 80, 64
     a = (torch.randn(b, m, k, device=device) * 0.1).to(torch.float8_e4m3fn)
     mat2 = (
@@ -118,9 +122,9 @@ def test_cudnn_fp8_gemm_workspace_growth_preserves_baked_pointer():
     _cudnn_gemm_fp8(workspace, a, mat2, a_scale, b_scale, out, out.dtype, tactic)
     torch.cuda.synchronize()
 
-    assert (
-        workspace.data_ptr() == ptr_before and workspace.numel() == 1024
-    ), "workspace growth invalidated the storage captured graphs reference"
+    assert workspace.data_ptr() == ptr_before and workspace.numel() == 1024, (
+        "workspace growth invalidated the storage captured graphs reference"
+    )
 
     graph.replay()
     torch.cuda.synchronize()

--- a/tests/gemm/test_workspace_graph_safety.py
+++ b/tests/gemm/test_workspace_graph_safety.py
@@ -1,0 +1,137 @@
+"""Workspace growth must never invalidate storage a captured CUDA graph references.
+
+Captured graph nodes hold the workspace's raw device address as a baked kernel
+argument. Growing a workspace by freeing-and-reallocating (``resize_()`` /
+cache-entry replacement) leaves every previously captured graph writing into
+memory the allocator may reuse (silent corruption) or unmap (Xid 31 MMU fault
+at replay). Both tests drive pre-existing library entry points and fail on the
+unsafe growth behavior without needing a GPU fault.
+"""
+
+import pytest
+import torch
+
+from flashinfer.utils import _cache_buf, _get_cache_buf
+
+SMALL = 8 * 1024 * 1024
+LARGE = 16 * 1024 * 1024
+SENTINEL = 0x5A
+
+
+def _capture_fill(buf: torch.Tensor) -> torch.cuda.CUDAGraph:
+    """Capture a graph whose only node writes SENTINEL through buf's data_ptr."""
+    stream = torch.cuda.Stream()
+    stream.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(stream):
+        buf.fill_(0)
+    torch.cuda.current_stream().wait_stream(stream)
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        buf.fill_(SENTINEL)
+    return graph
+
+
+def test_cache_buf_growth_keeps_graph_referenced_storage_alive():
+    """Growing a cached workspace must not free the old storage.
+
+    A captured graph plays the role of any captured kernel holding the old
+    buffer's address. With free-on-growth semantics the freed block is
+    reused by the fresh allocations below and replay corrupts them.
+    """
+    name = "test_ws_graph_safety_canary"
+    device = torch.device("cuda:0")
+    buf = _get_cache_buf(name, SMALL, device)
+    graph = _capture_fill(buf)
+
+    grown = _get_cache_buf(name, LARGE, device)
+    assert grown.size(0) >= LARGE
+    del buf
+
+    probes = [
+        torch.zeros(SMALL, dtype=torch.uint8, device=device) for _ in range(3)
+    ]
+    graph.replay()
+    torch.cuda.synchronize()
+    for probe in probes:
+        assert not (probe == SENTINEL).any(), (
+            "graph replay wrote into memory reused by a new allocation: "
+            "workspace growth freed storage a captured graph still references"
+        )
+    _cache_buf.pop((name, device), None)
+
+
+def test_cudnn_fp8_gemm_workspace_growth_preserves_baked_pointer():
+    """A cuDNN fp8 GEMM whose plan outgrows the workspace must not free it.
+
+    Mirrors the production failure: graphs capture the workspace address,
+    then a later execution selects a plan needing more workspace than the
+    buffer holds. The library must satisfy the demand without invalidating
+    the caller-visible tensor (the address captured graphs reference), and
+    the GEMM result must still be correct.
+    """
+    cudnn = pytest.importorskip("cudnn")
+    from flashinfer.gemm.gemm_base import (
+        _cudnn_gemm_fp8,
+        _get_cudnn_workspace_size,
+        _torch_data_type_to_cudnn_data_type,
+        build_cudnn_gemm_fp8_graph,
+    )
+
+    device = torch.device("cuda:0")
+    b, m, n, k = 1, 48, 80, 64
+    a = (torch.randn(b, m, k, device=device) * 0.1).to(torch.float8_e4m3fn)
+    mat2 = (
+        (torch.randn(b, n, k, device=device) * 0.1)
+        .to(torch.float8_e4m3fn)
+        .transpose(-2, -1)
+    )
+    a_scale = torch.ones(1, 1, 1, device=device, dtype=torch.float32)
+    b_scale = torch.ones(1, 1, 1, device=device, dtype=torch.float32)
+    out = torch.empty(b, m, n, device=device, dtype=torch.bfloat16)
+
+    plan_graph = build_cudnn_gemm_fp8_graph(
+        a.shape,
+        a.stride(),
+        mat2.shape,
+        mat2.stride(),
+        _torch_data_type_to_cudnn_data_type(a.dtype),
+        _torch_data_type_to_cudnn_data_type(mat2.dtype),
+        _torch_data_type_to_cudnn_data_type(out.dtype),
+        device,
+        policy=cudnn.build_plan_policy.ALL,
+    )
+    workspace = torch.empty(1024, dtype=torch.uint8, device=device)
+    tactic = next(
+        (
+            t
+            for t in range(plan_graph.get_execution_plan_count())
+            if _get_cudnn_workspace_size(plan_graph, t) > workspace.numel()
+        ),
+        None,
+    )
+    if tactic is None:
+        pytest.skip("no cuDNN plan at this shape needs more than 1KiB workspace")
+
+    graph = _capture_fill(workspace)
+    ptr_before = workspace.data_ptr()
+
+    _cudnn_gemm_fp8(workspace, a, mat2, a_scale, b_scale, out, out.dtype, tactic)
+    torch.cuda.synchronize()
+
+    assert (
+        workspace.data_ptr() == ptr_before and workspace.numel() == 1024
+    ), "workspace growth invalidated the storage captured graphs reference"
+
+    graph.replay()
+    torch.cuda.synchronize()
+    assert (workspace == SENTINEL).all(), "baked pointer no longer writable"
+
+    reference = torch.bmm(a.float(), mat2.float())
+    cos = torch.nn.functional.cosine_similarity(
+        reference.reshape(-1), out.float().reshape(-1), dim=0
+    )
+    assert cos > 0.99
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

Fixes #4398.

Workspace growth currently frees the old device buffer (`workspace.resize_(workspace_size)` in the cuDNN execute paths; cache-entry replacement in `_get_cache_buf`). A CUDA graph captured before the growth holds the old address as a baked kernel argument, so every previously captured graph then replays through freed memory — a GPU MMU fault (Xid 31, `unspecified launch failure` at first replay) when the VA gets unmapped, or silent corruption when the block is reused. See the issue for the full root-cause chain and instrumented evidence.

This PR makes growth **retire-and-replace**: allocate a new buffer, swap it into `_cache_buf`, and keep the old tensor alive in a registry so its storage outlives any graph that references it.

- `flashinfer/utils.py` — `_get_cache_buf` retires grown-over cached buffers into `_retired_cache_buf` instead of dropping them.
- `flashinfer/gemm/gemm_base.py` — new `_grow_workspace()` helper; all 8 `resize_(workspace_size)` sites converted. Long-lived cached buffers (or anything alive while a capture is in progress) are retired; short-lived tensors (autotuner profiling scratch, which is synthesized per profile and never captured) are freed normally, so profiling does not leak.
- `flashinfer/gemm/gemm_bf16_fp4_cudnn.py` — the 2 newer resize sites, same treatment.
- `tests/gemm/test_workspace_graph_safety.py` — two single-GPU regression tests that drive only pre-existing entry points and fail on the unsafe growth **without needing a GPU fault** (CI-safe):
  - `test_cache_buf_growth_keeps_graph_referenced_storage_alive`: capture a graph holding the cached buffer's pointer, grow via `_get_cache_buf`, replay — on unfixed code the freed block is reused by fresh allocations and the replay corrupts them.
  - `test_cudnn_fp8_gemm_workspace_growth_preserves_baked_pointer`: run a real cuDNN fp8 GEMM whose selected plan outgrows the provided workspace — on unfixed code the library `resize_`s the caller-visible tensor in place (pointer/storage invalidated); also asserts GEMM numerics against a `torch.bmm` reference.

Retention is bounded: growth per buffer key is monotone, so the registry holds at most one buffer per distinct high-water mark (in the reproducing workload: exactly one 32 MiB buffer per rank).

## Validation

- Unit tests on 8× RTX PRO 4500 (sm_120), cuDNN 9.19: both tests **fail on stock v0.6.14** with the expected messages and **pass with this patch** (also re-run after restore to exclude ordering artifacts).
- End-to-end at the originally crashing config (vLLM 0.26.0, `bmm_fp8(backend="auto")`, TP8, FP8 per-tensor `nvidia/Llama-3_3-Nemotron-Super-49B-v1_5-FP8`, FULL+PIECEWISE cudagraphs): stock crashed **5/5** at first replay with dmesg Xid 31; with this patch the runs are clean — including runs where the exact hazard event (cuDNN plan demanding 32 MiB + 256 B growing the shared buffer mid-capture-sequence) demonstrably fired and was retired — followed by sustained concurrent inference traffic.

## Notes

- Complementary follow-ups (separate PRs if there's interest): constrain cuDNN plan selection to the buffer budget via `cudnn-frontend`'s `deselect_workspace_greater_than` (mirrors the existing cublas `CUBLASLT_MATMUL_PREF_MAX_WORKSPACE_BYTES` contract), and/or a VA-stable growable workspace on CUDA VMM (`cuMemAddressReserve`/`cuMemMap`) — the latter validated locally as well.
- Root-cause analysis and patch developed with AI assistance; every change and all validation runs were reviewed and executed by the submitter.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workspace expansion during GEMM operations to preserve CUDA graph stability.
  * Prevented previously captured workspace memory from being overwritten when larger buffers are needed.
  * Maintained correct GEMM results across FP4, FP8, MXFP8, and BF16 execution paths.

* **Tests**
  * Added coverage verifying safe workspace growth and preserved CUDA graph pointers.
  * Added validation for cuDNN FP8 GEMM output after workspace expansion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->