### PR TITLE
[fix] disable tileN=192 for trtllmgen per-token NVFP4 MoE

### DIFF
--- a/csrc/trtllm_fused_moe_kernel_launcher.cu
+++ b/csrc/trtllm_fused_moe_kernel_launcher.cu
@@ -2920,7 +2920,8 @@ class FP4BlockScaleLauncher : public FusedMoeLauncher {
  public:
   static constexpr std::array<int32_t, 4> mBaseSupportedTileNums = {8, 16, 32, 64};
 
-  static std::vector<int32_t> getSupportedTileNums(btg::Dtype dtype_act, btg::Dtype dtype_weights) {
+  static std::vector<int32_t> getSupportedTileNums(btg::Dtype dtype_act, btg::Dtype dtype_weights,
+                                                   bool use_per_token_scaling) {
     std::vector<int32_t> tiles(mBaseSupportedTileNums.begin(), mBaseSupportedTileNums.end());
     if (dtype_act != btg::Dtype::Bfloat16) {
       tiles.push_back(128);
@@ -2930,7 +2931,9 @@ class FP4BlockScaleLauncher : public FusedMoeLauncher {
       // kernels (its only 192-tile kernels are FP8), and launchers are built
       // eagerly for every advertised tile, so advertising 192 there fails
       // runner construction outright.
-      if ((dtype_weights == btg::Dtype::E2m1 && dtype_act == btg::Dtype::E2m1) ||
+      // The exported per-token NVFP4 tile-192 path produces non-finite outputs (#4486).
+      if ((dtype_weights == btg::Dtype::E2m1 && dtype_act == btg::Dtype::E2m1 &&
+           !use_per_token_scaling) ||
           (dtype_weights == btg::Dtype::MxE2m1 && dtype_act == btg::Dtype::MxE4m3)) {
         tiles.push_back(192);
       }
@@ -3329,7 +3332,8 @@ class FP4BlockScaleLauncher : public FusedMoeLauncher {
                                                batchedGemm::gemm::BiasType gemm1_bias_type) {
     Array<Array<int64_t>> valid_configs;
 
-    std::vector<int32_t> tile_sizes = getSupportedTileNums(dtype_act, dtype_weights);
+    std::vector<int32_t> tile_sizes =
+        getSupportedTileNums(dtype_act, dtype_weights, use_per_token_scaling);
     std::set<int32_t> selected_tile_nums =
         computeSelectedTileN(tile_sizes, num_tokens, top_k, num_local_experts);
 
@@ -3976,8 +3980,8 @@ Array<Tensor> trtllm_fp4_block_scale_moe(
   }
 
   // Determine supported tile sizes
-  std::vector<int32_t> mSupportedTileN =
-      FP4BlockScaleLauncher::getSupportedTileNums(mDtypeAct, mDtypeWeights);
+  std::vector<int32_t> mSupportedTileN = FP4BlockScaleLauncher::getSupportedTileNums(
+      mDtypeAct, mDtypeWeights, per_token_scales.has_value());
   // Build launchers for ALL supported tiles so autotuner-cached tactics always find their tile_N.
 
   // Create a map of launchers for each tile size

--- a/tests/moe/test_trtllm_gen_moe_autotune_tactics.py
+++ b/tests/moe/test_trtllm_gen_moe_autotune_tactics.py
@@ -19,6 +19,7 @@ from typing import Literal
 
 import pytest
 import torch
+import flashinfer.autotuner as autotuner_module
 
 from flashinfer import (
     RoutingMethodType,
@@ -37,13 +38,22 @@ from flashinfer.fused_moe import (
     trtllm_fp8_block_scale_routed_moe,
     WeightLayout,
 )
-from flashinfer.fused_moe.core import Fp8QuantizationType, MoEInputs
+from flashinfer.fused_moe.core import (
+    Fp8QuantizationType,
+    MoEInputs,
+    get_trtllm_moe_sm100_module,
+)
 from flashinfer.jit.fused_moe import gen_trtllm_gen_fused_moe_sm100_module
 from flashinfer.tllm_enums import DtypeTrtllmGen
 from flashinfer.utils import (
     device_support_pdl,
     get_compute_capability,
     last_positive_power_of_2,
+)
+
+from . import utils as moe_utils
+from .test_trtllm_gen_per_token_moe import (
+    test_routed_fused_moe as _run_per_token_nvfp4_accuracy_case,
 )
 
 from .trtllm_gen_fused_moe_utils import (
@@ -310,6 +320,7 @@ def _enumerate_valid_tactics(
     intermediate_size: int,
     num_experts: int,
     num_tokens: int,
+    use_per_token_scaling: bool = False,
 ) -> list[list[int]]:
     """Enumerate every (tile_N, config) tactic the autotuner may select for
     the given problem shape."""
@@ -328,11 +339,64 @@ def _enumerate_valid_tactics(
             ActivationType.Swiglu.value,
             True,  # use_shuffled_weight
             WeightLayout.MajorK.value,
-            False,  # use_per_token_scaling
+            use_per_token_scaling,
             num_tokens,
             False,  # has_gemm1_lora_delta
         )
     )
+
+
+def test_nvfp4_per_token_all_tactics_are_correct(monkeypatch: pytest.MonkeyPatch):
+    """Every advertised per-token NVFP4 tactic must be numerically correct."""
+    if get_compute_capability(torch.device(device="cuda"))[0] not in [10]:
+        pytest.skip("Only work on SM100 / SM103.")
+
+    torch.manual_seed(42)
+    moe_op = gen_trtllm_gen_fused_moe_sm100_module().build_and_load()
+    valid_tactics = _enumerate_valid_tactics(
+        moe_op,
+        "NvFP4xNvFP4",
+        top_k=8,
+        hidden_size=2048,
+        intermediate_size=768,
+        num_experts=128,
+        num_tokens=4096,
+        use_per_token_scaling=True,
+    )
+    assert valid_tactics
+
+    moe_module = get_trtllm_moe_sm100_module()
+    real_autotune = autotuner_module.autotune
+    monkeypatch.setattr(
+        autotuner_module, "autotune", lambda _enabled: real_autotune(True)
+    )
+    tuner = AutoTuner.get()
+
+    for tactic in valid_tactics:
+        tactic = list(tactic)
+        monkeypatch.setattr(
+            moe_module.MoERunner,
+            "get_valid_tactics",
+            lambda self, inputs, profile, tactic=tactic: [tactic],
+        )
+        tuner.profiling_cache.clear()
+        tuner._file_configs.clear()
+        try:
+            with moe_utils.nvfp4_4over6_env(True):
+                _run_per_token_nvfp4_accuracy_case(
+                    num_tokens=4096,
+                    hidden_size=2048,
+                    intermediate_size=768,
+                    num_experts=128,
+                    top_k=8,
+                    use_4over6=True,
+                    weights_use_4over6=True,
+                )
+        except Exception as err:
+            raise AssertionError(
+                f"Per-token NVFP4 tactic {tactic} failed accuracy"
+            ) from err
+        torch.cuda.empty_cache()
 
 
 def test_nvfp4_per_tensor_small_shape_all_tactics_are_correct():


### PR DESCRIPTION
## 📌 Description
Fix Fixes #4486.
- Exclude tileN=192 from TRTLLM-Gen NVFP4 MoE when per-token scaling is enabled.
- Add an issue-shape, all-advertised-tactics numerical accuracy regression for per-token NVFP4.

This change therefore filters tileN=192 only for per-token NVFP4 instead of disabling the tile family for other supported FP4 modes.

## 🔍 Related Issues

Fixes #4486.

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit`.
- [x] I have installed the hook environments.
- [x] I have run pre-commit on all modified files and fixed the reported issues.

> If you are unsure of how to set up pre-commit, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All relevant tests are passing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved FP4 mixture-of-experts tactic selection when per-token scaling is enabled.
  * Prevented unsupported NVFP4 tile configurations from being selected in applicable scenarios.

* **Tests**
  * Added coverage to validate per-token NVFP4 tactics across supported hardware configurations.
  * Added accuracy checks for each eligible tactic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->