### PR TITLE
ci: upload GitHub unit-test JUnit reports

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -297,6 +297,13 @@ jobs:
         if: matrix.kind != 'aot'
         run: bash ci/bash.sh ${DOCKER_IMAGE} ./scripts/${{ matrix.script }}
 
+      - name: Make JUnit XML readable
+        if: ${{ always() && matrix.kind == 'h100' }}
+        run: |
+          if [ -d junit ]; then
+            sudo chmod -R a+rX junit
+          fi
+
       - name: Upload JUnit XML
         if: ${{ always() && matrix.kind == 'h100' }}
         uses: actions/upload-artifact@v4

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -297,6 +297,15 @@ jobs:
         if: matrix.kind != 'aot'
         run: bash ci/bash.sh ${DOCKER_IMAGE} ./scripts/${{ matrix.script }}
 
+      - name: Upload JUnit XML
+        if: ${{ always() && matrix.kind == 'h100' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: junit-h100-${{ github.run_id }}-${{ github.run_attempt }}
+          path: junit/**/*.xml
+          if-no-files-found: warn
+          retention-days: 30
+
 
   # ---------------------------------------------------------------------------
   # Test Results Summary


### PR DESCRIPTION
## Summary

- upload the H100 unit-test JUnit XML even when the test step fails
- retain reports for 30 days for later analysis
- warn when an early failure prevents XML generation

The A10G and T4 jobs still run legacy scripts that do not generate JUnit XML, so this only uploads reports from the H100 sharded runner.

## Validation

- pre-commit hooks passed
- git diff --check
- parsed .github/workflows/pr-test.yml with PyYAML

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Test results from H100 matrix runs are now uploaded as downloadable JUnit XML artifacts, including for failed or cancelled runs.
  * Test artifacts are retained for 30 days, with warnings shown when result files are unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->