### PR TITLE
feat(moe): align unified MoE do_finalize behavior with flat API

### DIFF
--- a/flashinfer/fused_moe/api.py
+++ b/flashinfer/fused_moe/api.py
@@ -228,8 +228,11 @@ class MoEFinalizeConfig:
     do_finalize : bool
         Whether to apply routing-weight scaling and accumulate the per-expert
         partial results into the output.  ``False`` returns the unreduced
-        per-expert partials, leaving the combine to the caller — only the
-        backends that advertise it support this.
+        TRTLLM intermediates as ``[gemm2_output, expert_weights,
+        expanded_idx_to_permuted_idx]``, leaving the combine to the caller.
+        The routing kernel emits ``expert_weights`` in bfloat16 regardless of
+        the routing-logits dtype. Only backends that advertise unfinalized
+        output support this mode.
     use_fused_finalize : bool
         Whether supported backends reduce routed outputs in the GEMM2 epilogue
         (atomic accumulation) instead of running a separate reduction kernel.

--- a/flashinfer/fused_moe/api.py
+++ b/flashinfer/fused_moe/api.py
@@ -230,9 +230,10 @@ class MoEFinalizeConfig:
         partial results into the output.  ``False`` returns the unreduced
         TRTLLM intermediates as ``[gemm2_output, expert_weights,
         expanded_idx_to_permuted_idx]``, leaving the combine to the caller.
-        The routing kernel emits ``expert_weights`` in bfloat16 regardless of
-        the routing-logits dtype. Only backends that advertise unfinalized
-        output support this mode.
+        For FromLogits routing, the routing kernel emits ``expert_weights`` in
+        bfloat16 regardless of the routing-logits dtype. Precomputed routing
+        preserves the caller-provided weights dtype. Only backends that
+        advertise unfinalized output support this mode.
     use_fused_finalize : bool
         Whether supported backends reduce routed outputs in the GEMM2 epilogue
         (atomic accumulation) instead of running a separate reduction kernel.

--- a/flashinfer/fused_moe/api.py
+++ b/flashinfer/fused_moe/api.py
@@ -231,9 +231,12 @@ class MoEFinalizeConfig:
         TRTLLM intermediates as ``[gemm2_output, expert_weights,
         expanded_idx_to_permuted_idx]``, leaving the combine to the caller.
         For FromLogits routing, the routing kernel emits ``expert_weights`` in
-        bfloat16 regardless of the routing-logits dtype. Precomputed routing
-        preserves the caller-provided weights dtype. Only backends that
-        advertise unfinalized output support this mode.
+        bfloat16 regardless of the routing-logits dtype. ``PackedPrecomputed``
+        routing also yields bfloat16 weights: the caller's values are narrowed
+        to bfloat16 when packed into the top-k ids. Only
+        ``UnpackedPrecomputed`` routing preserves the caller-provided weights
+        dtype, since it forwards ``topk_weights`` to the kernel unchanged.
+        Only backends that advertise unfinalized output support this mode.
     use_fused_finalize : bool
         Whether supported backends reduce routed outputs in the GEMM2 epilogue
         (atomic accumulation) instead of running a separate reduction kernel.

--- a/flashinfer/fused_moe/core.py
+++ b/flashinfer/fused_moe/core.py
@@ -1673,6 +1673,63 @@ def _alloc_trtllm_moe_output(
     )
 
 
+def _fake_trtllm_moe_output(
+    hidden_states: torch.Tensor,
+    *,
+    hidden_size: int,
+    intermediate_size: int,
+    top_k: int,
+    do_finalize: bool,
+    output: Optional[torch.Tensor] = None,
+    expert_weights: Optional[torch.Tensor] = None,
+    gemm1_lora_delta: Optional[torch.Tensor] = None,
+    num_fused_shared_experts: int = 0,
+) -> List[torch.Tensor]:
+    """Model the native TRTLLM MoE result contract for FakeTensor tracing."""
+    num_tokens = hidden_states.shape[0]
+    if do_finalize:
+        finalized = (
+            output
+            if output is not None and output.shape[1] == hidden_size
+            else hidden_states.new_empty(
+                (num_tokens, hidden_size), dtype=torch.bfloat16
+            )
+        )
+        if gemm1_lora_delta is None:
+            return [finalized]
+    else:
+        # Routing-dependent expert padding makes the first dimension dynamic.
+        gemm2_rows = torch.library.get_ctx().new_dynamic_size()
+        finalized = hidden_states.new_empty(
+            (gemm2_rows, hidden_size), dtype=torch.bfloat16
+        )
+
+    total_top_k = top_k + num_fused_shared_experts
+    expanded_idx_to_permuted_idx = hidden_states.new_empty(
+        (num_tokens * total_top_k,), dtype=torch.int32
+    )
+    if not do_finalize:
+        weights = (
+            expert_weights
+            if expert_weights is not None and expert_weights.numel() > 0
+            else hidden_states.new_empty(
+                (num_tokens, total_top_k), dtype=torch.bfloat16
+            )
+        )
+        result = [finalized, weights, expanded_idx_to_permuted_idx]
+    else:
+        result = [finalized, expanded_idx_to_permuted_idx]
+
+    if gemm1_lora_delta is not None:
+        gemm1_rows = torch.library.get_ctx().new_dynamic_size()
+        result.append(
+            hidden_states.new_empty(
+                (gemm1_rows, intermediate_size), dtype=torch.bfloat16
+            )
+        )
+    return result
+
+
 def _unpack_trtllm_moe_output(
     intermediate_output,
     output: torch.Tensor,
@@ -2789,11 +2846,16 @@ def _get_trtllm_moe_sm100_module_impl(enable_rubin: bool):
     ) -> List[torch.Tensor]:
         # Acknowledge the declared mutation-only argument without reading device data in fake mode.
         _ = routing_replay_out
