### PR TITLE
[MoE] Allow caller-owned output in CuTeDSL wrapper

### DIFF
--- a/flashinfer/fused_moe/cute_dsl/fused_moe.py
+++ b/flashinfer/fused_moe/cute_dsl/fused_moe.py
@@ -113,6 +113,40 @@ def _intermediate_c_dtype(output_dtype: torch.dtype) -> str:
     )
 
 
+def _validate_moe_output(
+    moe_output: torch.Tensor,
+    *,
+    num_tokens: int,
+    hidden_size: int,
+    output_dtype: torch.dtype,
+    device: torch.device,
+) -> None:
+    expected_shape = (num_tokens, hidden_size)
+    if tuple(moe_output.shape) != expected_shape:
+        raise ValueError(
+            f"moe_output must have shape {expected_shape}, "
+            f"got {tuple(moe_output.shape)}"
+        )
+    if moe_output.dtype != output_dtype:
+        raise TypeError(
+            f"moe_output must have dtype {output_dtype}, got {moe_output.dtype}"
+        )
+    if moe_output.device != device:
+        raise ValueError(
+            f"moe_output must be on device {device}, got {moe_output.device}"
+        )
+    if moe_output.layout != torch.strided:
+        raise ValueError(
+            "moe_output must use torch.strided layout, "
+            f"got layout={moe_output.layout}"
+        )
+    if not moe_output.is_contiguous():
+        raise ValueError(
+            "moe_output must be contiguous, "
+            f"got stride={moe_output.stride()}"
+        )
+
+
 def _get_cuda_graph_resources() -> Dict[str, Any]:
     """Get or create pre-allocated CUDA events and streams.
 
@@ -741,6 +775,7 @@ class CuteDslMoEWrapper:
         tactic: Optional[Tuple] = None,
         *,
         per_token_scale: Optional[torch.Tensor] = None,
+        moe_output: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
         r"""Run the CuTe-DSL NVFP4 fused-MoE forward pass.
 
@@ -781,6 +816,11 @@ class CuteDslMoEWrapper:
             tuner.
         per_token_scale : Optional[torch.Tensor]
             Optional W4A4 per-token input row scale for GEMM1.
+        moe_output : Optional[torch.Tensor]
+            Caller-owned output tensor of shape ``[num_tokens, hidden_size]``.
+            It must match the wrapper output dtype and input device and use a
+            contiguous strided layout. Both W4A4 and W4A16 runners write their
+            final output directly into this tensor when provided.
 
         Returns
         -------
