### PR TITLE
test incidental support for fp32 unpacked expert weights from #3763

### DIFF
--- a/tests/moe/test_trtllm_gen_routed_fused_moe.py
+++ b/tests/moe/test_trtllm_gen_routed_fused_moe.py
@@ -339,38 +339,58 @@ def test_trtllm_gen_routed_fused_moe_geglu(
     )
 
 
-def test_trtllm_gen_routed_fused_moe_unpacked_fp32():
-    # All quantization modes share this finalize path.
-    _run_trtllm_gen_routed_fused_moe_case(
-        num_tokens=8,
-        hidden_size=1024,
-        intermediate_size=1024,
-        top_k=4,
-        num_experts=128,
-        routing_method_type=RoutingMethodType.Renormalize,
-        quant_mode="MxFP4xBf16",
-        routing_format="unpacked_fp32",
-    )
-
-
-@pytest.mark.parametrize("num_tokens", [8, 64])
-@pytest.mark.parametrize("hidden_size", [1024, 2048])
-@pytest.mark.parametrize("intermediate_size", [1024, 2048])
-@pytest.mark.parametrize("num_experts", [8, 16])
-@pytest.mark.parametrize("top_k", [2, 4])
 @pytest.mark.parametrize(
-    "routing_method_type",
+    "routed_moe",
     [
-        RoutingMethodType.Renormalize,
+        pytest.param("bf16", id="trtllm_bf16_routed_moe"),
+        pytest.param("fp8_block_scale", id="trtllm_fp8_block_scale_routed_moe"),
+        pytest.param("fp4_block_scale", id="trtllm_fp4_block_scale_routed_moe"),
     ],
 )
