### PR TITLE
test: make heavy attention test files more efficient (bulk JIT precompile + faster references)

### DIFF
--- a/tests/attention/conftest.py
+++ b/tests/attention/conftest.py
@@ -2,9 +2,15 @@
 Conftest file for attention tests.
 
 Current features:
-1.  Bulk-precompile XQA decode kernels before the test file
-``test_trtllm_gen_attention_decode_xqa.py`` runs. Bulk-precompile avoids
-sequential compilation of kernels that can occupy 95% of the test's wall time.
+1.  Bulk-precompile JIT kernels before heavy test files run. Sequential
+first-use compilation inside a test session can occupy 85-95% of a file's
+wall time (measured on H100 CI: test_trtllm_gen_attention_decode_xqa.py,
+test_hopper_fp8_attention.py, test_fmha_v2_prefill.py,
+test_batch_prefill_kernels.py). For each registered file we derive the set
+of JitSpecs its collected test cases will need (mirroring the tests' own
+skip guards), compile them as one parallel ninja graph, and stage the
+resulting .so files into the AOT dir so test-time loads skip the
+per-module ninja dependency scan entirely.
 """
 
 import contextlib
@@ -15,8 +21,6 @@ import pytest
 import torch
 
 logger = logging.getLogger(__name__)
-
-_XQA_FILE = "test_trtllm_gen_attention_decode_xqa.py"
 
 _DT = {"bf16": torch.bfloat16, "fp16": torch.float16, "fp8": torch.float8_e4m3fn}
 
@@ -47,96 +51,394 @@ def _executed_xqa_uri(p):
     )
 
 
+def _xqa_specs(items):
+    from flashinfer.jit.xqa import gen_xqa_module
+
+    specs = {}
+    for it in items:
+        cs = getattr(it, "callspec", None)
+        if cs is None:
+            continue
+        kwargs = _executed_xqa_uri(cs.params)
+        if kwargs is None:
+            continue
+        try:
+            spec = gen_xqa_module(**kwargs)
+        except ValueError as e:
+            # Per-config unsupported (bad dtype/page_size/head_dim): skip just
+            # this config and keep prebuilding the rest.
+            logger.debug("prebuild: skipping unsupported xqa config %s: %s", kwargs, e)
+            continue
+        specs[spec.name] = spec
+    return list(specs.values())
+
+
+def _hopper_fp8_specs(items):
+    """JitSpecs for test_hopper_fp8_attention.py.
+
+    All tests in the file skip on non-SM90A. Module URIs depend only on
+    (backend, dtypes, head_dim); seq_len/batch_size/causal/M/N/R/C/num_heads/
+    page_size/scale_type do not affect them. The BatchDecode wrapper with
+    use_tensor_cores=True routes to the batch *prefill* module, so no decode
+    module is needed.
+    """
+    from flashinfer.utils import is_sm90a_supported
+
+    if not is_sm90a_supported(torch.device("cuda")):
+        return []
+
+    from flashinfer.prefill import gen_batch_prefill_module, gen_single_prefill_module
+    from flashinfer.quantization import gen_quantization_module
+
+    H, I = torch.half, torch.int32
+    specs = {}
+
+    def add(spec):
+        specs[spec.name] = spec
+
+    # Dedup on the parameter key BEFORE invoking any generator: spec
+    # construction is not free (jinja render + source writes), so it must run
+    # once per unique module, not once per collected test item.
+    single_keys = set()  # (backend, dtype, head_dim)
+    batch_keys = set()  # (dtype, head_dim)
+    need_quantization = False
+    for it in items:
+        cs = getattr(it, "callspec", None)
+        if cs is None:
+            continue
+        p = cs.params
+        fn = it.name.split("[")[0]
+        hd = p.get("head_dim", 128)
+        d = p.get("dtype", torch.float8_e4m3fn)
+        if fn == "test_single_prefill":
+            # fp16 fa3 reference + fp8 fa3 kernel
+            single_keys.add(("fa3", H, hd))
+            single_keys.add(("fa3", d, hd))
+        elif fn == "test_block_sparse_attention":
+            # fa2 custom-mask reference (+ packbits) + fp8 fa3 sparse wrapper
+            need_quantization = True
+            single_keys.add(("fa2", H, hd))
+            batch_keys.add((d, hd))
+        else:
+            # batch prefill ragged/paged/gqa, tensor-core decode, scale types:
+            # fp16 fa3 reference + fp8 fa3 kernel share the batch prefill module
+            batch_keys.add((H, hd))
+            batch_keys.add((d, hd))
+    for backend, d, hd in sorted(single_keys, key=str):
+        add(gen_single_prefill_module(backend, d, d, H, hd, hd, 0, False, False, False))
+    for d, hd in sorted(batch_keys, key=str):
+        add(gen_batch_prefill_module("fa3", d, d, H, I, hd, hd, 0, False, False, False))
+    if need_quantization:
+        add(gen_quantization_module())
+    return list(specs.values())
+
+
+def _fmha_v2_specs(items):
+    """JitSpecs for test_fmha_v2_prefill.py.
+
+    gen_fmha_v2_module URIs depend only on (input_layout, q dtype, o dtype);
+    all mask/window/softcap/skip-softmax kernel variants live inside one spec.
+    The attention-sink tests additionally compile an fa2/fa3 customize batch
+    prefill module (the AttentionSink variant) as reference.
+    """
+    from flashinfer.jit import gen_customize_batch_prefill_module, gen_fmha_v2_module
+    from flashinfer.jit.attention.variants import attention_sink_decl
+    from flashinfer.jit.utils import filename_safe_dtype_map
+    from flashinfer.utils import is_sm12x_supported, is_sm90a_supported
+
+    device = torch.device("cuda")
+    sm90 = is_sm90a_supported(device)
+    sm12x = is_sm12x_supported(device)
+    if not sm90 and not sm12x:
+        return []  # every test in the file skips: FMHA v2 needs SM90a or SM12x
+
+    specs = {}
+
+    def add(spec):
+        specs[spec.name] = spec
+
+    # Dedup on the parameter key BEFORE invoking any generator:
+    # gen_fmha_v2_module runs a heavyweight source-codegen pass, so it must be
+    # called once per unique (layout, dtype, o_dtype), not once per collected
+    # test item (~2.4k items would grind for many minutes).
+    fmha_keys = set()  # (layout, dtype, o_dtype-or-None)
+    sink_keys = set()  # (dtype, use_swa, head_dim)
+    need_sm120_module = False
+    for it in items:
+        cs = getattr(it, "callspec", None)
+        if cs is None:
+            continue
+        p = cs.params
+        fn = it.name.split("[")[0]
+        if fn == "test_fmha_v2_prefill_deepseek":
+            need_sm120_module = sm12x
+            continue
+        if fn == "test_trtllm_fmha_v2_prefill_sm120_large_head_dim" and not sm12x:
+            continue  # test skips on non-SM12x
+        dtype = p.get("dtype", torch.float16)
+        o_dtype = p.get("o_dtype")
+        layout = p.get(
+            "input_layout", "SEPARATE_Q_K_V"
+        )  # sinks test has no layout param
+        is_fp8 = dtype == torch.float8_e4m3fn
+        if not sm90 and (is_fp8 or layout == "SEPARATE_Q_K_V"):
+            continue  # mirrored from the test's SM12x skip guards
+        fmha_keys.add((layout, dtype, o_dtype if is_fp8 else None))
+        if fn == "test_trtllm_fmha_v2_prefill_attention_sinks":
+            sink_keys.add(
+                (dtype, p.get("window_left", -1) >= 0, p.get("head_dim", 128))
+            )
+
+    if need_sm120_module:
+        from flashinfer.jit import gen_trtllm_fmha_v2_sm120_module
+
+        add(gen_trtllm_fmha_v2_sm120_module())
+    for layout, dtype, o_dtype in sorted(fmha_keys, key=str):
+        add(gen_fmha_v2_module(layout, dtype, o_dtype))
+    for dtype, use_swa, head_dim in sorted(sink_keys, key=str):
+        # Reference path: BatchAttentionWithAttentionSinkWrapper(backend="fa3")
+        # (see flashinfer/attention/_core.py jit_args construction).
+        add(
+            gen_customize_batch_prefill_module(
+                "fa3",
+                f"batch_prefill_attention_sink_{filename_safe_dtype_map[dtype]}_swa_{use_swa}_fa3",
+                dtype,  # dtype_q
+                dtype,  # dtype_kv
+                dtype,  # dtype_o
+                torch.int32,  # idtype
+                head_dim,
+                head_dim,
+                ["sink"],
+                ["float"],
+                ["sm_scale"],
+                ["double"],
+                "AttentionSink",
+                attention_sink_decl["fa3"],
+                pos_encoding_mode=0,
+                use_sliding_window=use_swa,
+                use_fp16_qk_reduction=False,
+            )
+        )
+    return list(specs.values())
+
+
+def _batch_prefill_specs(items):
+    """JitSpecs for test_batch_prefill_kernels.py.
+
+    The file's module-scoped warmup_jit fixture covers the main fp16/fp8-kv
+    grids for head_dim 128/256; this collector adds the gap modules measured
+    as serial first-use compiles (head_dim 64/512, ALIBI, soft-cap, NVFP4
+    uint8-kv, bf16 references, cta-tile probes) and also includes the
+    fixture's grid so everything gets staged into the AOT dir (making the
+    fixture itself a fast no-op via skip_prebuilt).
+    """
+    from flashinfer.prefill import gen_batch_prefill_module, gen_single_prefill_module
+    from flashinfer.utils import get_compute_capability, is_sm90a_supported
+
+    device = torch.device("cuda")
+    cc_major = get_compute_capability(device)[0]
+    sm90 = is_sm90a_supported(device)
+
+    H, B, I, U8 = torch.half, torch.bfloat16, torch.int32, torch.uint8
+    specs = {}
+
+    def add(spec):
+        specs[spec.name] = spec
+
+    def bp(*args, **kwargs):
+        add(gen_batch_prefill_module(*args, **kwargs))
+
+    def sp(*args, **kwargs):
+        add(gen_single_prefill_module(*args, **kwargs))
+
+    fns = {it.name.split("[")[0] for it in items if getattr(it, "callspec", True)}
+
+    main_grid_fns = {
+        "test_batch_prefill_with_paged_kv_cache",
+        "test_batch_prefill_with_tuple_paged_kv_cache",
+        "test_batch_prefill_with_paged_kv_cache_custom_mask",
+        "test_batch_prefill_with_ragged_kv_cache",
+    }
+    if fns & main_grid_fns:
+        # head_dim 64 cases (fixture only builds 128/256); references use
+        # single_prefill with backend auto (fa3 on SM90 for pos_encoding 0).
+        for p in (0, 1):
+            bp("fa2", H, H, H, I, 64, 64, p, False, False, False)
+            sp("fa2", H, H, H, 64, 64, p, False, False, False)
+        if sm90:
+            bp("fa3", H, H, H, I, 64, 64, 0, False, False, False)
+            sp("fa3", H, H, H, 64, 64, 0, False, False, False)
+        # Fixture grid, included here so it gets AOT-staged.
+        try:
+            from tests.test_helpers.jit_utils import gen_prefill_attention_modules
+
+            for spec in gen_prefill_attention_modules(
+                [torch.float16],
+                [torch.float16, torch.float8_e4m3fn, torch.float8_e5m2],
+                [128, 256],
+                [0, 1],
+                [False],
+                [False],
+                [False],
+            ):
+                add(spec)
+        except ImportError:  # pragma: no cover - fixture still builds these
+            pass
+
+    # 16-bit FA2 head_dim > 256 needs SM80+ (tests use
+    # skip_if_head_dim_unsupported); don't build those modules on older GPUs.
+    hd512_ok = cc_major >= 8
+
+    if hd512_ok and fns & {
+        "test_batch_prefill_with_paged_kv_cache_head_dim_512",
+        "test_batch_prefill_with_ragged_kv_cache_head_dim_512",
+        "test_batch_prefill_paged_shared_kv_smem_unequal_kv_strides",
+    }:
+        # head_dim 512 forces fa2 for both wrapper and reference.
+        for p in (0, 1):
+            bp("fa2", H, H, H, I, 512, 512, p, False, False, False)
+            sp("fa2", H, H, H, 512, 512, p, False, False, False)
+
+    if "test_batch_prefill_with_ragged_kv_cache_custom_mask" in fns:
+        # custom mask forces fa2; ALIBI (=2) and soft-cap are fixture gaps.
+        for hd in (128, 256):
+            for p in (0, 1, 2):
+                for softcap in (False, True):
+                    bp("fa2", H, H, H, I, hd, hd, p, False, softcap, False)
+
+    if "test_batch_prefill_with_paged_kv_cache_multi_item_scoring" in fns:
+        for softcap in (False, True):
+            bp("fa2", H, H, H, I, 128, 128, 1, False, softcap, False)
+            sp("fa2", H, H, H, 128, 128, 1, False, softcap, False)
+
+    nvfp4_fns = {
+        "test_batch_prefill_with_paged_kv_cache_nvfp4",
+        "test_batch_prefill_with_paged_kv_cache_nvfp4_strided_scale_views",
+        "test_batch_prefill_with_ragged_kv_cache_nvfp4",
+        "test_batch_prefill_with_paged_kv_cache_nvfp4_large_head",
+        "test_batch_prefill_with_paged_kv_cache_nvfp4_large_head_bf16",
+        "test_batch_prefill_with_paged_kv_cache_nvfp4_rope_large_head",
+        "test_batch_prefill_with_paged_kv_cache_nvfp4_rope_large_head_bf16",
+        "test_batch_prefill_with_ragged_kv_cache_nvfp4_large_head",
+        "test_batch_prefill_with_ragged_kv_cache_nvfp4_rope_large_head",
+    }
+    if fns & nvfp4_fns:
+        # NVFP4 KV is uint8 (fp4x2_e2m1) and always fa2; references run on the
+        # dequantized dtype (bf16 references are not in the fixture grid).
+        for q in (H, B):
+            bp("fa2", q, U8, q, I, 128, 128, 0, False, False, False)
+            sp("fa2", q, q, q, 128, 128, 0, False, False, False)
+            if sm90:
+                sp("fa3", q, q, q, 128, 128, 0, False, False, False)
+            if hd512_ok:
+                for p in (0, 1):
+                    bp("fa2", q, U8, q, I, 512, 512, p, False, False, False)
+                    sp("fa2", q, q, q, 512, 512, p, False, False, False)
+
+    if (
+        "test_batch_prefill_with_paged_kv_cache_nvfp4_asymmetric" in fns
+        and cc_major >= 10
+    ):
+        for hd_qk, hd_vo in ((512, 256), (256, 128)):
+            bp("fa2", B, U8, B, I, hd_qk, hd_vo, 0, False, False, False)
+
+    if "test_batch_prefill_paged_cta_tile_q_smem_probe_qk448_vo256" in fns and hd512_ok:
+        bp("fa2", H, H, H, I, 448, 256, 0, False, False, False)
+        if cc_major >= 10:
+            bp("fa2", H, torch.float8_e4m3fn, H, I, 448, 256, 0, False, False, False)
+
+    return list(specs.values())
+
+
+# Registered heavy files: test file basename -> callable(items) -> list[JitSpec].
+_PREBUILD_SPEC_COLLECTORS = {
+    "test_trtllm_gen_attention_decode_xqa.py": _xqa_specs,
+    "test_hopper_fp8_attention.py": _hopper_fp8_specs,
+    "test_fmha_v2_prefill.py": _fmha_v2_specs,
+    "test_batch_prefill_kernels.py": _batch_prefill_specs,
+}
+
+
+def _stage_into_aot(specs):
+    """Hardlink (or copy) each freshly-built .so into the AOT path so
+    build_and_load loads it directly (no per-module ninja dependency scan at
+    test time). Returns the number of staged modules."""
+    staged = 0
+    for s in specs:
+        src = s.jit_library_path
+        dst = s.aot_path
+        if dst.exists() or not src.exists():
+            continue
+        dst.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            os.link(src, dst)  # hardlink: atomic + instant, same filesystem
+        except FileExistsError:
+            continue  # another worker staged it first; nothing to do
+        except OSError:
+            # Cross-filesystem (or link unsupported): copy to a temp file in
+            # the destination dir, then atomically rename into place so a
+            # concurrent worker never observes a partially written .so.
+            import shutil
+            import tempfile
+
+            fd, tmp = tempfile.mkstemp(dir=str(dst.parent), suffix=".tmp")
+            os.close(fd)
+            try:
+                shutil.copy2(src, tmp)
+                os.replace(tmp, dst)  # atomic on the same filesystem
+            except OSError:
+                with contextlib.suppress(OSError):
+                    os.unlink(tmp)
+                continue
+        staged += 1
+    return staged
+
+
 @pytest.hookimpl(trylast=True)
 def pytest_collection_modifyitems(session, config, items):
     # trylast: run after -k/-m deselection so we only build kernels for cases
     # that will actually execute.
-    xqa_items = [it for it in items if it.nodeid.split("::")[0].endswith(_XQA_FILE)]
-    if not xqa_items:
-        return
 
     # --collect-only enumerates tests without running them, so don't pre-build.
     if config.getoption("--collect-only"):
         return
 
     from flashinfer.jit.core import build_jit_specs
-    from flashinfer.jit.xqa import gen_xqa_module
 
     reporter = config.pluginmanager.getplugin("terminalreporter")
 
-    # The whole prebuild is a best-effort optimization. Any failure here must not
-    # abort collection for the entire suite.
-    try:
-        specs = {}
-        for it in xqa_items:
-            cs = getattr(it, "callspec", None)
-            if cs is None:
+    for fname, collect_specs in _PREBUILD_SPEC_COLLECTORS.items():
+        file_items = [it for it in items if it.nodeid.split("::")[0].endswith(fname)]
+        if not file_items:
+            continue
+
+        # The whole prebuild is a best-effort optimization. Any failure here
+        # must not abort collection for the entire suite.
+        try:
+            specs = collect_specs(file_items)
+            if not specs:
                 continue
-            kwargs = _executed_xqa_uri(cs.params)
-            if kwargs is None:
-                continue
-            try:
-                spec = gen_xqa_module(**kwargs)
-            except ValueError as e:
-                # Per-config unsupported (bad dtype/page_size/head_dim): skip just
-                # this config and keep prebuilding the rest.
-                logger.debug(
-                    "xqa-prebuild: skipping unsupported config %s: %s", kwargs, e
+
+            if reporter:
+                reporter.write_line(
+                    f"[jit-prebuild] {fname}: compiling {len(specs)} kernels in parallel..."
                 )
-                continue
-            specs[spec.name] = spec
 
-        specs = list(specs.values())
-        if not specs:
-            return
+            # One ninja graph, built in parallel; skip_prebuilt reuses anything
+            # already AOT'd.
+            build_jit_specs(specs, verbose=False)
+
+            staged = _stage_into_aot(specs)
+        except Exception as e:
+            if reporter:
+                reporter.write_line(
+                    f"[jit-prebuild] {fname}: prebuild failed ({e!r}); falling "
+                    "back to per-test JIT compilation."
+                )
+            continue
 
         if reporter:
             reporter.write_line(
-                f"[xqa-prebuild] compiling {len(specs)} XQA kernels in parallel..."
+                f"[jit-prebuild] {fname}: staged {staged} kernels into AOT dir; "
+                "tests will load-only."
             )
-
-        # One ninja graph, built in parallel; skip_prebuilt reuses anything already AOT'd.
-        build_jit_specs(specs, verbose=False)
-
-        # Stage each freshly-built .so into the AOT path so build_and_load loads it
-        # directly (no per-module ninja dependency scan at test time).
-        staged = 0
-        for s in specs:
-            src = s.jit_library_path
-            dst = s.aot_path
-            if dst.exists() or not src.exists():
-                continue
-            dst.parent.mkdir(parents=True, exist_ok=True)
-            try:
-                os.link(src, dst)  # hardlink: atomic + instant, same filesystem
-            except FileExistsError:
-                continue  # another worker staged it first; nothing to do
-            except OSError:
-                # Cross-filesystem (or link unsupported): copy to a temp file in
-                # the destination dir, then atomically rename into place so a
-                # concurrent worker never observes a partially written .so.
-                import shutil
-                import tempfile
-
-                fd, tmp = tempfile.mkstemp(dir=str(dst.parent), suffix=".tmp")
-                os.close(fd)
-                try:
-                    shutil.copy2(src, tmp)
-                    os.replace(tmp, dst)  # atomic on the same filesystem
-                except OSError:
-                    with contextlib.suppress(OSError):
-                        os.unlink(tmp)
-                    continue
-            staged += 1
-    except Exception as e:
-        if reporter:
-            reporter.write_line(
-                f"[xqa-prebuild] prebuild failed ({e!r}); falling back to "
-                "per-test JIT compilation."
-            )
-        return
-
-    if reporter:
-        reporter.write_line(
-            f"[xqa-prebuild] staged {staged} kernels into AOT dir; test will load-only."
-        )

--- a/tests/attention/conftest.py
+++ b/tests/attention/conftest.py
@@ -16,11 +16,16 @@ per-module ninja dependency scan entirely.
 import contextlib
 import logging
 import os
+import time
 
 import pytest
 import torch
 
 logger = logging.getLogger(__name__)
+
+# Set when a prebuild ran; pytest_sessionfinish uses it to flag collector
+# drift (modules that still compiled serially at test time).
+_prebuild_end_time = None
 
 _DT = {"bf16": torch.bfloat16, "fp16": torch.float16, "fp8": torch.float8_e4m3fn}
 
@@ -251,7 +256,7 @@ def _batch_prefill_specs(items):
     def sp(*args, **kwargs):
         add(gen_single_prefill_module(*args, **kwargs))
 
-    fns = {it.name.split("[")[0] for it in items if getattr(it, "callspec", True)}
+    fns = {it.name.split("[")[0] for it in items}
 
     main_grid_fns = {
         "test_batch_prefill_with_paged_kv_cache",
@@ -407,10 +412,12 @@ def pytest_collection_modifyitems(session, config, items):
 
     reporter = config.pluginmanager.getplugin("terminalreporter")
 
+    prebuilt_any = False
     for fname, collect_specs in _PREBUILD_SPEC_COLLECTORS.items():
         file_items = [it for it in items if it.nodeid.split("::")[0].endswith(fname)]
         if not file_items:
             continue
+        prebuilt_any = True
 
         # The whole prebuild is a best-effort optimization. Any failure here
         # must not abort collection for the entire suite.
@@ -442,3 +449,46 @@ def pytest_collection_modifyitems(session, config, items):
                 f"[jit-prebuild] {fname}: staged {staged} kernels into AOT dir; "
                 "tests will load-only."
             )
+
+    if prebuilt_any:
+        # Arm the collector-drift check in pytest_sessionfinish: anything
+        # nvcc-compiled after this point compiled serially at test time.
+        global _prebuild_end_time
+        _prebuild_end_time = time.time()
+
+
+@pytest.hookimpl(trylast=True)
+def pytest_sessionfinish(session, exitstatus):
+    """Collector-drift alarm.
+
+    If a registered file's dispatch logic changes (new dtype/layout/head_dim
+    -> new module URI) without its conftest collector being updated, the new
+    module silently compiles serially at test time and the file gets slow
+    again with no signal. Flag any nvcc module whose .so appeared after the
+    prebuild stage so the drift shows up as a one-line warning in the log.
+    """
+    if _prebuild_end_time is None:
+        return
+    try:
+        import flashinfer.jit.env as jit_env
+
+        late = sorted(
+            so.parent.name
+            for so in jit_env.FLASHINFER_JIT_DIR.rglob("*.so")
+            if so.stat().st_mtime > _prebuild_end_time
+        )
+        if not late:
+            return
+        reporter = session.config.pluginmanager.getplugin("terminalreporter")
+        if reporter:
+            shown = ", ".join(late[:5]) + (" ..." if len(late) > 5 else "")
+            reporter.write_line(
+                f"[jit-prebuild] WARNING: {len(late)} module(s) JIT-compiled "
+                f"after the prebuild stage: {shown}. If they belong to a "
+                "registered test file, its collector in "
+                "tests/attention/conftest.py has drifted from the test's "
+                "dispatch logic and should be updated.",
+                yellow=True,
+            )
+    except Exception:  # pragma: no cover - diagnostics must never fail the run
+        pass

--- a/tests/attention/test_batch_prefill_kernels.py
+++ b/tests/attention/test_batch_prefill_kernels.py
@@ -44,6 +44,31 @@ def skip_if_nvfp4_asymmetric_unsupported(head_dim_qk: int):
         )
 
 
+def _accumulate_mismatch_count(mismatch_counts, out, ref, rtol, atol):
+    """Record the per-request mismatch count on device without synchronizing.
+
+    The per-request reference loops used to call torch.testing.assert_close per
+    request, which synchronizes the device once per request (up to 128x per
+    test). Accumulating counts and checking once in _assert_no_ref_mismatch
+    keeps a single sync per test, with request-sized (not batch-sized)
+    comparison temporaries.
+    """
+    close = torch.isclose(
+        out.float(), ref.float(), rtol=rtol, atol=atol, equal_nan=True
+    )
+    mismatch_counts.append((~close).sum())
+
+
+def _assert_no_ref_mismatch(mismatch_counts):
+    counts = torch.stack(mismatch_counts).cpu()  # single device sync
+    if counts.any():
+        bad = counts.nonzero().flatten().tolist()
+        raise AssertionError(
+            f"output mismatches reference in request(s) {bad}; "
+            f"mismatched elements per request: {[int(counts[i]) for i in bad]}"
+        )
+
+
 @pytest.fixture(
     autouse=not has_flashinfer_jit_cache(),
     scope="module",
@@ -254,6 +279,7 @@ def test_batch_prefill_with_paged_kv_cache(
 
         g.replay()
 
+    mismatch_counts = []
     for i in range(batch_size):
         perm_dims = [0, 2, 1, 3] if kv_layout == "HND" else [0, 1, 2, 3]
         perm_dims_last = [1, 0, 2] if kv_layout == "HND" else [0, 1, 2]
@@ -305,7 +331,8 @@ def test_batch_prefill_with_paged_kv_cache(
             logits_soft_cap=logits_soft_cap,
         )
         o_i = o[q_indptr_cpu[i] : q_indptr_cpu[i + 1]]
-        torch.testing.assert_close(o_i, o_ref_i, rtol=1e-3, atol=1e-3)
+        _accumulate_mismatch_count(mismatch_counts, o_i, o_ref_i, rtol=1e-3, atol=1e-3)
+    _assert_no_ref_mismatch(mismatch_counts)
 
 
 @pytest.mark.parametrize("causal", [False, True])
@@ -372,6 +399,7 @@ def test_batch_prefill_with_paged_kv_cache_head_dim_512(
     torch.testing.assert_close(o, o_buffer, rtol=1e-3, atol=1e-3)
     torch.testing.assert_close(lse, lse_buffer, rtol=1e-3, atol=1e-3)
 
+    mismatch_counts = []
     for i in range(batch_size):
         qi = q[q_indptr_cpu[i] : q_indptr_cpu[i + 1]]
         ki = torch.cat(
@@ -405,7 +433,8 @@ def test_batch_prefill_with_paged_kv_cache_head_dim_512(
             backend="fa2",
         )
         o_i = o[q_indptr_cpu[i] : q_indptr_cpu[i + 1]]
-        torch.testing.assert_close(o_i, o_ref_i, rtol=1e-3, atol=1e-3)
+        _accumulate_mismatch_count(mismatch_counts, o_i, o_ref_i, rtol=1e-3, atol=1e-3)
+    _assert_no_ref_mismatch(mismatch_counts)
 
 
 @pytest.mark.parametrize("batch_size", [12, 17, 128])
@@ -593,6 +622,7 @@ def test_batch_prefill_with_tuple_paged_kv_cache(
         g.replay()
 
     k_cache, v_cache = kv_data_fp32
+    mismatch_counts = []
     for i in range(batch_size):
         perm_dims = [0, 2, 1, 3] if kv_layout == "HND" else [0, 1, 2, 3]
         perm_dims_last = [1, 0, 2] if kv_layout == "HND" else [0, 1, 2]
@@ -636,7 +666,8 @@ def test_batch_prefill_with_tuple_paged_kv_cache(
             logits_soft_cap=logits_soft_cap,
         )
         o_i = o[q_indptr_cpu[i] : q_indptr_cpu[i + 1]]
-        torch.testing.assert_close(o_i, o_ref_i, rtol=1e-3, atol=1e-3)
+        _accumulate_mismatch_count(mismatch_counts, o_i, o_ref_i, rtol=1e-3, atol=1e-3)
+    _assert_no_ref_mismatch(mismatch_counts)
 
 
 @pytest.mark.parametrize("batch_size", [12, 17, 128])
@@ -829,6 +860,7 @@ def test_batch_prefill_with_ragged_kv_cache(
     else:
         o = wrapper.run(q, k, v)
 
+    mismatch_counts = []
     for i in range(batch_size):
         o_ref_i = flashinfer.prefill.single_prefill_with_kv_cache(
             q[q_indptr[i] : q_indptr[i + 1]],
@@ -839,7 +871,8 @@ def test_batch_prefill_with_ragged_kv_cache(
             logits_soft_cap=logits_soft_cap,
         )
         o_i = o[q_indptr[i] : q_indptr[i + 1]]
-        torch.testing.assert_close(o_i, o_ref_i, rtol=1e-3, atol=1e-3)
+        _accumulate_mismatch_count(mismatch_counts, o_i, o_ref_i, rtol=1e-3, atol=1e-3)
+    _assert_no_ref_mismatch(mismatch_counts)
 
 
 @pytest.mark.parametrize("causal", [False, True])
@@ -905,6 +938,7 @@ def test_batch_prefill_with_ragged_kv_cache_head_dim_512(
     torch.testing.assert_close(o, o_buffer, rtol=1e-3, atol=1e-3)
     torch.testing.assert_close(lse, lse_buffer, rtol=1e-3, atol=1e-3)
 
+    mismatch_counts = []
     for i in range(batch_size):
         qi = q[q_indptr_cpu[i] : q_indptr_cpu[i + 1]]
         ki = k[kv_indptr_cpu[i] : kv_indptr_cpu[i + 1]]
@@ -918,7 +952,8 @@ def test_batch_prefill_with_ragged_kv_cache_head_dim_512(
             backend="fa2",
         )
         o_i = o[q_indptr_cpu[i] : q_indptr_cpu[i + 1]]
-        torch.testing.assert_close(o_i, o_ref_i, rtol=1e-3, atol=1e-3)
+        _accumulate_mismatch_count(mismatch_counts, o_i, o_ref_i, rtol=1e-3, atol=1e-3)
+    _assert_no_ref_mismatch(mismatch_counts)
 
 
 @pytest.mark.parametrize("batch_size", [12, 17, 128])

--- a/tests/attention/test_batch_prefill_kernels.py
+++ b/tests/attention/test_batch_prefill_kernels.py
@@ -53,9 +53,10 @@ def _accumulate_mismatch_count(mismatch_counts, out, ref, rtol, atol):
     keeps a single sync per test, with request-sized (not batch-sized)
     comparison temporaries.
     """