-        # Propagate the public finalized BF16 output shape for compile-time tracing.
-        seq_len = hidden_states.shape[0]
-        hidden_size = hidden_states.shape[1]
-
-        return [hidden_states.new_empty([seq_len, hidden_size], dtype=torch.bfloat16)]
+        return _fake_trtllm_moe_output(
+            hidden_states,
+            hidden_size=hidden_states.shape[1],
+            intermediate_size=intermediate_size,
+            top_k=top_k,
+            do_finalize=do_finalize,
+            output=output,
+            expert_weights=expert_weights,
+            gemm1_lora_delta=gemm1_lora_delta,
+        )
 
     @register_custom_op(
         "flashinfer::trtllm_fp8_per_tensor_scale_moe",
@@ -3022,11 +3084,14 @@ def _get_trtllm_moe_sm100_module_impl(enable_rubin: bool):
     ):
         # Acknowledge the declared mutation-only argument without reading device data in fake mode.
         _ = routing_replay_out
-        # Propagate the public finalized BF16 output shape for compile-time tracing.
-        seq_len = hidden_states.shape[0]
-        hidden_size = hidden_states.shape[1]
-
-        return [hidden_states.new_empty([seq_len, hidden_size], dtype=torch.bfloat16)]
+        return _fake_trtllm_moe_output(
+            hidden_states,
+            hidden_size=hidden_states.shape[1],
+            intermediate_size=intermediate_size,
+            top_k=top_k,
+            do_finalize=do_finalize,
+            output=output,
+        )
 
     @register_custom_op(
         "flashinfer::trtllm_fp8_per_tensor_scale_routed_moe",
@@ -3273,16 +3338,15 @@ def _get_trtllm_moe_sm100_module_impl(enable_rubin: bool):
     ):
         # Acknowledge the declared mutation-only argument without reading device data in fake mode.
         _ = routing_replay_out
-        # Fake mode supports only the finalized public result represented by this wrapper.
-        if not do_finalize:
-            raise NotImplementedError(
-                "The fake trtllm_fp8_per_tensor_scale_routed_moe op does not "
-                "support do_finalize=False"
-            )
-        seq_len = hidden_states.shape[0]
-        hidden_size = hidden_states.shape[1]
-
-        return [hidden_states.new_empty([seq_len, hidden_size], dtype=torch.bfloat16)]
+        return _fake_trtllm_moe_output(
+            hidden_states,
+            hidden_size=hidden_states.shape[1],
+            intermediate_size=intermediate_size,
+            top_k=top_k,
+            do_finalize=do_finalize,
+            output=output,
+            expert_weights=expert_weights,
+        )
 
     @register_custom_op(
         "flashinfer::trtllm_fp8_block_scale_moe",
@@ -3600,12 +3664,17 @@ def _get_trtllm_moe_sm100_module_impl(enable_rubin: bool):
     ) -> List[torch.Tensor]:
         # Acknowledge mutation-only and fallback-only controls without executing the native op.
         _ = routing_replay_out
-        _ = num_fused_shared_experts
-        # Propagate the finalized public BF16 result shape for compile-time tracing.
-        seq_len = hidden_states.shape[0]
-        hidden_size = hidden_states.shape[1]
-        # TODO: This is not correct for gemm1_lora_delta or do_finalize=False
-        return [hidden_states.new_empty([seq_len, hidden_size], dtype=torch.bfloat16)]
+        return _fake_trtllm_moe_output(
+            hidden_states,
+            hidden_size=hidden_states.shape[1],
+            intermediate_size=intermediate_size,
+            top_k=top_k,
+            do_finalize=do_finalize,
+            output=output,
+            expert_weights=expert_weights,
+            gemm1_lora_delta=gemm1_lora_delta,
+            num_fused_shared_experts=num_fused_shared_experts,
+        )
 
     @register_custom_op(
         "flashinfer::trtllm_fp4_block_scale_moe",
@@ -3948,13 +4017,17 @@ def _get_trtllm_moe_sm100_module_impl(enable_rubin: bool):
     ):
         # Acknowledge mutation-only and fallback-only controls without executing the native op.
         _ = routing_replay_out
-        _ = num_fused_shared_experts
-        # Respect a caller-provided output width when tracing the finalized public result.
-        seq_len = hidden_states.shape[0]
-        hidden_size = hidden_states.shape[1] if output is None else output.shape[1]
-
-        # TODO: This is not correct for gemm1_lora_delta or do_finalize=False
-        return [hidden_states.new_empty([seq_len, hidden_size], dtype=torch.bfloat16)]
+        return _fake_trtllm_moe_output(
+            hidden_states,
+            hidden_size=gemm2_weights.shape[1],
+            intermediate_size=intermediate_size,
+            top_k=top_k,
+            do_finalize=do_finalize,
+            output=output,
+            expert_weights=topk_weights,
+            gemm1_lora_delta=gemm1_lora_delta,
+            num_fused_shared_experts=num_fused_shared_experts,
+        )
 
     @register_custom_op(
         "flashinfer::trtllm_mxint4_block_scale_moe",
@@ -4213,11 +4286,16 @@ def _get_trtllm_moe_sm100_module_impl(enable_rubin: bool):
     ):
         # Acknowledge the declared mutation-only argument without reading device data in fake mode.
         _ = routing_replay_out
-        # Propagate the public finalized BF16 output shape for compile-time tracing.
-        seq_len = hidden_states.shape[0]
-        hidden_size = hidden_states.shape[1]
-
-        return [hidden_states.new_empty([seq_len, hidden_size], dtype=torch.bfloat16)]
+        return _fake_trtllm_moe_output(
+            hidden_states,
+            hidden_size=hidden_states.shape[1],
+            intermediate_size=intermediate_size,
+            top_k=top_k,
+            do_finalize=do_finalize,
+            output=output,
+            expert_weights=expert_weights,
+            gemm1_lora_delta=gemm1_lora_delta,
+        )
 
     return SimpleNamespace(
         trtllm_bf16_moe=trtllm_bf16_moe_op,

--- a/flashinfer/fused_moe/core.py
+++ b/flashinfer/fused_moe/core.py
@@ -2178,6 +2178,10 @@ def _get_trtllm_moe_sm100_module_impl(enable_rubin: bool):
                         list(da_body_workspace),
                         prepare_da_body,
                     )
