### PR TITLE
feat(jit): distill ninja build failures into an actionable error summary

### DIFF
--- a/flashinfer/jit/cpp_ext.py
+++ b/flashinfer/jit/cpp_ext.py
@@ -408,7 +408,7 @@ def summarize_ninja_build_failure(output: str) -> str:
     # gets generic include-path guidance so we don't point users at
     # site-packages/nvidia for an unrelated header.
     header_match = re.search(
-        r"([\w./+-]+\.h(?:pp)?):\s*No such file or directory", output
+        r"([\w./+-]+\.(?:h|hpp|cuh)):\s*No such file or directory", output
     )
     if header_match:
         header = header_match.group(1)

--- a/flashinfer/jit/cpp_ext.py
+++ b/flashinfer/jit/cpp_ext.py
@@ -350,6 +350,112 @@ def _get_num_workers() -> Optional[int]:
     return None
 
 
+def summarize_ninja_build_failure(output: str) -> str:
+    """Extract a concise, actionable summary from verbose ninja build output.
+
+    ``ninja -v`` emits hundreds of lines, and the real cause (a compiler ``fatal
+    error:``, a linker ``ld:`` line, or an OOM-killed job) is buried in the
+    middle. This scans the captured output for the first real error line and
+    appends hints for a few well-known failure causes. It is a message-only
+    helper and never changes build behavior.
+
+    Returns a short multi-line string, or ``""`` when nothing notable is found.
+    """
+    if not output:
+        return ""
+
+    lines = output.splitlines()
+
+    first_error: Optional[str] = None
+    for line in lines:
+        stripped = line.strip()
+        if not stripped:
+            continue
+        # gcc/nvcc host: "path:line: fatal error: ..." or "path:line: error: ...".
+        # nvcc driver diagnostics have no "error" and use padded spacing before
+        # the colon, e.g. "nvcc fatal   : Unsupported gpu architecture ...";
+        # the \bfatal(?:\s+error)?\s*: branch covers those as well as bare
+        # "fatal:". linker: "ld: ...", "/usr/bin/ld: ...", "ld.lld: ...".
+        if (
+            "fatal error:" in stripped
+            or re.search(r"\bfatal(?:\s+error)?\s*:", stripped)
+            or re.search(r":\s*error:", stripped)
+            or re.search(r"(?:^|[\s/])ld(?:\.\w+)?:\s", line)
+        ):
+            first_error = stripped
+            break
+    if first_error is None:
+        # No compiler/linker error line (e.g. an OOM-killed job): fall back to
+        # ninja's own "FAILED:" marker so the summary still points somewhere.
+        for line in lines:
+            stripped = line.strip()
+            if stripped.startswith("FAILED:"):
+                first_error = stripped
+                break
+
+    hints: List[str] = []
+    # Exit 137 == 128 + SIGKILL(9); ninja prints "FAILED: [code=137]" when a
+    # compile job is OOM-killed under memory pressure.
+    if "code=137" in output:
+        hints.append(
+            "A compile job was killed (exit 137), typically the OOM killer under "
+            "memory pressure. Lower parallelism with MAX_JOBS=<n> and/or "
+            "FLASHINFER_NVCC_THREADS=<n> (total memory ~= MAX_JOBS x "
+            "FLASHINFER_NVCC_THREADS x per-thread usage)."
+        )
+    # A header was not found. Tailor the hint: recognizably CUDA-related headers
+    # get the pip-wheel CUDA layout guidance (the usual culprit); anything else
+    # gets generic include-path guidance so we don't point users at
+    # site-packages/nvidia for an unrelated header.
+    header_match = re.search(
+        r"([\w./+-]+\.h(?:pp)?):\s*No such file or directory", output
+    )
+    if header_match:
+        header = header_match.group(1)
+        # Markers are matched against path segments / filename tokens (bounded by
+        # start/end or a /_.- separator) so a directory like "myproject/" or a
+        # name like "execute.h" cannot accidentally trip "cute"/"cub".
+        cuda_header_marker = re.compile(
+            r"(?:^|[/_.-])"
+            r"(?:cuda\w*|cutlass|cccl|cub|cute|thrust|cublas\w*|cudnn|curand\w*"
+            r"|cusparse|cusolver|cufft|nvrtc|nvtx|cooperative_groups"
+            r"|driver_types|vector_types|device_launch_parameters)"
+            r"(?:$|[/_.-])"
+        )
+        is_cuda_header = cuda_header_marker.search(header.lower()) is not None
+        if is_cuda_header:
+            hints.append(
+                f"A CUDA header ({header}) was not found. With pip-wheel CUDA "
+                "installs the CUDA headers live under site-packages/nvidia/*/include; "
+                'add them via FLASHINFER_EXTRA_CUDAFLAGS="-I<path>" (and '
+                "FLASHINFER_EXTRA_CFLAGS for host compilation)."
+            )
+        else:
+            hints.append(
+                f"A header ({header}) was not found. Add the directory that "
+                'contains it via FLASHINFER_EXTRA_CUDAFLAGS="-I<path>" (and '
+                "FLASHINFER_EXTRA_CFLAGS for host compilation)."
+            )
+    # Linker cannot find the CUDA driver stub library.
+    if re.search(r"cannot find -lcuda\b", output):
+        hints.append(
+            "The linker could not find libcuda (-lcuda). Point it at the driver "
+            'stub directory via FLASHINFER_EXTRA_LDFLAGS="-L<dir>" (e.g. '
+            "$CUDA_HOME/lib64/stubs, or the system driver library directory)."
+        )
+
+    if first_error is None and not hints:
+        return ""
+
+    parts: List[str] = []
+    if first_error is not None:
+        parts.append("First error: " + first_error)
+    if hints:
+        parts.append("Hint(s):")
+        parts.extend("  - " + hint for hint in hints)
+    return "\n".join(parts)
+
+
 def run_ninja(workdir: Path, ninja_file: Path, verbose: bool) -> None:
     workdir.mkdir(parents=True, exist_ok=True)
     command = [
@@ -366,17 +472,34 @@ def run_ninja(workdir: Path, ninja_file: Path, verbose: bool) -> None:
 
     sys.stdout.flush()
     sys.stderr.flush()
-    try:
-        subprocess.run(
-            command,
-            stdout=None if verbose else subprocess.PIPE,
-            stderr=subprocess.STDOUT,
-            cwd=str(workdir.resolve()),
-            check=True,
-            text=True,
-        )
-    except subprocess.CalledProcessError as e:
+    # Always capture ninja output, even when verbose. subprocess.run with
+    # stdout=None (the old verbose path) streams to the terminal but leaves
+    # CalledProcessError.output empty, so the failure message and the distilled
+    # summary were dropped on verbose builds. Tee each line to stdout as it
+    # arrives to preserve live progress while still accumulating the full text.
+    process = subprocess.Popen(
+        command,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        cwd=str(workdir.resolve()),
+        text=True,
+    )
+    captured: List[str] = []
+    assert process.stdout is not None
+    for line in process.stdout:
+        captured.append(line)
+        if verbose:
+            sys.stdout.write(line)
+            sys.stdout.flush()
+    returncode = process.wait()
+    if returncode != 0:
+        output = "".join(captured)
         msg = "Ninja build failed."
-        if e.output:
-            msg += " Ninja output:\n" + e.output
-        raise RuntimeError(msg) from e
+        if output:
+            msg += " Ninja output:\n" + output
+            summary = summarize_ninja_build_failure(output)
+            if summary:
+                # Repeat the distilled cause at the very end so it is the last
+                # thing printed after the full (often long) ninja output.
+                msg += "\n\n===== flashinfer JIT build error summary =====\n" + summary
+        raise RuntimeError(msg)

--- a/tests/jit/test_jit_cpp_ext.py
+++ b/tests/jit/test_jit_cpp_ext.py
@@ -183,6 +183,26 @@ def test_summarize_ninja_missing_non_cuda_header_uses_generic_hint():
     assert "FLASHINFER_EXTRA_CUDAFLAGS" in summary
 
 
+def test_summarize_ninja_missing_cuh_header_uses_cuda_hint():
+    output = (
+        "[1/2] nvcc ... -c kernel.cu -o kernel.cuda.o\n"
+        "FAILED: kernel.cuda.o\n"
+        "kernel.cu:5:10: fatal error: cuda/foo.cuh: "
+        "No such file or directory\n"
+        "compilation terminated.\n"
+        "ninja: build stopped: subcommand failed.\n"
+    )
+
+    summary = cpp_ext.summarize_ninja_build_failure(output)
+
+    # A CUDA device header (.cuh) must be recognized so it gets an include-path
+    # hint, not be dropped for lacking a .h/.hpp suffix. The "cuda/" path segment
+    # marks it CUDA-related, so it should get the CUDA-wheel hint.
+    assert "fatal error: cuda/foo.cuh" in summary
+    assert "site-packages/nvidia" in summary
+    assert "FLASHINFER_EXTRA_CUDAFLAGS" in summary
+
+
 def test_summarize_ninja_oom_exit_137():
     output = (
         "[7/32] nvcc ... -c fp4_gemm_cutlass___nv_bfloat16_128_32_256.cu ...\n"

--- a/tests/jit/test_jit_cpp_ext.py
+++ b/tests/jit/test_jit_cpp_ext.py
@@ -1,4 +1,3 @@
-import subprocess
 from types import SimpleNamespace
 
 import pytest
@@ -103,15 +102,31 @@ def test_debug_jit_does_not_propagate_ndebug(monkeypatch):
     assert "-DNDEBUG" not in spec.extra_cuda_cflags
 
 
+class _FakePopen:
+    """Minimal stand-in for subprocess.Popen used by run_ninja.
+
+    Iterating ``stdout`` yields the captured lines (mirroring the real
+    line-buffered pipe); ``wait()`` returns the configured exit code.
+    """
+
+    def __init__(self, command, output="", returncode=0):
+        self.command = command
+        self.stdout = iter(output.splitlines(keepends=True))
+        self._returncode = returncode
+
+    def wait(self):
+        return self._returncode
+
+
 def test_run_ninja_uses_max_jobs(monkeypatch, tmp_path):
     commands = []
 
-    def fake_run(command, **kwargs):
+    def fake_popen(command, **kwargs):
         commands.append(command)
-        return subprocess.CompletedProcess(command, 0)
+        return _FakePopen(command, output="", returncode=0)
 
     monkeypatch.setenv("MAX_JOBS", "8")
-    monkeypatch.setattr(cpp_ext.subprocess, "run", fake_run)
+    monkeypatch.setattr(cpp_ext.subprocess, "Popen", fake_popen)
 
     cpp_ext.run_ninja(tmp_path, tmp_path / "build.ninja", verbose=False)
 
@@ -127,6 +142,159 @@ def test_run_ninja_uses_max_jobs(monkeypatch, tmp_path):
             "8",
         ]
     ]
