### PR TITLE
feat(jit-cache): split cache into architecture provider wheels

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -534,6 +534,9 @@ match what the code uses today; values are strings unless noted.
 | `FLASHINFER_EXTRA_CFLAGS` | unset | `flashinfer/jit/cpp_ext.py` | Extra compiler flags passed to the host C++ compiler. |
 | `FLASHINFER_EXTRA_CUDAFLAGS` | unset | `flashinfer/jit/cpp_ext.py` | Extra compiler flags passed to `nvcc`. |
 | `FLASHINFER_EXTRA_LDFLAGS` | unset | `flashinfer/jit/cpp_ext.py` | Extra linker flags passed to the linker. |
+| `FLASHINFER_JIT_CACHE_WHEEL_KIND` | `legacy` | `flashinfer-jit-cache/build_backend.py` | Select `legacy` for the monolithic binary wheel or experimental `shim` mode for a pure-Python wheel whose dependencies install binary providers. |
+| `FLASHINFER_JIT_CACHE_PROVIDER_ARCHS` | falls back to `FLASHINFER_CUDA_ARCH_LIST` | `flashinfer-jit-cache/build_backend.py` | Space-separated provider architectures added to a shim wheel's exact `Requires-Dist` metadata. Required for a shim build when `FLASHINFER_CUDA_ARCH_LIST` is unset. |
+| `FLASHINFER_JIT_CACHE_PROVIDER_ARCH` | unset | `flashinfer-jit-cache-provider/package_config.py` | Select exactly one architecture, such as `9.0a` or `sm120f`, when building an experimental binary provider wheel. |
 
 ##### Cubin / Artifact Loader
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -537,6 +537,9 @@ match what the code uses today; values are strings unless noted.
 | `FLASHINFER_EXTRA_CFLAGS` | unset | `flashinfer/jit/cpp_ext.py` | Extra compiler flags passed to the host C++ compiler. |
 | `FLASHINFER_EXTRA_CUDAFLAGS` | unset | `flashinfer/jit/cpp_ext.py` | Extra compiler flags passed to `nvcc`. |
 | `FLASHINFER_EXTRA_LDFLAGS` | unset | `flashinfer/jit/cpp_ext.py` | Extra linker flags passed to the linker. |
+| `FLASHINFER_JIT_CACHE_WHEEL_KIND` | `legacy` | `flashinfer-jit-cache/build_backend.py` | Select `legacy` for the monolithic binary wheel or experimental `shim` mode for a pure-Python wheel whose dependencies install binary providers. |
+| `FLASHINFER_JIT_CACHE_PROVIDER_ARCHS` | falls back to `FLASHINFER_CUDA_ARCH_LIST` | `flashinfer-jit-cache/build_backend.py` | Space-separated provider architectures added to a shim wheel's exact `Requires-Dist` metadata. Required for a shim build when `FLASHINFER_CUDA_ARCH_LIST` is unset. |
+| `FLASHINFER_JIT_CACHE_PROVIDER_ARCH` | unset | `flashinfer-jit-cache-provider/package_config.py` | Select exactly one architecture, such as `9.0a` or `sm120f`, when building an experimental binary provider wheel. |
 
 ##### Cubin / Artifact Loader
 

--- a/docs/design_docs/jit_cache_provider_wheels.md
+++ b/docs/design_docs/jit_cache_provider_wheels.md
@@ -17,6 +17,10 @@ split such as `flashinfer-jit-cache+cu130.sm90` does not solve installation:
 those artifacts are versions of the same distribution, and pip can install only
 one of them at a time.
 
+The published jit-cache wheels contain host code plus architecture-specific
+SASS cubins. They do not contain PTX, so an sm80 cubin cannot provide a
+forward-compatible fallback for a later GPU architecture.
+
 The new layout must support both of these workflows:
 
 - A normal installation gets every provider published for its CUDA and CPU
@@ -94,16 +98,27 @@ flashinfer install-jit-cache-wheel --mode minimal --sm sm120f
 
 Without `--sm`, the CLI uses the visible CUDA devices. `--sm` may be repeated
 when preparing an image on a different machine. The current prototype provider
-is self-contained for one target, so minimal mode does not add an sm80 wheel.
+is self-contained for one target. Minimal mode installs exactly the detected or
+requested providers and never adds an implicit sm80 baseline.
 
-## What "Core" Means
+## SM80 Is Not a Baseline Provider
 
-There is currently no evidence that an sm80 shared library is a portable binary
-base for later architectures. FlashInfer's NVCC flags emit SASS targets such as
-`code=sm_80`; they do not emit a PTX fallback such as `code=compute_80`. NVIDIA
-documents cubin compatibility within a GPU architecture family, while PTX is
-the forward-compatible representation. An sm80-only `.so` therefore cannot be
-assumed to load on Hopper or Blackwell.
+FlashInfer's NVCC flags emit SASS targets such as `code=sm_80`; they do not emit
+a PTX fallback such as `code=compute_80`. NVIDIA documents cubin compatibility
+within a GPU architecture family, while PTX is the forward-compatible
+representation. An sm80 cubin therefore cannot run on Hopper or Blackwell.
+
+Artifact inspection confirms that this is also true of the published wheels,
+not just the current source flags. Every CUDA-bearing `.so` in the complete
+v0.4.0 cu128, cu129, and cu130 matrix for both x86_64 and AArch64 contained SASS
+and no PTX. A complete scan of the v0.6.16.post1 cu130 AArch64 wheel also found
+no PTX. The standalone `flashinfer-jit-cache` package has therefore never
+provided the proposed compute_80 PTX fallback in the audited release range.
+
+The sm80 provider remains useful for systems that actually contain Ampere GPUs.
+It is an independent provider, not a dependency of sm90, sm100, sm120, or sm121
+providers. Shim dependency lists are literal: sm80 is installed only when the
+published all-provider set or an explicit user selection includes it.
 
 The existing `sm80` capability in `flashinfer/aot.py` is a source and module
 enumeration condition: it selects kernels whose implementation requires the
@@ -119,15 +134,13 @@ For this design, use these terms precisely:
   dispatch.
 - **Provider coverage**: the SASS or PTX targets actually present in every
   `.so` in a provider.
-- **Core wheel**: reserved for a future wheel containing an explicitly audited
-  common module set with declared binary coverage. It must not mean "sm80".
 
 The initial provider build compiles the common and architecture modules together
 for one target. This duplicates common modules across the complete provider set,
 but it gives minimal installations correct native binaries and makes each wheel
-small enough to publish independently. A later common-module split is useful
-only if inventory data shows that it materially reduces total size without
-reintroducing a large fat-binary core.
+small enough to publish independently. A later common-module split would be a
+size optimization only. It is not needed for compatibility and should be added
+only if inventory data shows that it materially reduces total size.
 
 The first SM121 experiment found 652 SM121a-only modules, one host-only module,
 and four SM90a-only FA3 attention-sink modules in a 657-module provider. The
@@ -158,6 +171,7 @@ python -m build --wheel flashinfer-jit-cache-provider
 Build a shim whose default dependencies include the tested provider set:
 
 ```bash
+# sm80 is an independent provider in this explicit all-provider set.
 FLASHINFER_JIT_CACHE_WHEEL_KIND=shim \
 FLASHINFER_JIT_CACHE_PROVIDER_ARCHS="8.0 9.0a 12.0f" \
 FLASHINFER_LOCAL_VERSION=cu130 \
@@ -215,8 +229,9 @@ Before changing release workflows or making shim mode the default:
 
 1. Build each CUDA and CPU matrix entry on the fork and record compressed size,
    uncompressed size, module count, and build time per provider.
-2. Use `cuobjdump --list-elf` on every packaged `.so` and compare actual code
-   targets with the provider manifest.
+2. Use `cuobjdump --list-elf` and `cuobjdump --list-ptx` on every packaged `.so`.
+   Compare actual cubin targets with the provider manifest and require native
+   providers to contain no PTX.
 3. Compare module inventories from one-target builds with the current multi-arch
    build. Any module that appears only when `8.0` is added needs its AOT
    registration condition corrected or an explicit support decision.
@@ -233,7 +248,8 @@ Before changing release workflows or making shim mode the default:
 
 - Whether provider granularity should remain exact SM targets or combine targets
   only when every `.so` contains compatible code for the combined set.
-- Whether a measured common module set warrants separate core providers.
+- Whether a measured common module set warrants separate common-module
+  providers as a size optimization.
 - Whether provider manifests should include hashes and per-module code targets,
   rather than the provider-wide target list used by the prototype.
 - How long to retain legacy monolithic wheel production after the shim becomes

--- a/docs/design_docs/jit_cache_provider_wheels.md
+++ b/docs/design_docs/jit_cache_provider_wheels.md
@@ -1,0 +1,191 @@
+# JIT Cache Provider Wheels
+
+## Status
+
+This document describes an experimental replacement for the monolithic
+`flashinfer-jit-cache` wheel. The runtime discovery contract and a single-arch
+provider build prototype are implemented, but release workflows still build the
+legacy wheel by default. The provider inventory must be validated on the fork
+before this becomes the release format.
+
+## Problem
+
+The current wheel puts every generated AOT shared library in one distribution.
+Adding a CUDA architecture adds code to many of those libraries, so the wheel
+continues to grow and is already close to release-asset limits. A local-version
+split such as `flashinfer-jit-cache+cu130.sm90` does not solve installation:
+those artifacts are versions of the same distribution, and pip can install only
+one of them at a time.
+
+The new layout must support both of these workflows:
+
+- A normal installation gets every provider published for its CUDA and CPU
+  platform.
+- A size-sensitive installation gets only the provider for the target GPU, or
+  an explicitly selected set of GPU architectures.
+
+## Package Model
+
+`flashinfer-jit-cache` becomes a small shim. For a CUDA 13.0 build, its version
+remains aligned with FlashInfer, for example `0.6.16+cu130`, and its dependency
+metadata names all providers built in that release.
+
+Each binary wheel has a distinct distribution name and can therefore coexist:
+
+| Distribution | Python package | Declared target |
+| --- | --- | --- |
+| `flashinfer-jit-cache-sm80` | `flashinfer_jit_cache.providers.sm80` | `sm80` |
+| `flashinfer-jit-cache-sm90a` | `flashinfer_jit_cache.providers.sm90a` | `sm90a` |
+| `flashinfer-jit-cache-sm120f` | `flashinfer_jit_cache.providers.sm120f` | `sm120f` |
+
+CUDA compatibility remains in the version, and CPU compatibility remains in
+the wheel platform tag. For example, an x86 CUDA 13 provider is
+`flashinfer_jit_cache_sm120f-0.6.16+cu130-...-manylinux_2_28_x86_64.whl`.
+
+```mermaid
+flowchart LR
+    shim["flashinfer-jit-cache shim"] --> sm80["provider sm80"]
+    shim --> sm90["provider sm90a"]
+    shim --> sm120["provider sm120f"]
+    runtime["FlashInfer AOT resolver"] --> shim
+    runtime -->|"module + target SM"| selected["one compatible provider root"]
+```
+
+Provider wheels register the `flashinfer.jit_cache.providers` entry-point group.
+The entry point returns a generated manifest with this schema:
+
+```json
+{
+  "schema_version": 1,
+  "provider_id": "sm120f",
+  "distribution": "flashinfer-jit-cache-sm120f",
+  "version": "0.6.16+cu130",
+  "cuda_architectures": ["sm120f"],
+  "modules": ["module_name_1", "module_name_2"]
+}
+```
+
+The module list is generated from the packaged files, rather than maintained by
+hand. Runtime accepts a provider only when its FlashInfer version matches, its
+manifest contains the requested module, and its architecture set covers every
+target in the active compilation context. If no provider matches, normal JIT
+compilation remains the fallback. The legacy monolithic directory is checked
+first while both formats are supported.
+
+## Installation Modes
+
+The normal mode installs the shim with dependencies enabled:
+
+```bash
+flashinfer install-jit-cache-wheel
+```
+
+This leaves provider selection to the shim's static `Requires-Dist` metadata.
+Pip does not detect GPUs and should not be asked to make a hardware-dependent
+resolution decision.
+
+Minimal mode installs the shim and selected providers in one no-dependencies
+transaction:
+
+```bash
+flashinfer install-jit-cache-wheel --mode minimal
+flashinfer install-jit-cache-wheel --mode minimal --sm sm120f
+```
+
+Without `--sm`, the CLI uses the visible CUDA devices. `--sm` may be repeated
+when preparing an image on a different machine. The current prototype provider
+is self-contained for one target, so minimal mode does not add an sm80 wheel.
+
+## What "Core" Means
+
+There is currently no evidence that an sm80 shared library is a portable binary
+base for later architectures. FlashInfer's NVCC flags emit SASS targets such as
+`code=sm_80`; they do not emit a PTX fallback such as `code=compute_80`. NVIDIA
+documents cubin compatibility within a GPU architecture family, while PTX is
+the forward-compatible representation. An sm80-only `.so` therefore cannot be
+assumed to load on Hopper or Blackwell.
+
+The existing `sm80` capability in `flashinfer/aot.py` is a source and module
+enumeration condition: it selects kernels whose implementation requires the
+Ampere `cp.async` baseline. It does not establish binary portability. Adding
+`8.0` to a Blackwell build can change which module names are generated, but it
+does not make those modules usable on Blackwell, and it can conceal missing AOT
+registration conditions.
+
+For this design, use these terms precisely:
+
+- **Common module**: a module name used by several runtime architectures.
+- **Architecture module**: a module name selected only by architecture-specific
+  dispatch.
+- **Provider coverage**: the SASS or PTX targets actually present in every
+  `.so` in a provider.
+- **Core wheel**: reserved for a future wheel containing an explicitly audited
+  common module set with declared binary coverage. It must not mean "sm80".
+
+The initial provider build compiles the common and architecture modules together
+for one target. This duplicates common modules across the complete provider set,
+but it gives minimal installations correct native binaries and makes each wheel
+small enough to publish independently. A later common-module split is useful
+only if inventory data shows that it materially reduces total size without
+reintroducing a large fat-binary core.
+
+Relevant CUDA compatibility references:
+
+- [CUDA C Programming Guide: Binary Compatibility](https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#binary-compatibility)
+- [Blackwell Compatibility Guide](https://docs.nvidia.com/cuda/blackwell-compatibility-guide/index.html)
+
+## Prototype Builds
+
+The existing project remains a legacy monolithic build unless explicitly put in
+shim mode. This keeps release jobs unchanged during fork testing.
+
+Build one provider from `flashinfer-jit-cache-provider`:
+
+```bash
+FLASHINFER_JIT_CACHE_PROVIDER_ARCH=12.0f \
+FLASHINFER_LOCAL_VERSION=cu130 \
+python -m build --wheel flashinfer-jit-cache-provider
+```
+
+Build a shim whose default dependencies include the tested provider set:
+
+```bash
+FLASHINFER_JIT_CACHE_WHEEL_KIND=shim \
+FLASHINFER_JIT_CACHE_PROVIDER_ARCHS="8.0 9.0a 12.0f" \
+FLASHINFER_LOCAL_VERSION=cu130 \
+python -m build --wheel flashinfer-jit-cache
+```
+
+The provider backend forces `FLASHINFER_CUDA_ARCH_LIST` to exactly one declared
+target, compiles the AOT inventory, and generates the manifest from the copied
+libraries. Shim requirements exactly pin every provider to the shim version.
+
+## Validation Gates
+
+Before changing release workflows or making shim mode the default:
+
+1. Build each CUDA and CPU matrix entry on the fork and record compressed size,
+   uncompressed size, module count, and build time per provider.
+2. Use `cuobjdump --list-elf` on every packaged `.so` and compare actual code
+   targets with the provider manifest.
+3. Compare module inventories from one-target builds with the current multi-arch
+   build. Any module that appears only when `8.0` is added needs its AOT
+   registration condition corrected or an explicit support decision.
+4. Install only the target provider and run with `FLASHINFER_DISABLE_JIT=1` on
+   representative sm80, sm90a, sm100a, sm120f, and sm121a systems.
+5. Install the default shim with every provider and repeat the tests to verify
+   deterministic architecture selection.
+6. Test a process with heterogeneous visible GPUs. Until a provider contains
+   all required targets, it should miss AOT cleanly and fall back to JIT.
+7. Update release and nightly matrices, wheel-index parsing, documentation, and
+   stale-provider uninstall behavior only after the inventories pass.
+
+## Open Decisions
+
+- Whether provider granularity should remain exact SM targets or combine targets
+  only when every `.so` contains compatible code for the combined set.
+- Whether a measured common module set warrants separate core providers.
+- Whether provider manifests should include hashes and per-module code targets,
+  rather than the provider-wide target list used by the prototype.
+- How long to retain legacy monolithic wheel production after the shim becomes
+  the default.

--- a/docs/design_docs/jit_cache_provider_wheels.md
+++ b/docs/design_docs/jit_cache_provider_wheels.md
@@ -129,6 +129,14 @@ small enough to publish independently. A later common-module split is useful
 only if inventory data shows that it materially reduces total size without
 reintroducing a large fat-binary core.
 
+The first SM121 experiment found 652 SM121a-only modules, one host-only module,
+and four SM90a-only FA3 attention-sink modules in a 657-module provider. The
+foreign modules were 6.1 MB compressed out of a 250.2 MB compressed shared-object
+payload. They came from unconditional FA3 registration, not from a reusable
+binary base, and are now omitted unless the AOT target includes SM90. This is an
+example of an AOT inventory bug that a provider-wide architecture label alone
+would conceal.
+
 Relevant CUDA compatibility references:
 
 - [CUDA C Programming Guide: Binary Compatibility](https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#binary-compatibility)
@@ -185,8 +193,21 @@ version metadata, the shim's exact provider pin, provider entry-point discovery,
 manifest/module parity, and `cuobjdump --list-elf` output for every shared
 library. It writes `wheelhouse.json` with sizes, hashes, the module inventory,
 and observed per-module CUDA targets, plus a conventional `SHA256SUMS` file.
-The resulting wheels should then be installed on an SM121 system for the
-JIT-disabled runtime gate described below.
+Strict CUDA target validation is the default; set
+`CUDA_ARCHITECTURE_POLICY=report` only when inventorying a known mixed-target
+prototype. After installing the resulting wheels on the target system, run the
+JIT-disabled GPU gate with:
+
+```bash
+FLASHINFER_DISABLE_JIT=1 \
+python scripts/smoke_test_jit_cache_provider.py --provider sm121a
+```
+
+The initial DGX Spark build produced a 250,767,917-byte provider wheel containing
+657 modules (487,366,496 bytes uncompressed), a 16,105,950-byte
+`flashinfer-python` wheel, and a 4,349-byte shim. The build generated 3,404 Ninja
+steps with seven concurrent jobs. The installed provider resolved and launched
+`silu_and_mul` on an SM121 GB10 with JIT disabled.
 
 ## Validation Gates
 

--- a/docs/design_docs/jit_cache_provider_wheels.md
+++ b/docs/design_docs/jit_cache_provider_wheels.md
@@ -160,6 +160,34 @@ The provider backend forces `FLASHINFER_CUDA_ARCH_LIST` to exactly one declared
 target, compiles the AOT inventory, and generates the manifest from the copied
 libraries. Shim requirements exactly pin every provider to the shim version.
 
+### One-off SM121 wheelhouse
+
+On an AArch64 Docker host, the experiment can be built with:
+
+```bash
+scripts/build_jit_cache_provider_wheelhouse.sh
+```
+
+The wrapper defaults to the CUDA 13.0 PyTorch manylinux AArch64 builder, target
+`12.1a`, local version `cu130`, one NVCC thread, and at most four concurrent
+jobs. It builds these aligned-version artifacts under `dist/`:
+
+- `flashinfer-python`
+- `flashinfer-jit-cache-sm121a`
+- `flashinfer-jit-cache`, with an exact dependency on the SM121 provider only
+
+Set `OUTPUT_DIR`, `FLASHINFER_DEV_RELEASE_SUFFIX`, or
+`FLASHINFER_JIT_CACHE_PROVIDER_ARCH` to override the one-off defaults. Existing
+output is retained unless `CLEAN_OUTPUT=1` is explicit.
+
+The build does not require a GPU. Its final validation checks distribution and
+version metadata, the shim's exact provider pin, provider entry-point discovery,
+manifest/module parity, and `cuobjdump --list-elf` output for every shared
+library. It writes `wheelhouse.json` with sizes, hashes, the module inventory,
+and observed per-module CUDA targets, plus a conventional `SHA256SUMS` file.
+The resulting wheels should then be installed on an SM121 system for the
+JIT-disabled runtime gate described below.
+
 ## Validation Gates
 
 Before changing release workflows or making shim mode the default:

--- a/docs/design_docs/jit_cache_provider_wheels.md
+++ b/docs/design_docs/jit_cache_provider_wheels.md
@@ -17,9 +17,11 @@ split such as `flashinfer-jit-cache+cu130.sm90` does not solve installation:
 those artifacts are versions of the same distribution, and pip can install only
 one of them at a time.
 
-The published jit-cache wheels contain host code plus architecture-specific
-SASS cubins. They do not contain PTX, so an sm80 cubin cannot provide a
-forward-compatible fallback for a later GPU architecture.
+The published jit-cache wheels contain host code plus SASS cubins. They do not
+contain PTX. An unsuffixed sm80 cubin has CUDA's same-major binary compatibility,
+but cannot provide a fallback for Hopper or Blackwell. Architecture-specific
+targets such as sm90a and sm121a are exact-target binaries and are not forward
+compatible.
 
 The current monolithic build also uses size-oriented fatbin compression, omits
 single-request prefill/decode modules, and excludes selected architectures from
@@ -86,6 +88,27 @@ target in the active compilation context. If no provider matches, normal JIT
 compilation remains the fallback. The legacy monolithic directory is checked
 first while both formats are supported.
 
+### Target Compatibility Policy
+
+CUDA distinguishes three target kinds:
+
+- An architecture-specific `smXXa` or `compute_XXa` target runs only on that
+  exact compute capability. It is neither forward nor backward compatible.
+- A family-specific `smXXf` or `compute_XXf` target runs only on devices in the
+  CUDA-defined family for that target.
+- An unsuffixed cubin uses CUDA's baseline binary-compatibility rules, including
+  forward compatibility to a higher minor compute capability in the same major
+  family. Unsuffixed cubins are not compatible across major families.
+
+The initial provider implementation deliberately requires an exact manifest
+target match for all three forms. Minimal auto-detection on an SM121 device
+therefore installs the `sm121a` provider, not `sm120f`; similarly, an `sm100a`
+provider cannot satisfy an `sm103a` target. This conservative rule treats
+binary executability and complete AOT module coverage as separate questions.
+Broader baseline or family coverage can be introduced later only through
+explicit manifest coverage that has been validated for every packaged module;
+the resolver must never infer a closest lower provider from the target name.
+
 ## Installation Modes
 
 The normal mode installs the shim with dependencies enabled:
@@ -114,9 +137,11 @@ requested providers and never adds an implicit sm80 baseline.
 ## SM80 Is Not a Baseline Provider
 
 FlashInfer's NVCC flags emit SASS targets such as `code=sm_80`; they do not emit
-a PTX fallback such as `code=compute_80`. NVIDIA documents cubin compatibility
-within a GPU architecture family, while PTX is the forward-compatible
-representation. An sm80 cubin therefore cannot run on Hopper or Blackwell.
+a PTX fallback such as `code=compute_80`. NVIDIA documents unsuffixed cubin
+compatibility within the same major compute capability. Unsuffixed PTX can
+provide broader forward compatibility, but architecture-specific `compute_XXa`
+PTX remains exact-target only. An sm80 cubin therefore cannot run on Hopper or
+Blackwell.
 
 Artifact inspection confirms that this is also true of the published wheels,
 not just the current source flags. Every CUDA-bearing `.so` in the complete
@@ -275,7 +300,12 @@ Before changing release workflows or making shim mode the default:
    deterministic architecture selection.
 6. Test a process with heterogeneous visible GPUs. Until a provider contains
    all required targets, it should miss AOT cleanly and fall back to JIT.
-7. Update release and nightly matrices, wheel-index parsing, documentation, and
+7. Add negative selection tests proving that architecture-specific providers do
+   not match another compute capability, including sm100a versus sm103a and
+   sm121a versus future SM12x targets. Keep baseline and family providers exact
+   until broader coverage is represented explicitly and validated module by
+   module.
+8. Update release and nightly matrices, wheel-index parsing, documentation, and
    stale-provider uninstall behavior only after the inventories pass. Keep the
    CUDA version and PyTorch index in `ci/cuda-versions.json`, and add explicit
    provider coverage fields rather than inferring them from size-pruned
@@ -283,8 +313,9 @@ Before changing release workflows or making shim mode the default:
 
 ## Open Decisions
 
-- Whether provider granularity should remain exact SM targets or combine targets
-  only when every `.so` contains compatible code for the combined set.
+- Whether later provider manifests should add broader baseline or family
+  coverage after every `.so` and module inventory has been validated for the
+  additional devices. Architecture-specific `a` targets always remain exact.
 - Whether a measured common module set warrants separate common-module
   providers as a size optimization.
 - Whether provider manifests should include hashes and per-module code targets,

--- a/docs/design_docs/jit_cache_provider_wheels.md
+++ b/docs/design_docs/jit_cache_provider_wheels.md
@@ -21,6 +21,16 @@ The published jit-cache wheels contain host code plus architecture-specific
 SASS cubins. They do not contain PTX, so an sm80 cubin cannot provide a
 forward-compatible fallback for a later GPU architecture.
 
+The current monolithic build also uses size-oriented fatbin compression, omits
+single-request prefill/decode modules, and excludes selected architectures from
+size-constrained matrix entries. Those are useful tactical reductions, but they
+do not replace provider splitting: removing an architecture from an aggregate
+wheel removes its warm-cache coverage entirely. Provider coverage must therefore
+be a separate policy from the architecture list used to keep a monolithic wheel
+under its publication limit. In particular, standalone sm75 and sm121a providers
+can retain coverage even when those targets are absent from the corresponding
+aggregate wheel.
+
 The new layout must support both of these workflows:
 
 - A normal installation gets every provider published for its CUDA and CPU
@@ -179,8 +189,10 @@ python -m build --wheel flashinfer-jit-cache
 ```
 
 The provider backend forces `FLASHINFER_CUDA_ARCH_LIST` to exactly one declared
-target, compiles the AOT inventory, and generates the manifest from the copied
-libraries. Shim requirements exactly pin every provider to the shim version.
+target, installs the centrally configured provider-build dependencies in its
+isolated build environment, compiles the AOT inventory, and generates the
+manifest from the copied libraries. Shim requirements exactly pin every provider
+to the shim version.
 
 ### One-off SM121 wheelhouse
 
@@ -190,9 +202,11 @@ On an AArch64 Docker host, the experiment can be built with:
 scripts/build_jit_cache_provider_wheelhouse.sh
 ```
 
-The wrapper defaults to the CUDA 13.0 PyTorch manylinux AArch64 builder, target
-`12.1a`, local version `cu130`, one NVCC thread, and at most four concurrent
-jobs. It builds these aligned-version artifacts under `dist/`:
+The wrapper defaults to target `12.1a`, local version `cu130`, one NVCC thread,
+and at most four concurrent jobs. It resolves the CUDA version, PyTorch index,
+and manylinux builder from `ci/cuda-versions.json`, then constrains isolated PEP
+517 builds to the selected PyTorch distribution. It builds these aligned-version
+artifacts under `dist/`:
 
 - `flashinfer-python`
 - `flashinfer-jit-cache-sm121a`
@@ -201,6 +215,19 @@ jobs. It builds these aligned-version artifacts under `dist/`:
 Set `OUTPUT_DIR`, `FLASHINFER_DEV_RELEASE_SUFFIX`, or
 `FLASHINFER_JIT_CACHE_PROVIDER_ARCH` to override the one-off defaults. Existing
 output is retained unless `CLEAN_OUTPUT=1` is explicit.
+
+Use the same wrapper for a CUDA 13.4 provider by selecting the central matrix
+label. This chooses the `nightly/cu134` PyTorch index and CUDA 13.4 builder:
+
+```bash
+FLASHINFER_LOCAL_VERSION=cu134 \
+FLASHINFER_JIT_CACHE_PROVIDER_ARCH=12.1a \
+scripts/build_jit_cache_provider_wheelhouse.sh
+```
+
+`--print-config` resolves and prints this configuration without starting Docker.
+The selected provider may intentionally be absent from the monolithic matrix
+architecture list; sm121a is one such size-driven exception.
 
 The build does not require a GPU. Its final validation checks distribution and
 version metadata, the shim's exact provider pin, provider entry-point discovery,
@@ -221,7 +248,9 @@ The initial DGX Spark build produced a 250,767,917-byte provider wheel containin
 657 modules (487,366,496 bytes uncompressed), a 16,105,950-byte
 `flashinfer-python` wheel, and a 4,349-byte shim. The build generated 3,404 Ninja
 steps with seven concurrent jobs. The installed provider resolved and launched
-`silu_and_mul` on an SM121 GB10 with JIT disabled.
+`silu_and_mul` on an SM121 GB10 with JIT disabled. These are historical prototype
+measurements; current module pruning and compression flags require a fresh
+wheelhouse measurement before release integration.
 
 ## Validation Gates
 
@@ -242,7 +271,10 @@ Before changing release workflows or making shim mode the default:
 6. Test a process with heterogeneous visible GPUs. Until a provider contains
    all required targets, it should miss AOT cleanly and fall back to JIT.
 7. Update release and nightly matrices, wheel-index parsing, documentation, and
-   stale-provider uninstall behavior only after the inventories pass.
+   stale-provider uninstall behavior only after the inventories pass. Keep the
+   CUDA version and PyTorch index in `ci/cuda-versions.json`, and add explicit
+   provider coverage fields rather than inferring them from size-pruned
+   monolithic architecture lists.
 
 ## Open Decisions
 
@@ -252,5 +284,7 @@ Before changing release workflows or making shim mode the default:
   providers as a size optimization.
 - Whether provider manifests should include hashes and per-module code targets,
   rather than the provider-wide target list used by the prototype.
+- Which architectures removed from aggregate wheels for size, including sm75
+  and sm121a, should remain in each platform's default provider set.
 - How long to retain legacy monolithic wheel production after the shim becomes
   the default.

--- a/docs/design_docs/jit_cache_provider_wheels.md
+++ b/docs/design_docs/jit_cache_provider_wheels.md
@@ -178,6 +178,11 @@ FLASHINFER_LOCAL_VERSION=cu130 \
 python -m build --wheel flashinfer-jit-cache-provider
 ```
 
