### PR TITLE
feat(cascade): expose merge support checks

### DIFF
--- a/flashinfer/cascade.py
+++ b/flashinfer/cascade.py
@@ -29,7 +29,21 @@ from .trace.templates.cascade import (
     merge_state_trace,
     merge_states_trace,
 )
-from .utils import register_custom_op, register_fake_op
+from .utils import (
+    backend_requirement,
+    register_custom_op,
+    register_fake_op,
+    supported_compute_capability,
+)
+
+
+_CASCADE_SUPPORTED_CCS = [75, 80, 86, 89, 90, 100, 103, 107, 110, 120, 121]
+
+
+@supported_compute_capability(_CASCADE_SUPPORTED_CCS)
+def _cascade_merge_requirement(*_args, **_kwargs) -> bool:
+    """Cascade merge kernels use the generic CUDA path on supported SM tiers."""
+    return True
 
 
 @functools.cache
@@ -38,6 +52,7 @@ def get_cascade_module():
 
 
 @flashinfer_api(trace=merge_state_trace)
+@backend_requirement(backend_checks={}, common_check=_cascade_merge_requirement)
 @register_custom_op("flashinfer::merge_state", mutates_args=())
 def merge_state(
     v_a: torch.Tensor, s_a: torch.Tensor, v_b: torch.Tensor, s_b: torch.Tensor
@@ -105,6 +120,7 @@ def _fake_merge_state(
 
 
 @flashinfer_api(trace=merge_state_in_place_trace)
+@backend_requirement(backend_checks={}, common_check=_cascade_merge_requirement)
 @register_custom_op("flashinfer::merge_state_in_place", mutates_args=("v", "s"))
 def merge_state_in_place(
     v: torch.Tensor,
@@ -166,6 +182,7 @@ def _fake_merge_state_in_place(
 
 
 @flashinfer_api(trace=merge_states_trace)
+@backend_requirement(backend_checks={}, common_check=_cascade_merge_requirement)
 @register_custom_op("flashinfer::merge_states", mutates_args=())
 def merge_states(v: torch.Tensor, s: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
     r"""Merge multiple attention states (v, s).

--- a/tests/attention/test_cascade_support_checks.py
+++ b/tests/attention/test_cascade_support_checks.py
@@ -1,0 +1,28 @@
+import pytest
+
+import flashinfer
+
+
+_CASCADE_MERGE_APIS = (
+    flashinfer.merge_state,
+    flashinfer.merge_state_in_place,
+    flashinfer.merge_states,
+)
+
+
+@pytest.mark.parametrize(
+    "api",
+    _CASCADE_MERGE_APIS,
+    ids=lambda api: api.__name__,
+)
+def test_cascade_merge_support_checks(api):
+    assert hasattr(api, "is_compute_capability_supported")
+    assert hasattr(api, "has_backend_choices")
+
+    assert api.is_compute_capability_supported(75)
+    assert api.is_compute_capability_supported(86)
+    assert api.is_compute_capability_supported(107)
+    assert api.is_compute_capability_supported(121)
+    assert not api.is_compute_capability_supported(70)
+
+    assert not api.has_backend_choices()


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

Add support-check metadata to the cascade merge APIs:

- `merge_state`
- `merge_state_in_place`
- `merge_states`

All three APIs now expose `is_compute_capability_supported()` and
`has_backend_choices()` through the existing `backend_requirement`
infrastructure. The published compute-capability tiers match the generic CUDA
JIT component used by these kernels. This does not change kernel dispatch,
signatures, or numerical behavior.

## 🔍 Related Issues

Refs #2225

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

Targeted validation on an NVIDIA RTX 3090 (SM86):

- `3 passed` for the new support-check metadata test.
- `6 passed` for the three merge-state trace/reference test modules through the real CUDA JIT kernel path.
- `1 passed, 192 deselected` for the shared-prefix `merge_state` integration case.
- Final combined post-sync run: `10 passed, 192 deselected`.
- Triton cascade tests: `4 skipped` because that backend requires SM90; this PR does not change the Triton backend.

The full repository test suite was not run.

## Reviewer Notes

Physical GPU validation covers SM86. The other advertised tiers follow the
current generic JIT supported-compute-capability list and were not physically
tested. No benchmark was run because this is metadata-only and does not alter
the execution path.

AI-assisted contribution; the author reviewed the implementation, test
coverage, and kernel results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added support checks for cascade merge operations based on the device’s compute capability.
  * Improved backend selection behavior by preventing unsupported backends from being chosen.

* **Tests**
  * Added coverage for supported and unsupported compute capabilities across cascade merge operations.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->