### PR TITLE
[DO NOT MERGE] Demo: verify PR API/documentation bot

### DIFF
--- a/.claude/skills/pr-documentation-check-demo.md
+++ b/.claude/skills/pr-documentation-check-demo.md
@@ -1,3 +1,0 @@
-# PR documentation checker demo
-
-This temporary demo intentionally references `flashinfer/pr_checker_demo_missing.py`.

--- a/.claude/skills/pr-documentation-check-demo.md
+++ b/.claude/skills/pr-documentation-check-demo.md
@@ -1,0 +1,3 @@
+# PR documentation checker demo
+
+This temporary demo intentionally references `flashinfer/pr_checker_demo_missing.py`.

--- a/flashinfer/fused_moe/monomoe.py
+++ b/flashinfer/fused_moe/monomoe.py
@@ -25,6 +25,7 @@ kernel).  A tensor whose ``(E, N, K)`` is not this shape is rejected up front.
 
 import contextlib
 import functools
+import os
 from typing import Optional
 
 import torch
@@ -45,6 +46,9 @@ _MONOMOE_BS = 8  # BS8 kernel serves M <= 8
 _SCORING_SIGMOID = 0
 _SCORING_SOFTMAX = 1
 
+# DEMO ONLY: intentionally undocumented so the PR documentation bot reports it.
+_DEMO_MOE_DIAGNOSTICS = os.getenv("FLASHINFER_DEMO_MOE_DIAGNOSTICS")
+
 
 @functools.cache
 def _get_monomoe_module():
@@ -63,7 +67,7 @@ def _get_monomoe_module():
 
 
 @functools.cache
-@flashinfer_api
+# DEMO ONLY: @flashinfer_api intentionally removed to report an API break.
 def has_monomoe() -> bool:
     """Return True if the monomoe CUDA extension can be built and loaded."""
     try:
@@ -76,11 +80,7 @@ def has_monomoe() -> bool:
 @functools.cache
 @flashinfer_api
 def get_scratchpad_size_bytes() -> int:
-    """Return the global scratchpad size (bytes) required by the kernel.
-
-    Sourced from the C++ ``sizeof(MoEGemmSpec<Dims>)`` so the buffer can never
-    desync from the kernel's struct layout.
-    """
+    # DEMO ONLY: public API docstring intentionally removed.
     mod = _get_monomoe_module()
     return int(mod.monomoe_scratchpad_size())
 

--- a/flashinfer/fused_moe/monomoe.py
+++ b/flashinfer/fused_moe/monomoe.py
@@ -86,7 +86,13 @@ def get_scratchpad_size_bytes() -> int:
 
 
 @flashinfer_api
