### PR TITLE
fix(sampling): reject unsafe multi-CTA top-k launches on low-SM GPUs

### DIFF
--- a/csrc/renorm.cu
+++ b/csrc/renorm.cu
@@ -117,6 +117,14 @@ void top_k_mask_logits(TensorView logits, TensorView mask_logits,
     return true;
   });
 
+  if (status == cudaErrorNotSupported) {
+    TVM_FFI_ICHECK(false)
+        << "top_k_mask_logits does not support multi-CTA execution on GPUs with 16 or fewer "
+           "SMs because its cross-CTA software barrier cannot guarantee forward progress "
+        << "(vocab_size=" << vocab_size
+        << "). Use top_k_top_p_sampling_from_logits(..., filter_apply_order=\"joint\") when "
+           "joint filtering semantics are acceptable, or configure another sampling backend.";
+  }
   TVM_FFI_ICHECK(status == cudaSuccess)
       << "TopKMaskLogits failed with error code " << cudaGetErrorString(status);
 }

--- a/include/flashinfer/topk.cuh
+++ b/include/flashinfer/topk.cuh
@@ -1710,6 +1710,14 @@ cudaError_t RadixTopKMaskLogitsMultiCTA(DType* logits, DType* masked_logits, IdT
   const uint32_t smem_size = fixed_smem_aligned + chunk_size * sizeof(OrderedType);
   const bool single_cta = (ctas_per_group == 1);
 
+  // The multi-CTA path uses a software barrier whose participants must all be
+  // resident concurrently.  Low-SM GPUs cannot provide that guarantee once a
+  // row spans multiple CTAs, so fail before launching instead of risking a
+  // permanent stream hang.  The barrier-free single-CTA path remains enabled.
+  if (!single_cta && num_sms <= 16) {
+    return cudaErrorNotSupported;
+  }
+
   // Calculate number of groups (how many rows to process concurrently)
   uint32_t num_groups = std::min(static_cast<uint32_t>(num_sms) / ctas_per_group, batch_size);
   if (num_groups == 0) num_groups = 1;


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->

Prevent `top_k_mask_logits` from launching its multi-CTA radix kernel on GPUs with 16 or fewer SMs.

The multi-CTA implementation uses a software barrier that requires all participating CTAs to remain resident concurrently. Low-SM GPUs such as the 10-SM NVIDIA A16 cannot guarantee this, potentially causing the CUDA stream to hang indefinitely.

This change:
- Returns `cudaErrorNotSupported` before an unsafe multi-CTA launch.
- Preserves the barrier-free single-CTA path on low-SM GPUs.
- Reports an actionable error recommending `top_k_top_p_sampling_from_logits(..., filter_apply_order="joint")` when joint filtering semantics are acceptable, or another sampling backend.

## 🔍 Related Issues

<!-- Link any related issues here -->

#4544

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for top-k logit masking on GPUs with 16 or fewer streaming multiprocessors.
  * Displays a clearer message with the vocabulary size and guidance to use an alternative configuration.
  * Preserves existing behavior for supported GPUs and single-CTA execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->