### PR TITLE
fix(gemm): size the mm_fp4 shared workspace so SM120 stops allocating per call

### DIFF
--- a/flashinfer/gemm/gemm_base.py
+++ b/flashinfer/gemm/gemm_base.py
@@ -16,6 +16,7 @@ limitations under the License.
 
 import functools
 import logging
+import os
 import warnings
 from collections import defaultdict
 from dataclasses import astuple, replace
@@ -129,6 +130,18 @@ from ..utils import (
 )
 
 DEFAULT_WORKSPACE_SIZE = 32 * 1024 * 1024
+
+# The CUTLASS FP4 GEMM sizes its workspace from the problem shape, and on SM120
+# that request exceeds 32 MiB for the batch sizes that dominate decoding: a
+# 5120x34816 NVFP4 GEMM asks for 34 MiB at every M from 1 to 256. When the
+# shared buffer is smaller than the request, csrc/fp4_gemm_cutlass_sm120.cu
+# allocates a private workspace per call and lets it fall out of scope right
+# after an asynchronous launch, which puts a device allocation on the model's
+# hot path and inside CUDA graph capture. Give mm_fp4 a shared buffer large
+# enough that the fallback is not taken.
+MM_FP4_WORKSPACE_SIZE = (
+    int(os.environ.get("FLASHINFER_MM_FP4_WORKSPACE_MB", "256")) * 1024 * 1024
+)
 
 # sizeof(cublasLtMatmulAlgo_t) = uint64_t[8] = 64 bytes.
 # Shared by cuBLAS FP8, cuBLASLt BF16, and any other cuBLASLt-based runners.
@@ -6873,7 +6886,7 @@ def mm_fp4(
         )
 
     workspace_buffer = _get_cache_buf(
-        "mm_fp4_workspace", DEFAULT_WORKSPACE_SIZE, a.device
+        "mm_fp4_workspace", MM_FP4_WORKSPACE_SIZE, a.device
     )
 
     # Auto-select the best backend

--- a/tests/gemm/test_mm_fp4.py
+++ b/tests/gemm/test_mm_fp4.py
@@ -275,5 +275,63 @@ def test_mm_fp4_cute_dsl_misaligned_n_raises():
         )
 
 
+@pytest.mark.parametrize("m", [1, 8, 24, 128, 256])
+def test_mm_fp4_does_not_allocate_per_call(m):
+    """mm_fp4 must run out of its shared workspace, not allocate one per call.
+
+    The CUTLASS FP4 GEMM sizes its workspace from the problem shape. When the
+    shared buffer is smaller than that, csrc/fp4_gemm_cutlass_sm120.cu allocates
+    a private workspace for the call and releases it immediately after an
+    asynchronous launch, which puts a device allocation on the model's hot path
+    and inside CUDA graph capture. The shapes below are a 27B model's fused
+    gate/up projection, which asks for 34 MiB on SM120 at every M up to 256.
+    """
+    compute_capability = get_compute_capability(torch.device(device="cuda"))
+    cc_number = compute_capability[0] * 10 + compute_capability[1]
+    if not mm_fp4.is_backend_supported("cutlass", cc_number):
+        pytest.skip(f"cutlass mm_fp4 unsupported on compute capability {cc_number}")
+
+    k, n = 5120, 34816
+    a = torch.randn([m, k], device="cuda", dtype=torch.bfloat16)
+    b = torch.randn([n, k], device="cuda", dtype=torch.bfloat16) / 10
+    g_in = (448 * 6) / a.float().abs().nan_to_num().max()
+    g_w = (448 * 6) / b.float().abs().nan_to_num().max()
+    a_fp4, a_s = nvfp4_quantize(
+        a, g_in, sfLayout=SfLayout.layout_128x4, do_shuffle=False
+    )
+    b_fp4, b_s = nvfp4_quantize(
+        b, g_w, sfLayout=SfLayout.layout_128x4, do_shuffle=False
+    )
+    out = torch.empty([m, n], device="cuda", dtype=torch.bfloat16)
+
+    def run():
+        mm_fp4(
+            a_fp4,
+            b_fp4.T,
+            a_s,
+            b_s.T,
+            1.0 / (g_in * g_w),
+            torch.bfloat16,
+            out=out,
+            block_size=16,
+            use_8x4_sf_layout=False,
+            backend="cutlass",
+            use_nvfp4=True,
+        )
+
+    run()  # first call sizes the shared workspace and warms the memo table
+    torch.cuda.synchronize()
+    before = torch.cuda.memory_allocated()
+    torch.cuda.reset_peak_memory_stats()
+    run()
+    torch.cuda.synchronize()
+    transient = torch.cuda.max_memory_allocated() - before
+    assert transient < 1 << 20, (
+        f"mm_fp4 allocated {transient / 2**20:.2f} MiB during the call; the "
+        "shared workspace is too small for this shape and the kernel took the "
+        "per-call allocation fallback"
+    )
+
+
 if __name__ == "__main__":
     pytest.main([__file__])


