### PR TITLE
fix(cutile): stabilize autotune config selection in select GEMMs

### DIFF
--- a/flashinfer/gemm/kernels/cutile/_tune_select.py
+++ b/flashinfer/gemm/kernels/cutile/_tune_select.py
@@ -1,0 +1,56 @@
+# Copyright (c) 2026 by FlashInfer team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Deterministic ranking of cuTile ``exhaustive_search`` measurements.
+
+``exhaustive_search`` stops sampling a candidate once its error margin drops
+below max(1% of mean, 0.5 us). For fast kernels this margin is of the same
+order as the gap between the top candidates, so a raw argmin over the mean
+latencies picks a different winner from process to process. This module
+breaks such statistical ties with a deterministic config key so that repeated
+tuning of the same shape on the same GPU selects the same kernel.
+"""
+
+from typing import Any, Callable, Sequence
+
+# Two configs whose means differ by less than this fraction are considered
+# tied even when their confidence intervals do not overlap: run-to-run drift
+# of the mean itself is of this order, so ranking inside the band is noise.
+TIE_REL_TOL = 0.02
+
+
+def rank_measurements(
+    successes: Sequence[Any],
+    config_key: Callable[[Any], tuple],
+) -> list:
+    """Rank measurements fastest first, ordering ties by ``config_key``.
+
+    A measurement is tied with the fastest one when the gap between their
+    means is within the combined 95% error margins or within ``TIE_REL_TOL``
+    of the best mean. Tied measurements are ordered by ``config_key`` so the
+    selection is stable across runs; the rest keep the latency order.
+
+    ``config_key`` must map a config to a tuple of primitives forming a total
+    order. It only ever reorders statistically indistinguishable candidates,
+    so it cannot trade away measurable performance.
+    """
+    by_time = sorted(successes, key=lambda m: m.mean_us)
+    best = by_time[0]
+    tol = max(best.error_margin_us, TIE_REL_TOL * best.mean_us)
+
+    def _tied(m):
+        return m.mean_us - best.mean_us <= m.error_margin_us + tol
+
+    band = [m for m in by_time if _tied(m)]
+    rest = [m for m in by_time if not _tied(m)]
+    return sorted(band, key=lambda m: config_key(m.config)) + rest

--- a/flashinfer/gemm/kernels/cutile/_tune_select.py
+++ b/flashinfer/gemm/kernels/cutile/_tune_select.py
@@ -11,14 +11,16 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Deterministic ranking of cuTile ``exhaustive_search`` measurements.
+"""Stable ranking of cuTile ``exhaustive_search`` measurements.
 
 ``exhaustive_search`` stops sampling a candidate once its error margin drops
 below max(1% of mean, 0.5 us). For fast kernels this margin is of the same
 order as the gap between the top candidates, so a raw argmin over the mean
 latencies picks a different winner from process to process. This module
-breaks such statistical ties with a deterministic config key so that repeated
-tuning of the same shape on the same GPU selects the same kernel.
+breaks such statistical ties with a fixed config key, which reduces the
+run-to-run variance in the kernel selected for the same shape on the same
+GPU. The selection is not fully deterministic: the tie band itself still
+depends on the measured means and error margins.
 """
 
 from typing import Any, Callable, Sequence

--- a/flashinfer/gemm/kernels/cutile/_tune_select.py
+++ b/flashinfer/gemm/kernels/cutile/_tune_select.py
@@ -48,10 +48,13 @@ def rank_measurements(
     """
     by_time = sorted(successes, key=lambda m: m.mean_us)
     best = by_time[0]
-    tol = max(best.error_margin_us, TIE_REL_TOL * best.mean_us)
 
     def _tied(m):
-        return m.mean_us - best.mean_us <= m.error_margin_us + tol
+        gap = m.mean_us - best.mean_us
+        return (
+            gap <= m.error_margin_us + best.error_margin_us
+            or gap <= TIE_REL_TOL * best.mean_us
+        )
 
     band = [m for m in by_time if _tied(m)]
     rest = [m for m in by_time if not _tied(m)]

