### PR TITLE
WIP jit-cache wheel size fix: drop 12.1a from the cu129 aarch64 jit-cache wheel

### DIFF
--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -157,7 +157,9 @@ jobs:
       - name: Build wheel in container
         env:
           DOCKER_IMAGE: ${{ matrix.arch == 'aarch64' && format('pytorch/manylinuxaarch64-builder:cuda{0}', matrix.cuda) || format('pytorch/manylinux2_28-builder:cuda{0}', matrix.cuda) }}
-          FLASHINFER_CUDA_ARCH_LIST: ${{ matrix.cuda < '12.9' && '7.5 8.0 8.9 9.0a 10.0a 12.0a' || (matrix.cuda < '13.0' && (matrix.arch == 'aarch64' && '7.5 8.0 8.9 9.0a 10.0a 10.3a 12.0f 12.1a' || '7.5 8.0 8.9 9.0a 10.0a 10.3a 12.0f') || (matrix.arch == 'aarch64' && '7.5 8.0 8.9 9.0a 10.0a 10.3a 11.0a 12.0f 12.1a' || '7.5 8.0 8.9 9.0a 10.0a 10.3a 12.0f')) }}
+          # 12.1a is CUDA 13.0 aarch64 only: adding it to cu129 aarch64 too (#3684) pushed that
+          # wheel to 2.14 GiB, past GitHub's 2 GiB release-asset limit (#4519).
+          FLASHINFER_CUDA_ARCH_LIST: ${{ matrix.cuda < '12.9' && '7.5 8.0 8.9 9.0a 10.0a 12.0a' || (matrix.cuda < '13.0' && '7.5 8.0 8.9 9.0a 10.0a 10.3a 12.0f' || (matrix.arch == 'aarch64' && '7.5 8.0 8.9 9.0a 10.0a 10.3a 11.0a 12.0f 12.1a' || '7.5 8.0 8.9 9.0a 10.0a 10.3a 12.0f')) }}
           FLASHINFER_DEV_RELEASE_SUFFIX: ${{ needs.setup.outputs.dev_suffix }}
         run: |
           # Extract CUDA major and minor versions

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -192,7 +192,9 @@ jobs:
       - name: Build wheel in container
         env:
           DOCKER_IMAGE: ${{ matrix.arch == 'aarch64' && format('pytorch/manylinuxaarch64-builder:cuda{0}', matrix.cuda) || format('pytorch/manylinux2_28-builder:cuda{0}', matrix.cuda) }}
-          FLASHINFER_CUDA_ARCH_LIST: ${{ matrix.cuda < '12.9' && '7.5 8.0 8.9 9.0a 10.0a 12.0a' || (matrix.cuda < '13.0' && (matrix.arch == 'aarch64' && '7.5 8.0 8.9 9.0a 10.0a 10.3a 12.0f 12.1a' || '7.5 8.0 8.9 9.0a 10.0a 10.3a 12.0f') || (matrix.arch == 'aarch64' && '7.5 8.0 8.9 9.0a 10.0a 10.3a 11.0a 12.0f 12.1a' || '7.5 8.0 8.9 9.0a 10.0a 10.3a 12.0f')) }}
+          # 12.1a is CUDA 13.0 aarch64 only: adding it to cu129 aarch64 too (#3684) pushed that
+          # wheel to 2.14 GiB, past GitHub's 2 GiB release-asset limit (#4519).
+          FLASHINFER_CUDA_ARCH_LIST: ${{ matrix.cuda < '12.9' && '7.5 8.0 8.9 9.0a 10.0a 12.0a' || (matrix.cuda < '13.0' && '7.5 8.0 8.9 9.0a 10.0a 10.3a 12.0f' || (matrix.arch == 'aarch64' && '7.5 8.0 8.9 9.0a 10.0a 10.3a 11.0a 12.0f 12.1a' || '7.5 8.0 8.9 9.0a 10.0a 10.3a 12.0f')) }}
         run: |
           # Extract CUDA major and minor versions
           CUDA_MAJOR=$(echo "${{ matrix.cuda }}" | cut -d'.' -f1)


### PR DESCRIPTION
## 📌 Description

#3684 added `12.1a` to the aarch64 arch lists for **both** cu129 and cu130. Wheel sizes from the Actions artifact API, last good nightly (Aug 11) vs Aug 14:

| wheel | Aug 11 | Aug 14 | headroom vs 2 GiB |
| --- | --- | --- | --- |
| cu128 x86_64 | 1.238 | 1.274 | 743 MiB |
| cu128 aarch64 | 1.228 | 1.264 | 753 MiB |
| cu129 x86_64 | 1.861 | 1.906 | 96 MiB |
| **cu129 aarch64** | 1.848 | **2.143** | **−147 MiB** |
| cu130 x86_64 | 1.445 | 1.480 | 533 MiB |
| cu130 aarch64 | 1.619 | 1.852 | 151 MiB |

Only cu129 aarch64 is actually over. The cu130 wheels are missing from those releases as collateral: the upload loop is `for cuda in 128 129 130; do for arch in x86_64 aarch64` under `shell: bash -e`, so it aborts on the 4th asset and never attempts the cu130 pair.

Subtracting each aarch64 wheel's delta from its same-CUDA x86_64 delta prices the new target at **+256 MiB** on cu129 aarch64 and +204 MiB on cu130 aarch64. Removing it from cu129 aarch64 lands that wheel at roughly **1.893 GiB** (~110 MiB headroom). cu130 aarch64 keeps `12.1a` and fits at 1.852 GiB.

## 🔍 Related Issues

Fixes #4519. Caused by #3684. Wheel splitting (#4514) remains the durable fix —
cu129 x86_64 has only 96 MiB left and grew ~2.8 MiB/day between Jul 22 and Aug 12.

## 🚀 Pull Request Checklist

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

Workflow-only change; there is no unit test for the release matrix. Verified by
parsing both workflows as YAML and evaluating the expression for all six matrix
entries (table above).

## Reviewer Notes

Two questions worth a maintainer's call before this comes out of draft:

1. @jethachan — does SM121 need a warm AOT cache on **CUDA 12.9 aarch64** specifically,
   or is cu130 aarch64 sufficient? #3684's validation notes cover GB10 and RTX PRO 6000
   but do not say which CUDA minor was used.
2. The alternative is to keep `12.1a` and instead land per-module filtering in the style
   of #3947. That needs a minor-version filter added to `get_nvcc_flags_list`, which today
   filters on major version only — more invasive than seems wise for v0.6.18.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated CUDA 12.9 wheel builds to use a consistent architecture set across platforms.
  * Preserved the specialized architecture target for CUDA 13.0 ARM64 builds.
  * Documented wheel-size constraints for affected builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->