### PR TITLE
fix(jit): invalidate stale nvcc cache artifacts by build fingerprint

### DIFF
--- a/.claude/skills/add-cuda-kernel/SKILL.md
+++ b/.claude/skills/add-cuda-kernel/SKILL.md
@@ -236,6 +236,14 @@ def gen_scale_module(dtype_in, dtype_out):
 - URI uniquely identifies the module configuration
 - **NEVER write to package directories** - see "JIT Directory Rules" in `CLAUDE.md`
 
+`JitSpecNvcc` also records a per-module `meta.json` build fingerprint. Keep all
+generated translation units in `sources` and all relevant header roots in
+`extra_include_paths`; both are content-hashed. The current rendered Ninja
+configuration and toolchain/ABI identities are fingerprinted automatically.
+Missing or mismatched metadata causes the entire module build directory to be
+removed, and metadata is committed only after a successful Ninja build. Do not
+write build artifacts or metadata outside the `JitSpecNvcc` build lifecycle.
+
 ### (Optional) Specifying Supported CUDA Architectures
 
 FlashInfer uses `CompilationContext` to manage CUDA architecture targets. This is critical because some kernels only work on specific GPU architectures (e.g., Hopper SM90, Blackwell SM100).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -419,7 +419,10 @@ FlashInfer uses two-level caching to avoid recompilation:
 - CUDA architecture change
 - FlashInfer version change
 
-URI computed as: `hash(operation_type + parameters + source_hashes + flags + cuda_arch)`
+The URI identifies the operation's parameter-derived module configuration.
+For NVCC JIT modules, `meta.json` separately validates the cached `.so` against
+the source, rendered Ninja configuration, flags, architecture, ABI, and
+toolchain fingerprint described above.
 
 **Cache management:**
 - Clear cache: `rm -rf ~/.cache/flashinfer/`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -282,6 +282,22 @@ def gen_some_module(dtype_in, dtype_out, ...):
 
 The generated `build.ninja` file uses nvcc to compile .cu → .cuda.o → .so, then loads via TVM-FFI.
 
+#### NVCC JIT Cache Fingerprints
+
+Every `JitSpecNvcc` build directory contains a committed `meta.json` alongside
+its `.so`. The metadata fingerprints the module sources and include tree, the
+currently rendered Ninja configuration and flags, the FlashInfer wheel/git
+identity, Python/Torch/TVM-FFI ABI, and the nvcc/C++ toolchain. A JIT artifact is
+valid only when the `.so` exists and this fingerprint matches.
+
+Missing, corrupt, or mismatched metadata invalidates the whole module build
+directory before Ninja runs; never preserve an unverified `.o` or `.so`. Write
+`meta.json` atomically only after Ninja succeeds, using the exact pre-build
+snapshot associated with that invocation. `build_jit_specs()` applies the same
+contract and holds every selected module lock, in deterministic order, through
+the shared Ninja run and all metadata commits. AOT artifacts are prevalidated
+by packaging and do not use this JIT metadata gate.
+
 ### Jinja Templates (Optional)
 
 **Note: Jinja templates are NOT required.** You can write C++ code directly without templating.

--- a/flashinfer/jit/core.py
+++ b/flashinfer/jit/core.py
@@ -1,12 +1,16 @@
 import abc
 import dataclasses
 import functools
+import hashlib
+import json
 import logging
 import os
+import shutil
+import sysconfig
 from contextlib import nullcontext
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Sequence, Union, Hashable
+from typing import Any, Dict, List, Optional, Sequence, Tuple, Union, Hashable
 
 import tvm_ffi
 from filelock import FileLock
@@ -138,6 +142,127 @@ sm120f_nvcc_flags = ["-gencode=arch=compute_120f,code=sm_120f"] + common_nvcc_fl
 sm121a_nvcc_flags = ["-gencode=arch=compute_121a,code=sm_121a"] + common_nvcc_flags
 
 current_compilation_context = CompilationContext()
+
+_META_FILENAME = "meta.json"
+_META_SCHEMA_VERSION = 1
+
+
+def _hash_file_sha256(path: Path) -> str:
+    """Return the SHA-256 of ``path``'s contents, or ``None`` if unreadable."""
+    try:
+        with open(path, "rb") as f:
+            return hashlib.sha256(f.read()).hexdigest()
+    except OSError:
+        return None
+
+
+@functools.lru_cache(maxsize=1)
+def _hash_source_tree_cached(include_dirs: Tuple[Path, ...]) -> str:
+    return _hash_source_tree_uncached(include_dirs)
+
+
+def _hash_source_tree_uncached(include_dirs: Sequence[Path]) -> str:
+    """Hash the flashinfer C++/CUDA source tree under ``include_dirs``.
+
+    Each directory is walked independently; files are keyed by their absolute
+    path so overlapping roots (e.g. ``data/csrc`` and the repository ``csrc``)
+    are all covered without double-counting. Digest is stable regardless of
+    directory enumeration order.
+    """
+    sha = hashlib.sha256()
+    seen = set()
+    for base in include_dirs:
+        if base is None or not Path(base).is_dir():
+            continue
+        for root, _dirs, files in os.walk(Path(base)):
+            for fname in sorted(files):
+                fpath = Path(root) / fname
+                if fpath in seen:
+                    continue
+                seen.add(fpath)
+                sha.update(str(fpath).encode())
+                digest = _hash_file_sha256(fpath)
+                if digest is not None:
+                    sha.update(digest.encode())
+    return sha.hexdigest()
+
+
+def _hash_source_tree(include_dirs: Sequence[Path]) -> str:
+    return _hash_source_tree_cached(tuple(Path(p) for p in include_dirs))
+
+
+@functools.lru_cache(maxsize=1)
+def _get_wheel_record_hash() -> Optional[str]:
+    """Hash the wheel RECORD entries for files under ``flashinfer/``.
+
+    A wheel reinstall with different byte content (even at the same version)
+    changes this digest, so stale nvcc artifacts built from the previous
+    install are invalidated. Returns ``None`` when not installed from a wheel.
+    """
+    try:
+        import importlib.metadata as _md
+
+        dist = _md.distribution("flashinfer-python")
+        record = dist.read_text("RECORD")
+    except Exception:
+        return None
+    if record is None:
+        return None
+    sha = hashlib.sha256()
+    for line in record.splitlines():
+        entry = line.split(",", 1)[0]
+        if entry.startswith("flashinfer/"):
+            sha.update(entry.encode())
+    return sha.hexdigest()
+
+
+def _get_python_soabi() -> str:
+    soabi = sysconfig.get_config_var("SOABI")
+    return soabi or "unknown"
+
+
+@functools.lru_cache(maxsize=1)
+def _get_torch_build_identity() -> str:
+    """Torch version, bundled CUDA version and libstdc++ ABI as one string."""
+    try:
+        import torch
+
+        cxx11 = getattr(torch._C, "_GLIBCXX_USE_CXX11_ABI", None)
+        return f"torch={torch.__version__},cuda={torch.version.cuda},cxx11_abi={cxx11}"
+    except Exception:
+        return "torch=unknown"
+
+
+@functools.lru_cache(maxsize=1)
+def _get_tvm_ffi_version() -> str:
+    try:
+        import importlib.metadata as _md
+
+        return _md.version("tvm-ffi")
+    except Exception:
+        return "unknown"
+
+
+def _read_meta(meta_path: Path) -> Optional[dict]:
+    """Read and parse a module ``meta.json``; ``None`` when absent/corrupt."""
+    try:
+        with open(meta_path) as f:
+            return json.load(f)
+    except Exception:
+        return None
+
+
+def _write_meta_atomic(meta_path: Path, meta: dict) -> None:
+    """Atomically write ``meta.json`` via a temp file + ``os.replace``."""
+    meta_path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = meta_path.with_suffix(".json.tmp")
+    try:
+        with open(tmp, "w") as f:
+            json.dump(meta, f, indent=2, sort_keys=True)
+        os.replace(tmp, meta_path)
+    finally:
+        if tmp.exists():
+            tmp.unlink()
 
 
 @dataclasses.dataclass
@@ -375,6 +500,67 @@ class JitSpecNvcc(JitSpec):
     def lock_path(self) -> Path:
         return get_tmpdir() / f"{self.name}.lock"
 
