### PR TITLE
fix(sm120): explain sparse-MLA decode dispatch misses; add config query API

### DIFF
--- a/docs/api/attention.rst
+++ b/docs/api/attention.rst
@@ -217,6 +217,8 @@ PageAttention for MLA
     convert_compressed_page_aligned_sparse_indices_to_hca_metadata
     DSV4HCAMetadata
     xqa_batch_decode_with_kv_cache_mla
+    supported_sparse_mla_sm120_configs
+    SparseMLASm120DecodeConfig
 
 .. note::
 

--- a/flashinfer/mla/__init__.py
+++ b/flashinfer/mla/__init__.py
@@ -22,9 +22,16 @@ _PRIMS_TS_LAZY_EXPORTS = frozenset(
     }
 )
 
+_SPARSE_MLA_SM120_LAZY_EXPORTS = frozenset(
+    {
+        "SparseMLASm120DecodeConfig",
+        "supported_sparse_mla_sm120_configs",
+    }
+)
+
 
 def __getattr__(name: str):
-    """Resolve PrimTS MLA APIs without loading their runtime at import."""
+    """Resolve lazily-exported MLA APIs without loading their runtime at import."""
 
     if name in _PRIMS_TS_LAZY_EXPORTS:
         from ..attention.prims_ts import mla_decode as prims_ts_mla_decode
@@ -32,8 +39,17 @@ def __getattr__(name: str):
         value = getattr(prims_ts_mla_decode, name)
         globals()[name] = value
         return value
+    if name in _SPARSE_MLA_SM120_LAZY_EXPORTS:
+        from . import _sparse_mla_sm120
+
+        value = getattr(_sparse_mla_sm120, name)
+        globals()[name] = value
+        return value
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 def __dir__():
-    return sorted(set(globals()) | _PRIMS_TS_LAZY_EXPORTS)
+    """Include lazily-exported names alongside the module globals."""
+    return sorted(
+        set(globals()) | _PRIMS_TS_LAZY_EXPORTS | _SPARSE_MLA_SM120_LAZY_EXPORTS
+    )

--- a/flashinfer/mla/_sparse_mla_sm120.py
+++ b/flashinfer/mla/_sparse_mla_sm120.py
@@ -38,17 +38,23 @@ The user-facing sparse MLA entry points are
 for the DSv3.2 / GLM sparse top-k path. This module keeps only the SM120
 implementation hooks used by those dispatchers and focused kernel
 tests/benchmarks.
