### PR TITLE
ci: test PrimTS with CUTLASS DSL 4.7

### DIFF
--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -77,6 +77,40 @@ jobs:
           python -m build
           ls -lh dist/
 
+      - name: Verify published CUTLASS DSL dependency
+        run: |
+          python - <<'PY'
+          from email.parser import BytesParser
+          from pathlib import Path
+          from zipfile import ZipFile
+
+          from packaging.requirements import Requirement
+          from packaging.utils import canonicalize_name
+
+          expected = "==4.6.2"
+          wheels = list(Path("dist").glob("*.whl"))
+          if len(wheels) != 1:
+              raise SystemExit(f"expected one flashinfer-python wheel, found {wheels}")
+          with ZipFile(wheels[0]) as wheel:
+              metadata_paths = [name for name in wheel.namelist() if name.endswith(".dist-info/METADATA")]
+              if len(metadata_paths) != 1:
+                  raise SystemExit(f"expected one METADATA file, found {metadata_paths}")
+              metadata = BytesParser().parsebytes(wheel.read(metadata_paths[0]))
+          requirements = [Requirement(raw) for raw in metadata.get_all("Requires-Dist", [])]
+          dsl_requirements = [
+              requirement
+              for requirement in requirements
+              if canonicalize_name(requirement.name) == "nvidia-cutlass-dsl"
+          ]
+          if not dsl_requirements or any(
+              str(requirement.specifier) != expected for requirement in dsl_requirements
+          ):
+              raise SystemExit(
+                  f"CUTLASS DSL wheel requirements are {dsl_requirements}, expected {expected}"
+              )
+          print(f"CUTLASS DSL wheel metadata check passed: {expected}")
+          PY
+
       - name: Upload flashinfer-python artifact
         uses: actions/upload-artifact@v4
         with:

--- a/ci/setup_python.env
+++ b/ci/setup_python.env
@@ -8,6 +8,11 @@
 #   2. CI will install the specified version(s) before running tests
 #   3. Do NOT merge these changes to main - close the PR after testing
 #
+# Permanent CI dependency policy does not belong in this override file. The
+# committed CUTLASS DSL 4.7 test baseline is installed by the CI image and
+# test bootstrap scripts; nightly package metadata and consumer tests remain
+# on the version declared in requirements.txt.
+#
 # Example:
 #   TVM_FFI_REF=abc123def456  # Test a specific TVM-FFI commit
 #   TVM_FFI_REF=main          # Test TVM-FFI main branch

--- a/docker/install/install_python_packages.sh
+++ b/docker/install/install_python_packages.sh
@@ -19,6 +19,8 @@
 set -e
 set -u
 
+CUTLASS_DSL_CI_VERSION="4.7.0"
+
 pip3 install --upgrade "setuptools>=77" "pip>=24"
 
 # Accept CUDA version as parameter (e.g., cu126, cu128, cu129)
@@ -56,19 +58,40 @@ pip3 install -r /install/requirements.txt
 pip3 install responses pytest scipy build "$NVSHMEM4PY"
 pip3 install --upgrade "$CUDA_PYTHON"
 
-# Install cudnn package based on CUDA version
+# CI deliberately validates CUTLASS DSL 4.7 while published FlashInfer
+# packages retain their 4.6 dependency. Reinstall the complete package stack
+# after requirements.txt so neither the default pin nor a stale CUDA-family
+# libs wheel can leak into the test image.
+pip3 uninstall -y \
+  nvidia-cutlass-dsl \
+  nvidia-cutlass-dsl-libs-core \
+  nvidia-cutlass-dsl-libs-base \
+  nvidia-cutlass-dsl-libs-cu12 \
+  nvidia-cutlass-dsl-libs-cu13 2>/dev/null || true
+
+# Install cudnn and CUTLASS DSL packages based on CUDA version.
 if [[ "$CUDA_VERSION" == *"cu13"* ]]; then
   pip3 install --upgrade nvidia-cudnn-cu13
-  pip3 install --upgrade "nvidia-cutlass-dsl[cu13]==4.7.0"
+  CUTLASS_DSL_PACKAGE="nvidia-cutlass-dsl[cu13]==${CUTLASS_DSL_CI_VERSION}"
+  CUTLASS_DSL_PACKAGES="nvidia-cutlass-dsl nvidia-cutlass-dsl-libs-core nvidia-cutlass-dsl-libs-base nvidia-cutlass-dsl-libs-cu12 nvidia-cutlass-dsl-libs-cu13"
 else
   pip3 install --upgrade nvidia-cudnn-cu12
+  CUTLASS_DSL_PACKAGE="nvidia-cutlass-dsl==${CUTLASS_DSL_CI_VERSION}"
+  CUTLASS_DSL_PACKAGES="nvidia-cutlass-dsl nvidia-cutlass-dsl-libs-core nvidia-cutlass-dsl-libs-base nvidia-cutlass-dsl-libs-cu12"
 fi
