### PR TITLE
perf(moe): fold the SiTU beta reciprocal in the CuTe DSL MoE epilogue

### DIFF
--- a/flashinfer/fused_moe/cute_dsl/blackwell/blockscaled_contiguous_gather_grouped_gemm_act_fusion.py
+++ b/flashinfer/fused_moe/cute_dsl/blackwell/blockscaled_contiguous_gather_grouped_gemm_act_fusion.py
@@ -57,6 +57,7 @@ from ..moe_utils import (
 )
 from .custom_pipeline import PipelineCpAsyncUmma
 from .utils import (
+    f32_reciprocal,
     fmin,
     gelu_tanh_f32,
     griddepcontrol_launch_dependents,
@@ -2802,7 +2803,13 @@ class BlockScaledContiguousGatherGroupedGemmKernel:
                         swiglu_limit = cutlass.Float32(self.swiglu_limit)
                         LOG2_E = cutlass.Float32(1.4426950408889634)
                         if cutlass.const_expr(self.situ_beta is not None):
-                            situ_beta = cutlass.Float32(self.situ_beta)
+                            # Keep the Python float so situ_f32 can fold 1/beta.
+                            situ_beta = self.situ_beta
+                            if cutlass.const_expr(self.situ_linear_beta is not None):
+                                linear_beta = cutlass.Float32(self.situ_linear_beta)
+                                inv_linear_beta = cutlass.Float32(
+                                    f32_reciprocal(self.situ_linear_beta)
+                                )
                             if cutlass.const_expr(self.vectorized_f32):
                                 for i in cutlass.range_constexpr(
                                     0, cute.size(tTR_rAcc_up), 2
@@ -2836,18 +2843,15 @@ class BlockScaledContiguousGatherGroupedGemmKernel:
                                     if cutlass.const_expr(
                                         self.situ_linear_beta is not None
                                     ):
-                                        linear_beta = cutlass.Float32(
-                                            self.situ_linear_beta
-                                        )
                                         acc_vec_up_alpha = (
                                             linear_beta
                                             * tanh_f32(
-                                                acc_vec_up_alpha[0] / linear_beta,
+                                                acc_vec_up_alpha[0] * inv_linear_beta,
                                                 fastmath=True,
                                             ),
                                             linear_beta
                                             * tanh_f32(
-                                                acc_vec_up_alpha[1] / linear_beta,
+                                                acc_vec_up_alpha[1] * inv_linear_beta,
                                                 fastmath=True,
                                             ),
                                         )
@@ -2875,11 +2879,8 @@ class BlockScaledContiguousGatherGroupedGemmKernel:
                                     if cutlass.const_expr(
                                         self.situ_linear_beta is not None
                                     ):
-                                        linear_beta = cutlass.Float32(
-                                            self.situ_linear_beta
-                                        )
                                         acc_vec_up_alpha = linear_beta * tanh_f32(
-                                            acc_vec_up_alpha / linear_beta,
+                                            acc_vec_up_alpha * inv_linear_beta,
                                             fastmath=True,
                                         )
                                     tCompute[i] = acc_vec_up_alpha * situ_gate_value

--- a/flashinfer/fused_moe/cute_dsl/blackwell/utils.py
+++ b/flashinfer/fused_moe/cute_dsl/blackwell/utils.py
@@ -252,6 +252,18 @@ def tanh_f32(
     ) - cutlass.Float32(1.0)
 
 
+def f32_reciprocal(value: float) -> float:
+    """Return ``1 / fp32(value)``, rounded to fp32.
+
+    The reciprocal must come from the same fp32 value the kernel multiplies back
+    in.  Taking it from the unrounded Python float instead can differ by 1 ulp for
+    betas that are not fp32-exact.  (f64 carries at least 2p+2 bits for p=24, so
+    computing the quotient in f64 and rounding once to fp32 is correctly rounded.)
+    """
+    beta_f32 = ctypes.c_float(float(value)).value
+    return ctypes.c_float(1.0 / beta_f32).value
+
+
 def situ_f32(
     a: Union[float, cutlass.Float32],
     beta: Union[float, cutlass.Float32],
@@ -260,9 +272,15 @@ def situ_f32(
     """Compute SiTU: beta * tanh(x / beta) * sigmoid(x)."""
     x = cutlass.Float32(a)
     beta_f32 = cutlass.Float32(beta)
+    # Multiply by the reciprocal: `x / beta` is a per-element div.rn.f32 the backend
+    # cannot strength-reduce (1/25.0 is inexact) nor hoist (varying numerator).
+    if isinstance(beta, (float, int)):
+        inv_beta = cutlass.Float32(f32_reciprocal(beta))
+    else:
+        inv_beta = cutlass.Float32(1.0) / beta_f32
     return (
         beta_f32
-        * tanh_f32(x / beta_f32, fastmath=fastmath)
+        * tanh_f32(x * inv_beta, fastmath=fastmath)
         * sigmoid_f32(x, fastmath=fastmath)
     )
 


### PR DESCRIPTION
`x / beta` in the SiTU gate and up branches lowers to a per-element
`div.rn.f32`: folding it to `x * (1/beta)` is only legal when `1/beta` is
exact, which the SiTU betas (e.g. Kimi-K3's 25.0) are not.  Compute the
reciprocal at trace time and multiply instead.

`f32_reciprocal` derives it from the fp32 beta the kernel multiplies back in,
so `x * inv_beta` stays consistent with `x / beta_f32`; taking the reciprocal
of the unrounded Python float can differ by 1 ulp when beta is not fp32-exact.

Kimi-K3 MoE (E=896, topK=16, hidden=3584, intermediate=3072) on one B200 at
1000 W, NVFP4, pre-routed, autotuned, microseconds, best of 3 repeats of
50 timed iters:

| tokens | 1 | 8 | 64 | 512 | 2048 | 4096 | 8192 |
|---|---|---|---|---|---|---|---|
| SiTU before | 123 | 673 | 3167 | 4744 | 4779 | 4845 | 7826 |
| SiTU after | 77 | 363 | 1734 | 2702 | 2914 | 3011 | 4992 |
| SwiGLU | 75 | 360 | 1724 | 2677 | 2761 | 2998 | 4361 |

SiTU now lands within 1-6% of SwiGLU on the same kernel through 4096 tokens.

`pytest tests/moe/test_cute_dsl_fused_moe.py -k situ` is unchanged (7 passed,
2 failed; both failures pre-exist on main)
<!-- .github/pull_request_template.md -->

## 📌 Description

<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Performance**
  * Improved SiTU activation calculations by replacing repeated division with precomputed reciprocal multiplication.
  * Optimized both vectorized and scalar calculation paths while preserving existing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->