### PR TITLE
feat(xqa): support non-MLA head_dim 512 (Gemma-style GQA decode) on SM12x

### DIFF
--- a/csrc/xqa/defines.h
+++ b/csrc/xqa/defines.h
@@ -171,7 +171,9 @@ static_assert(CACHE_ELEM_ENUM != 0);
 #endif
 
 // true should be better if warpTile.x * cacheElemSize < 128. otherwise use false.
-#define GRP_LOAD_V (CACHE_ELEM_ENUM != 0) || (HEAD_ELEMS == 256 && BEAM_WIDTH > 1)
+// HEAD_ELEMS > 256 requires the group-shared full-head V buffer (see nbHeadSplits in mha.cu).
+#define GRP_LOAD_V \
+  (CACHE_ELEM_ENUM != 0) || (HEAD_ELEMS == 256 && BEAM_WIDTH > 1) || (HEAD_ELEMS > 256)
 
 // use custom barrier for NVRTC to avoid pulling in many headers
 #ifndef USE_CUSTOM_BARRIER

--- a/csrc/xqa/mha.cu
+++ b/csrc/xqa/mha.cu
@@ -89,7 +89,11 @@ constexpr uint32_t nbValidRows = headGrpSize * beamWidth;
 constexpr uint2 warpTile = {64, roundUp(nbValidRows, 16U)};
 static_assert(nbValidRows <= warpTile.y);
 
-constexpr uint32_t gemm1WarpsPerGrp = exactDiv(headElems, warpTile.x);
+// For headElems > warpTile.x * ctaShapeInWarps.x (i.e. 512), each gemm1 warp owns
+// nbHeadSplits head-dim slices of warpTile.x elems each (slice idx = warpIdxInGrp +
+// gemm1WarpsPerGrp * split), instead of requiring more warps than the CTA has.
+constexpr uint32_t gemm1WarpsPerGrp = mha::min(exactDiv(headElems, warpTile.x), ctaShapeInWarps.x);
+constexpr uint32_t nbHeadSplits = exactDiv(headElems, warpTile.x* gemm1WarpsPerGrp);
 constexpr uint32_t gemm1NbWarpGrps =
     exactDiv(ctaShapeInWarps.x, gemm1WarpsPerGrp);  // warp groups split along seqLen dim.
 
@@ -99,17 +103,22 @@ constexpr uint2 ctaTile = {
 
 constexpr uint32_t cvtExpansion = exactDiv(inputElemSize, cacheElemSize);
 
+// At HEAD_ELEMS > 256 the group-shared V buffer holds full heads (grpLoadV), so shrink
+// the V tile sequence length to keep smem within budget: on 99KB archs (SM86/89/120/121)
+// 16-bit KV needs 16 tokens per tile (fp8 fits at 32); 227KB archs fit 32 for both.
 #ifndef __CUDA_ARCH__
 constexpr uint32_t preferedKHeadPartBytes = 64;
-__constant__ constexpr uint32_t cacheVTileSeqLen = 32;
+__constant__ constexpr uint32_t cacheVTileSeqLen =
+    (HEAD_ELEMS > 256 && CACHE_ELEM_ENUM == 0 ? 16 : 32);
 #else
 #if __CUDA_ARCH__ == 860 || __CUDA_ARCH__ == 890 || __CUDA_ARCH__ == 1200 || __CUDA_ARCH__ == 1210
 constexpr uint32_t preferedKHeadPartBytes = 64;
-__constant__ constexpr uint32_t cacheVTileSeqLen = 32;
+__constant__ constexpr uint32_t cacheVTileSeqLen =
+    (HEAD_ELEMS > 256 && CACHE_ELEM_ENUM == 0 ? 16 : 32);
 #elif __CUDA_ARCH__ == 800 || __CUDA_ARCH__ == 870 || __CUDA_ARCH__ == 900 || \
     __CUDA_ARCH__ == 1000 || __CUDA_ARCH__ == 1030 || __CUDA_ARCH__ == 1100
 constexpr uint32_t preferedKHeadPartBytes = 128;
-__constant__ constexpr uint32_t cacheVTileSeqLen = 64;
+__constant__ constexpr uint32_t cacheVTileSeqLen = (HEAD_ELEMS > 256 ? 32 : 64);
 #else
 #error "perferedKHeadPartBytes not defined"
 #endif
@@ -131,6 +140,8 @@ constexpr uint32_t nbPartsPerInputQHead = exactDiv(paddedInputHeadBytes, qHeadPa
 // @fixme: when true, and nbVBuffers is only 2, we need to sync all warps in a group after finishing
 // using a buffer and before refill it with prefetch data. We may need at least 3.
 constexpr bool grpLoadV = GRP_LOAD_V;
+// Multiple head-dim slices per warp require the group-shared full-head V buffer.
+static_assert(nbHeadSplits == 1 || grpLoadV);
 
 // number of shared memory buffers for latency hiding
 constexpr uint32_t nbQBuffers = mha::min(nbPartsPerInputQHead, 2u);  // for latency hiding
@@ -848,7 +859,7 @@ __device__ inline void copyOutputToGlobalMem(Warp const& warp, OutputHead* dst, 
 #endif
                                              uint2 dstOffset, SharedMem::XSmemBuffer const& src) {
   static_assert(sizeof(PaddedInputHead) ==
-                grainBytes * SharedMem::XSmemBuffer::cols * gemm1WarpsPerGrp);
+                grainBytes * SharedMem::XSmemBuffer::cols * gemm1WarpsPerGrp * nbHeadSplits);
 #if SPEC_DEC
   static_assert(warpTile.y <= SharedMem::XSmemBuffer::rows);
 #else
@@ -1161,7 +1172,7 @@ __device__ inline void smemXVPartGemm(Warp const& warp, WarpAcc& acc, bool skipX
                                      SharedMem::VSmemBuffer::cols ==
                                  headElems);
   if (grpLoadV) {
-    assert(idxNSplit < gemm1WarpsPerGrp);
+    assert(idxNSplit < gemm1WarpsPerGrp * nbHeadSplits);
   } else {
     assert(idxNSplit == 0);
   }
@@ -2308,6 +2319,20 @@ CUBIN_EXPORT __global__
                      "todo: need to substrate from idxPageBeg for beam switching");
           loadPages(idxPageBeg);
         }
