### PR TITLE
add backward-compatible aliases for bsa_attn_fwd and bsa_attn_blk64_fwd

### DIFF
--- a/flashinfer/cute_dsl/sparse/__init__.py
+++ b/flashinfer/cute_dsl/sparse/__init__.py
@@ -11,3 +11,20 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+__all__ = [
+    "bsa_attn_fwd",
+    "bsa_attn_blk64_fwd",
+]
+
+
+def __getattr__(name):
+    if name == "bsa_attn_fwd":
+        from .bsa_attn_sm100_blk128 import bsa_attn_fwd
+
+        return bsa_attn_fwd
+    if name == "bsa_attn_blk64_fwd":
+        from .bsa_attn_sm100_blk64 import bsa_attn_blk64_fwd
+
+        return bsa_attn_blk64_fwd
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/flashinfer/cute_dsl/sparse/bsa_attn_sm100_blk128.py
+++ b/flashinfer/cute_dsl/sparse/bsa_attn_sm100_blk128.py
@@ -246,3 +246,20 @@ def bsa_attn_sm100_blk128_fwd(
             )
 
     return out, lse
+
+
+def bsa_attn_fwd(*args, **kwargs):
+    """Deprecated alias for bsa_attn_sm100_blk128_fwd.
+
+    .. deprecated:: 0.6.18
+        Use :func:`bsa_attn_sm100_blk128_fwd` instead.
+    """
+    import warnings
+
+    warnings.warn(
+        "bsa_attn_fwd is deprecated and will be removed in a future release. "
+        "Use bsa_attn_sm100_blk128_fwd instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return bsa_attn_sm100_blk128_fwd(*args, **kwargs)

--- a/flashinfer/cute_dsl/sparse/bsa_attn_sm100_blk64.py
+++ b/flashinfer/cute_dsl/sparse/bsa_attn_sm100_blk64.py
@@ -135,3 +135,20 @@ def bsa_attn_sm100_blk64_fwd(
         return out, lse
 
     return out, None
+
+
+def bsa_attn_blk64_fwd(*args, **kwargs):
+    """Deprecated alias for bsa_attn_sm100_blk64_fwd.
+
+    .. deprecated:: 0.6.18
+        Use :func:`bsa_attn_sm100_blk64_fwd` instead.
+    """
+    import warnings
+
+    warnings.warn(
+        "bsa_attn_blk64_fwd is deprecated and will be removed in a future release. "
+        "Use bsa_attn_sm100_blk64_fwd instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return bsa_attn_sm100_blk64_fwd(*args, **kwargs)


### PR DESCRIPTION
bsa_attn_fwd and bsa_attn_blk64_fwd were public APIs in v0.6.16/v0.6.17 that were renamed to bsa_attn_sm100_blk128_fwd and bsa_attn_sm100_blk64_fwd in PR #4259 without backward-compatible aliases, causing import failures.

Add deprecated shims to restore compatibility:
- bsa_attn_fwd -> bsa_attn_sm100_blk128_fwd (bsa_attn_sm100_blk128.py)
- bsa_attn_blk64_fwd -> bsa_attn_sm100_blk64_fwd (bsa_attn_sm100_blk64.py)

<!-- .github/pull_request_template.md -->

## 📌 Description

<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Deprecations**
  * Added deprecated compatibility aliases for the 128-block and 64-block sparse attention forward operations.
  * Calls through these aliases continue to work but now emit deprecation warnings.
  * Aliases are available through the sparse attention package exports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->