### PR TITLE
fix(gdn): handle padded inputs in SM100 CP prefill

### DIFF
--- a/flashinfer/gdn_kernels/blackwell/gated_delta_net_cp.py
+++ b/flashinfer/gdn_kernels/blackwell/gated_delta_net_cp.py
@@ -7,6 +7,7 @@ import cutlass.cute as cute
 import cutlass.pipeline as pipeline
 import cutlass.utils as utils
 import cutlass.utils.blackwell_helpers as sm100_utils
+from cutlass.utils import TensorMapManager, TensorMapUpdateMode
 from cutlass.cute.nvgpu import OperandMajorMode, cpasync, tcgen05
 
 from ..delta_rule_dsl.alpha import AlphaProcessor
@@ -20,6 +21,9 @@ from ..delta_rule_dsl.varlen_helper import (
 
 class CPDeltaRuleMNPrecomputeUtcmma1Sm100(KeyedCompileMixin):
     """Compute local CP transfer/state while keeping both recurrences in TMEM."""
+
+    bytes_per_tensormap = 128
+    num_tensormaps = 2
 
     def __init__(
         self,
@@ -163,6 +167,8 @@ class CPDeltaRuleMNPrecomputeUtcmma1Sm100(KeyedCompileMixin):
         is_transfer: bool,
         cta_coord,
         cta_layout,
+        tensormap_manager,
+        tensormap_ptr,
     ):
         handle = tensor_pipeline.acquire_and_advance()
         sTensor_stage = sTensor[None, None, handle.index]
@@ -185,8 +191,39 @@ class CPDeltaRuleMNPrecomputeUtcmma1Sm100(KeyedCompileMixin):
             cute.group_modes(sTensor_stage, 0, 2),
             cute.group_modes(gTensor, 0, 2),
         )
-        cute.copy(tma_atom, tTgT, tTsT, tma_bar_ptr=handle.barrier)
+        if cutlass.const_expr(is_transfer):
+            cute.copy(tma_atom, tTgT, tTsT, tma_bar_ptr=handle.barrier)
+        else:
+            if blk == 0:
+                tensormap_manager.fence_tensormap_update(tensormap_ptr)
+            cute.copy(
+                tma_atom,
+                tTgT,
+                tTsT,
+                tma_bar_ptr=handle.barrier,
+                tma_desc_ptr=tensormap_manager.get_tensormap_ptr(
+                    tensormap_ptr, cute.AddressSpace.generic
+                ),
+            )
         return tensor_pipeline
+
+    @cute.jit
+    def initialize_tensormap_workspace(self, workspace, grid_dim):
+        return cute.make_tensor(
+            workspace.iterator,
+            cute.make_layout(
+                (
+                    grid_dim[0] * grid_dim[1] * grid_dim[2],
+                    self.num_tensormaps,
+                    self.bytes_per_tensormap,
+                ),
+                stride=(
+                    self.num_tensormaps * self.bytes_per_tensormap,
+                    self.bytes_per_tensormap,
+                    1,
+                ),
+            ),
+        )
 
     @cute.jit
     def run_load_alpha_role_sm100(
@@ -933,6 +970,7 @@ class CPDeltaRuleMNPrecomputeUtcmma1Sm100(KeyedCompileMixin):
         total_cp_chunks: cutlass.Int32,
         max_cp_chunks_per_seq: cutlass.Int32,
         num_seqs: cutlass.Int32,
+        g_tensormap_workspace: cute.Tensor,
         stream,
     ):
         def make_mma(mnk, source_a, a_major, b_major):
@@ -1079,10 +1117,13 @@ class CPDeltaRuleMNPrecomputeUtcmma1Sm100(KeyedCompileMixin):
             tma_tensor_v,
             tma_atom_t,
             tma_tensor_t,
+            g_k,
+            g_v,
             g_alpha,
             g_transfer_t,
             g_state_t,
             g_cu_seqlens,
+            g_tensormap_workspace,
             k_layout,
             k_trans_layout,
             v_layout,
@@ -1124,10 +1165,13 @@ class CPDeltaRuleMNPrecomputeUtcmma1Sm100(KeyedCompileMixin):
         tma_tensor_v,
         tma_atom_t,
         tma_tensor_t,
+        g_k,
+        g_v,
         g_alpha,
         g_transfer_t,
         g_state_t,
         g_cu_seqlens,
+        g_tensormap_workspace,
         k_layout,
         k_trans_layout,
         v_layout,
