### PR TITLE
Add explicit NCCL local allreduce fallback

### DIFF
--- a/flashinfer/comm/__init__.py
+++ b/flashinfer/comm/__init__.py
@@ -78,6 +78,9 @@ from .trtllm_mnnvl_ar import (
     MNNVLAllReduceFusionWorkspace as MNNVLAllReduceFusionWorkspace,
 )
 from .allreduce import TRTLLMAllReduceFusionWorkspace as TRTLLMAllReduceFusionWorkspace
+from .allreduce import (
+    NCCLLocalAllReduceFusionWorkspace as NCCLLocalAllReduceFusionWorkspace,
+)
 from .allreduce import allreduce_fusion as allreduce_fusion
 from .allreduce import (
     create_allreduce_fusion_workspace as create_allreduce_fusion_workspace,

--- a/flashinfer/comm/allreduce.py
+++ b/flashinfer/comm/allreduce.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2025 by FlashInfer team.
+Copyright (c) 2025-2026 by FlashInfer team.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -22,7 +22,7 @@ logger = logging.getLogger(__name__)
 Unified AllReduce Fusion API
 
 This module provides a unified interface for AllReduce + RMSNorm fusion operations
-across different backends (TensorRT-LLM, MNNVL, MNNVL CuTe DSL).
+across different backends (TensorRT-LLM, MNNVL, and NCCL with local fusion).
 
 Example usage:
     >>> # Auto-select best backend based on topology
@@ -56,9 +56,11 @@ from typing import Union, Literal, Optional, Tuple, List, cast, Any
 from .workspace_base import AllReduceFusionWorkspace
 
 import torch
+import torch.distributed as dist
 from torch.distributed import ProcessGroup
 
 from flashinfer.api_logging import flashinfer_api
+from flashinfer.norm import fused_add_rmsnorm
 from flashinfer.trace.templates.comm import allreduce_fusion_trace
 from flashinfer.utils import is_confidential_compute
 
@@ -96,7 +98,7 @@ from .trtllm_mnnvl_ar import trtllm_mnnvl_fused_allreduce_add_rmsnorm_quant
 # Workspace classes wrap the underlying backend workspace implementations:
 # - TRTLLMAllReduceFusionWorkspace: Wraps trtllm_create_ipc_workspace_for_all_reduce_fusion
 # - MNNVLAllReduceFusionWorkspace: Wraps MNNVL workspace (see trtllm_mnnvl_ar.py)
-# - MNNVLCuteDSLAllReduceFusionWorkspace: Shared LL/BT/HT backend workspace
+# - NCCLLocalAllReduceFusionWorkspace: NCCL collective with local fusion kernels
 #
 # Each workspace:
 # 1. Calls the backend-specific workspace creation function in __init__
@@ -274,6 +276,60 @@ class TRTLLMAllReduceFusionWorkspace(AllReduceFusionWorkspace):
         self._destroyed = True
 
 
+class NCCLLocalAllReduceFusionWorkspace(AllReduceFusionWorkspace):
+    """NCCL collective followed by allocation-free local fusion kernels.
+
+    This explicit fallback backend reuses a caller-provided NCCL process group.
+    It does not allocate symmetric communication buffers and is not selected by
+    the ``"auto"`` backend heuristic.
+    """
+
+    def __init__(
+        self,
+        world_size: int,
+        rank: int,
+        max_token_num: int,
+        hidden_dim: int,
+        dtype: torch.dtype,
+        group: Optional[ProcessGroup] = None,
+    ):
+        super().__init__(world_size, rank)
+        if not dist.is_initialized():
+            raise RuntimeError("nccl_local requires an initialized process group")
+        if dist.get_backend(group) != "nccl":
+            raise ValueError("nccl_local requires a ProcessGroupNCCL group")
+        if dtype not in (torch.float16, torch.bfloat16):
+            raise ValueError("nccl_local supports torch.float16 and torch.bfloat16")
+
+        self.max_token_num = max_token_num
+        self.hidden_dim = hidden_dim
+        self.dtype = dtype
+        self.group = group
+
+    @property
+    def backend(self) -> str:
+        return "nccl_local"
+
+    def is_buffer_size_sufficient(
+        self,
+        tp_size: int,
+        num_tokens: int,
+        hidden_dim: int,
+        dtype: torch.dtype,
+        use_oneshot: Optional[Any] = None,
+    ) -> bool:
+        del use_oneshot
+        return (
+            tp_size == self.world_size
+            and num_tokens <= self.max_token_num
+            and hidden_dim == self.hidden_dim
+            and dtype == self.dtype
+        )
+
+    def destroy(self) -> None:
+        self._destroyed = True
+
+
 # ============================================================================
 # BACKEND CHECKS - Hard requirements for backend selection
 # ============================================================================
@@ -356,7 +412,7 @@ def _workspace_creation_heuristic(
 
 @flashinfer_api
 def create_allreduce_fusion_workspace(
-    backend: Literal["trtllm", "mnnvl", "auto"] = "auto",
+    backend: Literal["trtllm", "mnnvl", "nccl_local", "auto"] = "auto",
     world_size: int = None,
     rank: int = None,
     max_token_num: int = None,
@@ -381,9 +437,11 @@ def create_allreduce_fusion_workspace(
 
     Parameters
     ----------
-    backend : Literal["trtllm", "mnnvl", "auto"]
+    backend : Literal["trtllm", "mnnvl", "nccl_local", "auto"]
         Backend to use. ``"auto"`` uses a topology-based heuristic to pick
-        between ``"trtllm"`` and ``"mnnvl"``.
+        between ``"trtllm"`` and ``"mnnvl"``. ``"nccl_local"`` is an
+        explicit fallback that runs a NCCL collective followed by local fusion
+        kernels; it is never selected by ``"auto"``.
     world_size : int
         Number of ranks in the process group.
     rank : int
@@ -408,14 +466,16 @@ def create_allreduce_fusion_workspace(
         backend needs to be initialized with the correct strategy; the
         TRT-LLM backend works for both.
     group : Optional[ProcessGroup]
-        Process group used for symmetric-memory rendezvous (TRT-LLM backend
-        only). Defaults to ``torch.distributed.group.WORLD``.
+        Process group used for communication. The ``"nccl_local"`` backend
+        requires a NCCL process group. Defaults to
+        ``torch.distributed.group.WORLD``.
 
     Returns
     -------
     AllReduceFusionWorkspace
-        Either a ``TRTLLMAllReduceFusionWorkspace`` or
-        ``MNNVLAllReduceFusionWorkspace``. The workspace type determines
+        A ``TRTLLMAllReduceFusionWorkspace``,
+        ``MNNVLAllReduceFusionWorkspace``, or
+        ``NCCLLocalAllReduceFusionWorkspace``. The workspace type determines
         which backend :func:`allreduce_fusion` will dispatch to.
 
     Raises
@@ -535,6 +595,15 @@ def create_allreduce_fusion_workspace(
             comm_backend=comm_backend,
             buffer_size_in_bytes=buffer_size_in_bytes,
         )
+    elif actual_backend == "nccl_local":
+        return NCCLLocalAllReduceFusionWorkspace(
+            world_size=world_size,
+            rank=rank,
+            max_token_num=max_token_num,
+            hidden_dim=hidden_dim,
+            dtype=dtype,
+            group=group,
+        )
     else:
         raise RuntimeError(f"Unknown backend: {actual_backend}")
 
@@ -629,6 +698,9 @@ def allreduce_fusion(
         MNNVL supports the standard FP8/NVFP4 quant patterns (2-5) and
         dynamic FP8 patterns (10-11). Packed group quant patterns remain
         TRT-LLM only.
+
+        NCCL with local fusion supports only ``kAllReduce`` and
+        ``kARResidualRMSNorm``.
 
         ``kMoEFinalizeARResidualRMSNorm`` is available through TRT-LLM and
         the explicit MNNVL CuTe DSL backend.
@@ -742,6 +814,49 @@ def allreduce_fusion(
     ... )
     """
     # Dispatch based on workspace type
+    if isinstance(workspace, NCCLLocalAllReduceFusionWorkspace):
+        if pattern not in (
+            AllReduceFusionPattern.kAllReduce,
+            AllReduceFusionPattern.kARResidualRMSNorm,
+        ):
+            raise ValueError(
+                "nccl_local initially supports only kAllReduce and kARResidualRMSNorm"
+            )
+        if input.ndim != 2 or not input.is_contiguous():
+            raise ValueError("nccl_local input must be a contiguous 2D tensor")
+        if not workspace.is_buffer_size_sufficient(
+            workspace.world_size, input.shape[0], input.shape[1], input.dtype
+        ):
+            raise ValueError("nccl_local workspace is insufficient for the input")
+        if weight_bias != 0.0:
+            raise ValueError("nccl_local does not yet support RMSNorm weight_bias")
+
+        if output is None:
+            output = torch.empty_like(input)
+        output.copy_(input)
+        dist.all_reduce(output, group=workspace.group)
+        if pattern == AllReduceFusionPattern.kAllReduce:
+            return output
+
+        if residual_in is None or rms_gamma is None:
+            raise ValueError(
+                "residual_in and rms_gamma are required for kARResidualRMSNorm"
+            )
+        if residual_out is None:
+            residual_out = torch.empty_like(input)
+        if norm_out is None:
+            norm_out = torch.empty_like(input)
+        residual_out.copy_(residual_in)
+        norm_out.copy_(output)
+        fused_add_rmsnorm(
+            norm_out,
+            residual_out,
+            rms_gamma,
+            eps=rms_eps,
+            enable_pdl=launch_with_pdl,
+        )
+        return norm_out
+
     if isinstance(workspace, TRTLLMAllReduceFusionWorkspace):
         # TensorRT-LLM backend implementation
         if any(

--- a/flashinfer/comm/allreduce.py
+++ b/flashinfer/comm/allreduce.py
@@ -298,6 +298,14 @@ class NCCLLocalAllReduceFusionWorkspace(AllReduceFusionWorkspace):
             raise RuntimeError("nccl_local requires an initialized process group")
         if dist.get_backend(group) != "nccl":
             raise ValueError("nccl_local requires a ProcessGroupNCCL group")
+        group_world_size = dist.get_world_size(group)
+        group_rank = dist.get_rank(group)
+        if (world_size, rank) != (group_world_size, group_rank):
+            raise ValueError(
+                "nccl_local world_size/rank must match the provided process "
+                f"group: got ({world_size}, {rank}), expected "
+                f"({group_world_size}, {group_rank})"
+            )
         if dtype not in (torch.float16, torch.bfloat16):
             raise ValueError("nccl_local supports torch.float16 and torch.bfloat16")
 
@@ -828,7 +836,7 @@ def allreduce_fusion(
             workspace.world_size, input.shape[0], input.shape[1], input.dtype
         ):
             raise ValueError("nccl_local workspace is insufficient for the input")
-        if weight_bias != 0.0:
+        if pattern == AllReduceFusionPattern.kARResidualRMSNorm and weight_bias != 0.0:
             raise ValueError("nccl_local does not yet support RMSNorm weight_bias")
 
         if output is None:

--- a/tests/comm/test_allreduce_unified_api.py
+++ b/tests/comm/test_allreduce_unified_api.py
@@ -5,6 +5,7 @@ from typing import Optional, Tuple
 
 import pytest
 import torch
+import torch.distributed as dist
 from mpi4py import MPI
 
 import flashinfer.comm.trtllm_mnnvl_ar as trtllm_mnnvl_ar
@@ -16,6 +17,7 @@ from flashinfer.comm import (
     allreduce_fusion,
     AllReduceFusionPattern,
     AllReduceFusionWorkspace,
+    NCCLLocalAllReduceFusionWorkspace,
 )
 
 # Use flashinfer.norm.rmsnorm as reference implementation.
@@ -131,7 +133,13 @@ def run_allreduce_fusion_test(
         )
 
 
-def prepare_test_data(seq_len: int, hidden_size: int, dtype: torch.dtype, fusion: bool):
+def prepare_test_data(
+    seq_len: int,
+    hidden_size: int,
+    dtype: torch.dtype,
+    fusion: bool,
+    eps: float,
+):
     """Prepare test data distributed across MPI ranks."""
     comm = MPI.COMM_WORLD
     rank = comm.Get_rank()
@@ -160,9 +168,7 @@ def prepare_test_data(seq_len: int, hidden_size: int, dtype: torch.dtype, fusion
         # Fused case: AllReduce + Residual Add + RMS Norm
         allreduce_result = torch.sum(x_full, dim=0)  # AllReduce result
         residual_out = allreduce_result + residual  # Add residual
-        norm_out = rmsnorm(
-            residual_out, norm_weight, torch.finfo(dtype).eps, enable_pdl=False
-        )
+        norm_out = rmsnorm(residual_out, norm_weight, eps, enable_pdl=False)
 
         reference_output = (norm_out, residual_out)
     else:
@@ -235,7 +241,7 @@ def run_allreduce_test(
         test_data = []
         for seq_len in seq_lens:
             (x_local, residual, norm_weight), reference_output = prepare_test_data(
-                seq_len, hidden_size, dtype, fusion
+                seq_len, hidden_size, dtype, fusion, eps
             )
             test_data.append(
                 (seq_len, x_local, residual, norm_weight, reference_output)
@@ -335,6 +341,69 @@ def test_allreduce_nccl_local(
         hidden_size=7168,
         backend="nccl_local",
     )
+
+
+def _mock_nccl_group(monkeypatch, *, world_size: int = 4, rank: int = 1):
+    group = object()
+    monkeypatch.setattr(dist, "is_initialized", lambda: True)
+    monkeypatch.setattr(dist, "get_backend", lambda candidate: "nccl")
+    monkeypatch.setattr(dist, "get_world_size", lambda candidate: world_size)
+    monkeypatch.setattr(dist, "get_rank", lambda candidate: rank)
+    return group
+
+
+def test_nccl_local_workspace_accepts_matching_group_metadata(monkeypatch):
+    group = _mock_nccl_group(monkeypatch)
+    workspace = NCCLLocalAllReduceFusionWorkspace(
+        world_size=4,
+        rank=1,
+        max_token_num=8,
+        hidden_dim=16,
+        dtype=torch.float16,
+        group=group,
+    )
+    assert workspace.group is group
+
+
+@pytest.mark.parametrize("world_size,rank", [(3, 1), (4, 0)])
+def test_nccl_local_workspace_rejects_mismatched_group_metadata(
+    monkeypatch,
+    world_size: int,
+    rank: int,
+):
+    group = _mock_nccl_group(monkeypatch)
+    with pytest.raises(ValueError, match="must match the provided process group"):
+        NCCLLocalAllReduceFusionWorkspace(
+            world_size=world_size,
+            rank=rank,
+            max_token_num=8,
+            hidden_dim=16,
+            dtype=torch.float16,
+            group=group,
+        )
+
+
+def test_nccl_local_allreduce_ignores_weight_bias(monkeypatch):
+    group = _mock_nccl_group(monkeypatch)
+    monkeypatch.setattr(dist, "all_reduce", lambda output, group: None)
+    workspace = NCCLLocalAllReduceFusionWorkspace(
+        world_size=4,
+        rank=1,
+        max_token_num=8,
+        hidden_dim=16,
+        dtype=torch.float16,
+        group=group,
+    )
+    input_tensor = torch.arange(32, dtype=torch.float16).reshape(2, 16)
+
+    result = allreduce_fusion(
+        input=input_tensor,
+        workspace=workspace,
+        pattern=AllReduceFusionPattern.kAllReduce,
+        weight_bias=1.0,
+    )
+
+    torch.testing.assert_close(result, input_tensor)
 
 
 @pytest.mark.parametrize("seq_len", [64, 256])

--- a/tests/comm/test_allreduce_unified_api.py
+++ b/tests/comm/test_allreduce_unified_api.py
@@ -189,7 +189,7 @@ def run_allreduce_test(
         fusion: Whether to test fused allreduce+rmsnorm or just allreduce
         dtype: Data type for tensors
         hidden_size: Hidden dimension size
-        backend: Backend to use ("auto", "trtllm", "mnnvl")
+        backend: Backend to use ("auto", "trtllm", "mnnvl", "nccl_local")
     """
 
     comm = MPI.COMM_WORLD
@@ -284,7 +284,7 @@ def run_allreduce_test(
         if workspace is not None:
             workspace.destroy()
         # Cleanup torch.distributed if we initialized it
-        if backend in ("trtllm", "auto"):
+        if backend in ("trtllm", "nccl_local", "auto"):
             cleanup_torch_distributed()
 
     # Final synchronization
@@ -312,6 +312,29 @@ def test_allreduce_unified(
     Run with: mpirun -np <num_gpus> pytest tests/comm/test_allreduce_unified_api.py -vv -s
     """
     run_allreduce_test(monkeypatch, seq_lens, fusion, dtype, hidden_size, backend)
+
+
+@pytest.mark.parametrize("fusion", [False, True])
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+def test_allreduce_nccl_local(
+    monkeypatch,
+    fusion: bool,
+    dtype: torch.dtype,
+):
+    """Exercise the explicit NCCL fallback and local RMSNorm fusion.
+
+    Run with:
+        mpirun -np 4 pytest tests/comm/test_allreduce_unified_api.py \\
+            -k nccl_local -vv -s
+    """
+    run_allreduce_test(
+        monkeypatch,
+        seq_lens=[1, 64],
+        fusion=fusion,
+        dtype=dtype,
+        hidden_size=7168,
+        backend="nccl_local",
+    )
 
 
 @pytest.mark.parametrize("seq_len", [64, 256])


### PR DESCRIPTION
## Description

Add an explicit `nccl_local` backend to the unified AllReduce fusion API. It reuses an initialized NCCL process group, performs the collective into the caller's output buffer, and then uses FlashInfer's local fused add + RMSNorm kernel when requested.

The backend currently supports FP16/BF16 for `kAllReduce` and `kARResidualRMSNorm`. It is never selected by `backend="auto"`; callers must opt in with `backend="nccl_local"`. Unsupported patterns and RMSNorm weight bias fail clearly instead of silently changing semantics.

This provides a graph-compatible fallback on systems where symmetric-memory/custom-all-reduce backends are unavailable, without allocating symmetric communication buffers.

## Related Issues

None.

## Pull Request Checklist

### Pre-commit Checks

- [x] I have installed `pre-commit`.
- [x] I have installed the hooks.
- [x] I ran the hooks on all changed files; all hooks passed.

## Tests

- [x] Tests have been added for FP16/BF16, pure AllReduce, residual + RMSNorm, and workspace reuse across token counts.
- [x] `mpirun -np 4 pytest tests/comm/test_allreduce_unified_api.py -k nccl_local -vv -s`: 4 passed on four RTX 5060 Ti GPUs.
- [x] A separate four-rank test passed eager execution and CUDA Graph capture/replay for both supported patterns and dtypes.
- [x] SGLang Qwen2.5 TP4 E2E completed 25/25 non-empty requests with CUDA graphs.

## Reviewer Notes

The E2E latency difference versus the existing standard NCCL path was neutral: median batch-1 wall time 0.182 s versus 0.183 s, and batch-4 0.231 s versus 0.234 s. This PR is intended as an explicit reusable fallback API, not as a claim of a new collective performance fast path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the `nccl_local` all-reduce backend with optional local RMSNorm fusion.
  * Added workspace creation and management with validation for communication settings, supported data types, tensor layouts, buffers, and required inputs.
  * Exposed the new workspace through the communication package API.

* **Tests**
  * Added coverage for fused and unfused FP16/BF16 operations, communication metadata validation, and handling of optional normalization parameters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
