### PR TITLE
test(trace): restore discovery of five silently-skipped trace templates

### DIFF
--- a/tests/trace/test_fi_trace_template_consistency.py
+++ b/tests/trace/test_fi_trace_template_consistency.py
@@ -37,7 +37,10 @@ See the docstring in ``flashinfer/trace/templates/__init__.py`` for the full
 how-to guide.
 """
 
+import contextlib
+import importlib
 import inspect
+import sys
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
 import pytest
@@ -336,6 +339,20 @@ def _collect_template_func_pairs() -> List[Tuple[Callable, TraceTemplate, str]]:
     import flashinfer.prefill  # BatchPrefillWithPagedKVCacheWrapper, Ragged
     import flashinfer.sampling  # noqa: F401  # top_k_sampling_from_probs, etc.
 
+    # The modules below decorate trace templates but require optional
+    # dependencies (cuda-python, cutlass, ...) that may be missing in minimal
+    # environments; skip the ones that cannot import so the structural tests
+    # still run for whatever is available.
+    for mod in (
+        "flashinfer.comm.allreduce",  # allreduce_fusion
+        "flashinfer.comm.dcp_alltoall",  # decode_cp_a2a_alltoall
+        "flashinfer.concat_ops",  # concat_mla_k
+        "flashinfer.cute_dsl.attention.wrappers.batch_mla",  # cute_dsl_batch_mla_run
+        "flashinfer.cute_dsl.attention.wrappers.batch_prefill",  # cute_dsl_batch_prefill_run
+    ):
+        with contextlib.suppress(ImportError):
+            importlib.import_module(mod)
+
     from flashinfer.api_logging import _TRACE_REGISTRY
 
     return list(_TRACE_REGISTRY)
@@ -343,6 +360,38 @@ def _collect_template_func_pairs() -> List[Tuple[Callable, TraceTemplate, str]]:
 
 _ALL_PAIRS = _collect_template_func_pairs()
 _PAIR_IDS = [label for _, _, label in _ALL_PAIRS]
+
+
+def test_formerly_gap_templates_are_discovered():
+    """Regression: every importable trace-decorated module's templates must be
+    discovered by the consistency test (see issue #4367).
+
+    The templates of ``flashinfer.concat_ops`` (``concat_mla_k``),
+    ``flashinfer.comm.allreduce`` (``allreduce_fusion``),
+    ``flashinfer.comm.dcp_alltoall`` (``decode_cp_a2a_alltoall``) and the two
+    ``flashinfer.cute_dsl.attention.wrappers.*`` modules were silently absent
+    from ``_collect_template_func_pairs``. ``concat_mla_k`` is always required
+    in practice because ``flashinfer.concat_ops`` imports only torch; the
+    other labels are required only when their defining module imports
+    (optional deps such as cuda-python/cutlass may be missing in minimal
+    environments).
+    """
+    labels = {label for _, _, label in _ALL_PAIRS}
+    expected: Dict[str, str] = {
+        "flashinfer.concat_ops": "concat_mla_k",
+        "flashinfer.comm.allreduce": "allreduce_fusion",
+        "flashinfer.comm.dcp_alltoall": "decode_cp_a2a_alltoall",
+        "flashinfer.cute_dsl.attention.wrappers.batch_mla": "cute_dsl_batch_mla_run",
+        "flashinfer.cute_dsl.attention.wrappers.batch_prefill": "cute_dsl_batch_prefill_run",
+    }
+    required = set()
+    for module_name, label in expected.items():
+        with contextlib.suppress(ImportError):
+            importlib.import_module(module_name)
+        if module_name in sys.modules:
+            required.add(label)
+    missing = sorted(required - labels)
+    assert not missing, f"missing labels: {missing}"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/trace/test_template_init.py
+++ b/tests/trace/test_template_init.py
@@ -62,6 +62,7 @@ def _collect_pairs() -> List[Tuple[Callable, TraceTemplate, str]]:
         "flashinfer.cascade",
         "flashinfer.comm.allreduce",
         "flashinfer.comm.dcp_alltoall",
+        "flashinfer.concat_ops",
         "flashinfer.decode",
         "flashinfer.fused_moe",
         "flashinfer.gdn_decode",


### PR DESCRIPTION
## 📌 Description

The module inventories in `tests/trace/test_fi_trace_template_consistency.py` and `tests/trace/test_template_init.py` omit five modules decorated with `@flashinfer_api(trace=...)`, so their templates never reach `_TRACE_REGISTRY` and the parametrized tests silently skip: `flashinfer.concat_ops`, `flashinfer.comm.allreduce`, `flashinfer.comm.dcp_alltoall`, `flashinfer.cute_dsl.attention.wrappers.batch_mla`, and `flashinfer.cute_dsl.attention.wrappers.batch_prefill`.

This PR adds the five missing imports (each wrapped in `contextlib.suppress(ImportError)` so optional deps such as cuda-python/cutlass stay optional), adds `flashinfer.concat_ops` to `_MODULES`, and adds a regression test asserting the five labels are discovered.

Note: the literal test reported in #4367 (`test_registration_module_inventory_is_complete`) was already removed from `main` by revert #4344 before the issue was filed. This PR restores equivalent guard coverage for the same class of bug — incomplete inventory → tests silently skip.

## 🔍 Related Issues

- Closes #4367

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

The regression test fails on a clean BASE (missing exactly the 5 labels) and passes with the fix; both files run `823 passed, 169 skipped`.

## Reviewer Notes

This contribution was developed with AI assistance for code search, drafting, and implementation.

- The `tests/trace/` failure set is byte-identical to BASE (68 pre-existing GPU `*_reference_correctness.py` failures, unrelated).
- #4359 rewrites these two files as part of a larger sharding rework; this PR is an independent smaller fix, merge order left to maintainers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added regression coverage for discovering trace templates from optionally available modules.
  * Improved initialization consistency checks to include templates registered by concatenation operations.
  * Optional dependencies are now safely skipped when unavailable during test discovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
