### PR TITLE
feat(b12x): support MXFP4 dense GEMM on SM120

### DIFF
--- a/benchmarks/routines/gemm.py
+++ b/benchmarks/routines/gemm.py
@@ -1408,7 +1408,11 @@ def testMmFp4(args):
                 b=mat2_fp4.T if backend != "trtllm" else mat2_fp4_trtllm.T,
                 a_descale=input_inv_s,
                 b_descale=mat2_inv_s.T if backend != "trtllm" else mat2_inv_s_trtllm.T,
-                alpha=(alpha_for_cute_dsl_mxfp4 if (backend == "cute-dsl") else alpha),
+                alpha=(
+                    alpha_for_cute_dsl_mxfp4
+                    if backend in ("cute-dsl", "b12x")
+                    else alpha
+                ),
                 out_dtype=res_dtype,
                 block_size=16
                 if use_nvfp4
@@ -1446,7 +1450,9 @@ def testMmFp4(args):
             b=mat2_fp4.T if backend != "trtllm" else mat2_fp4_trtllm.T,
             a_descale=input_inv_s,
             b_descale=mat2_inv_s.T if backend != "trtllm" else mat2_inv_s_trtllm.T,
-            alpha=(alpha_for_cute_dsl_mxfp4 if (backend == "cute-dsl") else alpha),
+            alpha=(
+                alpha_for_cute_dsl_mxfp4 if backend in ("cute-dsl", "b12x") else alpha
+            ),
             out_dtype=res_dtype,
             block_size=block_size,
             use_8x4_sf_layout=not use_128x4_sf_layout,

--- a/flashinfer/gemm/gemm_base.py
+++ b/flashinfer/gemm/gemm_base.py
@@ -6041,7 +6041,7 @@ def _b12x_gemm_fp4_requirement(
     use_nvfp4: bool = True,
     enable_pdl: bool = True,  # unused
 ):
