### PR TITLE
bugfix: never resize_() the shared cuDNN GEMM workspace (use-after-free under CUDA graphs)

### DIFF
--- a/flashinfer/gemm/gemm_base.py
+++ b/flashinfer/gemm/gemm_base.py
@@ -2940,7 +2940,14 @@ def execute_cudnn_gemm_fp4_graph(
         # Satisfy oversized requests with a call-local buffer instead;
         # stream-ordered allocation keeps eager mode safe, and during
         # capture the buffer is owned by the capturing graph's pool.
-        workspace_buffer = torch.empty(
+        # The buffer must be ZERO-initialized: cuDNN split-K plans keep
+        # completion semaphores in the workspace, and a kernel handed a
+        # recycled dirty block spins on garbage semaphore values (observed
+        # as an indefinite 100%-utilization GPU hang; with
+        # CUDA_LAUNCH_BLOCKING=1 it surfaces as CUDA error 702). During
+        # capture the zero-fill is captured too, so replays re-arm the
+        # semaphores.
+        workspace_buffer = torch.zeros(
             workspace_size, dtype=torch.uint8, device=workspace_buffer.device
         )
 
@@ -3184,7 +3191,14 @@ def execute_cudnn_gemm_fp4_graph_override_shape(
         # Satisfy oversized requests with a call-local buffer instead;
         # stream-ordered allocation keeps eager mode safe, and during
         # capture the buffer is owned by the capturing graph's pool.
-        workspace = torch.empty(
+        # The buffer must be ZERO-initialized: cuDNN split-K plans keep
+        # completion semaphores in the workspace, and a kernel handed a
+        # recycled dirty block spins on garbage semaphore values (observed
+        # as an indefinite 100%-utilization GPU hang; with
+        # CUDA_LAUNCH_BLOCKING=1 it surfaces as CUDA error 702). During
+        # capture the zero-fill is captured too, so replays re-arm the
+        # semaphores.
+        workspace = torch.zeros(
             workspace_size, dtype=torch.uint8, device=workspace.device
         )
 
@@ -3277,7 +3291,14 @@ def execute_cudnn_gemm_mxfp8_graph(
         # Satisfy oversized requests with a call-local buffer instead;
         # stream-ordered allocation keeps eager mode safe, and during
         # capture the buffer is owned by the capturing graph's pool.
-        workspace_buffer = torch.empty(
+        # The buffer must be ZERO-initialized: cuDNN split-K plans keep
+        # completion semaphores in the workspace, and a kernel handed a
+        # recycled dirty block spins on garbage semaphore values (observed
+        # as an indefinite 100%-utilization GPU hang; with
+        # CUDA_LAUNCH_BLOCKING=1 it surfaces as CUDA error 702). During
+        # capture the zero-fill is captured too, so replays re-arm the
+        # semaphores.
+        workspace_buffer = torch.zeros(
             workspace_size, dtype=torch.uint8, device=workspace_buffer.device
         )
 
@@ -3509,7 +3530,14 @@ def execute_cudnn_gemm_mxfp8_graph_override_shape(
         # Satisfy oversized requests with a call-local buffer instead;
         # stream-ordered allocation keeps eager mode safe, and during
         # capture the buffer is owned by the capturing graph's pool.
-        workspace = torch.empty(
+        # The buffer must be ZERO-initialized: cuDNN split-K plans keep
+        # completion semaphores in the workspace, and a kernel handed a
+        # recycled dirty block spins on garbage semaphore values (observed
+        # as an indefinite 100%-utilization GPU hang; with
+        # CUDA_LAUNCH_BLOCKING=1 it surfaces as CUDA error 702). During
+        # capture the zero-fill is captured too, so replays re-arm the
+        # semaphores.
+        workspace = torch.zeros(
             workspace_size, dtype=torch.uint8, device=workspace.device
         )
 
@@ -3637,7 +3665,14 @@ def execute_cudnn_gemm_fp8_graph(
         # Satisfy oversized requests with a call-local buffer instead;
         # stream-ordered allocation keeps eager mode safe, and during
         # capture the buffer is owned by the capturing graph's pool.
-        workspace = torch.empty(
+        # The buffer must be ZERO-initialized: cuDNN split-K plans keep
+        # completion semaphores in the workspace, and a kernel handed a
+        # recycled dirty block spins on garbage semaphore values (observed
+        # as an indefinite 100%-utilization GPU hang; with
+        # CUDA_LAUNCH_BLOCKING=1 it surfaces as CUDA error 702). During
+        # capture the zero-fill is captured too, so replays re-arm the
+        # semaphores.
+        workspace = torch.zeros(
             workspace_size, dtype=torch.uint8, device=workspace.device
         )
 
@@ -3785,7 +3820,14 @@ def execute_cudnn_gemm_fp8_graph_override_shape(
         # Satisfy oversized requests with a call-local buffer instead;
         # stream-ordered allocation keeps eager mode safe, and during
         # capture the buffer is owned by the capturing graph's pool.
-        workspace = torch.empty(
+        # The buffer must be ZERO-initialized: cuDNN split-K plans keep
+        # completion semaphores in the workspace, and a kernel handed a
+        # recycled dirty block spins on garbage semaphore values (observed
+        # as an indefinite 100%-utilization GPU hang; with
+        # CUDA_LAUNCH_BLOCKING=1 it surfaces as CUDA error 702). During
+        # capture the zero-fill is captured too, so replays re-arm the
+        # semaphores.
+        workspace = torch.zeros(
             workspace_size, dtype=torch.uint8, device=workspace.device
         )
 
@@ -4089,7 +4131,14 @@ def execute_cudnn_gemm_bf16_graph(graph, a, b, bias, c_final, workspace, tactic=
         # Satisfy oversized requests with a call-local buffer instead;
         # stream-ordered allocation keeps eager mode safe, and during
         # capture the buffer is owned by the capturing graph's pool.
-        workspace = torch.empty(
+        # The buffer must be ZERO-initialized: cuDNN split-K plans keep
+        # completion semaphores in the workspace, and a kernel handed a
+        # recycled dirty block spins on garbage semaphore values (observed
+        # as an indefinite 100%-utilization GPU hang; with
+        # CUDA_LAUNCH_BLOCKING=1 it surfaces as CUDA error 702). During
+        # capture the zero-fill is captured too, so replays re-arm the
+        # semaphores.
+        workspace = torch.zeros(
             workspace_size, dtype=torch.uint8, device=workspace.device
         )
 
@@ -4274,7 +4323,14 @@ def execute_cudnn_gemm_bf16_graph_override_shape(
         # Satisfy oversized requests with a call-local buffer instead;
         # stream-ordered allocation keeps eager mode safe, and during
         # capture the buffer is owned by the capturing graph's pool.
-        workspace = torch.empty(
+        # The buffer must be ZERO-initialized: cuDNN split-K plans keep
+        # completion semaphores in the workspace, and a kernel handed a
+        # recycled dirty block spins on garbage semaphore values (observed
+        # as an indefinite 100%-utilization GPU hang; with
+        # CUDA_LAUNCH_BLOCKING=1 it surfaces as CUDA error 702). During
+        # capture the zero-fill is captured too, so replays re-arm the
+        # semaphores.
+        workspace = torch.zeros(
             workspace_size, dtype=torch.uint8, device=workspace.device
         )
 

--- a/flashinfer/gemm/gemm_base.py
+++ b/flashinfer/gemm/gemm_base.py
@@ -2933,7 +2933,16 @@ def execute_cudnn_gemm_fp4_graph(
 
     workspace_size = _get_cudnn_workspace_size(graph, plan_index)
     if workspace_buffer.numel() < workspace_size:
-        workspace_buffer.resize_(workspace_size)
+        # Never resize_() the shared workspace: its device address may be
+        # baked into captured CUDA graphs and referenced by in-flight
+        # launches, and resize_() frees the old storage, leaving those
+        # consumers reading and writing freed (soon re-allocated) memory.
+        # Satisfy oversized requests with a call-local buffer instead;
+        # stream-ordered allocation keeps eager mode safe, and during
+        # capture the buffer is owned by the capturing graph's pool.
+        workspace_buffer = torch.empty(
+            workspace_size, dtype=torch.uint8, device=workspace_buffer.device
+        )
 
     stream = torch.cuda.current_stream(a.device)
 
@@ -3168,7 +3177,16 @@ def execute_cudnn_gemm_fp4_graph_override_shape(
         override_strides,
     )
     if workspace.numel() < workspace_size:
-        workspace.resize_(workspace_size)
+        # Never resize_() the shared workspace: its device address may be
+        # baked into captured CUDA graphs and referenced by in-flight
+        # launches, and resize_() frees the old storage, leaving those
+        # consumers reading and writing freed (soon re-allocated) memory.
+        # Satisfy oversized requests with a call-local buffer instead;
+        # stream-ordered allocation keeps eager mode safe, and during
+        # capture the buffer is owned by the capturing graph's pool.
+        workspace = torch.empty(
+            workspace_size, dtype=torch.uint8, device=workspace.device
+        )
 
     if plan_index < 0:
         graph.execute(
@@ -3252,7 +3270,16 @@ def execute_cudnn_gemm_mxfp8_graph(
     workspace_size = _get_cudnn_workspace_size(graph, plan_index)
 
     if workspace_buffer.numel() < workspace_size:
-        workspace_buffer.resize_(workspace_size)
+        # Never resize_() the shared workspace: its device address may be
+        # baked into captured CUDA graphs and referenced by in-flight
+        # launches, and resize_() frees the old storage, leaving those
+        # consumers reading and writing freed (soon re-allocated) memory.
+        # Satisfy oversized requests with a call-local buffer instead;
+        # stream-ordered allocation keeps eager mode safe, and during
+        # capture the buffer is owned by the capturing graph's pool.
+        workspace_buffer = torch.empty(
+            workspace_size, dtype=torch.uint8, device=workspace_buffer.device
+        )
 
     stream = torch.cuda.current_stream(a.device)
 
@@ -3475,7 +3502,16 @@ def execute_cudnn_gemm_mxfp8_graph_override_shape(
         override_strides,
     )
     if workspace.numel() < workspace_size:
-        workspace.resize_(workspace_size)
+        # Never resize_() the shared workspace: its device address may be
+        # baked into captured CUDA graphs and referenced by in-flight
+        # launches, and resize_() frees the old storage, leaving those
+        # consumers reading and writing freed (soon re-allocated) memory.
+        # Satisfy oversized requests with a call-local buffer instead;
+        # stream-ordered allocation keeps eager mode safe, and during
+        # capture the buffer is owned by the capturing graph's pool.
+        workspace = torch.empty(
+            workspace_size, dtype=torch.uint8, device=workspace.device
+        )
 
     if plan_index < 0:
         graph.execute(
@@ -3594,7 +3630,16 @@ def execute_cudnn_gemm_fp8_graph(
 
     workspace_size = _get_cudnn_workspace_size(graph, plan_index)
     if workspace.numel() < workspace_size:
-        workspace.resize_(workspace_size)
+        # Never resize_() the shared workspace: its device address may be
+        # baked into captured CUDA graphs and referenced by in-flight
+        # launches, and resize_() frees the old storage, leaving those
+        # consumers reading and writing freed (soon re-allocated) memory.
+        # Satisfy oversized requests with a call-local buffer instead;
+        # stream-ordered allocation keeps eager mode safe, and during
+        # capture the buffer is owned by the capturing graph's pool.
+        workspace = torch.empty(
+            workspace_size, dtype=torch.uint8, device=workspace.device
+        )
 
     if plan_index < 0:
         graph.execute(variant_pack, workspace, handle=cudnn_handle)
@@ -3733,7 +3778,16 @@ def execute_cudnn_gemm_fp8_graph_override_shape(
         override_strides,
     )
     if workspace.numel() < workspace_size:
-        workspace.resize_(workspace_size)
+        # Never resize_() the shared workspace: its device address may be
+        # baked into captured CUDA graphs and referenced by in-flight
+        # launches, and resize_() frees the old storage, leaving those
+        # consumers reading and writing freed (soon re-allocated) memory.
+        # Satisfy oversized requests with a call-local buffer instead;
+        # stream-ordered allocation keeps eager mode safe, and during
+        # capture the buffer is owned by the capturing graph's pool.
+        workspace = torch.empty(
+            workspace_size, dtype=torch.uint8, device=workspace.device
+        )
 
     if plan_index < 0:
         graph.execute(
@@ -4028,7 +4082,16 @@ def execute_cudnn_gemm_bf16_graph(graph, a, b, bias, c_final, workspace, tactic=
 
     workspace_size = _get_cudnn_workspace_size(graph, plan_index)
     if workspace.numel() < workspace_size:
-        workspace.resize_(workspace_size)
+        # Never resize_() the shared workspace: its device address may be
+        # baked into captured CUDA graphs and referenced by in-flight
+        # launches, and resize_() frees the old storage, leaving those
+        # consumers reading and writing freed (soon re-allocated) memory.
+        # Satisfy oversized requests with a call-local buffer instead;
+        # stream-ordered allocation keeps eager mode safe, and during
+        # capture the buffer is owned by the capturing graph's pool.
+        workspace = torch.empty(
+            workspace_size, dtype=torch.uint8, device=workspace.device
+        )
 
     if plan_index < 0:
         graph.execute(variant_pack, workspace, handle=cudnn_handle)
@@ -4204,7 +4267,16 @@ def execute_cudnn_gemm_bf16_graph_override_shape(
         override_strides,
     )
     if workspace.numel() < workspace_size:
-        workspace.resize_(workspace_size)
+        # Never resize_() the shared workspace: its device address may be
+        # baked into captured CUDA graphs and referenced by in-flight
+        # launches, and resize_() frees the old storage, leaving those
+        # consumers reading and writing freed (soon re-allocated) memory.
+        # Satisfy oversized requests with a call-local buffer instead;
+        # stream-ordered allocation keeps eager mode safe, and during
+        # capture the buffer is owned by the capturing graph's pool.
+        workspace = torch.empty(
+            workspace_size, dtype=torch.uint8, device=workspace.device
+        )
 
     if plan_index < 0:
         graph.execute(


### PR DESCRIPTION
## Problem

Every cuDNN GEMM execute path in `flashinfer/gemm/gemm_base.py` grows the shared cache workspace in place when an execution plan asks for more than the current buffer:

```python
workspace_size = _get_cudnn_workspace_size(graph, plan_index)
if workspace_buffer.numel() < workspace_size:
    workspace_buffer.resize_(workspace_size)
```

`resize_()` to a larger size frees the old storage and re-allocates at a different device address. Two classes of consumer still hold the old address:

1. **Launches already enqueued on the stream.** The free returns the block to PyTorch's caching allocator, which can hand it to a new tensor while the enqueued kernel is still pending.
2. **CUDA graphs that captured earlier executes.** A captured graph holds the raw workspace pointer forever. After the resize, every replay makes cuDNN kernels read scratch from — and write scratch over — whatever tensors the allocator has placed in the freed block.

The workspace comes from `_get_cache_buf` (32 MiB default) and is shared process-wide per `(name, device)`, so one oversized plan poisons every previously captured graph that uses that workspace name.

## Observed failure (production, SM120)

Serving a ModelOpt NVFP4/FP8 mixed Qwen3.8-27B checkpoint under vLLM v0.26.0 (flashinfer 0.6.14), the FP8 linear layers route through `bmm_fp8` → autotuner → `CudnnFp8GemmRunner`. Instrumenting the resize sites showed that **during vLLM's piecewise CUDA graph capture** one cuDNN FP8 plan requested **33,554,688 bytes — 256 bytes more than the 32 MiB default** — and the workspace moved:

```
[F5WS 21:32:46] RESIZE old_ptr=0x7efadc000000 old=33554432 new=33554688
[F5WS 21:32:46] RESIZE done new_ptr=0x7efa8d200000
```

Eight of nine piecewise graphs had already been captured against `0x7efadc000000`. The server then fails after minutes under load, non-deterministically, in one of several ways (all documented with a matched-arm falsification matrix in vllm-project/vllm#52540):

- `CUDA error: an illegal memory access was encountered` surfacing at async sync points;
- GPU wedge: engine stops, GPU pinned at 100%, `Xid 8`, MMU `FAULT_PDE` faults at wild addresses;
- with this patch's instrumentation and GPU coredumps enabled: **`Warp Misaligned Address` inside `cudnn_generated_fort_native_sm80_matMul_pointwise_pointwise_knob_23_64x128x64_3_0`**, where a matrix base pointer argument held `0x27000013FF` — two packed int32s (39, 5119) of unrelated tensor data, i.e. the kernel loaded its pointers through the stale workspace.

MTTF under a 24-way sustained load was ~16.5 min with graphs on; `--enforce-eager` reduced the rate ~10× (no captured graphs; only the enqueued-launch window) but did not eliminate it. vllm-project/vllm#34948 reports matching signatures on the same model family.

## Fix

Satisfy an oversized request with a **call-local buffer** instead of mutating the shared one:

```python
if workspace_buffer.numel() < workspace_size:
    workspace_buffer = torch.empty(workspace_size, dtype=torch.uint8, device=...)
```

- Eager mode: stream-ordered allocation semantics make the temporary safe to drop after the enqueue (same-stream reuse is ordered after the kernel).
- Capture mode: the temporary is owned by the capturing graph's memory pool, so replays keep a stable, live address.
- The shared buffer still serves the common (≤ 32 MiB) case; repeated oversized calls at worst re-allocate from the caching allocator's free list.

All eight sites (bf16 / fp8 / fp4 / mxfp8, plain and override-shape variants) carry the same two-line pattern and get the same fix.

## Second finding (commit 2): the replacement buffer must be zeroed

Validating the first commit exposed the hang mode's mechanism. With the workspace address pinned but the oversized-request replacement allocated with `torch.empty`, the serving workload still hung at ~16 min (GPU pinned at 100%); under `CUDA_LAUNCH_BLOCKING=1` it failed within **45 seconds**, with the error surfacing exactly at `execute_cudnn_gemm_fp8_graph → execute_plan_at_index`:

```
RuntimeError: execute(handle, plan->get_raw_desc(), variant_pack_descriptor.get_ptr())
failed with message: cuCtxGetLimit returned error the launch timed out and was
terminated (702) ... CUDNN_STATUS_EXECUTION_FAILED_CUDA_DRIVER
```

cuDNN split-K plans keep completion semaphores inside the workspace (the observed oversized request is exactly `32 MiB + 256 B`). The old `resize_()` path handed the kernel freshly `cudaMalloc`'d — hence zeroed — pages, so the semaphores worked by accident; a call-local `torch.empty` can receive a recycled dirty block from PyTorch's caching allocator, and the kernel then spins forever on a garbage semaphore word. The same mechanism explains the pre-fix hang mode: after an in-place resize, captured graphs replay cuDNN launches against the freed workspace, whose memory now holds live tensor data — garbage semaphores (hang) or garbage pointer words (the misaligned/illegal-address coredump above).

Commit 2 therefore allocates the replacement with `torch.zeros`. During capture the zero-fill is captured too, so replays re-arm the semaphores; in eager mode it is a one-off memset on the rare oversized call. With this in place, the same launch-blocking configuration that died at 45 s runs clean (probe), and the full-speed soak results are below.

## Validation, and a third defect this PR does not fix

On the failing production configuration (RTX PRO 6000 Blackwell / SM120, vLLM v0.26.0 image with flashinfer 0.6.14, ModelOpt NVFP4/FP8-mixed Qwen3.8-27B whose per-tensor FP8 layers route through `bmm_fp8` → autotuner → `CudnnFp8GemmRunner`; 24-way sustained load, CUDA graphs ON):

| build | CUDA_LAUNCH_BLOCKING | outcome |
|---|---|---|
| stock | off | dies/wedges at 14.0–16.5 min (illegal access with GPU coredump, or 100% GPU hang) |
| commit 1 only (`torch.empty` replacement) | off | hang at ~16.5 min |
| commit 1 only | **on** | fails in **45 s** (CUDA 702 at `execute_plan_at_index`) |
| commits 1+2 (`torch.zeros`) | **on** | clean 15-minute probe (~20× the commit-1 failure time) |
| commits 1+2 | off | **still fails at ~13.5 min** — see below |
| commits 1+2 **+ cuDNN runner excluded from the fp8/bf16 autotune lanes** | off | **clean 55-minute soak** (3.3× baseline MTTF), 2,708 completions, 0 errors, and ~22% higher throughput than the cuDNN-tuned baseline (0.82/s vs 0.67/s) |

50 deterministic classification prompts (temperature 0, seed pinned): byte-identical answers on the fixed configurations.

**The remaining defect (not fixed here):** with both commits applied — workspace address stable and zero-initialized — a GPU coredump still caught a cuDNN kernel (`cudnn_generated_fort_native_sm120_matMul_pointwise_pointwise_knob_13_64x256x64_0_0`) faulting on `LDG.E` at address `0x1`, and an earlier dump caught the sm80 variant dereferencing `0x27000013FF` — in both cases pointer slots holding small integers that look like GEMM dims/strides. That is consistent with cuDNN's device-side parameter staging being rewritten while captured launches replay (the same handle serves both captured decode graphs and a continuous stream of eager prefill executes at ever-changing M). It cannot be fixed from this Python layer.

Notably, `main` already gates cuDNN out of the `bmm_fp8` auto candidates on SM12x when override_shape is unavailable (`_heuristic_func_bmm_fp8`, citing #3707 / RFC #3920 rule 6, "its async CUDA fault escapes … synchronous fallback"). The evidence above is the user-visible catastrophe that gate prevents; flashinfer 0.6.14 — what vLLM v0.26.0 ships — predates it. Two asks for maintainers beyond this PR's two commits: (1) consider backporting that gate (or this PR) to the release branch vLLM pins; (2) consider whether the autotuner should ever select `Cudnn*GemmRunner`s into lanes that will be captured into CUDA graphs while the same handle keeps serving eager executes, on any architecture, until the parameter-staging interaction is understood.

Related: #4549 / #4550 (a separate per-call workspace allocation issue in the SM120 CUTLASS FP4 path, found during the same investigation; that fix alone did not stop this failure).