+    @property
+    def meta_path(self) -> Path:
+        return self.build_dir / _META_FILENAME
+
+    @property
+    def expected_meta(self) -> dict:
+        """Build fingerprint for this module.
+
+        Every entry participates in cache invalidation: if any of them
+        differs from the committed ``meta.json``, the module build directory
+        is wiped and rebuilt. Source hashes cover both the module's own
+        sources and the C++/CUDA include tree so that a same-version wheel
+        reinstall with new bytes (whose mtimes may be *older* than the stale
+        artifacts) still triggers a rebuild.
+        """
+        from ..version import __version__ as _fi_version
+        from ..version import __git_commit__ as _fi_git_commit
+
+        include_dirs: List[Path] = []
+        if self.extra_include_dirs is not None:
+            include_dirs.extend(self.extra_include_dirs)
+        include_dirs.append(jit_env.FLASHINFER_CSRC_DIR)
+        # Source installs keep the C++/CUDA sources in the repository tree
+        # rather than ``data/csrc`` (populated only by the wheel build).
+        pkg_root = Path(__file__).resolve().parents[1]
+        for candidate in (
+            pkg_root / "data" / "csrc",
+            pkg_root.parent / "csrc",
+            pkg_root / "data" / "include",
+        ):
+            if candidate.is_dir() and candidate not in include_dirs:
+                include_dirs.append(candidate)
+
+        return {
+            "schema": _META_SCHEMA_VERSION,
+            "flashinfer_version": _fi_version,
+            "git_commit": _fi_git_commit,
+            "wheel_record_hash": _get_wheel_record_hash(),
+            "python_soabi": _get_python_soabi(),
+            "torch_build_identity": _get_torch_build_identity(),
+            "tvm_ffi_version": _get_tvm_ffi_version(),
+            "source_sha256": _hash_source_tree(tuple(include_dirs)),
+            "ninja_content_sha256": _hash_file_sha256(self.ninja_path),
+            "cflags": self.extra_cflags,
+            "cuda_cflags": self.extra_cuda_cflags,
+            "ldflags": self.extra_ldflags,
+        }
+
+    def _meta_matches(self) -> bool:
+        if not self.meta_path.exists():
+            return False
+        return _read_meta(self.meta_path) == self.expected_meta
+
+    def _invalidate_stale_build(self) -> None:
+        if self.build_dir.exists() and not self._meta_matches():
+            logger.info(
+                f"Invalidating stale nvcc module {self.name} "
+                "(build fingerprint mismatch)"
+            )
+            shutil.rmtree(self.build_dir, ignore_errors=True)
+
     def write_ninja(self) -> None:
         ninja_path = self.ninja_path
         self.build_dir.mkdir(parents=True, exist_ok=True)
@@ -423,8 +609,11 @@ class JitSpecNvcc(JitSpec):
             FileLock(self.lock_path, thread_local=False) if need_lock else nullcontext()
         )
         with lock:
+            self._invalidate_stale_build()
             self.write_ninja()
             run_ninja(self.build_dir, self.ninja_path, verbose)
+            if self.jit_library_path.exists():
+                _write_meta_atomic(self.meta_path, self.expected_meta)
 
     def load(self, so_path: Optional[Path] = None):
         return tvm_ffi.load_module(str(so_path or self.jit_library_path))

--- a/flashinfer/jit/core.py
+++ b/flashinfer/jit/core.py
@@ -7,7 +7,7 @@ import logging
 import os
 import shutil
 import sysconfig
-from contextlib import nullcontext
+from contextlib import ExitStack, nullcontext
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Sequence, Union, Hashable
@@ -543,6 +543,9 @@ class JitSpecNvcc(JitSpec):
 
     @property
     def expected_meta(self) -> dict:
+        return self._expected_meta(self._render_ninja())
+
+    def _expected_meta(self, ninja_content: str) -> dict:
         """Build fingerprint for this module.
 
         Every entry participates in cache invalidation: if any of them
@@ -583,7 +586,7 @@ class JitSpecNvcc(JitSpec):
             "sources_sha256": {
                 str(src): _hash_file_sha256(src) for src in self.sources
             },
-            "ninja_content_sha256": _hash_file_sha256(self.ninja_path),
+            "ninja_content_sha256": hashlib.sha256(ninja_content.encode()).hexdigest(),
             "cflags": self.extra_cflags,
             "cuda_cflags": self.extra_cuda_cflags,
             "ldflags": self.extra_ldflags,
@@ -595,14 +598,15 @@ class JitSpecNvcc(JitSpec):
         expected = self.expected_meta if expected is None else expected
         return _read_meta(self.meta_path) == expected
 
-    def _invalidate_stale_build(self) -> bool:
+    def _invalidate_stale_build(self, expected: Optional[dict] = None) -> bool:
         """Wipe the build dir when the committed fingerprint no longer matches.
 
         Returns ``True`` when the directory was actually removed (so the
-        caller knows to regenerate the ninja file). A directory without
-        ``meta.json`` is a fresh or in-progress build and is left alone.
+        caller knows to regenerate the ninja file). Missing or corrupt metadata
+        is a mismatch: an existing artifact without a committed fingerprint is
+        never safe to reuse.
         """
-        if self.meta_path.exists() and not self._meta_matches():
+        if self.build_dir.exists() and not self._meta_matches(expected):
             logger.info(
                 f"Invalidating stale nvcc module {self.name} "
                 "(build fingerprint mismatch)"
@@ -614,10 +618,9 @@ class JitSpecNvcc(JitSpec):
             return True
         return False
 
-    def write_ninja(self) -> None:
-        ninja_path = self.ninja_path
-        self.build_dir.mkdir(parents=True, exist_ok=True)
-        content = generate_ninja_build_for_op(
+    def _render_ninja(self) -> str:
+        """Render the Ninja configuration used by both metadata and build."""
+        return generate_ninja_build_for_op(
             name=self.name,
             sources=self.sources,
             extra_cflags=self.extra_cflags,
@@ -626,6 +629,11 @@ class JitSpecNvcc(JitSpec):
             extra_include_dirs=self.extra_include_dirs,
             needs_device_linking=self.needs_device_linking,
         )
+
+    def write_ninja(self, content: Optional[str] = None) -> None:
+        ninja_path = self.ninja_path
+        self.build_dir.mkdir(parents=True, exist_ok=True)
+        content = self._render_ninja() if content is None else content
         write_if_different(ninja_path, content)
 
     @property
@@ -662,17 +670,17 @@ class JitSpecNvcc(JitSpec):
             FileLock(self.lock_path, thread_local=False) if need_lock else nullcontext()
         )
         with lock:
-            self.write_ninja()
-            # A stale wipe removes the build dir (and its ninja file); regen it
-            # so the snapshot below matches what ninja will actually run.
-            if self._invalidate_stale_build():
-                self.write_ninja()
-            # Snapshot the fingerprint before building: if sources change
+            # Render once so the metadata snapshot describes exactly the Ninja
+            # configuration that this build writes and executes.
+            ninja_content = self._render_ninja()
+            expected = self._expected_meta(ninja_content)
+            self._invalidate_stale_build(expected)
+            self.write_ninja(ninja_content)
+            # Snapshot the remaining inputs before building: if sources change
             # mid-build, the committed metadata still describes the inputs
             # this build started from, and the next build (whose depfile now
             # differs) will recompile. Never bless objects with a fingerprint
             # computed after the fact.
-            expected = self.expected_meta
             run_ninja(self.build_dir, self.ninja_path, verbose)
             if self.jit_library_path.exists():
                 _write_meta_atomic(self.meta_path, expected)
@@ -859,8 +867,7 @@ def build_jit_specs(
     verbose: bool = False,
     skip_prebuilt: bool = True,
 ) -> None:
-    lines: List[str] = []
-    built_specs: List[tuple] = []
+    selected_specs: List[JitSpecNvcc] = []
     for spec in specs:
         if not isinstance(spec, JitSpecNvcc):
             raise TypeError(
@@ -869,25 +876,37 @@ def build_jit_specs(
             )
         if skip_prebuilt and spec.aot_path.exists():
             continue
-        with FileLock(spec.lock_path, thread_local=False):
+        selected_specs.append(spec)
+    if not selected_specs:
+        return
+
+    # Hold every module lock from invalidation through metadata commit. Sorting
+    # lock paths gives concurrent batch builders one acquisition order and
+    # prevents deadlocks when their module sets overlap.
+    with ExitStack() as stack:
+        for lock_path in sorted({spec.lock_path for spec in selected_specs}, key=str):
+            stack.enter_context(FileLock(lock_path, thread_local=False))
+
+        lines: List[str] = []
+        built_specs: List[tuple[JitSpecNvcc, dict]] = []
+        for spec in selected_specs:
             # Same fingerprint gate as JitSpecNvcc.build(): wipe stale build
             # dirs before the shared ninja run so a batch build can never
             # copy artifacts built from older sources.
-            spec.write_ninja()
-            if spec._invalidate_stale_build():
-                spec.write_ninja()
-            built_specs.append((spec, spec.expected_meta))
-        lines.append(f"subninja {spec.ninja_path}")
-    if not lines:
-        return
+            ninja_content = spec._render_ninja()
+            expected = spec._expected_meta(ninja_content)
+            spec._invalidate_stale_build(expected)
+            spec.write_ninja(ninja_content)
+            built_specs.append((spec, expected))
+            lines.append(f"subninja {spec.ninja_path}")
 
-    lines = ["ninja_required_version = 1.3"] + lines + [""]
+        lines = ["ninja_required_version = 1.3"] + lines + [""]
 
-    tmpdir = get_tmpdir()
-    with FileLock(tmpdir / "flashinfer_jit.lock", thread_local=False):
-        ninja_path = tmpdir / "flashinfer_jit.ninja"
-        write_if_different(ninja_path, "\n".join(lines))
-        run_ninja(jit_env.FLASHINFER_JIT_DIR, ninja_path, verbose)
-        for spec, expected in built_specs:
-            if spec.jit_library_path.exists():
-                _write_meta_atomic(spec.meta_path, expected)
+        tmpdir = get_tmpdir()
+        with FileLock(tmpdir / "flashinfer_jit.lock", thread_local=False):
+            ninja_path = tmpdir / "flashinfer_jit.ninja"
+            write_if_different(ninja_path, "\n".join(lines))
+            run_ninja(jit_env.FLASHINFER_JIT_DIR, ninja_path, verbose)
+            for spec, expected in built_specs:
+                if spec.jit_library_path.exists():
+                    _write_meta_atomic(spec.meta_path, expected)

--- a/flashinfer/jit/core.py
+++ b/flashinfer/jit/core.py
@@ -10,7 +10,7 @@ import sysconfig
 from contextlib import nullcontext
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Sequence, Tuple, Union, Hashable
+from typing import Any, Dict, List, Optional, Sequence, Union, Hashable
 
 import tvm_ffi
 from filelock import FileLock
@@ -156,25 +156,23 @@ def _hash_file_sha256(path: Path) -> str:
         return None
 
 
-@functools.lru_cache(maxsize=1)
-def _hash_source_tree_cached(include_dirs: Tuple[Path, ...]) -> str:
-    return _hash_source_tree_uncached(include_dirs)
-
-
-def _hash_source_tree_uncached(include_dirs: Sequence[Path]) -> str:
+def _hash_source_tree(include_dirs: Sequence[Path]) -> str:
     """Hash the flashinfer C++/CUDA source tree under ``include_dirs``.
 