-    # b12x backend requires CUDA 13+, 128x4 scale factor layout, and NVFP4 only.
+    # b12x backend requires CUDA 13+ and 128x4 scale factor layout.
     if get_cuda_version().major < 13:
         raise ValueError(
             "b12x FP4 GEMM requires CUDA 13 or later. "
@@ -6049,8 +6049,6 @@ def _b12x_gemm_fp4_requirement(
         )
     if use_8x4_sf_layout:
         raise ValueError("b12x FP4 GEMM only supports 128x4 scale factor layout.")
-    if not use_nvfp4:
-        raise ValueError("b12x FP4 GEMM only supports NVFP4 (sf_vec_size=16).")
     # K floor is 32 (TMA assumed_align=16 on K-major packed FP4), not tile_k=128: the
     # mainloop predicates the partial tile, so ragged K (192) works. Mirror can_implement.
     real_k = a.shape[1] * 2
@@ -6438,9 +6436,9 @@ def _b12x_gemm_fp4_runner(
             n = b.shape[1]
             real_k = k_packed * 2
 
-            sf_vec_size = 16
+            sf_vec_size = 16 if use_nvfp4 else 32
             ab_dtype = cutlass.Float4E2M1FN
-            sf_dtype = cutlass.Float8E4M3FN
+            sf_dtype = cutlass.Float8E4M3FN if use_nvfp4 else cutlass.Float8E8M0FNU
             batch_size = 1
 
             valid_tactics = []
@@ -6492,8 +6490,8 @@ def _b12x_gemm_fp4_runner(
             n = b.shape[1]
             real_k = k_packed * 2
 
-            sf_vec_size = 16
-            sf_dtype = cutlass.Float8E4M3FN
+            sf_vec_size = 16 if use_nvfp4 else 32
+            sf_dtype = cutlass.Float8E4M3FN if use_nvfp4 else cutlass.Float8E8M0FNU
             batch_size = 1
 
             if tactic is None or tactic == -1:
@@ -6623,10 +6621,10 @@ def _heuristic_func_mm_fp4(
     is_sm103 = major == 10 and minor == 3
     is_sm120 = major == 12 and minor == 0
 
-    # SM120 + CUDA 13: prefer b12x. SM121 (GB10) is intentionally excluded -- b12x
-    # is supported there as an explicit backend, but cutlass/cudnn are faster in
-    # most cases, so `auto` keeps using them.
-    if is_sm120 and use_nvfp4 and cuda_major >= 13:
+    # SM120 + CUDA 13: prefer b12x for both NVFP4 and MXFP4. SM121 (GB10) is
+    # intentionally excluded -- b12x is supported there as an explicit backend,
+    # but cutlass/cudnn are faster in most cases, so `auto` keeps using them.
+    if is_sm120 and cuda_major >= 13:
         return [c for c in ("b12x", "cutlass", "cudnn") if c in suitable_backends]
 
     # If cuda version is 13 or greater and cudnn version is 9.15 or greater:

--- a/flashinfer/gemm/kernels/dense_blockscaled_gemm_sm120_b12x.py
+++ b/flashinfer/gemm/kernels/dense_blockscaled_gemm_sm120_b12x.py
@@ -292,6 +292,14 @@ class DenseGemmKernel:
                 self.acc_dtype,
                 self.sf_dtype,
             )
+        elif self.sf_vec_size == 32:
+            # MXFP4 (sf_vec_size=32, E8M0 scale) requires the MmaMXF4Op
+            # warp-MMA; MmaMXF4NVF4Op is hard-coded to NVFP4 in cutlass-dsl.
+            mma_op = cute.nvgpu.warp.MmaMXF4Op(
+                self.a_dtype,
+                self.acc_dtype,
+                self.sf_dtype,
+            )
         else:
             mma_op = cute.nvgpu.warp.MmaMXF4NVF4Op(
                 self.a_dtype,
@@ -545,6 +553,41 @@ class DenseGemmKernel:
         )
         return
 
+    @staticmethod
+    def _align_sf_copy_ranks(src: cute.Tensor, dst: cute.Tensor):
+        """Normalize SF tensor ranks for a SMEM->RMEM ``cute.copy``.
+
+        ``cute.filter_zeros`` strips stride-0 (broadcast) modes. A scale factor
+        is shared by ``sf_vec_size`` data elements, so MXF4 (sf_vec_size=32) and
+        NVF4 (sf_vec_size=16) end up with a different number of broadcast modes,
+        and the SMEM and RMEM views can be left at different ranks (e.g. 3 vs 4).
+        Collapse the trailing modes of whichever side is deeper so that
+        ``cute.copy`` sees matching ranks.
+        """
+        src_rank = cute.rank(src)
+        dst_rank = cute.rank(dst)
+        if src_rank > dst_rank:
+            src = cute.group_modes(src, dst_rank - 1, src_rank)
+        elif dst_rank > src_rank:
+            dst = cute.group_modes(dst, src_rank - 1, dst_rank)
+        return src, dst
+
+    @staticmethod
+    def _collapse_to_vmk(partitioned_sf: cute.Tensor):
+        """Collapse a partitioned scale-factor view down to rank-3 ``(V, MN, K)``.
+
+        ``cute.flatten`` normalizes *nesting* but not the *number* of modes. The
+        SF SMEM layout carries a ``blk_sf // mma_nsf`` K sub-mode whose extent is
+        ``1`` for NVF4 (``mma_nsf == 4``) but ``2`` for MXF4 (``mma_nsf == 2``),
+        so MXF4 keeps one extra non-degenerate K mode and the view ends up at
+        rank 4. The mainloop indexes these fragments as ``t[None, tile, k_block]``,
+        which requires exactly rank 3, so fold the trailing K modes into one.
+        """
+        rank = cute.rank(partitioned_sf)
+        if rank > 3:
+            partitioned_sf = cute.group_modes(partitioned_sf, 2, rank)
+        return partitioned_sf
+
     def _partition_fragment_SFA(
         self,
         sfa_tensor: cute.Tensor,
@@ -557,6 +600,7 @@ class DenseGemmKernel:
         thr_vmk = (thr_vmnk[0], (thr_vmnk[1], thr_vmnk[3]))
         partitioned_sfa = thr_tensor[thr_vmk, (None, None)]
         partitioned_sfa = cute.group_modes(cute.flatten(partitioned_sfa), 0, 2)
+        partitioned_sfa = self._collapse_to_vmk(partitioned_sfa)
         return cute.make_fragment_like(partitioned_sfa)
 
     def _partition_fragment_SFB(
@@ -572,6 +616,7 @@ class DenseGemmKernel:
         partitioned_sfb = thr_tensor[thr_vnk, (None, None)]
         partitioned_sfb = cute.group_modes(cute.flatten(partitioned_sfb), 0, 2)
         partitioned_sfb = cute.group_modes(partitioned_sfb, 1, 3)
+        partitioned_sfb = self._collapse_to_vmk(partitioned_sfb)
         return cute.make_fragment_like(partitioned_sfb)
 
     def _thrfrg_SFA(self, sfa_tensor, tiled_mma: cute.TiledMma):
@@ -1391,6 +1436,18 @@ class DenseGemmKernel:
                 tCsSFB_p_filtered = cute.filter_zeros(tCsSFB_p)
                 tCrSFA_copy_view_filtered = cute.filter_zeros(tCrSFA_tile_copy_view)
                 tCrSFB_copy_view_filtered = cute.filter_zeros(tCrSFB_tile_copy_view)
+                (
+                    tCsSFA_p_filtered,
+                    tCrSFA_copy_view_filtered,
+                ) = self._align_sf_copy_ranks(
+                    tCsSFA_p_filtered, tCrSFA_copy_view_filtered
+                )
+                (
+                    tCsSFB_p_filtered,
+                    tCrSFB_copy_view_filtered,
+                ) = self._align_sf_copy_ranks(
+                    tCsSFB_p_filtered, tCrSFB_copy_view_filtered
+                )
 
                 # The fragments hold a full stage of scale factors, so copy
                 # them once per stage.
@@ -1475,6 +1532,18 @@ class DenseGemmKernel:
                             )
                             tCrSFB_copy_view_filtered = cute.filter_zeros(
                                 tCrSFB_tile_copy_view
+                            )
+                            (
+                                tCsSFA_p_filtered,
+                                tCrSFA_copy_view_filtered,
+                            ) = self._align_sf_copy_ranks(
+                                tCsSFA_p_filtered, tCrSFA_copy_view_filtered
+                            )
+                            (
+                                tCsSFB_p_filtered,
+                                tCrSFB_copy_view_filtered,
+                            ) = self._align_sf_copy_ranks(
+                                tCsSFB_p_filtered, tCrSFB_copy_view_filtered
                             )
                             cute.copy(
                                 smem_tiled_copy_SFA,

--- a/tests/gemm/test_mm_fp4.py
+++ b/tests/gemm/test_mm_fp4.py
@@ -44,14 +44,14 @@ def _test_mm_fp4(
             pytest.skip("b12x backend only supports 128x4 SF layout")
         if compute_capability[0] != 12:
             pytest.skip("b12x backend only supports SM120/SM121 GPUs.")
-        if not use_nvfp4:
-            pytest.skip("b12x backend only supports NVFP4 (sf_vec_size=16).")
         if torch.version.cuda and int(torch.version.cuda.split(".")[0]) < 13:
             pytest.skip("b12x backend requires CUDA 13+.")
     if not use_128x4_sf_layout and backend != "trtllm":
         pytest.skip("Skipping test for non-trtllm fp4 with use_128x4_sf_layout=False")
-    if not use_nvfp4 and backend not in ["cudnn", "auto", "cute-dsl"]:
-        pytest.skip("mx_fp4 is only supported for cudnn, cute-dsl, and auto backends")
+    if not use_nvfp4 and backend not in ["cudnn", "auto", "cute-dsl", "b12x"]:
+        pytest.skip(
+            "mx_fp4 is only supported for cudnn, cute-dsl, b12x, and auto backends"
+        )
 
     input = torch.randn([m, k], device="cuda", dtype=torch.bfloat16)
     mat2 = torch.randn([n, k], device="cuda", dtype=torch.bfloat16)


### PR DESCRIPTION
## 📌 Description

Enables **MXFP4** (block size 32, E8M0 scale factors) for the **b12x** (CuTe DSL) FP4 dense GEMM kernel on SM120, alongside the existing NVFP4 (block size 16, E4M3) path.

Ports the dense GEMM portion of #3541 onto current `main`.

### Changes

**Kernel** (`flashinfer/gemm/kernels/dense_blockscaled_gemm_sm120_b12x.py`)
- Select `MmaMXF4Op` when `sf_vec_size == 32`, keep `MmaMXF4NVF4Op` for 16 — the cutlass-dsl wrapper hard-codes `sf_vec_size`/`sf_dtype` per op, so the two modes need separate ops. Matches the pattern already used by the SM12x MoE kernels.
- Add `_collapse_to_vmk()` and `_align_sf_copy_ranks()` to normalize scale-factor view ranks. MXFP4 carries one extra non-degenerate K sub-mode (`blk_sf // mma_nsf` is 2 for MXFP4 vs 1 for NVFP4), which the rank-3 mainloop indexing and the SMEM→RMEM SF copies both require folded back. Both helpers are conditional, so NVFP4 behavior is unchanged.

**Backend dispatch** (`flashinfer/gemm/gemm_base.py`)
- Drop the `use_nvfp4` restriction in `_b12x_gemm_fp4_requirement`.
- Make `sf_vec_size`/`sf_dtype` dynamic in `B12xFp4GemmRunner` (`16`/`Float8E4M3FN` for NVFP4, `32`/`Float8E8M0FNU` for MXFP4).
- Let `_heuristic_func_mm_fp4` prefer b12x for MXFP4 as well on SM120 + CUDA 13.

**Benchmark harness** (`benchmarks/routines/gemm.py`)
- Extend the `alpha_for_cute_dsl_mxfp4` whitelist to include `b12x`. MXFP4 passes `alpha=None`, and b12x — being a CuTe DSL kernel — needs the same unit-alpha tensor as `cute-dsl`.

### Performance

Hardware: **NVIDIA RTX PRO 5000 Blackwell 72GB** (SM120), CUDA 13, `N=2048, K=2048`, bf16 output, `use_128x4_sf_layout`. Latency in ms, `speedup = cudnn / b12x`.

| M | MXFP4 b12x | MXFP4 cudnn | speedup | NVFP4 b12x | NVFP4 cudnn | speedup |
|---:|---:|---:|---:|---:|---:|---:|
| 1 | 0.008 | 0.010 | **1.25x** | 0.009 | 0.012 | **1.33x** |
| 2 | 0.007 | 0.010 | **1.43x** | 0.009 | 0.012 | **1.33x** |
| 4 | 0.007 | 0.010 | **1.43x** | 0.009 | 0.012 | **1.33x** |
| 8 | 0.008 | 0.010 | **1.25x** | 0.009 | 0.012 | **1.33x** |
| 16 | 0.007 | 0.010 | **1.43x** | 0.009 | 0.012 | **1.33x** |
| 32 | 0.007 | 0.010 | **1.43x** | 0.009 | 0.012 | **1.33x** |
| 64 | 0.008 | 0.010 | **1.25x** | 0.009 | 0.012 | **1.33x** |
| 128 | 0.008 | 0.010 | **1.25x** | 0.010 | 0.012 | **1.20x** |
| 256 | 0.009 | 0.011 | **1.22x** | 0.010 | 0.013 | **1.30x** |
| 512 | 0.019 | 0.012 | 0.63x | 0.013 | 0.013 | 1.00x |
| 1024 | 0.034 | 0.018 | 0.53x | 0.022 | 0.023 | 1.05x |
| 2048 | 0.050 | 0.033 | 0.66x | 0.033 | 0.032 | 0.97x |
| 4096 | 0.078 | 0.052 | 0.67x | 0.054 | 0.052 | 0.96x |

b12x is **1.20x–1.43x** faster than cuDNN in the decode / small-batch regime (M ≤ 256) for both quantization modes. cuDNN wins for M ≥ 512, where MXFP4 regresses more than NVFP4.

Since `auto` now ranks b12x first for MXFP4 on SM120 + CUDA 13, happy to gate that preference on an M threshold, or keep MXFP4 as an explicit `backend="b12x"` opt-in — whichever reviewers prefer. Worth noting cuDNN is currently the only other backend accepting MXFP4 here (`_cutlass_gemm_fp4_requirement` rejects it, trtllm does not cover SM120), so this adds a second viable MXFP4 path either way.

## 🔍 Related Issues

Ports the dense GEMM portion of #3541.

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

`tests/gemm/test_mm_fp4.py` on RTX PRO 5000 Blackwell 72GB:

```
5549 passed, 18409 skipped, 2028 warnings in 205.57s (0:03:25)
```

Skips are the expected combinations for this device: backends unsupported on compute capability 12.0 (`trtllm`, `cute-dsl`), and `use_128x4_sf_layout=False` (8x4 is trtllm-only).

Test-side change: removed the `use_nvfp4`-only skip for b12x and added `"b12x"` to the MXFP4 backend allowlist, so the existing `mxfp4` / `mxfp4_alpha` parametrizations now exercise the new path with reference checking.

## Reviewer Notes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added MXFP4 support for FP4 GEMM operations on supported hardware with CUDA 13+.
  * Automatic FP4 backend selection now supports both NVFP4 and MXFP4 modes, prioritizing the optimized backend where available.

* **Bug Fixes**
  * Improved scale-factor handling for reliable MXFP4 and NVFP4 matrix multiplication.
  * Expanded validation and test coverage for MXFP4 workloads on supported configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->