### PR TITLE
fix(trace): model the SM100/103 cute-dsl mm_bf16_fp4 prepared layout

### DIFF
--- a/flashinfer/trace/templates/gemm.py
+++ b/flashinfer/trace/templates/gemm.py
@@ -593,6 +593,34 @@ def _mm_bf16_fp4_cute_dsl_reference(a, b, b_descale, alpha=None, block_size=16):
     return _bf16_fp4_matmul(a, lut[codes] * sf, alpha)
 
 
+def _mm_bf16_fp4_cute_dsl_sm100_reference(a, b, b_descale, alpha=None, block_size=16):
+    """Reference for the SM100/103 cute-DSL-prepared layout.
+
+    b: [N, K//2] uint8 -- the canonical nvfp4 weight, passed through unchanged.
+    b_descale: (32, 4, N//128, 4, K_sf//4, 1) uint8 -- the strided view
+    ``convert_sf_to_mma_layout`` builds over the canonical 128x4-swizzled
+    FP8-E4M3 buffer, whose physical order is (groups, n_tiles, k_tiles, 32, 4,
+    4); permuting back to that order recovers the buffer to unswizzle.
+    """
+    n, k_half = b.shape
+    k = k_half * 2
+    sf_buffer = b_descale.permute(5, 2, 4, 0, 1, 3).reshape(-1)
+    sf_bytes = _unswizzle_sf_128x4(sf_buffer, n, k // block_size).contiguous()
+    sf = sf_bytes.view(torch.float8_e4m3fn).to(torch.float32)
+    lut = torch.tensor(_E2M1_VALUES, dtype=torch.float32, device=b.device)
+    b_int = b.to(torch.int64)
+    codes = torch.stack([b_int & 0xF, (b_int >> 4) & 0xF], dim=-1).reshape(n, k)
+    sf = sf.repeat_interleave(block_size, dim=1)
+    return _bf16_fp4_matmul(a, (lut[codes] * sf).T, alpha)
+
+
+cast(Any, _mm_bf16_fp4_cute_dsl_sm100_reference)._trace_reference_dependencies = (
+    _bf16_fp4_matmul,
+    _unswizzle_batched_sf_128x4,
+    _unswizzle_sf_128x4,
+)
+
+
 def _mm_bf16_fp4_cudnn_init(
     *,
     M: int,
@@ -658,7 +686,7 @@ def _mm_bf16_fp4_cute_dsl_init(
     device: str = "cuda",
     seed: int = 0,
 ):
-    """Build inputs for ``flashinfer.mm_bf16_fp4`` (cute-DSL backend).
+    """Build inputs for ``flashinfer.mm_bf16_fp4`` (cute-DSL backend, SM12x).
 
     Sourced from ``tests/gemm/test_mm_bf16_fp4.py``: quantize a randn
     bf16 weight via ``flashinfer.nvfp4_quantize`` (layout_128x4), then
@@ -678,6 +706,66 @@ def _mm_bf16_fp4_cute_dsl_init(
     major, minor = torch.cuda.get_device_capability(torch.device(device))
     if not mm_bf16_fp4.is_backend_supported("cute-dsl", major * 10 + minor):
         raise NotImplementedError(f"mm_bf16_fp4 is not supported on SM{major}{minor}")
+    if (major, minor) in ((10, 0), (10, 3)):
+        raise NotImplementedError(
+            f"SM{major}{minor} prepares a different cute-dsl layout; use "
+            "mm_bf16_fp4_cute_dsl_sm100_trace"
+        )
+
+    torch.manual_seed(seed)
+    a = torch.randn(M, K, dtype=torch.bfloat16, device=device)
+    w = torch.randn(N, K, dtype=torch.bfloat16, device=device)
+    g_w = (448.0 * 6.0) / w.float().abs().nan_to_num().max()
+    b_fp4, b_sf = nvfp4_quantize(
+        w, g_w, sfLayout=SfLayout.layout_128x4, do_shuffle=False, backend="cute-dsl"
+    )
+    alpha = torch.tensor([1.0 / g_w.item()], dtype=torch.float32, device=device)
+    b_p, sf_p, alpha_p = prepare_bf16_fp4_weights(
+        b_fp4, b_sf, alpha, backend="cute-dsl", block_size=block_size
+    )
+    return {
+        "a": a,
+        "b": b_p,
+        "b_descale": sf_p,
+        "alpha": alpha_p,
+        "backend": "cute-dsl",
+        "block_size": int(block_size),
+    }
+
+
+def _mm_bf16_fp4_cute_dsl_sm100_init(
+    *,
+    M: int,
+    N: int = 2048,
+    K: int = 7168,
+    block_size: int = 16,
+    K_div_2: int = 0,  # derived
+    N_div_128: int = 0,  # derived
+    K_sf_div_4: int = 0,  # derived
+    device: str = "cuda",
+    seed: int = 0,
+):
+    """Build inputs for ``flashinfer.mm_bf16_fp4`` (cute-DSL backend, SM100/103).
+
+    Same quantization as the SM12x init, but ``prepare_bf16_fp4_weights``
+    keeps the weight in its canonical ``(N, K//2)`` layout and returns the
+    scales as the 6-D strided MMA view the SM100 TMA descriptor consumes.
+    """
+    del K_div_2, N_div_128, K_sf_div_4
+    from flashinfer import (  # noqa: PLC0415
+        nvfp4_quantize,
+        prepare_bf16_fp4_weights,
+    )
+    from flashinfer.quantization.fp4_quantization import SfLayout  # noqa: PLC0415
+
+    if not torch.cuda.is_available() or torch.device(device).type != "cuda":
+        raise NotImplementedError("mm_bf16_fp4 init requires a CUDA device")
+    major, minor = torch.cuda.get_device_capability(torch.device(device))
+    if (major, minor) not in ((10, 0), (10, 3)):
+        raise NotImplementedError(
+            f"this template describes the SM100/103 cute-dsl layout; got "
+            f"SM{major}{minor}"
+        )
 
     torch.manual_seed(seed)
     a = torch.randn(M, K, dtype=torch.bfloat16, device=device)
@@ -782,17 +870,69 @@ mm_bf16_fp4_cute_dsl_trace = TraceTemplate(
     init=_mm_bf16_fp4_cute_dsl_init,
 )
 
+mm_bf16_fp4_cute_dsl_sm100_trace = TraceTemplate(
+    op_type="gemm_bf16_fp4",
+    name_prefix="mm_bf16_fp4_cute_dsl_sm100",
+    description=(
+        "bf16 x fp4 GEMM C = (A @ dequant(B).T) * alpha, cute-DSL-prepared weights "
+        "for SM100/103.  A is bf16; B is the canonical fp4 (e2m1fn_x2 packed as "
+        "uint8) [N, K//2] weight with fp8-e4m3 per-block scales kept in the "
+        "128x4-swizzled layout, viewed as the 6-D MMA layout the TMA descriptor "
+        "consumes."
+    ),
+    axes={
+        "M": Var(),
+        "N": Const(),
+        "K": Const(),
+        "block_size": Const(description="FP4 quantization block size (16 for nvfp4)."),
+    },
+    inputs={
+        "A": Tensor(["M", "K"], param="a", description="Activation, bfloat16."),
+        "B": Tensor(
+            ["N", "K_div_2"],
+            param="b",
+            description="Weight, fp4 e2m1fn_x2 packed as uint8, [N, K//2].",
+        ),
+        "b_descale": Tensor(
+            ["32", "4", "N_div_128", "4", "K_sf_div_4", "num_groups"],
+            description=(
+                "Per-block scales, fp8-e4m3 bytes as uint8, as the 6-D strided "
+                "view (32, 4, N//128, 4, K//block_size//4, 1) over the canonical "
+                "128x4-swizzled buffer."
+            ),
+        ),
+        "alpha": Tensor(
+            ["1"],
+            optional=True,
+            description="Optional global scale, float32, shape (1,).",
+        ),
+        "block_size": Scalar("int32", description="FP4 block size (always 16)."),
+    },
+    outputs={
+        "C": Tensor(["M", "N"], dtype_from="a"),
+    },
+    tags=["status:verified", "quantization:fp4"],
+    reference=_mm_bf16_fp4_cute_dsl_sm100_reference,
+    check=_fp4_gemm_check,
+    init=_mm_bf16_fp4_cute_dsl_sm100_init,
+)
+
 
 def mm_bf16_fp4_trace_dispatch(**kwargs):
     """Return the TraceTemplate for an ``mm_bf16_fp4`` call by backend.
 
-    The prepared weight layout differs per backend (int32 -> cute-dsl,
-    uint8 -> cudnn), so each gets its own template.  Pass as
+    ``prepare_bf16_fp4_weights`` produces three distinct layouts: cute-dsl on
+    SM12x tile-packs the weight into int32, cute-dsl on SM100/103 keeps the
+    canonical uint8 weight but hands back a 6-D scale view, and cudnn keeps the
+    canonical weight with linear 2-D scales.  Pass as
     ``trace=mm_bf16_fp4_trace_dispatch`` to ``@flashinfer_api``.
     """
     b = kwargs.get("b")
     if b is not None and b.dtype == torch.int32:
         return mm_bf16_fp4_cute_dsl_trace
+    b_descale = kwargs.get("b_descale")
+    if b_descale is not None and b_descale.dim() == 6:
+        return mm_bf16_fp4_cute_dsl_sm100_trace
     return mm_bf16_fp4_cudnn_trace
 
 
@@ -801,6 +941,7 @@ def mm_bf16_fp4_trace_dispatch(**kwargs):
 mm_bf16_fp4_trace_dispatch.templates = [  # type: ignore[attr-defined]
     mm_bf16_fp4_cudnn_trace,
     mm_bf16_fp4_cute_dsl_trace,
+    mm_bf16_fp4_cute_dsl_sm100_trace,
 ]
 
 

--- a/tests/trace/test_mm_bf16_fp4_reference_correctness.py
+++ b/tests/trace/test_mm_bf16_fp4_reference_correctness.py
@@ -18,19 +18,26 @@ def test_mm_bf16_fp4_reference_correctness(backend, shape_kwargs):
 
     The trace inits build *prepared* (backend-specific) weights via
     ``prepare_bf16_fp4_weights``; each backend's reference dequantizes
-    that prepared layout directly (the cute-dsl one inverts the MMA tile
-    permutation and decodes S0E5M3 scales).
+    that prepared layout directly (the SM12x cute-dsl one inverts the MMA
+    tile permutation and decodes S0E5M3 scales, while the SM100/103 one
+    unswizzles the 128x4 scale buffer).
     """
     import flashinfer
     from flashinfer.trace.templates.gemm import (
         mm_bf16_fp4_cudnn_trace,
+        mm_bf16_fp4_cute_dsl_sm100_trace,
         mm_bf16_fp4_cute_dsl_trace,
+        mm_bf16_fp4_trace_dispatch,
     )
 
-    tpl = {
-        "cudnn": mm_bf16_fp4_cudnn_trace,
-        "cute-dsl": mm_bf16_fp4_cute_dsl_trace,
-    }[backend]
+    if not torch.cuda.is_available():
+        pytest.skip("mm_bf16_fp4 requires a CUDA device")
+    if backend == "cudnn":
+        tpl = mm_bf16_fp4_cudnn_trace
+    elif torch.cuda.get_device_capability() in ((10, 0), (10, 3)):
+        tpl = mm_bf16_fp4_cute_dsl_sm100_trace
+    else:
+        tpl = mm_bf16_fp4_cute_dsl_trace
     try:
         inputs = tpl.init(**shape_kwargs)
         api = flashinfer.mm_bf16_fp4(
@@ -43,6 +50,9 @@ def test_mm_bf16_fp4_reference_correctness(backend, shape_kwargs):
         )
     except Exception as exc:
         pytest.skip(f"mm_bf16_fp4 ({backend}) unavailable: {exc}")
+    # The prepared layouts are what the dispatch keys off, so a real prepared
+    # call must resolve back to the template that describes it.
+    assert mm_bf16_fp4_trace_dispatch(**inputs) is tpl
     _assert_finite(inputs["a"])
     ref = tpl.reference(
         inputs["a"],


### PR DESCRIPTION
## 📌 Description

`tests/trace/test_mm_bf16_fp4_reference_correctness.py::test_mm_bf16_fp4_reference_correctness[*-cute-dsl]` fails on the whole SM100 family (12 failures on B300 / GB200 / GB300, both CUDA versions, in the `v0.6.18rc4` unit-test pipeline):

```
    device = b.device
>   k_sf, n = b_descale.shape
E   ValueError: too many values to unpack (expected 2)
flashinfer/trace/templates/gemm.py:550: ValueError
```

`prepare_bf16_fp4_weights` gained a **third** prepared layout when the SM100 cute-dsl w4a16 GEMM landed. The trace layer only knew two:

| path | `b` | `b_descale` |
|---|---|---|
| cuDNN | canonical `(N, K//2)` uint8 | linear `(N, K_sf)` fp8-e4m3 |
| cute-dsl SM12x | `(K//16, N*2)` int32 tile-packed | `(K_sf, N)` uint8 S0E5M3 |
| cute-dsl SM100/103 | canonical `(N, K//2)` uint8 | **6-D** `(32, 4, N//128, 4, K_sf//4, 1)` strided view over the 128x4-swizzled buffer |

Two consequences on SM100/103:

- `mm_bf16_fp4_cute_dsl_trace.reference` unpacks `b_descale.shape` as 2-D and raises the `ValueError` above.
- `mm_bf16_fp4_trace_dispatch` keys off the weight dtype (`int32` → cute-dsl), and the SM100 weight is `uint8`, so a cute-dsl call silently resolves to the **cuDNN** template. Shapes are not validated at trace time, so this would have quietly dumped a definition labelled `mm_bf16_fp4_cudnn` describing the wrong prepared layout.

This PR adds `mm_bf16_fp4_cute_dsl_sm100_trace` with its own init and reference, restricts the SM12x init to SM12x, and gives the dispatch a discriminator for all three layouts.

The new reference recovers the canonical scale buffer by permuting the strided view back to its documented physical order — `convert_sf_to_mma_layout` returns logical `(outer_m, inner_m, m_tile, inner_k, k_tile, group)` over physical `(group, m_tile, k_tile, 32, 4, 4)`, which is exactly what `_unswizzle_sf_128x4` expects — then decodes the canonical nvfp4 weight the same way the cuDNN reference does. I checked that reconstruction against `_unswizzle_sf_128x4` of the pre-`convert` buffer, and independently against the documented element-wise index mapping; both are bit-exact.

## 🔍 Related Issues

Regression from #4466 (`feat: sm100 cute_dsl w4a16 gemm`), which added the SM100 prepared layout without touching the trace layer. Not previously reported upstream.

## 🚀 Pull Request Checklist

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

Verified on a B200 (SM100, CUDA 13.0, cutlass-dsl 4.7.0), where the test reproduces the reported `ValueError` before the change:

- `tests/trace/test_mm_bf16_fp4_reference_correctness.py` — 4 failed → 4 passed
- `tests/gemm/test_mm_bf16_fp4.py` — 242 passed, 3 skipped
- `tests/trace/test_fi_trace_template_consistency.py`, `test_template_registry.py`, `test_template_init.py`, `test_rendered_source_standalone.py`, `test_fi_trace.py` — 1050 passed, 180 skipped

The reference test now picks the cute-dsl template matching the device and asserts `mm_bf16_fp4_trace_dispatch` resolves a real prepared call back to that template, so the misrouting cannot come back unnoticed.

## Reviewer Notes

Worth a second opinion on two judgement calls:

1. **A separate template rather than one branching reference.** The declared `axes`/`inputs` are what land in the dumped definition, and the SM100 weight and scale shapes differ from SM12x, so a single template cannot describe both honestly. If you would rather not trace this layout at all, the alternative is to make the SM12x init raise on SM100/103 and stop there — that also turns the failure into a skip, but leaves the dispatch mislabelling SM100 cute-dsl calls as cuDNN.
2. **Declaring a non-contiguous 6-D view as a template input.** It is an odd thing to put in a bench definition since it is a view, not an allocation. I described it as-is rather than substituting the underlying canonical buffer, because that view is literally what callers pass to `mm_bf16_fp4`. Happy to change the dim naming if you prefer something else.

I have no SM103 hardware; the SM100 and SM103 paths share `_prepare_cute_dsl_sm100`, so the gating treats them together.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for BF16×FP4 operations on SM100/103 GPUs with six-dimensional scale tensors.
  * Automatically selects the appropriate processing path based on tensor format and GPU capability.

* **Bug Fixes**
  * Improved scale reconstruction and dequantization accuracy for supported SM100/103 workloads.

* **Tests**
  * Expanded correctness coverage for backend and GPU-specific template selection.
  * Tests now handle environments without CUDA gracefully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->