### PR TITLE
fix(build): restore the nixl v1.3.1 submodule pin accidentally rolled back in #3759

### DIFF
--- a/build_backend.py
+++ b/build_backend.py
@@ -165,6 +165,15 @@ def _apply_patches(submodule_dir: Path, patches_dir: Path) -> None:
         print(f"[BUILD_NVEP] applied patch: {patch.name}")
 
 
+# NIXL wheel version for the non-hermetic EP build. Pin EXACTLY to the
+# 3rdparty/nixl submodule tag: nixl_ep_cpp.so is compiled from the submodule's
+# device kernels but loads the wheel's libnixl.so at runtime, and a version
+# skew (e.g. a 1.4.x wheel against the v1.3.1 kernels) fails at runtime with
+# device asserts (nixlPut != NIXL_IN_PROG -> illegal memory access). Bump this
+# and the submodule gitlink together.
+_NIXL_WHEEL_VERSION = "1.3.1"
+
+
 def _find_nixl_wheel_lib_dir() -> Path | None:
     """Locate the nixl-cu* pip wheel's libnixl.so directory.
 
@@ -248,7 +257,7 @@ def _build_nixl_ep() -> None:
             raise RuntimeError(
                 "The NIXL-EP build requires the nixl-cu13 wheel (the build "
                 "hook normally pre-installs it; see _ensure_nixl_wheel).\n"
-                "Run: uv pip install --no-deps 'nixl-cu13>=1.3.1'\n"
+                "Run: uv pip install --no-deps 'nixl-cu13==1.3.1'\n"
                 "Or set BUILD_NIXL_EP_HERMETIC=1 to build the full NIXL tree."
             )
         setup_args += [
@@ -535,9 +544,31 @@ def _ensure_nixl_wheel() -> None:
     missing wheel and the backend is gated as usual (skip or hard error).
     """
     if _find_nixl_wheel_lib_dir() is not None:
+        # A wheel is present — but only the pinned version is safe (see
+        # _NIXL_WHEEL_VERSION). Warn on skew instead of silently linking
+        # against a mismatched libnixl; --no-deps reinstalls are cheap, but
+        # downgrading behind the user's back would be surprising.
+        try:
+            from importlib.metadata import PackageNotFoundError, version
+
+            for pkg in ("nixl-cu13", "nixl-cu12", "nixl"):
+                try:
+                    found = version(pkg)
+                except PackageNotFoundError:
+                    continue
+                if found != _NIXL_WHEEL_VERSION:
+                    print(
+                        f"[BUILD_NVEP] WARNING: {pkg} {found} is installed but "
+                        f"the 3rdparty/nixl kernels are v{_NIXL_WHEEL_VERSION}; "
+                        "a version skew fails at runtime with device asserts. "
+                        f"Run: pip install --no-deps '{pkg}=={_NIXL_WHEEL_VERSION}'"
+                    )
+                break
+        except Exception:
+            pass
         return
     cuda_major = _detect_cuda_major()
-    wheel = f"nixl-cu{cuda_major}>=1.3.1"
+    wheel = f"nixl-cu{cuda_major}=={_NIXL_WHEEL_VERSION}"
     print(f"[BUILD_NVEP] pre-installing NIXL wheel --no-deps: {wheel}")
 
     uv_bin = shutil.which("uv")
@@ -628,7 +659,7 @@ def _nixl_buildable() -> tuple[bool, str]:
         if _find_nixl_wheel_lib_dir() is None:
             return False, (
                 "nixl pip wheel not importable (or libnixl.so missing); install with "
-                "`uv pip install --no-deps 'nixl-cu13>=1.3.1'` "
+                "`uv pip install --no-deps 'nixl-cu13==1.3.1'` "
                 "or set BUILD_NIXL_EP_HERMETIC=1 to build the full NIXL tree"
             )
     return True, ""
@@ -664,7 +695,7 @@ def _install_nvep_runtime_wheels(built_nixl: bool) -> None:
     cuda_major = _detect_cuda_major()
     wheels: list[str] = []
     if built_nixl:
-        wheels.append(f"nixl-cu{cuda_major}>=1.3.1")
+        wheels.append(f"nixl-cu{cuda_major}=={_NIXL_WHEEL_VERSION}")
     if not wheels:
         return
 
@@ -835,7 +866,7 @@ def _build_nvep_if_enabled() -> None:
             "source, disable isolation:\n"
             "    pip install --no-build-isolation .\n"
             "If NIXL-EP libs were still staged, install the runtime wheel "
-            "manually afterwards: pip install --no-deps 'nixl-cu13>=1.3.1'.",
+            "manually afterwards: pip install --no-deps 'nixl-cu13==1.3.1'.",
             flush=True,
         )
 

