### PR TITLE
fix(moe): resolve _collapse_to_vmk on the dense class for b12x MoE

### DIFF
--- a/flashinfer/gemm/kernels/dense_blockscaled_gemm_sm120_b12x.py
+++ b/flashinfer/gemm/kernels/dense_blockscaled_gemm_sm120_b12x.py
@@ -600,7 +600,9 @@ class DenseGemmKernel:
         thr_vmk = (thr_vmnk[0], (thr_vmnk[1], thr_vmnk[3]))
         partitioned_sfa = thr_tensor[thr_vmk, (None, None)]
         partitioned_sfa = cute.group_modes(cute.flatten(partitioned_sfa), 0, 2)
-        partitioned_sfa = self._collapse_to_vmk(partitioned_sfa)
+        # Class-resolved: the b12x MoE kernels borrow this method with a foreign
+        # ``self`` that does not define ``_collapse_to_vmk``.
+        partitioned_sfa = DenseGemmKernel._collapse_to_vmk(partitioned_sfa)
         return cute.make_fragment_like(partitioned_sfa)
 
     def _partition_fragment_SFB(
@@ -616,7 +618,7 @@ class DenseGemmKernel:
         partitioned_sfb = thr_tensor[thr_vnk, (None, None)]
         partitioned_sfb = cute.group_modes(cute.flatten(partitioned_sfb), 0, 2)
         partitioned_sfb = cute.group_modes(partitioned_sfb, 1, 3)
-        partitioned_sfb = self._collapse_to_vmk(partitioned_sfb)
+        partitioned_sfb = DenseGemmKernel._collapse_to_vmk(partitioned_sfb)
         return cute.make_fragment_like(partitioned_sfb)
 
     def _thrfrg_SFA(self, sfa_tensor, tiled_mma: cute.TiledMma):

--- a/tests/moe/test_b12x_fused_moe.py
+++ b/tests/moe/test_b12x_fused_moe.py
@@ -145,6 +145,78 @@ def test_gated_dynamic_optimized_capability_bounds(overrides, expected):
 
 
 @cute_dsl_available
+def test_borrowed_dense_methods_resolve_on_moe_kernels():
+    """MoE kernels invoke dense b12x methods with their own ``self``.
+
+    They do not subclass the dense kernel, so any class-level helper those
+    borrowed methods reach through ``self`` must be mirrored on the MoE
+    classes -- otherwise adding one breaks every MoE borrower at trace time.
+    """
+    import ast
+    import inspect
+    import textwrap
+
+    from flashinfer.fused_moe.cute_dsl.blackwell_sm12x._moe_dynamic.gated import (
+        MoEGatedDynamicKernel,
+    )
+    from flashinfer.fused_moe.cute_dsl.blackwell_sm12x._moe_dynamic.generic import (
+        MoEDynamicKernel,
+    )
+    from flashinfer.fused_moe.cute_dsl.blackwell_sm12x.moe_micro_kernel import (
+        MoEMicroKernel,
+    )
+    from flashinfer.fused_moe.cute_dsl.blackwell_sm12x.moe_static_kernel import (
+        MoEStaticKernel,
+    )
+    from flashinfer.gemm.kernels.dense_blockscaled_gemm_sm120_b12x import (
+        Sm120B12xBlockScaledDenseGemmKernel as dense_cls,
+    )
+
+    borrowers = (
+        MoEStaticKernel,
+        MoEMicroKernel,
+        MoEDynamicKernel,
+        MoEGatedDynamicKernel,
+    )
+
+    def _self_attrs(source):
+        return {
+            node.attr
+            for node in ast.walk(ast.parse(textwrap.dedent(source)))
+            if isinstance(node, ast.Attribute)
+            and isinstance(node.value, ast.Name)
+            and node.value.id == "self"
+        }
+
+    borrowed = set()
+    for cls in borrowers:
+        module_tree = ast.parse(inspect.getsource(inspect.getmodule(cls)))
+        for node in ast.walk(module_tree):
+            if (
+                isinstance(node, ast.Attribute)
+                and isinstance(node.value, ast.Attribute)
+                and node.value.attr == "_dense_cls"
+            ):
+                borrowed.add(node.attr)
+    assert borrowed, "expected the MoE kernels to borrow dense b12x methods"
+
+    for name in sorted(borrowed):
+        # Only class-level attributes matter here; per-instance state is
+        # supplied by each MoE kernel's own __init__.
+        needed = sorted(
+            attr
+            for attr in _self_attrs(inspect.getsource(getattr(dense_cls, name)))
+            if hasattr(dense_cls, attr)
+        )
+        for cls in borrowers:
+            missing = [attr for attr in needed if not hasattr(cls, attr)]
+            assert not missing, (
+                f"{cls.__name__} borrows {dense_cls.__name__}.{name} but is "
+                f"missing {missing}"
+            )
+
+
+@cute_dsl_available
 def test_gated_dynamic_constructor_rejects_unsupported_geometry():
     from flashinfer.fused_moe.cute_dsl.blackwell_sm12x._moe_dynamic.gated import (
         MoEGatedDynamicKernel,


### PR DESCRIPTION
## 📌 Description

Every b12x fused MoE test fails on RTX Pro 6000 Blackwell with CUDA 13 with:

```
AttributeError: 'MoEStaticKernel' object has no attribute '_collapse_to_vmk'
```

(same for `MoEDynamicKernel`, `MoEGatedDynamicKernel`, `MoEMicroKernel` — 120 failures in the `v0.6.18rc4` unit-test pipeline).

The b12x MoE kernels deliberately do **not** subclass `Sm120B12xBlockScaledDenseGemmKernel`; they borrow its unbound methods and pass their own instance as `self`, e.g.

```python
tCrSFA_full = self._dense_cls._partition_fragment_SFA(
    self,  # type: ignore[arg-type]
    sSFA[None, None, 0], thr_mma, tidx,
)
```

`_partition_fragment_SFA`/`_SFB` reach the `@staticmethod` `_collapse_to_vmk` through that borrowed `self`, which resolves against the MoE class — and none of the four borrowers mirrors it. All four define `_thrfrg_SFA`/`_thrfrg_SFB` delegating wrappers, which is why only `_collapse_to_vmk` breaks.

This fix resolves the static helper on the class instead, which fixes all four borrowers in one place. `DenseGemmKernel` has no subclasses and nothing overrides `_collapse_to_vmk`, so the dense path is behaviour identical.

The failures are CUDA-13-only because the b12x fused MoE tests are gated on `_cuda_13_or_newer()`, not because the bug is CUDA-version dependent.

## 🔍 Related Issues

Regression from #4479 (`support MXFP4 dense GEMM on SM120`), which introduced `_collapse_to_vmk`. Not previously reported upstream.

## 🚀 Pull Request Checklist

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

`test_borrowed_dense_methods_resolve_on_moe_kernels` derives the borrowed method set from the MoE modules and asserts that every class-level attribute those methods look up is mirrored on each borrower. It needs no GPU, so the next helper added this way fails on CPU instead of only on SM120 hardware. Verified it fails on the unfixed tree with

```
AssertionError: MoEStaticKernel borrows DenseGemmKernel._partition_fragment_SFA but is missing ['_collapse_to_vmk']
```

and passes with the fix. `tests/moe/test_b12x_fused_moe.py` is otherwise unchanged: 34 passed, 151 skipped (SM120-gated) on the SM100 box used here.

## Reviewer Notes

I do not have SM120 hardware, so the end-to-end b12x MoE kernels are not exercised locally — the fix is a pure attribute-resolution change and the new test reproduces the exact failure without a GPU, but a CI run on RTX Pro 6000 + CUDA 13 is the real confirmation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility for shared dense matrix multiplication methods used by mixture-of-experts kernels.
  * Prevented failures when these methods are reused across different kernel types.

* **Tests**
  * Added coverage verifying that all supported mixture-of-experts kernels provide the required shared functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->