+                    # Unlike the routed per-tensor entry point, the FromLogits
+                    # ABI does not accept the caller's expert_weights buffer;
+                    # the launcher owns and returns that tensor.
+                    expert_weights = None
                 if prepare_da_body or da_routing_metadata:
                     return list(result)
             elif (
@@ -2265,6 +2269,14 @@ def _get_trtllm_moe_sm100_module_impl(enable_rubin: bool):
                 )
                 if prepare_da_body or da_routing_metadata:
                     return list(result)
+
+            return _unpack_trtllm_moe_output(
+                result,
+                output,
+                kwargs["do_finalize"],
+                moe_inputs.gemm1_lora_delta,
+                expert_weights,
+            )
 
     class DABodyRunner:
         """Compose one ordinary MoERunner with prepared-metadata body execution."""
@@ -2566,7 +2578,7 @@ def _get_trtllm_moe_sm100_module_impl(enable_rubin: bool):
             # When routing_logits is provided, we must pass topk_ids/expert_weights with no allocation
             topk_ids = torch.empty(0, dtype=torch.int32, device=hidden_states.device)
             expert_weights = torch.empty(
-                0, dtype=routing_logits.dtype, device=hidden_states.device
+                0, dtype=torch.bfloat16, device=hidden_states.device
             )
         else:
             # When routing_logits is provided, we either have topk_ids/expert_weights,
@@ -2838,7 +2850,7 @@ def _get_trtllm_moe_sm100_module_impl(enable_rubin: bool):
             num_tokens, top_k, dtype=torch.int32, device=hidden_states.device
         )
         topk_weights = torch.empty(
-            num_tokens, top_k, dtype=routing_logits.dtype, device=hidden_states.device
+            num_tokens, top_k, dtype=torch.bfloat16, device=hidden_states.device
         )
 
         dtype_act = DtypeTrtllmGen.E4m3  # FP8 activation
@@ -3319,9 +3331,7 @@ def _get_trtllm_moe_sm100_module_impl(enable_rubin: bool):
                 "either topk_ids or routing_logits must be provided."
             )
             assert topk_ids.dtype == torch.int32, "topk_ids must be an int32 tensor."
-            routing_dtype = torch.bfloat16
-        else:
-            routing_dtype = routing_logits.dtype
+        routing_dtype = torch.bfloat16
 
         if enable_pdl is None:
             enable_pdl = device_support_pdl(hidden_states.device)
@@ -3992,7 +4002,7 @@ def _get_trtllm_moe_sm100_module_impl(enable_rubin: bool):
             # When routing_logits is provided, we must pass topk_ids/expert_weights with no allocation
             topk_ids = torch.empty(0, dtype=torch.int32, device=hidden_states.device)
             expert_weights = torch.empty(
-                0, dtype=routing_logits.dtype, device=hidden_states.device
+                0, dtype=torch.bfloat16, device=hidden_states.device
             )
         else:
             # When routing_logits is provided, we either have topk_ids/expert_weights,

--- a/flashinfer/fused_moe/core.py
+++ b/flashinfer/fused_moe/core.py
@@ -3765,6 +3765,10 @@ def _get_trtllm_moe_sm100_module_impl(enable_rubin: bool):
                     device=hidden_states.device,
                 )
             if topk_weights is None:
+                # FP4BlockScaleLauncher borrows this buffer instead of allocating
+                # FusedMoeLauncher::expert_weights. Keep it non-empty so
+                # do_finalize=False can return valid weights; the routing kernel
+                # fills it for both FromLogits and PackedPrecomputed.
                 topk_weights = torch.empty(
                     num_tokens,
                     top_k + num_fused_shared_experts,

--- a/flashinfer/fused_moe/layer.py
+++ b/flashinfer/fused_moe/layer.py
@@ -187,7 +187,7 @@ class MoELayer:
         self,
         act_pack: MoEActivationPack,
         weight_pack: MoEWeightPack,
-    ) -> torch.Tensor:
+    ) -> Union[torch.Tensor, List[torch.Tensor]]:
         ceiling = self.config.execution.tune_max_num_tokens
         if act_pack.num_tokens > ceiling:
             raise ValueError(

--- a/flashinfer/fused_moe/runners.py
+++ b/flashinfer/fused_moe/runners.py
@@ -1027,6 +1027,10 @@ class CuteDslNvfp4Runner(MoERunner):
 class _TrtllmRunnerBase(MoERunner):
     """Load the shared TRTLLM-gen module after support validation."""
 
+    _module: Any
+    _inner: Any
+    _static_kwargs: dict[str, Any]
+
     def _build(self) -> None:
         from .core import get_trtllm_moe_sm100_module
 
@@ -2481,12 +2485,11 @@ class TrtllmMxInt4RoutedRunner(_TrtllmRunnerBase):
             )
             routing_logits = act.routing_logits
             routing_bias = act.routing_bias
