### PR TITLE
perf(moe): reduce W4A16 scale factors without large temporaries

### DIFF
--- a/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_w4a16_prepare.py
+++ b/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_w4a16_prepare.py
@@ -152,12 +152,25 @@ def _nvfp4_compute_scale_factor(
 ) -> float:
     if a_dtype == torch.float16:
         return 1.0
-    max_scalar = 0.0
-    for expert in range(int(packed_scales.shape[0])):
-        ws_float = packed_scales[expert].float() * (2**7)
-        nonzero_mask = ws_float > 0
-        if bool(nonzero_mask.any().item()):
-            max_scalar = max(max_scalar, float(ws_float[nonzero_mask].max().item()))
+    if packed_scales.numel() == 0:
+        return 1.0
+
+    # NVFP4 block scales are nonnegative by contract, and nonnegative E4M3
+    # values preserve their ordering in the raw byte representation. PyTorch
+    # does not implement CUDA max for float8, so reduce an aliasing uint8 view
+    # and convert only the resulting scalar. Other source dtypes can use their
+    # native reduction. Neither path creates full-size FP32 copies or masks.
+    if packed_scales.dtype == torch.float8_e4m3fn:
+        max_scale = (
+            packed_scales.view(torch.uint8)
+            .max()
+            .view(torch.float8_e4m3fn)
+            .float()
+            .item()
+        )
+    else:
+        max_scale = packed_scales.max().float().item()
+    max_scalar = float(max_scale) * (2**7)
     if max_scalar > 0.0 and max_scalar < 448 * (2**7):
         return float(2 ** math.floor(math.log2((448 * (2**7)) / max_scalar)))
     return 1.0