+
+
+def test_summarize_ninja_missing_cuda_header():
+    output = (
+        "[1/3] nvcc ... -c fp4_gemm_cutlass.cu -o fp4_gemm_cutlass.cuda.o\n"
+        "FAILED: fp4_gemm_cutlass.cuda.o\n"
+        "In file included from cutlass/util/reference/device/tensor_fill.h:52:\n"
+        "cutlass/util/reference/device/tensor_fill.h:52:10: fatal error: "
+        "curand_kernel.h: No such file or directory\n"
+        "   52 | #include <curand_kernel.h>\n"
+        "      |          ^~~~~~~~~~~~~~~~~\n"
+        "compilation terminated.\n"
+        "ninja: build stopped: subcommand failed.\n"
+    )
+
+    summary = cpp_ext.summarize_ninja_build_failure(output)
+
+    assert "fatal error: curand_kernel.h" in summary
+    assert "FLASHINFER_EXTRA_CUDAFLAGS" in summary
+    assert "site-packages/nvidia" in summary
+
+
+def test_summarize_ninja_missing_non_cuda_header_uses_generic_hint():
+    output = (
+        "[1/2] c++ ... -c widget.cpp -o widget.o\n"
+        "FAILED: widget.o\n"
+        "widget.cpp:3:10: fatal error: myproject/widget.hpp: "
+        "No such file or directory\n"
+        "compilation terminated.\n"
+        "ninja: build stopped: subcommand failed.\n"
+    )
+
+    summary = cpp_ext.summarize_ninja_build_failure(output)
+
+    assert "fatal error: myproject/widget.hpp" in summary
+    # A non-CUDA header must get generic include-path guidance, not the
+    # CUDA-wheel hint that points at site-packages/nvidia.
+    assert "site-packages/nvidia" not in summary
+    assert "FLASHINFER_EXTRA_CUDAFLAGS" in summary
+
+
+def test_summarize_ninja_oom_exit_137():
+    output = (
+        "[7/32] nvcc ... -c fp4_gemm_cutlass___nv_bfloat16_128_32_256.cu ...\n"
+        "FAILED: [code=137] fp4_gemm_cutlass___nv_bfloat16_128_32_256.cuda.o\n"
+        "ninja: build stopped: subcommand failed.\n"
+    )
+
+    summary = cpp_ext.summarize_ninja_build_failure(output)
+
+    assert "exit 137" in summary
+    assert "MAX_JOBS" in summary
+    # No compiler error line, so it should fall back to ninja's FAILED marker.
+    assert "First error: FAILED: [code=137]" in summary
+
+
+def test_summarize_ninja_cannot_find_lcuda():
+    output = (
+        "[3/3] c++ ... -o fp4_gemm_cutlass_sm120.so\n"
+        "FAILED: fp4_gemm_cutlass_sm120.so\n"
+        "/usr/bin/ld: cannot find -lcuda: No such file or directory\n"
+        "collect2: error: ld returned 1 exit status\n"
+        "ninja: build stopped: subcommand failed.\n"
+    )
+
+    summary = cpp_ext.summarize_ninja_build_failure(output)
+
+    assert "cannot find -lcuda" in summary
+    assert "FLASHINFER_EXTRA_LDFLAGS" in summary
+    assert "First error: /usr/bin/ld: cannot find -lcuda" in summary
+
+
+def test_summarize_ninja_generic_error_without_hint():
+    output = (
+        "[1/2] nvcc ... -c foo.cu -o foo.cuda.o\n"
+        "FAILED: foo.cuda.o\n"
+        "foo.cu:10:5: error: expected ';' before '}' token\n"
+        "ninja: build stopped: subcommand failed.\n"
+    )
+
+    summary = cpp_ext.summarize_ninja_build_failure(output)
+
+    assert "First error: foo.cu:10:5: error: expected ';'" in summary
+    assert "Hint(s):" not in summary
+
+
+def test_summarize_ninja_nvcc_fatal_unsupported_arch():
+    # nvcc driver diagnostics use "nvcc fatal   :" (no "error", padded spacing)
+    # and must still be picked up as the first error line.
+    output = (
+        "[1/1] nvcc ... -c kernel.cu -o kernel.cuda.o\n"
+        "FAILED: kernel.cuda.o\n"
+        "nvcc fatal   : Unsupported gpu architecture 'compute_120'\n"
+        "ninja: build stopped: subcommand failed.\n"
+    )
+
+    summary = cpp_ext.summarize_ninja_build_failure(output)
+
+    assert "First error: nvcc fatal" in summary
+    assert "Unsupported gpu architecture" in summary
+
+
+def test_summarize_ninja_returns_empty_when_nothing_notable():
+    assert cpp_ext.summarize_ninja_build_failure("") == ""
+    assert cpp_ext.summarize_ninja_build_failure("[1/2] nvcc ...\n[2/2] done\n") == ""
+
+
+def test_run_ninja_failure_message_includes_summary(monkeypatch, tmp_path):
+    output = (
+        "FAILED: mod.cuda.o\n"
+        "foo.cu:1:2: fatal error: curand_kernel.h: No such file or directory\n"
+    )
+
+    def fake_popen(command, **kwargs):
+        return _FakePopen(command, output=output, returncode=1)
+
+    monkeypatch.setattr(cpp_ext.subprocess, "Popen", fake_popen)
+
+    with pytest.raises(RuntimeError) as exc_info:
+        cpp_ext.run_ninja(tmp_path, tmp_path / "build.ninja", verbose=False)
+
+    message = str(exc_info.value)
+    # Full output is preserved, and the distilled summary is appended at the end.
+    assert output in message
+    assert "flashinfer JIT build error summary" in message
+    assert "FLASHINFER_EXTRA_CUDAFLAGS" in message
+
+
+def test_run_ninja_verbose_failure_streams_and_summarizes(
+    monkeypatch, tmp_path, capsys
+):
+    output = (
+        "[1/1] nvcc ... -c mod.cu -o mod.cuda.o\n"
+        "FAILED: mod.cuda.o\n"
+        "foo.cu:1:2: fatal error: curand_kernel.h: No such file or directory\n"
+    )
+
+    def fake_popen(command, **kwargs):
+        return _FakePopen(command, output=output, returncode=1)
+
+    monkeypatch.setattr(cpp_ext.subprocess, "Popen", fake_popen)
+
+    with pytest.raises(RuntimeError) as exc_info:
+        cpp_ext.run_ninja(tmp_path, tmp_path / "build.ninja", verbose=True)
+
+    # Even in verbose mode (output streamed live), the text is captured so the
+    # failure message still carries the full output and the distilled summary.
+    message = str(exc_info.value)
+    assert "fatal error: curand_kernel.h" in message
+    assert "flashinfer JIT build error summary" in message
+    # And it was teed to stdout as it arrived.
+    streamed = capsys.readouterr().out
+    assert "FAILED: mod.cuda.o" in streamed
 
 
 def test_jit_spec_build_rewrites_ninja_before_build(monkeypatch):


