### PR TITLE
gemm: enable CUTLASS NVFP4 SVDQuant on SM107

### DIFF
--- a/flashinfer/gemm/gemm_svdquant.py
+++ b/flashinfer/gemm/gemm_svdquant.py
@@ -142,7 +142,7 @@ _NVFP4_SVDQUANT_GEMM_TUNING_CONFIG = TuningConfig(
 )
 
 
-@supported_compute_capability([100, 103])
+@supported_compute_capability([100, 103, 107])
 def _cutlass_nvfp4_svdquant_requirement(*args, **kwargs):
     return True
 

--- a/flashinfer/jit/gemm/core.py
+++ b/flashinfer/jit/gemm/core.py
@@ -163,7 +163,7 @@ def gen_gemm_sm100_module_cutlass_nvfp4_svdquant() -> JitSpec:
             write_if_different(dest_path, source)
 
     nvcc_flags = current_compilation_context.get_nvcc_flags_list(
-        supported_major_versions=[10]
+        supported_major_versions=[10], map_sm107_to_100f=True
     )
     return gen_jit_spec(
         "nvfp4_svdquant_gemm_cutlass",


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->

Fixes tests/gemm/test_nvfp4_svdquant_gemm.py failures on SM 107 by extending the support surface of CUTLASS NVFP4 SVDQuant. No kernel changes are made. We are just adding the SM100f (and SM107 when supported) compilation targets.

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for SVDQuant GEMM operations on compute capability 107 hardware.
  * Enabled NVFP4 SVDQuant GEMM compilation for SM107 devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->