### PR TITLE
[Bugfix]: handle empty query in SM120 sparse MLA decode for speculative decoding

### DIFF
--- a/flashinfer/mla/_core.py
+++ b/flashinfer/mla/_core.py
@@ -209,7 +209,7 @@ def _normalize_sparse_mla_indices_and_lens(
             raise ValueError(
                 f"Expected {name}.shape == {expected_shape}, got {tuple(indices.shape)}"
             )
-        indices = indices.reshape(batch_size * q_len_per_request, -1)
+        indices = indices.reshape(batch_size * q_len_per_request, sparse_topk)
     elif indices.ndim == 2:
         sparse_topk = int(indices.shape[-1])
         expected_shape = (batch_size * q_len_per_request, sparse_topk)
@@ -416,6 +416,13 @@ def _trtllm_batch_decode_sparse_mla_sm120(
 
     query_flat = query.reshape(batch_size * q_len_per_request, num_heads, head_dim)
     expected_out_shape = (batch_size, q_len_per_request, num_heads, 512)
+    # Early return: speculative decoding may produce 0 tokens on some EP ranks
+    if query_flat.shape[0] == 0:
+        out = torch.empty(expected_out_shape, dtype=torch.bfloat16, device=query.device)
+        if return_lse:
+            lse = torch.empty((0, num_heads), dtype=torch.float32, device=query.device)
+            return out, lse
+        return out
     if out is None:
         out = torch.empty(expected_out_shape, dtype=torch.bfloat16, device=query.device)
     else:


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

What does this PR do?

This PR fixes a crash in the SM120 sparse MLA decode path when certain EP ranks receive zero tokens, which happens during speculative decoding.

Changes:

1. Early return on empty query in _trtllm_batch_decode_sparse_mla_sm120: when query_flat.shape[0] == 0, the function now returns a correctly-shaped empty output tensor (and LSE if requested) instead of passing zero tokens to the sparse MLA kernel, which would fail shape validation or crash.

2. Explicit reshape dimension in _normalize_sparse_mla_indices_and_lens: changed reshape(..., -1) to reshape(..., sparse_topk) for clarity and safety — the dimension is already known from the indices tensor, so explicit is better than implicit.

Why it's needed:

In speculative decoding with expert parallelism (EP), it's common for some EP ranks to have no tokens to process in a given step. Without the early return, the zero-token query would hit shape errors deep inside the SM120 sparse MLA kernel. With this fix, the function gracefully handles the empty case and returns immediately, matching the behavior that the TRTLLM-GEN path already has for zero-token batches upstream.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of sparse MLA indices when using configured top-k widths.
  * Sparse MLA speculative decoding now safely handles ranks with zero tokens by returning empty results.
  * Prevented unnecessary decoder setup for empty speculative-decoding inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->