### PR TITLE
ci: apply --prerelease to rc in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -286,12 +286,12 @@ jobs:
           # Read release notes from file
           NOTES=$(cat ${{ steps.release-notes.outputs.notes_file }})
 
-          # Mark pre-release tags (rc/alpha/beta/dev) as such. GitHub only
-          # infers this in the web UI, never via the API, so an rc created here
-          # would otherwise be published as a full release and could take over
-          # the "Latest" badge. .postN is a real release and stays unflagged.
+          # gh/the API never infer pre-release status from the tag name (that is
+          # web-UI only), so flag PEP 440 pre-release suffixes explicitly --
+          # otherwise an rc publishes as a full release and can take over
+          # "Latest". .postN is a real release and stays unflagged.
           PRERELEASE_FLAG=""
-          if [[ "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+\.?(rc|alpha|beta|dev|a|b)[0-9]*$ ]]; then
+          if [[ "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+\.?(a|b|rc|dev)[0-9]*$ ]]; then
             PRERELEASE_FLAG="--prerelease"
             echo "Detected pre-release tag: $TAG"
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -286,10 +286,10 @@ jobs:
           # Read release notes from file
           NOTES=$(cat ${{ steps.release-notes.outputs.notes_file }})
 
-          # gh/the API never infer pre-release status from the tag name (that is
-          # web-UI only), so flag PEP 440 pre-release suffixes explicitly --
-          # otherwise an rc publishes as a full release and can take over
-          # "Latest". .postN is a real release and stays unflagged.
+          # The GitHub API never infers pre-release status from the tag name
+          # (that is web-UI only), so flag PEP 440 pre-release suffixes
+          # explicitly -- otherwise an rc publishes as a full release and can
+          # take over "Latest". .postN is a real release and stays unflagged.
           PRERELEASE_FLAG=""
           if [[ "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+\.?(a|b|rc|dev)[0-9]*$ ]]; then
             PRERELEASE_FLAG="--prerelease"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -286,10 +286,21 @@ jobs:
           # Read release notes from file
           NOTES=$(cat ${{ steps.release-notes.outputs.notes_file }})
 
+          # Mark pre-release tags (rc/alpha/beta/dev) as such. GitHub only
+          # infers this in the web UI, never via the API, so an rc created here
+          # would otherwise be published as a full release and could take over
+          # the "Latest" badge. .postN is a real release and stays unflagged.
+          PRERELEASE_FLAG=""
+          if [[ "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+\.?(rc|alpha|beta|dev|a|b)[0-9]*$ ]]; then
+            PRERELEASE_FLAG="--prerelease"
+            echo "Detected pre-release tag: $TAG"
+          fi
+
           # Create new release without assets first
           gh release create "$TAG" \
             --title "Release v${{ needs.setup.outputs.version }}" \
-            --notes "$NOTES"
+            --notes "$NOTES" \
+            $PRERELEASE_FLAG
 
       - name: Download flashinfer-python artifact
         uses: actions/download-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -409,10 +409,10 @@ jobs:
           # Read release notes from file
           NOTES=$(cat "${NOTES_FILE}")
 
-          # gh/the API never infer pre-release status from the tag name (that is
-          # web-UI only), so flag PEP 440 pre-release suffixes explicitly --
-          # otherwise an rc publishes as a full release and can take over
-          # "Latest". .postN is a real release and stays unflagged.
+          # The GitHub API never infers pre-release status from the tag name
+          # (that is web-UI only), so flag PEP 440 pre-release suffixes
+          # explicitly -- otherwise an rc publishes as a full release and can
+          # take over "Latest". .postN is a real release and stays unflagged.
           PRERELEASE_FLAG=""
           if [[ "${RELEASE_TAG}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+\.?(a|b|rc|dev)[0-9]*$ ]]; then
             PRERELEASE_FLAG="--prerelease"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -409,12 +409,12 @@ jobs:
           # Read release notes from file
           NOTES=$(cat "${NOTES_FILE}")
 
-          # Mark pre-release tags (rc/alpha/beta/dev) as such. GitHub only
-          # infers this in the web UI, never via the API, so an rc created here
-          # would otherwise be published as a full release and could take over
-          # the "Latest" badge. .postN is a real release and stays unflagged.
+          # gh/the API never infer pre-release status from the tag name (that is
+          # web-UI only), so flag PEP 440 pre-release suffixes explicitly --
+          # otherwise an rc publishes as a full release and can take over
+          # "Latest". .postN is a real release and stays unflagged.
           PRERELEASE_FLAG=""
-          if [[ "${RELEASE_TAG}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+\.?(rc|alpha|beta|dev|a|b)[0-9]*$ ]]; then
+          if [[ "${RELEASE_TAG}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+\.?(a|b|rc|dev)[0-9]*$ ]]; then
             PRERELEASE_FLAG="--prerelease"
             echo "Detected pre-release tag: ${RELEASE_TAG}"
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -409,10 +409,21 @@ jobs:
           # Read release notes from file
           NOTES=$(cat "${NOTES_FILE}")
 
+          # Mark pre-release tags (rc/alpha/beta/dev) as such. GitHub only
+          # infers this in the web UI, never via the API, so an rc created here
+          # would otherwise be published as a full release and could take over
+          # the "Latest" badge. .postN is a real release and stays unflagged.
+          PRERELEASE_FLAG=""
+          if [[ "${RELEASE_TAG}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+\.?(rc|alpha|beta|dev|a|b)[0-9]*$ ]]; then
+            PRERELEASE_FLAG="--prerelease"
+            echo "Detected pre-release tag: ${RELEASE_TAG}"
+          fi
+
           # Create new release without assets first
           gh release create "${RELEASE_TAG}" \
             --title "Release v${RELEASE_VERSION}" \
-            --notes "$NOTES"
+            --notes "$NOTES" \
+            $PRERELEASE_FLAG
 
       - name: Download flashinfer-python artifact
         uses: actions/download-artifact@v4


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

`release.yml` creates every release with a bare `gh release create` and no `--prerelease`:

```bash
gh release create "$TAG" \
  --title "Release v${{ needs.setup.outputs.version }}" \
  --notes "$NOTES"
```

The GitHub REST API defaults `prerelease: false`, and neither the API nor `gh` infers pre-release status from the tag name — the "this looks like a pre-release" auto-detection is a **web-UI affordance only**. So every `vX.Y.ZrcN` tag was published as a full release.

This matters because a non-prerelease release is eligible for the **Latest** badge (most recent non-draft/non-prerelease). `v0.6.17rc5` held Latest for ~28 minutes on 2026-08-07 until `v0.6.16.post3` was published. Anything resolving "latest release" via the API or download URLs could land on an rc.

PyPI is unaffected — PEP 440 treats `rcN` as a pre-release on its own, so `pip install flashinfer-python` already skips them without `--pre`.

This PR detects pre-release tags from the tag name and passes `--prerelease`, matching what `nightly-release.yml:230` already does (which is why every `nightly-*` tag is correctly flagged today). `.postN` is a real release and stays unflagged.

### Backfill already applied

The 16 affected releases were corrected out-of-band with `gh release edit --prerelease`. Recording them here for the audit trail:

| release | was | now |
|---|---|---|
| `v0.6.17rc5` | full release | pre-release |
| `v0.6.17rc1` | full release | pre-release |
| `v0.6.16rc5` | full release | pre-release |
| `v0.6.16rc4` | full release | pre-release |
| `v0.6.16rc3` | pre-release (fixed by hand earlier) | pre-release |
| `v0.6.13rc2` | full release | pre-release |
| `v0.6.13rc1` | full release | pre-release |
| `v0.6.12rc3` | full release | pre-release |
| `v0.6.12rc2` | full release | pre-release |
| `v0.6.12rc1` | full release | pre-release |
| `v0.6.11rc1` | full release | pre-release |
| `v0.6.10rc1` | full release | pre-release |
| `v0.6.9rc1` | full release | pre-release |
| `v0.6.8rc1` | full release | pre-release |
| `v0.6.0rc2` | full release | pre-release |
| `v0.6.0rc1` | full release | pre-release |

15 of 16 were mislabeled; `v0.6.16rc3` had already been corrected manually, which is consistent with this having been noticed before but never fixed at the source. No release notes, assets, or tags were touched — only the `prerelease` flag. **Latest** still resolves to `v0.6.17`.

## 🔍 Related Issues

None.

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

This is a CI workflow change with no Python surface, so there is nothing for `unittest` to cover. Verification done instead:

- Workflow YAML parses; all 7 jobs intact.
- Tag detection verified against real and edge-case tags:

  | tag | result |
  |---|---|
  | `v0.6.17rc5`, `v0.6.0rc1`, `v0.6.13rc2` | pre-release |
  | `v1.2.3a1`, `v1.2.3b2`, `v1.2.3.dev1`, `v1.2.3dev1`, `v1.2.3.rc1` | pre-release |
  | `v0.6.17`, `v0.6.16.post4`, `v0.6.16.post1` | full release |

- `pre-commit run --all-files` passes.
- The `on.pull_request` path trigger on `release.yml` means this PR runs the release workflow in dry-run mode; that is still in flight.

The remaining box is left unchecked because the repo test suite was not run locally — the change cannot affect it.

## Reviewer Notes

**Why `a|b|rc|dev` and not `alpha|beta`.** These are the canonical PEP 440 pre-release spellings; `alpha`/`beta` are non-canonical aliases that normalize away:

```
1.2.3alpha1 -> 1.2.3a1     1.2.3a1 -> 1.2.3a1     1.2.3rc1   -> 1.2.3rc1
1.2.3beta1  -> 1.2.3b1     1.2.3b1 -> 1.2.3b1     1.2.3.dev1 -> 1.2.3.dev1
```

So `a`/`b` are the forms that actually reach `version.txt` and wheel filenames. A hypothetical `v1.2.3alpha1` tag would not be flagged — but it is already broken independently, since the built wheel would be `1.2.3a1` and disagree with the tag. Every tag this repo has ever cut is `rc` (23) or `post` (21), so this is theoretical either way.

A stricter `packaging.version.Version(...).is_prerelease` parse would be more faithful, but there is no Python available in this step — hence the bash pattern.

Also note this PR triggers the full `build-flashinfer-jit-cache` matrix (3 CUDA × 2 arch, self-hosted, 6h timeout) via the existing path filter. Happy to cancel if that runner time is unwelcome for a workflow-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Release Management**
  * Release creation now automatically identifies tags that follow pre-release versioning conventions.
  * Pre-release versions are labeled as pre-releases, while post-release versions continue to be published as standard releases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->