### PR TITLE
feat(prefill): add return_lse_base_on_e option to BatchPrefillWithRaggedKVCacheWrapper

### DIFF
--- a/flashinfer/prefill.py
+++ b/flashinfer/prefill.py
@@ -4392,9 +4392,7 @@ class BatchPrefillWithRaggedKVCacheWrapper:
         self._sm_scale = sm_scale
         self._rope_scale = rope_scale
         self._rope_theta = rope_theta
-        return self.run_return_lse(
-            q, k, v, return_lse_base_on_e=return_lse_base_on_e
-        )
+        return self.run_return_lse(q, k, v, return_lse_base_on_e=return_lse_base_on_e)
 
     def end_forward(self) -> None:
         r"""Warning: this function is deprecated and has no effect."""

--- a/flashinfer/prefill.py
+++ b/flashinfer/prefill.py
@@ -3976,6 +3976,7 @@ class BatchPrefillWithRaggedKVCacheWrapper:
         out: Optional[torch.Tensor] = None,
         lse: Optional[torch.Tensor] = None,
         return_lse: bool = False,
+        return_lse_base_on_e: bool = False,
         enable_pdl: Optional[bool] = None,
         kv_cache_sf: Optional[
             Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]
@@ -4011,6 +4012,13 @@ class BatchPrefillWithRaggedKVCacheWrapper:
         enable_pdl : bool
             Whether to enable Programmatic Dependent Launch (PDL). See https://docs.nvidia.com/cuda/cuda-c-programming-guide/#programmatic-dependent-launch-and-synchronization
             Only supported for >= sm90, and currently only for FA2 and CUDA core decode.
+        return_lse_base_on_e : bool
+            Controls the base of the returned LSE values when ``return_lse=True``.
+            If ``False`` (default), the LSE is returned in base-2
+            (``log2(sum(exp2(...)))``) to match the kernel's internal log-base.
+            If ``True``, the LSE is converted to natural-log base
+            (``log(sum(exp(...)))``) for compatibility with merge/cascade APIs
+            that expect base-e LSEs.
         kv_cache_sf : Optional[Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]]
             Per-block scale factors for NVFP4 KV input.  Accepts either a single
             packed scale tensor or a ``(k_scales, v_scales)`` tuple matching the
@@ -4234,6 +4242,9 @@ class BatchPrefillWithRaggedKVCacheWrapper:
                 out=out,
                 lse=lse,
             )
+            if return_lse and return_lse_base_on_e:
+                # Kernels return base-2 LSE; convert to natural-log base.
+                lse = lse * 0.6931471805599453  # log2(e)
             return (out, lse) if return_lse else out
         elif self._backend == "cudnn":
             if self._seq_lens_q.dim() == 1:
@@ -4268,6 +4279,9 @@ class BatchPrefillWithRaggedKVCacheWrapper:
                 lse=lse,
             )
 
+            if return_lse and return_lse_base_on_e:
+                # Kernels return base-2 LSE; convert to natural-log base.
+                lse = lse * 0.6931471805599453  # log2(e)
             return (out, lse) if return_lse else out
 
         # Skip FP8->FP16 conversion for FA3 backend with FP8 support
@@ -4347,6 +4361,9 @@ class BatchPrefillWithRaggedKVCacheWrapper:
         if kv_cache_sf is not None and v_scale is not None and not is_float_one:
             out *= v_scale
 
+        if return_lse and return_lse_base_on_e:
+            # Kernels return base-2 LSE; convert to natural-log base.
+            lse = lse * 0.6931471805599453  # log2(e)
         return (out, lse) if return_lse else out
 
     run_return_lse = functools.partialmethod(run, return_lse=True)
@@ -4364,6 +4381,7 @@ class BatchPrefillWithRaggedKVCacheWrapper:
         sm_scale: Optional[float] = None,
         rope_scale: Optional[float] = None,
         rope_theta: Optional[float] = None,
+        return_lse_base_on_e: bool = False,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
         r"""Warning: This function is deprecated, please use :meth:`run_return_lse` instead."""
         self._causal = causal
@@ -4374,7 +4392,9 @@ class BatchPrefillWithRaggedKVCacheWrapper:
         self._sm_scale = sm_scale
         self._rope_scale = rope_scale
         self._rope_theta = rope_theta
-        return self.run_return_lse(q, k, v)
+        return self.run_return_lse(
+            q, k, v, return_lse_base_on_e=return_lse_base_on_e
+        )
 
     def end_forward(self) -> None:
         r"""Warning: this function is deprecated and has no effect."""

