### PR TITLE
Support per-token NVFP4 ReLU2 MoE

### DIFF
--- a/flashinfer/artifacts.py
+++ b/flashinfer/artifacts.py
@@ -175,11 +175,7 @@ class CheckSumHash:
     TRTLLM_GEN_BMM: str = (
         "4bbb1fe8373c0f8f340b539a90e9ff69c223bdacdc9d5410f59c2706d40c415f"
     )
-    DEEPGEMM: str = "1a2a166839042dbd2a57f48051c82cd1ad032815927c753db269a4ed10d0ffbf"
     DEEPGEMM_RUBIN: str = (
-        "09e961d4e3852a6cf81b3482d0604c09dcb1f69c1b7936f535c9ee2f53335184"
-    )
-    TRTLLM_GEN_GEMM: str = (
         "f97f90f9ce1dab73eb3d7c90fca4bbd52687642dd87a79dd10b77d7802b25c33"
     )
     TRTLLM_GEN_BMM_RUBIN: str = (

--- a/flashinfer/artifacts.py
+++ b/flashinfer/artifacts.py
@@ -137,7 +137,7 @@ class ArtifactPath:
 
     TRTLLM_GEN_FMHA: str = "2d6a5a029eefcc388ec0ceb87efb55d8bcce5c3c/fmha/trtllm-gen/"
     TRTLLM_GEN_BMM: str = (
-        "14e0be19166763fb6a00cc6cb0e9bcf9b0231159/batched_gemm-fe08bc1-9f05022/"
+        "8ec29a98612c3670f9f28825d1ed19f09496073b/batched_gemm-fa419f4-31ee4e5/"
     )
     TRTLLM_GEN_GEMM: str = (
         "10f64528a1172dae8e29601a3b99ab9dc78d37be/gemm-91e0ba0-2710384/"
@@ -173,7 +173,7 @@ class CheckSumHash:
         "d79b5c51fc8597fac57dae0da4afa114fb2014575e4ec3df099ad856d97cabc3"
     )
     TRTLLM_GEN_BMM: str = (
-        "4bbb1fe8373c0f8f340b539a90e9ff69c223bdacdc9d5410f59c2706d40c415f"
+        "011635d3c36756addcdc148eea90c984f2d7611ba375626aaaf466d355c80e50"
     )
     DEEPGEMM_RUBIN: str = (
         "f97f90f9ce1dab73eb3d7c90fca4bbd52687642dd87a79dd10b77d7802b25c33"

--- a/flashinfer/artifacts.py
+++ b/flashinfer/artifacts.py
@@ -175,7 +175,11 @@ class CheckSumHash:
     TRTLLM_GEN_BMM: str = (
         "011635d3c36756addcdc148eea90c984f2d7611ba375626aaaf466d355c80e50"
     )
+    DEEPGEMM: str = "1a2a166839042dbd2a57f48051c82cd1ad032815927c753db269a4ed10d0ffbf"
     DEEPGEMM_RUBIN: str = (
+        "09e961d4e3852a6cf81b3482d0604c09dcb1f69c1b7936f535c9ee2f53335184"
+    )
+    TRTLLM_GEN_GEMM: str = (
         "f97f90f9ce1dab73eb3d7c90fca4bbd52687642dd87a79dd10b77d7802b25c33"
     )
     TRTLLM_GEN_BMM_RUBIN: str = (

--- a/flashinfer/fused_moe/core.py
+++ b/flashinfer/fused_moe/core.py
@@ -6167,7 +6167,8 @@ def trtllm_fp4_block_scale_moe(
         ``[num_experts, M, hidden_size // (32 if mxfp4 else 16)]`` FC1 weight
         block scales, dtype float8, with the same ``M`` as ``gemm1_weights``.
     gemm1_bias : Optional[torch.Tensor]
-        ``[num_experts, 2 * intermediate_size]`` FC1 bias, ``float32``.
+        ``[num_experts, M]`` FC1 bias, ``float32``, with the same ``M`` as
+        ``gemm1_weights``.
     gemm1_alpha : Optional[torch.Tensor]
         ``[num_experts]`` swiglu alpha, ``float32``.
         For SiTU this is ``[local_num_experts]``, finite and positive;

--- a/flashinfer/fused_moe/runners.py
+++ b/flashinfer/fused_moe/runners.py
@@ -2256,6 +2256,7 @@ class TrtllmFp4RoutedRunner(_TrtllmRunnerBase):
         self._dtype_act = dtype_act
         self._dtype_weights = dtype_weights
         self._fp8_quantization_type = Fp8QuantizationType.NoneFp8
+        self._per_token: bool | None = self.config.quant.per_token_scale
 
         # enable_pdl=None means "auto" — resolve once here exactly like the
         # high-level wrapper does before building its MoERunner, because the raw
@@ -2288,7 +2289,7 @@ class TrtllmFp4RoutedRunner(_TrtllmRunnerBase):
             activation_type=self._activation_type,
             use_shuffled_weight=True,
             weight_layout=int(WeightLayout.MajorK),
-            use_per_token_scaling=False,
+            use_per_token_scaling=self._per_token,
             num_experts=self.config.routing.num_experts,
             num_fused_shared_experts=self._num_fused_shared_experts,
         )
@@ -2503,6 +2504,12 @@ class TrtllmFp4RoutedRunner(_TrtllmRunnerBase):
                 "Dedicated fused shared experts require FromLogits routing; "
                 "pre-routed callers must append shared ids and weights themselves."
             )
+
+        if self._per_token and not act.per_token_scale:
+            raise RuntimeError(
+                "Per-token NVFP4 scale is configured but no activation scale is given."
+            )
+
         if routing_input_mode == RoutingInputMode.FromLogits:
             # In-kernel routing: topk_ids/expert_weights are OUTPUT buffers the kernel fills.
             # Unlike the FP8 launcher, FP4 receives routing_input_mode explicitly;
@@ -2591,7 +2598,7 @@ class TrtllmFp4RoutedRunner(_TrtllmRunnerBase):
             hidden_states=act.hidden_states_q,
             hidden_states_scale=hidden_states_scale,
             gemm1_lora_delta=None,
-            per_token_scale=None,
+            per_token_scale=act.per_token_scale,
         )
 
         # Static (num_tokens-invariant) launch arguments for the fp4 branch of
@@ -2612,7 +2619,7 @@ class TrtllmFp4RoutedRunner(_TrtllmRunnerBase):
             output1_scale_scalar=v.get("output1_scale_scalar"),
             output1_scale_gate_scalar=v.get("output1_scale_gate_scalar"),
             output2_scale_scalar=v.get("output2_scale_scalar"),
-            per_token_scale=None,
+            per_token_scale=act.per_token_scale,
             num_experts=routing.num_experts,
             num_fused_shared_experts=self._num_fused_shared_experts,
             n_group=routing.n_group,

--- a/flashinfer/fused_moe/runners.py
+++ b/flashinfer/fused_moe/runners.py
@@ -2188,6 +2188,14 @@ class TrtllmFp4RoutedRunner(_TrtllmRunnerBase):
             )
         variant = self.config.quant.variant
         if variant in self.supported_quant_variants:
+            if (
+                self.config.quant.per_token_scale
+                and variant is not QuantVariant.NVFP4
+            ):
+                raise NotImplementedError(
+                    f"{type(self).__name__} does not support per-token scale for {variant.name}."
+                )
+
             from ..utils import get_compute_capability
 
             # Direct-runner guard: #4280 relanded the SM107 cubins removed by

--- a/flashinfer/fused_moe/runners.py
+++ b/flashinfer/fused_moe/runners.py
@@ -2188,10 +2188,7 @@ class TrtllmFp4RoutedRunner(_TrtllmRunnerBase):
             )
         variant = self.config.quant.variant
         if variant in self.supported_quant_variants:
