### PR TITLE
fix(gdn): keep FP8 states off SM100 CP path

### DIFF
--- a/flashinfer/gdn_prefill.py
+++ b/flashinfer/gdn_prefill.py
@@ -57,6 +57,7 @@ def _cp_delta_rule_rejection_reason(
     beta: Optional[torch.Tensor],
     output: torch.Tensor,
     initial_state: Optional[torch.Tensor],
+    output_state: Optional[torch.Tensor],
     checkpoint_every_n_tokens: int,
     state_checkpoints: Optional[torch.Tensor],
     checkpoint_cu_starts: Optional[torch.Tensor],
@@ -87,6 +88,19 @@ def _cp_delta_rule_rejection_reason(
         return f"CP delta rule only supports fp16/bf16 inputs, got {q.dtype}"
     if k.dtype != q.dtype or v.dtype != q.dtype or output.dtype != q.dtype:
         return "CP delta rule requires q/k/v/output dtypes to match"
+    if arch_major == 10:
+        for name, tensor in (
+            ("initial_state", initial_state),
+            ("output_state", output_state),
+        ):
+            if tensor is not None and tensor.dtype in (
+                torch.float8_e4m3fn,
+                torch.float8_e5m2,
+            ):
+                return (
+                    f"CP delta rule SM100 does not support FP8 {name}, "
+                    f"got {tensor.dtype}"
+                )
     for name, tensor in (("g", g), ("beta", beta)):
         if tensor is not None:
             if tensor.dtype != torch.float32:
@@ -394,6 +408,7 @@ def chunk_gated_delta_rule(
             beta=beta,
             output=output,
             initial_state=initial_state,
+            output_state=output_state,
             checkpoint_every_n_tokens=checkpoint_every_n_tokens,
             state_checkpoints=state_checkpoints,
             checkpoint_cu_starts=checkpoint_cu_starts,

--- a/tests/gdn/test_prefill_delta_rule.py
+++ b/tests/gdn/test_prefill_delta_rule.py
@@ -1064,6 +1064,7 @@ def _test_prefill_kernel_state_dtype(
     seq_lens: list[int],
     scale: float,
     seed: int | None = None,
+    use_cp: str | bool = False,
 ):
     _skip_if_not_sm100()
 
@@ -1122,7 +1123,7 @@ def _test_prefill_kernel_state_dtype(
         True,
         output=our_o,
         output_state=our_state,
-        use_cp=False,
+        use_cp=use_cp,
     )
 
     torch.cuda.synchronize()
@@ -1195,3 +1196,22 @@ def test_prefill_kernel_state_dtype(
         scale,
         seed=seed,
     )
+
+
+@pytest.mark.parametrize("state_dtype", [torch.float8_e4m3fn, torch.float8_e5m2])
+def test_prefill_auto_dispatch_fp8_state(qkv_factory, state_dtype: torch.dtype):
+    with pytest.warns(
+        RuntimeWarning, match="FP8 initial_state.*falling back to non-CP"
+    ):
+        _test_prefill_kernel_state_dtype(
+            qkv_factory,
+            "bfloat16",
+            state_dtype,
+            1,
+            1,
+            1,
+            128,
+            [64],
+            1.0 / math.sqrt(128),
+            use_cp="auto",
+        )


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

SM100's non-CP GDN prefill kernel supports FP8 recurrent states, but the CP
kernel currently accepts only float32, bfloat16, and float16 states. The public
`use_cp="auto"` rejection check did not account for that difference, so an
otherwise valid FP8 state could be routed to CP and fail depending on whether
the shape matched the CP heuristic.

This change rejects FP8 `initial_state` and `output_state` from the SM100 CP
path. Automatic dispatch falls back to the FP8-capable non-CP kernel, while an
explicit `use_cp=True` reports the existing capability error before launch.

The regression test covers both SM100-supported FP8 state formats with a
low-parallelism shape that matches the CP heuristic and checks the non-CP
result against the existing numerical reference.

## 🔍 Related Issues

None.

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

Validation performed locally:

- `ruff format` and `ruff check` on the changed files
- `git diff --check`
- direct dispatcher check for E4M3/E5M2 `initial_state` and `output_state`
- targeted pytest collection/execution: 2 skipped because the available GPU is SM86; the numerical regression requires SM100

## Reviewer Notes

Please run `tests/gdn/test_prefill_delta_rule.py::test_prefill_auto_dispatch_fp8_state`
on an SM100/SM103 system with CUDA 13.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for FP8 initial and output states on SM100 hardware.
  * Added automatic fallback handling when context parallelism is unsupported for FP8 state tensors.
  * Ensured affected prefill operations emit an appropriate warning and continue using a supported execution path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->