### PR TITLE
fix(gdn): compile and tune CuTe-DSL decode kernels for the operand device

### DIFF
--- a/flashinfer/gdn_kernels/blackwell/gdn_prefill.py
+++ b/flashinfer/gdn_kernels/blackwell/gdn_prefill.py
@@ -50,7 +50,7 @@ from .gated_delta_net_chunked import GatedDeltaNetChunkedKernel
 # the key because the tile scheduler and GQA reshape logic bake them in.
 @functools.cache
 def _get_compiled_cache(
-    arch: str,
+    target_key: tuple,
     num_sm: int,
     io_dtype_str: str,
     state_dtype_str: str,
@@ -194,7 +194,7 @@ def chunk_gated_delta_rule_sm100(
     # num_sm is baked into the kernel's tile scheduler, so it belongs in the key.
     target = gdn_device_target(q.device)
     cache = _get_compiled_cache(
-        target.arch,
+        target.compile_key,
         get_num_sm(q.device),
         str(q.dtype),
         str(state_torch_dtype),

--- a/flashinfer/gdn_kernels/blackwell/gdn_prefill.py
+++ b/flashinfer/gdn_kernels/blackwell/gdn_prefill.py
@@ -37,6 +37,7 @@ from cutlass.cute.runtime import from_dlpack
 
 from flashinfer.cute_dsl.utils import get_num_sm
 
+from ..device_target import gdn_compile_options, gdn_device_target
 from .gated_delta_net_chunked import GatedDeltaNetChunkedKernel
 
 
@@ -49,6 +50,8 @@ from .gated_delta_net_chunked import GatedDeltaNetChunkedKernel
 # the key because the tile scheduler and GQA reshape logic bake them in.
 @functools.cache
 def _get_compiled_cache(
+    arch: str,
+    num_sm: int,
     io_dtype_str: str,
     state_dtype_str: str,
     HQ: int,
@@ -188,7 +191,11 @@ def chunk_gated_delta_rule_sm100(
     use_state_indices = state_indices is not None
     _state_indices = state_indices if use_state_indices else None
 
+    # num_sm is baked into the kernel's tile scheduler, so it belongs in the key.
+    target = gdn_device_target(q.device)
     cache = _get_compiled_cache(
+        target.arch,
+        get_num_sm(q.device),
         str(q.dtype),
         str(state_torch_dtype),
         HQ,
@@ -290,7 +297,9 @@ def chunk_gated_delta_rule_sm100(
 
         stream = cuda.CUstream(torch.cuda.current_stream(device=q.device).cuda_stream)
 
-        compiled = cute.compile(
+        compiled = cute.compile[
+            gdn_compile_options(q.device, cute.EnableTVMFFI(True), cute.OptLevel(3))
+        ](
             gdn,
             q_cute,
             k_cute,
@@ -308,7 +317,6 @@ def chunk_gated_delta_rule_sm100(
             scale,
             workspace_cute,
             stream,
-            options="--enable-tvm-ffi --opt-level 3",
         )
 
         cache["compiled"] = compiled

--- a/flashinfer/gdn_kernels/blackwell/gdn_prefill.py
+++ b/flashinfer/gdn_kernels/blackwell/gdn_prefill.py
@@ -37,6 +37,7 @@ from cutlass.cute.runtime import from_dlpack
 
 from flashinfer.cute_dsl.utils import get_num_sm
 
+from ..device_target import gdn_compile_options, gdn_device_target
 from .gated_delta_net_chunked import GatedDeltaNetChunkedKernel
 from ...jit.cute_dsl_core import build_and_load_cute_dsl_kernel
 from ..cute_dsl_cache_naming import make_kernel_name
@@ -64,6 +65,8 @@ def _kernel_source_files() -> tuple:
 
 
 def _prefill_kernel_name(
+    arch: str,
+    num_sm: int,
     io_dtype_str: str,
     state_dtype_str: str,
     HQ: int,
@@ -78,14 +81,15 @@ def _prefill_kernel_name(
     cu_checkpoints_dtype_str: str,
     initial_state_inner_strides,
     output_state_inner_strides,
-    num_sm: int,
 ) -> str:
     """Specialization name within the gdn_blackwell_prefill module.
 
-    Encodes every ``_get_compiled_cache`` key component plus ``num_sm``, which
-    the compile below bakes in as ``max_active_clusters``.
+    Encodes every ``_get_compiled_cache`` key component, including ``num_sm``,
+    which the compile below bakes in as ``max_active_clusters``.
     """
     return make_kernel_name(
+        arch,
+        num_sm,
         io_dtype_str,
         state_dtype_str,
         HQ,
@@ -100,12 +104,13 @@ def _prefill_kernel_name(
         cu_checkpoints_dtype_str,
         initial_state_inner_strides,
         output_state_inner_strides,
-        num_sm,
     )
 
 
 @functools.cache
 def _get_compiled_cache(
+    arch: str,
+    num_sm: int,
     io_dtype_str: str,
     state_dtype_str: str,
     HQ: int,
@@ -256,7 +261,12 @@ def chunk_gated_delta_rule_sm100(
     use_state_indices = state_indices is not None
     _state_indices = state_indices if use_state_indices else None
 
+    # num_sm is baked in as max_active_clusters, so it belongs to the key.
+    target = gdn_device_target(q.device)
+    num_sm = get_num_sm(q.device)
     cache_key = (
+        target.arch,
+        num_sm,
         str(q.dtype),
         str(state_torch_dtype),
         HQ,
@@ -284,7 +294,6 @@ def chunk_gated_delta_rule_sm100(
 
     if "compiled" not in cache:
         # --- First call: compile the kernel ---
-        num_sm = get_num_sm(q.device)
         max_active_clusters = num_sm
 
         gdn = GatedDeltaNetChunkedKernel(
@@ -374,8 +383,10 @@ def chunk_gated_delta_rule_sm100(
 
         compiled = build_and_load_cute_dsl_kernel(
             _CUTE_DSL_MODULE,
-            _prefill_kernel_name(*cache_key, num_sm),
-            lambda: cute.compile(
+            _prefill_kernel_name(*cache_key),
+            lambda: cute.compile[
+                gdn_compile_options(q.device, cute.EnableTVMFFI(True), cute.OptLevel(3))
+            ](
                 gdn,
                 q_cute,
                 k_cute,
@@ -393,7 +404,6 @@ def chunk_gated_delta_rule_sm100(
                 scale,
                 workspace_cute,
                 stream,
-                options="--enable-tvm-ffi --opt-level 3",
             ),
             extra_key_files=_kernel_source_files(),
         )

--- a/flashinfer/gdn_kernels/blackwell/gdn_prefill.py
+++ b/flashinfer/gdn_kernels/blackwell/gdn_prefill.py
@@ -37,7 +37,7 @@ from cutlass.cute.runtime import from_dlpack
 
 from flashinfer.cute_dsl.utils import get_num_sm
 
-from ..device_target import gdn_compile_options, gdn_device_target
+from ..device_target import gdn_compile_options, gdn_device_target, target_arch
 from .gated_delta_net_chunked import GatedDeltaNetChunkedKernel
 from ...jit.cute_dsl_core import build_and_load_cute_dsl_kernel
 from ..cute_dsl_cache_naming import make_kernel_name
@@ -65,7 +65,7 @@ def _kernel_source_files() -> tuple:
 
 
 def _prefill_kernel_name(
-    arch: str,
+    target_key: tuple,
     num_sm: int,
     io_dtype_str: str,
     state_dtype_str: str,
@@ -88,7 +88,7 @@ def _prefill_kernel_name(
     which the compile below bakes in as ``max_active_clusters``.
     """
     return make_kernel_name(
-        arch,
+        target_arch(target_key),
         num_sm,
         io_dtype_str,
         state_dtype_str,
@@ -109,7 +109,7 @@ def _prefill_kernel_name(
 
 @functools.cache
 def _get_compiled_cache(
-    arch: str,
+    target_key: tuple,
     num_sm: int,
     io_dtype_str: str,
     state_dtype_str: str,
@@ -265,7 +265,7 @@ def chunk_gated_delta_rule_sm100(
     target = gdn_device_target(q.device)
     num_sm = get_num_sm(q.device)
     cache_key = (
-        target.arch,
+        target.compile_key,
         num_sm,
         str(q.dtype),
         str(state_torch_dtype),

--- a/flashinfer/gdn_kernels/device_target.py
+++ b/flashinfer/gdn_kernels/device_target.py
@@ -1,0 +1,64 @@
+"""Per-device compile target and launch policy for the GDN CuTe-DSL kernels.
+
+The DSL resolves its default ``GPUArch`` from ``CUTE_DSL_ARCH`` or CUDA device 0,
+so kernels compiled for operands on another device could be built and tuned for
+the wrong GPU. Resolve one target from the operand device and use it for both the
+``cute.compile`` options and the compile-cache key so the two always agree.
+"""
+
+import functools
+import os
+from typing import NamedTuple, Union
+
+import cutlass.cute as cute
+import torch
+
+
+class GdnDeviceTarget(NamedTuple):
+    """Architecture and launch policy of a single CUDA device."""
+
+    arch: str
+    major: int
+    minor: int
+    num_sms: int
+    use_packed_fma: bool
+
+
+@functools.lru_cache(maxsize=None)
+def _resolve(device_index: int) -> GdnDeviceTarget:
+    major, minor = torch.cuda.get_device_capability(device_index)
+    # CUTE_DSL_ARCH is the DSL's own cross-compile override; keep it authoritative.
+    env_arch = os.environ.get("CUTE_DSL_ARCH")
+    suffix = "a" if major >= 9 else ""
+    return GdnDeviceTarget(
+        arch=env_arch or f"sm_{major}{minor}{suffix}",
+        major=major,
+        minor=minor,
+        num_sms=torch.cuda.get_device_properties(device_index).multi_processor_count,
+        use_packed_fma=major >= 10,
+    )
+
+
+def gdn_device_target(device: Union[str, torch.device]) -> GdnDeviceTarget:
+    """Resolve the compile target from an operand's device."""
+    d = torch.device(device)
+    if d.type != "cuda":
+        raise ValueError(f"GDN CuTe-DSL kernels require CUDA tensors, got {d}")
+    return _resolve(torch.cuda.current_device() if d.index is None else d.index)
+
+
+@functools.lru_cache(maxsize=None)
+def _arch_options(arch: str) -> tuple:
+    return (cute.GPUArch(arch),)
+
+
+def gdn_compile_options(device: Union[str, torch.device], *extra) -> tuple:
+    """``cute.compile`` options pinned to ``device``'s architecture.
+
+    Apply via ``cute.compile[options](...)``: a string ``options=`` kwarg replaces
+    these wholesale rather than merging, which would silently drop the arch.
+    """
+    return _arch_options(gdn_device_target(device).arch) + tuple(extra)
+
+
+__all__ = ["GdnDeviceTarget", "gdn_compile_options", "gdn_device_target"]

--- a/flashinfer/gdn_kernels/device_target.py
+++ b/flashinfer/gdn_kernels/device_target.py
@@ -40,6 +40,45 @@ def _arch_string(major: int, minor: int) -> str:
     return f"sm_{major}{minor}{'a' if major >= 9 else ''}"
 
 
+def _dsl_runtime_arch() -> Union[str, None]:
+    """The arch the DSL will accept a JIT engine for, or ``None`` if unavailable."""
+    try:
+        from cutlass.cutlass_dsl import CuTeDSL
+
+        return CuTeDSL._get_dsl().envar.arch
+    except Exception:
+        return None
+
+
+def _check_dsl_can_run(target: GdnDeviceTarget) -> None:
+    """Reject a target the DSL would silently turn into a cross-compile.
+
+    The DSL builds a JIT engine only when its process-global arch (``CUTE_DSL_ARCH``,
+    else CUDA device 0) can run the requested target, so one process serves one
+    architecture. Without this the failure surfaces as an internal DSL error, or on
+    an unpinned build as ``cudaErrorNoKernelImageForDevice`` at launch.
+    """
+    runtime_arch = _dsl_runtime_arch()
+    if runtime_arch is None or runtime_arch == target.arch:
+        return
+    try:
+        from cutlass.base_dsl import Arch
+
+        if Arch.from_string(runtime_arch).can_run_binary_built_for(
+            Arch.from_string(target.arch)
+        ):
+            return
+    except Exception:
+        return
+    raise RuntimeError(
+        f"GDN CuTe-DSL cannot target cuda:{target.device_index} ({target.arch}): the "
+        f"CuTe DSL compiles this process for {runtime_arch}, taken from CUDA device 0 "
+        "unless CUTE_DSL_ARCH is set, and one process can only serve one architecture. "
+        f"Set CUTE_DSL_ARCH={target.arch} or restrict CUDA_VISIBLE_DEVICES to devices "
+        "of a single architecture."
+    )
+
+
 @functools.lru_cache(maxsize=None)
 def _resolve(device_index: int) -> GdnDeviceTarget:
     major, minor = torch.cuda.get_device_capability(device_index)
@@ -51,7 +90,7 @@ def _resolve(device_index: int) -> GdnDeviceTarget:
         if match is None:
             raise ValueError(f"CUTE_DSL_ARCH is not a recognized arch: {env_arch!r}")
         major, minor = int(match.group(1)), int(match.group(2))
-    return GdnDeviceTarget(
+    target = GdnDeviceTarget(
         device_index=device_index,
         arch=env_arch or _arch_string(major, minor),
         major=major,
@@ -59,6 +98,8 @@ def _resolve(device_index: int) -> GdnDeviceTarget:
         num_sms=torch.cuda.get_device_properties(device_index).multi_processor_count,
         use_packed_fma=major >= 10,
     )
+    _check_dsl_can_run(target)
+    return target
 
 
 def gdn_device_target(device: Union[str, torch.device]) -> GdnDeviceTarget:

--- a/flashinfer/gdn_kernels/device_target.py
+++ b/flashinfer/gdn_kernels/device_target.py
@@ -1,37 +1,59 @@
 """Per-device compile target and launch policy for the GDN CuTe-DSL kernels.
 
-The DSL resolves its default ``GPUArch`` from ``CUTE_DSL_ARCH`` or CUDA device 0,
-so kernels compiled for operands on another device could be built and tuned for
-the wrong GPU. Resolve one target from the operand device and use it for both the
-``cute.compile`` options and the compile-cache key so the two always agree.
+The DSL resolves its default ``GPUArch`` from ``CUTE_DSL_ARCH`` or CUDA device 0, and
+binds each compiled artifact to the device current at its first call, so both the
+compile options and the compile-cache key have to name the operand's device.
 """
 
 import functools
 import os
+import re
 from typing import NamedTuple, Union
 
 import cutlass.cute as cute
 import torch
 
+_ARCH_RE = re.compile(r"^sm_(\d+)(\d)[a-z]?$")
+
 
 class GdnDeviceTarget(NamedTuple):
     """Architecture and launch policy of a single CUDA device."""
 
+    device_index: int
     arch: str
     major: int
     minor: int
     num_sms: int
     use_packed_fma: bool
 
+    @property
+    def compile_key(self) -> tuple:
+        """Compile-cache identity.
+
+        The device index is part of it because a compiled artifact is pinned to the
+        device it first ran on; two devices must not share one cache entry.
+        """
+        return (self.device_index, self.arch)
+
+
+def _arch_string(major: int, minor: int) -> str:
+    return f"sm_{major}{minor}{'a' if major >= 9 else ''}"
+
 
 @functools.lru_cache(maxsize=None)
 def _resolve(device_index: int) -> GdnDeviceTarget:
     major, minor = torch.cuda.get_device_capability(device_index)
-    # CUTE_DSL_ARCH is the DSL's own cross-compile override; keep it authoritative.
+    # CUTE_DSL_ARCH is the DSL's own cross-compile override; an explicit GPUArch would
+    # otherwise beat it, so honor it here and derive the policy from it too.
     env_arch = os.environ.get("CUTE_DSL_ARCH")
-    suffix = "a" if major >= 9 else ""
+    if env_arch:
+        match = _ARCH_RE.match(env_arch)
+        if match is None:
+            raise ValueError(f"CUTE_DSL_ARCH is not a recognized arch: {env_arch!r}")
+        major, minor = int(match.group(1)), int(match.group(2))
     return GdnDeviceTarget(
-        arch=env_arch or f"sm_{major}{minor}{suffix}",
+        device_index=device_index,
+        arch=env_arch or _arch_string(major, minor),
         major=major,
         minor=minor,
         num_sms=torch.cuda.get_device_properties(device_index).multi_processor_count,
@@ -41,10 +63,12 @@ def _resolve(device_index: int) -> GdnDeviceTarget:
 
 def gdn_device_target(device: Union[str, torch.device]) -> GdnDeviceTarget:
     """Resolve the compile target from an operand's device."""
-    d = torch.device(device)
-    if d.type != "cuda":
-        raise ValueError(f"GDN CuTe-DSL kernels require CUDA tensors, got {d}")
-    return _resolve(torch.cuda.current_device() if d.index is None else d.index)
+    if not isinstance(device, torch.device):
+        device = torch.device(device)
+    if device.type != "cuda":
+        raise ValueError(f"GDN CuTe-DSL kernels require CUDA tensors, got {device}")
+    index = device.index
+    return _resolve(torch.cuda.current_device() if index is None else index)
 
 
 @functools.lru_cache(maxsize=None)

--- a/flashinfer/gdn_kernels/device_target.py
+++ b/flashinfer/gdn_kernels/device_target.py
@@ -54,6 +54,45 @@ def _arch_string(major: int, minor: int) -> str:
     return f"sm_{major}{minor}{'a' if major >= 9 else ''}"
 
 
+def _dsl_runtime_arch() -> Union[str, None]:
+    """The arch the DSL will accept a JIT engine for, or ``None`` if unavailable."""
+    try:
+        from cutlass.cutlass_dsl import CuTeDSL
+
+        return CuTeDSL._get_dsl().envar.arch
+    except Exception:
+        return None
+
+
+def _check_dsl_can_run(target: GdnDeviceTarget) -> None:
+    """Reject a target the DSL would silently turn into a cross-compile.
+
+    The DSL builds a JIT engine only when its process-global arch (``CUTE_DSL_ARCH``,
+    else CUDA device 0) can run the requested target, so one process serves one
+    architecture. Without this the failure surfaces as an internal DSL error, or on
+    an unpinned build as ``cudaErrorNoKernelImageForDevice`` at launch.
+    """
+    runtime_arch = _dsl_runtime_arch()
+    if runtime_arch is None or runtime_arch == target.arch:
+        return
+    try:
+        from cutlass.base_dsl import Arch
+
+        if Arch.from_string(runtime_arch).can_run_binary_built_for(
+            Arch.from_string(target.arch)
+        ):
+            return
+    except Exception:
+        return
+    raise RuntimeError(
+        f"GDN CuTe-DSL cannot target cuda:{target.device_index} ({target.arch}): the "
+        f"CuTe DSL compiles this process for {runtime_arch}, taken from CUDA device 0 "
+        "unless CUTE_DSL_ARCH is set, and one process can only serve one architecture. "
+        f"Set CUTE_DSL_ARCH={target.arch} or restrict CUDA_VISIBLE_DEVICES to devices "
+        "of a single architecture."
+    )
+
+
 @functools.lru_cache(maxsize=None)
 def _resolve(device_index: int) -> GdnDeviceTarget:
     major, minor = torch.cuda.get_device_capability(device_index)
@@ -65,7 +104,7 @@ def _resolve(device_index: int) -> GdnDeviceTarget:
         if match is None:
             raise ValueError(f"CUTE_DSL_ARCH is not a recognized arch: {env_arch!r}")
         major, minor = int(match.group(1)), int(match.group(2))
-    return GdnDeviceTarget(
+    target = GdnDeviceTarget(
         device_index=device_index,
         arch=env_arch or _arch_string(major, minor),
         major=major,
@@ -73,6 +112,8 @@ def _resolve(device_index: int) -> GdnDeviceTarget:
         num_sms=torch.cuda.get_device_properties(device_index).multi_processor_count,
         use_packed_fma=major >= 10,
     )
+    _check_dsl_can_run(target)
+    return target
 
 
 def gdn_device_target(device: Union[str, torch.device]) -> GdnDeviceTarget:

--- a/flashinfer/gdn_kernels/device_target.py
+++ b/flashinfer/gdn_kernels/device_target.py
@@ -1,37 +1,73 @@
 """Per-device compile target and launch policy for the GDN CuTe-DSL kernels.
 
-The DSL resolves its default ``GPUArch`` from ``CUTE_DSL_ARCH`` or CUDA device 0,
-so kernels compiled for operands on another device could be built and tuned for
-the wrong GPU. Resolve one target from the operand device and use it for both the
-``cute.compile`` options and the compile-cache key so the two always agree.
+The DSL resolves its default ``GPUArch`` from ``CUTE_DSL_ARCH`` or CUDA device 0, so
+compile options have to name the operand's device or a kernel gets built for someone
+else's architecture. The compile-cache key names it for a separate reason, see
+:attr:`GdnDeviceTarget.compile_key`.
 """
 
 import functools
 import os
+import re
 from typing import NamedTuple, Union
 
 import cutlass.cute as cute
 import torch
 
+_ARCH_RE = re.compile(r"^sm_(\d+)(\d)[a-z]?$")
+
 
 class GdnDeviceTarget(NamedTuple):
     """Architecture and launch policy of a single CUDA device."""
 
+    device_index: int
     arch: str
     major: int
     minor: int
     num_sms: int
     use_packed_fma: bool
 
+    @property
+    def compile_key(self) -> tuple:
+        """Compile-cache identity.
+
+        The device index is part of it because these cache entries also hold
+        device-resident defaults that nothing else keys by device. The compiled
+        artifact itself is device agnostic from DSL 4.6.2 on: a TVM-FFI function's
+        ``to()`` returns itself, and ``CudaDialectJitCompiledFunction.to()`` ignores
+        its device argument and loads the cubin on every device.
+        """
+        return (self.device_index, self.arch)
+
+
+def target_arch(target_key: tuple) -> str:
+    """The arch component of :attr:`GdnDeviceTarget.compile_key`.
+
+    On-disk artifacts are per arch, so the device index -- which separates
+    in-process entries only -- must not reach a kernel's specialization name.
+    """
+    _device_index, arch = target_key
+    return arch
+
+
+def _arch_string(major: int, minor: int) -> str:
+    return f"sm_{major}{minor}{'a' if major >= 9 else ''}"
+
 
 @functools.lru_cache(maxsize=None)
 def _resolve(device_index: int) -> GdnDeviceTarget:
     major, minor = torch.cuda.get_device_capability(device_index)
-    # CUTE_DSL_ARCH is the DSL's own cross-compile override; keep it authoritative.
+    # CUTE_DSL_ARCH is the DSL's own cross-compile override; an explicit GPUArch would
+    # otherwise beat it, so honor it here and derive the policy from it too.
     env_arch = os.environ.get("CUTE_DSL_ARCH")
-    suffix = "a" if major >= 9 else ""
+    if env_arch:
+        match = _ARCH_RE.match(env_arch)
+        if match is None:
+            raise ValueError(f"CUTE_DSL_ARCH is not a recognized arch: {env_arch!r}")
+        major, minor = int(match.group(1)), int(match.group(2))
     return GdnDeviceTarget(
-        arch=env_arch or f"sm_{major}{minor}{suffix}",
+        device_index=device_index,
+        arch=env_arch or _arch_string(major, minor),
         major=major,
         minor=minor,
         num_sms=torch.cuda.get_device_properties(device_index).multi_processor_count,
@@ -41,10 +77,12 @@ def _resolve(device_index: int) -> GdnDeviceTarget:
 
 def gdn_device_target(device: Union[str, torch.device]) -> GdnDeviceTarget:
     """Resolve the compile target from an operand's device."""
-    d = torch.device(device)
-    if d.type != "cuda":
-        raise ValueError(f"GDN CuTe-DSL kernels require CUDA tensors, got {d}")
-    return _resolve(torch.cuda.current_device() if d.index is None else d.index)
+    if not isinstance(device, torch.device):
+        device = torch.device(device)
+    if device.type != "cuda":
+        raise ValueError(f"GDN CuTe-DSL kernels require CUDA tensors, got {device}")
+    index = device.index
+    return _resolve(torch.cuda.current_device() if index is None else index)
 
 
 @functools.lru_cache(maxsize=None)
@@ -61,4 +99,9 @@ def gdn_compile_options(device: Union[str, torch.device], *extra) -> tuple:
     return _arch_options(gdn_device_target(device).arch) + tuple(extra)
 
 
-__all__ = ["GdnDeviceTarget", "gdn_compile_options", "gdn_device_target"]
+__all__ = [
+    "GdnDeviceTarget",
+    "gdn_compile_options",
+    "gdn_device_target",
+    "target_arch",
+]

--- a/flashinfer/gdn_kernels/experimental/kernel/gdn_fused_decode_cutedsl_sm120_pdl.py
+++ b/flashinfer/gdn_kernels/experimental/kernel/gdn_fused_decode_cutedsl_sm120_pdl.py
@@ -48,6 +48,7 @@ import cuda.bindings.driver as cuda_driver
 from cutlass.cute.runtime import from_dlpack
 
 from ....cuda_utils import checkCudaErrors
+from ...device_target import gdn_compile_options
 from ._stream_order import order_after_previous_stream
 
 # The layer geometry (HIDDEN, N_BA, QKV_DIM, H_Q, HV, D) is a compile-time
@@ -536,7 +537,7 @@ def fused_launch(
 # conv-state stride mode -- and, for the workspace, by (geometry, batch size,
 # device).  The compiled-kernel value is whatever ``cute.compile`` returns,
 # which has no public static type.
-_compiled: dict[tuple[tuple, int, float, int], Any] = {}
+_compiled: dict[tuple[tuple, int, float, int, str], Any] = {}
 _workspace_cache: dict[tuple[tuple, int, str], tuple[torch.Tensor, torch.Tensor]] = {}
 _launch_count = 0
 
@@ -579,7 +580,13 @@ def _cache_has(
     AND the per-(geometry, B, device) workspace exists — i.e. a call is
     capture-safe (kernel launches plus one stream memset, no compilation or
     allocation)."""
-    return (geometry, int(B), float(scale), int(conv_leading_dim)) in _compiled and (
+    return (
+        geometry,
+        int(B),
+        float(scale),
+        int(conv_leading_dim),
+        str(device),
+    ) in _compiled and (
         geometry,
         int(B),
         str(device),
@@ -685,7 +692,7 @@ def execute(
     # static stride-1 mode differs).
     cs_ld = conv_state_leading_dim(conv_state)
 
-    key = (geometry, B, scale_f, cs_ld)
+    key = (geometry, B, scale_f, cs_ld, str(dev))
     fn = _compiled.get(key)
     if fn is None:
         # The DLPack markers exist only to describe the argument layouts to
@@ -708,7 +715,7 @@ def execute(
         m_out = from_dlpack(output, enable_tvm_ffi=True).mark_layout_dynamic()
         m_qa = from_dlpack(qkv_act, enable_tvm_ffi=True).mark_layout_dynamic()
         m_part = from_dlpack(part, enable_tvm_ffi=True).mark_layout_dynamic()
-        fn = cute.compile(
+        fn = cute.compile[gdn_compile_options(dev, cute.EnableTVMFFI(True))](
             fused_launch,
             m_hidden,
             m_wba,
@@ -732,7 +739,6 @@ def execute(
             H_Q,
             HV,
             D,
-            options="--enable-tvm-ffi",
         )
         _compiled[key] = fn
     fn(
@@ -769,7 +775,7 @@ def compiled_variant_keys() -> list:
     """Compiled-kernel descriptors resident in this process."""
     return [
         f"{_geometry_tag(geometry)}_b{B}_scale{scale}_ld{leading_dim}"
-        for (geometry, B, scale, leading_dim) in sorted(_compiled)
+        for (geometry, B, scale, leading_dim, _device) in sorted(_compiled)
     ]
 
 

--- a/flashinfer/gdn_kernels/gdn_decode_bf16_state.py
+++ b/flashinfer/gdn_kernels/gdn_decode_bf16_state.py
@@ -3179,7 +3179,7 @@ def gated_delta_rule_mtp_wide_vec(
         per_token_pool_scatter,
         per_token_pool_scatter_flat,
         _dtype_key(A_log, dt_bias, initial_state_indices),
-        target.arch,
+        target.compile_key,
     )
 
     if cache_key not in _compiled_kernels_wide_vec:
@@ -3464,7 +3464,7 @@ def gated_delta_rule_t1_wide_vec(
         use_packed_fma,
         same_pool,
         _dtype_key(A_log, dt_bias, initial_state_indices),
-        target.arch,
+        target.compile_key,
     )
 
     if cache_key not in _compiled_kernels_wide_vec:
@@ -3845,7 +3845,7 @@ def gated_delta_rule_mtp(
         per_token_pool_scatter,
         per_token_pool_scatter_flat,
         _dtype_key(A_log, dt_bias, initial_state_indices),
-        target.arch,
+        target.compile_key,
     )
 
     if cache_key not in _compiled_kernels_mtp:

--- a/flashinfer/gdn_kernels/gdn_decode_bf16_state.py
+++ b/flashinfer/gdn_kernels/gdn_decode_bf16_state.py
@@ -47,6 +47,7 @@ import cuda.bindings.driver as cuda
 import torch
 from cutlass.cute.runtime import from_dlpack
 
+from .device_target import gdn_compile_options, gdn_device_target
 from .dtype_compat import as_bf16
 
 
@@ -2699,13 +2700,11 @@ def _run_wide_vec_t1(
 # ==============================================================================
 # PUBLIC API
 # ==============================================================================
-# Number of SMs on target GPU (detected dynamically)
-NUM_SMS = torch.cuda.get_device_properties(0).multi_processor_count
-
-# GPU architecture detected once at import time — avoids per-call
-# torch.cuda.get_device_capability() in the hot path.
-_GPU_MAJOR, _ = torch.cuda.get_device_capability(0)
-_USE_PACKED_FMA = _GPU_MAJOR >= 10
+_BF16_STATE_COMPILE_OPTS = (
+    cute.EnableTVMFFI(True),
+    cute.GenerateLineInfo(True),
+    cute.OptLevel(3),
+)
 
 
 def gated_delta_rule(
@@ -2857,7 +2856,7 @@ def _dtype_key(
     )
 
 
-def _select_tile_v_for_mtp(B: int, HV: int, V: int, T: int = 1) -> int:
+def _select_tile_v_for_mtp(B: int, HV: int, V: int, T: int = 1, *, num_sms: int) -> int:
     """Select optimal tile_v for the MTP BF16 kernel based on batch size and T.
 
     tile_v must be a multiple of 4 * MTP_ILP4_ROWS (= 16) and divide V=128.
@@ -2869,13 +2868,13 @@ def _select_tile_v_for_mtp(B: int, HV: int, V: int, T: int = 1) -> int:
         num_v_tiles = V // tv
         grid_size = B * HV * num_v_tiles
         # Want at least 4 waves for good occupancy
-        if grid_size >= 4 * NUM_SMS:
+        if grid_size >= 4 * num_sms:
             return tv
     return 32  # Minimum tile_v for maximum parallelism
 
 
 def _get_bf16_mtp_config(
-    batch_size: int, seq_len: int, num_v_heads: int, v_dim: int
+    batch_size: int, seq_len: int, num_v_heads: int, v_dim: int, *, num_sms: int
 ) -> tuple:
     """Select ``(tile_v, ilp_rows)`` for the BF16 MTP kernel.
 
@@ -2895,7 +2894,12 @@ def _get_bf16_mtp_config(
     if work_units <= 128:
         # Tiny grid: small tile_v gives more CTAs to fill SMs.
         return min(16, v_dim), 4
-    return _select_tile_v_for_mtp(batch_size, num_v_heads, v_dim, seq_len), 4
+    return (
+        _select_tile_v_for_mtp(
+            batch_size, num_v_heads, v_dim, seq_len, num_sms=num_sms
+        ),
+        4,
+    )
 
 
 # Threshold above which `gated_delta_rule_mtp` dispatches to the wide_vec
@@ -3066,8 +3070,9 @@ def gated_delta_rule_mtp_wide_vec(
         intermediate_states = h0_source[:1, :1, :1]
         effective_disable_final = disable_state_update
 
-    stream = cuda.CUstream(torch.cuda.current_stream().cuda_stream)
-    use_packed_fma = _USE_PACKED_FMA
+    target = gdn_device_target(q.device)
+    stream = cuda.CUstream(torch.cuda.current_stream(device=q.device).cuda_stream)
+    use_packed_fma = target.use_packed_fma
     # Single-pool callers either pass output_state_indices=None (defaults to
     # initial_state_indices below) or pass the same tensor for both. In both
     # cases the kernel can elide write-side base-pointer arithmetic via the
@@ -3174,6 +3179,7 @@ def gated_delta_rule_mtp_wide_vec(
         per_token_pool_scatter,
         per_token_pool_scatter_flat,
         _dtype_key(A_log, dt_bias, initial_state_indices),
+        target.arch,
     )
 
     if cache_key not in _compiled_kernels_wide_vec:
@@ -3225,7 +3231,9 @@ def gated_delta_rule_mtp_wide_vec(
         )
 
         _compiled_kernels_wide_vec[cache_key] = {
-            "compiled": cute.compile(
+            "compiled": cute.compile[
+                gdn_compile_options(q.device, *_BF16_STATE_COMPILE_OPTS)
+            ](
                 _run_wide_vec,
                 h_,
                 inter_,
@@ -3261,7 +3269,6 @@ def gated_delta_rule_mtp_wide_vec(
                 per_token_pool_scatter,
                 per_token_pool_scatter_flat,
                 stream,
-                options="--enable-tvm-ffi --generate-line-info --opt-level 3",
             ),
             # Per-B default tensors (B-dependent shapes; can't be shared
             # across batch sizes — see #L bug at cache_key without B).
@@ -3418,8 +3425,9 @@ def gated_delta_rule_t1_wide_vec(
         intermediate_states = h0_source[:1, :1, :1]
         effective_disable_final = disable_state_update
 
-    stream = cuda.CUstream(torch.cuda.current_stream().cuda_stream)
-    use_packed_fma = _USE_PACKED_FMA
+    target = gdn_device_target(q.device)
+    stream = cuda.CUstream(torch.cuda.current_stream(device=q.device).cuda_stream)
+    use_packed_fma = target.use_packed_fma
     # Single-pool callers either pass output_state_indices=None (defaults to
     # initial_state_indices below) or pass the same tensor for both. In both
     # cases the kernel can elide write-side base-pointer arithmetic via the
@@ -3456,6 +3464,7 @@ def gated_delta_rule_t1_wide_vec(
         use_packed_fma,
         same_pool,
         _dtype_key(A_log, dt_bias, initial_state_indices),
+        target.arch,
     )
 
     if cache_key not in _compiled_kernels_wide_vec:
@@ -3494,7 +3503,9 @@ def gated_delta_rule_t1_wide_vec(
         h0_out_idx_ = h0_idx_
 
         _compiled_kernels_wide_vec[cache_key] = {
-            "compiled": cute.compile(
+            "compiled": cute.compile[
+                gdn_compile_options(q.device, *_BF16_STATE_COMPILE_OPTS)
+            ](
                 _run_wide_vec_t1,
                 h_,
                 inter_,
@@ -3523,7 +3534,6 @@ def gated_delta_rule_t1_wide_vec(
                 use_packed_fma,
                 same_pool,
                 stream,
-                options="--enable-tvm-ffi --generate-line-info --opt-level 3",
             ),
             # Per-B default tensors (B-dependent shapes — see batch-dynamic
             # correctness note in gated_delta_rule_mtp_wide_vec).
@@ -3780,10 +3790,11 @@ def gated_delta_rule_mtp(
     # redirected here). Falls to the ILP=4 MTP path
     # (mtp_ilp4_kernel), which natively supports both single- and
     # split-pool, so the config picker is independent of pool mode.
-    tile_v, ilp_rows = _get_bf16_mtp_config(B, T, HV, V)
+    target = gdn_device_target(q.device)
+    tile_v, ilp_rows = _get_bf16_mtp_config(B, T, HV, V, num_sms=target.num_sms)
 
-    stream = cuda.CUstream(torch.cuda.current_stream().cuda_stream)
-    use_packed_fma = _USE_PACKED_FMA
+    stream = cuda.CUstream(torch.cuda.current_stream(device=q.device).cuda_stream)
+    use_packed_fma = target.use_packed_fma
     # Set same_pool=True when reads and writes alias (single-pool); the
     # kernel then DCEs write-side base-pointer arithmetic.
     same_pool = (
@@ -3834,6 +3845,7 @@ def gated_delta_rule_mtp(
         per_token_pool_scatter,
         per_token_pool_scatter_flat,
         _dtype_key(A_log, dt_bias, initial_state_indices),
+        target.arch,
     )
 
     if cache_key not in _compiled_kernels_mtp:
@@ -3885,7 +3897,9 @@ def gated_delta_rule_mtp(
         )
 
         _compiled_kernels_mtp[cache_key] = {
-            "compiled": cute.compile(
+            "compiled": cute.compile[
+                gdn_compile_options(q.device, *_BF16_STATE_COMPILE_OPTS)
+            ](
                 run_gdn_decode_bf16state_mtp_ilp4,
                 h_,
                 inter_,
@@ -3920,7 +3934,6 @@ def gated_delta_rule_mtp(
                 per_token_pool_scatter,
                 per_token_pool_scatter_flat,
                 stream,
-                options="--enable-tvm-ffi --generate-line-info --opt-level 3",
             ),
             # Per-B default tensors (B-dependent shapes — see batch-dynamic
             # correctness note in gated_delta_rule_mtp_wide_vec).

--- a/flashinfer/gdn_kernels/gdn_decode_bf16_state.py
+++ b/flashinfer/gdn_kernels/gdn_decode_bf16_state.py
@@ -47,7 +47,7 @@ import cuda.bindings.driver as cuda
 import torch
 from cutlass.cute.runtime import from_dlpack
 
-from .device_target import gdn_compile_options, gdn_device_target
+from .device_target import gdn_compile_options, gdn_device_target, target_arch
 from .dtype_compat import as_bf16
 from ..jit.cute_dsl_core import build_and_load_cute_dsl_kernel
 from .cute_dsl_cache_naming import make_kernel_name
@@ -2853,8 +2853,11 @@ def _bf16_state_kernel_name(variant: str, cache_key: tuple) -> str:
     ``variant`` distinguishes the compiled entry points sharing this module
     ("wide_vec", "wide_vec_t1", "mtp_ilp4"); ``cache_key`` is the in-process
     cache tuple, which already encodes every parameter that affects codegen.
+    Its last component is the compile target, of which only the arch names an
+    artifact.
     """
-    return make_kernel_name(variant, *cache_key)
+    *codegen, target_key = cache_key
+    return make_kernel_name(variant, target_arch(target_key), *codegen)
 
 
 def _dtype_key(
@@ -3193,7 +3196,7 @@ def gated_delta_rule_mtp_wide_vec(
         per_token_pool_scatter,
         per_token_pool_scatter_flat,
         _dtype_key(A_log, dt_bias, initial_state_indices),
-        target.arch,
+        target.compile_key,
     )
 
     if cache_key not in _compiled_kernels_wide_vec:
@@ -3483,7 +3486,7 @@ def gated_delta_rule_t1_wide_vec(
         use_packed_fma,
         same_pool,
         _dtype_key(A_log, dt_bias, initial_state_indices),
-        target.arch,
+        target.compile_key,
     )
 
     if cache_key not in _compiled_kernels_wide_vec:
@@ -3869,7 +3872,7 @@ def gated_delta_rule_mtp(
         per_token_pool_scatter,
         per_token_pool_scatter_flat,
         _dtype_key(A_log, dt_bias, initial_state_indices),
-        target.arch,
+        target.compile_key,
     )
 
     if cache_key not in _compiled_kernels_mtp:

--- a/flashinfer/gdn_kernels/gdn_decode_bf16_state.py
+++ b/flashinfer/gdn_kernels/gdn_decode_bf16_state.py
@@ -47,6 +47,7 @@ import cuda.bindings.driver as cuda
 import torch
 from cutlass.cute.runtime import from_dlpack
 
+from .device_target import gdn_compile_options, gdn_device_target
 from .dtype_compat import as_bf16
 from ..jit.cute_dsl_core import build_and_load_cute_dsl_kernel
 from .cute_dsl_cache_naming import make_kernel_name
@@ -2701,13 +2702,11 @@ def _run_wide_vec_t1(
 # ==============================================================================
 # PUBLIC API
 # ==============================================================================
-# Number of SMs on target GPU (detected dynamically)
-NUM_SMS = torch.cuda.get_device_properties(0).multi_processor_count
-
-# GPU architecture detected once at import time — avoids per-call
-# torch.cuda.get_device_capability() in the hot path.
-_GPU_MAJOR, _ = torch.cuda.get_device_capability(0)
-_USE_PACKED_FMA = _GPU_MAJOR >= 10
+_BF16_STATE_COMPILE_OPTS = (
+    cute.EnableTVMFFI(True),
+    cute.GenerateLineInfo(True),
+    cute.OptLevel(3),
+)
 
 
 def gated_delta_rule(
@@ -2871,7 +2870,7 @@ def _dtype_key(
     )
 
 
-def _select_tile_v_for_mtp(B: int, HV: int, V: int, T: int = 1) -> int:
+def _select_tile_v_for_mtp(B: int, HV: int, V: int, T: int = 1, *, num_sms: int) -> int:
     """Select optimal tile_v for the MTP BF16 kernel based on batch size and T.
 
     tile_v must be a multiple of 4 * MTP_ILP4_ROWS (= 16) and divide V=128.
@@ -2883,13 +2882,13 @@ def _select_tile_v_for_mtp(B: int, HV: int, V: int, T: int = 1) -> int:
         num_v_tiles = V // tv
         grid_size = B * HV * num_v_tiles
         # Want at least 4 waves for good occupancy
-        if grid_size >= 4 * NUM_SMS:
+        if grid_size >= 4 * num_sms:
             return tv
     return 32  # Minimum tile_v for maximum parallelism
 
 
 def _get_bf16_mtp_config(
-    batch_size: int, seq_len: int, num_v_heads: int, v_dim: int
+    batch_size: int, seq_len: int, num_v_heads: int, v_dim: int, *, num_sms: int
 ) -> tuple:
     """Select ``(tile_v, ilp_rows)`` for the BF16 MTP kernel.
 
@@ -2909,7 +2908,12 @@ def _get_bf16_mtp_config(
     if work_units <= 128:
         # Tiny grid: small tile_v gives more CTAs to fill SMs.
         return min(16, v_dim), 4
-    return _select_tile_v_for_mtp(batch_size, num_v_heads, v_dim, seq_len), 4
+    return (
+        _select_tile_v_for_mtp(
+            batch_size, num_v_heads, v_dim, seq_len, num_sms=num_sms
+        ),
+        4,
+    )
 
 
 # Threshold above which `gated_delta_rule_mtp` dispatches to the wide_vec
@@ -3080,8 +3084,9 @@ def gated_delta_rule_mtp_wide_vec(
         intermediate_states = h0_source[:1, :1, :1]
         effective_disable_final = disable_state_update
 
-    stream = cuda.CUstream(torch.cuda.current_stream().cuda_stream)
-    use_packed_fma = _USE_PACKED_FMA
+    target = gdn_device_target(q.device)
+    stream = cuda.CUstream(torch.cuda.current_stream(device=q.device).cuda_stream)
+    use_packed_fma = target.use_packed_fma
     # Single-pool callers either pass output_state_indices=None (defaults to
     # initial_state_indices below) or pass the same tensor for both. In both
     # cases the kernel can elide write-side base-pointer arithmetic via the
@@ -3188,6 +3193,7 @@ def gated_delta_rule_mtp_wide_vec(
         per_token_pool_scatter,
         per_token_pool_scatter_flat,
         _dtype_key(A_log, dt_bias, initial_state_indices),
+        target.arch,
     )
 
     if cache_key not in _compiled_kernels_wide_vec:
@@ -3242,7 +3248,9 @@ def gated_delta_rule_mtp_wide_vec(
             "compiled": build_and_load_cute_dsl_kernel(
                 _CUTE_DSL_MODULE,
                 _bf16_state_kernel_name("wide_vec", cache_key),
-                lambda: cute.compile(
+                lambda: cute.compile[
+                    gdn_compile_options(q.device, *_BF16_STATE_COMPILE_OPTS)
+                ](
                     _run_wide_vec,
                     h_,
                     inter_,
@@ -3278,7 +3286,6 @@ def gated_delta_rule_mtp_wide_vec(
                     per_token_pool_scatter,
                     per_token_pool_scatter_flat,
                     stream,
-                    options="--enable-tvm-ffi --generate-line-info --opt-level 3",
                 ),
                 extra_key_files=(__file__,),
             ),
@@ -3437,8 +3444,9 @@ def gated_delta_rule_t1_wide_vec(
         intermediate_states = h0_source[:1, :1, :1]
         effective_disable_final = disable_state_update
 
-    stream = cuda.CUstream(torch.cuda.current_stream().cuda_stream)
-    use_packed_fma = _USE_PACKED_FMA
+    target = gdn_device_target(q.device)
+    stream = cuda.CUstream(torch.cuda.current_stream(device=q.device).cuda_stream)
+    use_packed_fma = target.use_packed_fma
     # Single-pool callers either pass output_state_indices=None (defaults to
     # initial_state_indices below) or pass the same tensor for both. In both
     # cases the kernel can elide write-side base-pointer arithmetic via the
@@ -3475,6 +3483,7 @@ def gated_delta_rule_t1_wide_vec(
         use_packed_fma,
         same_pool,
         _dtype_key(A_log, dt_bias, initial_state_indices),
+        target.arch,
     )
 
     if cache_key not in _compiled_kernels_wide_vec:
@@ -3516,7 +3525,9 @@ def gated_delta_rule_t1_wide_vec(
             "compiled": build_and_load_cute_dsl_kernel(
                 _CUTE_DSL_MODULE,
                 _bf16_state_kernel_name("wide_vec_t1", cache_key),
-                lambda: cute.compile(
+                lambda: cute.compile[
+                    gdn_compile_options(q.device, *_BF16_STATE_COMPILE_OPTS)
+                ](
                     _run_wide_vec_t1,
                     h_,
                     inter_,
@@ -3545,7 +3556,6 @@ def gated_delta_rule_t1_wide_vec(
                     use_packed_fma,
                     same_pool,
                     stream,
-                    options="--enable-tvm-ffi --generate-line-info --opt-level 3",
                 ),
                 extra_key_files=(__file__,),
             ),
@@ -3804,10 +3814,11 @@ def gated_delta_rule_mtp(
     # redirected here). Falls to the ILP=4 MTP path
     # (mtp_ilp4_kernel), which natively supports both single- and
     # split-pool, so the config picker is independent of pool mode.
-    tile_v, ilp_rows = _get_bf16_mtp_config(B, T, HV, V)
+    target = gdn_device_target(q.device)
+    tile_v, ilp_rows = _get_bf16_mtp_config(B, T, HV, V, num_sms=target.num_sms)
 
-    stream = cuda.CUstream(torch.cuda.current_stream().cuda_stream)
-    use_packed_fma = _USE_PACKED_FMA
+    stream = cuda.CUstream(torch.cuda.current_stream(device=q.device).cuda_stream)
+    use_packed_fma = target.use_packed_fma
     # Set same_pool=True when reads and writes alias (single-pool); the
     # kernel then DCEs write-side base-pointer arithmetic.
     same_pool = (
@@ -3858,6 +3869,7 @@ def gated_delta_rule_mtp(
         per_token_pool_scatter,
         per_token_pool_scatter_flat,
         _dtype_key(A_log, dt_bias, initial_state_indices),
+        target.arch,
     )
 
     if cache_key not in _compiled_kernels_mtp:
@@ -3912,7 +3924,9 @@ def gated_delta_rule_mtp(
             "compiled": build_and_load_cute_dsl_kernel(
                 _CUTE_DSL_MODULE,
                 _bf16_state_kernel_name("mtp_ilp4", cache_key),
-                lambda: cute.compile(
+                lambda: cute.compile[
+                    gdn_compile_options(q.device, *_BF16_STATE_COMPILE_OPTS)
+                ](
                     run_gdn_decode_bf16state_mtp_ilp4,
                     h_,
                     inter_,
@@ -3947,7 +3961,6 @@ def gated_delta_rule_mtp(
                     per_token_pool_scatter,
                     per_token_pool_scatter_flat,
                     stream,
-                    options="--enable-tvm-ffi --generate-line-info --opt-level 3",
                 ),
                 extra_key_files=(__file__,),
             ),

--- a/flashinfer/gdn_kernels/gdn_decode_bf16_wy_output_only.py
+++ b/flashinfer/gdn_kernels/gdn_decode_bf16_wy_output_only.py
@@ -47,10 +47,9 @@ from cutlass.cute.typing import Int32, Int64
 from cutlass._mlir.dialects import llvm
 from cutlass.cutlass_dsl import T as mlir_T
 
+from .device_target import gdn_compile_options
 from .dtype_compat import as_bf16
 
-
-device = torch.device("cuda:0")
 
 # Fixed dims matching Triton v5
 T = 16
@@ -1947,8 +1946,7 @@ _CACHE: dict = {}
 
 
 def _compile_options(device: torch.device) -> tuple:
-    major, minor = torch.cuda.get_device_capability(device)
-    return (cute.GPUArch(f"sm_{major}{minor}a"),) if major == 12 else ()
+    return gdn_compile_options(device)
 
 
 # Persistent pre-zeroed T=16 input staging buffers for the T<16 path, keyed by
@@ -2332,12 +2330,7 @@ def gated_delta_rule_mtp(
             qkv_row_stride=_qkv_rs,
             ab_native=_ab_native_flag,
         )
-        options = _compile_options(device)
-        _CACHE[cache_key] = (
-            cute.compile[options](kernel, *args)
-            if options
-            else cute.compile(kernel, *args)
-        )
+        _CACHE[cache_key] = cute.compile[_compile_options(device)](kernel, *args)
     _CACHE[cache_key](*args)
 
     if output is None:

--- a/flashinfer/gdn_kernels/gdn_decode_bf16_wy_output_only.py
+++ b/flashinfer/gdn_kernels/gdn_decode_bf16_wy_output_only.py
@@ -47,7 +47,7 @@ from cutlass.cute.typing import Int32, Int64
 from cutlass._mlir.dialects import llvm
 from cutlass.cutlass_dsl import T as mlir_T
 
-from .device_target import gdn_compile_options
+from .device_target import gdn_compile_options, gdn_device_target
 from .dtype_compat import as_bf16
 
 
@@ -1945,10 +1945,6 @@ class GdnDecodeKernel:
 _CACHE: dict = {}
 
 
-def _compile_options(device: torch.device) -> tuple:
-    return gdn_compile_options(device)
-
-
 # Persistent pre-zeroed T=16 input staging buffers for the T<16 path, keyed by
 # (device, B, H, HK, HV, K, V, dtype, T). Reused across calls so short-T decode
 # pays only a T-row copy-in (no per-call F.pad realloc/re-zero).
@@ -2232,7 +2228,8 @@ def gated_delta_rule_mtp(
                 bb[:, :T].copy_(b)
             q, k, v, a, b = qb, kb, vb, ab, bb
 
-    _num_sms = torch.cuda.get_device_properties(device).multi_processor_count
+    target = gdn_device_target(device)
+    _num_sms = target.num_sms
     # One CTA per (b, hv) — full V tile per CTA. Per-CTA SMEM ~29.8 KB -> <=7 CTAs/SM (ncu, B200).
     _total_ctas = HV * B
     _needed = math.ceil(_total_ctas / _num_sms)
@@ -2259,10 +2256,8 @@ def gated_delta_rule_mtp(
     # compile and read H0 with the wrong strides -> ~3e-01 garbage outputs. Found
     # by the intense correctness sweep; invisible to the tests/benches, which use
     # one HV per process.
-    cc = torch.cuda.get_device_capability(device)
     cache_key: tuple = (
-        str(device),
-        cc,
+        target.compile_key,
         mbp,
         t_disc,
         n_valid,
@@ -2330,7 +2325,7 @@ def gated_delta_rule_mtp(
             qkv_row_stride=_qkv_rs,
             ab_native=_ab_native_flag,
         )
-        _CACHE[cache_key] = cute.compile[_compile_options(device)](kernel, *args)
+        _CACHE[cache_key] = cute.compile[gdn_compile_options(device)](kernel, *args)
     _CACHE[cache_key](*args)
 
     if output is None:

--- a/flashinfer/gdn_kernels/gdn_decode_bf16_wy_output_only.py
+++ b/flashinfer/gdn_kernels/gdn_decode_bf16_wy_output_only.py
@@ -47,10 +47,9 @@ from cutlass.cute.typing import Int32, Int64
 from cutlass._mlir.dialects import llvm
 from cutlass.cutlass_dsl import T as mlir_T
 
+from .device_target import gdn_compile_options
 from .dtype_compat import as_bf16
 
-
-device = torch.device("cuda:0")
 
 # Fixed dims matching Triton v5
 T = 16
@@ -1947,8 +1946,7 @@ _CACHE: dict = {}
 
 
 def _compile_options(device: torch.device) -> tuple:
-    major, minor = torch.cuda.get_device_capability(device)
-    return (cute.GPUArch(f"sm_{major}{minor}a"),) if major == 12 else ()
+    return gdn_compile_options(device)
 
 
 # Persistent pre-zeroed T=16 input staging buffers for the T<16 path, keyed by
@@ -2353,12 +2351,7 @@ def gated_delta_rule_mtp(
             qkv_row_stride=_qkv_rs,
             ab_native=_ab_native_flag,
         )
-        options = _compile_options(device)
-        _CACHE[cache_key] = (
-            cute.compile[options](kernel, *args)
-            if options
-            else cute.compile(kernel, *args)
-        )
+        _CACHE[cache_key] = cute.compile[_compile_options(device)](kernel, *args)
     _CACHE[cache_key](*args)
 
     if output is None:

--- a/flashinfer/gdn_kernels/gdn_decode_bf16_wy_output_only.py
+++ b/flashinfer/gdn_kernels/gdn_decode_bf16_wy_output_only.py
@@ -47,7 +47,7 @@ from cutlass.cute.typing import Int32, Int64
 from cutlass._mlir.dialects import llvm
 from cutlass.cutlass_dsl import T as mlir_T
 
-from .device_target import gdn_compile_options
+from .device_target import gdn_compile_options, gdn_device_target
 from .dtype_compat import as_bf16
 
 
@@ -1945,10 +1945,6 @@ class GdnDecodeKernel:
 _CACHE: dict = {}
 
 
-def _compile_options(device: torch.device) -> tuple:
-    return gdn_compile_options(device)
-
-
 # Persistent pre-zeroed T=16 input staging buffers for the T<16 path, keyed by
 # (stream, device, B, H, HK, HV, K, V, dtype, T). Reused across calls so short-T
 # decode pays only a T-row copy-in (no per-call F.pad realloc/re-zero). The
@@ -2253,7 +2249,8 @@ def gated_delta_rule_mtp(
                 bb[:, :T].copy_(b)
             q, k, v, a, b = qb, kb, vb, ab, bb
 
-    _num_sms = torch.cuda.get_device_properties(device).multi_processor_count
+    target = gdn_device_target(device)
+    _num_sms = target.num_sms
     # One CTA per (b, hv) — full V tile per CTA. Per-CTA SMEM ~29.8 KB -> <=7 CTAs/SM (ncu, B200).
     _total_ctas = HV * B
     _needed = math.ceil(_total_ctas / _num_sms)
@@ -2280,10 +2277,8 @@ def gated_delta_rule_mtp(
     # compile and read H0 with the wrong strides -> ~3e-01 garbage outputs. Found
     # by the intense correctness sweep; invisible to the tests/benches, which use
     # one HV per process.
-    cc = torch.cuda.get_device_capability(device)
     cache_key: tuple = (
-        str(device),
-        cc,
+        target.compile_key,
         mbp,
         t_disc,
         n_valid,
@@ -2351,7 +2346,7 @@ def gated_delta_rule_mtp(
             qkv_row_stride=_qkv_rs,
             ab_native=_ab_native_flag,
         )
-        _CACHE[cache_key] = cute.compile[_compile_options(device)](kernel, *args)
+        _CACHE[cache_key] = cute.compile[gdn_compile_options(device)](kernel, *args)
     _CACHE[cache_key](*args)
 
     if output is None:

--- a/flashinfer/gdn_kernels/gdn_decode_bf16_wy_ucache.py
+++ b/flashinfer/gdn_kernels/gdn_decode_bf16_wy_ucache.py
@@ -85,7 +85,7 @@ from cutlass.cute.typing import Int32, Int64
 from cutlass._mlir.dialects import llvm
 from cutlass.cutlass_dsl import T as mlir_T
 
-from .device_target import gdn_compile_options
+from .device_target import gdn_compile_options, gdn_device_target
 
 
 # Problem dimensions. One CTA processes a full V tile per (request, head).
@@ -2676,7 +2676,8 @@ def gated_delta_rule_mtp_ucache(
                 bb[:, :T].copy_(b)
             q, k, v, a, b = qb, kb, vb, ab, bb
 
-    _num_sms = torch.cuda.get_device_properties(device).multi_processor_count
+    target = gdn_device_target(device)
+    _num_sms = target.num_sms
     # One CTA per (b, hv) — full V tile per CTA. Per-CTA SMEM ~29.8 KB -> <=7 CTAs/SM.
     _total_ctas = HV * B
     _needed = math.ceil(_total_ctas / _num_sms)
@@ -2706,7 +2707,7 @@ def gated_delta_rule_mtp_ucache(
     # process mixing HV values would otherwise reuse a cubin with the wrong strides.
     cache_key: tuple = (
         "ucache-v1",
-        str(device),
+        target.compile_key,
         # io dtype: constant bf16 today (asserted at entry), keyed so a future
         # dtype-specialized body can never alias cubins across dtypes (GDN-C3).
         str(_io_dtype),

--- a/flashinfer/gdn_kernels/gdn_decode_bf16_wy_ucache.py
+++ b/flashinfer/gdn_kernels/gdn_decode_bf16_wy_ucache.py
@@ -85,8 +85,8 @@ from cutlass.cute.typing import Int32, Int64
 from cutlass._mlir.dialects import llvm
 from cutlass.cutlass_dsl import T as mlir_T
 
+from .device_target import gdn_compile_options
 
-device = torch.device("cuda:0")
 
 # Problem dimensions. One CTA processes a full V tile per (request, head).
 T = 16
@@ -2789,7 +2789,7 @@ def gated_delta_rule_mtp_ucache(
     ]
 
     if cache_key not in _CACHE:
-        _CACHE[cache_key] = cute.compile(
+        _CACHE[cache_key] = cute.compile[gdn_compile_options(device)](
             GdnDecodeUCacheKernel(
                 disable_state_update=True,
                 min_blocks_per_mp=mbp,

--- a/flashinfer/gdn_kernels/gdn_decode_bf16_wy_ucache.py
+++ b/flashinfer/gdn_kernels/gdn_decode_bf16_wy_ucache.py
@@ -85,7 +85,13 @@ from cutlass.cute.typing import Int32, Int64
 from cutlass._mlir.dialects import llvm
 from cutlass.cutlass_dsl import T as mlir_T
 
-from .device_target import gdn_compile_options, gdn_device_target
+try:
+    from .device_target import gdn_compile_options, gdn_device_target
+except ImportError:  # tests and benchmarks load this file by path, outside the package
+    from flashinfer.gdn_kernels.device_target import (
+        gdn_compile_options,
+        gdn_device_target,
+    )
 
 
 # Problem dimensions. One CTA processes a full V tile per (request, head).

--- a/flashinfer/gdn_kernels/gdn_decode_bf16_wy_ucache.py
+++ b/flashinfer/gdn_kernels/gdn_decode_bf16_wy_ucache.py
@@ -84,8 +84,8 @@ from cutlass.cute.typing import Int32, Int64
 from cutlass._mlir.dialects import llvm
 from cutlass.cutlass_dsl import T as mlir_T
 
+from .device_target import gdn_compile_options
 
-device = torch.device("cuda:0")
 
 # Problem dimensions. One CTA processes a full V tile per (request, head).
 T = 16
@@ -2788,7 +2788,7 @@ def gated_delta_rule_mtp_ucache(
     ]
 
     if cache_key not in _CACHE:
-        _CACHE[cache_key] = cute.compile(
+        _CACHE[cache_key] = cute.compile[gdn_compile_options(device)](
             GdnDecodeUCacheKernel(
                 disable_state_update=True,
                 min_blocks_per_mp=mbp,

--- a/flashinfer/gdn_kernels/gdn_decode_bf16_wy_ucache.py
+++ b/flashinfer/gdn_kernels/gdn_decode_bf16_wy_ucache.py
@@ -84,7 +84,7 @@ from cutlass.cute.typing import Int32, Int64
 from cutlass._mlir.dialects import llvm
 from cutlass.cutlass_dsl import T as mlir_T
 
-from .device_target import gdn_compile_options
+from .device_target import gdn_compile_options, gdn_device_target
 
 
 # Problem dimensions. One CTA processes a full V tile per (request, head).
@@ -2675,7 +2675,8 @@ def gated_delta_rule_mtp_ucache(
                 bb[:, :T].copy_(b)
             q, k, v, a, b = qb, kb, vb, ab, bb
 
-    _num_sms = torch.cuda.get_device_properties(device).multi_processor_count
+    target = gdn_device_target(device)
+    _num_sms = target.num_sms
     # One CTA per (b, hv) — full V tile per CTA. Per-CTA SMEM ~29.8 KB -> <=7 CTAs/SM.
     _total_ctas = HV * B
     _needed = math.ceil(_total_ctas / _num_sms)
@@ -2705,7 +2706,7 @@ def gated_delta_rule_mtp_ucache(
     # process mixing HV values would otherwise reuse a cubin with the wrong strides.
     cache_key: tuple = (
         "ucache-v1",
-        str(device),
+        target.compile_key,
         # io dtype: constant bf16 today (asserted at entry), keyed so a future
         # dtype-specialized body can never alias cubins across dtypes (GDN-C3).
         str(_io_dtype),

--- a/flashinfer/gdn_kernels/gdn_decode_bf16_wy_ucache.py
+++ b/flashinfer/gdn_kernels/gdn_decode_bf16_wy_ucache.py
@@ -84,7 +84,13 @@ from cutlass.cute.typing import Int32, Int64
 from cutlass._mlir.dialects import llvm
 from cutlass.cutlass_dsl import T as mlir_T
 
-from .device_target import gdn_compile_options, gdn_device_target
+try:
+    from .device_target import gdn_compile_options, gdn_device_target
+except ImportError:  # tests and benchmarks load this file by path, outside the package
+    from flashinfer.gdn_kernels.device_target import (
+        gdn_compile_options,
+        gdn_device_target,
+    )
 
 
 # Problem dimensions. One CTA processes a full V tile per (request, head).

--- a/flashinfer/gdn_kernels/gdn_decode_bf16_wy_ucache_flush.py
+++ b/flashinfer/gdn_kernels/gdn_decode_bf16_wy_ucache_flush.py
@@ -125,7 +125,7 @@ from cutlass.cute.typing import Int32, Int64
 from cutlass._mlir.dialects import llvm
 from cutlass.cutlass_dsl import T as mlir_T
 
-from .device_target import gdn_compile_options
+from .device_target import gdn_compile_options, gdn_device_target
 
 
 # Problem dimensions. One CTA processes a full V tile per (request, head).
@@ -3575,7 +3575,8 @@ def gated_delta_rule_mtp_ucache_flush(
                 bb[:, :T].copy_(b)
             q, k, v, a, b = qb, kb, vb, ab, bb
 
-    _num_sms = torch.cuda.get_device_properties(device).multi_processor_count
+    target = gdn_device_target(device)
+    _num_sms = target.num_sms
     # One CTA per (b, hv) — full V tile per CTA. Per-CTA SMEM ~29.8 KB -> <=7 CTAs/SM.
     _total_ctas = HV * B
     _needed = math.ceil(_total_ctas / _num_sms)
@@ -3609,7 +3610,7 @@ def gated_delta_rule_mtp_ucache_flush(
         str(IO_TORCH),
         str(ST_TORCH),
         str(RING_TORCH),
-        str(device),
+        target.compile_key,
         mbp,
         t_disc,
         n_valid,

--- a/flashinfer/gdn_kernels/gdn_decode_bf16_wy_ucache_flush.py
+++ b/flashinfer/gdn_kernels/gdn_decode_bf16_wy_ucache_flush.py
@@ -125,8 +125,8 @@ from cutlass.cute.typing import Int32, Int64
 from cutlass._mlir.dialects import llvm
 from cutlass.cutlass_dsl import T as mlir_T
 
+from .device_target import gdn_compile_options
 
-device = torch.device("cuda:0")
 
 # Problem dimensions. One CTA processes a full V tile per (request, head).
 T = 16
@@ -3706,7 +3706,7 @@ def gated_delta_rule_mtp_ucache_flush(
     ]
 
     if cache_key not in _CACHE:
-        _CACHE[cache_key] = cute.compile(
+        _CACHE[cache_key] = cute.compile[gdn_compile_options(device)](
             GdnDecodeUCacheFlushKernel(
                 disable_state_update=True,
                 min_blocks_per_mp=mbp,

--- a/flashinfer/gdn_kernels/gdn_decode_bf16_wy_ucache_flush.py
+++ b/flashinfer/gdn_kernels/gdn_decode_bf16_wy_ucache_flush.py
@@ -125,7 +125,13 @@ from cutlass.cute.typing import Int32, Int64
 from cutlass._mlir.dialects import llvm
 from cutlass.cutlass_dsl import T as mlir_T
 
-from .device_target import gdn_compile_options, gdn_device_target
+try:
+    from .device_target import gdn_compile_options, gdn_device_target
+except ImportError:  # tests and benchmarks load this file by path, outside the package
+    from flashinfer.gdn_kernels.device_target import (
+        gdn_compile_options,
+        gdn_device_target,
+    )
 
 
 # Problem dimensions. One CTA processes a full V tile per (request, head).

--- a/flashinfer/gdn_kernels/gdn_decode_bf16_wy_ucache_flush.py
+++ b/flashinfer/gdn_kernels/gdn_decode_bf16_wy_ucache_flush.py
@@ -124,7 +124,13 @@ from cutlass.cute.typing import Int32, Int64
 from cutlass._mlir.dialects import llvm
 from cutlass.cutlass_dsl import T as mlir_T
 
-from .device_target import gdn_compile_options, gdn_device_target
+try:
+    from .device_target import gdn_compile_options, gdn_device_target
+except ImportError:  # tests and benchmarks load this file by path, outside the package
+    from flashinfer.gdn_kernels.device_target import (
+        gdn_compile_options,
+        gdn_device_target,
+    )
 
 
 # Problem dimensions. One CTA processes a full V tile per (request, head).

--- a/flashinfer/gdn_kernels/gdn_decode_bf16_wy_ucache_flush.py
+++ b/flashinfer/gdn_kernels/gdn_decode_bf16_wy_ucache_flush.py
@@ -124,8 +124,8 @@ from cutlass.cute.typing import Int32, Int64
 from cutlass._mlir.dialects import llvm
 from cutlass.cutlass_dsl import T as mlir_T
 
+from .device_target import gdn_compile_options
 
-device = torch.device("cuda:0")
 
 # Problem dimensions. One CTA processes a full V tile per (request, head).
 T = 16
@@ -3705,7 +3705,7 @@ def gated_delta_rule_mtp_ucache_flush(
     ]
 
     if cache_key not in _CACHE:
-        _CACHE[cache_key] = cute.compile(
+        _CACHE[cache_key] = cute.compile[gdn_compile_options(device)](
             GdnDecodeUCacheFlushKernel(
                 disable_state_update=True,
                 min_blocks_per_mp=mbp,

--- a/flashinfer/gdn_kernels/gdn_decode_bf16_wy_ucache_flush.py
+++ b/flashinfer/gdn_kernels/gdn_decode_bf16_wy_ucache_flush.py
@@ -124,7 +124,7 @@ from cutlass.cute.typing import Int32, Int64
 from cutlass._mlir.dialects import llvm
 from cutlass.cutlass_dsl import T as mlir_T
 
-from .device_target import gdn_compile_options
+from .device_target import gdn_compile_options, gdn_device_target
 
 
 # Problem dimensions. One CTA processes a full V tile per (request, head).
@@ -3574,7 +3574,8 @@ def gated_delta_rule_mtp_ucache_flush(
                 bb[:, :T].copy_(b)
             q, k, v, a, b = qb, kb, vb, ab, bb
 
-    _num_sms = torch.cuda.get_device_properties(device).multi_processor_count
+    target = gdn_device_target(device)
+    _num_sms = target.num_sms
     # One CTA per (b, hv) — full V tile per CTA. Per-CTA SMEM ~29.8 KB -> <=7 CTAs/SM.
     _total_ctas = HV * B
     _needed = math.ceil(_total_ctas / _num_sms)
@@ -3608,7 +3609,7 @@ def gated_delta_rule_mtp_ucache_flush(
         str(IO_TORCH),
         str(ST_TORCH),
         str(RING_TORCH),
-        str(device),
+        target.compile_key,
         mbp,
         t_disc,
         n_valid,

--- a/flashinfer/gdn_kernels/gdn_decode_mtp.py
+++ b/flashinfer/gdn_kernels/gdn_decode_mtp.py
@@ -46,6 +46,7 @@ import cutlass.cute as cute
 from cutlass.cute.runtime import from_dlpack
 import cuda.bindings.driver as cuda
 
+from .device_target import gdn_compile_options, gdn_device_target
 from .dtype_compat import as_bf16
 
 # ============================================================================
@@ -2517,6 +2518,7 @@ def _get_compiled_mtp_kernel(
     use_smem_v: bool = False,
     use_packed_fma: bool = True,
     per_token_pool_scatter: bool = False,
+    arch: str = "",
 ):
     """Cache compiled optimized MTP kernel for given configuration."""
     return {}
@@ -2543,6 +2545,7 @@ def _get_compiled_mtp_kernel_inline(
     use_smem_v: bool = False,
     use_packed_fma: bool = True,
     per_token_pool_scatter: bool = False,
+    arch: str = "",
 ):
     """Cache compiled inline MTP kernel (BS <= 2) for given configuration."""
     return {}
@@ -2620,8 +2623,8 @@ def run_mtp_decode(
     # Dispatch between inline kernel and warp-specialized kernel based on CTA work units
     _, _, ilp_rows, use_smem_v = get_mtp_config(B, T, HV, V, disable_state_update)
     use_inline_kernel = (B * HV) <= 128
-    major, _ = torch.cuda.get_device_capability(q.device)
-    use_packed_fma = major >= 10  # SM100+ (Blackwell) supports packed F32x2
+    target = gdn_device_target(q.device)
+    use_packed_fma = target.use_packed_fma
 
     per_token_pool_scatter = ssm_state_indices is not None
 
@@ -2659,6 +2662,7 @@ def run_mtp_decode(
             use_smem_v,
             use_packed_fma,
             per_token_pool_scatter,
+            target.arch,
         )
         cache = _get_compiled_mtp_kernel_inline(*inline_cache_key)
     else:
@@ -2682,6 +2686,7 @@ def run_mtp_decode(
             use_smem_v,
             use_packed_fma,
             per_token_pool_scatter,
+            target.arch,
         )
         cache = _get_compiled_mtp_kernel(*warp_cache_key)
 
@@ -2715,7 +2720,7 @@ def run_mtp_decode(
         h0_out_indices = initial_state_indices
 
     if "compiled" not in cache:
-        stream = cuda.CUstream(torch.cuda.current_stream().cuda_stream)
+        stream = cuda.CUstream(torch.cuda.current_stream(device=q.device).cuda_stream)
 
         if use_pool_indexing:
             # 4D pool [pool, HV, V, K], possibly non-contiguous (e.g. a strided
@@ -2764,8 +2769,11 @@ def run_mtp_decode(
             ssm_state_indices_arg, assumed_align=16
         ).mark_layout_dynamic()
 
+        compile_options = gdn_compile_options(
+            q.device, cute.EnableTVMFFI(True), cute.GenerateLineInfo(True)
+        )
         if use_inline_kernel:
-            compiled = cute.compile(
+            compiled = cute.compile[compile_options](
                 run_gdn_verify_kernel_mtp_inline,
                 h0_source_tensor,
                 intermediate_states_tensor,
@@ -2802,10 +2810,9 @@ def run_mtp_decode(
                 use_packed_fma=use_packed_fma,
                 per_token_pool_scatter=per_token_pool_scatter,
                 stream=stream,
-                options="--enable-tvm-ffi --generate-line-info",
             )
         else:
-            compiled = cute.compile(
+            compiled = cute.compile[compile_options](
                 run_gdn_verify_kernel_mtp,
                 h0_source_tensor,
                 intermediate_states_tensor,
@@ -2842,13 +2849,12 @@ def run_mtp_decode(
                 use_packed_fma=use_packed_fma,
                 per_token_pool_scatter=per_token_pool_scatter,
                 stream=stream,
-                options="--enable-tvm-ffi --generate-line-info",
             )
         cache["compiled"] = compiled
     else:
         compiled = cache["compiled"]
 
-    stream = cuda.CUstream(torch.cuda.current_stream().cuda_stream)
+    stream = cuda.CUstream(torch.cuda.current_stream(device=q.device).cuda_stream)
     compiled(
         h0_source,
         intermediate_states,

--- a/flashinfer/gdn_kernels/gdn_decode_mtp.py
+++ b/flashinfer/gdn_kernels/gdn_decode_mtp.py
@@ -2499,6 +2499,7 @@ def run_gdn_verify_kernel_mtp_inline(
 
 @functools.cache
 def _get_compiled_mtp_kernel(
+    target_key: tuple,
     T: int,
     H: int,
     HV: int,
@@ -2518,7 +2519,6 @@ def _get_compiled_mtp_kernel(
     use_smem_v: bool = False,
     use_packed_fma: bool = True,
     per_token_pool_scatter: bool = False,
-    arch: str = "",
 ):
     """Cache compiled optimized MTP kernel for given configuration."""
     return {}
@@ -2526,6 +2526,7 @@ def _get_compiled_mtp_kernel(
 
 @functools.cache
 def _get_compiled_mtp_kernel_inline(
+    target_key: tuple,
     T: int,
     H: int,
     HV: int,
@@ -2545,7 +2546,6 @@ def _get_compiled_mtp_kernel_inline(
     use_smem_v: bool = False,
     use_packed_fma: bool = True,
     per_token_pool_scatter: bool = False,
-    arch: str = "",
 ):
     """Cache compiled inline MTP kernel (BS <= 2) for given configuration."""
     return {}
@@ -2643,6 +2643,7 @@ def run_mtp_decode(
 
     if use_inline_kernel:
         inline_cache_key = (
+            target.compile_key,
             T,
             H,
             HV,
@@ -2662,11 +2663,11 @@ def run_mtp_decode(
             use_smem_v,
             use_packed_fma,
             per_token_pool_scatter,
-            target.arch,
         )
         cache = _get_compiled_mtp_kernel_inline(*inline_cache_key)
     else:
         warp_cache_key = (
+            target.compile_key,
             T,
             H,
             HV,
@@ -2686,7 +2687,6 @@ def run_mtp_decode(
             use_smem_v,
             use_packed_fma,
             per_token_pool_scatter,
-            target.arch,
         )
         cache = _get_compiled_mtp_kernel(*warp_cache_key)
 

--- a/flashinfer/gdn_kernels/gdn_decode_mtp.py
+++ b/flashinfer/gdn_kernels/gdn_decode_mtp.py
@@ -48,7 +48,7 @@ import cuda.bindings.driver as cuda
 
 from ..jit.cute_dsl_core import build_and_load_cute_dsl_kernel
 from .cute_dsl_cache_naming import make_kernel_name
-
+from .device_target import gdn_compile_options, gdn_device_target
 from .dtype_compat import as_bf16
 
 # ============================================================================
@@ -2524,6 +2524,7 @@ def _mtp_kernel_name(
     use_smem_v: bool = False,
     use_packed_fma: bool = True,
     per_token_pool_scatter: bool = False,
+    arch: str = "",
 ) -> str:
     """Specialization name within the gdn_decode_mtp module, encoding the
     kernel variant ("inline" or "warp") and every parameter that affects
@@ -2548,6 +2549,7 @@ def _mtp_kernel_name(
         use_smem_v,
         use_packed_fma,
         per_token_pool_scatter,
+        arch,
     )
 
 
@@ -2571,6 +2573,7 @@ def _get_compiled_mtp_kernel(
     use_smem_v: bool = False,
     use_packed_fma: bool = True,
     per_token_pool_scatter: bool = False,
+    arch: str = "",
 ):
     """Cache compiled optimized MTP kernel for given configuration."""
     return {}
@@ -2596,6 +2599,7 @@ def _get_compiled_mtp_kernel_inline(
     use_smem_v: bool = False,
     use_packed_fma: bool = True,
     per_token_pool_scatter: bool = False,
+    arch: str = "",
 ):
     """Cache compiled inline MTP kernel (BS <= 2) for given configuration."""
     return {}
@@ -2673,8 +2677,8 @@ def run_mtp_decode(
     # Dispatch between inline kernel and warp-specialized kernel based on CTA work units
     _, _, ilp_rows, use_smem_v = get_mtp_config(B, T, HV, V, disable_state_update)
     use_inline_kernel = (B * HV) <= 128
-    major, _ = torch.cuda.get_device_capability(q.device)
-    use_packed_fma = major >= 10  # SM100+ (Blackwell) supports packed F32x2
+    target = gdn_device_target(q.device)
+    use_packed_fma = target.use_packed_fma
 
     per_token_pool_scatter = ssm_state_indices is not None
 
@@ -2711,6 +2715,7 @@ def run_mtp_decode(
             use_smem_v,
             use_packed_fma,
             per_token_pool_scatter,
+            target.arch,
         )
         cache = _get_compiled_mtp_kernel_inline(*inline_cache_key)
     else:
@@ -2733,6 +2738,7 @@ def run_mtp_decode(
             use_smem_v,
             use_packed_fma,
             per_token_pool_scatter,
+            target.arch,
         )
         cache = _get_compiled_mtp_kernel(*warp_cache_key)
 
@@ -2778,7 +2784,7 @@ def run_mtp_decode(
         h0_out_indices = initial_state_indices
 
     if "compiled" not in cache:
-        stream = cuda.CUstream(torch.cuda.current_stream().cuda_stream)
+        stream = cuda.CUstream(torch.cuda.current_stream(device=q.device).cuda_stream)
 
         if use_pool_indexing:
             # 4D pool [pool, HV, V, K], possibly non-contiguous (e.g. a strided
@@ -2825,31 +2831,14 @@ def run_mtp_decode(
             ssm_state_indices_arg, assumed_align=16
         ).mark_layout_dynamic()
 
+        compile_options = gdn_compile_options(
+            q.device, cute.EnableTVMFFI(True), cute.GenerateLineInfo(True)
+        )
         if use_inline_kernel:
             compiled = build_and_load_cute_dsl_kernel(
                 _CUTE_DSL_MODULE,
-                _mtp_kernel_name(
-                    "inline",
-                    T,
-                    H,
-                    HV,
-                    K,
-                    V,
-                    cache_steps,
-                    disable_state_update,
-                    use_pool_indexing,
-                    pool_strides_key,
-                    scale,
-                    use_qk_l2norm,
-                    tile_v,
-                    vec_size,
-                    dtype_key,
-                    ilp_rows,
-                    use_smem_v,
-                    use_packed_fma,
-                    per_token_pool_scatter,
-                ),
-                lambda: cute.compile(
+                _mtp_kernel_name("inline", *inline_cache_key),
+                lambda: cute.compile[compile_options](
                     run_gdn_verify_kernel_mtp_inline,
                     h0_source_tensor,
                     intermediate_states_tensor,
@@ -2888,35 +2877,14 @@ def run_mtp_decode(
                     use_packed_fma=use_packed_fma,
                     per_token_pool_scatter=per_token_pool_scatter,
                     stream=stream,
-                    options="--enable-tvm-ffi --generate-line-info",
                 ),
                 extra_key_files=(__file__,),
             )
         else:
             compiled = build_and_load_cute_dsl_kernel(
                 _CUTE_DSL_MODULE,
-                _mtp_kernel_name(
-                    "warp",
-                    T,
-                    H,
-                    HV,
-                    K,
-                    V,
-                    cache_steps,
-                    disable_state_update,
-                    use_pool_indexing,
-                    pool_strides_key,
-                    scale,
-                    use_qk_l2norm,
-                    tile_v,
-                    vec_size,
-                    dtype_key,
-                    ilp_rows,
-                    use_smem_v,
-                    use_packed_fma,
-                    per_token_pool_scatter,
-                ),
-                lambda: cute.compile(
+                _mtp_kernel_name("warp", *warp_cache_key),
+                lambda: cute.compile[compile_options](
                     run_gdn_verify_kernel_mtp,
                     h0_source_tensor,
                     intermediate_states_tensor,
@@ -2955,7 +2923,6 @@ def run_mtp_decode(
                     use_packed_fma=use_packed_fma,
                     per_token_pool_scatter=per_token_pool_scatter,
                     stream=stream,
-                    options="--enable-tvm-ffi --generate-line-info",
                 ),
                 extra_key_files=(__file__,),
             )
@@ -2963,7 +2930,7 @@ def run_mtp_decode(
     else:
         compiled = cache["compiled"]
 
-    stream = cuda.CUstream(torch.cuda.current_stream().cuda_stream)
+    stream = cuda.CUstream(torch.cuda.current_stream(device=q.device).cuda_stream)
     compiled(
         h0_source,
         intermediate_states,

--- a/flashinfer/gdn_kernels/gdn_decode_mtp.py
+++ b/flashinfer/gdn_kernels/gdn_decode_mtp.py
@@ -48,7 +48,7 @@ import cuda.bindings.driver as cuda
 
 from ..jit.cute_dsl_core import build_and_load_cute_dsl_kernel
 from .cute_dsl_cache_naming import make_kernel_name
-from .device_target import gdn_compile_options, gdn_device_target
+from .device_target import gdn_compile_options, gdn_device_target, target_arch
 from .dtype_compat import as_bf16
 
 # ============================================================================
@@ -2506,6 +2506,7 @@ _CUTE_DSL_MODULE = "gdn_decode_mtp"
 
 def _mtp_kernel_name(
     variant: str,
+    target_key: tuple,
     T: int,
     H: int,
     HV: int,
@@ -2524,13 +2525,13 @@ def _mtp_kernel_name(
     use_smem_v: bool = False,
     use_packed_fma: bool = True,
     per_token_pool_scatter: bool = False,
-    arch: str = "",
 ) -> str:
     """Specialization name within the gdn_decode_mtp module, encoding the
     kernel variant ("inline" or "warp") and every parameter that affects
     codegen."""
     return make_kernel_name(
         variant,
+        target_arch(target_key),
         T,
         H,
         HV,
@@ -2549,12 +2550,12 @@ def _mtp_kernel_name(
         use_smem_v,
         use_packed_fma,
         per_token_pool_scatter,
-        arch,
     )
 
 
 @functools.cache
 def _get_compiled_mtp_kernel(
+    target_key: tuple,
     T: int,
     H: int,
     HV: int,
@@ -2573,7 +2574,6 @@ def _get_compiled_mtp_kernel(
     use_smem_v: bool = False,
     use_packed_fma: bool = True,
     per_token_pool_scatter: bool = False,
-    arch: str = "",
 ):
     """Cache compiled optimized MTP kernel for given configuration."""
     return {}
@@ -2581,6 +2581,7 @@ def _get_compiled_mtp_kernel(
 
 @functools.cache
 def _get_compiled_mtp_kernel_inline(
+    target_key: tuple,
     T: int,
     H: int,
     HV: int,
@@ -2599,7 +2600,6 @@ def _get_compiled_mtp_kernel_inline(
     use_smem_v: bool = False,
     use_packed_fma: bool = True,
     per_token_pool_scatter: bool = False,
-    arch: str = "",
 ):
     """Cache compiled inline MTP kernel (BS <= 2) for given configuration."""
     return {}
@@ -2697,6 +2697,7 @@ def run_mtp_decode(
 
     if use_inline_kernel:
         inline_cache_key = (
+            target.compile_key,
             T,
             H,
             HV,
@@ -2715,11 +2716,11 @@ def run_mtp_decode(
             use_smem_v,
             use_packed_fma,
             per_token_pool_scatter,
-            target.arch,
         )
         cache = _get_compiled_mtp_kernel_inline(*inline_cache_key)
     else:
         warp_cache_key = (
+            target.compile_key,
             T,
             H,
             HV,
@@ -2738,7 +2739,6 @@ def run_mtp_decode(
             use_smem_v,
             use_packed_fma,
             per_token_pool_scatter,
-            target.arch,
         )
         cache = _get_compiled_mtp_kernel(*warp_cache_key)
 

--- a/flashinfer/gdn_kernels/gdn_decode_nontranspose.py
+++ b/flashinfer/gdn_kernels/gdn_decode_nontranspose.py
@@ -29,6 +29,8 @@ from cutlass.cute.nvgpu import cpasync
 from cutlass.cute.runtime import from_dlpack
 import cuda.bindings.driver as cuda
 
+from .device_target import gdn_compile_options, gdn_device_target
+
 # ============================================================================
 # Constants for NONTRANSPOSE version ([pool, HV, K, V])
 # ============================================================================
@@ -677,6 +679,7 @@ def run_gdn_decode_kernel_big_batch_nontranspose(
 
 @functools.cache
 def _get_compiled_decode_kernel_nontranspose(
+    arch: str,
     use_small_batch: bool,
     T: int,
     H: int,
@@ -722,7 +725,19 @@ def run_nontranspose_decode(
         use_qk_l2norm: Whether to apply L2 normalization.
     """
     use_small_batch = B < SMALL_BATCH_THRESHOLD_NT
-    cache_key = (use_small_batch, T, H, HV, K, V, q.dtype, scale, use_qk_l2norm)
+    target = gdn_device_target(q.device)
+    cache_key = (
+        target.arch,
+        use_small_batch,
+        T,
+        H,
+        HV,
+        K,
+        V,
+        q.dtype,
+        scale,
+        use_qk_l2norm,
+    )
     cache = _get_compiled_decode_kernel_nontranspose(*cache_key)
 
     aux_map = cache.setdefault("aux", {})
@@ -735,7 +750,7 @@ def run_nontranspose_decode(
     h0_indices, cu_seqlens = aux_map[aux_key]
 
     if "compiled" not in cache:
-        stream = cuda.CUstream(torch.cuda.current_stream().cuda_stream)
+        stream = cuda.CUstream(torch.cuda.current_stream(device=q.device).cuda_stream)
 
         # Choose kernel based on batch size
         if use_small_batch:
@@ -763,7 +778,7 @@ def run_nontranspose_decode(
         ).mark_layout_dynamic()
 
         # Use TVM FFI to reduce runtime overhead
-        compiled = cute.compile(
+        compiled = cute.compile[gdn_compile_options(q.device, cute.EnableTVMFFI(True))](
             run_func,
             cu_seqlens_tensor,
             q_tensor,
@@ -787,14 +802,13 @@ def run_nontranspose_decode(
             use_initial_state=True,
             use_qk_l2norm=use_qk_l2norm,
             stream=stream,
-            options="--enable-tvm-ffi",
         )
         cache["compiled"] = compiled
     else:
         compiled = cache["compiled"]
 
     # Run kernel directly with PyTorch tensors (no from_dlpack needed)
-    stream = cuda.CUstream(torch.cuda.current_stream().cuda_stream)
+    stream = cuda.CUstream(torch.cuda.current_stream(device=q.device).cuda_stream)
     compiled(
         cu_seqlens,
         q,

--- a/flashinfer/gdn_kernels/gdn_decode_nontranspose.py
+++ b/flashinfer/gdn_kernels/gdn_decode_nontranspose.py
@@ -679,7 +679,7 @@ def run_gdn_decode_kernel_big_batch_nontranspose(
 
 @functools.cache
 def _get_compiled_decode_kernel_nontranspose(
-    arch: str,
+    target_key: tuple,
     use_small_batch: bool,
     T: int,
     H: int,
@@ -727,7 +727,7 @@ def run_nontranspose_decode(
     use_small_batch = B < SMALL_BATCH_THRESHOLD_NT
     target = gdn_device_target(q.device)
     cache_key = (
-        target.arch,
+        target.compile_key,
         use_small_batch,
         T,
         H,

--- a/flashinfer/gdn_kernels/gdn_decode_nontranspose.py
+++ b/flashinfer/gdn_kernels/gdn_decode_nontranspose.py
@@ -31,7 +31,7 @@ import cuda.bindings.driver as cuda
 
 from ..jit.cute_dsl_core import build_and_load_cute_dsl_kernel
 from .cute_dsl_cache_naming import make_kernel_name
-from .device_target import gdn_compile_options, gdn_device_target
+from .device_target import gdn_compile_options, gdn_device_target, target_arch
 
 # ============================================================================
 # Constants for NONTRANSPOSE version ([pool, HV, K, V])
@@ -683,7 +683,7 @@ _CUTE_DSL_MODULE = "gdn_decode_nontranspose"
 
 
 def _nontranspose_kernel_name(
-    arch: str,
+    target_key: tuple,
     use_small_batch: bool,
     T: int,
     H: int,
@@ -697,7 +697,7 @@ def _nontranspose_kernel_name(
     """Specialization name within the gdn_decode_nontranspose module, encoding
     every parameter that affects codegen."""
     return make_kernel_name(
-        arch,
+        target_arch(target_key),
         "small" if use_small_batch else "big",
         T,
         H,
@@ -712,7 +712,7 @@ def _nontranspose_kernel_name(
 
 @functools.cache
 def _get_compiled_decode_kernel_nontranspose(
-    arch: str,
+    target_key: tuple,
     use_small_batch: bool,
     T: int,
     H: int,
@@ -760,7 +760,7 @@ def run_nontranspose_decode(
     use_small_batch = B < SMALL_BATCH_THRESHOLD_NT
     target = gdn_device_target(q.device)
     cache_key = (
-        target.arch,
+        target.compile_key,
         use_small_batch,
         T,
         H,

--- a/flashinfer/gdn_kernels/gdn_decode_nontranspose.py
+++ b/flashinfer/gdn_kernels/gdn_decode_nontranspose.py
@@ -31,6 +31,7 @@ import cuda.bindings.driver as cuda
 
 from ..jit.cute_dsl_core import build_and_load_cute_dsl_kernel
 from .cute_dsl_cache_naming import make_kernel_name
+from .device_target import gdn_compile_options, gdn_device_target
 
 # ============================================================================
 # Constants for NONTRANSPOSE version ([pool, HV, K, V])
@@ -682,6 +683,7 @@ _CUTE_DSL_MODULE = "gdn_decode_nontranspose"
 
 
 def _nontranspose_kernel_name(
+    arch: str,
     use_small_batch: bool,
     T: int,
     H: int,
@@ -695,6 +697,7 @@ def _nontranspose_kernel_name(
     """Specialization name within the gdn_decode_nontranspose module, encoding
     every parameter that affects codegen."""
     return make_kernel_name(
+        arch,
         "small" if use_small_batch else "big",
         T,
         H,
@@ -709,6 +712,7 @@ def _nontranspose_kernel_name(
 
 @functools.cache
 def _get_compiled_decode_kernel_nontranspose(
+    arch: str,
     use_small_batch: bool,
     T: int,
     H: int,
@@ -754,7 +758,19 @@ def run_nontranspose_decode(
         use_qk_l2norm: Whether to apply L2 normalization.
     """
     use_small_batch = B < SMALL_BATCH_THRESHOLD_NT
-    cache_key = (use_small_batch, T, H, HV, K, V, q.dtype, scale, use_qk_l2norm)
+    target = gdn_device_target(q.device)
+    cache_key = (
+        target.arch,
+        use_small_batch,
+        T,
+        H,
+        HV,
+        K,
+        V,
+        q.dtype,
+        scale,
+        use_qk_l2norm,
+    )
     cache = _get_compiled_decode_kernel_nontranspose(*cache_key)
 
     aux_map = cache.setdefault("aux", {})
@@ -767,7 +783,7 @@ def run_nontranspose_decode(
     h0_indices, cu_seqlens = aux_map[aux_key]
 
     if "compiled" not in cache:
-        stream = cuda.CUstream(torch.cuda.current_stream().cuda_stream)
+        stream = cuda.CUstream(torch.cuda.current_stream(device=q.device).cuda_stream)
 
         # Choose kernel based on batch size
         if use_small_batch:
@@ -798,7 +814,9 @@ def run_nontranspose_decode(
         compiled = build_and_load_cute_dsl_kernel(
             _CUTE_DSL_MODULE,
             _nontranspose_kernel_name(*cache_key),
-            lambda: cute.compile(
+            lambda: cute.compile[
+                gdn_compile_options(q.device, cute.EnableTVMFFI(True))
+            ](
                 run_func,
                 cu_seqlens_tensor,
                 q_tensor,
@@ -822,7 +840,6 @@ def run_nontranspose_decode(
                 use_initial_state=True,
                 use_qk_l2norm=use_qk_l2norm,
                 stream=stream,
-                options="--enable-tvm-ffi",
             ),
             extra_key_files=(__file__,),
         )
@@ -831,7 +848,7 @@ def run_nontranspose_decode(
         compiled = cache["compiled"]
 
     # Run kernel directly with PyTorch tensors (no from_dlpack needed)
-    stream = cuda.CUstream(torch.cuda.current_stream().cuda_stream)
+    stream = cuda.CUstream(torch.cuda.current_stream(device=q.device).cuda_stream)
     compiled(
         cu_seqlens,
         q,

--- a/flashinfer/gdn_kernels/gdn_decode_pretranspose.py
+++ b/flashinfer/gdn_kernels/gdn_decode_pretranspose.py
@@ -898,7 +898,7 @@ def run_gdn_decode_kernel_big_batch_pretranspose(
 
 @functools.cache
 def _get_compiled_decode_kernel(
-    arch: str,
+    target_key: tuple,
     T: int,
     H: int,
     HV: int,
@@ -966,7 +966,7 @@ def run_pretranspose_decode(
         stride1 = stride2 = stride3 = 0
     target = gdn_device_target(q.device)
     cache_key = (
-        target.arch,
+        target.compile_key,
         T,
         H,
         HV,

--- a/flashinfer/gdn_kernels/gdn_decode_pretranspose.py
+++ b/flashinfer/gdn_kernels/gdn_decode_pretranspose.py
@@ -30,6 +30,8 @@ from cutlass.cute.nvgpu import cpasync
 from cutlass.cute.runtime import from_dlpack
 import cuda.bindings.driver as cuda
 
+from .device_target import gdn_compile_options, gdn_device_target
+
 # ============================================================================
 # Constants for PRETRANSPOSE version ([B*HV, V, K])
 # ============================================================================
@@ -896,6 +898,7 @@ def run_gdn_decode_kernel_big_batch_pretranspose(
 
 @functools.cache
 def _get_compiled_decode_kernel(
+    arch: str,
     T: int,
     H: int,
     HV: int,
@@ -961,7 +964,9 @@ def run_pretranspose_decode(
         )
     else:
         stride1 = stride2 = stride3 = 0
+    target = gdn_device_target(q.device)
     cache_key = (
+        target.arch,
         T,
         H,
         HV,
@@ -997,7 +1002,7 @@ def run_pretranspose_decode(
         h0_out_indices = h0_indices
 
     if "compiled" not in cache:
-        stream = cuda.CUstream(torch.cuda.current_stream().cuda_stream)
+        stream = cuda.CUstream(torch.cuda.current_stream(device=q.device).cuda_stream)
 
         if use_pool_indexing:
             # Pool capacity and the distance between slots do not affect codegen.
@@ -1039,7 +1044,7 @@ def run_pretranspose_decode(
         run_func = run_gdn_decode_kernel_small_batch_pretranspose
 
         # Use TVM FFI to reduce runtime overhead
-        compiled = cute.compile(
+        compiled = cute.compile[gdn_compile_options(q.device, cute.EnableTVMFFI(True))](
             run_func,
             h0_source_tensor,
             A_log_tensor,
@@ -1066,14 +1071,13 @@ def run_pretranspose_decode(
             use_pool_indexing=use_pool_indexing,
             is_varlen=False,
             stream=stream,
-            options="--enable-tvm-ffi",
         )
         cache["compiled"] = compiled
     else:
         compiled = cache["compiled"]
 
     # Run kernel directly with PyTorch tensors (no from_dlpack needed)
-    stream = cuda.CUstream(torch.cuda.current_stream().cuda_stream)
+    stream = cuda.CUstream(torch.cuda.current_stream(device=q.device).cuda_stream)
     cache["compiled"](
         h0_source,
         A_log,

--- a/flashinfer/gdn_kernels/gdn_decode_pretranspose.py
+++ b/flashinfer/gdn_kernels/gdn_decode_pretranspose.py
@@ -32,7 +32,7 @@ import cuda.bindings.driver as cuda
 
 from ..jit.cute_dsl_core import build_and_load_cute_dsl_kernel
 from .cute_dsl_cache_naming import make_kernel_name
-from .device_target import gdn_compile_options, gdn_device_target
+from .device_target import gdn_compile_options, gdn_device_target, target_arch
 
 # ============================================================================
 # Constants for PRETRANSPOSE version ([B*HV, V, K])
@@ -902,7 +902,7 @@ _CUTE_DSL_MODULE = "gdn_decode_pretranspose"
 
 
 def _pretranspose_kernel_name(
-    arch: str,
+    target_key: tuple,
     T: int,
     H: int,
     HV: int,
@@ -920,7 +920,7 @@ def _pretranspose_kernel_name(
     every parameter that affects codegen."""
     return make_kernel_name(
         "decode",
-        arch,
+        target_arch(target_key),
         T,
         H,
         HV,
@@ -938,7 +938,7 @@ def _pretranspose_kernel_name(
 
 @functools.cache
 def _get_compiled_decode_kernel(
-    arch: str,
+    target_key: tuple,
     T: int,
     H: int,
     HV: int,
@@ -1006,7 +1006,7 @@ def run_pretranspose_decode(
         stride1 = stride2 = stride3 = 0
     target = gdn_device_target(q.device)
     cache_key = (
-        target.arch,
+        target.compile_key,
         T,
         H,
         HV,

--- a/flashinfer/gdn_kernels/gdn_decode_pretranspose.py
+++ b/flashinfer/gdn_kernels/gdn_decode_pretranspose.py
@@ -32,6 +32,7 @@ import cuda.bindings.driver as cuda
 
 from ..jit.cute_dsl_core import build_and_load_cute_dsl_kernel
 from .cute_dsl_cache_naming import make_kernel_name
+from .device_target import gdn_compile_options, gdn_device_target
 
 # ============================================================================
 # Constants for PRETRANSPOSE version ([B*HV, V, K])
@@ -901,6 +902,7 @@ _CUTE_DSL_MODULE = "gdn_decode_pretranspose"
 
 
 def _pretranspose_kernel_name(
+    arch: str,
     T: int,
     H: int,
     HV: int,
@@ -918,6 +920,7 @@ def _pretranspose_kernel_name(
     every parameter that affects codegen."""
     return make_kernel_name(
         "decode",
+        arch,
         T,
         H,
         HV,
@@ -935,6 +938,7 @@ def _pretranspose_kernel_name(
 
 @functools.cache
 def _get_compiled_decode_kernel(
+    arch: str,
     T: int,
     H: int,
     HV: int,
@@ -1000,7 +1004,9 @@ def run_pretranspose_decode(
         )
     else:
         stride1 = stride2 = stride3 = 0
+    target = gdn_device_target(q.device)
     cache_key = (
+        target.arch,
         T,
         H,
         HV,
@@ -1036,7 +1042,7 @@ def run_pretranspose_decode(
         h0_out_indices = h0_indices
 
     if "compiled" not in cache:
-        stream = cuda.CUstream(torch.cuda.current_stream().cuda_stream)
+        stream = cuda.CUstream(torch.cuda.current_stream(device=q.device).cuda_stream)
 
         if use_pool_indexing:
             # Pool capacity and the distance between slots do not affect codegen.
@@ -1081,7 +1087,9 @@ def run_pretranspose_decode(
         compiled = build_and_load_cute_dsl_kernel(
             _CUTE_DSL_MODULE,
             _pretranspose_kernel_name(*cache_key),
-            lambda: cute.compile(
+            lambda: cute.compile[
+                gdn_compile_options(q.device, cute.EnableTVMFFI(True))
+            ](
                 run_func,
                 h0_source_tensor,
                 A_log_tensor,
@@ -1108,7 +1116,6 @@ def run_pretranspose_decode(
                 use_pool_indexing=use_pool_indexing,
                 is_varlen=False,
                 stream=stream,
-                options="--enable-tvm-ffi",
             ),
             extra_key_files=(__file__,),
         )
@@ -1117,7 +1124,7 @@ def run_pretranspose_decode(
         compiled = cache["compiled"]
 
     # Run kernel directly with PyTorch tensors (no from_dlpack needed)
-    stream = cuda.CUstream(torch.cuda.current_stream().cuda_stream)
+    stream = cuda.CUstream(torch.cuda.current_stream(device=q.device).cuda_stream)
     cache["compiled"](
         h0_source,
         A_log,

--- a/tests/gdn/test_cute_dsl_kernel_cache.py
+++ b/tests/gdn/test_cute_dsl_kernel_cache.py
@@ -112,7 +112,7 @@ def test_make_kernel_name_caps_length_without_collision():
 # ---------------------------------------------------------------------------
 
 NONTRANSPOSE_BASELINE = {
-    "arch": "sm100a",
+    "target_key": (0, "sm100a"),
     "use_small_batch": True,
     "T": 1,
     "H": 16,
@@ -125,7 +125,7 @@ NONTRANSPOSE_BASELINE = {
 }
 
 PRETRANSPOSE_BASELINE = {
-    "arch": "sm100a",
+    "target_key": (0, "sm100a"),
     "T": 1,
     "H": 16,
     "HV": 32,
@@ -142,7 +142,7 @@ PRETRANSPOSE_BASELINE = {
 
 MTP_BASELINE = {
     "variant": "warp",
-    "arch": "sm100a",
+    "target_key": (0, "sm100a"),
     "T": 2,
     "H": 16,
     "HV": 32,
@@ -164,7 +164,7 @@ MTP_BASELINE = {
 }
 
 PREFILL_BASELINE = {
-    "arch": "sm100a",
+    "target_key": (0, "sm100a"),
     "io_dtype_str": "torch.bfloat16",
     "state_dtype_str": "torch.float32",
     "HQ": 32,
@@ -208,7 +208,7 @@ BF16_STATE_BASELINES = {
         False,  # per_token_pool_scatter
         False,  # per_token_pool_scatter_flat
         (torch.float32, torch.float32, torch.int32),  # _dtype_key
-        "sm100a",  # target arch
+        (0, "sm100a"),  # compile target
     ),
     "wide_vec_t1": (
         "v3_mtp_bf16_tiled_dynB",
@@ -229,7 +229,7 @@ BF16_STATE_BASELINES = {
         True,
         True,
         (torch.float32, torch.float32, torch.int32),
-        "sm100a",  # target arch
+        (0, "sm100a"),  # compile target
     ),
     "mtp_ilp4": (
         "mtp_bf16_dynB",
@@ -255,7 +255,7 @@ BF16_STATE_BASELINES = {
         False,  # per_token_pool_scatter
         False,  # per_token_pool_scatter_flat
         (torch.float32, torch.float32, torch.int32),
-        "sm100a",  # target arch
+        (0, "sm100a"),  # compile target
     ),
 }
 
@@ -301,7 +301,7 @@ def test_kernel_name_signature_covers_getter_params(getter, name_fn):
 @pytest.mark.parametrize(
     "param,alternate",
     [
-        ("arch", "sm90a"),
+        ("target_key", (0, "sm90a")),
         ("use_small_batch", False),
         ("T", 2),
         ("H", 32),
@@ -325,7 +325,7 @@ def test_nontranspose_name_varies_with_every_argument(param, alternate):
 @pytest.mark.parametrize(
     "param,alternate",
     [
-        ("arch", "sm90a"),
+        ("target_key", (0, "sm90a")),
         ("T", 2),
         ("H", 32),
         ("HV", 64),
@@ -353,7 +353,7 @@ def test_pretranspose_name_varies_with_every_argument(param, alternate):
     "param,alternate",
     [
         ("variant", "inline"),
-        ("arch", "sm90a"),
+        ("target_key", (0, "sm90a")),
         ("T", 3),
         ("H", 32),
         ("HV", 64),
@@ -399,7 +399,7 @@ def test_mtp_name_varies_with_every_argument(param, alternate):
         ("initial_state_inner_strides", (16384, 128, 1)),
         ("output_state_inner_strides", (16384, 128, 1)),
         ("num_sm", 132),
-        ("arch", "sm90a"),
+        ("target_key", (0, "sm90a")),
     ],
 )
 def test_prefill_name_varies_with_every_argument(param, alternate):
@@ -435,12 +435,50 @@ def _perturb(value):
 def test_bf16_state_name_varies_with_every_key_component(variant):
     key = BF16_STATE_BASELINES[variant]
     baseline = _bf16_state_kernel_name(variant, key)
-    for i in range(len(key)):
+    # The last component is the compile target, whose device index intentionally
+    # does not name an artifact (see test_kernel_names_ignore_the_device_index).
+    for i in range(len(key) - 1):
         perturbed = key[:i] + (_perturb(key[i]),) + key[i + 1 :]
         assert _bf16_state_kernel_name(variant, perturbed) != baseline, (
             f"_bf16_state_kernel_name ignores cache_key[{i}] = {key[i]!r} "
             f"for variant {variant!r}"
         )
+    other_arch = key[:-1] + ((key[-1][0], "sm90a"),)
+    assert _bf16_state_kernel_name(variant, other_arch) != baseline, (
+        f"_bf16_state_kernel_name ignores the target arch for variant {variant!r}"
+    )
+
+
+def test_kernel_names_ignore_the_device_index():
+    """Two devices of one arch must share an artifact, not fragment the cache.
+
+    The device index is in the in-process key because an artifact binds to the
+    device it first ran on; the exported ``.o`` depends only on the arch.
+    """
+    named = {
+        "nontranspose": (_nontranspose_kernel_name, NONTRANSPOSE_BASELINE),
+        "pretranspose": (_pretranspose_kernel_name, PRETRANSPOSE_BASELINE),
+        "mtp": (_mtp_kernel_name, MTP_BASELINE),
+        "prefill": (_prefill_kernel_name, PREFILL_BASELINE),
+    }
+    for label, (name_fn, baseline) in named.items():
+        device_index, arch = baseline["target_key"]
+        same_arch = {**baseline, "target_key": (device_index + 1, arch)}
+        other_arch = {**baseline, "target_key": (device_index, "sm90a")}
+        assert name_fn(**same_arch) == name_fn(**baseline), (
+            f"{label}: the device index must not name an artifact"
+        )
+        assert name_fn(**other_arch) != name_fn(**baseline), (
+            f"{label}: the target arch must name an artifact"
+        )
+
+    variant, key = "wide_vec", BF16_STATE_BASELINES["wide_vec"]
+    device_index, arch = key[-1]
+    assert _bf16_state_kernel_name(
+        variant, key[:-1] + ((device_index + 1, arch),)
+    ) == _bf16_state_kernel_name(variant, key), (
+        "bf16_state: the device index must not name an artifact"
+    )
 
 
 def test_bf16_state_name_distinguishes_variants():

--- a/tests/gdn/test_cute_dsl_kernel_cache.py
+++ b/tests/gdn/test_cute_dsl_kernel_cache.py
@@ -112,6 +112,7 @@ def test_make_kernel_name_caps_length_without_collision():
 # ---------------------------------------------------------------------------
 
 NONTRANSPOSE_BASELINE = {
+    "arch": "sm100a",
     "use_small_batch": True,
     "T": 1,
     "H": 16,
@@ -124,6 +125,7 @@ NONTRANSPOSE_BASELINE = {
 }
 
 PRETRANSPOSE_BASELINE = {
+    "arch": "sm100a",
     "T": 1,
     "H": 16,
     "HV": 32,
@@ -140,6 +142,7 @@ PRETRANSPOSE_BASELINE = {
 
 MTP_BASELINE = {
     "variant": "warp",
+    "arch": "sm100a",
     "T": 2,
     "H": 16,
     "HV": 32,
@@ -161,6 +164,7 @@ MTP_BASELINE = {
 }
 
 PREFILL_BASELINE = {
+    "arch": "sm100a",
     "io_dtype_str": "torch.bfloat16",
     "state_dtype_str": "torch.float32",
     "HQ": 32,
@@ -204,6 +208,7 @@ BF16_STATE_BASELINES = {
         False,  # per_token_pool_scatter
         False,  # per_token_pool_scatter_flat
         (torch.float32, torch.float32, torch.int32),  # _dtype_key
+        "sm100a",  # target arch
     ),
     "wide_vec_t1": (
         "v3_mtp_bf16_tiled_dynB",
@@ -224,6 +229,7 @@ BF16_STATE_BASELINES = {
         True,
         True,
         (torch.float32, torch.float32, torch.int32),
+        "sm100a",  # target arch
     ),
     "mtp_ilp4": (
         "mtp_bf16_dynB",
@@ -249,6 +255,7 @@ BF16_STATE_BASELINES = {
         False,  # per_token_pool_scatter
         False,  # per_token_pool_scatter_flat
         (torch.float32, torch.float32, torch.int32),
+        "sm100a",  # target arch
     ),
 }
 
@@ -294,6 +301,7 @@ def test_kernel_name_signature_covers_getter_params(getter, name_fn):
 @pytest.mark.parametrize(
     "param,alternate",
     [
+        ("arch", "sm90a"),
         ("use_small_batch", False),
         ("T", 2),
         ("H", 32),
@@ -317,6 +325,7 @@ def test_nontranspose_name_varies_with_every_argument(param, alternate):
 @pytest.mark.parametrize(
     "param,alternate",
     [
+        ("arch", "sm90a"),
         ("T", 2),
         ("H", 32),
         ("HV", 64),
@@ -344,6 +353,7 @@ def test_pretranspose_name_varies_with_every_argument(param, alternate):
     "param,alternate",
     [
         ("variant", "inline"),
+        ("arch", "sm90a"),
         ("T", 3),
         ("H", 32),
         ("HV", 64),
@@ -389,6 +399,7 @@ def test_mtp_name_varies_with_every_argument(param, alternate):
         ("initial_state_inner_strides", (16384, 128, 1)),
         ("output_state_inner_strides", (16384, 128, 1)),
         ("num_sm", 132),
+        ("arch", "sm90a"),
     ],
 )
 def test_prefill_name_varies_with_every_argument(param, alternate):

--- a/tests/gdn/test_cute_dsl_kernel_cache.py
+++ b/tests/gdn/test_cute_dsl_kernel_cache.py
@@ -437,6 +437,9 @@ def test_bf16_state_name_varies_with_every_key_component(variant):
     baseline = _bf16_state_kernel_name(variant, key)
     # The last component is the compile target, whose device index intentionally
     # does not name an artifact (see test_kernel_names_ignore_the_device_index).
+    assert key[-1] == (0, "sm100a"), (
+        f"the skipped component is no longer the compile target: {key[-1]!r}"
+    )
     for i in range(len(key) - 1):
         perturbed = key[:i] + (_perturb(key[i]),) + key[i + 1 :]
         assert _bf16_state_kernel_name(variant, perturbed) != baseline, (
@@ -452,8 +455,8 @@ def test_bf16_state_name_varies_with_every_key_component(variant):
 def test_kernel_names_ignore_the_device_index():
     """Two devices of one arch must share an artifact, not fragment the cache.
 
-    The device index is in the in-process key because an artifact binds to the
-    device it first ran on; the exported ``.o`` depends only on the arch.
+    The device index is in the in-process key to separate the device-resident
+    defaults an entry holds; the exported ``.o`` depends only on the arch.
     """
     named = {
         "nontranspose": (_nontranspose_kernel_name, NONTRANSPOSE_BASELINE),

--- a/tests/gdn/test_decode_delta_rule.py
+++ b/tests/gdn/test_decode_delta_rule.py
@@ -1277,10 +1277,21 @@ def test_verify_kernel_mtp_reuses_compile_across_cache_modes(monkeypatch, batch_
     original_compile = cute.compile
     compile_count = 0
 
-    def counted_compile(*args, **kwargs):
-        nonlocal compile_count
-        compile_count += 1
-        return original_compile(*args, **kwargs)
+    class CountedCompile:
+        """Stand-in for ``cute.compile``, which is used in its subscripted form."""
+
+        def __init__(self, compile_fn):
+            self._compile_fn = compile_fn
+
+        def __getitem__(self, options):
+            return CountedCompile(original_compile[options])
+
+        def __call__(self, *args, **kwargs):
+            nonlocal compile_count
+            compile_count += 1
+            return self._compile_fn(*args, **kwargs)
+
+    counted_compile = CountedCompile(original_compile)
 
     # Pin the disk cache off: a populated cache would satisfy the reuse
     # property with zero compiles, breaking the count-based assertion.

--- a/tests/gdn/test_decode_pretranspose_noncontiguous_pool.py
+++ b/tests/gdn/test_decode_pretranspose_noncontiguous_pool.py
@@ -159,11 +159,22 @@ def test_decode_pretranspose_pool_reuses_compile_across_outer_layouts(
     pool_compile_calls = 0
     original_compile = pretranspose_module.cute.compile
 
-    def counted_compile(*args, **kwargs):
-        nonlocal pool_compile_calls
-        if kwargs.get("use_pool_indexing", False):
-            pool_compile_calls += 1
-        return original_compile(*args, **kwargs)
+    class CountedCompile:
+        """Stand-in for ``cute.compile``, which is used in its subscripted form."""
+
+        def __init__(self, compile_fn):
+            self._compile_fn = compile_fn
+
+        def __getitem__(self, options):
+            return CountedCompile(original_compile[options])
+
+        def __call__(self, *args, **kwargs):
+            nonlocal pool_compile_calls
+            if kwargs.get("use_pool_indexing", False):
+                pool_compile_calls += 1
+            return self._compile_fn(*args, **kwargs)
+
+    counted_compile = CountedCompile(original_compile)
 
     pretranspose_module._get_compiled_decode_kernel.cache_clear()
     monkeypatch.setattr(pretranspose_module.cute, "compile", counted_compile)
@@ -225,6 +236,7 @@ def test_decode_pretranspose_pool_cache_keeps_inner_strides_static() -> None:
     """Layouts with different inner strides must keep separate cache entries."""
     pretranspose_module = _load_pretranspose_module()
     common = dict(
+        target_key=(0, "sm_90a"),
         T=1,
         H=16,
         HV=32,

--- a/tests/gdn/test_decode_pretranspose_noncontiguous_pool.py
+++ b/tests/gdn/test_decode_pretranspose_noncontiguous_pool.py
@@ -159,11 +159,22 @@ def test_decode_pretranspose_pool_reuses_compile_across_outer_layouts(
     pool_compile_calls = 0
     original_compile = pretranspose_module.cute.compile
 
-    def counted_compile(*args, **kwargs):
-        nonlocal pool_compile_calls
-        if kwargs.get("use_pool_indexing", False):
-            pool_compile_calls += 1
-        return original_compile(*args, **kwargs)
+    class CountedCompile:
+        """Stand-in for ``cute.compile``, which is used in its subscripted form."""
+
+        def __init__(self, compile_fn):
+            self._compile_fn = compile_fn
+
+        def __getitem__(self, options):
+            return CountedCompile(original_compile[options])
+
+        def __call__(self, *args, **kwargs):
+            nonlocal pool_compile_calls
+            if kwargs.get("use_pool_indexing", False):
+                pool_compile_calls += 1
+            return self._compile_fn(*args, **kwargs)
+
+    counted_compile = CountedCompile(original_compile)
 
     # Pin the disk cache off: a populated cache would satisfy the reuse
     # property with zero compiles, breaking the count-based assertion.
@@ -228,6 +239,7 @@ def test_decode_pretranspose_pool_cache_keeps_inner_strides_static() -> None:
     """Layouts with different inner strides must keep separate cache entries."""
     pretranspose_module = _load_pretranspose_module()
     common = dict(
+        target_key=(0, "sm_90a"),
         T=1,
         H=16,
         HV=32,

--- a/tests/gdn/test_gdn_device_target.py
+++ b/tests/gdn/test_gdn_device_target.py
@@ -58,6 +58,14 @@ def test_device_target_reads_the_requested_device(fake_devices):
     assert (d1.arch, d1.num_sms, d1.use_packed_fma) == ("sm_100a", 148, True)
 
 
+def test_compile_key_separates_devices(fake_devices):
+    """A compiled artifact is pinned to the device it first ran on, so two devices
+    must not share a cache entry even when they are the same architecture."""
+    assert dt.gdn_device_target("cuda:0").compile_key != (
+        dt.gdn_device_target("cuda:1").compile_key
+    )
+
+
 def test_index_less_device_follows_current_device(fake_devices, monkeypatch):
     assert dt.gdn_device_target("cuda").arch == "sm_90a"
     monkeypatch.setattr(torch.cuda, "current_device", lambda: 1)
@@ -67,7 +75,18 @@ def test_index_less_device_follows_current_device(fake_devices, monkeypatch):
 def test_cute_dsl_arch_env_override_wins(fake_devices, monkeypatch):
     monkeypatch.setenv("CUTE_DSL_ARCH", "sm_90a")
     dt._resolve.cache_clear()
-    assert dt.gdn_device_target("cuda:1").arch == "sm_90a"
+
+    target = dt.gdn_device_target("cuda:1")
+    # The whole policy must follow the override, not just the arch string: packed
+    # F32x2 codegen against an sm_90a target would not assemble.
+    assert (target.arch, target.major, target.use_packed_fma) == ("sm_90a", 9, False)
+
+
+def test_unparsable_cute_dsl_arch_is_rejected(fake_devices, monkeypatch):
+    monkeypatch.setenv("CUTE_DSL_ARCH", "hopper")
+    dt._resolve.cache_clear()
+    with pytest.raises(ValueError, match="not a recognized arch"):
+        dt.gdn_device_target("cuda:0")
 
 
 def test_non_cuda_device_is_rejected(fake_devices):
@@ -84,27 +103,40 @@ def test_compile_options_pin_arch_and_preserve_extras(fake_devices):
     assert options[1:] == extras
 
 
-def test_gdn_compile_sites_do_not_pass_string_options():
-    """``cute.compile[opts](..., options="...")`` drops ``opts`` instead of merging.
+def _is_cute_compile(func: ast.expr) -> bool:
+    target = func.value if isinstance(func, ast.Subscript) else func
+    if not isinstance(target, ast.Attribute) or target.attr != "compile":
+        return False
+    owner = target.value
+    if isinstance(owner, ast.Name):
+        return owner.id == "cute"
+    return isinstance(owner, ast.Attribute) and owner.attr == "cute"
 
-    The DSL replaces subscripted options wholesale when a string ``options=``
-    kwarg is present, so a string here would silently un-pin the target arch.
+
+def test_every_gdn_cute_compile_pins_an_explicit_target():
+    """Un-subscripted ``cute.compile`` targets whatever the DSL picks (device 0).
+
+    A string ``options=`` kwarg is equally unsafe: the DSL replaces subscripted
+    options wholesale when one is present, silently dropping the ``GPUArch``.
     """
-    offenders = []
+    unpinned, string_options = [], []
     for path in sorted(GDN_KERNELS_DIR.rglob("*.py")):
         tree = ast.parse(path.read_text(), filename=str(path))
         for node in ast.walk(tree):
-            if not isinstance(node, ast.Call):
+            if not isinstance(node, ast.Call) or not _is_cute_compile(node.func):
                 continue
-            if "compile" not in ast.dump(node.func):
-                continue
-            for kw in node.keywords:
-                if kw.arg == "options" and isinstance(kw.value, ast.Constant):
-                    offenders.append(f"{path.name}:{node.lineno}")
+            where = f"{path.name}:{node.lineno}"
+            if not isinstance(node.func, ast.Subscript):
+                unpinned.append(where)
+            if any(
+                kw.arg == "options" and isinstance(kw.value, ast.Constant)
+                for kw in node.keywords
+            ):
+                string_options.append(where)
 
-    assert not offenders, (
-        "pass compile options via cute.compile[gdn_compile_options(device, ...)] "
-        f"instead of a string options= kwarg: {offenders}"
+    assert not unpinned and not string_options, (
+        "call cute.compile[gdn_compile_options(device, ...)](...) instead; "
+        f"unpinned={unpinned} string_options={string_options}"
     )
 
 
@@ -119,45 +151,40 @@ def test_bf16_mtp_tile_v_follows_device_sm_count():
 @pytest.mark.skipif(
     torch.cuda.device_count() < 2, reason="needs at least two CUDA devices"
 )
-def test_decode_matches_across_current_device(monkeypatch):
-    """Operands on cuda:1 must decode identically whatever the current device is."""
+def test_decode_agrees_across_devices():
+    """The same decode must give the same answer on every device in one process.
+
+    A compiled CuTe-DSL artifact is pinned to the device it first ran on, so before
+    the device index entered the compile key the second device silently reused the
+    first device's artifact.
+    """
     from flashinfer.gdn_decode import gated_delta_rule_decode_pretranspose
 
     B, T, H, HV, K, V = 2, 1, 4, 4, 128, 128
-    device = torch.device("cuda", 1)
     torch.manual_seed(0)
+    cpu_inputs = {
+        "q": torch.randn(B, T, H, K, dtype=torch.bfloat16) * 0.1,
+        "k": torch.randn(B, T, H, K, dtype=torch.bfloat16) * 0.1,
+        "v": torch.randn(B, T, HV, V, dtype=torch.bfloat16) * 0.1,
+        "a": torch.randn(B, T, HV, dtype=torch.bfloat16) * 0.1,
+        "b": torch.randn(B, T, HV, dtype=torch.bfloat16) * 0.1,
+        "A_log": torch.randn(HV, dtype=torch.float32) * 0.1,
+        "dt_bias": torch.randn(HV, dtype=torch.float32) * 0.1,
+        "state": torch.randn(B, HV, V, K, dtype=torch.bfloat16) * 0.1,
+    }
 
-    def make(dtype):
-        return torch.randn(B, T, H, K, dtype=dtype, device=device) * 0.1
+    def run_on(index):
+        # The DSL binds an artifact to the current device, so make it the operand's.
+        with torch.cuda.device(index):
+            args = {k: v.cuda(index) for k, v in cpu_inputs.items()}
+            out, _ = gated_delta_rule_decode_pretranspose(
+                **args, scale=1.0 / math.sqrt(K), use_qk_l2norm=True
+            )
+            torch.cuda.synchronize(index)
+            return out.float().cpu()
 
-    q, k = make(torch.bfloat16), make(torch.bfloat16)
-    v = torch.randn(B, T, HV, V, dtype=torch.bfloat16, device=device) * 0.1
-    a = torch.randn(B, T, HV, dtype=torch.bfloat16, device=device) * 0.1
-    b = torch.randn(B, T, HV, dtype=torch.bfloat16, device=device) * 0.1
-    A_log = torch.randn(HV, dtype=torch.float32, device=device) * 0.1
-    dt_bias = torch.randn(HV, dtype=torch.float32, device=device) * 0.1
-    state = torch.randn(B, HV, V, K, dtype=torch.bfloat16, device=device) * 0.1
-
-    def run():
-        out, _ = gated_delta_rule_decode_pretranspose(
-            q=q,
-            k=k,
-            v=v,
-            state=state.clone(),
-            A_log=A_log,
-            a=a,
-            dt_bias=dt_bias,
-            b=b,
-            scale=1.0 / math.sqrt(K),
-            use_qk_l2norm=True,
-        )
-        return out
-
-    torch.cuda.set_device(0)
-    from_other_device = run()
-    torch.cuda.set_device(1)
-    from_same_device = run()
-
-    torch.testing.assert_close(
-        from_other_device.float(), from_same_device.float(), atol=0, rtol=0
-    )
+    original_device = torch.cuda.current_device()
+    try:
+        torch.testing.assert_close(run_on(0), run_on(1), atol=0, rtol=0)
+    finally:
+        torch.cuda.set_device(original_device)

--- a/tests/gdn/test_gdn_device_target.py
+++ b/tests/gdn/test_gdn_device_target.py
@@ -1,0 +1,163 @@
+"""
+Copyright (c) 2025 by FlashInfer team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from __future__ import annotations
+
+import ast
+import math
+import pathlib
+
+import cutlass.cute as cute
+import pytest
+import torch
+
+from flashinfer.gdn_kernels import device_target as dt
+
+GDN_KERNELS_DIR = pathlib.Path(dt.__file__).parent
+
+
+class _FakeProps:
+    def __init__(self, multi_processor_count: int) -> None:
+        self.multi_processor_count = multi_processor_count
+
+
+@pytest.fixture
+def fake_devices(monkeypatch):
+    """Two devices with different arch, SM count, and packed-FMA support."""
+    caps = {0: (9, 0), 1: (10, 0)}
+    sms = {0: 132, 1: 148}
+    monkeypatch.setattr(torch.cuda, "get_device_capability", lambda i: caps[i])
+    monkeypatch.setattr(
+        torch.cuda, "get_device_properties", lambda i: _FakeProps(sms[i])
+    )
+    monkeypatch.setattr(torch.cuda, "current_device", lambda: 0)
+    monkeypatch.delenv("CUTE_DSL_ARCH", raising=False)
+    dt._resolve.cache_clear()
+    yield
+    dt._resolve.cache_clear()
+
+
+def test_device_target_reads_the_requested_device(fake_devices):
+    d0 = dt.gdn_device_target("cuda:0")
+    d1 = dt.gdn_device_target("cuda:1")
+
+    assert (d0.arch, d0.num_sms, d0.use_packed_fma) == ("sm_90a", 132, False)
+    assert (d1.arch, d1.num_sms, d1.use_packed_fma) == ("sm_100a", 148, True)
+
+
+def test_index_less_device_follows_current_device(fake_devices, monkeypatch):
+    assert dt.gdn_device_target("cuda").arch == "sm_90a"
+    monkeypatch.setattr(torch.cuda, "current_device", lambda: 1)
+    assert dt.gdn_device_target("cuda").arch == "sm_100a"
+
+
+def test_cute_dsl_arch_env_override_wins(fake_devices, monkeypatch):
+    monkeypatch.setenv("CUTE_DSL_ARCH", "sm_90a")
+    dt._resolve.cache_clear()
+    assert dt.gdn_device_target("cuda:1").arch == "sm_90a"
+
+
+def test_non_cuda_device_is_rejected(fake_devices):
+    with pytest.raises(ValueError, match="require CUDA tensors"):
+        dt.gdn_device_target("cpu")
+
+
+def test_compile_options_pin_arch_and_preserve_extras(fake_devices):
+    extras = (cute.EnableTVMFFI(True), cute.OptLevel(3))
+    options = dt.gdn_compile_options("cuda:1", *extras)
+
+    assert isinstance(options[0], cute.GPUArch)
+    assert options[0].value == "sm_100a"
+    assert options[1:] == extras
+
+
+def test_gdn_compile_sites_do_not_pass_string_options():
+    """``cute.compile[opts](..., options="...")`` drops ``opts`` instead of merging.
+
+    The DSL replaces subscripted options wholesale when a string ``options=``
+    kwarg is present, so a string here would silently un-pin the target arch.
+    """
+    offenders = []
+    for path in sorted(GDN_KERNELS_DIR.rglob("*.py")):
+        tree = ast.parse(path.read_text(), filename=str(path))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            if "compile" not in ast.dump(node.func):
+                continue
+            for kw in node.keywords:
+                if kw.arg == "options" and isinstance(kw.value, ast.Constant):
+                    offenders.append(f"{path.name}:{node.lineno}")
+
+    assert not offenders, (
+        "pass compile options via cute.compile[gdn_compile_options(device, ...)] "
+        f"instead of a string options= kwarg: {offenders}"
+    )
+
+
+def test_bf16_mtp_tile_v_follows_device_sm_count():
+    from flashinfer.gdn_kernels import gdn_decode_bf16_state as bf16_state
+
+    small_gpu, _ = bf16_state._get_bf16_mtp_config(4, 2, 64, 128, num_sms=16)
+    large_gpu, _ = bf16_state._get_bf16_mtp_config(4, 2, 64, 128, num_sms=132)
+    assert small_gpu != large_gpu
+
+
+@pytest.mark.skipif(
+    torch.cuda.device_count() < 2, reason="needs at least two CUDA devices"
+)
+def test_decode_matches_across_current_device(monkeypatch):
+    """Operands on cuda:1 must decode identically whatever the current device is."""
+    from flashinfer.gdn_decode import gated_delta_rule_decode_pretranspose
+
+    B, T, H, HV, K, V = 2, 1, 4, 4, 128, 128
+    device = torch.device("cuda", 1)
+    torch.manual_seed(0)
+
+    def make(dtype):
+        return torch.randn(B, T, H, K, dtype=dtype, device=device) * 0.1
+
+    q, k = make(torch.bfloat16), make(torch.bfloat16)
+    v = torch.randn(B, T, HV, V, dtype=torch.bfloat16, device=device) * 0.1
+    a = torch.randn(B, T, HV, dtype=torch.bfloat16, device=device) * 0.1
+    b = torch.randn(B, T, HV, dtype=torch.bfloat16, device=device) * 0.1
+    A_log = torch.randn(HV, dtype=torch.float32, device=device) * 0.1
+    dt_bias = torch.randn(HV, dtype=torch.float32, device=device) * 0.1
+    state = torch.randn(B, HV, V, K, dtype=torch.bfloat16, device=device) * 0.1
+
+    def run():
+        out, _ = gated_delta_rule_decode_pretranspose(
+            q=q,
+            k=k,
+            v=v,
+            state=state.clone(),
+            A_log=A_log,
+            a=a,
+            dt_bias=dt_bias,
+            b=b,
+            scale=1.0 / math.sqrt(K),
+            use_qk_l2norm=True,
+        )
+        return out
+
+    torch.cuda.set_device(0)
+    from_other_device = run()
+    torch.cuda.set_device(1)
+    from_same_device = run()
+
+    torch.testing.assert_close(
+        from_other_device.float(), from_same_device.float(), atol=0, rtol=0
+    )

--- a/tests/gdn/test_gdn_device_target.py
+++ b/tests/gdn/test_gdn_device_target.py
@@ -45,6 +45,9 @@ def fake_devices(monkeypatch):
     )
     monkeypatch.setattr(torch.cuda, "current_device", lambda: 0)
     monkeypatch.delenv("CUTE_DSL_ARCH", raising=False)
+    # The real DSL arch comes from the host's device 0; neutralize it so these tests
+    # exercise resolution alone. test_rejects_* below drive the guard directly.
+    monkeypatch.setattr(dt, "_dsl_runtime_arch", lambda: None)
     dt._resolve.cache_clear()
     yield
     dt._resolve.cache_clear()
@@ -94,6 +97,18 @@ def test_non_cuda_device_is_rejected(fake_devices):
         dt.gdn_device_target("cpu")
 
 
+def test_rejects_a_device_the_dsl_would_cross_compile_for(fake_devices, monkeypatch):
+    """A mismatch here yields no JIT engine, so fail with the remedy instead."""
+    monkeypatch.setattr(dt, "_dsl_runtime_arch", lambda: "sm_89")
+    with pytest.raises(RuntimeError, match="CUTE_DSL_ARCH=sm_90a"):
+        dt.gdn_device_target("cuda:0")
+
+
+def test_accepts_a_device_matching_the_dsl_arch(fake_devices, monkeypatch):
+    monkeypatch.setattr(dt, "_dsl_runtime_arch", lambda: "sm_90a")
+    assert dt.gdn_device_target("cuda:0").arch == "sm_90a"
+
+
 def test_compile_options_pin_arch_and_preserve_extras(fake_devices):
     extras = (cute.EnableTVMFFI(True), cute.OptLevel(3))
     options = dt.gdn_compile_options("cuda:1", *extras)
@@ -140,6 +155,38 @@ def test_every_gdn_cute_compile_pins_an_explicit_target():
     )
 
 
+# tests/gdn/test_decode_ucache.py and benchmarks/bench_gdn_ucache_flush.py load these
+# by path to re-specialize them per dtype arm, so they execute outside the package.
+STANDALONE_LOADED = (
+    "gdn_decode_bf16_wy_ucache.py",
+    "gdn_decode_bf16_wy_ucache_flush.py",
+)
+
+
+@pytest.mark.parametrize("filename", STANDALONE_LOADED)
+def test_by_path_modules_guard_their_relative_imports(filename):
+    """A bare relative import raises ImportError when loaded outside the package."""
+    tree = ast.parse((GDN_KERNELS_DIR / filename).read_text(), filename=filename)
+    guarded = {
+        id(node)
+        for parent in ast.walk(tree)
+        if isinstance(parent, ast.Try)
+        for node in ast.walk(parent)
+        if isinstance(node, ast.ImportFrom)
+    }
+    unguarded = [
+        f"{filename}:{node.lineno}"
+        for node in ast.walk(tree)
+        if isinstance(node, ast.ImportFrom)
+        and node.level > 0
+        and id(node) not in guarded
+    ]
+    assert not unguarded, (
+        "wrap in try/ImportError with an absolute flashinfer.gdn_kernels fallback: "
+        f"{unguarded}"
+    )
+
+
 def test_bf16_mtp_tile_v_follows_device_sm_count():
     from flashinfer.gdn_kernels import gdn_decode_bf16_state as bf16_state
 
@@ -148,9 +195,20 @@ def test_bf16_mtp_tile_v_follows_device_sm_count():
     assert small_gpu != large_gpu
 
 
-@pytest.mark.skipif(
-    torch.cuda.device_count() < 2, reason="needs at least two CUDA devices"
-)
+def _gdn_capable_devices() -> list[int]:
+    """Indices of devices GDN supports, restricted to a single architecture.
+
+    The DSL builds a JIT engine only when its process-global arch (``CUTE_DSL_ARCH``
+    or CUDA device 0) can run the compiled target, so one process serves one arch.
+    """
+    by_capability: dict[tuple, list[int]] = {}
+    for index in range(torch.cuda.device_count()):
+        capability = torch.cuda.get_device_capability(index)
+        if capability[0] in (9, 10, 11, 12):
+            by_capability.setdefault(capability, []).append(index)
+    return max(by_capability.values(), key=len, default=[])
+
+
 def test_decode_agrees_across_devices():
     """The same decode must give the same answer on every device in one process.
 
@@ -158,6 +216,11 @@ def test_decode_agrees_across_devices():
     the device index entered the compile key the second device silently reused the
     first device's artifact.
     """
+    devices = _gdn_capable_devices()
+    if len(devices) < 2:
+        pytest.skip("needs two GDN-capable CUDA devices of the same architecture")
+    first, second = devices[0], devices[1]
+
     from flashinfer.gdn_decode import gated_delta_rule_decode_pretranspose
 
     B, T, H, HV, K, V = 2, 1, 4, 4, 128, 128
@@ -185,6 +248,6 @@ def test_decode_agrees_across_devices():
 
     original_device = torch.cuda.current_device()
     try:
-        torch.testing.assert_close(run_on(0), run_on(1), atol=0, rtol=0)
+        torch.testing.assert_close(run_on(first), run_on(second), atol=0, rtol=0)
     finally:
         torch.cuda.set_device(original_device)

--- a/tests/gdn/test_gdn_device_target.py
+++ b/tests/gdn/test_gdn_device_target.py
@@ -36,9 +36,9 @@ class _FakeProps:
 
 @pytest.fixture
 def fake_devices(monkeypatch):
-    """Two devices with different arch, SM count, and packed-FMA support."""
-    caps = {0: (9, 0), 1: (10, 0)}
-    sms = {0: 132, 1: 148}
+    """Three devices: two architectures, with cuda:0 and cuda:2 sharing one."""
+    caps = {0: (9, 0), 1: (10, 0), 2: (9, 0)}
+    sms = {0: 132, 1: 148, 2: 114}
     monkeypatch.setattr(torch.cuda, "get_device_capability", lambda i: caps[i])
     monkeypatch.setattr(
         torch.cuda, "get_device_properties", lambda i: _FakeProps(sms[i])
@@ -61,12 +61,13 @@ def test_device_target_reads_the_requested_device(fake_devices):
     assert (d1.arch, d1.num_sms, d1.use_packed_fma) == ("sm_100a", 148, True)
 
 
-def test_compile_key_separates_devices(fake_devices):
-    """A compiled artifact is pinned to the device it first ran on, so two devices
-    must not share a cache entry even when they are the same architecture."""
-    assert dt.gdn_device_target("cuda:0").compile_key != (
-        dt.gdn_device_target("cuda:1").compile_key
-    )
+def test_compile_key_separates_same_arch_devices(fake_devices):
+    """Cache entries hold device-resident default tensors, so same-arch devices
+    must not share one -- the arch alone cannot tell them apart."""
+    first, second = dt.gdn_device_target("cuda:0"), dt.gdn_device_target("cuda:2")
+
+    assert first.arch == second.arch
+    assert first.compile_key != second.compile_key
 
 
 def test_index_less_device_follows_current_device(fake_devices, monkeypatch):
@@ -128,8 +129,38 @@ def _is_cute_compile(func: ast.expr) -> bool:
     return isinstance(owner, ast.Attribute) and owner.attr == "cute"
 
 
+def _device_target_options(tree: ast.AST) -> set:
+    """Names bound to a ``gdn_compile_options(...)`` result in this module."""
+    return {
+        target.id
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Assign)
+        and isinstance(node.value, ast.Call)
+        and isinstance(node.value.func, ast.Name)
+        and node.value.func.id == "gdn_compile_options"
+        for target in node.targets
+        if isinstance(target, ast.Name)
+    }
+
+
+def _pins_a_device_target(subscript: ast.expr, bound: set) -> bool:
+    if isinstance(subscript, ast.Call):
+        return (
+            isinstance(subscript.func, ast.Name)
+            and subscript.func.id == "gdn_compile_options"
+        )
+    return isinstance(subscript, ast.Name) and subscript.id in bound
+
+
+# delta_rule_dsl/ and blackwell/gdn_cp_prefill.py compile through this shim, which
+# takes already-pinned options from its callers. Those callers pin an arch of their
+# own but key nothing by device; that is the rest of GDN-H3 (#4214).
+OPTIONS_FROM_CALLER = ("custom_compile_cache.py",)
+
+
 def test_every_gdn_cute_compile_pins_an_explicit_target():
-    """Un-subscripted ``cute.compile`` targets whatever the DSL picks (device 0).
+    """Un-subscripted ``cute.compile`` targets whatever the DSL picks (device 0),
+    and a subscript carrying no ``GPUArch`` is no better.
 
     A string ``options=`` kwarg is equally unsafe: the DSL replaces subscripted
     options wholesale when one is present, silently dropping the ``GPUArch``.
@@ -137,11 +168,15 @@ def test_every_gdn_cute_compile_pins_an_explicit_target():
     unpinned, string_options = [], []
     for path in sorted(GDN_KERNELS_DIR.rglob("*.py")):
         tree = ast.parse(path.read_text(), filename=str(path))
+        bound = _device_target_options(tree)
         for node in ast.walk(tree):
             if not isinstance(node, ast.Call) or not _is_cute_compile(node.func):
                 continue
             where = f"{path.name}:{node.lineno}"
-            if not isinstance(node.func, ast.Subscript):
+            if path.name not in OPTIONS_FROM_CALLER and not (
+                isinstance(node.func, ast.Subscript)
+                and _pins_a_device_target(node.func.slice, bound)
+            ):
                 unpinned.append(where)
             if any(
                 kw.arg == "options" and isinstance(kw.value, ast.Constant)
@@ -152,6 +187,68 @@ def test_every_gdn_cute_compile_pins_an_explicit_target():
     assert not unpinned and not string_options, (
         "call cute.compile[gdn_compile_options(device, ...)](...) instead; "
         f"unpinned={unpinned} string_options={string_options}"
+    )
+
+
+# Queries that answer for the ambient device instead of the operand's. Dispatch
+# makes the operand's device current today, so a bare call agrees by luck until
+# something invokes the kernel from anywhere else.
+AMBIENT_DEVICE_READS = (
+    "current_device",
+    "current_stream",
+    "gdn_compile_options",
+    "gdn_device_target",
+    "get_device_capability",
+    "get_device_properties",
+    "get_num_sm",
+)
+
+
+def _call_name(node: ast.Call) -> str:
+    func = node.func
+    if isinstance(func, ast.Attribute):
+        return func.attr
+    return func.id if isinstance(func, ast.Name) else ""
+
+
+def _ambient_device_reads(path: pathlib.Path) -> list:
+    """Device queries naming no device, or a hardcoded one."""
+    found = []
+    tree = ast.parse(path.read_text(), filename=str(path))
+    for node in ast.walk(tree):
+        name = _call_name(node) if isinstance(node, ast.Call) else ""
+        if name not in AMBIENT_DEVICE_READS:
+            continue
+        if (not node.args and not node.keywords) or (
+            node.args and isinstance(node.args[0], ast.Constant)
+        ):
+            found.append(f"{path.name}:{node.lineno} {name}")
+    return found
+
+
+def test_device_target_adopters_read_policy_off_the_operand():
+    """Launch policy and streams must follow the operand's device.
+
+    ``num_sms`` and ``use_packed_fma`` choose tile shapes and codegen, so taking
+    them from device 0 mistunes -- or miscompiles -- every other device, and a
+    stream from the ambient device launches somewhere else entirely. Both are
+    invisible on a single-GPU box, so guard them by AST: no GPU needed.
+    """
+    adopters = [
+        path
+        for path in sorted(GDN_KERNELS_DIR.rglob("*.py"))
+        if path.name != "device_target.py" and "gdn_compile_options" in path.read_text()
+    ]
+    assert adopters, "nothing imports gdn_compile_options; did the helper move?"
+    offenders = {
+        name: reads
+        for path in adopters
+        for name, reads in [(path.name, _ambient_device_reads(path))]
+        if reads
+    }
+    assert not offenders, (
+        f"name the operand's device: {offenders}. Launch policy comes from "
+        "gdn_device_target(q.device), streams from current_stream(q.device)."
     )
 
 
@@ -209,23 +306,14 @@ def _gdn_capable_devices() -> list[int]:
     return max(by_capability.values(), key=len, default=[])
 
 
-def test_decode_agrees_across_devices():
-    """The same decode must give the same answer on every device in one process.
+B, H, HV, K, V = 2, 4, 4, 128, 128
+SCALE = 1.0 / math.sqrt(K)
 
-    A compiled CuTe-DSL artifact is pinned to the device it first ran on, so before
-    the device index entered the compile key the second device silently reused the
-    first device's artifact.
-    """
-    devices = _gdn_capable_devices()
-    if len(devices) < 2:
-        pytest.skip("needs two GDN-capable CUDA devices of the same architecture")
-    first, second = devices[0], devices[1]
 
-    from flashinfer.gdn_decode import gated_delta_rule_decode_pretranspose
-
-    B, T, H, HV, K, V = 2, 1, 4, 4, 128, 128
+def _cross_device_inputs(T: int, index: int) -> dict:
+    """Identical operands on ``index``, seeded so every device gets the same bits."""
     torch.manual_seed(0)
-    cpu_inputs = {
+    cpu = {
         "q": torch.randn(B, T, H, K, dtype=torch.bfloat16) * 0.1,
         "k": torch.randn(B, T, H, K, dtype=torch.bfloat16) * 0.1,
         "v": torch.randn(B, T, HV, V, dtype=torch.bfloat16) * 0.1,
@@ -235,16 +323,71 @@ def test_decode_agrees_across_devices():
         "dt_bias": torch.randn(HV, dtype=torch.float32) * 0.1,
         "state": torch.randn(B, HV, V, K, dtype=torch.bfloat16) * 0.1,
     }
+    return {name: tensor.cuda(index) for name, tensor in cpu.items()}
 
-    def run_on(index):
-        # The DSL binds an artifact to the current device, so make it the operand's.
-        with torch.cuda.device(index):
-            args = {k: v.cuda(index) for k, v in cpu_inputs.items()}
-            out, _ = gated_delta_rule_decode_pretranspose(
-                **args, scale=1.0 / math.sqrt(K), use_qk_l2norm=True
-            )
-            torch.cuda.synchronize(index)
-            return out.float().cpu()
+
+def _pretranspose_on(index: int) -> torch.Tensor:
+    from flashinfer.gdn_decode import gated_delta_rule_decode_pretranspose
+
+    with torch.cuda.device(index):
+        args = _cross_device_inputs(T=1, index=index)
+        out, _ = gated_delta_rule_decode_pretranspose(
+            **args, scale=SCALE, use_qk_l2norm=True
+        )
+        torch.cuda.synchronize(index)
+        return out.float().cpu()
+
+
+def _bf16_state_mtp_on(index: int) -> torch.Tensor:
+    """The bf16-state MTP entry, whose cache value holds per-B default tensors.
+
+    ``accepted_steps`` is one of them, built on ``q.device`` and dereferenced by
+    the kernel, so an entry shared across devices hands the second device a
+    pointer into the first device's memory.
+    """
+    from flashinfer.gdn_kernels.gdn_decode_bf16_state import gated_delta_rule_mtp
+
+    with torch.cuda.device(index):
+        args = _cross_device_inputs(T=2, index=index)
+        out = gated_delta_rule_mtp(
+            A_log=args["A_log"],
+            a=args["a"],
+            dt_bias=args["dt_bias"],
+            q=args["q"],
+            k=args["k"],
+            v=args["v"],
+            b=args["b"],
+            initial_state_source=args["state"],
+            initial_state_indices=torch.arange(
+                B, dtype=torch.int32, device=f"cuda:{index}"
+            ),
+            use_qk_l2norm_in_kernel=True,
+            scale=SCALE,
+        )
+        torch.cuda.synchronize(index)
+        return out.float().cpu()
+
+
+CROSS_DEVICE_ENTRIES = {
+    "pretranspose": _pretranspose_on,
+    "bf16_state_mtp": _bf16_state_mtp_on,
+}
+
+
+@pytest.mark.parametrize("entry", sorted(CROSS_DEVICE_ENTRIES))
+def test_decode_agrees_across_devices(entry):
+    """The same decode must give the same answer on every device in one process.
+
+    Before the device index entered the compile key, the second device reused the
+    first's cache entry -- and with it the device-resident default tensors that
+    entry holds. ``bf16_state_mtp`` is the arm that can actually fail: pretranspose
+    keys its own per-device auxiliaries, so it is a sanity check, not a guard.
+    """
+    devices = _gdn_capable_devices()
+    if len(devices) < 2:
+        pytest.skip("needs two GDN-capable CUDA devices of the same architecture")
+    first, second = devices[0], devices[1]
+    run_on = CROSS_DEVICE_ENTRIES[entry]
 
     original_device = torch.cuda.current_device()
     try:

--- a/tests/gdn/test_multistream_overlap.py
+++ b/tests/gdn/test_multistream_overlap.py
@@ -300,6 +300,8 @@ def test_blackwell_prefill_workspace_not_in_compile_cache():
 
     # White-box: no workspace tensors may live in the compile-cache value.
     cache = prefill_mod._get_compiled_cache(
+        prefill_mod.gdn_device_target(device).compile_key,
+        prefill_mod.get_num_sm(device),
         str(x1["q"].dtype),
         str(x1["initial_state"].dtype),
         HQ,


### PR DESCRIPTION
## Summary

PR #2 of the GDN CuTe-DSL cache audit (#4214), covering **GDN-H2** and **GDN-H3**: GDN decode compiled and tuned for whatever GPU is CUDA device 0, not for the device the operands live on.

- **GDN-H2** — `gdn_decode_bf16_state.py` read SM count and compute capability from device 0 at import time. Those drive the `tile_v` wave heuristic and the `use_packed_fma` Constexpr, so operands elsewhere got the wrong specialization. On a mixed L40S + H100 NVL box, `_get_bf16_mtp_config(B=17, T=2, HV=32, V=128)` picks `tile_v=64` from the L40S's 142 SMs but `tile_v=128` from the H100's 132.
- **GDN-H3** — every GDN `cute.compile` omitted an explicit target, so the DSL resolved the arch from device 0, and the cubin was cached under a key containing neither arch nor device.

## What this does

New `flashinfer/gdn_kernels/device_target.py` resolves one target per device (arch, SM count, `use_packed_fma`, honoring `CUTE_DSL_ARCH`). The GDN decode and Blackwell prefill compile sites now drive both their compile options and their cache keys from that target, and launch streams follow `q.device`.

Two constraints shaped it:

- Compile options had to move from the string form to option objects. The DSL replaces subscripted options wholesale when a string `options=` is present, so `cute.compile[(GPUArch(...),)](..., options="...")` silently drops the arch.
- The target splits across two identities. The in-process key carries `(device_index, arch)` because those entries also hold device-resident default tensors that nothing else keys by device; the compiled artifact itself is device agnostic from DSL 4.6.2 on. The on-disk artifact name carries the arch alone — naming it by device would give every GPU its own copy of every kernel and defeat the disk cache.

Pinning `GPUArch` does not by itself let one process serve another device's architecture: the DSL builds a JIT engine only when its process-global arch (`CUTE_DSL_ARCH`, else device 0) can run the requested target. That case now raises an error naming `CUTE_DSL_ARCH=<arch>` instead of a DSL internal error or a launch-time `cudaErrorNoKernelImageForDevice`.

On homogeneous hardware this is a no-op: the arch suffix rule is the one the DSL's own `detect_gpu_arch` uses, so the compiled arch string is byte-identical to what it picked implicitly.

## Testing

B200 (`sm_100a`), `nvidia-cutlass-dsl==4.7.0`: full `tests/gdn/` — 3810 passed, 928 skipped, 13 failed, with all 13 reproducing on unmodified main in the same environment (12 isolated-subprocess tests that import `flashinfer` from the editable install; 1 disk-cache round trip that never triggers a compile). Earlier run on the mixed L40S + H100 NVL box: 3760 passed, 984 skipped, 0 failed.

`tests/gdn/test_gdn_device_target.py` adds resolver coverage (requested device, `CUTE_DSL_ARCH` override of arch *and* policy, rejection of a target the DSL would cross-compile), two AST guards — compile sites must pin the operand's target, and adopters must not read launch policy or streams off the ambient device — and a multi-GPU bit-exactness test that skips on a single-GPU box. The guards are mutation-checked: dropping the arch from the options, the device from the key's consumers, or the device from a stream or policy read each fails at least one.

Still to do before leaving draft: the multi-GPU test on a homogeneous two-GPU box. Its bf16-state MTP arm is the one that can fail there, since that cache value holds per-B index tensors the kernel dereferences; both arms have been run single-device.

## Out of scope

- GDN-H4 staging / workspace ownership → #4476
- `delta_rule_dsl/` and `blackwell/gdn_cp_prefill.py` compile through their own `cached_compile` shim (~20 sites). They do pin an arch, but from a module constant rather than the operand's device, and their cache is not keyed by device — the same GDN-H3 defect, left for a follow-up.
- `_get_compile_arch()` in `flashinfer/jit/cute_dsl_core.py` resolves the disk cache's arch from the *current* device, which need not be the operand's — the same defect one layer down. Harmless today only because this PR puts the arch in the kernel name, so a mislabeled directory cannot collide with a correctly labeled one.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added device-aware compilation for GDN kernels, automatically selecting architecture-specific options and execution settings.
  - Added support for cross-compilation architecture overrides with validation.
  - Improved kernel caching to distinguish device targets and architectures while sharing compatible compiled artifacts.

- **Bug Fixes**
  - Ensured kernels use the correct device-associated CUDA stream and runtime properties.

- **Tests**
  - Expanded coverage for device targeting, compilation options, cache specialization, multi-device execution, and cross-device consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->