### PR TITLE
Add support for GDP decode

### DIFF
--- a/flashinfer/__init__.py
+++ b/flashinfer/__init__.py
@@ -107,6 +107,7 @@ with contextlib.suppress(ImportError):
         B12xMoEWrapper as B12xMoEWrapper,
     )
     from .gdn_prefill import chunk_gated_delta_rule as chunk_gated_delta_rule
+    from .gdn_product import chunk_gated_delta_product as chunk_gated_delta_product
 from .gemm import SegmentGEMMWrapper as SegmentGEMMWrapper
 from .gemm import bmm_bf16 as bmm_bf16
 from .gemm import bmm_fp8 as bmm_fp8

--- a/flashinfer/gdn_product.py
+++ b/flashinfer/gdn_product.py
@@ -221,3 +221,159 @@ def chunk_gated_delta_product(
         return output, out[-1]
     else:
         return output
+
+
+# Sentinel written into `a` on the non-first micro-steps of each token, to make
+# the FUSED gate evaluate to alpha == 1.0 (no decay).
+#
+# Unlike prefill -- where `g` is a plain multiplicative tensor and the neutral
+# value is simply 1.0 -- the decode kernel computes the gate itself:
+#
+#     alpha = exp(-exp(A_log) * softplus(a + dt_bias))
+#
+# so neutralising it means driving softplus to zero through `a`. At -1e4 the
+# inner exp underflows to exactly 0, hence log1p(0) == 0 and alpha == 1.0
+# bit-exactly, for ANY A_log and dt_bias. Do NOT tighten this to -30: that is
+# one ULP short of 1.0 once exp(A_log)*softplus() exceeds 2^-24, and do NOT use
+# -inf, which becomes NaN in the kernel's `(1-use_softplus) * x` blend.
+GATE_NEUTRAL_A_SENTINEL = -1.0e4
+
+
+def gated_delta_product_mtp(
+    q: torch.Tensor,  # [B, T,      num_q_heads, K]
+    k: torch.Tensor,  # [B, T, n_h, num_k_heads, K]
+    v: torch.Tensor,  # [B, T, n_h, num_v_heads, V]
+    initial_state: torch.Tensor,  # [pool_size, HV, V, K] fp32 -- the state POOL
+    initial_state_indices: torch.Tensor,  # [B] read slot per batch row
+    A_log: torch.Tensor,  # [HV]
+    a: torch.Tensor,  # [B, T,      HV]  decay logits, ONE per real token
+    dt_bias: torch.Tensor,  # [HV]
+    b: torch.Tensor,  # [B, T, n_h, HV]  update-gate logits, per householder
+    scale: Optional[float] = None,
+    output: Optional[torch.Tensor] = None,  # [B, T, HV, V]
+    ssm_state_indices: Optional[torch.Tensor] = None,  # [B, T] per-token scatter
+    scratch_state_indices: Optional[torch.Tensor] = None,  # [B] throwaway slots
+    disable_state_update: Optional[bool] = None,
+    use_qk_l2norm: bool = True,
+    output_state_indices: Optional[torch.Tensor] = None,  # [B]
+    # expansion scratch -- see chunk_gated_delta_product
+    expanded_q: Optional[torch.Tensor] = None,  # [B, T*n_h, num_q_heads, K]
+    expanded_a: Optional[torch.Tensor] = None,  # [B, T*n_h, HV]
+    expanded_output: Optional[torch.Tensor] = None,  # [B, T*n_h, HV, V]
+    expanded_ssm_state_indices: Optional[torch.Tensor] = None,  # [B, T*n_h] int32
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    r"""Gated DeltaProduct decode / MTP.
+
+    GDP decode is :func:`flashinfer.gdn_decode.gated_delta_rule_mtp` with
+    ``T -> T * num_householder``: one real token becomes ``n_h`` micro-steps.
+    With speculative decoding on top, ``T`` is already ``num_spec + 1``, so the
+    expanded axis is ``n_h * (num_spec + 1)``.
+
+    Two things differ from the prefill wrapper, both because the decode kernel
+    is less of a blank slate:
+
+    1. **The gate is fused.** Prefill takes ``g`` directly; here the kernel
+       derives alpha from ``A_log``/``a``/``dt_bias``. Neutralising the gate on
+       micro-steps ``1..n_h-1`` therefore happens through ``a``, using
+       :data:`GATE_NEUTRAL_A_SENTINEL` -- not by writing 1.0 anywhere.
+    2. **The per-token state scatter is unguarded.** ``gated_delta_rule_mtp``
+       writes ``h_{t+1}`` to ``initial_state[ssm_state_indices[i, t]]`` for
+       every ``t``, with no "skip this one" sentinel (unlike FLA, whose kernel
+       guards on a non-positive slot id). Intermediate micro-steps must
+       therefore be pointed at a **throwaway pool row**, one per batch row --
+       see ``scratch_state_indices``.
+
+    Parameters
+    ----------
+    k, v, b : torch.Tensor
+        Carry a householder axis at dim 2. ``q`` and ``a`` do not: one query and
+        one gate per REAL token.
+    ssm_state_indices : torch.Tensor, optional
+        ``[B, T]`` int32, one pool slot per REAL token, as for GDN MTP. The
+        wrapper expands this to ``[B, T*n_h]``, routing micro-steps
+        ``1..n_h-1`` to the scratch rows and only the last micro-step of each
+        token to the caller's slot.
+    scratch_state_indices : torch.Tensor, optional
+        ``[B]`` int32. Pool rows whose contents are discarded -- one per batch
+        row, and they **must be distinct from each other and from every live
+        slot**, or two batch rows will race writing the same pool row. Required
+        when ``ssm_state_indices`` is given and ``n_h > 1``.
+    expanded_* : torch.Tensor, optional
+        Scratch for the expansion; required for CUDA graph capture. See
+        :func:`chunk_gated_delta_product` for why.
+
+    Returns
+    -------
+    ``(output, initial_state)``, matching ``gated_delta_rule_mtp``. ``output``
+    is ``[B, T, HV, V]`` -- one row per REAL token.
+    """
+    if k.dim() != 5 or v.dim() != 5:
+        raise ValueError(
+            f"k/v must carry a householder axis [B, T, n_h, H, D]; "
+            f"got k.shape={tuple(k.shape)}, v.shape={tuple(v.shape)}"
+        )
+    num_householder = k.size(2)
+    if v.size(2) != num_householder:
+        raise ValueError(
+            f"k/v householder counts differ: {num_householder} vs {v.size(2)}"
+        )
+    if b.dim() != 4 or b.size(2) != num_householder:
+        raise ValueError(
+            f"b must be [B, T, n_h, HV] with n_h={num_householder}; "
+            f"got {tuple(b.shape)}"
+        )
+    if a.dim() != 3:
+        raise ValueError(
+            f"a is one decay logit per REAL token, expected [B, T, HV]; "
+            f"got {tuple(a.shape)}"
+        )
+
+    from .gdn_decode import gated_delta_rule_mtp
+
+    # n_h == 1 is plain GDN MTP. Delegate so this path stays bit-identical.
+    if num_householder == 1:
+        return gated_delta_rule_mtp(
+            q,
+            k.squeeze(2),
+            v.squeeze(2),
+            initial_state,
+            initial_state_indices,
+            A_log,
+            a,
+            dt_bias,
+            b.squeeze(2),
+            scale=scale,
+            output=output,
+            ssm_state_indices=ssm_state_indices,
+            disable_state_update=disable_state_update,
+            use_qk_l2norm=use_qk_l2norm,
+            output_state_indices=output_state_indices,
+        )
+
+    # -----------------------------------------------------------------------
+    # TODO(you): the decode expansion.
+    #
+    #   k, v, b   [B, T, n_h, H, D] -> [B, T*n_h, H, D]      (flatten dims 1,2)
+    #   q         scatter into [:, n_h-1 :: n_h]             (read at the LAST)
+    #   a         scatter into [:, 0     :: n_h],
+    #             ALL OTHER ROWS = GATE_NEUTRAL_A_SENTINEL   (not 1.0! fused gate)
+    #   ssm_state_indices  [B, T] -> [B, T*n_h] int32:
+    #                 [:, n_h-1 :: n_h] = the caller's slots
+    #                 everything else   = scratch_state_indices[:, None]
+    #   out       gather [:, n_h-1 :: n_h]
+    #
+    # `initial_state`, `initial_state_indices` and `output_state_indices` pass
+    # through untouched -- the number of SEQUENCES is unchanged, only the token
+    # axis grows, and the state shape never depends on n_h.
+    #
+    # Watch for:
+    #  * The kernel asserts `ssm_state_indices.dtype == torch.int32` and
+    #    `T >= 2`. The expanded T is n_h*T so T>=2 is automatic for n_h>=2, but
+    #    the dtype is easy to lose through a `torch.full` default of int64.
+    #  * `expanded_a` must be PRE-FILLED with the sentinel, not zeros -- only
+    #    the [0::n_h] rows get written, exactly like expanded_g in prefill
+    #    (where the pre-fill value is 1.0 instead).
+    #  * Every batch row needs its OWN scratch slot. Sharing one across rows is
+    #    a data race, silent and nondeterministic.
+    # -----------------------------------------------------------------------
+    raise NotImplementedError("gated_delta_product_mtp: the n_h expansion")

--- a/flashinfer/gdn_product.py
+++ b/flashinfer/gdn_product.py
@@ -50,6 +50,10 @@ def chunk_gated_delta_product(
     output: Optional[torch.Tensor] = None,
     output_state: Optional[torch.Tensor] = None,
     state_indices: Optional[torch.Tensor] = None,
+    # expansion scratch -- required for cudagraph capture, else allocated here
+    expanded_q: Optional[torch.Tensor] = None,  # [T*n_h, num_q_heads,  D]
+    expanded_g: Optional[torch.Tensor] = None,  # [T*n_h, num_sab_heads]
+    expanded_output: Optional[torch.Tensor] = None,  # [T*n_h, num_o_heads,  D]
 ) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
     r"""Chunked Gated DeltaProduct attention for prefill.
 
@@ -122,40 +126,52 @@ def chunk_gated_delta_product(
             state_indices=state_indices,
         )
 
-    # -----------------------------------------------------------------------
-    # TODO(you): the expansion.
-    #
-    # Build the n_h-times-longer sequence, call chunk_gated_delta_rule on it,
-    # then slice back to one row per real token.
-    #
-    #   k, v      reshape [T, n_h, H, D] -> [T * n_h, H, D]
-    #   beta      reshape [T, n_h, H]    -> [T * n_h, H]
-    #   g         scatter: g_flat[0::n_h] = g, ELSE 1.0   (multiplicative!)
-    #   q         scatter: q_flat[n_h-1::n_h] = q, else anything (rows discarded)
-    #   cu_seqlens                       -> cu_seqlens * n_h
-    #
-    #   out_flat = chunk_gated_delta_rule(...)   # [T * n_h, num_o_heads, D]
-    #   out      = out_flat[n_h - 1 :: n_h]      # one row per real token
-    #
-    # Three things to get right, in rough order of how easy they are to miss:
-    #
-    #  * `output=` / `output_state=`. The caller's `output` buffer is sized for
-    #    T rows, but the kernel writes T * n_h. Allocate the expanded buffer
-    #    here and copy the strided slice into the caller's, or pass None and
-    #    copy afterwards. `output_state` is NOT expanded -- state shape is
-    #    independent of n_h -- so it can be forwarded unchanged.
-    #
-    #  * The strided slice `[n_h - 1 :: n_h]` is only valid because every
-    #    sequence's expanded length is a multiple of n_h, so every sequence
-    #    still starts at a multiple of n_h. That is what makes
-    #    `cu_seqlens * n_h` sufficient rather than needing per-sequence fixups.
-    #
-    #  * Zeroed q rows are safe (the in-kernel l2 norm has an eps), but the
-    #    rows are discarded anyway -- so replicating q is equally fine and
-    #    avoids depending on that eps.
-    #
-    # `tests/gdn/test_prefill_delta_product.py::test_reference_equals_expanded_
-    # delta_rule` already validates this exact expansion in pure torch. If the
-    # kernel disagrees, the fault is in the marshalling here, not the algebra.
-    # -----------------------------------------------------------------------
-    raise NotImplementedError("chunk_gated_delta_product: the n_h expansion")
+    # GDP = GDN with a sequence n_h times longer
+    k = torch.flatten(k, start_dim=0, end_dim=1)
+    v = torch.flatten(v, start_dim=0, end_dim=1)
+    if beta is not None:
+        beta = torch.flatten(beta, start_dim=0, end_dim=1)
+
+    if expanded_q is None:
+        expanded_q = torch.empty(
+            q.size(0) * num_householder, *q.shape[1:], dtype=q.dtype, device=q.device
+        )
+    expanded_q[::num_householder] = q
+
+    if g is not None:
+        if expanded_g is None:
+            expanded_g = torch.ones(
+                g.size(0) * num_householder,
+                *g.shape[1:],
+                dtype=g.dtype,
+                device=g.device,
+            )
+        expanded_g[::num_householder] = g
+    else:
+        expanded_g = None
+
+    if expanded_output is None:
+        expanded_output = torch.empty_like(expanded_q)
+
+    chunk_gated_delta_rule(
+        expanded_q,
+        k,
+        v,
+        expanded_g,
+        beta,
+        scale,
+        initial_state,
+        output_final_state,
+        cu_seqlens * num_householder,
+        use_qk_l2norm_in_kernel,
+        output=expanded_output,
+        output_state=output_state,
+        state_indices=state_indices,
+    )
+
+    if output is not None:
+        output[:] = expanded_output[::num_householder]
+        return output
+
+    else:
+        return expanded_output[::num_householder].clone()

--- a/flashinfer/gdn_product.py
+++ b/flashinfer/gdn_product.py
@@ -280,8 +280,8 @@ def gated_delta_product_mtp(
        writes ``h_{t+1}`` to ``initial_state[ssm_state_indices[i, t]]`` for
        every ``t``, with no "skip this one" sentinel (unlike FLA, whose kernel
        guards on a non-positive slot id). Intermediate micro-steps must
-       therefore be pointed at a **throwaway pool row**, one per batch row --
-       see ``scratch_state_indices``.
+       therefore be pointed at a **throwaway pool row** -- one shared row for
+       the whole batch is enough; see ``scratch_state_indices``.
 
     Parameters
     ----------
@@ -294,10 +294,22 @@ def gated_delta_product_mtp(
         ``1..n_h-1`` to the scratch rows and only the last micro-step of each
         token to the caller's slot.
     scratch_state_indices : torch.Tensor, optional
-        ``[B]`` int32. Pool rows whose contents are discarded -- one per batch
-        row, and they **must be distinct from each other and from every live
-        slot**, or two batch rows will race writing the same pool row. Required
-        when ``ssm_state_indices`` is given and ``n_h > 1``.
+        ``[B]`` or ``[1]`` int32. Pool rows that absorb the intermediate
+        micro-steps' state writes and are never read. Required when
+        ``ssm_state_indices`` is given and ``n_h > 1``.
+
+        The only constraint is that these rows are **disjoint from every live
+        slot** (anything in ``initial_state_indices`` / ``ssm_state_indices`` /
+        ``output_state_indices``). They need *not* be distinct from one another:
+        a single shared row for the whole batch is correct, because the kernel
+        reads the pool exactly once -- before the recurrence, through
+        ``initial_state_indices`` -- and the per-token scatter is write-only
+        thereafter. Concurrent stores to an address nobody reads are benign.
+
+        Prefer one shared row. A per-row scratch costs ``B`` state slots
+        (``HV * V * K * 4`` bytes each -- ~2 MiB at HV=32, K=V=128, so ~512 MiB
+        at B=256) to buy only better write locality, for traffic that is pure
+        waste either way. Phase 2's scatter guard removes these writes entirely.
     expanded_* : torch.Tensor, optional
         Scratch for the expansion; required for CUDA graph capture. See
         :func:`chunk_gated_delta_product` for why.
@@ -350,30 +362,117 @@ def gated_delta_product_mtp(
             output_state_indices=output_state_indices,
         )
 
-    # -----------------------------------------------------------------------
-    # TODO(you): the decode expansion.
-    #
-    #   k, v, b   [B, T, n_h, H, D] -> [B, T*n_h, H, D]      (flatten dims 1,2)
-    #   q         scatter into [:, n_h-1 :: n_h]             (read at the LAST)
-    #   a         scatter into [:, 0     :: n_h],
-    #             ALL OTHER ROWS = GATE_NEUTRAL_A_SENTINEL   (not 1.0! fused gate)
-    #   ssm_state_indices  [B, T] -> [B, T*n_h] int32:
-    #                 [:, n_h-1 :: n_h] = the caller's slots
-    #                 everything else   = scratch_state_indices[:, None]
-    #   out       gather [:, n_h-1 :: n_h]
-    #
-    # `initial_state`, `initial_state_indices` and `output_state_indices` pass
-    # through untouched -- the number of SEQUENCES is unchanged, only the token
-    # axis grows, and the state shape never depends on n_h.
-    #
-    # Watch for:
-    #  * The kernel asserts `ssm_state_indices.dtype == torch.int32` and
-    #    `T >= 2`. The expanded T is n_h*T so T>=2 is automatic for n_h>=2, but
-    #    the dtype is easy to lose through a `torch.full` default of int64.
-    #  * `expanded_a` must be PRE-FILLED with the sentinel, not zeros -- only
-    #    the [0::n_h] rows get written, exactly like expanded_g in prefill
-    #    (where the pre-fill value is 1.0 instead).
-    #  * Every batch row needs its OWN scratch slot. Sharing one across rows is
-    #    a data race, silent and nondeterministic.
-    # -----------------------------------------------------------------------
-    raise NotImplementedError("gated_delta_product_mtp: the n_h expansion")
+    # GDP = GDN with a sequence n_h times longer
+    k = torch.flatten(k, start_dim=1, end_dim=2)
+    v = torch.flatten(v, start_dim=1, end_dim=2)
+    b = torch.flatten(b, start_dim=1, end_dim=2)
+
+    if expanded_q is None:
+        expanded_q = torch.empty(
+            q.size(0),
+            q.size(1) * num_householder,
+            *q.shape[2:],
+            dtype=q.dtype,
+            device=q.device,
+        )
+    elif expanded_q.shape != (q.size(0), q.size(1) * num_householder, *q.shape[2:]):
+        raise ValueError("expanded_q shape must be [B, T*n_h, num_q_heads,  D]")
+    elif expanded_q.dtype != q.dtype:
+        raise ValueError(
+            f"expanded_q.dtype and q.dtype must match, got {expanded_q.dtype} != {q.dtype}"
+        )
+
+    expanded_q[:, num_householder - 1 :: num_householder] = q
+
+    if a.dtype != torch.float32:
+        raise ValueError(
+            f"a must be float32 (g/beta are always fp32 in this API, "
+            f"unlike q/k/v); got {a.dtype}"
+        )
+
+    if expanded_a is None:
+        expanded_a = torch.full(
+            (a.size(0), a.size(1) * num_householder, *a.shape[2:]),
+            GATE_NEUTRAL_A_SENTINEL,
+            dtype=a.dtype,
+            device=a.device,
+        )
+    elif expanded_a.shape != (a.size(0), a.size(1) * num_householder, *a.shape[2:]):
+        raise ValueError("expanded_a shape must be [B, T*n_h, num_sab_heads]")
+    elif expanded_a.dtype != torch.float32:
+        raise ValueError(
+            f"expanded_a must be float32 (a/beta are always fp32 in this API, "
+            f"unlike q/k/v); got {expanded_a.dtype}"
+        )
+    expanded_a[:, ::num_householder] = a
+
+    if expanded_output is None:
+        expanded_output = torch.empty(
+            expanded_q.size(0),
+            expanded_q.size(1),
+            max(q.size(2), v.size(2)),
+            q.size(3),
+            dtype=output.dtype if output is not None else q.dtype,
+            device=output.device if output is not None else q.device,
+        )
+    elif expanded_output.shape != (
+        expanded_q.size(0),
+        expanded_q.size(1),
+        max(q.size(2), v.size(2)),
+        q.size(3),
+    ):
+        raise ValueError("expanded_output shape must be [B, T*n_h, num_o_heads,  D]")
+
+    if ssm_state_indices is not None:
+        if scratch_state_indices is None:
+            raise ValueError(
+                "scratch_state_indices are required if ssm_state_indices is given"
+            )
+        if expanded_ssm_state_indices is None:
+            expanded_ssm_state_indices = torch.empty(
+                ssm_state_indices.size(0),
+                ssm_state_indices.size(1) * num_householder,
+                dtype=ssm_state_indices.dtype,
+                device=ssm_state_indices.device,
+            )
+        elif expanded_ssm_state_indices.shape != (
+            ssm_state_indices.size(0),
+            ssm_state_indices.size(1) * num_householder,
+        ):
+            raise ValueError("expanded_ssm_state_indices shape must be [B, T*n_h]")
+        elif expanded_ssm_state_indices.dtype != ssm_state_indices.dtype:
+            raise ValueError(
+                f"expanded_ssm_state_indices dtype must be {ssm_state_indices.dtype}"
+            )
+
+        expanded_ssm_state_indices[:] = scratch_state_indices[:, None]
+        expanded_ssm_state_indices[:, num_householder - 1 :: num_householder] = (
+            ssm_state_indices
+        )
+    else:
+        expanded_ssm_state_indices = None
+
+    _, state = gated_delta_rule_mtp(
+        expanded_q,
+        k,
+        v,
+        initial_state,
+        initial_state_indices,
+        A_log,
+        expanded_a,
+        dt_bias,
+        b,
+        scale=scale,
+        output=expanded_output,
+        ssm_state_indices=expanded_ssm_state_indices,
+        disable_state_update=disable_state_update,
+        use_qk_l2norm=use_qk_l2norm,
+        output_state_indices=output_state_indices,
+    )
+
+    if output is not None:
+        output[:] = expanded_output[:, num_householder - 1 :: num_householder]
+    else:
+        output = expanded_output[:, num_householder - 1 :: num_householder].clone()
+
+    return output, state

--- a/flashinfer/gdn_product.py
+++ b/flashinfer/gdn_product.py
@@ -136,7 +136,7 @@ def chunk_gated_delta_product(
         expanded_q = torch.empty(
             q.size(0) * num_householder, *q.shape[1:], dtype=q.dtype, device=q.device
         )
-    expanded_q[::num_householder] = q
+    expanded_q[num_householder - 1 :: num_householder] = q
 
     if g is not None:
         if expanded_g is None:
@@ -146,14 +146,25 @@ def chunk_gated_delta_product(
                 dtype=g.dtype,
                 device=g.device,
             )
+        elif expanded_g.dtype != torch.float32:
+            raise ValueError(
+                f"expanded_g must be float32 (g/beta are always fp32 in this API, "
+                f"unlike q/k/v); got {expanded_g.dtype}"
+            )
         expanded_g[::num_householder] = g
     else:
         expanded_g = None
 
     if expanded_output is None:
-        expanded_output = torch.empty_like(expanded_q)
+        expanded_output = torch.empty(
+            expanded_q.size(0),
+            max(q.size(1), v.size(1)),
+            q.size(2),
+            dtype=q.dtype,
+            device=q.device,
+        )
 
-    chunk_gated_delta_rule(
+    _, output_state = chunk_gated_delta_rule(
         expanded_q,
         k,
         v,
@@ -170,8 +181,8 @@ def chunk_gated_delta_product(
     )
 
     if output is not None:
-        output[:] = expanded_output[::num_householder]
-        return output
+        output[:] = expanded_output[num_householder - 1 :: num_householder]
+        return output, output_state
 
     else:
-        return expanded_output[::num_householder].clone()
+        return expanded_output[::num_householder].clone(), output_state

--- a/flashinfer/gdn_product.py
+++ b/flashinfer/gdn_product.py
@@ -172,7 +172,7 @@ def chunk_gated_delta_product(
         beta,
         scale,
         initial_state,
-        output_final_state,
+        True,
         cu_seqlens * num_householder,
         use_qk_l2norm_in_kernel,
         output=expanded_output,
@@ -182,7 +182,10 @@ def chunk_gated_delta_product(
 
     if output is not None:
         output[:] = expanded_output[num_householder - 1 :: num_householder]
-        return output, output_state
-
     else:
-        return expanded_output[::num_householder].clone(), output_state
+        output = expanded_output[::num_householder].clone()
+
+    if output_final_state:
+        return output, output_state
+    else:
+        return output

--- a/flashinfer/gdn_product.py
+++ b/flashinfer/gdn_product.py
@@ -14,17 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 Gated DeltaProduct (arXiv:2502.10297) -- API layer.
-
-DeltaProduct takes ``num_householder`` delta-rule steps per token instead of one:
-
-    A(x_i) = alpha_i * prod_{j=1..n_h} (I - beta_{i,j} k_{i,j} k_{i,j}^T)
-
-Phase 1 implements this as a host-side expansion over the existing GDN kernels:
-GDP is GDN run on a sequence ``n_h`` times longer, with the decay neutralised on
-all but the first micro-step of each token and the query read only from the last.
-No new kernel is required for correctness.
-
-The recurrent state is UNCHANGED in size -- ``n_h`` costs FLOPs, not bytes.
 """
 
 from __future__ import annotations
@@ -82,12 +71,34 @@ def chunk_gated_delta_product(
     initial_state, output_state, state_indices, cu_seqlens, ...
         As in ``chunk_gated_delta_rule``. Note the state shape does NOT depend
         on ``num_householder``.
+    expanded_q : torch.Tensor, optional
+        Scratch for the expanded query,
+        ``[total_seq_len * num_householder, num_q_heads, head_size]``, dtype of
+        ``q``.
+    expanded_g : torch.Tensor, optional
+        Scratch for the expanded gate,
+        ``[total_seq_len * num_householder, num_sab_heads]``. **Must be
+        float32** -- ``g`` and ``beta`` are always fp32 in this API even when
+        ``q``/``k``/``v`` are fp16/bf16, and a strided assignment into a
+        half-precision buffer downcasts silently.
+        Must be pre-filled with ``1.0``: only rows ``[0 :: n_h]`` are written
+        (the per-token gate), and the remaining micro-steps rely on the
+        multiplicative neutral value already being in place.
+    expanded_output : torch.Tensor, optional
+        Scratch for the kernel's output,
+        ``[total_seq_len * num_householder, num_o_heads, head_size]`` where
+        ``num_o_heads = max(num_q_heads, num_v_heads)``. Note this is **not**
+        ``num_q_heads`` -- under GVA the output is wider than the query.
+        Takes ``output``'s dtype when ``output`` is supplied, else ``q``'s, so
+        the final strided copy never silently casts.
 
     Returns
     -------
     Same contract as ``chunk_gated_delta_rule``: ``output`` when
     ``output_final_state`` is False, else ``(output, final_state)``. ``output``
     has one row per REAL token, ``[total_seq_len, num_o_heads, head_size]``.
+    When ``output`` is supplied it is written in place and returned; otherwise
+    a freshly allocated tensor is returned.
     """
     if k.dim() != 4 or v.dim() != 4:
         raise ValueError(
@@ -136,9 +147,22 @@ def chunk_gated_delta_product(
         expanded_q = torch.empty(
             q.size(0) * num_householder, *q.shape[1:], dtype=q.dtype, device=q.device
         )
+    elif expanded_q.shape != (q.size(0) * num_householder, *q.shape[1:]):
+        raise ValueError("expanded_q shape must be [T*n_h, num_q_heads,  D]")
+    elif expanded_q.dtype != q.dtype:
+        raise ValueError(
+            f"expanded_q.dtype and q.dtype must match, got {expanded_q.dtype} != {q.dtype}"
+        )
+
     expanded_q[num_householder - 1 :: num_householder] = q
 
     if g is not None:
+        if g.dtype != torch.float32:
+            raise ValueError(
+                f"g must be float32 (g/beta are always fp32 in this API, "
+                f"unlike q/k/v); got {g.dtype}"
+            )
+
         if expanded_g is None:
             expanded_g = torch.ones(
                 g.size(0) * num_householder,
@@ -146,6 +170,8 @@ def chunk_gated_delta_product(
                 dtype=g.dtype,
                 device=g.device,
             )
+        elif expanded_g.shape != (g.size(0) * num_householder, *g.shape[1:]):
+            raise ValueError("expanded_g shape must be [T*n_h, num_sab_heads]")
         elif expanded_g.dtype != torch.float32:
             raise ValueError(
                 f"expanded_g must be float32 (g/beta are always fp32 in this API, "
@@ -160,11 +186,17 @@ def chunk_gated_delta_product(
             expanded_q.size(0),
             max(q.size(1), v.size(1)),
             q.size(2),
-            dtype=q.dtype,
-            device=q.device,
+            dtype=output.dtype if output is not None else q.dtype,
+            device=output.device if output is not None else q.device,
         )
+    elif expanded_output.shape != (
+        expanded_q.size(0),
+        max(q.size(1), v.size(1)),
+        q.size(2),
+    ):
+        raise ValueError("expanded_output shape must be [T*n_h, num_o_heads,  D]")
 
-    _, output_state = chunk_gated_delta_rule(
+    out = chunk_gated_delta_rule(
         expanded_q,
         k,
         v,
@@ -172,7 +204,7 @@ def chunk_gated_delta_product(
         beta,
         scale,
         initial_state,
-        True,
+        output_final_state,
         cu_seqlens * num_householder,
         use_qk_l2norm_in_kernel,
         output=expanded_output,
@@ -183,9 +215,9 @@ def chunk_gated_delta_product(
     if output is not None:
         output[:] = expanded_output[num_householder - 1 :: num_householder]
     else:
-        output = expanded_output[::num_householder].clone()
+        output = expanded_output[num_householder - 1 :: num_householder].clone()
 
     if output_final_state:
-        return output, output_state
+        return output, out[-1]
     else:
         return output

--- a/flashinfer/gdn_product.py
+++ b/flashinfer/gdn_product.py
@@ -444,6 +444,10 @@ def gated_delta_product_mtp(
     else:
         expanded_ssm_state_indices = None
 
+    if initial_state_indices.data_ptr() % 16 != 0:
+        # GDN kernel requires 16-byte alignment on the index tensor
+        initial_state_indices = initial_state_indices.clone()
+
     _, state = gated_delta_rule_mtp(
         expanded_q,
         k,

--- a/flashinfer/gdn_product.py
+++ b/flashinfer/gdn_product.py
@@ -412,7 +412,8 @@ def gated_delta_product_mtp(
             expanded_q.size(1),
             max(q.size(2), v.size(2)),
             q.size(3),
-            dtype=output.dtype if output is not None else q.dtype,
+            # kernel hardcodes bf16...
+            dtype=torch.bfloat16,
             device=output.device if output is not None else q.device,
         )
     elif expanded_output.shape != (
@@ -475,4 +476,4 @@ def gated_delta_product_mtp(
     else:
         output = expanded_output[:, num_householder - 1 :: num_householder].clone()
 
-    return output, state
+    return output.to(q.dtype), state

--- a/flashinfer/gdn_product.py
+++ b/flashinfer/gdn_product.py
@@ -1,0 +1,161 @@
+"""
+Copyright (c) 2025 by FlashInfer team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Gated DeltaProduct (arXiv:2502.10297) -- API layer.
+
+DeltaProduct takes ``num_householder`` delta-rule steps per token instead of one:
+
+    A(x_i) = alpha_i * prod_{j=1..n_h} (I - beta_{i,j} k_{i,j} k_{i,j}^T)
+
+Phase 1 implements this as a host-side expansion over the existing GDN kernels:
+GDP is GDN run on a sequence ``n_h`` times longer, with the decay neutralised on
+all but the first micro-step of each token and the query read only from the last.
+No new kernel is required for correctness.
+
+The recurrent state is UNCHANGED in size -- ``n_h`` costs FLOPs, not bytes.
+"""
+
+from __future__ import annotations
+
+from typing import Optional, Tuple, Union
+
+import torch
+
+from .gdn_prefill import chunk_gated_delta_rule
+
+
+def chunk_gated_delta_product(
+    q: torch.Tensor,  # [total_seq_len,      num_q_heads, head_size]
+    k: torch.Tensor,  # [total_seq_len, n_h, num_k_heads, head_size]
+    v: torch.Tensor,  # [total_seq_len, n_h, num_v_heads, head_size]
+    g: Optional[torch.Tensor] = None,  # [total_seq_len,      num_sab_heads]
+    beta: Optional[torch.Tensor] = None,  # [total_seq_len, n_h, num_sab_heads]
+    scale: Optional[float] = None,
+    initial_state: Optional[torch.Tensor] = None,
+    output_final_state: bool = False,
+    cu_seqlens: Optional[torch.Tensor] = None,
+    use_qk_l2norm_in_kernel: bool = False,
+    output: Optional[torch.Tensor] = None,
+    output_state: Optional[torch.Tensor] = None,
+    state_indices: Optional[torch.Tensor] = None,
+) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
+    r"""Chunked Gated DeltaProduct attention for prefill.
+
+    Mirrors :func:`flashinfer.gdn_prefill.chunk_gated_delta_rule`, with a
+    householder axis added to ``k``, ``v`` and ``beta``. At ``n_h == 1`` this
+    delegates straight through and is bit-identical to the GDN entry point.
+
+    Parameters
+    ----------
+    q : torch.Tensor
+        Queries, ``[total_seq_len, num_q_heads, head_size]``. **One per real
+        token** -- the query axis is not expanded.
+    k, v : torch.Tensor
+        Keys/values, ``[total_seq_len, num_householder, num_*_heads, head_size]``.
+        The householder axis sits immediately after the token axis so that
+        ``reshape(total_seq_len * n_h, ...)`` yields the ``(t n) h d`` ordering
+        the expansion needs.
+    g : torch.Tensor, optional
+        Forget gate (alpha), ``[total_seq_len, num_sab_heads]``. **One per real
+        token** -- the gate models time passing, while the ``n_h`` householders
+        are all the same time step. MULTIPLICATIVE, neutral value ``1.0``
+        (not the log-space decay FLA uses, whose neutral value is ``0.0``).
+    beta : torch.Tensor, optional
+        Update gate, ``[total_seq_len, num_householder, num_sab_heads]`` -- one
+        per (token, householder).
+    initial_state, output_state, state_indices, cu_seqlens, ...
+        As in ``chunk_gated_delta_rule``. Note the state shape does NOT depend
+        on ``num_householder``.
+
+    Returns
+    -------
+    Same contract as ``chunk_gated_delta_rule``: ``output`` when
+    ``output_final_state`` is False, else ``(output, final_state)``. ``output``
+    has one row per REAL token, ``[total_seq_len, num_o_heads, head_size]``.
+    """
+    if k.dim() != 4 or v.dim() != 4:
+        raise ValueError(
+            f"k/v must carry a householder axis [T, n_h, H, D]; "
+            f"got k.shape={tuple(k.shape)}, v.shape={tuple(v.shape)}"
+        )
+    num_householder = k.size(1)
+    if v.size(1) != num_householder:
+        raise ValueError(
+            f"k/v householder counts differ: {num_householder} vs {v.size(1)}"
+        )
+    if beta is not None and beta.dim() == 3 and beta.size(1) != num_householder:
+        raise ValueError(f"beta householder count {beta.size(1)} != {num_householder}")
+    if g is not None and g.dim() != 2:
+        raise ValueError(
+            f"g is one gate per REAL token, expected [T, H]; got {tuple(g.shape)}"
+        )
+    if cu_seqlens is None:
+        raise ValueError("cu_seqlens is required (varlen mode), as for GDN")
+
+    # n_h == 1 is plain GDN. Delegate so this path stays bit-identical.
+    if num_householder == 1:
+        return chunk_gated_delta_rule(
+            q,
+            k.squeeze(1),
+            v.squeeze(1),
+            g,
+            beta.squeeze(1) if beta is not None else None,
+            scale,
+            initial_state,
+            output_final_state,
+            cu_seqlens,
+            use_qk_l2norm_in_kernel,
+            output=output,
+            output_state=output_state,
+            state_indices=state_indices,
+        )
+
+    # -----------------------------------------------------------------------
+    # TODO(you): the expansion.
+    #
+    # Build the n_h-times-longer sequence, call chunk_gated_delta_rule on it,
+    # then slice back to one row per real token.
+    #
+    #   k, v      reshape [T, n_h, H, D] -> [T * n_h, H, D]
+    #   beta      reshape [T, n_h, H]    -> [T * n_h, H]
+    #   g         scatter: g_flat[0::n_h] = g, ELSE 1.0   (multiplicative!)
+    #   q         scatter: q_flat[n_h-1::n_h] = q, else anything (rows discarded)
+    #   cu_seqlens                       -> cu_seqlens * n_h
+    #
+    #   out_flat = chunk_gated_delta_rule(...)   # [T * n_h, num_o_heads, D]
+    #   out      = out_flat[n_h - 1 :: n_h]      # one row per real token
+    #
+    # Three things to get right, in rough order of how easy they are to miss:
+    #
+    #  * `output=` / `output_state=`. The caller's `output` buffer is sized for
+    #    T rows, but the kernel writes T * n_h. Allocate the expanded buffer
+    #    here and copy the strided slice into the caller's, or pass None and
+    #    copy afterwards. `output_state` is NOT expanded -- state shape is
+    #    independent of n_h -- so it can be forwarded unchanged.
+    #
+    #  * The strided slice `[n_h - 1 :: n_h]` is only valid because every
+    #    sequence's expanded length is a multiple of n_h, so every sequence
+    #    still starts at a multiple of n_h. That is what makes
+    #    `cu_seqlens * n_h` sufficient rather than needing per-sequence fixups.
+    #
+    #  * Zeroed q rows are safe (the in-kernel l2 norm has an eps), but the
+    #    rows are discarded anyway -- so replicating q is equally fine and
+    #    avoids depending on that eps.
+    #
+    # `tests/gdn/test_prefill_delta_product.py::test_reference_equals_expanded_
+    # delta_rule` already validates this exact expansion in pure torch. If the
+    # kernel disagrees, the fault is in the marshalling here, not the algebra.
+    # -----------------------------------------------------------------------
+    raise NotImplementedError("chunk_gated_delta_product: the n_h expansion")

--- a/flashinfer/gdn_product.py
+++ b/flashinfer/gdn_product.py
@@ -384,12 +384,6 @@ def gated_delta_product_mtp(
 
     expanded_q[:, num_householder - 1 :: num_householder] = q
 
-    if a.dtype != torch.float32:
-        raise ValueError(
-            f"a must be float32 (g/beta are always fp32 in this API, "
-            f"unlike q/k/v); got {a.dtype}"
-        )
-
     if expanded_a is None:
         expanded_a = torch.full(
             (a.size(0), a.size(1) * num_householder, *a.shape[2:]),
@@ -399,11 +393,8 @@ def gated_delta_product_mtp(
         )
     elif expanded_a.shape != (a.size(0), a.size(1) * num_householder, *a.shape[2:]):
         raise ValueError("expanded_a shape must be [B, T*n_h, num_sab_heads]")
-    elif expanded_a.dtype != torch.float32:
-        raise ValueError(
-            f"expanded_a must be float32 (a/beta are always fp32 in this API, "
-            f"unlike q/k/v); got {expanded_a.dtype}"
-        )
+    elif expanded_a.dtype != a.dtype:
+        raise ValueError(f"expanded_a dtype must match a dtype ({a.dtype})")
     expanded_a[:, ::num_householder] = a
 
     if expanded_output is None:

--- a/tests/gdn/reference_delta_product.py
+++ b/tests/gdn/reference_delta_product.py
@@ -1,0 +1,150 @@
+"""
+Copyright (c) 2025 by FlashInfer team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Reference implementation of Gated DeltaProduct (arXiv:2502.10297).
+
+DeltaProduct takes ``num_householder`` delta-rule steps per token instead of one,
+giving a state transition of rank up to ``num_householder``:
+
+    A(x_i) = alpha_i * prod_{j=1..n_h} (I - beta_{i,j} k_{i,j} k_{i,j}^T)
+
+The gate ``alpha`` fires ONCE per real token; ``beta``/``k``/``v`` are per
+(token, householder). At ``num_householder == 1`` this must reduce exactly to
+``reference_delta_rule.delta_rule``.
+
+Layout note: the householder axis sits immediately after the token axis, so
+``x.reshape(total_seq_len * n_h, H, D)`` yields the ``(t n) h d`` ordering the
+kernel wrappers expand into.
+"""
+
+from __future__ import annotations
+
+import torch
+
+from .reference_delta_rule import exclusive_cumsum, matmul
+
+
+def delta_product(
+    q: torch.Tensor,  # [total_seq_len,      num_q_heads, head_size]
+    k: torch.Tensor,  # [total_seq_len, n_h, num_k_heads, head_size]
+    v: torch.Tensor,  # [total_seq_len, n_h, num_v_heads, head_size]
+    seq_lens: list[int],
+    *,
+    alpha: torch.Tensor | None = None,  # [total_seq_len,      num_sab_heads]
+    beta: torch.Tensor | None = None,  # [total_seq_len, n_h, num_sab_heads]
+    scale_factor: float = 1.0,
+    state_dtype: torch.dtype = torch.float32,
+):
+    """Returns (output, final_state).
+
+    output      [total_seq_len, num_o_heads, head_size]   -- one row per REAL token
+    final_state [num_seqs, num_sab_heads, head_size, head_size]   (K-major, [.., K, V])
+    """
+    assert k.dim() == 4 and v.dim() == 4, (
+        "k/v must have a householder axis: [T, n_h, H, D]"
+    )
+    n_h = k.size(1)
+    assert v.size(1) == n_h, (
+        f"k/v num_householders must match, got {n_h} != {v.size(1)}"
+    )
+
+    total_seqlen = q.size(0)
+    num_q_heads = q.size(1)
+    num_k_heads = k.size(2)
+    num_v_heads = v.size(2)
+    num_sab_heads = max(num_q_heads, num_v_heads)
+    head_size = k.size(3)
+
+    if alpha is None:
+        # same alpha for all householders for each real token
+        alpha = torch.ones(
+            total_seqlen, num_sab_heads, dtype=torch.float32, device=q.device
+        )
+    if beta is None:
+        # beta is per-householder
+        beta = torch.ones(
+            total_seqlen, n_h, num_sab_heads, dtype=torch.float32, device=q.device
+        )
+
+    # Broadcast heads exactly as reference_delta_rule does, but k/v have the
+    # extra householder axis at dim 1, so head expansion happens at dim 2.
+    if num_q_heads > num_v_heads:  # GQA
+        k = k.repeat_interleave(num_q_heads // num_k_heads, dim=2)
+        v = v.repeat_interleave(num_q_heads // num_v_heads, dim=2)
+    else:  # GVA
+        q = q.repeat_interleave(num_v_heads // num_q_heads, dim=1)
+        k = k.repeat_interleave(num_v_heads // num_k_heads, dim=2)
+    num_state_heads = q.size(1)
+
+    o = []
+    kv = []
+    seq_offset = exclusive_cumsum(seq_lens)
+    for seq_idx, seq_start in enumerate(seq_offset[:-1]):
+        seq_end = seq_offset[seq_idx + 1]
+        seq_len = seq_end - seq_start
+        s = slice(seq_start, seq_end)
+
+        qs, ks, vs = q[s], k[s], v[s]
+        alphas, betas = alpha[s], beta[s]
+
+        # state size remains fixed between GDN and GDP
+        state_HKV = torch.zeros(
+            num_state_heads, head_size, head_size, dtype=state_dtype, device=q.device
+        )
+
+        for i in range(seq_len):
+            alpha_H11 = alphas[i].unsqueeze(1).unsqueeze(2)
+            q_H1Q = qs[i].unsqueeze(1)
+
+            # apply alpha gating ONCE per real token
+            old_state_HKV = alpha_H11 * state_HKV.to(torch.float32)
+            for j in range(n_h):
+                k_H1K = ks[i, j].unsqueeze(1)
+                v_H1V = vs[i, j].unsqueeze(1)
+                beta_H11 = betas[i, j].unsqueeze(1).unsqueeze(2)
+
+                old_v_H1V = matmul(k_H1K, old_state_HKV)
+                new_v_H1V = beta_H11 * v_H1V + (1 - beta_H11) * old_v_H1V
+                state_remove = torch.einsum("htv,htk->hkv", old_v_H1V, k_H1K)
+                state_update = torch.einsum("htv,htk->hkv", new_v_H1V, k_H1K)
+                old_state_HKV = old_state_HKV - state_remove + state_update
+
+            state_HKV[:] = old_state_HKV.to(state_dtype)
+            o_H1V = scale_factor * matmul(q_H1Q, state_HKV.to(torch.float32))
+            o.append(o_H1V.squeeze(1))
+
+        kv.append(state_HKV.clone())
+
+    return torch.stack(o), torch.stack(kv)
+
+
+def expand_to_flat_sequence(
+    k: torch.Tensor,  # [T, n_h, H, D]
+    v: torch.Tensor,  # [T, n_h, H, D]
+    alpha: torch.Tensor | None,  # [T, H]
+    beta: torch.Tensor | None,  # [T, n_h, H]
+    q: torch.Tensor,  # [T, H, D]
+    cu_seqlens: torch.Tensor,
+):
+    """The Phase-1 expansion: GDP as GDN on a sequence n_h times longer.
+
+    Returns (q, k, v, alpha, beta, cu_seqlens) all on the expanded token axis,
+    ready to hand to ``chunk_gated_delta_rule``. Slice the result with
+    ``out[n_h - 1 :: n_h]`` to recover one row per real token.
+
+    NOTE: flashinfer's ``g`` is MULTIPLICATIVE alpha (neutral value 1.0), not the
+    log-space decay FLA uses (neutral value 0.0).
+    """
+    raise NotImplementedError("step 2 -- write this when you add the wrapper")

--- a/tests/gdn/reference_delta_product.py
+++ b/tests/gdn/reference_delta_product.py
@@ -37,11 +37,16 @@ def delta_product(
     beta: torch.Tensor | None = None,  # [total_seq_len, n_h, num_sab_heads]
     scale_factor: float = 1.0,
     state_dtype: torch.dtype = torch.float32,
+    initial_state: torch.Tensor | None = None,  # [num_seqs, H, K, V], K-major
 ):
     """Returns (output, final_state).
 
     output      [total_seq_len, num_o_heads, head_size]   -- one row per REAL token
     final_state [num_seqs, num_sab_heads, head_size, head_size]   (K-major, [.., K, V])
+
+    ``initial_state`` seeds each sequence instead of starting from zero. Needed
+    by the decode tests, where a step continues an existing state rather than
+    beginning a sequence; zero (the default) is the prefill case.
     """
     assert k.dim() == 4 and v.dim() == 4, (
         "k/v must have a householder axis: [T, n_h, H, D]"
@@ -91,9 +96,16 @@ def delta_product(
         alphas, betas = alpha[s], beta[s]
 
         # state size remains fixed between GDN and GDP
-        state_HKV = torch.zeros(
-            num_state_heads, head_size, head_size, dtype=state_dtype, device=q.device
-        )
+        if initial_state is None:
+            state_HKV = torch.zeros(
+                num_state_heads,
+                head_size,
+                head_size,
+                dtype=state_dtype,
+                device=q.device,
+            )
+        else:
+            state_HKV = initial_state[seq_idx].to(state_dtype).clone()
 
         for i in range(seq_len):
             alpha_H11 = alphas[i].unsqueeze(1).unsqueeze(2)

--- a/tests/gdn/reference_delta_product.py
+++ b/tests/gdn/reference_delta_product.py
@@ -15,15 +15,6 @@ limitations under the License.
 
 Reference implementation of Gated DeltaProduct (arXiv:2502.10297).
 
-DeltaProduct takes ``num_householder`` delta-rule steps per token instead of one,
-giving a state transition of rank up to ``num_householder``:
-
-    A(x_i) = alpha_i * prod_{j=1..n_h} (I - beta_{i,j} k_{i,j} k_{i,j}^T)
-
-The gate ``alpha`` fires ONCE per real token; ``beta``/``k``/``v`` are per
-(token, householder). At ``num_householder == 1`` this must reduce exactly to
-``reference_delta_rule.delta_rule``.
-
 Layout note: the householder axis sits immediately after the token axis, so
 ``x.reshape(total_seq_len * n_h, H, D)`` yields the ``(t n) h d`` ordering the
 kernel wrappers expand into.

--- a/tests/gdn/reference_delta_rule.py
+++ b/tests/gdn/reference_delta_rule.py
@@ -284,9 +284,11 @@ def delta_rule(
     if num_q_heads > num_v_heads:  # GQA
         k = k.repeat_interleave(num_q_heads // num_k_heads, dim=1)
         v = v.repeat_interleave(num_q_heads // num_v_heads, dim=1)
+        num_qkv_heads = num_q_heads
     else:  # GVA
         q = q.repeat_interleave(num_v_heads // num_q_heads, dim=1)
         k = k.repeat_interleave(num_v_heads // num_k_heads, dim=1)
+        num_qkv_heads = num_v_heads
 
     seq_offset = exclusive_cumsum(seq_lens)
     for seq_idx, seq_start in enumerate(seq_offset[:-1]):
@@ -302,7 +304,7 @@ def delta_rule(
         betas = beta[s]
 
         state_HKV = torch.zeros(
-            num_q_heads, head_size, head_size, dtype=state_dtype, device=q.device
+            num_qkv_heads, head_size, head_size, dtype=state_dtype, device=q.device
         )
         for i in range(seq_len):
             # var_DS where var is variable basename and DS is the dimensional semantics.

--- a/tests/gdn/test_decode_delta_product.py
+++ b/tests/gdn/test_decode_delta_product.py
@@ -1,0 +1,418 @@
+"""
+Copyright (c) 2025 by FlashInfer team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Phase 1, step 3: Gated DeltaProduct decode (MTP).
+
+Decode diverges from prefill in two ways that need their own tests, not just a
+port of the prefill suite:
+
+  * the gate is computed INSIDE the kernel from A_log/a/dt_bias, so the
+    neutral value for the non-first micro-steps is a sentinel in `a`, not a 1.0
+    in `g`. `test_gate_sentinel_is_exactly_neutral` pins that.
+  * the per-token state scatter is unguarded, so intermediate micro-steps write
+    to throwaway pool rows. `test_scratch_slots_are_inert` pins that.
+
+Layout note: decode is DENSE [B, T, ...], not varlen. The reference is still
+`delta_product`, reached by flattening to [B*T, ...] with seq_lens = [T]*B.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from flashinfer.gdn_product import GATE_NEUTRAL_A_SENTINEL, gated_delta_product_mtp
+
+from .reference_delta_product import delta_product
+from .test_prefill_delta_product import _skip_if_unsupported
+
+# Matches gdn_decode_mtp.py's constexpr softplus params.
+SOFTPLUS_BETA = 1.0
+SOFTPLUS_THRESHOLD = 20.0
+
+
+def gates_from_logits(A_log, a, dt_bias, b):
+    """Host-side twin of the kernel's fused gating (gdn_decode_mtp.py:415-436).
+
+        alpha = exp(-exp(A_log) * softplus(a + dt_bias))
+        beta  = sigmoid(b)
+
+    The reference takes alpha/beta directly, so every decode test has to cross
+    this bridge. Keep it in lockstep with the kernel or the tests measure the
+    wrong thing.
+    """
+    x = a + dt_bias
+    bx = SOFTPLUS_BETA * x
+    softplus_x = torch.where(
+        bx <= SOFTPLUS_THRESHOLD, (1.0 / SOFTPLUS_BETA) * torch.log1p(torch.exp(bx)), x
+    )
+    alpha = torch.exp(-torch.exp(A_log) * softplus_x)
+    return alpha, torch.sigmoid(b)
+
+
+def _gen_decode_inputs(B, T, n_h, num_q_heads, num_v_heads, K, V, dtype, device, seed):
+    """Dense decode inputs plus a state pool with B live slots and B scratch."""
+    torch.manual_seed(seed)
+    torch.cuda.manual_seed(seed)
+    HV = num_v_heads
+    with device:
+        q = torch.randn(B, T, num_q_heads, K, dtype=dtype) * 0.25
+        k = torch.randn(B, T, n_h, num_q_heads, K, dtype=dtype) * 0.25
+        v = torch.randn(B, T, n_h, HV, V, dtype=dtype) * 0.25
+        k = torch.nn.functional.normalize(k.float(), dim=-1).to(dtype)
+
+        A_log = torch.rand(HV, dtype=torch.float32) * 2.0 - 1.0
+        dt_bias = torch.rand(HV, dtype=torch.float32) * 2.0 - 1.0
+        a = torch.randn(B, T, HV, dtype=torch.float32)
+        b = torch.randn(B, T, n_h, HV, dtype=torch.float32)
+
+        # pool: rows [0, B) live, rows [B, 2B) scratch. Row 0 of a pool is a
+        # common sentinel elsewhere in flashinfer, so start live slots at 1.
+        pool = torch.randn(2 * B + 1, HV, V, K, dtype=torch.float32) * 0.1
+        initial_state_indices = torch.arange(1, B + 1, dtype=torch.int32)
+        scratch_state_indices = torch.arange(B + 1, 2 * B + 1, dtype=torch.int32)
+    return (
+        q,
+        k,
+        v,
+        A_log,
+        a,
+        dt_bias,
+        b,
+        pool,
+        initial_state_indices,
+        scratch_state_indices,
+    )
+
+
+def _reference(q, k, v, A_log, a, dt_bias, b, pool, idx, scale=1.0, use_l2_norm=True):
+    """delta_product over the dense batch, seeded from the pool rows.
+
+    ``use_l2_norm`` must track the wrapper's ``use_qk_l2norm``: the decode
+    kernel normalises **both q and k** internally (see
+    ``reference_delta_rule.decode_delta_rule``, which does the same under
+    ``use_l2_norm``), while ``delta_product`` normalises nothing. Forgetting q
+    here leaves the two sides differing by a per-row factor of ||q||.
+    """
+    B, T, n_h = k.shape[0], k.shape[1], k.shape[2]
+    alpha, beta = gates_from_logits(A_log, a, dt_bias, b)
+    if use_l2_norm:
+        q = torch.nn.functional.normalize(q.float(), p=2.0, dim=-1)
+        k = torch.nn.functional.normalize(k.float(), p=2.0, dim=-1)
+    # pool is [.., V, K]; the reference wants [.., K, V]
+    init = pool[idx.long()].transpose(-1, -2).contiguous()
+    o, state = delta_product(
+        q.reshape(B * T, *q.shape[2:]).float(),
+        k.reshape(B * T, *k.shape[2:]).float(),
+        v.reshape(B * T, *v.shape[2:]).float(),
+        [T] * B,
+        alpha=alpha.reshape(B * T, -1),
+        beta=beta.reshape(B * T, n_h, -1),
+        scale_factor=scale,
+        initial_state=init,
+    )
+    return o.reshape(B, T, *o.shape[1:]), state
+
+
+# --------------------------------------------------------------------------
+# 1. The sentinel. Pure arithmetic -- no kernel, no GPU arch requirement.
+# --------------------------------------------------------------------------
+@pytest.mark.parametrize("A_log_val", [-2.0, 0.0, 3.0], ids=lambda x: f"A_log={x}")
+@pytest.mark.parametrize("dt_bias_val", [-5.0, 0.0, 10.0], ids=lambda x: f"dt_bias={x}")
+def test_gate_sentinel_is_exactly_neutral(A_log_val, dt_bias_val):
+    """alpha must be EXACTLY 1.0 at the sentinel, for any A_log / dt_bias.
+
+    Not approximately: a micro-step that decays by even one ULP compounds over
+    n_h steps per token and over the whole sequence. -30 (the value the plan
+    originally suggested) fails this by one ULP once exp(A_log)*softplus()
+    exceeds 2^-24.
+    """
+    A_log = torch.tensor([A_log_val], dtype=torch.float32)
+    dt_bias = torch.tensor([dt_bias_val], dtype=torch.float32)
+    a = torch.tensor([[[GATE_NEUTRAL_A_SENTINEL]]], dtype=torch.float32)
+    b = torch.zeros_like(a)
+
+    alpha, _ = gates_from_logits(A_log, a, dt_bias, b)
+    assert (alpha == 1.0).all(), (
+        f"sentinel {GATE_NEUTRAL_A_SENTINEL} gave alpha={alpha.item():.10f} "
+        f"at A_log={A_log_val}, dt_bias={dt_bias_val}; must be exactly 1.0"
+    )
+    assert torch.isfinite(alpha).all(), "sentinel produced a non-finite gate"
+
+
+# --------------------------------------------------------------------------
+# 2. n_h == 1 must be the GDN MTP kernel, untouched.
+# --------------------------------------------------------------------------
+@pytest.mark.parametrize("T", [2, 4], ids=lambda t: f"T={t}")
+def test_decode_nh1_matches_gdn_mtp(T):
+    _skip_if_unsupported()
+    from flashinfer.gdn_decode import gated_delta_rule_mtp
+
+    B, n_h, H, K, V = 2, 1, 4, 128, 128
+    device, dtype = torch.device("cuda"), torch.float16
+    (q, k, v, A_log, a, dt_bias, b, pool, idx, _) = _gen_decode_inputs(
+        B, T, n_h, H, H, K, V, dtype, device, seed=0
+    )
+    pool_ref = pool.clone()
+
+    got_o, _ = gated_delta_product_mtp(
+        q,
+        k,
+        v,
+        pool,
+        idx,
+        A_log,
+        a,
+        dt_bias,
+        b,
+        scale=1.0,
+        disable_state_update=False,
+    )
+    ref_o, _ = gated_delta_rule_mtp(
+        q,
+        k.squeeze(2),
+        v.squeeze(2),
+        pool_ref,
+        idx,
+        A_log,
+        a,
+        dt_bias,
+        b.squeeze(2),
+        scale=1.0,
+        disable_state_update=False,
+    )
+    torch.cuda.synchronize()
+    torch.testing.assert_close(got_o, ref_o, atol=0, rtol=0)
+    torch.testing.assert_close(pool, pool_ref, atol=0, rtol=0)
+
+
+# --------------------------------------------------------------------------
+# 3. n_h > 1 against the reference.
+# --------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "num_householder", [1, 2, 3], ids=lambda nh: f"num_householder={nh}"
+)
+@pytest.mark.parametrize("T", [1, 2, 4], ids=lambda t: f"T={t}")
+@pytest.mark.parametrize(
+    "num_heads",
+    [(4, 4), (4, 8)],
+    ids=lambda qkv: "num_heads={0}/{1}".format(*qkv),  # (q, v) -- (4,8) is GVA
+)
+def test_decode_matches_reference(num_householder, T, num_heads):
+    _skip_if_unsupported()
+    if num_householder == 1 and T == 1:
+        # The expanded axis is n_h*T == 1, and gated_delta_rule_mtp is only
+        # valid for T > 1 -- its sibling gated_delta_rule_decode_pretranspose
+        # asserts `T == 1` and owns that case, while MTP has NO guard and
+        # silently returns garbage. Every other (n_h, T) here is fine: n_h >= 2
+        # makes the expanded axis >= 2 even when T == 1.
+        pytest.skip("n_h=1, T=1 expands to T=1, which is outside MTP's contract")
+    num_q_heads, num_v_heads = num_heads
+    B, K, V = 3, 128, 128
+    n_h = num_householder
+    device, dtype = torch.device("cuda"), torch.float16
+
+    (q, k, v, A_log, a, dt_bias, b, pool, idx, scratch) = _gen_decode_inputs(
+        B, T, n_h, num_q_heads, num_v_heads, K, V, dtype, device, seed=1
+    )
+    ref_o, ref_state = _reference(q, k, v, A_log, a, dt_bias, b, pool, idx)
+
+    got_o, got_pool = gated_delta_product_mtp(
+        q,
+        k,
+        v,
+        pool,
+        idx,
+        A_log,
+        a,
+        dt_bias,
+        b,
+        scale=1.0,
+        scratch_state_indices=scratch,
+        disable_state_update=False,
+    )
+    torch.cuda.synchronize()
+
+    assert got_o.shape == (B, T, num_v_heads, V), "one output row per REAL token"
+    torch.testing.assert_close(got_o, ref_o.to(dtype), atol=2e-3, rtol=1e-3)
+    # the live rows must hold each sequence's final state; pool is [.., V, K]
+    torch.testing.assert_close(
+        got_pool[idx.long()].transpose(-1, -2), ref_state, atol=1e-3, rtol=1e-4
+    )
+
+
+# --------------------------------------------------------------------------
+# 4. Scratch rows are written but never read back into the answer.
+# --------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "num_householder", [2, 3], ids=lambda nh: f"num_householder={nh}"
+)
+def test_scratch_slots_are_inert(num_householder):
+    """Poisoning the scratch rows beforehand must not change the result.
+
+    This is the check on the workaround for gdn_decode_mtp.py's unguarded
+    per-token scatter: the intermediate micro-steps DO write, we just need
+    their landing site to be irrelevant.
+    """
+    _skip_if_unsupported()
+    B, T, n_h, H, K, V = 3, 2, num_householder, 4, 128, 128
+    device, dtype = torch.device("cuda"), torch.float16
+
+    args = _gen_decode_inputs(B, T, n_h, H, H, K, V, dtype, device, seed=2)
+    (q, k, v, A_log, a, dt_bias, b, pool, idx, scratch) = args
+    clean_o, _ = gated_delta_product_mtp(
+        q,
+        k,
+        v,
+        pool.clone(),
+        idx,
+        A_log,
+        a,
+        dt_bias,
+        b,
+        scale=1.0,
+        scratch_state_indices=scratch,
+        disable_state_update=False,
+    )
+
+    poisoned = pool.clone()
+    poisoned[scratch.long()] = 1e30
+    poisoned_o, poisoned_pool = gated_delta_product_mtp(
+        q,
+        k,
+        v,
+        poisoned,
+        idx,
+        A_log,
+        a,
+        dt_bias,
+        b,
+        scale=1.0,
+        scratch_state_indices=scratch,
+        disable_state_update=False,
+    )
+    torch.cuda.synchronize()
+
+    torch.testing.assert_close(clean_o, poisoned_o, atol=0, rtol=0)
+    assert torch.isfinite(poisoned_pool[idx.long()]).all(), (
+        "poison leaked from a scratch row into a live slot -- scratch and live "
+        "slots are not disjoint, or an intermediate micro-step wrote a live row"
+    )
+
+
+# --------------------------------------------------------------------------
+# 5. Distinct scratch rows per batch entry.
+# --------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "num_householder", [2, 3], ids=lambda nh: f"num_householder={nh}"
+)
+def test_batch_rows_do_not_share_scratch(num_householder):
+    """Every batch row must land its intermediates in its own pool row.
+
+    Shared scratch is a write race: nondeterministic, and invisible unless the
+    rows carry different data. Running each row alone and comparing against the
+    batched run is what surfaces it.
+    """
+    _skip_if_unsupported()
+    B, T, n_h, H, K, V = 4, 2, num_householder, 4, 128, 128
+    device, dtype = torch.device("cuda"), torch.float16
+
+    (q, k, v, A_log, a, dt_bias, b, pool, idx, scratch) = _gen_decode_inputs(
+        B, T, n_h, H, H, K, V, dtype, device, seed=3
+    )
+    batched_o, _ = gated_delta_product_mtp(
+        q,
+        k,
+        v,
+        pool.clone(),
+        idx,
+        A_log,
+        a,
+        dt_bias,
+        b,
+        scale=1.0,
+        scratch_state_indices=scratch,
+        disable_state_update=False,
+    )
+    torch.cuda.synchronize()
+
+    for i in range(B):
+        s = slice(i, i + 1)
+        solo_o, _ = gated_delta_product_mtp(
+            q[s],
+            k[s],
+            v[s],
+            pool.clone(),
+            idx[s],
+            A_log,
+            a[s],
+            dt_bias,
+            b[s],
+            scale=1.0,
+            scratch_state_indices=scratch[s],
+            disable_state_update=False,
+        )
+        torch.cuda.synchronize()
+        torch.testing.assert_close(
+            batched_o[s],
+            solo_o,
+            atol=0,
+            rtol=0,
+            msg=lambda m: f"batch row {i} differs when run alone -- scratch race\n{m}",
+        )
+
+
+# --------------------------------------------------------------------------
+# 6. The reference BRIDGE itself, against flashinfer's own decode reference.
+#
+# _reference reaches delta_product through a dense->varlen reshape, a gate
+# computation and a state transpose. Any of those can be wrong independently of
+# the wrapper, and a wrong reference makes every other test in this file
+# meaningless. This pins it against decode_delta_rule -- an implementation
+# neither we nor the wrapper touch.
+#
+# Pure torch: no kernel, so this runs on any GPU, not just SM90+.
+# --------------------------------------------------------------------------
+@pytest.mark.parametrize("B", [1, 3], ids=lambda b: f"B={b}")
+@pytest.mark.parametrize(
+    "num_heads", [(4, 4), (4, 8)], ids=lambda qkv: "num_heads={0}/{1}".format(*qkv)
+)
+def test_reference_bridge_matches_decode_delta_rule(B, num_heads):
+    from .reference_delta_rule import decode_delta_rule
+
+    num_q_heads, num_v_heads = num_heads
+    T, n_h, K, V = 1, 1, 128, 128  # decode_delta_rule is single-step, n_h-free
+    device = torch.device("cuda")
+
+    (q, k, v, A_log, a, dt_bias, b, pool, idx, _) = _gen_decode_inputs(
+        B, T, n_h, num_q_heads, num_v_heads, K, V, torch.float32, device, seed=0
+    )
+    mine_o, mine_state = _reference(q, k, v, A_log, a, dt_bias, b, pool, idx)
+
+    ref_o, ref_state = decode_delta_rule(
+        q.squeeze(1).float(),
+        k.squeeze(1).squeeze(1).float(),
+        v.squeeze(1).squeeze(1).float(),
+        pool[idx.long()].transpose(-1, -2).contiguous(),  # [B, H, K, V]
+        A_log=A_log,
+        a=a.squeeze(1),
+        dt_bias=dt_bias,
+        b=b.squeeze(1).squeeze(1),
+        scale_factor=1.0,
+        use_l2_norm=True,
+    )
+
+    torch.testing.assert_close(mine_o.squeeze(1), ref_o, atol=1e-5, rtol=1e-5)
+    torch.testing.assert_close(mine_state, ref_state, atol=1e-5, rtol=1e-5)