+
+Decode kernels are instantiated for a fixed set of ``(num_heads, topk)``
+pairs; ``flashinfer.mla.supported_sparse_mla_sm120_configs`` enumerates them
+so callers can validate a configuration at init time.
 """
 
 from __future__ import annotations
 
 import functools
 import os
+from dataclasses import dataclass
 from types import SimpleNamespace
 from typing import List, Optional
 
 import torch
 
+from ..api_logging import flashinfer_api
 from ..autotuner import (
     AutoTuner,
     ConstraintSpec,
@@ -139,6 +145,175 @@ _MODEL_TYPE_GLM_NSA = 2
 _KV_SCALE_FORMATS = frozenset({"auto", "pow2_fp32", "arbitrary_fp32"})
 _BPT_DSV3_2 = 656
 _BPT_DSV4 = 584
+
+# Kernel-family names used in the public config query and error messages.
+_MODEL_TYPE_TO_FAMILY = {
+    _MODEL_TYPE_DSV3_2: "dsv3_2",
+    _MODEL_TYPE_DSV4: "dsv4",
+    _MODEL_TYPE_GLM_NSA: "glm_nsa",
+}
+
+
+@dataclass(frozen=True)
+class SparseMLASm120DecodeConfig:
+    """Instantiated decode-kernel set for one SM120 sparse-MLA kernel family.
+
+    Decode-form calls (``num_tokens <= max_num_tokens``) dispatch to a
+    standalone decode kernel only when their shape matches one of the
+    instantiations described here; there is no prefill fallback for such
+    calls. Larger calls go through the prefill orchestrator, which has its
+    own separately instantiated shape envelope; this config describes
+    decode only.
+
+    Attributes
+    ----------
+    d_qk : int
+        Query/key head dim served by this family (``512`` for DSv4, ``576``
+        for DSv3.2 / GLM-NSA).
+    page_block_size : int
+        The only KV page block size the decode kernels are instantiated for.
+    max_num_tokens : int
+        Largest ``num_tokens`` routed to the decode kernels (inclusive).
+    head_topk_pairs : frozenset[tuple[int, int]]
+        The instantiated ``(num_heads, topk)`` pairs.
+    """
+
+    d_qk: int
+    page_block_size: int
+    max_num_tokens: int
+    head_topk_pairs: frozenset[tuple[int, int]]
+
+    def supported_num_heads(self) -> tuple[int, ...]:
+        """Sorted head counts with at least one instantiated top-k."""
+        return tuple(sorted({h for h, _ in self.head_topk_pairs}))
+
+    def supported_topk(self, num_heads: Optional[int] = None) -> tuple[int, ...]:
+        """Sorted top-k values instantiated for ``num_heads`` (or any head count)."""
+        return tuple(
+            sorted(
+                {
+                    t
+                    for h, t in self.head_topk_pairs
+                    if num_heads is None or h == num_heads
+                }
+            )
+        )
+
+    def supports_decode(
+        self,
+        num_heads: int,
+        topk: int,
+        *,
+        num_tokens: int = 1,
+        page_block_size: Optional[int] = None,
+    ) -> bool:
+        """True iff a decode-form call with this shape reaches a decode kernel."""
+        if page_block_size is None:
+            page_block_size = self.page_block_size
+        return (
+            num_tokens <= self.max_num_tokens
+            and page_block_size == self.page_block_size
+            and (num_heads, topk) in self.head_topk_pairs
+        )
+
+
+@flashinfer_api
+def supported_sparse_mla_sm120_configs() -> dict[str, SparseMLASm120DecodeConfig]:
+    """Enumerate the instantiated SM120 sparse-MLA decode kernel configurations.
+
+    Lets callers validate a serving configuration at initialization time
+    instead of discovering an uninstantiated ``(num_heads, topk)`` pair on the
+    first decode-form request.
+
+    Returns
+    -------
+    dict[str, SparseMLASm120DecodeConfig]
+        Mapping from kernel family to its instantiated decode set, keyed by
+        ``"dsv4"`` (``d_qk=512``), ``"dsv3_2"`` (``d_qk=576``, power-of-2
+        FP32 scales), and ``"glm_nsa"`` (``d_qk=576``, arbitrary FP32 scales;
+        shares the DSv3.2 decode instantiations).
+
+    Examples
+    --------
+    >>> import flashinfer
+    >>> configs = flashinfer.mla.supported_sparse_mla_sm120_configs()
+    >>> configs["dsv4"].supports_decode(num_heads=64, topk=256)
+    True
+    """
+    dsv3_2 = SparseMLASm120DecodeConfig(
+        d_qk=576,
+        page_block_size=_DECODE_DSV3_2_PAGE_BLOCK_SIZE,
+        max_num_tokens=_DECODE_MAX_TOKENS,
+        head_topk_pairs=_DECODE_DSV3_2_DISPATCH,
+    )
+    return {
+        "dsv4": SparseMLASm120DecodeConfig(
+            d_qk=512,
+            page_block_size=_DECODE_DSV4_PAGE_BLOCK_SIZE,
+            max_num_tokens=_DECODE_MAX_TOKENS,
+            head_topk_pairs=_DECODE_DSV4_DISPATCH,
+        ),
+        "dsv3_2": dsv3_2,
+        "glm_nsa": dsv3_2,
+    }
+
+
+def _decode_dispatch_error_message(
+    *,
+    num_tokens: int,
+    num_heads: int,
+    topk: int,
+    d_qk: int,
+    page_block_size: int,
+    model_type: int,
+    extra_topk: int,
+) -> str:
+    """Build the decode dispatch-miss error, naming the mismatched parameter."""
+    family = _MODEL_TYPE_TO_FAMILY[model_type]
+    config = supported_sparse_mla_sm120_configs()[family]
+    reasons = []
+    if d_qk != config.d_qk:
+        reasons.append(
+            f"d_qk={d_qk} does not match the {family} decode family "
+            f"(requires d_qk={config.d_qk})"
+        )
+    if page_block_size != config.page_block_size:
+        reasons.append(
+            f"page_block_size={page_block_size} is unsupported; decode kernels "
+            f"are instantiated only for page_block_size={config.page_block_size}"
+        )
+    if (num_heads, topk) not in config.head_topk_pairs:
+        heads = config.supported_num_heads()
+        if num_heads in heads:
+            reasons.append(
+                f"topk={topk} is not instantiated for num_heads={num_heads}; "
+                f"available topk: {list(config.supported_topk(num_heads))}"
+            )
+        elif topk in config.supported_topk():
+            reasons.append(
+                f"num_heads={num_heads} is not instantiated for topk={topk}; "
+                f"available num_heads: {list(heads)}"
+            )
+        else:
+            reasons.append(
+                f"neither num_heads={num_heads} nor topk={topk} is instantiated; "
+                f"available num_heads: {list(heads)}; "
+                f"available topk: {list(config.supported_topk())}"
+            )
+    # The dispatch branches guarantee at least one reason; the fallback only
+    # guards future drift between them and this diagnosis.
+    detail = "; ".join(reasons) or "no matching decode instantiation"
+    return (
+        "SM120 sparse-MLA has no decode kernel for this shape: "
+        f"num_tokens={num_tokens}, num_heads={num_heads}, topk={topk}, "
+        f"d_qk={d_qk}, page_block_size={page_block_size}, "
+        f"model_type={family}, extra_topk={extra_topk}. "
+        f"Mismatch: {detail}. "
+        f"The prefill orchestrator only serves num_tokens > {_DECODE_MAX_TOKENS}, "
+        "so a decode-form call must match a decode instantiation exactly. "
+        "Query supported shapes at init time with "
+        "flashinfer.mla.supported_sparse_mla_sm120_configs()."
+    )
 
 
 def _require_d_v_512(d_v: int) -> None:
@@ -392,11 +567,15 @@ def get_sparse_mla_sm120_module():
         # the process in the kernel.
         if num_tokens <= _DECODE_MAX_TOKENS:
             raise ValueError(
-                "SM120 sparse-MLA has no decode kernel for this shape: "
-                f"num_tokens={num_tokens}, num_heads={num_heads}, topk={topk}, "
-                f"d_qk={d_qk}, page_block_size={kv_pbs}, model_type={model_type}, "
-                f"extra_topk={extra_topk}. Supported decode shapes are enumerated "
-                "in _DECODE_DSV4_DISPATCH and _DECODE_DSV3_2_DISPATCH."
+                _decode_dispatch_error_message(
+                    num_tokens=num_tokens,
+                    num_heads=num_heads,
+                    topk=topk,
+                    d_qk=d_qk,
+                    page_block_size=kv_pbs,
+                    model_type=model_type,
+                    extra_topk=extra_topk,
+                )
             )
 
         module.sparse_mla_sm120_paged_attention(

--- a/tests/attention/test_sparse_mla_sm120.py
+++ b/tests/attention/test_sparse_mla_sm120.py
@@ -455,6 +455,43 @@ def test_sparse_mla_sm120_decode_unsupported_shape_fails_before_prefill() -> Non
     with pytest.raises(
         ValueError,
         match=r"no decode kernel.*num_tokens=1, num_heads=16, topk=384",
+    ) as excinfo:
+        sparse_mla_sm120_paged_attention(
+            q,
+            kv_cache,
+            indices,
+            output,
+            out_lse,
+            d_qk**-0.5,
+            d_v=d_v,
+        )
+    # The error must name the actual mismatch, not just the token count.
+    msg = str(excinfo.value)
+    assert "topk=384 is not instantiated for num_heads=16" in msg
+    assert "available topk: [128, 192, 256, 512, 1024]" in msg
+    assert "supported_sparse_mla_sm120_configs" in msg
+
+
+def test_sparse_mla_sm120_decode_wrong_page_block_size_fails_before_prefill() -> None:
+    """A decode shape with an uninstantiated page size names the page size."""
+    device = torch.device("cuda")
+    num_tokens, num_heads, topk = 1, 16, 128
+    d_qk = d_v = 512
+    page_block_size = 128  # decode kernels only exist for 64
+
+    q = torch.empty((num_tokens, num_heads, d_qk), dtype=torch.bfloat16, device=device)
+    kv_cache = torch.empty(
+        (1, page_block_size, 1, 584), dtype=torch.uint8, device=device
+    )
+    indices = torch.zeros((num_tokens, topk), dtype=torch.int32, device=device)
+    output = torch.empty(
+        (num_tokens, num_heads, d_v), dtype=torch.bfloat16, device=device
+    )
+    out_lse = torch.empty((num_tokens, num_heads), dtype=torch.float32, device=device)
+
+    with pytest.raises(
+        ValueError,
+        match=r"page_block_size=128 is unsupported",
     ):
         sparse_mla_sm120_paged_attention(
             q,

--- a/tests/attention/test_sparse_mla_sm120_dispatch.py
+++ b/tests/attention/test_sparse_mla_sm120_dispatch.py
@@ -1,0 +1,240 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+# list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+"""Dispatch-table and config-query tests for sparse-MLA SM120.
+
+Pure-Python coverage of :func:`supported_sparse_mla_sm120_configs` and the
+decode dispatch-miss diagnostics (flashinfer-ai/flashinfer#4541). No GPU or
+JIT build required; the raise path inside the kernel dispatcher is covered by
+``test_sparse_mla_sm120.py`` on SM12x hardware.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import re
+
+import pytest
+
+import flashinfer
+from flashinfer.mla import (
+    SparseMLASm120DecodeConfig,
+    supported_sparse_mla_sm120_configs,
+)
+from flashinfer.mla._sparse_mla_sm120 import (
+    _DECODE_DSV3_2_DISPATCH,
+    _DECODE_DSV4_DISPATCH,
+    _DECODE_MAX_TOKENS,
+    _MODEL_TYPE_DSV3_2,
+    _MODEL_TYPE_DSV4,
+    _MODEL_TYPE_GLM_NSA,
+    _decode_dispatch_error_message,
+    _decode_dsv3_2_dispatchable,
+    _decode_dsv4_dispatchable,
+)
+
+
+def test_supported_configs_families() -> None:
+    """The query API mirrors the private dispatch tables exactly."""
+    configs = supported_sparse_mla_sm120_configs()
+    assert set(configs) == {"dsv4", "dsv3_2", "glm_nsa"}
+    assert all(
+        isinstance(config, SparseMLASm120DecodeConfig) for config in configs.values()
+    )
+
+    dsv4 = configs["dsv4"]
+    assert dsv4.d_qk == 512
+    assert dsv4.page_block_size == 64
+    assert dsv4.max_num_tokens == _DECODE_MAX_TOKENS
+    assert dsv4.head_topk_pairs == _DECODE_DSV4_DISPATCH
+
+    dsv3_2 = configs["dsv3_2"]
+    assert dsv3_2.d_qk == 576
+    assert dsv3_2.page_block_size == 64
+    assert dsv3_2.head_topk_pairs == _DECODE_DSV3_2_DISPATCH
+
+    # GLM-NSA shares the DSv3.2 decode instantiations (same config object).
+    assert configs["glm_nsa"] is dsv3_2
+
+
+def test_supported_configs_reachable_from_flashinfer_mla() -> None:
+    """The lazy export resolves through the public flashinfer.mla namespace."""
+    assert (
+        flashinfer.mla.supported_sparse_mla_sm120_configs
+        is supported_sparse_mla_sm120_configs
+    )
+    assert "supported_sparse_mla_sm120_configs" in dir(flashinfer.mla)
+    assert "SparseMLASm120DecodeConfig" in dir(flashinfer.mla)
+
+
+def test_supported_configs_are_frozen() -> None:
+    """Configs are immutable: frozen dataclass over frozenset pairs."""
+    configs = supported_sparse_mla_sm120_configs()
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        configs["dsv4"].d_qk = 999  # type: ignore[misc]
+    assert isinstance(configs["dsv4"].head_topk_pairs, frozenset)
+
+
+def test_supported_helpers() -> None:
+    """supported_num_heads / supported_topk return sorted tuples."""
+    dsv4 = supported_sparse_mla_sm120_configs()["dsv4"]
+    assert dsv4.supported_num_heads() == (8, 16, 32, 64, 128)
+    assert dsv4.supported_topk(64) == (128, 192, 256, 512, 1024)
+    assert dsv4.supported_topk() == (128, 192, 256, 512, 1024)
+    assert dsv4.supported_topk(48) == ()
+
+    dsv3_2 = supported_sparse_mla_sm120_configs()["dsv3_2"]
+    assert dsv3_2.supported_topk(64) == (128, 512, 1024, 2048)
+
+
+def test_supports_decode_matches_dispatch_predicates() -> None:
+    """config.supports_decode agrees with the internal dispatch predicates."""
+    configs = supported_sparse_mla_sm120_configs()
+    dsv4 = configs["dsv4"]
+    for num_heads, topk in sorted(dsv4.head_topk_pairs):
+        assert dsv4.supports_decode(num_heads, topk)
+        assert _decode_dsv4_dispatchable(1, num_heads, topk, 512, 64)
+        assert _decode_dsv4_dispatchable(_DECODE_MAX_TOKENS, num_heads, topk, 512, 64)
+
+    dsv3_2 = configs["dsv3_2"]
+    for num_heads, topk in sorted(dsv3_2.head_topk_pairs):
+        assert dsv3_2.supports_decode(num_heads, topk)
+        assert _decode_dsv3_2_dispatchable(1, num_heads, topk, 576, 64)
+
+
+def test_supports_decode_rejects_mismatches() -> None:
+    """supports_decode is False for any out-of-set shape parameter."""
+    dsv4 = supported_sparse_mla_sm120_configs()["dsv4"]
+    assert not dsv4.supports_decode(64, 384)  # topk not instantiated
+    assert not dsv4.supports_decode(48, 256)  # num_heads not instantiated
+    assert not dsv4.supports_decode(64, 256, page_block_size=32)
+    assert not dsv4.supports_decode(64, 256, num_tokens=_DECODE_MAX_TOKENS + 1)
+    assert dsv4.supports_decode(64, 256, num_tokens=_DECODE_MAX_TOKENS)
+    assert not _decode_dsv4_dispatchable(1, 64, 384, 512, 64)
+    assert not _decode_dsv4_dispatchable(_DECODE_MAX_TOKENS + 1, 64, 256, 512, 64)
+
+
+def test_error_message_names_topk_mismatch() -> None:
+    """The issue-#4541 scenario: decode-form call, uninstantiated topk."""
+    msg = _decode_dispatch_error_message(
+        num_tokens=5,
+        num_heads=64,
+        topk=384,
+        d_qk=512,
+        page_block_size=64,
+        model_type=_MODEL_TYPE_DSV4,
+        extra_topk=0,
+    )
+    assert "topk=384 is not instantiated for num_heads=64" in msg
+    assert "available topk: [128, 192, 256, 512, 1024]" in msg
+    assert "num_tokens > 64" in msg
+    assert "supported_sparse_mla_sm120_configs" in msg
+    # The matching page size must not be blamed.
+    assert "page_block_size=64 is unsupported" not in msg
+
+
+def test_error_message_names_num_heads_mismatch() -> None:
+    """An uninstantiated head count is named with the available ones."""
+    msg = _decode_dispatch_error_message(
+        num_tokens=1,
+        num_heads=48,
+        topk=256,
+        d_qk=512,
+        page_block_size=64,
+        model_type=_MODEL_TYPE_DSV4,
+        extra_topk=0,
+    )
+    assert "num_heads=48 is not instantiated for topk=256" in msg
+    assert "available num_heads: [8, 16, 32, 64, 128]" in msg
+
+
+def test_error_message_names_both_mismatches() -> None:
+    """Both num_heads and topk out of set are reported together."""
+    msg = _decode_dispatch_error_message(
+        num_tokens=1,
+        num_heads=48,
+        topk=384,
+        d_qk=512,
+        page_block_size=64,
+        model_type=_MODEL_TYPE_DSV4,
+        extra_topk=0,
+    )
+    assert "neither num_heads=48 nor topk=384 is instantiated" in msg
+    assert "available num_heads: [8, 16, 32, 64, 128]" in msg
+    assert "available topk: [128, 192, 256, 512, 1024]" in msg
+
+
+def test_error_message_names_page_block_size_mismatch() -> None:
+    """An uninstantiated page size is named; valid pairs are not blamed."""
+    msg = _decode_dispatch_error_message(
+        num_tokens=1,
+        num_heads=64,
+        topk=256,
+        d_qk=512,
+        page_block_size=32,
+        model_type=_MODEL_TYPE_DSV4,
+        extra_topk=0,
+    )
+    assert "page_block_size=32 is unsupported" in msg
+    assert "instantiated only for page_block_size=64" in msg
+    # (num_heads=64, topk=256) is instantiated, so it must not be blamed.
+    assert "topk=256 is not instantiated" not in msg
+
+
+def test_error_message_dsv3_2_family() -> None:
+    """DSv3.2 and GLM-NSA report their family name and topk set."""
+    for model_type, family in (
+        (_MODEL_TYPE_DSV3_2, "dsv3_2"),
+        (_MODEL_TYPE_GLM_NSA, "glm_nsa"),
+    ):
+        msg = _decode_dispatch_error_message(
+            num_tokens=2,
+            num_heads=128,
+            topk=192,
+            d_qk=576,
+            page_block_size=64,
+            model_type=model_type,
+            extra_topk=0,
+        )
+        assert f"model_type={family}" in msg
+        assert "topk=192 is not instantiated for num_heads=128" in msg
+        assert "available topk: [128, 512, 1024, 2048]" in msg
+
+
+def test_error_message_keeps_shape_summary_format() -> None:
+    """Callers grepping for the pre-existing message shape keep working."""
+    msg = _decode_dispatch_error_message(
+        num_tokens=1,
+        num_heads=16,
+        topk=384,
+        d_qk=512,
+        page_block_size=64,
+        model_type=_MODEL_TYPE_DSV4,
+        extra_topk=0,
+    )
+    assert re.search(r"no decode kernel.*num_tokens=1, num_heads=16, topk=384", msg)


### PR DESCRIPTION
## Description

Follow-up to #4380 for #4541.

On SM120, sparse-MLA decode kernels are instantiated for a fixed set of
`(num_heads, topk)` pairs with `page_block_size=64`. Since #4380, a
decode-form call (`num_tokens <= 64`) that misses every decode instantiation
raises in Python instead of reaching the prefill orchestrator's C++
`num_tokens > 64` assert, but the error is a flat parameter dump that points
at private module internals (`_DECODE_DSV4_DISPATCH` /
`_DECODE_DSV3_2_DISPATCH`), so the caller still has to open the source to
learn what to change. #4541 asks for the two remaining pieces, added here:

1. **Dispatch-miss diagnosis.** The `ValueError` now names the actual
   mismatch and enumerates what is instantiated, e.g.:

   ```
   SM120 sparse-MLA has no decode kernel for this shape: num_tokens=5,
   num_heads=64, topk=384, d_qk=512, page_block_size=64, model_type=dsv4,
   extra_topk=0. Mismatch: topk=384 is not instantiated for num_heads=64;
   available topk: [128, 192, 256, 512, 1024]. The prefill orchestrator only
   serves num_tokens > 64, so a decode-form call must match a decode
   instantiation exactly. Query supported shapes at init time with
   flashinfer.mla.supported_sparse_mla_sm120_configs().
   ```

   The diagnosis distinguishes uninstantiated `topk` (for an instantiated
   head count), uninstantiated `num_heads`, both, `page_block_size != 64`,
   and `d_qk`/family mismatch. The pre-existing message prefix and shape
   summary (`no decode kernel ... num_tokens=..., num_heads=..., topk=...`)
   are kept so existing callers matching on it keep working.

2. **`flashinfer.mla.supported_sparse_mla_sm120_configs()`** — a public
   query API returning a `{"dsv4" | "dsv3_2" | "glm_nsa":
   SparseMLASm120DecodeConfig}` mapping (frozen dataclass with `d_qk`,
   `page_block_size`, `max_num_tokens`, `head_topk_pairs`, plus
   `supports_decode()` / `supported_topk()` / `supported_num_heads()`
   helpers). This lets callers such as vLLM validate a serving configuration
   at init time instead of poking at private dispatch tables
   (vllm-project/vllm#51538 currently has to do the latter). Exported
   lazily from `flashinfer.mla` following the existing prims-ts lazy-export
   pattern, and added to the `docs/api/attention.rst` autosummary.

No kernel or dispatch-behavior changes: every shape that dispatched to a
kernel before still dispatches identically; only the no-kernel error path
and the new query API changed.

## Related Issues

Fixes #4541. Follow-up to #4380. Motivating downstream check:
vllm-project/vllm#51538.

## Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

## Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

Tested locally on an RTX 5070 Ti (SM120, CUDA 13.2, torch 2.8, JIT build from source):

- `pytest tests/attention/test_sparse_mla_sm120_dispatch.py` — **12 passed** (new file; pure Python, no GPU required)
- `pytest tests/attention/test_sparse_mla_sm120.py` — **310 passed** (full SM12x suite: all decode/prefill correctness tests plus the extended and new dispatch-failure tests)
- `pre-commit run --all-files` — all hooks pass (ruff check/format, mypy, whitespace/EOL)

## Reviewer Notes

- `tests/attention/test_sparse_mla_sm120_dispatch.py` is deliberately not
  gated on SM12x: it covers the config query and the message builder as pure
  Python so the diagnosis logic is exercised on any CI node. The actual raise
  inside the dispatcher stays covered by the (extended) SM12x-gated tests in
  `test_sparse_mla_sm120.py`.
- `supported_sparse_mla_sm120_configs()` exposes the instantiation sets by
  reference as `frozenset`s (immutable), so the public view can never drift
  from the dispatch tables.
- The `"glm_nsa"` entry aliases the `"dsv3_2"` config object since GLM-NSA
  decode shares the DSv3.2 instantiations; if the sets ever diverge, only the
  constructor needs to split.
- The new test file carries the same NVIDIA BSD-3 header as its sibling
  `test_sparse_mla_sm120.py` for consistency within the SM120 sparse-MLA
  family; happy to switch it to the Apache-2.0 header (or drop it) if you
  prefer for externally-authored tests.

Developed in combination with Claude Fable 5.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added public configuration details for supported SM120 sparse MLA decode variants, including dimensions, page sizes, token limits, head counts, and top-k values.
  - Added validation helpers for checking supported decode configurations.
  - Improved access to these APIs through the MLA package.

- **Bug Fixes**
  - Decode errors now identify unsupported dimensions, page sizes, head counts, and top-k values.

- **Documentation**
  - Expanded API documentation for the configuration query and configuration type.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->