### PR DESCRIPTION
## 📌 Description

`mm_fp4` hands the CUTLASS FP4 GEMM a fixed 32 MiB shared workspace. On SM120 the kernel asks for more than that at exactly the batch sizes that dominate decoding, so `csrc/fp4_gemm_cutlass_sm120.cu` takes its fallback branch:

```cpp
if (provided_workspace_size < required_workspace_size) {
  Tensor new_workspace =
      alloc_tensor({required_workspace_size}, DLDataType{kDLInt, 8, 1}, mat1.device());
  runKernel(new_workspace.data_ptr());
}
```

That allocates a private workspace, launches the GEMM asynchronously against it, and lets the tensor fall out of scope right after the launch. A 5120 × 34816 NVFP4 GEMM asks for 34 MiB at every M from 1 to 256 and only drops under 32 MiB at M ≥ 384, so serving a 27B model whose MLP layers are NVFP4 performs 64 allocate-and-free cycles of 34 MiB on every decode step. The same allocation happens inside CUDA graph capture, since vLLM captures decode graphs at batch sizes 1 through 48.

This PR sizes the shared buffer so the fallback is not taken, and adds a test that fails when a call allocates.

Measured on an RTX PRO 6000 Blackwell (SM120), driver 595.71.05, CUDA 13.0.2, torch 2.11.0+cu130, reading the torch allocator peak across one `mm_fp4(backend="cutlass")` call for K=5120, N=34816:

| M | before | after |
|---|---|---|
| 1 | 34.00 MiB | 0.00 MiB |
| 8 | 34.00 MiB | 0.00 MiB |
| 24 | 34.00 MiB | 0.00 MiB |
| 48 | 34.00 MiB | 0.00 MiB |
| 128 | 34.88 MiB | 0.88 MiB |
| 256 | 34.00 MiB | 0.00 MiB |
| 384 | 0.00 MiB | 0.00 MiB |

The cost is a larger persistent cached buffer, 256 MiB per device instead of 32 MiB, tunable through `FLASHINFER_MM_FP4_WORKSPACE_MB`.

A constant is the smaller half of the fix. `getWorkspaceSize` already knows the real requirement per shape, and `_get_cache_buf` already grows a cached buffer on demand, so exposing that number to Python and passing it would remove the guesswork entirely. Independently, the C++ fallback would be safer keeping its private workspace in a per-device cache that outlives the launch rather than in a scoped `Tensor`. I am happy to follow up with either, or to fold one in here if you prefer.

Two adjacent things noticed while reading `fp4_gemm_cutlass_template_sm120.h`, left alone in this PR:

- `getWorkspaceSizeImpl` takes the maximum over every config rather than the config being run, so the reported requirement is the worst tactic's.
- `getWorkspaceSize` memoizes into a function-local `static std::unordered_map` with no lock.

## 🔍 Related Issues

Fixes #4549

## 🚀 Pull Request Checklist

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

`tests/gemm/test_mm_fp4.py::test_mm_fp4_does_not_allocate_per_call` fails on `main` with `mm_fp4 allocated 34.00 MiB during the call` at all five parametrized batch sizes, and passes with this change. The 792 existing `cutlass` NVFP4 `mm_fp4` cases in that file still pass on SM120.

## Reviewer Notes

The 256 MiB default is a judgment call, not a derived bound: it clears the largest requirement I could produce on SM120 with room to spare, but a shape that needs more would silently fall back again. That is the argument for plumbing `getWorkspaceSize` through to Python instead, which I would rather do if you agree it is the right shape of fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved FP4 matrix multiplication memory handling by using a larger shared workspace.
  * Reduced unexpected transient GPU memory allocation during repeated FP4 operations.
  * Added support for configuring the workspace size through an environment setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->