### PR TITLE
fix(prefill): coherent SM120 e4m3 FMHAv2 layout gates (draft: sm120 e4m3 kernel silently writes no output)

### DIFF
--- a/flashinfer/prefill.py
+++ b/flashinfer/prefill.py
@@ -5295,10 +5295,18 @@ def trtllm_fmha_v2_prefill(
     elif input_layout == "SEPARATE_Q_K_V":
         assert isinstance(qkv, tuple)
         query, k_cache, v_cache = qkv[0], qkv[1], qkv[2]
-        if hasattr(torch, "float8_e4m3fn") and query.dtype == torch.float8_e4m3fn:
+        if (
+            hasattr(torch, "float8_e4m3fn")
+            and query.dtype == torch.float8_e4m3fn
+            and not is_sm12x_supported(query.device)
+        ):
+            # SM120/SM121 ship prebuilt e4m3 SEPARATE_Q_K_V kernels
+            # (fmha_v2_flash_attention_e4m3_*_192x128_sm120); other archs
+            # have e4m3 kernels only for the packed/contiguous/paged layouts.
             raise ValueError(
-                "FP8 (e4m3) is not supported for the SEPARATE_Q_K_V input layout. "
-                "Use PACKED_QKV, CONTIGUOUS_Q_KV, or Q_PAGED_KV layout instead."
+                "FP8 (e4m3) is not supported for the SEPARATE_Q_K_V input layout "
+                "on this architecture. Use PACKED_QKV, CONTIGUOUS_Q_KV, or "
+                "Q_PAGED_KV layout instead."
             )
         if logits_soft_cap_scale is not None and logits_soft_cap_scale > 0:
             raise ValueError(
@@ -5379,11 +5387,14 @@ def trtllm_fmha_v2_prefill(
     is_e4m3 = (
         query.dtype == torch.float8_e4m3fn if hasattr(torch, "float8_e4m3fn") else False
     )
-    if is_e4m3:
-        if is_sm12x_supported(query.device):
+    if is_e4m3 and is_sm12x_supported(query.device):
+        if input_layout != "SEPARATE_Q_K_V":
+            # The generated e4m3 kernel set for SM120 covers only the
+            # SEPARATE_Q_K_V layout (the packed/contiguous e4m3 templates do
+            # not instantiate for sm120 — see the Kernel_traits build errors).
             raise ValueError(
-                "FP8 (e4m3) is not yet supported for FMHAv2 on SM120 (Blackwell). "
-                "Use fp16 or bf16 instead."
+                "FP8 (e4m3) on SM120 currently supports only the "
+                "SEPARATE_Q_K_V input layout."
             )
     # Always pass 1.0: the C++ auto-detect (scale_softmax == 0.0) handles FP16/INT8/E4M3
     # but has no branch for BF16, where 0.0 would zero out the softmax output.


### PR DESCRIPTION
## Summary

The two e4m3 gates in `trtllm_fmha_v2_prefill` contradict each other on SM120/SM121:

- e4m3 is rejected for `SEPARATE_Q_K_V` — the **only** layout whose sm120 e4m3 kernels actually exist (`fmha_v2_flash_attention_e4m3_fp32_64_64_S_q_k_v_192x128[_output_bf16]_sm120.cu`, prebuilt in `gen_trtllm_fmha_v2_sm120_module`).
- The blanket "FP8 (e4m3) is not yet supported for FMHAv2 on SM120" raise points users at `PACKED_QKV`/`CONTIGUOUS_Q_KV`/`Q_PAGED_KV` — whose e4m3 templates do **not** instantiate for sm120 (`Kernel_traits` build errors, e.g. `Traits_=<error-type>` in `fmha_v2_flash_attention_e4m3_64_32_S_q_kv_256_..._sm120.cu`).

This PR aligns both gates with the real kernel inventory. **Draft** because of the finding below.

## Forensics: the sm120 e4m3 nl_tiled kernel silently writes no output

Measured on GB10 (sm121, CUDA 13, driver 580.159.03), MLA geometry (h=64, d_qk=192, d_v=128, causal, `SEPARATE_Q_K_V`):

- bf16 twin (`..._bf16_64_128_S_q_k_v_192x128_sm120_nl_tiled`) works correctly through the identical binding/launcher structure (same reordered `dim3 grid(loop_iters * ctas_per_o_row, h, b)`, same `Fused_multihead_attention_params_v2` fill).
- The e4m3 kernel **launches without any CUDA error** (verified via device synchronize after launch) and **writes nothing** — output buffer remains untouched (exactly 0 elements written; earlier "NaN" reports are an uninitialized `torch.empty` artifact).
- Eliminated by experiment: scale conventions (`scale_softmax` ∈ {1.0, 448.0}, `bmm2_scale` ∈ {1.0, 1/448, 448} — all zero output, including single-token identity cases where output must equal V), preprocessor branch selection (CUDA ≥ 11000 branch active; only `_nl_tiled` is compiled and it is the variant the binding calls), dtype dispatch (the `DATA_TYPE_E4M3 && output BF16` branch is reached), mask enum (CAUSAL case exists; bf16 works with the same mask), grid ordering (bf16 twin uses the identical ordering and works).
- Remaining suspects: the `Ada_qmma_e4m3_fp32_traits` epilogue path on sm120 (`bmm2_fp16_epilogue=true`, `fmha::bf16_t` output) and/or the `params.scale_bmm2_d` device-pointer plumbing for this path.

Repro scripts (standalone, ~1 min each once the gates are relaxed) available on request.

## Question for maintainers

Is the sm120 e4m3 `S_q_k_v` kernel set known-incomplete (matching the "not yet" wording), or is there a known launch/params requirement we're missing (e.g. `scale_bmm2_d` workspace slice, granular-tiling launch flag)? Happy to finish this — we have an iterating on-hardware repro loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MWYyLoUHokQsoUyJs1BXK1
