### PR TITLE
bugfix: fix both blk64 block-sparse attention hangs on Blackwell (SM103 CLC scheduler, correction reduce barrier ids)

### DIFF
--- a/flashinfer/cute_dsl/sparse/sm100_blk64/flash_fwd_kernel_sm100.h
+++ b/flashinfer/cute_dsl/sparse/sm100_blk64/flash_fwd_kernel_sm100.h
@@ -255,6 +255,15 @@ struct FusedAttnFwdSm100 {
     CollectiveEpilogue epilogue;
 
     if (warp_idx == kSchedWarp) {
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ == 1030
+      // SM103 uses one statically assigned tile per CTA; worker warps
+      // rendezvous in consumer_advance().  Keep this warp alive until the
+      // worker-side completion flag is visible so the CTA cannot retire early.
+      while (*reinterpret_cast<volatile int*>(&shared_storage.tmem_ready) != 2) {
+      }
+      __threadfence_block();
+      return;
+#else
       // ===== WG3 warp 15: CLC scheduler (lane 0 only) =====
       // Only lane 0 runs the scheduling loop (matching original pattern).
       // producer_tail drains the pipeline on exit.
@@ -273,6 +282,7 @@ struct FusedAttnFwdSm100 {
         }
         // producer_tail intentionally omitted (matches original)
       }
+#endif
     } else if (warp_idx == kMmaWarp) {
       // ===== WG3 warp 12: MMA (TMEM alloc here) =====
       tmem_alloc.allocate(TmemAllocator::Sm100TmemCapacityColumns, &shared_storage.tmem_base_ptr);
@@ -294,6 +304,13 @@ struct FusedAttnFwdSm100 {
                                  shared_storage, tmem_base, tile_nkv, mma_state);
         work = tile_sched.consumer_advance();
       }
