### PR TITLE
fix(jit): warn when CUDA toolkit < 12.8 drops capability flags from JIT builds

### DIFF
--- a/flashinfer/fused_moe/core.py
+++ b/flashinfer/fused_moe/core.py
@@ -53,8 +53,9 @@ from ..jit import (
     setup_cubin_loader,
 )
 from ..jit.core import logger
-from ..jit.cpp_ext import is_cuda_version_at_least
+from ..jit.cpp_ext import get_cuda_version
 from ..jit.fused_moe import (
+    cutlass_fused_moe_fp8_block_scale_supported,
     gen_cutlass_fused_moe_sm89_module,
     gen_cutlass_fused_moe_sm90_module,
     gen_cutlass_fused_moe_sm100_module,
@@ -1117,9 +1118,13 @@ def cutlass_fused_moe(
             raise NotImplementedError(
                 "FP8 block scaling not yet implemented for Blackwell."
             )
-        elif not is_cuda_version_at_least("12.8"):
+        elif not cutlass_fused_moe_fp8_block_scale_supported("90"):
             raise NotImplementedError(
-                "FP8 block scaling not implemented for CUDA 12.6 or lower."
+                "use_deepseek_fp8_block_scale=True requires the fused_moe_90 "
+                "module to be built with -DENABLE_FP8_BLOCK_SCALE, which was "
+                "dropped because the CUDA toolkit used for JIT compilation is "
+                f"{get_cuda_version()} (12.8+ is required). Upgrade the toolkit "
+                "or install a matching flashinfer-jit-cache wheel."
             )
 
     if enable_pdl is None:

--- a/flashinfer/jit/__init__.py
+++ b/flashinfer/jit/__init__.py
@@ -102,6 +102,7 @@ from .fp4_kv_dequantization import (
 from .fp4_kv_quantization import (
     gen_fp4_kv_quantization_module as gen_fp4_kv_quantization_module,
 )
+from .fp4_quantization import has_fp4_support as has_fp4_support
 from .flash_kda import (
     gen_flash_kda_m64_module as gen_flash_kda_m64_module,
 )

--- a/flashinfer/jit/cpp_ext.py
+++ b/flashinfer/jit/cpp_ext.py
@@ -91,6 +91,56 @@ def is_cuda_version_at_least(version_str: str) -> bool:
     return get_cuda_version() >= Version(version_str)
 
 
+def has_prebuilt_aot_module(module_name: str) -> bool:
+    """Whether a prebuilt AOT artifact for ``module_name`` exists.
+
+    Mirrors ``JitSpecNvcc.aot_path`` without constructing the spec (which
+    would run generation side effects). When this returns True, try_load()
+    serves the module from the AOT cache and no JIT build happens.
+    """
+    return (jit_env.FLASHINFER_AOT_DIR / module_name / f"{module_name}.so").exists()
+
+
+def version_gated_nvcc_flag(flag: str, min_version: str, module_name: str) -> str:
+    """Return ``flag`` if the CUDA toolkit is at least ``min_version``, else ``""``.
+
+    When the flag is dropped, warn loudly at flag-generation time so the
+    capability gap is visible when the module is built, instead of surfacing
+    much later as a generic "unsupported input combination" runtime error deep
+    inside kernel-runner construction (issue #3951). If a prebuilt AOT module
+    (e.g. from flashinfer-jit-cache) exists, the drop only affects a JIT flag
+    list that will never be compiled, so it is logged at info level instead of
+    warning.
+    """
+    if is_cuda_version_at_least(min_version):
+        return flag
+    if has_prebuilt_aot_module(module_name):
+        logger.info(
+            "%s: dropping %s from the JIT flags because the local CUDA toolkit "
+            "is %s (< %s), but a prebuilt AOT module exists and will be used, "
+            "so the gated kernels remain available. If the AOT module fails to "
+            "load, the JIT fallback build will lack %s.",
+            module_name,
+            flag,
+            get_cuda_version(),
+            min_version,
+            flag,
+        )
+        return ""
+    logger.warning(
+        "%s: dropping %s because the CUDA toolkit used for JIT compilation is "
+        "%s (< %s). Kernels gated by this flag will be unavailable in the "
+        "compiled module. Use a CUDA %s+ toolkit or install a matching "
+        "flashinfer-jit-cache wheel to enable them.",
+        module_name,
+        flag,
+        get_cuda_version(),
+        min_version,
+        min_version,
+    )
+    return ""
+
+
 def get_nvcc_parallelism_flags() -> List[str]:
     """Build nvcc flags controlled by FlashInfer parallelism environment variables."""
     env_var_name = "FLASHINFER_NVCC_THREADS"

--- a/flashinfer/jit/fp4_quantization.py
+++ b/flashinfer/jit/fp4_quantization.py
@@ -29,10 +29,13 @@ from .core import (
     sm120f_nvcc_flags,
     sm121a_nvcc_flags,
 )
-from .cpp_ext import is_cuda_version_at_least
+from .cpp_ext import version_gated_nvcc_flag
 
 
 def gen_fp4_quantization_module(nvcc_flags: List[str], device_arch: str) -> JitSpec:
+    enable_fp4_flag = version_gated_nvcc_flag(
+        "-DENABLE_FP4", "12.8", f"fp4_quantization_{device_arch}"
+    )
     return gen_jit_spec(
         f"fp4_quantization_{device_arch}",
         [
@@ -49,12 +52,12 @@ def gen_fp4_quantization_module(nvcc_flags: List[str], device_arch: str) -> JitS
         + [
             "-DENABLE_BF16",
             "-DENABLE_FP8",
-            "-DENABLE_FP4" if is_cuda_version_at_least("12.8") else "",
+            enable_fp4_flag,
         ],
         extra_cflags=[
             "-DENABLE_BF16",
             "-DENABLE_FP8",
-            "-DENABLE_FP4" if is_cuda_version_at_least("12.8") else "",
+            enable_fp4_flag,
         ],
         extra_include_paths=[
             jit_env.FLASHINFER_CSRC_DIR / "nv_internal",

--- a/flashinfer/jit/fp4_quantization.py
+++ b/flashinfer/jit/fp4_quantization.py
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import functools
 from typing import List
 
 from .core import JitSpec, gen_jit_spec
@@ -29,7 +30,29 @@ from .core import (
     sm120f_nvcc_flags,
     sm121a_nvcc_flags,
 )
-from .cpp_ext import version_gated_nvcc_flag
+from .cpp_ext import (
+    has_prebuilt_aot_module,
+    is_cuda_version_at_least,
+    version_gated_nvcc_flag,
+)
+
+
+@functools.cache
+def has_fp4_support(device_arch: str = "100") -> bool:
+    """Whether the fp4_quantization module for ``device_arch`` contains the
+    kernels gated by ``-DENABLE_FP4``.
+
+    They are compiled only when ``-DENABLE_FP4`` survives flag generation,
+    i.e. when a CUDA 12.8+ toolkit is used for JIT compilation or when a
+    prebuilt AOT module (built with a 12.8+ toolkit, e.g. from
+    flashinfer-jit-cache) is available. Public capability query requested in
+    issue #3951 so frameworks can gate fp4 paths before committing to a JIT
+    build. ``device_arch`` is the compute capability as a string, e.g. "100"
+    for SM100, matching ``get_fp4_quantization_module``.
+    """
+    if has_prebuilt_aot_module(f"fp4_quantization_{device_arch}"):
+        return True
+    return is_cuda_version_at_least("12.8")
 
 
 def gen_fp4_quantization_module(nvcc_flags: List[str], device_arch: str) -> JitSpec:

--- a/flashinfer/jit/fused_moe.py
+++ b/flashinfer/jit/fused_moe.py
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import functools
 from typing import List
 
 from . import env as jit_env
@@ -25,7 +26,11 @@ from .core import (
     sm90a_nvcc_flags,
     sm89_nvcc_flags,
 )
-from .cpp_ext import is_cuda_version_at_least
+from .cpp_ext import (
+    has_prebuilt_aot_module,
+    is_cuda_version_at_least,
+    version_gated_nvcc_flag,
+)
 from .cubin_loader import (
     get_artifact,
     get_meta_hash,
@@ -110,13 +115,30 @@ def gen_cutlass_fused_moe_sm100_module(use_fast_build: bool = False) -> JitSpec:
     return gen_cutlass_fused_moe_module(nvcc_flags, "100", use_fast_build)
 
 
+@functools.cache
+def cutlass_fused_moe_fp8_block_scale_supported(device_arch: str = "90") -> bool:
+    """Whether the cutlass fused_moe module for ``device_arch`` contains the
+    deepseek fp8 block-scale kernels.
+
+    They are compiled only when ``-DENABLE_FP8_BLOCK_SCALE`` survives flag
+    generation, i.e. when a CUDA 12.8+ toolkit is used for JIT compilation or
+    when a prebuilt AOT module (built with a 12.8+ toolkit, e.g. from
+    flashinfer-jit-cache) is available.
+    """
+    if has_prebuilt_aot_module(f"fused_moe_{device_arch}"):
+        return True
+    return is_cuda_version_at_least("12.8")
+
+
 def gen_cutlass_fused_moe_sm90_module(use_fast_build: bool = False) -> JitSpec:
     nvcc_flags = sm90a_nvcc_flags + [
         "-DCOMPILE_HOPPER_TMA_GEMMS",
         "-DCOMPILE_HOPPER_TMA_GROUPED_GEMMS",
         "-DENABLE_BF16",
         "-DENABLE_FP8",
-        "-DENABLE_FP8_BLOCK_SCALE" if is_cuda_version_at_least("12.8") else "",
+        version_gated_nvcc_flag("-DENABLE_FP8_BLOCK_SCALE", "12.8", "fused_moe_90"),
+        # ENABLE_FP4 needs no toolkit gate on SM90: the Hopper CUTLASS path
+        # uses cutlass::float_e2m1_t (see fp4_compat.h), not <cuda_fp4.h>.
         "-DENABLE_FP4",
         "-DUSING_OSS_CUTLASS_MOE_GEMM",
         "-DCUTLASS_ENABLE_GDC_FOR_SM90=1",
@@ -129,7 +151,7 @@ def gen_cutlass_fused_moe_sm89_module(use_fast_build: bool = False) -> JitSpec:
     nvcc_flags = sm89_nvcc_flags + [
         "-DENABLE_BF16",
         "-DENABLE_FP8",
-        "-DENABLE_FP8_BLOCK_SCALE" if is_cuda_version_at_least("12.8") else "",
+        version_gated_nvcc_flag("-DENABLE_FP8_BLOCK_SCALE", "12.8", "fused_moe_89"),
         "-DUSING_OSS_CUTLASS_MOE_GEMM",
     ]
     return gen_cutlass_fused_moe_module(nvcc_flags, "89", use_fast_build)

--- a/flashinfer/jit/gemm/fp8_blockscale.py
+++ b/flashinfer/jit/gemm/fp8_blockscale.py
@@ -4,7 +4,7 @@ from ..core import (
     gen_jit_spec,
     sm90a_nvcc_flags,
 )
-from ..cpp_ext import is_cuda_version_at_least
+from ..cpp_ext import version_gated_nvcc_flag
 
 
 def gen_fp8_blockscale_gemm_sm90_module(use_fast_build: bool = False) -> JitSpec:
@@ -13,7 +13,9 @@ def gen_fp8_blockscale_gemm_sm90_module(use_fast_build: bool = False) -> JitSpec
         "-DCOMPILE_HOPPER_TMA_GEMMS",
         "-DENABLE_BF16",
         "-DENABLE_FP8",
-        *(("-DENABLE_FP8_BLOCK_SCALE",) if is_cuda_version_at_least("12.8") else ()),
+        version_gated_nvcc_flag(
+            "-DENABLE_FP8_BLOCK_SCALE", "12.8", "fp8_blockscale_gemm_90"
+        ),
         "-DCUTLASS_ENABLE_GDC_FOR_SM90=1",
     ]
 

--- a/flashinfer/quantization/fp4_quantization.py
+++ b/flashinfer/quantization/fp4_quantization.py
@@ -43,7 +43,7 @@ from ..jit import (
     sm100f_nvcc_flags,
     sm90a_nvcc_flags,
 )
-from ..jit.cpp_ext import is_cuda_version_at_least
+from ..jit.cpp_ext import version_gated_nvcc_flag
 from ..utils import (
     backend_requirement,
     device_support_pdl,
@@ -202,6 +202,9 @@ def gen_fp4_quantization_sm121_module() -> JitSpec:
 
 
 def gen_fp4_quantization_module(nvcc_flags: List[str], device_arch: str) -> JitSpec:
+    enable_fp4_flag = version_gated_nvcc_flag(
+        "-DENABLE_FP4", "12.8", f"fp4_quantization_{device_arch}"
+    )
     return gen_jit_spec(
         f"fp4_quantization_{device_arch}",
         [
@@ -218,12 +221,12 @@ def gen_fp4_quantization_module(nvcc_flags: List[str], device_arch: str) -> JitS
         + [
             "-DENABLE_BF16",
             "-DENABLE_FP8",
-            "-DENABLE_FP4" if is_cuda_version_at_least("12.8") else "",
+            enable_fp4_flag,
         ],
         extra_cflags=[
             "-DENABLE_BF16",
             "-DENABLE_FP8",
-            "-DENABLE_FP4" if is_cuda_version_at_least("12.8") else "",
+            enable_fp4_flag,
         ],
         extra_include_paths=[
             jit_env.FLASHINFER_CSRC_DIR / "nv_internal",

--- a/tests/jit/test_toolkit_version_gated_flags.py
+++ b/tests/jit/test_toolkit_version_gated_flags.py
@@ -33,8 +33,10 @@ def _isolated_capability_state(monkeypatch, tmp_path):
     # changes warning behavior) and from the cached capability probe.
     monkeypatch.setattr(jit_env, "FLASHINFER_AOT_DIR", tmp_path / "aot-isolated")
     jit_fused_moe.cutlass_fused_moe_fp8_block_scale_supported.cache_clear()
+    jit_fp4_quantization.has_fp4_support.cache_clear()
     yield
     jit_fused_moe.cutlass_fused_moe_fp8_block_scale_supported.cache_clear()
+    jit_fp4_quantization.has_fp4_support.cache_clear()
 
 
 def _set_cuda_version(monkeypatch, version_str: str) -> None:
@@ -256,3 +258,32 @@ def test_fp8_block_scale_supported_with_aot_module_and_old_toolkit(
 
     _set_cuda_version(monkeypatch, "12.4")
     assert jit_fused_moe.cutlass_fused_moe_fp8_block_scale_supported("90") is True
+
+
+def test_has_fp4_support_follows_toolkit_version(monkeypatch, tmp_path):
+    monkeypatch.setattr(jit_env, "FLASHINFER_AOT_DIR", tmp_path / "aot")
+
+    _set_cuda_version(monkeypatch, "12.4")
+    assert jit_fp4_quantization.has_fp4_support("100") is False
+
+    jit_fp4_quantization.has_fp4_support.cache_clear()
+    _set_cuda_version(monkeypatch, "12.8")
+    # No-argument form requested in issue #3951; defaults to arch "100".
+    assert jit_fp4_quantization.has_fp4_support() is True
+
+
+def test_has_fp4_support_with_aot_module_and_old_toolkit(monkeypatch, tmp_path):
+    _make_aot_module(monkeypatch, tmp_path, "fp4_quantization_100")
+
+    _set_cuda_version(monkeypatch, "12.4")
+    assert jit_fp4_quantization.has_fp4_support("100") is True
+    # AOT presence is per-module: other arches still fall back to the
+    # toolkit-version check.
+    assert jit_fp4_quantization.has_fp4_support("90") is False
+
+
+def test_has_fp4_support_is_exported_from_flashinfer_jit():
+    # Issue #3951 asks for flashinfer.jit.has_fp4_support().
+    import flashinfer.jit
+
+    assert flashinfer.jit.has_fp4_support is jit_fp4_quantization.has_fp4_support

--- a/tests/jit/test_toolkit_version_gated_flags.py
+++ b/tests/jit/test_toolkit_version_gated_flags.py
@@ -1,0 +1,258 @@
+"""CPU-only tests for CUDA-toolkit-version-gated JIT compilation flags.
+
+Flags such as -DENABLE_FP4 and -DENABLE_FP8_BLOCK_SCALE are dropped from JIT
+nvcc flag lists when the local CUDA toolkit is older than 12.8. Issue #3951:
+this used to happen silently, and the resulting module later failed deep in
+kernel-runner construction with a misleading dtype-combination error. These
+tests pin the guarded behavior: the drop must warn loudly at flag-generation
+time, naming the toolkit version found and the required one, unless a prebuilt
+AOT module will serve the kernels anyway (then the drop is info-level), and
+capability probes must report the gap. The toolkit-version probe is
+monkeypatched so no nvcc or GPU is needed.
+"""
+
+import logging
+from types import SimpleNamespace
+
+import pytest
+from packaging.version import Version
+
+from flashinfer.jit import core, cpp_ext
+from flashinfer.jit import env as jit_env
+from flashinfer.jit import fp4_quantization as jit_fp4_quantization
+from flashinfer.jit import fused_moe as jit_fused_moe
+from flashinfer.jit.gemm import fp8_blockscale as jit_fp8_blockscale
+from flashinfer.quantization import fp4_quantization as quantization_fp4_quantization
+
+CPP_EXT_LOGGER = "flashinfer.jit.cpp_ext"
+
+
+@pytest.fixture(autouse=True)
+def _isolated_capability_state(monkeypatch, tmp_path):
+    # Isolate from the host's flashinfer-jit-cache install (AOT presence
+    # changes warning behavior) and from the cached capability probe.
+    monkeypatch.setattr(jit_env, "FLASHINFER_AOT_DIR", tmp_path / "aot-isolated")
+    jit_fused_moe.cutlass_fused_moe_fp8_block_scale_supported.cache_clear()
+    yield
+    jit_fused_moe.cutlass_fused_moe_fp8_block_scale_supported.cache_clear()
+
+
+def _set_cuda_version(monkeypatch, version_str: str) -> None:
+    monkeypatch.setattr(cpp_ext, "get_cuda_version", lambda: Version(version_str))
+
+
+def _make_aot_module(monkeypatch, tmp_path, module_name: str) -> None:
+    aot_dir = tmp_path / "aot"
+    (aot_dir / module_name).mkdir(parents=True)
+    (aot_dir / module_name / f"{module_name}.so").touch()
+    monkeypatch.setattr(jit_env, "FLASHINFER_AOT_DIR", aot_dir)
+
+
+def _cpp_ext_records(caplog):
+    return [r for r in caplog.records if r.name == CPP_EXT_LOGGER]
+
+
+def test_version_gated_nvcc_flag_kept_when_toolkit_new_enough(monkeypatch, caplog):
+    _set_cuda_version(monkeypatch, "12.8")
+    with caplog.at_level(logging.WARNING, logger=CPP_EXT_LOGGER):
+        flag = cpp_ext.version_gated_nvcc_flag("-DENABLE_FP4", "12.8", "some_module")
+
+    assert flag == "-DENABLE_FP4"
+    assert not _cpp_ext_records(caplog)
+
+
+def test_version_gated_nvcc_flag_dropped_with_loud_warning(monkeypatch, caplog):
+    _set_cuda_version(monkeypatch, "12.4")
+    with caplog.at_level(logging.WARNING, logger=CPP_EXT_LOGGER):
+        flag = cpp_ext.version_gated_nvcc_flag("-DENABLE_FP4", "12.8", "some_module")
+
+    assert flag == ""
+    warnings = [r for r in _cpp_ext_records(caplog) if r.levelno >= logging.WARNING]
+    assert len(warnings) == 1
+    message = warnings[0].getMessage()
+    assert "some_module" in message
+    assert "-DENABLE_FP4" in message
+    assert "12.4" in message
+    assert "12.8" in message
+
+
+def test_version_gated_nvcc_flag_demoted_to_info_with_aot_module(
+    monkeypatch, caplog, tmp_path
+):
+    _make_aot_module(monkeypatch, tmp_path, "some_module")
+    _set_cuda_version(monkeypatch, "12.4")
+
+    with caplog.at_level(logging.INFO, logger=CPP_EXT_LOGGER):
+        flag = cpp_ext.version_gated_nvcc_flag("-DENABLE_FP4", "12.8", "some_module")
+
+    # The flag is still dropped from the (never-compiled) JIT flag list, but
+    # the module will be served from the AOT cache, so no warning fires.
+    assert flag == ""
+    records = _cpp_ext_records(caplog)
+    assert len(records) == 1
+    assert records[0].levelno == logging.INFO
+    message = records[0].getMessage()
+    assert "some_module" in message
+    assert "-DENABLE_FP4" in message
+    assert "AOT" in message
+
+
+def _capture_cutlass_fused_moe_flags(monkeypatch):
+    captured = {}
+
+    def fake_gen(nvcc_flags, device_arch, use_fast_build=False):
+        captured["flags"] = nvcc_flags
+        captured["arch"] = device_arch
+        return SimpleNamespace(name=f"fused_moe_{device_arch}")
+
+    monkeypatch.setattr(jit_fused_moe, "gen_cutlass_fused_moe_module", fake_gen)
+    return captured
+
+
+def test_fused_moe_sm90_drops_fp8_block_scale_with_warning_below_12_8(
+    monkeypatch, caplog
+):
+    _set_cuda_version(monkeypatch, "12.4")
+    captured = _capture_cutlass_fused_moe_flags(monkeypatch)
+
+    with caplog.at_level(logging.WARNING, logger=CPP_EXT_LOGGER):
+        jit_fused_moe.gen_cutlass_fused_moe_sm90_module()
+
+    assert "-DENABLE_FP8_BLOCK_SCALE" not in captured["flags"]
+    # FP4 on SM90 goes through cutlass::float_e2m1_t (fp4_compat.h) and must
+    # stay enabled regardless of the toolkit version (issue #3951 regression).
+    assert "-DENABLE_FP4" in captured["flags"]
+    warnings = [r.getMessage() for r in _cpp_ext_records(caplog)]
+    assert any(
+        "fused_moe_90" in m and "-DENABLE_FP8_BLOCK_SCALE" in m and "12.8" in m
+        for m in warnings
+    )
+
+
+def test_fused_moe_sm90_keeps_fp8_block_scale_at_12_8(monkeypatch, caplog):
+    _set_cuda_version(monkeypatch, "12.8")
+    captured = _capture_cutlass_fused_moe_flags(monkeypatch)
+
+    with caplog.at_level(logging.WARNING, logger=CPP_EXT_LOGGER):
+        jit_fused_moe.gen_cutlass_fused_moe_sm90_module()
+
+    assert "-DENABLE_FP8_BLOCK_SCALE" in captured["flags"]
+    assert "-DENABLE_FP4" in captured["flags"]
+    assert not _cpp_ext_records(caplog)
+
+
+def test_fused_moe_sm90_no_warning_with_aot_module_below_12_8(
+    monkeypatch, caplog, tmp_path
+):
+    # The recommended install: flashinfer-jit-cache wheel plus an old local
+    # toolkit. The gated kernels come from the AOT module, so generating the
+    # (unused) JIT flags must not warn.
+    _make_aot_module(monkeypatch, tmp_path, "fused_moe_90")
+    _set_cuda_version(monkeypatch, "12.4")
+    captured = _capture_cutlass_fused_moe_flags(monkeypatch)
+
+    with caplog.at_level(logging.WARNING, logger=CPP_EXT_LOGGER):
+        jit_fused_moe.gen_cutlass_fused_moe_sm90_module()
+
+    assert "-DENABLE_FP8_BLOCK_SCALE" not in captured["flags"]
+    assert not [r for r in _cpp_ext_records(caplog) if r.levelno >= logging.WARNING]
+
+
+def test_fp8_blockscale_gemm_sm90_drops_flag_with_warning_below_12_8(
+    monkeypatch, caplog
+):
+    _set_cuda_version(monkeypatch, "12.4")
+    monkeypatch.setattr(core, "check_cuda_arch", lambda: None)
+
+    with caplog.at_level(logging.WARNING, logger=CPP_EXT_LOGGER):
+        spec = jit_fp8_blockscale.gen_fp8_blockscale_gemm_sm90_module()
+
+    assert "-DENABLE_FP8_BLOCK_SCALE" not in spec.extra_cuda_cflags
+    warnings = [r.getMessage() for r in _cpp_ext_records(caplog)]
+    assert len(warnings) == 1
+    assert "fp8_blockscale_gemm_90" in warnings[0]
+    assert "-DENABLE_FP8_BLOCK_SCALE" in warnings[0]
+    assert "12.4" in warnings[0]
+    assert "12.8" in warnings[0]
+
+
+def test_fp8_blockscale_gemm_sm90_keeps_flag_at_12_8(monkeypatch, caplog):
+    _set_cuda_version(monkeypatch, "12.8")
+    monkeypatch.setattr(core, "check_cuda_arch", lambda: None)
+
+    with caplog.at_level(logging.WARNING, logger=CPP_EXT_LOGGER):
+        spec = jit_fp8_blockscale.gen_fp8_blockscale_gemm_sm90_module()
+
+    assert "-DENABLE_FP8_BLOCK_SCALE" in spec.extra_cuda_cflags
+    assert not _cpp_ext_records(caplog)
+
+
+@pytest.mark.parametrize(
+    "gen_module",
+    [
+        jit_fp4_quantization.gen_fp4_quantization_module,
+        quantization_fp4_quantization.gen_fp4_quantization_module,
+    ],
+    ids=["jit", "quantization"],
+)
+def test_fp4_quantization_drops_fp4_with_single_warning_below_12_8(
+    monkeypatch, caplog, gen_module
+):
+    _set_cuda_version(monkeypatch, "12.4")
+    monkeypatch.setattr(core, "check_cuda_arch", lambda: None)
+
+    with caplog.at_level(logging.WARNING, logger=CPP_EXT_LOGGER):
+        spec = gen_module([], "100")
+
+    assert "-DENABLE_FP4" not in spec.extra_cuda_cflags
+    assert "-DENABLE_FP4" not in spec.extra_cflags
+    warnings = [
+        r.getMessage()
+        for r in _cpp_ext_records(caplog)
+        if "fp4_quantization_100" in r.getMessage()
+    ]
+    # One warning per generated module, not one per flag list.
+    assert len(warnings) == 1
+    assert "-DENABLE_FP4" in warnings[0]
+    assert "12.4" in warnings[0]
+    assert "12.8" in warnings[0]
+
+
+@pytest.mark.parametrize(
+    "gen_module",
+    [
+        jit_fp4_quantization.gen_fp4_quantization_module,
+        quantization_fp4_quantization.gen_fp4_quantization_module,
+    ],
+    ids=["jit", "quantization"],
+)
+def test_fp4_quantization_keeps_fp4_at_12_8(monkeypatch, caplog, gen_module):
+    _set_cuda_version(monkeypatch, "12.8")
+    monkeypatch.setattr(core, "check_cuda_arch", lambda: None)
+
+    with caplog.at_level(logging.WARNING, logger=CPP_EXT_LOGGER):
+        spec = gen_module([], "100")
+
+    assert "-DENABLE_FP4" in spec.extra_cuda_cflags
+    assert "-DENABLE_FP4" in spec.extra_cflags
+    assert not _cpp_ext_records(caplog)
+
+
+def test_fp8_block_scale_supported_follows_toolkit_version(monkeypatch, tmp_path):
+    monkeypatch.setattr(jit_env, "FLASHINFER_AOT_DIR", tmp_path / "aot")
+
+    _set_cuda_version(monkeypatch, "12.4")
+    assert jit_fused_moe.cutlass_fused_moe_fp8_block_scale_supported("90") is False
+
+    jit_fused_moe.cutlass_fused_moe_fp8_block_scale_supported.cache_clear()
+    _set_cuda_version(monkeypatch, "12.8")
+    assert jit_fused_moe.cutlass_fused_moe_fp8_block_scale_supported("90") is True
+
+
+def test_fp8_block_scale_supported_with_aot_module_and_old_toolkit(
+    monkeypatch, tmp_path
+):
+    _make_aot_module(monkeypatch, tmp_path, "fused_moe_90")
+
+    _set_cuda_version(monkeypatch, "12.4")
+    assert jit_fused_moe.cutlass_fused_moe_fp8_block_scale_supported("90") is True


### PR DESCRIPTION
## 📌 Description

When the JIT toolchain is older than CUDA 12.8, version-gated nvcc flags are dropped silently: `-DENABLE_FP4` in the fp4_quantization generators and `-DENABLE_FP8_BLOCK_SCALE` in the CUTLASS fused_moe 89/90 and fp8_blockscale_gemm_90 generators. The module builds fine without the capability and the first gated call fails deep in kernel-runner construction with a misleading dtype-combination error (see #3951, hit through vLLM W4A16-MXFP4 serving on a 12.4 toolkit).

- Add `version_gated_nvcc_flag()` in `flashinfer/jit/cpp_ext.py`: dropping a flag now logs a warning at flag-generation time naming the module, the flag, the toolkit version found, and the 12.8 requirement.
- Use it at all version-gated flag drop sites (`jit/fused_moe.py`, `jit/fp4_quantization.py`, `quantization/fp4_quantization.py`, `jit/gemm/fp8_blockscale.py`). One warning per generated module, not one per flag list.
- AOT-aware: when a prebuilt AOT artifact exists for the module (flashinfer-jit-cache), `try_load()` serves it and the JIT flag list is never compiled, so the drop is logged at info level instead of warning. The check goes through a new `has_prebuilt_aot_module()` helper mirroring `JitSpecNvcc.aot_path`. AOT wheel builds compile into a separate build dir and never read `FLASHINFER_AOT_DIR`, so self-builds with an old toolkit still warn loudly.
- Replace the vague `use_deepseek_fp8_block_scale` early error ("not implemented for CUDA 12.6 or lower") in `fused_moe/core.py` with one naming the actual cause and remedies, backed by a new `cutlass_fused_moe_fp8_block_scale_supported()` capability probe. The probe also accepts a prebuilt AOT `fused_moe_90` module, so flashinfer-jit-cache installs with an older local toolkit are no longer falsely rejected.
- Document why SM90 fused_moe keeps `-DENABLE_FP4` unconditionally after #3738 (Hopper path uses `cutlass::float_e2m1_t` from `fp4_compat.h`, no `<cuda_fp4.h>` needed) and pin it with a regression test, since that unconditional flag is what fixed the original fp4 repro on main.

## 🔍 Related Issues

Closes #3951

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

`tests/jit/test_toolkit_version_gated_flags.py` (14 tests) is CPU-only: it monkeypatches the toolkit-version probe to 12.4 and 12.8 and asserts flag presence, warning content (module name, dropped flag, found and required versions), warning count, info-level demotion when an AOT artifact exists, and the AOT escape hatch of the capability probe. Tests isolate `FLASHINFER_AOT_DIR` so a host jit-cache install cannot skew results. No nvcc or GPU required.

## Reviewer Notes

Two behavior changes with flashinfer-jit-cache installed and a local toolkit < 12.8: `cutlass_fused_moe(use_deepseek_fp8_block_scale=True)` previously raised NotImplementedError based on the local toolkit alone and now proceeds because the AOT module contains the kernels, and flag generation for AOT-served modules logs info instead of warning. Both assume AOT modules are built with a 12.8+ toolkit, which holds for the official wheels (cu128/cu129/cu130). Issue request 2 (a public `has_fp4_support()` query) is left out to keep this focused; the capability-probe pattern here is the template for it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added CUDA toolkit-aware support detection for FP4 and FP8 block-scale operations.
  * Preserved support when compatible prebuilt modules are available, even with older CUDA versions.
  * Added clearer status messages when required compilation features are unavailable.

* **Bug Fixes**
  * Prevented unsupported compiler flags from being applied during JIT compilation.

* **Tests**
  * Added coverage for CUDA version gating, prebuilt modules, capability detection, and diagnostic messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->