-            topk_ids = hidden_states.new_empty(
-                (num_tokens, routing.top_k), dtype=torch.int32
-            )
-            expert_weights = hidden_states.new_empty(
-                (num_tokens, routing.top_k), dtype=torch.bfloat16
-            )
+            # MxInt4 infers routing mode from these placeholders rather than
+            # receiving RoutingInputMode explicitly. Non-empty tensors select
+            # precomputed routing and would suppress routing_logits.
+            topk_ids = hidden_states.new_empty((0,), dtype=torch.int32)
+            expert_weights = hidden_states.new_empty((0,), dtype=torch.bfloat16)
         elif routing_input_mode == RoutingInputMode.PackedPrecomputed:
             _validate_prerouted_inputs(
                 act, num_tokens, routing.top_k, type(self).__name__

--- a/flashinfer/fused_moe/runners.py
+++ b/flashinfer/fused_moe/runners.py
@@ -823,6 +823,10 @@ class CuteDslNvfp4Runner(MoERunner):
             raise NotImplementedError(
                 f"{type(self).__name__} supports only the Swiglu activation."
             )
+        if not self.config.finalize.do_finalize:
+            raise NotImplementedError(
+                f"{type(self).__name__} requires do_finalize=True."
+            )
         if (
             self.config.quant.variant is QuantVariant.W4A16
             and self.config.quant.per_token_scale
@@ -1028,6 +1032,22 @@ class _TrtllmRunnerBase(MoERunner):
 
         self._module = get_trtllm_moe_sm100_module()
 
+    def _forward_inner(
+        self,
+        inputs: List[torch.Tensor],
+        tactic: Any,
+        do_preparation: bool,
+    ) -> torch.Tensor | List[torch.Tensor]:
+        result = self._inner.forward(
+            inputs,
+            tactic=tactic,
+            do_preparation=do_preparation,
+            **self._static_kwargs,
+        )
+        if self.config.finalize.do_finalize:
+            return inputs[0]
+        return result
+
 
 class TrtllmFp4RoutedRunner(_TrtllmRunnerBase):
     """FP4 adapter over the canonical trtllm-gen ``MoERunner``.
@@ -1181,18 +1201,12 @@ class TrtllmFp4RoutedRunner(_TrtllmRunnerBase):
         tactic: Any = -1,
         do_preparation: bool = False,
         **kwargs: Any,
-    ) -> torch.Tensor:
+    ) -> torch.Tensor | List[torch.Tensor]:
         self._require_built()
         # MoELayer's autotuner call passes no kwargs, so the static weight/config
-        # kwargs are injected here.  The inner runner writes the result in-place
-        # into inputs[0] (the output buffer of the MoeRunnerInputs list).
-        self._inner.forward(
-            inputs,
-            tactic=tactic,
-            do_preparation=do_preparation,
-            **self._static_kwargs,
-        )
-        return inputs[0]
+        # kwargs are injected here. Finalized calls write into inputs[0];
+        # unfinalized calls return the flat API's three-tensor result.
+        return self._forward_inner(inputs, tactic, do_preparation)
 
     def _validate_fp4_tensors(
         self,
@@ -1363,7 +1377,11 @@ class TrtllmFp4RoutedRunner(_TrtllmRunnerBase):
         hidden_states_scale = self._validate_fp4_tensors(act, v, hidden_size)
 
         output = act.hidden_states_q.new_empty(
-            (num_tokens, hidden_size), dtype=torch.bfloat16
+            (
+                num_tokens,
+                hidden_size if self.config.finalize.do_finalize else 0,
+            ),
+            dtype=torch.bfloat16,
         )
 
         routing_input_mode = act.routing_input_mode
@@ -1543,10 +1561,6 @@ class TrtllmFp8BlockRunner(_TrtllmRunnerBase):
             raise NotImplementedError(
                 f"{type(self).__name__} supports only the Swiglu activation."
             )
-        if not self.config.finalize.do_finalize:
-            raise NotImplementedError(
-                f"{type(self).__name__} supports only do_finalize=True."
-            )
         from ..utils import get_compute_capability
         from .api import TrtllmFp8BlockConfig
 
@@ -1637,15 +1651,9 @@ class TrtllmFp8BlockRunner(_TrtllmRunnerBase):
         tactic: Any = -1,
         do_preparation: bool = False,
         **kwargs: Any,
-    ) -> torch.Tensor:
+    ) -> torch.Tensor | List[torch.Tensor]:
         self._require_built()
-        self._inner.forward(
-            inputs,
-            tactic=tactic,
-            do_preparation=do_preparation,
-            **self._static_kwargs,
-        )
-        return inputs[0]
+        return self._forward_inner(inputs, tactic, do_preparation)
 
     def _validate_fp8_tensors(
         self,
@@ -1751,7 +1759,11 @@ class TrtllmFp8BlockRunner(_TrtllmRunnerBase):
         hidden_states_scale = self._validate_fp8_tensors(act, view, hidden_size)
 
         output = act.hidden_states_q.new_empty(
-            (num_tokens, hidden_size), dtype=torch.bfloat16
+            (
+                num_tokens,
+                hidden_size if self.config.finalize.do_finalize else 0,
+            ),
+            dtype=torch.bfloat16,
         )
         routing_input_mode = act.routing_input_mode
         if routing_input_mode == RoutingInputMode.FromLogits:
@@ -1825,7 +1837,7 @@ class TrtllmFp8BlockRunner(_TrtllmRunnerBase):
             routing_method_type=int(routing.method),
             use_shuffled_weight=self._use_shuffled_weight,
             weight_layout=int(WeightLayout.MajorK),
-            do_finalize=True,
+            do_finalize=self.config.finalize.do_finalize,
             enable_pdl=self._enable_pdl,
             # Matches the legacy block-FP8 FromLogits wrapper. Pre-routed
             # execution ignores this flag because weights are already final.
@@ -1875,10 +1887,6 @@ class TrtllmFp8PerTensorRunner(_TrtllmRunnerBase):
         if self.config.activation.type is not ActivationType.Swiglu:
             raise NotImplementedError(
                 f"{type(self).__name__} supports only the Swiglu activation."
-            )
-        if not self.config.finalize.do_finalize:
-            raise NotImplementedError(
-                f"{type(self).__name__} supports only do_finalize=True."
             )
         if (
             self.config.routing.method is RoutingMethodType.Llama4
@@ -1960,15 +1968,9 @@ class TrtllmFp8PerTensorRunner(_TrtllmRunnerBase):
         tactic: Any = -1,
         do_preparation: bool = False,
         **kwargs: Any,
-    ) -> torch.Tensor:
+    ) -> torch.Tensor | List[torch.Tensor]:
         self._require_built()
-        self._inner.forward(
-            inputs,
-            tactic=tactic,
-            do_preparation=do_preparation,
-            **self._static_kwargs,
-        )
-        return inputs[0]
+        return self._forward_inner(inputs, tactic, do_preparation)
 
     def _validate_tensors(
         self, act: MoEActivationPack, view: dict, hidden_size: int
@@ -2037,7 +2039,11 @@ class TrtllmFp8PerTensorRunner(_TrtllmRunnerBase):
         self._validate_tensors(act, view, hidden_size)
 
         output = act.hidden_states_q.new_empty(
-            (num_tokens, hidden_size), dtype=torch.bfloat16
+            (
+                num_tokens,
+                hidden_size if self.config.finalize.do_finalize else 0,
+            ),
+            dtype=torch.bfloat16,
         )
         routing_input_mode = act.routing_input_mode
         if routing_input_mode == RoutingInputMode.FromLogits:
@@ -2108,7 +2114,7 @@ class TrtllmFp8PerTensorRunner(_TrtllmRunnerBase):
             routed_scaling_factor=routing.routed_scaling_factor,
             use_routing_scales_on_input=(routing.method is RoutingMethodType.Llama4),
             routing_method_type=int(routing.method),
-            do_finalize=True,
+            do_finalize=self.config.finalize.do_finalize,
             enable_pdl=self._enable_pdl,
             norm_topk_prob=True,
             routing_replay_out=None,
@@ -2158,10 +2164,6 @@ class TrtllmBf16RoutedRunner(_TrtllmRunnerBase):
         if self.config.activation.type is not ActivationType.Swiglu:
             raise NotImplementedError(
                 f"{type(self).__name__} supports only the Swiglu activation."
-            )
-        if not self.config.finalize.do_finalize:
-            raise NotImplementedError(
-                f"{type(self).__name__} supports only do_finalize=True."
             )
         from ..utils import get_compute_capability
 
@@ -2237,15 +2239,9 @@ class TrtllmBf16RoutedRunner(_TrtllmRunnerBase):
         tactic: Any = -1,
         do_preparation: bool = False,
         **kwargs: Any,
-    ) -> torch.Tensor:
+    ) -> torch.Tensor | List[torch.Tensor]:
         self._require_built()
-        self._inner.forward(
-            inputs,
-            tactic=tactic,
-            do_preparation=do_preparation,
-            **self._static_kwargs,
-        )
-        return inputs[0]
+        return self._forward_inner(inputs, tactic, do_preparation)
 
     def pack_inputs(
         self, act: MoEActivationPack, weights: MoEWeightPack
@@ -2300,7 +2296,12 @@ class TrtllmBf16RoutedRunner(_TrtllmRunnerBase):
                 "PackedPrecomputed routing."
             )
 
-        output = hidden_states.new_empty((num_tokens, hidden_size))
+        output = hidden_states.new_empty(
+            (
+                num_tokens,
+                hidden_size if self.config.finalize.do_finalize else 0,
+            )
+        )
         moe_inputs = MoeRunnerInputs(
             output=output,
             routing_logits=routing_logits,
@@ -2368,10 +2369,6 @@ class TrtllmMxInt4RoutedRunner(_TrtllmRunnerBase):
         if self.config.activation.type is not ActivationType.Swiglu:
             raise NotImplementedError(
                 f"{type(self).__name__} supports only the Swiglu activation."
-            )
-        if not self.config.finalize.do_finalize:
-            raise NotImplementedError(
-                f"{type(self).__name__} supports only do_finalize=True."
             )
         from ..utils import get_compute_capability
         from .api import TrtllmMxInt4Config
@@ -2448,15 +2445,9 @@ class TrtllmMxInt4RoutedRunner(_TrtllmRunnerBase):
         tactic: Any = -1,
         do_preparation: bool = False,
         **kwargs: Any,
-    ) -> torch.Tensor:
+    ) -> torch.Tensor | List[torch.Tensor]:
         self._require_built()
-        self._inner.forward(
-            inputs,
-            tactic=tactic,
-            do_preparation=do_preparation,
-            **self._static_kwargs,
-        )
-        return inputs[0]
+        return self._forward_inner(inputs, tactic, do_preparation)
 
     def pack_inputs(
         self, act: MoEActivationPack, weights: MoEWeightPack
@@ -2488,17 +2479,6 @@ class TrtllmMxInt4RoutedRunner(_TrtllmRunnerBase):
             _validate_logits_inputs(
                 act, num_tokens, routing.num_experts, type(self).__name__
             )
-            if act.routing_logits.dtype != torch.bfloat16:
-                raise TypeError(
-                    f"{type(self).__name__}: FromLogits currently requires "
-                    f"bfloat16 routing_logits, got {act.routing_logits.dtype}."
-                )
-            if act.routing_bias is not None:
-                if act.routing_bias.dtype != torch.bfloat16:
-                    raise TypeError(
-                        f"{type(self).__name__}: routing_bias must be bfloat16, "
-                        f"got {act.routing_bias.dtype}."
-                    )
             routing_logits = act.routing_logits
             routing_bias = act.routing_bias
             topk_ids = hidden_states.new_empty(
@@ -2586,7 +2566,12 @@ class TrtllmMxInt4RoutedRunner(_TrtllmRunnerBase):
             type(self).__name__,
         )
 
-        output = hidden_states.new_empty((num_tokens, hidden_size))
+        output = hidden_states.new_empty(
+            (
+                num_tokens,
+                hidden_size if self.config.finalize.do_finalize else 0,
+            )
+        )
         moe_inputs = MoeRunnerInputs(
             output=output,
             routing_logits=routing_logits,

--- a/flashinfer/fused_moe/runners.py
+++ b/flashinfer/fused_moe/runners.py
@@ -1448,12 +1448,11 @@ class TrtllmFp4RoutedRunner(_TrtllmRunnerBase):
             routing_logits = None
             routing_bias = None
             topk_ids = _pack_prerouted_topk_ids(act)
-            # PackedPrecomputed still requires a (kernel-side) topk_weights buffer:
-            # the raw op declares it non-Optional.  The high-level wrapper allocates
-            # an empty bf16 placeholder here; we mirror that since we bypass it.
-            expert_weights = act.topk_weights.new_empty(
-                (num_tokens, routing.top_k), dtype=torch.bfloat16
-            )
+            # FP4 borrows this buffer but leaves its returned FFI slot undefined.
+            # Supply the packed weights so _unpack_trtllm_moe_output() can return
+            # them directly for do_finalize=False. Use BF16 to match the weights
+            # encoded in topk_ids.
+            expert_weights = act.topk_weights.to(torch.bfloat16).contiguous()
         elif routing_input_mode == RoutingInputMode.UnpackedPrecomputed:
             # UnpackedPrecomputed: both routing tensors are caller-owned kernel
             # inputs. Keep global ids intact; the launcher applies

--- a/tests/moe/test_unified_moe.py
+++ b/tests/moe/test_unified_moe.py
@@ -694,15 +694,18 @@ class TestMoERunnerSupport:
         with pytest.raises(NotImplementedError, match="Swiglu"):
             runner.check_support()
 
-    def test_fp8_block_unfinalized_not_supported(self):
+    def test_fp8_block_unfinalized_supported(self, monkeypatch):
+        import flashinfer.utils as utils
+
         cfg = self._nvfp4_swiglu(
             quant=QuantConfig(variant=QuantVariant.DeepSeekFp8),
             finalize=MoEFinalizeConfig(do_finalize=False),
         )
         runner = TrtllmFp8BlockRunner.__new__(TrtllmFp8BlockRunner)
         runner.config = cfg
-        with pytest.raises(NotImplementedError, match="do_finalize=True"):
-            runner.check_support()
+        runner.device = torch.device("cuda")
+        monkeypatch.setattr(utils, "get_compute_capability", lambda _: (10, 0))
+        runner.check_support()
 
     @pytest.mark.parametrize(
         ("runner_type", "variant"),
@@ -733,7 +736,7 @@ class TestMoERunnerSupport:
             with pytest.raises(NotImplementedError, match="SM100/SM103"):
                 runner.check_support()
 
-    def test_bf16_unfinalized_not_supported(self, monkeypatch):
+    def test_bf16_unfinalized_supported(self, monkeypatch):
         import flashinfer.utils as utils
 
         cfg = self._nvfp4_swiglu(
@@ -744,8 +747,7 @@ class TestMoERunnerSupport:
         runner.config = cfg
         runner.device = torch.device("cuda")
         monkeypatch.setattr(utils, "get_compute_capability", lambda _: (10, 0))
-        with pytest.raises(NotImplementedError, match="do_finalize=True"):
-            runner.check_support()
+        runner.check_support()
 
     def test_bf16_sm120_rejected_before_launch(self, monkeypatch):
         import flashinfer.utils as utils

--- a/tests/moe/test_unified_moe.py
+++ b/tests/moe/test_unified_moe.py
@@ -72,6 +72,7 @@ from flashinfer.fused_moe import (
     TrtllmMxInt4RoutedRunner,
 )
 from flashinfer.fused_moe.runners import MoERunner
+from flashinfer.fused_moe.core import _fake_trtllm_moe_output
 from flashinfer.utils import get_compute_capability
 
 
@@ -130,6 +131,67 @@ class TestEnumRepr:
     @pytest.mark.parametrize("member", list(QuantVariant))
     def test_quant_variant_repr(self, member):
         assert eval(repr(member)) == member
+
+
+class TestTrtllmFakeOutputContract:
+    class _FakeContext:
+        def __init__(self):
+            self._next = 16
+
+        def new_dynamic_size(self):
+            self._next += 1
+            return self._next
+
+    def test_unfinalized_generated_weights(self, monkeypatch):
+        monkeypatch.setattr(torch.library, "get_ctx", lambda: self._FakeContext())
+        hidden_states = torch.empty((4, 32), device="meta")
+        result = _fake_trtllm_moe_output(
+            hidden_states,
+            hidden_size=32,
+            intermediate_size=64,
+            top_k=2,
+            do_finalize=False,
+        )
+
+        assert len(result) == 3
+        assert result[0].shape == (17, 32)
+        assert result[1].shape == (4, 2)
+        assert result[1].dtype == torch.bfloat16
+        assert result[2].shape == (8,)
+        assert result[2].dtype == torch.int32
+
+    def test_unfinalized_preserves_precomputed_weights(self, monkeypatch):
+        monkeypatch.setattr(torch.library, "get_ctx", lambda: self._FakeContext())
+        hidden_states = torch.empty((4, 32), device="meta")
+        weights = torch.empty((4, 2), dtype=torch.float32, device="meta")
+        result = _fake_trtllm_moe_output(
+            hidden_states,
+            hidden_size=32,
+            intermediate_size=64,
+            top_k=2,
+            do_finalize=False,
+            expert_weights=weights,
+        )
+
+        assert result[1] is weights
+
+    def test_finalized_lora_arity(self, monkeypatch):
+        monkeypatch.setattr(torch.library, "get_ctx", lambda: self._FakeContext())
+        hidden_states = torch.empty((4, 32), device="meta")
+        lora_delta = torch.empty((4, 128), device="meta")
+        result = _fake_trtllm_moe_output(
+            hidden_states,
+            hidden_size=32,
+            intermediate_size=64,
+            top_k=2,
+            do_finalize=True,
+            gemm1_lora_delta=lora_delta,
+        )
+
+        assert len(result) == 3
+        assert result[0].shape == (4, 32)
+        assert result[1].shape == (8,)
+        assert result[2].shape == (17, 64)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/moe/test_unified_moe_fuzz.py
+++ b/tests/moe/test_unified_moe_fuzz.py
@@ -202,6 +202,7 @@ from flashinfer.fused_moe.api import (
     TrtllmMxInt4Config,
 )
 from flashinfer.fused_moe.layer import _BACKEND_RUNNERS
+from flashinfer.fused_moe.runners import _TrtllmRunnerBase
 from flashinfer.fused_moe.prepare import _quantize_mxfp4_linear
 from flashinfer.quantization import e2m1_and_ufp8sf_scale_to_float
 from flashinfer.quantization.fp8_quantization import mxfp8_quantize
@@ -992,6 +993,13 @@ _EP_BACKENDS = {
     for cfg_cls, runner_cls in _BACKEND_RUNNERS.items()
     if runner_cls.supports_expert_parallelism
 }
+# Backend config classes whose runner returns unfinalized intermediates. No
+# declared capability flag exists, so key off the TRTLLM runner base.
+_UNFINALIZED_BACKENDS = {
+    cfg_cls
+    for cfg_cls, runner_cls in _BACKEND_RUNNERS.items()
+    if issubclass(runner_cls, _TrtllmRunnerBase)
+}
 _UNPACKED_VARIANT_IDS = tuple(
     variant.name.lower()
     for variant, handler in _DTYPE.items()
@@ -1566,6 +1574,33 @@ _CURATED = [
             ("fp32", seed_base + 1),
         )
     ],
+    # PackedPrecomputed + unfinalized coverage. Packed ids encode BF16 routing
+    # weights, but FP4 borrows topk_weights instead of allocating its own buffer.
+    # The value assertion below guards the returned weights across all TRTLLM
+    # variants and catches an invalid FP4 buffer.
+    *[
+        Cfg(
+            32,
+            512,
+            512,
+            16,
+            4,
+            variant,
+            "uniform",
+            seed,
+            routing_method=RoutingMethodType.RenormalizeNaive,
+            routing_input_mode="prerouted",
+            do_finalize=False,
+        )
+        for variant, seed in (
+            ("bf16", 900_070),
+            ("fp8pertensor", 900_071),
+            ("deepseekfp8", 900_072),
+            ("mxint4", 900_073),
+            ("nvfp4", 900_074),
+            ("mxfp8", 900_075),
+        )
+    ],
 ]
 _CURATED_BY_SEED = {}
 for _cfg in _CURATED:
@@ -1898,6 +1933,10 @@ def test_unified_moe_fuzz(cfg):
         # Backends that accept separate tensors through their own ABI are not
         # implementations of RoutingInputMode.UnpackedPrecomputed.
         wired_backends = [B for B in wired_backends if B in _UNPACKED_BACKENDS]
+    if not cfg.do_finalize:
+        # Only TRTLLM returns unfinalized intermediates; like the EP filter
+        # below, this keeps an unsupported arch on the precise skip path.
+        wired_backends = [B for B in wired_backends if B in _UNFINALIZED_BACKENDS]
     if cfg.is_ep:
         # An EP shard needs the runner to map global ids onto a local expert subset;
         # backends without that capability (CUTLASS, b12x) would fail MoELayer's

--- a/tests/moe/test_unified_moe_fuzz.py
+++ b/tests/moe/test_unified_moe_fuzz.py
@@ -191,6 +191,7 @@ from flashinfer.fused_moe.api import (
     ExecutionConfig,
     ExpertConfig,
     MoEConfig,
+    MoEFinalizeConfig,
     QuantConfig,
     QuantVariant,
     RoutingConfig,
@@ -1038,6 +1039,7 @@ class Cfg:
     n_group: int = 0  # DeepSeekV3 group count (0 -> None)
     topk_group: int = 0  # DeepSeekV3 groups kept (0 -> None)
     routed_scaling: float = 0.0  # DeepSeekV3 weight scale (0.0 -> None)
+    do_finalize: bool = True
 
     @property
     def n_weight_rows(self):  # physical expert-major rows: routed + shared
@@ -1075,8 +1077,9 @@ class Cfg:
             if self.num_fused_shared_experts
             else ""
         )
+        finalize = "" if self.do_finalize else "unfinalized_"
         return (
-            f"{self.variant}_{sh}{mode}{self.routing_method.name}_{ld}{uwd}{self.route}_"
+            f"{self.variant}_{sh}{mode}{finalize}{self.routing_method.name}_{ld}{uwd}{self.route}_"
             f"e{self.num_experts}_{ep}{grp}k{self.top_k}_"
             f"t{self.num_tokens}_h{self.hidden}_i{self.intermediate}_s{self.seed}"
         )
@@ -1531,6 +1534,34 @@ _CURATED = [
             ("nvfp4", 1, 900_045),
             ("mxfp4", 2, 900_046),
             ("w4a16", 1, 900_044),
+        )
+    ],
+    # Issue #3926: every unified TRTLLM operator that exposes unfinalized
+    # intermediates must return BF16 expert weights for either logits dtype.
+    *[
+        Cfg(
+            32,
+            512,
+            512,
+            16,
+            4,
+            variant,
+            "uniform",
+            seed,
+            routing_method=RoutingMethodType.Default,
+            routing_input_mode="fromlogits",
+            logits_dtype=logits_dtype,
+            do_finalize=False,
+        )
+        for variant, seed_base in (
+            ("bf16", 900_050),
+            ("fp8pertensor", 900_052),
+            ("deepseekfp8", 900_054),
+            ("mxint4", 900_056),
+        )
+        for logits_dtype, seed in (
+            ("bf16", seed_base),
+            ("fp32", seed_base + 1),
         )
     ],
 ]
@@ -1998,6 +2029,7 @@ def test_unified_moe_fuzz(cfg):
                 else max(cfg.num_tokens, 8192)
             )
         ),
+        finalize=MoEFinalizeConfig(do_finalize=cfg.do_finalize),
     )
 
     try:
@@ -2006,6 +2038,24 @@ def test_unified_moe_fuzz(cfg):
         if _is_unsupported(e):
             pytest.skip(f"MoELayer rejected {cfg.label}: {e}")
         raise
+
+    if not cfg.do_finalize:
+        result = layer(act_pack, weight_pack)
+        assert isinstance(result, list) and len(result) == 3, (
+            "do_finalize=False must return "
+            "[gemm2_output, expert_weights, expanded_idx_to_permuted_idx], got "
+            f"{type(result).__name__} of length "
+            f"{len(result) if isinstance(result, list) else 'n/a'}"
+        )
+        gemm2_output, expert_weights, expanded_idx_to_permuted_idx = result
+        assert gemm2_output.shape[-1] == cfg.hidden
+        assert expert_weights.dtype == torch.bfloat16, (
+            "do_finalize=False expert_weights must be bfloat16, got "
+            f"{expert_weights.dtype} for routing_logits dtype {cfg.logits_dtype}"
+        )
+        assert tuple(expert_weights.shape) == (cfg.num_tokens, cfg.top_k)
+        assert expanded_idx_to_permuted_idx.numel() == cfg.num_tokens * cfg.top_k
+        return
 
     out_shape = (cfg.num_tokens, cfg.hidden)
 

--- a/tests/moe/test_unified_moe_fuzz.py
+++ b/tests/moe/test_unified_moe_fuzz.py
@@ -1558,6 +1558,8 @@ _CURATED = [
             ("fp8pertensor", 900_052),
             ("deepseekfp8", 900_054),
             ("mxint4", 900_056),
+            ("nvfp4", 900_058),
+            ("mxfp8", 900_060),
         )
         for logits_dtype, seed in (
             ("bf16", seed_base),
@@ -2055,6 +2057,35 @@ def test_unified_moe_fuzz(cfg):
         )
         assert tuple(expert_weights.shape) == (cfg.num_tokens, cfg.top_k)
         assert expanded_idx_to_permuted_idx.numel() == cfg.num_tokens * cfg.top_k
+        torch.testing.assert_close(
+            expert_weights.float(),
+            final_scales.to(torch.bfloat16).float(),
+            rtol=2e-2,
+            atol=2e-3,
+        )
+
+        permutation = expanded_idx_to_permuted_idx.to(torch.long)
+        assert (permutation >= 0).all()
+        assert permutation.unique().numel() == permutation.numel()
+        assert permutation.max().item() < gemm2_output.shape[0]
+
+        recombined = (
+            gemm2_output[permutation]
+            .view(cfg.num_tokens, cfg.top_k, cfg.hidden)
+            .float()
+            .mul(expert_weights.float().unsqueeze(-1))
+            .sum(dim=1)
+        )
+        abs_diff = (recombined - ref).abs()
+        over_tol = abs_diff > (atol + rtol * ref.abs())
+        if over_tol.any():
+            _fail(
+                cfg,
+                "unfinalized host recombination",
+                f"{int(over_tol.sum())}/{recombined.numel()} elems exceed tol",
+                recombined,
+                ref,
+            )
         return
 
     out_shape = (cfg.num_tokens, cfg.hidden)

--- a/tests/moe/test_unified_moe_mxint4.py
+++ b/tests/moe/test_unified_moe_mxint4.py
@@ -389,26 +389,27 @@ def test_mxint4_explicit_autotune_matches_reference():
 
 
 @mxint4_required
-def test_mxint4_from_logits_rejects_fp32_until_validated():
-    act, weights, config, _, _ = _make_case(
+def test_mxint4_from_logits_supports_fp32():
+    act, weights, config, reference, _ = _make_case(
         routing_input_mode=RoutingInputMode.FromLogits
     )
     act.routing_logits = act.routing_logits.float()
     runner = _build_mxint4_runner(config)
-    with pytest.raises(TypeError, match="requires bfloat16 routing_logits"):
-        runner.pack_inputs(act, weights)
+    output = runner.forward(runner.pack_inputs(act, weights))
+    _assert_mxint4_close(output, reference)
 
 
 @mxint4_required
-def test_mxint4_from_logits_rejects_fp32_bias():
-    act, weights, config, _, _ = _make_case(
+def test_mxint4_from_logits_supports_fp32_bias():
+    act, weights, config, reference, _ = _make_case(
         routing_input_mode=RoutingInputMode.FromLogits,
         routing_method=RoutingMethodType.DeepSeekV3,
     )
+    act.routing_logits = act.routing_logits.float()
     act.routing_bias = act.routing_bias.float()
     runner = _build_mxint4_runner(config)
-    with pytest.raises(TypeError, match="routing_bias must be bfloat16"):
-        runner.pack_inputs(act, weights)
+    output = runner.forward(runner.pack_inputs(act, weights))
+    _assert_mxint4_close(output, reference)
 
 
 @mxint4_required

--- a/tests/moe/test_unified_moe_mxint4.py
+++ b/tests/moe/test_unified_moe_mxint4.py
@@ -23,6 +23,7 @@ from flashinfer.fused_moe import (
     TrtllmMxInt4RoutedRunner,
 )
 from flashinfer.fused_moe.core import (
+    MoeRunnerInputs,
     _maybe_get_cached_w3_w1_permute_indices,
     get_w2_permute_indices_with_cache,
 )
@@ -395,7 +396,11 @@ def test_mxint4_from_logits_supports_fp32():
     )
     act.routing_logits = act.routing_logits.float()
     runner = _build_mxint4_runner(config)
-    output = runner.forward(runner.pack_inputs(act, weights))
+    inputs = runner.pack_inputs(act, weights)
+    packed = MoeRunnerInputs.from_list(inputs)
+    assert packed.topk_ids.numel() == 0
+    assert packed.expert_weights.numel() == 0
+    output = runner.forward(inputs)
     _assert_mxint4_close(output, reference)
 
 


### PR DESCRIPTION
## 📌 Description

Aligns Unified MoE `do_finalize=False` behavior with the TRTLLM Flat API.
- Returns `[gemm2_output, expert_weights, expanded_idx_to_permuted_idx]`
- Enables unfinalized output for TRTLLM BF16, FP8 block, FP8 per-tensor, FP4, MxInt4, and MXFP8 runners
- Returns BF16 expert weights for `FromLogits` and `PackedPrecomputed` routing
- Preserves caller-provided BF16/FP32 weights for `UnpackedPrecomputed` routing
- Supports BF16 and FP32 routing logits, including MxInt4 logits and bias
- Correctly returns packed FP4 routing weights without accessing an undefined launcher tensor
- Models finalized and unfinalized return contracts in fake implementations
- Adds numerical host-side recombination and permutation validation

## 🔍 Related Issues

Closes #3926

## 🚀 Pull Request Checklist

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used my preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

## 🧪 Tests
Tested in `flashinfer/flashinfer-ci-cu130:latest` on SM100:
- 18/18 targeted unfinalized fuzz configurations passed
- Unified MoE contract and runner-support tests passed
- MxInt4 FP32 logits and bias tests passed
- Packed-precomputed tests passed across all targeted TRTLLM variants

## Reviewer Notes
Please focus on:
- Unified and Flat API unfinalized return-contract parity
- Ownership and unpacking of routing-weight buffers
- Packed FP4 expert-weight handling
- FakeTensor output contracts
- MxInt4 FP32 routing logits and bias support


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added non-finalized Mixture-of-Experts execution across multiple routing and quantization modes.
  - Improved handling of intermediate outputs, expert weights, LoRA outputs, and dynamic output sizes.
  - Expanded support for FP32 routing logits and DeepSeekV3 routing inputs.
  - Improved backend capability reporting when configurations are unsupported.

- **Documentation**
  - Clarified finalization behavior, intermediate output formats, routing-weight types, and backend requirements.

- **Tests**
  - Added coverage for non-finalized outputs, routing configurations, output integrity, and reference accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->