### PR TITLE
feat(moe): add SiTU-GLU activation to the CUTLASS fused-MoE backend

### DIFF
--- a/benchmarks/routines/moe.py
+++ b/benchmarks/routines/moe.py
@@ -21,7 +21,7 @@ from flashinfer.fused_moe import (
     cutlass_fused_moe,
     fused_topk_deepseek,
 )
-from flashinfer.tllm_enums import RoutingMethodType
+from flashinfer.tllm_enums import RoutingMethodType, is_gated_activation
 from flashinfer import fp4_quantize, mxfp8_quantize
 from flashinfer.testing.utils import (
     bench_gpu_time,
@@ -74,19 +74,6 @@ def _activation_kwarg(fn, activation_type: ActivationType) -> dict:
             )
         return {"gated_act_type": _ACTIVATION_TO_GATED_ACT[activation_type]}
     return {}
-
-
-def is_gated_activation(activation_type: ActivationType) -> bool:
-    """Whether the activation splits FC1 output into gate/up halves (FC1 weight has 2*intermediate
-    rows). SwigluStep's clamp limit defaults to 7.0 (the Step-3 model value) in the kernel, so no
-    swiglu_limit tensor needs to be passed.
-    """
-    return activation_type in (
-        ActivationType.Swiglu,
-        ActivationType.Geglu,
-        ActivationType.SwigluBias,
-        ActivationType.SwigluStep,
-    )
 
 
 def run_moe_test(args):

--- a/csrc/fused_moe/cutlass_backend/cutlass_fused_moe_kernels.cuh
+++ b/csrc/fused_moe/cutlass_backend/cutlass_fused_moe_kernels.cuh
@@ -2245,6 +2245,47 @@ struct SwigluStepAdaptor {
   }
 };
 
+// SiTU-GLU (Kimi-K3 / mistral ffn_activations.situ_glu). A gated activation that transforms both
+// branches, evaluated in fp32 (bf16 rounding is visible at the tanh saturation points):
+//   out = (beta * tanh(gate / beta) * sigmoid(gate)) * (linear_beta * tanh(up / linear_beta))
+// Note the sigmoid reads the *uncapped* gate.
+struct SituAdaptor {
+  constexpr static bool IS_GLU = true;
+  float beta = 4.0f;
+  float linear_beta = 25.0f;
+
+  template <class T>
+  __device__ T operator()(T const& gate, T const& linear) const {
+    cutlass::epilogue::thread::Sigmoid<T> sigmoid{};
+    // tanh(z) == 2*sigmoid(2z) - 1. CUTLASS's Sigmoid uses ::expf, whereas its Tanh lowers to
+    // tanh.approx.f32 whose 2^-11 absolute error linear_beta=25 would amplify to ~1e-2.
+    // The `+ (-1.0f)` is because cutlass::Array has no operator-(Array, scalar).
+    auto tanh = [&](T const& z) { return sigmoid(z * 2.0f) * 2.0f + (-1.0f); };
+    return (tanh(gate * (1.0f / beta)) * sigmoid(gate) * beta) *
+           (tanh(linear * (1.0f / linear_beta)) * linear_beta);
+  }
+};
+
+__device__ inline bool hasPerExpertActivationParams(ActivationParams const& params) {
+  return params.swiglu_alpha || params.swiglu_beta || params.swiglu_limit || params.situ_beta ||
+         params.situ_linear_beta;
+}
+
+// Only assigns what the caller actually supplied, so each adaptor keeps its compile-time default
+// (e.g. SwigluStepAdaptor::limit == 7.0, SituAdaptor::beta == 4.0).
+template <class ActFn>
+__device__ void setPerExpertActivationParams(ActFn& fn, ActivationParams const& params,
+                                             int64_t expert) {
+  if constexpr (std::is_same_v<ActFn, SituAdaptor>) {
+    if (params.situ_beta) fn.beta = params.situ_beta[expert];
+    if (params.situ_linear_beta) fn.linear_beta = params.situ_linear_beta[expert];
+  } else {
+    if (params.swiglu_alpha) fn.alpha = params.swiglu_alpha[expert];
+    if (params.swiglu_beta) fn.beta = params.swiglu_beta[expert];
+    if (params.swiglu_limit) fn.limit = params.swiglu_limit[expert];
+  }
+}
+
 // ============================== Gated Activation =================================
 constexpr static int MAX_ACTIVATION_THREADS_PER_BLOCK = 256;
 