@@ -789,11 +829,20 @@ class CuteDslMoEWrapper:
         """
         num_tokens = token_selected_experts.size(0)
 
-        moe_output = torch.empty(
-            (num_tokens, self.hidden_size),
-            dtype=self.output_dtype,
-            device=x.device,
-        )
+        if moe_output is None:
+            moe_output = torch.empty(
+                (num_tokens, self.hidden_size),
+                dtype=self.output_dtype,
+                device=x.device,
+            )
+        else:
+            _validate_moe_output(
+                moe_output,
+                num_tokens=num_tokens,
+                hidden_size=self.hidden_size,
+                output_dtype=self.output_dtype,
+                device=x.device,
+            )
 
         # Use auto-tuner for tactic selection
         tuner = AutoTuner.get()

--- a/tests/moe/test_cute_dsl_fused_moe.py
+++ b/tests/moe/test_cute_dsl_fused_moe.py
@@ -1892,6 +1892,130 @@ class TestCuteDslMoEWrapper:
 
     pytestmark = _requires_dsl_arch
 
+    @staticmethod
+    def _caller_output_case(quant_mode: str, *, use_cuda_graph: bool = False):
+        from flashinfer import CuteDslMoEWrapper
+
+        num_tokens, hidden_size, intermediate_size = 128, 256, 512
+        num_experts, top_k = 256, 2
+        tensors = create_moe_tensors(
+            num_tokens=num_tokens,
+            hidden_size=hidden_size,
+            intermediate_size=intermediate_size,
+            num_experts=num_experts,
+            num_local_experts=num_experts,
+            top_k=top_k,
+        )
+        api_inputs, _ = _prepare_moe_quant_mode_inputs(tensors, quant_mode)
+        moe = CuteDslMoEWrapper(
+            num_experts=num_experts,
+            top_k=top_k,
+            hidden_size=hidden_size,
+            intermediate_size=intermediate_size,
+            use_cuda_graph=use_cuda_graph,
+            quant_mode=quant_mode,
+        )
+        run_kwargs = dict(
+            token_selected_experts=tensors["token_selected_experts"],
+            token_final_scales=tensors["token_final_scales"],
+            w1_weight=tensors["w1_weight"],
+            w1_weight_sf=tensors["w1_weight_sf"],
+            w1_alpha=tensors["w1_alpha"],
+            w2_weight=tensors["w2_weight"],
+            w2_weight_sf=tensors["w2_weight_sf"],
+            w2_alpha=tensors["w2_alpha"],
+            **api_inputs,
+        )
+        return moe, run_kwargs, num_tokens, hidden_size
+
+    @pytest.mark.parametrize("quant_mode", _MOE_QUANT_MODES)
+    def test_wrapper_caller_owned_output(self, quant_mode: str):
+        """Both wrapper runners write into caller-owned final storage."""
+        moe, run_kwargs, num_tokens, hidden_size = self._caller_output_case(quant_mode)
+        output = torch.full(
+            (num_tokens, hidden_size),
+            float("nan"),
+            device="cuda",
+            dtype=torch.bfloat16,
+        )
+
+        result = moe.run(**run_kwargs, moe_output=output)
+
+        assert result.data_ptr() == output.data_ptr()
+        assert not torch.isnan(result).any()
+        assert not torch.isinf(result).any()
+
+    @pytest.mark.parametrize("quant_mode", _MOE_QUANT_MODES)
+    def test_wrapper_caller_owned_output_cuda_graph(self, quant_mode: str):
+        """Caller-owned final storage remains stable across graph replay."""
+        moe, run_kwargs, num_tokens, hidden_size = self._caller_output_case(
+            quant_mode, use_cuda_graph=True
+        )
+        output = torch.empty(
+            (num_tokens, hidden_size), device="cuda", dtype=torch.bfloat16
+        )
+        for _ in range(3):
+            result = moe.run(**run_kwargs, moe_output=output)
+        torch.cuda.synchronize()
+        assert result.data_ptr() == output.data_ptr()
+
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph):
+            captured = moe.run(**run_kwargs, moe_output=output)
+        assert captured.data_ptr() == output.data_ptr()
+
+        graph.replay()
+        torch.cuda.synchronize()
+        first = output.clone()
+        graph.replay()
+        torch.cuda.synchronize()
+
+        assert not torch.isnan(output).any()
+        assert (first - output).abs().max().item() < 0.5
+
+    @pytest.mark.parametrize(
+        "invalid_output,error_type,error_match",
+        [
+            ("shape", ValueError, "must have shape"),
+            ("dtype", TypeError, "must have dtype"),
+            ("device", ValueError, "must be on device"),
+            ("noncontiguous", ValueError, "must be contiguous"),
+            ("layout", ValueError, "must use torch.strided layout"),
+        ],
+    )
+    def test_wrapper_caller_owned_output_validation(
+        self, invalid_output: str, error_type: type[Exception], error_match: str
+    ):
+        """Reject caller output that cannot safely back the final kernel."""
+        moe, run_kwargs, num_tokens, hidden_size = self._caller_output_case("w4a4")
+        if invalid_output == "shape":
+            output = torch.empty(
+                (num_tokens + 1, hidden_size), device="cuda", dtype=torch.bfloat16
+            )
+        elif invalid_output == "dtype":
+            output = torch.empty(
+                (num_tokens, hidden_size), device="cuda", dtype=torch.float16
+            )
+        elif invalid_output == "device":
+            output = torch.empty(
+                (num_tokens, hidden_size), device="cpu", dtype=torch.bfloat16
+            )
+        elif invalid_output == "noncontiguous":
+            output = torch.empty(
+                (num_tokens, hidden_size * 2),
+                device="cuda",
+                dtype=torch.bfloat16,
+            )[:, ::2]
+        else:
+            output = torch.zeros(
+                (num_tokens, hidden_size),
+                device="cuda",
+                dtype=torch.bfloat16,
+            ).to_sparse()
+
+        with pytest.raises(error_type, match=error_match):
+            moe.run(**run_kwargs, moe_output=output)
+
     @pytest.mark.parametrize("num_tokens", [128, 256, 512])
     @pytest.mark.parametrize("use_fused_finalize", [False, True])
     @pytest.mark.parametrize(


### PR DESCRIPTION
## What changed

Add an optional `moe_output` argument to `CuteDslMoEWrapper.run()`.

When supplied, the wrapper passes that caller-owned tensor through the existing
mode-specific runner and GEMM2 finalize path. Both W4A4 and W4A16 write into
the supplied tensor. When omitted, behavior is unchanged: the wrapper allocates
its output tensor as before.

Caller-owned output is rejected unless its shape, dtype, device, and dense
contiguous layout match the wrapper contract.

## Why

Communication runtimes such as FlashInfer A2A already own the final combine
workspace. The CuTeDSL wrapper's internal implementation can write into a
preallocated output, but the public CUDA-graph-capable wrapper did not expose
that capability. Callers therefore had to materialize a separate MoE output
and copy it into the communication workspace.

This is the simple final-output counterpart to the expanded owner-layout work
in #4268. It does not change routing or owner layout.

## Validation

- Rebased onto current `main`, including the newer W4A4/W4A16 wrapper.
- Caller-owned storage identity and output validity on one GB200 for W4A4 and
  W4A16: 2 passed.
- CUDA graph capture and repeated replay for W4A4 and W4A16: 2 passed.
- Invalid shape, dtype, device, non-contiguous layout, and sparse layout are
  rejected before runner invocation: 5 passed.
- Existing allocation behavior remains the default when `moe_output` is absent.

Focused operator experiment on one GB200 with H=7168, top-k=16, 32 experts,
intermediate=512, and 200 timed iterations per cell:

| Tokens | Owned output + copy | Direct-output saving |
| ---: | ---: | ---: |
| 1 | 388.6-394.8 us | 37.2-40.0 us (9.58-10.15%) |
| 4 | 387.6-394.1 us | 34.9-41.0 us (9.00-10.57%) |
| 16 | 388.6-392.0 us | 32.5-42.8 us (8.30-10.92%) |
| 64 | 388.7-404.6 us | 37.2-45.4 us (9.52-11.23%) |
| 256 | 387.9-391.6 us | 35.5-40.7 us (9.07-10.39%) |

These measurements were repeated after the current-main rebase, using three
separate processes. This is operator-only evidence, not a serving E2E claim.
The reduced expert shape intentionally isolates the output boundary.

AI assistance was used for implementation, testing, benchmarking, and PR
preparation. The submitting human should understand and be able to defend the
change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for supplying a preallocated output buffer when running fused mixture-of-experts operations.
  * Preserves the provided buffer during execution, including CUDA graph capture and replay.
* **Bug Fixes**
  * Added validation for output shape, data type, device, layout, and contiguity.
  * Invalid output buffers are now rejected with clear validation errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->