### PR TITLE
workaround(monomoe): skip AOT on CUDA < 12.8 to unblock cu126 CI

### DIFF
--- a/flashinfer/aot.py
+++ b/flashinfer/aot.py
@@ -602,7 +602,11 @@ def gen_all_modules(
             # MonoMoe kernel: single-kernel block-FP8 top-K MoE, Hopper
             # (SM90a) only (uses wgmma.mma_async + TMA).  Hard-specialized to
             # the fixed E=256/N=512/K=2048 shape (BS8).
-            jit_specs.append(gen_monomoe_module())
+            # Requires CUDA 12.8+: ptxas 12.6 rejects the TMA instruction
+            # used in tma_load_2d().  A proper PTX fix (shared::cluster form)
+            # is pending in a separate PR.
+            if get_cuda_version() >= Version("12.8"):
+                jit_specs.append(gen_monomoe_module())
         if has_sm100:
             jit_specs.append(gen_fp4_quantization_sm100_module())
             jit_specs.append(gen_cutlass_fused_moe_sm100_module())


### PR DESCRIPTION
## 📌 Description

The monomoe kernel's `tma_load_2d()` in `csrc/fused_moe/monomoe/src/ptx_utils.h` emits

```
cp.async.bulk.tensor.2d.shared::cta.global.tile.mbarrier::complete_tx::bytes
```

Both the `.shared::cta` state space and the `.tile` qualifier were introduced in
**PTX ISA 8.6 / CUDA 12.8**. `ptxas` 12.6 rejects the instruction with:

```
ptxas monomoe_binding.ptx: State space incorrect for instruction 'cp.async.bulk.tensor'
```

This breaks the `aot-build-import (cu126)` job on **every open PR**, blocking main.

This PR is a **minimal safety net**: it wraps `gen_monomoe_module()` in a
`CUDA >= 12.8` guard so older toolchains simply skip the kernel during AOT
codegen. No functional change on CUDA 12.8+, where the kernel is still built.

The **proper fix** — reverting the instruction to the PTX ISA 8.0
`.shared::cluster` form that CUTLASS itself emits for SM90
(`cute/arch/copy_sm90_tma.hpp`) — is in flight separately. Once that lands and
is validated, this guard can be reverted so monomoe is AOT-built on cu126 again.

## 🔍 Related Issues

- Regression introduced by the monomoe kernel rewrite (#4027); surfaced in #4048.
- Proper PTX fix: #4406
- Prior art: the `dcp_alltoall` module carries an equivalent ptxas-12.6
  `cp.async.bulk` workaround (gated via `has_sm100`, which implies CUDA >= 12.8).

## 🚀 Pull Request Checklist

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

This is a build-configuration guard, not a kernel change, so it adds no new
tests. The authoritative check is the `aot-build-import (cu126)` matrix job on
this PR going green. On CUDA 12.8+ the AOT module set is byte-for-byte unchanged.

## Reviewer Notes

Merging this is orthogonal to the proper fix — it only affects which modules AOT
attempts to compile on pre-12.8 toolchains. If you'd rather wait for the real PTX
fix (#4406) and skip the guard entirely, that's reasonable too; this exists so
main isn't blocked while that one is validated on hardware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with older CUDA versions by preventing unsupported MonoMoe AOT module generation.
  * MonoMoe JIT functionality is now used automatically when CUDA 12.8 or newer is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->