### PR TITLE
feat: unpacked FP8 per-tensor scaling support for TRTLLM fused MoE

### DIFF
--- a/csrc/trtllm_fused_moe_kernel_launcher.cu
+++ b/csrc/trtllm_fused_moe_kernel_launcher.cu
@@ -11,6 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include <cuda_bf16.h>
 #include <cuda_runtime.h>
 #include <flashinfer/exception.h>
 
@@ -837,6 +838,25 @@ inline std::vector<moe::dev::routing::routingPrecomputed::Data> makeMultiTileRou
   }
   return routing_data;
 }
+namespace {
+
+__global__ void cast_fp32_to_bf16_kernel(__nv_bfloat16* output, float const* input,
+                                         int64_t num_elements) {
+  int64_t const index = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  if (index < num_elements) {
+    output[index] = __float2bfloat16_rn(input[index]);
+  }
+}
+
+void cast_fp32_to_bf16(void* output, void const* input, int64_t num_elements, cudaStream_t stream) {
+  constexpr int32_t block_size = 256;
+  int32_t const grid_size = static_cast<int32_t>((num_elements + block_size - 1) / block_size);
+  cast_fp32_to_bf16_kernel<<<grid_size, block_size, 0, stream>>>(
+      static_cast<__nv_bfloat16*>(output), static_cast<float const*>(input), num_elements);
+  TVM_FFI_ICHECK(cudaGetLastError() == cudaSuccess) << "Failed to convert routing scales to BF16.";
+}
+
+}  // namespace
 
 // Validate routing_replay_out tensor properties.
 // NOTE: dim0 >= num_tokens is intentionally NOT checked — with CUDA graphs the buffer
@@ -1813,23 +1833,23 @@ class Fp8PerTensorLauncher : public FusedMoeLauncher {
  public:
   static constexpr std::array<int32_t, 5> mSupportedTileNums = {8, 16, 32, 64, 128};
 
-  // Constructor that passes TensorView parameters to base constructor.
-  // `routing_logits` is empty for the pre-computed (routed) path, in which case
-  // `expert_indices` carries the packed (expert_id << 16 | weight) top-k tensor.
   Fp8PerTensorLauncher(Optional<TensorView> const& routing_logits,
                        Optional<TensorView> const& routing_bias, TensorView const& hidden_states,
                        TensorView const& gemm1_weights, TensorView const& output1_scales_scalar,
                        TensorView const& output1_scales_gate_scalar,
                        TensorView const& gemm2_weights, TensorView const& output2_scales_scalar,
-                       Optional<TensorView> const& expert_indices = Optional<TensorView>())
+                       Optional<TensorView> const& expert_indices = Optional<TensorView>(),
+                       Optional<TensorView> const& expert_weights = Optional<TensorView>(),
+                       RoutingInputMode routing_input_mode = RoutingInputMode::FromLogits)
       : FusedMoeLauncher(routing_logits, routing_bias, hidden_states, gemm1_weights,
                          Optional<TensorView>(), Optional<TensorView>(output1_scales_scalar),
                          Optional<TensorView>(output1_scales_gate_scalar), gemm2_weights,
-                         Optional<TensorView>(output2_scales_scalar), Optional<TensorView>()),
+                         Optional<TensorView>(output2_scales_scalar), Optional<TensorView>(),
+                         routing_input_mode),
         expert_indices(expert_indices),
+        expert_weights(expert_weights),
         use_routing_scales_on_input(false) {}
 