-    Each directory is walked independently; files are keyed by their absolute
-    path so overlapping roots (e.g. ``data/csrc`` and the repository ``csrc``)
-    are all covered without double-counting. Digest is stable regardless of
-    directory enumeration order.
+    Recalculated on every call so a source edit under an editable install is
+    always observed (no process-wide cache that can go stale). Each directory
+    is walked independently; files are keyed by their absolute path so
+    overlapping roots (e.g. ``data/csrc`` and the repository ``csrc``) are all
+    covered without double-counting. Directories and files are walked in
+    sorted order for a deterministic digest.
     """
     sha = hashlib.sha256()
     seen = set()
     for base in include_dirs:
         if base is None or not Path(base).is_dir():
             continue
-        for root, _dirs, files in os.walk(Path(base)):
+        for root, dirs, files in os.walk(Path(base)):
+            dirs.sort()
             for fname in sorted(files):
                 fpath = Path(root) / fname
                 if fpath in seen:
@@ -187,17 +185,14 @@ def _hash_source_tree_uncached(include_dirs: Sequence[Path]) -> str:
     return sha.hexdigest()
 
 
-def _hash_source_tree(include_dirs: Sequence[Path]) -> str:
-    return _hash_source_tree_cached(tuple(Path(p) for p in include_dirs))
-
-
 @functools.lru_cache(maxsize=1)
 def _get_wheel_record_hash() -> Optional[str]:
-    """Hash the wheel RECORD entries for files under ``flashinfer/``.
+    """Hash the content digests of wheel RECORD entries under ``flashinfer/``.
 
-    A wheel reinstall with different byte content (even at the same version)
-    changes this digest, so stale nvcc artifacts built from the previous
-    install are invalidated. Returns ``None`` when not installed from a wheel.
+    Hashes the full RECORD row (path + ``sha256=...`` + size) rather than just
+    the path, so a same-version reinstall with different bytes invalidates
+    stale artifacts even when file paths are unchanged. Returns ``None`` when
+    not installed from a wheel.
     """
     try:
         import importlib.metadata as _md
@@ -210,9 +205,8 @@ def _get_wheel_record_hash() -> Optional[str]:
         return None
     sha = hashlib.sha256()
     for line in record.splitlines():
-        entry = line.split(",", 1)[0]
-        if entry.startswith("flashinfer/"):
-            sha.update(entry.encode())
+        if line.startswith("flashinfer/"):
+            sha.update(line.encode())
     return sha.hexdigest()
 
 
@@ -238,9 +232,44 @@ def _get_tvm_ffi_version() -> str:
     try:
         import importlib.metadata as _md
 
-        return _md.version("tvm-ffi")
+        # The PyPI distribution is ``apache-tvm-ffi``.
+        return _md.version("apache-tvm-ffi")
     except Exception:
         return "unknown"
+
+
+@functools.lru_cache(maxsize=1)
+def _get_compiler_identity() -> str:
+    """Identify the nvcc and host C++ toolchains used by the build.
+
+    ``torch.version.cuda`` reflects the bundled toolkit, not necessarily the
+    system ``nvcc``/``CXX`` the JIT build invokes, so capture the actual
+    compiler versions. The result is cached: the toolchain does not change
+    within a process.
+    """
+    import subprocess
+
+    def _version_of(binary: str) -> str:
+        try:
+            out = subprocess.run(
+                [binary, "--version"],
+                capture_output=True,
+                text=True,
+                timeout=10,
+                check=False,
+            )
+            first = (out.stdout or out.stderr).strip().splitlines()
+            return first[0][:200] if first else "unknown"
+        except Exception:
+            return "unknown"
+
+    nvcc = os.environ.get("FLASHINFER_NVCC", shutil.which("nvcc") or "nvcc")
+    cxx = os.environ.get("CXX", shutil.which("c++") or "c++")
+    return (
+        f"nvcc={_version_of(nvcc)};cxx={_version_of(cxx)};"
+        f"nvcc_launcher={os.environ.get('FLASHINFER_NVCC_LAUNCHER', '')};"
+        f"cxx_launcher={os.environ.get('FLASHINFER_CXX_LAUNCHER', '')}"
+    )
 
 
 def _read_meta(meta_path: Path) -> Optional[dict]:
@@ -253,9 +282,13 @@ def _read_meta(meta_path: Path) -> Optional[dict]:
 
 
 def _write_meta_atomic(meta_path: Path, meta: dict) -> None:
-    """Atomically write ``meta.json`` via a temp file + ``os.replace``."""
+    """Atomically write ``meta.json`` via a unique temp file + ``os.replace``.
+
+    Uses a process-unique temp name so concurrent unlocked ``build()`` calls
+    never race on a shared temp path.
+    """
     meta_path.parent.mkdir(parents=True, exist_ok=True)
-    tmp = meta_path.with_suffix(".json.tmp")
+    tmp = meta_path.parent / f".{meta_path.name}.{os.getpid()}.{id(meta):x}.tmp"
     try:
         with open(tmp, "w") as f:
             json.dump(meta, f, indent=2, sort_keys=True)
@@ -494,7 +527,11 @@ class JitSpecNvcc(JitSpec):
 
     @property
     def is_compiled(self) -> bool:
-        return self.get_library_path().exists()
+        # AOT artifacts are valid by construction; JIT artifacts require the
+        # build fingerprint to match, otherwise a stale .so counts as missing.
+        if self.is_aot:
+            return self.get_library_path().exists()
+        return self.get_library_path().exists() and self._meta_matches()
 
     @property
     def lock_path(self) -> Path:
@@ -541,25 +578,41 @@ class JitSpecNvcc(JitSpec):
             "python_soabi": _get_python_soabi(),
             "torch_build_identity": _get_torch_build_identity(),
             "tvm_ffi_version": _get_tvm_ffi_version(),
+            "compiler_identity": _get_compiler_identity(),
             "source_sha256": _hash_source_tree(tuple(include_dirs)),
+            "sources_sha256": {
+                str(src): _hash_file_sha256(src) for src in self.sources
+            },
             "ninja_content_sha256": _hash_file_sha256(self.ninja_path),
             "cflags": self.extra_cflags,
             "cuda_cflags": self.extra_cuda_cflags,
             "ldflags": self.extra_ldflags,
         }
 
-    def _meta_matches(self) -> bool:
+    def _meta_matches(self, expected: Optional[dict] = None) -> bool:
         if not self.meta_path.exists():
             return False
-        return _read_meta(self.meta_path) == self.expected_meta
+        expected = self.expected_meta if expected is None else expected
+        return _read_meta(self.meta_path) == expected
 
-    def _invalidate_stale_build(self) -> None:
-        if self.build_dir.exists() and not self._meta_matches():
+    def _invalidate_stale_build(self) -> bool:
+        """Wipe the build dir when the committed fingerprint no longer matches.
+
+        Returns ``True`` when the directory was actually removed (so the
+        caller knows to regenerate the ninja file). A directory without
+        ``meta.json`` is a fresh or in-progress build and is left alone.
+        """
+        if self.meta_path.exists() and not self._meta_matches():
             logger.info(
                 f"Invalidating stale nvcc module {self.name} "
                 "(build fingerprint mismatch)"
             )
-            shutil.rmtree(self.build_dir, ignore_errors=True)
+            # A failed wipe must abort: continuing would compile into a
+            # directory that still holds stale objects and then "bless" them
+            # with a fresh meta.json.
+            shutil.rmtree(self.build_dir)
+            return True
+        return False
 
     def write_ninja(self) -> None:
         ninja_path = self.ninja_path
@@ -609,11 +662,20 @@ class JitSpecNvcc(JitSpec):
             FileLock(self.lock_path, thread_local=False) if need_lock else nullcontext()
         )
         with lock:
-            self._invalidate_stale_build()
             self.write_ninja()
+            # A stale wipe removes the build dir (and its ninja file); regen it
+            # so the snapshot below matches what ninja will actually run.
+            if self._invalidate_stale_build():
+                self.write_ninja()
+            # Snapshot the fingerprint before building: if sources change
+            # mid-build, the committed metadata still describes the inputs
+            # this build started from, and the next build (whose depfile now
+            # differs) will recompile. Never bless objects with a fingerprint
+            # computed after the fact.
+            expected = self.expected_meta
             run_ninja(self.build_dir, self.ninja_path, verbose)
             if self.jit_library_path.exists():
-                _write_meta_atomic(self.meta_path, self.expected_meta)
+                _write_meta_atomic(self.meta_path, expected)
 
     def load(self, so_path: Optional[Path] = None):
         return tvm_ffi.load_module(str(so_path or self.jit_library_path))
@@ -798,6 +860,7 @@ def build_jit_specs(
     skip_prebuilt: bool = True,
 ) -> None:
     lines: List[str] = []