+A direct build uses the native `linux_<arch>` platform tag. The wheelhouse
+wrapper opts into `manylinux_2_28` only after verifying the selected container
+uses glibc 2.28 or older; custom `DOCKER_IMAGE` values remain native-tagged
+unless the caller explicitly requests and satisfies that check.
+
 Build a shim whose default dependencies include the tested provider set:
 
 ```bash

--- a/flashinfer-jit-cache-provider/.gitignore
+++ b/flashinfer-jit-cache-provider/.gitignore
@@ -1,0 +1,6 @@
+build/
+dist/
+*.egg-info/
+flashinfer_jit_cache_provider/_build_meta.py
+flashinfer_jit_cache_provider/manifest.json
+flashinfer_jit_cache_provider/jit_cache/

--- a/flashinfer-jit-cache-provider/build_backend.py
+++ b/flashinfer-jit-cache-provider/build_backend.py
@@ -1,0 +1,187 @@
+"""PEP 517 backend for architecture-specific jit-cache provider wheels."""
+
+import json
+import os
+import platform
+import subprocess
+import sys
+from pathlib import Path
+
+from setuptools import build_meta as _orig
+from wheel.bdist_wheel import bdist_wheel
+
+from package_config import (
+    PROJECT_ROOT,
+    PROVIDER_SOURCE_DIR,
+    get_provider_build_config,
+)
+
+
+sys.path.insert(0, str(PROJECT_ROOT))
+
+from build_utils import get_git_version
+
+
+os.environ["FLASHINFER_DISABLE_VERSION_CHECK"] = "1"
+config = get_provider_build_config()
+os.environ["FLASHINFER_CUDA_ARCH_LIST"] = config.cuda_architecture
+
+
+def _write_build_metadata() -> None:
+    metadata_path = PROVIDER_SOURCE_DIR / "_build_meta.py"
+    metadata_path.write_text(
+        '"""Generated jit-cache provider build metadata."""\n'
+        f'__version__ = "{config.version}"\n'
+        f'__git_version__ = "{get_git_version(cwd=PROJECT_ROOT)}"\n'
+    )
+
+
+_write_build_metadata()
+
+
+def _ensure_build_inputs() -> None:
+    submodule_paths = [
+        PROJECT_ROOT / "3rdparty" / "cutlass" / "include",
+        PROJECT_ROOT / "3rdparty" / "spdlog" / "include",
+        PROJECT_ROOT / "3rdparty" / "cccl" / "cub",
+    ]
+    if not all(path.exists() for path in submodule_paths):
+        result = subprocess.run(
+            ["git", "submodule", "update", "--init", "--recursive"],
+            cwd=str(PROJECT_ROOT),
+            capture_output=True,
+            check=False,
+        )
+        missing = [str(path) for path in submodule_paths if not path.exists()]
+        if result.returncode != 0 and missing:
+            raise RuntimeError(
+                f"git submodule update failed and submodules are missing: {missing}\n"
+                f"git stderr: {result.stderr.decode().strip()}"
+            )
+
+    import importlib.util
+
+    backend_spec = importlib.util.spec_from_file_location(
+        "main_build_backend", PROJECT_ROOT / "build_backend.py"
+    )
+    if backend_spec is None or backend_spec.loader is None:
+        raise RuntimeError("Could not load the FlashInfer build backend")
+    main_build_backend = importlib.util.module_from_spec(backend_spec)
+    backend_spec.loader.exec_module(main_build_backend)
+    main_build_backend._create_data_dir(use_symlinks=True)
+
+
+def _write_provider_manifest(jit_cache_dir: Path) -> None:
+    modules = sorted(
+        module_dir.name
+        for module_dir in jit_cache_dir.iterdir()
+        if module_dir.is_dir() and (module_dir / f"{module_dir.name}.so").is_file()
+    )
+    if not modules:
+        raise RuntimeError("No .so files were generated for the jit-cache provider")
+
+    manifest = {
+        "schema_version": 1,
+        "provider_id": config.provider_tag,
+        "distribution": config.distribution,
+        "version": config.version,
+        "cuda_architectures": [config.provider_tag],
+        "modules": modules,
+    }
+    (PROVIDER_SOURCE_DIR / "manifest.json").write_text(
+        json.dumps(manifest, indent=2, sort_keys=True) + "\n"
+    )
+
+
+def _build_aot_modules(verbose: bool = True) -> None:
+    _ensure_build_inputs()
+
+    from flashinfer import aot
+
+    jit_cache_dir = PROVIDER_SOURCE_DIR / "jit_cache"
+    build_dir = PROJECT_ROOT / "build" / "aot-providers" / config.provider_tag
+    aot.compile_and_package_modules(
+        out_dir=jit_cache_dir,
+        build_dir=build_dir,
+        project_root=PROJECT_ROOT,
+        config=None,
+        verbose=verbose,
+        skip_prebuilt=False,
+    )
+    _write_provider_manifest(jit_cache_dir)
+
+
+class PlatformSpecificBdistWheel(bdist_wheel):
+    """Mark provider wheels as Linux platform wheels using the stable ABI tag."""
+
+    def finalize_options(self):
+        super().finalize_options()
+        self.root_is_pure = False
+        self.py_limited_api = "cp39"
+
+    def get_tag(self):
+        machine = platform.machine()
+        if platform.system() == "Linux" and machine in ("x86_64", "aarch64"):
+            platform_tag = f"manylinux_2_28_{machine}"
+        elif platform.system() == "Linux":
+            platform_tag = f"linux_{machine}"
+        else:
+            import distutils.util
+
+            platform_tag = (
+                distutils.util.get_platform().replace("-", "_").replace(".", "_")
+            )
+        return "cp39", "abi3", platform_tag
+
+
+class _MonkeyPatchBdistWheel:
+    def __enter__(self):
+        from setuptools.command import bdist_wheel as setuptools_bdist_wheel
+
+        self.original_bdist_wheel = setuptools_bdist_wheel.bdist_wheel
+        setuptools_bdist_wheel.bdist_wheel = PlatformSpecificBdistWheel
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        from setuptools.command import bdist_wheel as setuptools_bdist_wheel
+
+        setuptools_bdist_wheel.bdist_wheel = self.original_bdist_wheel
+
+
+def build_wheel(wheel_directory, config_settings=None, metadata_directory=None):
+    print(
+        f"Building {config.distribution} {config.version} for "
+        f"{config.cuda_architecture}"
+    )
+    _build_aot_modules()
+    with _MonkeyPatchBdistWheel():
+        return _orig.build_wheel(wheel_directory, config_settings, metadata_directory)
+
+
+def build_editable(wheel_directory, config_settings=None, metadata_directory=None):
+    _build_aot_modules()
+    build_editable_impl = getattr(_orig, "build_editable", None)
+    if build_editable_impl is None:
+        raise RuntimeError("build_editable not supported by setuptools backend")
+    with _MonkeyPatchBdistWheel():
+        return build_editable_impl(wheel_directory, config_settings, metadata_directory)
+
+
+def prepare_metadata_for_build_wheel(metadata_directory, config_settings=None):
+    with _MonkeyPatchBdistWheel():
+        return _orig.prepare_metadata_for_build_wheel(
+            metadata_directory, config_settings
+        )
+
+
+def prepare_metadata_for_build_editable(metadata_directory, config_settings=None):
+    with _MonkeyPatchBdistWheel():
+        return _orig.prepare_metadata_for_build_editable(
+            metadata_directory, config_settings
+        )
+
+
+get_requires_for_build_wheel = _orig.get_requires_for_build_wheel
+get_requires_for_build_editable = getattr(
+    _orig, "get_requires_for_build_editable", None
+)

--- a/flashinfer-jit-cache-provider/build_backend.py
+++ b/flashinfer-jit-cache-provider/build_backend.py
@@ -3,6 +3,7 @@
 import json
 import os
 import platform
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -25,6 +26,8 @@ from build_utils import get_build_dependency_requirements, get_git_version
 os.environ["FLASHINFER_DISABLE_VERSION_CHECK"] = "1"
 config = get_provider_build_config()
 os.environ["FLASHINFER_CUDA_ARCH_LIST"] = config.cuda_architecture
+
+PROVIDER_PLATFORM_TAG_ENV = "FLASHINFER_JIT_CACHE_PROVIDER_PLATFORM_TAG"
 
 
 def _write_build_metadata() -> None:
@@ -111,8 +114,38 @@ def _build_aot_modules(verbose: bool = True) -> None:
     _write_provider_manifest(jit_cache_dir)
 
 
+def _provider_platform_tag(default_platform_tag: str) -> str:
+    requested_tag = os.environ.get(PROVIDER_PLATFORM_TAG_ENV, "").strip()
+    if not requested_tag:
+        return default_platform_tag
+
+    machine = platform.machine()
+    expected_tag = f"manylinux_2_28_{machine}"
+    libc_name, libc_version = platform.libc_ver()
+    libc_match = re.fullmatch(r"(\d+)\.(\d+)", libc_version)
+    if (
+        platform.system() != "Linux"
+        or machine not in ("x86_64", "aarch64")
+        or requested_tag != expected_tag
+        or libc_name != "glibc"
+        or libc_match is None
+    ):
+        raise RuntimeError(
+            f"Unsupported provider platform tag {requested_tag!r} for "
+            f"{platform.system()} {machine} with {libc_name} {libc_version}; "
+            f"expected {expected_tag!r} on glibc 2.28 or older"
+        )
+    glibc_version = tuple(int(part) for part in libc_match.groups())
+    if glibc_version > (2, 28):
+        raise RuntimeError(
+            f"glibc {libc_version} is too new for provider platform tag "
+            f"{requested_tag!r}"
+        )
+    return requested_tag
+
+
 class PlatformSpecificBdistWheel(bdist_wheel):
-    """Mark provider wheels as Linux platform wheels using the stable ABI tag."""
+    """Build a native provider wheel with a stable Python ABI tag."""
 
     def finalize_options(self):
         super().finalize_options()
@@ -120,17 +153,8 @@ class PlatformSpecificBdistWheel(bdist_wheel):
         self.py_limited_api = "cp39"
 
     def get_tag(self):
-        machine = platform.machine()
-        if platform.system() == "Linux" and machine in ("x86_64", "aarch64"):
-            platform_tag = f"manylinux_2_28_{machine}"
-        elif platform.system() == "Linux":
-            platform_tag = f"linux_{machine}"
-        else:
-            import distutils.util
-
-            platform_tag = (
-                distutils.util.get_platform().replace("-", "_").replace(".", "_")
-            )
+        _, _, default_platform_tag = super().get_tag()
+        platform_tag = _provider_platform_tag(default_platform_tag)
         return "cp39", "abi3", platform_tag
 
 

--- a/flashinfer-jit-cache-provider/build_backend.py
+++ b/flashinfer-jit-cache-provider/build_backend.py
@@ -19,7 +19,7 @@ from package_config import (
 
 sys.path.insert(0, str(PROJECT_ROOT))
 
-from build_utils import get_git_version
+from build_utils import get_build_dependency_requirements, get_git_version
 
 
 os.environ["FLASHINFER_DISABLE_VERSION_CHECK"] = "1"
@@ -181,7 +181,16 @@ def prepare_metadata_for_build_editable(metadata_directory, config_settings=None
         )
 
 
-get_requires_for_build_wheel = _orig.get_requires_for_build_wheel
-get_requires_for_build_editable = getattr(
-    _orig, "get_requires_for_build_editable", None
-)
+def get_requires_for_build_wheel(config_settings=None):
+    """Install configured dependencies in the isolated wheel build env."""
+    return [
+        *_orig.get_requires_for_build_wheel(config_settings),
+        *get_build_dependency_requirements(config.cuda_major),
+    ]
+
+
+def get_requires_for_build_editable(config_settings=None):
+    """Install configured dependencies in the isolated editable build env."""
+    get_requires = getattr(_orig, "get_requires_for_build_editable", None)
+    requirements = [] if get_requires is None else get_requires(config_settings)
+    return [*requirements, *get_build_dependency_requirements(config.cuda_major)]

--- a/flashinfer-jit-cache-provider/flashinfer_jit_cache_provider/__init__.py
+++ b/flashinfer-jit-cache-provider/flashinfer_jit_cache_provider/__init__.py
@@ -1,0 +1,27 @@
+"""Runtime entry point used by an installed jit-cache provider wheel."""
+
+import json
+from pathlib import Path
+from typing import Any, Dict
+
+
+_PACKAGE_DIR = Path(__file__).resolve().parent
+
+
+def get_provider() -> Dict[str, Any]:
+    """Return this provider's generated manifest to the jit-cache shim."""
+    manifest_path = _PACKAGE_DIR / "manifest.json"
+    with manifest_path.open() as manifest_file:
+        manifest = json.load(manifest_file)
+    manifest["jit_cache_dir"] = str(_PACKAGE_DIR / "jit_cache")
+    return manifest
+
+
+try:
+    from ._build_meta import __git_version__, __version__
+except ModuleNotFoundError:
+    __version__ = "0.0.0+unknown"
+    __git_version__ = "unknown"
+
+
+__all__ = ["get_provider"]

--- a/flashinfer-jit-cache-provider/package_config.py
+++ b/flashinfer-jit-cache-provider/package_config.py
@@ -1,0 +1,80 @@
+"""Build configuration shared by the jit-cache provider backend and setup.py."""
+
+import os
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+PROVIDER_SOURCE_DIR = Path(__file__).resolve().parent / "flashinfer_jit_cache_provider"
+
+
+def normalize_cuda_architecture(architecture: str) -> tuple[str, str]:
+    """Return ``(nvcc_arch, provider_tag)`` for a CUDA architecture spelling."""
+    normalized = architecture.strip().lower()
+    for prefix in ("compute_", "sm_", "sm"):
+        if normalized.startswith(prefix):
+            normalized = normalized[len(prefix) :]
+            break
+
+    dotted_match = re.fullmatch(r"(\d{1,2})\.(\d)([af]?)", normalized)
+    compact_match = re.fullmatch(r"(\d{2,3})([af]?)", normalized)
+    if dotted_match is not None:
+        major = int(dotted_match.group(1))
+        minor = int(dotted_match.group(2))
+        suffix = dotted_match.group(3)
+    elif compact_match is not None:
+        digits, suffix = compact_match.groups()
+        major = int(digits[:-1])
+        minor = int(digits[-1])
+    else:
+        raise ValueError(
+            f"Invalid FLASHINFER_JIT_CACHE_PROVIDER_ARCH={architecture!r}; "
+            "use a value such as '8.0', '9.0a', or 'sm120f'"
+        )
+
+    nvcc_arch = f"{major}.{minor}{suffix}"
+    provider_tag = f"sm{major}{minor}{suffix}"
+    return nvcc_arch, provider_tag
+
+
+def get_package_version() -> str:
+    version_file = PROJECT_ROOT / "version.txt"
+    version = version_file.read_text().strip() if version_file.exists() else "0.0.0"
+
+    dev_suffix = os.environ.get("FLASHINFER_DEV_RELEASE_SUFFIX", "").strip()
+    if dev_suffix:
+        version = f"{version}.dev{dev_suffix}"
+
+    local_version = os.environ.get("FLASHINFER_LOCAL_VERSION", "").strip()
+    if local_version:
+        version = f"{version}+{local_version}"
+    return version
+
+
+@dataclass(frozen=True)
+class ProviderBuildConfig:
+    cuda_architecture: str
+    provider_tag: str
+    distribution: str
+    package: str
+    version: str
+
+
+def get_provider_build_config() -> ProviderBuildConfig:
+    architecture = os.environ.get("FLASHINFER_JIT_CACHE_PROVIDER_ARCH", "").strip()
+    if not architecture:
+        raise RuntimeError(
+            "FLASHINFER_JIT_CACHE_PROVIDER_ARCH must select exactly one provider "
+            "architecture, for example '8.0' or '12.0f'"
+        )
+
+    cuda_architecture, provider_tag = normalize_cuda_architecture(architecture)
+    return ProviderBuildConfig(
+        cuda_architecture=cuda_architecture,
+        provider_tag=provider_tag,
+        distribution=f"flashinfer-jit-cache-{provider_tag}",
+        package=f"flashinfer_jit_cache.providers.{provider_tag}",
+        version=get_package_version(),
+    )

--- a/flashinfer-jit-cache-provider/package_config.py
+++ b/flashinfer-jit-cache-provider/package_config.py
@@ -4,6 +4,7 @@ import os
 import re
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Optional
 
 
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
@@ -53,9 +54,19 @@ def get_package_version() -> str:
     return version
 
 
+def get_cuda_major() -> Optional[str]:
+    """Derive the CUDA major from a local wheel label such as ``cu134``."""
+    local_version = os.environ.get("FLASHINFER_LOCAL_VERSION", "").strip()
+    match = re.fullmatch(r"cu(\d{2,})", local_version)
+    if match is None:
+        return None
+    return match.group(1)[:-1]
+
+
 @dataclass(frozen=True)
 class ProviderBuildConfig:
     cuda_architecture: str
+    cuda_major: Optional[str]
     provider_tag: str
     distribution: str
     package: str
@@ -73,6 +84,7 @@ def get_provider_build_config() -> ProviderBuildConfig:
     cuda_architecture, provider_tag = normalize_cuda_architecture(architecture)
     return ProviderBuildConfig(
         cuda_architecture=cuda_architecture,
+        cuda_major=get_cuda_major(),
         provider_tag=provider_tag,
         distribution=f"flashinfer-jit-cache-{provider_tag}",
         package=f"flashinfer_jit_cache.providers.{provider_tag}",

--- a/flashinfer-jit-cache-provider/pyproject.toml
+++ b/flashinfer-jit-cache-provider/pyproject.toml
@@ -1,0 +1,4 @@
+[build-system]
+requires = ["setuptools>=77", "packaging>=24", "wheel", "tqdm", "torch", "ninja", "requests", "numpy", "nvidia-ml-py", "apache-tvm-ffi>=0.1,<0.2"]
+build-backend = "build_backend"
+backend-path = ["."]

--- a/flashinfer-jit-cache-provider/setup.py
+++ b/flashinfer-jit-cache-provider/setup.py
@@ -1,0 +1,28 @@
+"""Setuptools configuration for one architecture-specific provider wheel."""
+
+from setuptools import setup
+
+from package_config import get_provider_build_config
+
+
+config = get_provider_build_config()
+
+setup(
+    name=config.distribution,
+    version=config.version,
+    description=f"FlashInfer pre-compiled JIT cache provider for {config.provider_tag}",
+    license="Apache-2.0",
+    author="FlashInfer team",
+    url="https://github.com/flashinfer-ai/flashinfer",
+    python_requires=">=3.9",
+    packages=[config.package],
+    package_dir={config.package: "flashinfer_jit_cache_provider"},
+    package_data={config.package: ["manifest.json", "jit_cache/**/*.so"]},
+    include_package_data=False,
+    zip_safe=False,
+    entry_points={
+        "flashinfer.jit_cache.providers": [
+            f"{config.provider_tag}={config.package}:get_provider"
+        ]
+    },
+)

--- a/flashinfer-jit-cache/.gitignore
+++ b/flashinfer-jit-cache/.gitignore
@@ -7,3 +7,5 @@ build/
 dist/
 flashinfer_jit_cache/jit_cache/
 _build_meta.py
+flashinfer_jit_cache/_build_meta.py
+flashinfer_jit_cache/_provider_requirements.txt

--- a/flashinfer-jit-cache/build_backend.py
+++ b/flashinfer-jit-cache/build_backend.py
@@ -17,6 +17,8 @@ limitations under the License.
 import sys
 import os
 import platform
+import re
+import shutil
 from pathlib import Path
 from setuptools import build_meta as _orig
 from wheel.bdist_wheel import bdist_wheel
@@ -28,6 +30,55 @@ from build_utils import get_git_version
 
 # Skip version check when building flashinfer-jit-cache package
 os.environ["FLASHINFER_DISABLE_VERSION_CHECK"] = "1"
+
+
+def _wheel_kind() -> str:
+    kind = os.environ.get("FLASHINFER_JIT_CACHE_WHEEL_KIND", "legacy").strip()
+    if kind not in ("legacy", "shim"):
+        raise RuntimeError(
+            f"Invalid FLASHINFER_JIT_CACHE_WHEEL_KIND={kind!r}; "
+            "expected 'legacy' or 'shim'"
+        )
+    return kind
+
+
+def _provider_tag(architecture: str) -> str:
+    normalized = architecture.strip().lower()
+    for prefix in ("compute_", "sm_", "sm"):
+        if normalized.startswith(prefix):
+            normalized = normalized[len(prefix) :]
+            break
+    normalized = normalized.replace(".", "").replace("_", "")
+    if not re.fullmatch(r"\d{2,3}[af]?", normalized):
+        raise RuntimeError(f"Invalid provider CUDA architecture {architecture!r}")
+    return f"sm{normalized}"
+
+
+def _write_provider_requirements(version: str) -> None:
+    requirements_path = (
+        Path(__file__).parent / "flashinfer_jit_cache" / "_provider_requirements.txt"
+    )
+    requirements = []
+    if _wheel_kind() == "shim":
+        architecture_list = os.environ.get(
+            "FLASHINFER_JIT_CACHE_PROVIDER_ARCHS",
+            os.environ.get("FLASHINFER_CUDA_ARCH_LIST", ""),
+        )
+        if not architecture_list.strip():
+            raise RuntimeError(
+                "A shim build requires FLASHINFER_JIT_CACHE_PROVIDER_ARCHS "
+                "or FLASHINFER_CUDA_ARCH_LIST"
+            )
+        provider_tags = sorted(
+            {_provider_tag(architecture) for architecture in architecture_list.split()}
+        )
+        requirements = [
+            f"flashinfer-jit-cache-{provider_tag}=={version}"
+            for provider_tag in provider_tags
+        ]
+    requirements_path.write_text(
+        "\n".join(requirements) + ("\n" if requirements else "")
+    )
 
 
 def _create_build_metadata():
@@ -61,6 +112,7 @@ def _create_build_metadata():
     # If file exists and not in git repo (installing from sdist), keep existing file
     if build_meta_file.exists() and not in_git_repo:
         print("Build metadata file already exists (not in git repo), keeping it")
+        _write_provider_requirements(version)
         return version
 
     # In git repo (editable) or file doesn't exist, create/update it
@@ -70,6 +122,7 @@ def _create_build_metadata():
         f.write(f'__git_version__ = "{git_version}"\n')
 
     print(f"Created build metadata file with version {version}")
+    _write_provider_requirements(version)
     return version
 
 
@@ -157,7 +210,15 @@ def _build_aot_modules():
 
 def _prepare_build():
     """Shared preparation logic for both wheel and editable builds."""
-    _build_aot_modules()
+    _create_build_metadata()
+    if _wheel_kind() == "legacy":
+        _build_aot_modules()
+        return
+
+    # A shim wheel owns discovery and dependency metadata, not binary modules.
+    aot_package_dir = Path(__file__).parent / "flashinfer_jit_cache" / "jit_cache"
+    if aot_package_dir.exists():
+        shutil.rmtree(aot_package_dir)
 
 
 class PlatformSpecificBdistWheel(bdist_wheel):
@@ -213,12 +274,16 @@ class _MonkeyPatchBdistWheel:
 
 def build_wheel(wheel_directory, config_settings=None, metadata_directory=None):
     """Build wheel with custom AOT module compilation."""
-    print("Building flashinfer-jit-cache wheel...")
+    print(f"Building flashinfer-jit-cache {_wheel_kind()} wheel...")
 
     _prepare_build()
 
-    with _MonkeyPatchBdistWheel():
-        return _orig.build_wheel(wheel_directory, config_settings, metadata_directory)
+    if _wheel_kind() == "legacy":
+        with _MonkeyPatchBdistWheel():
+            return _orig.build_wheel(
+                wheel_directory, config_settings, metadata_directory
+            )
+    return _orig.build_wheel(wheel_directory, config_settings, metadata_directory)
 
 
 def build_editable(wheel_directory, config_settings=None, metadata_directory=None):
@@ -227,30 +292,39 @@ def build_editable(wheel_directory, config_settings=None, metadata_directory=Non
 
     _prepare_build()
 
-    # Now build the editable install using setuptools
     _orig_build_editable = getattr(_orig, "build_editable", None)
     if _orig_build_editable is None:
         raise RuntimeError("build_editable not supported by setuptools backend")
 
-    result = _orig_build_editable(wheel_directory, config_settings, metadata_directory)
+    if _wheel_kind() == "legacy":
+        with _MonkeyPatchBdistWheel():
+            return _orig_build_editable(
+                wheel_directory, config_settings, metadata_directory
+            )
 
-    return result
+    return _orig_build_editable(wheel_directory, config_settings, metadata_directory)
 
 
 def prepare_metadata_for_build_wheel(metadata_directory, config_settings=None):
     """Prepare metadata with platform-specific wheel tags."""
-    with _MonkeyPatchBdistWheel():
-        return _orig.prepare_metadata_for_build_wheel(
-            metadata_directory, config_settings
-        )
+    if _wheel_kind() == "legacy":
+        with _MonkeyPatchBdistWheel():
+            return _orig.prepare_metadata_for_build_wheel(
+                metadata_directory, config_settings
+            )
+    return _orig.prepare_metadata_for_build_wheel(metadata_directory, config_settings)
 
 
 def prepare_metadata_for_build_editable(metadata_directory, config_settings=None):
     """Prepare metadata for editable install."""
-    with _MonkeyPatchBdistWheel():
-        return _orig.prepare_metadata_for_build_editable(
-            metadata_directory, config_settings
-        )
+    if _wheel_kind() == "legacy":
+        with _MonkeyPatchBdistWheel():
+            return _orig.prepare_metadata_for_build_editable(
+                metadata_directory, config_settings
+            )
+    return _orig.prepare_metadata_for_build_editable(
+        metadata_directory, config_settings
+    )
 
 
 # Export the required interface

--- a/flashinfer-jit-cache/build_backend.py
+++ b/flashinfer-jit-cache/build_backend.py
@@ -72,6 +72,7 @@ def _write_provider_requirements(version: str) -> None:
         provider_tags = sorted(
             {_provider_tag(architecture) for architecture in architecture_list.split()}
         )
+        # Provider lists are literal; sm80 SASS is not a portable baseline.
         requirements = [
             f"flashinfer-jit-cache-{provider_tag}=={version}"
             for provider_tag in provider_tags

--- a/flashinfer-jit-cache/build_backend.py
+++ b/flashinfer-jit-cache/build_backend.py
@@ -17,6 +17,8 @@ limitations under the License.
 import sys
 import os
 import platform
+import re
+import shutil
 from pathlib import Path
 from setuptools import build_meta as _orig
 from wheel.bdist_wheel import bdist_wheel
@@ -28,6 +30,55 @@ from build_utils import get_build_dependency_requirements, get_git_version
 
 # Skip version check when building flashinfer-jit-cache package
 os.environ["FLASHINFER_DISABLE_VERSION_CHECK"] = "1"
+
+
+def _wheel_kind() -> str:
+    kind = os.environ.get("FLASHINFER_JIT_CACHE_WHEEL_KIND", "legacy").strip()
+    if kind not in ("legacy", "shim"):
+        raise RuntimeError(
+            f"Invalid FLASHINFER_JIT_CACHE_WHEEL_KIND={kind!r}; "
+            "expected 'legacy' or 'shim'"
+        )
+    return kind
+
+
+def _provider_tag(architecture: str) -> str:
+    normalized = architecture.strip().lower()
+    for prefix in ("compute_", "sm_", "sm"):
+        if normalized.startswith(prefix):
+            normalized = normalized[len(prefix) :]
+            break
+    normalized = normalized.replace(".", "").replace("_", "")
+    if not re.fullmatch(r"\d{2,3}[af]?", normalized):
+        raise RuntimeError(f"Invalid provider CUDA architecture {architecture!r}")
+    return f"sm{normalized}"
+
+
+def _write_provider_requirements(version: str) -> None:
+    requirements_path = (
+        Path(__file__).parent / "flashinfer_jit_cache" / "_provider_requirements.txt"
+    )
+    requirements = []
+    if _wheel_kind() == "shim":
+        architecture_list = os.environ.get(
+            "FLASHINFER_JIT_CACHE_PROVIDER_ARCHS",
+            os.environ.get("FLASHINFER_CUDA_ARCH_LIST", ""),
+        )
+        if not architecture_list.strip():
+            raise RuntimeError(
+                "A shim build requires FLASHINFER_JIT_CACHE_PROVIDER_ARCHS "
+                "or FLASHINFER_CUDA_ARCH_LIST"
+            )
+        provider_tags = sorted(
+            {_provider_tag(architecture) for architecture in architecture_list.split()}
+        )
+        requirements = [
+            f"flashinfer-jit-cache-{provider_tag}=={version}"
+            for provider_tag in provider_tags
+        ]
+    requirements_path.write_text(
+        "\n".join(requirements) + ("\n" if requirements else "")
+    )
 
 
 def _create_build_metadata():
@@ -61,6 +112,7 @@ def _create_build_metadata():
     # If file exists and not in git repo (installing from sdist), keep existing file
     if build_meta_file.exists() and not in_git_repo:
         print("Build metadata file already exists (not in git repo), keeping it")
+        _write_provider_requirements(version)
         return version
 
     # In git repo (editable) or file doesn't exist, create/update it
@@ -70,6 +122,7 @@ def _create_build_metadata():
         f.write(f'__git_version__ = "{git_version}"\n')
 
     print(f"Created build metadata file with version {version}")
+    _write_provider_requirements(version)
     return version
 
 
@@ -157,7 +210,15 @@ def _build_aot_modules():
 
 def _prepare_build():
     """Shared preparation logic for both wheel and editable builds."""
-    _build_aot_modules()
+    _create_build_metadata()
+    if _wheel_kind() == "legacy":
+        _build_aot_modules()
+        return
+
+    # A shim wheel owns discovery and dependency metadata, not binary modules.
+    aot_package_dir = Path(__file__).parent / "flashinfer_jit_cache" / "jit_cache"
+    if aot_package_dir.exists():
+        shutil.rmtree(aot_package_dir)
 
 
 class PlatformSpecificBdistWheel(bdist_wheel):
@@ -213,12 +274,16 @@ class _MonkeyPatchBdistWheel:
 
 def build_wheel(wheel_directory, config_settings=None, metadata_directory=None):
     """Build wheel with custom AOT module compilation."""
-    print("Building flashinfer-jit-cache wheel...")
+    print(f"Building flashinfer-jit-cache {_wheel_kind()} wheel...")
 
     _prepare_build()
 
-    with _MonkeyPatchBdistWheel():
-        return _orig.build_wheel(wheel_directory, config_settings, metadata_directory)
+    if _wheel_kind() == "legacy":
+        with _MonkeyPatchBdistWheel():
+            return _orig.build_wheel(
+                wheel_directory, config_settings, metadata_directory
+            )
+    return _orig.build_wheel(wheel_directory, config_settings, metadata_directory)
 
 
 def build_editable(wheel_directory, config_settings=None, metadata_directory=None):
@@ -227,30 +292,39 @@ def build_editable(wheel_directory, config_settings=None, metadata_directory=Non
 
     _prepare_build()
 
-    # Now build the editable install using setuptools
     _orig_build_editable = getattr(_orig, "build_editable", None)
     if _orig_build_editable is None:
         raise RuntimeError("build_editable not supported by setuptools backend")
 
-    result = _orig_build_editable(wheel_directory, config_settings, metadata_directory)
+    if _wheel_kind() == "legacy":
+        with _MonkeyPatchBdistWheel():
+            return _orig_build_editable(
+                wheel_directory, config_settings, metadata_directory
+            )
 
-    return result
+    return _orig_build_editable(wheel_directory, config_settings, metadata_directory)
 
 
 def prepare_metadata_for_build_wheel(metadata_directory, config_settings=None):
     """Prepare metadata with platform-specific wheel tags."""
-    with _MonkeyPatchBdistWheel():
-        return _orig.prepare_metadata_for_build_wheel(
-            metadata_directory, config_settings
-        )
+    if _wheel_kind() == "legacy":
+        with _MonkeyPatchBdistWheel():
+            return _orig.prepare_metadata_for_build_wheel(
+                metadata_directory, config_settings
+            )
+    return _orig.prepare_metadata_for_build_wheel(metadata_directory, config_settings)
 
 
 def prepare_metadata_for_build_editable(metadata_directory, config_settings=None):
     """Prepare metadata for editable install."""
-    with _MonkeyPatchBdistWheel():
-        return _orig.prepare_metadata_for_build_editable(
-            metadata_directory, config_settings
-        )
+    if _wheel_kind() == "legacy":
+        with _MonkeyPatchBdistWheel():
+            return _orig.prepare_metadata_for_build_editable(
+                metadata_directory, config_settings
+            )
+    return _orig.prepare_metadata_for_build_editable(
+        metadata_directory, config_settings
+    )
 
 
 def get_requires_for_build_wheel(config_settings=None):

--- a/flashinfer-jit-cache/flashinfer_jit_cache/__init__.py
+++ b/flashinfer-jit-cache/flashinfer_jit_cache/__init__.py
@@ -14,12 +14,116 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import os
+import importlib.metadata
+import logging
+import re
+from dataclasses import dataclass
 from pathlib import Path
-from typing import List, Optional
+from typing import Any, FrozenSet, Mapping, Tuple
+
+
+logger = logging.getLogger(__name__)
+
+JIT_CACHE_PROVIDER_ENTRY_POINT_GROUP = "flashinfer.jit_cache.providers"
+JIT_CACHE_PROVIDER_SCHEMA_VERSION = 1
 
 # Get the path to the AOT modules directory within this package
 jit_cache_dir = Path(__file__).parent / "jit_cache"
+
+
+def _normalize_cuda_architecture(architecture: str) -> str:
+    """Normalize CUDA architecture spellings to names such as ``sm90a``."""
+    normalized = architecture.strip().lower()
+    for prefix in ("compute_", "sm_", "sm"):
+        if normalized.startswith(prefix):
+            normalized = normalized[len(prefix) :]
+            break
+    normalized = normalized.replace(".", "").replace("_", "")
+    if not re.fullmatch(r"\d{2,3}[af]?", normalized):
+        raise ValueError(f"Invalid CUDA architecture {architecture!r}")
+    return f"sm{normalized}"
+
+
+@dataclass(frozen=True)
+class JitCacheProvider:
+    """Description of one installed jit-cache binary provider."""
+
+    provider_id: str
+    distribution: str
+    version: str
+    jit_cache_dir: Path
+    cuda_architectures: FrozenSet[str]
+    modules: FrozenSet[str]
+
+
+def _provider_from_mapping(
+    provider_id: str, manifest: Mapping[str, Any]
+) -> JitCacheProvider:
+    schema_version = manifest.get("schema_version")
+    if schema_version != JIT_CACHE_PROVIDER_SCHEMA_VERSION:
+        raise ValueError(
+            f"Provider {provider_id!r} uses unsupported manifest schema "
+            f"{schema_version!r}; expected {JIT_CACHE_PROVIDER_SCHEMA_VERSION}"
+        )
+
+    required_fields = (
+        "distribution",
+        "version",
+        "jit_cache_dir",
+        "cuda_architectures",
+        "modules",
+    )
+    missing_fields = [field for field in required_fields if field not in manifest]
+    if missing_fields:
+        raise ValueError(
+            f"Provider {provider_id!r} is missing fields: {', '.join(missing_fields)}"
+        )
+
+    cache_dir = Path(str(manifest["jit_cache_dir"])).resolve()
+    cuda_architectures = frozenset(
+        _normalize_cuda_architecture(str(architecture))
+        for architecture in manifest["cuda_architectures"]
+    )
+    modules = frozenset(str(module) for module in manifest["modules"])
+    if not cuda_architectures:
+        raise ValueError(f"Provider {provider_id!r} has no CUDA architectures")
+    if not modules:
+        raise ValueError(f"Provider {provider_id!r} has no modules")
+
+    return JitCacheProvider(
+        provider_id=provider_id,
+        distribution=str(manifest["distribution"]),
+        version=str(manifest["version"]),
+        jit_cache_dir=cache_dir,
+        cuda_architectures=cuda_architectures,
+        modules=modules,
+    )
+
+
+def _provider_entry_points() -> Tuple[importlib.metadata.EntryPoint, ...]:
+    entry_points = importlib.metadata.entry_points()
+    if hasattr(entry_points, "select"):
+        return tuple(entry_points.select(group=JIT_CACHE_PROVIDER_ENTRY_POINT_GROUP))
+    return tuple(entry_points.get(JIT_CACHE_PROVIDER_ENTRY_POINT_GROUP, ()))
+
+
+def get_jit_cache_providers() -> Tuple[JitCacheProvider, ...]:
+    """Discover installed binary providers registered through package metadata."""
+    providers = []
+    for entry_point in _provider_entry_points():
+        try:
+            factory = entry_point.load()
+            manifest = factory()
+            if not isinstance(manifest, Mapping):
+                raise TypeError("provider factory must return a mapping")
+            providers.append(_provider_from_mapping(entry_point.name, manifest))
+        except Exception as error:
+            logger.warning(
+                "Ignoring invalid flashinfer jit-cache provider %s: %s",
+                entry_point.name,
+                error,
+            )
+    return tuple(sorted(providers, key=lambda provider: provider.provider_id))
 
 
 def get_jit_cache_dir() -> str:
@@ -36,5 +140,9 @@ except ModuleNotFoundError:
 
 
 __all__ = [
+    "JIT_CACHE_PROVIDER_ENTRY_POINT_GROUP",
+    "JIT_CACHE_PROVIDER_SCHEMA_VERSION",
+    "JitCacheProvider",
     "get_jit_cache_dir",
+    "get_jit_cache_providers",
 ]

--- a/flashinfer-jit-cache/pyproject.toml
+++ b/flashinfer-jit-cache/pyproject.toml
@@ -5,9 +5,9 @@ backend-path = ["."]
 
 [project]
 name = "flashinfer-jit-cache"
-dynamic = ["version"]
-description = "Pre-compiled JIT Cache for FlashInfer"
-readme = {text = "This package contains pre-compiled JIT Cache for FlashInfer. It provides most of the necessary shared libraries (.so files) of FlashInfer.", content-type = "text/plain"}
+dynamic = ["version", "dependencies"]
+description = "JIT cache provider shim for FlashInfer"
+readme = {text = "This package discovers compatible pre-compiled FlashInfer JIT cache providers. Legacy builds may also contain the shared libraries directly.", content-type = "text/plain"}
 requires-python = ">=3.9"
 license = {text = "Apache-2.0"}
 authors = [
@@ -28,8 +28,6 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
-dependencies = []
-
 [project.urls]
 Homepage = "https://github.com/flashinfer-ai/flashinfer"
 Documentation = "https://github.com/flashinfer-ai/flashinfer"
@@ -42,6 +40,7 @@ include-package-data = true
 
 [tool.setuptools.dynamic]
 version = {attr = "flashinfer_jit_cache.__version__"}
+dependencies = {file = ["flashinfer_jit_cache/_provider_requirements.txt"]}
 
 [tool.setuptools.package-data]
 flashinfer_jit_cache = ["jit_cache/**/*.so"]

--- a/flashinfer/__main__.py
+++ b/flashinfer/__main__.py
@@ -16,6 +16,7 @@ limitations under the License.
 
 import copy
 import os
+import re
 from packaging.version import InvalidVersion, Version
 import subprocess
 import sys
@@ -146,6 +147,45 @@ def _build_jit_cache_requirement(flashinfer_version: str, cuda_index_label: str)
     return f"flashinfer-jit-cache=={public_version}+{cuda_index_label}"
 
 
+def _normalize_jit_cache_provider_tag(cuda_architecture: str) -> str:
+    normalized = cuda_architecture.strip().lower()
+    for prefix in ("compute_", "sm_", "sm"):
+        if normalized.startswith(prefix):
+            normalized = normalized[len(prefix) :]
+            break
+    normalized = normalized.replace(".", "").replace("_", "")
+    if not re.fullmatch(r"\d{2,3}[af]?", normalized):
+        raise click.ClickException(
+            f"Invalid SM architecture '{cuda_architecture}'. "
+            "Use a value such as 'sm80', 'sm90a', or 'sm120f'."
+        )
+    return f"sm{normalized}"
+
+
+def _detect_jit_cache_provider_tags() -> tuple[str, ...]:
+    provider_tags = tuple(
+        sorted(
+            {
+                _normalize_jit_cache_provider_tag(f"{major}{minor}")
+                for major, minor in current_compilation_context.TARGET_CUDA_ARCHS
+            }
+        )
+    )
+    if not provider_tags:
+        raise click.ClickException(
+            "No CUDA architecture could be detected. Pass --sm explicitly when "
+            "installing minimal jit-cache providers on a host without a visible GPU."
+        )
+    return provider_tags
+
+
+def _build_jit_cache_provider_requirement(
+    flashinfer_version: str, cuda_index_label: str, provider_tag: str
+) -> str:
+    public_version = _get_public_flashinfer_version(flashinfer_version)
+    return f"flashinfer-jit-cache-{provider_tag}=={public_version}+{cuda_index_label}"
+
+
 def _build_cubin_requirement(flashinfer_version: str) -> str:
     public_version = _get_public_flashinfer_version(flashinfer_version)
     return f"flashinfer-cubin=={public_version}"
@@ -163,19 +203,25 @@ def _build_jit_cache_index_url(cuda_index_label: str, nightly: bool) -> str:
 
 
 def _build_pip_install_cmd(
-    requirement: str, index_url: str, nightly: bool
+    requirements: str | list[str],
+    index_url: str,
+    nightly: bool,
+    no_deps: bool = True,
 ) -> list[str]:
+    if isinstance(requirements, str):
+        requirements = [requirements]
     cmd = [
         sys.executable,
         "-m",
         "pip",
         "install",
         "--upgrade",
-        "--no-deps",
     ]
+    if no_deps:
+        cmd.append("--no-deps")
     if nightly:
         cmd.append("--pre")
-    cmd.extend(["--index-url", index_url, requirement])
+    cmd.extend(["--index-url", index_url, *requirements])
     return cmd
 
 
@@ -223,18 +269,48 @@ def _install_jit_cache_wheel(
     index_url: str | None,
     nightly: bool,
     dry_run: bool,
+    mode: str = "all",
+    sm_architectures: tuple[str, ...] = (),
 ) -> None:
     detected_cuda_version = _parse_cuda_version(cuda_version)
     wheel_cuda_version = _resolve_jit_cache_cuda_version(detected_cuda_version)
     cuda_index_label = _cuda_version_to_index_label(wheel_cuda_version)
     resolved_flashinfer_version = flashinfer_version or __version__
-    requirement = _build_jit_cache_requirement(
+    shim_requirement = _build_jit_cache_requirement(
         resolved_flashinfer_version, cuda_index_label
     )
     resolved_index_url = index_url or _build_jit_cache_index_url(
         cuda_index_label, nightly
     )
-    cmd = _build_pip_install_cmd(requirement, resolved_index_url, nightly)
+    if sm_architectures and mode != "minimal":
+        raise click.ClickException("--sm can only be used with --mode minimal.")
+
+    provider_tags: tuple[str, ...] = ()
+    requirements = [shim_requirement]
+    if mode == "minimal":
+        provider_tags = tuple(
+            sorted(
+                {
+                    _normalize_jit_cache_provider_tag(architecture)
+                    for architecture in sm_architectures
+                }
+            )
+        )
+        if not provider_tags:
+            provider_tags = _detect_jit_cache_provider_tags()
+        requirements.extend(
+            _build_jit_cache_provider_requirement(
+                resolved_flashinfer_version, cuda_index_label, provider_tag
+            )
+            for provider_tag in provider_tags
+        )
+
+    cmd = _build_pip_install_cmd(
+        requirements,
+        resolved_index_url,
+        nightly,
+        no_deps=mode == "minimal",
+    )
 
     click.secho("=== JIT Cache Wheel Install ===", fg="yellow")
     click.secho("FlashInfer version:", fg="magenta", nl=False)
@@ -243,10 +319,15 @@ def _install_jit_cache_wheel(
     click.secho(f" {detected_cuda_version}", fg="cyan")
     click.secho("Wheel CUDA label:", fg="magenta", nl=False)
     click.secho(f" {cuda_index_label}", fg="cyan")
+    click.secho("Install mode:", fg="magenta", nl=False)
+    click.secho(f" {mode}", fg="cyan")
+    if provider_tags:
+        click.secho("Providers:", fg="magenta", nl=False)
+        click.secho(f" {', '.join(provider_tags)}", fg="cyan")
     click.secho("Wheel index:", fg="magenta", nl=False)
     click.secho(f" {resolved_index_url}", fg="cyan")
     click.secho("Requirement:", fg="magenta", nl=False)
-    click.secho(f" {requirement}", fg="cyan")
+    click.secho(f" {' '.join(requirements)}", fg="cyan")
     _run_pip_install_cmd(
         cmd, dry_run, "✅ flashinfer-jit-cache installed successfully."
     )
@@ -507,6 +588,25 @@ def clear_cubin_cmd():
     help="Override the FlashInfer version to install a matching jit-cache wheel for.",
 )
 @click.option(
+    "--mode",
+    type=click.Choice(("all", "minimal")),
+    default="all",
+    show_default=True,
+    help=(
+        "Install all provider dependencies declared by the shim, or only the "
+        "providers selected by --sm or the visible GPUs."
+    ),
+)
+@click.option(
+    "--sm",
+    "sm_architectures",
+    multiple=True,
+    help=(
+        "CUDA architecture to install in minimal mode, such as sm80, sm90a, "
+        "or sm120f. May be repeated."
+    ),
+)
+@click.option(
     "--index-url",
     default=None,
     help="Explicit wheel index URL (overrides the auto-generated FlashInfer index URL).",
@@ -522,11 +622,23 @@ def clear_cubin_cmd():
     help="Print the pip command without executing it.",
 )
 def install_jit_cache_wheel_cmd(
-    cuda_version, flashinfer_version, index_url, nightly, dry_run
+    cuda_version,
+    flashinfer_version,
+    mode,
+    sm_architectures,
+    index_url,
+    nightly,
+    dry_run,
 ):
     """Install the matching flashinfer-jit-cache wheel."""
     _install_jit_cache_wheel(
-        cuda_version, flashinfer_version, index_url, nightly, dry_run
+        cuda_version,
+        flashinfer_version,
+        index_url,
+        nightly,
+        dry_run,
+        mode,
+        sm_architectures,
     )
 
 

--- a/flashinfer/__main__.py
+++ b/flashinfer/__main__.py
@@ -594,7 +594,8 @@ def clear_cubin_cmd():
     show_default=True,
     help=(
         "Install all provider dependencies declared by the shim, or only the "
-        "providers selected by --sm or the visible GPUs."
+        "providers selected by --sm or the visible GPUs. Minimal mode does not "
+        "add a baseline provider."
     ),
 )
 @click.option(

--- a/flashinfer/__main__.py
+++ b/flashinfer/__main__.py
@@ -16,6 +16,7 @@ limitations under the License.
 
 import copy
 import os
+import re
 from packaging.version import InvalidVersion, Version
 import subprocess
 import sys
@@ -145,6 +146,45 @@ def _build_jit_cache_requirement(flashinfer_version: str, cuda_index_label: str)
     return f"flashinfer-jit-cache=={public_version}+{cuda_index_label}"
 
 
+def _normalize_jit_cache_provider_tag(cuda_architecture: str) -> str:
+    normalized = cuda_architecture.strip().lower()
+    for prefix in ("compute_", "sm_", "sm"):
+        if normalized.startswith(prefix):
+            normalized = normalized[len(prefix) :]
+            break
+    normalized = normalized.replace(".", "").replace("_", "")
+    if not re.fullmatch(r"\d{2,3}[af]?", normalized):
+        raise click.ClickException(
+            f"Invalid SM architecture '{cuda_architecture}'. "
+            "Use a value such as 'sm80', 'sm90a', or 'sm120f'."
+        )
+    return f"sm{normalized}"
+
+
+def _detect_jit_cache_provider_tags() -> tuple[str, ...]:
+    provider_tags = tuple(
+        sorted(
+            {
+                _normalize_jit_cache_provider_tag(f"{major}{minor}")
+                for major, minor in current_compilation_context.TARGET_CUDA_ARCHS
+            }
+        )
+    )
+    if not provider_tags:
+        raise click.ClickException(
+            "No CUDA architecture could be detected. Pass --sm explicitly when "
+            "installing minimal jit-cache providers on a host without a visible GPU."
+        )
+    return provider_tags
+
+
+def _build_jit_cache_provider_requirement(
+    flashinfer_version: str, cuda_index_label: str, provider_tag: str
+) -> str:
+    public_version = _get_public_flashinfer_version(flashinfer_version)
+    return f"flashinfer-jit-cache-{provider_tag}=={public_version}+{cuda_index_label}"
+
+
 def _build_cubin_requirement(flashinfer_version: str) -> str:
     public_version = _get_public_flashinfer_version(flashinfer_version)
     return f"flashinfer-cubin=={public_version}"
@@ -162,19 +202,25 @@ def _build_jit_cache_index_url(cuda_index_label: str, nightly: bool) -> str:
 
 
 def _build_pip_install_cmd(
-    requirement: str, index_url: str, nightly: bool
+    requirements: str | list[str],
+    index_url: str,
+    nightly: bool,
+    no_deps: bool = True,
 ) -> list[str]:
+    if isinstance(requirements, str):
+        requirements = [requirements]
     cmd = [
         sys.executable,
         "-m",
         "pip",
         "install",
         "--upgrade",
-        "--no-deps",
     ]
+    if no_deps:
+        cmd.append("--no-deps")
     if nightly:
         cmd.append("--pre")
-    cmd.extend(["--index-url", index_url, requirement])
+    cmd.extend(["--index-url", index_url, *requirements])
     return cmd
 
 
@@ -222,18 +268,48 @@ def _install_jit_cache_wheel(
     index_url: str | None,
     nightly: bool,
     dry_run: bool,
+    mode: str = "all",
+    sm_architectures: tuple[str, ...] = (),
 ) -> None:
     detected_cuda_version = _parse_cuda_version(cuda_version)
     wheel_cuda_version = _resolve_jit_cache_cuda_version(detected_cuda_version)
     cuda_index_label = _cuda_version_to_index_label(wheel_cuda_version)
     resolved_flashinfer_version = flashinfer_version or __version__
-    requirement = _build_jit_cache_requirement(
+    shim_requirement = _build_jit_cache_requirement(
         resolved_flashinfer_version, cuda_index_label
     )
     resolved_index_url = index_url or _build_jit_cache_index_url(
         cuda_index_label, nightly
     )
-    cmd = _build_pip_install_cmd(requirement, resolved_index_url, nightly)
+    if sm_architectures and mode != "minimal":
+        raise click.ClickException("--sm can only be used with --mode minimal.")
+
+    provider_tags: tuple[str, ...] = ()
+    requirements = [shim_requirement]
+    if mode == "minimal":
+        provider_tags = tuple(
+            sorted(
+                {
+                    _normalize_jit_cache_provider_tag(architecture)
+                    for architecture in sm_architectures
+                }
+            )
+        )
+        if not provider_tags:
+            provider_tags = _detect_jit_cache_provider_tags()
+        requirements.extend(
+            _build_jit_cache_provider_requirement(
+                resolved_flashinfer_version, cuda_index_label, provider_tag
+            )
+            for provider_tag in provider_tags
+        )
+
+    cmd = _build_pip_install_cmd(
+        requirements,
+        resolved_index_url,
+        nightly,
+        no_deps=mode == "minimal",
+    )
 
     click.secho("=== JIT Cache Wheel Install ===", fg="yellow")
     click.secho("FlashInfer version:", fg="magenta", nl=False)
@@ -242,10 +318,15 @@ def _install_jit_cache_wheel(
     click.secho(f" {detected_cuda_version}", fg="cyan")
     click.secho("Wheel CUDA label:", fg="magenta", nl=False)
     click.secho(f" {cuda_index_label}", fg="cyan")
+    click.secho("Install mode:", fg="magenta", nl=False)
+    click.secho(f" {mode}", fg="cyan")
+    if provider_tags:
+        click.secho("Providers:", fg="magenta", nl=False)
+        click.secho(f" {', '.join(provider_tags)}", fg="cyan")
     click.secho("Wheel index:", fg="magenta", nl=False)
     click.secho(f" {resolved_index_url}", fg="cyan")
     click.secho("Requirement:", fg="magenta", nl=False)
-    click.secho(f" {requirement}", fg="cyan")
+    click.secho(f" {' '.join(requirements)}", fg="cyan")
     _run_pip_install_cmd(
         cmd, dry_run, "✅ flashinfer-jit-cache installed successfully."
     )
@@ -506,6 +587,25 @@ def clear_cubin_cmd():
     help="Override the FlashInfer version to install a matching jit-cache wheel for.",
 )
 @click.option(
+    "--mode",
+    type=click.Choice(("all", "minimal")),
+    default="all",
+    show_default=True,
+    help=(
+        "Install all provider dependencies declared by the shim, or only the "
+        "providers selected by --sm or the visible GPUs."
+    ),
+)
+@click.option(
+    "--sm",
+    "sm_architectures",
+    multiple=True,
+    help=(
+        "CUDA architecture to install in minimal mode, such as sm80, sm90a, "
+        "or sm120f. May be repeated."
+    ),
+)
+@click.option(
     "--index-url",
     default=None,
     help="Explicit wheel index URL (overrides the auto-generated FlashInfer index URL).",
@@ -521,11 +621,23 @@ def clear_cubin_cmd():
     help="Print the pip command without executing it.",
 )
 def install_jit_cache_wheel_cmd(
-    cuda_version, flashinfer_version, index_url, nightly, dry_run
+    cuda_version,
+    flashinfer_version,
+    mode,
+    sm_architectures,
+    index_url,
+    nightly,
+    dry_run,
 ):
     """Install the matching flashinfer-jit-cache wheel."""
     _install_jit_cache_wheel(
-        cuda_version, flashinfer_version, index_url, nightly, dry_run
+        cuda_version,
+        flashinfer_version,
+        index_url,
+        nightly,
+        dry_run,
+        mode,
+        sm_architectures,
     )
 
 

--- a/flashinfer/__main__.py
+++ b/flashinfer/__main__.py
@@ -593,7 +593,8 @@ def clear_cubin_cmd():
     show_default=True,
     help=(
         "Install all provider dependencies declared by the shim, or only the "
-        "providers selected by --sm or the visible GPUs."
+        "providers selected by --sm or the visible GPUs. Minimal mode does not "
+        "add a baseline provider."
     ),
 )
 @click.option(

--- a/flashinfer/aot.py
+++ b/flashinfer/aot.py
@@ -371,7 +371,7 @@ def gen_attention(
         from .jit.attention import gen_batch_prefill_attention_sink_module
 
         for dtype in f16_dtype_:
-            for backend in ["fa2", "fa3"]:
+            for backend in ["fa2"] + (["fa3"] if has_sm90 else []):
                 for use_swa in [True, False]:
                     yield gen_batch_prefill_attention_sink_module(
                         backend=backend,

--- a/flashinfer/aot.py
+++ b/flashinfer/aot.py
@@ -123,7 +123,10 @@ from .jit.fused_moe import (
 from .jit.cake_fused_moe_warp_decode import (
     gen_cake_fused_moe_warp_decode_module,
 )
-from .jit.bgmv_moe import gen_bgmv_moe_module
+from .jit.bgmv_moe import (
+    BGMV_MOE_SUPPORTED_MAJOR_VERSIONS,
+    gen_bgmv_moe_module,
+)
 from .jit.blackwell_bgmv_moe import (
     BLACKWELL_BGMV_MOE_DTYPES,
     BLACKWELL_BGMV_MOE_HIDDEN_SIZES,
@@ -530,6 +533,7 @@ def gen_all_modules(
 ) -> List[JitSpec]:
     jit_specs: List[JitSpec] = []
     jit_specs.append(gen_spdlog_module())
+    has_bgmv_moe = sm_capabilities.get("bgmv_moe", False)
     has_sm80 = sm_capabilities.get("sm80", False)
     has_sm90 = sm_capabilities.get("sm90", False)
     has_sm100 = sm_capabilities.get("sm100", False)
@@ -733,7 +737,8 @@ def gen_all_modules(
     if add_moe:
         jit_specs.append(gen_gemm_module())
         # Multi-LoRA MoE BGMV kernel
-        jit_specs.append(gen_bgmv_moe_module())
+        if has_bgmv_moe:
+            jit_specs.append(gen_bgmv_moe_module())
         if sm_capabilities.get("sm100a_exact", False):
             jit_specs.extend(
                 gen_blackwell_bgmv_moe_module(hidden_size, dtype)
@@ -1190,6 +1195,10 @@ def detect_sm_capabilities():
     }
     flash_kda_decode_sm103_arches = {(10, "3a"), (10, "3f")}
     return {
+        "bgmv_moe": any(
+            major in BGMV_MOE_SUPPORTED_MAJOR_VERSIONS
+            for major, _ in compilation_context.TARGET_CUDA_ARCHS
+        ),
         "sm80": has_any_sm8x and cuda_version >= Version("11.0"),
         "sm90": has_sm("compute_90", "12.3"),
         "sm100": has_sm("compute_100", "12.8"),

--- a/flashinfer/aot.py
+++ b/flashinfer/aot.py
@@ -395,7 +395,7 @@ def gen_attention(
         from .jit.attention import gen_batch_prefill_attention_sink_module
 
         for dtype in f16_dtype_:
-            for backend in ["fa2", "fa3"]:
+            for backend in ["fa2"] + (["fa3"] if has_sm90 else []):
                 for use_swa in [True, False]:
                     yield gen_batch_prefill_attention_sink_module(
                         backend=backend,

--- a/flashinfer/jit/bgmv_moe.py
+++ b/flashinfer/jit/bgmv_moe.py
@@ -23,6 +23,9 @@ from . import env as jit_env
 from .core import gen_jit_spec, logger, current_compilation_context
 
 
+BGMV_MOE_SUPPORTED_MAJOR_VERSIONS = (9, 10, 11, 12)
+
+
 def _get_bgmv_moe_csrc_dir() -> Path:
     """Get the path to the BGMV MoE CUDA source directory.
 
@@ -58,7 +61,7 @@ def gen_bgmv_moe_module():
     Generate the JIT compilation spec for the BGMV MoE CUDA kernels.
 
     This compiles the multi-LoRA MoE BGMV shrink/expand kernel pair.
-    Supports SM70+ (V100, A100, H100, B200).
+    The JIT integration currently targets SM90 and newer architectures.
 
     Returns:
         JitSpec that can be built and loaded.
@@ -107,9 +110,9 @@ def gen_bgmv_moe_module():
             raise FileNotFoundError(f"BGMV MoE header file not found: {src_path}")
         shutil.copy(src_path, gen_directory / fname)
 
-    # Get nvcc flags for supported architectures (SM70+)
+    # Get nvcc flags for the architectures supported by this JIT integration.
     nvcc_flags = current_compilation_context.get_nvcc_flags_list(
-        supported_major_versions=[9, 10, 11, 12]  # SM90+ (H100, B200)
+        supported_major_versions=BGMV_MOE_SUPPORTED_MAJOR_VERSIONS
     )
 
     spec = gen_jit_spec(

--- a/flashinfer/jit/core.py
+++ b/flashinfer/jit/core.py
@@ -361,7 +361,7 @@ class JitSpecNvcc(JitSpec):
 
     @property
     def aot_path(self) -> Path:
-        return jit_env.FLASHINFER_AOT_DIR / self.name / f"{self.name}.so"
+        return jit_env.get_aot_path(self.name)
 
     @property
     def is_aot(self) -> bool:

--- a/flashinfer/jit/core.py
+++ b/flashinfer/jit/core.py
@@ -362,7 +362,7 @@ class JitSpecNvcc(JitSpec):
 
     @property
     def aot_path(self) -> Path:
-        return jit_env.FLASHINFER_AOT_DIR / self.name / f"{self.name}.so"
+        return jit_env.get_aot_path(self.name)
 
     @property
     def is_aot(self) -> bool:

--- a/flashinfer/jit/env.py
+++ b/flashinfer/jit/env.py
@@ -21,6 +21,9 @@ limitations under the License.
 import logging
 import os
 import pathlib
+from dataclasses import dataclass
+from typing import FrozenSet, Tuple
+
 from ..compilation_context import CompilationContext
 from ..version import __version__ as flashinfer_version
 
@@ -110,39 +113,106 @@ def _get_cubin_dir():
 FLASHINFER_CUBIN_DIR: pathlib.Path = _get_cubin_dir()
 
 
-def _get_aot_dir():
+@dataclass(frozen=True)
+class AOTProvider:
+    """Installed package that owns a set of architecture-specific AOT modules."""
+
+    provider_id: str
+    distribution: str
+    version: str
+    jit_cache_dir: pathlib.Path
+    cuda_architectures: FrozenSet[str]
+    modules: FrozenSet[str]
+
+
+def _check_jit_cache_version(distribution: str, package_version: str) -> None:
+    # NOTE(Zihao): jit-cache versions contain a CUDA local-version suffix,
+    # for example 0.3.1+cu129, so compare the FlashInfer version prefix.
+    if (
+        not os.getenv("FLASHINFER_DISABLE_VERSION_CHECK")
+        and flashinfer_version != "0.0.0+unknown"
+        and not package_version.startswith(flashinfer_version)
+    ):
+        raise RuntimeError(
+            f"{distribution} version ({package_version}) does not match "
+            f"flashinfer version ({flashinfer_version}). "
+            "Please install the same version of both packages. "
+            "Set FLASHINFER_DISABLE_VERSION_CHECK=1 to bypass this check."
+        )
+
+
+def _get_aot_locations() -> Tuple[pathlib.Path, Tuple[AOTProvider, ...]]:
     """
-    Get the AOT directory path with the following priority:
-    1. flashinfer-jit-cache package if installed
-    2. Default fallback to _package_root / "data" / "aot"
+    Get the legacy AOT directory and any installed binary provider packages.
+
+    ``flashinfer-jit-cache`` historically owned one directory containing every
+    module. Newer shim builds discover separately installable providers while
+    retaining that directory as a compatibility fallback.
     """
-    # First check if flashinfer-jit-cache package is installed
     if has_flashinfer_jit_cache():
         import flashinfer_jit_cache
 
         flashinfer_jit_cache_version = flashinfer_jit_cache.__version__
-        # NOTE(Zihao): we don't use exact version match here because the version of flashinfer-jit-cache
-        # contains the CUDA version suffix: e.g. 0.3.1+cu129.
-        # Allow bypassing version check with environment variable
-        if (
-            not os.getenv("FLASHINFER_DISABLE_VERSION_CHECK")
-            and flashinfer_version != "0.0.0+unknown"
-            and not flashinfer_jit_cache_version.startswith(flashinfer_version)
-        ):
-            raise RuntimeError(
-                f"flashinfer-jit-cache version ({flashinfer_jit_cache_version}) does not match "
-                f"flashinfer version ({flashinfer_version}). "
-                "Please install the same version of both packages. "
-                "Set FLASHINFER_DISABLE_VERSION_CHECK=1 to bypass this check."
-            )
+        _check_jit_cache_version("flashinfer-jit-cache", flashinfer_jit_cache_version)
 
-        return pathlib.Path(flashinfer_jit_cache.get_jit_cache_dir())
+        providers = []
+        get_providers = getattr(flashinfer_jit_cache, "get_jit_cache_providers", None)
+        if get_providers is not None:
+            for provider in get_providers():
+                _check_jit_cache_version(provider.distribution, provider.version)
+                providers.append(
+                    AOTProvider(
+                        provider_id=provider.provider_id,
+                        distribution=provider.distribution,
+                        version=provider.version,
+                        jit_cache_dir=pathlib.Path(provider.jit_cache_dir),
+                        cuda_architectures=frozenset(provider.cuda_architectures),
+                        modules=frozenset(provider.modules),
+                    )
+                )
 
-    # Fall back to default directory
-    return _package_root / "data" / "aot"
+        return (
+            pathlib.Path(flashinfer_jit_cache.get_jit_cache_dir()),
+            tuple(providers),
+        )
+
+    return _package_root / "data" / "aot", ()
 
 
-FLASHINFER_AOT_DIR: pathlib.Path = _get_aot_dir()
+FLASHINFER_AOT_DIR, FLASHINFER_AOT_PROVIDERS = _get_aot_locations()
+FLASHINFER_AOT_DIRS: Tuple[pathlib.Path, ...] = (FLASHINFER_AOT_DIR,) + tuple(
+    provider.jit_cache_dir for provider in FLASHINFER_AOT_PROVIDERS
+)
+
+
+def _target_cuda_architectures() -> FrozenSet[str]:
+    compilation_context = CompilationContext()
+    return frozenset(
+        f"sm{major}{minor}" for major, minor in compilation_context.TARGET_CUDA_ARCHS
+    )
+
+
+def get_aot_path(module_name: str) -> pathlib.Path:
+    """Resolve an AOT module from the legacy wheel or a compatible provider."""
+    legacy_path = FLASHINFER_AOT_DIR / module_name / f"{module_name}.so"
+    if legacy_path.exists():
+        return legacy_path
+
+    target_architectures = _target_cuda_architectures()
+    if not target_architectures:
+        return legacy_path
+    for provider in FLASHINFER_AOT_PROVIDERS:
+        if module_name not in provider.modules:
+            continue
+        if not target_architectures.issubset(provider.cuda_architectures):
+            continue
+        provider_path = provider.jit_cache_dir / module_name / f"{module_name}.so"
+        if provider_path.exists():
+            return provider_path
+
+    # JitSpec uses this stable path for existence checks and diagnostics when
+    # no compatible prebuilt module is installed.
+    return legacy_path
 
 
 def _get_workspace_dir_name() -> pathlib.Path:

--- a/flashinfer/jit/env.py
+++ b/flashinfer/jit/env.py
@@ -193,6 +193,19 @@ def _target_cuda_architectures() -> FrozenSet[str]:
     )
 
 
+def _provider_covers_targets(
+    provider_architectures: FrozenSet[str], target_architectures: FrozenSet[str]
+) -> bool:
+    """Return whether a provider explicitly covers every active CUDA target.
+
+    Exact matching is intentional. In particular, ``a`` targets are
+    architecture-specific and cannot be forwarded to another compute capability.
+    Baseline and ``f`` targets also remain exact here until provider manifests can
+    distinguish executable compatibility from complete AOT module coverage.
+    """
+    return target_architectures.issubset(provider_architectures)
+
+
 def get_aot_path(module_name: str) -> pathlib.Path:
     """Resolve an AOT module from the legacy wheel or a compatible provider."""
     legacy_path = FLASHINFER_AOT_DIR / module_name / f"{module_name}.so"
@@ -205,7 +218,9 @@ def get_aot_path(module_name: str) -> pathlib.Path:
     for provider in FLASHINFER_AOT_PROVIDERS:
         if module_name not in provider.modules:
             continue
-        if not target_architectures.issubset(provider.cuda_architectures):
+        if not _provider_covers_targets(
+            provider.cuda_architectures, target_architectures
+        ):
             continue
         provider_path = provider.jit_cache_dir / module_name / f"{module_name}.so"
         if provider_path.exists():

--- a/flashinfer/jit/env.py
+++ b/flashinfer/jit/env.py
@@ -127,11 +127,12 @@ class AOTProvider:
 
 def _check_jit_cache_version(distribution: str, package_version: str) -> None:
     # NOTE(Zihao): jit-cache versions contain a CUDA local-version suffix,
-    # for example 0.3.1+cu129, so compare the FlashInfer version prefix.
+    # for example 0.3.1+cu129, so allow only that suffix after an exact version.
     if (
         not os.getenv("FLASHINFER_DISABLE_VERSION_CHECK")
         and flashinfer_version != "0.0.0+unknown"
-        and not package_version.startswith(flashinfer_version)
+        and package_version != flashinfer_version
+        and not package_version.startswith(f"{flashinfer_version}+")
     ):
         raise RuntimeError(
             f"{distribution} version ({package_version}) does not match "

--- a/scripts/build_flashinfer_jit_cache_whl.sh
+++ b/scripts/build_flashinfer_jit_cache_whl.sh
@@ -28,6 +28,8 @@ echo "=========================================="
 echo "Building flashinfer-jit-cache wheel"
 echo "=========================================="
 
+: "${PYTORCH_INDEX:?PYTORCH_INDEX must be set}"
+
 compute_jit_cache_parallelism
 
 # Display build environment info
@@ -60,61 +62,10 @@ export PATH="/opt/python/${PYTHON_ABI}-${PYTHON_ABI}/bin:$PATH"
 export LD_LIBRARY_PATH="/usr/local/cuda/lib64:/usr/local/cuda/lib64/stubs:$LD_LIBRARY_PATH"
 
 EXPECTED_CUDA_VERSION="${CUDA_MAJOR}.${CUDA_MINOR}"
-NVCC_CUDA_VERSION=$(nvcc --version | sed -n 's/.*release \([0-9][0-9]*\.[0-9][0-9]*\).*/\1/p' | head -n1)
-if [ "${NVCC_CUDA_VERSION}" != "${EXPECTED_CUDA_VERSION}" ]; then
-  echo "ERROR: nvcc reports CUDA ${NVCC_CUDA_VERSION:-unknown}; expected ${EXPECTED_CUDA_VERSION}" >&2
-  exit 1
-fi
-echo "nvcc CUDA version check passed: ${NVCC_CUDA_VERSION}"
+validate_jit_cache_cuda_toolchain "${EXPECTED_CUDA_VERSION}"
 
 echo "::group::Install build system"
-pip install --upgrade build
-
-PYTORCH_INDEX_URL="https://download.pytorch.org/whl/${PYTORCH_INDEX}"
-if python3 - "${EXPECTED_CUDA_VERSION}" <<'PY'
-import sys
-
-try:
-    import torch
-except ImportError:
-    raise SystemExit(1)
-
-raise SystemExit(0 if torch.version.cuda == sys.argv[1] else 1)
-PY
-then
-  echo "Using preinstalled PyTorch for CUDA ${EXPECTED_CUDA_VERSION}"
-else
-  TORCH_INSTALL_ARGS=(--upgrade torch --index-url "${PYTORCH_INDEX_URL}")
-  if [[ "${PYTORCH_INDEX}" == nightly/* ]]; then
-    TORCH_INSTALL_ARGS=(--pre "${TORCH_INSTALL_ARGS[@]}")
-  fi
-  pip install "${TORCH_INSTALL_ARGS[@]}"
-fi
-
-python3 - "${EXPECTED_CUDA_VERSION}" <<'PY'
-import importlib.metadata
-import sys
-import torch
-
-expected = sys.argv[1]
-if torch.version.cuda != expected:
-    raise SystemExit(
-        f"ERROR: PyTorch targets CUDA {torch.version.cuda}; expected CUDA {expected}"
-    )
-print(f"PyTorch CUDA version check passed: {torch.__version__} ({torch.version.cuda})")
-print(f"PyTorch distribution version: {importlib.metadata.version('torch')}")
-PY
-
-# The PEP 517 build runs in an isolated environment. Constrain its torch build
-# dependency to the version selected above and expose the matching stable or
-# nightly PyTorch index to that environment.
-TORCH_CONSTRAINT=$(mktemp)
-python3 -c 'import importlib.metadata as m; print("torch==" + m.version("torch"))' > "${TORCH_CONSTRAINT}"
-export PIP_CONSTRAINT="${TORCH_CONSTRAINT}"
-export PIP_EXTRA_INDEX_URL="${PYTORCH_INDEX_URL}"
-if [[ "${PYTORCH_INDEX}" == nightly/* ]]; then
-  export PIP_PRE=1
-fi
+setup_jit_cache_python_build python3 "${EXPECTED_CUDA_VERSION}" "${PYTORCH_INDEX}"
 echo "::endgroup::"
 
 # Optional: set up sccache for compiler caching with S3 backend

--- a/scripts/build_flashinfer_jit_cache_whl.sh
+++ b/scripts/build_flashinfer_jit_cache_whl.sh
@@ -10,6 +10,7 @@ source "${SCRIPT_DIR}/jit_cache_build_common.sh"
 
 finish_sccache_stats() {
   local exit_code=$?
+  cleanup_jit_cache_python_build || true
   collect_sccache_stats || true
   return "${exit_code}"
 }

--- a/scripts/build_jit_cache_provider_wheelhouse.sh
+++ b/scripts/build_jit_cache_provider_wheelhouse.sh
@@ -66,6 +66,13 @@ run_on_host() {
     echo "Container: ${DOCKER_IMAGE}"
     echo "Output: ${output_dir}"
 
+    # Older root-run builds may leave ignored generated paths that the
+    # UID-matched build container cannot remove from the bind mount.
+    docker run --rm \
+        -v "${REPO_ROOT}:/workspace" \
+        "${DOCKER_IMAGE}" \
+        rm -rf /workspace/flashinfer/data /workspace/flashinfer/_build_meta.py
+
     docker run --rm \
         --user "${host_uid}:${host_gid}" \
         -v "${REPO_ROOT}:/workspace" \

--- a/scripts/build_jit_cache_provider_wheelhouse.sh
+++ b/scripts/build_jit_cache_provider_wheelhouse.sh
@@ -31,6 +31,7 @@ normalize_provider_tag() {
 : "${AOT_MAX_JOBS_CAP:=4}"
 : "${AOT_MAX_JOBS_MEMORY_GB:=16}"
 : "${FLASHINFER_NVCC_THREADS:=1}"
+: "${CUDA_ARCHITECTURE_POLICY:=report}"
 : "${CLEAN_OUTPUT:=0}"
 
 PROVIDER_TAG=$(normalize_provider_tag "${FLASHINFER_JIT_CACHE_PROVIDER_ARCH}")
@@ -84,6 +85,7 @@ run_on_host() {
         -e CUDA_MAJOR="${CUDA_MAJOR}" \
         -e CUDA_MINOR="${CUDA_MINOR}" \
         -e CUDA_VERSION="${CUDA_VERSION}" \
+        -e CUDA_ARCHITECTURE_POLICY="${CUDA_ARCHITECTURE_POLICY}" \
         -e FLASHINFER_DEV_RELEASE_SUFFIX="${FLASHINFER_DEV_RELEASE_SUFFIX}" \
         -e FLASHINFER_JIT_CACHE_PROVIDER_ARCH="${FLASHINFER_JIT_CACHE_PROVIDER_ARCH}" \
         -e FLASHINFER_LOCAL_VERSION="${FLASHINFER_LOCAL_VERSION}" \
@@ -186,6 +188,7 @@ run_in_container() {
         --provider "${PROVIDER_TAG}" \
         --version "${PACKAGE_VERSION}" \
         --cuobjdump /usr/local/cuda/bin/cuobjdump \
+        --cuda-architecture-policy "${CUDA_ARCHITECTURE_POLICY}" \
         --install-smoke
 
     echo "Built wheelhouse: ${output_dir}"

--- a/scripts/build_jit_cache_provider_wheelhouse.sh
+++ b/scripts/build_jit_cache_provider_wheelhouse.sh
@@ -1,0 +1,197 @@
+#!/bin/bash
+# Build a local FlashInfer Python + jit-cache provider + shim wheelhouse.
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO_ROOT=$(cd "${SCRIPT_DIR}/.." && pwd)
+
+normalize_provider_tag() {
+    local architecture=${1,,}
+    architecture=${architecture#compute_}
+    architecture=${architecture#sm_}
+    architecture=${architecture#sm}
+    architecture=${architecture//./}
+    architecture=${architecture//_/}
+    if ! [[ "${architecture}" =~ ^[0-9]{2,3}[af]?$ ]]; then
+        echo "Invalid provider architecture: $1" >&2
+        return 1
+    fi
+    printf 'sm%s\n' "${architecture}"
+}
+
+: "${FLASHINFER_JIT_CACHE_PROVIDER_ARCH:=12.1a}"
+: "${FLASHINFER_LOCAL_VERSION:=cu130}"
+: "${FLASHINFER_DEV_RELEASE_SUFFIX:=$(date -u +%Y%m%d)}"
+: "${CUDA_VERSION:=13.0}"
+: "${CUDA_MAJOR:=13}"
+: "${CUDA_MINOR:=0}"
+: "${ARCH:=aarch64}"
+: "${DOCKER_IMAGE:=pytorch/manylinuxaarch64-builder:cuda13.0}"
+: "${AOT_MAX_JOBS_CAP:=4}"
+: "${AOT_MAX_JOBS_MEMORY_GB:=16}"
+: "${FLASHINFER_NVCC_THREADS:=1}"
+: "${CLEAN_OUTPUT:=0}"
+
+PROVIDER_TAG=$(normalize_provider_tag "${FLASHINFER_JIT_CACHE_PROVIDER_ARCH}")
+PACKAGE_VERSION=$(tr -d '[:space:]' < "${REPO_ROOT}/version.txt")
+PACKAGE_VERSION="${PACKAGE_VERSION}.dev${FLASHINFER_DEV_RELEASE_SUFFIX}+${FLASHINFER_LOCAL_VERSION}"
+
+run_on_host() {
+    local output_dir cache_dir host_uid host_gid
+    output_dir=${OUTPUT_DIR:-"${REPO_ROOT}/dist/jit-cache-wheelhouse-${PROVIDER_TAG}-${FLASHINFER_LOCAL_VERSION}-dev${FLASHINFER_DEV_RELEASE_SUFFIX}"}
+    cache_dir=${FLASHINFER_CI_CACHE:-"${XDG_CACHE_HOME:-${HOME}/.cache}/flashinfer-wheelhouse"}
+
+    command -v docker >/dev/null 2>&1 || {
+        echo "docker is required" >&2
+        exit 1
+    }
+
+    mkdir -p "${output_dir}" "${cache_dir}"
+    output_dir=$(cd "${output_dir}" && pwd)
+    cache_dir=$(cd "${cache_dir}" && pwd)
+
+    if [ "${CLEAN_OUTPUT}" = "1" ]; then
+        find "${output_dir}" -mindepth 1 -maxdepth 1 -type f -delete
+    elif find "${output_dir}" -mindepth 1 -maxdepth 1 -type f -print -quit | grep -q .; then
+        echo "Output directory is not empty: ${output_dir}" >&2
+        echo "Set CLEAN_OUTPUT=1 or choose a different OUTPUT_DIR." >&2
+        exit 1
+    fi
+
+    host_uid=$(id -u)
+    host_gid=$(id -g)
+
+    echo "Building ${PACKAGE_VERSION} provider ${PROVIDER_TAG}"
+    echo "Container: ${DOCKER_IMAGE}"
+    echo "Output: ${output_dir}"
+
+    docker run --rm \
+        --user "${host_uid}:${host_gid}" \
+        -v "${REPO_ROOT}:/workspace" \
+        -v "${output_dir}:/wheelhouse" \
+        -v "${cache_dir}:/ci-cache" \
+        -e AOT_MAX_JOBS_CAP="${AOT_MAX_JOBS_CAP}" \
+        -e AOT_MAX_JOBS_MEMORY_GB="${AOT_MAX_JOBS_MEMORY_GB}" \
+        -e ARCH="${ARCH}" \
+        -e CUDA_MAJOR="${CUDA_MAJOR}" \
+        -e CUDA_MINOR="${CUDA_MINOR}" \
+        -e CUDA_VERSION="${CUDA_VERSION}" \
+        -e FLASHINFER_DEV_RELEASE_SUFFIX="${FLASHINFER_DEV_RELEASE_SUFFIX}" \
+        -e FLASHINFER_JIT_CACHE_PROVIDER_ARCH="${FLASHINFER_JIT_CACHE_PROVIDER_ARCH}" \
+        -e FLASHINFER_LOCAL_VERSION="${FLASHINFER_LOCAL_VERSION}" \
+        -e FLASHINFER_NVCC_THREADS="${FLASHINFER_NVCC_THREADS}" \
+        -e HOST_GID="${host_gid}" \
+        -e HOST_UID="${host_uid}" \
+        -e OUTPUT_DIR=/wheelhouse \
+        -e PYTHON_BIN="${PYTHON_BIN:-/opt/python/cp312-cp312/bin/python}" \
+        -e FLASHINFER_CI_CACHE=/ci-cache \
+        -w /workspace \
+        "${DOCKER_IMAGE}" \
+        bash /workspace/scripts/build_jit_cache_provider_wheelhouse.sh --inside-container
+}
+
+run_in_container() {
+    local python_bin build_venv python output_dir
+    python_bin=${PYTHON_BIN:-/opt/python/cp312-cp312/bin/python}
+    build_venv=${BUILD_VENV:-/tmp/flashinfer-wheelhouse-venv}
+    output_dir=${OUTPUT_DIR:-/wheelhouse}
+
+    if [ "$(uname -m)" != "${ARCH}" ]; then
+        echo "Container architecture $(uname -m) does not match ARCH=${ARCH}" >&2
+        exit 1
+    fi
+    if [ ! -x "${python_bin}" ]; then
+        echo "Python interpreter not found: ${python_bin}" >&2
+        exit 1
+    fi
+    if [ ! -x /usr/local/cuda/bin/nvcc ]; then
+        echo "CUDA compiler not found at /usr/local/cuda/bin/nvcc" >&2
+        exit 1
+    fi
+
+    mkdir -p "${output_dir}" /tmp/flashinfer-home
+    export HOME=/tmp/flashinfer-home
+    export CONDA_pkgs_dirs="${FLASHINFER_CI_CACHE}/conda-pkgs"
+    export XDG_CACHE_HOME="${FLASHINFER_CI_CACHE}/xdg-cache"
+    export PIP_CACHE_DIR="${FLASHINFER_CI_CACHE}/pip-cache"
+    export LD_LIBRARY_PATH="/usr/local/cuda/lib64:/usr/local/cuda/lib64/stubs:${LD_LIBRARY_PATH:-}"
+    mkdir -p "${CONDA_pkgs_dirs}" "${XDG_CACHE_HOME}" "${PIP_CACHE_DIR}"
+
+    "${python_bin}" -m venv "${build_venv}"
+    python="${build_venv}/bin/python"
+    "${python}" -m pip install --disable-pip-version-check --upgrade build
+
+    # shellcheck source=scripts/jit_cache_build_common.sh
+    source "${SCRIPT_DIR}/jit_cache_build_common.sh"
+    compute_jit_cache_parallelism
+
+    export BUILD_NVEP=0
+    export FLASHINFER_DISABLE_VERSION_CHECK=1
+    export FLASHINFER_CUDA_ARCH_LIST="${FLASHINFER_JIT_CACHE_PROVIDER_ARCH}"
+
+    echo "=========================================="
+    echo "Building provider wheelhouse"
+    echo "=========================================="
+    echo "Version: ${PACKAGE_VERSION}"
+    echo "Provider: ${PROVIDER_TAG} (${FLASHINFER_CUDA_ARCH_LIST})"
+    echo "CUDA: $(/usr/local/cuda/bin/nvcc --version | tail -n 1)"
+    echo "Architecture: $(uname -m)"
+    echo "MAX_JOBS: ${MAX_JOBS}"
+    echo "NVCC_THREADS: ${FLASHINFER_NVCC_THREADS}"
+    echo "Memory budget per job: ${MEM_PER_JOB} GB"
+
+    rm -rf \
+        "${REPO_ROOT}/flashinfer-jit-cache-provider/build" \
+        "${REPO_ROOT}/flashinfer-jit-cache-provider/dist" \
+        "${REPO_ROOT}/flashinfer-jit-cache-provider/flashinfer_jit_cache_provider/jit_cache" \
+        "${REPO_ROOT}/flashinfer-jit-cache/build" \
+        "${REPO_ROOT}/flashinfer-jit-cache/dist" \
+        "${REPO_ROOT}/flashinfer-jit-cache/flashinfer_jit_cache/jit_cache"
+    rm -f \
+        "${REPO_ROOT}/flashinfer-jit-cache-provider/flashinfer_jit_cache_provider/manifest.json" \
+        "${REPO_ROOT}/flashinfer-jit-cache-provider/flashinfer_jit_cache_provider/_build_meta.py" \
+        "${REPO_ROOT}/flashinfer-jit-cache/flashinfer_jit_cache/_build_meta.py" \
+        "${REPO_ROOT}/flashinfer-jit-cache/flashinfer_jit_cache/_provider_requirements.txt"
+    find "${REPO_ROOT}/flashinfer-jit-cache-provider" \
+        "${REPO_ROOT}/flashinfer-jit-cache" \
+        -maxdepth 1 -type d -name '*.egg-info' -exec rm -rf {} +
+
+    echo "Building flashinfer-python..."
+    "${python}" -m build --wheel --outdir "${output_dir}" "${REPO_ROOT}"
+
+    echo "Building ${PROVIDER_TAG} provider..."
+    FLASHINFER_JIT_CACHE_PROVIDER_ARCH="${FLASHINFER_JIT_CACHE_PROVIDER_ARCH}" \
+        "${python}" -m build --wheel --outdir "${output_dir}" \
+        "${REPO_ROOT}/flashinfer-jit-cache-provider"
+
+    echo "Building one-provider shim..."
+    FLASHINFER_JIT_CACHE_WHEEL_KIND=shim \
+    FLASHINFER_JIT_CACHE_PROVIDER_ARCHS="${FLASHINFER_JIT_CACHE_PROVIDER_ARCH}" \
+        "${python}" -m build --wheel --outdir "${output_dir}" \
+        "${REPO_ROOT}/flashinfer-jit-cache"
+
+    echo "Validating wheelhouse..."
+    "${python}" "${SCRIPT_DIR}/verify_jit_cache_provider_wheelhouse.py" \
+        --wheelhouse "${output_dir}" \
+        --provider "${PROVIDER_TAG}" \
+        --version "${PACKAGE_VERSION}" \
+        --cuobjdump /usr/local/cuda/bin/cuobjdump \
+        --install-smoke
+
+    echo "Built wheelhouse: ${output_dir}"
+    ls -lh "${output_dir}"
+}
+
+case "${1:-}" in
+    --inside-container)
+        run_in_container
+        ;;
+    "")
+        run_on_host
+        ;;
+    *)
+        echo "Usage: $0 [--inside-container]" >&2
+        exit 2
+        ;;
+esac

--- a/scripts/build_jit_cache_provider_wheelhouse.sh
+++ b/scripts/build_jit_cache_provider_wheelhouse.sh
@@ -142,6 +142,7 @@ run_in_container() {
     echo "Memory budget per job: ${MEM_PER_JOB} GB"
 
     rm -rf \
+        "${REPO_ROOT}/flashinfer/data" \
         "${REPO_ROOT}/flashinfer-jit-cache-provider/build" \
         "${REPO_ROOT}/flashinfer-jit-cache-provider/dist" \
         "${REPO_ROOT}/flashinfer-jit-cache-provider/flashinfer_jit_cache_provider/jit_cache" \
@@ -149,6 +150,7 @@ run_in_container() {
         "${REPO_ROOT}/flashinfer-jit-cache/dist" \
         "${REPO_ROOT}/flashinfer-jit-cache/flashinfer_jit_cache/jit_cache"
     rm -f \
+        "${REPO_ROOT}/flashinfer/_build_meta.py" \
         "${REPO_ROOT}/flashinfer-jit-cache-provider/flashinfer_jit_cache_provider/manifest.json" \
         "${REPO_ROOT}/flashinfer-jit-cache-provider/flashinfer_jit_cache_provider/_build_meta.py" \
         "${REPO_ROOT}/flashinfer-jit-cache/flashinfer_jit_cache/_build_meta.py" \

--- a/scripts/build_jit_cache_provider_wheelhouse.sh
+++ b/scripts/build_jit_cache_provider_wheelhouse.sh
@@ -31,7 +31,7 @@ normalize_provider_tag() {
 : "${AOT_MAX_JOBS_CAP:=4}"
 : "${AOT_MAX_JOBS_MEMORY_GB:=16}"
 : "${FLASHINFER_NVCC_THREADS:=1}"
-: "${CUDA_ARCHITECTURE_POLICY:=report}"
+: "${CUDA_ARCHITECTURE_POLICY:=strict}"
 : "${CLEAN_OUTPUT:=0}"
 
 PROVIDER_TAG=$(normalize_provider_tag "${FLASHINFER_JIT_CACHE_PROVIDER_ARCH}")

--- a/scripts/build_jit_cache_provider_wheelhouse.sh
+++ b/scripts/build_jit_cache_provider_wheelhouse.sh
@@ -23,6 +23,8 @@ normalize_provider_tag() {
 resolve_cuda_config() {
     local config_values config_version config_pytorch_index config_arch_list
     local configured_cuda_version=${CUDA_VERSION:-}
+    local configured_docker_image=${DOCKER_IMAGE:-}
+    local default_platform_tag="manylinux_2_28_${ARCH}"
 
     config_values=$(python3 - \
         "${REPO_ROOT}/ci/cuda-versions.json" \
@@ -65,7 +67,7 @@ PY
     export PYTORCH_INDEX="${config_pytorch_index}"
     export FLASHINFER_JIT_CACHE_MONOLITHIC_ARCHS="${config_arch_list}"
 
-    if [ -z "${DOCKER_IMAGE:-}" ]; then
+    if [ -z "${configured_docker_image}" ]; then
         case "${ARCH}" in
             aarch64)
                 DOCKER_IMAGE="pytorch/manylinuxaarch64-builder:cuda${CUDA_VERSION}"
@@ -78,7 +80,9 @@ PY
                 exit 2
                 ;;
         esac
+        : "${FLASHINFER_JIT_CACHE_PROVIDER_PLATFORM_TAG:=${default_platform_tag}}"
         export DOCKER_IMAGE
+        export FLASHINFER_JIT_CACHE_PROVIDER_PLATFORM_TAG
     fi
 }
 
@@ -105,7 +109,38 @@ print_config() {
     echo "pytorch_index=${PYTORCH_INDEX}"
     echo "cpu_arch=${ARCH}"
     echo "container=${DOCKER_IMAGE}"
+    echo "provider_platform_tag=${FLASHINFER_JIT_CACHE_PROVIDER_PLATFORM_TAG:-native}"
     echo "monolithic_arch_list=${FLASHINFER_JIT_CACHE_MONOLITHIC_ARCHS}"
+}
+
+validate_provider_platform_tag() {
+    local platform_tag=${FLASHINFER_JIT_CACHE_PROVIDER_PLATFORM_TAG:-}
+    local expected_tag="manylinux_2_28_${ARCH}"
+    local libc_name libc_version libc_major libc_minor
+
+    if [ -z "${platform_tag}" ]; then
+        return
+    fi
+    if [ "${platform_tag}" != "${expected_tag}" ]; then
+        echo "Provider platform tag ${platform_tag} does not match ${expected_tag}" >&2
+        exit 2
+    fi
+    if ! read -r libc_name libc_version < <(getconf GNU_LIBC_VERSION 2>/dev/null); then
+        echo "${platform_tag} requires a glibc build environment" >&2
+        exit 2
+    fi
+    if [ "${libc_name}" != "glibc" ] || \
+       ! [[ "${libc_version}" =~ ^([0-9]+)\.([0-9]+)$ ]]; then
+        echo "Could not verify glibc compatibility for ${platform_tag}: ${libc_name} ${libc_version}" >&2
+        exit 2
+    fi
+    libc_major=${BASH_REMATCH[1]}
+    libc_minor=${BASH_REMATCH[2]}
+    if (( libc_major > 2 || (libc_major == 2 && libc_minor > 28) )); then
+        echo "glibc ${libc_version} is too new to claim ${platform_tag}" >&2
+        exit 2
+    fi
+    echo "Verified ${platform_tag} builder with glibc ${libc_version}"
 }
 
 run_on_host() {
@@ -156,10 +191,12 @@ run_on_host() {
         -e CUDA_MINOR="${CUDA_MINOR}" \
         -e CUDA_VERSION="${CUDA_VERSION}" \
         -e CUDA_ARCHITECTURE_POLICY="${CUDA_ARCHITECTURE_POLICY}" \
+        -e DOCKER_IMAGE="${DOCKER_IMAGE}" \
         -e FLASHINFER_DEV_RELEASE_SUFFIX="${FLASHINFER_DEV_RELEASE_SUFFIX}" \
         -e FLASHINFER_JIT_CACHE_PROVIDER_ARCH="${FLASHINFER_JIT_CACHE_PROVIDER_ARCH}" \
         -e FLASHINFER_LOCAL_VERSION="${FLASHINFER_LOCAL_VERSION}" \
         -e FLASHINFER_JIT_CACHE_MONOLITHIC_ARCHS="${FLASHINFER_JIT_CACHE_MONOLITHIC_ARCHS}" \
+        -e FLASHINFER_JIT_CACHE_PROVIDER_PLATFORM_TAG="${FLASHINFER_JIT_CACHE_PROVIDER_PLATFORM_TAG:-}" \
         -e FLASHINFER_NVCC_THREADS="${FLASHINFER_NVCC_THREADS}" \
         -e HOST_GID="${host_gid}" \
         -e HOST_UID="${host_uid}" \
@@ -204,8 +241,15 @@ run_in_container() {
 
     # shellcheck source=scripts/jit_cache_build_common.sh
     source "${SCRIPT_DIR}/jit_cache_build_common.sh"
+    finish_provider_build() {
+        local exit_code=$?
+        cleanup_jit_cache_python_build || true
+        return "${exit_code}"
+    }
+    trap finish_provider_build EXIT
     compute_jit_cache_parallelism
     validate_jit_cache_cuda_toolchain "${CUDA_VERSION}" /usr/local/cuda/bin/nvcc
+    validate_provider_platform_tag
 
     echo "::group::Install build system"
     setup_jit_cache_python_build "${python}" "${CUDA_VERSION}" "${PYTORCH_INDEX}"
@@ -265,6 +309,7 @@ run_in_container() {
         --wheelhouse "${output_dir}" \
         --provider "${PROVIDER_TAG}" \
         --version "${PACKAGE_VERSION}" \
+        --provider-platform-tag "${FLASHINFER_JIT_CACHE_PROVIDER_PLATFORM_TAG:-}" \
         --cuobjdump /usr/local/cuda/bin/cuobjdump \
         --cuda-architecture-policy "${CUDA_ARCHITECTURE_POLICY}" \
         --install-smoke

--- a/scripts/build_jit_cache_provider_wheelhouse.sh
+++ b/scripts/build_jit_cache_provider_wheelhouse.sh
@@ -20,23 +20,93 @@ normalize_provider_tag() {
     printf 'sm%s\n' "${architecture}"
 }
 
+resolve_cuda_config() {
+    local config_values config_version config_pytorch_index config_arch_list
+    local configured_cuda_version=${CUDA_VERSION:-}
+
+    config_values=$(python3 - \
+        "${REPO_ROOT}/ci/cuda-versions.json" \
+        "${FLASHINFER_LOCAL_VERSION}" \
+        "${ARCH}" <<'PY'
+import json
+import sys
+
+config_path, label, machine = sys.argv[1:]
+with open(config_path) as config_file:
+    entries = json.load(config_file)["jit_cache"]
+
+try:
+    entry = next(item for item in entries if item["label"] == label)
+except StopIteration:
+    labels = ", ".join(item["label"] for item in entries)
+    raise SystemExit(f"Unknown JIT-cache CUDA label {label!r}; expected one of: {labels}")
+
+arch_field = f"{machine}_arch_list"
+try:
+    arch_list = entry[arch_field]
+except KeyError:
+    raise SystemExit(f"Unsupported provider CPU architecture {machine!r}") from None
+
+print(entry["version"], entry["pytorch_index"], arch_list, sep="\t")
+PY
+    )
+    IFS=$'\t' read -r config_version config_pytorch_index config_arch_list \
+        <<< "${config_values}"
+
+    if [ -n "${configured_cuda_version}" ] && \
+       [ "${configured_cuda_version}" != "${config_version}" ]; then
+        echo "CUDA_VERSION=${configured_cuda_version} conflicts with ${FLASHINFER_LOCAL_VERSION} (${config_version})" >&2
+        exit 2
+    fi
+
+    export CUDA_VERSION="${config_version}"
+    export CUDA_MAJOR="${config_version%%.*}"
+    export CUDA_MINOR="${config_version#*.}"
+    export PYTORCH_INDEX="${config_pytorch_index}"
+    export FLASHINFER_JIT_CACHE_MONOLITHIC_ARCHS="${config_arch_list}"
+
+    if [ -z "${DOCKER_IMAGE:-}" ]; then
+        case "${ARCH}" in
+            aarch64)
+                DOCKER_IMAGE="pytorch/manylinuxaarch64-builder:cuda${CUDA_VERSION}"
+                ;;
+            x86_64)
+                DOCKER_IMAGE="pytorch/manylinux2_28-builder:cuda${CUDA_VERSION}"
+                ;;
+            *)
+                echo "Unsupported provider CPU architecture: ${ARCH}" >&2
+                exit 2
+                ;;
+        esac
+        export DOCKER_IMAGE
+    fi
+}
+
 : "${FLASHINFER_JIT_CACHE_PROVIDER_ARCH:=12.1a}"
 : "${FLASHINFER_LOCAL_VERSION:=cu130}"
 : "${FLASHINFER_DEV_RELEASE_SUFFIX:=$(date -u +%Y%m%d)}"
-: "${CUDA_VERSION:=13.0}"
-: "${CUDA_MAJOR:=13}"
-: "${CUDA_MINOR:=0}"
 : "${ARCH:=aarch64}"
-: "${DOCKER_IMAGE:=pytorch/manylinuxaarch64-builder:cuda13.0}"
 : "${AOT_MAX_JOBS_CAP:=4}"
 : "${AOT_MAX_JOBS_MEMORY_GB:=16}"
 : "${FLASHINFER_NVCC_THREADS:=1}"
 : "${CUDA_ARCHITECTURE_POLICY:=strict}"
 : "${CLEAN_OUTPUT:=0}"
 
+resolve_cuda_config
+
 PROVIDER_TAG=$(normalize_provider_tag "${FLASHINFER_JIT_CACHE_PROVIDER_ARCH}")
 PACKAGE_VERSION=$(tr -d '[:space:]' < "${REPO_ROOT}/version.txt")
 PACKAGE_VERSION="${PACKAGE_VERSION}.dev${FLASHINFER_DEV_RELEASE_SUFFIX}+${FLASHINFER_LOCAL_VERSION}"
+
+print_config() {
+    echo "provider=${PROVIDER_TAG}"
+    echo "cuda_label=${FLASHINFER_LOCAL_VERSION}"
+    echo "cuda_version=${CUDA_VERSION}"
+    echo "pytorch_index=${PYTORCH_INDEX}"
+    echo "cpu_arch=${ARCH}"
+    echo "container=${DOCKER_IMAGE}"
+    echo "monolithic_arch_list=${FLASHINFER_JIT_CACHE_MONOLITHIC_ARCHS}"
+}
 
 run_on_host() {
     local output_dir cache_dir host_uid host_gid
@@ -89,11 +159,13 @@ run_on_host() {
         -e FLASHINFER_DEV_RELEASE_SUFFIX="${FLASHINFER_DEV_RELEASE_SUFFIX}" \
         -e FLASHINFER_JIT_CACHE_PROVIDER_ARCH="${FLASHINFER_JIT_CACHE_PROVIDER_ARCH}" \
         -e FLASHINFER_LOCAL_VERSION="${FLASHINFER_LOCAL_VERSION}" \
+        -e FLASHINFER_JIT_CACHE_MONOLITHIC_ARCHS="${FLASHINFER_JIT_CACHE_MONOLITHIC_ARCHS}" \
         -e FLASHINFER_NVCC_THREADS="${FLASHINFER_NVCC_THREADS}" \
         -e HOST_GID="${host_gid}" \
         -e HOST_UID="${host_uid}" \
         -e OUTPUT_DIR=/wheelhouse \
         -e PYTHON_BIN="${PYTHON_BIN:-/opt/python/cp312-cp312/bin/python}" \
+        -e PYTORCH_INDEX="${PYTORCH_INDEX}" \
         -e FLASHINFER_CI_CACHE=/ci-cache \
         -w /workspace \
         "${DOCKER_IMAGE}" \
@@ -129,11 +201,15 @@ run_in_container() {
 
     "${python_bin}" -m venv "${build_venv}"
     python="${build_venv}/bin/python"
-    "${python}" -m pip install --disable-pip-version-check --upgrade build
 
     # shellcheck source=scripts/jit_cache_build_common.sh
     source "${SCRIPT_DIR}/jit_cache_build_common.sh"
     compute_jit_cache_parallelism
+    validate_jit_cache_cuda_toolchain "${CUDA_VERSION}" /usr/local/cuda/bin/nvcc
+
+    echo "::group::Install build system"
+    setup_jit_cache_python_build "${python}" "${CUDA_VERSION}" "${PYTORCH_INDEX}"
+    echo "::endgroup::"
 
     export BUILD_NVEP=0
     export FLASHINFER_DISABLE_VERSION_CHECK=1
@@ -145,7 +221,9 @@ run_in_container() {
     echo "Version: ${PACKAGE_VERSION}"
     echo "Provider: ${PROVIDER_TAG} (${FLASHINFER_CUDA_ARCH_LIST})"
     echo "CUDA: $(/usr/local/cuda/bin/nvcc --version | tail -n 1)"
+    echo "PyTorch index: ${PYTORCH_INDEX}"
     echo "Architecture: $(uname -m)"
+    echo "Monolithic matrix targets: ${FLASHINFER_JIT_CACHE_MONOLITHIC_ARCHS}"
     echo "MAX_JOBS: ${MAX_JOBS}"
     echo "NVCC_THREADS: ${FLASHINFER_NVCC_THREADS}"
     echo "Memory budget per job: ${MEM_PER_JOB} GB"
@@ -202,8 +280,11 @@ case "${1:-}" in
     "")
         run_on_host
         ;;
+    --print-config)
+        print_config
+        ;;
     *)
-        echo "Usage: $0 [--inside-container]" >&2
+        echo "Usage: $0 [--inside-container|--print-config]" >&2
         exit 2
         ;;
 esac

--- a/scripts/jit_cache_build_common.sh
+++ b/scripts/jit_cache_build_common.sh
@@ -2,6 +2,7 @@
 # Shared helpers for building flashinfer-jit-cache wheels.
 # Sourced by:
 #   - scripts/build_flashinfer_jit_cache_whl.sh         (release/nightly)
+#   - scripts/build_jit_cache_provider_wheelhouse.sh    (provider experiment)
 #   - scripts/task_test_jit_cache_package_build_import.sh (PR tests)
 
 SCCACHE_VERSION="0.17.0"
@@ -76,6 +77,93 @@ compute_jit_cache_parallelism() {
   export MAX_JOBS=$max_jobs
   export FLASHINFER_NVCC_THREADS=$nvcc_threads
   export MEM_PER_JOB=$mem_per_job
+}
+
+# Verify that the selected compiler matches the CUDA matrix entry.
+#
+# Args:
+#   $1 - Expected CUDA major.minor version (e.g. "13.4").
+#   $2 - Optional nvcc executable (default: nvcc from PATH).
+validate_jit_cache_cuda_toolchain() {
+  local expected_cuda_version=$1
+  local nvcc_bin=${2:-nvcc}
+  local nvcc_cuda_version
+
+  nvcc_cuda_version=$(
+    "${nvcc_bin}" --version |
+      sed -n 's/.*release \([0-9][0-9]*\.[0-9][0-9]*\).*/\1/p' |
+      head -n1
+  )
+  if [ "${nvcc_cuda_version}" != "${expected_cuda_version}" ]; then
+    echo "ERROR: nvcc reports CUDA ${nvcc_cuda_version:-unknown}; expected ${expected_cuda_version}" >&2
+    return 1
+  fi
+  echo "nvcc CUDA version check passed: ${nvcc_cuda_version}"
+}
+
+# Install the matrix-selected PyTorch build environment and constrain the
+# isolated PEP 517 build to that exact distribution.
+#
+# Args:
+#   $1 - Python executable used to invoke the build frontend.
+#   $2 - Expected CUDA major.minor version.
+#   $3 - PyTorch index label (e.g. "cu130" or "nightly/cu134").
+#
+# Exports: PIP_CONSTRAINT, PIP_EXTRA_INDEX_URL, and PIP_PRE for nightly indexes.
+setup_jit_cache_python_build() {
+  local python_bin=$1
+  local expected_cuda_version=$2
+  local pytorch_index=$3
+  local pytorch_index_url="https://download.pytorch.org/whl/${pytorch_index}"
+
+  "${python_bin}" -m pip install --upgrade build
+
+  if "${python_bin}" - "${expected_cuda_version}" <<'PY'
+import sys
+
+try:
+    import torch
+except ImportError:
+    raise SystemExit(1)
+
+raise SystemExit(0 if torch.version.cuda == sys.argv[1] else 1)
+PY
+  then
+    echo "Using preinstalled PyTorch for CUDA ${expected_cuda_version}"
+  else
+    local -a torch_install_args=(
+      --upgrade torch --index-url "${pytorch_index_url}"
+    )
+    if [[ "${pytorch_index}" == nightly/* ]]; then
+      torch_install_args=(--pre "${torch_install_args[@]}")
+    fi
+    "${python_bin}" -m pip install "${torch_install_args[@]}"
+  fi
+
+  "${python_bin}" - "${expected_cuda_version}" <<'PY'
+import importlib.metadata
+import sys
+import torch
+
+expected = sys.argv[1]
+if torch.version.cuda != expected:
+    raise SystemExit(
+        f"ERROR: PyTorch targets CUDA {torch.version.cuda}; expected CUDA {expected}"
+    )
+print(f"PyTorch CUDA version check passed: {torch.__version__} ({torch.version.cuda})")
+print(f"PyTorch distribution version: {importlib.metadata.version('torch')}")
+PY
+
+  local torch_constraint
+  torch_constraint=$(mktemp)
+  "${python_bin}" -c \
+    'import importlib.metadata as m; print("torch==" + m.version("torch"))' \
+    > "${torch_constraint}"
+  export PIP_CONSTRAINT="${torch_constraint}"
+  export PIP_EXTRA_INDEX_URL="${pytorch_index_url}"
+  if [[ "${pytorch_index}" == nightly/* ]]; then
+    export PIP_PRE=1
+  fi
 }
 
 # Download and install a released sccache binary to /usr/local/bin/sccache,

--- a/scripts/jit_cache_build_common.sh
+++ b/scripts/jit_cache_build_common.sh
@@ -110,6 +110,7 @@ validate_jit_cache_cuda_toolchain() {
 #   $3 - PyTorch index label (e.g. "cu130" or "nightly/cu134").
 #
 # Exports: PIP_CONSTRAINT, PIP_EXTRA_INDEX_URL, and PIP_PRE for nightly indexes.
+# Call cleanup_jit_cache_python_build from the caller's existing EXIT handler.
 setup_jit_cache_python_build() {
   local python_bin=$1
   local expected_cuda_version=$2
@@ -154,16 +155,42 @@ print(f"PyTorch CUDA version check passed: {torch.__version__} ({torch.version.c
 print(f"PyTorch distribution version: {importlib.metadata.version('torch')}")
 PY
 
-  local torch_constraint
-  torch_constraint=$(mktemp)
+  if [[ -v PIP_CONSTRAINT ]]; then
+    JIT_CACHE_PREVIOUS_PIP_CONSTRAINT=${PIP_CONSTRAINT}
+    JIT_CACHE_RESTORE_PIP_CONSTRAINT=1
+  else
+    JIT_CACHE_PREVIOUS_PIP_CONSTRAINT=
+    JIT_CACHE_RESTORE_PIP_CONSTRAINT=0
+  fi
+
+  JIT_CACHE_TORCH_CONSTRAINT=$(mktemp)
   "${python_bin}" -c \
     'import importlib.metadata as m; print("torch==" + m.version("torch"))' \
-    > "${torch_constraint}"
-  export PIP_CONSTRAINT="${torch_constraint}"
-  export PIP_EXTRA_INDEX_URL="${pytorch_index_url}"
+    > "${JIT_CACHE_TORCH_CONSTRAINT}"
+  export PIP_CONSTRAINT="${JIT_CACHE_TORCH_CONSTRAINT}"
+  case " ${PIP_EXTRA_INDEX_URL:-} " in
+    *" ${pytorch_index_url} "*) ;;
+    *)
+      export PIP_EXTRA_INDEX_URL="${PIP_EXTRA_INDEX_URL:+${PIP_EXTRA_INDEX_URL} }${pytorch_index_url}"
+      ;;
+  esac
   if [[ "${pytorch_index}" == nightly/* ]]; then
     export PIP_PRE=1
   fi
+}
+
+cleanup_jit_cache_python_build() {
+  if [ -n "${JIT_CACHE_TORCH_CONSTRAINT:-}" ]; then
+    rm -f "${JIT_CACHE_TORCH_CONSTRAINT}"
+  fi
+  if [ "${JIT_CACHE_RESTORE_PIP_CONSTRAINT:-0}" = "1" ]; then
+    export PIP_CONSTRAINT="${JIT_CACHE_PREVIOUS_PIP_CONSTRAINT}"
+  else
+    unset PIP_CONSTRAINT
+  fi
+  unset JIT_CACHE_TORCH_CONSTRAINT
+  unset JIT_CACHE_PREVIOUS_PIP_CONSTRAINT
+  unset JIT_CACHE_RESTORE_PIP_CONSTRAINT
 }
 
 # Download and install a released sccache binary to /usr/local/bin/sccache,

--- a/scripts/jit_cache_build_common.sh
+++ b/scripts/jit_cache_build_common.sh
@@ -109,7 +109,8 @@ validate_jit_cache_cuda_toolchain() {
 #   $2 - Expected CUDA major.minor version.
 #   $3 - PyTorch index label (e.g. "cu130" or "nightly/cu134").
 #
-# Exports: PIP_CONSTRAINT, PIP_EXTRA_INDEX_URL, and PIP_PRE for nightly indexes.
+# Exports: PIP_CONSTRAINT, PIP_BUILD_CONSTRAINT, PIP_EXTRA_INDEX_URL, and
+# PIP_PRE for nightly indexes.
 # Call cleanup_jit_cache_python_build from the caller's existing EXIT handler.
 setup_jit_cache_python_build() {
   local python_bin=$1
@@ -162,12 +163,20 @@ PY
     JIT_CACHE_PREVIOUS_PIP_CONSTRAINT=
     JIT_CACHE_RESTORE_PIP_CONSTRAINT=0
   fi
+  if [[ -v PIP_BUILD_CONSTRAINT ]]; then
+    JIT_CACHE_PREVIOUS_PIP_BUILD_CONSTRAINT=${PIP_BUILD_CONSTRAINT}
+    JIT_CACHE_RESTORE_PIP_BUILD_CONSTRAINT=1
+  else
+    JIT_CACHE_PREVIOUS_PIP_BUILD_CONSTRAINT=
+    JIT_CACHE_RESTORE_PIP_BUILD_CONSTRAINT=0
+  fi
 
   JIT_CACHE_TORCH_CONSTRAINT=$(mktemp)
   "${python_bin}" -c \
     'import importlib.metadata as m; print("torch==" + m.version("torch"))' \
     > "${JIT_CACHE_TORCH_CONSTRAINT}"
   export PIP_CONSTRAINT="${JIT_CACHE_TORCH_CONSTRAINT}"
+  export PIP_BUILD_CONSTRAINT="${JIT_CACHE_TORCH_CONSTRAINT}"
   case " ${PIP_EXTRA_INDEX_URL:-} " in
     *" ${pytorch_index_url} "*) ;;
     *)
@@ -188,9 +197,16 @@ cleanup_jit_cache_python_build() {
   else
     unset PIP_CONSTRAINT
   fi
+  if [ "${JIT_CACHE_RESTORE_PIP_BUILD_CONSTRAINT:-0}" = "1" ]; then
+    export PIP_BUILD_CONSTRAINT="${JIT_CACHE_PREVIOUS_PIP_BUILD_CONSTRAINT}"
+  else
+    unset PIP_BUILD_CONSTRAINT
+  fi
   unset JIT_CACHE_TORCH_CONSTRAINT
   unset JIT_CACHE_PREVIOUS_PIP_CONSTRAINT
   unset JIT_CACHE_RESTORE_PIP_CONSTRAINT
+  unset JIT_CACHE_PREVIOUS_PIP_BUILD_CONSTRAINT
+  unset JIT_CACHE_RESTORE_PIP_BUILD_CONSTRAINT
 }
 
 # Download and install a released sccache binary to /usr/local/bin/sccache,

--- a/scripts/jit_cache_provider_validation.py
+++ b/scripts/jit_cache_provider_validation.py
@@ -1,0 +1,281 @@
+"""Shared validation primitives for FlashInfer JIT-cache provider artifacts."""
+
+from __future__ import annotations
+
+import configparser
+import json
+import re
+import subprocess
+import tempfile
+import zipfile
+from dataclasses import dataclass
+from email.parser import BytesParser
+from pathlib import Path
+from typing import Any
+
+
+def canonicalize_distribution(name: str) -> str:
+    return re.sub(r"[-_.]+", "-", name).lower()
+
+
+@dataclass(frozen=True)
+class Wheel:
+    path: Path
+    distribution: str
+    version: str
+    requirements: tuple[str, ...]
+    contents: tuple[str, ...]
+    metadata_path: str
+
+    @classmethod
+    def open(cls, path: Path) -> "Wheel":
+        with zipfile.ZipFile(path) as archive:
+            contents = tuple(sorted(archive.namelist()))
+            metadata_paths = [
+                name for name in contents if name.endswith(".dist-info/METADATA")
+            ]
+            if len(metadata_paths) != 1:
+                raise ValueError(
+                    f"{path.name}: expected one METADATA file, found "
+                    f"{len(metadata_paths)}"
+                )
+            metadata_path = metadata_paths[0]
+            metadata = BytesParser().parsebytes(archive.read(metadata_path))
+        return cls(
+            path=path,
+            distribution=metadata["Name"],
+            version=metadata["Version"],
+            requirements=tuple(metadata.get_all("Requires-Dist", [])),
+            contents=contents,
+            metadata_path=metadata_path,
+        )
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise ValueError(message)
+
+
+def normalize_requirement(requirement: str) -> tuple[str, str]:
+    match = re.fullmatch(r"\s*([A-Za-z0-9_.-]+)\s*==\s*([^\s;]+)\s*", requirement)
+    if match is None:
+        raise ValueError(f"Expected an exact provider pin, got {requirement!r}")
+    return canonicalize_distribution(match.group(1)), match.group(2)
+
+
+def read_provider_manifest(wheel: Wheel, provider: str) -> tuple[dict[str, Any], str]:
+    package_suffix = f"flashinfer_jit_cache/providers/{provider}/manifest.json"
+    manifest_paths = [
+        path
+        for path in wheel.contents
+        if path == package_suffix or path.endswith(f".data/purelib/{package_suffix}")
+    ]
+    require(
+        len(manifest_paths) == 1,
+        f"{wheel.path.name}: expected one {package_suffix}, found {manifest_paths}",
+    )
+    manifest_path = manifest_paths[0]
+    package_prefix = manifest_path.removesuffix("/manifest.json")
+    with zipfile.ZipFile(wheel.path) as archive:
+        manifest = json.loads(archive.read(manifest_path))
+    return manifest, package_prefix
+
+
+def validate_provider(
+    wheel: Wheel,
+    provider: str,
+    expected_version: str,
+    expected_platform_tag: str | None = None,
+) -> tuple[dict[str, Any], dict[str, str]]:
+    expected_distribution = f"flashinfer-jit-cache-{provider}"
+    require(
+        canonicalize_distribution(wheel.distribution) == expected_distribution,
+        f"Unexpected provider distribution: {wheel.distribution}",
+    )
+    require(
+        wheel.version == expected_version,
+        f"Provider version {wheel.version} does not match {expected_version}",
+    )
+    require(not wheel.requirements, "Provider wheel must not depend on other wheels")
+    if expected_platform_tag:
+        require(
+            wheel.path.name.endswith(f"-{expected_platform_tag}.whl"),
+            f"Provider wheel {wheel.path.name} does not use {expected_platform_tag}",
+        )
+
+    manifest, package_prefix = read_provider_manifest(wheel, provider)
+    require(manifest.get("schema_version") == 1, "Unsupported provider manifest")
+    require(manifest.get("provider_id") == provider, "Provider ID mismatch")
+    require(
+        canonicalize_distribution(str(manifest.get("distribution", "")))
+        == expected_distribution,
+        "Provider manifest distribution mismatch",
+    )
+    require(manifest.get("version") == expected_version, "Manifest version mismatch")
+    require(
+        manifest.get("cuda_architectures") == [provider],
+        "Provider manifest must declare exactly its own architecture",
+    )
+
+    module_paths: dict[str, str] = {}
+    so_prefix = f"{package_prefix}/jit_cache/"
+    for path in wheel.contents:
+        if not path.startswith(so_prefix) or not path.endswith(".so"):
+            continue
+        relative = path.removeprefix(so_prefix)
+        parts = relative.split("/")
+        require(
+            len(parts) == 2 and parts[1] == f"{parts[0]}.so",
+            f"Unexpected provider shared-library path: {path}",
+        )
+        module_paths[parts[0]] = path
+
+    require(module_paths, "Provider wheel contains no shared libraries")
+    manifest_modules = set(manifest.get("modules", []))
+    require(
+        manifest_modules == set(module_paths),
+        "Provider manifest modules do not match packaged shared libraries",
+    )
+
+    entry_points_path = wheel.metadata_path.replace("METADATA", "entry_points.txt")
+    require(
+        entry_points_path in wheel.contents,
+        f"{wheel.path.name}: missing provider entry point",
+    )
+    parser = configparser.ConfigParser(interpolation=None)
+    with zipfile.ZipFile(wheel.path) as archive:
+        parser.read_string(archive.read(entry_points_path).decode())
+    group = "flashinfer.jit_cache.providers"
+    require(parser.has_section(group), f"Missing {group} entry-point group")
+    expected_entry_point = f"flashinfer_jit_cache.providers.{provider}:get_provider"
+    require(
+        parser.get(group, provider, fallback="").strip() == expected_entry_point,
+        f"Provider entry point does not match {expected_entry_point}",
+    )
+    return manifest, module_paths
+
+
+def validate_shim(
+    wheel: Wheel,
+    expected_version: str,
+    expected_providers: set[str],
+    expected_platform_tag: str | None = None,
+) -> None:
+    require(
+        canonicalize_distribution(wheel.distribution) == "flashinfer-jit-cache",
+        f"Unexpected shim distribution: {wheel.distribution}",
+    )
+    require(
+        wheel.version == expected_version,
+        f"Shim version {wheel.version} does not match {expected_version}",
+    )
+    require(
+        not any(path.endswith(".so") for path in wheel.contents),
+        "Shim wheel must not contain shared libraries",
+    )
+    if expected_platform_tag:
+        require(
+            wheel.path.name.endswith(f"-{expected_platform_tag}.whl"),
+            f"Shim wheel {wheel.path.name} does not use {expected_platform_tag}",
+        )
+
+    normalized_requirements = [
+        normalize_requirement(requirement) for requirement in wheel.requirements
+    ]
+    requirements = dict(normalized_requirements)
+    require(
+        len(requirements) == len(normalized_requirements),
+        "Shim contains duplicate provider requirements",
+    )
+    expected_requirements = {
+        f"flashinfer-jit-cache-{provider}": expected_version
+        for provider in expected_providers
+    }
+    require(
+        requirements == expected_requirements,
+        f"Shim requirements {requirements} do not match {expected_requirements}",
+    )
+
+
+def inspect_cuda_architectures(
+    wheel: Wheel,
+    module_paths: dict[str, str],
+    provider: str,
+    cuobjdump: Path,
+    strict: bool,
+) -> tuple[dict[str, list[str]], list[str]]:
+    require(cuobjdump.is_file(), f"cuobjdump not found: {cuobjdump}")
+    result: dict[str, list[str]] = {}
+    ptx_modules: list[str] = []
+    architecture_pattern = re.compile(r"\bsm[_-]?([0-9]{2,3}[af]?)\b", re.IGNORECASE)
+
+    with tempfile.TemporaryDirectory(prefix="flashinfer-cuobjdump-") as temp_dir:
+        temp_root = Path(temp_dir)
+        with zipfile.ZipFile(wheel.path) as archive:
+            for index, (module, archive_path) in enumerate(
+                sorted(module_paths.items())
+            ):
+                extracted_path = temp_root / f"{index}.so"
+                extracted_path.write_bytes(archive.read(archive_path))
+                process = subprocess.run(
+                    [str(cuobjdump), "--list-elf", str(extracted_path)],
+                    check=False,
+                    capture_output=True,
+                    text=True,
+                )
+                if (
+                    process.returncode != 0
+                    and "does not contain device code" in process.stderr
+                ):
+                    result[module] = []
+                    continue
+                require(
+                    process.returncode == 0,
+                    f"cuobjdump failed for {module}: {process.stderr.strip()}",
+                )
+                targets = sorted(
+                    {
+                        f"sm{match.lower()}"
+                        for match in architecture_pattern.findall(process.stdout)
+                    }
+                )
+                result[module] = targets
+                ptx_process = subprocess.run(
+                    [str(cuobjdump), "--list-ptx", str(extracted_path)],
+                    check=False,
+                    capture_output=True,
+                    text=True,
+                )
+                ptx_output = "\n".join(
+                    output.strip()
+                    for output in (ptx_process.stdout, ptx_process.stderr)
+                    if output.strip()
+                )
+                require(
+                    ptx_process.returncode == 0,
+                    f"cuobjdump PTX inspection failed for {module}: {ptx_output}",
+                )
+                if "No PTX file found" not in ptx_output:
+                    ptx_modules.append(module)
+
+    mismatches = {
+        module: targets
+        for module, targets in result.items()
+        if targets and targets != [provider]
+    }
+    if strict and mismatches:
+        examples = ", ".join(
+            f"{module}={targets}"
+            for module, targets in list(sorted(mismatches.items()))[:10]
+        )
+        require(
+            False,
+            f"{len(mismatches)} modules do not contain only {provider}: {examples}",
+        )
+    if strict and ptx_modules:
+        examples = ", ".join(sorted(ptx_modules)[:10])
+        require(
+            False,
+            f"{len(ptx_modules)} native-provider modules contain PTX: {examples}",
+        )
+    return result, sorted(ptx_modules)

--- a/scripts/smoke_test_jit_cache_provider.py
+++ b/scripts/smoke_test_jit_cache_provider.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Run a JIT-disabled GPU smoke test against an installed provider wheel."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--provider", required=True)
+    return parser.parse_args()
+
+
+def provider_capability(provider: str) -> tuple[int, int]:
+    match = re.fullmatch(r"sm(\d{1,2})(\d)[af]?", provider.lower())
+    if match is None:
+        raise ValueError(f"Invalid provider ID: {provider}")
+    return int(match.group(1)), int(match.group(2))
+
+
+def main() -> int:
+    args = parse_args()
+    os.environ.setdefault("FLASHINFER_DISABLE_JIT", "1")
+
+    import torch
+
+    capability = torch.cuda.get_device_capability()
+    expected_capability = provider_capability(args.provider)
+    if capability != expected_capability:
+        raise RuntimeError(
+            f"Visible GPU capability {capability} does not match "
+            f"{args.provider} ({expected_capability})"
+        )
+
+    import flashinfer
+    from flashinfer.jit import env as jit_env
+
+    provider_path = jit_env.get_aot_path("silu_and_mul")
+    expected_path_part = f"providers/{args.provider}/jit_cache"
+    if expected_path_part not in provider_path.as_posix():
+        raise RuntimeError(
+            f"silu_and_mul resolved outside {args.provider}: {provider_path}"
+        )
+
+    input_tensor = torch.randn(4, 512, device="cuda", dtype=torch.float16)
+    output = flashinfer.silu_and_mul(input_tensor)
+    expected = torch.nn.functional.silu(input_tensor[:, :256].float())
+    expected *= input_tensor[:, 256:].float()
+    torch.cuda.synchronize()
+    torch.testing.assert_close(output.float(), expected, rtol=1e-2, atol=1e-2)
+
+    print(
+        json.dumps(
+            {
+                "device": torch.cuda.get_device_name(),
+                "capability": capability,
+                "provider_path": str(provider_path),
+                "output_shape": list(output.shape),
+                "max_abs_error": float((output.float() - expected).abs().max()),
+            },
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/verify_jit_cache_provider_wheelhouse.py
+++ b/scripts/verify_jit_cache_provider_wheelhouse.py
@@ -206,9 +206,10 @@ def inspect_cuda_architectures(
     provider: str,
     cuobjdump: Path,
     strict: bool,
-) -> dict[str, list[str]]:
+) -> tuple[dict[str, list[str]], list[str]]:
     require(cuobjdump.is_file(), f"cuobjdump not found: {cuobjdump}")
     result: dict[str, list[str]] = {}
+    ptx_modules: list[str] = []
     architecture_pattern = re.compile(r"\bsm[_-]?([0-9]{2,3}[af]?)\b", re.IGNORECASE)
 
     with tempfile.TemporaryDirectory(prefix="flashinfer-cuobjdump-") as temp_dir:
@@ -239,6 +240,23 @@ def inspect_cuda_architectures(
                     }
                 )
                 result[module] = targets
+                ptx_process = subprocess.run(
+                    [str(cuobjdump), "--list-ptx", str(extracted_path)],
+                    check=False,
+                    capture_output=True,
+                    text=True,
+                )
+                ptx_output = "\n".join(
+                    output.strip()
+                    for output in (ptx_process.stdout, ptx_process.stderr)
+                    if output.strip()
+                )
+                require(
+                    ptx_process.returncode == 0,
+                    f"cuobjdump PTX inspection failed for {module}: {ptx_output}",
+                )
+                if "No PTX file found" not in ptx_output:
+                    ptx_modules.append(module)
 
     mismatches = {
         module: targets
@@ -254,7 +272,13 @@ def inspect_cuda_architectures(
             False,
             f"{len(mismatches)} modules do not contain only {provider}: {examples}",
         )
-    return result
+    if strict and ptx_modules:
+        examples = ", ".join(sorted(ptx_modules)[:10])
+        require(
+            False,
+            f"{len(ptx_modules)} native-provider modules contain PTX: {examples}",
+        )
+    return result, sorted(ptx_modules)
 
 
 def run_install_smoke(shim: Wheel, provider: Wheel, provider_id: str) -> None:
@@ -312,6 +336,7 @@ def write_report(
     provider: str,
     manifest: dict[str, Any],
     module_architectures: dict[str, list[str]],
+    ptx_modules: list[str],
 ) -> None:
     architecture_summary = {
         "provider_only": sum(
@@ -337,6 +362,8 @@ def write_report(
         "modules": sorted(manifest["modules"]),
         "module_cuda_architectures": module_architectures,
         "module_cuda_architecture_summary": architecture_summary,
+        "ptx_module_count": len(ptx_modules),
+        "ptx_modules": ptx_modules,
         "wheels": {
             distribution: {
                 "filename": wheel.path.name,
@@ -400,8 +427,9 @@ def main() -> int:
     validate_shim(shim, args.provider, args.version)
 
     module_architectures: dict[str, list[str]] = {}
+    ptx_modules: list[str] = []
     if args.cuobjdump is not None:
-        module_architectures = inspect_cuda_architectures(
+        module_architectures, ptx_modules = inspect_cuda_architectures(
             provider_wheel,
             module_paths,
             args.provider,
@@ -417,10 +445,11 @@ def main() -> int:
         args.provider,
         manifest,
         module_architectures,
+        ptx_modules,
     )
     print(
         f"Validated {args.provider}: {len(module_paths)} modules, "
-        f"{len(wheel_paths)} wheels"
+        f"{len(ptx_modules)} PTX modules, {len(wheel_paths)} wheels"
     )
     return 0
 

--- a/scripts/verify_jit_cache_provider_wheelhouse.py
+++ b/scripts/verify_jit_cache_provider_wheelhouse.py
@@ -222,6 +222,12 @@ def inspect_cuda_architectures(
                     capture_output=True,
                     text=True,
                 )
+                if (
+                    process.returncode != 0
+                    and "does not contain device code" in process.stderr
+                ):
+                    result[module] = []
+                    continue
                 require(
                     process.returncode == 0,
                     f"cuobjdump failed for {module}: {process.stderr.strip()}",

--- a/scripts/verify_jit_cache_provider_wheelhouse.py
+++ b/scripts/verify_jit_cache_provider_wheelhouse.py
@@ -78,12 +78,18 @@ def normalize_requirement(requirement: str) -> tuple[str, str]:
 
 
 def read_provider_manifest(wheel: Wheel, provider: str) -> tuple[dict[str, Any], str]:
-    package_prefix = f"flashinfer_jit_cache/providers/{provider}"
-    manifest_path = f"{package_prefix}/manifest.json"
+    package_suffix = f"flashinfer_jit_cache/providers/{provider}/manifest.json"
+    manifest_paths = [
+        path
+        for path in wheel.contents
+        if path == package_suffix or path.endswith(f".data/purelib/{package_suffix}")
+    ]
     require(
-        manifest_path in wheel.contents,
-        f"{wheel.path.name}: missing {manifest_path}",
+        len(manifest_paths) == 1,
+        f"{wheel.path.name}: expected one {package_suffix}, found {manifest_paths}",
     )
+    manifest_path = manifest_paths[0]
+    package_prefix = manifest_path.removesuffix("/manifest.json")
     with zipfile.ZipFile(wheel.path) as archive:
         manifest = json.loads(archive.read(manifest_path))
     return manifest, package_prefix

--- a/scripts/verify_jit_cache_provider_wheelhouse.py
+++ b/scripts/verify_jit_cache_provider_wheelhouse.py
@@ -205,6 +205,7 @@ def inspect_cuda_architectures(
     module_paths: dict[str, str],
     provider: str,
     cuobjdump: Path,
+    strict: bool,
 ) -> dict[str, list[str]]:
     require(cuobjdump.is_file(), f"cuobjdump not found: {cuobjdump}")
     result: dict[str, list[str]] = {}
@@ -231,12 +232,20 @@ def inspect_cuda_architectures(
                         for match in architecture_pattern.findall(process.stdout)
                     }
                 )
-                require(targets, f"cuobjdump found no cubin targets in {module}")
-                require(
-                    targets == [provider],
-                    f"{module} contains {targets}; expected only {provider}",
-                )
                 result[module] = targets
+
+    mismatches = {
+        module: targets for module, targets in result.items() if targets != [provider]
+    }
+    if strict and mismatches:
+        examples = ", ".join(
+            f"{module}={targets}"
+            for module, targets in list(sorted(mismatches.items()))[:10]
+        )
+        require(
+            False,
+            f"{len(mismatches)} modules do not contain only {provider}: {examples}",
+        )
     return result
 
 
@@ -296,6 +305,20 @@ def write_report(
     manifest: dict[str, Any],
     module_architectures: dict[str, list[str]],
 ) -> None:
+    architecture_summary = {
+        "provider_only": sum(
+            targets == [provider] for targets in module_architectures.values()
+        ),
+        "mixed": sum(
+            provider in targets and targets != [provider]
+            for targets in module_architectures.values()
+        ),
+        "foreign_only": sum(
+            bool(targets) and provider not in targets
+            for targets in module_architectures.values()
+        ),
+        "no_cubin": sum(not targets for targets in module_architectures.values()),
+    }
     report = {
         "schema_version": 1,
         "generated_at": datetime.now(timezone.utc).isoformat(),
@@ -305,6 +328,7 @@ def write_report(
         "module_count": len(manifest["modules"]),
         "modules": sorted(manifest["modules"]),
         "module_cuda_architectures": module_architectures,
+        "module_cuda_architecture_summary": architecture_summary,
         "wheels": {
             distribution: {
                 "filename": wheel.path.name,
@@ -330,6 +354,12 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--provider", required=True)
     parser.add_argument("--version", required=True)
     parser.add_argument("--cuobjdump", type=Path)
+    parser.add_argument(
+        "--cuda-architecture-policy",
+        choices=("strict", "report"),
+        default="strict",
+        help="Fail on non-provider cubins, or retain them in the inventory report",
+    )
     parser.add_argument("--install-smoke", action="store_true")
     return parser.parse_args()
 
@@ -368,6 +398,7 @@ def main() -> int:
             module_paths,
             args.provider,
             args.cuobjdump,
+            strict=args.cuda_architecture_policy == "strict",
         )
     if args.install_smoke:
         run_install_smoke(shim, provider_wheel, args.provider)

--- a/scripts/verify_jit_cache_provider_wheelhouse.py
+++ b/scripts/verify_jit_cache_provider_wheelhouse.py
@@ -241,7 +241,9 @@ def inspect_cuda_architectures(
                 result[module] = targets
 
     mismatches = {
-        module: targets for module, targets in result.items() if targets != [provider]
+        module: targets
+        for module, targets in result.items()
+        if targets and targets != [provider]
     }
     if strict and mismatches:
         examples = ", ".join(

--- a/scripts/verify_jit_cache_provider_wheelhouse.py
+++ b/scripts/verify_jit_cache_provider_wheelhouse.py
@@ -1,0 +1,388 @@
+#!/usr/bin/env python3
+"""Validate a local FlashInfer jit-cache provider wheelhouse."""
+
+from __future__ import annotations
+
+import argparse
+import configparser
+import hashlib
+import json
+import os
+import re
+import subprocess
+import sys
+import tempfile
+import zipfile
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from email.parser import BytesParser
+from pathlib import Path
+from typing import Any
+
+
+def canonicalize_distribution(name: str) -> str:
+    return re.sub(r"[-_.]+", "-", name).lower()
+
+
+def sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as file:
+        for chunk in iter(lambda: file.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+@dataclass(frozen=True)
+class Wheel:
+    path: Path
+    distribution: str
+    version: str
+    requirements: tuple[str, ...]
+    contents: tuple[str, ...]
+    metadata_path: str
+
+    @classmethod
+    def open(cls, path: Path) -> "Wheel":
+        with zipfile.ZipFile(path) as archive:
+            contents = tuple(sorted(archive.namelist()))
+            metadata_paths = [
+                name for name in contents if name.endswith(".dist-info/METADATA")
+            ]
+            if len(metadata_paths) != 1:
+                raise ValueError(
+                    f"{path.name}: expected one METADATA file, found "
+                    f"{len(metadata_paths)}"
+                )
+            metadata_path = metadata_paths[0]
+            metadata = BytesParser().parsebytes(archive.read(metadata_path))
+        return cls(
+            path=path,
+            distribution=metadata["Name"],
+            version=metadata["Version"],
+            requirements=tuple(metadata.get_all("Requires-Dist", [])),
+            contents=contents,
+            metadata_path=metadata_path,
+        )
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise ValueError(message)
+
+
+def normalize_requirement(requirement: str) -> tuple[str, str]:
+    match = re.fullmatch(r"\s*([A-Za-z0-9_.-]+)\s*==\s*([^\s;]+)\s*", requirement)
+    if match is None:
+        raise ValueError(f"Expected an exact provider pin, got {requirement!r}")
+    return canonicalize_distribution(match.group(1)), match.group(2)
+
+
+def read_provider_manifest(wheel: Wheel, provider: str) -> tuple[dict[str, Any], str]:
+    package_prefix = f"flashinfer_jit_cache/providers/{provider}"
+    manifest_path = f"{package_prefix}/manifest.json"
+    require(
+        manifest_path in wheel.contents,
+        f"{wheel.path.name}: missing {manifest_path}",
+    )
+    with zipfile.ZipFile(wheel.path) as archive:
+        manifest = json.loads(archive.read(manifest_path))
+    return manifest, package_prefix
+
+
+def validate_provider(
+    wheel: Wheel, provider: str, expected_version: str
+) -> tuple[dict[str, Any], dict[str, str]]:
+    expected_distribution = f"flashinfer-jit-cache-{provider}"
+    require(
+        canonicalize_distribution(wheel.distribution) == expected_distribution,
+        f"Unexpected provider distribution: {wheel.distribution}",
+    )
+    require(
+        wheel.version == expected_version,
+        f"Provider version {wheel.version} does not match {expected_version}",
+    )
+    require(not wheel.requirements, "Provider wheel must not depend on other wheels")
+
+    manifest, package_prefix = read_provider_manifest(wheel, provider)
+    require(manifest.get("schema_version") == 1, "Unsupported provider manifest")
+    require(manifest.get("provider_id") == provider, "Provider ID mismatch")
+    require(
+        canonicalize_distribution(str(manifest.get("distribution", "")))
+        == expected_distribution,
+        "Provider manifest distribution mismatch",
+    )
+    require(manifest.get("version") == expected_version, "Manifest version mismatch")
+    require(
+        manifest.get("cuda_architectures") == [provider],
+        "Provider manifest must declare exactly its own architecture",
+    )
+
+    module_paths: dict[str, str] = {}
+    so_prefix = f"{package_prefix}/jit_cache/"
+    for path in wheel.contents:
+        if not path.startswith(so_prefix) or not path.endswith(".so"):
+            continue
+        relative = path.removeprefix(so_prefix)
+        parts = relative.split("/")
+        require(
+            len(parts) == 2 and parts[1] == f"{parts[0]}.so",
+            f"Unexpected provider shared-library path: {path}",
+        )
+        module_paths[parts[0]] = path
+
+    require(module_paths, "Provider wheel contains no shared libraries")
+    manifest_modules = set(manifest.get("modules", []))
+    require(
+        manifest_modules == set(module_paths),
+        "Provider manifest modules do not match packaged shared libraries",
+    )
+
+    entry_points_path = wheel.metadata_path.replace("METADATA", "entry_points.txt")
+    require(
+        entry_points_path in wheel.contents,
+        f"{wheel.path.name}: missing provider entry point",
+    )
+    parser = configparser.ConfigParser()
+    with zipfile.ZipFile(wheel.path) as archive:
+        parser.read_string(archive.read(entry_points_path).decode())
+    group = "flashinfer.jit_cache.providers"
+    require(parser.has_section(group), f"Missing {group} entry-point group")
+    expected_entry_point = f"flashinfer_jit_cache.providers.{provider}:get_provider"
+    require(
+        parser.get(group, provider, fallback="").strip() == expected_entry_point,
+        f"Provider entry point does not match {expected_entry_point}",
+    )
+    return manifest, module_paths
+
+
+def validate_shim(wheel: Wheel, provider: str, expected_version: str) -> None:
+    require(
+        canonicalize_distribution(wheel.distribution) == "flashinfer-jit-cache",
+        f"Unexpected shim distribution: {wheel.distribution}",
+    )
+    require(
+        wheel.version == expected_version,
+        f"Shim version {wheel.version} does not match {expected_version}",
+    )
+    require(
+        not any(path.endswith(".so") for path in wheel.contents),
+        "Shim wheel must not contain shared libraries",
+    )
+    require(
+        len(wheel.requirements) == 1,
+        f"Shim must have one provider requirement, found {wheel.requirements}",
+    )
+    requirement_name, requirement_version = normalize_requirement(wheel.requirements[0])
+    require(
+        requirement_name == f"flashinfer-jit-cache-{provider}",
+        f"Shim requires unexpected provider {requirement_name}",
+    )
+    require(
+        requirement_version == expected_version,
+        f"Shim provider pin {requirement_version} does not match {expected_version}",
+    )
+
+
+def validate_flashinfer_python(wheel: Wheel, expected_version: str) -> None:
+    require(
+        canonicalize_distribution(wheel.distribution) == "flashinfer-python",
+        f"Unexpected FlashInfer distribution: {wheel.distribution}",
+    )
+    require(
+        wheel.version == expected_version,
+        f"FlashInfer version {wheel.version} does not match {expected_version}",
+    )
+
+
+def inspect_cuda_architectures(
+    wheel: Wheel,
+    module_paths: dict[str, str],
+    provider: str,
+    cuobjdump: Path,
+) -> dict[str, list[str]]:
+    require(cuobjdump.is_file(), f"cuobjdump not found: {cuobjdump}")
+    result: dict[str, list[str]] = {}
+    architecture_pattern = re.compile(r"\bsm[_-]?([0-9]{2,3}[af]?)\b", re.IGNORECASE)
+
+    with tempfile.TemporaryDirectory(prefix="flashinfer-cuobjdump-") as temp_dir:
+        temp_root = Path(temp_dir)
+        with zipfile.ZipFile(wheel.path) as archive:
+            for module, archive_path in sorted(module_paths.items()):
+                extracted_path = Path(archive.extract(archive_path, temp_root))
+                process = subprocess.run(
+                    [str(cuobjdump), "--list-elf", str(extracted_path)],
+                    check=False,
+                    capture_output=True,
+                    text=True,
+                )
+                require(
+                    process.returncode == 0,
+                    f"cuobjdump failed for {module}: {process.stderr.strip()}",
+                )
+                targets = sorted(
+                    {
+                        f"sm{match.lower()}"
+                        for match in architecture_pattern.findall(process.stdout)
+                    }
+                )
+                require(targets, f"cuobjdump found no cubin targets in {module}")
+                require(
+                    targets == [provider],
+                    f"{module} contains {targets}; expected only {provider}",
+                )
+                result[module] = targets
+    return result
+
+
+def run_install_smoke(shim: Wheel, provider: Wheel, provider_id: str) -> None:
+    with tempfile.TemporaryDirectory(
+        prefix="flashinfer-wheelhouse-install-"
+    ) as temp_dir:
+        subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "pip",
+                "install",
+                "--disable-pip-version-check",
+                "--no-deps",
+                "--no-index",
+                "--target",
+                temp_dir,
+                str(provider.path),
+                str(shim.path),
+            ],
+            check=True,
+        )
+        smoke_code = """
+import json
+from flashinfer_jit_cache import get_jit_cache_providers
+
+providers = get_jit_cache_providers()
+assert len(providers) == 1, providers
+provider = providers[0]
+print(json.dumps({
+    "provider_id": provider.provider_id,
+    "cuda_architectures": sorted(provider.cuda_architectures),
+    "module_count": len(provider.modules),
+}))
+"""
+        process = subprocess.run(
+            [sys.executable, "-c", smoke_code],
+            check=True,
+            capture_output=True,
+            text=True,
+            env={**os.environ, "PYTHONPATH": temp_dir},
+        )
+        result = json.loads(process.stdout.strip().splitlines()[-1])
+        require(result["provider_id"] == provider_id, "Installed provider ID mismatch")
+        require(
+            result["cuda_architectures"] == [provider_id],
+            "Installed provider architecture mismatch",
+        )
+        require(result["module_count"] > 0, "Installed provider has no modules")
+
+
+def write_report(
+    wheelhouse: Path,
+    wheels: dict[str, Wheel],
+    provider: str,
+    manifest: dict[str, Any],
+    module_architectures: dict[str, list[str]],
+) -> None:
+    report = {
+        "schema_version": 1,
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "provider_id": provider,
+        "version": manifest["version"],
+        "cuda_architectures": manifest["cuda_architectures"],
+        "module_count": len(manifest["modules"]),
+        "modules": sorted(manifest["modules"]),
+        "module_cuda_architectures": module_architectures,
+        "wheels": {
+            distribution: {
+                "filename": wheel.path.name,
+                "size_bytes": wheel.path.stat().st_size,
+                "sha256": sha256(wheel.path),
+            }
+            for distribution, wheel in sorted(wheels.items())
+        },
+    }
+    (wheelhouse / "wheelhouse.json").write_text(
+        json.dumps(report, indent=2, sort_keys=True) + "\n"
+    )
+    checksum_lines = [
+        f"{details['sha256']}  {details['filename']}"
+        for details in report["wheels"].values()
+    ]
+    (wheelhouse / "SHA256SUMS").write_text("\n".join(checksum_lines) + "\n")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--wheelhouse", type=Path, required=True)
+    parser.add_argument("--provider", required=True)
+    parser.add_argument("--version", required=True)
+    parser.add_argument("--cuobjdump", type=Path)
+    parser.add_argument("--install-smoke", action="store_true")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    wheel_paths = sorted(args.wheelhouse.glob("*.whl"))
+    require(len(wheel_paths) == 3, f"Expected three wheels, found {len(wheel_paths)}")
+    opened_wheels = [Wheel.open(path) for path in wheel_paths]
+    wheels = {
+        canonicalize_distribution(wheel.distribution): wheel for wheel in opened_wheels
+    }
+    expected_distributions = {
+        "flashinfer-python",
+        "flashinfer-jit-cache",
+        f"flashinfer-jit-cache-{args.provider}",
+    }
+    require(
+        set(wheels) == expected_distributions,
+        f"Unexpected wheel distributions: {sorted(wheels)}",
+    )
+
+    flashinfer_python = wheels["flashinfer-python"]
+    shim = wheels["flashinfer-jit-cache"]
+    provider_wheel = wheels[f"flashinfer-jit-cache-{args.provider}"]
+    validate_flashinfer_python(flashinfer_python, args.version)
+    manifest, module_paths = validate_provider(
+        provider_wheel, args.provider, args.version
+    )
+    validate_shim(shim, args.provider, args.version)
+
+    module_architectures: dict[str, list[str]] = {}
+    if args.cuobjdump is not None:
+        module_architectures = inspect_cuda_architectures(
+            provider_wheel,
+            module_paths,
+            args.provider,
+            args.cuobjdump,
+        )
+    if args.install_smoke:
+        run_install_smoke(shim, provider_wheel, args.provider)
+
+    write_report(
+        args.wheelhouse,
+        wheels,
+        args.provider,
+        manifest,
+        module_architectures,
+    )
+    print(
+        f"Validated {args.provider}: {len(module_paths)} modules, "
+        f"{len(wheel_paths)} wheels"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except (OSError, ValueError, subprocess.CalledProcessError) as error:
+        print(f"ERROR: {error}", file=sys.stderr)
+        raise SystemExit(1) from None

--- a/scripts/verify_jit_cache_provider_wheelhouse.py
+++ b/scripts/verify_jit_cache_provider_wheelhouse.py
@@ -96,7 +96,10 @@ def read_provider_manifest(wheel: Wheel, provider: str) -> tuple[dict[str, Any],
 
 
 def validate_provider(
-    wheel: Wheel, provider: str, expected_version: str
+    wheel: Wheel,
+    provider: str,
+    expected_version: str,
+    expected_platform_tag: str | None = None,
 ) -> tuple[dict[str, Any], dict[str, str]]:
     expected_distribution = f"flashinfer-jit-cache-{provider}"
     require(
@@ -108,6 +111,11 @@ def validate_provider(
         f"Provider version {wheel.version} does not match {expected_version}",
     )
     require(not wheel.requirements, "Provider wheel must not depend on other wheels")
+    if expected_platform_tag:
+        require(
+            wheel.path.name.endswith(f"-{expected_platform_tag}.whl"),
+            f"Provider wheel {wheel.path.name} does not use {expected_platform_tag}",
+        )
 
     manifest, package_prefix = read_provider_manifest(wheel, provider)
     require(manifest.get("schema_version") == 1, "Unsupported provider manifest")
@@ -388,6 +396,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--wheelhouse", type=Path, required=True)
     parser.add_argument("--provider", required=True)
     parser.add_argument("--version", required=True)
+    parser.add_argument("--provider-platform-tag", default="")
     parser.add_argument("--cuobjdump", type=Path)
     parser.add_argument(
         "--cuda-architecture-policy",
@@ -422,7 +431,10 @@ def main() -> int:
     provider_wheel = wheels[f"flashinfer-jit-cache-{args.provider}"]
     validate_flashinfer_python(flashinfer_python, args.version)
     manifest, module_paths = validate_provider(
-        provider_wheel, args.provider, args.version
+        provider_wheel,
+        args.provider,
+        args.version,
+        args.provider_platform_tag or None,
     )
     validate_shim(shim, args.provider, args.version)
 

--- a/scripts/verify_jit_cache_provider_wheelhouse.py
+++ b/scripts/verify_jit_cache_provider_wheelhouse.py
@@ -4,24 +4,24 @@
 from __future__ import annotations
 
 import argparse
-import configparser
 import hashlib
 import json
 import os
-import re
 import subprocess
 import sys
 import tempfile
-import zipfile
-from dataclasses import dataclass
 from datetime import datetime, timezone
-from email.parser import BytesParser
 from pathlib import Path
 from typing import Any
 
-
-def canonicalize_distribution(name: str) -> str:
-    return re.sub(r"[-_.]+", "-", name).lower()
+from jit_cache_provider_validation import (
+    Wheel,
+    canonicalize_distribution,
+    inspect_cuda_architectures,
+    require,
+    validate_provider,
+    validate_shim,
+)
 
 
 def sha256(path: Path) -> str:
@@ -30,171 +30,6 @@ def sha256(path: Path) -> str:
         for chunk in iter(lambda: file.read(1024 * 1024), b""):
             digest.update(chunk)
     return digest.hexdigest()
-
-
-@dataclass(frozen=True)
-class Wheel:
-    path: Path
-    distribution: str
-    version: str
-    requirements: tuple[str, ...]
-    contents: tuple[str, ...]
-    metadata_path: str
-
-    @classmethod
-    def open(cls, path: Path) -> "Wheel":
-        with zipfile.ZipFile(path) as archive:
-            contents = tuple(sorted(archive.namelist()))
-            metadata_paths = [
-                name for name in contents if name.endswith(".dist-info/METADATA")
-            ]
-            if len(metadata_paths) != 1:
-                raise ValueError(
-                    f"{path.name}: expected one METADATA file, found "
-                    f"{len(metadata_paths)}"
-                )
-            metadata_path = metadata_paths[0]
-            metadata = BytesParser().parsebytes(archive.read(metadata_path))
-        return cls(
-            path=path,
-            distribution=metadata["Name"],
-            version=metadata["Version"],
-            requirements=tuple(metadata.get_all("Requires-Dist", [])),
-            contents=contents,
-            metadata_path=metadata_path,
-        )
-
-
-def require(condition: bool, message: str) -> None:
-    if not condition:
-        raise ValueError(message)
-
-
-def normalize_requirement(requirement: str) -> tuple[str, str]:
-    match = re.fullmatch(r"\s*([A-Za-z0-9_.-]+)\s*==\s*([^\s;]+)\s*", requirement)
-    if match is None:
-        raise ValueError(f"Expected an exact provider pin, got {requirement!r}")
-    return canonicalize_distribution(match.group(1)), match.group(2)
-
-
-def read_provider_manifest(wheel: Wheel, provider: str) -> tuple[dict[str, Any], str]:
-    package_suffix = f"flashinfer_jit_cache/providers/{provider}/manifest.json"
-    manifest_paths = [
-        path
-        for path in wheel.contents
-        if path == package_suffix or path.endswith(f".data/purelib/{package_suffix}")
-    ]
-    require(
-        len(manifest_paths) == 1,
-        f"{wheel.path.name}: expected one {package_suffix}, found {manifest_paths}",
-    )
-    manifest_path = manifest_paths[0]
-    package_prefix = manifest_path.removesuffix("/manifest.json")
-    with zipfile.ZipFile(wheel.path) as archive:
-        manifest = json.loads(archive.read(manifest_path))
-    return manifest, package_prefix
-
-
-def validate_provider(
-    wheel: Wheel,
-    provider: str,
-    expected_version: str,
-    expected_platform_tag: str | None = None,
-) -> tuple[dict[str, Any], dict[str, str]]:
-    expected_distribution = f"flashinfer-jit-cache-{provider}"
-    require(
-        canonicalize_distribution(wheel.distribution) == expected_distribution,
-        f"Unexpected provider distribution: {wheel.distribution}",
-    )
-    require(
-        wheel.version == expected_version,
-        f"Provider version {wheel.version} does not match {expected_version}",
-    )
-    require(not wheel.requirements, "Provider wheel must not depend on other wheels")
-    if expected_platform_tag:
-        require(
-            wheel.path.name.endswith(f"-{expected_platform_tag}.whl"),
-            f"Provider wheel {wheel.path.name} does not use {expected_platform_tag}",
-        )
-
-    manifest, package_prefix = read_provider_manifest(wheel, provider)
-    require(manifest.get("schema_version") == 1, "Unsupported provider manifest")
-    require(manifest.get("provider_id") == provider, "Provider ID mismatch")
-    require(
-        canonicalize_distribution(str(manifest.get("distribution", "")))
-        == expected_distribution,
-        "Provider manifest distribution mismatch",
-    )
-    require(manifest.get("version") == expected_version, "Manifest version mismatch")
-    require(
-        manifest.get("cuda_architectures") == [provider],
-        "Provider manifest must declare exactly its own architecture",
-    )
-
-    module_paths: dict[str, str] = {}
-    so_prefix = f"{package_prefix}/jit_cache/"
-    for path in wheel.contents:
-        if not path.startswith(so_prefix) or not path.endswith(".so"):
-            continue
-        relative = path.removeprefix(so_prefix)
-        parts = relative.split("/")
-        require(
-            len(parts) == 2 and parts[1] == f"{parts[0]}.so",
-            f"Unexpected provider shared-library path: {path}",
-        )
-        module_paths[parts[0]] = path
-
-    require(module_paths, "Provider wheel contains no shared libraries")
-    manifest_modules = set(manifest.get("modules", []))
-    require(
-        manifest_modules == set(module_paths),
-        "Provider manifest modules do not match packaged shared libraries",
-    )
-
-    entry_points_path = wheel.metadata_path.replace("METADATA", "entry_points.txt")
-    require(
-        entry_points_path in wheel.contents,
-        f"{wheel.path.name}: missing provider entry point",
-    )
-    parser = configparser.ConfigParser()
-    with zipfile.ZipFile(wheel.path) as archive:
-        parser.read_string(archive.read(entry_points_path).decode())
-    group = "flashinfer.jit_cache.providers"
-    require(parser.has_section(group), f"Missing {group} entry-point group")
-    expected_entry_point = f"flashinfer_jit_cache.providers.{provider}:get_provider"
-    require(
-        parser.get(group, provider, fallback="").strip() == expected_entry_point,
-        f"Provider entry point does not match {expected_entry_point}",
-    )
-    return manifest, module_paths
-
-
-def validate_shim(wheel: Wheel, provider: str, expected_version: str) -> None:
-    require(
-        canonicalize_distribution(wheel.distribution) == "flashinfer-jit-cache",
-        f"Unexpected shim distribution: {wheel.distribution}",
-    )
-    require(
-        wheel.version == expected_version,
-        f"Shim version {wheel.version} does not match {expected_version}",
-    )
-    require(
-        not any(path.endswith(".so") for path in wheel.contents),
-        "Shim wheel must not contain shared libraries",
-    )
-    require(
-        len(wheel.requirements) == 1,
-        f"Shim must have one provider requirement, found {wheel.requirements}",
-    )
-    requirement_name, requirement_version = normalize_requirement(wheel.requirements[0])
-    require(
-        requirement_name == f"flashinfer-jit-cache-{provider}",
-        f"Shim requires unexpected provider {requirement_name}",
-    )
-    require(
-        requirement_version == expected_version,
-        f"Shim provider pin {requirement_version} does not match {expected_version}",
-    )
 
 
 def validate_flashinfer_python(wheel: Wheel, expected_version: str) -> None:
@@ -206,87 +41,6 @@ def validate_flashinfer_python(wheel: Wheel, expected_version: str) -> None:
         wheel.version == expected_version,
         f"FlashInfer version {wheel.version} does not match {expected_version}",
     )
-
-
-def inspect_cuda_architectures(
-    wheel: Wheel,
-    module_paths: dict[str, str],
-    provider: str,
-    cuobjdump: Path,
-    strict: bool,
-) -> tuple[dict[str, list[str]], list[str]]:
-    require(cuobjdump.is_file(), f"cuobjdump not found: {cuobjdump}")
-    result: dict[str, list[str]] = {}
-    ptx_modules: list[str] = []
-    architecture_pattern = re.compile(r"\bsm[_-]?([0-9]{2,3}[af]?)\b", re.IGNORECASE)
-
-    with tempfile.TemporaryDirectory(prefix="flashinfer-cuobjdump-") as temp_dir:
-        temp_root = Path(temp_dir)
-        with zipfile.ZipFile(wheel.path) as archive:
-            for module, archive_path in sorted(module_paths.items()):
-                extracted_path = Path(archive.extract(archive_path, temp_root))
-                process = subprocess.run(
-                    [str(cuobjdump), "--list-elf", str(extracted_path)],
-                    check=False,
-                    capture_output=True,
-                    text=True,
-                )
-                if (
-                    process.returncode != 0
-                    and "does not contain device code" in process.stderr
-                ):
-                    result[module] = []
-                    continue
-                require(
-                    process.returncode == 0,
-                    f"cuobjdump failed for {module}: {process.stderr.strip()}",
-                )
-                targets = sorted(
-                    {
-                        f"sm{match.lower()}"
-                        for match in architecture_pattern.findall(process.stdout)
-                    }
-                )
-                result[module] = targets
-                ptx_process = subprocess.run(
-                    [str(cuobjdump), "--list-ptx", str(extracted_path)],
-                    check=False,
-                    capture_output=True,
-                    text=True,
-                )
-                ptx_output = "\n".join(
-                    output.strip()
-                    for output in (ptx_process.stdout, ptx_process.stderr)
-                    if output.strip()
-                )
-                require(
-                    ptx_process.returncode == 0,
-                    f"cuobjdump PTX inspection failed for {module}: {ptx_output}",
-                )
-                if "No PTX file found" not in ptx_output:
-                    ptx_modules.append(module)
-
-    mismatches = {
-        module: targets
-        for module, targets in result.items()
-        if targets and targets != [provider]
-    }
-    if strict and mismatches:
-        examples = ", ".join(
-            f"{module}={targets}"
-            for module, targets in list(sorted(mismatches.items()))[:10]
-        )
-        require(
-            False,
-            f"{len(mismatches)} modules do not contain only {provider}: {examples}",
-        )
-    if strict and ptx_modules:
-        examples = ", ".join(sorted(ptx_modules)[:10])
-        require(
-            False,
-            f"{len(ptx_modules)} native-provider modules contain PTX: {examples}",
-        )
-    return result, sorted(ptx_modules)
 
 
 def run_install_smoke(shim: Wheel, provider: Wheel, provider_id: str) -> None:
@@ -436,7 +190,7 @@ def main() -> int:
         args.version,
         args.provider_platform_tag or None,
     )
-    validate_shim(shim, args.provider, args.version)
+    validate_shim(shim, args.version, {args.provider})
 
     module_architectures: dict[str, list[str]] = {}
     ptx_modules: list[str] = []

--- a/tests/cli/test_cli_cmds.py
+++ b/tests/cli/test_cli_cmds.py
@@ -137,6 +137,70 @@ def test_install_cubin_wheel_cmd_mocked(monkeypatch):
     assert recorded["check"] is False
 
 
+def test_install_jit_cache_wheel_cmd_minimal_explicit_sm(monkeypatch):
+    import flashinfer.__main__ as flashinfer_main
+
+    recorded = {}
+
+    def mock_run(cmd, check=False):
+        recorded["cmd"] = cmd
+
+        class Result:
+            returncode = 0
+
+        return Result()
+
+    monkeypatch.setattr(flashinfer_main.torch.version, "cuda", "13.0")
+    monkeypatch.setattr("flashinfer.__main__.__version__", "0.4.1")
+    monkeypatch.setattr("flashinfer.__main__.subprocess.run", mock_run)
+
+    out = _test_cmd_helper(
+        [
+            "install-jit-cache-wheel",
+            "--mode",
+            "minimal",
+            "--sm",
+            "12.0f",
+        ]
+    )
+
+    _assert_output_contains_all(out, "Install mode: minimal", "Providers: sm120f")
+    assert recorded["cmd"] == [
+        sys.executable,
+        "-m",
+        "pip",
+        "install",
+        "--upgrade",
+        "--no-deps",
+        "--index-url",
+        "https://flashinfer.ai/whl/cu130",
+        "flashinfer-jit-cache==0.4.1+cu130",
+        "flashinfer-jit-cache-sm120f==0.4.1+cu130",
+    ]
+
+
+def test_install_jit_cache_wheel_cmd_minimal_detects_visible_sm(monkeypatch):
+    import flashinfer.__main__ as flashinfer_main
+
+    monkeypatch.setattr(flashinfer_main.torch.version, "cuda", "12.9")
+    monkeypatch.setattr("flashinfer.__main__.__version__", "0.4.1")
+    monkeypatch.setattr(
+        flashinfer_main.current_compilation_context,
+        "TARGET_CUDA_ARCHS",
+        {(9, "0a")},
+    )
+
+    out = _test_cmd_helper(
+        ["install-jit-cache-wheel", "--mode", "minimal", "--dry-run"]
+    )
+
+    _assert_output_contains_all(
+        out,
+        "Providers: sm90a",
+        "flashinfer-jit-cache-sm90a==0.4.1+cu129",
+    )
+
+
 def test_install_cubin_wheel_cmd_nightly_dry_run(monkeypatch):
     monkeypatch.setattr("flashinfer.__main__.__version__", "0.4.1.dev20260421")
 
@@ -299,7 +363,6 @@ def test_install_jit_cache_wheel_cmd_mocked(monkeypatch):
         "pip",
         "install",
         "--upgrade",
-        "--no-deps",
         "--index-url",
         "https://flashinfer.ai/whl/cu129",
         "flashinfer-jit-cache==0.4.1+cu129",
@@ -483,7 +546,6 @@ def test_download_kernels_cmd_mocked(monkeypatch):
                 "pip",
                 "install",
                 "--upgrade",
-                "--no-deps",
                 "--index-url",
                 "https://flashinfer.ai/whl/cu129",
                 "flashinfer-jit-cache==0.4.1+cu129",

--- a/tests/cli/test_cli_cmds.py
+++ b/tests/cli/test_cli_cmds.py
@@ -137,7 +137,7 @@ def test_install_cubin_wheel_cmd_mocked(monkeypatch):
     assert recorded["check"] is False
 
 
-def test_install_jit_cache_wheel_cmd_minimal_explicit_sm(monkeypatch):
+def test_install_jit_cache_wheel_cmd_minimal_does_not_add_sm80(monkeypatch):
     import flashinfer.__main__ as flashinfer_main
 
     recorded = {}

--- a/tests/cli/test_cli_cmds.py
+++ b/tests/cli/test_cli_cmds.py
@@ -145,7 +145,7 @@ def test_install_cubin_wheel_cmd_mocked(monkeypatch):
     assert recorded["check"] is False
 
 
-def test_install_jit_cache_wheel_cmd_minimal_explicit_sm(monkeypatch):
+def test_install_jit_cache_wheel_cmd_minimal_does_not_add_sm80(monkeypatch):
     import flashinfer.__main__ as flashinfer_main
 
     recorded = {}

--- a/tests/cli/test_cli_cmds.py
+++ b/tests/cli/test_cli_cmds.py
@@ -209,6 +209,31 @@ def test_install_jit_cache_wheel_cmd_minimal_detects_visible_sm(monkeypatch):
     )
 
 
+def test_install_jit_cache_wheel_cmd_minimal_keeps_arch_specific_target_exact(
+    monkeypatch,
+):
+    import flashinfer.__main__ as flashinfer_main
+
+    monkeypatch.setattr(flashinfer_main.torch.version, "cuda", "13.0")
+    monkeypatch.setattr("flashinfer.__main__.__version__", "0.4.1")
+    monkeypatch.setattr(
+        flashinfer_main.current_compilation_context,
+        "TARGET_CUDA_ARCHS",
+        {(12, "1a")},
+    )
+
+    out = _test_cmd_helper(
+        ["install-jit-cache-wheel", "--mode", "minimal", "--dry-run"]
+    )
+
+    _assert_output_contains_all(
+        out,
+        "Providers: sm121a",
+        "flashinfer-jit-cache-sm121a==0.4.1+cu130",
+    )
+    assert "flashinfer-jit-cache-sm120f" not in out
+
+
 def test_install_cubin_wheel_cmd_nightly_dry_run(monkeypatch):
     monkeypatch.setattr("flashinfer.__main__.__version__", "0.4.1.dev20260421")
 

--- a/tests/cli/test_cli_cmds.py
+++ b/tests/cli/test_cli_cmds.py
@@ -145,6 +145,70 @@ def test_install_cubin_wheel_cmd_mocked(monkeypatch):
     assert recorded["check"] is False
 
 
+def test_install_jit_cache_wheel_cmd_minimal_explicit_sm(monkeypatch):
+    import flashinfer.__main__ as flashinfer_main
+
+    recorded = {}
+
+    def mock_run(cmd, check=False):
+        recorded["cmd"] = cmd
+
+        class Result:
+            returncode = 0
+
+        return Result()
+
+    monkeypatch.setattr(flashinfer_main.torch.version, "cuda", "13.0")
+    monkeypatch.setattr("flashinfer.__main__.__version__", "0.4.1")
+    monkeypatch.setattr("flashinfer.__main__.subprocess.run", mock_run)
+
+    out = _test_cmd_helper(
+        [
+            "install-jit-cache-wheel",
+            "--mode",
+            "minimal",
+            "--sm",
+            "12.0f",
+        ]
+    )
+
+    _assert_output_contains_all(out, "Install mode: minimal", "Providers: sm120f")
+    assert recorded["cmd"] == [
+        sys.executable,
+        "-m",
+        "pip",
+        "install",
+        "--upgrade",
+        "--no-deps",
+        "--index-url",
+        "https://flashinfer.ai/whl/cu130",
+        "flashinfer-jit-cache==0.4.1+cu130",
+        "flashinfer-jit-cache-sm120f==0.4.1+cu130",
+    ]
+
+
+def test_install_jit_cache_wheel_cmd_minimal_detects_visible_sm(monkeypatch):
+    import flashinfer.__main__ as flashinfer_main
+
+    monkeypatch.setattr(flashinfer_main.torch.version, "cuda", "12.9")
+    monkeypatch.setattr("flashinfer.__main__.__version__", "0.4.1")
+    monkeypatch.setattr(
+        flashinfer_main.current_compilation_context,
+        "TARGET_CUDA_ARCHS",
+        {(9, "0a")},
+    )
+
+    out = _test_cmd_helper(
+        ["install-jit-cache-wheel", "--mode", "minimal", "--dry-run"]
+    )
+
+    _assert_output_contains_all(
+        out,
+        "Providers: sm90a",
+        "flashinfer-jit-cache-sm90a==0.4.1+cu129",
+    )
+
+
 def test_install_cubin_wheel_cmd_nightly_dry_run(monkeypatch):
     monkeypatch.setattr("flashinfer.__main__.__version__", "0.4.1.dev20260421")
 
@@ -307,7 +371,6 @@ def test_install_jit_cache_wheel_cmd_mocked(monkeypatch):
         "pip",
         "install",
         "--upgrade",
-        "--no-deps",
         "--index-url",
         "https://flashinfer.ai/whl/cu129",
         "flashinfer-jit-cache==0.4.1+cu129",
@@ -531,7 +594,6 @@ def test_download_kernels_cmd_mocked(monkeypatch):
                 "pip",
                 "install",
                 "--upgrade",
-                "--no-deps",
                 "--index-url",
                 "https://flashinfer.ai/whl/cu129",
                 "flashinfer-jit-cache==0.4.1+cu129",

--- a/tests/jit/test_bgmv_moe_jit.py
+++ b/tests/jit/test_bgmv_moe_jit.py
@@ -1,0 +1,86 @@
+"""
+Copyright (c) 2026 by FlashInfer team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+from packaging.version import Version
+
+
+@pytest.mark.parametrize(
+    ("target_archs", "expected"),
+    [
+        ({(8, "0")}, False),
+        ({(9, "0a")}, True),
+        ({(12, "0f")}, True),
+    ],
+)
+def test_detect_bgmv_moe_capability(monkeypatch, target_archs, expected):
+    from flashinfer import aot
+
+    class FakeCompilationContext:
+        TARGET_CUDA_ARCHS = target_archs
+
+        def get_nvcc_flags_list(self, supported_major_versions=None):
+            del supported_major_versions
+            return [
+                f"-gencode=arch=compute_{major}{minor},code=sm_{major}{minor}"
+                for major, minor in sorted(self.TARGET_CUDA_ARCHS)
+            ]
+
+    monkeypatch.setattr(aot, "CompilationContext", FakeCompilationContext)
+    monkeypatch.setattr(aot, "get_cuda_version", lambda: Version("13.0"))
+
+    assert aot.detect_sm_capabilities()["bgmv_moe"] is expected
+
+
+@pytest.mark.parametrize("supported", [False, True])
+def test_aot_registers_bgmv_moe_only_for_supported_target(monkeypatch, supported):
+    from flashinfer import aot
+
+    monkeypatch.setattr(
+        aot, "gen_spdlog_module", lambda: SimpleNamespace(name="spdlog")
+    )
+    monkeypatch.setattr(aot, "gen_attention", lambda *args: ())
+    monkeypatch.setattr(
+        aot, "gen_cudnn_fmha_module", lambda: SimpleNamespace(name="cudnn_fmha")
+    )
+    monkeypatch.setattr(aot, "gen_gemm_module", lambda: SimpleNamespace(name="gemm"))
+    monkeypatch.setattr(
+        aot, "gen_hash_topk_module", lambda: SimpleNamespace(name="hash_topk")
+    )
+    monkeypatch.setattr(
+        aot, "gen_bgmv_moe_module", lambda: SimpleNamespace(name="bgmv_moe")
+    )
+
+    specs = aot.gen_all_modules(
+        [],
+        [],
+        [],
+        [],
+        [],
+        [],
+        {"bgmv_moe": supported},
+        False,
+        False,
+        False,
+        True,
+        False,
+        False,
+        False,
+    )
+
+    assert ("bgmv_moe" in {spec.name for spec in specs}) is supported

--- a/tests/jit/test_jit_cache_providers.py
+++ b/tests/jit/test_jit_cache_providers.py
@@ -1,0 +1,256 @@
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+from flashinfer.jit import env as jit_env
+
+
+class _FakeEntryPoint:
+    def __init__(self, name, manifest):
+        self.name = name
+        self._manifest = manifest
+
+    def load(self):
+        return lambda: self._manifest
+
+
+class _FakeEntryPoints(tuple):
+    def select(self, *, group):
+        if group == "flashinfer.jit_cache.providers":
+            return self
+        return ()
+
+
+@pytest.fixture
+def jit_cache_shim_module():
+    package_dir = (
+        Path(__file__).resolve().parents[2]
+        / "flashinfer-jit-cache"
+        / "flashinfer_jit_cache"
+    )
+    module_name = "_test_flashinfer_jit_cache"
+    spec = importlib.util.spec_from_file_location(
+        module_name,
+        package_dir / "__init__.py",
+        submodule_search_locations=[str(package_dir)],
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    try:
+        spec.loader.exec_module(module)
+        yield module
+    finally:
+        sys.modules.pop(module_name, None)
+
+
+@pytest.fixture
+def provider_package_config_module():
+    config_path = (
+        Path(__file__).resolve().parents[2]
+        / "flashinfer-jit-cache-provider"
+        / "package_config.py"
+    )
+    module_name = "_test_jit_cache_provider_package_config"
+    spec = importlib.util.spec_from_file_location(module_name, config_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    try:
+        spec.loader.exec_module(module)
+        yield module
+    finally:
+        sys.modules.pop(module_name, None)
+
+
+def _create_aot_module(root: Path, module_name: str) -> Path:
+    module_dir = root / module_name
+    module_dir.mkdir(parents=True)
+    module_path = module_dir / f"{module_name}.so"
+    module_path.touch()
+    return module_path
+
+
+def test_shim_discovers_and_normalizes_provider(
+    monkeypatch, tmp_path, jit_cache_shim_module
+):
+    manifest = {
+        "schema_version": 1,
+        "distribution": "flashinfer-jit-cache-sm90a",
+        "version": "0.6.16+cu130",
+        "jit_cache_dir": str(tmp_path),
+        "cuda_architectures": ["9.0a"],
+        "modules": ["attention_module"],
+    }
+    entry_points = _FakeEntryPoints((_FakeEntryPoint("sm90a", manifest),))
+    monkeypatch.setattr(
+        jit_cache_shim_module.importlib.metadata,
+        "entry_points",
+        lambda: entry_points,
+    )
+
+    providers = jit_cache_shim_module.get_jit_cache_providers()
+
+    assert len(providers) == 1
+    assert providers[0].provider_id == "sm90a"
+    assert providers[0].cuda_architectures == frozenset({"sm90a"})
+    assert providers[0].modules == frozenset({"attention_module"})
+
+
+def test_shim_ignores_invalid_provider(monkeypatch, caplog, jit_cache_shim_module):
+    manifest = {
+        "schema_version": 1,
+        "distribution": "flashinfer-jit-cache-sm80",
+        "version": "0.6.16+cu130",
+        "jit_cache_dir": "/tmp/provider",
+        "cuda_architectures": ["8.0"],
+        "modules": [],
+    }
+    entry_points = _FakeEntryPoints((_FakeEntryPoint("sm80", manifest),))
+    monkeypatch.setattr(
+        jit_cache_shim_module.importlib.metadata,
+        "entry_points",
+        lambda: entry_points,
+    )
+
+    assert jit_cache_shim_module.get_jit_cache_providers() == ()
+    assert "has no modules" in caplog.text
+
+
+@pytest.mark.parametrize(
+    ("architecture", "expected_architecture", "expected_tag"),
+    [
+        ("8.0", "8.0", "sm80"),
+        ("sm90a", "9.0a", "sm90a"),
+        ("compute_120f", "12.0f", "sm120f"),
+        ("12.1a", "12.1a", "sm121a"),
+    ],
+)
+def test_provider_build_config_normalizes_architecture(
+    provider_package_config_module,
+    architecture,
+    expected_architecture,
+    expected_tag,
+):
+    assert provider_package_config_module.normalize_cuda_architecture(architecture) == (
+        expected_architecture,
+        expected_tag,
+    )
+
+
+def test_provider_build_config_uses_distinct_distribution_name(
+    monkeypatch, provider_package_config_module
+):
+    monkeypatch.setenv("FLASHINFER_JIT_CACHE_PROVIDER_ARCH", "9.0a")
+    monkeypatch.setenv("FLASHINFER_LOCAL_VERSION", "cu130")
+
+    config = provider_package_config_module.get_provider_build_config()
+
+    assert config.provider_tag == "sm90a"
+    assert config.distribution == "flashinfer-jit-cache-sm90a"
+    assert config.package == "flashinfer_jit_cache.providers.sm90a"
+    assert config.version.endswith("+cu130")
+
+
+def test_get_aot_path_selects_provider_for_target_arch(monkeypatch, tmp_path):
+    legacy_root = tmp_path / "legacy"
+    sm80_root = tmp_path / "sm80"
+    sm90_root = tmp_path / "sm90a"
+    expected = _create_aot_module(sm90_root, "attention_module")
+    _create_aot_module(sm80_root, "attention_module")
+
+    providers = (
+        jit_env.AOTProvider(
+            provider_id="sm80",
+            distribution="flashinfer-jit-cache-sm80",
+            version="0.6.16+cu130",
+            jit_cache_dir=sm80_root,
+            cuda_architectures=frozenset({"sm80"}),
+            modules=frozenset({"attention_module"}),
+        ),
+        jit_env.AOTProvider(
+            provider_id="sm90a",
+            distribution="flashinfer-jit-cache-sm90a",
+            version="0.6.16+cu130",
+            jit_cache_dir=sm90_root,
+            cuda_architectures=frozenset({"sm90a"}),
+            modules=frozenset({"attention_module"}),
+        ),
+    )
+    monkeypatch.setattr(jit_env, "FLASHINFER_AOT_DIR", legacy_root)
+    monkeypatch.setattr(jit_env, "FLASHINFER_AOT_PROVIDERS", providers)
+    monkeypatch.setattr(
+        jit_env, "_target_cuda_architectures", lambda: frozenset({"sm90a"})
+    )
+
+    assert jit_env.get_aot_path("attention_module") == expected
+
+
+def test_get_aot_path_requires_provider_to_cover_all_targets(monkeypatch, tmp_path):
+    legacy_root = tmp_path / "legacy"
+    provider_root = tmp_path / "sm90a"
+    _create_aot_module(provider_root, "attention_module")
+    provider = jit_env.AOTProvider(
+        provider_id="sm90a",
+        distribution="flashinfer-jit-cache-sm90a",
+        version="0.6.16+cu130",
+        jit_cache_dir=provider_root,
+        cuda_architectures=frozenset({"sm90a"}),
+        modules=frozenset({"attention_module"}),
+    )
+    monkeypatch.setattr(jit_env, "FLASHINFER_AOT_DIR", legacy_root)
+    monkeypatch.setattr(jit_env, "FLASHINFER_AOT_PROVIDERS", (provider,))
+    monkeypatch.setattr(
+        jit_env,
+        "_target_cuda_architectures",
+        lambda: frozenset({"sm80", "sm90a"}),
+    )
+
+    assert jit_env.get_aot_path("attention_module") == (
+        legacy_root / "attention_module" / "attention_module.so"
+    )
+
+
+def test_get_aot_path_does_not_guess_when_target_is_unknown(monkeypatch, tmp_path):
+    legacy_root = tmp_path / "legacy"
+    provider_root = tmp_path / "sm80"
+    _create_aot_module(provider_root, "attention_module")
+    provider = jit_env.AOTProvider(
+        provider_id="sm80",
+        distribution="flashinfer-jit-cache-sm80",
+        version="0.6.16+cu130",
+        jit_cache_dir=provider_root,
+        cuda_architectures=frozenset({"sm80"}),
+        modules=frozenset({"attention_module"}),
+    )
+    monkeypatch.setattr(jit_env, "FLASHINFER_AOT_DIR", legacy_root)
+    monkeypatch.setattr(jit_env, "FLASHINFER_AOT_PROVIDERS", (provider,))
+    monkeypatch.setattr(jit_env, "_target_cuda_architectures", lambda: frozenset())
+
+    assert jit_env.get_aot_path("attention_module") == (
+        legacy_root / "attention_module" / "attention_module.so"
+    )
+
+
+def test_get_aot_path_prefers_legacy_monolithic_wheel(monkeypatch, tmp_path):
+    legacy_root = tmp_path / "legacy"
+    provider_root = tmp_path / "sm80"
+    expected = _create_aot_module(legacy_root, "attention_module")
+    _create_aot_module(provider_root, "attention_module")
+    provider = jit_env.AOTProvider(
+        provider_id="sm80",
+        distribution="flashinfer-jit-cache-sm80",
+        version="0.6.16+cu130",
+        jit_cache_dir=provider_root,
+        cuda_architectures=frozenset({"sm80"}),
+        modules=frozenset({"attention_module"}),
+    )
+    monkeypatch.setattr(jit_env, "FLASHINFER_AOT_DIR", legacy_root)
+    monkeypatch.setattr(jit_env, "FLASHINFER_AOT_PROVIDERS", (provider,))
+    monkeypatch.setattr(
+        jit_env, "_target_cuda_architectures", lambda: frozenset({"sm80"})
+    )
+
+    assert jit_env.get_aot_path("attention_module") == expected

--- a/tests/jit/test_jit_cache_providers.py
+++ b/tests/jit/test_jit_cache_providers.py
@@ -1,5 +1,7 @@
 import importlib.util
+import subprocess
 import sys
+import zipfile
 from pathlib import Path
 
 import pytest
@@ -55,6 +57,25 @@ def provider_package_config_module():
     )
     module_name = "_test_jit_cache_provider_package_config"
     spec = importlib.util.spec_from_file_location(module_name, config_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    try:
+        spec.loader.exec_module(module)
+        yield module
+    finally:
+        sys.modules.pop(module_name, None)
+
+
+@pytest.fixture
+def wheelhouse_verifier_module():
+    verifier_path = (
+        Path(__file__).resolve().parents[2]
+        / "scripts"
+        / "verify_jit_cache_provider_wheelhouse.py"
+    )
+    module_name = "_test_jit_cache_wheelhouse_verifier"
+    spec = importlib.util.spec_from_file_location(module_name, verifier_path)
     assert spec is not None and spec.loader is not None
     module = importlib.util.module_from_spec(spec)
     sys.modules[module_name] = module
@@ -152,6 +173,91 @@ def test_provider_build_config_uses_distinct_distribution_name(
     assert config.distribution == "flashinfer-jit-cache-sm90a"
     assert config.package == "flashinfer_jit_cache.providers.sm90a"
     assert config.version.endswith("+cu130")
+
+
+def test_native_provider_cuda_inspection_reports_no_ptx(
+    monkeypatch, tmp_path, wheelhouse_verifier_module
+):
+    wheel_path = tmp_path / "provider.whl"
+    archive_path = "provider/jit_cache/test_module/test_module.so"
+    with zipfile.ZipFile(wheel_path, "w") as archive:
+        archive.writestr(archive_path, b"test")
+    wheel = wheelhouse_verifier_module.Wheel(
+        path=wheel_path,
+        distribution="flashinfer-jit-cache-sm120f",
+        version="0.6.16+cu130",
+        requirements=(),
+        contents=(archive_path,),
+        metadata_path="provider.dist-info/METADATA",
+    )
+    cuobjdump = tmp_path / "cuobjdump"
+    cuobjdump.touch()
+
+    def mock_run(cmd, **_kwargs):
+        if cmd[1] == "--list-elf":
+            return subprocess.CompletedProcess(
+                cmd, 0, stdout="ELF file 1: test.sm120f.cubin\n", stderr=""
+            )
+        assert cmd[1] == "--list-ptx"
+        return subprocess.CompletedProcess(
+            cmd,
+            0,
+            stdout="",
+            stderr="cuobjdump info: No PTX file found to extract\n",
+        )
+
+    monkeypatch.setattr(wheelhouse_verifier_module.subprocess, "run", mock_run)
+
+    architectures, ptx_modules = wheelhouse_verifier_module.inspect_cuda_architectures(
+        wheel,
+        {"test_module": archive_path},
+        "sm120f",
+        cuobjdump,
+        strict=True,
+    )
+
+    assert architectures == {"test_module": ["sm120f"]}
+    assert ptx_modules == []
+
+
+def test_native_provider_cuda_inspection_rejects_ptx(
+    monkeypatch, tmp_path, wheelhouse_verifier_module
+):
+    wheel_path = tmp_path / "provider.whl"
+    archive_path = "provider/jit_cache/test_module/test_module.so"
+    with zipfile.ZipFile(wheel_path, "w") as archive:
+        archive.writestr(archive_path, b"test")
+    wheel = wheelhouse_verifier_module.Wheel(
+        path=wheel_path,
+        distribution="flashinfer-jit-cache-sm120f",
+        version="0.6.16+cu130",
+        requirements=(),
+        contents=(archive_path,),
+        metadata_path="provider.dist-info/METADATA",
+    )
+    cuobjdump = tmp_path / "cuobjdump"
+    cuobjdump.touch()
+
+    def mock_run(cmd, **_kwargs):
+        if cmd[1] == "--list-elf":
+            return subprocess.CompletedProcess(
+                cmd, 0, stdout="ELF file 1: test.sm120f.cubin\n", stderr=""
+            )
+        assert cmd[1] == "--list-ptx"
+        return subprocess.CompletedProcess(
+            cmd, 0, stdout="PTX file 1: test.compute_80.ptx\n", stderr=""
+        )
+
+    monkeypatch.setattr(wheelhouse_verifier_module.subprocess, "run", mock_run)
+
+    with pytest.raises(ValueError, match="native-provider modules contain PTX"):
+        wheelhouse_verifier_module.inspect_cuda_architectures(
+            wheel,
+            {"test_module": archive_path},
+            "sm120f",
+            cuobjdump,
+            strict=True,
+        )
 
 
 def test_get_aot_path_selects_provider_for_target_arch(monkeypatch, tmp_path):

--- a/tests/jit/test_jit_cache_providers.py
+++ b/tests/jit/test_jit_cache_providers.py
@@ -212,6 +212,14 @@ def test_provider_backend_uses_configured_build_dependencies(monkeypatch, tmp_pa
     monkeypatch.setitem(sys.modules, "package_config", package_config)
     monkeypatch.setitem(sys.modules, "build_utils", build_utils)
     monkeypatch.setattr(sys, "path", list(sys.path))
+    # Register environment mutations performed during backend import for teardown.
+    monkeypatch.setenv(
+        "FLASHINFER_DISABLE_VERSION_CHECK",
+        os.environ.get("FLASHINFER_DISABLE_VERSION_CHECK", ""),
+    )
+    monkeypatch.setenv(
+        "FLASHINFER_CUDA_ARCH_LIST", os.environ.get("FLASHINFER_CUDA_ARCH_LIST", "")
+    )
 
     module_name = "_test_jit_cache_provider_build_backend"
     spec = importlib.util.spec_from_file_location(module_name, backend_path)
@@ -250,7 +258,7 @@ def test_provider_backend_uses_configured_build_dependencies(monkeypatch, tmp_pa
 
         monkeypatch.setenv(module.PROVIDER_PLATFORM_TAG_ENV, "manylinux_2_28_x86_64")
         monkeypatch.setattr(module.platform, "libc_ver", lambda: ("glibc", "2.34"))
-        with pytest.raises(RuntimeError, match="glibc 2.34 is too new"):
+        with pytest.raises(RuntimeError, match=r"glibc 2\.34 is too new"):
             module._provider_platform_tag("linux_x86_64")
     finally:
         sys.modules.pop(module_name, None)
@@ -356,14 +364,17 @@ set -euo pipefail
 trap 'touch "{trap_marker}"' EXIT
 source "{common_script}"
 export PIP_CONSTRAINT=/tmp/original-constraint
+export PIP_BUILD_CONSTRAINT=/tmp/original-build-constraint
 export PIP_EXTRA_INDEX_URL=https://mirror.example/simple
 setup_jit_cache_python_build "{fake_python}" 13.0 cu130
 generated_constraint=${{PIP_CONSTRAINT}}
 test -f "${{generated_constraint}}"
+test "${{PIP_BUILD_CONSTRAINT}}" = "${{generated_constraint}}"
 test "${{PIP_EXTRA_INDEX_URL}}" = "https://mirror.example/simple https://download.pytorch.org/whl/cu130"
 cleanup_jit_cache_python_build
 test ! -e "${{generated_constraint}}"
 test "${{PIP_CONSTRAINT}}" = /tmp/original-constraint
+test "${{PIP_BUILD_CONSTRAINT}}" = /tmp/original-build-constraint
 """
 
     subprocess.run(["bash", "-c", script], check=True)

--- a/tests/jit/test_jit_cache_providers.py
+++ b/tests/jit/test_jit_cache_providers.py
@@ -490,6 +490,44 @@ def test_get_aot_path_selects_provider_for_target_arch(monkeypatch, tmp_path):
     assert jit_env.get_aot_path("attention_module") == expected
 
 
+@pytest.mark.parametrize(
+    ("provider_architecture", "target_architecture"),
+    [
+        ("sm100a", "sm103a"),
+        ("sm120f", "sm121a"),
+        ("sm80", "sm86"),
+    ],
+)
+def test_get_aot_path_does_not_infer_provider_compatibility(
+    monkeypatch,
+    tmp_path,
+    provider_architecture,
+    target_architecture,
+):
+    legacy_root = tmp_path / "legacy"
+    provider_root = tmp_path / provider_architecture
+    _create_aot_module(provider_root, "attention_module")
+    provider = jit_env.AOTProvider(
+        provider_id=provider_architecture,
+        distribution=f"flashinfer-jit-cache-{provider_architecture}",
+        version="0.6.16+cu130",
+        jit_cache_dir=provider_root,
+        cuda_architectures=frozenset({provider_architecture}),
+        modules=frozenset({"attention_module"}),
+    )
+    monkeypatch.setattr(jit_env, "FLASHINFER_AOT_DIR", legacy_root)
+    monkeypatch.setattr(jit_env, "FLASHINFER_AOT_PROVIDERS", (provider,))
+    monkeypatch.setattr(
+        jit_env,
+        "_target_cuda_architectures",
+        lambda: frozenset({target_architecture}),
+    )
+
+    assert jit_env.get_aot_path("attention_module") == (
+        legacy_root / "attention_module" / "attention_module.so"
+    )
+
+
 def test_get_aot_path_requires_provider_to_cover_all_targets(monkeypatch, tmp_path):
     legacy_root = tmp_path / "legacy"
     provider_root = tmp_path / "sm90a"

--- a/tests/jit/test_jit_cache_providers.py
+++ b/tests/jit/test_jit_cache_providers.py
@@ -1,8 +1,10 @@
 import importlib.util
+import os
 import subprocess
 import sys
 import zipfile
 from pathlib import Path
+from types import ModuleType, SimpleNamespace
 
 import pytest
 
@@ -145,6 +147,7 @@ def test_shim_ignores_invalid_provider(monkeypatch, caplog, jit_cache_shim_modul
     [
         ("8.0", "8.0", "sm80"),
         ("sm90a", "9.0a", "sm90a"),
+        ("10.7a", "10.7a", "sm107a"),
         ("compute_120f", "12.0f", "sm120f"),
         ("12.1a", "12.1a", "sm121a"),
     ],
@@ -170,9 +173,100 @@ def test_provider_build_config_uses_distinct_distribution_name(
     config = provider_package_config_module.get_provider_build_config()
 
     assert config.provider_tag == "sm90a"
+    assert config.cuda_major == "13"
     assert config.distribution == "flashinfer-jit-cache-sm90a"
     assert config.package == "flashinfer_jit_cache.providers.sm90a"
     assert config.version.endswith("+cu130")
+
+
+def test_provider_backend_uses_configured_build_dependencies(monkeypatch, tmp_path):
+    backend_path = (
+        Path(__file__).resolve().parents[2]
+        / "flashinfer-jit-cache-provider"
+        / "build_backend.py"
+    )
+    provider_source = tmp_path / "flashinfer_jit_cache_provider"
+    provider_source.mkdir()
+    config = SimpleNamespace(
+        cuda_architecture="10.7a",
+        cuda_major="13",
+        provider_tag="sm107a",
+        distribution="flashinfer-jit-cache-sm107a",
+        package="flashinfer_jit_cache.providers.sm107a",
+        version="0.6.18+cu134",
+    )
+
+    package_config = ModuleType("package_config")
+    package_config.PROJECT_ROOT = tmp_path
+    package_config.PROVIDER_SOURCE_DIR = provider_source
+    package_config.get_provider_build_config = lambda: config
+
+    build_utils = ModuleType("build_utils")
+    build_utils.get_git_version = lambda cwd=None: "deadbeef"
+    build_utils.get_build_dependency_requirements = lambda cuda_major: [
+        "nvidia-cutlass-dsl[cu13]>=4.6.2a0"
+        if cuda_major == "13"
+        else "nvidia-cutlass-dsl>=4.6.2a0"
+    ]
+
+    monkeypatch.setitem(sys.modules, "package_config", package_config)
+    monkeypatch.setitem(sys.modules, "build_utils", build_utils)
+    monkeypatch.setattr(sys, "path", list(sys.path))
+
+    module_name = "_test_jit_cache_provider_build_backend"
+    spec = importlib.util.spec_from_file_location(module_name, backend_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    try:
+        spec.loader.exec_module(module)
+        monkeypatch.setattr(
+            module._orig,
+            "get_requires_for_build_wheel",
+            lambda _settings: ["setuptools>=77"],
+        )
+        monkeypatch.setattr(
+            module._orig,
+            "get_requires_for_build_editable",
+            lambda _settings: ["setuptools>=77"],
+        )
+
+        expected = ["setuptools>=77", "nvidia-cutlass-dsl[cu13]>=4.6.2a0"]
+        assert module.get_requires_for_build_wheel(None) == expected
+        assert module.get_requires_for_build_editable(None) == expected
+    finally:
+        sys.modules.pop(module_name, None)
+
+
+def test_provider_wheelhouse_resolves_cu134_from_shared_config():
+    script_path = (
+        Path(__file__).resolve().parents[2]
+        / "scripts"
+        / "build_jit_cache_provider_wheelhouse.sh"
+    )
+    env = os.environ.copy()
+    env.update(
+        {
+            "ARCH": "aarch64",
+            "FLASHINFER_JIT_CACHE_PROVIDER_ARCH": "12.1a",
+            "FLASHINFER_LOCAL_VERSION": "cu134",
+        }
+    )
+    env.pop("CUDA_VERSION", None)
+    env.pop("DOCKER_IMAGE", None)
+
+    result = subprocess.run(
+        ["bash", str(script_path), "--print-config"],
+        check=True,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+    assert "provider=sm121a" in result.stdout
+    assert "cuda_version=13.4" in result.stdout
+    assert "pytorch_index=nightly/cu134" in result.stdout
+    assert "container=pytorch/manylinuxaarch64-builder:cuda13.4" in result.stdout
 
 
 def test_native_provider_cuda_inspection_reports_no_ptx(

--- a/tests/jit/test_jit_cache_providers.py
+++ b/tests/jit/test_jit_cache_providers.py
@@ -234,6 +234,24 @@ def test_provider_backend_uses_configured_build_dependencies(monkeypatch, tmp_pa
         expected = ["setuptools>=77", "nvidia-cutlass-dsl[cu13]>=4.6.2a0"]
         assert module.get_requires_for_build_wheel(None) == expected
         assert module.get_requires_for_build_editable(None) == expected
+
+        monkeypatch.delenv(module.PROVIDER_PLATFORM_TAG_ENV, raising=False)
+        assert module._provider_platform_tag("linux_x86_64") == "linux_x86_64"
+
+        monkeypatch.setattr(module.platform, "system", lambda: "Linux")
+        monkeypatch.setattr(module.platform, "machine", lambda: "x86_64")
+        monkeypatch.setattr(module.platform, "libc_ver", lambda: ("glibc", "2.28"))
+        monkeypatch.setenv(module.PROVIDER_PLATFORM_TAG_ENV, "manylinux_2_28_x86_64")
+        assert module._provider_platform_tag("linux_x86_64") == "manylinux_2_28_x86_64"
+
+        monkeypatch.setenv(module.PROVIDER_PLATFORM_TAG_ENV, "manylinux_2_28_aarch64")
+        with pytest.raises(RuntimeError, match="Unsupported provider platform tag"):
+            module._provider_platform_tag("linux_x86_64")
+
+        monkeypatch.setenv(module.PROVIDER_PLATFORM_TAG_ENV, "manylinux_2_28_x86_64")
+        monkeypatch.setattr(module.platform, "libc_ver", lambda: ("glibc", "2.34"))
+        with pytest.raises(RuntimeError, match="glibc 2.34 is too new"):
+            module._provider_platform_tag("linux_x86_64")
     finally:
         sys.modules.pop(module_name, None)
 
@@ -254,6 +272,7 @@ def test_provider_wheelhouse_resolves_cu134_from_shared_config():
     )
     env.pop("CUDA_VERSION", None)
     env.pop("DOCKER_IMAGE", None)
+    env.pop("FLASHINFER_JIT_CACHE_PROVIDER_PLATFORM_TAG", None)
 
     result = subprocess.run(
         ["bash", str(script_path), "--print-config"],
@@ -267,6 +286,89 @@ def test_provider_wheelhouse_resolves_cu134_from_shared_config():
     assert "cuda_version=13.4" in result.stdout
     assert "pytorch_index=nightly/cu134" in result.stdout
     assert "container=pytorch/manylinuxaarch64-builder:cuda13.4" in result.stdout
+    assert "provider_platform_tag=manylinux_2_28_aarch64" in result.stdout
+
+
+def test_provider_wheelhouse_custom_container_defaults_to_native_tag():
+    script_path = (
+        Path(__file__).resolve().parents[2]
+        / "scripts"
+        / "build_jit_cache_provider_wheelhouse.sh"
+    )
+    env = os.environ.copy()
+    env.update(
+        {
+            "ARCH": "x86_64",
+            "DOCKER_IMAGE": "example.invalid/custom-builder:latest",
+            "FLASHINFER_JIT_CACHE_PROVIDER_ARCH": "10.7a",
+            "FLASHINFER_LOCAL_VERSION": "cu134",
+        }
+    )
+    env.pop("CUDA_VERSION", None)
+    env.pop("FLASHINFER_JIT_CACHE_PROVIDER_PLATFORM_TAG", None)
+
+    result = subprocess.run(
+        ["bash", str(script_path), "--print-config"],
+        check=True,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+    assert "container=example.invalid/custom-builder:latest" in result.stdout
+    assert "provider_platform_tag=native" in result.stdout
+
+
+@pytest.mark.parametrize(
+    "package_version",
+    ("0.6.18", "0.6.18+cu130", "0.6.18+cu134"),
+)
+def test_jit_cache_version_requires_exact_public_version(monkeypatch, package_version):
+    monkeypatch.delenv("FLASHINFER_DISABLE_VERSION_CHECK", raising=False)
+    monkeypatch.setattr(jit_env, "flashinfer_version", "0.6.18")
+
+    jit_env._check_jit_cache_version("flashinfer-jit-cache", package_version)
+
+
+def test_jit_cache_version_rejects_unbounded_prefix(monkeypatch):
+    monkeypatch.delenv("FLASHINFER_DISABLE_VERSION_CHECK", raising=False)
+    monkeypatch.setattr(jit_env, "flashinfer_version", "0.6.1")
+
+    with pytest.raises(RuntimeError, match="does not match flashinfer version"):
+        jit_env._check_jit_cache_version("flashinfer-jit-cache", "0.6.10+cu130")
+
+
+def test_jit_cache_build_setup_preserves_indexes_and_cleans_constraint(tmp_path):
+    common_script = (
+        Path(__file__).resolve().parents[2] / "scripts" / "jit_cache_build_common.sh"
+    )
+    fake_python = tmp_path / "python"
+    fake_python.write_text(
+        "#!/bin/bash\n"
+        'if [ "${1:-}" = "-c" ]; then\n'
+        "  printf '%s\\n' 'torch==2.9.0+cu130'\n"
+        "fi\n"
+    )
+    fake_python.chmod(0o755)
+    trap_marker = tmp_path / "trap-ran"
+    script = f"""
+set -euo pipefail
+trap 'touch "{trap_marker}"' EXIT
+source "{common_script}"
+export PIP_CONSTRAINT=/tmp/original-constraint
+export PIP_EXTRA_INDEX_URL=https://mirror.example/simple
+setup_jit_cache_python_build "{fake_python}" 13.0 cu130
+generated_constraint=${{PIP_CONSTRAINT}}
+test -f "${{generated_constraint}}"
+test "${{PIP_EXTRA_INDEX_URL}}" = "https://mirror.example/simple https://download.pytorch.org/whl/cu130"
+cleanup_jit_cache_python_build
+test ! -e "${{generated_constraint}}"
+test "${{PIP_CONSTRAINT}}" = /tmp/original-constraint
+"""
+
+    subprocess.run(["bash", "-c", script], check=True)
+
+    assert trap_marker.is_file()
 
 
 def test_native_provider_cuda_inspection_reports_no_ptx(

--- a/tests/jit/test_jit_cache_providers.py
+++ b/tests/jit/test_jit_cache_providers.py
@@ -70,14 +70,14 @@ def provider_package_config_module():
 
 
 @pytest.fixture
-def wheelhouse_verifier_module():
-    verifier_path = (
+def provider_validation_module():
+    validation_path = (
         Path(__file__).resolve().parents[2]
         / "scripts"
-        / "verify_jit_cache_provider_wheelhouse.py"
+        / "jit_cache_provider_validation.py"
     )
-    module_name = "_test_jit_cache_wheelhouse_verifier"
-    spec = importlib.util.spec_from_file_location(module_name, verifier_path)
+    module_name = "_test_jit_cache_provider_validation"
+    spec = importlib.util.spec_from_file_location(module_name, validation_path)
     assert spec is not None and spec.loader is not None
     module = importlib.util.module_from_spec(spec)
     sys.modules[module_name] = module
@@ -264,69 +264,6 @@ def test_provider_backend_uses_configured_build_dependencies(monkeypatch, tmp_pa
         sys.modules.pop(module_name, None)
 
 
-def test_provider_wheelhouse_resolves_cu134_from_shared_config():
-    script_path = (
-        Path(__file__).resolve().parents[2]
-        / "scripts"
-        / "build_jit_cache_provider_wheelhouse.sh"
-    )
-    env = os.environ.copy()
-    env.update(
-        {
-            "ARCH": "aarch64",
-            "FLASHINFER_JIT_CACHE_PROVIDER_ARCH": "12.1a",
-            "FLASHINFER_LOCAL_VERSION": "cu134",
-        }
-    )
-    env.pop("CUDA_VERSION", None)
-    env.pop("DOCKER_IMAGE", None)
-    env.pop("FLASHINFER_JIT_CACHE_PROVIDER_PLATFORM_TAG", None)
-
-    result = subprocess.run(
-        ["bash", str(script_path), "--print-config"],
-        check=True,
-        capture_output=True,
-        text=True,
-        env=env,
-    )
-
-    assert "provider=sm121a" in result.stdout
-    assert "cuda_version=13.4" in result.stdout
-    assert "pytorch_index=nightly/cu134" in result.stdout
-    assert "container=pytorch/manylinuxaarch64-builder:cuda13.4" in result.stdout
-    assert "provider_platform_tag=manylinux_2_28_aarch64" in result.stdout
-
-
-def test_provider_wheelhouse_custom_container_defaults_to_native_tag():
-    script_path = (
-        Path(__file__).resolve().parents[2]
-        / "scripts"
-        / "build_jit_cache_provider_wheelhouse.sh"
-    )
-    env = os.environ.copy()
-    env.update(
-        {
-            "ARCH": "x86_64",
-            "DOCKER_IMAGE": "example.invalid/custom-builder:latest",
-            "FLASHINFER_JIT_CACHE_PROVIDER_ARCH": "10.7a",
-            "FLASHINFER_LOCAL_VERSION": "cu134",
-        }
-    )
-    env.pop("CUDA_VERSION", None)
-    env.pop("FLASHINFER_JIT_CACHE_PROVIDER_PLATFORM_TAG", None)
-
-    result = subprocess.run(
-        ["bash", str(script_path), "--print-config"],
-        check=True,
-        capture_output=True,
-        text=True,
-        env=env,
-    )
-
-    assert "container=example.invalid/custom-builder:latest" in result.stdout
-    assert "provider_platform_tag=native" in result.stdout
-
-
 @pytest.mark.parametrize(
     "package_version",
     ("0.6.18", "0.6.18+cu130", "0.6.18+cu134"),
@@ -383,13 +320,13 @@ test "${{PIP_BUILD_CONSTRAINT}}" = /tmp/original-build-constraint
 
 
 def test_native_provider_cuda_inspection_reports_no_ptx(
-    monkeypatch, tmp_path, wheelhouse_verifier_module
+    monkeypatch, tmp_path, provider_validation_module
 ):
     wheel_path = tmp_path / "provider.whl"
     archive_path = "provider/jit_cache/test_module/test_module.so"
     with zipfile.ZipFile(wheel_path, "w") as archive:
         archive.writestr(archive_path, b"test")
-    wheel = wheelhouse_verifier_module.Wheel(
+    wheel = provider_validation_module.Wheel(
         path=wheel_path,
         distribution="flashinfer-jit-cache-sm120f",
         version="0.6.16+cu130",
@@ -413,9 +350,9 @@ def test_native_provider_cuda_inspection_reports_no_ptx(
             stderr="cuobjdump info: No PTX file found to extract\n",
         )
 
-    monkeypatch.setattr(wheelhouse_verifier_module.subprocess, "run", mock_run)
+    monkeypatch.setattr(provider_validation_module.subprocess, "run", mock_run)
 
-    architectures, ptx_modules = wheelhouse_verifier_module.inspect_cuda_architectures(
+    architectures, ptx_modules = provider_validation_module.inspect_cuda_architectures(
         wheel,
         {"test_module": archive_path},
         "sm120f",
@@ -428,13 +365,13 @@ def test_native_provider_cuda_inspection_reports_no_ptx(
 
 
 def test_native_provider_cuda_inspection_rejects_ptx(
-    monkeypatch, tmp_path, wheelhouse_verifier_module
+    monkeypatch, tmp_path, provider_validation_module
 ):
     wheel_path = tmp_path / "provider.whl"
     archive_path = "provider/jit_cache/test_module/test_module.so"
     with zipfile.ZipFile(wheel_path, "w") as archive:
         archive.writestr(archive_path, b"test")
-    wheel = wheelhouse_verifier_module.Wheel(
+    wheel = provider_validation_module.Wheel(
         path=wheel_path,
         distribution="flashinfer-jit-cache-sm120f",
         version="0.6.16+cu130",
@@ -455,10 +392,10 @@ def test_native_provider_cuda_inspection_rejects_ptx(
             cmd, 0, stdout="PTX file 1: test.compute_80.ptx\n", stderr=""
         )
 
-    monkeypatch.setattr(wheelhouse_verifier_module.subprocess, "run", mock_run)
+    monkeypatch.setattr(provider_validation_module.subprocess, "run", mock_run)
 
     with pytest.raises(ValueError, match="native-provider modules contain PTX"):
-        wheelhouse_verifier_module.inspect_cuda_architectures(
+        provider_validation_module.inspect_cuda_architectures(
             wheel,
             {"test_module": archive_path},
             "sm120f",


### PR DESCRIPTION
## 📌 Description

This PR turns `flashinfer-jit-cache` into a small top-level shim backed by independently installable, architecture-specific provider wheels. It retains legacy monolithic cache discovery as a fallback while adding:

- provider package metadata and entry-point discovery
- exact CUDA architecture matching, including suffixed targets such as `sm90a`, `sm120f`, and `sm121a`
- a default installation mode whose shim dependencies name the complete published provider set
- a minimal installation mode that selects only an explicitly requested or locally detected provider, with no implicit SM80 baseline
- provider wheelhouse build, binary inventory, installation, and JIT-disabled GPU smoke tooling
- AOT capability gating so unsupported modules, currently BGMV MoE on SM80, are omitted from that provider rather than failing its build

The provider matrix is intentionally independent of the size-pruned monolithic wheel matrix. Architecture-specific wheels may therefore preserve useful native targets such as SM121a without adding them back to every monolithic wheel. Native providers are SASS-only; the shim does not rely on PTX or an SM80 compatibility baseline.

## 🔍 Related Issues

- Follow-up design to #3265
- Incorporates current-main behavior from #4469, #4527, #4682, #4711, #4757, and #4760

## 🧪 Validation

### Provider canaries

Two end-to-end CUDA 13.0 canaries have exercised provider build, strict binary inspection, shim/provider installation, provider discovery, top-level import without CUTLASS DSL, and a JIT-disabled `silu_and_mul` numerical smoke:

| System | Target | Provider result |
| --- | --- | --- |
| x86_64 A100 test system | A100 / SM80 | 113.8 MiB; every CUDA-bearing module SM80-only; zero PTX |
| DGX Spark | aarch64 GB10 / SM121a | 173.0 MiB; 558 modules; every CUDA-bearing module SM121a-only; zero PTX |

The x86_64 A100 artifact was built before the final BGMV capability correction and contained 207 modules. Final-branch source-level SM80 AOT enumeration produces 206 modules with `bgmv_moe` absent, and the associated focused suite passed 30 tests. A final-head SM80 provider wheel still needs to be rebuilt to confirm that exact packaged inventory.

The Spark provider could load its packaged BGMV module, but a BGMV numerical invocation exceeded the device's dynamic shared-memory limit (approximately 216 KiB requested versus approximately 101 KiB available). That is a pre-existing kernel/runtime limitation and is outside this packaging change; the independent `silu_and_mul` provider smoke passed.

### Current branch and CI

- CodeRabbit passes and all inline review threads are resolved.
- Pre-commit, documentation, and public API/documentation checks pass.
- The existing monolithic release workflow passes for cu129, cu130, and cu134 on both x86_64 and aarch64. These jobs validate backward compatibility, not provider-wheel publication.
- The manually authorized [full PR test run](https://github.com/flashinfer-ai/flashinfer/actions/runs/33890607699) passes all four cu129/cu130 x64/arm64 AOT build-import jobs, all five A10G JIT shards, and the T4 JIT job. The H100 JIT job is still running as of September 4, 2026.
- After the latest review fixes, the focused provider suite passed on an x86_64 A100 test system in a disposable container: 25 passed, 1 warning. `pre-commit`, `bash -n`, and `git diff --check` also pass.

The branch is currently mergeable. It will be rebased onto `main` once more before merge; intervening main-branch changes reviewed so far do not alter the provider packaging or AOT capability implementation.

## Remaining Validation

Before enabling provider publication in a release workflow:

- let the current H100 PR test finish and address any real failure
- rebuild the final-head SM80 provider and repeat strict inventory, install, and GPU smoke validation
- build and inspect a real cu134 provider artifact; current cu134 CI covers only the legacy wheel and static configuration paths
- validate default all-provider installation plus minimal auto-detected and explicit-target installation against a multi-provider wheelhouse
- teach `scripts/update_whl_index.py` to recognize provider distribution names
- add an artifact-only shadow provider matrix to nightly/release automation and collect size, build-time, homogeneous GPU, and heterogeneous GPU results before changing the public release format

## Reviewer Notes

The main policy question is the explicit provider coverage matrix for each CUDA and CPU architecture. The current implementation makes the conservative choices: exact target matching, literal shim dependencies, no closest-lower-architecture inference, no implicit SM80 provider, and normal JIT compilation when no compatible AOT provider is available.

This is ready for human review of the package contract, installation UX, and release shape. The remaining items above are release-enablement validation rather than evidence that the architectural split itself has not been exercised.

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added experimental architecture-specific JIT-cache provider wheels with automatic discovery and legacy fallback.
  * Added `install-jit-cache-wheel` options for full or minimal installation and CUDA architecture selection.
  * Added tools to build, validate, and smoke-test provider packages.

* **Bug Fixes**
  * Improved architecture-aware AOT module selection and generation.
  * Prevented incompatible architectures from being selected automatically.

* **Documentation**
  * Documented provider-wheel configuration, installation modes, and experimental build options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