--- a/flashinfer/moe_ep/backends/split/comm/nixl_ep/__init__.py
+++ b/flashinfer/moe_ep/backends/split/comm/nixl_ep/__init__.py
@@ -112,8 +112,8 @@ def _preload_libnixl() -> None:
             raise MoEEpNotBuiltError(
                 "Could not locate the NIXL runtime libraries. Install with "
                 "one of:\n"
-                "    uv pip install --no-deps 'nixl-cu13>=1.3.1'\n"
-                "    pip install --no-deps 'nixl-cu13>=1.3.1'\n"
+                "    uv pip install --no-deps 'nixl-cu13==1.3.1'\n"
+                "    pip install --no-deps 'nixl-cu13==1.3.1'\n"
                 "or set LD_LIBRARY_PATH to a directory containing libnixl.so."
             ) from e
 
@@ -124,7 +124,7 @@ def _preload_libnixl() -> None:
         raise MoEEpNotBuiltError(
             f"libnixl.so is missing from the NIXL wheel lib dir at "
             f"{nixl_lib_dir}. Reinstall: "
-            "uv pip install --no-deps 'nixl-cu13>=1.3.1'"
+            "uv pip install --no-deps 'nixl-cu13==1.3.1'"
         )
     for libname in _NIXL_BASE_LIBS:
         libpath = nixl_lib_dir / libname
@@ -137,7 +137,7 @@ def _preload_libnixl() -> None:
                 f"Failed to load NIXL base lib {libpath}: {e}. The wheel "
                 "may be corrupted or built against a different glibc/CUDA. "
                 "Reinstall with: "
-                "uv pip install --force-reinstall --no-deps 'nixl-cu13>=1.3.1'"
+                "uv pip install --force-reinstall --no-deps 'nixl-cu13==1.3.1'"
             ) from e
 
 

--- a/flashinfer/moe_ep/backends/split/comm/nixl_ep/__init__.py
+++ b/flashinfer/moe_ep/backends/split/comm/nixl_ep/__init__.py
@@ -124,7 +124,7 @@ def _preload_libnixl() -> None:
         raise MoEEpNotBuiltError(
             f"libnixl.so is missing from the NIXL wheel lib dir at "
             f"{nixl_lib_dir}. Reinstall: "
-            "uv pip install --no-deps 'nixl-cu13==1.3.1'"
+            "uv pip install --force-reinstall --no-deps 'nixl-cu13==1.3.1'"
         )
     for libname in _NIXL_BASE_LIBS:
         libpath = nixl_lib_dir / libname


### PR DESCRIPTION
## 📌 Description

PR #3759 (FP8 quantized two-shot AllReduce) unintentionally rolled the `3rdparty/nixl` gitlink back from v1.3.1 (`b20f4d0a`, pinned by #4075) to v1.1.0 (`05e4243f`) — that PR touches only `flashinfer/comm/` quantized-allreduce code and never mentions nixl, so this looks like a stale submodule pointer that slipped into the commit. cc @kailashbuki to confirm.

Main's NIXL-EP build tooling has targeted v1.3.1 since #4075 (which set this pin and refreshed the EP patches), while the gitlink now points at v1.1.0 again, so every `BUILD_NIXL_EP=1` install is broken at TOT (both verified against clean v1.1.0 / v1.3.1 checkouts):
- `3rdparty_patches/nixl/0002-ep-only-build.patch` no longer applies to the v1.1.0 tree (`error: patch failed: meson_options.txt:49`).
- `build_backend.py` passes `-Dnixl_cuda_arch_list`, a meson option that doesn't exist in v1.1.0 (added in NIXL v1.2.0, ai-dynamo/nixl#1639), so `meson setup` would fail even if the patch applied.

## 🔧 Changes

- **`3rdparty/nixl`**: gitlink restored to v1.3.1 (`b20f4d0a`).
- **`build_backend.py`**: the nixl-cu13 wheel is now installed `==1.3.1` via `_NIXL_WHEEL_VERSION` (bump together with the gitlink) instead of `>=1.3.1`. A 1.4.x wheel over the v1.3.1 device kernels builds and imports fine, then dies at the first dispatch with device asserts (`nixlPut != NIXL_IN_PROG` → `cudaErrorIllegalAddress`); the hook now also warns when an already-installed wheel skews from the pin.

## ✅ Validation

Pipecleaned on 8x B200 with this pin: `BUILD_NIXL_EP=1` build from a clean checkout, NIXL-EP transport smoke + low-latency dispatch sweep across DeepSeek-V3/V4, Kimi-K2, and Qwen3.5-397B shapes — all passing. Patch applicability re-verified against pristine v1.1.0 and v1.3.1 trees.

## 🧪 Test coverage

No new tests; this restores the pin the existing NIXL-EP path (merged in #4075) was built and tested against. Existing multi-GPU EP tests cover the transport.

AI-assisted (Claude Code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized NIXL installation and wheel handling on the exact version 1.3.1.
  * Added clearer warnings and corrective installation guidance when a different NIXL version is detected.
  * Updated missing-wheel and runtime installation messages to reference `nixl-cu13==1.3.1`.
  * Updated the bundled NIXL integration to align with the supported release and improve compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->