-            if (
-                self.config.quant.per_token_scale
-                and variant is not QuantVariant.NVFP4
-            ):
+            if self.config.quant.per_token_scale and variant is not QuantVariant.NVFP4:
                 raise NotImplementedError(
                     f"{type(self).__name__} does not support per-token scale for {variant.name}."
                 )
@@ -2256,7 +2253,7 @@ class TrtllmFp4RoutedRunner(_TrtllmRunnerBase):
         self._dtype_act = dtype_act
         self._dtype_weights = dtype_weights
         self._fp8_quantization_type = Fp8QuantizationType.NoneFp8
-        self._per_token: bool | None = self.config.quant.per_token_scale
+        self._per_token = bool(self.config.quant.per_token_scale)
 
         # enable_pdl=None means "auto" — resolve once here exactly like the
         # high-level wrapper does before building its MoERunner, because the raw
@@ -2505,7 +2502,7 @@ class TrtllmFp4RoutedRunner(_TrtllmRunnerBase):
                 "pre-routed callers must append shared ids and weights themselves."
             )
 
-        if self._per_token and not act.per_token_scale:
+        if self._per_token and act.per_token_scale is None:
             raise RuntimeError(
                 "Per-token NVFP4 scale is configured but no activation scale is given."
             )

--- a/flashinfer/moe_ep/backends/split/kernel/fused_moe/weights.py
+++ b/flashinfer/moe_ep/backends/split/kernel/fused_moe/weights.py
@@ -84,7 +84,7 @@ def materialize_fused_moe_weights(
     routing = moe_config.routing
     num_local = experts.local_num_experts or routing.num_experts
     hidden = weights.w13.shape[-1]
-    intermediate = weights.w13.shape[-2] // 2
+    intermediate = experts.intermediate_size
 
     pack = FusedMoEWeightPack()
 
@@ -107,6 +107,7 @@ def materialize_fused_moe_weights(
                 num_local_experts=num_local,
                 hidden_size=hidden,
                 intermediate_size=intermediate,
+                activation=moe_config.activation,
                 device=weights.w13.device,
             )
             pack.prepare_for("trtllm_fp4_routed", view)

--- a/tests/moe/test_trtllm_gen_moe_autotune_tactics.py
+++ b/tests/moe/test_trtllm_gen_moe_autotune_tactics.py
@@ -321,6 +321,7 @@ def _enumerate_valid_tactics(
     num_experts: int,
     num_tokens: int,
     use_per_token_scaling: bool = False,
+    activation_type: ActivationType = ActivationType.Swiglu,
 ) -> list[list[int]]:
     """Enumerate every (tile_N, config) tactic the autotuner may select for
     the given problem shape."""
@@ -336,7 +337,7 @@ def _enumerate_valid_tactics(
             hidden_size,
             intermediate_size,
             num_experts,  # num_local_experts
-            ActivationType.Swiglu.value,
+            activation_type.value,
             True,  # use_shuffled_weight
             WeightLayout.MajorK.value,
             use_per_token_scaling,
@@ -346,7 +347,16 @@ def _enumerate_valid_tactics(
     )
 
 
-def test_nvfp4_per_token_all_tactics_are_correct(monkeypatch: pytest.MonkeyPatch):
+@pytest.mark.parametrize(
+    "activation_type",
+    [
+        pytest.param(ActivationType.Swiglu, id="Swiglu"),
+        pytest.param(ActivationType.Relu2, id="Relu2"),
+    ],
+)
+def test_nvfp4_per_token_all_tactics_are_correct(
+    monkeypatch: pytest.MonkeyPatch, activation_type: ActivationType
+):
     """Every advertised per-token NVFP4 tactic must be numerically correct."""
     if get_compute_capability(torch.device(device="cuda"))[0] not in [10]:
         pytest.skip("Only work on SM100 / SM103.")
@@ -362,6 +372,7 @@ def test_nvfp4_per_token_all_tactics_are_correct(monkeypatch: pytest.MonkeyPatch
         num_experts=128,
         num_tokens=4096,
         use_per_token_scaling=True,
+        activation_type=activation_type,
     )
     assert valid_tactics
 
@@ -391,10 +402,12 @@ def test_nvfp4_per_token_all_tactics_are_correct(monkeypatch: pytest.MonkeyPatch
                     top_k=8,
                     use_4over6=True,
                     weights_use_4over6=True,
+                    activation_type=activation_type,
                 )
         except Exception as err:
             raise AssertionError(
-                f"Per-token NVFP4 tactic {tactic} failed accuracy"
+                f"Per-token NVFP4 tactic {tactic} failed accuracy "
+                f"for {activation_type.name}"
             ) from err
         torch.cuda.empty_cache()
 

--- a/tests/moe/test_trtllm_gen_per_token_moe.py
+++ b/tests/moe/test_trtllm_gen_per_token_moe.py
@@ -66,6 +66,13 @@ cache_permute_indices: Dict[tuple, torch.Tensor] = {}
 @pytest.mark.parametrize("top_k", [4])
 @pytest.mark.parametrize("use_4over6", [False, True])
 @pytest.mark.parametrize("weights_use_4over6", [False, True])
+@pytest.mark.parametrize(
+    "activation_type",
+    [
+        pytest.param(ActivationType.Swiglu, id="Swiglu"),
+        pytest.param(ActivationType.Relu2, id="Relu2"),
+    ],
+)
 def test_routed_fused_moe(
     num_tokens: int,
     hidden_size: int,
@@ -74,12 +81,16 @@ def test_routed_fused_moe(
     top_k: int,
     use_4over6: bool,
     weights_use_4over6: bool,
+    activation_type: ActivationType,
 ):
     device = torch.device("cuda:0")
     compute_capability = get_compute_capability(torch.device(device="cuda"))
     if compute_capability[0] not in [10]:
         pytest.skip("These tests are only guaranteed to work on SM100 and SM103 GPUs.")
     enable_pdl = device_support_pdl(device)
+
+    is_gated = activation_type.is_gated
+    fc1_out_size = intermediate_size * (2 if is_gated else 1)
 
     # ======== Input Tensors ========
     hidden_states_bf16 = torch.randn(
@@ -91,7 +102,7 @@ def test_routed_fused_moe(
     w13_bf16 = (
         torch.randn(
             num_experts,
-            intermediate_size * 2,
+            fc1_out_size,
             hidden_size,
             device=device,
             dtype=torch.bfloat16,
@@ -158,7 +169,7 @@ def test_routed_fused_moe(
             sfLayout=SfLayout.layout_linear,
         )
     w13_scale = w13_scale.view(torch.float8_e4m3fn).reshape(
-        num_experts, intermediate_size * 2, -1
+        num_experts, fc1_out_size, -1
     )
     w2_scale = w2_scale.view(torch.float8_e4m3fn).reshape(num_experts, hidden_size, -1)
 
@@ -216,9 +227,12 @@ def test_routed_fused_moe(
     for e in range(num_experts):
         mask = flat_ids == e  # [num_tokens*top_k]
         e_hidden = flat_hidden[mask]  # [n_e, hidden_size]
-        up_gate_e = e_hidden @ w13_dequant[e].T  # [n_e, 2*intermediate_size]
-        up_e, gate_e = up_gate_e.chunk(2, dim=-1)
-        inter_e = F.silu(gate_e) * up_e  # [n_e, intermediate_size]
+        up_gate_e = e_hidden @ w13_dequant[e].T  # [n_e, fc1_out_size]
+        if is_gated:
+            up_e, gate_e = up_gate_e.chunk(2, dim=-1)
+            inter_e = F.silu(gate_e) * up_e  # [n_e, intermediate_size]
+        else:
+            inter_e = F.relu(up_gate_e) ** 2  # [n_e, intermediate_size]
         expert_out[mask] = inter_e @ w2_dequant[e].T  # [n_e, hidden_size]
     # Weighted sum back to [num_tokens, hidden_size]
     reference = (
@@ -239,6 +253,7 @@ def test_routed_fused_moe(
             cache_permute_indices,
             w13[i].view(torch.uint8),
             epilogue_tile_m,
+            is_gated_act_gemm=is_gated,
         )
         w13_shuffled.append(
             w13[i].view(torch.uint8)[permute_indices.to(device)].contiguous()
@@ -248,10 +263,11 @@ def test_routed_fused_moe(
             w13_scale[i].view(torch.uint8),
             epilogue_tile_m,
             num_elts_per_sf=16,
+            is_gated_act_gemm=is_gated,
         )
         w13_scale_shuffled.append(
             block_scale_interleave(
-                w13_scale.reshape(num_experts, intermediate_size * 2, -1)[i]
+                w13_scale.reshape(num_experts, fc1_out_size, -1)[i]
                 .view(torch.uint8)[permute_sf_indices.to(device)]
                 .contiguous()
             )
@@ -282,7 +298,16 @@ def test_routed_fused_moe(
     w2_shuffled = torch.stack(w2_shuffled)
     w2_scale_shuffled = torch.stack(w2_scale_shuffled).view(torch.float8_e4m3fn)
 
-    output1_scale_scalar = torch.stack([w13_global_scale_inv] * num_experts)
+    # For a non-linear elementwise activation (Relu2) the kernel applies the gate scalar
+    # *before* the activation and the c scalar *after*, so the dequantization factor must
+    # ride on the gate scalar only -- s * relu(x)^2 != relu(s * x)^2.  The c scalar then
+    # carries just the output quantization factor, which is 1 here because FC1 emits bf16
+    # under per-token scaling.  Gated activations take the dequant on both.
+    # Mirrors scale_c_fc1 / scale_gate_fc1 in tests/moe/trtllm_gen_fused_moe_utils.py.
+    output1_scale_scalar = torch.stack(
+        [w13_global_scale_inv if is_gated else torch.ones_like(w13_global_scale_inv)]
+        * num_experts
+    )
     output1_scale_gate_scalar = torch.stack([w13_global_scale_inv] * num_experts)
     output2_scale_scalar = torch.stack([w2_global_scale_inv] * num_experts)
 
@@ -322,7 +347,7 @@ def test_routed_fused_moe(
         RoutingMethodType.TopK.value,
         True,  # do_finalize
         enable_pdl,
-        ActivationType.Swiglu.value,  # act_type
+        activation_type.value,  # act_type
         per_token_scale_inv,
         None,
     )

--- a/tests/moe/test_unified_moe.py
+++ b/tests/moe/test_unified_moe.py
@@ -2644,10 +2644,17 @@ class TestTrtllmFp4UnpackedContract:
         )
         assert runner._static_kwargs["local_expert_offset"] == 32
 
+    @pytest.mark.parametrize(
+        "activation",
+        [
+            pytest.param(SwiGLU(), id="swiglu"),
+            pytest.param(ReLU2(), id="relu2"),
+        ],
+    )
     @pytest.mark.parametrize("weights_dtype", [torch.bfloat16, torch.float32])
-    def test_cuda_graph_replay_matches_eager(self, weights_dtype):
+    def test_cuda_graph_replay_matches_eager(self, weights_dtype, activation):
         device = torch.device("cuda", torch.cuda.current_device())
-        num_tokens, hidden_size, intermediate_size = 16, 256, 512
+        num_tokens, hidden_size, intermediate_size = 16, 1024, 512
         num_experts, top_k = 8, 2
         tensors = create_moe_tensors(
             num_tokens=num_tokens,
@@ -2656,14 +2663,21 @@ class TestTrtllmFp4UnpackedContract:
             num_experts=num_experts,
             num_local_experts=num_experts,
             top_k=top_k,
+            gated=activation.is_gated,
+            use_per_token_activation=True,
+            use_nontrivial_alphas=False,
         )
         config = MoEConfig(
             routing=RoutingConfig(num_experts=num_experts, top_k=top_k),
-            quant=QuantConfig(variant=QuantVariant.NVFP4),
+            quant=QuantConfig(
+                variant=QuantVariant.NVFP4,
+                per_token_scale=True,
+            ),
             experts=ExpertConfig(
                 intermediate_size=intermediate_size,
                 local_num_experts=num_experts,
             ),
+            activation=activation,
         )
         runner = _build_direct_runner(TrtllmFp4RoutedRunner, config, device)
         act_pack = MoEActivationPack(
@@ -2671,25 +2685,69 @@ class TestTrtllmFp4UnpackedContract:
             hidden_states_scale=tensors["x_sf"].squeeze(-1),
             topk_ids=tensors["token_selected_experts"],
             topk_weights=tensors["token_final_scales"].to(weights_dtype),
+            per_token_scale=tensors["x_per_token_scale"],
             routing_input_mode=RoutingInputMode.UnpackedPrecomputed,
         )
         weight_pack = MoEWeightPack()
+        prepared_weights = TrtllmFp4Config.prepare_weights(
+            tensors["w1_weight_bf16"],
+            tensors["w2_weight_bf16"],
+            num_local_experts=num_experts,
+            hidden_size=hidden_size,
+            intermediate_size=intermediate_size,
+            activation=activation,
+            device=device,
+        )
+        fc1_size = intermediate_size * (2 if activation.is_gated else 1)
+        assert prepared_weights["gemm1_weights"].shape == (
+            num_experts,
+            fc1_size,
+            hidden_size // 2,
+        )
+        assert prepared_weights["gemm1_weights_scale"].shape == (
+            num_experts,
+            fc1_size,
+            hidden_size // 16,
+        )
         weight_pack.prepare_for(
             runner.backend_key,
-            TrtllmFp4Config.prepare_weights(
-                tensors["w1_weight_bf16"],
-                tensors["w2_weight_bf16"],
-                num_local_experts=num_experts,
-                hidden_size=hidden_size,
-                intermediate_size=intermediate_size,
-                device=device,
-            ),
+            prepared_weights,
         )
         inputs = runner.pack_inputs(act_pack, weight_pack)
+        from flashinfer.fused_moe.core import MoeRunnerInputs
+
+        moe_inputs = MoeRunnerInputs.from_list(inputs)
+        assert moe_inputs.per_token_scale is act_pack.per_token_scale
+        assert runner._static_kwargs["per_token_scale"] is act_pack.per_token_scale
+        assert runner._inner.use_per_token_scaling is True
         for _ in range(3):
             runner.forward(inputs, tactic=-1)
         torch.cuda.synchronize()
         eager = runner.forward(inputs, tactic=-1).clone()
+
+        ones = torch.ones(num_experts, device=device, dtype=torch.float32)
+        reference = compute_reference_moe_fp4(
+            hidden_states=tensors["x_ref"],
+            gemm1_weights=tensors["w1_weight_bf16"],
+            gemm2_weights=tensors["w2_weight_bf16"],
+            gemm1_alpha=ones,
+            gemm2_alpha=ones,
+            token_selected_experts=act_pack.topk_ids,
+            token_final_scales=act_pack.topk_weights,
+            num_tokens=num_tokens,
+            num_experts=num_experts,
+            top_k=top_k,
+            hidden_size=hidden_size,
+            intermediate_size=intermediate_size,
+            fc2_input_scale=tensors["fc2_input_scale"],
+            use_per_token_activation=True,
+            activation_type=activation.type,
+        )
+        passed, pct, atol = check_accuracy(eager, reference)
+        assert passed, (
+            f"{activation.type.name}: only {pct * 100:.2f}% values within "
+            f"tolerance (atol={atol:.4f})"
+        )
 
         graph = torch.cuda.CUDAGraph()
         with torch.cuda.graph(graph):

--- a/tests/moe/test_unified_moe.py
+++ b/tests/moe/test_unified_moe.py
@@ -1198,7 +1198,7 @@ class TestMoERunnerSupport:
             (TrtllmFp8BlockRunner, QuantVariant.DeepSeekFp8),
         ),
     )
-    def test_non_swiglu_activation_not_supported(self, runner_type, variant, act):
+    def test_not_supported_activation(self, runner_type, variant, act):
         cfg = self._nvfp4_swiglu(
             quant=QuantConfig(variant=variant),
             activation=act,


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

This PR adds the per-token NVFP4 MoE kernel with ReLU2 as the activation (used by Nemotron 3).

## 🔍 Related Issues

Fixes #3584 

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added CUTLASS support for NVFP4, FP8, MXFP8/MXFP4, W4A8, and Humming MoE quantization formats.
  * Added support for Relu2 activation alongside SwiGLU in TensorRT-LLM FP4 routed MoE workflows.
  * Added per-tensor and block scaling options for supported FP8 workflows.
  * Added backend-specific weight preparation and validation for supported GPU architectures.

* **Bug Fixes**
  * Improved CUDA compatibility messages and corrected FP4/FP8 shape and scaling documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->