@@ -1162,6 +1206,25 @@ class CPDeltaRuleMNPrecomputeUtcmma1Sm100(KeyedCompileMixin):
         t_blocks_per_cp_chunk = cute.ceil_div(chunk_len, self.BLK)
         t_block_start = varlen_chunk_idx(
             seq_idx, seq_start, chunk_idx_in_seq * t_blocks_per_cp_chunk, self.BLK
+        )
+
+        grid_dim = cute.arch.grid_dim()
+        cta_linear_idx = (
+            cute.arch.block_idx()[2] * grid_dim[1] * grid_dim[0]
+            + seq_idx * grid_dim[0]
+            + bx
+        )
+        tensormap_manager = TensorMapManager(
+            TensorMapUpdateMode.GMEM, self.bytes_per_tensormap
+        )
+        g_tensormap_workspace = self.initialize_tensormap_workspace(
+            g_tensormap_workspace, grid_dim
+        )
+        tensormap_k_ptr = tensormap_manager.get_tensormap_ptr(
+            g_tensormap_workspace[(cta_linear_idx, 0, None)].iterator
+        )
+        tensormap_v_ptr = tensormap_manager.get_tensormap_ptr(
+            g_tensormap_workspace[(cta_linear_idx, 1, None)].iterator
         )
 
         allocator = utils.SmemAllocator()
@@ -1459,6 +1522,37 @@ class CPDeltaRuleMNPrecomputeUtcmma1Sm100(KeyedCompileMixin):
             )
         elif is_valid_chunk and warp_idx == self.tma_warp_id:
             cute.arch.setmaxregister_decrease(self.num_regs_other)
+            tensormap_manager.init_tensormap_from_atom(
+                tma_atom_k, tensormap_k_ptr, self.tma_warp_id
+            )
+            tensormap_manager.init_tensormap_from_atom(
+                tma_atom_v, tensormap_v_ptr, self.tma_warp_id
+            )
+            tensormap_manager.fence_tensormap_initialization()
+
+            # Bound K/V by the logical end read from device cu_seqlens.  The
+            # physical tensors may contain collective padding after seq_end.
+            bounded_k = cute.make_tensor(
+                g_k.iterator,
+                cute.make_layout(
+                    (g_k.shape[0], seq_end, g_k.shape[2]),
+                    stride=(g_k.stride[0], g_k.stride[1], g_k.stride[2]),
+                ),
+            )
+            bounded_v = cute.make_tensor(
+                g_v.iterator,
+                cute.make_layout(
+                    (g_v.shape[0], seq_end, g_v.shape[2]),
+                    stride=(g_v.stride[0], g_v.stride[1], g_v.stride[2]),
+                ),
+            )
+            tensormap_manager.update_tensormap(
+                (bounded_k, bounded_v),
+                (tma_atom_k, tma_atom_v),
+                (tensormap_k_ptr, tensormap_v_ptr),
+                self.tma_warp_id,
+                (None, None),
+            )
             for blk in cutlass.range(num_blocks, unroll=1):
                 load_k_producer = self.load_tensor_block_tma_sm100(
                     tma_atom_k,
@@ -1472,6 +1566,8 @@ class CPDeltaRuleMNPrecomputeUtcmma1Sm100(KeyedCompileMixin):
                     False,
                     tensor_cta_coord,
                     tensor_cta_layout,
+                    tensormap_manager,
+                    tensormap_k_ptr,
                 )
                 load_v_producer = self.load_tensor_block_tma_sm100(
                     tma_atom_v,
@@ -1485,6 +1581,8 @@ class CPDeltaRuleMNPrecomputeUtcmma1Sm100(KeyedCompileMixin):
                     False,
                     tensor_cta_coord,
                     tensor_cta_layout,
+                    tensormap_manager,
+                    tensormap_v_ptr,
                 )
                 load_t_producer = self.load_tensor_block_tma_sm100(
                     tma_atom_t,
@@ -1498,6 +1596,8 @@ class CPDeltaRuleMNPrecomputeUtcmma1Sm100(KeyedCompileMixin):
                     True,
                     tensor_cta_coord,
                     tensor_cta_layout,
+                    tensormap_manager,
+                    tensormap_k_ptr,
                 )
         elif is_valid_chunk and warp_idx == self.alpha_warp_id:
             cute.arch.setmaxregister_decrease(self.num_regs_other)

--- a/flashinfer/gdn_kernels/blackwell/gdn_cp_prefill.py
+++ b/flashinfer/gdn_kernels/blackwell/gdn_cp_prefill.py
@@ -302,6 +302,16 @@ def cp_delta_rule_mn_precompute_dsl_sm100(
         kernel_dtype, _cu_seqlens_dtype(cu_seqlens.dtype)
     )
     compile_options = _blackwell_compile_options(device)