+    built_specs: List[tuple] = []
     for spec in specs:
         if not isinstance(spec, JitSpecNvcc):
             raise TypeError(
@@ -806,9 +869,15 @@ def build_jit_specs(
             )
         if skip_prebuilt and spec.aot_path.exists():
             continue
-        lines.append(f"subninja {spec.ninja_path}")
         with FileLock(spec.lock_path, thread_local=False):
+            # Same fingerprint gate as JitSpecNvcc.build(): wipe stale build
+            # dirs before the shared ninja run so a batch build can never
+            # copy artifacts built from older sources.
             spec.write_ninja()
+            if spec._invalidate_stale_build():
+                spec.write_ninja()
+            built_specs.append((spec, spec.expected_meta))
+        lines.append(f"subninja {spec.ninja_path}")
     if not lines:
         return
 
@@ -819,3 +888,6 @@ def build_jit_specs(
         ninja_path = tmpdir / "flashinfer_jit.ninja"
         write_if_different(ninja_path, "\n".join(lines))
         run_ninja(jit_env.FLASHINFER_JIT_DIR, ninja_path, verbose)
+        for spec, expected in built_specs:
+            if spec.jit_library_path.exists():
+                _write_meta_atomic(spec.meta_path, expected)

--- a/flashinfer/jit/core.py
+++ b/flashinfer/jit/core.py
@@ -2,6 +2,7 @@ import abc
 import dataclasses
 import functools
 import hashlib
+import inspect
 import json
 import logging
 import os
@@ -23,6 +24,17 @@ from .utils import write_if_different
 os.makedirs(jit_env.FLASHINFER_WORKSPACE_DIR, exist_ok=True)
 # Note: Do NOT create FLASHINFER_CSRC_DIR here - it's the package directory
 # which may be read-only after installation
+
+
+class _PersistentFileLock(FileLock):
+    """Native file lock whose pathname remains stable on shared caches."""
+
+    def __init__(self, lock_file: Union[str, os.PathLike], **kwargs: Any):
+        # Older filelock releases do not expose this option; their Unix
+        # backend already preserves the lock pathname.
+        if "preserve_lock_file" in inspect.signature(FileLock).parameters:
+            kwargs["preserve_lock_file"] = True
+        super().__init__(lock_file, **kwargs)
 
 
 class MissingJITCacheError(RuntimeError):
@@ -885,7 +897,7 @@ def build_jit_specs(
     # prevents deadlocks when their module sets overlap.
     with ExitStack() as stack:
         for lock_path in sorted({spec.lock_path for spec in selected_specs}, key=str):
-            stack.enter_context(FileLock(lock_path, thread_local=False))
+            stack.enter_context(_PersistentFileLock(lock_path, thread_local=False))
 
         lines: List[str] = []
         built_specs: List[tuple[JitSpecNvcc, dict]] = []

--- a/flashinfer/jit/core.py
+++ b/flashinfer/jit/core.py
@@ -8,6 +8,7 @@ import logging
 import os
 import shutil
 import sysconfig
+import tempfile
 from contextlib import ExitStack, nullcontext
 from datetime import datetime
 from pathlib import Path
@@ -616,7 +617,9 @@ class JitSpecNvcc(JitSpec):
         Returns ``True`` when the directory was actually removed (so the
         caller knows to regenerate the ninja file). Missing or corrupt metadata
         is a mismatch: an existing artifact without a committed fingerprint is
-        never safe to reuse.
+        never safe to reuse. Generated input sources may live below the build
+        directory, so their top-level trees are staged outside it while stale
+        compiler outputs are removed.
         """
         if self.build_dir.exists() and not self._meta_matches(expected):
             logger.info(
@@ -626,7 +629,44 @@ class JitSpecNvcc(JitSpec):
             # A failed wipe must abort: continuing would compile into a
             # directory that still holds stale objects and then "bless" them
             # with a fresh meta.json.
-            shutil.rmtree(self.build_dir)
+            build_dir = Path(os.path.abspath(self.build_dir))
+            source_roots = set()
+            for source in self.sources:
+                source_abs = Path(os.path.abspath(source))
+                try:
+                    if os.path.commonpath((build_dir, source_abs)) != str(build_dir):
+                        continue
+                except ValueError:
+                    continue
+                relative = source_abs.relative_to(build_dir)
+                if relative.parts:
+                    source_roots.add(build_dir / relative.parts[0])
+
+            existing_roots = sorted(
+                (path for path in source_roots if path.exists() or path.is_symlink()),
+                key=str,
+            )
+            if not existing_roots:
+                shutil.rmtree(self.build_dir)
+                return True
+
+            staging_dir = Path(
+                tempfile.mkdtemp(
+                    prefix=f".{self.name}.sources.", dir=self.build_dir.parent
+                )
+            )
+            staged = []
+            try:
+                for source_root in existing_roots:
+                    staged_root = staging_dir / source_root.name
+                    source_root.replace(staged_root)
+                    staged.append((staged_root, source_root))
+                shutil.rmtree(self.build_dir)
+            finally:
+                self.build_dir.mkdir(parents=True, exist_ok=True)
+                for staged_root, source_root in staged:
+                    staged_root.replace(source_root)
+                staging_dir.rmdir()
             return True
         return False
 

--- a/tests/jit/test_jit_cpp_ext.py
+++ b/tests/jit/test_jit_cpp_ext.py
@@ -1,4 +1,6 @@
+import os
 import subprocess
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
@@ -289,3 +291,176 @@ def test_prefill_jit_helper_skips_fa3_unsupported_large_head(monkeypatch):
     assert ("batch", "fa3", 512, 512) not in calls
     assert ("single", "fa2", 512, 512) in calls
     assert ("batch", "fa2", 512, 512) in calls
+
+
+# ---------------------------------------------------------------------------
+# NVCC JIT cache build-fingerprint invalidation (meta.json)
+# ---------------------------------------------------------------------------
+
+
+def _make_nvcc_spec(monkeypatch, tmp_path, name="test_fp_module", mtime_shift=None):
+    """Build a JitSpecNvcc isolated in tmp_path, with source files in a
+    separate (later-hashed) tree whose mtimes can be backdated."""
+    monkeypatch.setattr(core.jit_env, "FLASHINFER_JIT_DIR", tmp_path / "jit")
+    monkeypatch.setattr(core, "check_cuda_arch", lambda: None)
+
+    src_dir = tmp_path / "src"
+    src_dir.mkdir(parents=True, exist_ok=True)
+    src = src_dir / "kernel.cu"
+    src.write_text("__global__ void k() {}")
+    if mtime_shift is not None:
+        os.utime(src, (mtime_shift, mtime_shift))
+
+    spec = core.JitSpecNvcc(
+        name=name,
+        sources=[src],
+        extra_cflags=None,
+        extra_cuda_cflags=None,
+        extra_ldflags=None,
+        extra_include_dirs=None,
+    )
+
+    calls = {}
+
+    def fake_write_ninja():
+        spec.build_dir.mkdir(parents=True, exist_ok=True)
+        (spec.build_dir / "build.ninja").write_text("ninja_required_version = 1.3\n")
+
+    def fake_run_ninja(*_args, **_kwargs):
+        (spec.build_dir / f"{spec.name}.so").write_bytes(b"\x7fELF")
+        calls["builds"] = calls.get("builds", 0) + 1
+
+    monkeypatch.setattr(spec, "write_ninja", fake_write_ninja)
+    monkeypatch.setattr(core, "run_ninja", fake_run_ninja)
+    monkeypatch.setattr(core.jit_env, "FLASHINFER_CSRC_DIR", tmp_path / "csrc")
+    return spec, calls
+
+
+def test_meta_schema_invariants(monkeypatch, tmp_path):
+    spec, _ = _make_nvcc_spec(monkeypatch, tmp_path)
+    meta = spec.expected_meta
+    assert meta["schema"] == core._META_SCHEMA_VERSION
+    assert "flashinfer_version" in meta
+    assert "python_soabi" in meta
+    assert "torch_build_identity" in meta
+    assert "source_sha256" in meta
+    assert "cflags" in meta
+    assert "cuda_cflags" in meta
+    # Deterministic: computing twice yields identical metadata.
+    assert meta == spec.expected_meta
+
+
+def test_meta_committed_after_successful_build(monkeypatch, tmp_path):
+    spec, calls = _make_nvcc_spec(monkeypatch, tmp_path)
+    assert not spec.meta_path.exists()
+    spec.build(verbose=False, need_lock=False)
+    assert spec.meta_path.exists()
+    assert core._read_meta(spec.meta_path) == spec.expected_meta
+    assert calls["builds"] == 1
+
+
+def test_stale_source_rewrites_same_mtime_still_invalidates(monkeypatch, tmp_path):
+    """Source bytes change while the mtime stays *older* than the committed
+    artifacts: the fingerprint must change and wipe the stale build dir."""
+    spec, calls = _make_nvcc_spec(monkeypatch, tmp_path, mtime_shift=1_700_000_000)
+    # First build: mtime is old already; a naive ninja timestamp scan would
+    # think everything is fresh. Meta still commits.
+    spec.build(verbose=False, need_lock=False)
+    assert (spec.build_dir / f"{spec.name}.so").exists()
+
+    # Change the source content, keep its mtime unchanged.
+    src = spec.sources[0]
+    old_mtime = src.stat().st_mtime
+    src.write_text("__global__ void k() {}\n// changed")
+    os.utime(src, (old_mtime, old_mtime))
+    assert src.stat().st_mtime == old_mtime
+
+    spec.build(verbose=False, need_lock=False)
+    assert calls["builds"] == 2
+    assert (spec.build_dir / f"{spec.name}.so").exists()
+    assert core._read_meta(spec.meta_path) == spec.expected_meta
+
+
+def test_compile_flags_change_invalidates(monkeypatch, tmp_path):
+    spec, calls = _make_nvcc_spec(monkeypatch, tmp_path)
+    spec.build(verbose=False, need_lock=False)
+    assert calls["builds"] == 1
+
+    spec.extra_cuda_cflags = ["-O3", "-gencode=arch=compute_90a,code=sm_90a"]
+    spec.build(verbose=False, need_lock=False)
+    assert calls["builds"] == 2
+
+
+def test_matching_meta_keeps_build_dir_and_ninja_incremental(monkeypatch, tmp_path):
+    spec, calls = _make_nvcc_spec(monkeypatch, tmp_path)
+    spec.build(verbose=False, need_lock=False)
+    assert calls["builds"] == 1
+    build_dir = spec.build_dir
+    assert build_dir.exists()
+
+    # No source/flag change: build() keeps the dir and run_ninja is still
+    # invoked (ninja owns the fine-grained incremental decision), so builds
+    # counter increments once per call but the .so/meta are stable.
+    spec.build(verbose=False, need_lock=False)
+    assert calls["builds"] == 2
+    assert build_dir.exists()
+    assert core._read_meta(spec.meta_path) == spec.expected_meta
+
+
+def test_missing_meta_triggers_rebuild(monkeypatch, tmp_path):
+    spec, calls = _make_nvcc_spec(monkeypatch, tmp_path)
+    spec.build(verbose=False, need_lock=False)
+    assert calls["builds"] == 1
+    spec.meta_path.unlink()
+    spec.build(verbose=False, need_lock=False)
+    assert calls["builds"] == 2
+    assert core._read_meta(spec.meta_path) == spec.expected_meta
+
+
+def test_corrupt_meta_triggers_rebuild(monkeypatch, tmp_path):
+    spec, calls = _make_nvcc_spec(monkeypatch, tmp_path)
+    spec.build(verbose=False, need_lock=False)
+    assert calls["builds"] == 1
+    spec.meta_path.write_text("{ not valid json !!!")
+    spec.build(verbose=False, need_lock=False)
+    assert calls["builds"] == 2
+    assert core._read_meta(spec.meta_path) == spec.expected_meta
+
+
+def test_failed_ninja_does_not_commit_meta(monkeypatch, tmp_path):
+    spec, _ = _make_nvcc_spec(monkeypatch, tmp_path)
+
+    def failing_ninja(*_args, **_kwargs):
+        raise RuntimeError("nvcc failed")
+
+    monkeypatch.setattr(core, "run_ninja", failing_ninja)
+    with pytest.raises(RuntimeError, match="nvcc failed"):
+        spec.build(verbose=False, need_lock=False)
+    assert not spec.meta_path.exists()
+
+
+def test_aot_path_ignores_meta(monkeypatch, tmp_path):
+    """AOT artifacts are loaded without touching JIT meta.json."""
+    spec, _ = _make_nvcc_spec(monkeypatch, tmp_path)
+    aot = tmp_path / "aot" / spec.name / f"{spec.name}.so"
+    aot.parent.mkdir(parents=True, exist_ok=True)
+    aot.write_bytes(b"\x7fELF")
+    monkeypatch.setattr(core.jit_env, "FLASHINFER_AOT_DIR", tmp_path / "aot")
+    assert spec.is_aot
+    # try_load routes to the AOT path and never consults meta.json.
+    monkeypatch.setattr(
+        spec, "load", lambda so_path=None: SimpleNamespace(path=so_path)
+    )
+    loaded = spec.try_load()
+    assert loaded is not None
+    assert loaded.path == aot
+
+
+def test_meta_is_json_serializable(monkeypatch, tmp_path):
+    spec, _ = _make_nvcc_spec(monkeypatch, tmp_path)
+    import json as _json
+
+    _json.dumps(spec.expected_meta)
+    # numpy scalars or Path objects must not leak into the fingerprint.
+    for v in spec.expected_meta.values():
+        assert not isinstance(v, Path)

--- a/tests/jit/test_jit_cpp_ext.py
+++ b/tests/jit/test_jit_cpp_ext.py
@@ -452,6 +452,31 @@ def test_missing_meta_triggers_rebuild(monkeypatch, tmp_path):
     assert core._read_meta(spec.meta_path) == spec.expected_meta
 
 
+def test_invalidation_preserves_generated_sources_in_build_dir(monkeypatch, tmp_path):
+    """Generated source trees are build inputs, not stale build outputs."""
+    spec, calls = _make_nvcc_spec(monkeypatch, tmp_path)
+    generated_dir = spec.build_dir / "generated"
+    generated_dir.mkdir(parents=True)
+    generated_source = generated_dir / "kernel.cu"
+    generated_source.write_text("__global__ void generated() {}")
+    generated_helper = generated_dir / "kernel_config.inc"
+    generated_helper.write_text("// generated helper")
+    spec.sources = [generated_source]
+
+    stale_artifact = spec.build_dir / "stale-without-meta"
+    stale_artifact.write_text("old build output")
+    spec.jit_library_path.write_bytes(b"old shared library")
+
+    spec.build(verbose=False, need_lock=False)
+
+    assert calls["builds"] == 1
+    assert generated_source.read_text() == "__global__ void generated() {}"
+    assert generated_helper.read_text() == "// generated helper"
+    assert not stale_artifact.exists()
+    assert spec.jit_library_path.read_bytes() == b"\x7fELF"
+    assert core._read_meta(spec.meta_path) == spec.expected_meta
+
+
 def test_corrupt_meta_triggers_rebuild(monkeypatch, tmp_path):
     spec, calls = _make_nvcc_spec(monkeypatch, tmp_path)
     spec.build(verbose=False, need_lock=False)

--- a/tests/jit/test_jit_cpp_ext.py
+++ b/tests/jit/test_jit_cpp_ext.py
@@ -303,6 +303,10 @@ def _make_nvcc_spec(monkeypatch, tmp_path, name="test_fp_module", mtime_shift=No
     separate (later-hashed) tree whose mtimes can be backdated."""
     monkeypatch.setattr(core.jit_env, "FLASHINFER_JIT_DIR", tmp_path / "jit")
     monkeypatch.setattr(core, "check_cuda_arch", lambda: None)
+    monkeypatch.setattr(core, "_get_compiler_identity", lambda: "nvcc=mock;cxx=mock")
+    # Deterministic fingerprints regardless of the host toolchain.
+    monkeypatch.setattr(core, "_get_wheel_record_hash", lambda: "mock-record")
+    monkeypatch.setattr(core, "_get_tvm_ffi_version", lambda: "mock-tvmffi")
 
     src_dir = tmp_path / "src"
     src_dir.mkdir(parents=True, exist_ok=True)
@@ -327,7 +331,10 @@ def _make_nvcc_spec(monkeypatch, tmp_path, name="test_fp_module", mtime_shift=No
         (spec.build_dir / "build.ninja").write_text("ninja_required_version = 1.3\n")
 
     def fake_run_ninja(*_args, **_kwargs):
+        spec.build_dir.mkdir(parents=True, exist_ok=True)
         (spec.build_dir / f"{spec.name}.so").write_bytes(b"\x7fELF")
+        # Sentinel proving the directory was freshly rebuilt from scratch.
+        (spec.build_dir / "built.marker").write_text("1")
         calls["builds"] = calls.get("builds", 0) + 1
 
     monkeypatch.setattr(spec, "write_ninja", fake_write_ninja)
@@ -367,6 +374,7 @@ def test_stale_source_rewrites_same_mtime_still_invalidates(monkeypatch, tmp_pat
     # think everything is fresh. Meta still commits.
     spec.build(verbose=False, need_lock=False)
     assert (spec.build_dir / f"{spec.name}.so").exists()
+    assert (spec.build_dir / "built.marker").exists()
 
     # Change the source content, keep its mtime unchanged.
     src = spec.sources[0]
@@ -377,6 +385,9 @@ def test_stale_source_rewrites_same_mtime_still_invalidates(monkeypatch, tmp_pat
 
     spec.build(verbose=False, need_lock=False)
     assert calls["builds"] == 2
+    # The stale directory was actually wiped and rebuilt (marker refreshed).
+    assert (spec.build_dir / "built.marker").exists()
+    assert (spec.build_dir / "built.marker").read_text() == "1"
     assert (spec.build_dir / f"{spec.name}.so").exists()
     assert core._read_meta(spec.meta_path) == spec.expected_meta
 
@@ -389,6 +400,8 @@ def test_compile_flags_change_invalidates(monkeypatch, tmp_path):
     spec.extra_cuda_cflags = ["-O3", "-gencode=arch=compute_90a,code=sm_90a"]
     spec.build(verbose=False, need_lock=False)
     assert calls["builds"] == 2
+    assert (spec.build_dir / "built.marker").exists()
+    assert core._read_meta(spec.meta_path) == spec.expected_meta
 
 
 def test_matching_meta_keeps_build_dir_and_ninja_incremental(monkeypatch, tmp_path):
@@ -464,3 +477,125 @@ def test_meta_is_json_serializable(monkeypatch, tmp_path):
     # numpy scalars or Path objects must not leak into the fingerprint.
     for v in spec.expected_meta.values():
         assert not isinstance(v, Path)
+
+
+def test_module_source_hash_independent_of_include_tree(monkeypatch, tmp_path):
+    """A change to the module's own source file invalidates even when the
+    include tree hash is unchanged."""
+    spec, calls = _make_nvcc_spec(monkeypatch, tmp_path)
+    spec.build(verbose=False, need_lock=False)
+    assert calls["builds"] == 1
+
+    # Mutate the module source (in spec.sources, not the include tree).
+    src = spec.sources[0]
+    old_mtime = src.stat().st_mtime
+    src.write_text(src.read_text() + "\n// module-source change")
+    os.utime(src, (old_mtime, old_mtime))
+
+    meta_before = core._read_meta(spec.meta_path)
+    assert meta_before["sources_sha256"] != spec.expected_meta["sources_sha256"]
+
+    spec.build(verbose=False, need_lock=False)
+    assert calls["builds"] == 2
+    assert core._read_meta(spec.meta_path) == spec.expected_meta
+
+
+def test_include_tree_change_invalidates_without_source_change(monkeypatch, tmp_path):
+    """A change under the include tree invalidates even when the module's
+    own sources are untouched."""
+    spec, calls = _make_nvcc_spec(monkeypatch, tmp_path)
+    # Redirect the include-tree hash at a controlled directory.
+    include_dir = tmp_path / "include_tree"
+    include_dir.mkdir(parents=True, exist_ok=True)
+    (include_dir / "helper.cuh").write_text("// v1")
+    monkeypatch.setattr(spec, "extra_include_dirs", [include_dir])
+
+    spec.build(verbose=False, need_lock=False)
+    assert calls["builds"] == 1
+
+    # Mutate a file inside the include tree only.
+    (include_dir / "helper.cuh").write_text("// v2")
+
+    spec.build(verbose=False, need_lock=False)
+    assert calls["builds"] == 2
+    assert core._read_meta(spec.meta_path) == spec.expected_meta
+
+
+def test_build_jit_specs_applies_fingerprint_and_commits_meta(monkeypatch, tmp_path):
+    """The batch precompile path must run the same fingerprint gate and commit
+    meta.json for every module it builds (no stale-artifact reuse)."""
+    spec1, calls1 = _make_nvcc_spec(
+        monkeypatch, tmp_path, name="batch_a", mtime_shift=1_700_000_000
+    )
+    spec2, calls2 = _make_nvcc_spec(
+        monkeypatch, tmp_path, name="batch_b", mtime_shift=1_700_000_000
+    )
+
+    # A batch ninja run "compiles" every subninja module under the JIT dir.
+    def batch_run_ninja(*_args, **_kwargs):
+        jit_root = core.jit_env.FLASHINFER_JIT_DIR
+        for child in jit_root.iterdir():
+            if not child.is_dir():
+                continue
+            so = child / f"{child.name}.so"
+            so.write_bytes(b"\x7fELF")
+            (child / "built.marker").write_text("1")
+            for name_, calls_ in ((spec1, calls1), (spec2, calls2)):
+                if name_.build_dir == child:
+                    calls_["builds"] = calls_.get("builds", 0) + 1
+
+    monkeypatch.setattr(core, "run_ninja", batch_run_ninja)
+
+    # Build both via the batch entry point.
+    core.build_jit_specs([spec1, spec2], verbose=False, skip_prebuilt=False)
+    assert calls1["builds"] == 1 and calls2["builds"] == 1
+    assert spec1.meta_path.exists() and spec2.meta_path.exists()
+    assert core._read_meta(spec1.meta_path) == spec1.expected_meta
+    assert core._read_meta(spec2.meta_path) == spec2.expected_meta
+
+    # Same-mtime source change to batch_a must invalidate and rebuild it,
+    # while batch_b (unchanged) is preserved.
+    src = spec1.sources[0]
+    old_mtime = src.stat().st_mtime
+    src.write_text(src.read_text() + "\n// changed")
+    os.utime(src, (old_mtime, old_mtime))
+
+    core.build_jit_specs([spec1, spec2], verbose=False, skip_prebuilt=False)
+    assert calls1["builds"] == 2
+    assert calls2["builds"] == 2  # run_ninja invoked for both (ninja decides)
+    assert core._read_meta(spec1.meta_path) == spec1.expected_meta
+    assert core._read_meta(spec2.meta_path) == spec2.expected_meta
+
+
+def test_wipe_failure_aborts_build(monkeypatch, tmp_path):
+    """A failed stale-directory wipe must abort instead of blessing residual
+    objects with a fresh meta.json."""
+    spec, calls = _make_nvcc_spec(monkeypatch, tmp_path)
+    spec.build(verbose=False, need_lock=False)
+    assert calls["builds"] == 1
+
+    # Make the fingerprint mismatch, then force rmtree to fail.
+    spec.extra_cuda_cflags = ["-O3", "-gencode=arch=compute_90a,code=sm_90a"]
+
+    def failing_rmtree(*_a, **_k):
+        raise OSError("cannot remove")
+
+    monkeypatch.setattr(core.shutil, "rmtree", failing_rmtree)
+    meta_before = core._read_meta(spec.meta_path)
+    with pytest.raises(OSError, match="cannot remove"):
+        spec.build(verbose=False, need_lock=False)
+    # The failed build must not refresh the fingerprint to bless residual
+    # objects compiled from the old source.
+    assert core._read_meta(spec.meta_path) == meta_before
+    assert not spec.is_compiled
+
+
+def test_is_compiled_requires_valid_meta(monkeypatch, tmp_path):
+    spec, _ = _make_nvcc_spec(monkeypatch, tmp_path)
+    assert not spec.is_compiled
+    spec.build(verbose=False, need_lock=False)
+    assert spec.is_compiled
+    # Corrupt the committed meta: .so still exists but the module is not
+    # considered compiled anymore.
+    spec.meta_path.write_text("{ broken")
+    assert not spec.is_compiled

--- a/tests/jit/test_jit_cpp_ext.py
+++ b/tests/jit/test_jit_cpp_ext.py
@@ -1,5 +1,6 @@
 import os
 import subprocess
+import sys
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -144,7 +145,7 @@ def test_jit_spec_build_rewrites_ninja_before_build(monkeypatch):
         extra_include_dirs=None,
     )
 
-    monkeypatch.setattr(spec, "write_ninja", lambda: writes.append(True))
+    monkeypatch.setattr(spec, "write_ninja", lambda _content=None: writes.append(True))
     monkeypatch.setattr(core, "run_ninja", lambda *_args, **_kwargs: None)
 
     spec.build(verbose=False, need_lock=False)
@@ -326,9 +327,18 @@ def _make_nvcc_spec(monkeypatch, tmp_path, name="test_fp_module", mtime_shift=No
 
     calls = {}
 
-    def fake_write_ninja():
+    def fake_render_ninja():
+        return (
+            "ninja_required_version = 1.3\n"
+            f"cflags = {spec.extra_cflags}\n"
+            f"cuda_cflags = {spec.extra_cuda_cflags}\n"
+            f"ldflags = {spec.extra_ldflags}\n"
+        )
+
+    def fake_write_ninja(content=None):
         spec.build_dir.mkdir(parents=True, exist_ok=True)
-        (spec.build_dir / "build.ninja").write_text("ninja_required_version = 1.3\n")
+        content = fake_render_ninja() if content is None else content
+        (spec.build_dir / "build.ninja").write_text(content)
 
     def fake_run_ninja(*_args, **_kwargs):
         spec.build_dir.mkdir(parents=True, exist_ok=True)
@@ -337,6 +347,7 @@ def _make_nvcc_spec(monkeypatch, tmp_path, name="test_fp_module", mtime_shift=No
         (spec.build_dir / "built.marker").write_text("1")
         calls["builds"] = calls.get("builds", 0) + 1
 
+    monkeypatch.setattr(spec, "_render_ninja", fake_render_ninja)
     monkeypatch.setattr(spec, "write_ninja", fake_write_ninja)
     monkeypatch.setattr(core, "run_ninja", fake_run_ninja)
     monkeypatch.setattr(core.jit_env, "FLASHINFER_CSRC_DIR", tmp_path / "csrc")
@@ -375,6 +386,9 @@ def test_stale_source_rewrites_same_mtime_still_invalidates(monkeypatch, tmp_pat
     spec.build(verbose=False, need_lock=False)
     assert (spec.build_dir / f"{spec.name}.so").exists()
     assert (spec.build_dir / "built.marker").exists()
+    stale_artifact = spec.build_dir / "stale-artifact"
+    stale_artifact.write_text("must be removed")
+    old_meta = core._read_meta(spec.meta_path)
 
     # Change the source content, keep its mtime unchanged.
     src = spec.sources[0]
@@ -385,7 +399,12 @@ def test_stale_source_rewrites_same_mtime_still_invalidates(monkeypatch, tmp_pat
 
     spec.build(verbose=False, need_lock=False)
     assert calls["builds"] == 2
-    # The stale directory was actually wiped and rebuilt (marker refreshed).
+    # The stale directory was actually wiped before the fake build recreated
+    # its normal outputs.
+    assert not stale_artifact.exists()
+    assert (
+        core._read_meta(spec.meta_path)["sources_sha256"] != old_meta["sources_sha256"]
+    )
     assert (spec.build_dir / "built.marker").exists()
     assert (spec.build_dir / "built.marker").read_text() == "1"
     assert (spec.build_dir / f"{spec.name}.so").exists()
@@ -425,8 +444,11 @@ def test_missing_meta_triggers_rebuild(monkeypatch, tmp_path):
     spec.build(verbose=False, need_lock=False)
     assert calls["builds"] == 1
     spec.meta_path.unlink()
+    stale_artifact = spec.build_dir / "stale-without-meta"
+    stale_artifact.write_text("must be removed")
     spec.build(verbose=False, need_lock=False)
     assert calls["builds"] == 2
+    assert not stale_artifact.exists()
     assert core._read_meta(spec.meta_path) == spec.expected_meta
 
 
@@ -435,8 +457,35 @@ def test_corrupt_meta_triggers_rebuild(monkeypatch, tmp_path):
     spec.build(verbose=False, need_lock=False)
     assert calls["builds"] == 1
     spec.meta_path.write_text("{ not valid json !!!")
+    stale_artifact = spec.build_dir / "stale-with-corrupt-meta"
+    stale_artifact.write_text("must be removed")
     spec.build(verbose=False, need_lock=False)
     assert calls["builds"] == 2
+    assert not stale_artifact.exists()
+    assert core._read_meta(spec.meta_path) == spec.expected_meta
+
+
+def test_rendered_ninja_change_invalidates_existing_build(monkeypatch, tmp_path):
+    """Fingerprint the Ninja content the current process would render, not the
+    previous build.ninja stored in the cache directory."""
+    spec, calls = _make_nvcc_spec(monkeypatch, tmp_path)
+    spec.build(verbose=False, need_lock=False)
+    assert calls["builds"] == 1
+    old_meta = core._read_meta(spec.meta_path)
+    stale_artifact = spec.build_dir / "stale-ninja-config"
+    stale_artifact.write_text("must be removed")
+
+    old_render = spec._render_ninja
+    monkeypatch.setattr(
+        spec, "_render_ninja", lambda: old_render() + "generator_input = changed\n"
+    )
+    assert (
+        old_meta["ninja_content_sha256"] != spec.expected_meta["ninja_content_sha256"]
+    )
+
+    spec.build(verbose=False, need_lock=False)
+    assert calls["builds"] == 2
+    assert not stale_artifact.exists()
     assert core._read_meta(spec.meta_path) == spec.expected_meta
 
 
@@ -565,6 +614,56 @@ def test_build_jit_specs_applies_fingerprint_and_commits_meta(monkeypatch, tmp_p
     assert calls2["builds"] == 2  # run_ninja invoked for both (ninja decides)
     assert core._read_meta(spec1.meta_path) == spec1.expected_meta
     assert core._read_meta(spec2.meta_path) == spec2.expected_meta
+
+
+def _lock_is_held_by_another_process(lock_path: Path) -> bool:
+    """Probe a FileLock from a separate interpreter.
+
+    A single-spec build uses this same lock, so a timeout proves it cannot race
+    the batch builder while Ninja runs or metadata is committed.
+    """
+    script = """
+import sys
+from filelock import FileLock, Timeout
+
+try:
+    with FileLock(sys.argv[1], timeout=0.2, thread_local=False):
+        pass
+except Timeout:
+    raise SystemExit(0)
+raise SystemExit(1)
+"""
+    result = subprocess.run(
+        [sys.executable, "-c", script, str(lock_path)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return result.returncode == 0
+
+
+def test_build_jit_specs_holds_module_lock_through_meta_commit(monkeypatch, tmp_path):
+    spec, _ = _make_nvcc_spec(monkeypatch, tmp_path, name="batch_locked")
+    lock_observations = []
+
+    def batch_run_ninja(*_args, **_kwargs):
+        lock_observations.append(_lock_is_held_by_another_process(spec.lock_path))
+        spec.jit_library_path.write_bytes(b"\x7fELF")
+
+    original_write_meta = core._write_meta_atomic
+
+    def write_meta_while_observing_lock(meta_path, meta):
+        lock_observations.append(_lock_is_held_by_another_process(spec.lock_path))
+        original_write_meta(meta_path, meta)
+
+    monkeypatch.setattr(core, "run_ninja", batch_run_ninja)
+    monkeypatch.setattr(core, "_write_meta_atomic", write_meta_while_observing_lock)
+
+    core.build_jit_specs([spec], verbose=False, skip_prebuilt=False)
+
+    assert lock_observations == [True, True]
+    assert not _lock_is_held_by_another_process(spec.lock_path)
+    assert core._read_meta(spec.meta_path) == spec.expected_meta
 
 
 def test_wipe_failure_aborts_build(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary

FlashInfer's nvcc JIT cache (under `~/.cache/flashinfer/`) is validated by Ninja's file **mtime** scan alone. When a wheel is reinstalled at the *same version*, the wheel's source files may carry **older mtimes** than the previously compiled artifacts. Ninja then treats the stale `.so`/`.o` as up-to-date and reuses them even though the C++/CUDA source bytes changed, producing a module linked from a mix of old and new objects. On sm_121a this manifested as a `fused_moe_120.so` that deadlocked `cutlass_fused_moe` at launch (GPU idle, scheduler stuck in epoll/futex, 300s watchdog timeout).

This PR adds a per-module `meta.json` build fingerprint to `JitSpecNvcc`. The build directory is wiped and rebuilt whenever the committed fingerprint is missing, corrupt, or different; the fingerprint is committed atomically **only after** a successful compile, and **only as a snapshot taken before the build** (a mid-build source edit can never bless objects with a post-hoc fingerprint). Ninja's fine-grained header mtime scan is preserved — this only adds a cheap content/ABI gate on top. AOT loading and `FLASHINFER_DISABLE_JIT` are unchanged. Old caches without `meta.json` get one conservative rebuild on first use after upgrade.

## Fingerprint contents

* schema version
* FlashInfer version + git commit
* wheel `RECORD` digest for files under `flashinfer/` — hashes the **full row** (path + content `sha256=` + size), so a same-version reinstall with different bytes invalidates even when paths are unchanged
* Python `SOABI`
* Torch version, bundled CUDA version, libstdc++ ABI
* TVM-FFI version (via the actual distribution name `apache-tvm-ffi`)
* **nvcc and host-CXX compiler identity** (`FLASHINFER_NVCC`/`nvcc`, `CXX`/`c++`, launchers)
* SHA-256 of the C++/CUDA source tree (both `data/csrc` and repo-tree `csrc/` for source installs), recomputed on every call so editable-install edits are always observed; `os.walk` dirs/files are sorted for a deterministic digest
* SHA-256 of the module's own source files (`sources_sha256`)
* SHA-256 of the current rendered Ninja configuration (the same snapshot written for the build)
* compile flags (cflags / cuda_cflags / ldflags)

## Scope

* Generated input sources that reside under a module build directory (for example, `trtllm_fmha_v2/generated/`) are staged and restored across invalidation, while stale compiler outputs are still removed.\n* Both the single-module `JitSpecNvcc.build()` **and** the batch precompile path `build_jit_specs()` run the same fingerprint gate: stale dirs are wiped before building and `meta.json` is committed after a successful shared ninja run, so a batch/AOT build can never copy stale artifacts. Module locks are acquired in deterministic order and held through the shared Ninja run and every metadata commit.
* A failed build-dir wipe aborts the build (a partial directory is never blessed with a fresh fingerprint); `meta.json` is written via a process-unique temp file + `os.replace`.
* `JitSpecNvcc.is_compiled` now requires a valid `meta.json` for JIT artifacts (AOT artifacts remain valid by construction).

## Test plan

* `pytest -q tests/jit/test_jit_cpp_ext.py` — new GPU-free tests cover: source content change with **unchanged (older) mtime**, module-source vs include-tree invalidation independently, compile-flag change, missing/corrupt `meta.json`, matching fingerprint preserving the build dir (Ninja owns incrementality), generated-source preservation during invalidation, failed Ninja not committing metadata, AOT path ignoring meta, the **batch** precompile path, current-rendered-Ninja invalidation, cross-process batch/single lock exclusion, **wipe-failure abort**, `is_compiled` semantics, JSON serializability, deterministic metadata. A `built.marker` sentinel asserts the stale dir is actually wiped.
* Focused fingerprint/locking tests: **18 passed**. Full file: **37 passed, 1 pre-existing environment failure** due to missing `flashinfer/data/csrc/batch_prefill_customize_config.jinja`.
* Pre-commit hooks all pass.
* On DGX Spark (sm_121a): fingerprint computation overhead \~11 ms per module (well under the 100 ms budget); stale same-mtime source triggers a rebuild; an old cache without `meta.json` is conservatively rebuilt once and then stable; the batch path behaves identically.

Fixes flashinfer-ai/flashinfer#4489

## Notes

* Not handled here: parallel-compile OOM (flashinfer-ai/flashinfer#3634) — tracked separately; validation still uses `MAX_JOBS=1`.
* Does not change public Python APIs, env vars, or kernel ABI.
* The mid-build source-edit window is additionally covered by Ninja's depfile scan, which triggers a rebuild on the next run if a source changes during compilation.

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved JIT compilation caching by detecting changes to source files, compiler settings, Python ABI, and supported toolchains.
  * Automatically rebuilds stale, missing, or corrupted build artifacts.
  * Prevents failed compilations from leaving misleading cache metadata.
* **Reliability**
  * Reuses valid cached builds to avoid unnecessary recompilation.
  * Improved validation and consistency for individual and batch JIT builds.
  * Added safe coordination for concurrent builds sharing cached artifacts.
  * AOT artifacts remain available without additional cache metadata checks.
* **Documentation**
  * Clarified JIT cache validation and rebuild behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CUDA JIT build-cache reliability by detecting changes to source files, build settings, compilers, and runtime environments.
  * Automatically discards stale or incomplete cached builds and rebuilds them when needed.
  * Added safer handling for concurrent and batch builds, reducing cache conflicts.
  * Failed compilations no longer leave behind metadata that could incorrectly validate future builds.
  * Existing AOT artifacts continue to load without the new cache validation.

* **Documentation**
  * Documented JIT cache validation and invalidation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->