@@ -2276,26 +2317,12 @@ __global__ void doGatedActivationKernel(ActivationOutputType* output,
   int64_t const num_elems_in_col = inter_size / ACTIVATION_ELEM_PER_THREAD;
   int64_t const inter_size_vec = inter_size / ACTIVATION_ELEM_PER_THREAD;
 
-  float gate_alpha = 1.0f;
-  float gate_bias = 0.0f;
-  float gate_limit = std::numeric_limits<float>::infinity();
-  if (activation_type.swiglu_alpha || activation_type.swiglu_beta || activation_type.swiglu_limit) {
-    int expert = findTotalEltsLessThanTarget(expert_first_token_offset, num_experts_per_node,
-                                             (int64_t)token + 1) -
-                 1;
-    gate_alpha = activation_type.swiglu_alpha ? activation_type.swiglu_alpha[expert] : 1.0f;
-    gate_bias = activation_type.swiglu_beta ? activation_type.swiglu_beta[expert] : 0.0f;
-    gate_limit = activation_type.swiglu_limit ? activation_type.swiglu_limit[expert]
-                                              : std::numeric_limits<float>::infinity();
-  }
-
   ActFn fn{};
-  fn.alpha = gate_alpha;
-  fn.beta = gate_bias;
-  // Keep the activation's compile-time default limit (e.g. 7.0 for SwigluStep) unless the caller
-  // supplied a per-expert swiglu_limit tensor.
-  if (activation_type.swiglu_limit) {
-    fn.limit = gate_limit;
+  if (hasPerExpertActivationParams(activation_type)) {
+    int64_t const expert = findTotalEltsLessThanTarget(expert_first_token_offset,
+                                                       num_experts_per_node, (int64_t)token + 1) -
+                           1;
+    setPerExpertActivationParams(fn, activation_type, expert);
   }
   for (int64_t elem_index = start_offset; elem_index < num_elems_in_col; elem_index += stride) {
     auto linear_value = arrayConvert<GemmResultElem, ComputeElem>(gemm_result_vec[elem_index]);
@@ -2328,6 +2355,8 @@ void doGatedActivation(ActivationOutputType* output, GemmOutputType const* gemm_
                  ? &doGatedActivationKernel<ActivationOutputType, GemmOutputType, SwigluBiasAdaptor>
              : activation_type == ActivationType::SwigluStep
                  ? &doGatedActivationKernel<ActivationOutputType, GemmOutputType, SwigluStepAdaptor>
+             : activation_type == ActivationType::Situ
+                 ? &doGatedActivationKernel<ActivationOutputType, GemmOutputType, SituAdaptor>
                  : nullptr;
   TLLM_CHECK_WITH_INFO(fn != nullptr, "Invalid activation type");
   fn<<<blocks, threads, 0, stream>>>(output, gemm_result, expert_first_token_offset, inter_size,
@@ -2391,22 +2420,13 @@ __global__ __launch_bounds__(MAX_ACTIVATION_THREADS_PER_BLOCK) void doActivation
     size_t output_offset = token * inter_size;
 
     int64_t expert = 0;
-    float gate_alpha = 1.0f;
-    float gate_beta = 0.0f;
-    float gate_limit = std::numeric_limits<float>::infinity();
     if (bias_ptr || IsNVFP4 || IsMXFP8 || use_per_expert_act_scale ||
-        activation_params.swiglu_alpha || activation_params.swiglu_beta ||
-        activation_params.swiglu_limit) {
+        hasPerExpertActivationParams(activation_params)) {
       expert = permuted_token_selected_experts
                    ? permuted_token_selected_experts[token]
                    : findTotalEltsLessThanTarget(expert_first_token_offset, num_experts_per_node,
                                                  token + 1) -
                          1;
-
-      gate_alpha = activation_params.swiglu_alpha ? activation_params.swiglu_alpha[expert] : 1.0f;
-      gate_beta = activation_params.swiglu_beta ? activation_params.swiglu_beta[expert] : 0.0f;
-      gate_limit = activation_params.swiglu_limit ? activation_params.swiglu_limit[expert]
-                                                  : std::numeric_limits<float>::infinity();
     }
 
     size_t act_scale_idx = use_per_expert_act_scale ? expert : 0;
@@ -2444,13 +2464,7 @@ __global__ __launch_bounds__(MAX_ACTIVATION_THREADS_PER_BLOCK) void doActivation
     int64_t const gated_off_vec = gated_off / ACTIVATION_ELEM_PER_THREAD;
 
     ActFn fn{};
-    fn.alpha = gate_alpha;
-    fn.beta = gate_beta;
-    // Keep the activation's compile-time default limit (e.g. 7.0 for SwigluStep) unless the caller
-    // supplied a per-expert swiglu_limit tensor.
-    if (activation_params.swiglu_limit) {
-      fn.limit = gate_limit;
-    }
+    setPerExpertActivationParams(fn, activation_params, expert);
     auto compute_activation = [&](int64_t elem_index) {
       GemmResultElem fc1_gemm_value;
       cutlass::arch::global_load<GemmResultElem, sizeof(GemmResultElem)>(
@@ -2670,7 +2684,11 @@ void doActivation(T* output, GemmOutputType const* gemm_result, float const* fp8
                               IdentityAdaptor<cutlass::epilogue::thread::Identity>,
                               decltype(block_scaling_type)::value,
                               decltype(disableFP4QuantFastMathTag)::value,
-                              decltype(nvfp4_4over6_config_tag)>  // Identity
+                              decltype(nvfp4_4over6_config_tag)>,  // Identity
+          &doActivationKernel<T, GemmOutputType, ScaleBiasType, SituAdaptor,
+                              decltype(block_scaling_type)::value,
+                              decltype(disableFP4QuantFastMathTag)::value,
+                              decltype(nvfp4_4over6_config_tag)>  // Situ
       };
       return fn_list[static_cast<int>(activation_type.activation_type)];
     };

--- a/csrc/fused_moe/cutlass_backend/flashinfer_cutlass_fused_moe_binding.cu
+++ b/csrc/fused_moe/cutlass_backend/flashinfer_cutlass_fused_moe_binding.cu
@@ -81,6 +81,17 @@ class DtypeUtils {
   DtypeUtils() = default;
 };
 
+// Validates one of the optional per-expert activation scale tensors (swiglu_alpha, situ_beta, ...)
+// and returns its data pointer, or nullptr when the caller did not supply it.
+inline float const* checkedPerExpertScale(Optional<TensorView> const& scale,
+                                          int num_experts_on_rank, char const* name) {
+  if (!scale.has_value()) return nullptr;
+  CHECK_INPUT_AND_TYPE(scale.value(), dl_float32);
+  TVM_FFI_ICHECK_EQ(scale.value().size(0), num_experts_on_rank)
+      << name << " must have num_experts_on_rank elements.";
+  return static_cast<float const*>(scale.value().data_ptr());
+}
+
 class FusedMoeRunner : public tvm::ffi::ModuleObj {
  public:
   template <
@@ -302,6 +313,7 @@ class FusedMoeRunner : public tvm::ffi::ModuleObj {
               Optional<TensorView> fc2_expert_biases, Optional<Array<Tensor>> quant_scales,
               Optional<TensorView> input_sf, Optional<TensorView> swiglu_alpha,
               Optional<TensorView> swiglu_beta, Optional<TensorView> swiglu_limit,
+              Optional<TensorView> situ_beta, Optional<TensorView> situ_linear_beta,
               bool swizzled_input_sf, int64_t tp_size, int64_t tp_rank, int64_t ep_size,
               int64_t ep_rank, int64_t cluster_size, int64_t cluster_rank, bool enable_alltoall,
               bool min_latency_mode, Optional<Array<int64_t>> profile_ids, bool enable_pdl,
@@ -397,21 +409,6 @@ class FusedMoeRunner : public tvm::ffi::ModuleObj {
     int const num_experts_on_rank = fc2_expert_weights.size(0);
     auto const num_experts_total = static_cast<int>(num_experts_on_rank * ep_size);
     auto parallelism_config = kernels::MOEParallelismConfig(tp_size, tp_rank, ep_size, ep_rank);
-    if (swiglu_alpha.has_value()) {
-      CHECK_INPUT_AND_TYPE(swiglu_alpha.value(), dl_float32);
-      TVM_FFI_ICHECK_EQ(swiglu_alpha.value().size(0), num_experts_on_rank)
-          << "swiglu_alpha must have num_experts_on_rank elements.";
-    }
-    if (swiglu_beta.has_value()) {
-      CHECK_INPUT_AND_TYPE(swiglu_beta.value(), dl_float32);
-      TVM_FFI_ICHECK_EQ(swiglu_beta.value().size(0), num_experts_on_rank)
-          << "swiglu_beta must have num_experts_on_rank elements.";
-    }
-    if (swiglu_limit.has_value()) {
-      CHECK_INPUT_AND_TYPE(swiglu_limit.value(), dl_float32);
-      TVM_FFI_ICHECK_EQ(swiglu_limit.value().size(0), num_experts_on_rank)
-          << "swiglu_limit must have num_experts_on_rank elements.";
-    }
     // Swiglu + swiglu_alpha/beta/limit selects the SwigluBias kernel; other gated activations
     // (e.g. SwigluStep) keep their own kernel.
     if (base_activation_type == ActivationType::Swiglu &&
@@ -420,12 +417,11 @@ class FusedMoeRunner : public tvm::ffi::ModuleObj {
     }
     auto activation_params = ActivationParams(
         base_activation_type,
-        reinterpret_cast<float const*>(swiglu_alpha.has_value() ? swiglu_alpha.value().data_ptr()
-                                                                : nullptr),
-        reinterpret_cast<float const*>(swiglu_beta.has_value() ? swiglu_beta.value().data_ptr()
-                                                               : nullptr),
-        reinterpret_cast<float const*>(swiglu_limit.has_value() ? swiglu_limit.value().data_ptr()
-                                                                : nullptr));
+        checkedPerExpertScale(swiglu_alpha, num_experts_on_rank, "swiglu_alpha"),
+        checkedPerExpertScale(swiglu_beta, num_experts_on_rank, "swiglu_beta"),
+        checkedPerExpertScale(swiglu_limit, num_experts_on_rank, "swiglu_limit"),
+        checkedPerExpertScale(situ_beta, num_experts_on_rank, "situ_beta"),
+        checkedPerExpertScale(situ_linear_beta, num_experts_on_rank, "situ_linear_beta"));
 
     setRunnerProfiles(profile_ids);
 
@@ -486,7 +482,8 @@ class FusedMoeRunner : public tvm::ffi::ModuleObj {
                          Optional<TensorView> fc2_expert_biases,
                          Optional<Array<Tensor>> quant_scales, Optional<TensorView> input_sf,
                          Optional<TensorView> swiglu_alpha, Optional<TensorView> swiglu_beta,
-                         Optional<TensorView> swiglu_limit, bool swizzled_input_sf,
+                         Optional<TensorView> swiglu_limit, Optional<TensorView> situ_beta,
+                         Optional<TensorView> situ_linear_beta, bool swizzled_input_sf,
                          TensorView num_active_experts_per_node, TensorView experts_to_token_score,
                          TensorView active_expert_global_ids, int64_t tp_size, int64_t tp_rank,
                          int64_t ep_size, int64_t ep_rank, int64_t cluster_size,
@@ -567,21 +564,6 @@ class FusedMoeRunner : public tvm::ffi::ModuleObj {
     int const num_experts_on_rank = fc2_expert_weights.size(0);
     auto const num_experts_total = static_cast<int>(num_experts_on_rank * ep_size);
     auto parallelism_config = kernels::MOEParallelismConfig(tp_size, tp_rank, ep_size, ep_rank);
-    if (swiglu_alpha.has_value()) {
-      CHECK_INPUT_AND_TYPE(swiglu_alpha.value(), dl_float32);
-      TVM_FFI_ICHECK_EQ(swiglu_alpha.value().size(0), num_experts_on_rank)
-          << "swiglu_alpha must have num_experts_on_rank elements.";
-    }
-    if (swiglu_beta.has_value()) {
-      CHECK_INPUT_AND_TYPE(swiglu_beta.value(), dl_float32);
-      TVM_FFI_ICHECK_EQ(swiglu_beta.value().size(0), num_experts_on_rank)
-          << "swiglu_beta must have num_experts_on_rank elements.";
-    }
-    if (swiglu_limit.has_value()) {
-      CHECK_INPUT_AND_TYPE(swiglu_limit.value(), dl_float32);
-      TVM_FFI_ICHECK_EQ(swiglu_limit.value().size(0), num_experts_on_rank)
-          << "swiglu_limit must have num_experts_on_rank elements.";
-    }
     // Swiglu + swiglu_alpha/beta/limit selects the SwigluBias kernel; other gated activations
     // (e.g. SwigluStep) keep their own kernel.
     if (base_activation_type == ActivationType::Swiglu &&
@@ -590,12 +572,11 @@ class FusedMoeRunner : public tvm::ffi::ModuleObj {
     }
     auto activation_params = ActivationParams(
         base_activation_type,
-        reinterpret_cast<float const*>(swiglu_alpha.has_value() ? swiglu_alpha.value().data_ptr()
-                                                                : nullptr),
-        reinterpret_cast<float const*>(swiglu_beta.has_value() ? swiglu_beta.value().data_ptr()
-                                                               : nullptr),
-        reinterpret_cast<float const*>(swiglu_limit.has_value() ? swiglu_limit.value().data_ptr()
-                                                                : nullptr));
+        checkedPerExpertScale(swiglu_alpha, num_experts_on_rank, "swiglu_alpha"),
+        checkedPerExpertScale(swiglu_beta, num_experts_on_rank, "swiglu_beta"),
+        checkedPerExpertScale(swiglu_limit, num_experts_on_rank, "swiglu_limit"),
+        checkedPerExpertScale(situ_beta, num_experts_on_rank, "situ_beta"),
+        checkedPerExpertScale(situ_linear_beta, num_experts_on_rank, "situ_linear_beta"));
 
     setRunnerProfiles(profile_ids);
 
@@ -811,16 +792,17 @@ class FusedMoeRunner : public tvm::ffi::ModuleObj {
                  Optional<TensorView> fc2_expert_biases, Optional<Array<Tensor>> quant_scales,
                  Optional<TensorView> input_sf, Optional<TensorView> swiglu_alpha,
                  Optional<TensorView> swiglu_beta, Optional<TensorView> swiglu_limit,
+                 Optional<TensorView> situ_beta, Optional<TensorView> situ_linear_beta,
                  bool swizzled_input_sf, int64_t tp_size, int64_t tp_rank, int64_t ep_size,
                  int64_t ep_rank, int64_t cluster_size, int64_t cluster_rank, bool enable_alltoall,
                  bool min_latency_mode, Optional<Array<int64_t>> profile_ids, bool enable_pdl,
                  int64_t base_activation_type, Optional<TensorView> workspace_buffer) {
             runMoe(output, input, token_selected_experts, token_final_scales, fc1_expert_weights,
                    fc1_expert_biases, fc2_expert_weights, fc2_expert_biases, quant_scales, input_sf,
-                   swiglu_alpha, swiglu_beta, swiglu_limit, swizzled_input_sf, tp_size, tp_rank,
-                   ep_size, ep_rank, cluster_size, cluster_rank, enable_alltoall, min_latency_mode,
-                   profile_ids, enable_pdl, static_cast<ActivationType>(base_activation_type),
-                   workspace_buffer);
+                   swiglu_alpha, swiglu_beta, swiglu_limit, situ_beta, situ_linear_beta,
+                   swizzled_input_sf, tp_size, tp_rank, ep_size, ep_rank, cluster_size,
+                   cluster_rank, enable_alltoall, min_latency_mode, profile_ids, enable_pdl,
+                   static_cast<ActivationType>(base_activation_type), workspace_buffer);
           });
     } else if (name == "run_moe_min_latency") {
       return Function::FromTyped(
@@ -830,20 +812,21 @@ class FusedMoeRunner : public tvm::ffi::ModuleObj {
                  Optional<TensorView> fc2_expert_biases, Optional<Array<Tensor>> quant_scales,
                  Optional<TensorView> input_sf, Optional<TensorView> swiglu_alpha,
                  Optional<TensorView> swiglu_beta, Optional<TensorView> swiglu_limit,
+                 Optional<TensorView> situ_beta, Optional<TensorView> situ_linear_beta,
                  bool swizzled_input_sf, TensorView num_active_experts_per_node,
                  TensorView experts_to_token_score, TensorView active_expert_global_ids,
                  int64_t tp_size, int64_t tp_rank, int64_t ep_size, int64_t ep_rank,
                  int64_t cluster_size, int64_t cluster_rank, bool enable_alltoall,
                  bool min_latency_mode, Optional<Array<int64_t>> profile_ids, bool enable_pdl,
                  int64_t base_activation_type, Optional<TensorView> workspace_buffer) {
-            runMoeMinLantency(output, input, token_selected_experts, token_final_scales,
-                              fc1_expert_weights, fc1_expert_biases, fc2_expert_weights,
-                              fc2_expert_biases, quant_scales, input_sf, swiglu_alpha, swiglu_beta,
-                              swiglu_limit, swizzled_input_sf, num_active_experts_per_node,
-                              experts_to_token_score, active_expert_global_ids, tp_size, tp_rank,
-                              ep_size, ep_rank, cluster_size, cluster_rank, enable_alltoall,
-                              min_latency_mode, profile_ids, enable_pdl,
-                              static_cast<ActivationType>(base_activation_type), workspace_buffer);
+            runMoeMinLantency(
+                output, input, token_selected_experts, token_final_scales, fc1_expert_weights,
+                fc1_expert_biases, fc2_expert_weights, fc2_expert_biases, quant_scales, input_sf,
+                swiglu_alpha, swiglu_beta, swiglu_limit, situ_beta, situ_linear_beta,
+                swizzled_input_sf, num_active_experts_per_node, experts_to_token_score,
+                active_expert_global_ids, tp_size, tp_rank, ep_size, ep_rank, cluster_size,
+                cluster_rank, enable_alltoall, min_latency_mode, profile_ids, enable_pdl,
+                static_cast<ActivationType>(base_activation_type), workspace_buffer);
           });
     } else if (name == "get_workspace_size") {
       return Function::FromTyped([this](int64_t num_rows, int64_t hidden_size, int64_t inter_size,

--- a/csrc/nv_internal/tensorrt_llm/kernels/cutlass_kernels/include/common.h
+++ b/csrc/nv_internal/tensorrt_llm/kernels/cutlass_kernels/include/common.h
@@ -30,6 +30,7 @@ enum class ActivationType {
   SwigluStep,
   GegluTanh,
   Identity,
+  Situ,
   InvalidType
 };
 

--- a/csrc/nv_internal/tensorrt_llm/kernels/cutlass_kernels/include/moe_gemm_kernels.h
+++ b/csrc/nv_internal/tensorrt_llm/kernels/cutlass_kernels/include/moe_gemm_kernels.h
@@ -244,7 +244,7 @@ constexpr bool isGatedActivation(ActivationType activation_type) {
   return activation_type == ActivationType::Swiglu || activation_type == ActivationType::Geglu ||
          activation_type == ActivationType::SwigluBias ||
          activation_type == ActivationType::SwigluStep ||
-         activation_type == ActivationType::GegluTanh;
+         activation_type == ActivationType::GegluTanh || activation_type == ActivationType::Situ;
 }
 
 enum class Sm90Wfp4Afp8ScaleMode : uint8_t {

--- a/csrc/nv_internal/tensorrt_llm/kernels/cutlass_kernels/include/moe_kernels.h
+++ b/csrc/nv_internal/tensorrt_llm/kernels/cutlass_kernels/include/moe_kernels.h
@@ -118,6 +118,9 @@ struct ActivationParams {
   float const* swiglu_alpha = nullptr;
   float const* swiglu_beta = nullptr;
   float const* swiglu_limit = nullptr;
+  // SiTU-GLU per-expert tanh scales; nullptr uses the SituAdaptor compile-time defaults.
+  float const* situ_beta = nullptr;
+  float const* situ_linear_beta = nullptr;
 
   explicit ActivationParams(ActivationType activation_type) : activation_type(activation_type) {
     TLLM_CHECK_WITH_INFO(
@@ -126,11 +129,14 @@ struct ActivationParams {
   }
 
   ActivationParams(ActivationType activation_type, float const* swiglu_alpha,
-                   float const* swiglu_beta, float const* swiglu_limit)
+                   float const* swiglu_beta, float const* swiglu_limit,
+                   float const* situ_beta = nullptr, float const* situ_linear_beta = nullptr)
       : activation_type(activation_type),
         swiglu_alpha(swiglu_alpha),
         swiglu_beta(swiglu_beta),
-        swiglu_limit(swiglu_limit) {}
+        swiglu_limit(swiglu_limit),
+        situ_beta(situ_beta),
+        situ_linear_beta(situ_linear_beta) {}
 
   // TODO Port everything properly and get rid of these implicit conversions
   operator ActivationType() const { return activation_type; }

--- a/flashinfer/fused_moe/core.py
+++ b/flashinfer/fused_moe/core.py
@@ -884,6 +884,8 @@ def get_cutlass_fused_moe_module(backend: str = "100", use_fast_build: bool = Fa
         swiglu_alpha: Optional[torch.Tensor] = None,
         swiglu_beta: Optional[torch.Tensor] = None,
         swiglu_limit: Optional[torch.Tensor] = None,
+        situ_beta: Optional[torch.Tensor] = None,
+        situ_linear_beta: Optional[torch.Tensor] = None,
         swizzled_input_sf: bool = True,
         tp_size: int = 1,
         tp_rank: int = 0,
@@ -1015,6 +1017,8 @@ def get_cutlass_fused_moe_module(backend: str = "100", use_fast_build: bool = Fa
             swiglu_alpha,
             swiglu_beta,
             swiglu_limit,
+            situ_beta,
+            situ_linear_beta,
             swizzled_input_sf,
             *min_latency_output,
             tp_size,
@@ -1058,6 +1062,8 @@ def get_cutlass_fused_moe_module(backend: str = "100", use_fast_build: bool = Fa
         swiglu_alpha: Optional[torch.Tensor] = None,
         swiglu_beta: Optional[torch.Tensor] = None,
         swiglu_limit: Optional[torch.Tensor] = None,
+        situ_beta: Optional[torch.Tensor] = None,
+        situ_linear_beta: Optional[torch.Tensor] = None,
         swizzled_input_sf: bool = True,
         tp_size: int = 1,
         tp_rank: int = 0,
@@ -1185,6 +1191,8 @@ def cutlass_fused_moe(
     swiglu_alpha: Optional[torch.Tensor] = None,
     swiglu_beta: Optional[torch.Tensor] = None,
     swiglu_limit: Optional[torch.Tensor] = None,
+    situ_beta: Optional[torch.Tensor] = None,
+    situ_linear_beta: Optional[torch.Tensor] = None,
     tp_size: int = 1,
     tp_rank: int = 0,
     ep_size: int = 1,
@@ -1277,6 +1285,14 @@ def cutlass_fused_moe(
 
     swiglu_limit : Optional[torch.Tensor]
         Swiglu limit for swiglu activation.
+
+    situ_beta : Optional[torch.Tensor]
+        Per-expert ``beta`` tanh scale for the ``Situ`` activation (float32,
+        ``[num_experts_on_rank]``). ``None`` uses ``DEFAULT_SITU_BETA``.
+
+    situ_linear_beta : Optional[torch.Tensor]
+        Per-expert ``linear_beta`` tanh scale for the ``Situ`` activation (float32,
+        ``[num_experts_on_rank]``). ``None`` uses ``DEFAULT_SITU_LINEAR_BETA``.
 
     tp_size : int = 1
         Tensor parallelism size. Defaults to 1.
@@ -1447,6 +1463,8 @@ def cutlass_fused_moe(
             swiglu_alpha,
             swiglu_beta,
             swiglu_limit,
+            situ_beta,
+            situ_linear_beta,
             swizzled_input_sf,
             tp_size,
             tp_rank,

--- a/flashinfer/fused_moe/core.py
+++ b/flashinfer/fused_moe/core.py
@@ -1191,8 +1191,6 @@ def cutlass_fused_moe(
     swiglu_alpha: Optional[torch.Tensor] = None,
     swiglu_beta: Optional[torch.Tensor] = None,
     swiglu_limit: Optional[torch.Tensor] = None,
-    situ_beta: Optional[torch.Tensor] = None,
-    situ_linear_beta: Optional[torch.Tensor] = None,
     tp_size: int = 1,
     tp_rank: int = 0,
     ep_size: int = 1,
@@ -1214,6 +1212,9 @@ def cutlass_fused_moe(
     use_fused_finalize: bool = True,
     profile_ids: Optional[List[int]] = None,
     workspace_buffer: Optional[torch.Tensor] = None,
+    *,
+    situ_beta: Optional[torch.Tensor] = None,
+    situ_linear_beta: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
     """Compute a Mixture of Experts (MoE) layer using CUTLASS backend.
 

--- a/flashinfer/fused_moe/core.py
+++ b/flashinfer/fused_moe/core.py
@@ -633,6 +633,8 @@ def get_cutlass_fused_moe_module(backend: str = "100", use_fast_build: bool = Fa
         swiglu_alpha: Optional[torch.Tensor] = None,
         swiglu_beta: Optional[torch.Tensor] = None,
         swiglu_limit: Optional[torch.Tensor] = None,
+        situ_beta: Optional[torch.Tensor] = None,
+        situ_linear_beta: Optional[torch.Tensor] = None,
         swizzled_input_sf: bool = True,
         tp_size: int = 1,
         tp_rank: int = 0,
@@ -764,6 +766,8 @@ def get_cutlass_fused_moe_module(backend: str = "100", use_fast_build: bool = Fa
             swiglu_alpha,
             swiglu_beta,
             swiglu_limit,
+            situ_beta,
+            situ_linear_beta,
             swizzled_input_sf,
             *min_latency_output,
             tp_size,
@@ -807,6 +811,8 @@ def get_cutlass_fused_moe_module(backend: str = "100", use_fast_build: bool = Fa
         swiglu_alpha: Optional[torch.Tensor] = None,
         swiglu_beta: Optional[torch.Tensor] = None,
         swiglu_limit: Optional[torch.Tensor] = None,
+        situ_beta: Optional[torch.Tensor] = None,
+        situ_linear_beta: Optional[torch.Tensor] = None,
         swizzled_input_sf: bool = True,
         tp_size: int = 1,
         tp_rank: int = 0,
@@ -934,6 +940,8 @@ def cutlass_fused_moe(
     swiglu_alpha: Optional[torch.Tensor] = None,
     swiglu_beta: Optional[torch.Tensor] = None,
     swiglu_limit: Optional[torch.Tensor] = None,
+    situ_beta: Optional[torch.Tensor] = None,
+    situ_linear_beta: Optional[torch.Tensor] = None,
     tp_size: int = 1,
     tp_rank: int = 0,
     ep_size: int = 1,
@@ -1026,6 +1034,14 @@ def cutlass_fused_moe(
 
     swiglu_limit : Optional[torch.Tensor]
         Swiglu limit for swiglu activation.
+
+    situ_beta : Optional[torch.Tensor]
+        Per-expert ``beta`` tanh scale for the ``Situ`` activation (float32,
+        ``[num_experts_on_rank]``). ``None`` uses ``DEFAULT_SITU_BETA``.
+
+    situ_linear_beta : Optional[torch.Tensor]
+        Per-expert ``linear_beta`` tanh scale for the ``Situ`` activation (float32,
+        ``[num_experts_on_rank]``). ``None`` uses ``DEFAULT_SITU_LINEAR_BETA``.
 
     tp_size : int = 1
         Tensor parallelism size. Defaults to 1.
@@ -1196,6 +1212,8 @@ def cutlass_fused_moe(
             swiglu_alpha,
             swiglu_beta,
             swiglu_limit,
+            situ_beta,
+            situ_linear_beta,
             swizzled_input_sf,
             tp_size,
             tp_rank,

--- a/flashinfer/tllm_enums.py
+++ b/flashinfer/tllm_enums.py
@@ -103,6 +103,11 @@ DEFAULT_SWIGLU_ALPHA = 1.0
 DEFAULT_SWIGLU_BETA = 0.0
 DEFAULT_SWIGLU_LIMIT = torch.finfo(torch.float32).max
 
+# SiTU-GLU tanh scales. Must match the SituAdaptor defaults in
+# csrc/fused_moe/cutlass_backend/cutlass_fused_moe_kernels.cuh.
+DEFAULT_SITU_BETA = 4.0
+DEFAULT_SITU_LINEAR_BETA = 25.0
+
 
 def normalize_activation_type(
     activation_type: Union[int, ActivationType],

--- a/flashinfer/tllm_enums.py
+++ b/flashinfer/tllm_enums.py
@@ -101,6 +101,11 @@ DEFAULT_SWIGLU_ALPHA = 1.0
 DEFAULT_SWIGLU_BETA = 0.0
 DEFAULT_SWIGLU_LIMIT = torch.finfo(torch.float32).max
 
+# SiTU-GLU tanh scales. Must match the SituAdaptor defaults in
+# csrc/fused_moe/cutlass_backend/cutlass_fused_moe_kernels.cuh.
+DEFAULT_SITU_BETA = 4.0
+DEFAULT_SITU_LINEAR_BETA = 25.0
+
 
 def normalize_activation_type(
     activation_type: Union[int, ActivationType],

--- a/tests/moe/test_trtllm_cutlass_fused_moe.py
+++ b/tests/moe/test_trtllm_cutlass_fused_moe.py
@@ -20,6 +20,7 @@ import struct
 
 import pytest
 from flashinfer.fused_moe.core import ActivationType
+from flashinfer.tllm_enums import DEFAULT_SITU_BETA, DEFAULT_SITU_LINEAR_BETA
 import torch
 from torch.nn import functional as F
 
@@ -51,6 +52,17 @@ FLOAT8_E4M3_MAX = torch.finfo(torch.float8_e4m3fn).max
 FP8_DTYPE = torch.float8_e4m3fn
 
 set_nvfp4_4over6_env = moe_utils.set_nvfp4_4over6_env
+
+
+def make_situ_scales(num_experts):
+    """Per-expert SiTU-GLU tanh scales, deliberately different from DEFAULT_SITU_BETA /
+    DEFAULT_SITU_LINEAR_BETA so a kernel silently falling back to those would fail."""
+    return {
+        "situ_beta": torch.full((num_experts,), 5.0, dtype=torch.float32).cuda(),
+        "situ_linear_beta": torch.full(
+            (num_experts,), 18.0, dtype=torch.float32
+        ).cuda(),
+    }
 
 
 def dynamic_per_tensor_fp8_quant(x: torch.tensor) -> tuple[torch.tensor, torch.tensor]:
@@ -323,6 +335,8 @@ def compute_with_experts(
     beta=None,
     limit=None,
     activation_type=ActivationType.Swiglu,
+    situ_beta=DEFAULT_SITU_BETA,
+    situ_linear_beta=DEFAULT_SITU_LINEAR_BETA,
 ):
     results = torch.zeros_like(x)
     for expert_id in range(num_experts):
@@ -359,6 +373,22 @@ def compute_with_experts(
             x2 = x2.clamp_(min=-limit, max=limit) + beta
 
             inter = x1_scaled * x2
+        elif activation_type == ActivationType.Situ:
+            # SiTU-GLU, computed in fp32; see SituAdaptor in cutlass_fused_moe_kernels.cuh.
+            # situ_beta / situ_linear_beta are per-expert when given as a tensor/list.
+            sb = float(
+                situ_beta[expert_id] if hasattr(situ_beta, "__getitem__") else situ_beta
+            )
+            slb = float(
+                situ_linear_beta[expert_id]
+                if hasattr(situ_linear_beta, "__getitem__")
+                else situ_linear_beta
+            )
+            gate = (expert_inputs @ w1_expert.t()).float()
+            up = (expert_inputs @ w3_expert.t()).float()
+            out_glu = sb * torch.tanh(gate / sb) * torch.sigmoid(gate)
+            out_linear = slb * torch.tanh(up / slb)
+            inter = (out_glu * out_linear).to(x.dtype)
         else:
             inter = F.silu(expert_inputs @ w1_expert.t()) * (
                 expert_inputs @ w3_expert.t()
@@ -390,12 +420,23 @@ EP_TOP_K = [2]
 @pytest.mark.parametrize("top_k", TOP_K_VALUES)
 @pytest.mark.parametrize("intermediate_size", INTERMEDIATE_SIZES)
 @pytest.mark.parametrize(
-    "activation_type",
-    [ActivationType.Swiglu, ActivationType.SwigluStep],
-    ids=["swiglu", "swiglustep"],
+    "activation_type, situ_per_expert",
+    [
+        (ActivationType.Swiglu, False),
+        (ActivationType.SwigluStep, False),
+        (ActivationType.Situ, False),
+        (ActivationType.Situ, True),
+    ],
+    ids=["swiglu", "swiglustep", "situ_default", "situ_per_expert"],
 )
 def test_moe(
-    batch_size, hidden_size, num_experts, top_k, intermediate_size, activation_type
+    batch_size,
+    hidden_size,
+    num_experts,
+    top_k,
+    intermediate_size,
+    activation_type,
+    situ_per_expert,
 ):
     # Skip invalid configurations
     if top_k > num_experts:
@@ -425,6 +466,13 @@ def test_moe(
     )
 
     routing_weights, selected_experts = compute_routing(router_logits, top_k)
+
+    # When situ_per_expert is off the kernel must fall back to its compile-time defaults, which is
+    # what compute_with_experts() uses by default. The per-expert scales below are deliberately
+    # non-default so the test fails if the kernel ignores the tensors and falls back anyway.
+    situ_kwargs = make_situ_scales(num_experts) if situ_per_expert else {}
+    ref_situ_kwargs = {k: v.tolist() for k, v in situ_kwargs.items()}
+
     ref_output = compute_with_experts(
         num_experts,
         x,
@@ -433,6 +481,7 @@ def test_moe(
         selected_experts,
         routing_weights,
         activation_type=activation_type,
+        **ref_situ_kwargs,
     )
     flash_output = torch.empty_like(ref_output)
     flash_output = fused_moe.cutlass_fused_moe(
@@ -445,6 +494,7 @@ def test_moe(
         output=flash_output,
         quant_scales=None,
         activation_type=activation_type,
+        **situ_kwargs,
     )
 
     torch.testing.assert_close(ref_output, flash_output[0], rtol=1e-2, atol=1e-2)
@@ -613,8 +663,8 @@ def test_moe_unfused_finalize(
 @pytest.mark.parametrize("otype, wtype", [(torch.float16, torch.float8_e4m3fn)])
 @pytest.mark.parametrize(
     "activation_type",
-    [ActivationType.Swiglu, ActivationType.SwigluStep],
-    ids=["swiglu", "swiglustep"],
+    [ActivationType.Swiglu, ActivationType.SwigluStep, ActivationType.Situ],
+    ids=["swiglu", "swiglustep", "situ"],
 )
 def test_moe_fp8(
     batch_size,
@@ -661,6 +711,11 @@ def test_moe_fp8(
         w31_dequantized.data[expert_id].copy_(torch.mul(w31_quant.to(dtype=otype), s31))
         w2_dequantized.data[expert_id].copy_(torch.mul(w2_quant.to(dtype=otype), s2))
 
+    situ_kwargs = (
+        make_situ_scales(num_experts) if activation_type == ActivationType.Situ else {}
+    )
+    ref_situ_kwargs = {k: v.tolist() for k, v in situ_kwargs.items()}
+
     routing_weights, selected_experts = compute_routing(router_logits, top_k)
     ref_output = compute_with_experts(
         num_experts,
@@ -670,6 +725,7 @@ def test_moe_fp8(
         selected_experts,
         routing_weights,
         activation_type=activation_type,
+        **ref_situ_kwargs,
     )
     flash_output = torch.empty_like(ref_output)
     # For fp8, the hidden_state expects quantized.
@@ -693,6 +749,7 @@ def test_moe_fp8(
         quant_scales=quant_scales,
         output=flash_output,
         activation_type=activation_type,
+        **situ_kwargs,
     )
     torch.testing.assert_close(ref_output, flash_output, rtol=1e-1, atol=1e-1)
 


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

  Adds SiTU-GLU activation support to the CUTLASS fused-MoE backend, covering all SM variants (SM89/90/100/103/120) via the shared activation kernel code.

  - Adds `ActivationType::Situ = 10` enum value (consistent with the TRT-LLM Gen path in #4180)
  - Implements `SituAdaptor` with `beta` (default 4.0) and `linear_beta` (default 25.0) per the SiTU paper (Kimi-K3)
  - Uses `2·sigmoid(2z)−1` for tanh (matching the CuTe-DSL path in #4009) — avoids `tanh.approx.f32` error amplification at `linear_beta=25`
  - Supports per-expert `situ_beta` / `situ_linear_beta` tensors
  - Refactors per-expert activation param dispatch into `setPerExpertActivationParams()` / `hasPerExpertActivationParams()` helpers (reduces duplication across `doGatedActivationKernel` and `doActivationKernel`)
  - Tests both default and per-expert parameters in BF16 and FP8

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] `pytest tests/moe/test_trtllm_cutlass_fused_moe.py` — SiTU cases in both `test_moe` (BF16) and `test_moe_fp8`

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added SiTU-GLU activation support for fused Mixture-of-Experts operations.
  - Added optional global or per-expert SiTU scaling parameters.
  - Added support across standard, low-latency, and FP8 MoE execution paths.
  - Added default SiTU scaling values when custom parameters are not provided.
  - Added validation for per-expert scaling inputs.

- **Tests**
  - Added coverage for default and per-expert SiTU scales, including FP8 execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->