### PR TITLE
fix(attention): derive FA2 prefill planner num_blocks_per_sm from occupancy

### DIFF
--- a/csrc/batch_prefill.cu
+++ b/csrc/batch_prefill.cu
@@ -67,7 +67,7 @@ Array<int64_t> BatchPrefillWithKVCachePlan(
       static_cast<IdType*>(kv_indptr.data_ptr()), total_num_rows, batch_size, num_qo_heads,
       num_kv_heads, head_dim_qk, head_dim_vo, page_size, enable_cuda_graph,
       /*sizeof_dtype_o=*/2, window_left, fixed_split_size, disable_split_kv, num_colocated_ctas,
-      uniform_q_len, stream, /*kv_dtype_bytes=*/sizeof(DTypeKV));
+      uniform_q_len, MakeFA2PrefillDTypeInfo<DTypeQ, DTypeKV>(), stream);
 
   TVM_FFI_ICHECK(status == cudaSuccess)
       << "Failed to plan prefill with error: " << cudaGetErrorString(status);
@@ -93,7 +93,7 @@ Array<int64_t> BatchPrefillWithKVCacheWorkspaceSize(
       static_cast<IdType*>(qo_indptr.data_ptr()), static_cast<IdType*>(kv_indptr.data_ptr()),
       total_num_rows, batch_size, num_qo_heads, num_kv_heads, head_dim_qk, head_dim_vo, page_size,
       enable_cuda_graph, /*sizeof_dtype_o=*/2, window_left, fixed_split_size, disable_split_kv,
-      num_colocated_ctas, uniform_q_len, stream, /*kv_dtype_bytes=*/sizeof(DTypeKV));
+      num_colocated_ctas, uniform_q_len, MakeFA2PrefillDTypeInfo<DTypeQ, DTypeKV>(), stream);
 
   TVM_FFI_ICHECK(status == cudaSuccess)
       << "Failed to calculate prefill workspace size with error: " << cudaGetErrorString(status);

--- a/include/flashinfer/attention/prefill.cuh
+++ b/include/flashinfer/attention/prefill.cuh
@@ -39,6 +39,7 @@
 #include "../utils.cuh"
 #include "cascade.cuh"
 #include "mask.cuh"