+      } else if constexpr (cacheVTileSeqStride % tokensPerPage != 0) {
+        // Neither "an xIter fits in one page" nor "a vIter advances whole pages" holds
+        // (e.g. cacheVTileSeqLen 16 with page size 32). Incremental stepping cannot be
+        // exact here, so derive the next tile's first page directly from its absolute
+        // sequence offset (nextStep already accounts for the multi-block sub-sequence
+        // stride via seqIter).
+        uint32_t seqIterN, xIterN, vIterN, idxBeamN;
+        mha::tie(seqIterN, xIterN, vIterN, idxBeamN) = nextStep(seqIter, xIter, vIter, idxBeam);
+        unused(idxBeamN);
+        uint32_t const seqOffsetNext = ctaTile.x * seqIterN +
+                                       warpTile.x * nbXTilesPerXIter * xIterN +
+                                       cacheVTileSeqStride * vIterN + cacheVTileSeqLen * warpGrpIdx;
+        idxPageBeg = seqOffsetNext / tokensPerPage;
+        loadPages(idxPageBeg);
       } else {
         constexpr auto step_per_viter = exactDiv(cacheVTileSeqStride, tokensPerPage);
         bool const isLastVIter = (vIter == nbVItersPerXIter - 1);
@@ -2375,8 +2400,8 @@ CUBIN_EXPORT __global__
     globalRowMax.fill(safeInitRowMax);
     ThrdRegRowMax globalRowSum;
     globalRowSum.fill(0);
-    // the accumulator
-    WarpAcc acc{};
+    // the accumulators, one per head-dim slice owned by this warp
+    Vec<WarpAcc, nbHeadSplits> accs{};
     if (grpLoadV) {
       unused(pWarpGrpBar->arrive());
     }
@@ -2489,7 +2514,10 @@ CUBIN_EXPORT __global__
                   ThrdRegRowMax const accRowScales = expf(globalRowMaxOld - globalRowMax);
                   globalRowSum = globalRowSum * accRowScales;
                   // @fixme: when tmpAcc is used, this can be delayed.
-                  rescaleAcc(warp, acc, accRowNeedRescaleMask, accRowScales);
+#pragma unroll
+                  for (uint32_t hs = 0; hs < nbHeadSplits; hs++) {
+                    rescaleAcc(warp, accs[hs], accRowNeedRescaleMask, accRowScales);
+                  }
                 }
                 if (!enableMicroFastPath || !skipXRowRescale) {
                   xRowScales = skipXRowRescale ? xRowScales : expf(xTileRowMax - globalRowMax);
@@ -2509,25 +2537,31 @@ CUBIN_EXPORT __global__
             auto const& smemVSfPart = getSmemVSfTile(idxCurrSMemVBuf);
 #endif
 
-            // do computation from shared memory X and V tiles
+            // do computation from shared memory X and V tiles. With nbHeadSplits > 1
+            // (headElems > 256), each warp computes multiple head-dim slices from the
+            // group-shared full-head V tile.
+#pragma unroll
+            for (uint32_t hs = 0; hs < nbHeadSplits; hs++) {
+              uint32_t const idxNSplit = grpLoadV ? (warpIdxInGrp + gemm1WarpsPerGrp * hs) : 0;
 #if BEAM_WIDTH == 1
-            smemXVPartGemm<CacheElem>(warp, acc, skipXRowRescale, xRowNeedRescaleMask, xRowScales,
-                                      smemXTile, idxVTile, smemVTile,
+              smemXVPartGemm<CacheElem>(warp, accs[hs], skipXRowRescale, xRowNeedRescaleMask,
+                                        xRowScales, smemXTile, idxVTile, smemVTile,
 #if ENABLE_4BIT_KV_CACHE
-                                      smemVSfPart,
+                                        smemVSfPart,
 #endif
-                                      grpLoadV ? warpIdxInGrp : 0);
+                                        idxNSplit);
 #else
-            WarpAcc tmpAcc{};
-            smemXVPartGemm<CacheElem>(warp, tmpAcc, skipXRowRescale, xRowNeedRescaleMask,
-                                      xRowScales, smemXTile, idxVTile, smemVTile,
+              WarpAcc tmpAcc{};
+              smemXVPartGemm<CacheElem>(warp, tmpAcc, skipXRowRescale, xRowNeedRescaleMask,
+                                        xRowScales, smemXTile, idxVTile, smemVTile,
 #if ENABLE_4BIT_KV_CACHE
-                                      smemVSfPart,
+                                        smemVSfPart,
 #endif
-                                      grpLoadV ? warpIdxInGrp : 0);
-            pickAccRowsForBeamSearch(warp, acc, tmpAcc, isConvergedTile(seqIter), idxBeam,
-                                     [](float& d, float s) { d += s; });
+                                        idxNSplit);
+              pickAccRowsForBeamSearch(warp, accs[hs], tmpAcc, isConvergedTile(seqIter), idxBeam,
+                                       [](float& d, float s) { d += s; });
 #endif
+            }
             if (grpLoadV) {
               unused(pWarpGrpBar->arrive());
             }
@@ -2568,7 +2602,10 @@ CUBIN_EXPORT __global__
         auto const globalRowMaxNew = fmaxf(globalRowMax, otherRowMax);
         auto const scaleForThis = expf(globalRowMax - globalRowMaxNew);
         auto const scaleForOther = expf(otherRowMax - globalRowMaxNew);
-        rescaleAcc(warp, acc, fullRescaleMask, scaleForThis);
+#pragma unroll
+        for (uint32_t hs = 0; hs < nbHeadSplits; hs++) {
+          rescaleAcc(warp, accs[hs], fullRescaleMask, scaleForThis);
+        }
         globalRowSum = globalRowSum * scaleForThis + otherRowSum * scaleForOther;
         globalRowMax = globalRowMaxNew;
       }
