### PR TITLE
Add back TRTLLM Gen MoE split-K

### DIFF
--- a/csrc/trtllm_batched_gemm_runner.cu
+++ b/csrc/trtllm_batched_gemm_runner.cu
@@ -197,9 +197,6 @@ TrtllmGenBatchedGemmRunner::TrtllmGenBatchedGemmRunner(
       // Sm100f cubins miss the f2fp patch, so sm103 must fall back to Sm103a for it.
       if (sm_version == 103 && options.mPatchF2fp && config.mSm != tg::CudaArch::Sm103a) continue;
       if (mOptions.transposeMmaOutput && options.mEpilogueTileM == mOptions.epilogueTileM) {
-        // Skip cubins with clusterZ > 1 due to correctness issues described in
-        // https://github.com/flashinfer-ai/flashinfer/issues/3197
-        if (options.mClusterDimZ > 1) continue;
         mPassingConfigIndices.push_back(i);
       }
     }

--- a/flashinfer/artifacts.py
+++ b/flashinfer/artifacts.py
@@ -137,7 +137,7 @@ class ArtifactPath:
 
     TRTLLM_GEN_FMHA: str = "ce0795149bb2a183db22de04a3fec3aca65fff04/fmha/trtllm-gen/"
     TRTLLM_GEN_BMM: str = (
-        "5988e15c0e6d006c6a64c0f6c6748b4d3150c1af/batched_gemm-3d40263-3e19f0a/"
+        "14e0be19166763fb6a00cc6cb0e9bcf9b0231159/batched_gemm-fe08bc1-9f05022/"
     )
     TRTLLM_GEN_GEMM: str = (
         "10f64528a1172dae8e29601a3b99ab9dc78d37be/gemm-91e0ba0-2710384/"
@@ -173,7 +173,7 @@ class CheckSumHash:
         "a8d5d3e86f5ee7dfecd36a8d6cf9a933ca0cb8225a2f954f0212c5db2d250f40"
     )
     TRTLLM_GEN_BMM: str = (
-        "b19ed6c8b1d3fc13ced823bd65ee764d35a19080aea97e742c82ee73ce4c19b0"
+        "4bbb1fe8373c0f8f340b539a90e9ff69c223bdacdc9d5410f59c2706d40c415f"
     )
     DEEPGEMM: str = "1a2a166839042dbd2a57f48051c82cd1ad032815927c753db269a4ed10d0ffbf"
     DEEPGEMM_RUBIN: str = (


### PR DESCRIPTION
## 📌 Description

This PR re-enables TRTLLM Gen MoE split-K tactics which was closed in https://github.com/flashinfer-ai/flashinfer/pull/3227 because of accuracy issue. The error is now fixed

## 🔍 Related Issues

- #3197
- #3227

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

Validated on NVIDIA B300 (SM103):

```text
NvFP4xNvFP4: 0 / 1104 tactics failed
MxFP4xMxFP8: 0 / 2880 tactics failed
MxFp8:        0 / 2880 tactics failed
3 passed, 3 warnings in 970.21s
```

Each tactic was forced for 10 identical-input runs and checked for NaN/Inf, large errors, and nondeterministic output. The sweep loaded split-K configurations with `clusterDimZ` 2, 3, and 4.

Touched-file pre-commit also passed:

```bash
pre-commit run --files csrc/trtllm_batched_gemm_runner.cu flashinfer/artifacts.py
```

## Reviewer Notes

The updated BMM artifact metadata contains 330 split-K-2, 34 split-K-3, and 34 split-K-4 configurations.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved batched matrix multiplication compatibility by enabling additional optimized configurations.
  * Preserved existing handling for data types, scaling, fused activations, hardware compatibility, and fallback behavior.

* **Performance**
  * Updated the packaged matrix multiplication artifact to support the latest improvements and ensure reliable artifact verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->