+
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ == 1030
+      if (lane_idx == 0) {
+        __threadfence_block();
+        *reinterpret_cast<volatile int*>(&shared_storage.tmem_ready) = 2;
+      }
+#endif
 
       tmem_alloc.free(shared_storage.tmem_base_ptr, TmemAllocator::Sm100TmemCapacityColumns);
     } else if (warp_idx == kEpiWarp) {

--- a/flashinfer/cute_dsl/sparse/sm100_blk64/flash_fwd_kernel_sm100.h
+++ b/flashinfer/cute_dsl/sparse/sm100_blk64/flash_fwd_kernel_sm100.h
@@ -80,16 +80,22 @@ struct FusedAttnFwdSm100 {
   static constexpr int kRegsOther = 56;
 
   // ---- Named barriers (used by both mainloop softmax and mainloop correction) ----
-  // IDs 0-7: per-warp sm_stats (BSA pattern: bar.arrive + bar.sync for SMEM visibility).
+  // User IDs 0-7: per-warp sm_stats (BSA pattern: bar.arrive + bar.sync for SMEM visibility).
   //   stage(0,1) x warp(0,1,2,3) = 8 barriers, 64 threads each (32 softmax + 32 correction).
   //   Softmax: bar.arrive (non-blocking), Correction: bar.arrive_and_wait (blocking).
-  // IDs 4-5 reused for correction reduce (they don't overlap in time with sm_stats IDs 4-5).
+  //   CUTLASS offsets user IDs by ReservedNamedBarrierCount(8) => hardware 8..15,
+  //   which consumes the entire user ID space (8 + 8 = 16 = HardwareMaxNumNamedBarriers).
+  //
+  // The correction warp-pair reduce barriers used to be aliased onto user IDs 4-5
+  // on the assumption that they never overlap the sm_stats traffic in time. Nothing
+  // enforced that -- the four correction warps run independently -- so a reduce
+  // arrival could complete a stage-1 sm_stats barrier and wedge the CTA. They now
+  // live on hardware barriers 1-2 via the reserved enum; see
+  // CollectiveMainloopFwd::reduce_barrier_sync().
   enum NamedBarriers : int {
-    SmStatsNotify = 0,  // +(stage*4+warp_idx): IDs 0..7
+    SmStatsNotify = 0,  // +(stage*4+warp_idx): user IDs 0..7 (hardware 8..15)
                         // 64 threads each: 32 softmax + 32 correction
                         // Softmax: bar.arrive (non-blocking), Correction: bar.sync (blocking)
-    Reduce_02 = 4,      // Reused after sm_stats done. Correction warp-pair (8,10)
-    Reduce_13 = 5,      // Reused after sm_stats done. Correction warp-pair (9,11)
   };
 
   // ---- SharedStorage ----
@@ -256,12 +262,17 @@ struct FusedAttnFwdSm100 {
 
     if (warp_idx == kSchedWarp) {
 #if defined(__CUDA_ARCH__) && __CUDA_ARCH__ == 1030
-      // SM103 uses one statically assigned tile per CTA; worker warps
-      // rendezvous in consumer_advance().  Keep this warp alive until the
-      // worker-side completion flag is visible so the CTA cannot retire early.
-      while (*reinterpret_cast<volatile int*>(&shared_storage.tmem_ready) != 2) {
-      }
-      __threadfence_block();
+      // SM103 uses one statically assigned tile per CTA.  The scheduler warp
+      // does no work on this path, so it simply joins the exit rendezvous in
+      // consumer_advance() -- all 16 warps, hence the 512-thread count there.
+      // An earlier revision instead parked this warp on a completion flag set
+      // by the MMA warp, which made the rendezvous a 480-thread barrier plus a
+      // second, redundant handshake guarding an invariant the rendezvous
+      // already provides.  One barrier for all 512 threads is equivalent and
+      // leaves a single synchronization point to reason about.
+      flash::tcgen05_fence_before_sync();
+      cutlass::arch::NamedBarrier(512, cutlass::arch::ReservedNamedBarriers::Sm120MainloopBarrier)
+          .arrive_and_wait();
       return;
 #else
       // ===== WG3 warp 15: CLC scheduler (lane 0 only) =====
@@ -305,13 +316,9 @@ struct FusedAttnFwdSm100 {
         work = tile_sched.consumer_advance();
       }
 
-#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ == 1030
-      if (lane_idx == 0) {
-        __threadfence_block();
-        *reinterpret_cast<volatile int*>(&shared_storage.tmem_ready) = 2;
-      }
-#endif
-
+      // SM103: the 512-thread barrier inside the final consumer_advance() is
+      // the exit rendezvous; every consumer is done with TMEM once MMA gets
+      // here, so free directly -- no completion flag.
       tmem_alloc.free(shared_storage.tmem_base_ptr, TmemAllocator::Sm100TmemCapacityColumns);
     } else if (warp_idx == kEpiWarp) {
       // ===== WG3 warp 13: Epilogue TMA store =====

--- a/flashinfer/cute_dsl/sparse/sm100_blk64/mainloop_fwd_sm100.hpp
+++ b/flashinfer/cute_dsl/sparse/sm100_blk64/mainloop_fwd_sm100.hpp
@@ -836,10 +836,38 @@ struct CollectiveMainloopFwd {
     }
   }
 
+  // Correction warp-pair reduce barrier (warps w and w^2, kRows = 64 threads).
+  //
+  // These must not share an id with the SmStats barriers.  Correction warp w
+  // reaches its reduce arrival while its partner w^2 may still be blocked on
+  // its own stage-1 SmStats barrier, and nothing orders the two: the four
+  // correction warps run independently up to this point.  With the previous
+  // user ids (Reduce_02 == 4 == the stage-1 SmStats id of correction warp 0,
+  // Reduce_13 == 5 == that of correction warp 1) a reduce arrival could
+  // complete a SmStats barrier instead, consuming the softmax partner's
+  // arrival.  The correction warp then blocked forever on an arrival nobody
+  // would make, the epilogue warp never received its 128th o_epi commit, and
+  // the CTA wedged.  Observed live as exactly that warp map: correction warp 0
+  // alone at a SmStats barrier, the other 14 warps parked at the exit
+  // rendezvous, and the epilogue warp inside its elect_one waiting on o_epi.
+  //
+  // The reserved-enum NamedBarrier ctor applies no +ReservedNamedBarrierCount
+  // offset, so these land on hardware barriers 1 and 2 -- both unused by this
+  // kernel (0 = __syncthreads, 7 = SM103 exit rendezvous, 8..15 = SmStats).
+  CUTLASS_DEVICE static void reduce_barrier_sync(int pair_sel) {
+    using cutlass::arch::NamedBarrier;
+    using cutlass::arch::ReservedNamedBarriers;
+    if (pair_sel) {
+      NamedBarrier(kRows, ReservedNamedBarriers::TransposeBarrier).arrive_and_wait();
+    } else {
+      NamedBarrier(kRows, ReservedNamedBarriers::EpilogueBarrier).arrive_and_wait();
+    }
+  }
+
   template <typename SmemTensorO, typename EpiStorage, typename NamedBarriers>
   CUTLASS_DEVICE static void correction_combine(uint32_t tmem_o0, uint32_t tmem_o1, float my_scale0,
                                                 float my_scale1, int corr_warp, int lane_idx,
-                                                int reduce_bar, EpiStorage& el, SmemTensorO& sO) {
+                                                int reduce_pair, EpiStorage& el, SmemTensorO& sO) {
     using namespace cute;
 
     // Pass 1: each warp computes weighted O and writes ALL chunks to OWN slot
@@ -872,7 +900,7 @@ struct CollectiveMainloopFwd {
     }
 
     // Single barrier: all warps' exchange writes visible
-    cutlass::arch::NamedBarrier::arrive_and_wait(kRows, reduce_bar);
+    reduce_barrier_sync(reduce_pair);
 
     // Pass 2: warps 0,1 read own + partner exchange data → add → bf16 → sO
     {
@@ -1002,13 +1030,13 @@ struct CollectiveMainloopFwd {
 
     // ---- (f) Warp-pair stats exchange + combine weight ----
     auto sO = make_tensor(make_smem_ptr(el.sO.begin()), SmemLayoutO{});
-    const int reduce_bar = (corr_warp & 1) ? NamedBarriers::Reduce_13 : NamedBarriers::Reduce_02;
+    const int reduce_pair = corr_warp & 1;
 
     float my_weight;
     {
       el.o_staging[corr_warp ^ 2][lane_idx * 2 + 0] = my_sum;
       el.o_staging[corr_warp ^ 2][lane_idx * 2 + 1] = my_max;
-      NamedBarrier::arrive_and_wait(kRows, reduce_bar);
+      reduce_barrier_sync(reduce_pair);
 
       float partner_sum = el.o_staging[corr_warp][lane_idx * 2 + 0];
       float partner_max = el.o_staging[corr_warp][lane_idx * 2 + 1];
@@ -1041,7 +1069,7 @@ struct CollectiveMainloopFwd {
     float my_scale0 = scale0 * my_weight;
     float my_scale1 = scale1 * my_weight;
     correction_combine<decltype(sO), decltype(el), NamedBarriers>(
-        tmem_o0, tmem_o1, my_scale0, my_scale1, corr_warp, lane_idx, reduce_bar, el, sO);
+        tmem_o0, tmem_o1, my_scale0, my_scale1, corr_warp, lane_idx, reduce_pair, el, sO);
 
     // ---- (h) Fence + signal epilogue warp ----
     cutlass::arch::fence_view_async_shared();

--- a/flashinfer/cute_dsl/sparse/sm100_blk64/tile_scheduler.hpp
+++ b/flashinfer/cute_dsl/sparse/sm100_blk64/tile_scheduler.hpp
@@ -104,17 +104,17 @@ struct CLCTileScheduler {
     cutlass::arch::fence_view_async_shared();
 #if defined(__CUDA_ARCH__) && __CUDA_ARCH__ == 1030
     // SM103: process exactly the CTA's initial tile.  The CLC transition used
-    // by the SM100 persistent path can deadlock after repeated launches on
-    // B300.  All 480 worker threads rendezvous before MMA releases TMEM.
+    // by the SM100 persistent path deadlocks on the first launch on B300.
+    // All 512 threads rendezvous here before MMA releases TMEM.
     //
     // Barrier choice: CUTLASS offsets integer barrier ids by
-    // ReservedNamedBarrierCount (8).  This kernel's SmStats barriers occupy
-    // user ids 0-7 (hardware 8-15), so any integer id here overflows past 15
-    // and wraps onto hardware barrier 0 -- the __syncthreads barrier -- letting
-    // unrelated arrivals release this rendezvous early and wedge the CTA.
-    // Sm120MainloopBarrier (hardware id 7, reserved-enum ctor applies no
-    // offset) is unused by this SM100/SM103 kernel, so take it directly.
-    cutlass::arch::NamedBarrier(480, cutlass::arch::ReservedNamedBarriers::Sm120MainloopBarrier)
+    // ReservedNamedBarrierCount (8), and this kernel's SmStats barriers already
+    // occupy user ids 0-7 (hardware 8-15) -- the whole integer user id space.
+    // Any integer id here would resolve past hardware barrier 15, which is out
+    // of range and undefined.  Sm120MainloopBarrier (hardware id 7; the
+    // reserved-enum ctor applies no offset) is unused by this SM100/SM103
+    // kernel, so take it directly.
+    cutlass::arch::NamedBarrier(512, cutlass::arch::ReservedNamedBarriers::Sm120MainloopBarrier)
         .arrive_and_wait();
     return {0, 0, 0, false};
 #else

--- a/flashinfer/cute_dsl/sparse/sm100_blk64/tile_scheduler.hpp
+++ b/flashinfer/cute_dsl/sparse/sm100_blk64/tile_scheduler.hpp
@@ -102,6 +102,22 @@ struct CLCTileScheduler {
     flash::tcgen05_fence_before_sync();
     cutlass::arch::fence_view_async_tmem_store();
     cutlass::arch::fence_view_async_shared();
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ == 1030
+    // SM103: process exactly the CTA's initial tile.  The CLC transition used
+    // by the SM100 persistent path can deadlock after repeated launches on
+    // B300.  All 480 worker threads rendezvous before MMA releases TMEM.
+    //
+    // Barrier choice: CUTLASS offsets integer barrier ids by
+    // ReservedNamedBarrierCount (8).  This kernel's SmStats barriers occupy
+    // user ids 0-7 (hardware 8-15), so any integer id here overflows past 15
+    // and wraps onto hardware barrier 0 -- the __syncthreads barrier -- letting
+    // unrelated arrivals release this rendezvous early and wedge the CTA.
+    // Sm120MainloopBarrier (hardware id 7, reserved-enum ctor applies no
+    // offset) is unused by this SM100/SM103 kernel, so take it directly.
+    cutlass::arch::NamedBarrier(480, cutlass::arch::ReservedNamedBarriers::Sm120MainloopBarrier)
+        .arrive_and_wait();
+    return {0, 0, 0, false};
+#else
     // Release old CLC result (enables scheduler's next producer_acquire)
     pipeline_clc.consumer_release(cons_state);
     clc_transition_fence();
@@ -117,6 +133,7 @@ struct CLCTileScheduler {
     }
     flash::tcgen05_commit();
     return decode(resp.row_tile, params.num_row_tiles, params.num_heads);
+#endif
   }
 
   // ---- Producer tail: drain pipeline before exit ----


### PR DESCRIPTION
## What

The cute_dsl blk64 block-sparse attention forward kernel has two independent hangs on
Blackwell. This PR fixes both, kernel-side only, three files.

1. **SM103 (B300), deterministic.** The CLC persistent-scheduler path deadlocks on the first
   launch, every time. Fixed by statically dispatching `__CUDA_ARCH__ == 1030` to a
   non-persistent one-tile-per-CTA schedule.
2. **Intermittent, architecture-independent.** A named-barrier id collision in the correction
   warpgroup wedges a single CTA. On the configuration measured here (8xB300, MiniMax-H3 T2VA
   serving) that is roughly once every ~25 requests; the rate is timing-dependent, so treat the
   number as specific to that workload. This is the defect the earlier revision of this PR
   flagged as unresolved. **It is now root-caused and fixed.**

SM100 behavior is unchanged for (1) — the CLC path stays exactly as it was behind the arch
guard. Fix (2) is architecture-independent and applies to the stock SM100 path as well.

## Fix 1: SM103 CLC scheduler hang

On SM103, after a CLC transition the scheduler response never becomes visible to the CTA
waiting in `consumer_advance()`, so worker warps spin forever at full occupancy. Instead of
chasing the CLC path on this architecture, `consumer_advance()` processes exactly the CTA's
statically assigned tile and all 512 threads rendezvous on a named barrier before MMA releases
TMEM.

Barrier choice: CUTLASS offsets integer barrier ids by `ReservedNamedBarrierCount` (8), and
this kernel's SmStats barriers already occupy user ids 0-7 (hardware 8-15) — the entire
integer user id space. Any integer id here would resolve past hardware barrier 15, which is
out of range and undefined. `ReservedNamedBarriers::Sm120MainloopBarrier` (hardware id 7; the
reserved-enum ctor applies no offset) is unused by this kernel, so the rendezvous takes it
directly.

## Fix 2: correction reduce barrier id collision

`NamedBarriers` allocated the SmStats barriers as `SmStatsNotify + Stage*4 + warp`, user ids
0-7, and then aliased the correction warp-pair reduce barriers onto ids 4-5:

```
Reduce_02 = 4,      // Reused after sm_stats done. Correction warp-pair (8,10)
Reduce_13 = 5,      // Reused after sm_stats done. Correction warp-pair (9,11)
```

But `SmStatsNotify + 1*kCorrWarps + corr_warp` is **4** for correction warp 0 and **5** for
correction warp 1 — exactly the two reduce ids. The comment asserts the two uses never overlap
in time. Nothing enforces that: the four correction warps are mutually independent right up to
the reduce.

The interleaving that breaks it:

1. Correction warp 2 — which depends on softmax WG1 warp **2** (id 6) and on `o_acc`, not on
   anything correction warp 0 is waiting for — runs ahead and arrives at the reduce barrier,
   putting 32 threads on id 4.
2. Softmax WG1 warp 0 issues its closing `arrive` on id 4. That arrival was meant to complete
   correction warp 0's stage-1 handshake, but 32 + 32 now reaches 64 and the barrier
   **releases between the wrong parties**: correction warp 2 proceeds as if warp 0 had joined
   the reduce, and the softmax arrival is spent.
3. Correction warp 0 only now reaches its stage-1 handshake and puts 32 threads on id 4. The
   64th never comes — softmax WG1 warp 0 arrives exactly once per round, and that arrival is
   already gone.
4. Correction warp 0 blocks forever, so `pipeline_o_epi.notify` never reaches its 128th
   arrival, the epilogue warp waits on it inside its `elect_one_sync()` block, and the CTA
   never retires. The wedged rank then stalls the Ulysses all-to-all and the NCCL watchdog
   kills the job minutes later. Other interleavings of the same collision desync the pairing
   in the same way and wedge one of the two warps involved.

The window is not narrow. Between softmax WG1 warp 0's last p_lastsplit commit and its closing
`arrive` sit a blocking `sm_stats.producer_acquire` (which waits on all four correction warps),
a full `update_row_sum` pass, SMEM stores and a fence — while MMA's final PV only depends on
the p_lastsplit commit, so `o_acc` can go ready inside that window and let correction warp 2
run straight through.

Fix: move the reduce barriers onto hardware barriers 1-2 through the reserved `NamedBarrier`
enum ctor. There is no free integer user id available.

### Evidence

A wedged CTA was captured live with cuda-gdb: grid 4130, exactly one CTA still resident, every
warp blocked. Directly observed in that dump:

- **logical warp 8 = `corr_warp` 0** — the exact warp whose stage-1 SmStats id collides with
  `Reduce_02` — sits alone at a PC distinct from correction warps 1-3, which share a PC.
  Nothing else in `correction()` makes warp 0 diverge from its three peers this way.
- the epilogue warp is inside its `elect_one_sync()` block (active lane mask `0x1`). The only
  blocking wait in that block is `pipeline_o_epi.consumer_wait`, which is exactly what a
  missing 128th arrival from correction warp 0 produces.
- the remaining warps are blocked at their own late-exit points, consistent with having
  finished the tile and being unable to retire.

Scope of the evidence: the dump was taken on the build in this PR's first commit, so the exit
rendezvous there was still the 480-thread barrier plus the scheduler-warp completion flag, not
today's single 512-thread rendezvous. The two load-bearing observations — correction warp 0
diverging from warps 1-3, and the epilogue warp stuck on `o_epi` — live in the mainloop and are
independent of the exit protocol. The exact instruction each of the other warps stopped at was
not decoded: that binary no longer exists, and the addresses cannot be mapped after the fact.

Two notes for anyone reading such a dump: cuda-gdb's `Wp` column is the hardware warp slot, so
the logical warp is `First Active ThreadIdx / 32`; and `BAR.SYNC.DEFER_BLOCKING` advances the
PC past the barrier, so a warp still blocked at a rendezvous displays at the following
instruction (often `EXIT`, which reads misleadingly like an early exit).

## Also in this revision

The SM103 exit path is simplified. The scheduler warp does no work on that path, so it now
joins the same rendezvous as everyone else (512 threads) instead of spinning on a separate
completion flag set by the MMA warp. That removes a 480-thread barrier plus a redundant
handshake guarding an invariant the rendezvous already provides, leaving one synchronization
point.

Two claims from the first revision are corrected in the comments. The out-of-range integer
barrier id is undefined behaviour and remains worth fixing, but the mechanism previously
stated for the intermittent hang — stray `__syncthreads` arrivals on hardware barrier 0
inflating the rendezvous count — has no source: this kernel contains exactly one
`__syncthreads()`, executed once by all 512 threads before warp dispatch, and the compiled
SASS contains exactly one `BAR.SYNC` on hardware barrier 0. Likewise, the "softmax warps at
`EXIT`" reading of the original dump was a misread of `DEFER_BLOCKING`, as described above.

## Validation

- 8xB300 (SM103), MiniMax-H3 T2VA serving, cache + block-sparse config: **100/100 requests
  clean**. Before this revision, two runs of the identical configuration wedged at request 7
  and request 19 respectively. At the observed ~1/25 rate, 100 clean requests by chance is
  ~1.7%.
- Latency unchanged (11.0-11.5 s per request, matching the pre-fix runs); `REG:128` unchanged.
- **The race was also corrupting results silently.** Per-request output md5s cycle over 3
  prompts, so a correct run yields exactly 3 distinct values. After the fix: 3 distinct md5s
  over 100 requests (34/33/33). Before: the same 3 values plus 3 one-off strays in only 19
  requests, at positions 3/10/16 — scattered, not warmup. The deadlock is the rare fatal
  branch of the same race; the common branch is a wrong answer.
- SASS check on the built kernel: the reduce barriers emit `BAR.SYNC 0x1, 0x40` /
  `BAR.SYNC 0x2, 0x40`, disjoint from the SmStats barriers (hardware 8-15), from
  `__syncthreads` (hardware 0), and from the SM103 rendezvous (hardware 7).
- Compiles for both `sm_100a` and `sm_103a`; the barrier-layout check above was confirmed on
  both cubins, i.e. fix 2 lands on the stock CLC path too.
- 20k-iteration single-GPU microbench with randomized block patterns at real MiniMax-H3 shapes:
  hang-free. Note this bench never reproduced fix 2's race — back-to-back iterations keep the
  inter-warp skew in a narrow band, and the race needs the irregular delays that co-resident
  kernels produce under real serving. It is not a useful gate for this class of bug;
  per-request output determinism is.
- End-to-end MiniMax-H3 T2VA serving passes a same-seed LPIPS quality gate against the dense
  reference.

Honest scope note: the end-to-end numbers are all from 8xB300. The SM100 claim for fix 2 rests
on code reading plus the compile and SASS checks, not on an SM100 serving run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

