### PR TITLE
perf(sm120): optimize NVFP4 attention with N64 score-slot reuse

### DIFF
--- a/benchmarks/bench_sm120_attention.py
+++ b/benchmarks/bench_sm120_attention.py
@@ -26,13 +26,14 @@ import torch
 
 
 DEFAULT_CONFIGS = (
-    (4, 8, 4096, 128, False),
-    (1, 8, 32768, 128, False),
+    (4, 8, 8, 4096, 128, False),
+    (1, 8, 8, 32768, 128, False),
 )
 PER_BLOCK_MEAN = True
 CSV_FIELDS = (
     "batch_size",
-    "num_heads",
+    "num_qo_heads",
+    "num_kv_heads",
     "seq_len",
     "head_dim",
     "causal",
@@ -64,7 +65,8 @@ def _patch_cutlass_dsl_operand_major_mode() -> None:
 @dataclass(frozen=True)
 class BenchConfig:
     batch_size: int
-    num_heads: int
+    num_qo_heads: int
+    num_kv_heads: int
     seq_len: int
     head_dim: int
     causal: bool
@@ -88,7 +90,23 @@ def parse_args() -> argparse.Namespace:
         type=int,
         nargs="+",
         default=None,
-        help="Number of attention heads.",
+        help="Legacy alias that sets equal query/output and KV head counts.",
+    )
+    parser.add_argument(
+        "--num-qo-heads",
+        "--num_qo_heads",
+        type=int,
+        nargs="+",
+        default=None,
+        help="Number of query/output attention heads.",
+    )
+    parser.add_argument(
+        "--num-kv-heads",
+        "--num_kv_heads",
+        type=int,
+        nargs="+",
+        default=None,
+        help="Number of key/value attention heads.",
     )
     parser.add_argument(
         "--seq-len",
@@ -208,26 +226,43 @@ def broadcast_shape_lists(values: dict[str, list[int]]) -> dict[str, list[int]]:
 
 
 def build_configs(args: argparse.Namespace) -> list[BenchConfig]:
+    if args.num_heads is not None and (
+        args.num_qo_heads is not None or args.num_kv_heads is not None
+    ):
+        raise ValueError(
+            "--num-heads cannot be combined with --num-qo-heads or --num-kv-heads"
+        )
+
+    num_qo_heads = args.num_heads if args.num_heads is not None else args.num_qo_heads
+    num_kv_heads = args.num_heads if args.num_heads is not None else args.num_kv_heads
     has_custom_shape = any(
         arg is not None
-        for arg in (args.batch_size, args.num_heads, args.seq_len, args.head_dim)
+        for arg in (
+            args.batch_size,
+            num_qo_heads,
+            num_kv_heads,
+            args.seq_len,
+            args.head_dim,
+        )
     )
     if not has_custom_shape:
         return [
             BenchConfig(
                 batch_size=batch_size,
-                num_heads=num_heads,
+                num_qo_heads=num_qo_heads,
+                num_kv_heads=num_kv_heads,
                 seq_len=seq_len,
                 head_dim=head_dim,
                 causal=args.causal if args.causal is not None else causal,
             )
-            for batch_size, num_heads, seq_len, head_dim, causal in DEFAULT_CONFIGS
+            for batch_size, num_qo_heads, num_kv_heads, seq_len, head_dim, causal in DEFAULT_CONFIGS
         ]
 
     values = broadcast_shape_lists(
         {
             "batch_size": expand_values("batch_size", args.batch_size, 4),
-            "num_heads": expand_values("num_heads", args.num_heads, 8),
+            "num_qo_heads": expand_values("num_qo_heads", num_qo_heads, 8),
+            "num_kv_heads": expand_values("num_kv_heads", num_kv_heads, 8),
             "seq_len": expand_values("seq_len", args.seq_len, 4096),
             "head_dim": expand_values("head_dim", args.head_dim, 128),
         }
@@ -236,7 +271,8 @@ def build_configs(args: argparse.Namespace) -> list[BenchConfig]:
     return [
         BenchConfig(
             batch_size=values["batch_size"][idx],
-            num_heads=values["num_heads"][idx],
+            num_qo_heads=values["num_qo_heads"][idx],
+            num_kv_heads=values["num_kv_heads"][idx],
             seq_len=values["seq_len"][idx],
             head_dim=values["head_dim"][idx],
             causal=causal,
@@ -248,8 +284,19 @@ def build_configs(args: argparse.Namespace) -> list[BenchConfig]:
 def validate_config(config: BenchConfig) -> None:
     if config.batch_size <= 0:
         raise ValueError(f"batch_size must be positive, got {config.batch_size}")
-    if config.num_heads <= 0:
-        raise ValueError(f"num_heads must be positive, got {config.num_heads}")
+    if config.num_qo_heads <= 0 or config.num_kv_heads <= 0:
+        raise ValueError(
+            "num_qo_heads and num_kv_heads must be positive, "
+            f"got {config.num_qo_heads} and {config.num_kv_heads}"
+        )
+    if (
+        config.num_qo_heads < config.num_kv_heads
+        or config.num_qo_heads % config.num_kv_heads != 0
+    ):
+        raise ValueError(
+            "num_qo_heads must be greater than or equal to and divisible by "
+            f"num_kv_heads, got {config.num_qo_heads} and {config.num_kv_heads}"
+        )
     if config.seq_len <= 0 or config.seq_len % 128 != 0:
         raise ValueError(
             f"seq_len must be positive and divisible by 128, got {config.seq_len}"
@@ -263,7 +310,7 @@ def attention_flops(config: BenchConfig) -> float:
     return (
         factor
         * config.batch_size
-        * config.num_heads
+        * config.num_qo_heads
         * config.seq_len
         * config.seq_len
         * config.head_dim
@@ -324,14 +371,21 @@ def bench_config(
 
     q = torch.randn(
         config.batch_size,
-        config.num_heads,
+        config.num_qo_heads,
         config.seq_len,
         config.head_dim,
         dtype=dtype,
         device="cuda",
     )
-    k = torch.randn_like(q)
-    v = torch.randn_like(q)
+    k = torch.randn(
+        config.batch_size,
+        config.num_kv_heads,
+        config.seq_len,
+        config.head_dim,
+        dtype=dtype,
+        device="cuda",
+    )
+    v = torch.randn_like(k)
 
     sm_scale = 1.0 / math.sqrt(config.head_dim)
     out = torch.empty_like(q)
@@ -339,7 +393,7 @@ def bench_config(
     if return_lse:
         lse = torch.empty(
             config.batch_size,
-            config.num_heads,
+            config.num_qo_heads,
             config.seq_len,
             dtype=torch.float32,
             device="cuda",
@@ -445,7 +499,8 @@ def bench_config(
 
     print(
         "nvfp4_attention_sm120 "
-        f"B={config.batch_size} H={config.num_heads} S={config.seq_len} "
+        f"B={config.batch_size} Hq={config.num_qo_heads} "
+        f"Hkv={config.num_kv_heads} S={config.seq_len} "
         f"D={config.head_dim} causal={config.causal} dtype={dtype}: "
         f"return_lse={return_lse}, "
         f"attention_only={attention_only_ms:.3f} ms "
@@ -465,7 +520,8 @@ def bench_config(
     )
     return {
         "batch_size": config.batch_size,
-        "num_heads": config.num_heads,
+        "num_qo_heads": config.num_qo_heads,
+        "num_kv_heads": config.num_kv_heads,
         "seq_len": config.seq_len,
         "head_dim": config.head_dim,
         "causal": config.causal,

--- a/benchmarks/bench_sm120_attention.py
+++ b/benchmarks/bench_sm120_attention.py
@@ -453,49 +453,68 @@ def bench_config(
     attention_only_tflops = tflops_per_sec(config, attention_only_ms)
     end_to_end_tflops = tflops_per_sec(config, end_to_end_ms)
 
-    from flashinfer.prefill import fmha_v2_prefill_sm120
-
-    q_bshd = q.permute(0, 2, 1, 3).contiguous()
-    k_bshd = k.permute(0, 2, 1, 3).contiguous()
-    v_bshd = v.permute(0, 2, 1, 3).contiguous()
-    q_fp8, q_scale = quantize_e4m3(q_bshd)
-    k_fp8, k_scale = quantize_e4m3(k_bshd)
-    v_fp8, v_scale = quantize_e4m3(v_bshd)
-    out_fp8 = torch.empty_like(q_bshd, dtype=torch.bfloat16)
-    scale_bmm1_d = torch.tensor(
-        [q_scale * k_scale * sm_scale], dtype=torch.float32, device=q.device
+    fp8_baseline_available = (
+        config.num_qo_heads == config.num_kv_heads and dtype == torch.bfloat16
     )
-    scale_bmm2_d = torch.tensor([v_scale], dtype=torch.float32, device=q.device)
+    fp8_attention_only_ms = None
+    fp8_attention_only_tflops = None
+    nvfp4_speedup_over_fp8 = None
+    if fp8_baseline_available:
+        from flashinfer.prefill import fmha_v2_prefill_sm120
 
-    def fp8_attention_only():
-        return fmha_v2_prefill_sm120(
-            q_fp8,
-            k_fp8,
-            v_fp8,
-            out_fp8,
-            num_heads=config.num_heads,
-            head_dim=config.head_dim,
-            seq_len=config.seq_len,
-            scale_softmax=1.0,
-            scale_bmm1=q_scale * k_scale * sm_scale,
-            scale_bmm2=v_scale,
-            scale_bmm1_d=scale_bmm1_d,
-            scale_bmm2_d=scale_bmm2_d,
-            causal=config.causal,
+        q_bshd = q.permute(0, 2, 1, 3).contiguous()
+        k_bshd = k.permute(0, 2, 1, 3).contiguous()
+        v_bshd = v.permute(0, 2, 1, 3).contiguous()
+        q_fp8, q_scale = quantize_e4m3(q_bshd)
+        k_fp8, k_scale = quantize_e4m3(k_bshd)
+        v_fp8, v_scale = quantize_e4m3(v_bshd)
+        out_fp8 = torch.empty_like(q_bshd, dtype=dtype)
+        lse_fp8 = None
+        if return_lse:
+            lse_fp8 = torch.empty(
+                config.batch_size,
+                config.seq_len,
+                config.num_qo_heads,
+                2,
+                dtype=torch.float32,
+                device=q.device,
+            )
+        scale_bmm1_d = torch.tensor(
+            [q_scale * k_scale * sm_scale], dtype=torch.float32, device=q.device
         )
+        scale_bmm2_d = torch.tensor([v_scale], dtype=torch.float32, device=q.device)
 
-    fp8_attention_only()
-    torch.cuda.synchronize()
-    fp8_attention_only_ms = median_gpu_ms(
-        fp8_attention_only,
-        warmup,
-        repeat,
-        use_cuda_graph=attention_cuda_graph,
-        cold_l2_cache=not attention_cuda_graph,
-        num_iters_within_graph=1,
-    )
-    fp8_attention_only_tflops = tflops_per_sec(config, fp8_attention_only_ms)
-    nvfp4_speedup_over_fp8 = fp8_attention_only_ms / attention_only_ms
+        def fp8_attention_only():
+            return fmha_v2_prefill_sm120(
+                q_fp8,
+                k_fp8,
+                v_fp8,
+                out_fp8,
+                num_heads=config.num_qo_heads,
+                head_dim=config.head_dim,
+                seq_len=config.seq_len,
+                scale_softmax=1.0,
+                scale_bmm1=q_scale * k_scale * sm_scale,
+                scale_bmm2=v_scale,
+                scale_bmm1_d=scale_bmm1_d,
+                scale_bmm2_d=scale_bmm2_d,
+                causal=config.causal,
+                return_lse=return_lse,
+                lse=lse_fp8,
+            )
+
+        fp8_attention_only()
+        torch.cuda.synchronize()
+        fp8_attention_only_ms = median_gpu_ms(
+            fp8_attention_only,
+            warmup,
+            repeat,
+            use_cuda_graph=attention_cuda_graph,
+            cold_l2_cache=not attention_cuda_graph,
+            num_iters_within_graph=1,
+        )
+        fp8_attention_only_tflops = tflops_per_sec(config, fp8_attention_only_ms)
+        nvfp4_speedup_over_fp8 = fp8_attention_only_ms / attention_only_ms
 
     print(
         "nvfp4_attention_sm120 "
@@ -509,15 +528,25 @@ def bench_config(
         f"end_to_end={end_to_end_ms:.3f} ms "
         f"({end_to_end_tflops:.3f} attention-TFLOPs/s)"
     )
-    print(
-        "fmha_v2_prefill_sm120_fp8 "
-        f"B={config.batch_size} H={config.num_heads} S={config.seq_len} "
-        f"D={config.head_dim} causal={config.causal}: "
-        f"attention_only={fp8_attention_only_ms:.3f} ms "
-        f"({fp8_attention_only_tflops:.3f} TFLOPs/s, "
-        f"cuda_graph={attention_cuda_graph}), "
-        f"nvfp4_speedup={nvfp4_speedup_over_fp8:.3f}x"
-    )
+    if fp8_baseline_available:
+        print(
+            "fmha_v2_prefill_sm120_fp8 "
+            f"B={config.batch_size} H={config.num_qo_heads} S={config.seq_len} "
+            f"D={config.head_dim} causal={config.causal}: "
+            f"attention_only={fp8_attention_only_ms:.3f} ms "
+            f"({fp8_attention_only_tflops:.3f} TFLOPs/s, "
+            f"cuda_graph={attention_cuda_graph}), "
+            f"nvfp4_speedup={nvfp4_speedup_over_fp8:.3f}x"
+        )
+    else:
+        print(
+            "fmha_v2_prefill_sm120_fp8 "
+            f"B={config.batch_size} Hq={config.num_qo_heads} "
+            f"Hkv={config.num_kv_heads} S={config.seq_len} "
+            f"D={config.head_dim} causal={config.causal}: "
+            "attention_only=unavailable "
+            "(requires equal Q/KV head counts and BF16 input/output)"
+        )
     return {
         "batch_size": config.batch_size,
         "num_qo_heads": config.num_qo_heads,

--- a/benchmarks/bench_sm120_attention.py
+++ b/benchmarks/bench_sm120_attention.py
@@ -36,6 +36,7 @@ CSV_FIELDS = (
     "seq_len",
     "head_dim",
     "causal",
+    "return_lse",
     "dtype",
     "attention_only_ms",
     "attention_only_tflops",
@@ -125,6 +126,11 @@ def parse_args() -> argparse.Namespace:
         choices=("float16", "bfloat16"),
         default="bfloat16",
         help="Input/output dtype before NVFP4 quantization.",
+    )
+    parser.add_argument(
+        "--return-lse",
+        action="store_true",
+        help="Compute log-sum-exp in addition to the attention output.",
     )
     parser.add_argument(
         "--warmup",
@@ -308,6 +314,7 @@ def bench_config(
     warmup: int,
     repeat: int,
     attention_cuda_graph: bool,
+    return_lse: bool,
 ) -> dict[str, object]:
     _patch_cutlass_dsl_operand_major_mode()
     import flashinfer
@@ -328,13 +335,15 @@ def bench_config(
 
     sm_scale = 1.0 / math.sqrt(config.head_dim)
     out = torch.empty_like(q)
-    lse = torch.empty(
-        config.batch_size,
-        config.num_heads,
-        config.seq_len,
-        dtype=torch.float32,
-        device="cuda",
-    )
+    lse = None
+    if return_lse:
+        lse = torch.empty(
+            config.batch_size,
+            config.num_heads,
+            config.seq_len,
+            dtype=torch.float32,
+            device="cuda",
+        )
 
     quantized_qkv = flashinfer.nvfp4_attention_sm120_quantize_qkv(
         q, k, v, per_block_mean=PER_BLOCK_MEAN
@@ -347,6 +356,7 @@ def bench_config(
         out=out,
         lse=lse,
         out_dtype=dtype,
+        return_lse=return_lse,
     )
     torch.cuda.synchronize()
 
@@ -359,6 +369,7 @@ def bench_config(
             out=out,
             lse=lse,
             out_dtype=dtype,
+            return_lse=return_lse,
         )
 
     def end_to_end():
@@ -373,6 +384,7 @@ def bench_config(
             out=out,
             lse=lse,
             out_dtype=dtype,
+            return_lse=return_lse,
         )
 
     attention_only_ms = median_gpu_ms(
@@ -435,6 +447,7 @@ def bench_config(
         "nvfp4_attention_sm120 "
         f"B={config.batch_size} H={config.num_heads} S={config.seq_len} "
         f"D={config.head_dim} causal={config.causal} dtype={dtype}: "
+        f"return_lse={return_lse}, "
         f"attention_only={attention_only_ms:.3f} ms "
         f"({attention_only_tflops:.3f} TFLOPs/s, "
         f"cuda_graph={attention_cuda_graph}), "
@@ -456,6 +469,7 @@ def bench_config(
         "seq_len": config.seq_len,
         "head_dim": config.head_dim,
         "causal": config.causal,
+        "return_lse": return_lse,
         "dtype": dtype_label(dtype),
         "attention_only_ms": attention_only_ms,
         "attention_only_tflops": attention_only_tflops,
@@ -498,6 +512,7 @@ def main() -> None:
                 args.warmup,
                 args.repeat,
                 attention_cuda_graph=not args.no_attention_cuda_graph,
+                return_lse=args.return_lse,
             )
         )
 

--- a/csrc/nvfp4_attention_sm120/nvfp4_attention_sm120_binding.cu
+++ b/csrc/nvfp4_attention_sm120/nvfp4_attention_sm120_binding.cu
@@ -81,7 +81,7 @@ int round_multiple(int x, int m) { return (x + m - 1) / m * m; }
 void set_params_fprop(Flash_fwd_params& params, TensorView q, TensorView k, TensorView v,
                       TensorView q_scale, TensorView k_scale, TensorView v_scale,
                       TensorView qk_correction, TensorView out, ffi::Optional<TensorView> maybe_lse,
-                      float sm_scale, bool causal, bool per_block_mean) {
+                      float sm_scale, bool causal, bool per_block_mean, int64_t unpadded_k_len) {
   params = {};
 
   const int batch = static_cast<int>(q.size(0));
@@ -141,7 +141,7 @@ void set_params_fprop(Flash_fwd_params& params, TensorView q, TensorView k, Tens
   params.h_h_k_ratio = num_qo_heads / num_kv_heads;
   params.seqlen_q = seq_len_q;
   params.seqlen_k = seq_len_k;
-  params.unpadded_seqlen_k = seq_len_k;
+  params.unpadded_seqlen_k = static_cast<int>(unpadded_k_len);
   params.seqlen_q_rounded = round_multiple(seq_len_q, 128);
   params.seqlen_k_rounded = round_multiple(seq_len_k, 128);
   params.d = head_dim;
@@ -202,7 +202,8 @@ void run_mha_fwd(Flash_fwd_params& params, cudaStream_t stream) {
 
 void fwd(TensorView q_fp4, TensorView k_fp4, TensorView v_fp4_t, TensorView q_scale,
          TensorView k_scale, TensorView v_scale_t, TensorView qk_correction, TensorView out,
-         ffi::Optional<TensorView> maybe_lse, double sm_scale, bool causal, bool per_block_mean) {
+         ffi::Optional<TensorView> maybe_lse, double sm_scale, bool causal, bool per_block_mean,
+         int64_t unpadded_k_len) {
   CHECK_INPUT(q_fp4);
   CHECK_INPUT(k_fp4);
   CHECK_INPUT(v_fp4_t);
@@ -251,11 +252,16 @@ void fwd(TensorView q_fp4, TensorView k_fp4, TensorView v_fp4_t, TensorView q_sc
   const int64_t batch = q_fp4.size(0);
   const int64_t num_qo_heads = q_fp4.size(1);
   const int64_t num_kv_heads = k_fp4.size(1);
-  const int64_t seq_len = q_fp4.size(2);
+  const int64_t seq_len_q = q_fp4.size(2);
+  const int64_t seq_len_k = k_fp4.size(2);
   const int64_t head_dim = q_fp4.size(3) * 2;
 
   TVM_FFI_ICHECK(head_dim == 64 || head_dim == 128) << "head_dim must be 64 or 128";
-  TVM_FFI_ICHECK_EQ(seq_len % 128, 0) << "seq_len must be a multiple of 128";
+  TVM_FFI_ICHECK_EQ(seq_len_q % 128, 0) << "Q sequence length must be a multiple of 128";
+  TVM_FFI_ICHECK_EQ(seq_len_k % 128, 0) << "K/V sequence length must be a multiple of 128";
+  TVM_FFI_ICHECK_GT(unpadded_k_len, 0) << "unpadded_k_len must be positive";
+  TVM_FFI_ICHECK_LE(unpadded_k_len, seq_len_k)
+      << "unpadded_k_len must not exceed the physical K/V sequence length";
   TVM_FFI_ICHECK_GT(num_qo_heads, 0) << "num_qo_heads must be positive";
   TVM_FFI_ICHECK_GT(num_kv_heads, 0) << "num_kv_heads must be positive";
   TVM_FFI_ICHECK_GE(num_qo_heads, num_kv_heads)
@@ -264,43 +270,42 @@ void fwd(TensorView q_fp4, TensorView k_fp4, TensorView v_fp4_t, TensorView q_sc
       << "num_qo_heads must be divisible by num_kv_heads";
 
   TVM_FFI_ICHECK_EQ(k_fp4.size(0), batch);
-  TVM_FFI_ICHECK_EQ(k_fp4.size(2), seq_len);
   TVM_FFI_ICHECK_EQ(k_fp4.size(3), q_fp4.size(3));
 
   TVM_FFI_ICHECK_EQ(v_fp4_t.size(0), batch);
   TVM_FFI_ICHECK_EQ(v_fp4_t.size(1), num_kv_heads);
   TVM_FFI_ICHECK_EQ(v_fp4_t.size(2), head_dim);
-  TVM_FFI_ICHECK_EQ(v_fp4_t.size(3), seq_len / 2);
+  TVM_FFI_ICHECK_EQ(v_fp4_t.size(3), seq_len_k / 2);
 
   TVM_FFI_ICHECK_EQ(q_scale.size(0), batch);
   TVM_FFI_ICHECK_EQ(q_scale.size(1), num_qo_heads);
-  TVM_FFI_ICHECK_EQ(q_scale.size(2), seq_len);
+  TVM_FFI_ICHECK_EQ(q_scale.size(2), seq_len_q);
   TVM_FFI_ICHECK_EQ(q_scale.size(3), head_dim / 16);
   TVM_FFI_ICHECK_EQ(k_scale.size(0), batch);
   TVM_FFI_ICHECK_EQ(k_scale.size(1), num_kv_heads);
-  TVM_FFI_ICHECK_EQ(k_scale.size(2), seq_len);
+  TVM_FFI_ICHECK_EQ(k_scale.size(2), seq_len_k);
   TVM_FFI_ICHECK_EQ(k_scale.size(3), head_dim / 16);
   TVM_FFI_ICHECK_EQ(v_scale_t.size(0), batch);
   TVM_FFI_ICHECK_EQ(v_scale_t.size(1), num_kv_heads);
   TVM_FFI_ICHECK_EQ(v_scale_t.size(2), head_dim);
-  TVM_FFI_ICHECK_EQ(v_scale_t.size(3), seq_len / 16);
+  TVM_FFI_ICHECK_EQ(v_scale_t.size(3), seq_len_k / 16);
 
   // Compact correction: one row per 128-token Q block. The kernel's TMA
   // layout addresses the tensor this way and broadcasts each row across
   // the rows of the corresponding Q tile.
   TVM_FFI_ICHECK_EQ(qk_correction.size(0), batch);
   TVM_FFI_ICHECK_EQ(qk_correction.size(1), num_qo_heads);
-  TVM_FFI_ICHECK_EQ(qk_correction.size(2), per_block_mean ? seq_len / 128 : 1);
-  TVM_FFI_ICHECK_EQ(qk_correction.size(3), seq_len);
+  TVM_FFI_ICHECK_EQ(qk_correction.size(2), per_block_mean ? seq_len_q / 128 : 1);
+  TVM_FFI_ICHECK_EQ(qk_correction.size(3), seq_len_k);
 
   TVM_FFI_ICHECK_EQ(out.size(0), batch);
   TVM_FFI_ICHECK_EQ(out.size(1), num_qo_heads);
-  TVM_FFI_ICHECK_EQ(out.size(2), seq_len);
+  TVM_FFI_ICHECK_EQ(out.size(2), seq_len_q);
   TVM_FFI_ICHECK_EQ(out.size(3), head_dim);
   if (maybe_lse.has_value()) {
     TVM_FFI_ICHECK_EQ(maybe_lse.value().size(0), batch);
     TVM_FFI_ICHECK_EQ(maybe_lse.value().size(1), num_qo_heads);
-    TVM_FFI_ICHECK_EQ(maybe_lse.value().size(2), seq_len);
+    TVM_FFI_ICHECK_EQ(maybe_lse.value().size(2), seq_len_q);
   }
 
   check_same_device(q_fp4, k_fp4, "k_fp4");
@@ -316,7 +321,7 @@ void fwd(TensorView q_fp4, TensorView k_fp4, TensorView v_fp4_t, TensorView q_sc
 
   cudaStream_t stream = get_stream(q_fp4.device());
 
-  if (seq_len == 0) {
+  if (seq_len_q == 0) {
     status = cudaMemsetAsync(out.data_ptr(), 0, numel(out) * get_element_size(out), stream);
     TVM_FFI_ICHECK(status == cudaSuccess)
         << "cudaMemsetAsync(out) failed: " << cudaGetErrorString(status);
@@ -340,7 +345,7 @@ void fwd(TensorView q_fp4, TensorView k_fp4, TensorView v_fp4_t, TensorView q_sc
 
   Flash_fwd_params params;
   set_params_fprop(params, q_fp4, k_fp4, v_fp4_t, q_scale, k_scale, v_scale_t, qk_correction, out,
-                   maybe_lse, static_cast<float>(sm_scale), causal, per_block_mean);
+                   maybe_lse, static_cast<float>(sm_scale), causal, per_block_mean, unpadded_k_len);
   run_mha_fwd(params, stream);
 }
 

--- a/csrc/nvfp4_attention_sm120/nvfp4_attention_sm120_binding.cu
+++ b/csrc/nvfp4_attention_sm120/nvfp4_attention_sm120_binding.cu
@@ -80,8 +80,8 @@ int round_multiple(int x, int m) { return (x + m - 1) / m * m; }
 
 void set_params_fprop(Flash_fwd_params& params, TensorView q, TensorView k, TensorView v,
                       TensorView q_scale, TensorView k_scale, TensorView v_scale,
-                      TensorView qk_correction, TensorView out, TensorView lse, float sm_scale,
-                      bool causal, bool per_block_mean) {
+                      TensorView qk_correction, TensorView out, ffi::Optional<TensorView> maybe_lse,
+                      float sm_scale, bool causal, bool per_block_mean) {
   params = {};
 
   const int batch = static_cast<int>(q.size(0));
@@ -131,7 +131,8 @@ void set_params_fprop(Flash_fwd_params& params, TensorView q, TensorView k, Tens
   params.cu_seqlens_k = nullptr;
   params.seqused_k = nullptr;
   params.p_ptr = nullptr;
-  params.softmax_lse_ptr = lse.data_ptr();
+  params.softmax_lse_ptr =
+      maybe_lse.has_value() ? static_cast<float*>(maybe_lse.value().data_ptr()) : nullptr;
 
   params.b = batch;
   params.h = num_heads;
@@ -168,25 +169,31 @@ void set_params_fprop(Flash_fwd_params& params, TensorView q, TensorView k, Tens
   params.tile_count_semaphore = nullptr;
 }
 
-template <bool IsBF16>
+template <bool ReturnLSE, bool IsBF16>
 void run_mha_fwd_dispatch_dtype(Flash_fwd_params& params, cudaStream_t stream) {
   using OType = std::conditional_t<IsBF16, cutlass::bfloat16_t, cutlass::half_t>;
   if (params.d == 64) {
-    ::nvfp4_attention::run_mha_fwd_<cutlass::nv_float4_t<cutlass::float_e2m1_t>, 64, OType>(params,
-                                                                                            stream);
+    ::nvfp4_attention::run_mha_fwd_<cutlass::nv_float4_t<cutlass::float_e2m1_t>, 64, OType,
+                                    ReturnLSE>(params, stream);
   } else if (params.d == 128) {
-    ::nvfp4_attention::run_mha_fwd_<cutlass::nv_float4_t<cutlass::float_e2m1_t>, 128, OType>(
-        params, stream);
+    ::nvfp4_attention::run_mha_fwd_<cutlass::nv_float4_t<cutlass::float_e2m1_t>, 128, OType,
+                                    ReturnLSE>(params, stream);
   } else {
     TVM_FFI_ICHECK(false) << "Unsupported head dimension " << params.d;
   }
 }
 
 void run_mha_fwd(Flash_fwd_params& params, cudaStream_t stream) {
-  if (params.is_bf16) {
-    run_mha_fwd_dispatch_dtype<true>(params, stream);
+  if (params.softmax_lse_ptr != nullptr) {
+    if (params.is_bf16) {
+      run_mha_fwd_dispatch_dtype<true, true>(params, stream);
+    } else {
+      run_mha_fwd_dispatch_dtype<true, false>(params, stream);
+    }
+  } else if (params.is_bf16) {
+    run_mha_fwd_dispatch_dtype<false, true>(params, stream);
   } else {
-    run_mha_fwd_dispatch_dtype<false>(params, stream);
+    run_mha_fwd_dispatch_dtype<false, false>(params, stream);
   }
 }
 
@@ -194,7 +201,7 @@ void run_mha_fwd(Flash_fwd_params& params, cudaStream_t stream) {
 
 void fwd(TensorView q_fp4, TensorView k_fp4, TensorView v_fp4_t, TensorView q_scale,
          TensorView k_scale, TensorView v_scale_t, TensorView qk_correction, TensorView out,
-         TensorView lse, double sm_scale, bool causal, bool per_block_mean) {
+         ffi::Optional<TensorView> maybe_lse, double sm_scale, bool causal, bool per_block_mean) {
   CHECK_INPUT(q_fp4);
   CHECK_INPUT(k_fp4);
   CHECK_INPUT(v_fp4_t);
@@ -203,7 +210,9 @@ void fwd(TensorView q_fp4, TensorView k_fp4, TensorView v_fp4_t, TensorView q_sc
   CHECK_INPUT(v_scale_t);
   CHECK_INPUT(qk_correction);
   CHECK_INPUT(out);
-  CHECK_INPUT(lse);
+  if (maybe_lse.has_value()) {
+    CHECK_INPUT(maybe_lse.value());
+  }
 
   CHECK_DIM(4, q_fp4);
   CHECK_DIM(4, k_fp4);
@@ -213,7 +222,9 @@ void fwd(TensorView q_fp4, TensorView k_fp4, TensorView v_fp4_t, TensorView q_sc
   CHECK_DIM(4, v_scale_t);
   CHECK_DIM(4, qk_correction);
   CHECK_DIM(4, out);
-  CHECK_DIM(3, lse);
+  if (maybe_lse.has_value()) {
+    CHECK_DIM(3, maybe_lse.value());
+  }
 
   TVM_FFI_ICHECK_EQ(q_fp4.dtype(), dl_uint8) << "q_fp4 must be uint8 packed FP4";
   TVM_FFI_ICHECK_EQ(k_fp4.dtype(), dl_uint8) << "k_fp4 must be uint8 packed FP4";
@@ -222,7 +233,9 @@ void fwd(TensorView q_fp4, TensorView k_fp4, TensorView v_fp4_t, TensorView q_sc
   TVM_FFI_ICHECK_EQ(k_scale.dtype(), dl_float8_e4m3fn) << "k_scale must be float8_e4m3fn";
   TVM_FFI_ICHECK_EQ(v_scale_t.dtype(), dl_float8_e4m3fn) << "v_scale_t must be float8_e4m3fn";
   TVM_FFI_ICHECK_EQ(qk_correction.dtype(), dl_float32) << "qk_correction must be float32";
-  TVM_FFI_ICHECK_EQ(lse.dtype(), dl_float32) << "lse must be float32";
+  if (maybe_lse.has_value()) {
+    TVM_FFI_ICHECK_EQ(maybe_lse.value().dtype(), dl_float32) << "lse must be float32";
+  }
   TVM_FFI_ICHECK(out.dtype() == dl_bfloat16 || out.dtype() == dl_float16)
       << "out must be bfloat16 or float16";
 
@@ -277,9 +290,11 @@ void fwd(TensorView q_fp4, TensorView k_fp4, TensorView v_fp4_t, TensorView q_sc
   TVM_FFI_ICHECK_EQ(out.size(1), num_heads);
   TVM_FFI_ICHECK_EQ(out.size(2), seq_len);
   TVM_FFI_ICHECK_EQ(out.size(3), head_dim);
-  TVM_FFI_ICHECK_EQ(lse.size(0), batch);
-  TVM_FFI_ICHECK_EQ(lse.size(1), num_heads);
-  TVM_FFI_ICHECK_EQ(lse.size(2), seq_len);
+  if (maybe_lse.has_value()) {
+    TVM_FFI_ICHECK_EQ(maybe_lse.value().size(0), batch);
+    TVM_FFI_ICHECK_EQ(maybe_lse.value().size(1), num_heads);
+    TVM_FFI_ICHECK_EQ(maybe_lse.value().size(2), seq_len);
+  }
 
   check_same_device(q_fp4, k_fp4, "k_fp4");
   check_same_device(q_fp4, v_fp4_t, "v_fp4_t");
@@ -288,7 +303,9 @@ void fwd(TensorView q_fp4, TensorView k_fp4, TensorView v_fp4_t, TensorView q_sc
   check_same_device(q_fp4, v_scale_t, "v_scale_t");
   check_same_device(q_fp4, qk_correction, "qk_correction");
   check_same_device(q_fp4, out, "out");
-  check_same_device(q_fp4, lse, "lse");
+  if (maybe_lse.has_value()) {
+    check_same_device(q_fp4, maybe_lse.value(), "lse");
+  }
 
   cudaStream_t stream = get_stream(q_fp4.device());
 
@@ -296,25 +313,27 @@ void fwd(TensorView q_fp4, TensorView k_fp4, TensorView v_fp4_t, TensorView q_sc
     status = cudaMemsetAsync(out.data_ptr(), 0, numel(out) * get_element_size(out), stream);
     TVM_FFI_ICHECK(status == cudaSuccess)
         << "cudaMemsetAsync(out) failed: " << cudaGetErrorString(status);
-    status = cudaMemsetAsync(lse.data_ptr(), 0, numel(lse) * get_element_size(lse), stream);
-    TVM_FFI_ICHECK(status == cudaSuccess)
-        << "cudaMemsetAsync(lse) failed: " << cudaGetErrorString(status);
+    if (maybe_lse.has_value()) {
+      auto lse = maybe_lse.value();
+      status = cudaMemsetAsync(lse.data_ptr(), 0, numel(lse) * get_element_size(lse), stream);
+      TVM_FFI_ICHECK(status == cudaSuccess)
+          << "cudaMemsetAsync(lse) failed: " << cudaGetErrorString(status);
+    }
     return;
   }
 
-  // lse is allocated uninitialized by the caller (torch.empty). The fwd kernel
-  // writes `out` for every query row but does not guarantee writing every
-  // (batch, head, seq) entry of lse, so reading it back can surface whatever
-  // garbage the allocator handed out (observed as flaky NaNs in lse under a
-  // dirty allocator, depending on test/run ordering). Zero it first, mirroring
-  // the seq_len==0 branch above, so unwritten entries are a defined 0.
-  status = cudaMemsetAsync(lse.data_ptr(), 0, numel(lse) * get_element_size(lse), stream);
-  TVM_FFI_ICHECK(status == cudaSuccess)
-      << "cudaMemsetAsync(lse) failed: " << cudaGetErrorString(status);
+  if (maybe_lse.has_value()) {
+    // LSE may be allocated uninitialized by the caller. Zero it first so any
+    // entries not written by the kernel have a defined value.
+    auto lse = maybe_lse.value();
+    status = cudaMemsetAsync(lse.data_ptr(), 0, numel(lse) * get_element_size(lse), stream);
+    TVM_FFI_ICHECK(status == cudaSuccess)
+        << "cudaMemsetAsync(lse) failed: " << cudaGetErrorString(status);
+  }
 
   Flash_fwd_params params;
   set_params_fprop(params, q_fp4, k_fp4, v_fp4_t, q_scale, k_scale, v_scale_t, qk_correction, out,
-                   lse, static_cast<float>(sm_scale), causal, per_block_mean);
+                   maybe_lse, static_cast<float>(sm_scale), causal, per_block_mean);
   run_mha_fwd(params, stream);
 }
 

--- a/csrc/nvfp4_attention_sm120/nvfp4_attention_sm120_binding.cu
+++ b/csrc/nvfp4_attention_sm120/nvfp4_attention_sm120_binding.cu
@@ -85,7 +85,8 @@ void set_params_fprop(Flash_fwd_params& params, TensorView q, TensorView k, Tens
   params = {};
 
   const int batch = static_cast<int>(q.size(0));
-  const int num_heads = static_cast<int>(q.size(1));
+  const int num_qo_heads = static_cast<int>(q.size(1));
+  const int num_kv_heads = static_cast<int>(k.size(1));
   const int seq_len_q = static_cast<int>(q.size(2));
   const int seq_len_k = static_cast<int>(k.size(2));
   const int head_dim = static_cast<int>(q.size(3) * 2);
@@ -135,9 +136,9 @@ void set_params_fprop(Flash_fwd_params& params, TensorView q, TensorView k, Tens
       maybe_lse.has_value() ? static_cast<float*>(maybe_lse.value().data_ptr()) : nullptr;
 
   params.b = batch;
-  params.h = num_heads;
-  params.h_k = num_heads;
-  params.h_h_k_ratio = 1;
+  params.h = num_qo_heads;
+  params.h_k = num_kv_heads;
+  params.h_h_k_ratio = num_qo_heads / num_kv_heads;
   params.seqlen_q = seq_len_q;
   params.seqlen_k = seq_len_k;
   params.unpadded_seqlen_k = seq_len_k;
@@ -145,7 +146,7 @@ void set_params_fprop(Flash_fwd_params& params, TensorView q, TensorView k, Tens
   params.seqlen_k_rounded = round_multiple(seq_len_k, 128);
   params.d = head_dim;
   params.d_rounded = head_dim;
-  params.head_divmod = cutlass::FastDivmod(num_heads);
+  params.head_divmod = cutlass::FastDivmod(num_qo_heads);
 
   params.scale_softmax = sm_scale;
   params.scale_softmax_log2 = sm_scale * 1.4426950408889634f;
@@ -248,33 +249,39 @@ void fwd(TensorView q_fp4, TensorView k_fp4, TensorView v_fp4_t, TensorView q_sc
       << "NVFP4 attention SM120 kernel requires compute capability 12.0 or 12.1";
 
   const int64_t batch = q_fp4.size(0);
-  const int64_t num_heads = q_fp4.size(1);
+  const int64_t num_qo_heads = q_fp4.size(1);
+  const int64_t num_kv_heads = k_fp4.size(1);
   const int64_t seq_len = q_fp4.size(2);
   const int64_t head_dim = q_fp4.size(3) * 2;
 
   TVM_FFI_ICHECK(head_dim == 64 || head_dim == 128) << "head_dim must be 64 or 128";
   TVM_FFI_ICHECK_EQ(seq_len % 128, 0) << "seq_len must be a multiple of 128";
+  TVM_FFI_ICHECK_GT(num_qo_heads, 0) << "num_qo_heads must be positive";
+  TVM_FFI_ICHECK_GT(num_kv_heads, 0) << "num_kv_heads must be positive";
+  TVM_FFI_ICHECK_GE(num_qo_heads, num_kv_heads)
+      << "num_qo_heads must be greater than or equal to num_kv_heads";
+  TVM_FFI_ICHECK_EQ(num_qo_heads % num_kv_heads, 0)
+      << "num_qo_heads must be divisible by num_kv_heads";
 
   TVM_FFI_ICHECK_EQ(k_fp4.size(0), batch);
-  TVM_FFI_ICHECK_EQ(k_fp4.size(1), num_heads);
   TVM_FFI_ICHECK_EQ(k_fp4.size(2), seq_len);
   TVM_FFI_ICHECK_EQ(k_fp4.size(3), q_fp4.size(3));
 
   TVM_FFI_ICHECK_EQ(v_fp4_t.size(0), batch);
-  TVM_FFI_ICHECK_EQ(v_fp4_t.size(1), num_heads);
+  TVM_FFI_ICHECK_EQ(v_fp4_t.size(1), num_kv_heads);
   TVM_FFI_ICHECK_EQ(v_fp4_t.size(2), head_dim);
   TVM_FFI_ICHECK_EQ(v_fp4_t.size(3), seq_len / 2);
 
   TVM_FFI_ICHECK_EQ(q_scale.size(0), batch);
-  TVM_FFI_ICHECK_EQ(q_scale.size(1), num_heads);
+  TVM_FFI_ICHECK_EQ(q_scale.size(1), num_qo_heads);
   TVM_FFI_ICHECK_EQ(q_scale.size(2), seq_len);
   TVM_FFI_ICHECK_EQ(q_scale.size(3), head_dim / 16);
   TVM_FFI_ICHECK_EQ(k_scale.size(0), batch);
-  TVM_FFI_ICHECK_EQ(k_scale.size(1), num_heads);
+  TVM_FFI_ICHECK_EQ(k_scale.size(1), num_kv_heads);
   TVM_FFI_ICHECK_EQ(k_scale.size(2), seq_len);
   TVM_FFI_ICHECK_EQ(k_scale.size(3), head_dim / 16);
   TVM_FFI_ICHECK_EQ(v_scale_t.size(0), batch);
-  TVM_FFI_ICHECK_EQ(v_scale_t.size(1), num_heads);
+  TVM_FFI_ICHECK_EQ(v_scale_t.size(1), num_kv_heads);
   TVM_FFI_ICHECK_EQ(v_scale_t.size(2), head_dim);
   TVM_FFI_ICHECK_EQ(v_scale_t.size(3), seq_len / 16);
 
@@ -282,17 +289,17 @@ void fwd(TensorView q_fp4, TensorView k_fp4, TensorView v_fp4_t, TensorView q_sc
   // layout addresses the tensor this way and broadcasts each row across
   // the rows of the corresponding Q tile.
   TVM_FFI_ICHECK_EQ(qk_correction.size(0), batch);
-  TVM_FFI_ICHECK_EQ(qk_correction.size(1), num_heads);
+  TVM_FFI_ICHECK_EQ(qk_correction.size(1), num_qo_heads);
   TVM_FFI_ICHECK_EQ(qk_correction.size(2), per_block_mean ? seq_len / 128 : 1);
   TVM_FFI_ICHECK_EQ(qk_correction.size(3), seq_len);
 
   TVM_FFI_ICHECK_EQ(out.size(0), batch);
-  TVM_FFI_ICHECK_EQ(out.size(1), num_heads);
+  TVM_FFI_ICHECK_EQ(out.size(1), num_qo_heads);
   TVM_FFI_ICHECK_EQ(out.size(2), seq_len);
   TVM_FFI_ICHECK_EQ(out.size(3), head_dim);
   if (maybe_lse.has_value()) {
     TVM_FFI_ICHECK_EQ(maybe_lse.value().size(0), batch);
-    TVM_FFI_ICHECK_EQ(maybe_lse.value().size(1), num_heads);
+    TVM_FFI_ICHECK_EQ(maybe_lse.value().size(1), num_qo_heads);
     TVM_FFI_ICHECK_EQ(maybe_lse.value().size(2), seq_len);
   }
 

--- a/flashinfer/nvfp4_attention_sm120.py
+++ b/flashinfer/nvfp4_attention_sm120.py
@@ -83,13 +83,13 @@ def _preprocess_qkv(
             )
         if tensor.ndim != 4:
             raise ValueError(
-                f"{name} must have shape [batch, num_heads, seq_len, head_dim], "
+                f"{name} must have shape [batch, heads, seq_len, head_dim], "
                 f"got shape={tuple(tensor.shape)}"
             )
-    if q.shape != k.shape or q.shape != v.shape:
+    if k.shape != v.shape:
         raise ValueError(
-            "q, k, and v must have the same shape, "
-            f"got q={tuple(q.shape)}, k={tuple(k.shape)}, v={tuple(v.shape)}"
+            "k and v must have the same shape, "
+            f"got k={tuple(k.shape)}, v={tuple(v.shape)}"
         )
     if q.dtype != k.dtype or q.dtype != v.dtype:
         raise ValueError(
@@ -100,7 +100,24 @@ def _preprocess_qkv(
     _check_same_device("k", k, "q", q)
     _check_same_device("v", v, "q", q)
 
-    batch, num_heads, seq_len, head_dim = q.shape
+    batch, num_qo_heads, seq_len, head_dim = q.shape
+    if k.shape[0] != batch or k.shape[2] != seq_len or k.shape[3] != head_dim:
+        raise ValueError(
+            "q, k, and v must have the same batch size, sequence length, and "
+            "head dimension, "
+            f"got q={tuple(q.shape)}, k={tuple(k.shape)}, v={tuple(v.shape)}"
+        )
+    num_kv_heads = k.shape[1]
+    if num_qo_heads <= 0 or num_kv_heads <= 0:
+        raise ValueError(
+            "num_qo_heads and num_kv_heads must be positive, "
+            f"got {num_qo_heads} and {num_kv_heads}"
+        )
+    if num_qo_heads < num_kv_heads or num_qo_heads % num_kv_heads != 0:
+        raise ValueError(
+            "num_qo_heads must be greater than or equal to and divisible by "
+            f"num_kv_heads, got {num_qo_heads} and {num_kv_heads}"
+        )
     if head_dim not in _SUPPORTED_HEAD_DIMS:
         raise ValueError(f"head_dim must be 64 or 128, got {head_dim}")
 
@@ -110,11 +127,17 @@ def _preprocess_qkv(
 
     if per_block_mean:
         num_groups = seq_len // _TOKEN_BLOCK_SIZE
-        q_grouped = q.reshape(batch, num_heads, num_groups, _TOKEN_BLOCK_SIZE, head_dim)
+        q_grouped = q.reshape(
+            batch,
+            num_qo_heads,
+            num_groups,
+            _TOKEN_BLOCK_SIZE,
+            head_dim,
+        )
         qm = q_grouped.mean(dim=3)
         q = (
             (q_grouped - qm.unsqueeze(3))
-            .reshape(batch, num_heads, seq_len, head_dim)
+            .reshape(batch, num_qo_heads, seq_len, head_dim)
             .contiguous()
         )
     else:
@@ -127,10 +150,21 @@ def _preprocess_qkv(
     # broadcasts each row across the 128 rows of the Q tile in smem.
     # Multiply in fp32: a float16 matmul output would overflow at 65504
     # even though the accumulation itself runs in fp32.
-    qk_correction = torch.matmul(
-        qm.to(torch.float32), k.transpose(-2, -1).to(torch.float32)
+    num_q_groups = qm.shape[2]
+    qm_grouped = qm.reshape(
+        batch,
+        num_kv_heads,
+        (num_qo_heads // num_kv_heads) * num_q_groups,
+        head_dim,
     )
-    qk_correction = qk_correction.contiguous()
+    qk_correction = (
+        torch.matmul(
+            qm_grouped.to(torch.float32),
+            k.transpose(-2, -1).to(torch.float32),
+        )
+        .reshape(batch, num_qo_heads, num_q_groups, seq_len)
+        .contiguous()
+    )
     return q.contiguous(), k.contiguous(), v.contiguous(), qk_correction
 
 
@@ -152,9 +186,12 @@ def nvfp4_attention_sm120_quantize_qkv(
 ]:
     r"""Preprocess and quantize dense Q/K/V tensors for SM120 NVFP4 attention.
 
-    The input layout is ``[batch, num_heads, seq_len, head_dim]``. Inputs must be
-    contiguous CUDA tensors with the same shape, dtype, and device. The sequence
-    dimension is padded to a multiple of 128 before Q/K/V are quantized.
+    The input layout is ``[batch, num_qo_heads, seq_len, head_dim]`` for Q and
+    ``[batch, num_kv_heads, seq_len, head_dim]`` for K/V. Inputs must be
+    contiguous CUDA tensors with the same batch size, sequence length, head
+    dimension, dtype, and device. ``num_qo_heads`` must be greater than or equal
+    to and divisible by ``num_kv_heads``. The sequence dimension is padded to a
+    multiple of 128 before Q/K/V are quantized.
 
     Parameters
     ----------
@@ -169,27 +206,42 @@ def nvfp4_attention_sm120_quantize_qkv(
     Tuple[torch.Tensor, ...]
         ``q_fp4``, ``k_fp4``, transposed ``v_fp4_t``, scale tensors
         ``q_scale``, ``k_scale``, ``v_scale_t``, and the compact FP32 QK
-        correction with shape ``[batch, num_heads, seq_len / 128, seq_len]``
-        (``[batch, num_heads, 1, seq_len]`` when ``per_block_mean=False``).
+        correction with shape
+        ``[batch, num_qo_heads, seq_len / 128, seq_len]``
+        (``[batch, num_qo_heads, 1, seq_len]`` when
+        ``per_block_mean=False``).
     """
     q_proc, k_proc, v_proc, qk_correction = _preprocess_qkv(q, k, v, per_block_mean)
-    batch, num_heads, seq_len, head_dim = q_proc.shape
+    batch, num_qo_heads, seq_len, head_dim = q_proc.shape
+    num_kv_heads = k_proc.shape[1]
 
     q_fp4 = torch.empty(
-        (batch, num_heads, seq_len, head_dim // 2), device=q.device, dtype=torch.uint8
+        (batch, num_qo_heads, seq_len, head_dim // 2),
+        device=q.device,
+        dtype=torch.uint8,
     )
-    k_fp4 = torch.empty_like(q_fp4)
+    k_fp4 = torch.empty(
+        (batch, num_kv_heads, seq_len, head_dim // 2),
+        device=q.device,
+        dtype=torch.uint8,
+    )
     v_fp4_t = torch.empty(
-        (batch, num_heads, head_dim, seq_len // 2), device=q.device, dtype=torch.uint8
+        (batch, num_kv_heads, head_dim, seq_len // 2),
+        device=q.device,
+        dtype=torch.uint8,
     )
     q_scale = torch.empty(
-        (batch, num_heads, seq_len, head_dim // 16),
+        (batch, num_qo_heads, seq_len, head_dim // 16),
         device=q.device,
         dtype=torch.float8_e4m3fn,
     )
-    k_scale = torch.empty_like(q_scale)
+    k_scale = torch.empty(
+        (batch, num_kv_heads, seq_len, head_dim // 16),
+        device=q.device,
+        dtype=torch.float8_e4m3fn,
+    )
     v_scale_t = torch.empty(
-        (batch, num_heads, head_dim, seq_len // 16),
+        (batch, num_kv_heads, head_dim, seq_len // 16),
         device=q.device,
         dtype=torch.float8_e4m3fn,
     )
@@ -211,7 +263,7 @@ def _check_inputs(
     v_scale_t: torch.Tensor,
     qk_correction: torch.Tensor,
     per_block_mean: bool,
-) -> Tuple[int, int, int, int]:
+) -> Tuple[int, int, int, int, int]:
     for name, tensor in (
         ("q_fp4", q_fp4),
         ("k_fp4", k_fp4),
@@ -248,14 +300,36 @@ def _check_inputs(
 
     if q_fp4.ndim != 4:
         raise ValueError(
-            "q_fp4 must have shape [batch, num_heads, seq_len, head_dim / 2]"
+            "q_fp4 must have shape [batch, num_qo_heads, seq_len, head_dim / 2]"
         )
-    if k_fp4.shape != q_fp4.shape:
+    if k_fp4.ndim != 4:
         raise ValueError(
-            f"k_fp4 shape {tuple(k_fp4.shape)} must match q_fp4 {tuple(q_fp4.shape)}"
+            "k_fp4 must have shape [batch, num_kv_heads, seq_len, head_dim / 2]"
         )
 
-    batch, num_heads, seq_len, packed_head_dim = q_fp4.shape
+    batch, num_qo_heads, seq_len, packed_head_dim = q_fp4.shape
+    kv_batch, num_kv_heads, kv_seq_len, kv_packed_head_dim = k_fp4.shape
+    if (
+        kv_batch != batch
+        or kv_seq_len != seq_len
+        or kv_packed_head_dim != packed_head_dim
+    ):
+        raise ValueError(
+            "q_fp4 and k_fp4 must have the same batch size, sequence length, "
+            "and packed head dimension, "
+            f"got q_fp4={tuple(q_fp4.shape)} and k_fp4={tuple(k_fp4.shape)}"
+        )
+    if num_qo_heads <= 0 or num_kv_heads <= 0:
+        raise ValueError(
+            "num_qo_heads and num_kv_heads must be positive, "
+            f"got {num_qo_heads} and {num_kv_heads}"
+        )
+    if num_qo_heads < num_kv_heads or num_qo_heads % num_kv_heads != 0:
+        raise ValueError(
+            "num_qo_heads must be greater than or equal to and divisible by "
+            f"num_kv_heads, got {num_qo_heads} and {num_kv_heads}"
+        )
+
     head_dim = packed_head_dim * 2
     if head_dim not in _SUPPORTED_HEAD_DIMS:
         raise ValueError(f"head_dim must be 64 or 128, got {head_dim}")
@@ -264,21 +338,22 @@ def _check_inputs(
     if head_dim % 16 != 0:
         raise ValueError(f"head_dim must be divisible by 16, got {head_dim}")
 
-    expected_v = (batch, num_heads, head_dim, seq_len // 2)
+    expected_v = (batch, num_kv_heads, head_dim, seq_len // 2)
     if tuple(v_fp4_t.shape) != expected_v:
         raise ValueError(f"v_fp4_t shape {tuple(v_fp4_t.shape)} must be {expected_v}")
 
-    expected_sf_qk = (batch, num_heads, seq_len, head_dim // 16)
-    if tuple(q_scale.shape) != expected_sf_qk:
+    expected_q_scale = (batch, num_qo_heads, seq_len, head_dim // 16)
+    if tuple(q_scale.shape) != expected_q_scale:
         raise ValueError(
-            f"q_scale shape {tuple(q_scale.shape)} must be {expected_sf_qk}"
+            f"q_scale shape {tuple(q_scale.shape)} must be {expected_q_scale}"
         )
-    if tuple(k_scale.shape) != expected_sf_qk:
+    expected_k_scale = (batch, num_kv_heads, seq_len, head_dim // 16)
+    if tuple(k_scale.shape) != expected_k_scale:
         raise ValueError(
-            f"k_scale shape {tuple(k_scale.shape)} must be {expected_sf_qk}"
+            f"k_scale shape {tuple(k_scale.shape)} must be {expected_k_scale}"
         )
 
-    expected_v_scale = (batch, num_heads, head_dim, seq_len // 16)
+    expected_v_scale = (batch, num_kv_heads, head_dim, seq_len // 16)
     if tuple(v_scale_t.shape) != expected_v_scale:
         raise ValueError(
             f"v_scale_t shape {tuple(v_scale_t.shape)} must be {expected_v_scale}"
@@ -287,10 +362,10 @@ def _check_inputs(
     if (
         qk_correction.ndim != 4
         or qk_correction.shape[0] != batch
-        or qk_correction.shape[1] != num_heads
+        or qk_correction.shape[1] != num_qo_heads
     ):
         raise ValueError(
-            "qk_correction must have shape [batch, num_heads, seq_len_s, seq_len]"
+            "qk_correction must have shape [batch, num_qo_heads, seq_len_s, seq_len]"
         )
     expected_delta_groups = seq_len // _TOKEN_BLOCK_SIZE if per_block_mean else 1
     if qk_correction.shape[2] != expected_delta_groups:
@@ -303,7 +378,7 @@ def _check_inputs(
             f"qk_correction last dimension must be {seq_len}, got {qk_correction.shape[-1]}"
         )
 
-    return batch, num_heads, seq_len, head_dim
+    return batch, num_qo_heads, num_kv_heads, seq_len, head_dim
 
 
 @supported_compute_capability([120, 121])
@@ -328,9 +403,10 @@ def nvfp4_attention_sm120_fwd(
     r"""Run SM120 NVFP4 attention on pre-quantized Q/K/V tensors.
 
     The packed tensors should be produced by
-    :func:`nvfp4_attention_sm120_quantize_qkv`. ``q_fp4`` and ``k_fp4`` use layout
-    ``[batch, num_heads, seq_len, head_dim / 2]``; ``v_fp4_t`` and ``v_scale_t`` are
-    stored transposed as ``[batch, num_heads, head_dim, packed_seq_len]``.
+    :func:`nvfp4_attention_sm120_quantize_qkv`. ``q_fp4`` uses layout
+    ``[batch, num_qo_heads, seq_len, head_dim / 2]`` and ``k_fp4`` uses
+    ``[batch, num_kv_heads, seq_len, head_dim / 2]``. ``v_fp4_t`` and
+    ``v_scale_t`` are stored transposed with ``num_kv_heads``.
 
     Parameters
     ----------
@@ -366,7 +442,7 @@ def nvfp4_attention_sm120_fwd(
         attention output and log-sum-exp tensor.
     """
     per_block_mean = bool(per_block_mean)
-    batch, num_heads, seq_len, head_dim = _check_inputs(
+    batch, num_qo_heads, _, seq_len, head_dim = _check_inputs(
         q_fp4,
         k_fp4,
         v_fp4_t,
@@ -387,16 +463,17 @@ def nvfp4_attention_sm120_fwd(
                 f"out_dtype must be torch.float16 or torch.bfloat16, got {out_dtype}"
             )
         out = torch.empty(
-            (batch, num_heads, seq_len, head_dim),
+            (batch, num_qo_heads, seq_len, head_dim),
             device=q_fp4.device,
             dtype=out_dtype,
         )
     else:
         _check_cuda_contiguous("out", out)
         _check_same_device("out", out, "q_fp4", q_fp4)
-        if tuple(out.shape) != (batch, num_heads, seq_len, head_dim):
+        if tuple(out.shape) != (batch, num_qo_heads, seq_len, head_dim):
             raise ValueError(
-                f"out shape {tuple(out.shape)} must be {(batch, num_heads, seq_len, head_dim)}"
+                f"out shape {tuple(out.shape)} must be "
+                f"{(batch, num_qo_heads, seq_len, head_dim)}"
             )
         if out.dtype not in _SUPPORTED_OUT_DTYPES:
             raise ValueError(
@@ -408,16 +485,17 @@ def nvfp4_attention_sm120_fwd(
     if return_lse:
         if lse is None:
             lse = torch.empty(
-                (batch, num_heads, seq_len),
+                (batch, num_qo_heads, seq_len),
                 device=q_fp4.device,
                 dtype=torch.float32,
             )
         else:
             _check_cuda_contiguous("lse", lse)
             _check_same_device("lse", lse, "q_fp4", q_fp4)
-            if tuple(lse.shape) != (batch, num_heads, seq_len):
+            if tuple(lse.shape) != (batch, num_qo_heads, seq_len):
                 raise ValueError(
-                    f"lse shape {tuple(lse.shape)} must be {(batch, num_heads, seq_len)}"
+                    f"lse shape {tuple(lse.shape)} must be "
+                    f"{(batch, num_qo_heads, seq_len)}"
                 )
             if lse.dtype != torch.float32:
                 raise ValueError(f"lse must have dtype torch.float32, got {lse.dtype}")

--- a/flashinfer/nvfp4_attention_sm120.py
+++ b/flashinfer/nvfp4_attention_sm120.py
@@ -100,11 +100,10 @@ def _preprocess_qkv(
     _check_same_device("k", k, "q", q)
     _check_same_device("v", v, "q", q)
 
-    batch, num_qo_heads, seq_len, head_dim = q.shape
-    if k.shape[0] != batch or k.shape[2] != seq_len or k.shape[3] != head_dim:
+    batch, num_qo_heads, _, head_dim = q.shape
+    if k.shape[0] != batch or k.shape[3] != head_dim:
         raise ValueError(
-            "q, k, and v must have the same batch size, sequence length, and "
-            "head dimension, "
+            "q, k, and v must have the same batch size and head dimension, "
             f"got q={tuple(q.shape)}, k={tuple(k.shape)}, v={tuple(v.shape)}"
         )
     num_kv_heads = k.shape[1]
@@ -123,10 +122,11 @@ def _preprocess_qkv(
 
     k = k - k.mean(dim=-2, keepdim=True)
     q, k, v = map(_pad_seq_len_to_128, (q, k, v))
-    seq_len = q.shape[2]
+    seq_len_q = q.shape[2]
+    seq_len_k = k.shape[2]
 
     if per_block_mean:
-        num_groups = seq_len // _TOKEN_BLOCK_SIZE
+        num_groups = seq_len_q // _TOKEN_BLOCK_SIZE
         q_grouped = q.reshape(
             batch,
             num_qo_heads,
@@ -137,7 +137,7 @@ def _preprocess_qkv(
         qm = q_grouped.mean(dim=3)
         q = (
             (q_grouped - qm.unsqueeze(3))
-            .reshape(batch, num_qo_heads, seq_len, head_dim)
+            .reshape(batch, num_qo_heads, seq_len_q, head_dim)
             .contiguous()
         )
     else:
@@ -145,7 +145,7 @@ def _preprocess_qkv(
         q = (q - qm).contiguous()
 
     # Compact layout: one correction row per 128-token Q block ([B, H,
-    # seq_len / 128, seq_len]), or a single row when per_block_mean=False.
+    # M_pad / 128, N_pad]), or a single row when per_block_mean=False.
     # The kernel's TMA descriptor addresses the tensor this way and
     # broadcasts each row across the 128 rows of the Q tile in smem.
     # Multiply in fp32: a float16 matmul output would overflow at 65504
@@ -162,7 +162,7 @@ def _preprocess_qkv(
             qm_grouped.to(torch.float32),
             k.transpose(-2, -1).to(torch.float32),
         )
-        .reshape(batch, num_qo_heads, num_q_groups, seq_len)
+        .reshape(batch, num_qo_heads, num_q_groups, seq_len_k)
         .contiguous()
     )
     return q.contiguous(), k.contiguous(), v.contiguous(), qk_correction
@@ -186,12 +186,12 @@ def nvfp4_attention_sm120_quantize_qkv(
 ]:
     r"""Preprocess and quantize dense Q/K/V tensors for SM120 NVFP4 attention.
 
-    The input layout is ``[batch, num_qo_heads, seq_len, head_dim]`` for Q and
-    ``[batch, num_kv_heads, seq_len, head_dim]`` for K/V. Inputs must be
-    contiguous CUDA tensors with the same batch size, sequence length, head
-    dimension, dtype, and device. ``num_qo_heads`` must be greater than or equal
-    to and divisible by ``num_kv_heads``. The sequence dimension is padded to a
-    multiple of 128 before Q/K/V are quantized.
+    The input layout is ``[batch, num_qo_heads, M, head_dim]`` for Q and
+    ``[batch, num_kv_heads, N, head_dim]`` for K/V. Inputs must be contiguous
+    CUDA tensors with the same batch size, head dimension, dtype, and device.
+    ``num_qo_heads`` must be greater than or equal to and divisible by
+    ``num_kv_heads``. Q is padded independently to ``M_pad = round_up(M, 128)``;
+    K/V are padded to ``N_pad = round_up(N, 128)``.
 
     Parameters
     ----------
@@ -207,41 +207,42 @@ def nvfp4_attention_sm120_quantize_qkv(
         ``q_fp4``, ``k_fp4``, transposed ``v_fp4_t``, scale tensors
         ``q_scale``, ``k_scale``, ``v_scale_t``, and the compact FP32 QK
         correction with shape
-        ``[batch, num_qo_heads, seq_len / 128, seq_len]``
-        (``[batch, num_qo_heads, 1, seq_len]`` when
+        ``[batch, num_qo_heads, M_pad / 128, N_pad]``
+        (``[batch, num_qo_heads, 1, N_pad]`` when
         ``per_block_mean=False``).
     """
     q_proc, k_proc, v_proc, qk_correction = _preprocess_qkv(q, k, v, per_block_mean)
-    batch, num_qo_heads, seq_len, head_dim = q_proc.shape
+    batch, num_qo_heads, seq_len_q, head_dim = q_proc.shape
     num_kv_heads = k_proc.shape[1]
+    seq_len_k = k_proc.shape[2]
 
     q_fp4 = torch.empty(
-        (batch, num_qo_heads, seq_len, head_dim // 2),
+        (batch, num_qo_heads, seq_len_q, head_dim // 2),
         device=q.device,
         dtype=torch.uint8,
     )
     k_fp4 = torch.empty(
-        (batch, num_kv_heads, seq_len, head_dim // 2),
+        (batch, num_kv_heads, seq_len_k, head_dim // 2),
         device=q.device,
         dtype=torch.uint8,
     )
     v_fp4_t = torch.empty(
-        (batch, num_kv_heads, head_dim, seq_len // 2),
+        (batch, num_kv_heads, head_dim, seq_len_k // 2),
         device=q.device,
         dtype=torch.uint8,
     )
     q_scale = torch.empty(
-        (batch, num_qo_heads, seq_len, head_dim // 16),
+        (batch, num_qo_heads, seq_len_q, head_dim // 16),
         device=q.device,
         dtype=torch.float8_e4m3fn,
     )
     k_scale = torch.empty(
-        (batch, num_kv_heads, seq_len, head_dim // 16),
+        (batch, num_kv_heads, seq_len_k, head_dim // 16),
         device=q.device,
         dtype=torch.float8_e4m3fn,
     )
     v_scale_t = torch.empty(
-        (batch, num_kv_heads, head_dim, seq_len // 16),
+        (batch, num_kv_heads, head_dim, seq_len_k // 16),
         device=q.device,
         dtype=torch.float8_e4m3fn,
     )
@@ -263,7 +264,7 @@ def _check_inputs(
     v_scale_t: torch.Tensor,
     qk_correction: torch.Tensor,
     per_block_mean: bool,
-) -> Tuple[int, int, int, int, int]:
+) -> Tuple[int, int, int, int, int, int]:
     for name, tensor in (
         ("q_fp4", q_fp4),
         ("k_fp4", k_fp4),
@@ -307,16 +308,12 @@ def _check_inputs(
             "k_fp4 must have shape [batch, num_kv_heads, seq_len, head_dim / 2]"
         )
 
-    batch, num_qo_heads, seq_len, packed_head_dim = q_fp4.shape
-    kv_batch, num_kv_heads, kv_seq_len, kv_packed_head_dim = k_fp4.shape
-    if (
-        kv_batch != batch
-        or kv_seq_len != seq_len
-        or kv_packed_head_dim != packed_head_dim
-    ):
+    batch, num_qo_heads, seq_len_q, packed_head_dim = q_fp4.shape
+    kv_batch, num_kv_heads, seq_len_k, kv_packed_head_dim = k_fp4.shape
+    if kv_batch != batch or kv_packed_head_dim != packed_head_dim:
         raise ValueError(
-            "q_fp4 and k_fp4 must have the same batch size, sequence length, "
-            "and packed head dimension, "
+            "q_fp4 and k_fp4 must have the same batch size and packed head "
+            "dimension, "
             f"got q_fp4={tuple(q_fp4.shape)} and k_fp4={tuple(k_fp4.shape)}"
         )
     if num_qo_heads <= 0 or num_kv_heads <= 0:
@@ -333,27 +330,33 @@ def _check_inputs(
     head_dim = packed_head_dim * 2
     if head_dim not in _SUPPORTED_HEAD_DIMS:
         raise ValueError(f"head_dim must be 64 or 128, got {head_dim}")
-    if seq_len % _TOKEN_BLOCK_SIZE != 0:
-        raise ValueError(f"seq_len must be padded to a multiple of 128, got {seq_len}")
+    if seq_len_q % _TOKEN_BLOCK_SIZE != 0:
+        raise ValueError(
+            f"Q sequence length must be padded to a multiple of 128, got {seq_len_q}"
+        )
+    if seq_len_k % _TOKEN_BLOCK_SIZE != 0:
+        raise ValueError(
+            f"K/V sequence length must be padded to a multiple of 128, got {seq_len_k}"
+        )
     if head_dim % 16 != 0:
         raise ValueError(f"head_dim must be divisible by 16, got {head_dim}")
 
-    expected_v = (batch, num_kv_heads, head_dim, seq_len // 2)
+    expected_v = (batch, num_kv_heads, head_dim, seq_len_k // 2)
     if tuple(v_fp4_t.shape) != expected_v:
         raise ValueError(f"v_fp4_t shape {tuple(v_fp4_t.shape)} must be {expected_v}")
 
-    expected_q_scale = (batch, num_qo_heads, seq_len, head_dim // 16)
+    expected_q_scale = (batch, num_qo_heads, seq_len_q, head_dim // 16)
     if tuple(q_scale.shape) != expected_q_scale:
         raise ValueError(
             f"q_scale shape {tuple(q_scale.shape)} must be {expected_q_scale}"
         )
-    expected_k_scale = (batch, num_kv_heads, seq_len, head_dim // 16)
+    expected_k_scale = (batch, num_kv_heads, seq_len_k, head_dim // 16)
     if tuple(k_scale.shape) != expected_k_scale:
         raise ValueError(
             f"k_scale shape {tuple(k_scale.shape)} must be {expected_k_scale}"
         )
 
-    expected_v_scale = (batch, num_kv_heads, head_dim, seq_len // 16)
+    expected_v_scale = (batch, num_kv_heads, head_dim, seq_len_k // 16)
     if tuple(v_scale_t.shape) != expected_v_scale:
         raise ValueError(
             f"v_scale_t shape {tuple(v_scale_t.shape)} must be {expected_v_scale}"
@@ -365,20 +368,22 @@ def _check_inputs(
         or qk_correction.shape[1] != num_qo_heads
     ):
         raise ValueError(
-            "qk_correction must have shape [batch, num_qo_heads, seq_len_s, seq_len]"
+            "qk_correction must have shape "
+            "[batch, num_qo_heads, q_block_count, padded_k_len]"
         )
-    expected_delta_groups = seq_len // _TOKEN_BLOCK_SIZE if per_block_mean else 1
+    expected_delta_groups = seq_len_q // _TOKEN_BLOCK_SIZE if per_block_mean else 1
     if qk_correction.shape[2] != expected_delta_groups:
         raise ValueError(
             f"qk_correction must have one row per 128-token block "
             f"({expected_delta_groups}), got {qk_correction.shape[2]}"
         )
-    if qk_correction.shape[-1] != seq_len:
+    if qk_correction.shape[-1] != seq_len_k:
         raise ValueError(
-            f"qk_correction last dimension must be {seq_len}, got {qk_correction.shape[-1]}"
+            f"qk_correction last dimension must be {seq_len_k}, "
+            f"got {qk_correction.shape[-1]}"
         )
 
-    return batch, num_qo_heads, num_kv_heads, seq_len, head_dim
+    return batch, num_qo_heads, num_kv_heads, seq_len_q, seq_len_k, head_dim
 
 
 @supported_compute_capability([120, 121])
@@ -399,13 +404,14 @@ def nvfp4_attention_sm120_fwd(
     out_dtype: torch.dtype = torch.bfloat16,
     softmax_scale: Optional[float] = None,
     return_lse: bool = True,
+    unpadded_k_len: Optional[int] = None,
 ) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
     r"""Run SM120 NVFP4 attention on pre-quantized Q/K/V tensors.
 
     The packed tensors should be produced by
     :func:`nvfp4_attention_sm120_quantize_qkv`. ``q_fp4`` uses layout
-    ``[batch, num_qo_heads, seq_len, head_dim / 2]`` and ``k_fp4`` uses
-    ``[batch, num_kv_heads, seq_len, head_dim / 2]``. ``v_fp4_t`` and
+    ``[batch, num_qo_heads, M_pad, head_dim / 2]`` and ``k_fp4`` uses
+    ``[batch, num_kv_heads, N_pad, head_dim / 2]``. ``v_fp4_t`` and
     ``v_scale_t`` are stored transposed with ``num_kv_heads``.
 
     Parameters
@@ -435,6 +441,10 @@ def nvfp4_attention_sm120_fwd(
         Whether to compute and return the log-sum-exp tensor. Defaults to
         ``True`` for compatibility with the legacy ``(out, lse)`` return
         contract. Set to ``False`` to return only the attention output.
+    unpadded_k_len : Optional[int], optional
+        Logical K/V sequence length. Values at or beyond this position are
+        masked before softmax. Defaults to the physical ``N_pad`` extent for
+        backward compatibility.
 
     Returns
     -------
@@ -443,7 +453,7 @@ def nvfp4_attention_sm120_fwd(
         attention output and log-sum-exp tensor.
     """
     per_block_mean = bool(per_block_mean)
-    batch, num_qo_heads, _, seq_len, head_dim = _check_inputs(
+    batch, num_qo_heads, _, seq_len_q, seq_len_k, head_dim = _check_inputs(
         q_fp4,
         k_fp4,
         v_fp4_t,
@@ -453,6 +463,17 @@ def nvfp4_attention_sm120_fwd(
         qk_correction,
         per_block_mean,
     )
+    if unpadded_k_len is None:
+        unpadded_k_len = seq_len_k
+    elif isinstance(unpadded_k_len, bool) or not isinstance(unpadded_k_len, int):
+        raise ValueError(
+            f"unpadded_k_len must be an integer or None, got {unpadded_k_len!r}"
+        )
+    if not 0 < unpadded_k_len <= seq_len_k:
+        raise ValueError(
+            f"unpadded_k_len must satisfy 0 < unpadded_k_len <= {seq_len_k}, "
+            f"got {unpadded_k_len}"
+        )
     if sm_scale is not None and softmax_scale is not None:
         raise ValueError("Specify only one of sm_scale or softmax_scale")
     if sm_scale is None:
@@ -464,17 +485,17 @@ def nvfp4_attention_sm120_fwd(
                 f"out_dtype must be torch.float16 or torch.bfloat16, got {out_dtype}"
             )
         out = torch.empty(
-            (batch, num_qo_heads, seq_len, head_dim),
+            (batch, num_qo_heads, seq_len_q, head_dim),
             device=q_fp4.device,
             dtype=out_dtype,
         )
     else:
         _check_cuda_contiguous("out", out)
         _check_same_device("out", out, "q_fp4", q_fp4)
-        if tuple(out.shape) != (batch, num_qo_heads, seq_len, head_dim):
+        if tuple(out.shape) != (batch, num_qo_heads, seq_len_q, head_dim):
             raise ValueError(
                 f"out shape {tuple(out.shape)} must be "
-                f"{(batch, num_qo_heads, seq_len, head_dim)}"
+                f"{(batch, num_qo_heads, seq_len_q, head_dim)}"
             )
         if out.dtype not in _SUPPORTED_OUT_DTYPES:
             raise ValueError(
@@ -486,17 +507,17 @@ def nvfp4_attention_sm120_fwd(
     if return_lse:
         if lse is None:
             lse = torch.empty(
-                (batch, num_qo_heads, seq_len),
+                (batch, num_qo_heads, seq_len_q),
                 device=q_fp4.device,
                 dtype=torch.float32,
             )
         else:
             _check_cuda_contiguous("lse", lse)
             _check_same_device("lse", lse, "q_fp4", q_fp4)
-            if tuple(lse.shape) != (batch, num_qo_heads, seq_len):
+            if tuple(lse.shape) != (batch, num_qo_heads, seq_len_q):
                 raise ValueError(
                     f"lse shape {tuple(lse.shape)} must be "
-                    f"{(batch, num_qo_heads, seq_len)}"
+                    f"{(batch, num_qo_heads, seq_len_q)}"
                 )
             if lse.dtype != torch.float32:
                 raise ValueError(f"lse must have dtype torch.float32, got {lse.dtype}")
@@ -514,5 +535,6 @@ def nvfp4_attention_sm120_fwd(
         float(sm_scale),
         bool(causal),
         per_block_mean,
+        unpadded_k_len,
     )
     return (out, lse) if return_lse else out

--- a/flashinfer/nvfp4_attention_sm120.py
+++ b/flashinfer/nvfp4_attention_sm120.py
@@ -398,7 +398,7 @@ def nvfp4_attention_sm120_fwd(
     lse: Optional[torch.Tensor] = None,
     out_dtype: torch.dtype = torch.bfloat16,
     softmax_scale: Optional[float] = None,
-    return_lse: bool = False,
+    return_lse: bool = True,
 ) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
     r"""Run SM120 NVFP4 attention on pre-quantized Q/K/V tensors.
 
@@ -433,7 +433,8 @@ def nvfp4_attention_sm120_fwd(
         Deprecated alias for ``sm_scale``.
     return_lse : bool, optional
         Whether to compute and return the log-sum-exp tensor. Defaults to
-        ``False``.
+        ``True`` for compatibility with the legacy ``(out, lse)`` return
+        contract. Set to ``False`` to return only the attention output.
 
     Returns
     -------

--- a/flashinfer/nvfp4_attention_sm120.py
+++ b/flashinfer/nvfp4_attention_sm120.py
@@ -15,7 +15,7 @@ limitations under the License.
 """
 
 import functools
-from typing import Optional, Tuple
+from typing import Optional, Tuple, Union
 
 import torch
 
@@ -323,7 +323,8 @@ def nvfp4_attention_sm120_fwd(
     lse: Optional[torch.Tensor] = None,
     out_dtype: torch.dtype = torch.bfloat16,
     softmax_scale: Optional[float] = None,
-) -> Tuple[torch.Tensor, torch.Tensor]:
+    return_lse: bool = False,
+) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
     r"""Run SM120 NVFP4 attention on pre-quantized Q/K/V tensors.
 
     The packed tensors should be produced by
@@ -354,11 +355,15 @@ def nvfp4_attention_sm120_fwd(
         Output dtype used when ``out`` is not provided.
     softmax_scale : Optional[float], optional
         Deprecated alias for ``sm_scale``.
+    return_lse : bool, optional
+        Whether to compute and return the log-sum-exp tensor. Defaults to
+        ``False``.
 
     Returns
     -------
-    Tuple[torch.Tensor, torch.Tensor]
-        Attention output and log-sum-exp tensor.
+    Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]
+        The attention output when ``return_lse`` is ``False``; otherwise, the
+        attention output and log-sum-exp tensor.
     """
     per_block_mean = bool(per_block_mean)
     batch, num_heads, seq_len, head_dim = _check_inputs(
@@ -398,19 +403,24 @@ def nvfp4_attention_sm120_fwd(
                 f"out must have dtype torch.float16 or torch.bfloat16, got {out.dtype}"
             )
 
-    if lse is None:
-        lse = torch.empty(
-            (batch, num_heads, seq_len), device=q_fp4.device, dtype=torch.float32
-        )
-    else:
-        _check_cuda_contiguous("lse", lse)
-        _check_same_device("lse", lse, "q_fp4", q_fp4)
-        if tuple(lse.shape) != (batch, num_heads, seq_len):
-            raise ValueError(
-                f"lse shape {tuple(lse.shape)} must be {(batch, num_heads, seq_len)}"
+    if not return_lse and lse is not None:
+        raise ValueError("lse can only be provided when return_lse=True")
+    if return_lse:
+        if lse is None:
+            lse = torch.empty(
+                (batch, num_heads, seq_len),
+                device=q_fp4.device,
+                dtype=torch.float32,
             )
-        if lse.dtype != torch.float32:
-            raise ValueError(f"lse must have dtype torch.float32, got {lse.dtype}")
+        else:
+            _check_cuda_contiguous("lse", lse)
+            _check_same_device("lse", lse, "q_fp4", q_fp4)
+            if tuple(lse.shape) != (batch, num_heads, seq_len):
+                raise ValueError(
+                    f"lse shape {tuple(lse.shape)} must be {(batch, num_heads, seq_len)}"
+                )
+            if lse.dtype != torch.float32:
+                raise ValueError(f"lse must have dtype torch.float32, got {lse.dtype}")
 
     get_nvfp4_attention_sm120_module().fwd(
         q_fp4,
@@ -426,4 +436,4 @@ def nvfp4_attention_sm120_fwd(
         bool(causal),
         per_block_mean,
     )
-    return out, lse
+    return (out, lse) if return_lse else out

--- a/flashinfer/trace/template.py
+++ b/flashinfer/trace/template.py
@@ -434,6 +434,10 @@ class Tensor:
     dtype_from:
         For *outputs*: name of an input ``param`` whose dtype to copy.
         Takes precedence over ``dtype`` when both are set.
+    dtype_from_scalar:
+        For *outputs*: name of an optional dtype-valued scalar to use when the
+        tensor named by ``dtype_from`` is absent. Takes precedence over
+        ``dtype`` but not over ``dtype_from``.
     optional:
         Whether the tensor may be absent.
     description:
@@ -448,6 +452,7 @@ class Tensor:
         tuple_idx: Optional[int] = None,
         dtype: Optional[str] = None,
         dtype_from: Optional[str] = None,
+        dtype_from_scalar: Optional[str] = None,
         optional: bool = False,
         description: str = "",
     ) -> None:
@@ -456,6 +461,7 @@ class Tensor:
         self.tuple_idx = tuple_idx
         self.dtype = dtype
         self.dtype_from = dtype_from
+        self.dtype_from_scalar = dtype_from_scalar
         self.optional = optional
         self.description = description
 
@@ -788,6 +794,11 @@ class TraceTemplate:
                         ref_t = _get_tensor(kwargs, ref_param)
                         if ref_t is not None:
                             dtype = _dtype_str(ref_t.dtype)
+                        elif (
+                            descriptor.dtype_from_scalar is not None
+                            and kwargs.get(descriptor.dtype_from_scalar) is not None
+                        ):
+                            dtype = _dtype_str(kwargs[descriptor.dtype_from_scalar])
                         else:
                             # dtype_from may reference an output param that is
                             # absent when tracing symbolically; fall back to the

--- a/flashinfer/trace/templates/nvfp4_attention_sm120.py
+++ b/flashinfer/trace/templates/nvfp4_attention_sm120.py
@@ -83,10 +83,17 @@ nvfp4_attention_sm120_fwd_trace = TraceTemplate(
         "sm_scale": Scalar("float32"),
         "causal": Scalar("bool"),
         "per_block_mean": Scalar("bool"),
+        "return_lse": Scalar(
+            "bool", optional=True, description="Bool: also compute and return LSE."
+        ),
     },
     outputs={
         "out": Tensor(["batch_size", "num_heads", "seq_len", "head_dim"]),
-        "lse": Tensor(["batch_size", "num_heads", "seq_len"]),
+        "lse": Tensor(
+            ["batch_size", "num_heads", "seq_len"],
+            dtype="float32",
+            optional=True,
+        ),
     },
     tags=["sm120", "nvfp4"],
 )

--- a/flashinfer/trace/templates/nvfp4_attention_sm120.py
+++ b/flashinfer/trace/templates/nvfp4_attention_sm120.py
@@ -157,6 +157,7 @@ nvfp4_attention_sm120_fwd_trace = TraceTemplate(
             param="out",
             dtype="bfloat16",
             dtype_from="out",
+            dtype_from_scalar="out_dtype",
         ),
         "lse": Tensor(
             ["batch_size", "num_qo_heads", "padded_qo_len"],

--- a/flashinfer/trace/templates/nvfp4_attention_sm120.py
+++ b/flashinfer/trace/templates/nvfp4_attention_sm120.py
@@ -21,7 +21,8 @@ nvfp4_attention_sm120_quantize_qkv_trace = TraceTemplate(
     description="Preprocess and quantize dense Q/K/V tensors for the SM120 NVFP4 attention kernel.",
     axes={
         "batch_size": Var(),
-        "num_heads": Var(),
+        "num_qo_heads": Var(),
+        "num_kv_heads": Var(),
         "seq_len": Var(),
         "head_dim": Const(),
         "packed_head_dim": Var(),
@@ -31,25 +32,30 @@ nvfp4_attention_sm120_quantize_qkv_trace = TraceTemplate(
         "correction_seq_len": Var(),
     },
     inputs={
-        "q": Tensor(["batch_size", "num_heads", "seq_len", "head_dim"]),
-        "k": Tensor(["batch_size", "num_heads", "seq_len", "head_dim"]),
-        "v": Tensor(["batch_size", "num_heads", "seq_len", "head_dim"]),
+        "q": Tensor(["batch_size", "num_qo_heads", "seq_len", "head_dim"]),
+        "k": Tensor(["batch_size", "num_kv_heads", "seq_len", "head_dim"]),
+        "v": Tensor(["batch_size", "num_kv_heads", "seq_len", "head_dim"]),
         "per_block_mean": Scalar("bool"),
     },
     outputs={
-        "q_fp4": Tensor(["batch_size", "num_heads", "seq_len", "packed_head_dim"]),
-        "k_fp4": Tensor(["batch_size", "num_heads", "seq_len", "packed_head_dim"]),
-        "v_fp4_t": Tensor(["batch_size", "num_heads", "head_dim", "packed_seq_len"]),
-        "q_scale": Tensor(["batch_size", "num_heads", "seq_len", "scale_head_dim"]),
-        "k_scale": Tensor(["batch_size", "num_heads", "seq_len", "scale_head_dim"]),
-        "v_scale_t": Tensor(["batch_size", "num_heads", "head_dim", "scale_seq_len"]),
+        "q_fp4": Tensor(["batch_size", "num_qo_heads", "seq_len", "packed_head_dim"]),
+        "k_fp4": Tensor(["batch_size", "num_kv_heads", "seq_len", "packed_head_dim"]),
+        "v_fp4_t": Tensor(["batch_size", "num_kv_heads", "head_dim", "packed_seq_len"]),
+        "q_scale": Tensor(["batch_size", "num_qo_heads", "seq_len", "scale_head_dim"]),
+        "k_scale": Tensor(["batch_size", "num_kv_heads", "seq_len", "scale_head_dim"]),
+        "v_scale_t": Tensor(
+            ["batch_size", "num_kv_heads", "head_dim", "scale_seq_len"]
+        ),
         "qk_correction": Tensor(
-            ["batch_size", "num_heads", "correction_seq_len", "seq_len"]
+            ["batch_size", "num_qo_heads", "correction_seq_len", "seq_len"]
         ),
     },
     constraints=[
         "head_dim == 2 * packed_head_dim",
         "head_dim == 16 * scale_head_dim",
+        "num_kv_heads > 0",
+        "num_qo_heads >= num_kv_heads",
+        "num_qo_heads % num_kv_heads == 0",
     ],
     tags=["sm120", "nvfp4"],
 )
@@ -61,7 +67,8 @@ nvfp4_attention_sm120_fwd_trace = TraceTemplate(
     description="Run the SM120 NVFP4 attention forward kernel on pre-quantized Q/K/V tensors.",
     axes={
         "batch_size": Var(),
-        "num_heads": Var(),
+        "num_qo_heads": Var(),
+        "num_kv_heads": Var(),
         "seq_len": Var(),
         "head_dim": Const(),
         "packed_head_dim": Const(),
@@ -71,14 +78,16 @@ nvfp4_attention_sm120_fwd_trace = TraceTemplate(
         "correction_seq_len": Var(),
     },
     inputs={
-        "q_fp4": Tensor(["batch_size", "num_heads", "seq_len", "packed_head_dim"]),
-        "k_fp4": Tensor(["batch_size", "num_heads", "seq_len", "packed_head_dim"]),
-        "v_fp4_t": Tensor(["batch_size", "num_heads", "head_dim", "packed_seq_len"]),
-        "q_scale": Tensor(["batch_size", "num_heads", "seq_len", "scale_head_dim"]),
-        "k_scale": Tensor(["batch_size", "num_heads", "seq_len", "scale_head_dim"]),
-        "v_scale_t": Tensor(["batch_size", "num_heads", "head_dim", "scale_seq_len"]),
+        "q_fp4": Tensor(["batch_size", "num_qo_heads", "seq_len", "packed_head_dim"]),
+        "k_fp4": Tensor(["batch_size", "num_kv_heads", "seq_len", "packed_head_dim"]),
+        "v_fp4_t": Tensor(["batch_size", "num_kv_heads", "head_dim", "packed_seq_len"]),
+        "q_scale": Tensor(["batch_size", "num_qo_heads", "seq_len", "scale_head_dim"]),
+        "k_scale": Tensor(["batch_size", "num_kv_heads", "seq_len", "scale_head_dim"]),
+        "v_scale_t": Tensor(
+            ["batch_size", "num_kv_heads", "head_dim", "scale_seq_len"]
+        ),
         "qk_correction": Tensor(
-            ["batch_size", "num_heads", "correction_seq_len", "seq_len"]
+            ["batch_size", "num_qo_heads", "correction_seq_len", "seq_len"]
         ),
         "sm_scale": Scalar("float32"),
         "causal": Scalar("bool"),
@@ -88,12 +97,17 @@ nvfp4_attention_sm120_fwd_trace = TraceTemplate(
         ),
     },
     outputs={
-        "out": Tensor(["batch_size", "num_heads", "seq_len", "head_dim"]),
+        "out": Tensor(["batch_size", "num_qo_heads", "seq_len", "head_dim"]),
         "lse": Tensor(
-            ["batch_size", "num_heads", "seq_len"],
+            ["batch_size", "num_qo_heads", "seq_len"],
             dtype="float32",
             optional=True,
         ),
     },
+    constraints=[
+        "num_kv_heads > 0",
+        "num_qo_heads >= num_kv_heads",
+        "num_qo_heads % num_kv_heads == 0",
+    ],
     tags=["sm120", "nvfp4"],
 )

--- a/flashinfer/trace/templates/nvfp4_attention_sm120.py
+++ b/flashinfer/trace/templates/nvfp4_attention_sm120.py
@@ -23,36 +23,69 @@ nvfp4_attention_sm120_quantize_qkv_trace = TraceTemplate(
         "batch_size": Var(),
         "num_qo_heads": Var(),
         "num_kv_heads": Var(),
-        "seq_len": Var(),
+        "qo_len": Var(),
+        "kv_len": Var(),
+        "padded_qo_len": Var(),
+        "padded_kv_len": Var(),
         "head_dim": Const(),
         "packed_head_dim": Var(),
         "scale_head_dim": Var(),
-        "packed_seq_len": Var(),
-        "scale_seq_len": Var(),
-        "correction_seq_len": Var(),
+        "packed_kv_len": Var(),
+        "scale_kv_len": Var(),
+        "correction_q_blocks": Var(),
     },
     inputs={
-        "q": Tensor(["batch_size", "num_qo_heads", "seq_len", "head_dim"]),
-        "k": Tensor(["batch_size", "num_kv_heads", "seq_len", "head_dim"]),
-        "v": Tensor(["batch_size", "num_kv_heads", "seq_len", "head_dim"]),
+        "q": Tensor(["batch_size", "num_qo_heads", "qo_len", "head_dim"]),
+        "k": Tensor(["batch_size", "num_kv_heads", "kv_len", "head_dim"]),
+        "v": Tensor(["batch_size", "num_kv_heads", "kv_len", "head_dim"]),
         "per_block_mean": Scalar("bool"),
     },
     outputs={
-        "q_fp4": Tensor(["batch_size", "num_qo_heads", "seq_len", "packed_head_dim"]),
-        "k_fp4": Tensor(["batch_size", "num_kv_heads", "seq_len", "packed_head_dim"]),
-        "v_fp4_t": Tensor(["batch_size", "num_kv_heads", "head_dim", "packed_seq_len"]),
-        "q_scale": Tensor(["batch_size", "num_qo_heads", "seq_len", "scale_head_dim"]),
-        "k_scale": Tensor(["batch_size", "num_kv_heads", "seq_len", "scale_head_dim"]),
+        "q_fp4": Tensor(
+            ["batch_size", "num_qo_heads", "padded_qo_len", "packed_head_dim"],
+            dtype="uint8",
+        ),
+        "k_fp4": Tensor(
+            ["batch_size", "num_kv_heads", "padded_kv_len", "packed_head_dim"],
+            dtype="uint8",
+        ),
+        "v_fp4_t": Tensor(
+            ["batch_size", "num_kv_heads", "head_dim", "packed_kv_len"],
+            dtype="uint8",
+        ),
+        "q_scale": Tensor(
+            ["batch_size", "num_qo_heads", "padded_qo_len", "scale_head_dim"],
+            dtype="float8_e4m3fn",
+        ),
+        "k_scale": Tensor(
+            ["batch_size", "num_kv_heads", "padded_kv_len", "scale_head_dim"],
+            dtype="float8_e4m3fn",
+        ),
         "v_scale_t": Tensor(
-            ["batch_size", "num_kv_heads", "head_dim", "scale_seq_len"]
+            ["batch_size", "num_kv_heads", "head_dim", "scale_kv_len"],
+            dtype="float8_e4m3fn",
         ),
         "qk_correction": Tensor(
-            ["batch_size", "num_qo_heads", "correction_seq_len", "seq_len"]
+            [
+                "batch_size",
+                "num_qo_heads",
+                "correction_q_blocks",
+                "padded_kv_len",
+            ],
+            dtype="float32",
         ),
     },
     constraints=[
         "head_dim == 2 * packed_head_dim",
         "head_dim == 16 * scale_head_dim",
+        "padded_qo_len % 128 == 0",
+        "padded_kv_len % 128 == 0",
+        "padded_qo_len >= qo_len",
+        "padded_qo_len - qo_len < 128",
+        "padded_kv_len >= kv_len",
+        "padded_kv_len - kv_len < 128",
+        "padded_kv_len == 2 * packed_kv_len",
+        "padded_kv_len == 16 * scale_kv_len",
         "num_kv_heads > 0",
         "num_qo_heads >= num_kv_heads",
         "num_qo_heads % num_kv_heads == 0",
@@ -69,42 +102,74 @@ nvfp4_attention_sm120_fwd_trace = TraceTemplate(
         "batch_size": Var(),
         "num_qo_heads": Var(),
         "num_kv_heads": Var(),
-        "seq_len": Var(),
+        "padded_qo_len": Var(),
+        "padded_kv_len": Var(),
         "head_dim": Const(),
         "packed_head_dim": Const(),
         "scale_head_dim": Const(),
-        "packed_seq_len": Var(),
-        "scale_seq_len": Var(),
-        "correction_seq_len": Var(),
+        "packed_kv_len": Var(),
+        "scale_kv_len": Var(),
+        "correction_q_blocks": Var(),
     },
     inputs={
-        "q_fp4": Tensor(["batch_size", "num_qo_heads", "seq_len", "packed_head_dim"]),
-        "k_fp4": Tensor(["batch_size", "num_kv_heads", "seq_len", "packed_head_dim"]),
-        "v_fp4_t": Tensor(["batch_size", "num_kv_heads", "head_dim", "packed_seq_len"]),
-        "q_scale": Tensor(["batch_size", "num_qo_heads", "seq_len", "scale_head_dim"]),
-        "k_scale": Tensor(["batch_size", "num_kv_heads", "seq_len", "scale_head_dim"]),
-        "v_scale_t": Tensor(
-            ["batch_size", "num_kv_heads", "head_dim", "scale_seq_len"]
+        "q_fp4": Tensor(
+            ["batch_size", "num_qo_heads", "padded_qo_len", "packed_head_dim"]
         ),
+        "k_fp4": Tensor(
+            ["batch_size", "num_kv_heads", "padded_kv_len", "packed_head_dim"]
+        ),
+        "v_fp4_t": Tensor(["batch_size", "num_kv_heads", "head_dim", "packed_kv_len"]),
+        "q_scale": Tensor(
+            ["batch_size", "num_qo_heads", "padded_qo_len", "scale_head_dim"]
+        ),
+        "k_scale": Tensor(
+            ["batch_size", "num_kv_heads", "padded_kv_len", "scale_head_dim"]
+        ),
+        "v_scale_t": Tensor(["batch_size", "num_kv_heads", "head_dim", "scale_kv_len"]),
         "qk_correction": Tensor(
-            ["batch_size", "num_qo_heads", "correction_seq_len", "seq_len"]
+            [
+                "batch_size",
+                "num_qo_heads",
+                "correction_q_blocks",
+                "padded_kv_len",
+            ]
         ),
         "sm_scale": Scalar("float32"),
         "causal": Scalar("bool"),
         "per_block_mean": Scalar("bool"),
+        "out": Tensor(
+            ["batch_size", "num_qo_heads", "padded_qo_len", "head_dim"],
+            optional=True,
+        ),
+        "lse": Tensor(
+            ["batch_size", "num_qo_heads", "padded_qo_len"],
+            optional=True,
+        ),
+        "out_dtype": Scalar("dtype", optional=True),
+        "unpadded_k_len": Scalar("int32", optional=True),
         "return_lse": Scalar(
             "bool", optional=True, description="Bool: also compute and return LSE."
         ),
     },
     outputs={
-        "out": Tensor(["batch_size", "num_qo_heads", "seq_len", "head_dim"]),
+        "out": Tensor(
+            ["batch_size", "num_qo_heads", "padded_qo_len", "head_dim"],
+            param="out",
+            dtype="bfloat16",
+            dtype_from="out",
+        ),
         "lse": Tensor(
-            ["batch_size", "num_qo_heads", "seq_len"],
+            ["batch_size", "num_qo_heads", "padded_qo_len"],
+            param="lse",
             dtype="float32",
             optional=True,
         ),
     },
     constraints=[
+        "padded_qo_len % 128 == 0",
+        "padded_kv_len % 128 == 0",
+        "padded_kv_len == 2 * packed_kv_len",
+        "padded_kv_len == 16 * scale_kv_len",
         "num_kv_heads > 0",
         "num_qo_heads >= num_kv_heads",
         "num_qo_heads % num_kv_heads == 0",

--- a/include/flashinfer/attention/sm120/nvfp4_attention_sm120/api/launcher.h
+++ b/include/flashinfer/attention/sm120/nvfp4_attention_sm120/api/launcher.h
@@ -34,7 +34,7 @@
 
 namespace nvfp4_attention {
 
-template <typename Kernel_traits, bool Is_causal>
+template <typename Kernel_traits, bool Is_causal, bool ReturnLSE>
 void run_flash_fwd(Flash_fwd_params& params, cudaStream_t stream) {
   using Element = typename Kernel_traits::Element;
   using ElementSF = typename Kernel_traits::ElementSF;
@@ -93,7 +93,8 @@ void run_flash_fwd(Flash_fwd_params& params, cudaStream_t stream) {
                                                   params.is_causal};
   typename Scheduler::Params scheduler_params = Scheduler::to_underlying_arguments(scheduler_args);
 
-  void* kernel = (void*)nvfp4_attention::attention_kernel_ws<Kernel_traits, Is_causal, Scheduler>;
+  void* kernel =
+      (void*)nvfp4_attention::attention_kernel_ws<Kernel_traits, Is_causal, ReturnLSE, Scheduler>;
 
   int smem_size = sizeof(typename Kernel_traits::SharedStorage);
   if (smem_size >= 48 * 1024) {
@@ -124,7 +125,7 @@ void run_flash_fwd(Flash_fwd_params& params, cudaStream_t stream) {
   FLASHINFER_CUDA_CHECK(cudaGetLastError());
 }
 
-template <typename T, int Headdim, typename O = cutlass::bfloat16_t>
+template <typename T, int Headdim, typename O = cutlass::bfloat16_t, bool ReturnLSE = true>
 void run_mha_fwd_(Flash_fwd_params& params, cudaStream_t stream) {
   using DeltaSType = float;
 
@@ -135,7 +136,7 @@ void run_mha_fwd_(Flash_fwd_params& params, cudaStream_t stream) {
         static constexpr int kBlockN = 128;
         run_flash_fwd<
             Flash_fwd_kernel_traits<Headdim, 128, kBlockN, kStages, 1, per_block, T, O, DeltaSType>,
-            Is_causal>(params, stream);
+            Is_causal, ReturnLSE>(params, stream);
       } else {
         static_assert(Headdim == 64 || Headdim == 128, "Unsupported Headdim");
       }

--- a/include/flashinfer/attention/sm120/nvfp4_attention_sm120/api/launcher.h
+++ b/include/flashinfer/attention/sm120/nvfp4_attention_sm120/api/launcher.h
@@ -70,9 +70,10 @@ void run_flash_fwd(Flash_fwd_params& params, cudaStream_t stream) {
        {params.d, params.seqlen_k, params.h_k, params.b},
 
        static_cast<ElementDS const*>(params.delta_s_ptr),
-       {params.seqlen_s, params.seqlen_k, params.h_k, params.b},
+       {params.seqlen_s, params.seqlen_k, params.h, params.b},
        {params.ds_row_stride, _1{}, params.ds_head_stride, params.ds_batch_stride},
 
+       cutlass::FastDivmod(params.h_h_k_ratio),
        params.scale_softmax_log2});
 
   typename CollectiveEpilogue::Params epilogue_params =

--- a/include/flashinfer/attention/sm120/nvfp4_attention_sm120/compute/consumer/softmax.cuh
+++ b/include/flashinfer/attention/sm120/nvfp4_attention_sm120/compute/consumer/softmax.cuh
@@ -309,6 +309,105 @@ struct SoftmaxFused {
 #endif
   }
 
+  // Establish the row maximum and online rescale from the complete N128 score tile
+  // before either N64 slot is retired and reused by the next QK tile.
+  template <bool FirstTile, bool InfCheck = false, typename TensorAcc, typename TensorMax>
+  CUTLASS_DEVICE void prepare_online_softmax_n128(TensorAcc& acc, TensorMax& AbsMaxP,
+                                                  const float softmax_scale_log2) {
+    Tensor acc_reduction_view =
+        make_tensor(acc.data(), nvfp4_attention::convert_to_reduction_layout(acc.layout()));
+
+    static_assert(decltype(size<1, 1>(acc_reduction_view))::value == 4,
+                  "An N128 score tile must contain four N32 MMA repeats");
+
+    if constexpr (FirstTile) {
+      fill(row_max, -INFINITY);
+      clear(row_sum);
+      fill(scores_scale, 1.f);
+    }
+
+    CUTLASS_PRAGMA_UNROLL
+    for (int mi = 0; mi < size<0>(acc_reduction_view); ++mi) {
+      float const scores_max_prev = row_max(mi);
+      auto find_chunk_max = [&](auto ni) {
+        float local_max = -INFINITY;
+        CUTLASS_PRAGMA_UNROLL
+        for (int ei = 0; ei < size<1, 0>(acc_reduction_view); ++ei) {
+          local_max = fmaxf(local_max, acc_reduction_view(mi, make_coord(ei, ni)));
+        }
+        float const max_recv = __shfl_xor_sync(int32_t(-1), local_max, 1);
+        AbsMaxP(mi, ni) = fmaxf(local_max, max_recv);
+        row_max(mi) = fmaxf(row_max(mi), AbsMaxP(mi, ni));
+      };
+      find_chunk_max(_0{});
+      find_chunk_max(_1{});
+      find_chunk_max(_2{});
+      find_chunk_max(_3{});
+      row_max(mi) = reduce_row_max_from_pairs(row_max(mi));
+
+      if constexpr (!FirstTile) {
+        float const scores_max_cur =
+            !InfCheck ? row_max(mi) : (row_max(mi) == -INFINITY ? 0.f : row_max(mi));
+        scores_scale(mi) =
+            softmax_exp2<InfCheck>((scores_max_prev - scores_max_cur) * softmax_scale_log2);
+        row_sum(mi) *= scores_scale(mi);
+      }
+    }
+  }
+
+  template <int ScoreSlot, bool InfCheck = false, typename TensorAcc, typename TensorMax>
+  CUTLASS_DEVICE void softmax_quantize_n64(TensorAcc& acc, TensorMax& AbsMaxP,
+                                           const float softmax_scale_log2) {
+    Tensor acc_reduction_view =
+        make_tensor(acc.data(), nvfp4_attention::convert_to_reduction_layout(acc.layout()));
+    Tensor acc_conversion_view =
+        make_tensor(acc.data(), nvfp4_attention::convert_to_conversion_layout(acc.layout()));
+    Tensor acc_conversion_slot = acc_conversion_view(_, _, Int<ScoreSlot>{});
+    auto acc_conversion_flatten =
+        group_modes<1, 4>(group_modes<0, 2>(flatten(acc_conversion_slot)));
+    Tensor AbsMaxP_slot = AbsMaxP(_, make_coord(_, _, Int<ScoreSlot>{}));
+
+    static_assert(ScoreSlot == 0 || ScoreSlot == 1, "N64 score slot must be 0 or 1");
+    static_assert(decltype(size<1, 1>(acc_reduction_view))::value == 4,
+                  "An N128 score tile must contain four N32 MMA repeats");
+    CUTLASS_PRAGMA_UNROLL
+    for (int mi = 0; mi < size<0>(acc_reduction_view); ++mi) {
+      float const max_scaled =
+          InfCheck ? (row_max(mi) == -INFINITY
+                          ? 0.f
+                          : (row_max(mi) * softmax_scale_log2 + fp8_scalexfp4_scale_log2))
+                   : (row_max(mi) * softmax_scale_log2 + fp8_scalexfp4_scale_log2);
+
+      auto exp2_sum = [&](auto ni) {
+        CUTLASS_PRAGMA_UNROLL
+        for (int ei = 0; ei < size<1, 0>(acc_reduction_view); ++ei) {
+          float const p = softmax_exp2<InfCheck>(
+              acc_reduction_view(mi, make_coord(ei, ni)) * softmax_scale_log2 - max_scaled);
+          acc_reduction_view(mi, make_coord(ei, ni)) = p;
+          row_sum(mi) += p;
+        }
+        AbsMaxP(mi, ni) = softmax_exp2<InfCheck>(AbsMaxP(mi, ni) * softmax_scale_log2 - max_scaled +
+                                                 fp4_scale_log2);
+      };
+      if constexpr (ScoreSlot == 0) {
+        exp2_sum(_0{});
+        exp2_sum(_1{});
+      } else {
+        exp2_sum(_2{});
+        exp2_sum(_3{});
+      }
+    }
+
+    CUTLASS_PRAGMA_UNROLL
+    for (int i = 0; i < size(AbsMaxP_slot); ++i) {
+      float const inv_absmax = safe_inv_absmax(AbsMaxP_slot(i));
+      CUTLASS_PRAGMA_UNROLL
+      for (int j = 0; j < size<0>(acc_conversion_flatten); ++j) {
+        acc_conversion_flatten(j, i) *= inv_absmax;
+      }
+    }
+  }
+
 #if defined(FP16_SOFTMAX)
 
   template <bool FirstTile, bool InfCheck = false, typename TensorAcc, typename TensorMax>
@@ -479,6 +578,20 @@ struct SoftmaxFused {
       for (int ni = 0; ni < size<1>(o_store_reduction_view); ++ni) {
         o_store_reduction_view(mi, ni) =
             o_store_reduction_view(mi, ni) * scores_scale(mi) + o_tmp_reduction_view(mi, ni);
+      }
+    }
+  }
+
+  template <typename TensorAcc>
+  CUTLASS_DEVICE void rescale_o_inplace(TensorAcc& o_store) {
+    Tensor o_store_reduction_view =
+        make_tensor(o_store.data(), nvfp4_attention::convert_to_reduction_layout(o_store.layout()));
+
+    CUTLASS_PRAGMA_UNROLL
+    for (int mi = 0; mi < size(row_max); ++mi) {
+      CUTLASS_PRAGMA_UNROLL
+      for (int ni = 0; ni < size<1>(o_store_reduction_view); ++ni) {
+        o_store_reduction_view(mi, ni) *= scores_scale(mi);
       }
     }
   }
@@ -762,8 +875,10 @@ struct SoftmaxFused {
 
   template <bool InfCheck>
   __device__ __forceinline__ static float softmax_exp2(float x) {
-    if (x <= -126.0f) {
-      return 0.0f;
+    if constexpr (InfCheck) {
+      if (x <= -126.0f) {
+        return 0.0f;
+      }
     }
 #if defined(SOFTMAX_FMA_EXP2)
     if constexpr (!InfCheck) {

--- a/include/flashinfer/attention/sm120/nvfp4_attention_sm120/compute/consumer/softmax.cuh
+++ b/include/flashinfer/attention/sm120/nvfp4_attention_sm120/compute/consumer/softmax.cuh
@@ -25,6 +25,11 @@
 
 namespace nvfp4_attention {
 
+using cute::_;
+using cute::_0;
+using cute::_1;
+using cute::_2;
+using cute::_3;
 using cute::clear;
 using cute::copy;
 using cute::fill;

--- a/include/flashinfer/attention/sm120/nvfp4_attention_sm120/compute/mainloop.cuh
+++ b/include/flashinfer/attention/sm120/nvfp4_attention_sm120/compute/mainloop.cuh
@@ -814,6 +814,41 @@ struct CollectiveMainloopFwd {
       }
     };
 
+    auto process_score_slot = [&](auto score_slot,
+                                  auto has_next_tile) __attribute__((always_inline)) {
+      constexpr int ScoreSlot = decltype(score_slot)::value;
+      constexpr bool HasNextTile = decltype(has_next_tile)::value;
+      static_assert(ScoreSlot == 0 || ScoreSlot == 1, "N64 score slot must be 0 or 1");
+
+      softmax_fused.template softmax_quantize_n64<ScoreSlot, Is_causal>(
+          tSrS, AbsMaxP, mainloop_params.softmax_scale_log2);
+      if constexpr (ScoreSlot == 0) {
+        // Keep one convergence point while score registers transition from
+        // softmax input to packed P and then back to the next QK tile.
+        __syncwarp();
+      }
+      quantize(score_slot);
+
+      if constexpr (HasNextTile) {
+        if constexpr (ScoreSlot == 0) {
+          consumer_wait(pipeline_k, smem_pipe_read_k);
+        }
+        add_delta_s_slot(tSrS, score_slot);
+        refill_score_slot(score_slot);
+        if constexpr (ScoreSlot == 1) {
+          pipeline_k.consumer_release(smem_pipe_read_k);
+          ++smem_pipe_read_k;
+        }
+      }
+
+      if constexpr (ScoreSlot == 0) {
+        consumer_wait(pipeline_v, smem_pipe_read_v);
+      }
+      copy_v_block(score_slot);
+      cute::gemm(tiled_mma_pv, make_zip_tensor(tOrP(_, _, score_slot), tOrSFP(_, _, score_slot)),
+                 make_zip_tensor(tOrVt(_, _, score_slot), tOrSFVt(_, _, score_slot)), tOrO_store);
+    };
+
     consumer_wait(pipeline_q, smem_pipe_read_q);
     copy(smem_tiled_copy_Q, tSsQ, tSrQ_copy_view);
     copy(smem_tiled_copy_SFQ, tSsSFQ, tSrSFQ_copy_view);
@@ -853,34 +888,8 @@ struct CollectiveMainloopFwd {
     // separately below.
 #pragma unroll 1
     for (int tile_idx = 0; tile_idx < n_block_count - 1; ++tile_idx) {
-      softmax_fused.template softmax_quantize_n64<0, Is_causal>(tSrS, AbsMaxP,
-                                                                mainloop_params.softmax_scale_log2);
-      // Keep one convergence point while score registers transition from
-      // softmax input to packed P and then back to the next QK tile.
-      __syncwarp();
-      quantize(_0{});
-
-      consumer_wait(pipeline_k, smem_pipe_read_k);
-      add_delta_s_slot(tSrS, _0{});
-      refill_score_slot(_0{});
-
-      consumer_wait(pipeline_v, smem_pipe_read_v);
-      copy_v_block(_0{});
-      cute::gemm(tiled_mma_pv, make_zip_tensor(tOrP(_, _, _0{}), tOrSFP(_, _, _0{})),
-                 make_zip_tensor(tOrVt(_, _, _0{}), tOrSFVt(_, _, _0{})), tOrO_store);
-
-      softmax_fused.template softmax_quantize_n64<1, Is_causal>(tSrS, AbsMaxP,
-                                                                mainloop_params.softmax_scale_log2);
-      quantize(_1{});
-
-      add_delta_s_slot(tSrS, _1{});
-      refill_score_slot(_1{});
-      pipeline_k.consumer_release(smem_pipe_read_k);
-      ++smem_pipe_read_k;
-
-      copy_v_block(_1{});
-      cute::gemm(tiled_mma_pv, make_zip_tensor(tOrP(_, _, _1{}), tOrSFP(_, _, _1{})),
-                 make_zip_tensor(tOrVt(_, _, _1{}), tOrSFVt(_, _, _1{})), tOrO_store);
+      process_score_slot(_0{}, cute::true_type{});
+      process_score_slot(_1{}, cute::true_type{});
 
       pipeline_v.consumer_release(smem_pipe_read_v);
       ++smem_pipe_read_v;
@@ -896,23 +905,8 @@ struct CollectiveMainloopFwd {
 
     // Drain the final score tile without carrying a per-iteration
     // has-next-tile predicate through the hot loop.
-    softmax_fused.template softmax_quantize_n64<0, Is_causal>(tSrS, AbsMaxP,
-                                                              mainloop_params.softmax_scale_log2);
-    __syncwarp();
-    quantize(_0{});
-
-    consumer_wait(pipeline_v, smem_pipe_read_v);
-    copy_v_block(_0{});
-    cute::gemm(tiled_mma_pv, make_zip_tensor(tOrP(_, _, _0{}), tOrSFP(_, _, _0{})),
-               make_zip_tensor(tOrVt(_, _, _0{}), tOrSFVt(_, _, _0{})), tOrO_store);
-
-    softmax_fused.template softmax_quantize_n64<1, Is_causal>(tSrS, AbsMaxP,
-                                                              mainloop_params.softmax_scale_log2);
-    quantize(_1{});
-
-    copy_v_block(_1{});
-    cute::gemm(tiled_mma_pv, make_zip_tensor(tOrP(_, _, _1{}), tOrSFP(_, _, _1{})),
-               make_zip_tensor(tOrVt(_, _, _1{}), tOrSFVt(_, _, _1{})), tOrO_store);
+    process_score_slot(_0{}, cute::false_type{});
+    process_score_slot(_1{}, cute::false_type{});
 
     pipeline_v.consumer_release(smem_pipe_read_v);
     ++smem_pipe_read_v;

--- a/include/flashinfer/attention/sm120/nvfp4_attention_sm120/compute/mainloop.cuh
+++ b/include/flashinfer/attention/sm120/nvfp4_attention_sm120/compute/mainloop.cuh
@@ -28,6 +28,7 @@
 #include "../utils/layout.cuh"
 #include "../utils/math.cuh"
 #include "cute/tensor.hpp"
+#include "cutlass/fast_math.h"
 #include "cutlass/gemm/collective/collective_builder.hpp"
 #include "cutlass/pipeline/pipeline.hpp"
 namespace nvfp4_attention {
@@ -157,6 +158,7 @@ struct CollectiveMainloopFwd {
     ElementDS const* ptr_ds;
     ShapeQKV const shape_ds;
     StrideQKV const stride_ds;
+    cutlass::FastDivmod const group_size_fastdiv;
     float const softmax_scale_log2;
   };
 
@@ -176,6 +178,7 @@ struct CollectiveMainloopFwd {
     TMA_Vt tma_load_Vt;
     TMA_SFVt tma_load_SFVt;
     TMA_DS tma_load_DS;
+    cutlass::FastDivmod const group_size_fastdiv;
     float const softmax_scale_log2;
   };
 
@@ -215,7 +218,8 @@ struct CollectiveMainloopFwd {
     return {args.shape_Q, layout_sfq,    args.shape_K, args.unpadded_shape_K,
             layout_sfk,   args.shape_Vt, layout_sfvt,  layout_ds,
             tma_load_Q,   tma_load_sfq,  tma_load_K,   tma_load_sfk,
-            tma_load_Vt,  tma_load_sfvt, tma_load_ds,  args.softmax_scale_log2};
+            tma_load_Vt,  tma_load_sfvt, tma_load_ds,  args.group_size_fastdiv,
+            args.softmax_scale_log2};
   }
 
   CUTLASS_DEVICE
@@ -363,6 +367,7 @@ struct CollectiveMainloopFwd {
     static constexpr int kBlockN = get<1>(TileShape_MNK{});
 
     auto [m_block, bidh, bidb] = work_tile_info.get_block_coord(scheduler_params);
+    int const kv_head = mainloop_params.group_size_fastdiv.divide(bidh);
 
     int n_block_max = get_n_block_max(mainloop_params, m_block);
 
@@ -388,8 +393,8 @@ struct CollectiveMainloopFwd {
     Tensor gQ =
         local_tile(mQ(_, _, bidh, bidb), select<0, 2>(TileShape_MNK{}), make_coord(m_block, _0{}));
     Tensor gK =
-        local_tile(mK(_, _, bidh, bidb), select<1, 2>(TileShape_MNK{}), make_coord(_, _0{}));
-    Tensor gVt = local_tile(mVt(_, _, bidh, bidb),
+        local_tile(mK(_, _, kv_head, bidb), select<1, 2>(TileShape_MNK{}), make_coord(_, _0{}));
+    Tensor gVt = local_tile(mVt(_, _, kv_head, bidb),
                             make_shape(shape<2>(TileShape_MNK{}), shape<1>(TileShape_MNK{})),
                             make_coord(_0{}, _));
     Tensor gDS = [&] {
@@ -404,8 +409,8 @@ struct CollectiveMainloopFwd {
     Tensor gSFQ = local_tile(mSFQ(_, _, bidh, bidb), select<0, 2>(TileShape_MNK{}),
                              make_coord(m_block, _0{}));
     Tensor gSFK =
-        local_tile(mSFK(_, _, bidh, bidb), select<1, 2>(TileShape_MNK{}), make_coord(_, _0{}));
-    Tensor gSFVt = local_tile(mSFVt(_, _, bidh, bidb),
+        local_tile(mSFK(_, _, kv_head, bidb), select<1, 2>(TileShape_MNK{}), make_coord(_, _0{}));
+    Tensor gSFVt = local_tile(mSFVt(_, _, kv_head, bidb),
                               make_shape(shape<2>(TileShape_MNK{}), shape<1>(TileShape_MNK{})),
                               make_coord(_0{}, _));
     auto block_tma_q = mainloop_params.tma_load_Q.get_slice(_0{});

--- a/include/flashinfer/attention/sm120/nvfp4_attention_sm120/compute/mainloop.cuh
+++ b/include/flashinfer/attention/sm120/nvfp4_attention_sm120/compute/mainloop.cuh
@@ -215,10 +215,22 @@ struct CollectiveMainloopFwd {
     TMA_SFVt tma_load_sfvt = make_tma_copy<uint16_t>(
         GmemTiledCopySF{}, mSFVt, SmemLayoutSFVt{}(_, _, _0{}),
         make_shape(shape<2>(TileShape_MNK{}), shape<1>(TileShape_MNK{})), _1{});
-    return {args.shape_Q, layout_sfq,    args.shape_K, args.unpadded_shape_K,
-            layout_sfk,   args.shape_Vt, layout_sfvt,  layout_ds,
-            tma_load_Q,   tma_load_sfq,  tma_load_K,   tma_load_sfk,
-            tma_load_Vt,  tma_load_sfvt, tma_load_ds,  args.group_size_fastdiv,
+    return {args.shape_Q,
+            layout_sfq,
+            args.shape_K,
+            args.unpadded_shape_K,
+            layout_sfk,
+            args.shape_Vt,
+            layout_sfvt,
+            layout_ds,
+            tma_load_Q,
+            tma_load_sfq,
+            tma_load_K,
+            tma_load_sfk,
+            tma_load_Vt,
+            tma_load_sfvt,
+            tma_load_ds,
+            args.group_size_fastdiv,
             args.softmax_scale_log2};
   }
 
@@ -826,10 +838,11 @@ struct CollectiveMainloopFwd {
     ++smem_pipe_read_k;
 
     int const first_n_block = n_block_count - 1;
-    // The quantized fixed-length binding pads K to N128 and exposes no
-    // separate unpadded length, so noncausal tiles are always fully valid.
-    // Compile the mask machinery out of that hot specialization entirely.
     if constexpr (Is_causal) {
+      apply_mask(tSrS, first_n_block);
+    } else if (unpadded_seqlen_k < seqlen_k) {
+      // Only the prologue owns the highest (possibly partial) K tile. All
+      // tiles rebuilt in the steady-state loop below are fully valid.
       apply_mask(tSrS, first_n_block);
     }
     softmax_fused.template prepare_online_softmax_n128<true, Is_causal>(

--- a/include/flashinfer/attention/sm120/nvfp4_attention_sm120/compute/mainloop.cuh
+++ b/include/flashinfer/attention/sm120/nvfp4_attention_sm120/compute/mainloop.cuh
@@ -509,14 +509,14 @@ struct CollectiveMainloopFwd {
   };
 
   template <typename SharedStorage, typename FrgTensorO, typename SoftmaxFused,
-            typename MathOrderBarrier, typename TmaRefill = NoOpRefill>
+            typename TmaRefill = NoOpRefill>
   CUTLASS_DEVICE void mma(Params const& mainloop_params, MainloopPipelineQ pipeline_q,
                           MainloopPipeline pipeline_k, MainloopPipeline pipeline_v,
                           PipelineStateQ& smem_pipe_read_q, PipelineState& smem_pipe_read_k,
                           PipelineState& smem_pipe_read_v, FrgTensorO& tOrO_store,
                           SoftmaxFused& softmax_fused, int n_block_count, int thread_idx,
                           int work_idx, int m_block, int wg_id, SharedStorage& shared_storage,
-                          MathOrderBarrier& math_order, TmaRefill tma_refill = {}) {
+                          TmaRefill tma_refill = {}) {
     static_assert(is_rmem<FrgTensorO>::value, "O tensor must be rmem resident.");
 
     static constexpr int kBlockM = get<0>(TileShape_MNK{});
@@ -613,6 +613,14 @@ struct CollectiveMainloopFwd {
       copy(smem_tiled_copy_SFK, tSsSFK_stage(_, _, block_id), tSrSFK_copy_view(_, _, block_id));
     };
 
+    auto copy_k_group = [&](auto group_id) {
+      auto tSsK_stage = tSsK(_, _, _, smem_pipe_read_k.index());
+      auto tSsSFK_stage = tSsSFK(_, _, _, smem_pipe_read_k.index());
+      copy(smem_tiled_copy_K, tSsK_stage(_, group_id, _0{}), tSrK_copy_view(_, group_id, _0{}));
+      copy(smem_tiled_copy_SFK, tSsSFK_stage(_, group_id, _0{}),
+           tSrSFK_copy_view(_, group_id, _0{}));
+    };
+
     auto copy_v_block = [&](auto block_id) {
       auto tOsVt_stage = tOsVt(_, _, _, smem_pipe_read_v.index());
       auto tOsSFVt_stage = tOsSFVt(_, _, _, smem_pipe_read_v.index());
@@ -620,26 +628,33 @@ struct CollectiveMainloopFwd {
       copy(smem_tiled_copy_SFV, tOsSFVt_stage(_, _, block_id), tOrSFVt_copy_view(_, _, block_id));
     };
 
-    auto add_delta_s = [&](auto& acc) {
+    auto add_delta_s_slot = [&](auto& acc, auto score_slot) {
       auto acc_float4 = recast<float4>(acc);
+      constexpr int ScoreSlot = decltype(score_slot)::value;
+      constexpr int MmaNPerScoreSlot = 2;
+      constexpr int FirstMmaN = ScoreSlot * MmaNPerScoreSlot;
       int quad_id = (thread_idx % 4) * 2;
       if constexpr (std::is_same_v<ElementDS, float>) {
         auto tSsDS_stage = recast<float4>(sDS(_, _, smem_pipe_read_k.index()));
-        for (int i = 0; i < 4; i++) {
-          auto num = quad_id + i * 8;
+        CUTLASS_PRAGMA_UNROLL
+        for (int local_i = 0; local_i < MmaNPerScoreSlot; ++local_i) {
+          int const global_i = FirstMmaN + local_i;
+          auto num = quad_id + global_i * 8;
           float4 delta_s_0 = tSsDS_stage(make_coord(_0{}, _0{}), make_coord(num, _0{}));
           float4 delta_s_1 = tSsDS_stage(make_coord(_0{}, _0{}), make_coord(num + 1, _0{}));
-          acc_float4(make_coord(make_coord(_0{}, _0{}), _0{}), _0{}, i) = delta_s_0;
-          acc_float4(make_coord(make_coord(_0{}, _0{}), _1{}), _0{}, i) = delta_s_0;
-          acc_float4(make_coord(make_coord(_0{}, _1{}), _0{}), _0{}, i) = delta_s_1;
-          acc_float4(make_coord(make_coord(_0{}, _1{}), _1{}), _0{}, i) = delta_s_1;
+          acc_float4(make_coord(make_coord(_0{}, _0{}), _0{}), _0{}, global_i) = delta_s_0;
+          acc_float4(make_coord(make_coord(_0{}, _0{}), _1{}), _0{}, global_i) = delta_s_0;
+          acc_float4(make_coord(make_coord(_0{}, _1{}), _0{}), _0{}, global_i) = delta_s_1;
+          acc_float4(make_coord(make_coord(_0{}, _1{}), _1{}), _0{}, global_i) = delta_s_1;
         }
       } else {
         using ElementDSVec = cutlass::Array<ElementDS, 4>;
         auto tSsDS_stage = recast<ElementDSVec>(sDS(_, _, smem_pipe_read_k.index()));
         cutlass::NumericConverter<float, ElementDS> convert;
-        for (int i = 0; i < 4; i++) {
-          auto num = quad_id + i * 8;
+        CUTLASS_PRAGMA_UNROLL
+        for (int local_i = 0; local_i < MmaNPerScoreSlot; ++local_i) {
+          int const global_i = FirstMmaN + local_i;
+          auto num = quad_id + global_i * 8;
           ElementDSVec ds0 = tSsDS_stage(make_coord(_0{}, _0{}), make_coord(num, _0{}));
           ElementDSVec ds1 = tSsDS_stage(make_coord(_0{}, _0{}), make_coord(num + 1, _0{}));
           float4 delta_s_0;
@@ -652,26 +667,65 @@ struct CollectiveMainloopFwd {
           delta_s_1.y = convert(ds1[1]);
           delta_s_1.z = convert(ds1[2]);
           delta_s_1.w = convert(ds1[3]);
-          acc_float4(make_coord(make_coord(_0{}, _0{}), _0{}), _0{}, i) = delta_s_0;
-          acc_float4(make_coord(make_coord(_0{}, _0{}), _1{}), _0{}, i) = delta_s_0;
-          acc_float4(make_coord(make_coord(_0{}, _1{}), _0{}), _0{}, i) = delta_s_1;
-          acc_float4(make_coord(make_coord(_0{}, _1{}), _1{}), _0{}, i) = delta_s_1;
+          acc_float4(make_coord(make_coord(_0{}, _0{}), _0{}), _0{}, global_i) = delta_s_0;
+          acc_float4(make_coord(make_coord(_0{}, _0{}), _1{}), _0{}, global_i) = delta_s_0;
+          acc_float4(make_coord(make_coord(_0{}, _1{}), _0{}), _0{}, global_i) = delta_s_1;
+          acc_float4(make_coord(make_coord(_0{}, _1{}), _1{}), _0{}, global_i) = delta_s_1;
         }
       }
     };
 
+    constexpr int NumScoreSlots = 2;
     Tensor tSrS =
         partition_fragment_C(tiled_mma_qk, make_shape(Int<kBlockMPerWG>{}, Int<kBlockN>{}));
-    Tensor tSrS_converion_view =
+    Tensor tSrS_conversion_view =
         make_tensor(tSrS.data(), nvfp4_attention::convert_to_conversion_layout(tSrS.layout()));
     Tensor AbsMaxP = make_tensor_like<float>(make_layout(
-        shape(group<1, 4>(flatten(tSrS_converion_view.layout()(make_coord(_0{}, _), _, _))))));
+        shape(group<1, 4>(flatten(tSrS_conversion_view.layout()(make_coord(_0{}, _), _, _))))));
+
+    static_assert(kBlockN == 128, "N64 score-slot reuse requires an N128 attention tile");
+    static_assert(decltype(size<2>(tSrS))::value == 4,
+                  "The N128 score tile must contain four N32 MMA repeats");
+    static_assert(decltype(size<2>(tSrS_conversion_view))::value == NumScoreSlots,
+                  "The N128 score allocation must expose two N64 conversion slots");
+    static_assert(decltype(size<2>(tOrP))::value == NumScoreSlots,
+                  "Each score slot must map to one PV block");
+
+    auto refill_score_slot = [&](auto score_slot) {
+      constexpr int ScoreSlot = decltype(score_slot)::value;
+      static_assert(ScoreSlot == 0 || ScoreSlot == 1, "N64 score slot must be 0 or 1");
+      constexpr int FirstMmaN = ScoreSlot * 2;
+      copy_k_group(Int<FirstMmaN>{});
+      copy_k_group(Int<FirstMmaN + 1>{});
+      CUTLASS_PRAGMA_UNROLL
+      for (int k_block = 0; k_block < size<2>(tSrQ); ++k_block) {
+        if constexpr (ScoreSlot == 0) {
+          cute::gemm(tiled_mma_qk,
+                     make_zip_tensor(tSrQ(_, _, k_block), tSrSFQ(_, _, k_block))(_, _0{}),
+                     make_zip_tensor(tSrK(_, _, k_block), tSrSFK(_, _, k_block))(_, _0{}),
+                     tSrS(_, _0{}, _0{}));
+          cute::gemm(tiled_mma_qk,
+                     make_zip_tensor(tSrQ(_, _, k_block), tSrSFQ(_, _, k_block))(_, _0{}),
+                     make_zip_tensor(tSrK(_, _, k_block), tSrSFK(_, _, k_block))(_, _1{}),
+                     tSrS(_, _0{}, _1{}));
+        } else {
+          cute::gemm(tiled_mma_qk,
+                     make_zip_tensor(tSrQ(_, _, k_block), tSrSFQ(_, _, k_block))(_, _0{}),
+                     make_zip_tensor(tSrK(_, _, k_block), tSrSFK(_, _, k_block))(_, _2{}),
+                     tSrS(_, _0{}, _2{}));
+          cute::gemm(tiled_mma_qk,
+                     make_zip_tensor(tSrQ(_, _, k_block), tSrSFQ(_, _, k_block))(_, _0{}),
+                     make_zip_tensor(tSrK(_, _, k_block), tSrSFK(_, _, k_block))(_, _3{}),
+                     tSrS(_, _0{}, _3{}));
+        }
+      }
+    };
 
     auto col_limit_causal = [&](int row, int n_block) {
       return row + wg_m_offset + 1 + seqlen_k - n_block * kBlockN - seqlen_q + m_block * kBlockM;
     };
 
-    auto apply_mask = [&](auto& tSrS_local, int n_block_local) {
+    auto apply_mask = [&](auto& scores, int n_block_local) {
       int const valid_cols = int(unpadded_seqlen_k - n_block_local * kBlockN);
       if constexpr (!Is_causal) {
         if (valid_cols >= kBlockN) {
@@ -683,27 +737,30 @@ struct CollectiveMainloopFwd {
         }
       }
 
-      Tensor cS = cute::make_identity_tensor(make_shape(Int<kBlockMPerWG>{}, Int<kBlockN>{}));
-      Tensor tScS = thread_mma_qk.partition_C(cS);
+      // The flattened QK accumulator advances by one N32 repeat every 16
+      // entries. Within a repeat, lane and entry bits give the logical
+      // row/column without keeping an identity tensor live.
       CUTLASS_PRAGMA_UNROLL
-      for (int i = 0; i < size(tSrS_local); ++i) {
-        int const col = nvfp4_attention::qk_acc_col_to_k_col(int(get<1>(tScS(i))));
+      for (int i = 0; i < size(scores); ++i) {
+        int const lane = thread_idx & 31;
+        int const col = ((i >> 4) << 5) + ((lane & 3) << 3) + (i & 7);
         if constexpr (!Is_causal) {
           if (col >= int(unpadded_seqlen_k - n_block_local * kBlockN)) {
-            tSrS_local(i) = -INFINITY;
+            scores(i) = -INFINITY;
           }
         } else {
-          if (col >= std::min(seqlen_k - n_block_local * kBlockN,
-                              col_limit_causal(int(get<0>(tScS(i))), n_block_local))) {
-            tSrS_local(i) = -INFINITY;
+          int const row = (thread_idx >> 5) * 16 + ((i & 8) != 0 ? 8 : 0) + (lane >> 2);
+          if (col >=
+              std::min(seqlen_k - n_block_local * kBlockN, col_limit_causal(row, n_block_local))) {
+            scores(i) = -INFINITY;
           }
         }
       }
     };
 
-    auto quantize = [&](auto mma_k, auto acc_conversion_view) {
+    auto quantize = [&](auto mma_k) {
       Tensor AbsMaxP_stagek = AbsMaxP(_, make_coord(_, _, mma_k));
-      Tensor acc_conversion_stagek = acc_conversion_view(_, _, mma_k);
+      Tensor acc_conversion_stagek = tSrS_conversion_view(_, _, mma_k);
       Tensor SFP = make_tensor_like<cutlass::float_ue4m3_t>(AbsMaxP_stagek.layout());
       Tensor SFP_uint32_view = recast<uint32_t>(SFP);
       CUTLASS_PRAGMA_UNROLL
@@ -745,85 +802,103 @@ struct CollectiveMainloopFwd {
     copy(smem_tiled_copy_SFQ, tSsSFQ, tSrSFQ_copy_view);
     pipeline_q.consumer_release(smem_pipe_read_q);
     ++smem_pipe_read_q;
+    clear(tOrO_store);
 
-    bool is_first_compute = true;
+    // Prologue: build the first complete N128 score tile. The steady-state loop
+    // below consumes it one N64 half at a time while constructing the next tile
+    // in the just-retired score registers.
+    consumer_wait(pipeline_k, smem_pipe_read_k);
+    add_delta_s_slot(tSrS, _0{});
+    add_delta_s_slot(tSrS, _1{});
 
+    CUTLASS_PRAGMA_UNROLL
+    for (int k_block = 0; k_block < size<2>(tSrK); ++k_block) {
+      copy_k_block(k_block);
+      cute::gemm(tiled_mma_qk, make_zip_tensor(tSrQ(_, _, k_block), tSrSFQ(_, _, k_block)),
+                 make_zip_tensor(tSrK(_, _, k_block), tSrSFK(_, _, k_block)), tSrS);
+    }
+    pipeline_k.consumer_release(smem_pipe_read_k);
+    ++smem_pipe_read_k;
+
+    int const first_n_block = n_block_count - 1;
+    // The quantized fixed-length binding pads K to N128 and exposes no
+    // separate unpadded length, so noncausal tiles are always fully valid.
+    // Compile the mask machinery out of that hot specialization entirely.
+    if constexpr (Is_causal) {
+      apply_mask(tSrS, first_n_block);
+    }
+    softmax_fused.template prepare_online_softmax_n128<true, Is_causal>(
+        tSrS, AbsMaxP, mainloop_params.softmax_scale_log2);
+
+    // Steady state. This loop always has a following K tile, which keeps the
+    // refill and pipeline-control path branch-free. The final tile is drained
+    // separately below.
 #pragma unroll 1
-    for (int tile_idx = 0; tile_idx < n_block_count; ++tile_idx) {
-      int n_block = n_block_count - 1 - tile_idx;
+    for (int tile_idx = 0; tile_idx < n_block_count - 1; ++tile_idx) {
+      softmax_fused.template softmax_quantize_n64<0, Is_causal>(tSrS, AbsMaxP,
+                                                                mainloop_params.softmax_scale_log2);
+      // Keep one convergence point while score registers transition from
+      // softmax input to packed P and then back to the next QK tile.
+      __syncwarp();
+      quantize(_0{});
 
       consumer_wait(pipeline_k, smem_pipe_read_k);
+      add_delta_s_slot(tSrS, _0{});
+      refill_score_slot(_0{});
 
-      Tensor tSrS_local =
-          partition_fragment_C(tiled_mma_qk, make_shape(Int<kBlockMPerWG>{}, Int<kBlockN>{}));
-      Tensor tSrS_local_cv = make_tensor(
-          tSrS_local.data(), nvfp4_attention::convert_to_conversion_layout(tSrS_local.layout()));
+      consumer_wait(pipeline_v, smem_pipe_read_v);
+      copy_v_block(_0{});
+      cute::gemm(tiled_mma_pv, make_zip_tensor(tOrP(_, _, _0{}), tOrSFP(_, _, _0{})),
+                 make_zip_tensor(tOrVt(_, _, _0{}), tOrSFVt(_, _, _0{})), tOrO_store);
 
-      CUTLASS_PRAGMA_UNROLL
-      for (int k_block = 0; k_block < size<2>(tSrK); ++k_block) {
-        copy_k_block(k_block);
-      }
-      add_delta_s(tSrS_local);
+      softmax_fused.template softmax_quantize_n64<1, Is_causal>(tSrS, AbsMaxP,
+                                                                mainloop_params.softmax_scale_log2);
+      quantize(_1{});
+
+      add_delta_s_slot(tSrS, _1{});
+      refill_score_slot(_1{});
       pipeline_k.consumer_release(smem_pipe_read_k);
       ++smem_pipe_read_k;
 
-      if constexpr (!Is_causal) {
-        math_order.arrive();
-      }
+      copy_v_block(_1{});
+      cute::gemm(tiled_mma_pv, make_zip_tensor(tOrP(_, _, _1{}), tOrSFP(_, _, _1{})),
+                 make_zip_tensor(tOrVt(_, _, _1{}), tOrSFVt(_, _, _1{})), tOrO_store);
 
-      CUTLASS_PRAGMA_UNROLL
-      for (int k_block = 0; k_block < size<2>(tSrQ); ++k_block) {
-        cute::gemm(tiled_mma_qk, make_zip_tensor(tSrQ(_, _, k_block), tSrSFQ(_, _, k_block)),
-                   make_zip_tensor(tSrK(_, _, k_block), tSrSFK(_, _, k_block)), tSrS_local);
-      }
-
-      apply_mask(tSrS_local, n_block);
-      if (is_first_compute) {
-        softmax_fused.template online_softmax_with_quant<true, Is_causal>(
-            tSrS_local, AbsMaxP, mainloop_params.softmax_scale_log2);
-      } else {
-        softmax_fused.template online_softmax_with_quant<false, Is_causal>(
-            tSrS_local, AbsMaxP, mainloop_params.softmax_scale_log2);
-      }
-
-      auto quantize_score = [&](auto mma_k) { quantize(mma_k, tSrS_local_cv); };
-
-      math_order.wait();
-      consumer_wait(pipeline_v, smem_pipe_read_v);
-      copy_v_block(_0{});
-      quantize_score(_0{});
-
-      if (is_first_compute) {
-        CUTLASS_PRAGMA_UNROLL
-        for (int v_block = 0; v_block < size<2>(tOrP); ++v_block) {
-          cute::gemm(tiled_mma_pv, make_zip_tensor(tOrP(_, _, v_block), tOrSFP(_, _, v_block)),
-                     make_zip_tensor(tOrVt(_, _, v_block), tOrSFVt(_, _, v_block)), tOrO_store);
-          if (v_block < size<2>(tOrP) - 1) {
-            copy_v_block(v_block + 1);
-            quantize_score(v_block + 1);
-          }
-        }
-        is_first_compute = false;
-      } else {
-        Tensor tOrO = make_fragment_like(tOrO_store);
-        CUTLASS_PRAGMA_UNROLL
-        for (int v_block = 0; v_block < size<2>(tOrP); ++v_block) {
-          cute::gemm(tiled_mma_pv, make_zip_tensor(tOrP(_, _, v_block), tOrSFP(_, _, v_block)),
-                     make_zip_tensor(tOrVt(_, _, v_block), tOrSFVt(_, _, v_block)), tOrO);
-          if (v_block < size<2>(tOrP) - 1) {
-            copy_v_block(v_block + 1);
-            quantize_score(v_block + 1);
-          }
-        }
-        softmax_fused.rescale_o(tOrO_store, tOrO);
-      }
-
-      math_order.arrive();
       pipeline_v.consumer_release(smem_pipe_read_v);
       ++smem_pipe_read_v;
-
       tma_refill.refill_v(tile_idx);
+
+      // N blocks are consumed from high to low. Only the prologue tile can
+      // intersect the causal diagonal or the unpadded K tail; every
+      // subsequent tile is fully valid.
+      softmax_fused.template prepare_online_softmax_n128<false, Is_causal>(
+          tSrS, AbsMaxP, mainloop_params.softmax_scale_log2);
+      softmax_fused.rescale_o_inplace(tOrO_store);
     }
+
+    // Drain the final score tile without carrying a per-iteration
+    // has-next-tile predicate through the hot loop.
+    softmax_fused.template softmax_quantize_n64<0, Is_causal>(tSrS, AbsMaxP,
+                                                              mainloop_params.softmax_scale_log2);
+    __syncwarp();
+    quantize(_0{});
+
+    consumer_wait(pipeline_v, smem_pipe_read_v);
+    copy_v_block(_0{});
+    cute::gemm(tiled_mma_pv, make_zip_tensor(tOrP(_, _, _0{}), tOrSFP(_, _, _0{})),
+               make_zip_tensor(tOrVt(_, _, _0{}), tOrSFVt(_, _, _0{})), tOrO_store);
+
+    softmax_fused.template softmax_quantize_n64<1, Is_causal>(tSrS, AbsMaxP,
+                                                              mainloop_params.softmax_scale_log2);
+    quantize(_1{});
+
+    copy_v_block(_1{});
+    cute::gemm(tiled_mma_pv, make_zip_tensor(tOrP(_, _, _1{}), tOrSFP(_, _, _1{})),
+               make_zip_tensor(tOrVt(_, _, _1{}), tOrSFVt(_, _, _1{})), tOrO_store);
+
+    pipeline_v.consumer_release(smem_pipe_read_v);
+    ++smem_pipe_read_v;
+    tma_refill.refill_v(n_block_count - 1);
 
     softmax_fused.finalize(tOrO_store);
     return;

--- a/include/flashinfer/attention/sm120/nvfp4_attention_sm120/compute/producer/load_k.cuh
+++ b/include/flashinfer/attention/sm120/nvfp4_attention_sm120/compute/producer/load_k.cuh
@@ -76,8 +76,8 @@ struct KLoader {
   template <typename MainloopParams, typename SharedStorage>
   __device__ __forceinline__ static auto prepare_tma_tensors(const MainloopParams& mainloop_params,
                                                              SharedStorage& shared_storage,
-                                                             int m_block, int query_head, int kv_head,
-                                                             int bidb,
+                                                             int m_block, int query_head,
+                                                             int kv_head, int bidb,
                                                              uint2 cluster_local_block_id) {
     auto sK = make_tensor(make_smem_ptr(shared_storage.smem_k.begin()), SmemLayoutK{});
     auto sSFK = make_tensor(make_smem_ptr(shared_storage.smem_SFK.begin()), SmemLayoutSFK{});

--- a/include/flashinfer/attention/sm120/nvfp4_attention_sm120/compute/producer/load_k.cuh
+++ b/include/flashinfer/attention/sm120/nvfp4_attention_sm120/compute/producer/load_k.cuh
@@ -76,7 +76,8 @@ struct KLoader {
   template <typename MainloopParams, typename SharedStorage>
   __device__ __forceinline__ static auto prepare_tma_tensors(const MainloopParams& mainloop_params,
                                                              SharedStorage& shared_storage,
-                                                             int m_block, int bidh, int bidb,
+                                                             int m_block, int query_head, int kv_head,
+                                                             int bidb,
                                                              uint2 cluster_local_block_id) {
     auto sK = make_tensor(make_smem_ptr(shared_storage.smem_k.begin()), SmemLayoutK{});
     auto sSFK = make_tensor(make_smem_ptr(shared_storage.smem_SFK.begin()), SmemLayoutSFK{});
@@ -86,16 +87,17 @@ struct KLoader {
     auto mSFK = mainloop_params.tma_load_SFK.get_tma_tensor(shape(mainloop_params.layout_SFK));
     auto mDS = mainloop_params.tma_load_DS.get_tma_tensor(shape(mainloop_params.layout_DS));
 
-    auto gK = local_tile(mK(_, _, bidh, bidb), select<1, 2>(TileShape_MNK{}), make_coord(_, _0{}));
+    auto gK =
+        local_tile(mK(_, _, kv_head, bidb), select<1, 2>(TileShape_MNK{}), make_coord(_, _0{}));
     auto gSFK =
-        local_tile(mSFK(_, _, bidh, bidb), select<1, 2>(TileShape_MNK{}), make_coord(_, _0{}));
+        local_tile(mSFK(_, _, kv_head, bidb), select<1, 2>(TileShape_MNK{}), make_coord(_, _0{}));
 
     auto gDS = [&] {
       if constexpr (BlockMean) {
-        return local_tile(mDS(_, _, bidh, bidb), select<0, 1>(TileShape_MNK{}),
+        return local_tile(mDS(_, _, query_head, bidb), select<0, 1>(TileShape_MNK{}),
                           make_coord(m_block, _));
       } else {
-        return local_tile(mDS(_, _, bidh, bidb), select<0, 1>(TileShape_MNK{}),
+        return local_tile(mDS(_, _, query_head, bidb), select<0, 1>(TileShape_MNK{}),
                           make_coord(_0{}, _));
       }
     }();

--- a/include/flashinfer/attention/sm120/nvfp4_attention_sm120/compute/producer/load_q.cuh
+++ b/include/flashinfer/attention/sm120/nvfp4_attention_sm120/compute/producer/load_q.cuh
@@ -67,16 +67,16 @@ struct QLoader {
   template <typename MainloopParams, typename SharedStorage>
   __device__ __forceinline__ static auto prepare_tma_tensors(const MainloopParams& mainloop_params,
                                                              SharedStorage& shared_storage,
-                                                             int m_block, int query_head, int bidb) {
+                                                             int m_block, int query_head,
+                                                             int bidb) {
     auto sQ = make_tensor(make_smem_ptr(shared_storage.smem_q.begin()), SmemLayoutQ{});
     auto sSFQ = make_tensor(make_smem_ptr(shared_storage.smem_SFQ.begin()), SmemLayoutSFQ{});
 
     auto mQ = mainloop_params.tma_load_Q.get_tma_tensor(mainloop_params.shape_Q);
     auto mSFQ = mainloop_params.tma_load_SFQ.get_tma_tensor(shape(mainloop_params.layout_SFQ));
 
-    auto gQ =
-        local_tile(mQ(_, _, query_head, bidb), select<0, 2>(TileShape_MNK{}),
-                   make_coord(m_block, _0{}));
+    auto gQ = local_tile(mQ(_, _, query_head, bidb), select<0, 2>(TileShape_MNK{}),
+                         make_coord(m_block, _0{}));
     auto gSFQ = local_tile(mSFQ(_, _, query_head, bidb), select<0, 2>(TileShape_MNK{}),
                            make_coord(m_block, _0{}));
 

--- a/include/flashinfer/attention/sm120/nvfp4_attention_sm120/compute/producer/load_q.cuh
+++ b/include/flashinfer/attention/sm120/nvfp4_attention_sm120/compute/producer/load_q.cuh
@@ -67,7 +67,7 @@ struct QLoader {
   template <typename MainloopParams, typename SharedStorage>
   __device__ __forceinline__ static auto prepare_tma_tensors(const MainloopParams& mainloop_params,
                                                              SharedStorage& shared_storage,
-                                                             int m_block, int bidh, int bidb) {
+                                                             int m_block, int query_head, int bidb) {
     auto sQ = make_tensor(make_smem_ptr(shared_storage.smem_q.begin()), SmemLayoutQ{});
     auto sSFQ = make_tensor(make_smem_ptr(shared_storage.smem_SFQ.begin()), SmemLayoutSFQ{});
 
@@ -75,8 +75,9 @@ struct QLoader {
     auto mSFQ = mainloop_params.tma_load_SFQ.get_tma_tensor(shape(mainloop_params.layout_SFQ));
 
     auto gQ =
-        local_tile(mQ(_, _, bidh, bidb), select<0, 2>(TileShape_MNK{}), make_coord(m_block, _0{}));
-    auto gSFQ = local_tile(mSFQ(_, _, bidh, bidb), select<0, 2>(TileShape_MNK{}),
+        local_tile(mQ(_, _, query_head, bidb), select<0, 2>(TileShape_MNK{}),
+                   make_coord(m_block, _0{}));
+    auto gSFQ = local_tile(mSFQ(_, _, query_head, bidb), select<0, 2>(TileShape_MNK{}),
                            make_coord(m_block, _0{}));
 
     auto block_tma_q = mainloop_params.tma_load_Q.get_slice(_0{});

--- a/include/flashinfer/attention/sm120/nvfp4_attention_sm120/compute/producer/load_v.cuh
+++ b/include/flashinfer/attention/sm120/nvfp4_attention_sm120/compute/producer/load_v.cuh
@@ -69,7 +69,7 @@ struct VLoader {
   template <typename MainloopParams, typename SharedStorage>
   __device__ __forceinline__ static auto prepare_tma_tensors(const MainloopParams& mainloop_params,
                                                              SharedStorage& shared_storage,
-                                                             int bidh, int bidb,
+                                                             int kv_head, int bidb,
                                                              uint2 cluster_local_block_id) {
     auto sVt = make_tensor(make_smem_ptr(shared_storage.smem_v.begin()), SmemLayoutV{});
     auto sSFVt = make_tensor(make_smem_ptr(shared_storage.smem_SFV.begin()), SmemLayoutSFV{});
@@ -77,10 +77,10 @@ struct VLoader {
     auto mVt = mainloop_params.tma_load_Vt.get_tma_tensor(mainloop_params.shape_Vt);
     auto mSFVt = mainloop_params.tma_load_SFVt.get_tma_tensor(shape(mainloop_params.layout_SFVt));
 
-    auto gVt = local_tile(mVt(_, _, bidh, bidb),
+    auto gVt = local_tile(mVt(_, _, kv_head, bidb),
                           make_shape(shape<2>(TileShape_MNK{}), shape<1>(TileShape_MNK{})),
                           make_coord(_0{}, _));
-    auto gSFVt = local_tile(mSFVt(_, _, bidh, bidb),
+    auto gSFVt = local_tile(mSFVt(_, _, kv_head, bidb),
                             make_shape(shape<2>(TileShape_MNK{}), shape<1>(TileShape_MNK{})),
                             make_coord(_0{}, _));
 

--- a/include/flashinfer/attention/sm120/nvfp4_attention_sm120/kernel/attention_kernel.h
+++ b/include/flashinfer/attention/sm120/nvfp4_attention_sm120/kernel/attention_kernel.h
@@ -49,9 +49,9 @@ using namespace cute;
 #define NVFP4_ATTENTION_MIN_BLOCKS_PER_SM 1
 #endif
 
-#define CONSUMER_REG_ALLOC 232
+#define CONSUMER_REG_ALLOC (Is_causal ? 240 : 232)
 
-template <typename Ktraits, bool Is_causal, typename TileScheduler>
+template <typename Ktraits, bool Is_causal, bool ReturnLSE, typename TileScheduler>
 __global__ void __launch_bounds__(Ktraits::kNWarps* cutlass::NumThreadsPerWarp,
                                   NVFP4_ATTENTION_MIN_BLOCKS_PER_SM)
     attention_kernel_ws(
@@ -145,15 +145,6 @@ __global__ void __launch_bounds__(Ktraits::kNWarps* cutlass::NumThreadsPerWarp,
   params_epilogue_barrier.group_size_list = epilogue_barrier_group_size_list;
   EpilogueBarrier barrier_o(shared_storage.barrier_o, params_epilogue_barrier);
 
-  using MathOrderBarrier = typename Ktraits::MathOrderBarrier;
-  uint32_t math_order_group_sizes[2] = {cutlass::NumThreadsPerWarpGroup,
-                                        cutlass::NumThreadsPerWarpGroup};
-  typename MathOrderBarrier::Params math_order_params;
-
-  math_order_params.group_id = (warp_group_role == WarpGroupRole::Consumer1) ? 1 : 0;
-  math_order_params.group_size_list = math_order_group_sizes;
-  MathOrderBarrier math_order(shared_storage.math_order, math_order_params);
-
   CollectiveMainloop collective_mainloop;
   CollectiveEpilogue collective_epilogue;
 
@@ -240,16 +231,18 @@ __global__ void __launch_bounds__(Ktraits::kNWarps* cutlass::NumThreadsPerWarp,
 
       collective_mainloop.mma(mainloop_params, pipeline_q, pipeline_k, pipeline_v, smem_pipe_read_q,
                               smem_pipe_read_k, smem_pipe_read_v, tOrO, softmax_fused, n_block_max,
-                              mma_thread_idx, work_idx, m_block, wg_id, shared_storage, math_order);
+                              mma_thread_idx, work_idx, m_block, wg_id, shared_storage);
 
       barrier_o.wait();
 
       collective_epilogue.mma_store(shared_storage, tiled_mma_pv, tOrO, mma_thread_idx, wg_id);
 
-      LSEWriter<Ktraits>::write_lse(
-          epilogue_params.ptr_LSE, select<0, 2, 3>(epilogue_params.shape_O),
-          epilogue_params.stride_LSE, softmax_fused, mainloop_params.softmax_scale_log2,
-          tiled_mma_pv, mma_thread_idx, m_block * kBlockM + wg_id * kBlockMPerWG, bidh, bidb);
+      if constexpr (ReturnLSE) {
+        LSEWriter<Ktraits>::write_lse(
+            epilogue_params.ptr_LSE, select<0, 2, 3>(epilogue_params.shape_O),
+            epilogue_params.stride_LSE, softmax_fused, mainloop_params.softmax_scale_log2,
+            tiled_mma_pv, mma_thread_idx, m_block * kBlockM + wg_id * kBlockMPerWG, bidh, bidb);
+      }
 
       barrier_o.arrive();
 

--- a/include/flashinfer/attention/sm120/nvfp4_attention_sm120/kernel/scheduler.h
+++ b/include/flashinfer/attention/sm120/nvfp4_attention_sm120/kernel/scheduler.h
@@ -17,6 +17,8 @@
 
 #pragma once
 
+#include <algorithm>
+
 #include "cute/tensor.hpp"
 #include "cutlass/fast_math.h"
 
@@ -93,7 +95,36 @@ class StaticPersistentTileScheduler {
             args.is_causal};
   }
 
-  static dim3 get_grid_dim(Arguments const& args, int num_sm) { return {uint32_t(num_sm)}; }
+  static dim3 get_grid_dim(Arguments const& args, int num_sm) {
+    int const total_blocks = args.num_blocks_m * args.num_head * args.num_batch;
+    if (!args.is_causal) {
+      int const waves = cute::ceil_div(total_blocks, num_sm);
+      // Use the smallest persistent grid that preserves the same maximum
+      // number of work tiles per CTA. This removes CTAs that would retire one
+      // wave early and reduces producer/TMA contention for short shapes.
+      return {uint32_t(cute::ceil_div(total_blocks, waves))};
+    }
+
+    int grid = std::min(total_blocks, num_sm);
+    if (args.num_blocks_m <= 32 && total_blocks > grid) {
+      // Pick the nearest grid size whose persistent stride is coprime to the
+      // number of M blocks. Combined with the heavy/light row order below,
+      // this avoids repeatedly assigning the same triangular work classes to
+      // a CTA. For 32 M blocks on a 188-SM GPU this selects 187 CTAs.
+      auto gcd = [](int a, int b) {
+        while (b != 0) {
+          int const remainder = a % b;
+          a = b;
+          b = remainder;
+        }
+        return a;
+      };
+      while (grid > 1 && gcd(grid, args.num_blocks_m) != 1) {
+        --grid;
+      }
+    }
+    return {uint32_t(grid)};
+  }
 
   struct WorkTileInfo {
     int tile_idx;
@@ -104,10 +135,20 @@ class StaticPersistentTileScheduler {
     CUTLASS_DEVICE
     cute::tuple<int32_t, int32_t, int32_t> get_block_coord(Params const& params) const {
       int m_block, bidh, bidb;
-      bidb = params.head_divmod.divmod(bidh, params.m_block_divmod.divmod(m_block, tile_idx));
+      int const flat_head = params.m_block_divmod.divmod(m_block, tile_idx);
       if (params.is_causal) {
-        m_block = params.num_blocks_m - 1 - m_block;
+        if (params.num_blocks_m <= 32) {
+          // Visit high, low, next-high, next-low. With a coprime persistent
+          // stride this minimizes the maximum triangular work assigned to any
+          // CTA, which determines the short-shape kernel tail.
+          m_block = (m_block & 1) ? (m_block >> 1) : (params.num_blocks_m - 1 - (m_block >> 1));
+        } else if ((flat_head & 1) == 0) {
+          // Alternate the M traversal direction across heads/batches. This
+          // balances long causal shapes while retaining all SMs.
+          m_block = params.num_blocks_m - 1 - m_block;
+        }
       }
+      bidb = params.head_divmod.divmod(bidh, flat_head);
       return {m_block, bidh, bidb};
     }
   };

--- a/include/flashinfer/attention/sm120/nvfp4_attention_sm120/kernel/traits.h
+++ b/include/flashinfer/attention/sm120/nvfp4_attention_sm120/kernel/traits.h
@@ -59,7 +59,6 @@ struct SharedStorageQKVOwithSF : cute::aligned_struct<128, _0> {
         typename nvfp4_attention::OrderedSequenceBarrierVarGroupSize<EpiStages, 2>::SharedStorage
         barrier_o;
 
-    alignas(16) typename nvfp4_attention::OrderedSequenceBarrier<2, 2>::SharedStorage math_order;
     int tile_count_semaphore;
   };
 };
@@ -234,8 +233,6 @@ struct Flash_fwd_kernel_traits {
 
   using EpilogueBarrier =
       typename nvfp4_attention::OrderedSequenceBarrierVarGroupSize<EpiStages, 2>;
-
-  using MathOrderBarrier = nvfp4_attention::OrderedSequenceBarrier<2, 2>;
 };
 
 }  // namespace nvfp4_attention

--- a/tests/attention/test_nvfp4_attention_sm120.py
+++ b/tests/attention/test_nvfp4_attention_sm120.py
@@ -358,6 +358,7 @@ def test_nvfp4_attention_sm120_structured_q_correction(per_block_mean):
         sm_scale=head_dim**-0.5,
         causal=False,
         per_block_mean=per_block_mean,
+        return_lse=False,
     )
     torch.cuda.synchronize()
 
@@ -468,18 +469,22 @@ def test_nvfp4_attention_sm120_without_lse(causal):
     v = torch.randn_like(q)
 
     quantized = flashinfer.nvfp4_attention_sm120_quantize_qkv(q, k, v)
-    out_with_lse, _ = flashinfer.nvfp4_attention_sm120_fwd(
-        *quantized, sm_scale=head_dim**-0.5, causal=causal, return_lse=True
+    out_default, lse_default = flashinfer.nvfp4_attention_sm120_fwd(
+        *quantized, sm_scale=head_dim**-0.5, causal=causal
     )
     out_without_lse = flashinfer.nvfp4_attention_sm120_fwd(
         *quantized,
         sm_scale=head_dim**-0.5,
         causal=causal,
+        return_lse=False,
     )
     torch.cuda.synchronize()
 
+    assert isinstance(out_default, torch.Tensor)
+    assert isinstance(lse_default, torch.Tensor)
+    assert lse_default.shape == (batch, num_heads, seq_len)
     assert isinstance(out_without_lse, torch.Tensor)
-    torch.testing.assert_close(out_without_lse, out_with_lse, rtol=0, atol=5e-4)
+    torch.testing.assert_close(out_without_lse, out_default, rtol=0, atol=5e-4)
 
 
 @torch.inference_mode()
@@ -507,6 +512,7 @@ def test_nvfp4_attention_sm120_causal_mask_column_order():
         qk_correction,
         sm_scale=head_dim**-0.5,
         causal=True,
+        return_lse=False,
     )
     torch.cuda.synchronize()
     out = out[0, 0].float()

--- a/tests/attention/test_nvfp4_attention_sm120.py
+++ b/tests/attention/test_nvfp4_attention_sm120.py
@@ -530,6 +530,255 @@ def test_nvfp4_attention_sm120_causal_mask_column_order():
     assert cos_sim >= 0.98
 
 
+@pytest.mark.parametrize(
+    (
+        "seq_len_q",
+        "seq_len_k",
+        "num_qo_heads",
+        "num_kv_heads",
+        "head_dim",
+        "input_dtype",
+        "out_dtype",
+        "per_block_mean",
+        "causal",
+        "provided_out",
+        "return_lse",
+    ),
+    [
+        pytest.param(
+            128,
+            256,
+            4,
+            4,
+            64,
+            torch.bfloat16,
+            torch.bfloat16,
+            True,
+            False,
+            False,
+            True,
+            id="mha-m-lt-n-aligned-d64-bf16",
+        ),
+        pytest.param(
+            193,
+            321,
+            8,
+            2,
+            128,
+            torch.bfloat16,
+            torch.float16,
+            True,
+            False,
+            True,
+            False,
+            id="gqa-m-lt-n-unaligned-d128-fp16-out",
+        ),
+        pytest.param(
+            385,
+            193,
+            4,
+            1,
+            64,
+            torch.float16,
+            torch.bfloat16,
+            False,
+            False,
+            False,
+            True,
+            id="mqa-m-gt-n-unaligned-d64-fp16-in",
+        ),
+        pytest.param(
+            257,
+            257,
+            4,
+            4,
+            128,
+            torch.bfloat16,
+            torch.bfloat16,
+            True,
+            True,
+            True,
+            True,
+            id="mha-square-unaligned-d128-causal",
+        ),
+    ],
+)
+@torch.inference_mode()
+def test_nvfp4_attention_sm120_rectangular(
+    seq_len_q,
+    seq_len_k,
+    num_qo_heads,
+    num_kv_heads,
+    head_dim,
+    input_dtype,
+    out_dtype,
+    per_block_mean,
+    causal,
+    provided_out,
+    return_lse,
+):
+    _require_sm120()
+
+    torch.manual_seed(42)
+    q = torch.randn(
+        (1, num_qo_heads, seq_len_q, head_dim),
+        device="cuda",
+        dtype=input_dtype,
+    )
+    k = torch.randn(
+        (1, num_kv_heads, seq_len_k, head_dim),
+        device="cuda",
+        dtype=input_dtype,
+    )
+    v = torch.randn_like(k)
+
+    quantized = flashinfer.nvfp4_attention_sm120_quantize_qkv(
+        q, k, v, per_block_mean=per_block_mean
+    )
+    q_fp4, k_fp4, v_fp4_t, q_scale, k_scale, v_scale_t, correction = quantized
+    seq_len_q_pad = math.ceil(seq_len_q / 128) * 128
+    seq_len_k_pad = math.ceil(seq_len_k / 128) * 128
+    correction_rows = seq_len_q_pad // 128 if per_block_mean else 1
+    assert q_fp4.shape == (1, num_qo_heads, seq_len_q_pad, head_dim // 2)
+    assert k_fp4.shape == (1, num_kv_heads, seq_len_k_pad, head_dim // 2)
+    assert v_fp4_t.shape == (1, num_kv_heads, head_dim, seq_len_k_pad // 2)
+    assert q_scale.shape == (1, num_qo_heads, seq_len_q_pad, head_dim // 16)
+    assert k_scale.shape == (1, num_kv_heads, seq_len_k_pad, head_dim // 16)
+    assert v_scale_t.shape == (1, num_kv_heads, head_dim, seq_len_k_pad // 16)
+    assert correction.shape == (1, num_qo_heads, correction_rows, seq_len_k_pad)
+
+    out_buffer = None
+    if provided_out:
+        out_buffer = torch.empty(
+            (1, num_qo_heads, seq_len_q_pad, head_dim),
+            device="cuda",
+            dtype=out_dtype,
+        )
+    result = flashinfer.nvfp4_attention_sm120_fwd(
+        *quantized,
+        per_block_mean=per_block_mean,
+        out=out_buffer,
+        out_dtype=out_dtype,
+        causal=causal,
+        return_lse=return_lse,
+        unpadded_k_len=seq_len_k,
+    )
+    if return_lse:
+        out, lse = result
+        assert lse.shape == (1, num_qo_heads, seq_len_q_pad)
+        assert torch.isfinite(lse[:, :, :seq_len_q]).all()
+    else:
+        out = result
+    torch.cuda.synchronize()
+
+    assert out.shape == (1, num_qo_heads, seq_len_q_pad, head_dim)
+    assert out.dtype == out_dtype
+    if provided_out:
+        assert out is out_buffer
+
+    kv_indices = torch.arange(num_qo_heads, device="cuda") // (
+        num_qo_heads // num_kv_heads
+    )
+    k_expanded = k.index_select(1, kv_indices)
+    v_expanded = v.index_select(1, kv_indices)
+    ref = F.scaled_dot_product_attention(
+        q.float(),
+        k_expanded.float(),
+        v_expanded.float(),
+        is_causal=causal,
+        scale=head_dim**-0.5,
+    )
+    out = out[:, :, :seq_len_q]
+    cos_sim = F.cosine_similarity(out.float().reshape(1, -1), ref.reshape(1, -1)).item()
+    mean_abs_err = (out.float() - ref).abs().mean().item()
+    assert cos_sim >= 0.94
+    assert mean_abs_err <= 0.10
+
+    if return_lse:
+        k_centered = k.float() - k.float().mean(dim=-2, keepdim=True)
+        scores = torch.matmul(
+            q.float(), k_centered.index_select(1, kv_indices).transpose(-2, -1)
+        ) * (head_dim**-0.5)
+        if causal:
+            mask = torch.triu(
+                torch.ones(
+                    seq_len_q,
+                    seq_len_k,
+                    device="cuda",
+                    dtype=torch.bool,
+                ),
+                diagonal=1,
+            )
+            scores.masked_fill_(mask, float("-inf"))
+        lse_ref = torch.logsumexp(scores, dim=-1)
+        lse_diff = (lse[:, :, :seq_len_q] - lse_ref).abs()
+        assert lse_diff.mean().item() <= 0.05
+        assert lse_diff.max().item() <= 0.5
+
+
+@torch.inference_mode()
+def test_nvfp4_attention_sm120_rectangular_matches_square_padded_oracle():
+    _require_sm120()
+
+    torch.manual_seed(42)
+    seq_len_q, seq_len_k, head_dim = 192, 320, 128
+    q = torch.randn((1, 4, seq_len_q, head_dim), device="cuda", dtype=torch.bfloat16)
+    k = torch.randn((1, 2, seq_len_k, head_dim), device="cuda", dtype=torch.bfloat16)
+    v = torch.randn_like(k)
+
+    rectangular = flashinfer.nvfp4_attention_sm120_quantize_qkv(q, k, v)
+    out_rectangular = flashinfer.nvfp4_attention_sm120_fwd(
+        *rectangular, return_lse=False, unpadded_k_len=seq_len_k
+    )
+
+    q_square = F.pad(q, (0, 0, 0, seq_len_k - seq_len_q))
+    square = flashinfer.nvfp4_attention_sm120_quantize_qkv(q_square, k, v)
+    out_square = flashinfer.nvfp4_attention_sm120_fwd(
+        *square, return_lse=False, unpadded_k_len=seq_len_k
+    )
+    torch.cuda.synchronize()
+
+    torch.testing.assert_close(
+        out_rectangular[:, :, :seq_len_q],
+        out_square[:, :, :seq_len_q],
+        rtol=0,
+        atol=0,
+    )
+
+
+@torch.inference_mode()
+def test_nvfp4_attention_sm120_unpadded_k_len_masks_tail_garbage():
+    _require_sm120()
+
+    torch.manual_seed(42)
+    seq_len_q, seq_len_k, head_dim = 160, 192, 128
+    q = torch.randn((1, 4, seq_len_q, head_dim), device="cuda", dtype=torch.bfloat16)
+    k = torch.randn((1, 2, seq_len_k, head_dim), device="cuda", dtype=torch.bfloat16)
+    v = torch.randn_like(k)
+    quantized = flashinfer.nvfp4_attention_sm120_quantize_qkv(q, k, v)
+
+    baseline = flashinfer.nvfp4_attention_sm120_fwd(
+        *quantized, return_lse=False, unpadded_k_len=seq_len_k
+    )
+    with_garbage = [tensor.clone() for tensor in quantized]
+    with_garbage[1][:, :, seq_len_k:].fill_(0x77)
+    with_garbage[2][:, :, :, seq_len_k // 2 :].fill_(0x77)
+    with_garbage[4][:, :, seq_len_k:].fill_(1.0)
+    with_garbage[6][..., seq_len_k:].fill_(1.0e4)
+    actual = flashinfer.nvfp4_attention_sm120_fwd(
+        *with_garbage, return_lse=False, unpadded_k_len=seq_len_k
+    )
+    torch.cuda.synchronize()
+
+    torch.testing.assert_close(actual, baseline, rtol=0, atol=0)
+
+    for invalid_len in (0, quantized[1].shape[2] + 1):
+        with pytest.raises(ValueError, match="unpadded_k_len"):
+            flashinfer.nvfp4_attention_sm120_fwd(
+                *quantized, return_lse=False, unpadded_k_len=invalid_len
+            )
+
+
 def test_nvfp4_split_kv_gate_dtype_logic():
     """The split-KV gate must fire for NVFP4 KV and only for NVFP4 KV.
 

--- a/tests/attention/test_nvfp4_attention_sm120.py
+++ b/tests/attention/test_nvfp4_attention_sm120.py
@@ -87,6 +87,24 @@ def _reference_attention(q, k, v, causal):
     return torch.matmul(probs, v.float()).to(q.dtype)
 
 
+def _expand_quantized_kv_to_qo_heads(quantized):
+    q_fp4, k_fp4, v_fp4_t, q_scale, k_scale, v_scale_t, qk_correction = quantized
+    num_qo_heads = q_fp4.shape[1]
+    num_kv_heads = k_fp4.shape[1]
+    kv_indices = torch.arange(num_qo_heads, device=q_fp4.device) // (
+        num_qo_heads // num_kv_heads
+    )
+    return (
+        q_fp4,
+        k_fp4.index_select(1, kv_indices).contiguous(),
+        v_fp4_t.index_select(1, kv_indices).contiguous(),
+        q_scale,
+        k_scale.index_select(1, kv_indices).contiguous(),
+        v_scale_t.index_select(1, kv_indices).contiguous(),
+        qk_correction,
+    )
+
+
 def _run_nvfp4_attention_sm120_accuracy_case(
     batch,
     num_heads,
@@ -182,6 +200,110 @@ def test_nvfp4_attention_sm120_accuracy(
         cos_threshold,
         mean_abs_err_threshold,
     )
+
+
+@pytest.mark.parametrize(
+    ("num_qo_heads", "num_kv_heads", "seq_len", "head_dim", "causal", "per_block_mean"),
+    [
+        pytest.param(8, 4, 256, 64, False, True, id="gqa2-d64"),
+        pytest.param(8, 2, 384, 128, True, True, id="gqa4-d128-causal"),
+        pytest.param(8, 1, 256, 128, False, False, id="mqa-d128-global-mean"),
+    ],
+)
+@torch.inference_mode()
+def test_nvfp4_attention_sm120_gqa_matches_expanded_packed_oracle(
+    num_qo_heads,
+    num_kv_heads,
+    seq_len,
+    head_dim,
+    causal,
+    per_block_mean,
+):
+    _require_sm120()
+
+    torch.manual_seed(42)
+    q = torch.randn(
+        (1, num_qo_heads, seq_len, head_dim),
+        device="cuda",
+        dtype=torch.bfloat16,
+    )
+    k = torch.randn(
+        (1, num_kv_heads, seq_len, head_dim),
+        device="cuda",
+        dtype=torch.bfloat16,
+    )
+    v = torch.randn_like(k)
+
+    quantized = flashinfer.nvfp4_attention_sm120_quantize_qkv(
+        q, k, v, per_block_mean=per_block_mean
+    )
+    q_fp4, k_fp4, v_fp4_t, q_scale, k_scale, v_scale_t, correction = quantized
+    num_q_blocks = seq_len // 128 if per_block_mean else 1
+    assert q_fp4.shape == (1, num_qo_heads, seq_len, head_dim // 2)
+    assert k_fp4.shape == (1, num_kv_heads, seq_len, head_dim // 2)
+    assert v_fp4_t.shape == (1, num_kv_heads, head_dim, seq_len // 2)
+    assert q_scale.shape == (1, num_qo_heads, seq_len, head_dim // 16)
+    assert k_scale.shape == (1, num_kv_heads, seq_len, head_dim // 16)
+    assert v_scale_t.shape == (1, num_kv_heads, head_dim, seq_len // 16)
+    assert correction.shape == (1, num_qo_heads, num_q_blocks, seq_len)
+
+    out_gqa, lse_gqa = flashinfer.nvfp4_attention_sm120_fwd(
+        *quantized,
+        causal=causal,
+        per_block_mean=per_block_mean,
+        return_lse=True,
+    )
+    out_expanded, lse_expanded = flashinfer.nvfp4_attention_sm120_fwd(
+        *_expand_quantized_kv_to_qo_heads(quantized),
+        causal=causal,
+        per_block_mean=per_block_mean,
+        return_lse=True,
+    )
+    torch.cuda.synchronize()
+
+    torch.testing.assert_close(out_gqa, out_expanded, rtol=0, atol=0)
+    torch.testing.assert_close(lse_gqa, lse_expanded, rtol=0, atol=0)
+
+    kv_indices = torch.arange(num_qo_heads, device=q.device) // (
+        num_qo_heads // num_kv_heads
+    )
+    ref = torch.nn.functional.scaled_dot_product_attention(
+        q.float(),
+        k.index_select(1, kv_indices).float(),
+        v.index_select(1, kv_indices).float(),
+        is_causal=causal,
+        scale=head_dim**-0.5,
+    )
+    cos_sim = F.cosine_similarity(
+        out_gqa.float().reshape(1, -1), ref.reshape(1, -1)
+    ).item()
+    assert cos_sim >= 0.94
+
+
+@torch.inference_mode()
+def test_nvfp4_attention_sm120_rejects_nonuniform_gqa_ratio():
+    _require_sm120()
+
+    q = torch.randn((1, 6, 128, 128), device="cuda", dtype=torch.bfloat16)
+    k = torch.randn((1, 4, 128, 128), device="cuda", dtype=torch.bfloat16)
+    v = torch.randn_like(k)
+
+    with pytest.raises(ValueError, match="num_qo_heads"):
+        flashinfer.nvfp4_attention_sm120_quantize_qkv(q, k, v)
+
+
+@torch.inference_mode()
+def test_nvfp4_attention_sm120_rejects_kv_head_correction():
+    _require_sm120()
+
+    q = torch.randn((1, 8, 128, 128), device="cuda", dtype=torch.bfloat16)
+    k = torch.randn((1, 2, 128, 128), device="cuda", dtype=torch.bfloat16)
+    v = torch.randn_like(k)
+    quantized = list(flashinfer.nvfp4_attention_sm120_quantize_qkv(q, k, v))
+    quantized[6] = quantized[6][:, :2].contiguous()
+
+    with pytest.raises(ValueError, match="qk_correction"):
+        flashinfer.nvfp4_attention_sm120_fwd(*quantized)
 
 
 @pytest.mark.parametrize("per_block_mean", [True, False])

--- a/tests/attention/test_nvfp4_attention_sm120.py
+++ b/tests/attention/test_nvfp4_attention_sm120.py
@@ -119,6 +119,7 @@ def _run_nvfp4_attention_sm120_accuracy_case(
         qk_correction,
         sm_scale=head_dim**-0.5,
         causal=causal,
+        return_lse=True,
     )
 
     torch.cuda.synchronize()
@@ -224,7 +225,7 @@ def test_nvfp4_attention_sm120_structured_q_correction(per_block_mean):
     expected_rows = seq_len // 128 if per_block_mean else 1
     assert qk_correction.shape == (batch, num_heads, expected_rows, seq_len)
 
-    out, _ = flashinfer.nvfp4_attention_sm120_fwd(
+    out = flashinfer.nvfp4_attention_sm120_fwd(
         q_fp4,
         k_fp4,
         v_fp4_t,
@@ -263,7 +264,7 @@ def test_nvfp4_attention_sm120_output_magnitude():
 
     quantized = flashinfer.nvfp4_attention_sm120_quantize_qkv(q, k, v)
     out, lse = flashinfer.nvfp4_attention_sm120_fwd(
-        *quantized, sm_scale=head_dim**-0.5, causal=False
+        *quantized, sm_scale=head_dim**-0.5, causal=False, return_lse=True
     )
     torch.cuda.synchronize()
 
@@ -313,7 +314,7 @@ def test_nvfp4_attention_sm120_lse(causal):
 
     quantized = flashinfer.nvfp4_attention_sm120_quantize_qkv(q, k, v)
     _, lse = flashinfer.nvfp4_attention_sm120_fwd(
-        *quantized, sm_scale=head_dim**-0.5, causal=causal
+        *quantized, sm_scale=head_dim**-0.5, causal=causal, return_lse=True
     )
     torch.cuda.synchronize()
 
@@ -331,6 +332,34 @@ def test_nvfp4_attention_sm120_lse(causal):
     assert diff.max().item() <= 0.5
 
 
+@pytest.mark.parametrize("causal", [False, True])
+@torch.inference_mode()
+def test_nvfp4_attention_sm120_without_lse(causal):
+    _require_sm120()
+
+    torch.manual_seed(42)
+    batch, num_heads, seq_len, head_dim = 1, 2, 256, 128
+    q = torch.randn(
+        (batch, num_heads, seq_len, head_dim), device="cuda", dtype=torch.bfloat16
+    )
+    k = torch.randn_like(q)
+    v = torch.randn_like(q)
+
+    quantized = flashinfer.nvfp4_attention_sm120_quantize_qkv(q, k, v)
+    out_with_lse, _ = flashinfer.nvfp4_attention_sm120_fwd(
+        *quantized, sm_scale=head_dim**-0.5, causal=causal, return_lse=True
+    )
+    out_without_lse = flashinfer.nvfp4_attention_sm120_fwd(
+        *quantized,
+        sm_scale=head_dim**-0.5,
+        causal=causal,
+    )
+    torch.cuda.synchronize()
+
+    assert isinstance(out_without_lse, torch.Tensor)
+    torch.testing.assert_close(out_without_lse, out_with_lse, rtol=0, atol=5e-4)
+
+
 @torch.inference_mode()
 def test_nvfp4_attention_sm120_causal_mask_column_order():
     _require_sm120()
@@ -346,7 +375,7 @@ def test_nvfp4_attention_sm120_causal_mask_column_order():
     q_fp4, k_fp4, v_fp4_t, q_scale, k_scale, v_scale_t, qk_correction = (
         flashinfer.nvfp4_attention_sm120_quantize_qkv(q, k, v)
     )
-    out, _ = flashinfer.nvfp4_attention_sm120_fwd(
+    out = flashinfer.nvfp4_attention_sm120_fwd(
         q_fp4,
         k_fp4,
         v_fp4_t,

--- a/tests/trace/test_fi_trace.py
+++ b/tests/trace/test_fi_trace.py
@@ -81,6 +81,67 @@ def test_trace_default_check():
     assert standard_check([ref], [actual])
 
 
+def test_nvfp4_attention_sm120_trace_output_dtype_precedence():
+    batch, num_qo_heads, num_kv_heads = 1, 8, 2
+    seq_len_q, seq_len_k, head_dim = 256, 384, 128
+    kwargs = {
+        "q_fp4": torch.empty(
+            batch, num_qo_heads, seq_len_q, head_dim // 2, dtype=torch.uint8
+        ),
+        "k_fp4": torch.empty(
+            batch, num_kv_heads, seq_len_k, head_dim // 2, dtype=torch.uint8
+        ),
+        "v_fp4_t": torch.empty(
+            batch, num_kv_heads, head_dim, seq_len_k // 2, dtype=torch.uint8
+        ),
+        "q_scale": torch.empty(
+            batch,
+            num_qo_heads,
+            seq_len_q,
+            head_dim // 16,
+            dtype=torch.float8_e4m3fn,
+        ),
+        "k_scale": torch.empty(
+            batch,
+            num_kv_heads,
+            seq_len_k,
+            head_dim // 16,
+            dtype=torch.float8_e4m3fn,
+        ),
+        "v_scale_t": torch.empty(
+            batch,
+            num_kv_heads,
+            head_dim,
+            seq_len_k // 16,
+            dtype=torch.float8_e4m3fn,
+        ),
+        "qk_correction": torch.empty(
+            batch,
+            num_qo_heads,
+            seq_len_q // 128,
+            seq_len_k,
+            dtype=torch.float32,
+        ),
+        "sm_scale": head_dim**-0.5,
+        "causal": False,
+        "per_block_mean": True,
+    }
+
+    default_defn = flashinfer.nvfp4_attention_sm120_fwd.fi_trace(**kwargs)
+    assert default_defn["outputs"]["out"]["dtype"] == "bfloat16"
+
+    dtype_defn = flashinfer.nvfp4_attention_sm120_fwd.fi_trace(
+        **kwargs, out_dtype=torch.float16
+    )
+    assert dtype_defn["outputs"]["out"]["dtype"] == "float16"
+
+    out = torch.empty(batch, num_qo_heads, seq_len_q, head_dim, dtype=torch.bfloat16)
+    out_defn = flashinfer.nvfp4_attention_sm120_fwd.fi_trace(
+        **kwargs, out=out, out_dtype=torch.float16
+    )
+    assert out_defn["outputs"]["out"]["dtype"] == "bfloat16"
+
+
 def test_all_registered_trace_templates_have_check():
     from flashinfer.api_logging import _TRACE_REGISTRY
 


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

This PR optimizes the CUTLASS/CUDA SM120 NVFP4 attention forward kernel, with a focus on head-dimension-128 workloads used by Cosmos inference.

The largest performance contribution is **symmetric N64/N64 score-slot reuse** inside the existing N128 attention tile:

1. Compute the complete N128 QK score tile and establish the row maximum and online-softmax rescale across all 128 columns.
2. Softmax-quantize the first N64 score slot and consume it in the PV MMA.
3. Reuse that retired score-register slot immediately for the next tile's QK scores while the second N64 slot is consumed.
4. Repeat symmetrically for the second slot.

This avoids keeping a second full score fragment live and exposes more QK/PV overlap while preserving the full-N128 softmax reduction.

Additional kernel changes:

- Split the main loop into a prologue, branch-free steady state, and final drain.
- Remove the obsolete math-order barrier and reduce warp synchronization.
- Compile masking out of the noncausal specialization. For causal traversal, only the first tile can intersect the diagonal; subsequent tiles are fully valid.
- Derive mask row/column coordinates directly instead of retaining an identity tensor.
- Tune consumer register allocation and persistent CTA scheduling/work distribution for both short and long causal/noncausal workloads.
- Add a compile-time LSE specialization so the output-only path does not allocate or write LSE.

### LSE API behavior

`return_lse=False` is now the default and returns only the attention output tensor:

~~~python
out = flashinfer.nvfp4_attention_sm120_fwd(..., return_lse=False)
~~~

`return_lse=True` preserves the LSE-capable path and returns `(out, lse)`:

~~~python
out, lse = flashinfer.nvfp4_attention_sm120_fwd(..., return_lse=True)
~~~

Disabling LSE only removes the LSE allocation/writeback; it does not remove any computation required for the attention output. The tests compare the output-only and LSE-enabled specializations, and the existing output/LSE reference checks continue to pass.

### Performance

Local measurements used one NVIDIA RTX PRO 6000 Blackwell Server Edition GPU (SM120, 188 SMs), BF16 input/output, `D=128`, `per_block_mean=True`, and `return_lse=False`. The table reports CUDA-Graph attention-only kernel timing (median of 100 iterations after 10 warmups); QKV quantization is excluded. The maximum supported 2430 MHz graphics clock was requested and monitored during the runs.

| Shape | Mode | [#3640](https://github.com/flashinfer-ai/flashinfer/pull/3640) baseline (reported) | CuTe DSL reference (reported) | This PR (measured) | Latency vs #3640 | Latency vs CuTe DSL |
|---|---:|---:|---:|---:|---:|---:|
| B4, H8, S4096, D128 | Noncausal | 0.299 ms / 920.5 TFLOP/s | 0.262 ms / 1050.2 TFLOP/s | **0.262 ms / 1050.1 TFLOP/s** | **-12.4%** | same at reported precision |
| B1, H8, S32768, D128 | Noncausal | 4.970 ms / 884.9 TFLOP/s | 4.398 ms / 1000.0 TFLOP/s | **4.079 ms / 1078.2 TFLOP/s** | **-17.9%** | **-7.3%** |
| B4, H8, S4096, D128 | Causal | 0.223 ms / 616.6 TFLOP/s | 0.180 ms / 764.1 TFLOP/s | **0.165 ms / 830.6 TFLOP/s** | **-26.0%** | **-8.3%** |
| B1, H8, S32768, D128 | Causal | 2.958 ms / 743.3 TFLOP/s | 2.516 ms / 874.0 TFLOP/s | **2.207 ms / 996.5 TFLOP/s** | **-25.4%** | **-12.3%** |

The #3640 and CuTe DSL columns reproduce the values shared in the RTX Blackwell kernel performance design document; they were not remeasured in the same run as this PR. The relative percentages therefore use the published rounded latencies and should be treated as cross-run comparisons.

## Contributors

- [Atharva Joshi (@atharvajoshi10)](https://github.com/atharvajoshi10) — contributed the CuTe DSL kernel optimization and design document, including the symmetric N64/N64 score-slot reuse strategy, together with the RTX PRO 6000 benchmark results that motivated this CUTLASS implementation.

## 🔍 Related Issues

- Follow-up to #3640.
- Builds on the SM120 NVFP4 attention/LSE implementation in #3838.

## 🚀 Pull Request Checklist

### ✅ Pre-commit Checks

- [x] I installed `pre-commit` in an isolated environment.
- [x] I ran `pre-commit run --all-files`; all hooks passed.

## 🧪 Tests

- [x] Tests were added for both `return_lse=False` and `return_lse=True`.
- [x] `python -m pytest -q tests/attention/test_nvfp4_attention_sm120.py` — **16 passed**.
- [x] Output-only and LSE-enabled attention outputs match with `rtol=0, atol=5e-4`; LSE-enabled reference checks pass.

## Reviewer Notes

Please pay particular attention to:

- The intentional API default change: callers that need the previous `(out, lse)` result should pass `return_lse=True`.
- The full-N128 max/rescale followed by per-N64 softmax quantization and score-slot reuse.
- The persistent scheduler changes for triangular causal work distribution.

The upstream `pre-commit` check is green. The full PR test matrix is currently skipped by the repository's unauthorized-PR gate and requires maintainer approval before it can run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added grouped-query and multi-query attention support with separate query and key/value head counts.
  * Added optional LSE output and support for unpadded key/value sequence lengths.
  * Added configurable output buffers and output data types.
  * Enhanced tracing and benchmarking for the new attention options.

* **Bug Fixes**
  * Improved validation for head ratios, tensor shapes, sequence lengths, and masking.
  * Improved scheduling and handling of empty or irregular sequence shapes.

* **Tests**
  * Added coverage for GQA/MQA, LSE behavior, unpadded sequences, output dtypes, tracing, and invalid inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->