--- a/tests/moe/test_b12x_w4a16_prepare.py
+++ b/tests/moe/test_b12x_w4a16_prepare.py
@@ -1,0 +1,95 @@
+"""
+Copyright (c) 2026 by FlashInfer team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import math
+
+import pytest
+import torch
+
+
+pytestmark = pytest.mark.skipif(
+    not torch.cuda.is_available(), reason="requires a CUDA device"
+)
+
+
+def _reference_scale_factor(scales: torch.Tensor, a_dtype: torch.dtype) -> float:
+    if a_dtype == torch.float16:
+        return 1.0
+    ws_float = scales.float() * (2**7)
+    positive = ws_float[ws_float > 0]
+    if positive.numel() == 0:
+        return 1.0
+    max_scalar = float(positive.max().item())
+    if max_scalar < 448 * (2**7):
+        return float(2 ** math.floor(math.log2((448 * (2**7)) / max_scalar)))
+    return 1.0
+
+
+@pytest.mark.parametrize(
+    "values,expected",
+    [
+        ([0.0], 1.0),
+        ([1.0], 256.0),
+        ([0.0, 2.0, 224.0], 2.0),
+        ([448.0], 1.0),
+    ],
+)
+def test_nvfp4_compute_scale_factor_boundaries(values, expected):
+    from flashinfer.fused_moe.cute_dsl.blackwell_sm12x.moe_w4a16_prepare import (
+        _nvfp4_compute_scale_factor,
+    )
+
+    scales = torch.tensor(values, device="cuda").to(torch.float8_e4m3fn)
+
+    assert _nvfp4_compute_scale_factor(scales, torch.bfloat16) == expected
+
+
+def test_nvfp4_compute_scale_factor_matches_reference_across_experts():
+    from flashinfer.fused_moe.cute_dsl.blackwell_sm12x.moe_w4a16_prepare import (
+        _nvfp4_compute_scale_factor,
+    )
+
+    values = torch.tensor(
+        [
+            [0.0, 0.5, 1.0, 1.5],
+            [2.0, 3.0, 4.0, 6.0],
+            [8.0, 12.0, 16.0, 24.0],
+        ],
+        device="cuda",
+    ).to(torch.float8_e4m3fn)
+
+    assert _nvfp4_compute_scale_factor(
+        values, torch.bfloat16
+    ) == _reference_scale_factor(values, torch.bfloat16)
+
+    bf16_values = values.float().to(torch.bfloat16)
+    assert _nvfp4_compute_scale_factor(
+        bf16_values, torch.bfloat16
+    ) == _reference_scale_factor(bf16_values, torch.bfloat16)
+
+
+def test_nvfp4_compute_scale_factor_empty_and_fp16_bypass():
+    from flashinfer.fused_moe.cute_dsl.blackwell_sm12x.moe_w4a16_prepare import (
+        _nvfp4_compute_scale_factor,
+    )
+
+    empty = torch.empty((0, 4), dtype=torch.float8_e4m3fn, device="cuda")
+    scales = torch.full((2, 4), 448.0, dtype=torch.float32, device="cuda").to(
+        torch.float8_e4m3fn
+    )
+
+    assert _nvfp4_compute_scale_factor(empty, torch.bfloat16) == 1.0
+    assert _nvfp4_compute_scale_factor(scales, torch.float16) == 1.0

--- a/tests/moe/test_b12x_w4a16_prepare.py
+++ b/tests/moe/test_b12x_w4a16_prepare.py
@@ -19,9 +19,12 @@ import math
 import pytest
 import torch
 
+from flashinfer.utils import is_sm12x_supported
+
 
 pytestmark = pytest.mark.skipif(
-    not torch.cuda.is_available(), reason="requires a CUDA device"
+    not (torch.cuda.is_available() and is_sm12x_supported(torch.device("cuda"))),
+    reason="requires an SM12x CUDA device",
 )
 
 


### PR DESCRIPTION
## Description

Reduce the W4A16 NVFP4 scale factor without materializing full-size FP32 copies and boolean masks.

NVFP4 block scales are nonnegative, and nonnegative E4M3 values preserve their ordering in their raw byte representation. Because PyTorch does not implement CUDA `max` for float8, this change reduces an aliasing `uint8` view and converts only the resulting scalar. Other source dtypes use their native reduction. Empty inputs preserve the existing `1.0` fallback.

On an RTX PRO 5000 Blackwell (SM120), for a 32 MiB `[256, 1024, 128]` scale tensor:

| implementation | median | peak temporary allocation |
|---|---:|---:|
| current `main` (per-expert FP32 + mask) | 53.441 ms | 3,258,368 B |
| this PR (single reduction) | 0.479 ms | 1,536 B |

This is a 111.7x reduction-time improvement for this synthetic shape. The historical full-tensor implementation discussed in the linked vLLM issue could allocate substantially more; the comparison above is specifically against current FlashInfer `main`.

AI assistance: this change and its validation were performed with OpenAI Codex assistance.

## Related Issues

- https://github.com/vllm-project/vllm/issues/49031

## Pull Request Checklist

### Pre-commit Checks

- [x] I have installed `pre-commit`.
- [x] I have installed the hooks.
- [x] I have run the hooks manually and fixed all reported issues.

## Tests

- [x] Tests have been added for boundary values, multi-expert reduction, the BF16 source path, empty input, and the FP16 bypass.
- [x] `pytest -q tests/moe/test_b12x_w4a16_prepare.py` — 6 passed.
- [x] B12x MoE conformance suite — 28 passed.
- [x] Pre-commit hooks passed.

## Reviewer Notes

The raw-byte reduction relies on the existing NVFP4 contract that scale values are nonnegative E4M3 values. The fallback for non-float8 scale tensors intentionally uses the dtype's native CUDA reduction.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved NVFP4 scale-factor computation for empty inputs and different numeric formats.
  * Improved handling of scale values across experts, including float8 and bfloat16 inputs.
  * Preserved expected float16 behavior and improved boundary-value handling.

* **Tests**
  * Added coverage for boundary values, multiple experts, empty inputs, and supported data types.
  * Added validation against reference results for consistent scale-factor calculations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->