### PR TITLE
Add support for GDP prefill

### DIFF
--- a/flashinfer/__init__.py
+++ b/flashinfer/__init__.py
@@ -107,6 +107,7 @@ with contextlib.suppress(ImportError):
         B12xMoEWrapper as B12xMoEWrapper,
     )
     from .gdn_prefill import chunk_gated_delta_rule as chunk_gated_delta_rule
+    from .gdn_product import chunk_gated_delta_product as chunk_gated_delta_product
 from .gemm import SegmentGEMMWrapper as SegmentGEMMWrapper
 from .gemm import bmm_bf16 as bmm_bf16
 from .gemm import bmm_fp8 as bmm_fp8

--- a/flashinfer/gdn_product.py
+++ b/flashinfer/gdn_product.py
@@ -50,6 +50,10 @@ def chunk_gated_delta_product(
     output: Optional[torch.Tensor] = None,
     output_state: Optional[torch.Tensor] = None,
     state_indices: Optional[torch.Tensor] = None,
+    # expansion scratch -- required for cudagraph capture, else allocated here
+    expanded_q: Optional[torch.Tensor] = None,  # [T*n_h, num_q_heads,  D]
+    expanded_g: Optional[torch.Tensor] = None,  # [T*n_h, num_sab_heads]
+    expanded_output: Optional[torch.Tensor] = None,  # [T*n_h, num_o_heads,  D]
 ) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
     r"""Chunked Gated DeltaProduct attention for prefill.
 
@@ -122,40 +126,52 @@ def chunk_gated_delta_product(
             state_indices=state_indices,
         )
 
-    # -----------------------------------------------------------------------
-    # TODO(you): the expansion.
-    #
-    # Build the n_h-times-longer sequence, call chunk_gated_delta_rule on it,
-    # then slice back to one row per real token.
-    #
-    #   k, v      reshape [T, n_h, H, D] -> [T * n_h, H, D]
-    #   beta      reshape [T, n_h, H]    -> [T * n_h, H]
-    #   g         scatter: g_flat[0::n_h] = g, ELSE 1.0   (multiplicative!)
-    #   q         scatter: q_flat[n_h-1::n_h] = q, else anything (rows discarded)
-    #   cu_seqlens                       -> cu_seqlens * n_h
-    #
-    #   out_flat = chunk_gated_delta_rule(...)   # [T * n_h, num_o_heads, D]
-    #   out      = out_flat[n_h - 1 :: n_h]      # one row per real token
-    #
-    # Three things to get right, in rough order of how easy they are to miss:
-    #
-    #  * `output=` / `output_state=`. The caller's `output` buffer is sized for
-    #    T rows, but the kernel writes T * n_h. Allocate the expanded buffer
-    #    here and copy the strided slice into the caller's, or pass None and
-    #    copy afterwards. `output_state` is NOT expanded -- state shape is
-    #    independent of n_h -- so it can be forwarded unchanged.
-    #
-    #  * The strided slice `[n_h - 1 :: n_h]` is only valid because every
-    #    sequence's expanded length is a multiple of n_h, so every sequence
-    #    still starts at a multiple of n_h. That is what makes
-    #    `cu_seqlens * n_h` sufficient rather than needing per-sequence fixups.
-    #
-    #  * Zeroed q rows are safe (the in-kernel l2 norm has an eps), but the
-    #    rows are discarded anyway -- so replicating q is equally fine and
-    #    avoids depending on that eps.
-    #
-    # `tests/gdn/test_prefill_delta_product.py::test_reference_equals_expanded_
-    # delta_rule` already validates this exact expansion in pure torch. If the
-    # kernel disagrees, the fault is in the marshalling here, not the algebra.
-    # -----------------------------------------------------------------------
-    raise NotImplementedError("chunk_gated_delta_product: the n_h expansion")
+    # GDP = GDN with a sequence n_h times longer
+    k = torch.flatten(k, start_dim=0, end_dim=1)
+    v = torch.flatten(v, start_dim=0, end_dim=1)
+    if beta is not None:
+        beta = torch.flatten(beta, start_dim=0, end_dim=1)
+
+    if expanded_q is None:
+        expanded_q = torch.empty(
+            q.size(0) * num_householder, *q.shape[1:], dtype=q.dtype, device=q.device
+        )
+    expanded_q[::num_householder] = q
+
+    if g is not None:
+        if expanded_g is None:
+            expanded_g = torch.ones(
+                g.size(0) * num_householder,
+                *g.shape[1:],
+                dtype=g.dtype,
+                device=g.device,
+            )
+        expanded_g[::num_householder] = g
+    else:
+        expanded_g = None
+
+    if expanded_output is None:
+        expanded_output = torch.empty_like(expanded_q)
+
+    chunk_gated_delta_rule(
+        expanded_q,
+        k,
+        v,
+        expanded_g,
+        beta,
+        scale,
+        initial_state,
+        output_final_state,
+        cu_seqlens * num_householder,
+        use_qk_l2norm_in_kernel,
+        output=expanded_output,
+        output_state=output_state,
+        state_indices=state_indices,
+    )
+
+    if output is not None:
+        output[:] = expanded_output[::num_householder]
+        return output
+
+    else:
+        return expanded_output[::num_householder].clone()

--- a/flashinfer/gdn_product.py
+++ b/flashinfer/gdn_product.py
@@ -136,7 +136,7 @@ def chunk_gated_delta_product(
         expanded_q = torch.empty(
             q.size(0) * num_householder, *q.shape[1:], dtype=q.dtype, device=q.device
         )
-    expanded_q[::num_householder] = q
+    expanded_q[num_householder - 1 :: num_householder] = q
 
     if g is not None:
         if expanded_g is None:
@@ -146,14 +146,25 @@ def chunk_gated_delta_product(
                 dtype=g.dtype,
                 device=g.device,
             )
+        elif expanded_g.dtype != torch.float32:
+            raise ValueError(
+                f"expanded_g must be float32 (g/beta are always fp32 in this API, "
+                f"unlike q/k/v); got {expanded_g.dtype}"
+            )
         expanded_g[::num_householder] = g
     else:
         expanded_g = None
 
     if expanded_output is None:
-        expanded_output = torch.empty_like(expanded_q)
+        expanded_output = torch.empty(
+            expanded_q.size(0),
+            max(q.size(1), v.size(1)),
+            q.size(2),
+            dtype=q.dtype,
+            device=q.device,
+        )
 
-    chunk_gated_delta_rule(
+    _, output_state = chunk_gated_delta_rule(
         expanded_q,
         k,
         v,
@@ -170,8 +181,8 @@ def chunk_gated_delta_product(
     )
 
     if output is not None:
-        output[:] = expanded_output[::num_householder]
-        return output
+        output[:] = expanded_output[num_householder - 1 :: num_householder]
+        return output, output_state
 
     else:
-        return expanded_output[::num_householder].clone()
+        return expanded_output[::num_householder].clone(), output_state

--- a/flashinfer/gdn_product.py
+++ b/flashinfer/gdn_product.py
@@ -172,7 +172,7 @@ def chunk_gated_delta_product(
         beta,
         scale,
         initial_state,
-        output_final_state,
+        True,
         cu_seqlens * num_householder,
         use_qk_l2norm_in_kernel,
         output=expanded_output,
@@ -182,7 +182,10 @@ def chunk_gated_delta_product(
 
     if output is not None:
         output[:] = expanded_output[num_householder - 1 :: num_householder]
-        return output, output_state
-
     else:
-        return expanded_output[::num_householder].clone(), output_state
+        output = expanded_output[::num_householder].clone()
+
+    if output_final_state:
+        return output, output_state
+    else:
+        return output

--- a/flashinfer/gdn_product.py
+++ b/flashinfer/gdn_product.py
@@ -14,17 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 Gated DeltaProduct (arXiv:2502.10297) -- API layer.
-
-DeltaProduct takes ``num_householder`` delta-rule steps per token instead of one:
-
-    A(x_i) = alpha_i * prod_{j=1..n_h} (I - beta_{i,j} k_{i,j} k_{i,j}^T)
-
-Phase 1 implements this as a host-side expansion over the existing GDN kernels:
-GDP is GDN run on a sequence ``n_h`` times longer, with the decay neutralised on
-all but the first micro-step of each token and the query read only from the last.
-No new kernel is required for correctness.
-
-The recurrent state is UNCHANGED in size -- ``n_h`` costs FLOPs, not bytes.
 """
 
 from __future__ import annotations