--- a/tests/gdn/test_decode_delta_product.py
+++ b/tests/gdn/test_decode_delta_product.py
@@ -30,6 +30,8 @@ Layout note: decode is DENSE [B, T, ...], not varlen. The reference is still
 
 from __future__ import annotations
 
+from typing import NamedTuple
+
 import pytest
 import torch
 
@@ -62,8 +64,30 @@ def gates_from_logits(A_log, a, dt_bias, b):
     return alpha, torch.sigmoid(b)
 
 
+class DecodeInputs(NamedTuple):
+    q: torch.Tensor  # [B, T,      Hq, K]
+    k: torch.Tensor  # [B, T, n_h, Hq, K]
+    v: torch.Tensor  # [B, T, n_h, HV, V]
+    A_log: torch.Tensor  # [HV]
+    a: torch.Tensor  # [B, T,      HV]
+    dt_bias: torch.Tensor  # [HV]
+    b: torch.Tensor  # [B, T, n_h, HV]
+    pool: torch.Tensor  # [pool_size, HV, V, K]
+    initial_state_indices: torch.Tensor  # [B]
+    ssm_state_indices: torch.Tensor  # [B, T] one snapshot slot per REAL token
+    scratch_state_indices: torch.Tensor  # [B]
+
+
 def _gen_decode_inputs(B, T, n_h, num_q_heads, num_v_heads, K, V, dtype, device, seed):
