### PR TITLE
fix(gemm): validate cached CuTeDSL BF16 tactics

### DIFF
--- a/flashinfer/gemm/gemm_base.py
+++ b/flashinfer/gemm/gemm_base.py
@@ -1564,9 +1564,31 @@ def _cute_dsl_direct_bf16_gemm_runner(
         autotune_tactics,
         default_tactic,
         run_direct_dense,
+        validate_tactic,
     )
 
     class CuteDSLDirectBf16Runner(TunableRunner):
+        def is_tactic_compatible(
+            self, inputs: List[torch.Tensor], tactic: object
+        ) -> bool:
+            if tactic == -1:
+                return True
+            a, b, bias, *_ = inputs
+            if bias is not None:
+                return False
+            try:
+                if not isinstance(tactic, (DirectTactic, tuple, list)):
+                    return False
+                tactic = (
+                    tactic
+                    if isinstance(tactic, DirectTactic)
+                    else DirectTactic(*tactic)
+                )
+                validate_tactic(tactic, a.shape[0], b.shape[1], a.shape[1])
+            except (TypeError, ValueError):
+                return False
+            return True
+
         def get_cache_key_extras(self, inputs: List[torch.Tensor]) -> tuple:
             a, _, _, pdl, out, *_ = inputs
             return (
@@ -1632,6 +1654,7 @@ def bf16_gemm_sm100(
     is_b_k_major = b.stride(-2) == 1
 
     runners = []
+    direct_runner = None
     if "cudnn" in runner_names:
         runners.append(
             _cudnn_gemm_bf16_runner(
@@ -1678,6 +1701,13 @@ def bf16_gemm_sm100(
         _BF16_GEMM_SM100_TUNING_CONFIG,
         inputs,
     )
+
+    if (
+        direct_runner is not None
+        and runner is direct_runner
+        and not direct_runner.is_tactic_compatible(inputs, tactic)
+    ):
+        runner, tactic = runners[0], -1
 
     runner(inputs=inputs, tactic=tactic)
 

--- a/tests/gemm/test_mm_bf16.py
+++ b/tests/gemm/test_mm_bf16.py
@@ -8,7 +8,7 @@ from flashinfer.gemm import is_cuda_tile_available
 from flashinfer.utils import get_compute_capability, is_sm100a_supported
 
 
-@pytest.mark.parametrize("m", [1, 8, 16, 32, 64])
+@pytest.mark.parametrize("m", [1, 8, 16, 25, 32, 64])
 @pytest.mark.parametrize("n", [1024, 2048, 4096])
 @pytest.mark.parametrize("k", [1024, 2048, 3072])
 @pytest.mark.parametrize("res_dtype", [torch.bfloat16, torch.float16, torch.float32])


### PR DESCRIPTION
## Summary

- validate a selected CuTeDSL BF16 direct tactic against the concrete runtime shape in the BF16 dispatch
- fall back through the actual-shape runner order when the cached direct tactic is incompatible
- add M=25 to the existing BF16 accuracy matrix

## Root cause

Bucketed M=25 can reuse a direct tactic tuned for M=32 with rows_per_block=8, which does not divide 25.

## Testing

- B300/SM103a: CuTeDSL BF16 M=25 accuracy with autotune disabled and enabled
- touched-file pre-commit checks, including mypy and Ruff

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved BF16 matrix multiplication reliability by validating selected performance configurations before execution.
  * Added fallback behavior when a selected configuration is incompatible with the input shape or operation settings.
  * Prevented unsupported bias-enabled inputs from using the direct BF16 execution path.

* **Tests**
  * Expanded BF16 matrix multiplication coverage to include an additional matrix size.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->