-    close = torch.isclose(
-        out.float(), ref.float(), rtol=rtol, atol=atol, equal_nan=True
-    )
+    # Shape check up front: isclose broadcasts, assert_close would not.
+    assert out.shape == ref.shape, f"shape mismatch: {out.shape} vs {ref.shape}"
+    # equal_nan=False matches torch.testing.assert_close's default strictness.
+    close = torch.isclose(out.float(), ref.float(), rtol=rtol, atol=atol)
     mismatch_counts.append((~close).sum())
 
 

--- a/tests/attention/test_fmha_v2_prefill.py
+++ b/tests/attention/test_fmha_v2_prefill.py
@@ -132,68 +132,95 @@ def attention_ref_torch(
 
     outputs = []
     lse_outputs = []
+    # Host copies once (one sync each) instead of per-request .item() syncs.
+    seq_lens_cpu = seq_lens.cpu()
+    cum_seq_lens_q_cpu = cum_seq_lens_q.cpu()
+    cum_seq_lens_kv_cpu = cum_seq_lens_kv.cpu()
     for b in range(batch_size):
-        seq_len = seq_lens[b].item()
-        q_start = cum_seq_lens_q[b].item()
-        q_end = cum_seq_lens_q[b + 1].item()
+        seq_len = int(seq_lens_cpu[b])
+        q_start = int(cum_seq_lens_q_cpu[b])
+        q_end = int(cum_seq_lens_q_cpu[b + 1])
         q_len = q_end - q_start
         q_seq = q_float[q_start:q_end]
 
         if is_paged:
             num_pages_needed = (seq_len + page_size - 1) // page_size
-            k_pages = []
-            v_pages = []
-            for p in range(num_pages_needed):
-                page_idx = block_tables[b, p].item()
-                k_pages.append(paged_kv_cache[page_idx, 0])
-                v_pages.append(paged_kv_cache[page_idx, 1])
-            k_seq = torch.cat(k_pages, dim=0)[:seq_len].float() * k_scale
-            v_seq = torch.cat(v_pages, dim=0)[:seq_len].float() * v_scale
+            # Single gather instead of one .item() sync + slice per page.
+            pages = block_tables[b, :num_pages_needed].long()
+            k_seq = (
+                (
+                    paged_kv_cache[pages, 0].reshape(-1, num_kv_heads, head_dim)[
+                        :seq_len
+                    ]
+                ).float()
+                * k_scale
+            )
+            v_seq = (
+                (
+                    paged_kv_cache[pages, 1].reshape(-1, num_kv_heads, head_dim)[
+                        :seq_len
+                    ]
+                ).float()
+                * v_scale
+            )
         else:
-            kv_start = cum_seq_lens_kv[b].item()
-            kv_end = cum_seq_lens_kv[b + 1].item()
+            kv_start = int(cum_seq_lens_kv_cpu[b])
+            kv_end = int(cum_seq_lens_kv_cpu[b + 1])
             k_seq = k_flat[kv_start:kv_end].float() * k_scale
             v_seq = v_flat[kv_start:kv_end].float() * v_scale
 
-        o_seq = torch.zeros(
-            q_len, num_qo_heads, head_dim, dtype=torch.float32, device=device
+        head_dim_v = v_seq.shape[-1]
+
+        # Masks depend only on positions: build once per sequence, shared by
+        # all heads (the previous per-head loop rebuilt them per head).
+        drop_mask = None
+        if causal or window_left >= 0:
+            q_indices = torch.arange(q_len, device=device).unsqueeze(1)
+            kv_indices = torch.arange(seq_len, device=device).unsqueeze(0)
+            offset = seq_len - q_len
+            keep = torch.ones(q_len, seq_len, dtype=torch.bool, device=device)
+            if causal:
+                keep &= (q_indices + offset) >= kv_indices
+            if window_left >= 0:
+                keep &= kv_indices >= (q_indices + offset - window_left)
+            drop_mask = ~keep
+
+        # Batch the per-head math by KV-head group: identical formula, but one
+        # [G, q_len, kv_len] matmul per KV head instead of a Python loop over
+        # every query head. Grouped (not all-heads-at-once) to bound the
+        # materialized fp32 score matrix at long sequence lengths.
+        G = heads_per_group
+        q_grouped = q_seq.permute(1, 0, 2).reshape(num_kv_heads, G, q_len, head_dim)
+        o_seq = torch.empty(
+            q_len, num_qo_heads, head_dim_v, dtype=torch.float32, device=device
         )
         if return_lse:
-            lse_seq = torch.zeros(
+            lse_seq = torch.empty(
                 q_len, num_qo_heads, dtype=torch.float32, device=device
             )
 
-        for h in range(num_qo_heads):
-            kv_h = h // heads_per_group
-
-            q_h = q_seq[:, h, :]
-            k_h = k_seq[:, kv_h, :]
-            v_h = v_seq[:, kv_h, :]
-
-            scores = torch.matmul(q_h, k_h.t()) * sm_scale
+        for kv_h in range(num_kv_heads):
+            k_h = k_seq[:, kv_h, :]  # [kv_len, head_dim]
+            v_h = v_seq[:, kv_h, :]  # [kv_len, head_dim_v]
+            # [G, q_len, kv_len]; in-place ops below to bound fp32 temporaries.
+            scores = torch.matmul(q_grouped[kv_h], k_h.t().unsqueeze(0))
+            scores.mul_(sm_scale)
 
             if logits_soft_cap > 0.0:
-                scores = logits_soft_cap * torch.tanh(scores / logits_soft_cap)
+                scores.div_(logits_soft_cap).tanh_().mul_(logits_soft_cap)
 
-            if causal:
-                q_indices = torch.arange(q_len, device=device).unsqueeze(1)
-                kv_indices = torch.arange(seq_len, device=device).unsqueeze(0)
-                offset = seq_len - q_len
-                causal_mask = (q_indices + offset) >= kv_indices
-                scores = scores.masked_fill(~causal_mask, float("-inf"))
+            if drop_mask is not None:
+                scores.masked_fill_(drop_mask, float("-inf"))
 
-            if window_left >= 0:
-                q_indices = torch.arange(q_len, device=device).unsqueeze(1)
-                kv_indices = torch.arange(seq_len, device=device).unsqueeze(0)
-                offset = seq_len - q_len
-                window_mask = kv_indices >= (q_indices + offset - window_left)
-                scores = scores.masked_fill(~window_mask, float("-inf"))
-
+            h_lo = kv_h * G
+            h_hi = h_lo + G
             if return_lse:
-                lse_seq[:, h] = torch.logsumexp(scores, dim=-1)
+                lse_seq[:, h_lo:h_hi] = torch.logsumexp(scores, dim=-1).permute(1, 0)
 
             attn = torch.softmax(scores, dim=-1)
-            o_seq[:, h, :] = torch.matmul(attn, v_h)
+            o_seq[:, h_lo:h_hi, :] = torch.matmul(attn, v_h.unsqueeze(0)).permute(
+                1, 0, 2
+            )
 
         outputs.append(o_seq)
         if return_lse:
@@ -268,64 +295,77 @@ def chunked_attention_ref_torch(
     q_float = q_flat.float()
 
     outputs = []
+    # Host copies once (one sync each) instead of per-request .item() syncs.
+    seq_lens_cpu = seq_lens.cpu()
+    cum_seq_lens_q_cpu = cum_seq_lens_q.cpu()
+    cum_seq_lens_kv_cpu = cum_seq_lens_kv.cpu()
     for b in range(batch_size):
-        kv_len = seq_lens[b].item()
-        q_start = cum_seq_lens_q[b].item()
-        q_end = cum_seq_lens_q[b + 1].item()
+        kv_len = int(seq_lens_cpu[b])
+        q_start = int(cum_seq_lens_q_cpu[b])
+        q_end = int(cum_seq_lens_q_cpu[b + 1])
         q_len = q_end - q_start
         q_seq = q_float[q_start:q_end]
 
         if is_paged:
             num_pages_needed = (kv_len + page_size - 1) // page_size
-            k_pages = []
-            v_pages = []
-            for p in range(num_pages_needed):
-                page_idx = block_tables[b, p].item()
-                k_pages.append(paged_kv_cache[page_idx, 0])
-                v_pages.append(paged_kv_cache[page_idx, 1])
-            k_seq = torch.cat(k_pages, dim=0)[:kv_len].float()
-            v_seq = torch.cat(v_pages, dim=0)[:kv_len].float()
+            # Single gather instead of one .item() sync + slice per page.
+            pages = block_tables[b, :num_pages_needed].long()
+            k_seq = (
+                paged_kv_cache[pages, 0]
+                .reshape(-1, num_kv_heads, head_dim)[:kv_len]
+                .float()
+            )
+            v_seq = (
+                paged_kv_cache[pages, 1]
+                .reshape(-1, num_kv_heads, head_dim)[:kv_len]
+                .float()
+            )
         else:
-            kv_start = cum_seq_lens_kv[b].item()
-            kv_end = cum_seq_lens_kv[b + 1].item()
+            kv_start = int(cum_seq_lens_kv_cpu[b])
+            kv_end = int(cum_seq_lens_kv_cpu[b + 1])
             k_seq = k_flat[kv_start:kv_end].float()
             v_seq = v_flat[kv_start:kv_end].float()
-
-        o_seq = torch.zeros(
-            q_len, num_qo_heads, head_dim, dtype=torch.float32, device=device
-        )
 
         # Absolute KV-space positions for each query token.
         # Query token i corresponds to KV position (kv_len - q_len + i).
         offset = kv_len - q_len
 
-        for h in range(num_qo_heads):
-            kv_h = h // heads_per_group
-            q_h = q_seq[:, h, :]
+        # Build chunked causal mask once per sequence (shared by all heads).
+        # q_abs[i] = offset + i  (absolute KV-space row for query token i)
+        # kv_pos[j] = j           (KV column index)
+        q_abs = torch.arange(q_len, device=device).unsqueeze(1) + offset
+        kv_pos = torch.arange(kv_len, device=device).unsqueeze(0)
+
+        # Causal: col <= row
+        causal_mask = kv_pos <= q_abs
+
+        # Chunk left boundary: col >= floor(row / chunk_size) * chunk_size
+        chunk_start = (q_abs // chunked_attention_size) * chunked_attention_size
+        chunk_mask = kv_pos >= chunk_start
+
+        drop_mask = ~(causal_mask & chunk_mask)
+
+        # Batch the per-head math by KV-head group (see attention_ref_torch).
+        G = heads_per_group
+        q_grouped = q_seq.permute(1, 0, 2).reshape(num_kv_heads, G, q_len, head_dim)
+        o_seq = torch.empty(
+            q_len, num_qo_heads, head_dim, dtype=torch.float32, device=device
+        )
+
+        for kv_h in range(num_kv_heads):
             k_h = k_seq[:, kv_h, :]
             v_h = v_seq[:, kv_h, :]
 
-            # scores: [q_len, kv_len]
-            scores = torch.matmul(q_h, k_h.t()) * sm_scale
-
-            # Build chunked causal mask.
-            # q_abs[i] = offset + i  (absolute KV-space row for query token i)
-            # kv_pos[j] = j           (KV column index)
-            q_abs = torch.arange(q_len, device=device).unsqueeze(1) + offset
-            kv_pos = torch.arange(kv_len, device=device).unsqueeze(0)
-
-            # Causal: col <= row
-            causal_mask = kv_pos <= q_abs
-
-            # Chunk left boundary: col >= floor(row / chunk_size) * chunk_size
-            chunk_start = (q_abs // chunked_attention_size) * chunked_attention_size
-            chunk_mask = kv_pos >= chunk_start
-
-            mask = causal_mask & chunk_mask
-            scores = scores.masked_fill(~mask, float("-inf"))
+            # scores: [G, q_len, kv_len]
+            scores = torch.matmul(q_grouped[kv_h], k_h.t().unsqueeze(0))
+            scores.mul_(sm_scale)
+            scores.masked_fill_(drop_mask, float("-inf"))
 
             attn = torch.softmax(scores, dim=-1)
-            o_seq[:, h, :] = torch.matmul(attn, v_h)
+            h_lo = kv_h * G
+            o_seq[:, h_lo : h_lo + G, :] = torch.matmul(attn, v_h.unsqueeze(0)).permute(
+                1, 0, 2
+            )
 
         outputs.append(o_seq)
 

--- a/tests/attention/test_hopper_fp8_attention.py
+++ b/tests/attention/test_hopper_fp8_attention.py
@@ -13,7 +13,13 @@ from flashinfer.utils import is_sm90a_supported
 @functools.lru_cache(maxsize=2)
 def _workspace_buffer(size_mb: int = 128) -> torch.Tensor:
     """Shared workspace buffer: allocating (and zeroing) 128 MB per test adds
-    up over thousands of parametrizations; the wrappers treat it as scratch."""
+    up over thousands of parametrizations; the wrappers treat it as scratch.
+
+    INVARIANT for callers: when two wrappers share this buffer, fully finish
+    plan()+run() on one wrapper before calling plan() on the other. plan()
+    stores metadata in the workspace that the wrapper's run() reads, so an
+    interleaving like plan_a -> plan_b -> run_a would corrupt run_a.
+    """
     return torch.zeros(size_mb * 1024 * 1024, dtype=torch.uint8, device="cuda")
 
 

--- a/tests/attention/test_hopper_fp8_attention.py
+++ b/tests/attention/test_hopper_fp8_attention.py
@@ -11,41 +11,69 @@ from flashinfer.utils import is_sm90a_supported
 
 
 @functools.lru_cache(maxsize=2)
+def _workspace_buffer_on(device_index: int, size_mb: int) -> torch.Tensor:
+    return torch.zeros(
+        size_mb * 1024 * 1024, dtype=torch.uint8, device=f"cuda:{device_index}"
+    )
+
+
 def _workspace_buffer(size_mb: int = 128) -> torch.Tensor:
     """Shared workspace buffer: allocating (and zeroing) 128 MB per test adds
     up over thousands of parametrizations; the wrappers treat it as scratch.
+    Cached per current CUDA device.
 
     INVARIANT for callers: when two wrappers share this buffer, fully finish
     plan()+run() on one wrapper before calling plan() on the other. plan()
     stores metadata in the workspace that the wrapper's run() reads, so an
     interleaving like plan_a -> plan_b -> run_a would corrupt run_a.
     """
-    return torch.zeros(size_mb * 1024 * 1024, dtype=torch.uint8, device="cuda")
+    return _workspace_buffer_on(torch.cuda.current_device(), size_mb)
 
 
+# Unbounded on purpose: pytest's parametrize execution order interleaves the
+# (M, N, R, C) patterns, so a small LRU thrashes (measured: full file 37s with
+# maxsize=8 vs 16s unbounded). All 144 patterns total ~430 MiB on an
+# SM90A-only file (80+ GB GPUs); the module-teardown fixture below releases
+# them as soon as the file finishes instead of holding them to process exit.
 @functools.lru_cache(maxsize=None)
+def _block_sparse_pattern_on(
+    device_index: int, M: int, N: int, R: int, C: int
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    device = f"cuda:{device_index}"
+    MB = M // R
+    NB = N // C
+    rng = np.random.default_rng(seed=0)
+    S = sp.sparse.random(MB, NB, density=0.25, random_state=rng).tocsr()
+    indptr = torch.from_numpy(S.indptr).to(device)
+    indices = torch.from_numpy(S.indices).to(device)
+    data_mask = torch.ones((S.nnz, R, C), dtype=torch.bool, device=device)
+    bsr = sp.sparse.bsr_matrix(
+        (np.ones((S.nnz, R, C), dtype=bool), S.indices, S.indptr), shape=(M, N)
+    )
+    dense_mask = torch.from_numpy(bsr.toarray()).to(device=device, dtype=torch.bool)
+    return indptr, indices, data_mask, dense_mask
+
+
 def _block_sparse_pattern(
     M: int, N: int, R: int, C: int
 ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
-    """Cached BSR pattern + dense mask for (M, N, R, C).
+    """Cached BSR pattern + dense mask for (M, N, R, C) on the current device.
 
     The pattern is seeded (rng seed 0), so it depends only on the block-grid
     shape; the same pattern is reused across num_heads/head_dim/dtype
     parametrizations (24x reuse), avoiding a per-test scipy build and a dense
     M x N numpy round-trip + H2D copy.
     """
-    MB = M // R
-    NB = N // C
-    rng = np.random.default_rng(seed=0)
-    S = sp.sparse.random(MB, NB, density=0.25, random_state=rng).tocsr()
-    indptr = torch.from_numpy(S.indptr).cuda()
-    indices = torch.from_numpy(S.indices).cuda()
-    data_mask = torch.ones((S.nnz, R, C), dtype=torch.bool, device="cuda")
-    bsr = sp.sparse.bsr_matrix(
-        (np.ones((S.nnz, R, C), dtype=bool), S.indices, S.indptr), shape=(M, N)
-    )
-    dense_mask = torch.from_numpy(bsr.toarray()).to(device="cuda", dtype=torch.bool)
-    return indptr, indices, data_mask, dense_mask
+    return _block_sparse_pattern_on(torch.cuda.current_device(), M, N, R, C)
+
+
+@pytest.fixture(autouse=True, scope="module")
+def _release_cached_gpu_buffers():
+    """Release the cached patterns/workspace when this module finishes so a
+    multi-file pytest session doesn't hold their GPU memory to process exit."""
+    yield
+    _block_sparse_pattern_on.cache_clear()
+    _workspace_buffer_on.cache_clear()
 
 
 def get_fp8_dtype_minmax(dtype: torch.dtype) -> Tuple[float, float]:

--- a/tests/attention/test_hopper_fp8_attention.py
+++ b/tests/attention/test_hopper_fp8_attention.py
@@ -1,3 +1,4 @@
+import functools
 from typing import Tuple
 
 import numpy as np
@@ -7,6 +8,38 @@ import torch
 
 import flashinfer
 from flashinfer.utils import is_sm90a_supported
+
+
+@functools.lru_cache(maxsize=2)
+def _workspace_buffer(size_mb: int = 128) -> torch.Tensor:
+    """Shared workspace buffer: allocating (and zeroing) 128 MB per test adds
+    up over thousands of parametrizations; the wrappers treat it as scratch."""
+    return torch.zeros(size_mb * 1024 * 1024, dtype=torch.uint8, device="cuda")
+
+
+@functools.lru_cache(maxsize=None)
+def _block_sparse_pattern(
+    M: int, N: int, R: int, C: int
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Cached BSR pattern + dense mask for (M, N, R, C).
+
+    The pattern is seeded (rng seed 0), so it depends only on the block-grid
+    shape; the same pattern is reused across num_heads/head_dim/dtype
+    parametrizations (24x reuse), avoiding a per-test scipy build and a dense
+    M x N numpy round-trip + H2D copy.
+    """
+    MB = M // R
+    NB = N // C
+    rng = np.random.default_rng(seed=0)
+    S = sp.sparse.random(MB, NB, density=0.25, random_state=rng).tocsr()
+    indptr = torch.from_numpy(S.indptr).cuda()
+    indices = torch.from_numpy(S.indices).cuda()
+    data_mask = torch.ones((S.nnz, R, C), dtype=torch.bool, device="cuda")
+    bsr = sp.sparse.bsr_matrix(
+        (np.ones((S.nnz, R, C), dtype=bool), S.indices, S.indptr), shape=(M, N)
+    )
+    dense_mask = torch.from_numpy(bsr.toarray()).to(device="cuda", dtype=torch.bool)
+    return indptr, indices, data_mask, dense_mask
 
 
 def get_fp8_dtype_minmax(dtype: torch.dtype) -> Tuple[float, float]:
@@ -105,27 +138,6 @@ def broadcast_scale_to_per_head(scale: torch.Tensor, num_heads: int) -> torch.Te
         return scale
 
 
-def bsr_attention_ref(
-    q,
-    k,
-    v,
-    indptr,
-    indices,
-    mask_data,
-):
-    M = q.shape[0]
-    N = k.shape[0]
-    bsr = sp.sparse.bsr_matrix(
-        (mask_data.cpu().numpy(), indices.cpu().numpy(), indptr.cpu().numpy()),
-        shape=(M, N),
-    )
-    dense_mask = torch.tensor(bsr.toarray(), dtype=bool, device=q.device)
-    o = flashinfer.prefill.single_prefill_with_kv_cache(
-        q, k, v, custom_mask=dense_mask, backend="fa2"
-    )
-    return o
-
-
 # Test single_prefill correctness: MSE should be below threshold
 @pytest.mark.parametrize("seq_len", [117, 509, 1011, 2372, 7777, 12315])
 @pytest.mark.parametrize("num_heads", [24, 32])
@@ -195,18 +207,19 @@ def test_block_sparse_attention(
     # setup random seed for reproducibility
     torch.manual_seed(0)
     np.random.seed(0)
-    # Build sparse mask
-    MB = M // R
-    NB = N // C
-    rng = np.random.default_rng(seed=0)
-    S = sp.sparse.random(MB, NB, density=0.25, random_state=rng).tocsr()
-    indptr = torch.from_numpy(S.indptr).cuda()
-    indices = torch.from_numpy(S.indices).cuda()
-    nnz = S.nnz
+    # Build sparse mask (cached per block-grid shape; seeded identically to the
+    # previous inline construction)
     if mask_inside_block:
+        indptr, indices, _, _ = _block_sparse_pattern(M, N, R, C)
+        nnz = indices.numel()
         data_mask = (torch.rand((nnz, R, C)) > 0.5).to(torch.bool).cuda()
+        bsr = sp.sparse.bsr_matrix(
+            (data_mask.cpu().numpy(), indices.cpu().numpy(), indptr.cpu().numpy()),
+            shape=(M, N),
+        )
+        dense_mask = torch.tensor(bsr.toarray(), dtype=bool, device="cuda")
     else:
-        data_mask = torch.ones((nnz, R, C), dtype=torch.bool, device="cuda")
+        indptr, indices, data_mask, dense_mask = _block_sparse_pattern(M, N, R, C)
 
     # Random inputs
     q = torch.randn((M, num_heads, head_dim), dtype=torch.float16, device="cuda")
@@ -214,10 +227,12 @@ def test_block_sparse_attention(
     v = torch.randn((N, num_heads, head_dim), dtype=torch.float16, device="cuda")
 
     # Reference output via dense mask
-    o_ref = bsr_attention_ref(q, k, v, indptr, indices, data_mask)
+    o_ref = flashinfer.prefill.single_prefill_with_kv_cache(
+        q, k, v, custom_mask=dense_mask, backend="fa2"
+    )
 
     # Plan and run BlockSparseAttention
-    workspace_buffer = torch.zeros(128 * 1024 * 1024, dtype=torch.uint8, device="cuda")
+    workspace_buffer = _workspace_buffer()
     sparse_wrapper = flashinfer.sparse.BlockSparseAttentionWrapper(
         workspace_buffer, backend="fa3"
     )
@@ -299,7 +314,7 @@ def test_batch_prefill_ragged(batch_size, num_heads, head_dim, causal, dtype):
 
     # Get reference output using fp16
     wrapper_fp16 = flashinfer.BatchPrefillWithRaggedKVCacheWrapper(
-        torch.empty(128 * 1024 * 1024, dtype=torch.uint8, device="cuda"),
+        _workspace_buffer(),
         "NHD",
         backend="fa3",
     )
@@ -321,7 +336,7 @@ def test_batch_prefill_ragged(batch_size, num_heads, head_dim, causal, dtype):
 
     # Run FP8 batch prefill with ragged KV cache
     wrapper_fp8 = flashinfer.BatchPrefillWithRaggedKVCacheWrapper(
-        torch.empty(128 * 1024 * 1024, dtype=torch.uint8, device="cuda"),
+        _workspace_buffer(),
         "NHD",
         backend="fa3",
     )
@@ -469,7 +484,7 @@ def test_batch_prefill_paged(batch_size, num_heads, head_dim, causal, dtype):
 
     # Get reference output using fp16
     wrapper_fp16 = flashinfer.BatchPrefillWithPagedKVCacheWrapper(
-        torch.empty(128 * 1024 * 1024, dtype=torch.uint8, device="cuda"),
+        _workspace_buffer(),
         "NHD",
         backend="fa3",
     )
@@ -498,7 +513,7 @@ def test_batch_prefill_paged(batch_size, num_heads, head_dim, causal, dtype):
 
     # Run FP8 batch prefill with paged KV cache
     wrapper_fp8 = flashinfer.BatchPrefillWithPagedKVCacheWrapper(
-        torch.empty(128 * 1024 * 1024, dtype=torch.uint8, device="cuda"),
+        _workspace_buffer(),
         "NHD",
         backend="fa3",
     )
@@ -611,7 +626,7 @@ def test_batch_prefill_paged_gqa(
 
     # Get reference output using fp16
     wrapper_fp16 = flashinfer.BatchPrefillWithPagedKVCacheWrapper(
-        torch.empty(128 * 1024 * 1024, dtype=torch.uint8, device="cuda"),
+        _workspace_buffer(),
         "NHD",
         backend="fa3",
     )
@@ -639,7 +654,7 @@ def test_batch_prefill_paged_gqa(
 
     # Run FP8 batch prefill with paged KV cache
     wrapper_fp8 = flashinfer.BatchPrefillWithPagedKVCacheWrapper(
-        torch.empty(128 * 1024 * 1024, dtype=torch.uint8, device="cuda"),
+        _workspace_buffer(),
         "NHD",
         backend="fa3",
     )
@@ -734,7 +749,7 @@ def test_batch_decode_paged(batch_size, num_qo_heads, num_kv_heads, head_dim, dt
 
     # Get reference output using fp16
     wrapper_fp16 = flashinfer.BatchDecodeWithPagedKVCacheWrapper(
-        torch.empty(128 * 1024 * 1024, dtype=torch.uint8, device="cuda"),
+        _workspace_buffer(),
         kv_layout="NHD",
         use_tensor_cores=True,
         backend="fa3",
@@ -761,7 +776,7 @@ def test_batch_decode_paged(batch_size, num_qo_heads, num_kv_heads, head_dim, dt
 
     # Run FP8 batch decode with paged KV cache
     wrapper_fp8 = flashinfer.BatchDecodeWithPagedKVCacheWrapper(
-        torch.empty(128 * 1024 * 1024, dtype=torch.uint8, device="cuda"),
+        _workspace_buffer(),
         kv_layout="NHD",
         use_tensor_cores=True,
         backend="fa3",
@@ -865,7 +880,7 @@ def test_batch_prefill_paged_scale_types(scale_type, dtype):
 
     # Get reference output using fp16
     wrapper_fp16 = flashinfer.BatchPrefillWithPagedKVCacheWrapper(
-        torch.empty(128 * 1024 * 1024, dtype=torch.uint8, device="cuda"),
+        _workspace_buffer(),
         "NHD",
         backend="fa3",
     )
@@ -907,7 +922,7 @@ def test_batch_prefill_paged_scale_types(scale_type, dtype):
 
     # Run FP8 batch prefill with paged KV cache
     wrapper_fp8 = flashinfer.BatchPrefillWithPagedKVCacheWrapper(
-        torch.empty(128 * 1024 * 1024, dtype=torch.uint8, device="cuda"),
+        _workspace_buffer(),
         "NHD",
         backend="fa3",
     )


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->

The three slowest files in the H100 unit-test CI job (`task_run_unit_tests.sh`) spend 85–95% of their wall time on serial first-use JIT compilation, and most of the rest in slow host-side reference code — not in the kernels under test. This PR makes them more efficient without changing what is tested: same kernels, same parametrizations, same tolerances

**1. Bulk JIT precompilation (`tests/attention/conftest.py`)**

Generalizes the existing XQA prebuild hook into a per-file registry covering `test_hopper_fp8_attention.py`, `test_fmha_v2_prefill.py`, and `test_batch_prefill_kernels.py` (XQA behavior unchanged). 

For each registered file the hook derives the unique set of JitSpecs its collected tests will need, compiles them as one parallel ninja graph via `build_jit_specs`, and hardlinks the built `.so`s into the AOT dir so test-time loads skip the per-module ninja dependency scan. 

Collectors mirror each test's own arch skip guards (SM90a-only for hopper fp8; SM90a/SM12x split for fmha_v2; SM80+/SM100+ gates for large head dims and fp8/NVFP4 KV), so non-applicable hardware builds nothing. **Any failure falls back to normal per-test JIT for that file only.**


**2. Faster references / host-side work**
- `test_hopper_fp8_attention.py`: the seeded block-sparse BSR pattern + dense mask are cached per `(M, N, R, C)` (identical values, 24× reuse across heads/head_dim/dtype), and the eleven per-test 128 MB workspace allocations are replaced with one shared buffer. The sharing invariant (finish `plan()+run()` on one wrapper before planning another) is documented in the helper and verified at every call site: all tests complete the fp16 reference wrapper before the fp8 wrapper plans.
- `test_batch_prefill_kernels.py`: the per-request reference loops accumulate mismatch counts on-device and check once per test (previously up to 128 synchronizing `assert_close` calls per test), keeping request-sized comparison temporaries. The check asserts shapes up front (`isclose` broadcasts) and uses `equal_nan=False` to match `assert_close`'s default strictness; failures report the offending request indices.
- `test_fmha_v2_prefill.py`: `attention_ref_torch` / `chunked_attention_ref_torch` compute the same formula batched per KV-head group (one `[G, q_len, kv_len]` matmul per KV head instead of a Python loop over every query head), build position masks once per sequence, use in-place score ops to bound fp32 temporaries at long sequence lengths, and gather paged KV with one tensor index instead of a per-page `.item()` sync. This also cuts the reference's host RSS substantially.

**CI Time shrinkage**
* Current PR: `PR Test / JIT Unittest (H100) (pull_request)Successful in 237m`
* Adjacent PR #4509: `PR Test / JIT Unittest (H100) (pull_request)Successful in 292m`

Ten longest tests from logs
[Current PR:](https://github.com/flashinfer-ai/flashinfer/actions/runs/31755970069/job/94631720709?pr=4511)
```
Top 10 longest-running source files:
   1. tests/gdn/test_decode_delta_rule.py - duration 1h00m31s, peak RSS 2.8 GiB, peak GPU 41.1 GiB, samples 1290
   2. tests/attention/test_trtllm_gen_attention_decode_xqa.py - duration 18m42s, peak RSS 28.4 GiB, peak GPU 3.1 GiB, samples 374
   3. tests/attention/test_batch_attention.py - duration 18m27s, peak RSS 155.8 GiB, peak GPU 12.5 GiB, samples 284
   4. tests/attention/test_sliding_window.py - duration 16m55s, peak RSS 96.7 GiB, peak GPU 3.0 GiB, samples 318
   5. tests/attention/test_xqa.py - duration 15m01s, peak RSS 2.7 GiB, peak GPU 1002 MiB, samples 292
   6. tests/attention/test_xqa_batch_decode.py - duration 14m39s, peak RSS 2.7 GiB, peak GPU 4.7 GiB, samples 240
   7. tests/gemm/test_bmm_fp8.py - duration 14m08s, peak RSS 6.7 GiB, peak GPU 4.2 GiB, samples 336
   8. tests/attention/test_batch_prefill_kernels.py - duration 14m00s, peak RSS 44.2 GiB, peak GPU 18.9 GiB, samples 272
   9. tests/gemm/test_unified_gemm_fuzz.py - duration 11m47s, peak RSS 12.4 GiB, peak GPU 5.7 GiB, samples 289
  10. tests/attention/test_hopper.py - duration 11m18s, peak RSS 27.3 GiB, peak GPU 45.5 GiB, samples 248
```
[From PR #4509](https://github.com/flashinfer-ai/flashinfer/actions/runs/31745272862/job/94598305980?pr=4509)
```
Top 10 longest-running source files:
   1. tests/gdn/test_decode_delta_rule.py - duration 56m40s, peak RSS 2.7 GiB, peak GPU 41.1 GiB, samples 1281
   2. tests/attention/test_batch_prefill_kernels.py - duration 43m07s, peak RSS 49.6 GiB, peak GPU 19.0 GiB, samples 874
   3. tests/attention/test_fmha_v2_prefill.py - duration 20m13s, peak RSS 30.9 GiB, peak GPU 15.9 GiB, samples 218
   4. tests/attention/test_xqa.py - duration 19m38s, peak RSS 2.7 GiB, peak GPU 1002 MiB, samples 343
   5. tests/attention/test_sliding_window.py - duration 19m35s, peak RSS 182.4 GiB, peak GPU 3.0 GiB, samples 343
   6. tests/attention/test_trtllm_gen_attention_decode_xqa.py - duration 19m28s, peak RSS 28.0 GiB, peak GPU 3.1 GiB, samples 381
   7. tests/attention/test_batch_decode_kernels.py - duration 18m31s, peak RSS 67.0 GiB, peak GPU 63.7 GiB, samples 276
   8. tests/attention/test_hopper.py - duration 18m28s, peak RSS 26.6 GiB, peak GPU 49.5 GiB, samples 372
   9. tests/attention/test_hopper_fp8_attention.py - duration 18m12s, peak RSS 34.7 GiB, peak GPU 4.6 GiB, samples 397
  10. tests/attention/test_single_prefill.py - duration 15m38s, peak RSS 7.4 GiB, peak GPU 1.2 GiB, samples 264
```

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Tests

* Improved attention test performance by reducing repeated setup, synchronization, and memory allocation overhead.
* Enhanced validation for batch prefill and paged attention scenarios, including clearer reporting of mismatched requests and elements.
* Improved test reliability across supported hardware and configurations by handling unsupported cases more gracefully.
* Optimized reference implementations for paged and grouped attention while preserving expected results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->