### PR TITLE
fix(attention): use exact FA2 grid for no-split CUDA graphs

### DIFF
--- a/flashinfer/decode.py
+++ b/flashinfer/decode.py
@@ -1238,7 +1238,9 @@ class BatchDecodeWithPagedKVCacheWrapper:
                 args.append(fixed_split_size)
                 args.append(disable_split_kv)
                 args.append(0)  # num_colocated_ctas
-                args.append(q_len_per_req if q_len_per_req > 1 else 0)  # uniform_q_len
+                args.append(
+                    q_len_per_req if q_len_per_req > 1 or disable_split_kv else 0
+                )  # uniform_q_len
         else:
             if self._jit_module is not None:
                 module = self._jit_module
@@ -1730,7 +1732,9 @@ class BatchDecodeWithPagedKVCacheWrapper:
                 args.append(fixed_split_size)
                 args.append(disable_split_kv)
                 args.append(0)  # num_colocated_ctas
-                args.append(q_len_per_req if q_len_per_req > 1 else 0)  # uniform_q_len
+                args.append(
+                    q_len_per_req if q_len_per_req > 1 or disable_split_kv else 0
+                )  # uniform_q_len
             self._plan_info = self._cached_module.plan(
                 *args,
             )
@@ -4142,7 +4146,7 @@ def fast_decode_plan(
                     args.append(disable_split_kv)
                     args.append(0)  # num_colocated_ctas
                     args.append(
-                        q_len_per_req if q_len_per_req > 1 else 0
+                        q_len_per_req if q_len_per_req > 1 or disable_split_kv else 0
                     )  # uniform_q_len
                 self._plan_info = self._cached_module.plan(
                     *args,

--- a/flashinfer/decode.py
+++ b/flashinfer/decode.py
@@ -1197,7 +1197,9 @@ class BatchDecodeWithPagedKVCacheWrapper:
                 args.append(fixed_split_size)
                 args.append(disable_split_kv)
                 args.append(0)  # num_colocated_ctas
-                args.append(q_len_per_req if q_len_per_req > 1 else 0)  # uniform_q_len
+                args.append(
+                    q_len_per_req if q_len_per_req > 1 or disable_split_kv else 0
+                )  # uniform_q_len
         else:
             if self._jit_module is not None:
                 module = self._jit_module
@@ -1689,7 +1691,9 @@ class BatchDecodeWithPagedKVCacheWrapper:
                 args.append(fixed_split_size)
                 args.append(disable_split_kv)
                 args.append(0)  # num_colocated_ctas
-                args.append(q_len_per_req if q_len_per_req > 1 else 0)  # uniform_q_len
+                args.append(
+                    q_len_per_req if q_len_per_req > 1 or disable_split_kv else 0
+                )  # uniform_q_len
             self._plan_info = self._cached_module.plan(
                 *args,
             )
@@ -3900,7 +3904,7 @@ def fast_decode_plan(
                     args.append(disable_split_kv)
                     args.append(0)  # num_colocated_ctas
                     args.append(
-                        q_len_per_req if q_len_per_req > 1 else 0
+                        q_len_per_req if q_len_per_req > 1 or disable_split_kv else 0
                     )  # uniform_q_len
                 self._plan_info = self._cached_module.plan(
                     *args,

--- a/include/flashinfer/attention/scheduler.cuh
+++ b/include/flashinfer/attention/scheduler.cuh
@@ -668,8 +668,17 @@ inline auto PrefillSplitQOKVIndptr(IdType* qo_indptr_h, IdType* kv_indptr_h,
     o_indptr.push_back(o_indptr.back() + qo_len * num_chunks_kv);
   }
 
-  const size_t padded_batch_size =
-      enable_cuda_graph ? std::max(max_batch_size_if_split, total_num_tiles_q) : new_batch_size;
+  // A positive uniform_q_len is a graph invariant supplied by tensor-core decode. With split-KV
+  // disabled, every q tile produces exactly one scheduler entry, so new_batch_size is both
+  // graph-stable and fully initialized.
+  const bool exact_no_split_graph = enable_cuda_graph && disable_split_kv && uniform_q_len > 0;
+  size_t padded_batch_size;
+  if (exact_no_split_graph) {
+    padded_batch_size = new_batch_size;
+  } else {
+    padded_batch_size =
+        enable_cuda_graph ? std::max(max_batch_size_if_split, total_num_tiles_q) : new_batch_size;
+  }
   FLASHINFER_CHECK(new_batch_size <= padded_batch_size,
                    "new batch size should not exceed padded batch size. If you are using fixed "
                    "split size, please consider disabling cuda graph.");

--- a/include/flashinfer/attention/scheduler.cuh
+++ b/include/flashinfer/attention/scheduler.cuh
@@ -669,8 +669,17 @@ inline auto PrefillSplitQOKVIndptr(IdType* qo_indptr_h, IdType* kv_indptr_h,
     o_indptr.push_back(o_indptr.back() + qo_len * num_chunks_kv);
   }
 
-  const size_t padded_batch_size =
-      enable_cuda_graph ? std::max(max_batch_size_if_split, total_num_tiles_q) : new_batch_size;
+  // A positive uniform_q_len is a graph invariant supplied by tensor-core decode. With split-KV
+  // disabled, every q tile produces exactly one scheduler entry, so new_batch_size is both
+  // graph-stable and fully initialized.
+  const bool exact_no_split_graph = enable_cuda_graph && disable_split_kv && uniform_q_len > 0;
+  size_t padded_batch_size;
+  if (exact_no_split_graph) {
+    padded_batch_size = new_batch_size;
+  } else {
+    padded_batch_size =
+        enable_cuda_graph ? std::max(max_batch_size_if_split, total_num_tiles_q) : new_batch_size;
+  }
   FLASHINFER_CHECK(new_batch_size <= padded_batch_size,
                    "new batch size should not exceed padded batch size. If you are using fixed "
                    "split size, please consider disabling cuda graph.");

--- a/tests/attention/test_tensor_cores_decode.py
+++ b/tests/attention/test_tensor_cores_decode.py
@@ -53,6 +53,277 @@ def warmup_jit():
     yield
 
 
+def _assert_uniform_no_split_plan(
+    wrapper,
+    batch_size: int,
+    q_len_per_req: int,
+    num_qo_heads: int,
+    num_kv_heads: int,
+):
+    plan = list(wrapper._plan_info)
+    assert len(plan) == 15
+    assert plan[13:] == [1, 0]
+
+    group_size = num_qo_heads // num_kv_heads
+    cta_tile_q = plan[3]
+    tiles_per_request = (q_len_per_req * group_size + cta_tile_q - 1) // cta_tile_q
+    expected_grid = batch_size * tiles_per_request
+    assert plan[0] == expected_grid
+
+    host_workspace = wrapper._pin_memory_int_workspace_buffer
+
+    def read_int32(offset):
+        return host_workspace[offset : offset + expected_grid * 4].view(torch.int32)
+
+    expected_request_indices = torch.arange(
+        batch_size, dtype=torch.int32
+    ).repeat_interleave(tiles_per_request)
+    expected_qo_tile_indices = torch.arange(
+        tiles_per_request, dtype=torch.int32
+    ).repeat(batch_size)
+    expected_kv_tile_indices = torch.zeros(expected_grid, dtype=torch.int32)
+
+    assert torch.equal(read_int32(plan[4]), expected_request_indices)
+    assert torch.equal(read_int32(plan[5]), expected_qo_tile_indices)
+    assert torch.equal(read_int32(plan[6]), expected_kv_tile_indices)
+    return plan
+
+
+@pytest.mark.parametrize("use_fast_plan", [False, True])
+@pytest.mark.parametrize(
+    "batch_size,q_len_per_req,num_qo_heads,num_kv_heads,head_dim,expected_grid",
+    [
+        (1, 1, 16, 16, 128, 1),
+        (2, 1, 16, 2, 128, 2),
+        (8, 1, 128, 1, 256, 16),
+        (2, 3, 16, 2, 128, 2),
+    ],
+)
+def test_cuda_graph_uniform_no_split_plan_uses_initialized_grid(
+    use_fast_plan: bool,
+    batch_size: int,
+    q_len_per_req: int,
+    num_qo_heads: int,
+    num_kv_heads: int,
+    head_dim: int,
+    expected_grid: int,
+):
+    page_size = 1
+    kv_len = max(q_len_per_req, 4)
+    total_num_pages = batch_size * kv_len
+    kv_indptr = (
+        torch.arange(batch_size + 1, dtype=torch.int32, device="cuda:0") * kv_len
+    )
+    kv_indices = torch.arange(total_num_pages, dtype=torch.int32, device="cuda:0")
+    kv_last_page_len = torch.ones(batch_size, dtype=torch.int32, device="cuda:0")
+    workspace_buffer = torch.empty(
+        128 * 1024 * 1024, dtype=torch.uint8, device="cuda:0"
+    )
+    wrapper = flashinfer.BatchDecodeWithPagedKVCacheWrapper(
+        workspace_buffer,
+        "NHD",
+        use_cuda_graph=True,
+        use_tensor_cores=True,
+        paged_kv_indptr_buffer=torch.empty_like(kv_indptr),
+        paged_kv_indices_buffer=torch.empty_like(kv_indices),
+        paged_kv_last_page_len_buffer=torch.empty_like(kv_last_page_len),
+        backend="fa2",
+    )
+
+    plan_args = (
+        kv_indptr,
+        kv_indices,
+        kv_last_page_len,
+        num_qo_heads,
+        num_kv_heads,
+        head_dim,
+        page_size,
+    )
+    plan_kwargs = {
+        "q_data_type": torch.float16,
+        "kv_data_type": torch.float16,
+        "disable_split_kv": True,
+        "q_len_per_req": q_len_per_req,
+    }
+
+    wrapper._pin_memory_int_workspace_buffer.fill_(0xA5)
+    wrapper.plan(*plan_args, **plan_kwargs)
+    torch.cuda.current_stream().synchronize()
+    regular_plan = _assert_uniform_no_split_plan(
+        wrapper, batch_size, q_len_per_req, num_qo_heads, num_kv_heads
+    )
+    plan_type = type(wrapper._plan_info)
+
+    if use_fast_plan:
+        wrapper._pin_memory_int_workspace_buffer.fill_(0xA5)
+        flashinfer.fast_decode_plan(
+            wrapper,
+            *plan_args,
+            **plan_kwargs,
+            global_override_indptr_cpu=kv_indptr.cpu(),
+        )
+        torch.cuda.current_stream().synchronize()
+        assert type(wrapper._plan_info) is plan_type
+        assert list(wrapper._plan_info) == regular_plan
+
+    plan = _assert_uniform_no_split_plan(
+        wrapper, batch_size, q_len_per_req, num_qo_heads, num_kv_heads
+    )
+    assert plan[0] == expected_grid
+
+
+@pytest.mark.parametrize("use_fast_plan", [False, True])
+@pytest.mark.parametrize("q_len_per_req", [1, 3])
+def test_cuda_graph_uniform_no_split_replan_replay(
+    use_fast_plan: bool, q_len_per_req: int
+):
+    torch.manual_seed(42)
+    batch_size = 2
+    num_qo_heads = 16
+    num_kv_heads = 2
+    head_dim = 128
+    page_size = 1
+    dtype = torch.float16
+    short_kv_len = max(2, q_len_per_req)
+    long_kv_len = 129
+
+    def build_kv_layout(kv_len):
+        indptr = (
+            torch.arange(batch_size + 1, dtype=torch.int32, device="cuda:0") * kv_len
+        )
+        indices = torch.arange(batch_size * kv_len, dtype=torch.int32, device="cuda:0")
+        last_page_len = torch.ones(batch_size, dtype=torch.int32, device="cuda:0")
+        return indptr, indices, last_page_len
+
+    short_layout = build_kv_layout(short_kv_len)
+    long_layout = build_kv_layout(long_kv_len)
+    max_num_pages = batch_size * long_kv_len
+    kv_data = torch.randn(
+        max_num_pages,
+        2,
+        page_size,
+        num_kv_heads,
+        head_dim,
+        dtype=dtype,
+        device="cuda:0",
+    )
+    q = torch.randn(
+        batch_size * q_len_per_req,
+        num_qo_heads,
+        head_dim,
+        dtype=dtype,
+        device="cuda:0",
+    )
+
+    graph_workspace = torch.empty(128 * 1024 * 1024, dtype=torch.uint8, device="cuda:0")
+    wrapper = flashinfer.BatchDecodeWithPagedKVCacheWrapper(
+        graph_workspace,
+        "NHD",
+        use_cuda_graph=True,
+        use_tensor_cores=True,
+        paged_kv_indptr_buffer=torch.empty(
+            batch_size + 1, dtype=torch.int32, device="cuda:0"
+        ),
+        paged_kv_indices_buffer=torch.empty(
+            max_num_pages, dtype=torch.int32, device="cuda:0"
+        ),
+        paged_kv_last_page_len_buffer=torch.empty(
+            batch_size, dtype=torch.int32, device="cuda:0"
+        ),
+        backend="fa2",
+    )
+
+    def plan_graph(layout, fast):
+        indptr, indices, last_page_len = layout
+        wrapper._pin_memory_int_workspace_buffer.fill_(0xA5)
+        if fast:
+            wrapper._paged_kv_indptr_buf.copy_(indptr)
+            wrapper._paged_kv_indices_buf[: len(indices)].copy_(indices)
+            wrapper._paged_kv_last_page_len_buf.copy_(last_page_len)
+            flashinfer.fast_decode_plan(
+                wrapper,
+                indptr,
+                indices,
+                last_page_len,
+                num_qo_heads,
+                num_kv_heads,
+                head_dim,
+                page_size,
+                q_data_type=dtype,
+                kv_data_type=dtype,
+                disable_split_kv=True,
+                q_len_per_req=q_len_per_req,
+                global_override_indptr_cpu=indptr.cpu(),
+            )
+        else:
+            wrapper.plan(
+                indptr,
+                indices,
+                last_page_len,
+                num_qo_heads,
+                num_kv_heads,
+                head_dim,
+                page_size,
+                q_data_type=dtype,
+                kv_data_type=dtype,
+                disable_split_kv=True,
+                q_len_per_req=q_len_per_req,
+            )
+        torch.cuda.current_stream().synchronize()
+        return _assert_uniform_no_split_plan(
+            wrapper, batch_size, q_len_per_req, num_qo_heads, num_kv_heads
+        )
+
+    if use_fast_plan:
+        plan_graph(short_layout, False)
+    short_plan = plan_graph(short_layout, use_fast_plan)
+
+    stream = torch.cuda.Stream()
+    stream.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(stream):
+        for _ in range(3):
+            out = wrapper.run(q, kv_data)
+    torch.cuda.current_stream().wait_stream(stream)
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        out = wrapper.run(q, kv_data, out=out)
+
+    reference_workspace = torch.empty(
+        128 * 1024 * 1024, dtype=torch.uint8, device="cuda:0"
+    )
+    reference_wrapper = flashinfer.BatchDecodeWithPagedKVCacheWrapper(
+        reference_workspace, "NHD", use_tensor_cores=True, backend="fa2"
+    )
+
+    def reference(layout):
+        indptr, indices, last_page_len = layout
+        reference_wrapper.plan(
+            indptr,
+            indices,
+            last_page_len,
+            num_qo_heads,
+            num_kv_heads,
+            head_dim,
+            page_size,
+            q_data_type=dtype,
+            kv_data_type=dtype,
+            disable_split_kv=True,
+            q_len_per_req=q_len_per_req,
+        )
+        return reference_wrapper.run(q, kv_data)
+
+    graph.replay()
+    torch.cuda.synchronize()
+    torch.testing.assert_close(out, reference(short_layout), rtol=1e-3, atol=1e-3)
+
+    long_plan = plan_graph(long_layout, use_fast_plan)
+    assert long_plan == short_plan
+    graph.replay()
+    torch.cuda.synchronize()
+    torch.testing.assert_close(out, reference(long_layout), rtol=1e-3, atol=1e-3)
+
+
 @pytest.mark.parametrize("kv_len", [54, 128, 999, 32789])
 @pytest.mark.parametrize("num_kv_heads", [4, 8])
 @pytest.mark.parametrize("group_size", [1, 4, 8])

--- a/tests/attention/test_workspace_size.py
+++ b/tests/attention/test_workspace_size.py
@@ -112,6 +112,59 @@ def test_batch_decode_workspace_size_plans_with_exact_buffers(use_cuda_graph):
     assert wrapper._plan_info is not None
 
 
+def test_batch_decode_workspace_size_plans_fa2_no_split_cuda_graph():
+    batch_size = 2
+    kv_len = 2
+    page_size = 1
+    num_qo_heads = 16
+    num_kv_heads = 2
+    head_dim = 128
+    dtype = torch.float16
+
+    indptr, indices, last_page_len = _paged_kv_inputs(batch_size, kv_len, page_size)
+    wrapper = flashinfer.decode.BatchDecodeWithPagedKVCacheWrapper(
+        _byte_workspace(32 * 1024 * 1024),
+        use_cuda_graph=True,
+        use_tensor_cores=True,
+        paged_kv_indptr_buffer=torch.empty_like(indptr),
+        paged_kv_indices_buffer=torch.empty_like(indices),
+        paged_kv_last_page_len_buffer=torch.empty_like(last_page_len),
+        backend="fa2",
+    )
+    plan_args = (
+        indptr,
+        indices,
+        last_page_len,
+        num_qo_heads,
+        num_kv_heads,
+        head_dim,
+        page_size,
+    )
+    plan_kwargs = {
+        "q_data_type": dtype,
+        "kv_data_type": dtype,
+        "disable_split_kv": True,
+    }
+
+    float_workspace_size, int_workspace_size = wrapper.workspace_size(
+        *plan_args, **plan_kwargs
+    )
+    wrapper.reset_workspace_buffer(
+        _byte_workspace(float_workspace_size),
+        _byte_workspace(int_workspace_size),
+    )
+    wrapper.plan(*plan_args, **plan_kwargs)
+    torch.cuda.current_stream().synchronize()
+
+    plan = list(wrapper._plan_info)
+    assert float_workspace_size == 0
+    assert (
+        int_workspace_size
+        == plan[2] + torch.empty((), dtype=torch.int32).element_size()
+    )
+    assert plan[0] == batch_size
+
+
 def _run_batch_prefill_workspace_size_plan(
     use_cuda_graph=False,
     fixed_split_size=None,


### PR DESCRIPTION
## 📌 Description

FA2 tensor-core decode uses the prefill scheduler. For a CUDA-graph plan with split-KV disabled, the planner creates one scheduler entry for each real request and query tile, then pads `padded_batch_size` to a split-work occupancy bound. The validity mask is allocated only for split-KV plans, while the kernel launches `padded_batch_size` blocks in grid-x. Blocks in the no-split tail can therefore read scheduler entries that planning did not initialize.

For a uniform query length, the initialized grid is:

`batch_size * ceil((q_len_per_req * num_qo_heads / num_kv_heads) / cta_tile_q)`

This PR:

- passes `q_len_per_req` as `uniform_q_len` during workspace sizing, regular planning, and `fast_decode_plan()` when split-KV is disabled;
- verifies the uniform length against every request during planning;
- uses `new_batch_size` for CUDA-graph plans when split-KV is disabled and `uniform_q_len` is positive;
- retains the existing padding formula for ragged graphs, split-KV graphs, eager execution, and other decode backends.

The fixed graph shape makes query tiling stable, and each query tile has one initialized scheduler entry. Public function signatures, the FFI ABI, configuration, and dependencies are unchanged.

### Validation

The H100-tested patch was rebased onto main commit `e04a5a5d`; its stable patch ID is unchanged. Current-base checks:

- changed-file pre-commit hooks: pass;
- Python compile checks: pass;
- `git diff --check`: pass;
- repository documentation and public-API checks: pass.

Focused H100 validation completed with **13 tests passing in 342.51 seconds**. It covers workspace sizing, regular and fast planners, batch sizes 1, 2, and 8, MHA, GQA, multiple query tiles, and graph capture followed by KV-length replan and replay. The checked-in cases use FP16. Separate BF16 runs produced the profiling results below.

The graph-replay outputs matched eager output exactly, with maximum absolute difference `0.0`. Eager no-split plans and split-KV CUDA-graph plans retained their previous behavior.

Environment: NVIDIA H100 80GB HBM3, 132 SMs, driver 570.148.08, Python 3.12.13, PyTorch 2.11.0+cu129, CUDA 12.9, and `flashinfer/flashinfer-ci-cu129:20260408-4cce866`.

Representative BF16 case: batch size 2, 16 query heads, 2 KV heads, head dimension 128, and page size 1.

- Grid-x decreased from 132 to 2.
- Total attention CTAs decreased from 264 to 4.
- Integer workspace size decreased from 1,604 bytes to 68 bytes.
- Nsight recorded `(132, 1, 2)` before and `(2, 1, 2)` after.

Two captured-graph replay measurements were collected for each case:

| Planner | KV length | Padded p50 trials | Bounded p50 trials |
|---|---:|---:|---:|
| Regular | 2 | 9.466, 9.354 µs | 6.431, 6.352 µs |
| Regular | 8,192 | 124.652, 124.589 µs | 80.720, 80.682 µs |
| Fast | 2 | 9.606, 9.487 µs | 6.424, 6.424 µs |
| Fast | 8,192 | 125.443, 126.030 µs | 80.704, 80.702 µs |

These measurements isolate captured attention replay. The host planner tail was zero-filled to avoid profiling arbitrary stale indices, and both measured variants matched reference output. A separately poisoned tail confirmed that planning leaves those entries untouched; it was inspected without launching.

## 🔍 Related Issues

Fixes #4002.

## 🚀 Pull Request Checklist

### ✅ Pre-commit Checks

- [x] Pre-commit checks pass on every changed file.
- [x] The repository pre-commit workflow passes.

## 🧪 Tests

- [x] Focused planning, workspace, and graph-replay tests were added.
- [x] Focused H100 tests pass.
- [ ] Repository-managed multi-architecture tests are pending maintainer authorization.

## Reviewer Notes

Please review the scheduler invariant for `enable_cuda_graph && disable_split_kv && uniform_q_len > 0`, together with the `uniform_q_len` plumbing through workspace sizing and both planner entry points.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for context-parallel speculative decoding with configurable context rank and world size.
  * Improved planning for uniform single-token decode requests when split-KV is disabled.

* **Bug Fixes**
  * Corrected CUDA graph planning and workspace sizing for tensor-core decode workloads.

* **Tests**
  * Added coverage for CUDA graph planning, replanning, replay, and FA2 workspace sizing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->