--- a/tests/attention/test_ragged_lse_base.py
+++ b/tests/attention/test_ragged_lse_base.py
@@ -1,0 +1,138 @@
+"""
+Copyright (c) 2026 by FlashInfer team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import math
+
+import pytest
+import torch
+
+import flashinfer
+
+LN2 = 0.6931471805599453
+
+
+def _torch_attn_lse(q, k, v, causal, sm_scale):
+    """fp32 torch-native attention + natural-log LSE. q [T,H,Dqk], k/v [S,H,*]."""
+    qf = q.float().permute(1, 0, 2)
+    kf = k.float().permute(1, 0, 2)
+    vf = v.float().permute(1, 0, 2)
+    scores = qf @ kf.transpose(-1, -2) * sm_scale
+    if causal:
+        T_, S = scores.shape[-2:]
+        mask = torch.triu(
+            torch.ones(T_, S, dtype=torch.bool, device=q.device), diagonal=S - T_ + 1
+        )
+        scores = scores.masked_fill(mask, float("-inf"))
+    lse = torch.logsumexp(scores, dim=-1).permute(1, 0)
+    out = (torch.softmax(scores, dim=-1) @ vf).permute(1, 0, 2)
+    return out, lse
+
+
+def _merge_state(o1, lse1, o2, lse2):
+    """fp32 natural-log merge of two attention states (out, natural-log LSE)."""
+    m = torch.maximum(lse1, lse2)
+    e1 = torch.exp(lse1 - m).unsqueeze(-1)
+    e2 = torch.exp(lse2 - m).unsqueeze(-1)
+    return (o1.float() * e1 + o2.float() * e2) / (e1 + e2)
+
+
+@pytest.mark.parametrize("prefix_len", [512, 4096])
+def test_ragged_lse_base_on_e(prefix_len):
+    """forward_return_lse yields base-2 LSE by default and natural-log LSE with
+    return_lse_base_on_e=True; only the natural-log form merges correctly with
+    base-e merge consumers (e.g. chunked-prefix attention merges)."""
+    torch.manual_seed(0)
+    dev = "cuda"
+    num_heads, head_dim_qk, head_dim_vo = 16, 192, 128
+    extend_len = 16
+    sm_scale = head_dim_qk**-0.5
+
+    q = torch.randn(extend_len, num_heads, head_dim_qk, dtype=torch.bfloat16, device=dev)
+    k_pre = torch.randn(prefix_len, num_heads, head_dim_qk, dtype=torch.bfloat16, device=dev)
+    v_pre = torch.randn(prefix_len, num_heads, head_dim_vo, dtype=torch.bfloat16, device=dev)
+    k_ext = torch.randn(extend_len, num_heads, head_dim_qk, dtype=torch.bfloat16, device=dev)
+    v_ext = torch.randn(extend_len, num_heads, head_dim_vo, dtype=torch.bfloat16, device=dev)
+
+    workspace = torch.empty(256 * 1024 * 1024, dtype=torch.uint8, device=dev)
+
+    def make_wrapper():
+        return flashinfer.prefill.BatchPrefillWithRaggedKVCacheWrapper(
+            workspace, "NHD", backend="cutlass"
+        )
+
+    def begin(w, qo_tokens, kv_tokens):
+        w.begin_forward(
+            qo_indptr=torch.tensor([0, qo_tokens], dtype=torch.int32, device=dev),
+            kv_indptr=torch.tensor([0, kv_tokens], dtype=torch.int32, device=dev),
+            num_qo_heads=num_heads,
+            num_kv_heads=num_heads,
+            head_dim_qk=head_dim_qk,
+            head_dim_vo=head_dim_vo,
+            q_data_type=torch.bfloat16,
+        )
+
+    # Exact reference: one ragged call over the full sequence.
+    w = make_wrapper()
+    begin(w, extend_len, prefix_len + extend_len)
+    k_full = torch.cat([k_pre, k_ext], 0)
+    v_full = torch.cat([v_pre, v_ext], 0)
+    o_ref, _ = w.forward_return_lse(q, k_full, v_full, causal=True, sm_scale=sm_scale)
+
+    # Extend part (causal) and prefix chunk (non-causal), both with base-e LSE.
+    w1 = make_wrapper()
+    begin(w1, extend_len, extend_len)
+    o_ext, lse_ext = w1.forward_return_lse(
+        q, k_ext, v_ext, causal=True, sm_scale=sm_scale, return_lse_base_on_e=True
+    )
+    w2 = make_wrapper()
+    begin(w2, extend_len, prefix_len)
+    o_pre, lse_pre = w2.forward_return_lse(
+        q, k_pre, v_pre, causal=False, sm_scale=sm_scale, return_lse_base_on_e=True
+    )
+
+    # 1) default (no flag): LSE must be base-2.
+    _, lse_ext_default = w1.forward_return_lse(
+        q, k_ext, v_ext, causal=True, sm_scale=sm_scale
+    )
+    _, lse_ext_true = _torch_attn_lse(q, k_ext, v_ext, True, sm_scale)
+    default_vs_ln = (lse_ext_default - lse_ext_true).abs().max().item()
+    default_vs_log2 = (lse_ext_default - lse_ext_true * math.log2(math.e)).abs().max().item()
+    assert default_vs_log2 < 1e-3 and default_vs_ln > 0.1, (
+        f"default LSE should be base-2 (vs log2 err={default_vs_log2:.2e}, "
+        f"vs ln err={default_vs_ln:.2e})"
+    )
+
+    # 2) with the flag: LSE must be natural-log.
+    flag_vs_ln = (lse_ext - lse_ext_true).abs().max().item()
+    assert flag_vs_ln < 1e-2, f"flagged LSE should be natural-log (err={flag_vs_ln:.2e})"
+
+    # 3) merge with natural-log LSE matches the full-sequence result; merging the
+    #    raw base-2 LSE with a base-e merge consumer does not.
+    o_merged_good = _merge_state(o_pre, lse_pre, o_ext, lse_ext)
+    err_good = (o_merged_good - o_ref.float()).abs().max().item()
+    o_merged_bad = _merge_state(o_pre, lse_pre / LN2, o_ext, lse_ext / LN2)
+    err_bad = (o_merged_bad - o_ref.float()).abs().max().item()
+    assert err_good < 1e-2, f"base-e merge should be exact (err={err_good:.2e})"
+    assert err_bad > 10 * err_good, (
+        f"base-2 LSE with a base-e merge should be visibly wrong "
+        f"(err_bad={err_bad:.2e}, err_good={err_good:.2e})"
+    )
+
+
+if __name__ == "__main__":
+    test_ragged_lse_base_on_e(512)
+    test_ragged_lse_base_on_e(4096)
+    print("PASS")

--- a/tests/attention/test_ragged_lse_base.py
+++ b/tests/attention/test_ragged_lse_base.py
@@ -60,11 +60,21 @@ def test_ragged_lse_base_on_e(prefix_len):
     extend_len = 16
     sm_scale = head_dim_qk**-0.5
 
-    q = torch.randn(extend_len, num_heads, head_dim_qk, dtype=torch.bfloat16, device=dev)
-    k_pre = torch.randn(prefix_len, num_heads, head_dim_qk, dtype=torch.bfloat16, device=dev)
-    v_pre = torch.randn(prefix_len, num_heads, head_dim_vo, dtype=torch.bfloat16, device=dev)
-    k_ext = torch.randn(extend_len, num_heads, head_dim_qk, dtype=torch.bfloat16, device=dev)
-    v_ext = torch.randn(extend_len, num_heads, head_dim_vo, dtype=torch.bfloat16, device=dev)
+    q = torch.randn(
+        extend_len, num_heads, head_dim_qk, dtype=torch.bfloat16, device=dev
+    )
+    k_pre = torch.randn(
+        prefix_len, num_heads, head_dim_qk, dtype=torch.bfloat16, device=dev
+    )
+    v_pre = torch.randn(
+        prefix_len, num_heads, head_dim_vo, dtype=torch.bfloat16, device=dev
+    )
+    k_ext = torch.randn(
+        extend_len, num_heads, head_dim_qk, dtype=torch.bfloat16, device=dev
+    )
+    v_ext = torch.randn(
+        extend_len, num_heads, head_dim_vo, dtype=torch.bfloat16, device=dev
+    )
 
     workspace = torch.empty(256 * 1024 * 1024, dtype=torch.uint8, device=dev)
 
@@ -109,7 +119,9 @@ def test_ragged_lse_base_on_e(prefix_len):
     )
     _, lse_ext_true = _torch_attn_lse(q, k_ext, v_ext, True, sm_scale)
     default_vs_ln = (lse_ext_default - lse_ext_true).abs().max().item()
-    default_vs_log2 = (lse_ext_default - lse_ext_true * math.log2(math.e)).abs().max().item()
+    default_vs_log2 = (
+        (lse_ext_default - lse_ext_true * math.log2(math.e)).abs().max().item()
+    )
     assert default_vs_log2 < 1e-3 and default_vs_ln > 0.1, (
         f"default LSE should be base-2 (vs log2 err={default_vs_log2:.2e}, "
         f"vs ln err={default_vs_ln:.2e})"
@@ -117,7 +129,9 @@ def test_ragged_lse_base_on_e(prefix_len):
 
     # 2) with the flag: LSE must be natural-log.
     flag_vs_ln = (lse_ext - lse_ext_true).abs().max().item()
-    assert flag_vs_ln < 1e-2, f"flagged LSE should be natural-log (err={flag_vs_ln:.2e})"
+    assert flag_vs_ln < 1e-2, (
+        f"flagged LSE should be natural-log (err={flag_vs_ln:.2e})"
+    )
 
     # 3) merge with natural-log LSE matches the full-sequence result; merging the
     #    raw base-2 LSE with a base-e merge consumer does not.


### PR DESCRIPTION
## Description

FlashInfer's attention kernels return LSE in base 2 (`log2(sum(exp2(x)))`); see #2113.
This is consistent inside FlashInfer, but merge implementations in downstream consumers
(flash-attn / sgl_kernel / FA3 convention, e.g. `merge_state_v2` in sglang's
chunked-prefix attention) expect LSE in base e. When base-2 LSE is passed to a base-e
merge, the merge weights are computed with the wrong logarithm base and the merged
output is incorrect.

Measured error from this mismatch (chunked-prefix attention: extend + prefix chunk +
merge), against an fp32 torch reference: max |error| = 0.105 at prefix_len=4096; the
error increases with prefix length. After converting base 2 to base e at the merge
boundary: max |error| = 0.0005.

Change: add the opt-in parameter `return_lse_base_on_e` (same design as #2114, which
added it to the MLA paged path):

- `BatchPrefillWithRaggedKVCacheWrapper.run(...)` gains `return_lse_base_on_e: bool = False`.
  When `True`, the returned LSE is multiplied by `ln(2)` (base 2 to base e). Applied at
  all three backend return points (fa2/cutlass/cudnn).
- `forward_return_lse(...)` gains the same parameter and forwards it.
- Default behavior is unchanged: with `return_lse_base_on_e=False` the returned LSE is
  byte-identical to before (verified with `torch.equal` on attention outputs; the
  flagged LSE equals `default * ln(2)` exactly).
- Docstrings state both conventions, using the same wording as `mla/_core.py`.

## Related Issues

- #2113 — base-2 vs base-e LSE convention; maintainers requested an opt-in parameter,
  not a default change
- #2114 — added `return_lse_base_on_e` to the MLA paged path; this PR applies the same
  design to the ragged prefill path

## Pull Request Checklist

### Pre-commit Checks

- [x] I have installed `pre-commit` and run the hooks on the changed files.
  (`ruff format` / `ruff check` pass; the pre-commit CI job is green.)

## Tests

- [x] Tests have been added or updated as needed.

`tests/attention/test_ragged_lse_base.py` (prefix_len = 512 and 4096):

1. Default call returns base-2 LSE (`≈ ln(lse) * log2(e)`, and `≠ ln(lse)`).
2. `return_lse_base_on_e=True` returns base-e LSE (error < 1e-2 vs fp32 torch).
3. A base-e merge of extend + prefix-chunk states matches a single full-sequence call
   to < 1e-2 (measured ≈ 5e-4); the same merge on base-2 LSE has error ≈ 0.105.

`pytest tests/attention/test_ragged_lse_base.py` → 2 passed (NVIDIA B300, sm_103a).
Default-path outputs are bit-identical with and without the parameter.

## Evidence (figures)

Merge error vs prefix length: base-2 LSE passed to a base-e merge is 1–2 orders of
magnitude above the reference across the sweep; base-e LSE from
`return_lse_base_on_e=True` stays at ~2e-3–6e-3 of the reference scale:

![merge error vs prefix length](https://raw.githubusercontent.com/advpropsys/flashinfer/pr-assets/fig1_merge_error_vs_prefix.png)

Worked example (prefix=2048, extend=512). Left: wrapper LSE in base 2 and base e.
Right: merge softmax weight of the prefix chunk; interpreting base-2 values as base e
over-weights the prefix chunk:

![LSE and merge weights](https://raw.githubusercontent.com/advpropsys/flashinfer/pr-assets/fig2_lse_and_merge_weights.png)

Serving-level |Δlogprob| (sglang chunked-prefix attention on a hybrid MLA model, B300):
0.27–1.69 before the fix vs 5e-4 max (vs fp32) after. The grey band (0.036–0.087) is
the reference path's own run-to-run variance:

![serving dlogprob](https://raw.githubusercontent.com/advpropsys/flashinfer/pr-assets/fig3_serving_dlogprob.png)

## Reviewer Notes

- The change is opt-in only. Consumers that already convert base 2 to base e themselves
  (e.g. sglang's current workaround) can later pass `return_lse_base_on_e=True` instead.
  Consumers that use base-2 LSE (flashinfer's cascade attention, trtllm paths) are
  unaffected.
- Downstream measurement (sglang serving, BailingMoeV3 hybrid on B300), with the
  conversion applied at the consumer: chunked-prefix attention matches the fp32
  reference to 5e-4; serving outputs are bit-exact vs the unpatched stack on
  short/4k/6k prompts; and the corrected path replaces the fa2 paged MLA kernel in
  concurrent prefill (231.7 ms → 34.9 ms cutlass per 8k-token block).