--- a/flashinfer/gemm/kernels/cutile/bmm_bf16_cutile.py
+++ b/flashinfer/gemm/kernels/cutile/bmm_bf16_cutile.py
@@ -47,6 +47,8 @@ import cuda.tile as ct
 import torch
 from cuda.tile.tune import exhaustive_search
 
+from ._tune_select import rank_measurements
+
 
 def make_bmm_bf16_tune_cache() -> dict:
     """Create a fresh tune cache for :func:`bmm_bf16_cutile`.
@@ -247,6 +249,20 @@ def _bmm_bf16_autotune_configs(device=None):
                     )
 
 
+def _config_sort_key(cfg):
+    """Deterministic tie-break order: prefer the config that launches the
+    fewest CTAs, then the smallest tile. Extra occupancy only adds no-op
+    CTAs when the tile count already covers the grid."""
+    return (
+        cfg.occupancy,
+        cfg.num_ctas,
+        cfg.BLOCK_M * cfg.BLOCK_N,
+        cfg.BLOCK_M,
+        cfg.BLOCK_K,
+        cfg.GROUP_SIZE_M,
+    )
+
+
 def _bmm_bf16_autotune_and_launch(
     stream,
     a_flat,  # (B*M, K) row-major bf16
@@ -329,9 +345,10 @@ def _bmm_bf16_autotune_and_launch(
         )
 
         # exhaustive_search ranks configs by latency only — verify correctness
-        # (no NaN, no Inf) by re-running each ranked config in order and
-        # accepting the first one whose output is finite. Mirrors gemm.py.
-        ranked = sorted(result.successes, key=lambda m: m.mean_us)
+        # (no NaN, no Inf) by re-running each ranked config in order (fastest
+        # first, statistical ties broken deterministically) and accepting the
+        # first one whose output is finite. Mirrors gemm.py.
+        ranked = rank_measurements(result.successes, _config_sort_key)
         best_cfg = None
         for measure in ranked:
             trial_cfg = measure.config
@@ -348,8 +365,8 @@ def _bmm_bf16_autotune_and_launch(
             break
         if best_cfg is None:
             # All autotune candidates produced NaN/Inf or failed; fall back to
-            # exhaustive_search's nominal best so we still launch something.
-            best_cfg = result.best.config
+            # the top-ranked config so we still launch something.
+            best_cfg = ranked[0].config
 
         tune_cache[cache_key] = (
             best_cfg,

--- a/flashinfer/gemm/kernels/cutile/bmm_bf16_cutile.py
+++ b/flashinfer/gemm/kernels/cutile/bmm_bf16_cutile.py
@@ -250,9 +250,9 @@ def _bmm_bf16_autotune_configs(device=None):
 
 
 def _config_sort_key(cfg):
-    """Deterministic tie-break order: prefer the config that launches the
-    fewest CTAs, then the smallest tile. Extra occupancy only adds no-op
-    CTAs when the tile count already covers the grid."""
+    """Tie-break order among statistically tied configs: lowest occupancy
+    first, then fewest CTAs, then the smallest tile. Extra occupancy only
+    adds no-op CTAs when the tile count already covers the grid."""
     return (
         cfg.occupancy,
         cfg.num_ctas,
@@ -346,8 +346,8 @@ def _bmm_bf16_autotune_and_launch(
 
         # exhaustive_search ranks configs by latency only — verify correctness
         # (no NaN, no Inf) by re-running each ranked config in order (fastest
-        # first, statistical ties broken deterministically) and accepting the
-        # first one whose output is finite. Mirrors gemm.py.
+        # first, statistical ties broken by a fixed config key) and accepting
+        # the first one whose output is finite. Mirrors gemm.py.
         ranked = rank_measurements(result.successes, _config_sort_key)
         best_cfg = None
         for measure in ranked:

--- a/flashinfer/gemm/kernels/cutile/gemm_fp8_nt_groupwise_cutile.py
+++ b/flashinfer/gemm/kernels/cutile/gemm_fp8_nt_groupwise_cutile.py
@@ -48,6 +48,8 @@ import cuda.tile as ct
 import torch
 from cuda.tile.tune import exhaustive_search
 
+from ._tune_select import rank_measurements
+
 
 # Module-level tune cache:
 #   key:   (M, N, K, block_n, block_k, output_dtype_int, dtype, str(device))
@@ -215,6 +217,16 @@ def _w8a8_autotune_configs(block_n_quant, block_k_quant):
                 )
 
 
+def _w8a8_config_sort_key(cfg):
+    """Deterministic tie-break order among statistically tied configs."""
+    return (
+        cfg.occupancy,
+        cfg.num_ctas,
+        cfg.BLOCK_SIZE_M,
+        int(cfg.swap_ab),
+    )
+
+
 def _w8a8_early_config_prune(configs, M):
     """Drop configs whose BLOCK_SIZE_M exceeds the M dimension."""
     pruned = [cfg for cfg in configs if cfg.BLOCK_SIZE_M <= M]
@@ -299,7 +311,7 @@ def _w8a8_autotune_and_launch(
             args_fn,
             hints_fn,
         )
-        best_cfg = result.best.config
+        best_cfg = rank_measurements(result.successes, _w8a8_config_sort_key)[0].config
         tuned_kernel = ct.kernel(
             _w8a8_block_fp8_matmul_kernel._pyfunc,
             num_ctas=best_cfg.num_ctas,

--- a/flashinfer/gemm/kernels/cutile/gemm_fp8_nt_groupwise_cutile.py
+++ b/flashinfer/gemm/kernels/cutile/gemm_fp8_nt_groupwise_cutile.py
@@ -335,7 +335,7 @@ def _w8a8_autotune_configs(block_n_quant, block_k_quant):
 
 
 def _w8a8_config_sort_key(cfg):
-    """Deterministic tie-break order among statistically tied configs."""
+    """Tie-break order among statistically tied configs."""
     return (
         cfg.occupancy,
         cfg.num_ctas,

--- a/flashinfer/gemm/kernels/cutile/gemm_fp8_nt_groupwise_cutile.py
+++ b/flashinfer/gemm/kernels/cutile/gemm_fp8_nt_groupwise_cutile.py
@@ -42,6 +42,7 @@ import torch
 from cuda.tile.tune import exhaustive_search
 
 from ....cutile.cutile_common import cached_replace_hints
+from ._tune_select import rank_measurements
 
 
 # Module-level tune cache:
@@ -333,6 +334,16 @@ def _w8a8_autotune_configs(block_n_quant, block_k_quant):
                 )
 
 
+def _w8a8_config_sort_key(cfg):
+    """Deterministic tie-break order among statistically tied configs."""
+    return (
+        cfg.occupancy,
+        cfg.num_ctas,
+        cfg.BLOCK_SIZE_M,
+        int(cfg.swap_ab),
+    )
+
+
 def _w8a8_early_config_prune(configs, M):
     """Drop configs whose BLOCK_SIZE_M exceeds the M dimension."""
     pruned = [cfg for cfg in configs if cfg.BLOCK_SIZE_M <= M]
@@ -427,7 +438,7 @@ def _w8a8_autotune_and_launch(
             build_args,
             hints_fn,
         )
-        best_cfg = result.best.config
+        best_cfg = rank_measurements(result.successes, _w8a8_config_sort_key)[0].config
         tuned_kernel = ct.kernel(
             kernel._pyfunc,
             num_ctas=best_cfg.num_ctas,

--- a/flashinfer/gemm/kernels/cutile/mm_bf16_cutile.py
+++ b/flashinfer/gemm/kernels/cutile/mm_bf16_cutile.py
@@ -36,6 +36,8 @@ import cuda.tile as ct
 import torch
 from cuda.tile.tune import exhaustive_search
 
+from ._tune_select import rank_measurements
+
 
 def _cdiv(a: int, b: int) -> int:
     """Ceiling division helper."""
@@ -256,6 +258,21 @@ def _autotune_configs(device=None):
                         occupancy=occupancy,
                         EPILOGUE_SUBTILE=0,
                     )
+
+
+def _config_sort_key(cfg):
+    """Deterministic tie-break order: prefer the config that launches the
+    fewest CTAs, then the smallest tile. Extra occupancy only adds no-op
+    CTAs when the tile count already covers the grid."""
+    return (
+        cfg.occupancy,
+        cfg.num_ctas,
+        cfg.BLOCK_M * cfg.BLOCK_N,
+        cfg.BLOCK_M,
+        cfg.BLOCK_K,
+        cfg.GROUP_SIZE_M,
+        cfg.EPILOGUE_SUBTILE,
+    )
 
 
 def _default_kernel_config(device=None):
@@ -514,8 +531,9 @@ def _gemm_alpha_beta_cutile(
             # exhaustive_search ranks configs by latency only — it does not
             # verify numerical correctness. We've observed configurations that
             # complete in measurable time but produce NaN on specific shape
-            # combinations. Walk the success list from fastest to slowest and
-            # pick the first config whose output is NaN/Inf-free.
+            # combinations. Walk the success list (fastest first, statistical
+            # ties broken deterministically) and pick the first config whose
+            # output is NaN/Inf-free.
             #
             # A reference is computed from torch.mm on the same inputs; we
             # accept the cfg if its output matches the reference's overall
@@ -523,7 +541,7 @@ def _gemm_alpha_beta_cutile(
             # cosine-similarity threshold here — the kernel itself is bit-
             # identical to TileGym's verified version, so any genuine
             # correctness mismatch would surface differently.
-            ranked = sorted(result.successes, key=lambda m: m.mean_us)
+            ranked = rank_measurements(result.successes, _config_sort_key)
             best_cfg = None
             tuned_kernel = None
             # Reuse the pre-allocated ``autotune_out`` rather than allocating
@@ -593,13 +611,13 @@ def _gemm_alpha_beta_cutile(
 
             if best_cfg is None:
                 # All autotune candidates produced NaN/Inf or failed at probe
-                # time. Fall back to exhaustive_search's nominal best so we
-                # still launch something — it at least completed one timed
-                # run successfully. Mirrors bmm.py. We deliberately avoid
+                # time. Fall back to the top-ranked config so we still launch
+                # something — it at least completed one timed run
+                # successfully. Mirrors bmm.py. We deliberately avoid
                 # ``_default_kernel_config`` here because its hand-picked
                 # shape (BLOCK_M=256 on sm100) is not guaranteed to work for
                 # rare small-M shapes the autotune space already covered.
-                best_cfg = result.best.config
+                best_cfg = ranked[0].config
                 tuned_kernel = _gemm_alpha_beta_kernel_cutile.replace_hints(
                     num_ctas=best_cfg.num_ctas,
                     occupancy=best_cfg.occupancy,

--- a/flashinfer/gemm/kernels/cutile/mm_bf16_cutile.py
+++ b/flashinfer/gemm/kernels/cutile/mm_bf16_cutile.py
@@ -261,9 +261,9 @@ def _autotune_configs(device=None):
 
 
 def _config_sort_key(cfg):
-    """Deterministic tie-break order: prefer the config that launches the
-    fewest CTAs, then the smallest tile. Extra occupancy only adds no-op
-    CTAs when the tile count already covers the grid."""
+    """Tie-break order among statistically tied configs: lowest occupancy
+    first, then fewest CTAs, then the smallest tile. Extra occupancy only
+    adds no-op CTAs when the tile count already covers the grid."""
     return (
         cfg.occupancy,
         cfg.num_ctas,
@@ -532,8 +532,8 @@ def _gemm_alpha_beta_cutile(
             # verify numerical correctness. We've observed configurations that
             # complete in measurable time but produce NaN on specific shape
             # combinations. Walk the success list (fastest first, statistical
-            # ties broken deterministically) and pick the first config whose
-            # output is NaN/Inf-free.
+            # ties broken by a fixed config key) and pick the first config
+            # whose output is NaN/Inf-free.
             #
             # A reference is computed from torch.mm on the same inputs; we
             # accept the cfg if its output matches the reference's overall

--- a/tests/gemm/test_cutile_tune_select.py
+++ b/tests/gemm/test_cutile_tune_select.py
@@ -1,0 +1,99 @@
+from types import SimpleNamespace
+
+from flashinfer.gemm.kernels.cutile._tune_select import TIE_REL_TOL, rank_measurements
+
+
+def _measure(mean_us, error_margin_us, occupancy, block_m=64, block_n=64):
+    return SimpleNamespace(
+        mean_us=mean_us,
+        error_margin_us=error_margin_us,
+        config=SimpleNamespace(
+            occupancy=occupancy,
+            num_ctas=1,
+            BLOCK_M=block_m,
+            BLOCK_N=block_n,
+            BLOCK_K=64,
+            GROUP_SIZE_M=8,
+        ),
+    )
+
+
+def _key(cfg):
+    return (
+        cfg.occupancy,
+        cfg.num_ctas,
+        cfg.BLOCK_M * cfg.BLOCK_N,
+        cfg.BLOCK_M,
+        cfg.BLOCK_K,
+        cfg.GROUP_SIZE_M,
+    )
+
+
+def test_ci_overlap_tie_prefers_key_order():
+    # occupancy=8 measures fastest but within combined error margins of
+    # occupancy=1, so the deterministic key decides.
+    measurements = [
+        _measure(52.3, 0.5, occupancy=8),
+        _measure(52.6, 0.5, occupancy=1),
+    ]
+    ranked = rank_measurements(measurements, _key)
+    assert [m.config.occupancy for m in ranked] == [1, 8]
+
+
+def test_rel_tol_floor_catches_narrow_ci():
+    # Gap exceeds the combined error margins but stays under TIE_REL_TOL of
+    # the best mean, so it is still treated as a tie.
+    best, second = 51.4, 52.0
+    assert second - best > 0.2 + 0.3
+    assert second - best < TIE_REL_TOL * best
+    measurements = [
+        _measure(best, 0.2, occupancy=8),
+        _measure(second, 0.3, occupancy=1),
+    ]
+    ranked = rank_measurements(measurements, _key)
+    assert [m.config.occupancy for m in ranked] == [1, 8]
+
+
+def test_clear_winner_stays_first():
+    measurements = [
+        _measure(50.0, 0.1, occupancy=8),
+        _measure(60.0, 0.1, occupancy=1),
+    ]
+    ranked = rank_measurements(measurements, _key)
+    assert [m.config.occupancy for m in ranked] == [8, 1]
+
+
+def test_non_tied_tail_keeps_latency_order():
+    measurements = [
+        _measure(52.3, 0.5, occupancy=8),
+        _measure(52.6, 0.5, occupancy=1),
+        _measure(70.0, 0.5, occupancy=1, block_m=256),
+        _measure(60.0, 0.5, occupancy=4, block_m=128),
+    ]
+    ranked = rank_measurements(measurements, _key)
+    assert [m.mean_us for m in ranked] == [52.6, 52.3, 60.0, 70.0]
+
+
+def test_input_order_does_not_matter():
+    measurements = [
+        _measure(52.6, 0.5, occupancy=1),
+        _measure(60.0, 0.5, occupancy=4, block_m=128),
+        _measure(52.3, 0.5, occupancy=8),
+    ]
+    forward = rank_measurements(measurements, _key)
+    backward = rank_measurements(list(reversed(measurements)), _key)
+    assert [m.mean_us for m in forward] == [m.mean_us for m in backward]
+    assert forward[0].config.occupancy == 1
+
+
+def test_all_measurements_are_returned():
+    measurements = [_measure(50.0 + i, 0.5, occupancy=1 + i % 4) for i in range(8)]
+    ranked = rank_measurements(measurements, _key)
+    assert len(ranked) == len(measurements)
+    assert {id(m) for m in ranked} == {id(m) for m in measurements}
+
+
+def test_single_measurement():
+    measurements = [_measure(52.3, 0.5, occupancy=8)]
+    ranked = rank_measurements(measurements, _key)
+    assert ranked == measurements

--- a/tests/gemm/test_cutile_tune_select.py
+++ b/tests/gemm/test_cutile_tune_select.py
@@ -54,6 +54,21 @@ def test_rel_tol_floor_catches_narrow_ci():
     assert [m.config.occupancy for m in ranked] == [1, 8]
 
 
+def test_gap_outside_both_rules_is_not_tied():
+    # The gap exceeds the combined error margins (0.7) and TIE_REL_TOL of the
+    # best mean (2.0), so the slower candidate must keep its latency rank
+    # even though its own margin plus the relative band (2.6) would cover it.
+    best, second = 100.0, 102.5
+    assert second - best > 0.1 + 0.6
+    assert second - best > TIE_REL_TOL * best
+    measurements = [
+        _measure(best, 0.1, occupancy=8),
+        _measure(second, 0.6, occupancy=1),
+    ]
+    ranked = rank_measurements(measurements, _key)
+    assert [m.config.occupancy for m in ranked] == [8, 1]
+
+
 def test_clear_winner_stays_first():
     measurements = [
         _measure(50.0, 0.1, occupancy=8),

--- a/tests/gemm/test_cutile_tune_select.py
+++ b/tests/gemm/test_cutile_tune_select.py
@@ -31,7 +31,7 @@ def _key(cfg):
 
 def test_ci_overlap_tie_prefers_key_order():
     # occupancy=8 measures fastest but within combined error margins of
-    # occupancy=1, so the deterministic key decides.
+    # occupancy=1, so the config key decides.
     measurements = [
         _measure(52.3, 0.5, occupancy=8),
         _measure(52.6, 0.5, occupancy=1),


### PR DESCRIPTION
## 📌 Description

<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->
Adds a small shared helper and applies it to the `mm_bf16`, `bmm_bf16`, and `gemm_fp8_nt_groupwise` cuTile paths, with unit tests. Other cuTile GEMMs (alpha-beta, masked/ragged bmm, block-scaled, grouped FP8) and FMHA are not touched.

`exhaustive_search` stops sampling a candidate once its error margin drops below max(1% of mean, 0.5 us). For fast kernels this margin is of the same order as the gap between the top candidates, so the argmin decision is made inside the measurement noise. In my testing on an RTX PRO 6000 Blackwell (SM120) with `mm_bf16` m=1, n=4096, k=4096, the top-2 gap was 0.1 to 0.3 us while the reported margins were 0.4 to 0.5 us, and 11 fresh processes split 6 to 5 between `occupancy=8` and `occupancy=1`.

A candidate is treated as tied with the fastest one when the gap between their means is within the combined 95% error margins, or within 2% of the best mean (run-to-run drift of the mean itself is of this order, so ranking inside that band is noise). Tied candidates are ordered by a fixed config key, lowest occupancy first, then fewest CTAs, then smallest tile; the rest keep the latency order. The NaN/Inf probe in the mm and bmm paths walks the same reordered list, so its fallback follows the same order.

This reduces run-to-run variance in the selected config; it does not make the selection fully deterministic, since the tie band still depends on the measured means and margins.

Preferring the lowest occupancy within a tie seems safe here: when total_tiles already covers the grid, higher occupancy only adds CTAs that exit the persistent loop immediately.
## 🔍 Related Issues

<!-- Link any related issues here -->
#4433
## 🚀 Pull Request Checklist

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

12 fresh-process autotune runs of the m=1, n=4096, k=4096 case on SM120 after the change: the winner is `occupancy=1` in 12 of 12 runs. Before the change, 11 runs split 6 to 5 between two configs.

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Improved cuTile autotuning to select configurations more consistently when measured performance is nearly identical.
  * Added deterministic tie-breaking for equivalent configurations, improving reproducibility across runs.
  * Improved fallback behavior when candidate validation fails by selecting the highest-ranked available configuration.

* **Tests**
  * Added coverage for latency ties, tolerance handling, clear winners, ordering independence, preservation of results, and single-result scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->