### PR TITLE
fix(test): repair MoEFinalizeConfig call site in b12x unified MoE tests (#4395)

### DIFF
--- a/tests/moe/test_unified_moe_b12x.py
+++ b/tests/moe/test_unified_moe_b12x.py
@@ -115,6 +115,7 @@ class TestB12xUnifiedValidation:
         activation=ActivationConfig.swiglu,
         experts=None,
         execution=None,
+        finalize=None,
     ):
         return MoEConfig(
             routing=RoutingConfig(num_experts=8, top_k=2),
@@ -123,6 +124,7 @@ class TestB12xUnifiedValidation:
             activation=activation,
             backend=BackendOptions((backend,)),
             execution=execution or ExecutionConfig(),
+            finalize=finalize or MoEFinalizeConfig(),
         )
 
     @pytest.mark.parametrize("runner_type", (B12xNvfp4Runner, B12xW4A16Runner))


### PR DESCRIPTION
## Problem

rc4 QA on `rtx_5090` fails with:

```
tests.moe.test_unified_moe_b12x.TestB12xUnifiedValidation.test_b12x_does_not_support_unfinalized_output
TypeError: TestB12xUnifiedValidation._config() got an unexpected keyword argument 'finalize'
```

Closes #4395

## Cause

`fe1be4dd` ("split finalize knobs out of `ExecutionConfig` into `MoEFinalizeConfig`", the
release-branch backport of #4385 / issue #4325) rewrote every call site of the form

```python
execution=ExecutionConfig(do_finalize=False),
```

into

```python
finalize=MoEFinalizeConfig(do_finalize=False),
```

That is correct where the call constructs a `MoEConfig`. But
`TestB12xUnifiedValidation.test_b12x_does_not_support_unfinalized_output` does not construct
`MoEConfig` directly — it calls the test class's own `_config()` helper, whose signature only
accepts `execution=`. So the rewrite converted a passing test into a `TypeError` at call time.
The failure is a plain host-side `TypeError` during config construction; no GPU is involved,
which is why it shows up on `rtx_5090` QA as an outright error rather than a skip.

## Fix

Give `_config()` a `finalize=None` keyword and forward `finalize=finalize or MoEFinalizeConfig()`
into `MoEConfig`, mirroring how `execution` is already handled. One-line-shaped change, test-only;
no library code touched.

## Audit of the rest of the rewrite

I checked every site `fe1be4dd` touched, plus grepped the tree for other helpers that could be hit
the same way:

| Site | Receiver of `finalize=` | Verdict |
|---|---|---|
| `tests/moe/test_unified_moe.py:648` (`test_fp8_block_unfinalized_not_supported`) | `TestMoERunnerSupport._nvfp4_swiglu(**overrides)`, which splats straight into `MoEConfig(**base)` | OK |
| `tests/moe_ep/test_constraints.py:273` | `MoEConfig(...)` directly | OK |
| `tests/moe_ep/test_constraints.py:280` | `dataclasses.replace(moe_config, finalize=...)` | OK |
| `tests/moe/test_unified_moe_b12x.py:220` | `TestB12xUnifiedValidation._config(...)` helper | **BROKEN — fixed here** |

Additional greps, all clean:
- `MoEFinalizeConfig(` across `tests/ benchmarks/ docs/ flashinfer/` — the four sites above plus two
  direct-construction repr tests.
- No leftover `ExecutionConfig(... do_finalize ...)` anywhere.
- No leftover `.execution.do_finalize` / `.execution.use_fused_finalize` attribute reads.
- `_config` is the only helper in the tree with an `execution=` keyword parameter
  (`benchmarks/bench_moe_ep.py` forwards `execution=execution` but builds `MoEConfig` directly and
  never passes `finalize`).

So this is the only broken site on this branch.

## Validation (what I actually ran)

On an internal node, inside the `flashinfer-ci-cu130` image with an editable install. The GPU
present was an A100, so the SM120/SM121 b12x GPU tests **skipped**; the failing test and its
neighbours are CPU-only config/support tests, which is exactly where this bug lives.

**Before** (at `d4cd4c76`, rc4):

```
$ python3 -m pytest tests/moe/test_unified_moe_b12x.py -q --no-header -k TestB12xUnifiedValidation
...............F.............                                            [100%]
=================================== FAILURES ===================================
___ TestB12xUnifiedValidation.test_b12x_does_not_support_unfinalized_output ____
    def test_b12x_does_not_support_unfinalized_output(self, monkeypatch):
>       config = self._config(
            B12xNvfp4Config(),
            QuantVariant.NVFP4,
            finalize=MoEFinalizeConfig(do_finalize=False),
        )
E       TypeError: TestB12xUnifiedValidation._config() got an unexpected keyword argument 'finalize'
1 failed, 28 passed, 29 deselected, 2 warnings in 1.22s
```

**After** (this branch):

```
$ python3 -m pytest tests/moe/test_unified_moe_b12x.py -q --no-header -k TestB12xUnifiedValidation
.............................                                            [100%]
29 passed, 29 deselected, 2 warnings in 0.41s

$ python3 -m pytest tests/moe/test_unified_moe_b12x.py tests/moe_ep/test_constraints.py -q --no-header
59 passed, 28 skipped, 2 warnings in 0.41s      # the 28 skips are the SM120/121 GPU classes

$ python3 -m pytest tests/moe/test_unified_moe.py -q --no-header -k "TestReprRoundTrip or TestMoERunnerSupport"
70 passed, 131 deselected, 2 warnings in 0.42s
```

`pre-commit run --files tests/moe/test_unified_moe_b12x.py` passes.

**Not run:** the SM120/SM121 b12x GPU tests (no SM12x silicon available to me) and the rest of the
MoE GPU suites. This change is test-scaffolding only and cannot affect them.

## Companion

The same defect exists on the unmerged main-bound PR #4385; I pushed the equivalent commit
(`96d294a6`) onto that branch rather than opening a second PR against `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)