@@ -2591,9 +2628,11 @@ CUBIN_EXPORT __global__
 #if LOW_PREC_OUTPUT
       voScale *= rcpOutScale;
 #endif
-      rescaleAcc(warp, acc, fullRescaleMask, rcpRowSum * ThrdRegRowMax::filled(voScale));
+#pragma unroll
+      for (uint32_t hs = 0; hs < nbHeadSplits; hs++) {
+        rescaleAcc(warp, accs[hs], fullRescaleMask, rcpRowSum * ThrdRegRowMax::filled(voScale));
+      }
     }
-    GemmOutRegTile const outTile = toFp16(acc);
 
     auto mergeAndSaveOutTile = [&](GemmOutRegTile const& tile, bool reorder) {
       if constexpr (gemm1NbWarpGrps == 1) {
@@ -2626,11 +2665,30 @@ CUBIN_EXPORT __global__
 #else
     bool reorderOutRows = inputElemSize == 2 && cacheElemSize == 1;
 #endif
-    SharedMem::XSmemBuffer* smemOutTile = mergeAndSaveOutTile(outTile, reorderOutRows);
-    // In multi-block mode only the last CTA writes the merged output; the other
-    // sub-sequences only contribute their partials via global scratch below.
-    bool ctaShouldWriteOut = !isMultiBlock;
-    if (isMultiBlock) {
+    // Writes one head-dim slice (warpTile.x elems) of the output from the swizzled smem tile.
+    auto writeOutSlice = [&](SharedMem::XSmemBuffer const& smemOutTile, uint32_t hs) {
+      uint32_t const dstColOffset = warpTile.x * (warpIdxInGrp + gemm1WarpsPerGrp * hs);
+#if SPEC_DEC
+      copyOutputToGlobalMem(warp, &output[reqSeqOffset * nbQHeads], nbQHeads, headGrpSize,
+                            (idxHeadGrp * headGrpSize), nbValidHeadTokens,
+                            uint2{dstColOffset, nbValidRows * warpIdx.y + idxHeadTokenInGrp},
+                            smemOutTile);
+#else
+      copyOutputToGlobalMem(warp, &output[nbQHeads * beamWidth * idxReq], nbQHeads, idxHeadGrp,
+                            uint2{dstColOffset, nbValidRows * warpIdx.y}, smemOutTile);
+#endif
+    };
+    if (!isMultiBlock) {
+      // The swizzle buffer is reused across splits; the __syncthreads() at the start of
+      // mergeAndSaveOutTile separates one split's global write from the next split's store.
+#pragma unroll
+      for (uint32_t hs = 0; hs < nbHeadSplits; hs++) {
+        SharedMem::XSmemBuffer* smemOutTile = mergeAndSaveOutTile(toFp16(accs[hs]), reorderOutRows);
+        if (warpGrpIdx == 0) {
+          writeOutSlice(*smemOutTile, hs);
+        }
+      }
+    } else {
       static_assert(ctaShapeInWarps.y == 1, "not implemented");
 #if SPEC_DEC
       // Includes both kHeads and qTokens.
@@ -2658,12 +2716,18 @@ CUBIN_EXPORT __global__
         rowSumBuffers[idxBuf].storeFromReg<false>(warp, globalRowSum);
       }
       using ScratchBuf = Array2D<LdGrain, nbValidRows, SharedMem::XSmemBuffer::cols>;
-      TinyPtr<Vec<ScratchBuf, gemm1WarpsPerGrp>> const scratchBuffers =
-          segmenter.newSeg<Vec<ScratchBuf, gemm1WarpsPerGrp>>(nbSubSeq);
-      // copy output to scratch
-      copyGrains<false, nbValidRows * ScratchBuf::cols, gemm1NbWarpGrps>(
-          warpGrpIdx, &scratchBuffers[idxBuf][warpIdxInGrp](0, 0), &(*smemOutTile)(0, 0));
-      __syncthreads();
+      constexpr uint32_t nbHeadSlices = gemm1WarpsPerGrp * nbHeadSplits;
+      TinyPtr<Vec<ScratchBuf, nbHeadSlices>> const scratchBuffers =
+          segmenter.newSeg<Vec<ScratchBuf, nbHeadSlices>>(nbSubSeq);
+      // copy output to scratch, one head-dim slice at a time
+#pragma unroll
+      for (uint32_t hs = 0; hs < nbHeadSplits; hs++) {
+        SharedMem::XSmemBuffer* smemOutTile = mergeAndSaveOutTile(toFp16(accs[hs]), reorderOutRows);
+        copyGrains<false, nbValidRows * ScratchBuf::cols, gemm1NbWarpGrps>(
+            warpGrpIdx, &scratchBuffers[idxBuf][warpIdxInGrp + gemm1WarpsPerGrp * hs](0, 0),
+            &(*smemOutTile)(0, 0));
+        __syncthreads();
+      }
 #if __CUDA_ARCH__ == 1210
       // GB10 (sm121): device-scope release so the partials just written to global
       // scratch are visible to the last CTA (a different block) before the
@@ -2703,7 +2767,6 @@ CUBIN_EXPORT __global__
 
       // merge if we are the last CTA.
       bool const isLastCta = mbsmem.isLastCta;
-      ctaShouldWriteOut = isLastCta;
       if (isLastCta) {
         MultiBlockSMem::MBBuf& mbbuf = mbsmem.storage[warpIdx.y];
         SMemWarpRowMax& smemRowMax = reinterpret_cast<SMemWarpRowMax&>(smem);
@@ -2720,13 +2783,14 @@ CUBIN_EXPORT __global__
         auto getTileBuf = [&](auto& buffers, uint32_t d) -> decltype(buffers[0][0][0])& {
           return buffers[warpGrpIdx][warpIdxInGrp][d];
         };
-        auto loadBufAsync = [&](uint32_t n) {
+        auto loadBufAsync = [&](uint32_t n, uint32_t hs) {
           uint32_t const d = n / gemm1NbWarpGrps % nbTileBuffers;
           SharedMem::XSmemBuffer& dstTile = getTileBuf(mbbuf.tiles, d);
           SMemWarpRowMax& dstRowSum = getTileBuf(mbbuf.tileRowSums, d);
           SMemWarpRowMax& dstRowMax = getTileBuf(mbbuf.tileRowMax, d);
           copyGrains<true, sizeof(ScratchBuf) / grainBytes, 1, true>(
-              0, &dstTile(0, 0), &scratchBuffers[idxBufBase + n][warpIdxInGrp](0, 0));
+              0, &dstTile(0, 0),
+              &scratchBuffers[idxBufBase + n][warpIdxInGrp + gemm1WarpsPerGrp * hs](0, 0));
           constexpr uint32_t nbGrainsPerRowMaxBuf = exactDiv(sizeof(SMemWarpRowMax), grainBytes);
           copyGrains<true, roundUp(nbGrainsPerRowMaxBuf, 32u), 1, nbGrainsPerRowMaxBuf % 32 == 0>(
               0, reinterpret_cast<LdGrain*>(&dstRowSum),
@@ -2737,73 +2801,74 @@ CUBIN_EXPORT __global__
               reinterpret_cast<LdGrain const*>(&rowMaxBuffers[idxBufBase + n]),
               nbGrainsPerRowMaxBuf);
         };
-        loadBufAsync(warpGrpIdx);
-        ldgsts::commitGroup();
-        WarpAcc sumAcc{};
-        ThrdRegRowMax partialMergedRowSum{};
-        for (uint32_t n = warpGrpIdx; n < nbSubSeqPerSeq; n += gemm1NbWarpGrps) {
-          if (n + gemm1NbWarpGrps < nbSubSeqPerSeq) {
-            loadBufAsync(n + gemm1NbWarpGrps);
-          }
+        // Merge one head-dim slice at a time. mergedRowSum is recomputed per slice from
+        // per-subseq scalars; the value is identical across slices. The smem regions used
+        // by mbbuf tiles and the mergeAndSaveOutTile swizzle buffer are ordered by the
+        // __syncthreads() calls inside this loop and in mergeAndSaveOutTile.
+        for (uint32_t hs = 0; hs < nbHeadSplits; hs++) {
+          loadBufAsync(warpGrpIdx, hs);
           ldgsts::commitGroup();
-          ldgsts::waitGroup<1>();
-          uint32_t const d = n / gemm1NbWarpGrps % nbTileBuffers;
-          WarpAcc tile = toWarpAcc(loadGemmOutTile(warp, mbbuf.tiles[warpGrpIdx][warpIdxInGrp][d]));
-          ThrdRegRowMax const tileRowMax = getTileBuf(mbbuf.tileRowMax, d).loadToReg<false>(warp);
-          ThrdRegRowMax const tileRowSum = getTileBuf(mbbuf.tileRowSums, d).loadToReg<false>(warp);
-          ThrdRegRowMax const tileRowScales = expf(tileRowMax - mergedRowMax);
-          ThrdRegRowMax const scaledTileRowSum = tileRowSum * tileRowScales;
-          partialMergedRowSum = partialMergedRowSum + scaledTileRowSum;
-          assert(std::isfinite(partialMergedRowSum[0]));
-          rescaleAcc(warp, tile, fullRescaleMask, scaledTileRowSum);
-          sumAcc = sumAcc + tile;
-        }
-
-        ThrdRegRowMax mergedRowSum{};
-        if (gemm1NbWarpGrps == 1) {
-          mergedRowSum = partialMergedRowSum;
-        } else {
-          if (warpIdxInGrp == 0) {
-            mbbuf.mergedRowSum[warpGrpIdx].storeFromReg<false>(warp, partialMergedRowSum);
+          WarpAcc sumAcc{};
+          ThrdRegRowMax partialMergedRowSum{};
+          for (uint32_t n = warpGrpIdx; n < nbSubSeqPerSeq; n += gemm1NbWarpGrps) {
+            if (n + gemm1NbWarpGrps < nbSubSeqPerSeq) {
+              loadBufAsync(n + gemm1NbWarpGrps, hs);
+            }
+            ldgsts::commitGroup();
+            ldgsts::waitGroup<1>();
+            uint32_t const d = n / gemm1NbWarpGrps % nbTileBuffers;
+            WarpAcc tile =
+                toWarpAcc(loadGemmOutTile(warp, mbbuf.tiles[warpGrpIdx][warpIdxInGrp][d]));
+            ThrdRegRowMax const tileRowMax = getTileBuf(mbbuf.tileRowMax, d).loadToReg<false>(warp);
+            ThrdRegRowMax const tileRowSum =
+                getTileBuf(mbbuf.tileRowSums, d).loadToReg<false>(warp);
+            ThrdRegRowMax const tileRowScales = expf(tileRowMax - mergedRowMax);
+            ThrdRegRowMax const scaledTileRowSum = tileRowSum * tileRowScales;
+            partialMergedRowSum = partialMergedRowSum + scaledTileRowSum;
+            assert(std::isfinite(partialMergedRowSum[0]));
+            rescaleAcc(warp, tile, fullRescaleMask, scaledTileRowSum);
+            sumAcc = sumAcc + tile;
           }
-          __syncthreads();
+
+          ThrdRegRowMax mergedRowSum{};
+          if (gemm1NbWarpGrps == 1) {
+            mergedRowSum = partialMergedRowSum;
+          } else {
+            if (warpIdxInGrp == 0) {
+              mbbuf.mergedRowSum[warpGrpIdx].storeFromReg<false>(warp, partialMergedRowSum);
+            }
+            __syncthreads();
 #ifndef NDEBUG
-          assert((mbbuf.mergedRowSum[warpGrpIdx].loadToReg<false>(warp) == partialMergedRowSum)[0]);
-          __syncthreads();
+            assert(
+                (mbbuf.mergedRowSum[warpGrpIdx].loadToReg<false>(warp) == partialMergedRowSum)[0]);
+            __syncthreads();
 #endif
 #pragma unroll
-          for (uint32_t i = 0; i < gemm1NbWarpGrps; i++) {
-            mergedRowSum = mergedRowSum + mbbuf.mergedRowSum[i].loadToReg<false>(warp);
-            assert(std::isfinite(mergedRowSum[0]));
+            for (uint32_t i = 0; i < gemm1NbWarpGrps; i++) {
+              mergedRowSum = mergedRowSum + mbbuf.mergedRowSum[i].loadToReg<false>(warp);
+              assert(std::isfinite(mergedRowSum[0]));
+            }
           }
-        }
-        if (attentionSinks != nullptr) {
-          // Attention sinks are per head.
+          if (attentionSinks != nullptr) {
+            // Attention sinks are per head.
 #if SPEC_DEC
-          addAttentionSinksSpecDec(mergedRowSum, mergedRowMax,
-                                   attentionSinks + headGrpSize * idxHeadGrp, headGrpSize);
+            addAttentionSinksSpecDec(mergedRowSum, mergedRowMax,
+                                     attentionSinks + headGrpSize * idxHeadGrp, headGrpSize);
 #else
-          addAttentionSinks(mergedRowSum, mergedRowMax, attentionSinks + headGrpSize * idxHeadGrp);
+            addAttentionSinks(mergedRowSum, mergedRowMax,
+                              attentionSinks + headGrpSize * idxHeadGrp);
 #endif
+          }
+          __syncthreads();
+          rescaleAcc(warp, sumAcc, fullRescaleMask, __frcp_rn(mergedRowSum));
+          GemmOutRegTile const mergedOutTile = toFp16(sumAcc);
+          SharedMem::XSmemBuffer* smemOutTile = mergeAndSaveOutTile(mergedOutTile, false);
+          if (warpGrpIdx == 0) {
+            writeOutSlice(*smemOutTile, hs);
+          }
+          __syncthreads();
         }
-        __syncthreads();
-        rescaleAcc(warp, sumAcc, fullRescaleMask, __frcp_rn(mergedRowSum));
-        GemmOutRegTile const mergedOutTile = toFp16(sumAcc);
-        smemOutTile = mergeAndSaveOutTile(mergedOutTile, false);
       }
-    }
-    if (ctaShouldWriteOut && warpGrpIdx == 0) {
-#if SPEC_DEC
-      copyOutputToGlobalMem(
-          warp, &output[reqSeqOffset * nbQHeads], nbQHeads, headGrpSize, (idxHeadGrp * headGrpSize),
-          nbValidHeadTokens,
-          uint2{warpTile.x * warpIdxInGrp, nbValidRows * warpIdx.y + idxHeadTokenInGrp},
-          *smemOutTile);
-#else
-      copyOutputToGlobalMem(warp, &output[nbQHeads * beamWidth * idxReq], nbQHeads, idxHeadGrp,
-                            uint2{warpTile.x * warpIdxInGrp, nbValidRows * warpIdx.y},
-                            *smemOutTile);
-#endif
     }
   }
 }

--- a/csrc/xqa/mha.h
+++ b/csrc/xqa/mha.h
@@ -28,11 +28,14 @@ using CacheElemConverter = ElemTypeConverter<CACHE_ELEM_ENUM>;
 using CacheElem = CacheElemConverter::Type;
 constexpr uint32_t validElemsPerHead = HEAD_ELEMS;
 constexpr bool isMLA = IS_MLA;
-static_assert((isMLA || validElemsPerHead <= 256) &&
+static_assert((isMLA || validElemsPerHead <= 512) &&
               (sizeof(CacheElem) * validElemsPerHead) % 16 == 0);
 constexpr uint32_t headElems =
-    validElemsPerHead <= 64 ? 64 : (validElemsPerHead <= 128 ? 128 : (isMLA ? 576 : 256));
-static_assert(headElems == 64 || headElems == 128 || headElems == 256 || headElems == 576,
+    validElemsPerHead <= 64
+        ? 64
+        : (validElemsPerHead <= 128 ? 128 : (isMLA ? 576 : (validElemsPerHead <= 256 ? 256 : 512)));
+static_assert(headElems == 64 || headElems == 128 || headElems == 256 || headElems == 512 ||
+                  headElems == 576,
               "not implemented");
 constexpr uint32_t beamWidth = BEAM_WIDTH;
 constexpr uint32_t headGrpSize = HEAD_GRP_SIZE;

--- a/csrc/xqa/mhaUtils.cuh
+++ b/csrc/xqa/mhaUtils.cuh
@@ -120,31 +120,33 @@ __device__ inline void copyPartialHeadsAsync(
   constexpr uint32_t thrdLdBytes = exactDiv(warpLdBytes, warp_size);
   assertIsPowerOf2<thrdLdBytes>();
   static_assert(thrdLdBytes >= grainBytesSmem);
-  // a segment is responsible for loading one partial head collaboratively
-  constexpr uint32_t thrdsPerSeg = exactDiv(partBytes, grainBytesSmem);
-  static_assert(thrdsPerSeg > 0 && thrdsPerSeg <= warp_size);
-  assertIsPowerOf2<thrdsPerSeg>();
+  // a segment is responsible for loading one partial head collaboratively. A segment may
+  // span multiple warp iterations when a partial head is larger than one warp-wide load
+  // (grainsPerPart > warp_size, e.g. full 512-elem fp16 heads).
+  constexpr uint32_t grainsPerPart = exactDiv(partBytes, grainBytesSmem);
+  static_assert(grainsPerPart > 0);
+  assertIsPowerOf2<grainsPerPart>();
   assert(__shfl_sync(0xFU << (laneId() / 4 * 4), src.offset, 0, 4) == src.offset);
   auto const warpLane = laneId();
-  uint32_t const segIdx = warpLane / thrdsPerSeg;
-  uint32_t const segLane = warpLane % thrdsPerSeg;
-  constexpr uint32_t partsPerWarpInst = exactDiv(grainBytesSmem * warp_size, partBytes);
 #pragma unroll
   for (uint32_t i = 0; i < thrdLdBytes / grainBytesSmem; i++) {
-    uint32_t const idxHeadLocal = partsPerWarpInst * i + segIdx;
+    // flat grain index into the warp's copy region, laid out part-major. Equivalent to the
+    // previous segIdx/segLane scheme for grainsPerPart <= warp_size.
+    uint32_t const flatGrainIdx = warp_size * i + warpLane;
+    uint32_t const idxHeadLocal = flatGrainIdx / grainsPerPart;
+    uint32_t const grainInPart = flatGrainIdx % grainsPerPart;
     assert(idxHeadLocal < maxNbCopiedHeads);
     bool const isHeadInBound = isFull || (idxHeadLocal < nbAvailHeads);
-    constexpr uint32_t grainsPerPart = exactDiv(partBytes, grainBytesSmem);
     using SrcHead = mha::decay_t<decltype(src[0])>;
     constexpr uint32_t nbValidGrains = exactDiv(sizeof(SrcHead), grainBytesGmem);
-    uint32_t const idxGrainInsideHead = grainsPerPart * idxPart + segLane;
+    uint32_t const idxGrainInsideHead = grainsPerPart * idxPart + grainInPart;
     bool const isGrainInBound = (!isHeadPadded || idxGrainInsideHead < nbValidGrains);
     SrcHead const* const pSrcHead = src + localHeadIdxMap(idxHeadLocal);
     bool const isValidPage = (pSrcHead != nullptr);
     Vec<uint8_t, grainBytesGmem> const* const pSrc =
         reinterpret_cast<Vec<uint8_t, grainBytesGmem> const*>(pSrcHead) + idxGrainInsideHead;
     Vec<uint8_t, grainBytesSmem>* const pDst = reinterpret_cast<Vec<uint8_t, grainBytesSmem>*>(
-        &dst.template at<swizzle>(dstHeadOffset + idxHeadLocal, segLane));
+        &dst.template at<swizzle>(dstHeadOffset + idxHeadLocal, grainInPart));
 #if !ENABLE_4BIT_KV_CACHE
     // 4-bit KV cache is not bank-conflict free now.
     assert(!hasBankConflict(pDst));

--- a/flashinfer/jit/xqa.py
+++ b/flashinfer/jit/xqa.py
@@ -85,10 +85,22 @@ def gen_xqa_module(
         )
     flag_tokens_per_page = [f"-DTOKENS_PER_PAGE={page_size}"]
 
-    if head_dim % 16 != 0 or head_dim > 256 or head_dim < 16:
+    if head_dim % 16 != 0 or head_dim > 512 or head_dim < 16:
         raise ValueError(
-            f"Invalid head_dim: {head_dim}, must be divisible by 16 and in range [16, 256]"
+            f"Invalid head_dim: {head_dim}, must be divisible by 16 and in range [16, 512]"
         )
+    if head_dim > 256:
+        # headElems > 256 uses per-warp head-dim splits in mha.cu (see nbHeadSplits);
+        # the specialized SPEC_DEC/SM90-GMMA paths do not support it, and the
+        # persistent-Q smem budget requires head_group_ratio <= 16.
+        if q_seq_len > 1:
+            raise ValueError(
+                f"head_dim {head_dim} > 256 does not support speculative decoding (q_seq_len > 1)"
+            )
+        if head_group_ratio > 16:
+            raise ValueError(
+                f"head_dim {head_dim} > 256 requires head_group_ratio <= 16, got {head_group_ratio}"
+            )
     flag_head_dim = [f"-DHEAD_ELEMS={head_dim}"]
 
     flag_head_group_ratio = [f"-DHEAD_GRP_SIZE={head_group_ratio}"]
@@ -138,7 +150,8 @@ def gen_xqa_module(
         jit_env.FLASHINFER_CSRC_DIR / "flashinfer_xqa_binding.cu",
     ]
 
-    if _has_sm90_target():
+    if _has_sm90_target() and head_dim <= 256:
+        # The SM90 GMMA kernel does not support head_dim > 256.
         sources.append(jit_env.FLASHINFER_CSRC_DIR / "xqa/mha_sm90.cu")
         sources.append(jit_env.FLASHINFER_CSRC_DIR / "xqa/tensorMap.cpp")
         flag_sm90_mha = ["-DUSE_SM90_MHA=1"]

--- a/flashinfer/xqa.py
+++ b/flashinfer/xqa.py
@@ -386,6 +386,7 @@ def xqa(
     if (
         k_cache.dtype == torch.float8_e4m3fn
         and get_compute_capability(torch.device(device="cuda"))[0] == 9
+        and head_dim <= 256  # SM90 kernel does not support head_dim > 256
     ):
         run_sm90_fp8_mha = True
     else:

--- a/tests/attention/test_xqa_batch_decode.py
+++ b/tests/attention/test_xqa_batch_decode.py
@@ -390,18 +390,23 @@ def generate_spec_dec_mask(
     reason="XQA is only supported on SM90, SM100, SM120/SM121 GPUs",
 )
 @pytest.mark.parametrize(
-    "batch_size,q_len_per_req,page_size,num_kv_heads,head_grp_size",
+    "batch_size,q_len_per_req,page_size,num_kv_heads,head_grp_size,head_dim",
     [
-        (4, 4, 64, 4, 2),
-        (4, 2, 16, 2, 4),
-        (4, 3, 32, 2, 6),
-        (4, 1, 16, 2, 1),
-        (4, 1, 32, 2, 5),
-        (128, 1, 64, 2, 6),
-        (256, 1, 64, 4, 8),
+        (4, 4, 64, 4, 2, 128),
+        (4, 2, 16, 2, 4, 128),
+        (4, 3, 32, 2, 6, 128),
+        (4, 1, 16, 2, 1, 128),
+        (4, 1, 32, 2, 5, 128),
+        (128, 1, 64, 2, 6, 128),
+        (256, 1, 64, 4, 8, 128),
         # 32 q heads / 2 kv heads (group ratio 16)
-        (4, 1, 32, 2, 16),
-        (4, 4, 32, 2, 16),
+        (4, 1, 32, 2, 16, 128),
+        (4, 4, 32, 2, 16, 128),
+        # head_dim 512 (Gemma-style GQA), decode only (no spec dec)
+        (4, 1, 32, 2, 4, 512),
+        (4, 1, 32, 2, 5, 512),
+        (16, 1, 64, 2, 8, 512),
+        (4, 1, 16, 2, 16, 512),
     ],
 )
 @pytest.mark.parametrize("window_left", [-1, 127])
@@ -427,6 +432,7 @@ def test_xqa_batch_decode(
     page_size,
     num_kv_heads,
     head_grp_size,
+    head_dim,
     window_left,
     q_dtype,
     o_dtype,
@@ -443,7 +449,6 @@ def test_xqa_batch_decode(
 
     # Set up test parameters
     torch.manual_seed(0)
-    head_dim = 128
 
     # Generate random sequence lengths
     num_qo_heads = num_kv_heads * head_grp_size
@@ -641,6 +646,7 @@ def test_xqa_batch_decode_spec_dec_sliding_window(
         page_size=page_size,
         num_kv_heads=num_kv_heads,
         head_grp_size=head_grp_size,
+        head_dim=128,
         window_left=window_left,
         q_dtype=q_dtype,
         o_dtype=o_dtype,
@@ -1173,6 +1179,7 @@ if __name__ == "__main__":
         page_size=16,
         num_kv_heads=2,
         head_grp_size=1,
+        head_dim=128,
         window_left=-1,
         q_dtype="bf16",
         kv_dtype="bf16",


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->

XQA currently rejects `head_dim > 256`, blocking Gemma-style GQA decode (head_dim 512) — notably on SM120/121 where XQA is the default choice for decode backend. Existing kernel path for head dim <= 256 should be identical as before
  
Also included:
- Fix for a latent (previously unreachable) V page-advance bug when `cacheVTileSeqStride % tokensPerPage != 0`: `exactDiv` yielded a zero page step under NDEBUG. Required for fp16 KV at 512 on SM12x (16-token V tiles with 32-token pages).
- `copyPartialHeadsAsync` generalized to head parts wider than one warp-load (equivalent indexing for all existing configs).
- **JIT-only by design**: >256 stays out of the AOT prebuild to protect flashinfer-jit-cache binary size.



### Performance
In general, 
* No regressions observed on head_dim=256.
* head_dim=512 performance is comparable to `fa2` backend

RTX PRO 6000 (SM120), decode q_len=1, 4 KV heads, group 4, page 32:
  
| Config | XQA (this PR) | FA2 tensor-core decode (only prior option) |
|---|---|---|
| fp16 KV, b64, seq 4096 | 1505 µs | 1417 µs |
| **fp8 KV, b64, seq 4096** | **741 µs** | n/a (FA2 has no fp8 KV at 512) |
| fp8 KV, b256, seq 1024 | 755 µs | n/a (fp16 FA2: 1411 µs) |


## 🔍 Related Issues

<!-- Link any related issues here -->

#4546

Note: smem was not really a blocker; it just needed a slight kernel redesign.

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for attention head dimensions up to 512 elements.
  * Improved grouped value loading and processing for larger heads.
  * Enabled large-head batch decoding in supported configurations.

* **Bug Fixes**
  * Improved handling of split heads, partial data, page transitions, and output reduction.
  * Updated kernel selection to use compatible execution paths for larger dimensions.

* **Tests**
  * Expanded batch-decoding coverage with multiple 512-element head-dimension scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->