-    """Dense decode inputs plus a state pool with B live slots and B scratch."""
+    """Dense decode inputs plus a state pool partitioned into disjoint regions.
+
+    Pool layout -- every region must be disjoint or the tests measure nothing:
+
+        row 0                       unused (0 is a sentinel elsewhere in flashinfer)
+        [1, 1+B)                    initial states, one per batch row
+        [1+B, 1+B+B*T)              per-REAL-token snapshots, ssm_state_indices
+        [1+B+B*T, 1+B+B*T+B)        scratch, absorbs the intermediate micro-steps
+    """
     torch.manual_seed(seed)
     torch.cuda.manual_seed(seed)
     HV = num_v_heads
@@ -78,23 +102,11 @@ def _gen_decode_inputs(B, T, n_h, num_q_heads, num_v_heads, K, V, dtype, device,
         a = torch.randn(B, T, HV, dtype=torch.float32)
         b = torch.randn(B, T, n_h, HV, dtype=torch.float32)
 
-        # pool: rows [0, B) live, rows [B, 2B) scratch. Row 0 of a pool is a
-        # common sentinel elsewhere in flashinfer, so start live slots at 1.
-        pool = torch.randn(2 * B + 1, HV, V, K, dtype=torch.float32) * 0.1
-        initial_state_indices = torch.arange(1, B + 1, dtype=torch.int32)
-        scratch_state_indices = torch.arange(B + 1, 2 * B + 1, dtype=torch.int32)
-    return (
-        q,
-        k,
-        v,
-        A_log,
-        a,
-        dt_bias,
-        b,
-        pool,
-        initial_state_indices,
-        scratch_state_indices,
-    )
+        pool = torch.randn(1 + B + B * T + B, HV, V, K, dtype=torch.float32) * 0.1
+        initial = torch.arange(1, 1 + B, dtype=torch.int32)
+        ssm = torch.arange(1 + B, 1 + B + B * T, dtype=torch.int32).reshape(B, T)
+        scratch = torch.arange(1 + B + B * T, 1 + B + B * T + B, dtype=torch.int32)
+    return DecodeInputs(q, k, v, A_log, a, dt_bias, b, pool, initial, ssm, scratch)
 
 
 def _reference(q, k, v, A_log, a, dt_bias, b, pool, idx, scale=1.0, use_l2_norm=True):
@@ -162,7 +174,7 @@ def test_decode_nh1_matches_gdn_mtp(T):
 
     B, n_h, H, K, V = 2, 1, 4, 128, 128
     device, dtype = torch.device("cuda"), torch.float16
-    (q, k, v, A_log, a, dt_bias, b, pool, idx, _) = _gen_decode_inputs(
+    q, k, v, A_log, a, dt_bias, b, pool, idx, ssm, scratch = _gen_decode_inputs(
         B, T, n_h, H, H, K, V, dtype, device, seed=0
     )
     pool_ref = pool.clone()
@@ -224,7 +236,7 @@ def test_decode_matches_reference(num_householder, T, num_heads):
     n_h = num_householder
     device, dtype = torch.device("cuda"), torch.float16
 
-    (q, k, v, A_log, a, dt_bias, b, pool, idx, scratch) = _gen_decode_inputs(
+    q, k, v, A_log, a, dt_bias, b, pool, idx, ssm, scratch = _gen_decode_inputs(
         B, T, n_h, num_q_heads, num_v_heads, K, V, dtype, device, seed=1
     )
     ref_o, ref_state = _reference(q, k, v, A_log, a, dt_bias, b, pool, idx)
@@ -240,7 +252,10 @@ def test_decode_matches_reference(num_householder, T, num_heads):
         dt_bias,
         b,
         scale=1.0,
-        scratch_state_indices=scratch,
+        # no ssm_state_indices: this is the PLAIN continuous-batching path.
+        # State moves via initial_state_indices (read) and output_state_indices
+        # (write, defaulting to the read slot); no per-token scatter, hence no
+        # scratch. Snapshots are test 7's job.
         disable_state_update=False,
     )
     torch.cuda.synchronize()
@@ -270,8 +285,9 @@ def test_scratch_slots_are_inert(num_householder):
     B, T, n_h, H, K, V = 3, 2, num_householder, 4, 128, 128
     device, dtype = torch.device("cuda"), torch.float16
 
-    args = _gen_decode_inputs(B, T, n_h, H, H, K, V, dtype, device, seed=2)
-    (q, k, v, A_log, a, dt_bias, b, pool, idx, scratch) = args
+    q, k, v, A_log, a, dt_bias, b, pool, idx, ssm, scratch = _gen_decode_inputs(
+        B, T, n_h, H, H, K, V, dtype, device, seed=2
+    )
     clean_o, _ = gated_delta_product_mtp(
         q,
         k,
@@ -283,6 +299,7 @@ def test_scratch_slots_are_inert(num_householder):
         dt_bias,
         b,
         scale=1.0,
+        ssm_state_indices=ssm,
         scratch_state_indices=scratch,
         disable_state_update=False,
     )
@@ -300,6 +317,7 @@ def test_scratch_slots_are_inert(num_householder):
         dt_bias,
         b,
         scale=1.0,
+        ssm_state_indices=ssm,
         scratch_state_indices=scratch,
         disable_state_update=False,
     )
@@ -313,25 +331,32 @@ def test_scratch_slots_are_inert(num_householder):
 
 
 # --------------------------------------------------------------------------
-# 5. Distinct scratch rows per batch entry.
+# 5. Batch rows must not contaminate one another.
+#
+# NOT a scratch-race test: sharing one scratch row across the batch is legal.
+# The kernel reads the pool once, before the recurrence, via
+# initial_state_indices; the per-token scatter is write-only after that, so
+# concurrent stores to a row nobody reads are benign. This checks the broader
+# invariant -- a row's result must not depend on who it was batched with --
+# and pins that BOTH scratch layouts satisfy it.
 # --------------------------------------------------------------------------
 @pytest.mark.parametrize(
     "num_householder", [2, 3], ids=lambda nh: f"num_householder={nh}"
 )
-def test_batch_rows_do_not_share_scratch(num_householder):
-    """Every batch row must land its intermediates in its own pool row.
-
-    Shared scratch is a write race: nondeterministic, and invisible unless the
-    rows carry different data. Running each row alone and comparing against the
-    batched run is what surfaces it.
-    """
+@pytest.mark.parametrize("shared_scratch", [True, False], ids=["shared", "per_row"])
+def test_batch_rows_are_independent(num_householder, shared_scratch):
+    """Running a row alone must match running it in a batch."""
     _skip_if_unsupported()
     B, T, n_h, H, K, V = 4, 2, num_householder, 4, 128, 128
     device, dtype = torch.device("cuda"), torch.float16
 
-    (q, k, v, A_log, a, dt_bias, b, pool, idx, scratch) = _gen_decode_inputs(
+    q, k, v, A_log, a, dt_bias, b, pool, idx, ssm, scratch = _gen_decode_inputs(
         B, T, n_h, H, H, K, V, dtype, device, seed=3
     )
+    if shared_scratch:
+        # every row funnels its intermediates into ONE throwaway pool row
+        scratch = scratch[:1].expand(B).contiguous()
+
     batched_o, _ = gated_delta_product_mtp(
         q,
         k,
@@ -343,34 +368,36 @@ def test_batch_rows_do_not_share_scratch(num_householder):
         dt_bias,
         b,
         scale=1.0,
+        ssm_state_indices=ssm,
         scratch_state_indices=scratch,
         disable_state_update=False,
     )
     torch.cuda.synchronize()
 
     for i in range(B):
-        s = slice(i, i + 1)
+        sl = slice(i, i + 1)
         solo_o, _ = gated_delta_product_mtp(
-            q[s],
-            k[s],
-            v[s],
+            q[sl],
+            k[sl],
+            v[sl],
             pool.clone(),
-            idx[s],
+            idx[sl],
             A_log,
-            a[s],
+            a[sl],
             dt_bias,
-            b[s],
+            b[sl],
             scale=1.0,
-            scratch_state_indices=scratch[s],
+            ssm_state_indices=ssm[sl],
+            scratch_state_indices=scratch[sl],
             disable_state_update=False,
         )
         torch.cuda.synchronize()
         torch.testing.assert_close(
-            batched_o[s],
+            batched_o[sl],
             solo_o,
             atol=0,
             rtol=0,
-            msg=lambda m: f"batch row {i} differs when run alone -- scratch race\n{m}",
+            msg=lambda m: f"row {i} differs when run alone -- cross-batch leak\n{m}",
         )
 
 
@@ -396,7 +423,7 @@ def test_reference_bridge_matches_decode_delta_rule(B, num_heads):
     T, n_h, K, V = 1, 1, 128, 128  # decode_delta_rule is single-step, n_h-free
     device = torch.device("cuda")
 
-    (q, k, v, A_log, a, dt_bias, b, pool, idx, _) = _gen_decode_inputs(
+    q, k, v, A_log, a, dt_bias, b, pool, idx, ssm, scratch = _gen_decode_inputs(
         B, T, n_h, num_q_heads, num_v_heads, K, V, torch.float32, device, seed=0
     )
     mine_o, mine_state = _reference(q, k, v, A_log, a, dt_bias, b, pool, idx)
@@ -416,3 +443,74 @@ def test_reference_bridge_matches_decode_delta_rule(B, num_heads):
 
     torch.testing.assert_close(mine_o.squeeze(1), ref_o, atol=1e-5, rtol=1e-5)
     torch.testing.assert_close(mine_state, ref_state, atol=1e-5, rtol=1e-5)
+
+
+# --------------------------------------------------------------------------
+# 7. Per-token state snapshots -- the property speculative decoding needs.
+#
+# ssm_state_indices[i, t] must end up holding the state AS OF real token t, so
+# that a rejected draft can roll the sequence back to any accepted prefix. This
+# is the only test that pins the scatter remap: it fails if the LAST micro-step
+# of each token is not the one routed to the caller's slot (e.g. an off-by-one
+# leaving the state after householder 0 there instead), and it fails if the
+# intermediates land on live rows rather than scratch.
+# --------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "num_householder", [1, 2, 3], ids=lambda nh: f"num_householder={nh}"
+)
+@pytest.mark.parametrize("T", [2, 3], ids=lambda t: f"T={t}")
+def test_per_token_state_snapshots(num_householder, T):
+    _skip_if_unsupported()
+    B, n_h, H, K, V = 3, num_householder, 4, 128, 128
+    device, dtype = torch.device("cuda"), torch.float16
+
+    q, k, v, A_log, a, dt_bias, b, pool, idx, ssm, scratch = _gen_decode_inputs(
+        B, T, n_h, H, H, K, V, dtype, device, seed=5
+    )
+
+    # state after each REAL token: rerun the reference over growing prefixes
+    want = []
+    for t in range(T):
+        _, st = _reference(
+            q[:, : t + 1],
+            k[:, : t + 1],
+            v[:, : t + 1],
+            A_log,
+            a[:, : t + 1],
+            dt_bias,
+            b[:, : t + 1],
+            pool,
+            idx,
+        )
+        want.append(st)
+
+    _, got_pool = gated_delta_product_mtp(
+        q,
+        k,
+        v,
+        pool,
+        idx,
+        A_log,
+        a,
+        dt_bias,
+        b,
+        scale=1.0,
+        ssm_state_indices=ssm,
+        scratch_state_indices=scratch,
+        disable_state_update=False,
+    )
+    torch.cuda.synchronize()
+
+    for t in range(T):
+        got = got_pool[ssm[:, t].long()].transpose(-1, -2)  # [.., V, K] -> [.., K, V]
+        torch.testing.assert_close(
+            got,
+            want[t],
+            atol=1e-3,
+            rtol=1e-4,
+            msg=lambda m: (
+                f"snapshot for real token {t} is wrong. A state after only the "
+                f"FIRST householder here means the scatter remap targets "
+                f"[0::n_h] instead of [n_h-1::n_h].\n{m}"
+            ),
+        )

--- a/tests/gdn/test_decode_delta_product.py
+++ b/tests/gdn/test_decode_delta_product.py
@@ -55,6 +55,9 @@ def gates_from_logits(A_log, a, dt_bias, b):
     this bridge. Keep it in lockstep with the kernel or the tests measure the
     wrong thing.
     """
+    # a/b arrive in the MODEL dtype (fp16/bf16); the kernel promotes internally,
+    # so the host-side twin has to as well or it measures a different function.
+    a, b = a.float(), b.float()
     x = a + dt_bias
     bx = SOFTPLUS_BETA * x
     softplus_x = torch.where(
@@ -92,17 +95,28 @@ def _gen_decode_inputs(B, T, n_h, num_q_heads, num_v_heads, K, V, dtype, device,
     torch.cuda.manual_seed(seed)
     HV = num_v_heads
     with device:
-        q = torch.randn(B, T, num_q_heads, K, dtype=dtype) * 0.25
-        k = torch.randn(B, T, n_h, num_q_heads, K, dtype=dtype) * 0.25
-        v = torch.randn(B, T, n_h, HV, V, dtype=dtype) * 0.25
-        k = torch.nn.functional.normalize(k.float(), dim=-1).to(dtype)
+        # Magnitudes and dtypes mirror the house MTP test
+        # (test_decode_delta_rule.py::test_gated_delta_rule_mtp). Two of these
+        # are load-bearing, not cosmetic:
+        #
+        #  * `a` and `b` are the MODEL dtype, not fp32. They are raw logits the
+        #    kernel converts internally. Only A_log and dt_bias are fp32. This
+        #    is the opposite of prefill, where `g`/`beta` are consumed directly
+        #    and must be fp32 -- generalising the prefill rule to decode makes
+        #    the gate wrong from the very first token.
+        #  * everything is scaled to ~0.1 (state ~0.01). Unscaled randn drives
+        #    softplus(a + dt_bias) into a range where alpha swings hard, which
+        #    is numerically far nastier than anything the kernel is tuned for.
+        q = torch.randn(B, T, num_q_heads, K, dtype=dtype) * 0.1
+        k = torch.randn(B, T, n_h, num_q_heads, K, dtype=dtype) * 0.1
+        v = torch.randn(B, T, n_h, HV, V, dtype=dtype) * 0.1
 
-        A_log = torch.rand(HV, dtype=torch.float32) * 2.0 - 1.0
-        dt_bias = torch.rand(HV, dtype=torch.float32) * 2.0 - 1.0
-        a = torch.randn(B, T, HV, dtype=torch.float32)
-        b = torch.randn(B, T, n_h, HV, dtype=torch.float32)
+        A_log = torch.randn(HV, dtype=torch.float32) * 0.1
+        dt_bias = torch.randn(HV, dtype=torch.float32) * 0.1
+        a = torch.randn(B, T, HV, dtype=dtype) * 0.1
+        b = torch.randn(B, T, n_h, HV, dtype=dtype) * 0.1
 
-        pool = torch.randn(1 + B + B * T + B, HV, V, K, dtype=torch.float32) * 0.1
+        pool = torch.randn(1 + B + B * T + B, HV, V, K, dtype=torch.float32) * 0.01
         initial = torch.arange(1, 1 + B, dtype=torch.int32)
         ssm = torch.arange(1 + B, 1 + B + B * T, dtype=torch.int32).reshape(B, T)
         scratch = torch.arange(1 + B + B * T, 1 + B + B * T + B, dtype=torch.int32)

--- a/tests/gdn/test_decode_delta_product.py
+++ b/tests/gdn/test_decode_delta_product.py
@@ -186,10 +186,10 @@ def test_decode_nh1_matches_gdn_mtp(T):
     _skip_if_unsupported()
     from flashinfer.gdn_decode import gated_delta_rule_mtp
 
-    B, n_h, H, K, V = 2, 1, 4, 128, 128
-    device, dtype = torch.device("cuda"), torch.float16
+    B, n_h, HQ, HV, K, V = 2, 1, 16, 32, 128, 128
+    device, dtype = torch.device("cuda"), torch.bfloat16
     q, k, v, A_log, a, dt_bias, b, pool, idx, ssm, scratch = _gen_decode_inputs(
-        B, T, n_h, H, H, K, V, dtype, device, seed=0
+        B, T, n_h, HQ, HV, K, V, dtype, device, seed=0
     )
     pool_ref = pool.clone()
 
@@ -233,22 +233,22 @@ def test_decode_nh1_matches_gdn_mtp(T):
 @pytest.mark.parametrize("T", [1, 2, 4], ids=lambda t: f"T={t}")
 @pytest.mark.parametrize(
     "num_heads",
-    [(4, 4), (4, 8)],
-    ids=lambda qkv: "num_heads={0}/{1}".format(*qkv),  # (q, v) -- (4,8) is GVA
+    # (q, v). (16, 32) is the ONLY config test_decode_delta_rule.py exercises for
+    # MTP, and the tile heuristics (get_tile_v_mtp) are parameterised on HV --
+    # smaller head counts are outside the kernel's tested envelope.
+    [(16, 32)],
+    ids=lambda qkv: "num_heads={0}/{1}".format(*qkv),
 )
 def test_decode_matches_reference(num_householder, T, num_heads):
     _skip_if_unsupported()
-    if num_householder == 1 and T == 1:
-        # The expanded axis is n_h*T == 1, and gated_delta_rule_mtp is only
-        # valid for T > 1 -- its sibling gated_delta_rule_decode_pretranspose
-        # asserts `T == 1` and owns that case, while MTP has NO guard and
-        # silently returns garbage. Every other (n_h, T) here is fine: n_h >= 2
-        # makes the expanded axis >= 2 even when T == 1.
-        pytest.skip("n_h=1, T=1 expands to T=1, which is outside MTP's contract")
+    # n_h=1, T=1 is included deliberately. gated_delta_rule_mtp documents itself
+    # as T > 1 in seven places and enforces it nowhere, but T=1 is computed
+    # correctly -- verified against the first token of a T=2 run (max|d| = 0).
+    # The docs are over-restrictive; the code is not.
     num_q_heads, num_v_heads = num_heads
     B, K, V = 3, 128, 128
     n_h = num_householder
-    device, dtype = torch.device("cuda"), torch.float16
+    device, dtype = torch.device("cuda"), torch.bfloat16
 
     q, k, v, A_log, a, dt_bias, b, pool, idx, ssm, scratch = _gen_decode_inputs(
         B, T, n_h, num_q_heads, num_v_heads, K, V, dtype, device, seed=1
@@ -275,10 +275,11 @@ def test_decode_matches_reference(num_householder, T, num_heads):
     torch.cuda.synchronize()
 
     assert got_o.shape == (B, T, num_v_heads, V), "one output row per REAL token"
-    torch.testing.assert_close(got_o, ref_o.to(dtype), atol=2e-3, rtol=1e-3)
+    # tolerances from test_decode_delta_rule.py's MTP test (bf16)
+    torch.testing.assert_close(got_o, ref_o.to(dtype), atol=1e-2, rtol=5e-3)
     # the live rows must hold each sequence's final state; pool is [.., V, K]
     torch.testing.assert_close(
-        got_pool[idx.long()].transpose(-1, -2), ref_state, atol=1e-3, rtol=1e-4
+        got_pool[idx.long()].transpose(-1, -2), ref_state, atol=1e-2, rtol=5e-3
     )
 
 
@@ -296,11 +297,11 @@ def test_scratch_slots_are_inert(num_householder):
     their landing site to be irrelevant.
     """
     _skip_if_unsupported()
-    B, T, n_h, H, K, V = 3, 2, num_householder, 4, 128, 128
-    device, dtype = torch.device("cuda"), torch.float16
+    B, T, n_h, HQ, HV, K, V = 3, 2, num_householder, 16, 32, 128, 128
+    device, dtype = torch.device("cuda"), torch.bfloat16
 
     q, k, v, A_log, a, dt_bias, b, pool, idx, ssm, scratch = _gen_decode_inputs(
-        B, T, n_h, H, H, K, V, dtype, device, seed=2
+        B, T, n_h, HQ, HV, K, V, dtype, device, seed=2
     )
     clean_o, _ = gated_delta_product_mtp(
         q,
@@ -361,11 +362,11 @@ def test_scratch_slots_are_inert(num_householder):
 def test_batch_rows_are_independent(num_householder, shared_scratch):
     """Running a row alone must match running it in a batch."""
     _skip_if_unsupported()
-    B, T, n_h, H, K, V = 4, 2, num_householder, 4, 128, 128
-    device, dtype = torch.device("cuda"), torch.float16
+    B, T, n_h, HQ, HV, K, V = 4, 2, num_householder, 16, 32, 128, 128
+    device, dtype = torch.device("cuda"), torch.bfloat16
 
     q, k, v, A_log, a, dt_bias, b, pool, idx, ssm, scratch = _gen_decode_inputs(
-        B, T, n_h, H, H, K, V, dtype, device, seed=3
+        B, T, n_h, HQ, HV, K, V, dtype, device, seed=3
     )
     if shared_scratch:
         # every row funnels its intermediates into ONE throwaway pool row
@@ -395,14 +396,18 @@ def test_batch_rows_are_independent(num_householder, shared_scratch):
             k[sl],
             v[sl],
             pool.clone(),
-            idx[sl],
+            # .clone() the INDEX slices: a 1-element int32 slice is contiguous
+            # but carries a 4-byte-granular offset, and the kernel demands
+            # 16-byte data alignment. The q/k/v/a/b slices are safe -- their
+            # per-row strides are large enough to stay aligned.
+            idx[sl].clone(),
             A_log,
             a[sl],
             dt_bias,
             b[sl],
             scale=1.0,
-            ssm_state_indices=ssm[sl],
-            scratch_state_indices=scratch[sl],
+            ssm_state_indices=ssm[sl].clone(),
+            scratch_state_indices=scratch[sl].clone(),
             disable_state_update=False,
         )
         torch.cuda.synchronize()
@@ -428,7 +433,7 @@ def test_batch_rows_are_independent(num_householder, shared_scratch):
 # --------------------------------------------------------------------------
 @pytest.mark.parametrize("B", [1, 3], ids=lambda b: f"B={b}")
 @pytest.mark.parametrize(
-    "num_heads", [(4, 4), (4, 8)], ids=lambda qkv: "num_heads={0}/{1}".format(*qkv)
+    "num_heads", [(16, 32)], ids=lambda qkv: "num_heads={0}/{1}".format(*qkv)
 )
 def test_reference_bridge_matches_decode_delta_rule(B, num_heads):
     from .reference_delta_rule import decode_delta_rule
@@ -475,11 +480,11 @@ def test_reference_bridge_matches_decode_delta_rule(B, num_heads):
 @pytest.mark.parametrize("T", [2, 3], ids=lambda t: f"T={t}")
 def test_per_token_state_snapshots(num_householder, T):
     _skip_if_unsupported()
-    B, n_h, H, K, V = 3, num_householder, 4, 128, 128
-    device, dtype = torch.device("cuda"), torch.float16
+    B, n_h, HQ, HV, K, V = 3, num_householder, 16, 32, 128, 128
+    device, dtype = torch.device("cuda"), torch.bfloat16
 
     q, k, v, A_log, a, dt_bias, b, pool, idx, ssm, scratch = _gen_decode_inputs(
-        B, T, n_h, H, H, K, V, dtype, device, seed=5
+        B, T, n_h, HQ, HV, K, V, dtype, device, seed=5
     )
 
     # state after each REAL token: rerun the reference over growing prefixes
@@ -520,8 +525,8 @@ def test_per_token_state_snapshots(num_householder, T):
         torch.testing.assert_close(
             got,
             want[t],
-            atol=1e-3,
-            rtol=1e-4,
+            atol=1e-2,
+            rtol=5e-3,
             msg=lambda m: (
                 f"snapshot for real token {t} is wrong. A state after only the "
                 f"FIRST householder here means the scatter remap targets "

--- a/tests/gdn/test_prefill_delta_product.py
+++ b/tests/gdn/test_prefill_delta_product.py
@@ -1,0 +1,286 @@
+"""
+Copyright (c) 2025 by FlashInfer team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from __future__ import annotations
+
+import random
+
+import pytest
+import torch
+
+from flashinfer.gdn_prefill import chunk_gated_delta_rule
+from flashinfer.utils import (
+    is_sm90a_supported,
+    is_sm100a_supported,
+    is_sm12x_supported,
+)
+
+from .reference_delta_product import delta_product
+from .reference_delta_rule import delta_rule, exclusive_cumsum
+
+
+def _skip_if_unsupported():
+    """Mirror of test_prefill_delta_rule._skip_if_unsupported."""
+    device = torch.device("cuda")
+    if is_sm100a_supported(device):
+        cuda_major = int(torch.version.cuda.split(".")[0]) if torch.version.cuda else 0
+        if cuda_major < 13:
+            pytest.skip(
+                f"SM100 GDN prefill requires CUDA 13+, got {torch.version.cuda}"
+            )
+        return
+    if is_sm90a_supported(device) or is_sm12x_supported(device):
+        return
+    pytest.skip("GDN prefill requires SM90, SM100, or SM12x")
+
+
+def _gen_product_inputs(
+    seq_lens,
+    num_householder,
+    num_q_heads,
+    num_k_heads,
+    num_v_heads,
+    head_size,
+    dtype,
+    qkv_factory,
+    device,
+):
+    """Build q/k/v/alpha/beta with a householder axis at dim 1 of k and v.
+
+    Reuses ``conftest.gen_qkv`` by generating n_h times as many k/v rows and
+    folding the extra rows into the householder axis -- so the element
+    distribution matches the existing GDN tests exactly.
+    """
+    total_seqlen = sum(seq_lens)
+    num_sab_heads = max(num_q_heads, num_v_heads)
+
+    with device:
+        # one q per real token; n_h keys/values per real token
+        q, _, _ = qkv_factory(
+            seq_lens, num_q_heads, num_k_heads, num_v_heads, head_size, dtype
+        )
+        _, k, v = qkv_factory(
+            [s * num_householder for s in seq_lens],
+            num_q_heads,
+            num_k_heads,
+            num_v_heads,
+            head_size,
+            dtype,
+        )
+        k = k.reshape(total_seqlen, num_householder, num_k_heads, head_size)
+        v = v.reshape(total_seqlen, num_householder, num_v_heads, head_size)
+        # l2 norm k to avoid numerical instability (as the GDN tests do)
+        k = torch.nn.functional.normalize(k, p=2.0, dim=-1)
+
+        alpha = torch.rand(total_seqlen, num_sab_heads)
+        beta = torch.rand(total_seqlen, num_householder, num_sab_heads)
+        cu_seqlens = torch.tensor(exclusive_cumsum(seq_lens), dtype=torch.int64)
+
+    return q, k, v, alpha, beta, cu_seqlens
+
+
+@pytest.mark.parametrize(
+    "seq_lens",
+    [[64], [128], [64, 128, 512]],
+    ids=lambda seqlens: "seq_lens=" + ",".join(map(str, seqlens)),
+)
+@pytest.mark.parametrize("head_size", [128], ids=lambda hs: f"head_size={hs}")
+@pytest.mark.parametrize(
+    "num_heads",
+    [(8, 8, 8), (8, 8, 16)],
+    ids=lambda qkv: "num_heads={0}/{1}/{2}".format(*qkv),
+)  # (q, k, v) -- GVA
+@pytest.mark.parametrize("dtype", ["float16", "bfloat16"])
+def test_reference_nh1_equals_delta_rule(
+    qkv_factory, seq_lens, head_size, num_heads, dtype, seed=0
+):
+    """At n_h == 1, DeltaProduct IS DeltaNet. Exact equality -- same fp ops, same order."""
+    random.seed(seed)
+    torch.random.manual_seed(seed)
+    torch.cuda.manual_seed(seed)
+
+    num_q_heads, num_k_heads, num_v_heads = num_heads
+    device = torch.device("cuda")
+    dtype = getattr(torch, dtype)
+
+    q, k, v, alpha, beta, _ = _gen_product_inputs(
+        seq_lens,
+        1,
+        num_q_heads,
+        num_k_heads,
+        num_v_heads,
+        head_size,
+        dtype,
+        qkv_factory,
+        device,
+    )
+
+    prod_o, prod_state = delta_product(
+        q.float(),
+        k.float(),
+        v.float(),
+        seq_lens,
+        alpha=alpha,
+        beta=beta,
+        scale_factor=1.0,
+    )
+    rule_o, rule_state = delta_rule(
+        q.float(),
+        k.squeeze(1).float(),
+        v.squeeze(1).float(),
+        seq_lens,
+        alpha=alpha,
+        beta=beta.squeeze(1),
+        scale_factor=1.0,
+    )
+
+    torch.testing.assert_close(prod_o, rule_o, atol=0, rtol=0)
+    torch.testing.assert_close(prod_state, rule_state, atol=0, rtol=0)
+
+
+@pytest.mark.parametrize("seq_lens", [[64], [256], [64, 128, 512]])
+@pytest.mark.parametrize("head_size", [128])
+@pytest.mark.parametrize("num_heads", [(8, 8, 8), (8, 8, 16)])
+@pytest.mark.parametrize("dtype", ["float16", "bfloat16"])
+def test_reference_nh1_matches_kernel(
+    qkv_factory, seq_lens, head_size, num_heads, dtype, seed=0
+):
+    _skip_if_unsupported()
+    random.seed(seed)
+    torch.random.manual_seed(seed)
+    torch.cuda.manual_seed(seed)
+
+    num_q_heads, num_k_heads, num_v_heads = num_heads
+    num_o_heads = num_sab_heads = max(num_q_heads, num_v_heads)
+    num_seqs, total_seqlen = len(seq_lens), sum(seq_lens)
+    device = torch.device("cuda")
+    dtype = getattr(torch, dtype)
+
+    q, k, v, alpha, beta, cu_seqlens = _gen_product_inputs(
+        seq_lens,
+        1,
+        num_q_heads,
+        num_k_heads,
+        num_v_heads,
+        head_size,
+        dtype,
+        qkv_factory,
+        device,
+    )
+
+    our_o = torch.full(
+        (total_seqlen, num_o_heads, head_size),
+        float("nan"),
+        dtype=q.dtype,
+        device=device,
+    )
+    our_state = torch.full(
+        (num_seqs, num_sab_heads, head_size, head_size),
+        float("nan"),
+        dtype=torch.float32,
+        device=device,
+    )
+    chunk_gated_delta_rule(
+        q,
+        k.squeeze(1),
+        v.squeeze(1),
+        alpha,
+        beta.squeeze(1),
+        1.0,  # scale
+        None,  # initial_state
+        True,  # output_final_state
+        cu_seqlens,
+        True,  # use_qk_l2norm_in_kernel
+        output=our_o,
+        output_state=our_state,
+    )
+    torch.cuda.synchronize()
+    our_state = our_state.transpose(
+        -1, -2
+    )  # kernel is [.., V, K]; reference is [.., K, V]
+
+    ref_o, ref_state = delta_product(
+        q.float(),
+        k.float(),
+        v.float(),
+        seq_lens,
+        alpha=alpha,
+        beta=beta,
+        scale_factor=1.0,
+    )
+
+    if dtype == torch.bfloat16:
+        atol_o, rtol_o, atol_kv, rtol_kv = 1e-2, 1e-2, 5e-3, 1e-3
+    else:
+        atol_o, rtol_o, atol_kv, rtol_kv = 2e-3, 1e-3, 1e-3, 1e-4
+
+    torch.testing.assert_close(our_o, ref_o.to(q.dtype), atol=atol_o, rtol=rtol_o)
+    torch.testing.assert_close(our_state, ref_state, atol=atol_kv, rtol=rtol_kv)
+
+
+@pytest.mark.parametrize("num_householder", [1, 2, 3, 4])
+@pytest.mark.parametrize("seq_lens", [[128], [64, 128, 512]])
+@pytest.mark.parametrize("num_heads", [(8, 8, 8), (8, 8, 16)])
+def test_reference_equals_expanded_delta_rule(
+    qkv_factory, num_householder, seq_lens, num_heads, seed=0
+):
+    """GDP is GDN on a sequence n_h times longer.
+
+    Gate on the first micro-step of each token (neutral value 1.0 -- alpha here
+    is multiplicative, not log-space), query only on the last, then read every
+    n_h-th output row.
+    """
+    random.seed(seed)
+    torch.random.manual_seed(seed)
+    torch.cuda.manual_seed(seed)
+
+    num_q_heads, num_k_heads, num_v_heads = num_heads
+    num_sab_heads = max(num_q_heads, num_v_heads)
+    head_size, n_h = 128, num_householder
+    total_seqlen = sum(seq_lens)
+    device = torch.device("cuda")
+
+    q, k, v, alpha, beta, _ = _gen_product_inputs(
+        seq_lens,
+        n_h,
+        num_q_heads,
+        num_k_heads,
+        num_v_heads,
+        head_size,
+        torch.float16,
+        qkv_factory,
+        device,
+    )
+    q, k, v = q.float(), k.float(), v.float()
+
+    prod_o, prod_state = delta_product(q, k, v, seq_lens, alpha=alpha, beta=beta)
+
+    with device:
+        alpha_flat = torch.ones(total_seqlen * n_h, num_sab_heads)
+        alpha_flat[0::n_h] = alpha
+        q_flat = torch.zeros(total_seqlen * n_h, num_q_heads, head_size)
+        q_flat[n_h - 1 :: n_h] = q
+    rule_o, rule_state = delta_rule(
+        q_flat,
+        k.reshape(total_seqlen * n_h, num_k_heads, head_size),
+        v.reshape(total_seqlen * n_h, num_v_heads, head_size),
+        [s * n_h for s in seq_lens],
+        alpha=alpha_flat,
+        beta=beta.reshape(total_seqlen * n_h, num_sab_heads),
+    )
+
+    torch.testing.assert_close(prod_o, rule_o[n_h - 1 :: n_h], atol=1e-5, rtol=1e-5)
+    torch.testing.assert_close(prod_state, rule_state, atol=1e-5, rtol=1e-5)

--- a/tests/gdn/test_prefill_delta_product.py
+++ b/tests/gdn/test_prefill_delta_product.py
@@ -12,6 +12,19 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
+
+Note on ``use_qk_l2norm_in_kernel``: as of this writing the prefill path
+**ignores it**. ``chunk_gated_delta_rule`` declares and documents the parameter,
+but no SM90/SM100/SM120 prefill kernel reads it, and vLLM's bridge normalises
+q/k on the host before calling in (see ``fi_chunk_gated_delta_rule``). These
+tests therefore pass ``False`` and pre-normalise ``k`` in
+``_gen_product_inputs`` -- which is what the algorithm actually needs
+(``||k|| == 1`` for the Householder interpretation; q needs nothing). Passing
+``True`` behaves identically today but would silently break these tests the day
+the flag is implemented.
+
+Decode is the opposite: there ``use_qk_l2norm`` is live and normalises BOTH q
+and k, which is why ``test_decode_delta_product._reference`` mirrors it.
 """
 
 from __future__ import annotations
@@ -212,7 +225,7 @@ def test_reference_nh1_matches_kernel(
         None,  # initial_state
         True,  # output_final_state
         cu_seqlens,
-        True,  # use_qk_l2norm_in_kernel
+        False,  # use_qk_l2norm_in_kernel -- see note below; k is pre-normalised
         output=our_o,
         output_state=our_state,
     )
@@ -369,7 +382,7 @@ def test_prefill_kernel_matches_reference(
         None,  # initial_state
         True,  # output_final_state
         cu_seqlens,
-        True,  # use_qk_l2norm_in_kernel
+        False,  # use_qk_l2norm_in_kernel -- see note below; k is pre-normalised
         output=our_o,
         output_state=our_state,
     )
@@ -469,7 +482,7 @@ def test_prefill_kernel_output_conventions(
         None,  # initial_state
         output_final_state,
         cu_seqlens,
-        True,  # use_qk_l2norm_in_kernel
+        False,  # use_qk_l2norm_in_kernel -- see note below; k is pre-normalised
         output=our_o,
         output_state=None,  # force the wrapper to own the state buffer
     )

--- a/tests/gdn/test_prefill_delta_product.py
+++ b/tests/gdn/test_prefill_delta_product.py
@@ -398,3 +398,115 @@ def test_prefill_kernel_matches_reference(
 
     torch.testing.assert_close(our_o, ref_o.to(q.dtype), atol=atol_o, rtol=rtol_o)
     torch.testing.assert_close(our_state, ref_state, atol=atol_kv, rtol=rtol_kv)
+
+
+# --------------------------------------------------------------------------
+# The four (pass_output x output_final_state) combinations. Every other test
+# passes output= and output_final_state=True, which leaves the wrapper's
+# allocate-and-return path and its no-state path completely unexercised --
+# and those are exactly where a wrong strided gather or a hardcoded
+# output_final_state can hide.
+# --------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "pass_output", [True, False], ids=["output=buf", "output=None"]
+)
+@pytest.mark.parametrize(
+    "output_final_state", [True, False], ids=["final_state", "no_final_state"]
+)
+@pytest.mark.parametrize(
+    "num_householder", [1, 3], ids=lambda nh: f"num_householder={nh}"
+)
+@pytest.mark.parametrize(
+    "num_heads",
+    [(8, 8, 8), (8, 8, 16)],
+    ids=lambda qkv: "num_heads={0}/{1}/{2}".format(*qkv),
+)
+def test_prefill_kernel_output_conventions(
+    qkv_factory, pass_output, output_final_state, num_householder, num_heads, seed=0
+):
+    """Return contract and output rows must not depend on how they're requested."""
+    _skip_if_unsupported()
+    random.seed(seed)
+    torch.random.manual_seed(seed)
+    torch.cuda.manual_seed(seed)
+
+    num_q_heads, num_k_heads, num_v_heads = num_heads
+    num_o_heads = num_sab_heads = max(num_q_heads, num_v_heads)
+    seq_lens = [64, 128, 512]
+    head_size, n_h = 128, num_householder
+    num_seqs, total_seqlen = len(seq_lens), sum(seq_lens)
+    device = torch.device("cuda")
+    dtype = torch.float16
+
+    q, k, v, alpha, beta, cu_seqlens = _gen_product_inputs(
+        seq_lens,
+        n_h,
+        num_q_heads,
+        num_k_heads,
+        num_v_heads,
+        head_size,
+        dtype,
+        qkv_factory,
+        device,
+    )
+
+    our_o = None
+    if pass_output:
+        our_o = torch.full(
+            (total_seqlen, num_o_heads, head_size),
+            float("nan"),
+            dtype=dtype,
+            device=device,
+        )
+
+    result = chunk_gated_delta_product(
+        q,
+        k,
+        v,
+        alpha,
+        beta,
+        1.0,  # scale
+        None,  # initial_state
+        output_final_state,
+        cu_seqlens,
+        True,  # use_qk_l2norm_in_kernel
+        output=our_o,
+        output_state=None,  # force the wrapper to own the state buffer
+    )
+    torch.cuda.synchronize()
+
+    # --- return contract mirrors chunk_gated_delta_rule ---
+    if output_final_state:
+        assert isinstance(result, tuple) and len(result) == 2, (
+            f"output_final_state=True must return (output, final_state); "
+            f"got {type(result)}"
+        )
+        got_o, got_state = result
+        assert got_state is not None, "final_state requested but None returned"
+        assert got_state.shape == (num_seqs, num_sab_heads, head_size, head_size)
+    else:
+        assert not isinstance(result, tuple), (
+            "output_final_state=False must return the output tensor alone, "
+            f"got a {type(result)}"
+        )
+        got_o, got_state = result, None
+
+    if pass_output:
+        assert got_o is our_o, "output= was supplied; the same tensor must come back"
+    assert got_o.shape == (total_seqlen, num_o_heads, head_size)
+    assert not got_o.isnan().any(), "output rows left unwritten"
+
+    ref_o, ref_state = delta_product(
+        q.float(),
+        k.float(),
+        v.float(),
+        seq_lens,
+        alpha=alpha,
+        beta=beta,
+        scale_factor=1.0,
+    )
+    torch.testing.assert_close(got_o, ref_o.to(dtype), atol=2e-3, rtol=1e-3)
+    if got_state is not None:
+        torch.testing.assert_close(
+            got_state.transpose(-1, -2), ref_state, atol=1e-3, rtol=1e-4
+        )

--- a/tests/gdn/test_prefill_delta_product.py
+++ b/tests/gdn/test_prefill_delta_product.py
@@ -22,6 +22,7 @@ import pytest
 import torch
 
 from flashinfer.gdn_prefill import chunk_gated_delta_rule
+from flashinfer.gdn_product import chunk_gated_delta_product
 from flashinfer.utils import (
     is_sm90a_supported,
     is_sm100a_supported,
@@ -302,3 +303,98 @@ def test_reference_equals_expanded_delta_rule(
 
     torch.testing.assert_close(prod_o, rule_o[n_h - 1 :: n_h], atol=1e-5, rtol=1e-5)
     torch.testing.assert_close(prod_state, rule_state, atol=1e-5, rtol=1e-5)
+
+
+@pytest.mark.parametrize(
+    "num_householder", [1, 2, 3, 4], ids=lambda nh: f"num_householder={nh}"
+)
+@pytest.mark.parametrize(
+    "seq_lens",
+    [[64], [256], [64, 128, 512]],
+    ids=lambda s: "seq_lens=" + ",".join(map(str, s)),
+)
+@pytest.mark.parametrize(
+    "num_heads",
+    [(8, 8, 8), (8, 8, 16)],
+    ids=lambda qkv: "num_heads={0}/{1}/{2}".format(*qkv),
+)
+@pytest.mark.parametrize("dtype", ["float16", "bfloat16"])
+def test_prefill_kernel_matches_reference(
+    qkv_factory, num_householder, seq_lens, num_heads, dtype, seed=0
+):
+    """chunk_gated_delta_product == delta_product reference, on real kernels."""
+    _skip_if_unsupported()
+    random.seed(seed)
+    torch.random.manual_seed(seed)
+    torch.cuda.manual_seed(seed)
+
+    num_q_heads, num_k_heads, num_v_heads = num_heads
+    num_o_heads = num_sab_heads = max(num_q_heads, num_v_heads)
+    num_seqs, total_seqlen = len(seq_lens), sum(seq_lens)
+    head_size, n_h = 128, num_householder
+    device = torch.device("cuda")
+    dtype = getattr(torch, dtype)
+
+    q, k, v, alpha, beta, cu_seqlens = _gen_product_inputs(
+        seq_lens,
+        n_h,
+        num_q_heads,
+        num_k_heads,
+        num_v_heads,
+        head_size,
+        dtype,
+        qkv_factory,
+        device,
+    )
+
+    our_o = torch.full(
+        (total_seqlen, num_o_heads, head_size),
+        float("nan"),
+        dtype=q.dtype,
+        device=device,
+    )
+    our_state = torch.full(
+        (num_seqs, num_sab_heads, head_size, head_size),
+        float("nan"),
+        dtype=torch.float32,
+        device=device,
+    )
+    chunk_gated_delta_product(
+        q,
+        k,
+        v,
+        alpha,
+        beta,
+        1.0,  # scale
+        None,  # initial_state
+        True,  # output_final_state
+        cu_seqlens,
+        True,  # use_qk_l2norm_in_kernel
+        output=our_o,
+        output_state=our_state,
+    )
+    torch.cuda.synchronize()
+
+    # state shape must not depend on n_h -- this is the whole selling point
+    assert our_state.shape == (num_seqs, num_sab_heads, head_size, head_size)
+    assert not our_o.isnan().any(), "output buffer left partially unwritten"
+
+    our_state = our_state.transpose(-1, -2)  # kernel [.., V, K] -> ref [.., K, V]
+
+    ref_o, ref_state = delta_product(
+        q.float(),
+        k.float(),
+        v.float(),
+        seq_lens,
+        alpha=alpha,
+        beta=beta,
+        scale_factor=1.0,
+    )
+
+    if dtype == torch.bfloat16:
+        atol_o, rtol_o, atol_kv, rtol_kv = 1e-2, 1e-2, 5e-3, 1e-3
+    else:
+        atol_o, rtol_o, atol_kv, rtol_kv = 2e-3, 1e-3, 1e-3, 1e-4
+
+    torch.testing.assert_close(our_o, ref_o.to(q.dtype), atol=atol_o, rtol=rtol_o)
+    torch.testing.assert_close(our_state, ref_state, atol=atol_kv, rtol=rtol_kv)

--- a/tests/gdn/test_prefill_delta_product.py
+++ b/tests/gdn/test_prefill_delta_product.py
@@ -151,9 +151,17 @@ def test_reference_nh1_equals_delta_rule(
     torch.testing.assert_close(prod_state, rule_state, atol=0, rtol=0)
 
 
-@pytest.mark.parametrize("seq_lens", [[64], [256], [64, 128, 512]])
-@pytest.mark.parametrize("head_size", [128])
-@pytest.mark.parametrize("num_heads", [(8, 8, 8), (8, 8, 16)])
+@pytest.mark.parametrize(
+    "seq_lens",
+    [[64], [256], [64, 128, 512]],
+    ids=lambda seqlens: "seq_lens=" + ",".join(map(str, seqlens)),
+)
+@pytest.mark.parametrize("head_size", [128], ids=lambda hs: f"head_size={hs}")
+@pytest.mark.parametrize(
+    "num_heads",
+    [(8, 8, 8), (8, 8, 16)],
+    ids=lambda qkv: "num_heads={0}/{1}/{2}".format(*qkv),
+)
 @pytest.mark.parametrize("dtype", ["float16", "bfloat16"])
 def test_reference_nh1_matches_kernel(
     qkv_factory, seq_lens, head_size, num_heads, dtype, seed=0
@@ -231,9 +239,19 @@ def test_reference_nh1_matches_kernel(
     torch.testing.assert_close(our_state, ref_state, atol=atol_kv, rtol=rtol_kv)
 
 
-@pytest.mark.parametrize("num_householder", [1, 2, 3, 4])
-@pytest.mark.parametrize("seq_lens", [[128], [64, 128, 512]])
-@pytest.mark.parametrize("num_heads", [(8, 8, 8), (8, 8, 16)])
+@pytest.mark.parametrize(
+    "num_householder", [1, 2, 3, 4], ids=lambda nh: f"num_householder={nh}"
+)
+@pytest.mark.parametrize(
+    "seq_lens",
+    [[128], [64, 128, 512]],
+    ids=lambda seqlens: "seq_lens=" + ",".join(map(str, seqlens)),
+)
+@pytest.mark.parametrize(
+    "num_heads",
+    [(8, 8, 8), (8, 8, 16)],
+    ids=lambda qkv: "num_heads={0}/{1}/{2}".format(*qkv),
+)
 def test_reference_equals_expanded_delta_rule(
     qkv_factory, num_householder, seq_lens, num_heads, seed=0
 ):

--- a/tests/gdn/test_prefill_delta_product_cudagraph.py
+++ b/tests/gdn/test_prefill_delta_product_cudagraph.py
@@ -1,0 +1,261 @@
+"""
+Copyright (c) 2025 by FlashInfer team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+CUDA graph capture/replay for chunk_gated_delta_product.
+
+Two failure modes this catches that the eager tests cannot:
+
+  * A host sync inside the wrapper -- ``.item()``, ``.tolist()``, ``int(t)``,
+    or any data-dependent control flow on a device tensor. Capture raises.
+  * Values baked in at capture time. The expansion derives ``cu_seqlens * n_h``,
+    ``g_flat`` and ``q_flat`` from device tensors; if any of that is computed on
+    the host, replay silently reuses the captured numbers. So we replay with
+    DIFFERENT input contents and check the output tracks them.
+
+Note the graph-safe calling convention: pass ``output=``/``output_state=`` so
+results land in caller-owned buffers. Letting the wrapper allocate works under
+capture (the allocation joins the graph pool) but the returned tensor is the
+same storage on every replay, which is a sharper edge than it looks.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from flashinfer.gdn_product import chunk_gated_delta_product
+
+from .reference_delta_product import delta_product
+from .test_prefill_delta_product import _gen_product_inputs, _skip_if_unsupported
+
+
+@pytest.mark.parametrize(
+    "num_householder", [1, 2, 3], ids=lambda nh: f"num_householder={nh}"
+)
+@pytest.mark.parametrize(
+    "num_heads",
+    [(8, 8, 8), (8, 8, 16)],
+    ids=lambda qkv: "num_heads={0}/{1}/{2}".format(*qkv),
+)
+@pytest.mark.parametrize("dtype", ["float16", "bfloat16"])
+def test_cudagraph_capture_and_replay(qkv_factory, num_householder, num_heads, dtype):
+    _skip_if_unsupported()
+
+    num_q_heads, num_k_heads, num_v_heads = num_heads
+    num_o_heads = num_sab_heads = max(num_q_heads, num_v_heads)
+    seq_lens = [64, 128, 256]
+    head_size, n_h = 128, num_householder
+    num_seqs, total_seqlen = len(seq_lens), sum(seq_lens)
+    device = torch.device("cuda")
+    dtype = getattr(torch, dtype)
+
+    def gen(seed):
+        torch.random.manual_seed(seed)
+        torch.cuda.manual_seed(seed)
+        return _gen_product_inputs(
+            seq_lens,
+            n_h,
+            num_q_heads,
+            num_k_heads,
+            num_v_heads,
+            head_size,
+            dtype,
+            qkv_factory,
+            device,
+        )
+
+    # Static buffers -- graphs fix both shapes AND addresses, so every replay
+    # must read from and write to exactly these tensors.
+    q, k, v, alpha, beta, cu_seqlens = gen(0)
+    our_o = torch.empty(
+        (total_seqlen, num_o_heads, head_size), dtype=dtype, device=device
+    )
+    our_state = torch.empty(
+        (num_seqs, num_sab_heads, head_size, head_size),
+        dtype=torch.float32,
+        device=device,
+    )
+
+    def run_op():
+        chunk_gated_delta_product(
+            q,
+            k,
+            v,
+            alpha,
+            beta,
+            1.0,  # scale
+            None,  # initial_state
+            True,  # output_final_state
+            cu_seqlens,
+            True,  # use_qk_l2norm_in_kernel
+            output=our_o,
+            output_state=our_state,
+        )
+
+    # Warm up on a side stream. This is not politeness: flashinfer JIT-compiles
+    # and autotunes on first call for a given shape, and neither may happen
+    # inside a capture.
+    warmup_stream = torch.cuda.Stream()
+    warmup_stream.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(warmup_stream):
+        for _ in range(3):
+            run_op()
+    torch.cuda.current_stream().wait_stream(warmup_stream)
+    torch.cuda.synchronize()
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        run_op()
+    torch.cuda.synchronize()
+
+    if dtype == torch.bfloat16:
+        atol_o, rtol_o, atol_kv, rtol_kv = 1e-2, 1e-2, 5e-3, 1e-3
+    else:
+        atol_o, rtol_o, atol_kv, rtol_kv = 2e-3, 1e-3, 1e-3, 1e-4
+
+    # Replay with fresh contents each round. If anything was computed on the
+    # host at capture time, these will not track.
+    for step in range(2):
+        new_q, new_k, new_v, new_alpha, new_beta, _ = gen(1000 + step)
+        q.copy_(new_q)
+        k.copy_(new_k)
+        v.copy_(new_v)
+        alpha.copy_(new_alpha)
+        beta.copy_(new_beta)
+
+        our_o.fill_(float("nan"))
+        our_state.fill_(float("nan"))
+        graph.replay()
+        torch.cuda.synchronize()
+
+        assert not our_o.isnan().any(), (
+            f"step {step}: output not fully written on replay -- a strided "
+            f"copy-back is likely missing rows"
+        )
+        assert not our_state.isnan().any(), f"step {step}: state not written"
+
+        ref_o, ref_state = delta_product(
+            new_q.float(),
+            new_k.float(),
+            new_v.float(),
+            seq_lens,
+            alpha=new_alpha,
+            beta=new_beta,
+            scale_factor=1.0,
+        )
+        torch.testing.assert_close(
+            our_o,
+            ref_o.to(dtype),
+            atol=atol_o,
+            rtol=rtol_o,
+            msg=lambda m: f"step {step} output mismatch after replay\n{m}",
+        )
+        torch.testing.assert_close(
+            our_state.transpose(-1, -2),
+            ref_state,
+            atol=atol_kv,
+            rtol=rtol_kv,
+            msg=lambda m: f"step {step} state mismatch after replay\n{m}",
+        )
+
+
+@pytest.mark.parametrize(
+    "num_householder", [2, 3], ids=lambda nh: f"num_householder={nh}"
+)
+def test_cudagraph_replay_is_not_frozen(qkv_factory, num_householder):
+    """A graph that ignored its inputs would still pass a single-replay check.
+
+    Replay twice with different data and assert the two outputs DIFFER -- this
+    is the cheap guard against a capture that merely re-emits stale results.
+    """
+    _skip_if_unsupported()
+
+    seq_lens = [128]
+    head_size, n_h = 128, num_householder
+    num_q_heads = num_k_heads = num_v_heads = 8
+    total_seqlen = sum(seq_lens)
+    device = torch.device("cuda")
+    dtype = torch.float16
+
+    def gen(seed):
+        torch.random.manual_seed(seed)
+        torch.cuda.manual_seed(seed)
+        return _gen_product_inputs(
+            seq_lens,
+            n_h,
+            num_q_heads,
+            num_k_heads,
+            num_v_heads,
+            head_size,
+            dtype,
+            qkv_factory,
+            device,
+        )
+
+    q, k, v, alpha, beta, cu_seqlens = gen(0)
+    our_o = torch.empty(
+        (total_seqlen, num_v_heads, head_size), dtype=dtype, device=device
+    )
+    our_state = torch.empty(
+        (len(seq_lens), num_v_heads, head_size, head_size),
+        dtype=torch.float32,
+        device=device,
+    )
+
+    def run_op():
+        chunk_gated_delta_product(
+            q,
+            k,
+            v,
+            alpha,
+            beta,
+            1.0,
+            None,
+            True,
+            cu_seqlens,
+            True,
+            output=our_o,
+            output_state=our_state,
+        )
+
+    warmup_stream = torch.cuda.Stream()
+    warmup_stream.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(warmup_stream):
+        for _ in range(3):
+            run_op()
+    torch.cuda.current_stream().wait_stream(warmup_stream)
+    torch.cuda.synchronize()
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        run_op()
+    torch.cuda.synchronize()
+
+    outs = []
+    for seed in (1000, 2000):
+        new_q, new_k, new_v, new_alpha, new_beta, _ = gen(seed)
+        q.copy_(new_q)
+        k.copy_(new_k)
+        v.copy_(new_v)
+        alpha.copy_(new_alpha)
+        beta.copy_(new_beta)
+        graph.replay()
+        torch.cuda.synchronize()
+        outs.append(our_o.clone())
+
+    assert not torch.allclose(outs[0], outs[1]), (
+        "replay produced identical output for different inputs -- the graph is "
+        "not reading its input buffers"
+    )

--- a/tests/gdn/test_prefill_delta_product_cudagraph.py
+++ b/tests/gdn/test_prefill_delta_product_cudagraph.py
@@ -14,20 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 CUDA graph capture/replay for chunk_gated_delta_product.
-
-Two failure modes this catches that the eager tests cannot:
-
-  * A host sync inside the wrapper -- ``.item()``, ``.tolist()``, ``int(t)``,
-    or any data-dependent control flow on a device tensor. Capture raises.
-  * Values baked in at capture time. The expansion derives ``cu_seqlens * n_h``,
-    ``g_flat`` and ``q_flat`` from device tensors; if any of that is computed on
-    the host, replay silently reuses the captured numbers. So we replay with
-    DIFFERENT input contents and check the output tracks them.
-
-Note the graph-safe calling convention: pass ``output=``/``output_state=`` so
-results land in caller-owned buffers. Letting the wrapper allocate works under
-capture (the allocation joins the graph pool) but the returned tensor is the
-same storage on every replay, which is a sharper edge than it looks.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

Builds upon PR #4438 and adds support for GDP decode, again without modifying or adding kernels. We use the GDN MTP decode kernel since it can handle multiple tokens per-sequence, unlike the non-MTP kernel.

Things to keep in mind:
1. Unlike the prefill kernel, which takes `g` directly, the decode kernel takes `a` and computes `g`, so to prevent gating the multiple householders we need to give a small enough `a` that will make `g` evaluate to zero, but avoid `-inf` since that will generate `nan` under `fastmath=True`.
2. The fake tokens require `ssm_state_indices` to write to, so an extra state allocation for a scratch space for these writes is required. However, since we never read these, we can allocate a single state scratch space and reuse it for all the fake householder tokens.
3. Like the prefill case, the expanded buffers require preallocating for cuda graphs.

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [V] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [V] I have installed the hooks with `pre-commit install`.
- [V] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [V] Tests have been added or updated as needed.
- [V] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->
