### PR TITLE
ci: install quack-kernels with --no-deps so it cannot downgrade CuTe DSL

### DIFF
--- a/flashinfer/cute_dsl/sparse/sm100_blk128/__init__.py
+++ b/flashinfer/cute_dsl/sparse/sm100_blk128/__init__.py
@@ -17,6 +17,7 @@ try:
 except ImportError as e:
     raise ImportError(
         "The vsa_sm100_blk128 backend requires the `quack-kernels` package.\n"
-        "Install it from PyPI:\n"
-        "    pip install quack-kernels==0.6.4"
+        "Install it from PyPI (--no-deps: quack-kernels pins an older "
+        "nvidia-cutlass-dsl than flashinfer requires):\n"
+        "    pip install --no-deps quack-kernels==0.6.4"
     ) from e

--- a/scripts/setup_test_env.sh
+++ b/scripts/setup_test_env.sh
@@ -52,12 +52,18 @@ fi
 # and installed here for CI only. The blk128 backend supports SM100/SM103, so we
 # install quack-kernels only when such a GPU is present to avoid slowing unrelated CI jobs.
 # The correct PyPI distribution name is quack-kernels (top-level package: quack).
+# --no-deps: quack-kernels 0.6.4 hard-pins nvidia-cutlass-dsl==4.6.2, which would
+# downgrade the DSL this job just pinned and leave libs-cu13 skewed (#4555). Its
+# remaining deps are either already installed (torch, apache-tvm-ffi, einops) or
+# listed alongside it here.
 SM_MAJOR=$(python -c "import torch; print(torch.cuda.get_device_capability()[0])" 2>/dev/null || echo "")
 if [ "${SM_MAJOR}" = "10" ]; then
   echo "========================================"
   echo "Detected SM${SM_MAJOR} (SM100/SM103); installing quack-kernels for VSA blk128 tests"
   echo "========================================"
-  pip install "quack-kernels==0.6.4"
+  pip install --no-deps "quack-kernels==0.6.4" "torch-c-dlpack-ext"
+  # Fail here rather than as a confusing test error if --no-deps left a gap.
+  python -c "import quack"
   echo "quack-kernels install complete."
   echo ""
 fi

--- a/scripts/setup_test_env.sh
+++ b/scripts/setup_test_env.sh
@@ -61,7 +61,13 @@ if [ "${SM_MAJOR}" = "10" ]; then
   echo "========================================"
   echo "Detected SM${SM_MAJOR} (SM100/SM103); installing quack-kernels for VSA blk128 tests"
   echo "========================================"
-  pip install --no-deps "quack-kernels==0.6.4" "torch-c-dlpack-ext"
+  DSL_VERSION_BEFORE=$(python -c "import importlib.metadata as m; print(m.version('nvidia-cutlass-dsl'))" 2>/dev/null || echo "")
+  pip install --no-deps "quack-kernels==0.6.4" "torch-c-dlpack-ext==0.1.5"
+  DSL_VERSION_AFTER=$(python -c "import importlib.metadata as m; print(m.version('nvidia-cutlass-dsl'))" 2>/dev/null || echo "")
+  if [ "${DSL_VERSION_BEFORE}" != "${DSL_VERSION_AFTER}" ]; then
+    echo "ERROR: quack-kernels install moved nvidia-cutlass-dsl from ${DSL_VERSION_BEFORE} to ${DSL_VERSION_AFTER}" >&2
+    return 1 2>/dev/null || exit 1
+  fi
   # Fail here rather than as a confusing test error if --no-deps left a gap.
   python -c "import quack"
   echo "quack-kernels install complete."

