### PR TITLE
stabilize pytest node IDs for external scopes to fix issues 4499 and 4500

### DIFF
--- a/scripts/test_sharding/runner.py
+++ b/scripts/test_sharding/runner.py
@@ -277,6 +277,17 @@ def _isolated_collection_groups(test_path: Path) -> list[tuple[str, list[Path]]]
     return groups
 
 
+def _pytest_root(repo_root: Path, test_path: Path) -> Path:
+    """Return the stable pytest root used for collection and execution."""
+    resolved_repo = repo_root.resolve()
+    resolved_test = test_path.resolve()
+    try:
+        resolved_test.relative_to(resolved_repo)
+    except ValueError:
+        return resolved_test if resolved_test.is_dir() else resolved_test.parent
+    return resolved_repo
+
+
 def _collect_partition(
     repo_root: Path,
     test_path: Path,
@@ -292,6 +303,7 @@ def _collect_partition(
 ) -> list[dict[str, Any]]:
     output = directory / f"collection-{partition_index:02d}.json"
     log_path = directory / f"collection-{partition_index:02d}.log"
+    pytest_root = _pytest_root(repo_root, test_path)
     env = os.environ.copy()
     pythonpath = env.get("PYTHONPATH")
     env["PYTHONPATH"] = (
@@ -301,6 +313,7 @@ def _collect_partition(
         sys.executable,
         "-m",
         "pytest",
+        f"--rootdir={pytest_root}",
         "--collect-only",
         "-q",
         "-q",
@@ -1012,6 +1025,7 @@ class _ShardProgress:
 @dataclass
 class _ShardExecutor:
     repo_root: Path
+    pytest_root: Path
     junit_dir: Path
     plan: Plan
     execution: ExecutionSettings
@@ -1263,6 +1277,7 @@ class _ShardExecutor:
                 result = execute_batch(
                     BatchExecutionRequest(
                         repo_root=self.repo_root,
+                        pytest_root=self.pytest_root,
                         junit_dir=self.junit_dir,
                         unit=unit,
                         batch=batch,
@@ -1516,6 +1531,7 @@ def execute_shard(
     plan: Plan,
     execution: ExecutionSettings,
     operation_started_at: float,
+    test_path: Path,
 ) -> int:
     if not 0 <= execution.shard_index < plan.options.shard_count:
         raise RunnerStateError(
@@ -1583,6 +1599,7 @@ def execute_shard(
         )
         shard_executor = _ShardExecutor(
             repo_root=repo_root,
+            pytest_root=_pytest_root(repo_root, test_path),
             junit_dir=junit_dir,
             plan=plan,
             execution=execution,

--- a/scripts/test_sharding/workers.py
+++ b/scripts/test_sharding/workers.py
@@ -31,6 +31,7 @@ class BatchExecution:
 @dataclass(frozen=True)
 class BatchExecutionRequest:
     repo_root: Path
+    pytest_root: Path
     junit_dir: Path
     unit: Unit
     batch: Batch
@@ -339,6 +340,7 @@ def _pytest_command(
         sys.executable,
         "-m",
         "pytest",
+        f"--rootdir={request.pytest_root}",
         "--continue-on-collection-errors",
         "-p",
         "scripts.test_sharding.pytest_plugin",
@@ -383,7 +385,7 @@ def _run_pytest(
         log.flush()
         process = subprocess.Popen(
             command,
-            cwd=request.repo_root,
+            cwd=request.pytest_root,
             env=_pytest_environment(request),
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,

--- a/scripts/unit_test_runner.py
+++ b/scripts/unit_test_runner.py
@@ -464,6 +464,7 @@ def _execute_command(args: argparse.Namespace, operation_started_at: float) -> i
         plan=plan,
         execution=execution,
         operation_started_at=operation_started_at,
+        test_path=selection.test_path,
     )
 
 

--- a/tests/test_sharding/test_runner_cli.py
+++ b/tests/test_sharding/test_runner_cli.py
@@ -565,6 +565,36 @@ def test_sm90():
     assert [node["order"] for node in isolated_nodes] == [0]
 
 
+def test_pytest_root_is_stable_for_repository_and_external_scopes(
+    tmp_path: Path,
+) -> None:
+    suite = tmp_path / "suite"
+    suite.mkdir()
+    test_file = suite / "test_sample.py"
+    test_file.write_text("def test_case(): pass\n", encoding="utf-8")
+
+    assert runner._pytest_root(REPO_ROOT, REPO_ROOT / "tests") == REPO_ROOT.resolve()
+    assert runner._pytest_root(REPO_ROOT, suite) == suite.resolve()
+    assert runner._pytest_root(REPO_ROOT, test_file) == suite.resolve()
+
+
+def test_collection_preserves_external_pytest_config(tmp_path: Path) -> None:
+    suite = tmp_path / "suite"
+    suite.mkdir()
+    (suite / "pytest.ini").write_text(
+        "[pytest]\npython_files = check_*.py\n",
+        encoding="utf-8",
+    )
+    (suite / "check_sample.py").write_text(
+        "def test_case(): pass\n",
+        encoding="utf-8",
+    )
+
+    nodes = runner._collect_nodes(REPO_ROOT, suite, 15, 0)
+
+    assert [node["nodeid"] for node in nodes] == ["check_sample.py::test_case"]
+
+
 def test_collection_termination_uses_configured_grace(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -670,6 +700,7 @@ def test_worker_exception_is_reported_as_infrastructure_error(
         plan=plan,
         execution=execution,
         operation_started_at=time.time(),
+        test_path=REPO_ROOT / "tests",
     )
 
     assert result == 3
@@ -760,6 +791,7 @@ def test_setup_error_is_not_masked_when_lease_cleanup_also_fails(
             plan=plan,
             execution=execution,
             operation_started_at=time.time(),
+            test_path=REPO_ROOT / "tests",
         )
 
     assert "cannot close shard leases" in capsys.readouterr().out
@@ -820,6 +852,7 @@ def test_partial_shard_lease_claim_is_rolled_back(
             plan=plan,
             execution=execution,
             operation_started_at=time.time(),
+            test_path=REPO_ROOT / "tests",
         )
 
     leases = tmp_path / "junit" / "attempts" / "attempt-0001" / "leases"
@@ -966,6 +999,7 @@ def test_lease_heartbeat_failure_aborts_work_and_is_reported(
         plan=plan,
         execution=execution,
         operation_started_at=time.time(),
+        test_path=REPO_ROOT / "tests",
     )
 
     assert result == 3
@@ -1005,7 +1039,11 @@ def test_collection_deadline_reports_that_pytest_was_killed(tmp_path: Path) -> N
 
 def test_plan_run_and_completed_reuse_publish_resumable_artifacts(
     tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    # Pytest 9 may otherwise inherit the repository root for this external
+    # temporary suite, which used to leak pytest-of-*/... prefixes into node IDs.
+    monkeypatch.setenv("PYTEST_ADDOPTS", f"--rootdir={REPO_ROOT}")
     suite = tmp_path / "suite"
     suite.mkdir()
     (suite / "conftest.py").write_text(

--- a/tests/test_sharding/test_workers.py
+++ b/tests/test_sharding/test_workers.py
@@ -77,6 +77,7 @@ raise SystemExit(3)
     result = execute_batch(
         BatchExecutionRequest(
             repo_root=Path(__file__).resolve().parents[2],
+            pytest_root=Path(__file__).resolve().parents[2],
             junit_dir=tmp_path / "junit",
             unit=unit,
             batch=batch,
@@ -151,6 +152,7 @@ def _fake_batch_request(tmp_path: Path) -> BatchExecutionRequest:
     )
     return BatchExecutionRequest(
         repo_root=Path(__file__).resolve().parents[2],
+        pytest_root=Path(__file__).resolve().parents[2],
         junit_dir=tmp_path / "junit",
         unit=unit,
         batch=batch,


### PR DESCRIPTION
## 📌 Description

Add `--rootdir` to pytest run, such that the test node IDs will not change due to the rootdir change. This fixes issues 4499 and 5000.

## 🔍 Related Issues

https://github.com/flashinfer-ai/flashinfer/issues/4500
https://github.com/flashinfer-ai/flashinfer/issues/4499

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved test sharding reliability by stabilizing pytest’s root directory for both repository-local and external test paths.
  * Preserved external pytest configuration during test collection.
  * Ensured consistent test identifiers and resumable artifacts across planning, execution, and reuse workflows.

* **Tests**
  * Added coverage for root directory selection, external configuration handling, and shard execution scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->