+pip3 install --upgrade "$CUTLASS_DSL_PACKAGE"
 
-# Fail the build if torch or cuda-python drifted off this image's CUDA major.
+# Fail the build if torch, cuda-python, or CUTLASS DSL drifted from the CI
+# image contract.
 python3 -c "
 import importlib.metadata as m, sys, torch
 for name, ver in (('torch', torch.version.cuda or ''), ('cuda-python', m.version('cuda-python'))):
     if ver.split('.')[0] != '${CUDA_MAJOR}':
         sys.exit(f'ERROR: {name} targets CUDA {ver}, but this image is CUDA ${CUDA_MAJOR}')
+for name in '${CUTLASS_DSL_PACKAGES}'.split():
+    ver = m.version(name)
+    if ver != '${CUTLASS_DSL_CI_VERSION}':
+        sys.exit(f'ERROR: {name} is {ver}, expected ${CUTLASS_DSL_CI_VERSION}')
 print('CUDA ${CUDA_MAJOR} check passed:', torch.__version__)
+print('CUTLASS DSL CI check passed: ${CUTLASS_DSL_CI_VERSION}')
 "

--- a/docs/api/attention.rst
+++ b/docs/api/attention.rst
@@ -17,6 +17,15 @@ for the public entry points, supported contracts, and examples. Current accuracy
 and performance signoff is on SM100a/B200; SM103a/B300 is architecture-gated
 but not yet signoff-qualified.
 
+.. note::
+
+    Release and nightly packages retain ``nvidia-cutlass-dsl==4.6.2`` for the
+    general FlashInfer runtime. PrimTS requires ``nvidia-cutlass-dsl>=4.7.0``
+    and is validated after a CI-only 4.7.0 override. Importing PrimTS on the
+    default version raises a feature-local error; other FlashInfer APIs remain
+    available. See the PrimTS guide index above for CUDA 12 and CUDA 13 install
+    commands and the package-metadata caveat.
+
 .. currentmodule:: flashinfer.attention.prims_ts
 
 FMHA Context/Prefill

--- a/docs/build_docs.sh
+++ b/docs/build_docs.sh
@@ -6,6 +6,10 @@ echo "Building FlashInfer documentation..."
 # Install flashinfer package first
 echo "Installing FlashInfer package..."
 pip install -e ..
+# PrimTS autodoc imports require the source-test CUTLASS DSL version rather
+# than the published package default.
+# shellcheck disable=SC1091
+source ../scripts/setup_ci_test_env.sh
 
 make clean
 make SPHINXOPTS='-T -v' html

--- a/flashinfer/attention/_prims_ts_dependency.py
+++ b/flashinfer/attention/_prims_ts_dependency.py
@@ -1,0 +1,58 @@
+# Copyright (c) 2026 by FlashInfer team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Feature-local CUTLASS DSL dependency check for PrimTS attention."""
+
+from collections.abc import Callable
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as distribution_version
+
+from packaging.version import InvalidVersion, Version
+
+_CUTLASS_DSL_DISTRIBUTION = "nvidia-cutlass-dsl"
+_MINIMUM_CUTLASS_DSL_VERSION = Version("4.7.0")
+
+
+def require_prims_ts_cutlass_dsl(
+    get_version: Callable[[str], str] = distribution_version,
+) -> str:
+    """Return the installed DSL version or reject an unsupported PrimTS import."""
+
+    install_hint = (
+        "Install nvidia-cutlass-dsl==4.7.0, or "
+        "nvidia-cutlass-dsl[cu13]==4.7.0 for CUDA 13."
+    )
+    try:
+        installed_text = get_version(_CUTLASS_DSL_DISTRIBUTION)
+    except PackageNotFoundError as error:
+        raise ImportError(
+            "flashinfer.attention.prims_ts requires nvidia-cutlass-dsl>=4.7.0, "
+            f"but it is not installed. {install_hint}"
+        ) from error
+
+    try:
+        installed = Version(installed_text)
+    except InvalidVersion as error:
+        raise ImportError(
+            "flashinfer.attention.prims_ts requires nvidia-cutlass-dsl>=4.7.0, "
+            f"but found an invalid version {installed_text!r}. {install_hint}"
+        ) from error
+
+    if installed < _MINIMUM_CUTLASS_DSL_VERSION:
+        raise ImportError(
+            "flashinfer.attention.prims_ts requires nvidia-cutlass-dsl>=4.7.0, "
+            f"but found {installed_text}. FlashInfer's default dependency remains 4.6.2. "
+            f"{install_hint}"
+        )
+    return installed_text

