### PR TITLE
chore: add KDA CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -63,6 +63,22 @@ flashinfer/mamba/               @kahyunnam @yzh119 @bkryu @jimmyzho @ishovkun
 include/flashinfer/mamba/       @kahyunnam @yzh119 @bkryu @jimmyzho @ishovkun
 tests/mamba/                    @kahyunnam @yzh119 @bkryu @jimmyzho @ishovkun
 
+# ── KDA ──
+benchmarks/bench_recurrent_kda*          @kahyunnam @yzh119 @bkryu @jimmyzho
+csrc/kda/                                @kahyunnam @yzh119 @bkryu @jimmyzho
+docs/api/kda.rst                         @kahyunnam @yzh119 @bkryu @jimmyzho
+docs/api/kda_decode.rst                  @kahyunnam @yzh119 @bkryu @jimmyzho
+docs/api/kda_prefill.rst                 @kahyunnam @yzh119 @bkryu @jimmyzho
+flashinfer/jit/flash_kda.py              @kahyunnam @yzh119 @bkryu @jimmyzho
+flashinfer/jit/flash_kda_decode.py       @kahyunnam @yzh119 @bkryu @jimmyzho
+flashinfer/kda.py                        @kahyunnam @yzh119 @bkryu @jimmyzho
+flashinfer/kda_decode.py                 @kahyunnam @yzh119 @bkryu @jimmyzho
+flashinfer/kda_kernels/                  @kahyunnam @yzh119 @bkryu @jimmyzho
+flashinfer/kda_prefill.py                @kahyunnam @yzh119 @bkryu @jimmyzho
+flashinfer/trace/templates/kda.py        @kahyunnam @yzh119 @bkryu @jimmyzho
+tests/jit/test_flash_kda*                @kahyunnam @yzh119 @bkryu @jimmyzho
+tests/kda/                               @kahyunnam @yzh119 @bkryu @jimmyzho
+
 # ── Autotuner ──
 flashinfer/autotuner/    @qiching @yzh119 @bkryu @aleozlx
 tests/autotuner/         @qiching @yzh119 @bkryu @aleozlx


### PR DESCRIPTION
## Summary
- Add a dedicated KDA section to `.github/CODEOWNERS` for linear attention PIC group.
- Primary owner `@kahyunnam`; secondary reviewer  `@jimmyzho`,  alternate general owners`@yzh119 @bkryu`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added ownership rules for KDA benchmarks, source code, documentation, implementations, kernels, tracing, and tests.
  * Assigned designated maintainers to review changes in these areas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->