@@ -82,12 +71,34 @@ def chunk_gated_delta_product(
     initial_state, output_state, state_indices, cu_seqlens, ...
         As in ``chunk_gated_delta_rule``. Note the state shape does NOT depend
         on ``num_householder``.
+    expanded_q : torch.Tensor, optional
+        Scratch for the expanded query,
+        ``[total_seq_len * num_householder, num_q_heads, head_size]``, dtype of
+        ``q``.
+    expanded_g : torch.Tensor, optional
+        Scratch for the expanded gate,
+        ``[total_seq_len * num_householder, num_sab_heads]``. **Must be
+        float32** -- ``g`` and ``beta`` are always fp32 in this API even when
+        ``q``/``k``/``v`` are fp16/bf16, and a strided assignment into a
+        half-precision buffer downcasts silently.
+        Must be pre-filled with ``1.0``: only rows ``[0 :: n_h]`` are written
+        (the per-token gate), and the remaining micro-steps rely on the
+        multiplicative neutral value already being in place.
+    expanded_output : torch.Tensor, optional
+        Scratch for the kernel's output,
+        ``[total_seq_len * num_householder, num_o_heads, head_size]`` where
+        ``num_o_heads = max(num_q_heads, num_v_heads)``. Note this is **not**
+        ``num_q_heads`` -- under GVA the output is wider than the query.
+        Takes ``output``'s dtype when ``output`` is supplied, else ``q``'s, so
+        the final strided copy never silently casts.
 
     Returns
     -------
     Same contract as ``chunk_gated_delta_rule``: ``output`` when
     ``output_final_state`` is False, else ``(output, final_state)``. ``output``
     has one row per REAL token, ``[total_seq_len, num_o_heads, head_size]``.
+    When ``output`` is supplied it is written in place and returned; otherwise
+    a freshly allocated tensor is returned.
     """
     if k.dim() != 4 or v.dim() != 4:
         raise ValueError(
@@ -136,9 +147,22 @@ def chunk_gated_delta_product(
         expanded_q = torch.empty(
             q.size(0) * num_householder, *q.shape[1:], dtype=q.dtype, device=q.device
         )
+    elif expanded_q.shape != (q.size(0) * num_householder, *q.shape[1:]):
+        raise ValueError("expanded_q shape must be [T*n_h, num_q_heads,  D]")
+    elif expanded_q.dtype != q.dtype:
+        raise ValueError(
+            f"expanded_q.dtype and q.dtype must match, got {expanded_q.dtype} != {q.dtype}"
+        )
+
     expanded_q[num_householder - 1 :: num_householder] = q
 
     if g is not None:
+        if g.dtype != torch.float32:
+            raise ValueError(
+                f"g must be float32 (g/beta are always fp32 in this API, "
+                f"unlike q/k/v); got {g.dtype}"
+            )
+
         if expanded_g is None:
             expanded_g = torch.ones(
                 g.size(0) * num_householder,
@@ -146,6 +170,8 @@ def chunk_gated_delta_product(
                 dtype=g.dtype,
                 device=g.device,
             )
+        elif expanded_g.shape != (g.size(0) * num_householder, *g.shape[1:]):
+            raise ValueError("expanded_g shape must be [T*n_h, num_sab_heads]")
         elif expanded_g.dtype != torch.float32:
             raise ValueError(
                 f"expanded_g must be float32 (g/beta are always fp32 in this API, "
@@ -160,11 +186,17 @@ def chunk_gated_delta_product(
             expanded_q.size(0),
             max(q.size(1), v.size(1)),
             q.size(2),
-            dtype=q.dtype,
-            device=q.device,
+            dtype=output.dtype if output is not None else q.dtype,
+            device=output.device if output is not None else q.device,
         )
+    elif expanded_output.shape != (
+        expanded_q.size(0),
+        max(q.size(1), v.size(1)),
+        q.size(2),
+    ):
+        raise ValueError("expanded_output shape must be [T*n_h, num_o_heads,  D]")
 
-    _, output_state = chunk_gated_delta_rule(
+    out = chunk_gated_delta_rule(
         expanded_q,
         k,
         v,
@@ -172,7 +204,7 @@ def chunk_gated_delta_product(
         beta,
         scale,
         initial_state,
-        True,
+        output_final_state,
         cu_seqlens * num_householder,
         use_qk_l2norm_in_kernel,
         output=expanded_output,
@@ -183,9 +215,9 @@ def chunk_gated_delta_product(
     if output is not None:
         output[:] = expanded_output[num_householder - 1 :: num_householder]
     else:
-        output = expanded_output[::num_householder].clone()
+        output = expanded_output[num_householder - 1 :: num_householder].clone()
 
     if output_final_state:
-        return output, output_state
+        return output, out[-1]
     else:
         return output

--- a/flashinfer/gdn_product.py
+++ b/flashinfer/gdn_product.py
@@ -1,0 +1,161 @@
+"""
+Copyright (c) 2025 by FlashInfer team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Gated DeltaProduct (arXiv:2502.10297) -- API layer.
+
+DeltaProduct takes ``num_householder`` delta-rule steps per token instead of one:
+
+    A(x_i) = alpha_i * prod_{j=1..n_h} (I - beta_{i,j} k_{i,j} k_{i,j}^T)
+
+Phase 1 implements this as a host-side expansion over the existing GDN kernels:
+GDP is GDN run on a sequence ``n_h`` times longer, with the decay neutralised on
+all but the first micro-step of each token and the query read only from the last.
+No new kernel is required for correctness.
+
+The recurrent state is UNCHANGED in size -- ``n_h`` costs FLOPs, not bytes.
+"""
+
+from __future__ import annotations
+
+from typing import Optional, Tuple, Union
+
+import torch
+
+from .gdn_prefill import chunk_gated_delta_rule
+
+
+def chunk_gated_delta_product(
+    q: torch.Tensor,  # [total_seq_len,      num_q_heads, head_size]
+    k: torch.Tensor,  # [total_seq_len, n_h, num_k_heads, head_size]
+    v: torch.Tensor,  # [total_seq_len, n_h, num_v_heads, head_size]
+    g: Optional[torch.Tensor] = None,  # [total_seq_len,      num_sab_heads]
+    beta: Optional[torch.Tensor] = None,  # [total_seq_len, n_h, num_sab_heads]
+    scale: Optional[float] = None,
+    initial_state: Optional[torch.Tensor] = None,
+    output_final_state: bool = False,
+    cu_seqlens: Optional[torch.Tensor] = None,
+    use_qk_l2norm_in_kernel: bool = False,
+    output: Optional[torch.Tensor] = None,
+    output_state: Optional[torch.Tensor] = None,
+    state_indices: Optional[torch.Tensor] = None,
+) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
+    r"""Chunked Gated DeltaProduct attention for prefill.
+
+    Mirrors :func:`flashinfer.gdn_prefill.chunk_gated_delta_rule`, with a
+    householder axis added to ``k``, ``v`` and ``beta``. At ``n_h == 1`` this
+    delegates straight through and is bit-identical to the GDN entry point.
+
+    Parameters
+    ----------
+    q : torch.Tensor
+        Queries, ``[total_seq_len, num_q_heads, head_size]``. **One per real
+        token** -- the query axis is not expanded.
+    k, v : torch.Tensor
+        Keys/values, ``[total_seq_len, num_householder, num_*_heads, head_size]``.
+        The householder axis sits immediately after the token axis so that
+        ``reshape(total_seq_len * n_h, ...)`` yields the ``(t n) h d`` ordering
+        the expansion needs.
+    g : torch.Tensor, optional
+        Forget gate (alpha), ``[total_seq_len, num_sab_heads]``. **One per real
+        token** -- the gate models time passing, while the ``n_h`` householders
+        are all the same time step. MULTIPLICATIVE, neutral value ``1.0``
+        (not the log-space decay FLA uses, whose neutral value is ``0.0``).
+    beta : torch.Tensor, optional
+        Update gate, ``[total_seq_len, num_householder, num_sab_heads]`` -- one
+        per (token, householder).
+    initial_state, output_state, state_indices, cu_seqlens, ...
+        As in ``chunk_gated_delta_rule``. Note the state shape does NOT depend
+        on ``num_householder``.
+
+    Returns
+    -------
+    Same contract as ``chunk_gated_delta_rule``: ``output`` when
+    ``output_final_state`` is False, else ``(output, final_state)``. ``output``
+    has one row per REAL token, ``[total_seq_len, num_o_heads, head_size]``.
+    """
+    if k.dim() != 4 or v.dim() != 4:
+        raise ValueError(
+            f"k/v must carry a householder axis [T, n_h, H, D]; "
+            f"got k.shape={tuple(k.shape)}, v.shape={tuple(v.shape)}"
+        )
+    num_householder = k.size(1)
+    if v.size(1) != num_householder:
+        raise ValueError(
+            f"k/v householder counts differ: {num_householder} vs {v.size(1)}"
+        )
+    if beta is not None and beta.dim() == 3 and beta.size(1) != num_householder:
+        raise ValueError(f"beta householder count {beta.size(1)} != {num_householder}")
+    if g is not None and g.dim() != 2:
+        raise ValueError(
+            f"g is one gate per REAL token, expected [T, H]; got {tuple(g.shape)}"
+        )
+    if cu_seqlens is None:
+        raise ValueError("cu_seqlens is required (varlen mode), as for GDN")
+
+    # n_h == 1 is plain GDN. Delegate so this path stays bit-identical.
+    if num_householder == 1:
+        return chunk_gated_delta_rule(
+            q,
+            k.squeeze(1),
+            v.squeeze(1),
+            g,
+            beta.squeeze(1) if beta is not None else None,
+            scale,
+            initial_state,
+            output_final_state,
+            cu_seqlens,
+            use_qk_l2norm_in_kernel,
+            output=output,
+            output_state=output_state,
+            state_indices=state_indices,
+        )
+
+    # -----------------------------------------------------------------------
+    # TODO(you): the expansion.
+    #
+    # Build the n_h-times-longer sequence, call chunk_gated_delta_rule on it,
+    # then slice back to one row per real token.
+    #
+    #   k, v      reshape [T, n_h, H, D] -> [T * n_h, H, D]
+    #   beta      reshape [T, n_h, H]    -> [T * n_h, H]
+    #   g         scatter: g_flat[0::n_h] = g, ELSE 1.0   (multiplicative!)
+    #   q         scatter: q_flat[n_h-1::n_h] = q, else anything (rows discarded)
+    #   cu_seqlens                       -> cu_seqlens * n_h
+    #
+    #   out_flat = chunk_gated_delta_rule(...)   # [T * n_h, num_o_heads, D]
+    #   out      = out_flat[n_h - 1 :: n_h]      # one row per real token
+    #
+    # Three things to get right, in rough order of how easy they are to miss:
+    #
+    #  * `output=` / `output_state=`. The caller's `output` buffer is sized for
+    #    T rows, but the kernel writes T * n_h. Allocate the expanded buffer
+    #    here and copy the strided slice into the caller's, or pass None and
+    #    copy afterwards. `output_state` is NOT expanded -- state shape is
+    #    independent of n_h -- so it can be forwarded unchanged.
+    #
+    #  * The strided slice `[n_h - 1 :: n_h]` is only valid because every
+    #    sequence's expanded length is a multiple of n_h, so every sequence
+    #    still starts at a multiple of n_h. That is what makes
+    #    `cu_seqlens * n_h` sufficient rather than needing per-sequence fixups.
+    #
+    #  * Zeroed q rows are safe (the in-kernel l2 norm has an eps), but the
+    #    rows are discarded anyway -- so replicating q is equally fine and
+    #    avoids depending on that eps.
+    #
+    # `tests/gdn/test_prefill_delta_product.py::test_reference_equals_expanded_
+    # delta_rule` already validates this exact expansion in pure torch. If the
+    # kernel disagrees, the fault is in the marshalling here, not the algebra.
+    # -----------------------------------------------------------------------
+    raise NotImplementedError("chunk_gated_delta_product: the n_h expansion")

--- a/tests/gdn/reference_delta_product.py
+++ b/tests/gdn/reference_delta_product.py
@@ -1,0 +1,150 @@
+"""
+Copyright (c) 2025 by FlashInfer team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Reference implementation of Gated DeltaProduct (arXiv:2502.10297).
+
+DeltaProduct takes ``num_householder`` delta-rule steps per token instead of one,
+giving a state transition of rank up to ``num_householder``:
+
+    A(x_i) = alpha_i * prod_{j=1..n_h} (I - beta_{i,j} k_{i,j} k_{i,j}^T)
+
+The gate ``alpha`` fires ONCE per real token; ``beta``/``k``/``v`` are per
+(token, householder). At ``num_householder == 1`` this must reduce exactly to
+``reference_delta_rule.delta_rule``.
+
+Layout note: the householder axis sits immediately after the token axis, so
+``x.reshape(total_seq_len * n_h, H, D)`` yields the ``(t n) h d`` ordering the
+kernel wrappers expand into.
+"""
+
+from __future__ import annotations
+
+import torch
+
+from .reference_delta_rule import exclusive_cumsum, matmul
+
+
+def delta_product(
+    q: torch.Tensor,  # [total_seq_len,      num_q_heads, head_size]
+    k: torch.Tensor,  # [total_seq_len, n_h, num_k_heads, head_size]
+    v: torch.Tensor,  # [total_seq_len, n_h, num_v_heads, head_size]
+    seq_lens: list[int],
+    *,
+    alpha: torch.Tensor | None = None,  # [total_seq_len,      num_sab_heads]
+    beta: torch.Tensor | None = None,  # [total_seq_len, n_h, num_sab_heads]
+    scale_factor: float = 1.0,
+    state_dtype: torch.dtype = torch.float32,
+):
+    """Returns (output, final_state).
+
+    output      [total_seq_len, num_o_heads, head_size]   -- one row per REAL token
+    final_state [num_seqs, num_sab_heads, head_size, head_size]   (K-major, [.., K, V])
+    """
+    assert k.dim() == 4 and v.dim() == 4, (
+        "k/v must have a householder axis: [T, n_h, H, D]"
+    )
+    n_h = k.size(1)
+    assert v.size(1) == n_h, (
+        f"k/v num_householders must match, got {n_h} != {v.size(1)}"
+    )
+
+    total_seqlen = q.size(0)
+    num_q_heads = q.size(1)
+    num_k_heads = k.size(2)
+    num_v_heads = v.size(2)
+    num_sab_heads = max(num_q_heads, num_v_heads)
+    head_size = k.size(3)
+
+    if alpha is None:
+        # same alpha for all householders for each real token
+        alpha = torch.ones(
+            total_seqlen, num_sab_heads, dtype=torch.float32, device=q.device
+        )
+    if beta is None:
+        # beta is per-householder
+        beta = torch.ones(
+            total_seqlen, n_h, num_sab_heads, dtype=torch.float32, device=q.device
+        )
+
+    # Broadcast heads exactly as reference_delta_rule does, but k/v have the
+    # extra householder axis at dim 1, so head expansion happens at dim 2.
+    if num_q_heads > num_v_heads:  # GQA
+        k = k.repeat_interleave(num_q_heads // num_k_heads, dim=2)
+        v = v.repeat_interleave(num_q_heads // num_v_heads, dim=2)
+    else:  # GVA
+        q = q.repeat_interleave(num_v_heads // num_q_heads, dim=1)
+        k = k.repeat_interleave(num_v_heads // num_k_heads, dim=2)
+    num_state_heads = q.size(1)
+
+    o = []
+    kv = []
+    seq_offset = exclusive_cumsum(seq_lens)
+    for seq_idx, seq_start in enumerate(seq_offset[:-1]):
+        seq_end = seq_offset[seq_idx + 1]
+        seq_len = seq_end - seq_start
+        s = slice(seq_start, seq_end)
+
+        qs, ks, vs = q[s], k[s], v[s]
+        alphas, betas = alpha[s], beta[s]
+
+        # state size remains fixed between GDN and GDP
+        state_HKV = torch.zeros(
+            num_state_heads, head_size, head_size, dtype=state_dtype, device=q.device
+        )
+
+        for i in range(seq_len):
+            alpha_H11 = alphas[i].unsqueeze(1).unsqueeze(2)
+            q_H1Q = qs[i].unsqueeze(1)
+
+            # apply alpha gating ONCE per real token
+            old_state_HKV = alpha_H11 * state_HKV.to(torch.float32)
+            for j in range(n_h):
+                k_H1K = ks[i, j].unsqueeze(1)
+                v_H1V = vs[i, j].unsqueeze(1)
+                beta_H11 = betas[i, j].unsqueeze(1).unsqueeze(2)
+
+                old_v_H1V = matmul(k_H1K, old_state_HKV)
+                new_v_H1V = beta_H11 * v_H1V + (1 - beta_H11) * old_v_H1V
+                state_remove = torch.einsum("htv,htk->hkv", old_v_H1V, k_H1K)
+                state_update = torch.einsum("htv,htk->hkv", new_v_H1V, k_H1K)
+                old_state_HKV = old_state_HKV - state_remove + state_update
+
+            state_HKV[:] = old_state_HKV.to(state_dtype)
+            o_H1V = scale_factor * matmul(q_H1Q, state_HKV.to(torch.float32))
+            o.append(o_H1V.squeeze(1))
+
+        kv.append(state_HKV.clone())
+
+    return torch.stack(o), torch.stack(kv)
+
+
+def expand_to_flat_sequence(
+    k: torch.Tensor,  # [T, n_h, H, D]
+    v: torch.Tensor,  # [T, n_h, H, D]
+    alpha: torch.Tensor | None,  # [T, H]
+    beta: torch.Tensor | None,  # [T, n_h, H]
+    q: torch.Tensor,  # [T, H, D]
+    cu_seqlens: torch.Tensor,
+):
+    """The Phase-1 expansion: GDP as GDN on a sequence n_h times longer.
+
+    Returns (q, k, v, alpha, beta, cu_seqlens) all on the expanded token axis,
+    ready to hand to ``chunk_gated_delta_rule``. Slice the result with
+    ``out[n_h - 1 :: n_h]`` to recover one row per real token.
+
+    NOTE: flashinfer's ``g`` is MULTIPLICATIVE alpha (neutral value 1.0), not the
+    log-space decay FLA uses (neutral value 0.0).
+    """
+    raise NotImplementedError("step 2 -- write this when you add the wrapper")

--- a/tests/gdn/reference_delta_product.py
+++ b/tests/gdn/reference_delta_product.py
@@ -15,15 +15,6 @@ limitations under the License.
 
 Reference implementation of Gated DeltaProduct (arXiv:2502.10297).
 
-DeltaProduct takes ``num_householder`` delta-rule steps per token instead of one,
-giving a state transition of rank up to ``num_householder``:
-
-    A(x_i) = alpha_i * prod_{j=1..n_h} (I - beta_{i,j} k_{i,j} k_{i,j}^T)
-
-The gate ``alpha`` fires ONCE per real token; ``beta``/``k``/``v`` are per
-(token, householder). At ``num_householder == 1`` this must reduce exactly to
-``reference_delta_rule.delta_rule``.
-
 Layout note: the householder axis sits immediately after the token axis, so
 ``x.reshape(total_seq_len * n_h, H, D)`` yields the ``(t n) h d`` ordering the
 kernel wrappers expand into.

--- a/tests/gdn/reference_delta_rule.py
+++ b/tests/gdn/reference_delta_rule.py
@@ -284,9 +284,11 @@ def delta_rule(
     if num_q_heads > num_v_heads:  # GQA
         k = k.repeat_interleave(num_q_heads // num_k_heads, dim=1)
         v = v.repeat_interleave(num_q_heads // num_v_heads, dim=1)
+        num_qkv_heads = num_q_heads
     else:  # GVA
         q = q.repeat_interleave(num_v_heads // num_q_heads, dim=1)
         k = k.repeat_interleave(num_v_heads // num_k_heads, dim=1)
+        num_qkv_heads = num_v_heads
 
     seq_offset = exclusive_cumsum(seq_lens)
     for seq_idx, seq_start in enumerate(seq_offset[:-1]):
@@ -302,7 +304,7 @@ def delta_rule(
         betas = beta[s]
 
         state_HKV = torch.zeros(
-            num_q_heads, head_size, head_size, dtype=state_dtype, device=q.device
+            num_qkv_heads, head_size, head_size, dtype=state_dtype, device=q.device
         )
         for i in range(seq_len):
             # var_DS where var is variable basename and DS is the dimensional semantics.

--- a/tests/gdn/test_prefill_delta_product.py
+++ b/tests/gdn/test_prefill_delta_product.py
@@ -1,0 +1,286 @@
+"""
+Copyright (c) 2025 by FlashInfer team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from __future__ import annotations
+
+import random
+
+import pytest
+import torch
+
+from flashinfer.gdn_prefill import chunk_gated_delta_rule
+from flashinfer.utils import (
+    is_sm90a_supported,
+    is_sm100a_supported,
+    is_sm12x_supported,
+)
+
+from .reference_delta_product import delta_product
+from .reference_delta_rule import delta_rule, exclusive_cumsum
+
+
+def _skip_if_unsupported():
+    """Mirror of test_prefill_delta_rule._skip_if_unsupported."""
+    device = torch.device("cuda")
+    if is_sm100a_supported(device):
+        cuda_major = int(torch.version.cuda.split(".")[0]) if torch.version.cuda else 0
+        if cuda_major < 13:
+            pytest.skip(
+                f"SM100 GDN prefill requires CUDA 13+, got {torch.version.cuda}"
+            )
+        return
+    if is_sm90a_supported(device) or is_sm12x_supported(device):
+        return
+    pytest.skip("GDN prefill requires SM90, SM100, or SM12x")
+
+
+def _gen_product_inputs(
+    seq_lens,
+    num_householder,
+    num_q_heads,
+    num_k_heads,
+    num_v_heads,
+    head_size,
+    dtype,
+    qkv_factory,
+    device,
+):
+    """Build q/k/v/alpha/beta with a householder axis at dim 1 of k and v.
+
+    Reuses ``conftest.gen_qkv`` by generating n_h times as many k/v rows and
+    folding the extra rows into the householder axis -- so the element
+    distribution matches the existing GDN tests exactly.
+    """
+    total_seqlen = sum(seq_lens)
+    num_sab_heads = max(num_q_heads, num_v_heads)
+
+    with device:
+        # one q per real token; n_h keys/values per real token
+        q, _, _ = qkv_factory(
+            seq_lens, num_q_heads, num_k_heads, num_v_heads, head_size, dtype
+        )
+        _, k, v = qkv_factory(
+            [s * num_householder for s in seq_lens],
+            num_q_heads,
+            num_k_heads,
+            num_v_heads,
+            head_size,
+            dtype,
+        )
+        k = k.reshape(total_seqlen, num_householder, num_k_heads, head_size)
+        v = v.reshape(total_seqlen, num_householder, num_v_heads, head_size)
+        # l2 norm k to avoid numerical instability (as the GDN tests do)
+        k = torch.nn.functional.normalize(k, p=2.0, dim=-1)
+
+        alpha = torch.rand(total_seqlen, num_sab_heads)
+        beta = torch.rand(total_seqlen, num_householder, num_sab_heads)
+        cu_seqlens = torch.tensor(exclusive_cumsum(seq_lens), dtype=torch.int64)
+
+    return q, k, v, alpha, beta, cu_seqlens
+
+
+@pytest.mark.parametrize(
+    "seq_lens",
+    [[64], [128], [64, 128, 512]],
+    ids=lambda seqlens: "seq_lens=" + ",".join(map(str, seqlens)),
+)
+@pytest.mark.parametrize("head_size", [128], ids=lambda hs: f"head_size={hs}")
+@pytest.mark.parametrize(
+    "num_heads",
+    [(8, 8, 8), (8, 8, 16)],
+    ids=lambda qkv: "num_heads={0}/{1}/{2}".format(*qkv),
+)  # (q, k, v) -- GVA
+@pytest.mark.parametrize("dtype", ["float16", "bfloat16"])
+def test_reference_nh1_equals_delta_rule(
+    qkv_factory, seq_lens, head_size, num_heads, dtype, seed=0
+):
+    """At n_h == 1, DeltaProduct IS DeltaNet. Exact equality -- same fp ops, same order."""
+    random.seed(seed)
+    torch.random.manual_seed(seed)
+    torch.cuda.manual_seed(seed)
+
+    num_q_heads, num_k_heads, num_v_heads = num_heads
+    device = torch.device("cuda")
+    dtype = getattr(torch, dtype)
+
+    q, k, v, alpha, beta, _ = _gen_product_inputs(
+        seq_lens,
+        1,
+        num_q_heads,
+        num_k_heads,
+        num_v_heads,
+        head_size,
+        dtype,
+        qkv_factory,
+        device,
+    )
+
+    prod_o, prod_state = delta_product(
+        q.float(),
+        k.float(),
+        v.float(),
+        seq_lens,
+        alpha=alpha,
+        beta=beta,
+        scale_factor=1.0,
+    )
+    rule_o, rule_state = delta_rule(
+        q.float(),
+        k.squeeze(1).float(),
+        v.squeeze(1).float(),
+        seq_lens,
+        alpha=alpha,
+        beta=beta.squeeze(1),
+        scale_factor=1.0,
+    )
+
+    torch.testing.assert_close(prod_o, rule_o, atol=0, rtol=0)
+    torch.testing.assert_close(prod_state, rule_state, atol=0, rtol=0)
+
+
+@pytest.mark.parametrize("seq_lens", [[64], [256], [64, 128, 512]])
+@pytest.mark.parametrize("head_size", [128])
+@pytest.mark.parametrize("num_heads", [(8, 8, 8), (8, 8, 16)])
+@pytest.mark.parametrize("dtype", ["float16", "bfloat16"])
+def test_reference_nh1_matches_kernel(
+    qkv_factory, seq_lens, head_size, num_heads, dtype, seed=0
+):
+    _skip_if_unsupported()
+    random.seed(seed)
+    torch.random.manual_seed(seed)
+    torch.cuda.manual_seed(seed)
+
+    num_q_heads, num_k_heads, num_v_heads = num_heads
+    num_o_heads = num_sab_heads = max(num_q_heads, num_v_heads)
+    num_seqs, total_seqlen = len(seq_lens), sum(seq_lens)
+    device = torch.device("cuda")
+    dtype = getattr(torch, dtype)
+
+    q, k, v, alpha, beta, cu_seqlens = _gen_product_inputs(
+        seq_lens,
+        1,
+        num_q_heads,
+        num_k_heads,
+        num_v_heads,
+        head_size,
+        dtype,
+        qkv_factory,
+        device,
+    )
+
+    our_o = torch.full(
+        (total_seqlen, num_o_heads, head_size),
+        float("nan"),
+        dtype=q.dtype,
+        device=device,
+    )
+    our_state = torch.full(
+        (num_seqs, num_sab_heads, head_size, head_size),
+        float("nan"),
+        dtype=torch.float32,
+        device=device,
+    )
+    chunk_gated_delta_rule(
+        q,
+        k.squeeze(1),
+        v.squeeze(1),
+        alpha,
+        beta.squeeze(1),
+        1.0,  # scale
+        None,  # initial_state
+        True,  # output_final_state
+        cu_seqlens,
+        True,  # use_qk_l2norm_in_kernel
+        output=our_o,
+        output_state=our_state,
+    )
+    torch.cuda.synchronize()
+    our_state = our_state.transpose(
+        -1, -2
+    )  # kernel is [.., V, K]; reference is [.., K, V]
+
+    ref_o, ref_state = delta_product(
+        q.float(),
+        k.float(),
+        v.float(),
+        seq_lens,
+        alpha=alpha,
+        beta=beta,
+        scale_factor=1.0,
+    )
+
+    if dtype == torch.bfloat16:
+        atol_o, rtol_o, atol_kv, rtol_kv = 1e-2, 1e-2, 5e-3, 1e-3
+    else:
+        atol_o, rtol_o, atol_kv, rtol_kv = 2e-3, 1e-3, 1e-3, 1e-4
+
+    torch.testing.assert_close(our_o, ref_o.to(q.dtype), atol=atol_o, rtol=rtol_o)
+    torch.testing.assert_close(our_state, ref_state, atol=atol_kv, rtol=rtol_kv)
+
+
+@pytest.mark.parametrize("num_householder", [1, 2, 3, 4])
+@pytest.mark.parametrize("seq_lens", [[128], [64, 128, 512]])
+@pytest.mark.parametrize("num_heads", [(8, 8, 8), (8, 8, 16)])
+def test_reference_equals_expanded_delta_rule(
+    qkv_factory, num_householder, seq_lens, num_heads, seed=0
+):
+    """GDP is GDN on a sequence n_h times longer.
+
+    Gate on the first micro-step of each token (neutral value 1.0 -- alpha here
+    is multiplicative, not log-space), query only on the last, then read every
+    n_h-th output row.
+    """
+    random.seed(seed)
+    torch.random.manual_seed(seed)
+    torch.cuda.manual_seed(seed)
+
+    num_q_heads, num_k_heads, num_v_heads = num_heads
+    num_sab_heads = max(num_q_heads, num_v_heads)
+    head_size, n_h = 128, num_householder
+    total_seqlen = sum(seq_lens)
+    device = torch.device("cuda")
+
+    q, k, v, alpha, beta, _ = _gen_product_inputs(
+        seq_lens,
+        n_h,
+        num_q_heads,
+        num_k_heads,
+        num_v_heads,
+        head_size,
+        torch.float16,
+        qkv_factory,
+        device,
+    )
+    q, k, v = q.float(), k.float(), v.float()
+
+    prod_o, prod_state = delta_product(q, k, v, seq_lens, alpha=alpha, beta=beta)
+
+    with device:
+        alpha_flat = torch.ones(total_seqlen * n_h, num_sab_heads)
+        alpha_flat[0::n_h] = alpha
+        q_flat = torch.zeros(total_seqlen * n_h, num_q_heads, head_size)
+        q_flat[n_h - 1 :: n_h] = q
+    rule_o, rule_state = delta_rule(
+        q_flat,
+        k.reshape(total_seqlen * n_h, num_k_heads, head_size),
+        v.reshape(total_seqlen * n_h, num_v_heads, head_size),
+        [s * n_h for s in seq_lens],
+        alpha=alpha_flat,
+        beta=beta.reshape(total_seqlen * n_h, num_sab_heads),
+    )
+
+    torch.testing.assert_close(prod_o, rule_o[n_h - 1 :: n_h], atol=1e-5, rtol=1e-5)
+    torch.testing.assert_close(prod_state, rule_state, atol=1e-5, rtol=1e-5)

--- a/tests/gdn/test_prefill_delta_product.py
+++ b/tests/gdn/test_prefill_delta_product.py
@@ -398,3 +398,115 @@ def test_prefill_kernel_matches_reference(
 
     torch.testing.assert_close(our_o, ref_o.to(q.dtype), atol=atol_o, rtol=rtol_o)
     torch.testing.assert_close(our_state, ref_state, atol=atol_kv, rtol=rtol_kv)
+
+
+# --------------------------------------------------------------------------
+# The four (pass_output x output_final_state) combinations. Every other test
+# passes output= and output_final_state=True, which leaves the wrapper's
+# allocate-and-return path and its no-state path completely unexercised --
+# and those are exactly where a wrong strided gather or a hardcoded
+# output_final_state can hide.
+# --------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "pass_output", [True, False], ids=["output=buf", "output=None"]
+)
+@pytest.mark.parametrize(
+    "output_final_state", [True, False], ids=["final_state", "no_final_state"]
+)
+@pytest.mark.parametrize(
+    "num_householder", [1, 3], ids=lambda nh: f"num_householder={nh}"
+)
+@pytest.mark.parametrize(
+    "num_heads",
+    [(8, 8, 8), (8, 8, 16)],
+    ids=lambda qkv: "num_heads={0}/{1}/{2}".format(*qkv),
+)
+def test_prefill_kernel_output_conventions(
+    qkv_factory, pass_output, output_final_state, num_householder, num_heads, seed=0
+):
+    """Return contract and output rows must not depend on how they're requested."""
+    _skip_if_unsupported()
+    random.seed(seed)
+    torch.random.manual_seed(seed)
+    torch.cuda.manual_seed(seed)
+
+    num_q_heads, num_k_heads, num_v_heads = num_heads
+    num_o_heads = num_sab_heads = max(num_q_heads, num_v_heads)
+    seq_lens = [64, 128, 512]
+    head_size, n_h = 128, num_householder
+    num_seqs, total_seqlen = len(seq_lens), sum(seq_lens)
+    device = torch.device("cuda")
+    dtype = torch.float16
+
+    q, k, v, alpha, beta, cu_seqlens = _gen_product_inputs(
+        seq_lens,
+        n_h,
+        num_q_heads,
+        num_k_heads,
+        num_v_heads,
+        head_size,
+        dtype,
+        qkv_factory,
+        device,
+    )
+
+    our_o = None
+    if pass_output:
+        our_o = torch.full(
+            (total_seqlen, num_o_heads, head_size),
+            float("nan"),
+            dtype=dtype,
+            device=device,
+        )
+
+    result = chunk_gated_delta_product(
+        q,
+        k,
+        v,
+        alpha,
+        beta,
+        1.0,  # scale
+        None,  # initial_state
+        output_final_state,
+        cu_seqlens,
+        True,  # use_qk_l2norm_in_kernel
+        output=our_o,
+        output_state=None,  # force the wrapper to own the state buffer
+    )
+    torch.cuda.synchronize()
+
+    # --- return contract mirrors chunk_gated_delta_rule ---
+    if output_final_state:
+        assert isinstance(result, tuple) and len(result) == 2, (
+            f"output_final_state=True must return (output, final_state); "
+            f"got {type(result)}"
+        )
+        got_o, got_state = result
+        assert got_state is not None, "final_state requested but None returned"
+        assert got_state.shape == (num_seqs, num_sab_heads, head_size, head_size)
+    else:
+        assert not isinstance(result, tuple), (
+            "output_final_state=False must return the output tensor alone, "
+            f"got a {type(result)}"
+        )
+        got_o, got_state = result, None
+
+    if pass_output:
+        assert got_o is our_o, "output= was supplied; the same tensor must come back"
+    assert got_o.shape == (total_seqlen, num_o_heads, head_size)
+    assert not got_o.isnan().any(), "output rows left unwritten"
+
+    ref_o, ref_state = delta_product(
+        q.float(),
+        k.float(),
+        v.float(),
+        seq_lens,
+        alpha=alpha,
+        beta=beta,
+        scale_factor=1.0,
+    )
+    torch.testing.assert_close(got_o, ref_o.to(dtype), atol=2e-3, rtol=1e-3)
+    if got_state is not None:
+        torch.testing.assert_close(
+            got_state.transpose(-1, -2), ref_state, atol=1e-3, rtol=1e-4
+        )

--- a/tests/gdn/test_prefill_delta_product.py
+++ b/tests/gdn/test_prefill_delta_product.py
@@ -22,6 +22,7 @@ import pytest
 import torch
 
 from flashinfer.gdn_prefill import chunk_gated_delta_rule
+from flashinfer.gdn_product import chunk_gated_delta_product
 from flashinfer.utils import (
     is_sm90a_supported,
     is_sm100a_supported,
@@ -302,3 +303,98 @@ def test_reference_equals_expanded_delta_rule(
 
     torch.testing.assert_close(prod_o, rule_o[n_h - 1 :: n_h], atol=1e-5, rtol=1e-5)
     torch.testing.assert_close(prod_state, rule_state, atol=1e-5, rtol=1e-5)
+
+
+@pytest.mark.parametrize(
+    "num_householder", [1, 2, 3, 4], ids=lambda nh: f"num_householder={nh}"
+)
+@pytest.mark.parametrize(
+    "seq_lens",
+    [[64], [256], [64, 128, 512]],
+    ids=lambda s: "seq_lens=" + ",".join(map(str, s)),
+)
+@pytest.mark.parametrize(
+    "num_heads",
+    [(8, 8, 8), (8, 8, 16)],
+    ids=lambda qkv: "num_heads={0}/{1}/{2}".format(*qkv),
+)
+@pytest.mark.parametrize("dtype", ["float16", "bfloat16"])
+def test_prefill_kernel_matches_reference(
+    qkv_factory, num_householder, seq_lens, num_heads, dtype, seed=0
+):
+    """chunk_gated_delta_product == delta_product reference, on real kernels."""
+    _skip_if_unsupported()
+    random.seed(seed)
+    torch.random.manual_seed(seed)
+    torch.cuda.manual_seed(seed)
+
+    num_q_heads, num_k_heads, num_v_heads = num_heads
+    num_o_heads = num_sab_heads = max(num_q_heads, num_v_heads)
+    num_seqs, total_seqlen = len(seq_lens), sum(seq_lens)
+    head_size, n_h = 128, num_householder
+    device = torch.device("cuda")
+    dtype = getattr(torch, dtype)
+
+    q, k, v, alpha, beta, cu_seqlens = _gen_product_inputs(
+        seq_lens,
+        n_h,
+        num_q_heads,
+        num_k_heads,
+        num_v_heads,
+        head_size,
+        dtype,
+        qkv_factory,
+        device,
+    )
+
+    our_o = torch.full(
+        (total_seqlen, num_o_heads, head_size),
+        float("nan"),
+        dtype=q.dtype,
+        device=device,
+    )
+    our_state = torch.full(
+        (num_seqs, num_sab_heads, head_size, head_size),
+        float("nan"),
+        dtype=torch.float32,
+        device=device,
+    )
+    chunk_gated_delta_product(
+        q,
+        k,
+        v,
+        alpha,
+        beta,
+        1.0,  # scale
+        None,  # initial_state
+        True,  # output_final_state
+        cu_seqlens,
+        True,  # use_qk_l2norm_in_kernel
+        output=our_o,
+        output_state=our_state,
+    )
+    torch.cuda.synchronize()
+
+    # state shape must not depend on n_h -- this is the whole selling point
+    assert our_state.shape == (num_seqs, num_sab_heads, head_size, head_size)
+    assert not our_o.isnan().any(), "output buffer left partially unwritten"
+
+    our_state = our_state.transpose(-1, -2)  # kernel [.., V, K] -> ref [.., K, V]
+
+    ref_o, ref_state = delta_product(
+        q.float(),
+        k.float(),
+        v.float(),
+        seq_lens,
+        alpha=alpha,
+        beta=beta,
+        scale_factor=1.0,
+    )
+
+    if dtype == torch.bfloat16:
+        atol_o, rtol_o, atol_kv, rtol_kv = 1e-2, 1e-2, 5e-3, 1e-3
+    else:
+        atol_o, rtol_o, atol_kv, rtol_kv = 2e-3, 1e-3, 1e-3, 1e-4
+
+    torch.testing.assert_close(our_o, ref_o.to(q.dtype), atol=atol_o, rtol=rtol_o)
+    torch.testing.assert_close(our_state, ref_state, atol=atol_kv, rtol=rtol_kv)

--- a/tests/gdn/test_prefill_delta_product.py
+++ b/tests/gdn/test_prefill_delta_product.py
@@ -151,9 +151,17 @@ def test_reference_nh1_equals_delta_rule(
     torch.testing.assert_close(prod_state, rule_state, atol=0, rtol=0)
 
 
-@pytest.mark.parametrize("seq_lens", [[64], [256], [64, 128, 512]])
-@pytest.mark.parametrize("head_size", [128])
-@pytest.mark.parametrize("num_heads", [(8, 8, 8), (8, 8, 16)])
+@pytest.mark.parametrize(
+    "seq_lens",
+    [[64], [256], [64, 128, 512]],
+    ids=lambda seqlens: "seq_lens=" + ",".join(map(str, seqlens)),
+)
+@pytest.mark.parametrize("head_size", [128], ids=lambda hs: f"head_size={hs}")
+@pytest.mark.parametrize(
+    "num_heads",
+    [(8, 8, 8), (8, 8, 16)],
+    ids=lambda qkv: "num_heads={0}/{1}/{2}".format(*qkv),
+)
 @pytest.mark.parametrize("dtype", ["float16", "bfloat16"])
 def test_reference_nh1_matches_kernel(
     qkv_factory, seq_lens, head_size, num_heads, dtype, seed=0
@@ -231,9 +239,19 @@ def test_reference_nh1_matches_kernel(
     torch.testing.assert_close(our_state, ref_state, atol=atol_kv, rtol=rtol_kv)
 
 
-@pytest.mark.parametrize("num_householder", [1, 2, 3, 4])
-@pytest.mark.parametrize("seq_lens", [[128], [64, 128, 512]])
-@pytest.mark.parametrize("num_heads", [(8, 8, 8), (8, 8, 16)])
+@pytest.mark.parametrize(
+    "num_householder", [1, 2, 3, 4], ids=lambda nh: f"num_householder={nh}"
+)
+@pytest.mark.parametrize(
+    "seq_lens",
+    [[128], [64, 128, 512]],
+    ids=lambda seqlens: "seq_lens=" + ",".join(map(str, seqlens)),
+)
+@pytest.mark.parametrize(
+    "num_heads",
+    [(8, 8, 8), (8, 8, 16)],
+    ids=lambda qkv: "num_heads={0}/{1}/{2}".format(*qkv),
+)
 def test_reference_equals_expanded_delta_rule(
     qkv_factory, num_householder, seq_lens, num_heads, seed=0
 ):

--- a/tests/gdn/test_prefill_delta_product_cudagraph.py
+++ b/tests/gdn/test_prefill_delta_product_cudagraph.py
@@ -1,0 +1,261 @@
+"""
+Copyright (c) 2025 by FlashInfer team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+CUDA graph capture/replay for chunk_gated_delta_product.
+
+Two failure modes this catches that the eager tests cannot:
+
+  * A host sync inside the wrapper -- ``.item()``, ``.tolist()``, ``int(t)``,
+    or any data-dependent control flow on a device tensor. Capture raises.
+  * Values baked in at capture time. The expansion derives ``cu_seqlens * n_h``,
+    ``g_flat`` and ``q_flat`` from device tensors; if any of that is computed on
+    the host, replay silently reuses the captured numbers. So we replay with
+    DIFFERENT input contents and check the output tracks them.
+
+Note the graph-safe calling convention: pass ``output=``/``output_state=`` so
+results land in caller-owned buffers. Letting the wrapper allocate works under
+capture (the allocation joins the graph pool) but the returned tensor is the
+same storage on every replay, which is a sharper edge than it looks.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from flashinfer.gdn_product import chunk_gated_delta_product
+
+from .reference_delta_product import delta_product
+from .test_prefill_delta_product import _gen_product_inputs, _skip_if_unsupported
+
+
+@pytest.mark.parametrize(
+    "num_householder", [1, 2, 3], ids=lambda nh: f"num_householder={nh}"
+)
+@pytest.mark.parametrize(
+    "num_heads",
+    [(8, 8, 8), (8, 8, 16)],
+    ids=lambda qkv: "num_heads={0}/{1}/{2}".format(*qkv),
+)
+@pytest.mark.parametrize("dtype", ["float16", "bfloat16"])
+def test_cudagraph_capture_and_replay(qkv_factory, num_householder, num_heads, dtype):
+    _skip_if_unsupported()
+
+    num_q_heads, num_k_heads, num_v_heads = num_heads
+    num_o_heads = num_sab_heads = max(num_q_heads, num_v_heads)
+    seq_lens = [64, 128, 256]
+    head_size, n_h = 128, num_householder
+    num_seqs, total_seqlen = len(seq_lens), sum(seq_lens)
+    device = torch.device("cuda")
+    dtype = getattr(torch, dtype)
+
+    def gen(seed):
+        torch.random.manual_seed(seed)
+        torch.cuda.manual_seed(seed)
+        return _gen_product_inputs(
+            seq_lens,
+            n_h,
+            num_q_heads,
+            num_k_heads,
+            num_v_heads,
+            head_size,
+            dtype,
+            qkv_factory,
+            device,
+        )
+
+    # Static buffers -- graphs fix both shapes AND addresses, so every replay
+    # must read from and write to exactly these tensors.
+    q, k, v, alpha, beta, cu_seqlens = gen(0)
+    our_o = torch.empty(
+        (total_seqlen, num_o_heads, head_size), dtype=dtype, device=device
+    )
+    our_state = torch.empty(
+        (num_seqs, num_sab_heads, head_size, head_size),
+        dtype=torch.float32,
+        device=device,
+    )
+
+    def run_op():
+        chunk_gated_delta_product(
+            q,
+            k,
+            v,
+            alpha,
+            beta,
+            1.0,  # scale
+            None,  # initial_state
+            True,  # output_final_state
+            cu_seqlens,
+            True,  # use_qk_l2norm_in_kernel
+            output=our_o,
+            output_state=our_state,
+        )
+
+    # Warm up on a side stream. This is not politeness: flashinfer JIT-compiles
+    # and autotunes on first call for a given shape, and neither may happen
+    # inside a capture.
+    warmup_stream = torch.cuda.Stream()
+    warmup_stream.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(warmup_stream):
+        for _ in range(3):
+            run_op()
+    torch.cuda.current_stream().wait_stream(warmup_stream)
+    torch.cuda.synchronize()
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        run_op()
+    torch.cuda.synchronize()
+
+    if dtype == torch.bfloat16:
+        atol_o, rtol_o, atol_kv, rtol_kv = 1e-2, 1e-2, 5e-3, 1e-3
+    else:
+        atol_o, rtol_o, atol_kv, rtol_kv = 2e-3, 1e-3, 1e-3, 1e-4
+
+    # Replay with fresh contents each round. If anything was computed on the
+    # host at capture time, these will not track.
+    for step in range(2):
+        new_q, new_k, new_v, new_alpha, new_beta, _ = gen(1000 + step)
+        q.copy_(new_q)
+        k.copy_(new_k)
+        v.copy_(new_v)
+        alpha.copy_(new_alpha)
+        beta.copy_(new_beta)
+
+        our_o.fill_(float("nan"))
+        our_state.fill_(float("nan"))
+        graph.replay()
+        torch.cuda.synchronize()
+
+        assert not our_o.isnan().any(), (
+            f"step {step}: output not fully written on replay -- a strided "
+            f"copy-back is likely missing rows"
+        )
+        assert not our_state.isnan().any(), f"step {step}: state not written"
+
+        ref_o, ref_state = delta_product(
+            new_q.float(),
+            new_k.float(),
+            new_v.float(),
+            seq_lens,
+            alpha=new_alpha,
+            beta=new_beta,
+            scale_factor=1.0,
+        )
+        torch.testing.assert_close(
+            our_o,
+            ref_o.to(dtype),
+            atol=atol_o,
+            rtol=rtol_o,
+            msg=lambda m: f"step {step} output mismatch after replay\n{m}",
+        )
+        torch.testing.assert_close(
+            our_state.transpose(-1, -2),
+            ref_state,
+            atol=atol_kv,
+            rtol=rtol_kv,
+            msg=lambda m: f"step {step} state mismatch after replay\n{m}",
+        )
+
+
+@pytest.mark.parametrize(
+    "num_householder", [2, 3], ids=lambda nh: f"num_householder={nh}"
+)
+def test_cudagraph_replay_is_not_frozen(qkv_factory, num_householder):
+    """A graph that ignored its inputs would still pass a single-replay check.
+
+    Replay twice with different data and assert the two outputs DIFFER -- this
+    is the cheap guard against a capture that merely re-emits stale results.
+    """
+    _skip_if_unsupported()
+
+    seq_lens = [128]
+    head_size, n_h = 128, num_householder
+    num_q_heads = num_k_heads = num_v_heads = 8
+    total_seqlen = sum(seq_lens)
+    device = torch.device("cuda")
+    dtype = torch.float16
+
+    def gen(seed):
+        torch.random.manual_seed(seed)
+        torch.cuda.manual_seed(seed)
+        return _gen_product_inputs(
+            seq_lens,
+            n_h,
+            num_q_heads,
+            num_k_heads,
+            num_v_heads,
+            head_size,
+            dtype,
+            qkv_factory,
+            device,
+        )
+
+    q, k, v, alpha, beta, cu_seqlens = gen(0)
+    our_o = torch.empty(
+        (total_seqlen, num_v_heads, head_size), dtype=dtype, device=device
+    )
+    our_state = torch.empty(
+        (len(seq_lens), num_v_heads, head_size, head_size),
+        dtype=torch.float32,
+        device=device,
+    )
+
+    def run_op():
+        chunk_gated_delta_product(
+            q,
+            k,
+            v,
+            alpha,
+            beta,
+            1.0,
+            None,
+            True,
+            cu_seqlens,
+            True,
+            output=our_o,
+            output_state=our_state,
+        )
+
+    warmup_stream = torch.cuda.Stream()
+    warmup_stream.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(warmup_stream):
+        for _ in range(3):
+            run_op()
+    torch.cuda.current_stream().wait_stream(warmup_stream)
+    torch.cuda.synchronize()
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        run_op()
+    torch.cuda.synchronize()
+
+    outs = []
+    for seed in (1000, 2000):
+        new_q, new_k, new_v, new_alpha, new_beta, _ = gen(seed)
+        q.copy_(new_q)
+        k.copy_(new_k)
+        v.copy_(new_v)
+        alpha.copy_(new_alpha)
+        beta.copy_(new_beta)
+        graph.replay()
+        torch.cuda.synchronize()
+        outs.append(our_o.clone())
+
+    assert not torch.allclose(outs[0], outs[1]), (
+        "replay produced identical output for different inputs -- the graph is "
+        "not reading its input buffers"
+    )

--- a/tests/gdn/test_prefill_delta_product_cudagraph.py
+++ b/tests/gdn/test_prefill_delta_product_cudagraph.py
@@ -14,20 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 CUDA graph capture/replay for chunk_gated_delta_product.
-
-Two failure modes this catches that the eager tests cannot:
-
-  * A host sync inside the wrapper -- ``.item()``, ``.tolist()``, ``int(t)``,
-    or any data-dependent control flow on a device tensor. Capture raises.
-  * Values baked in at capture time. The expansion derives ``cu_seqlens * n_h``,
-    ``g_flat`` and ``q_flat`` from device tensors; if any of that is computed on
-    the host, replay silently reuses the captured numbers. So we replay with
-    DIFFERENT input contents and check the output tracks them.
-
-Note the graph-safe calling convention: pass ``output=``/``output_state=`` so
-results land in caller-owned buffers. Letting the wrapper allocate works under
-capture (the allocation joins the graph pool) but the returned tensor is the
-same storage on every replay, which is a sharper edge than it looks.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

This PR enables running GDP prefill, using the existing GDN API (without adding or modifying any kernels).
GDP is just GDN applied multiple times to the same token, so instead of modifying the kernel we can simply make the GDP input seem like a long normal GDN input, with two subtleties:
1. GDP applies state alpha gate once per REAL token, so we take the GDP alpha and inflate it with 1s so intra-token updates don't gate the state.
2. q, the output, and alpha (due to the above) require expansion, which requires pre-allocated scratch buffers to work under cuda graphs.

Disclaimer: This is obviously NOT the optimized option, and adding support for GDP to the kernel itself would yield better performance. This is simply am enablement PR and we plan to optimize later behind the API introduced here.

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [V] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [V] I have installed the hooks with `pre-commit install`.
- [V] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [V] Tests have been added or updated as needed.
- [V] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->
