### PR TITLE
feat(gdn): add pooled state and state checkpointing and dtype support for feature parity

### DIFF
--- a/flashinfer/gdn_kernels/blackwell/gated_delta_net_chunked.py
+++ b/flashinfer/gdn_kernels/blackwell/gated_delta_net_chunked.py
@@ -1259,7 +1259,7 @@ class GatedDeltaNetChunkedKernel:
             while work.is_valid_tile:
                 batch_idx, head_idx, _ = work.tile_idx
                 batch_start = cu_seqlens[batch_idx]
-                seqlen_b = cu_seqlens[batch_idx + 1] - batch_start
+                seqlen_b = cutlass.Int32(cu_seqlens[batch_idx + 1] - batch_start)
                 num_pairs = 2
                 num_pairs_b = cute.ceil_div(seqlen_b, self.b_t * num_pairs)
 
@@ -1326,7 +1326,7 @@ class GatedDeltaNetChunkedKernel:
             while work.is_valid_tile:
                 batch_idx, head_idx, _ = work.tile_idx
                 batch_start = cu_seqlens[batch_idx]
-                seqlen_b = cu_seqlens[batch_idx + 1] - batch_start
+                seqlen_b = cutlass.Int32(cu_seqlens[batch_idx + 1] - batch_start)
                 num_chunks_b = cute.ceil_div(seqlen_b, self.b_t)
                 if num_chunks_b > 0:
                     checkpoint_offset = 0
@@ -1454,7 +1454,7 @@ class GatedDeltaNetChunkedKernel:
             while work.is_valid_tile:
                 batch_idx, _, _ = work.tile_idx
                 batch_start = cu_seqlens[batch_idx]
-                seqlen_b = cu_seqlens[batch_idx + 1] - batch_start
+                seqlen_b = cutlass.Int32(cu_seqlens[batch_idx + 1] - batch_start)
                 num_pairs_b = cute.ceil_div(seqlen_b, self.b_t * 2)
                 for _pair_idx in cutlass.range(num_pairs_b):
                     (
@@ -1490,7 +1490,7 @@ class GatedDeltaNetChunkedKernel:
             while work.is_valid_tile:
                 batch_idx, _, _ = work.tile_idx
                 batch_start = cu_seqlens[batch_idx]
-                seqlen_b = cu_seqlens[batch_idx + 1] - batch_start
+                seqlen_b = cutlass.Int32(cu_seqlens[batch_idx + 1] - batch_start)
                 num_chunks = cute.ceil_div(seqlen_b, self.b_t * 2) * 2
 
                 run_cg1_mma = num_chunks > 0
@@ -1612,7 +1612,7 @@ class GatedDeltaNetChunkedKernel:
                 batch_idx, head_idx, _ = work.tile_idx
                 batch_start = cu_seqlens[batch_idx]
                 batch_end = cu_seqlens[batch_idx + 1]
-                seqlen_b = batch_end - batch_start
+                seqlen_b = cutlass.Int32(batch_end - batch_start)
                 num_pairs = 2
                 num_pairs_b = cute.ceil_div(seqlen_b, self.b_t * num_pairs)
                 num_chunks_b = num_pairs_b * num_pairs
@@ -1729,7 +1729,7 @@ class GatedDeltaNetChunkedKernel:
                 batch_idx, head_idx, _ = work.tile_idx
                 batch_start = cu_seqlens[batch_idx]
                 batch_end = cu_seqlens[batch_idx + 1]
-                seqlen_b = batch_end - batch_start
+                seqlen_b = cutlass.Int32(batch_end - batch_start)
                 num_pairs = 2
                 num_pairs_b = cute.ceil_div(seqlen_b, self.b_t * num_pairs)
                 num_chunks_b = num_pairs_b * num_pairs
@@ -2455,7 +2455,7 @@ class GatedDeltaNetChunkedKernel:
         while work.is_valid_tile:
             batch_idx, _, _ = work.tile_idx
             batch_start = cu_seqlens[batch_idx]
-            seqlen_b = cu_seqlens[batch_idx + 1] - batch_start
+            seqlen_b = cutlass.Int32(cu_seqlens[batch_idx + 1] - batch_start)
             num_pairs_b = cute.ceil_div(seqlen_b, self.b_t * 2)
             num_chunks_padded = num_pairs_b * 2
             first_loop_chunk = 0
@@ -3978,7 +3978,7 @@ class GatedDeltaNetChunkedKernel:
         tGR_tCrState = cute.make_rmem_tensor_like(tRT_tCcState, self.state_dtype)
 
         if cutlass.const_expr(mS_indices is not None):
-            state_row = mS_indices[batch_idx]
+            state_row = cutlass.Int32(mS_indices[batch_idx])
         else:
             state_row = batch_idx
         gS_init = cute.flat_divide(
@@ -4031,7 +4031,7 @@ class GatedDeltaNetChunkedKernel:
         cg1_tidx = tidx % num_threads_cg1
         state_elements = self.mma_tiler_kv[0] * self.mma_tiler_kv[1]
         if cutlass.const_expr(mS_indices is not None):
-            state_row = mS_indices[batch_idx]
+            state_row = cutlass.Int32(mS_indices[batch_idx])
         else:
             state_row = batch_idx
         for linear_idx in cutlass.range(
@@ -4129,7 +4129,7 @@ class GatedDeltaNetChunkedKernel:
                         )
             if cutlass.const_expr(self.store_final_state):
                 if cutlass.const_expr(mS_indices is not None):
-                    state_row = mS_indices[batch_idx]
+                    state_row = cutlass.Int32(mS_indices[batch_idx])
                 else:
                     state_row = batch_idx
                 gS_out = cute.flat_divide(

--- a/flashinfer/gdn_kernels/blackwell/gated_delta_net_cp.py
+++ b/flashinfer/gdn_kernels/blackwell/gated_delta_net_cp.py
@@ -1528,6 +1528,9 @@ class CPDeltaRuleFixupUtcmmaSm100(KeyedCompileMixin):
         state_dtype: Type[cutlass.Numeric] = cutlass.Float32,
         cu_seqlens_dtype: Type[cutlass.Numeric] = cutlass.Int32,
         use_state_indices: bool = False,
+        state_indices_dtype: Type[cutlass.Numeric] | None = None,
+        initial_state_inner_strides: tuple[int, ...] | None = None,
+        output_state_inner_strides: tuple[int, ...] | None = None,
         store_initial_state: bool = False,
     ):
         self.needs_initial_state = needs_initial_state
@@ -1536,6 +1539,9 @@ class CPDeltaRuleFixupUtcmmaSm100(KeyedCompileMixin):
         self.state_dtype = state_dtype
         self.cu_seqlens_dtype = cu_seqlens_dtype
         self.use_state_indices = use_state_indices
+        self.state_indices_dtype = state_indices_dtype
+        self.initial_state_inner_strides = initial_state_inner_strides
+        self.output_state_inner_strides = output_state_inner_strides
         self.store_initial_state = store_initial_state
         self.acc_dtype = cutlass.Float32
         self.mma_dtype = cutlass.TFloat32
@@ -1566,6 +1572,9 @@ class CPDeltaRuleFixupUtcmmaSm100(KeyedCompileMixin):
             "state_dtype",
             "cu_seqlens_dtype",
             "use_state_indices",
+            "state_indices_dtype",
+            "initial_state_inner_strides",
+            "output_state_inner_strides",
             "store_initial_state",
             "m_stage",
             "n_stage",

--- a/flashinfer/gdn_kernels/blackwell/gated_delta_net_cp_prefill.py
+++ b/flashinfer/gdn_kernels/blackwell/gated_delta_net_cp_prefill.py
@@ -161,6 +161,7 @@ class CPDeltaRulePrefillTcgen05Sm100(KeyedCompileMixin):
         io_dtype: Type[cutlass.Numeric],
         acc_dtype: Type[cutlass.Numeric],
         state_dtype: Type[cutlass.Numeric],
+        checkpoint_dtype: Type[cutlass.Numeric],
         mma_tiler_qk: Tuple[int, int, int],
         mma_tiler_qs: Tuple[int, int, int],
         mma_tiler_qkv: Tuple[int, int, int],
@@ -179,6 +180,7 @@ class CPDeltaRulePrefillTcgen05Sm100(KeyedCompileMixin):
         self.cu_seqlens_dtype = cu_seqlens_dtype
         self.acc_dtype = acc_dtype
         self.state_dtype = state_dtype
+        self.checkpoint_dtype = checkpoint_dtype
         self.mma_tiler_qk = mma_tiler_qk
         self.mma_tiler_qs = mma_tiler_qs
         self.mma_tiler_qkv = mma_tiler_qkv
@@ -192,7 +194,7 @@ class CPDeltaRulePrefillTcgen05Sm100(KeyedCompileMixin):
         # initial state, zero, or the fixed-up state from the previous CP chunk.
         self.use_initial_state = True
         self.store_final_state = store_final_state
-        self.enable_checkpoints = False
+        self.enable_checkpoints = enable_checkpoints
         self.is_persistent = False
 
         # ------------------------------------------------------------------
@@ -276,6 +278,7 @@ class CPDeltaRulePrefillTcgen05Sm100(KeyedCompileMixin):
             "cu_seqlens_dtype",
             "acc_dtype",
             "state_dtype",
+            "checkpoint_dtype",
             "mma_tiler_qk",
             "mma_tiler_qs",
             "mma_tiler_qkv",
@@ -284,6 +287,7 @@ class CPDeltaRulePrefillTcgen05Sm100(KeyedCompileMixin):
             "head_ratio",
             "needs_initial_state",
             "store_final_state",
+            "enable_checkpoints",
         )
 
     def _setup_attributes(self):
@@ -392,6 +396,9 @@ class CPDeltaRulePrefillTcgen05Sm100(KeyedCompileMixin):
         fixed_state: cute.Tensor,
         initial_state: Optional[cute.Tensor],
         state_out: cute.Tensor,
+        state_checkpoints: cute.Tensor,
+        checkpoint_cu_starts: cute.Tensor,
+        checkpoint_every_n_tokens: cutlass.Int32,
         cp_chunk_len: cutlass.Int32,
         total_cp_chunks: cutlass.Int32,
         max_cp_chunks_per_seq: cutlass.Int32,
@@ -536,6 +543,29 @@ class CPDeltaRulePrefillTcgen05Sm100(KeyedCompileMixin):
             )
         else:
             state_out = fixed_state
+        if cutlass.const_expr(self.enable_checkpoints):
+            state_checkpoints = cute.make_tensor(
+                state_checkpoints.iterator,
+                cute.make_layout(
+                    (
+                        state_checkpoints.shape[2],
+                        state_checkpoints.shape[3],
+                        (h_r, h_qv),
+                        state_checkpoints.shape[0],
+                    ),
+                    stride=(
+                        state_checkpoints.stride[2],
+                        state_checkpoints.stride[3],
+                        (
+                            state_checkpoints.stride[1],
+                            h_r * state_checkpoints.stride[1],
+                        ),
+                        state_checkpoints.stride[0],
+                    ),
+                ),
+            )
+        else:
+            state_checkpoints = state_out
 
         # ------------------------------------------------------------------
         # Build tiled MMAs  (one per logical GEMM group, differing in operand major modes)
@@ -839,6 +869,9 @@ class CPDeltaRulePrefillTcgen05Sm100(KeyedCompileMixin):
             fixed_state,
             initial_state,
             state_out,
+            state_checkpoints,
+            checkpoint_cu_starts,
+            checkpoint_every_n_tokens,
             cp_chunk_len,
             h_r * h_qv,
             scale,
@@ -884,7 +917,8 @@ class CPDeltaRulePrefillTcgen05Sm100(KeyedCompileMixin):
         valid_chunk_len = cutlass.Int32(0)
         if chunk_idx < num_cp_chunks:
             valid_chunk_len = varlen_chunk_valid_len(seq_len, chunk_idx, cp_chunk_len)
-        tok_offset = seq_start + chunk_idx * cp_chunk_len
+        seq_token_offset = chunk_idx * cp_chunk_len
+        tok_offset = seq_start + seq_token_offset
         cp_chunk_idx = varlen_chunk_idx(seq_idx, seq_start, chunk_idx, cp_chunk_len)
         t_blocks_per_cp_chunk = cute.ceil_div(cp_chunk_len, self.b_t)
         t_block_start = varlen_chunk_idx(
@@ -898,6 +932,8 @@ class CPDeltaRulePrefillTcgen05Sm100(KeyedCompileMixin):
             num_cp_chunks,
             cp_chunk_idx,
             t_block_start,
+            seq_len,
+            seq_token_offset,
         )
 
     # -----------------------------------------------------------------------
@@ -929,6 +965,9 @@ class CPDeltaRulePrefillTcgen05Sm100(KeyedCompileMixin):
         mFixedState: cute.Tensor,
         mInitialState: Optional[cute.Tensor],
         mStateOut: cute.Tensor,
+        mStateCheckpoints: cute.Tensor,
+        checkpoint_cu_starts: cute.Tensor,
+        checkpoint_every_n_tokens: cutlass.Int32,
         cp_chunk_len: cutlass.Int32,
         num_sab_heads: cutlass.Int32,
         scale: cutlass.Float32,
@@ -977,6 +1016,8 @@ class CPDeltaRulePrefillTcgen05Sm100(KeyedCompileMixin):
             num_cp_chunks,
             cp_chunk_idx,
             t_block_start,
+            seq_len,
+            seq_token_offset,
         ) = self.get_cp_work(cu_seqlens, bidy, bidx, num_sab_heads, cp_chunk_len)
         # ------------------------------------------------------------------
         # TMA descriptor GMEM workspace - one q/k/v/o descriptor set per CTA.
@@ -1310,6 +1351,12 @@ class CPDeltaRulePrefillTcgen05Sm100(KeyedCompileMixin):
                     sO, o_smem_layout_staged.inner
                 )
                 checkpoint_offset = 0
+                if cutlass.const_expr(self.enable_checkpoints):
+                    checkpoint_offset = cutlass.Int32(checkpoint_cu_starts[bidy])
+                    if seq_token_offset > 0:
+                        checkpoint_offset += (
+                            seq_token_offset - cutlass.Int32(1)
+                        ) // checkpoint_every_n_tokens
                 is_first_chunk = True
                 for chunk_idx in cutlass.range(num_chunks_b):
                     (
@@ -1331,7 +1378,11 @@ class CPDeltaRulePrefillTcgen05Sm100(KeyedCompileMixin):
                         scale,
                         (tiled_mma_kv, tiled_mma_qs, tiled_mma_qkv),
                         (sV_pisl, sCumsumlog, sCumprod, sCumprod, sO_pisl),
-                        (mStateOut, checkpoint_offset, cutlass.Int32(0)),
+                        (
+                            mStateCheckpoints,
+                            checkpoint_offset,
+                            checkpoint_every_n_tokens,
+                        ),
                         (
                             load_v_consumer,
                             load_gate_consumer,
@@ -1345,7 +1396,15 @@ class CPDeltaRulePrefillTcgen05Sm100(KeyedCompileMixin):
                             decay_v_ready_producer,
                             o_store_producer,
                         ),
-                        (chunk_idx, num_pairs_b, head_idx, chunk_len, is_first_chunk),
+                        (
+                            chunk_idx,
+                            num_pairs_b,
+                            head_idx,
+                            chunk_len,
+                            is_first_chunk,
+                            seq_token_offset,
+                            seq_len,
+                        ),
                     )
                     is_first_chunk = False
 
@@ -1360,9 +1419,10 @@ class CPDeltaRulePrefillTcgen05Sm100(KeyedCompileMixin):
                         tiled_mma_kv,
                         kv_acc_consumer,
                         chunk_len,
-                        mStateOut,
-                        cutlass.Int32(0),
-                        cutlass.Int32(0),
+                        seq_len,
+                        mStateCheckpoints,
+                        checkpoint_offset,
+                        checkpoint_every_n_tokens,
                     )
                 else:
                     kv_acc_handle = kv_acc_consumer.wait_and_advance()
@@ -2372,6 +2432,7 @@ class CPDeltaRulePrefillTcgen05Sm100(KeyedCompileMixin):
         # MMA -> CG1 consumer; waited+released inside this method
         kv_acc_consumer,
         seqlen_b,
+        checkpoint_token,
         mS_checkpoints,
         checkpoint_offset,
         checkpoint_every_n_tokens,
@@ -2412,6 +2473,9 @@ class CPDeltaRulePrefillTcgen05Sm100(KeyedCompileMixin):
         tTR_tCcState = thr_state_t2r.partition_D(tCcState)
         tTR_rState = cute.make_rmem_tensor_like(tTR_tCcState, self.acc_dtype)
         tRG_rState = cute.make_rmem_tensor_like(tTR_tCcState, self.state_dtype)
+        tRC_rCheckpoint = cute.make_rmem_tensor_like(
+            tTR_tCcState, self.checkpoint_dtype
+        )
 
         # Wait for last GEMM-7 to finish.
         kv_acc_handle = kv_acc_consumer.wait_and_advance()
@@ -2429,7 +2493,7 @@ class CPDeltaRulePrefillTcgen05Sm100(KeyedCompileMixin):
             else:
                 tRG_rState = tTR_rState
             if cutlass.const_expr(self.enable_checkpoints):
-                if seqlen_b % checkpoint_every_n_tokens == 0:
+                if checkpoint_token % checkpoint_every_n_tokens == 0:
                     num_valid_chunks_b = cute.ceil_div(seqlen_b, self.b_t)
                     if num_valid_chunks_b % 2 == 0:
                         gS_checkpoints = cute.flat_divide(
@@ -2437,8 +2501,16 @@ class CPDeltaRulePrefillTcgen05Sm100(KeyedCompileMixin):
                             (self.mma_tiler_kv[0], self.mma_tiler_kv[1]),
                         )[None, None, 0, 0]
                         tSgCheckpoints = thr_state_t2r.partition_D(gS_checkpoints)
+                        if cutlass.const_expr(self.acc_dtype != self.checkpoint_dtype):
+                            tRC_rCheckpoint[None, 0, sub].store(
+                                tTR_rState[None, 0, sub]
+                                .load()
+                                .to(self.checkpoint_dtype)
+                            )
+                        else:
+                            tRC_rCheckpoint = tTR_rState
                         cute.autovec_copy(
-                            tRG_rState[None, 0, sub],
+                            tRC_rCheckpoint[None, 0, sub],
                             tSgCheckpoints[None, 0, sub],
                             l1c_evict_priority=cute.nvgpu.CacheEvictionPriority.NO_ALLOCATE,
                         )
@@ -2689,7 +2761,15 @@ class CPDeltaRulePrefillTcgen05Sm100(KeyedCompileMixin):
             o_store_producer,
         ) = pipeline_args
         tiled_mma_kv, tiled_mma_qs, tiled_mma_qkv = mma_args
-        chunk_iter, num_pairs_b, head_idx, seqlen_b, is_first_chunk = work_args
+        (
+            chunk_iter,
+            num_pairs_b,
+            head_idx,
+            seqlen_b,
+            is_first_chunk,
+            seq_token_offset,
+            seq_len,
+        ) = work_args
 
         # ------------------------------------------------------------------
         # Preamble (identical to compute_group_1)
@@ -2727,7 +2807,9 @@ class CPDeltaRulePrefillTcgen05Sm100(KeyedCompileMixin):
         tTR_tCcState = thr_state_t2r.partition_D(tCcState)
         tRT_tCtState = thr_state_r2t.partition_D(tCtState_mn_view)
         tTR_rState = cute.make_rmem_tensor_like(tTR_tCcState, self.acc_dtype)
-        tRG_rState = cute.make_rmem_tensor_like(tTR_tCcState, self.state_dtype)
+        tRC_rCheckpoint = cute.make_rmem_tensor_like(
+            tTR_tCcState, self.checkpoint_dtype
+        )
 
         state_inp_shape = tiled_mma_qs.partition_shape_A(
             (self.mma_tiler_qs[0], self.mma_tiler_qs[2])
@@ -2938,10 +3020,10 @@ class CPDeltaRulePrefillTcgen05Sm100(KeyedCompileMixin):
             )
             cute.arch.fence_view_async_tmem_store()
             state_inp_handle.commit()
-            checkpoint_token = self.b_t * chunk_iter
+            checkpoint_token = seq_token_offset + self.b_t * chunk_iter
             if cutlass.const_expr(self.enable_checkpoints):
                 if checkpoint_token > 0:
-                    if checkpoint_token <= seqlen_b:
+                    if checkpoint_token <= seq_len:
                         if checkpoint_token % checkpoint_every_n_tokens == 0:
                             gS_checkpoints = cute.flat_divide(
                                 mS_checkpoints[
@@ -2956,16 +3038,18 @@ class CPDeltaRulePrefillTcgen05Sm100(KeyedCompileMixin):
                                 ),
                             )[None, None, 0, 0]
                             tSgCheckpoints = thr_state_t2r.partition_D(gS_checkpoints)
-                            if cutlass.const_expr(self.state_dtype != self.acc_dtype):
-                                tRG_rState[None, 0, None].store(
+                            if cutlass.const_expr(
+                                self.checkpoint_dtype != self.acc_dtype
+                            ):
+                                tRC_rCheckpoint[None, 0, None].store(
                                     tTR_rState[None, 0, None]
                                     .load()
-                                    .to(self.state_dtype)
+                                    .to(self.checkpoint_dtype)
                                 )
                             else:
-                                tRG_rState = tTR_rState
+                                tRC_rCheckpoint = tTR_rState
                             cute.autovec_copy(
-                                tRG_rState[None, 0, None],
+                                tRC_rCheckpoint[None, 0, None],
                                 tSgCheckpoints[None, 0, None],
                                 l1c_evict_priority=cute.nvgpu.CacheEvictionPriority.NO_ALLOCATE,
                             )
@@ -2978,7 +3062,7 @@ class CPDeltaRulePrefillTcgen05Sm100(KeyedCompileMixin):
             )
             if cutlass.const_expr(self.enable_checkpoints):
                 if checkpoint_token > 0:
-                    if checkpoint_token <= seqlen_b:
+                    if checkpoint_token <= seq_len:
                         if checkpoint_token % checkpoint_every_n_tokens == 0:
                             checkpoint_offset += 1
             cute.arch.fence_view_async_tmem_store()

--- a/flashinfer/gdn_kernels/blackwell/gated_delta_net_cp_prefill.py
+++ b/flashinfer/gdn_kernels/blackwell/gated_delta_net_cp_prefill.py
@@ -175,9 +175,11 @@ class CPDeltaRulePrefillTcgen05Sm100(KeyedCompileMixin):
         enable_checkpoints: bool = False,
         is_persistent: bool = True,
         cu_seqlens_dtype: Type[cutlass.Numeric] = cutlass.Int32,
+        checkpoint_cu_starts_dtype: Type[cutlass.Numeric] | None = None,
     ):
         self.io_dtype = io_dtype
         self.cu_seqlens_dtype = cu_seqlens_dtype
+        self.checkpoint_cu_starts_dtype = checkpoint_cu_starts_dtype
         self.acc_dtype = acc_dtype
         self.state_dtype = state_dtype
         self.checkpoint_dtype = checkpoint_dtype
@@ -276,6 +278,7 @@ class CPDeltaRulePrefillTcgen05Sm100(KeyedCompileMixin):
         self.manual_cache_key(
             "io_dtype",
             "cu_seqlens_dtype",
+            "checkpoint_cu_starts_dtype",
             "acc_dtype",
             "state_dtype",
             "checkpoint_dtype",
@@ -1353,10 +1356,7 @@ class CPDeltaRulePrefillTcgen05Sm100(KeyedCompileMixin):
                 checkpoint_offset = 0
                 if cutlass.const_expr(self.enable_checkpoints):
                     checkpoint_offset = cutlass.Int32(checkpoint_cu_starts[bidy])
-                    if seq_token_offset > 0:
-                        checkpoint_offset += (
-                            seq_token_offset - cutlass.Int32(1)
-                        ) // checkpoint_every_n_tokens
+                    checkpoint_offset += seq_token_offset // checkpoint_every_n_tokens
                 is_first_chunk = True
                 for chunk_idx in cutlass.range(num_chunks_b):
                     (
@@ -1408,21 +1408,31 @@ class CPDeltaRulePrefillTcgen05Sm100(KeyedCompileMixin):
                     )
                     is_first_chunk = False
 
-                if cp_chunk_idx_in_seq == num_cp_chunks - 1:
+                store_output_state = cp_chunk_idx_in_seq == num_cp_chunks - 1
+                store_cp_boundary = False
+                if cutlass.const_expr(self.enable_checkpoints):
+                    cp_chunk_end = seq_token_offset + chunk_len
+                    store_cp_boundary = cp_chunk_end % checkpoint_every_n_tokens == 0
+                # The ending CTA owns its CP-boundary checkpoint.  This avoids
+                # racing its main-kernel state against the next CTA's fixed state.
+                if store_output_state or store_cp_boundary:
                     kv_acc_consumer = self._store_final_state(
                         tidx,
                         mStateOut,
+                        mFixedState,
                         None,
                         head_idx,
                         bidy,
+                        cp_chunk_idx,
                         tmem_ptr,
                         tiled_mma_kv,
                         kv_acc_consumer,
                         chunk_len,
-                        seq_len,
+                        seq_token_offset + chunk_len,
                         mStateCheckpoints,
                         checkpoint_offset,
                         checkpoint_every_n_tokens,
+                        store_output_state,
                     )
                 else:
                     kv_acc_handle = kv_acc_consumer.wait_and_advance()
@@ -2424,9 +2434,11 @@ class CPDeltaRulePrefillTcgen05Sm100(KeyedCompileMixin):
         tidx,
         # full output-state GMEM tensor (DK, DV, (h_r, h_qv), B) fp32
         mS_out,
+        mFixedState,
         mS_indices,
         head_idx,
         batch_idx,
+        fixed_state_idx,
         tmem_ptr,
         tiled_mma_kv,
         # MMA -> CG1 consumer; waited+released inside this method
@@ -2436,11 +2448,12 @@ class CPDeltaRulePrefillTcgen05Sm100(KeyedCompileMixin):
         mS_checkpoints,
         checkpoint_offset,
         checkpoint_every_n_tokens,
+        store_output_state,
     ):
-        """Store final recurrent state from TMEM (fp32) to GMEM mS_out.
+        """Store a CP-boundary checkpoint and, if requested, the final state.
 
-        Waits for the last GEMM-7 (kv_acc) to complete, reads state TMEM -> registers,
-        writes registers -> GMEM fp32, then releases the consumer handle.
+        Checkpoints use the fixup-produced FP32 fixed state, matching the public
+        output-state path.  The optional final state uses the main-kernel TMEM state.
         """
         num_threads_cg1 = self.threads_per_warp * len(self.compute_group_1_warp_ids)
         cg1_tidx = tidx % num_threads_cg1
@@ -2472,10 +2485,22 @@ class CPDeltaRulePrefillTcgen05Sm100(KeyedCompileMixin):
         tTR_tCtState = thr_state_t2r.partition_S(tCtState_mn_view)
         tTR_tCcState = thr_state_t2r.partition_D(tCcState)
         tTR_rState = cute.make_rmem_tensor_like(tTR_tCcState, self.acc_dtype)
+        atom_state_r2t = cute.make_copy_atom(
+            tcgen05.copy.St32x32bOp(tcgen05.copy.Repetition(32)), self.acc_dtype
+        )
+        tiled_state_r2t = tcgen05.make_tmem_copy(atom_state_r2t, tCtState_for_t2r)
+        thr_state_r2t = tiled_state_r2t.get_slice(cg1_tidx)
+        tRT_tCcState = thr_state_r2t.partition_S(tCcState)
+        tGR_rFixedState = cute.make_rmem_tensor_like(tRT_tCcState, self.acc_dtype)
         tRG_rState = cute.make_rmem_tensor_like(tTR_tCcState, self.state_dtype)
         tRC_rCheckpoint = cute.make_rmem_tensor_like(
             tTR_tCcState, self.checkpoint_dtype
         )
+        gFixedCheckpoint = cute.flat_divide(
+            mFixedState[None, None, head_idx, fixed_state_idx],
+            (self.mma_tiler_kv[0], self.mma_tiler_kv[1]),
+        )[None, None, 0, 0]
+        tGR_tCgFixedState = thr_state_r2t.partition_S(gFixedCheckpoint)
 
         # Wait for last GEMM-7 to finish.
         kv_acc_handle = kv_acc_consumer.wait_and_advance()
@@ -2494,41 +2519,45 @@ class CPDeltaRulePrefillTcgen05Sm100(KeyedCompileMixin):
                 tRG_rState = tTR_rState
             if cutlass.const_expr(self.enable_checkpoints):
                 if checkpoint_token % checkpoint_every_n_tokens == 0:
-                    num_valid_chunks_b = cute.ceil_div(seqlen_b, self.b_t)
-                    if num_valid_chunks_b % 2 == 0:
-                        gS_checkpoints = cute.flat_divide(
-                            mS_checkpoints[None, None, head_idx, checkpoint_offset],
-                            (self.mma_tiler_kv[0], self.mma_tiler_kv[1]),
-                        )[None, None, 0, 0]
-                        tSgCheckpoints = thr_state_t2r.partition_D(gS_checkpoints)
-                        if cutlass.const_expr(self.acc_dtype != self.checkpoint_dtype):
-                            tRC_rCheckpoint[None, 0, sub].store(
-                                tTR_rState[None, 0, sub]
-                                .load()
-                                .to(self.checkpoint_dtype)
-                            )
-                        else:
-                            tRC_rCheckpoint = tTR_rState
-                        cute.autovec_copy(
-                            tRC_rCheckpoint[None, 0, sub],
-                            tSgCheckpoints[None, 0, sub],
-                            l1c_evict_priority=cute.nvgpu.CacheEvictionPriority.NO_ALLOCATE,
+                    cute.autovec_copy(
+                        tGR_tCgFixedState[None, 0, sub],
+                        tGR_rFixedState[None, 0, sub],
+                        l1c_evict_priority=cute.nvgpu.CacheEvictionPriority.NO_ALLOCATE,
+                    )
+                    gS_checkpoints = cute.flat_divide(
+                        mS_checkpoints[None, None, head_idx, checkpoint_offset],
+                        (self.mma_tiler_kv[0], self.mma_tiler_kv[1]),
+                    )[None, None, 0, 0]
+                    tSgCheckpoints = thr_state_t2r.partition_D(gS_checkpoints)
+                    if cutlass.const_expr(self.acc_dtype != self.checkpoint_dtype):
+                        tRC_rCheckpoint[None, 0, sub].store(
+                            tGR_rFixedState[None, 0, sub]
+                            .load()
+                            .to(self.checkpoint_dtype)
                         )
+                    else:
+                        tRC_rCheckpoint = tGR_rFixedState
+                    cute.autovec_copy(
+                        tRC_rCheckpoint[None, 0, sub],
+                        tSgCheckpoints[None, 0, sub],
+                        l1c_evict_priority=cute.nvgpu.CacheEvictionPriority.NO_ALLOCATE,
+                    )
             if cutlass.const_expr(self.store_final_state):
-                if cutlass.const_expr(mS_indices is not None):
-                    state_idx = mS_indices[batch_idx]
-                else:
-                    state_idx = batch_idx
-                gS_out = cute.flat_divide(
-                    mS_out[None, None, head_idx, state_idx],
-                    (self.mma_tiler_kv[0], self.mma_tiler_kv[1]),
-                )[None, None, 0, 0]
-                tRG_tCgState = thr_state_t2r.partition_D(gS_out)
-                cute.autovec_copy(
-                    tRG_rState[None, 0, sub],
-                    tRG_tCgState[None, 0, sub],
-                    l1c_evict_priority=cute.nvgpu.CacheEvictionPriority.NO_ALLOCATE,
-                )
+                if store_output_state:
+                    if cutlass.const_expr(mS_indices is not None):
+                        state_idx = mS_indices[batch_idx]
+                    else:
+                        state_idx = batch_idx
+                    gS_out = cute.flat_divide(
+                        mS_out[None, None, head_idx, state_idx],
+                        (self.mma_tiler_kv[0], self.mma_tiler_kv[1]),
+                    )[None, None, 0, 0]
+                    tRG_tCgState = thr_state_t2r.partition_D(gS_out)
+                    cute.autovec_copy(
+                        tRG_rState[None, 0, sub],
+                        tRG_tCgState[None, 0, sub],
+                        l1c_evict_priority=cute.nvgpu.CacheEvictionPriority.NO_ALLOCATE,
+                    )
         kv_acc_handle.release()
         return kv_acc_consumer
 
@@ -3022,8 +3051,8 @@ class CPDeltaRulePrefillTcgen05Sm100(KeyedCompileMixin):
             state_inp_handle.commit()
             checkpoint_token = seq_token_offset + self.b_t * chunk_iter
             if cutlass.const_expr(self.enable_checkpoints):
-                if checkpoint_token > 0:
-                    if checkpoint_token <= seq_len:
+                if chunk_iter > 0:
+                    if checkpoint_token < seq_token_offset + seqlen_b:
                         if checkpoint_token % checkpoint_every_n_tokens == 0:
                             gS_checkpoints = cute.flat_divide(
                                 mS_checkpoints[
@@ -3061,8 +3090,8 @@ class CPDeltaRulePrefillTcgen05Sm100(KeyedCompileMixin):
                 tRT_tCtState[None, 0, None, kv_prev_handle.index],
             )
             if cutlass.const_expr(self.enable_checkpoints):
-                if checkpoint_token > 0:
-                    if checkpoint_token <= seq_len:
+                if chunk_iter > 0:
+                    if checkpoint_token < seq_token_offset + seqlen_b:
                         if checkpoint_token % checkpoint_every_n_tokens == 0:
                             checkpoint_offset += 1
             cute.arch.fence_view_async_tmem_store()

--- a/flashinfer/gdn_kernels/blackwell/gdn_cp_prefill.py
+++ b/flashinfer/gdn_kernels/blackwell/gdn_cp_prefill.py
@@ -632,17 +632,20 @@ def cp_delta_rule_fixup_dsl_sm100(
 def _get_prefill_kernel(
     kernel_dtype,
     state_dtype,
+    checkpoint_dtype,
     num_sm,
     is_gqa,
     head_ratio,
     needs_initial_state,
     store_final_state,
+    enable_checkpoints,
     cu_seqlens_dtype,
 ):
     return CPDeltaRulePrefillTcgen05Sm100(
         io_dtype=kernel_dtype,
         acc_dtype=cutlass.Float32,
         state_dtype=state_dtype,
+        checkpoint_dtype=checkpoint_dtype,
         mma_tiler_qk=(64, 64, 128),
         mma_tiler_qs=(128, 64, 128),
         mma_tiler_qkv=(128, 64, 64),
@@ -653,7 +656,7 @@ def _get_prefill_kernel(
         head_ratio=head_ratio,
         use_initial_state=needs_initial_state,
         store_final_state=store_final_state,
-        enable_checkpoints=False,
+        enable_checkpoints=enable_checkpoints,
         is_persistent=False,
         cu_seqlens_dtype=cu_seqlens_dtype,
     )
@@ -674,6 +677,9 @@ def cp_delta_rule_prefill_dsl_sm100(
     cp_chunk_len: int = 4096,
     max_seqlen: int | None = None,
     initial_state: torch.Tensor | None = None,
+    state_checkpoints: torch.Tensor | None = None,
+    checkpoint_cu_starts: torch.Tensor | None = None,
+    checkpoint_every_n_tokens: int = 0,
     *,
     _skip_check: bool = False,
     _device=None,
@@ -723,6 +729,7 @@ def cp_delta_rule_prefill_dsl_sm100(
     num_k_heads = k.shape[1]
     num_v_heads = v.shape[1]
     num_sab_heads = max(num_q_heads, num_v_heads)
+    enable_checkpoints = checkpoint_every_n_tokens > 0
     total_t_blocks = workspace_num_chunks_host(cu_seqlens, 64, total_seqlen)
     total_cp_chunks = workspace_num_chunks_host(cu_seqlens, cp_chunk_len, total_seqlen)
     if not _skip_check:
@@ -771,6 +778,37 @@ def cp_delta_rule_prefill_dsl_sm100(
                 raise RuntimeError(
                     f"initial_state must have shape {expected_state_shape}, got {tuple(initial_state.shape)}"
                 )
+        if checkpoint_every_n_tokens < 0 or checkpoint_every_n_tokens % 64 != 0:
+            raise RuntimeError(
+                "checkpoint_every_n_tokens must be a non-negative multiple of 64, "
+                f"got {checkpoint_every_n_tokens}"
+            )
+        if enable_checkpoints:
+            if state_checkpoints is None or checkpoint_cu_starts is None:
+                raise RuntimeError(
+                    "state_checkpoints and checkpoint_cu_starts are required when "
+                    "checkpointing is enabled"
+                )
+            if tuple(state_checkpoints.shape[1:]) != (num_sab_heads, d, d):
+                raise RuntimeError(
+                    "state_checkpoints must have shape "
+                    f"[*, {num_sab_heads}, {d}, {d}], got {tuple(state_checkpoints.shape)}"
+                )
+            if checkpoint_cu_starts.shape != (num_seqs + 1,):
+                raise RuntimeError(
+                    "checkpoint_cu_starts must have shape "
+                    f"{(num_seqs + 1,)}, got {tuple(checkpoint_cu_starts.shape)}"
+                )
+            if checkpoint_cu_starts.dtype != torch.int64:
+                raise RuntimeError(
+                    "checkpoint_cu_starts must have dtype int64, "
+                    f"got {checkpoint_cu_starts.dtype}"
+                )
+        elif state_checkpoints is not None or checkpoint_cu_starts is not None:
+            raise RuntimeError(
+                "state_checkpoints and checkpoint_cu_starts must be None when "
+                "checkpointing is disabled"
+            )
         if not _FullyFusedDeltaRuleSm120.can_implement(
             num_q_heads, num_k_heads, num_v_heads, d, q.element_size()
         ):
@@ -786,6 +824,8 @@ def cp_delta_rule_prefill_dsl_sm100(
             ("fixed_state", fixed_state),
             ("alpha", alpha),
             ("o", o),
+            ("state_checkpoints", state_checkpoints),
+            ("checkpoint_cu_starts", checkpoint_cu_starts),
         ):
             if tensor is not None and not tensor.is_contiguous():
                 raise RuntimeError(f"{name} must be contiguous")
@@ -831,14 +871,17 @@ def cp_delta_rule_prefill_dsl_sm100(
         if needs_initial_state
         else torch.float32
     )
+    checkpoint_dtype = state_checkpoints.dtype if enable_checkpoints else state_dtype
     kernel = _get_prefill_kernel(
         kernel_dtype,
         _cutlass_state_dtype(state_dtype),
+        _cutlass_state_dtype(checkpoint_dtype),
         num_sm,
         is_gqa,
         head_ratio,
         needs_initial_state,
         store_final_state,
+        enable_checkpoints,
         _cu_seqlens_dtype(cu_seqlens.dtype),
     )
     compile_options = _blackwell_compile_options(device)
@@ -865,6 +908,14 @@ def cp_delta_rule_prefill_dsl_sm100(
         if store_final_state:
             state_cute = from_dlpack(state, assumed_align=16)
             _mark_state_layout(state_cute, False, d)
+        state_checkpoints_cute = None
+        checkpoint_cu_starts_cute = None
+        if enable_checkpoints:
+            state_checkpoints_cute = from_dlpack(state_checkpoints, assumed_align=16)
+            _mark_state_layout(state_checkpoints_cute, False, d)
+            checkpoint_cu_starts_cute = from_dlpack(
+                checkpoint_cu_starts, assumed_align=8
+            ).mark_layout_dynamic()
         kernel_args = (
             from_dlpack(q, assumed_align=16).mark_layout_dynamic(),
             from_dlpack(k, assumed_align=16).mark_layout_dynamic(),
@@ -876,6 +927,9 @@ def cp_delta_rule_prefill_dsl_sm100(
             from_dlpack(fixed_state, assumed_align=16).mark_layout_dynamic(),
             initial_state_cute,
             state_cute,
+            state_checkpoints_cute,
+            checkpoint_cu_starts_cute,
+            cutlass.Int32(checkpoint_every_n_tokens),
             cutlass.Int32(cp_chunk_len),
             cutlass.Int32(total_cp_chunks),
             cutlass.Int32(max_cp_chunks_per_seq),
@@ -896,6 +950,9 @@ def cp_delta_rule_prefill_dsl_sm100(
         fixed_state,
         initial_state if needs_initial_state else None,
         state if store_final_state else None,
+        state_checkpoints if enable_checkpoints else None,
+        checkpoint_cu_starts if enable_checkpoints else None,
+        checkpoint_every_n_tokens,
         cp_chunk_len,
         total_cp_chunks,
         max_cp_chunks_per_seq,
@@ -919,6 +976,9 @@ def cp_delta_rule_dsl_sm100(
     *,
     initial_state: torch.Tensor | None = None,
     state_indices: torch.Tensor | None = None,
+    state_checkpoints: torch.Tensor | None = None,
+    checkpoint_cu_starts: torch.Tensor | None = None,
+    checkpoint_every_n_tokens: int = 0,
     max_seqlen: int | None = None,
     cp_chunk_len: int | None = None,
     cp_chunk_len_granularity: int = CP_CHUNK_LEN_GRANULARITY,
@@ -985,6 +1045,7 @@ def cp_delta_rule_dsl_sm100(
     num_k_heads = k.shape[1]
     num_v_heads = v.shape[1]
     num_sab_heads = max(num_q_heads, num_v_heads)
+    enable_checkpoints = checkpoint_every_n_tokens > 0
     if o.shape[1] != num_sab_heads or alpha.shape[1] != num_sab_heads:
         raise RuntimeError(
             f"o/alpha/beta heads must equal max(q heads, v heads)={num_sab_heads}"
@@ -1025,6 +1086,37 @@ def cp_delta_rule_dsl_sm100(
         raise RuntimeError(
             f"state_indices must have shape {(num_seqs,)} and dtype int32"
         )
+    if checkpoint_every_n_tokens < 0 or checkpoint_every_n_tokens % 64 != 0:
+        raise RuntimeError(
+            "checkpoint_every_n_tokens must be a non-negative multiple of 64, "
+            f"got {checkpoint_every_n_tokens}"
+        )
+    if enable_checkpoints:
+        if state_checkpoints is None or checkpoint_cu_starts is None:
+            raise RuntimeError(
+                "state_checkpoints and checkpoint_cu_starts are required when "
+                "checkpointing is enabled"
+            )
+        if tuple(state_checkpoints.shape[1:]) != (num_sab_heads, d, d):
+            raise RuntimeError(
+                "state_checkpoints must have shape "
+                f"[*, {num_sab_heads}, {d}, {d}], got {tuple(state_checkpoints.shape)}"
+            )
+        if checkpoint_cu_starts.shape != (num_seqs + 1,):
+            raise RuntimeError(
+                "checkpoint_cu_starts must have shape "
+                f"{(num_seqs + 1,)}, got {tuple(checkpoint_cu_starts.shape)}"
+            )
+        if checkpoint_cu_starts.dtype != torch.int64:
+            raise RuntimeError(
+                "checkpoint_cu_starts must have dtype int64, "
+                f"got {checkpoint_cu_starts.dtype}"
+            )
+    elif state_checkpoints is not None or checkpoint_cu_starts is not None:
+        raise RuntimeError(
+            "state_checkpoints and checkpoint_cu_starts must be None when "
+            "checkpointing is disabled"
+        )
     if d != 128:
         raise RuntimeError(f"CPDeltaRuleSm100 only supports D=128, got {d}")
     if q.dtype not in (torch.float16, torch.bfloat16):
@@ -1052,6 +1144,8 @@ def cp_delta_rule_dsl_sm100(
         ("beta", beta),
         ("o", o),
         ("state_indices", state_indices),
+        ("state_checkpoints", state_checkpoints),
+        ("checkpoint_cu_starts", checkpoint_cu_starts),
     ):
         if tensor is not None and not tensor.is_contiguous():
             raise RuntimeError(f"{name} must be contiguous")
@@ -1122,6 +1216,9 @@ def cp_delta_rule_dsl_sm100(
             cp_chunk_len=cp_chunk_len,
             max_seqlen=max_seqlen,
             initial_state=initial_state_workspace,
+            state_checkpoints=state_checkpoints,
+            checkpoint_cu_starts=checkpoint_cu_starts,
+            checkpoint_every_n_tokens=checkpoint_every_n_tokens,
             _skip_check=True,
             _device=device,
             _stream=stream,

--- a/flashinfer/gdn_kernels/blackwell/gdn_cp_prefill.py
+++ b/flashinfer/gdn_kernels/blackwell/gdn_cp_prefill.py
@@ -476,10 +476,7 @@ def cp_delta_rule_fixup_dsl_sm100(
                         f"{('[N_pool]' if use_state_indices else f'[{cu_seqlens.shape[0] - 1}]')}"
                         f" + {expected_tail}, got {tuple(tensor.shape)}"
                     )
-                if tensor.dtype not in (torch.float32, torch.bfloat16, torch.float16):
-                    raise RuntimeError(
-                        f"{name} must have dtype float32, bfloat16, or float16, got {tensor.dtype}"
-                    )
+                _cutlass_state_dtype(tensor.dtype)
         if use_state_indices:
             if not is_integer_dtype(state_indices.dtype) or state_indices.shape != (
                 cu_seqlens.shape[0] - 1,
@@ -796,10 +793,7 @@ def cp_delta_rule_prefill_dsl_sm100(
                 raise RuntimeError(
                     f"state must have shape {expected_state_shape}, got {tuple(state.shape)}"
                 )
-            if state.dtype not in (torch.float32, torch.bfloat16, torch.float16):
-                raise RuntimeError(
-                    f"state must have dtype float32, bfloat16, or float16, got {state.dtype}"
-                )
+            _cutlass_state_dtype(state.dtype)
         if initial_state is not None:
             if initial_state.shape != expected_state_shape:
                 raise RuntimeError(
@@ -1155,15 +1149,9 @@ def cp_delta_rule_dsl_sm100(
         raise RuntimeError("q/k/v/o dtypes must match")
     if alpha.dtype != torch.float32 or beta.dtype != torch.float32:
         raise RuntimeError("alpha and beta must have dtype torch.float32")
-    for name, tensor in (("state", state), ("initial_state", initial_state)):
-        if tensor is not None and tensor.dtype not in (
-            torch.float32,
-            torch.bfloat16,
-            torch.float16,
-        ):
-            raise RuntimeError(
-                f"{name} must have dtype float32, bfloat16, or float16, got {tensor.dtype}"
-            )
+    for tensor in (state, initial_state):
+        if tensor is not None:
+            _cutlass_state_dtype(tensor.dtype)
     for name, tensor in (
         ("q", q),
         ("k", k),

--- a/flashinfer/gdn_kernels/blackwell/gdn_cp_prefill.py
+++ b/flashinfer/gdn_kernels/blackwell/gdn_cp_prefill.py
@@ -23,6 +23,8 @@ from ..delta_rule_dsl.delta_rule_sm120 import _FullyFusedDeltaRuleSm120
 from ..delta_rule_dsl.varlen_helper import (
     CP_CHUNK_LEN_GRANULARITY,
     choose_cp_chunk_len_host,
+    integer_dtype_to_cutlass,
+    is_integer_dtype,
     max_num_chunks_host,
     workspace_num_chunks_host,
 )
@@ -54,12 +56,7 @@ class CPDeltaRuleTPrecomputeSm100(CPDeltaRuleTPrecomputeSm120):
 
 
 def _cu_seqlens_dtype(dtype):
-    try:
-        return {torch.int32: cutlass.Int32, torch.int64: cutlass.Int64}[dtype]
-    except KeyError as err:
-        raise RuntimeError(
-            f"cu_seqlens must have dtype torch.int32 or torch.int64, got {dtype}"
-        ) from err
+    return integer_dtype_to_cutlass(dtype)
 
 
 @functools.cache
@@ -360,6 +357,9 @@ def _get_fixup_kernel(
     initial_state_dtype,
     output_state_dtype,
     use_state_indices,
+    state_indices_dtype,
+    initial_state_inner_strides,
+    output_state_inner_strides,
     kernel_kind,
     cu_seqlens_dtype,
 ):
@@ -372,6 +372,9 @@ def _get_fixup_kernel(
             state_dtype=output_state_dtype,
             cu_seqlens_dtype=cu_seqlens_dtype,
             use_state_indices=use_state_indices,
+            state_indices_dtype=state_indices_dtype,
+            initial_state_inner_strides=initial_state_inner_strides,
+            output_state_inner_strides=output_state_inner_strides,
             store_initial_state=needs_initial_state,
         )
     if kernel_kind == "simt_row8":
@@ -383,6 +386,9 @@ def _get_fixup_kernel(
             state_dtype=output_state_dtype,
             cu_seqlens_dtype=cu_seqlens_dtype,
             use_state_indices=use_state_indices,
+            state_indices_dtype=state_indices_dtype,
+            initial_state_inner_strides=initial_state_inner_strides,
+            output_state_inner_strides=output_state_inner_strides,
             store_initial_state=needs_initial_state,
         )
     if kernel_kind == "hmma":
@@ -393,6 +399,9 @@ def _get_fixup_kernel(
             state_dtype=output_state_dtype,
             cu_seqlens_dtype=cu_seqlens_dtype,
             use_state_indices=use_state_indices,
+            state_indices_dtype=state_indices_dtype,
+            initial_state_inner_strides=initial_state_inner_strides,
+            output_state_inner_strides=output_state_inner_strides,
             store_initial_state=needs_initial_state,
         )
     if kernel_kind in ("utcmma", "utcmma64", "utcmma128"):
@@ -404,6 +413,9 @@ def _get_fixup_kernel(
             state_dtype=output_state_dtype,
             cu_seqlens_dtype=cu_seqlens_dtype,
             use_state_indices=use_state_indices,
+            state_indices_dtype=state_indices_dtype,
+            initial_state_inner_strides=initial_state_inner_strides,
+            output_state_inner_strides=output_state_inner_strides,
             store_initial_state=needs_initial_state,
         )
     raise ValueError(f"Unsupported fixup kernel kind: {kernel_kind}")
@@ -469,11 +481,11 @@ def cp_delta_rule_fixup_dsl_sm100(
                         f"{name} must have dtype float32, bfloat16, or float16, got {tensor.dtype}"
                     )
         if use_state_indices:
-            if state_indices.dtype != torch.int32 or state_indices.shape != (
+            if not is_integer_dtype(state_indices.dtype) or state_indices.shape != (
                 cu_seqlens.shape[0] - 1,
             ):
                 raise RuntimeError(
-                    f"state_indices must have shape {(cu_seqlens.shape[0] - 1,)} and dtype int32"
+                    f"state_indices must have shape {(cu_seqlens.shape[0] - 1,)} and an integer dtype"
                 )
         for name, tensor in (
             ("local_transfer", local_transfer),
@@ -486,10 +498,12 @@ def cp_delta_rule_fixup_dsl_sm100(
             ("initial_state", initial_state),
             ("output_state", output_state),
         ):
-            if tensor is not None and tensor.stride()[1:] != (128 * 128, 128, 1):
-                raise RuntimeError(
-                    f"{name} must be contiguous in its inner [H, V, K] modes"
-                )
+            if (
+                tensor is not None
+                and not use_state_indices
+                and not tensor.is_contiguous()
+            ):
+                raise RuntimeError(f"{name} must be contiguous")
 
     total_cp_chunks, num_heads, _, d = local_transfer.shape
     if not _skip_check:
@@ -560,6 +574,17 @@ def cp_delta_rule_fixup_dsl_sm100(
         initial_state_dtype,
         output_state_dtype,
         use_state_indices,
+        _cu_seqlens_dtype(state_indices.dtype) if use_state_indices else None,
+        (
+            tuple(initial_state.stride()[1:])
+            if use_state_indices and needs_initial_state
+            else None
+        ),
+        (
+            tuple(output_state.stride()[1:])
+            if use_state_indices and store_final_state
+            else None
+        ),
         _kernel_kind,
         _cu_seqlens_dtype(cu_seqlens.dtype),
     )
@@ -640,6 +665,7 @@ def _get_prefill_kernel(
     store_final_state,
     enable_checkpoints,
     cu_seqlens_dtype,
+    checkpoint_cu_starts_dtype,
 ):
     return CPDeltaRulePrefillTcgen05Sm100(
         io_dtype=kernel_dtype,
@@ -659,6 +685,7 @@ def _get_prefill_kernel(
         enable_checkpoints=enable_checkpoints,
         is_persistent=False,
         cu_seqlens_dtype=cu_seqlens_dtype,
+        checkpoint_cu_starts_dtype=checkpoint_cu_starts_dtype,
     )
 
 
@@ -799,9 +826,9 @@ def cp_delta_rule_prefill_dsl_sm100(
                     "checkpoint_cu_starts must have shape "
                     f"{(num_seqs + 1,)}, got {tuple(checkpoint_cu_starts.shape)}"
                 )
-            if checkpoint_cu_starts.dtype != torch.int64:
+            if not is_integer_dtype(checkpoint_cu_starts.dtype):
                 raise RuntimeError(
-                    "checkpoint_cu_starts must have dtype int64, "
+                    "checkpoint_cu_starts must have an integer dtype, "
                     f"got {checkpoint_cu_starts.dtype}"
                 )
         elif state_checkpoints is not None or checkpoint_cu_starts is not None:
@@ -883,6 +910,7 @@ def cp_delta_rule_prefill_dsl_sm100(
         store_final_state,
         enable_checkpoints,
         _cu_seqlens_dtype(cu_seqlens.dtype),
+        (_cu_seqlens_dtype(checkpoint_cu_starts.dtype) if enable_checkpoints else None),
     )
     compile_options = _blackwell_compile_options(device)
     workspace_size = (
@@ -1081,10 +1109,10 @@ def cp_delta_rule_dsl_sm100(
             f"got {tuple(initial_state.shape)}"
         )
     if use_state_indices and (
-        state_indices.dtype != torch.int32 or state_indices.shape != (num_seqs,)
+        not is_integer_dtype(state_indices.dtype) or state_indices.shape != (num_seqs,)
     ):
         raise RuntimeError(
-            f"state_indices must have shape {(num_seqs,)} and dtype int32"
+            f"state_indices must have shape {(num_seqs,)} and an integer dtype"
         )
     if checkpoint_every_n_tokens < 0 or checkpoint_every_n_tokens % 64 != 0:
         raise RuntimeError(
@@ -1107,9 +1135,9 @@ def cp_delta_rule_dsl_sm100(
                 "checkpoint_cu_starts must have shape "
                 f"{(num_seqs + 1,)}, got {tuple(checkpoint_cu_starts.shape)}"
             )
-        if checkpoint_cu_starts.dtype != torch.int64:
+        if not is_integer_dtype(checkpoint_cu_starts.dtype):
             raise RuntimeError(
-                "checkpoint_cu_starts must have dtype int64, "
+                "checkpoint_cu_starts must have an integer dtype, "
                 f"got {checkpoint_cu_starts.dtype}"
             )
     elif state_checkpoints is not None or checkpoint_cu_starts is not None:
@@ -1150,10 +1178,8 @@ def cp_delta_rule_dsl_sm100(
         if tensor is not None and not tensor.is_contiguous():
             raise RuntimeError(f"{name} must be contiguous")
     for name, tensor in (("state", state), ("initial_state", initial_state)):
-        if tensor is not None and tensor.stride()[1:] != (d * d, d, 1):
-            raise RuntimeError(
-                f"{name} must be contiguous in its inner [H, V, K] modes"
-            )
+        if tensor is not None and not use_state_indices and not tensor.is_contiguous():
+            raise RuntimeError(f"{name} must be contiguous")
 
     with torch.cuda.nvtx.range("cp_delta_rule_sm100"):
         t = cp_delta_rule_t_precompute_dsl_sm100(

--- a/flashinfer/gdn_kernels/blackwell/gdn_prefill.py
+++ b/flashinfer/gdn_kernels/blackwell/gdn_prefill.py
@@ -58,6 +58,11 @@ def _get_compiled_cache(
     store_final_state: bool,
     enable_checkpoints: bool,
     use_state_indices: bool,
+    cu_seqlens_dtype_str: str,
+    state_indices_dtype_str: str,
+    cu_checkpoints_dtype_str: str,
+    initial_state_inner_strides: tuple[int, ...] | None,
+    output_state_inner_strides: tuple[int, ...] | None,
 ):
     """Return a mutable dict that lazily stores the compiled kernel."""
     return {}
@@ -198,6 +203,19 @@ def chunk_gated_delta_rule_sm100(
         store_final_state,
         enable_checkpoints,
         use_state_indices,
+        str(cu_seqlens.dtype),
+        str(state_indices.dtype) if state_indices is not None else "none",
+        str(cu_checkpoints.dtype) if cu_checkpoints is not None else "none",
+        (
+            tuple(initial_state.stride()[1:])
+            if use_state_indices and initial_state is not None
+            else None
+        ),
+        (
+            tuple(output_state.stride()[1:])
+            if use_state_indices and output_state is not None
+            else None
+        ),
     )
 
     if "compiled" not in cache:

--- a/flashinfer/gdn_kernels/delta_rule_dsl/delta_rule_cp_sm120.py
+++ b/flashinfer/gdn_kernels/delta_rule_dsl/delta_rule_cp_sm120.py
@@ -34,6 +34,7 @@ from .helpers import (
     load_tensor_as_b,
     round_down,
     select_tensor_10,
+    state_dtype_to_cutlass,
 )
 from .varlen_helper import (
     CP_CHUNK_LEN_GRANULARITY,
@@ -2869,6 +2870,7 @@ class CPDeltaRuleFixupSimtSm120(KeyedCompileMixin):
 @functools.cache
 def _get_fixup_kernel(
     needs_initial_state,
+    initial_state_dtype,
     kernel_kind,
     use_state_indices,
     cu_seqlens_dtype,
@@ -2877,6 +2879,7 @@ def _get_fixup_kernel(
 ):
     kernel_kwargs = dict(
         needs_initial_state=needs_initial_state,
+        initial_state_dtype=state_dtype_to_cutlass(initial_state_dtype),
         cu_seqlens_dtype=integer_dtype_to_cutlass(cu_seqlens_dtype),
         use_state_indices=use_state_indices,
         state_indices_dtype=(
@@ -2950,10 +2953,7 @@ def cp_delta_rule_fixup_dsl_sm120(
                     f"{('[N_pool]' if use_state_indices else f'[{cu_seqlens.shape[0] - 1}]')} "
                     f"+ {expected_tail}, got {tuple(initial_state.shape)}"
                 )
-            if initial_state.dtype != torch.float32:
-                raise RuntimeError(
-                    f"initial_state must have dtype torch.float32, got {initial_state.dtype}"
-                )
+            state_dtype_to_cutlass(initial_state.dtype)
         if use_state_indices and (
             not is_integer_dtype(state_indices.dtype)
             or state_indices.shape != (cu_seqlens.shape[0] - 1,)
@@ -3028,6 +3028,7 @@ def cp_delta_rule_fixup_dsl_sm120(
     compile_options = _sm120_compile_options(device)
     kernel = _get_fixup_kernel(
         needs_initial_state,
+        initial_state.dtype if needs_initial_state else torch.float32,
         _kernel_kind,
         use_state_indices,
         cu_seqlens.dtype,
@@ -3122,6 +3123,9 @@ class CPDeltaRulePrefillSm120(KeyedCompileMixin):
         acc_dtype: type[cutlass.Numeric] = cutlass.Float32,
         needs_initial_state: bool = False,
         store_final_state: bool = True,
+        initial_state_dtype: type[cutlass.Numeric] = cutlass.Float32,
+        state_dtype: type[cutlass.Numeric] = cutlass.Float32,
+        checkpoint_state_dtype: type[cutlass.Numeric] = cutlass.Float32,
         use_state_indices: bool = False,
         needs_checkpointing: bool = False,
         cu_seqlens_dtype: torch.dtype = torch.int64,
@@ -3138,6 +3142,9 @@ class CPDeltaRulePrefillSm120(KeyedCompileMixin):
         self.D = 128
         self.needs_initial_state = needs_initial_state
         self.store_final_state = store_final_state
+        self.initial_state_dtype = initial_state_dtype
+        self.state_dtype = state_dtype
+        self.checkpoint_state_dtype = checkpoint_state_dtype
         self.use_state_indices = use_state_indices
         self.needs_checkpointing = needs_checkpointing
         self.cu_seqlens_dtype = cu_seqlens_dtype
@@ -3157,6 +3164,9 @@ class CPDeltaRulePrefillSm120(KeyedCompileMixin):
             "needs_alpha",
             "needs_initial_state",
             "store_final_state",
+            "initial_state_dtype",
+            "state_dtype",
+            "checkpoint_state_dtype",
             "use_state_indices",
             "needs_checkpointing",
             "cu_seqlens_dtype",
@@ -3513,7 +3523,7 @@ class CPDeltaRulePrefillSm120(KeyedCompileMixin):
         tKVcKV = kv_thr_mma.partition_C(c_kv)
         for i in cutlass.range(cute.size(tKVrKV), unroll_full=True):
             v_idx, k_idx = tKVcKV[i]
-            tKVrKV[i] = gKV[k_idx, v_idx]
+            tKVrKV[i] = gKV[k_idx, v_idx].to(self.acc_dtype)
 
     @cute.jit
     def kv_store(
@@ -3526,7 +3536,7 @@ class CPDeltaRulePrefillSm120(KeyedCompileMixin):
         tKVcKV = kv_thr_mma.partition_C(c_kv)
         for i in cutlass.range(cute.size(tKVrKV), unroll_full=True):
             v_idx, k_idx = tKVcKV[i]
-            gKV[k_idx, v_idx] = tKVrKV[i]
+            gKV[k_idx, v_idx] = tKVrKV[i].to(gKV.element_type)
 
     @cute.jit
     def maybe_store_checkpoint(
@@ -5152,6 +5162,9 @@ def _get_prefill_kernel(
     kernel_dtype,
     needs_initial_state,
     store_final_state,
+    initial_state_dtype,
+    state_dtype,
+    checkpoint_state_dtype,
     use_state_indices,
     needs_checkpointing,
     cu_seqlens_dtype,
@@ -5164,6 +5177,9 @@ def _get_prefill_kernel(
         kernel_dtype,
         needs_initial_state=needs_initial_state,
         store_final_state=store_final_state,
+        initial_state_dtype=state_dtype_to_cutlass(initial_state_dtype),
+        state_dtype=state_dtype_to_cutlass(state_dtype),
+        checkpoint_state_dtype=state_dtype_to_cutlass(checkpoint_state_dtype),
         use_state_indices=use_state_indices,
         needs_checkpointing=needs_checkpointing,
         cu_seqlens_dtype=cu_seqlens_dtype,
@@ -5351,17 +5367,16 @@ def cp_delta_rule_prefill_dsl_sm120(
             raise RuntimeError(
                 f"alpha must have dtype torch.float32, got {alpha.dtype}"
             )
-        if initial_state is not None and initial_state.dtype != torch.float32:
-            raise RuntimeError(
-                f"initial_state must have dtype torch.float32, got {initial_state.dtype}"
-            )
+        if initial_state is not None:
+            state_dtype_to_cutlass(initial_state.dtype)
+        if state is not None:
+            state_dtype_to_cutlass(state.dtype)
         if needs_checkpointing:
-            if state_checkpoints.dtype != torch.float32 or tuple(
-                state_checkpoints.shape[1:]
-            ) != (num_sab_heads, d, d):
+            state_dtype_to_cutlass(state_checkpoints.dtype)
+            if tuple(state_checkpoints.shape[1:]) != (num_sab_heads, d, d):
                 raise RuntimeError(
                     "state_checkpoints must have shape "
-                    f"[*, {num_sab_heads}, {d}, {d}] and dtype float32"
+                    f"[*, {num_sab_heads}, {d}, {d}], got {tuple(state_checkpoints.shape)}"
                 )
             if not is_integer_dtype(
                 checkpoint_cu_starts.dtype
@@ -5441,6 +5456,13 @@ def cp_delta_rule_prefill_dsl_sm120(
         kernel_dtype,
         needs_initial_state=needs_initial_state,
         store_final_state=store_final_state,
+        initial_state_dtype=(
+            initial_state.dtype if needs_initial_state else torch.float32
+        ),
+        state_dtype=state.dtype if store_final_state else torch.float32,
+        checkpoint_state_dtype=(
+            state_checkpoints.dtype if needs_checkpointing else torch.float32
+        ),
         use_state_indices=use_state_indices,
         needs_checkpointing=needs_checkpointing,
         cu_seqlens_dtype=cu_seqlens.dtype,
@@ -5712,17 +5734,16 @@ def cp_delta_rule_dsl_sm120(
         raise RuntimeError(
             f"alpha/beta must have dtype torch.float32, got {alpha.dtype} and {beta.dtype}"
         )
-    if initial_state is not None and initial_state.dtype != torch.float32:
-        raise RuntimeError(
-            f"initial_state must have dtype torch.float32, got {initial_state.dtype}"
-        )
+    if initial_state is not None:
+        state_dtype_to_cutlass(initial_state.dtype)
+    if state is not None:
+        state_dtype_to_cutlass(state.dtype)
     if needs_checkpointing:
-        if state_checkpoints.dtype != torch.float32 or tuple(
-            state_checkpoints.shape[1:]
-        ) != (num_sab_heads, d, d):
+        state_dtype_to_cutlass(state_checkpoints.dtype)
+        if tuple(state_checkpoints.shape[1:]) != (num_sab_heads, d, d):
             raise RuntimeError(
                 "state_checkpoints must have shape "
-                f"[*, {num_sab_heads}, {d}, {d}] and dtype float32"
+                f"[*, {num_sab_heads}, {d}, {d}], got {tuple(state_checkpoints.shape)}"
             )
         if not is_integer_dtype(
             checkpoint_cu_starts.dtype

--- a/flashinfer/gdn_kernels/delta_rule_dsl/delta_rule_cp_sm120.py
+++ b/flashinfer/gdn_kernels/delta_rule_dsl/delta_rule_cp_sm120.py
@@ -104,7 +104,7 @@ class CPDeltaRuleTPrecomputeSm120(KeyedCompileMixin):
         sK_DS: cute.Tensor,
         k_pipeline,
         k_producer_state,
-        tok_offset: cutlass.Int32,
+        tok_offset,
         head_idx: cutlass.Int32,
     ):
         mK = cute.domain_offset(
@@ -135,7 +135,7 @@ class CPDeltaRuleTPrecomputeSm120(KeyedCompileMixin):
         sBeta: cute.Tensor,
         beta_pipeline,
         beta_producer_state,
-        tok_offset: cutlass.Int32,
+        tok_offset,
         head_idx: cutlass.Int32,
         valid_len: cutlass.Int32,
         num_heads: cutlass.Int32,
@@ -326,9 +326,8 @@ class CPDeltaRuleTPrecomputeSm120(KeyedCompileMixin):
         sab_head_idx = bx % num_sab_heads
         k_head_idx = sab_head_idx * num_k_heads // num_sab_heads
         block_idx_in_seq = bx // num_sab_heads
-        seq_start = cutlass.Int32(cu_seqlens[seq_idx])
-        seq_end = cutlass.Int32(cu_seqlens[seq_idx + 1])
-        seq_len = seq_end - seq_start
+        seq_start = cu_seqlens[seq_idx]
+        seq_len = cutlass.Int32(cu_seqlens[seq_idx + 1] - seq_start)
         num_blocks = chunks_for_len(seq_len, self.BLK)
         if block_idx_in_seq < num_blocks:
             tok_offset = seq_start + block_idx_in_seq * self.BLK
@@ -750,7 +749,7 @@ class CPDeltaRuleMNPrecomputeSm120(KeyedCompileMixin):
         sTensor: cute.Tensor,
         tensor_pipeline,
         tensor_producer_state,
-        tok_offset: cutlass.Int32,
+        tok_offset,
         t_block_start: cutlass.Int32,
         head_idx: cutlass.Int32,
         blk: cutlass.Int32,
@@ -796,7 +795,7 @@ class CPDeltaRuleMNPrecomputeSm120(KeyedCompileMixin):
         self,
         g_alpha: cute.Tensor,
         sAlpha: cute.Tensor,
-        tok_offset: cutlass.Int32,
+        tok_offset,
         head_idx: cutlass.Int32,
         blk: cutlass.Int32,
         chunk_len: cutlass.Int32,
@@ -1020,7 +1019,7 @@ class CPDeltaRuleMNPrecomputeSm120(KeyedCompileMixin):
         sTensor: cute.Tensor,
         tensor_pipeline,
         tensor_producer_state,
-        tok_offset: cutlass.Int32,
+        tok_offset,
         t_block_start: cutlass.Int32,
         head_idx: cutlass.Int32,
         num_blocks: cutlass.Int32,
@@ -1048,7 +1047,7 @@ class CPDeltaRuleMNPrecomputeSm120(KeyedCompileMixin):
         sAlpha: cute.Tensor,
         alpha_pipeline,
         alpha_producer_state,
-        tok_offset: cutlass.Int32,
+        tok_offset,
         head_idx: cutlass.Int32,
         chunk_len: cutlass.Int32,
         num_blocks: cutlass.Int32,
@@ -1377,9 +1376,8 @@ class CPDeltaRuleMNPrecomputeSm120(KeyedCompileMixin):
         k_head_idx = sab_head_idx * num_k_heads // num_sab_heads
         v_head_idx = sab_head_idx * num_v_heads // num_sab_heads
         chunk_idx_in_seq = bx // num_sab_heads
-        seq_start = cutlass.Int32(g_cu_seqlens[seq_idx])
-        seq_end = cutlass.Int32(g_cu_seqlens[seq_idx + 1])
-        seq_len = seq_end - seq_start
+        seq_start = g_cu_seqlens[seq_idx]
+        seq_len = cutlass.Int32(g_cu_seqlens[seq_idx + 1] - seq_start)
         num_cp_chunks = chunks_for_len(seq_len, chunk_len)
         is_valid_chunk = chunk_idx_in_seq < num_cp_chunks
 
@@ -2188,9 +2186,8 @@ class CPDeltaRuleFixupHmmaSm120(KeyedCompileMixin):
         head_seq_idx = bx // self.row_ctas
         head_idx = head_seq_idx % num_heads
         seq_idx = head_seq_idx // num_heads
-        seq_start = cutlass.Int32(g_cu_seqlens[seq_idx])
-        seq_end = cutlass.Int32(g_cu_seqlens[seq_idx + 1])
-        seq_len = seq_end - seq_start
+        seq_start = g_cu_seqlens[seq_idx]
+        seq_len = cutlass.Int32(g_cu_seqlens[seq_idx + 1] - seq_start)
         num_chunks = chunks_for_len(seq_len, chunk_len)
         chunk_start = varlen_chunk_idx(seq_idx, seq_start, 0, chunk_len)
 
@@ -2721,9 +2718,9 @@ class CPDeltaRuleFixupSimtSm120(KeyedCompileMixin):
         head_seq_idx = bx // self.row_ctas
         head_idx = head_seq_idx % num_heads
         seq_idx = head_seq_idx // num_heads
-        seq_start = cutlass.Int32(g_cu_seqlens[seq_idx])
-        seq_end = cutlass.Int32(g_cu_seqlens[seq_idx + 1])
-        seq_len = seq_end - seq_start
+        seq_start = g_cu_seqlens[seq_idx]
+        seq_end = g_cu_seqlens[seq_idx + 1]
+        seq_len = cutlass.Int32(seq_end - seq_start)
         num_chunks = chunks_for_len(seq_len, chunk_len)
         chunk_start = varlen_chunk_idx(seq_idx, seq_start, 0, chunk_len)
         gap_start = chunk_start + num_chunks
@@ -3303,7 +3300,7 @@ class CPDeltaRulePrefillSm120(KeyedCompileMixin):
         v_pipeline,
         v_producer_state,
         blk: cutlass.Int32,
-        tok_start: cutlass.Int32,
+        tok_start,
         q_head_idx: cutlass.Int32,
         k_head_idx: cutlass.Int32,
         v_head_idx: cutlass.Int32,
@@ -3392,7 +3389,7 @@ class CPDeltaRulePrefillSm120(KeyedCompileMixin):
         sAlpha: cute.Tensor,
         g_alpha: cute.Tensor,
         blk_tok: cutlass.Int32,
-        tok_end: cutlass.Int32,
+        tok_end,
         sab_head_idx: cutlass.Int32,
         num_sab_heads: cutlass.Int32,
         alpha_stage: cutlass.Int32,
@@ -3426,7 +3423,7 @@ class CPDeltaRulePrefillSm120(KeyedCompileMixin):
         k_pipeline,
         v_pipeline,
         num_blocks: cutlass.Int32,
-        tok_start: cutlass.Int32,
+        tok_start,
         q_head_idx: cutlass.Int32,
         k_head_idx: cutlass.Int32,
         v_head_idx: cutlass.Int32,
@@ -3476,8 +3473,8 @@ class CPDeltaRulePrefillSm120(KeyedCompileMixin):
         alpha_pipeline,
         scale: cutlass.Float32,
         num_blocks: cutlass.Int32,
-        tok_start: cutlass.Int32,
-        tok_end: cutlass.Int32,
+        tok_start,
+        tok_end,
         sab_head_idx: cutlass.Int32,
         num_sab_heads: cutlass.Int32,
     ):
@@ -4792,9 +4789,8 @@ class CPDeltaRulePrefillSm120(KeyedCompileMixin):
         k_head_idx = o_head_idx * num_k_heads // num_sab_heads
         v_head_idx = o_head_idx * num_v_heads // num_sab_heads
         chunk_idx_in_seq = bx // num_sab_heads
-        seq_start = cutlass.Int32(g_cu_seqlens[seq_idx])
-        seq_end = cutlass.Int32(g_cu_seqlens[seq_idx + 1])
-        seq_len = seq_end - seq_start
+        seq_start = g_cu_seqlens[seq_idx]
+        seq_len = cutlass.Int32(g_cu_seqlens[seq_idx + 1] - seq_start)
         num_cp_chunks = chunks_for_len(seq_len, chunk_len)
         is_valid_chunk = chunk_idx_in_seq < num_cp_chunks
 

--- a/flashinfer/gdn_kernels/delta_rule_dsl/delta_rule_cp_sm120.py
+++ b/flashinfer/gdn_kernels/delta_rule_dsl/delta_rule_cp_sm120.py
@@ -2825,13 +2825,13 @@ class CPDeltaRuleFixupSimtSm120(KeyedCompileMixin):
 
 
 @functools.cache
-def _get_fixup_kernel(needs_initial_state, kernel_kind):
+def _get_fixup_kernel(needs_initial_state, kernel_kind, use_state_indices):
     if kernel_kind == "simt_row4":
-        return CPDeltaRuleFixupSimtSm120(needs_initial_state, 4)
+        return CPDeltaRuleFixupSimtSm120(needs_initial_state, 4, use_state_indices)
     if kernel_kind == "simt_row8":
-        return CPDeltaRuleFixupSimtSm120(needs_initial_state, 8)
+        return CPDeltaRuleFixupSimtSm120(needs_initial_state, 8, use_state_indices)
     if kernel_kind == "hmma":
-        return CPDeltaRuleFixupHmmaSm120(needs_initial_state)
+        return CPDeltaRuleFixupHmmaSm120(needs_initial_state, use_state_indices)
     raise ValueError(f"Unsupported fixup kernel kind: {kernel_kind}")
 
 
@@ -2842,6 +2842,7 @@ def cp_delta_rule_fixup_dsl_sm120(
     total_seqlen: int,
     cp_chunk_len: int = 4096,
     initial_state: torch.Tensor | None = None,
+    state_indices: torch.Tensor | None = None,
     *,
     _skip_check: bool = False,
     _kernel_kind: str | None = None,
@@ -2877,30 +2878,48 @@ def cp_delta_rule_fixup_dsl_sm120(
                 "CPDeltaRuleFixupSm120 only supports float32 inputs, "
                 f"got {local_transfer.dtype} and {local_state.dtype}"
             )
+        use_state_indices = state_indices is not None
         if initial_state is not None:
-            if initial_state.shape != (
-                cu_seqlens.shape[0] - 1,
-                local_transfer.shape[1],
-                128,
-                128,
+            expected_tail = (local_transfer.shape[1], 128, 128)
+            if (
+                not use_state_indices
+                and initial_state.shape != (cu_seqlens.shape[0] - 1, *expected_tail)
+            ) or (
+                use_state_indices and tuple(initial_state.shape[1:]) != expected_tail
             ):
                 raise RuntimeError(
                     "initial_state must have shape "
-                    f"{(cu_seqlens.shape[0] - 1, local_transfer.shape[1], 128, 128)}, got {tuple(initial_state.shape)}"
+                    f"{('[N_pool]' if use_state_indices else f'[{cu_seqlens.shape[0] - 1}]')} "
+                    f"+ {expected_tail}, got {tuple(initial_state.shape)}"
                 )
             if initial_state.dtype != torch.float32:
                 raise RuntimeError(
                     f"initial_state must have dtype torch.float32, got {initial_state.dtype}"
                 )
+        if use_state_indices and (
+            state_indices.dtype != torch.int32
+            or state_indices.shape != (cu_seqlens.shape[0] - 1,)
+        ):
+            raise RuntimeError(
+                f"state_indices must have shape {(cu_seqlens.shape[0] - 1,)} and dtype int32"
+            )
         for name, tensor in (
             ("local_transfer", local_transfer),
             ("local_state", local_state),
-            ("initial_state", initial_state),
+            ("state_indices", state_indices),
         ):
             if tensor is None:
                 continue
             if not tensor.is_contiguous():
                 raise RuntimeError(f"{name} must be contiguous")
+        if initial_state is not None:
+            if use_state_indices:
+                if initial_state.stride()[1:] != (128 * 128, 128, 1):
+                    raise RuntimeError(
+                        "initial_state inner dimensions must be contiguous when state_indices is used"
+                    )
+            elif not initial_state.is_contiguous():
+                raise RuntimeError("initial_state must be contiguous")
     total_cp_chunks, num_heads, _, _ = local_transfer.shape
     if not _skip_check:
         if cp_chunk_len <= 0:
@@ -2943,6 +2962,7 @@ def cp_delta_rule_fixup_dsl_sm120(
     )
 
     needs_initial_state = initial_state is not None
+    use_state_indices = state_indices is not None
     if _kernel_kind is None:
         # NCU on SM120 shows row4 is best for H <= 8 and row8 wins for H = 16.
         # HMMA remains the fallback above that.
@@ -2953,17 +2973,20 @@ def cp_delta_rule_fixup_dsl_sm120(
         else:
             _kernel_kind = "hmma"
     compile_options = _sm120_compile_options(device)
-    kernel = _get_fixup_kernel(needs_initial_state, _kernel_kind)
+    kernel = _get_fixup_kernel(needs_initial_state, _kernel_kind, use_state_indices)
     compiled = get_cached_compile(kernel, compile_options)
     if compiled is None:
         from_dlpack = lambda *args, **kwargs: cute.runtime.from_dlpack(
             *args, **{**kwargs, "enable_tvm_ffi": True}
         )
         initial_state_cute = (
-            from_dlpack(
-                initial_state.reshape(-1), assumed_align=16
-            ).mark_layout_dynamic()
+            from_dlpack(initial_state, assumed_align=16).mark_layout_dynamic()
             if needs_initial_state
+            else None
+        )
+        state_indices_cute = (
+            from_dlpack(state_indices, assumed_align=4).mark_layout_dynamic()
+            if use_state_indices
             else None
         )
         kernel_args = (
@@ -2979,7 +3002,7 @@ def cp_delta_rule_fixup_dsl_sm120(
                 fixed_state.reshape(-1), assumed_align=128
             ).mark_layout_dynamic(),
             None,
-            None,
+            state_indices_cute,
             from_dlpack(cu_seqlens, assumed_align=8).mark_layout_dynamic(),
             cutlass.Int32(cp_chunk_len),
             cutlass.Int32(total_cp_chunks),
@@ -2991,11 +3014,11 @@ def cp_delta_rule_fixup_dsl_sm120(
     compiled(
         local_transfer_tma,
         local_state_tma,
-        initial_state.reshape(-1) if needs_initial_state else None,
+        initial_state if needs_initial_state else None,
         None,
         fixed_state.reshape(-1),
         None,
-        None,
+        state_indices if use_state_indices else None,
         cu_seqlens,
         cp_chunk_len,
         total_cp_chunks,
@@ -3035,6 +3058,8 @@ class CPDeltaRulePrefillSm120(KeyedCompileMixin):
         acc_dtype: type[cutlass.Numeric] = cutlass.Float32,
         needs_initial_state: bool = False,
         store_final_state: bool = True,
+        use_state_indices: bool = False,
+        needs_checkpointing: bool = False,
     ):
         self.needs_alpha = True
         self.dtype = dtype
@@ -3044,6 +3069,8 @@ class CPDeltaRulePrefillSm120(KeyedCompileMixin):
         self.D = 128
         self.needs_initial_state = needs_initial_state
         self.store_final_state = store_final_state
+        self.use_state_indices = use_state_indices
+        self.needs_checkpointing = needs_checkpointing
         self.q_stage = 1
         self.k_stage = 1
         self.v_stage = 1
@@ -3056,6 +3083,8 @@ class CPDeltaRulePrefillSm120(KeyedCompileMixin):
             "needs_alpha",
             "needs_initial_state",
             "store_final_state",
+            "use_state_indices",
+            "needs_checkpointing",
             "dtype",
             "acc_dtype",
             "BLK_Q",
@@ -3419,6 +3448,41 @@ class CPDeltaRulePrefillSm120(KeyedCompileMixin):
         for i in cutlass.range(cute.size(tKVrKV), unroll_full=True):
             v_idx, k_idx = tKVcKV[i]
             gKV[k_idx, v_idx] = tKVrKV[i]
+
+    @cute.jit
+    def maybe_store_checkpoint(
+        self,
+        tKVrKV: cute.Tensor,
+        g_state_checkpoints: cute.Tensor,
+        checkpoint_cu_starts: cute.Tensor,
+        checkpoint_every_n_tokens: cutlass.Int32,
+        kv_thr_mma,
+        seq_idx: cutlass.Int32,
+        o_head_idx: cutlass.Int32,
+        num_sab_heads: cutlass.Int32,
+        total_checkpoints: cutlass.Int32,
+        block_end: cutlass.Int32,
+        seq_len: cutlass.Int32,
+    ):
+        if cutlass.const_expr(self.needs_checkpointing):
+            if (
+                block_end <= seq_len
+                and block_end % checkpoint_every_n_tokens == cutlass.Int32(0)
+            ):
+                checkpoint_idx = (
+                    cutlass.Int32(checkpoint_cu_starts[seq_idx])
+                    + block_end // checkpoint_every_n_tokens
+                    - cutlass.Int32(1)
+                )
+                checkpoint_layout = cute.make_ordered_layout(
+                    (self.D, self.D, num_sab_heads, total_checkpoints),
+                    order=(0, 1, 2, 3),
+                )
+                mCheckpoint = cute.make_tensor(
+                    g_state_checkpoints.iterator, checkpoint_layout
+                )
+                gCheckpointKV = mCheckpoint[None, None, o_head_idx, checkpoint_idx]
+                self.kv_store(tKVrKV, gCheckpointKV, kv_thr_mma)
 
     @cute.jit
     def load_t_tma(
@@ -3892,12 +3956,17 @@ class CPDeltaRulePrefillSm120(KeyedCompileMixin):
         g_state: cute.Tensor,
         g_fixed_state: cute.Tensor,
         g_initial_state: cute.Tensor,
+        g_state_indices: cute.Tensor,
+        g_state_checkpoints: cute.Tensor,
+        checkpoint_cu_starts: cute.Tensor,
         work_desc: WorkDesc,
         public_seq_idx: cutlass.Int32,
         fixed_state_idx: cutlass.Int32,
         load_fixed_state,
         load_initial_state,
         store_state,
+        seq_block_offset: cutlass.Int32,
+        full_seq_len: cutlass.Int32,
         scale: cutlass.Float32,
         wg_idx: cutlass.Int32,
         math_tidx: cutlass.Int32,
@@ -3907,6 +3976,8 @@ class CPDeltaRulePrefillSm120(KeyedCompileMixin):
         num_sab_heads: cutlass.Int32,
         num_chunks: cutlass.Int32,
         num_seqs: cutlass.Int32,
+        total_checkpoints: cutlass.Int32,
+        checkpoint_every_n_tokens: cutlass.Int32,
         produce_aux: cutlass.Constexpr,
     ):
         self._math_order_init(wg_idx)
@@ -3976,15 +4047,46 @@ class CPDeltaRulePrefillSm120(KeyedCompileMixin):
             tQKcMqk = qk_thr_mma.partition_C(cMqk)
             tKKcMkk = kk_thr_mma.partition_C(cMqk)
 
-        state_layout = cute.make_ordered_layout(
+        packed_state_layout = cute.make_ordered_layout(
             (self.D, self.D, num_sab_heads, num_seqs), order=(0, 1, 2, 3)
         )
+        state_idx = public_seq_idx
+        if cutlass.const_expr(self.use_state_indices):
+            state_idx = cutlass.Int32(g_state_indices[public_seq_idx])
+        output_state_idx = public_seq_idx
+        if cutlass.const_expr(self.use_state_indices and self.store_final_state):
+            output_state_idx = state_idx
+            state_layout = cute.make_layout(
+                (self.D, self.D, num_sab_heads, g_state.shape[0]),
+                stride=(
+                    g_state.stride[3],
+                    g_state.stride[2],
+                    g_state.stride[1],
+                    g_state.stride[0],
+                ),
+            )
+        else:
+            state_layout = packed_state_layout
         o_head_idx = work_desc.o_head_idx(num_q_heads, num_v_heads)
         mState = cute.make_tensor(g_state.iterator, state_layout)
-        gStateKV = mState[None, None, o_head_idx, public_seq_idx]
+        gStateKV = mState[None, None, o_head_idx, output_state_idx]
         if cutlass.const_expr(self.needs_initial_state):
-            mInitialState = cute.make_tensor(g_initial_state.iterator, state_layout)
-            gInitialKV = mInitialState[None, None, o_head_idx, public_seq_idx]
+            if cutlass.const_expr(self.use_state_indices):
+                initial_state_layout = cute.make_layout(
+                    (self.D, self.D, num_sab_heads, g_initial_state.shape[0]),
+                    stride=(
+                        g_initial_state.stride[3],
+                        g_initial_state.stride[2],
+                        g_initial_state.stride[1],
+                        g_initial_state.stride[0],
+                    ),
+                )
+            else:
+                initial_state_layout = packed_state_layout
+            mInitialState = cute.make_tensor(
+                g_initial_state.iterator, initial_state_layout
+            )
+            gInitialKV = mInitialState[None, None, o_head_idx, state_idx]
         fixed_state_layout = cute.make_ordered_layout(
             (self.D, self.D, num_sab_heads, num_chunks), order=(0, 1, 2, 3)
         )
@@ -4158,6 +4260,20 @@ class CPDeltaRulePrefillSm120(KeyedCompileMixin):
                     scale,
                     wg_idx,
                 )
+        self.maybe_store_checkpoint(
+            tKVrKV,
+            g_state_checkpoints,
+            checkpoint_cu_starts,
+            checkpoint_every_n_tokens,
+            kv_thr_mma,
+            public_seq_idx,
+            o_head_idx,
+            num_sab_heads,
+            total_checkpoints,
+            seq_block_offset + cutlass.Int32(self.BLK_KV),
+            full_seq_len,
+        )
+
         for blk in cutlass.range(1, num_blocks - 1, 1, unroll=1):
             if cutlass.const_expr(produce_aux):
                 (
@@ -4234,6 +4350,20 @@ class CPDeltaRulePrefillSm120(KeyedCompileMixin):
                 tKVrKV,
                 scale,
                 wg_idx,
+            )
+            self.maybe_store_checkpoint(
+                tKVrKV,
+                g_state_checkpoints,
+                checkpoint_cu_starts,
+                checkpoint_every_n_tokens,
+                kv_thr_mma,
+                public_seq_idx,
+                o_head_idx,
+                num_sab_heads,
+                total_checkpoints,
+                seq_block_offset
+                + (blk + cutlass.Int32(1)) * cutlass.Int32(self.BLK_KV),
+                full_seq_len,
             )
         if num_blocks != 1:
             last_blk = num_blocks - 1
@@ -4314,6 +4444,20 @@ class CPDeltaRulePrefillSm120(KeyedCompileMixin):
                 scale,
                 wg_idx,
             )
+            self.maybe_store_checkpoint(
+                tKVrKV,
+                g_state_checkpoints,
+                checkpoint_cu_starts,
+                checkpoint_every_n_tokens,
+                kv_thr_mma,
+                public_seq_idx,
+                o_head_idx,
+                num_sab_heads,
+                total_checkpoints,
+                seq_block_offset
+                + (last_blk + cutlass.Int32(1)) * cutlass.Int32(self.BLK_KV),
+                full_seq_len,
+            )
         if cutlass.const_expr(self.store_final_state):
             if store_state:
                 self.kv_store(tKVrKV, gStateKV, kv_thr_mma)
@@ -4330,6 +4474,9 @@ class CPDeltaRulePrefillSm120(KeyedCompileMixin):
         g_state: cute.Tensor,
         g_fixed_state: cute.Tensor,
         g_initial_state: cute.Tensor,
+        g_state_indices: cute.Tensor,
+        g_state_checkpoints: cute.Tensor,
+        checkpoint_cu_starts: cute.Tensor,
         g_tensormaps: cute.Tensor,
         g_cu_seqlens: cute.Tensor,
         scale: cutlass.Float32,
@@ -4341,6 +4488,8 @@ class CPDeltaRulePrefillSm120(KeyedCompileMixin):
         total_cp_chunks: cutlass.Int32,
         max_cp_chunks_per_seq: cutlass.Int32,
         num_seqs: cutlass.Int32,
+        total_checkpoints: cutlass.Int32,
+        checkpoint_every_n_tokens: cutlass.Int32,
         stream,
     ):
         qkv_smem_layout_atom = warpgroup.make_smem_layout_atom(
@@ -4485,6 +4634,9 @@ class CPDeltaRulePrefillSm120(KeyedCompileMixin):
             g_state,
             g_fixed_state,
             g_initial_state,
+            g_state_indices,
+            g_state_checkpoints,
+            checkpoint_cu_starts,
             g_tensormaps,
             g_cu_seqlens,
             scale,
@@ -4495,6 +4647,8 @@ class CPDeltaRulePrefillSm120(KeyedCompileMixin):
             chunk_len,
             total_cp_chunks,
             num_seqs,
+            total_checkpoints,
+            checkpoint_every_n_tokens,
         ).launch(
             grid=(num_sab_heads * max_cp_chunks_per_seq, num_seqs, 1),
             block=(384, 1, 1),
@@ -4520,6 +4674,9 @@ class CPDeltaRulePrefillSm120(KeyedCompileMixin):
         g_state: cute.Tensor,
         g_fixed_state: cute.Tensor,
         g_initial_state: cute.Tensor,
+        g_state_indices: cute.Tensor,
+        g_state_checkpoints: cute.Tensor,
+        checkpoint_cu_starts: cute.Tensor,
         g_tensormaps: cute.Tensor,
         g_cu_seqlens: cute.Tensor,
         scale: cutlass.Float32,
@@ -4530,6 +4687,8 @@ class CPDeltaRulePrefillSm120(KeyedCompileMixin):
         chunk_len: cutlass.Int32,
         total_cp_chunks: cutlass.Int32,
         num_seqs: cutlass.Int32,
+        total_checkpoints: cutlass.Int32,
+        checkpoint_every_n_tokens: cutlass.Int32,
     ):
         NUM_LOAD_WARP_GROUPS = 1
         NUM_STATE_MMA_WARP_GROUPS = 2
@@ -4845,12 +5004,17 @@ class CPDeltaRulePrefillSm120(KeyedCompileMixin):
                         g_state,
                         g_fixed_state,
                         g_initial_state,
+                        g_state_indices,
+                        g_state_checkpoints,
+                        checkpoint_cu_starts,
                         work_desc,
                         seq_idx,
                         fixed_state_idx,
                         load_fixed_state,
                         load_initial_state,
                         store_state,
+                        chunk_idx_in_seq * chunk_len,
+                        seq_len,
                         scale,
                         wg_idx,
                         math_tidx,
@@ -4860,6 +5024,8 @@ class CPDeltaRulePrefillSm120(KeyedCompileMixin):
                         num_sab_heads,
                         total_cp_chunks,
                         num_seqs,
+                        total_checkpoints,
+                        checkpoint_every_n_tokens,
                         True,
                     )
                 else:
@@ -4884,12 +5050,17 @@ class CPDeltaRulePrefillSm120(KeyedCompileMixin):
                         g_state,
                         g_fixed_state,
                         g_initial_state,
+                        g_state_indices,
+                        g_state_checkpoints,
+                        checkpoint_cu_starts,
                         work_desc,
                         seq_idx,
                         fixed_state_idx,
                         load_fixed_state,
                         load_initial_state,
                         store_state,
+                        chunk_idx_in_seq * chunk_len,
+                        seq_len,
                         scale,
                         wg_idx,
                         math_tidx,
@@ -4899,16 +5070,26 @@ class CPDeltaRulePrefillSm120(KeyedCompileMixin):
                         num_sab_heads,
                         total_cp_chunks,
                         num_seqs,
+                        total_checkpoints,
+                        checkpoint_every_n_tokens,
                         False,
                     )
 
 
 @functools.cache
-def _get_prefill_kernel(kernel_dtype, needs_initial_state, store_final_state):
+def _get_prefill_kernel(
+    kernel_dtype,
+    needs_initial_state,
+    store_final_state,
+    use_state_indices,
+    needs_checkpointing,
+):
     return CPDeltaRulePrefillSm120(
         kernel_dtype,
         needs_initial_state=needs_initial_state,
         store_final_state=store_final_state,
+        use_state_indices=use_state_indices,
+        needs_checkpointing=needs_checkpointing,
     )
 
 
@@ -4927,6 +5108,10 @@ def cp_delta_rule_prefill_dsl_sm120(
     cp_chunk_len: int = 4096,
     max_seqlen: int | None = None,
     initial_state: torch.Tensor | None = None,
+    state_indices: torch.Tensor | None = None,
+    state_checkpoints: torch.Tensor | None = None,
+    checkpoint_cu_starts: torch.Tensor | None = None,
+    checkpoint_every_n_tokens: int = 0,
     *,
     _skip_check: bool = False,
     _device=None,
@@ -4941,6 +5126,7 @@ def cp_delta_rule_prefill_dsl_sm120(
     import cuda.bindings.driver as cuda_driver
 
     device = q.device if _device is None else _device
+    needs_checkpointing = checkpoint_every_n_tokens > 0
     if not _skip_check:
         if q.ndim != 3:
             raise RuntimeError(
@@ -4974,6 +5160,17 @@ def cp_delta_rule_prefill_dsl_sm120(
         if cp_chunk_len % 64 != 0:
             raise RuntimeError(
                 f"cp_chunk_len must be a multiple of 64, got {cp_chunk_len}"
+            )
+        if checkpoint_every_n_tokens < 0 or checkpoint_every_n_tokens % 64 != 0:
+            raise RuntimeError(
+                "checkpoint_every_n_tokens must be a non-negative multiple of 64, "
+                f"got {checkpoint_every_n_tokens}"
+            )
+        if needs_checkpointing and (
+            state_checkpoints is None or checkpoint_cu_starts is None
+        ):
+            raise RuntimeError(
+                "state_checkpoints and checkpoint_cu_starts are required when checkpointing is enabled"
             )
         if cu_seqlens.dtype != torch.int64:
             raise RuntimeError(
@@ -5015,8 +5212,16 @@ def cp_delta_rule_prefill_dsl_sm120(
             )
         expected_fixed_state_shape = (total_cp_chunks, num_sab_heads, d, d)
         expected_state_shape = (num_seqs, num_sab_heads, d, d)
+        use_state_indices = state_indices is not None
         if fixed_state.shape != expected_fixed_state_shape or (
-            state is not None and state.shape != expected_state_shape
+            state is not None
+            and (
+                (not use_state_indices and state.shape != expected_state_shape)
+                or (
+                    use_state_indices
+                    and tuple(state.shape[1:]) != expected_state_shape[1:]
+                )
+            )
         ):
             raise RuntimeError(
                 "fixed_state/state must have shapes "
@@ -5024,9 +5229,23 @@ def cp_delta_rule_prefill_dsl_sm120(
                 f"got {tuple(fixed_state.shape)} and "
                 f"{None if state is None else tuple(state.shape)}"
             )
-        if initial_state is not None and initial_state.shape != expected_state_shape:
+        if initial_state is not None and (
+            (not use_state_indices and initial_state.shape != expected_state_shape)
+            or (
+                use_state_indices
+                and tuple(initial_state.shape[1:]) != expected_state_shape[1:]
+            )
+        ):
             raise RuntimeError(
-                f"initial_state must have shape {expected_state_shape}, got {tuple(initial_state.shape)}"
+                f"initial_state must have shape "
+                f"{('[N_pool]' if use_state_indices else f'[{num_seqs}]')} + {expected_state_shape[1:]}, "
+                f"got {tuple(initial_state.shape)}"
+            )
+        if use_state_indices and (
+            state_indices.dtype != torch.int32 or state_indices.shape != (num_seqs,)
+        ):
+            raise RuntimeError(
+                f"state_indices must have shape {(num_seqs,)} and dtype int32"
             )
         if q.shape[-1] != 128:
             raise RuntimeError(
@@ -5054,20 +5273,46 @@ def cp_delta_rule_prefill_dsl_sm120(
             raise RuntimeError(
                 f"initial_state must have dtype torch.float32, got {initial_state.dtype}"
             )
+        if needs_checkpointing:
+            if state_checkpoints.dtype != torch.float32 or tuple(
+                state_checkpoints.shape[1:]
+            ) != (num_sab_heads, d, d):
+                raise RuntimeError(
+                    "state_checkpoints must have shape "
+                    f"[*, {num_sab_heads}, {d}, {d}] and dtype float32"
+                )
+            if (
+                checkpoint_cu_starts.dtype != torch.int64
+                or checkpoint_cu_starts.shape != (num_seqs + 1,)
+            ):
+                raise RuntimeError(
+                    f"checkpoint_cu_starts must have shape {(num_seqs + 1,)} and dtype int64"
+                )
         for name, tensor in (
             ("q", q),
             ("k", k),
             ("v", v),
             ("t", t),
             ("fixed_state", fixed_state),
-            ("initial_state", initial_state),
             ("alpha", alpha),
             ("o", o),
-            ("state", state),
+            ("state_indices", state_indices),
+            ("state_checkpoints", state_checkpoints),
+            ("checkpoint_cu_starts", checkpoint_cu_starts),
         ):
             if tensor is None:
                 continue
             if not tensor.is_contiguous():
+                raise RuntimeError(f"{name} must be contiguous")
+        for name, tensor in (("state", state), ("initial_state", initial_state)):
+            if tensor is None:
+                continue
+            if use_state_indices:
+                if tensor.stride()[1:] != (d * d, d, 1):
+                    raise RuntimeError(
+                        f"{name} inner dimensions must be contiguous when state_indices is used"
+                    )
+            elif not tensor.is_contiguous():
                 raise RuntimeError(f"{name} must be contiguous")
     max_cp_chunks_per_seq = max_num_chunks_host(max_seqlen, cp_chunk_len)
     if total_cp_chunks == 0:
@@ -5115,7 +5360,14 @@ def cp_delta_rule_prefill_dsl_sm120(
 
     needs_initial_state = initial_state is not None
     store_final_state = state is not None
-    kernel = _get_prefill_kernel(kernel_dtype, needs_initial_state, store_final_state)
+    use_state_indices = state_indices is not None
+    kernel = _get_prefill_kernel(
+        kernel_dtype,
+        needs_initial_state,
+        store_final_state,
+        use_state_indices,
+        needs_checkpointing,
+    )
     state_arg = state if store_final_state else fixed_state
     compile_options = _sm120_compile_options(device)
     compiled = get_cached_compile(kernel, compile_options)
@@ -5124,10 +5376,26 @@ def cp_delta_rule_prefill_dsl_sm120(
             *args, **{**kwargs, "enable_tvm_ffi": True}
         )
         initial_state_cute = (
-            from_dlpack(
-                initial_state.reshape(-1), assumed_align=16
-            ).mark_layout_dynamic()
+            from_dlpack(initial_state, assumed_align=16).mark_layout_dynamic()
             if needs_initial_state
+            else None
+        )
+        state_indices_cute = (
+            from_dlpack(state_indices, assumed_align=4).mark_layout_dynamic()
+            if use_state_indices
+            else None
+        )
+        total_checkpoints = state_checkpoints.shape[0] if needs_checkpointing else 1
+        state_checkpoints_cute = (
+            from_dlpack(
+                state_checkpoints.reshape(-1), assumed_align=16
+            ).mark_layout_dynamic()
+            if needs_checkpointing
+            else None
+        )
+        checkpoint_cu_cute = (
+            from_dlpack(checkpoint_cu_starts, assumed_align=8).mark_layout_dynamic()
+            if needs_checkpointing
             else None
         )
         kernel_args = (
@@ -5137,11 +5405,14 @@ def cp_delta_rule_prefill_dsl_sm120(
             from_dlpack(t_tma, assumed_align=16).mark_layout_dynamic(leading_dim=1),
             from_dlpack(o_tma, assumed_align=16).mark_layout_dynamic(leading_dim=0),
             from_dlpack(alpha.reshape(-1), assumed_align=16).mark_layout_dynamic(),
-            from_dlpack(state_arg.reshape(-1), assumed_align=16).mark_layout_dynamic(),
+            from_dlpack(state_arg, assumed_align=16).mark_layout_dynamic(),
             from_dlpack(
                 fixed_state.reshape(-1), assumed_align=16
             ).mark_layout_dynamic(),
             initial_state_cute,
+            state_indices_cute,
+            state_checkpoints_cute,
+            checkpoint_cu_cute,
             from_dlpack(tensormaps_t, assumed_align=128).mark_layout_dynamic(),
             from_dlpack(cu_seqlens, assumed_align=8).mark_layout_dynamic(),
             cutlass.Float32(scale),
@@ -5153,6 +5424,8 @@ def cp_delta_rule_prefill_dsl_sm120(
             cutlass.Int32(total_cp_chunks),
             cutlass.Int32(max_cp_chunks_per_seq),
             cutlass.Int32(num_seqs),
+            cutlass.Int32(total_checkpoints),
+            cutlass.Int32(checkpoint_every_n_tokens),
             stream,
         )
         compiled = cached_compile(kernel, *kernel_args, compile_options=compile_options)
@@ -5163,9 +5436,12 @@ def cp_delta_rule_prefill_dsl_sm120(
         t_tma,
         o_tma,
         alpha.reshape(-1),
-        state_arg.reshape(-1),
+        state_arg,
         fixed_state.reshape(-1),
-        initial_state.reshape(-1) if needs_initial_state else None,
+        initial_state if needs_initial_state else None,
+        state_indices if use_state_indices else None,
+        state_checkpoints.reshape(-1) if needs_checkpointing else None,
+        checkpoint_cu_starts if needs_checkpointing else None,
         tensormaps_t,
         cu_seqlens,
         scale,
@@ -5177,6 +5453,8 @@ def cp_delta_rule_prefill_dsl_sm120(
         total_cp_chunks,
         max_cp_chunks_per_seq,
         num_seqs,
+        state_checkpoints.shape[0] if needs_checkpointing else 1,
+        checkpoint_every_n_tokens,
         stream,
     )
 
@@ -5193,6 +5471,10 @@ def cp_delta_rule_dsl_sm120(
     scale: float,
     *,
     initial_state: torch.Tensor | None = None,
+    state_indices: torch.Tensor | None = None,
+    state_checkpoints: torch.Tensor | None = None,
+    checkpoint_cu_starts: torch.Tensor | None = None,
+    checkpoint_every_n_tokens: int = 0,
     max_seqlen: int | None = None,
     cp_chunk_len: int | None = None,
     cp_chunk_len_granularity: int = CP_CHUNK_LEN_GRANULARITY,
@@ -5254,6 +5536,18 @@ def cp_delta_rule_dsl_sm120(
         )
     if cp_chunk_len % 64 != 0:
         raise RuntimeError(f"cp_chunk_len must be a multiple of 64, got {cp_chunk_len}")
+    needs_checkpointing = checkpoint_every_n_tokens > 0
+    if checkpoint_every_n_tokens < 0 or checkpoint_every_n_tokens % 64 != 0:
+        raise RuntimeError(
+            "checkpoint_every_n_tokens must be a non-negative multiple of 64, "
+            f"got {checkpoint_every_n_tokens}"
+        )
+    if needs_checkpointing and (
+        state_checkpoints is None or checkpoint_cu_starts is None
+    ):
+        raise RuntimeError(
+            "state_checkpoints and checkpoint_cu_starts are required when checkpointing is enabled"
+        )
     if cu_seqlens.dtype != torch.int64:
         raise RuntimeError(
             f"cu_seqlens must have dtype torch.int64, got {cu_seqlens.dtype}"
@@ -5284,13 +5578,33 @@ def cp_delta_rule_dsl_sm120(
             f"of k heads, got q={num_q_heads}, k={num_k_heads}, v={num_v_heads}"
         )
     expected_state_shape = (num_seqs, num_sab_heads, d, d)
-    if state is not None and state.shape != expected_state_shape:
+    use_state_indices = state_indices is not None
+    if state is not None and (
+        (not use_state_indices and state.shape != expected_state_shape)
+        or (use_state_indices and tuple(state.shape[1:]) != expected_state_shape[1:])
+    ):
         raise RuntimeError(
-            f"state must have shape {expected_state_shape}, got {tuple(state.shape)}"
+            f"state must have shape "
+            f"{('[N_pool]' if use_state_indices else f'[{num_seqs}]')} + {expected_state_shape[1:]}, "
+            f"got {tuple(state.shape)}"
         )
-    if initial_state is not None and initial_state.shape != expected_state_shape:
+    if initial_state is not None and (
+        (not use_state_indices and initial_state.shape != expected_state_shape)
+        or (
+            use_state_indices
+            and tuple(initial_state.shape[1:]) != expected_state_shape[1:]
+        )
+    ):
         raise RuntimeError(
-            f"initial_state must have shape {expected_state_shape}, got {tuple(initial_state.shape)}"
+            f"initial_state must have shape "
+            f"{('[N_pool]' if use_state_indices else f'[{num_seqs}]')} + {expected_state_shape[1:]}, "
+            f"got {tuple(initial_state.shape)}"
+        )
+    if use_state_indices and (
+        state_indices.dtype != torch.int32 or state_indices.shape != (num_seqs,)
+    ):
+        raise RuntimeError(
+            f"state_indices must have shape {(num_seqs,)} and dtype int32"
         )
     if q.shape[-1] != 128:
         raise RuntimeError(f"CPDeltaRuleSm120 only supports D=128, got {q.shape[-1]}")
@@ -5311,6 +5625,20 @@ def cp_delta_rule_dsl_sm120(
         raise RuntimeError(
             f"initial_state must have dtype torch.float32, got {initial_state.dtype}"
         )
+    if needs_checkpointing:
+        if state_checkpoints.dtype != torch.float32 or tuple(
+            state_checkpoints.shape[1:]
+        ) != (num_sab_heads, d, d):
+            raise RuntimeError(
+                "state_checkpoints must have shape "
+                f"[*, {num_sab_heads}, {d}, {d}] and dtype float32"
+            )
+        if checkpoint_cu_starts.dtype != torch.int64 or checkpoint_cu_starts.shape != (
+            num_seqs + 1,
+        ):
+            raise RuntimeError(
+                f"checkpoint_cu_starts must have shape {(num_seqs + 1,)} and dtype int64"
+            )
     for name, tensor in (
         ("q", q),
         ("k", k),
@@ -5318,12 +5646,23 @@ def cp_delta_rule_dsl_sm120(
         ("alpha", alpha),
         ("beta", beta),
         ("o", o),
-        ("state", state),
-        ("initial_state", initial_state),
+        ("state_indices", state_indices),
+        ("state_checkpoints", state_checkpoints),
+        ("checkpoint_cu_starts", checkpoint_cu_starts),
     ):
         if tensor is None:
             continue
         if not tensor.is_contiguous():
+            raise RuntimeError(f"{name} must be contiguous")
+    for name, tensor in (("state", state), ("initial_state", initial_state)):
+        if tensor is None:
+            continue
+        if use_state_indices:
+            if tensor.stride()[1:] != (d * d, d, 1):
+                raise RuntimeError(
+                    f"{name} inner dimensions must be contiguous when state_indices is used"
+                )
+        elif not tensor.is_contiguous():
             raise RuntimeError(f"{name} must be contiguous")
 
     t = cp_delta_rule_t_precompute_dsl_sm120(
@@ -5356,6 +5695,7 @@ def cp_delta_rule_dsl_sm120(
         total_seqlen,
         cp_chunk_len=cp_chunk_len,
         initial_state=initial_state,
+        state_indices=state_indices,
         _skip_check=True,
         _device=device,
         _stream=stream,
@@ -5376,6 +5716,10 @@ def cp_delta_rule_dsl_sm120(
         cp_chunk_len=cp_chunk_len,
         max_seqlen=max_seqlen,
         initial_state=initial_state,
+        state_indices=state_indices,
+        state_checkpoints=state_checkpoints,
+        checkpoint_cu_starts=checkpoint_cu_starts,
+        checkpoint_every_n_tokens=checkpoint_every_n_tokens,
         _skip_check=True,
         _device=device,
         _stream=stream,

--- a/flashinfer/gdn_kernels/delta_rule_dsl/delta_rule_cp_sm120.py
+++ b/flashinfer/gdn_kernels/delta_rule_dsl/delta_rule_cp_sm120.py
@@ -39,6 +39,8 @@ from .varlen_helper import (
     CP_CHUNK_LEN_GRANULARITY,
     choose_cp_chunk_len_host,
     chunks_for_len,
+    integer_dtype_to_cutlass,
+    is_integer_dtype,
     max_num_chunks_host,
     varlen_chunk_idx,
     varlen_chunk_valid_len,
@@ -478,8 +480,11 @@ class CPDeltaRuleTPrecomputeSm120(KeyedCompileMixin):
 
 
 @functools.cache
-def _get_t_precompute_kernel(kernel_dtype):
-    return CPDeltaRuleTPrecomputeSm120(kernel_dtype)
+def _get_t_precompute_kernel(kernel_dtype, cu_seqlens_dtype):
+    return CPDeltaRuleTPrecomputeSm120(
+        kernel_dtype,
+        cu_seqlens_dtype=integer_dtype_to_cutlass(cu_seqlens_dtype),
+    )
 
 
 def cp_delta_rule_t_precompute_dsl_sm120(
@@ -518,9 +523,9 @@ def cp_delta_rule_t_precompute_dsl_sm120(
             raise RuntimeError(
                 f"total_seqlen must match k.shape[0], got {total_seqlen} and {k.shape[0]}"
             )
-        if cu_seqlens.dtype != torch.int64:
+        if not is_integer_dtype(cu_seqlens.dtype):
             raise RuntimeError(
-                f"cu_seqlens must have dtype torch.int64, got {cu_seqlens.dtype}"
+                f"cu_seqlens must have an integer dtype, got {cu_seqlens.dtype}"
             )
         if not cu_seqlens.is_contiguous():
             raise RuntimeError("cu_seqlens must be contiguous")
@@ -577,7 +582,7 @@ def cp_delta_rule_t_precompute_dsl_sm120(
     )
 
     compile_options = _sm120_compile_options(device)
-    kernel = _get_t_precompute_kernel(kernel_dtype)
+    kernel = _get_t_precompute_kernel(kernel_dtype, cu_seqlens.dtype)
     compiled = get_cached_compile(kernel, compile_options)
     if compiled is None:
         from_dlpack = lambda *args, **kwargs: cute.runtime.from_dlpack(
@@ -649,9 +654,11 @@ class CPDeltaRuleMNPrecomputeSm120(KeyedCompileMixin):
         self,
         dtype: type[cutlass.Numeric] = cutlass.Float16,
         acc_dtype: type[cutlass.Numeric] = cutlass.Float32,
+        cu_seqlens_dtype: type[cutlass.Numeric] = cutlass.Int64,
     ):
         self.dtype = dtype
         self.acc_dtype = acc_dtype
+        self.cu_seqlens_dtype = cu_seqlens_dtype
         self.BLK = 64
         self.D = 128
         self.k_stage = 2
@@ -661,6 +668,7 @@ class CPDeltaRuleMNPrecomputeSm120(KeyedCompileMixin):
         self.manual_cache_key(
             "dtype",
             "acc_dtype",
+            "cu_seqlens_dtype",
             "BLK",
             "D",
             "k_stage",
@@ -1625,8 +1633,11 @@ class CPDeltaRuleMNPrecomputeSm120(KeyedCompileMixin):
 
 
 @functools.cache
-def _get_mn_precompute_kernel(kernel_dtype):
-    return CPDeltaRuleMNPrecomputeSm120(kernel_dtype)
+def _get_mn_precompute_kernel(kernel_dtype, cu_seqlens_dtype):
+    return CPDeltaRuleMNPrecomputeSm120(
+        kernel_dtype,
+        cu_seqlens_dtype=integer_dtype_to_cutlass(cu_seqlens_dtype),
+    )
 
 
 def cp_delta_rule_mn_precompute_dsl_sm120(
@@ -1676,9 +1687,9 @@ def cp_delta_rule_mn_precompute_dsl_sm120(
             raise RuntimeError(
                 f"cp_chunk_len must be a multiple of 64, got {cp_chunk_len}"
             )
-        if cu_seqlens.dtype != torch.int64:
+        if not is_integer_dtype(cu_seqlens.dtype):
             raise RuntimeError(
-                f"cu_seqlens must have dtype torch.int64, got {cu_seqlens.dtype}"
+                f"cu_seqlens must have an integer dtype, got {cu_seqlens.dtype}"
             )
         if not cu_seqlens.is_contiguous():
             raise RuntimeError("cu_seqlens must be contiguous")
@@ -1764,7 +1775,7 @@ def cp_delta_rule_mn_precompute_dsl_sm120(
     )
 
     compile_options = _sm120_compile_options(device)
-    kernel = _get_mn_precompute_kernel(kernel_dtype)
+    kernel = _get_mn_precompute_kernel(kernel_dtype, cu_seqlens.dtype)
     compiled = get_cached_compile(kernel, compile_options)
     if compiled is None:
         from_dlpack = lambda *args, **kwargs: cute.runtime.from_dlpack(
@@ -1821,6 +1832,9 @@ class CPDeltaRuleFixupHmmaSm120(KeyedCompileMixin):
         state_dtype: type[cutlass.Numeric] = cutlass.Float32,
         cu_seqlens_dtype: type[cutlass.Numeric] = cutlass.Int64,
         use_state_indices: bool = False,
+        state_indices_dtype: type[cutlass.Numeric] | None = None,
+        initial_state_inner_strides: tuple[int, ...] | None = None,
+        output_state_inner_strides: tuple[int, ...] | None = None,
         store_initial_state: bool = False,
     ):
         self.needs_initial_state = needs_initial_state
@@ -1829,6 +1843,9 @@ class CPDeltaRuleFixupHmmaSm120(KeyedCompileMixin):
         self.state_dtype = state_dtype
         self.cu_seqlens_dtype = cu_seqlens_dtype
         self.use_state_indices = use_state_indices
+        self.state_indices_dtype = state_indices_dtype
+        self.initial_state_inner_strides = initial_state_inner_strides
+        self.output_state_inner_strides = output_state_inner_strides
         self.store_initial_state = store_initial_state
         self.D = 128
         self.rows_per_cta = 64
@@ -1850,6 +1867,9 @@ class CPDeltaRuleFixupHmmaSm120(KeyedCompileMixin):
             "state_dtype",
             "cu_seqlens_dtype",
             "use_state_indices",
+            "state_indices_dtype",
+            "initial_state_inner_strides",
+            "output_state_inner_strides",
             "store_initial_state",
             "D",
             "rows_per_cta",
@@ -2214,16 +2234,20 @@ class CPDeltaRuleFixupHmmaSm120(KeyedCompileMixin):
         if cutlass.const_expr(self.use_state_indices):
             state_idx = cutlass.Int32(g_state_indices_t[seq_idx])
         if cutlass.const_expr(self.needs_initial_state):
+            initial_state_ref_layout = cute.make_layout(
+                (
+                    g_initial_state_t.shape[0],
+                    g_initial_state_t.shape[1],
+                    self.D,
+                    self.D,
+                ),
+                stride=g_initial_state_t.stride,
+            )
+            indexed_initial_state_layout = cute.select(
+                initial_state_ref_layout, mode=[2, 3, 1, 0]
+            )
             if cutlass.const_expr(self.use_state_indices):
-                initial_state_layout = cute.make_layout(
-                    (self.D, self.D, num_heads, g_initial_state_t.shape[0]),
-                    stride=(
-                        g_initial_state_t.stride[2],
-                        g_initial_state_t.stride[3],
-                        g_initial_state_t.stride[1],
-                        g_initial_state_t.stride[0],
-                    ),
-                )
+                initial_state_layout = indexed_initial_state_layout
                 gInitialState = cute.make_tensor(
                     g_initial_state_t.iterator, initial_state_layout
                 )
@@ -2234,16 +2258,20 @@ class CPDeltaRuleFixupHmmaSm120(KeyedCompileMixin):
         else:
             gInitialState = gFixedState
         if cutlass.const_expr(self.store_final_state):
+            output_state_ref_layout = cute.make_layout(
+                (
+                    g_output_state_t.shape[0],
+                    g_output_state_t.shape[1],
+                    self.D,
+                    self.D,
+                ),
+                stride=g_output_state_t.stride,
+            )
+            indexed_output_state_layout = cute.select(
+                output_state_ref_layout, mode=[2, 3, 1, 0]
+            )
             if cutlass.const_expr(self.use_state_indices):
-                output_state_layout = cute.make_layout(
-                    (self.D, self.D, num_heads, g_output_state_t.shape[0]),
-                    stride=(
-                        g_output_state_t.stride[2],
-                        g_output_state_t.stride[3],
-                        g_output_state_t.stride[1],
-                        g_output_state_t.stride[0],
-                    ),
-                )
+                output_state_layout = indexed_output_state_layout
                 gOutputState = cute.make_tensor(
                     g_output_state_t.iterator, output_state_layout
                 )
@@ -2444,6 +2472,9 @@ class CPDeltaRuleFixupSimtSm120(KeyedCompileMixin):
         state_dtype: type[cutlass.Numeric] = cutlass.Float32,
         cu_seqlens_dtype: type[cutlass.Numeric] = cutlass.Int64,
         use_state_indices: bool = False,
+        state_indices_dtype: type[cutlass.Numeric] | None = None,
+        initial_state_inner_strides: tuple[int, ...] | None = None,
+        output_state_inner_strides: tuple[int, ...] | None = None,
         store_initial_state: bool = False,
     ):
         self.needs_initial_state = needs_initial_state
@@ -2452,6 +2483,9 @@ class CPDeltaRuleFixupSimtSm120(KeyedCompileMixin):
         self.state_dtype = state_dtype
         self.cu_seqlens_dtype = cu_seqlens_dtype
         self.use_state_indices = use_state_indices
+        self.state_indices_dtype = state_indices_dtype
+        self.initial_state_inner_strides = initial_state_inner_strides
+        self.output_state_inner_strides = output_state_inner_strides
         self.store_initial_state = store_initial_state
         self.D = 128
         self.rows_per_cta = rows_per_cta
@@ -2467,6 +2501,9 @@ class CPDeltaRuleFixupSimtSm120(KeyedCompileMixin):
             "state_dtype",
             "cu_seqlens_dtype",
             "use_state_indices",
+            "state_indices_dtype",
+            "initial_state_inner_strides",
+            "output_state_inner_strides",
             "store_initial_state",
             "D",
             "rows_per_cta",
@@ -2718,16 +2755,20 @@ class CPDeltaRuleFixupSimtSm120(KeyedCompileMixin):
         if cutlass.const_expr(self.use_state_indices):
             state_idx = cutlass.Int32(g_state_indices_t[seq_idx])
         if cutlass.const_expr(self.needs_initial_state):
+            initial_state_ref_layout = cute.make_layout(
+                (
+                    g_initial_state_t.shape[0],
+                    g_initial_state_t.shape[1],
+                    self.D,
+                    self.D,
+                ),
+                stride=g_initial_state_t.stride,
+            )
+            indexed_initial_state_layout = cute.select(
+                initial_state_ref_layout, mode=[2, 3, 1, 0]
+            )
             if cutlass.const_expr(self.use_state_indices):
-                initial_state_layout = cute.make_layout(
-                    (self.D, self.D, num_heads, g_initial_state_t.shape[0]),
-                    stride=(
-                        g_initial_state_t.stride[2],
-                        g_initial_state_t.stride[3],
-                        g_initial_state_t.stride[1],
-                        g_initial_state_t.stride[0],
-                    ),
-                )
+                initial_state_layout = indexed_initial_state_layout
                 gInitialState = cute.make_tensor(
                     g_initial_state_t.iterator, initial_state_layout
                 )
@@ -2738,16 +2779,20 @@ class CPDeltaRuleFixupSimtSm120(KeyedCompileMixin):
         else:
             gInitialState = gFixedState
         if cutlass.const_expr(self.store_final_state):
+            output_state_ref_layout = cute.make_layout(
+                (
+                    g_output_state_t.shape[0],
+                    g_output_state_t.shape[1],
+                    self.D,
+                    self.D,
+                ),
+                stride=g_output_state_t.stride,
+            )
+            indexed_output_state_layout = cute.select(
+                output_state_ref_layout, mode=[2, 3, 1, 0]
+            )
             if cutlass.const_expr(self.use_state_indices):
-                output_state_layout = cute.make_layout(
-                    (self.D, self.D, num_heads, g_output_state_t.shape[0]),
-                    stride=(
-                        g_output_state_t.stride[2],
-                        g_output_state_t.stride[3],
-                        g_output_state_t.stride[1],
-                        g_output_state_t.stride[0],
-                    ),
-                )
+                output_state_layout = indexed_output_state_layout
                 gOutputState = cute.make_tensor(
                     g_output_state_t.iterator, output_state_layout
                 )
@@ -2825,13 +2870,29 @@ class CPDeltaRuleFixupSimtSm120(KeyedCompileMixin):
 
 
 @functools.cache
-def _get_fixup_kernel(needs_initial_state, kernel_kind, use_state_indices):
+def _get_fixup_kernel(
+    needs_initial_state,
+    kernel_kind,
+    use_state_indices,
+    cu_seqlens_dtype,
+    state_indices_dtype,
+    initial_state_inner_strides,
+):
+    kernel_kwargs = dict(
+        needs_initial_state=needs_initial_state,
+        cu_seqlens_dtype=integer_dtype_to_cutlass(cu_seqlens_dtype),
+        use_state_indices=use_state_indices,
+        state_indices_dtype=(
+            integer_dtype_to_cutlass(state_indices_dtype) if use_state_indices else None
+        ),
+        initial_state_inner_strides=initial_state_inner_strides,
+    )
     if kernel_kind == "simt_row4":
-        return CPDeltaRuleFixupSimtSm120(needs_initial_state, 4, use_state_indices)
+        return CPDeltaRuleFixupSimtSm120(rows_per_cta=4, **kernel_kwargs)
     if kernel_kind == "simt_row8":
-        return CPDeltaRuleFixupSimtSm120(needs_initial_state, 8, use_state_indices)
+        return CPDeltaRuleFixupSimtSm120(rows_per_cta=8, **kernel_kwargs)
     if kernel_kind == "hmma":
-        return CPDeltaRuleFixupHmmaSm120(needs_initial_state, use_state_indices)
+        return CPDeltaRuleFixupHmmaSm120(**kernel_kwargs)
     raise ValueError(f"Unsupported fixup kernel kind: {kernel_kind}")
 
 
@@ -2897,11 +2958,11 @@ def cp_delta_rule_fixup_dsl_sm120(
                     f"initial_state must have dtype torch.float32, got {initial_state.dtype}"
                 )
         if use_state_indices and (
-            state_indices.dtype != torch.int32
+            not is_integer_dtype(state_indices.dtype)
             or state_indices.shape != (cu_seqlens.shape[0] - 1,)
         ):
             raise RuntimeError(
-                f"state_indices must have shape {(cu_seqlens.shape[0] - 1,)} and dtype int32"
+                f"state_indices must have shape {(cu_seqlens.shape[0] - 1,)} and an integer dtype"
             )
         for name, tensor in (
             ("local_transfer", local_transfer),
@@ -2913,20 +2974,15 @@ def cp_delta_rule_fixup_dsl_sm120(
             if not tensor.is_contiguous():
                 raise RuntimeError(f"{name} must be contiguous")
         if initial_state is not None:
-            if use_state_indices:
-                if initial_state.stride()[1:] != (128 * 128, 128, 1):
-                    raise RuntimeError(
-                        "initial_state inner dimensions must be contiguous when state_indices is used"
-                    )
-            elif not initial_state.is_contiguous():
+            if not use_state_indices and not initial_state.is_contiguous():
                 raise RuntimeError("initial_state must be contiguous")
     total_cp_chunks, num_heads, _, _ = local_transfer.shape
     if not _skip_check:
         if cp_chunk_len <= 0:
             raise RuntimeError(f"cp_chunk_len must be positive, got {cp_chunk_len}")
-        if cu_seqlens.dtype != torch.int64:
+        if not is_integer_dtype(cu_seqlens.dtype):
             raise RuntimeError(
-                f"cu_seqlens must have dtype torch.int64, got {cu_seqlens.dtype}"
+                f"cu_seqlens must have an integer dtype, got {cu_seqlens.dtype}"
             )
         expected_chunks = workspace_num_chunks_host(
             cu_seqlens, cp_chunk_len, total_seqlen
@@ -2973,7 +3029,18 @@ def cp_delta_rule_fixup_dsl_sm120(
         else:
             _kernel_kind = "hmma"
     compile_options = _sm120_compile_options(device)
-    kernel = _get_fixup_kernel(needs_initial_state, _kernel_kind, use_state_indices)
+    kernel = _get_fixup_kernel(
+        needs_initial_state,
+        _kernel_kind,
+        use_state_indices,
+        cu_seqlens.dtype,
+        state_indices.dtype if use_state_indices else None,
+        (
+            tuple(initial_state.stride()[1:])
+            if use_state_indices and needs_initial_state
+            else None
+        ),
+    )
     compiled = get_cached_compile(kernel, compile_options)
     if compiled is None:
         from_dlpack = lambda *args, **kwargs: cute.runtime.from_dlpack(
@@ -3060,6 +3127,11 @@ class CPDeltaRulePrefillSm120(KeyedCompileMixin):
         store_final_state: bool = True,
         use_state_indices: bool = False,
         needs_checkpointing: bool = False,
+        cu_seqlens_dtype: torch.dtype = torch.int64,
+        state_indices_dtype: torch.dtype | None = None,
+        checkpoint_cu_starts_dtype: torch.dtype | None = None,
+        state_inner_strides: tuple[int, ...] | None = None,
+        initial_state_inner_strides: tuple[int, ...] | None = None,
     ):
         self.needs_alpha = True
         self.dtype = dtype
@@ -3071,6 +3143,11 @@ class CPDeltaRulePrefillSm120(KeyedCompileMixin):
         self.store_final_state = store_final_state
         self.use_state_indices = use_state_indices
         self.needs_checkpointing = needs_checkpointing
+        self.cu_seqlens_dtype = cu_seqlens_dtype
+        self.state_indices_dtype = state_indices_dtype
+        self.checkpoint_cu_starts_dtype = checkpoint_cu_starts_dtype
+        self.state_inner_strides = state_inner_strides
+        self.initial_state_inner_strides = initial_state_inner_strides
         self.q_stage = 1
         self.k_stage = 1
         self.v_stage = 1
@@ -3085,6 +3162,11 @@ class CPDeltaRulePrefillSm120(KeyedCompileMixin):
             "store_final_state",
             "use_state_indices",
             "needs_checkpointing",
+            "cu_seqlens_dtype",
+            "state_indices_dtype",
+            "checkpoint_cu_starts_dtype",
+            "state_inner_strides",
+            "initial_state_inner_strides",
             "dtype",
             "acc_dtype",
             "BLK_Q",
@@ -4050,37 +4132,30 @@ class CPDeltaRulePrefillSm120(KeyedCompileMixin):
         packed_state_layout = cute.make_ordered_layout(
             (self.D, self.D, num_sab_heads, num_seqs), order=(0, 1, 2, 3)
         )
+        state_ref_shape = (g_state.shape[0], g_state.shape[1], self.D, self.D)
+        state_ref_layout = cute.make_layout(state_ref_shape, stride=g_state.stride)
+        indexed_state_layout = cute.select(state_ref_layout, mode=[3, 2, 1, 0])
         state_idx = public_seq_idx
         if cutlass.const_expr(self.use_state_indices):
             state_idx = cutlass.Int32(g_state_indices[public_seq_idx])
         output_state_idx = public_seq_idx
         if cutlass.const_expr(self.use_state_indices and self.store_final_state):
             output_state_idx = state_idx
-            state_layout = cute.make_layout(
-                (self.D, self.D, num_sab_heads, g_state.shape[0]),
-                stride=(
-                    g_state.stride[3],
-                    g_state.stride[2],
-                    g_state.stride[1],
-                    g_state.stride[0],
-                ),
-            )
+            state_layout = indexed_state_layout
         else:
             state_layout = packed_state_layout
         o_head_idx = work_desc.o_head_idx(num_q_heads, num_v_heads)
         mState = cute.make_tensor(g_state.iterator, state_layout)
         gStateKV = mState[None, None, o_head_idx, output_state_idx]
         if cutlass.const_expr(self.needs_initial_state):
+            initial_state_ref_layout = cute.make_layout(
+                state_ref_shape, stride=g_initial_state.stride
+            )
+            indexed_initial_state_layout = cute.select(
+                initial_state_ref_layout, mode=[3, 2, 1, 0]
+            )
             if cutlass.const_expr(self.use_state_indices):
-                initial_state_layout = cute.make_layout(
-                    (self.D, self.D, num_sab_heads, g_initial_state.shape[0]),
-                    stride=(
-                        g_initial_state.stride[3],
-                        g_initial_state.stride[2],
-                        g_initial_state.stride[1],
-                        g_initial_state.stride[0],
-                    ),
-                )
+                initial_state_layout = indexed_initial_state_layout
             else:
                 initial_state_layout = packed_state_layout
             mInitialState = cute.make_tensor(
@@ -5083,6 +5158,11 @@ def _get_prefill_kernel(
     store_final_state,
     use_state_indices,
     needs_checkpointing,
+    cu_seqlens_dtype,
+    state_indices_dtype,
+    checkpoint_cu_starts_dtype,
+    state_inner_strides,
+    initial_state_inner_strides,
 ):
     return CPDeltaRulePrefillSm120(
         kernel_dtype,
@@ -5090,6 +5170,11 @@ def _get_prefill_kernel(
         store_final_state=store_final_state,
         use_state_indices=use_state_indices,
         needs_checkpointing=needs_checkpointing,
+        cu_seqlens_dtype=cu_seqlens_dtype,
+        state_indices_dtype=state_indices_dtype,
+        checkpoint_cu_starts_dtype=checkpoint_cu_starts_dtype,
+        state_inner_strides=state_inner_strides,
+        initial_state_inner_strides=initial_state_inner_strides,
     )
 
 
@@ -5172,9 +5257,9 @@ def cp_delta_rule_prefill_dsl_sm120(
             raise RuntimeError(
                 "state_checkpoints and checkpoint_cu_starts are required when checkpointing is enabled"
             )
-        if cu_seqlens.dtype != torch.int64:
+        if not is_integer_dtype(cu_seqlens.dtype):
             raise RuntimeError(
-                f"cu_seqlens must have dtype torch.int64, got {cu_seqlens.dtype}"
+                f"cu_seqlens must have an integer dtype, got {cu_seqlens.dtype}"
             )
         if not cu_seqlens.is_contiguous():
             raise RuntimeError("cu_seqlens must be contiguous")
@@ -5242,10 +5327,11 @@ def cp_delta_rule_prefill_dsl_sm120(
                 f"got {tuple(initial_state.shape)}"
             )
         if use_state_indices and (
-            state_indices.dtype != torch.int32 or state_indices.shape != (num_seqs,)
+            not is_integer_dtype(state_indices.dtype)
+            or state_indices.shape != (num_seqs,)
         ):
             raise RuntimeError(
-                f"state_indices must have shape {(num_seqs,)} and dtype int32"
+                f"state_indices must have shape {(num_seqs,)} and an integer dtype"
             )
         if q.shape[-1] != 128:
             raise RuntimeError(
@@ -5281,12 +5367,11 @@ def cp_delta_rule_prefill_dsl_sm120(
                     "state_checkpoints must have shape "
                     f"[*, {num_sab_heads}, {d}, {d}] and dtype float32"
                 )
-            if (
-                checkpoint_cu_starts.dtype != torch.int64
-                or checkpoint_cu_starts.shape != (num_seqs + 1,)
-            ):
+            if not is_integer_dtype(
+                checkpoint_cu_starts.dtype
+            ) or checkpoint_cu_starts.shape != (num_seqs + 1,):
                 raise RuntimeError(
-                    f"checkpoint_cu_starts must have shape {(num_seqs + 1,)} and dtype int64"
+                    f"checkpoint_cu_starts must have shape {(num_seqs + 1,)} and an integer dtype"
                 )
         for name, tensor in (
             ("q", q),
@@ -5307,12 +5392,7 @@ def cp_delta_rule_prefill_dsl_sm120(
         for name, tensor in (("state", state), ("initial_state", initial_state)):
             if tensor is None:
                 continue
-            if use_state_indices:
-                if tensor.stride()[1:] != (d * d, d, 1):
-                    raise RuntimeError(
-                        f"{name} inner dimensions must be contiguous when state_indices is used"
-                    )
-            elif not tensor.is_contiguous():
+            if not use_state_indices and not tensor.is_contiguous():
                 raise RuntimeError(f"{name} must be contiguous")
     max_cp_chunks_per_seq = max_num_chunks_host(max_seqlen, cp_chunk_len)
     if total_cp_chunks == 0:
@@ -5363,10 +5443,25 @@ def cp_delta_rule_prefill_dsl_sm120(
     use_state_indices = state_indices is not None
     kernel = _get_prefill_kernel(
         kernel_dtype,
-        needs_initial_state,
-        store_final_state,
-        use_state_indices,
-        needs_checkpointing,
+        needs_initial_state=needs_initial_state,
+        store_final_state=store_final_state,
+        use_state_indices=use_state_indices,
+        needs_checkpointing=needs_checkpointing,
+        cu_seqlens_dtype=cu_seqlens.dtype,
+        state_indices_dtype=state_indices.dtype if use_state_indices else None,
+        checkpoint_cu_starts_dtype=(
+            checkpoint_cu_starts.dtype if needs_checkpointing else None
+        ),
+        state_inner_strides=(
+            tuple(state.stride()[1:])
+            if use_state_indices and store_final_state
+            else None
+        ),
+        initial_state_inner_strides=(
+            tuple(initial_state.stride()[1:])
+            if use_state_indices and needs_initial_state
+            else None
+        ),
     )
     state_arg = state if store_final_state else fixed_state
     compile_options = _sm120_compile_options(device)
@@ -5548,9 +5643,9 @@ def cp_delta_rule_dsl_sm120(
         raise RuntimeError(
             "state_checkpoints and checkpoint_cu_starts are required when checkpointing is enabled"
         )
-    if cu_seqlens.dtype != torch.int64:
+    if not is_integer_dtype(cu_seqlens.dtype):
         raise RuntimeError(
-            f"cu_seqlens must have dtype torch.int64, got {cu_seqlens.dtype}"
+            f"cu_seqlens must have an integer dtype, got {cu_seqlens.dtype}"
         )
     if not cu_seqlens.is_contiguous():
         raise RuntimeError("cu_seqlens must be contiguous")
@@ -5601,10 +5696,10 @@ def cp_delta_rule_dsl_sm120(
             f"got {tuple(initial_state.shape)}"
         )
     if use_state_indices and (
-        state_indices.dtype != torch.int32 or state_indices.shape != (num_seqs,)
+        not is_integer_dtype(state_indices.dtype) or state_indices.shape != (num_seqs,)
     ):
         raise RuntimeError(
-            f"state_indices must have shape {(num_seqs,)} and dtype int32"
+            f"state_indices must have shape {(num_seqs,)} and an integer dtype"
         )
     if q.shape[-1] != 128:
         raise RuntimeError(f"CPDeltaRuleSm120 only supports D=128, got {q.shape[-1]}")
@@ -5633,11 +5728,11 @@ def cp_delta_rule_dsl_sm120(
                 "state_checkpoints must have shape "
                 f"[*, {num_sab_heads}, {d}, {d}] and dtype float32"
             )
-        if checkpoint_cu_starts.dtype != torch.int64 or checkpoint_cu_starts.shape != (
-            num_seqs + 1,
-        ):
+        if not is_integer_dtype(
+            checkpoint_cu_starts.dtype
+        ) or checkpoint_cu_starts.shape != (num_seqs + 1,):
             raise RuntimeError(
-                f"checkpoint_cu_starts must have shape {(num_seqs + 1,)} and dtype int64"
+                f"checkpoint_cu_starts must have shape {(num_seqs + 1,)} and an integer dtype"
             )
     for name, tensor in (
         ("q", q),
@@ -5657,12 +5752,7 @@ def cp_delta_rule_dsl_sm120(
     for name, tensor in (("state", state), ("initial_state", initial_state)):
         if tensor is None:
             continue
-        if use_state_indices:
-            if tensor.stride()[1:] != (d * d, d, 1):
-                raise RuntimeError(
-                    f"{name} inner dimensions must be contiguous when state_indices is used"
-                )
-        elif not tensor.is_contiguous():
+        if not use_state_indices and not tensor.is_contiguous():
             raise RuntimeError(f"{name} must be contiguous")
 
     t = cp_delta_rule_t_precompute_dsl_sm120(

--- a/flashinfer/gdn_kernels/delta_rule_dsl/delta_rule_cp_sm90.py
+++ b/flashinfer/gdn_kernels/delta_rule_dsl/delta_rule_cp_sm90.py
@@ -86,7 +86,7 @@ class CPDeltaRuleTPrecomputeSm90(KeyedCompileMixin):
         sK_DS: cute.Tensor,
         k_pipeline,
         k_producer_state,
-        tok_offset: cutlass.Int32,
+        tok_offset,
         head_idx: cutlass.Int32,
     ):
         mK = cute.domain_offset(
@@ -117,7 +117,7 @@ class CPDeltaRuleTPrecomputeSm90(KeyedCompileMixin):
         sBeta: cute.Tensor,
         beta_pipeline,
         beta_producer_state,
-        tok_offset: cutlass.Int32,
+        tok_offset,
         head_idx: cutlass.Int32,
         valid_len: cutlass.Int32,
         num_heads: cutlass.Int32,
@@ -308,9 +308,8 @@ class CPDeltaRuleTPrecomputeSm90(KeyedCompileMixin):
         sab_head_idx = bx % num_sab_heads
         k_head_idx = sab_head_idx * num_k_heads // num_sab_heads
         block_idx_in_seq = bx // num_sab_heads
-        seq_start = cutlass.Int32(cu_seqlens[seq_idx])
-        seq_end = cutlass.Int32(cu_seqlens[seq_idx + 1])
-        seq_len = seq_end - seq_start
+        seq_start = cu_seqlens[seq_idx]
+        seq_len = cutlass.Int32(cu_seqlens[seq_idx + 1] - seq_start)
         num_blocks = chunks_for_len(seq_len, self.BLK)
         if block_idx_in_seq < num_blocks:
             tok_offset = seq_start + block_idx_in_seq * self.BLK
@@ -725,7 +724,7 @@ class CPDeltaRuleMNPrecomputeSm90(KeyedCompileMixin):
         sTensor: cute.Tensor,
         tensor_pipeline,
         tensor_producer_state,
-        tok_offset: cutlass.Int32,
+        tok_offset,
         t_block_start: cutlass.Int32,
         head_idx: cutlass.Int32,
         blk: cutlass.Int32,
@@ -771,7 +770,7 @@ class CPDeltaRuleMNPrecomputeSm90(KeyedCompileMixin):
         self,
         g_alpha: cute.Tensor,
         sAlpha: cute.Tensor,
-        tok_offset: cutlass.Int32,
+        tok_offset,
         head_idx: cutlass.Int32,
         blk: cutlass.Int32,
         chunk_len: cutlass.Int32,
@@ -1014,7 +1013,7 @@ class CPDeltaRuleMNPrecomputeSm90(KeyedCompileMixin):
         sTensor: cute.Tensor,
         tensor_pipeline,
         tensor_producer_state,
-        tok_offset: cutlass.Int32,
+        tok_offset,
         t_block_start: cutlass.Int32,
         head_idx: cutlass.Int32,
         num_blocks: cutlass.Int32,
@@ -1042,7 +1041,7 @@ class CPDeltaRuleMNPrecomputeSm90(KeyedCompileMixin):
         sAlpha: cute.Tensor,
         alpha_pipeline,
         alpha_producer_state,
-        tok_offset: cutlass.Int32,
+        tok_offset,
         head_idx: cutlass.Int32,
         chunk_len: cutlass.Int32,
         num_blocks: cutlass.Int32,
@@ -1371,9 +1370,8 @@ class CPDeltaRuleMNPrecomputeSm90(KeyedCompileMixin):
         k_head_idx = sab_head_idx * num_k_heads // num_sab_heads
         v_head_idx = sab_head_idx * num_v_heads // num_sab_heads
         chunk_idx_in_seq = bx // num_sab_heads
-        seq_start = cutlass.Int32(g_cu_seqlens[seq_idx])
-        seq_end = cutlass.Int32(g_cu_seqlens[seq_idx + 1])
-        seq_len = seq_end - seq_start
+        seq_start = g_cu_seqlens[seq_idx]
+        seq_len = cutlass.Int32(g_cu_seqlens[seq_idx + 1] - seq_start)
         num_cp_chunks = chunks_for_len(seq_len, chunk_len)
         is_valid_chunk = chunk_idx_in_seq < num_cp_chunks
 
@@ -2186,9 +2184,8 @@ class CPDeltaRuleFixupHmmaSm90(KeyedCompileMixin):
         head_seq_idx = bx // self.row_ctas
         head_idx = head_seq_idx % num_heads
         seq_idx = head_seq_idx // num_heads
-        seq_start = cutlass.Int32(g_cu_seqlens[seq_idx])
-        seq_end = cutlass.Int32(g_cu_seqlens[seq_idx + 1])
-        seq_len = seq_end - seq_start
+        seq_start = g_cu_seqlens[seq_idx]
+        seq_len = cutlass.Int32(g_cu_seqlens[seq_idx + 1] - seq_start)
         num_chunks = chunks_for_len(seq_len, chunk_len)
         chunk_start = varlen_chunk_idx(seq_idx, seq_start, 0, chunk_len)
 
@@ -2585,9 +2582,9 @@ class CPDeltaRuleFixupSimtSm90(KeyedCompileMixin):
         head_seq_idx = bx // self.row_ctas
         head_idx = head_seq_idx % num_heads
         seq_idx = head_seq_idx // num_heads
-        seq_start = cutlass.Int32(g_cu_seqlens[seq_idx])
-        seq_end = cutlass.Int32(g_cu_seqlens[seq_idx + 1])
-        seq_len = seq_end - seq_start
+        seq_start = g_cu_seqlens[seq_idx]
+        seq_end = g_cu_seqlens[seq_idx + 1]
+        seq_len = cutlass.Int32(seq_end - seq_start)
         num_chunks = chunks_for_len(seq_len, chunk_len)
         chunk_start = varlen_chunk_idx(seq_idx, seq_start, 0, chunk_len)
         gap_start = chunk_start + num_chunks
@@ -3911,9 +3908,8 @@ class CPDeltaRulePrefillSm90(_FullyFusedDeltaRuleSm90):
         k_head_idx = o_head_idx * num_k_heads // num_sab_heads
         v_head_idx = o_head_idx * num_v_heads // num_sab_heads
         chunk_idx_in_seq = bx // num_sab_heads
-        seq_start = cutlass.Int32(g_cu_seqlens[seq_idx])
-        seq_end = cutlass.Int32(g_cu_seqlens[seq_idx + 1])
-        seq_len = seq_end - seq_start
+        seq_start = g_cu_seqlens[seq_idx]
+        seq_len = cutlass.Int32(g_cu_seqlens[seq_idx + 1] - seq_start)
         num_cp_chunks = chunks_for_len(seq_len, chunk_len)
         is_valid_chunk = chunk_idx_in_seq < num_cp_chunks
 

--- a/flashinfer/gdn_kernels/delta_rule_dsl/delta_rule_cp_sm90.py
+++ b/flashinfer/gdn_kernels/delta_rule_dsl/delta_rule_cp_sm90.py
@@ -33,6 +33,7 @@ from .varlen_helper import (
     CP_CHUNK_LEN_GRANULARITY,
     choose_cp_chunk_len_host,
     chunks_for_len,
+    is_integer_dtype,
     max_num_chunks_host,
     varlen_chunk_idx,
     varlen_chunk_valid_len,
@@ -65,13 +66,17 @@ class CPDeltaRuleTPrecomputeSm90(KeyedCompileMixin):
         self,
         dtype: type[cutlass.Numeric] = cutlass.Float16,
         acc_dtype: type[cutlass.Numeric] = cutlass.Float32,
+        cu_seqlens_dtype: torch.dtype = torch.int64,
     ):
         self.dtype = dtype
         self.acc_dtype = acc_dtype
+        self.cu_seqlens_dtype = cu_seqlens_dtype
         self.inverse_dtype = cutlass.Float16
         self.BLK = 64
         self.D = 128
-        self.manual_cache_key("dtype", "acc_dtype", "inverse_dtype", "BLK", "D")
+        self.manual_cache_key(
+            "dtype", "acc_dtype", "cu_seqlens_dtype", "inverse_dtype", "BLK", "D"
+        )
 
     @cute.jit
     def load_k_tile_tma(
@@ -456,8 +461,8 @@ class CPDeltaRuleTPrecomputeSm90(KeyedCompileMixin):
 
 
 @functools.cache
-def _get_t_precompute_kernel(kernel_dtype):
-    return CPDeltaRuleTPrecomputeSm90(kernel_dtype)
+def _get_t_precompute_kernel(kernel_dtype, cu_seqlens_dtype):
+    return CPDeltaRuleTPrecomputeSm90(kernel_dtype, cu_seqlens_dtype=cu_seqlens_dtype)
 
 
 def cp_delta_rule_t_precompute_dsl_sm90(
@@ -496,9 +501,9 @@ def cp_delta_rule_t_precompute_dsl_sm90(
             raise RuntimeError(
                 f"total_seqlen must match k.shape[0], got {total_seqlen} and {k.shape[0]}"
             )
-        if cu_seqlens.dtype != torch.int64:
+        if not is_integer_dtype(cu_seqlens.dtype):
             raise RuntimeError(
-                f"cu_seqlens must have dtype torch.int64, got {cu_seqlens.dtype}"
+                f"cu_seqlens must have an integer dtype, got {cu_seqlens.dtype}"
             )
         if not cu_seqlens.is_contiguous():
             raise RuntimeError("cu_seqlens must be contiguous")
@@ -554,7 +559,7 @@ def cp_delta_rule_t_precompute_dsl_sm90(
         else cuda_driver.CUstream(torch.cuda.current_stream(device).cuda_stream)
     )
 
-    kernel = _get_t_precompute_kernel(kernel_dtype)
+    kernel = _get_t_precompute_kernel(kernel_dtype, cu_seqlens.dtype)
     compiled = get_cached_compile(kernel, _SM90_COMPILE_OPTIONS)
     if compiled is None:
         from_dlpack = lambda *args, **kwargs: cute.runtime.from_dlpack(
@@ -628,9 +633,11 @@ class CPDeltaRuleMNPrecomputeSm90(KeyedCompileMixin):
         self,
         dtype: type[cutlass.Numeric] = cutlass.Float16,
         acc_dtype: type[cutlass.Numeric] = cutlass.Float32,
+        cu_seqlens_dtype: torch.dtype = torch.int64,
     ):
         self.dtype = dtype
         self.acc_dtype = acc_dtype
+        self.cu_seqlens_dtype = cu_seqlens_dtype
         self.BLK = 64
         self.D = 128
         self.k_stage = 3
@@ -640,6 +647,7 @@ class CPDeltaRuleMNPrecomputeSm90(KeyedCompileMixin):
         self.manual_cache_key(
             "dtype",
             "acc_dtype",
+            "cu_seqlens_dtype",
             "BLK",
             "D",
             "k_stage",
@@ -1620,8 +1628,8 @@ class CPDeltaRuleMNPrecomputeSm90(KeyedCompileMixin):
 
 
 @functools.cache
-def _get_mn_precompute_kernel(kernel_dtype):
-    return CPDeltaRuleMNPrecomputeSm90(kernel_dtype)
+def _get_mn_precompute_kernel(kernel_dtype, cu_seqlens_dtype):
+    return CPDeltaRuleMNPrecomputeSm90(kernel_dtype, cu_seqlens_dtype=cu_seqlens_dtype)
 
 
 def cp_delta_rule_mn_precompute_dsl_sm90(
@@ -1671,9 +1679,9 @@ def cp_delta_rule_mn_precompute_dsl_sm90(
             raise RuntimeError(
                 f"cp_chunk_len must be a multiple of 64, got {cp_chunk_len}"
             )
-        if cu_seqlens.dtype != torch.int64:
+        if not is_integer_dtype(cu_seqlens.dtype):
             raise RuntimeError(
-                f"cu_seqlens must have dtype torch.int64, got {cu_seqlens.dtype}"
+                f"cu_seqlens must have an integer dtype, got {cu_seqlens.dtype}"
             )
         if not cu_seqlens.is_contiguous():
             raise RuntimeError("cu_seqlens must be contiguous")
@@ -1758,7 +1766,7 @@ def cp_delta_rule_mn_precompute_dsl_sm90(
         else cuda_driver.CUstream(torch.cuda.current_stream(device).cuda_stream)
     )
 
-    kernel = _get_mn_precompute_kernel(kernel_dtype)
+    kernel = _get_mn_precompute_kernel(kernel_dtype, cu_seqlens.dtype)
     compiled = get_cached_compile(kernel, _SM90_COMPILE_OPTIONS)
     if compiled is None:
         from_dlpack = lambda *args, **kwargs: cute.runtime.from_dlpack(
@@ -1832,9 +1840,15 @@ class CPDeltaRuleFixupHmmaSm90(KeyedCompileMixin):
         self,
         needs_initial_state: bool = False,
         use_state_indices: bool = False,
+        cu_seqlens_dtype: torch.dtype = torch.int64,
+        state_indices_dtype: torch.dtype | None = None,
+        initial_state_inner_strides: tuple[int, ...] | None = None,
     ):
         self.needs_initial_state = needs_initial_state
         self.use_state_indices = use_state_indices
+        self.cu_seqlens_dtype = cu_seqlens_dtype
+        self.state_indices_dtype = state_indices_dtype
+        self.initial_state_inner_strides = initial_state_inner_strides
         self.D = 128
         self.rows_per_cta = 64
         self.row_ctas = 2
@@ -1855,6 +1869,9 @@ class CPDeltaRuleFixupHmmaSm90(KeyedCompileMixin):
         self.manual_cache_key(
             "needs_initial_state",
             "use_state_indices",
+            "cu_seqlens_dtype",
+            "state_indices_dtype",
+            "initial_state_inner_strides",
             "D",
             "rows_per_cta",
             "row_ctas",
@@ -2204,16 +2221,20 @@ class CPDeltaRuleFixupHmmaSm90(KeyedCompileMixin):
         if cutlass.const_expr(self.use_state_indices):
             state_idx = cutlass.Int32(g_state_indices_t[seq_idx])
         if cutlass.const_expr(self.needs_initial_state):
+            initial_state_ref_layout = cute.make_layout(
+                (
+                    g_initial_state_t.shape[0],
+                    g_initial_state_t.shape[1],
+                    self.D,
+                    self.D,
+                ),
+                stride=g_initial_state_t.stride,
+            )
+            indexed_initial_state_layout = cute.select(
+                initial_state_ref_layout, mode=[2, 3, 1, 0]
+            )
             if cutlass.const_expr(self.use_state_indices):
-                initial_state_layout = cute.make_layout(
-                    (self.D, self.D, num_heads, g_initial_state_t.shape[0]),
-                    stride=(
-                        g_initial_state_t.stride[2],
-                        g_initial_state_t.stride[3],
-                        g_initial_state_t.stride[1],
-                        g_initial_state_t.stride[0],
-                    ),
-                )
+                initial_state_layout = indexed_initial_state_layout
             else:
                 initial_state_layout = fixed_state_layout
             gInitialState = cute.make_tensor(
@@ -2336,9 +2357,15 @@ class CPDeltaRuleFixupSimtSm90(KeyedCompileMixin):
         needs_initial_state: bool = False,
         rows_per_cta: int = 4,
         use_state_indices: bool = False,
+        cu_seqlens_dtype: torch.dtype = torch.int64,
+        state_indices_dtype: torch.dtype | None = None,
+        initial_state_inner_strides: tuple[int, ...] | None = None,
     ):
         self.needs_initial_state = needs_initial_state
         self.use_state_indices = use_state_indices
+        self.cu_seqlens_dtype = cu_seqlens_dtype
+        self.state_indices_dtype = state_indices_dtype
+        self.initial_state_inner_strides = initial_state_inner_strides
         self.D = 128
         self.rows_per_cta = rows_per_cta
         self.row_ctas = self.D // self.rows_per_cta
@@ -2349,6 +2376,9 @@ class CPDeltaRuleFixupSimtSm90(KeyedCompileMixin):
         self.manual_cache_key(
             "needs_initial_state",
             "use_state_indices",
+            "cu_seqlens_dtype",
+            "state_indices_dtype",
+            "initial_state_inner_strides",
             "D",
             "rows_per_cta",
             "row_ctas",
@@ -2589,16 +2619,20 @@ class CPDeltaRuleFixupSimtSm90(KeyedCompileMixin):
         if cutlass.const_expr(self.use_state_indices):
             state_idx = cutlass.Int32(g_state_indices_t[seq_idx])
         if cutlass.const_expr(self.needs_initial_state):
+            initial_state_ref_layout = cute.make_layout(
+                (
+                    g_initial_state_t.shape[0],
+                    g_initial_state_t.shape[1],
+                    self.D,
+                    self.D,
+                ),
+                stride=g_initial_state_t.stride,
+            )
+            indexed_initial_state_layout = cute.select(
+                initial_state_ref_layout, mode=[2, 3, 1, 0]
+            )
             if cutlass.const_expr(self.use_state_indices):
-                initial_state_layout = cute.make_layout(
-                    (self.D, self.D, num_heads, g_initial_state_t.shape[0]),
-                    stride=(
-                        g_initial_state_t.stride[2],
-                        g_initial_state_t.stride[3],
-                        g_initial_state_t.stride[1],
-                        g_initial_state_t.stride[0],
-                    ),
-                )
+                initial_state_layout = indexed_initial_state_layout
             else:
                 initial_state_layout = fixed_state_layout
             gInitialState = cute.make_tensor(
@@ -2656,13 +2690,40 @@ class CPDeltaRuleFixupSimtSm90(KeyedCompileMixin):
 
 
 @functools.cache
-def _get_fixup_kernel(needs_initial_state, kernel_kind, use_state_indices):
+def _get_fixup_kernel(
+    needs_initial_state,
+    kernel_kind,
+    use_state_indices,
+    cu_seqlens_dtype,
+    state_indices_dtype,
+    initial_state_inner_strides,
+):
     if kernel_kind == "simt_row4":
-        return CPDeltaRuleFixupSimtSm90(needs_initial_state, 4, use_state_indices)
+        return CPDeltaRuleFixupSimtSm90(
+            needs_initial_state=needs_initial_state,
+            rows_per_cta=4,
+            use_state_indices=use_state_indices,
+            cu_seqlens_dtype=cu_seqlens_dtype,
+            state_indices_dtype=state_indices_dtype,
+            initial_state_inner_strides=initial_state_inner_strides,
+        )
     if kernel_kind == "simt_row8":
-        return CPDeltaRuleFixupSimtSm90(needs_initial_state, 8, use_state_indices)
+        return CPDeltaRuleFixupSimtSm90(
+            needs_initial_state=needs_initial_state,
+            rows_per_cta=8,
+            use_state_indices=use_state_indices,
+            cu_seqlens_dtype=cu_seqlens_dtype,
+            state_indices_dtype=state_indices_dtype,
+            initial_state_inner_strides=initial_state_inner_strides,
+        )
     if kernel_kind == "hmma":
-        return CPDeltaRuleFixupHmmaSm90(needs_initial_state, use_state_indices)
+        return CPDeltaRuleFixupHmmaSm90(
+            needs_initial_state=needs_initial_state,
+            use_state_indices=use_state_indices,
+            cu_seqlens_dtype=cu_seqlens_dtype,
+            state_indices_dtype=state_indices_dtype,
+            initial_state_inner_strides=initial_state_inner_strides,
+        )
     raise ValueError(f"Unsupported fixup kernel kind: {kernel_kind}")
 
 
@@ -2728,11 +2789,11 @@ def cp_delta_rule_fixup_dsl_sm90(
                     f"initial_state must have dtype torch.float32, got {initial_state.dtype}"
                 )
         if use_state_indices and (
-            state_indices.dtype != torch.int32
+            not is_integer_dtype(state_indices.dtype)
             or state_indices.shape != (cu_seqlens.shape[0] - 1,)
         ):
             raise RuntimeError(
-                f"state_indices must have shape {(cu_seqlens.shape[0] - 1,)} and dtype int32"
+                f"state_indices must have shape {(cu_seqlens.shape[0] - 1,)} and an integer dtype"
             )
         for name, tensor in (
             ("local_transfer", local_transfer),
@@ -2744,20 +2805,15 @@ def cp_delta_rule_fixup_dsl_sm90(
             if not tensor.is_contiguous():
                 raise RuntimeError(f"{name} must be contiguous")
         if initial_state is not None:
-            if use_state_indices:
-                if initial_state.stride()[1:] != (128 * 128, 128, 1):
-                    raise RuntimeError(
-                        "initial_state inner dimensions must be contiguous when state_indices is used"
-                    )
-            elif not initial_state.is_contiguous():
+            if not use_state_indices and not initial_state.is_contiguous():
                 raise RuntimeError("initial_state must be contiguous")
     total_cp_chunks, num_heads, _, _ = local_transfer.shape
     if not _skip_check:
         if cp_chunk_len <= 0:
             raise RuntimeError(f"cp_chunk_len must be positive, got {cp_chunk_len}")
-        if cu_seqlens.dtype != torch.int64:
+        if not is_integer_dtype(cu_seqlens.dtype):
             raise RuntimeError(
-                f"cu_seqlens must have dtype torch.int64, got {cu_seqlens.dtype}"
+                f"cu_seqlens must have an integer dtype, got {cu_seqlens.dtype}"
             )
         expected_chunks = workspace_num_chunks_host(
             cu_seqlens, cp_chunk_len, total_seqlen
@@ -2801,7 +2857,18 @@ def cp_delta_rule_fixup_dsl_sm90(
             _kernel_kind = "simt_row8"
         else:
             _kernel_kind = "hmma"
-    kernel = _get_fixup_kernel(needs_initial_state, _kernel_kind, use_state_indices)
+    kernel = _get_fixup_kernel(
+        needs_initial_state,
+        _kernel_kind,
+        use_state_indices,
+        cu_seqlens.dtype,
+        state_indices.dtype if use_state_indices else None,
+        (
+            tuple(initial_state.stride()[1:])
+            if use_state_indices and needs_initial_state
+            else None
+        ),
+    )
     compiled = get_cached_compile(kernel, _SM90_COMPILE_OPTIONS)
     if compiled is None:
         from_dlpack = lambda *args, **kwargs: cute.runtime.from_dlpack(
@@ -2864,6 +2931,11 @@ class CPDeltaRulePrefillSm90(_FullyFusedDeltaRuleSm90):
         store_final_state: bool = True,
         use_state_indices: bool = False,
         needs_checkpointing: bool = False,
+        cu_seqlens_dtype: torch.dtype = torch.int64,
+        state_indices_dtype: torch.dtype | None = None,
+        checkpoint_cu_starts_dtype: torch.dtype | None = None,
+        state_inner_strides: tuple[int, ...] | None = None,
+        initial_state_inner_strides: tuple[int, ...] | None = None,
     ):
         super().__init__(
             True,
@@ -2873,6 +2945,11 @@ class CPDeltaRulePrefillSm90(_FullyFusedDeltaRuleSm90):
             dtype,
             acc_dtype,
             use_state_indices=use_state_indices,
+            cu_seqlens_dtype=cu_seqlens_dtype,
+            state_indices_dtype=state_indices_dtype,
+            checkpoint_cu_starts_dtype=checkpoint_cu_starts_dtype,
+            state_inner_strides=state_inner_strides,
+            init_state_inner_strides=initial_state_inner_strides,
         )
         self.needs_initial_state = needs_initial_state
         self.store_final_state = store_final_state
@@ -2885,6 +2962,11 @@ class CPDeltaRulePrefillSm90(_FullyFusedDeltaRuleSm90):
             "needs_initial_state",
             "store_final_state",
             "use_state_indices",
+            "cu_seqlens_dtype",
+            "state_indices_dtype",
+            "checkpoint_cu_starts_dtype",
+            "state_inner_strides",
+            "init_state_inner_strides",
             "dtype",
             "acc_dtype",
             "inverse_dtype",
@@ -3352,37 +3434,30 @@ class CPDeltaRulePrefillSm90(_FullyFusedDeltaRuleSm90):
         packed_state_layout = cute.make_ordered_layout(
             (self.D, self.D, num_sab_heads, num_seqs), order=(0, 1, 2, 3)
         )
+        state_ref_shape = (g_state.shape[0], g_state.shape[1], self.D, self.D)
+        state_ref_layout = cute.make_layout(state_ref_shape, stride=g_state.stride)
+        indexed_state_layout = cute.select(state_ref_layout, mode=[3, 2, 1, 0])
         state_idx = public_seq_idx
         if cutlass.const_expr(self.use_state_indices):
             state_idx = cutlass.Int32(g_state_indices[public_seq_idx])
         output_state_idx = public_seq_idx
         if cutlass.const_expr(self.use_state_indices and self.store_final_state):
             output_state_idx = state_idx
-            state_layout = cute.make_layout(
-                (self.D, self.D, num_sab_heads, g_state.shape[0]),
-                stride=(
-                    g_state.stride[3],
-                    g_state.stride[2],
-                    g_state.stride[1],
-                    g_state.stride[0],
-                ),
-            )
+            state_layout = indexed_state_layout
         else:
             state_layout = packed_state_layout
         o_head_idx = work_desc.o_head_idx(num_q_heads, num_v_heads)
         mState = cute.make_tensor(g_state.iterator, state_layout)
         gStateKV = mState[None, None, o_head_idx, output_state_idx]
         if cutlass.const_expr(self.needs_initial_state):
+            initial_state_ref_layout = cute.make_layout(
+                state_ref_shape, stride=g_initial_state.stride
+            )
+            indexed_initial_state_layout = cute.select(
+                initial_state_ref_layout, mode=[3, 2, 1, 0]
+            )
             if cutlass.const_expr(self.use_state_indices):
-                initial_state_layout = cute.make_layout(
-                    (self.D, self.D, num_sab_heads, g_initial_state.shape[0]),
-                    stride=(
-                        g_initial_state.stride[3],
-                        g_initial_state.stride[2],
-                        g_initial_state.stride[1],
-                        g_initial_state.stride[0],
-                    ),
-                )
+                initial_state_layout = indexed_initial_state_layout
             else:
                 initial_state_layout = packed_state_layout
             mInitialState = cute.make_tensor(
@@ -4175,6 +4250,11 @@ def _get_prefill_kernel(
     store_final_state,
     use_state_indices,
     needs_checkpointing,
+    cu_seqlens_dtype,
+    state_indices_dtype,
+    checkpoint_cu_starts_dtype,
+    state_inner_strides,
+    initial_state_inner_strides,
 ):
     return CPDeltaRulePrefillSm90(
         kernel_dtype,
@@ -4182,6 +4262,11 @@ def _get_prefill_kernel(
         store_final_state=store_final_state,
         use_state_indices=use_state_indices,
         needs_checkpointing=needs_checkpointing,
+        cu_seqlens_dtype=cu_seqlens_dtype,
+        state_indices_dtype=state_indices_dtype,
+        checkpoint_cu_starts_dtype=checkpoint_cu_starts_dtype,
+        state_inner_strides=state_inner_strides,
+        initial_state_inner_strides=initial_state_inner_strides,
     )
 
 
@@ -4264,9 +4349,9 @@ def cp_delta_rule_prefill_dsl_sm90(
             raise RuntimeError(
                 "state_checkpoints and checkpoint_cu_starts are required when checkpointing is enabled"
             )
-        if cu_seqlens.dtype != torch.int64:
+        if not is_integer_dtype(cu_seqlens.dtype):
             raise RuntimeError(
-                f"cu_seqlens must have dtype torch.int64, got {cu_seqlens.dtype}"
+                f"cu_seqlens must have an integer dtype, got {cu_seqlens.dtype}"
             )
         if not cu_seqlens.is_contiguous():
             raise RuntimeError("cu_seqlens must be contiguous")
@@ -4334,10 +4419,11 @@ def cp_delta_rule_prefill_dsl_sm90(
                 f"got {tuple(initial_state.shape)}"
             )
         if use_state_indices and (
-            state_indices.dtype != torch.int32 or state_indices.shape != (num_seqs,)
+            not is_integer_dtype(state_indices.dtype)
+            or state_indices.shape != (num_seqs,)
         ):
             raise RuntimeError(
-                f"state_indices must have shape {(num_seqs,)} and dtype int32"
+                f"state_indices must have shape {(num_seqs,)} and an integer dtype"
             )
         if q.shape[-1] != 128:
             raise RuntimeError(
@@ -4373,12 +4459,11 @@ def cp_delta_rule_prefill_dsl_sm90(
                     "state_checkpoints must have shape "
                     f"[*, {num_sab_heads}, {d}, {d}] and dtype float32"
                 )
-            if (
-                checkpoint_cu_starts.dtype != torch.int64
-                or checkpoint_cu_starts.shape != (num_seqs + 1,)
-            ):
+            if not is_integer_dtype(
+                checkpoint_cu_starts.dtype
+            ) or checkpoint_cu_starts.shape != (num_seqs + 1,):
                 raise RuntimeError(
-                    f"checkpoint_cu_starts must have shape {(num_seqs + 1,)} and dtype int64"
+                    f"checkpoint_cu_starts must have shape {(num_seqs + 1,)} and an integer dtype"
                 )
         for name, tensor in (
             ("q", q),
@@ -4399,12 +4484,7 @@ def cp_delta_rule_prefill_dsl_sm90(
         for name, tensor in (("state", state), ("initial_state", initial_state)):
             if tensor is None:
                 continue
-            if use_state_indices:
-                if tensor.stride()[1:] != (d * d, d, 1):
-                    raise RuntimeError(
-                        f"{name} inner dimensions must be contiguous when state_indices is used"
-                    )
-            elif not tensor.is_contiguous():
+            if not use_state_indices and not tensor.is_contiguous():
                 raise RuntimeError(f"{name} must be contiguous")
     max_cp_chunks_per_seq = max_num_chunks_host(max_seqlen, cp_chunk_len)
     if total_cp_chunks == 0:
@@ -4453,10 +4533,25 @@ def cp_delta_rule_prefill_dsl_sm90(
     use_state_indices = state_indices is not None
     kernel = _get_prefill_kernel(
         kernel_dtype,
-        needs_initial_state,
-        store_final_state,
-        use_state_indices,
-        needs_checkpointing,
+        needs_initial_state=needs_initial_state,
+        store_final_state=store_final_state,
+        use_state_indices=use_state_indices,
+        needs_checkpointing=needs_checkpointing,
+        cu_seqlens_dtype=cu_seqlens.dtype,
+        state_indices_dtype=state_indices.dtype if use_state_indices else None,
+        checkpoint_cu_starts_dtype=(
+            checkpoint_cu_starts.dtype if needs_checkpointing else None
+        ),
+        state_inner_strides=(
+            tuple(state.stride()[1:])
+            if use_state_indices and store_final_state
+            else None
+        ),
+        initial_state_inner_strides=(
+            tuple(initial_state.stride()[1:])
+            if use_state_indices and needs_initial_state
+            else None
+        ),
     )
     state_arg = state if store_final_state else fixed_state
     compiled = get_cached_compile(kernel, _SM90_COMPILE_OPTIONS)
@@ -4639,9 +4734,9 @@ def cp_delta_rule_dsl_sm90(
         raise RuntimeError(
             "state_checkpoints and checkpoint_cu_starts are required when checkpointing is enabled"
         )
-    if cu_seqlens.dtype != torch.int64:
+    if not is_integer_dtype(cu_seqlens.dtype):
         raise RuntimeError(
-            f"cu_seqlens must have dtype torch.int64, got {cu_seqlens.dtype}"
+            f"cu_seqlens must have an integer dtype, got {cu_seqlens.dtype}"
         )
     if not cu_seqlens.is_contiguous():
         raise RuntimeError("cu_seqlens must be contiguous")
@@ -4692,10 +4787,10 @@ def cp_delta_rule_dsl_sm90(
             f"got {tuple(initial_state.shape)}"
         )
     if use_state_indices and (
-        state_indices.dtype != torch.int32 or state_indices.shape != (num_seqs,)
+        not is_integer_dtype(state_indices.dtype) or state_indices.shape != (num_seqs,)
     ):
         raise RuntimeError(
-            f"state_indices must have shape {(num_seqs,)} and dtype int32"
+            f"state_indices must have shape {(num_seqs,)} and an integer dtype"
         )
     if q.shape[-1] != 128:
         raise RuntimeError(f"CPDeltaRuleSm90 only supports D=128, got {q.shape[-1]}")
@@ -4724,11 +4819,11 @@ def cp_delta_rule_dsl_sm90(
                 "state_checkpoints must have shape "
                 f"[*, {num_sab_heads}, {d}, {d}] and dtype float32"
             )
-        if checkpoint_cu_starts.dtype != torch.int64 or checkpoint_cu_starts.shape != (
-            num_seqs + 1,
-        ):
+        if not is_integer_dtype(
+            checkpoint_cu_starts.dtype
+        ) or checkpoint_cu_starts.shape != (num_seqs + 1,):
             raise RuntimeError(
-                f"checkpoint_cu_starts must have shape {(num_seqs + 1,)} and dtype int64"
+                f"checkpoint_cu_starts must have shape {(num_seqs + 1,)} and an integer dtype"
             )
     for name, tensor in (
         ("q", q),
@@ -4748,12 +4843,7 @@ def cp_delta_rule_dsl_sm90(
     for name, tensor in (("state", state), ("initial_state", initial_state)):
         if tensor is None:
             continue
-        if use_state_indices:
-            if tensor.stride()[1:] != (d * d, d, 1):
-                raise RuntimeError(
-                    f"{name} inner dimensions must be contiguous when state_indices is used"
-                )
-        elif not tensor.is_contiguous():
+        if not use_state_indices and not tensor.is_contiguous():
             raise RuntimeError(f"{name} must be contiguous")
 
     t = cp_delta_rule_t_precompute_dsl_sm90(

--- a/flashinfer/gdn_kernels/delta_rule_dsl/delta_rule_cp_sm90.py
+++ b/flashinfer/gdn_kernels/delta_rule_dsl/delta_rule_cp_sm90.py
@@ -1828,8 +1828,13 @@ class CPDeltaRuleFixupHmmaSm90(KeyedCompileMixin):
         )
         return min(248, registers_per_thread)
 
-    def __init__(self, needs_initial_state: bool = False):
+    def __init__(
+        self,
+        needs_initial_state: bool = False,
+        use_state_indices: bool = False,
+    ):
         self.needs_initial_state = needs_initial_state
+        self.use_state_indices = use_state_indices
         self.D = 128
         self.rows_per_cta = 64
         self.row_ctas = 2
@@ -1849,6 +1854,7 @@ class CPDeltaRuleFixupHmmaSm90(KeyedCompileMixin):
         self.use_3xtf32 = False
         self.manual_cache_key(
             "needs_initial_state",
+            "use_state_indices",
             "D",
             "rows_per_cta",
             "row_ctas",
@@ -2068,6 +2074,7 @@ class CPDeltaRuleFixupHmmaSm90(KeyedCompileMixin):
         g_transfer_t: cute.Tensor,
         g_local_state_t: cute.Tensor,
         g_initial_state_t: cute.Tensor,
+        g_state_indices_t: cute.Tensor,
         g_fixed_state_t: cute.Tensor,
         g_cu_seqlens: cute.Tensor,
         chunk_len: cutlass.Int32,
@@ -2122,6 +2129,7 @@ class CPDeltaRuleFixupHmmaSm90(KeyedCompileMixin):
             tma_atom_n,
             tma_tensor_n,
             g_initial_state_t,
+            g_state_indices_t,
             g_fixed_state_t,
             g_cu_seqlens,
             chunk_len,
@@ -2144,6 +2152,7 @@ class CPDeltaRuleFixupHmmaSm90(KeyedCompileMixin):
         tma_atom_n: cute.CopyAtom,
         tma_tensor_n: cute.Tensor,
         g_initial_state_t: cute.Tensor,
+        g_state_indices_t: cute.Tensor,
         g_fixed_state_t: cute.Tensor,
         g_cu_seqlens: cute.Tensor,
         chunk_len: cutlass.Int32,
@@ -2191,9 +2200,24 @@ class CPDeltaRuleFixupHmmaSm90(KeyedCompileMixin):
             (self.D, self.D, num_heads, num_seqs),
             stride=(self.D, 1, self.D * self.D, self.D * self.D * num_heads),
         )
+        state_idx = seq_idx
+        if cutlass.const_expr(self.use_state_indices):
+            state_idx = cutlass.Int32(g_state_indices_t[seq_idx])
         if cutlass.const_expr(self.needs_initial_state):
+            if cutlass.const_expr(self.use_state_indices):
+                initial_state_layout = cute.make_layout(
+                    (self.D, self.D, num_heads, g_initial_state_t.shape[0]),
+                    stride=(
+                        g_initial_state_t.stride[2],
+                        g_initial_state_t.stride[3],
+                        g_initial_state_t.stride[1],
+                        g_initial_state_t.stride[0],
+                    ),
+                )
+            else:
+                initial_state_layout = fixed_state_layout
             gInitialState = cute.make_tensor(
-                g_initial_state_t.iterator, fixed_state_layout
+                g_initial_state_t.iterator, initial_state_layout
             )
         else:
             gInitialState = gFixedState
@@ -2299,7 +2323,7 @@ class CPDeltaRuleFixupHmmaSm90(KeyedCompileMixin):
                     num_chunks,
                     total_cp_chunks,
                     chunk_start,
-                    seq_idx,
+                    state_idx,
                     head_idx,
                     row_cta_idx,
                     math_tidx,
@@ -2311,8 +2335,10 @@ class CPDeltaRuleFixupSimtSm90(KeyedCompileMixin):
         self,
         needs_initial_state: bool = False,
         rows_per_cta: int = 4,
+        use_state_indices: bool = False,
     ):
         self.needs_initial_state = needs_initial_state
+        self.use_state_indices = use_state_indices
         self.D = 128
         self.rows_per_cta = rows_per_cta
         self.row_ctas = self.D // self.rows_per_cta
@@ -2322,6 +2348,7 @@ class CPDeltaRuleFixupSimtSm90(KeyedCompileMixin):
         self.registers_per_thread = 256
         self.manual_cache_key(
             "needs_initial_state",
+            "use_state_indices",
             "D",
             "rows_per_cta",
             "row_ctas",
@@ -2471,6 +2498,7 @@ class CPDeltaRuleFixupSimtSm90(KeyedCompileMixin):
         g_transfer_t: cute.Tensor,
         g_local_state_t: cute.Tensor,
         g_initial_state_t: cute.Tensor,
+        g_state_indices_t: cute.Tensor,
         g_fixed_state_t: cute.Tensor,
         g_cu_seqlens: cute.Tensor,
         chunk_len: cutlass.Int32,
@@ -2492,6 +2520,7 @@ class CPDeltaRuleFixupSimtSm90(KeyedCompileMixin):
             g_transfer_t,
             g_local_state_t,
             g_initial_state_t,
+            g_state_indices_t,
             g_fixed_state_t,
             g_cu_seqlens,
             chunk_len,
@@ -2512,6 +2541,7 @@ class CPDeltaRuleFixupSimtSm90(KeyedCompileMixin):
         g_transfer_t: cute.Tensor,
         g_local_state_t: cute.Tensor,
         g_initial_state_t: cute.Tensor,
+        g_state_indices_t: cute.Tensor,
         g_fixed_state_t: cute.Tensor,
         g_cu_seqlens: cute.Tensor,
         chunk_len: cutlass.Int32,
@@ -2555,9 +2585,24 @@ class CPDeltaRuleFixupSimtSm90(KeyedCompileMixin):
             (self.D, self.D, num_heads, num_seqs),
             stride=(self.D, 1, self.D * self.D, self.D * self.D * num_heads),
         )
+        state_idx = seq_idx
+        if cutlass.const_expr(self.use_state_indices):
+            state_idx = cutlass.Int32(g_state_indices_t[seq_idx])
         if cutlass.const_expr(self.needs_initial_state):
+            if cutlass.const_expr(self.use_state_indices):
+                initial_state_layout = cute.make_layout(
+                    (self.D, self.D, num_heads, g_initial_state_t.shape[0]),
+                    stride=(
+                        g_initial_state_t.stride[2],
+                        g_initial_state_t.stride[3],
+                        g_initial_state_t.stride[1],
+                        g_initial_state_t.stride[0],
+                    ),
+                )
+            else:
+                initial_state_layout = fixed_state_layout
             gInitialState = cute.make_tensor(
-                g_initial_state_t.iterator, fixed_state_layout
+                g_initial_state_t.iterator, initial_state_layout
             )
         else:
             gInitialState = gFixedState
@@ -2579,7 +2624,7 @@ class CPDeltaRuleFixupSimtSm90(KeyedCompileMixin):
         gFixedState_seq = cute.domain_offset((0, 0, chunk_start), gFixedState_cta)
         if cutlass.const_expr(self.needs_initial_state):
             gInitialState_cta = cute.local_tile(
-                gInitialState[None, None, head_idx, seq_idx],
+                gInitialState[None, None, head_idx, state_idx],
                 (self.rows_per_cta, self.D),
                 (row_cta_idx, 0),
             )
@@ -2611,13 +2656,13 @@ class CPDeltaRuleFixupSimtSm90(KeyedCompileMixin):
 
 
 @functools.cache
-def _get_fixup_kernel(needs_initial_state, kernel_kind):
+def _get_fixup_kernel(needs_initial_state, kernel_kind, use_state_indices):
     if kernel_kind == "simt_row4":
-        return CPDeltaRuleFixupSimtSm90(needs_initial_state, 4)
+        return CPDeltaRuleFixupSimtSm90(needs_initial_state, 4, use_state_indices)
     if kernel_kind == "simt_row8":
-        return CPDeltaRuleFixupSimtSm90(needs_initial_state, 8)
+        return CPDeltaRuleFixupSimtSm90(needs_initial_state, 8, use_state_indices)
     if kernel_kind == "hmma":
-        return CPDeltaRuleFixupHmmaSm90(needs_initial_state)
+        return CPDeltaRuleFixupHmmaSm90(needs_initial_state, use_state_indices)
     raise ValueError(f"Unsupported fixup kernel kind: {kernel_kind}")
 
 
@@ -2628,6 +2673,7 @@ def cp_delta_rule_fixup_dsl_sm90(
     total_seqlen: int,
     cp_chunk_len: int = 4096,
     initial_state: torch.Tensor | None = None,
+    state_indices: torch.Tensor | None = None,
     *,
     _skip_check: bool = False,
     _kernel_kind: str | None = None,
@@ -2663,30 +2709,48 @@ def cp_delta_rule_fixup_dsl_sm90(
                 "CPDeltaRuleFixupSm90 only supports float32 inputs, "
                 f"got {local_transfer.dtype} and {local_state.dtype}"
             )
+        use_state_indices = state_indices is not None
         if initial_state is not None:
-            if initial_state.shape != (
-                cu_seqlens.shape[0] - 1,
-                local_transfer.shape[1],
-                128,
-                128,
+            expected_tail = (local_transfer.shape[1], 128, 128)
+            if (
+                not use_state_indices
+                and initial_state.shape != (cu_seqlens.shape[0] - 1, *expected_tail)
+            ) or (
+                use_state_indices and tuple(initial_state.shape[1:]) != expected_tail
             ):
                 raise RuntimeError(
                     "initial_state must have shape "
-                    f"{(cu_seqlens.shape[0] - 1, local_transfer.shape[1], 128, 128)}, got {tuple(initial_state.shape)}"
+                    f"{('[N_pool]' if use_state_indices else f'[{cu_seqlens.shape[0] - 1}]')} "
+                    f"+ {expected_tail}, got {tuple(initial_state.shape)}"
                 )
             if initial_state.dtype != torch.float32:
                 raise RuntimeError(
                     f"initial_state must have dtype torch.float32, got {initial_state.dtype}"
                 )
+        if use_state_indices and (
+            state_indices.dtype != torch.int32
+            or state_indices.shape != (cu_seqlens.shape[0] - 1,)
+        ):
+            raise RuntimeError(
+                f"state_indices must have shape {(cu_seqlens.shape[0] - 1,)} and dtype int32"
+            )
         for name, tensor in (
             ("local_transfer", local_transfer),
             ("local_state", local_state),
-            ("initial_state", initial_state),
+            ("state_indices", state_indices),
         ):
             if tensor is None:
                 continue
             if not tensor.is_contiguous():
                 raise RuntimeError(f"{name} must be contiguous")
+        if initial_state is not None:
+            if use_state_indices:
+                if initial_state.stride()[1:] != (128 * 128, 128, 1):
+                    raise RuntimeError(
+                        "initial_state inner dimensions must be contiguous when state_indices is used"
+                    )
+            elif not initial_state.is_contiguous():
+                raise RuntimeError("initial_state must be contiguous")
     total_cp_chunks, num_heads, _, _ = local_transfer.shape
     if not _skip_check:
         if cp_chunk_len <= 0:
@@ -2729,6 +2793,7 @@ def cp_delta_rule_fixup_dsl_sm90(
     )
 
     needs_initial_state = initial_state is not None
+    use_state_indices = state_indices is not None
     if _kernel_kind is None:
         if num_heads <= 8:
             _kernel_kind = "simt_row4"
@@ -2736,17 +2801,20 @@ def cp_delta_rule_fixup_dsl_sm90(
             _kernel_kind = "simt_row8"
         else:
             _kernel_kind = "hmma"
-    kernel = _get_fixup_kernel(needs_initial_state, _kernel_kind)
+    kernel = _get_fixup_kernel(needs_initial_state, _kernel_kind, use_state_indices)
     compiled = get_cached_compile(kernel, _SM90_COMPILE_OPTIONS)
     if compiled is None:
         from_dlpack = lambda *args, **kwargs: cute.runtime.from_dlpack(
             *args, **{**kwargs, "enable_tvm_ffi": True}
         )
         initial_state_cute = (
-            from_dlpack(
-                initial_state.reshape(-1), assumed_align=16
-            ).mark_layout_dynamic()
+            from_dlpack(initial_state, assumed_align=16).mark_layout_dynamic()
             if needs_initial_state
+            else None
+        )
+        state_indices_cute = (
+            from_dlpack(state_indices, assumed_align=4).mark_layout_dynamic()
+            if use_state_indices
             else None
         )
         kernel_args = (
@@ -2757,6 +2825,7 @@ def cp_delta_rule_fixup_dsl_sm90(
                 leading_dim=1
             ),
             initial_state_cute,
+            state_indices_cute,
             from_dlpack(
                 fixed_state.reshape(-1), assumed_align=128
             ).mark_layout_dynamic(),
@@ -2773,7 +2842,8 @@ def cp_delta_rule_fixup_dsl_sm90(
     compiled(
         local_transfer_tma,
         local_state_tma,
-        initial_state.reshape(-1) if needs_initial_state else None,
+        initial_state if needs_initial_state else None,
+        state_indices if use_state_indices else None,
         fixed_state.reshape(-1),
         cu_seqlens,
         cp_chunk_len,
@@ -2792,8 +2862,18 @@ class CPDeltaRulePrefillSm90(_FullyFusedDeltaRuleSm90):
         acc_dtype: type[cutlass.Numeric] = cutlass.Float32,
         needs_initial_state: bool = False,
         store_final_state: bool = True,
+        use_state_indices: bool = False,
+        needs_checkpointing: bool = False,
     ):
-        super().__init__(True, False, True, False, dtype, acc_dtype)
+        super().__init__(
+            True,
+            False,
+            True,
+            needs_checkpointing,
+            dtype,
+            acc_dtype,
+            use_state_indices=use_state_indices,
+        )
         self.needs_initial_state = needs_initial_state
         self.store_final_state = store_final_state
         self.t_stage = 2
@@ -2804,6 +2884,7 @@ class CPDeltaRulePrefillSm90(_FullyFusedDeltaRuleSm90):
             "needs_checkpointing",
             "needs_initial_state",
             "store_final_state",
+            "use_state_indices",
             "dtype",
             "acc_dtype",
             "inverse_dtype",
@@ -3203,12 +3284,17 @@ class CPDeltaRulePrefillSm90(_FullyFusedDeltaRuleSm90):
         g_state: cute.Tensor,
         g_fixed_state: cute.Tensor,
         g_initial_state: cute.Tensor,
+        g_state_indices: cute.Tensor,
+        g_state_checkpoints: cute.Tensor,
+        checkpoint_cu_starts: cute.Tensor,
         work_desc: WorkDesc,
         public_seq_idx: cutlass.Int32,
         fixed_state_idx: cutlass.Int32,
         load_fixed_state,
         load_initial_state,
         store_state,
+        seq_block_offset: cutlass.Int32,
+        full_seq_len: cutlass.Int32,
         scale: cutlass.Float32,
         wg_idx: cutlass.Int32,
         math_tidx: cutlass.Int32,
@@ -3218,6 +3304,8 @@ class CPDeltaRulePrefillSm90(_FullyFusedDeltaRuleSm90):
         num_sab_heads: cutlass.Int32,
         num_chunks: cutlass.Int32,
         num_seqs: cutlass.Int32,
+        total_checkpoints: cutlass.Int32,
+        checkpoint_every_n_tokens: cutlass.Int32,
     ):
         self._math_order_init(wg_idx)
         q_consumer_state = pipeline.make_pipeline_state(
@@ -3261,15 +3349,46 @@ class CPDeltaRulePrefillSm90(_FullyFusedDeltaRuleSm90):
         )
         tKVrKV.fill(self.acc_dtype(0.0))
 
-        state_layout = cute.make_ordered_layout(
+        packed_state_layout = cute.make_ordered_layout(
             (self.D, self.D, num_sab_heads, num_seqs), order=(0, 1, 2, 3)
         )
+        state_idx = public_seq_idx
+        if cutlass.const_expr(self.use_state_indices):
+            state_idx = cutlass.Int32(g_state_indices[public_seq_idx])
+        output_state_idx = public_seq_idx
+        if cutlass.const_expr(self.use_state_indices and self.store_final_state):
+            output_state_idx = state_idx
+            state_layout = cute.make_layout(
+                (self.D, self.D, num_sab_heads, g_state.shape[0]),
+                stride=(
+                    g_state.stride[3],
+                    g_state.stride[2],
+                    g_state.stride[1],
+                    g_state.stride[0],
+                ),
+            )
+        else:
+            state_layout = packed_state_layout
         o_head_idx = work_desc.o_head_idx(num_q_heads, num_v_heads)
         mState = cute.make_tensor(g_state.iterator, state_layout)
-        gStateKV = mState[None, None, o_head_idx, public_seq_idx]
+        gStateKV = mState[None, None, o_head_idx, output_state_idx]
         if cutlass.const_expr(self.needs_initial_state):
-            mInitialState = cute.make_tensor(g_initial_state.iterator, state_layout)
-            gInitialKV = mInitialState[None, None, o_head_idx, public_seq_idx]
+            if cutlass.const_expr(self.use_state_indices):
+                initial_state_layout = cute.make_layout(
+                    (self.D, self.D, num_sab_heads, g_initial_state.shape[0]),
+                    stride=(
+                        g_initial_state.stride[3],
+                        g_initial_state.stride[2],
+                        g_initial_state.stride[1],
+                        g_initial_state.stride[0],
+                    ),
+                )
+            else:
+                initial_state_layout = packed_state_layout
+            mInitialState = cute.make_tensor(
+                g_initial_state.iterator, initial_state_layout
+            )
+            gInitialKV = mInitialState[None, None, o_head_idx, state_idx]
         fixed_state_layout = cute.make_ordered_layout(
             (self.D, self.D, num_sab_heads, num_chunks), order=(0, 1, 2, 3)
         )
@@ -3324,8 +3443,22 @@ class CPDeltaRulePrefillSm90(_FullyFusedDeltaRuleSm90):
             scale,
             wg_idx,
         )
+        self.maybe_store_checkpoint(
+            tKVrKV,
+            g_state_checkpoints,
+            checkpoint_cu_starts,
+            checkpoint_every_n_tokens,
+            kv_tiled_mma,
+            math_tidx,
+            public_seq_idx,
+            o_head_idx,
+            num_sab_heads,
+            total_checkpoints,
+            seq_block_offset + cutlass.Int32(self.BLK_KV),
+            full_seq_len,
+        )
 
-        for _ in cutlass.range(1, num_blocks - 1, 1, unroll=1):
+        for blk in cutlass.range(1, num_blocks - 1, 1, unroll=1):
             (
                 q_consumer_state,
                 k_consumer_state,
@@ -3365,6 +3498,21 @@ class CPDeltaRulePrefillSm90(_FullyFusedDeltaRuleSm90):
                 tKVrKV,
                 scale,
                 wg_idx,
+            )
+            self.maybe_store_checkpoint(
+                tKVrKV,
+                g_state_checkpoints,
+                checkpoint_cu_starts,
+                checkpoint_every_n_tokens,
+                kv_tiled_mma,
+                math_tidx,
+                public_seq_idx,
+                o_head_idx,
+                num_sab_heads,
+                total_checkpoints,
+                seq_block_offset
+                + (blk + cutlass.Int32(1)) * cutlass.Int32(self.BLK_KV),
+                full_seq_len,
             )
 
         if num_blocks != 1:
@@ -3410,6 +3558,21 @@ class CPDeltaRulePrefillSm90(_FullyFusedDeltaRuleSm90):
                 scale,
                 wg_idx,
             )
+            self.maybe_store_checkpoint(
+                tKVrKV,
+                g_state_checkpoints,
+                checkpoint_cu_starts,
+                checkpoint_every_n_tokens,
+                kv_tiled_mma,
+                math_tidx,
+                public_seq_idx,
+                o_head_idx,
+                num_sab_heads,
+                total_checkpoints,
+                seq_block_offset
+                + (last_blk + cutlass.Int32(1)) * cutlass.Int32(self.BLK_KV),
+                full_seq_len,
+            )
         if cutlass.const_expr(self.store_final_state):
             if store_state:
                 self.kv_store(tKVrKV, gStateKV, kv_tiled_mma, math_tidx)
@@ -3426,6 +3589,9 @@ class CPDeltaRulePrefillSm90(_FullyFusedDeltaRuleSm90):
         g_state: cute.Tensor,
         g_fixed_state: cute.Tensor,
         g_initial_state: cute.Tensor,
+        g_state_indices: cute.Tensor,
+        g_state_checkpoints: cute.Tensor,
+        checkpoint_cu_starts: cute.Tensor,
         g_tensormaps: cute.Tensor,
         g_cu_seqlens: cute.Tensor,
         scale: cutlass.Float32,
@@ -3437,6 +3603,8 @@ class CPDeltaRulePrefillSm90(_FullyFusedDeltaRuleSm90):
         total_cp_chunks: cutlass.Int32,
         max_cp_chunks_per_seq: cutlass.Int32,
         num_seqs: cutlass.Int32,
+        total_checkpoints: cutlass.Int32,
+        checkpoint_every_n_tokens: cutlass.Int32,
         stream,
     ):
         qkv_smem_layout_atom = warpgroup.make_smem_layout_atom(
@@ -3581,6 +3749,9 @@ class CPDeltaRulePrefillSm90(_FullyFusedDeltaRuleSm90):
             g_state,
             g_fixed_state,
             g_initial_state,
+            g_state_indices,
+            g_state_checkpoints,
+            checkpoint_cu_starts,
             g_tensormaps,
             g_cu_seqlens,
             scale,
@@ -3591,6 +3762,8 @@ class CPDeltaRulePrefillSm90(_FullyFusedDeltaRuleSm90):
             chunk_len,
             total_cp_chunks,
             num_seqs,
+            total_checkpoints,
+            checkpoint_every_n_tokens,
         ).launch(
             grid=(num_sab_heads * max_cp_chunks_per_seq, num_seqs, 1),
             block=(512, 1, 1),
@@ -3616,6 +3789,9 @@ class CPDeltaRulePrefillSm90(_FullyFusedDeltaRuleSm90):
         g_state: cute.Tensor,
         g_fixed_state: cute.Tensor,
         g_initial_state: cute.Tensor,
+        g_state_indices: cute.Tensor,
+        g_state_checkpoints: cute.Tensor,
+        checkpoint_cu_starts: cute.Tensor,
         g_tensormaps: cute.Tensor,
         g_cu_seqlens: cute.Tensor,
         scale: cutlass.Float32,
@@ -3626,6 +3802,8 @@ class CPDeltaRulePrefillSm90(_FullyFusedDeltaRuleSm90):
         chunk_len: cutlass.Int32,
         total_cp_chunks: cutlass.Int32,
         num_seqs: cutlass.Int32,
+        total_checkpoints: cutlass.Int32,
+        checkpoint_every_n_tokens: cutlass.Int32,
     ):
         NUM_LOAD_WARP_GROUPS = 1
         NUM_STATE_MMA_WARP_GROUPS = 2
@@ -3965,12 +4143,17 @@ class CPDeltaRulePrefillSm90(_FullyFusedDeltaRuleSm90):
                         g_state,
                         g_fixed_state,
                         g_initial_state,
+                        g_state_indices,
+                        g_state_checkpoints,
+                        checkpoint_cu_starts,
                         work_desc,
                         seq_idx,
                         fixed_state_idx,
                         load_fixed_state,
                         load_initial_state,
                         store_state,
+                        chunk_idx_in_seq * chunk_len,
+                        seq_len,
                         scale,
                         wg_idx,
                         math_tidx,
@@ -3980,15 +4163,25 @@ class CPDeltaRulePrefillSm90(_FullyFusedDeltaRuleSm90):
                         num_sab_heads,
                         total_cp_chunks,
                         num_seqs,
+                        total_checkpoints,
+                        checkpoint_every_n_tokens,
                     )
 
 
 @functools.cache
-def _get_prefill_kernel(kernel_dtype, needs_initial_state, store_final_state):
+def _get_prefill_kernel(
+    kernel_dtype,
+    needs_initial_state,
+    store_final_state,
+    use_state_indices,
+    needs_checkpointing,
+):
     return CPDeltaRulePrefillSm90(
         kernel_dtype,
         needs_initial_state=needs_initial_state,
         store_final_state=store_final_state,
+        use_state_indices=use_state_indices,
+        needs_checkpointing=needs_checkpointing,
     )
 
 
@@ -4007,6 +4200,10 @@ def cp_delta_rule_prefill_dsl_sm90(
     cp_chunk_len: int = 4096,
     max_seqlen: int | None = None,
     initial_state: torch.Tensor | None = None,
+    state_indices: torch.Tensor | None = None,
+    state_checkpoints: torch.Tensor | None = None,
+    checkpoint_cu_starts: torch.Tensor | None = None,
+    checkpoint_every_n_tokens: int = 0,
     *,
     _skip_check: bool = False,
     _device=None,
@@ -4021,6 +4218,7 @@ def cp_delta_rule_prefill_dsl_sm90(
     import cuda.bindings.driver as cuda_driver
 
     device = q.device if _device is None else _device
+    needs_checkpointing = checkpoint_every_n_tokens > 0
     if not _skip_check:
         if q.ndim != 3:
             raise RuntimeError(
@@ -4054,6 +4252,17 @@ def cp_delta_rule_prefill_dsl_sm90(
         if cp_chunk_len % 64 != 0:
             raise RuntimeError(
                 f"cp_chunk_len must be a multiple of 64, got {cp_chunk_len}"
+            )
+        if checkpoint_every_n_tokens < 0 or checkpoint_every_n_tokens % 64 != 0:
+            raise RuntimeError(
+                "checkpoint_every_n_tokens must be a non-negative multiple of 64, "
+                f"got {checkpoint_every_n_tokens}"
+            )
+        if needs_checkpointing and (
+            state_checkpoints is None or checkpoint_cu_starts is None
+        ):
+            raise RuntimeError(
+                "state_checkpoints and checkpoint_cu_starts are required when checkpointing is enabled"
             )
         if cu_seqlens.dtype != torch.int64:
             raise RuntimeError(
@@ -4095,8 +4304,16 @@ def cp_delta_rule_prefill_dsl_sm90(
             )
         expected_fixed_state_shape = (total_cp_chunks, num_sab_heads, d, d)
         expected_state_shape = (num_seqs, num_sab_heads, d, d)
+        use_state_indices = state_indices is not None
         if fixed_state.shape != expected_fixed_state_shape or (
-            state is not None and state.shape != expected_state_shape
+            state is not None
+            and (
+                (not use_state_indices and state.shape != expected_state_shape)
+                or (
+                    use_state_indices
+                    and tuple(state.shape[1:]) != expected_state_shape[1:]
+                )
+            )
         ):
             raise RuntimeError(
                 "fixed_state/state must have shapes "
@@ -4104,9 +4321,23 @@ def cp_delta_rule_prefill_dsl_sm90(
                 f"got {tuple(fixed_state.shape)} and "
                 f"{None if state is None else tuple(state.shape)}"
             )
-        if initial_state is not None and initial_state.shape != expected_state_shape:
+        if initial_state is not None and (
+            (not use_state_indices and initial_state.shape != expected_state_shape)
+            or (
+                use_state_indices
+                and tuple(initial_state.shape[1:]) != expected_state_shape[1:]
+            )
+        ):
             raise RuntimeError(
-                f"initial_state must have shape {expected_state_shape}, got {tuple(initial_state.shape)}"
+                f"initial_state must have shape "
+                f"{('[N_pool]' if use_state_indices else f'[{num_seqs}]')} + {expected_state_shape[1:]}, "
+                f"got {tuple(initial_state.shape)}"
+            )
+        if use_state_indices and (
+            state_indices.dtype != torch.int32 or state_indices.shape != (num_seqs,)
+        ):
+            raise RuntimeError(
+                f"state_indices must have shape {(num_seqs,)} and dtype int32"
             )
         if q.shape[-1] != 128:
             raise RuntimeError(
@@ -4134,20 +4365,46 @@ def cp_delta_rule_prefill_dsl_sm90(
             raise RuntimeError(
                 f"initial_state must have dtype torch.float32, got {initial_state.dtype}"
             )
+        if needs_checkpointing:
+            if state_checkpoints.dtype != torch.float32 or tuple(
+                state_checkpoints.shape[1:]
+            ) != (num_sab_heads, d, d):
+                raise RuntimeError(
+                    "state_checkpoints must have shape "
+                    f"[*, {num_sab_heads}, {d}, {d}] and dtype float32"
+                )
+            if (
+                checkpoint_cu_starts.dtype != torch.int64
+                or checkpoint_cu_starts.shape != (num_seqs + 1,)
+            ):
+                raise RuntimeError(
+                    f"checkpoint_cu_starts must have shape {(num_seqs + 1,)} and dtype int64"
+                )
         for name, tensor in (
             ("q", q),
             ("k", k),
             ("v", v),
             ("t", t),
             ("fixed_state", fixed_state),
-            ("initial_state", initial_state),
             ("alpha", alpha),
             ("o", o),
-            ("state", state),
+            ("state_indices", state_indices),
+            ("state_checkpoints", state_checkpoints),
+            ("checkpoint_cu_starts", checkpoint_cu_starts),
         ):
             if tensor is None:
                 continue
             if not tensor.is_contiguous():
+                raise RuntimeError(f"{name} must be contiguous")
+        for name, tensor in (("state", state), ("initial_state", initial_state)):
+            if tensor is None:
+                continue
+            if use_state_indices:
+                if tensor.stride()[1:] != (d * d, d, 1):
+                    raise RuntimeError(
+                        f"{name} inner dimensions must be contiguous when state_indices is used"
+                    )
+            elif not tensor.is_contiguous():
                 raise RuntimeError(f"{name} must be contiguous")
     max_cp_chunks_per_seq = max_num_chunks_host(max_seqlen, cp_chunk_len)
     if total_cp_chunks == 0:
@@ -4193,7 +4450,14 @@ def cp_delta_rule_prefill_dsl_sm90(
 
     needs_initial_state = initial_state is not None
     store_final_state = state is not None
-    kernel = _get_prefill_kernel(kernel_dtype, needs_initial_state, store_final_state)
+    use_state_indices = state_indices is not None
+    kernel = _get_prefill_kernel(
+        kernel_dtype,
+        needs_initial_state,
+        store_final_state,
+        use_state_indices,
+        needs_checkpointing,
+    )
     state_arg = state if store_final_state else fixed_state
     compiled = get_cached_compile(kernel, _SM90_COMPILE_OPTIONS)
     if compiled is None:
@@ -4201,10 +4465,26 @@ def cp_delta_rule_prefill_dsl_sm90(
             *args, **{**kwargs, "enable_tvm_ffi": True}
         )
         initial_state_cute = (
-            from_dlpack(
-                initial_state.reshape(-1), assumed_align=16
-            ).mark_layout_dynamic()
+            from_dlpack(initial_state, assumed_align=16).mark_layout_dynamic()
             if needs_initial_state
+            else None
+        )
+        state_indices_cute = (
+            from_dlpack(state_indices, assumed_align=4).mark_layout_dynamic()
+            if use_state_indices
+            else None
+        )
+        total_checkpoints = state_checkpoints.shape[0] if needs_checkpointing else 1
+        state_checkpoints_cute = (
+            from_dlpack(
+                state_checkpoints.reshape(-1), assumed_align=16
+            ).mark_layout_dynamic()
+            if needs_checkpointing
+            else None
+        )
+        checkpoint_cu_cute = (
+            from_dlpack(checkpoint_cu_starts, assumed_align=8).mark_layout_dynamic()
+            if needs_checkpointing
             else None
         )
         kernel_args = (
@@ -4214,11 +4494,14 @@ def cp_delta_rule_prefill_dsl_sm90(
             from_dlpack(t_tma, assumed_align=16).mark_layout_dynamic(leading_dim=1),
             from_dlpack(o_tma, assumed_align=16).mark_layout_dynamic(leading_dim=0),
             from_dlpack(alpha.reshape(-1), assumed_align=16).mark_layout_dynamic(),
-            from_dlpack(state_arg.reshape(-1), assumed_align=16).mark_layout_dynamic(),
+            from_dlpack(state_arg, assumed_align=16).mark_layout_dynamic(),
             from_dlpack(
                 fixed_state.reshape(-1), assumed_align=16
             ).mark_layout_dynamic(),
             initial_state_cute,
+            state_indices_cute,
+            state_checkpoints_cute,
+            checkpoint_cu_cute,
             from_dlpack(tensormaps_t, assumed_align=128).mark_layout_dynamic(),
             from_dlpack(cu_seqlens, assumed_align=8).mark_layout_dynamic(),
             cutlass.Float32(scale),
@@ -4230,6 +4513,8 @@ def cp_delta_rule_prefill_dsl_sm90(
             cutlass.Int32(total_cp_chunks),
             cutlass.Int32(max_cp_chunks_per_seq),
             cutlass.Int32(num_seqs),
+            cutlass.Int32(total_checkpoints),
+            cutlass.Int32(checkpoint_every_n_tokens),
             stream,
         )
         compiled = cached_compile(
@@ -4242,9 +4527,12 @@ def cp_delta_rule_prefill_dsl_sm90(
         t_tma,
         o_tma,
         alpha.reshape(-1),
-        state_arg.reshape(-1),
+        state_arg,
         fixed_state.reshape(-1),
-        initial_state.reshape(-1) if needs_initial_state else None,
+        initial_state if needs_initial_state else None,
+        state_indices if use_state_indices else None,
+        state_checkpoints.reshape(-1) if needs_checkpointing else None,
+        checkpoint_cu_starts if needs_checkpointing else None,
         tensormaps_t,
         cu_seqlens,
         scale,
@@ -4256,6 +4544,8 @@ def cp_delta_rule_prefill_dsl_sm90(
         total_cp_chunks,
         max_cp_chunks_per_seq,
         num_seqs,
+        state_checkpoints.shape[0] if needs_checkpointing else 1,
+        checkpoint_every_n_tokens,
         stream,
     )
 
@@ -4272,6 +4562,10 @@ def cp_delta_rule_dsl_sm90(
     scale: float,
     *,
     initial_state: torch.Tensor | None = None,
+    state_indices: torch.Tensor | None = None,
+    state_checkpoints: torch.Tensor | None = None,
+    checkpoint_cu_starts: torch.Tensor | None = None,
+    checkpoint_every_n_tokens: int = 0,
     max_seqlen: int | None = None,
     cp_chunk_len: int | None = None,
     cp_chunk_len_granularity: int = CP_CHUNK_LEN_GRANULARITY,
@@ -4333,6 +4627,18 @@ def cp_delta_rule_dsl_sm90(
         )
     if cp_chunk_len % 64 != 0:
         raise RuntimeError(f"cp_chunk_len must be a multiple of 64, got {cp_chunk_len}")
+    needs_checkpointing = checkpoint_every_n_tokens > 0
+    if checkpoint_every_n_tokens < 0 or checkpoint_every_n_tokens % 64 != 0:
+        raise RuntimeError(
+            "checkpoint_every_n_tokens must be a non-negative multiple of 64, "
+            f"got {checkpoint_every_n_tokens}"
+        )
+    if needs_checkpointing and (
+        state_checkpoints is None or checkpoint_cu_starts is None
+    ):
+        raise RuntimeError(
+            "state_checkpoints and checkpoint_cu_starts are required when checkpointing is enabled"
+        )
     if cu_seqlens.dtype != torch.int64:
         raise RuntimeError(
             f"cu_seqlens must have dtype torch.int64, got {cu_seqlens.dtype}"
@@ -4363,13 +4669,33 @@ def cp_delta_rule_dsl_sm90(
             f"of k heads, got q={num_q_heads}, k={num_k_heads}, v={num_v_heads}"
         )
     expected_state_shape = (num_seqs, num_sab_heads, d, d)
-    if state is not None and state.shape != expected_state_shape:
+    use_state_indices = state_indices is not None
+    if state is not None and (
+        (not use_state_indices and state.shape != expected_state_shape)
+        or (use_state_indices and tuple(state.shape[1:]) != expected_state_shape[1:])
+    ):
         raise RuntimeError(
-            f"state must have shape {expected_state_shape}, got {tuple(state.shape)}"
+            f"state must have shape "
+            f"{('[N_pool]' if use_state_indices else f'[{num_seqs}]')} + {expected_state_shape[1:]}, "
+            f"got {tuple(state.shape)}"
         )
-    if initial_state is not None and initial_state.shape != expected_state_shape:
+    if initial_state is not None and (
+        (not use_state_indices and initial_state.shape != expected_state_shape)
+        or (
+            use_state_indices
+            and tuple(initial_state.shape[1:]) != expected_state_shape[1:]
+        )
+    ):
         raise RuntimeError(
-            f"initial_state must have shape {expected_state_shape}, got {tuple(initial_state.shape)}"
+            f"initial_state must have shape "
+            f"{('[N_pool]' if use_state_indices else f'[{num_seqs}]')} + {expected_state_shape[1:]}, "
+            f"got {tuple(initial_state.shape)}"
+        )
+    if use_state_indices and (
+        state_indices.dtype != torch.int32 or state_indices.shape != (num_seqs,)
+    ):
+        raise RuntimeError(
+            f"state_indices must have shape {(num_seqs,)} and dtype int32"
         )
     if q.shape[-1] != 128:
         raise RuntimeError(f"CPDeltaRuleSm90 only supports D=128, got {q.shape[-1]}")
@@ -4390,6 +4716,20 @@ def cp_delta_rule_dsl_sm90(
         raise RuntimeError(
             f"initial_state must have dtype torch.float32, got {initial_state.dtype}"
         )
+    if needs_checkpointing:
+        if state_checkpoints.dtype != torch.float32 or tuple(
+            state_checkpoints.shape[1:]
+        ) != (num_sab_heads, d, d):
+            raise RuntimeError(
+                "state_checkpoints must have shape "
+                f"[*, {num_sab_heads}, {d}, {d}] and dtype float32"
+            )
+        if checkpoint_cu_starts.dtype != torch.int64 or checkpoint_cu_starts.shape != (
+            num_seqs + 1,
+        ):
+            raise RuntimeError(
+                f"checkpoint_cu_starts must have shape {(num_seqs + 1,)} and dtype int64"
+            )
     for name, tensor in (
         ("q", q),
         ("k", k),
@@ -4397,12 +4737,23 @@ def cp_delta_rule_dsl_sm90(
         ("alpha", alpha),
         ("beta", beta),
         ("o", o),
-        ("state", state),
-        ("initial_state", initial_state),
+        ("state_indices", state_indices),
+        ("state_checkpoints", state_checkpoints),
+        ("checkpoint_cu_starts", checkpoint_cu_starts),
     ):
         if tensor is None:
             continue
         if not tensor.is_contiguous():
+            raise RuntimeError(f"{name} must be contiguous")
+    for name, tensor in (("state", state), ("initial_state", initial_state)):
+        if tensor is None:
+            continue
+        if use_state_indices:
+            if tensor.stride()[1:] != (d * d, d, 1):
+                raise RuntimeError(
+                    f"{name} inner dimensions must be contiguous when state_indices is used"
+                )
+        elif not tensor.is_contiguous():
             raise RuntimeError(f"{name} must be contiguous")
 
     t = cp_delta_rule_t_precompute_dsl_sm90(
@@ -4435,6 +4786,7 @@ def cp_delta_rule_dsl_sm90(
         total_seqlen,
         cp_chunk_len=cp_chunk_len,
         initial_state=initial_state,
+        state_indices=state_indices,
         _skip_check=True,
         _device=device,
         _stream=stream,
@@ -4455,6 +4807,10 @@ def cp_delta_rule_dsl_sm90(
         cp_chunk_len=cp_chunk_len,
         max_seqlen=max_seqlen,
         initial_state=initial_state,
+        state_indices=state_indices,
+        state_checkpoints=state_checkpoints,
+        checkpoint_cu_starts=checkpoint_cu_starts,
+        checkpoint_every_n_tokens=checkpoint_every_n_tokens,
         _skip_check=True,
         _device=device,
         _stream=stream,

--- a/flashinfer/gdn_kernels/delta_rule_dsl/delta_rule_cp_sm90.py
+++ b/flashinfer/gdn_kernels/delta_rule_dsl/delta_rule_cp_sm90.py
@@ -28,6 +28,7 @@ from .helpers import (
     load_tensor_as_a,
     round_down,
     select_tensor_10,
+    state_dtype_to_cutlass,
 )
 from .varlen_helper import (
     CP_CHUNK_LEN_GRANULARITY,
@@ -1837,12 +1838,14 @@ class CPDeltaRuleFixupHmmaSm90(KeyedCompileMixin):
     def __init__(
         self,
         needs_initial_state: bool = False,
+        initial_state_dtype: type[cutlass.Numeric] = cutlass.Float32,
         use_state_indices: bool = False,
         cu_seqlens_dtype: torch.dtype = torch.int64,
         state_indices_dtype: torch.dtype | None = None,
         initial_state_inner_strides: tuple[int, ...] | None = None,
     ):
         self.needs_initial_state = needs_initial_state
+        self.initial_state_dtype = initial_state_dtype
         self.use_state_indices = use_state_indices
         self.cu_seqlens_dtype = cu_seqlens_dtype
         self.state_indices_dtype = state_indices_dtype
@@ -1866,6 +1869,7 @@ class CPDeltaRuleFixupHmmaSm90(KeyedCompileMixin):
         self.use_3xtf32 = False
         self.manual_cache_key(
             "needs_initial_state",
+            "initial_state_dtype",
             "use_state_indices",
             "cu_seqlens_dtype",
             "state_indices_dtype",
@@ -2037,7 +2041,11 @@ class CPDeltaRuleFixupHmmaSm90(KeyedCompileMixin):
             start = cutlass.Int32(0)
 
             # init tSMrState from initial_state
-            cute.autovec_copy(tSMgInitialState, tSMrState_cv)
+            tSMrInitialState = cute.make_rmem_tensor_like(
+                tSMrState_cv, self.initial_state_dtype
+            )
+            cute.autovec_copy(tSMgInitialState, tSMrInitialState)
+            tSMrState_cv.store(tSMrInitialState.load().to(cutlass.Float32))
 
         for chunk_idx in cutlass.range(start, num_chunks, unroll=1):
             TF32.convert_tf32_c_to_kpermuted_a(tSMrState, tSMrS)
@@ -2352,6 +2360,7 @@ class CPDeltaRuleFixupSimtSm90(KeyedCompileMixin):
     def __init__(
         self,
         needs_initial_state: bool = False,
+        initial_state_dtype: type[cutlass.Numeric] = cutlass.Float32,
         rows_per_cta: int = 4,
         use_state_indices: bool = False,
         cu_seqlens_dtype: torch.dtype = torch.int64,
@@ -2359,6 +2368,7 @@ class CPDeltaRuleFixupSimtSm90(KeyedCompileMixin):
         initial_state_inner_strides: tuple[int, ...] | None = None,
     ):
         self.needs_initial_state = needs_initial_state
+        self.initial_state_dtype = initial_state_dtype
         self.use_state_indices = use_state_indices
         self.cu_seqlens_dtype = cu_seqlens_dtype
         self.state_indices_dtype = state_indices_dtype
@@ -2372,6 +2382,7 @@ class CPDeltaRuleFixupSimtSm90(KeyedCompileMixin):
         self.registers_per_thread = 256
         self.manual_cache_key(
             "needs_initial_state",
+            "initial_state_dtype",
             "use_state_indices",
             "cu_seqlens_dtype",
             "state_indices_dtype",
@@ -2397,7 +2408,7 @@ class CPDeltaRuleFixupSimtSm90(KeyedCompileMixin):
         start = cutlass.Int32(0)
         if cutlass.const_expr(self.needs_initial_state):
             for i in cutlass.range_constexpr(self.rows_per_cta):
-                sState[i, col] = gInitialState[i, col]
+                sState[i, col] = gInitialState[i, col].to(cutlass.Float32)
         else:
             start = cutlass.Int32(1)
             for i in cutlass.range_constexpr(self.rows_per_cta):
@@ -2689,6 +2700,7 @@ class CPDeltaRuleFixupSimtSm90(KeyedCompileMixin):
 @functools.cache
 def _get_fixup_kernel(
     needs_initial_state,
+    initial_state_dtype,
     kernel_kind,
     use_state_indices,
     cu_seqlens_dtype,
@@ -2698,6 +2710,7 @@ def _get_fixup_kernel(
     if kernel_kind == "simt_row4":
         return CPDeltaRuleFixupSimtSm90(
             needs_initial_state=needs_initial_state,
+            initial_state_dtype=state_dtype_to_cutlass(initial_state_dtype),
             rows_per_cta=4,
             use_state_indices=use_state_indices,
             cu_seqlens_dtype=cu_seqlens_dtype,
@@ -2707,6 +2720,7 @@ def _get_fixup_kernel(
     if kernel_kind == "simt_row8":
         return CPDeltaRuleFixupSimtSm90(
             needs_initial_state=needs_initial_state,
+            initial_state_dtype=state_dtype_to_cutlass(initial_state_dtype),
             rows_per_cta=8,
             use_state_indices=use_state_indices,
             cu_seqlens_dtype=cu_seqlens_dtype,
@@ -2716,6 +2730,7 @@ def _get_fixup_kernel(
     if kernel_kind == "hmma":
         return CPDeltaRuleFixupHmmaSm90(
             needs_initial_state=needs_initial_state,
+            initial_state_dtype=state_dtype_to_cutlass(initial_state_dtype),
             use_state_indices=use_state_indices,
             cu_seqlens_dtype=cu_seqlens_dtype,
             state_indices_dtype=state_indices_dtype,
@@ -2781,10 +2796,7 @@ def cp_delta_rule_fixup_dsl_sm90(
                     f"{('[N_pool]' if use_state_indices else f'[{cu_seqlens.shape[0] - 1}]')} "
                     f"+ {expected_tail}, got {tuple(initial_state.shape)}"
                 )
-            if initial_state.dtype != torch.float32:
-                raise RuntimeError(
-                    f"initial_state must have dtype torch.float32, got {initial_state.dtype}"
-                )
+            state_dtype_to_cutlass(initial_state.dtype)
         if use_state_indices and (
             not is_integer_dtype(state_indices.dtype)
             or state_indices.shape != (cu_seqlens.shape[0] - 1,)
@@ -2856,6 +2868,7 @@ def cp_delta_rule_fixup_dsl_sm90(
             _kernel_kind = "hmma"
     kernel = _get_fixup_kernel(
         needs_initial_state,
+        initial_state.dtype if needs_initial_state else torch.float32,
         _kernel_kind,
         use_state_indices,
         cu_seqlens.dtype,
@@ -2926,6 +2939,9 @@ class CPDeltaRulePrefillSm90(_FullyFusedDeltaRuleSm90):
         acc_dtype: type[cutlass.Numeric] = cutlass.Float32,
         needs_initial_state: bool = False,
         store_final_state: bool = True,
+        initial_state_dtype: type[cutlass.Numeric] = cutlass.Float32,
+        state_dtype: type[cutlass.Numeric] = cutlass.Float32,
+        checkpoint_state_dtype: type[cutlass.Numeric] = cutlass.Float32,
         use_state_indices: bool = False,
         needs_checkpointing: bool = False,
         cu_seqlens_dtype: torch.dtype = torch.int64,
@@ -2950,6 +2966,9 @@ class CPDeltaRulePrefillSm90(_FullyFusedDeltaRuleSm90):
         )
         self.needs_initial_state = needs_initial_state
         self.store_final_state = store_final_state
+        self.initial_state_dtype = initial_state_dtype
+        self.state_dtype = state_dtype
+        self.checkpoint_state_dtype = checkpoint_state_dtype
         self.t_stage = 2
         self.manual_cache_key(
             "needs_alpha",
@@ -2958,6 +2977,9 @@ class CPDeltaRulePrefillSm90(_FullyFusedDeltaRuleSm90):
             "needs_checkpointing",
             "needs_initial_state",
             "store_final_state",
+            "initial_state_dtype",
+            "state_dtype",
+            "checkpoint_state_dtype",
             "use_state_indices",
             "cu_seqlens_dtype",
             "state_indices_dtype",
@@ -4244,6 +4266,9 @@ def _get_prefill_kernel(
     kernel_dtype,
     needs_initial_state,
     store_final_state,
+    initial_state_dtype,
+    state_dtype,
+    checkpoint_state_dtype,
     use_state_indices,
     needs_checkpointing,
     cu_seqlens_dtype,
@@ -4256,6 +4281,9 @@ def _get_prefill_kernel(
         kernel_dtype,
         needs_initial_state=needs_initial_state,
         store_final_state=store_final_state,
+        initial_state_dtype=state_dtype_to_cutlass(initial_state_dtype),
+        state_dtype=state_dtype_to_cutlass(state_dtype),
+        checkpoint_state_dtype=state_dtype_to_cutlass(checkpoint_state_dtype),
         use_state_indices=use_state_indices,
         needs_checkpointing=needs_checkpointing,
         cu_seqlens_dtype=cu_seqlens_dtype,
@@ -4443,17 +4471,16 @@ def cp_delta_rule_prefill_dsl_sm90(
             raise RuntimeError(
                 f"alpha must have dtype torch.float32, got {alpha.dtype}"
             )
-        if initial_state is not None and initial_state.dtype != torch.float32:
-            raise RuntimeError(
-                f"initial_state must have dtype torch.float32, got {initial_state.dtype}"
-            )
+        if initial_state is not None:
+            state_dtype_to_cutlass(initial_state.dtype)
+        if state is not None:
+            state_dtype_to_cutlass(state.dtype)
         if needs_checkpointing:
-            if state_checkpoints.dtype != torch.float32 or tuple(
-                state_checkpoints.shape[1:]
-            ) != (num_sab_heads, d, d):
+            state_dtype_to_cutlass(state_checkpoints.dtype)
+            if tuple(state_checkpoints.shape[1:]) != (num_sab_heads, d, d):
                 raise RuntimeError(
                     "state_checkpoints must have shape "
-                    f"[*, {num_sab_heads}, {d}, {d}] and dtype float32"
+                    f"[*, {num_sab_heads}, {d}, {d}], got {tuple(state_checkpoints.shape)}"
                 )
             if not is_integer_dtype(
                 checkpoint_cu_starts.dtype
@@ -4531,6 +4558,13 @@ def cp_delta_rule_prefill_dsl_sm90(
         kernel_dtype,
         needs_initial_state=needs_initial_state,
         store_final_state=store_final_state,
+        initial_state_dtype=(
+            initial_state.dtype if needs_initial_state else torch.float32
+        ),
+        state_dtype=state.dtype if store_final_state else torch.float32,
+        checkpoint_state_dtype=(
+            state_checkpoints.dtype if needs_checkpointing else torch.float32
+        ),
         use_state_indices=use_state_indices,
         needs_checkpointing=needs_checkpointing,
         cu_seqlens_dtype=cu_seqlens.dtype,
@@ -4803,17 +4837,16 @@ def cp_delta_rule_dsl_sm90(
         raise RuntimeError(
             f"alpha/beta must have dtype torch.float32, got {alpha.dtype} and {beta.dtype}"
         )
-    if initial_state is not None and initial_state.dtype != torch.float32:
-        raise RuntimeError(
-            f"initial_state must have dtype torch.float32, got {initial_state.dtype}"
-        )
+    if initial_state is not None:
+        state_dtype_to_cutlass(initial_state.dtype)
+    if state is not None:
+        state_dtype_to_cutlass(state.dtype)
     if needs_checkpointing:
-        if state_checkpoints.dtype != torch.float32 or tuple(
-            state_checkpoints.shape[1:]
-        ) != (num_sab_heads, d, d):
+        state_dtype_to_cutlass(state_checkpoints.dtype)
+        if tuple(state_checkpoints.shape[1:]) != (num_sab_heads, d, d):
             raise RuntimeError(
                 "state_checkpoints must have shape "
-                f"[*, {num_sab_heads}, {d}, {d}] and dtype float32"
+                f"[*, {num_sab_heads}, {d}, {d}], got {tuple(state_checkpoints.shape)}"
             )
         if not is_integer_dtype(
             checkpoint_cu_starts.dtype

--- a/flashinfer/gdn_kernels/delta_rule_dsl/delta_rule_sm120.py
+++ b/flashinfer/gdn_kernels/delta_rule_dsl/delta_rule_sm120.py
@@ -14,7 +14,7 @@ from .custom_compile_cache import (
     sm12x_compile_options,
 )
 from .collective_inverse_hmma import CollectiveInverse
-from .helpers import SM80, round_down
+from .helpers import SM80, round_down, state_dtype_to_cutlass
 from .schedule import WorkDesc
 from .varlen_helper import is_integer_dtype
 
@@ -120,6 +120,9 @@ class _FullyFusedDeltaRuleSm120(KeyedCompileMixin):
         needs_checkpointing: bool,
         dtype: type[cutlass.Numeric] = cutlass.Float16,
         acc_dtype: type[cutlass.Numeric] = cutlass.Float32,
+        initial_state_dtype: type[cutlass.Numeric] = cutlass.Float32,
+        state_dtype: type[cutlass.Numeric] = cutlass.Float32,
+        checkpoint_state_dtype: type[cutlass.Numeric] = cutlass.Float32,
         use_state_indices: bool = False,
         cu_seqlens_dtype: torch.dtype = torch.int64,
         state_indices_dtype: torch.dtype | None = None,
@@ -133,6 +136,9 @@ class _FullyFusedDeltaRuleSm120(KeyedCompileMixin):
         self.needs_checkpointing = needs_checkpointing
         self.dtype = dtype
         self.acc_dtype = acc_dtype
+        self.initial_state_dtype = initial_state_dtype
+        self.state_dtype = state_dtype
+        self.checkpoint_state_dtype = checkpoint_state_dtype
         self.use_state_indices = use_state_indices
         self.cu_seqlens_dtype = cu_seqlens_dtype
         self.state_indices_dtype = state_indices_dtype
@@ -155,6 +161,9 @@ class _FullyFusedDeltaRuleSm120(KeyedCompileMixin):
             "needs_checkpointing",
             "dtype",
             "acc_dtype",
+            "initial_state_dtype",
+            "state_dtype",
+            "checkpoint_state_dtype",
             "use_state_indices",
             "cu_seqlens_dtype",
             "state_indices_dtype",
@@ -652,7 +661,7 @@ class _FullyFusedDeltaRuleSm120(KeyedCompileMixin):
         tKVcKV = kv_thr_mma.partition_C(c_kv)
         for i in cutlass.range(cute.size(tKVrKV), unroll_full=True):
             v_idx, k_idx = tKVcKV[i]
-            tKVrKV[i] = gKV[k_idx, v_idx]
+            tKVrKV[i] = gKV[k_idx, v_idx].to(self.acc_dtype)
 
     @cute.jit
     def kv_store(
@@ -665,7 +674,7 @@ class _FullyFusedDeltaRuleSm120(KeyedCompileMixin):
         tKVcKV = kv_thr_mma.partition_C(c_kv)
         for i in cutlass.range(cute.size(tKVrKV), unroll_full=True):
             v_idx, k_idx = tKVcKV[i]
-            gKV[k_idx, v_idx] = tKVrKV[i]
+            gKV[k_idx, v_idx] = tKVrKV[i].to(gKV.element_type)
 
     @cute.jit
     def maybe_store_checkpoint(
@@ -2040,12 +2049,11 @@ def delta_rule_prefill_dsl(
         raise RuntimeError(f"alpha must have dtype torch.float32, got {alpha.dtype}")
     if beta is not None and beta.dtype != torch.float32:
         raise RuntimeError(f"beta must have dtype torch.float32, got {beta.dtype}")
-    if init_state is not None and init_state.dtype != torch.float32:
-        raise RuntimeError(
-            f"init_state must have dtype torch.float32, got {init_state.dtype}"
-        )
-    if state.dtype != torch.float32:
-        raise RuntimeError(f"state must have dtype torch.float32, got {state.dtype}")
+    if init_state is not None:
+        state_dtype_to_cutlass(init_state.dtype)
+    state_dtype_to_cutlass(state.dtype)
+    if state_checkpoints is not None:
+        state_dtype_to_cutlass(state_checkpoints.dtype)
     if not is_integer_dtype(cu_seqlens.dtype):
         raise RuntimeError(
             f"cu_seqlens must have an integer dtype, got {cu_seqlens.dtype}"
@@ -2171,6 +2179,13 @@ def delta_rule_prefill_dsl(
         needs_init_state,
         needs_checkpointing,
         kernel_dtype,
+        initial_state_dtype=state_dtype_to_cutlass(
+            init_state.dtype if needs_init_state else torch.float32
+        ),
+        state_dtype=state_dtype_to_cutlass(state.dtype),
+        checkpoint_state_dtype=state_dtype_to_cutlass(
+            state_checkpoints.dtype if needs_checkpointing else torch.float32
+        ),
         use_state_indices=use_state_indices,
         cu_seqlens_dtype=cu_seqlens.dtype,
         state_indices_dtype=state_indices.dtype if use_state_indices else None,

--- a/flashinfer/gdn_kernels/delta_rule_dsl/delta_rule_sm120.py
+++ b/flashinfer/gdn_kernels/delta_rule_dsl/delta_rule_sm120.py
@@ -119,6 +119,7 @@ class _FullyFusedDeltaRuleSm120(KeyedCompileMixin):
         needs_checkpointing: bool,
         dtype: type[cutlass.Numeric] = cutlass.Float16,
         acc_dtype: type[cutlass.Numeric] = cutlass.Float32,
+        use_state_indices: bool = False,
     ):
         self.needs_alpha = needs_alpha
         self.needs_beta = needs_beta
@@ -126,6 +127,7 @@ class _FullyFusedDeltaRuleSm120(KeyedCompileMixin):
         self.needs_checkpointing = needs_checkpointing
         self.dtype = dtype
         self.acc_dtype = acc_dtype
+        self.use_state_indices = use_state_indices
         self.inverse_dtype = cutlass.Float16
         self.BLK_Q = 64
         self.BLK_KV = 64
@@ -142,6 +144,7 @@ class _FullyFusedDeltaRuleSm120(KeyedCompileMixin):
             "needs_checkpointing",
             "dtype",
             "acc_dtype",
+            "use_state_indices",
             "inverse_dtype",
             "BLK_Q",
             "BLK_KV",
@@ -1188,6 +1191,7 @@ class _FullyFusedDeltaRuleSm120(KeyedCompileMixin):
         beta_pipeline,
         g_state: cute.Tensor,
         g_init_state: cute.Tensor,
+        g_state_indices: cute.Tensor,
         g_state_checkpoints: cute.Tensor,
         checkpoint_cu_starts: cute.Tensor,
         work_desc: WorkDesc,
@@ -1233,15 +1237,41 @@ class _FullyFusedDeltaRuleSm120(KeyedCompileMixin):
         )
         tKVrKV.fill(self.acc_dtype(0.0))
 
-        state_layout = cute.make_ordered_layout(
+        packed_state_layout = cute.make_ordered_layout(
             (self.D, self.D, num_sab_heads, num_seqs), order=(0, 1, 2, 3)
         )
+        state_idx = work_desc.seq_idx
+        if cutlass.const_expr(self.use_state_indices):
+            state_idx = cutlass.Int32(g_state_indices[work_desc.seq_idx])
+            state_layout = cute.make_layout(
+                (self.D, self.D, num_sab_heads, g_state.shape[0]),
+                stride=(
+                    g_state.stride[3],
+                    g_state.stride[2],
+                    g_state.stride[1],
+                    g_state.stride[0],
+                ),
+            )
+        else:
+            state_layout = packed_state_layout
         o_head_idx = work_desc.o_head_idx(num_q_heads, num_v_heads)
         mState = cute.make_tensor(g_state.iterator, state_layout)
-        gStateKV = mState[None, None, o_head_idx, work_desc.seq_idx]
+        gStateKV = mState[None, None, o_head_idx, state_idx]
         if cutlass.const_expr(self.needs_init_state):
-            mInitState = cute.make_tensor(g_init_state.iterator, state_layout)
-            gInitKV = mInitState[None, None, o_head_idx, work_desc.seq_idx]
+            if cutlass.const_expr(self.use_state_indices):
+                init_state_layout = cute.make_layout(
+                    (self.D, self.D, num_sab_heads, g_init_state.shape[0]),
+                    stride=(
+                        g_init_state.stride[3],
+                        g_init_state.stride[2],
+                        g_init_state.stride[1],
+                        g_init_state.stride[0],
+                    ),
+                )
+            else:
+                init_state_layout = packed_state_layout
+            mInitState = cute.make_tensor(g_init_state.iterator, init_state_layout)
+            gInitKV = mInitState[None, None, o_head_idx, state_idx]
             self.kv_load(tKVrKV, gInitKV, kv_thr_mma)
 
         first_B = work_desc.seq_len
@@ -1463,6 +1493,7 @@ class _FullyFusedDeltaRuleSm120(KeyedCompileMixin):
         g_beta: cute.Tensor,
         g_state: cute.Tensor,
         g_init_state: cute.Tensor,
+        g_state_indices: cute.Tensor,
         g_state_checkpoints: cute.Tensor,
         checkpoint_cu_starts: cute.Tensor,
         g_tensormaps: cute.Tensor,
@@ -1620,6 +1651,7 @@ class _FullyFusedDeltaRuleSm120(KeyedCompileMixin):
             tma_tensor_o,
             g_state,
             g_init_state,
+            g_state_indices,
             g_state_checkpoints,
             checkpoint_cu_starts,
             g_tensormaps,
@@ -1655,6 +1687,7 @@ class _FullyFusedDeltaRuleSm120(KeyedCompileMixin):
         tma_tensor_o: cute.Tensor,
         g_state: cute.Tensor,
         g_init_state: cute.Tensor,
+        g_state_indices: cute.Tensor,
         g_state_checkpoints: cute.Tensor,
         checkpoint_cu_starts: cute.Tensor,
         g_tensormaps: cute.Tensor,
@@ -1924,6 +1957,7 @@ class _FullyFusedDeltaRuleSm120(KeyedCompileMixin):
                 beta_pipeline,
                 g_state,
                 g_init_state,
+                g_state_indices,
                 g_state_checkpoints,
                 checkpoint_cu_starts,
                 work_desc,
@@ -1957,6 +1991,7 @@ def delta_rule_prefill_dsl(
     state_checkpoints: torch.Tensor | None = None,
     checkpoint_cu_starts: torch.Tensor | None = None,
     checkpoint_every_n_tokens: int = 0,
+    state_indices: torch.Tensor | None = None,
 ):
     from cutlass.cute.runtime import from_dlpack
     import cuda.bindings.driver as cuda_driver
@@ -1980,6 +2015,7 @@ def delta_rule_prefill_dsl(
     needs_beta = beta is not None
     needs_init_state = init_state is not None
     needs_checkpointing = checkpoint_every_n_tokens > 0
+    use_state_indices = state_indices is not None
     kernel_dtype = {
         torch.float16: cutlass.Float16,
         torch.bfloat16: cutlass.BFloat16,
@@ -2006,18 +2042,50 @@ def delta_rule_prefill_dsl(
             f"cu_seqlens must have dtype torch.int64, got {cu_seqlens.dtype}"
         )
 
+    expected_state_tail = (num_sab_heads, D, D)
+    for name, tensor in (("state", state), ("init_state", init_state)):
+        if tensor is None:
+            continue
+        if (
+            not use_state_indices and tensor.shape != (num_seqs, *expected_state_tail)
+        ) or (use_state_indices and tuple(tensor.shape[1:]) != expected_state_tail):
+            raise RuntimeError(
+                f"{name} must have shape "
+                f"{('[N_pool]' if use_state_indices else f'[{num_seqs}]')} + {expected_state_tail}, "
+                f"got {tuple(tensor.shape)}"
+            )
+    if use_state_indices and (
+        state_indices.dtype != torch.int32 or state_indices.shape != (num_seqs,)
+    ):
+        raise RuntimeError(
+            f"state_indices must have shape {(num_seqs,)} and dtype int32"
+        )
+
     for name, tensor in (
         ("q", q),
         ("k", k),
         ("v", v),
         ("o", o),
-        ("state", state),
         ("cu_seqlens", cu_seqlens),
     ):
         if not tensor.is_contiguous():
             raise RuntimeError(f"{name} must be contiguous")
-    for name, tensor in (("alpha", alpha), ("beta", beta), ("init_state", init_state)):
+    for name, tensor in (
+        ("alpha", alpha),
+        ("beta", beta),
+        ("state_indices", state_indices),
+    ):
         if tensor is not None and not tensor.is_contiguous():
+            raise RuntimeError(f"{name} must be contiguous")
+    for name, tensor in (("state", state), ("init_state", init_state)):
+        if tensor is None:
+            continue
+        if use_state_indices:
+            if tensor.stride()[1:] != (D * D, D, 1):
+                raise RuntimeError(
+                    f"{name} inner dimensions must be contiguous when state_indices is used"
+                )
+        elif not tensor.is_contiguous():
             raise RuntimeError(f"{name} must be contiguous")
 
     total_seqlen = q.shape[0]
@@ -2067,10 +2135,15 @@ def delta_rule_prefill_dsl(
         if needs_beta
         else None
     )
-    state_cute = from_dlpack(state.reshape(-1), assumed_align=16).mark_layout_dynamic()
+    state_cute = from_dlpack(state, assumed_align=16).mark_layout_dynamic()
     init_state_cute = (
-        from_dlpack(init_state.reshape(-1), assumed_align=16).mark_layout_dynamic()
+        from_dlpack(init_state, assumed_align=16).mark_layout_dynamic()
         if needs_init_state
+        else None
+    )
+    state_indices_cute = (
+        from_dlpack(state_indices, assumed_align=4).mark_layout_dynamic()
+        if use_state_indices
         else None
     )
     state_checkpoints_cute = (
@@ -2089,7 +2162,12 @@ def delta_rule_prefill_dsl(
     cu_cute = from_dlpack(cu_seqlens, assumed_align=8).mark_layout_dynamic()
 
     delta_rule_kernel = _FullyFusedDeltaRuleSm120(
-        needs_alpha, needs_beta, needs_init_state, needs_checkpointing, kernel_dtype
+        needs_alpha,
+        needs_beta,
+        needs_init_state,
+        needs_checkpointing,
+        kernel_dtype,
+        use_state_indices=use_state_indices,
     )
 
     kernel_args = (
@@ -2101,6 +2179,7 @@ def delta_rule_prefill_dsl(
         beta_cute,
         state_cute,
         init_state_cute,
+        state_indices_cute,
         state_checkpoints_cute,
         checkpoint_cu_cute,
         tensormaps_cute,

--- a/flashinfer/gdn_kernels/delta_rule_dsl/delta_rule_sm120.py
+++ b/flashinfer/gdn_kernels/delta_rule_dsl/delta_rule_sm120.py
@@ -16,6 +16,7 @@ from .custom_compile_cache import (
 from .collective_inverse_hmma import CollectiveInverse
 from .helpers import SM80, round_down
 from .schedule import WorkDesc
+from .varlen_helper import is_integer_dtype
 
 
 # ─── Named-barrier IDs used by the compute kernel ────────────────────────────
@@ -120,6 +121,11 @@ class _FullyFusedDeltaRuleSm120(KeyedCompileMixin):
         dtype: type[cutlass.Numeric] = cutlass.Float16,
         acc_dtype: type[cutlass.Numeric] = cutlass.Float32,
         use_state_indices: bool = False,
+        cu_seqlens_dtype: torch.dtype = torch.int64,
+        state_indices_dtype: torch.dtype | None = None,
+        checkpoint_cu_starts_dtype: torch.dtype | None = None,
+        state_inner_strides: tuple[int, ...] | None = None,
+        init_state_inner_strides: tuple[int, ...] | None = None,
     ):
         self.needs_alpha = needs_alpha
         self.needs_beta = needs_beta
@@ -128,6 +134,11 @@ class _FullyFusedDeltaRuleSm120(KeyedCompileMixin):
         self.dtype = dtype
         self.acc_dtype = acc_dtype
         self.use_state_indices = use_state_indices
+        self.cu_seqlens_dtype = cu_seqlens_dtype
+        self.state_indices_dtype = state_indices_dtype
+        self.checkpoint_cu_starts_dtype = checkpoint_cu_starts_dtype
+        self.state_inner_strides = state_inner_strides
+        self.init_state_inner_strides = init_state_inner_strides
         self.inverse_dtype = cutlass.Float16
         self.BLK_Q = 64
         self.BLK_KV = 64
@@ -145,6 +156,11 @@ class _FullyFusedDeltaRuleSm120(KeyedCompileMixin):
             "dtype",
             "acc_dtype",
             "use_state_indices",
+            "cu_seqlens_dtype",
+            "state_indices_dtype",
+            "checkpoint_cu_starts_dtype",
+            "state_inner_strides",
+            "init_state_inner_strides",
             "inverse_dtype",
             "BLK_Q",
             "BLK_KV",
@@ -1240,34 +1256,27 @@ class _FullyFusedDeltaRuleSm120(KeyedCompileMixin):
         packed_state_layout = cute.make_ordered_layout(
             (self.D, self.D, num_sab_heads, num_seqs), order=(0, 1, 2, 3)
         )
+        state_ref_shape = (g_state.shape[0], g_state.shape[1], self.D, self.D)
+        state_ref_layout = cute.make_layout(state_ref_shape, stride=g_state.stride)
+        indexed_state_layout = cute.select(state_ref_layout, mode=[3, 2, 1, 0])
         state_idx = work_desc.seq_idx
         if cutlass.const_expr(self.use_state_indices):
             state_idx = cutlass.Int32(g_state_indices[work_desc.seq_idx])
-            state_layout = cute.make_layout(
-                (self.D, self.D, num_sab_heads, g_state.shape[0]),
-                stride=(
-                    g_state.stride[3],
-                    g_state.stride[2],
-                    g_state.stride[1],
-                    g_state.stride[0],
-                ),
-            )
+            state_layout = indexed_state_layout
         else:
             state_layout = packed_state_layout
         o_head_idx = work_desc.o_head_idx(num_q_heads, num_v_heads)
         mState = cute.make_tensor(g_state.iterator, state_layout)
         gStateKV = mState[None, None, o_head_idx, state_idx]
         if cutlass.const_expr(self.needs_init_state):
+            init_state_ref_layout = cute.make_layout(
+                state_ref_shape, stride=g_init_state.stride
+            )
+            indexed_init_state_layout = cute.select(
+                init_state_ref_layout, mode=[3, 2, 1, 0]
+            )
             if cutlass.const_expr(self.use_state_indices):
-                init_state_layout = cute.make_layout(
-                    (self.D, self.D, num_sab_heads, g_init_state.shape[0]),
-                    stride=(
-                        g_init_state.stride[3],
-                        g_init_state.stride[2],
-                        g_init_state.stride[1],
-                        g_init_state.stride[0],
-                    ),
-                )
+                init_state_layout = indexed_init_state_layout
             else:
                 init_state_layout = packed_state_layout
             mInitState = cute.make_tensor(g_init_state.iterator, init_state_layout)
@@ -2037,9 +2046,9 @@ def delta_rule_prefill_dsl(
         )
     if state.dtype != torch.float32:
         raise RuntimeError(f"state must have dtype torch.float32, got {state.dtype}")
-    if cu_seqlens.dtype != torch.int64:
+    if not is_integer_dtype(cu_seqlens.dtype):
         raise RuntimeError(
-            f"cu_seqlens must have dtype torch.int64, got {cu_seqlens.dtype}"
+            f"cu_seqlens must have an integer dtype, got {cu_seqlens.dtype}"
         )
 
     expected_state_tail = (num_sab_heads, D, D)
@@ -2055,10 +2064,10 @@ def delta_rule_prefill_dsl(
                 f"got {tuple(tensor.shape)}"
             )
     if use_state_indices and (
-        state_indices.dtype != torch.int32 or state_indices.shape != (num_seqs,)
+        not is_integer_dtype(state_indices.dtype) or state_indices.shape != (num_seqs,)
     ):
         raise RuntimeError(
-            f"state_indices must have shape {(num_seqs,)} and dtype int32"
+            f"state_indices must have shape {(num_seqs,)} and an integer dtype"
         )
 
     for name, tensor in (
@@ -2080,12 +2089,7 @@ def delta_rule_prefill_dsl(
     for name, tensor in (("state", state), ("init_state", init_state)):
         if tensor is None:
             continue
-        if use_state_indices:
-            if tensor.stride()[1:] != (D * D, D, 1):
-                raise RuntimeError(
-                    f"{name} inner dimensions must be contiguous when state_indices is used"
-                )
-        elif not tensor.is_contiguous():
+        if not use_state_indices and not tensor.is_contiguous():
             raise RuntimeError(f"{name} must be contiguous")
 
     total_seqlen = q.shape[0]
@@ -2168,6 +2172,17 @@ def delta_rule_prefill_dsl(
         needs_checkpointing,
         kernel_dtype,
         use_state_indices=use_state_indices,
+        cu_seqlens_dtype=cu_seqlens.dtype,
+        state_indices_dtype=state_indices.dtype if use_state_indices else None,
+        checkpoint_cu_starts_dtype=(
+            checkpoint_cu_starts.dtype if needs_checkpointing else None
+        ),
+        state_inner_strides=(tuple(state.stride()[1:]) if use_state_indices else None),
+        init_state_inner_strides=(
+            tuple(init_state.stride()[1:])
+            if use_state_indices and needs_init_state
+            else None
+        ),
     )
 
     kernel_args = (

--- a/flashinfer/gdn_kernels/delta_rule_dsl/delta_rule_sm120.py
+++ b/flashinfer/gdn_kernels/delta_rule_dsl/delta_rule_sm120.py
@@ -184,15 +184,15 @@ class _FullyFusedDeltaRuleSm120(KeyedCompileMixin):
         o_head_idx = bx % num_sab_heads
         q_head_idx = o_head_idx * num_q_heads // num_sab_heads
         v_head_idx = o_head_idx * num_v_heads // num_sab_heads
-        tok_start = cutlass.Int32(cu_seqlens[seq_idx])
-        tok_end = cutlass.Int32(cu_seqlens[seq_idx + 1])
+        tok_start = cu_seqlens[seq_idx]
+        seq_len = cutlass.Int32(cu_seqlens[seq_idx + 1] - tok_start)
 
         return WorkDesc(
             seq_idx=seq_idx,
             private_q_head_idx=q_head_idx,
             private_v_head_idx=v_head_idx,
             tok_offset=tok_start,
-            seq_len=tok_end - tok_start,
+            seq_len=seq_len,
             tile_idx=cutlass.Int32(0),
         )
 
@@ -503,7 +503,7 @@ class _FullyFusedDeltaRuleSm120(KeyedCompileMixin):
         v_pipeline,
         v_producer_state,
         blk: cutlass.Int32,
-        tok_start: cutlass.Int32,
+        tok_start,
         q_head_idx: cutlass.Int32,
         k_head_idx: cutlass.Int32,
         v_head_idx: cutlass.Int32,
@@ -596,7 +596,7 @@ class _FullyFusedDeltaRuleSm120(KeyedCompileMixin):
         sAlpha: cute.Tensor,
         g_alpha: cute.Tensor,
         blk_tok: cutlass.Int32,
-        tok_end: cutlass.Int32,
+        tok_end,
         sab_head_idx: cutlass.Int32,
         num_sab_heads: cutlass.Int32,
         alpha_stage: cutlass.Int32,
@@ -623,7 +623,7 @@ class _FullyFusedDeltaRuleSm120(KeyedCompileMixin):
         sBeta: cute.Tensor,
         g_beta: cute.Tensor,
         blk_tok: cutlass.Int32,
-        tok_end: cutlass.Int32,
+        tok_end,
         sab_head_idx: cutlass.Int32,
         num_sab_heads: cutlass.Int32,
         beta_stage: cutlass.Int32,
@@ -1074,7 +1074,7 @@ class _FullyFusedDeltaRuleSm120(KeyedCompileMixin):
         k_pipeline,
         v_pipeline,
         num_blocks: cutlass.Int32,
-        tok_start: cutlass.Int32,
+        tok_start,
         q_head_idx: cutlass.Int32,
         k_head_idx: cutlass.Int32,
         v_head_idx: cutlass.Int32,
@@ -1124,8 +1124,8 @@ class _FullyFusedDeltaRuleSm120(KeyedCompileMixin):
         alpha_pipeline,
         scale: cutlass.Float32,
         num_blocks: cutlass.Int32,
-        tok_start: cutlass.Int32,
-        tok_end: cutlass.Int32,
+        tok_start,
+        tok_end,
         sab_head_idx: cutlass.Int32,
         num_sab_heads: cutlass.Int32,
     ):
@@ -1160,8 +1160,8 @@ class _FullyFusedDeltaRuleSm120(KeyedCompileMixin):
         g_beta: cute.Tensor,
         beta_pipeline,
         num_blocks: cutlass.Int32,
-        tok_start: cutlass.Int32,
-        tok_end: cutlass.Int32,
+        tok_start,
+        tok_end,
         sab_head_idx: cutlass.Int32,
         num_sab_heads: cutlass.Int32,
     ):

--- a/flashinfer/gdn_kernels/delta_rule_dsl/delta_rule_sm90.py
+++ b/flashinfer/gdn_kernels/delta_rule_dsl/delta_rule_sm90.py
@@ -12,6 +12,7 @@ from .custom_compile_cache import KeyedCompileMixin, cached_compile
 from .collective_inverse_hmma import CollectiveInverse
 from .helpers import SM90, round_down, select_tensor_10
 from .schedule import WorkDesc
+from .varlen_helper import is_integer_dtype
 
 
 # ─── Named-barrier IDs used by the compute kernel ────────────────────────────
@@ -126,6 +127,11 @@ class _FullyFusedDeltaRuleSm90(KeyedCompileMixin):
         dtype: type[cutlass.Numeric] = cutlass.Float16,
         acc_dtype: type[cutlass.Numeric] = cutlass.Float32,
         use_state_indices: bool = False,
+        cu_seqlens_dtype: torch.dtype = torch.int64,
+        state_indices_dtype: torch.dtype | None = None,
+        checkpoint_cu_starts_dtype: torch.dtype | None = None,
+        state_inner_strides: tuple[int, ...] | None = None,
+        init_state_inner_strides: tuple[int, ...] | None = None,
     ):
         self.needs_alpha = needs_alpha
         self.needs_beta = needs_beta
@@ -134,6 +140,11 @@ class _FullyFusedDeltaRuleSm90(KeyedCompileMixin):
         self.dtype = dtype
         self.acc_dtype = acc_dtype
         self.use_state_indices = use_state_indices
+        self.cu_seqlens_dtype = cu_seqlens_dtype
+        self.state_indices_dtype = state_indices_dtype
+        self.checkpoint_cu_starts_dtype = checkpoint_cu_starts_dtype
+        self.state_inner_strides = state_inner_strides
+        self.init_state_inner_strides = init_state_inner_strides
         self.inverse_dtype = cutlass.Float16
         self.BLK_Q = 64
         self.BLK_KV = 64
@@ -153,6 +164,11 @@ class _FullyFusedDeltaRuleSm90(KeyedCompileMixin):
             "dtype",
             "acc_dtype",
             "use_state_indices",
+            "cu_seqlens_dtype",
+            "state_indices_dtype",
+            "checkpoint_cu_starts_dtype",
+            "state_inner_strides",
+            "init_state_inner_strides",
             "inverse_dtype",
             "BLK_Q",
             "BLK_KV",
@@ -1201,34 +1217,27 @@ class _FullyFusedDeltaRuleSm90(KeyedCompileMixin):
         packed_state_layout = cute.make_ordered_layout(
             (self.D, self.D, num_sab_heads, num_seqs), order=(0, 1, 2, 3)
         )
+        state_ref_shape = (g_state.shape[0], g_state.shape[1], self.D, self.D)
+        state_ref_layout = cute.make_layout(state_ref_shape, stride=g_state.stride)
+        indexed_state_layout = cute.select(state_ref_layout, mode=[3, 2, 1, 0])
         state_idx = work_desc.seq_idx
         if cutlass.const_expr(self.use_state_indices):
             state_idx = cutlass.Int32(g_state_indices[work_desc.seq_idx])
-            state_layout = cute.make_layout(
-                (self.D, self.D, num_sab_heads, g_state.shape[0]),
-                stride=(
-                    g_state.stride[3],
-                    g_state.stride[2],
-                    g_state.stride[1],
-                    g_state.stride[0],
-                ),
-            )
+            state_layout = indexed_state_layout
         else:
             state_layout = packed_state_layout
         o_head_idx = work_desc.o_head_idx(num_q_heads, num_v_heads)
         mState = cute.make_tensor(g_state.iterator, state_layout)
         gStateKV = mState[None, None, o_head_idx, state_idx]
         if cutlass.const_expr(self.needs_init_state):
+            init_state_ref_layout = cute.make_layout(
+                state_ref_shape, stride=g_init_state.stride
+            )
+            indexed_init_state_layout = cute.select(
+                init_state_ref_layout, mode=[3, 2, 1, 0]
+            )
             if cutlass.const_expr(self.use_state_indices):
-                init_state_layout = cute.make_layout(
-                    (self.D, self.D, num_sab_heads, g_init_state.shape[0]),
-                    stride=(
-                        g_init_state.stride[3],
-                        g_init_state.stride[2],
-                        g_init_state.stride[1],
-                        g_init_state.stride[0],
-                    ),
-                )
+                init_state_layout = indexed_init_state_layout
             else:
                 init_state_layout = packed_state_layout
             mInitState = cute.make_tensor(g_init_state.iterator, init_state_layout)
@@ -2380,9 +2389,9 @@ def delta_rule_prefill_dsl_sm90(
         )
     if state.dtype != torch.float32:
         raise RuntimeError(f"state must have dtype torch.float32, got {state.dtype}")
-    if cu_seqlens.dtype != torch.int64:
+    if not is_integer_dtype(cu_seqlens.dtype):
         raise RuntimeError(
-            f"cu_seqlens must have dtype torch.int64, got {cu_seqlens.dtype}"
+            f"cu_seqlens must have an integer dtype, got {cu_seqlens.dtype}"
         )
 
     expected_state_tail = (num_sab_heads, D, D)
@@ -2398,10 +2407,10 @@ def delta_rule_prefill_dsl_sm90(
                 f"got {tuple(tensor.shape)}"
             )
     if use_state_indices and (
-        state_indices.dtype != torch.int32 or state_indices.shape != (num_seqs,)
+        not is_integer_dtype(state_indices.dtype) or state_indices.shape != (num_seqs,)
     ):
         raise RuntimeError(
-            f"state_indices must have shape {(num_seqs,)} and dtype int32"
+            f"state_indices must have shape {(num_seqs,)} and an integer dtype"
         )
 
     for name, tensor in (
@@ -2423,12 +2432,7 @@ def delta_rule_prefill_dsl_sm90(
     for name, tensor in (("state", state), ("init_state", init_state)):
         if tensor is None:
             continue
-        if use_state_indices:
-            if tensor.stride()[1:] != (D * D, D, 1):
-                raise RuntimeError(
-                    f"{name} inner dimensions must be contiguous when state_indices is used"
-                )
-        elif not tensor.is_contiguous():
+        if not use_state_indices and not tensor.is_contiguous():
             raise RuntimeError(f"{name} must be contiguous")
 
     total_seqlen = q.shape[0]
@@ -2511,6 +2515,17 @@ def delta_rule_prefill_dsl_sm90(
         needs_checkpointing,
         kernel_dtype,
         use_state_indices=use_state_indices,
+        cu_seqlens_dtype=cu_seqlens.dtype,
+        state_indices_dtype=state_indices.dtype if use_state_indices else None,
+        checkpoint_cu_starts_dtype=(
+            checkpoint_cu_starts.dtype if needs_checkpointing else None
+        ),
+        state_inner_strides=(tuple(state.stride()[1:]) if use_state_indices else None),
+        init_state_inner_strides=(
+            tuple(init_state.stride()[1:])
+            if use_state_indices and needs_init_state
+            else None
+        ),
     )
 
     kernel_args = (

--- a/flashinfer/gdn_kernels/delta_rule_dsl/delta_rule_sm90.py
+++ b/flashinfer/gdn_kernels/delta_rule_dsl/delta_rule_sm90.py
@@ -10,7 +10,7 @@ from .alpha import AlphaProcessor
 from .collective_store_tma import CollectiveStoreTma
 from .custom_compile_cache import KeyedCompileMixin, cached_compile
 from .collective_inverse_hmma import CollectiveInverse
-from .helpers import SM90, round_down, select_tensor_10
+from .helpers import SM90, round_down, select_tensor_10, state_dtype_to_cutlass
 from .schedule import WorkDesc
 from .varlen_helper import is_integer_dtype
 
@@ -126,6 +126,9 @@ class _FullyFusedDeltaRuleSm90(KeyedCompileMixin):
         needs_checkpointing: bool,
         dtype: type[cutlass.Numeric] = cutlass.Float16,
         acc_dtype: type[cutlass.Numeric] = cutlass.Float32,
+        initial_state_dtype: type[cutlass.Numeric] = cutlass.Float32,
+        state_dtype: type[cutlass.Numeric] = cutlass.Float32,
+        checkpoint_state_dtype: type[cutlass.Numeric] = cutlass.Float32,
         use_state_indices: bool = False,
         cu_seqlens_dtype: torch.dtype = torch.int64,
         state_indices_dtype: torch.dtype | None = None,
@@ -139,6 +142,9 @@ class _FullyFusedDeltaRuleSm90(KeyedCompileMixin):
         self.needs_checkpointing = needs_checkpointing
         self.dtype = dtype
         self.acc_dtype = acc_dtype
+        self.initial_state_dtype = initial_state_dtype
+        self.state_dtype = state_dtype
+        self.checkpoint_state_dtype = checkpoint_state_dtype
         self.use_state_indices = use_state_indices
         self.cu_seqlens_dtype = cu_seqlens_dtype
         self.state_indices_dtype = state_indices_dtype
@@ -163,6 +169,9 @@ class _FullyFusedDeltaRuleSm90(KeyedCompileMixin):
             "needs_checkpointing",
             "dtype",
             "acc_dtype",
+            "initial_state_dtype",
+            "state_dtype",
+            "checkpoint_state_dtype",
             "use_state_indices",
             "cu_seqlens_dtype",
             "state_indices_dtype",
@@ -640,7 +649,9 @@ class _FullyFusedDeltaRuleSm90(KeyedCompileMixin):
         tiled_copy_kv = cute.make_tiled_copy_C(copy_atom_kv, kv_tiled_mma)
         thr_copy_kv = tiled_copy_kv.get_slice(thread_idx)
         tKVgKV = thr_copy_kv.partition_S(select_tensor_10(gKV))
-        cute.copy(tiled_copy_kv, tKVgKV, tKVrKV)
+        tKVrKV_storage = cute.make_rmem_tensor_like(tKVrKV, gKV.element_type)
+        cute.copy(tiled_copy_kv, tKVgKV, tKVrKV_storage)
+        tKVrKV.store(tKVrKV_storage.load().to(self.acc_dtype))
 
     @cute.jit
     def kv_store(
@@ -656,7 +667,9 @@ class _FullyFusedDeltaRuleSm90(KeyedCompileMixin):
         tiled_copy_kv = cute.make_tiled_copy_C(copy_atom_kv, kv_tiled_mma)
         thr_copy_kv = tiled_copy_kv.get_slice(thread_idx)
         tKVgKV = thr_copy_kv.partition_D(select_tensor_10(gKV))
-        cute.copy(tiled_copy_kv, tKVrKV, tKVgKV)
+        tKVrKV_storage = cute.make_rmem_tensor_like(tKVrKV, gKV.element_type)
+        tKVrKV_storage.store(tKVrKV.load().to(gKV.element_type))
+        cute.copy(tiled_copy_kv, tKVrKV_storage, tKVgKV)
 
     @cute.jit
     def maybe_store_checkpoint(
@@ -2383,12 +2396,11 @@ def delta_rule_prefill_dsl_sm90(
         raise RuntimeError(f"alpha must have dtype torch.float32, got {alpha.dtype}")
     if beta is not None and beta.dtype != torch.float32:
         raise RuntimeError(f"beta must have dtype torch.float32, got {beta.dtype}")
-    if init_state is not None and init_state.dtype != torch.float32:
-        raise RuntimeError(
-            f"init_state must have dtype torch.float32, got {init_state.dtype}"
-        )
-    if state.dtype != torch.float32:
-        raise RuntimeError(f"state must have dtype torch.float32, got {state.dtype}")
+    if init_state is not None:
+        state_dtype_to_cutlass(init_state.dtype)
+    state_dtype_to_cutlass(state.dtype)
+    if state_checkpoints is not None:
+        state_dtype_to_cutlass(state_checkpoints.dtype)
     if not is_integer_dtype(cu_seqlens.dtype):
         raise RuntimeError(
             f"cu_seqlens must have an integer dtype, got {cu_seqlens.dtype}"
@@ -2514,6 +2526,13 @@ def delta_rule_prefill_dsl_sm90(
         needs_init_state,
         needs_checkpointing,
         kernel_dtype,
+        initial_state_dtype=state_dtype_to_cutlass(
+            init_state.dtype if needs_init_state else torch.float32
+        ),
+        state_dtype=state_dtype_to_cutlass(state.dtype),
+        checkpoint_state_dtype=state_dtype_to_cutlass(
+            state_checkpoints.dtype if needs_checkpointing else torch.float32
+        ),
         use_state_indices=use_state_indices,
         cu_seqlens_dtype=cu_seqlens.dtype,
         state_indices_dtype=state_indices.dtype if use_state_indices else None,

--- a/flashinfer/gdn_kernels/delta_rule_dsl/delta_rule_sm90.py
+++ b/flashinfer/gdn_kernels/delta_rule_dsl/delta_rule_sm90.py
@@ -125,6 +125,7 @@ class _FullyFusedDeltaRuleSm90(KeyedCompileMixin):
         needs_checkpointing: bool,
         dtype: type[cutlass.Numeric] = cutlass.Float16,
         acc_dtype: type[cutlass.Numeric] = cutlass.Float32,
+        use_state_indices: bool = False,
     ):
         self.needs_alpha = needs_alpha
         self.needs_beta = needs_beta
@@ -132,6 +133,7 @@ class _FullyFusedDeltaRuleSm90(KeyedCompileMixin):
         self.needs_checkpointing = needs_checkpointing
         self.dtype = dtype
         self.acc_dtype = acc_dtype
+        self.use_state_indices = use_state_indices
         self.inverse_dtype = cutlass.Float16
         self.BLK_Q = 64
         self.BLK_KV = 64
@@ -150,6 +152,7 @@ class _FullyFusedDeltaRuleSm90(KeyedCompileMixin):
             "needs_checkpointing",
             "dtype",
             "acc_dtype",
+            "use_state_indices",
             "inverse_dtype",
             "BLK_Q",
             "BLK_KV",
@@ -1138,6 +1141,7 @@ class _FullyFusedDeltaRuleSm90(KeyedCompileMixin):
         alpha_pipeline,
         g_state: cute.Tensor,
         g_init_state: cute.Tensor,
+        g_state_indices: cute.Tensor,
         g_state_checkpoints: cute.Tensor,
         checkpoint_cu_starts: cute.Tensor,
         work_desc: WorkDesc,
@@ -1194,15 +1198,41 @@ class _FullyFusedDeltaRuleSm90(KeyedCompileMixin):
         )
         tKVrKV.fill(self.acc_dtype(0.0))
 
-        state_layout = cute.make_ordered_layout(
+        packed_state_layout = cute.make_ordered_layout(
             (self.D, self.D, num_sab_heads, num_seqs), order=(0, 1, 2, 3)
         )
+        state_idx = work_desc.seq_idx
+        if cutlass.const_expr(self.use_state_indices):
+            state_idx = cutlass.Int32(g_state_indices[work_desc.seq_idx])
+            state_layout = cute.make_layout(
+                (self.D, self.D, num_sab_heads, g_state.shape[0]),
+                stride=(
+                    g_state.stride[3],
+                    g_state.stride[2],
+                    g_state.stride[1],
+                    g_state.stride[0],
+                ),
+            )
+        else:
+            state_layout = packed_state_layout
         o_head_idx = work_desc.o_head_idx(num_q_heads, num_v_heads)
         mState = cute.make_tensor(g_state.iterator, state_layout)
-        gStateKV = mState[None, None, o_head_idx, work_desc.seq_idx]
+        gStateKV = mState[None, None, o_head_idx, state_idx]
         if cutlass.const_expr(self.needs_init_state):
-            mInitState = cute.make_tensor(g_init_state.iterator, state_layout)
-            gInitKV = mInitState[None, None, o_head_idx, work_desc.seq_idx]
+            if cutlass.const_expr(self.use_state_indices):
+                init_state_layout = cute.make_layout(
+                    (self.D, self.D, num_sab_heads, g_init_state.shape[0]),
+                    stride=(
+                        g_init_state.stride[3],
+                        g_init_state.stride[2],
+                        g_init_state.stride[1],
+                        g_init_state.stride[0],
+                    ),
+                )
+            else:
+                init_state_layout = packed_state_layout
+            mInitState = cute.make_tensor(g_init_state.iterator, init_state_layout)
+            gInitKV = mInitState[None, None, o_head_idx, state_idx]
             self.kv_load(tKVrKV, gInitKV, kv_tiled_mma, math_tidx)
 
         first_B = work_desc.seq_len
@@ -1740,6 +1770,7 @@ class _FullyFusedDeltaRuleSm90(KeyedCompileMixin):
         g_beta: cute.Tensor,
         g_state: cute.Tensor,
         g_init_state: cute.Tensor,
+        g_state_indices: cute.Tensor,
         g_state_checkpoints: cute.Tensor,
         checkpoint_cu_starts: cute.Tensor,
         g_tensormaps: cute.Tensor,
@@ -1899,6 +1930,7 @@ class _FullyFusedDeltaRuleSm90(KeyedCompileMixin):
             tma_tensor_o,
             g_state,
             g_init_state,
+            g_state_indices,
             g_state_checkpoints,
             checkpoint_cu_starts,
             g_tensormaps,
@@ -1934,6 +1966,7 @@ class _FullyFusedDeltaRuleSm90(KeyedCompileMixin):
         tma_tensor_o: cute.Tensor,
         g_state: cute.Tensor,
         g_init_state: cute.Tensor,
+        g_state_indices: cute.Tensor,
         g_state_checkpoints: cute.Tensor,
         checkpoint_cu_starts: cute.Tensor,
         g_tensormaps: cute.Tensor,
@@ -2267,6 +2300,7 @@ class _FullyFusedDeltaRuleSm90(KeyedCompileMixin):
                     alpha_pipeline,
                     g_state,
                     g_init_state,
+                    g_state_indices,
                     g_state_checkpoints,
                     checkpoint_cu_starts,
                     work_desc,
@@ -2300,6 +2334,7 @@ def delta_rule_prefill_dsl_sm90(
     state_checkpoints: torch.Tensor | None = None,
     checkpoint_cu_starts: torch.Tensor | None = None,
     checkpoint_every_n_tokens: int = 0,
+    state_indices: torch.Tensor | None = None,
 ):
     from cutlass.cute.runtime import from_dlpack
     import cuda.bindings.driver as cuda_driver
@@ -2323,6 +2358,7 @@ def delta_rule_prefill_dsl_sm90(
     needs_beta = beta is not None
     needs_init_state = init_state is not None
     needs_checkpointing = checkpoint_every_n_tokens > 0
+    use_state_indices = state_indices is not None
     kernel_dtype = {
         torch.float16: cutlass.Float16,
         torch.bfloat16: cutlass.BFloat16,
@@ -2349,18 +2385,50 @@ def delta_rule_prefill_dsl_sm90(
             f"cu_seqlens must have dtype torch.int64, got {cu_seqlens.dtype}"
         )
 
+    expected_state_tail = (num_sab_heads, D, D)
+    for name, tensor in (("state", state), ("init_state", init_state)):
+        if tensor is None:
+            continue
+        if (
+            not use_state_indices and tensor.shape != (num_seqs, *expected_state_tail)
+        ) or (use_state_indices and tuple(tensor.shape[1:]) != expected_state_tail):
+            raise RuntimeError(
+                f"{name} must have shape "
+                f"{('[N_pool]' if use_state_indices else f'[{num_seqs}]')} + {expected_state_tail}, "
+                f"got {tuple(tensor.shape)}"
+            )
+    if use_state_indices and (
+        state_indices.dtype != torch.int32 or state_indices.shape != (num_seqs,)
+    ):
+        raise RuntimeError(
+            f"state_indices must have shape {(num_seqs,)} and dtype int32"
+        )
+
     for name, tensor in (
         ("q", q),
         ("k", k),
         ("v", v),
         ("o", o),
-        ("state", state),
         ("cu_seqlens", cu_seqlens),
     ):
         if not tensor.is_contiguous():
             raise RuntimeError(f"{name} must be contiguous")
-    for name, tensor in (("alpha", alpha), ("beta", beta), ("init_state", init_state)):
+    for name, tensor in (
+        ("alpha", alpha),
+        ("beta", beta),
+        ("state_indices", state_indices),
+    ):
         if tensor is not None and not tensor.is_contiguous():
+            raise RuntimeError(f"{name} must be contiguous")
+    for name, tensor in (("state", state), ("init_state", init_state)):
+        if tensor is None:
+            continue
+        if use_state_indices:
+            if tensor.stride()[1:] != (D * D, D, 1):
+                raise RuntimeError(
+                    f"{name} inner dimensions must be contiguous when state_indices is used"
+                )
+        elif not tensor.is_contiguous():
             raise RuntimeError(f"{name} must be contiguous")
 
     total_seqlen = q.shape[0]
@@ -2410,10 +2478,15 @@ def delta_rule_prefill_dsl_sm90(
         if needs_beta
         else None
     )
-    state_cute = from_dlpack(state.reshape(-1), assumed_align=16).mark_layout_dynamic()
+    state_cute = from_dlpack(state, assumed_align=16).mark_layout_dynamic()
     init_state_cute = (
-        from_dlpack(init_state.reshape(-1), assumed_align=16).mark_layout_dynamic()
+        from_dlpack(init_state, assumed_align=16).mark_layout_dynamic()
         if needs_init_state
+        else None
+    )
+    state_indices_cute = (
+        from_dlpack(state_indices, assumed_align=4).mark_layout_dynamic()
+        if use_state_indices
         else None
     )
     state_checkpoints_cute = (
@@ -2432,7 +2505,12 @@ def delta_rule_prefill_dsl_sm90(
     cu_cute = from_dlpack(cu_seqlens, assumed_align=8).mark_layout_dynamic()
 
     delta_rule_kernel = _FullyFusedDeltaRuleSm90(
-        needs_alpha, needs_beta, needs_init_state, needs_checkpointing, kernel_dtype
+        needs_alpha,
+        needs_beta,
+        needs_init_state,
+        needs_checkpointing,
+        kernel_dtype,
+        use_state_indices=use_state_indices,
     )
 
     kernel_args = (
@@ -2444,6 +2522,7 @@ def delta_rule_prefill_dsl_sm90(
         beta_cute,
         state_cute,
         init_state_cute,
+        state_indices_cute,
         state_checkpoints_cute,
         checkpoint_cu_cute,
         tensormaps_cute,

--- a/flashinfer/gdn_kernels/delta_rule_dsl/delta_rule_sm90.py
+++ b/flashinfer/gdn_kernels/delta_rule_dsl/delta_rule_sm90.py
@@ -194,15 +194,15 @@ class _FullyFusedDeltaRuleSm90(KeyedCompileMixin):
         o_head_idx = bx % num_sab_heads
         q_head_idx = o_head_idx * num_q_heads // num_sab_heads
         v_head_idx = o_head_idx * num_v_heads // num_sab_heads
-        tok_start = cutlass.Int32(cu_seqlens[seq_idx])
-        tok_end = cutlass.Int32(cu_seqlens[seq_idx + 1])
+        tok_start = cu_seqlens[seq_idx]
+        seq_len = cutlass.Int32(cu_seqlens[seq_idx + 1] - tok_start)
 
         return WorkDesc(
             seq_idx=seq_idx,
             private_q_head_idx=q_head_idx,
             private_v_head_idx=v_head_idx,
             tok_offset=tok_start,
-            seq_len=tok_end - tok_start,
+            seq_len=seq_len,
             tile_idx=cutlass.Int32(0),
         )
 
@@ -488,7 +488,7 @@ class _FullyFusedDeltaRuleSm90(KeyedCompileMixin):
         v_pipeline,
         v_producer_state,
         blk: cutlass.Int32,
-        tok_start: cutlass.Int32,
+        tok_start,
         q_head_idx: cutlass.Int32,
         k_head_idx: cutlass.Int32,
         v_head_idx: cutlass.Int32,
@@ -581,7 +581,7 @@ class _FullyFusedDeltaRuleSm90(KeyedCompileMixin):
         sAlpha: cute.Tensor,
         g_alpha: cute.Tensor,
         blk_tok: cutlass.Int32,
-        tok_end: cutlass.Int32,
+        tok_end,
         sab_head_idx: cutlass.Int32,
         num_sab_heads: cutlass.Int32,
         alpha_stage: cutlass.Int32,
@@ -608,7 +608,7 @@ class _FullyFusedDeltaRuleSm90(KeyedCompileMixin):
         sBeta: cute.Tensor,
         g_beta: cute.Tensor,
         blk_tok: cutlass.Int32,
-        tok_end: cutlass.Int32,
+        tok_end,
         sab_head_idx: cutlass.Int32,
         num_sab_heads: cutlass.Int32,
         beta_stage: cutlass.Int32,
@@ -1024,7 +1024,7 @@ class _FullyFusedDeltaRuleSm90(KeyedCompileMixin):
         k_pipeline,
         v_pipeline,
         num_blocks: cutlass.Int32,
-        tok_start: cutlass.Int32,
+        tok_start,
         q_head_idx: cutlass.Int32,
         k_head_idx: cutlass.Int32,
         v_head_idx: cutlass.Int32,
@@ -1074,8 +1074,8 @@ class _FullyFusedDeltaRuleSm90(KeyedCompileMixin):
         alpha_pipeline,
         scale: cutlass.Float32,
         num_blocks: cutlass.Int32,
-        tok_start: cutlass.Int32,
-        tok_end: cutlass.Int32,
+        tok_start,
+        tok_end,
         sab_head_idx: cutlass.Int32,
         num_sab_heads: cutlass.Int32,
     ):
@@ -1110,8 +1110,8 @@ class _FullyFusedDeltaRuleSm90(KeyedCompileMixin):
         g_beta: cute.Tensor,
         beta_pipeline,
         num_blocks: cutlass.Int32,
-        tok_start: cutlass.Int32,
-        tok_end: cutlass.Int32,
+        tok_start,
+        tok_end,
         sab_head_idx: cutlass.Int32,
         num_sab_heads: cutlass.Int32,
     ):

--- a/flashinfer/gdn_kernels/delta_rule_dsl/helpers.py
+++ b/flashinfer/gdn_kernels/delta_rule_dsl/helpers.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
 
+import torch
 import cutlass
 import cutlass.cute as cute
 import cutlass._mlir.dialects.cute_nvgpu as _cute_nvgpu_ir
@@ -13,6 +14,22 @@ from cutlass._mlir.dialects import llvm
 
 def round_down(a: int, b: int) -> int:
     return (a // b) * b
+
+
+def state_dtype_to_cutlass(dtype: torch.dtype) -> type[cutlass.Numeric]:
+    state_dtypes = {
+        torch.float32: cutlass.Float32,
+        torch.bfloat16: cutlass.BFloat16,
+        torch.float16: cutlass.Float16,
+        torch.float8_e4m3fn: cutlass.Float8E4M3FN,
+        torch.float8_e5m2: cutlass.Float8E5M2,
+    }
+    if dtype not in state_dtypes:
+        raise ValueError(
+            f"Unsupported state dtype {dtype}, expected float32, bfloat16, "
+            "float16, float8_e4m3fn, or float8_e5m2"
+        )
+    return state_dtypes[dtype]
 
 
 @dataclass(frozen=True)

--- a/flashinfer/gdn_kernels/delta_rule_dsl/schedule.py
+++ b/flashinfer/gdn_kernels/delta_rule_dsl/schedule.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from typing import Any
 
 import cutlass
 import cutlass.cute as cute
@@ -10,7 +11,7 @@ class WorkDesc:
     seq_idx: cutlass.Int32
     private_q_head_idx: cutlass.Int32
     private_v_head_idx: cutlass.Int32
-    tok_offset: cutlass.Int32
+    tok_offset: Any
 
     # shape
     seq_len: cutlass.Int32

--- a/flashinfer/gdn_kernels/delta_rule_dsl/varlen_helper.py
+++ b/flashinfer/gdn_kernels/delta_rule_dsl/varlen_helper.py
@@ -191,12 +191,12 @@ def choose_cp_chunk_len_host(
 
 @cute.jit
 def chunk_bound(
-    seq_idx: cutlass.Int32, total: cutlass.Int32, chunk_size: cutlass.Int32
+    seq_idx: cutlass.Int32, total, chunk_size: cutlass.Int32
 ) -> cutlass.Int32:
     m = seq_idx
     if total < m:
-        m = total
-    return m + (total - m) // chunk_size
+        m = cutlass.Int32(total)
+    return cutlass.Int32(m + (total - m) // chunk_size)
 
 
 @cute.jit
@@ -215,9 +215,11 @@ def logical_chunk_to_work_desc(
     chunk_idx_in_seq = logical_chunk_idx
     running = cutlass.Int32(0)
     for candidate_seq in cutlass.range(num_seqs, unroll=1):
-        seq_start = cutlass.Int32(cu_seqlens[candidate_seq])
-        seq_end = cutlass.Int32(cu_seqlens[candidate_seq + cutlass.Int32(1)])
-        seq_chunks = chunks_for_len(seq_end - seq_start, chunk_size)
+        seq_start = cu_seqlens[candidate_seq]
+        seq_len = cutlass.Int32(
+            cu_seqlens[candidate_seq + cutlass.Int32(1)] - seq_start
+        )
+        seq_chunks = chunks_for_len(seq_len, chunk_size)
         next_running = running + seq_chunks
         if logical_chunk_idx >= running and logical_chunk_idx < next_running:
             seq_idx = candidate_seq
@@ -229,7 +231,7 @@ def logical_chunk_to_work_desc(
 @cute.jit
 def varlen_chunk_idx(
     seq_idx: cutlass.Int32,
-    tok_idx_start: cutlass.Int32,
+    tok_idx_start,
     chunk_idx_in_seq: cutlass.Int32,
     chunk_size: cutlass.Int32,
 ) -> cutlass.Int32:

--- a/flashinfer/gdn_kernels/delta_rule_dsl/varlen_helper.py
+++ b/flashinfer/gdn_kernels/delta_rule_dsl/varlen_helper.py
@@ -19,6 +19,26 @@ CP_GDDR_PARALLELISM_THRESHOLD_NUMERATOR = 1
 CP_GDDR_PARALLELISM_THRESHOLD_DENOMINATOR = 3
 
 
+_INTEGER_DTYPES = (
+    torch.int32,
+    torch.int64,
+)
+
+
+def is_integer_dtype(dtype: torch.dtype) -> bool:
+    return dtype in _INTEGER_DTYPES
+
+
+def integer_dtype_to_cutlass(dtype: torch.dtype) -> type[cutlass.Numeric]:
+    try:
+        return {
+            torch.int32: cutlass.Int32,
+            torch.int64: cutlass.Int64,
+        }[dtype]
+    except KeyError as err:
+        raise RuntimeError(f"expected an integer dtype, got {dtype}") from err
+
+
 def _ceil_div(a, b):
     return (a + b - 1) // b
 

--- a/flashinfer/gdn_prefill.py
+++ b/flashinfer/gdn_prefill.py
@@ -79,7 +79,7 @@ def _cp_delta_rule_rejection_reason(
         checkpoint_every_n_tokens > 0
         or state_checkpoints is not None
         or checkpoint_cu_starts is not None
-    ):
+    ) and arch_major != 9:
         return "CP delta rule does not support state checkpointing yet"
     if q.shape[-1] != 128:
         return f"CP delta rule only supports head_size=128, got {q.shape[-1]}"
@@ -167,7 +167,7 @@ def chunk_gated_delta_rule(
         ``[num_seqs, num_sab_heads, head_size, head_size]``.  Must be
         float32 on SM90/SM120.  The SM100 path also accepts bfloat16,
         float16, float8_e4m3fn, and float8_e5m2.  Starts from zero state
-        when ``None``.  When ``state_indices`` is given (SM100/SM103 only),
+        when ``None``.  When ``state_indices`` is given (SM90/SM100/SM103),
         this is instead the state **pool** ``[N_pool, num_sab_heads,
         head_size, head_size]`` and sequence ``i`` reads its initial state
         from row ``state_indices[i]``; the pool may be non-compact (padded
@@ -205,7 +205,8 @@ def chunk_gated_delta_rule(
         num_sab_heads, head_size, head_size]``.  Must be float32 on
         SM90/SM120.  The SM100 path also accepts bfloat16, float16,
         float8_e4m3fn, and float8_e5m2.  Required when
-        ``checkpoint_every_n_tokens > 0``.
+        ``checkpoint_every_n_tokens > 0``. Context-parallel checkpointing is
+        currently supported on SM90 only.
     checkpoint_cu_starts : torch.Tensor, optional
         Cumulative checkpoint counts of shape ``[num_seqs + 1]``, int64.
         ``checkpoint_cu_starts[i+1] - checkpoint_cu_starts[i]`` is the
@@ -221,7 +222,7 @@ def chunk_gated_delta_rule(
         routing, ``True`` requires CP support, and ``False`` disables CP.
         Default: ``"auto"``.
     state_indices : torch.Tensor, optional
-        Int32 tensor of shape ``[num_seqs]`` (SM100/SM103 only). When provided,
+        Int32 tensor of shape ``[num_seqs]`` (SM90/SM100/SM103). When provided,
         ``initial_state`` and ``output_state`` are treated as a state pool whose
         first dimension is indexed by these slot ids rather than laid out in
         sequence order: sequence ``i`` reads its initial state from row
@@ -364,14 +365,12 @@ def chunk_gated_delta_rule(
     )
     will_use_cp = use_cp is True or (use_cp == "auto" and cp_heuristic_matches)
     if state_indices is not None:
-        # Indexed state-pool I/O is only implemented in the SM100/SM103 non-CP
-        # CuTe-DSL kernel. Reject it on every other dispatch path (SM90, SM120,
-        # or CP) rather than silently ignoring it and reading/writing the state
-        # in packed, sequence-ordered layout.
-        if _arch_major != 10:
+        # Reject unsupported dispatch paths rather than silently reading/writing
+        # the state in packed, sequence-ordered layout.
+        if _arch_major not in (9, 10):
             raise NotImplementedError(
-                "state_indices is only supported on the SM100/SM103 GDN prefill "
-                f"kernel (non-CP); got compute-capability major {_arch_major}, "
+                "state_indices is only supported on the SM90/SM100/SM103 GDN "
+                f"prefill kernels; got compute-capability major {_arch_major}, "
                 f"use_cp={use_cp!r}."
             )
         # The kernel writes each final state to output_state[state_indices[i]],
@@ -440,6 +439,15 @@ def chunk_gated_delta_rule(
             state_indices_kwargs = (
                 {"state_indices": state_indices} if state_indices is not None else {}
             )
+            checkpoint_kwargs = (
+                {
+                    "state_checkpoints": state_checkpoints,
+                    "checkpoint_cu_starts": checkpoint_cu_starts,
+                    "checkpoint_every_n_tokens": checkpoint_every_n_tokens,
+                }
+                if _arch_major == 9
+                else {}
+            )
             cp_delta_rule_dsl(
                 output,
                 output_state,
@@ -448,11 +456,12 @@ def chunk_gated_delta_rule(
                 v,
                 _g,
                 _beta,
-                cu_seqlens,
+                cu_seqlens.to(torch.int64) if _arch_major == 9 else cu_seqlens,
                 _scale,
                 initial_state=initial_state,
                 max_seqlen=total_seq_len,
                 **state_indices_kwargs,
+                **checkpoint_kwargs,
             )
             if output_final_state:
                 return output, output_state
@@ -571,6 +580,7 @@ def chunk_gated_delta_rule(
             if checkpoint_cu_starts is not None
             else None,
             checkpoint_every_n_tokens,
+            state_indices=state_indices,
         )
     else:
         raise NotImplementedError("GDN prefill DSL kernel is unavailable")

--- a/flashinfer/gdn_prefill.py
+++ b/flashinfer/gdn_prefill.py
@@ -30,7 +30,10 @@ from .gdn_kernels import (
     cp_delta_rule_dsl_sm100,
     cp_delta_rule_dsl_sm120,
 )
-from .gdn_kernels.delta_rule_dsl.varlen_helper import should_use_cp_host
+from .gdn_kernels.delta_rule_dsl.varlen_helper import (
+    is_integer_dtype,
+    should_use_cp_host,
+)
 
 
 _SM100_STATE_DTYPES: tuple[torch.dtype, ...] = (
@@ -106,12 +109,6 @@ def _cp_delta_rule_rejection_reason(
     if initial_state is not None:
         if state_indices is None and not initial_state.is_contiguous():
             return "CP delta rule requires initial_state to be contiguous"
-        if state_indices is not None and initial_state.stride()[1:] != (
-            initial_state.shape[2] * initial_state.shape[3],
-            initial_state.shape[3],
-            1,
-        ):
-            return "CP delta rule requires initial_state to be contiguous in [H, V, K]"
     return None
 
 
@@ -134,6 +131,7 @@ def chunk_gated_delta_rule(
     checkpoint_every_n_tokens: int = 0,
     use_cp: Literal["auto"] | bool = "auto",
     state_indices: Optional[torch.Tensor] = None,
+    _cp_chunk_len: Optional[int] = None,
 ) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
     r"""Chunked Gated Delta Rule (GDN) attention for prefill.
 
@@ -288,6 +286,10 @@ def chunk_gated_delta_rule(
         )
 
     assert cu_seqlens is not None, "cu_seqlens is required for varlen mode"
+    if not is_integer_dtype(cu_seqlens.dtype):
+        raise ValueError(
+            f"cu_seqlens must have an integer dtype, got {cu_seqlens.dtype}"
+        )
 
     num_seqs = cu_seqlens.size(0) - 1
     total_seq_len = q.size(0)
@@ -314,9 +316,10 @@ def chunk_gated_delta_rule(
                 f"[total_checkpoints, num_sab_heads, head_size, head_size], "
                 f"got {state_checkpoints.ndim}D"
             )
-        if checkpoint_cu_starts.dtype != torch.int64:
+        if not is_integer_dtype(checkpoint_cu_starts.dtype):
             raise ValueError(
-                f"checkpoint_cu_starts must be int64, got {checkpoint_cu_starts.dtype}"
+                "checkpoint_cu_starts must have an integer dtype, "
+                f"got {checkpoint_cu_starts.dtype}"
             )
         if checkpoint_cu_starts.ndim != 1:
             raise ValueError(
@@ -365,6 +368,15 @@ def chunk_gated_delta_rule(
     )
     will_use_cp = use_cp is True or (use_cp == "auto" and cp_heuristic_matches)
     if state_indices is not None:
+        if not is_integer_dtype(state_indices.dtype):
+            raise ValueError(
+                f"state_indices must have an integer dtype, got {state_indices.dtype}"
+            )
+        if state_indices.shape != (num_seqs,):
+            raise ValueError(
+                f"state_indices must have shape {(num_seqs,)}, "
+                f"got {tuple(state_indices.shape)}"
+            )
         # Reject unsupported dispatch paths rather than silently reading/writing
         # the state in packed, sequence-ordered layout.
         if _arch_major not in (9, 10, 12):
@@ -456,10 +468,11 @@ def chunk_gated_delta_rule(
                 v,
                 _g,
                 _beta,
-                cu_seqlens.to(torch.int64) if _arch_major in (9, 12) else cu_seqlens,
+                cu_seqlens,
                 _scale,
                 initial_state=initial_state,
                 max_seqlen=total_seq_len,
+                cp_chunk_len=_cp_chunk_len,
                 **state_indices_kwargs,
                 **checkpoint_kwargs,
             )
@@ -504,11 +517,6 @@ def chunk_gated_delta_rule(
             )
         )
 
-        # Convert checkpoint_cu_starts from int64 cu_starts to int32 cu_checkpoints
-        _cu_checkpoints = None
-        if checkpoint_every_n_tokens > 0 and checkpoint_cu_starts is not None:
-            _cu_checkpoints = checkpoint_cu_starts.to(torch.int32)
-
         chunk_gated_delta_rule_sm100(
             q,
             k,
@@ -516,12 +524,12 @@ def chunk_gated_delta_rule(
             _g,
             _beta,
             output,
-            cu_seqlens.to(torch.int32),
+            cu_seqlens,
             initial_state,
             output_state,
             _scale,
             checkpoint_every_n_tokens=checkpoint_every_n_tokens,
-            cu_checkpoints=_cu_checkpoints,
+            cu_checkpoints=checkpoint_cu_starts,
             output_checkpoints=state_checkpoints,
             state_indices=state_indices,
         )
@@ -547,12 +555,10 @@ def chunk_gated_delta_rule(
             initial_state,
             g,
             beta,
-            cu_seqlens.to(torch.int64),
+            cu_seqlens,
             _scale,
             state_checkpoints,
-            checkpoint_cu_starts.to(torch.int64)
-            if checkpoint_cu_starts is not None
-            else None,
+            checkpoint_cu_starts,
             checkpoint_every_n_tokens,
             state_indices=state_indices,
         )
@@ -577,12 +583,10 @@ def chunk_gated_delta_rule(
             initial_state,
             g,
             beta,
-            cu_seqlens.to(torch.int64),
+            cu_seqlens,
             _scale,
             state_checkpoints,
-            checkpoint_cu_starts.to(torch.int64)
-            if checkpoint_cu_starts is not None
-            else None,
+            checkpoint_cu_starts,
             checkpoint_every_n_tokens,
             state_indices=state_indices,
         )

--- a/flashinfer/gdn_prefill.py
+++ b/flashinfer/gdn_prefill.py
@@ -79,7 +79,7 @@ def _cp_delta_rule_rejection_reason(
         checkpoint_every_n_tokens > 0
         or state_checkpoints is not None
         or checkpoint_cu_starts is not None
-    ) and arch_major not in (9, 10):
+    ) and arch_major not in (9, 10, 12):
         return "CP delta rule does not support state checkpointing yet"
     if q.shape[-1] != 128:
         return f"CP delta rule only supports head_size=128, got {q.shape[-1]}"
@@ -167,7 +167,7 @@ def chunk_gated_delta_rule(
         ``[num_seqs, num_sab_heads, head_size, head_size]``.  Must be
         float32 on SM90/SM120.  The SM100 path also accepts bfloat16,
         float16, float8_e4m3fn, and float8_e5m2.  Starts from zero state
-        when ``None``.  When ``state_indices`` is given (SM90/SM100/SM103),
+        when ``None``.  When ``state_indices`` is given (SM90/SM100/SM103/SM120),
         this is instead the state **pool** ``[N_pool, num_sab_heads,
         head_size, head_size]`` and sequence ``i`` reads its initial state
         from row ``state_indices[i]``; the pool may be non-compact (padded
@@ -206,7 +206,7 @@ def chunk_gated_delta_rule(
         SM90/SM120.  The SM100 path also accepts bfloat16, float16,
         float8_e4m3fn, and float8_e5m2.  Required when
         ``checkpoint_every_n_tokens > 0``. Context-parallel checkpointing is
-        currently supported on SM90 and SM100.
+        currently supported on SM90, SM100, and SM120.
     checkpoint_cu_starts : torch.Tensor, optional
         Cumulative checkpoint counts of shape ``[num_seqs + 1]``, int64.
         ``checkpoint_cu_starts[i+1] - checkpoint_cu_starts[i]`` is the
@@ -222,7 +222,7 @@ def chunk_gated_delta_rule(
         routing, ``True`` requires CP support, and ``False`` disables CP.
         Default: ``"auto"``.
     state_indices : torch.Tensor, optional
-        Int32 tensor of shape ``[num_seqs]`` (SM90/SM100/SM103). When provided,
+        Int32 tensor of shape ``[num_seqs]`` (SM90/SM100/SM103/SM120). When provided,
         ``initial_state`` and ``output_state`` are treated as a state pool whose
         first dimension is indexed by these slot ids rather than laid out in
         sequence order: sequence ``i`` reads its initial state from row
@@ -367,9 +367,9 @@ def chunk_gated_delta_rule(
     if state_indices is not None:
         # Reject unsupported dispatch paths rather than silently reading/writing
         # the state in packed, sequence-ordered layout.
-        if _arch_major not in (9, 10):
+        if _arch_major not in (9, 10, 12):
             raise NotImplementedError(
-                "state_indices is only supported on the SM90/SM100/SM103 GDN "
+                "state_indices is only supported on the SM90/SM100/SM103/SM120 GDN "
                 f"prefill kernels; got compute-capability major {_arch_major}, "
                 f"use_cp={use_cp!r}."
             )
@@ -445,7 +445,7 @@ def chunk_gated_delta_rule(
                     "checkpoint_cu_starts": checkpoint_cu_starts,
                     "checkpoint_every_n_tokens": checkpoint_every_n_tokens,
                 }
-                if _arch_major in (9, 10)
+                if _arch_major in (9, 10, 12)
                 else {}
             )
             cp_delta_rule_dsl(
@@ -456,7 +456,7 @@ def chunk_gated_delta_rule(
                 v,
                 _g,
                 _beta,
-                cu_seqlens.to(torch.int64) if _arch_major == 9 else cu_seqlens,
+                cu_seqlens.to(torch.int64) if _arch_major in (9, 12) else cu_seqlens,
                 _scale,
                 initial_state=initial_state,
                 max_seqlen=total_seq_len,
@@ -530,10 +530,13 @@ def chunk_gated_delta_rule(
         if chunk_gated_delta_rule_sm120 is None:
             raise NotImplementedError("SM120 GDN prefill DSL kernel is unavailable")
         if output_state is None:
+            output_state_shape = (
+                initial_state.shape
+                if state_indices is not None and initial_state is not None
+                else (num_seqs, num_sab_heads, head_size, head_size)
+            )
             output_state = torch.empty(
-                (num_seqs, num_sab_heads, head_size, head_size),
-                dtype=torch.float32,
-                device=device,
+                output_state_shape, dtype=torch.float32, device=device
             )
         chunk_gated_delta_rule_sm120(
             output,
@@ -551,6 +554,7 @@ def chunk_gated_delta_rule(
             if checkpoint_cu_starts is not None
             else None,
             checkpoint_every_n_tokens,
+            state_indices=state_indices,
         )
     elif _arch_major == 9:
         # SM90 Hopper path (CuTe DSL kernel)

--- a/flashinfer/gdn_prefill.py
+++ b/flashinfer/gdn_prefill.py
@@ -79,7 +79,7 @@ def _cp_delta_rule_rejection_reason(
         checkpoint_every_n_tokens > 0
         or state_checkpoints is not None
         or checkpoint_cu_starts is not None
-    ) and arch_major != 9:
+    ) and arch_major not in (9, 10):
         return "CP delta rule does not support state checkpointing yet"
     if q.shape[-1] != 128:
         return f"CP delta rule only supports head_size=128, got {q.shape[-1]}"
@@ -206,7 +206,7 @@ def chunk_gated_delta_rule(
         SM90/SM120.  The SM100 path also accepts bfloat16, float16,
         float8_e4m3fn, and float8_e5m2.  Required when
         ``checkpoint_every_n_tokens > 0``. Context-parallel checkpointing is
-        currently supported on SM90 only.
+        currently supported on SM90 and SM100.
     checkpoint_cu_starts : torch.Tensor, optional
         Cumulative checkpoint counts of shape ``[num_seqs + 1]``, int64.
         ``checkpoint_cu_starts[i+1] - checkpoint_cu_starts[i]`` is the
@@ -445,7 +445,7 @@ def chunk_gated_delta_rule(
                     "checkpoint_cu_starts": checkpoint_cu_starts,
                     "checkpoint_every_n_tokens": checkpoint_every_n_tokens,
                 }
-                if _arch_major == 9
+                if _arch_major in (9, 10)
                 else {}
             )
             cp_delta_rule_dsl(

--- a/flashinfer/gdn_prefill.py
+++ b/flashinfer/gdn_prefill.py
@@ -36,7 +36,7 @@ from .gdn_kernels.delta_rule_dsl.varlen_helper import (
 )
 
 
-_SM100_STATE_DTYPES: tuple[torch.dtype, ...] = (
+_STATE_DTYPES: tuple[torch.dtype, ...] = (
     torch.float32,
     torch.bfloat16,
     torch.float16,
@@ -163,8 +163,7 @@ def chunk_gated_delta_rule(
     initial_state : torch.Tensor, optional
         Initial KV state. Packed, sequence-ordered shape
         ``[num_seqs, num_sab_heads, head_size, head_size]``.  Must be
-        float32 on SM90/SM120.  The SM100 path also accepts bfloat16,
-        float16, float8_e4m3fn, and float8_e5m2.  Starts from zero state
+        float32, bfloat16, float16, float8_e4m3fn, or float8_e5m2. Starts from zero state
         when ``None``.  When ``state_indices`` is given (SM90/SM100/SM103/SM120),
         this is instead the state **pool** ``[N_pool, num_sab_heads,
         head_size, head_size]`` and sequence ``i`` reads its initial state
@@ -189,9 +188,8 @@ def chunk_gated_delta_rule(
         ``None``.
     output_state : torch.Tensor, optional
         Pre-allocated output state tensor. Packed, sequence-ordered shape
-        ``[num_seqs, num_sab_heads, head_size, head_size]``.  Must be float32
-        on SM90/SM120.  The SM100 path also accepts bfloat16, float16,
-        float8_e4m3fn, and float8_e5m2.  Required when
+        ``[num_seqs, num_sab_heads, head_size, head_size]``. May be float32,
+        bfloat16, float16, float8_e4m3fn, or float8_e5m2. Required when
         ``output_final_state=True``.  When ``state_indices`` is given it is
         instead the output state **pool** ``[N_pool, ...]`` and sequence
         ``i``'s final state is written to row ``state_indices[i]`` (in place
@@ -200,9 +198,8 @@ def chunk_gated_delta_rule(
         buffer would be indexed out of bounds by the pool slot ids).
     state_checkpoints : torch.Tensor, optional
         Pre-allocated checkpoint tensor of shape ``[total_checkpoints,
-        num_sab_heads, head_size, head_size]``.  Must be float32 on
-        SM90/SM120.  The SM100 path also accepts bfloat16, float16,
-        float8_e4m3fn, and float8_e5m2.  Required when
+        num_sab_heads, head_size, head_size]``. May be float32, bfloat16,
+        float16, float8_e4m3fn, or float8_e5m2. Required when
         ``checkpoint_every_n_tokens > 0``. Context-parallel checkpointing is
         currently supported on SM90, SM100, and SM120.
     checkpoint_cu_starts : torch.Tensor, optional
@@ -301,13 +298,10 @@ def chunk_gated_delta_rule(
 
     if checkpoint_every_n_tokens > 0:
         assert state_checkpoints is not None and checkpoint_cu_starts is not None
-        state_checkpoint_dtypes: tuple[torch.dtype, ...] = (torch.float32,)
-        if q.is_cuda and get_compute_capability(q.device)[0] == 10:
-            state_checkpoint_dtypes = _SM100_STATE_DTYPES
-        if state_checkpoints.dtype not in state_checkpoint_dtypes:
+        if state_checkpoints.dtype not in _STATE_DTYPES:
             raise ValueError(
                 "state_checkpoints must have dtype "
-                f"{_format_dtype_list(state_checkpoint_dtypes)}, "
+                f"{_format_dtype_list(_STATE_DTYPES)}, "
                 f"got {state_checkpoints.dtype}"
             )
         if state_checkpoints.ndim != 4:

--- a/tests/gdn/test_prefill_cp_delta_rule.py
+++ b/tests/gdn/test_prefill_cp_delta_rule.py
@@ -995,16 +995,14 @@ def test_cp_delta_rule_public_wrapper_matches_non_cp_prefill(
 @torch.inference_mode()
 @pytest.mark.parametrize("state_dtype", [torch.bfloat16, torch.float16])
 @pytest.mark.parametrize("seq_lens", [[128], [256, 64]])
-def test_sm100_cp_delta_rule_external_state_dtype(
+def test_cp_delta_rule_external_state_dtype(
     qkv_factory,
     state_dtype,
     seq_lens,
     seed=int(os.environ.get("SEED", "0")),
 ):
-    device = torch.device("cuda")
-    if not is_sm100a_supported(device):
-        pytest.skip("typed CP state requires SM100/SM103")
     _skip_if_cp_unsupported()
+    device = torch.device("cuda")
     _seed_all(seed)
     dtype = torch.bfloat16
     head_size = 128

--- a/tests/gdn/test_prefill_delta_rule.py
+++ b/tests/gdn/test_prefill_delta_rule.py
@@ -875,8 +875,9 @@ def test_checkpoint_correctness(
     if use_cp and not (
         is_sm90a_supported(torch.device("cuda"))
         or is_sm100a_supported(torch.device("cuda"))
+        or is_sm12x_supported(torch.device("cuda"))
     ):
-        pytest.skip("CP state checkpointing requires SM90 or SM100")
+        pytest.skip("CP state checkpointing requires SM90, SM100, or SM120")
     scale = 1.0 / math.sqrt(head_size)
     _test_checkpoint(
         qkv_factory,

--- a/tests/gdn/test_prefill_delta_rule.py
+++ b/tests/gdn/test_prefill_delta_rule.py
@@ -719,6 +719,7 @@ def _test_checkpoint(
     scale: float,
     checkpoint_every_n_tokens: int,
     seed: int | None = None,
+    use_cp: bool = False,
 ):
     """Test state checkpointing by comparing against prefix-based reference runs."""
     _skip_if_unsupported()
@@ -787,7 +788,7 @@ def _test_checkpoint(
         state_checkpoints=state_checkpoints,
         checkpoint_cu_starts=checkpoint_cu_starts,
         checkpoint_every_n_tokens=checkpoint_every_n_tokens,
-        use_cp=False,
+        use_cp=use_cp,
     )
     torch.cuda.synchronize()
 
@@ -839,11 +840,13 @@ def _test_checkpoint(
             actual_ckpt = state_checkpoints[ckpt_global_idx]
             expected_ckpt = prefix_state[0]
 
+            atol = 1e-2 if use_cp and dtype == torch.bfloat16 else 1e-3
+            rtol = 5e-3 if use_cp and dtype == torch.bfloat16 else 1e-4
             torch.testing.assert_close(
                 actual_ckpt,
                 expected_ckpt,
-                atol=1e-3,
-                rtol=1e-4,
+                atol=atol,
+                rtol=rtol,
                 msg=f"Checkpoint mismatch: seq={seq_idx}, ckpt={ckpt_idx}",
             )
 
@@ -856,6 +859,7 @@ def _test_checkpoint(
 )
 @pytest.mark.parametrize("seq_lens", [[256], [128, 256, 512]])
 @pytest.mark.parametrize("dtype", ["float16", "bfloat16"])
+@pytest.mark.parametrize("use_cp", [False, True])
 def test_checkpoint_correctness(
     qkv_factory,
     dtype: str,
@@ -865,8 +869,14 @@ def test_checkpoint_correctness(
     head_size: int,
     seq_lens: list[int],
     checkpoint_every_n_tokens: int,
+    use_cp: bool,
     seed: int = int(os.environ.get("SEED", "0")),
 ):
+    if use_cp and not (
+        is_sm90a_supported(torch.device("cuda"))
+        or is_sm100a_supported(torch.device("cuda"))
+    ):
+        pytest.skip("CP state checkpointing requires SM90 or SM100")
     scale = 1.0 / math.sqrt(head_size)
     _test_checkpoint(
         qkv_factory,
@@ -879,6 +889,7 @@ def test_checkpoint_correctness(
         scale,
         checkpoint_every_n_tokens,
         seed,
+        use_cp=use_cp,
     )
 
 

--- a/tests/gdn/test_prefill_delta_rule.py
+++ b/tests/gdn/test_prefill_delta_rule.py
@@ -789,6 +789,7 @@ def _test_checkpoint(
         checkpoint_cu_starts=checkpoint_cu_starts,
         checkpoint_every_n_tokens=checkpoint_every_n_tokens,
         use_cp=use_cp,
+        _cp_chunk_len=checkpoint_every_n_tokens if use_cp else None,
     )
     torch.cuda.synchronize()
 
@@ -832,7 +833,8 @@ def _test_checkpoint(
                 True,
                 output=prefix_o,
                 output_state=prefix_state,
-                use_cp=False,
+                use_cp=use_cp,
+                _cp_chunk_len=checkpoint_every_n_tokens if use_cp else None,
             )
             torch.cuda.synchronize()
 
@@ -840,14 +842,8 @@ def _test_checkpoint(
             actual_ckpt = state_checkpoints[ckpt_global_idx]
             expected_ckpt = prefix_state[0]
 
-            atol = 1e-2 if use_cp and dtype == torch.bfloat16 else 1e-3
-            rtol = 5e-3 if use_cp and dtype == torch.bfloat16 else 1e-4
-            torch.testing.assert_close(
-                actual_ckpt,
-                expected_ckpt,
-                atol=atol,
-                rtol=rtol,
-                msg=f"Checkpoint mismatch: seq={seq_idx}, ckpt={ckpt_idx}",
+            assert torch.equal(actual_ckpt, expected_ckpt), (
+                f"Checkpoint mismatch: seq={seq_idx}, ckpt={ckpt_idx}"
             )
 
 

--- a/tests/gdn/test_prefill_delta_rule.py
+++ b/tests/gdn/test_prefill_delta_rule.py
@@ -1057,7 +1057,7 @@ def test_checkpoint_wrong_cu_starts_size(qkv_factory):
 
 
 # ---------------------------------------------------------------------------
-# State dtype tests (SM100 only)
+# State dtype tests
 # ---------------------------------------------------------------------------
 
 
@@ -1071,9 +1071,12 @@ def _test_prefill_kernel_state_dtype(
     head_size: int,
     seq_lens: list[int],
     scale: float,
+    use_cp: bool,
     seed: int | None = None,
 ):
-    _skip_if_not_sm100()
+    _skip_if_unsupported()
+    if use_cp:
+        _skip_if_cp_unsupported()
 
     random.seed(seed)
     torch.random.manual_seed(seed)
@@ -1130,7 +1133,7 @@ def _test_prefill_kernel_state_dtype(
         True,
         output=our_o,
         output_state=our_state,
-        use_cp=False,
+        use_cp=use_cp,
     )
 
     torch.cuda.synchronize()
@@ -1178,6 +1181,7 @@ def _test_prefill_kernel_state_dtype(
     "state_dtype",
     [torch.bfloat16, torch.float16, torch.float8_e4m3fn, torch.float8_e5m2],
 )
+@pytest.mark.parametrize("use_cp", [False, True])
 def test_prefill_kernel_state_dtype(
     qkv_factory,
     dtype: str,
@@ -1188,6 +1192,7 @@ def test_prefill_kernel_state_dtype(
     seq_lens: list[int],
     scale: float | str,
     state_dtype: torch.dtype,
+    use_cp: bool,
     seed: int = int(os.environ.get("SEED", "0")),
 ):
     scale = 1.0 / math.sqrt(head_size) if scale == "auto" else scale
@@ -1201,5 +1206,6 @@ def test_prefill_kernel_state_dtype(
         head_size,
         seq_lens,
         scale,
+        use_cp,
         seed=seed,
     )

--- a/tests/gdn/test_prefill_state_indices.py
+++ b/tests/gdn/test_prefill_state_indices.py
@@ -24,11 +24,11 @@ from flashinfer.utils import get_compute_capability, is_sm100a_supported
 from flashinfer.gdn_prefill import chunk_gated_delta_rule
 
 
-def _skip_if_not_sm90_or_sm100():
+def _skip_if_not_supported():
     device = torch.device("cuda")
     major, _ = get_compute_capability(device)
-    if major not in (9, 10):
-        pytest.skip("state_indices GDN prefill path requires SM90 or SM100/SM103")
+    if major not in (9, 10, 12):
+        pytest.skip("state_indices GDN prefill path requires SM90, SM100, or SM120")
     cuda_major = int(torch.version.cuda.split(".")[0]) if torch.version.cuda else 0
     if is_sm100a_supported(device) and cuda_major < 13:
         pytest.skip(f"SM100 GDN prefill requires CUDA 13+, got {torch.version.cuda}")
@@ -64,7 +64,9 @@ def _make_inputs(seq_lens, H, D, dtype, device, seed):
     )
     g = torch.exp(g_log).contiguous()
     beta = torch.rand(total, H, dtype=torch.float32, device=device).contiguous()
-    state_dtype = torch.float32 if get_compute_capability(device)[0] == 9 else dtype
+    state_dtype = (
+        torch.float32 if get_compute_capability(device)[0] in (9, 12) else dtype
+    )
     init_state = torch.randn(
         num_seqs, H, D, D, dtype=state_dtype, device=device
     ).contiguous()
@@ -139,7 +141,7 @@ def test_prefill_state_indices_matches_packed(dtype, seq_lens, H, pad, use_cp):
     """A pool + state_indices in-place update must match the packed,
     sequence-ordered baseline bitwise (the kernel math is identical; only the
     addressed gmem row differs)."""
-    _skip_if_not_sm90_or_sm100()
+    _skip_if_not_supported()
     device = torch.device("cuda")
     D = 128
     num_seqs = len(seq_lens)
@@ -187,7 +189,7 @@ def test_prefill_state_indices_requires_output_state_pool():
     """With state_indices set, output_state must be a caller-provided pool: an
     auto-allocated compact [num_seqs, ...] tensor would be indexed out of bounds
     by the pool slot ids, so output_state=None must be rejected."""
-    _skip_if_not_sm90_or_sm100()
+    _skip_if_not_supported()
     device = torch.device("cuda")
     H, D = 16, 128
     seq_lens = [128, 64]
@@ -223,10 +225,10 @@ def test_prefill_state_indices_requires_output_state_pool():
 @pytest.mark.parametrize("use_cp", [False, True])
 def test_prefill_state_indices_with_state_checkpoints(use_cp):
     """Indexed final-state I/O must not change packed checkpoint ordering."""
-    _skip_if_not_sm90_or_sm100()
+    _skip_if_not_supported()
     device = torch.device("cuda")
-    if use_cp and get_compute_capability(device)[0] not in (9, 10):
-        pytest.skip("CP state checkpointing requires SM90 or SM100")
+    if use_cp and get_compute_capability(device)[0] not in (9, 10, 12):
+        pytest.skip("CP state checkpointing requires SM90, SM100, or SM120")
     H, D = 16, 128
     seq_lens = [128, 512]
     num_seqs = len(seq_lens)
@@ -320,7 +322,7 @@ def test_prefill_state_indices_with_state_checkpoints(use_cp):
 @pytest.mark.parametrize("use_cp", [False, True])
 def test_prefill_state_indices_without_final_state(use_cp):
     """A state pool can supply initial state without requesting a final state."""
-    _skip_if_not_sm90_or_sm100()
+    _skip_if_not_supported()
     device = torch.device("cuda")
     H, D = 16, 128
     seq_lens = [64, 512]
@@ -363,7 +365,7 @@ def test_prefill_state_indices_without_final_state(use_cp):
 @pytest.mark.parametrize("use_cp", [False, True])
 def test_prefill_state_indices_none_is_default(use_cp):
     """state_indices=None must reproduce the packed path exactly (default)."""
-    _skip_if_not_sm90_or_sm100()
+    _skip_if_not_supported()
     device = torch.device("cuda")
     H, D = 16, 128
     seq_lens = [128, 192]

--- a/tests/gdn/test_prefill_state_indices.py
+++ b/tests/gdn/test_prefill_state_indices.py
@@ -24,6 +24,12 @@ from flashinfer.utils import get_compute_capability, is_sm100a_supported
 from flashinfer.gdn_prefill import chunk_gated_delta_rule
 
 
+INTEGER_DTYPES = (
+    torch.int32,
+    torch.int64,
+)
+
+
 def _skip_if_not_supported():
     device = torch.device("cuda")
     major, _ = get_compute_capability(device)
@@ -106,24 +112,29 @@ def _run(
     return output, final
 
 
-def _make_pool(init_state, perm, n_pool, pad, dtype, device):
+def _make_pool(init_state, perm, n_pool, pad, dtype, device, inner_stride=1):
     """Build a state pool holding init_state[i] at row perm[i].
 
-    ``pad > 0`` gives the pool a padded (non-compact) *first-dimension* stride
-    while keeping the inner ``[H, V, K]`` block fully contiguous -- exactly
-    TRT-LLM's mamba cache layout, where conv+ssm are packed per slot so only the
-    per-slot (dim-0) stride is padded. Built via ``as_strided`` over flat storage
-    so the padding lands only between slots, not inside the state block.
+    ``pad > 0`` gives the pool a padded first-dimension stride, matching a state
+    pool packed with other per-slot data. ``inner_stride > 1`` additionally
+    exercises a fully strided ``[H, V, K]`` view.
     """
     _, H, D, _ = init_state.shape
-    if pad == 0:
+    if pad == 0 and inner_stride == 1:
         pool = torch.zeros(n_pool, H, D, D, dtype=dtype, device=device)
     else:
-        slot_stride = H * D * D + pad  # usable state block + inter-slot padding
+        slot_stride = H * D * D * inner_stride + pad
         storage = torch.zeros(n_pool * slot_stride, dtype=dtype, device=device)
-        pool = storage.as_strided((n_pool, H, D, D), (slot_stride, D * D, D, 1))
-        assert not pool.is_contiguous()  # dim-0 stride padded
-        assert pool.stride()[1:] == (D * D, D, 1)  # inner [H, V, K] contiguous
+        pool = storage.as_strided(
+            (n_pool, H, D, D),
+            (
+                slot_stride,
+                D * D * inner_stride,
+                D * inner_stride,
+                inner_stride,
+            ),
+        )
+        assert not pool.is_contiguous()
     for i, r in enumerate(perm):
         pool[r] = init_state[i]
     return pool
@@ -185,6 +196,124 @@ def test_prefill_state_indices_matches_packed(dtype, seq_lens, H, pad, use_cp):
     assert torch.equal(pool[untouched], torch.zeros_like(pool[untouched]))
 
 
+@pytest.mark.parametrize("index_dtype", INTEGER_DTYPES)
+@pytest.mark.parametrize("use_cp", [False, True])
+def test_prefill_integer_index_dtypes(index_dtype, use_cp):
+    """Sequence and state indices retain their integer dtype across dispatch."""
+    _skip_if_not_supported()
+    device = torch.device("cuda")
+    H, D = 8, 128
+    seq_lens = [64]
+    q, k, v, g, beta, cu_seqlens, init_state = _make_inputs(
+        seq_lens, H, D, torch.bfloat16, device, seed=5
+    )
+    cu_seqlens = cu_seqlens.to(index_dtype)
+
+    packed_state = torch.empty_like(init_state)
+    packed_output, packed_final = _run(
+        q,
+        k,
+        v,
+        g,
+        beta,
+        cu_seqlens,
+        init_state.clone(),
+        packed_state,
+        None,
+        use_cp,
+    )
+
+    slots = [2]
+    pool = _make_pool(init_state, slots, 4, 96, init_state.dtype, device)
+    state_indices = torch.tensor(slots, dtype=index_dtype, device=device)
+    indexed_output, indexed_final = _run(
+        q,
+        k,
+        v,
+        g,
+        beta,
+        cu_seqlens,
+        pool,
+        pool,
+        state_indices,
+        use_cp,
+    )
+    torch.cuda.synchronize()
+
+    assert torch.equal(packed_output, indexed_output)
+    assert torch.equal(packed_final, indexed_final[slots])
+
+
+@pytest.mark.parametrize("use_cp", [False, True])
+def test_prefill_state_indices_preserves_inner_strides(use_cp):
+    """Indexed state views use the tensor's actual shape and strides."""
+    _skip_if_not_supported()
+    device = torch.device("cuda")
+    H, D = 8, 128
+    seq_lens = [64]
+    q, k, v, g, beta, cu_seqlens, init_state = _make_inputs(
+        seq_lens, H, D, torch.bfloat16, device, seed=6
+    )
+
+    packed_state = torch.empty_like(init_state)
+    packed_output, packed_final = _run(
+        q,
+        k,
+        v,
+        g,
+        beta,
+        cu_seqlens,
+        init_state.clone(),
+        packed_state,
+        None,
+        use_cp,
+    )
+
+    slots = [2]
+    state_indices = torch.tensor(slots, dtype=torch.int32, device=device)
+    contiguous_pool = _make_pool(init_state, slots, 4, 96, init_state.dtype, device)
+    contiguous_output, contiguous_final = _run(
+        q,
+        k,
+        v,
+        g,
+        beta,
+        cu_seqlens,
+        contiguous_pool,
+        contiguous_pool,
+        state_indices,
+        use_cp,
+    )
+    assert torch.equal(packed_output, contiguous_output)
+    assert torch.equal(packed_final, contiguous_final[slots])
+
+    pool = _make_pool(
+        init_state,
+        slots,
+        4,
+        96,
+        init_state.dtype,
+        device,
+        inner_stride=2,
+    )
+    indexed_output, indexed_final = _run(
+        q,
+        k,
+        v,
+        g,
+        beta,
+        cu_seqlens,
+        pool,
+        pool,
+        state_indices,
+        use_cp,
+    )
+    torch.cuda.synchronize()
+
+    assert torch.equal(packed_output, indexed_output)
+    assert torch.equal(packed_final, indexed_final[slots])
+
+
 def test_prefill_state_indices_requires_output_state_pool():
     """With state_indices set, output_state must be a caller-provided pool: an
     auto-allocated compact [num_seqs, ...] tensor would be indexed out of bounds
@@ -219,103 +348,6 @@ def test_prefill_state_indices_requires_output_state_pool():
             output=out,
             output_state=None,  # must be rejected when state_indices is set
             state_indices=idx,
-        )
-
-
-@pytest.mark.parametrize("use_cp", [False, True])
-def test_prefill_state_indices_with_state_checkpoints(use_cp):
-    """Indexed final-state I/O must not change packed checkpoint ordering."""
-    _skip_if_not_supported()
-    device = torch.device("cuda")
-    if use_cp and get_compute_capability(device)[0] not in (9, 10, 12):
-        pytest.skip("CP state checkpointing requires SM90, SM100, or SM120")
-    H, D = 16, 128
-    seq_lens = [128, 512]
-    num_seqs = len(seq_lens)
-    q, k, v, g, beta, cu_seqlens, init_state = _make_inputs(
-        seq_lens, H, D, torch.bfloat16, device, seed=3
-    )
-    checkpoint_every = 64
-    checkpoint_counts = [seq_len // checkpoint_every for seq_len in seq_lens]
-    checkpoint_cu_starts = torch.tensor(
-        [0, *torch.cumsum(torch.tensor(checkpoint_counts), 0).tolist()],
-        dtype=torch.int64,
-        device=device,
-    )
-    checkpoint_shape = (sum(checkpoint_counts), H, D, D)
-
-    packed_state = torch.empty_like(init_state)
-    packed_checkpoints = torch.empty(
-        checkpoint_shape, dtype=init_state.dtype, device=device
-    )
-    packed_output = torch.empty_like(q)
-    output_a, final_a = chunk_gated_delta_rule(
-        q,
-        k,
-        v,
-        g,
-        beta,
-        initial_state=init_state.clone(),
-        output_final_state=True,
-        cu_seqlens=cu_seqlens,
-        output=packed_output,
-        output_state=packed_state,
-        state_checkpoints=packed_checkpoints,
-        checkpoint_cu_starts=checkpoint_cu_starts,
-        checkpoint_every_n_tokens=checkpoint_every,
-        use_cp=use_cp,
-    )
-
-    n_pool = num_seqs + 4
-    slots = [4, 1]
-    pool = _make_pool(init_state, slots, n_pool, 96, init_state.dtype, device)
-    state_indices = torch.tensor(slots, dtype=torch.int32, device=device)
-    indexed_checkpoints = torch.empty_like(packed_checkpoints)
-    indexed_output = torch.empty_like(q)
-    output_b, final_b = chunk_gated_delta_rule(
-        q,
-        k,
-        v,
-        g,
-        beta,
-        initial_state=pool,
-        output_final_state=True,
-        cu_seqlens=cu_seqlens,
-        output=indexed_output,
-        output_state=pool,
-        state_checkpoints=indexed_checkpoints,
-        checkpoint_cu_starts=checkpoint_cu_starts,
-        checkpoint_every_n_tokens=checkpoint_every,
-        state_indices=state_indices,
-        use_cp=use_cp,
-    )
-    torch.cuda.synchronize()
-
-    assert torch.equal(output_a, output_b)
-    assert torch.equal(final_a, final_b[slots])
-    assert torch.equal(packed_checkpoints, indexed_checkpoints)
-    if use_cp:
-        reference_checkpoints = torch.empty_like(packed_checkpoints)
-        chunk_gated_delta_rule(
-            q,
-            k,
-            v,
-            g,
-            beta,
-            initial_state=init_state.clone(),
-            output_final_state=False,
-            cu_seqlens=cu_seqlens,
-            state_checkpoints=reference_checkpoints,
-            checkpoint_cu_starts=checkpoint_cu_starts,
-            checkpoint_every_n_tokens=checkpoint_every,
-            use_cp=False,
-        )
-        torch.cuda.synchronize()
-        torch.testing.assert_close(
-            packed_checkpoints,
-            reference_checkpoints,
-            atol=1e-2,
-            rtol=5e-3,
         )
 
 

--- a/tests/gdn/test_prefill_state_indices.py
+++ b/tests/gdn/test_prefill_state_indices.py
@@ -225,8 +225,8 @@ def test_prefill_state_indices_with_state_checkpoints(use_cp):
     """Indexed final-state I/O must not change packed checkpoint ordering."""
     _skip_if_not_sm90_or_sm100()
     device = torch.device("cuda")
-    if use_cp and get_compute_capability(device)[0] != 9:
-        pytest.skip("CP state checkpointing is implemented by the SM90 kernel")
+    if use_cp and get_compute_capability(device)[0] not in (9, 10):
+        pytest.skip("CP state checkpointing requires SM90 or SM100")
     H, D = 16, 128
     seq_lens = [128, 512]
     num_seqs = len(seq_lens)

--- a/tests/gdn/test_prefill_state_indices.py
+++ b/tests/gdn/test_prefill_state_indices.py
@@ -20,16 +20,17 @@ import torch
 import torch.nn.functional as F
 import pytest
 
-from flashinfer.utils import is_sm100a_supported
+from flashinfer.utils import get_compute_capability, is_sm100a_supported
 from flashinfer.gdn_prefill import chunk_gated_delta_rule
 
 
-def _skip_if_not_sm100():
+def _skip_if_not_sm90_or_sm100():
     device = torch.device("cuda")
-    if not is_sm100a_supported(device):
-        pytest.skip("state_indices GDN prefill path requires SM100/SM103 (Blackwell)")
+    major, _ = get_compute_capability(device)
+    if major not in (9, 10):
+        pytest.skip("state_indices GDN prefill path requires SM90 or SM100/SM103")
     cuda_major = int(torch.version.cuda.split(".")[0]) if torch.version.cuda else 0
-    if cuda_major < 13:
+    if is_sm100a_supported(device) and cuda_major < 13:
         pytest.skip(f"SM100 GDN prefill requires CUDA 13+, got {torch.version.cuda}")
 
 
@@ -63,7 +64,10 @@ def _make_inputs(seq_lens, H, D, dtype, device, seed):
     )
     g = torch.exp(g_log).contiguous()
     beta = torch.rand(total, H, dtype=torch.float32, device=device).contiguous()
-    init_state = torch.randn(num_seqs, H, D, D, dtype=dtype, device=device).contiguous()
+    state_dtype = torch.float32 if get_compute_capability(device)[0] == 9 else dtype
+    init_state = torch.randn(
+        num_seqs, H, D, D, dtype=state_dtype, device=device
+    ).contiguous()
     return q, k, v, g, beta, cu_seqlens, init_state
 
 
@@ -128,14 +132,14 @@ def _make_pool(init_state, perm, n_pool, pad, dtype, device):
     "seq_lens",
     [[128], [256], [128, 192, 64], [64, 512]],
 )
-@pytest.mark.parametrize("H", [16, 32])
+@pytest.mark.parametrize("H", [8, 16, 32])
 @pytest.mark.parametrize("pad", [0, 96])  # 0 = compact pool, 96 = non-compact
 @pytest.mark.parametrize("use_cp", [False, True])
 def test_prefill_state_indices_matches_packed(dtype, seq_lens, H, pad, use_cp):
     """A pool + state_indices in-place update must match the packed,
     sequence-ordered baseline bitwise (the kernel math is identical; only the
     addressed gmem row differs)."""
-    _skip_if_not_sm100()
+    _skip_if_not_sm90_or_sm100()
     device = torch.device("cuda")
     D = 128
     num_seqs = len(seq_lens)
@@ -144,7 +148,8 @@ def test_prefill_state_indices_matches_packed(dtype, seq_lens, H, pad, use_cp):
     )
 
     # (a) packed baseline, no state_indices
-    out_state_a = torch.empty(num_seqs, H, D, D, dtype=dtype, device=device)
+    state_dtype = init_state.dtype
+    out_state_a = torch.empty(num_seqs, H, D, D, dtype=state_dtype, device=device)
     output_a, final_a = _run(
         q,
         k,
@@ -163,7 +168,7 @@ def test_prefill_state_indices_matches_packed(dtype, seq_lens, H, pad, use_cp):
     n_pool = num_seqs + 5
     perm = [(i * 3 + 2) % n_pool for i in range(num_seqs)]
     assert len(set(perm)) == num_seqs  # distinct slots
-    pool = _make_pool(init_state, perm, n_pool, pad, dtype, device)
+    pool = _make_pool(init_state, perm, n_pool, pad, state_dtype, device)
     idx = torch.tensor(perm, dtype=torch.int32, device=device)
     output_b, _ = _run(q, k, v, g, beta, cu_seqlens, pool, pool, idx, use_cp)
     torch.cuda.synchronize()
@@ -182,7 +187,7 @@ def test_prefill_state_indices_requires_output_state_pool():
     """With state_indices set, output_state must be a caller-provided pool: an
     auto-allocated compact [num_seqs, ...] tensor would be indexed out of bounds
     by the pool slot ids, so output_state=None must be rejected."""
-    _skip_if_not_sm100()
+    _skip_if_not_sm90_or_sm100()
     device = torch.device("cuda")
     H, D = 16, 128
     seq_lens = [128, 64]
@@ -192,10 +197,10 @@ def test_prefill_state_indices_requires_output_state_pool():
     )
     n_pool = num_seqs + 3
     perm = list(range(num_seqs))
-    pool = _make_pool(init_state, perm, n_pool, 0, torch.bfloat16, device)
+    pool = _make_pool(init_state, perm, n_pool, 0, init_state.dtype, device)
     idx = torch.tensor(perm, dtype=torch.int32, device=device)
     out = torch.empty(sum(seq_lens), H, D, dtype=torch.bfloat16, device=device)
-    # On the supported SM100/SM103 path this must be the output_state ValueError,
+    # On supported SM90/SM100 paths this must be the output_state ValueError,
     # not NotImplementedError (which would mean the kernel was wrongly rejected).
     with pytest.raises(ValueError, match="explicit output_state pool"):
         chunk_gated_delta_rule(
@@ -216,9 +221,149 @@ def test_prefill_state_indices_requires_output_state_pool():
 
 
 @pytest.mark.parametrize("use_cp", [False, True])
+def test_prefill_state_indices_with_state_checkpoints(use_cp):
+    """Indexed final-state I/O must not change packed checkpoint ordering."""
+    _skip_if_not_sm90_or_sm100()
+    device = torch.device("cuda")
+    if use_cp and get_compute_capability(device)[0] != 9:
+        pytest.skip("CP state checkpointing is implemented by the SM90 kernel")
+    H, D = 16, 128
+    seq_lens = [128, 512]
+    num_seqs = len(seq_lens)
+    q, k, v, g, beta, cu_seqlens, init_state = _make_inputs(
+        seq_lens, H, D, torch.bfloat16, device, seed=3
+    )
+    checkpoint_every = 64
+    checkpoint_counts = [seq_len // checkpoint_every for seq_len in seq_lens]
+    checkpoint_cu_starts = torch.tensor(
+        [0, *torch.cumsum(torch.tensor(checkpoint_counts), 0).tolist()],
+        dtype=torch.int64,
+        device=device,
+    )
+    checkpoint_shape = (sum(checkpoint_counts), H, D, D)
+
+    packed_state = torch.empty_like(init_state)
+    packed_checkpoints = torch.empty(
+        checkpoint_shape, dtype=init_state.dtype, device=device
+    )
+    packed_output = torch.empty_like(q)
+    output_a, final_a = chunk_gated_delta_rule(
+        q,
+        k,
+        v,
+        g,
+        beta,
+        initial_state=init_state.clone(),
+        output_final_state=True,
+        cu_seqlens=cu_seqlens,
+        output=packed_output,
+        output_state=packed_state,
+        state_checkpoints=packed_checkpoints,
+        checkpoint_cu_starts=checkpoint_cu_starts,
+        checkpoint_every_n_tokens=checkpoint_every,
+        use_cp=use_cp,
+    )
+
+    n_pool = num_seqs + 4
+    slots = [4, 1]
+    pool = _make_pool(init_state, slots, n_pool, 96, init_state.dtype, device)
+    state_indices = torch.tensor(slots, dtype=torch.int32, device=device)
+    indexed_checkpoints = torch.empty_like(packed_checkpoints)
+    indexed_output = torch.empty_like(q)
+    output_b, final_b = chunk_gated_delta_rule(
+        q,
+        k,
+        v,
+        g,
+        beta,
+        initial_state=pool,
+        output_final_state=True,
+        cu_seqlens=cu_seqlens,
+        output=indexed_output,
+        output_state=pool,
+        state_checkpoints=indexed_checkpoints,
+        checkpoint_cu_starts=checkpoint_cu_starts,
+        checkpoint_every_n_tokens=checkpoint_every,
+        state_indices=state_indices,
+        use_cp=use_cp,
+    )
+    torch.cuda.synchronize()
+
+    assert torch.equal(output_a, output_b)
+    assert torch.equal(final_a, final_b[slots])
+    assert torch.equal(packed_checkpoints, indexed_checkpoints)
+    if use_cp:
+        reference_checkpoints = torch.empty_like(packed_checkpoints)
+        chunk_gated_delta_rule(
+            q,
+            k,
+            v,
+            g,
+            beta,
+            initial_state=init_state.clone(),
+            output_final_state=False,
+            cu_seqlens=cu_seqlens,
+            state_checkpoints=reference_checkpoints,
+            checkpoint_cu_starts=checkpoint_cu_starts,
+            checkpoint_every_n_tokens=checkpoint_every,
+            use_cp=False,
+        )
+        torch.cuda.synchronize()
+        torch.testing.assert_close(
+            packed_checkpoints,
+            reference_checkpoints,
+            atol=1e-2,
+            rtol=5e-3,
+        )
+
+
+@pytest.mark.parametrize("use_cp", [False, True])
+def test_prefill_state_indices_without_final_state(use_cp):
+    """A state pool can supply initial state without requesting a final state."""
+    _skip_if_not_sm90_or_sm100()
+    device = torch.device("cuda")
+    H, D = 16, 128
+    seq_lens = [64, 512]
+    q, k, v, g, beta, cu_seqlens, init_state = _make_inputs(
+        seq_lens, H, D, torch.bfloat16, device, seed=4
+    )
+
+    packed_output = chunk_gated_delta_rule(
+        q,
+        k,
+        v,
+        g,
+        beta,
+        initial_state=init_state,
+        output_final_state=False,
+        cu_seqlens=cu_seqlens,
+        use_cp=use_cp,
+    )
+
+    slots = [3, 0]
+    pool = _make_pool(init_state, slots, 5, 96, init_state.dtype, device)
+    state_indices = torch.tensor(slots, dtype=torch.int32, device=device)
+    indexed_output = chunk_gated_delta_rule(
+        q,
+        k,
+        v,
+        g,
+        beta,
+        initial_state=pool,
+        output_final_state=False,
+        cu_seqlens=cu_seqlens,
+        state_indices=state_indices,
+        use_cp=use_cp,
+    )
+    torch.cuda.synchronize()
+
+    assert torch.equal(packed_output, indexed_output)
+
+
+@pytest.mark.parametrize("use_cp", [False, True])
 def test_prefill_state_indices_none_is_default(use_cp):
     """state_indices=None must reproduce the packed path exactly (default)."""
-    _skip_if_not_sm100()
+    _skip_if_not_sm90_or_sm100()
     device = torch.device("cuda")
     H, D = 16, 128
     seq_lens = [128, 192]
@@ -226,9 +371,9 @@ def test_prefill_state_indices_none_is_default(use_cp):
     q, k, v, g, beta, cu_seqlens, init_state = _make_inputs(
         seq_lens, H, D, torch.bfloat16, device, seed=1
     )
-    s1 = torch.empty(num_seqs, H, D, D, dtype=torch.bfloat16, device=device)
+    s1 = torch.empty(num_seqs, H, D, D, dtype=init_state.dtype, device=device)
     o1, f1 = _run(q, k, v, g, beta, cu_seqlens, init_state.clone(), s1, None, use_cp)
-    s2 = torch.empty(num_seqs, H, D, D, dtype=torch.bfloat16, device=device)
+    s2 = torch.empty(num_seqs, H, D, D, dtype=init_state.dtype, device=device)
     o2, f2 = _run(q, k, v, g, beta, cu_seqlens, init_state.clone(), s2, None, use_cp)
     torch.cuda.synchronize()
     assert torch.equal(o1, o2)


### PR DESCRIPTION
## Summary

- add indexed pooled-state support to the SM90 and SM120 non-CP and CP GDN prefill paths
- add context-parallel state checkpointing on SM90, SM100, and SM120
- preserve padded state-pool first-dimension strides while requiring contiguous inner `[H, V, K]` layouts
- extend pooled-state and checkpoint correctness coverage across the supported architectures

## Why

The optimized GDN prefill implementations did not expose the same pooled-state and context-parallel checkpoint capabilities across SM90, SM100, and SM120. This change brings those architecture-specific paths to feature parity through the public dispatch.

## Validation

- SM120 RTX PRO 6000: `python -m pytest -q tests/gdn/test_prefill_state_indices.py tests/gdn/test_prefill_delta_rule.py::test_checkpoint_correctness -x` — 135 passed
- SM100 B200: the same focused suite — 135 passed
- pre-commit hooks passed for all changed files


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added optional state checkpoints during prefill, with configurable intervals and context-parallel support.
  - Added pooled/indexed state storage with custom layouts and strides.
  - Expanded supported data types for state, checkpoint, sequence-length, and index tensors.
  - Extended these capabilities across supported NVIDIA architectures.

- **Bug Fixes**
  - Improved handling of final states, checkpoint boundaries, and varied tensor layouts.
  - Added stronger validation for state shapes, dtypes, strides, and integer metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->