--- a/flashinfer/attention/prims_ts/README.md
+++ b/flashinfer/attention/prims_ts/README.md
@@ -8,6 +8,42 @@ and cache semantics without tuning knobs.
 Current accuracy and performance signoff is on SM100a/B200. SM103a/B300 is
 admitted by the runtime architecture guard but is not yet signoff-qualified.
 
+## CUTLASS DSL version policy
+
+Published FlashInfer packages, including nightlies, retain
+`nvidia-cutlass-dsl==4.6.2` for the general runtime. The experimental PrimTS
+attention kernels use APIs introduced in CUTLASS DSL 4.7 and require
+`nvidia-cutlass-dsl>=4.7.0`. Importing `flashinfer.attention.prims_ts` with the
+default 4.6.2 dependency raises a feature-local error; importing and using
+other FlashInfer APIs does not require the PrimTS override.
+
+FlashInfer source CI and documentation builds replace the complete CUTLASS DSL
+package stack with 4.7.0 before validating PrimTS. That test-only environment
+does not change the dependency metadata of release or nightly artifacts, whose
+consumer tests restore and verify 4.6.2.
+
+To opt into PrimTS, replace the installed DSL stack with the package for the
+environment's CUDA major version:
+
+```bash
+python -m pip uninstall -y \
+  nvidia-cutlass-dsl \
+  nvidia-cutlass-dsl-libs-core \
+  nvidia-cutlass-dsl-libs-base \
+  nvidia-cutlass-dsl-libs-cu12 \
+  nvidia-cutlass-dsl-libs-cu13
+
+# CUDA 12
+python -m pip install "nvidia-cutlass-dsl==4.7.0"
+
+# CUDA 13
+python -m pip install "nvidia-cutlass-dsl[cu13]==4.7.0"
+```
+
+This is a feature-specific override of FlashInfer's 4.6.2 package dependency,
+so `pip check` will report the intentional version difference. Keep the
+override confined to environments that use or validate PrimTS.
+
 ## Guides and public APIs
 
 Import all entries below from `flashinfer.attention.prims_ts`.
@@ -23,10 +59,11 @@ output/workspace ownership, examples, limitations, and validation commands.
 
 ## Validation
 
