### PR TITLE
fix(xqa): out-of-bounds read of attention sinks in SM90 kernel epilogue

### DIFF
--- a/csrc/xqa/mha_sm90.cu
+++ b/csrc/xqa/mha_sm90.cu
@@ -1880,11 +1880,12 @@ __device__ inline RegColWiseVec loadGmemColWiseVecWithDup(ShmQWiseVec const& gme
   for (uint32_t i = 0; i < exactDiv(ShmQWiseVec::size, gmma::instNBase); i++) {
     static_assert(nbThrdsPerInstNBase * RegColWiseVec::size ==
                   exactDiv(ShmQWiseVec::size, GmmaAccCoreMat::cols));
-    uint32_t const clampedIdx = mha::min(i * nbThrdsPerInstNBase + idx, bound);
-    uint32_t const baseOffset = clampedIdx * GmmaAccCoreMat::cols;
+    uint32_t const baseOffset = (i * nbThrdsPerInstNBase + idx) * GmmaAccCoreMat::cols;
 #pragma unroll
     for (uint32_t j = 0; j < GmmaAccCoreMat::cols; j++) {
-      ret[i][j] = gmemVec[baseOffset + j];
+      // Clamp per element: `bound` is the max valid element index and the gmem vector holds only
+      // bound+1 floats (< ShmQWiseVec::size). Padding lanes duplicate the last valid element.
+      ret[i][j] = gmemVec[mha::min(baseOffset + j, bound)];
     }
   }
   return ret;


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->


Fixes an out-of-bounds global read reported by compute-sanitizer initcheck on `tests/attention/test_xqa_batch_decode.py`, H100. (does not impact other archs)

**Issue:** In `loadGmemColWiseVecWithDup` (`csrc/xqa/mha_sm90.cu`), the bounds clamp is applied to a pair-group index but `bound` is an element index (`headGrpSize - 1`), and the clamped index is then scaled by `GmmaAccCoreMat::cols`. The attention-sinks array holds only `headGrpSize` floats while `ShmQWiseVec` is padded to `roundUp(headGrpSize, 8)`, so whenever `headGrpSize % 8 != 0` and sinks are enabled, padding lanes read up to 12 bytes past the end of the sinks tensor. Results are unaffected in practice (the stray values only feed padding lanes that are masked at write-out), but the read targets unrelated memory.
  
**Fix:** clamp per element — `gmemVec[mha::min(baseOffset + j, bound)]` — so padding lanes duplicate the last valid element, matching the multi-block combine path's existing convention.
  
**Compute-sanitizer results** (H100, `head_group_ratio=5`, fp8 KV, sinks enabled; memcheck +
`PYTORCH_NO_CUDA_MEMORY_CACHING=1` reproduces the report deterministically): 
- Before: 64× `Invalid __global__ read of size 4 bytes` at `kernel_mha+0x2d30` ("5 bytes after the nearest allocation of size 40 bytes" = the sinks tensor) — same kernel/offset as the original initcheck record.
- After: `ERROR SUMMARY: 0 errors` (memcheck and initcheck). Affected test subsets pass unchanged (`head_group_ratio` 5 and 6 configs).

**No performance regression:** the change is two branchless integer clamps in the once-per-CTA epilogue, executed only when sinks are enabled. A/B on the affected config (H100, batch 128, 4K KV): 77.1 µs before vs 76.9 µs after — identical within noise.


## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where padded lanes could read beyond valid vector data during certain operations.
  * Improved handling of final duplicated elements when vector widths do not align with the accumulator width.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->