+#include "prefill_occupancy.cuh"
 #include "variants.cuh"
 namespace flashinfer {
 
@@ -51,49 +52,15 @@ DEFINE_HAS_MEMBER(maybe_max_item_len_ptr)
 DEFINE_HAS_MEMBER(maybe_k_cache_sf)
 DEFINE_HAS_MEMBER(maybe_v_cache_sf)
 
-// Type trait to detect packed NVFP4 KV cache types (__nv_fp4x2_e2m1 stores 2 FP4 per byte).
-template <typename T>
-struct is_fp4_type : std::false_type {};
-#if CUDA_VERSION >= 12080
-template <>
-struct is_fp4_type<__nv_fp4x2_e2m1> : std::true_type {};
-#endif
-template <typename T>
-inline constexpr bool is_fp4_type_v = is_fp4_type<T>::value;
+// is_fp4_type / is_fp4_type_v, NVFP4_SF_VEC_SIZE and the get_num_{warps_q,warps_kv,mma_q}
+// tile-shape helpers now live in prefill_occupancy.cuh, which the prefill planner
+// also includes so that both sides derive the CTA shape from one definition.
 
 namespace cg = cooperative_groups;
 using cp_async::SharedMemFillMode;
 using mma::MMAMode;
 
 constexpr uint32_t WARP_SIZE = 32;
-// Number of NVFP4 elements sharing one scale factor (UE4M3 byte).
-constexpr uint32_t NVFP4_SF_VEC_SIZE = 16;
-
-constexpr uint32_t get_num_warps_q(const uint32_t cta_tile_q) {
-  if (cta_tile_q == 32) {
-    return 1;  // HEAD_DIM_VO >= 512
-  }
-  if (cta_tile_q > 16) {
-    return 4;
-  } else {
-    return 1;
-  }
-}
-
-constexpr uint32_t get_num_warps_kv(const uint32_t cta_tile_kv) {
-  return 4 / get_num_warps_q(cta_tile_kv);
-}
-
-constexpr uint32_t get_num_mma_q(const uint32_t cta_tile_q) {
-  if (cta_tile_q == 32) {
-    return 2;  // HEAD_DIM_VO >= 512
-  }
-  if (cta_tile_q > 64) {
-    return 2;
-  } else {
-    return 1;
-  }
-}
 
 // NVFP4 KV-cache scale-factor staging (one UE4M3 byte per NVFP4_SF_VEC_SIZE elements), used only
 // when DTypeKV is FP4. Kept as an empty base for other dtypes so it adds 0 bytes via EBO instead
@@ -4212,6 +4179,14 @@ cudaError_t BatchPrefillWithRaggedKVCacheDispatched(Params params, typename Para
   // minimum *valid* tile rather than NUM_MMA_KV=1.
   constexpr uint32_t kMinValidMmaKV =
       (sizeof(DTypeKV) == 1 && NUM_WARPS_Q > 2) ? (NUM_WARPS_Q / 2) : 1;
+  // PrefillPlanImpl budgets its split-KV grid against FA2PrefillCtaSmemLowerBound
+  // because it has none of the template parameters above in scope. That is only
+  // sound while the bound never exceeds what this launcher actually requires;
+  // pin it here for every instantiation the build produces.
+  static_assert(FA2PrefillCtaSmemLowerBound(CTA_TILE_Q, HEAD_DIM_QK, HEAD_DIM_VO,
+                                            MakeFA2PrefillDTypeInfo<DTypeQ, DTypeKV>()) <=
+                    kFixedSmem + kMinValidMmaKV * kKVSmemPerMmaKV,
+                "the planner's shared-memory lower bound exceeds this kernel's requirement");
   const int num_ctas_per_sm =
       max_smem_per_sm >= 2 * (kFixedSmem + kMinValidMmaKV * kKVSmemPerMmaKV) ? 2 : 1;
   // The occupancy budget (max_smem_per_sm / num_ctas_per_sm) can exceed the
@@ -4411,6 +4386,11 @@ cudaError_t BatchPrefillWithPagedKVCacheDispatched(Params params, typename Param
   // minimum *valid* tile rather than NUM_MMA_KV=1.
   constexpr uint32_t kMinValidMmaKV =
       (sizeof(DTypeKV) == 1 && NUM_WARPS_Q > 2) ? (NUM_WARPS_Q / 2) : 1;
+  // See the matching static_assert in BatchPrefillWithRaggedKVCacheDispatched.
+  static_assert(FA2PrefillCtaSmemLowerBound(CTA_TILE_Q, HEAD_DIM_QK, HEAD_DIM_VO,
+                                            MakeFA2PrefillDTypeInfo<DTypeQ, DTypeKV>()) <=
+                    kFixedSmem + kMinValidMmaKV * kKVSmemPerMmaKV,
+                "the planner's shared-memory lower bound exceeds this kernel's requirement");
   const int num_ctas_per_sm =
       max_smem_per_sm >= 2 * (kFixedSmem + kMinValidMmaKV * kKVSmemPerMmaKV) ? 2 : 1;
   const int max_smem_per_threadblock =

--- a/include/flashinfer/attention/prefill_occupancy.cuh
+++ b/include/flashinfer/attention/prefill_occupancy.cuh
@@ -1,0 +1,209 @@
+/*
+ * Copyright (c) 2026 by FlashInfer team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef FLASHINFER_ATTENTION_PREFILL_OCCUPANCY_CUH_
+#define FLASHINFER_ATTENTION_PREFILL_OCCUPANCY_CUH_
+
+#include <cuda_runtime.h>
+#if CUDA_VERSION >= 12080
+#include <cuda_fp4.h>
+#endif
+
+#include <cstdint>
+#include <type_traits>
+
+namespace flashinfer {
+
+// Number of NVFP4 elements sharing one scale factor (UE4M3 byte).
+constexpr uint32_t NVFP4_SF_VEC_SIZE = 16;
+
+// Type trait to detect packed NVFP4 KV cache types (__nv_fp4x2_e2m1 stores 2 FP4 per byte).
+template <typename T>
+struct is_fp4_type : std::false_type {};
+#if CUDA_VERSION >= 12080
+template <>
+struct is_fp4_type<__nv_fp4x2_e2m1> : std::true_type {};
+#endif
+template <typename T>
+inline constexpr bool is_fp4_type_v = is_fp4_type<T>::value;
+
+constexpr uint32_t get_num_warps_q(const uint32_t cta_tile_q) {
+  if (cta_tile_q == 32) {
+    return 1;  // HEAD_DIM_VO >= 512
+  }
+  if (cta_tile_q > 16) {
+    return 4;
+  } else {
+    return 1;
+  }
+}
+
+constexpr uint32_t get_num_warps_kv(const uint32_t cta_tile_kv) {
+  return 4 / get_num_warps_q(cta_tile_kv);
+}
+
+constexpr uint32_t get_num_mma_q(const uint32_t cta_tile_q) {
+  if (cta_tile_q == 32) {
+    return 2;  // HEAD_DIM_VO >= 512
+  }
+  if (cta_tile_q > 64) {
+    return 2;
+  } else {
+    return 1;
+  }
+}
+
+/*!
+ * \brief The dtype facts FA2PrefillCtaSmemLowerBound needs, derived from the types.
+ *
+ * These three values must describe the same pair of types, and two of them cannot
+ * be recovered from each other: FP8 and NVFP4 KV are both 1 byte, so `kv_is_fp4`
+ * is independent information, and there is no value of it that is safe to guess
+ * (guessing `false` for an FP4 cache turns on `kUseRepack`, which the ragged and
+ * paged launchers do not charge, and the bound then *exceeds* the launcher's
+ * requirement -- the one direction that is unsound).
+ *
+ * Callers therefore never spell the fields out; they call
+ * MakeFA2PrefillDTypeInfo<DTypeQ, DTypeKV>(), which computes all three from the
+ * types themselves. There is no defaulted overload on purpose, and the members
+ * are private behind a friend-only constructor so that "spell the fields out"
+ * is a compile error rather than a convention.
+ */
+class FA2PrefillDTypeInfo;
+
+template <typename DTypeQ, typename DTypeKV>
+constexpr FA2PrefillDTypeInfo MakeFA2PrefillDTypeInfo();
+
+class FA2PrefillDTypeInfo {
+ public:
+  constexpr uint32_t q_dtype_bytes() const { return q_dtype_bytes_; }
+  constexpr uint32_t kv_dtype_bytes() const { return kv_dtype_bytes_; }
+  constexpr bool kv_is_fp4() const { return kv_is_fp4_; }
+
+ private:
+  // Private tag: the constructor cannot be named outside the friend factory, so
+  // this is not an aggregate, has no default constructor, and exposes no mutable
+  // member. Aggregate init, designated init, value init and copy-then-mutate are
+  // all compile errors -- the only way to obtain a value is from the types.
+  struct FromTypes {};
+  constexpr FA2PrefillDTypeInfo(FromTypes, uint32_t q_bytes, uint32_t kv_bytes, bool is_fp4)
+      : q_dtype_bytes_(q_bytes), kv_dtype_bytes_(kv_bytes), kv_is_fp4_(is_fp4) {}
+
+  template <typename DTypeQ, typename DTypeKV>
+  friend constexpr FA2PrefillDTypeInfo MakeFA2PrefillDTypeInfo();
+
+  uint32_t q_dtype_bytes_;
+  uint32_t kv_dtype_bytes_;
+  bool kv_is_fp4_;
+};
+
+template <typename DTypeQ, typename DTypeKV>
+constexpr FA2PrefillDTypeInfo MakeFA2PrefillDTypeInfo() {
+  return FA2PrefillDTypeInfo(FA2PrefillDTypeInfo::FromTypes{},
+                             static_cast<uint32_t>(sizeof(DTypeQ)),
+                             static_cast<uint32_t>(sizeof(DTypeKV)), is_fp4_type_v<DTypeKV>);
+}
+
+/*!
+ * \brief Lower bound, in bytes, on the shared memory one FA2 prefill CTA needs.
+ *
+ * The kernel launchers already decide how many CTAs fit on an SM:
+ *
+ *   num_ctas_per_sm =
+ *       max_smem_per_sm >= 2 * (kFixedSmem + kMinValidMmaKV * kKVSmemPerMmaKV) ? 2 : 1;
+ *
+ * (BatchPrefillWithRaggedKVCacheDispatched / BatchPrefillWithPagedKVCacheDispatched
+ * in prefill.cuh).  The planner cannot evaluate that expression directly:
+ * PrefillPlanImpl is templated only on <MATERIALIZE, IdType> and the plan entry
+ * point is shared by the ragged and paged run paths.  This function reproduces
+ * the same arithmetic from quantities the plan-time translation unit does have,
+ * and for every quantity that is still not observable it substitutes the choice
+ * that makes the requirement *smallest*.  The result is therefore always <= the
+ * launcher's value; prefill.cuh pins that per instantiation with a static_assert.
+ *
+ * The inequality direction is the load-bearing property.  The planner only uses
+ * this to lower num_blocks_per_sm from 2 to 1, so an under-estimate merely keeps
+ * the historical behaviour, whereas an over-estimate would shrink the split-KV
+ * grid on a configuration that really does hold two CTAs per SM.
+ *
+ * Quantities that remain unobservable at plan time, and how each is handled:
+ *   - AttentionVariant::use_softmax (bound to the run-time mask mode) and the
+ *     ragged/paged launcher identity (one plan entry point serves both):
+ *     kVOSplitDispatch is treated as false, dropping both the per-tile and the
+ *     fixed VO-split allocations, and the wider (ragged) kLargeHeadWarpSplit
+ *     predicate is taken, halving NUM_WARPS_KV.  Every remaining term is
+ *     non-decreasing in NUM_WARPS_KV, so both substitutions only remove bytes.
+ *   - NVFP4 scale-factor staging: dropped, because the ragged and paged
+ *     launchers do not count it either (only the single-prefill launcher does).
+ *     See the note at the term itself.
+ *   - POS_ENCODING_MODE: kSharedRopeFreqSmem is dropped (it is >= 0).  It is
+ *     visible in the plan TU but is at most 4 * (HEAD_DIM_QK / 32) * 16 bytes
+ *     and never changes the predicate's outcome, so it is left out to keep the
+ *     shared contract narrow.
+ *   - MASK_MODE and USE_FP16_QK_REDUCTION do not enter the launcher's
+ *     expression at all.
+ *
+ * \param cta_tile_q   CTA_TILE_Q the run path will dispatch on, i.e. plan_info.cta_tile_q
+ * \param head_dim_qk  HEAD_DIM_QK
+ * \param head_dim_vo  HEAD_DIM_VO
+ * \param dtype_info   from MakeFA2PrefillDTypeInfo<DTypeQ, DTypeKV>()
+ */
+constexpr uint32_t FA2PrefillCtaSmemLowerBound(uint32_t cta_tile_q, uint32_t head_dim_qk,
+                                               uint32_t head_dim_vo,
+                                               FA2PrefillDTypeInfo dtype_info) {
+  const uint32_t q_dtype_bytes = dtype_info.q_dtype_bytes();
+  const uint32_t kv_dtype_bytes = dtype_info.kv_dtype_bytes();
+  const bool kv_is_fp4 = dtype_info.kv_is_fp4();
+  const uint32_t num_mma_d_vo = head_dim_vo / 16;
+  // kLargeHeadWarpSplit / kBf16VOSplit, taken unconditionally: it gives
+  // NUM_WARPS_KV = 2 where the paged FP8 path would use 4.
+  const bool large_head_warp_split = (head_dim_vo >= 512) && (cta_tile_q == 32);
+  const uint32_t num_warps_q = large_head_warp_split ? 2u : get_num_warps_q(cta_tile_q);
+  const uint32_t num_warps_kv = large_head_warp_split ? 2u : get_num_warps_kv(cta_tile_q);
+
+  // kUseRepack
+  const bool use_repack = (kv_dtype_bytes == 1) && !kv_is_fp4 && (head_dim_vo != 64) &&
+                          (head_dim_vo <= 256) && (cta_tile_q > 16);
+  // kKVShared
+  const bool kv_shared = !kv_is_fp4 && (num_mma_d_vo > 16) && (num_mma_d_vo % num_warps_kv == 0) &&
+                         (head_dim_qk == head_dim_vo) && (kv_dtype_bytes == 2 || cta_tile_q > 16);
+
+  // kKVSmemPerMmaKV, without the kVOSplitDispatch term.
+  uint32_t kv_smem_per_mma_kv =
+      kv_shared ? (head_dim_qk * 16 * num_warps_kv * kv_dtype_bytes)
+                : ((head_dim_qk + head_dim_vo) * 16 * num_warps_kv * kv_dtype_bytes);
+  if (use_repack) {
+    kv_smem_per_mma_kv +=
+        (head_dim_qk > head_dim_vo ? head_dim_qk : head_dim_vo) * 16 * num_warps_kv * q_dtype_bytes;
+  }
+  // NOTE: the NVFP4 scale-factor staging term is deliberately NOT counted. Only
+  // SinglePrefillWithKVCacheDispatched includes it in its occupancy budget; the
+  // ragged and paged launchers -- the only two this planner feeds -- omit it.
+  // Adding it here would make the estimate exceed their requirement, i.e. break
+  // the direction this whole function depends on. Leaving it out also stays
+  // correct if the launchers later start counting it, since the term is
+  // non-negative.
+  // kFixedSmem, without kVOSplitFixedSmem and kSharedRopeFreqSmem.
+  const uint32_t fixed_smem = cta_tile_q * head_dim_qk * q_dtype_bytes;
+  // kMinValidMmaKV
+  const uint32_t min_valid_mma_kv =
+      (kv_dtype_bytes == 1 && num_warps_q > 2) ? (num_warps_q / 2) : 1u;
+
+  return fixed_smem + min_valid_mma_kv * kv_smem_per_mma_kv;
+}
+
+}  // namespace flashinfer
+
+#endif  // FLASHINFER_ATTENTION_PREFILL_OCCUPANCY_CUH_

--- a/include/flashinfer/attention/scheduler.cuh
+++ b/include/flashinfer/attention/scheduler.cuh
@@ -30,6 +30,7 @@
 #include "../pos_enc.cuh"
 #include "../utils.cuh"
 #include "heap.h"
+#include "prefill_occupancy.cuh"
 
 namespace flashinfer {
 
@@ -541,6 +542,39 @@ inline cudaError_t DecodePlanWorkspaceSize(size_t& float_workspace_size_in_bytes
       enable_cuda_graph, stream, work_estimation_func);
 }
 
+/*!
+ * \brief The CTA_TILE_Q the FA2 prefill run path will dispatch on for this plan.
+ *
+ * Factored out of PrefillSplitQOKVIndptr so that PrefillPlanImpl can size its
+ * occupancy budget against the same tile without the two ever drifting apart.
+ * It reads only qo_indptr_h and shape metadata, so it can be evaluated before
+ * the split budget it feeds into.
+ */
+template <typename IdType>
+inline uint32_t FA2PlanCtaTileQ(IdType* qo_indptr_h, uint32_t total_num_rows, uint32_t batch_size,
+                                uint32_t gqa_group_size, bool enable_cuda_graph,
+                                int64_t uniform_q_len, uint32_t head_dim_vo, uint32_t head_dim_qk,
+                                uint32_t kv_dtype_bytes) {
+  if (enable_cuda_graph) {
+    if (uniform_q_len > 0) {
+      // The caller guarantees that every request has exactly uniform_q_len rows
+      // in every plan replayed through this graph.
+      const uint64_t packed_uniform_len = uint64_t(uniform_q_len) * gqa_group_size;
+      return FA2DetermineCtaTileQ(packed_uniform_len, head_dim_vo, head_dim_qk, kv_dtype_bytes);
+    }
+    // The dummy data the graph is captured with fixes the maximum token count.
+    const uint64_t max_seq_len = total_num_rows - batch_size + 1;
+    const uint64_t max_qo_len = uint64_t(max_seq_len) * gqa_group_size;
+    return FA2DetermineCtaTileQ(max_qo_len, head_dim_vo, head_dim_qk, kv_dtype_bytes);
+  }
+  int64_t sum_packed_qo_len = 0;
+  for (uint32_t i = 0; i < batch_size; ++i) {
+    sum_packed_qo_len += int64_t(qo_indptr_h[i + 1] - qo_indptr_h[i]) * int64_t(gqa_group_size);
+  }
+  const int64_t avg_packed_qo_len = sum_packed_qo_len / batch_size;
+  return FA2DetermineCtaTileQ(avg_packed_qo_len, head_dim_vo, head_dim_qk, kv_dtype_bytes);
+}
+
 template <typename IdType>
 inline auto PrefillSplitQOKVIndptr(IdType* qo_indptr_h, IdType* kv_indptr_h,
                                    uint32_t total_num_rows, uint32_t batch_size,
@@ -577,7 +611,10 @@ inline auto PrefillSplitQOKVIndptr(IdType* qo_indptr_h, IdType* kv_indptr_h,
 
   // step 2: determine cta_tile_q, kv_chunk_size and total_num_tiles_q
   const uint32_t min_kv_chunk_size = std::max((128 / page_size), 1U);
-  uint32_t cta_tile_q;
+  // Single source of truth, shared with PrefillPlanImpl's occupancy budget.
+  const uint32_t cta_tile_q =
+      FA2PlanCtaTileQ(qo_indptr_h, total_num_rows, batch_size, gqa_group_size, enable_cuda_graph,
+                      uniform_q_len, head_dim, head_dim_qk, kv_dtype_bytes);
   uint32_t total_num_tiles_q;
   if (enable_cuda_graph) {
     if (uniform_q_len > 0) {
@@ -594,16 +631,8 @@ inline auto PrefillSplitQOKVIndptr(IdType* qo_indptr_h, IdType* kv_indptr_h,
           FLASHINFER_ERROR(err_msg.str());
         }
       }
-      cta_tile_q = FA2DetermineCtaTileQ(packed_uniform_len, head_dim, head_dim_qk, kv_dtype_bytes);
       total_num_tiles_q = batch_size * ceil_div(packed_uniform_len, cta_tile_q);
     } else {
-      // When CUDA graphs are enabled, the lengths of sequences determined by
-      // qo_indptr_h can vary. We assume that the dummy data based on which
-      // the CUDA graph is created fixes the maximum number of tokens.
-      const uint64_t max_seq_len = total_num_rows - batch_size + 1;
-      uint64_t max_qo_len = uint64_t(max_seq_len) * gqa_group_size;
-      cta_tile_q = FA2DetermineCtaTileQ(max_qo_len, head_dim, head_dim_qk, kv_dtype_bytes);
-
       // Find an upper bound for the number of tiles, derived from the total
       // number of rows and the batch size.  The sum of qo lengths rounded
       // up to cta_tile_q will not exceed this number derived from the total
@@ -611,13 +640,6 @@ inline auto PrefillSplitQOKVIndptr(IdType* qo_indptr_h, IdType* kv_indptr_h,
       total_num_tiles_q = ceil_div(total_num_rows * gqa_group_size, cta_tile_q) + batch_size - 1;
     }
   } else {
-    int64_t sum_packed_qo_len = 0;
-    for (uint32_t i = 0; i < batch_size; ++i) {
-      sum_packed_qo_len += packed_qo_len_arr[i];
-    }
-    const int64_t avg_packed_qo_len = sum_packed_qo_len / batch_size;
-    cta_tile_q = FA2DetermineCtaTileQ(avg_packed_qo_len, head_dim, head_dim_qk, kv_dtype_bytes);
-
     total_num_tiles_q = 0;
     for (uint32_t i = 0; i < batch_size; ++i) {
       total_num_tiles_q += ceil_div(packed_qo_len_arr[i], cta_tile_q);
@@ -771,8 +793,16 @@ inline cudaError_t PrefillPlanImpl(
     bool disable_split_kv,
     int64_t num_colocated_ctas,  // for POD attention, limit prefill
                                  // splits by #colocated decode CTAs
-    int64_t uniform_q_len, cudaStream_t stream, uint32_t kv_dtype_bytes = 2) {
+    int64_t uniform_q_len,
+    // Built by MakeFA2PrefillDTypeInfo<DTypeQ, DTypeKV>() so the three dtype facts
+    // cannot disagree with each other. Deliberately has no default: no constant is
+    // safe for kv_is_fp4 (see FA2PrefillDTypeInfo).
+    FA2PrefillDTypeInfo dtype_info, cudaStream_t stream) {
   (void)sizeof_dtype_o;
+  // Single source of truth for the KV element size: it used to arrive both here
+  // and as a separate defaulted kv_dtype_bytes parameter, which is two facts that
+  // can disagree. Read it off dtype_info instead.
+  const uint32_t kv_dtype_bytes = dtype_info.kv_dtype_bytes();
   if (num_qo_heads % num_kv_heads != 0) {
     std::ostringstream err_msg;
     err_msg << "num_qo_heads " << num_qo_heads << " should be divisible by num_kv_heads "
@@ -780,12 +810,60 @@ inline cudaError_t PrefillPlanImpl(
     FLASHINFER_ERROR(err_msg.str());
   }
 
-  // step 0: get the number of SMs
+  // step 0: get the number of SMs and how many CTAs of this kernel fit on one
   int num_sm = 0;
   int dev_id = 0;
+  int max_smem_per_sm = 0;
   FLASHINFER_CUDA_CALL(cudaGetDevice(&dev_id));
   FLASHINFER_CUDA_CALL(cudaDeviceGetAttribute(&num_sm, cudaDevAttrMultiProcessorCount, dev_id));
+  FLASHINFER_CUDA_CALL(cudaDeviceGetAttribute(&max_smem_per_sm,
+                                              cudaDevAttrMaxSharedMemoryPerMultiprocessor, dev_id));
+  // The run path already derives its CTAs-per-SM from this same attribute
+  // (num_ctas_per_sm in BatchPrefillWith{Ragged,Paged}KVCacheDispatched), and on
+  // shared-memory-tight parts it resolves to 1 while this planner used to assume
+  // 2 unconditionally -- budgeting the split-KV grid against twice the CTAs the
+  // machine can actually hold, which costs a second, mostly empty wave.
+  //
+  // Mirror that decision here. FA2PrefillCtaSmemLowerBound is a *lower* bound on
+  // the kernel's per-CTA shared memory (prefill.cuh static_asserts this for every
+  // instantiation), so num_blocks_per_sm drops to 1 only when the launcher will
+  // also pick 1; whenever the launcher fits two CTAs the historical value of 2 is
+  // preserved exactly. cta_tile_q comes from the same helper PrefillSplitQOKVIndptr
+  // uses below, so the tile the estimate is made against is the tile that runs.
+  //
+  // Two paths keep the historical value of 2 instead:
+  //
+  //  * fixed_split_size > 0 (and split-KV not disabled). There the caller supplies
+  //    kv_chunk_size directly and PrefillSplitQOKVIndptr skips the binary search,
+  //    so new_batch_size does not depend on this budget at all -- while under CUDA
+  //    graphs padded_batch_size = max(max_batch_size_if_split, total_num_tiles_q)
+  //    still does. Lowering the budget on that path cannot help (the split is
+  //    already pinned) and can push padded_batch_size below new_batch_size, which
+  //    trips the FLASHINFER_CHECK below and turns a working plan() into an error.
+  //  * num_colocated_ctas > 0, i.e. the POD prefill leg that actually has decode
+  //    CTAs colocated with it. That leg is planned here but *run* by a different
+  //    kernel (batch_pod.cu) with a different shared-memory footprint, and
+  //    halving this budget would also halve the point at which POD stops
+  //    splitting; out of scope for a correction aimed at the FA2 launchers.
+  //    This bypass is a subset of POD, not all of it: PODWithPagedKVCacheWrapper
+  //    (single prefill) and the decode leg of BatchPODWithPagedKVCacheWrapper
+  //    both pass 0 here, and the batch wrapper zeroes it again for the prefill
+  //    leg when the prefill is large (total_num_rows_p > 1536, flashinfer/pod.py).
+  //    Those plans take the correction like any other FA2 prefill plan.
+  const bool uses_fixed_split = (fixed_split_size > 0) && !disable_split_kv;
+  const bool apply_occupancy_correction = !uses_fixed_split && (num_colocated_ctas == 0);
   int num_blocks_per_sm = 2;
+  if (apply_occupancy_correction) {
+    const uint32_t cta_tile_q_hint =
+        FA2PlanCtaTileQ(qo_indptr_h, total_num_rows, batch_size, num_qo_heads / num_kv_heads,
+                        enable_cuda_graph, uniform_q_len, head_dim_vo, head_dim_qk, kv_dtype_bytes);
+    const uint32_t cta_smem_lower_bound =
+        FA2PrefillCtaSmemLowerBound(cta_tile_q_hint, head_dim_qk, head_dim_vo, dtype_info);
+    num_blocks_per_sm =
+        (static_cast<int64_t>(max_smem_per_sm) >= 2 * static_cast<int64_t>(cta_smem_lower_bound))
+            ? 2
+            : 1;
+  }
   int64_t available_ctas = static_cast<int64_t>(num_blocks_per_sm) * num_sm - num_colocated_ctas;
   int max_grid_size = static_cast<int>(std::max<int64_t>(0, available_ctas));
   uint32_t max_batch_size_if_split = max_grid_size / num_kv_heads;
@@ -904,8 +982,8 @@ inline cudaError_t PrefillPlan(void* float_buffer, size_t float_workspace_size_i
                                int32_t fixed_split_size, bool disable_split_kv,
                                int64_t num_colocated_ctas,  // for POD attention, limit prefill
                                                             // splits by #colocated decode CTAs
-                               int64_t uniform_q_len, cudaStream_t stream,
-                               uint32_t kv_dtype_bytes = 2) {
+                               int64_t uniform_q_len, FA2PrefillDTypeInfo dtype_info,
+                               cudaStream_t stream) {
   size_t used_float_workspace_size = 0;
   size_t used_int_workspace_size = 0;
   return PrefillPlanImpl<true>(used_float_workspace_size, used_int_workspace_size, float_buffer,
@@ -914,7 +992,7 @@ inline cudaError_t PrefillPlan(void* float_buffer, size_t float_workspace_size_i
                                total_num_rows, batch_size, num_qo_heads, num_kv_heads, head_dim_qk,
                                head_dim_vo, page_size, enable_cuda_graph, sizeof_dtype_o,
                                window_left, fixed_split_size, disable_split_kv, num_colocated_ctas,
-                               uniform_q_len, stream, kv_dtype_bytes);
+                               uniform_q_len, dtype_info, stream);
 }
 
 template <typename IdType>
@@ -923,8 +1001,8 @@ inline cudaError_t PrefillPlanWorkspaceSize(
     IdType* kv_indptr_h, uint32_t total_num_rows, uint32_t batch_size, uint32_t num_qo_heads,
     uint32_t num_kv_heads, uint32_t head_dim_qk, uint32_t head_dim_vo, uint32_t page_size,
     bool enable_cuda_graph, uint32_t sizeof_dtype_o, int32_t window_left, int32_t fixed_split_size,
-    bool disable_split_kv, int64_t num_colocated_ctas, int64_t uniform_q_len, cudaStream_t stream,
-    uint32_t kv_dtype_bytes = 2) {
+    bool disable_split_kv, int64_t num_colocated_ctas, int64_t uniform_q_len,
+    FA2PrefillDTypeInfo dtype_info, cudaStream_t stream) {
   PrefillPlanInfo plan_info;
   return PrefillPlanImpl<false>(float_workspace_size_in_bytes, int_workspace_size_in_bytes,
                                 /*float_buffer=*/nullptr, /*float_workspace_size_in_bytes=*/0,
@@ -933,7 +1011,7 @@ inline cudaError_t PrefillPlanWorkspaceSize(
                                 kv_indptr_h, total_num_rows, batch_size, num_qo_heads, num_kv_heads,
                                 head_dim_qk, head_dim_vo, page_size, enable_cuda_graph,
                                 sizeof_dtype_o, window_left, fixed_split_size, disable_split_kv,
-                                num_colocated_ctas, uniform_q_len, stream, kv_dtype_bytes);
+                                num_colocated_ctas, uniform_q_len, dtype_info, stream);
 }
 
 inline float cost_function(int qo_len, int kv_len) { return 2 * float(qo_len) + kv_len; }

--- a/tests/attention/test_prefill_occupancy_planner.py
+++ b/tests/attention/test_prefill_occupancy_planner.py
@@ -1,0 +1,583 @@
+"""
+Copyright (c) 2026 by FlashInfer team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+"""
+Regression tests for the FA2 prefill planner occupancy predicate.
+
+The planner (PrefillPlanImpl in scheduler.cuh) used to hardcode
+``int num_blocks_per_sm = 2;`` while the launchers
+(BatchPrefillWith{Ragged,Paged}KVCacheDispatched in prefill.cuh) derive the
+actual CTAs-per-SM from ``cudaDevAttrMaxSharedMemoryPerMultiprocessor`` and the
+kernel's shared-memory formula. On shared-memory-tight parts (e.g. GB10
+sm_121 with 102400 B/SM) the launcher yields 1, not 2, so the planner
+over-allocated the split-KV grid by 2x.
+
+This module pins the property the patch actually guarantees, in the direction
+it holds: **the planner drops to 1 only where the launcher does too, and
+whenever the launcher fits two CTAs the historical value of 2 is preserved
+exactly**.
+
+The converse is deliberately *not* claimed. Because
+``FA2PrefillCtaSmemLowerBound`` is a lower bound rather than an equality, there
+are configurations where the launcher takes 1 CTA/SM while the planner still
+says 2 -- the original over-allocation survives there, attenuated but present.
+The tests below therefore assert ``planner == 1 => launcher == 1``, never
+``launcher == 1 => planner == 1``.
+
+It also pins the B-1 regression (``fixed_split_size > 0`` under CUDA graphs must
+keep ``num_blocks_per_sm = 2`` to avoid a ``FLASHINFER_CHECK`` failure on
+``padded_batch_size``) and the POD narrowing (``num_colocated_ctas > 0`` keeps
+the historical value).
+
+All three GPU-gated tests pin ``backend="fa2"``. The wrapper defaults to
+``backend="auto"``, which may resolve to fa3/cudnn/trtllm-gen depending on the
+part and on which JIT artifacts happen to be present; those paths do not go
+through ``PrefillPlanImpl`` at all, so ``plan_info`` would not carry the FA2
+``padded_batch_size`` these tests assert on. Pinning keeps the assertions
+aimed at the planner this change actually touches.
+
+Design:
+  * The *predicate logic* tests are CPU-only (no GPU required). They mirror the
+    shared-memory arithmetic of both the planner and the launcher in Python and
+    assert the bound relationship holds over a representative config matrix.
+    This is the same model used by ``check_bound.py`` in the evidence pack,
+    collapsed to a single function pair and parametrised.
+  * The *behavioural* tests are GPU-gated (``pytest.mark.skipif(not
+    torch.cuda.is_available(), ...)``) and assert ``plan_info.padded_batch_size``
+    on a shape where the correction applies and on a shape where it does not,
+    plus the B-1 fixed-split + cuda_graph regression. Expectations are derived
+    from device properties, not hardcoded, so the test is self-checking on any
+    part (a part where the occupancy does not flip at the chosen head_dim skips
+    rather than fails).
+"""
+
+from dataclasses import dataclass
+
+import pytest
+import torch
+
+# ---------------------------------------------------------------------------
+# CPU-only predicate logic mirror. No GPU, no flashinfer import required.
+# ---------------------------------------------------------------------------
+#
+# These two functions reproduce the arithmetic of:
+#   * FA2PrefillCtaSmemLowerBound (planner side, prefill_occupancy.cuh)
+#   * kFixedSmem + kMinValidMmaKV * kKVSmemPerMmaKV (launcher side, prefill.cuh)
+# at the granularity that affects num_ctas_per_sm. They are intentionally a
+# second transcription -- the whole point of the in-tree static_assert is that
+# a same-author pair of models can hide a shared error; an independent
+# transcription in a different language catches what a C++-only check cannot.
+#
+# Reference: include/flashinfer/attention/prefill.cuh @ 0d25b183
+#            ragged: :4148-4216, paged: :4347-4415
+
+
+def _get_num_warps_q(cta_tile_q: int) -> int:
+    if cta_tile_q == 32:
+        return 1  # HEAD_DIM_VO >= 512
+    if cta_tile_q > 16:
+        return 4
+    return 1
+
+
+def _get_num_warps_kv(cta_tile_q: int) -> int:
+    return 4 // _get_num_warps_q(cta_tile_q)
+
+
+@dataclass(frozen=True)
+class DtypeInfo:
+    q_dtype_bytes: int
+    kv_dtype_bytes: int
+    kv_is_fp4: bool
+
+
+def planner_lower_bound(
+    cta_tile_q: int,
+    head_dim_qk: int,
+    head_dim_vo: int,
+    dtype_info: DtypeInfo,
+) -> int:
+    """Mirror of FA2PrefillCtaSmemLowerBound (the planner-side lower bound).
+
+    Drops kVOSplitDispatch (both per-tile and fixed), kSharedRopeFreqSmem, and
+    the NVFP4 SF staging term -- each is non-negative, so dropping them can only
+    lower the estimate. Forces kLargeHeadWarpSplit when vo>=512 & ctq==32 (the
+    ragged predicate, which gives the smaller NUM_WARPS_KV).
+    """
+    q_bytes = dtype_info.q_dtype_bytes
+    kv_bytes = dtype_info.kv_dtype_bytes
+    kv_is_fp4 = dtype_info.kv_is_fp4
+    num_mma_d_vo = head_dim_vo // 16
+
+    large_head_warp_split = (head_dim_vo >= 512) and (cta_tile_q == 32)
+    num_warps_q = 2 if large_head_warp_split else _get_num_warps_q(cta_tile_q)
+    num_warps_kv = 2 if large_head_warp_split else _get_num_warps_kv(cta_tile_q)
+
+    use_repack = (
+        kv_bytes == 1
+        and not kv_is_fp4
+        and head_dim_vo != 64
+        and head_dim_vo <= 256
+        and cta_tile_q > 16
+    )
+    kv_shared = (
+        not kv_is_fp4
+        and num_mma_d_vo > 16
+        and num_mma_d_vo % num_warps_kv == 0
+        and head_dim_qk == head_dim_vo
+        and (kv_bytes == 2 or cta_tile_q > 16)
+    )
+
+    if kv_shared:
+        kv_smem_per_mma_kv = head_dim_qk * 16 * num_warps_kv * kv_bytes
+    else:
+        kv_smem_per_mma_kv = (head_dim_qk + head_dim_vo) * 16 * num_warps_kv * kv_bytes
+    if use_repack:
+        kv_smem_per_mma_kv += (
+            max(head_dim_qk, head_dim_vo) * 16 * num_warps_kv * q_bytes
+        )
+    # NVFP4 SF term deliberately NOT counted (ragged/paged launchers do not).
+
+    fixed_smem = cta_tile_q * head_dim_qk * q_bytes
+    min_valid_mma_kv = (num_warps_q // 2) if (kv_bytes == 1 and num_warps_q > 2) else 1
+    return fixed_smem + min_valid_mma_kv * kv_smem_per_mma_kv
+
+
+def launcher_requirement(
+    cta_tile_q: int,
+    head_dim_qk: int,
+    head_dim_vo: int,
+    dtype_info: DtypeInfo,
+    *,
+    is_paged: bool,
+    use_softmax: bool,
+) -> int:
+    """Mirror of kFixedSmem + kMinValidMmaKV * kKVSmemPerMmaKV (launcher side).
+
+    This is the value the launcher actually charges. ``is_paged`` and
+    ``use_softmax`` select between the ragged and paged kLargeHeadWarpSplit /
+    kVOSplitDispatch predicates.
+    """
+    q_bytes = dtype_info.q_dtype_bytes
+    kv_bytes = dtype_info.kv_dtype_bytes
+    kv_is_fp4 = dtype_info.kv_is_fp4
+    num_mma_d_vo = head_dim_vo // 16
+
+    # kLargeHeadWarpSplit / kBf16VOSplit -- launcher-specific.
+    # ragged: (kv_bytes<=2 or fp4) and vo>=512 and ctq==32
+    # paged:  (kv_bytes==2 or fp4) and vo>=512 and ctq==32
+    large_head_warp_split_ragged = (
+        (kv_bytes <= 2 or kv_is_fp4) and head_dim_vo >= 512 and cta_tile_q == 32
+    )
+    large_head_warp_split_paged = (
+        (kv_bytes == 2 or kv_is_fp4) and head_dim_vo >= 512 and cta_tile_q == 32
+    )
+    large_head_warp_split = (
+        large_head_warp_split_ragged if not is_paged else large_head_warp_split_paged
+    )
+    num_warps_q = 2 if large_head_warp_split else _get_num_warps_q(cta_tile_q)
+    num_warps_kv = 2 if large_head_warp_split else _get_num_warps_kv(cta_tile_q)
+
+    use_repack = (
+        kv_bytes == 1
+        and not kv_is_fp4
+        and head_dim_vo != 64
+        and head_dim_vo <= 256
+        and cta_tile_q > 16
+    )
+    kv_shared = (
+        not kv_is_fp4
+        and num_mma_d_vo > 16
+        and num_mma_d_vo % num_warps_kv == 0
+        and head_dim_qk == head_dim_vo
+        and (kv_bytes == 2 or cta_tile_q > 16)
+    )
+
+    if kv_shared:
+        kv_smem_per_mma_kv = head_dim_qk * 16 * num_warps_kv * kv_bytes
+    else:
+        kv_smem_per_mma_kv = (head_dim_qk + head_dim_vo) * 16 * num_warps_kv * kv_bytes
+    if use_repack:
+        kv_smem_per_mma_kv += (
+            max(head_dim_qk, head_dim_vo) * 16 * num_warps_kv * q_bytes
+        )
+
+    # kVOSplitDispatch (launcher-specific).
+    vo_split_dispatch_paged = num_mma_d_vo > 16 and num_mma_d_vo % num_warps_kv == 0
+    vo_split_dispatch_ragged = vo_split_dispatch_paged and (
+        (kv_bytes == 2 or kv_is_fp4) and use_softmax
+    )
+    vo_split_dispatch = (
+        vo_split_dispatch_ragged if not is_paged else vo_split_dispatch_paged
+    )
+    if vo_split_dispatch:
+        kv_smem_per_mma_kv += num_warps_kv * cta_tile_q * 8
+        fixed_smem_extra = num_warps_kv * cta_tile_q * 8 + 2048
+    else:
+        fixed_smem_extra = 0
+
+    # kSharedRopeFreqSmem -- non-negative, planner drops it.
+    # (omitted from the planner bound; included here for completeness.)
+    # We test with POS_ENCODING_MODE == NONE in the parametrisation below, so it
+    # is 0; the bound relationship holds either way because the term is >= 0.
+
+    fixed_smem = cta_tile_q * head_dim_qk * q_bytes + fixed_smem_extra
+    min_valid_mma_kv = (num_warps_q // 2) if (kv_bytes == 1 and num_warps_q > 2) else 1
+    return fixed_smem + min_valid_mma_kv * kv_smem_per_mma_kv
+
+
+# ---------------------------------------------------------------------------
+# CPU-only: the core invariant -- planner bound <= launcher requirement.
+# ---------------------------------------------------------------------------
+
+# Representative config matrix. Not exhaustive (the C++ static_assert is
+# exhaustive over instantiations); this is the independent second check.
+_HEAD_DIMS = [
+    (64, 64),
+    (128, 128),
+    (192, 128),
+    (192, 192),
+    (256, 256),
+    (512, 512),
+    (576, 512),
+]
+_CTA_TILE_QS = [16, 32, 64, 128]
+_DTYPES = [
+    DtypeInfo(2, 2, False),  # bf16/bf16
+    DtypeInfo(2, 1, False),  # bf16 Q, fp8 KV
+    DtypeInfo(2, 1, True),  # bf16 Q, nvfp4 KV
+]
+
+
+def _config_ids():
+    ids = []
+    for hd_qk, hd_vo in _HEAD_DIMS:
+        for ctq in _CTA_TILE_QS:
+            for di in _DTYPES:
+                for is_paged in (False, True):
+                    for use_softmax in (False, True):
+                        ids.append(
+                            f"hd{hd_qk}-{hd_vo}_ctq{ctq}"
+                            f"_q{di.q_dtype_bytes}kv{di.kv_dtype_bytes}"
+                            f"{'fp4' if di.kv_is_fp4 else ''}"
+                            f"{'paged' if is_paged else 'ragged'}"
+                            f"{'sm' if use_softmax else 'nosm'}"
+                        )
+    return ids
+
+
+_CONFIGS = [
+    (hd_qk, hd_vo, ctq, di, is_paged, use_softmax)
+    for (hd_qk, hd_vo) in _HEAD_DIMS
+    for ctq in _CTA_TILE_QS
+    for di in _DTYPES
+    for is_paged in (False, True)
+    for use_softmax in (False, True)
+]
+
+
+@pytest.mark.parametrize(
+    "hd_qk,hd_vo,ctq,di,is_paged,use_softmax", _CONFIGS, ids=_config_ids()
+)
+def test_planner_bound_le_launcher_requirement(
+    hd_qk, hd_vo, ctq, di, is_paged, use_softmax
+):
+    """planner_lower_bound <= launcher_requirement for every config.
+
+    This is the load-bearing property: if the planner's smem estimate ever
+    exceeds the launcher's, num_blocks_per_sm would drop to 1 on a part where
+    the launcher actually fits two CTAs -- a performance regression. The C++
+    static_assert pins this per-instantiation; this test is the independent
+    second transcription.
+    """
+    bound = planner_lower_bound(ctq, hd_qk, hd_vo, di)
+    req = launcher_requirement(
+        ctq, hd_qk, hd_vo, di, is_paged=is_paged, use_softmax=use_softmax
+    )
+    assert bound <= req, (
+        f"planner bound {bound} > launcher requirement {req} for "
+        f"hd={hd_qk}/{hd_vo} ctq={ctq} di={di} "
+        f"is_paged={is_paged} use_softmax={use_softmax}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# CPU-only: the corollary -- num_blocks_per_sm == 1 implies launcher == 1.
+# ---------------------------------------------------------------------------
+
+# Representative SMEM budgets. GB10 = 102400, H200 = 233472, plus a synthetic
+# large value to confirm the 2-CTA path.
+_SMEM_BUDGETS = [102400, 233472, 512 * 1024]
+
+
+@pytest.mark.parametrize("smem_budget", _SMEM_BUDGETS, ids=lambda v: f"smem{v}")
+@pytest.mark.parametrize(
+    "hd_qk,hd_vo,ctq,di,is_paged,use_softmax", _CONFIGS, ids=_config_ids()
+)
+def test_planner_picks_1_implies_launcher_picks_1(
+    smem_budget, hd_qk, hd_vo, ctq, di, is_paged, use_softmax
+):
+    """If planner says 1 CTA/SM, the launcher also says 1.
+
+    Contrapositive of the property that matters: whenever the launcher fits
+    two CTAs, the planner keeps 2 (byte-identical to today's plan).
+    """
+    bound = planner_lower_bound(ctq, hd_qk, hd_vo, di)
+    req = launcher_requirement(
+        ctq, hd_qk, hd_vo, di, is_paged=is_paged, use_softmax=use_softmax
+    )
+    planner_nbps = 2 if (smem_budget >= 2 * bound) else 1
+    launcher_nbps = 2 if (smem_budget >= 2 * req) else 1
+    if planner_nbps == 1:
+        assert launcher_nbps == 1, (
+            f"planner picked 1 ({bound=}, budget={smem_budget}) but launcher "
+            f"picked {launcher_nbps} ({req=}) -- planner over-demoted"
+        )
+
+
+# ---------------------------------------------------------------------------
+# GPU-gated behavioural tests. Skip cleanly when no GPU or when the
+# occupancy does not flip at the chosen head_dim on this part.
+# ---------------------------------------------------------------------------
+
+_GPU_AVAILABLE = torch.cuda.is_available()
+
+
+def _device_props():
+    if not _GPU_AVAILABLE:
+        return None
+    p = torch.cuda.get_device_properties(0)
+    return p
+
+
+def _ceil_div(a, b):
+    return -(-a // b)
+
+
+def _determine_cta_tile_q(avg_packed_qo_len, hd_vo, hd_qk, kv_bytes):
+    """include/flashinfer/utils.cuh:408-486 (Ampere+ branch only)."""
+    qk = hd_qk or hd_vo
+    if hd_vo >= 512:
+        return 16 if avg_packed_qo_len <= 32 else 32
+    if qk >= 512:
+        return 16
+    if avg_packed_qo_len > 64 and hd_vo < 256:
+        return 128
+    if avg_packed_qo_len > 16:
+        return 64
+    return 16
+
+
+def _predict_padded_bs(nbps, num_sm, D, B, QL, KL_pages, H, HKV, PS, graph, fixed):
+    """scheduler.cuh plan arithmetic, parameterised by num_blocks_per_sm."""
+    gqa = H // HKV
+    packed = [QL * gqa] * B
+    kvlens = [KL_pages] * B
+    avg = sum(packed) // B
+    ctq = _determine_cta_tile_q(avg, D, D, 2)
+    min_chunk = max(128 // PS, 1)
+    budget = max(0, nbps * num_sm) // HKV
+
+    if fixed is not None and fixed > 0:
+        chunk = fixed
+    else:
+        lo, hi = min_chunk, max(1, max(kvlens))
+        while lo < hi:
+            mid = (lo + hi) // 2
+            nbs = sum(
+                _ceil_div(p, ctq) * _ceil_div(max(k, 1), mid)
+                for p, k in zip(packed, kvlens, strict=False)
+            )
+            if nbs > budget:
+                lo = mid + 1
+            else:
+                hi = mid
+        chunk = lo
+
+    new_bs = 0
+    for p, k in zip(packed, kvlens, strict=False):
+        nchunks = _ceil_div(max(k, 1), chunk)
+        new_bs += _ceil_div(p, ctq) * nchunks
+
+    if graph:
+        total_tiles = _ceil_div(B * QL * gqa, ctq) + B - 1
+        padded = max(budget, total_tiles)
+    else:
+        padded = new_bs
+    return padded
+
+
+@pytest.mark.skipif(not _GPU_AVAILABLE, reason="requires CUDA")
+def test_planner_padded_batch_size_matches_predicate_on_affected_shape():
+    """On a part where the occupancy flips at hd256, the patched planner's
+    padded_batch_size must equal the nbps=1 model, not the nbps=2 model.
+
+    Skips (not fails) on parts where the occupancy does not flip at hd256.
+    """
+    import flashinfer
+
+    p = _device_props()
+    num_sm = p.multi_processor_count
+    smem_per_sm = p.shared_memory_per_multiprocessor
+
+    D, B, QL, KL, H, HKV, PS = 256, 1, 1, 12288, 16, 1, 16
+    KL_pages = KL // PS
+
+    di = DtypeInfo(2, 2, False)
+    ctq = _determine_cta_tile_q(QL * (H // HKV), D, D, 2)
+    bound = planner_lower_bound(ctq, D, D, di)
+    # If the part fits 2 CTAs at this shape, the correction is inert here.
+    if smem_per_sm >= 2 * bound:
+        pytest.skip(
+            f"part fits 2 CTAs/SM at hd256 ctq=16 (smem={smem_per_sm}, "
+            f"bound={bound}); correction does not apply, nothing to assert"
+        )
+
+    ws = torch.empty(256 * 1024 * 1024, dtype=torch.uint8, device="cuda")
+    w = flashinfer.BatchPrefillWithPagedKVCacheWrapper(ws, "NHD", backend="fa2")
+    qo = torch.tensor([0, QL], device="cuda", dtype=torch.int32)
+    kvp = torch.tensor([0, KL_pages], device="cuda", dtype=torch.int32)
+    idx = torch.arange(0, KL_pages, device="cuda", dtype=torch.int32)
+    lpl = torch.full((B,), PS, device="cuda", dtype=torch.int32)
+    w.plan(
+        qo,
+        kvp,
+        idx,
+        lpl,
+        H,
+        HKV,
+        D,
+        PS,
+        causal=True,
+        q_data_type=torch.bfloat16,
+        kv_data_type=torch.bfloat16,
+    )
+    observed = int(w._plan_info[0])
+    expected_patched = _predict_padded_bs(
+        1, num_sm, D, B, QL, KL_pages, H, HKV, PS, False, None
+    )
+    expected_baseline = _predict_padded_bs(
+        2, num_sm, D, B, QL, KL_pages, H, HKV, PS, False, None
+    )
+    assert expected_patched != expected_baseline, (
+        "discriminator dead: nbps=1 and nbps=2 predict the same padded_bs "
+        f"({expected_patched}); test cannot tell builds apart on this part"
+    )
+    assert observed == expected_patched, (
+        f"observed padded_batch_size={observed} but patched model predicts "
+        f"{expected_patched} (baseline would be {expected_baseline})"
+    )
+
+
+@pytest.mark.skipif(not _GPU_AVAILABLE, reason="requires CUDA")
+def test_planner_noop_on_mainstream_shape():
+    """On hd128 the bound is small enough that every modern part fits 2 CTAs,
+    so the patched planner must produce the same plan as the baseline
+    (nbps=2). Asserts byte-identical padded_batch_size against the nbps=2
+    model."""
+    import flashinfer
+
+    p = _device_props()
+    num_sm = p.multi_processor_count
+
+    D, B, QL, KL, H, HKV, PS = 128, 8, 16, 8192, 8, 8, 16
+    KL_pages = KL // PS
+
+    di = DtypeInfo(2, 2, False)
+    ctq = _determine_cta_tile_q(QL * (H // HKV), D, D, 2)
+    bound = planner_lower_bound(ctq, D, D, di)
+    # This test asserts the no-op; if the part somehow flips here, the
+    # affected-shape test above is the right one.
+    if p.shared_memory_per_multiprocessor < 2 * bound:
+        pytest.skip("part flips at hd128; covered by the affected-shape test")
+
+    ws = torch.empty(256 * 1024 * 1024, dtype=torch.uint8, device="cuda")
+    w = flashinfer.BatchPrefillWithPagedKVCacheWrapper(ws, "NHD", backend="fa2")
+    qo = torch.arange(0, B + 1, device="cuda", dtype=torch.int32) * QL
+    kvp = torch.arange(0, B + 1, device="cuda", dtype=torch.int32) * KL_pages
+    idx = torch.arange(0, B * KL_pages, device="cuda", dtype=torch.int32)
+    lpl = torch.full((B,), PS, device="cuda", dtype=torch.int32)
+    w.plan(
+        qo,
+        kvp,
+        idx,
+        lpl,
+        H,
+        HKV,
+        D,
+        PS,
+        causal=True,
+        q_data_type=torch.bfloat16,
+        kv_data_type=torch.bfloat16,
+    )
+    observed = int(w._plan_info[0])
+    expected = _predict_padded_bs(
+        2, num_sm, D, B, QL, KL_pages, H, HKV, PS, False, None
+    )
+    assert observed == expected, (
+        f"hd128 no-op: observed padded_batch_size={observed}, expected {expected} "
+        f"(nbps=2 model; the patch must not change hd128)"
+    )
+
+
+@pytest.mark.skipif(not _GPU_AVAILABLE, reason="requires CUDA")
+def test_b1_fixed_split_size_under_cuda_graph_does_not_raise():
+    """R1 finding B-1: with fixed_split_size > 0 and use_cuda_graph=True,
+    lowering num_blocks_per_sm could push padded_batch_size below
+    new_batch_size and trip FLASHINFER_CHECK. The patch keeps nbps=2 on
+    that path; this test asserts plan() does not raise.
+
+    Runs on any part (the fixed-split path is part-independent: nbps stays 2
+    by construction, so the check is structural, not occupancy-dependent)."""
+    import flashinfer
+
+    D, B, QL, KL, H, HKV, PS = 192, 4, 4, 256, 8, 8, 16
+
+    ws = torch.empty(256 * 1024 * 1024, dtype=torch.uint8, device="cuda")
+    qo = torch.arange(0, B + 1, device="cuda", dtype=torch.int32) * QL
+    kvp = torch.arange(0, B + 1, device="cuda", dtype=torch.int32) * (KL // PS)
+    idx = torch.arange(0, B * (KL // PS), device="cuda", dtype=torch.int32)
+    lpl = torch.full((B,), PS, device="cuda", dtype=torch.int32)
+    bufs = [t.clone() for t in (qo, kvp, idx, lpl)]
+    w = flashinfer.BatchPrefillWithPagedKVCacheWrapper(
+        ws,
+        "NHD",
+        backend="fa2",
+        use_cuda_graph=True,
+        qo_indptr_buf=bufs[0],
+        paged_kv_indptr_buf=bufs[1],
+        paged_kv_indices_buf=bufs[2],
+        paged_kv_last_page_len_buf=bufs[3],
+    )
+    # Must not raise. On the pre-fix patch (v2) this raised RuntimeError
+    # because padded_batch_size was halved below new_batch_size.
+    w.plan(
+        bufs[0],
+        bufs[1],
+        bufs[2],
+        bufs[3],
+        H,
+        HKV,
+        D,
+        PS,
+        causal=True,
+        q_data_type=torch.bfloat16,
+        kv_data_type=torch.bfloat16,
+        fixed_split_size=8,
+    )
+    # If we got here, the B-1 narrowing held. Sanity-check the plan produced
+    # a non-zero padded_batch_size.
+    assert int(w._plan_info[0]) > 0


### PR DESCRIPTION

## 📌 Description

The FA2 prefill planner hardcodes `int num_blocks_per_sm = 2;` (`scheduler.cuh:788`), while the
launchers derive the actual CTAs/SM from `cudaDevAttrMaxSharedMemoryPerMultiprocessor` and the
kernel's shared-memory formula. Where the launcher resolves to 1, the planner budgets the split-KV
grid against twice the CTAs the machine can hold: where the split-KV search binds (short-q, long KV,
off the 128-token min-chunk floor) that roughly halves the KV chunk and up to doubles
`padded_batch_size`, buying a second, mostly empty wave; elsewhere it is inert. This is planner-side
— the launcher itself is correct, unlike the launcher-side clamps in #3526 and #3863.

**Change.** Replace the literal with a bounded reproduction of the launcher's predicate: the same
`max_smem_per_sm >= 2 x per-CTA-smem` decision, from the same attribute, over a proven lower bound on
the shared-memory formula (`static_assert`-pinned `<=` the launcher's value per instantiation), in a
new header `prefill_occupancy.cuh`. Being a lower bound, `num_blocks_per_sm` drops to 1 only where the
launcher does; wherever the launcher fits two CTAs the historical `2` is preserved exactly.
`cta_tile_q` moves into `FA2PlanCtaTileQ` so the budget is sized against the tile that runs. Not the
runtime `cudaOccupancyMaxActiveBlocksPerMultiprocessor` query: this repo already treats that call as
unreliable — it is commented out at `scheduler.cuh:302-306` with a `// fixme` saying it yields 0 at
times, and `pod.cuh:351` works around the same behaviour.

**Three behaviour changes:**

1. `fixed_split_size > 0` keeps `num_blocks_per_sm = 2`: the caller pins `kv_chunk_size` so the budget
   cannot help, but under CUDA graphs lowering it can push `padded_batch_size` below `new_batch_size`
   and turn a working `plan()` into an error.
2. `num_colocated_ctas > 0` keeps `2` (that POD prefill leg runs in `batch_pod.cu`, different
   footprint). A subset of POD only: `PODWithPagedKVCacheWrapper` and the decode leg of
   `BatchPODWithPagedKVCacheWrapper` pass `0`, as does the batch wrapper's prefill leg once
   `total_num_rows_p > 1536`; those take the correction.
3. `FA2PlanCtaTileQ` extraction changes no behaviour.

Line references are against `main` @ `750dbfd5`.

## 🔍 Related Issues

None tracks the planner literal. Related but launcher-side, not planner-side: #3526, #3863 (merged
shared-memory clamps); #3620 and its proposed fix #3621 (open).

## 📊 Measurements

**GB10 (sm_121, 102400 B/SM)** — paged, bf16, `head_dim` 256/256, 16 QO / 1 KV head, `batch=1`,
`qo_len=1`, `page_size=16`, non-causal; median µs, 50 iters / 10 warmup:

| kv_len | before | after | speedup |
|---:|---:|---:|---:|
| 8192 | 35.04 | 28.90 | 1.21x |
| 16384 | 40.99 | 33.95 | 1.21x |
| 24576 | 63.42 | 46.43 | 1.37x |

Controls 4096 / 6144 are within ±1% of 1.00x with bit-identical output (max abs diff 0.0); across the
changed rows max abs diff is ≤ 4.9e-4 (bf16). Beyond 24576 the advantage narrows — 1.03–1.05x at
32768–131072. Mainstream `head_dim` 64 and 128 are outside the affected set: at 128/128 this is a
byte-identical no-op.

**H200 (sm_90, 233472 B/SM)**, `head_dim_qk`/`head_dim_vo` = 576/512, `CTA_TILE_Q=16` — a large part
still resolves to 1 CTA/SM here (162304 B per CTA; `2 x 162304 = 324608 > 233472`). Two arms from one
commit, separate process and JIT workspace each, 8 kv_lens per case:

| case | `padded_batch_size` before → after | speedup (median) |
|---|---|---|
| ragged, bf16 + fp16, kv_len ≥ 24576 | 192–264 → 132 | 1.11–1.18x |
| paged, bf16 + fp16, kv_len ≥ 24576 | 192–256 → 128/131 | 1.11–1.16x |
| paged 128/128 bf16 (control) | 64–256, unchanged | plan-level no-op |

`padded_batch_size` saturates at `2 x num_sm = 264` before and `1 x num_sm = 132` after, read off the
planner's output. Below the crossover (kv_len ≤ 16384) plans are byte-identical and outputs
bit-identical, as is the entire 128/128 control. Across the 24 changed rows max abs diff is ≤ 2.4e-4
(bf16) / ≤ 3.1e-5 (fp16) — 1–2 ULP at the measured scale, from the changed split-KV reduction order.
Arms ran sequentially, baseline first, and the identical-plan control still reads 0.93–1.00x, so the
drift penalises the patched arm: these figures are understated.

**Repro**: build with and without the patch, give each arm its own `FLASHINFER_WORKSPACE_BASE` (a
shared JIT cache reuses the other arm's binary), time the paged/ragged prefill wrappers at the shapes
above. The plan-level effect needs no timing — call `plan()` and read `padded_batch_size`. Glad to
port this to `benchmarks/flashinfer_benchmark.py` if preferred.

## 🚀 Pull Request Checklist

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> `pre-commit run --all-files` is clean on this branch (13 hooks passed, 1 skipped — no symlinks to
> check). `clang-format` did flag one line in `scheduler.cuh`; it is fixed here, and the only change
> was re-wrapping the arguments of a `cudaDeviceGetAttribute` call.

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

`tests/attention/test_prefill_occupancy_planner.py` is new: 1344 CPU-only cases pinning
`planner_bound <= launcher_requirement` and its corollary (planner picks 1 implies launcher picks 1)
across head dims, tiles, dtypes, ragged/paged and three shared-memory budgets; plus three GPU-gated
cases asserting `padded_batch_size` against a device-derived model on an affected shape, a no-op at
`head_dim 128`, and the `fixed_split_size` + `use_cuda_graph` regression from item 1. All pass on GB10
(1344 CPU in 0.6 s, 3 GPU in 60 s). A separate 155,280-configuration sweep found 0 violations.

The CPU cases re-derive the arithmetic in Python on purpose: the `static_assert` is exhaustive but
shares an author with the helper it checks, so a shared misreading would satisfy it and this would not
— happy to trim it to the flipping configurations, split it out, or drop it. The GPU-gated cases
`skip` where the occupancy does not flip, so they pin correctness on parts that flip rather than
guarantee coverage on every runner.

`tests/attention/test_batch_prefill_kernels.py` was run in full against this revision on GB10:
**8790 passed, 1320 skipped, 5760 xfailed, 1 failed in 18m30s**. The single failure is
`test_single_prefill_torch_compile_cuda_graph`, which is **pre-existing and unrelated**: it shells
out to a `torch.compile` subprocess that dies in Triton's AOT linker on this aarch64 box, it
reproduces identically on an unpatched tree, and it exercises *single* prefill — a path with no
planner, so `PrefillPlanImpl` is never reached.

## Reviewer Notes

AI tools assisted with analysis and drafting; I reviewed the change and understand the
implementation, tests, measurements, and rationale.

Limitations:

1. It is a lower bound, not an equality: where loose, the launcher may take 1 while the planner says
   2, so the over-allocation survives there attenuated. It is never made worse.
2. The known loose region is `head_dim_vo >= 512` paged FP8/NVFP4 (~2x); not corrected.
3. A change lowering the launcher's real per-CTA requirement below this bound surfaces as a build
   failure inside a JIT compile.
4. If #3621 lands the bound stays sound by construction (a larger true requirement keeps it `<=`), but
   its constants should be re-verified against that PR's sampled value.
5. The POD narrowing's blast radius is argued from the `flashinfer/pod.py` call sites, not a
   wall-clock A/B on a POD workload.
6. On H200 the rope and `use_fp16_qk_reduction` axes are argued from the shared-memory expression
   (`kSharedRopeFreqSmem` needs `HEAD_DIM_QK == HEAD_DIM_VO`, which 576/512 fails) rather than
   measured; 576/512 was run at `batch=1`, `qo_len=1`, `num_kv_heads=1` only.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved attention prefill planning to account for query and key/value data types, including FP4 formats.
  * Improved shared-memory occupancy estimates for more reliable kernel launch planning.
  * Prevented mismatches between planner and launcher resource requirements.
  * Preserved expected behavior for standard shapes, fixed split sizes, and CUDA Graph usage.

* **Tests**
  * Added coverage for occupancy planning across representative data types, shapes, and launch configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->