### PR TITLE
fix(comm): align MNNVL two-shot workspace stages

### DIFF
--- a/flashinfer/comm/trtllm_mnnvl_ar.py
+++ b/flashinfer/comm/trtllm_mnnvl_ar.py
@@ -17,7 +17,7 @@ from flashinfer.comm.mapping import Mapping
 from flashinfer.api_logging import flashinfer_api
 
 from ..jit import gen_trtllm_mnnvl_comm_module
-from ..utils import register_custom_op
+from ..utils import register_custom_op, round_up
 from ..fp4_quantization import _compute_swizzled_layout_sf_size
 from .mnnvl import CommBackend, McastGPUBuffer, MPIBackend, SymmDeviceMemory
 from .trtllm_ar import QuantizationSFLayout
@@ -125,6 +125,10 @@ class MNNVLAllReduceFusionWorkspace(AllReduceFusionWorkspace):
                 f"[MNNVL Allreduce] Using provided buffer size override in bytes: {buffer_size_in_bytes} bytes."
             )
 
+        # Two-shot splits each Lamport buffer into two 16B-aligned stages.
+        buffer_alignment = 2 * 16
+        buffer_size_in_bytes = round_up(buffer_size_in_bytes, buffer_alignment)
+
         if comm_backend is None:
             comm_backend = MPIBackend()
         if buffer_size_in_bytes > (2**32 - 1):
@@ -156,9 +160,11 @@ class MNNVLAllReduceFusionWorkspace(AllReduceFusionWorkspace):
         self.ptrs = self.handle.mcast_device_memory.get_buffer_ptrs_host()
 
         allocated_size = self.handle.buf_size
-        # We want the buffer size to be aligned to 16B which is the granularity for buffer management.
         self.buffer_size_bytes = (
-            math.floor(allocated_size / self.NUM_LAMPORT_BUFFERS) // 16 * 16
+            allocated_size
+            // self.NUM_LAMPORT_BUFFERS
+            // buffer_alignment
+            * buffer_alignment
         )
         # This workspace size is used for checking the buffer. We need to set it to the actual size in use. The buffer free logic does not rely on this size.
         self.workspace_size_bytes = self.buffer_size_bytes * self.NUM_LAMPORT_BUFFERS

--- a/flashinfer/comm/trtllm_mnnvl_ar.py
+++ b/flashinfer/comm/trtllm_mnnvl_ar.py
@@ -60,6 +60,8 @@ class MNNVLQuantType:
 
 class MNNVLAllReduceFusionWorkspace(AllReduceFusionWorkspace):
     NUM_LAMPORT_BUFFERS = 3
+    TWOSHOT_NUM_STAGES = 2
+    PACKED_ALIGNMENT_BYTES = 16
 
     def __init__(
         self,
@@ -125,8 +127,7 @@ class MNNVLAllReduceFusionWorkspace(AllReduceFusionWorkspace):
                 f"[MNNVL Allreduce] Using provided buffer size override in bytes: {buffer_size_in_bytes} bytes."
             )
 
-        # Two-shot splits each Lamport buffer into two 16B-aligned stages.
-        buffer_alignment = 2 * 16
+        buffer_alignment = self.TWOSHOT_NUM_STAGES * self.PACKED_ALIGNMENT_BYTES
         buffer_size_in_bytes = round_up(buffer_size_in_bytes, buffer_alignment)
 
         if comm_backend is None:

--- a/tests/comm/test_trtllm_mnnvl_allreduce.py
+++ b/tests/comm/test_trtllm_mnnvl_allreduce.py
@@ -391,6 +391,7 @@ def run_mnnvl_ar_full(
     legacy_explicit_workspace_bytes: Optional[int] = None,
     legacy_api: bool = False,
     inject_sentinel_patterns: bool = False,
+    workspace_max_num_tokens: Optional[int] = None,
 ):
     """Core test logic for MNNVL AllReduce operations.
 
@@ -401,6 +402,7 @@ def run_mnnvl_ar_full(
         dtype: Data type for tensors
         hidden_size: Hidden dimension size
         explicit_workspace_bytes: If provided, use this workspace size instead of default
+        workspace_max_num_tokens: Workspace capacity override
     """
 
     gpus_per_node = torch.cuda.device_count()
@@ -463,7 +465,7 @@ def run_mnnvl_ar_full(
         else:
             workspace = trtllm_mnnvl_ar.MNNVLAllReduceFusionWorkspace(
                 mapping,
-                max_num_tokens=max(seq_lens),
+                max_num_tokens=workspace_max_num_tokens or max(seq_lens),
                 hidden_dim=hidden_size,
                 dtype=dtype,
                 comm_backend=comm_backend,
@@ -988,6 +990,18 @@ def test_mnnvl_allreduce_refactored(
     """Test MNNVL AllReduce with refactored API."""
     run_mnnvl_ar_full(
         monkeypatch, seq_lens, fusion, dtype, hidden_size, legacy_api=False
+    )
+
+
+def test_mnnvl_twoshot_large_workspace_alignment(monkeypatch):
+    """Two-shot stages remain aligned with a large workspace."""
+    run_mnnvl_ar_full(
+        monkeypatch,
+        [64],
+        False,
+        torch.bfloat16,
+        7168,
+        workspace_max_num_tokens=16384,
     )
 
 


### PR DESCRIPTION
## Summary

- align each MNNVL Lamport buffer to 32 bytes so both 16-byte two-shot stages remain aligned
- round requested and allocated workspace sizes to the same invariant
- add a large-workspace regression test matching the failing Kimi K3 configuration

## Root cause

The workspace previously aligned each Lamport buffer to 16 bytes. Two-shot all-reduce then divides that buffer into two stages and accesses each stage with 16-byte vector operations. A buffer whose size is 16 modulo 32 therefore places the second stage at an 8-byte-aligned address, causing `CUDA error: misaligned address`.

For the reproduced `max_num_tokens=16384`, BF16, hidden-size 7168 case, the old per-buffer size was 536,870,224 bytes (`size % 32 == 16`). The fixed size is 536,870,208 bytes (`size % 32 == 0`).

## Duplicate check

I searched open FlashInfer PRs for MNNVL stage/workspace alignment, Lamport two-shot alignment, and MNNVL misaligned-address fixes. No open PR fixes this issue. The closest historical changes (#2074, #2118, and #2955) add large-workspace support or change allocation, but retain the 16-byte per-buffer alignment that causes this failure.

## Validation

- `pre-commit run --files flashinfer/comm/trtllm_mnnvl_ar.py tests/comm/test_trtllm_mnnvl_allreduce.py`
- TP2 GB200 regression: `1 passed, 275 deselected`
- standalone TP4 GB200 large-workspace two-shot all-reduce
- four-node Kimi K3 startup with TP4 / DP4 / EP16 and FlashInfer all-reduce: all 51 piecewise and 35 full CUDA graphs captured; no misaligned-address error

OpenAI Codex was used to assist with diagnosis and implementation. The submitter reviewed the complete diff and validation results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workspace allocation alignment for more reliable communication operations.
  * Fixed capacity calculations when using larger workspaces, including workspaces exceeding the tested sequence length.
  * Improved support for two-stage operations with large workspace configurations.
  * Increased reliability for operations using varied workspace sizes and aligned memory buffers.

* **Tests**
  * Added regression coverage for large-workspace alignment and two-stage operation scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->