### PR TITLE
feat(fmha-context): Qk0_Pv0_Qk1_Pv1 paired MMA order support

### DIFF
--- a/flashinfer/attention/prims_ts/context.py
+++ b/flashinfer/attention/prims_ts/context.py
@@ -1032,6 +1032,10 @@ def _get_compiled_context(
         h_r=num_qo_heads // num_kv_heads,
         enable_skip_correction=True,
         causal_single_kv_tile=causal_single_kv_tile,
+        has_q_offset=has_q_offset,
+        has_uniform_varlen=uniform_packed_lengths,
+        uniform_seq_len_q=max_seq_len_q if uniform_packed_lengths else 0,
+        uniform_seq_len_k=max_seq_len_k if uniform_packed_lengths else 0,
     )
     with torch.cuda.device(device_index):
         max_active_clusters = int(utils.HardwareInfo().get_max_active_clusters(1))
@@ -1073,6 +1077,10 @@ def _get_compiled_context(
             h_r=num_qo_heads // num_kv_heads,
             enable_skip_correction=True,
             causal_single_kv_tile=causal_single_kv_tile,
+            has_q_offset=has_q_offset,
+            has_uniform_varlen=uniform_packed_lengths,
+            uniform_seq_len_q=max_seq_len_q if uniform_packed_lengths else 0,
+            uniform_seq_len_k=max_seq_len_k if uniform_packed_lengths else 0,
         )
     elif not is_persistent:
         fmha = FmhaTs(
@@ -1089,13 +1097,13 @@ def _get_compiled_context(
             h_r=num_qo_heads // num_kv_heads,
             enable_skip_correction=True,
             causal_single_kv_tile=causal_single_kv_tile,
+            has_q_offset=has_q_offset,
+            has_uniform_varlen=uniform_packed_lengths,
+            uniform_seq_len_q=max_seq_len_q if uniform_packed_lengths else 0,
+            uniform_seq_len_k=max_seq_len_k if uniform_packed_lengths else 0,
         )
     fmha.cfg.has_varlen = packed
-    fmha.cfg.has_uniform_varlen = uniform_packed_lengths
-    if uniform_packed_lengths:
-        fmha.cfg.uniform_seq_len_q = max_seq_len_q
-        fmha.cfg.uniform_seq_len_k = max_seq_len_k
-    fmha.cfg.has_q_offset = has_q_offset
+    # Passed into FmhaTs(...) above (before schedule selection); do not re-assign.
     if fmha.cfg.kv_tile_n != _CONTEXT_KV_TILE_N:
         raise RuntimeError(
             "context packed-K specialization assumes kv_tile_n="
@@ -1289,6 +1297,10 @@ def _get_compiled_paged_context(
         # The fixed one-tile shortcut assumes contiguous fixed-shape K/V and
         # is intentionally disabled for the page-table path.
         causal_single_kv_tile=False,
+        has_q_offset=has_q_offset,
+        has_uniform_varlen=uniform_packed_lengths,
+        uniform_seq_len_q=max_seq_len_q if uniform_packed_lengths else 0,
+        uniform_seq_len_k=max_seq_len_k if uniform_packed_lengths else 0,
     )
     num_seq_tiles = (max_seq_len_q + fmha.cfg.cta_tiler[0] - 1) // fmha.cfg.cta_tiler[0]
     num_head_tiles = num_qo_heads // fmha.cfg.work_tile_q_heads
@@ -1329,6 +1341,10 @@ def _get_compiled_paged_context(
             num_tokens_per_page=page_size,
             max_num_pages_per_seq_kv=max_num_pages_per_seq_kv,
             causal_single_kv_tile=False,
+            has_q_offset=has_q_offset,
+            has_uniform_varlen=uniform_packed_lengths,
+            uniform_seq_len_q=max_seq_len_q if uniform_packed_lengths else 0,
+            uniform_seq_len_k=max_seq_len_k if uniform_packed_lengths else 0,
         )
     elif not paged_is_persistent:
         fmha = FmhaTs(
@@ -1348,13 +1364,13 @@ def _get_compiled_paged_context(
             num_tokens_per_page=page_size,
             max_num_pages_per_seq_kv=max_num_pages_per_seq_kv,
             causal_single_kv_tile=False,
+            has_q_offset=has_q_offset,
+            has_uniform_varlen=uniform_packed_lengths,
+            uniform_seq_len_q=max_seq_len_q if uniform_packed_lengths else 0,
+            uniform_seq_len_k=max_seq_len_k if uniform_packed_lengths else 0,
         )
     fmha.cfg.has_varlen = True
-    fmha.cfg.has_uniform_varlen = uniform_packed_lengths
-    if uniform_packed_lengths:
-        fmha.cfg.uniform_seq_len_q = max_seq_len_q
-        fmha.cfg.uniform_seq_len_k = max_seq_len_k
-    fmha.cfg.has_q_offset = has_q_offset
+    # Passed into FmhaTs(...) above (before schedule selection); do not re-assign.
     if fmha.cfg.kv_tile_n != _CONTEXT_KV_TILE_N:
         raise RuntimeError(
             "context packed-K specialization assumes kv_tile_n="

--- a/flashinfer/attention/prims_ts/kernels/fmha_context/README.md
+++ b/flashinfer/attention/prims_ts/kernels/fmha_context/README.md
@@ -164,6 +164,10 @@ natural 32-lane window or the ordinary per-tile path. This is an internal
 consequence of the task topology, static geometry, and resource capacity; it
 is not a user-selectable tuning parameter.
 
+On Blackwell Ultra (SM103a) with `head_dim_v >= 128`, the paired
+(two-instance) MMA task uses the `Qk0_Pv0_Qk1_Pv1` interleaved schedule:
+each iter runs `Qk0 -> Pv0 -> Qk1 -> Pv1` and both PVs share the same V.
+
 | Source | Responsibility |
 | --- | --- |
 | [`../../context.py`](../../context.py) | Public validation, metadata translation, automatic scheduling, JIT caching, and launch adaptation |

--- a/flashinfer/attention/prims_ts/kernels/fmha_context/fmha_kernel.py
+++ b/flashinfer/attention/prims_ts/kernels/fmha_context/fmha_kernel.py
@@ -1009,18 +1009,18 @@ def build_context_task_manager(
         name="tmem_sp0",
     )
     tmem_p0: TmemPResource | None = None
-    # OrderP01 mbarriers guard the interleaved paired cross-alias TMEM layout.
+    # OrderedSequence mbarriers guard the interleaved paired cross-alias TMEM layout.
     # Two 8-byte mbarriers packed into one 16-byte SMEM allocation, shared
     # across softmax0/softmax1.  softmax0 owns the allocation; softmax1 refers
-    # to it via ``order_p01_alloc`` without contributing to placement.
-    order_p01_alloc: SmemAllocation | None = None
+    # to it via ``ordered_sequence_alloc`` without contributing to placement.
+    ordered_sequence_alloc: SmemAllocation | None = None
     if (
         cfg.has_tmem_p_pipeline
         and not cfg.single_qkv_instance
         and cfg.mma_order == MmaOrder.Qk0Pv0Qk1Pv1
     ):
-        order_p01_alloc = SmemAllocation(
-            name="tmem_order_p01",
+        ordered_sequence_alloc = SmemAllocation(
+            name="tmem_ordered_sequence",
             size_bytes=16,
             alignment=8,
         )
@@ -1030,8 +1030,8 @@ def build_context_task_manager(
             cfg=cfg,
             tmem_p_offset=cfg.tmem_p0_offset,
             inst_id=0,
-            order_p01_alloc=order_p01_alloc,
-            owns_order_p01_alloc=order_p01_alloc is not None,
+            ordered_sequence_alloc=ordered_sequence_alloc,
+            owns_ordered_sequence_alloc=ordered_sequence_alloc is not None,
             name="tmem_p0",
         )
     tmem_vec0 = TmemStatsResource(
@@ -1086,19 +1086,15 @@ def build_context_task_manager(
             name="tmem_sp1",
         )
         if cfg.has_tmem_p_pipeline:
-            # Interleaved paired cross-alias layout: softmax1 writes P1 into the
-            # physical TMEM columns vacated by softmax0's S0 read (and PV0
-            # reads P0 from the columns vacated by softmax1's S1 read).
-            # Each instance therefore needs its own producer/consumer barrier
-            # so PVi can gate on softmaxi's P store and softmaxi can gate on
-            # the prior PVi consuming it before overwriting.
+            # Cross-alias: P1 lives in Softmax0's S columns (and P0 in Softmax1's).
+            # Dedicated tp barriers let PVi wait on Softmaxi P, independent of spi.
             tmem_p1 = TmemPResource(
                 pipeline_config=tmem_p1_pipeline_cfg,
                 cfg=cfg,
                 tmem_p_offset=cfg.tmem_p1_offset,
                 inst_id=1,
-                order_p01_alloc=order_p01_alloc,
-                owns_order_p01_alloc=False,
+                ordered_sequence_alloc=ordered_sequence_alloc,
+                owns_ordered_sequence_alloc=False,
                 name="tmem_p1",
             )
         tmem_vec1 = TmemStatsResource(
@@ -1134,14 +1130,8 @@ def build_context_task_manager(
             name="tmem_stats_done_1",
         )
 
-    # Wire each softmax's TmemSPResource to its paired TmemPResource so the
-    # OrderP01 mbarrier helpers can reach the peer's barrier via
-    # ``self._tp_ref`` (see
-    # :meth:`TmemSPResource.order_p01_arrive_if_paired`, called from the
-    # paired softmax task body in fmha_tasks.py). Done here, after both
-    # resources are constructed, to avoid reordering the resource builds.
-    # When ``order_p01_alloc is None`` the underlying mbarriers are absent
-    # and the helpers fold to no-ops at trace time.
+    # Link spi → tpi after both exist; OrderedSequence helpers use _tp_ref
+    # (no-op when ordered_sequence_alloc is None).
     if tmem_p0 is not None:
         tmem_sp0._tp_ref = tmem_p0
     if tmem_sp1 is not None and tmem_p1 is not None:
@@ -1568,13 +1558,7 @@ def _should_use_tmem_p_pipeline(cfg: FmhaConfig) -> bool:
 
 @functools.cache
 def _current_sm_major_minor() -> tuple[int, int] | None:
-    """Return the current CUDA device compute capability, or None on failure.
-
-    Runs during host-side kernel construction so it is safe to import torch and
-    query the device. Returns None if torch or the CUDA driver is unavailable
-    (e.g., during unit tests that construct FmhaConfig without a live device);
-    callers must treat None as "arch heuristic does not apply".
-    """
+    """Return (major, minor) for the current CUDA device, or None if unavailable."""
     try:
         import torch
 
@@ -1586,41 +1570,15 @@ def _current_sm_major_minor() -> tuple[int, int] | None:
 
 
 def _should_use_qk_pv_interleaved_paired_schedule(cfg: FmhaConfig) -> bool:
-    """Return whether the paired MMA task should use ``Qk0_Pv0_Qk1_Pv1``.
+    """True when the paired MMA task should use ``Qk0_Pv0_Qk1_Pv1``.
 
-    Only the paired (``num_qkv_instances == 2``) topology is a candidate.
-    Selection is arch-driven: Blackwell Ultra (SM103a) context kernels with
-    ``head_dim_v >= 128`` opt in to the interleaved schedule.
-
-    Query-paired causal peer0-skip and head-paired mode are intentionally
-    excluded here: their peer0/peer1 tile counts diverge, and the new
-    schedule locks a single V per iter for both instances. Supporting them
-    is a follow-up that has to widen ``pv_mma``'s skip-invalid handling.
-
-    Plain causal (``cfg.is_causal``) is also excluded for now: the causal
-    TAIL under the cross-alias TMEM layout requires an MMA-side QK refresh
-    of S0/S1 with K_{N-1} before softmax's TAIL row_max reads them, plus
-    an OrderP01-elided softmax TAIL branch. Until those land, route causal
-    back to the legacy ``Pv0_Qk0_Pv1_Qk1`` schedule to avoid NaNs from the
-    peer's LOOP-N-2 STTM(P_peer) writes still living in the aliased
-    columns when the causal TAIL re-reads S.
-
-    Paged KV (``cfg.use_paged_kv``) is also excluded for now: every observed
-    non-causal D128 paged case regresses on the interleaved schedule (all
-    three ``paged_dense_k_mask_accuracy[*-d128]`` shapes plus both
-    ``d128_paged_s16k_runtime`` dtypes produce NaNs or L2 ~1.0). Contiguous
-    and packed varlen dense cases stay correct, so the regression appears
-    tied to the paged K/V TMA path interacting with the cross-alias TMEM
-    layout rather than to the varlen dense-K mask itself. Route paged back
-    to the legacy schedule until the paged interaction is root-caused.
+    Opt-in for SM103a context with ``head_dim_v >= 128``. Excludes
+    head-paired and causal peer0-skip (divergent peer tile counts).
+    Plain causal uses the same order with peer0 empty ``sp0`` + Softmax0 drain.
     """
     if cfg.single_qkv_instance:
         return False
     if cfg.head_paired or cfg.skip_causal_invalid_peer0:
-        return False
-    if cfg.is_causal:
-        return False
-    if cfg.use_paged_kv:
         return False
     head_dim_v = cfg.pv_mma_tiler[1]
     if head_dim_v < 128:
@@ -1758,24 +1716,12 @@ def _configure_pipeline_stages(cfg: FmhaConfig, *, is_clc_dynamic: bool) -> None
         if _should_use_qk_pv_interleaved_paired_schedule(cfg)
         else MmaOrder.Pv0Qk0Pv1Qk1
     )
-    # TMEM P offsets: the FmhaConfig class defaults (P0=160 inside S1, P1=32
-    # inside S0) implement the cross-alias layout required by the interleaved
-    # Qk0Pv0Qk1Pv1 schedule (OrderP01 mbarriers serialize the cross-alias
-    # writes). The legacy Pv0Qk0Pv1Qk1 schedule has no such barrier and its
-    # per-iter QK0→S0 write would clobber the peer's P1 slot before PV1 reads
-    # it (and symmetrically QK1→S1 clobbers P0 before PV0 reads it) under the
-    # cross-alias layout. Restore the same-instance aliasing for the legacy
-    # schedule so each peer's P lives inside its own S range, out of the
-    # OTHER peer's QK write path.
-    if cfg.mma_order == MmaOrder.Pv0Qk0Pv1Qk1 and not cfg.single_qkv_instance:
-        cfg.tmem_p0_offset = cfg.tmem_s0_offset + cfg.tmem_x_load_s
-        cfg.tmem_p1_offset = cfg.tmem_s1_offset + cfg.tmem_x_load_s
-    # Stage-scoped stats and the 2-stage SP/corr pipelines belong to the
-    # single-instance staged topology, where next-tile QK overlaps prior-tile
-    # PV inside one MMA instance. The interleaved paired schedule keeps
-    # mma_softmax_stage=1 per instance (one live S/P per peer) even though it
-    # also opts into has_tmem_p_pipeline, so it does not need the split-stage
-    # stats layout.
+    # Qk0Pv0Qk1Pv1 paired: cross-alias P offsets (P0@S1, P1@S0). Else keep defaults.
+    if cfg.mma_order == MmaOrder.Qk0Pv0Qk1Pv1 and not cfg.single_qkv_instance:
+        cfg.tmem_p0_offset = cfg.tmem_s1_offset + cfg.tmem_x_load_s
+        cfg.tmem_p1_offset = cfg.tmem_s0_offset + cfg.tmem_x_load_s
+    # Split-stage SP/stats: single-instance staged KV only. Interleaved paired
+    # keeps mma_softmax_stage=1 even with has_tmem_p_pipeline.
     uses_split_sp_staging = cfg.single_qkv_instance and cfg.stage_kv_by_head_dim
     cfg.stage_scoped_tmem_stats = uses_split_sp_staging
     cfg.mma_softmax_stage = 2 if uses_split_sp_staging else 1

--- a/flashinfer/attention/prims_ts/kernels/fmha_context/fmha_kernel.py
+++ b/flashinfer/attention/prims_ts/kernels/fmha_context/fmha_kernel.py
@@ -132,6 +132,7 @@ Entry points:
   - FmhaTs                   -- class with @cute.jit __call__ and kernel
 """
 
+import functools
 import warnings
 from dataclasses import dataclass
 from collections.abc import Callable
@@ -165,6 +166,7 @@ from .fmha_resources import (
     FmhaConfig,
     GmemOResource,
     GmemQKVResource,
+    MmaOrder,
     S0S1SequenceResource,
     SmemKVResource,
     SmemOResource,
@@ -801,6 +803,12 @@ def build_context_task_manager(
         consumer_group=umma_hw_group,
         cta_layout_vmnk=cluster_shape_vmnk,
     )
+    tmem_p1_pipeline_cfg = PipelineConfig.create_async_umma_pipeline_cfg(
+        num_stages=cfg.mma_softmax_stage,
+        producer_group=softmax_group,
+        consumer_group=umma_hw_group,
+        cta_layout_vmnk=cluster_shape_vmnk,
+    )
     tmem_o_pipeline_cfg = PipelineConfig.create_umma_async_pipeline_cfg(
         num_stages=cfg.mma_corr_stage,
         producer_group=umma_hw_group,
@@ -1001,11 +1009,29 @@ def build_context_task_manager(
         name="tmem_sp0",
     )
     tmem_p0: TmemPResource | None = None
+    # OrderP01 mbarriers guard the interleaved paired cross-alias TMEM layout.
+    # Two 8-byte mbarriers packed into one 16-byte SMEM allocation, shared
+    # across softmax0/softmax1.  softmax0 owns the allocation; softmax1 refers
+    # to it via ``order_p01_alloc`` without contributing to placement.
+    order_p01_alloc: SmemAllocation | None = None
+    if (
+        cfg.has_tmem_p_pipeline
+        and not cfg.single_qkv_instance
+        and cfg.mma_order == MmaOrder.Qk0Pv0Qk1Pv1
+    ):
+        order_p01_alloc = SmemAllocation(
+            name="tmem_order_p01",
+            size_bytes=16,
+            alignment=8,
+        )
     if cfg.has_tmem_p_pipeline:
         tmem_p0 = TmemPResource(
             pipeline_config=tmem_p0_pipeline_cfg,
             cfg=cfg,
             tmem_p_offset=cfg.tmem_p0_offset,
+            inst_id=0,
+            order_p01_alloc=order_p01_alloc,
+            owns_order_p01_alloc=order_p01_alloc is not None,
             name="tmem_p0",
         )
     tmem_vec0 = TmemStatsResource(
@@ -1039,6 +1065,7 @@ def build_context_task_manager(
 
     single_qkv_instance = cfg.single_qkv_instance
     tmem_sp1: TmemSPResource | None = None
+    tmem_p1: TmemPResource | None = None
     tmem_vec1: TmemStatsResource | None = None
     smem_o_1: SmemOResource | None = None
     gmem_o_1: GmemOResource | None = None
@@ -1058,6 +1085,22 @@ def build_context_task_manager(
             scale_softmax_log2=scale_softmax_log2,
             name="tmem_sp1",
         )
+        if cfg.has_tmem_p_pipeline:
+            # Interleaved paired cross-alias layout: softmax1 writes P1 into the
+            # physical TMEM columns vacated by softmax0's S0 read (and PV0
+            # reads P0 from the columns vacated by softmax1's S1 read).
+            # Each instance therefore needs its own producer/consumer barrier
+            # so PVi can gate on softmaxi's P store and softmaxi can gate on
+            # the prior PVi consuming it before overwriting.
+            tmem_p1 = TmemPResource(
+                pipeline_config=tmem_p1_pipeline_cfg,
+                cfg=cfg,
+                tmem_p_offset=cfg.tmem_p1_offset,
+                inst_id=1,
+                order_p01_alloc=order_p01_alloc,
+                owns_order_p01_alloc=False,
+                name="tmem_p1",
+            )
         tmem_vec1 = TmemStatsResource(
             pipeline_config=tmem_vec1_pipeline_cfg,
             cfg=cfg,
@@ -1090,6 +1133,19 @@ def build_context_task_manager(
             pipeline_config=tmem_stats_done_1_pipeline_cfg,
             name="tmem_stats_done_1",
         )
+
+    # Wire each softmax's TmemSPResource to its paired TmemPResource so the
+    # OrderP01 mbarrier helpers can reach the peer's barrier via
+    # ``self._tp_ref`` (see
+    # :meth:`TmemSPResource.order_p01_arrive_if_paired`, called from the
+    # paired softmax task body in fmha_tasks.py). Done here, after both
+    # resources are constructed, to avoid reordering the resource builds.
+    # When ``order_p01_alloc is None`` the underlying mbarriers are absent
+    # and the helpers fold to no-ops at trace time.
+    if tmem_p0 is not None:
+        tmem_sp0._tp_ref = tmem_p0
+    if tmem_sp1 is not None and tmem_p1 is not None:
+        tmem_sp1._tp_ref = tmem_p1
 
     tmem_o_kwargs = tmem_o_extra_kwargs or {}
     tmem_o = TmemOResource(
@@ -1143,6 +1199,7 @@ def build_context_task_manager(
         tmem_sp0,
         tmem_sp1,
         tmem_p0,
+        tmem_p1,
         tmem_o,
         tmem_stats_done_0,
         tmem_stats_done_1,
@@ -1169,7 +1226,7 @@ def build_context_task_manager(
             1,
             tmem_sp1,
             tmem_vec1,
-            None,
+            tmem_p1,
             s0s1_seq,
             work_queue,
             **softmax1_domain_kwargs,
@@ -1311,6 +1368,8 @@ def build_context_task_manager(
         )
         if not cfg.stats_via_smem:
             resource_dependency_graph[tmem_stats_done_1] = [tmem_vec1]
+        if tmem_p1 is not None:
+            resource_dependency_graph[tmem_p1] = scheduler_deps(tmem_sp1)
     if work_queue is not None:
         resource_dependency_graph[work_queue] = [work_queue] if is_clc_dynamic else []
     if smem_page_offsets_kv is not None:
@@ -1347,6 +1406,8 @@ def build_context_task_manager(
         add_smem_resource(tmem_stats_done_0)
     if tmem_sp1 is not None:
         add_smem_resource(tmem_sp1)
+    if tmem_p1 is not None:
+        add_smem_resource(tmem_p1)
     if tmem_vec1 is not None:
         add_smem_resource(tmem_vec1)
     if s0s1_seq is not None:
@@ -1488,12 +1549,84 @@ def build_context_task_manager(
 def _should_use_tmem_p_pipeline(cfg: FmhaConfig) -> bool:
     """Return whether P readiness needs its own TMEM pipeline resource.
 
-    The TMEM P pipeline belongs to the staged, single-QKV-instance topology.
-    That path stages K/V by 128-wide head-dimension slices and uses a separate
-    P-ready handoff so the MMA task can overlap next-tile QK with previous-tile
-    PV. The paired D128 path keeps P on TmemSPResource.
+    Two topologies need a P-ready handoff separate from TmemSPResource:
+
+    * The staged, single-QKV-instance path (K/V staged by 128-wide head-dim
+      slices) uses it to overlap next-tile QK with previous-tile PV.
+    * The interleaved paired (``Qk0_Pv0_Qk1_Pv1``) schedule uses cross-alias
+      TMEM where softmax0's P0 lives in the physical columns that softmax1's
+      S1 read consumed (and symmetrically for P1/S0). Each instance's PV must
+      wait for its softmax to finish writing P, and softmax must wait for the
+      previous PV to consume it before overwriting.
     """
-    return cfg.single_qkv_instance and cfg.stage_kv_by_head_dim
+    if cfg.single_qkv_instance and cfg.stage_kv_by_head_dim:
+        return True
+    if _should_use_qk_pv_interleaved_paired_schedule(cfg):
+        return True
+    return False
+
+
+@functools.cache
+def _current_sm_major_minor() -> tuple[int, int] | None:
+    """Return the current CUDA device compute capability, or None on failure.
+
+    Runs during host-side kernel construction so it is safe to import torch and
+    query the device. Returns None if torch or the CUDA driver is unavailable
+    (e.g., during unit tests that construct FmhaConfig without a live device);
+    callers must treat None as "arch heuristic does not apply".
+    """
+    try:
+        import torch
+
+        if not torch.cuda.is_available():
+            return None
+        return torch.cuda.get_device_capability()
+    except Exception:
+        return None
+
+
+def _should_use_qk_pv_interleaved_paired_schedule(cfg: FmhaConfig) -> bool:
+    """Return whether the paired MMA task should use ``Qk0_Pv0_Qk1_Pv1``.
+
+    Only the paired (``num_qkv_instances == 2``) topology is a candidate.
+    Selection is arch-driven: Blackwell Ultra (SM103a) context kernels with
+    ``head_dim_v >= 128`` opt in to the interleaved schedule.
+
+    Query-paired causal peer0-skip and head-paired mode are intentionally
+    excluded here: their peer0/peer1 tile counts diverge, and the new
+    schedule locks a single V per iter for both instances. Supporting them
+    is a follow-up that has to widen ``pv_mma``'s skip-invalid handling.
+
+    Plain causal (``cfg.is_causal``) is also excluded for now: the causal
+    TAIL under the cross-alias TMEM layout requires an MMA-side QK refresh
+    of S0/S1 with K_{N-1} before softmax's TAIL row_max reads them, plus
+    an OrderP01-elided softmax TAIL branch. Until those land, route causal
+    back to the legacy ``Pv0_Qk0_Pv1_Qk1`` schedule to avoid NaNs from the
+    peer's LOOP-N-2 STTM(P_peer) writes still living in the aliased
+    columns when the causal TAIL re-reads S.
+
+    Paged KV (``cfg.use_paged_kv``) is also excluded for now: every observed
+    non-causal D128 paged case regresses on the interleaved schedule (all
+    three ``paged_dense_k_mask_accuracy[*-d128]`` shapes plus both
+    ``d128_paged_s16k_runtime`` dtypes produce NaNs or L2 ~1.0). Contiguous
+    and packed varlen dense cases stay correct, so the regression appears
+    tied to the paged K/V TMA path interacting with the cross-alias TMEM
+    layout rather than to the varlen dense-K mask itself. Route paged back
+    to the legacy schedule until the paged interaction is root-caused.
+    """
+    if cfg.single_qkv_instance:
+        return False
+    if cfg.head_paired or cfg.skip_causal_invalid_peer0:
+        return False
+    if cfg.is_causal:
+        return False
+    if cfg.use_paged_kv:
+        return False
+    head_dim_v = cfg.pv_mma_tiler[1]
+    if head_dim_v < 128:
+        return False
+    capability = _current_sm_major_minor()
+    return capability == (10, 3)
 
 
 _Q_ROW_SMEM_ALIGNMENT_BYTES = 128
@@ -1516,7 +1649,11 @@ def _context_pipeline_stage_counts(
             else 0
         ),
         "tmem_sp": cfg.mma_softmax_stage * cfg.num_qkv_instances,
-        "tmem_p": cfg.mma_softmax_stage if cfg.has_tmem_p_pipeline else 0,
+        "tmem_p": (
+            cfg.mma_softmax_stage * cfg.num_qkv_instances
+            if cfg.has_tmem_p_pipeline
+            else 0
+        ),
         "tmem_vec": cfg.softmax_corr_stage * cfg.num_qkv_instances,
         "tmem_o": cfg.mma_corr_stage,
         "smem_o": cfg.num_qkv_instances,
@@ -1616,9 +1753,33 @@ def _configure_pipeline_stages(cfg: FmhaConfig, *, is_clc_dynamic: bool) -> None
     cfg.q_stage = cfg.num_qkv_instances
     cfg.kv_stage = 3
     cfg.has_tmem_p_pipeline = _should_use_tmem_p_pipeline(cfg)
-    cfg.stage_scoped_tmem_stats = cfg.has_tmem_p_pipeline
-    cfg.mma_softmax_stage = 2 if cfg.has_tmem_p_pipeline else 1
-    cfg.softmax_corr_stage = 2 if cfg.stage_scoped_tmem_stats else 1
+    cfg.mma_order = (
+        MmaOrder.Qk0Pv0Qk1Pv1
+        if _should_use_qk_pv_interleaved_paired_schedule(cfg)
+        else MmaOrder.Pv0Qk0Pv1Qk1
+    )
+    # TMEM P offsets: the FmhaConfig class defaults (P0=160 inside S1, P1=32
+    # inside S0) implement the cross-alias layout required by the interleaved
+    # Qk0Pv0Qk1Pv1 schedule (OrderP01 mbarriers serialize the cross-alias
+    # writes). The legacy Pv0Qk0Pv1Qk1 schedule has no such barrier and its
+    # per-iter QK0→S0 write would clobber the peer's P1 slot before PV1 reads
+    # it (and symmetrically QK1→S1 clobbers P0 before PV0 reads it) under the
+    # cross-alias layout. Restore the same-instance aliasing for the legacy
+    # schedule so each peer's P lives inside its own S range, out of the
+    # OTHER peer's QK write path.
+    if cfg.mma_order == MmaOrder.Pv0Qk0Pv1Qk1 and not cfg.single_qkv_instance:
+        cfg.tmem_p0_offset = cfg.tmem_s0_offset + cfg.tmem_x_load_s
+        cfg.tmem_p1_offset = cfg.tmem_s1_offset + cfg.tmem_x_load_s
+    # Stage-scoped stats and the 2-stage SP/corr pipelines belong to the
+    # single-instance staged topology, where next-tile QK overlaps prior-tile
+    # PV inside one MMA instance. The interleaved paired schedule keeps
+    # mma_softmax_stage=1 per instance (one live S/P per peer) even though it
+    # also opts into has_tmem_p_pipeline, so it does not need the split-stage
+    # stats layout.
+    uses_split_sp_staging = cfg.single_qkv_instance and cfg.stage_kv_by_head_dim
+    cfg.stage_scoped_tmem_stats = uses_split_sp_staging
+    cfg.mma_softmax_stage = 2 if uses_split_sp_staging else 1
+    cfg.softmax_corr_stage = 2 if uses_split_sp_staging else 1
     # SMEM-backed D256 removes the independent StatsDone credit and always
     # writes the same physical O0 accumulator. Its MMA->Correction handoff must
     # therefore be single-stage so PV(i+1) cannot overwrite O0 before

--- a/flashinfer/attention/prims_ts/kernels/fmha_context/fmha_kernel.py
+++ b/flashinfer/attention/prims_ts/kernels/fmha_context/fmha_kernel.py
@@ -1573,7 +1573,8 @@ def _should_use_qk_pv_interleaved_paired_schedule(cfg: FmhaConfig) -> bool:
     """True when the paired MMA task should use ``Qk0_Pv0_Qk1_Pv1``.
 
     Opt-in for SM103a context with ``head_dim_v >= 128``. Excludes head-paired.
-    Causal (including peer0-skip) uses the same order with peer0-balancing drains.
+    Causal (including peer0-skip and non-tile-aligned k>q) uses the same order
+    with peer0-balancing drains.
     """
     if cfg.single_qkv_instance:
         return False
@@ -1582,13 +1583,6 @@ def _should_use_qk_pv_interleaved_paired_schedule(cfg: FmhaConfig) -> bool:
     head_dim_v = cfg.pv_mma_tiler[1]
     if head_dim_v < 128:
         return False
-    if cfg.is_causal:
-        # A non-tile-aligned bottom-right Q offset (k>q not a K/V-tile multiple)
-        # self-disables skip_causal_invalid_peer0 and pushes a right mask into
-        # the LOOP, leaving peer0's drain unbalanced -> deadlock. Defer to the
-        # legacy Pv0Qk0Pv1Qk1 schedule, which masks per LOOP iteration.
-        if cfg.has_q_offset and not cfg.has_tile_aligned_uniform_q_offset:
-            return False
     capability = _current_sm_major_minor()
     return capability == (10, 3)
 

--- a/flashinfer/attention/prims_ts/kernels/fmha_context/fmha_kernel.py
+++ b/flashinfer/attention/prims_ts/kernels/fmha_context/fmha_kernel.py
@@ -1572,17 +1572,23 @@ def _current_sm_major_minor() -> tuple[int, int] | None:
 def _should_use_qk_pv_interleaved_paired_schedule(cfg: FmhaConfig) -> bool:
     """True when the paired MMA task should use ``Qk0_Pv0_Qk1_Pv1``.
 
-    Opt-in for SM103a context with ``head_dim_v >= 128``. Excludes
-    head-paired and causal peer0-skip (divergent peer tile counts).
-    Plain causal uses the same order with peer0 empty ``sp0`` + Softmax0 drain.
+    Opt-in for SM103a context with ``head_dim_v >= 128``. Excludes head-paired.
+    Causal (including peer0-skip) uses the same order with peer0-balancing drains.
     """
     if cfg.single_qkv_instance:
         return False
-    if cfg.head_paired or cfg.skip_causal_invalid_peer0:
+    if cfg.head_paired:
         return False
     head_dim_v = cfg.pv_mma_tiler[1]
     if head_dim_v < 128:
         return False
+    if cfg.is_causal:
+        # A non-tile-aligned bottom-right Q offset (k>q not a K/V-tile multiple)
+        # self-disables skip_causal_invalid_peer0 and pushes a right mask into
+        # the LOOP, leaving peer0's drain unbalanced -> deadlock. Defer to the
+        # legacy Pv0Qk0Pv1Qk1 schedule, which masks per LOOP iteration.
+        if cfg.has_q_offset and not cfg.has_tile_aligned_uniform_q_offset:
+            return False
     capability = _current_sm_major_minor()
     return capability == (10, 3)
 
@@ -2364,8 +2370,18 @@ class FmhaTs:
         max_num_pages_per_seq_kv: int = 1,
         causal_single_kv_tile: bool = False,
         exhaustive_deadlock_race_check: bool = True,
+        has_q_offset: bool = False,
+        has_uniform_varlen: bool = False,
+        uniform_seq_len_q: int = 0,
+        uniform_seq_len_k: int = 0,
     ) -> None:
-        """Initialize mode-specific tiling, dtype, and schedule configuration."""
+        """Initialize mode-specific tiling, dtype, and schedule configuration.
+
+        ``has_q_offset``/``has_uniform_varlen``/``uniform_seq_len_{q,k}`` describe
+        the causal k>q geometry. They are constructor args (not post-construction
+        ``cfg`` assignments) because paired schedule selection must observe the
+        true geometry when it picks ``mma_order``.
+        """
         head_paired = resolve_head_paired_mode(
             head_paired=head_paired,
             is_causal=is_causal,
@@ -2408,6 +2424,11 @@ class FmhaTs:
 
         cfg = FmhaConfig()
         self.cfg = cfg
+        # Must be set before schedule selection in _configure_pipeline_stages.
+        cfg.has_q_offset = has_q_offset
+        cfg.has_uniform_varlen = has_uniform_varlen
+        cfg.uniform_seq_len_q = uniform_seq_len_q
+        cfg.uniform_seq_len_k = uniform_seq_len_k
         if d > 128:
             cfg.num_qkv_instances = 1
         cfg.use_paged_kv = use_paged_kv

--- a/flashinfer/attention/prims_ts/kernels/fmha_context/fmha_resources.py
+++ b/flashinfer/attention/prims_ts/kernels/fmha_context/fmha_resources.py
@@ -4047,15 +4047,22 @@ class TmemOResource(MemoryResource):
             first_o0_write = False
             first_o1_write_maybe = True
 
-        # In causal mode, check if O0 MMA should skip the last LOOP iteration.
+        # Elide peer0's PV0 over its trailing fully-masked tile. Location differs
+        # by schedule: legacy folds the last PV into the LOOP (skip last LOOP
+        # iter); interleaved pipelines PV one tile behind QK so peer0's only
+        # invalid PV0(V_{N-1}) lands in the TAIL (skip there, not the LOOP, which
+        # still holds valid tiles).
         skip_o0_invalid = False
-        if cutlass.const_expr(
-            self.cfg.skip_causal_invalid_peer0
-            and writes_o0
-            and section == FmhaStage.Loop
-        ):
-            if not is_tail:
-                skip_o0_invalid = stage_info.loop_offset == (stage_info.loop_end - 1)
+        if cutlass.const_expr(self.cfg.skip_causal_invalid_peer0 and writes_o0):
+            if cutlass.const_expr(self.cfg.uses_qk_pv_interleaved_paired_schedule):
+                skip_o0_invalid = cutlass.const_expr(
+                    section == FmhaStage.Tail and is_tail
+                )
+            elif cutlass.const_expr(section == FmhaStage.Loop):
+                if not is_tail:
+                    skip_o0_invalid = stage_info.loop_offset == (
+                        stage_info.loop_end - 1
+                    )
 
         if not skip_o0_invalid:
             tmem_ptr_raw = self.tmem_ptr_raw_cached
@@ -4281,13 +4288,15 @@ class TmemOResource(MemoryResource):
         else:
             tmem_o_offset = self.tmem_o1_offset
 
-        # In causal mode with no Q right offset, skip the invalid O0 correction
-        # in the last LOOP iteration. The task domain pads partial final CTAs so
-        # this slot is always outside peer0's causal reach.
+        # Skip peer0's invalid O0 correction on the last LOOP iter (domain pads
+        # partial CTAs so it is outside peer0's causal reach). Interleaved is
+        # exempt: it pipelines PV behind QK so every LOOP O0 rescale is valid and
+        # the invalid tile carries no PV0 -- nothing to skip here.
         skip_o0_invalid = False
         if cutlass.const_expr(
             self.cfg.skip_causal_invalid_peer0
             and not self.cfg.single_qkv_instance
+            and not self.cfg.uses_qk_pv_interleaved_paired_schedule
             and inst_idx == 0
         ):
             # This is O0 correction; check if this is the last LOOP iteration.

--- a/flashinfer/attention/prims_ts/kernels/fmha_context/fmha_resources.py
+++ b/flashinfer/attention/prims_ts/kernels/fmha_context/fmha_resources.py
@@ -359,10 +359,7 @@ class FmhaConfig:
 
         Causal TAIL specialisation also gates on ``self.is_causal``.
         """
-        return (
-            not self.single_qkv_instance
-            and self.mma_order == MmaOrder.Qk0Pv0Qk1Pv1
-        )
+        return not self.single_qkv_instance and self.mma_order == MmaOrder.Qk0Pv0Qk1Pv1
 
     @property
     def uses_qk_pv_interleaved_causal_paired_schedule(self) -> bool:

--- a/flashinfer/attention/prims_ts/kernels/fmha_context/fmha_resources.py
+++ b/flashinfer/attention/prims_ts/kernels/fmha_context/fmha_resources.py
@@ -155,21 +155,11 @@ def _placeholder_softmax_chunks(cfg: Any) -> SoftmaxChunks:
 
 
 class MmaOrder(enum.Enum):
-    """Per-iter QK/PV interleave pattern for the paired MMA task.
+    """Per-iter QK/PV order for the paired MMA task.
 
-    ``Pv0Qk0Pv1Qk1`` is the historical TS paired schedule: each KV-tile
-    iteration issues ``Qk0(new K) -> Pv1(prev V) -> Qk1(new K) -> Pv0(new V)``,
-    locking V twice per iter across two logical tiles.
-
-    ``Qk0Pv0Qk1Pv1`` is the interleaved paired schedule: both PVs consume the
-    same V window (single V lock per iter), and QK for iter i+1 is issued
-    between Pv0 and Pv1 so softmax on iter i's S overlaps with next-iter QK.
-    Causal support is layered on top of this same enum value: when
-    ``FmhaConfig.is_causal`` is set, the MMA schedule holds ``K_{N-1}`` live
-    through TAIL and re-issues ``QK(K_{N-1})`` to refresh ``S0``/``S1``
-    before softmax's TAIL row_max/exp2_p reads them, and softmax's TAIL
-    causal branch elides the LOOP-style OrderP01 handshake. See
-    :attr:`FmhaConfig.uses_qk_pv_interleaved_paired_schedule` for the gate.
+    ``Pv0Qk0Pv1Qk1``: historical — ``Qk0 → Pv1 → Qk1 → Pv0``, V locked twice/iter.
+    ``Qk0Pv0Qk1Pv1``: interleaved — one V lock/iter; QK(i+1) between Pv0/Pv1.
+    Causal reuses the latter (TAIL dual-PV off ``V_{N-1}``; peer0 empty ``sp0`` + Softmax0 drain).
     """
 
     Pv0Qk0Pv1Qk1 = 0
@@ -207,10 +197,7 @@ class FmhaConfig:
     # Number of interleaved Q/KV/O instances per CTA: two selects the paired
     # schedule, while one selects the single-instance schedule used for D>128.
     num_qkv_instances: int = 2
-    # Per-iter QK/PV interleave pattern for the paired MMA task; ignored when
-    # single_qkv_instance is True. Defaults to the historical schedule
-    # (Pv0Qk0Pv1Qk1) so single-instance and non-Blackwell-Ultra deployments are
-    # unchanged. Selection is made by _configure_pipeline_stages.
+    # Paired MMA QK/PV order; ignored when single_qkv_instance. Default historical.
     mma_order: MmaOrder = MmaOrder.Pv0Qk0Pv1Qk1
 
     # Pipeline stages
@@ -256,26 +243,19 @@ class FmhaConfig:
     num_regs_correction: int = 96
     num_regs_other: int = 32
 
-    # TMEM layout (the paired schedule uses these class-default offsets;
-    # _configure_single_instance_tmem_layout overrides for single-instance).
-    #
-    # S/P interleave layout with cross-instance aliasing: S0 and P1 share
-    # the same physical TMEM columns, and S1 and P0 share the same physical
-    # TMEM columns. Concretely, S0 spans cols [0, 128) (FP32 accumulator)
-    # and P1 is packed inside that range at col 32; S1 spans cols [128, 256)
-    # and P0 is packed inside that range at col 160. This lets softmax on
-    # one peer write P into the physical slot vacated by the OTHER peer's
-    # S read, so the pipeline naturally sequences QK/softmax/PV across the
-    # two peers through the shared physical buffers.
+    # TMEM layout (paired defaults; single-instance overrides in
+    # _configure_single_instance_tmem_layout). Same-instance S↔P by default
+    # (P0@S0, P1@S1); Qk0Pv0Qk1Pv1 overrides to cross-alias in
+    # _configure_pipeline_stages.
     tmem_alloc_cols: int = 512
     tmem_stats_cols: int = 4
     tmem_s0_offset: int = 0
     tmem_s1_offset: int = 128
     tmem_o0_offset: int = 256
     tmem_o1_offset: int = 384
-    # Cross-alias: P0 lives inside S1's range, P1 lives inside S0's range.
-    tmem_p0_offset: int = 160
-    tmem_p1_offset: int = 32
+    # Same-instance: P0 inside S0, P1 inside S1.
+    tmem_p0_offset: int = 32
+    tmem_p1_offset: int = 160
     tmem_vec0_offset: int = 0
     tmem_vec1_offset: int = 128
 
@@ -375,23 +355,22 @@ class FmhaConfig:
 
     @property
     def uses_qk_pv_interleaved_paired_schedule(self) -> bool:
-        """Return whether the paired MMA task uses the interleaved order.
+        """True when paired MMA uses ``Qk0 → Pv0 → Qk1 → Pv1`` (else historical).
 
-        True selects the ``Qk0 -> Pv0 -> Qk1 -> Pv1`` schedule (single V lock
-        per iter, next-iter QK issued between Pv0 and Pv1). False keeps the
-        historical asymmetric ``Qk0 -> Pv1(prev V) -> Qk1 -> Pv0(new V)``.
-        Only meaningful on the paired (num_qkv_instances == 2) path.
-
-        Causal support is layered on top of this same schedule: consumers
-        who need to specialise the TAIL for causal (hold ``K_{N-1}`` across
-        TAIL, re-issue ``QK(K_{N-1})`` to refresh ``S0``/``S1``, elide the
-        LOOP-style OrderP01 handshake in softmax's TAIL) gate on
-        ``self.is_causal`` in addition to this property.
+        Causal TAIL specialisation also gates on ``self.is_causal``.
         """
         return (
             not self.single_qkv_instance
             and self.mma_order == MmaOrder.Qk0Pv0Qk1Pv1
         )
+
+    @property
+    def uses_qk_pv_interleaved_causal_paired_schedule(self) -> bool:
+        """True when interleaved paired MMA runs causal TAIL (off ``V_{N-1}``).
+
+        Peer0 empty ``sp0`` + Softmax0 drain for correction; gated on ``is_causal``.
+        """
+        return self.uses_qk_pv_interleaved_paired_schedule and self.is_causal
 
     @property
     def uses_early_tile_sum(self) -> bool:
@@ -1942,13 +1921,8 @@ class TmemSPResource(MemoryResource):
     # Softmax warp per-warp P address.
     tmem_p_addr_cached: TmemAddr | None = field(init=False, default=None)
     _alloc: Constexpr[Optional[TmemAllocation]] = field(init=False, default=None)
-    # Back-reference to *this softmax's* TmemPResource, used only under the
-    # interleaved paired schedule to reach the OrderP01 mbarrier helpers
-    # (:meth:`TmemPResource._order_p01_arrive` /
-    # :meth:`TmemPResource._order_p01_wait`). Left as ``None`` otherwise, in
-    # which case :meth:`order_p01_arrive_if_paired` /
-    # :meth:`order_p01_wait_if_paired` fold to no-ops at trace time. Wired
-    # post-construction by ``build_resources`` in fmha_kernel.py.
+    # Softmax → its TmemPResource (_tp_ref); OS helpers no-op if unset.
+    # Wired by build_resources after both resources exist.
     _tp_ref: Optional[MemoryResource] = field(init=False, default=None)
     old_row_max: Constexpr[TaskLocalVariable] = TaskLocalVariable.uninitialized()
     row_max: Constexpr[TaskLocalVariable] = TaskLocalVariable.uninitialized()
@@ -2898,32 +2872,22 @@ class TmemSPResource(MemoryResource):
 
     @consumer_work(work_attrs=WorkAttr.AUXILIARY)
     @cute.jit
-    def order_p01_arrive_if_paired(self, stage_info: StageInfo) -> None:
-        """Signal the OrderP01 peer that LDTM(S_own) is done.
-
-        Called by the paired softmax task body (``_paired_softmax_body`` in
-        fmha_tasks.py) once immediately after every ``*_row_max`` call.
-        Folds to a no-op at trace time when ``_tp_ref is None`` (single-
-        instance or non-interleaved schedule). ``AUXILIARY`` so it does not
-        participate in the SP producer-consumer handshake.
-        """
+    def ordered_sequence_arrive_if_paired(self, stage_info: StageInfo) -> None:
+        """Arrive OS peer after LDTM(S); no-op if ``_tp_ref`` is unset."""
         _ = stage_info
         if cutlass.const_expr(self._tp_ref is not None):
-            self._tp_ref._order_p01_arrive()
+            self._tp_ref._ordered_sequence_arrive()
 
     @consumer_work(work_attrs=WorkAttr.AUXILIARY)
     @cute.jit
-    def order_p01_wait_if_paired(self, stage_info: StageInfo) -> None:
-        """Block until the OrderP01 peer's LDTM(S_peer) is done.
+    def ordered_sequence_wait_if_paired(self, stage_info: StageInfo) -> None:
+        """Wait until OS peer finishes LDTM(S); no-op if ``_tp_ref`` is unset.
 
-        Called by the paired softmax task body once immediately before every
-        ``*_exp2_p`` call so STTM(P_own) waits for the peer's LDTM of the
-        aliased physical columns. Also folds to a no-op at trace time when
-        ``_tp_ref is None``.
+        Pre-loop wait burns the init credit; in-loop wait gates each STTM(P).
         """
         _ = stage_info
         if cutlass.const_expr(self._tp_ref is not None):
-            self._tp_ref._order_p01_wait()
+            self._tp_ref._ordered_sequence_wait()
 
     @consumer_work(returns=(old_row_max, row_max))
     @cute.jit
@@ -3435,45 +3399,24 @@ class TmemSPResource(MemoryResource):
 class TmemPResource(MemoryResource):
     """Pipeline-only P handoff for split S/P scheduling.
 
-    Softmax stores P into the TMEM columns owned by ``TmemSPResource`` and
-    commits this AsyncUmma resource. The MMA task waits on it before issuing
-    PV, so the next QK can use the other S/P stage without using the S acquire
-    as an implicit P-ready wait.
+    Softmax stores P into ``TmemSPResource`` TMEM and commits this resource;
+    MMA waits before PV so next QK need not treat S-acquire as P-ready.
 
-    OrderP01 (interleaved paired schedule only)
-    -------------------------------------------
-    Under the ``Qk0_Pv0_Qk1_Pv1`` schedule, S0/P1 alias the same physical TMEM
-    columns [0, 128), and S1/P0 alias [128, 256). ``S0S1SequenceResource``
-    orders P stores between the two softmax warps, but it does NOT prevent
-    softmax(i) from writing P_i while the peer is still LOADING S_peer from
-    the same physical columns.
-
-    OrderP01 fixes that race with one mbarrier per peer::
-
-        barrier[0]   barrier[1]
-            ^            ^
-            |            |
-        peer1.arrive  peer0.arrive     (after own LDTM(S) completes)
-            |            |
-        peer0.wait    peer1.wait       (before own STTM(P) starts)
-
-    So each peer waits on its own barrier and arrives on the peer's barrier.
-    The barriers live in shared memory, one ``Int64`` slot each, allocated
-    via ``order_p01_alloc``. See :meth:`_order_p01_wait` /
-    :meth:`_order_p01_arrive` for the low-level primitives and
-    :class:`TmemSPResource` for the softmax-side call sites.
+    OrderedSequence (interleaved only): S0↔P1 / S1↔P0 alias means STTM(P)
+    can race with the peer still LDTM(S). One mbarrier per peer: arrive after
+    own LDTM(S), wait before own STTM(P) (SMEM via ``ordered_sequence_alloc``).
     """
 
     cfg: Constexpr[FmhaConfig] = field(init=False, default=None)
     tmem_p_offset: Constexpr[int] = field(init=False, default=None)
     inst_id: Constexpr[int] = field(init=False, default=0)
-    order_p01_alloc: Constexpr[Optional[SmemAllocation]] = field(
+    ordered_sequence_alloc: Constexpr[Optional[SmemAllocation]] = field(
         init=False, default=None
     )
-    owns_order_p01_alloc: Constexpr[bool] = field(init=False, default=False)
+    owns_ordered_sequence_alloc: Constexpr[bool] = field(init=False, default=False)
     tmem_p_base: Constexpr[TaskLocalVariable] = TaskLocalVariable.uninitialized()
-    _order_p01_barrier_ptr: object = field(init=False, default=None)
-    _order_p01_phase: object = field(init=False, default=None)
+    _ordered_sequence_barrier_ptr: object = field(init=False, default=None)
+    _ordered_sequence_phase: object = field(init=False, default=None)
 
     def __init__(
         self,
@@ -3481,8 +3424,8 @@ class TmemPResource(MemoryResource):
         cfg: FmhaConfig,
         tmem_p_offset: int,
         inst_id: int = 0,
-        order_p01_alloc: Optional[SmemAllocation] = None,
-        owns_order_p01_alloc: bool = False,
+        ordered_sequence_alloc: Optional[SmemAllocation] = None,
+        owns_ordered_sequence_alloc: bool = False,
         **kwargs: Any,
     ) -> None:
         """Bind the base P TMEM offset used by the split S/P pipeline."""
@@ -3490,8 +3433,8 @@ class TmemPResource(MemoryResource):
         self.cfg = cfg
         self.tmem_p_offset = tmem_p_offset
         self.inst_id = inst_id
-        self.order_p01_alloc = order_p01_alloc
-        self.owns_order_p01_alloc = owns_order_p01_alloc
+        self.ordered_sequence_alloc = ordered_sequence_alloc
+        self.owns_ordered_sequence_alloc = owns_ordered_sequence_alloc
         self.tmem_p_base = TaskLocalVariable(
             dtype=Int32,
             default=Int32(tmem_p_offset),
@@ -3503,9 +3446,9 @@ class TmemPResource(MemoryResource):
         return []
 
     def get_smem_requirements(self) -> list[SmemAllocation]:
-        """Return the OrderP01 mbarrier allocation for the owning instance."""
-        if self.owns_order_p01_alloc and self.order_p01_alloc is not None:
-            return [self.order_p01_alloc]
+        """Return the OrderedSequence mbarrier allocation for the owning instance."""
+        if self.owns_ordered_sequence_alloc and self.ordered_sequence_alloc is not None:
+            return [self.ordered_sequence_alloc]
         return []
 
     @cute.jit
@@ -3514,31 +3457,29 @@ class TmemPResource(MemoryResource):
         context=None,
         captured_schedule: Constexpr[bool] = False,
     ) -> None:
-        """Initialize the tmem_p pipeline and the OrderP01 mbarriers."""
+        """Initialize the tmem_p pipeline and the OrderedSequence mbarriers."""
         super().initialize_runtime_state_internal(context, captured_schedule)
         if cutlass.const_expr(
             context is not None
             and context.smem_base is not None
-            and self.order_p01_alloc is not None
+            and self.ordered_sequence_alloc is not None
         ):
-            self._order_p01_barrier_ptr = cute.make_ptr(
+            self._ordered_sequence_barrier_ptr = cute.make_ptr(
                 cutlass.Int64,
-                context.smem_base.data_ptr() + self.order_p01_alloc.offset,
+                context.smem_base.data_ptr() + self.ordered_sequence_alloc.offset,
                 mem_space=cute.AddressSpace.smem,
             )
-        # Both barriers start at parity 0. Local phase tracks the parity we
-        # expect to WAIT AGAINST on our own barrier (the one the peer arrives
-        # on). ``mbarrier_wait(phase)`` returns when barrier parity != phase,
-        # so init phase 0 makes iter 0's wait block until the peer's first
-        # arrive flips the barrier, which is the correct behavior for
-        # ordering our STTM(P_own) after the peer's LDTM(S_peer).
-        self._order_p01_phase = Int32(0)
-        if cutlass.const_expr(self._order_p01_barrier_ptr is not None):
-            self._init_order_p01_barriers()
+        # Phase 0: wait until peer's first arrive flips our barrier (before STTM(P)).
+        self._ordered_sequence_phase = Int32(0)
+        if cutlass.const_expr(self._ordered_sequence_barrier_ptr is not None):
+            self._init_ordered_sequence_barriers()
 
     @cute.jit
-    def _init_order_p01_barriers(self) -> None:
-        """Initialize the two mbarriers backing the OrderedSequence pair."""
+    def _init_ordered_sequence_barriers(self) -> None:
+        """Init OS mbarriers (count=128); plant one credit on ``barrier[0]`` only.
+
+        Peer0 pre-loop wait returns immediately; peer1 waits until peer0 arrives.
+        """
         warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx())
         # softmax0 warp 2 initializes barrier 0 (waited on by softmax0);
         # softmax1 warp 2 initializes barrier 1 (waited on by softmax1).
@@ -3550,9 +3491,18 @@ class TmemPResource(MemoryResource):
         if warp_idx == bar_init_warp:
             with cute.arch.elect_one():
                 cute.arch.mbarrier_init(
-                    self._order_p01_barrier_ptr + self.inst_id,
+                    self._ordered_sequence_barrier_ptr + self.inst_id,
                     Int32(128),
                 )
+                if cutlass.const_expr(self.inst_id == 0):
+                    # Pre-plant a full-warpgroup credit on barrier[0] only,
+                    # so peer 0's pre-loop wait unblocks immediately and
+                    # peer 1's pre-loop wait blocks on peer 0's first arrive
+                    # — establishing the peer0 -> peer1 ordering for iter 0.
+                    cute.arch.mbarrier_arrive(
+                        self._ordered_sequence_barrier_ptr + self.inst_id,
+                        arrive_count=128,
+                    )
         cute.arch.mbarrier_init_fence()
         prims.barrier_cta_sync(
             self.cfg.tmem_bar_id,
@@ -3560,43 +3510,21 @@ class TmemPResource(MemoryResource):
         )
 
     @cute.jit
-    def _order_p01_wait(self) -> None:
-        """Block until the peer has finished LDTM(S_peer); then advance phase.
-
-        Softmax(i) must call this before STTM(P_i) so the peer's LDTM(S_peer)
-        on the aliased physical TMEM columns has finished. Called indirectly
-        as ``sp._tp_ref._order_p01_wait()`` from inside
-        :meth:`TmemSPResource.exp2_p` / :meth:`TmemSPResource.masked_exp2_p`.
-
-        Phase discipline: we wait on ``barrier[inst_id]``, which the peer
-        arrives on. ``mbarrier_wait(phase)`` returns when barrier parity has
-        FLIPPED away from ``phase``, so the local phase XORs AFTER wait
-        completes. Both peers start at phase 0 (matching the barriers'
-        initial parity); see d873ed31 for the XOR-on-wait rationale.
-        """
-        if cutlass.const_expr(self._order_p01_barrier_ptr is not None):
+    def _ordered_sequence_wait(self) -> None:
+        """Wait on ``barrier[inst_id]`` until peer LDTM(S) is done; then XOR phase."""
+        if cutlass.const_expr(self._ordered_sequence_barrier_ptr is not None):
             cute.arch.mbarrier_wait(
-                self._order_p01_barrier_ptr + self.inst_id,
-                self._order_p01_phase,
+                self._ordered_sequence_barrier_ptr + self.inst_id,
+                self._ordered_sequence_phase,
             )
-            self._order_p01_phase = self._order_p01_phase ^ Int32(1)
+            self._ordered_sequence_phase = self._ordered_sequence_phase ^ Int32(1)
 
     @cute.jit
-    def _order_p01_arrive(self) -> None:
-        """Signal the peer that LDTM(S_own) is finished.
-
-        Called indirectly as ``sp._tp_ref._order_p01_arrive()`` from inside
-        the row_max work methods on :class:`TmemSPResource` (compute_row_max,
-        masked_row_max, and their loop/tail variants) once LDTM(S_own) has
-        drained. Arrival unblocks the peer's :meth:`_order_p01_wait` before
-        it starts STTM(P_peer) on the aliased columns.
-
-        Does NOT touch local phase: local phase tracks
-        ``barrier[inst_id]``, which is arrived on by the peer, not by us.
-        """
-        if cutlass.const_expr(self._order_p01_barrier_ptr is not None):
+    def _ordered_sequence_arrive(self) -> None:
+        """Arrive on peer's barrier after LDTM(S); does not touch local phase."""
+        if cutlass.const_expr(self._ordered_sequence_barrier_ptr is not None):
             peer_id = 1 - self.inst_id
-            cute.arch.mbarrier_arrive(self._order_p01_barrier_ptr + peer_id)
+            cute.arch.mbarrier_arrive(self._ordered_sequence_barrier_ptr + peer_id)
 
     @cute.jit
     def create_function_variables(self, context: Optional[Any] = None) -> Int32:
@@ -4103,20 +4031,9 @@ class TmemOResource(MemoryResource):
         LOOP iteration, since Softmax0's domain is N-2 but MMA's domain is N-1.
         The task domain pads partial final CTAs so this slot is always outside
         peer0's causal reach.
-
-        Under ``uses_qk_pv_interleaved_paired_schedule``
-        (``Qk0_Pv0_Qk1_Pv1``) HEAD carries no PV; each LOOP/TAIL iter issues
-        PV0 (``inst_idx=0`` → O0) and PV1 (``inst_idx=1`` → O1) on the same V
-        window, so the inst_idx-to-O mapping and first-write bookkeeping
-        differ from the historical schedule.
         """
         if cutlass.const_expr(self.cfg.uses_qk_pv_interleaved_paired_schedule):
-            # Qk0_Pv0_Qk1_Pv1: inst_idx=0 writes O0, inst_idx=1 writes O1.
-            # First writes fall out of the dynamic scale_d branch below
-            # (LOOP iter 0 or TAIL when the loop domain is empty).
             writes_o0 = inst_idx == 0
-            first_o0_write = False
-            first_o1_write_maybe = False
         elif cutlass.const_expr(section == FmhaStage.Head):
             writes_o0 = True
             first_o0_write = True

--- a/flashinfer/attention/prims_ts/kernels/fmha_context/fmha_resources.py
+++ b/flashinfer/attention/prims_ts/kernels/fmha_context/fmha_resources.py
@@ -58,6 +58,7 @@ GMEM resources (no pipeline)
 - GmemOResource   : TMA descriptor for O stores.
 """
 
+import enum
 import math
 from dataclasses import dataclass, field, replace
 from typing import Any, Optional, TypeAlias
@@ -149,6 +150,33 @@ def _placeholder_softmax_chunks(cfg: Any) -> SoftmaxChunks:
 
 
 # ---------------------------------------------------------------------------
+# MMA schedule variants for the paired MMA task
+# ---------------------------------------------------------------------------
+
+
+class MmaOrder(enum.Enum):
+    """Per-iter QK/PV interleave pattern for the paired MMA task.
+
+    ``Pv0Qk0Pv1Qk1`` is the historical TS paired schedule: each KV-tile
+    iteration issues ``Qk0(new K) -> Pv1(prev V) -> Qk1(new K) -> Pv0(new V)``,
+    locking V twice per iter across two logical tiles.
+
+    ``Qk0Pv0Qk1Pv1`` is the interleaved paired schedule: both PVs consume the
+    same V window (single V lock per iter), and QK for iter i+1 is issued
+    between Pv0 and Pv1 so softmax on iter i's S overlaps with next-iter QK.
+    Causal support is layered on top of this same enum value: when
+    ``FmhaConfig.is_causal`` is set, the MMA schedule holds ``K_{N-1}`` live
+    through TAIL and re-issues ``QK(K_{N-1})`` to refresh ``S0``/``S1``
+    before softmax's TAIL row_max/exp2_p reads them, and softmax's TAIL
+    causal branch elides the LOOP-style OrderP01 handshake. See
+    :attr:`FmhaConfig.uses_qk_pv_interleaved_paired_schedule` for the gate.
+    """
+
+    Pv0Qk0Pv1Qk1 = 0
+    Qk0Pv0Qk1Pv1 = 1
+
+
+# ---------------------------------------------------------------------------
 # FmhaConfig -- kernel-wide configuration
 # ---------------------------------------------------------------------------
 
@@ -179,6 +207,11 @@ class FmhaConfig:
     # Number of interleaved Q/KV/O instances per CTA: two selects the paired
     # schedule, while one selects the single-instance schedule used for D>128.
     num_qkv_instances: int = 2
+    # Per-iter QK/PV interleave pattern for the paired MMA task; ignored when
+    # single_qkv_instance is True. Defaults to the historical schedule
+    # (Pv0Qk0Pv1Qk1) so single-instance and non-Blackwell-Ultra deployments are
+    # unchanged. Selection is made by _configure_pipeline_stages.
+    mma_order: MmaOrder = MmaOrder.Pv0Qk0Pv1Qk1
 
     # Pipeline stages
     q_stage: int = 2
@@ -223,15 +256,26 @@ class FmhaConfig:
     num_regs_correction: int = 96
     num_regs_other: int = 32
 
-    # TMEM layout
+    # TMEM layout (the paired schedule uses these class-default offsets;
+    # _configure_single_instance_tmem_layout overrides for single-instance).
+    #
+    # S/P interleave layout with cross-instance aliasing: S0 and P1 share
+    # the same physical TMEM columns, and S1 and P0 share the same physical
+    # TMEM columns. Concretely, S0 spans cols [0, 128) (FP32 accumulator)
+    # and P1 is packed inside that range at col 32; S1 spans cols [128, 256)
+    # and P0 is packed inside that range at col 160. This lets softmax on
+    # one peer write P into the physical slot vacated by the OTHER peer's
+    # S read, so the pipeline naturally sequences QK/softmax/PV across the
+    # two peers through the shared physical buffers.
     tmem_alloc_cols: int = 512
     tmem_stats_cols: int = 4
     tmem_s0_offset: int = 0
     tmem_s1_offset: int = 128
     tmem_o0_offset: int = 256
     tmem_o1_offset: int = 384
-    tmem_p0_offset: int = 32
-    tmem_p1_offset: int = 160
+    # Cross-alias: P0 lives inside S1's range, P1 lives inside S0's range.
+    tmem_p0_offset: int = 160
+    tmem_p1_offset: int = 32
     tmem_vec0_offset: int = 0
     tmem_vec1_offset: int = 128
 
@@ -328,6 +372,26 @@ class FmhaConfig:
     def single_qkv_instance(self) -> bool:
         """Return whether one work tile carries a single Q/KV/O instance."""
         return self.num_qkv_instances == 1
+
+    @property
+    def uses_qk_pv_interleaved_paired_schedule(self) -> bool:
+        """Return whether the paired MMA task uses the interleaved order.
+
+        True selects the ``Qk0 -> Pv0 -> Qk1 -> Pv1`` schedule (single V lock
+        per iter, next-iter QK issued between Pv0 and Pv1). False keeps the
+        historical asymmetric ``Qk0 -> Pv1(prev V) -> Qk1 -> Pv0(new V)``.
+        Only meaningful on the paired (num_qkv_instances == 2) path.
+
+        Causal support is layered on top of this same schedule: consumers
+        who need to specialise the TAIL for causal (hold ``K_{N-1}`` across
+        TAIL, re-issue ``QK(K_{N-1})`` to refresh ``S0``/``S1``, elide the
+        LOOP-style OrderP01 handshake in softmax's TAIL) gate on
+        ``self.is_causal`` in addition to this property.
+        """
+        return (
+            not self.single_qkv_instance
+            and self.mma_order == MmaOrder.Qk0Pv0Qk1Pv1
+        )
 
     @property
     def uses_early_tile_sum(self) -> bool:
@@ -1878,6 +1942,14 @@ class TmemSPResource(MemoryResource):
     # Softmax warp per-warp P address.
     tmem_p_addr_cached: TmemAddr | None = field(init=False, default=None)
     _alloc: Constexpr[Optional[TmemAllocation]] = field(init=False, default=None)
+    # Back-reference to *this softmax's* TmemPResource, used only under the
+    # interleaved paired schedule to reach the OrderP01 mbarrier helpers
+    # (:meth:`TmemPResource._order_p01_arrive` /
+    # :meth:`TmemPResource._order_p01_wait`). Left as ``None`` otherwise, in
+    # which case :meth:`order_p01_arrive_if_paired` /
+    # :meth:`order_p01_wait_if_paired` fold to no-ops at trace time. Wired
+    # post-construction by ``build_resources`` in fmha_kernel.py.
+    _tp_ref: Optional[MemoryResource] = field(init=False, default=None)
     old_row_max: Constexpr[TaskLocalVariable] = TaskLocalVariable.uninitialized()
     row_max: Constexpr[TaskLocalVariable] = TaskLocalVariable.uninitialized()
     row_sum: Constexpr[TaskLocalVariable] = TaskLocalVariable.uninitialized()
@@ -1909,6 +1981,7 @@ class TmemSPResource(MemoryResource):
         self.cum_seqlen_q = cum_seqlen_q
         self.cum_seqlen_k = cum_seqlen_k
         self.scale_softmax_log2 = scale_softmax_log2
+        self._tp_ref = None
         self._alloc = TmemAllocation(
             f"tmem_sp_q{q_half}",
             cfg.qk_mma_tiler[1] * cfg.mma_softmax_stage,
@@ -2823,6 +2896,35 @@ class TmemSPResource(MemoryResource):
         cute.arch.fence_view_async_tmem_store()
         return local_sum_pair_0[0] + local_sum_pair_0[1]
 
+    @consumer_work(work_attrs=WorkAttr.AUXILIARY)
+    @cute.jit
+    def order_p01_arrive_if_paired(self, stage_info: StageInfo) -> None:
+        """Signal the OrderP01 peer that LDTM(S_own) is done.
+
+        Called by the paired softmax task body (``_paired_softmax_body`` in
+        fmha_tasks.py) once immediately after every ``*_row_max`` call.
+        Folds to a no-op at trace time when ``_tp_ref is None`` (single-
+        instance or non-interleaved schedule). ``AUXILIARY`` so it does not
+        participate in the SP producer-consumer handshake.
+        """
+        _ = stage_info
+        if cutlass.const_expr(self._tp_ref is not None):
+            self._tp_ref._order_p01_arrive()
+
+    @consumer_work(work_attrs=WorkAttr.AUXILIARY)
+    @cute.jit
+    def order_p01_wait_if_paired(self, stage_info: StageInfo) -> None:
+        """Block until the OrderP01 peer's LDTM(S_peer) is done.
+
+        Called by the paired softmax task body once immediately before every
+        ``*_exp2_p`` call so STTM(P_own) waits for the peer's LDTM of the
+        aliased physical columns. Also folds to a no-op at trace time when
+        ``_tp_ref is None``.
+        """
+        _ = stage_info
+        if cutlass.const_expr(self._tp_ref is not None):
+            self._tp_ref._order_p01_wait()
+
     @consumer_work(returns=(old_row_max, row_max))
     @cute.jit
     def compute_row_max(
@@ -3337,23 +3439,59 @@ class TmemPResource(MemoryResource):
     commits this AsyncUmma resource. The MMA task waits on it before issuing
     PV, so the next QK can use the other S/P stage without using the S acquire
     as an implicit P-ready wait.
+
+    OrderP01 (interleaved paired schedule only)
+    -------------------------------------------
+    Under the ``Qk0_Pv0_Qk1_Pv1`` schedule, S0/P1 alias the same physical TMEM
+    columns [0, 128), and S1/P0 alias [128, 256). ``S0S1SequenceResource``
+    orders P stores between the two softmax warps, but it does NOT prevent
+    softmax(i) from writing P_i while the peer is still LOADING S_peer from
+    the same physical columns.
+
+    OrderP01 fixes that race with one mbarrier per peer::
+
+        barrier[0]   barrier[1]
+            ^            ^
+            |            |
+        peer1.arrive  peer0.arrive     (after own LDTM(S) completes)
+            |            |
+        peer0.wait    peer1.wait       (before own STTM(P) starts)
+
+    So each peer waits on its own barrier and arrives on the peer's barrier.
+    The barriers live in shared memory, one ``Int64`` slot each, allocated
+    via ``order_p01_alloc``. See :meth:`_order_p01_wait` /
+    :meth:`_order_p01_arrive` for the low-level primitives and
+    :class:`TmemSPResource` for the softmax-side call sites.
     """
 
     cfg: Constexpr[FmhaConfig] = field(init=False, default=None)
     tmem_p_offset: Constexpr[int] = field(init=False, default=None)
+    inst_id: Constexpr[int] = field(init=False, default=0)
+    order_p01_alloc: Constexpr[Optional[SmemAllocation]] = field(
+        init=False, default=None
+    )
+    owns_order_p01_alloc: Constexpr[bool] = field(init=False, default=False)
     tmem_p_base: Constexpr[TaskLocalVariable] = TaskLocalVariable.uninitialized()
+    _order_p01_barrier_ptr: object = field(init=False, default=None)
+    _order_p01_phase: object = field(init=False, default=None)
 
     def __init__(
         self,
         pipeline_config: PipelineConfig,
         cfg: FmhaConfig,
         tmem_p_offset: int,
+        inst_id: int = 0,
+        order_p01_alloc: Optional[SmemAllocation] = None,
+        owns_order_p01_alloc: bool = False,
         **kwargs: Any,
     ) -> None:
         """Bind the base P TMEM offset used by the split S/P pipeline."""
         super().__init__(pipeline_config=pipeline_config, **kwargs)
         self.cfg = cfg
         self.tmem_p_offset = tmem_p_offset
+        self.inst_id = inst_id
+        self.order_p01_alloc = order_p01_alloc
+        self.owns_order_p01_alloc = owns_order_p01_alloc
         self.tmem_p_base = TaskLocalVariable(
             dtype=Int32,
             default=Int32(tmem_p_offset),
@@ -3363,6 +3501,102 @@ class TmemPResource(MemoryResource):
     def get_tmem_requirements(self) -> list[TmemAllocation]:
         """Return no allocation because P aliases the TmemSP allocation."""
         return []
+
+    def get_smem_requirements(self) -> list[SmemAllocation]:
+        """Return the OrderP01 mbarrier allocation for the owning instance."""
+        if self.owns_order_p01_alloc and self.order_p01_alloc is not None:
+            return [self.order_p01_alloc]
+        return []
+
+    @cute.jit
+    def initialize_runtime_state_internal(
+        self,
+        context=None,
+        captured_schedule: Constexpr[bool] = False,
+    ) -> None:
+        """Initialize the tmem_p pipeline and the OrderP01 mbarriers."""
+        super().initialize_runtime_state_internal(context, captured_schedule)
+        if cutlass.const_expr(
+            context is not None
+            and context.smem_base is not None
+            and self.order_p01_alloc is not None
+        ):
+            self._order_p01_barrier_ptr = cute.make_ptr(
+                cutlass.Int64,
+                context.smem_base.data_ptr() + self.order_p01_alloc.offset,
+                mem_space=cute.AddressSpace.smem,
+            )
+        # Both barriers start at parity 0. Local phase tracks the parity we
+        # expect to WAIT AGAINST on our own barrier (the one the peer arrives
+        # on). ``mbarrier_wait(phase)`` returns when barrier parity != phase,
+        # so init phase 0 makes iter 0's wait block until the peer's first
+        # arrive flips the barrier, which is the correct behavior for
+        # ordering our STTM(P_own) after the peer's LDTM(S_peer).
+        self._order_p01_phase = Int32(0)
+        if cutlass.const_expr(self._order_p01_barrier_ptr is not None):
+            self._init_order_p01_barriers()
+
+    @cute.jit
+    def _init_order_p01_barriers(self) -> None:
+        """Initialize the two mbarriers backing the OrderedSequence pair."""
+        warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx())
+        # softmax0 warp 2 initializes barrier 0 (waited on by softmax0);
+        # softmax1 warp 2 initializes barrier 1 (waited on by softmax1).
+        bar_init_warp = Int32(
+            self.cfg.softmax0_warp_ids[2]
+            if self.inst_id == 0
+            else self.cfg.softmax1_warp_ids[2]
+        )
+        if warp_idx == bar_init_warp:
+            with cute.arch.elect_one():
+                cute.arch.mbarrier_init(
+                    self._order_p01_barrier_ptr + self.inst_id,
+                    Int32(128),
+                )
+        cute.arch.mbarrier_init_fence()
+        prims.barrier_cta_sync(
+            self.cfg.tmem_bar_id,
+            thread_count=self.cfg.block_warps * cute.arch.WARP_SIZE,
+        )
+
+    @cute.jit
+    def _order_p01_wait(self) -> None:
+        """Block until the peer has finished LDTM(S_peer); then advance phase.
+
+        Softmax(i) must call this before STTM(P_i) so the peer's LDTM(S_peer)
+        on the aliased physical TMEM columns has finished. Called indirectly
+        as ``sp._tp_ref._order_p01_wait()`` from inside
+        :meth:`TmemSPResource.exp2_p` / :meth:`TmemSPResource.masked_exp2_p`.
+
+        Phase discipline: we wait on ``barrier[inst_id]``, which the peer
+        arrives on. ``mbarrier_wait(phase)`` returns when barrier parity has
+        FLIPPED away from ``phase``, so the local phase XORs AFTER wait
+        completes. Both peers start at phase 0 (matching the barriers'
+        initial parity); see d873ed31 for the XOR-on-wait rationale.
+        """
+        if cutlass.const_expr(self._order_p01_barrier_ptr is not None):
+            cute.arch.mbarrier_wait(
+                self._order_p01_barrier_ptr + self.inst_id,
+                self._order_p01_phase,
+            )
+            self._order_p01_phase = self._order_p01_phase ^ Int32(1)
+
+    @cute.jit
+    def _order_p01_arrive(self) -> None:
+        """Signal the peer that LDTM(S_own) is finished.
+
+        Called indirectly as ``sp._tp_ref._order_p01_arrive()`` from inside
+        the row_max work methods on :class:`TmemSPResource` (compute_row_max,
+        masked_row_max, and their loop/tail variants) once LDTM(S_own) has
+        drained. Arrival unblocks the peer's :meth:`_order_p01_wait` before
+        it starts STTM(P_peer) on the aliased columns.
+
+        Does NOT touch local phase: local phase tracks
+        ``barrier[inst_id]``, which is arrived on by the peer, not by us.
+        """
+        if cutlass.const_expr(self._order_p01_barrier_ptr is not None):
+            peer_id = 1 - self.inst_id
+            cute.arch.mbarrier_arrive(self._order_p01_barrier_ptr + peer_id)
 
     @cute.jit
     def create_function_variables(self, context: Optional[Any] = None) -> Int32:
@@ -3869,8 +4103,21 @@ class TmemOResource(MemoryResource):
         LOOP iteration, since Softmax0's domain is N-2 but MMA's domain is N-1.
         The task domain pads partial final CTAs so this slot is always outside
         peer0's causal reach.
+
+        Under ``uses_qk_pv_interleaved_paired_schedule``
+        (``Qk0_Pv0_Qk1_Pv1``) HEAD carries no PV; each LOOP/TAIL iter issues
+        PV0 (``inst_idx=0`` → O0) and PV1 (``inst_idx=1`` → O1) on the same V
+        window, so the inst_idx-to-O mapping and first-write bookkeeping
+        differ from the historical schedule.
         """
-        if cutlass.const_expr(section == FmhaStage.Head):
+        if cutlass.const_expr(self.cfg.uses_qk_pv_interleaved_paired_schedule):
+            # Qk0_Pv0_Qk1_Pv1: inst_idx=0 writes O0, inst_idx=1 writes O1.
+            # First writes fall out of the dynamic scale_d branch below
+            # (LOOP iter 0 or TAIL when the loop domain is empty).
+            writes_o0 = inst_idx == 0
+            first_o0_write = False
+            first_o1_write_maybe = False
+        elif cutlass.const_expr(section == FmhaStage.Head):
             writes_o0 = True
             first_o0_write = True
             first_o1_write_maybe = False
@@ -3987,6 +4234,16 @@ class TmemOResource(MemoryResource):
                     scale_d = stage_info.loop_end > 0
                 elif cutlass.const_expr(section == FmhaStage.Loop):
                     scale_d = stage_info.loop_offset > 0
+                else:
+                    scale_d = False
+            elif cutlass.const_expr(self.cfg.uses_qk_pv_interleaved_paired_schedule):
+                # Interleaved paired schedule: HEAD has no PV, so LOOP iter 0
+                # or TAIL (when the LOOP domain is empty) is the first write
+                # for both O0 and O1.
+                if cutlass.const_expr(section == FmhaStage.Loop):
+                    scale_d = stage_info.loop_offset > 0
+                elif cutlass.const_expr(section == FmhaStage.Tail):
+                    scale_d = stage_info.loop_end > 0
                 else:
                     scale_d = False
             elif cutlass.const_expr(first_o0_write):

--- a/flashinfer/attention/prims_ts/kernels/fmha_context/fmha_tasks.py
+++ b/flashinfer/attention/prims_ts/kernels/fmha_context/fmha_tasks.py
@@ -1027,18 +1027,16 @@ def create_mma_task(
                     skv.release()
                     skv.release()
 
-                # TAIL: both PVs on V_{n-1} (no QK). Empty sp matches Softmax
-                # TAIL drain: both peers if non-causal; peer0 only if causal
-                # (drop peer0 pair → TAIL correction regress).
+                # TAIL: both PVs on V_{n-1} (no QK). Non-causal drains an empty
+                # sp0+sp1 pair to match Softmax's TAIL. The causal branch drains
+                # neither: peer0/peer1 stay paired through the to/tp handshake
+                # alone (verified deadlock-free on SM103a, incl. the
+                # skip_causal_invalid_peer0 geometry).
                 skv.wait()
                 desc_v_base = skv.v_desc()
                 if cutlass.const_expr(
                     smem_q.cfg.uses_qk_pv_interleaved_causal_paired_schedule
                 ):
-                    # Peer0 empty S slot, kept even when PV0 is elided so sp0
-                    # stays paired with Softmax0's ghost slot.
-                    sp0.acquire()
-                    sp0.commit()
                     # Peer0 PV0 over V_{n-1}: math is a constexpr no-op under
                     # skip_causal_invalid_peer0, but the to/tp0 handshake still
                     # cycles to stay paired with Softmax0's ghost and Correction.
@@ -1928,17 +1926,8 @@ def create_softmax_task(
                 )
                 vec.commit()
             elif tmem_sp.cfg.uses_qk_pv_interleaved_causal_paired_schedule:
-                # Causal TAIL. Peer0's masked row-max must read the REAL last
-                # causal tile S, which MMA commits from its last LOOP sp0 slot;
-                # the empty peer0 slot that matches MMA's TAIL sp0.acquire/commit
-                # is drained AFTER the masked slot (below) so FIFO sp0 binding
-                # lines up: masked <- MMA LOOP[last], empty <- MMA TAIL. Draining
-                # it *before* masked would swap the binding -- masked would read
-                # MMA's empty TAIL slot while the real last-tile S is silently
-                # consumed -- which both corrupts the result and desynchronises
-                # the peer0/peer1 OrderedSequence phase. This mirrors the
-                # skip_causal_invalid_peer0 layout, where the empty slot likewise
-                # trails the ghost slot.
+                # Causal TAIL: masked wait binds to MMA's last LOOP sp commit.
+                # No empty TAIL sp drain.
                 sp.wait()
                 old_row_max, row_max = sp.masked_row_max(
                     row_max=row_max,
@@ -2010,22 +1999,6 @@ def create_softmax_task(
                         tp.commit()
                     if s0s1_seq is not None:
                         seq.commit()
-                    sp.release()
-                if tmem_sp.uses_query_paired_invalid_tail:
-                    # Peer0's empty TAIL S slot (consumes MMA's TAIL
-                    # sp0.acquire/commit), no OrderedSequence/tp -- the tile is
-                    # fully elided so there is no P to order. Placed AFTER the
-                    # ghost so the ghost binds to MMA's early LOOP commit; see the
-                    # Causal TAIL note above.
-                    sp.wait()
-                    sp.release()
-                elif index == 0:
-                    # Non-skip peer0: same empty TAIL S slot as the skip case,
-                    # but there is no ghost slot in front of it. It trails the
-                    # masked slot so masked binds to MMA's real last LOOP sp0
-                    # commit and this drain binds to MMA's empty TAIL commit. No
-                    # OrderedSequence/tp: nothing real is produced here.
-                    sp.wait()
                     sp.release()
                 old_row_max = sp.softmax_aux_identity(row_max=row_max)
                 vec.acquire()

--- a/flashinfer/attention/prims_ts/kernels/fmha_context/fmha_tasks.py
+++ b/flashinfer/attention/prims_ts/kernels/fmha_context/fmha_tasks.py
@@ -650,6 +650,7 @@ def create_mma_task(
     tmem_sp0: TmemSPResource,
     tmem_sp1: TmemSPResource | None,
     tmem_p0: TmemPResource | None,
+    tmem_p1: TmemPResource | None,
     tmem_o: TmemOResource,
     tmem_vec_done_0: TmemStatsDoneResource,
     tmem_vec_done_1: TmemStatsDoneResource | None,
@@ -898,6 +899,215 @@ def create_mma_task(
 
     if tmem_sp1 is None or tmem_vec_done_1 is None:
         raise ValueError("paired MMA scheduling requires peer-1 resources")
+
+    if smem_q.cfg.uses_qk_pv_interleaved_paired_schedule:
+        if tmem_p0 is None or tmem_p1 is None:
+            raise ValueError(
+                "interleaved paired MMA scheduling requires TmemP pipeline resources"
+            )
+        split_src = _src_resources(
+            smem_q,
+            smem_kv,
+            tmem_p0,
+            tmem_p1,
+            work_queue=work_queue,
+        )
+
+        @schedule
+        def mma_schedule(
+            sq: SmemQResource,
+            skv: SmemKVResource,
+            sp0: TmemSPResource,
+            sp1: TmemSPResource,
+            tp0: TmemPResource,
+            tp1: TmemPResource,
+            to: TmemOResource,
+            vd0: TmemStatsDoneResource,
+            vd1: TmemStatsDoneResource,
+            wq: WorkQueue | None = None,
+        ) -> None:
+            """Interleaved ``Qk0_Pv0_Qk1_Pv1`` paired MMA schedule.
+
+            HEAD issues QK(Q0,K0)->S0 and QK(Q1,K0)->S1 with no PV. Each LOOP
+            iter processes V_i and K_{i+1} and issues the four MMAs strictly
+            in order QK0 -> PV0 -> QK1 -> PV1. Under the cross-alias TMEM
+            layout, softmaxi's P store lives in the physical columns that
+            the OTHER peer's S read consumed, so PVi must gate on softmaxi's
+            fresh P via a dedicated ``tpi`` producer/consumer barrier that
+            is independent from ``spi``. Sequencing per iter:
+
+                sp0.acquire ; QK0 ; sp0.commit  (S0 handed off to softmax0)
+                to.acquire ; tp0.wait ; PV0 ; to.commit ; tp0.release
+                sp1.acquire ; QK1 ; sp1.commit  (S1 handed off to softmax1)
+                to.acquire ; tp1.wait ; PV1 ; to.commit ; tp1.release
+
+            V_i is locked once and consumed by both PVs. TAIL processes
+            V_{n-1} with both PV0 and PV1 (no further QK). The intra-warp
+            UMMA async queue preserves the serial issue order, which is
+            what guarantees the QK1 write does not clobber the P0 slot
+            until PV0 has consumed it (and symmetrically for QK0(N+1) vs P1).
+            """
+            sq.init_descriptor_state()
+            skv.init_descriptor_state()
+            sp0.init_mma_state()
+            sp1.init_mma_state()
+            to.init_mma_state()
+            with _work_tile_schedule_loop(wq, skip_if=skip_work_tile_if):
+                # HEAD: consume Q0, Q1, K0 and issue both QKs. No PV -- both
+                # PVs live in LOOP/TAIL to share a single V lock per iter.
+                sq.wait()
+                desc_q0_base = sq.q0_desc(inst_idx=0)
+                skv.wait()
+                desc_k_base = skv.k_desc()
+                if not smem_q.cfg.stats_via_smem:
+                    vd0.acquire()
+                sp0.acquire()
+                sp0.qk_mma(
+                    desc_q_base=desc_q0_base,
+                    desc_k_base=desc_k_base,
+                    section=FmhaStage.Head,
+                )
+                sp0.commit()
+                if not smem_q.cfg.stats_via_smem:
+                    vd0.commit()
+                sq.wait()
+                desc_q1_base = sq.q1_desc(inst_idx=1)
+                if not smem_q.cfg.stats_via_smem:
+                    vd1.acquire()
+                sp1.acquire()
+                sp1.qk_mma(
+                    desc_q_base=desc_q1_base,
+                    desc_k_base=desc_k_base,
+                    section=FmhaStage.Head,
+                )
+                sp1.commit()
+                if not smem_q.cfg.stats_via_smem:
+                    vd1.commit()
+                # Release K0; V_0 is next.
+                skv.release()
+
+                # LOOP: serial QK0 -> PV0 -> QK1 -> PV1. Each PVi waits on
+                # its own tpi (softmax's P0/P1 store) so cross-alias writes
+                # on the shared physical columns cannot race the reads.
+                with domain_loop(loop_start, loop_end, loop_step):
+                    # Wait V_i then K_{i+1} up-front (FIFO w.r.t. load pipe).
+                    skv.wait()
+                    desc_v_base = skv.v_desc()
+                    skv.wait()
+                    desc_k_base = skv.k_desc()
+
+                    # QK0(Q0, K_{i+1}) -> S0.
+                    sp0.acquire()
+                    sp0.qk_mma(
+                        desc_q_base=desc_q0_base,
+                        desc_k_base=desc_k_base,
+                        section=FmhaStage.Loop,
+                    )
+                    sp0.commit()
+                    # PV0(V_i): P0 * V_i -> O0. tp0 gates on softmax0's P0
+                    # store; release tp0 once the UMMA has consumed P0.
+                    to.acquire()
+                    tp0.wait()
+                    to.pv_mma(
+                        desc_v_base=desc_v_base,
+                        section=FmhaStage.Loop,
+                        inst_idx=0,
+                    )
+                    to.commit()
+                    tp0.release()
+
+                    # QK1(Q1, K_{i+1}) -> S1. Follows PV0 in the MMA queue,
+                    # which is what prevents QK1 from clobbering P0's slot
+                    # before PV0 has drained it.
+                    sp1.acquire()
+                    sp1.qk_mma(
+                        desc_q_base=desc_q1_base,
+                        desc_k_base=desc_k_base,
+                        section=FmhaStage.Loop,
+                    )
+                    sp1.commit()
+                    # PV1(V_i): P1 * V_i -> O1 (same V window as PV0).
+                    to.acquire()
+                    tp1.wait()
+                    to.pv_mma(
+                        desc_v_base=desc_v_base,
+                        section=FmhaStage.Loop,
+                        inst_idx=1,
+                    )
+                    to.commit()
+                    tp1.release()
+
+                    # FIFO release order: V_i first, then K_{i+1}.
+                    skv.release()
+                    skv.release()
+
+                # TAIL: V_{n-1} feeds both PV0 and PV1 (no further QK).
+                #
+                # Softmax's non-causal TAIL emits an extra sp.wait/sp.release
+                # to close its stats slot (see :func:`_paired_softmax_body` —
+                # non-causal else-branch calls ``sp.wait(); sp.release()``
+                # before writing the final stats). That extra wait/release
+                # needs a matching producer acquire+commit from MMA — the
+                # legacy ``Pv0_Qk0_Pv1_Qk1`` schedule provided it implicitly
+                # via the deferred SP-commit pattern (``sp0.commit`` /
+                # ``sp1.commit`` in its TAIL). This schedule handles P via
+                # ``tpi``, so we issue the closing sp acquire+commit here
+                # explicitly, once per instance.
+                skv.wait()
+                desc_v_base = skv.v_desc()
+                sp0.acquire()
+                sp0.commit()
+                to.acquire()
+                tp0.wait()
+                to.pv_mma(
+                    desc_v_base=desc_v_base,
+                    section=FmhaStage.Tail,
+                    inst_idx=0,
+                    is_tail=True,
+                )
+                to.commit()
+                tp0.release()
+                sp1.acquire()
+                sp1.commit()
+                to.acquire()
+                tp1.wait()
+                to.pv_mma(
+                    desc_v_base=desc_v_base,
+                    section=FmhaStage.Tail,
+                    inst_idx=1,
+                    is_tail=True,
+                )
+                to.commit()
+                tp1.release()
+                skv.release()
+                # Release Q0, Q1 (held live across every K tile).
+                sq.release()
+                sq.release()
+
+        captured_schedule = _schedule_with_work_queue(
+            mma_schedule,
+            smem_q,
+            smem_kv,
+            tmem_sp0,
+            tmem_sp1,
+            tmem_p0,
+            tmem_p1,
+            tmem_o,
+            tmem_vec_done_0,
+            tmem_vec_done_1,
+            work_queue=work_queue,
+        )
+        return task_class(
+            src_resources=split_src,
+            dst_resources=[tmem_sp0, tmem_sp1, tmem_o]
+            + ([] if smem_q.cfg.stats_via_smem else [tmem_vec_done_0, tmem_vec_done_1]),
+            warp_idx=12,
+            num_warps=1,
+            schedule=captured_schedule,
+            name="MmaTask",
+            num_registers=smem_q.cfg.num_regs_other,
+            **task_kwargs,
+        )
 
     @schedule
     def mma_schedule(
@@ -1524,23 +1734,53 @@ def create_softmax_task(
         )
 
     # Paired QKV instances use separate SP resources. S0S1SequenceResource
-    # orders their P stores, so this path does not need the TMEM P handoff.
+    # orders their P stores across peers. Under the interleaved paired
+    # (``Qk0_Pv0_Qk1_Pv1``) schedule, each softmax also drives a dedicated
+    # ``tp`` producer barrier so that PV(i) can wait on softmax(i)'s exp2_p
+    # store; this is required because softmax(i) writes P(i) into physical
+    # TMEM columns that live inside the OTHER peer's S range (cross-alias
+    # layout).
+    p_pipeline_enabled = tmem_p is not None
+
     if s0s1_seq is not None and index == 1:
         src = _src_resources(tmem_sp, s0s1_seq, work_queue=work_queue)
     else:
         src = _src_resources(tmem_sp, work_queue=work_queue)
     dst = [tmem_vec]
+    if p_pipeline_enabled:
+        dst.append(tmem_p)
     if s0s1_seq is not None and index == 0:
         dst.append(s0s1_seq)
 
-    @schedule
-    def softmax_schedule(
+    def _paired_softmax_body(
         sp: TmemSPResource,
         vec: TmemStatsResource,
+        tp: TmemPResource | None,
         seq: S0S1SequenceResource,
-        wq: WorkQueue | None = None,
+        wq: WorkQueue | None,
     ) -> None:
-        """Captured schedule for one softmax warp group."""
+        """Shared body for the paired softmax schedule.
+
+        Two synchronization layers apply under the interleaved paired
+        schedule (``tp is not None``); both are owned by this body:
+
+        1. Outer producer-consumer pipeline: each ``exp2_p`` /
+           ``masked_exp2_p`` is wrapped in ``tp.acquire`` / ``tp.commit``
+           so PV(i) can gate on softmax(i) finishing its P store.
+        2. Cross-alias TMEM ordering (OrderP01): STTM(P_i) must not run
+           while the peer is still doing LDTM(S_peer) on the same
+           physical columns. This body calls
+           ``sp.order_p01_arrive_if_paired()`` immediately after every
+           ``*_row_max`` (LDTM(S_own) done, peer may start STTM(P_peer))
+           and ``sp.order_p01_wait_if_paired()`` immediately before every
+           ``*_exp2_p`` (block until peer's LDTM(S_peer) done, then
+           STTM(P_own)). Both fold to no-ops at trace time when the
+           schedule is not interleaved (``sp._tp_ref is None``).
+
+        ``invalid_exp2_p`` skips both LDTM and STTM, and MMA elides the
+        matching PV for the invalid peer tail, so it is deliberately
+        unfenced.
+        """
         if tmem_sp.enable_early_tile_sum:
             # The contribution is produced and consumed inside each iteration;
             # do not carry even the scalar tile sum through the persistent loop.
@@ -1590,6 +1830,8 @@ def create_softmax_task(
                     )
                 else:
                     old_row_max, row_max = sp.compute_row_max(row_max=row_max)
+                # LDTM(S_own) is complete; signal the OrderP01 peer.
+                sp.order_p01_arrive_if_paired()
                 vec.store_vec(
                     old_row_max=old_row_max,
                     row_max=row_max,
@@ -1604,11 +1846,18 @@ def create_softmax_task(
                 else:
                     # Softmax1 is the S0-S1 consumer: wait/release sequence.
                     seq.wait()
-                # Apply softmax and write P.
+                # Apply softmax and write P (cross-alias P store under the
+                # interleaved paired schedule): wait for the peer's LDTM(S_peer)
+                # before STTM(P_own).
+                if tp is not None:
+                    tp.acquire()
+                sp.order_p01_wait_if_paired()
                 p_chunk = sp.exp2_p(
                     row_max=row_max,
                     scale_softmax_log2=scale_softmax_log2,
                 )
+                if tp is not None:
+                    tp.commit()
                 if s0s1_seq is None:
                     pass
                 elif index == 0:
@@ -1637,6 +1886,7 @@ def create_softmax_task(
                     q_offset=q_offset,
                     section=FmhaStage.Tail,
                 )
+                sp.order_p01_arrive_if_paired()
                 vec.store_vec(
                     old_row_max=old_row_max,
                     row_max=row_max,
@@ -1649,10 +1899,15 @@ def create_softmax_task(
                     seq.acquire()
                 else:
                     seq.wait()
+                if tp is not None:
+                    tp.acquire()
+                sp.order_p01_wait_if_paired()
                 p_chunk = sp.exp2_p(
                     row_max=row_max,
                     scale_softmax_log2=scale_softmax_log2,
                 )
+                if tp is not None:
+                    tp.commit()
                 if s0s1_seq is None:
                     pass
                 elif index == 0:
@@ -1687,6 +1942,7 @@ def create_softmax_task(
                     row_max=row_max,
                     q_offset=q_offset,
                 )
+                sp.order_p01_arrive_if_paired()
                 vec.store_vec(
                     old_row_max=old_row_max,
                     row_max=row_max,
@@ -1695,10 +1951,15 @@ def create_softmax_task(
                 vec.commit()
                 if s0s1_seq is not None:
                     seq.acquire()
+                if tp is not None:
+                    tp.acquire()
+                sp.order_p01_wait_if_paired()
                 p_chunk = sp.masked_exp2_p(
                     row_max=row_max,
                     scale_softmax_log2=scale_softmax_log2,
                 )
+                if tp is not None:
+                    tp.commit()
                 if s0s1_seq is not None:
                     seq.commit()
                 sp.release()
@@ -1721,6 +1982,8 @@ def create_softmax_task(
                     vec.commit()
                     if s0s1_seq is not None:
                         seq.acquire()
+                    # invalid_exp2_p is a no-op; MMA elides the matching PV so
+                    # no tp handshake is needed for this padded peer slot.
                     sp.invalid_exp2_p(row_max=row_max)
                     if s0s1_seq is not None:
                         seq.commit()
@@ -1743,6 +2006,7 @@ def create_softmax_task(
                     row_max=row_max,
                     q_offset=q_offset,
                 )
+                sp.order_p01_arrive_if_paired()
                 vec.store_vec(
                     old_row_max=old_row_max,
                     row_max=row_max,
@@ -1751,10 +2015,15 @@ def create_softmax_task(
                 vec.commit()
                 if s0s1_seq is not None:
                     seq.wait()
+                if tp is not None:
+                    tp.acquire()
+                sp.order_p01_wait_if_paired()
                 p_chunk = sp.masked_exp2_p(
                     row_max=row_max,
                     scale_softmax_log2=scale_softmax_log2,
                 )
+                if tp is not None:
+                    tp.commit()
                 if s0s1_seq is not None:
                     seq.release()
                 sp.release()
@@ -1790,9 +2059,42 @@ def create_softmax_task(
                 )
                 vec.commit()
 
-    captured_schedule = _schedule_with_work_queue(
-        softmax_schedule, tmem_sp, tmem_vec, s0s1_seq, work_queue=work_queue
-    )
+    if p_pipeline_enabled:
+
+        @schedule
+        def softmax_schedule(
+            sp: TmemSPResource,
+            vec: TmemStatsResource,
+            tp: TmemPResource,
+            seq: S0S1SequenceResource,
+            wq: WorkQueue | None = None,
+        ) -> None:
+            """Interleaved paired softmax schedule: publishes P through tp."""
+            _paired_softmax_body(sp, vec, tp, seq, wq)
+
+        captured_schedule = _schedule_with_work_queue(
+            softmax_schedule,
+            tmem_sp,
+            tmem_vec,
+            tmem_p,
+            s0s1_seq,
+            work_queue=work_queue,
+        )
+    else:
+
+        @schedule
+        def softmax_schedule(
+            sp: TmemSPResource,
+            vec: TmemStatsResource,
+            seq: S0S1SequenceResource,
+            wq: WorkQueue | None = None,
+        ) -> None:
+            """Legacy paired softmax schedule: P stores are ordered via seq."""
+            _paired_softmax_body(sp, vec, None, seq, wq)
+
+        captured_schedule = _schedule_with_work_queue(
+            softmax_schedule, tmem_sp, tmem_vec, s0s1_seq, work_queue=work_queue
+        )
     return task_class(
         src_resources=src,
         dst_resources=dst,

--- a/flashinfer/attention/prims_ts/kernels/fmha_context/fmha_tasks.py
+++ b/flashinfer/attention/prims_ts/kernels/fmha_context/fmha_tasks.py
@@ -928,24 +928,10 @@ def create_mma_task(
         ) -> None:
             """Interleaved ``Qk0_Pv0_Qk1_Pv1`` paired MMA schedule.
 
-            HEAD issues QK(Q0,K0)->S0 and QK(Q1,K0)->S1 with no PV. Each LOOP
-            iter processes V_i and K_{i+1} and issues the four MMAs strictly
-            in order QK0 -> PV0 -> QK1 -> PV1. Under the cross-alias TMEM
-            layout, softmaxi's P store lives in the physical columns that
-            the OTHER peer's S read consumed, so PVi must gate on softmaxi's
-            fresh P via a dedicated ``tpi`` producer/consumer barrier that
-            is independent from ``spi``. Sequencing per iter:
-
-                sp0.acquire ; QK0 ; sp0.commit  (S0 handed off to softmax0)
-                to.acquire ; tp0.wait ; PV0 ; to.commit ; tp0.release
-                sp1.acquire ; QK1 ; sp1.commit  (S1 handed off to softmax1)
-                to.acquire ; tp1.wait ; PV1 ; to.commit ; tp1.release
-
-            V_i is locked once and consumed by both PVs. TAIL processes
-            V_{n-1} with both PV0 and PV1 (no further QK). The intra-warp
-            UMMA async queue preserves the serial issue order, which is
-            what guarantees the QK1 write does not clobber the P0 slot
-            until PV0 has consumed it (and symmetrically for QK0(N+1) vs P1).
+            HEAD: QK0/QK1 only. LOOP/TAIL: ``QK0 -> PV0 -> QK1 -> PV1`` with
+            one V lock per iter (TAIL reuses ``V_{n-1}``, no QK). ``tpi`` gates
+            PVi on softmaxi P (cross-alias; independent of ``spi``). UMMA issue
+            order keeps QK1 from clobbering P0 before PV0 (and symmetrically).
             """
             sq.init_descriptor_state()
             skv.init_descriptor_state()
@@ -1041,45 +1027,63 @@ def create_mma_task(
                     skv.release()
                     skv.release()
 
-                # TAIL: V_{n-1} feeds both PV0 and PV1 (no further QK).
-                #
-                # Softmax's non-causal TAIL emits an extra sp.wait/sp.release
-                # to close its stats slot (see :func:`_paired_softmax_body` —
-                # non-causal else-branch calls ``sp.wait(); sp.release()``
-                # before writing the final stats). That extra wait/release
-                # needs a matching producer acquire+commit from MMA — the
-                # legacy ``Pv0_Qk0_Pv1_Qk1`` schedule provided it implicitly
-                # via the deferred SP-commit pattern (``sp0.commit`` /
-                # ``sp1.commit`` in its TAIL). This schedule handles P via
-                # ``tpi``, so we issue the closing sp acquire+commit here
-                # explicitly, once per instance.
+                # TAIL: both PVs on V_{n-1} (no QK). Empty sp matches Softmax
+                # TAIL drain: both peers if non-causal; peer0 only if causal
+                # (drop peer0 pair → TAIL correction regress).
                 skv.wait()
                 desc_v_base = skv.v_desc()
-                sp0.acquire()
-                sp0.commit()
-                to.acquire()
-                tp0.wait()
-                to.pv_mma(
-                    desc_v_base=desc_v_base,
-                    section=FmhaStage.Tail,
-                    inst_idx=0,
-                    is_tail=True,
-                )
-                to.commit()
-                tp0.release()
-                sp1.acquire()
-                sp1.commit()
-                to.acquire()
-                tp1.wait()
-                to.pv_mma(
-                    desc_v_base=desc_v_base,
-                    section=FmhaStage.Tail,
-                    inst_idx=1,
-                    is_tail=True,
-                )
-                to.commit()
-                tp1.release()
-                skv.release()
+                if cutlass.const_expr(
+                    smem_q.cfg.uses_qk_pv_interleaved_causal_paired_schedule
+                ):
+                    sp0.acquire()
+                    sp0.commit()
+                    to.acquire()
+                    tp0.wait()
+                    to.pv_mma(
+                        desc_v_base=desc_v_base,
+                        section=FmhaStage.Tail,
+                        inst_idx=0,
+                        is_tail=True,
+                    )
+                    to.commit()
+                    tp0.release()
+                    to.acquire()
+                    tp1.wait()
+                    to.pv_mma(
+                        desc_v_base=desc_v_base,
+                        section=FmhaStage.Tail,
+                        inst_idx=1,
+                        is_tail=True,
+                    )
+                    to.commit()
+                    tp1.release()
+                    skv.release()
+                else:
+                    sp0.acquire()
+                    sp0.commit()
+                    to.acquire()
+                    tp0.wait()
+                    to.pv_mma(
+                        desc_v_base=desc_v_base,
+                        section=FmhaStage.Tail,
+                        inst_idx=0,
+                        is_tail=True,
+                    )
+                    to.commit()
+                    tp0.release()
+                    sp1.acquire()
+                    sp1.commit()
+                    to.acquire()
+                    tp1.wait()
+                    to.pv_mma(
+                        desc_v_base=desc_v_base,
+                        section=FmhaStage.Tail,
+                        inst_idx=1,
+                        is_tail=True,
+                    )
+                    to.commit()
+                    tp1.release()
+                    skv.release()
                 # Release Q0, Q1 (held live across every K tile).
                 sq.release()
                 sq.release()
@@ -1733,13 +1737,8 @@ def create_softmax_task(
             **task_kwargs,
         )
 
-    # Paired QKV instances use separate SP resources. S0S1SequenceResource
-    # orders their P stores across peers. Under the interleaved paired
-    # (``Qk0_Pv0_Qk1_Pv1``) schedule, each softmax also drives a dedicated
-    # ``tp`` producer barrier so that PV(i) can wait on softmax(i)'s exp2_p
-    # store; this is required because softmax(i) writes P(i) into physical
-    # TMEM columns that live inside the OTHER peer's S range (cross-alias
-    # layout).
+    # Paired: separate SP per peer. Interleaved also needs dedicated ``tp``
+    # so PVi waits on Softmaxi P (cross-alias into the other peer's S columns).
     p_pipeline_enabled = tmem_p is not None
 
     if s0s1_seq is not None and index == 1:
@@ -1761,25 +1760,11 @@ def create_softmax_task(
     ) -> None:
         """Shared body for the paired softmax schedule.
 
-        Two synchronization layers apply under the interleaved paired
-        schedule (``tp is not None``); both are owned by this body:
-
-        1. Outer producer-consumer pipeline: each ``exp2_p`` /
-           ``masked_exp2_p`` is wrapped in ``tp.acquire`` / ``tp.commit``
-           so PV(i) can gate on softmax(i) finishing its P store.
-        2. Cross-alias TMEM ordering (OrderP01): STTM(P_i) must not run
-           while the peer is still doing LDTM(S_peer) on the same
-           physical columns. This body calls
-           ``sp.order_p01_arrive_if_paired()`` immediately after every
-           ``*_row_max`` (LDTM(S_own) done, peer may start STTM(P_peer))
-           and ``sp.order_p01_wait_if_paired()`` immediately before every
-           ``*_exp2_p`` (block until peer's LDTM(S_peer) done, then
-           STTM(P_own)). Both fold to no-ops at trace time when the
-           schedule is not interleaved (``sp._tp_ref is None``).
-
-        ``invalid_exp2_p`` skips both LDTM and STTM, and MMA elides the
-        matching PV for the invalid peer tail, so it is deliberately
-        unfenced.
+        Under interleaved (``tp is not None``): ``tp.acquire/commit`` around
+        ``*_exp2_p`` so PV waits on P; OrderedSequence arrive after ``*_row_max``
+        / wait before ``*_exp2_p`` so STTM(P) follows peer LDTM(S) on aliased
+        columns (no-ops when ``sp._tp_ref is None``). ``invalid_exp2_p`` skips
+        both and stays unfenced (MMA elides the matching PV).
         """
         if tmem_sp.enable_early_tile_sum:
             # The contribution is produced and consumed inside each iteration;
@@ -1788,6 +1773,10 @@ def create_softmax_task(
         else:
             p_chunk = sp.init_softmax_state()
         scale_softmax_log2 = sp.load_scale_softmax_log2()
+        # Consume the pre-planted 128-arrive credit so iter 0's cross-alias
+        # handshake is primed before the first STTM(P_own). No-op when the
+        # schedule is not interleaved (sp._tp_ref is None).
+        sp.ordered_sequence_wait_if_paired()
         vec.init_store_state()
         with _work_tile_schedule_loop(wq, skip_if=skip_work_tile_if):
             # Recompute per-tile SP/Vec TMEM state.
@@ -1830,8 +1819,8 @@ def create_softmax_task(
                     )
                 else:
                     old_row_max, row_max = sp.compute_row_max(row_max=row_max)
-                # LDTM(S_own) is complete; signal the OrderP01 peer.
-                sp.order_p01_arrive_if_paired()
+                # LDTM(S_own) is complete; signal the OrderedSequence peer.
+                sp.ordered_sequence_arrive_if_paired()
                 vec.store_vec(
                     old_row_max=old_row_max,
                     row_max=row_max,
@@ -1851,7 +1840,7 @@ def create_softmax_task(
                 # before STTM(P_own).
                 if tp is not None:
                     tp.acquire()
-                sp.order_p01_wait_if_paired()
+                sp.ordered_sequence_wait_if_paired()
                 p_chunk = sp.exp2_p(
                     row_max=row_max,
                     scale_softmax_log2=scale_softmax_log2,
@@ -1886,7 +1875,7 @@ def create_softmax_task(
                     q_offset=q_offset,
                     section=FmhaStage.Tail,
                 )
-                sp.order_p01_arrive_if_paired()
+                sp.ordered_sequence_arrive_if_paired()
                 vec.store_vec(
                     old_row_max=old_row_max,
                     row_max=row_max,
@@ -1901,7 +1890,7 @@ def create_softmax_task(
                     seq.wait()
                 if tp is not None:
                     tp.acquire()
-                sp.order_p01_wait_if_paired()
+                sp.ordered_sequence_wait_if_paired()
                 p_chunk = sp.exp2_p(
                     row_max=row_max,
                     scale_softmax_log2=scale_softmax_log2,
@@ -1933,6 +1922,68 @@ def create_softmax_task(
                     final_stats=True,
                 )
                 vec.commit()
+            elif tmem_sp.cfg.uses_qk_pv_interleaved_causal_paired_schedule:
+                # Causal TAIL. Peer 0 first drains an extra S slot (matched by
+                # MMA's peer-0 TAIL sp0.acquire/commit) before its masked
+                # row-max; dropping this regresses peer-0 TAIL correction. The
+                # OrderedSequence handshake below orders the cross-alias
+                # STTM(P) write.
+                if index == 0:
+                    sp.wait()
+                    sp.release()
+                sp.wait()
+                old_row_max, row_max = sp.masked_row_max(
+                    row_max=row_max,
+                    q_offset=q_offset,
+                )
+                # LDTM(S_own) is complete; signal the OrderedSequence peer.
+                sp.ordered_sequence_arrive_if_paired()
+                vec.store_vec(
+                    old_row_max=old_row_max,
+                    row_max=row_max,
+                    row_sum=row_sum,
+                )
+                vec.commit()
+                if s0s1_seq is None:
+                    pass
+                elif index == 0:
+                    seq.acquire()
+                else:
+                    seq.wait()
+                if tp is not None:
+                    tp.acquire()
+                # Wait for peer's LDTM(S_peer) before STTM(P_own) at the
+                # cross-alias column.
+                sp.ordered_sequence_wait_if_paired()
+                p_chunk = sp.masked_exp2_p(
+                    row_max=row_max,
+                    scale_softmax_log2=scale_softmax_log2,
+                )
+                if tp is not None:
+                    tp.commit()
+                if s0s1_seq is None:
+                    pass
+                elif index == 0:
+                    seq.commit()
+                else:
+                    seq.release()
+                sp.release()
+                row_sum = sp.softmax_aux_reduce(
+                    old_row_max=old_row_max,
+                    row_max=row_max,
+                    row_sum=row_sum,
+                    p_chunk=p_chunk,
+                    scale_softmax_log2=scale_softmax_log2,
+                )
+                old_row_max = sp.softmax_aux_identity(row_max=row_max)
+                vec.acquire()
+                vec.store_vec(
+                    old_row_max=old_row_max,
+                    row_max=row_max,
+                    row_sum=row_sum,
+                    final_stats=True,
+                )
+                vec.commit()
             elif tmem_sp.uses_query_paired_causal_tail_mask:
                 # Query-paired maps Q1 to the next S tile. Its generic causal
                 # tail uses masked_row_max(), which includes q_half * q_tile_m
@@ -1942,7 +1993,7 @@ def create_softmax_task(
                     row_max=row_max,
                     q_offset=q_offset,
                 )
-                sp.order_p01_arrive_if_paired()
+                sp.ordered_sequence_arrive_if_paired()
                 vec.store_vec(
                     old_row_max=old_row_max,
                     row_max=row_max,
@@ -1953,7 +2004,7 @@ def create_softmax_task(
                     seq.acquire()
                 if tp is not None:
                     tp.acquire()
-                sp.order_p01_wait_if_paired()
+                sp.ordered_sequence_wait_if_paired()
                 p_chunk = sp.masked_exp2_p(
                     row_max=row_max,
                     scale_softmax_log2=scale_softmax_log2,
@@ -2006,7 +2057,7 @@ def create_softmax_task(
                     row_max=row_max,
                     q_offset=q_offset,
                 )
-                sp.order_p01_arrive_if_paired()
+                sp.ordered_sequence_arrive_if_paired()
                 vec.store_vec(
                     old_row_max=old_row_max,
                     row_max=row_max,
@@ -2017,7 +2068,7 @@ def create_softmax_task(
                     seq.wait()
                 if tp is not None:
                     tp.acquire()
-                sp.order_p01_wait_if_paired()
+                sp.ordered_sequence_wait_if_paired()
                 p_chunk = sp.masked_exp2_p(
                     row_max=row_max,
                     scale_softmax_log2=scale_softmax_log2,
@@ -2058,6 +2109,11 @@ def create_softmax_task(
                     final_stats=True,
                 )
                 vec.commit()
+        # Peer 0 posts one closing arrive so peer 1's final wait_if_paired
+        # does not deadlock (barrier[1] is one flip short after barrier[0]-only
+        # pre-plant; barrier[0] already balances without a peer-1 closer).
+        if cutlass.const_expr(index == 0):
+            sp.ordered_sequence_arrive_if_paired()
 
     if p_pipeline_enabled:
 

--- a/flashinfer/attention/prims_ts/kernels/fmha_context/fmha_tasks.py
+++ b/flashinfer/attention/prims_ts/kernels/fmha_context/fmha_tasks.py
@@ -1035,8 +1035,13 @@ def create_mma_task(
                 if cutlass.const_expr(
                     smem_q.cfg.uses_qk_pv_interleaved_causal_paired_schedule
                 ):
+                    # Peer0 empty S slot, kept even when PV0 is elided so sp0
+                    # stays paired with Softmax0's ghost slot.
                     sp0.acquire()
                     sp0.commit()
+                    # Peer0 PV0 over V_{n-1}: math is a constexpr no-op under
+                    # skip_causal_invalid_peer0, but the to/tp0 handshake still
+                    # cycles to stay paired with Softmax0's ghost and Correction.
                     to.acquire()
                     tp0.wait()
                     to.pv_mma(
@@ -1923,12 +1928,13 @@ def create_softmax_task(
                 )
                 vec.commit()
             elif tmem_sp.cfg.uses_qk_pv_interleaved_causal_paired_schedule:
-                # Causal TAIL. Peer 0 first drains an extra S slot (matched by
-                # MMA's peer-0 TAIL sp0.acquire/commit) before its masked
-                # row-max; dropping this regresses peer-0 TAIL correction. The
-                # OrderedSequence handshake below orders the cross-alias
-                # STTM(P) write.
-                if index == 0:
+                # Causal TAIL. Non-skip peer0 drains an extra empty S slot here
+                # (matched by MMA's peer0 TAIL sp0.acquire/commit) before its
+                # masked row-max. Under skip_causal_invalid_peer0 that drain
+                # moves AFTER the ghost slot (below) so the ghost's sp.wait binds
+                # to MMA's early LOOP sp0 commit, avoiding the peer0/peer1
+                # OrderedSequence phase deadlock.
+                if index == 0 and not tmem_sp.uses_query_paired_invalid_tail:
                     sp.wait()
                     sp.release()
                 sp.wait()
@@ -1975,6 +1981,42 @@ def create_softmax_task(
                     p_chunk=p_chunk,
                     scale_softmax_log2=scale_softmax_log2,
                 )
+                if tmem_sp.uses_query_paired_invalid_tail:
+                    # Ghost slot for peer0's trailing fully-masked tile: MMA
+                    # elides the QK0/PV0 math but still cycles every barrier, so
+                    # replay the full peer0 handshake (sp/vec/s0s1_seq/
+                    # OrderedSequence/tp0) to stay paired. invalid_exp2_p writes
+                    # no real P; tp0 still fires so MMA's TAIL tp0.wait has a
+                    # producer.
+                    sp.wait()
+                    old_row_max, row_max = sp.invalid_row_max(row_max=row_max)
+                    sp.ordered_sequence_arrive_if_paired()
+                    vec.acquire()
+                    vec.store_vec(
+                        old_row_max=old_row_max,
+                        row_max=row_max,
+                        row_sum=row_sum,
+                    )
+                    vec.commit()
+                    if s0s1_seq is not None:
+                        seq.acquire()
+                    if tp is not None:
+                        tp.acquire()
+                    sp.ordered_sequence_wait_if_paired()
+                    sp.invalid_exp2_p(row_max=row_max)
+                    if tp is not None:
+                        tp.commit()
+                    if s0s1_seq is not None:
+                        seq.commit()
+                    sp.release()
+                if tmem_sp.uses_query_paired_invalid_tail:
+                    # Peer0's empty TAIL S slot (consumes MMA's TAIL
+                    # sp0.acquire/commit), no OrderedSequence/tp -- the tile is
+                    # fully elided so there is no P to order. Placed AFTER the
+                    # ghost so the ghost binds to MMA's early LOOP commit; see the
+                    # Causal TAIL note above.
+                    sp.wait()
+                    sp.release()
                 old_row_max = sp.softmax_aux_identity(row_max=row_max)
                 vec.acquire()
                 vec.store_vec(
@@ -2393,6 +2435,10 @@ def create_correction_task(
                     vd0.wait()
                     vd0.release()
                 v0.release()
+                # Peer0 TAIL O0 store. The MMA TAIL PV0 math is a no-op under
+                # skip_causal_invalid_peer0 but to.acquire/commit still fire, so
+                # keep the normal to.wait/release: the O0 accumulated from the
+                # LOOP's valid PV0 is what gets stored.
                 to.wait()
                 so0.acquire()
                 so0.store_o(

--- a/flashinfer/attention/prims_ts/kernels/fmha_context/fmha_tasks.py
+++ b/flashinfer/attention/prims_ts/kernels/fmha_context/fmha_tasks.py
@@ -1776,10 +1776,10 @@ def create_softmax_task(
         else:
             p_chunk = sp.init_softmax_state()
         scale_softmax_log2 = sp.load_scale_softmax_log2()
-        # Consume the pre-planted 128-arrive credit so iter 0's cross-alias
-        # handshake is primed before the first STTM(P_own). No-op when the
-        # schedule is not interleaved (sp._tp_ref is None).
-        sp.ordered_sequence_wait_if_paired()
+        # bar0 prime (peer0): same-tile handshake, so once per CTA outside the
+        # loop. bar1's is per-tile (below). No-op when not interleaved.
+        if cutlass.const_expr(index == 0):
+            sp.ordered_sequence_wait_if_paired()
         vec.init_store_state()
         with _work_tile_schedule_loop(wq, skip_if=skip_work_tile_if):
             # Recompute per-tile SP/Vec TMEM state.
@@ -1789,6 +1789,11 @@ def create_softmax_task(
                 q_offset = sp.cache_q_offset()
             if tmem_sp.uses_packed_dense_k_mask:
                 seqlen_k = sp.cache_seqlen_k()
+            # bar1 prime (peer1), per-tile: keeps its forward-skew credit off the
+            # loop-back edge -- the T>=2 deadlock. Peer0's closer (below) matches
+            # it; skip-wrapped so both drop together. No-op when not interleaved.
+            if cutlass.const_expr(index == 1):
+                sp.ordered_sequence_wait_if_paired()
             # Reserve a stats slot before the first softmax result is published.
             vec.acquire()
             with domain_loop(loop_start, loop_end, loop_step):
@@ -2134,11 +2139,11 @@ def create_softmax_task(
                     final_stats=True,
                 )
                 vec.commit()
-        # Peer 0 posts one closing arrive so peer 1's final wait_if_paired
-        # does not deadlock (barrier[1] is one flip short after barrier[0]-only
-        # pre-plant; barrier[0] already balances without a peer-1 closer).
-        if cutlass.const_expr(index == 0):
-            sp.ordered_sequence_arrive_if_paired()
+            # bar1 closer (peer0): matches peer1's per-tile prime. After the tail
+            # chain so it follows peer0's last LDTM(S0) (P1 aliases S0, WAR).
+            # No-op when not interleaved.
+            if cutlass.const_expr(index == 0):
+                sp.ordered_sequence_arrive_if_paired()
 
     if p_pipeline_enabled:
 

--- a/flashinfer/attention/prims_ts/kernels/fmha_context/fmha_tasks.py
+++ b/flashinfer/attention/prims_ts/kernels/fmha_context/fmha_tasks.py
@@ -1928,15 +1928,17 @@ def create_softmax_task(
                 )
                 vec.commit()
             elif tmem_sp.cfg.uses_qk_pv_interleaved_causal_paired_schedule:
-                # Causal TAIL. Non-skip peer0 drains an extra empty S slot here
-                # (matched by MMA's peer0 TAIL sp0.acquire/commit) before its
-                # masked row-max. Under skip_causal_invalid_peer0 that drain
-                # moves AFTER the ghost slot (below) so the ghost's sp.wait binds
-                # to MMA's early LOOP sp0 commit, avoiding the peer0/peer1
-                # OrderedSequence phase deadlock.
-                if index == 0 and not tmem_sp.uses_query_paired_invalid_tail:
-                    sp.wait()
-                    sp.release()
+                # Causal TAIL. Peer0's masked row-max must read the REAL last
+                # causal tile S, which MMA commits from its last LOOP sp0 slot;
+                # the empty peer0 slot that matches MMA's TAIL sp0.acquire/commit
+                # is drained AFTER the masked slot (below) so FIFO sp0 binding
+                # lines up: masked <- MMA LOOP[last], empty <- MMA TAIL. Draining
+                # it *before* masked would swap the binding -- masked would read
+                # MMA's empty TAIL slot while the real last-tile S is silently
+                # consumed -- which both corrupts the result and desynchronises
+                # the peer0/peer1 OrderedSequence phase. This mirrors the
+                # skip_causal_invalid_peer0 layout, where the empty slot likewise
+                # trails the ghost slot.
                 sp.wait()
                 old_row_max, row_max = sp.masked_row_max(
                     row_max=row_max,
@@ -2015,6 +2017,14 @@ def create_softmax_task(
                     # fully elided so there is no P to order. Placed AFTER the
                     # ghost so the ghost binds to MMA's early LOOP commit; see the
                     # Causal TAIL note above.
+                    sp.wait()
+                    sp.release()
+                elif index == 0:
+                    # Non-skip peer0: same empty TAIL S slot as the skip case,
+                    # but there is no ghost slot in front of it. It trails the
+                    # masked slot so masked binds to MMA's real last LOOP sp0
+                    # commit and this drain binds to MMA's empty TAIL commit. No
+                    # OrderedSequence/tp: nothing real is produced here.
                     sp.wait()
                     sp.release()
                 old_row_max = sp.softmax_aux_identity(row_max=row_max)


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

Adds the interleaved `Qk0_Pv0_Qk1_Pv1` paired MMA order for the PrimTS task-scheduled FMHA context kernels, extends it to causal and paged-KV cases, and fixes several deadlock / correctness issues found on Blackwell (SM103a / B300A).

**Commits (6):**

- **feat(fmha-context): MR-872 Qk0_Pv0_Qk1_Pv1 paired MMA order** — introduce the paired MMA ordering.
- **feat(fmha-context): extend Qk0_Pv0_Qk1_Pv1 to causal and paged KV** — support causal masking and paged KV under the new order.
- **feat(fmha-context): skip_causal_invalid_peer0 in Qk0_Pv0_Qk1_Pv1** — skip invalid peer0 tiles in causal.
- **fix(fmha-context): run non-aligned k>q causal in Qk0_Pv0_Qk1_Pv1** — resolve a FIFO sp0 binding bug so non-tile-aligned bottom-right causal offsets run on the interleaved order instead of falling back to the legacy `Pv0Qk0Pv1Qk1` path.
- **refactor(fmha-context): drop balanced empty peer0 sp slot in causal TAIL** — remove a no-data producer/consumer pair in lockstep, keeping the sp0 FIFO balanced.
- **fix(fmha-context): per-tile bar1 handshake fixes T>=2 interleaved deadlock** — split the bar0/bar1 handshakes by peer and scope so the bar1 forward-skew credit is consumed within each work tile and never crosses the persistent loop-back edge.

**Files changed (5):** `context.py`, `fmha_context/README.md`, `fmha_context/fmha_kernel.py`, `fmha_context/fmha_resources.py`, `fmha_context/fmha_tasks.py`.

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

Per the commit messages, changes were verified on B300A (SM103a, cc=(10,3)): full context suite (132 passed) and mask suite (9 passed) with 0 failures/hangs, plus CPU deadlock/race oracles and on-device `skip_causal_invalid_peer0` repros.

## Reviewer Notes

Commits were cherry-picked onto current `main`; one comment-only merge conflict in `fmha_kernel.py` was resolved by keeping `main`'s fuller comment (no code change).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Added an optimized paired execution schedule for supported hardware and larger attention head dimensions.
  * Improved attention performance for interleaved query-key and value processing.
  * Improved handling of variable-length, uniform-length, and offset-based attention configurations.
  * Enhanced synchronization and resource management for paired attention processing.

* **Documentation**
  * Documented the paired execution schedule and its operation across attention stages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->