### PR TITLE
perf(gdn): reuse pretranspose kernels across pool capacity and stride

### DIFF
--- a/flashinfer/gdn_kernels/gdn_decode_pretranspose.py
+++ b/flashinfer/gdn_kernels/gdn_decode_pretranspose.py
@@ -905,8 +905,6 @@ def _get_compiled_decode_kernel(
     scale: float,
     use_qk_l2norm: bool,
     use_pool_indexing: bool = False,
-    pool_size: int = 0,
-    stride0: int = 0,
     stride1: int = 0,
     stride2: int = 0,
     stride3: int = 0,
@@ -956,10 +954,13 @@ def run_pretranspose_decode(
     """
     # Compile kernel with TVM FFI (cached)
     if use_pool_indexing:
-        pool_size = int(h0_source.shape[0])
         stride0, stride1, stride2, stride3 = tuple(int(x) for x in h0_source.stride())
+        assert stride0 % 4 == 0, (
+            "initial_state stride(0) must be a multiple of 4 FP32 elements "
+            f"for 128-bit state copies, got stride(0)={stride0}"
+        )
     else:
-        pool_size = stride0 = stride1 = stride2 = stride3 = 0
+        stride1 = stride2 = stride3 = 0
     cache_key = (
         T,
         H,
@@ -970,8 +971,6 @@ def run_pretranspose_decode(
         scale,
         use_qk_l2norm,
         use_pool_indexing,
-        pool_size,
-        stride0,
         stride1,
         stride2,
         stride3,
@@ -1000,8 +999,20 @@ def run_pretranspose_decode(
     if "compiled" not in cache:
         stream = cuda.CUstream(torch.cuda.current_stream().cuda_stream)
 
-        h0_source_tensor = from_dlpack(h0_source, assumed_align=16)
-        if not use_pool_indexing:
+        if use_pool_indexing:
+            # Pool capacity and the distance between slots do not affect codegen.
+            # Keep the inner state layout static while accepting arbitrary pool
+            # sizes and padded slot strides through the same compiled callable.
+            sym_pool_size = cute.sym_int()
+            sym_pool_stride0 = cute.sym_int64(divisibility=4)
+            h0_source_tensor = cute.runtime.make_fake_tensor(
+                cute.Float32,
+                shape=(sym_pool_size, HV, V, K),
+                stride=(sym_pool_stride0, stride1, stride2, stride3),
+                assumed_align=16,
+            )
+        else:
+            h0_source_tensor = from_dlpack(h0_source, assumed_align=16)
             h0_source_tensor = h0_source_tensor.mark_compact_shape_dynamic(
                 mode=0, stride_order=(0, 1, 2), divisibility=1
             )

--- a/tests/gdn/test_decode_pretranspose_noncontiguous_pool.py
+++ b/tests/gdn/test_decode_pretranspose_noncontiguous_pool.py
@@ -16,6 +16,7 @@ limitations under the License.
 
 from __future__ import annotations
 
+import importlib
 import random
 
 import pytest
@@ -41,6 +42,13 @@ def _skip_if_not_sm90_or_later() -> None:
     cc = get_compute_capability(torch.device("cuda"))
     if cc[0] not in [9, 10, 11, 12]:
         pytest.skip(f"GDN decode requires SM90+ or SM100+, but got SM{cc[0]}{cc[1]}")
+
+
+def _load_pretranspose_module():
+    try:
+        return importlib.import_module("flashinfer.gdn_kernels.gdn_decode_pretranspose")
+    except ImportError as exc:
+        pytest.skip(f"CuTe DSL pretranspose kernel is unavailable: {exc}")
 
 
 @pytest.mark.parametrize("page_gap", [2, 3])
@@ -123,6 +131,156 @@ def test_decode_pretranspose_pool_noncontiguous_state(page_gap: int) -> None:
     torch.testing.assert_close(
         pool_under_test[untouched], pool_source[untouched], atol=0.0, rtol=0.0
     )
+
+
+def test_decode_pretranspose_pool_reuses_compile_across_outer_layouts(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Pool capacity and leading stride reuse one compiled specialization."""
+    _skip_if_not_sm90_or_later()
+
+    B, T, H, HV, K, V = 2, 1, 16, 32, 128, 128
+    device = torch.device("cuda")
+    qkv_dtype = torch.bfloat16
+
+    with device:
+        q = torch.randn(B, T, H, K, dtype=qkv_dtype)
+        k = torch.nn.functional.normalize(
+            torch.randn(B, T, H, K, dtype=qkv_dtype), p=2.0, dim=-1
+        )
+        v = torch.randn(B, T, HV, V, dtype=qkv_dtype)
+        A_log = torch.randn(HV, dtype=torch.float32) * 0.1
+        dt_bias = torch.randn(HV, dtype=torch.float32) * 0.1
+        a = torch.randn(B, T, HV, dtype=qkv_dtype) * 0.1
+        b = torch.randn(B, T, HV, dtype=qkv_dtype)
+        indices = torch.arange(B, dtype=torch.int32)
+
+    pretranspose_module = _load_pretranspose_module()
+    pool_compile_calls = 0
+    original_compile = pretranspose_module.cute.compile
+
+    def counted_compile(*args, **kwargs):
+        nonlocal pool_compile_calls
+        if kwargs.get("use_pool_indexing", False):
+            pool_compile_calls += 1
+        return original_compile(*args, **kwargs)
+
+    pretranspose_module._get_compiled_decode_kernel.cache_clear()
+    monkeypatch.setattr(pretranspose_module.cute, "compile", counted_compile)
+
+    try:
+        inner_strides = None
+        for pool_size, page_gap in ((B * 2, 2), (B * 3, 2), (B * 3, 3)):
+            with device:
+                storage = torch.randn(
+                    pool_size, page_gap, HV, V, K, dtype=torch.float32
+                )
+                pool = storage[:, page_gap - 1]
+                gathered_state = pool[indices].clone()
+                if inner_strides is None:
+                    inner_strides = pool.stride()[1:]
+                else:
+                    assert pool.stride()[1:] == inner_strides
+
+                pool_output, _ = gated_delta_rule_decode_pretranspose(
+                    q=q,
+                    k=k,
+                    v=v,
+                    state=None,
+                    A_log=A_log,
+                    a=a,
+                    dt_bias=dt_bias,
+                    b=b,
+                    scale=1.0,
+                    use_qk_l2norm=True,
+                    initial_state=pool,
+                    initial_state_indices=indices,
+                )
+                direct_output, direct_state = gated_delta_rule_decode_pretranspose(
+                    q=q,
+                    k=k,
+                    v=v,
+                    state=gathered_state,
+                    A_log=A_log,
+                    a=a,
+                    dt_bias=dt_bias,
+                    b=b,
+                    scale=1.0,
+                    use_qk_l2norm=True,
+                )
+                torch.cuda.synchronize()
+                torch.testing.assert_close(
+                    pool_output, direct_output, atol=5e-3, rtol=5e-3
+                )
+                torch.testing.assert_close(
+                    pool[indices], direct_state, atol=5e-3, rtol=5e-3
+                )
+
+        assert pool_compile_calls == 1
+    finally:
+        pretranspose_module._get_compiled_decode_kernel.cache_clear()
+
+
+def test_decode_pretranspose_pool_cache_keeps_inner_strides_static() -> None:
+    """Layouts with different inner strides must keep separate cache entries."""
+    pretranspose_module = _load_pretranspose_module()
+    common = dict(
+        T=1,
+        H=16,
+        HV=32,
+        K=128,
+        V=128,
+        dtype=torch.bfloat16,
+        scale=1.0,
+        use_qk_l2norm=True,
+        use_pool_indexing=True,
+        stride2=128,
+        stride3=1,
+    )
+
+    pretranspose_module._get_compiled_decode_kernel.cache_clear()
+    try:
+        compact = pretranspose_module._get_compiled_decode_kernel(
+            stride1=128 * 128, **common
+        )
+        padded_inner = pretranspose_module._get_compiled_decode_kernel(
+            stride1=129 * 128, **common
+        )
+        assert compact is not padded_inner
+    finally:
+        pretranspose_module._get_compiled_decode_kernel.cache_clear()
+
+
+def test_decode_pretranspose_pool_rejects_misaligned_slot_stride() -> None:
+    """Each pool slot must preserve the alignment required by 128-bit copies."""
+    pretranspose_module = _load_pretranspose_module()
+    pool = torch.empty_strided((2, 1, 1, 1), (5, 1, 1, 1))
+    dummy = torch.empty(0)
+
+    with pytest.raises(
+        AssertionError,
+        match=r"stride\(0\) must be a multiple of 4 FP32 elements",
+    ):
+        pretranspose_module.run_pretranspose_decode(
+            h0_source=pool,
+            A_log=dummy,
+            a=dummy,
+            dt_bias=dummy,
+            q=dummy,
+            k=dummy,
+            v=dummy,
+            b=dummy,
+            output=dummy,
+            B=1,
+            T=1,
+            H=1,
+            HV=1,
+            K=1,
+            V=1,
+            scale=1.0,
+            use_qk_l2norm=False,
+            use_pool_indexing=True,
+        )
 
 
 # ============================================================================


### PR DESCRIPTION
## 📌 Description

Make the leading pool dimension of the GDN pretranspose path dynamic:

- Treat pool capacity and `stride[0]` as runtime values.
- Keep `HV/V/K` and inner strides compile-time static.
- Remove pool capacity and leading stride from the compilation cache key.
- Preserve 64-bit pool-offset arithmetic.

This allows one compiled kernel to be reused across non-contiguous state pools with different capacities and leading strides.

## 🔍 Related Issues

Partially addresses #4110.

## 🚀 Pull Request Checklist

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit`.
- [x] I have installed the hooks.
- [x] I have run `pre-commit run --all-files`.

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All relevant tests are passing.

Validated on H800/SM90a and RTX 5090/SM120, including non-contiguous pools, compile reuse, and large 64-bit offsets. No steady-state regression was observed; cold compilation time was reduced by approximately 62%.

## Reviewer Notes

Only the outer pool mode is dynamic. Inner dimensions and strides remain static for kernel specialization.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved pretranspose kernel reuse across different pool capacities and outer memory layouts, reducing unnecessary recompilation.
  * Preserved separate handling for layouts with differing inner strides.

* **Reliability**
  * Added validation to reject pool slot strides that are not properly aligned for efficient data transfer.

* **Tests**
  * Expanded coverage for cache reuse, layout variations, alignment validation, and environments where the optional kernel is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->