### PR TITLE
fix: enumerate artifacts from checksum manifests

### DIFF
--- a/flashinfer/artifacts.py
+++ b/flashinfer/artifacts.py
@@ -267,10 +267,9 @@ def _get_host_cpu_arch() -> str:
 
 
 def get_subdir_file_list() -> Generator[tuple[str, str], None, None]:
-    base = FLASHINFER_CUBINS_REPOSITORY
     cpu_arch = _get_host_cpu_arch()
 
-    cubin_dirs = [
+    artifact_dirs = [
         ArtifactPath.TRTLLM_GEN_FMHA,
         ArtifactPath.TRTLLM_GEN_BMM,
         ArtifactPath.TRTLLM_GEN_GEMM,
@@ -285,57 +284,18 @@ def get_subdir_file_list() -> Generator[tuple[str, str], None, None]:
         ),
     ]
 
-    # Get checksums of all files
-    checksums = get_checksums(cubin_dirs)
-
-    # The meta info header files first.
-    yield (
-        safe_urljoin(ArtifactPath.TRTLLM_GEN_FMHA, "include/flashInferMetaInfo.h"),
-        checksums[
-            safe_urljoin(ArtifactPath.TRTLLM_GEN_FMHA, "include/flashInferMetaInfo.h")
-        ],
-    )
-    yield (
-        safe_urljoin(ArtifactPath.TRTLLM_GEN_GEMM, "include/flashinferMetaInfo.h"),
-        checksums[
-            safe_urljoin(ArtifactPath.TRTLLM_GEN_GEMM, "include/flashinferMetaInfo.h")
-        ],
-    )
-    yield (
-        safe_urljoin(ArtifactPath.TRTLLM_GEN_BMM, "include/flashinferMetaInfo.h"),
-        checksums[
-            safe_urljoin(ArtifactPath.TRTLLM_GEN_BMM, "include/flashinferMetaInfo.h")
-        ],
-    )
-    yield (
-        safe_urljoin(
-            ArtifactPath.TRTLLM_GEN_GEMM_RUBIN, "include/flashinferMetaInfo.h"
-        ),
-        checksums[
-            safe_urljoin(
-                ArtifactPath.TRTLLM_GEN_GEMM_RUBIN, "include/flashinferMetaInfo.h"
-            )
-        ],
-    )
-    yield (
-        safe_urljoin(ArtifactPath.TRTLLM_GEN_BMM_RUBIN, "include/flashinferMetaInfo.h"),
-        checksums[
-            safe_urljoin(
-                ArtifactPath.TRTLLM_GEN_BMM_RUBIN, "include/flashinferMetaInfo.h"
-            )
-        ],
-    )
-
-    # All the actual kernel cubin's.
-    for cubin_dir in cubin_dirs:
-        checksum_path = safe_urljoin(cubin_dir, "checksums.txt")
+    # The manifests are authoritative. Directory indexes are HTML pages and
+    # may contain artifact types other than cubins, such as CuTe DSL shared
+    # objects. Enumerating from the manifests also keeps downloads and checksum
+    # verification on the same file set.
+    checksums = get_checksums(artifact_dirs)
+    for artifact_dir in artifact_dirs:
+        checksum_path = safe_urljoin(artifact_dir, "checksums.txt")
         yield (checksum_path, CheckSumHash.map_checksums[checksum_path])
-        for name in get_available_cubin_files(safe_urljoin(base, cubin_dir)):
-            full_path = safe_urljoin(cubin_dir, name)
-            yield (full_path, checksums[full_path])
-        for name in get_available_header_files(safe_urljoin(base, cubin_dir)):
-            full_path = safe_urljoin(cubin_dir, name)
-            yield (full_path, checksums[full_path])
+        artifact_prefix = artifact_dir.rstrip("/") + "/"
+        for full_path, checksum in checksums.items():
+            if full_path.startswith(artifact_prefix):
+                yield (full_path, checksum)
 
 
 def download_artifacts() -> None:

--- a/tests/test_artifacts.py
+++ b/tests/test_artifacts.py
@@ -346,7 +346,6 @@ def test_get_checksums_falls_back_to_cached_manifest(monkeypatch, tmp_path):
 
 @responses.activate
 def test_get_subdir_file_list(monkeypatch, tmp_path):
-    _mock_file_index_responses()
     from flashinfer import artifacts
 
     # Set up temporary directory for downloading checksums
@@ -460,25 +459,16 @@ f9a0b1c2d3e4 kernel.fp8_m_grouped_gemm.0457375eb02f.cubin
         status=200,
     )
 
-    # Mock DSL_FMHA checksums + directory index for the host cpu_arch.
+    # Mock DSL_FMHA checksums for the host cpu_arch.
     # Pin to x86_64 so the test is deterministic regardless of the runner arch.
     monkeypatch.setattr(artifacts, "_get_host_cpu_arch", lambda: "x86_64")
     checksums_dsl_fmha = "aabbccdd11223344 cute_dsl_fmha_bf16_h128_causal_nonpersistent_varlen_tvmffi.so\n"
-    # Minimal directory index: an empty HTML page with no cubin/header hrefs.
-    # This avoids 404 retry overhead while still exercising the code path.
-    empty_dir_index = '<html><body><pre><a href="../">../</a></pre></body></html>'
     for sm_arch in artifact_paths.DSL_FMHA_ARCHS:
         subdir = safe_urljoin(artifact_paths.DSL_FMHA, f"x86_64/{sm_arch}/")
         responses.add(
             responses.GET,
             safe_urljoin(test_cubin_repository, safe_urljoin(subdir, "checksums.txt")),
             body=checksums_dsl_fmha,
-            status=200,
-        )
-        responses.add(
-            responses.GET,
-            safe_urljoin(test_cubin_repository, subdir),
-            body=empty_dir_index,
             status=200,
         )
 
@@ -537,6 +527,14 @@ f9a0b1c2d3e4 kernel.fp8_m_grouped_gemm.0457375eb02f.cubin
     # which failed verification for every shared name.
     by_path = dict(cubin_files)
     assert len(by_path) == len(cubin_files), "duplicate paths in cubin file list"
+
+    dsl_fmha_name = "cute_dsl_fmha_bf16_h128_causal_nonpersistent_varlen_tvmffi.so"
+    for sm_arch in artifact_paths.DSL_FMHA_ARCHS:
+        dsl_fmha_path = safe_urljoin(
+            artifact_paths.DSL_FMHA,
+            f"x86_64/{sm_arch}/{dsl_fmha_name}",
+        )
+        assert by_path[dsl_fmha_path] == "aabbccdd11223344"
 
     for shared_name, plain_dir, rubin_dir in (
         (


### PR DESCRIPTION
## 📌 Description

Use each artifact directory's `checksums.txt` as the download list instead of parsing its HTML index. This includes CuTe DSL shared libraries and keeps enumeration aligned with checksum verification.

On the current aarch64 manifests, the old path found 0 of 1,456 CuTe DSL `.so` files; this path finds all 1,456.

## 🔍 Related Issues

Closes #4432

## 🚀 Pull Request Checklist

- [x] `pre-commit run --all-files`
- [x] Tests added for CuTe DSL `.so` enumeration
- [x] `pytest tests/test_artifacts.py` (6 passed)

## Reviewer Notes

`get_available_cubin_files` and `get_available_header_files` remain unchanged for compatibility; only the bulk artifact download path now uses the manifests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved artifact discovery and verification by relying on checksum manifests.
  * Ensured architecture-specific artifacts resolve against their expected checksums.
  * Removed dependence on directory indexes and hard-coded artifact file listings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->