-def test_trtllm_gen_fp8_routed_fused_moe(
+def test_trtllm_gen_routed_fused_moe_unpacked_fp32(
+    routed_moe: Literal["bf16", "fp8_block_scale", "fp4_block_scale"],
+):
+    if routed_moe == "bf16":
+        _run_trtllm_gen_bf16_routed_fused_moe_case(
+            num_tokens=8,
+            hidden_size=1024,
+            intermediate_size=1024,
+            top_k=2,
+            num_experts=8,
+            routing_method_type=RoutingMethodType.Renormalize,
+            routing_format="unpacked_fp32",
+        )
+    elif routed_moe == "fp8_block_scale":
+        _run_trtllm_gen_fp8_routed_fused_moe_case(
+            num_tokens=8,
+            hidden_size=1024,
+            intermediate_size=1024,
+            top_k=2,
+            num_experts=8,
+            routing_method_type=RoutingMethodType.Renormalize,
+            routing_format="unpacked_fp32",
+        )
+    else:
+        _run_trtllm_gen_routed_fused_moe_case(
+            num_tokens=8,
+            hidden_size=1024,
+            intermediate_size=1024,
+            top_k=4,
+            num_experts=128,
+            routing_method_type=RoutingMethodType.Renormalize,
+            quant_mode="MxFP4xBf16",
+            routing_format="unpacked_fp32",
+        )
+
+
+def _run_trtllm_gen_fp8_routed_fused_moe_case(
     num_tokens: int,
     hidden_size: int,
     intermediate_size: int,
     top_k: int,
     num_experts: int,
     routing_method_type: RoutingMethodType,
+    routing_format: Literal["packed", "unpacked_fp32"],
 ):
     """Test FP8 block scale routed MoE matches standard routing."""
     compute_capability = get_compute_capability(torch.device(device="cuda"))
@@ -462,16 +482,18 @@ def test_trtllm_gen_fp8_routed_fused_moe(
         torch.arange(num_tokens, device=device).unsqueeze(1), topk_ids
     ].to(torch.bfloat16)
 
-    # Pack topk_ids and topk_weights into single tensor
-    # Format: (expert_id << 16) | (weight_bf16.view(int16))
-    packed_topk_ids = (topk_ids << 16) | topk_weights.view(torch.int16).to(torch.int32)
+    if routing_format == "packed":
+        routing_input = (topk_ids << 16) | topk_weights.view(torch.int16).to(
+            torch.int32
+        )
+    else:
+        routing_input = (topk_ids, topk_weights.to(torch.float32))
 
-    # Run with pre-computed routing (packed format)
     output = torch.empty(
         num_tokens, hidden_size, dtype=torch.bfloat16, device=hidden_states.device
     )
     trtllm_fp8_block_scale_routed_moe(
-        topk_ids=packed_topk_ids,
+        topk_ids=routing_input,
         routing_bias=None,
         hidden_states=hidden_states,
         hidden_states_scale=hidden_states_scale,
@@ -500,6 +522,36 @@ def test_trtllm_gen_fp8_routed_fused_moe(
     # mismatch percentage
     mismatch_pct = (~mask).float().mean().item() * 100
     assert mismatch_pct < 10, f"Mismatch percentage is {mismatch_pct:.2f}%"
+
+
+@pytest.mark.parametrize("num_tokens", [8, 64])
+@pytest.mark.parametrize("hidden_size", [1024, 2048])
+@pytest.mark.parametrize("intermediate_size", [1024, 2048])
+@pytest.mark.parametrize("num_experts", [8, 16])
+@pytest.mark.parametrize("top_k", [2, 4])
+@pytest.mark.parametrize(
+    "routing_method_type",
+    [
+        RoutingMethodType.Renormalize,
+    ],
+)
+def test_trtllm_gen_fp8_routed_fused_moe(
+    num_tokens: int,
+    hidden_size: int,
+    intermediate_size: int,
+    top_k: int,
+    num_experts: int,
+    routing_method_type: RoutingMethodType,
+):
+    _run_trtllm_gen_fp8_routed_fused_moe_case(
+        num_tokens,
+        hidden_size,
+        intermediate_size,
+        top_k,
+        num_experts,
+        routing_method_type,
+        "packed",
+    )
 
 
 @pytest.mark.parametrize("num_tokens", [8, 64])
@@ -710,24 +762,14 @@ def test_trtllm_gen_fp8_per_tensor_routed_fused_moe_nonzero_expert_offset():
     torch.testing.assert_close(sharded, baseline, rtol=1e-2, atol=1e-2)
 
 
-@pytest.mark.parametrize("num_tokens", [8, 64])
-@pytest.mark.parametrize("hidden_size", [1024, 2048])
-@pytest.mark.parametrize("intermediate_size", [1024, 2048])
-@pytest.mark.parametrize("num_experts", [8, 16])
-@pytest.mark.parametrize("top_k", [2, 4])
-@pytest.mark.parametrize(
-    "routing_method_type",
-    [
-        RoutingMethodType.Renormalize,
-    ],
-)
-def test_trtllm_gen_bf16_routed_fused_moe(
+def _run_trtllm_gen_bf16_routed_fused_moe_case(
     num_tokens: int,
     hidden_size: int,
     intermediate_size: int,
     top_k: int,
     num_experts: int,
     routing_method_type: RoutingMethodType,
+    routing_format: Literal["packed", "unpacked_fp32"],
 ):
     """Test Bf16 scale routed MoE matches standard routing."""
     compute_capability = get_compute_capability(torch.device(device="cuda"))
@@ -806,15 +848,15 @@ def test_trtllm_gen_bf16_routed_fused_moe(
         torch.arange(num_tokens, device=device).unsqueeze(1), topk_ids
     ].to(torch.bfloat16)
 
-    # Pack topk_ids and expert_weights into single tensor
-    # Format: (expert_id << 16) | (weight_bf16.view(int16))
-    packed_topk_ids = (topk_ids << 16) | expert_weights.view(torch.int16).to(
-        torch.int32
-    )
+    if routing_format == "packed":
+        routing_input = (topk_ids << 16) | expert_weights.view(torch.int16).to(
+            torch.int32
+        )
+    else:
+        routing_input = (topk_ids, expert_weights.to(torch.float32))
 
-    # Run with pre-computed routing (packed format)
     output = trtllm_bf16_routed_moe(
-        topk_ids=packed_topk_ids,
+        topk_ids=routing_input,
         hidden_states=hidden_states,
         gemm1_weights=gemm1_weights,
         gemm2_weights=gemm2_weights,
@@ -838,6 +880,36 @@ def test_trtllm_gen_bf16_routed_fused_moe(
     # mismatch percentage
     mismatch_pct = (~mask).float().mean().item() * 100
     assert mismatch_pct < 10, f"Mismatch percentage is {mismatch_pct:.2f}%"
+
+
+@pytest.mark.parametrize("num_tokens", [8, 64])
+@pytest.mark.parametrize("hidden_size", [1024, 2048])
+@pytest.mark.parametrize("intermediate_size", [1024, 2048])
+@pytest.mark.parametrize("num_experts", [8, 16])
+@pytest.mark.parametrize("top_k", [2, 4])
+@pytest.mark.parametrize(
+    "routing_method_type",
+    [
+        RoutingMethodType.Renormalize,
+    ],
+)
+def test_trtllm_gen_bf16_routed_fused_moe(
+    num_tokens: int,
+    hidden_size: int,
+    intermediate_size: int,
+    top_k: int,
+    num_experts: int,
+    routing_method_type: RoutingMethodType,
+):
+    _run_trtllm_gen_bf16_routed_fused_moe_case(
+        num_tokens,
+        hidden_size,
+        intermediate_size,
+        top_k,
+        num_experts,
+        routing_method_type,
+        "packed",
+    )
 
 
 @pytest.mark.parametrize("num_tokens", [8, 64])
@@ -957,7 +1029,11 @@ def test_trtllm_gen_mxint4_routed_fused_moe(
         pytest.param(ActivationType.Relu2.value, id="Relu2"),
     ],
 )
-def test_trtllm_gen_fp8_mxfp8_routed_activation_parity(activation_type: int):
+@pytest.mark.parametrize("routing_format", ["packed", "unpacked_fp32"])
+def test_trtllm_gen_fp8_mxfp8_routed_activation_parity(
+    activation_type: int,
+    routing_format: Literal["packed", "unpacked_fp32"],
+):
     """MXFP8 routed path should match non-routed reference for gated and non-gated activations."""
     compute_capability = get_compute_capability(torch.device(device="cuda"))
     if compute_capability[0] not in [10]:
@@ -1086,9 +1162,14 @@ def test_trtllm_gen_fp8_mxfp8_routed_activation_parity(activation_type: int):
     packed_topk_ids = (topk_ids << 16) | expert_weights.view(torch.int16).to(
         torch.int32
     )
+    routing_input = (
+        packed_topk_ids
+        if routing_format == "packed"
+        else (topk_ids, expert_weights.to(torch.float32))
+    )
 
     output_routed = trtllm_fp8_block_scale_routed_moe(
-        topk_ids=packed_topk_ids,
+        topk_ids=routing_input,
         routing_bias=None,
         hidden_states=quant_inputs["hidden_states"],
         hidden_states_scale=quant_inputs["hidden_states_scale"],
@@ -1114,7 +1195,9 @@ def test_trtllm_gen_fp8_mxfp8_routed_activation_parity(activation_type: int):
 
     close = torch.isclose(output_ref, output_routed, atol=1e-2, rtol=1e-2)
     mismatch_pct = (~close).float().mean().item() * 100
-    assert mismatch_pct < 10, f"Mismatch percentage is {mismatch_pct:.2f}%"
+    assert mismatch_pct < 10, (
+        f"{routing_format} mismatch percentage is {mismatch_pct:.2f}%"
+    )
 
 
 @pytest.mark.parametrize("num_tokens", [1, 7, 32])


### PR DESCRIPTION
## 📌 Description

Add unpacked FP32 routing coverage for BF16, FP8, FP4, and MXFP8 routed MoE paths.

## 🔍 Related Issues

Testing to address this comment: https://github.com/vllm-project/vllm/pull/46872#pullrequestreview-4897058875.

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [X] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [X] I have installed the hooks with `pre-commit install`.
- [X] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

None.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded routed mixture-of-experts coverage to support both packed and unpacked FP32 routing inputs.
  * Added coverage for BF16, FP8 block-scale, and FP4 block-scale implementations.
  * Improved activation-parity checks to report the routing format when mismatches occur.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->