### PR TITLE
fix(gemm): stop dispatching fp8 groupwise GEMM to the racy small-batch kernel

### DIFF
--- a/csrc/gemm_groupwise_sm100.cu
+++ b/csrc/gemm_groupwise_sm100.cu
@@ -115,8 +115,24 @@ void CutlassGemmGroupwiseScaledSM100(TensorView float_workspace_buffer, TensorVi
               const int k = static_cast<int>(A.size(1));
 
               cudaError_t status;
+              // The small-batch (low-latency) kernel computes D^T = B^T @ A^T so it can use a
+              // 16-wide N tile instead of wasting a 128-wide M tile on m <= 32 rows. That swap
+              // also mirrors the blockwise scale granularities: the per-token (granularity-1)
+              // scale of A becomes a granularity-1 scale along N, i.e. the CUTLASS collective
+              // runs with ScaleMsPerTile == 1 and ScaleNsPerTile == 16 instead of the usual
+              // ScaleMsPerTile == 128 / ScaleNsPerTile == 1.
+              //
+              // That mirrored configuration races in the CUTLASS SM100 blockwise-scaling
+              // mainloop's cp.async scale-factor pipeline: roughly 0.3% of launches consume one
+              // scale-factor column before its cp.async has landed, which corrupts exactly one
+              // output row of one N tile (see flashinfer-ai/flashinfer#4396 - reproduced on
+              // SM103/GB300 for m in [24, 32], never reproduced through the general kernel on
+              // identical inputs). Take the general kernel until CUTLASS is fixed; re-enabling is
+              // a one-line change here once it is.
+              constexpr bool kEnableLowLatencySmallBatch = false;
               // Small-batch-size kernel is not compatible with (scale_granularity_m=128).
-              constexpr bool can_use_small_batch = (SCALE_GRANULARITY_M == 1);
+              constexpr bool can_use_small_batch =
+                  kEnableLowLatencySmallBatch && (SCALE_GRANULARITY_M == 1);
               if (can_use_small_batch && m <= 32) {
                 status = flashinfer::gemm::CutlassGroupwiseScaledGEMMSM100LowLatency<
                     SCALE_GRANULARITY_M, SCALE_GRANULARITY_N, SCALE_GRANULARITY_K, SCALE_MAJOR_K,

--- a/flashinfer/gemm/gemm_base.py
+++ b/flashinfer/gemm/gemm_base.py
@@ -7334,17 +7334,35 @@ def gemm_fp8_nt_groupwise(
                 scale_major_mode,
             )
         elif is_sm100a_supported(a.device):
+            # With MN-major scales SFA is M-contiguous and the SM100 kernel loads it with a
+            # 4-element vector, so `can_implement` rejects any m that is not a multiple of 4
+            # (this is the padding requirement called out in the docstring above). Pad and
+            # slice back rather than making the caller do it; the padded rows are zero, so
+            # they only produce discarded zero output rows.
+            m = a.shape[0]
+            m_padded = (m + 3) // 4 * 4
+            if scale_major_mode == "MN" and m_padded != m:
+                a_in = a.new_zeros((m_padded, a.shape[1]))
+                a_in[:m] = a
+                a_scale_in = a_scale.new_zeros((a_scale.shape[0], m_padded))
+                a_scale_in[:, :m] = a_scale
+                out_in = out.new_empty((m_padded, out.shape[1]))
+            else:
+                a_in, a_scale_in, out_in = a, a_scale, out
+
             get_gemm_sm100_module().gemm_fp8_nt_groupwise(
                 workspace_buffer,
-                a,
+                a_in,
                 b,
-                a_scale,
+                a_scale_in,
                 b_scale,
-                out,
+                out_in,
                 *scale_granularity_mnk,
                 scale_major_mode,
                 mma_sm,
             )
+            if out_in is not out:
+                out.copy_(out_in[:m])
         else:
             raise ValueError(f"Unsupported device for FP8 GEMM: {a.device}")
     elif backend == "trtllm":


### PR DESCRIPTION
## Summary

Closes #4396.

`gemm_fp8_nt_groupwise` (cutlass backend) dispatches `m <= 32` to
`CutlassGroupwiseScaledGEMMSM100LowLatency` (added in #2327). That kernel computes
`D^T = B^T @ A^T` so it can use a 16-wide N tile instead of spending a 128-wide M tile on
`m <= 32` rows. The A/B swap also **mirrors the blockwise scale granularities**, so the CUTLASS
SM100 blockwise-scaling collective runs with `ScaleMsPerTile == 1` / `ScaleNsPerTile == 16`
instead of the usual `ScaleMsPerTile == 128` / `ScaleNsPerTile == 1`.

That mirrored configuration **races** in the collective's `cp.async` scale-factor pipeline
(`sm100_mma_warpspecialized_blockwise_scaling.hpp`, `load_sf`): a scale-factor column is
occasionally consumed before its `cp.async` has landed. Because that scale is shared by every
row of the CTA's M tile, one stale value corrupts **exactly one output row of exactly one N
tile**.

Two commits:

1. Stop dispatching to the small-batch kernel. The kernel and its explicit instantiations are
   left in place, so re-enabling is a one-line change once CUTLASS is fixed.
2. Pad `m` to a multiple of 4 for MN-major scales, so the general kernel can serve the small-`m`
   shapes the removed kernel used to cover (details below).

## Is this a regression?

**No — pre-existing.** The dispatch and the kernel are unchanged since #2327 (Jan 2026), and
`csrc/gemm_groupwise_sm100.cu` / `include/flashinfer/gemm/gemm_groupwise_sm100.cuh` are
byte-identical between `main` and `release-v0.6.17` at rc4. The two commits rc4 adds over rc3 are
MoE-only. It surfaces intermittently because the failure rate is well under 1%, so most CI runs
are green.

## Root-cause evidence

The failure signature is highly specific and matches the CI report:

```
CAUGHT at try 71 seed 71: 124/8192 mismatched      # CI reported 124 / 8192 (1.5%)
  nan in output: False
  max abs diff 0.89844
  bad rows (m) = [1]                               # one output row
  bad row count per row = {1: 124}
  ncols=124 min=0 max=127
  cols//128 = [0]                                  # one 128-wide N block
```

The CI report's cited extremes are `(8, 42)` and `(8, 123)` — same row, same `n < 128` block.

- **Non-deterministic.** Re-running the caught inputs 100x reproduces 0-3 failures, so it is a
  race, not bad data. It is not seed-reproducible, which is why an isolated
  `pytest -k small_batch_size` passes (16 passed) and a full-file run usually does too.
- **The general kernel is clean.** The identical inputs through the non-swap kernel (M padded to
  64) give 0/100 failures.
- **Not architecture-specific.** Also reproduces on B200 / SM100 (148 SM), not only GB300 /
  SM103 (154 SM): `CAUGHT at try 90: 125/8192 mismatched, bad rows (m) = [3], cols//128 = [0]`.
  So an arch gate would not be sufficient.
- **Only the swap-AB path.** `m` 1..23 and 33..40 are clean over 200 seeds each; failures show up
  for `m` in 24..32 and the rate grows with `m` (more scale columns per tile → more chances for
  one to be stale).

Note for anyone trying to replay the CI seed: `torch.randn` on CUDA is not bit-identical across
GPUs with different SM counts, so `manual_seed(0)` does not reproduce CI's exact tensors on a
different box. The repro had to be driven statistically.

## Before / after (measured on hardware)

Harness: `n=256, k=256, scale_major_mode="K"`, `backend="cutlass"`, 6000 invocations per `m`,
compared against the dequantized reference at the test's `atol=rtol=1e-2`.

GB300 (SM103, 154 SM), same node, same script, only the patch differing:

| m | before | after |
|---|--------|-------|
| 24 | 18/6000 | 0/6000 |
| 28 | 25/6000 | 0/6000 |
| 32 | 36/6000 | 0/6000 |
| **total** | **79/18000 (0.44%)** | **0/18000** |

Reproduced on a second GB300: also **0/18000** after the patch.

Test suite on the patched build (GB300):

```
266 passed, 2159 deselected   # -k "(test_fp8_groupwise_gemm and cutlass) or small_batch_size"
16 passed,  2409 deselected   # -k small_batch_size
658 passed, 63 skipped        # full file with the 4096/8192 shapes filtered out
```

## Why the second commit

Falling back to the general kernel initially broke
`test_fp8_groupwise_gemm_small_batch_size[MN-256-{128,256}-1]` with
`can_implement(arguments) failed`. With MN-major scales SFA is M-contiguous and is loaded with a
4-element vector, so the SM100 kernel requires `m % 4 == 0` — the padding requirement already
documented in the `gemm_fp8_nt_groupwise` docstring. It was only ever enforced for `m > 32`,
because below that the swap-AB kernel served those shapes; `m` = 33, 127, 129, 130 have been
raising all along.

Probing the accepted `m` set on GB300:

| scale_major_mode | before | after |
|---|---|---|
| K | all of 1..40, 64, 127, 128, 129, 130 | unchanged |
| MN | only {4, 8, ..., 40, 64, 128} | all of 1..40, 64, 127, 128, 129, 130 |

So this also fixes a pre-existing gap rather than just papering over the fallback. The fast path
is untouched when `m % 4 == 0`, and it follows the pad-and-slice pattern already used in #2261.

## Trade-off

This gives up the 10-40% small-batch speedup from #2327 in exchange for correctness. The proper
fix belongs in the CUTLASS blockwise-scaling collective; flipping `kEnableLowLatencySmallBatch`
back to `true` is all that is needed here once that lands.

## Backport — NOT recommended

~~Should be cherry-picked to `release-v0.6.17`.~~ **Retracted.**

`2bf87713` (#2327, 2026-01-13) is an ancestor of v0.6.13, v0.6.14, v0.6.15, v0.6.16 and
v0.6.16.post2, so this has shipped in at least five releases over ~7 months with **no field
reports** — every sighting is CI (#3944, then #4396). 0.6.17 is therefore not broken relative to
anything users already run, and cherry-picking would trade a rare, never-reported glitch for a
**guaranteed 10-40% small-batch perf regression** landing at rc4/rc5.

Leave `release-v0.6.17` as-is; land the proper fix on `main` for 0.6.18.

**This PR is a draft** while the remedy is decided — see the comments. The diagnosis is settled
(the tolerance is not the problem); what is open is whether to disable the fast path at all, or
repair the CUTLASS scale-factor pipeline and keep #2327's speedup. Commit 2 (the MN-major
`m % 4` padding) has no perf cost and can land independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved SM100 FP8 groupwise GEMM support for inputs whose row count is not divisible by 4.
  - Preserved the expected output shape by removing internal padding before returning results.
  - Routed affected small-batch operations through the general GEMM path for improved reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
