### PR TITLE
ci: upgrade sccache and retain stats

### DIFF
--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -167,7 +167,7 @@ jobs:
           export CUDA_MINOR
           export FLASHINFER_LOCAL_VERSION="cu${CUDA_MAJOR}${CUDA_MINOR}"
 
-          mkdir -p ${{ github.workspace }}/ci-cache
+          mkdir -p ${{ github.workspace }}/ci-cache ${{ github.workspace }}/sccache-diagnostics
 
           docker run --rm \
             -v ${{ github.workspace }}:/workspace \
@@ -185,10 +185,35 @@ jobs:
             -e AWS_ACCESS_KEY_ID="${{ secrets.SCCACHE_AWS_ACCESS_KEY_ID }}" \
             -e AWS_SECRET_ACCESS_KEY="${{ secrets.SCCACHE_AWS_SECRET_ACCESS_KEY }}" \
             -e SCCACHE_REGION="${{ vars.SCCACHE_REGION }}" \
+            -e SCCACHE_DIAGNOSTICS_DIR=/workspace/sccache-diagnostics \
             -w /workspace \
             ${{ env.DOCKER_IMAGE }} \
             bash /workspace/scripts/build_flashinfer_jit_cache_whl.sh
         timeout-minutes: 360
+
+      - name: Record sccache job metadata
+        if: always()
+        env:
+          DOCKER_IMAGE: ${{ matrix.arch == 'aarch64' && format('pytorch/manylinuxaarch64-builder:cuda{0}', matrix.cuda) || format('pytorch/manylinux2_28-builder:cuda{0}', matrix.cuda) }}
+        run: |
+          mkdir -p "${GITHUB_WORKSPACE}/sccache-diagnostics"
+          IMAGE_DIGESTS=$(docker image inspect --format '{{json .RepoDigests}}' "${DOCKER_IMAGE}" 2>/dev/null || printf 'unavailable')
+          {
+            printf 'git_commit=%s\n' "$(git rev-parse HEAD)"
+            printf 'docker_image=%s\n' "${DOCKER_IMAGE}"
+            printf 'docker_image_repo_digests=%s\n' "${IMAGE_DIGESTS}"
+            printf 'matrix_cuda=%s\n' "${{ matrix.cuda }}"
+            printf 'matrix_arch=%s\n' "${{ matrix.arch }}"
+          } > "${GITHUB_WORKSPACE}/sccache-diagnostics/job-metadata.txt"
+
+      - name: Upload sccache diagnostics
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: sccache-diagnostics-cuda${{ matrix.cuda }}-${{ matrix.arch }}
+          path: sccache-diagnostics/
+          if-no-files-found: warn
+          retention-days: 14
 
       - name: Display wheel size
         run: du -h flashinfer-jit-cache/dist/*

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -167,7 +167,7 @@ jobs:
           export CUDA_MINOR
           export FLASHINFER_LOCAL_VERSION="cu${CUDA_MAJOR}${CUDA_MINOR}"
 
-          mkdir -p ${{ github.workspace }}/ci-cache ${{ github.workspace }}/sccache-diagnostics
+          mkdir -p ${{ github.workspace }}/ci-cache ${{ github.workspace }}/sccache-stats
 
           docker run --rm \
             -v ${{ github.workspace }}:/workspace \
@@ -185,18 +185,28 @@ jobs:
             -e AWS_ACCESS_KEY_ID="${{ secrets.SCCACHE_AWS_ACCESS_KEY_ID }}" \
             -e AWS_SECRET_ACCESS_KEY="${{ secrets.SCCACHE_AWS_SECRET_ACCESS_KEY }}" \
             -e SCCACHE_REGION="${{ vars.SCCACHE_REGION }}" \
-            -e SCCACHE_DIAGNOSTICS_DIR=/workspace/sccache-diagnostics \
+            -e SCCACHE_STATS_DIR=/workspace/sccache-stats \
             -w /workspace \
             ${{ env.DOCKER_IMAGE }} \
             bash /workspace/scripts/build_flashinfer_jit_cache_whl.sh
         timeout-minutes: 360
+
+      - name: Display sccache stats
+        if: always()
+        run: |
+          STATS_FILE="${GITHUB_WORKSPACE}/sccache-stats/sccache-stats.txt"
+          if [ -s "${STATS_FILE}" ]; then
+            cat "${STATS_FILE}"
+          else
+            echo "::warning::sccache stats were not produced"
+          fi
 
       - name: Record sccache job metadata
         if: always()
         env:
           DOCKER_IMAGE: ${{ matrix.arch == 'aarch64' && format('pytorch/manylinuxaarch64-builder:cuda{0}', matrix.cuda) || format('pytorch/manylinux2_28-builder:cuda{0}', matrix.cuda) }}
         run: |
-          mkdir -p "${GITHUB_WORKSPACE}/sccache-diagnostics"
+          mkdir -p "${GITHUB_WORKSPACE}/sccache-stats"
           IMAGE_DIGESTS=$(docker image inspect --format '{{json .RepoDigests}}' "${DOCKER_IMAGE}" 2>/dev/null || printf 'unavailable')
           {
             printf 'git_commit=%s\n' "$(git rev-parse HEAD)"
@@ -204,14 +214,14 @@ jobs:
             printf 'docker_image_repo_digests=%s\n' "${IMAGE_DIGESTS}"
             printf 'matrix_cuda=%s\n' "${{ matrix.cuda }}"
             printf 'matrix_arch=%s\n' "${{ matrix.arch }}"
-          } > "${GITHUB_WORKSPACE}/sccache-diagnostics/job-metadata.txt"
+          } > "${GITHUB_WORKSPACE}/sccache-stats/job-metadata.txt"
 
-      - name: Upload sccache diagnostics
+      - name: Upload sccache stats
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: sccache-diagnostics-cuda${{ matrix.cuda }}-${{ matrix.arch }}
-          path: sccache-diagnostics/
+          name: sccache-stats-cuda${{ matrix.cuda }}-${{ matrix.arch }}
+          path: sccache-stats/
           if-no-files-found: warn
           retention-days: 14
 

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -286,19 +286,29 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.SCCACHE_AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.SCCACHE_AWS_SECRET_ACCESS_KEY }}
         run: |
-          mkdir -p "${GITHUB_WORKSPACE}/sccache-diagnostics"
+          mkdir -p "${GITHUB_WORKSPACE}/sccache-stats"
           bash ci/bash.sh "${DOCKER_IMAGE}" \
             -e SCCACHE_BUCKET "${SCCACHE_BUCKET}" \
             -e SCCACHE_REGION "${SCCACHE_REGION}" \
             -e AWS_ACCESS_KEY_ID \
             -e AWS_SECRET_ACCESS_KEY \
-            -e SCCACHE_DIAGNOSTICS_DIR /workspace/sccache-diagnostics \
+            -e SCCACHE_STATS_DIR /workspace/sccache-stats \
             --no-gpu ./scripts/${{ matrix.script }}
+
+      - name: Display sccache stats
+        if: always() && matrix.kind == 'aot'
+        run: |
+          STATS_FILE="${GITHUB_WORKSPACE}/sccache-stats/sccache-stats.txt"
+          if [ -s "${STATS_FILE}" ]; then
+            cat "${STATS_FILE}"
+          else
+            echo "::warning::sccache stats were not produced"
+          fi
 
       - name: Record sccache job metadata
         if: always() && matrix.kind == 'aot'
         run: |
-          mkdir -p "${GITHUB_WORKSPACE}/sccache-diagnostics"
+          mkdir -p "${GITHUB_WORKSPACE}/sccache-stats"
           IMAGE_DIGESTS=$(docker image inspect --format '{{json .RepoDigests}}' "${DOCKER_IMAGE}" 2>/dev/null || printf 'unavailable')
           {
             printf 'git_commit=%s\n' "$(git rev-parse HEAD)"
@@ -306,14 +316,14 @@ jobs:
             printf 'docker_image_repo_digests=%s\n' "${IMAGE_DIGESTS}"
             printf 'matrix_cuda=%s\n' "${{ matrix.cuda }}"
             printf 'matrix_arch=%s\n' "${{ matrix.runner[2] }}"
-          } > "${GITHUB_WORKSPACE}/sccache-diagnostics/job-metadata.txt"
+          } > "${GITHUB_WORKSPACE}/sccache-stats/job-metadata.txt"
 
-      - name: Upload sccache diagnostics
+      - name: Upload sccache stats
         if: always() && matrix.kind == 'aot'
         uses: actions/upload-artifact@v4
         with:
-          name: sccache-diagnostics-${{ matrix.cuda }}-${{ matrix.runner[2] }}
-          path: sccache-diagnostics/
+          name: sccache-stats-${{ matrix.cuda }}-${{ matrix.runner[2] }}
+          path: sccache-stats/
           if-no-files-found: warn
           retention-days: 14
 

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -286,12 +286,36 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.SCCACHE_AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.SCCACHE_AWS_SECRET_ACCESS_KEY }}
         run: |
+          mkdir -p "${GITHUB_WORKSPACE}/sccache-diagnostics"
           bash ci/bash.sh "${DOCKER_IMAGE}" \
             -e SCCACHE_BUCKET "${SCCACHE_BUCKET}" \
             -e SCCACHE_REGION "${SCCACHE_REGION}" \
             -e AWS_ACCESS_KEY_ID \
             -e AWS_SECRET_ACCESS_KEY \
+            -e SCCACHE_DIAGNOSTICS_DIR /workspace/sccache-diagnostics \
             --no-gpu ./scripts/${{ matrix.script }}
+
+      - name: Record sccache job metadata
+        if: always() && matrix.kind == 'aot'
+        run: |
+          mkdir -p "${GITHUB_WORKSPACE}/sccache-diagnostics"
+          IMAGE_DIGESTS=$(docker image inspect --format '{{json .RepoDigests}}' "${DOCKER_IMAGE}" 2>/dev/null || printf 'unavailable')
+          {
+            printf 'git_commit=%s\n' "$(git rev-parse HEAD)"
+            printf 'docker_image=%s\n' "${DOCKER_IMAGE}"
+            printf 'docker_image_repo_digests=%s\n' "${IMAGE_DIGESTS}"
+            printf 'matrix_cuda=%s\n' "${{ matrix.cuda }}"
+            printf 'matrix_arch=%s\n' "${{ matrix.runner[2] }}"
+          } > "${GITHUB_WORKSPACE}/sccache-diagnostics/job-metadata.txt"
+
+      - name: Upload sccache diagnostics
+        if: always() && matrix.kind == 'aot'
+        uses: actions/upload-artifact@v4
+        with:
+          name: sccache-diagnostics-${{ matrix.cuda }}-${{ matrix.runner[2] }}
+          path: sccache-diagnostics/
+          if-no-files-found: warn
+          retention-days: 14
 
       - name: Run Test
         if: matrix.kind != 'aot'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -201,7 +201,7 @@ jobs:
           export CUDA_MINOR
           export FLASHINFER_LOCAL_VERSION="cu${CUDA_MAJOR}${CUDA_MINOR}"
 
-          mkdir -p ${{ github.workspace }}/ci-cache ${{ github.workspace }}/sccache-diagnostics
+          mkdir -p ${{ github.workspace }}/ci-cache ${{ github.workspace }}/sccache-stats
 
           docker run --rm \
             -v ${{ github.workspace }}:/workspace \
@@ -218,18 +218,28 @@ jobs:
             -e AWS_ACCESS_KEY_ID="${{ secrets.SCCACHE_AWS_ACCESS_KEY_ID }}" \
             -e AWS_SECRET_ACCESS_KEY="${{ secrets.SCCACHE_AWS_SECRET_ACCESS_KEY }}" \
             -e SCCACHE_REGION="${{ vars.SCCACHE_REGION }}" \
-            -e SCCACHE_DIAGNOSTICS_DIR=/workspace/sccache-diagnostics \
+            -e SCCACHE_STATS_DIR=/workspace/sccache-stats \
             -w /workspace \
             ${{ env.DOCKER_IMAGE }} \
             bash /workspace/scripts/build_flashinfer_jit_cache_whl.sh
         timeout-minutes: 360
+
+      - name: Display sccache stats
+        if: always()
+        run: |
+          STATS_FILE="${GITHUB_WORKSPACE}/sccache-stats/sccache-stats.txt"
+          if [ -s "${STATS_FILE}" ]; then
+            cat "${STATS_FILE}"
+          else
+            echo "::warning::sccache stats were not produced"
+          fi
 
       - name: Record sccache job metadata
         if: always()
         env:
           DOCKER_IMAGE: ${{ matrix.arch == 'aarch64' && format('pytorch/manylinuxaarch64-builder:cuda{0}', matrix.cuda) || format('pytorch/manylinux2_28-builder:cuda{0}', matrix.cuda) }}
         run: |
-          mkdir -p "${GITHUB_WORKSPACE}/sccache-diagnostics"
+          mkdir -p "${GITHUB_WORKSPACE}/sccache-stats"
           IMAGE_DIGESTS=$(docker image inspect --format '{{json .RepoDigests}}' "${DOCKER_IMAGE}" 2>/dev/null || printf 'unavailable')
           {
             printf 'git_commit=%s\n' "$(git rev-parse HEAD)"
@@ -237,14 +247,14 @@ jobs:
             printf 'docker_image_repo_digests=%s\n' "${IMAGE_DIGESTS}"
             printf 'matrix_cuda=%s\n' "${{ matrix.cuda }}"
             printf 'matrix_arch=%s\n' "${{ matrix.arch }}"
-          } > "${GITHUB_WORKSPACE}/sccache-diagnostics/job-metadata.txt"
+          } > "${GITHUB_WORKSPACE}/sccache-stats/job-metadata.txt"
 
-      - name: Upload sccache diagnostics
+      - name: Upload sccache stats
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: sccache-diagnostics-cuda${{ matrix.cuda }}-${{ matrix.arch }}
-          path: sccache-diagnostics/
+          name: sccache-stats-cuda${{ matrix.cuda }}-${{ matrix.arch }}
+          path: sccache-stats/
           if-no-files-found: warn
           retention-days: 14
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -201,7 +201,7 @@ jobs:
           export CUDA_MINOR
           export FLASHINFER_LOCAL_VERSION="cu${CUDA_MAJOR}${CUDA_MINOR}"
 
-          mkdir -p ${{ github.workspace }}/ci-cache
+          mkdir -p ${{ github.workspace }}/ci-cache ${{ github.workspace }}/sccache-diagnostics
 
           docker run --rm \
             -v ${{ github.workspace }}:/workspace \
@@ -218,10 +218,35 @@ jobs:
             -e AWS_ACCESS_KEY_ID="${{ secrets.SCCACHE_AWS_ACCESS_KEY_ID }}" \
             -e AWS_SECRET_ACCESS_KEY="${{ secrets.SCCACHE_AWS_SECRET_ACCESS_KEY }}" \
             -e SCCACHE_REGION="${{ vars.SCCACHE_REGION }}" \
+            -e SCCACHE_DIAGNOSTICS_DIR=/workspace/sccache-diagnostics \
             -w /workspace \
             ${{ env.DOCKER_IMAGE }} \
             bash /workspace/scripts/build_flashinfer_jit_cache_whl.sh
         timeout-minutes: 360
+
+      - name: Record sccache job metadata
+        if: always()
+        env:
+          DOCKER_IMAGE: ${{ matrix.arch == 'aarch64' && format('pytorch/manylinuxaarch64-builder:cuda{0}', matrix.cuda) || format('pytorch/manylinux2_28-builder:cuda{0}', matrix.cuda) }}
+        run: |
+          mkdir -p "${GITHUB_WORKSPACE}/sccache-diagnostics"
+          IMAGE_DIGESTS=$(docker image inspect --format '{{json .RepoDigests}}' "${DOCKER_IMAGE}" 2>/dev/null || printf 'unavailable')
+          {
+            printf 'git_commit=%s\n' "$(git rev-parse HEAD)"
+            printf 'docker_image=%s\n' "${DOCKER_IMAGE}"
+            printf 'docker_image_repo_digests=%s\n' "${IMAGE_DIGESTS}"
+            printf 'matrix_cuda=%s\n' "${{ matrix.cuda }}"
+            printf 'matrix_arch=%s\n' "${{ matrix.arch }}"
+          } > "${GITHUB_WORKSPACE}/sccache-diagnostics/job-metadata.txt"
+
+      - name: Upload sccache diagnostics
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: sccache-diagnostics-cuda${{ matrix.cuda }}-${{ matrix.arch }}
+          path: sccache-diagnostics/
+          if-no-files-found: warn
+          retention-days: 14
 
       - name: Display wheel size
         run: du -h flashinfer-jit-cache/dist/*

--- a/scripts/build_flashinfer_jit_cache_whl.sh
+++ b/scripts/build_flashinfer_jit_cache_whl.sh
@@ -8,13 +8,13 @@ SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=scripts/jit_cache_build_common.sh
 source "${SCRIPT_DIR}/jit_cache_build_common.sh"
 
-finish_sccache_diagnostics() {
+finish_sccache_stats() {
   local exit_code=$?
-  collect_sccache_diagnostics || true
+  collect_sccache_stats || true
   return "${exit_code}"
 }
 
-trap finish_sccache_diagnostics EXIT
+trap finish_sccache_stats EXIT
 
 PYTHON_VERSION_FILE="${SCRIPT_DIR}/../.python-version"
 PYTHON_VERSION="$(tr -d '[:space:]' < "${PYTHON_VERSION_FILE}")"

--- a/scripts/build_flashinfer_jit_cache_whl.sh
+++ b/scripts/build_flashinfer_jit_cache_whl.sh
@@ -8,6 +8,14 @@ SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=scripts/jit_cache_build_common.sh
 source "${SCRIPT_DIR}/jit_cache_build_common.sh"
 
+finish_sccache_diagnostics() {
+  local exit_code=$?
+  collect_sccache_diagnostics || true
+  return "${exit_code}"
+}
+
+trap finish_sccache_diagnostics EXIT
+
 PYTHON_VERSION_FILE="${SCRIPT_DIR}/../.python-version"
 PYTHON_VERSION="$(tr -d '[:space:]' < "${PYTHON_VERSION_FILE}")"
 if [[ ! "${PYTHON_VERSION}" =~ ^3\.[0-9]+$ ]]; then
@@ -92,13 +100,6 @@ if [ -n "${OUTPUT_DIR}" ]; then
     echo "Copying wheels to output directory: ${OUTPUT_DIR}"
     mkdir -p "${OUTPUT_DIR}"
     cp -v dist/*.whl "${OUTPUT_DIR}/"
-fi
-
-# Print sccache stats if enabled
-if [ -n "$SCCACHE_BUCKET" ]; then
-  echo "::group::sccache stats"
-  sccache --show-stats
-  echo "::endgroup::"
 fi
 
 echo ""

--- a/scripts/jit_cache_build_common.sh
+++ b/scripts/jit_cache_build_common.sh
@@ -4,6 +4,10 @@
 #   - scripts/build_flashinfer_jit_cache_whl.sh         (release/nightly)
 #   - scripts/task_test_jit_cache_package_build_import.sh (PR tests)
 
+SCCACHE_VERSION="0.17.0"
+# The v0.17 client-side architecture remains opt-in while this change isolates
+# the version upgrade from a separate execution-mode change.
+
 # Compute MAX_JOBS and FLASHINFER_NVCC_THREADS from system memory/CPU,
 # clamping FLASHINFER_NVCC_THREADS to a sane range and budgeting per-job
 # memory to avoid OOMs on multi-arch builds.
@@ -111,14 +115,15 @@ install_sccache() {
 #   $1 - Cache key prefix tag (e.g. "cuda128-x86_64").
 #   $2 - Source root directory for SCCACHE_BASEDIRS.
 #
-# Reads (optional): SCCACHE_REGION, AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY.
+# Reads (optional): SCCACHE_REGION, SCCACHE_DIAGNOSTICS_DIR,
+# AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY.
 # Sets/exports: SCCACHE_*, FLASHINFER_NVCC_LAUNCHER, FLASHINFER_CXX_LAUNCHER.
 setup_sccache() {
   local key_prefix=$1
   local source_root=$2
   local sccache_arch
   sccache_arch=$(uname -m)
-  install_sccache "0.9.1" "${sccache_arch}"
+  install_sccache "${SCCACHE_VERSION}" "${sccache_arch}"
 
   export SCCACHE_REGION="${SCCACHE_REGION:-us-west-2}"
   export SCCACHE_BASEDIRS="${source_root}${SCCACHE_BASEDIRS:+:${SCCACHE_BASEDIRS}}"
@@ -132,18 +137,88 @@ setup_sccache() {
   case $- in *x*) _sccache_xtrace=1; set +x ;; esac
   if [ -n "${AWS_ACCESS_KEY_ID:-}" ] && [ -n "${AWS_SECRET_ACCESS_KEY:-}" ]; then
     unset SCCACHE_S3_NO_CREDENTIALS
+    export FLASHINFER_SCCACHE_CACHE_MODE="read-write"
     echo "sccache mode: read-write"
   else
     unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN
     export SCCACHE_S3_NO_CREDENTIALS=true
+    export FLASHINFER_SCCACHE_CACHE_MODE="read-only"
     echo "sccache mode: read-only (public bucket, no credentials)"
   fi
   (( _sccache_xtrace )) && set -x
 
+  if [ -n "${SCCACHE_DIAGNOSTICS_DIR:-}" ]; then
+    mkdir -p "${SCCACHE_DIAGNOSTICS_DIR}"
+    export SCCACHE_ERROR_LOG="${SCCACHE_DIAGNOSTICS_DIR}/sccache-debug.log"
+    # Keep this below trace: trace-level compile requests include the full
+    # compiler environment, which contains the S3 credentials in write jobs.
+    export SCCACHE_LOG="sccache=debug"
+    export SCCACHE_LOG_MILLIS=1
+  fi
+
   sccache --start-server
+  sccache --zero-stats
+  export FLASHINFER_SCCACHE_ACTIVE=true
   echo "sccache version: $(sccache --version)"
   echo "sccache bucket: ${SCCACHE_BUCKET}"
   echo "sccache region: ${SCCACHE_REGION}"
   echo "sccache prefix: ${SCCACHE_S3_KEY_PREFIX}"
   echo "sccache basedirs: ${SCCACHE_BASEDIRS}"
+
+  if [ -n "${SCCACHE_DIAGNOSTICS_DIR:-}" ]; then
+    local git_commit
+    git_commit=$(git -C "${source_root}" rev-parse HEAD 2>/dev/null || true)
+    {
+      printf 'git_commit=%s\n' "${git_commit:-unknown}"
+      printf 'sccache_version=%s\n' "$(sccache --version)"
+      printf 'sccache_cache_mode=%s\n' "${FLASHINFER_SCCACHE_CACHE_MODE}"
+      printf 'sccache_bucket=%s\n' "${SCCACHE_BUCKET}"
+      printf 'sccache_region=%s\n' "${SCCACHE_REGION}"
+      printf 'sccache_key_prefix=%s\n' "${SCCACHE_S3_KEY_PREFIX}"
+      printf 'sccache_basedirs=%s\n' "${SCCACHE_BASEDIRS}"
+      printf 'sccache_client_side=%s\n' "${SCCACHE_CLIENT_SIDE:-false}"
+      printf 'machine_arch=%s\n' "${sccache_arch}"
+      printf 'cuda_version=%s\n' "${CUDA_VERSION:-unknown}"
+      printf 'cuda_arch_list=%s\n' "${FLASHINFER_CUDA_ARCH_LIST:-unknown}"
+    } > "${SCCACHE_DIAGNOSTICS_DIR}/sccache-metadata.txt"
+  fi
+}
+
+# Print final stats and, when SCCACHE_DIAGNOSTICS_DIR is configured, retain
+# text/JSON stats plus the server debug log for artifact upload. This helper is
+# intended for EXIT traps; callers should ignore failures so diagnostics never
+# mask the build result.
+collect_sccache_diagnostics() {
+  if [ "${FLASHINFER_SCCACHE_ACTIVE:-false}" != "true" ] || \
+     [ "${FLASHINFER_SCCACHE_DIAGNOSTICS_COLLECTED:-false}" = "true" ] || \
+     ! command -v sccache >/dev/null 2>&1; then
+    return 0
+  fi
+  export FLASHINFER_SCCACHE_DIAGNOSTICS_COLLECTED=true
+
+  echo "::group::sccache stats"
+  if [ -n "${SCCACHE_DIAGNOSTICS_DIR:-}" ]; then
+    mkdir -p "${SCCACHE_DIAGNOSTICS_DIR}"
+    if ! sccache --show-stats > "${SCCACHE_DIAGNOSTICS_DIR}/sccache-stats.txt"; then
+      echo "WARNING: Failed to collect text sccache stats" >&2
+    fi
+    cat "${SCCACHE_DIAGNOSTICS_DIR}/sccache-stats.txt" 2>/dev/null || true
+    if ! sccache --show-stats --stats-format=json \
+        > "${SCCACHE_DIAGNOSTICS_DIR}/sccache-stats.json"; then
+      echo "WARNING: Failed to collect JSON sccache stats" >&2
+    fi
+    if ! sccache --show-adv-stats --stats-format=json \
+        > "${SCCACHE_DIAGNOSTICS_DIR}/sccache-advanced-stats.json"; then
+      echo "WARNING: Failed to collect advanced JSON sccache stats" >&2
+    fi
+    if ! sccache --stop-server \
+        > "${SCCACHE_DIAGNOSTICS_DIR}/sccache-stop-server.txt" 2>&1; then
+      echo "WARNING: Failed to stop the sccache server" >&2
+    fi
+  else
+    sccache --show-stats || true
+    sccache --stop-server >/dev/null 2>&1 || true
+  fi
+  export FLASHINFER_SCCACHE_ACTIVE=false
+  echo "::endgroup::"
 }

--- a/scripts/jit_cache_build_common.sh
+++ b/scripts/jit_cache_build_common.sh
@@ -115,7 +115,7 @@ install_sccache() {
 #   $1 - Cache key prefix tag (e.g. "cuda128-x86_64").
 #   $2 - Source root directory for SCCACHE_BASEDIRS.
 #
-# Reads (optional): SCCACHE_REGION, SCCACHE_DIAGNOSTICS_DIR,
+# Reads (optional): SCCACHE_REGION, SCCACHE_STATS_DIR,
 # AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY.
 # Sets/exports: SCCACHE_*, FLASHINFER_NVCC_LAUNCHER, FLASHINFER_CXX_LAUNCHER.
 setup_sccache() {
@@ -147,15 +147,6 @@ setup_sccache() {
   fi
   (( _sccache_xtrace )) && set -x
 
-  if [ -n "${SCCACHE_DIAGNOSTICS_DIR:-}" ]; then
-    mkdir -p "${SCCACHE_DIAGNOSTICS_DIR}"
-    export SCCACHE_ERROR_LOG="${SCCACHE_DIAGNOSTICS_DIR}/sccache-debug.log"
-    # Keep this below trace: trace-level compile requests include the full
-    # compiler environment, which contains the S3 credentials in write jobs.
-    export SCCACHE_LOG="sccache=debug"
-    export SCCACHE_LOG_MILLIS=1
-  fi
-
   sccache --start-server
   sccache --zero-stats
   export FLASHINFER_SCCACHE_ACTIVE=true
@@ -165,7 +156,8 @@ setup_sccache() {
   echo "sccache prefix: ${SCCACHE_S3_KEY_PREFIX}"
   echo "sccache basedirs: ${SCCACHE_BASEDIRS}"
 
-  if [ -n "${SCCACHE_DIAGNOSTICS_DIR:-}" ]; then
+  if [ -n "${SCCACHE_STATS_DIR:-}" ]; then
+    mkdir -p "${SCCACHE_STATS_DIR}"
     local git_commit
     git_commit=$(git -C "${source_root}" rev-parse HEAD 2>/dev/null || true)
     {
@@ -180,45 +172,40 @@ setup_sccache() {
       printf 'machine_arch=%s\n' "${sccache_arch}"
       printf 'cuda_version=%s\n' "${CUDA_VERSION:-unknown}"
       printf 'cuda_arch_list=%s\n' "${FLASHINFER_CUDA_ARCH_LIST:-unknown}"
-    } > "${SCCACHE_DIAGNOSTICS_DIR}/sccache-metadata.txt"
+    } > "${SCCACHE_STATS_DIR}/sccache-metadata.txt"
   fi
 }
 
-# Print final stats and, when SCCACHE_DIAGNOSTICS_DIR is configured, retain
-# text/JSON stats plus the server debug log for artifact upload. This helper is
-# intended for EXIT traps; callers should ignore failures so diagnostics never
-# mask the build result.
-collect_sccache_diagnostics() {
+# When SCCACHE_STATS_DIR is configured, retain text/JSON stats for a dedicated
+# workflow log step and artifact upload. Otherwise, print the stats directly.
+# This helper is intended for EXIT traps; callers should ignore failures so
+# stats collection never masks the build result.
+collect_sccache_stats() {
   if [ "${FLASHINFER_SCCACHE_ACTIVE:-false}" != "true" ] || \
-     [ "${FLASHINFER_SCCACHE_DIAGNOSTICS_COLLECTED:-false}" = "true" ] || \
+     [ "${FLASHINFER_SCCACHE_STATS_COLLECTED:-false}" = "true" ] || \
      ! command -v sccache >/dev/null 2>&1; then
     return 0
   fi
-  export FLASHINFER_SCCACHE_DIAGNOSTICS_COLLECTED=true
+  export FLASHINFER_SCCACHE_STATS_COLLECTED=true
 
-  echo "::group::sccache stats"
-  if [ -n "${SCCACHE_DIAGNOSTICS_DIR:-}" ]; then
-    mkdir -p "${SCCACHE_DIAGNOSTICS_DIR}"
-    if ! sccache --show-stats > "${SCCACHE_DIAGNOSTICS_DIR}/sccache-stats.txt"; then
+  if [ -n "${SCCACHE_STATS_DIR:-}" ]; then
+    mkdir -p "${SCCACHE_STATS_DIR}"
+    if ! sccache --show-stats > "${SCCACHE_STATS_DIR}/sccache-stats.txt"; then
       echo "WARNING: Failed to collect text sccache stats" >&2
     fi
-    cat "${SCCACHE_DIAGNOSTICS_DIR}/sccache-stats.txt" 2>/dev/null || true
     if ! sccache --show-stats --stats-format=json \
-        > "${SCCACHE_DIAGNOSTICS_DIR}/sccache-stats.json"; then
+        > "${SCCACHE_STATS_DIR}/sccache-stats.json"; then
       echo "WARNING: Failed to collect JSON sccache stats" >&2
     fi
     if ! sccache --show-adv-stats --stats-format=json \
-        > "${SCCACHE_DIAGNOSTICS_DIR}/sccache-advanced-stats.json"; then
+        > "${SCCACHE_STATS_DIR}/sccache-advanced-stats.json"; then
       echo "WARNING: Failed to collect advanced JSON sccache stats" >&2
     fi
-    if ! sccache --stop-server \
-        > "${SCCACHE_DIAGNOSTICS_DIR}/sccache-stop-server.txt" 2>&1; then
-      echo "WARNING: Failed to stop the sccache server" >&2
-    fi
   else
+    echo "::group::sccache stats"
     sccache --show-stats || true
-    sccache --stop-server >/dev/null 2>&1 || true
+    echo "::endgroup::"
   fi
+  sccache --stop-server >/dev/null 2>&1 || true
   export FLASHINFER_SCCACHE_ACTIVE=false
-  echo "::endgroup::"
 }

--- a/scripts/task_test_jit_cache_package_build_import.sh
+++ b/scripts/task_test_jit_cache_package_build_import.sh
@@ -114,7 +114,7 @@ finish_aot_memory_monitoring() {
     if [ "$exit_code" -ne 0 ]; then
         print_aot_memory_diagnostics
     fi
-    collect_sccache_diagnostics || true
+    collect_sccache_stats || true
 }
 
 trap finish_aot_memory_monitoring EXIT

--- a/scripts/task_test_jit_cache_package_build_import.sh
+++ b/scripts/task_test_jit_cache_package_build_import.sh
@@ -114,6 +114,7 @@ finish_aot_memory_monitoring() {
     if [ "$exit_code" -ne 0 ]; then
         print_aot_memory_diagnostics
     fi
+    collect_sccache_diagnostics || true
 }
 
 trap finish_aot_memory_monitoring EXIT
@@ -258,12 +259,6 @@ run_with_aot_memory_monitor "verify_all_modules_compiled" python scripts/verify_
     exit 1
 }
 echo "✓ All modules verified successfully"
-
-echo ""
-echo "========================================"
-echo "sccache stats"
-echo "========================================"
-sccache --show-stats
 
 echo ""
 echo "========================================"


### PR DESCRIPTION
## Summary

- pin the JIT-cache build helper to [sccache v0.17.0](https://github.com/mozilla/sccache/releases/tag/v0.17.0) for both x86_64 and aarch64 builds
- collect text, JSON, and advanced JSON stats from an EXIT hook so failed builds retain evidence without changing their exit status
- add a dedicated `Display sccache stats` workflow step to each nightly, release, and PR AOT matrix job that enables sccache
- retain safe cache/build metadata, including cache mode, key prefix, source SHA, CUDA architecture list, container tag, and pulled image digest
- upload the stats and metadata with `if: always()` for later comparison

## Motivation

The nightly JIT-cache jobs are reporting unexpectedly low hit rates. The existing `::group::sccache stats` markers were valid and GitHub rendered them as a foldable section, but that section was buried near the end of a roughly 294,000-line container-build step. A separate workflow step makes the final stats immediately visible in the job step list, while machine-readable artifacts make runs easy to compare later.

The v0.17 client-side execution mode remains disabled because it is opt-in; this keeps the version upgrade separate from an execution-mode change. Full sccache debug logging is intentionally not enabled to avoid runtime, artifact-size, and credential-exposure risk.

## Artifact contents

- `sccache-stats.txt`
- `sccache-stats.json`
- `sccache-advanced-stats.json`
- `sccache-metadata.txt`
- `job-metadata.txt`

Artifacts are retained for 14 days and are uploaded on both success and failure.

## Validation

- verified official v0.17.0 Linux musl archives and checksum assets for x86_64 and aarch64
- exercised setup, metadata, text/JSON/advanced stats, secret exclusion, and EXIT collection with a mocked sccache lifecycle
- confirmed the stats-only path does not set `SCCACHE_LOG` or `SCCACHE_ERROR_LOG` and does not create a debug-log artifact
- `bash -n` on all changed shell scripts
- YAML parsing on all changed workflows
- actionlint v1.7.12, filtering only the repository baseline shellcheck and custom self-hosted runner-label diagnostics
- repository pre-commit hooks on all changed files
- `git diff --check`

A real CUDA JIT-cache build was not run locally; the workflow matrix will provide that behavioral validation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added build diagnostics capturing cache statistics and build environment metadata.
  * Build and test artifacts now include diagnostic reports retained for 14 days.

* **Bug Fixes**
  * Diagnostic collection now runs even when builds fail or exit early.
  * Collection failures no longer change the original build result.
  * Added warnings when cache statistics are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->