--- a/tests/attention/test_vsa_block_sparse.py
+++ b/tests/attention/test_vsa_block_sparse.py
@@ -60,7 +60,7 @@ pytestmark = [
     pytest.mark.skipif(
         not _HAS_QUACK,
         reason="VSA SM100 backend requires the quack package "
-        "(pip install quack-kernels==0.6.4)",
+        "(pip install --no-deps quack-kernels==0.6.4)",
     ),
     pytest.mark.skipif(
         torch.cuda.is_available()


### PR DESCRIPTION
## Summary

`quack-kernels==0.6.4` (the newest release on PyPI) hard-pins
`nvidia-cutlass-dsl==4.6.2`, while flashinfer pins `nvidia-cutlass-dsl==4.7.0`
(`requirements.txt`, `pyproject.toml` cu12/cu13 extras). Installing quack with
its dependency closure therefore rolls the DSL back.

Because only the `[cu13]` extra carries `nvidia-cutlass-dsl-libs-cu13`, a plain
`pip install quack-kernels==0.6.4` moves the frontend plus libs-base/core/cu12
to 4.6.2 and leaves libs-cu13 where it was — the mixed install reported in
#4555. pip notices, but only prints it and exits 0, so nothing fails at install
time:

```
ERROR: pip's dependency resolver does not currently take into account all the packages
that are installed. ... nvidia-cutlass-dsl-libs-cu13 4.7.0 requires
nvidia-cutlass-dsl-libs-base==4.7.0, but you have nvidia-cutlass-dsl-libs-base 4.6.2
which is incompatible.
```

flashinfer's own CI walks into this: `scripts/setup_test_env.sh` installs
quack-kernels on every SM100/SM103 runner, and in `scripts/task_run_unit_tests.sh`
it is sourced *after* `install_and_verify` has pinned
`nvidia-cutlass-dsl[cu13]==4.7.0` — a step whose comment says it exists "to
avoid version skew between libs-base and libs-cu13". Every CuTe-DSL test in
those jobs then runs on a 4.6.2 frontend that flashinfer does not support. (In
`scripts/task_jit_run_tests_part*.sh` the downgrade is transient, since the
following `pip install -e .` re-resolves `requirements.txt`.) The install hints
we show users (`sm100_blk128/__init__.py`, the VSA skip reason) have the same
effect on a working install.

flashinfer only uses pure-Python CuTe-DSL helpers from quack
(`ParamsBase`, `layout_utils.{select,reshape_acc_to_mn}`,
`copy_utils.{tma_get_copy_fn,partition_D_position_independent,cvt_copy,predicate_k}`),
all of which work under DSL 4.7.0, so the pin does not need to bind us:

- install quack with `--no-deps` (plus `torch-c-dlpack-ext==0.1.5`, its only dep
  not already in `requirements.txt`), assert the DSL version did not move, and
  smoke-check `import quack`
- advertise `pip install --no-deps quack-kernels==0.6.4` in the backend
  `ImportError` and the test skip reason

Scope, to be clear about what this does and does not fix: it keeps a *fresh*
install (CI or user) on the pinned DSL. It cannot repair an environment that is
already skewed, because plain `nvidia-cutlass-dsl==4.7.0` never touches
`libs-cu13` — that needs `pip install "nvidia-cutlass-dsl[cu13]==4.7.0"`.
Relaxing the `==4.6.2` pin itself remains an upstream ask for quack.

## Test plan

On a B200 (SM100), torch 2.13.0+cu130, DSL 4.7.0:

- `source scripts/setup_test_env.sh` now leaves the DSL untouched —
  `DSL 4.7.0 | libs-base 4.7.0 | libs-cu13 4.7.0 | quack-kernels 0.6.4`
  (before this change, the same script produced frontend 4.6.2 with libs-cu13 4.7.0)
- `pytest tests/attention/test_vsa_block_sparse.py -k "not blk64 and not auto_80k"`
  → `23 passed, 8 skipped` (all quack-backed blk128 tests) against DSL 4.7.0
- `pre-commit run --files scripts/setup_test_env.sh flashinfer/cute_dsl/sparse/sm100_blk128/__init__.py tests/attention/test_vsa_block_sparse.py` → pass

The deselected cases fail in my sandbox with and without this change, for
reasons unrelated to the DSL: the `*_blk64` tests need a populated
`3rdparty/cutlass` (`fatal error: cutlass/cluster_launch.hpp`) and
`test_vsa_vs_auto_80k` needs the `flashinfer/data` package-data links. Those
need a CI run to confirm.

Note the skew is a latent hazard rather than an always-fatal one: the blk128
tests also pass on the skewed stack, which is why this went unnoticed. The
demonstrable harm is testing off the pinned DSL version.

Related to #4555.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved missing-dependency guidance for block-sparse attention features.
  * Prevented installation instructions from downgrading the required CUTLASS DSL version.
  * Added verification that the optional `quack` module imports successfully during test environment setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->