### PR TITLE
test(gdn): trim GDN decode test matrix to distinct kernel specializations

### DIFF
--- a/tests/gdn/test_decode_delta_rule.py
+++ b/tests/gdn/test_decode_delta_rule.py
@@ -1271,7 +1271,8 @@ def test_verify_kernel_mtp(
 # ============================================================================
 
 
-@pytest.mark.parametrize("seq_len", [2, 3, 4, 5, 6, 7, 8])
+# T >= 3 all select the same tile config, so 3/5/6/7 only re-specialize on T.
+@pytest.mark.parametrize("seq_len", [2, 4, 8])
 # One B per get_mtp_config bucket.
 @pytest.mark.parametrize("batch_size", [1, 4, 8, 16, 64])
 @pytest.mark.parametrize("dtype", ["bfloat16"])
@@ -1288,8 +1289,8 @@ def test_mtp_fp32_state_with_cache_and_state_update(
     - FP32 h state (not bf16)
     - cache_intermediate_states=True
     - disable_state_update=False (h is updated)
-    - All batch sizes: 1, 2, 4, 8, 16, 32, 64, 128, 256, 512
-    - All sequence lengths: 2, 3, 4, 5, 6, 7, 8
+    - One batch size per get_mtp_config bucket: 1, 4, 8, 16, 64
+    - Sequence lengths 2, 4, 8 (T>=3 shares one tile config)
     """
     scale_val = 1.0 / math.sqrt(128)  # head_size=128
     _test_verify_kernel_mtp(
@@ -2346,7 +2347,8 @@ except ImportError:
 
 @pytest.mark.parametrize("tile_v", [32, 64, 128])
 @pytest.mark.parametrize("cache_intermediate_states", [True, False])
-@pytest.mark.parametrize("seq_len", [2, 3, 4, 5, 6, 7, 8])
+# T >= 3 all select the same tile config, so 3/5/6/7 only re-specialize on T.
+@pytest.mark.parametrize("seq_len", [2, 4, 8])
 @pytest.mark.parametrize("head_size", [128])
 @pytest.mark.parametrize(
     "num_q_heads, num_k_heads, num_v_heads",

--- a/tests/gdn/test_decode_delta_rule.py
+++ b/tests/gdn/test_decode_delta_rule.py
@@ -268,7 +268,8 @@ def _test_decode_kernel_pretranspose(
     "num_q_heads, num_k_heads, num_v_heads",
     [(16, 16, 32)],
 )
-@pytest.mark.parametrize("batch_size", [1, 2, 4, 8, 16, 32, 64, 128, 256, 512])
+# B is absent from the compile key; these span small/threshold/large grids.
+@pytest.mark.parametrize("batch_size", [1, 32, 512])
 @pytest.mark.parametrize("dtype", ["bfloat16"])
 def test_decode_kernel_basic_pretranspose(
     dtype: str,
@@ -433,7 +434,8 @@ def _test_decode_kernel_nontranspose(
     "num_q_heads, num_k_heads, num_v_heads",
     [(16, 16, 32)],
 )
-@pytest.mark.parametrize("batch_size", [1, 2, 4, 8, 16, 32, 64, 128, 256, 512])
+# use_small_batch = B < 32 is the only batch term in the compile key.
+@pytest.mark.parametrize("batch_size", [1, 16, 32, 512])
 @pytest.mark.parametrize("dtype", ["bfloat16"])
 def test_decode_kernel_basic_nontranspose(
     dtype: str,
@@ -1229,7 +1231,8 @@ def _test_verify_kernel_mtp(
     "num_q_heads, num_k_heads, num_v_heads",
     [(16, 16, 32)],
 )
-@pytest.mark.parametrize("batch_size", [1, 2, 4, 8, 16])
+# One B per get_mtp_config bucket.
+@pytest.mark.parametrize("batch_size", [1, 4, 8, 16])
 @pytest.mark.parametrize("dtype", ["bfloat16"])
 def test_verify_kernel_mtp(
     dtype: str,
@@ -1269,7 +1272,8 @@ def test_verify_kernel_mtp(
 
 
 @pytest.mark.parametrize("seq_len", [2, 3, 4, 5, 6, 7, 8])
-@pytest.mark.parametrize("batch_size", [1, 2, 4, 8, 16, 32, 64, 128, 256, 512])
+# One B per get_mtp_config bucket.
+@pytest.mark.parametrize("batch_size", [1, 4, 8, 16, 64])
 @pytest.mark.parametrize("dtype", ["bfloat16"])
 def test_mtp_fp32_state_with_cache_and_state_update(
     dtype: str,
@@ -2077,7 +2081,8 @@ def _test_gdn_decode_bf16_state_t1_kernel(
     "num_q_heads, num_k_heads, num_v_heads",
     [(16, 16, 32), (16, 16, 64)],
 )
-@pytest.mark.parametrize("batch_size", [1, 2, 4, 8, 16, 32, 64, 128, 256, 512])
+# One B per _get_bf16_mtp_config bucket, at both HV=32 and HV=64.
+@pytest.mark.parametrize("batch_size", [1, 4, 8, 16, 32])
 @pytest.mark.parametrize("dtype", ["bfloat16"])
 def test_gdn_decode_bf16_state_t1_kernel(
     dtype: str,
@@ -2347,7 +2352,8 @@ except ImportError:
     "num_q_heads, num_k_heads, num_v_heads",
     [(16, 16, 64)],
 )
-@pytest.mark.parametrize("batch_size", [1, 2, 4, 8, 16, 32, 64, 128, 256])
+# tile_v is an explicit axis here, so B adds no specialization.
+@pytest.mark.parametrize("batch_size", [1, 16, 256])
 @pytest.mark.parametrize("dtype", ["bfloat16"])
 def test_gdn_decode_bf16_state_wide_vec_mtp_kernel(
     monkeypatch,


### PR DESCRIPTION
## 📌 Description

`tests/gdn/test_decode_delta_rule.py` re-ran the same compiled cubins many times
over. Two independent reasons, both verified against the cache keys rather than
assumed:

**1. Batch size is not a compile key.** It has been dynamic since #3649, so it
reaches the cache only through coarse buckets:

| Path | How `B` enters the key |
|------|------------------------|
| pretranspose (`gdn_decode_pretranspose.py:964`) | not at all |
| bf16-state wide-vec (`gdn_decode_bf16_state.py:3440`) | not at all — the tests build a contiguous pool, so `pool_size_key = -1` and `pool_slot_stride = (-1,)` are B-independent sentinels |
| nontranspose (`gdn_decode_nontranspose.py:725`) | only via `use_small_batch = B < 32` |
| fp32 / bf16 MTP (`gdn_decode_mtp.py:2500`, `gdn_decode_bf16_state.py:3813`) | only via `get_mtp_config` / `_get_bf16_mtp_config` |

The clearest case was `test_gdn_decode_bf16_state_wide_vec_mtp_kernel`: 378 of the
file's 817 parametrized cases (46%) but only **42** compile keys, because `tile_v`
is an explicit monkeypatched axis and the 9 batch sizes contribute nothing.

The first commit keeps one batch size per bucket. I verified each kept set
reproduces the *full* key set, at `NUM_SMS` 108/132/148 — this caught a real
mistake, where `[1,8,16,32]` for `test_gdn_decode_bf16_state_t1_kernel` silently
dropped the `HV=64, tile_v=32` key (that test sweeps `HV` ∈ {32,64}).

**2. Intermediate `seq_len` values only re-specialize on `T`.** `get_mtp_config`
returns an identical `(tile_v, vec_size, ilp_rows, use_smem_v)` set for every
`T >= 3`, so T=3/5/6/7 compile fresh MTP cubins without covering a tile config
that T=4 or T=8 does not already cover. `T=2` is kept as the one structurally
distinct case — it alone reaches the `ilp=8` and `tile_v=16 / ilp=2` branches.

### Effect

| | cases | compile keys (retuned tests) |
|---|---|---|
| before | 817 | 102 |
| after batch collapse | 501 | 102 |
| after `seq_len` trim | 409 | 62 |

Collected tests go 838 → 416 (409 parametrized + 7 non-parametrized).

### Coverage cost

The first commit costs nothing in specialization coverage — the same cubins still
run, just at fewer runtime batch sizes. The second commit is a deliberate
reduction: T=3/5/6/7 still exercise distinct unrolled loop counts, so a
T-specific off-by-one would no longer be caught. It is a separate commit so it
can be dropped if reviewers would rather keep the full sweep.

## 🔍 Related Issues

Refs #4110 (GDN cold-compile CI time). Complements #4128 and #4444, which remove
key entries that provably do not reach codegen; this removes test cases that map
onto keys already covered.

## 🚀 Pull Request Checklist

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

## 🧪 Tests

- [x] `pytest tests/gdn/test_decode_delta_rule.py -q` on H100: **416 passed in 32m25s**
- [ ] GPU CI for the timing comparison

## Reviewer Notes

- I did not measure a clean before/after wall clock: the ~38 min baseline I was
  working from comes from #4219's description rather than the same machine, so
  I'd rather let CI provide the comparison than quote a number I can't stand
  behind. The case and key counts above are exact and static.
- Worth noting for #4110 more broadly: cutting 50% of the cases bought
  substantially less than 50% of the wall clock, which suggests the remaining
  cost is dominated by compilation and fixed overhead rather than per-case
  execution. That points at persistent/AOT CuTe-DSL artifacts (GDN-P1 in #4214)
  as the larger lever.
- The batch sizes kept per test are load-bearing, not arbitrary — each set is one
  representative per config bucket. I left a one-line comment at each site so
  they don't get "restored" later.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Streamlined decode and MTP test coverage to use representative batch sizes and sequence lengths.
  * Preserved coverage for key thresholds, tile configurations, transposition modes, precision variants, and sequence-length scenarios.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->