### PR TITLE
feat(cake_backend): add Blackwell Router GEMM

### DIFF
--- a/csrc/cake_router_gemm/cake_router_gemm_m10_k6144_device.cu
+++ b/csrc/cake_router_gemm/cake_router_gemm_m10_k6144_device.cu
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) 2026 by FlashInfer team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+typedef unsigned char      uint8_t;
+typedef unsigned short     uint16_t;
+typedef unsigned int       uint32_t;
+typedef unsigned long long uint64_t;
+typedef signed int         int32_t;
+typedef short int          int16_t;
+struct __align__(128) CakeTensorMap { uint64_t opaque[16]; };
+template <int N>
+struct __align__(128) CakeTensorMapPack { CakeTensorMap maps[N]; };
+
+typedef struct __align__(64) { uint64_t opaque[16]; } CUtensorMap;
+
+#include <cuda_bf16.h>
+
+__device__ __forceinline__ int make_warp_uniform(int x) {
+    int result;
+    asm volatile("shfl.sync.idx.b32 %0, %1, 0, 0x1F, 0xFFFFFFFF;"
+                 : "=r"(result) : "r"(x));
+    return result;
+}
+
+#define CAKE_INF CUDART_INF_F
+#define NUM_MAIN_STAGES 1
+#define SMEM_RED_OFF 0
+#define SMEM_RED_STAGE_BYTES 160
+#define SMEM_RED_STRIDE 160
+#define SMEM_TOTAL 256
+#define THREADS 128
+
+#include <math_constants.h>
+
+extern "C" {
+
+__global__ __launch_bounds__(128, 1) void
+kernel_cake_blackwell_router_gemm_m10_k6144(__nv_bfloat16* __restrict__ mat_a, __nv_bfloat16* __restrict__ mat_b, float* __restrict__ out_f32, __nv_bfloat16* __restrict__ out_bf16, int num_experts, int out_is_bf16)
+{
+    const int tid = threadIdx.x;
+    const int warp = make_warp_uniform(tid / 32);
+    const int lane = tid % 32;
+
+    extern __shared__ __align__(1024) char smem_raw[];
+    int smem;
+    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+
+    const int bid = blockIdx.x;
+    const int num_bids = gridDim.x;
+
+    // Kernel setup ops
+    float* red = reinterpret_cast<float*>(smem_raw + 0);
+    const int red_addr = smem + 0;
+
+    // === Task calls (dependency order) ===
+    int expert = blockIdx.x;
+    float acc[10];
+    #pragma unroll
+    for (int m = 0; m < 10; m++) {
+        acc[m] = 0.0f;
+    }
+    asm volatile("griddepcontrol.wait;" ::: "memory");
+    #pragma unroll
+    for (int ki = 0; ki < 6; ki++) {
+        int k_base = ki * 1024 + tid * 8;
+        float _vec_load_0[8];
+        {
+            const uint4* _vptr_0 = reinterpret_cast<const uint4*>(mat_b + (expert * 6144 + k_base) + 0);
+            uint4 _vld_0[1];
+            #pragma unroll
+            for (int _blk = 0; _blk < 1; _blk++) {
+                _vld_0[_blk] = _vptr_0[_blk];
+                uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
+                #pragma unroll
+                for (int _pair = 0; _pair < 4; _pair++) {
+                    asm volatile(
+                        "{\n\t"
+                        "shl.b32 %0, %2, 16;\n\t"
+                        "and.b32 %1, %2, 0xffff0000;\n\t"
+                        "}\n"
+                        : "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[1])
+                        : "r"(_vpairs_0[_pair]));
+                }
+            }
+        }
+        #pragma unroll
+        for (int m_1 = 0; m_1 < 10; m_1++) {
+            float _vec_load_1[8];
+            {
+                const uint4* _vptr_1 = reinterpret_cast<const uint4*>(mat_a + (m_1 * 6144 + k_base) + 0);
+                uint4 _vld_1[1];
+                #pragma unroll
+                for (int _blk = 0; _blk < 1; _blk++) {
+                    _vld_1[_blk] = _vptr_1[_blk];
+                    uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
+                    #pragma unroll
+                    for (int _pair = 0; _pair < 4; _pair++) {
+                        asm volatile(
+                            "{\n\t"
+                            "shl.b32 %0, %2, 16;\n\t"
+                            "and.b32 %1, %2, 0xffff0000;\n\t"
+                            "}\n"
+                            : "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[1])
+                            : "r"(_vpairs_1[_pair]));
+                    }
+                }
+            }
+            #pragma unroll
+            for (int j = 0; j < 8; j++) {
+                float _fma_0 = __fmaf_rn(_vec_load_1[j], _vec_load_0[j], acc[m_1]);
+                acc[m_1] = _fma_0;
+            }
+        }
+    }
+    #pragma unroll
+    for (int m_2 = 0; m_2 < 10; m_2++) {
+        float _warp_reduce_0 = acc[m_2];
+        #pragma unroll
+        for (int offset = 16; offset > 0; offset >>= 1)
+            _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
+        float warp_sum = _warp_reduce_0;
+        if (lane == 0) {
+            red[m_2 * 4 + warp] = warp_sum;
+        }
+    }
+    asm volatile("barrier.sync 2, 128;" ::: "memory");
+    if (warp == 0) {
+        if (lane < 10) {
+            int m_3 = lane;
+            float total = red[m_3 * 4];
+            #pragma unroll
+            for (int source_warp = 1; source_warp < 4; source_warp++) {
+                total = total + red[m_3 * 4 + source_warp];
+            }
+            int offset = m_3 * num_experts + expert;
+            if (out_is_bf16 == 0) {
+                *(reinterpret_cast<float*>(out_f32 + offset) + (0)) = total;
+            } else {
+                *(reinterpret_cast<__nv_bfloat16*>(out_bf16 + offset) + (0)) = __float2bfloat16_rn(total);
+            }
+        }
+    }
+    asm volatile("griddepcontrol.launch_dependents;" ::: "memory");
+}
+
+} // extern "C"

--- a/csrc/cake_router_gemm/cake_router_gemm_m10_k6144_device.cu
+++ b/csrc/cake_router_gemm/cake_router_gemm_m10_k6144_device.cu
@@ -14,25 +14,30 @@
  * limitations under the License.
  */
 
-typedef unsigned char      uint8_t;
-typedef unsigned short     uint16_t;
-typedef unsigned int       uint32_t;
+typedef unsigned char uint8_t;
+typedef unsigned short uint16_t;
+typedef unsigned int uint32_t;
 typedef unsigned long long uint64_t;
-typedef signed int         int32_t;
-typedef short int          int16_t;
-struct __align__(128) CakeTensorMap { uint64_t opaque[16]; };
+typedef signed int int32_t;
+typedef short int int16_t;
+struct __align__(128) CakeTensorMap {
+  uint64_t opaque[16];
+};
 template <int N>
-struct __align__(128) CakeTensorMapPack { CakeTensorMap maps[N]; };
+struct __align__(128) CakeTensorMapPack {
+  CakeTensorMap maps[N];
+};
 
-typedef struct __align__(64) { uint64_t opaque[16]; } CUtensorMap;
+typedef struct __align__(64) {
+  uint64_t opaque[16];
+} CUtensorMap;
 
 #include <cuda_bf16.h>
 
 __device__ __forceinline__ int make_warp_uniform(int x) {
-    int result;
-    asm volatile("shfl.sync.idx.b32 %0, %1, 0, 0x1F, 0xFFFFFFFF;"
-                 : "=r"(result) : "r"(x));
-    return result;
+  int result;
+  asm volatile("shfl.sync.idx.b32 %0, %1, 0, 0x1F, 0xFFFFFFFF;" : "=r"(result) : "r"(x));
+  return result;
 }
 
 #define CAKE_INF CUDART_INF_F
@@ -47,113 +52,116 @@ __device__ __forceinline__ int make_warp_uniform(int x) {
 
 extern "C" {
 
-__global__ __launch_bounds__(128, 1) void
-kernel_cake_blackwell_router_gemm_m10_k6144(__nv_bfloat16* __restrict__ mat_a, __nv_bfloat16* __restrict__ mat_b, float* __restrict__ out_f32, __nv_bfloat16* __restrict__ out_bf16, int num_experts, int out_is_bf16)
-{
-    const int tid = threadIdx.x;
-    const int warp = make_warp_uniform(tid / 32);
-    const int lane = tid % 32;
+__global__ __launch_bounds__(128, 1) void kernel_cake_blackwell_router_gemm_m10_k6144(
+    __nv_bfloat16* __restrict__ mat_a, __nv_bfloat16* __restrict__ mat_b,
+    float* __restrict__ out_f32, __nv_bfloat16* __restrict__ out_bf16, int num_experts,
+    int out_is_bf16) {
+  const int tid = threadIdx.x;
+  const int warp = make_warp_uniform(tid / 32);
+  const int lane = tid % 32;
 
-    extern __shared__ __align__(1024) char smem_raw[];
-    int smem;
-    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+  extern __shared__ __align__(1024) char smem_raw[];
+  int smem;
+  smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
 
-    const int bid = blockIdx.x;
-    const int num_bids = gridDim.x;
+  const int bid = blockIdx.x;
+  const int num_bids = gridDim.x;
 
-    // Kernel setup ops
-    float* red = reinterpret_cast<float*>(smem_raw + 0);
-    const int red_addr = smem + 0;
+  // Kernel setup ops
+  float* red = reinterpret_cast<float*>(smem_raw + 0);
+  const int red_addr = smem + 0;
 
-    // === Task calls (dependency order) ===
-    int expert = blockIdx.x;
-    float acc[10];
-    #pragma unroll
-    for (int m = 0; m < 10; m++) {
-        acc[m] = 0.0f;
-    }
-    asm volatile("griddepcontrol.wait;" ::: "memory");
-    #pragma unroll
-    for (int ki = 0; ki < 6; ki++) {
-        int k_base = ki * 1024 + tid * 8;
-        float _vec_load_0[8];
-        {
-            const uint4* _vptr_0 = reinterpret_cast<const uint4*>(mat_b + (expert * 6144 + k_base) + 0);
-            uint4 _vld_0[1];
-            #pragma unroll
-            for (int _blk = 0; _blk < 1; _blk++) {
-                _vld_0[_blk] = _vptr_0[_blk];
-                uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
-                #pragma unroll
-                for (int _pair = 0; _pair < 4; _pair++) {
-                    asm volatile(
-                        "{\n\t"
-                        "shl.b32 %0, %2, 16;\n\t"
-                        "and.b32 %1, %2, 0xffff0000;\n\t"
-                        "}\n"
-                        : "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[1])
-                        : "r"(_vpairs_0[_pair]));
-                }
-            }
+  // === Task calls (dependency order) ===
+  int expert = blockIdx.x;
+  float acc[10];
+#pragma unroll
+  for (int m = 0; m < 10; m++) {
+    acc[m] = 0.0f;
+  }
+  asm volatile("griddepcontrol.wait;" ::: "memory");
+#pragma unroll
+  for (int ki = 0; ki < 6; ki++) {
+    int k_base = ki * 1024 + tid * 8;
+    float _vec_load_0[8];
+    {
+      const uint4* _vptr_0 = reinterpret_cast<const uint4*>(mat_b + (expert * 6144 + k_base) + 0);
+      uint4 _vld_0[1];
+#pragma unroll
+      for (int _blk = 0; _blk < 1; _blk++) {
+        _vld_0[_blk] = _vptr_0[_blk];
+        uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
+#pragma unroll
+        for (int _pair = 0; _pair < 4; _pair++) {
+          asm volatile(
+              "{\n\t"
+              "shl.b32 %0, %2, 16;\n\t"
+              "and.b32 %1, %2, 0xffff0000;\n\t"
+              "}\n"
+              : "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[0]),
+                "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[1])
+              : "r"(_vpairs_0[_pair]));
         }
-        #pragma unroll
-        for (int m_1 = 0; m_1 < 10; m_1++) {
-            float _vec_load_1[8];
-            {
-                const uint4* _vptr_1 = reinterpret_cast<const uint4*>(mat_a + (m_1 * 6144 + k_base) + 0);
-                uint4 _vld_1[1];
-                #pragma unroll
-                for (int _blk = 0; _blk < 1; _blk++) {
-                    _vld_1[_blk] = _vptr_1[_blk];
-                    uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
-                    #pragma unroll
-                    for (int _pair = 0; _pair < 4; _pair++) {
-                        asm volatile(
-                            "{\n\t"
-                            "shl.b32 %0, %2, 16;\n\t"
-                            "and.b32 %1, %2, 0xffff0000;\n\t"
-                            "}\n"
-                            : "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[1])
-                            : "r"(_vpairs_1[_pair]));
-                    }
-                }
-            }
-            #pragma unroll
-            for (int j = 0; j < 8; j++) {
-                float _fma_0 = __fmaf_rn(_vec_load_1[j], _vec_load_0[j], acc[m_1]);
-                acc[m_1] = _fma_0;
-            }
-        }
+      }
     }
-    #pragma unroll
-    for (int m_2 = 0; m_2 < 10; m_2++) {
-        float _warp_reduce_0 = acc[m_2];
-        #pragma unroll
-        for (int offset = 16; offset > 0; offset >>= 1)
-            _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
-        float warp_sum = _warp_reduce_0;
-        if (lane == 0) {
-            red[m_2 * 4 + warp] = warp_sum;
+#pragma unroll
+    for (int m_1 = 0; m_1 < 10; m_1++) {
+      float _vec_load_1[8];
+      {
+        const uint4* _vptr_1 = reinterpret_cast<const uint4*>(mat_a + (m_1 * 6144 + k_base) + 0);
+        uint4 _vld_1[1];
+#pragma unroll
+        for (int _blk = 0; _blk < 1; _blk++) {
+          _vld_1[_blk] = _vptr_1[_blk];
+          uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
+#pragma unroll
+          for (int _pair = 0; _pair < 4; _pair++) {
+            asm volatile(
+                "{\n\t"
+                "shl.b32 %0, %2, 16;\n\t"
+                "and.b32 %1, %2, 0xffff0000;\n\t"
+                "}\n"
+                : "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[0]),
+                  "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[1])
+                : "r"(_vpairs_1[_pair]));
+          }
         }
+      }
+#pragma unroll
+      for (int j = 0; j < 8; j++) {
+        float _fma_0 = __fmaf_rn(_vec_load_1[j], _vec_load_0[j], acc[m_1]);
+        acc[m_1] = _fma_0;
+      }
     }
-    asm volatile("barrier.sync 2, 128;" ::: "memory");
-    if (warp == 0) {
-        if (lane < 10) {
-            int m_3 = lane;
-            float total = red[m_3 * 4];
-            #pragma unroll
-            for (int source_warp = 1; source_warp < 4; source_warp++) {
-                total = total + red[m_3 * 4 + source_warp];
-            }
-            int offset = m_3 * num_experts + expert;
-            if (out_is_bf16 == 0) {
-                *(reinterpret_cast<float*>(out_f32 + offset) + (0)) = total;
-            } else {
-                *(reinterpret_cast<__nv_bfloat16*>(out_bf16 + offset) + (0)) = __float2bfloat16_rn(total);
-            }
-        }
+  }
+#pragma unroll
+  for (int m_2 = 0; m_2 < 10; m_2++) {
+    float _warp_reduce_0 = acc[m_2];
+#pragma unroll
+    for (int offset = 16; offset > 0; offset >>= 1)
+      _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
+    float warp_sum = _warp_reduce_0;
+    if (lane == 0) {
+      red[m_2 * 4 + warp] = warp_sum;
     }
-    asm volatile("griddepcontrol.launch_dependents;" ::: "memory");
+  }
+  asm volatile("barrier.sync 2, 128;" ::: "memory");
+  if (warp == 0) {
+    if (lane < 10) {
+      int m_3 = lane;
+      float total = red[m_3 * 4];
+#pragma unroll
+      for (int source_warp = 1; source_warp < 4; source_warp++) {
+        total = total + red[m_3 * 4 + source_warp];
+      }
+      int offset = m_3 * num_experts + expert;
+      if (out_is_bf16 == 0) {
+        *(reinterpret_cast<float*>(out_f32 + offset) + (0)) = total;
+      } else {
+        *(reinterpret_cast<__nv_bfloat16*>(out_bf16 + offset) + (0)) = __float2bfloat16_rn(total);
+      }
+    }
+  }
+  asm volatile("griddepcontrol.launch_dependents;" ::: "memory");
 }
 
-} // extern "C"
+}  // extern "C"

--- a/csrc/cake_router_gemm/cake_router_gemm_m10_k7168_device.cu
+++ b/csrc/cake_router_gemm/cake_router_gemm_m10_k7168_device.cu
@@ -14,25 +14,30 @@
  * limitations under the License.
  */
 
-typedef unsigned char      uint8_t;
-typedef unsigned short     uint16_t;
-typedef unsigned int       uint32_t;
+typedef unsigned char uint8_t;
+typedef unsigned short uint16_t;
+typedef unsigned int uint32_t;
 typedef unsigned long long uint64_t;
-typedef signed int         int32_t;
-typedef short int          int16_t;
-struct __align__(128) CakeTensorMap { uint64_t opaque[16]; };
+typedef signed int int32_t;
+typedef short int int16_t;
+struct __align__(128) CakeTensorMap {
+  uint64_t opaque[16];
+};
 template <int N>
-struct __align__(128) CakeTensorMapPack { CakeTensorMap maps[N]; };
+struct __align__(128) CakeTensorMapPack {
+  CakeTensorMap maps[N];
+};
 
-typedef struct __align__(64) { uint64_t opaque[16]; } CUtensorMap;
+typedef struct __align__(64) {
+  uint64_t opaque[16];
+} CUtensorMap;
 
 #include <cuda_bf16.h>
 
 __device__ __forceinline__ int make_warp_uniform(int x) {
-    int result;
-    asm volatile("shfl.sync.idx.b32 %0, %1, 0, 0x1F, 0xFFFFFFFF;"
-                 : "=r"(result) : "r"(x));
-    return result;
+  int result;
+  asm volatile("shfl.sync.idx.b32 %0, %1, 0, 0x1F, 0xFFFFFFFF;" : "=r"(result) : "r"(x));
+  return result;
 }
 
 #define CAKE_INF CUDART_INF_F
@@ -47,113 +52,116 @@ __device__ __forceinline__ int make_warp_uniform(int x) {
 
 extern "C" {
 
-__global__ __launch_bounds__(128, 1) void
-kernel_cake_blackwell_router_gemm_m10_k7168(__nv_bfloat16* __restrict__ mat_a, __nv_bfloat16* __restrict__ mat_b, float* __restrict__ out_f32, __nv_bfloat16* __restrict__ out_bf16, int num_experts, int out_is_bf16)
-{
-    const int tid = threadIdx.x;
-    const int warp = make_warp_uniform(tid / 32);
-    const int lane = tid % 32;
+__global__ __launch_bounds__(128, 1) void kernel_cake_blackwell_router_gemm_m10_k7168(
+    __nv_bfloat16* __restrict__ mat_a, __nv_bfloat16* __restrict__ mat_b,
+    float* __restrict__ out_f32, __nv_bfloat16* __restrict__ out_bf16, int num_experts,
+    int out_is_bf16) {
+  const int tid = threadIdx.x;
+  const int warp = make_warp_uniform(tid / 32);
+  const int lane = tid % 32;
 
-    extern __shared__ __align__(1024) char smem_raw[];
-    int smem;
-    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+  extern __shared__ __align__(1024) char smem_raw[];
+  int smem;
+  smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
 
-    const int bid = blockIdx.x;
-    const int num_bids = gridDim.x;
+  const int bid = blockIdx.x;
+  const int num_bids = gridDim.x;
 
-    // Kernel setup ops
-    float* red = reinterpret_cast<float*>(smem_raw + 0);
-    const int red_addr = smem + 0;
+  // Kernel setup ops
+  float* red = reinterpret_cast<float*>(smem_raw + 0);
+  const int red_addr = smem + 0;
 
-    // === Task calls (dependency order) ===
-    int expert = blockIdx.x;
-    float acc[10];
-    #pragma unroll
-    for (int m = 0; m < 10; m++) {
-        acc[m] = 0.0f;
-    }
-    asm volatile("griddepcontrol.wait;" ::: "memory");
-    #pragma unroll
-    for (int ki = 0; ki < 7; ki++) {
-        int k_base = ki * 1024 + tid * 8;
-        float _vec_load_0[8];
-        {
-            const uint4* _vptr_0 = reinterpret_cast<const uint4*>(mat_b + (expert * 7168 + k_base) + 0);
-            uint4 _vld_0[1];
-            #pragma unroll
-            for (int _blk = 0; _blk < 1; _blk++) {
-                _vld_0[_blk] = _vptr_0[_blk];
-                uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
-                #pragma unroll
-                for (int _pair = 0; _pair < 4; _pair++) {
-                    asm volatile(
-                        "{\n\t"
-                        "shl.b32 %0, %2, 16;\n\t"
-                        "and.b32 %1, %2, 0xffff0000;\n\t"
-                        "}\n"
-                        : "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[1])
-                        : "r"(_vpairs_0[_pair]));
-                }
-            }
+  // === Task calls (dependency order) ===
+  int expert = blockIdx.x;
+  float acc[10];
+#pragma unroll
+  for (int m = 0; m < 10; m++) {
+    acc[m] = 0.0f;
+  }
+  asm volatile("griddepcontrol.wait;" ::: "memory");
+#pragma unroll
+  for (int ki = 0; ki < 7; ki++) {
+    int k_base = ki * 1024 + tid * 8;
+    float _vec_load_0[8];
+    {
+      const uint4* _vptr_0 = reinterpret_cast<const uint4*>(mat_b + (expert * 7168 + k_base) + 0);
+      uint4 _vld_0[1];
+#pragma unroll
+      for (int _blk = 0; _blk < 1; _blk++) {
+        _vld_0[_blk] = _vptr_0[_blk];
+        uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
+#pragma unroll
+        for (int _pair = 0; _pair < 4; _pair++) {
+          asm volatile(
+              "{\n\t"
+              "shl.b32 %0, %2, 16;\n\t"
+              "and.b32 %1, %2, 0xffff0000;\n\t"
+              "}\n"
+              : "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[0]),
+                "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[1])
+              : "r"(_vpairs_0[_pair]));
         }
-        #pragma unroll
-        for (int m_1 = 0; m_1 < 10; m_1++) {
-            float _vec_load_1[8];
-            {
-                const uint4* _vptr_1 = reinterpret_cast<const uint4*>(mat_a + (m_1 * 7168 + k_base) + 0);
-                uint4 _vld_1[1];
-                #pragma unroll
-                for (int _blk = 0; _blk < 1; _blk++) {
-                    _vld_1[_blk] = _vptr_1[_blk];
-                    uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
-                    #pragma unroll
-                    for (int _pair = 0; _pair < 4; _pair++) {
-                        asm volatile(
-                            "{\n\t"
-                            "shl.b32 %0, %2, 16;\n\t"
-                            "and.b32 %1, %2, 0xffff0000;\n\t"
-                            "}\n"
-                            : "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[1])
-                            : "r"(_vpairs_1[_pair]));
-                    }
-                }
-            }
-            #pragma unroll
-            for (int j = 0; j < 8; j++) {
-                float _fma_0 = __fmaf_rn(_vec_load_1[j], _vec_load_0[j], acc[m_1]);
-                acc[m_1] = _fma_0;
-            }
-        }
+      }
     }
-    #pragma unroll
-    for (int m_2 = 0; m_2 < 10; m_2++) {
-        float _warp_reduce_0 = acc[m_2];
-        #pragma unroll
-        for (int offset = 16; offset > 0; offset >>= 1)
-            _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
-        float warp_sum = _warp_reduce_0;
-        if (lane == 0) {
-            red[m_2 * 4 + warp] = warp_sum;
+#pragma unroll
+    for (int m_1 = 0; m_1 < 10; m_1++) {
+      float _vec_load_1[8];
+      {
+        const uint4* _vptr_1 = reinterpret_cast<const uint4*>(mat_a + (m_1 * 7168 + k_base) + 0);
+        uint4 _vld_1[1];
+#pragma unroll
+        for (int _blk = 0; _blk < 1; _blk++) {
+          _vld_1[_blk] = _vptr_1[_blk];
+          uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
+#pragma unroll
+          for (int _pair = 0; _pair < 4; _pair++) {
+            asm volatile(
+                "{\n\t"
+                "shl.b32 %0, %2, 16;\n\t"
+                "and.b32 %1, %2, 0xffff0000;\n\t"
+                "}\n"
+                : "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[0]),
+                  "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[1])
+                : "r"(_vpairs_1[_pair]));
+          }
         }
+      }
+#pragma unroll
+      for (int j = 0; j < 8; j++) {
+        float _fma_0 = __fmaf_rn(_vec_load_1[j], _vec_load_0[j], acc[m_1]);
+        acc[m_1] = _fma_0;
+      }
     }
-    asm volatile("barrier.sync 2, 128;" ::: "memory");
-    if (warp == 0) {
-        if (lane < 10) {
-            int m_3 = lane;
-            float total = red[m_3 * 4];
-            #pragma unroll
-            for (int source_warp = 1; source_warp < 4; source_warp++) {
-                total = total + red[m_3 * 4 + source_warp];
-            }
-            int offset = m_3 * num_experts + expert;
-            if (out_is_bf16 == 0) {
-                *(reinterpret_cast<float*>(out_f32 + offset) + (0)) = total;
-            } else {
-                *(reinterpret_cast<__nv_bfloat16*>(out_bf16 + offset) + (0)) = __float2bfloat16_rn(total);
-            }
-        }
+  }
+#pragma unroll
+  for (int m_2 = 0; m_2 < 10; m_2++) {
+    float _warp_reduce_0 = acc[m_2];
+#pragma unroll
+    for (int offset = 16; offset > 0; offset >>= 1)
+      _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
+    float warp_sum = _warp_reduce_0;
+    if (lane == 0) {
+      red[m_2 * 4 + warp] = warp_sum;
     }
-    asm volatile("griddepcontrol.launch_dependents;" ::: "memory");
+  }
+  asm volatile("barrier.sync 2, 128;" ::: "memory");
+  if (warp == 0) {
+    if (lane < 10) {
+      int m_3 = lane;
+      float total = red[m_3 * 4];
+#pragma unroll
+      for (int source_warp = 1; source_warp < 4; source_warp++) {
+        total = total + red[m_3 * 4 + source_warp];
+      }
+      int offset = m_3 * num_experts + expert;
+      if (out_is_bf16 == 0) {
+        *(reinterpret_cast<float*>(out_f32 + offset) + (0)) = total;
+      } else {
+        *(reinterpret_cast<__nv_bfloat16*>(out_bf16 + offset) + (0)) = __float2bfloat16_rn(total);
+      }
+    }
+  }
+  asm volatile("griddepcontrol.launch_dependents;" ::: "memory");
 }
 
-} // extern "C"
+}  // extern "C"

--- a/csrc/cake_router_gemm/cake_router_gemm_m10_k7168_device.cu
+++ b/csrc/cake_router_gemm/cake_router_gemm_m10_k7168_device.cu
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) 2026 by FlashInfer team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+typedef unsigned char      uint8_t;
+typedef unsigned short     uint16_t;
+typedef unsigned int       uint32_t;
+typedef unsigned long long uint64_t;
+typedef signed int         int32_t;
+typedef short int          int16_t;
+struct __align__(128) CakeTensorMap { uint64_t opaque[16]; };
+template <int N>
+struct __align__(128) CakeTensorMapPack { CakeTensorMap maps[N]; };
+
+typedef struct __align__(64) { uint64_t opaque[16]; } CUtensorMap;
+
+#include <cuda_bf16.h>
+
+__device__ __forceinline__ int make_warp_uniform(int x) {
+    int result;
+    asm volatile("shfl.sync.idx.b32 %0, %1, 0, 0x1F, 0xFFFFFFFF;"
+                 : "=r"(result) : "r"(x));
+    return result;
+}
+
+#define CAKE_INF CUDART_INF_F
+#define NUM_MAIN_STAGES 1
+#define SMEM_RED_OFF 0
+#define SMEM_RED_STAGE_BYTES 160
+#define SMEM_RED_STRIDE 160
+#define SMEM_TOTAL 256
+#define THREADS 128
+
+#include <math_constants.h>
+
+extern "C" {
+
+__global__ __launch_bounds__(128, 1) void
+kernel_cake_blackwell_router_gemm_m10_k7168(__nv_bfloat16* __restrict__ mat_a, __nv_bfloat16* __restrict__ mat_b, float* __restrict__ out_f32, __nv_bfloat16* __restrict__ out_bf16, int num_experts, int out_is_bf16)
+{
+    const int tid = threadIdx.x;
+    const int warp = make_warp_uniform(tid / 32);
+    const int lane = tid % 32;
+
+    extern __shared__ __align__(1024) char smem_raw[];
+    int smem;
+    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+
+    const int bid = blockIdx.x;
+    const int num_bids = gridDim.x;
+
+    // Kernel setup ops
+    float* red = reinterpret_cast<float*>(smem_raw + 0);
+    const int red_addr = smem + 0;
+
+    // === Task calls (dependency order) ===
+    int expert = blockIdx.x;
+    float acc[10];
+    #pragma unroll
+    for (int m = 0; m < 10; m++) {
+        acc[m] = 0.0f;
+    }
+    asm volatile("griddepcontrol.wait;" ::: "memory");
+    #pragma unroll
+    for (int ki = 0; ki < 7; ki++) {
+        int k_base = ki * 1024 + tid * 8;
+        float _vec_load_0[8];
+        {
+            const uint4* _vptr_0 = reinterpret_cast<const uint4*>(mat_b + (expert * 7168 + k_base) + 0);
+            uint4 _vld_0[1];
+            #pragma unroll
+            for (int _blk = 0; _blk < 1; _blk++) {
+                _vld_0[_blk] = _vptr_0[_blk];
+                uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
+                #pragma unroll
+                for (int _pair = 0; _pair < 4; _pair++) {
+                    asm volatile(
+                        "{\n\t"
+                        "shl.b32 %0, %2, 16;\n\t"
+                        "and.b32 %1, %2, 0xffff0000;\n\t"
+                        "}\n"
+                        : "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[1])
+                        : "r"(_vpairs_0[_pair]));
+                }
+            }
+        }
+        #pragma unroll
+        for (int m_1 = 0; m_1 < 10; m_1++) {
+            float _vec_load_1[8];
+            {
+                const uint4* _vptr_1 = reinterpret_cast<const uint4*>(mat_a + (m_1 * 7168 + k_base) + 0);
+                uint4 _vld_1[1];
+                #pragma unroll
+                for (int _blk = 0; _blk < 1; _blk++) {
+                    _vld_1[_blk] = _vptr_1[_blk];
+                    uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
+                    #pragma unroll
+                    for (int _pair = 0; _pair < 4; _pair++) {
+                        asm volatile(
+                            "{\n\t"
+                            "shl.b32 %0, %2, 16;\n\t"
+                            "and.b32 %1, %2, 0xffff0000;\n\t"
+                            "}\n"
+                            : "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[1])
+                            : "r"(_vpairs_1[_pair]));
+                    }
+                }
+            }
+            #pragma unroll
+            for (int j = 0; j < 8; j++) {
+                float _fma_0 = __fmaf_rn(_vec_load_1[j], _vec_load_0[j], acc[m_1]);
+                acc[m_1] = _fma_0;
+            }
+        }
+    }
+    #pragma unroll
+    for (int m_2 = 0; m_2 < 10; m_2++) {
+        float _warp_reduce_0 = acc[m_2];
+        #pragma unroll
+        for (int offset = 16; offset > 0; offset >>= 1)
+            _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
+        float warp_sum = _warp_reduce_0;
+        if (lane == 0) {
+            red[m_2 * 4 + warp] = warp_sum;
+        }
+    }
+    asm volatile("barrier.sync 2, 128;" ::: "memory");
+    if (warp == 0) {
+        if (lane < 10) {
+            int m_3 = lane;
+            float total = red[m_3 * 4];
+            #pragma unroll
+            for (int source_warp = 1; source_warp < 4; source_warp++) {
+                total = total + red[m_3 * 4 + source_warp];
+            }
+            int offset = m_3 * num_experts + expert;
+            if (out_is_bf16 == 0) {
+                *(reinterpret_cast<float*>(out_f32 + offset) + (0)) = total;
+            } else {
+                *(reinterpret_cast<__nv_bfloat16*>(out_bf16 + offset) + (0)) = __float2bfloat16_rn(total);
+            }
+        }
+    }
+    asm volatile("griddepcontrol.launch_dependents;" ::: "memory");
+}
+
+} // extern "C"

--- a/csrc/cake_router_gemm/cake_router_gemm_m11_k6144_device.cu
+++ b/csrc/cake_router_gemm/cake_router_gemm_m11_k6144_device.cu
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) 2026 by FlashInfer team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+typedef unsigned char      uint8_t;
+typedef unsigned short     uint16_t;
+typedef unsigned int       uint32_t;
+typedef unsigned long long uint64_t;
+typedef signed int         int32_t;
+typedef short int          int16_t;
+struct __align__(128) CakeTensorMap { uint64_t opaque[16]; };
+template <int N>
+struct __align__(128) CakeTensorMapPack { CakeTensorMap maps[N]; };
+
+typedef struct __align__(64) { uint64_t opaque[16]; } CUtensorMap;
+
+#include <cuda_bf16.h>
+
+__device__ __forceinline__ int make_warp_uniform(int x) {
+    int result;
+    asm volatile("shfl.sync.idx.b32 %0, %1, 0, 0x1F, 0xFFFFFFFF;"
+                 : "=r"(result) : "r"(x));
+    return result;
+}
+
+#define CAKE_INF CUDART_INF_F
+#define NUM_MAIN_STAGES 1
+#define SMEM_RED_OFF 0
+#define SMEM_RED_STAGE_BYTES 176
+#define SMEM_RED_STRIDE 176
+#define SMEM_TOTAL 256
+#define THREADS 128
+
+#include <math_constants.h>
+
+extern "C" {
+
+__global__ __launch_bounds__(128, 1) void
+kernel_cake_blackwell_router_gemm_m11_k6144(__nv_bfloat16* __restrict__ mat_a, __nv_bfloat16* __restrict__ mat_b, float* __restrict__ out_f32, __nv_bfloat16* __restrict__ out_bf16, int num_experts, int out_is_bf16)
+{
+    const int tid = threadIdx.x;
+    const int warp = make_warp_uniform(tid / 32);
+    const int lane = tid % 32;
+
+    extern __shared__ __align__(1024) char smem_raw[];
+    int smem;
+    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+
+    const int bid = blockIdx.x;
+    const int num_bids = gridDim.x;
+
+    // Kernel setup ops
+    float* red = reinterpret_cast<float*>(smem_raw + 0);
+    const int red_addr = smem + 0;
+
+    // === Task calls (dependency order) ===
+    int expert = blockIdx.x;
+    float acc[11];
+    #pragma unroll
+    for (int m = 0; m < 11; m++) {
+        acc[m] = 0.0f;
+    }
+    asm volatile("griddepcontrol.wait;" ::: "memory");
+    #pragma unroll
+    for (int ki = 0; ki < 6; ki++) {
+        int k_base = ki * 1024 + tid * 8;
+        float _vec_load_0[8];
+        {
+            const uint4* _vptr_0 = reinterpret_cast<const uint4*>(mat_b + (expert * 6144 + k_base) + 0);
+            uint4 _vld_0[1];
+            #pragma unroll
+            for (int _blk = 0; _blk < 1; _blk++) {
+                _vld_0[_blk] = _vptr_0[_blk];
+                uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
+                #pragma unroll
+                for (int _pair = 0; _pair < 4; _pair++) {
+                    asm volatile(
+                        "{\n\t"
+                        "shl.b32 %0, %2, 16;\n\t"
+                        "and.b32 %1, %2, 0xffff0000;\n\t"
+                        "}\n"
+                        : "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[1])
+                        : "r"(_vpairs_0[_pair]));
+                }
+            }
+        }
+        #pragma unroll
+        for (int m_1 = 0; m_1 < 11; m_1++) {
+            float _vec_load_1[8];
+            {
+                const uint4* _vptr_1 = reinterpret_cast<const uint4*>(mat_a + (m_1 * 6144 + k_base) + 0);
+                uint4 _vld_1[1];
+                #pragma unroll
+                for (int _blk = 0; _blk < 1; _blk++) {
+                    _vld_1[_blk] = _vptr_1[_blk];
+                    uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
+                    #pragma unroll
+                    for (int _pair = 0; _pair < 4; _pair++) {
+                        asm volatile(
+                            "{\n\t"
+                            "shl.b32 %0, %2, 16;\n\t"
+                            "and.b32 %1, %2, 0xffff0000;\n\t"
+                            "}\n"
+                            : "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[1])
+                            : "r"(_vpairs_1[_pair]));
+                    }
+                }
+            }
+            #pragma unroll
+            for (int j = 0; j < 8; j++) {
+                float _fma_0 = __fmaf_rn(_vec_load_1[j], _vec_load_0[j], acc[m_1]);
+                acc[m_1] = _fma_0;
+            }
+        }
+    }
+    #pragma unroll
+    for (int m_2 = 0; m_2 < 11; m_2++) {
+        float _warp_reduce_0 = acc[m_2];
+        #pragma unroll
+        for (int offset = 16; offset > 0; offset >>= 1)
+            _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
+        float warp_sum = _warp_reduce_0;
+        if (lane == 0) {
+            red[m_2 * 4 + warp] = warp_sum;
+        }
+    }
+    asm volatile("barrier.sync 2, 128;" ::: "memory");
+    if (warp == 0) {
+        if (lane < 11) {
+            int m_3 = lane;
+            float total = red[m_3 * 4];
+            #pragma unroll
+            for (int source_warp = 1; source_warp < 4; source_warp++) {
+                total = total + red[m_3 * 4 + source_warp];
+            }
+            int offset = m_3 * num_experts + expert;
+            if (out_is_bf16 == 0) {
+                *(reinterpret_cast<float*>(out_f32 + offset) + (0)) = total;
+            } else {
+                *(reinterpret_cast<__nv_bfloat16*>(out_bf16 + offset) + (0)) = __float2bfloat16_rn(total);
+            }
+        }
+    }
+    asm volatile("griddepcontrol.launch_dependents;" ::: "memory");
+}
+
+} // extern "C"

--- a/csrc/cake_router_gemm/cake_router_gemm_m11_k6144_device.cu
+++ b/csrc/cake_router_gemm/cake_router_gemm_m11_k6144_device.cu
@@ -14,25 +14,30 @@
  * limitations under the License.
  */
 
-typedef unsigned char      uint8_t;
-typedef unsigned short     uint16_t;
-typedef unsigned int       uint32_t;
+typedef unsigned char uint8_t;
+typedef unsigned short uint16_t;
+typedef unsigned int uint32_t;
 typedef unsigned long long uint64_t;
-typedef signed int         int32_t;
-typedef short int          int16_t;
-struct __align__(128) CakeTensorMap { uint64_t opaque[16]; };
+typedef signed int int32_t;
+typedef short int int16_t;
+struct __align__(128) CakeTensorMap {
+  uint64_t opaque[16];
+};
 template <int N>
-struct __align__(128) CakeTensorMapPack { CakeTensorMap maps[N]; };
+struct __align__(128) CakeTensorMapPack {
+  CakeTensorMap maps[N];
+};
 
-typedef struct __align__(64) { uint64_t opaque[16]; } CUtensorMap;
+typedef struct __align__(64) {
+  uint64_t opaque[16];
+} CUtensorMap;
 
 #include <cuda_bf16.h>
 
 __device__ __forceinline__ int make_warp_uniform(int x) {
-    int result;
-    asm volatile("shfl.sync.idx.b32 %0, %1, 0, 0x1F, 0xFFFFFFFF;"
-                 : "=r"(result) : "r"(x));
-    return result;
+  int result;
+  asm volatile("shfl.sync.idx.b32 %0, %1, 0, 0x1F, 0xFFFFFFFF;" : "=r"(result) : "r"(x));
+  return result;
 }
 
 #define CAKE_INF CUDART_INF_F
@@ -47,113 +52,116 @@ __device__ __forceinline__ int make_warp_uniform(int x) {
 
 extern "C" {
 
-__global__ __launch_bounds__(128, 1) void
-kernel_cake_blackwell_router_gemm_m11_k6144(__nv_bfloat16* __restrict__ mat_a, __nv_bfloat16* __restrict__ mat_b, float* __restrict__ out_f32, __nv_bfloat16* __restrict__ out_bf16, int num_experts, int out_is_bf16)
-{
-    const int tid = threadIdx.x;
-    const int warp = make_warp_uniform(tid / 32);
-    const int lane = tid % 32;
+__global__ __launch_bounds__(128, 1) void kernel_cake_blackwell_router_gemm_m11_k6144(
+    __nv_bfloat16* __restrict__ mat_a, __nv_bfloat16* __restrict__ mat_b,
+    float* __restrict__ out_f32, __nv_bfloat16* __restrict__ out_bf16, int num_experts,
+    int out_is_bf16) {
+  const int tid = threadIdx.x;
+  const int warp = make_warp_uniform(tid / 32);
+  const int lane = tid % 32;
 
-    extern __shared__ __align__(1024) char smem_raw[];
-    int smem;
-    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+  extern __shared__ __align__(1024) char smem_raw[];
+  int smem;
+  smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
 
-    const int bid = blockIdx.x;
-    const int num_bids = gridDim.x;
+  const int bid = blockIdx.x;
+  const int num_bids = gridDim.x;
 
-    // Kernel setup ops
-    float* red = reinterpret_cast<float*>(smem_raw + 0);
-    const int red_addr = smem + 0;
+  // Kernel setup ops
+  float* red = reinterpret_cast<float*>(smem_raw + 0);
+  const int red_addr = smem + 0;
 
-    // === Task calls (dependency order) ===
-    int expert = blockIdx.x;
-    float acc[11];
-    #pragma unroll
-    for (int m = 0; m < 11; m++) {
-        acc[m] = 0.0f;
-    }
-    asm volatile("griddepcontrol.wait;" ::: "memory");
-    #pragma unroll
-    for (int ki = 0; ki < 6; ki++) {
-        int k_base = ki * 1024 + tid * 8;
-        float _vec_load_0[8];
-        {
-            const uint4* _vptr_0 = reinterpret_cast<const uint4*>(mat_b + (expert * 6144 + k_base) + 0);
-            uint4 _vld_0[1];
-            #pragma unroll
-            for (int _blk = 0; _blk < 1; _blk++) {
-                _vld_0[_blk] = _vptr_0[_blk];
-                uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
-                #pragma unroll
-                for (int _pair = 0; _pair < 4; _pair++) {
-                    asm volatile(
-                        "{\n\t"
-                        "shl.b32 %0, %2, 16;\n\t"
-                        "and.b32 %1, %2, 0xffff0000;\n\t"
-                        "}\n"
-                        : "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[1])
-                        : "r"(_vpairs_0[_pair]));
-                }
-            }
+  // === Task calls (dependency order) ===
+  int expert = blockIdx.x;
+  float acc[11];
+#pragma unroll
+  for (int m = 0; m < 11; m++) {
+    acc[m] = 0.0f;
+  }
+  asm volatile("griddepcontrol.wait;" ::: "memory");
+#pragma unroll
+  for (int ki = 0; ki < 6; ki++) {
+    int k_base = ki * 1024 + tid * 8;
+    float _vec_load_0[8];
+    {
+      const uint4* _vptr_0 = reinterpret_cast<const uint4*>(mat_b + (expert * 6144 + k_base) + 0);
+      uint4 _vld_0[1];
+#pragma unroll
+      for (int _blk = 0; _blk < 1; _blk++) {
+        _vld_0[_blk] = _vptr_0[_blk];
+        uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
+#pragma unroll
+        for (int _pair = 0; _pair < 4; _pair++) {
+          asm volatile(
+              "{\n\t"
+              "shl.b32 %0, %2, 16;\n\t"
+              "and.b32 %1, %2, 0xffff0000;\n\t"
+              "}\n"
+              : "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[0]),
+                "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[1])
+              : "r"(_vpairs_0[_pair]));
         }
-        #pragma unroll
-        for (int m_1 = 0; m_1 < 11; m_1++) {
-            float _vec_load_1[8];
-            {
-                const uint4* _vptr_1 = reinterpret_cast<const uint4*>(mat_a + (m_1 * 6144 + k_base) + 0);
-                uint4 _vld_1[1];
-                #pragma unroll
-                for (int _blk = 0; _blk < 1; _blk++) {
-                    _vld_1[_blk] = _vptr_1[_blk];
-                    uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
-                    #pragma unroll
-                    for (int _pair = 0; _pair < 4; _pair++) {
-                        asm volatile(
-                            "{\n\t"
-                            "shl.b32 %0, %2, 16;\n\t"
-                            "and.b32 %1, %2, 0xffff0000;\n\t"
-                            "}\n"
-                            : "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[1])
-                            : "r"(_vpairs_1[_pair]));
-                    }
-                }
-            }
-            #pragma unroll
-            for (int j = 0; j < 8; j++) {
-                float _fma_0 = __fmaf_rn(_vec_load_1[j], _vec_load_0[j], acc[m_1]);
-                acc[m_1] = _fma_0;
-            }
-        }
+      }
     }
-    #pragma unroll
-    for (int m_2 = 0; m_2 < 11; m_2++) {
-        float _warp_reduce_0 = acc[m_2];
-        #pragma unroll
-        for (int offset = 16; offset > 0; offset >>= 1)
-            _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
-        float warp_sum = _warp_reduce_0;
-        if (lane == 0) {
-            red[m_2 * 4 + warp] = warp_sum;
+#pragma unroll
+    for (int m_1 = 0; m_1 < 11; m_1++) {
+      float _vec_load_1[8];
+      {
+        const uint4* _vptr_1 = reinterpret_cast<const uint4*>(mat_a + (m_1 * 6144 + k_base) + 0);
+        uint4 _vld_1[1];
+#pragma unroll
+        for (int _blk = 0; _blk < 1; _blk++) {
+          _vld_1[_blk] = _vptr_1[_blk];
+          uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
+#pragma unroll
+          for (int _pair = 0; _pair < 4; _pair++) {
+            asm volatile(
+                "{\n\t"
+                "shl.b32 %0, %2, 16;\n\t"
+                "and.b32 %1, %2, 0xffff0000;\n\t"
+                "}\n"
+                : "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[0]),
+                  "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[1])
+                : "r"(_vpairs_1[_pair]));
+          }
         }
+      }
+#pragma unroll
+      for (int j = 0; j < 8; j++) {
+        float _fma_0 = __fmaf_rn(_vec_load_1[j], _vec_load_0[j], acc[m_1]);
+        acc[m_1] = _fma_0;
+      }
     }
-    asm volatile("barrier.sync 2, 128;" ::: "memory");
-    if (warp == 0) {
-        if (lane < 11) {
-            int m_3 = lane;
-            float total = red[m_3 * 4];
-            #pragma unroll
-            for (int source_warp = 1; source_warp < 4; source_warp++) {
-                total = total + red[m_3 * 4 + source_warp];
-            }
-            int offset = m_3 * num_experts + expert;
-            if (out_is_bf16 == 0) {
-                *(reinterpret_cast<float*>(out_f32 + offset) + (0)) = total;
-            } else {
-                *(reinterpret_cast<__nv_bfloat16*>(out_bf16 + offset) + (0)) = __float2bfloat16_rn(total);
-            }
-        }
+  }
+#pragma unroll
+  for (int m_2 = 0; m_2 < 11; m_2++) {
+    float _warp_reduce_0 = acc[m_2];
+#pragma unroll
+    for (int offset = 16; offset > 0; offset >>= 1)
+      _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
+    float warp_sum = _warp_reduce_0;
+    if (lane == 0) {
+      red[m_2 * 4 + warp] = warp_sum;
     }
-    asm volatile("griddepcontrol.launch_dependents;" ::: "memory");
+  }
+  asm volatile("barrier.sync 2, 128;" ::: "memory");
+  if (warp == 0) {
+    if (lane < 11) {
+      int m_3 = lane;
+      float total = red[m_3 * 4];
+#pragma unroll
+      for (int source_warp = 1; source_warp < 4; source_warp++) {
+        total = total + red[m_3 * 4 + source_warp];
+      }
+      int offset = m_3 * num_experts + expert;
+      if (out_is_bf16 == 0) {
+        *(reinterpret_cast<float*>(out_f32 + offset) + (0)) = total;
+      } else {
+        *(reinterpret_cast<__nv_bfloat16*>(out_bf16 + offset) + (0)) = __float2bfloat16_rn(total);
+      }
+    }
+  }
+  asm volatile("griddepcontrol.launch_dependents;" ::: "memory");
 }
 
-} // extern "C"
+}  // extern "C"

--- a/csrc/cake_router_gemm/cake_router_gemm_m11_k7168_device.cu
+++ b/csrc/cake_router_gemm/cake_router_gemm_m11_k7168_device.cu
@@ -14,25 +14,30 @@
  * limitations under the License.
  */
 
-typedef unsigned char      uint8_t;
-typedef unsigned short     uint16_t;
-typedef unsigned int       uint32_t;
+typedef unsigned char uint8_t;
+typedef unsigned short uint16_t;
+typedef unsigned int uint32_t;
 typedef unsigned long long uint64_t;
-typedef signed int         int32_t;
-typedef short int          int16_t;
-struct __align__(128) CakeTensorMap { uint64_t opaque[16]; };
+typedef signed int int32_t;
+typedef short int int16_t;
+struct __align__(128) CakeTensorMap {
+  uint64_t opaque[16];
+};
 template <int N>
-struct __align__(128) CakeTensorMapPack { CakeTensorMap maps[N]; };
+struct __align__(128) CakeTensorMapPack {
+  CakeTensorMap maps[N];
+};
 
-typedef struct __align__(64) { uint64_t opaque[16]; } CUtensorMap;
+typedef struct __align__(64) {
+  uint64_t opaque[16];
+} CUtensorMap;
 
 #include <cuda_bf16.h>
 
 __device__ __forceinline__ int make_warp_uniform(int x) {
-    int result;
-    asm volatile("shfl.sync.idx.b32 %0, %1, 0, 0x1F, 0xFFFFFFFF;"
-                 : "=r"(result) : "r"(x));
-    return result;
+  int result;
+  asm volatile("shfl.sync.idx.b32 %0, %1, 0, 0x1F, 0xFFFFFFFF;" : "=r"(result) : "r"(x));
+  return result;
 }
 
 #define CAKE_INF CUDART_INF_F
@@ -47,113 +52,116 @@ __device__ __forceinline__ int make_warp_uniform(int x) {
 
 extern "C" {
 
-__global__ __launch_bounds__(128, 1) void
-kernel_cake_blackwell_router_gemm_m11_k7168(__nv_bfloat16* __restrict__ mat_a, __nv_bfloat16* __restrict__ mat_b, float* __restrict__ out_f32, __nv_bfloat16* __restrict__ out_bf16, int num_experts, int out_is_bf16)
-{
-    const int tid = threadIdx.x;
-    const int warp = make_warp_uniform(tid / 32);
-    const int lane = tid % 32;
+__global__ __launch_bounds__(128, 1) void kernel_cake_blackwell_router_gemm_m11_k7168(
+    __nv_bfloat16* __restrict__ mat_a, __nv_bfloat16* __restrict__ mat_b,
+    float* __restrict__ out_f32, __nv_bfloat16* __restrict__ out_bf16, int num_experts,
+    int out_is_bf16) {
+  const int tid = threadIdx.x;
+  const int warp = make_warp_uniform(tid / 32);
+  const int lane = tid % 32;
 
-    extern __shared__ __align__(1024) char smem_raw[];
-    int smem;
-    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+  extern __shared__ __align__(1024) char smem_raw[];
+  int smem;
+  smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
 
-    const int bid = blockIdx.x;
-    const int num_bids = gridDim.x;
+  const int bid = blockIdx.x;
+  const int num_bids = gridDim.x;
 
-    // Kernel setup ops
-    float* red = reinterpret_cast<float*>(smem_raw + 0);
-    const int red_addr = smem + 0;
+  // Kernel setup ops
+  float* red = reinterpret_cast<float*>(smem_raw + 0);
+  const int red_addr = smem + 0;
 
-    // === Task calls (dependency order) ===
-    int expert = blockIdx.x;
-    float acc[11];
-    #pragma unroll
-    for (int m = 0; m < 11; m++) {
-        acc[m] = 0.0f;
-    }
-    asm volatile("griddepcontrol.wait;" ::: "memory");
-    #pragma unroll
-    for (int ki = 0; ki < 7; ki++) {
-        int k_base = ki * 1024 + tid * 8;
-        float _vec_load_0[8];
-        {
-            const uint4* _vptr_0 = reinterpret_cast<const uint4*>(mat_b + (expert * 7168 + k_base) + 0);
-            uint4 _vld_0[1];
-            #pragma unroll
-            for (int _blk = 0; _blk < 1; _blk++) {
-                _vld_0[_blk] = _vptr_0[_blk];
-                uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
-                #pragma unroll
-                for (int _pair = 0; _pair < 4; _pair++) {
-                    asm volatile(
-                        "{\n\t"
-                        "shl.b32 %0, %2, 16;\n\t"
-                        "and.b32 %1, %2, 0xffff0000;\n\t"
-                        "}\n"
-                        : "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[1])
-                        : "r"(_vpairs_0[_pair]));
-                }
-            }
+  // === Task calls (dependency order) ===
+  int expert = blockIdx.x;
+  float acc[11];
+#pragma unroll
+  for (int m = 0; m < 11; m++) {
+    acc[m] = 0.0f;
+  }
+  asm volatile("griddepcontrol.wait;" ::: "memory");
+#pragma unroll
+  for (int ki = 0; ki < 7; ki++) {
+    int k_base = ki * 1024 + tid * 8;
+    float _vec_load_0[8];
+    {
+      const uint4* _vptr_0 = reinterpret_cast<const uint4*>(mat_b + (expert * 7168 + k_base) + 0);
+      uint4 _vld_0[1];
+#pragma unroll
+      for (int _blk = 0; _blk < 1; _blk++) {
+        _vld_0[_blk] = _vptr_0[_blk];
+        uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
+#pragma unroll
+        for (int _pair = 0; _pair < 4; _pair++) {
+          asm volatile(
+              "{\n\t"
+              "shl.b32 %0, %2, 16;\n\t"
+              "and.b32 %1, %2, 0xffff0000;\n\t"
+              "}\n"
+              : "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[0]),
+                "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[1])
+              : "r"(_vpairs_0[_pair]));
         }
-        #pragma unroll
-        for (int m_1 = 0; m_1 < 11; m_1++) {
-            float _vec_load_1[8];
-            {
-                const uint4* _vptr_1 = reinterpret_cast<const uint4*>(mat_a + (m_1 * 7168 + k_base) + 0);
-                uint4 _vld_1[1];
-                #pragma unroll
-                for (int _blk = 0; _blk < 1; _blk++) {
-                    _vld_1[_blk] = _vptr_1[_blk];
-                    uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
-                    #pragma unroll
-                    for (int _pair = 0; _pair < 4; _pair++) {
-                        asm volatile(
-                            "{\n\t"
-                            "shl.b32 %0, %2, 16;\n\t"
-                            "and.b32 %1, %2, 0xffff0000;\n\t"
-                            "}\n"
-                            : "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[1])
-                            : "r"(_vpairs_1[_pair]));
-                    }
-                }
-            }
-            #pragma unroll
-            for (int j = 0; j < 8; j++) {
-                float _fma_0 = __fmaf_rn(_vec_load_1[j], _vec_load_0[j], acc[m_1]);
-                acc[m_1] = _fma_0;
-            }
-        }
+      }
     }
-    #pragma unroll
-    for (int m_2 = 0; m_2 < 11; m_2++) {
-        float _warp_reduce_0 = acc[m_2];
-        #pragma unroll
-        for (int offset = 16; offset > 0; offset >>= 1)
-            _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
-        float warp_sum = _warp_reduce_0;
-        if (lane == 0) {
-            red[m_2 * 4 + warp] = warp_sum;
+#pragma unroll
+    for (int m_1 = 0; m_1 < 11; m_1++) {
+      float _vec_load_1[8];
+      {
+        const uint4* _vptr_1 = reinterpret_cast<const uint4*>(mat_a + (m_1 * 7168 + k_base) + 0);
+        uint4 _vld_1[1];
+#pragma unroll
+        for (int _blk = 0; _blk < 1; _blk++) {
+          _vld_1[_blk] = _vptr_1[_blk];
+          uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
+#pragma unroll
+          for (int _pair = 0; _pair < 4; _pair++) {
+            asm volatile(
+                "{\n\t"
+                "shl.b32 %0, %2, 16;\n\t"
+                "and.b32 %1, %2, 0xffff0000;\n\t"
+                "}\n"
+                : "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[0]),
+                  "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[1])
+                : "r"(_vpairs_1[_pair]));
+          }
         }
+      }
+#pragma unroll
+      for (int j = 0; j < 8; j++) {
+        float _fma_0 = __fmaf_rn(_vec_load_1[j], _vec_load_0[j], acc[m_1]);
+        acc[m_1] = _fma_0;
+      }
     }
-    asm volatile("barrier.sync 2, 128;" ::: "memory");
-    if (warp == 0) {
-        if (lane < 11) {
-            int m_3 = lane;
-            float total = red[m_3 * 4];
-            #pragma unroll
-            for (int source_warp = 1; source_warp < 4; source_warp++) {
-                total = total + red[m_3 * 4 + source_warp];
-            }
-            int offset = m_3 * num_experts + expert;
-            if (out_is_bf16 == 0) {
-                *(reinterpret_cast<float*>(out_f32 + offset) + (0)) = total;
-            } else {
-                *(reinterpret_cast<__nv_bfloat16*>(out_bf16 + offset) + (0)) = __float2bfloat16_rn(total);
-            }
-        }
+  }
+#pragma unroll
+  for (int m_2 = 0; m_2 < 11; m_2++) {
+    float _warp_reduce_0 = acc[m_2];
+#pragma unroll
+    for (int offset = 16; offset > 0; offset >>= 1)
+      _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
+    float warp_sum = _warp_reduce_0;
+    if (lane == 0) {
+      red[m_2 * 4 + warp] = warp_sum;
     }
-    asm volatile("griddepcontrol.launch_dependents;" ::: "memory");
+  }
+  asm volatile("barrier.sync 2, 128;" ::: "memory");
+  if (warp == 0) {
+    if (lane < 11) {
+      int m_3 = lane;
+      float total = red[m_3 * 4];
+#pragma unroll
+      for (int source_warp = 1; source_warp < 4; source_warp++) {
+        total = total + red[m_3 * 4 + source_warp];
+      }
+      int offset = m_3 * num_experts + expert;
+      if (out_is_bf16 == 0) {
+        *(reinterpret_cast<float*>(out_f32 + offset) + (0)) = total;
+      } else {
+        *(reinterpret_cast<__nv_bfloat16*>(out_bf16 + offset) + (0)) = __float2bfloat16_rn(total);
+      }
+    }
+  }
+  asm volatile("griddepcontrol.launch_dependents;" ::: "memory");
 }
 
-} // extern "C"
+}  // extern "C"

--- a/csrc/cake_router_gemm/cake_router_gemm_m11_k7168_device.cu
+++ b/csrc/cake_router_gemm/cake_router_gemm_m11_k7168_device.cu
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) 2026 by FlashInfer team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+typedef unsigned char      uint8_t;
+typedef unsigned short     uint16_t;
+typedef unsigned int       uint32_t;
+typedef unsigned long long uint64_t;
+typedef signed int         int32_t;
+typedef short int          int16_t;
+struct __align__(128) CakeTensorMap { uint64_t opaque[16]; };
+template <int N>
+struct __align__(128) CakeTensorMapPack { CakeTensorMap maps[N]; };
+
+typedef struct __align__(64) { uint64_t opaque[16]; } CUtensorMap;
+
+#include <cuda_bf16.h>
+
+__device__ __forceinline__ int make_warp_uniform(int x) {
+    int result;
+    asm volatile("shfl.sync.idx.b32 %0, %1, 0, 0x1F, 0xFFFFFFFF;"
+                 : "=r"(result) : "r"(x));
+    return result;
+}
+
+#define CAKE_INF CUDART_INF_F
+#define NUM_MAIN_STAGES 1
+#define SMEM_RED_OFF 0
+#define SMEM_RED_STAGE_BYTES 176
+#define SMEM_RED_STRIDE 176
+#define SMEM_TOTAL 256
+#define THREADS 128
+
+#include <math_constants.h>
+
+extern "C" {
+
+__global__ __launch_bounds__(128, 1) void
+kernel_cake_blackwell_router_gemm_m11_k7168(__nv_bfloat16* __restrict__ mat_a, __nv_bfloat16* __restrict__ mat_b, float* __restrict__ out_f32, __nv_bfloat16* __restrict__ out_bf16, int num_experts, int out_is_bf16)
+{
+    const int tid = threadIdx.x;
+    const int warp = make_warp_uniform(tid / 32);
+    const int lane = tid % 32;
+
+    extern __shared__ __align__(1024) char smem_raw[];
+    int smem;
+    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+
+    const int bid = blockIdx.x;
+    const int num_bids = gridDim.x;
+
+    // Kernel setup ops
+    float* red = reinterpret_cast<float*>(smem_raw + 0);
+    const int red_addr = smem + 0;
+
+    // === Task calls (dependency order) ===
+    int expert = blockIdx.x;
+    float acc[11];
+    #pragma unroll
+    for (int m = 0; m < 11; m++) {
+        acc[m] = 0.0f;
+    }
+    asm volatile("griddepcontrol.wait;" ::: "memory");
+    #pragma unroll
+    for (int ki = 0; ki < 7; ki++) {
+        int k_base = ki * 1024 + tid * 8;
+        float _vec_load_0[8];
+        {
+            const uint4* _vptr_0 = reinterpret_cast<const uint4*>(mat_b + (expert * 7168 + k_base) + 0);
+            uint4 _vld_0[1];
+            #pragma unroll
+            for (int _blk = 0; _blk < 1; _blk++) {
+                _vld_0[_blk] = _vptr_0[_blk];
+                uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
+                #pragma unroll
+                for (int _pair = 0; _pair < 4; _pair++) {
+                    asm volatile(
+                        "{\n\t"
+                        "shl.b32 %0, %2, 16;\n\t"
+                        "and.b32 %1, %2, 0xffff0000;\n\t"
+                        "}\n"
+                        : "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[1])
+                        : "r"(_vpairs_0[_pair]));
+                }
+            }
+        }
+        #pragma unroll
+        for (int m_1 = 0; m_1 < 11; m_1++) {
+            float _vec_load_1[8];
+            {
+                const uint4* _vptr_1 = reinterpret_cast<const uint4*>(mat_a + (m_1 * 7168 + k_base) + 0);
+                uint4 _vld_1[1];
+                #pragma unroll
+                for (int _blk = 0; _blk < 1; _blk++) {
+                    _vld_1[_blk] = _vptr_1[_blk];
+                    uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
+                    #pragma unroll
+                    for (int _pair = 0; _pair < 4; _pair++) {
+                        asm volatile(
+                            "{\n\t"
+                            "shl.b32 %0, %2, 16;\n\t"
+                            "and.b32 %1, %2, 0xffff0000;\n\t"
+                            "}\n"
+                            : "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[1])
+                            : "r"(_vpairs_1[_pair]));
+                    }
+                }
+            }
+            #pragma unroll
+            for (int j = 0; j < 8; j++) {
+                float _fma_0 = __fmaf_rn(_vec_load_1[j], _vec_load_0[j], acc[m_1]);
+                acc[m_1] = _fma_0;
+            }
+        }
+    }
+    #pragma unroll
+    for (int m_2 = 0; m_2 < 11; m_2++) {
+        float _warp_reduce_0 = acc[m_2];
+        #pragma unroll
+        for (int offset = 16; offset > 0; offset >>= 1)
+            _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
+        float warp_sum = _warp_reduce_0;
+        if (lane == 0) {
+            red[m_2 * 4 + warp] = warp_sum;
+        }
+    }
+    asm volatile("barrier.sync 2, 128;" ::: "memory");
+    if (warp == 0) {
+        if (lane < 11) {
+            int m_3 = lane;
+            float total = red[m_3 * 4];
+            #pragma unroll
+            for (int source_warp = 1; source_warp < 4; source_warp++) {
+                total = total + red[m_3 * 4 + source_warp];
+            }
+            int offset = m_3 * num_experts + expert;
+            if (out_is_bf16 == 0) {
+                *(reinterpret_cast<float*>(out_f32 + offset) + (0)) = total;
+            } else {
+                *(reinterpret_cast<__nv_bfloat16*>(out_bf16 + offset) + (0)) = __float2bfloat16_rn(total);
+            }
+        }
+    }
+    asm volatile("griddepcontrol.launch_dependents;" ::: "memory");
+}
+
+} // extern "C"

--- a/csrc/cake_router_gemm/cake_router_gemm_m12_k6144_device.cu
+++ b/csrc/cake_router_gemm/cake_router_gemm_m12_k6144_device.cu
@@ -14,25 +14,30 @@
  * limitations under the License.
  */
 
-typedef unsigned char      uint8_t;
-typedef unsigned short     uint16_t;
-typedef unsigned int       uint32_t;
+typedef unsigned char uint8_t;
+typedef unsigned short uint16_t;
+typedef unsigned int uint32_t;
 typedef unsigned long long uint64_t;
-typedef signed int         int32_t;
-typedef short int          int16_t;
-struct __align__(128) CakeTensorMap { uint64_t opaque[16]; };
+typedef signed int int32_t;
+typedef short int int16_t;
+struct __align__(128) CakeTensorMap {
+  uint64_t opaque[16];
+};
 template <int N>
-struct __align__(128) CakeTensorMapPack { CakeTensorMap maps[N]; };
+struct __align__(128) CakeTensorMapPack {
+  CakeTensorMap maps[N];
+};
 
-typedef struct __align__(64) { uint64_t opaque[16]; } CUtensorMap;
+typedef struct __align__(64) {
+  uint64_t opaque[16];
+} CUtensorMap;
 
 #include <cuda_bf16.h>
 
 __device__ __forceinline__ int make_warp_uniform(int x) {
-    int result;
-    asm volatile("shfl.sync.idx.b32 %0, %1, 0, 0x1F, 0xFFFFFFFF;"
-                 : "=r"(result) : "r"(x));
-    return result;
+  int result;
+  asm volatile("shfl.sync.idx.b32 %0, %1, 0, 0x1F, 0xFFFFFFFF;" : "=r"(result) : "r"(x));
+  return result;
 }
 
 #define CAKE_INF CUDART_INF_F
@@ -47,113 +52,116 @@ __device__ __forceinline__ int make_warp_uniform(int x) {
 
 extern "C" {
 
-__global__ __launch_bounds__(128, 1) void
-kernel_cake_blackwell_router_gemm_m12_k6144(__nv_bfloat16* __restrict__ mat_a, __nv_bfloat16* __restrict__ mat_b, float* __restrict__ out_f32, __nv_bfloat16* __restrict__ out_bf16, int num_experts, int out_is_bf16)
-{
-    const int tid = threadIdx.x;
-    const int warp = make_warp_uniform(tid / 32);
-    const int lane = tid % 32;
+__global__ __launch_bounds__(128, 1) void kernel_cake_blackwell_router_gemm_m12_k6144(
+    __nv_bfloat16* __restrict__ mat_a, __nv_bfloat16* __restrict__ mat_b,
+    float* __restrict__ out_f32, __nv_bfloat16* __restrict__ out_bf16, int num_experts,
+    int out_is_bf16) {
+  const int tid = threadIdx.x;
+  const int warp = make_warp_uniform(tid / 32);
+  const int lane = tid % 32;
 
-    extern __shared__ __align__(1024) char smem_raw[];
-    int smem;
-    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+  extern __shared__ __align__(1024) char smem_raw[];
+  int smem;
+  smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
 
-    const int bid = blockIdx.x;
-    const int num_bids = gridDim.x;
+  const int bid = blockIdx.x;
+  const int num_bids = gridDim.x;
 
-    // Kernel setup ops
-    float* red = reinterpret_cast<float*>(smem_raw + 0);
-    const int red_addr = smem + 0;
+  // Kernel setup ops
+  float* red = reinterpret_cast<float*>(smem_raw + 0);
+  const int red_addr = smem + 0;
 
-    // === Task calls (dependency order) ===
-    int expert = blockIdx.x;
-    float acc[12];
-    #pragma unroll
-    for (int m = 0; m < 12; m++) {
-        acc[m] = 0.0f;
-    }
-    asm volatile("griddepcontrol.wait;" ::: "memory");
-    #pragma unroll
-    for (int ki = 0; ki < 6; ki++) {
-        int k_base = ki * 1024 + tid * 8;
-        float _vec_load_0[8];
-        {
-            const uint4* _vptr_0 = reinterpret_cast<const uint4*>(mat_b + (expert * 6144 + k_base) + 0);
-            uint4 _vld_0[1];
-            #pragma unroll
-            for (int _blk = 0; _blk < 1; _blk++) {
-                _vld_0[_blk] = _vptr_0[_blk];
-                uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
-                #pragma unroll
-                for (int _pair = 0; _pair < 4; _pair++) {
-                    asm volatile(
-                        "{\n\t"
-                        "shl.b32 %0, %2, 16;\n\t"
-                        "and.b32 %1, %2, 0xffff0000;\n\t"
-                        "}\n"
-                        : "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[1])
-                        : "r"(_vpairs_0[_pair]));
-                }
-            }
+  // === Task calls (dependency order) ===
+  int expert = blockIdx.x;
+  float acc[12];
+#pragma unroll
+  for (int m = 0; m < 12; m++) {
+    acc[m] = 0.0f;
+  }
+  asm volatile("griddepcontrol.wait;" ::: "memory");
+#pragma unroll
+  for (int ki = 0; ki < 6; ki++) {
+    int k_base = ki * 1024 + tid * 8;
+    float _vec_load_0[8];
+    {
+      const uint4* _vptr_0 = reinterpret_cast<const uint4*>(mat_b + (expert * 6144 + k_base) + 0);
+      uint4 _vld_0[1];
+#pragma unroll
+      for (int _blk = 0; _blk < 1; _blk++) {
+        _vld_0[_blk] = _vptr_0[_blk];
+        uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
+#pragma unroll
+        for (int _pair = 0; _pair < 4; _pair++) {
+          asm volatile(
+              "{\n\t"
+              "shl.b32 %0, %2, 16;\n\t"
+              "and.b32 %1, %2, 0xffff0000;\n\t"
+              "}\n"
+              : "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[0]),
+                "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[1])
+              : "r"(_vpairs_0[_pair]));
         }
-        #pragma unroll
-        for (int m_1 = 0; m_1 < 12; m_1++) {
-            float _vec_load_1[8];
-            {
-                const uint4* _vptr_1 = reinterpret_cast<const uint4*>(mat_a + (m_1 * 6144 + k_base) + 0);
-                uint4 _vld_1[1];
-                #pragma unroll
-                for (int _blk = 0; _blk < 1; _blk++) {
-                    _vld_1[_blk] = _vptr_1[_blk];
-                    uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
-                    #pragma unroll
-                    for (int _pair = 0; _pair < 4; _pair++) {
-                        asm volatile(
-                            "{\n\t"
-                            "shl.b32 %0, %2, 16;\n\t"
-                            "and.b32 %1, %2, 0xffff0000;\n\t"
-                            "}\n"
-                            : "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[1])
-                            : "r"(_vpairs_1[_pair]));
-                    }
-                }
-            }
-            #pragma unroll
-            for (int j = 0; j < 8; j++) {
-                float _fma_0 = __fmaf_rn(_vec_load_1[j], _vec_load_0[j], acc[m_1]);
-                acc[m_1] = _fma_0;
-            }
-        }
+      }
     }
-    #pragma unroll
-    for (int m_2 = 0; m_2 < 12; m_2++) {
-        float _warp_reduce_0 = acc[m_2];
-        #pragma unroll
-        for (int offset = 16; offset > 0; offset >>= 1)
-            _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
-        float warp_sum = _warp_reduce_0;
-        if (lane == 0) {
-            red[m_2 * 4 + warp] = warp_sum;
+#pragma unroll
+    for (int m_1 = 0; m_1 < 12; m_1++) {
+      float _vec_load_1[8];
+      {
+        const uint4* _vptr_1 = reinterpret_cast<const uint4*>(mat_a + (m_1 * 6144 + k_base) + 0);
+        uint4 _vld_1[1];
+#pragma unroll
+        for (int _blk = 0; _blk < 1; _blk++) {
+          _vld_1[_blk] = _vptr_1[_blk];
+          uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
+#pragma unroll
+          for (int _pair = 0; _pair < 4; _pair++) {
+            asm volatile(
+                "{\n\t"
+                "shl.b32 %0, %2, 16;\n\t"
+                "and.b32 %1, %2, 0xffff0000;\n\t"
+                "}\n"
+                : "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[0]),
+                  "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[1])
+                : "r"(_vpairs_1[_pair]));
+          }
         }
+      }
+#pragma unroll
+      for (int j = 0; j < 8; j++) {
+        float _fma_0 = __fmaf_rn(_vec_load_1[j], _vec_load_0[j], acc[m_1]);
+        acc[m_1] = _fma_0;
+      }
     }
-    asm volatile("barrier.sync 2, 128;" ::: "memory");
-    if (warp == 0) {
-        if (lane < 12) {
-            int m_3 = lane;
-            float total = red[m_3 * 4];
-            #pragma unroll
-            for (int source_warp = 1; source_warp < 4; source_warp++) {
-                total = total + red[m_3 * 4 + source_warp];
-            }
-            int offset = m_3 * num_experts + expert;
-            if (out_is_bf16 == 0) {
-                *(reinterpret_cast<float*>(out_f32 + offset) + (0)) = total;
-            } else {
-                *(reinterpret_cast<__nv_bfloat16*>(out_bf16 + offset) + (0)) = __float2bfloat16_rn(total);
-            }
-        }
+  }
+#pragma unroll
+  for (int m_2 = 0; m_2 < 12; m_2++) {
+    float _warp_reduce_0 = acc[m_2];
+#pragma unroll
+    for (int offset = 16; offset > 0; offset >>= 1)
+      _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
+    float warp_sum = _warp_reduce_0;
+    if (lane == 0) {
+      red[m_2 * 4 + warp] = warp_sum;
     }
-    asm volatile("griddepcontrol.launch_dependents;" ::: "memory");
+  }
+  asm volatile("barrier.sync 2, 128;" ::: "memory");
+  if (warp == 0) {
+    if (lane < 12) {
+      int m_3 = lane;
+      float total = red[m_3 * 4];
+#pragma unroll
+      for (int source_warp = 1; source_warp < 4; source_warp++) {
+        total = total + red[m_3 * 4 + source_warp];
+      }
+      int offset = m_3 * num_experts + expert;
+      if (out_is_bf16 == 0) {
+        *(reinterpret_cast<float*>(out_f32 + offset) + (0)) = total;
+      } else {
+        *(reinterpret_cast<__nv_bfloat16*>(out_bf16 + offset) + (0)) = __float2bfloat16_rn(total);
+      }
+    }
+  }
+  asm volatile("griddepcontrol.launch_dependents;" ::: "memory");
 }
 
-} // extern "C"
+}  // extern "C"

--- a/csrc/cake_router_gemm/cake_router_gemm_m12_k6144_device.cu
+++ b/csrc/cake_router_gemm/cake_router_gemm_m12_k6144_device.cu
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) 2026 by FlashInfer team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+typedef unsigned char      uint8_t;
+typedef unsigned short     uint16_t;
+typedef unsigned int       uint32_t;
+typedef unsigned long long uint64_t;
+typedef signed int         int32_t;
+typedef short int          int16_t;
+struct __align__(128) CakeTensorMap { uint64_t opaque[16]; };
+template <int N>
+struct __align__(128) CakeTensorMapPack { CakeTensorMap maps[N]; };
+
+typedef struct __align__(64) { uint64_t opaque[16]; } CUtensorMap;
+
+#include <cuda_bf16.h>
+
+__device__ __forceinline__ int make_warp_uniform(int x) {
+    int result;
+    asm volatile("shfl.sync.idx.b32 %0, %1, 0, 0x1F, 0xFFFFFFFF;"
+                 : "=r"(result) : "r"(x));
+    return result;
+}
+
+#define CAKE_INF CUDART_INF_F
+#define NUM_MAIN_STAGES 1
+#define SMEM_RED_OFF 0
+#define SMEM_RED_STAGE_BYTES 192
+#define SMEM_RED_STRIDE 192
+#define SMEM_TOTAL 256
+#define THREADS 128
+
+#include <math_constants.h>
+
+extern "C" {
+
+__global__ __launch_bounds__(128, 1) void
+kernel_cake_blackwell_router_gemm_m12_k6144(__nv_bfloat16* __restrict__ mat_a, __nv_bfloat16* __restrict__ mat_b, float* __restrict__ out_f32, __nv_bfloat16* __restrict__ out_bf16, int num_experts, int out_is_bf16)
+{
+    const int tid = threadIdx.x;
+    const int warp = make_warp_uniform(tid / 32);
+    const int lane = tid % 32;
+
+    extern __shared__ __align__(1024) char smem_raw[];
+    int smem;
+    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+
+    const int bid = blockIdx.x;
+    const int num_bids = gridDim.x;
+
+    // Kernel setup ops
+    float* red = reinterpret_cast<float*>(smem_raw + 0);
+    const int red_addr = smem + 0;
+
+    // === Task calls (dependency order) ===
+    int expert = blockIdx.x;
+    float acc[12];
+    #pragma unroll
+    for (int m = 0; m < 12; m++) {
+        acc[m] = 0.0f;
+    }
+    asm volatile("griddepcontrol.wait;" ::: "memory");
+    #pragma unroll
+    for (int ki = 0; ki < 6; ki++) {
+        int k_base = ki * 1024 + tid * 8;
+        float _vec_load_0[8];
+        {
+            const uint4* _vptr_0 = reinterpret_cast<const uint4*>(mat_b + (expert * 6144 + k_base) + 0);
+            uint4 _vld_0[1];
+            #pragma unroll
+            for (int _blk = 0; _blk < 1; _blk++) {
+                _vld_0[_blk] = _vptr_0[_blk];
+                uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
+                #pragma unroll
+                for (int _pair = 0; _pair < 4; _pair++) {
+                    asm volatile(
+                        "{\n\t"
+                        "shl.b32 %0, %2, 16;\n\t"
+                        "and.b32 %1, %2, 0xffff0000;\n\t"
+                        "}\n"
+                        : "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[1])
+                        : "r"(_vpairs_0[_pair]));
+                }
+            }
+        }
+        #pragma unroll
+        for (int m_1 = 0; m_1 < 12; m_1++) {
+            float _vec_load_1[8];
+            {
+                const uint4* _vptr_1 = reinterpret_cast<const uint4*>(mat_a + (m_1 * 6144 + k_base) + 0);
+                uint4 _vld_1[1];
+                #pragma unroll
+                for (int _blk = 0; _blk < 1; _blk++) {
+                    _vld_1[_blk] = _vptr_1[_blk];
+                    uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
+                    #pragma unroll
+                    for (int _pair = 0; _pair < 4; _pair++) {
+                        asm volatile(
+                            "{\n\t"
+                            "shl.b32 %0, %2, 16;\n\t"
+                            "and.b32 %1, %2, 0xffff0000;\n\t"
+                            "}\n"
+                            : "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[1])
+                            : "r"(_vpairs_1[_pair]));
+                    }
+                }
+            }
+            #pragma unroll
+            for (int j = 0; j < 8; j++) {
+                float _fma_0 = __fmaf_rn(_vec_load_1[j], _vec_load_0[j], acc[m_1]);
+                acc[m_1] = _fma_0;
+            }
+        }
+    }
+    #pragma unroll
+    for (int m_2 = 0; m_2 < 12; m_2++) {
+        float _warp_reduce_0 = acc[m_2];
+        #pragma unroll
+        for (int offset = 16; offset > 0; offset >>= 1)
+            _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
+        float warp_sum = _warp_reduce_0;
+        if (lane == 0) {
+            red[m_2 * 4 + warp] = warp_sum;
+        }
+    }
+    asm volatile("barrier.sync 2, 128;" ::: "memory");
+    if (warp == 0) {
+        if (lane < 12) {
+            int m_3 = lane;
+            float total = red[m_3 * 4];
+            #pragma unroll
+            for (int source_warp = 1; source_warp < 4; source_warp++) {
+                total = total + red[m_3 * 4 + source_warp];
+            }
+            int offset = m_3 * num_experts + expert;
+            if (out_is_bf16 == 0) {
+                *(reinterpret_cast<float*>(out_f32 + offset) + (0)) = total;
+            } else {
+                *(reinterpret_cast<__nv_bfloat16*>(out_bf16 + offset) + (0)) = __float2bfloat16_rn(total);
+            }
+        }
+    }
+    asm volatile("griddepcontrol.launch_dependents;" ::: "memory");
+}
+
+} // extern "C"

--- a/csrc/cake_router_gemm/cake_router_gemm_m12_k7168_device.cu
+++ b/csrc/cake_router_gemm/cake_router_gemm_m12_k7168_device.cu
@@ -14,25 +14,30 @@
  * limitations under the License.
  */
 
-typedef unsigned char      uint8_t;
-typedef unsigned short     uint16_t;
-typedef unsigned int       uint32_t;
+typedef unsigned char uint8_t;
+typedef unsigned short uint16_t;
+typedef unsigned int uint32_t;
 typedef unsigned long long uint64_t;
-typedef signed int         int32_t;
-typedef short int          int16_t;
-struct __align__(128) CakeTensorMap { uint64_t opaque[16]; };
+typedef signed int int32_t;
+typedef short int int16_t;
+struct __align__(128) CakeTensorMap {
+  uint64_t opaque[16];
+};
 template <int N>
-struct __align__(128) CakeTensorMapPack { CakeTensorMap maps[N]; };
+struct __align__(128) CakeTensorMapPack {
+  CakeTensorMap maps[N];
+};
 
-typedef struct __align__(64) { uint64_t opaque[16]; } CUtensorMap;
+typedef struct __align__(64) {
+  uint64_t opaque[16];
+} CUtensorMap;
 
 #include <cuda_bf16.h>
 
 __device__ __forceinline__ int make_warp_uniform(int x) {
-    int result;
-    asm volatile("shfl.sync.idx.b32 %0, %1, 0, 0x1F, 0xFFFFFFFF;"
-                 : "=r"(result) : "r"(x));
-    return result;
+  int result;
+  asm volatile("shfl.sync.idx.b32 %0, %1, 0, 0x1F, 0xFFFFFFFF;" : "=r"(result) : "r"(x));
+  return result;
 }
 
 #define CAKE_INF CUDART_INF_F
@@ -47,113 +52,116 @@ __device__ __forceinline__ int make_warp_uniform(int x) {
 
 extern "C" {
 
-__global__ __launch_bounds__(128, 1) void
-kernel_cake_blackwell_router_gemm_m12_k7168(__nv_bfloat16* __restrict__ mat_a, __nv_bfloat16* __restrict__ mat_b, float* __restrict__ out_f32, __nv_bfloat16* __restrict__ out_bf16, int num_experts, int out_is_bf16)
-{
-    const int tid = threadIdx.x;
-    const int warp = make_warp_uniform(tid / 32);
-    const int lane = tid % 32;
+__global__ __launch_bounds__(128, 1) void kernel_cake_blackwell_router_gemm_m12_k7168(
+    __nv_bfloat16* __restrict__ mat_a, __nv_bfloat16* __restrict__ mat_b,
+    float* __restrict__ out_f32, __nv_bfloat16* __restrict__ out_bf16, int num_experts,
+    int out_is_bf16) {
+  const int tid = threadIdx.x;
+  const int warp = make_warp_uniform(tid / 32);
+  const int lane = tid % 32;
 
-    extern __shared__ __align__(1024) char smem_raw[];
-    int smem;
-    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+  extern __shared__ __align__(1024) char smem_raw[];
+  int smem;
+  smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
 
-    const int bid = blockIdx.x;
-    const int num_bids = gridDim.x;
+  const int bid = blockIdx.x;
+  const int num_bids = gridDim.x;
 
-    // Kernel setup ops
-    float* red = reinterpret_cast<float*>(smem_raw + 0);
-    const int red_addr = smem + 0;
+  // Kernel setup ops
+  float* red = reinterpret_cast<float*>(smem_raw + 0);
+  const int red_addr = smem + 0;
 
-    // === Task calls (dependency order) ===
-    int expert = blockIdx.x;
-    float acc[12];
-    #pragma unroll
-    for (int m = 0; m < 12; m++) {
-        acc[m] = 0.0f;
-    }
-    asm volatile("griddepcontrol.wait;" ::: "memory");
-    #pragma unroll
-    for (int ki = 0; ki < 7; ki++) {
-        int k_base = ki * 1024 + tid * 8;
-        float _vec_load_0[8];
-        {
-            const uint4* _vptr_0 = reinterpret_cast<const uint4*>(mat_b + (expert * 7168 + k_base) + 0);
-            uint4 _vld_0[1];
-            #pragma unroll
-            for (int _blk = 0; _blk < 1; _blk++) {
-                _vld_0[_blk] = _vptr_0[_blk];
-                uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
-                #pragma unroll
-                for (int _pair = 0; _pair < 4; _pair++) {
-                    asm volatile(
-                        "{\n\t"
-                        "shl.b32 %0, %2, 16;\n\t"
-                        "and.b32 %1, %2, 0xffff0000;\n\t"
-                        "}\n"
-                        : "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[1])
-                        : "r"(_vpairs_0[_pair]));
-                }
-            }
+  // === Task calls (dependency order) ===
+  int expert = blockIdx.x;
+  float acc[12];
+#pragma unroll
+  for (int m = 0; m < 12; m++) {
+    acc[m] = 0.0f;
+  }
+  asm volatile("griddepcontrol.wait;" ::: "memory");
+#pragma unroll
+  for (int ki = 0; ki < 7; ki++) {
+    int k_base = ki * 1024 + tid * 8;
+    float _vec_load_0[8];
+    {
+      const uint4* _vptr_0 = reinterpret_cast<const uint4*>(mat_b + (expert * 7168 + k_base) + 0);
+      uint4 _vld_0[1];
+#pragma unroll
+      for (int _blk = 0; _blk < 1; _blk++) {
+        _vld_0[_blk] = _vptr_0[_blk];
+        uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
+#pragma unroll
+        for (int _pair = 0; _pair < 4; _pair++) {
+          asm volatile(
+              "{\n\t"
+              "shl.b32 %0, %2, 16;\n\t"
+              "and.b32 %1, %2, 0xffff0000;\n\t"
+              "}\n"
+              : "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[0]),
+                "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[1])
+              : "r"(_vpairs_0[_pair]));
         }
-        #pragma unroll
-        for (int m_1 = 0; m_1 < 12; m_1++) {
-            float _vec_load_1[8];
-            {
-                const uint4* _vptr_1 = reinterpret_cast<const uint4*>(mat_a + (m_1 * 7168 + k_base) + 0);
-                uint4 _vld_1[1];
-                #pragma unroll
-                for (int _blk = 0; _blk < 1; _blk++) {
-                    _vld_1[_blk] = _vptr_1[_blk];
-                    uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
-                    #pragma unroll
-                    for (int _pair = 0; _pair < 4; _pair++) {
-                        asm volatile(
-                            "{\n\t"
-                            "shl.b32 %0, %2, 16;\n\t"
-                            "and.b32 %1, %2, 0xffff0000;\n\t"
-                            "}\n"
-                            : "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[1])
-                            : "r"(_vpairs_1[_pair]));
-                    }
-                }
-            }
-            #pragma unroll
-            for (int j = 0; j < 8; j++) {
-                float _fma_0 = __fmaf_rn(_vec_load_1[j], _vec_load_0[j], acc[m_1]);
-                acc[m_1] = _fma_0;
-            }
-        }
+      }
     }
-    #pragma unroll
-    for (int m_2 = 0; m_2 < 12; m_2++) {
-        float _warp_reduce_0 = acc[m_2];
-        #pragma unroll
-        for (int offset = 16; offset > 0; offset >>= 1)
-            _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
-        float warp_sum = _warp_reduce_0;
-        if (lane == 0) {
-            red[m_2 * 4 + warp] = warp_sum;
+#pragma unroll
+    for (int m_1 = 0; m_1 < 12; m_1++) {
+      float _vec_load_1[8];
+      {
+        const uint4* _vptr_1 = reinterpret_cast<const uint4*>(mat_a + (m_1 * 7168 + k_base) + 0);
+        uint4 _vld_1[1];
+#pragma unroll
+        for (int _blk = 0; _blk < 1; _blk++) {
+          _vld_1[_blk] = _vptr_1[_blk];
+          uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
+#pragma unroll
+          for (int _pair = 0; _pair < 4; _pair++) {
+            asm volatile(
+                "{\n\t"
+                "shl.b32 %0, %2, 16;\n\t"
+                "and.b32 %1, %2, 0xffff0000;\n\t"
+                "}\n"
+                : "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[0]),
+                  "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[1])
+                : "r"(_vpairs_1[_pair]));
+          }
         }
+      }
+#pragma unroll
+      for (int j = 0; j < 8; j++) {
+        float _fma_0 = __fmaf_rn(_vec_load_1[j], _vec_load_0[j], acc[m_1]);
+        acc[m_1] = _fma_0;
+      }
     }
-    asm volatile("barrier.sync 2, 128;" ::: "memory");
-    if (warp == 0) {
-        if (lane < 12) {
-            int m_3 = lane;
-            float total = red[m_3 * 4];
-            #pragma unroll
-            for (int source_warp = 1; source_warp < 4; source_warp++) {
-                total = total + red[m_3 * 4 + source_warp];
-            }
-            int offset = m_3 * num_experts + expert;
-            if (out_is_bf16 == 0) {
-                *(reinterpret_cast<float*>(out_f32 + offset) + (0)) = total;
-            } else {
-                *(reinterpret_cast<__nv_bfloat16*>(out_bf16 + offset) + (0)) = __float2bfloat16_rn(total);
-            }
-        }
+  }
+#pragma unroll
+  for (int m_2 = 0; m_2 < 12; m_2++) {
+    float _warp_reduce_0 = acc[m_2];
+#pragma unroll
+    for (int offset = 16; offset > 0; offset >>= 1)
+      _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
+    float warp_sum = _warp_reduce_0;
+    if (lane == 0) {
+      red[m_2 * 4 + warp] = warp_sum;
     }
-    asm volatile("griddepcontrol.launch_dependents;" ::: "memory");
+  }
+  asm volatile("barrier.sync 2, 128;" ::: "memory");
+  if (warp == 0) {
+    if (lane < 12) {
+      int m_3 = lane;
+      float total = red[m_3 * 4];
+#pragma unroll
+      for (int source_warp = 1; source_warp < 4; source_warp++) {
+        total = total + red[m_3 * 4 + source_warp];
+      }
+      int offset = m_3 * num_experts + expert;
+      if (out_is_bf16 == 0) {
+        *(reinterpret_cast<float*>(out_f32 + offset) + (0)) = total;
+      } else {
+        *(reinterpret_cast<__nv_bfloat16*>(out_bf16 + offset) + (0)) = __float2bfloat16_rn(total);
+      }
+    }
+  }
+  asm volatile("griddepcontrol.launch_dependents;" ::: "memory");
 }
 
-} // extern "C"
+}  // extern "C"

--- a/csrc/cake_router_gemm/cake_router_gemm_m12_k7168_device.cu
+++ b/csrc/cake_router_gemm/cake_router_gemm_m12_k7168_device.cu
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) 2026 by FlashInfer team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+typedef unsigned char      uint8_t;
+typedef unsigned short     uint16_t;
+typedef unsigned int       uint32_t;
+typedef unsigned long long uint64_t;
+typedef signed int         int32_t;
+typedef short int          int16_t;
+struct __align__(128) CakeTensorMap { uint64_t opaque[16]; };
+template <int N>
+struct __align__(128) CakeTensorMapPack { CakeTensorMap maps[N]; };
+
+typedef struct __align__(64) { uint64_t opaque[16]; } CUtensorMap;
+
+#include <cuda_bf16.h>
+
+__device__ __forceinline__ int make_warp_uniform(int x) {
+    int result;
+    asm volatile("shfl.sync.idx.b32 %0, %1, 0, 0x1F, 0xFFFFFFFF;"
+                 : "=r"(result) : "r"(x));
+    return result;
+}
+
+#define CAKE_INF CUDART_INF_F
+#define NUM_MAIN_STAGES 1
+#define SMEM_RED_OFF 0
+#define SMEM_RED_STAGE_BYTES 192
+#define SMEM_RED_STRIDE 192
+#define SMEM_TOTAL 256
+#define THREADS 128
+
+#include <math_constants.h>
+
+extern "C" {
+
+__global__ __launch_bounds__(128, 1) void
+kernel_cake_blackwell_router_gemm_m12_k7168(__nv_bfloat16* __restrict__ mat_a, __nv_bfloat16* __restrict__ mat_b, float* __restrict__ out_f32, __nv_bfloat16* __restrict__ out_bf16, int num_experts, int out_is_bf16)
+{
+    const int tid = threadIdx.x;
+    const int warp = make_warp_uniform(tid / 32);
+    const int lane = tid % 32;
+
+    extern __shared__ __align__(1024) char smem_raw[];
+    int smem;
+    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+
+    const int bid = blockIdx.x;
+    const int num_bids = gridDim.x;
+
+    // Kernel setup ops
+    float* red = reinterpret_cast<float*>(smem_raw + 0);
+    const int red_addr = smem + 0;
+
+    // === Task calls (dependency order) ===
+    int expert = blockIdx.x;
+    float acc[12];
+    #pragma unroll
+    for (int m = 0; m < 12; m++) {
+        acc[m] = 0.0f;
+    }
+    asm volatile("griddepcontrol.wait;" ::: "memory");
+    #pragma unroll
+    for (int ki = 0; ki < 7; ki++) {
+        int k_base = ki * 1024 + tid * 8;
+        float _vec_load_0[8];
+        {
+            const uint4* _vptr_0 = reinterpret_cast<const uint4*>(mat_b + (expert * 7168 + k_base) + 0);
+            uint4 _vld_0[1];
+            #pragma unroll
+            for (int _blk = 0; _blk < 1; _blk++) {
+                _vld_0[_blk] = _vptr_0[_blk];
+                uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
+                #pragma unroll
+                for (int _pair = 0; _pair < 4; _pair++) {
+                    asm volatile(
+                        "{\n\t"
+                        "shl.b32 %0, %2, 16;\n\t"
+                        "and.b32 %1, %2, 0xffff0000;\n\t"
+                        "}\n"
+                        : "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[1])
+                        : "r"(_vpairs_0[_pair]));
+                }
+            }
+        }
+        #pragma unroll
+        for (int m_1 = 0; m_1 < 12; m_1++) {
+            float _vec_load_1[8];
+            {
+                const uint4* _vptr_1 = reinterpret_cast<const uint4*>(mat_a + (m_1 * 7168 + k_base) + 0);
+                uint4 _vld_1[1];
+                #pragma unroll
+                for (int _blk = 0; _blk < 1; _blk++) {
+                    _vld_1[_blk] = _vptr_1[_blk];
+                    uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
+                    #pragma unroll
+                    for (int _pair = 0; _pair < 4; _pair++) {
+                        asm volatile(
+                            "{\n\t"
+                            "shl.b32 %0, %2, 16;\n\t"
+                            "and.b32 %1, %2, 0xffff0000;\n\t"
+                            "}\n"
+                            : "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[1])
+                            : "r"(_vpairs_1[_pair]));
+                    }
+                }
+            }
+            #pragma unroll
+            for (int j = 0; j < 8; j++) {
+                float _fma_0 = __fmaf_rn(_vec_load_1[j], _vec_load_0[j], acc[m_1]);
+                acc[m_1] = _fma_0;
+            }
+        }
+    }
+    #pragma unroll
+    for (int m_2 = 0; m_2 < 12; m_2++) {
+        float _warp_reduce_0 = acc[m_2];
+        #pragma unroll
+        for (int offset = 16; offset > 0; offset >>= 1)
+            _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
+        float warp_sum = _warp_reduce_0;
+        if (lane == 0) {
+            red[m_2 * 4 + warp] = warp_sum;
+        }
+    }
+    asm volatile("barrier.sync 2, 128;" ::: "memory");
+    if (warp == 0) {
+        if (lane < 12) {
+            int m_3 = lane;
+            float total = red[m_3 * 4];
+            #pragma unroll
+            for (int source_warp = 1; source_warp < 4; source_warp++) {
+                total = total + red[m_3 * 4 + source_warp];
+            }
+            int offset = m_3 * num_experts + expert;
+            if (out_is_bf16 == 0) {
+                *(reinterpret_cast<float*>(out_f32 + offset) + (0)) = total;
+            } else {
+                *(reinterpret_cast<__nv_bfloat16*>(out_bf16 + offset) + (0)) = __float2bfloat16_rn(total);
+            }
+        }
+    }
+    asm volatile("griddepcontrol.launch_dependents;" ::: "memory");
+}
+
+} // extern "C"

--- a/csrc/cake_router_gemm/cake_router_gemm_m13_k6144_device.cu
+++ b/csrc/cake_router_gemm/cake_router_gemm_m13_k6144_device.cu
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) 2026 by FlashInfer team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+typedef unsigned char      uint8_t;
+typedef unsigned short     uint16_t;
+typedef unsigned int       uint32_t;
+typedef unsigned long long uint64_t;
+typedef signed int         int32_t;
+typedef short int          int16_t;
+struct __align__(128) CakeTensorMap { uint64_t opaque[16]; };
+template <int N>
+struct __align__(128) CakeTensorMapPack { CakeTensorMap maps[N]; };
+
+typedef struct __align__(64) { uint64_t opaque[16]; } CUtensorMap;
+
+#include <cuda_bf16.h>
+
+__device__ __forceinline__ int make_warp_uniform(int x) {
+    int result;
+    asm volatile("shfl.sync.idx.b32 %0, %1, 0, 0x1F, 0xFFFFFFFF;"
+                 : "=r"(result) : "r"(x));
+    return result;
+}
+
+#define CAKE_INF CUDART_INF_F
+#define NUM_MAIN_STAGES 1
+#define SMEM_RED_OFF 0
+#define SMEM_RED_STAGE_BYTES 208
+#define SMEM_RED_STRIDE 208
+#define SMEM_TOTAL 256
+#define THREADS 128
+
+#include <math_constants.h>
+
+extern "C" {
+
+__global__ __launch_bounds__(128, 1) void
+kernel_cake_blackwell_router_gemm_m13_k6144(__nv_bfloat16* __restrict__ mat_a, __nv_bfloat16* __restrict__ mat_b, float* __restrict__ out_f32, __nv_bfloat16* __restrict__ out_bf16, int num_experts, int out_is_bf16)
+{
+    const int tid = threadIdx.x;
+    const int warp = make_warp_uniform(tid / 32);
+    const int lane = tid % 32;
+
+    extern __shared__ __align__(1024) char smem_raw[];
+    int smem;
+    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+
+    const int bid = blockIdx.x;
+    const int num_bids = gridDim.x;
+
+    // Kernel setup ops
+    float* red = reinterpret_cast<float*>(smem_raw + 0);
+    const int red_addr = smem + 0;
+
+    // === Task calls (dependency order) ===
+    int expert = blockIdx.x;
+    float acc[13];
+    #pragma unroll
+    for (int m = 0; m < 13; m++) {
+        acc[m] = 0.0f;
+    }
+    asm volatile("griddepcontrol.wait;" ::: "memory");
+    #pragma unroll
+    for (int ki = 0; ki < 6; ki++) {
+        int k_base = ki * 1024 + tid * 8;
+        float _vec_load_0[8];
+        {
+            const uint4* _vptr_0 = reinterpret_cast<const uint4*>(mat_b + (expert * 6144 + k_base) + 0);
+            uint4 _vld_0[1];
+            #pragma unroll
+            for (int _blk = 0; _blk < 1; _blk++) {
+                _vld_0[_blk] = _vptr_0[_blk];
+                uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
+                #pragma unroll
+                for (int _pair = 0; _pair < 4; _pair++) {
+                    asm volatile(
+                        "{\n\t"
+                        "shl.b32 %0, %2, 16;\n\t"
+                        "and.b32 %1, %2, 0xffff0000;\n\t"
+                        "}\n"
+                        : "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[1])
+                        : "r"(_vpairs_0[_pair]));
+                }
+            }
+        }
+        #pragma unroll
+        for (int m_1 = 0; m_1 < 13; m_1++) {
+            float _vec_load_1[8];
+            {
+                const uint4* _vptr_1 = reinterpret_cast<const uint4*>(mat_a + (m_1 * 6144 + k_base) + 0);
+                uint4 _vld_1[1];
+                #pragma unroll
+                for (int _blk = 0; _blk < 1; _blk++) {
+                    _vld_1[_blk] = _vptr_1[_blk];
+                    uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
+                    #pragma unroll
+                    for (int _pair = 0; _pair < 4; _pair++) {
+                        asm volatile(
+                            "{\n\t"
+                            "shl.b32 %0, %2, 16;\n\t"
+                            "and.b32 %1, %2, 0xffff0000;\n\t"
+                            "}\n"
+                            : "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[1])
+                            : "r"(_vpairs_1[_pair]));
+                    }
+                }
+            }
+            #pragma unroll
+            for (int j = 0; j < 8; j++) {
+                float _fma_0 = __fmaf_rn(_vec_load_1[j], _vec_load_0[j], acc[m_1]);
+                acc[m_1] = _fma_0;
+            }
+        }
+    }
+    #pragma unroll
+    for (int m_2 = 0; m_2 < 13; m_2++) {
+        float _warp_reduce_0 = acc[m_2];
+        #pragma unroll
+        for (int offset = 16; offset > 0; offset >>= 1)
+            _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
+        float warp_sum = _warp_reduce_0;
+        if (lane == 0) {
+            red[m_2 * 4 + warp] = warp_sum;
+        }
+    }
+    asm volatile("barrier.sync 2, 128;" ::: "memory");
+    if (warp == 0) {
+        if (lane < 13) {
+            int m_3 = lane;
+            float total = red[m_3 * 4];
+            #pragma unroll
+            for (int source_warp = 1; source_warp < 4; source_warp++) {
+                total = total + red[m_3 * 4 + source_warp];
+            }
+            int offset = m_3 * num_experts + expert;
+            if (out_is_bf16 == 0) {
+                *(reinterpret_cast<float*>(out_f32 + offset) + (0)) = total;
+            } else {
+                *(reinterpret_cast<__nv_bfloat16*>(out_bf16 + offset) + (0)) = __float2bfloat16_rn(total);
+            }
+        }
+    }
+    asm volatile("griddepcontrol.launch_dependents;" ::: "memory");
+}
+
+} // extern "C"

--- a/csrc/cake_router_gemm/cake_router_gemm_m13_k6144_device.cu
+++ b/csrc/cake_router_gemm/cake_router_gemm_m13_k6144_device.cu
@@ -14,25 +14,30 @@
  * limitations under the License.
  */
 
-typedef unsigned char      uint8_t;
-typedef unsigned short     uint16_t;
-typedef unsigned int       uint32_t;
+typedef unsigned char uint8_t;
+typedef unsigned short uint16_t;
+typedef unsigned int uint32_t;
 typedef unsigned long long uint64_t;
-typedef signed int         int32_t;
-typedef short int          int16_t;
-struct __align__(128) CakeTensorMap { uint64_t opaque[16]; };
+typedef signed int int32_t;
+typedef short int int16_t;
+struct __align__(128) CakeTensorMap {
+  uint64_t opaque[16];
+};
 template <int N>
-struct __align__(128) CakeTensorMapPack { CakeTensorMap maps[N]; };
+struct __align__(128) CakeTensorMapPack {
+  CakeTensorMap maps[N];
+};
 
-typedef struct __align__(64) { uint64_t opaque[16]; } CUtensorMap;
+typedef struct __align__(64) {
+  uint64_t opaque[16];
+} CUtensorMap;
 
 #include <cuda_bf16.h>
 
 __device__ __forceinline__ int make_warp_uniform(int x) {
-    int result;
-    asm volatile("shfl.sync.idx.b32 %0, %1, 0, 0x1F, 0xFFFFFFFF;"
-                 : "=r"(result) : "r"(x));
-    return result;
+  int result;
+  asm volatile("shfl.sync.idx.b32 %0, %1, 0, 0x1F, 0xFFFFFFFF;" : "=r"(result) : "r"(x));
+  return result;
 }
 
 #define CAKE_INF CUDART_INF_F
@@ -47,113 +52,116 @@ __device__ __forceinline__ int make_warp_uniform(int x) {
 
 extern "C" {
 
-__global__ __launch_bounds__(128, 1) void
-kernel_cake_blackwell_router_gemm_m13_k6144(__nv_bfloat16* __restrict__ mat_a, __nv_bfloat16* __restrict__ mat_b, float* __restrict__ out_f32, __nv_bfloat16* __restrict__ out_bf16, int num_experts, int out_is_bf16)
-{
-    const int tid = threadIdx.x;
-    const int warp = make_warp_uniform(tid / 32);
-    const int lane = tid % 32;
+__global__ __launch_bounds__(128, 1) void kernel_cake_blackwell_router_gemm_m13_k6144(
+    __nv_bfloat16* __restrict__ mat_a, __nv_bfloat16* __restrict__ mat_b,
+    float* __restrict__ out_f32, __nv_bfloat16* __restrict__ out_bf16, int num_experts,
+    int out_is_bf16) {
+  const int tid = threadIdx.x;
+  const int warp = make_warp_uniform(tid / 32);
+  const int lane = tid % 32;
 
-    extern __shared__ __align__(1024) char smem_raw[];
-    int smem;
-    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+  extern __shared__ __align__(1024) char smem_raw[];
+  int smem;
+  smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
 
-    const int bid = blockIdx.x;
-    const int num_bids = gridDim.x;
+  const int bid = blockIdx.x;
+  const int num_bids = gridDim.x;
 
-    // Kernel setup ops
-    float* red = reinterpret_cast<float*>(smem_raw + 0);
-    const int red_addr = smem + 0;
+  // Kernel setup ops
+  float* red = reinterpret_cast<float*>(smem_raw + 0);
+  const int red_addr = smem + 0;
 
-    // === Task calls (dependency order) ===
-    int expert = blockIdx.x;
-    float acc[13];
-    #pragma unroll
-    for (int m = 0; m < 13; m++) {
-        acc[m] = 0.0f;
-    }
-    asm volatile("griddepcontrol.wait;" ::: "memory");
-    #pragma unroll
-    for (int ki = 0; ki < 6; ki++) {
-        int k_base = ki * 1024 + tid * 8;
-        float _vec_load_0[8];
-        {
-            const uint4* _vptr_0 = reinterpret_cast<const uint4*>(mat_b + (expert * 6144 + k_base) + 0);
-            uint4 _vld_0[1];
-            #pragma unroll
-            for (int _blk = 0; _blk < 1; _blk++) {
-                _vld_0[_blk] = _vptr_0[_blk];
-                uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
-                #pragma unroll
-                for (int _pair = 0; _pair < 4; _pair++) {
-                    asm volatile(
-                        "{\n\t"
-                        "shl.b32 %0, %2, 16;\n\t"
-                        "and.b32 %1, %2, 0xffff0000;\n\t"
-                        "}\n"
-                        : "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[1])
-                        : "r"(_vpairs_0[_pair]));
-                }
-            }
+  // === Task calls (dependency order) ===
+  int expert = blockIdx.x;
+  float acc[13];
+#pragma unroll
+  for (int m = 0; m < 13; m++) {
+    acc[m] = 0.0f;
+  }
+  asm volatile("griddepcontrol.wait;" ::: "memory");
+#pragma unroll
+  for (int ki = 0; ki < 6; ki++) {
+    int k_base = ki * 1024 + tid * 8;
+    float _vec_load_0[8];
+    {
+      const uint4* _vptr_0 = reinterpret_cast<const uint4*>(mat_b + (expert * 6144 + k_base) + 0);
+      uint4 _vld_0[1];
+#pragma unroll
+      for (int _blk = 0; _blk < 1; _blk++) {
+        _vld_0[_blk] = _vptr_0[_blk];
+        uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
+#pragma unroll
+        for (int _pair = 0; _pair < 4; _pair++) {
+          asm volatile(
+              "{\n\t"
+              "shl.b32 %0, %2, 16;\n\t"
+              "and.b32 %1, %2, 0xffff0000;\n\t"
+              "}\n"
+              : "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[0]),
+                "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[1])
+              : "r"(_vpairs_0[_pair]));
         }
-        #pragma unroll
-        for (int m_1 = 0; m_1 < 13; m_1++) {
-            float _vec_load_1[8];
-            {
-                const uint4* _vptr_1 = reinterpret_cast<const uint4*>(mat_a + (m_1 * 6144 + k_base) + 0);
-                uint4 _vld_1[1];
-                #pragma unroll
-                for (int _blk = 0; _blk < 1; _blk++) {
-                    _vld_1[_blk] = _vptr_1[_blk];
-                    uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
-                    #pragma unroll
-                    for (int _pair = 0; _pair < 4; _pair++) {
-                        asm volatile(
-                            "{\n\t"
-                            "shl.b32 %0, %2, 16;\n\t"
-                            "and.b32 %1, %2, 0xffff0000;\n\t"
-                            "}\n"
-                            : "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[1])
-                            : "r"(_vpairs_1[_pair]));
-                    }
-                }
-            }
-            #pragma unroll
-            for (int j = 0; j < 8; j++) {
-                float _fma_0 = __fmaf_rn(_vec_load_1[j], _vec_load_0[j], acc[m_1]);
-                acc[m_1] = _fma_0;
-            }
-        }
+      }
     }
-    #pragma unroll
-    for (int m_2 = 0; m_2 < 13; m_2++) {
-        float _warp_reduce_0 = acc[m_2];
-        #pragma unroll
-        for (int offset = 16; offset > 0; offset >>= 1)
-            _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
-        float warp_sum = _warp_reduce_0;
-        if (lane == 0) {
-            red[m_2 * 4 + warp] = warp_sum;
+#pragma unroll
+    for (int m_1 = 0; m_1 < 13; m_1++) {
+      float _vec_load_1[8];
+      {
+        const uint4* _vptr_1 = reinterpret_cast<const uint4*>(mat_a + (m_1 * 6144 + k_base) + 0);
+        uint4 _vld_1[1];
+#pragma unroll
+        for (int _blk = 0; _blk < 1; _blk++) {
+          _vld_1[_blk] = _vptr_1[_blk];
+          uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
+#pragma unroll
+          for (int _pair = 0; _pair < 4; _pair++) {
+            asm volatile(
+                "{\n\t"
+                "shl.b32 %0, %2, 16;\n\t"
+                "and.b32 %1, %2, 0xffff0000;\n\t"
+                "}\n"
+                : "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[0]),
+                  "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[1])
+                : "r"(_vpairs_1[_pair]));
+          }
         }
+      }
+#pragma unroll
+      for (int j = 0; j < 8; j++) {
+        float _fma_0 = __fmaf_rn(_vec_load_1[j], _vec_load_0[j], acc[m_1]);
+        acc[m_1] = _fma_0;
+      }
     }
-    asm volatile("barrier.sync 2, 128;" ::: "memory");
-    if (warp == 0) {
-        if (lane < 13) {
-            int m_3 = lane;
-            float total = red[m_3 * 4];
-            #pragma unroll
-            for (int source_warp = 1; source_warp < 4; source_warp++) {
-                total = total + red[m_3 * 4 + source_warp];
-            }
-            int offset = m_3 * num_experts + expert;
-            if (out_is_bf16 == 0) {
-                *(reinterpret_cast<float*>(out_f32 + offset) + (0)) = total;
-            } else {
-                *(reinterpret_cast<__nv_bfloat16*>(out_bf16 + offset) + (0)) = __float2bfloat16_rn(total);
-            }
-        }
+  }
+#pragma unroll
+  for (int m_2 = 0; m_2 < 13; m_2++) {
+    float _warp_reduce_0 = acc[m_2];
+#pragma unroll
+    for (int offset = 16; offset > 0; offset >>= 1)
+      _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
+    float warp_sum = _warp_reduce_0;
+    if (lane == 0) {
+      red[m_2 * 4 + warp] = warp_sum;
     }
-    asm volatile("griddepcontrol.launch_dependents;" ::: "memory");
+  }
+  asm volatile("barrier.sync 2, 128;" ::: "memory");
+  if (warp == 0) {
+    if (lane < 13) {
+      int m_3 = lane;
+      float total = red[m_3 * 4];
+#pragma unroll
+      for (int source_warp = 1; source_warp < 4; source_warp++) {
+        total = total + red[m_3 * 4 + source_warp];
+      }
+      int offset = m_3 * num_experts + expert;
+      if (out_is_bf16 == 0) {
+        *(reinterpret_cast<float*>(out_f32 + offset) + (0)) = total;
+      } else {
+        *(reinterpret_cast<__nv_bfloat16*>(out_bf16 + offset) + (0)) = __float2bfloat16_rn(total);
+      }
+    }
+  }
+  asm volatile("griddepcontrol.launch_dependents;" ::: "memory");
 }
 
-} // extern "C"
+}  // extern "C"

--- a/csrc/cake_router_gemm/cake_router_gemm_m13_k7168_device.cu
+++ b/csrc/cake_router_gemm/cake_router_gemm_m13_k7168_device.cu
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) 2026 by FlashInfer team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+typedef unsigned char      uint8_t;
+typedef unsigned short     uint16_t;
+typedef unsigned int       uint32_t;
+typedef unsigned long long uint64_t;
+typedef signed int         int32_t;
+typedef short int          int16_t;
+struct __align__(128) CakeTensorMap { uint64_t opaque[16]; };
+template <int N>
+struct __align__(128) CakeTensorMapPack { CakeTensorMap maps[N]; };
+
+typedef struct __align__(64) { uint64_t opaque[16]; } CUtensorMap;
+
+#include <cuda_bf16.h>
+
+__device__ __forceinline__ int make_warp_uniform(int x) {
+    int result;
+    asm volatile("shfl.sync.idx.b32 %0, %1, 0, 0x1F, 0xFFFFFFFF;"
+                 : "=r"(result) : "r"(x));
+    return result;
+}
+
+#define CAKE_INF CUDART_INF_F
+#define NUM_MAIN_STAGES 1
+#define SMEM_RED_OFF 0
+#define SMEM_RED_STAGE_BYTES 208
+#define SMEM_RED_STRIDE 208
+#define SMEM_TOTAL 256
+#define THREADS 128
+
+#include <math_constants.h>
+
+extern "C" {
+
+__global__ __launch_bounds__(128, 1) void
+kernel_cake_blackwell_router_gemm_m13_k7168(__nv_bfloat16* __restrict__ mat_a, __nv_bfloat16* __restrict__ mat_b, float* __restrict__ out_f32, __nv_bfloat16* __restrict__ out_bf16, int num_experts, int out_is_bf16)
+{
+    const int tid = threadIdx.x;
+    const int warp = make_warp_uniform(tid / 32);
+    const int lane = tid % 32;
+
+    extern __shared__ __align__(1024) char smem_raw[];
+    int smem;
+    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+
+    const int bid = blockIdx.x;
+    const int num_bids = gridDim.x;
+
+    // Kernel setup ops
+    float* red = reinterpret_cast<float*>(smem_raw + 0);
+    const int red_addr = smem + 0;
+
+    // === Task calls (dependency order) ===
+    int expert = blockIdx.x;
+    float acc[13];
+    #pragma unroll
+    for (int m = 0; m < 13; m++) {
+        acc[m] = 0.0f;
+    }
+    asm volatile("griddepcontrol.wait;" ::: "memory");
+    #pragma unroll
+    for (int ki = 0; ki < 7; ki++) {
+        int k_base = ki * 1024 + tid * 8;
+        float _vec_load_0[8];
+        {
+            const uint4* _vptr_0 = reinterpret_cast<const uint4*>(mat_b + (expert * 7168 + k_base) + 0);
+            uint4 _vld_0[1];
+            #pragma unroll
+            for (int _blk = 0; _blk < 1; _blk++) {
+                _vld_0[_blk] = _vptr_0[_blk];
+                uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
+                #pragma unroll
+                for (int _pair = 0; _pair < 4; _pair++) {
+                    asm volatile(
+                        "{\n\t"
+                        "shl.b32 %0, %2, 16;\n\t"
+                        "and.b32 %1, %2, 0xffff0000;\n\t"
+                        "}\n"
+                        : "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[1])
+                        : "r"(_vpairs_0[_pair]));
+                }
+            }
+        }
+        #pragma unroll
+        for (int m_1 = 0; m_1 < 13; m_1++) {
+            float _vec_load_1[8];
+            {
+                const uint4* _vptr_1 = reinterpret_cast<const uint4*>(mat_a + (m_1 * 7168 + k_base) + 0);
+                uint4 _vld_1[1];
+                #pragma unroll
+                for (int _blk = 0; _blk < 1; _blk++) {
+                    _vld_1[_blk] = _vptr_1[_blk];
+                    uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
+                    #pragma unroll
+                    for (int _pair = 0; _pair < 4; _pair++) {
+                        asm volatile(
+                            "{\n\t"
+                            "shl.b32 %0, %2, 16;\n\t"
+                            "and.b32 %1, %2, 0xffff0000;\n\t"
+                            "}\n"
+                            : "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[1])
+                            : "r"(_vpairs_1[_pair]));
+                    }
+                }
+            }
+            #pragma unroll
+            for (int j = 0; j < 8; j++) {
+                float _fma_0 = __fmaf_rn(_vec_load_1[j], _vec_load_0[j], acc[m_1]);
+                acc[m_1] = _fma_0;
+            }
+        }
+    }
+    #pragma unroll
+    for (int m_2 = 0; m_2 < 13; m_2++) {
+        float _warp_reduce_0 = acc[m_2];
+        #pragma unroll
+        for (int offset = 16; offset > 0; offset >>= 1)
+            _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
+        float warp_sum = _warp_reduce_0;
+        if (lane == 0) {
+            red[m_2 * 4 + warp] = warp_sum;
+        }
+    }
+    asm volatile("barrier.sync 2, 128;" ::: "memory");
+    if (warp == 0) {
+        if (lane < 13) {
+            int m_3 = lane;
+            float total = red[m_3 * 4];
+            #pragma unroll
+            for (int source_warp = 1; source_warp < 4; source_warp++) {
+                total = total + red[m_3 * 4 + source_warp];
+            }
+            int offset = m_3 * num_experts + expert;
+            if (out_is_bf16 == 0) {
+                *(reinterpret_cast<float*>(out_f32 + offset) + (0)) = total;
+            } else {
+                *(reinterpret_cast<__nv_bfloat16*>(out_bf16 + offset) + (0)) = __float2bfloat16_rn(total);
+            }
+        }
+    }
+    asm volatile("griddepcontrol.launch_dependents;" ::: "memory");
+}
+
+} // extern "C"

--- a/csrc/cake_router_gemm/cake_router_gemm_m13_k7168_device.cu
+++ b/csrc/cake_router_gemm/cake_router_gemm_m13_k7168_device.cu
@@ -14,25 +14,30 @@
  * limitations under the License.
  */
 
-typedef unsigned char      uint8_t;
-typedef unsigned short     uint16_t;
-typedef unsigned int       uint32_t;
+typedef unsigned char uint8_t;
+typedef unsigned short uint16_t;
+typedef unsigned int uint32_t;
 typedef unsigned long long uint64_t;
-typedef signed int         int32_t;
-typedef short int          int16_t;
-struct __align__(128) CakeTensorMap { uint64_t opaque[16]; };
+typedef signed int int32_t;
+typedef short int int16_t;
+struct __align__(128) CakeTensorMap {
+  uint64_t opaque[16];
+};
 template <int N>
-struct __align__(128) CakeTensorMapPack { CakeTensorMap maps[N]; };
+struct __align__(128) CakeTensorMapPack {
+  CakeTensorMap maps[N];
+};
 
-typedef struct __align__(64) { uint64_t opaque[16]; } CUtensorMap;
+typedef struct __align__(64) {
+  uint64_t opaque[16];
+} CUtensorMap;
 
 #include <cuda_bf16.h>
 
 __device__ __forceinline__ int make_warp_uniform(int x) {
-    int result;
-    asm volatile("shfl.sync.idx.b32 %0, %1, 0, 0x1F, 0xFFFFFFFF;"
-                 : "=r"(result) : "r"(x));
-    return result;
+  int result;
+  asm volatile("shfl.sync.idx.b32 %0, %1, 0, 0x1F, 0xFFFFFFFF;" : "=r"(result) : "r"(x));
+  return result;
 }
 
 #define CAKE_INF CUDART_INF_F
@@ -47,113 +52,116 @@ __device__ __forceinline__ int make_warp_uniform(int x) {
 
 extern "C" {
 
-__global__ __launch_bounds__(128, 1) void
-kernel_cake_blackwell_router_gemm_m13_k7168(__nv_bfloat16* __restrict__ mat_a, __nv_bfloat16* __restrict__ mat_b, float* __restrict__ out_f32, __nv_bfloat16* __restrict__ out_bf16, int num_experts, int out_is_bf16)
-{
-    const int tid = threadIdx.x;
-    const int warp = make_warp_uniform(tid / 32);
-    const int lane = tid % 32;
+__global__ __launch_bounds__(128, 1) void kernel_cake_blackwell_router_gemm_m13_k7168(
+    __nv_bfloat16* __restrict__ mat_a, __nv_bfloat16* __restrict__ mat_b,
+    float* __restrict__ out_f32, __nv_bfloat16* __restrict__ out_bf16, int num_experts,
+    int out_is_bf16) {
+  const int tid = threadIdx.x;
+  const int warp = make_warp_uniform(tid / 32);
+  const int lane = tid % 32;
 
-    extern __shared__ __align__(1024) char smem_raw[];
-    int smem;
-    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+  extern __shared__ __align__(1024) char smem_raw[];
+  int smem;
+  smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
 
-    const int bid = blockIdx.x;
-    const int num_bids = gridDim.x;
+  const int bid = blockIdx.x;
+  const int num_bids = gridDim.x;
 
-    // Kernel setup ops
-    float* red = reinterpret_cast<float*>(smem_raw + 0);
-    const int red_addr = smem + 0;
+  // Kernel setup ops
+  float* red = reinterpret_cast<float*>(smem_raw + 0);
+  const int red_addr = smem + 0;
 
-    // === Task calls (dependency order) ===
-    int expert = blockIdx.x;
-    float acc[13];
-    #pragma unroll
-    for (int m = 0; m < 13; m++) {
-        acc[m] = 0.0f;
-    }
-    asm volatile("griddepcontrol.wait;" ::: "memory");
-    #pragma unroll
-    for (int ki = 0; ki < 7; ki++) {
-        int k_base = ki * 1024 + tid * 8;
-        float _vec_load_0[8];
-        {
-            const uint4* _vptr_0 = reinterpret_cast<const uint4*>(mat_b + (expert * 7168 + k_base) + 0);
-            uint4 _vld_0[1];
-            #pragma unroll
-            for (int _blk = 0; _blk < 1; _blk++) {
-                _vld_0[_blk] = _vptr_0[_blk];
-                uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
-                #pragma unroll
-                for (int _pair = 0; _pair < 4; _pair++) {
-                    asm volatile(
-                        "{\n\t"
-                        "shl.b32 %0, %2, 16;\n\t"
-                        "and.b32 %1, %2, 0xffff0000;\n\t"
-                        "}\n"
-                        : "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[1])
-                        : "r"(_vpairs_0[_pair]));
-                }
-            }
+  // === Task calls (dependency order) ===
+  int expert = blockIdx.x;
+  float acc[13];
+#pragma unroll
+  for (int m = 0; m < 13; m++) {
+    acc[m] = 0.0f;
+  }
+  asm volatile("griddepcontrol.wait;" ::: "memory");
+#pragma unroll
+  for (int ki = 0; ki < 7; ki++) {
+    int k_base = ki * 1024 + tid * 8;
+    float _vec_load_0[8];
+    {
+      const uint4* _vptr_0 = reinterpret_cast<const uint4*>(mat_b + (expert * 7168 + k_base) + 0);
+      uint4 _vld_0[1];
+#pragma unroll
+      for (int _blk = 0; _blk < 1; _blk++) {
+        _vld_0[_blk] = _vptr_0[_blk];
+        uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
+#pragma unroll
+        for (int _pair = 0; _pair < 4; _pair++) {
+          asm volatile(
+              "{\n\t"
+              "shl.b32 %0, %2, 16;\n\t"
+              "and.b32 %1, %2, 0xffff0000;\n\t"
+              "}\n"
+              : "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[0]),
+                "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[1])
+              : "r"(_vpairs_0[_pair]));
         }
-        #pragma unroll
-        for (int m_1 = 0; m_1 < 13; m_1++) {
-            float _vec_load_1[8];
-            {
-                const uint4* _vptr_1 = reinterpret_cast<const uint4*>(mat_a + (m_1 * 7168 + k_base) + 0);
-                uint4 _vld_1[1];
-                #pragma unroll
-                for (int _blk = 0; _blk < 1; _blk++) {
-                    _vld_1[_blk] = _vptr_1[_blk];
-                    uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
-                    #pragma unroll
-                    for (int _pair = 0; _pair < 4; _pair++) {
-                        asm volatile(
-                            "{\n\t"
-                            "shl.b32 %0, %2, 16;\n\t"
-                            "and.b32 %1, %2, 0xffff0000;\n\t"
-                            "}\n"
-                            : "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[1])
-                            : "r"(_vpairs_1[_pair]));
-                    }
-                }
-            }
-            #pragma unroll
-            for (int j = 0; j < 8; j++) {
-                float _fma_0 = __fmaf_rn(_vec_load_1[j], _vec_load_0[j], acc[m_1]);
-                acc[m_1] = _fma_0;
-            }
-        }
+      }
     }
-    #pragma unroll
-    for (int m_2 = 0; m_2 < 13; m_2++) {
-        float _warp_reduce_0 = acc[m_2];
-        #pragma unroll
-        for (int offset = 16; offset > 0; offset >>= 1)
-            _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
-        float warp_sum = _warp_reduce_0;
-        if (lane == 0) {
-            red[m_2 * 4 + warp] = warp_sum;
+#pragma unroll
+    for (int m_1 = 0; m_1 < 13; m_1++) {
+      float _vec_load_1[8];
+      {
+        const uint4* _vptr_1 = reinterpret_cast<const uint4*>(mat_a + (m_1 * 7168 + k_base) + 0);
+        uint4 _vld_1[1];
+#pragma unroll
+        for (int _blk = 0; _blk < 1; _blk++) {
+          _vld_1[_blk] = _vptr_1[_blk];
+          uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
+#pragma unroll
+          for (int _pair = 0; _pair < 4; _pair++) {
+            asm volatile(
+                "{\n\t"
+                "shl.b32 %0, %2, 16;\n\t"
+                "and.b32 %1, %2, 0xffff0000;\n\t"
+                "}\n"
+                : "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[0]),
+                  "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[1])
+                : "r"(_vpairs_1[_pair]));
+          }
         }
+      }
+#pragma unroll
+      for (int j = 0; j < 8; j++) {
+        float _fma_0 = __fmaf_rn(_vec_load_1[j], _vec_load_0[j], acc[m_1]);
+        acc[m_1] = _fma_0;
+      }
     }
-    asm volatile("barrier.sync 2, 128;" ::: "memory");
-    if (warp == 0) {
-        if (lane < 13) {
-            int m_3 = lane;
-            float total = red[m_3 * 4];
-            #pragma unroll
-            for (int source_warp = 1; source_warp < 4; source_warp++) {
-                total = total + red[m_3 * 4 + source_warp];
-            }
-            int offset = m_3 * num_experts + expert;
-            if (out_is_bf16 == 0) {
-                *(reinterpret_cast<float*>(out_f32 + offset) + (0)) = total;
-            } else {
-                *(reinterpret_cast<__nv_bfloat16*>(out_bf16 + offset) + (0)) = __float2bfloat16_rn(total);
-            }
-        }
+  }
+#pragma unroll
+  for (int m_2 = 0; m_2 < 13; m_2++) {
+    float _warp_reduce_0 = acc[m_2];
+#pragma unroll
+    for (int offset = 16; offset > 0; offset >>= 1)
+      _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
+    float warp_sum = _warp_reduce_0;
+    if (lane == 0) {
+      red[m_2 * 4 + warp] = warp_sum;
     }
-    asm volatile("griddepcontrol.launch_dependents;" ::: "memory");
+  }
+  asm volatile("barrier.sync 2, 128;" ::: "memory");
+  if (warp == 0) {
+    if (lane < 13) {
+      int m_3 = lane;
+      float total = red[m_3 * 4];
+#pragma unroll
+      for (int source_warp = 1; source_warp < 4; source_warp++) {
+        total = total + red[m_3 * 4 + source_warp];
+      }
+      int offset = m_3 * num_experts + expert;
+      if (out_is_bf16 == 0) {
+        *(reinterpret_cast<float*>(out_f32 + offset) + (0)) = total;
+      } else {
+        *(reinterpret_cast<__nv_bfloat16*>(out_bf16 + offset) + (0)) = __float2bfloat16_rn(total);
+      }
+    }
+  }
+  asm volatile("griddepcontrol.launch_dependents;" ::: "memory");
 }
 
-} // extern "C"
+}  // extern "C"

--- a/csrc/cake_router_gemm/cake_router_gemm_m14_k6144_device.cu
+++ b/csrc/cake_router_gemm/cake_router_gemm_m14_k6144_device.cu
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) 2026 by FlashInfer team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+typedef unsigned char      uint8_t;
+typedef unsigned short     uint16_t;
+typedef unsigned int       uint32_t;
+typedef unsigned long long uint64_t;
+typedef signed int         int32_t;
+typedef short int          int16_t;
+struct __align__(128) CakeTensorMap { uint64_t opaque[16]; };
+template <int N>
+struct __align__(128) CakeTensorMapPack { CakeTensorMap maps[N]; };
+
+typedef struct __align__(64) { uint64_t opaque[16]; } CUtensorMap;
+
+#include <cuda_bf16.h>
+
+__device__ __forceinline__ int make_warp_uniform(int x) {
+    int result;
+    asm volatile("shfl.sync.idx.b32 %0, %1, 0, 0x1F, 0xFFFFFFFF;"
+                 : "=r"(result) : "r"(x));
+    return result;
+}
+
+#define CAKE_INF CUDART_INF_F
+#define NUM_MAIN_STAGES 1
+#define SMEM_RED_OFF 0
+#define SMEM_RED_STAGE_BYTES 224
+#define SMEM_RED_STRIDE 224
+#define SMEM_TOTAL 256
+#define THREADS 128
+
+#include <math_constants.h>
+
+extern "C" {
+
+__global__ __launch_bounds__(128, 1) void
+kernel_cake_blackwell_router_gemm_m14_k6144(__nv_bfloat16* __restrict__ mat_a, __nv_bfloat16* __restrict__ mat_b, float* __restrict__ out_f32, __nv_bfloat16* __restrict__ out_bf16, int num_experts, int out_is_bf16)
+{
+    const int tid = threadIdx.x;
+    const int warp = make_warp_uniform(tid / 32);
+    const int lane = tid % 32;
+
+    extern __shared__ __align__(1024) char smem_raw[];
+    int smem;
+    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+
+    const int bid = blockIdx.x;
+    const int num_bids = gridDim.x;
+
+    // Kernel setup ops
+    float* red = reinterpret_cast<float*>(smem_raw + 0);
+    const int red_addr = smem + 0;
+
+    // === Task calls (dependency order) ===
+    int expert = blockIdx.x;
+    float acc[14];
+    #pragma unroll
+    for (int m = 0; m < 14; m++) {
+        acc[m] = 0.0f;
+    }
+    asm volatile("griddepcontrol.wait;" ::: "memory");
+    #pragma unroll
+    for (int ki = 0; ki < 6; ki++) {
+        int k_base = ki * 1024 + tid * 8;
+        float _vec_load_0[8];
+        {
+            const uint4* _vptr_0 = reinterpret_cast<const uint4*>(mat_b + (expert * 6144 + k_base) + 0);
+            uint4 _vld_0[1];
+            #pragma unroll
+            for (int _blk = 0; _blk < 1; _blk++) {
+                _vld_0[_blk] = _vptr_0[_blk];
+                uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
+                #pragma unroll
+                for (int _pair = 0; _pair < 4; _pair++) {
+                    asm volatile(
+                        "{\n\t"
+                        "shl.b32 %0, %2, 16;\n\t"
+                        "and.b32 %1, %2, 0xffff0000;\n\t"
+                        "}\n"
+                        : "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[1])
+                        : "r"(_vpairs_0[_pair]));
+                }
+            }
+        }
+        #pragma unroll
+        for (int m_1 = 0; m_1 < 14; m_1++) {
+            float _vec_load_1[8];
+            {
+                const uint4* _vptr_1 = reinterpret_cast<const uint4*>(mat_a + (m_1 * 6144 + k_base) + 0);
+                uint4 _vld_1[1];
+                #pragma unroll
+                for (int _blk = 0; _blk < 1; _blk++) {
+                    _vld_1[_blk] = _vptr_1[_blk];
+                    uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
+                    #pragma unroll
+                    for (int _pair = 0; _pair < 4; _pair++) {
+                        asm volatile(
+                            "{\n\t"
+                            "shl.b32 %0, %2, 16;\n\t"
+                            "and.b32 %1, %2, 0xffff0000;\n\t"
+                            "}\n"
+                            : "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[1])
+                            : "r"(_vpairs_1[_pair]));
+                    }
+                }
+            }
+            #pragma unroll
+            for (int j = 0; j < 8; j++) {
+                float _fma_0 = __fmaf_rn(_vec_load_1[j], _vec_load_0[j], acc[m_1]);
+                acc[m_1] = _fma_0;
+            }
+        }
+    }
+    #pragma unroll
+    for (int m_2 = 0; m_2 < 14; m_2++) {
+        float _warp_reduce_0 = acc[m_2];
+        #pragma unroll
+        for (int offset = 16; offset > 0; offset >>= 1)
+            _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
+        float warp_sum = _warp_reduce_0;
+        if (lane == 0) {
+            red[m_2 * 4 + warp] = warp_sum;
+        }
+    }
+    asm volatile("barrier.sync 2, 128;" ::: "memory");
+    if (warp == 0) {
+        if (lane < 14) {
+            int m_3 = lane;
+            float total = red[m_3 * 4];
+            #pragma unroll
+            for (int source_warp = 1; source_warp < 4; source_warp++) {
+                total = total + red[m_3 * 4 + source_warp];
+            }
+            int offset = m_3 * num_experts + expert;
+            if (out_is_bf16 == 0) {
+                *(reinterpret_cast<float*>(out_f32 + offset) + (0)) = total;
+            } else {
+                *(reinterpret_cast<__nv_bfloat16*>(out_bf16 + offset) + (0)) = __float2bfloat16_rn(total);
+            }
+        }
+    }
+    asm volatile("griddepcontrol.launch_dependents;" ::: "memory");
+}
+
+} // extern "C"

--- a/csrc/cake_router_gemm/cake_router_gemm_m14_k6144_device.cu
+++ b/csrc/cake_router_gemm/cake_router_gemm_m14_k6144_device.cu
@@ -14,25 +14,30 @@
  * limitations under the License.
  */
 
-typedef unsigned char      uint8_t;
-typedef unsigned short     uint16_t;
-typedef unsigned int       uint32_t;
+typedef unsigned char uint8_t;
+typedef unsigned short uint16_t;
+typedef unsigned int uint32_t;
 typedef unsigned long long uint64_t;
-typedef signed int         int32_t;
-typedef short int          int16_t;
-struct __align__(128) CakeTensorMap { uint64_t opaque[16]; };
+typedef signed int int32_t;
+typedef short int int16_t;
+struct __align__(128) CakeTensorMap {
+  uint64_t opaque[16];
+};
 template <int N>
-struct __align__(128) CakeTensorMapPack { CakeTensorMap maps[N]; };
+struct __align__(128) CakeTensorMapPack {
+  CakeTensorMap maps[N];
+};
 
-typedef struct __align__(64) { uint64_t opaque[16]; } CUtensorMap;
+typedef struct __align__(64) {
+  uint64_t opaque[16];
+} CUtensorMap;
 
 #include <cuda_bf16.h>
 
 __device__ __forceinline__ int make_warp_uniform(int x) {
-    int result;
-    asm volatile("shfl.sync.idx.b32 %0, %1, 0, 0x1F, 0xFFFFFFFF;"
-                 : "=r"(result) : "r"(x));
-    return result;
+  int result;
+  asm volatile("shfl.sync.idx.b32 %0, %1, 0, 0x1F, 0xFFFFFFFF;" : "=r"(result) : "r"(x));
+  return result;
 }
 
 #define CAKE_INF CUDART_INF_F
@@ -47,113 +52,116 @@ __device__ __forceinline__ int make_warp_uniform(int x) {
 
 extern "C" {
 
-__global__ __launch_bounds__(128, 1) void
-kernel_cake_blackwell_router_gemm_m14_k6144(__nv_bfloat16* __restrict__ mat_a, __nv_bfloat16* __restrict__ mat_b, float* __restrict__ out_f32, __nv_bfloat16* __restrict__ out_bf16, int num_experts, int out_is_bf16)
-{
-    const int tid = threadIdx.x;
-    const int warp = make_warp_uniform(tid / 32);
-    const int lane = tid % 32;
+__global__ __launch_bounds__(128, 1) void kernel_cake_blackwell_router_gemm_m14_k6144(
+    __nv_bfloat16* __restrict__ mat_a, __nv_bfloat16* __restrict__ mat_b,
+    float* __restrict__ out_f32, __nv_bfloat16* __restrict__ out_bf16, int num_experts,
+    int out_is_bf16) {
+  const int tid = threadIdx.x;
+  const int warp = make_warp_uniform(tid / 32);
+  const int lane = tid % 32;
 
-    extern __shared__ __align__(1024) char smem_raw[];
-    int smem;
-    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+  extern __shared__ __align__(1024) char smem_raw[];
+  int smem;
+  smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
 
-    const int bid = blockIdx.x;
-    const int num_bids = gridDim.x;
+  const int bid = blockIdx.x;
+  const int num_bids = gridDim.x;
 
-    // Kernel setup ops
-    float* red = reinterpret_cast<float*>(smem_raw + 0);
-    const int red_addr = smem + 0;
+  // Kernel setup ops
+  float* red = reinterpret_cast<float*>(smem_raw + 0);
+  const int red_addr = smem + 0;
 
-    // === Task calls (dependency order) ===
-    int expert = blockIdx.x;
-    float acc[14];
-    #pragma unroll
-    for (int m = 0; m < 14; m++) {
-        acc[m] = 0.0f;
-    }
-    asm volatile("griddepcontrol.wait;" ::: "memory");
-    #pragma unroll
-    for (int ki = 0; ki < 6; ki++) {
-        int k_base = ki * 1024 + tid * 8;
-        float _vec_load_0[8];
-        {
-            const uint4* _vptr_0 = reinterpret_cast<const uint4*>(mat_b + (expert * 6144 + k_base) + 0);
-            uint4 _vld_0[1];
-            #pragma unroll
-            for (int _blk = 0; _blk < 1; _blk++) {
-                _vld_0[_blk] = _vptr_0[_blk];
-                uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
-                #pragma unroll
-                for (int _pair = 0; _pair < 4; _pair++) {
-                    asm volatile(
-                        "{\n\t"
-                        "shl.b32 %0, %2, 16;\n\t"
-                        "and.b32 %1, %2, 0xffff0000;\n\t"
-                        "}\n"
-                        : "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[1])
-                        : "r"(_vpairs_0[_pair]));
-                }
-            }
+  // === Task calls (dependency order) ===
+  int expert = blockIdx.x;
+  float acc[14];
+#pragma unroll
+  for (int m = 0; m < 14; m++) {
+    acc[m] = 0.0f;
+  }
+  asm volatile("griddepcontrol.wait;" ::: "memory");
+#pragma unroll
+  for (int ki = 0; ki < 6; ki++) {
+    int k_base = ki * 1024 + tid * 8;
+    float _vec_load_0[8];
+    {
+      const uint4* _vptr_0 = reinterpret_cast<const uint4*>(mat_b + (expert * 6144 + k_base) + 0);
+      uint4 _vld_0[1];
+#pragma unroll
+      for (int _blk = 0; _blk < 1; _blk++) {
+        _vld_0[_blk] = _vptr_0[_blk];
+        uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
+#pragma unroll
+        for (int _pair = 0; _pair < 4; _pair++) {
+          asm volatile(
+              "{\n\t"
+              "shl.b32 %0, %2, 16;\n\t"
+              "and.b32 %1, %2, 0xffff0000;\n\t"
+              "}\n"
+              : "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[0]),
+                "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[1])
+              : "r"(_vpairs_0[_pair]));
         }
-        #pragma unroll
-        for (int m_1 = 0; m_1 < 14; m_1++) {
-            float _vec_load_1[8];
-            {
-                const uint4* _vptr_1 = reinterpret_cast<const uint4*>(mat_a + (m_1 * 6144 + k_base) + 0);
-                uint4 _vld_1[1];
-                #pragma unroll
-                for (int _blk = 0; _blk < 1; _blk++) {
-                    _vld_1[_blk] = _vptr_1[_blk];
-                    uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
-                    #pragma unroll
-                    for (int _pair = 0; _pair < 4; _pair++) {
-                        asm volatile(
-                            "{\n\t"
-                            "shl.b32 %0, %2, 16;\n\t"
-                            "and.b32 %1, %2, 0xffff0000;\n\t"
-                            "}\n"
-                            : "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[1])
-                            : "r"(_vpairs_1[_pair]));
-                    }
-                }
-            }
-            #pragma unroll
-            for (int j = 0; j < 8; j++) {
-                float _fma_0 = __fmaf_rn(_vec_load_1[j], _vec_load_0[j], acc[m_1]);
-                acc[m_1] = _fma_0;
-            }
-        }
+      }
     }
-    #pragma unroll
-    for (int m_2 = 0; m_2 < 14; m_2++) {
-        float _warp_reduce_0 = acc[m_2];
-        #pragma unroll
-        for (int offset = 16; offset > 0; offset >>= 1)
-            _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
-        float warp_sum = _warp_reduce_0;
-        if (lane == 0) {
-            red[m_2 * 4 + warp] = warp_sum;
+#pragma unroll
+    for (int m_1 = 0; m_1 < 14; m_1++) {
+      float _vec_load_1[8];
+      {
+        const uint4* _vptr_1 = reinterpret_cast<const uint4*>(mat_a + (m_1 * 6144 + k_base) + 0);
+        uint4 _vld_1[1];
+#pragma unroll
+        for (int _blk = 0; _blk < 1; _blk++) {
+          _vld_1[_blk] = _vptr_1[_blk];
+          uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
+#pragma unroll
+          for (int _pair = 0; _pair < 4; _pair++) {
+            asm volatile(
+                "{\n\t"
+                "shl.b32 %0, %2, 16;\n\t"
+                "and.b32 %1, %2, 0xffff0000;\n\t"
+                "}\n"
+                : "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[0]),
+                  "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[1])
+                : "r"(_vpairs_1[_pair]));
+          }
         }
+      }
+#pragma unroll
+      for (int j = 0; j < 8; j++) {
+        float _fma_0 = __fmaf_rn(_vec_load_1[j], _vec_load_0[j], acc[m_1]);
+        acc[m_1] = _fma_0;
+      }
     }
-    asm volatile("barrier.sync 2, 128;" ::: "memory");
-    if (warp == 0) {
-        if (lane < 14) {
-            int m_3 = lane;
-            float total = red[m_3 * 4];
-            #pragma unroll
-            for (int source_warp = 1; source_warp < 4; source_warp++) {
-                total = total + red[m_3 * 4 + source_warp];
-            }
-            int offset = m_3 * num_experts + expert;
-            if (out_is_bf16 == 0) {
-                *(reinterpret_cast<float*>(out_f32 + offset) + (0)) = total;
-            } else {
-                *(reinterpret_cast<__nv_bfloat16*>(out_bf16 + offset) + (0)) = __float2bfloat16_rn(total);
-            }
-        }
+  }
+#pragma unroll
+  for (int m_2 = 0; m_2 < 14; m_2++) {
+    float _warp_reduce_0 = acc[m_2];
+#pragma unroll
+    for (int offset = 16; offset > 0; offset >>= 1)
+      _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
+    float warp_sum = _warp_reduce_0;
+    if (lane == 0) {
+      red[m_2 * 4 + warp] = warp_sum;
     }
-    asm volatile("griddepcontrol.launch_dependents;" ::: "memory");
+  }
+  asm volatile("barrier.sync 2, 128;" ::: "memory");
+  if (warp == 0) {
+    if (lane < 14) {
+      int m_3 = lane;
+      float total = red[m_3 * 4];
+#pragma unroll
+      for (int source_warp = 1; source_warp < 4; source_warp++) {
+        total = total + red[m_3 * 4 + source_warp];
+      }
+      int offset = m_3 * num_experts + expert;
+      if (out_is_bf16 == 0) {
+        *(reinterpret_cast<float*>(out_f32 + offset) + (0)) = total;
+      } else {
+        *(reinterpret_cast<__nv_bfloat16*>(out_bf16 + offset) + (0)) = __float2bfloat16_rn(total);
+      }
+    }
+  }
+  asm volatile("griddepcontrol.launch_dependents;" ::: "memory");
 }
 
-} // extern "C"
+}  // extern "C"

--- a/csrc/cake_router_gemm/cake_router_gemm_m14_k7168_device.cu
+++ b/csrc/cake_router_gemm/cake_router_gemm_m14_k7168_device.cu
@@ -14,25 +14,30 @@
  * limitations under the License.
  */
 
-typedef unsigned char      uint8_t;
-typedef unsigned short     uint16_t;
-typedef unsigned int       uint32_t;
+typedef unsigned char uint8_t;
+typedef unsigned short uint16_t;
+typedef unsigned int uint32_t;
 typedef unsigned long long uint64_t;
-typedef signed int         int32_t;
-typedef short int          int16_t;
-struct __align__(128) CakeTensorMap { uint64_t opaque[16]; };
+typedef signed int int32_t;
+typedef short int int16_t;
+struct __align__(128) CakeTensorMap {
+  uint64_t opaque[16];
+};
 template <int N>
-struct __align__(128) CakeTensorMapPack { CakeTensorMap maps[N]; };
+struct __align__(128) CakeTensorMapPack {
+  CakeTensorMap maps[N];
+};
 
-typedef struct __align__(64) { uint64_t opaque[16]; } CUtensorMap;
+typedef struct __align__(64) {
+  uint64_t opaque[16];
+} CUtensorMap;
 
 #include <cuda_bf16.h>
 
 __device__ __forceinline__ int make_warp_uniform(int x) {
-    int result;
-    asm volatile("shfl.sync.idx.b32 %0, %1, 0, 0x1F, 0xFFFFFFFF;"
-                 : "=r"(result) : "r"(x));
-    return result;
+  int result;
+  asm volatile("shfl.sync.idx.b32 %0, %1, 0, 0x1F, 0xFFFFFFFF;" : "=r"(result) : "r"(x));
+  return result;
 }
 
 #define CAKE_INF CUDART_INF_F
@@ -47,113 +52,116 @@ __device__ __forceinline__ int make_warp_uniform(int x) {
 
 extern "C" {
 
-__global__ __launch_bounds__(128, 1) void
-kernel_cake_blackwell_router_gemm_m14_k7168(__nv_bfloat16* __restrict__ mat_a, __nv_bfloat16* __restrict__ mat_b, float* __restrict__ out_f32, __nv_bfloat16* __restrict__ out_bf16, int num_experts, int out_is_bf16)
-{
-    const int tid = threadIdx.x;
-    const int warp = make_warp_uniform(tid / 32);
-    const int lane = tid % 32;
+__global__ __launch_bounds__(128, 1) void kernel_cake_blackwell_router_gemm_m14_k7168(
+    __nv_bfloat16* __restrict__ mat_a, __nv_bfloat16* __restrict__ mat_b,
+    float* __restrict__ out_f32, __nv_bfloat16* __restrict__ out_bf16, int num_experts,
+    int out_is_bf16) {
+  const int tid = threadIdx.x;
+  const int warp = make_warp_uniform(tid / 32);
+  const int lane = tid % 32;
 
-    extern __shared__ __align__(1024) char smem_raw[];
-    int smem;
-    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+  extern __shared__ __align__(1024) char smem_raw[];
+  int smem;
+  smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
 
-    const int bid = blockIdx.x;
-    const int num_bids = gridDim.x;
+  const int bid = blockIdx.x;
+  const int num_bids = gridDim.x;
 
-    // Kernel setup ops
-    float* red = reinterpret_cast<float*>(smem_raw + 0);
-    const int red_addr = smem + 0;
+  // Kernel setup ops
+  float* red = reinterpret_cast<float*>(smem_raw + 0);
+  const int red_addr = smem + 0;
 
-    // === Task calls (dependency order) ===
-    int expert = blockIdx.x;
-    float acc[14];
-    #pragma unroll
-    for (int m = 0; m < 14; m++) {
-        acc[m] = 0.0f;
-    }
-    asm volatile("griddepcontrol.wait;" ::: "memory");
-    #pragma unroll
-    for (int ki = 0; ki < 7; ki++) {
-        int k_base = ki * 1024 + tid * 8;
-        float _vec_load_0[8];
-        {
-            const uint4* _vptr_0 = reinterpret_cast<const uint4*>(mat_b + (expert * 7168 + k_base) + 0);
-            uint4 _vld_0[1];
-            #pragma unroll
-            for (int _blk = 0; _blk < 1; _blk++) {
-                _vld_0[_blk] = _vptr_0[_blk];
-                uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
-                #pragma unroll
-                for (int _pair = 0; _pair < 4; _pair++) {
-                    asm volatile(
-                        "{\n\t"
-                        "shl.b32 %0, %2, 16;\n\t"
-                        "and.b32 %1, %2, 0xffff0000;\n\t"
-                        "}\n"
-                        : "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[1])
-                        : "r"(_vpairs_0[_pair]));
-                }
-            }
+  // === Task calls (dependency order) ===
+  int expert = blockIdx.x;
+  float acc[14];
+#pragma unroll
+  for (int m = 0; m < 14; m++) {
+    acc[m] = 0.0f;
+  }
+  asm volatile("griddepcontrol.wait;" ::: "memory");
+#pragma unroll
+  for (int ki = 0; ki < 7; ki++) {
+    int k_base = ki * 1024 + tid * 8;
+    float _vec_load_0[8];
+    {
+      const uint4* _vptr_0 = reinterpret_cast<const uint4*>(mat_b + (expert * 7168 + k_base) + 0);
+      uint4 _vld_0[1];
+#pragma unroll
+      for (int _blk = 0; _blk < 1; _blk++) {
+        _vld_0[_blk] = _vptr_0[_blk];
+        uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
+#pragma unroll
+        for (int _pair = 0; _pair < 4; _pair++) {
+          asm volatile(
+              "{\n\t"
+              "shl.b32 %0, %2, 16;\n\t"
+              "and.b32 %1, %2, 0xffff0000;\n\t"
+              "}\n"
+              : "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[0]),
+                "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[1])
+              : "r"(_vpairs_0[_pair]));
         }
-        #pragma unroll
-        for (int m_1 = 0; m_1 < 14; m_1++) {
-            float _vec_load_1[8];
-            {
-                const uint4* _vptr_1 = reinterpret_cast<const uint4*>(mat_a + (m_1 * 7168 + k_base) + 0);
-                uint4 _vld_1[1];
-                #pragma unroll
-                for (int _blk = 0; _blk < 1; _blk++) {
-                    _vld_1[_blk] = _vptr_1[_blk];
-                    uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
-                    #pragma unroll
-                    for (int _pair = 0; _pair < 4; _pair++) {
-                        asm volatile(
-                            "{\n\t"
-                            "shl.b32 %0, %2, 16;\n\t"
-                            "and.b32 %1, %2, 0xffff0000;\n\t"
-                            "}\n"
-                            : "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[1])
-                            : "r"(_vpairs_1[_pair]));
-                    }
-                }
-            }
-            #pragma unroll
-            for (int j = 0; j < 8; j++) {
-                float _fma_0 = __fmaf_rn(_vec_load_1[j], _vec_load_0[j], acc[m_1]);
-                acc[m_1] = _fma_0;
-            }
-        }
+      }
     }
-    #pragma unroll
-    for (int m_2 = 0; m_2 < 14; m_2++) {
-        float _warp_reduce_0 = acc[m_2];
-        #pragma unroll
-        for (int offset = 16; offset > 0; offset >>= 1)
-            _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
-        float warp_sum = _warp_reduce_0;
-        if (lane == 0) {
-            red[m_2 * 4 + warp] = warp_sum;
+#pragma unroll
+    for (int m_1 = 0; m_1 < 14; m_1++) {
+      float _vec_load_1[8];
+      {
+        const uint4* _vptr_1 = reinterpret_cast<const uint4*>(mat_a + (m_1 * 7168 + k_base) + 0);
+        uint4 _vld_1[1];
+#pragma unroll
+        for (int _blk = 0; _blk < 1; _blk++) {
+          _vld_1[_blk] = _vptr_1[_blk];
+          uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
+#pragma unroll
+          for (int _pair = 0; _pair < 4; _pair++) {
+            asm volatile(
+                "{\n\t"
+                "shl.b32 %0, %2, 16;\n\t"
+                "and.b32 %1, %2, 0xffff0000;\n\t"
+                "}\n"
+                : "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[0]),
+                  "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[1])
+                : "r"(_vpairs_1[_pair]));
+          }
         }
+      }
+#pragma unroll
+      for (int j = 0; j < 8; j++) {
+        float _fma_0 = __fmaf_rn(_vec_load_1[j], _vec_load_0[j], acc[m_1]);
+        acc[m_1] = _fma_0;
+      }
     }
-    asm volatile("barrier.sync 2, 128;" ::: "memory");
-    if (warp == 0) {
-        if (lane < 14) {
-            int m_3 = lane;
-            float total = red[m_3 * 4];
-            #pragma unroll
-            for (int source_warp = 1; source_warp < 4; source_warp++) {
-                total = total + red[m_3 * 4 + source_warp];
-            }
-            int offset = m_3 * num_experts + expert;
-            if (out_is_bf16 == 0) {
-                *(reinterpret_cast<float*>(out_f32 + offset) + (0)) = total;
-            } else {
-                *(reinterpret_cast<__nv_bfloat16*>(out_bf16 + offset) + (0)) = __float2bfloat16_rn(total);
-            }
-        }
+  }
+#pragma unroll
+  for (int m_2 = 0; m_2 < 14; m_2++) {
+    float _warp_reduce_0 = acc[m_2];
+#pragma unroll
+    for (int offset = 16; offset > 0; offset >>= 1)
+      _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
+    float warp_sum = _warp_reduce_0;
+    if (lane == 0) {
+      red[m_2 * 4 + warp] = warp_sum;
     }
-    asm volatile("griddepcontrol.launch_dependents;" ::: "memory");
+  }
+  asm volatile("barrier.sync 2, 128;" ::: "memory");
+  if (warp == 0) {
+    if (lane < 14) {
+      int m_3 = lane;
+      float total = red[m_3 * 4];
+#pragma unroll
+      for (int source_warp = 1; source_warp < 4; source_warp++) {
+        total = total + red[m_3 * 4 + source_warp];
+      }
+      int offset = m_3 * num_experts + expert;
+      if (out_is_bf16 == 0) {
+        *(reinterpret_cast<float*>(out_f32 + offset) + (0)) = total;
+      } else {
+        *(reinterpret_cast<__nv_bfloat16*>(out_bf16 + offset) + (0)) = __float2bfloat16_rn(total);
+      }
+    }
+  }
+  asm volatile("griddepcontrol.launch_dependents;" ::: "memory");
 }
 
-} // extern "C"
+}  // extern "C"

--- a/csrc/cake_router_gemm/cake_router_gemm_m14_k7168_device.cu
+++ b/csrc/cake_router_gemm/cake_router_gemm_m14_k7168_device.cu
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) 2026 by FlashInfer team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+typedef unsigned char      uint8_t;
+typedef unsigned short     uint16_t;
+typedef unsigned int       uint32_t;
+typedef unsigned long long uint64_t;
+typedef signed int         int32_t;
+typedef short int          int16_t;
+struct __align__(128) CakeTensorMap { uint64_t opaque[16]; };
+template <int N>
+struct __align__(128) CakeTensorMapPack { CakeTensorMap maps[N]; };
+
+typedef struct __align__(64) { uint64_t opaque[16]; } CUtensorMap;
+
+#include <cuda_bf16.h>
+
+__device__ __forceinline__ int make_warp_uniform(int x) {
+    int result;
+    asm volatile("shfl.sync.idx.b32 %0, %1, 0, 0x1F, 0xFFFFFFFF;"
+                 : "=r"(result) : "r"(x));
+    return result;
+}
+
+#define CAKE_INF CUDART_INF_F
+#define NUM_MAIN_STAGES 1
+#define SMEM_RED_OFF 0
+#define SMEM_RED_STAGE_BYTES 224
+#define SMEM_RED_STRIDE 224
+#define SMEM_TOTAL 256
+#define THREADS 128
+
+#include <math_constants.h>
+
+extern "C" {
+
+__global__ __launch_bounds__(128, 1) void
+kernel_cake_blackwell_router_gemm_m14_k7168(__nv_bfloat16* __restrict__ mat_a, __nv_bfloat16* __restrict__ mat_b, float* __restrict__ out_f32, __nv_bfloat16* __restrict__ out_bf16, int num_experts, int out_is_bf16)
+{
+    const int tid = threadIdx.x;
+    const int warp = make_warp_uniform(tid / 32);
+    const int lane = tid % 32;
+
+    extern __shared__ __align__(1024) char smem_raw[];
+    int smem;
+    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+
+    const int bid = blockIdx.x;
+    const int num_bids = gridDim.x;
+
+    // Kernel setup ops
+    float* red = reinterpret_cast<float*>(smem_raw + 0);
+    const int red_addr = smem + 0;
+
+    // === Task calls (dependency order) ===
+    int expert = blockIdx.x;
+    float acc[14];
+    #pragma unroll
+    for (int m = 0; m < 14; m++) {
+        acc[m] = 0.0f;
+    }
+    asm volatile("griddepcontrol.wait;" ::: "memory");
+    #pragma unroll
+    for (int ki = 0; ki < 7; ki++) {
+        int k_base = ki * 1024 + tid * 8;
+        float _vec_load_0[8];
+        {
+            const uint4* _vptr_0 = reinterpret_cast<const uint4*>(mat_b + (expert * 7168 + k_base) + 0);
+            uint4 _vld_0[1];
+            #pragma unroll
+            for (int _blk = 0; _blk < 1; _blk++) {
+                _vld_0[_blk] = _vptr_0[_blk];
+                uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
+                #pragma unroll
+                for (int _pair = 0; _pair < 4; _pair++) {
+                    asm volatile(
+                        "{\n\t"
+                        "shl.b32 %0, %2, 16;\n\t"
+                        "and.b32 %1, %2, 0xffff0000;\n\t"
+                        "}\n"
+                        : "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[1])
+                        : "r"(_vpairs_0[_pair]));
+                }
+            }
+        }
+        #pragma unroll
+        for (int m_1 = 0; m_1 < 14; m_1++) {
+            float _vec_load_1[8];
+            {
+                const uint4* _vptr_1 = reinterpret_cast<const uint4*>(mat_a + (m_1 * 7168 + k_base) + 0);
+                uint4 _vld_1[1];
+                #pragma unroll
+                for (int _blk = 0; _blk < 1; _blk++) {
+                    _vld_1[_blk] = _vptr_1[_blk];
+                    uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
+                    #pragma unroll
+                    for (int _pair = 0; _pair < 4; _pair++) {
+                        asm volatile(
+                            "{\n\t"
+                            "shl.b32 %0, %2, 16;\n\t"
+                            "and.b32 %1, %2, 0xffff0000;\n\t"
+                            "}\n"
+                            : "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[1])
+                            : "r"(_vpairs_1[_pair]));
+                    }
+                }
+            }
+            #pragma unroll
+            for (int j = 0; j < 8; j++) {
+                float _fma_0 = __fmaf_rn(_vec_load_1[j], _vec_load_0[j], acc[m_1]);
+                acc[m_1] = _fma_0;
+            }
+        }
+    }
+    #pragma unroll
+    for (int m_2 = 0; m_2 < 14; m_2++) {
+        float _warp_reduce_0 = acc[m_2];
+        #pragma unroll
+        for (int offset = 16; offset > 0; offset >>= 1)
+            _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
+        float warp_sum = _warp_reduce_0;
+        if (lane == 0) {
+            red[m_2 * 4 + warp] = warp_sum;
+        }
+    }
+    asm volatile("barrier.sync 2, 128;" ::: "memory");
+    if (warp == 0) {
+        if (lane < 14) {
+            int m_3 = lane;
+            float total = red[m_3 * 4];
+            #pragma unroll
+            for (int source_warp = 1; source_warp < 4; source_warp++) {
+                total = total + red[m_3 * 4 + source_warp];
+            }
+            int offset = m_3 * num_experts + expert;
+            if (out_is_bf16 == 0) {
+                *(reinterpret_cast<float*>(out_f32 + offset) + (0)) = total;
+            } else {
+                *(reinterpret_cast<__nv_bfloat16*>(out_bf16 + offset) + (0)) = __float2bfloat16_rn(total);
+            }
+        }
+    }
+    asm volatile("griddepcontrol.launch_dependents;" ::: "memory");
+}
+
+} // extern "C"

--- a/csrc/cake_router_gemm/cake_router_gemm_m15_k6144_device.cu
+++ b/csrc/cake_router_gemm/cake_router_gemm_m15_k6144_device.cu
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) 2026 by FlashInfer team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+typedef unsigned char      uint8_t;
+typedef unsigned short     uint16_t;
+typedef unsigned int       uint32_t;
+typedef unsigned long long uint64_t;
+typedef signed int         int32_t;
+typedef short int          int16_t;
+struct __align__(128) CakeTensorMap { uint64_t opaque[16]; };
+template <int N>
+struct __align__(128) CakeTensorMapPack { CakeTensorMap maps[N]; };
+
+typedef struct __align__(64) { uint64_t opaque[16]; } CUtensorMap;
+
+#include <cuda_bf16.h>
+
+__device__ __forceinline__ int make_warp_uniform(int x) {
+    int result;
+    asm volatile("shfl.sync.idx.b32 %0, %1, 0, 0x1F, 0xFFFFFFFF;"
+                 : "=r"(result) : "r"(x));
+    return result;
+}
+
+#define CAKE_INF CUDART_INF_F
+#define NUM_MAIN_STAGES 1
+#define SMEM_RED_OFF 0
+#define SMEM_RED_STAGE_BYTES 240
+#define SMEM_RED_STRIDE 240
+#define SMEM_TOTAL 256
+#define THREADS 128
+
+#include <math_constants.h>
+
+extern "C" {
+
+__global__ __launch_bounds__(128, 1) void
+kernel_cake_blackwell_router_gemm_m15_k6144(__nv_bfloat16* __restrict__ mat_a, __nv_bfloat16* __restrict__ mat_b, float* __restrict__ out_f32, __nv_bfloat16* __restrict__ out_bf16, int num_experts, int out_is_bf16)
+{
+    const int tid = threadIdx.x;
+    const int warp = make_warp_uniform(tid / 32);
+    const int lane = tid % 32;
+
+    extern __shared__ __align__(1024) char smem_raw[];
+    int smem;
+    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+
+    const int bid = blockIdx.x;
+    const int num_bids = gridDim.x;
+
+    // Kernel setup ops
+    float* red = reinterpret_cast<float*>(smem_raw + 0);
+    const int red_addr = smem + 0;
+
+    // === Task calls (dependency order) ===
+    int expert = blockIdx.x;
+    float acc[15];
+    #pragma unroll
+    for (int m = 0; m < 15; m++) {
+        acc[m] = 0.0f;
+    }
+    asm volatile("griddepcontrol.wait;" ::: "memory");
+    #pragma unroll
+    for (int ki = 0; ki < 6; ki++) {
+        int k_base = ki * 1024 + tid * 8;
+        float _vec_load_0[8];
+        {
+            const uint4* _vptr_0 = reinterpret_cast<const uint4*>(mat_b + (expert * 6144 + k_base) + 0);
+            uint4 _vld_0[1];
+            #pragma unroll
+            for (int _blk = 0; _blk < 1; _blk++) {
+                _vld_0[_blk] = _vptr_0[_blk];
+                uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
+                #pragma unroll
+                for (int _pair = 0; _pair < 4; _pair++) {
+                    asm volatile(
+                        "{\n\t"
+                        "shl.b32 %0, %2, 16;\n\t"
+                        "and.b32 %1, %2, 0xffff0000;\n\t"
+                        "}\n"
+                        : "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[1])
+                        : "r"(_vpairs_0[_pair]));
+                }
+            }
+        }
+        #pragma unroll
+        for (int m_1 = 0; m_1 < 15; m_1++) {
+            float _vec_load_1[8];
+            {
+                const uint4* _vptr_1 = reinterpret_cast<const uint4*>(mat_a + (m_1 * 6144 + k_base) + 0);
+                uint4 _vld_1[1];
+                #pragma unroll
+                for (int _blk = 0; _blk < 1; _blk++) {
+                    _vld_1[_blk] = _vptr_1[_blk];
+                    uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
+                    #pragma unroll
+                    for (int _pair = 0; _pair < 4; _pair++) {
+                        asm volatile(
+                            "{\n\t"
+                            "shl.b32 %0, %2, 16;\n\t"
+                            "and.b32 %1, %2, 0xffff0000;\n\t"
+                            "}\n"
+                            : "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[1])
+                            : "r"(_vpairs_1[_pair]));
+                    }
+                }
+            }
+            #pragma unroll
+            for (int j = 0; j < 8; j++) {
+                float _fma_0 = __fmaf_rn(_vec_load_1[j], _vec_load_0[j], acc[m_1]);
+                acc[m_1] = _fma_0;
+            }
+        }
+    }
+    #pragma unroll
+    for (int m_2 = 0; m_2 < 15; m_2++) {
+        float _warp_reduce_0 = acc[m_2];
+        #pragma unroll
+        for (int offset = 16; offset > 0; offset >>= 1)
+            _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
+        float warp_sum = _warp_reduce_0;
+        if (lane == 0) {
+            red[m_2 * 4 + warp] = warp_sum;
+        }
+    }
+    asm volatile("barrier.sync 2, 128;" ::: "memory");
+    if (warp == 0) {
+        if (lane < 15) {
+            int m_3 = lane;
+            float total = red[m_3 * 4];
+            #pragma unroll
+            for (int source_warp = 1; source_warp < 4; source_warp++) {
+                total = total + red[m_3 * 4 + source_warp];
+            }
+            int offset = m_3 * num_experts + expert;
+            if (out_is_bf16 == 0) {
+                *(reinterpret_cast<float*>(out_f32 + offset) + (0)) = total;
+            } else {
+                *(reinterpret_cast<__nv_bfloat16*>(out_bf16 + offset) + (0)) = __float2bfloat16_rn(total);
+            }
+        }
+    }
+    asm volatile("griddepcontrol.launch_dependents;" ::: "memory");
+}
+
+} // extern "C"

--- a/csrc/cake_router_gemm/cake_router_gemm_m15_k6144_device.cu
+++ b/csrc/cake_router_gemm/cake_router_gemm_m15_k6144_device.cu
@@ -14,25 +14,30 @@
  * limitations under the License.
  */
 
-typedef unsigned char      uint8_t;
-typedef unsigned short     uint16_t;
-typedef unsigned int       uint32_t;
+typedef unsigned char uint8_t;
+typedef unsigned short uint16_t;
+typedef unsigned int uint32_t;
 typedef unsigned long long uint64_t;
-typedef signed int         int32_t;
-typedef short int          int16_t;
-struct __align__(128) CakeTensorMap { uint64_t opaque[16]; };
+typedef signed int int32_t;
+typedef short int int16_t;
+struct __align__(128) CakeTensorMap {
+  uint64_t opaque[16];
+};
 template <int N>
-struct __align__(128) CakeTensorMapPack { CakeTensorMap maps[N]; };
+struct __align__(128) CakeTensorMapPack {
+  CakeTensorMap maps[N];
+};
 
-typedef struct __align__(64) { uint64_t opaque[16]; } CUtensorMap;
+typedef struct __align__(64) {
+  uint64_t opaque[16];
+} CUtensorMap;
 
 #include <cuda_bf16.h>
 
 __device__ __forceinline__ int make_warp_uniform(int x) {
-    int result;
-    asm volatile("shfl.sync.idx.b32 %0, %1, 0, 0x1F, 0xFFFFFFFF;"
-                 : "=r"(result) : "r"(x));
-    return result;
+  int result;
+  asm volatile("shfl.sync.idx.b32 %0, %1, 0, 0x1F, 0xFFFFFFFF;" : "=r"(result) : "r"(x));
+  return result;
 }
 
 #define CAKE_INF CUDART_INF_F
@@ -47,113 +52,116 @@ __device__ __forceinline__ int make_warp_uniform(int x) {
 
 extern "C" {
 
-__global__ __launch_bounds__(128, 1) void
-kernel_cake_blackwell_router_gemm_m15_k6144(__nv_bfloat16* __restrict__ mat_a, __nv_bfloat16* __restrict__ mat_b, float* __restrict__ out_f32, __nv_bfloat16* __restrict__ out_bf16, int num_experts, int out_is_bf16)
-{
-    const int tid = threadIdx.x;
-    const int warp = make_warp_uniform(tid / 32);
-    const int lane = tid % 32;
+__global__ __launch_bounds__(128, 1) void kernel_cake_blackwell_router_gemm_m15_k6144(
+    __nv_bfloat16* __restrict__ mat_a, __nv_bfloat16* __restrict__ mat_b,
+    float* __restrict__ out_f32, __nv_bfloat16* __restrict__ out_bf16, int num_experts,
+    int out_is_bf16) {
+  const int tid = threadIdx.x;
+  const int warp = make_warp_uniform(tid / 32);
+  const int lane = tid % 32;
 
-    extern __shared__ __align__(1024) char smem_raw[];
-    int smem;
-    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+  extern __shared__ __align__(1024) char smem_raw[];
+  int smem;
+  smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
 
-    const int bid = blockIdx.x;
-    const int num_bids = gridDim.x;
+  const int bid = blockIdx.x;
+  const int num_bids = gridDim.x;
 
-    // Kernel setup ops
-    float* red = reinterpret_cast<float*>(smem_raw + 0);
-    const int red_addr = smem + 0;
+  // Kernel setup ops
+  float* red = reinterpret_cast<float*>(smem_raw + 0);
+  const int red_addr = smem + 0;
 
-    // === Task calls (dependency order) ===
-    int expert = blockIdx.x;
-    float acc[15];
-    #pragma unroll
-    for (int m = 0; m < 15; m++) {
-        acc[m] = 0.0f;
-    }
-    asm volatile("griddepcontrol.wait;" ::: "memory");
-    #pragma unroll
-    for (int ki = 0; ki < 6; ki++) {
-        int k_base = ki * 1024 + tid * 8;
-        float _vec_load_0[8];
-        {
-            const uint4* _vptr_0 = reinterpret_cast<const uint4*>(mat_b + (expert * 6144 + k_base) + 0);
-            uint4 _vld_0[1];
-            #pragma unroll
-            for (int _blk = 0; _blk < 1; _blk++) {
-                _vld_0[_blk] = _vptr_0[_blk];
-                uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
-                #pragma unroll
-                for (int _pair = 0; _pair < 4; _pair++) {
-                    asm volatile(
-                        "{\n\t"
-                        "shl.b32 %0, %2, 16;\n\t"
-                        "and.b32 %1, %2, 0xffff0000;\n\t"
-                        "}\n"
-                        : "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[1])
-                        : "r"(_vpairs_0[_pair]));
-                }
-            }
+  // === Task calls (dependency order) ===
+  int expert = blockIdx.x;
+  float acc[15];
+#pragma unroll
+  for (int m = 0; m < 15; m++) {
+    acc[m] = 0.0f;
+  }
+  asm volatile("griddepcontrol.wait;" ::: "memory");
+#pragma unroll
+  for (int ki = 0; ki < 6; ki++) {
+    int k_base = ki * 1024 + tid * 8;
+    float _vec_load_0[8];
+    {
+      const uint4* _vptr_0 = reinterpret_cast<const uint4*>(mat_b + (expert * 6144 + k_base) + 0);
+      uint4 _vld_0[1];
+#pragma unroll
+      for (int _blk = 0; _blk < 1; _blk++) {
+        _vld_0[_blk] = _vptr_0[_blk];
+        uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
+#pragma unroll
+        for (int _pair = 0; _pair < 4; _pair++) {
+          asm volatile(
+              "{\n\t"
+              "shl.b32 %0, %2, 16;\n\t"
+              "and.b32 %1, %2, 0xffff0000;\n\t"
+              "}\n"
+              : "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[0]),
+                "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[1])
+              : "r"(_vpairs_0[_pair]));
         }
-        #pragma unroll
-        for (int m_1 = 0; m_1 < 15; m_1++) {
-            float _vec_load_1[8];
-            {
-                const uint4* _vptr_1 = reinterpret_cast<const uint4*>(mat_a + (m_1 * 6144 + k_base) + 0);
-                uint4 _vld_1[1];
-                #pragma unroll
-                for (int _blk = 0; _blk < 1; _blk++) {
-                    _vld_1[_blk] = _vptr_1[_blk];
-                    uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
-                    #pragma unroll
-                    for (int _pair = 0; _pair < 4; _pair++) {
-                        asm volatile(
-                            "{\n\t"
-                            "shl.b32 %0, %2, 16;\n\t"
-                            "and.b32 %1, %2, 0xffff0000;\n\t"
-                            "}\n"
-                            : "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[1])
-                            : "r"(_vpairs_1[_pair]));
-                    }
-                }
-            }
-            #pragma unroll
-            for (int j = 0; j < 8; j++) {
-                float _fma_0 = __fmaf_rn(_vec_load_1[j], _vec_load_0[j], acc[m_1]);
-                acc[m_1] = _fma_0;
-            }
-        }
+      }
     }
-    #pragma unroll
-    for (int m_2 = 0; m_2 < 15; m_2++) {
-        float _warp_reduce_0 = acc[m_2];
-        #pragma unroll
-        for (int offset = 16; offset > 0; offset >>= 1)
-            _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
-        float warp_sum = _warp_reduce_0;
-        if (lane == 0) {
-            red[m_2 * 4 + warp] = warp_sum;
+#pragma unroll
+    for (int m_1 = 0; m_1 < 15; m_1++) {
+      float _vec_load_1[8];
+      {
+        const uint4* _vptr_1 = reinterpret_cast<const uint4*>(mat_a + (m_1 * 6144 + k_base) + 0);
+        uint4 _vld_1[1];
+#pragma unroll
+        for (int _blk = 0; _blk < 1; _blk++) {
+          _vld_1[_blk] = _vptr_1[_blk];
+          uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
+#pragma unroll
+          for (int _pair = 0; _pair < 4; _pair++) {
+            asm volatile(
+                "{\n\t"
+                "shl.b32 %0, %2, 16;\n\t"
+                "and.b32 %1, %2, 0xffff0000;\n\t"
+                "}\n"
+                : "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[0]),
+                  "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[1])
+                : "r"(_vpairs_1[_pair]));
+          }
         }
+      }
+#pragma unroll
+      for (int j = 0; j < 8; j++) {
+        float _fma_0 = __fmaf_rn(_vec_load_1[j], _vec_load_0[j], acc[m_1]);
+        acc[m_1] = _fma_0;
+      }
     }
-    asm volatile("barrier.sync 2, 128;" ::: "memory");
-    if (warp == 0) {
-        if (lane < 15) {
-            int m_3 = lane;
-            float total = red[m_3 * 4];
-            #pragma unroll
-            for (int source_warp = 1; source_warp < 4; source_warp++) {
-                total = total + red[m_3 * 4 + source_warp];
-            }
-            int offset = m_3 * num_experts + expert;
-            if (out_is_bf16 == 0) {
-                *(reinterpret_cast<float*>(out_f32 + offset) + (0)) = total;
-            } else {
-                *(reinterpret_cast<__nv_bfloat16*>(out_bf16 + offset) + (0)) = __float2bfloat16_rn(total);
-            }
-        }
+  }
+#pragma unroll
+  for (int m_2 = 0; m_2 < 15; m_2++) {
+    float _warp_reduce_0 = acc[m_2];
+#pragma unroll
+    for (int offset = 16; offset > 0; offset >>= 1)
+      _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
+    float warp_sum = _warp_reduce_0;
+    if (lane == 0) {
+      red[m_2 * 4 + warp] = warp_sum;
     }
-    asm volatile("griddepcontrol.launch_dependents;" ::: "memory");
+  }
+  asm volatile("barrier.sync 2, 128;" ::: "memory");
+  if (warp == 0) {
+    if (lane < 15) {
+      int m_3 = lane;
+      float total = red[m_3 * 4];
+#pragma unroll
+      for (int source_warp = 1; source_warp < 4; source_warp++) {
+        total = total + red[m_3 * 4 + source_warp];
+      }
+      int offset = m_3 * num_experts + expert;
+      if (out_is_bf16 == 0) {
+        *(reinterpret_cast<float*>(out_f32 + offset) + (0)) = total;
+      } else {
+        *(reinterpret_cast<__nv_bfloat16*>(out_bf16 + offset) + (0)) = __float2bfloat16_rn(total);
+      }
+    }
+  }
+  asm volatile("griddepcontrol.launch_dependents;" ::: "memory");
 }
 
-} // extern "C"
+}  // extern "C"

--- a/csrc/cake_router_gemm/cake_router_gemm_m15_k7168_device.cu
+++ b/csrc/cake_router_gemm/cake_router_gemm_m15_k7168_device.cu
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) 2026 by FlashInfer team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+typedef unsigned char      uint8_t;
+typedef unsigned short     uint16_t;
+typedef unsigned int       uint32_t;
+typedef unsigned long long uint64_t;
+typedef signed int         int32_t;
+typedef short int          int16_t;
+struct __align__(128) CakeTensorMap { uint64_t opaque[16]; };
+template <int N>
+struct __align__(128) CakeTensorMapPack { CakeTensorMap maps[N]; };
+
+typedef struct __align__(64) { uint64_t opaque[16]; } CUtensorMap;
+
+#include <cuda_bf16.h>
+
+__device__ __forceinline__ int make_warp_uniform(int x) {
+    int result;
+    asm volatile("shfl.sync.idx.b32 %0, %1, 0, 0x1F, 0xFFFFFFFF;"
+                 : "=r"(result) : "r"(x));
+    return result;
+}
+
+#define CAKE_INF CUDART_INF_F
+#define NUM_MAIN_STAGES 1
+#define SMEM_RED_OFF 0
+#define SMEM_RED_STAGE_BYTES 240
+#define SMEM_RED_STRIDE 240
+#define SMEM_TOTAL 256
+#define THREADS 128
+
+#include <math_constants.h>
+
+extern "C" {
+
+__global__ __launch_bounds__(128, 1) void
+kernel_cake_blackwell_router_gemm_m15_k7168(__nv_bfloat16* __restrict__ mat_a, __nv_bfloat16* __restrict__ mat_b, float* __restrict__ out_f32, __nv_bfloat16* __restrict__ out_bf16, int num_experts, int out_is_bf16)
+{
+    const int tid = threadIdx.x;
+    const int warp = make_warp_uniform(tid / 32);
+    const int lane = tid % 32;
+
+    extern __shared__ __align__(1024) char smem_raw[];
+    int smem;
+    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+
+    const int bid = blockIdx.x;
+    const int num_bids = gridDim.x;
+
+    // Kernel setup ops
+    float* red = reinterpret_cast<float*>(smem_raw + 0);
+    const int red_addr = smem + 0;
+
+    // === Task calls (dependency order) ===
+    int expert = blockIdx.x;
+    float acc[15];
+    #pragma unroll
+    for (int m = 0; m < 15; m++) {
+        acc[m] = 0.0f;
+    }
+    asm volatile("griddepcontrol.wait;" ::: "memory");
+    #pragma unroll
+    for (int ki = 0; ki < 7; ki++) {
+        int k_base = ki * 1024 + tid * 8;
+        float _vec_load_0[8];
+        {
+            const uint4* _vptr_0 = reinterpret_cast<const uint4*>(mat_b + (expert * 7168 + k_base) + 0);
+            uint4 _vld_0[1];
+            #pragma unroll
+            for (int _blk = 0; _blk < 1; _blk++) {
+                _vld_0[_blk] = _vptr_0[_blk];
+                uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
+                #pragma unroll
+                for (int _pair = 0; _pair < 4; _pair++) {
+                    asm volatile(
+                        "{\n\t"
+                        "shl.b32 %0, %2, 16;\n\t"
+                        "and.b32 %1, %2, 0xffff0000;\n\t"
+                        "}\n"
+                        : "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[1])
+                        : "r"(_vpairs_0[_pair]));
+                }
+            }
+        }
+        #pragma unroll
+        for (int m_1 = 0; m_1 < 15; m_1++) {
+            float _vec_load_1[8];
+            {
+                const uint4* _vptr_1 = reinterpret_cast<const uint4*>(mat_a + (m_1 * 7168 + k_base) + 0);
+                uint4 _vld_1[1];
+                #pragma unroll
+                for (int _blk = 0; _blk < 1; _blk++) {
+                    _vld_1[_blk] = _vptr_1[_blk];
+                    uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
+                    #pragma unroll
+                    for (int _pair = 0; _pair < 4; _pair++) {
+                        asm volatile(
+                            "{\n\t"
+                            "shl.b32 %0, %2, 16;\n\t"
+                            "and.b32 %1, %2, 0xffff0000;\n\t"
+                            "}\n"
+                            : "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[1])
+                            : "r"(_vpairs_1[_pair]));
+                    }
+                }
+            }
+            #pragma unroll
+            for (int j = 0; j < 8; j++) {
+                float _fma_0 = __fmaf_rn(_vec_load_1[j], _vec_load_0[j], acc[m_1]);
+                acc[m_1] = _fma_0;
+            }
+        }
+    }
+    #pragma unroll
+    for (int m_2 = 0; m_2 < 15; m_2++) {
+        float _warp_reduce_0 = acc[m_2];
+        #pragma unroll
+        for (int offset = 16; offset > 0; offset >>= 1)
+            _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
+        float warp_sum = _warp_reduce_0;
+        if (lane == 0) {
+            red[m_2 * 4 + warp] = warp_sum;
+        }
+    }
+    asm volatile("barrier.sync 2, 128;" ::: "memory");
+    if (warp == 0) {
+        if (lane < 15) {
+            int m_3 = lane;
+            float total = red[m_3 * 4];
+            #pragma unroll
+            for (int source_warp = 1; source_warp < 4; source_warp++) {
+                total = total + red[m_3 * 4 + source_warp];
+            }
+            int offset = m_3 * num_experts + expert;
+            if (out_is_bf16 == 0) {
+                *(reinterpret_cast<float*>(out_f32 + offset) + (0)) = total;
+            } else {
+                *(reinterpret_cast<__nv_bfloat16*>(out_bf16 + offset) + (0)) = __float2bfloat16_rn(total);
+            }
+        }
+    }
+    asm volatile("griddepcontrol.launch_dependents;" ::: "memory");
+}
+
+} // extern "C"

--- a/csrc/cake_router_gemm/cake_router_gemm_m15_k7168_device.cu
+++ b/csrc/cake_router_gemm/cake_router_gemm_m15_k7168_device.cu
@@ -14,25 +14,30 @@
  * limitations under the License.
  */
 
-typedef unsigned char      uint8_t;
-typedef unsigned short     uint16_t;
-typedef unsigned int       uint32_t;
+typedef unsigned char uint8_t;
+typedef unsigned short uint16_t;
+typedef unsigned int uint32_t;
 typedef unsigned long long uint64_t;
-typedef signed int         int32_t;
-typedef short int          int16_t;
-struct __align__(128) CakeTensorMap { uint64_t opaque[16]; };
+typedef signed int int32_t;
+typedef short int int16_t;
+struct __align__(128) CakeTensorMap {
+  uint64_t opaque[16];
+};
 template <int N>
-struct __align__(128) CakeTensorMapPack { CakeTensorMap maps[N]; };
+struct __align__(128) CakeTensorMapPack {
+  CakeTensorMap maps[N];
+};
 
-typedef struct __align__(64) { uint64_t opaque[16]; } CUtensorMap;
+typedef struct __align__(64) {
+  uint64_t opaque[16];
+} CUtensorMap;
 
 #include <cuda_bf16.h>
 
 __device__ __forceinline__ int make_warp_uniform(int x) {
-    int result;
-    asm volatile("shfl.sync.idx.b32 %0, %1, 0, 0x1F, 0xFFFFFFFF;"
-                 : "=r"(result) : "r"(x));
-    return result;
+  int result;
+  asm volatile("shfl.sync.idx.b32 %0, %1, 0, 0x1F, 0xFFFFFFFF;" : "=r"(result) : "r"(x));
+  return result;
 }
 
 #define CAKE_INF CUDART_INF_F
@@ -47,113 +52,116 @@ __device__ __forceinline__ int make_warp_uniform(int x) {
 
 extern "C" {
 
-__global__ __launch_bounds__(128, 1) void
-kernel_cake_blackwell_router_gemm_m15_k7168(__nv_bfloat16* __restrict__ mat_a, __nv_bfloat16* __restrict__ mat_b, float* __restrict__ out_f32, __nv_bfloat16* __restrict__ out_bf16, int num_experts, int out_is_bf16)
-{
-    const int tid = threadIdx.x;
-    const int warp = make_warp_uniform(tid / 32);
-    const int lane = tid % 32;
+__global__ __launch_bounds__(128, 1) void kernel_cake_blackwell_router_gemm_m15_k7168(
+    __nv_bfloat16* __restrict__ mat_a, __nv_bfloat16* __restrict__ mat_b,
+    float* __restrict__ out_f32, __nv_bfloat16* __restrict__ out_bf16, int num_experts,
+    int out_is_bf16) {
+  const int tid = threadIdx.x;
+  const int warp = make_warp_uniform(tid / 32);
+  const int lane = tid % 32;
 
-    extern __shared__ __align__(1024) char smem_raw[];
-    int smem;
-    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+  extern __shared__ __align__(1024) char smem_raw[];
+  int smem;
+  smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
 
-    const int bid = blockIdx.x;
-    const int num_bids = gridDim.x;
+  const int bid = blockIdx.x;
+  const int num_bids = gridDim.x;
 
-    // Kernel setup ops
-    float* red = reinterpret_cast<float*>(smem_raw + 0);
-    const int red_addr = smem + 0;
+  // Kernel setup ops
+  float* red = reinterpret_cast<float*>(smem_raw + 0);
+  const int red_addr = smem + 0;
 
-    // === Task calls (dependency order) ===
-    int expert = blockIdx.x;
-    float acc[15];
-    #pragma unroll
-    for (int m = 0; m < 15; m++) {
-        acc[m] = 0.0f;
-    }
-    asm volatile("griddepcontrol.wait;" ::: "memory");
-    #pragma unroll
-    for (int ki = 0; ki < 7; ki++) {
-        int k_base = ki * 1024 + tid * 8;
-        float _vec_load_0[8];
-        {
-            const uint4* _vptr_0 = reinterpret_cast<const uint4*>(mat_b + (expert * 7168 + k_base) + 0);
-            uint4 _vld_0[1];
-            #pragma unroll
-            for (int _blk = 0; _blk < 1; _blk++) {
-                _vld_0[_blk] = _vptr_0[_blk];
-                uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
-                #pragma unroll
-                for (int _pair = 0; _pair < 4; _pair++) {
-                    asm volatile(
-                        "{\n\t"
-                        "shl.b32 %0, %2, 16;\n\t"
-                        "and.b32 %1, %2, 0xffff0000;\n\t"
-                        "}\n"
-                        : "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[1])
-                        : "r"(_vpairs_0[_pair]));
-                }
-            }
+  // === Task calls (dependency order) ===
+  int expert = blockIdx.x;
+  float acc[15];
+#pragma unroll
+  for (int m = 0; m < 15; m++) {
+    acc[m] = 0.0f;
+  }
+  asm volatile("griddepcontrol.wait;" ::: "memory");
+#pragma unroll
+  for (int ki = 0; ki < 7; ki++) {
+    int k_base = ki * 1024 + tid * 8;
+    float _vec_load_0[8];
+    {
+      const uint4* _vptr_0 = reinterpret_cast<const uint4*>(mat_b + (expert * 7168 + k_base) + 0);
+      uint4 _vld_0[1];
+#pragma unroll
+      for (int _blk = 0; _blk < 1; _blk++) {
+        _vld_0[_blk] = _vptr_0[_blk];
+        uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
+#pragma unroll
+        for (int _pair = 0; _pair < 4; _pair++) {
+          asm volatile(
+              "{\n\t"
+              "shl.b32 %0, %2, 16;\n\t"
+              "and.b32 %1, %2, 0xffff0000;\n\t"
+              "}\n"
+              : "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[0]),
+                "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[1])
+              : "r"(_vpairs_0[_pair]));
         }
-        #pragma unroll
-        for (int m_1 = 0; m_1 < 15; m_1++) {
-            float _vec_load_1[8];
-            {
-                const uint4* _vptr_1 = reinterpret_cast<const uint4*>(mat_a + (m_1 * 7168 + k_base) + 0);
-                uint4 _vld_1[1];
-                #pragma unroll
-                for (int _blk = 0; _blk < 1; _blk++) {
-                    _vld_1[_blk] = _vptr_1[_blk];
-                    uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
-                    #pragma unroll
-                    for (int _pair = 0; _pair < 4; _pair++) {
-                        asm volatile(
-                            "{\n\t"
-                            "shl.b32 %0, %2, 16;\n\t"
-                            "and.b32 %1, %2, 0xffff0000;\n\t"
-                            "}\n"
-                            : "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[1])
-                            : "r"(_vpairs_1[_pair]));
-                    }
-                }
-            }
-            #pragma unroll
-            for (int j = 0; j < 8; j++) {
-                float _fma_0 = __fmaf_rn(_vec_load_1[j], _vec_load_0[j], acc[m_1]);
-                acc[m_1] = _fma_0;
-            }
-        }
+      }
     }
-    #pragma unroll
-    for (int m_2 = 0; m_2 < 15; m_2++) {
-        float _warp_reduce_0 = acc[m_2];
-        #pragma unroll
-        for (int offset = 16; offset > 0; offset >>= 1)
-            _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
-        float warp_sum = _warp_reduce_0;
-        if (lane == 0) {
-            red[m_2 * 4 + warp] = warp_sum;
+#pragma unroll
+    for (int m_1 = 0; m_1 < 15; m_1++) {
+      float _vec_load_1[8];
+      {
+        const uint4* _vptr_1 = reinterpret_cast<const uint4*>(mat_a + (m_1 * 7168 + k_base) + 0);
+        uint4 _vld_1[1];
+#pragma unroll
+        for (int _blk = 0; _blk < 1; _blk++) {
+          _vld_1[_blk] = _vptr_1[_blk];
+          uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
+#pragma unroll
+          for (int _pair = 0; _pair < 4; _pair++) {
+            asm volatile(
+                "{\n\t"
+                "shl.b32 %0, %2, 16;\n\t"
+                "and.b32 %1, %2, 0xffff0000;\n\t"
+                "}\n"
+                : "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[0]),
+                  "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[1])
+                : "r"(_vpairs_1[_pair]));
+          }
         }
+      }
+#pragma unroll
+      for (int j = 0; j < 8; j++) {
+        float _fma_0 = __fmaf_rn(_vec_load_1[j], _vec_load_0[j], acc[m_1]);
+        acc[m_1] = _fma_0;
+      }
     }
-    asm volatile("barrier.sync 2, 128;" ::: "memory");
-    if (warp == 0) {
-        if (lane < 15) {
-            int m_3 = lane;
-            float total = red[m_3 * 4];
-            #pragma unroll
-            for (int source_warp = 1; source_warp < 4; source_warp++) {
-                total = total + red[m_3 * 4 + source_warp];
-            }
-            int offset = m_3 * num_experts + expert;
-            if (out_is_bf16 == 0) {
-                *(reinterpret_cast<float*>(out_f32 + offset) + (0)) = total;
-            } else {
-                *(reinterpret_cast<__nv_bfloat16*>(out_bf16 + offset) + (0)) = __float2bfloat16_rn(total);
-            }
-        }
+  }
+#pragma unroll
+  for (int m_2 = 0; m_2 < 15; m_2++) {
+    float _warp_reduce_0 = acc[m_2];
+#pragma unroll
+    for (int offset = 16; offset > 0; offset >>= 1)
+      _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
+    float warp_sum = _warp_reduce_0;
+    if (lane == 0) {
+      red[m_2 * 4 + warp] = warp_sum;
     }
-    asm volatile("griddepcontrol.launch_dependents;" ::: "memory");
+  }
+  asm volatile("barrier.sync 2, 128;" ::: "memory");
+  if (warp == 0) {
+    if (lane < 15) {
+      int m_3 = lane;
+      float total = red[m_3 * 4];
+#pragma unroll
+      for (int source_warp = 1; source_warp < 4; source_warp++) {
+        total = total + red[m_3 * 4 + source_warp];
+      }
+      int offset = m_3 * num_experts + expert;
+      if (out_is_bf16 == 0) {
+        *(reinterpret_cast<float*>(out_f32 + offset) + (0)) = total;
+      } else {
+        *(reinterpret_cast<__nv_bfloat16*>(out_bf16 + offset) + (0)) = __float2bfloat16_rn(total);
+      }
+    }
+  }
+  asm volatile("griddepcontrol.launch_dependents;" ::: "memory");
 }
 
-} // extern "C"
+}  // extern "C"

--- a/csrc/cake_router_gemm/cake_router_gemm_m16_k6144_device.cu
+++ b/csrc/cake_router_gemm/cake_router_gemm_m16_k6144_device.cu
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) 2026 by FlashInfer team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+typedef unsigned char      uint8_t;
+typedef unsigned short     uint16_t;
+typedef unsigned int       uint32_t;
+typedef unsigned long long uint64_t;
+typedef signed int         int32_t;
+typedef short int          int16_t;
+struct __align__(128) CakeTensorMap { uint64_t opaque[16]; };
+template <int N>
+struct __align__(128) CakeTensorMapPack { CakeTensorMap maps[N]; };
+
+typedef struct __align__(64) { uint64_t opaque[16]; } CUtensorMap;
+
+#include <cuda_bf16.h>
+
+__device__ __forceinline__ int make_warp_uniform(int x) {
+    int result;
+    asm volatile("shfl.sync.idx.b32 %0, %1, 0, 0x1F, 0xFFFFFFFF;"
+                 : "=r"(result) : "r"(x));
+    return result;
+}
+
+#define CAKE_INF CUDART_INF_F
+#define NUM_MAIN_STAGES 1
+#define SMEM_RED_OFF 0
+#define SMEM_RED_STAGE_BYTES 256
+#define SMEM_RED_STRIDE 256
+#define SMEM_TOTAL 256
+#define THREADS 128
+
+#include <math_constants.h>
+
+extern "C" {
+
+__global__ __launch_bounds__(128, 1) void
+kernel_cake_blackwell_router_gemm_m16_k6144(__nv_bfloat16* __restrict__ mat_a, __nv_bfloat16* __restrict__ mat_b, float* __restrict__ out_f32, __nv_bfloat16* __restrict__ out_bf16, int num_experts, int out_is_bf16)
+{
+    const int tid = threadIdx.x;
+    const int warp = make_warp_uniform(tid / 32);
+    const int lane = tid % 32;
+
+    extern __shared__ __align__(1024) char smem_raw[];
+    int smem;
+    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+
+    const int bid = blockIdx.x;
+    const int num_bids = gridDim.x;
+
+    // Kernel setup ops
+    float* red = reinterpret_cast<float*>(smem_raw + 0);
+    const int red_addr = smem + 0;
+
+    // === Task calls (dependency order) ===
+    int expert = blockIdx.x;
+    float acc[16];
+    #pragma unroll
+    for (int m = 0; m < 16; m++) {
+        acc[m] = 0.0f;
+    }
+    asm volatile("griddepcontrol.wait;" ::: "memory");
+    #pragma unroll
+    for (int ki = 0; ki < 6; ki++) {
+        int k_base = ki * 1024 + tid * 8;
+        float _vec_load_0[8];
+        {
+            const uint4* _vptr_0 = reinterpret_cast<const uint4*>(mat_b + (expert * 6144 + k_base) + 0);
+            uint4 _vld_0[1];
+            #pragma unroll
+            for (int _blk = 0; _blk < 1; _blk++) {
+                _vld_0[_blk] = _vptr_0[_blk];
+                uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
+                #pragma unroll
+                for (int _pair = 0; _pair < 4; _pair++) {
+                    asm volatile(
+                        "{\n\t"
+                        "shl.b32 %0, %2, 16;\n\t"
+                        "and.b32 %1, %2, 0xffff0000;\n\t"
+                        "}\n"
+                        : "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[1])
+                        : "r"(_vpairs_0[_pair]));
+                }
+            }
+        }
+        #pragma unroll
+        for (int m_1 = 0; m_1 < 16; m_1++) {
+            float _vec_load_1[8];
+            {
+                const uint4* _vptr_1 = reinterpret_cast<const uint4*>(mat_a + (m_1 * 6144 + k_base) + 0);
+                uint4 _vld_1[1];
+                #pragma unroll
+                for (int _blk = 0; _blk < 1; _blk++) {
+                    _vld_1[_blk] = _vptr_1[_blk];
+                    uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
+                    #pragma unroll
+                    for (int _pair = 0; _pair < 4; _pair++) {
+                        asm volatile(
+                            "{\n\t"
+                            "shl.b32 %0, %2, 16;\n\t"
+                            "and.b32 %1, %2, 0xffff0000;\n\t"
+                            "}\n"
+                            : "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[1])
+                            : "r"(_vpairs_1[_pair]));
+                    }
+                }
+            }
+            #pragma unroll
+            for (int j = 0; j < 8; j++) {
+                float _fma_0 = __fmaf_rn(_vec_load_1[j], _vec_load_0[j], acc[m_1]);
+                acc[m_1] = _fma_0;
+            }
+        }
+    }
+    #pragma unroll
+    for (int m_2 = 0; m_2 < 16; m_2++) {
+        float _warp_reduce_0 = acc[m_2];
+        #pragma unroll
+        for (int offset = 16; offset > 0; offset >>= 1)
+            _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
+        float warp_sum = _warp_reduce_0;
+        if (lane == 0) {
+            red[m_2 * 4 + warp] = warp_sum;
+        }
+    }
+    asm volatile("barrier.sync 2, 128;" ::: "memory");
+    if (warp == 0) {
+        if (lane < 16) {
+            int m_3 = lane;
+            float total = red[m_3 * 4];
+            #pragma unroll
+            for (int source_warp = 1; source_warp < 4; source_warp++) {
+                total = total + red[m_3 * 4 + source_warp];
+            }
+            int offset = m_3 * num_experts + expert;
+            if (out_is_bf16 == 0) {
+                *(reinterpret_cast<float*>(out_f32 + offset) + (0)) = total;
+            } else {
+                *(reinterpret_cast<__nv_bfloat16*>(out_bf16 + offset) + (0)) = __float2bfloat16_rn(total);
+            }
+        }
+    }
+    asm volatile("griddepcontrol.launch_dependents;" ::: "memory");
+}
+
+} // extern "C"

--- a/csrc/cake_router_gemm/cake_router_gemm_m16_k6144_device.cu
+++ b/csrc/cake_router_gemm/cake_router_gemm_m16_k6144_device.cu
@@ -14,25 +14,30 @@
  * limitations under the License.
  */
 
-typedef unsigned char      uint8_t;
-typedef unsigned short     uint16_t;
-typedef unsigned int       uint32_t;
+typedef unsigned char uint8_t;
+typedef unsigned short uint16_t;
+typedef unsigned int uint32_t;
 typedef unsigned long long uint64_t;
-typedef signed int         int32_t;
-typedef short int          int16_t;
-struct __align__(128) CakeTensorMap { uint64_t opaque[16]; };
+typedef signed int int32_t;
+typedef short int int16_t;
+struct __align__(128) CakeTensorMap {
+  uint64_t opaque[16];
+};
 template <int N>
-struct __align__(128) CakeTensorMapPack { CakeTensorMap maps[N]; };
+struct __align__(128) CakeTensorMapPack {
+  CakeTensorMap maps[N];
+};
 
-typedef struct __align__(64) { uint64_t opaque[16]; } CUtensorMap;
+typedef struct __align__(64) {
+  uint64_t opaque[16];
+} CUtensorMap;
 
 #include <cuda_bf16.h>
 
 __device__ __forceinline__ int make_warp_uniform(int x) {
-    int result;
-    asm volatile("shfl.sync.idx.b32 %0, %1, 0, 0x1F, 0xFFFFFFFF;"
-                 : "=r"(result) : "r"(x));
-    return result;
+  int result;
+  asm volatile("shfl.sync.idx.b32 %0, %1, 0, 0x1F, 0xFFFFFFFF;" : "=r"(result) : "r"(x));
+  return result;
 }
 
 #define CAKE_INF CUDART_INF_F
@@ -47,113 +52,116 @@ __device__ __forceinline__ int make_warp_uniform(int x) {
 
 extern "C" {
 
-__global__ __launch_bounds__(128, 1) void
-kernel_cake_blackwell_router_gemm_m16_k6144(__nv_bfloat16* __restrict__ mat_a, __nv_bfloat16* __restrict__ mat_b, float* __restrict__ out_f32, __nv_bfloat16* __restrict__ out_bf16, int num_experts, int out_is_bf16)
-{
-    const int tid = threadIdx.x;
-    const int warp = make_warp_uniform(tid / 32);
-    const int lane = tid % 32;
+__global__ __launch_bounds__(128, 1) void kernel_cake_blackwell_router_gemm_m16_k6144(
+    __nv_bfloat16* __restrict__ mat_a, __nv_bfloat16* __restrict__ mat_b,
+    float* __restrict__ out_f32, __nv_bfloat16* __restrict__ out_bf16, int num_experts,
+    int out_is_bf16) {
+  const int tid = threadIdx.x;
+  const int warp = make_warp_uniform(tid / 32);
+  const int lane = tid % 32;
 
-    extern __shared__ __align__(1024) char smem_raw[];
-    int smem;
-    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+  extern __shared__ __align__(1024) char smem_raw[];
+  int smem;
+  smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
 
-    const int bid = blockIdx.x;
-    const int num_bids = gridDim.x;
+  const int bid = blockIdx.x;
+  const int num_bids = gridDim.x;
 
-    // Kernel setup ops
-    float* red = reinterpret_cast<float*>(smem_raw + 0);
-    const int red_addr = smem + 0;
+  // Kernel setup ops
+  float* red = reinterpret_cast<float*>(smem_raw + 0);
+  const int red_addr = smem + 0;
 
-    // === Task calls (dependency order) ===
-    int expert = blockIdx.x;
-    float acc[16];
-    #pragma unroll
-    for (int m = 0; m < 16; m++) {
-        acc[m] = 0.0f;
-    }
-    asm volatile("griddepcontrol.wait;" ::: "memory");
-    #pragma unroll
-    for (int ki = 0; ki < 6; ki++) {
-        int k_base = ki * 1024 + tid * 8;
-        float _vec_load_0[8];
-        {
-            const uint4* _vptr_0 = reinterpret_cast<const uint4*>(mat_b + (expert * 6144 + k_base) + 0);
-            uint4 _vld_0[1];
-            #pragma unroll
-            for (int _blk = 0; _blk < 1; _blk++) {
-                _vld_0[_blk] = _vptr_0[_blk];
-                uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
-                #pragma unroll
-                for (int _pair = 0; _pair < 4; _pair++) {
-                    asm volatile(
-                        "{\n\t"
-                        "shl.b32 %0, %2, 16;\n\t"
-                        "and.b32 %1, %2, 0xffff0000;\n\t"
-                        "}\n"
-                        : "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[1])
-                        : "r"(_vpairs_0[_pair]));
-                }
-            }
+  // === Task calls (dependency order) ===
+  int expert = blockIdx.x;
+  float acc[16];
+#pragma unroll
+  for (int m = 0; m < 16; m++) {
+    acc[m] = 0.0f;
+  }
+  asm volatile("griddepcontrol.wait;" ::: "memory");
+#pragma unroll
+  for (int ki = 0; ki < 6; ki++) {
+    int k_base = ki * 1024 + tid * 8;
+    float _vec_load_0[8];
+    {
+      const uint4* _vptr_0 = reinterpret_cast<const uint4*>(mat_b + (expert * 6144 + k_base) + 0);
+      uint4 _vld_0[1];
+#pragma unroll
+      for (int _blk = 0; _blk < 1; _blk++) {
+        _vld_0[_blk] = _vptr_0[_blk];
+        uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
+#pragma unroll
+        for (int _pair = 0; _pair < 4; _pair++) {
+          asm volatile(
+              "{\n\t"
+              "shl.b32 %0, %2, 16;\n\t"
+              "and.b32 %1, %2, 0xffff0000;\n\t"
+              "}\n"
+              : "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[0]),
+                "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[1])
+              : "r"(_vpairs_0[_pair]));
         }
-        #pragma unroll
-        for (int m_1 = 0; m_1 < 16; m_1++) {
-            float _vec_load_1[8];
-            {
-                const uint4* _vptr_1 = reinterpret_cast<const uint4*>(mat_a + (m_1 * 6144 + k_base) + 0);
-                uint4 _vld_1[1];
-                #pragma unroll
-                for (int _blk = 0; _blk < 1; _blk++) {
-                    _vld_1[_blk] = _vptr_1[_blk];
-                    uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
-                    #pragma unroll
-                    for (int _pair = 0; _pair < 4; _pair++) {
-                        asm volatile(
-                            "{\n\t"
-                            "shl.b32 %0, %2, 16;\n\t"
-                            "and.b32 %1, %2, 0xffff0000;\n\t"
-                            "}\n"
-                            : "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[1])
-                            : "r"(_vpairs_1[_pair]));
-                    }
-                }
-            }
-            #pragma unroll
-            for (int j = 0; j < 8; j++) {
-                float _fma_0 = __fmaf_rn(_vec_load_1[j], _vec_load_0[j], acc[m_1]);
-                acc[m_1] = _fma_0;
-            }
-        }
+      }
     }
-    #pragma unroll
-    for (int m_2 = 0; m_2 < 16; m_2++) {
-        float _warp_reduce_0 = acc[m_2];
-        #pragma unroll
-        for (int offset = 16; offset > 0; offset >>= 1)
-            _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
-        float warp_sum = _warp_reduce_0;
-        if (lane == 0) {
-            red[m_2 * 4 + warp] = warp_sum;
+#pragma unroll
+    for (int m_1 = 0; m_1 < 16; m_1++) {
+      float _vec_load_1[8];
+      {
+        const uint4* _vptr_1 = reinterpret_cast<const uint4*>(mat_a + (m_1 * 6144 + k_base) + 0);
+        uint4 _vld_1[1];
+#pragma unroll
+        for (int _blk = 0; _blk < 1; _blk++) {
+          _vld_1[_blk] = _vptr_1[_blk];
+          uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
+#pragma unroll
+          for (int _pair = 0; _pair < 4; _pair++) {
+            asm volatile(
+                "{\n\t"
+                "shl.b32 %0, %2, 16;\n\t"
+                "and.b32 %1, %2, 0xffff0000;\n\t"
+                "}\n"
+                : "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[0]),
+                  "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[1])
+                : "r"(_vpairs_1[_pair]));
+          }
         }
+      }
+#pragma unroll
+      for (int j = 0; j < 8; j++) {
+        float _fma_0 = __fmaf_rn(_vec_load_1[j], _vec_load_0[j], acc[m_1]);
+        acc[m_1] = _fma_0;
+      }
     }
-    asm volatile("barrier.sync 2, 128;" ::: "memory");
-    if (warp == 0) {
-        if (lane < 16) {
-            int m_3 = lane;
-            float total = red[m_3 * 4];
-            #pragma unroll
-            for (int source_warp = 1; source_warp < 4; source_warp++) {
-                total = total + red[m_3 * 4 + source_warp];
-            }
-            int offset = m_3 * num_experts + expert;
-            if (out_is_bf16 == 0) {
-                *(reinterpret_cast<float*>(out_f32 + offset) + (0)) = total;
-            } else {
-                *(reinterpret_cast<__nv_bfloat16*>(out_bf16 + offset) + (0)) = __float2bfloat16_rn(total);
-            }
-        }
+  }
+#pragma unroll
+  for (int m_2 = 0; m_2 < 16; m_2++) {
+    float _warp_reduce_0 = acc[m_2];
+#pragma unroll
+    for (int offset = 16; offset > 0; offset >>= 1)
+      _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
+    float warp_sum = _warp_reduce_0;
+    if (lane == 0) {
+      red[m_2 * 4 + warp] = warp_sum;
     }
-    asm volatile("griddepcontrol.launch_dependents;" ::: "memory");
+  }
+  asm volatile("barrier.sync 2, 128;" ::: "memory");
+  if (warp == 0) {
+    if (lane < 16) {
+      int m_3 = lane;
+      float total = red[m_3 * 4];
+#pragma unroll
+      for (int source_warp = 1; source_warp < 4; source_warp++) {
+        total = total + red[m_3 * 4 + source_warp];
+      }
+      int offset = m_3 * num_experts + expert;
+      if (out_is_bf16 == 0) {
+        *(reinterpret_cast<float*>(out_f32 + offset) + (0)) = total;
+      } else {
+        *(reinterpret_cast<__nv_bfloat16*>(out_bf16 + offset) + (0)) = __float2bfloat16_rn(total);
+      }
+    }
+  }
+  asm volatile("griddepcontrol.launch_dependents;" ::: "memory");
 }
 
-} // extern "C"
+}  // extern "C"

--- a/csrc/cake_router_gemm/cake_router_gemm_m16_k7168_device.cu
+++ b/csrc/cake_router_gemm/cake_router_gemm_m16_k7168_device.cu
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) 2026 by FlashInfer team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+typedef unsigned char      uint8_t;
+typedef unsigned short     uint16_t;
+typedef unsigned int       uint32_t;
+typedef unsigned long long uint64_t;
+typedef signed int         int32_t;
+typedef short int          int16_t;
+struct __align__(128) CakeTensorMap { uint64_t opaque[16]; };
+template <int N>
+struct __align__(128) CakeTensorMapPack { CakeTensorMap maps[N]; };
+
+typedef struct __align__(64) { uint64_t opaque[16]; } CUtensorMap;
+
+#include <cuda_bf16.h>
+
+__device__ __forceinline__ int make_warp_uniform(int x) {
+    int result;
+    asm volatile("shfl.sync.idx.b32 %0, %1, 0, 0x1F, 0xFFFFFFFF;"
+                 : "=r"(result) : "r"(x));
+    return result;
+}
+
+#define CAKE_INF CUDART_INF_F
+#define NUM_MAIN_STAGES 1
+#define SMEM_RED_OFF 0
+#define SMEM_RED_STAGE_BYTES 256
+#define SMEM_RED_STRIDE 256
+#define SMEM_TOTAL 256
+#define THREADS 128
+
+#include <math_constants.h>
+
+extern "C" {
+
+__global__ __launch_bounds__(128, 1) void
+kernel_cake_blackwell_router_gemm_m16_k7168(__nv_bfloat16* __restrict__ mat_a, __nv_bfloat16* __restrict__ mat_b, float* __restrict__ out_f32, __nv_bfloat16* __restrict__ out_bf16, int num_experts, int out_is_bf16)
+{
+    const int tid = threadIdx.x;
+    const int warp = make_warp_uniform(tid / 32);
+    const int lane = tid % 32;
+
+    extern __shared__ __align__(1024) char smem_raw[];
+    int smem;
+    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+
+    const int bid = blockIdx.x;
+    const int num_bids = gridDim.x;
+
+    // Kernel setup ops
+    float* red = reinterpret_cast<float*>(smem_raw + 0);
+    const int red_addr = smem + 0;
+
+    // === Task calls (dependency order) ===
+    int expert = blockIdx.x;
+    float acc[16];
+    #pragma unroll
+    for (int m = 0; m < 16; m++) {
+        acc[m] = 0.0f;
+    }
+    asm volatile("griddepcontrol.wait;" ::: "memory");
+    #pragma unroll
+    for (int ki = 0; ki < 7; ki++) {
+        int k_base = ki * 1024 + tid * 8;
+        float _vec_load_0[8];
+        {
+            const uint4* _vptr_0 = reinterpret_cast<const uint4*>(mat_b + (expert * 7168 + k_base) + 0);
+            uint4 _vld_0[1];
+            #pragma unroll
+            for (int _blk = 0; _blk < 1; _blk++) {
+                _vld_0[_blk] = _vptr_0[_blk];
+                uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
+                #pragma unroll
+                for (int _pair = 0; _pair < 4; _pair++) {
+                    asm volatile(
+                        "{\n\t"
+                        "shl.b32 %0, %2, 16;\n\t"
+                        "and.b32 %1, %2, 0xffff0000;\n\t"
+                        "}\n"
+                        : "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[1])
+                        : "r"(_vpairs_0[_pair]));
+                }
+            }
+        }
+        #pragma unroll
+        for (int m_1 = 0; m_1 < 16; m_1++) {
+            float _vec_load_1[8];
+            {
+                const uint4* _vptr_1 = reinterpret_cast<const uint4*>(mat_a + (m_1 * 7168 + k_base) + 0);
+                uint4 _vld_1[1];
+                #pragma unroll
+                for (int _blk = 0; _blk < 1; _blk++) {
+                    _vld_1[_blk] = _vptr_1[_blk];
+                    uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
+                    #pragma unroll
+                    for (int _pair = 0; _pair < 4; _pair++) {
+                        asm volatile(
+                            "{\n\t"
+                            "shl.b32 %0, %2, 16;\n\t"
+                            "and.b32 %1, %2, 0xffff0000;\n\t"
+                            "}\n"
+                            : "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[1])
+                            : "r"(_vpairs_1[_pair]));
+                    }
+                }
+            }
+            #pragma unroll
+            for (int j = 0; j < 8; j++) {
+                float _fma_0 = __fmaf_rn(_vec_load_1[j], _vec_load_0[j], acc[m_1]);
+                acc[m_1] = _fma_0;
+            }
+        }
+    }
+    #pragma unroll
+    for (int m_2 = 0; m_2 < 16; m_2++) {
+        float _warp_reduce_0 = acc[m_2];
+        #pragma unroll
+        for (int offset = 16; offset > 0; offset >>= 1)
+            _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
+        float warp_sum = _warp_reduce_0;
+        if (lane == 0) {
+            red[m_2 * 4 + warp] = warp_sum;
+        }
+    }
+    asm volatile("barrier.sync 2, 128;" ::: "memory");
+    if (warp == 0) {
+        if (lane < 16) {
+            int m_3 = lane;
+            float total = red[m_3 * 4];
+            #pragma unroll
+            for (int source_warp = 1; source_warp < 4; source_warp++) {
+                total = total + red[m_3 * 4 + source_warp];
+            }
+            int offset = m_3 * num_experts + expert;
+            if (out_is_bf16 == 0) {
+                *(reinterpret_cast<float*>(out_f32 + offset) + (0)) = total;
+            } else {
+                *(reinterpret_cast<__nv_bfloat16*>(out_bf16 + offset) + (0)) = __float2bfloat16_rn(total);
+            }
+        }
+    }
+    asm volatile("griddepcontrol.launch_dependents;" ::: "memory");
+}
+
+} // extern "C"

--- a/csrc/cake_router_gemm/cake_router_gemm_m16_k7168_device.cu
+++ b/csrc/cake_router_gemm/cake_router_gemm_m16_k7168_device.cu
@@ -14,25 +14,30 @@
  * limitations under the License.
  */
 
-typedef unsigned char      uint8_t;
-typedef unsigned short     uint16_t;
-typedef unsigned int       uint32_t;
+typedef unsigned char uint8_t;
+typedef unsigned short uint16_t;
+typedef unsigned int uint32_t;
 typedef unsigned long long uint64_t;
-typedef signed int         int32_t;
-typedef short int          int16_t;
-struct __align__(128) CakeTensorMap { uint64_t opaque[16]; };
+typedef signed int int32_t;
+typedef short int int16_t;
+struct __align__(128) CakeTensorMap {
+  uint64_t opaque[16];
+};
 template <int N>
-struct __align__(128) CakeTensorMapPack { CakeTensorMap maps[N]; };
+struct __align__(128) CakeTensorMapPack {
+  CakeTensorMap maps[N];
+};
 
-typedef struct __align__(64) { uint64_t opaque[16]; } CUtensorMap;
+typedef struct __align__(64) {
+  uint64_t opaque[16];
+} CUtensorMap;
 
 #include <cuda_bf16.h>
 
 __device__ __forceinline__ int make_warp_uniform(int x) {
-    int result;
-    asm volatile("shfl.sync.idx.b32 %0, %1, 0, 0x1F, 0xFFFFFFFF;"
-                 : "=r"(result) : "r"(x));
-    return result;
+  int result;
+  asm volatile("shfl.sync.idx.b32 %0, %1, 0, 0x1F, 0xFFFFFFFF;" : "=r"(result) : "r"(x));
+  return result;
 }
 
 #define CAKE_INF CUDART_INF_F
@@ -47,113 +52,116 @@ __device__ __forceinline__ int make_warp_uniform(int x) {
 
 extern "C" {
 
-__global__ __launch_bounds__(128, 1) void
-kernel_cake_blackwell_router_gemm_m16_k7168(__nv_bfloat16* __restrict__ mat_a, __nv_bfloat16* __restrict__ mat_b, float* __restrict__ out_f32, __nv_bfloat16* __restrict__ out_bf16, int num_experts, int out_is_bf16)
-{
-    const int tid = threadIdx.x;
-    const int warp = make_warp_uniform(tid / 32);
-    const int lane = tid % 32;
+__global__ __launch_bounds__(128, 1) void kernel_cake_blackwell_router_gemm_m16_k7168(
+    __nv_bfloat16* __restrict__ mat_a, __nv_bfloat16* __restrict__ mat_b,
+    float* __restrict__ out_f32, __nv_bfloat16* __restrict__ out_bf16, int num_experts,
+    int out_is_bf16) {
+  const int tid = threadIdx.x;
+  const int warp = make_warp_uniform(tid / 32);
+  const int lane = tid % 32;
 
-    extern __shared__ __align__(1024) char smem_raw[];
-    int smem;
-    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+  extern __shared__ __align__(1024) char smem_raw[];
+  int smem;
+  smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
 
-    const int bid = blockIdx.x;
-    const int num_bids = gridDim.x;
+  const int bid = blockIdx.x;
+  const int num_bids = gridDim.x;
 
-    // Kernel setup ops
-    float* red = reinterpret_cast<float*>(smem_raw + 0);
-    const int red_addr = smem + 0;
+  // Kernel setup ops
+  float* red = reinterpret_cast<float*>(smem_raw + 0);
+  const int red_addr = smem + 0;
 
-    // === Task calls (dependency order) ===
-    int expert = blockIdx.x;
-    float acc[16];
-    #pragma unroll
-    for (int m = 0; m < 16; m++) {
-        acc[m] = 0.0f;
-    }
-    asm volatile("griddepcontrol.wait;" ::: "memory");
-    #pragma unroll
-    for (int ki = 0; ki < 7; ki++) {
-        int k_base = ki * 1024 + tid * 8;
-        float _vec_load_0[8];
-        {
-            const uint4* _vptr_0 = reinterpret_cast<const uint4*>(mat_b + (expert * 7168 + k_base) + 0);
-            uint4 _vld_0[1];
-            #pragma unroll
-            for (int _blk = 0; _blk < 1; _blk++) {
-                _vld_0[_blk] = _vptr_0[_blk];
-                uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
-                #pragma unroll
-                for (int _pair = 0; _pair < 4; _pair++) {
-                    asm volatile(
-                        "{\n\t"
-                        "shl.b32 %0, %2, 16;\n\t"
-                        "and.b32 %1, %2, 0xffff0000;\n\t"
-                        "}\n"
-                        : "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[1])
-                        : "r"(_vpairs_0[_pair]));
-                }
-            }
+  // === Task calls (dependency order) ===
+  int expert = blockIdx.x;
+  float acc[16];
+#pragma unroll
+  for (int m = 0; m < 16; m++) {
+    acc[m] = 0.0f;
+  }
+  asm volatile("griddepcontrol.wait;" ::: "memory");
+#pragma unroll
+  for (int ki = 0; ki < 7; ki++) {
+    int k_base = ki * 1024 + tid * 8;
+    float _vec_load_0[8];
+    {
+      const uint4* _vptr_0 = reinterpret_cast<const uint4*>(mat_b + (expert * 7168 + k_base) + 0);
+      uint4 _vld_0[1];
+#pragma unroll
+      for (int _blk = 0; _blk < 1; _blk++) {
+        _vld_0[_blk] = _vptr_0[_blk];
+        uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
+#pragma unroll
+        for (int _pair = 0; _pair < 4; _pair++) {
+          asm volatile(
+              "{\n\t"
+              "shl.b32 %0, %2, 16;\n\t"
+              "and.b32 %1, %2, 0xffff0000;\n\t"
+              "}\n"
+              : "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[0]),
+                "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[1])
+              : "r"(_vpairs_0[_pair]));
         }
-        #pragma unroll
-        for (int m_1 = 0; m_1 < 16; m_1++) {
-            float _vec_load_1[8];
-            {
-                const uint4* _vptr_1 = reinterpret_cast<const uint4*>(mat_a + (m_1 * 7168 + k_base) + 0);
-                uint4 _vld_1[1];
-                #pragma unroll
-                for (int _blk = 0; _blk < 1; _blk++) {
-                    _vld_1[_blk] = _vptr_1[_blk];
-                    uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
-                    #pragma unroll
-                    for (int _pair = 0; _pair < 4; _pair++) {
-                        asm volatile(
-                            "{\n\t"
-                            "shl.b32 %0, %2, 16;\n\t"
-                            "and.b32 %1, %2, 0xffff0000;\n\t"
-                            "}\n"
-                            : "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[1])
-                            : "r"(_vpairs_1[_pair]));
-                    }
-                }
-            }
-            #pragma unroll
-            for (int j = 0; j < 8; j++) {
-                float _fma_0 = __fmaf_rn(_vec_load_1[j], _vec_load_0[j], acc[m_1]);
-                acc[m_1] = _fma_0;
-            }
-        }
+      }
     }
-    #pragma unroll
-    for (int m_2 = 0; m_2 < 16; m_2++) {
-        float _warp_reduce_0 = acc[m_2];
-        #pragma unroll
-        for (int offset = 16; offset > 0; offset >>= 1)
-            _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
-        float warp_sum = _warp_reduce_0;
-        if (lane == 0) {
-            red[m_2 * 4 + warp] = warp_sum;
+#pragma unroll
+    for (int m_1 = 0; m_1 < 16; m_1++) {
+      float _vec_load_1[8];
+      {
+        const uint4* _vptr_1 = reinterpret_cast<const uint4*>(mat_a + (m_1 * 7168 + k_base) + 0);
+        uint4 _vld_1[1];
+#pragma unroll
+        for (int _blk = 0; _blk < 1; _blk++) {
+          _vld_1[_blk] = _vptr_1[_blk];
+          uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
+#pragma unroll
+          for (int _pair = 0; _pair < 4; _pair++) {
+            asm volatile(
+                "{\n\t"
+                "shl.b32 %0, %2, 16;\n\t"
+                "and.b32 %1, %2, 0xffff0000;\n\t"
+                "}\n"
+                : "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[0]),
+                  "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[1])
+                : "r"(_vpairs_1[_pair]));
+          }
         }
+      }
+#pragma unroll
+      for (int j = 0; j < 8; j++) {
+        float _fma_0 = __fmaf_rn(_vec_load_1[j], _vec_load_0[j], acc[m_1]);
+        acc[m_1] = _fma_0;
+      }
     }
-    asm volatile("barrier.sync 2, 128;" ::: "memory");
-    if (warp == 0) {
-        if (lane < 16) {
-            int m_3 = lane;
-            float total = red[m_3 * 4];
-            #pragma unroll
-            for (int source_warp = 1; source_warp < 4; source_warp++) {
-                total = total + red[m_3 * 4 + source_warp];
-            }
-            int offset = m_3 * num_experts + expert;
-            if (out_is_bf16 == 0) {
-                *(reinterpret_cast<float*>(out_f32 + offset) + (0)) = total;
-            } else {
-                *(reinterpret_cast<__nv_bfloat16*>(out_bf16 + offset) + (0)) = __float2bfloat16_rn(total);
-            }
-        }
+  }
+#pragma unroll
+  for (int m_2 = 0; m_2 < 16; m_2++) {
+    float _warp_reduce_0 = acc[m_2];
+#pragma unroll
+    for (int offset = 16; offset > 0; offset >>= 1)
+      _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
+    float warp_sum = _warp_reduce_0;
+    if (lane == 0) {
+      red[m_2 * 4 + warp] = warp_sum;
     }
-    asm volatile("griddepcontrol.launch_dependents;" ::: "memory");
+  }
+  asm volatile("barrier.sync 2, 128;" ::: "memory");
+  if (warp == 0) {
+    if (lane < 16) {
+      int m_3 = lane;
+      float total = red[m_3 * 4];
+#pragma unroll
+      for (int source_warp = 1; source_warp < 4; source_warp++) {
+        total = total + red[m_3 * 4 + source_warp];
+      }
+      int offset = m_3 * num_experts + expert;
+      if (out_is_bf16 == 0) {
+        *(reinterpret_cast<float*>(out_f32 + offset) + (0)) = total;
+      } else {
+        *(reinterpret_cast<__nv_bfloat16*>(out_bf16 + offset) + (0)) = __float2bfloat16_rn(total);
+      }
+    }
+  }
+  asm volatile("griddepcontrol.launch_dependents;" ::: "memory");
 }
 
-} // extern "C"
+}  // extern "C"

--- a/csrc/cake_router_gemm/cake_router_gemm_m1_k6144_device.cu
+++ b/csrc/cake_router_gemm/cake_router_gemm_m1_k6144_device.cu
@@ -14,25 +14,30 @@
  * limitations under the License.
  */
 
-typedef unsigned char      uint8_t;
-typedef unsigned short     uint16_t;
-typedef unsigned int       uint32_t;
+typedef unsigned char uint8_t;
+typedef unsigned short uint16_t;
+typedef unsigned int uint32_t;
 typedef unsigned long long uint64_t;
-typedef signed int         int32_t;
-typedef short int          int16_t;
-struct __align__(128) CakeTensorMap { uint64_t opaque[16]; };
+typedef signed int int32_t;
+typedef short int int16_t;
+struct __align__(128) CakeTensorMap {
+  uint64_t opaque[16];
+};
 template <int N>
-struct __align__(128) CakeTensorMapPack { CakeTensorMap maps[N]; };
+struct __align__(128) CakeTensorMapPack {
+  CakeTensorMap maps[N];
+};
 
-typedef struct __align__(64) { uint64_t opaque[16]; } CUtensorMap;
+typedef struct __align__(64) {
+  uint64_t opaque[16];
+} CUtensorMap;
 
 #include <cuda_bf16.h>
 
 __device__ __forceinline__ int make_warp_uniform(int x) {
-    int result;
-    asm volatile("shfl.sync.idx.b32 %0, %1, 0, 0x1F, 0xFFFFFFFF;"
-                 : "=r"(result) : "r"(x));
-    return result;
+  int result;
+  asm volatile("shfl.sync.idx.b32 %0, %1, 0, 0x1F, 0xFFFFFFFF;" : "=r"(result) : "r"(x));
+  return result;
 }
 
 #define CAKE_INF CUDART_INF_F
@@ -47,113 +52,116 @@ __device__ __forceinline__ int make_warp_uniform(int x) {
 
 extern "C" {
 
-__global__ __launch_bounds__(128, 1) void
-kernel_cake_blackwell_router_gemm_m1_k6144(__nv_bfloat16* __restrict__ mat_a, __nv_bfloat16* __restrict__ mat_b, float* __restrict__ out_f32, __nv_bfloat16* __restrict__ out_bf16, int num_experts, int out_is_bf16)
-{
-    const int tid = threadIdx.x;
-    const int warp = make_warp_uniform(tid / 32);
-    const int lane = tid % 32;
+__global__ __launch_bounds__(128, 1) void kernel_cake_blackwell_router_gemm_m1_k6144(
+    __nv_bfloat16* __restrict__ mat_a, __nv_bfloat16* __restrict__ mat_b,
+    float* __restrict__ out_f32, __nv_bfloat16* __restrict__ out_bf16, int num_experts,
+    int out_is_bf16) {
+  const int tid = threadIdx.x;
+  const int warp = make_warp_uniform(tid / 32);
+  const int lane = tid % 32;
 
-    extern __shared__ __align__(1024) char smem_raw[];
-    int smem;
-    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+  extern __shared__ __align__(1024) char smem_raw[];
+  int smem;
+  smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
 
-    const int bid = blockIdx.x;
-    const int num_bids = gridDim.x;
+  const int bid = blockIdx.x;
+  const int num_bids = gridDim.x;
 
-    // Kernel setup ops
-    float* red = reinterpret_cast<float*>(smem_raw + 0);
-    const int red_addr = smem + 0;
+  // Kernel setup ops
+  float* red = reinterpret_cast<float*>(smem_raw + 0);
+  const int red_addr = smem + 0;
 
-    // === Task calls (dependency order) ===
-    int expert = blockIdx.x;
-    float acc[1];
-    #pragma unroll
-    for (int m = 0; m < 1; m++) {
-        acc[m] = 0.0f;
-    }
-    asm volatile("griddepcontrol.wait;" ::: "memory");
-    #pragma unroll
-    for (int ki = 0; ki < 6; ki++) {
-        int k_base = ki * 1024 + tid * 8;
-        float _vec_load_0[8];
-        {
-            const uint4* _vptr_0 = reinterpret_cast<const uint4*>(mat_b + (expert * 6144 + k_base) + 0);
-            uint4 _vld_0[1];
-            #pragma unroll
-            for (int _blk = 0; _blk < 1; _blk++) {
-                _vld_0[_blk] = _vptr_0[_blk];
-                uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
-                #pragma unroll
-                for (int _pair = 0; _pair < 4; _pair++) {
-                    asm volatile(
-                        "{\n\t"
-                        "shl.b32 %0, %2, 16;\n\t"
-                        "and.b32 %1, %2, 0xffff0000;\n\t"
-                        "}\n"
-                        : "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[1])
-                        : "r"(_vpairs_0[_pair]));
-                }
-            }
+  // === Task calls (dependency order) ===
+  int expert = blockIdx.x;
+  float acc[1];
+#pragma unroll
+  for (int m = 0; m < 1; m++) {
+    acc[m] = 0.0f;
+  }
+  asm volatile("griddepcontrol.wait;" ::: "memory");
+#pragma unroll
+  for (int ki = 0; ki < 6; ki++) {
+    int k_base = ki * 1024 + tid * 8;
+    float _vec_load_0[8];
+    {
+      const uint4* _vptr_0 = reinterpret_cast<const uint4*>(mat_b + (expert * 6144 + k_base) + 0);
+      uint4 _vld_0[1];
+#pragma unroll
+      for (int _blk = 0; _blk < 1; _blk++) {
+        _vld_0[_blk] = _vptr_0[_blk];
+        uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
+#pragma unroll
+        for (int _pair = 0; _pair < 4; _pair++) {
+          asm volatile(
+              "{\n\t"
+              "shl.b32 %0, %2, 16;\n\t"
+              "and.b32 %1, %2, 0xffff0000;\n\t"
+              "}\n"
+              : "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[0]),
+                "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[1])
+              : "r"(_vpairs_0[_pair]));
         }
-        #pragma unroll
-        for (int m_1 = 0; m_1 < 1; m_1++) {
-            float _vec_load_1[8];
-            {
-                const uint4* _vptr_1 = reinterpret_cast<const uint4*>(mat_a + (m_1 * 6144 + k_base) + 0);
-                uint4 _vld_1[1];
-                #pragma unroll
-                for (int _blk = 0; _blk < 1; _blk++) {
-                    _vld_1[_blk] = _vptr_1[_blk];
-                    uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
-                    #pragma unroll
-                    for (int _pair = 0; _pair < 4; _pair++) {
-                        asm volatile(
-                            "{\n\t"
-                            "shl.b32 %0, %2, 16;\n\t"
-                            "and.b32 %1, %2, 0xffff0000;\n\t"
-                            "}\n"
-                            : "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[1])
-                            : "r"(_vpairs_1[_pair]));
-                    }
-                }
-            }
-            #pragma unroll
-            for (int j = 0; j < 8; j++) {
-                float _fma_0 = __fmaf_rn(_vec_load_1[j], _vec_load_0[j], acc[m_1]);
-                acc[m_1] = _fma_0;
-            }
-        }
+      }
     }
-    #pragma unroll
-    for (int m_2 = 0; m_2 < 1; m_2++) {
-        float _warp_reduce_0 = acc[m_2];
-        #pragma unroll
-        for (int offset = 16; offset > 0; offset >>= 1)
-            _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
-        float warp_sum = _warp_reduce_0;
-        if (lane == 0) {
-            red[m_2 * 4 + warp] = warp_sum;
+#pragma unroll
+    for (int m_1 = 0; m_1 < 1; m_1++) {
+      float _vec_load_1[8];
+      {
+        const uint4* _vptr_1 = reinterpret_cast<const uint4*>(mat_a + (m_1 * 6144 + k_base) + 0);
+        uint4 _vld_1[1];
+#pragma unroll
+        for (int _blk = 0; _blk < 1; _blk++) {
+          _vld_1[_blk] = _vptr_1[_blk];
+          uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
+#pragma unroll
+          for (int _pair = 0; _pair < 4; _pair++) {
+            asm volatile(
+                "{\n\t"
+                "shl.b32 %0, %2, 16;\n\t"
+                "and.b32 %1, %2, 0xffff0000;\n\t"
+                "}\n"
+                : "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[0]),
+                  "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[1])
+                : "r"(_vpairs_1[_pair]));
+          }
         }
+      }
+#pragma unroll
+      for (int j = 0; j < 8; j++) {
+        float _fma_0 = __fmaf_rn(_vec_load_1[j], _vec_load_0[j], acc[m_1]);
+        acc[m_1] = _fma_0;
+      }
     }
-    asm volatile("barrier.sync 2, 128;" ::: "memory");
-    if (warp == 0) {
-        if (lane < 1) {
-            int m_3 = lane;
-            float total = red[m_3 * 4];
-            #pragma unroll
-            for (int source_warp = 1; source_warp < 4; source_warp++) {
-                total = total + red[m_3 * 4 + source_warp];
-            }
-            int offset = m_3 * num_experts + expert;
-            if (out_is_bf16 == 0) {
-                *(reinterpret_cast<float*>(out_f32 + offset) + (0)) = total;
-            } else {
-                *(reinterpret_cast<__nv_bfloat16*>(out_bf16 + offset) + (0)) = __float2bfloat16_rn(total);
-            }
-        }
+  }
+#pragma unroll
+  for (int m_2 = 0; m_2 < 1; m_2++) {
+    float _warp_reduce_0 = acc[m_2];
+#pragma unroll
+    for (int offset = 16; offset > 0; offset >>= 1)
+      _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
+    float warp_sum = _warp_reduce_0;
+    if (lane == 0) {
+      red[m_2 * 4 + warp] = warp_sum;
     }
-    asm volatile("griddepcontrol.launch_dependents;" ::: "memory");
+  }
+  asm volatile("barrier.sync 2, 128;" ::: "memory");
+  if (warp == 0) {
+    if (lane < 1) {
+      int m_3 = lane;
+      float total = red[m_3 * 4];
+#pragma unroll
+      for (int source_warp = 1; source_warp < 4; source_warp++) {
+        total = total + red[m_3 * 4 + source_warp];
+      }
+      int offset = m_3 * num_experts + expert;
+      if (out_is_bf16 == 0) {
+        *(reinterpret_cast<float*>(out_f32 + offset) + (0)) = total;
+      } else {
+        *(reinterpret_cast<__nv_bfloat16*>(out_bf16 + offset) + (0)) = __float2bfloat16_rn(total);
+      }
+    }
+  }
+  asm volatile("griddepcontrol.launch_dependents;" ::: "memory");
 }
 
-} // extern "C"
+}  // extern "C"

--- a/csrc/cake_router_gemm/cake_router_gemm_m1_k6144_device.cu
+++ b/csrc/cake_router_gemm/cake_router_gemm_m1_k6144_device.cu
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) 2026 by FlashInfer team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+typedef unsigned char      uint8_t;
+typedef unsigned short     uint16_t;
+typedef unsigned int       uint32_t;
+typedef unsigned long long uint64_t;
+typedef signed int         int32_t;
+typedef short int          int16_t;
+struct __align__(128) CakeTensorMap { uint64_t opaque[16]; };
+template <int N>
+struct __align__(128) CakeTensorMapPack { CakeTensorMap maps[N]; };
+
+typedef struct __align__(64) { uint64_t opaque[16]; } CUtensorMap;
+
+#include <cuda_bf16.h>
+
+__device__ __forceinline__ int make_warp_uniform(int x) {
+    int result;
+    asm volatile("shfl.sync.idx.b32 %0, %1, 0, 0x1F, 0xFFFFFFFF;"
+                 : "=r"(result) : "r"(x));
+    return result;
+}
+
+#define CAKE_INF CUDART_INF_F
+#define NUM_MAIN_STAGES 1
+#define SMEM_RED_OFF 0
+#define SMEM_RED_STAGE_BYTES 16
+#define SMEM_RED_STRIDE 16
+#define SMEM_TOTAL 128
+#define THREADS 128
+
+#include <math_constants.h>
+
+extern "C" {
+
+__global__ __launch_bounds__(128, 1) void
+kernel_cake_blackwell_router_gemm_m1_k6144(__nv_bfloat16* __restrict__ mat_a, __nv_bfloat16* __restrict__ mat_b, float* __restrict__ out_f32, __nv_bfloat16* __restrict__ out_bf16, int num_experts, int out_is_bf16)
+{
+    const int tid = threadIdx.x;
+    const int warp = make_warp_uniform(tid / 32);
+    const int lane = tid % 32;
+
+    extern __shared__ __align__(1024) char smem_raw[];
+    int smem;
+    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+
+    const int bid = blockIdx.x;
+    const int num_bids = gridDim.x;
+
+    // Kernel setup ops
+    float* red = reinterpret_cast<float*>(smem_raw + 0);
+    const int red_addr = smem + 0;
+
+    // === Task calls (dependency order) ===
+    int expert = blockIdx.x;
+    float acc[1];
+    #pragma unroll
+    for (int m = 0; m < 1; m++) {
+        acc[m] = 0.0f;
+    }
+    asm volatile("griddepcontrol.wait;" ::: "memory");
+    #pragma unroll
+    for (int ki = 0; ki < 6; ki++) {
+        int k_base = ki * 1024 + tid * 8;
+        float _vec_load_0[8];
+        {
+            const uint4* _vptr_0 = reinterpret_cast<const uint4*>(mat_b + (expert * 6144 + k_base) + 0);
+            uint4 _vld_0[1];
+            #pragma unroll
+            for (int _blk = 0; _blk < 1; _blk++) {
+                _vld_0[_blk] = _vptr_0[_blk];
+                uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
+                #pragma unroll
+                for (int _pair = 0; _pair < 4; _pair++) {
+                    asm volatile(
+                        "{\n\t"
+                        "shl.b32 %0, %2, 16;\n\t"
+                        "and.b32 %1, %2, 0xffff0000;\n\t"
+                        "}\n"
+                        : "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[1])
+                        : "r"(_vpairs_0[_pair]));
+                }
+            }
+        }
+        #pragma unroll
+        for (int m_1 = 0; m_1 < 1; m_1++) {
+            float _vec_load_1[8];
+            {
+                const uint4* _vptr_1 = reinterpret_cast<const uint4*>(mat_a + (m_1 * 6144 + k_base) + 0);
+                uint4 _vld_1[1];
+                #pragma unroll
+                for (int _blk = 0; _blk < 1; _blk++) {
+                    _vld_1[_blk] = _vptr_1[_blk];
+                    uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
+                    #pragma unroll
+                    for (int _pair = 0; _pair < 4; _pair++) {
+                        asm volatile(
+                            "{\n\t"
+                            "shl.b32 %0, %2, 16;\n\t"
+                            "and.b32 %1, %2, 0xffff0000;\n\t"
+                            "}\n"
+                            : "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[1])
+                            : "r"(_vpairs_1[_pair]));
+                    }
+                }
+            }
+            #pragma unroll
+            for (int j = 0; j < 8; j++) {
+                float _fma_0 = __fmaf_rn(_vec_load_1[j], _vec_load_0[j], acc[m_1]);
+                acc[m_1] = _fma_0;
+            }
+        }
+    }
+    #pragma unroll
+    for (int m_2 = 0; m_2 < 1; m_2++) {
+        float _warp_reduce_0 = acc[m_2];
+        #pragma unroll
+        for (int offset = 16; offset > 0; offset >>= 1)
+            _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
+        float warp_sum = _warp_reduce_0;
+        if (lane == 0) {
+            red[m_2 * 4 + warp] = warp_sum;
+        }
+    }
+    asm volatile("barrier.sync 2, 128;" ::: "memory");
+    if (warp == 0) {
+        if (lane < 1) {
+            int m_3 = lane;
+            float total = red[m_3 * 4];
+            #pragma unroll
+            for (int source_warp = 1; source_warp < 4; source_warp++) {
+                total = total + red[m_3 * 4 + source_warp];
+            }
+            int offset = m_3 * num_experts + expert;
+            if (out_is_bf16 == 0) {
+                *(reinterpret_cast<float*>(out_f32 + offset) + (0)) = total;
+            } else {
+                *(reinterpret_cast<__nv_bfloat16*>(out_bf16 + offset) + (0)) = __float2bfloat16_rn(total);
+            }
+        }
+    }
+    asm volatile("griddepcontrol.launch_dependents;" ::: "memory");
+}
+
+} // extern "C"

--- a/csrc/cake_router_gemm/cake_router_gemm_m1_k7168_device.cu
+++ b/csrc/cake_router_gemm/cake_router_gemm_m1_k7168_device.cu
@@ -14,25 +14,30 @@
  * limitations under the License.
  */
 
-typedef unsigned char      uint8_t;
-typedef unsigned short     uint16_t;
-typedef unsigned int       uint32_t;
+typedef unsigned char uint8_t;
+typedef unsigned short uint16_t;
+typedef unsigned int uint32_t;
 typedef unsigned long long uint64_t;
-typedef signed int         int32_t;
-typedef short int          int16_t;
-struct __align__(128) CakeTensorMap { uint64_t opaque[16]; };
+typedef signed int int32_t;
+typedef short int int16_t;
+struct __align__(128) CakeTensorMap {
+  uint64_t opaque[16];
+};
 template <int N>
-struct __align__(128) CakeTensorMapPack { CakeTensorMap maps[N]; };
+struct __align__(128) CakeTensorMapPack {
+  CakeTensorMap maps[N];
+};
 
-typedef struct __align__(64) { uint64_t opaque[16]; } CUtensorMap;
+typedef struct __align__(64) {
+  uint64_t opaque[16];
+} CUtensorMap;
 
 #include <cuda_bf16.h>
 
 __device__ __forceinline__ int make_warp_uniform(int x) {
-    int result;
-    asm volatile("shfl.sync.idx.b32 %0, %1, 0, 0x1F, 0xFFFFFFFF;"
-                 : "=r"(result) : "r"(x));
-    return result;
+  int result;
+  asm volatile("shfl.sync.idx.b32 %0, %1, 0, 0x1F, 0xFFFFFFFF;" : "=r"(result) : "r"(x));
+  return result;
 }
 
 #define CAKE_INF CUDART_INF_F
@@ -47,113 +52,116 @@ __device__ __forceinline__ int make_warp_uniform(int x) {
 
 extern "C" {
 
-__global__ __launch_bounds__(128, 1) void
-kernel_cake_blackwell_router_gemm_m1_k7168(__nv_bfloat16* __restrict__ mat_a, __nv_bfloat16* __restrict__ mat_b, float* __restrict__ out_f32, __nv_bfloat16* __restrict__ out_bf16, int num_experts, int out_is_bf16)
-{
-    const int tid = threadIdx.x;
-    const int warp = make_warp_uniform(tid / 32);
-    const int lane = tid % 32;
+__global__ __launch_bounds__(128, 1) void kernel_cake_blackwell_router_gemm_m1_k7168(
+    __nv_bfloat16* __restrict__ mat_a, __nv_bfloat16* __restrict__ mat_b,
+    float* __restrict__ out_f32, __nv_bfloat16* __restrict__ out_bf16, int num_experts,
+    int out_is_bf16) {
+  const int tid = threadIdx.x;
+  const int warp = make_warp_uniform(tid / 32);
+  const int lane = tid % 32;
 
-    extern __shared__ __align__(1024) char smem_raw[];
-    int smem;
-    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+  extern __shared__ __align__(1024) char smem_raw[];
+  int smem;
+  smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
 
-    const int bid = blockIdx.x;
-    const int num_bids = gridDim.x;
+  const int bid = blockIdx.x;
+  const int num_bids = gridDim.x;
 
-    // Kernel setup ops
-    float* red = reinterpret_cast<float*>(smem_raw + 0);
-    const int red_addr = smem + 0;
+  // Kernel setup ops
+  float* red = reinterpret_cast<float*>(smem_raw + 0);
+  const int red_addr = smem + 0;
 
-    // === Task calls (dependency order) ===
-    int expert = blockIdx.x;
-    float acc[1];
-    #pragma unroll
-    for (int m = 0; m < 1; m++) {
-        acc[m] = 0.0f;
-    }
-    asm volatile("griddepcontrol.wait;" ::: "memory");
-    #pragma unroll
-    for (int ki = 0; ki < 7; ki++) {
-        int k_base = ki * 1024 + tid * 8;
-        float _vec_load_0[8];
-        {
-            const uint4* _vptr_0 = reinterpret_cast<const uint4*>(mat_b + (expert * 7168 + k_base) + 0);
-            uint4 _vld_0[1];
-            #pragma unroll
-            for (int _blk = 0; _blk < 1; _blk++) {
-                _vld_0[_blk] = _vptr_0[_blk];
-                uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
-                #pragma unroll
-                for (int _pair = 0; _pair < 4; _pair++) {
-                    asm volatile(
-                        "{\n\t"
-                        "shl.b32 %0, %2, 16;\n\t"
-                        "and.b32 %1, %2, 0xffff0000;\n\t"
-                        "}\n"
-                        : "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[1])
-                        : "r"(_vpairs_0[_pair]));
-                }
-            }
+  // === Task calls (dependency order) ===
+  int expert = blockIdx.x;
+  float acc[1];
+#pragma unroll
+  for (int m = 0; m < 1; m++) {
+    acc[m] = 0.0f;
+  }
+  asm volatile("griddepcontrol.wait;" ::: "memory");
+#pragma unroll
+  for (int ki = 0; ki < 7; ki++) {
+    int k_base = ki * 1024 + tid * 8;
+    float _vec_load_0[8];
+    {
+      const uint4* _vptr_0 = reinterpret_cast<const uint4*>(mat_b + (expert * 7168 + k_base) + 0);
+      uint4 _vld_0[1];
+#pragma unroll
+      for (int _blk = 0; _blk < 1; _blk++) {
+        _vld_0[_blk] = _vptr_0[_blk];
+        uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
+#pragma unroll
+        for (int _pair = 0; _pair < 4; _pair++) {
+          asm volatile(
+              "{\n\t"
+              "shl.b32 %0, %2, 16;\n\t"
+              "and.b32 %1, %2, 0xffff0000;\n\t"
+              "}\n"
+              : "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[0]),
+                "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[1])
+              : "r"(_vpairs_0[_pair]));
         }
-        #pragma unroll
-        for (int m_1 = 0; m_1 < 1; m_1++) {
-            float _vec_load_1[8];
-            {
-                const uint4* _vptr_1 = reinterpret_cast<const uint4*>(mat_a + (m_1 * 7168 + k_base) + 0);
-                uint4 _vld_1[1];
-                #pragma unroll
-                for (int _blk = 0; _blk < 1; _blk++) {
-                    _vld_1[_blk] = _vptr_1[_blk];
-                    uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
-                    #pragma unroll
-                    for (int _pair = 0; _pair < 4; _pair++) {
-                        asm volatile(
-                            "{\n\t"
-                            "shl.b32 %0, %2, 16;\n\t"
-                            "and.b32 %1, %2, 0xffff0000;\n\t"
-                            "}\n"
-                            : "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[1])
-                            : "r"(_vpairs_1[_pair]));
-                    }
-                }
-            }
-            #pragma unroll
-            for (int j = 0; j < 8; j++) {
-                float _fma_0 = __fmaf_rn(_vec_load_1[j], _vec_load_0[j], acc[m_1]);
-                acc[m_1] = _fma_0;
-            }
-        }
+      }
     }
-    #pragma unroll
-    for (int m_2 = 0; m_2 < 1; m_2++) {
-        float _warp_reduce_0 = acc[m_2];
-        #pragma unroll
-        for (int offset = 16; offset > 0; offset >>= 1)
-            _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
-        float warp_sum = _warp_reduce_0;
-        if (lane == 0) {
-            red[m_2 * 4 + warp] = warp_sum;
+#pragma unroll
+    for (int m_1 = 0; m_1 < 1; m_1++) {
+      float _vec_load_1[8];
+      {
+        const uint4* _vptr_1 = reinterpret_cast<const uint4*>(mat_a + (m_1 * 7168 + k_base) + 0);
+        uint4 _vld_1[1];
+#pragma unroll
+        for (int _blk = 0; _blk < 1; _blk++) {
+          _vld_1[_blk] = _vptr_1[_blk];
+          uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
+#pragma unroll
+          for (int _pair = 0; _pair < 4; _pair++) {
+            asm volatile(
+                "{\n\t"
+                "shl.b32 %0, %2, 16;\n\t"
+                "and.b32 %1, %2, 0xffff0000;\n\t"
+                "}\n"
+                : "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[0]),
+                  "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[1])
+                : "r"(_vpairs_1[_pair]));
+          }
         }
+      }
+#pragma unroll
+      for (int j = 0; j < 8; j++) {
+        float _fma_0 = __fmaf_rn(_vec_load_1[j], _vec_load_0[j], acc[m_1]);
+        acc[m_1] = _fma_0;
+      }
     }
-    asm volatile("barrier.sync 2, 128;" ::: "memory");
-    if (warp == 0) {
-        if (lane < 1) {
-            int m_3 = lane;
-            float total = red[m_3 * 4];
-            #pragma unroll
-            for (int source_warp = 1; source_warp < 4; source_warp++) {
-                total = total + red[m_3 * 4 + source_warp];
-            }
-            int offset = m_3 * num_experts + expert;
-            if (out_is_bf16 == 0) {
-                *(reinterpret_cast<float*>(out_f32 + offset) + (0)) = total;
-            } else {
-                *(reinterpret_cast<__nv_bfloat16*>(out_bf16 + offset) + (0)) = __float2bfloat16_rn(total);
-            }
-        }
+  }
+#pragma unroll
+  for (int m_2 = 0; m_2 < 1; m_2++) {
+    float _warp_reduce_0 = acc[m_2];
+#pragma unroll
+    for (int offset = 16; offset > 0; offset >>= 1)
+      _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
+    float warp_sum = _warp_reduce_0;
+    if (lane == 0) {
+      red[m_2 * 4 + warp] = warp_sum;
     }
-    asm volatile("griddepcontrol.launch_dependents;" ::: "memory");
+  }
+  asm volatile("barrier.sync 2, 128;" ::: "memory");
+  if (warp == 0) {
+    if (lane < 1) {
+      int m_3 = lane;
+      float total = red[m_3 * 4];
+#pragma unroll
+      for (int source_warp = 1; source_warp < 4; source_warp++) {
+        total = total + red[m_3 * 4 + source_warp];
+      }
+      int offset = m_3 * num_experts + expert;
+      if (out_is_bf16 == 0) {
+        *(reinterpret_cast<float*>(out_f32 + offset) + (0)) = total;
+      } else {
+        *(reinterpret_cast<__nv_bfloat16*>(out_bf16 + offset) + (0)) = __float2bfloat16_rn(total);
+      }
+    }
+  }
+  asm volatile("griddepcontrol.launch_dependents;" ::: "memory");
 }
 
-} // extern "C"
+}  // extern "C"

--- a/csrc/cake_router_gemm/cake_router_gemm_m1_k7168_device.cu
+++ b/csrc/cake_router_gemm/cake_router_gemm_m1_k7168_device.cu
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) 2026 by FlashInfer team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+typedef unsigned char      uint8_t;
+typedef unsigned short     uint16_t;
+typedef unsigned int       uint32_t;
+typedef unsigned long long uint64_t;
+typedef signed int         int32_t;
+typedef short int          int16_t;
+struct __align__(128) CakeTensorMap { uint64_t opaque[16]; };
+template <int N>
+struct __align__(128) CakeTensorMapPack { CakeTensorMap maps[N]; };
+
+typedef struct __align__(64) { uint64_t opaque[16]; } CUtensorMap;
+
+#include <cuda_bf16.h>
+
+__device__ __forceinline__ int make_warp_uniform(int x) {
+    int result;
+    asm volatile("shfl.sync.idx.b32 %0, %1, 0, 0x1F, 0xFFFFFFFF;"
+                 : "=r"(result) : "r"(x));
+    return result;
+}
+
+#define CAKE_INF CUDART_INF_F
+#define NUM_MAIN_STAGES 1
+#define SMEM_RED_OFF 0
+#define SMEM_RED_STAGE_BYTES 16
+#define SMEM_RED_STRIDE 16
+#define SMEM_TOTAL 128
+#define THREADS 128
+
+#include <math_constants.h>
+
+extern "C" {
+
+__global__ __launch_bounds__(128, 1) void
+kernel_cake_blackwell_router_gemm_m1_k7168(__nv_bfloat16* __restrict__ mat_a, __nv_bfloat16* __restrict__ mat_b, float* __restrict__ out_f32, __nv_bfloat16* __restrict__ out_bf16, int num_experts, int out_is_bf16)
+{
+    const int tid = threadIdx.x;
+    const int warp = make_warp_uniform(tid / 32);
+    const int lane = tid % 32;
+
+    extern __shared__ __align__(1024) char smem_raw[];
+    int smem;
+    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+
+    const int bid = blockIdx.x;
+    const int num_bids = gridDim.x;
+
+    // Kernel setup ops
+    float* red = reinterpret_cast<float*>(smem_raw + 0);
+    const int red_addr = smem + 0;
+
+    // === Task calls (dependency order) ===
+    int expert = blockIdx.x;
+    float acc[1];
+    #pragma unroll
+    for (int m = 0; m < 1; m++) {
+        acc[m] = 0.0f;
+    }
+    asm volatile("griddepcontrol.wait;" ::: "memory");
+    #pragma unroll
+    for (int ki = 0; ki < 7; ki++) {
+        int k_base = ki * 1024 + tid * 8;
+        float _vec_load_0[8];
+        {
+            const uint4* _vptr_0 = reinterpret_cast<const uint4*>(mat_b + (expert * 7168 + k_base) + 0);
+            uint4 _vld_0[1];
+            #pragma unroll
+            for (int _blk = 0; _blk < 1; _blk++) {
+                _vld_0[_blk] = _vptr_0[_blk];
+                uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
+                #pragma unroll
+                for (int _pair = 0; _pair < 4; _pair++) {
+                    asm volatile(
+                        "{\n\t"
+                        "shl.b32 %0, %2, 16;\n\t"
+                        "and.b32 %1, %2, 0xffff0000;\n\t"
+                        "}\n"
+                        : "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[1])
+                        : "r"(_vpairs_0[_pair]));
+                }
+            }
+        }
+        #pragma unroll
+        for (int m_1 = 0; m_1 < 1; m_1++) {
+            float _vec_load_1[8];
+            {
+                const uint4* _vptr_1 = reinterpret_cast<const uint4*>(mat_a + (m_1 * 7168 + k_base) + 0);
+                uint4 _vld_1[1];
+                #pragma unroll
+                for (int _blk = 0; _blk < 1; _blk++) {
+                    _vld_1[_blk] = _vptr_1[_blk];
+                    uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
+                    #pragma unroll
+                    for (int _pair = 0; _pair < 4; _pair++) {
+                        asm volatile(
+                            "{\n\t"
+                            "shl.b32 %0, %2, 16;\n\t"
+                            "and.b32 %1, %2, 0xffff0000;\n\t"
+                            "}\n"
+                            : "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[1])
+                            : "r"(_vpairs_1[_pair]));
+                    }
+                }
+            }
+            #pragma unroll
+            for (int j = 0; j < 8; j++) {
+                float _fma_0 = __fmaf_rn(_vec_load_1[j], _vec_load_0[j], acc[m_1]);
+                acc[m_1] = _fma_0;
+            }
+        }
+    }
+    #pragma unroll
+    for (int m_2 = 0; m_2 < 1; m_2++) {
+        float _warp_reduce_0 = acc[m_2];
+        #pragma unroll
+        for (int offset = 16; offset > 0; offset >>= 1)
+            _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
+        float warp_sum = _warp_reduce_0;
+        if (lane == 0) {
+            red[m_2 * 4 + warp] = warp_sum;
+        }
+    }
+    asm volatile("barrier.sync 2, 128;" ::: "memory");
+    if (warp == 0) {
+        if (lane < 1) {
+            int m_3 = lane;
+            float total = red[m_3 * 4];
+            #pragma unroll
+            for (int source_warp = 1; source_warp < 4; source_warp++) {
+                total = total + red[m_3 * 4 + source_warp];
+            }
+            int offset = m_3 * num_experts + expert;
+            if (out_is_bf16 == 0) {
+                *(reinterpret_cast<float*>(out_f32 + offset) + (0)) = total;
+            } else {
+                *(reinterpret_cast<__nv_bfloat16*>(out_bf16 + offset) + (0)) = __float2bfloat16_rn(total);
+            }
+        }
+    }
+    asm volatile("griddepcontrol.launch_dependents;" ::: "memory");
+}
+
+} // extern "C"

--- a/csrc/cake_router_gemm/cake_router_gemm_m2_k6144_device.cu
+++ b/csrc/cake_router_gemm/cake_router_gemm_m2_k6144_device.cu
@@ -14,25 +14,30 @@
  * limitations under the License.
  */
 
-typedef unsigned char      uint8_t;
-typedef unsigned short     uint16_t;
-typedef unsigned int       uint32_t;
+typedef unsigned char uint8_t;
+typedef unsigned short uint16_t;
+typedef unsigned int uint32_t;
 typedef unsigned long long uint64_t;
-typedef signed int         int32_t;
-typedef short int          int16_t;
-struct __align__(128) CakeTensorMap { uint64_t opaque[16]; };
+typedef signed int int32_t;
+typedef short int int16_t;
+struct __align__(128) CakeTensorMap {
+  uint64_t opaque[16];
+};
 template <int N>
-struct __align__(128) CakeTensorMapPack { CakeTensorMap maps[N]; };
+struct __align__(128) CakeTensorMapPack {
+  CakeTensorMap maps[N];
+};
 
-typedef struct __align__(64) { uint64_t opaque[16]; } CUtensorMap;
+typedef struct __align__(64) {
+  uint64_t opaque[16];
+} CUtensorMap;
 
 #include <cuda_bf16.h>
 
 __device__ __forceinline__ int make_warp_uniform(int x) {
-    int result;
-    asm volatile("shfl.sync.idx.b32 %0, %1, 0, 0x1F, 0xFFFFFFFF;"
-                 : "=r"(result) : "r"(x));
-    return result;
+  int result;
+  asm volatile("shfl.sync.idx.b32 %0, %1, 0, 0x1F, 0xFFFFFFFF;" : "=r"(result) : "r"(x));
+  return result;
 }
 
 #define CAKE_INF CUDART_INF_F
@@ -47,113 +52,116 @@ __device__ __forceinline__ int make_warp_uniform(int x) {
 
 extern "C" {
 
-__global__ __launch_bounds__(128, 1) void
-kernel_cake_blackwell_router_gemm_m2_k6144(__nv_bfloat16* __restrict__ mat_a, __nv_bfloat16* __restrict__ mat_b, float* __restrict__ out_f32, __nv_bfloat16* __restrict__ out_bf16, int num_experts, int out_is_bf16)
-{
-    const int tid = threadIdx.x;
-    const int warp = make_warp_uniform(tid / 32);
-    const int lane = tid % 32;
+__global__ __launch_bounds__(128, 1) void kernel_cake_blackwell_router_gemm_m2_k6144(
+    __nv_bfloat16* __restrict__ mat_a, __nv_bfloat16* __restrict__ mat_b,
+    float* __restrict__ out_f32, __nv_bfloat16* __restrict__ out_bf16, int num_experts,
+    int out_is_bf16) {
+  const int tid = threadIdx.x;
+  const int warp = make_warp_uniform(tid / 32);
+  const int lane = tid % 32;
 
-    extern __shared__ __align__(1024) char smem_raw[];
-    int smem;
-    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+  extern __shared__ __align__(1024) char smem_raw[];
+  int smem;
+  smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
 
-    const int bid = blockIdx.x;
-    const int num_bids = gridDim.x;
+  const int bid = blockIdx.x;
+  const int num_bids = gridDim.x;
 
-    // Kernel setup ops
-    float* red = reinterpret_cast<float*>(smem_raw + 0);
-    const int red_addr = smem + 0;
+  // Kernel setup ops
+  float* red = reinterpret_cast<float*>(smem_raw + 0);
+  const int red_addr = smem + 0;
 
-    // === Task calls (dependency order) ===
-    int expert = blockIdx.x;
-    float acc[2];
-    #pragma unroll
-    for (int m = 0; m < 2; m++) {
-        acc[m] = 0.0f;
-    }
-    asm volatile("griddepcontrol.wait;" ::: "memory");
-    #pragma unroll
-    for (int ki = 0; ki < 6; ki++) {
-        int k_base = ki * 1024 + tid * 8;
-        float _vec_load_0[8];
-        {
-            const uint4* _vptr_0 = reinterpret_cast<const uint4*>(mat_b + (expert * 6144 + k_base) + 0);
-            uint4 _vld_0[1];
-            #pragma unroll
-            for (int _blk = 0; _blk < 1; _blk++) {
-                _vld_0[_blk] = _vptr_0[_blk];
-                uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
-                #pragma unroll
-                for (int _pair = 0; _pair < 4; _pair++) {
-                    asm volatile(
-                        "{\n\t"
-                        "shl.b32 %0, %2, 16;\n\t"
-                        "and.b32 %1, %2, 0xffff0000;\n\t"
-                        "}\n"
-                        : "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[1])
-                        : "r"(_vpairs_0[_pair]));
-                }
-            }
+  // === Task calls (dependency order) ===
+  int expert = blockIdx.x;
+  float acc[2];
+#pragma unroll
+  for (int m = 0; m < 2; m++) {
+    acc[m] = 0.0f;
+  }
+  asm volatile("griddepcontrol.wait;" ::: "memory");
+#pragma unroll
+  for (int ki = 0; ki < 6; ki++) {
+    int k_base = ki * 1024 + tid * 8;
+    float _vec_load_0[8];
+    {
+      const uint4* _vptr_0 = reinterpret_cast<const uint4*>(mat_b + (expert * 6144 + k_base) + 0);
+      uint4 _vld_0[1];
+#pragma unroll
+      for (int _blk = 0; _blk < 1; _blk++) {
+        _vld_0[_blk] = _vptr_0[_blk];
+        uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
+#pragma unroll
+        for (int _pair = 0; _pair < 4; _pair++) {
+          asm volatile(
+              "{\n\t"
+              "shl.b32 %0, %2, 16;\n\t"
+              "and.b32 %1, %2, 0xffff0000;\n\t"
+              "}\n"
+              : "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[0]),
+                "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[1])
+              : "r"(_vpairs_0[_pair]));
         }
-        #pragma unroll
-        for (int m_1 = 0; m_1 < 2; m_1++) {
-            float _vec_load_1[8];
-            {
-                const uint4* _vptr_1 = reinterpret_cast<const uint4*>(mat_a + (m_1 * 6144 + k_base) + 0);
-                uint4 _vld_1[1];
-                #pragma unroll
-                for (int _blk = 0; _blk < 1; _blk++) {
-                    _vld_1[_blk] = _vptr_1[_blk];
-                    uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
-                    #pragma unroll
-                    for (int _pair = 0; _pair < 4; _pair++) {
-                        asm volatile(
-                            "{\n\t"
-                            "shl.b32 %0, %2, 16;\n\t"
-                            "and.b32 %1, %2, 0xffff0000;\n\t"
-                            "}\n"
-                            : "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[1])
-                            : "r"(_vpairs_1[_pair]));
-                    }
-                }
-            }
-            #pragma unroll
-            for (int j = 0; j < 8; j++) {
-                float _fma_0 = __fmaf_rn(_vec_load_1[j], _vec_load_0[j], acc[m_1]);
-                acc[m_1] = _fma_0;
-            }
-        }
+      }
     }
-    #pragma unroll
-    for (int m_2 = 0; m_2 < 2; m_2++) {
-        float _warp_reduce_0 = acc[m_2];
-        #pragma unroll
-        for (int offset = 16; offset > 0; offset >>= 1)
-            _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
-        float warp_sum = _warp_reduce_0;
-        if (lane == 0) {
-            red[m_2 * 4 + warp] = warp_sum;
+#pragma unroll
+    for (int m_1 = 0; m_1 < 2; m_1++) {
+      float _vec_load_1[8];
+      {
+        const uint4* _vptr_1 = reinterpret_cast<const uint4*>(mat_a + (m_1 * 6144 + k_base) + 0);
+        uint4 _vld_1[1];
+#pragma unroll
+        for (int _blk = 0; _blk < 1; _blk++) {
+          _vld_1[_blk] = _vptr_1[_blk];
+          uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
+#pragma unroll
+          for (int _pair = 0; _pair < 4; _pair++) {
+            asm volatile(
+                "{\n\t"
+                "shl.b32 %0, %2, 16;\n\t"
+                "and.b32 %1, %2, 0xffff0000;\n\t"
+                "}\n"
+                : "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[0]),
+                  "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[1])
+                : "r"(_vpairs_1[_pair]));
+          }
         }
+      }
+#pragma unroll
+      for (int j = 0; j < 8; j++) {
+        float _fma_0 = __fmaf_rn(_vec_load_1[j], _vec_load_0[j], acc[m_1]);
+        acc[m_1] = _fma_0;
+      }
     }
-    asm volatile("barrier.sync 2, 128;" ::: "memory");
-    if (warp == 0) {
-        if (lane < 2) {
-            int m_3 = lane;
-            float total = red[m_3 * 4];
-            #pragma unroll
-            for (int source_warp = 1; source_warp < 4; source_warp++) {
-                total = total + red[m_3 * 4 + source_warp];
-            }
-            int offset = m_3 * num_experts + expert;
-            if (out_is_bf16 == 0) {
-                *(reinterpret_cast<float*>(out_f32 + offset) + (0)) = total;
-            } else {
-                *(reinterpret_cast<__nv_bfloat16*>(out_bf16 + offset) + (0)) = __float2bfloat16_rn(total);
-            }
-        }
+  }
+#pragma unroll
+  for (int m_2 = 0; m_2 < 2; m_2++) {
+    float _warp_reduce_0 = acc[m_2];
+#pragma unroll
+    for (int offset = 16; offset > 0; offset >>= 1)
+      _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
+    float warp_sum = _warp_reduce_0;
+    if (lane == 0) {
+      red[m_2 * 4 + warp] = warp_sum;
     }
-    asm volatile("griddepcontrol.launch_dependents;" ::: "memory");
+  }
+  asm volatile("barrier.sync 2, 128;" ::: "memory");
+  if (warp == 0) {
+    if (lane < 2) {
+      int m_3 = lane;
+      float total = red[m_3 * 4];
+#pragma unroll
+      for (int source_warp = 1; source_warp < 4; source_warp++) {
+        total = total + red[m_3 * 4 + source_warp];
+      }
+      int offset = m_3 * num_experts + expert;
+      if (out_is_bf16 == 0) {
+        *(reinterpret_cast<float*>(out_f32 + offset) + (0)) = total;
+      } else {
+        *(reinterpret_cast<__nv_bfloat16*>(out_bf16 + offset) + (0)) = __float2bfloat16_rn(total);
+      }
+    }
+  }
+  asm volatile("griddepcontrol.launch_dependents;" ::: "memory");
 }
 
-} // extern "C"
+}  // extern "C"

--- a/csrc/cake_router_gemm/cake_router_gemm_m2_k6144_device.cu
+++ b/csrc/cake_router_gemm/cake_router_gemm_m2_k6144_device.cu
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) 2026 by FlashInfer team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+typedef unsigned char      uint8_t;
+typedef unsigned short     uint16_t;
+typedef unsigned int       uint32_t;
+typedef unsigned long long uint64_t;
+typedef signed int         int32_t;
+typedef short int          int16_t;
+struct __align__(128) CakeTensorMap { uint64_t opaque[16]; };
+template <int N>
+struct __align__(128) CakeTensorMapPack { CakeTensorMap maps[N]; };
+
+typedef struct __align__(64) { uint64_t opaque[16]; } CUtensorMap;
+
+#include <cuda_bf16.h>
+
+__device__ __forceinline__ int make_warp_uniform(int x) {
+    int result;
+    asm volatile("shfl.sync.idx.b32 %0, %1, 0, 0x1F, 0xFFFFFFFF;"
+                 : "=r"(result) : "r"(x));
+    return result;
+}
+
+#define CAKE_INF CUDART_INF_F
+#define NUM_MAIN_STAGES 1
+#define SMEM_RED_OFF 0
+#define SMEM_RED_STAGE_BYTES 32
+#define SMEM_RED_STRIDE 32
+#define SMEM_TOTAL 128
+#define THREADS 128
+
+#include <math_constants.h>
+
+extern "C" {
+
+__global__ __launch_bounds__(128, 1) void
+kernel_cake_blackwell_router_gemm_m2_k6144(__nv_bfloat16* __restrict__ mat_a, __nv_bfloat16* __restrict__ mat_b, float* __restrict__ out_f32, __nv_bfloat16* __restrict__ out_bf16, int num_experts, int out_is_bf16)
+{
+    const int tid = threadIdx.x;
+    const int warp = make_warp_uniform(tid / 32);
+    const int lane = tid % 32;
+
+    extern __shared__ __align__(1024) char smem_raw[];
+    int smem;
+    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+
+    const int bid = blockIdx.x;
+    const int num_bids = gridDim.x;
+
+    // Kernel setup ops
+    float* red = reinterpret_cast<float*>(smem_raw + 0);
+    const int red_addr = smem + 0;
+
+    // === Task calls (dependency order) ===
+    int expert = blockIdx.x;
+    float acc[2];
+    #pragma unroll
+    for (int m = 0; m < 2; m++) {
+        acc[m] = 0.0f;
+    }
+    asm volatile("griddepcontrol.wait;" ::: "memory");
+    #pragma unroll
+    for (int ki = 0; ki < 6; ki++) {
+        int k_base = ki * 1024 + tid * 8;
+        float _vec_load_0[8];
+        {
+            const uint4* _vptr_0 = reinterpret_cast<const uint4*>(mat_b + (expert * 6144 + k_base) + 0);
+            uint4 _vld_0[1];
+            #pragma unroll
+            for (int _blk = 0; _blk < 1; _blk++) {
+                _vld_0[_blk] = _vptr_0[_blk];
+                uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
+                #pragma unroll
+                for (int _pair = 0; _pair < 4; _pair++) {
+                    asm volatile(
+                        "{\n\t"
+                        "shl.b32 %0, %2, 16;\n\t"
+                        "and.b32 %1, %2, 0xffff0000;\n\t"
+                        "}\n"
+                        : "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[1])
+                        : "r"(_vpairs_0[_pair]));
+                }
+            }
+        }
+        #pragma unroll
+        for (int m_1 = 0; m_1 < 2; m_1++) {
+            float _vec_load_1[8];
+            {
+                const uint4* _vptr_1 = reinterpret_cast<const uint4*>(mat_a + (m_1 * 6144 + k_base) + 0);
+                uint4 _vld_1[1];
+                #pragma unroll
+                for (int _blk = 0; _blk < 1; _blk++) {
+                    _vld_1[_blk] = _vptr_1[_blk];
+                    uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
+                    #pragma unroll
+                    for (int _pair = 0; _pair < 4; _pair++) {
+                        asm volatile(
+                            "{\n\t"
+                            "shl.b32 %0, %2, 16;\n\t"
+                            "and.b32 %1, %2, 0xffff0000;\n\t"
+                            "}\n"
+                            : "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[1])
+                            : "r"(_vpairs_1[_pair]));
+                    }
+                }
+            }
+            #pragma unroll
+            for (int j = 0; j < 8; j++) {
+                float _fma_0 = __fmaf_rn(_vec_load_1[j], _vec_load_0[j], acc[m_1]);
+                acc[m_1] = _fma_0;
+            }
+        }
+    }
+    #pragma unroll
+    for (int m_2 = 0; m_2 < 2; m_2++) {
+        float _warp_reduce_0 = acc[m_2];
+        #pragma unroll
+        for (int offset = 16; offset > 0; offset >>= 1)
+            _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
+        float warp_sum = _warp_reduce_0;
+        if (lane == 0) {
+            red[m_2 * 4 + warp] = warp_sum;
+        }
+    }
+    asm volatile("barrier.sync 2, 128;" ::: "memory");
+    if (warp == 0) {
+        if (lane < 2) {
+            int m_3 = lane;
+            float total = red[m_3 * 4];
+            #pragma unroll
+            for (int source_warp = 1; source_warp < 4; source_warp++) {
+                total = total + red[m_3 * 4 + source_warp];
+            }
+            int offset = m_3 * num_experts + expert;
+            if (out_is_bf16 == 0) {
+                *(reinterpret_cast<float*>(out_f32 + offset) + (0)) = total;
+            } else {
+                *(reinterpret_cast<__nv_bfloat16*>(out_bf16 + offset) + (0)) = __float2bfloat16_rn(total);
+            }
+        }
+    }
+    asm volatile("griddepcontrol.launch_dependents;" ::: "memory");
+}
+
+} // extern "C"

--- a/csrc/cake_router_gemm/cake_router_gemm_m2_k7168_device.cu
+++ b/csrc/cake_router_gemm/cake_router_gemm_m2_k7168_device.cu
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) 2026 by FlashInfer team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+typedef unsigned char      uint8_t;
+typedef unsigned short     uint16_t;
+typedef unsigned int       uint32_t;
+typedef unsigned long long uint64_t;
+typedef signed int         int32_t;
+typedef short int          int16_t;
+struct __align__(128) CakeTensorMap { uint64_t opaque[16]; };
+template <int N>
+struct __align__(128) CakeTensorMapPack { CakeTensorMap maps[N]; };
+
+typedef struct __align__(64) { uint64_t opaque[16]; } CUtensorMap;
+
+#include <cuda_bf16.h>
+
+__device__ __forceinline__ int make_warp_uniform(int x) {
+    int result;
+    asm volatile("shfl.sync.idx.b32 %0, %1, 0, 0x1F, 0xFFFFFFFF;"
+                 : "=r"(result) : "r"(x));
+    return result;
+}
+
+#define CAKE_INF CUDART_INF_F
+#define NUM_MAIN_STAGES 1
+#define SMEM_RED_OFF 0
+#define SMEM_RED_STAGE_BYTES 32
+#define SMEM_RED_STRIDE 32
+#define SMEM_TOTAL 128
+#define THREADS 128
+
+#include <math_constants.h>
+
+extern "C" {
+
+__global__ __launch_bounds__(128, 1) void
+kernel_cake_blackwell_router_gemm_m2_k7168(__nv_bfloat16* __restrict__ mat_a, __nv_bfloat16* __restrict__ mat_b, float* __restrict__ out_f32, __nv_bfloat16* __restrict__ out_bf16, int num_experts, int out_is_bf16)
+{
+    const int tid = threadIdx.x;
+    const int warp = make_warp_uniform(tid / 32);
+    const int lane = tid % 32;
+
+    extern __shared__ __align__(1024) char smem_raw[];
+    int smem;
+    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+
+    const int bid = blockIdx.x;
+    const int num_bids = gridDim.x;
+
+    // Kernel setup ops
+    float* red = reinterpret_cast<float*>(smem_raw + 0);
+    const int red_addr = smem + 0;
+
+    // === Task calls (dependency order) ===
+    int expert = blockIdx.x;
+    float acc[2];
+    #pragma unroll
+    for (int m = 0; m < 2; m++) {
+        acc[m] = 0.0f;
+    }
+    asm volatile("griddepcontrol.wait;" ::: "memory");
+    #pragma unroll
+    for (int ki = 0; ki < 7; ki++) {
+        int k_base = ki * 1024 + tid * 8;
+        float _vec_load_0[8];
+        {
+            const uint4* _vptr_0 = reinterpret_cast<const uint4*>(mat_b + (expert * 7168 + k_base) + 0);
+            uint4 _vld_0[1];
+            #pragma unroll
+            for (int _blk = 0; _blk < 1; _blk++) {
+                _vld_0[_blk] = _vptr_0[_blk];
+                uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
+                #pragma unroll
+                for (int _pair = 0; _pair < 4; _pair++) {
+                    asm volatile(
+                        "{\n\t"
+                        "shl.b32 %0, %2, 16;\n\t"
+                        "and.b32 %1, %2, 0xffff0000;\n\t"
+                        "}\n"
+                        : "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[1])
+                        : "r"(_vpairs_0[_pair]));
+                }
+            }
+        }
+        #pragma unroll
+        for (int m_1 = 0; m_1 < 2; m_1++) {
+            float _vec_load_1[8];
+            {
+                const uint4* _vptr_1 = reinterpret_cast<const uint4*>(mat_a + (m_1 * 7168 + k_base) + 0);
+                uint4 _vld_1[1];
+                #pragma unroll
+                for (int _blk = 0; _blk < 1; _blk++) {
+                    _vld_1[_blk] = _vptr_1[_blk];
+                    uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
+                    #pragma unroll
+                    for (int _pair = 0; _pair < 4; _pair++) {
+                        asm volatile(
+                            "{\n\t"
+                            "shl.b32 %0, %2, 16;\n\t"
+                            "and.b32 %1, %2, 0xffff0000;\n\t"
+                            "}\n"
+                            : "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[1])
+                            : "r"(_vpairs_1[_pair]));
+                    }
+                }
+            }
+            #pragma unroll
+            for (int j = 0; j < 8; j++) {
+                float _fma_0 = __fmaf_rn(_vec_load_1[j], _vec_load_0[j], acc[m_1]);
+                acc[m_1] = _fma_0;
+            }
+        }
+    }
+    #pragma unroll
+    for (int m_2 = 0; m_2 < 2; m_2++) {
+        float _warp_reduce_0 = acc[m_2];
+        #pragma unroll
+        for (int offset = 16; offset > 0; offset >>= 1)
+            _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
+        float warp_sum = _warp_reduce_0;
+        if (lane == 0) {
+            red[m_2 * 4 + warp] = warp_sum;
+        }
+    }
+    asm volatile("barrier.sync 2, 128;" ::: "memory");
+    if (warp == 0) {
+        if (lane < 2) {
+            int m_3 = lane;
+            float total = red[m_3 * 4];
+            #pragma unroll
+            for (int source_warp = 1; source_warp < 4; source_warp++) {
+                total = total + red[m_3 * 4 + source_warp];
+            }
+            int offset = m_3 * num_experts + expert;
+            if (out_is_bf16 == 0) {
+                *(reinterpret_cast<float*>(out_f32 + offset) + (0)) = total;
+            } else {
+                *(reinterpret_cast<__nv_bfloat16*>(out_bf16 + offset) + (0)) = __float2bfloat16_rn(total);
+            }
+        }
+    }
+    asm volatile("griddepcontrol.launch_dependents;" ::: "memory");
+}
+
+} // extern "C"

--- a/csrc/cake_router_gemm/cake_router_gemm_m2_k7168_device.cu
+++ b/csrc/cake_router_gemm/cake_router_gemm_m2_k7168_device.cu
@@ -14,25 +14,30 @@
  * limitations under the License.
  */
 
-typedef unsigned char      uint8_t;
-typedef unsigned short     uint16_t;
-typedef unsigned int       uint32_t;
+typedef unsigned char uint8_t;
+typedef unsigned short uint16_t;
+typedef unsigned int uint32_t;
 typedef unsigned long long uint64_t;
-typedef signed int         int32_t;
-typedef short int          int16_t;
-struct __align__(128) CakeTensorMap { uint64_t opaque[16]; };
+typedef signed int int32_t;
+typedef short int int16_t;
+struct __align__(128) CakeTensorMap {
+  uint64_t opaque[16];
+};
 template <int N>
-struct __align__(128) CakeTensorMapPack { CakeTensorMap maps[N]; };
+struct __align__(128) CakeTensorMapPack {
+  CakeTensorMap maps[N];
+};
 
-typedef struct __align__(64) { uint64_t opaque[16]; } CUtensorMap;
+typedef struct __align__(64) {
+  uint64_t opaque[16];
+} CUtensorMap;
 
 #include <cuda_bf16.h>
 
 __device__ __forceinline__ int make_warp_uniform(int x) {
-    int result;
-    asm volatile("shfl.sync.idx.b32 %0, %1, 0, 0x1F, 0xFFFFFFFF;"
-                 : "=r"(result) : "r"(x));
-    return result;
+  int result;
+  asm volatile("shfl.sync.idx.b32 %0, %1, 0, 0x1F, 0xFFFFFFFF;" : "=r"(result) : "r"(x));
+  return result;
 }
 
 #define CAKE_INF CUDART_INF_F
@@ -47,113 +52,116 @@ __device__ __forceinline__ int make_warp_uniform(int x) {
 
 extern "C" {
 
-__global__ __launch_bounds__(128, 1) void
-kernel_cake_blackwell_router_gemm_m2_k7168(__nv_bfloat16* __restrict__ mat_a, __nv_bfloat16* __restrict__ mat_b, float* __restrict__ out_f32, __nv_bfloat16* __restrict__ out_bf16, int num_experts, int out_is_bf16)
-{
-    const int tid = threadIdx.x;
-    const int warp = make_warp_uniform(tid / 32);
-    const int lane = tid % 32;
+__global__ __launch_bounds__(128, 1) void kernel_cake_blackwell_router_gemm_m2_k7168(
+    __nv_bfloat16* __restrict__ mat_a, __nv_bfloat16* __restrict__ mat_b,
+    float* __restrict__ out_f32, __nv_bfloat16* __restrict__ out_bf16, int num_experts,
+    int out_is_bf16) {
+  const int tid = threadIdx.x;
+  const int warp = make_warp_uniform(tid / 32);
+  const int lane = tid % 32;
 
-    extern __shared__ __align__(1024) char smem_raw[];
-    int smem;
-    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+  extern __shared__ __align__(1024) char smem_raw[];
+  int smem;
+  smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
 
-    const int bid = blockIdx.x;
-    const int num_bids = gridDim.x;
+  const int bid = blockIdx.x;
+  const int num_bids = gridDim.x;
 
-    // Kernel setup ops
-    float* red = reinterpret_cast<float*>(smem_raw + 0);
-    const int red_addr = smem + 0;
+  // Kernel setup ops
+  float* red = reinterpret_cast<float*>(smem_raw + 0);
+  const int red_addr = smem + 0;
 
-    // === Task calls (dependency order) ===
-    int expert = blockIdx.x;
-    float acc[2];
-    #pragma unroll
-    for (int m = 0; m < 2; m++) {
-        acc[m] = 0.0f;
-    }
-    asm volatile("griddepcontrol.wait;" ::: "memory");
-    #pragma unroll
-    for (int ki = 0; ki < 7; ki++) {
-        int k_base = ki * 1024 + tid * 8;
-        float _vec_load_0[8];
-        {
-            const uint4* _vptr_0 = reinterpret_cast<const uint4*>(mat_b + (expert * 7168 + k_base) + 0);
-            uint4 _vld_0[1];
-            #pragma unroll
-            for (int _blk = 0; _blk < 1; _blk++) {
-                _vld_0[_blk] = _vptr_0[_blk];
-                uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
-                #pragma unroll
-                for (int _pair = 0; _pair < 4; _pair++) {
-                    asm volatile(
-                        "{\n\t"
-                        "shl.b32 %0, %2, 16;\n\t"
-                        "and.b32 %1, %2, 0xffff0000;\n\t"
-                        "}\n"
-                        : "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[1])
-                        : "r"(_vpairs_0[_pair]));
-                }
-            }
+  // === Task calls (dependency order) ===
+  int expert = blockIdx.x;
+  float acc[2];
+#pragma unroll
+  for (int m = 0; m < 2; m++) {
+    acc[m] = 0.0f;
+  }
+  asm volatile("griddepcontrol.wait;" ::: "memory");
+#pragma unroll
+  for (int ki = 0; ki < 7; ki++) {
+    int k_base = ki * 1024 + tid * 8;
+    float _vec_load_0[8];
+    {
+      const uint4* _vptr_0 = reinterpret_cast<const uint4*>(mat_b + (expert * 7168 + k_base) + 0);
+      uint4 _vld_0[1];
+#pragma unroll
+      for (int _blk = 0; _blk < 1; _blk++) {
+        _vld_0[_blk] = _vptr_0[_blk];
+        uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
+#pragma unroll
+        for (int _pair = 0; _pair < 4; _pair++) {
+          asm volatile(
+              "{\n\t"
+              "shl.b32 %0, %2, 16;\n\t"
+              "and.b32 %1, %2, 0xffff0000;\n\t"
+              "}\n"
+              : "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[0]),
+                "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[1])
+              : "r"(_vpairs_0[_pair]));
         }
-        #pragma unroll
-        for (int m_1 = 0; m_1 < 2; m_1++) {
-            float _vec_load_1[8];
-            {
-                const uint4* _vptr_1 = reinterpret_cast<const uint4*>(mat_a + (m_1 * 7168 + k_base) + 0);
-                uint4 _vld_1[1];
-                #pragma unroll
-                for (int _blk = 0; _blk < 1; _blk++) {
-                    _vld_1[_blk] = _vptr_1[_blk];
-                    uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
-                    #pragma unroll
-                    for (int _pair = 0; _pair < 4; _pair++) {
-                        asm volatile(
-                            "{\n\t"
-                            "shl.b32 %0, %2, 16;\n\t"
-                            "and.b32 %1, %2, 0xffff0000;\n\t"
-                            "}\n"
-                            : "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[1])
-                            : "r"(_vpairs_1[_pair]));
-                    }
-                }
-            }
-            #pragma unroll
-            for (int j = 0; j < 8; j++) {
-                float _fma_0 = __fmaf_rn(_vec_load_1[j], _vec_load_0[j], acc[m_1]);
-                acc[m_1] = _fma_0;
-            }
-        }
+      }
     }
-    #pragma unroll
-    for (int m_2 = 0; m_2 < 2; m_2++) {
-        float _warp_reduce_0 = acc[m_2];
-        #pragma unroll
-        for (int offset = 16; offset > 0; offset >>= 1)
-            _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
-        float warp_sum = _warp_reduce_0;
-        if (lane == 0) {
-            red[m_2 * 4 + warp] = warp_sum;
+#pragma unroll
+    for (int m_1 = 0; m_1 < 2; m_1++) {
+      float _vec_load_1[8];
+      {
+        const uint4* _vptr_1 = reinterpret_cast<const uint4*>(mat_a + (m_1 * 7168 + k_base) + 0);
+        uint4 _vld_1[1];
+#pragma unroll
+        for (int _blk = 0; _blk < 1; _blk++) {
+          _vld_1[_blk] = _vptr_1[_blk];
+          uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
+#pragma unroll
+          for (int _pair = 0; _pair < 4; _pair++) {
+            asm volatile(
+                "{\n\t"
+                "shl.b32 %0, %2, 16;\n\t"
+                "and.b32 %1, %2, 0xffff0000;\n\t"
+                "}\n"
+                : "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[0]),
+                  "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[1])
+                : "r"(_vpairs_1[_pair]));
+          }
         }
+      }
+#pragma unroll
+      for (int j = 0; j < 8; j++) {
+        float _fma_0 = __fmaf_rn(_vec_load_1[j], _vec_load_0[j], acc[m_1]);
+        acc[m_1] = _fma_0;
+      }
     }
-    asm volatile("barrier.sync 2, 128;" ::: "memory");
-    if (warp == 0) {
-        if (lane < 2) {
-            int m_3 = lane;
-            float total = red[m_3 * 4];
-            #pragma unroll
-            for (int source_warp = 1; source_warp < 4; source_warp++) {
-                total = total + red[m_3 * 4 + source_warp];
-            }
-            int offset = m_3 * num_experts + expert;
-            if (out_is_bf16 == 0) {
-                *(reinterpret_cast<float*>(out_f32 + offset) + (0)) = total;
-            } else {
-                *(reinterpret_cast<__nv_bfloat16*>(out_bf16 + offset) + (0)) = __float2bfloat16_rn(total);
-            }
-        }
+  }
+#pragma unroll
+  for (int m_2 = 0; m_2 < 2; m_2++) {
+    float _warp_reduce_0 = acc[m_2];
+#pragma unroll
+    for (int offset = 16; offset > 0; offset >>= 1)
+      _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
+    float warp_sum = _warp_reduce_0;
+    if (lane == 0) {
+      red[m_2 * 4 + warp] = warp_sum;
     }
-    asm volatile("griddepcontrol.launch_dependents;" ::: "memory");
+  }
+  asm volatile("barrier.sync 2, 128;" ::: "memory");
+  if (warp == 0) {
+    if (lane < 2) {
+      int m_3 = lane;
+      float total = red[m_3 * 4];
+#pragma unroll
+      for (int source_warp = 1; source_warp < 4; source_warp++) {
+        total = total + red[m_3 * 4 + source_warp];
+      }
+      int offset = m_3 * num_experts + expert;
+      if (out_is_bf16 == 0) {
+        *(reinterpret_cast<float*>(out_f32 + offset) + (0)) = total;
+      } else {
+        *(reinterpret_cast<__nv_bfloat16*>(out_bf16 + offset) + (0)) = __float2bfloat16_rn(total);
+      }
+    }
+  }
+  asm volatile("griddepcontrol.launch_dependents;" ::: "memory");
 }
 
-} // extern "C"
+}  // extern "C"

--- a/csrc/cake_router_gemm/cake_router_gemm_m3_k6144_device.cu
+++ b/csrc/cake_router_gemm/cake_router_gemm_m3_k6144_device.cu
@@ -14,25 +14,30 @@
  * limitations under the License.
  */
 
-typedef unsigned char      uint8_t;
-typedef unsigned short     uint16_t;
-typedef unsigned int       uint32_t;
+typedef unsigned char uint8_t;
+typedef unsigned short uint16_t;
+typedef unsigned int uint32_t;
 typedef unsigned long long uint64_t;
-typedef signed int         int32_t;
-typedef short int          int16_t;
-struct __align__(128) CakeTensorMap { uint64_t opaque[16]; };
+typedef signed int int32_t;
+typedef short int int16_t;
+struct __align__(128) CakeTensorMap {
+  uint64_t opaque[16];
+};
 template <int N>
-struct __align__(128) CakeTensorMapPack { CakeTensorMap maps[N]; };
+struct __align__(128) CakeTensorMapPack {
+  CakeTensorMap maps[N];
+};
 
-typedef struct __align__(64) { uint64_t opaque[16]; } CUtensorMap;
+typedef struct __align__(64) {
+  uint64_t opaque[16];
+} CUtensorMap;
 
 #include <cuda_bf16.h>
 
 __device__ __forceinline__ int make_warp_uniform(int x) {
-    int result;
-    asm volatile("shfl.sync.idx.b32 %0, %1, 0, 0x1F, 0xFFFFFFFF;"
-                 : "=r"(result) : "r"(x));
-    return result;
+  int result;
+  asm volatile("shfl.sync.idx.b32 %0, %1, 0, 0x1F, 0xFFFFFFFF;" : "=r"(result) : "r"(x));
+  return result;
 }
 
 #define CAKE_INF CUDART_INF_F
@@ -47,113 +52,116 @@ __device__ __forceinline__ int make_warp_uniform(int x) {
 
 extern "C" {
 
-__global__ __launch_bounds__(128, 1) void
-kernel_cake_blackwell_router_gemm_m3_k6144(__nv_bfloat16* __restrict__ mat_a, __nv_bfloat16* __restrict__ mat_b, float* __restrict__ out_f32, __nv_bfloat16* __restrict__ out_bf16, int num_experts, int out_is_bf16)
-{
-    const int tid = threadIdx.x;
-    const int warp = make_warp_uniform(tid / 32);
-    const int lane = tid % 32;
+__global__ __launch_bounds__(128, 1) void kernel_cake_blackwell_router_gemm_m3_k6144(
+    __nv_bfloat16* __restrict__ mat_a, __nv_bfloat16* __restrict__ mat_b,
+    float* __restrict__ out_f32, __nv_bfloat16* __restrict__ out_bf16, int num_experts,
+    int out_is_bf16) {
+  const int tid = threadIdx.x;
+  const int warp = make_warp_uniform(tid / 32);
+  const int lane = tid % 32;
 
-    extern __shared__ __align__(1024) char smem_raw[];
-    int smem;
-    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+  extern __shared__ __align__(1024) char smem_raw[];
+  int smem;
+  smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
 
-    const int bid = blockIdx.x;
-    const int num_bids = gridDim.x;
+  const int bid = blockIdx.x;
+  const int num_bids = gridDim.x;
 
-    // Kernel setup ops
-    float* red = reinterpret_cast<float*>(smem_raw + 0);
-    const int red_addr = smem + 0;
+  // Kernel setup ops
+  float* red = reinterpret_cast<float*>(smem_raw + 0);
+  const int red_addr = smem + 0;
 
-    // === Task calls (dependency order) ===
-    int expert = blockIdx.x;
-    float acc[3];
-    #pragma unroll
-    for (int m = 0; m < 3; m++) {
-        acc[m] = 0.0f;
-    }
-    asm volatile("griddepcontrol.wait;" ::: "memory");
-    #pragma unroll
-    for (int ki = 0; ki < 6; ki++) {
-        int k_base = ki * 1024 + tid * 8;
-        float _vec_load_0[8];
-        {
-            const uint4* _vptr_0 = reinterpret_cast<const uint4*>(mat_b + (expert * 6144 + k_base) + 0);
-            uint4 _vld_0[1];
-            #pragma unroll
-            for (int _blk = 0; _blk < 1; _blk++) {
-                _vld_0[_blk] = _vptr_0[_blk];
-                uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
-                #pragma unroll
-                for (int _pair = 0; _pair < 4; _pair++) {
-                    asm volatile(
-                        "{\n\t"
-                        "shl.b32 %0, %2, 16;\n\t"
-                        "and.b32 %1, %2, 0xffff0000;\n\t"
-                        "}\n"
-                        : "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[1])
-                        : "r"(_vpairs_0[_pair]));
-                }
-            }
+  // === Task calls (dependency order) ===
+  int expert = blockIdx.x;
+  float acc[3];
+#pragma unroll
+  for (int m = 0; m < 3; m++) {
+    acc[m] = 0.0f;
+  }
+  asm volatile("griddepcontrol.wait;" ::: "memory");
+#pragma unroll
+  for (int ki = 0; ki < 6; ki++) {
+    int k_base = ki * 1024 + tid * 8;
+    float _vec_load_0[8];
+    {
+      const uint4* _vptr_0 = reinterpret_cast<const uint4*>(mat_b + (expert * 6144 + k_base) + 0);
+      uint4 _vld_0[1];
+#pragma unroll
+      for (int _blk = 0; _blk < 1; _blk++) {
+        _vld_0[_blk] = _vptr_0[_blk];
+        uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
+#pragma unroll
+        for (int _pair = 0; _pair < 4; _pair++) {
+          asm volatile(
+              "{\n\t"
+              "shl.b32 %0, %2, 16;\n\t"
+              "and.b32 %1, %2, 0xffff0000;\n\t"
+              "}\n"
+              : "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[0]),
+                "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[1])
+              : "r"(_vpairs_0[_pair]));
         }
-        #pragma unroll
-        for (int m_1 = 0; m_1 < 3; m_1++) {
-            float _vec_load_1[8];
-            {
-                const uint4* _vptr_1 = reinterpret_cast<const uint4*>(mat_a + (m_1 * 6144 + k_base) + 0);
-                uint4 _vld_1[1];
-                #pragma unroll
-                for (int _blk = 0; _blk < 1; _blk++) {
-                    _vld_1[_blk] = _vptr_1[_blk];
-                    uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
-                    #pragma unroll
-                    for (int _pair = 0; _pair < 4; _pair++) {
-                        asm volatile(
-                            "{\n\t"
-                            "shl.b32 %0, %2, 16;\n\t"
-                            "and.b32 %1, %2, 0xffff0000;\n\t"
-                            "}\n"
-                            : "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[1])
-                            : "r"(_vpairs_1[_pair]));
-                    }
-                }
-            }
-            #pragma unroll
-            for (int j = 0; j < 8; j++) {
-                float _fma_0 = __fmaf_rn(_vec_load_1[j], _vec_load_0[j], acc[m_1]);
-                acc[m_1] = _fma_0;
-            }
-        }
+      }
     }
-    #pragma unroll
-    for (int m_2 = 0; m_2 < 3; m_2++) {
-        float _warp_reduce_0 = acc[m_2];
-        #pragma unroll
-        for (int offset = 16; offset > 0; offset >>= 1)
-            _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
-        float warp_sum = _warp_reduce_0;
-        if (lane == 0) {
-            red[m_2 * 4 + warp] = warp_sum;
+#pragma unroll
+    for (int m_1 = 0; m_1 < 3; m_1++) {
+      float _vec_load_1[8];
+      {
+        const uint4* _vptr_1 = reinterpret_cast<const uint4*>(mat_a + (m_1 * 6144 + k_base) + 0);
+        uint4 _vld_1[1];
+#pragma unroll
+        for (int _blk = 0; _blk < 1; _blk++) {
+          _vld_1[_blk] = _vptr_1[_blk];
+          uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
+#pragma unroll
+          for (int _pair = 0; _pair < 4; _pair++) {
+            asm volatile(
+                "{\n\t"
+                "shl.b32 %0, %2, 16;\n\t"
+                "and.b32 %1, %2, 0xffff0000;\n\t"
+                "}\n"
+                : "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[0]),
+                  "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[1])
+                : "r"(_vpairs_1[_pair]));
+          }
         }
+      }
+#pragma unroll
+      for (int j = 0; j < 8; j++) {
+        float _fma_0 = __fmaf_rn(_vec_load_1[j], _vec_load_0[j], acc[m_1]);
+        acc[m_1] = _fma_0;
+      }
     }
-    asm volatile("barrier.sync 2, 128;" ::: "memory");
-    if (warp == 0) {
-        if (lane < 3) {
-            int m_3 = lane;
-            float total = red[m_3 * 4];
-            #pragma unroll
-            for (int source_warp = 1; source_warp < 4; source_warp++) {
-                total = total + red[m_3 * 4 + source_warp];
-            }
-            int offset = m_3 * num_experts + expert;
-            if (out_is_bf16 == 0) {
-                *(reinterpret_cast<float*>(out_f32 + offset) + (0)) = total;
-            } else {
-                *(reinterpret_cast<__nv_bfloat16*>(out_bf16 + offset) + (0)) = __float2bfloat16_rn(total);
-            }
-        }
+  }
+#pragma unroll
+  for (int m_2 = 0; m_2 < 3; m_2++) {
+    float _warp_reduce_0 = acc[m_2];
+#pragma unroll
+    for (int offset = 16; offset > 0; offset >>= 1)
+      _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
+    float warp_sum = _warp_reduce_0;
+    if (lane == 0) {
+      red[m_2 * 4 + warp] = warp_sum;
     }
-    asm volatile("griddepcontrol.launch_dependents;" ::: "memory");
+  }
+  asm volatile("barrier.sync 2, 128;" ::: "memory");
+  if (warp == 0) {
+    if (lane < 3) {
+      int m_3 = lane;
+      float total = red[m_3 * 4];
+#pragma unroll
+      for (int source_warp = 1; source_warp < 4; source_warp++) {
+        total = total + red[m_3 * 4 + source_warp];
+      }
+      int offset = m_3 * num_experts + expert;
+      if (out_is_bf16 == 0) {
+        *(reinterpret_cast<float*>(out_f32 + offset) + (0)) = total;
+      } else {
+        *(reinterpret_cast<__nv_bfloat16*>(out_bf16 + offset) + (0)) = __float2bfloat16_rn(total);
+      }
+    }
+  }
+  asm volatile("griddepcontrol.launch_dependents;" ::: "memory");
 }
 
-} // extern "C"
+}  // extern "C"

--- a/csrc/cake_router_gemm/cake_router_gemm_m3_k6144_device.cu
+++ b/csrc/cake_router_gemm/cake_router_gemm_m3_k6144_device.cu
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) 2026 by FlashInfer team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+typedef unsigned char      uint8_t;
+typedef unsigned short     uint16_t;
+typedef unsigned int       uint32_t;
+typedef unsigned long long uint64_t;
+typedef signed int         int32_t;
+typedef short int          int16_t;
+struct __align__(128) CakeTensorMap { uint64_t opaque[16]; };
+template <int N>
+struct __align__(128) CakeTensorMapPack { CakeTensorMap maps[N]; };
+
+typedef struct __align__(64) { uint64_t opaque[16]; } CUtensorMap;
+
+#include <cuda_bf16.h>
+
+__device__ __forceinline__ int make_warp_uniform(int x) {
+    int result;
+    asm volatile("shfl.sync.idx.b32 %0, %1, 0, 0x1F, 0xFFFFFFFF;"
+                 : "=r"(result) : "r"(x));
+    return result;
+}
+
+#define CAKE_INF CUDART_INF_F
+#define NUM_MAIN_STAGES 1
+#define SMEM_RED_OFF 0
+#define SMEM_RED_STAGE_BYTES 48
+#define SMEM_RED_STRIDE 48
+#define SMEM_TOTAL 128
+#define THREADS 128
+
+#include <math_constants.h>
+
+extern "C" {
+
+__global__ __launch_bounds__(128, 1) void
+kernel_cake_blackwell_router_gemm_m3_k6144(__nv_bfloat16* __restrict__ mat_a, __nv_bfloat16* __restrict__ mat_b, float* __restrict__ out_f32, __nv_bfloat16* __restrict__ out_bf16, int num_experts, int out_is_bf16)
+{
+    const int tid = threadIdx.x;
+    const int warp = make_warp_uniform(tid / 32);
+    const int lane = tid % 32;
+
+    extern __shared__ __align__(1024) char smem_raw[];
+    int smem;
+    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+
+    const int bid = blockIdx.x;
+    const int num_bids = gridDim.x;
+
+    // Kernel setup ops
+    float* red = reinterpret_cast<float*>(smem_raw + 0);
+    const int red_addr = smem + 0;
+
+    // === Task calls (dependency order) ===
+    int expert = blockIdx.x;
+    float acc[3];
+    #pragma unroll
+    for (int m = 0; m < 3; m++) {
+        acc[m] = 0.0f;
+    }
+    asm volatile("griddepcontrol.wait;" ::: "memory");
+    #pragma unroll
+    for (int ki = 0; ki < 6; ki++) {
+        int k_base = ki * 1024 + tid * 8;
+        float _vec_load_0[8];
+        {
+            const uint4* _vptr_0 = reinterpret_cast<const uint4*>(mat_b + (expert * 6144 + k_base) + 0);
+            uint4 _vld_0[1];
+            #pragma unroll
+            for (int _blk = 0; _blk < 1; _blk++) {
+                _vld_0[_blk] = _vptr_0[_blk];
+                uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
+                #pragma unroll
+                for (int _pair = 0; _pair < 4; _pair++) {
+                    asm volatile(
+                        "{\n\t"
+                        "shl.b32 %0, %2, 16;\n\t"
+                        "and.b32 %1, %2, 0xffff0000;\n\t"
+                        "}\n"
+                        : "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[1])
+                        : "r"(_vpairs_0[_pair]));
+                }
+            }
+        }
+        #pragma unroll
+        for (int m_1 = 0; m_1 < 3; m_1++) {
+            float _vec_load_1[8];
+            {
+                const uint4* _vptr_1 = reinterpret_cast<const uint4*>(mat_a + (m_1 * 6144 + k_base) + 0);
+                uint4 _vld_1[1];
+                #pragma unroll
+                for (int _blk = 0; _blk < 1; _blk++) {
+                    _vld_1[_blk] = _vptr_1[_blk];
+                    uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
+                    #pragma unroll
+                    for (int _pair = 0; _pair < 4; _pair++) {
+                        asm volatile(
+                            "{\n\t"
+                            "shl.b32 %0, %2, 16;\n\t"
+                            "and.b32 %1, %2, 0xffff0000;\n\t"
+                            "}\n"
+                            : "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[1])
+                            : "r"(_vpairs_1[_pair]));
+                    }
+                }
+            }
+            #pragma unroll
+            for (int j = 0; j < 8; j++) {
+                float _fma_0 = __fmaf_rn(_vec_load_1[j], _vec_load_0[j], acc[m_1]);
+                acc[m_1] = _fma_0;
+            }
+        }
+    }
+    #pragma unroll
+    for (int m_2 = 0; m_2 < 3; m_2++) {
+        float _warp_reduce_0 = acc[m_2];
+        #pragma unroll
+        for (int offset = 16; offset > 0; offset >>= 1)
+            _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
+        float warp_sum = _warp_reduce_0;
+        if (lane == 0) {
+            red[m_2 * 4 + warp] = warp_sum;
+        }
+    }
+    asm volatile("barrier.sync 2, 128;" ::: "memory");
+    if (warp == 0) {
+        if (lane < 3) {
+            int m_3 = lane;
+            float total = red[m_3 * 4];
+            #pragma unroll
+            for (int source_warp = 1; source_warp < 4; source_warp++) {
+                total = total + red[m_3 * 4 + source_warp];
+            }
+            int offset = m_3 * num_experts + expert;
+            if (out_is_bf16 == 0) {
+                *(reinterpret_cast<float*>(out_f32 + offset) + (0)) = total;
+            } else {
+                *(reinterpret_cast<__nv_bfloat16*>(out_bf16 + offset) + (0)) = __float2bfloat16_rn(total);
+            }
+        }
+    }
+    asm volatile("griddepcontrol.launch_dependents;" ::: "memory");
+}
+
+} // extern "C"

--- a/csrc/cake_router_gemm/cake_router_gemm_m3_k7168_device.cu
+++ b/csrc/cake_router_gemm/cake_router_gemm_m3_k7168_device.cu
@@ -14,25 +14,30 @@
  * limitations under the License.
  */
 
-typedef unsigned char      uint8_t;
-typedef unsigned short     uint16_t;
-typedef unsigned int       uint32_t;
+typedef unsigned char uint8_t;
+typedef unsigned short uint16_t;
+typedef unsigned int uint32_t;
 typedef unsigned long long uint64_t;
-typedef signed int         int32_t;
-typedef short int          int16_t;
-struct __align__(128) CakeTensorMap { uint64_t opaque[16]; };
+typedef signed int int32_t;
+typedef short int int16_t;
+struct __align__(128) CakeTensorMap {
+  uint64_t opaque[16];
+};
 template <int N>
-struct __align__(128) CakeTensorMapPack { CakeTensorMap maps[N]; };
+struct __align__(128) CakeTensorMapPack {
+  CakeTensorMap maps[N];
+};
 
-typedef struct __align__(64) { uint64_t opaque[16]; } CUtensorMap;
+typedef struct __align__(64) {
+  uint64_t opaque[16];
+} CUtensorMap;
 
 #include <cuda_bf16.h>
 
 __device__ __forceinline__ int make_warp_uniform(int x) {
-    int result;
-    asm volatile("shfl.sync.idx.b32 %0, %1, 0, 0x1F, 0xFFFFFFFF;"
-                 : "=r"(result) : "r"(x));
-    return result;
+  int result;
+  asm volatile("shfl.sync.idx.b32 %0, %1, 0, 0x1F, 0xFFFFFFFF;" : "=r"(result) : "r"(x));
+  return result;
 }
 
 #define CAKE_INF CUDART_INF_F
@@ -47,113 +52,116 @@ __device__ __forceinline__ int make_warp_uniform(int x) {
 
 extern "C" {
 
-__global__ __launch_bounds__(128, 1) void
-kernel_cake_blackwell_router_gemm_m3_k7168(__nv_bfloat16* __restrict__ mat_a, __nv_bfloat16* __restrict__ mat_b, float* __restrict__ out_f32, __nv_bfloat16* __restrict__ out_bf16, int num_experts, int out_is_bf16)
-{
-    const int tid = threadIdx.x;
-    const int warp = make_warp_uniform(tid / 32);
-    const int lane = tid % 32;
+__global__ __launch_bounds__(128, 1) void kernel_cake_blackwell_router_gemm_m3_k7168(
+    __nv_bfloat16* __restrict__ mat_a, __nv_bfloat16* __restrict__ mat_b,
+    float* __restrict__ out_f32, __nv_bfloat16* __restrict__ out_bf16, int num_experts,
+    int out_is_bf16) {
+  const int tid = threadIdx.x;
+  const int warp = make_warp_uniform(tid / 32);
+  const int lane = tid % 32;
 
-    extern __shared__ __align__(1024) char smem_raw[];
-    int smem;
-    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+  extern __shared__ __align__(1024) char smem_raw[];
+  int smem;
+  smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
 
-    const int bid = blockIdx.x;
-    const int num_bids = gridDim.x;
+  const int bid = blockIdx.x;
+  const int num_bids = gridDim.x;
 
-    // Kernel setup ops
-    float* red = reinterpret_cast<float*>(smem_raw + 0);
-    const int red_addr = smem + 0;
+  // Kernel setup ops
+  float* red = reinterpret_cast<float*>(smem_raw + 0);
+  const int red_addr = smem + 0;
 
-    // === Task calls (dependency order) ===
-    int expert = blockIdx.x;
-    float acc[3];
-    #pragma unroll
-    for (int m = 0; m < 3; m++) {
-        acc[m] = 0.0f;
-    }
-    asm volatile("griddepcontrol.wait;" ::: "memory");
-    #pragma unroll
-    for (int ki = 0; ki < 7; ki++) {
-        int k_base = ki * 1024 + tid * 8;
-        float _vec_load_0[8];
-        {
-            const uint4* _vptr_0 = reinterpret_cast<const uint4*>(mat_b + (expert * 7168 + k_base) + 0);
-            uint4 _vld_0[1];
-            #pragma unroll
-            for (int _blk = 0; _blk < 1; _blk++) {
-                _vld_0[_blk] = _vptr_0[_blk];
-                uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
-                #pragma unroll
-                for (int _pair = 0; _pair < 4; _pair++) {
-                    asm volatile(
-                        "{\n\t"
-                        "shl.b32 %0, %2, 16;\n\t"
-                        "and.b32 %1, %2, 0xffff0000;\n\t"
-                        "}\n"
-                        : "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[1])
-                        : "r"(_vpairs_0[_pair]));
-                }
-            }
+  // === Task calls (dependency order) ===
+  int expert = blockIdx.x;
+  float acc[3];
+#pragma unroll
+  for (int m = 0; m < 3; m++) {
+    acc[m] = 0.0f;
+  }
+  asm volatile("griddepcontrol.wait;" ::: "memory");
+#pragma unroll
+  for (int ki = 0; ki < 7; ki++) {
+    int k_base = ki * 1024 + tid * 8;
+    float _vec_load_0[8];
+    {
+      const uint4* _vptr_0 = reinterpret_cast<const uint4*>(mat_b + (expert * 7168 + k_base) + 0);
+      uint4 _vld_0[1];
+#pragma unroll
+      for (int _blk = 0; _blk < 1; _blk++) {
+        _vld_0[_blk] = _vptr_0[_blk];
+        uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
+#pragma unroll
+        for (int _pair = 0; _pair < 4; _pair++) {
+          asm volatile(
+              "{\n\t"
+              "shl.b32 %0, %2, 16;\n\t"
+              "and.b32 %1, %2, 0xffff0000;\n\t"
+              "}\n"
+              : "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[0]),
+                "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[1])
+              : "r"(_vpairs_0[_pair]));
         }
-        #pragma unroll
-        for (int m_1 = 0; m_1 < 3; m_1++) {
-            float _vec_load_1[8];
-            {
-                const uint4* _vptr_1 = reinterpret_cast<const uint4*>(mat_a + (m_1 * 7168 + k_base) + 0);
-                uint4 _vld_1[1];
-                #pragma unroll
-                for (int _blk = 0; _blk < 1; _blk++) {
-                    _vld_1[_blk] = _vptr_1[_blk];
-                    uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
-                    #pragma unroll
-                    for (int _pair = 0; _pair < 4; _pair++) {
-                        asm volatile(
-                            "{\n\t"
-                            "shl.b32 %0, %2, 16;\n\t"
-                            "and.b32 %1, %2, 0xffff0000;\n\t"
-                            "}\n"
-                            : "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[1])
-                            : "r"(_vpairs_1[_pair]));
-                    }
-                }
-            }
-            #pragma unroll
-            for (int j = 0; j < 8; j++) {
-                float _fma_0 = __fmaf_rn(_vec_load_1[j], _vec_load_0[j], acc[m_1]);
-                acc[m_1] = _fma_0;
-            }
-        }
+      }
     }
-    #pragma unroll
-    for (int m_2 = 0; m_2 < 3; m_2++) {
-        float _warp_reduce_0 = acc[m_2];
-        #pragma unroll
-        for (int offset = 16; offset > 0; offset >>= 1)
-            _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
-        float warp_sum = _warp_reduce_0;
-        if (lane == 0) {
-            red[m_2 * 4 + warp] = warp_sum;
+#pragma unroll
+    for (int m_1 = 0; m_1 < 3; m_1++) {
+      float _vec_load_1[8];
+      {
+        const uint4* _vptr_1 = reinterpret_cast<const uint4*>(mat_a + (m_1 * 7168 + k_base) + 0);
+        uint4 _vld_1[1];
+#pragma unroll
+        for (int _blk = 0; _blk < 1; _blk++) {
+          _vld_1[_blk] = _vptr_1[_blk];
+          uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
+#pragma unroll
+          for (int _pair = 0; _pair < 4; _pair++) {
+            asm volatile(
+                "{\n\t"
+                "shl.b32 %0, %2, 16;\n\t"
+                "and.b32 %1, %2, 0xffff0000;\n\t"
+                "}\n"
+                : "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[0]),
+                  "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[1])
+                : "r"(_vpairs_1[_pair]));
+          }
         }
+      }
+#pragma unroll
+      for (int j = 0; j < 8; j++) {
+        float _fma_0 = __fmaf_rn(_vec_load_1[j], _vec_load_0[j], acc[m_1]);
+        acc[m_1] = _fma_0;
+      }
     }
-    asm volatile("barrier.sync 2, 128;" ::: "memory");
-    if (warp == 0) {
-        if (lane < 3) {
-            int m_3 = lane;
-            float total = red[m_3 * 4];
-            #pragma unroll
-            for (int source_warp = 1; source_warp < 4; source_warp++) {
-                total = total + red[m_3 * 4 + source_warp];
-            }
-            int offset = m_3 * num_experts + expert;
-            if (out_is_bf16 == 0) {
-                *(reinterpret_cast<float*>(out_f32 + offset) + (0)) = total;
-            } else {
-                *(reinterpret_cast<__nv_bfloat16*>(out_bf16 + offset) + (0)) = __float2bfloat16_rn(total);
-            }
-        }
+  }
+#pragma unroll
+  for (int m_2 = 0; m_2 < 3; m_2++) {
+    float _warp_reduce_0 = acc[m_2];
+#pragma unroll
+    for (int offset = 16; offset > 0; offset >>= 1)
+      _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
+    float warp_sum = _warp_reduce_0;
+    if (lane == 0) {
+      red[m_2 * 4 + warp] = warp_sum;
     }
-    asm volatile("griddepcontrol.launch_dependents;" ::: "memory");
+  }
+  asm volatile("barrier.sync 2, 128;" ::: "memory");
+  if (warp == 0) {
+    if (lane < 3) {
+      int m_3 = lane;
+      float total = red[m_3 * 4];
+#pragma unroll
+      for (int source_warp = 1; source_warp < 4; source_warp++) {
+        total = total + red[m_3 * 4 + source_warp];
+      }
+      int offset = m_3 * num_experts + expert;
+      if (out_is_bf16 == 0) {
+        *(reinterpret_cast<float*>(out_f32 + offset) + (0)) = total;
+      } else {
+        *(reinterpret_cast<__nv_bfloat16*>(out_bf16 + offset) + (0)) = __float2bfloat16_rn(total);
+      }
+    }
+  }
+  asm volatile("griddepcontrol.launch_dependents;" ::: "memory");
 }
 
-} // extern "C"
+}  // extern "C"

--- a/csrc/cake_router_gemm/cake_router_gemm_m3_k7168_device.cu
+++ b/csrc/cake_router_gemm/cake_router_gemm_m3_k7168_device.cu
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) 2026 by FlashInfer team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+typedef unsigned char      uint8_t;
+typedef unsigned short     uint16_t;
+typedef unsigned int       uint32_t;
+typedef unsigned long long uint64_t;
+typedef signed int         int32_t;
+typedef short int          int16_t;
+struct __align__(128) CakeTensorMap { uint64_t opaque[16]; };
+template <int N>
+struct __align__(128) CakeTensorMapPack { CakeTensorMap maps[N]; };
+
+typedef struct __align__(64) { uint64_t opaque[16]; } CUtensorMap;
+
+#include <cuda_bf16.h>
+
+__device__ __forceinline__ int make_warp_uniform(int x) {
+    int result;
+    asm volatile("shfl.sync.idx.b32 %0, %1, 0, 0x1F, 0xFFFFFFFF;"
+                 : "=r"(result) : "r"(x));
+    return result;
+}
+
+#define CAKE_INF CUDART_INF_F
+#define NUM_MAIN_STAGES 1
+#define SMEM_RED_OFF 0
+#define SMEM_RED_STAGE_BYTES 48
+#define SMEM_RED_STRIDE 48
+#define SMEM_TOTAL 128
+#define THREADS 128
+
+#include <math_constants.h>
+
+extern "C" {
+
+__global__ __launch_bounds__(128, 1) void
+kernel_cake_blackwell_router_gemm_m3_k7168(__nv_bfloat16* __restrict__ mat_a, __nv_bfloat16* __restrict__ mat_b, float* __restrict__ out_f32, __nv_bfloat16* __restrict__ out_bf16, int num_experts, int out_is_bf16)
+{
+    const int tid = threadIdx.x;
+    const int warp = make_warp_uniform(tid / 32);
+    const int lane = tid % 32;
+
+    extern __shared__ __align__(1024) char smem_raw[];
+    int smem;
+    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+
+    const int bid = blockIdx.x;
+    const int num_bids = gridDim.x;
+
+    // Kernel setup ops
+    float* red = reinterpret_cast<float*>(smem_raw + 0);
+    const int red_addr = smem + 0;
+
+    // === Task calls (dependency order) ===
+    int expert = blockIdx.x;
+    float acc[3];
+    #pragma unroll
+    for (int m = 0; m < 3; m++) {
+        acc[m] = 0.0f;
+    }
+    asm volatile("griddepcontrol.wait;" ::: "memory");
+    #pragma unroll
+    for (int ki = 0; ki < 7; ki++) {
+        int k_base = ki * 1024 + tid * 8;
+        float _vec_load_0[8];
+        {
+            const uint4* _vptr_0 = reinterpret_cast<const uint4*>(mat_b + (expert * 7168 + k_base) + 0);
+            uint4 _vld_0[1];
+            #pragma unroll
+            for (int _blk = 0; _blk < 1; _blk++) {
+                _vld_0[_blk] = _vptr_0[_blk];
+                uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
+                #pragma unroll
+                for (int _pair = 0; _pair < 4; _pair++) {
+                    asm volatile(
+                        "{\n\t"
+                        "shl.b32 %0, %2, 16;\n\t"
+                        "and.b32 %1, %2, 0xffff0000;\n\t"
+                        "}\n"
+                        : "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[1])
+                        : "r"(_vpairs_0[_pair]));
+                }
+            }
+        }
+        #pragma unroll
+        for (int m_1 = 0; m_1 < 3; m_1++) {
+            float _vec_load_1[8];
+            {
+                const uint4* _vptr_1 = reinterpret_cast<const uint4*>(mat_a + (m_1 * 7168 + k_base) + 0);
+                uint4 _vld_1[1];
+                #pragma unroll
+                for (int _blk = 0; _blk < 1; _blk++) {
+                    _vld_1[_blk] = _vptr_1[_blk];
+                    uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
+                    #pragma unroll
+                    for (int _pair = 0; _pair < 4; _pair++) {
+                        asm volatile(
+                            "{\n\t"
+                            "shl.b32 %0, %2, 16;\n\t"
+                            "and.b32 %1, %2, 0xffff0000;\n\t"
+                            "}\n"
+                            : "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[1])
+                            : "r"(_vpairs_1[_pair]));
+                    }
+                }
+            }
+            #pragma unroll
+            for (int j = 0; j < 8; j++) {
+                float _fma_0 = __fmaf_rn(_vec_load_1[j], _vec_load_0[j], acc[m_1]);
+                acc[m_1] = _fma_0;
+            }
+        }
+    }
+    #pragma unroll
+    for (int m_2 = 0; m_2 < 3; m_2++) {
+        float _warp_reduce_0 = acc[m_2];
+        #pragma unroll
+        for (int offset = 16; offset > 0; offset >>= 1)
+            _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
+        float warp_sum = _warp_reduce_0;
+        if (lane == 0) {
+            red[m_2 * 4 + warp] = warp_sum;
+        }
+    }
+    asm volatile("barrier.sync 2, 128;" ::: "memory");
+    if (warp == 0) {
+        if (lane < 3) {
+            int m_3 = lane;
+            float total = red[m_3 * 4];
+            #pragma unroll
+            for (int source_warp = 1; source_warp < 4; source_warp++) {
+                total = total + red[m_3 * 4 + source_warp];
+            }
+            int offset = m_3 * num_experts + expert;
+            if (out_is_bf16 == 0) {
+                *(reinterpret_cast<float*>(out_f32 + offset) + (0)) = total;
+            } else {
+                *(reinterpret_cast<__nv_bfloat16*>(out_bf16 + offset) + (0)) = __float2bfloat16_rn(total);
+            }
+        }
+    }
+    asm volatile("griddepcontrol.launch_dependents;" ::: "memory");
+}
+
+} // extern "C"

--- a/csrc/cake_router_gemm/cake_router_gemm_m4_k6144_device.cu
+++ b/csrc/cake_router_gemm/cake_router_gemm_m4_k6144_device.cu
@@ -14,25 +14,30 @@
  * limitations under the License.
  */
 
-typedef unsigned char      uint8_t;
-typedef unsigned short     uint16_t;
-typedef unsigned int       uint32_t;
+typedef unsigned char uint8_t;
+typedef unsigned short uint16_t;
+typedef unsigned int uint32_t;
 typedef unsigned long long uint64_t;
-typedef signed int         int32_t;
-typedef short int          int16_t;
-struct __align__(128) CakeTensorMap { uint64_t opaque[16]; };
+typedef signed int int32_t;
+typedef short int int16_t;
+struct __align__(128) CakeTensorMap {
+  uint64_t opaque[16];
+};
 template <int N>
-struct __align__(128) CakeTensorMapPack { CakeTensorMap maps[N]; };
+struct __align__(128) CakeTensorMapPack {
+  CakeTensorMap maps[N];
+};
 
-typedef struct __align__(64) { uint64_t opaque[16]; } CUtensorMap;
+typedef struct __align__(64) {
+  uint64_t opaque[16];
+} CUtensorMap;
 
 #include <cuda_bf16.h>
 
 __device__ __forceinline__ int make_warp_uniform(int x) {
-    int result;
-    asm volatile("shfl.sync.idx.b32 %0, %1, 0, 0x1F, 0xFFFFFFFF;"
-                 : "=r"(result) : "r"(x));
-    return result;
+  int result;
+  asm volatile("shfl.sync.idx.b32 %0, %1, 0, 0x1F, 0xFFFFFFFF;" : "=r"(result) : "r"(x));
+  return result;
 }
 
 #define CAKE_INF CUDART_INF_F
@@ -47,113 +52,116 @@ __device__ __forceinline__ int make_warp_uniform(int x) {
 
 extern "C" {
 
-__global__ __launch_bounds__(128, 1) void
-kernel_cake_blackwell_router_gemm_m4_k6144(__nv_bfloat16* __restrict__ mat_a, __nv_bfloat16* __restrict__ mat_b, float* __restrict__ out_f32, __nv_bfloat16* __restrict__ out_bf16, int num_experts, int out_is_bf16)
-{
-    const int tid = threadIdx.x;
-    const int warp = make_warp_uniform(tid / 32);
-    const int lane = tid % 32;
+__global__ __launch_bounds__(128, 1) void kernel_cake_blackwell_router_gemm_m4_k6144(
+    __nv_bfloat16* __restrict__ mat_a, __nv_bfloat16* __restrict__ mat_b,
+    float* __restrict__ out_f32, __nv_bfloat16* __restrict__ out_bf16, int num_experts,
+    int out_is_bf16) {
+  const int tid = threadIdx.x;
+  const int warp = make_warp_uniform(tid / 32);
+  const int lane = tid % 32;
 
-    extern __shared__ __align__(1024) char smem_raw[];
-    int smem;
-    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+  extern __shared__ __align__(1024) char smem_raw[];
+  int smem;
+  smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
 
-    const int bid = blockIdx.x;
-    const int num_bids = gridDim.x;
+  const int bid = blockIdx.x;
+  const int num_bids = gridDim.x;
 
-    // Kernel setup ops
-    float* red = reinterpret_cast<float*>(smem_raw + 0);
-    const int red_addr = smem + 0;
+  // Kernel setup ops
+  float* red = reinterpret_cast<float*>(smem_raw + 0);
+  const int red_addr = smem + 0;
 
-    // === Task calls (dependency order) ===
-    int expert = blockIdx.x;
-    float acc[4];
-    #pragma unroll
-    for (int m = 0; m < 4; m++) {
-        acc[m] = 0.0f;
-    }
-    asm volatile("griddepcontrol.wait;" ::: "memory");
-    #pragma unroll
-    for (int ki = 0; ki < 6; ki++) {
-        int k_base = ki * 1024 + tid * 8;
-        float _vec_load_0[8];
-        {
-            const uint4* _vptr_0 = reinterpret_cast<const uint4*>(mat_b + (expert * 6144 + k_base) + 0);
-            uint4 _vld_0[1];
-            #pragma unroll
-            for (int _blk = 0; _blk < 1; _blk++) {
-                _vld_0[_blk] = _vptr_0[_blk];
-                uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
-                #pragma unroll
-                for (int _pair = 0; _pair < 4; _pair++) {
-                    asm volatile(
-                        "{\n\t"
-                        "shl.b32 %0, %2, 16;\n\t"
-                        "and.b32 %1, %2, 0xffff0000;\n\t"
-                        "}\n"
-                        : "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[1])
-                        : "r"(_vpairs_0[_pair]));
-                }
-            }
+  // === Task calls (dependency order) ===
+  int expert = blockIdx.x;
+  float acc[4];
+#pragma unroll
+  for (int m = 0; m < 4; m++) {
+    acc[m] = 0.0f;
+  }
+  asm volatile("griddepcontrol.wait;" ::: "memory");
+#pragma unroll
+  for (int ki = 0; ki < 6; ki++) {
+    int k_base = ki * 1024 + tid * 8;
+    float _vec_load_0[8];
+    {
+      const uint4* _vptr_0 = reinterpret_cast<const uint4*>(mat_b + (expert * 6144 + k_base) + 0);
+      uint4 _vld_0[1];
+#pragma unroll
+      for (int _blk = 0; _blk < 1; _blk++) {
+        _vld_0[_blk] = _vptr_0[_blk];
+        uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
+#pragma unroll
+        for (int _pair = 0; _pair < 4; _pair++) {
+          asm volatile(
+              "{\n\t"
+              "shl.b32 %0, %2, 16;\n\t"
+              "and.b32 %1, %2, 0xffff0000;\n\t"
+              "}\n"
+              : "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[0]),
+                "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[1])
+              : "r"(_vpairs_0[_pair]));
         }
-        #pragma unroll
-        for (int m_1 = 0; m_1 < 4; m_1++) {
-            float _vec_load_1[8];
-            {
-                const uint4* _vptr_1 = reinterpret_cast<const uint4*>(mat_a + (m_1 * 6144 + k_base) + 0);
-                uint4 _vld_1[1];
-                #pragma unroll
-                for (int _blk = 0; _blk < 1; _blk++) {
-                    _vld_1[_blk] = _vptr_1[_blk];
-                    uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
-                    #pragma unroll
-                    for (int _pair = 0; _pair < 4; _pair++) {
-                        asm volatile(
-                            "{\n\t"
-                            "shl.b32 %0, %2, 16;\n\t"
-                            "and.b32 %1, %2, 0xffff0000;\n\t"
-                            "}\n"
-                            : "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[1])
-                            : "r"(_vpairs_1[_pair]));
-                    }
-                }
-            }
-            #pragma unroll
-            for (int j = 0; j < 8; j++) {
-                float _fma_0 = __fmaf_rn(_vec_load_1[j], _vec_load_0[j], acc[m_1]);
-                acc[m_1] = _fma_0;
-            }
-        }
+      }
     }
-    #pragma unroll
-    for (int m_2 = 0; m_2 < 4; m_2++) {
-        float _warp_reduce_0 = acc[m_2];
-        #pragma unroll
-        for (int offset = 16; offset > 0; offset >>= 1)
-            _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
-        float warp_sum = _warp_reduce_0;
-        if (lane == 0) {
-            red[m_2 * 4 + warp] = warp_sum;
+#pragma unroll
+    for (int m_1 = 0; m_1 < 4; m_1++) {
+      float _vec_load_1[8];
+      {
+        const uint4* _vptr_1 = reinterpret_cast<const uint4*>(mat_a + (m_1 * 6144 + k_base) + 0);
+        uint4 _vld_1[1];
+#pragma unroll
+        for (int _blk = 0; _blk < 1; _blk++) {
+          _vld_1[_blk] = _vptr_1[_blk];
+          uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
+#pragma unroll
+          for (int _pair = 0; _pair < 4; _pair++) {
+            asm volatile(
+                "{\n\t"
+                "shl.b32 %0, %2, 16;\n\t"
+                "and.b32 %1, %2, 0xffff0000;\n\t"
+                "}\n"
+                : "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[0]),
+                  "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[1])
+                : "r"(_vpairs_1[_pair]));
+          }
         }
+      }
+#pragma unroll
+      for (int j = 0; j < 8; j++) {
+        float _fma_0 = __fmaf_rn(_vec_load_1[j], _vec_load_0[j], acc[m_1]);
+        acc[m_1] = _fma_0;
+      }
     }
-    asm volatile("barrier.sync 2, 128;" ::: "memory");
-    if (warp == 0) {
-        if (lane < 4) {
-            int m_3 = lane;
-            float total = red[m_3 * 4];
-            #pragma unroll
-            for (int source_warp = 1; source_warp < 4; source_warp++) {
-                total = total + red[m_3 * 4 + source_warp];
-            }
-            int offset = m_3 * num_experts + expert;
-            if (out_is_bf16 == 0) {
-                *(reinterpret_cast<float*>(out_f32 + offset) + (0)) = total;
-            } else {
-                *(reinterpret_cast<__nv_bfloat16*>(out_bf16 + offset) + (0)) = __float2bfloat16_rn(total);
-            }
-        }
+  }
+#pragma unroll
+  for (int m_2 = 0; m_2 < 4; m_2++) {
+    float _warp_reduce_0 = acc[m_2];
+#pragma unroll
+    for (int offset = 16; offset > 0; offset >>= 1)
+      _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
+    float warp_sum = _warp_reduce_0;
+    if (lane == 0) {
+      red[m_2 * 4 + warp] = warp_sum;
     }
-    asm volatile("griddepcontrol.launch_dependents;" ::: "memory");
+  }
+  asm volatile("barrier.sync 2, 128;" ::: "memory");
+  if (warp == 0) {
+    if (lane < 4) {
+      int m_3 = lane;
+      float total = red[m_3 * 4];
+#pragma unroll
+      for (int source_warp = 1; source_warp < 4; source_warp++) {
+        total = total + red[m_3 * 4 + source_warp];
+      }
+      int offset = m_3 * num_experts + expert;
+      if (out_is_bf16 == 0) {
+        *(reinterpret_cast<float*>(out_f32 + offset) + (0)) = total;
+      } else {
+        *(reinterpret_cast<__nv_bfloat16*>(out_bf16 + offset) + (0)) = __float2bfloat16_rn(total);
+      }
+    }
+  }
+  asm volatile("griddepcontrol.launch_dependents;" ::: "memory");
 }
 
-} // extern "C"
+}  // extern "C"

--- a/csrc/cake_router_gemm/cake_router_gemm_m4_k6144_device.cu
+++ b/csrc/cake_router_gemm/cake_router_gemm_m4_k6144_device.cu
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) 2026 by FlashInfer team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+typedef unsigned char      uint8_t;
+typedef unsigned short     uint16_t;
+typedef unsigned int       uint32_t;
+typedef unsigned long long uint64_t;
+typedef signed int         int32_t;
+typedef short int          int16_t;
+struct __align__(128) CakeTensorMap { uint64_t opaque[16]; };
+template <int N>
+struct __align__(128) CakeTensorMapPack { CakeTensorMap maps[N]; };
+
+typedef struct __align__(64) { uint64_t opaque[16]; } CUtensorMap;
+
+#include <cuda_bf16.h>
+
+__device__ __forceinline__ int make_warp_uniform(int x) {
+    int result;
+    asm volatile("shfl.sync.idx.b32 %0, %1, 0, 0x1F, 0xFFFFFFFF;"
+                 : "=r"(result) : "r"(x));
+    return result;
+}
+
+#define CAKE_INF CUDART_INF_F
+#define NUM_MAIN_STAGES 1
+#define SMEM_RED_OFF 0
+#define SMEM_RED_STAGE_BYTES 64
+#define SMEM_RED_STRIDE 64
+#define SMEM_TOTAL 128
+#define THREADS 128
+
+#include <math_constants.h>
+
+extern "C" {
+
+__global__ __launch_bounds__(128, 1) void
+kernel_cake_blackwell_router_gemm_m4_k6144(__nv_bfloat16* __restrict__ mat_a, __nv_bfloat16* __restrict__ mat_b, float* __restrict__ out_f32, __nv_bfloat16* __restrict__ out_bf16, int num_experts, int out_is_bf16)
+{
+    const int tid = threadIdx.x;
+    const int warp = make_warp_uniform(tid / 32);
+    const int lane = tid % 32;
+
+    extern __shared__ __align__(1024) char smem_raw[];
+    int smem;
+    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+
+    const int bid = blockIdx.x;
+    const int num_bids = gridDim.x;
+
+    // Kernel setup ops
+    float* red = reinterpret_cast<float*>(smem_raw + 0);
+    const int red_addr = smem + 0;
+
+    // === Task calls (dependency order) ===
+    int expert = blockIdx.x;
+    float acc[4];
+    #pragma unroll
+    for (int m = 0; m < 4; m++) {
+        acc[m] = 0.0f;
+    }
+    asm volatile("griddepcontrol.wait;" ::: "memory");
+    #pragma unroll
+    for (int ki = 0; ki < 6; ki++) {
+        int k_base = ki * 1024 + tid * 8;
+        float _vec_load_0[8];
+        {
+            const uint4* _vptr_0 = reinterpret_cast<const uint4*>(mat_b + (expert * 6144 + k_base) + 0);
+            uint4 _vld_0[1];
+            #pragma unroll
+            for (int _blk = 0; _blk < 1; _blk++) {
+                _vld_0[_blk] = _vptr_0[_blk];
+                uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
+                #pragma unroll
+                for (int _pair = 0; _pair < 4; _pair++) {
+                    asm volatile(
+                        "{\n\t"
+                        "shl.b32 %0, %2, 16;\n\t"
+                        "and.b32 %1, %2, 0xffff0000;\n\t"
+                        "}\n"
+                        : "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[1])
+                        : "r"(_vpairs_0[_pair]));
+                }
+            }
+        }
+        #pragma unroll
+        for (int m_1 = 0; m_1 < 4; m_1++) {
+            float _vec_load_1[8];
+            {
+                const uint4* _vptr_1 = reinterpret_cast<const uint4*>(mat_a + (m_1 * 6144 + k_base) + 0);
+                uint4 _vld_1[1];
+                #pragma unroll
+                for (int _blk = 0; _blk < 1; _blk++) {
+                    _vld_1[_blk] = _vptr_1[_blk];
+                    uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
+                    #pragma unroll
+                    for (int _pair = 0; _pair < 4; _pair++) {
+                        asm volatile(
+                            "{\n\t"
+                            "shl.b32 %0, %2, 16;\n\t"
+                            "and.b32 %1, %2, 0xffff0000;\n\t"
+                            "}\n"
+                            : "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[1])
+                            : "r"(_vpairs_1[_pair]));
+                    }
+                }
+            }
+            #pragma unroll
+            for (int j = 0; j < 8; j++) {
+                float _fma_0 = __fmaf_rn(_vec_load_1[j], _vec_load_0[j], acc[m_1]);
+                acc[m_1] = _fma_0;
+            }
+        }
+    }
+    #pragma unroll
+    for (int m_2 = 0; m_2 < 4; m_2++) {
+        float _warp_reduce_0 = acc[m_2];
+        #pragma unroll
+        for (int offset = 16; offset > 0; offset >>= 1)
+            _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
+        float warp_sum = _warp_reduce_0;
+        if (lane == 0) {
+            red[m_2 * 4 + warp] = warp_sum;
+        }
+    }
+    asm volatile("barrier.sync 2, 128;" ::: "memory");
+    if (warp == 0) {
+        if (lane < 4) {
+            int m_3 = lane;
+            float total = red[m_3 * 4];
+            #pragma unroll
+            for (int source_warp = 1; source_warp < 4; source_warp++) {
+                total = total + red[m_3 * 4 + source_warp];
+            }
+            int offset = m_3 * num_experts + expert;
+            if (out_is_bf16 == 0) {
+                *(reinterpret_cast<float*>(out_f32 + offset) + (0)) = total;
+            } else {
+                *(reinterpret_cast<__nv_bfloat16*>(out_bf16 + offset) + (0)) = __float2bfloat16_rn(total);
+            }
+        }
+    }
+    asm volatile("griddepcontrol.launch_dependents;" ::: "memory");
+}
+
+} // extern "C"

--- a/csrc/cake_router_gemm/cake_router_gemm_m4_k7168_device.cu
+++ b/csrc/cake_router_gemm/cake_router_gemm_m4_k7168_device.cu
@@ -14,25 +14,30 @@
  * limitations under the License.
  */
 
-typedef unsigned char      uint8_t;
-typedef unsigned short     uint16_t;
-typedef unsigned int       uint32_t;
+typedef unsigned char uint8_t;
+typedef unsigned short uint16_t;
+typedef unsigned int uint32_t;
 typedef unsigned long long uint64_t;
-typedef signed int         int32_t;
-typedef short int          int16_t;
-struct __align__(128) CakeTensorMap { uint64_t opaque[16]; };
+typedef signed int int32_t;
+typedef short int int16_t;
+struct __align__(128) CakeTensorMap {
+  uint64_t opaque[16];
+};
 template <int N>
-struct __align__(128) CakeTensorMapPack { CakeTensorMap maps[N]; };
+struct __align__(128) CakeTensorMapPack {
+  CakeTensorMap maps[N];
+};
 
-typedef struct __align__(64) { uint64_t opaque[16]; } CUtensorMap;
+typedef struct __align__(64) {
+  uint64_t opaque[16];
+} CUtensorMap;
 
 #include <cuda_bf16.h>
 
 __device__ __forceinline__ int make_warp_uniform(int x) {
-    int result;
-    asm volatile("shfl.sync.idx.b32 %0, %1, 0, 0x1F, 0xFFFFFFFF;"
-                 : "=r"(result) : "r"(x));
-    return result;
+  int result;
+  asm volatile("shfl.sync.idx.b32 %0, %1, 0, 0x1F, 0xFFFFFFFF;" : "=r"(result) : "r"(x));
+  return result;
 }
 
 #define CAKE_INF CUDART_INF_F
@@ -47,113 +52,116 @@ __device__ __forceinline__ int make_warp_uniform(int x) {
 
 extern "C" {
 
-__global__ __launch_bounds__(128, 1) void
-kernel_cake_blackwell_router_gemm_m4_k7168(__nv_bfloat16* __restrict__ mat_a, __nv_bfloat16* __restrict__ mat_b, float* __restrict__ out_f32, __nv_bfloat16* __restrict__ out_bf16, int num_experts, int out_is_bf16)
-{
-    const int tid = threadIdx.x;
-    const int warp = make_warp_uniform(tid / 32);
-    const int lane = tid % 32;
+__global__ __launch_bounds__(128, 1) void kernel_cake_blackwell_router_gemm_m4_k7168(
+    __nv_bfloat16* __restrict__ mat_a, __nv_bfloat16* __restrict__ mat_b,
+    float* __restrict__ out_f32, __nv_bfloat16* __restrict__ out_bf16, int num_experts,
+    int out_is_bf16) {
+  const int tid = threadIdx.x;
+  const int warp = make_warp_uniform(tid / 32);
+  const int lane = tid % 32;
 
-    extern __shared__ __align__(1024) char smem_raw[];
-    int smem;
-    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+  extern __shared__ __align__(1024) char smem_raw[];
+  int smem;
+  smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
 
-    const int bid = blockIdx.x;
-    const int num_bids = gridDim.x;
+  const int bid = blockIdx.x;
+  const int num_bids = gridDim.x;
 
-    // Kernel setup ops
-    float* red = reinterpret_cast<float*>(smem_raw + 0);
-    const int red_addr = smem + 0;
+  // Kernel setup ops
+  float* red = reinterpret_cast<float*>(smem_raw + 0);
+  const int red_addr = smem + 0;
 
-    // === Task calls (dependency order) ===
-    int expert = blockIdx.x;
-    float acc[4];
-    #pragma unroll
-    for (int m = 0; m < 4; m++) {
-        acc[m] = 0.0f;
-    }
-    asm volatile("griddepcontrol.wait;" ::: "memory");
-    #pragma unroll
-    for (int ki = 0; ki < 7; ki++) {
-        int k_base = ki * 1024 + tid * 8;
-        float _vec_load_0[8];
-        {
-            const uint4* _vptr_0 = reinterpret_cast<const uint4*>(mat_b + (expert * 7168 + k_base) + 0);
-            uint4 _vld_0[1];
-            #pragma unroll
-            for (int _blk = 0; _blk < 1; _blk++) {
-                _vld_0[_blk] = _vptr_0[_blk];
-                uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
-                #pragma unroll
-                for (int _pair = 0; _pair < 4; _pair++) {
-                    asm volatile(
-                        "{\n\t"
-                        "shl.b32 %0, %2, 16;\n\t"
-                        "and.b32 %1, %2, 0xffff0000;\n\t"
-                        "}\n"
-                        : "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[1])
-                        : "r"(_vpairs_0[_pair]));
-                }
-            }
+  // === Task calls (dependency order) ===
+  int expert = blockIdx.x;
+  float acc[4];
+#pragma unroll
+  for (int m = 0; m < 4; m++) {
+    acc[m] = 0.0f;
+  }
+  asm volatile("griddepcontrol.wait;" ::: "memory");
+#pragma unroll
+  for (int ki = 0; ki < 7; ki++) {
+    int k_base = ki * 1024 + tid * 8;
+    float _vec_load_0[8];
+    {
+      const uint4* _vptr_0 = reinterpret_cast<const uint4*>(mat_b + (expert * 7168 + k_base) + 0);
+      uint4 _vld_0[1];
+#pragma unroll
+      for (int _blk = 0; _blk < 1; _blk++) {
+        _vld_0[_blk] = _vptr_0[_blk];
+        uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
+#pragma unroll
+        for (int _pair = 0; _pair < 4; _pair++) {
+          asm volatile(
+              "{\n\t"
+              "shl.b32 %0, %2, 16;\n\t"
+              "and.b32 %1, %2, 0xffff0000;\n\t"
+              "}\n"
+              : "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[0]),
+                "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[1])
+              : "r"(_vpairs_0[_pair]));
         }
-        #pragma unroll
-        for (int m_1 = 0; m_1 < 4; m_1++) {
-            float _vec_load_1[8];
-            {
-                const uint4* _vptr_1 = reinterpret_cast<const uint4*>(mat_a + (m_1 * 7168 + k_base) + 0);
-                uint4 _vld_1[1];
-                #pragma unroll
-                for (int _blk = 0; _blk < 1; _blk++) {
-                    _vld_1[_blk] = _vptr_1[_blk];
-                    uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
-                    #pragma unroll
-                    for (int _pair = 0; _pair < 4; _pair++) {
-                        asm volatile(
-                            "{\n\t"
-                            "shl.b32 %0, %2, 16;\n\t"
-                            "and.b32 %1, %2, 0xffff0000;\n\t"
-                            "}\n"
-                            : "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[1])
-                            : "r"(_vpairs_1[_pair]));
-                    }
-                }
-            }
-            #pragma unroll
-            for (int j = 0; j < 8; j++) {
-                float _fma_0 = __fmaf_rn(_vec_load_1[j], _vec_load_0[j], acc[m_1]);
-                acc[m_1] = _fma_0;
-            }
-        }
+      }
     }
-    #pragma unroll
-    for (int m_2 = 0; m_2 < 4; m_2++) {
-        float _warp_reduce_0 = acc[m_2];
-        #pragma unroll
-        for (int offset = 16; offset > 0; offset >>= 1)
-            _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
-        float warp_sum = _warp_reduce_0;
-        if (lane == 0) {
-            red[m_2 * 4 + warp] = warp_sum;
+#pragma unroll
+    for (int m_1 = 0; m_1 < 4; m_1++) {
+      float _vec_load_1[8];
+      {
+        const uint4* _vptr_1 = reinterpret_cast<const uint4*>(mat_a + (m_1 * 7168 + k_base) + 0);
+        uint4 _vld_1[1];
+#pragma unroll
+        for (int _blk = 0; _blk < 1; _blk++) {
+          _vld_1[_blk] = _vptr_1[_blk];
+          uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
+#pragma unroll
+          for (int _pair = 0; _pair < 4; _pair++) {
+            asm volatile(
+                "{\n\t"
+                "shl.b32 %0, %2, 16;\n\t"
+                "and.b32 %1, %2, 0xffff0000;\n\t"
+                "}\n"
+                : "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[0]),
+                  "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[1])
+                : "r"(_vpairs_1[_pair]));
+          }
         }
+      }
+#pragma unroll
+      for (int j = 0; j < 8; j++) {
+        float _fma_0 = __fmaf_rn(_vec_load_1[j], _vec_load_0[j], acc[m_1]);
+        acc[m_1] = _fma_0;
+      }
     }
-    asm volatile("barrier.sync 2, 128;" ::: "memory");
-    if (warp == 0) {
-        if (lane < 4) {
-            int m_3 = lane;
-            float total = red[m_3 * 4];
-            #pragma unroll
-            for (int source_warp = 1; source_warp < 4; source_warp++) {
-                total = total + red[m_3 * 4 + source_warp];
-            }
-            int offset = m_3 * num_experts + expert;
-            if (out_is_bf16 == 0) {
-                *(reinterpret_cast<float*>(out_f32 + offset) + (0)) = total;
-            } else {
-                *(reinterpret_cast<__nv_bfloat16*>(out_bf16 + offset) + (0)) = __float2bfloat16_rn(total);
-            }
-        }
+  }
+#pragma unroll
+  for (int m_2 = 0; m_2 < 4; m_2++) {
+    float _warp_reduce_0 = acc[m_2];
+#pragma unroll
+    for (int offset = 16; offset > 0; offset >>= 1)
+      _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
+    float warp_sum = _warp_reduce_0;
+    if (lane == 0) {
+      red[m_2 * 4 + warp] = warp_sum;
     }
-    asm volatile("griddepcontrol.launch_dependents;" ::: "memory");
+  }
+  asm volatile("barrier.sync 2, 128;" ::: "memory");
+  if (warp == 0) {
+    if (lane < 4) {
+      int m_3 = lane;
+      float total = red[m_3 * 4];
+#pragma unroll
+      for (int source_warp = 1; source_warp < 4; source_warp++) {
+        total = total + red[m_3 * 4 + source_warp];
+      }
+      int offset = m_3 * num_experts + expert;
+      if (out_is_bf16 == 0) {
+        *(reinterpret_cast<float*>(out_f32 + offset) + (0)) = total;
+      } else {
+        *(reinterpret_cast<__nv_bfloat16*>(out_bf16 + offset) + (0)) = __float2bfloat16_rn(total);
+      }
+    }
+  }
+  asm volatile("griddepcontrol.launch_dependents;" ::: "memory");
 }
 
-} // extern "C"
+}  // extern "C"

--- a/csrc/cake_router_gemm/cake_router_gemm_m4_k7168_device.cu
+++ b/csrc/cake_router_gemm/cake_router_gemm_m4_k7168_device.cu
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) 2026 by FlashInfer team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+typedef unsigned char      uint8_t;
+typedef unsigned short     uint16_t;
+typedef unsigned int       uint32_t;
+typedef unsigned long long uint64_t;
+typedef signed int         int32_t;
+typedef short int          int16_t;
+struct __align__(128) CakeTensorMap { uint64_t opaque[16]; };
+template <int N>
+struct __align__(128) CakeTensorMapPack { CakeTensorMap maps[N]; };
+
+typedef struct __align__(64) { uint64_t opaque[16]; } CUtensorMap;
+
+#include <cuda_bf16.h>
+
+__device__ __forceinline__ int make_warp_uniform(int x) {
+    int result;
+    asm volatile("shfl.sync.idx.b32 %0, %1, 0, 0x1F, 0xFFFFFFFF;"
+                 : "=r"(result) : "r"(x));
+    return result;
+}
+
+#define CAKE_INF CUDART_INF_F
+#define NUM_MAIN_STAGES 1
+#define SMEM_RED_OFF 0
+#define SMEM_RED_STAGE_BYTES 64
+#define SMEM_RED_STRIDE 64
+#define SMEM_TOTAL 128
+#define THREADS 128
+
+#include <math_constants.h>
+
+extern "C" {
+
+__global__ __launch_bounds__(128, 1) void
+kernel_cake_blackwell_router_gemm_m4_k7168(__nv_bfloat16* __restrict__ mat_a, __nv_bfloat16* __restrict__ mat_b, float* __restrict__ out_f32, __nv_bfloat16* __restrict__ out_bf16, int num_experts, int out_is_bf16)
+{
+    const int tid = threadIdx.x;
+    const int warp = make_warp_uniform(tid / 32);
+    const int lane = tid % 32;
+
+    extern __shared__ __align__(1024) char smem_raw[];
+    int smem;
+    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+
+    const int bid = blockIdx.x;
+    const int num_bids = gridDim.x;
+
+    // Kernel setup ops
+    float* red = reinterpret_cast<float*>(smem_raw + 0);
+    const int red_addr = smem + 0;
+
+    // === Task calls (dependency order) ===
+    int expert = blockIdx.x;
+    float acc[4];
+    #pragma unroll
+    for (int m = 0; m < 4; m++) {
+        acc[m] = 0.0f;
+    }
+    asm volatile("griddepcontrol.wait;" ::: "memory");
+    #pragma unroll
+    for (int ki = 0; ki < 7; ki++) {
+        int k_base = ki * 1024 + tid * 8;
+        float _vec_load_0[8];
+        {
+            const uint4* _vptr_0 = reinterpret_cast<const uint4*>(mat_b + (expert * 7168 + k_base) + 0);
+            uint4 _vld_0[1];
+            #pragma unroll
+            for (int _blk = 0; _blk < 1; _blk++) {
+                _vld_0[_blk] = _vptr_0[_blk];
+                uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
+                #pragma unroll
+                for (int _pair = 0; _pair < 4; _pair++) {
+                    asm volatile(
+                        "{\n\t"
+                        "shl.b32 %0, %2, 16;\n\t"
+                        "and.b32 %1, %2, 0xffff0000;\n\t"
+                        "}\n"
+                        : "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[1])
+                        : "r"(_vpairs_0[_pair]));
+                }
+            }
+        }
+        #pragma unroll
+        for (int m_1 = 0; m_1 < 4; m_1++) {
+            float _vec_load_1[8];
+            {
+                const uint4* _vptr_1 = reinterpret_cast<const uint4*>(mat_a + (m_1 * 7168 + k_base) + 0);
+                uint4 _vld_1[1];
+                #pragma unroll
+                for (int _blk = 0; _blk < 1; _blk++) {
+                    _vld_1[_blk] = _vptr_1[_blk];
+                    uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
+                    #pragma unroll
+                    for (int _pair = 0; _pair < 4; _pair++) {
+                        asm volatile(
+                            "{\n\t"
+                            "shl.b32 %0, %2, 16;\n\t"
+                            "and.b32 %1, %2, 0xffff0000;\n\t"
+                            "}\n"
+                            : "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[1])
+                            : "r"(_vpairs_1[_pair]));
+                    }
+                }
+            }
+            #pragma unroll
+            for (int j = 0; j < 8; j++) {
+                float _fma_0 = __fmaf_rn(_vec_load_1[j], _vec_load_0[j], acc[m_1]);
+                acc[m_1] = _fma_0;
+            }
+        }
+    }
+    #pragma unroll
+    for (int m_2 = 0; m_2 < 4; m_2++) {
+        float _warp_reduce_0 = acc[m_2];
+        #pragma unroll
+        for (int offset = 16; offset > 0; offset >>= 1)
+            _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
+        float warp_sum = _warp_reduce_0;
+        if (lane == 0) {
+            red[m_2 * 4 + warp] = warp_sum;
+        }
+    }
+    asm volatile("barrier.sync 2, 128;" ::: "memory");
+    if (warp == 0) {
+        if (lane < 4) {
+            int m_3 = lane;
+            float total = red[m_3 * 4];
+            #pragma unroll
+            for (int source_warp = 1; source_warp < 4; source_warp++) {
+                total = total + red[m_3 * 4 + source_warp];
+            }
+            int offset = m_3 * num_experts + expert;
+            if (out_is_bf16 == 0) {
+                *(reinterpret_cast<float*>(out_f32 + offset) + (0)) = total;
+            } else {
+                *(reinterpret_cast<__nv_bfloat16*>(out_bf16 + offset) + (0)) = __float2bfloat16_rn(total);
+            }
+        }
+    }
+    asm volatile("griddepcontrol.launch_dependents;" ::: "memory");
+}
+
+} // extern "C"

--- a/csrc/cake_router_gemm/cake_router_gemm_m5_k6144_device.cu
+++ b/csrc/cake_router_gemm/cake_router_gemm_m5_k6144_device.cu
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) 2026 by FlashInfer team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+typedef unsigned char      uint8_t;
+typedef unsigned short     uint16_t;
+typedef unsigned int       uint32_t;
+typedef unsigned long long uint64_t;
+typedef signed int         int32_t;
+typedef short int          int16_t;
+struct __align__(128) CakeTensorMap { uint64_t opaque[16]; };
+template <int N>
+struct __align__(128) CakeTensorMapPack { CakeTensorMap maps[N]; };
+
+typedef struct __align__(64) { uint64_t opaque[16]; } CUtensorMap;
+
+#include <cuda_bf16.h>
+
+__device__ __forceinline__ int make_warp_uniform(int x) {
+    int result;
+    asm volatile("shfl.sync.idx.b32 %0, %1, 0, 0x1F, 0xFFFFFFFF;"
+                 : "=r"(result) : "r"(x));
+    return result;
+}
+
+#define CAKE_INF CUDART_INF_F
+#define NUM_MAIN_STAGES 1
+#define SMEM_RED_OFF 0
+#define SMEM_RED_STAGE_BYTES 80
+#define SMEM_RED_STRIDE 80
+#define SMEM_TOTAL 128
+#define THREADS 128
+
+#include <math_constants.h>
+
+extern "C" {
+
+__global__ __launch_bounds__(128, 1) void
+kernel_cake_blackwell_router_gemm_m5_k6144(__nv_bfloat16* __restrict__ mat_a, __nv_bfloat16* __restrict__ mat_b, float* __restrict__ out_f32, __nv_bfloat16* __restrict__ out_bf16, int num_experts, int out_is_bf16)
+{
+    const int tid = threadIdx.x;
+    const int warp = make_warp_uniform(tid / 32);
+    const int lane = tid % 32;
+
+    extern __shared__ __align__(1024) char smem_raw[];
+    int smem;
+    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+
+    const int bid = blockIdx.x;
+    const int num_bids = gridDim.x;
+
+    // Kernel setup ops
+    float* red = reinterpret_cast<float*>(smem_raw + 0);
+    const int red_addr = smem + 0;
+
+    // === Task calls (dependency order) ===
+    int expert = blockIdx.x;
+    float acc[5];
+    #pragma unroll
+    for (int m = 0; m < 5; m++) {
+        acc[m] = 0.0f;
+    }
+    asm volatile("griddepcontrol.wait;" ::: "memory");
+    #pragma unroll
+    for (int ki = 0; ki < 6; ki++) {
+        int k_base = ki * 1024 + tid * 8;
+        float _vec_load_0[8];
+        {
+            const uint4* _vptr_0 = reinterpret_cast<const uint4*>(mat_b + (expert * 6144 + k_base) + 0);
+            uint4 _vld_0[1];
+            #pragma unroll
+            for (int _blk = 0; _blk < 1; _blk++) {
+                _vld_0[_blk] = _vptr_0[_blk];
+                uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
+                #pragma unroll
+                for (int _pair = 0; _pair < 4; _pair++) {
+                    asm volatile(
+                        "{\n\t"
+                        "shl.b32 %0, %2, 16;\n\t"
+                        "and.b32 %1, %2, 0xffff0000;\n\t"
+                        "}\n"
+                        : "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[1])
+                        : "r"(_vpairs_0[_pair]));
+                }
+            }
+        }
+        #pragma unroll
+        for (int m_1 = 0; m_1 < 5; m_1++) {
+            float _vec_load_1[8];
+            {
+                const uint4* _vptr_1 = reinterpret_cast<const uint4*>(mat_a + (m_1 * 6144 + k_base) + 0);
+                uint4 _vld_1[1];
+                #pragma unroll
+                for (int _blk = 0; _blk < 1; _blk++) {
+                    _vld_1[_blk] = _vptr_1[_blk];
+                    uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
+                    #pragma unroll
+                    for (int _pair = 0; _pair < 4; _pair++) {
+                        asm volatile(
+                            "{\n\t"
+                            "shl.b32 %0, %2, 16;\n\t"
+                            "and.b32 %1, %2, 0xffff0000;\n\t"
+                            "}\n"
+                            : "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[1])
+                            : "r"(_vpairs_1[_pair]));
+                    }
+                }
+            }
+            #pragma unroll
+            for (int j = 0; j < 8; j++) {
+                float _fma_0 = __fmaf_rn(_vec_load_1[j], _vec_load_0[j], acc[m_1]);
+                acc[m_1] = _fma_0;
+            }
+        }
+    }
+    #pragma unroll
+    for (int m_2 = 0; m_2 < 5; m_2++) {
+        float _warp_reduce_0 = acc[m_2];
+        #pragma unroll
+        for (int offset = 16; offset > 0; offset >>= 1)
+            _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
+        float warp_sum = _warp_reduce_0;
+        if (lane == 0) {
+            red[m_2 * 4 + warp] = warp_sum;
+        }
+    }
+    asm volatile("barrier.sync 2, 128;" ::: "memory");
+    if (warp == 0) {
+        if (lane < 5) {
+            int m_3 = lane;
+            float total = red[m_3 * 4];
+            #pragma unroll
+            for (int source_warp = 1; source_warp < 4; source_warp++) {
+                total = total + red[m_3 * 4 + source_warp];
+            }
+            int offset = m_3 * num_experts + expert;
+            if (out_is_bf16 == 0) {
+                *(reinterpret_cast<float*>(out_f32 + offset) + (0)) = total;
+            } else {
+                *(reinterpret_cast<__nv_bfloat16*>(out_bf16 + offset) + (0)) = __float2bfloat16_rn(total);
+            }
+        }
+    }
+    asm volatile("griddepcontrol.launch_dependents;" ::: "memory");
+}
+
+} // extern "C"

--- a/csrc/cake_router_gemm/cake_router_gemm_m5_k6144_device.cu
+++ b/csrc/cake_router_gemm/cake_router_gemm_m5_k6144_device.cu
@@ -14,25 +14,30 @@
  * limitations under the License.
  */
 
-typedef unsigned char      uint8_t;
-typedef unsigned short     uint16_t;
-typedef unsigned int       uint32_t;
+typedef unsigned char uint8_t;
+typedef unsigned short uint16_t;
+typedef unsigned int uint32_t;
 typedef unsigned long long uint64_t;
-typedef signed int         int32_t;
-typedef short int          int16_t;
-struct __align__(128) CakeTensorMap { uint64_t opaque[16]; };
+typedef signed int int32_t;
+typedef short int int16_t;
+struct __align__(128) CakeTensorMap {
+  uint64_t opaque[16];
+};
 template <int N>
-struct __align__(128) CakeTensorMapPack { CakeTensorMap maps[N]; };
+struct __align__(128) CakeTensorMapPack {
+  CakeTensorMap maps[N];
+};
 
-typedef struct __align__(64) { uint64_t opaque[16]; } CUtensorMap;
+typedef struct __align__(64) {
+  uint64_t opaque[16];
+} CUtensorMap;
 
 #include <cuda_bf16.h>
 
 __device__ __forceinline__ int make_warp_uniform(int x) {
-    int result;
-    asm volatile("shfl.sync.idx.b32 %0, %1, 0, 0x1F, 0xFFFFFFFF;"
-                 : "=r"(result) : "r"(x));
-    return result;
+  int result;
+  asm volatile("shfl.sync.idx.b32 %0, %1, 0, 0x1F, 0xFFFFFFFF;" : "=r"(result) : "r"(x));
+  return result;
 }
 
 #define CAKE_INF CUDART_INF_F
@@ -47,113 +52,116 @@ __device__ __forceinline__ int make_warp_uniform(int x) {
 
 extern "C" {
 
-__global__ __launch_bounds__(128, 1) void
-kernel_cake_blackwell_router_gemm_m5_k6144(__nv_bfloat16* __restrict__ mat_a, __nv_bfloat16* __restrict__ mat_b, float* __restrict__ out_f32, __nv_bfloat16* __restrict__ out_bf16, int num_experts, int out_is_bf16)
-{
-    const int tid = threadIdx.x;
-    const int warp = make_warp_uniform(tid / 32);
-    const int lane = tid % 32;
+__global__ __launch_bounds__(128, 1) void kernel_cake_blackwell_router_gemm_m5_k6144(
+    __nv_bfloat16* __restrict__ mat_a, __nv_bfloat16* __restrict__ mat_b,
+    float* __restrict__ out_f32, __nv_bfloat16* __restrict__ out_bf16, int num_experts,
+    int out_is_bf16) {
+  const int tid = threadIdx.x;
+  const int warp = make_warp_uniform(tid / 32);
+  const int lane = tid % 32;
 
-    extern __shared__ __align__(1024) char smem_raw[];
-    int smem;
-    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+  extern __shared__ __align__(1024) char smem_raw[];
+  int smem;
+  smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
 
-    const int bid = blockIdx.x;
-    const int num_bids = gridDim.x;
+  const int bid = blockIdx.x;
+  const int num_bids = gridDim.x;
 
-    // Kernel setup ops
-    float* red = reinterpret_cast<float*>(smem_raw + 0);
-    const int red_addr = smem + 0;
+  // Kernel setup ops
+  float* red = reinterpret_cast<float*>(smem_raw + 0);
+  const int red_addr = smem + 0;
 
-    // === Task calls (dependency order) ===
-    int expert = blockIdx.x;
-    float acc[5];
-    #pragma unroll
-    for (int m = 0; m < 5; m++) {
-        acc[m] = 0.0f;
-    }
-    asm volatile("griddepcontrol.wait;" ::: "memory");
-    #pragma unroll
-    for (int ki = 0; ki < 6; ki++) {
-        int k_base = ki * 1024 + tid * 8;
-        float _vec_load_0[8];
-        {
-            const uint4* _vptr_0 = reinterpret_cast<const uint4*>(mat_b + (expert * 6144 + k_base) + 0);
-            uint4 _vld_0[1];
-            #pragma unroll
-            for (int _blk = 0; _blk < 1; _blk++) {
-                _vld_0[_blk] = _vptr_0[_blk];
-                uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
-                #pragma unroll
-                for (int _pair = 0; _pair < 4; _pair++) {
-                    asm volatile(
-                        "{\n\t"
-                        "shl.b32 %0, %2, 16;\n\t"
-                        "and.b32 %1, %2, 0xffff0000;\n\t"
-                        "}\n"
-                        : "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[1])
-                        : "r"(_vpairs_0[_pair]));
-                }
-            }
+  // === Task calls (dependency order) ===
+  int expert = blockIdx.x;
+  float acc[5];
+#pragma unroll
+  for (int m = 0; m < 5; m++) {
+    acc[m] = 0.0f;
+  }
+  asm volatile("griddepcontrol.wait;" ::: "memory");
+#pragma unroll
+  for (int ki = 0; ki < 6; ki++) {
+    int k_base = ki * 1024 + tid * 8;
+    float _vec_load_0[8];
+    {
+      const uint4* _vptr_0 = reinterpret_cast<const uint4*>(mat_b + (expert * 6144 + k_base) + 0);
+      uint4 _vld_0[1];
+#pragma unroll
+      for (int _blk = 0; _blk < 1; _blk++) {
+        _vld_0[_blk] = _vptr_0[_blk];
+        uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
+#pragma unroll
+        for (int _pair = 0; _pair < 4; _pair++) {
+          asm volatile(
+              "{\n\t"
+              "shl.b32 %0, %2, 16;\n\t"
+              "and.b32 %1, %2, 0xffff0000;\n\t"
+              "}\n"
+              : "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[0]),
+                "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[1])
+              : "r"(_vpairs_0[_pair]));
         }
-        #pragma unroll
-        for (int m_1 = 0; m_1 < 5; m_1++) {
-            float _vec_load_1[8];
-            {
-                const uint4* _vptr_1 = reinterpret_cast<const uint4*>(mat_a + (m_1 * 6144 + k_base) + 0);
-                uint4 _vld_1[1];
-                #pragma unroll
-                for (int _blk = 0; _blk < 1; _blk++) {
-                    _vld_1[_blk] = _vptr_1[_blk];
-                    uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
-                    #pragma unroll
-                    for (int _pair = 0; _pair < 4; _pair++) {
-                        asm volatile(
-                            "{\n\t"
-                            "shl.b32 %0, %2, 16;\n\t"
-                            "and.b32 %1, %2, 0xffff0000;\n\t"
-                            "}\n"
-                            : "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[1])
-                            : "r"(_vpairs_1[_pair]));
-                    }
-                }
-            }
-            #pragma unroll
-            for (int j = 0; j < 8; j++) {
-                float _fma_0 = __fmaf_rn(_vec_load_1[j], _vec_load_0[j], acc[m_1]);
-                acc[m_1] = _fma_0;
-            }
-        }
+      }
     }
-    #pragma unroll
-    for (int m_2 = 0; m_2 < 5; m_2++) {
-        float _warp_reduce_0 = acc[m_2];
-        #pragma unroll
-        for (int offset = 16; offset > 0; offset >>= 1)
-            _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
-        float warp_sum = _warp_reduce_0;
-        if (lane == 0) {
-            red[m_2 * 4 + warp] = warp_sum;
+#pragma unroll
+    for (int m_1 = 0; m_1 < 5; m_1++) {
+      float _vec_load_1[8];
+      {
+        const uint4* _vptr_1 = reinterpret_cast<const uint4*>(mat_a + (m_1 * 6144 + k_base) + 0);
+        uint4 _vld_1[1];
+#pragma unroll
+        for (int _blk = 0; _blk < 1; _blk++) {
+          _vld_1[_blk] = _vptr_1[_blk];
+          uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
+#pragma unroll
+          for (int _pair = 0; _pair < 4; _pair++) {
+            asm volatile(
+                "{\n\t"
+                "shl.b32 %0, %2, 16;\n\t"
+                "and.b32 %1, %2, 0xffff0000;\n\t"
+                "}\n"
+                : "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[0]),
+                  "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[1])
+                : "r"(_vpairs_1[_pair]));
+          }
         }
+      }
+#pragma unroll
+      for (int j = 0; j < 8; j++) {
+        float _fma_0 = __fmaf_rn(_vec_load_1[j], _vec_load_0[j], acc[m_1]);
+        acc[m_1] = _fma_0;
+      }
     }
-    asm volatile("barrier.sync 2, 128;" ::: "memory");
-    if (warp == 0) {
-        if (lane < 5) {
-            int m_3 = lane;
-            float total = red[m_3 * 4];
-            #pragma unroll
-            for (int source_warp = 1; source_warp < 4; source_warp++) {
-                total = total + red[m_3 * 4 + source_warp];
-            }
-            int offset = m_3 * num_experts + expert;
-            if (out_is_bf16 == 0) {
-                *(reinterpret_cast<float*>(out_f32 + offset) + (0)) = total;
-            } else {
-                *(reinterpret_cast<__nv_bfloat16*>(out_bf16 + offset) + (0)) = __float2bfloat16_rn(total);
-            }
-        }
+  }
+#pragma unroll
+  for (int m_2 = 0; m_2 < 5; m_2++) {
+    float _warp_reduce_0 = acc[m_2];
+#pragma unroll
+    for (int offset = 16; offset > 0; offset >>= 1)
+      _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
+    float warp_sum = _warp_reduce_0;
+    if (lane == 0) {
+      red[m_2 * 4 + warp] = warp_sum;
     }
-    asm volatile("griddepcontrol.launch_dependents;" ::: "memory");
+  }
+  asm volatile("barrier.sync 2, 128;" ::: "memory");
+  if (warp == 0) {
+    if (lane < 5) {
+      int m_3 = lane;
+      float total = red[m_3 * 4];
+#pragma unroll
+      for (int source_warp = 1; source_warp < 4; source_warp++) {
+        total = total + red[m_3 * 4 + source_warp];
+      }
+      int offset = m_3 * num_experts + expert;
+      if (out_is_bf16 == 0) {
+        *(reinterpret_cast<float*>(out_f32 + offset) + (0)) = total;
+      } else {
+        *(reinterpret_cast<__nv_bfloat16*>(out_bf16 + offset) + (0)) = __float2bfloat16_rn(total);
+      }
+    }
+  }
+  asm volatile("griddepcontrol.launch_dependents;" ::: "memory");
 }
 
-} // extern "C"
+}  // extern "C"

--- a/csrc/cake_router_gemm/cake_router_gemm_m5_k7168_device.cu
+++ b/csrc/cake_router_gemm/cake_router_gemm_m5_k7168_device.cu
@@ -14,25 +14,30 @@
  * limitations under the License.
  */
 
-typedef unsigned char      uint8_t;
-typedef unsigned short     uint16_t;
-typedef unsigned int       uint32_t;
+typedef unsigned char uint8_t;
+typedef unsigned short uint16_t;
+typedef unsigned int uint32_t;
 typedef unsigned long long uint64_t;
-typedef signed int         int32_t;
-typedef short int          int16_t;
-struct __align__(128) CakeTensorMap { uint64_t opaque[16]; };
+typedef signed int int32_t;
+typedef short int int16_t;
+struct __align__(128) CakeTensorMap {
+  uint64_t opaque[16];
+};
 template <int N>
-struct __align__(128) CakeTensorMapPack { CakeTensorMap maps[N]; };
+struct __align__(128) CakeTensorMapPack {
+  CakeTensorMap maps[N];
+};
 
-typedef struct __align__(64) { uint64_t opaque[16]; } CUtensorMap;
+typedef struct __align__(64) {
+  uint64_t opaque[16];
+} CUtensorMap;
 
 #include <cuda_bf16.h>
 
 __device__ __forceinline__ int make_warp_uniform(int x) {
-    int result;
-    asm volatile("shfl.sync.idx.b32 %0, %1, 0, 0x1F, 0xFFFFFFFF;"
-                 : "=r"(result) : "r"(x));
-    return result;
+  int result;
+  asm volatile("shfl.sync.idx.b32 %0, %1, 0, 0x1F, 0xFFFFFFFF;" : "=r"(result) : "r"(x));
+  return result;
 }
 
 #define CAKE_INF CUDART_INF_F
@@ -47,113 +52,116 @@ __device__ __forceinline__ int make_warp_uniform(int x) {
 
 extern "C" {
 
-__global__ __launch_bounds__(128, 1) void
-kernel_cake_blackwell_router_gemm_m5_k7168(__nv_bfloat16* __restrict__ mat_a, __nv_bfloat16* __restrict__ mat_b, float* __restrict__ out_f32, __nv_bfloat16* __restrict__ out_bf16, int num_experts, int out_is_bf16)
-{
-    const int tid = threadIdx.x;
-    const int warp = make_warp_uniform(tid / 32);
-    const int lane = tid % 32;
+__global__ __launch_bounds__(128, 1) void kernel_cake_blackwell_router_gemm_m5_k7168(
+    __nv_bfloat16* __restrict__ mat_a, __nv_bfloat16* __restrict__ mat_b,
+    float* __restrict__ out_f32, __nv_bfloat16* __restrict__ out_bf16, int num_experts,
+    int out_is_bf16) {
+  const int tid = threadIdx.x;
+  const int warp = make_warp_uniform(tid / 32);
+  const int lane = tid % 32;
 
-    extern __shared__ __align__(1024) char smem_raw[];
-    int smem;
-    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+  extern __shared__ __align__(1024) char smem_raw[];
+  int smem;
+  smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
 
-    const int bid = blockIdx.x;
-    const int num_bids = gridDim.x;
+  const int bid = blockIdx.x;
+  const int num_bids = gridDim.x;
 
-    // Kernel setup ops
-    float* red = reinterpret_cast<float*>(smem_raw + 0);
-    const int red_addr = smem + 0;
+  // Kernel setup ops
+  float* red = reinterpret_cast<float*>(smem_raw + 0);
+  const int red_addr = smem + 0;
 
-    // === Task calls (dependency order) ===
-    int expert = blockIdx.x;
-    float acc[5];
-    #pragma unroll
-    for (int m = 0; m < 5; m++) {
-        acc[m] = 0.0f;
-    }
-    asm volatile("griddepcontrol.wait;" ::: "memory");
-    #pragma unroll
-    for (int ki = 0; ki < 7; ki++) {
-        int k_base = ki * 1024 + tid * 8;
-        float _vec_load_0[8];
-        {
-            const uint4* _vptr_0 = reinterpret_cast<const uint4*>(mat_b + (expert * 7168 + k_base) + 0);
-            uint4 _vld_0[1];
-            #pragma unroll
-            for (int _blk = 0; _blk < 1; _blk++) {
-                _vld_0[_blk] = _vptr_0[_blk];
-                uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
-                #pragma unroll
-                for (int _pair = 0; _pair < 4; _pair++) {
-                    asm volatile(
-                        "{\n\t"
-                        "shl.b32 %0, %2, 16;\n\t"
-                        "and.b32 %1, %2, 0xffff0000;\n\t"
-                        "}\n"
-                        : "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[1])
-                        : "r"(_vpairs_0[_pair]));
-                }
-            }
+  // === Task calls (dependency order) ===
+  int expert = blockIdx.x;
+  float acc[5];
+#pragma unroll
+  for (int m = 0; m < 5; m++) {
+    acc[m] = 0.0f;
+  }
+  asm volatile("griddepcontrol.wait;" ::: "memory");
+#pragma unroll
+  for (int ki = 0; ki < 7; ki++) {
+    int k_base = ki * 1024 + tid * 8;
+    float _vec_load_0[8];
+    {
+      const uint4* _vptr_0 = reinterpret_cast<const uint4*>(mat_b + (expert * 7168 + k_base) + 0);
+      uint4 _vld_0[1];
+#pragma unroll
+      for (int _blk = 0; _blk < 1; _blk++) {
+        _vld_0[_blk] = _vptr_0[_blk];
+        uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
+#pragma unroll
+        for (int _pair = 0; _pair < 4; _pair++) {
+          asm volatile(
+              "{\n\t"
+              "shl.b32 %0, %2, 16;\n\t"
+              "and.b32 %1, %2, 0xffff0000;\n\t"
+              "}\n"
+              : "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[0]),
+                "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[1])
+              : "r"(_vpairs_0[_pair]));
         }
-        #pragma unroll
-        for (int m_1 = 0; m_1 < 5; m_1++) {
-            float _vec_load_1[8];
-            {
-                const uint4* _vptr_1 = reinterpret_cast<const uint4*>(mat_a + (m_1 * 7168 + k_base) + 0);
-                uint4 _vld_1[1];
-                #pragma unroll
-                for (int _blk = 0; _blk < 1; _blk++) {
-                    _vld_1[_blk] = _vptr_1[_blk];
-                    uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
-                    #pragma unroll
-                    for (int _pair = 0; _pair < 4; _pair++) {
-                        asm volatile(
-                            "{\n\t"
-                            "shl.b32 %0, %2, 16;\n\t"
-                            "and.b32 %1, %2, 0xffff0000;\n\t"
-                            "}\n"
-                            : "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[1])
-                            : "r"(_vpairs_1[_pair]));
-                    }
-                }
-            }
-            #pragma unroll
-            for (int j = 0; j < 8; j++) {
-                float _fma_0 = __fmaf_rn(_vec_load_1[j], _vec_load_0[j], acc[m_1]);
-                acc[m_1] = _fma_0;
-            }
-        }
+      }
     }
-    #pragma unroll
-    for (int m_2 = 0; m_2 < 5; m_2++) {
-        float _warp_reduce_0 = acc[m_2];
-        #pragma unroll
-        for (int offset = 16; offset > 0; offset >>= 1)
-            _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
-        float warp_sum = _warp_reduce_0;
-        if (lane == 0) {
-            red[m_2 * 4 + warp] = warp_sum;
+#pragma unroll
+    for (int m_1 = 0; m_1 < 5; m_1++) {
+      float _vec_load_1[8];
+      {
+        const uint4* _vptr_1 = reinterpret_cast<const uint4*>(mat_a + (m_1 * 7168 + k_base) + 0);
+        uint4 _vld_1[1];
+#pragma unroll
+        for (int _blk = 0; _blk < 1; _blk++) {
+          _vld_1[_blk] = _vptr_1[_blk];
+          uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
+#pragma unroll
+          for (int _pair = 0; _pair < 4; _pair++) {
+            asm volatile(
+                "{\n\t"
+                "shl.b32 %0, %2, 16;\n\t"
+                "and.b32 %1, %2, 0xffff0000;\n\t"
+                "}\n"
+                : "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[0]),
+                  "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[1])
+                : "r"(_vpairs_1[_pair]));
+          }
         }
+      }
+#pragma unroll
+      for (int j = 0; j < 8; j++) {
+        float _fma_0 = __fmaf_rn(_vec_load_1[j], _vec_load_0[j], acc[m_1]);
+        acc[m_1] = _fma_0;
+      }
     }
-    asm volatile("barrier.sync 2, 128;" ::: "memory");
-    if (warp == 0) {
-        if (lane < 5) {
-            int m_3 = lane;
-            float total = red[m_3 * 4];
-            #pragma unroll
-            for (int source_warp = 1; source_warp < 4; source_warp++) {
-                total = total + red[m_3 * 4 + source_warp];
-            }
-            int offset = m_3 * num_experts + expert;
-            if (out_is_bf16 == 0) {
-                *(reinterpret_cast<float*>(out_f32 + offset) + (0)) = total;
-            } else {
-                *(reinterpret_cast<__nv_bfloat16*>(out_bf16 + offset) + (0)) = __float2bfloat16_rn(total);
-            }
-        }
+  }
+#pragma unroll
+  for (int m_2 = 0; m_2 < 5; m_2++) {
+    float _warp_reduce_0 = acc[m_2];
+#pragma unroll
+    for (int offset = 16; offset > 0; offset >>= 1)
+      _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
+    float warp_sum = _warp_reduce_0;
+    if (lane == 0) {
+      red[m_2 * 4 + warp] = warp_sum;
     }
-    asm volatile("griddepcontrol.launch_dependents;" ::: "memory");
+  }
+  asm volatile("barrier.sync 2, 128;" ::: "memory");
+  if (warp == 0) {
+    if (lane < 5) {
+      int m_3 = lane;
+      float total = red[m_3 * 4];
+#pragma unroll
+      for (int source_warp = 1; source_warp < 4; source_warp++) {
+        total = total + red[m_3 * 4 + source_warp];
+      }
+      int offset = m_3 * num_experts + expert;
+      if (out_is_bf16 == 0) {
+        *(reinterpret_cast<float*>(out_f32 + offset) + (0)) = total;
+      } else {
+        *(reinterpret_cast<__nv_bfloat16*>(out_bf16 + offset) + (0)) = __float2bfloat16_rn(total);
+      }
+    }
+  }
+  asm volatile("griddepcontrol.launch_dependents;" ::: "memory");
 }
 
-} // extern "C"
+}  // extern "C"

--- a/csrc/cake_router_gemm/cake_router_gemm_m5_k7168_device.cu
+++ b/csrc/cake_router_gemm/cake_router_gemm_m5_k7168_device.cu
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) 2026 by FlashInfer team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+typedef unsigned char      uint8_t;
+typedef unsigned short     uint16_t;
+typedef unsigned int       uint32_t;
+typedef unsigned long long uint64_t;
+typedef signed int         int32_t;
+typedef short int          int16_t;
+struct __align__(128) CakeTensorMap { uint64_t opaque[16]; };
+template <int N>
+struct __align__(128) CakeTensorMapPack { CakeTensorMap maps[N]; };
+
+typedef struct __align__(64) { uint64_t opaque[16]; } CUtensorMap;
+
+#include <cuda_bf16.h>
+
+__device__ __forceinline__ int make_warp_uniform(int x) {
+    int result;
+    asm volatile("shfl.sync.idx.b32 %0, %1, 0, 0x1F, 0xFFFFFFFF;"
+                 : "=r"(result) : "r"(x));
+    return result;
+}
+
+#define CAKE_INF CUDART_INF_F
+#define NUM_MAIN_STAGES 1
+#define SMEM_RED_OFF 0
+#define SMEM_RED_STAGE_BYTES 80
+#define SMEM_RED_STRIDE 80
+#define SMEM_TOTAL 128
+#define THREADS 128
+
+#include <math_constants.h>
+
+extern "C" {
+
+__global__ __launch_bounds__(128, 1) void
+kernel_cake_blackwell_router_gemm_m5_k7168(__nv_bfloat16* __restrict__ mat_a, __nv_bfloat16* __restrict__ mat_b, float* __restrict__ out_f32, __nv_bfloat16* __restrict__ out_bf16, int num_experts, int out_is_bf16)
+{
+    const int tid = threadIdx.x;
+    const int warp = make_warp_uniform(tid / 32);
+    const int lane = tid % 32;
+
+    extern __shared__ __align__(1024) char smem_raw[];
+    int smem;
+    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+
+    const int bid = blockIdx.x;
+    const int num_bids = gridDim.x;
+
+    // Kernel setup ops
+    float* red = reinterpret_cast<float*>(smem_raw + 0);
+    const int red_addr = smem + 0;
+
+    // === Task calls (dependency order) ===
+    int expert = blockIdx.x;
+    float acc[5];
+    #pragma unroll
+    for (int m = 0; m < 5; m++) {
+        acc[m] = 0.0f;
+    }
+    asm volatile("griddepcontrol.wait;" ::: "memory");
+    #pragma unroll
+    for (int ki = 0; ki < 7; ki++) {
+        int k_base = ki * 1024 + tid * 8;
+        float _vec_load_0[8];
+        {
+            const uint4* _vptr_0 = reinterpret_cast<const uint4*>(mat_b + (expert * 7168 + k_base) + 0);
+            uint4 _vld_0[1];
+            #pragma unroll
+            for (int _blk = 0; _blk < 1; _blk++) {
+                _vld_0[_blk] = _vptr_0[_blk];
+                uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
+                #pragma unroll
+                for (int _pair = 0; _pair < 4; _pair++) {
+                    asm volatile(
+                        "{\n\t"
+                        "shl.b32 %0, %2, 16;\n\t"
+                        "and.b32 %1, %2, 0xffff0000;\n\t"
+                        "}\n"
+                        : "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[1])
+                        : "r"(_vpairs_0[_pair]));
+                }
+            }
+        }
+        #pragma unroll
+        for (int m_1 = 0; m_1 < 5; m_1++) {
+            float _vec_load_1[8];
+            {
+                const uint4* _vptr_1 = reinterpret_cast<const uint4*>(mat_a + (m_1 * 7168 + k_base) + 0);
+                uint4 _vld_1[1];
+                #pragma unroll
+                for (int _blk = 0; _blk < 1; _blk++) {
+                    _vld_1[_blk] = _vptr_1[_blk];
+                    uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
+                    #pragma unroll
+                    for (int _pair = 0; _pair < 4; _pair++) {
+                        asm volatile(
+                            "{\n\t"
+                            "shl.b32 %0, %2, 16;\n\t"
+                            "and.b32 %1, %2, 0xffff0000;\n\t"
+                            "}\n"
+                            : "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[1])
+                            : "r"(_vpairs_1[_pair]));
+                    }
+                }
+            }
+            #pragma unroll
+            for (int j = 0; j < 8; j++) {
+                float _fma_0 = __fmaf_rn(_vec_load_1[j], _vec_load_0[j], acc[m_1]);
+                acc[m_1] = _fma_0;
+            }
+        }
+    }
+    #pragma unroll
+    for (int m_2 = 0; m_2 < 5; m_2++) {
+        float _warp_reduce_0 = acc[m_2];
+        #pragma unroll
+        for (int offset = 16; offset > 0; offset >>= 1)
+            _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
+        float warp_sum = _warp_reduce_0;
+        if (lane == 0) {
+            red[m_2 * 4 + warp] = warp_sum;
+        }
+    }
+    asm volatile("barrier.sync 2, 128;" ::: "memory");
+    if (warp == 0) {
+        if (lane < 5) {
+            int m_3 = lane;
+            float total = red[m_3 * 4];
+            #pragma unroll
+            for (int source_warp = 1; source_warp < 4; source_warp++) {
+                total = total + red[m_3 * 4 + source_warp];
+            }
+            int offset = m_3 * num_experts + expert;
+            if (out_is_bf16 == 0) {
+                *(reinterpret_cast<float*>(out_f32 + offset) + (0)) = total;
+            } else {
+                *(reinterpret_cast<__nv_bfloat16*>(out_bf16 + offset) + (0)) = __float2bfloat16_rn(total);
+            }
+        }
+    }
+    asm volatile("griddepcontrol.launch_dependents;" ::: "memory");
+}
+
+} // extern "C"

--- a/csrc/cake_router_gemm/cake_router_gemm_m6_k6144_device.cu
+++ b/csrc/cake_router_gemm/cake_router_gemm_m6_k6144_device.cu
@@ -14,25 +14,30 @@
  * limitations under the License.
  */
 
-typedef unsigned char      uint8_t;
-typedef unsigned short     uint16_t;
-typedef unsigned int       uint32_t;
+typedef unsigned char uint8_t;
+typedef unsigned short uint16_t;
+typedef unsigned int uint32_t;
 typedef unsigned long long uint64_t;
-typedef signed int         int32_t;
-typedef short int          int16_t;
-struct __align__(128) CakeTensorMap { uint64_t opaque[16]; };
+typedef signed int int32_t;
+typedef short int int16_t;
+struct __align__(128) CakeTensorMap {
+  uint64_t opaque[16];
+};
 template <int N>
-struct __align__(128) CakeTensorMapPack { CakeTensorMap maps[N]; };
+struct __align__(128) CakeTensorMapPack {
+  CakeTensorMap maps[N];
+};
 
-typedef struct __align__(64) { uint64_t opaque[16]; } CUtensorMap;
+typedef struct __align__(64) {
+  uint64_t opaque[16];
+} CUtensorMap;
 
 #include <cuda_bf16.h>
 
 __device__ __forceinline__ int make_warp_uniform(int x) {
-    int result;
-    asm volatile("shfl.sync.idx.b32 %0, %1, 0, 0x1F, 0xFFFFFFFF;"
-                 : "=r"(result) : "r"(x));
-    return result;
+  int result;
+  asm volatile("shfl.sync.idx.b32 %0, %1, 0, 0x1F, 0xFFFFFFFF;" : "=r"(result) : "r"(x));
+  return result;
 }
 
 #define CAKE_INF CUDART_INF_F
@@ -47,113 +52,116 @@ __device__ __forceinline__ int make_warp_uniform(int x) {
 
 extern "C" {
 
-__global__ __launch_bounds__(128, 1) void
-kernel_cake_blackwell_router_gemm_m6_k6144(__nv_bfloat16* __restrict__ mat_a, __nv_bfloat16* __restrict__ mat_b, float* __restrict__ out_f32, __nv_bfloat16* __restrict__ out_bf16, int num_experts, int out_is_bf16)
-{
-    const int tid = threadIdx.x;
-    const int warp = make_warp_uniform(tid / 32);
-    const int lane = tid % 32;
+__global__ __launch_bounds__(128, 1) void kernel_cake_blackwell_router_gemm_m6_k6144(
+    __nv_bfloat16* __restrict__ mat_a, __nv_bfloat16* __restrict__ mat_b,
+    float* __restrict__ out_f32, __nv_bfloat16* __restrict__ out_bf16, int num_experts,
+    int out_is_bf16) {
+  const int tid = threadIdx.x;
+  const int warp = make_warp_uniform(tid / 32);
+  const int lane = tid % 32;
 
-    extern __shared__ __align__(1024) char smem_raw[];
-    int smem;
-    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+  extern __shared__ __align__(1024) char smem_raw[];
+  int smem;
+  smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
 
-    const int bid = blockIdx.x;
-    const int num_bids = gridDim.x;
+  const int bid = blockIdx.x;
+  const int num_bids = gridDim.x;
 
-    // Kernel setup ops
-    float* red = reinterpret_cast<float*>(smem_raw + 0);
-    const int red_addr = smem + 0;
+  // Kernel setup ops
+  float* red = reinterpret_cast<float*>(smem_raw + 0);
+  const int red_addr = smem + 0;
 
-    // === Task calls (dependency order) ===
-    int expert = blockIdx.x;
-    float acc[6];
-    #pragma unroll
-    for (int m = 0; m < 6; m++) {
-        acc[m] = 0.0f;
-    }
-    asm volatile("griddepcontrol.wait;" ::: "memory");
-    #pragma unroll
-    for (int ki = 0; ki < 6; ki++) {
-        int k_base = ki * 1024 + tid * 8;
-        float _vec_load_0[8];
-        {
-            const uint4* _vptr_0 = reinterpret_cast<const uint4*>(mat_b + (expert * 6144 + k_base) + 0);
-            uint4 _vld_0[1];
-            #pragma unroll
-            for (int _blk = 0; _blk < 1; _blk++) {
-                _vld_0[_blk] = _vptr_0[_blk];
-                uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
-                #pragma unroll
-                for (int _pair = 0; _pair < 4; _pair++) {
-                    asm volatile(
-                        "{\n\t"
-                        "shl.b32 %0, %2, 16;\n\t"
-                        "and.b32 %1, %2, 0xffff0000;\n\t"
-                        "}\n"
-                        : "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[1])
-                        : "r"(_vpairs_0[_pair]));
-                }
-            }
+  // === Task calls (dependency order) ===
+  int expert = blockIdx.x;
+  float acc[6];
+#pragma unroll
+  for (int m = 0; m < 6; m++) {
+    acc[m] = 0.0f;
+  }
+  asm volatile("griddepcontrol.wait;" ::: "memory");
+#pragma unroll
+  for (int ki = 0; ki < 6; ki++) {
+    int k_base = ki * 1024 + tid * 8;
+    float _vec_load_0[8];
+    {
+      const uint4* _vptr_0 = reinterpret_cast<const uint4*>(mat_b + (expert * 6144 + k_base) + 0);
+      uint4 _vld_0[1];
+#pragma unroll
+      for (int _blk = 0; _blk < 1; _blk++) {
+        _vld_0[_blk] = _vptr_0[_blk];
+        uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
+#pragma unroll
+        for (int _pair = 0; _pair < 4; _pair++) {
+          asm volatile(
+              "{\n\t"
+              "shl.b32 %0, %2, 16;\n\t"
+              "and.b32 %1, %2, 0xffff0000;\n\t"
+              "}\n"
+              : "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[0]),
+                "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[1])
+              : "r"(_vpairs_0[_pair]));
         }
-        #pragma unroll
-        for (int m_1 = 0; m_1 < 6; m_1++) {
-            float _vec_load_1[8];
-            {
-                const uint4* _vptr_1 = reinterpret_cast<const uint4*>(mat_a + (m_1 * 6144 + k_base) + 0);
-                uint4 _vld_1[1];
-                #pragma unroll
-                for (int _blk = 0; _blk < 1; _blk++) {
-                    _vld_1[_blk] = _vptr_1[_blk];
-                    uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
-                    #pragma unroll
-                    for (int _pair = 0; _pair < 4; _pair++) {
-                        asm volatile(
-                            "{\n\t"
-                            "shl.b32 %0, %2, 16;\n\t"
-                            "and.b32 %1, %2, 0xffff0000;\n\t"
-                            "}\n"
-                            : "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[1])
-                            : "r"(_vpairs_1[_pair]));
-                    }
-                }
-            }
-            #pragma unroll
-            for (int j = 0; j < 8; j++) {
-                float _fma_0 = __fmaf_rn(_vec_load_1[j], _vec_load_0[j], acc[m_1]);
-                acc[m_1] = _fma_0;
-            }
-        }
+      }
     }
-    #pragma unroll
-    for (int m_2 = 0; m_2 < 6; m_2++) {
-        float _warp_reduce_0 = acc[m_2];
-        #pragma unroll
-        for (int offset = 16; offset > 0; offset >>= 1)
-            _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
-        float warp_sum = _warp_reduce_0;
-        if (lane == 0) {
-            red[m_2 * 4 + warp] = warp_sum;
+#pragma unroll
+    for (int m_1 = 0; m_1 < 6; m_1++) {
+      float _vec_load_1[8];
+      {
+        const uint4* _vptr_1 = reinterpret_cast<const uint4*>(mat_a + (m_1 * 6144 + k_base) + 0);
+        uint4 _vld_1[1];
+#pragma unroll
+        for (int _blk = 0; _blk < 1; _blk++) {
+          _vld_1[_blk] = _vptr_1[_blk];
+          uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
+#pragma unroll
+          for (int _pair = 0; _pair < 4; _pair++) {
+            asm volatile(
+                "{\n\t"
+                "shl.b32 %0, %2, 16;\n\t"
+                "and.b32 %1, %2, 0xffff0000;\n\t"
+                "}\n"
+                : "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[0]),
+                  "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[1])
+                : "r"(_vpairs_1[_pair]));
+          }
         }
+      }
+#pragma unroll
+      for (int j = 0; j < 8; j++) {
+        float _fma_0 = __fmaf_rn(_vec_load_1[j], _vec_load_0[j], acc[m_1]);
+        acc[m_1] = _fma_0;
+      }
     }
-    asm volatile("barrier.sync 2, 128;" ::: "memory");
-    if (warp == 0) {
-        if (lane < 6) {
-            int m_3 = lane;
-            float total = red[m_3 * 4];
-            #pragma unroll
-            for (int source_warp = 1; source_warp < 4; source_warp++) {
-                total = total + red[m_3 * 4 + source_warp];
-            }
-            int offset = m_3 * num_experts + expert;
-            if (out_is_bf16 == 0) {
-                *(reinterpret_cast<float*>(out_f32 + offset) + (0)) = total;
-            } else {
-                *(reinterpret_cast<__nv_bfloat16*>(out_bf16 + offset) + (0)) = __float2bfloat16_rn(total);
-            }
-        }
+  }
+#pragma unroll
+  for (int m_2 = 0; m_2 < 6; m_2++) {
+    float _warp_reduce_0 = acc[m_2];
+#pragma unroll
+    for (int offset = 16; offset > 0; offset >>= 1)
+      _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
+    float warp_sum = _warp_reduce_0;
+    if (lane == 0) {
+      red[m_2 * 4 + warp] = warp_sum;
     }
-    asm volatile("griddepcontrol.launch_dependents;" ::: "memory");
+  }
+  asm volatile("barrier.sync 2, 128;" ::: "memory");
+  if (warp == 0) {
+    if (lane < 6) {
+      int m_3 = lane;
+      float total = red[m_3 * 4];
+#pragma unroll
+      for (int source_warp = 1; source_warp < 4; source_warp++) {
+        total = total + red[m_3 * 4 + source_warp];
+      }
+      int offset = m_3 * num_experts + expert;
+      if (out_is_bf16 == 0) {
+        *(reinterpret_cast<float*>(out_f32 + offset) + (0)) = total;
+      } else {
+        *(reinterpret_cast<__nv_bfloat16*>(out_bf16 + offset) + (0)) = __float2bfloat16_rn(total);
+      }
+    }
+  }
+  asm volatile("griddepcontrol.launch_dependents;" ::: "memory");
 }
 
-} // extern "C"
+}  // extern "C"

--- a/csrc/cake_router_gemm/cake_router_gemm_m6_k6144_device.cu
+++ b/csrc/cake_router_gemm/cake_router_gemm_m6_k6144_device.cu
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) 2026 by FlashInfer team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+typedef unsigned char      uint8_t;
+typedef unsigned short     uint16_t;
+typedef unsigned int       uint32_t;
+typedef unsigned long long uint64_t;
+typedef signed int         int32_t;
+typedef short int          int16_t;
+struct __align__(128) CakeTensorMap { uint64_t opaque[16]; };
+template <int N>
+struct __align__(128) CakeTensorMapPack { CakeTensorMap maps[N]; };
+
+typedef struct __align__(64) { uint64_t opaque[16]; } CUtensorMap;
+
+#include <cuda_bf16.h>
+
+__device__ __forceinline__ int make_warp_uniform(int x) {
+    int result;
+    asm volatile("shfl.sync.idx.b32 %0, %1, 0, 0x1F, 0xFFFFFFFF;"
+                 : "=r"(result) : "r"(x));
+    return result;
+}
+
+#define CAKE_INF CUDART_INF_F
+#define NUM_MAIN_STAGES 1
+#define SMEM_RED_OFF 0
+#define SMEM_RED_STAGE_BYTES 96
+#define SMEM_RED_STRIDE 96
+#define SMEM_TOTAL 128
+#define THREADS 128
+
+#include <math_constants.h>
+
+extern "C" {
+
+__global__ __launch_bounds__(128, 1) void
+kernel_cake_blackwell_router_gemm_m6_k6144(__nv_bfloat16* __restrict__ mat_a, __nv_bfloat16* __restrict__ mat_b, float* __restrict__ out_f32, __nv_bfloat16* __restrict__ out_bf16, int num_experts, int out_is_bf16)
+{
+    const int tid = threadIdx.x;
+    const int warp = make_warp_uniform(tid / 32);
+    const int lane = tid % 32;
+
+    extern __shared__ __align__(1024) char smem_raw[];
+    int smem;
+    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+
+    const int bid = blockIdx.x;
+    const int num_bids = gridDim.x;
+
+    // Kernel setup ops
+    float* red = reinterpret_cast<float*>(smem_raw + 0);
+    const int red_addr = smem + 0;
+
+    // === Task calls (dependency order) ===
+    int expert = blockIdx.x;
+    float acc[6];
+    #pragma unroll
+    for (int m = 0; m < 6; m++) {
+        acc[m] = 0.0f;
+    }
+    asm volatile("griddepcontrol.wait;" ::: "memory");
+    #pragma unroll
+    for (int ki = 0; ki < 6; ki++) {
+        int k_base = ki * 1024 + tid * 8;
+        float _vec_load_0[8];
+        {
+            const uint4* _vptr_0 = reinterpret_cast<const uint4*>(mat_b + (expert * 6144 + k_base) + 0);
+            uint4 _vld_0[1];
+            #pragma unroll
+            for (int _blk = 0; _blk < 1; _blk++) {
+                _vld_0[_blk] = _vptr_0[_blk];
+                uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
+                #pragma unroll
+                for (int _pair = 0; _pair < 4; _pair++) {
+                    asm volatile(
+                        "{\n\t"
+                        "shl.b32 %0, %2, 16;\n\t"
+                        "and.b32 %1, %2, 0xffff0000;\n\t"
+                        "}\n"
+                        : "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[1])
+                        : "r"(_vpairs_0[_pair]));
+                }
+            }
+        }
+        #pragma unroll
+        for (int m_1 = 0; m_1 < 6; m_1++) {
+            float _vec_load_1[8];
+            {
+                const uint4* _vptr_1 = reinterpret_cast<const uint4*>(mat_a + (m_1 * 6144 + k_base) + 0);
+                uint4 _vld_1[1];
+                #pragma unroll
+                for (int _blk = 0; _blk < 1; _blk++) {
+                    _vld_1[_blk] = _vptr_1[_blk];
+                    uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
+                    #pragma unroll
+                    for (int _pair = 0; _pair < 4; _pair++) {
+                        asm volatile(
+                            "{\n\t"
+                            "shl.b32 %0, %2, 16;\n\t"
+                            "and.b32 %1, %2, 0xffff0000;\n\t"
+                            "}\n"
+                            : "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[1])
+                            : "r"(_vpairs_1[_pair]));
+                    }
+                }
+            }
+            #pragma unroll
+            for (int j = 0; j < 8; j++) {
+                float _fma_0 = __fmaf_rn(_vec_load_1[j], _vec_load_0[j], acc[m_1]);
+                acc[m_1] = _fma_0;
+            }
+        }
+    }
+    #pragma unroll
+    for (int m_2 = 0; m_2 < 6; m_2++) {
+        float _warp_reduce_0 = acc[m_2];
+        #pragma unroll
+        for (int offset = 16; offset > 0; offset >>= 1)
+            _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
+        float warp_sum = _warp_reduce_0;
+        if (lane == 0) {
+            red[m_2 * 4 + warp] = warp_sum;
+        }
+    }
+    asm volatile("barrier.sync 2, 128;" ::: "memory");
+    if (warp == 0) {
+        if (lane < 6) {
+            int m_3 = lane;
+            float total = red[m_3 * 4];
+            #pragma unroll
+            for (int source_warp = 1; source_warp < 4; source_warp++) {
+                total = total + red[m_3 * 4 + source_warp];
+            }
+            int offset = m_3 * num_experts + expert;
+            if (out_is_bf16 == 0) {
+                *(reinterpret_cast<float*>(out_f32 + offset) + (0)) = total;
+            } else {
+                *(reinterpret_cast<__nv_bfloat16*>(out_bf16 + offset) + (0)) = __float2bfloat16_rn(total);
+            }
+        }
+    }
+    asm volatile("griddepcontrol.launch_dependents;" ::: "memory");
+}
+
+} // extern "C"

--- a/csrc/cake_router_gemm/cake_router_gemm_m6_k7168_device.cu
+++ b/csrc/cake_router_gemm/cake_router_gemm_m6_k7168_device.cu
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) 2026 by FlashInfer team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+typedef unsigned char      uint8_t;
+typedef unsigned short     uint16_t;
+typedef unsigned int       uint32_t;
+typedef unsigned long long uint64_t;
+typedef signed int         int32_t;
+typedef short int          int16_t;
+struct __align__(128) CakeTensorMap { uint64_t opaque[16]; };
+template <int N>
+struct __align__(128) CakeTensorMapPack { CakeTensorMap maps[N]; };
+
+typedef struct __align__(64) { uint64_t opaque[16]; } CUtensorMap;
+
+#include <cuda_bf16.h>
+
+__device__ __forceinline__ int make_warp_uniform(int x) {
+    int result;
+    asm volatile("shfl.sync.idx.b32 %0, %1, 0, 0x1F, 0xFFFFFFFF;"
+                 : "=r"(result) : "r"(x));
+    return result;
+}
+
+#define CAKE_INF CUDART_INF_F
+#define NUM_MAIN_STAGES 1
+#define SMEM_RED_OFF 0
+#define SMEM_RED_STAGE_BYTES 96
+#define SMEM_RED_STRIDE 96
+#define SMEM_TOTAL 128
+#define THREADS 128
+
+#include <math_constants.h>
+
+extern "C" {
+
+__global__ __launch_bounds__(128, 1) void
+kernel_cake_blackwell_router_gemm_m6_k7168(__nv_bfloat16* __restrict__ mat_a, __nv_bfloat16* __restrict__ mat_b, float* __restrict__ out_f32, __nv_bfloat16* __restrict__ out_bf16, int num_experts, int out_is_bf16)
+{
+    const int tid = threadIdx.x;
+    const int warp = make_warp_uniform(tid / 32);
+    const int lane = tid % 32;
+
+    extern __shared__ __align__(1024) char smem_raw[];
+    int smem;
+    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+
+    const int bid = blockIdx.x;
+    const int num_bids = gridDim.x;
+
+    // Kernel setup ops
+    float* red = reinterpret_cast<float*>(smem_raw + 0);
+    const int red_addr = smem + 0;
+
+    // === Task calls (dependency order) ===
+    int expert = blockIdx.x;
+    float acc[6];
+    #pragma unroll
+    for (int m = 0; m < 6; m++) {
+        acc[m] = 0.0f;
+    }
+    asm volatile("griddepcontrol.wait;" ::: "memory");
+    #pragma unroll
+    for (int ki = 0; ki < 7; ki++) {
+        int k_base = ki * 1024 + tid * 8;
+        float _vec_load_0[8];
+        {
+            const uint4* _vptr_0 = reinterpret_cast<const uint4*>(mat_b + (expert * 7168 + k_base) + 0);
+            uint4 _vld_0[1];
+            #pragma unroll
+            for (int _blk = 0; _blk < 1; _blk++) {
+                _vld_0[_blk] = _vptr_0[_blk];
+                uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
+                #pragma unroll
+                for (int _pair = 0; _pair < 4; _pair++) {
+                    asm volatile(
+                        "{\n\t"
+                        "shl.b32 %0, %2, 16;\n\t"
+                        "and.b32 %1, %2, 0xffff0000;\n\t"
+                        "}\n"
+                        : "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[1])
+                        : "r"(_vpairs_0[_pair]));
+                }
+            }
+        }
+        #pragma unroll
+        for (int m_1 = 0; m_1 < 6; m_1++) {
+            float _vec_load_1[8];
+            {
+                const uint4* _vptr_1 = reinterpret_cast<const uint4*>(mat_a + (m_1 * 7168 + k_base) + 0);
+                uint4 _vld_1[1];
+                #pragma unroll
+                for (int _blk = 0; _blk < 1; _blk++) {
+                    _vld_1[_blk] = _vptr_1[_blk];
+                    uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
+                    #pragma unroll
+                    for (int _pair = 0; _pair < 4; _pair++) {
+                        asm volatile(
+                            "{\n\t"
+                            "shl.b32 %0, %2, 16;\n\t"
+                            "and.b32 %1, %2, 0xffff0000;\n\t"
+                            "}\n"
+                            : "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[1])
+                            : "r"(_vpairs_1[_pair]));
+                    }
+                }
+            }
+            #pragma unroll
+            for (int j = 0; j < 8; j++) {
+                float _fma_0 = __fmaf_rn(_vec_load_1[j], _vec_load_0[j], acc[m_1]);
+                acc[m_1] = _fma_0;
+            }
+        }
+    }
+    #pragma unroll
+    for (int m_2 = 0; m_2 < 6; m_2++) {
+        float _warp_reduce_0 = acc[m_2];
+        #pragma unroll
+        for (int offset = 16; offset > 0; offset >>= 1)
+            _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
+        float warp_sum = _warp_reduce_0;
+        if (lane == 0) {
+            red[m_2 * 4 + warp] = warp_sum;
+        }
+    }
+    asm volatile("barrier.sync 2, 128;" ::: "memory");
+    if (warp == 0) {
+        if (lane < 6) {
+            int m_3 = lane;
+            float total = red[m_3 * 4];
+            #pragma unroll
+            for (int source_warp = 1; source_warp < 4; source_warp++) {
+                total = total + red[m_3 * 4 + source_warp];
+            }
+            int offset = m_3 * num_experts + expert;
+            if (out_is_bf16 == 0) {
+                *(reinterpret_cast<float*>(out_f32 + offset) + (0)) = total;
+            } else {
+                *(reinterpret_cast<__nv_bfloat16*>(out_bf16 + offset) + (0)) = __float2bfloat16_rn(total);
+            }
+        }
+    }
+    asm volatile("griddepcontrol.launch_dependents;" ::: "memory");
+}
+
+} // extern "C"

--- a/csrc/cake_router_gemm/cake_router_gemm_m6_k7168_device.cu
+++ b/csrc/cake_router_gemm/cake_router_gemm_m6_k7168_device.cu
@@ -14,25 +14,30 @@
  * limitations under the License.
  */
 
-typedef unsigned char      uint8_t;
-typedef unsigned short     uint16_t;
-typedef unsigned int       uint32_t;
+typedef unsigned char uint8_t;
+typedef unsigned short uint16_t;
+typedef unsigned int uint32_t;
 typedef unsigned long long uint64_t;
-typedef signed int         int32_t;
-typedef short int          int16_t;
-struct __align__(128) CakeTensorMap { uint64_t opaque[16]; };
+typedef signed int int32_t;
+typedef short int int16_t;
+struct __align__(128) CakeTensorMap {
+  uint64_t opaque[16];
+};
 template <int N>
-struct __align__(128) CakeTensorMapPack { CakeTensorMap maps[N]; };
+struct __align__(128) CakeTensorMapPack {
+  CakeTensorMap maps[N];
+};
 
-typedef struct __align__(64) { uint64_t opaque[16]; } CUtensorMap;
+typedef struct __align__(64) {
+  uint64_t opaque[16];
+} CUtensorMap;
 
 #include <cuda_bf16.h>
 
 __device__ __forceinline__ int make_warp_uniform(int x) {
-    int result;
-    asm volatile("shfl.sync.idx.b32 %0, %1, 0, 0x1F, 0xFFFFFFFF;"
-                 : "=r"(result) : "r"(x));
-    return result;
+  int result;
+  asm volatile("shfl.sync.idx.b32 %0, %1, 0, 0x1F, 0xFFFFFFFF;" : "=r"(result) : "r"(x));
+  return result;
 }
 
 #define CAKE_INF CUDART_INF_F
@@ -47,113 +52,116 @@ __device__ __forceinline__ int make_warp_uniform(int x) {
 
 extern "C" {
 
-__global__ __launch_bounds__(128, 1) void
-kernel_cake_blackwell_router_gemm_m6_k7168(__nv_bfloat16* __restrict__ mat_a, __nv_bfloat16* __restrict__ mat_b, float* __restrict__ out_f32, __nv_bfloat16* __restrict__ out_bf16, int num_experts, int out_is_bf16)
-{
-    const int tid = threadIdx.x;
-    const int warp = make_warp_uniform(tid / 32);
-    const int lane = tid % 32;
+__global__ __launch_bounds__(128, 1) void kernel_cake_blackwell_router_gemm_m6_k7168(
+    __nv_bfloat16* __restrict__ mat_a, __nv_bfloat16* __restrict__ mat_b,
+    float* __restrict__ out_f32, __nv_bfloat16* __restrict__ out_bf16, int num_experts,
+    int out_is_bf16) {
+  const int tid = threadIdx.x;
+  const int warp = make_warp_uniform(tid / 32);
+  const int lane = tid % 32;
 
-    extern __shared__ __align__(1024) char smem_raw[];
-    int smem;
-    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+  extern __shared__ __align__(1024) char smem_raw[];
+  int smem;
+  smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
 
-    const int bid = blockIdx.x;
-    const int num_bids = gridDim.x;
+  const int bid = blockIdx.x;
+  const int num_bids = gridDim.x;
 
-    // Kernel setup ops
-    float* red = reinterpret_cast<float*>(smem_raw + 0);
-    const int red_addr = smem + 0;
+  // Kernel setup ops
+  float* red = reinterpret_cast<float*>(smem_raw + 0);
+  const int red_addr = smem + 0;
 
-    // === Task calls (dependency order) ===
-    int expert = blockIdx.x;
-    float acc[6];
-    #pragma unroll
-    for (int m = 0; m < 6; m++) {
-        acc[m] = 0.0f;
-    }
-    asm volatile("griddepcontrol.wait;" ::: "memory");
-    #pragma unroll
-    for (int ki = 0; ki < 7; ki++) {
-        int k_base = ki * 1024 + tid * 8;
-        float _vec_load_0[8];
-        {
-            const uint4* _vptr_0 = reinterpret_cast<const uint4*>(mat_b + (expert * 7168 + k_base) + 0);
-            uint4 _vld_0[1];
-            #pragma unroll
-            for (int _blk = 0; _blk < 1; _blk++) {
-                _vld_0[_blk] = _vptr_0[_blk];
-                uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
-                #pragma unroll
-                for (int _pair = 0; _pair < 4; _pair++) {
-                    asm volatile(
-                        "{\n\t"
-                        "shl.b32 %0, %2, 16;\n\t"
-                        "and.b32 %1, %2, 0xffff0000;\n\t"
-                        "}\n"
-                        : "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[1])
-                        : "r"(_vpairs_0[_pair]));
-                }
-            }
+  // === Task calls (dependency order) ===
+  int expert = blockIdx.x;
+  float acc[6];
+#pragma unroll
+  for (int m = 0; m < 6; m++) {
+    acc[m] = 0.0f;
+  }
+  asm volatile("griddepcontrol.wait;" ::: "memory");
+#pragma unroll
+  for (int ki = 0; ki < 7; ki++) {
+    int k_base = ki * 1024 + tid * 8;
+    float _vec_load_0[8];
+    {
+      const uint4* _vptr_0 = reinterpret_cast<const uint4*>(mat_b + (expert * 7168 + k_base) + 0);
+      uint4 _vld_0[1];
+#pragma unroll
+      for (int _blk = 0; _blk < 1; _blk++) {
+        _vld_0[_blk] = _vptr_0[_blk];
+        uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
+#pragma unroll
+        for (int _pair = 0; _pair < 4; _pair++) {
+          asm volatile(
+              "{\n\t"
+              "shl.b32 %0, %2, 16;\n\t"
+              "and.b32 %1, %2, 0xffff0000;\n\t"
+              "}\n"
+              : "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[0]),
+                "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[1])
+              : "r"(_vpairs_0[_pair]));
         }
-        #pragma unroll
-        for (int m_1 = 0; m_1 < 6; m_1++) {
-            float _vec_load_1[8];
-            {
-                const uint4* _vptr_1 = reinterpret_cast<const uint4*>(mat_a + (m_1 * 7168 + k_base) + 0);
-                uint4 _vld_1[1];
-                #pragma unroll
-                for (int _blk = 0; _blk < 1; _blk++) {
-                    _vld_1[_blk] = _vptr_1[_blk];
-                    uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
-                    #pragma unroll
-                    for (int _pair = 0; _pair < 4; _pair++) {
-                        asm volatile(
-                            "{\n\t"
-                            "shl.b32 %0, %2, 16;\n\t"
-                            "and.b32 %1, %2, 0xffff0000;\n\t"
-                            "}\n"
-                            : "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[1])
-                            : "r"(_vpairs_1[_pair]));
-                    }
-                }
-            }
-            #pragma unroll
-            for (int j = 0; j < 8; j++) {
-                float _fma_0 = __fmaf_rn(_vec_load_1[j], _vec_load_0[j], acc[m_1]);
-                acc[m_1] = _fma_0;
-            }
-        }
+      }
     }
-    #pragma unroll
-    for (int m_2 = 0; m_2 < 6; m_2++) {
-        float _warp_reduce_0 = acc[m_2];
-        #pragma unroll
-        for (int offset = 16; offset > 0; offset >>= 1)
-            _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
-        float warp_sum = _warp_reduce_0;
-        if (lane == 0) {
-            red[m_2 * 4 + warp] = warp_sum;
+#pragma unroll
+    for (int m_1 = 0; m_1 < 6; m_1++) {
+      float _vec_load_1[8];
+      {
+        const uint4* _vptr_1 = reinterpret_cast<const uint4*>(mat_a + (m_1 * 7168 + k_base) + 0);
+        uint4 _vld_1[1];
+#pragma unroll
+        for (int _blk = 0; _blk < 1; _blk++) {
+          _vld_1[_blk] = _vptr_1[_blk];
+          uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
+#pragma unroll
+          for (int _pair = 0; _pair < 4; _pair++) {
+            asm volatile(
+                "{\n\t"
+                "shl.b32 %0, %2, 16;\n\t"
+                "and.b32 %1, %2, 0xffff0000;\n\t"
+                "}\n"
+                : "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[0]),
+                  "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[1])
+                : "r"(_vpairs_1[_pair]));
+          }
         }
+      }
+#pragma unroll
+      for (int j = 0; j < 8; j++) {
+        float _fma_0 = __fmaf_rn(_vec_load_1[j], _vec_load_0[j], acc[m_1]);
+        acc[m_1] = _fma_0;
+      }
     }
-    asm volatile("barrier.sync 2, 128;" ::: "memory");
-    if (warp == 0) {
-        if (lane < 6) {
-            int m_3 = lane;
-            float total = red[m_3 * 4];
-            #pragma unroll
-            for (int source_warp = 1; source_warp < 4; source_warp++) {
-                total = total + red[m_3 * 4 + source_warp];
-            }
-            int offset = m_3 * num_experts + expert;
-            if (out_is_bf16 == 0) {
-                *(reinterpret_cast<float*>(out_f32 + offset) + (0)) = total;
-            } else {
-                *(reinterpret_cast<__nv_bfloat16*>(out_bf16 + offset) + (0)) = __float2bfloat16_rn(total);
-            }
-        }
+  }
+#pragma unroll
+  for (int m_2 = 0; m_2 < 6; m_2++) {
+    float _warp_reduce_0 = acc[m_2];
+#pragma unroll
+    for (int offset = 16; offset > 0; offset >>= 1)
+      _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
+    float warp_sum = _warp_reduce_0;
+    if (lane == 0) {
+      red[m_2 * 4 + warp] = warp_sum;
     }
-    asm volatile("griddepcontrol.launch_dependents;" ::: "memory");
+  }
+  asm volatile("barrier.sync 2, 128;" ::: "memory");
+  if (warp == 0) {
+    if (lane < 6) {
+      int m_3 = lane;
+      float total = red[m_3 * 4];
+#pragma unroll
+      for (int source_warp = 1; source_warp < 4; source_warp++) {
+        total = total + red[m_3 * 4 + source_warp];
+      }
+      int offset = m_3 * num_experts + expert;
+      if (out_is_bf16 == 0) {
+        *(reinterpret_cast<float*>(out_f32 + offset) + (0)) = total;
+      } else {
+        *(reinterpret_cast<__nv_bfloat16*>(out_bf16 + offset) + (0)) = __float2bfloat16_rn(total);
+      }
+    }
+  }
+  asm volatile("griddepcontrol.launch_dependents;" ::: "memory");
 }
 
-} // extern "C"
+}  // extern "C"

--- a/csrc/cake_router_gemm/cake_router_gemm_m7_k6144_device.cu
+++ b/csrc/cake_router_gemm/cake_router_gemm_m7_k6144_device.cu
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) 2026 by FlashInfer team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+typedef unsigned char      uint8_t;
+typedef unsigned short     uint16_t;
+typedef unsigned int       uint32_t;
+typedef unsigned long long uint64_t;
+typedef signed int         int32_t;
+typedef short int          int16_t;
+struct __align__(128) CakeTensorMap { uint64_t opaque[16]; };
+template <int N>
+struct __align__(128) CakeTensorMapPack { CakeTensorMap maps[N]; };
+
+typedef struct __align__(64) { uint64_t opaque[16]; } CUtensorMap;
+
+#include <cuda_bf16.h>
+
+__device__ __forceinline__ int make_warp_uniform(int x) {
+    int result;
+    asm volatile("shfl.sync.idx.b32 %0, %1, 0, 0x1F, 0xFFFFFFFF;"
+                 : "=r"(result) : "r"(x));
+    return result;
+}
+
+#define CAKE_INF CUDART_INF_F
+#define NUM_MAIN_STAGES 1
+#define SMEM_RED_OFF 0
+#define SMEM_RED_STAGE_BYTES 112
+#define SMEM_RED_STRIDE 112
+#define SMEM_TOTAL 128
+#define THREADS 128
+
+#include <math_constants.h>
+
+extern "C" {
+
+__global__ __launch_bounds__(128, 1) void
+kernel_cake_blackwell_router_gemm_m7_k6144(__nv_bfloat16* __restrict__ mat_a, __nv_bfloat16* __restrict__ mat_b, float* __restrict__ out_f32, __nv_bfloat16* __restrict__ out_bf16, int num_experts, int out_is_bf16)
+{
+    const int tid = threadIdx.x;
+    const int warp = make_warp_uniform(tid / 32);
+    const int lane = tid % 32;
+
+    extern __shared__ __align__(1024) char smem_raw[];
+    int smem;
+    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+
+    const int bid = blockIdx.x;
+    const int num_bids = gridDim.x;
+
+    // Kernel setup ops
+    float* red = reinterpret_cast<float*>(smem_raw + 0);
+    const int red_addr = smem + 0;
+
+    // === Task calls (dependency order) ===
+    int expert = blockIdx.x;
+    float acc[7];
+    #pragma unroll
+    for (int m = 0; m < 7; m++) {
+        acc[m] = 0.0f;
+    }
+    asm volatile("griddepcontrol.wait;" ::: "memory");
+    #pragma unroll
+    for (int ki = 0; ki < 6; ki++) {
+        int k_base = ki * 1024 + tid * 8;
+        float _vec_load_0[8];
+        {
+            const uint4* _vptr_0 = reinterpret_cast<const uint4*>(mat_b + (expert * 6144 + k_base) + 0);
+            uint4 _vld_0[1];
+            #pragma unroll
+            for (int _blk = 0; _blk < 1; _blk++) {
+                _vld_0[_blk] = _vptr_0[_blk];
+                uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
+                #pragma unroll
+                for (int _pair = 0; _pair < 4; _pair++) {
+                    asm volatile(
+                        "{\n\t"
+                        "shl.b32 %0, %2, 16;\n\t"
+                        "and.b32 %1, %2, 0xffff0000;\n\t"
+                        "}\n"
+                        : "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[1])
+                        : "r"(_vpairs_0[_pair]));
+                }
+            }
+        }
+        #pragma unroll
+        for (int m_1 = 0; m_1 < 7; m_1++) {
+            float _vec_load_1[8];
+            {
+                const uint4* _vptr_1 = reinterpret_cast<const uint4*>(mat_a + (m_1 * 6144 + k_base) + 0);
+                uint4 _vld_1[1];
+                #pragma unroll
+                for (int _blk = 0; _blk < 1; _blk++) {
+                    _vld_1[_blk] = _vptr_1[_blk];
+                    uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
+                    #pragma unroll
+                    for (int _pair = 0; _pair < 4; _pair++) {
+                        asm volatile(
+                            "{\n\t"
+                            "shl.b32 %0, %2, 16;\n\t"
+                            "and.b32 %1, %2, 0xffff0000;\n\t"
+                            "}\n"
+                            : "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[1])
+                            : "r"(_vpairs_1[_pair]));
+                    }
+                }
+            }
+            #pragma unroll
+            for (int j = 0; j < 8; j++) {
+                float _fma_0 = __fmaf_rn(_vec_load_1[j], _vec_load_0[j], acc[m_1]);
+                acc[m_1] = _fma_0;
+            }
+        }
+    }
+    #pragma unroll
+    for (int m_2 = 0; m_2 < 7; m_2++) {
+        float _warp_reduce_0 = acc[m_2];
+        #pragma unroll
+        for (int offset = 16; offset > 0; offset >>= 1)
+            _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
+        float warp_sum = _warp_reduce_0;
+        if (lane == 0) {
+            red[m_2 * 4 + warp] = warp_sum;
+        }
+    }
+    asm volatile("barrier.sync 2, 128;" ::: "memory");
+    if (warp == 0) {
+        if (lane < 7) {
+            int m_3 = lane;
+            float total = red[m_3 * 4];
+            #pragma unroll
+            for (int source_warp = 1; source_warp < 4; source_warp++) {
+                total = total + red[m_3 * 4 + source_warp];
+            }
+            int offset = m_3 * num_experts + expert;
+            if (out_is_bf16 == 0) {
+                *(reinterpret_cast<float*>(out_f32 + offset) + (0)) = total;
+            } else {
+                *(reinterpret_cast<__nv_bfloat16*>(out_bf16 + offset) + (0)) = __float2bfloat16_rn(total);
+            }
+        }
+    }
+    asm volatile("griddepcontrol.launch_dependents;" ::: "memory");
+}
+
+} // extern "C"

--- a/csrc/cake_router_gemm/cake_router_gemm_m7_k6144_device.cu
+++ b/csrc/cake_router_gemm/cake_router_gemm_m7_k6144_device.cu
@@ -14,25 +14,30 @@
  * limitations under the License.
  */
 
-typedef unsigned char      uint8_t;
-typedef unsigned short     uint16_t;
-typedef unsigned int       uint32_t;
+typedef unsigned char uint8_t;
+typedef unsigned short uint16_t;
+typedef unsigned int uint32_t;
 typedef unsigned long long uint64_t;
-typedef signed int         int32_t;
-typedef short int          int16_t;
-struct __align__(128) CakeTensorMap { uint64_t opaque[16]; };
+typedef signed int int32_t;
+typedef short int int16_t;
+struct __align__(128) CakeTensorMap {
+  uint64_t opaque[16];
+};
 template <int N>
-struct __align__(128) CakeTensorMapPack { CakeTensorMap maps[N]; };
+struct __align__(128) CakeTensorMapPack {
+  CakeTensorMap maps[N];
+};
 
-typedef struct __align__(64) { uint64_t opaque[16]; } CUtensorMap;
+typedef struct __align__(64) {
+  uint64_t opaque[16];
+} CUtensorMap;
 
 #include <cuda_bf16.h>
 
 __device__ __forceinline__ int make_warp_uniform(int x) {
-    int result;
-    asm volatile("shfl.sync.idx.b32 %0, %1, 0, 0x1F, 0xFFFFFFFF;"
-                 : "=r"(result) : "r"(x));
-    return result;
+  int result;
+  asm volatile("shfl.sync.idx.b32 %0, %1, 0, 0x1F, 0xFFFFFFFF;" : "=r"(result) : "r"(x));
+  return result;
 }
 
 #define CAKE_INF CUDART_INF_F
@@ -47,113 +52,116 @@ __device__ __forceinline__ int make_warp_uniform(int x) {
 
 extern "C" {
 
-__global__ __launch_bounds__(128, 1) void
-kernel_cake_blackwell_router_gemm_m7_k6144(__nv_bfloat16* __restrict__ mat_a, __nv_bfloat16* __restrict__ mat_b, float* __restrict__ out_f32, __nv_bfloat16* __restrict__ out_bf16, int num_experts, int out_is_bf16)
-{
-    const int tid = threadIdx.x;
-    const int warp = make_warp_uniform(tid / 32);
-    const int lane = tid % 32;
+__global__ __launch_bounds__(128, 1) void kernel_cake_blackwell_router_gemm_m7_k6144(
+    __nv_bfloat16* __restrict__ mat_a, __nv_bfloat16* __restrict__ mat_b,
+    float* __restrict__ out_f32, __nv_bfloat16* __restrict__ out_bf16, int num_experts,
+    int out_is_bf16) {
+  const int tid = threadIdx.x;
+  const int warp = make_warp_uniform(tid / 32);
+  const int lane = tid % 32;
 
-    extern __shared__ __align__(1024) char smem_raw[];
-    int smem;
-    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+  extern __shared__ __align__(1024) char smem_raw[];
+  int smem;
+  smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
 
-    const int bid = blockIdx.x;
-    const int num_bids = gridDim.x;
+  const int bid = blockIdx.x;
+  const int num_bids = gridDim.x;
 
-    // Kernel setup ops
-    float* red = reinterpret_cast<float*>(smem_raw + 0);
-    const int red_addr = smem + 0;
+  // Kernel setup ops
+  float* red = reinterpret_cast<float*>(smem_raw + 0);
+  const int red_addr = smem + 0;
 
-    // === Task calls (dependency order) ===
-    int expert = blockIdx.x;
-    float acc[7];
-    #pragma unroll
-    for (int m = 0; m < 7; m++) {
-        acc[m] = 0.0f;
-    }
-    asm volatile("griddepcontrol.wait;" ::: "memory");
-    #pragma unroll
-    for (int ki = 0; ki < 6; ki++) {
-        int k_base = ki * 1024 + tid * 8;
-        float _vec_load_0[8];
-        {
-            const uint4* _vptr_0 = reinterpret_cast<const uint4*>(mat_b + (expert * 6144 + k_base) + 0);
-            uint4 _vld_0[1];
-            #pragma unroll
-            for (int _blk = 0; _blk < 1; _blk++) {
-                _vld_0[_blk] = _vptr_0[_blk];
-                uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
-                #pragma unroll
-                for (int _pair = 0; _pair < 4; _pair++) {
-                    asm volatile(
-                        "{\n\t"
-                        "shl.b32 %0, %2, 16;\n\t"
-                        "and.b32 %1, %2, 0xffff0000;\n\t"
-                        "}\n"
-                        : "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[1])
-                        : "r"(_vpairs_0[_pair]));
-                }
-            }
+  // === Task calls (dependency order) ===
+  int expert = blockIdx.x;
+  float acc[7];
+#pragma unroll
+  for (int m = 0; m < 7; m++) {
+    acc[m] = 0.0f;
+  }
+  asm volatile("griddepcontrol.wait;" ::: "memory");
+#pragma unroll
+  for (int ki = 0; ki < 6; ki++) {
+    int k_base = ki * 1024 + tid * 8;
+    float _vec_load_0[8];
+    {
+      const uint4* _vptr_0 = reinterpret_cast<const uint4*>(mat_b + (expert * 6144 + k_base) + 0);
+      uint4 _vld_0[1];
+#pragma unroll
+      for (int _blk = 0; _blk < 1; _blk++) {
+        _vld_0[_blk] = _vptr_0[_blk];
+        uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
+#pragma unroll
+        for (int _pair = 0; _pair < 4; _pair++) {
+          asm volatile(
+              "{\n\t"
+              "shl.b32 %0, %2, 16;\n\t"
+              "and.b32 %1, %2, 0xffff0000;\n\t"
+              "}\n"
+              : "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[0]),
+                "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[1])
+              : "r"(_vpairs_0[_pair]));
         }
-        #pragma unroll
-        for (int m_1 = 0; m_1 < 7; m_1++) {
-            float _vec_load_1[8];
-            {
-                const uint4* _vptr_1 = reinterpret_cast<const uint4*>(mat_a + (m_1 * 6144 + k_base) + 0);
-                uint4 _vld_1[1];
-                #pragma unroll
-                for (int _blk = 0; _blk < 1; _blk++) {
-                    _vld_1[_blk] = _vptr_1[_blk];
-                    uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
-                    #pragma unroll
-                    for (int _pair = 0; _pair < 4; _pair++) {
-                        asm volatile(
-                            "{\n\t"
-                            "shl.b32 %0, %2, 16;\n\t"
-                            "and.b32 %1, %2, 0xffff0000;\n\t"
-                            "}\n"
-                            : "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[1])
-                            : "r"(_vpairs_1[_pair]));
-                    }
-                }
-            }
-            #pragma unroll
-            for (int j = 0; j < 8; j++) {
-                float _fma_0 = __fmaf_rn(_vec_load_1[j], _vec_load_0[j], acc[m_1]);
-                acc[m_1] = _fma_0;
-            }
-        }
+      }
     }
-    #pragma unroll
-    for (int m_2 = 0; m_2 < 7; m_2++) {
-        float _warp_reduce_0 = acc[m_2];
-        #pragma unroll
-        for (int offset = 16; offset > 0; offset >>= 1)
-            _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
-        float warp_sum = _warp_reduce_0;
-        if (lane == 0) {
-            red[m_2 * 4 + warp] = warp_sum;
+#pragma unroll
+    for (int m_1 = 0; m_1 < 7; m_1++) {
+      float _vec_load_1[8];
+      {
+        const uint4* _vptr_1 = reinterpret_cast<const uint4*>(mat_a + (m_1 * 6144 + k_base) + 0);
+        uint4 _vld_1[1];
+#pragma unroll
+        for (int _blk = 0; _blk < 1; _blk++) {
+          _vld_1[_blk] = _vptr_1[_blk];
+          uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
+#pragma unroll
+          for (int _pair = 0; _pair < 4; _pair++) {
+            asm volatile(
+                "{\n\t"
+                "shl.b32 %0, %2, 16;\n\t"
+                "and.b32 %1, %2, 0xffff0000;\n\t"
+                "}\n"
+                : "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[0]),
+                  "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[1])
+                : "r"(_vpairs_1[_pair]));
+          }
         }
+      }
+#pragma unroll
+      for (int j = 0; j < 8; j++) {
+        float _fma_0 = __fmaf_rn(_vec_load_1[j], _vec_load_0[j], acc[m_1]);
+        acc[m_1] = _fma_0;
+      }
     }
-    asm volatile("barrier.sync 2, 128;" ::: "memory");
-    if (warp == 0) {
-        if (lane < 7) {
-            int m_3 = lane;
-            float total = red[m_3 * 4];
-            #pragma unroll
-            for (int source_warp = 1; source_warp < 4; source_warp++) {
-                total = total + red[m_3 * 4 + source_warp];
-            }
-            int offset = m_3 * num_experts + expert;
-            if (out_is_bf16 == 0) {
-                *(reinterpret_cast<float*>(out_f32 + offset) + (0)) = total;
-            } else {
-                *(reinterpret_cast<__nv_bfloat16*>(out_bf16 + offset) + (0)) = __float2bfloat16_rn(total);
-            }
-        }
+  }
+#pragma unroll
+  for (int m_2 = 0; m_2 < 7; m_2++) {
+    float _warp_reduce_0 = acc[m_2];
+#pragma unroll
+    for (int offset = 16; offset > 0; offset >>= 1)
+      _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
+    float warp_sum = _warp_reduce_0;
+    if (lane == 0) {
+      red[m_2 * 4 + warp] = warp_sum;
     }
-    asm volatile("griddepcontrol.launch_dependents;" ::: "memory");
+  }
+  asm volatile("barrier.sync 2, 128;" ::: "memory");
+  if (warp == 0) {
+    if (lane < 7) {
+      int m_3 = lane;
+      float total = red[m_3 * 4];
+#pragma unroll
+      for (int source_warp = 1; source_warp < 4; source_warp++) {
+        total = total + red[m_3 * 4 + source_warp];
+      }
+      int offset = m_3 * num_experts + expert;
+      if (out_is_bf16 == 0) {
+        *(reinterpret_cast<float*>(out_f32 + offset) + (0)) = total;
+      } else {
+        *(reinterpret_cast<__nv_bfloat16*>(out_bf16 + offset) + (0)) = __float2bfloat16_rn(total);
+      }
+    }
+  }
+  asm volatile("griddepcontrol.launch_dependents;" ::: "memory");
 }
 
-} // extern "C"
+}  // extern "C"

--- a/csrc/cake_router_gemm/cake_router_gemm_m7_k7168_device.cu
+++ b/csrc/cake_router_gemm/cake_router_gemm_m7_k7168_device.cu
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) 2026 by FlashInfer team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+typedef unsigned char      uint8_t;
+typedef unsigned short     uint16_t;
+typedef unsigned int       uint32_t;
+typedef unsigned long long uint64_t;
+typedef signed int         int32_t;
+typedef short int          int16_t;
+struct __align__(128) CakeTensorMap { uint64_t opaque[16]; };
+template <int N>
+struct __align__(128) CakeTensorMapPack { CakeTensorMap maps[N]; };
+
+typedef struct __align__(64) { uint64_t opaque[16]; } CUtensorMap;
+
+#include <cuda_bf16.h>
+
+__device__ __forceinline__ int make_warp_uniform(int x) {
+    int result;
+    asm volatile("shfl.sync.idx.b32 %0, %1, 0, 0x1F, 0xFFFFFFFF;"
+                 : "=r"(result) : "r"(x));
+    return result;
+}
+
+#define CAKE_INF CUDART_INF_F
+#define NUM_MAIN_STAGES 1
+#define SMEM_RED_OFF 0
+#define SMEM_RED_STAGE_BYTES 112
+#define SMEM_RED_STRIDE 112
+#define SMEM_TOTAL 128
+#define THREADS 128
+
+#include <math_constants.h>
+
+extern "C" {
+
+__global__ __launch_bounds__(128, 1) void
+kernel_cake_blackwell_router_gemm_m7_k7168(__nv_bfloat16* __restrict__ mat_a, __nv_bfloat16* __restrict__ mat_b, float* __restrict__ out_f32, __nv_bfloat16* __restrict__ out_bf16, int num_experts, int out_is_bf16)
+{
+    const int tid = threadIdx.x;
+    const int warp = make_warp_uniform(tid / 32);
+    const int lane = tid % 32;
+
+    extern __shared__ __align__(1024) char smem_raw[];
+    int smem;
+    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+
+    const int bid = blockIdx.x;
+    const int num_bids = gridDim.x;
+
+    // Kernel setup ops
+    float* red = reinterpret_cast<float*>(smem_raw + 0);
+    const int red_addr = smem + 0;
+
+    // === Task calls (dependency order) ===
+    int expert = blockIdx.x;
+    float acc[7];
+    #pragma unroll
+    for (int m = 0; m < 7; m++) {
+        acc[m] = 0.0f;
+    }
+    asm volatile("griddepcontrol.wait;" ::: "memory");
+    #pragma unroll
+    for (int ki = 0; ki < 7; ki++) {
+        int k_base = ki * 1024 + tid * 8;
+        float _vec_load_0[8];
+        {
+            const uint4* _vptr_0 = reinterpret_cast<const uint4*>(mat_b + (expert * 7168 + k_base) + 0);
+            uint4 _vld_0[1];
+            #pragma unroll
+            for (int _blk = 0; _blk < 1; _blk++) {
+                _vld_0[_blk] = _vptr_0[_blk];
+                uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
+                #pragma unroll
+                for (int _pair = 0; _pair < 4; _pair++) {
+                    asm volatile(
+                        "{\n\t"
+                        "shl.b32 %0, %2, 16;\n\t"
+                        "and.b32 %1, %2, 0xffff0000;\n\t"
+                        "}\n"
+                        : "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[1])
+                        : "r"(_vpairs_0[_pair]));
+                }
+            }
+        }
+        #pragma unroll
+        for (int m_1 = 0; m_1 < 7; m_1++) {
+            float _vec_load_1[8];
+            {
+                const uint4* _vptr_1 = reinterpret_cast<const uint4*>(mat_a + (m_1 * 7168 + k_base) + 0);
+                uint4 _vld_1[1];
+                #pragma unroll
+                for (int _blk = 0; _blk < 1; _blk++) {
+                    _vld_1[_blk] = _vptr_1[_blk];
+                    uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
+                    #pragma unroll
+                    for (int _pair = 0; _pair < 4; _pair++) {
+                        asm volatile(
+                            "{\n\t"
+                            "shl.b32 %0, %2, 16;\n\t"
+                            "and.b32 %1, %2, 0xffff0000;\n\t"
+                            "}\n"
+                            : "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[1])
+                            : "r"(_vpairs_1[_pair]));
+                    }
+                }
+            }
+            #pragma unroll
+            for (int j = 0; j < 8; j++) {
+                float _fma_0 = __fmaf_rn(_vec_load_1[j], _vec_load_0[j], acc[m_1]);
+                acc[m_1] = _fma_0;
+            }
+        }
+    }
+    #pragma unroll
+    for (int m_2 = 0; m_2 < 7; m_2++) {
+        float _warp_reduce_0 = acc[m_2];
+        #pragma unroll
+        for (int offset = 16; offset > 0; offset >>= 1)
+            _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
+        float warp_sum = _warp_reduce_0;
+        if (lane == 0) {
+            red[m_2 * 4 + warp] = warp_sum;
+        }
+    }
+    asm volatile("barrier.sync 2, 128;" ::: "memory");
+    if (warp == 0) {
+        if (lane < 7) {
+            int m_3 = lane;
+            float total = red[m_3 * 4];
+            #pragma unroll
+            for (int source_warp = 1; source_warp < 4; source_warp++) {
+                total = total + red[m_3 * 4 + source_warp];
+            }
+            int offset = m_3 * num_experts + expert;
+            if (out_is_bf16 == 0) {
+                *(reinterpret_cast<float*>(out_f32 + offset) + (0)) = total;
+            } else {
+                *(reinterpret_cast<__nv_bfloat16*>(out_bf16 + offset) + (0)) = __float2bfloat16_rn(total);
+            }
+        }
+    }
+    asm volatile("griddepcontrol.launch_dependents;" ::: "memory");
+}
+
+} // extern "C"

--- a/csrc/cake_router_gemm/cake_router_gemm_m7_k7168_device.cu
+++ b/csrc/cake_router_gemm/cake_router_gemm_m7_k7168_device.cu
@@ -14,25 +14,30 @@
  * limitations under the License.
  */
 
-typedef unsigned char      uint8_t;
-typedef unsigned short     uint16_t;
-typedef unsigned int       uint32_t;
+typedef unsigned char uint8_t;
+typedef unsigned short uint16_t;
+typedef unsigned int uint32_t;
 typedef unsigned long long uint64_t;
-typedef signed int         int32_t;
-typedef short int          int16_t;
-struct __align__(128) CakeTensorMap { uint64_t opaque[16]; };
+typedef signed int int32_t;
+typedef short int int16_t;
+struct __align__(128) CakeTensorMap {
+  uint64_t opaque[16];
+};
 template <int N>
-struct __align__(128) CakeTensorMapPack { CakeTensorMap maps[N]; };
+struct __align__(128) CakeTensorMapPack {
+  CakeTensorMap maps[N];
+};
 
-typedef struct __align__(64) { uint64_t opaque[16]; } CUtensorMap;
+typedef struct __align__(64) {
+  uint64_t opaque[16];
+} CUtensorMap;
 
 #include <cuda_bf16.h>
 
 __device__ __forceinline__ int make_warp_uniform(int x) {
-    int result;
-    asm volatile("shfl.sync.idx.b32 %0, %1, 0, 0x1F, 0xFFFFFFFF;"
-                 : "=r"(result) : "r"(x));
-    return result;
+  int result;
+  asm volatile("shfl.sync.idx.b32 %0, %1, 0, 0x1F, 0xFFFFFFFF;" : "=r"(result) : "r"(x));
+  return result;
 }
 
 #define CAKE_INF CUDART_INF_F
@@ -47,113 +52,116 @@ __device__ __forceinline__ int make_warp_uniform(int x) {
 
 extern "C" {
 
-__global__ __launch_bounds__(128, 1) void
-kernel_cake_blackwell_router_gemm_m7_k7168(__nv_bfloat16* __restrict__ mat_a, __nv_bfloat16* __restrict__ mat_b, float* __restrict__ out_f32, __nv_bfloat16* __restrict__ out_bf16, int num_experts, int out_is_bf16)
-{
-    const int tid = threadIdx.x;
-    const int warp = make_warp_uniform(tid / 32);
-    const int lane = tid % 32;
+__global__ __launch_bounds__(128, 1) void kernel_cake_blackwell_router_gemm_m7_k7168(
+    __nv_bfloat16* __restrict__ mat_a, __nv_bfloat16* __restrict__ mat_b,
+    float* __restrict__ out_f32, __nv_bfloat16* __restrict__ out_bf16, int num_experts,
+    int out_is_bf16) {
+  const int tid = threadIdx.x;
+  const int warp = make_warp_uniform(tid / 32);
+  const int lane = tid % 32;
 
-    extern __shared__ __align__(1024) char smem_raw[];
-    int smem;
-    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+  extern __shared__ __align__(1024) char smem_raw[];
+  int smem;
+  smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
 
-    const int bid = blockIdx.x;
-    const int num_bids = gridDim.x;
+  const int bid = blockIdx.x;
+  const int num_bids = gridDim.x;
 
-    // Kernel setup ops
-    float* red = reinterpret_cast<float*>(smem_raw + 0);
-    const int red_addr = smem + 0;
+  // Kernel setup ops
+  float* red = reinterpret_cast<float*>(smem_raw + 0);
+  const int red_addr = smem + 0;
 
-    // === Task calls (dependency order) ===
-    int expert = blockIdx.x;
-    float acc[7];
-    #pragma unroll
-    for (int m = 0; m < 7; m++) {
-        acc[m] = 0.0f;
-    }
-    asm volatile("griddepcontrol.wait;" ::: "memory");
-    #pragma unroll
-    for (int ki = 0; ki < 7; ki++) {
-        int k_base = ki * 1024 + tid * 8;
-        float _vec_load_0[8];
-        {
-            const uint4* _vptr_0 = reinterpret_cast<const uint4*>(mat_b + (expert * 7168 + k_base) + 0);
-            uint4 _vld_0[1];
-            #pragma unroll
-            for (int _blk = 0; _blk < 1; _blk++) {
-                _vld_0[_blk] = _vptr_0[_blk];
-                uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
-                #pragma unroll
-                for (int _pair = 0; _pair < 4; _pair++) {
-                    asm volatile(
-                        "{\n\t"
-                        "shl.b32 %0, %2, 16;\n\t"
-                        "and.b32 %1, %2, 0xffff0000;\n\t"
-                        "}\n"
-                        : "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[1])
-                        : "r"(_vpairs_0[_pair]));
-                }
-            }
+  // === Task calls (dependency order) ===
+  int expert = blockIdx.x;
+  float acc[7];
+#pragma unroll
+  for (int m = 0; m < 7; m++) {
+    acc[m] = 0.0f;
+  }
+  asm volatile("griddepcontrol.wait;" ::: "memory");
+#pragma unroll
+  for (int ki = 0; ki < 7; ki++) {
+    int k_base = ki * 1024 + tid * 8;
+    float _vec_load_0[8];
+    {
+      const uint4* _vptr_0 = reinterpret_cast<const uint4*>(mat_b + (expert * 7168 + k_base) + 0);
+      uint4 _vld_0[1];
+#pragma unroll
+      for (int _blk = 0; _blk < 1; _blk++) {
+        _vld_0[_blk] = _vptr_0[_blk];
+        uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
+#pragma unroll
+        for (int _pair = 0; _pair < 4; _pair++) {
+          asm volatile(
+              "{\n\t"
+              "shl.b32 %0, %2, 16;\n\t"
+              "and.b32 %1, %2, 0xffff0000;\n\t"
+              "}\n"
+              : "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[0]),
+                "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[1])
+              : "r"(_vpairs_0[_pair]));
         }
-        #pragma unroll
-        for (int m_1 = 0; m_1 < 7; m_1++) {
-            float _vec_load_1[8];
-            {
-                const uint4* _vptr_1 = reinterpret_cast<const uint4*>(mat_a + (m_1 * 7168 + k_base) + 0);
-                uint4 _vld_1[1];
-                #pragma unroll
-                for (int _blk = 0; _blk < 1; _blk++) {
-                    _vld_1[_blk] = _vptr_1[_blk];
-                    uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
-                    #pragma unroll
-                    for (int _pair = 0; _pair < 4; _pair++) {
-                        asm volatile(
-                            "{\n\t"
-                            "shl.b32 %0, %2, 16;\n\t"
-                            "and.b32 %1, %2, 0xffff0000;\n\t"
-                            "}\n"
-                            : "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[1])
-                            : "r"(_vpairs_1[_pair]));
-                    }
-                }
-            }
-            #pragma unroll
-            for (int j = 0; j < 8; j++) {
-                float _fma_0 = __fmaf_rn(_vec_load_1[j], _vec_load_0[j], acc[m_1]);
-                acc[m_1] = _fma_0;
-            }
-        }
+      }
     }
-    #pragma unroll
-    for (int m_2 = 0; m_2 < 7; m_2++) {
-        float _warp_reduce_0 = acc[m_2];
-        #pragma unroll
-        for (int offset = 16; offset > 0; offset >>= 1)
-            _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
-        float warp_sum = _warp_reduce_0;
-        if (lane == 0) {
-            red[m_2 * 4 + warp] = warp_sum;
+#pragma unroll
+    for (int m_1 = 0; m_1 < 7; m_1++) {
+      float _vec_load_1[8];
+      {
+        const uint4* _vptr_1 = reinterpret_cast<const uint4*>(mat_a + (m_1 * 7168 + k_base) + 0);
+        uint4 _vld_1[1];
+#pragma unroll
+        for (int _blk = 0; _blk < 1; _blk++) {
+          _vld_1[_blk] = _vptr_1[_blk];
+          uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
+#pragma unroll
+          for (int _pair = 0; _pair < 4; _pair++) {
+            asm volatile(
+                "{\n\t"
+                "shl.b32 %0, %2, 16;\n\t"
+                "and.b32 %1, %2, 0xffff0000;\n\t"
+                "}\n"
+                : "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[0]),
+                  "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[1])
+                : "r"(_vpairs_1[_pair]));
+          }
         }
+      }
+#pragma unroll
+      for (int j = 0; j < 8; j++) {
+        float _fma_0 = __fmaf_rn(_vec_load_1[j], _vec_load_0[j], acc[m_1]);
+        acc[m_1] = _fma_0;
+      }
     }
-    asm volatile("barrier.sync 2, 128;" ::: "memory");
-    if (warp == 0) {
-        if (lane < 7) {
-            int m_3 = lane;
-            float total = red[m_3 * 4];
-            #pragma unroll
-            for (int source_warp = 1; source_warp < 4; source_warp++) {
-                total = total + red[m_3 * 4 + source_warp];
-            }
-            int offset = m_3 * num_experts + expert;
-            if (out_is_bf16 == 0) {
-                *(reinterpret_cast<float*>(out_f32 + offset) + (0)) = total;
-            } else {
-                *(reinterpret_cast<__nv_bfloat16*>(out_bf16 + offset) + (0)) = __float2bfloat16_rn(total);
-            }
-        }
+  }
+#pragma unroll
+  for (int m_2 = 0; m_2 < 7; m_2++) {
+    float _warp_reduce_0 = acc[m_2];
+#pragma unroll
+    for (int offset = 16; offset > 0; offset >>= 1)
+      _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
+    float warp_sum = _warp_reduce_0;
+    if (lane == 0) {
+      red[m_2 * 4 + warp] = warp_sum;
     }
-    asm volatile("griddepcontrol.launch_dependents;" ::: "memory");
+  }
+  asm volatile("barrier.sync 2, 128;" ::: "memory");
+  if (warp == 0) {
+    if (lane < 7) {
+      int m_3 = lane;
+      float total = red[m_3 * 4];
+#pragma unroll
+      for (int source_warp = 1; source_warp < 4; source_warp++) {
+        total = total + red[m_3 * 4 + source_warp];
+      }
+      int offset = m_3 * num_experts + expert;
+      if (out_is_bf16 == 0) {
+        *(reinterpret_cast<float*>(out_f32 + offset) + (0)) = total;
+      } else {
+        *(reinterpret_cast<__nv_bfloat16*>(out_bf16 + offset) + (0)) = __float2bfloat16_rn(total);
+      }
+    }
+  }
+  asm volatile("griddepcontrol.launch_dependents;" ::: "memory");
 }
 
-} // extern "C"
+}  // extern "C"

--- a/csrc/cake_router_gemm/cake_router_gemm_m8_k6144_device.cu
+++ b/csrc/cake_router_gemm/cake_router_gemm_m8_k6144_device.cu
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) 2026 by FlashInfer team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+typedef unsigned char      uint8_t;
+typedef unsigned short     uint16_t;
+typedef unsigned int       uint32_t;
+typedef unsigned long long uint64_t;
+typedef signed int         int32_t;
+typedef short int          int16_t;
+struct __align__(128) CakeTensorMap { uint64_t opaque[16]; };
+template <int N>
+struct __align__(128) CakeTensorMapPack { CakeTensorMap maps[N]; };
+
+typedef struct __align__(64) { uint64_t opaque[16]; } CUtensorMap;
+
+#include <cuda_bf16.h>
+
+__device__ __forceinline__ int make_warp_uniform(int x) {
+    int result;
+    asm volatile("shfl.sync.idx.b32 %0, %1, 0, 0x1F, 0xFFFFFFFF;"
+                 : "=r"(result) : "r"(x));
+    return result;
+}
+
+#define CAKE_INF CUDART_INF_F
+#define NUM_MAIN_STAGES 1
+#define SMEM_RED_OFF 0
+#define SMEM_RED_STAGE_BYTES 128
+#define SMEM_RED_STRIDE 128
+#define SMEM_TOTAL 128
+#define THREADS 128
+
+#include <math_constants.h>
+
+extern "C" {
+
+__global__ __launch_bounds__(128, 1) void
+kernel_cake_blackwell_router_gemm_m8_k6144(__nv_bfloat16* __restrict__ mat_a, __nv_bfloat16* __restrict__ mat_b, float* __restrict__ out_f32, __nv_bfloat16* __restrict__ out_bf16, int num_experts, int out_is_bf16)
+{
+    const int tid = threadIdx.x;
+    const int warp = make_warp_uniform(tid / 32);
+    const int lane = tid % 32;
+
+    extern __shared__ __align__(1024) char smem_raw[];
+    int smem;
+    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+
+    const int bid = blockIdx.x;
+    const int num_bids = gridDim.x;
+
+    // Kernel setup ops
+    float* red = reinterpret_cast<float*>(smem_raw + 0);
+    const int red_addr = smem + 0;
+
+    // === Task calls (dependency order) ===
+    int expert = blockIdx.x;
+    float acc[8];
+    #pragma unroll
+    for (int m = 0; m < 8; m++) {
+        acc[m] = 0.0f;
+    }
+    asm volatile("griddepcontrol.wait;" ::: "memory");
+    #pragma unroll
+    for (int ki = 0; ki < 6; ki++) {
+        int k_base = ki * 1024 + tid * 8;
+        float _vec_load_0[8];
+        {
+            const uint4* _vptr_0 = reinterpret_cast<const uint4*>(mat_b + (expert * 6144 + k_base) + 0);
+            uint4 _vld_0[1];
+            #pragma unroll
+            for (int _blk = 0; _blk < 1; _blk++) {
+                _vld_0[_blk] = _vptr_0[_blk];
+                uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
+                #pragma unroll
+                for (int _pair = 0; _pair < 4; _pair++) {
+                    asm volatile(
+                        "{\n\t"
+                        "shl.b32 %0, %2, 16;\n\t"
+                        "and.b32 %1, %2, 0xffff0000;\n\t"
+                        "}\n"
+                        : "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[1])
+                        : "r"(_vpairs_0[_pair]));
+                }
+            }
+        }
+        #pragma unroll
+        for (int m_1 = 0; m_1 < 8; m_1++) {
+            float _vec_load_1[8];
+            {
+                const uint4* _vptr_1 = reinterpret_cast<const uint4*>(mat_a + (m_1 * 6144 + k_base) + 0);
+                uint4 _vld_1[1];
+                #pragma unroll
+                for (int _blk = 0; _blk < 1; _blk++) {
+                    _vld_1[_blk] = _vptr_1[_blk];
+                    uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
+                    #pragma unroll
+                    for (int _pair = 0; _pair < 4; _pair++) {
+                        asm volatile(
+                            "{\n\t"
+                            "shl.b32 %0, %2, 16;\n\t"
+                            "and.b32 %1, %2, 0xffff0000;\n\t"
+                            "}\n"
+                            : "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[1])
+                            : "r"(_vpairs_1[_pair]));
+                    }
+                }
+            }
+            #pragma unroll
+            for (int j = 0; j < 8; j++) {
+                float _fma_0 = __fmaf_rn(_vec_load_1[j], _vec_load_0[j], acc[m_1]);
+                acc[m_1] = _fma_0;
+            }
+        }
+    }
+    #pragma unroll
+    for (int m_2 = 0; m_2 < 8; m_2++) {
+        float _warp_reduce_0 = acc[m_2];
+        #pragma unroll
+        for (int offset = 16; offset > 0; offset >>= 1)
+            _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
+        float warp_sum = _warp_reduce_0;
+        if (lane == 0) {
+            red[m_2 * 4 + warp] = warp_sum;
+        }
+    }
+    asm volatile("barrier.sync 2, 128;" ::: "memory");
+    if (warp == 0) {
+        if (lane < 8) {
+            int m_3 = lane;
+            float total = red[m_3 * 4];
+            #pragma unroll
+            for (int source_warp = 1; source_warp < 4; source_warp++) {
+                total = total + red[m_3 * 4 + source_warp];
+            }
+            int offset = m_3 * num_experts + expert;
+            if (out_is_bf16 == 0) {
+                *(reinterpret_cast<float*>(out_f32 + offset) + (0)) = total;
+            } else {
+                *(reinterpret_cast<__nv_bfloat16*>(out_bf16 + offset) + (0)) = __float2bfloat16_rn(total);
+            }
+        }
+    }
+    asm volatile("griddepcontrol.launch_dependents;" ::: "memory");
+}
+
+} // extern "C"

--- a/csrc/cake_router_gemm/cake_router_gemm_m8_k6144_device.cu
+++ b/csrc/cake_router_gemm/cake_router_gemm_m8_k6144_device.cu
@@ -14,25 +14,30 @@
  * limitations under the License.
  */
 
-typedef unsigned char      uint8_t;
-typedef unsigned short     uint16_t;
-typedef unsigned int       uint32_t;
+typedef unsigned char uint8_t;
+typedef unsigned short uint16_t;
+typedef unsigned int uint32_t;
 typedef unsigned long long uint64_t;
-typedef signed int         int32_t;
-typedef short int          int16_t;
-struct __align__(128) CakeTensorMap { uint64_t opaque[16]; };
+typedef signed int int32_t;
+typedef short int int16_t;
+struct __align__(128) CakeTensorMap {
+  uint64_t opaque[16];
+};
 template <int N>
-struct __align__(128) CakeTensorMapPack { CakeTensorMap maps[N]; };
+struct __align__(128) CakeTensorMapPack {
+  CakeTensorMap maps[N];
+};
 
-typedef struct __align__(64) { uint64_t opaque[16]; } CUtensorMap;
+typedef struct __align__(64) {
+  uint64_t opaque[16];
+} CUtensorMap;
 
 #include <cuda_bf16.h>
 
 __device__ __forceinline__ int make_warp_uniform(int x) {
-    int result;
-    asm volatile("shfl.sync.idx.b32 %0, %1, 0, 0x1F, 0xFFFFFFFF;"
-                 : "=r"(result) : "r"(x));
-    return result;
+  int result;
+  asm volatile("shfl.sync.idx.b32 %0, %1, 0, 0x1F, 0xFFFFFFFF;" : "=r"(result) : "r"(x));
+  return result;
 }
 
 #define CAKE_INF CUDART_INF_F
@@ -47,113 +52,116 @@ __device__ __forceinline__ int make_warp_uniform(int x) {
 
 extern "C" {
 
-__global__ __launch_bounds__(128, 1) void
-kernel_cake_blackwell_router_gemm_m8_k6144(__nv_bfloat16* __restrict__ mat_a, __nv_bfloat16* __restrict__ mat_b, float* __restrict__ out_f32, __nv_bfloat16* __restrict__ out_bf16, int num_experts, int out_is_bf16)
-{
-    const int tid = threadIdx.x;
-    const int warp = make_warp_uniform(tid / 32);
-    const int lane = tid % 32;
+__global__ __launch_bounds__(128, 1) void kernel_cake_blackwell_router_gemm_m8_k6144(
+    __nv_bfloat16* __restrict__ mat_a, __nv_bfloat16* __restrict__ mat_b,
+    float* __restrict__ out_f32, __nv_bfloat16* __restrict__ out_bf16, int num_experts,
+    int out_is_bf16) {
+  const int tid = threadIdx.x;
+  const int warp = make_warp_uniform(tid / 32);
+  const int lane = tid % 32;
 
-    extern __shared__ __align__(1024) char smem_raw[];
-    int smem;
-    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+  extern __shared__ __align__(1024) char smem_raw[];
+  int smem;
+  smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
 
-    const int bid = blockIdx.x;
-    const int num_bids = gridDim.x;
+  const int bid = blockIdx.x;
+  const int num_bids = gridDim.x;
 
-    // Kernel setup ops
-    float* red = reinterpret_cast<float*>(smem_raw + 0);
-    const int red_addr = smem + 0;
+  // Kernel setup ops
+  float* red = reinterpret_cast<float*>(smem_raw + 0);
+  const int red_addr = smem + 0;
 
-    // === Task calls (dependency order) ===
-    int expert = blockIdx.x;
-    float acc[8];
-    #pragma unroll
-    for (int m = 0; m < 8; m++) {
-        acc[m] = 0.0f;
-    }
-    asm volatile("griddepcontrol.wait;" ::: "memory");
-    #pragma unroll
-    for (int ki = 0; ki < 6; ki++) {
-        int k_base = ki * 1024 + tid * 8;
-        float _vec_load_0[8];
-        {
-            const uint4* _vptr_0 = reinterpret_cast<const uint4*>(mat_b + (expert * 6144 + k_base) + 0);
-            uint4 _vld_0[1];
-            #pragma unroll
-            for (int _blk = 0; _blk < 1; _blk++) {
-                _vld_0[_blk] = _vptr_0[_blk];
-                uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
-                #pragma unroll
-                for (int _pair = 0; _pair < 4; _pair++) {
-                    asm volatile(
-                        "{\n\t"
-                        "shl.b32 %0, %2, 16;\n\t"
-                        "and.b32 %1, %2, 0xffff0000;\n\t"
-                        "}\n"
-                        : "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[1])
-                        : "r"(_vpairs_0[_pair]));
-                }
-            }
+  // === Task calls (dependency order) ===
+  int expert = blockIdx.x;
+  float acc[8];
+#pragma unroll
+  for (int m = 0; m < 8; m++) {
+    acc[m] = 0.0f;
+  }
+  asm volatile("griddepcontrol.wait;" ::: "memory");
+#pragma unroll
+  for (int ki = 0; ki < 6; ki++) {
+    int k_base = ki * 1024 + tid * 8;
+    float _vec_load_0[8];
+    {
+      const uint4* _vptr_0 = reinterpret_cast<const uint4*>(mat_b + (expert * 6144 + k_base) + 0);
+      uint4 _vld_0[1];
+#pragma unroll
+      for (int _blk = 0; _blk < 1; _blk++) {
+        _vld_0[_blk] = _vptr_0[_blk];
+        uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
+#pragma unroll
+        for (int _pair = 0; _pair < 4; _pair++) {
+          asm volatile(
+              "{\n\t"
+              "shl.b32 %0, %2, 16;\n\t"
+              "and.b32 %1, %2, 0xffff0000;\n\t"
+              "}\n"
+              : "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[0]),
+                "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[1])
+              : "r"(_vpairs_0[_pair]));
         }
-        #pragma unroll
-        for (int m_1 = 0; m_1 < 8; m_1++) {
-            float _vec_load_1[8];
-            {
-                const uint4* _vptr_1 = reinterpret_cast<const uint4*>(mat_a + (m_1 * 6144 + k_base) + 0);
-                uint4 _vld_1[1];
-                #pragma unroll
-                for (int _blk = 0; _blk < 1; _blk++) {
-                    _vld_1[_blk] = _vptr_1[_blk];
-                    uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
-                    #pragma unroll
-                    for (int _pair = 0; _pair < 4; _pair++) {
-                        asm volatile(
-                            "{\n\t"
-                            "shl.b32 %0, %2, 16;\n\t"
-                            "and.b32 %1, %2, 0xffff0000;\n\t"
-                            "}\n"
-                            : "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[1])
-                            : "r"(_vpairs_1[_pair]));
-                    }
-                }
-            }
-            #pragma unroll
-            for (int j = 0; j < 8; j++) {
-                float _fma_0 = __fmaf_rn(_vec_load_1[j], _vec_load_0[j], acc[m_1]);
-                acc[m_1] = _fma_0;
-            }
-        }
+      }
     }
-    #pragma unroll
-    for (int m_2 = 0; m_2 < 8; m_2++) {
-        float _warp_reduce_0 = acc[m_2];
-        #pragma unroll
-        for (int offset = 16; offset > 0; offset >>= 1)
-            _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
-        float warp_sum = _warp_reduce_0;
-        if (lane == 0) {
-            red[m_2 * 4 + warp] = warp_sum;
+#pragma unroll
+    for (int m_1 = 0; m_1 < 8; m_1++) {
+      float _vec_load_1[8];
+      {
+        const uint4* _vptr_1 = reinterpret_cast<const uint4*>(mat_a + (m_1 * 6144 + k_base) + 0);
+        uint4 _vld_1[1];
+#pragma unroll
+        for (int _blk = 0; _blk < 1; _blk++) {
+          _vld_1[_blk] = _vptr_1[_blk];
+          uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
+#pragma unroll
+          for (int _pair = 0; _pair < 4; _pair++) {
+            asm volatile(
+                "{\n\t"
+                "shl.b32 %0, %2, 16;\n\t"
+                "and.b32 %1, %2, 0xffff0000;\n\t"
+                "}\n"
+                : "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[0]),
+                  "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[1])
+                : "r"(_vpairs_1[_pair]));
+          }
         }
+      }
+#pragma unroll
+      for (int j = 0; j < 8; j++) {
+        float _fma_0 = __fmaf_rn(_vec_load_1[j], _vec_load_0[j], acc[m_1]);
+        acc[m_1] = _fma_0;
+      }
     }
-    asm volatile("barrier.sync 2, 128;" ::: "memory");
-    if (warp == 0) {
-        if (lane < 8) {
-            int m_3 = lane;
-            float total = red[m_3 * 4];
-            #pragma unroll
-            for (int source_warp = 1; source_warp < 4; source_warp++) {
-                total = total + red[m_3 * 4 + source_warp];
-            }
-            int offset = m_3 * num_experts + expert;
-            if (out_is_bf16 == 0) {
-                *(reinterpret_cast<float*>(out_f32 + offset) + (0)) = total;
-            } else {
-                *(reinterpret_cast<__nv_bfloat16*>(out_bf16 + offset) + (0)) = __float2bfloat16_rn(total);
-            }
-        }
+  }
+#pragma unroll
+  for (int m_2 = 0; m_2 < 8; m_2++) {
+    float _warp_reduce_0 = acc[m_2];
+#pragma unroll
+    for (int offset = 16; offset > 0; offset >>= 1)
+      _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
+    float warp_sum = _warp_reduce_0;
+    if (lane == 0) {
+      red[m_2 * 4 + warp] = warp_sum;
     }
-    asm volatile("griddepcontrol.launch_dependents;" ::: "memory");
+  }
+  asm volatile("barrier.sync 2, 128;" ::: "memory");
+  if (warp == 0) {
+    if (lane < 8) {
+      int m_3 = lane;
+      float total = red[m_3 * 4];
+#pragma unroll
+      for (int source_warp = 1; source_warp < 4; source_warp++) {
+        total = total + red[m_3 * 4 + source_warp];
+      }
+      int offset = m_3 * num_experts + expert;
+      if (out_is_bf16 == 0) {
+        *(reinterpret_cast<float*>(out_f32 + offset) + (0)) = total;
+      } else {
+        *(reinterpret_cast<__nv_bfloat16*>(out_bf16 + offset) + (0)) = __float2bfloat16_rn(total);
+      }
+    }
+  }
+  asm volatile("griddepcontrol.launch_dependents;" ::: "memory");
 }
 
-} // extern "C"
+}  // extern "C"

--- a/csrc/cake_router_gemm/cake_router_gemm_m8_k7168_device.cu
+++ b/csrc/cake_router_gemm/cake_router_gemm_m8_k7168_device.cu
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) 2026 by FlashInfer team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+typedef unsigned char      uint8_t;
+typedef unsigned short     uint16_t;
+typedef unsigned int       uint32_t;
+typedef unsigned long long uint64_t;
+typedef signed int         int32_t;
+typedef short int          int16_t;
+struct __align__(128) CakeTensorMap { uint64_t opaque[16]; };
+template <int N>
+struct __align__(128) CakeTensorMapPack { CakeTensorMap maps[N]; };
+
+typedef struct __align__(64) { uint64_t opaque[16]; } CUtensorMap;
+
+#include <cuda_bf16.h>
+
+__device__ __forceinline__ int make_warp_uniform(int x) {
+    int result;
+    asm volatile("shfl.sync.idx.b32 %0, %1, 0, 0x1F, 0xFFFFFFFF;"
+                 : "=r"(result) : "r"(x));
+    return result;
+}
+
+#define CAKE_INF CUDART_INF_F
+#define NUM_MAIN_STAGES 1
+#define SMEM_RED_OFF 0
+#define SMEM_RED_STAGE_BYTES 128
+#define SMEM_RED_STRIDE 128
+#define SMEM_TOTAL 128
+#define THREADS 128
+
+#include <math_constants.h>
+
+extern "C" {
+
+__global__ __launch_bounds__(128, 1) void
+kernel_cake_blackwell_router_gemm_m8_k7168(__nv_bfloat16* __restrict__ mat_a, __nv_bfloat16* __restrict__ mat_b, float* __restrict__ out_f32, __nv_bfloat16* __restrict__ out_bf16, int num_experts, int out_is_bf16)
+{
+    const int tid = threadIdx.x;
+    const int warp = make_warp_uniform(tid / 32);
+    const int lane = tid % 32;
+
+    extern __shared__ __align__(1024) char smem_raw[];
+    int smem;
+    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+
+    const int bid = blockIdx.x;
+    const int num_bids = gridDim.x;
+
+    // Kernel setup ops
+    float* red = reinterpret_cast<float*>(smem_raw + 0);
+    const int red_addr = smem + 0;
+
+    // === Task calls (dependency order) ===
+    int expert = blockIdx.x;
+    float acc[8];
+    #pragma unroll
+    for (int m = 0; m < 8; m++) {
+        acc[m] = 0.0f;
+    }
+    asm volatile("griddepcontrol.wait;" ::: "memory");
+    #pragma unroll
+    for (int ki = 0; ki < 7; ki++) {
+        int k_base = ki * 1024 + tid * 8;
+        float _vec_load_0[8];
+        {
+            const uint4* _vptr_0 = reinterpret_cast<const uint4*>(mat_b + (expert * 7168 + k_base) + 0);
+            uint4 _vld_0[1];
+            #pragma unroll
+            for (int _blk = 0; _blk < 1; _blk++) {
+                _vld_0[_blk] = _vptr_0[_blk];
+                uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
+                #pragma unroll
+                for (int _pair = 0; _pair < 4; _pair++) {
+                    asm volatile(
+                        "{\n\t"
+                        "shl.b32 %0, %2, 16;\n\t"
+                        "and.b32 %1, %2, 0xffff0000;\n\t"
+                        "}\n"
+                        : "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[1])
+                        : "r"(_vpairs_0[_pair]));
+                }
+            }
+        }
+        #pragma unroll
+        for (int m_1 = 0; m_1 < 8; m_1++) {
+            float _vec_load_1[8];
+            {
+                const uint4* _vptr_1 = reinterpret_cast<const uint4*>(mat_a + (m_1 * 7168 + k_base) + 0);
+                uint4 _vld_1[1];
+                #pragma unroll
+                for (int _blk = 0; _blk < 1; _blk++) {
+                    _vld_1[_blk] = _vptr_1[_blk];
+                    uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
+                    #pragma unroll
+                    for (int _pair = 0; _pair < 4; _pair++) {
+                        asm volatile(
+                            "{\n\t"
+                            "shl.b32 %0, %2, 16;\n\t"
+                            "and.b32 %1, %2, 0xffff0000;\n\t"
+                            "}\n"
+                            : "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[1])
+                            : "r"(_vpairs_1[_pair]));
+                    }
+                }
+            }
+            #pragma unroll
+            for (int j = 0; j < 8; j++) {
+                float _fma_0 = __fmaf_rn(_vec_load_1[j], _vec_load_0[j], acc[m_1]);
+                acc[m_1] = _fma_0;
+            }
+        }
+    }
+    #pragma unroll
+    for (int m_2 = 0; m_2 < 8; m_2++) {
+        float _warp_reduce_0 = acc[m_2];
+        #pragma unroll
+        for (int offset = 16; offset > 0; offset >>= 1)
+            _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
+        float warp_sum = _warp_reduce_0;
+        if (lane == 0) {
+            red[m_2 * 4 + warp] = warp_sum;
+        }
+    }
+    asm volatile("barrier.sync 2, 128;" ::: "memory");
+    if (warp == 0) {
+        if (lane < 8) {
+            int m_3 = lane;
+            float total = red[m_3 * 4];
+            #pragma unroll
+            for (int source_warp = 1; source_warp < 4; source_warp++) {
+                total = total + red[m_3 * 4 + source_warp];
+            }
+            int offset = m_3 * num_experts + expert;
+            if (out_is_bf16 == 0) {
+                *(reinterpret_cast<float*>(out_f32 + offset) + (0)) = total;
+            } else {
+                *(reinterpret_cast<__nv_bfloat16*>(out_bf16 + offset) + (0)) = __float2bfloat16_rn(total);
+            }
+        }
+    }
+    asm volatile("griddepcontrol.launch_dependents;" ::: "memory");
+}
+
+} // extern "C"

--- a/csrc/cake_router_gemm/cake_router_gemm_m8_k7168_device.cu
+++ b/csrc/cake_router_gemm/cake_router_gemm_m8_k7168_device.cu
@@ -14,25 +14,30 @@
  * limitations under the License.
  */
 
-typedef unsigned char      uint8_t;
-typedef unsigned short     uint16_t;
-typedef unsigned int       uint32_t;
+typedef unsigned char uint8_t;
+typedef unsigned short uint16_t;
+typedef unsigned int uint32_t;
 typedef unsigned long long uint64_t;
-typedef signed int         int32_t;
-typedef short int          int16_t;
-struct __align__(128) CakeTensorMap { uint64_t opaque[16]; };
+typedef signed int int32_t;
+typedef short int int16_t;
+struct __align__(128) CakeTensorMap {
+  uint64_t opaque[16];
+};
 template <int N>
-struct __align__(128) CakeTensorMapPack { CakeTensorMap maps[N]; };
+struct __align__(128) CakeTensorMapPack {
+  CakeTensorMap maps[N];
+};
 
-typedef struct __align__(64) { uint64_t opaque[16]; } CUtensorMap;
+typedef struct __align__(64) {
+  uint64_t opaque[16];
+} CUtensorMap;
 
 #include <cuda_bf16.h>
 
 __device__ __forceinline__ int make_warp_uniform(int x) {
-    int result;
-    asm volatile("shfl.sync.idx.b32 %0, %1, 0, 0x1F, 0xFFFFFFFF;"
-                 : "=r"(result) : "r"(x));
-    return result;
+  int result;
+  asm volatile("shfl.sync.idx.b32 %0, %1, 0, 0x1F, 0xFFFFFFFF;" : "=r"(result) : "r"(x));
+  return result;
 }
 
 #define CAKE_INF CUDART_INF_F
@@ -47,113 +52,116 @@ __device__ __forceinline__ int make_warp_uniform(int x) {
 
 extern "C" {
 
-__global__ __launch_bounds__(128, 1) void
-kernel_cake_blackwell_router_gemm_m8_k7168(__nv_bfloat16* __restrict__ mat_a, __nv_bfloat16* __restrict__ mat_b, float* __restrict__ out_f32, __nv_bfloat16* __restrict__ out_bf16, int num_experts, int out_is_bf16)
-{
-    const int tid = threadIdx.x;
-    const int warp = make_warp_uniform(tid / 32);
-    const int lane = tid % 32;
+__global__ __launch_bounds__(128, 1) void kernel_cake_blackwell_router_gemm_m8_k7168(
+    __nv_bfloat16* __restrict__ mat_a, __nv_bfloat16* __restrict__ mat_b,
+    float* __restrict__ out_f32, __nv_bfloat16* __restrict__ out_bf16, int num_experts,
+    int out_is_bf16) {
+  const int tid = threadIdx.x;
+  const int warp = make_warp_uniform(tid / 32);
+  const int lane = tid % 32;
 
-    extern __shared__ __align__(1024) char smem_raw[];
-    int smem;
-    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+  extern __shared__ __align__(1024) char smem_raw[];
+  int smem;
+  smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
 
-    const int bid = blockIdx.x;
-    const int num_bids = gridDim.x;
+  const int bid = blockIdx.x;
+  const int num_bids = gridDim.x;
 
-    // Kernel setup ops
-    float* red = reinterpret_cast<float*>(smem_raw + 0);
-    const int red_addr = smem + 0;
+  // Kernel setup ops
+  float* red = reinterpret_cast<float*>(smem_raw + 0);
+  const int red_addr = smem + 0;
 
-    // === Task calls (dependency order) ===
-    int expert = blockIdx.x;
-    float acc[8];
-    #pragma unroll
-    for (int m = 0; m < 8; m++) {
-        acc[m] = 0.0f;
-    }
-    asm volatile("griddepcontrol.wait;" ::: "memory");
-    #pragma unroll
-    for (int ki = 0; ki < 7; ki++) {
-        int k_base = ki * 1024 + tid * 8;
-        float _vec_load_0[8];
-        {
-            const uint4* _vptr_0 = reinterpret_cast<const uint4*>(mat_b + (expert * 7168 + k_base) + 0);
-            uint4 _vld_0[1];
-            #pragma unroll
-            for (int _blk = 0; _blk < 1; _blk++) {
-                _vld_0[_blk] = _vptr_0[_blk];
-                uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
-                #pragma unroll
-                for (int _pair = 0; _pair < 4; _pair++) {
-                    asm volatile(
-                        "{\n\t"
-                        "shl.b32 %0, %2, 16;\n\t"
-                        "and.b32 %1, %2, 0xffff0000;\n\t"
-                        "}\n"
-                        : "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[1])
-                        : "r"(_vpairs_0[_pair]));
-                }
-            }
+  // === Task calls (dependency order) ===
+  int expert = blockIdx.x;
+  float acc[8];
+#pragma unroll
+  for (int m = 0; m < 8; m++) {
+    acc[m] = 0.0f;
+  }
+  asm volatile("griddepcontrol.wait;" ::: "memory");
+#pragma unroll
+  for (int ki = 0; ki < 7; ki++) {
+    int k_base = ki * 1024 + tid * 8;
+    float _vec_load_0[8];
+    {
+      const uint4* _vptr_0 = reinterpret_cast<const uint4*>(mat_b + (expert * 7168 + k_base) + 0);
+      uint4 _vld_0[1];
+#pragma unroll
+      for (int _blk = 0; _blk < 1; _blk++) {
+        _vld_0[_blk] = _vptr_0[_blk];
+        uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
+#pragma unroll
+        for (int _pair = 0; _pair < 4; _pair++) {
+          asm volatile(
+              "{\n\t"
+              "shl.b32 %0, %2, 16;\n\t"
+              "and.b32 %1, %2, 0xffff0000;\n\t"
+              "}\n"
+              : "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[0]),
+                "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[1])
+              : "r"(_vpairs_0[_pair]));
         }
-        #pragma unroll
-        for (int m_1 = 0; m_1 < 8; m_1++) {
-            float _vec_load_1[8];
-            {
-                const uint4* _vptr_1 = reinterpret_cast<const uint4*>(mat_a + (m_1 * 7168 + k_base) + 0);
-                uint4 _vld_1[1];
-                #pragma unroll
-                for (int _blk = 0; _blk < 1; _blk++) {
-                    _vld_1[_blk] = _vptr_1[_blk];
-                    uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
-                    #pragma unroll
-                    for (int _pair = 0; _pair < 4; _pair++) {
-                        asm volatile(
-                            "{\n\t"
-                            "shl.b32 %0, %2, 16;\n\t"
-                            "and.b32 %1, %2, 0xffff0000;\n\t"
-                            "}\n"
-                            : "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[1])
-                            : "r"(_vpairs_1[_pair]));
-                    }
-                }
-            }
-            #pragma unroll
-            for (int j = 0; j < 8; j++) {
-                float _fma_0 = __fmaf_rn(_vec_load_1[j], _vec_load_0[j], acc[m_1]);
-                acc[m_1] = _fma_0;
-            }
-        }
+      }
     }
-    #pragma unroll
-    for (int m_2 = 0; m_2 < 8; m_2++) {
-        float _warp_reduce_0 = acc[m_2];
-        #pragma unroll
-        for (int offset = 16; offset > 0; offset >>= 1)
-            _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
-        float warp_sum = _warp_reduce_0;
-        if (lane == 0) {
-            red[m_2 * 4 + warp] = warp_sum;
+#pragma unroll
+    for (int m_1 = 0; m_1 < 8; m_1++) {
+      float _vec_load_1[8];
+      {
+        const uint4* _vptr_1 = reinterpret_cast<const uint4*>(mat_a + (m_1 * 7168 + k_base) + 0);
+        uint4 _vld_1[1];
+#pragma unroll
+        for (int _blk = 0; _blk < 1; _blk++) {
+          _vld_1[_blk] = _vptr_1[_blk];
+          uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
+#pragma unroll
+          for (int _pair = 0; _pair < 4; _pair++) {
+            asm volatile(
+                "{\n\t"
+                "shl.b32 %0, %2, 16;\n\t"
+                "and.b32 %1, %2, 0xffff0000;\n\t"
+                "}\n"
+                : "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[0]),
+                  "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[1])
+                : "r"(_vpairs_1[_pair]));
+          }
         }
+      }
+#pragma unroll
+      for (int j = 0; j < 8; j++) {
+        float _fma_0 = __fmaf_rn(_vec_load_1[j], _vec_load_0[j], acc[m_1]);
+        acc[m_1] = _fma_0;
+      }
     }
-    asm volatile("barrier.sync 2, 128;" ::: "memory");
-    if (warp == 0) {
-        if (lane < 8) {
-            int m_3 = lane;
-            float total = red[m_3 * 4];
-            #pragma unroll
-            for (int source_warp = 1; source_warp < 4; source_warp++) {
-                total = total + red[m_3 * 4 + source_warp];
-            }
-            int offset = m_3 * num_experts + expert;
-            if (out_is_bf16 == 0) {
-                *(reinterpret_cast<float*>(out_f32 + offset) + (0)) = total;
-            } else {
-                *(reinterpret_cast<__nv_bfloat16*>(out_bf16 + offset) + (0)) = __float2bfloat16_rn(total);
-            }
-        }
+  }
+#pragma unroll
+  for (int m_2 = 0; m_2 < 8; m_2++) {
+    float _warp_reduce_0 = acc[m_2];
+#pragma unroll
+    for (int offset = 16; offset > 0; offset >>= 1)
+      _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
+    float warp_sum = _warp_reduce_0;
+    if (lane == 0) {
+      red[m_2 * 4 + warp] = warp_sum;
     }
-    asm volatile("griddepcontrol.launch_dependents;" ::: "memory");
+  }
+  asm volatile("barrier.sync 2, 128;" ::: "memory");
+  if (warp == 0) {
+    if (lane < 8) {
+      int m_3 = lane;
+      float total = red[m_3 * 4];
+#pragma unroll
+      for (int source_warp = 1; source_warp < 4; source_warp++) {
+        total = total + red[m_3 * 4 + source_warp];
+      }
+      int offset = m_3 * num_experts + expert;
+      if (out_is_bf16 == 0) {
+        *(reinterpret_cast<float*>(out_f32 + offset) + (0)) = total;
+      } else {
+        *(reinterpret_cast<__nv_bfloat16*>(out_bf16 + offset) + (0)) = __float2bfloat16_rn(total);
+      }
+    }
+  }
+  asm volatile("griddepcontrol.launch_dependents;" ::: "memory");
 }
 
-} // extern "C"
+}  // extern "C"

--- a/csrc/cake_router_gemm/cake_router_gemm_m9_k6144_device.cu
+++ b/csrc/cake_router_gemm/cake_router_gemm_m9_k6144_device.cu
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) 2026 by FlashInfer team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+typedef unsigned char      uint8_t;
+typedef unsigned short     uint16_t;
+typedef unsigned int       uint32_t;
+typedef unsigned long long uint64_t;
+typedef signed int         int32_t;
+typedef short int          int16_t;
+struct __align__(128) CakeTensorMap { uint64_t opaque[16]; };
+template <int N>
+struct __align__(128) CakeTensorMapPack { CakeTensorMap maps[N]; };
+
+typedef struct __align__(64) { uint64_t opaque[16]; } CUtensorMap;
+
+#include <cuda_bf16.h>
+
+__device__ __forceinline__ int make_warp_uniform(int x) {
+    int result;
+    asm volatile("shfl.sync.idx.b32 %0, %1, 0, 0x1F, 0xFFFFFFFF;"
+                 : "=r"(result) : "r"(x));
+    return result;
+}
+
+#define CAKE_INF CUDART_INF_F
+#define NUM_MAIN_STAGES 1
+#define SMEM_RED_OFF 0
+#define SMEM_RED_STAGE_BYTES 144
+#define SMEM_RED_STRIDE 144
+#define SMEM_TOTAL 256
+#define THREADS 128
+
+#include <math_constants.h>
+
+extern "C" {
+
+__global__ __launch_bounds__(128, 1) void
+kernel_cake_blackwell_router_gemm_m9_k6144(__nv_bfloat16* __restrict__ mat_a, __nv_bfloat16* __restrict__ mat_b, float* __restrict__ out_f32, __nv_bfloat16* __restrict__ out_bf16, int num_experts, int out_is_bf16)
+{
+    const int tid = threadIdx.x;
+    const int warp = make_warp_uniform(tid / 32);
+    const int lane = tid % 32;
+
+    extern __shared__ __align__(1024) char smem_raw[];
+    int smem;
+    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+
+    const int bid = blockIdx.x;
+    const int num_bids = gridDim.x;
+
+    // Kernel setup ops
+    float* red = reinterpret_cast<float*>(smem_raw + 0);
+    const int red_addr = smem + 0;
+
+    // === Task calls (dependency order) ===
+    int expert = blockIdx.x;
+    float acc[9];
+    #pragma unroll
+    for (int m = 0; m < 9; m++) {
+        acc[m] = 0.0f;
+    }
+    asm volatile("griddepcontrol.wait;" ::: "memory");
+    #pragma unroll
+    for (int ki = 0; ki < 6; ki++) {
+        int k_base = ki * 1024 + tid * 8;
+        float _vec_load_0[8];
+        {
+            const uint4* _vptr_0 = reinterpret_cast<const uint4*>(mat_b + (expert * 6144 + k_base) + 0);
+            uint4 _vld_0[1];
+            #pragma unroll
+            for (int _blk = 0; _blk < 1; _blk++) {
+                _vld_0[_blk] = _vptr_0[_blk];
+                uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
+                #pragma unroll
+                for (int _pair = 0; _pair < 4; _pair++) {
+                    asm volatile(
+                        "{\n\t"
+                        "shl.b32 %0, %2, 16;\n\t"
+                        "and.b32 %1, %2, 0xffff0000;\n\t"
+                        "}\n"
+                        : "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[1])
+                        : "r"(_vpairs_0[_pair]));
+                }
+            }
+        }
+        #pragma unroll
+        for (int m_1 = 0; m_1 < 9; m_1++) {
+            float _vec_load_1[8];
+            {
+                const uint4* _vptr_1 = reinterpret_cast<const uint4*>(mat_a + (m_1 * 6144 + k_base) + 0);
+                uint4 _vld_1[1];
+                #pragma unroll
+                for (int _blk = 0; _blk < 1; _blk++) {
+                    _vld_1[_blk] = _vptr_1[_blk];
+                    uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
+                    #pragma unroll
+                    for (int _pair = 0; _pair < 4; _pair++) {
+                        asm volatile(
+                            "{\n\t"
+                            "shl.b32 %0, %2, 16;\n\t"
+                            "and.b32 %1, %2, 0xffff0000;\n\t"
+                            "}\n"
+                            : "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[1])
+                            : "r"(_vpairs_1[_pair]));
+                    }
+                }
+            }
+            #pragma unroll
+            for (int j = 0; j < 8; j++) {
+                float _fma_0 = __fmaf_rn(_vec_load_1[j], _vec_load_0[j], acc[m_1]);
+                acc[m_1] = _fma_0;
+            }
+        }
+    }
+    #pragma unroll
+    for (int m_2 = 0; m_2 < 9; m_2++) {
+        float _warp_reduce_0 = acc[m_2];
+        #pragma unroll
+        for (int offset = 16; offset > 0; offset >>= 1)
+            _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
+        float warp_sum = _warp_reduce_0;
+        if (lane == 0) {
+            red[m_2 * 4 + warp] = warp_sum;
+        }
+    }
+    asm volatile("barrier.sync 2, 128;" ::: "memory");
+    if (warp == 0) {
+        if (lane < 9) {
+            int m_3 = lane;
+            float total = red[m_3 * 4];
+            #pragma unroll
+            for (int source_warp = 1; source_warp < 4; source_warp++) {
+                total = total + red[m_3 * 4 + source_warp];
+            }
+            int offset = m_3 * num_experts + expert;
+            if (out_is_bf16 == 0) {
+                *(reinterpret_cast<float*>(out_f32 + offset) + (0)) = total;
+            } else {
+                *(reinterpret_cast<__nv_bfloat16*>(out_bf16 + offset) + (0)) = __float2bfloat16_rn(total);
+            }
+        }
+    }
+    asm volatile("griddepcontrol.launch_dependents;" ::: "memory");
+}
+
+} // extern "C"

--- a/csrc/cake_router_gemm/cake_router_gemm_m9_k6144_device.cu
+++ b/csrc/cake_router_gemm/cake_router_gemm_m9_k6144_device.cu
@@ -14,25 +14,30 @@
  * limitations under the License.
  */
 
-typedef unsigned char      uint8_t;
-typedef unsigned short     uint16_t;
-typedef unsigned int       uint32_t;
+typedef unsigned char uint8_t;
+typedef unsigned short uint16_t;
+typedef unsigned int uint32_t;
 typedef unsigned long long uint64_t;
-typedef signed int         int32_t;
-typedef short int          int16_t;
-struct __align__(128) CakeTensorMap { uint64_t opaque[16]; };
+typedef signed int int32_t;
+typedef short int int16_t;
+struct __align__(128) CakeTensorMap {
+  uint64_t opaque[16];
+};
 template <int N>
-struct __align__(128) CakeTensorMapPack { CakeTensorMap maps[N]; };
+struct __align__(128) CakeTensorMapPack {
+  CakeTensorMap maps[N];
+};
 
-typedef struct __align__(64) { uint64_t opaque[16]; } CUtensorMap;
+typedef struct __align__(64) {
+  uint64_t opaque[16];
+} CUtensorMap;
 
 #include <cuda_bf16.h>
 
 __device__ __forceinline__ int make_warp_uniform(int x) {
-    int result;
-    asm volatile("shfl.sync.idx.b32 %0, %1, 0, 0x1F, 0xFFFFFFFF;"
-                 : "=r"(result) : "r"(x));
-    return result;
+  int result;
+  asm volatile("shfl.sync.idx.b32 %0, %1, 0, 0x1F, 0xFFFFFFFF;" : "=r"(result) : "r"(x));
+  return result;
 }
 
 #define CAKE_INF CUDART_INF_F
@@ -47,113 +52,116 @@ __device__ __forceinline__ int make_warp_uniform(int x) {
 
 extern "C" {
 
-__global__ __launch_bounds__(128, 1) void
-kernel_cake_blackwell_router_gemm_m9_k6144(__nv_bfloat16* __restrict__ mat_a, __nv_bfloat16* __restrict__ mat_b, float* __restrict__ out_f32, __nv_bfloat16* __restrict__ out_bf16, int num_experts, int out_is_bf16)
-{
-    const int tid = threadIdx.x;
-    const int warp = make_warp_uniform(tid / 32);
-    const int lane = tid % 32;
+__global__ __launch_bounds__(128, 1) void kernel_cake_blackwell_router_gemm_m9_k6144(
+    __nv_bfloat16* __restrict__ mat_a, __nv_bfloat16* __restrict__ mat_b,
+    float* __restrict__ out_f32, __nv_bfloat16* __restrict__ out_bf16, int num_experts,
+    int out_is_bf16) {
+  const int tid = threadIdx.x;
+  const int warp = make_warp_uniform(tid / 32);
+  const int lane = tid % 32;
 
-    extern __shared__ __align__(1024) char smem_raw[];
-    int smem;
-    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+  extern __shared__ __align__(1024) char smem_raw[];
+  int smem;
+  smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
 
-    const int bid = blockIdx.x;
-    const int num_bids = gridDim.x;
+  const int bid = blockIdx.x;
+  const int num_bids = gridDim.x;
 
-    // Kernel setup ops
-    float* red = reinterpret_cast<float*>(smem_raw + 0);
-    const int red_addr = smem + 0;
+  // Kernel setup ops
+  float* red = reinterpret_cast<float*>(smem_raw + 0);
+  const int red_addr = smem + 0;
 
-    // === Task calls (dependency order) ===
-    int expert = blockIdx.x;
-    float acc[9];
-    #pragma unroll
-    for (int m = 0; m < 9; m++) {
-        acc[m] = 0.0f;
-    }
-    asm volatile("griddepcontrol.wait;" ::: "memory");
-    #pragma unroll
-    for (int ki = 0; ki < 6; ki++) {
-        int k_base = ki * 1024 + tid * 8;
-        float _vec_load_0[8];
-        {
-            const uint4* _vptr_0 = reinterpret_cast<const uint4*>(mat_b + (expert * 6144 + k_base) + 0);
-            uint4 _vld_0[1];
-            #pragma unroll
-            for (int _blk = 0; _blk < 1; _blk++) {
-                _vld_0[_blk] = _vptr_0[_blk];
-                uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
-                #pragma unroll
-                for (int _pair = 0; _pair < 4; _pair++) {
-                    asm volatile(
-                        "{\n\t"
-                        "shl.b32 %0, %2, 16;\n\t"
-                        "and.b32 %1, %2, 0xffff0000;\n\t"
-                        "}\n"
-                        : "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[1])
-                        : "r"(_vpairs_0[_pair]));
-                }
-            }
+  // === Task calls (dependency order) ===
+  int expert = blockIdx.x;
+  float acc[9];
+#pragma unroll
+  for (int m = 0; m < 9; m++) {
+    acc[m] = 0.0f;
+  }
+  asm volatile("griddepcontrol.wait;" ::: "memory");
+#pragma unroll
+  for (int ki = 0; ki < 6; ki++) {
+    int k_base = ki * 1024 + tid * 8;
+    float _vec_load_0[8];
+    {
+      const uint4* _vptr_0 = reinterpret_cast<const uint4*>(mat_b + (expert * 6144 + k_base) + 0);
+      uint4 _vld_0[1];
+#pragma unroll
+      for (int _blk = 0; _blk < 1; _blk++) {
+        _vld_0[_blk] = _vptr_0[_blk];
+        uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
+#pragma unroll
+        for (int _pair = 0; _pair < 4; _pair++) {
+          asm volatile(
+              "{\n\t"
+              "shl.b32 %0, %2, 16;\n\t"
+              "and.b32 %1, %2, 0xffff0000;\n\t"
+              "}\n"
+              : "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[0]),
+                "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[1])
+              : "r"(_vpairs_0[_pair]));
         }
-        #pragma unroll
-        for (int m_1 = 0; m_1 < 9; m_1++) {
-            float _vec_load_1[8];
-            {
-                const uint4* _vptr_1 = reinterpret_cast<const uint4*>(mat_a + (m_1 * 6144 + k_base) + 0);
-                uint4 _vld_1[1];
-                #pragma unroll
-                for (int _blk = 0; _blk < 1; _blk++) {
-                    _vld_1[_blk] = _vptr_1[_blk];
-                    uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
-                    #pragma unroll
-                    for (int _pair = 0; _pair < 4; _pair++) {
-                        asm volatile(
-                            "{\n\t"
-                            "shl.b32 %0, %2, 16;\n\t"
-                            "and.b32 %1, %2, 0xffff0000;\n\t"
-                            "}\n"
-                            : "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[1])
-                            : "r"(_vpairs_1[_pair]));
-                    }
-                }
-            }
-            #pragma unroll
-            for (int j = 0; j < 8; j++) {
-                float _fma_0 = __fmaf_rn(_vec_load_1[j], _vec_load_0[j], acc[m_1]);
-                acc[m_1] = _fma_0;
-            }
-        }
+      }
     }
-    #pragma unroll
-    for (int m_2 = 0; m_2 < 9; m_2++) {
-        float _warp_reduce_0 = acc[m_2];
-        #pragma unroll
-        for (int offset = 16; offset > 0; offset >>= 1)
-            _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
-        float warp_sum = _warp_reduce_0;
-        if (lane == 0) {
-            red[m_2 * 4 + warp] = warp_sum;
+#pragma unroll
+    for (int m_1 = 0; m_1 < 9; m_1++) {
+      float _vec_load_1[8];
+      {
+        const uint4* _vptr_1 = reinterpret_cast<const uint4*>(mat_a + (m_1 * 6144 + k_base) + 0);
+        uint4 _vld_1[1];
+#pragma unroll
+        for (int _blk = 0; _blk < 1; _blk++) {
+          _vld_1[_blk] = _vptr_1[_blk];
+          uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
+#pragma unroll
+          for (int _pair = 0; _pair < 4; _pair++) {
+            asm volatile(
+                "{\n\t"
+                "shl.b32 %0, %2, 16;\n\t"
+                "and.b32 %1, %2, 0xffff0000;\n\t"
+                "}\n"
+                : "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[0]),
+                  "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[1])
+                : "r"(_vpairs_1[_pair]));
+          }
         }
+      }
+#pragma unroll
+      for (int j = 0; j < 8; j++) {
+        float _fma_0 = __fmaf_rn(_vec_load_1[j], _vec_load_0[j], acc[m_1]);
+        acc[m_1] = _fma_0;
+      }
     }
-    asm volatile("barrier.sync 2, 128;" ::: "memory");
-    if (warp == 0) {
-        if (lane < 9) {
-            int m_3 = lane;
-            float total = red[m_3 * 4];
-            #pragma unroll
-            for (int source_warp = 1; source_warp < 4; source_warp++) {
-                total = total + red[m_3 * 4 + source_warp];
-            }
-            int offset = m_3 * num_experts + expert;
-            if (out_is_bf16 == 0) {
-                *(reinterpret_cast<float*>(out_f32 + offset) + (0)) = total;
-            } else {
-                *(reinterpret_cast<__nv_bfloat16*>(out_bf16 + offset) + (0)) = __float2bfloat16_rn(total);
-            }
-        }
+  }
+#pragma unroll
+  for (int m_2 = 0; m_2 < 9; m_2++) {
+    float _warp_reduce_0 = acc[m_2];
+#pragma unroll
+    for (int offset = 16; offset > 0; offset >>= 1)
+      _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
+    float warp_sum = _warp_reduce_0;
+    if (lane == 0) {
+      red[m_2 * 4 + warp] = warp_sum;
     }
-    asm volatile("griddepcontrol.launch_dependents;" ::: "memory");
+  }
+  asm volatile("barrier.sync 2, 128;" ::: "memory");
+  if (warp == 0) {
+    if (lane < 9) {
+      int m_3 = lane;
+      float total = red[m_3 * 4];
+#pragma unroll
+      for (int source_warp = 1; source_warp < 4; source_warp++) {
+        total = total + red[m_3 * 4 + source_warp];
+      }
+      int offset = m_3 * num_experts + expert;
+      if (out_is_bf16 == 0) {
+        *(reinterpret_cast<float*>(out_f32 + offset) + (0)) = total;
+      } else {
+        *(reinterpret_cast<__nv_bfloat16*>(out_bf16 + offset) + (0)) = __float2bfloat16_rn(total);
+      }
+    }
+  }
+  asm volatile("griddepcontrol.launch_dependents;" ::: "memory");
 }
 
-} // extern "C"
+}  // extern "C"

--- a/csrc/cake_router_gemm/cake_router_gemm_m9_k7168_device.cu
+++ b/csrc/cake_router_gemm/cake_router_gemm_m9_k7168_device.cu
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) 2026 by FlashInfer team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+typedef unsigned char      uint8_t;
+typedef unsigned short     uint16_t;
+typedef unsigned int       uint32_t;
+typedef unsigned long long uint64_t;
+typedef signed int         int32_t;
+typedef short int          int16_t;
+struct __align__(128) CakeTensorMap { uint64_t opaque[16]; };
+template <int N>
+struct __align__(128) CakeTensorMapPack { CakeTensorMap maps[N]; };
+
+typedef struct __align__(64) { uint64_t opaque[16]; } CUtensorMap;
+
+#include <cuda_bf16.h>
+
+__device__ __forceinline__ int make_warp_uniform(int x) {
+    int result;
+    asm volatile("shfl.sync.idx.b32 %0, %1, 0, 0x1F, 0xFFFFFFFF;"
+                 : "=r"(result) : "r"(x));
+    return result;
+}
+
+#define CAKE_INF CUDART_INF_F
+#define NUM_MAIN_STAGES 1
+#define SMEM_RED_OFF 0
+#define SMEM_RED_STAGE_BYTES 144
+#define SMEM_RED_STRIDE 144
+#define SMEM_TOTAL 256
+#define THREADS 128
+
+#include <math_constants.h>
+
+extern "C" {
+
+__global__ __launch_bounds__(128, 1) void
+kernel_cake_blackwell_router_gemm_m9_k7168(__nv_bfloat16* __restrict__ mat_a, __nv_bfloat16* __restrict__ mat_b, float* __restrict__ out_f32, __nv_bfloat16* __restrict__ out_bf16, int num_experts, int out_is_bf16)
+{
+    const int tid = threadIdx.x;
+    const int warp = make_warp_uniform(tid / 32);
+    const int lane = tid % 32;
+
+    extern __shared__ __align__(1024) char smem_raw[];
+    int smem;
+    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+
+    const int bid = blockIdx.x;
+    const int num_bids = gridDim.x;
+
+    // Kernel setup ops
+    float* red = reinterpret_cast<float*>(smem_raw + 0);
+    const int red_addr = smem + 0;
+
+    // === Task calls (dependency order) ===
+    int expert = blockIdx.x;
+    float acc[9];
+    #pragma unroll
+    for (int m = 0; m < 9; m++) {
+        acc[m] = 0.0f;
+    }
+    asm volatile("griddepcontrol.wait;" ::: "memory");
+    #pragma unroll
+    for (int ki = 0; ki < 7; ki++) {
+        int k_base = ki * 1024 + tid * 8;
+        float _vec_load_0[8];
+        {
+            const uint4* _vptr_0 = reinterpret_cast<const uint4*>(mat_b + (expert * 7168 + k_base) + 0);
+            uint4 _vld_0[1];
+            #pragma unroll
+            for (int _blk = 0; _blk < 1; _blk++) {
+                _vld_0[_blk] = _vptr_0[_blk];
+                uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
+                #pragma unroll
+                for (int _pair = 0; _pair < 4; _pair++) {
+                    asm volatile(
+                        "{\n\t"
+                        "shl.b32 %0, %2, 16;\n\t"
+                        "and.b32 %1, %2, 0xffff0000;\n\t"
+                        "}\n"
+                        : "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[1])
+                        : "r"(_vpairs_0[_pair]));
+                }
+            }
+        }
+        #pragma unroll
+        for (int m_1 = 0; m_1 < 9; m_1++) {
+            float _vec_load_1[8];
+            {
+                const uint4* _vptr_1 = reinterpret_cast<const uint4*>(mat_a + (m_1 * 7168 + k_base) + 0);
+                uint4 _vld_1[1];
+                #pragma unroll
+                for (int _blk = 0; _blk < 1; _blk++) {
+                    _vld_1[_blk] = _vptr_1[_blk];
+                    uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
+                    #pragma unroll
+                    for (int _pair = 0; _pair < 4; _pair++) {
+                        asm volatile(
+                            "{\n\t"
+                            "shl.b32 %0, %2, 16;\n\t"
+                            "and.b32 %1, %2, 0xffff0000;\n\t"
+                            "}\n"
+                            : "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[1])
+                            : "r"(_vpairs_1[_pair]));
+                    }
+                }
+            }
+            #pragma unroll
+            for (int j = 0; j < 8; j++) {
+                float _fma_0 = __fmaf_rn(_vec_load_1[j], _vec_load_0[j], acc[m_1]);
+                acc[m_1] = _fma_0;
+            }
+        }
+    }
+    #pragma unroll
+    for (int m_2 = 0; m_2 < 9; m_2++) {
+        float _warp_reduce_0 = acc[m_2];
+        #pragma unroll
+        for (int offset = 16; offset > 0; offset >>= 1)
+            _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
+        float warp_sum = _warp_reduce_0;
+        if (lane == 0) {
+            red[m_2 * 4 + warp] = warp_sum;
+        }
+    }
+    asm volatile("barrier.sync 2, 128;" ::: "memory");
+    if (warp == 0) {
+        if (lane < 9) {
+            int m_3 = lane;
+            float total = red[m_3 * 4];
+            #pragma unroll
+            for (int source_warp = 1; source_warp < 4; source_warp++) {
+                total = total + red[m_3 * 4 + source_warp];
+            }
+            int offset = m_3 * num_experts + expert;
+            if (out_is_bf16 == 0) {
+                *(reinterpret_cast<float*>(out_f32 + offset) + (0)) = total;
+            } else {
+                *(reinterpret_cast<__nv_bfloat16*>(out_bf16 + offset) + (0)) = __float2bfloat16_rn(total);
+            }
+        }
+    }
+    asm volatile("griddepcontrol.launch_dependents;" ::: "memory");
+}
+
+} // extern "C"

--- a/csrc/cake_router_gemm/cake_router_gemm_m9_k7168_device.cu
+++ b/csrc/cake_router_gemm/cake_router_gemm_m9_k7168_device.cu
@@ -14,25 +14,30 @@
  * limitations under the License.
  */
 
-typedef unsigned char      uint8_t;
-typedef unsigned short     uint16_t;
-typedef unsigned int       uint32_t;
+typedef unsigned char uint8_t;
+typedef unsigned short uint16_t;
+typedef unsigned int uint32_t;
 typedef unsigned long long uint64_t;
-typedef signed int         int32_t;
-typedef short int          int16_t;
-struct __align__(128) CakeTensorMap { uint64_t opaque[16]; };
+typedef signed int int32_t;
+typedef short int int16_t;
+struct __align__(128) CakeTensorMap {
+  uint64_t opaque[16];
+};
 template <int N>
-struct __align__(128) CakeTensorMapPack { CakeTensorMap maps[N]; };
+struct __align__(128) CakeTensorMapPack {
+  CakeTensorMap maps[N];
+};
 
-typedef struct __align__(64) { uint64_t opaque[16]; } CUtensorMap;
+typedef struct __align__(64) {
+  uint64_t opaque[16];
+} CUtensorMap;
 
 #include <cuda_bf16.h>
 
 __device__ __forceinline__ int make_warp_uniform(int x) {
-    int result;
-    asm volatile("shfl.sync.idx.b32 %0, %1, 0, 0x1F, 0xFFFFFFFF;"
-                 : "=r"(result) : "r"(x));
-    return result;
+  int result;
+  asm volatile("shfl.sync.idx.b32 %0, %1, 0, 0x1F, 0xFFFFFFFF;" : "=r"(result) : "r"(x));
+  return result;
 }
 
 #define CAKE_INF CUDART_INF_F
@@ -47,113 +52,116 @@ __device__ __forceinline__ int make_warp_uniform(int x) {
 
 extern "C" {
 
-__global__ __launch_bounds__(128, 1) void
-kernel_cake_blackwell_router_gemm_m9_k7168(__nv_bfloat16* __restrict__ mat_a, __nv_bfloat16* __restrict__ mat_b, float* __restrict__ out_f32, __nv_bfloat16* __restrict__ out_bf16, int num_experts, int out_is_bf16)
-{
-    const int tid = threadIdx.x;
-    const int warp = make_warp_uniform(tid / 32);
-    const int lane = tid % 32;
+__global__ __launch_bounds__(128, 1) void kernel_cake_blackwell_router_gemm_m9_k7168(
+    __nv_bfloat16* __restrict__ mat_a, __nv_bfloat16* __restrict__ mat_b,
+    float* __restrict__ out_f32, __nv_bfloat16* __restrict__ out_bf16, int num_experts,
+    int out_is_bf16) {
+  const int tid = threadIdx.x;
+  const int warp = make_warp_uniform(tid / 32);
+  const int lane = tid % 32;
 
-    extern __shared__ __align__(1024) char smem_raw[];
-    int smem;
-    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+  extern __shared__ __align__(1024) char smem_raw[];
+  int smem;
+  smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
 
-    const int bid = blockIdx.x;
-    const int num_bids = gridDim.x;
+  const int bid = blockIdx.x;
+  const int num_bids = gridDim.x;
 
-    // Kernel setup ops
-    float* red = reinterpret_cast<float*>(smem_raw + 0);
-    const int red_addr = smem + 0;
+  // Kernel setup ops
+  float* red = reinterpret_cast<float*>(smem_raw + 0);
+  const int red_addr = smem + 0;
 
-    // === Task calls (dependency order) ===
-    int expert = blockIdx.x;
-    float acc[9];
-    #pragma unroll
-    for (int m = 0; m < 9; m++) {
-        acc[m] = 0.0f;
-    }
-    asm volatile("griddepcontrol.wait;" ::: "memory");
-    #pragma unroll
-    for (int ki = 0; ki < 7; ki++) {
-        int k_base = ki * 1024 + tid * 8;
-        float _vec_load_0[8];
-        {
-            const uint4* _vptr_0 = reinterpret_cast<const uint4*>(mat_b + (expert * 7168 + k_base) + 0);
-            uint4 _vld_0[1];
-            #pragma unroll
-            for (int _blk = 0; _blk < 1; _blk++) {
-                _vld_0[_blk] = _vptr_0[_blk];
-                uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
-                #pragma unroll
-                for (int _pair = 0; _pair < 4; _pair++) {
-                    asm volatile(
-                        "{\n\t"
-                        "shl.b32 %0, %2, 16;\n\t"
-                        "and.b32 %1, %2, 0xffff0000;\n\t"
-                        "}\n"
-                        : "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[1])
-                        : "r"(_vpairs_0[_pair]));
-                }
-            }
+  // === Task calls (dependency order) ===
+  int expert = blockIdx.x;
+  float acc[9];
+#pragma unroll
+  for (int m = 0; m < 9; m++) {
+    acc[m] = 0.0f;
+  }
+  asm volatile("griddepcontrol.wait;" ::: "memory");
+#pragma unroll
+  for (int ki = 0; ki < 7; ki++) {
+    int k_base = ki * 1024 + tid * 8;
+    float _vec_load_0[8];
+    {
+      const uint4* _vptr_0 = reinterpret_cast<const uint4*>(mat_b + (expert * 7168 + k_base) + 0);
+      uint4 _vld_0[1];
+#pragma unroll
+      for (int _blk = 0; _blk < 1; _blk++) {
+        _vld_0[_blk] = _vptr_0[_blk];
+        uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
+#pragma unroll
+        for (int _pair = 0; _pair < 4; _pair++) {
+          asm volatile(
+              "{\n\t"
+              "shl.b32 %0, %2, 16;\n\t"
+              "and.b32 %1, %2, 0xffff0000;\n\t"
+              "}\n"
+              : "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[0]),
+                "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[1])
+              : "r"(_vpairs_0[_pair]));
         }
-        #pragma unroll
-        for (int m_1 = 0; m_1 < 9; m_1++) {
-            float _vec_load_1[8];
-            {
-                const uint4* _vptr_1 = reinterpret_cast<const uint4*>(mat_a + (m_1 * 7168 + k_base) + 0);
-                uint4 _vld_1[1];
-                #pragma unroll
-                for (int _blk = 0; _blk < 1; _blk++) {
-                    _vld_1[_blk] = _vptr_1[_blk];
-                    uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
-                    #pragma unroll
-                    for (int _pair = 0; _pair < 4; _pair++) {
-                        asm volatile(
-                            "{\n\t"
-                            "shl.b32 %0, %2, 16;\n\t"
-                            "and.b32 %1, %2, 0xffff0000;\n\t"
-                            "}\n"
-                            : "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[1])
-                            : "r"(_vpairs_1[_pair]));
-                    }
-                }
-            }
-            #pragma unroll
-            for (int j = 0; j < 8; j++) {
-                float _fma_0 = __fmaf_rn(_vec_load_1[j], _vec_load_0[j], acc[m_1]);
-                acc[m_1] = _fma_0;
-            }
-        }
+      }
     }
-    #pragma unroll
-    for (int m_2 = 0; m_2 < 9; m_2++) {
-        float _warp_reduce_0 = acc[m_2];
-        #pragma unroll
-        for (int offset = 16; offset > 0; offset >>= 1)
-            _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
-        float warp_sum = _warp_reduce_0;
-        if (lane == 0) {
-            red[m_2 * 4 + warp] = warp_sum;
+#pragma unroll
+    for (int m_1 = 0; m_1 < 9; m_1++) {
+      float _vec_load_1[8];
+      {
+        const uint4* _vptr_1 = reinterpret_cast<const uint4*>(mat_a + (m_1 * 7168 + k_base) + 0);
+        uint4 _vld_1[1];
+#pragma unroll
+        for (int _blk = 0; _blk < 1; _blk++) {
+          _vld_1[_blk] = _vptr_1[_blk];
+          uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
+#pragma unroll
+          for (int _pair = 0; _pair < 4; _pair++) {
+            asm volatile(
+                "{\n\t"
+                "shl.b32 %0, %2, 16;\n\t"
+                "and.b32 %1, %2, 0xffff0000;\n\t"
+                "}\n"
+                : "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[0]),
+                  "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[1])
+                : "r"(_vpairs_1[_pair]));
+          }
         }
+      }
+#pragma unroll
+      for (int j = 0; j < 8; j++) {
+        float _fma_0 = __fmaf_rn(_vec_load_1[j], _vec_load_0[j], acc[m_1]);
+        acc[m_1] = _fma_0;
+      }
     }
-    asm volatile("barrier.sync 2, 128;" ::: "memory");
-    if (warp == 0) {
-        if (lane < 9) {
-            int m_3 = lane;
-            float total = red[m_3 * 4];
-            #pragma unroll
-            for (int source_warp = 1; source_warp < 4; source_warp++) {
-                total = total + red[m_3 * 4 + source_warp];
-            }
-            int offset = m_3 * num_experts + expert;
-            if (out_is_bf16 == 0) {
-                *(reinterpret_cast<float*>(out_f32 + offset) + (0)) = total;
-            } else {
-                *(reinterpret_cast<__nv_bfloat16*>(out_bf16 + offset) + (0)) = __float2bfloat16_rn(total);
-            }
-        }
+  }
+#pragma unroll
+  for (int m_2 = 0; m_2 < 9; m_2++) {
+    float _warp_reduce_0 = acc[m_2];
+#pragma unroll
+    for (int offset = 16; offset > 0; offset >>= 1)
+      _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
+    float warp_sum = _warp_reduce_0;
+    if (lane == 0) {
+      red[m_2 * 4 + warp] = warp_sum;
     }
-    asm volatile("griddepcontrol.launch_dependents;" ::: "memory");
+  }
+  asm volatile("barrier.sync 2, 128;" ::: "memory");
+  if (warp == 0) {
+    if (lane < 9) {
+      int m_3 = lane;
+      float total = red[m_3 * 4];
+#pragma unroll
+      for (int source_warp = 1; source_warp < 4; source_warp++) {
+        total = total + red[m_3 * 4 + source_warp];
+      }
+      int offset = m_3 * num_experts + expert;
+      if (out_is_bf16 == 0) {
+        *(reinterpret_cast<float*>(out_f32 + offset) + (0)) = total;
+      } else {
+        *(reinterpret_cast<__nv_bfloat16*>(out_bf16 + offset) + (0)) = __float2bfloat16_rn(total);
+      }
+    }
+  }
+  asm volatile("griddepcontrol.launch_dependents;" ::: "memory");
 }
 
-} // extern "C"
+}  // extern "C"

--- a/flashinfer/gemm/routergemm.py
+++ b/flashinfer/gemm/routergemm.py
@@ -171,6 +171,62 @@ def get_dsv3_router_gemm_module():
     )
 
 
+@functools.cache
+def get_cake_router_gemm_module():
+    from flashinfer.jit.cake_router_gemm import run
+
+    @register_custom_op(
+        "flashinfer::cake_ml3_router_gemm_op",
+        mutates_args=["out"],
+    )
+    def mm_M1_16_K7168_N128(
+        mat_a: torch.Tensor,
+        mat_b: torch.Tensor,
+        out: torch.Tensor,
+        launch_with_pdl: bool = True,
+    ) -> None:
+        run(mat_a, mat_b, out, launch_with_pdl)
+
+    @register_custom_op(
+        "flashinfer::cake_dsv3_router_gemm_op",
+        mutates_args=["out"],
+    )
+    def mm_M1_16_K7168_N256(
+        mat_a: torch.Tensor,
+        mat_b: torch.Tensor,
+        out: torch.Tensor,
+        launch_with_pdl: bool = True,
+    ) -> None:
+        run(mat_a, mat_b, out, launch_with_pdl)
+
+    @register_custom_op(
+        "flashinfer::cake_glm_dsa_router_gemm_op",
+        mutates_args=["out"],
+    )
+    def mm_M1_16_K6144_N256(
+        mat_a: torch.Tensor,
+        mat_b: torch.Tensor,
+        out: torch.Tensor,
+        launch_with_pdl: bool = True,
+    ) -> None:
+        run(mat_a, mat_b, out, launch_with_pdl)
+
+    return SimpleNamespace(
+        mm_M1_16_K7168_N128=mm_M1_16_K7168_N128,
+        mm_M1_16_K7168_N256=mm_M1_16_K7168_N256,
+        mm_M1_16_K6144_N256=mm_M1_16_K6144_N256,
+    )
+
+
+def get_router_gemm_module(*, backend: str):
+    if backend != "cake":
+        raise ValueError(f"unsupported Router GEMM backend: {backend!r}")
+    major, minor = get_compute_capability(torch.device("cuda"))
+    if major == 10 and minor in (0, 3):
+        return get_cake_router_gemm_module()
+    return get_dsv3_router_gemm_module()
+
+
 @backend_requirement({}, common_check=_mm_M1_16_K7168_N128_shape_checks)
 @flashinfer_api
 def mm_M1_16_K7168_N128(
@@ -212,7 +268,7 @@ def mm_M1_16_K7168_N128(
     dimensions, strides, or dtypes do not match the expected Mistral Large 3
     configuration.
     """
-    get_dsv3_router_gemm_module().mm_M1_16_K7168_N128(
+    get_router_gemm_module(backend="cake").mm_M1_16_K7168_N128(
         mat_a, mat_b, out, launch_with_pdl
     )
 
@@ -258,7 +314,7 @@ def mm_M1_16_K7168_N256(
     ``ValueError`` if tensor dimensions, strides, or dtypes do not match the
     expected DeepSeek-V3 router configuration.
     """
-    get_dsv3_router_gemm_module().mm_M1_16_K7168_N256(
+    get_router_gemm_module(backend="cake").mm_M1_16_K7168_N256(
         mat_a, mat_b, out, launch_with_pdl
     )
 
@@ -304,7 +360,7 @@ def mm_M1_16_K6144_N256(
     ``ValueError`` if tensor dimensions, strides, or dtypes do not match the
     expected GLM-MoE-DSA configuration.
     """
-    get_dsv3_router_gemm_module().mm_M1_16_K6144_N256(
+    get_router_gemm_module(backend="cake").mm_M1_16_K6144_N256(
         mat_a, mat_b, out, launch_with_pdl
     )
 

--- a/flashinfer/jit/cake_router_gemm.py
+++ b/flashinfer/jit/cake_router_gemm.py
@@ -159,10 +159,7 @@ def _program_source(num_tokens: int, hidden_dim: int) -> Path:
         raise ValueError(f"num_tokens must be in [1, 16], got {num_tokens}")
     if hidden_dim not in (6144, 7168):
         raise ValueError(f"hidden_dim must be 6144 or 7168, got {hidden_dim}")
-    source = (
-        _source_dir()
-        / f"cake_router_gemm_m{num_tokens}_k{hidden_dim}_device.cu"
-    )
+    source = _source_dir() / f"cake_router_gemm_m{num_tokens}_k{hidden_dim}_device.cu"
     if not source.is_file():
         raise RuntimeError(
             f"Cake Router GEMM source package is incomplete for M={num_tokens}, "

--- a/flashinfer/jit/cake_router_gemm.py
+++ b/flashinfer/jit/cake_router_gemm.py
@@ -1,0 +1,240 @@
+"""
+Copyright (c) 2026 by FlashInfer team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+# Source-built Cake Router GEMM programs for datacenter Blackwell.
+
+from __future__ import annotations
+
+import functools
+import hashlib
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import torch
+from tvm_ffi import cpp
+
+from . import env as jit_env
+
+
+_HOST_SOURCE = r"""
+// Cake Router GEMM source-level cubin launcher.
+#include <cuda.h>
+#include <cuda_runtime.h>
+#include <tvm/ffi/container/tensor.h>
+#include <tvm/ffi/error.h>
+#include <tvm/ffi/extra/c_env_api.h>
+#include <tvm/ffi/extra/cuda/cubin_launcher.h>
+#include <tvm/ffi/function.h>
+
+#include <cstdint>
+
+TVM_FFI_EMBED_CUBIN(CAKE_MODULE_IDENT);
+
+namespace cake_router_gemm {
+
+using tvm::ffi::TensorView;
+
+void CheckCudaTensor(const TensorView& tensor, const char* name) {
+  TVM_FFI_CHECK(tensor.device().device_type == kDLCUDA, ValueError)
+      << name << " must be a CUDA tensor";
+}
+
+void Run(TensorView mat_a, TensorView mat_b, TensorView out,
+         bool launch_with_pdl, int64_t out_is_bf16) {
+  CheckCudaTensor(mat_a, "mat_a");
+  CheckCudaTensor(mat_b, "mat_b");
+  CheckCudaTensor(out, "out");
+  TVM_FFI_CHECK(mat_a.device().device_id == mat_b.device().device_id &&
+                    mat_a.device().device_id == out.device().device_id,
+                ValueError)
+      << "mat_a, mat_b, and out must be on the same CUDA device";
+  TVM_FFI_CHECK(out_is_bf16 == 0 || out_is_bf16 == 1, ValueError)
+      << "out_is_bf16 must be 0 or 1";
+
+  DLDevice device = mat_a.device();
+  cudaStream_t stream =
+      (cudaStream_t)TVMFFIEnvGetStream(device.device_type, device.device_id);
+  void* p_mat_a = mat_a.data_ptr();
+  void* p_mat_b = mat_b.data_ptr();
+  void* p_out_f32 = out.data_ptr();
+  void* p_out_bf16 = out.data_ptr();
+  int32_t num_experts = (int32_t)mat_b.size(1);
+  int32_t output_selector = (int32_t)out_is_bf16;
+  void* args[] = {&p_mat_a, &p_mat_b, &p_out_f32, &p_out_bf16,
+                  &num_experts, &output_selector};
+
+  static auto kernel = TVM_FFI_EMBED_CUBIN_GET_KERNEL(
+      CAKE_MODULE_IDENT, "CAKE_KERNEL_SYMBOL");
+  tvm::ffi::cuda_api::LaunchConfig config;
+  int num_attrs = 0;
+#if TVM_FFI_CUBIN_LAUNCHER_USE_DRIVER_API
+  CUlaunchAttribute attrs[1];
+  if (launch_with_pdl) {
+    attrs[0].id = CU_LAUNCH_ATTRIBUTE_PROGRAMMATIC_STREAM_SERIALIZATION;
+    attrs[0].value.programmaticStreamSerializationAllowed = 1;
+    num_attrs = 1;
+  }
+  config.gridDimX = (uint32_t)num_experts;
+  config.gridDimY = 1;
+  config.gridDimZ = 1;
+  config.blockDimX = 128;
+  config.blockDimY = 1;
+  config.blockDimZ = 1;
+  config.sharedMemBytes = CAKE_SMEM_BYTES;
+  config.hStream = stream;
+  config.attrs = attrs;
+  config.numAttrs = num_attrs;
+#else
+  cudaLaunchAttribute attrs[1];
+  if (launch_with_pdl) {
+    attrs[0].id = cudaLaunchAttributeProgrammaticStreamSerialization;
+    attrs[0].val.programmaticStreamSerializationAllowed = 1;
+    num_attrs = 1;
+  }
+  config.gridDim = {(uint32_t)num_experts, 1, 1};
+  config.blockDim = {128, 1, 1};
+  config.dynamicSmemBytes = CAKE_SMEM_BYTES;
+  config.stream = stream;
+  config.attrs = attrs;
+  config.numAttrs = num_attrs;
+#endif
+  TVM_FFI_CHECK_CUBIN_LAUNCHER_CUDA_ERROR(kernel.LaunchEx(args, config));
+}
+
+}  // namespace cake_router_gemm
+
+TVM_FFI_DLL_EXPORT_TYPED_FUNC(run, cake_router_gemm::Run);
+"""
+
+
+def _source_dir() -> Path:
+    packaged = jit_env.FLASHINFER_CSRC_DIR / "cake_router_gemm"
+    if packaged.is_dir():
+        return packaged
+    return Path(__file__).resolve().parents[2] / "csrc" / "cake_router_gemm"
+
+
+def _target_arch() -> str:
+    capability = torch.cuda.get_device_capability()
+    if capability == (10, 0):
+        return "sm_100a"
+    if capability == (10, 3):
+        return "sm_103a"
+    raise ValueError(
+        "Cake Router GEMM requires SM100 or SM103, got "
+        f"SM{capability[0]}{capability[1]}"
+    )
+
+
+def _nvcc() -> Path:
+    candidate = shutil.which("nvcc")
+    if candidate is None:
+        cuda_root = os.environ.get("CUDA_HOME") or os.environ.get("CUDA_PATH")
+        if cuda_root:
+            path = Path(cuda_root) / "bin" / "nvcc"
+            if path.is_file():
+                candidate = str(path)
+    if candidate is None:
+        raise RuntimeError("nvcc is required to build the Cake Router GEMM backend")
+    return Path(candidate).resolve()
+
+
+def _program_source(num_tokens: int, hidden_dim: int) -> Path:
+    if not 1 <= num_tokens <= 16:
+        raise ValueError(f"num_tokens must be in [1, 16], got {num_tokens}")
+    if hidden_dim not in (6144, 7168):
+        raise ValueError(f"hidden_dim must be 6144 or 7168, got {hidden_dim}")
+    source = (
+        _source_dir()
+        / f"cake_router_gemm_m{num_tokens}_k{hidden_dim}_device.cu"
+    )
+    if not source.is_file():
+        raise RuntimeError(
+            f"Cake Router GEMM source package is incomplete for M={num_tokens}, "
+            f"K={hidden_dim}"
+        )
+    return source
+
+
+@functools.cache
+def _load_program(num_tokens: int, hidden_dim: int, arch: str):
+    source = _program_source(num_tokens, hidden_dim)
+    nvcc = _nvcc()
+    module_ident = f"cake_router_gemm_m{num_tokens}_k{hidden_dim}"
+    kernel_symbol = f"kernel_cake_blackwell_router_gemm_m{num_tokens}_k{hidden_dim}"
+    host_source = (
+        _HOST_SOURCE.replace("CAKE_MODULE_IDENT", module_ident)
+        .replace("CAKE_KERNEL_SYMBOL", kernel_symbol)
+        .replace("CAKE_SMEM_BYTES", str(num_tokens * 16))
+    )
+
+    digest = hashlib.sha256()
+    digest.update(source.read_bytes())
+    digest.update(host_source.encode())
+    digest.update(arch.encode())
+    digest.update(str(nvcc).encode())
+    key = digest.hexdigest()[:16]
+    build_dir = jit_env.FLASHINFER_JIT_DIR / f"{module_ident}_{arch}_{key}"
+    build_dir.mkdir(parents=True, exist_ok=True)
+    cubin_path = build_dir / f"{module_ident}.cubin"
+    if not cubin_path.is_file():
+        temporary_cubin = build_dir / f"{module_ident}.{os.getpid()}.tmp.cubin"
+        command = [
+            str(nvcc),
+            "-cubin",
+            f"-arch={arch}",
+            "--std=c++17",
+            "-O3",
+            "--use_fast_math",
+            "-I",
+            str(nvcc.parent.parent / "include"),
+            str(source),
+            "-o",
+            str(temporary_cubin),
+        ]
+        process = subprocess.run(command, text=True, capture_output=True)
+        if process.returncode != 0:
+            temporary_cubin.unlink(missing_ok=True)
+            raise RuntimeError(
+                f"Cake Router GEMM nvcc failed for M={num_tokens}, "
+                f"K={hidden_dim}, arch={arch}:\n{process.stderr}"
+            )
+        os.replace(temporary_cubin, cubin_path)
+
+    return cpp.load_inline(
+        f"{module_ident}_{arch}_{key}",
+        cpp_sources=host_source,
+        embed_cubin={module_ident: cubin_path.read_bytes()},
+        extra_include_paths=[str(nvcc.parent.parent / "include")],
+        extra_cflags=["-O3"],
+        extra_ldflags=["-lcuda"],
+        build_directory=str(build_dir),
+    )
+
+
+def run(
+    mat_a: torch.Tensor,
+    mat_b: torch.Tensor,
+    out: torch.Tensor,
+    launch_with_pdl: bool,
+) -> None:
+    module = _load_program(int(mat_a.shape[0]), int(mat_a.shape[1]), _target_arch())
+    module.run(mat_a, mat_b, out, launch_with_pdl, int(out.dtype == torch.bfloat16))
+
+
+__all__ = ["run"]

--- a/tests/model_optimizations/test_router_gemms.py
+++ b/tests/model_optimizations/test_router_gemms.py
@@ -9,8 +9,20 @@ import torch.nn.functional as F
 from flashinfer.utils import get_compute_capability
 
 
+@pytest.mark.parametrize("num_tokens", range(1, 17))
+@pytest.mark.parametrize("hidden_dim", [6144, 7168])
+def test_cake_router_gemm_source_matrix(num_tokens, hidden_dim):
+    from flashinfer.jit.cake_router_gemm import _program_source
+
+    source = _program_source(num_tokens, hidden_dim)
+    text = source.read_text(encoding="utf-8")
+    assert (
+        f"kernel_cake_blackwell_router_gemm_m{num_tokens}_k{hidden_dim}" in text
+    )
+
+
 # Positive tests
-@pytest.mark.parametrize("num_tokens", [1, 2, 3, 5, 8, 13, 16])
+@pytest.mark.parametrize("num_tokens", range(1, 17))
 @pytest.mark.parametrize(
     "num_experts,output_dtype,hidden_dim,fn_to_test",
     (
@@ -33,7 +45,8 @@ def test_dsv3_router_gemm_op(
         num_experts, hidden_dim, device="cuda", dtype=torch.bfloat16
     ).t()  # column major
     out = torch.empty(num_tokens, num_experts, device="cuda", dtype=output_dtype)
-    fn_to_test(mat_a, mat_b, out, launch_with_pdl=launch_with_pdl)
+    result = fn_to_test(mat_a, mat_b, out, launch_with_pdl=launch_with_pdl)
+    assert result is None
     ref = mat_a @ mat_b
 
     cos_sim = F.cosine_similarity(ref.reshape(-1), out.reshape(-1), dim=0)

--- a/tests/model_optimizations/test_router_gemms.py
+++ b/tests/model_optimizations/test_router_gemms.py
@@ -16,9 +16,7 @@ def test_cake_router_gemm_source_matrix(num_tokens, hidden_dim):
 
     source = _program_source(num_tokens, hidden_dim)
     text = source.read_text(encoding="utf-8")
-    assert (
-        f"kernel_cake_blackwell_router_gemm_m{num_tokens}_k{hidden_dim}" in text
-    )
+    assert f"kernel_cake_blackwell_router_gemm_m{num_tokens}_k{hidden_dim}" in text
 
 
 # Positive tests


### PR DESCRIPTION
| API | M | PDL | GB300 speedup | B200 speedup | Tracker |
|---|---:|:---:|---:|---:|---|
| `mm_M1_16_K7168_N256` | 1 | off | 1.0101x | 1.0102x | [#4254](https://github.com/flashinfer-ai/flashinfer/issues/4254) |
| `mm_M1_16_K7168_N256` | 1 | on | 1.0208x | 1.0102x |  |
| `mm_M1_16_K7168_N256` | 2 | off | 1.0490x | 1.0583x |  |
| `mm_M1_16_K7168_N256` | 2 | on | 1.0490x | 1.0583x |  |
| `mm_M1_16_K7168_N256` | 3 | off | 1.0085x | 1.0167x |  |
| `mm_M1_16_K7168_N256` | 3 | on | 1.0085x | 1.0167x |  |
| `mm_M1_16_K7168_N256` | 4 | off | 1.0331x | 1.0403x |  |
| `mm_M1_16_K7168_N256` | 4 | on | 1.0331x | 1.0403x |  |
| `mm_M1_16_K7168_N256` | 5 | off | 1.0781x | 1.0763x |  |
| `mm_M1_16_K7168_N256` | 5 | on | 1.0781x | 1.0763x |  |
| `mm_M1_16_K7168_N256` | 6 | off | 1.1061x | 1.0956x |  |
| `mm_M1_16_K7168_N256` | 6 | on | 1.1061x | 1.0956x |  |
| `mm_M1_16_K7168_N256` | 7 | off | 1.0544x | 1.0466x |  |
| `mm_M1_16_K7168_N256` | 7 | on | 1.0544x | 1.0464x |  |
| `mm_M1_16_K7168_N256` | 8 | off | 1.0915x | 1.1032x |  |
| `mm_M1_16_K7168_N256` | 8 | on | 1.0987x | 1.1032x |  |
| `mm_M1_16_K7168_N256` | 9 | off | 1.0955x | 1.1195x |  |
| `mm_M1_16_K7168_N256` | 9 | on | 1.0955x | 1.1132x |  |
| `mm_M1_16_K7168_N256` | 10 | off | 1.0351x | 1.0339x |  |
| `mm_M1_16_K7168_N256` | 10 | on | 1.0347x | 1.0335x |  |
| `mm_M1_16_K7168_N256` | 11 | off | 1.0912x | 1.0778x |  |
| `mm_M1_16_K7168_N256` | 11 | on | 1.0914x | 1.0889x |  |
| `mm_M1_16_K7168_N256` | 12 | off | 1.0946x | 1.0924x |  |
| `mm_M1_16_K7168_N256` | 12 | on | 1.1061x | 1.0982x |  |
| `mm_M1_16_K7168_N256` | 13 | off | 1.0885x | 1.0914x |  |
| `mm_M1_16_K7168_N256` | 13 | on | 1.0938x | 1.0859x |  |
| `mm_M1_16_K7168_N256` | 14 | off | 1.1300x | 1.1366x |  |
| `mm_M1_16_K7168_N256` | 14 | on | 1.1300x | 1.1364x |  |
| `mm_M1_16_K7168_N256` | 15 | off | 1.1054x | 1.1078x |  |
| `mm_M1_16_K7168_N256` | 15 | on | 1.1100x | 1.1073x |  |
| `mm_M1_16_K7168_N256` | 16 | off | 1.1198x | 1.1212x |  |
| `mm_M1_16_K7168_N256` | 16 | on | 1.1198x | 1.1166x |  |
| `mm_M1_16_K7168_N128` | 1 | off | 1.0247x | 1.0119x |  |
| `mm_M1_16_K7168_N128` | 1 | on | 1.0247x | 1.0119x |  |
| `mm_M1_16_K7168_N128` | 2 | off | 1.0941x | 1.0916x |  |
| `mm_M1_16_K7168_N128` | 2 | on | 1.0941x | 1.0920x |  |
| `mm_M1_16_K7168_N128` | 3 | off | 1.0297x | 1.0291x |  |
| `mm_M1_16_K7168_N128` | 3 | on | 1.0297x | 1.0291x |  |
| `mm_M1_16_K7168_N128` | 4 | off | 1.0280x | 1.0364x |  |
| `mm_M1_16_K7168_N128` | 4 | on | 1.0280x | 1.0364x |  |
| `mm_M1_16_K7168_N128` | 5 | off | 1.1071x | 1.0948x |  |
| `mm_M1_16_K7168_N128` | 5 | on | 1.1071x | 1.0948x |  |
| `mm_M1_16_K7168_N128` | 6 | off | 1.1304x | 1.1167x |  |
| `mm_M1_16_K7168_N128` | 6 | on | 1.1220x | 1.1167x |  |
| `mm_M1_16_K7168_N128` | 7 | off | 1.0382x | 1.0448x |  |
| `mm_M1_16_K7168_N128` | 7 | on | 1.0382x | 1.0445x |  |
| `mm_M1_16_K7168_N128` | 8 | off | 1.1185x | 1.1151x |  |
| `mm_M1_16_K7168_N128` | 8 | on | 1.1185x | 1.1151x |  |
| `mm_M1_16_K7168_N128` | 9 | off | 1.1223x | 1.1189x |  |
| `mm_M1_16_K7168_N128` | 9 | on | 1.1223x | 1.1189x |  |
| `mm_M1_16_K7168_N128` | 10 | off | 1.0516x | 1.0439x |  |
| `mm_M1_16_K7168_N128` | 10 | on | 1.0516x | 1.0437x |  |
| `mm_M1_16_K7168_N128` | 11 | off | 1.1076x | 1.1173x |  |
| `mm_M1_16_K7168_N128` | 11 | on | 1.1076x | 1.1173x |  |
| `mm_M1_16_K7168_N128` | 12 | off | 1.1280x | 1.1190x |  |
| `mm_M1_16_K7168_N128` | 12 | on | 1.1280x | 1.1190x |  |
| `mm_M1_16_K7168_N128` | 13 | off | 1.1080x | 1.1103x |  |
| `mm_M1_16_K7168_N128` | 13 | on | 1.1080x | 1.0991x |  |
| `mm_M1_16_K7168_N128` | 14 | off | 1.1297x | 1.1258x |  |
| `mm_M1_16_K7168_N128` | 14 | on | 1.1237x | 1.1257x |  |
| `mm_M1_16_K7168_N128` | 15 | off | 1.1333x | 1.1307x |  |
| `mm_M1_16_K7168_N128` | 15 | on | 1.1333x | 1.1307x |  |
| `mm_M1_16_K7168_N128` | 16 | off | 1.1386x | 1.1345x |  |
| `mm_M1_16_K7168_N128` | 16 | on | 1.1443x | 1.1298x |  |
| `mm_M1_16_K6144_N256` | 1 | off | 1.0110x | 1.0108x |  |
| `mm_M1_16_K6144_N256` | 1 | on | 1.0110x | 1.0108x |  |
| `mm_M1_16_K6144_N256` | 2 | off | 1.0211x | 1.0206x |  |
| `mm_M1_16_K6144_N256` | 2 | on | 1.0211x | 1.0206x |  |
| `mm_M1_16_K6144_N256` | 3 | off | 1.0990x | 1.0769x |  |
| `mm_M1_16_K6144_N256` | 3 | on | 1.0990x | 1.0865x |  |
| `mm_M1_16_K6144_N256` | 4 | off | 1.0174x | 1.0512x |  |
| `mm_M1_16_K6144_N256` | 4 | on | 1.0174x | 1.0342x |  |
| `mm_M1_16_K6144_N256` | 5 | off | 1.0252x | 1.0247x |  |
| `mm_M1_16_K6144_N256` | 5 | on | 1.0252x | 1.0244x |  |
| `mm_M1_16_K6144_N256` | 6 | off | 1.1048x | 1.1021x |  |
| `mm_M1_16_K6144_N256` | 6 | on | 1.1129x | 1.0938x |  |
| `mm_M1_16_K6144_N256` | 7 | off | 1.0455x | 1.0597x |  |
| `mm_M1_16_K6144_N256` | 7 | on | 1.0455x | 1.0447x |  |
| `mm_M1_16_K6144_N256` | 8 | off | 1.0493x | 1.0550x |  |
| `mm_M1_16_K6144_N256` | 8 | on | 1.0493x | 1.0479x |  |
| `mm_M1_16_K6144_N256` | 9 | off | 1.0884x | 1.0927x |  |
| `mm_M1_16_K6144_N256` | 9 | on | 1.0884x | 1.0927x |  |
| `mm_M1_16_K6144_N256` | 10 | off | 1.0779x | 1.0755x |  |
| `mm_M1_16_K6144_N256` | 10 | on | 1.0779x | 1.0818x |  |
| `mm_M1_16_K6144_N256` | 11 | off | 1.0692x | 1.0791x |  |
| `mm_M1_16_K6144_N256` | 11 | on | 1.0692x | 1.0793x |  |
| `mm_M1_16_K6144_N256` | 12 | off | 1.1012x | 1.0862x |  |
| `mm_M1_16_K6144_N256` | 12 | on | 1.1012x | 1.0862x |  |
| `mm_M1_16_K6144_N256` | 13 | off | 1.1471x | 1.1364x |  |
| `mm_M1_16_K6144_N256` | 13 | on | 1.1471x | 1.1366x |  |
| `mm_M1_16_K6144_N256` | 14 | off | 1.1461x | 1.1351x |  |
| `mm_M1_16_K6144_N256` | 14 | on | 1.1461x | 1.1413x |  |
| `mm_M1_16_K6144_N256` | 15 | off | 1.0947x | 1.0769x |  |
| `mm_M1_16_K6144_N256` | 15 | on | 1.0947x | 1.0769x |  |
| `mm_M1_16_K6144_N256` | 16 | off | 1.1015x | 1.0837x |  |
| `mm_M1_16_K6144_N256` | 16 | on | 1.1015x | 1.0837x |  |


| E2E workload | Hardware | Baseline | Cake Router GEMM | Aggregate speedup | Per-run speedup range | Accuracy delta | Tracker |
|---|---|---:|---:|---:|---:|---:|---|
| GSM8K, DeepSeek-V3-0324 FP8, TP4/EP4, 1,319 questions x 2 reversed-order runs | 4x GB300 | 68.672 tok/s | 68.876 tok/s | 1.0030x | 0.9895x-1.0169x | 93.442% to 94.428% (+0.986 pp) | [SGLang #35417](https://github.com/sgl-project/sglang/pull/35417) |
