### PR TITLE
skip the deliberate-trap test under compute-sanitizer

### DIFF
--- a/tests/attention/test_page.py
+++ b/tests/attention/test_page.py
@@ -1,3 +1,4 @@
+import os
 import subprocess
 import sys
 import textwrap
@@ -43,6 +44,22 @@ def _skip_if_fp8_e4m3_scale_unsupported():
     major, minor = get_compute_capability(torch.device("cuda:0"))
     if major < 8:
         pytest.skip(f"SM{major}{minor} does not support FP8 E4M3 scale tensors")
+
+
+def _is_compute_sanitizer_active() -> bool:
+    """Detect whether the process runs under compute-sanitizer.
+
+    The tool injects itself through environment variables that child processes
+    inherit, so this also holds inside a subprocess a test spawns. CUDA 13.x
+    uses the NV_SANITIZER_INJECTION_* set; older toolkits use
+    CUDA_INJECTION64_PATH, which Nsight tools set too, hence the value check.
+    """
+    if any(name.startswith("NV_SANITIZER_INJECTION_") for name in os.environ):
+        return True
+    return any(
+        "sanitizer" in os.environ.get(name, "").lower()
+        for name in ("CUDA_INJECTION64_PATH", "NVTX_INJECTION64_PATH")
+    )
 
 
 def _make_small_nvfp4_append_inputs(device="cuda:0"):
@@ -589,6 +606,11 @@ def test_nvfp4_quantize_append_paged_kv_cache_with_slot_mapping_cuda_graph_captu
     torch.cuda.synchronize()
 
 
+@pytest.mark.skipif(
+    _is_compute_sanitizer_active(),
+    reason="the replay below makes the kernel execute its `trap;` guard on purpose, "
+    "which compute-sanitizer reports as errors and slows past this test's timeout",
+)
 def test_nvfp4_quantize_append_paged_kv_cache_with_slot_mapping_cuda_graph_bad_scale():
     _skip_if_fp8_e4m3_scale_unsupported()
 


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->
fix https://nvbugspro.nvidia.com/bug/6563314

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated CUDA graph testing to skip a test when compute-sanitizer is active.
  * Added a clear explanation for the skip, preventing intentional kernel traps from causing sanitizer timeouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->