### PR TITLE
fix(gemm): gate cuDNN out of fp8_gemm_sm100 on SM12x

### DIFF
--- a/flashinfer/gemm/gemm_base.py
+++ b/flashinfer/gemm/gemm_base.py
@@ -1701,7 +1701,31 @@ def fp8_gemm_sm100(
     if "cublas" in runner_names:
         runners.append(get_gemm_module().cublas_fp8_gemm_runner())
     if "cudnn" in runner_names:
-        runners.append(_cudnn_gemm_fp8_runner())
+        # On SM12x without override_shape (cuDNN backend < 9.23.1) cuDNN builds
+        # a fresh ``policy=ALL`` execution graph for every distinct problem
+        # shape. At serving time, where the token count changes almost every
+        # step, that is unbounded host-side work and each build also loads a
+        # CUDA module that is never released, so device memory grows for the
+        # lifetime of the process. Same condition ``bmm_fp8`` auto already
+        # gates on (#4165); repeated here because callers can reach this
+        # helper with an explicitly built runner list that never passes
+        # through the ``bmm_fp8`` heuristic. Only skipped when another runner
+        # is available, so an explicit cuDNN-only request still works.
+        if (
+            runners
+            and _match_sm_version(a.device, ["120", "121"])
+            and not _is_cudnn_override_shape_available()
+        ):
+            if "fp8_gemm_sm100" not in _CUDNN_SM12X_SKIP_LOGGED:
+                _CUDNN_SM12X_SKIP_LOGGED.add("fp8_gemm_sm100")
+                logger.warning(
+                    "Skipping cuDNN in fp8_gemm candidates on SM12x: "
+                    "override_shape unavailable (cuDNN backend < 9.23.1); "
+                    "per-shape policy=ALL graph build is unbounded at serving "
+                    "time and leaks a CUDA module per build."
+                )
+        else:
+            runners.append(_cudnn_gemm_fp8_runner())
     assert runners, "No suitable runners found"
 
     inputs = [a, b, scale_a, scale_b, out, workspace_buffer]

--- a/tests/autotuner/test_autotuner_bmm_fp8.py
+++ b/tests/autotuner/test_autotuner_bmm_fp8.py
@@ -248,3 +248,71 @@ def test_bmm_fp8_heuristic_gates_cudnn_on_sm12x_without_override_shape(monkeypat
 
     # override_shape available -> cuDNN retained.
     assert "cudnn" in call(override_shape_available=True)
+
+
+def test_fp8_gemm_sm100_gates_cudnn_on_sm12x_without_override_shape(monkeypatch):
+    """``fp8_gemm_sm100`` must apply the same SM12x/override_shape gate as the
+    ``bmm_fp8`` auto heuristic (#4165).
+
+    Callers can reach this helper with an already-built runner-name list that
+    never passed through ``_heuristic_func_bmm_fp8``, so the gate is repeated
+    here. Without ``override_shape`` (cuDNN backend < 9.23.1) each distinct
+    problem shape triggers a fresh ``policy=ALL`` graph build, and every build
+    also loads a CUDA module that is never released -- device memory grows for
+    the lifetime of the process.
+
+    An explicit cuDNN-only request is still honoured, so opting in deliberately
+    keeps working. SM version and cuDNN availability are monkeypatched so this
+    runs on any host.
+    """
+    monkeypatch.setattr(gemm_base, "_match_sm_version", lambda dev, vers: "120" in vers)
+
+    cudnn_runner = object()
+    cutlass_runner = object()
+    seen = {}
+
+    class _FakeTuner:
+        def choose_one(self, name, runners, config, inputs):
+            seen["runners"] = list(runners)
+            return (lambda inputs, tactic: None), 0
+
+    class _FakeAutoTuner:
+        @staticmethod
+        def get():
+            return _FakeTuner()
+
+    class _FakeCutlassModule:
+        @staticmethod
+        def cutlass_fp8_gemm_runner():
+            return cutlass_runner
+
+    monkeypatch.setattr(gemm_base, "AutoTuner", _FakeAutoTuner)
+    monkeypatch.setattr(gemm_base, "_cudnn_gemm_fp8_runner", lambda: cudnn_runner)
+    monkeypatch.setattr(
+        gemm_base, "get_gemm_sm120_module_cutlass_fp8", lambda: _FakeCutlassModule
+    )
+
+    t = torch.empty(1, 1, 1)
+
+    def call(runner_names, override_shape_available):
+        monkeypatch.setattr(
+            gemm_base,
+            "_is_cudnn_override_shape_available",
+            lambda: override_shape_available,
+        )
+        gemm_base.fp8_gemm_sm100(t, t, t, t, t, t, runner_names)
+        return seen["runners"]
+
+    both = ["cutlass_sm12x", "cudnn"]
+
+    # override_shape unavailable -> cuDNN dropped, cutlass retained.
+    runners = call(both, override_shape_available=False)
+    assert cudnn_runner not in runners
+    assert cutlass_runner in runners
+
+    # override_shape available -> cuDNN retained.
+    assert cudnn_runner in call(both, override_shape_available=True)
+
+    # Explicit cuDNN-only request is still honoured even when gated, so the
+    # "No suitable runners found" assertion can never be tripped by the gate.
+    assert cudnn_runner in call(["cudnn"], override_shape_available=False)


### PR DESCRIPTION
## 📌 Description

#4165 gated cuDNN out of the `bmm_fp8` `auto` candidates on SM12x when `override_shape` is unavailable, but the gate lives inside `_heuristic_func_bmm_fp8`. `fp8_gemm_sm100()` still does:

```python
if "cudnn" in runner_names:
    runners.append(_cudnn_gemm_fp8_runner())
```

so any caller that reaches this helper with an already-built `runner_names` list — rather than through the `bmm_fp8` heuristic — keeps the pre-#4165 behaviour. This PR applies the same condition there.

Beyond the unbounded host-side `policy=ALL` build per shape that #4165 describes, I measured a second consequence of the same rebuild loop on an SM120 (RTX PRO 6000) serving deployment: **each graph build also loads a CUDA module that is never released**, so native device memory grows for the lifetime of the process.

Measured with a CUPTI injection library (`CUDA_INJECTION64_PATH`), cuDNN backend `91701`, FlashInfer 0.6.14, continuous batching so M changes almost every step:

| | cuDNN FP8 GEMM | after switching that layer off cuDNN |
| --- | --- | --- |
| CUPTI `MODULE_LOADED` | ~150/min, no plateau | plateaus (~546 total, then flat) |
| CUPTI `MODULE_UNLOAD_STARTING` | **0** for the whole process lifetime | 0 |
| device memory (`nvidia-smi`, engine pid) | **+~10 MiB/min**, unbounded | flat over 12 h |

The activity records also show the growth as unfreed `CUPTI_ACTIVITY_MEMORY_KIND_DEVICE_STATIC` allocations — static `__device__` storage, which is what arrives with a module load — which is what pointed at module loading rather than a tensor-level leak. It is invisible to the torch caching allocator, and to `cuMemAlloc`/`cudaMalloc` interposition, because module loading goes through neither.

The gate only applies when at least one other runner is already registered, so an explicit cuDNN-only request is still honoured and the `assert runners, "No suitable runners found"` cannot be tripped by it.

## 🔍 Related Issues

- #4165 — the `bmm_fp8` auto gate this mirrors (same condition, sibling entry point)
- #3920 — RFC, runner-contract rule 6

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

`test_fp8_gemm_sm100_gates_cudnn_on_sm12x_without_override_shape` added next to #4165's test, in the same monkeypatched style so it needs no SM12x hardware or cuDNN install. It covers all three cases: gated when `override_shape` is unavailable, retained when it is available, and retained for an explicit cuDNN-only request.

Verified it fails without the `gemm_base.py` change and passes with it. The rest of that file's tests need a CUDA build of torch, so they were not run locally.

## Reviewer Notes

Two things worth a look:

1. **Placement.** I repeated the condition rather than factoring it into a shared helper with `_heuristic_func_bmm_fp8`, to keep the diff small and avoid touching recently merged code. Happy to extract a helper if you'd prefer one.
2. **The "other runner available" carve-out.** It keeps an explicit `backend="cudnn"` working rather than silently overriding a deliberate choice. If you'd rather gate unconditionally and let the assertion fire, that is a one-line change — but it would turn an explicit opt-in into a hard failure on SM12x.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved FP8 GEMM runner selection on SM12x systems when cuDNN lacks override-shape support.
  * Preserves cuDNN when it is the only available option and honors explicit cuDNN requests.
  * Added a warning when cuDNN is excluded.

* **Tests**
  * Added regression coverage for cuDNN availability and selection scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->