### PR TITLE
fix(ci): correct documentation finding locations and skipped runs

### DIFF
--- a/.github/workflows/pr-api-doc-comment.yml
+++ b/.github/workflows/pr-api-doc-comment.yml
@@ -15,7 +15,9 @@ jobs:
     concurrency:
       group: pr-documentation-${{ github.event.workflow_run.head_repository.full_name }}-${{ github.event.workflow_run.head_sha }}
       cancel-in-progress: false
-    if: github.event.workflow_run.event == 'pull_request'
+    if: >-
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion != 'skipped'
     continue-on-error: true
     runs-on: ubuntu-latest
     steps:

--- a/scripts/pr_checks/check_cross_sources.py
+++ b/scripts/pr_checks/check_cross_sources.py
@@ -397,20 +397,28 @@ def _paths_in_fragment(fragment: str) -> list[str]:
     return paths
 
 
-def iter_markdown_paths(text: str) -> list[str]:
-    """Extract paths from code spans, fenced code blocks, and table rows."""
-    paths: list[str] = []
+def iter_markdown_path_locations(text: str) -> list[tuple[str, int]]:
+    """Extract paths and their first line from Markdown path-bearing contexts."""
+    paths: dict[str, int] = {}
     for match in _INLINE_CODE_RE.finditer(text):
-        paths.extend(_paths_in_fragment(match.group(1)))
+        line_number = text.count("\n", 0, match.start()) + 1
+        for path in _paths_in_fragment(match.group(1)):
+            paths[path] = min(paths.get(path, line_number), line_number)
 
     in_fence = False
-    for line in text.splitlines():
+    for line_number, line in enumerate(text.splitlines(), 1):
         if line.lstrip().startswith("```"):
             in_fence = not in_fence
             continue
         if in_fence or "|" in line:
-            paths.extend(_paths_in_fragment(_INLINE_CODE_RE.sub("", line)))
-    return list(dict.fromkeys(paths))
+            for path in _paths_in_fragment(_INLINE_CODE_RE.sub("", line)):
+                paths[path] = min(paths.get(path, line_number), line_number)
+    return list(paths.items())
+
+
+def iter_markdown_paths(text: str) -> list[str]:
+    """Extract paths from code spans, fenced code blocks, and table rows."""
+    return [path for path, _ in iter_markdown_path_locations(text)]
 
 
 def check_quickref_paths_exist() -> list[Finding]:
@@ -419,7 +427,7 @@ def check_quickref_paths_exist() -> list[Finding]:
     text = CLAUDE_MD.read_text("utf-8", "replace")
     out: list[Finding] = []
     seen: set[str] = set()
-    for path in iter_markdown_paths(text):
+    for path, line in iter_markdown_path_locations(text):
         # Skip URLs, glob-like patterns, env var demo strings
         if path.startswith(("http", "/")):
             continue
@@ -444,7 +452,9 @@ def check_quickref_paths_exist() -> list[Finding]:
         out.append(
             Finding(
                 check=QUICKREF_PATHS,
-                location="CLAUDE.md",
+                location=f"CLAUDE.md:{line}",
+                file="CLAUDE.md",
+                line=line,
                 message=f"Referenced path does not exist: `{path}`",
             )
         )
@@ -468,7 +478,7 @@ def check_skill_refs_exist() -> list[Finding]:
         except Exception:
             continue
 
-        for path in iter_markdown_paths(text):
+        for path, line in iter_markdown_path_locations(text):
             if path.startswith(("http", "/")):
                 continue
             if any(ch in path for ch in ("*", "?")):
@@ -483,7 +493,9 @@ def check_skill_refs_exist() -> list[Finding]:
             out.append(
                 Finding(
                     check=SKILL_REFS,
-                    location=str(rel),
+                    location=f"{rel}:{line}",
+                    file=str(rel),
+                    line=line,
                     message=f"Referenced path does not exist: `{path}`",
                 )
             )


### PR DESCRIPTION
## Summary

- Preserve the source line of paths extracted from inline code, fenced blocks, and Markdown tables.
- Populate `file` and `line` for `quickref_paths_exist` and `skill_refs_exist` findings.
- Use the earliest source line when the same path occurs more than once.
- Skip the write-capable reporter when the producer workflow concludes `skipped`.

## Problems

Markdown path findings discarded source positions, so the PR adapter fell back to line 1 and inline comments could be attached to the wrong line or fail to post when line 1 was not commentable.

Draft pull requests intentionally skip the producer job and therefore do not create report artifacts. The `workflow_run` reporter still ran for those skipped producers and incorrectly rendered the expected absence of reports as `ADVISORY CHECKER REPORT IS INCOMPLETE`.

## Behavior after this change

- Quick-reference and skill-reference findings carry their actual file and earliest source line.
- The reporter does not run for a producer workflow whose conclusion is `skipped`.
- A producer that actually runs but fails to upload valid reports still reaches the reporter and retains the incomplete-report warning.
- When a draft PR becomes ready for review, the producer runs normally and the reporter resumes normal sticky/inline behavior.

## Scope

- Keep `iter_markdown_paths()` as a compatibility wrapper.
- Do not change inline-comment deduplication or historical-comment cleanup.
- Do not include temporary demo regressions.

## Verification

- Focused assertions cover inline code, fenced blocks, table rows, compatibility output, and duplicate paths choosing the earliest line.
- Workflow YAML parsed successfully.
- `pre-commit run --files .github/workflows/pr-api-doc-comment.yml scripts/pr_checks/check_cross_sources.py`
- `scripts/check_pr_api_diff.py --base origin/main --head HEAD`: 0 findings
- `scripts/check_pr_document.py --base origin/main --head HEAD`: 0 new findings