+    tensormap_workspace_size = (
+        num_sab_heads
+        * max_cp_chunks_per_seq
+        * num_seqs
+        * CPDeltaRuleMNPrecomputeUtcmma1Sm100.num_tensormaps
+        * CPDeltaRuleMNPrecomputeUtcmma1Sm100.bytes_per_tensormap
+    )
+    tensormap_workspace = _get_cache_buf(
+        "gdn_cp_sm100_mn_tensormaps", tensormap_workspace_size, device
+    )[:tensormap_workspace_size]
     compiled = get_cached_compile(kernel, compile_options)
     if compiled is None:
         from_dlpack = lambda *args, **kwargs: cute.runtime.from_dlpack(
@@ -322,6 +332,7 @@ def cp_delta_rule_mn_precompute_dsl_sm100(
             cutlass.Int32(total_cp_chunks),
             cutlass.Int32(max_cp_chunks_per_seq),
             cutlass.Int32(num_seqs),
+            from_dlpack(tensormap_workspace, assumed_align=128).mark_layout_dynamic(),
             stream,
         )
         compiled = cached_compile(kernel, *kernel_args, compile_options=compile_options)
@@ -340,6 +351,7 @@ def cp_delta_rule_mn_precompute_dsl_sm100(
         total_cp_chunks,
         max_cp_chunks_per_seq,
         num_seqs,
+        tensormap_workspace,
         stream,
     )
     return transfer_t, state_t

--- a/tests/gdn/test_prefill_cp_delta_rule.py
+++ b/tests/gdn/test_prefill_cp_delta_rule.py
@@ -993,6 +993,72 @@ def test_cp_delta_rule_public_wrapper_matches_non_cp_prefill(
 
 
 @torch.inference_mode()
+def test_sm100_cp_delta_rule_ignores_physical_padding(
+    seed=int(os.environ.get("SEED", "0")),
+):
+    device = torch.device("cuda")
+    if not is_sm100a_supported(device):
+        pytest.skip("physical-padding regression test requires SM100/SM103")
+    _skip_if_cp_unsupported()
+    _seed_all(seed)
+
+    dtype = torch.bfloat16
+    physical_len = 520
+    logical_len = 517
+    num_qk_heads = 4
+    num_v_heads = 32
+    head_size = 128
+    cu_seqlens = torch.tensor([0, logical_len], dtype=torch.int32, device=device)
+
+    q = torch.randn(physical_len, num_qk_heads, head_size, dtype=dtype, device=device)
+    k = torch.randn(physical_len, num_qk_heads, head_size, dtype=dtype, device=device)
+    v = torch.randn(physical_len, num_v_heads, head_size, dtype=dtype, device=device)
+    q = torch.nn.functional.normalize(q.float(), dim=-1).to(dtype).contiguous()
+    k = torch.nn.functional.normalize(k.float(), dim=-1).to(dtype).contiguous()
+    v = v.contiguous()
+    alpha = _make_gates(physical_len, num_v_heads, 0.9, device)
+    beta = _make_gates(physical_len, num_v_heads, 0.9, device)
+
+    neutral = (q.clone(), k.clone(), v.clone())
+    for tensor in neutral:
+        tensor[logical_len:].zero_()
+    poisoned = (q.clone(), k.clone(), v.clone())
+    for tensor in poisoned:
+        tensor[logical_len:].fill_(float("nan"))
+    alpha[logical_len:].fill_(1.0)
+    beta[logical_len:].zero_()
+
+    def run(inputs, use_cp):
+        return chunk_gated_delta_rule(
+            *inputs,
+            alpha,
+            beta,
+            1.0 / math.sqrt(head_size),
+            None,
+            True,
+            cu_seqlens,
+            False,
+            use_cp=use_cp,
+        )
+
+    cp_output, cp_state = run(poisoned, use_cp=True)
+    neutral_output, neutral_state = run(neutral, use_cp=True)
+    non_cp_output, non_cp_state = run(poisoned, use_cp=False)
+    torch.cuda.synchronize()
+
+    assert torch.isfinite(cp_output[:logical_len]).all()
+    assert torch.isfinite(cp_state).all()
+    torch.testing.assert_close(
+        cp_output[:logical_len], neutral_output[:logical_len], atol=0.0, rtol=0.0
+    )
+    torch.testing.assert_close(cp_state, neutral_state, atol=0.0, rtol=0.0)
+    torch.testing.assert_close(
+        cp_output[:logical_len], non_cp_output[:logical_len], atol=4e-2, rtol=4e-2
+    )
+    torch.testing.assert_close(cp_state, non_cp_state, atol=4e-2, rtol=4e-2)
+
+
+@torch.inference_mode()
 @pytest.mark.parametrize("state_dtype", [torch.bfloat16, torch.float16])
 @pytest.mark.parametrize("seq_lens", [[128], [256, 64]])
 def test_sm100_cp_delta_rule_external_state_dtype(


### PR DESCRIPTION
Frameworks may pass padded Q/K/V buffers whose padding values are undefined. The non-CP path already handles this using device-side cu_seqlens, but the SM100 CP path did not.

This change adds the same handling to the CP kernel, with no API change and negligible performance impact.

cc @guangyunh-nv 

<!-- .github/pull_request_template.md -->

## 📌 Description

<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved context-parallel Gated Delta Net prefill performance and reliability on supported Blackwell GPUs.
  - Prevented physical padding beyond the logical sequence length from affecting outputs or recurrent states.
  - Ensured finite, consistent results with non-context-parallel execution, including inputs containing invalid padding values.

- **Tests**
  - Added regression coverage for padded and NaN-poisoned sequence inputs across supported Blackwell architectures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->