-def alloc_scratchpad(device: torch.device) -> torch.Tensor:
+def demo_unlisted_monomoe_api() -> bool:
+    """DEMO ONLY: expose an API that is intentionally absent from docs/api."""
+    return True
+
+
+@flashinfer_api
+def alloc_scratchpad(device: torch.device, demo_alignment: int) -> torch.Tensor:
     """Allocate a zero-initialized scratchpad on ``device`` for the kernel.
 
     Returns a 1-D ``uint8`` tensor sized to :func:`get_scratchpad_size_bytes`.

--- a/scripts/pr_checks/check_cross_sources.py
+++ b/scripts/pr_checks/check_cross_sources.py
@@ -403,7 +403,7 @@ def iter_markdown_path_locations(text: str) -> list[tuple[str, int]]:
     for match in _INLINE_CODE_RE.finditer(text):
         line_number = text.count("\n", 0, match.start()) + 1
         for path in _paths_in_fragment(match.group(1)):
-            paths.setdefault(path, line_number)
+            paths[path] = min(paths.get(path, line_number), line_number)
 
     in_fence = False
     for line_number, line in enumerate(text.splitlines(), 1):
@@ -412,7 +412,7 @@ def iter_markdown_path_locations(text: str) -> list[tuple[str, int]]:
             continue
         if in_fence or "|" in line:
             for path in _paths_in_fragment(_INLINE_CODE_RE.sub("", line)):
-                paths.setdefault(path, line_number)
+                paths[path] = min(paths.get(path, line_number), line_number)
     return list(paths.items())
 
 

--- a/scripts/pr_checks/check_cross_sources.py
+++ b/scripts/pr_checks/check_cross_sources.py
@@ -397,20 +397,28 @@ def _paths_in_fragment(fragment: str) -> list[str]:
     return paths
 
 
-def iter_markdown_paths(text: str) -> list[str]:
-    """Extract paths from code spans, fenced code blocks, and table rows."""
-    paths: list[str] = []
+def iter_markdown_path_locations(text: str) -> list[tuple[str, int]]:
+    """Extract paths and their first line from Markdown path-bearing contexts."""
+    paths: dict[str, int] = {}
     for match in _INLINE_CODE_RE.finditer(text):
-        paths.extend(_paths_in_fragment(match.group(1)))
+        line_number = text.count("\n", 0, match.start()) + 1
+        for path in _paths_in_fragment(match.group(1)):
+            paths.setdefault(path, line_number)
 
     in_fence = False
-    for line in text.splitlines():
+    for line_number, line in enumerate(text.splitlines(), 1):
         if line.lstrip().startswith("```"):
             in_fence = not in_fence
             continue
         if in_fence or "|" in line:
-            paths.extend(_paths_in_fragment(_INLINE_CODE_RE.sub("", line)))
-    return list(dict.fromkeys(paths))
+            for path in _paths_in_fragment(_INLINE_CODE_RE.sub("", line)):
+                paths.setdefault(path, line_number)
+    return list(paths.items())
+
+
+def iter_markdown_paths(text: str) -> list[str]:
+    """Extract paths from code spans, fenced code blocks, and table rows."""
+    return [path for path, _ in iter_markdown_path_locations(text)]
 
 
 def check_quickref_paths_exist() -> list[Finding]:
@@ -419,7 +427,7 @@ def check_quickref_paths_exist() -> list[Finding]:
     text = CLAUDE_MD.read_text("utf-8", "replace")
     out: list[Finding] = []
     seen: set[str] = set()
-    for path in iter_markdown_paths(text):
+    for path, line in iter_markdown_path_locations(text):
         # Skip URLs, glob-like patterns, env var demo strings
         if path.startswith(("http", "/")):
             continue
@@ -444,7 +452,9 @@ def check_quickref_paths_exist() -> list[Finding]:
         out.append(
             Finding(
                 check=QUICKREF_PATHS,
-                location="CLAUDE.md",
+                location=f"CLAUDE.md:{line}",
+                file="CLAUDE.md",
+                line=line,
                 message=f"Referenced path does not exist: `{path}`",
             )
         )
@@ -468,7 +478,7 @@ def check_skill_refs_exist() -> list[Finding]:
         except Exception:
             continue
 
-        for path in iter_markdown_paths(text):
+        for path, line in iter_markdown_path_locations(text):
             if path.startswith(("http", "/")):
                 continue
             if any(ch in path for ch in ("*", "?")):
@@ -483,7 +493,9 @@ def check_skill_refs_exist() -> list[Finding]:
             out.append(
                 Finding(
                     check=SKILL_REFS,
-                    location=str(rel),
+                    location=f"{rel}:{line}",
+                    file=str(rel),
+                    line=line,
                     message=f"Referenced path does not exist: `{path}`",
                 )
             )


### PR DESCRIPTION
## Purpose

Temporary, ready-for-review demo for the advisory API/documentation checker merged in #3917. **DO NOT MERGE.**

The PR retains the original Demo1/Demo2 scenarios and adds complementary API/doc cases. It also carries the Markdown line-location fix discovered during live verification.

## Intentional demo changes

All changes below are deliberately invalid and must not land:

1. Remove `@flashinfer_api` from `has_monomoe` → public API removal and stale RST entry.
2. Add required `demo_alignment` to `alloc_scratchpad` without updating its docstring → breaking signature and undocumented argument.
3. Add `demo_unlisted_monomoe_api` without an API RST entry → missing RST coverage.
4. Remove the `get_scratchpad_size_bytes` docstring → missing docstring.
5. Read `FLASHINFER_DEMO_MOE_DIAGNOSTICS` without documenting it → env-var documentation drift.
6. Add a nonexistent path to a temporary skill Markdown file → skill-reference drift with exact line reporting.

## Verified live

- ✅ [PR Documentation Checks / Public API and documentation](https://github.com/flashinfer-ai/flashinfer/actions/runs/31764702517/job/94658024035?pr=4516) is green.
- ✅ [Actions job summary](https://github.com/flashinfer-ai/flashinfer/actions/runs/31764702517?pr=4516#summary-94658024035) reports **2 public API findings** and **6 static documentation findings**.
- ✅ [Default-branch reporter](https://github.com/flashinfer-ai/flashinfer/actions/runs/31764751365) succeeded.
- ✅ [Sticky PR summary](https://github.com/flashinfer-ai/flashinfer/pull/4516#issuecomment-5288370330) contains all 8 report rows.
- ✅ The [original three-inline review](https://github.com/flashinfer-ai/flashinfer/pull/4516#pullrequestreview-4933288111) was preserved without duplicates.
- ✅ The [incremental three-inline review](https://github.com/flashinfer-ai/flashinfer/pull/4516#pullrequestreview-4933342926) added only the new findings.

### Inline findings

- [API removal](https://github.com/flashinfer-ai/flashinfer/pull/4516#discussion_r3780582169)
- [Breaking signature](https://github.com/flashinfer-ai/flashinfer/pull/4516#discussion_r3780631020)
- [Undocumented argument](https://github.com/flashinfer-ai/flashinfer/pull/4516#discussion_r3780631023)
- [Missing docstring](https://github.com/flashinfer-ai/flashinfer/pull/4516#discussion_r3780582172)
- [Undocumented env var](https://github.com/flashinfer-ai/flashinfer/pull/4516#discussion_r3780582173)
- [Broken skill reference](https://github.com/flashinfer-ai/flashinfer/pull/4516#discussion_r3780631026)

The two API↔RST findings use the synthetic `docs/api:1` location and are therefore shown in the sticky summary rather than as inline comments. Findings remain advisory: the checker job stays green.

## Local verification

- `scripts/check_pr_api_diff.py`: 2 findings
- `scripts/check_pr_document.py`: 6 new findings
- Focused Markdown path-location assertions passed, including duplicate paths across fenced and inline contexts
- Pre-commit passed for all changed files

## Cleanup

Close this PR after demonstration. The intentional regressions must never be merged. **DO NOT MERGE.**