### PR TITLE
Adding var-window FMHA context support for PrimsTS.

### DIFF
--- a/flashinfer/attention/prims_ts/context.py
+++ b/flashinfer/attention/prims_ts/context.py
@@ -1701,10 +1701,15 @@ class BatchPrefillTSWrapper:
             Fixed or packed query, key, and value tensors.
         qo_indptr, kv_indptr : torch.Tensor, optional
             Cumulative query and K/V offsets for packed-ragged input.
-        mask_type : {"dense", "causal"}
-            Attention mask mode.
+        mask_type : {"dense", "causal", "variable_window"}
+            Attention mask mode. ``variable_window`` is supported only for
+            fixed-shape inputs.
         window_left : int
             Left sliding-window extent, or ``-1`` to disable the window.
+        variable_window_token_starts, variable_window_token_ends : torch.Tensor, optional
+            Inclusive per-query K bounds required for ``variable_window``.
+            Both must be CUDA int32 tensors shaped ``[B, Sq]`` and satisfy
+            ``0 <= starts[b, q] <= ends[b, q] < Sk``.
         sm_scale : float, optional
             Softmax scale; defaults to the inverse square root of head size.
         output_scale : float
@@ -2107,10 +2112,15 @@ def batch_prefill(
         Fixed or packed query, key, and value tensors.
     qo_indptr, kv_indptr : torch.Tensor, optional
         Cumulative query and K/V offsets for packed-ragged input.
-    mask_type : {"dense", "causal"}
-        Attention mask mode.
+    mask_type : {"dense", "causal", "variable_window"}
+        Attention mask mode. ``variable_window`` is supported only for
+        fixed-shape inputs.
     window_left : int
         Left sliding-window extent, or ``-1`` to disable the window.
+    variable_window_token_starts, variable_window_token_ends : torch.Tensor, optional
+        Inclusive per-query K bounds required for ``variable_window``. Both
+        must be CUDA int32 tensors shaped ``[B, Sq]`` and satisfy
+        ``0 <= starts[b, q] <= ends[b, q] < Sk``.
     sm_scale : float, optional
         Softmax scale; defaults to the inverse square root of head size.
     output_scale : float

--- a/flashinfer/attention/prims_ts/context.py
+++ b/flashinfer/attention/prims_ts/context.py
@@ -220,9 +220,10 @@ def _validate_device(device: torch.device) -> int:
 def _validate_mask(mask_type: str) -> None:
     if not isinstance(mask_type, str):
         raise TypeError("mask_type must be a string")
-    if mask_type not in ("dense", "causal"):
+    if mask_type not in ("dense", "causal", "variable_window"):
         raise ValueError(
-            f"mask_type must be exactly 'dense' or 'causal', got {mask_type!r}"
+            "mask_type must be exactly 'dense', 'causal', or "
+            f"'variable_window', got {mask_type!r}"
         )
 
 
@@ -238,6 +239,40 @@ def _validate_window_left(window_left: int, mask_type: str) -> int:
     if window_left > 0 and mask_type != "causal":
         raise ValueError("a positive window_left requires mask_type='causal'")
     return window_left
+
+
+def _validate_variable_window_bounds(
+    starts: Optional[torch.Tensor],
+    ends: Optional[torch.Tensor],
+    *,
+    geometry: _ContextGeometry,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Validate inclusive per-query K bounds for contiguous attention."""
+    if starts is None or ends is None:
+        raise ValueError(
+            "variable_window_token_starts and variable_window_token_ends are "
+            "required for mask_type='variable_window'"
+        )
+    if geometry.packed:
+        raise NotImplementedError(
+            "variable_window currently requires fixed [B, S, H, D] tensors"
+        )
+    expected_shape = (geometry.batch_size, geometry.max_seq_len_q)
+    for tensor, name in (
+        (starts, "variable_window_token_starts"),
+        (ends, "variable_window_token_ends"),
+    ):
+        _validate_tensor(tensor, name)
+        if tensor.device != geometry.device:
+            raise ValueError(f"{name} must be on {geometry.device}, got {tensor.device}")
+        if tensor.dtype != torch.int32:
+            raise ValueError(f"{name} must have dtype torch.int32, got {tensor.dtype}")
+        if tuple(tensor.shape) != expected_shape:
+            raise ValueError(
+                f"{name} must have shape {expected_shape}, got {tuple(tensor.shape)}"
+            )
+        _validate_compact(tensor, name, "[B, Sq]")
+    return starts.flatten(), ends.flatten()
 
 
 def _validate_scale(value: object, name: str) -> float:
@@ -1010,6 +1045,7 @@ def _get_compiled_context(
     input_dtype = dtype_map[q_dtype_key]
     output_dtype = dtype_map[output_dtype_key]
     is_causal = mask_type == "causal"
+    has_variable_window = mask_type == "variable_window"
     # Construct the scheduler-independent topology first. Immutable
     # single-instance domains can use the lower-overhead static persistent
     # queue; paired or live-ragged domains are reconstructed with CLC.
@@ -1021,6 +1057,7 @@ def _get_compiled_context(
         d=head_dim,
         is_persistent=True,
         is_causal=is_causal,
+        has_variable_window=has_variable_window,
         balance_causal_workload=_uses_heavy_first_static_causal_raster(
             mask_type=mask_type,
             window_left=window_left,
@@ -1067,6 +1104,7 @@ def _get_compiled_context(
             d=head_dim,
             is_persistent=True,
             is_causal=is_causal,
+            has_variable_window=has_variable_window,
             is_clc_dynamic=True,
             head_paired=head_paired,
             window_size_left=window_left if window_left > 0 else 0,
@@ -1083,6 +1121,7 @@ def _get_compiled_context(
             d=head_dim,
             is_persistent=False,
             is_causal=is_causal,
+            has_variable_window=has_variable_window,
             is_clc_dynamic=False,
             head_paired=head_paired,
             window_size_left=window_left if window_left > 0 else 0,
@@ -1116,6 +1155,8 @@ def _get_compiled_context(
         output_scale: cute.Tensor,
         qo_indptr: cute.Tensor,
         kv_indptr: cute.Tensor,
+        variable_window_token_starts: cute.Tensor,
+        variable_window_token_ends: cute.Tensor,
         stream: cuda_drv.CUstream,
         static_max_active_clusters: cutlass.Constexpr[int],
         static_packed: cutlass.Constexpr[bool],
@@ -1138,6 +1179,8 @@ def _get_compiled_context(
                 kv_indptr,
                 cutlass.Int32(static_max_seq_len_q),
                 cutlass.Int32(static_max_seq_len_k),
+                variable_window_token_starts=variable_window_token_starts,
+                variable_window_token_ends=variable_window_token_ends,
             )
         else:
             fmha(
@@ -1149,6 +1192,8 @@ def _get_compiled_context(
                 output_scale,
                 static_max_active_clusters,
                 stream,
+                variable_window_token_starts=variable_window_token_starts,
+                variable_window_token_ends=variable_window_token_ends,
             )
 
     def fake_compact(dtype, shape, assumed_align):
@@ -1182,6 +1227,15 @@ def _get_compiled_context(
     output_scale_fake = fake_compact(cutlass.Float32, (1,), 4)
     qo_indptr_fake = fake_compact(cutlass.Int32, indptr_shape, 4)
     kv_indptr_fake = fake_compact(cutlass.Int32, indptr_shape, 4)
+    variable_window_shape = (
+        (batch_size * max_seq_len_q,) if has_variable_window else (1,)
+    )
+    variable_window_starts_fake = fake_compact(
+        cutlass.Int32, variable_window_shape, 4
+    )
+    variable_window_ends_fake = fake_compact(
+        cutlass.Int32, variable_window_shape, 4
+    )
     stream_fake = cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=True)
 
     # Task objects carry loop-local state through generated control flow, so
@@ -1197,6 +1251,8 @@ def _get_compiled_context(
             output_scale_fake,
             qo_indptr_fake,
             kv_indptr_fake,
+            variable_window_starts_fake,
+            variable_window_ends_fake,
             stream_fake,
             max_active_clusters,
             packed,
@@ -1580,8 +1636,10 @@ class BatchPrefillTSWrapper:
         *,
         qo_indptr: Optional[torch.Tensor] = None,
         kv_indptr: Optional[torch.Tensor] = None,
-        mask_type: Literal["dense", "causal"] = "dense",
+        mask_type: Literal["dense", "causal", "variable_window"] = "dense",
         window_left: int = -1,
+        variable_window_token_starts: Optional[torch.Tensor] = None,
+        variable_window_token_ends: Optional[torch.Tensor] = None,
         sm_scale: Optional[float] = None,
         output_scale: float = 1.0,
         out_dtype: Optional[torch.dtype] = None,
@@ -1625,6 +1683,28 @@ class BatchPrefillTSWrapper:
             window_left=window_left,
             output_dtype=resolved_out_dtype,
         )
+        if mask_type == "variable_window":
+            planned_window_starts, planned_window_ends = (
+                _validate_variable_window_bounds(
+                    variable_window_token_starts,
+                    variable_window_token_ends,
+                    geometry=geometry,
+                )
+            )
+        else:
+            if (
+                variable_window_token_starts is not None
+                or variable_window_token_ends is not None
+            ):
+                raise ValueError(
+                    "variable-window bounds require mask_type='variable_window'"
+                )
+            planned_window_starts = torch.empty(
+                1, dtype=torch.int32, device=geometry.device
+            )
+            planned_window_ends = torch.empty(
+                1, dtype=torch.int32, device=geometry.device
+            )
         if sm_scale is None:
             sm_scale = 1.0 / math.sqrt(geometry.head_dim)
         sm_scale = _validate_scale(sm_scale, "sm_scale")
@@ -1663,6 +1743,8 @@ class BatchPrefillTSWrapper:
         self._kv_indptr = planned_kv_indptr
         self._scale_softmax_log2 = scale_tensor
         self._output_scale = output_scale_tensor
+        self._variable_window_token_starts = planned_window_starts
+        self._variable_window_token_ends = planned_window_ends
         self._compiled = compiled
         self._policy = policy
         self._planned = True
@@ -1701,6 +1783,8 @@ class BatchPrefillTSWrapper:
                 ("kv_indptr", self._kv_indptr),
                 ("scale_softmax_log2", self._scale_softmax_log2),
                 ("output_scale", self._output_scale),
+                ("variable_window_token_starts", self._variable_window_token_starts),
+                ("variable_window_token_ends", self._variable_window_token_ends),
             )
         self._compiled(
             q,
@@ -1711,6 +1795,8 @@ class BatchPrefillTSWrapper:
             self._output_scale,
             self._qo_indptr,
             self._kv_indptr,
+            self._variable_window_token_starts,
+            self._variable_window_token_ends,
         )
         return out
 
@@ -1936,8 +2022,10 @@ def batch_prefill(
     *,
     qo_indptr: Optional[torch.Tensor] = None,
     kv_indptr: Optional[torch.Tensor] = None,
-    mask_type: Literal["dense", "causal"] = "dense",
+    mask_type: Literal["dense", "causal", "variable_window"] = "dense",
     window_left: int = -1,
+    variable_window_token_starts: Optional[torch.Tensor] = None,
+    variable_window_token_ends: Optional[torch.Tensor] = None,
     sm_scale: Optional[float] = None,
     output_scale: float = 1.0,
     out_dtype: Optional[torch.dtype] = None,
@@ -1985,6 +2073,8 @@ def batch_prefill(
         kv_indptr=kv_indptr,
         mask_type=mask_type,
         window_left=window_left,
+        variable_window_token_starts=variable_window_token_starts,
+        variable_window_token_ends=variable_window_token_ends,
         sm_scale=sm_scale,
         output_scale=output_scale,
         out_dtype=resolved_out_dtype,

--- a/flashinfer/attention/prims_ts/context.py
+++ b/flashinfer/attention/prims_ts/context.py
@@ -264,7 +264,9 @@ def _validate_variable_window_bounds(
     ):
         _validate_tensor(tensor, name)
         if tensor.device != geometry.device:
-            raise ValueError(f"{name} must be on {geometry.device}, got {tensor.device}")
+            raise ValueError(
+                f"{name} must be on {geometry.device}, got {tensor.device}"
+            )
         if tensor.dtype != torch.int32:
             raise ValueError(f"{name} must have dtype torch.int32, got {tensor.dtype}")
         if tuple(tensor.shape) != expected_shape:
@@ -1230,12 +1232,8 @@ def _get_compiled_context(
     variable_window_shape = (
         (batch_size * max_seq_len_q,) if has_variable_window else (1,)
     )
-    variable_window_starts_fake = fake_compact(
-        cutlass.Int32, variable_window_shape, 4
-    )
-    variable_window_ends_fake = fake_compact(
-        cutlass.Int32, variable_window_shape, 4
-    )
+    variable_window_starts_fake = fake_compact(cutlass.Int32, variable_window_shape, 4)
+    variable_window_ends_fake = fake_compact(cutlass.Int32, variable_window_shape, 4)
     stream_fake = cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=True)
 
     # Task objects carry loop-local state through generated control flow, so

--- a/flashinfer/attention/prims_ts/context.py
+++ b/flashinfer/attention/prims_ts/context.py
@@ -65,6 +65,7 @@ _SUPPORTED_COMPUTE_CAPABILITIES = ((10, 0), (10, 3))
 _INT32_MAX = 2**31 - 1
 _CUDA_GRID_YZ_MAX = 65_535
 _CONTEXT_KV_TILE_N = 128
+_CONTEXT_Q_TILE_M = 128
 # Query-paired D128 represents two 128-row Q tiles in one work tile.  Kernel
 # coordinates include the padded tail of that 256-row span and, for masking,
 # its exclusive right boundary.  Reserve the maximum 255-row tail padding in
@@ -275,6 +276,32 @@ def _validate_variable_window_bounds(
             )
         _validate_compact(tensor, name, "[B, Sq]")
     return starts.flatten(), ends.flatten()
+
+
+def _build_variable_window_cta_starts(
+    starts: torch.Tensor, *, geometry: _ContextGeometry
+) -> torch.Tensor:
+    """Reduce fixed per-row starts into one minimum for each kernel Q CTA."""
+    cta_m = (
+        _CONTEXT_MAX_Q_ROWS_PER_WORK_TILE
+        if geometry.head_dim == _CONTEXT_Q_TILE_M
+        else _CONTEXT_Q_TILE_M
+    )
+    num_seq_tiles = (geometry.max_seq_len_q + cta_m - 1) // cta_m
+    padded_rows = num_seq_tiles * cta_m
+    starts_2d = starts.view(geometry.batch_size, geometry.max_seq_len_q)
+    if padded_rows != geometry.max_seq_len_q:
+        padded = torch.full(
+            (geometry.batch_size, padded_rows),
+            _INT32_MAX,
+            dtype=torch.int32,
+            device=geometry.device,
+        )
+        padded[:, : geometry.max_seq_len_q] = starts_2d
+        starts_2d = padded
+    return (
+        starts_2d.view(geometry.batch_size, num_seq_tiles, cta_m).amin(dim=-1).flatten()
+    )
 
 
 def _validate_scale(value: object, name: str) -> float:
@@ -782,9 +809,13 @@ def _resolve_paged_geometry(
 ) -> tuple[_PagedContextGeometry, _PagedContextMetadata]:
     """Validate packed-Q paged-KV inputs and materialize their static ABI."""
 
+    _validate_mask(mask_type)
+    if mask_type == "variable_window":
+        raise NotImplementedError(
+            "mask_type='variable_window' is not supported for paged context"
+        )
     _validate_base_tensors(q, k_cache, v_cache)
     _validate_output_dtype(output_dtype)
-    _validate_mask(mask_type)
     window_left = _validate_window_left(window_left, mask_type)
     page_size = _validate_page_size(page_size)
     device_index = _validate_device(q.device)
@@ -1159,6 +1190,7 @@ def _get_compiled_context(
         kv_indptr: cute.Tensor,
         variable_window_token_starts: cute.Tensor,
         variable_window_token_ends: cute.Tensor,
+        variable_window_cta_starts: cute.Tensor,
         stream: cuda_drv.CUstream,
         static_max_active_clusters: cutlass.Constexpr[int],
         static_packed: cutlass.Constexpr[bool],
@@ -1183,6 +1215,7 @@ def _get_compiled_context(
                 cutlass.Int32(static_max_seq_len_k),
                 variable_window_token_starts=variable_window_token_starts,
                 variable_window_token_ends=variable_window_token_ends,
+                variable_window_cta_starts=variable_window_cta_starts,
             )
         else:
             fmha(
@@ -1196,6 +1229,7 @@ def _get_compiled_context(
                 stream,
                 variable_window_token_starts=variable_window_token_starts,
                 variable_window_token_ends=variable_window_token_ends,
+                variable_window_cta_starts=variable_window_cta_starts,
             )
 
     def fake_compact(dtype, shape, assumed_align):
@@ -1234,6 +1268,19 @@ def _get_compiled_context(
     )
     variable_window_starts_fake = fake_compact(cutlass.Int32, variable_window_shape, 4)
     variable_window_ends_fake = fake_compact(cutlass.Int32, variable_window_shape, 4)
+    variable_window_cta_m = (
+        _CONTEXT_MAX_Q_ROWS_PER_WORK_TILE
+        if head_dim == _CONTEXT_Q_TILE_M
+        else _CONTEXT_Q_TILE_M
+    )
+    variable_window_cta_shape = (
+        (batch_size * cute.ceil_div(max_seq_len_q, variable_window_cta_m),)
+        if has_variable_window
+        else (1,)
+    )
+    variable_window_cta_starts_fake = fake_compact(
+        cutlass.Int32, variable_window_cta_shape, 4
+    )
     stream_fake = cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=True)
 
     # Task objects carry loop-local state through generated control flow, so
@@ -1251,6 +1298,7 @@ def _get_compiled_context(
             kv_indptr_fake,
             variable_window_starts_fake,
             variable_window_ends_fake,
+            variable_window_cta_starts_fake,
             stream_fake,
             max_active_clusters,
             packed,
@@ -1682,12 +1730,20 @@ class BatchPrefillTSWrapper:
             output_dtype=resolved_out_dtype,
         )
         if mask_type == "variable_window":
-            planned_window_starts, planned_window_ends = (
+            validated_window_starts, validated_window_ends = (
                 _validate_variable_window_bounds(
                     variable_window_token_starts,
                     variable_window_token_ends,
                     geometry=geometry,
                 )
+            )
+            # Variable-window bounds are plan metadata. Keep one internal
+            # snapshot so row masks and the reduced CTA origins cannot diverge
+            # if the caller later modifies its tensors.
+            planned_window_starts = validated_window_starts.clone()
+            planned_window_ends = validated_window_ends.clone()
+            planned_window_cta_starts = _build_variable_window_cta_starts(
+                planned_window_starts, geometry=geometry
             )
         else:
             if (
@@ -1701,6 +1757,9 @@ class BatchPrefillTSWrapper:
                 1, dtype=torch.int32, device=geometry.device
             )
             planned_window_ends = torch.empty(
+                1, dtype=torch.int32, device=geometry.device
+            )
+            planned_window_cta_starts = torch.empty(
                 1, dtype=torch.int32, device=geometry.device
             )
         if sm_scale is None:
@@ -1743,6 +1802,7 @@ class BatchPrefillTSWrapper:
         self._output_scale = output_scale_tensor
         self._variable_window_token_starts = planned_window_starts
         self._variable_window_token_ends = planned_window_ends
+        self._variable_window_cta_starts = planned_window_cta_starts
         self._compiled = compiled
         self._policy = policy
         self._planned = True
@@ -1783,6 +1843,7 @@ class BatchPrefillTSWrapper:
                 ("output_scale", self._output_scale),
                 ("variable_window_token_starts", self._variable_window_token_starts),
                 ("variable_window_token_ends", self._variable_window_token_ends),
+                ("variable_window_cta_starts", self._variable_window_cta_starts),
             )
         self._compiled(
             q,
@@ -1795,6 +1856,7 @@ class BatchPrefillTSWrapper:
             self._kv_indptr,
             self._variable_window_token_starts,
             self._variable_window_token_ends,
+            self._variable_window_cta_starts,
         )
         return out
 

--- a/flashinfer/attention/prims_ts/context.py
+++ b/flashinfer/attention/prims_ts/context.py
@@ -65,7 +65,7 @@ _SUPPORTED_COMPUTE_CAPABILITIES = ((10, 0), (10, 3))
 _INT32_MAX = 2**31 - 1
 _CUDA_GRID_YZ_MAX = 65_535
 _CONTEXT_KV_TILE_N = 128
-_CONTEXT_Q_TILE_M = 128
+_CONTEXT_TILE_SIZE_Q = 128
 # Query-paired D128 represents two 128-row Q tiles in one work tile.  Kernel
 # coordinates include the padded tail of that 256-row span and, for masking,
 # its exclusive right boundary.  Reserve the maximum 255-row tail padding in
@@ -282,13 +282,13 @@ def _build_variable_window_cta_starts(
     starts: torch.Tensor, *, geometry: _ContextGeometry
 ) -> torch.Tensor:
     """Reduce fixed per-row starts into one minimum for each kernel Q CTA."""
-    cta_m = (
+    tile_size_q = (
         _CONTEXT_MAX_Q_ROWS_PER_WORK_TILE
-        if geometry.head_dim == _CONTEXT_Q_TILE_M
-        else _CONTEXT_Q_TILE_M
+        if geometry.head_dim == _CONTEXT_TILE_SIZE_Q
+        else _CONTEXT_TILE_SIZE_Q
     )
-    num_seq_tiles = (geometry.max_seq_len_q + cta_m - 1) // cta_m
-    padded_rows = num_seq_tiles * cta_m
+    num_seq_tiles = (geometry.max_seq_len_q + tile_size_q - 1) // tile_size_q
+    padded_rows = num_seq_tiles * tile_size_q
     starts_2d = starts.view(geometry.batch_size, geometry.max_seq_len_q)
     if padded_rows != geometry.max_seq_len_q:
         padded = torch.full(
@@ -300,7 +300,9 @@ def _build_variable_window_cta_starts(
         padded[:, : geometry.max_seq_len_q] = starts_2d
         starts_2d = padded
     return (
-        starts_2d.view(geometry.batch_size, num_seq_tiles, cta_m).amin(dim=-1).flatten()
+        starts_2d.view(geometry.batch_size, num_seq_tiles, tile_size_q)
+        .amin(dim=-1)
+        .flatten()
     )
 
 
@@ -1268,13 +1270,13 @@ def _get_compiled_context(
     )
     variable_window_starts_fake = fake_compact(cutlass.Int32, variable_window_shape, 4)
     variable_window_ends_fake = fake_compact(cutlass.Int32, variable_window_shape, 4)
-    variable_window_cta_m = (
+    variable_window_tile_size_q = (
         _CONTEXT_MAX_Q_ROWS_PER_WORK_TILE
-        if head_dim == _CONTEXT_Q_TILE_M
-        else _CONTEXT_Q_TILE_M
+        if head_dim == _CONTEXT_TILE_SIZE_Q
+        else _CONTEXT_TILE_SIZE_Q
     )
     variable_window_cta_shape = (
-        (batch_size * cute.ceil_div(max_seq_len_q, variable_window_cta_m),)
+        (batch_size * cute.ceil_div(max_seq_len_q, variable_window_tile_size_q),)
         if has_variable_window
         else (1,)
     )

--- a/flashinfer/attention/prims_ts/kernels/fmha_context/fmha_kernel.py
+++ b/flashinfer/attention/prims_ts/kernels/fmha_context/fmha_kernel.py
@@ -557,9 +557,7 @@ class VariableWindowDomainTask(Task):
         first_k = Int32(
             self._variable_window_token_starts[packed_q_base + first_local_q]
         )
-        last_k = Int32(
-            self._variable_window_token_ends[packed_q_base + last_local_q]
-        )
+        last_k = Int32(self._variable_window_token_ends[packed_q_base + last_local_q])
         first_k_tile = first_k // self._kv_n
         last_k_tile = (last_k + self._kv_n) // self._kv_n
         return last_k_tile - first_k_tile - self._offset

--- a/flashinfer/attention/prims_ts/kernels/fmha_context/fmha_kernel.py
+++ b/flashinfer/attention/prims_ts/kernels/fmha_context/fmha_kernel.py
@@ -192,6 +192,7 @@ from .fmha_tasks import (
 from .helpers import (
     bottom_right_window_max_tiles,
     bottom_right_window_tile_start,
+    variable_window_cta_min_start,
 )
 from cutlass.experimental import primitives as prims
 
@@ -522,6 +523,7 @@ class VariableWindowDomainTask(Task):
         self,
         variable_window_token_starts: cute.Tensor,
         variable_window_token_ends: cute.Tensor,
+        variable_window_cta_starts: cute.Tensor,
         num_kv_tiles: int | Int32,
         q_stride: int | Int32,
         cta_m: int,
@@ -536,6 +538,7 @@ class VariableWindowDomainTask(Task):
         super().__init__(**kwargs)
         self._variable_window_token_starts = variable_window_token_starts
         self._variable_window_token_ends = variable_window_token_ends
+        self._variable_window_cta_starts = variable_window_cta_starts
         self._num_kv_tiles = num_kv_tiles
         self._q_stride = q_stride
         self._cta_m = cta_m
@@ -554,8 +557,12 @@ class VariableWindowDomainTask(Task):
             self._q_stride - Int32(1),
         )
         packed_q_base = batch_coord * self._q_stride
-        first_k = Int32(
-            self._variable_window_token_starts[packed_q_base + first_local_q]
+        first_k = variable_window_cta_min_start(
+            self._variable_window_cta_starts,
+            batch_coord=batch_coord,
+            seq_coord=seq_coord,
+            q_stride=self._q_stride,
+            cta_m=self._cta_m,
         )
         last_k = Int32(self._variable_window_token_ends[packed_q_base + last_local_q])
         first_k_tile = first_k // self._kv_n
@@ -628,6 +635,7 @@ def build_context_task_manager(
     cum_seqlen_k: cute.Tensor | None,
     variable_window_token_starts: cute.Tensor | None = None,
     variable_window_token_ends: cute.Tensor | None = None,
+    variable_window_cta_starts: cute.Tensor | None = None,
     variable_window_q_stride: int | Int32 = 0,
     scale_softmax_log2: cute.Tensor | None = None,
     output_scale: cute.Tensor | None = None,
@@ -926,6 +934,7 @@ def build_context_task_manager(
         seqlens_kv=g_seq_lens_kv,
         max_seq_len_kv=max_seq_len_kv,
         variable_window_token_starts=variable_window_token_starts,
+        variable_window_cta_starts=variable_window_cta_starts,
         variable_window_q_stride=variable_window_q_stride,
         name="gmem_qkv",
     )
@@ -1052,6 +1061,7 @@ def build_context_task_manager(
         cum_seqlen_k=cum_seqlen_k,
         variable_window_token_starts=variable_window_token_starts,
         variable_window_token_ends=variable_window_token_ends,
+        variable_window_cta_starts=variable_window_cta_starts,
         variable_window_q_stride=variable_window_q_stride,
         scale_softmax_log2=scale_softmax_log2,
         name="tmem_sp0",
@@ -1113,6 +1123,7 @@ def build_context_task_manager(
             cum_seqlen_k=cum_seqlen_k,
             variable_window_token_starts=variable_window_token_starts,
             variable_window_token_ends=variable_window_token_ends,
+            variable_window_cta_starts=variable_window_cta_starts,
             variable_window_q_stride=variable_window_q_stride,
             scale_softmax_log2=scale_softmax_log2,
             name="tmem_sp1",
@@ -1982,6 +1993,7 @@ def _select_fmha_domain_policy(
     cum_seqlen_k: cute.Tensor | None,
     variable_window_token_starts: cute.Tensor | None = None,
     variable_window_token_ends: cute.Tensor | None = None,
+    variable_window_cta_starts: cute.Tensor | None = None,
     variable_window_q_stride: int | Int32 = 0,
 ) -> FmhaDomainPolicy:
     """Select loop domains and softmax masks for the configured FMHA mode."""
@@ -1993,12 +2005,17 @@ def _select_fmha_domain_policy(
         else None
     )
     if cfg.has_variable_window:
-        if variable_window_token_starts is None or variable_window_token_ends is None:
+        if (
+            variable_window_token_starts is None
+            or variable_window_token_ends is None
+            or variable_window_cta_starts is None
+        ):
             raise ValueError("VariableWindow domain requires start and end tensors")
         base_kwargs: DomainKwargs = {
             "task_class": VariableWindowDomainTask,
             "variable_window_token_starts": variable_window_token_starts,
             "variable_window_token_ends": variable_window_token_ends,
+            "variable_window_cta_starts": variable_window_cta_starts,
             "num_kv_tiles": num_kv_tiles,
             "q_stride": variable_window_q_stride,
             "cta_m": cfg.cta_tiler[0],
@@ -2173,6 +2190,7 @@ def build_fmha_task_manager(
     num_kv_tiles: int | Int32,
     variable_window_token_starts: cute.Tensor | None = None,
     variable_window_token_ends: cute.Tensor | None = None,
+    variable_window_cta_starts: cute.Tensor | None = None,
     variable_window_q_stride: int | Int32 = 0,
     scale_softmax_log2: cute.Tensor | None = None,
     output_scale: cute.Tensor | None = None,
@@ -2247,6 +2265,7 @@ def build_fmha_task_manager(
         ),
         variable_window_token_starts=variable_window_token_starts,
         variable_window_token_ends=variable_window_token_ends,
+        variable_window_cta_starts=variable_window_cta_starts,
         variable_window_q_stride=variable_window_q_stride,
     )
 
@@ -2261,6 +2280,7 @@ def build_fmha_task_manager(
         cum_seqlen_k=cum_seqlen_k,
         variable_window_token_starts=variable_window_token_starts,
         variable_window_token_ends=variable_window_token_ends,
+        variable_window_cta_starts=variable_window_cta_starts,
         variable_window_q_stride=variable_window_q_stride,
         scale_softmax_log2=scale_softmax_log2,
         output_scale=output_scale,
@@ -2375,6 +2395,10 @@ class FmhaTs:
         if has_variable_window and (is_causal or window_size_left > 0):
             raise ValueError(
                 "VariableWindow bounds replace causal and sliding-window masks"
+            )
+        if has_variable_window and use_paged_kv:
+            raise NotImplementedError(
+                "variable-window masking is not supported for paged context"
             )
         validate_head_paired_head_ratio(head_paired=head_paired, h_r=h_r)
         if use_paged_kv:
@@ -2555,6 +2579,7 @@ class FmhaTs:
         seq_lens_kv: cute.Tensor | None = None,
         variable_window_token_starts: cute.Tensor | None = None,
         variable_window_token_ends: cute.Tensor | None = None,
+        variable_window_cta_starts: cute.Tensor | None = None,
     ) -> None:
         """Set up TMA descriptors, compute grid, and launch the kernel.
 
@@ -2569,6 +2594,7 @@ class FmhaTs:
             if cutlass.const_expr(
                 variable_window_token_starts is None
                 or variable_window_token_ends is None
+                or variable_window_cta_starts is None
             ):
                 raise ValueError("VariableWindow requires start and end tensors")
 
@@ -2817,6 +2843,7 @@ class FmhaTs:
             Int32(s_k),
             variable_window_token_starts,
             variable_window_token_ends,
+            variable_window_cta_starts,
             Int32(s_q),
             self.is_persistent,
             self.is_clc_dynamic,
@@ -2855,6 +2882,7 @@ class FmhaTs:
         max_seq_len_kv: Int32 | None,
         variable_window_token_starts: cute.Tensor | None,
         variable_window_token_ends: cute.Tensor | None,
+        variable_window_cta_starts: cute.Tensor | None,
         variable_window_q_stride: Int32,
         is_persistent: cutlass.Constexpr[bool] = True,
         is_clc_dynamic: cutlass.Constexpr[bool] = False,
@@ -2914,6 +2942,7 @@ class FmhaTs:
             num_kv_tiles=num_kv_tiles,
             variable_window_token_starts=variable_window_token_starts,
             variable_window_token_ends=variable_window_token_ends,
+            variable_window_cta_starts=variable_window_cta_starts,
             variable_window_q_stride=variable_window_q_stride,
             scale_softmax_log2=scale_softmax_log2,
             output_scale=output_scale,

--- a/flashinfer/attention/prims_ts/kernels/fmha_context/fmha_kernel.py
+++ b/flashinfer/attention/prims_ts/kernels/fmha_context/fmha_kernel.py
@@ -535,6 +535,25 @@ class VariableWindowDomainTask(Task):
         offset: int = 0,
         **kwargs: Any,
     ) -> None:
+        """Initialize a variable-window task domain.
+
+        Args:
+            variable_window_token_starts: Flattened inclusive K-token start for
+                every Q row, laid out with ``q_stride`` rows per batch.
+            variable_window_token_ends: Flattened inclusive K-token end for
+                every Q row, using the same layout as the start tensor.
+            variable_window_cta_starts: Precomputed minimum K-token start for
+                each Q CTA, used as the common K/V load origin.
+            num_kv_tiles: Planned maximum number of K/V tiles.
+            q_stride: Number of Q rows per batch in the flattened bound tensors.
+            tile_size_q: Number of Q rows covered by one CTA.
+            tile_size_kv: Number of K/V tokens covered by one loop tile.
+            seq_idx: Index of the Q-sequence coordinate in ``tile_coord``.
+            batch_idx: Index of the batch coordinate in ``tile_coord``.
+            offset: Domain-count decrement. Zero selects N; one selects N-1.
+            **kwargs: Remaining ``Task`` arguments, including the required
+                captured ``schedule``.
+        """
         if kwargs.get("schedule") is None:
             raise ValueError("VariableWindow domain tasks require a captured schedule")
         super().__init__(**kwargs)

--- a/flashinfer/attention/prims_ts/kernels/fmha_context/fmha_kernel.py
+++ b/flashinfer/attention/prims_ts/kernels/fmha_context/fmha_kernel.py
@@ -235,8 +235,8 @@ def _init_causal_domain_state(
     task: Task,
     *,
     num_kv_tiles: int | Int32,
-    cta_m: int | Int32,
-    kv_n: int | Int32,
+    tile_size_q: int | Int32,
+    tile_size_kv: int | Int32,
     q_offset: int | Int32,
     seq_idx: int,
     batch_idx: int | None,
@@ -253,26 +253,28 @@ def _init_causal_domain_state(
     """Initialize causal-domain fields and the static validation domain."""
     static_domain = None
     if isinstance(num_kv_tiles, int):
-        assert isinstance(cta_m, int) and isinstance(kv_n, int)
+        assert isinstance(tile_size_q, int) and isinstance(tile_size_kv, int)
         if packed_window:
             static_domain = min(
                 num_kv_tiles,
                 bottom_right_window_max_tiles(
-                    q_tile_m=cta_m,
-                    kv_tile_n=kv_n,
+                    q_tile_m=tile_size_q,
+                    kv_tile_n=tile_size_kv,
                     window_size_left=window_size_left,
                 ),
             )
         else:
             seq_coord = 0
-            max_q_row = q_offset + seq_coord * cta_m + cta_m - 1
-            causal_n = max_q_row // kv_n + 1
-            static_domain = max(cta_m // kv_n, min(num_kv_tiles, causal_n))
+            max_q_row = q_offset + seq_coord * tile_size_q + tile_size_q - 1
+            causal_n = max_q_row // tile_size_kv + 1
+            static_domain = max(
+                tile_size_q // tile_size_kv, min(num_kv_tiles, causal_n)
+            )
         if window_size_left > 0 and not packed_window:
             static_domain -= bottom_right_window_tile_start(
                 seq_coord=0,
-                q_tile_m=cta_m,
-                kv_tile_n=kv_n,
+                q_tile_m=tile_size_q,
+                kv_tile_n=tile_size_kv,
                 q_offset=q_offset,
                 window_size_left=window_size_left,
             )
@@ -281,10 +283,8 @@ def _init_causal_domain_state(
         static_domain = max(static_domain, 0)
     _init_task_with_domain(task, kwargs, static_domain, task_init=task_init)
     task._num_kv_tiles = num_kv_tiles
-    # M dimension size for Q*K.
-    task._cta_m = cta_m
-    # N dimension size for Q*K.
-    task._kv_n = kv_n
+    task._tile_size_q = tile_size_q
+    task._tile_size_kv = tile_size_kv
     task._q_offset = q_offset
     # Index of the sequence coordinate in tile_coord.
     task._seq_idx = seq_idx
@@ -315,8 +315,8 @@ class CausalDomainTask(Task):
     def __init__(
         self,
         num_kv_tiles: int | Int32,
-        cta_m: int | Int32,
-        kv_n: int | Int32,
+        tile_size_q: int | Int32,
+        tile_size_kv: int | Int32,
         q_offset: int | Int32 = 0,
         seq_idx: int = 0,
         batch_idx: int | None = None,
@@ -333,8 +333,8 @@ class CausalDomainTask(Task):
 
         Args:
             num_kv_tiles: Total number of K/V tiles in the sequence.
-            cta_m: Number of Q rows covered by one CTA tile.
-            kv_n: Number of K/V rows covered by one K-loop iteration.
+            tile_size_q: Number of Q rows covered by one CTA tile.
+            tile_size_kv: Number of K/V rows covered by one K-loop iteration.
             q_offset: Causal row-index shift for S_q < S_kv.
             seq_idx: Index of the sequence coordinate in ``tile_coord``.
             batch_idx: Index of the request coordinate in ``tile_coord`` for
@@ -360,8 +360,8 @@ class CausalDomainTask(Task):
         _init_causal_domain_state(
             self,
             num_kv_tiles=num_kv_tiles,
-            cta_m=cta_m,
-            kv_n=kv_n,
+            tile_size_q=tile_size_q,
+            tile_size_kv=tile_size_kv,
             q_offset=q_offset,
             seq_idx=seq_idx,
             batch_idx=batch_idx,
@@ -395,9 +395,9 @@ class CausalDomainTask(Task):
             k_begin = Int32(self._cum_seqlen_k[batch_coord])
             seqlen_q = Int32(self._cum_seqlen_q[batch_coord + Int32(1)]) - q_begin
             seqlen_k = Int32(self._cum_seqlen_k[batch_coord + Int32(1)]) - k_begin
-            runtime_q_tile_active = Int32(seq_coord * self._cta_m < seqlen_q)
+            runtime_q_tile_active = Int32(seq_coord * self._tile_size_q < seqlen_q)
             q_offset = seqlen_k - seqlen_q
-            num_kv_tiles = cute.ceil_div(seqlen_k, self._kv_n)
+            num_kv_tiles = cute.ceil_div(seqlen_k, self._tile_size_kv)
             if cutlass.const_expr(self._runtime_kv_tile_multiple > 1):
                 num_kv_tiles = (
                     cute.ceil_div(num_kv_tiles, self._runtime_kv_tile_multiple)
@@ -405,24 +405,24 @@ class CausalDomainTask(Task):
                 )
         if self._packed_window:
             max_window_tiles = bottom_right_window_max_tiles(
-                q_tile_m=self._cta_m,
-                kv_tile_n=self._kv_n,
+                q_tile_m=self._tile_size_q,
+                kv_tile_n=self._tile_size_kv,
                 window_size_left=self._window_size_left,
             )
             result = _domain_min(num_kv_tiles, max_window_tiles)
         else:
-            max_q_row = q_offset + seq_coord * self._cta_m + self._cta_m - 1
-            causal_n = max_q_row // self._kv_n + 1
+            max_q_row = q_offset + seq_coord * self._tile_size_q + self._tile_size_q - 1
+            causal_n = max_q_row // self._tile_size_kv + 1
             # Softmax assumes there is at least one Q-tile-width of K work.
             result = _domain_max(
-                self._cta_m // self._kv_n,
+                self._tile_size_q // self._tile_size_kv,
                 _domain_min(num_kv_tiles, causal_n),
             )
         if self._window_size_left > 0 and not self._packed_window:
             result -= bottom_right_window_tile_start(
                 seq_coord=seq_coord,
-                q_tile_m=self._cta_m,
-                kv_tile_n=self._kv_n,
+                q_tile_m=self._tile_size_q,
+                kv_tile_n=self._tile_size_kv,
                 q_offset=q_offset,
                 window_size_left=self._window_size_left,
             )
@@ -435,7 +435,9 @@ class CausalDomainTask(Task):
             # those slots instead of traversing K/V according to a large
             # bottom-right offset. Resource-level ragged extents suppress the
             # dummy Q/O traffic; the minimum domains preserve task handoffs.
-            minimum_domain = max(self._cta_m // self._kv_n - self._offset, 0)
+            minimum_domain = max(
+                self._tile_size_q // self._tile_size_kv - self._offset, 0
+            )
             result = (
                 runtime_q_tile_active * result
                 + (Int32(1) - runtime_q_tile_active) * minimum_domain
@@ -449,8 +451,8 @@ class CausalSoftmaxDomainTask(CausalDomainTask):
     def __init__(
         self,
         num_kv_tiles: int | Int32,
-        cta_m: int | Int32,
-        kv_n: int | Int32,
+        tile_size_q: int | Int32,
+        tile_size_kv: int | Int32,
         q_offset: int | Int32 = 0,
         seq_idx: int = 0,
         batch_idx: int | None = None,
@@ -469,9 +471,9 @@ class CausalSoftmaxDomainTask(CausalDomainTask):
         ----------
         num_kv_tiles : int or Int32
             Total number of K/V tiles in the sequence.
-        cta_m : int or Int32
+        tile_size_q : int or Int32
             Number of Q rows covered by one CTA tile.
-        kv_n : int or Int32
+        tile_size_kv : int or Int32
             Number of K/V rows covered by one K-loop iteration.
         q_offset : int or Int32
             Causal row-index shift for S_q < S_kv.
@@ -500,8 +502,8 @@ class CausalSoftmaxDomainTask(CausalDomainTask):
         _init_causal_domain_state(
             self,
             num_kv_tiles=num_kv_tiles,
-            cta_m=cta_m,
-            kv_n=kv_n,
+            tile_size_q=tile_size_q,
+            tile_size_kv=tile_size_kv,
             q_offset=q_offset,
             seq_idx=seq_idx,
             batch_idx=batch_idx,
@@ -526,8 +528,8 @@ class VariableWindowDomainTask(Task):
         variable_window_cta_starts: cute.Tensor,
         num_kv_tiles: int | Int32,
         q_stride: int | Int32,
-        cta_m: int,
-        kv_n: int,
+        tile_size_q: int,
+        tile_size_kv: int,
         seq_idx: int,
         batch_idx: int,
         offset: int = 0,
@@ -541,8 +543,8 @@ class VariableWindowDomainTask(Task):
         self._variable_window_cta_starts = variable_window_cta_starts
         self._num_kv_tiles = num_kv_tiles
         self._q_stride = q_stride
-        self._cta_m = cta_m
-        self._kv_n = kv_n
+        self._tile_size_q = tile_size_q
+        self._tile_size_kv = tile_size_kv
         self._seq_idx = seq_idx
         self._batch_idx = batch_idx
         self._offset = offset
@@ -551,9 +553,9 @@ class VariableWindowDomainTask(Task):
         """Return the number of K tiles intersecting this Q CTA's bounds."""
         seq_coord = Int32(tile_coord[self._seq_idx])
         batch_coord = Int32(tile_coord[self._batch_idx])
-        first_local_q = seq_coord * self._cta_m
+        first_local_q = seq_coord * self._tile_size_q
         last_local_q = cute.math.min(
-            first_local_q + self._cta_m - Int32(1),
+            first_local_q + self._tile_size_q - Int32(1),
             self._q_stride - Int32(1),
         )
         packed_q_base = batch_coord * self._q_stride
@@ -562,11 +564,11 @@ class VariableWindowDomainTask(Task):
             batch_coord=batch_coord,
             seq_coord=seq_coord,
             q_stride=self._q_stride,
-            cta_m=self._cta_m,
+            tile_size_q=self._tile_size_q,
         )
         last_k = Int32(self._variable_window_token_ends[packed_q_base + last_local_q])
-        first_k_tile = first_k // self._kv_n
-        last_k_tile = (last_k + self._kv_n) // self._kv_n
+        first_k_tile = first_k // self._tile_size_kv
+        last_k_tile = (last_k + self._tile_size_kv) // self._tile_size_kv
         return last_k_tile - first_k_tile - self._offset
 
 
@@ -1935,8 +1937,8 @@ def _configure_common_launch_flags(
 def _causal_domain_kwargs(
     *,
     num_kv_tiles: int | Int32,
-    cta_m: int,
-    kv_n: int,
+    tile_size_q: int,
+    tile_size_kv: int,
     q_offset: int | Int32,
     seq_idx: int,
     batch_idx: int | None = None,
@@ -1958,8 +1960,8 @@ def _causal_domain_kwargs(
     result: DomainKwargs = {
         "task_class": CausalDomainTask,
         "num_kv_tiles": num_kv_tiles,
-        "cta_m": cta_m,
-        "kv_n": kv_n,
+        "tile_size_q": tile_size_q,
+        "tile_size_kv": tile_size_kv,
         "q_offset": q_offset,
         "seq_idx": seq_idx,
         "offset": offset,
@@ -2018,8 +2020,8 @@ def _select_fmha_domain_policy(
             "variable_window_cta_starts": variable_window_cta_starts,
             "num_kv_tiles": num_kv_tiles,
             "q_stride": variable_window_q_stride,
-            "cta_m": cfg.cta_tiler[0],
-            "kv_n": cfg.kv_tile_n,
+            "tile_size_q": cfg.cta_tiler[0],
+            "tile_size_kv": cfg.kv_tile_n,
             "seq_idx": seq_idx,
             "batch_idx": batch_idx,
         }
@@ -2036,8 +2038,8 @@ def _select_fmha_domain_policy(
     if cfg.head_paired and cfg.is_causal:
         causal_n = _causal_domain_kwargs(
             num_kv_tiles=num_kv_tiles,
-            cta_m=cfg.q_tile_m,
-            kv_n=cfg.kv_tile_n,
+            tile_size_q=cfg.q_tile_m,
+            tile_size_kv=cfg.kv_tile_n,
             q_offset=q_offset,
             seq_idx=seq_idx,
             offset=0,
@@ -2047,8 +2049,8 @@ def _select_fmha_domain_policy(
         )
         causal_n_minus_1 = _causal_domain_kwargs(
             num_kv_tiles=num_kv_tiles,
-            cta_m=cfg.q_tile_m,
-            kv_n=cfg.kv_tile_n,
+            tile_size_q=cfg.q_tile_m,
+            tile_size_kv=cfg.kv_tile_n,
             q_offset=q_offset,
             seq_idx=seq_idx,
             offset=1,
@@ -2101,8 +2103,8 @@ def _select_fmha_domain_policy(
         )
         causal_n = _causal_domain_kwargs(
             num_kv_tiles=num_kv_tiles,
-            cta_m=cfg.cta_tiler[0],
-            kv_n=cfg.kv_tile_n,
+            tile_size_q=cfg.cta_tiler[0],
+            tile_size_kv=cfg.kv_tile_n,
             q_offset=q_offset,
             seq_idx=seq_idx,
             batch_idx=batch_idx,
@@ -2114,8 +2116,8 @@ def _select_fmha_domain_policy(
         )
         causal_n_minus_1 = _causal_domain_kwargs(
             num_kv_tiles=num_kv_tiles,
-            cta_m=cfg.cta_tiler[0],
-            kv_n=cfg.kv_tile_n,
+            tile_size_q=cfg.cta_tiler[0],
+            tile_size_kv=cfg.kv_tile_n,
             q_offset=q_offset,
             seq_idx=seq_idx,
             batch_idx=batch_idx,
@@ -2127,8 +2129,8 @@ def _select_fmha_domain_policy(
         )
         causal_n_minus_2 = _causal_domain_kwargs(
             num_kv_tiles=num_kv_tiles,
-            cta_m=cfg.cta_tiler[0],
-            kv_n=cfg.kv_tile_n,
+            tile_size_q=cfg.cta_tiler[0],
+            tile_size_kv=cfg.kv_tile_n,
             q_offset=q_offset,
             seq_idx=seq_idx,
             batch_idx=batch_idx,

--- a/flashinfer/attention/prims_ts/kernels/fmha_context/fmha_kernel.py
+++ b/flashinfer/attention/prims_ts/kernels/fmha_context/fmha_kernel.py
@@ -515,6 +515,56 @@ class CausalSoftmaxDomainTask(CausalDomainTask):
         )
 
 
+class VariableWindowDomainTask(Task):
+    """Task whose K-loop domain comes from packed-Q window endpoints."""
+
+    def __init__(
+        self,
+        variable_window_token_starts: cute.Tensor,
+        variable_window_token_ends: cute.Tensor,
+        num_kv_tiles: int | Int32,
+        q_stride: int | Int32,
+        cta_m: int,
+        kv_n: int,
+        seq_idx: int,
+        batch_idx: int,
+        offset: int = 0,
+        **kwargs: Any,
+    ) -> None:
+        if kwargs.get("schedule") is None:
+            raise ValueError("VariableWindow domain tasks require a captured schedule")
+        super().__init__(**kwargs)
+        self._variable_window_token_starts = variable_window_token_starts
+        self._variable_window_token_ends = variable_window_token_ends
+        self._num_kv_tiles = num_kv_tiles
+        self._q_stride = q_stride
+        self._cta_m = cta_m
+        self._kv_n = kv_n
+        self._seq_idx = seq_idx
+        self._batch_idx = batch_idx
+        self._offset = offset
+
+    def get_domain(self, tile_coord: cute.Coord) -> Int32:
+        """Return the number of K tiles intersecting this Q CTA's bounds."""
+        seq_coord = Int32(tile_coord[self._seq_idx])
+        batch_coord = Int32(tile_coord[self._batch_idx])
+        first_local_q = seq_coord * self._cta_m
+        last_local_q = cute.math.min(
+            first_local_q + self._cta_m - Int32(1),
+            self._q_stride - Int32(1),
+        )
+        packed_q_base = batch_coord * self._q_stride
+        first_k = Int32(
+            self._variable_window_token_starts[packed_q_base + first_local_q]
+        )
+        last_k = Int32(
+            self._variable_window_token_ends[packed_q_base + last_local_q]
+        )
+        first_k_tile = first_k // self._kv_n
+        last_k_tile = (last_k + self._kv_n) // self._kv_n
+        return last_k_tile - first_k_tile - self._offset
+
+
 DomainPolicyValue = int | bool | Int32 | type[Task] | cute.Tensor
 DomainKwargs = dict[str, DomainPolicyValue]
 
@@ -578,6 +628,9 @@ def build_context_task_manager(
     tma_o_desc: cutlass.Pointer | None,
     cum_seqlen_q: cute.Tensor | None,
     cum_seqlen_k: cute.Tensor | None,
+    variable_window_token_starts: cute.Tensor | None = None,
+    variable_window_token_ends: cute.Tensor | None = None,
+    variable_window_q_stride: int | Int32 = 0,
     scale_softmax_log2: cute.Tensor | None = None,
     output_scale: cute.Tensor | None = None,
     g_page_idx_kv: cute.Pointer | None = None,
@@ -874,6 +927,8 @@ def build_context_task_manager(
         cfg=cfg,
         seqlens_kv=g_seq_lens_kv,
         max_seq_len_kv=max_seq_len_kv,
+        variable_window_token_starts=variable_window_token_starts,
+        variable_window_q_stride=variable_window_q_stride,
         name="gmem_qkv",
     )
     smem_q = SmemQResource(
@@ -997,6 +1052,9 @@ def build_context_task_manager(
         q_offset=q_offset,
         cum_seqlen_q=cum_seqlen_q,
         cum_seqlen_k=cum_seqlen_k,
+        variable_window_token_starts=variable_window_token_starts,
+        variable_window_token_ends=variable_window_token_ends,
+        variable_window_q_stride=variable_window_q_stride,
         scale_softmax_log2=scale_softmax_log2,
         name="tmem_sp0",
     )
@@ -1055,6 +1113,9 @@ def build_context_task_manager(
             q_offset=q_offset,
             cum_seqlen_q=cum_seqlen_q,
             cum_seqlen_k=cum_seqlen_k,
+            variable_window_token_starts=variable_window_token_starts,
+            variable_window_token_ends=variable_window_token_ends,
+            variable_window_q_stride=variable_window_q_stride,
             scale_softmax_log2=scale_softmax_log2,
             name="tmem_sp1",
         )
@@ -1852,12 +1913,14 @@ def _configure_common_launch_flags(
     is_causal: bool,
     balance_causal_workload: bool,
     window_size_left: int,
+    has_variable_window: bool,
 ) -> None:
     """Fill launch flags shared by query-paired and head-paired modes."""
     cfg.h_r = h_r
     cfg.is_causal = is_causal
     cfg.balance_causal_workload = balance_causal_workload
     cfg.window_size_left = window_size_left
+    cfg.has_variable_window = has_variable_window
 
 
 def _causal_domain_kwargs(
@@ -1919,6 +1982,9 @@ def _select_fmha_domain_policy(
     q_offset: int | Int32,
     cum_seqlen_q: cute.Tensor | None,
     cum_seqlen_k: cute.Tensor | None,
+    variable_window_token_starts: cute.Tensor | None = None,
+    variable_window_token_ends: cute.Tensor | None = None,
+    variable_window_q_stride: int | Int32 = 0,
 ) -> FmhaDomainPolicy:
     """Select loop domains and softmax masks for the configured FMHA mode."""
     seq_idx = cfg.work_tile_coord_indices[0]
@@ -1928,6 +1994,28 @@ def _select_fmha_domain_policy(
         if cfg.uses_causal_reversed_head_batch_seq_tile_order
         else None
     )
+    if cfg.has_variable_window:
+        if variable_window_token_starts is None or variable_window_token_ends is None:
+            raise ValueError("VariableWindow domain requires start and end tensors")
+        base_kwargs: DomainKwargs = {
+            "task_class": VariableWindowDomainTask,
+            "variable_window_token_starts": variable_window_token_starts,
+            "variable_window_token_ends": variable_window_token_ends,
+            "num_kv_tiles": num_kv_tiles,
+            "q_stride": variable_window_q_stride,
+            "cta_m": cfg.cta_tiler[0],
+            "kv_n": cfg.kv_tile_n,
+            "seq_idx": seq_idx,
+            "batch_idx": batch_idx,
+        }
+        domain_n_kwargs = {**base_kwargs, "offset": 0}
+        domain_n_minus_1_kwargs = {**base_kwargs, "offset": 1}
+        return FmhaDomainPolicy(
+            domain_n_kwargs=domain_n_kwargs,
+            domain_n_minus_1_kwargs=domain_n_minus_1_kwargs,
+            softmax0_domain_kwargs=domain_n_kwargs,
+            softmax1_domain_kwargs=domain_n_kwargs,
+        )
     # Head-paired causal/window: both peers use the same Q sequence tile from
     # adjacent Q heads, so both softmax tasks share the same causal tail domain.
     if cfg.head_paired and cfg.is_causal:
@@ -2085,6 +2173,9 @@ def build_fmha_task_manager(
     cum_seqlen_q: cute.Tensor | None,
     cum_seqlen_k: cute.Tensor | None,
     num_kv_tiles: int | Int32,
+    variable_window_token_starts: cute.Tensor | None = None,
+    variable_window_token_ends: cute.Tensor | None = None,
+    variable_window_q_stride: int | Int32 = 0,
     scale_softmax_log2: cute.Tensor | None = None,
     output_scale: cute.Tensor | None = None,
     q_offset: int | Int32 = 0,
@@ -2156,6 +2247,9 @@ def build_fmha_task_manager(
         cum_seqlen_k=(
             cum_seqlen_k if cfg.has_varlen and not cfg.has_uniform_varlen else None
         ),
+        variable_window_token_starts=variable_window_token_starts,
+        variable_window_token_ends=variable_window_token_ends,
+        variable_window_q_stride=variable_window_q_stride,
     )
 
     return build_context_task_manager(
@@ -2167,6 +2261,9 @@ def build_fmha_task_manager(
         tma_o_desc=tma_o_desc,
         cum_seqlen_q=cum_seqlen_q,
         cum_seqlen_k=cum_seqlen_k,
+        variable_window_token_starts=variable_window_token_starts,
+        variable_window_token_ends=variable_window_token_ends,
+        variable_window_q_stride=variable_window_q_stride,
         scale_softmax_log2=scale_softmax_log2,
         output_scale=output_scale,
         g_page_idx_kv=g_page_idx_kv,
@@ -2250,6 +2347,7 @@ class FmhaTs:
         is_clc_dynamic: bool = False,
         head_paired: bool = False,
         window_size_left: int = 0,
+        has_variable_window: bool = False,
         h_r: int = 1,
         enable_skip_correction: bool = True,
         use_paged_kv: bool = False,
@@ -2276,6 +2374,10 @@ class FmhaTs:
             raise ValueError("CLC dynamic scheduling requires persistent mode")
         if head_paired and not is_persistent:
             raise ValueError("Head-paired scheduling requires persistent mode")
+        if has_variable_window and (is_causal or window_size_left > 0):
+            raise ValueError(
+                "VariableWindow bounds replace causal and sliding-window masks"
+            )
         validate_head_paired_head_ratio(head_paired=head_paired, h_r=h_r)
         if use_paged_kv:
             if num_tokens_per_page not in _SUPPORTED_CONTEXT_PAGE_SIZES:
@@ -2361,6 +2463,7 @@ class FmhaTs:
                 is_causal=is_causal,
                 balance_causal_workload=balance_causal_workload,
                 window_size_left=window_size_left,
+                has_variable_window=has_variable_window,
             )
             _configure_early_tile_sum_policy(cfg, is_persistent=is_persistent)
             return
@@ -2428,6 +2531,7 @@ class FmhaTs:
             is_causal=is_causal,
             balance_causal_workload=balance_causal_workload,
             window_size_left=window_size_left,
+            has_variable_window=has_variable_window,
         )
         _configure_early_tile_sum_policy(cfg, is_persistent=is_persistent)
 
@@ -2451,6 +2555,8 @@ class FmhaTs:
         max_seqlen_k: Int32 | None = None,
         page_idx_kv: cute.Tensor | None = None,
         seq_lens_kv: cute.Tensor | None = None,
+        variable_window_token_starts: cute.Tensor | None = None,
+        variable_window_token_ends: cute.Tensor | None = None,
     ) -> None:
         """Set up TMA descriptors, compute grid, and launch the kernel.
 
@@ -2461,6 +2567,12 @@ class FmhaTs:
         quantization scales into these runtime tensors.
         """
         cfg = self.cfg
+        if cutlass.const_expr(cfg.has_variable_window):
+            if cutlass.const_expr(
+                variable_window_token_starts is None
+                or variable_window_token_ends is None
+            ):
+                raise ValueError("VariableWindow requires start and end tensors")
 
         # Create TMA descriptors. Both query-paired and head-paired modes use
         # the same logical Q/K/V/O tensor-map boxes after FmhaConfig lowers the
@@ -2705,6 +2817,9 @@ class FmhaTs:
             page_idx_kv_iter,
             seq_lens_kv_iter,
             Int32(s_k),
+            variable_window_token_starts,
+            variable_window_token_ends,
+            Int32(s_q),
             self.is_persistent,
             self.is_clc_dynamic,
         ).launch(
@@ -2740,6 +2855,9 @@ class FmhaTs:
         page_idx_kv: cute.Pointer | None,
         seq_lens_kv: cute.Pointer | None,
         max_seq_len_kv: Int32 | None,
+        variable_window_token_starts: cute.Tensor | None,
+        variable_window_token_ends: cute.Tensor | None,
+        variable_window_q_stride: Int32,
         is_persistent: cutlass.Constexpr[bool] = True,
         is_clc_dynamic: cutlass.Constexpr[bool] = False,
     ) -> None:
@@ -2796,6 +2914,9 @@ class FmhaTs:
             g_seq_lens_kv=seq_lens_kv,
             max_seq_len_kv=max_seq_len_kv,
             num_kv_tiles=num_kv_tiles,
+            variable_window_token_starts=variable_window_token_starts,
+            variable_window_token_ends=variable_window_token_ends,
+            variable_window_q_stride=variable_window_q_stride,
             scale_softmax_log2=scale_softmax_log2,
             output_scale=output_scale,
             q_offset=q_offset,

--- a/flashinfer/attention/prims_ts/kernels/fmha_context/fmha_resources.py
+++ b/flashinfer/attention/prims_ts/kernels/fmha_context/fmha_resources.py
@@ -983,7 +983,7 @@ class GmemQKVResource(MemoryResource):
                 batch_coord=batch_coord,
                 seq_coord=seq_coord,
                 q_stride=self.variable_window_q_stride,
-                cta_m=self.cfg.cta_tiler[0],
+                tile_size_q=self.cfg.cta_tiler[0],
             )
             kv_tile_start = min_window_start // self.cfg.kv_tile_n
         return (
@@ -2451,7 +2451,7 @@ class TmemSPResource(MemoryResource):
             batch_coord=batch_coord,
             seq_coord=seq_coord,
             q_stride=self.variable_window_q_stride,
-            cta_m=self.cfg.cta_tiler[0],
+            tile_size_q=self.cfg.cta_tiler[0],
         )
         kv_base = (min_window_start // self.cfg.kv_tile_n) * self.cfg.kv_tile_n
         return (

--- a/flashinfer/attention/prims_ts/kernels/fmha_context/fmha_resources.py
+++ b/flashinfer/attention/prims_ts/kernels/fmha_context/fmha_resources.py
@@ -2441,6 +2441,10 @@ class TmemSPResource(MemoryResource):
             + self.q_half * self.cfg.peer_q_seq_tile_stride * self.cfg.q_tile_m
             + row_in_tile
         )
+        local_q = cute.math.min(
+            local_q,
+            self.variable_window_q_stride - Int32(1),
+        )
         packed_q = batch_coord * self.variable_window_q_stride + local_q
         min_window_start = variable_window_cta_min_start(
             self.variable_window_cta_starts,

--- a/flashinfer/attention/prims_ts/kernels/fmha_context/fmha_resources.py
+++ b/flashinfer/attention/prims_ts/kernels/fmha_context/fmha_resources.py
@@ -125,11 +125,7 @@ def _mask_score_quad(
     score2: Float32,
     score3: Float32,
 ) -> tuple[Float32, Float32, Float32, Float32]:
-    """Expand four bitmap bits with setp and replace invalid scores.
-
-    Use and/setp because CUDA 13.3 libNVVM fails to compile the equivalent
-    `r2p.b32 {valid0, valid1, valid2, valid3}.reverse, {$r0}.b0, 0x0f;`.
-    """
+    """Expand four bitmap bits with setp and replace invalid scores."""
     return cute.arch.inline_ptx(
         """
         {
@@ -3084,8 +3080,6 @@ class TmemSPResource(MemoryResource):
             masked_scores = []
             for quad_idx in cutlass.range_constexpr(tmem_x // 4):
                 quad_base = quad_idx * 4
-                # CUDA 13.3 NVVM rejects r2p in this kernel, so expand each
-                # four-bit group with ordinary setp instructions.
                 masked_scores.extend(
                     _mask_score_quad(
                         valid_bits >> Int32(quad_base),

--- a/flashinfer/attention/prims_ts/kernels/fmha_context/fmha_resources.py
+++ b/flashinfer/attention/prims_ts/kernels/fmha_context/fmha_resources.py
@@ -88,6 +88,7 @@ from .helpers import (
     bottom_right_window_left_bound,
     bottom_right_window_tile_start,
     freeze_smem_descriptor,
+    variable_window_cta_min_start,
 )
 from cutlass.experimental import primitives as prims
 
@@ -787,6 +788,7 @@ class GmemQKVResource(MemoryResource):
     cum_seqlen_q: cute.Tensor | None = field(init=False, default=None)
     cum_seqlen_k: cute.Tensor | None = field(init=False, default=None)
     variable_window_token_starts: cute.Tensor | None = field(init=False, default=None)
+    variable_window_cta_starts: cute.Tensor | None = field(init=False, default=None)
     variable_window_q_stride: int | Int32 = field(init=False, default=0)
     q_offset_default: int | Int32 = field(init=False, default=0)
     seqlens_kv: cute.Pointer | None = field(init=False, default=None)
@@ -817,6 +819,7 @@ class GmemQKVResource(MemoryResource):
         seqlens_kv: cute.Pointer | None = None,
         max_seq_len_kv: Int32 | int | None = None,
         variable_window_token_starts: cute.Tensor | None = None,
+        variable_window_cta_starts: cute.Tensor | None = None,
         variable_window_q_stride: int | Int32 = 0,
         **kwargs: Any,
     ) -> None:
@@ -831,6 +834,7 @@ class GmemQKVResource(MemoryResource):
         self.seqlens_kv = seqlens_kv
         self.max_seq_len_kv = max_seq_len_kv
         self.variable_window_token_starts = variable_window_token_starts
+        self.variable_window_cta_starts = variable_window_cta_starts
         self.variable_window_q_stride = variable_window_q_stride
         self.cfg = cfg
         self.seq_coord = TaskLocalVariable(
@@ -974,13 +978,14 @@ class GmemQKVResource(MemoryResource):
                     // self.cfg.seq_tile_n,
                 )
         if cutlass.const_expr(self.cfg.has_variable_window):
-            first_local_q = (
-                seq_coord * self.cfg.q_tile_m * self.cfg.work_tile_q_seq_tiles
+            min_window_start = variable_window_cta_min_start(
+                self.variable_window_cta_starts,
+                batch_coord=batch_coord,
+                seq_coord=seq_coord,
+                q_stride=self.variable_window_q_stride,
+                cta_m=self.cfg.cta_tiler[0],
             )
-            packed_q = batch_coord * self.variable_window_q_stride + first_local_q
-            kv_tile_start = (
-                Int32(self.variable_window_token_starts[packed_q]) // self.cfg.kv_tile_n
-            )
+            kv_tile_start = min_window_start // self.cfg.kv_tile_n
         return (
             seq_coord,
             head_coord,
@@ -1936,6 +1941,7 @@ class TmemSPResource(MemoryResource):
     cum_seqlen_k: cute.Tensor | None = field(init=False, default=None)
     variable_window_token_starts: cute.Tensor | None = field(init=False, default=None)
     variable_window_token_ends: cute.Tensor | None = field(init=False, default=None)
+    variable_window_cta_starts: cute.Tensor | None = field(init=False, default=None)
     variable_window_q_stride: int | Int32 = field(init=False, default=0)
     scale_softmax_log2: cute.Tensor | None = field(init=False, default=None)
     tmem_addr_cached: TmemAddr | None = field(init=False, default=None)
@@ -1973,6 +1979,7 @@ class TmemSPResource(MemoryResource):
         cum_seqlen_k: cute.Tensor | None = None,
         variable_window_token_starts: cute.Tensor | None = None,
         variable_window_token_ends: cute.Tensor | None = None,
+        variable_window_cta_starts: cute.Tensor | None = None,
         variable_window_q_stride: int | Int32 = 0,
         scale_softmax_log2: cute.Tensor | None = None,
         **kwargs: Any,
@@ -1989,6 +1996,7 @@ class TmemSPResource(MemoryResource):
         self.cum_seqlen_k = cum_seqlen_k
         self.variable_window_token_starts = variable_window_token_starts
         self.variable_window_token_ends = variable_window_token_ends
+        self.variable_window_cta_starts = variable_window_cta_starts
         self.variable_window_q_stride = variable_window_q_stride
         self.scale_softmax_log2 = scale_softmax_log2
         self._alloc = TmemAllocation(
@@ -2438,23 +2446,14 @@ class TmemSPResource(MemoryResource):
             + row_in_tile
         )
         packed_q = batch_coord * self.variable_window_q_stride + local_q
-        first_local_q = seq_coord * self.cfg.q_tile_m * self.cfg.work_tile_q_seq_tiles
-        first_packed_q = batch_coord * self.variable_window_q_stride + first_local_q
-        window_tile_start = Int32(0)
-        if cute.arch.lane_idx() == 0:
-            window_tile_start = (
-                Int32(self.variable_window_token_starts[first_packed_q])
-                // self.cfg.kv_tile_n
-            )
-        window_tile_start = prims.shfl_sync(
-            thread_mask=0xFFFFFFFF,
-            val=window_tile_start,
-            offset=0,
-            mask_and_clamp=0x1F,
-            kind=prims.Shfl.IDX,
-            return_value_and_is_valid=False,
+        min_window_start = variable_window_cta_min_start(
+            self.variable_window_cta_starts,
+            batch_coord=batch_coord,
+            seq_coord=seq_coord,
+            q_stride=self.variable_window_q_stride,
+            cta_m=self.cfg.cta_tiler[0],
         )
-        kv_base = window_tile_start * self.cfg.kv_tile_n
+        kv_base = (min_window_start // self.cfg.kv_tile_n) * self.cfg.kv_tile_n
         return (
             Int32(self.variable_window_token_starts[packed_q]) - kv_base,
             Int32(self.variable_window_token_ends[packed_q]) - kv_base,

--- a/flashinfer/attention/prims_ts/kernels/fmha_context/fmha_resources.py
+++ b/flashinfer/attention/prims_ts/kernels/fmha_context/fmha_resources.py
@@ -979,8 +979,7 @@ class GmemQKVResource(MemoryResource):
             )
             packed_q = batch_coord * self.variable_window_q_stride + first_local_q
             kv_tile_start = (
-                Int32(self.variable_window_token_starts[packed_q])
-                // self.cfg.kv_tile_n
+                Int32(self.variable_window_token_starts[packed_q]) // self.cfg.kv_tile_n
             )
         return (
             seq_coord,
@@ -1955,8 +1954,12 @@ class TmemSPResource(MemoryResource):
     p_chunk: Constexpr[TaskLocalVariable] = TaskLocalVariable.uninitialized()
     q_offset: Constexpr[TaskLocalVariable] = TaskLocalVariable.uninitialized()
     seqlen_k: Constexpr[TaskLocalVariable] = TaskLocalVariable.uninitialized()
-    variable_window_start: Constexpr[TaskLocalVariable] = TaskLocalVariable.uninitialized()
-    variable_window_end: Constexpr[TaskLocalVariable] = TaskLocalVariable.uninitialized()
+    variable_window_start: Constexpr[TaskLocalVariable] = (
+        TaskLocalVariable.uninitialized()
+    )
+    variable_window_end: Constexpr[TaskLocalVariable] = (
+        TaskLocalVariable.uninitialized()
+    )
 
     def __init__(
         self,
@@ -2435,9 +2438,7 @@ class TmemSPResource(MemoryResource):
             + row_in_tile
         )
         packed_q = batch_coord * self.variable_window_q_stride + local_q
-        first_local_q = (
-            seq_coord * self.cfg.q_tile_m * self.cfg.work_tile_q_seq_tiles
-        )
+        first_local_q = seq_coord * self.cfg.q_tile_m * self.cfg.work_tile_q_seq_tiles
         first_packed_q = batch_coord * self.variable_window_q_stride + first_local_q
         window_tile_start = Int32(0)
         if cute.arch.lane_idx() == 0:

--- a/flashinfer/attention/prims_ts/kernels/fmha_context/fmha_resources.py
+++ b/flashinfer/attention/prims_ts/kernels/fmha_context/fmha_resources.py
@@ -107,6 +107,57 @@ _tmem_sp_sdata: dict[int, list] = {}
 
 
 @cute.jit
+def _bmsk_clamp(start: Int32, width: Int32) -> Int32:
+    """Create a contiguous 32-bit mask with clamped bounds."""
+    return cute.arch.inline_ptx(
+        "bmsk.clamp.b32 {$w0}, {$r0}, {$r1};",
+        write_only_types=[Int32],
+        read_only_args=[start, width],
+    )
+
+
+@cute.jit
+def _mask_score_quad(
+    valid_bits: Int32,
+    score0: Float32,
+    score1: Float32,
+    score2: Float32,
+    score3: Float32,
+) -> tuple[Float32, Float32, Float32, Float32]:
+    """Expand four bitmap bits with setp and replace invalid scores.
+
+    Use and/setp because CUDA 13.3 libNVVM fails to compile the equivalent
+    `r2p.b32 {valid0, valid1, valid2, valid3}.reverse, {$r0}.b0, 0x0f;`.
+    """
+    return cute.arch.inline_ptx(
+        """
+        {
+            .reg .pred valid<4>;
+            .reg .b32 bit;
+            mov.b32 {$w0}, {$r1};
+            mov.b32 {$w1}, {$r2};
+            mov.b32 {$w2}, {$r3};
+            mov.b32 {$w3}, {$r4};
+            and.b32 bit, {$r0}, 0x1;
+            setp.ne.u32 valid0, bit, 0;
+            and.b32 bit, {$r0}, 0x2;
+            setp.ne.u32 valid1, bit, 0;
+            and.b32 bit, {$r0}, 0x4;
+            setp.ne.u32 valid2, bit, 0;
+            and.b32 bit, {$r0}, 0x8;
+            setp.ne.u32 valid3, bit, 0;
+            @!valid0 mov.b32 {$w0}, 0xff800000;
+            @!valid1 mov.b32 {$w1}, 0xff800000;
+            @!valid2 mov.b32 {$w2}, 0xff800000;
+            @!valid3 mov.b32 {$w3}, 0xff800000;
+        }
+        """,
+        write_only_types=[Float32, Float32, Float32, Float32],
+        read_only_args=[valid_bits, score0, score1, score2, score3],
+    )
+
+
+@cute.jit
 def _pack_float4_to_fp8_e4m3(
     v0: Float32,
     v1: Float32,
@@ -251,6 +302,8 @@ class FmhaConfig:
 
     # Causal masking: when True, mask out positions where k_idx > q_idx
     is_causal: bool = False
+    # Explicit packed-Q inclusive [start, end] bounds replace static masks.
+    has_variable_window: bool = False
     # Causal balancing uses head_batch_seq logical tile order and reverses Q
     # sequence tiles.
     balance_causal_workload: bool = False
@@ -733,6 +786,8 @@ class GmemQKVResource(MemoryResource):
     tma_v_desc: cutlass.Pointer | None = field(init=False, default=None)
     cum_seqlen_q: cute.Tensor | None = field(init=False, default=None)
     cum_seqlen_k: cute.Tensor | None = field(init=False, default=None)
+    variable_window_token_starts: cute.Tensor | None = field(init=False, default=None)
+    variable_window_q_stride: int | Int32 = field(init=False, default=0)
     q_offset_default: int | Int32 = field(init=False, default=0)
     seqlens_kv: cute.Pointer | None = field(init=False, default=None)
     max_seq_len_kv: Optional[Int32 | int] = field(init=False, default=None)
@@ -761,6 +816,8 @@ class GmemQKVResource(MemoryResource):
         cfg: FmhaConfig,
         seqlens_kv: cute.Pointer | None = None,
         max_seq_len_kv: Int32 | int | None = None,
+        variable_window_token_starts: cute.Tensor | None = None,
+        variable_window_q_stride: int | Int32 = 0,
         **kwargs: Any,
     ) -> None:
         """Bind Q/K/V descriptors, optional varlen metadata, and FMHA config."""
@@ -773,6 +830,8 @@ class GmemQKVResource(MemoryResource):
         self.q_offset_default = q_offset
         self.seqlens_kv = seqlens_kv
         self.max_seq_len_kv = max_seq_len_kv
+        self.variable_window_token_starts = variable_window_token_starts
+        self.variable_window_q_stride = variable_window_q_stride
         self.cfg = cfg
         self.seq_coord = TaskLocalVariable(
             dtype=Int32,
@@ -914,6 +973,15 @@ class GmemQKVResource(MemoryResource):
                     )
                     // self.cfg.seq_tile_n,
                 )
+        if cutlass.const_expr(self.cfg.has_variable_window):
+            first_local_q = (
+                seq_coord * self.cfg.q_tile_m * self.cfg.work_tile_q_seq_tiles
+            )
+            packed_q = batch_coord * self.variable_window_q_stride + first_local_q
+            kv_tile_start = (
+                Int32(self.variable_window_token_starts[packed_q])
+                // self.cfg.kv_tile_n
+            )
         return (
             seq_coord,
             head_coord,
@@ -1867,6 +1935,9 @@ class TmemSPResource(MemoryResource):
     q_offset_default: int | Int32 = field(init=False, default=0)
     cum_seqlen_q: cute.Tensor | None = field(init=False, default=None)
     cum_seqlen_k: cute.Tensor | None = field(init=False, default=None)
+    variable_window_token_starts: cute.Tensor | None = field(init=False, default=None)
+    variable_window_token_ends: cute.Tensor | None = field(init=False, default=None)
+    variable_window_q_stride: int | Int32 = field(init=False, default=0)
     scale_softmax_log2: cute.Tensor | None = field(init=False, default=None)
     tmem_addr_cached: TmemAddr | None = field(init=False, default=None)
     # Precomputed TMEM pointers/addresses (set by auxiliary work). Avoids
@@ -1884,6 +1955,8 @@ class TmemSPResource(MemoryResource):
     p_chunk: Constexpr[TaskLocalVariable] = TaskLocalVariable.uninitialized()
     q_offset: Constexpr[TaskLocalVariable] = TaskLocalVariable.uninitialized()
     seqlen_k: Constexpr[TaskLocalVariable] = TaskLocalVariable.uninitialized()
+    variable_window_start: Constexpr[TaskLocalVariable] = TaskLocalVariable.uninitialized()
+    variable_window_end: Constexpr[TaskLocalVariable] = TaskLocalVariable.uninitialized()
 
     def __init__(
         self,
@@ -1895,6 +1968,9 @@ class TmemSPResource(MemoryResource):
         q_offset: int | Int32 = 0,
         cum_seqlen_q: cute.Tensor | None = None,
         cum_seqlen_k: cute.Tensor | None = None,
+        variable_window_token_starts: cute.Tensor | None = None,
+        variable_window_token_ends: cute.Tensor | None = None,
+        variable_window_q_stride: int | Int32 = 0,
         scale_softmax_log2: cute.Tensor | None = None,
         **kwargs: Any,
     ) -> None:
@@ -1908,6 +1984,9 @@ class TmemSPResource(MemoryResource):
         self.q_offset_default = q_offset
         self.cum_seqlen_q = cum_seqlen_q
         self.cum_seqlen_k = cum_seqlen_k
+        self.variable_window_token_starts = variable_window_token_starts
+        self.variable_window_token_ends = variable_window_token_ends
+        self.variable_window_q_stride = variable_window_q_stride
         self.scale_softmax_log2 = scale_softmax_log2
         self._alloc = TmemAllocation(
             f"tmem_sp_q{q_half}",
@@ -1954,6 +2033,16 @@ class TmemSPResource(MemoryResource):
             default=Int32(0),
             docs="Request-local K/V sequence length for packed dense masking.",
         )
+        self.variable_window_start = TaskLocalVariable(
+            dtype=Int32,
+            default=Int32(0),
+            docs="Inclusive first K position for this Q row.",
+        )
+        self.variable_window_end = TaskLocalVariable(
+            dtype=Int32,
+            default=Int32(0),
+            docs="Inclusive last K position for this Q row.",
+        )
         self.scale_softmax_log2_value = TaskLocalVariable(
             dtype=Float32,
             # Placeholder before load_scale_softmax_log2 reads the runtime tensor.
@@ -1985,6 +2074,11 @@ class TmemSPResource(MemoryResource):
     def uses_varlen_q_offset_cache(self) -> bool:
         """Return whether masks need a per-work-tile varlen Q/K offset."""
         return self.cfg.has_varlen and self.cfg.has_q_offset
+
+    @property
+    def uses_variable_window(self) -> bool:
+        """Return whether softmax consumes explicit packed-Q row bounds."""
+        return self.cfg.has_variable_window
 
     @property
     def uses_fixed_dense_k_tail_mask(self) -> bool:
@@ -2320,6 +2414,50 @@ class TmemSPResource(MemoryResource):
         batch_coord = self._varlen_batch_coord(stage_info)
         cuseqlen_k = Int32(self.cum_seqlen_k[batch_coord])
         return Int32(self.cum_seqlen_k[batch_coord + Int32(1)]) - cuseqlen_k
+
+    @consumer_work(
+        work_attrs=WorkAttr.AUXILIARY,
+        returns=(variable_window_start, variable_window_end),
+    )
+    @cute.jit
+    def cache_variable_window_bounds(
+        self, stage_info: StageInfo
+    ) -> tuple[Int32, Int32]:
+        """Load this lane's bounds relative to the CTA's first K/V tile."""
+        seq_coord, _, batch_coord = _resolve_work_tile_coords(
+            self.cfg, stage_info.work_tile.tile_idx
+        )
+        warp_id_in_sg = cute.arch.warp_idx() % 4
+        row_in_tile = warp_id_in_sg * cute.arch.WARP_SIZE + cute.arch.lane_idx()
+        local_q = (
+            seq_coord * self.cfg.q_tile_m * self.cfg.work_tile_q_seq_tiles
+            + self.q_half * self.cfg.peer_q_seq_tile_stride * self.cfg.q_tile_m
+            + row_in_tile
+        )
+        packed_q = batch_coord * self.variable_window_q_stride + local_q
+        first_local_q = (
+            seq_coord * self.cfg.q_tile_m * self.cfg.work_tile_q_seq_tiles
+        )
+        first_packed_q = batch_coord * self.variable_window_q_stride + first_local_q
+        window_tile_start = Int32(0)
+        if cute.arch.lane_idx() == 0:
+            window_tile_start = (
+                Int32(self.variable_window_token_starts[first_packed_q])
+                // self.cfg.kv_tile_n
+            )
+        window_tile_start = prims.shfl_sync(
+            thread_mask=0xFFFFFFFF,
+            val=window_tile_start,
+            offset=0,
+            mask_and_clamp=0x1F,
+            kind=prims.Shfl.IDX,
+            return_value_and_is_valid=False,
+        )
+        kv_base = window_tile_start * self.cfg.kv_tile_n
+        return (
+            Int32(self.variable_window_token_starts[packed_q]) - kv_base,
+            Int32(self.variable_window_token_ends[packed_q]) - kv_base,
+        )
 
     @cute.jit
     def _load_s_chunks(self, stage_info: StageInfo) -> SoftmaxChunks:
@@ -2905,6 +3043,61 @@ class TmemSPResource(MemoryResource):
                 s_data[chunk_idx] = cutlass.vector.where(
                     mask, s_data[chunk_idx], neg_inf
                 )
+        return self._reduce_row_max(s_data, row_max)
+
+    @consumer_work(returns=(old_row_max, row_max))
+    @cute.jit
+    def variable_window_row_max(
+        self,
+        stage_info: StageInfo,
+        *,
+        row_max: SoftmaxScalar,
+        window_start: Int32,
+        window_end: Int32,
+    ) -> tuple[SoftmaxScalar, SoftmaxScalar]:
+        """Mask S using inclusive per-row VariableWindow bounds."""
+        tmem_x = self.cfg.tmem_x_load_s
+        num_chunks = self.cfg.qk_mma_tiler[1] // tmem_x
+        s_data = self._load_s_chunks(stage_info)
+        kv_tile_base = stage_info.loop_offset * self.cfg.kv_tile_n
+        tile_n = self.cfg.qk_mma_tiler[1]
+        left_oob = cute.math.min(
+            cute.math.max(window_start - kv_tile_base, Int32(0)),
+            Int32(tile_n),
+        )
+        right_valid = cute.math.min(
+            cute.math.max(window_end + Int32(1) - kv_tile_base, Int32(0)),
+            Int32(tile_n),
+        )
+        for chunk_idx in cutlass.range_constexpr(num_chunks):
+            chunk_base = Int32(chunk_idx * tmem_x)
+            chunk_left = cute.math.min(
+                cute.math.max(left_oob - chunk_base, Int32(0)),
+                Int32(tmem_x),
+            )
+            chunk_right = cute.math.min(
+                cute.math.max(right_valid - chunk_base, Int32(0)),
+                Int32(tmem_x),
+            )
+            valid_bits = _bmsk_clamp(chunk_left, chunk_right - chunk_left)
+            chunk = s_data[chunk_idx]
+            masked_scores = []
+            for quad_idx in cutlass.range_constexpr(tmem_x // 4):
+                quad_base = quad_idx * 4
+                # CUDA 13.3 NVVM rejects r2p in this kernel, so expand each
+                # four-bit group with ordinary setp instructions.
+                masked_scores.extend(
+                    _mask_score_quad(
+                        valid_bits >> Int32(quad_base),
+                        chunk[quad_base],
+                        chunk[quad_base + 1],
+                        chunk[quad_base + 2],
+                        chunk[quad_base + 3],
+                    )
+                )
+            s_data[chunk_idx] = cutlass.Vector.from_elements(
+                tuple(masked_scores), self.cfg.qk_acc_dtype
+            )
         return self._reduce_row_max(s_data, row_max)
 
     @consumer_work(returns=(old_row_max, row_max))

--- a/flashinfer/attention/prims_ts/kernels/fmha_context/fmha_tasks.py
+++ b/flashinfer/attention/prims_ts/kernels/fmha_context/fmha_tasks.py
@@ -1097,11 +1097,21 @@ def create_softmax_task(
                         q_offset = sp.cache_q_offset()
                     if tmem_sp.uses_packed_dense_k_mask:
                         seqlen_k = sp.cache_seqlen_k()
+                    window_start = Int32(0)
+                    window_end = Int32(0)
+                    if tmem_sp.uses_variable_window:
+                        window_start, window_end = sp.cache_variable_window_bounds()
                     vec.acquire()
                     with domain_loop(loop_start, loop_end, loop_step):
                         # Softmax(i): wait for QK(Q,Ki) -> S(i).
                         sp.wait()
-                        if tmem_sp.uses_left_window_loop_mask:
+                        if tmem_sp.uses_variable_window:
+                            old_row_max, row_max = sp.variable_window_row_max(
+                                row_max=row_max,
+                                window_start=window_start,
+                                window_end=window_end,
+                            )
+                        elif tmem_sp.uses_left_window_loop_mask:
                             old_row_max, row_max = sp.left_masked_row_max(
                                 row_max=row_max,
                                 q_offset=q_offset,
@@ -1369,10 +1379,20 @@ def create_softmax_task(
                     q_offset = sp.cache_q_offset()
                 if tmem_sp.uses_packed_dense_k_mask:
                     seqlen_k = sp.cache_seqlen_k()
+                window_start = Int32(0)
+                window_end = Int32(0)
+                if tmem_sp.uses_variable_window:
+                    window_start, window_end = sp.cache_variable_window_bounds()
                 vec.acquire()
                 with domain_loop(loop_start, loop_end, loop_step):
                     sp.wait()
-                    if tmem_sp.uses_left_window_loop_mask:
+                    if tmem_sp.uses_variable_window:
+                        old_row_max, row_max = sp.variable_window_row_max(
+                            row_max=row_max,
+                            window_start=window_start,
+                            window_end=window_end,
+                        )
+                    elif tmem_sp.uses_left_window_loop_mask:
                         old_row_max, row_max = sp.left_masked_row_max(
                             row_max=row_max,
                             q_offset=q_offset,
@@ -1557,12 +1577,22 @@ def create_softmax_task(
                 q_offset = sp.cache_q_offset()
             if tmem_sp.uses_packed_dense_k_mask:
                 seqlen_k = sp.cache_seqlen_k()
+            window_start = Int32(0)
+            window_end = Int32(0)
+            if tmem_sp.uses_variable_window:
+                window_start, window_end = sp.cache_variable_window_bounds()
             # Reserve a stats slot before the first softmax result is published.
             vec.acquire()
             with domain_loop(loop_start, loop_end, loop_step):
                 sp.wait()
                 # Compute row max and publish vec.
-                if tmem_sp.uses_left_window_loop_mask:
+                if tmem_sp.uses_variable_window:
+                    old_row_max, row_max = sp.variable_window_row_max(
+                        row_max=row_max,
+                        window_start=window_start,
+                        window_end=window_end,
+                    )
+                elif tmem_sp.uses_left_window_loop_mask:
                     old_row_max, row_max = sp.left_masked_row_max(
                         row_max=row_max,
                         q_offset=q_offset,

--- a/flashinfer/attention/prims_ts/kernels/fmha_context/helpers.py
+++ b/flashinfer/attention/prims_ts/kernels/fmha_context/helpers.py
@@ -15,8 +15,23 @@
 
 """Low-level helper intrinsics for FMHA context TS resources."""
 
+import cutlass
 import cutlass.cute as cute
 from cutlass import Int32, Int64
+
+
+@cute.jit
+def variable_window_cta_min_start(
+    cta_starts: cute.Tensor,
+    *,
+    batch_coord: Int32,
+    seq_coord: Int32,
+    q_stride: int | Int32,
+    cta_m: cutlass.Constexpr[int],
+) -> Int32:
+    """Load the plan-time minimum variable-window start for one Q CTA."""
+    num_seq_tiles = cute.ceil_div(q_stride, cta_m)
+    return Int32(cta_starts[batch_coord * num_seq_tiles + seq_coord])
 
 
 def bottom_right_window_left_bound(

--- a/flashinfer/attention/prims_ts/kernels/fmha_context/helpers.py
+++ b/flashinfer/attention/prims_ts/kernels/fmha_context/helpers.py
@@ -27,10 +27,10 @@ def variable_window_cta_min_start(
     batch_coord: Int32,
     seq_coord: Int32,
     q_stride: int | Int32,
-    cta_m: cutlass.Constexpr[int],
+    tile_size_q: cutlass.Constexpr[int],
 ) -> Int32:
     """Load the plan-time minimum variable-window start for one Q CTA."""
-    num_seq_tiles = cute.ceil_div(q_stride, cta_m)
+    num_seq_tiles = cute.ceil_div(q_stride, tile_size_q)
     return Int32(cta_starts[batch_coord * num_seq_tiles + seq_coord])
 
 

--- a/tests/attention/test_attention_ts_context.py
+++ b/tests/attention/test_attention_ts_context.py
@@ -1944,6 +1944,49 @@ def test_attention_ts_context_variable_window_uses_cta_minimum_start(head_dim: i
     _assert_context_correct(actual, case, expected=expected)
 
 
+@pytest.mark.parametrize("head_dim", (128, 256), ids=("d128", "d256"))
+@pytest.mark.arch_blackwell
+@_REQUIRES_CONTEXT_GPU
+def test_attention_ts_context_variable_window_clamps_padded_q_rows(head_dim: int):
+    """Padded Q rows must not read past flattened per-row window bounds."""
+
+    seq_len = 33
+    case = _make_context_case(
+        q_lengths=(seq_len, seq_len),
+        k_lengths=(seq_len, seq_len),
+        num_qo_heads=2,
+        num_kv_heads=2,
+        qkv_dtype=torch.float16,
+        packed=False,
+        mask_type="variable_window",
+        head_dim=head_dim,
+        output_dtype=torch.float16,
+        output_scale=1.0,
+        device="cuda",
+        seed=2026082701 + head_dim,
+    )
+
+    query_positions = torch.arange(seq_len, dtype=torch.int32, device="cuda")
+    ends = query_positions.unsqueeze(0).expand(2, -1).contiguous()
+    starts = torch.clamp(ends - 7, min=0)
+
+    wrapper = BatchPrefillTSWrapper()
+    wrapper.plan(
+        case.q,
+        case.k,
+        case.v,
+        mask_type="variable_window",
+        variable_window_token_starts=starts,
+        variable_window_token_ends=ends,
+        sm_scale=case.sm_scale,
+        output_scale=case.output_scale,
+        out_dtype=case.output_dtype,
+    )
+    actual = wrapper.run(case.q, case.k, case.v)
+    expected = _variable_window_reference(case, starts, ends)
+    _assert_context_correct(actual, case, expected=expected)
+
+
 @pytest.mark.arch_blackwell
 @_REQUIRES_CONTEXT_GPU
 def test_attention_ts_context_fixed_dense_k_tail_excludes_tma_padding():

--- a/tests/attention/test_attention_ts_context.py
+++ b/tests/attention/test_attention_ts_context.py
@@ -363,6 +363,42 @@ def _context_reference(case: _ContextCase) -> torch.Tensor:
     return torch.cat(outputs) if case.packed else torch.stack(outputs)
 
 
+@torch.no_grad()
+def _variable_window_reference(
+    case: _ContextCase,
+    starts: torch.Tensor,
+    ends: torch.Tensor,
+) -> torch.Tensor:
+    """Independent FP32 oracle for fixed per-Q inclusive window bounds."""
+
+    if case.packed:
+        raise ValueError("variable-window test reference requires fixed storage")
+    outputs = []
+    for batch_idx in range(len(case.q_lengths)):
+        q = case.q[batch_idx].float()
+        k = case.k[batch_idx].float()
+        v = case.v[batch_idx].float()
+        head_ratio = q.shape[1] // k.shape[1]
+        k = k.repeat_interleave(head_ratio, dim=1)
+        v = v.repeat_interleave(head_ratio, dim=1)
+
+        scores = torch.einsum("qhd,khd->hqk", q, k)
+        key_positions = torch.arange(
+            k.shape[0], dtype=torch.int32, device=k.device
+        ).unsqueeze(0)
+        valid = (key_positions >= starts[batch_idx].unsqueeze(1)) & (
+            key_positions <= ends[batch_idx].unsqueeze(1)
+        )
+        probabilities = torch.softmax(
+            scores.masked_fill(~valid.unsqueeze(0), -torch.inf) * case.sm_scale,
+            dim=-1,
+        )
+        outputs.append(
+            torch.einsum("hqk,khd->qhd", probabilities, v) * case.output_scale
+        )
+    return torch.stack(outputs)
+
+
 def _assert_context_correct(
     actual: torch.Tensor,
     case: _ContextCase,
@@ -486,6 +522,8 @@ def test_attention_ts_context_alias_guard_covers_fixed_plan_storage(
         "kv_indptr",
         "scale_softmax_log2",
         "output_scale",
+        "variable_window_token_starts",
+        "variable_window_token_ends",
     )
 
     for aliased_name in (*argument_names, *retained_names):
@@ -1743,6 +1781,90 @@ def test_attention_ts_context_bounded_public_correctness_matrix(
     else:
         actual = _run_one_shot(case)
     _assert_context_correct(actual, case)
+
+
+@pytest.mark.parametrize("head_dim", (128, 256), ids=("d128", "d256"))
+@pytest.mark.arch_blackwell
+@_REQUIRES_CONTEXT_GPU
+def test_attention_ts_context_variable_window_t1_i1_t2_i2(
+    head_dim: int,
+):
+    """Exercise the 2560-token text/image variable-window mask."""
+
+    seq_len = 2560
+    left_window = 128
+    right_window = 128
+    image_segments = ((256, 1280), (1536, 2560))
+    case = _make_context_case(
+        q_lengths=(seq_len,),
+        k_lengths=(seq_len,),
+        num_qo_heads=2,
+        num_kv_heads=1,
+        qkv_dtype=torch.float16,
+        packed=False,
+        mask_type="variable_window",
+        head_dim=head_dim,
+        output_dtype=torch.float16,
+        output_scale=1.0,
+        device="cuda",
+        seed=2026073001 + head_dim,
+    )
+
+    query_positions = torch.arange(seq_len, dtype=torch.int32, device="cuda")
+    starts = torch.clamp(query_positions - left_window, min=0)
+    ends = query_positions.clone()
+    for segment_start, segment_end in image_segments:
+        in_segment = (query_positions >= segment_start) & (
+            query_positions < segment_end
+        )
+        image_end = torch.clamp(
+            query_positions + right_window,
+            max=segment_end - 1,
+        )
+        ends = torch.where(in_segment, image_end, ends)
+    starts = starts.unsqueeze(0).contiguous()
+    ends = ends.unsqueeze(0).contiguous()
+
+    # T1[0:256], I1[256:1280], T2[1280:1536], I2[1536:2560].
+    assert starts[0, (0, 255, 256, 1279, 1280, 1535, 1536, 2559)].tolist() == [
+        0,
+        127,
+        128,
+        1151,
+        1152,
+        1407,
+        1408,
+        2431,
+    ]
+    end_checkpoints = (0, 255, 256, 1151, 1279, 1280, 1535, 1536, 2431, 2559)
+    assert ends[0, end_checkpoints].tolist() == [
+        0,
+        255,
+        384,
+        1279,
+        1279,
+        1280,
+        1535,
+        1664,
+        2559,
+        2559,
+    ]
+
+    wrapper = BatchPrefillTSWrapper()
+    wrapper.plan(
+        case.q,
+        case.k,
+        case.v,
+        mask_type="variable_window",
+        variable_window_token_starts=starts,
+        variable_window_token_ends=ends,
+        sm_scale=case.sm_scale,
+        output_scale=case.output_scale,
+        out_dtype=case.output_dtype,
+    )
+    actual = wrapper.run(case.q, case.k, case.v)
+    expected = _variable_window_reference(case, starts, ends)
+    _assert_context_correct(actual, case, expected=expected)
 
 
 @pytest.mark.arch_blackwell

--- a/tests/attention/test_attention_ts_context.py
+++ b/tests/attention/test_attention_ts_context.py
@@ -1516,7 +1516,7 @@ def test_attention_ts_context_paged_rejects_variable_window_before_compile(
 
     with pytest.raises(
         NotImplementedError,
-        match="variable-window masking.*not supported for paged context",
+        match=r"variable-window masking.*not supported for paged context",
     ):
         FmhaTs(has_variable_window=True, use_paged_kv=True)
 
@@ -1527,7 +1527,7 @@ def test_attention_ts_context_paged_rejects_variable_window_before_compile(
     wrapper = BatchPrefillPagedTSWrapper()
     with pytest.raises(
         NotImplementedError,
-        match="variable_window.*not supported for paged context",
+        match=r"variable_window.*not supported for paged context",
     ):
         wrapper.plan(
             None,

--- a/tests/attention/test_attention_ts_context.py
+++ b/tests/attention/test_attention_ts_context.py
@@ -524,6 +524,7 @@ def test_attention_ts_context_alias_guard_covers_fixed_plan_storage(
         "output_scale",
         "variable_window_token_starts",
         "variable_window_token_ends",
+        "variable_window_cta_starts",
     )
 
     for aliased_name in (*argument_names, *retained_names):
@@ -1508,6 +1509,39 @@ def test_attention_ts_context_paged_uniform_geometry_has_distinct_semantic_key()
     )
 
 
+def test_attention_ts_context_paged_rejects_variable_window_before_compile(
+    monkeypatch,
+):
+    """Paged context must not silently dispatch variable windows as dense."""
+
+    with pytest.raises(
+        NotImplementedError,
+        match="variable-window masking.*not supported for paged context",
+    ):
+        FmhaTs(has_variable_window=True, use_paged_kv=True)
+
+    def fail_compile(*args, **kwargs):
+        pytest.fail("paged variable-window validation reached kernel compilation")
+
+    monkeypatch.setattr(context_module, "_get_compiled_paged_context", fail_compile)
+    wrapper = BatchPrefillPagedTSWrapper()
+    with pytest.raises(
+        NotImplementedError,
+        match="variable_window.*not supported for paged context",
+    ):
+        wrapper.plan(
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            mask_type="variable_window",
+            out_dtype=torch.float16,
+        )
+
+
 @pytest.mark.arch_blackwell
 @_REQUIRES_CONTEXT_GPU
 def test_attention_ts_context_rejects_int32_page_table_offset_overflow(monkeypatch):
@@ -1849,6 +1883,49 @@ def test_attention_ts_context_variable_window_t1_i1_t2_i2(
         2559,
         2559,
     ]
+
+    wrapper = BatchPrefillTSWrapper()
+    wrapper.plan(
+        case.q,
+        case.k,
+        case.v,
+        mask_type="variable_window",
+        variable_window_token_starts=starts,
+        variable_window_token_ends=ends,
+        sm_scale=case.sm_scale,
+        output_scale=case.output_scale,
+        out_dtype=case.output_dtype,
+    )
+    actual = wrapper.run(case.q, case.k, case.v)
+    expected = _variable_window_reference(case, starts, ends)
+    _assert_context_correct(actual, case, expected=expected)
+
+
+@pytest.mark.parametrize("head_dim", (128, 256), ids=("d128", "d256"))
+@pytest.mark.arch_blackwell
+@_REQUIRES_CONTEXT_GPU
+def test_attention_ts_context_variable_window_uses_cta_minimum_start(head_dim: int):
+    """A later Q row may extend into a K tile earlier than the CTA's first row."""
+
+    seq_len_q = 256
+    seq_len_k = 256
+    case = _make_context_case(
+        q_lengths=(seq_len_q,),
+        k_lengths=(seq_len_k,),
+        num_qo_heads=2,
+        num_kv_heads=1,
+        qkv_dtype=torch.float16,
+        packed=False,
+        mask_type="variable_window",
+        head_dim=head_dim,
+        output_dtype=torch.float16,
+        output_scale=1.0,
+        device="cuda",
+        seed=2026081901 + head_dim,
+    )
+    starts = torch.full((1, seq_len_q), 128, dtype=torch.int32, device="cuda")
+    starts[0, 160] = 0
+    ends = torch.full((1, seq_len_q), seq_len_k - 1, dtype=torch.int32, device="cuda")
 
     wrapper = BatchPrefillTSWrapper()
     wrapper.plan(


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

1. Adding variable attention window support which allows each Q token has its own window range.
2. Performance:
- Q/K/V/O shape: [64, 2560, 8, D], D=128 or 256.
- Dtype: [FP15, FP8]
- 4 Seqence in one batchL T1[0:256], I1[256:1280], T2[1280:1536], I2[1536:2560]
- Base mask is causal with `left_window=128`.
- `I1` and `I2` additionally allow `right_window=128`, capped at their own segment end.

|  D  | Dtype  | FmhaTs ms | TRT-LLM-GEN ms |
| --- | ------ | --------- | -------------- |
| 256 |  fp16  |   0.6066  |     0.6554     |
| 128 |  fp16  |   0.3538  |     0.4027     |
| 256 |  fp8   |   0.3898  |     0.4424     |
| 128 |  fp8   |   0.3361  |     0.3231     |

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added variable-window attention support for packed sequences.
  * Planning and prefill APIs now accept per-query window start and end bounds.
  * Supports configurable attention ranges with CUDA int32 boundary tensors.
  * Improved window-boundary handling across query tiles for more accurate masking.
  * Added support for longer text and image sequences with variable attention windows.

* **Bug Fixes**
  * Added validation for window bounds, incompatible mask settings, and output aliasing.
  * Paged variable-window attention now reports a clear unsupported-configuration error.

* **Tests**
  * Added correctness coverage across multiple head dimensions, sequence lengths, and boundary cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->