### PR TITLE
Declutter output by collating all tests not run due to runner timeout

### DIFF
--- a/scripts/test_sharding/junit.py
+++ b/scripts/test_sharding/junit.py
@@ -11,6 +11,9 @@ from .io import atomic_write_xml
 from .models import base_function_for_nodeid, source_file_for_nodeid
 
 
+TIMEOUT_DIAGNOSTIC = "not executed due to timeout"
+
+
 @dataclass(frozen=True)
 class TestCaseResult:
     nodeid: str
@@ -228,9 +231,9 @@ def create_synthetic_batch_xml(
         result = ET.SubElement(
             testcase,
             result_tag,
-            message="not executed due to timeout",
+            message=TIMEOUT_DIAGNOSTIC,
         )
-        result.text = "not executed due to timeout"
+        result.text = TIMEOUT_DIAGNOSTIC
     root = ET.Element(
         "testsuites",
         tests=str(len(nodeids)),

--- a/scripts/test_sharding/summary.py
+++ b/scripts/test_sharding/summary.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from typing import Any, TypedDict, cast
 
 from .io import atomic_write_json, atomic_write_text
-from .junit import validate_batch_xml
+from .junit import TIMEOUT_DIAGNOSTIC, validate_batch_xml
 from .models import Batch, Plan, Unit
 from .planner import CapacityMetrics, capacity_metrics
 from .state import AttemptRecord, list_attempts, load_attempt, state_lock
@@ -705,7 +705,16 @@ def _failure_detail_lines(
     if not failed_nodes:
         return []
     lines = [_TERMINAL_SEPARATOR, "FAILED TEST NODES", _TERMINAL_SEPARATOR]
+    timeout_failures: list[FailedNodeSummary] = []
+    regular_failures: list[FailedNodeSummary] = []
     for failure in failed_nodes:
+        diagnostic = str(failure["diagnostic"])
+        if failure["synthetic"] and diagnostic.strip() == TIMEOUT_DIAGNOSTIC:
+            timeout_failures.append(failure)
+        else:
+            regular_failures.append(failure)
+
+    for failure in regular_failures:
         diagnostic = str(failure["diagnostic"])
         encoded = diagnostic.encode("utf-8")
         truncated = len(encoded) > diagnostic_limit
@@ -726,6 +735,10 @@ def _failure_detail_lines(
                 f"    junit: {failure['junit_path']}",
             ]
         )
+    if timeout_failures:
+        count = len(timeout_failures)
+        noun = "node" if count == 1 else "nodes"
+        lines.append(f"  {TIMEOUT_DIAGNOSTIC.capitalize()} ({count} {noun})")
     return lines
 
 


### PR DESCRIPTION
## 📌 Description

Currently, when a unit test is terminated due to a timeout, the list of test nodes could be marked as failed. Then, in the summary, all failures are printed with the failure message and other details. Since a runner timeout can cause a lot of test nodes to fail, the list of failures will be very long and cause the summary to be cluttered. This PR removes these (since the failures are not to be fixed one by one) but reports a summary count instead.

## 🔍 Related Issues

Nil. Internal discussion only.

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

Unit test failures can be due to an actual failure because the test did not pass, or a "synthetic failure" that is assigned to a test because of a timeout. The former is still reported with the failure message. The latter is the focus of this PR. Synthetic failures can be caused by the following reasons:

- The node executing when the timeout occurred.
- Nodes that were never started.
- Nodes that completed earlier in the killed batch, since their temporary results are also discarded.
- Unit timeout versus overall runner deadline on a per-node basis.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved test result summaries for timed-out tests.
  * Timeout failures are now clearly distinguished from regular failures.
  * Timeout summaries use accurate singular or plural wording, while regular failures retain detailed diagnostics and links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->