-  // Whether the caller supplied pre-computed packed routing (expert_indices) instead of logits.
   bool has_precomputed_routing() const {
     return expert_indices.has_value() && expert_indices.value().ndim() == 2 &&
            expert_indices.value().size(0) > 0;
@@ -1860,7 +1880,7 @@ class Fp8PerTensorLauncher : public FusedMoeLauncher {
   }
 
   void check_routing() const override {
-    // Pre-computed packed routing: expert_indices is (expert_id << 16) | (weight_bf16.view(int16))
+    FusedMoeLauncher::check_routing_common();
     if (has_precomputed_routing()) {
       TVM_FFI_ICHECK_EQ(expert_indices.value().size(0), hidden_states.size(0))
           << "expert_indices and hidden_states must have same number of tokens.";
@@ -1869,14 +1889,25 @@ class Fp8PerTensorLauncher : public FusedMoeLauncher {
       TVM_FFI_ICHECK_EQ(expert_indices.value().dtype(), dl_int32)
           << "expert_indices must be int32.";
     }
-    FusedMoeLauncher::check_routing_common();
+    if (is_unpacked_routing()) {
+      TVM_FFI_ICHECK(has_precomputed_routing())
+          << "expert_indices must be a 2D [num_tokens, top_k] tensor for unpacked precomputed "
+             "routing.";
+      TVM_FFI_ICHECK(expert_weights.has_value())
+          << "expert_weights is required for unpacked precomputed routing.";
+      auto const& weights = expert_weights.value();
+      TVM_FFI_ICHECK(weights.dtype() == dl_bfloat16 || weights.dtype() == dl_float32)
+          << "expert_weights must be bfloat16 or float32 for unpacked precomputed routing.";
+      TVM_FFI_ICHECK_EQ(weights.ndim(), 2) << "expert_weights must be 2D.";
+      TVM_FFI_ICHECK_EQ(weights.size(0), hidden_states.size(0))
+          << "expert_weights and hidden_states must have same number of tokens.";
+      TVM_FFI_ICHECK_EQ(weights.size(1), args->top_k) << "expert_weights dim1 must match top_k.";
+    }
   }
 
   void prepare_routing() override {
     FusedMoeLauncher::prepare_routing_common();
 
-    // For the pre-computed path, point the routing runner at the caller's packed
-    // expert_indices instead of the buffer allocated by prepare_routing_common().
     if (has_precomputed_routing()) {
       workspace.routing_expert_indexes =
           static_cast<int*>(const_cast<void*>(expert_indices.value().data_ptr()));
@@ -1905,17 +1936,31 @@ class Fp8PerTensorLauncher : public FusedMoeLauncher {
     mRoutingLogitsDtype =
         routing_logits_dtype == dl_float32 ? btg::Dtype::Fp32 : btg::Dtype::Bfloat16;
 
-    // Allocate the routing-output buffer as bf16 to match the kernel's output
-    // (always Bfloat16, never the logits dtype); a fp32 alloc would mislabel bf16
-    // data when this buffer is surfaced to the caller verbatim on
-    // do_finalize=false. See #3595.
-    expert_weights =
-        alloc_tensor({args->num_tokens, args->top_k}, dl_bfloat16, hidden_states.device());
-
-    workspace.expert_weights = expert_weights.data_ptr();
-    if (static_cast<RoutingMethodType>(routing_method_type) == RoutingMethodType::Llama4) {
-      workspace.token_scales = expert_weights.data_ptr();  // Consumed by permuteGemm1 kernel
+    if (is_unpacked_routing()) {
+      auto const& weights = expert_weights.value();
+      args->mDtypeExpW = expert_weights_dtype(weights);
+      workspace.expert_weights = const_cast<void*>(weights.data_ptr());
+    } else {
+      FusedMoeLauncher::expert_weights =
+          alloc_tensor({args->num_tokens, args->top_k}, dl_bfloat16, hidden_states.device());
+      workspace.expert_weights = FusedMoeLauncher::expert_weights.data_ptr();
     }
+    if (static_cast<RoutingMethodType>(routing_method_type) == RoutingMethodType::Llama4) {
+      if (is_unpacked_routing() && expert_weights.value().dtype() == dl_float32) {
+        auto const& weights = expert_weights.value();
+        routing_scales =
+            alloc_tensor({args->num_tokens, args->top_k}, dl_bfloat16, hidden_states.device());
+        cast_fp32_to_bf16(routing_scales.data_ptr(), weights.data_ptr(), weights.numel(),
+                          get_stream(hidden_states.device()));
+        workspace.token_scales = routing_scales.data_ptr();
+      } else {
+        workspace.token_scales = workspace.expert_weights;
+      }
+    }
+  }
+
+  int32_t* precomputed_expert_ids() const override {
+    return expert_indices.has_value() ? unpacked_expert_ids(expert_indices.value()) : nullptr;
   }
 
   void check_moe() const override {
@@ -2007,6 +2052,7 @@ class Fp8PerTensorLauncher : public FusedMoeLauncher {
     ffi::CUDADeviceGuard device_guard(hidden_states.device().device_id);
     TVM_FFI_ICHECK(args->do_finalize) << "FP8 per-tensor DA bodies require finalized output.";
     bind_routing_metadata(routing_metadata);
+    args->mDtypeExpW = expert_weights_dtype(routing_metadata.expert_weights);
     check_moe();
     prepare_moe(moe_tactic);
     return {gemm1_output, gemm1_output_scale, gemm2_output, workspace_fc1, workspace_fc2};
@@ -2019,6 +2065,7 @@ class Fp8PerTensorLauncher : public FusedMoeLauncher {
     ffi::CUDADeviceGuard device_guard(hidden_states.device().device_id);
     TVM_FFI_ICHECK(args->do_finalize) << "FP8 per-tensor DA bodies require finalized output.";
     bind_routing_metadata(routing_metadata);
+    args->mDtypeExpW = expert_weights_dtype(routing_metadata.expert_weights);
     prepare_moe_runner(moe_tactic);
     workspace.hidden_states_scale_linear = nullptr;
     workspace.activation_output = nullptr;
@@ -2042,67 +2089,14 @@ class Fp8PerTensorLauncher : public FusedMoeLauncher {
   }
 
  private:
-  Optional<TensorView> expert_indices;  // packed pre-computed routing; empty => route from logits
+  Optional<TensorView> expert_indices;
+  Optional<TensorView> expert_weights;
   bool use_routing_scales_on_input;
   Tensor gemm1_output_scale;
   Tensor activation_output_scale;
+  Tensor routing_scales;
 
  public:
-  // Override to handle pre-computed (packed) routing in addition to routing from logits.
-  MoeRunResultBuffers run(int64_t moe_tactic, bool enable_pdl = true,
-                          bool use_routing_scales_on_input = false, bool use_deep_seek_fp8 = false,
-                          bool return_activation_output = false) override {
-    check_routing();
-    prepare_routing();
-
-    tensorrt_llm::kernels::trtllmgen_moe::Routing::Runner routing_runner(tile_tokens_dim);
-    cudaStream_t routing_stream = get_stream(hidden_states.device());
-
-    bool const use_precomputed = has_precomputed_routing();
-
-    int16_t* replay_ptr = nullptr;
-    if (routing_replay_out.has_value()) {
-      replay_ptr = reinterpret_cast<int16_t*>(routing_replay_out.value().data_ptr());
-    }
-
-    routing_runner.run(
-        use_precomputed ? nullptr : args->routing_logits, args->routing_bias, args->num_tokens,
-        args->num_experts, args->top_k, args->num_fused_shared_experts, args->n_group,
-        args->topk_group, args->local_expert_offset, args->local_num_experts,
-        args->routed_scaling_factor, workspace.routing_expert_indexes,
-        static_cast<int*>(expert_count_histogram.data_ptr()),
-        static_cast<int*>(total_num_padded_tokens.data_ptr()),
-        static_cast<int*>(expanded_idx_to_permuted_idx.data_ptr()),
-        workspace.permuted_idx_to_expanded_idx,
-        static_cast<int*>(permuted_idx_to_token_idx.data_ptr()), nullptr /*expertIds*/,
-        workspace.expert_weights, static_cast<int*>(num_tokens_per_expert.data_ptr()),
-        static_cast<int*>(cta_idx_xy_to_batch_idx.data_ptr()),
-        static_cast<int*>(cta_idx_xy_to_mn_limit.data_ptr()),
-        static_cast<int*>(num_non_exiting_ctas.data_ptr()), args->mDtypeElt, mRoutingBiasDtype,
-        use_routing_scales_on_input, use_deep_seek_fp8,
-        static_cast<RoutingMethodType>(routing_method_type), routing_stream, mRoutingLogitsDtype,
-        norm_topk_prob, replay_ptr, enable_pdl);
-
-    check_moe();
-    prepare_moe(moe_tactic);
-
-    cudaStream_t moe_stream = get_stream(hidden_states.device());
-    moe_runner->run(*args, workspace, hidden_states.device().device_id, moe_stream, moe_tactic,
-                    enable_pdl);
-
-    MoeRunResultBuffers result(args->do_finalize, args->do_finalize ? output : gemm2_output);
-    if (!args->do_finalize) {
-      result.expert_weights = FusedMoeLauncher::expert_weights;
-    }
-    if (!args->do_finalize || return_activation_output) {
-      result.expanded_to_permuted_indices = expanded_idx_to_permuted_idx;
-    }
-    if (return_activation_output) {
-      result.activation_output = gemm1_output;
-    }
-    return result;
-  }
-
   static Array<Array<int64_t>> getValidConfigs(int64_t top_k, int64_t hidden_size,
                                                int64_t intermediate_size, int64_t num_local_experts,
                                                int64_t num_tokens, int64_t act_type,
@@ -3581,24 +3575,23 @@ Array<Tensor> trtllm_fp8_per_tensor_scale_moe(
   return selected_launcher->run(config, enable_pdl, use_routing_scales_on_input).to_ffi();
 }
 
-// Pre-routed variant of trtllm_fp8_per_tensor_scale_moe.
 Array<Tensor> trtllm_fp8_per_tensor_scale_routed_moe(
-    TensorView expert_indices, Optional<TensorView> routing_bias, TensorView hidden_states,
-    TensorView gemm1_weights, TensorView output1_scales_scalar,
-    TensorView output1_scales_gate_scalar, TensorView gemm2_weights,
-    TensorView output2_scales_scalar, TensorView output, int64_t num_experts, int64_t top_k,
-    Optional<int64_t> n_group, Optional<int64_t> topk_group, int64_t intermediate_size,
-    int64_t local_expert_offset, int64_t local_num_experts, Optional<double> routed_scaling_factor,
-    bool use_routing_scales_on_input, int64_t routing_method_type, bool do_finalize,
-    bool enable_pdl, Array<int64_t> config_index, int64_t activation_type, bool norm_topk_prob,
-    Optional<TensorView> routing_replay_out, Array<Tensor> da_routing_metadata,
-    Array<Tensor> da_body_workspace, bool is_da_body_preparation) {
+    int64_t routing_input_mode, TensorView expert_indices, TensorView expert_weights,
+    Optional<TensorView> routing_bias, TensorView hidden_states, TensorView gemm1_weights,
+    TensorView output1_scales_scalar, TensorView output1_scales_gate_scalar,
+    TensorView gemm2_weights, TensorView output2_scales_scalar, TensorView output,
+    int64_t num_experts, int64_t top_k, Optional<int64_t> n_group, Optional<int64_t> topk_group,
+    int64_t intermediate_size, int64_t local_expert_offset, int64_t local_num_experts,
+    Optional<double> routed_scaling_factor, bool use_routing_scales_on_input,
+    int64_t routing_method_type, bool do_finalize, bool enable_pdl, Array<int64_t> config_index,
+    int64_t activation_type, bool norm_topk_prob, Optional<TensorView> routing_replay_out,
+    Array<Tensor> da_routing_metadata, Array<Tensor> da_body_workspace,
+    bool is_da_body_preparation) {
   // Basic type validation
   auto const dtype = hidden_states.dtype();
   auto const activation = validateAndCastActivationType(activation_type);
 
-  TVM_FFI_ICHECK_EQ(expert_indices.dtype(), dl_int32)
-      << "FP8 MoE: expert_indices must be int32 (packed expert_id/weight).";
+  TVM_FFI_ICHECK_EQ(expert_indices.dtype(), dl_int32) << "FP8 MoE: expert_indices must be int32.";
   TVM_FFI_ICHECK(expert_indices.device().device_type == kDLCUDA)
       << "FP8 MoE: expert_indices must be a CUDA tensor.";
   TVM_FFI_ICHECK(expert_indices.device().device_id == hidden_states.device().device_id)
@@ -3660,12 +3653,11 @@ Array<Tensor> trtllm_fp8_per_tensor_scale_routed_moe(
     args->output = output.data_ptr();
     args->output_scale = nullptr;
 
-    // Create and initialize launcher for this tile size, in pre-computed routing mode
-    // (empty routing_logits, packed expert_indices).
     auto launcher = std::make_unique<Fp8PerTensorLauncher>(
         Optional<TensorView>(), routing_bias, hidden_states, gemm1_weights, output1_scales_scalar,
         output1_scales_gate_scalar, gemm2_weights, output2_scales_scalar,
-        Optional<TensorView>(expert_indices));
+        Optional<TensorView>(expert_indices), Optional<TensorView>(expert_weights),
+        static_cast<RoutingInputMode>(routing_input_mode));
     launcher->init(std::move(args), curr_tile_N, routing_method_type, use_shuffled_weight,
                    weight_layout, use_routing_scales_on_input, activation, norm_topk_prob);
     launcher->set_routing_replay_out(routing_replay_out);

--- a/flashinfer/fused_moe/api.py
+++ b/flashinfer/fused_moe/api.py
@@ -999,10 +999,10 @@ class MoEActivationPack:
       selection on the host and passes ``topk_ids`` + ``topk_weights``.
       The TRTLLM runners normally combine both fields into one packed ``int32``
       tensor before launch.
-    * ``UnpackedPrecomputed`` — **pre-routed, separate kernel inputs**: currently
-      supported by the TRTLLM FP4 runner. The caller supplies ``int32`` ids and
-      BF16 or FP32 weights directly, avoiding packed-id construction. The
-      launcher consumes the weights in their native dtype.
+    * ``UnpackedPrecomputed`` — **pre-routed, separate kernel inputs**: supported
+      by the TRTLLM runners. The caller supplies ``int32`` ids and BF16 or FP32
+      weights directly, avoiding packed-id construction. The launcher consumes
+      the weights in their native dtype.
     * ``FromLogits`` — **in-kernel**: the caller passes raw ``routing_logits`` (and, for bias-aware
       methods like DeepSeekV3/MiniMax2, ``routing_bias``); the kernel computes the top-k selection
       itself per ``RoutingConfig.method``.  ``topk_ids`` / ``topk_weights`` stay ``None`` — the
@@ -1025,7 +1025,7 @@ class MoEActivationPack:
     # Pre-routed top-k selection (Packed/Unpacked modes); None under FromLogits.
     topk_ids: Optional[Tensor] = None  # [M, top_k] int32 (expert indices)
     # [M, top_k] routing weights: float32 for PackedPrecomputed; bfloat16 or
-    # float32 for TRTLLM FP4 UnpackedPrecomputed.
+    # float32 for TRTLLM UnpackedPrecomputed.
     topk_weights: Optional[Tensor] = None
     # Per-token NVFP4 row scale, shape [M].
     per_token_scale: Optional[Tensor] = field(default=None, kw_only=True)

--- a/flashinfer/fused_moe/core.py
+++ b/flashinfer/fused_moe/core.py
@@ -2113,9 +2113,11 @@ def _get_trtllm_moe_sm100_module_impl(enable_rubin: bool):
                         prepare_da_body,
                     )
                 elif routing_logits is None:
-                    # FP8 per tensor scale, pre-computed (packed) routing.
+                    # FP8 per tensor scale, pre-computed routing.
                     result = moe_op.trtllm_fp8_per_tensor_scale_routed_moe(
+                        kwargs["routing_input_mode"],
                         topk_ids,
+                        topk_weights,
                         kwargs["routing_bias"],
                         hidden_states,
                         kwargs["gemm1_weights"],
@@ -3019,7 +3021,9 @@ def _get_trtllm_moe_sm100_module_impl(enable_rubin: bool):
         mutates_args=("routing_replay_out",),
     )
     def trtllm_fp8_per_tensor_scale_routed_moe_op(
+        routing_input_mode: int,
         topk_ids: torch.Tensor,
+        expert_weights: torch.Tensor | None,
         routing_bias: Optional[torch.Tensor],
         hidden_states: torch.Tensor,
         gemm1_weights: torch.Tensor,
@@ -3065,11 +3069,10 @@ def _get_trtllm_moe_sm100_module_impl(enable_rubin: bool):
                 hidden_states.device,
                 "output",
             )
-        # Pre-computed routing: the kernel unpacks the routing weights from topk_ids
-        # into this buffer, so it is an OUTPUT (allocated for the autotuner's shape spec).
-        expert_weights = torch.empty(
-            num_tokens, top_k, dtype=torch.bfloat16, device=hidden_states.device
-        )
+        if expert_weights is None:
+            expert_weights = torch.empty(
+                0, dtype=torch.bfloat16, device=hidden_states.device
+            )
 
         dtype_act = DtypeTrtllmGen.E4m3  # FP8 activation
         dtype_weights = DtypeTrtllmGen.E4m3  # FP8 weights
@@ -3085,6 +3088,7 @@ def _get_trtllm_moe_sm100_module_impl(enable_rubin: bool):
             weight_layout=WeightLayout.MajorK,
             use_shuffled_weight=True,
             activation_type=activation_type,
+            use_per_token_scaling=use_routing_scales_on_input,
             num_experts=num_experts,
         )
 
@@ -3101,12 +3105,13 @@ def _get_trtllm_moe_sm100_module_impl(enable_rubin: bool):
         tuning_config = moe_runner._make_tuning_config(
             moe_inputs,
             tune_max_num_tokens=tune_max_num_tokens,
+            routing_input_mode=RoutingInputMode(routing_input_mode),
             use_cuda_graph=True,
             use_cold_l2_cache=True,
         )
 
         runner_kwargs = {
-            "routing_input_mode": RoutingInputMode.PackedPrecomputed,
+            "routing_input_mode": routing_input_mode,
             "routing_bias": routing_bias,
             "gemm1_weights": gemm1_weights,
             "output1_scales_scalar": output1_scales_scalar,
@@ -3136,10 +3141,11 @@ def _get_trtllm_moe_sm100_module_impl(enable_rubin: bool):
         )
 
         def run_selected_tactic(tactic: Any) -> List[torch.Tensor]:
-            """Launch the unchanged packed FP8 per-tensor operation."""
-            # Preserve the exact packed-routing FFI ABI for baseline and selected tactics.
+            """Launch the FP8 per-tensor operation with one fixed tactic."""
             intermediate_output = moe_op.trtllm_fp8_per_tensor_scale_routed_moe(
+                routing_input_mode,
                 topk_ids,
+                expert_weights,
                 routing_bias,
                 hidden_states,
                 gemm1_weights,
@@ -3168,15 +3174,29 @@ def _get_trtllm_moe_sm100_module_impl(enable_rubin: bool):
                 [],
                 False,
             )
-            # Convert the native result back to the established public output contract.
             return _unpack_trtllm_moe_output(
-                intermediate_output, output, do_finalize, None
+                intermediate_output, output, do_finalize, None, expert_weights
             )
 
+        routing_mode = RoutingInputMode(routing_input_mode)
         # When do_finalize=False, the FC2 output format is determined on device based on runtime
         # expert distribution. Therefore it is not eligible for DA until we can canonicalize
-        # output format. The exact launcher owns dtype, optional-operand, and top-k validation.
-        da_eligible = do_finalize and 0 < num_experts <= DA_MAX_EXPERTS
+        # output format. FP32 Llama4 weights also need the ordinary launcher's BF16 token-scale
+        # conversion, whose scratch buffer is not part of the prepared-body ABI.
+        da_eligible = (
+            routing_mode
+            in (
+                RoutingInputMode.PackedPrecomputed,
+                RoutingInputMode.UnpackedPrecomputed,
+            )
+            and do_finalize
+            and not (
+                routing_mode is RoutingInputMode.UnpackedPrecomputed
+                and use_routing_scales_on_input
+                and expert_weights.dtype == torch.float32
+            )
+            and 0 < num_experts <= DA_MAX_EXPERTS
+        )
         if not da_eligible:
             return run_selected_tactic(tactic)
 
@@ -3195,7 +3215,7 @@ def _get_trtllm_moe_sm100_module_impl(enable_rubin: bool):
             inputs=moe_inputs.to_list(),
             runner_kwargs=runner_kwargs,
             baseline_tactic=tactic,
-            routing_input_mode=RoutingInputMode.PackedPrecomputed,
+            routing_input_mode=routing_input_mode,
             routing_id_index=MoeRunnerInputs.idx("topk_ids"),
             routing_weight_index=MoeRunnerInputs.idx("expert_weights"),
             num_experts=num_experts,
@@ -3206,13 +3226,15 @@ def _get_trtllm_moe_sm100_module_impl(enable_rubin: bool):
             routed_scaling_factor=routed_scaling_factor,
             run_fixed_tactic=run_selected_tactic,
             finish_switch=lambda: _unpack_trtllm_moe_output(
-                [], output, do_finalize, None
+                [], output, do_finalize, None, expert_weights
             ),
         )
 
     @register_fake_op("flashinfer::trtllm_fp8_per_tensor_scale_routed_moe")
     def _fake_trtllm_fp8_per_tensor_scale_routed_moe(
+        routing_input_mode: int,
         topk_ids: torch.Tensor,
+        expert_weights: torch.Tensor | None,
         routing_bias: Optional[torch.Tensor],
         hidden_states: torch.Tensor,
         gemm1_weights: torch.Tensor,
@@ -5370,7 +5392,7 @@ def trtllm_fp8_per_tensor_scale_moe(
 
 @flashinfer_api(trace=trtllm_fp8_per_tensor_scale_routed_moe_trace)
 def trtllm_fp8_per_tensor_scale_routed_moe(
-    topk_ids: torch.Tensor,
+    topk_ids: Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]],
     routing_bias: Optional[torch.Tensor],
     hidden_states: torch.Tensor,
     gemm1_weights: torch.Tensor,
@@ -5397,17 +5419,20 @@ def trtllm_fp8_per_tensor_scale_routed_moe(
 ) -> Union[List[torch.Tensor], torch.Tensor]:
     r"""Pre-routed FP8 per-tensor-scale MoE operation.
 
-    Like :func:`trtllm_fp8_per_tensor_scale_moe`, but consumes a pre-computed
-    packed ``(expert_id, weight)`` tensor instead of routing logits.  Use this
-    entry point for distributed MoE where routing (top-k selection, including
-    EPLB redundant-expert placement) happens in an external DP/EP dispatch, or
-    for CUDA-graph capture (avoids the CPU-GPU sync from logits processing).
+    Like :func:`trtllm_fp8_per_tensor_scale_moe`, but consumes pre-computed
+    routing instead of routing logits, either as a packed ``(expert_id, weight)``
+    tensor or as a ``(topk_ids, topk_weights)`` pair. Use this entry point for
+    distributed MoE where routing (top-k selection, including EPLB
+    redundant-expert placement) happens in an external DP/EP dispatch, or for
+    CUDA-graph capture (avoids the CPU-GPU sync from logits processing).
 
     Parameters
     ----------
-    topk_ids : torch.Tensor
+    topk_ids : torch.Tensor or Tuple[torch.Tensor, torch.Tensor]
         ``[seq_len, top_k]`` int32 tensor of packed expert indices and weights
         with format ``(expert_id << 16) | (weight_bf16.view(int16))``.
+        Alternatively a ``(topk_ids, topk_weights)`` pair of plain ``int32``
+        indices and ``bfloat16`` or ``float32`` weights.
     routing_bias : Optional[torch.Tensor]
         ``[num_experts]`` tensor of routing bias (may be ``None``).
     hidden_states : torch.Tensor
@@ -5467,8 +5492,11 @@ def trtllm_fp8_per_tensor_scale_routed_moe(
         ``[gemm2_output, expert_weights, expanded_idx_to_permuted_idx]``.
     """
     _validate_routing_replay_out(routing_replay_out, top_k)
+    topk_ids_tensor, topk_weights, routing_mode = _split_precomputed_routing(topk_ids)
     result = get_trtllm_moe_sm100_module().trtllm_fp8_per_tensor_scale_routed_moe(
-        topk_ids,
+        routing_mode,
+        topk_ids_tensor,
+        topk_weights,
         routing_bias,
         hidden_states,
         gemm1_weights,

--- a/flashinfer/fused_moe/runners.py
+++ b/flashinfer/fused_moe/runners.py
@@ -1841,13 +1841,14 @@ class TrtllmFp8PerTensorRunner(_TrtllmRunnerBase):
     The kernel consumes prequantized E4M3 activations and weights. Its calibrated
     activation/weight multipliers are folded into three per-expert FP32 epilogue
     scale vectors, so ``MoEActivationPack.hidden_states_scale`` remains ``None``.
-    Routing can be computed from logits or supplied as packed precomputed
-    ``(global_expert_id << 16) | bf16(weight)`` values.
+    Routing can be computed from logits or supplied as packed or unpacked
+    precomputed expert IDs and weights.
     """
 
     backend_key = "trtllm_fp8_per_tensor"
     supported_routing_modes = (
         RoutingInputMode.PackedPrecomputed,
+        RoutingInputMode.UnpackedPrecomputed,
         RoutingInputMode.FromLogits,
     )
     supported_quant_variants = (QuantVariant.FP8PerTensor,)
@@ -1915,7 +1916,7 @@ class TrtllmFp8PerTensorRunner(_TrtllmRunnerBase):
         self._require_built()
         if self._inner is not None:
             return
-        from ..tllm_enums import WeightLayout
+        from ..tllm_enums import RoutingMethodType, WeightLayout
 
         self._inner = self._module.MoERunner(
             top_k=self.config.routing.top_k,
@@ -1928,7 +1929,9 @@ class TrtllmFp8PerTensorRunner(_TrtllmRunnerBase):
             activation_type=self._activation_type,
             use_shuffled_weight=True,
             weight_layout=int(WeightLayout.MajorK),
-            use_per_token_scaling=False,
+            use_per_token_scaling=(
+                self.config.routing.method is RoutingMethodType.Llama4
+            ),
             num_experts=self.config.routing.num_experts,
         )
 
@@ -2045,13 +2048,26 @@ class TrtllmFp8PerTensorRunner(_TrtllmRunnerBase):
             routing_logits = None
             routing_bias = None
             topk_ids = _pack_prerouted_topk_ids(act)
-            # The routed per-tensor op allocates its own expert-weight buffer
-            # and consumes only the packed topk_ids from this generic schema.
-            expert_weights = None
+            expert_weights = act.topk_weights.new_empty(
+                0, dtype=torch.bfloat16, device=act.topk_weights.device
+            )
+        elif routing_input_mode == RoutingInputMode.UnpackedPrecomputed:
+            _validate_prerouted_inputs(
+                act,
+                num_tokens,
+                routing.top_k,
+                type(self).__name__,
+                allowed_weights_dtypes=(torch.bfloat16, torch.float32),
+                require_contiguous=True,
+            )
+            routing_logits = None
+            routing_bias = None
+            topk_ids = act.topk_ids
+            expert_weights = act.topk_weights
         else:
             raise NotImplementedError(
-                f"{type(self).__name__} supports only FromLogits and "
-                "PackedPrecomputed routing."
+                f"{type(self).__name__} supports only FromLogits, "
+                "PackedPrecomputed, and UnpackedPrecomputed routing."
             )
 
         moe_inputs = MoeRunnerInputs(
@@ -2065,6 +2081,7 @@ class TrtllmFp8PerTensorRunner(_TrtllmRunnerBase):
             per_token_scale=None,
         )
         self._static_kwargs = dict(
+            routing_input_mode=routing_input_mode,
             routing_bias=routing_bias,
             gemm1_weights=view["gemm1_weights"],
             output1_scales_scalar=view["output1_scales_scalar"],

--- a/tests/moe/test_trtllm_gen_routed_fused_moe.py
+++ b/tests/moe/test_trtllm_gen_routed_fused_moe.py
@@ -566,6 +566,7 @@ def test_trtllm_gen_fp8_routed_fused_moe(
         RoutingMethodType.RenormalizeNaive,
     ],
 )
+@pytest.mark.parametrize("routing_format", ["packed", "unpacked_fp32"])
 def test_trtllm_gen_fp8_per_tensor_routed_fused_moe(
     num_tokens: int,
     hidden_size: int,
@@ -573,15 +574,15 @@ def test_trtllm_gen_fp8_per_tensor_routed_fused_moe(
     top_k: int,
     num_experts: int,
     routing_method_type: RoutingMethodType,
+    routing_format: Literal["packed", "unpacked_fp32"],
 ):
     """Pre-routed FP8 per-tensor MoE matches the logits (self-routing) kernel.
 
-    Feeds the packed (expert_id << 16 | weight) routing derived from the same
-    logits to ``trtllm_fp8_per_tensor_scale_routed_moe`` and asserts it produces
-    the same output as ``trtllm_fp8_per_tensor_scale_moe``. This is the numeric
-    parity check for the pre-routed per-tensor path used by the vLLM modular
-    (DP/EP/EPLB) kernel. The per-tensor scale scalars are shared verbatim by both
-    calls, so the test isolates the routing path (weights need not be calibrated).
+    Feeds routing derived from the same logits to
+    ``trtllm_fp8_per_tensor_scale_routed_moe`` and asserts it produces the same
+    output as ``trtllm_fp8_per_tensor_scale_moe``. The routed input is either
+    packed or separate IDs and FP32 weights. The per-tensor scale scalars are
+    shared verbatim by both calls, so the test isolates the routing path.
     """
     compute_capability = get_compute_capability(torch.device(device="cuda"))
     if compute_capability[0] not in [10]:
@@ -647,14 +648,18 @@ def test_trtllm_gen_fp8_per_tensor_routed_fused_moe(
     topk_weights = topk_weights_ref.view(num_tokens, num_experts)[
         torch.arange(num_tokens, device=device).unsqueeze(1), topk_ids
     ].to(torch.bfloat16)
-    # Format: (expert_id << 16) | (weight_bf16.view(int16))
-    packed_topk_ids = (topk_ids << 16) | topk_weights.view(torch.int16).to(torch.int32)
+    if routing_format == "packed":
+        routing_input = (topk_ids << 16) | topk_weights.view(torch.int16).to(
+            torch.int32
+        )
+    else:
+        routing_input = (topk_ids, topk_weights.to(torch.float32))
 
     output = torch.empty(
         num_tokens, hidden_size, dtype=torch.bfloat16, device=hidden_states.device
     )
     trtllm_fp8_per_tensor_scale_routed_moe(
-        topk_ids=packed_topk_ids,
+        topk_ids=routing_input,
         routing_bias=None,
         hidden_states=hidden_states,
         gemm1_weights=gemm1_weights,

--- a/tests/moe/test_unified_moe_fp8.py
+++ b/tests/moe/test_unified_moe_fp8.py
@@ -718,7 +718,10 @@ def _make_per_tensor_fp8_case(
             routing_logits=logits,
         )
     else:
-        assert routing_input_mode is RoutingInputMode.PackedPrecomputed
+        assert routing_input_mode in (
+            RoutingInputMode.PackedPrecomputed,
+            RoutingInputMode.UnpackedPrecomputed,
+        )
         act = MoEActivationPack(
             hidden_states_q=x_q,
             hidden_states_scale=x_scale,
@@ -764,8 +767,12 @@ def _assert_per_tensor_fp8_close(out: torch.Tensor, ref: torch.Tensor) -> None:
 
 @pytest.mark.parametrize(
     "routing_input_mode",
-    [RoutingInputMode.FromLogits, RoutingInputMode.PackedPrecomputed],
-    ids=["from-logits", "packed"],
+    [
+        RoutingInputMode.FromLogits,
+        RoutingInputMode.PackedPrecomputed,
+        RoutingInputMode.UnpackedPrecomputed,
+    ],
+    ids=["from-logits", "packed", "unpacked"],
 )
 def test_fp8_per_tensor_layer_and_direct_runner_match_reference(routing_input_mode):
     act, weights, config, ref, _ = _make_per_tensor_fp8_case(
@@ -782,8 +789,12 @@ def test_fp8_per_tensor_layer_and_direct_runner_match_reference(routing_input_mo
 
 @pytest.mark.parametrize(
     "routing_input_mode",
-    [RoutingInputMode.FromLogits, RoutingInputMode.PackedPrecomputed],
-    ids=["from-logits", "packed"],
+    [
+        RoutingInputMode.FromLogits,
+        RoutingInputMode.PackedPrecomputed,
+        RoutingInputMode.UnpackedPrecomputed,
+    ],
+    ids=["from-logits", "packed", "unpacked"],
 )
 def test_fp8_per_tensor_llama4_routes_scale_on_input(routing_input_mode):
     act, weights, config, ref, _ = _make_per_tensor_fp8_case(
@@ -808,8 +819,12 @@ def test_fp8_per_tensor_llama4_routes_scale_on_input(routing_input_mode):
 
 @pytest.mark.parametrize(
     "routing_input_mode",
-    [RoutingInputMode.FromLogits, RoutingInputMode.PackedPrecomputed],
-    ids=["from-logits", "packed"],
+    [
+        RoutingInputMode.FromLogits,
+        RoutingInputMode.PackedPrecomputed,
+        RoutingInputMode.UnpackedPrecomputed,
+    ],
+    ids=["from-logits", "packed", "unpacked"],
 )
 def test_fp8_per_tensor_nonzero_expert_offset(routing_input_mode):
     act, weights, config, ref, _ = _make_per_tensor_fp8_case(
@@ -843,7 +858,8 @@ def test_fp8_per_tensor_packed_ids_keep_global_ids_and_weight_bits():
     runner = _build_per_tensor_fp8_runner(config)
     moe_inputs = MoeRunnerInputs.from_list(runner.pack_inputs(act, weights))
     packed = moe_inputs.topk_ids
-    assert moe_inputs.expert_weights is None
+    assert moe_inputs.expert_weights is not None
+    assert moe_inputs.expert_weights.numel() == 0
     assert torch.equal(packed >> 16, expected_ids)
     assert torch.equal(packed & 0xFFFF, expected_bits)
 
@@ -884,8 +900,12 @@ def test_fp8_per_tensor_routing_replay_matches_reference():
 
 @pytest.mark.parametrize(
     "routing_input_mode",
-    [RoutingInputMode.FromLogits, RoutingInputMode.PackedPrecomputed],
-    ids=["from-logits", "packed"],
+    [
+        RoutingInputMode.FromLogits,
+        RoutingInputMode.PackedPrecomputed,
+        RoutingInputMode.UnpackedPrecomputed,
+    ],
+    ids=["from-logits", "packed", "unpacked"],
 )
 def test_fp8_per_tensor_cuda_graph_replay(routing_input_mode):
     act, weights, config, ref, _ = _make_per_tensor_fp8_case(


### PR DESCRIPTION
## 📌 Description

This PR adds unpacked precomputed routing support to
`trtllm_fp8_per_tensor_scale_routed_moe` while preserving the existing packed
routing format.

Previously, the Python wrapper assumed `topk_ids` was always a packed tensor.
Passing the standard `(topk_ids, topk_weights)` tuple therefore failed before
reaching FlashInfer because the wrapper tried to access `dtype` on the tuple.

The changes:

- Accept either the existing packed `int32` tensor or separate `int32` expert
  IDs and BF16/FP32 routing weights.
- Propagate the routing input mode and separate routing weights through the
  Python custom op and C++ launcher.
- Borrow unpacked routing tensors directly and select the correct routing-weight
  dtype instead of constructing the packed representation.
- Reuse the common fused-MoE execution path for packed, unpacked, and
  logits-based routing.
- Preserve packed-format behavior, including the launcher-owned BF16 routing
  weight buffer.
- Convert unpacked FP32 weights to a launcher-owned BF16 token-scale buffer only
  for Llama4 routing, where the available per-tensor FP8 GEMM cubins require
  BF16 routing scales on the GEMM1 input. The original FP32 routing weights are
  retained for the normal routing/finalization contract.
- Enable unpacked routing in the unified per-tensor FP8 runner and configure its
  autotuning path consistently for Llama4 per-token scaling.

## 🔍 Related Issues

Supports merging https://github.com/vllm-project/vllm/pull/46872.

## 🚀 Pull Request Checklist

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

Validation performed:

- Packed and unpacked-FP32 public per-tensor FP8 routed-MoE parity tests.
- Unified runner coverage for logits, packed, and unpacked routing.
- Llama4 unpacked-FP32 correctness test.
- Llama4 unpacked-FP32 CUDA graph capture and replay test.

## Reviewer Notes

Please focus on the Llama4-specific conversion. Unpacked FP32 routing weights
are consumed directly by the normal per-tensor FP8 routing/finalization path.
Llama4 additionally uses those weights as GEMM1 token scales, while the
currently shipped scale-only E4M3 GEMM cubins expect BF16 token scales. The
conversion is therefore limited to that combination and does not add overhead
to ordinary unpacked routing.

The packed API remains supported and follows its existing internal-buffer path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for unpacked precomputed routing with separate expert IDs and weights in FP8 routed MoE operations.
  * Expanded Llama4 routing support with per-token scaling and FP32 routing-weight conversion.
  * Added validation for routing formats and expert-index types.

* **Bug Fixes**
  * Improved handling and reuse of caller-provided routing weights.

* **Tests**
  * Expanded coverage for packed and unpacked routing, CUDA graph replay, and Llama4 scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->