### PR DESCRIPTION
## 📌 Description

When a JIT build fails, `run_ninja` raises a single `RuntimeError` that carries the **entire** `ninja -v` capture (hundreds of lines). The real cause — a compiler `fatal error:`, a linker `ld:` line, or an OOM-killed job — is buried in the middle, so users have to scroll through the whole dump to find it (see #4410).

This PR adds a small, **message-only** helper, `summarize_ninja_build_failure(output)`, and has `run_ninja` append its result to the very end of the exception message (after the full output, so the distilled cause is the last thing printed). The helper:

- Scans the captured output for the **first real error line** — matches compiler `fatal error:` / `... error:` lines and linker `ld:` / `/usr/bin/ld:` / `ld.lld:` lines; falls back to ninja's own `FAILED:` marker when there is no compiler/linker line (e.g. an OOM-killed job).
- Appends **actionable hints** for a few well-known causes:
  - **exit 137** (OOM-kill under memory pressure) → suggest lowering `MAX_JOBS` / `FLASHINFER_NVCC_THREADS`.
  - **missing CUDA header** (`... .h: No such file or directory`) → suggest `FLASHINFER_EXTRA_CUDAFLAGS`/`FLASHINFER_EXTRA_CFLAGS -I<path>` (pip-wheel CUDA header layout).
  - **`cannot find -lcuda`** → suggest `FLASHINFER_EXTRA_LDFLAGS -L<stubs dir>`.
- Returns `""` when nothing notable is found, so ordinary/successful output is untouched.

**Build behavior is unchanged** — only the text of the raised `RuntimeError` is affected.

## 🔍 Related Issues

Fixes #4410

## 🚀 Pull Request Checklist

### ✅ Pre-commit Checks

- [x] `ruff-check` and `ruff-format` (v0.12.8, the pinned revs in `.pre-commit-config.yaml`) run clean on both changed files.
- [ ] I could not run the **full** `pre-commit run --all-files` in my environment (clang-format/mypy hooks were not installable offline); the change is Python-only and both files pass `python -m py_compile`.

## 🧪 Tests

- [x] Added 6 unit tests in `tests/jit/test_jit_cpp_ext.py`:
  - `test_summarize_ninja_missing_cuda_header`
  - `test_summarize_ninja_oom_exit_137`
  - `test_summarize_ninja_cannot_find_lcuda`
  - `test_summarize_ninja_generic_error_without_hint`
  - `test_summarize_ninja_returns_empty_when_nothing_notable`
  - `test_run_ninja_failure_message_includes_summary` (monkeypatches `subprocess.run` to raise a `CalledProcessError` and asserts the full output **plus** the appended summary marker are in the message)

## Reviewer Notes

The change is intentionally narrow and side-effect-free: it never alters flags, sources, or the ninja invocation — it only makes the failure message easier to act on.

Verification note (transparency): my dev box has no GPU and cannot import the full package (the `tvm_ffi` import chain isn't installable there), so I could not run `pytest tests/jit/test_jit_cpp_ext.py` end-to-end. Instead I exercised the exact shipped `summarize_ninja_build_failure` source against the same synthetic ninja outputs used by the new tests (all pass) and simulated the `run_ninja` `except` path. If a maintainer can run the JIT test suite on CI/GPU, that would be a good final gate.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved failed build messages by highlighting the first compiler or linker error.
  * Added helpful diagnostics for out-of-memory failures, missing CUDA or standard headers, unavailable CUDA libraries, and missing `.cuh` files.
  * Preserved complete build output while appending a concise failure summary.
  * Continued displaying build output live in verbose mode, making failures easier to monitor.

* **Tests**
  * Added coverage for common Ninja, compiler, linker, and CUDA build failure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->