-Run the numerical, graph, scheduler/resource, alias-safety, and public-surface
-contracts:
+After installing CUTLASS DSL 4.7.0, run the numerical, graph,
+scheduler/resource, alias-safety, and public-surface contracts:
 
 ```bash
+python -c 'import importlib.metadata as m; assert m.version("nvidia-cutlass-dsl") == "4.7.0"'
 pytest -q \
   tests/attention/test_attention_ts_context.py \
   tests/attention/test_attention_ts_decode.py \

--- a/flashinfer/attention/prims_ts/__init__.py
+++ b/flashinfer/attention/prims_ts/__init__.py
@@ -14,6 +14,10 @@
 
 """Experimental task-scheduled attention entry points."""
 
+from .._prims_ts_dependency import require_prims_ts_cutlass_dsl
+
+require_prims_ts_cutlass_dsl()
+
 from .decode import (
     BatchDecodePagedTSWrapper,
     batch_decode_with_paged_kv_cache,

--- a/flashinfer/attention/prims_ts/kernels/fmha_context/README.md
+++ b/flashinfer/attention/prims_ts/kernels/fmha_context/README.md
@@ -5,6 +5,10 @@ kernel used by FlashInfer's experimental Blackwell APIs. One implementation
 serves fixed contiguous, packed-ragged contiguous, and packed-query paged-KV
 attention with MHA or GQA.
 
+This kernel requires `nvidia-cutlass-dsl>=4.7.0`; see the shared
+[CUTLASS DSL version policy](../../README.md#cutlass-dsl-version-policy) for
+the package-default and CI behavior.
+
 The public API exposes attention semantics, not scheduling controls. Contiguous
 and paged plans select a nonpersistent, static-persistent, or CLC-persistent
 launch from logical work, task topology, live-metadata requirements, causal

--- a/flashinfer/attention/prims_ts/kernels/fmha_decode/README.md
+++ b/flashinfer/attention/prims_ts/kernels/fmha_decode/README.md
@@ -5,6 +5,10 @@ FlashInfer's experimental paged decode APIs on NVIDIA Blackwell GPUs. It
 supports token-at-a-time decode, small fixed speculative-query batches, and
 packed variable-length queries over a paged K/V cache.
 
+This kernel requires `nvidia-cutlass-dsl>=4.7.0`; see the shared
+[CUTLASS DSL version policy](../../README.md#cutlass-dsl-version-policy) for
+the package-default and CI behavior.
+
 The public API describes attention semantics and cache metadata. Tile shapes
 and launch policy are selected internally for the problem and GPU. Fixed-Q
 plans may use direct, persistent, or split-KV execution. Packed-Q and

--- a/flashinfer/attention/prims_ts/kernels/mla_decode/README.md
+++ b/flashinfer/attention/prims_ts/kernels/mla_decode/README.md
@@ -6,6 +6,10 @@ paged-cache APIs. The implementation accepts the post-matrix-absorption MLA
 layout: every query/cache row contains a 512-element latent component followed
 by a 64-element RoPE component, while output contains the 512 latent values.
 
+This kernel requires `nvidia-cutlass-dsl>=4.7.0`; see the shared
+[CUTLASS DSL version policy](../../README.md#cutlass-dsl-version-policy) for
+the package-default and CI behavior.
+
 FlashInfer selects the 1-CTA throughput/latency family or the 2-CTA throughput
 family automatically. Query grouping, persistent scheduling, split-KV, and
 local versus separate reduction are implementation decisions. Unsupported

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,8 +25,8 @@ urls = { Homepage = "https://github.com/flashinfer-ai/flashinfer" }
 license-files = ["LICENSE", "LICENSE*.txt"]
 
 [project.optional-dependencies]
-cu12 = ["nvidia-cutlass-dsl==4.7.0"]
-cu13 = ["nvidia-cutlass-dsl[cu13]==4.7.0"]
+cu12 = ["nvidia-cutlass-dsl==4.6.2"]
+cu13 = ["nvidia-cutlass-dsl[cu13]==4.6.2"]
 # DEPRECATED alias, kept so existing `pip install ".[nvep]"` commands keep
 # working. The moe_ep runtime deps (cuda-python, nccl4py) are now part of the
 # BASE dependencies (requirements.txt) and the NIXL-EP submodule build runs by

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,7 +29,7 @@ nccl4py>=0.3.1
 ninja
 numpy
 nvidia-cudnn-frontend>=1.25.0
-nvidia-cutlass-dsl==4.7.0
+nvidia-cutlass-dsl==4.6.2
 nvidia-ml-py
 packaging>=24.2
 requests

--- a/scripts/build_in_container.sh
+++ b/scripts/build_in_container.sh
@@ -128,7 +128,7 @@ uv pip install --python "${VENV}/bin/python" --no-deps \
 # nccl4py's cuda.core/cuda-bindings come along here.
 uv pip install --python "${VENV}/bin/python" \
     numpy einops ninja nvidia-ml-py click requests tabulate tqdm \
-    "nvidia-cutlass-dsl[cu13]==4.7.0" "nvidia-cudnn-frontend>=1.13.0" \
+    "nvidia-cutlass-dsl[cu13]==4.6.2" "nvidia-cudnn-frontend>=1.13.0" \
     "cuda-tile>=1.4.0" "cuda-python>=13.0" "nccl4py>=0.3.1" \
     "nvidia-nccl-cu13>=2.30.7"   # B200 NCCL-EP needs >=2.30.7; load this first on LD_LIBRARY_PATH
 

--- a/scripts/setup_ci_test_env.sh
+++ b/scripts/setup_ci_test_env.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+# Set up dependency versions for source-based CI tests.
+#
+# This script must be sourced after the project dependencies are installed.
+# Published and nightly FlashInfer packages retain the version declared in
+# requirements.txt; only source-based CI validation opts into CUTLASS DSL 4.7.
+
+: "${CUTLASS_DSL_CI_VERSION:=${CUTLASS_DSL_VERSION:-4.7.0}}"
+
+CUDA_MAJOR=$(python -c \
+  'import torch; version = torch.version.cuda; print(version.split(".")[0] if version else "12")' \
+  2>/dev/null || echo 12)
+if [ "$CUDA_MAJOR" = "13" ]; then
+  CUTLASS_DSL_PACKAGE="nvidia-cutlass-dsl[cu13]==${CUTLASS_DSL_CI_VERSION}"
+  CUTLASS_DSL_PACKAGES=(
+    nvidia-cutlass-dsl
+    nvidia-cutlass-dsl-libs-core
+    nvidia-cutlass-dsl-libs-base
+    nvidia-cutlass-dsl-libs-cu12
+    nvidia-cutlass-dsl-libs-cu13
+  )
+else
+  CUTLASS_DSL_PACKAGE="nvidia-cutlass-dsl==${CUTLASS_DSL_CI_VERSION}"
+  CUTLASS_DSL_PACKAGES=(
+    nvidia-cutlass-dsl
+    nvidia-cutlass-dsl-libs-core
+    nvidia-cutlass-dsl-libs-base
+    nvidia-cutlass-dsl-libs-cu12
+  )
+fi
+
+pip uninstall -y \
+  nvidia-cutlass-dsl \
+  nvidia-cutlass-dsl-libs-core \
+  nvidia-cutlass-dsl-libs-base \
+  nvidia-cutlass-dsl-libs-cu12 \
+  nvidia-cutlass-dsl-libs-cu13 2>/dev/null || true
+pip install "${CUTLASS_DSL_PACKAGE}"
+
+python - "${CUTLASS_DSL_CI_VERSION}" "${CUTLASS_DSL_PACKAGES[@]}" <<'PY'
+import importlib.metadata as metadata
+import sys
+
+expected, *packages = sys.argv[1:]
+for name in packages:
+    version = metadata.version(name)
+    if version != expected:
+        raise SystemExit(f"ERROR: {name} is {version}, expected {expected}")
+print(f"CUTLASS DSL CI check passed: {expected}")
+PY

--- a/scripts/setup_test_env.sh
+++ b/scripts/setup_test_env.sh
@@ -59,7 +59,7 @@ if [ -n "${CUTLASS_DSL_VERSION:-}" ]; then
   echo "Overriding nvidia-cutlass-dsl with: ${CUTLASS_DSL_PKG}"
   echo "========================================"
   # Clean uninstall old packages first (recommended by NVIDIA docs)
-  pip uninstall nvidia-cutlass-dsl nvidia-cutlass-dsl-libs-base nvidia-cutlass-dsl-libs-cu12 nvidia-cutlass-dsl-libs-cu13 -y 2>/dev/null || true
+  pip uninstall nvidia-cutlass-dsl nvidia-cutlass-dsl-libs-core nvidia-cutlass-dsl-libs-base nvidia-cutlass-dsl-libs-cu12 nvidia-cutlass-dsl-libs-cu13 -y 2>/dev/null || true
   pip install "${CUTLASS_DSL_PKG}"
   echo "nvidia-cutlass-dsl override complete."
   echo ""

--- a/scripts/task_jit_run_tests_part1.sh
+++ b/scripts/task_jit_run_tests_part1.sh
@@ -6,11 +6,13 @@ set -x
 : ${CUDA_VISIBLE_DEVICES:=0}
 : ${SKIP_INSTALL:=0}
 
-# Source test environment setup (handles package overrides like TVM-FFI)
+# Source the pre-install guards and optional dependency overrides.
 source "$(dirname "${BASH_SOURCE[0]}")/setup_test_env.sh"
 
 if [ "$SKIP_INSTALL" = "0" ]; then
   pip install -e . -v
+  # shellcheck disable=SC1091
+  source "$(dirname "${BASH_SOURCE[0]}")/setup_ci_test_env.sh"
 fi
 
 # Run each test file separately to isolate CUDA memory issues

--- a/scripts/task_jit_run_tests_part2.sh
+++ b/scripts/task_jit_run_tests_part2.sh
@@ -6,11 +6,13 @@ set -x
 : ${CUDA_VISIBLE_DEVICES:=0}
 : ${SKIP_INSTALL:=0}
 
-# Source test environment setup (handles package overrides like TVM-FFI)
+# Source the pre-install guards and optional dependency overrides.
 source "$(dirname "${BASH_SOURCE[0]}")/setup_test_env.sh"
 
 if [ "$SKIP_INSTALL" = "0" ]; then
   pip install -e . -v
+  # shellcheck disable=SC1091
+  source "$(dirname "${BASH_SOURCE[0]}")/setup_ci_test_env.sh"
 fi
 
 # Run each test file separately to isolate CUDA memory issues

--- a/scripts/task_jit_run_tests_part3.sh
+++ b/scripts/task_jit_run_tests_part3.sh
@@ -6,11 +6,13 @@ set -x
 : ${CUDA_VISIBLE_DEVICES:=0}
 : ${SKIP_INSTALL:=0}
 
-# Source test environment setup (handles package overrides like TVM-FFI)
+# Source the pre-install guards and optional dependency overrides.
 source "$(dirname "${BASH_SOURCE[0]}")/setup_test_env.sh"
 
 if [ "$SKIP_INSTALL" = "0" ]; then
   pip install -e . -v
+  # shellcheck disable=SC1091
+  source "$(dirname "${BASH_SOURCE[0]}")/setup_ci_test_env.sh"
 fi
 
 # Run each test file separately to isolate CUDA memory issues

--- a/scripts/task_jit_run_tests_part4.sh
+++ b/scripts/task_jit_run_tests_part4.sh
@@ -6,11 +6,13 @@ set -x
 : ${CUDA_VISIBLE_DEVICES:=0}
 : ${SKIP_INSTALL:=0}
 
-# Source test environment setup (handles package overrides like TVM-FFI)
+# Source the pre-install guards and optional dependency overrides.
 source "$(dirname "${BASH_SOURCE[0]}")/setup_test_env.sh"
 
 if [ "$SKIP_INSTALL" = "0" ]; then
   pip install -e . -v
+  # shellcheck disable=SC1091
+  source "$(dirname "${BASH_SOURCE[0]}")/setup_ci_test_env.sh"
 fi
 
 export PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True  # avoid memory fragmentation

--- a/scripts/task_jit_run_tests_part5.sh
+++ b/scripts/task_jit_run_tests_part5.sh
@@ -6,11 +6,13 @@ set -x
 : ${CUDA_VISIBLE_DEVICES:=0}
 : ${SKIP_INSTALL:=0}
 
-# Source test environment setup (handles package overrides like TVM-FFI)
+# Source the pre-install guards and optional dependency overrides.
 source "$(dirname "${BASH_SOURCE[0]}")/setup_test_env.sh"
 
 if [ "$SKIP_INSTALL" = "0" ]; then
   pip install -e . -v
+  # shellcheck disable=SC1091
+  source "$(dirname "${BASH_SOURCE[0]}")/setup_ci_test_env.sh"
 fi
 
 # Run each test file separately to isolate CUDA memory issues

--- a/scripts/task_run_unit_tests.sh
+++ b/scripts/task_run_unit_tests.sh
@@ -133,11 +133,6 @@ main() {
 
         install_and_verify
 
-        # Apply dependency overrides after installation since pip may overwrite
-        # the versions established by the CI image.
-        # shellcheck disable=SC1091
-        source "${SCRIPT_DIR}/setup_test_env.sh"
-
         # tests/moe_ep needs its additional runtime stack only on CUDA 13 images.
         local cuda_major
         cuda_major=$(python -c \
@@ -145,6 +140,10 @@ main() {
             2>/dev/null || echo 0)
         if [[ "${TEST_PATH:-}" == *moe_ep* ]] && [ "${cuda_major}" -ge 13 ]; then
             FI_SRC="$(pwd)" bash docker/install/build_flashinfer_ep_pytorch.sh
+            # The EP setup performs another dependency-resolving editable
+            # install, so restore the source-CI DSL baseline afterward.
+            # shellcheck disable=SC1091
+            source "${SCRIPT_DIR}/setup_ci_test_env.sh"
         fi
     fi
 

--- a/scripts/task_test_jit_cache_package_build_import.sh
+++ b/scripts/task_test_jit_cache_package_build_import.sh
@@ -5,7 +5,7 @@ set -x
 
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
-# Source test environment setup (handles package overrides like TVM-FFI)
+# Source the pre-install guards and optional dependency overrides.
 source "${SCRIPT_DIR}/setup_test_env.sh"
 # shellcheck source=scripts/jit_cache_build_common.sh
 source "${SCRIPT_DIR}/jit_cache_build_common.sh"
@@ -197,6 +197,9 @@ run_with_aot_memory_monitor "pip_install_flashinfer_editable" \
     exit 1
 }
 echo "✓ Flashinfer package installed successfully"
+# Apply the source-test dependency policy after the editable install.
+# shellcheck disable=SC1091
+source "${SCRIPT_DIR}/setup_ci_test_env.sh"
 
 # Set up sccache for compiler caching with S3 backend.
 # Uses read-write mode when AWS credentials are available (nightly/release builds),

--- a/scripts/task_test_multi_gpu_comm_kernels.sh
+++ b/scripts/task_test_multi_gpu_comm_kernels.sh
@@ -5,7 +5,7 @@ set -eo pipefail
 # Get the directory where this script is located
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-# Source test environment setup (handles package overrides like TVM-FFI)
+# Source the pre-install guards and optional dependency overrides.
 source "${SCRIPT_DIR}/setup_test_env.sh"
 
 # Set MPI command prefix for multi-GPU tests

--- a/scripts/task_test_multi_node_comm_kernels.sh
+++ b/scripts/task_test_multi_node_comm_kernels.sh
@@ -4,7 +4,8 @@ set -eo pipefail
 
 # Get the directory where this script is located
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-# Source test environment setup (handles package overrides like TVM-FFI)
+
+# Source the pre-install guards and optional dependency overrides.
 source "${SCRIPT_DIR}/setup_test_env.sh"
 
 # Clean Python bytecode cache to avoid stale imports (e.g., after module refactoring)

--- a/scripts/task_test_nightly_build.sh
+++ b/scripts/task_test_nightly_build.sh
@@ -3,6 +3,8 @@
 set -eo pipefail
 set -x
 
+NIGHTLY_CUTLASS_DSL_VERSION="4.6.2"
+
 # Source test environment setup (handles package overrides like TVM-FFI)
 source "$(dirname "${BASH_SOURCE[0]}")/setup_test_env.sh"
 
@@ -45,6 +47,47 @@ export FLASHINFER_DISABLE_JIT=1
 
 echo "Installing flashinfer-python from ${DIST_PYTHON_DIR}..."
 pip install ${DIST_PYTHON_DIR}/*.tar.gz
+
+# Nightly artifacts must be tested with their published 4.6 dependency even
+# though the reusable CI image starts on 4.7. Reinstall the complete stack so
+# this job represents a normal package consumer rather than the PrimTS CI
+# source-test override.
+CUDA_MAJOR=$(python -c "import torch; print(torch.version.cuda.split('.')[0])")
+pip uninstall -y \
+  nvidia-cutlass-dsl \
+  nvidia-cutlass-dsl-libs-core \
+  nvidia-cutlass-dsl-libs-base \
+  nvidia-cutlass-dsl-libs-cu12 \
+  nvidia-cutlass-dsl-libs-cu13 2>/dev/null || true
+if [ "$CUDA_MAJOR" = "13" ]; then
+  CUTLASS_DSL_PACKAGE="nvidia-cutlass-dsl[cu13]==${NIGHTLY_CUTLASS_DSL_VERSION}"
+  CUTLASS_DSL_PACKAGES="nvidia-cutlass-dsl nvidia-cutlass-dsl-libs-core nvidia-cutlass-dsl-libs-base nvidia-cutlass-dsl-libs-cu12 nvidia-cutlass-dsl-libs-cu13"
+else
+  CUTLASS_DSL_PACKAGE="nvidia-cutlass-dsl==${NIGHTLY_CUTLASS_DSL_VERSION}"
+  CUTLASS_DSL_PACKAGES="nvidia-cutlass-dsl nvidia-cutlass-dsl-libs-core nvidia-cutlass-dsl-libs-base nvidia-cutlass-dsl-libs-cu12"
+fi
+pip install --upgrade "$CUTLASS_DSL_PACKAGE"
+python -c "
+import importlib.metadata as m, sys
+from packaging.requirements import Requirement
+from packaging.utils import canonicalize_name
+
+expected = '${NIGHTLY_CUTLASS_DSL_VERSION}'
+for name in '${CUTLASS_DSL_PACKAGES}'.split():
+    version = m.version(name)
+    if version != expected:
+        sys.exit(f'ERROR: {name} is {version}, expected {expected}')
+requirements = [Requirement(raw) for raw in (m.distribution('flashinfer-python').requires or [])]
+dsl_requirements = [
+    requirement
+    for requirement in requirements
+    if canonicalize_name(requirement.name) == 'nvidia-cutlass-dsl'
+]
+if not dsl_requirements or any(str(requirement.specifier) != f'=={expected}' for requirement in dsl_requirements):
+    sys.exit(f'ERROR: flashinfer-python CUTLASS DSL requirements are {dsl_requirements}, expected =={expected}')
+print(f'Nightly CUTLASS DSL package check passed: {expected}')
+"
+pip check
 
 # Verify installation
 echo "Verifying installation..."

--- a/scripts/task_test_single_node_comm_kernels.sh
+++ b/scripts/task_test_single_node_comm_kernels.sh
@@ -5,7 +5,7 @@ set -x
 : ${MAX_JOBS:=$(nproc)}
 : ${CUDA_VISIBLE_DEVICES:=0}
 
-# Source test environment setup (handles package overrides like TVM-FFI)
+# Source the pre-install guards and optional dependency overrides.
 source "$(dirname "${BASH_SOURCE[0]}")/setup_test_env.sh"
 
 # Clean Python bytecode cache to avoid stale imports (e.g., after module refactoring)
@@ -16,6 +16,8 @@ echo "Cache cleaned."
 echo ""
 
 pip install -e . -v
+# shellcheck disable=SC1091
+source "$(dirname "${BASH_SOURCE[0]}")/setup_ci_test_env.sh"
 
 # nvshmem4py-cu12 pins cuda-python<=12.9; letting pip resolve its deps on a
 # cu13 container downgrades cuda-python/cuda-bindings and makes the next

--- a/scripts/test_utils.sh
+++ b/scripts/test_utils.sh
@@ -291,11 +291,10 @@ install_and_verify() {
         pip install -r requirements-test.txt
         python -c "import pytest_timeout"
 
-        # Install nvidia-cutlass-dsl with the correct CUDA extra to avoid
-        # version skew between libs-base and libs-cu13.
-        if [[ "${CUDA_VERSION}" == *"cu13"* || "${CUDA_VERSION}" == 13.* ]]; then
-            pip install --upgrade "nvidia-cutlass-dsl[cu13]==4.7.0"
-        fi
+        # Source-based CI validates PrimTS and forward compatibility on 4.7.0
+        # after installing the package's default 4.6.2 dependency.
+        # shellcheck disable=SC1091
+        source "${SCRIPT_DIR}/setup_ci_test_env.sh"
 
         # Install local python sources
         pip install -e . -v --no-deps

--- a/tests/attention/test_attention_ts_context.py
+++ b/tests/attention/test_attention_ts_context.py
@@ -29,7 +29,7 @@ import torch
 pytest.importorskip(
     "cutlass",
     minversion="4.7.0",
-    reason="PrimTS attention tests require nvidia-cutlass-dsl==4.7.0",
+    reason="PrimTS attention tests require nvidia-cutlass-dsl>=4.7.0",
 )
 
 from cutlass import BFloat16, Float16, Float8E4M3FN

--- a/tests/attention/test_attention_ts_decode.py
+++ b/tests/attention/test_attention_ts_decode.py
@@ -28,7 +28,7 @@ import torch
 pytest.importorskip(
     "cutlass",
     minversion="4.7.0",
-    reason="PrimTS attention tests require nvidia-cutlass-dsl==4.7.0",
+    reason="PrimTS attention tests require nvidia-cutlass-dsl>=4.7.0",
 )
 
 import cutlass

--- a/tests/attention/test_attention_ts_dependency.py
+++ b/tests/attention/test_attention_ts_dependency.py
@@ -1,0 +1,43 @@
+# Copyright (c) 2026 by FlashInfer team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from importlib.metadata import PackageNotFoundError
+
+import pytest
+
+from flashinfer.attention._prims_ts_dependency import require_prims_ts_cutlass_dsl
+
+
+@pytest.mark.parametrize("version", ["4.7.0", "4.7.1", "5.0.0"])
+def test_prims_ts_accepts_cutlass_dsl_47_or_newer(version: str) -> None:
+    assert require_prims_ts_cutlass_dsl(lambda _: version) == version
+
+
+@pytest.mark.parametrize("version", ["4.6.0", "4.6.2"])
+def test_prims_ts_rejects_cutlass_dsl_46(version: str) -> None:
+    with pytest.raises(ImportError, match=r"requires nvidia-cutlass-dsl>=4\.7\.0"):
+        require_prims_ts_cutlass_dsl(lambda _: version)
+
+
+def test_prims_ts_rejects_missing_cutlass_dsl() -> None:
+    def missing_distribution(name: str) -> str:
+        raise PackageNotFoundError(name)
+
+    with pytest.raises(ImportError, match="but it is not installed"):
+        require_prims_ts_cutlass_dsl(missing_distribution)
+
+
+def test_prims_ts_rejects_invalid_cutlass_dsl_version() -> None:
+    with pytest.raises(ImportError, match="invalid version"):
+        require_prims_ts_cutlass_dsl(lambda _: "development")

--- a/tests/attention/test_attention_ts_mask.py
+++ b/tests/attention/test_attention_ts_mask.py
@@ -19,7 +19,7 @@ import pytest
 pytest.importorskip(
     "cutlass",
     minversion="4.7.0",
-    reason="PrimTS attention tests require nvidia-cutlass-dsl==4.7.0",
+    reason="PrimTS attention tests require nvidia-cutlass-dsl>=4.7.0",
 )
 
 from flashinfer.attention.prims_ts.kernels.mask import (

--- a/tests/attention/test_attention_ts_mla_decode.py
+++ b/tests/attention/test_attention_ts_mla_decode.py
@@ -27,7 +27,7 @@ import torch
 pytest.importorskip(
     "cutlass",
     minversion="4.7.0",
-    reason="PrimTS attention tests require nvidia-cutlass-dsl==4.7.0",
+    reason="PrimTS attention tests require nvidia-cutlass-dsl>=4.7.0",
 )
 
 import cutlass.pipeline as pipeline


### PR DESCRIPTION
## Summary

- Restore the packaged CUTLASS DSL dependency to 4.6.2.
- Install and verify CUTLASS DSL 4.7.0 only in CI images and source-test/docs bootstrap for PrimTS.
- Keep nightly artifacts and consumer tests on 4.6.2, with metadata checks preventing version drift.
- Document the PrimTS 4.7 requirement and report it only when PrimTS is imported.

## Validation

- 16 PrimTS dependency and mask tests passed.
- Wheel metadata and a 4.6.2 consumer environment were verified.
- The 4.7.0 CI bootstrap and documentation build passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * PrimTS attention APIs now support CUTLASS DSL 4.7.0 and newer.
  * Clear installation guidance is provided when the required dependency is missing or outdated.
  * Other FlashInfer APIs continue using CUTLASS DSL 4.6.2.

* **Documentation**
  * Added guidance explaining CUTLASS DSL version requirements, installation options, and packaging behavior for PrimTS and related kernels.

* **Bug Fixes**
  * Improved dependency validation across builds, installations, and test environments to detect incompatible CUTLASS DSL versions earlier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->