### PR TITLE
fix(gdn): accept naturally aligned parameter views in BF16 decode

### DIFF
--- a/flashinfer/gdn_kernels/gdn_decode_bf16_state.py
+++ b/flashinfer/gdn_kernels/gdn_decode_bf16_state.py
@@ -3204,8 +3204,13 @@ def gated_delta_rule_mtp_wide_vec(
         v_ = _mark_batch_dynamic(v)
         a_ = _mark_batch_dynamic(a)
         b_ = _mark_batch_dynamic(b)
-        A_log_ = from_dlpack(A_log, assumed_align=32, enable_tvm_ffi=True)
-        dt_bias_ = from_dlpack(dt_bias, assumed_align=32, enable_tvm_ffi=True)
+        # These vectors are loaded elementwise, so require only their scalar
+        # alignment. Parameter slices with a nonzero storage_offset are valid
+        # inputs but are not necessarily aligned to a 32-byte boundary.
+        A_log_ = from_dlpack(A_log, assumed_align=4, enable_tvm_ffi=True)
+        dt_bias_ = from_dlpack(
+            dt_bias, assumed_align=dt_bias.element_size(), enable_tvm_ffi=True
+        )
         o_ = _mark_batch_dynamic(output if output is not None else _placeholder_output)
         h0_idx_ = _mark_index_dynamic(
             initial_state_indices
@@ -3483,8 +3488,13 @@ def gated_delta_rule_t1_wide_vec(
         v_ = _mark_batch_dynamic(v)
         a_ = _mark_batch_dynamic(a)
         b_ = _mark_batch_dynamic(b)
-        A_log_ = from_dlpack(A_log, assumed_align=32, enable_tvm_ffi=True)
-        dt_bias_ = from_dlpack(dt_bias, assumed_align=32, enable_tvm_ffi=True)
+        # These vectors are loaded elementwise, so require only their scalar
+        # alignment. Parameter slices with a nonzero storage_offset are valid
+        # inputs but are not necessarily aligned to a 32-byte boundary.
+        A_log_ = from_dlpack(A_log, assumed_align=4, enable_tvm_ffi=True)
+        dt_bias_ = from_dlpack(
+            dt_bias, assumed_align=dt_bias.element_size(), enable_tvm_ffi=True
+        )
         o_ = _mark_batch_dynamic(output if output is not None else _placeholder_output)
         h0_idx_ = _mark_index_dynamic(
             initial_state_indices
@@ -3864,8 +3874,13 @@ def gated_delta_rule_mtp(
         v_ = _mark_batch_dynamic(v)
         a_ = _mark_batch_dynamic(a)
         b_ = _mark_batch_dynamic(b)
-        A_log_ = from_dlpack(A_log, assumed_align=32, enable_tvm_ffi=True)
-        dt_bias_ = from_dlpack(dt_bias, assumed_align=32, enable_tvm_ffi=True)
+        # These vectors are loaded elementwise, so require only their scalar
+        # alignment. Parameter slices with a nonzero storage_offset are valid
+        # inputs but are not necessarily aligned to a 32-byte boundary.
+        A_log_ = from_dlpack(A_log, assumed_align=4, enable_tvm_ffi=True)
+        dt_bias_ = from_dlpack(
+            dt_bias, assumed_align=dt_bias.element_size(), enable_tvm_ffi=True
+        )
         o_ = _mark_batch_dynamic(output if output is not None else _placeholder_output)
         h0_idx_ = _mark_index_dynamic(
             initial_state_indices

--- a/tests/gdn/test_decode_delta_rule.py
+++ b/tests/gdn/test_decode_delta_rule.py
@@ -4171,6 +4171,53 @@ def _packed_qkv_params(batch_size, seq_len, num_v_heads, device):
     return a, b, A_log, dt_bias
 
 
+def test_decode_pretranspose_accepts_naturally_aligned_parameter_views():
+    """BF16 decode must accept contiguous parameter slices with scalar alignment."""
+    _skip_if_not_sm90_or_later()
+    torch.manual_seed(0)
+    B, H, HV, D = 1, 4, 24, 128
+    dev = torch.device("cuda")
+
+    q = torch.randn(B, 1, H, D, dtype=torch.bfloat16, device=dev)
+    k = torch.randn_like(q)
+    v = torch.randn(B, 1, HV, D, dtype=torch.bfloat16, device=dev)
+    a = torch.randn(B, 1, HV, dtype=torch.bfloat16, device=dev)
+    b = torch.randn_like(a)
+    state = torch.zeros(2, HV, D, D, dtype=torch.bfloat16, device=dev)
+    indices = torch.ones(B, dtype=torch.int32, device=dev)
+
+    # Slicing at offset one preserves contiguity but guarantees only the
+    # scalar dtype alignment, not a 32-byte allocation alignment.
+    A_log = torch.randn(HV + 1, dtype=torch.float32, device=dev)[1:]
+    dt_bias = torch.randn(HV + 1, dtype=torch.bfloat16, device=dev)[1:]
+    assert A_log.is_contiguous() and A_log.data_ptr() % 32 == 4
+    assert dt_bias.is_contiguous() and dt_bias.data_ptr() % 32 == 2
+
+    kwargs = dict(
+        q=q,
+        k=k,
+        v=v,
+        state=None,
+        a=a,
+        b=b,
+        initial_state_indices=indices,
+    )
+    out_view, state_view = gated_delta_rule_decode_pretranspose(
+        A_log=A_log,
+        dt_bias=dt_bias,
+        initial_state=state.clone(),
+        **kwargs,
+    )
+    out_aligned, state_aligned = gated_delta_rule_decode_pretranspose(
+        A_log=A_log.clone(),
+        dt_bias=dt_bias.clone(),
+        initial_state=state.clone(),
+        **kwargs,
+    )
+    torch.testing.assert_close(out_view, out_aligned, atol=0, rtol=0)
+    torch.testing.assert_close(state_view, state_aligned, atol=0, rtol=0)
+
+
 @pytest.mark.parametrize("state_dtype", ["bfloat16", "float32"])
 @pytest.mark.parametrize("batch_size", [2, 8, 64])
 def test_decode_pretranspose_packed_qkv(batch_size: int, state_dtype: str):


### PR DESCRIPTION
## 📌 Description

Allow the BF16-state GDN decode kernels to accept contiguous `A_log` and
`dt_bias` parameter views that have scalar dtype alignment but not 32-byte
allocation alignment.

These vectors are loaded elementwise. Their three CuTe DLPack descriptors now
declare the alignment actually required by the loads: 4 bytes for float32
`A_log` and `dt_bias.element_size()` for `dt_bias`. No kernel implementation,
dispatch policy, precision, or CUDA graph behavior changes.

The regression test constructs views at storage offset one, verifies their
addresses are not 32-byte aligned, and compares their output and updated state
against allocation-aligned clones bit-for-bit.

## 🔍 Related Issues

Closes #4582

## 🚀 Pull Request Checklist

### ✅ Pre-commit Checks

- [ ] I have installed `pre-commit` and run `pre-commit run --all-files`.

## 🧪 Tests

- [x] Added BF16 GDN decode coverage for naturally aligned parameter views.
- [x] Existing standalone B30Z reproducer passes with bit-identical output.
- [ ] Upstream GPU test run pending.

## Reviewer Notes

Validated on NVIDIA B30Z (SM103), CUDA 13.0, PyTorch 2.11.0+cu130. Before the
change, CuTe rejects the float32 `A_log` view (`ptr % 32 == 4`) before kernel
launch. After the change, the native FlashInfer kernel runs without parameter
copies or backend substitution.
