### PR TITLE
Enable top_k_varlen on Rubin (SM107) and add the DKG filtered-radix backend (`radix_filter`)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -63,7 +63,7 @@ repos:
       -   id: mypy
           args: ["--config-file", "pyproject.toml", "--exclude", "flashinfer-cubin/"]
           files: ^flashinfer/
-          exclude: ^(flashinfer-cubin/|flashinfer/attention/prims_ts/kernels/|3rdparty/|build/|flashinfer/cute_dsl/attention/fmha/(fmha\.py|fmha_blockscaled\.py|helpers/)|flashinfer/gemm/kernels/dense_blockscaled_gemm_sm107\.py|flashinfer/fused_moe/cute_dsl/rubin/(blockscaled_contiguous_gather_grouped_gemm_swiglu_fusion\.py|blockscaled_contiguous_grouped_gemm_finalize_fusion\.py))
+          exclude: ^(flashinfer-cubin/|flashinfer/attention/prims_ts/kernels/|3rdparty/|build/|flashinfer/cute_dsl/attention/fmha/(fmha\.py|fmha_blockscaled\.py|helpers/)|flashinfer/gemm/kernels/dense_blockscaled_gemm_sm107\.py|flashinfer/fused_moe/cute_dsl/rubin/(blockscaled_contiguous_gather_grouped_gemm_swiglu_fusion\.py|blockscaled_contiguous_grouped_gemm_finalize_fusion\.py)|flashinfer/topk_varlen/kernels/filtered_topk_(util|decode)\.py)
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.

--- a/flashinfer/topk_varlen/kernels/filtered_topk_decode.py
+++ b/flashinfer/topk_varlen/kernels/filtered_topk_decode.py
@@ -1,0 +1,1921 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+# list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+# Vendored from the NVIDIA dynamic-kernel-generator (DKG) repository,
+# cutlass_ir/compiler/python/examples/CuTeDSL/cute/blackwell/kernel/top_k/filtered_top_k_decode_varlen.py
+# at DKG master b45e50a7336 (merge request !25590, "[CuTeDSL] Adapt radix top-k to
+# Rubin arch").
+#
+# Changes from upstream are limited to: this header, removal of DKG-internal
+# release markers, and import rewrites to flashinfer-relative paths. The kernel
+# algorithm is unmodified so upstream fixes can be re-applied by re-vendoring.
+
+import math
+
+import cuda.bindings.driver as cuda
+import cutlass
+import cutlass.cute as cute
+import torch
+from cutlass.cute.nvgpu import cpasync
+from cutlass import testing
+from cutlass.torch import dtype as torch_dtype
+
+from .filtered_topk_util import (
+    _RUBIN_TOPK_ARCHITECTURES,
+    FilteredTopKKernelVarlen,
+    auto_tma_load,
+    auto_unroll_factor,
+    compare_top_k_results,
+    create_random_logits,
+    get_topk_architecture_config,
+    run_reference_top_k,
+    tma_tuned_default,
+)
+
+
+def _get_num_sms() -> int:
+    """Return the number of SMs on the current device (cached)."""
+    if not hasattr(_get_num_sms, "_value"):
+        _get_num_sms._value = torch.cuda.get_device_properties().multi_processor_count
+    return _get_num_sms._value
+
+
+"""
+A high-performance topk kernel example based on radix-based filter algorithm for
+the NVIDIA Blackwell SM100 architecture based on CuTe DSL.
+
+The radix-based filter top-k algorithm mainly includes two phases: coarse filter and multi-round fine-grained filter.
+For each phase:
+1. histogram: Build a histogram of the input values using vectorized loads.
+2. prefix sum: Find the threshold bin using prefix sum.
+3. find target bin id: Find the target bin id using multiple rounds.
+Finally, write the top-k values and indices to the output tensor.
+
+Supported data types:
+- Float32
+- Float16
+- BFloat16
+
+To run this example:
+.. code-block:: bash
+    python examples/blackwell/sort/filter_top_k_decode_varlen.py  \
+      --dtype Float32 --batch_size 1 --max_num_cols 4096 --next_n 3 \
+      --top_k 2048 --wrapper-mode single-cta \
+      --do_ref_check --return_val --benchmark
+
+Constraints for this example:
+* The supported top_k range is [1, 16384].
+* The input tensor has data contiguous on the n dimension (row-major).
+* The supported input data types are Float32, Float16, or BFloat16.
+"""
+
+
+class FilteredTopKKernelVarlenDecode(FilteredTopKKernelVarlen):
+    def __init__(
+        self,
+        dtype: cutlass.Numeric,
+        max_num_cols: int,
+        top_k: int,
+        next_n: int = 1,
+        num_copy_bits: int = 256,
+        return_val: bool = True,
+        large_occupancy: bool = False,
+        # for multi-cta version.
+        enable_multi_cta: bool = False,
+        chunk_size_per_cta: int = 16384,
+        num_ctas_per_row: int = 1,
+        merge_blocks: bool = False,
+        enable_dynamic_multi_cta: bool = False,
+        varlen_merge_input: bool = False,
+        overflow_policy: str = "REREAD",
+        cache_smem_values: bool = False,
+        single_pass_multi_cta: bool = False,
+        target_blocks_per_sm: int = 4,
+        architecture: str = "sm_100",
+        unroll_factor: int = 4,
+        enable_tma_load: bool = False,
+        enable_tma_load_p3: bool = False,
+        tma_num_stages: int = 4,
+        tma_num_stages_p3: int = 2,
+    ):
+        self._large_occupancy = large_occupancy
+        self._target_blocks_per_sm = target_blocks_per_sm
+        # async-TMA load (p1 + p3), hard-restricted to the large-occupancy single-CTA
+        # path (_tma_ok) -- cluster / small-occupancy always keep LDG even if forced on.
+        # The tuned auto-default lives in _prepare_one_pass_topk, which passes a concrete
+        # flag; None here defaults OFF (constructing this class directly needs an opt-in).
+        _tma_ok = large_occupancy and not single_pass_multi_cta
+        _enable_tma_load = _tma_ok and enable_tma_load
+        _enable_tma_load_p3 = _tma_ok and enable_tma_load_p3
+        _tma_num_stages = tma_num_stages
+        _tma_num_stages_p3 = tma_num_stages_p3
+        super().__init__(
+            dtype,
+            max_num_cols,
+            top_k,
+            num_copy_bits,
+            return_val,
+            enable_multi_cta,
+            chunk_size_per_cta,
+            num_ctas_per_row,
+            merge_blocks,
+            overflow_policy=overflow_policy,
+            # large_occupancy always uses 512 threads; pass it early so that
+            # _compute_smem_input_size_for_occupancy() sees the correct num_warps.
+            num_threads_override=512 if large_occupancy else 0,
+            cache_smem_values=cache_smem_values,
+            single_pass_multi_cta=single_pass_multi_cta,
+            architecture=architecture,
+            unroll_factor=unroll_factor,
+            enable_tma_load=_enable_tma_load,
+            tma_num_stages=_tma_num_stages,
+            enable_tma_load_p3=_enable_tma_load_p3,
+            tma_num_stages_p3=_tma_num_stages_p3,
+        )
+        self.next_n = next_n
+        self.enable_multi_cta = enable_multi_cta
+        self.chunk_size_per_cta = chunk_size_per_cta
+        self.merge_blocks = merge_blocks
+        self.num_ctas_per_row = num_ctas_per_row
+        self.enable_dynamic_multi_cta = enable_dynamic_multi_cta
+        self.varlen_merge_input = varlen_merge_input
+
+        if cutlass.const_expr(self.merge_blocks):
+            # Cap vec_size so tile_width (num_threads_per_cta * vec_size) <= max_num_cols,
+            # preventing OOB s_indices from _fill_oob padding.
+            _vec_cap = max(
+                1,
+                2
+                ** int(
+                    math.log2(max(self.max_num_cols // self.num_threads_per_cta, 1))
+                ),
+            )
+            self.num_copy_bits = min(self.num_copy_bits, _vec_cap * self.dtype.width)
+            self.vec_size = self.num_copy_bits // self.dtype.width
+
+        # Resolve the "auto" (0) unroll sentinel now that threads/vec_size and
+        # the per-CTA scan extent are known.
+        if self.unroll_factor == 0:
+            blocks_per_sm = self._target_blocks_per_sm if self._large_occupancy else 1
+            per_cta_cols = (
+                self.chunk_size_per_cta
+                if (self.enable_multi_cta or self.single_pass_multi_cta)
+                else self.max_num_cols
+            )
+            self.unroll_factor = auto_unroll_factor(
+                per_cta_cols,
+                self.num_threads_per_cta,
+                blocks_per_sm,
+                self.vec_size,
+                self.dtype.width // 8,
+            )
+
+    def _compute_smem_input_size(self) -> int:
+        if cutlass.const_expr(self._large_occupancy):
+            return self._compute_smem_input_size_for_occupancy(
+                target_blocks_per_sm=self._target_blocks_per_sm
+            )
+        return self._compute_smem_input_size_for_occupancy(target_blocks_per_sm=1)
+
+    @cute.kernel
+    def filtered_topk_kernel(
+        self,
+        input: cute.Tensor,
+        indices: cute.Tensor,
+        extra_buffer: cute.Tensor,
+        seqlen: cute.Tensor,
+        output_indices: cute.Tensor,
+        output_values: cute.Tensor,
+        tma_atom=None,
+        tma_tensor=None,
+    ):
+        """CuTe DSL implementation of TopK kernel based on radix-based filter algorithm."""
+        cute.arch.griddepcontrol_wait()
+
+        smem = cutlass.memory.SmemAllocator()
+        # Keep control fields separate because each has a distinct indexing scheme.
+        s_histogram_buf_layout = cute.make_ordered_layout((self.radix + 1), order=(0))
+        s_histogram = smem.allocate_tensor(
+            element_type=cutlass.Int32,
+            layout=s_histogram_buf_layout,
+            byte_alignment=128,
+        )
+        s_counter = smem.allocate_tensor(
+            element_type=cutlass.Int32,
+            layout=cute.make_ordered_layout((1), order=(0)),
+            byte_alignment=128,
+        )
+        s_threshold_bin_id = smem.allocate_tensor(
+            element_type=cutlass.Int32,
+            layout=cute.make_ordered_layout((1), order=(0)),
+            byte_alignment=128,
+        )
+        s_num_input = smem.allocate_tensor(
+            element_type=cutlass.Int32,
+            layout=cute.make_ordered_layout((2,), order=(0)),
+            byte_alignment=128,
+        )
+        if cutlass.const_expr(self.enable_gmem_store or self.enable_bounded_spill):
+            g_num_input = smem.allocate_tensor(
+                element_type=cutlass.Int32,
+                layout=cute.make_ordered_layout((2), order=(0)),
+                byte_alignment=128,
+            )
+        else:
+            g_num_input = None
+        s_indices = smem.allocate_tensor(
+            element_type=self.index_type,
+            layout=cute.make_ordered_layout((self.top_k,), order=(0)),
+            byte_alignment=128,
+        )
+        # Candidate buffer + async-TMA staging. Each TMA ring (p1 histogram, p3 filter)
+        # needs SMEM; instead of a dedicated buffer (which would shrink the candidate
+        # capacity S), it ALIASES a candidate region that is idle while that phase runs
+        # -> zero extra SMEM. The ring must fit its aliased region
+        # (n_stages * tile_bytes <= region bytes); that is guaranteed upstream (__init__
+        # asserts capacity, adaptively caps n_stages, and reserves the mbarriers), so no
+        # runtime check is needed here. Three cases:
+        #   p1                : whole candidate buffer is unused during the histogram
+        #                       (no candidate written yet) -> aliased below.
+        #   p3 fp32 (nbuf==2) : buffer 1 is idle during the filter (candidates go to
+        #                       buffer 0) -> alias buffer 1 (this branch).
+        #   p3 fp16/bf16 (1)  : single buffer, nothing idle -> dedicated carve (else).
+        if cutlass.const_expr(
+            self.enable_tma_load_p3 and self.num_buffer_smem_input_idx == 2
+        ):
+            # Buffer-major layout: one contiguous Int32 pool split into `n_buffers`
+            # equal, 128B-padded slots (so buffer 1 is one contiguous region the p3
+            # staging can alias). idx/val are (n_buffers, capacity) strided views into
+            # the slots, so kernel access is unchanged.
+            n_buffers = self.num_buffer_smem_input_idx
+            capacity = self.filtered_topk_smem_input_size  # candidate slots / buffer
+            idx_bytes = self.index_type.width // 8
+            val_bytes = self.ordered_type.width // 8 if self.cache_smem_values else 0
+            slot_bytes = ((capacity * (idx_bytes + val_bytes) + 127) // 128) * 128
+            int32_bytes = 4  # pool element size; byte offsets below are / int32_bytes
+
+            pool = smem.allocate_tensor(
+                element_type=cutlass.Int32,
+                layout=cute.make_ordered_layout(
+                    ((n_buffers * slot_bytes) // int32_bytes,), order=(0,)
+                ),
+                byte_alignment=128,
+            )
+            base = pool.iterator
+            # idx double-buffer: buffer b at byte offset b * slot_bytes.
+            s_input_idx = cute.make_tensor(
+                cute.recast_ptr(base, dtype=self.index_type),
+                cute.make_layout(
+                    (n_buffers, capacity), stride=(slot_bytes // idx_bytes, 1)
+                ),
+            )
+            if cutlass.const_expr(self.cache_smem_values):
+                # val double-buffer, placed right after idx inside each slot.
+                s_input_val = cute.make_tensor(
+                    cute.recast_ptr(
+                        base + (capacity * idx_bytes) // int32_bytes,
+                        dtype=self.ordered_type,
+                    ),
+                    cute.make_layout(
+                        (n_buffers, capacity), stride=(slot_bytes // val_bytes, 1)
+                    ),
+                )
+            else:
+                s_input_val = None
+            # p3 staging ring aliases buffer 1 (byte offset slot_bytes).
+            tile_cols = self.num_threads_per_cta * self.vec_size
+            s_tma_stage_p3 = cute.make_tensor(
+                cute.recast_ptr(base + slot_bytes // int32_bytes, dtype=self.dtype),
+                cute.make_ordered_layout(
+                    (self.tma_num_stages_p3, 1, tile_cols), order=(2, 1, 0)
+                ),
+            )
+            s_tma_mbar_p3 = smem.allocate_array(
+                cutlass.Int64, 2 * self.tma_num_stages_p3
+            )
+        else:
+            # fp16/bf16 p3: dedicated carve (no idle buffer to alias); or p3 off.
+            # Either way the candidate buffer keeps its plain flat (nbuf,S) layout.
+            if cutlass.const_expr(self.enable_tma_load_p3):
+                tile_cols = self.num_threads_per_cta * self.vec_size
+                s_tma_stage_p3 = smem.allocate_tensor(
+                    element_type=self.dtype,
+                    layout=cute.make_ordered_layout(
+                        (self.tma_num_stages_p3, 1, tile_cols), order=(2, 1, 0)
+                    ),
+                    byte_alignment=128,
+                )
+                s_tma_mbar_p3 = smem.allocate_array(
+                    cutlass.Int64, 2 * self.tma_num_stages_p3
+                )
+            else:
+                s_tma_stage_p3 = None
+                s_tma_mbar_p3 = None
+            if cutlass.const_expr(not self.enable_reread_always):
+                s_input_idx = smem.allocate_tensor(
+                    element_type=self.index_type,
+                    layout=cute.make_ordered_layout(
+                        (
+                            self.num_buffer_smem_input_idx,
+                            self.filtered_topk_smem_input_size,
+                        ),
+                        order=(1, 0),
+                    ),
+                    byte_alignment=128,
+                )
+            else:
+                s_input_idx = None
+            if cutlass.const_expr(
+                self.cache_smem_values and not self.enable_reread_always
+            ):
+                s_input_val = smem.allocate_tensor(
+                    element_type=self.ordered_type,
+                    layout=cute.make_ordered_layout(
+                        (
+                            self.num_buffer_smem_input_idx,
+                            self.filtered_topk_smem_input_size,
+                        ),
+                        order=(1, 0),
+                    ),
+                    byte_alignment=128,
+                )
+            else:
+                s_input_val = None
+        # p1 staging ring aliases the (idle) candidate buffer s_input_idx -- see the
+        # alias note above. Zero extra SMEM; S unchanged.
+        if cutlass.const_expr(self.enable_tma_load):
+            tile_cols = self.num_threads_per_cta * self.vec_size
+            s_tma_stage = cute.make_tensor(
+                cute.recast_ptr(s_input_idx.iterator, dtype=self.dtype),
+                cute.make_ordered_layout(
+                    (self.tma_num_stages, 1, tile_cols), order=(2, 1, 0)
+                ),
+            )
+            s_tma_mbar = smem.allocate_array(cutlass.Int64, 2 * self.tma_num_stages)
+        else:
+            s_tma_stage = None
+            s_tma_mbar = None
+        if cutlass.const_expr(self.enable_reread or self.enable_bounded_spill):
+            s_overflow_flag = smem.allocate_tensor(
+                element_type=cutlass.Int32,
+                layout=cute.make_ordered_layout((1,), order=(0,)),
+                byte_alignment=128,
+            )
+        else:
+            s_overflow_flag = None
+        s_last_remain = smem.allocate_tensor(
+            element_type=cutlass.Int32,
+            layout=cute.make_ordered_layout((1,), order=(0,)),
+            byte_alignment=128,
+        )
+        num_warps = cutlass.const_expr(
+            min(self.radix, self.num_threads_per_cta) // cutlass.Int32(32)
+        )
+        s_warp_sums = smem.allocate_tensor(
+            element_type=cute.Int32,
+            layout=cute.make_ordered_layout((num_warps,), order=(0,)),
+            byte_alignment=128,
+        )
+        # SP multi-CTA (radix-filter cluster): separate DSMEM merge target so the
+        # local s_histogram is never written in-place while peers read it.
+        # (The collection prefix-scan scratch reuses s_histogram, not this buffer.)
+        if cutlass.const_expr(self.single_pass_multi_cta):
+            s_hist_merged = smem.allocate_tensor(
+                element_type=cutlass.Int32,
+                layout=cute.make_ordered_layout((self.radix + 1), order=(0)),
+                byte_alignment=128,
+            )
+        else:
+            s_hist_merged = None
+
+        # Thread and block indexing
+        bidx, bidy, _ = cute.arch.block_idx()
+
+        # ---- SP multi-CTA (radix-filter cluster) block indexing + dispatch ----
+        # 1D grid = (num_rows * ctas_per_group,), cluster = (ctas_per_group,1,1).
+        # row_id / cta_in_group derived from the global block index; needed_ctas
+        # from seqlen decides solo (needed_ctas==1) vs cluster (>=2) at runtime.
+        need_cluster_sync = False
+        cta_in_group = 0
+        # Cluster mode derives its row and CTA coordinates before the common path.
+        if cutlass.const_expr(self.single_pass_multi_cta):
+            row_id = bidx // self.num_ctas_per_row
+            cta_in_group = bidx % self.num_ctas_per_row
+            _batch = row_id // self.next_n
+            _off = row_id % self.next_n
+            _eff = seqlen[_batch] - self.next_n + _off + 1
+            chunk_start = self.chunk_size_per_cta * cta_in_group
+            row_start = chunk_start
+            row_end = min(_eff, chunk_start + self.chunk_size_per_cta)
+            length = row_end - row_start
+            _needed = (_eff + self.chunk_size_per_cta - 1) // self.chunk_size_per_cta
+            if _needed < 1:
+                _needed = 1
+            need_cluster_sync = _needed >= 2
+            # The cluster radix search has no threshold when the whole row fits
+            # in top_k. Let CTA 0 take the full row through the trivial path.
+            if _eff <= self.top_k:
+                need_cluster_sync = False
+                row_start = 0
+                length = _eff
+            # score/dst index the row (not the global block).
+            bidx = row_id
+
+        if cutlass.const_expr(not self.single_pass_multi_cta):
+            if cutlass.const_expr(self.enable_dynamic_multi_cta):
+                # 2D grid with early exit: bidx = row_id, bidy = chunk_id.
+                # Each CTA computes how many chunks its row actually needs
+                # from seqlen and exits early if bidy >= num_needed_ctas.
+                # This avoids prefix sum + binary search overhead entirely.
+                num_rows_val = seqlen.shape[0] * self.next_n
+
+            row_start = 0
+            row_end = 0
+            length = 0
+            seq_len = 0
+
+            if not cutlass.const_expr(self.merge_blocks):
+                seq_len = seqlen[bidx // self.next_n]
+                row_end = seq_len - self.next_n + (bidx % self.next_n) + 1
+                length = row_end - row_start
+
+        if cutlass.const_expr(self.enable_multi_cta):
+            # update row_start and row_end.
+            row_start = self.chunk_size_per_cta * bidy
+            row_end = min(row_end, row_start + self.chunk_size_per_cta)
+            length = row_end - row_start
+            output_indices = cute.flat_divide(output_indices, (1, self.top_k))[
+                0, None, bidx, bidy
+            ]
+            output_values = cute.flat_divide(output_values, (1, self.top_k))[
+                0, None, bidx, bidy
+            ]
+
+        if cutlass.const_expr(self.merge_blocks):
+            if cutlass.const_expr(self.varlen_merge_input):
+                # Varlen merge: compute per-row valid length from seqlen.
+                _batch = bidx // self.next_n
+                _off = bidx % self.next_n
+                _eff = seqlen[_batch] - self.next_n + _off + 1
+                _num_ctas = (
+                    _eff + self.chunk_size_per_cta - 1
+                ) // self.chunk_size_per_cta
+                if _num_ctas < 1:
+                    _num_ctas = 1
+                merge_width = _num_ctas * self.top_k
+                row_end = merge_width
+                length = merge_width
+            else:
+                # Existing fixed-length path
+                # Note, after 1st kernel, the output is fix-lenght.
+                # Note, for merge_block kernels, need to ensure max_num_cols is the same as bucketed_num_cols.
+                row_end = self.max_num_cols
+                length = self.max_num_cols
+
+        # Skip CTAs that exceed this row's actual chunk count.
+        _should_run = True
+        if cutlass.const_expr(self.enable_dynamic_multi_cta):
+            _batch_check = bidx // self.next_n
+            _off_check = bidx % self.next_n
+            _eff_check = seqlen[_batch_check] - self.next_n + _off_check + 1
+            _needed_ctas = (
+                _eff_check + self.chunk_size_per_cta - 1
+            ) // self.chunk_size_per_cta
+            if _needed_ctas < 1:
+                _needed_ctas = 1
+            _should_run = (bidx < num_rows_val) and (bidy < _needed_ctas)
+        if cutlass.const_expr(self.single_pass_multi_cta):
+            # Solo fast path (needed_ctas == 1): only cta_in_group 0 has data;
+            # the rest exit silently. Because the branch is cluster-uniform
+            # (all CTAs of a cluster compute the same need_cluster_sync) no CTA
+            # waits on a cluster barrier, so this cannot deadlock. In cluster
+            # mode (need_cluster_sync) every CTA must run (no early exit).
+            if (not need_cluster_sync) and cta_in_group != 0:
+                _should_run = False
+
+        if _should_run:
+            self.filtered_topk_kernel_per_row(
+                input,
+                indices,
+                extra_buffer,
+                output_indices,
+                output_values,
+                row_start,
+                length,
+                bidx,
+                s_histogram,
+                s_counter,
+                s_threshold_bin_id,
+                s_num_input,
+                g_num_input,
+                s_indices,
+                s_input_idx,
+                s_input_val,
+                s_last_remain,
+                num_warps,
+                s_warp_sums,
+                s_overflow_flag,
+                need_cluster_sync,
+                s_hist_merged,
+                cta_in_group,
+                tma_atom=tma_atom,
+                tma_tensor=tma_tensor,
+                s_tma_stage=s_tma_stage,
+                s_tma_mbar=s_tma_mbar,
+                s_tma_stage_p3=s_tma_stage_p3,
+                s_tma_mbar_p3=s_tma_mbar_p3,
+            )
+
+        cute.arch.griddepcontrol_launch_dependents()
+
+    @cute.jit
+    def __call__(
+        self,
+        input_values,
+        indices,
+        extra_buffer,
+        seqlen,
+        output_indices,
+        output_values,
+        stream: cuda.CUstream,
+        min_blocks_per_mp: cutlass.Constexpr[int] = 1,
+    ):
+        """Host function for the filtered topk kernel"""
+        num_rows = input_values.shape[0]
+        if cutlass.const_expr(self.single_pass_multi_cta):
+            # 1D grid = num_rows * ctas_per_group; each cluster owns one row.
+            blocks = (num_rows * self.num_ctas_per_row, 1, 1)
+            cluster = (self.num_ctas_per_row, 1, 1)
+        else:
+            blocks = (num_rows, self.num_ctas_per_row, 1)
+            cluster = None
+
+        # p1/p3 async-TMA: build the cp.async.bulk (UTMALDG) atom on the 2D input; the
+        # per-CTA tile is one coarse-scan iteration's columns (num_threads * vec_size),
+        # loaded at runtime coord (row=bidx, col_tile). Off by default.
+        if cutlass.const_expr(self.enable_tma_load or self.enable_tma_load_p3):
+            tile_cols = self.num_threads_per_cta * self.vec_size
+            tma_smem_layout = cute.make_layout((1, tile_cols), stride=(tile_cols, 1))
+            tma_cta_tiler = cute.product_each(tma_smem_layout.shape)
+            tma_atom, tma_tensor = cpasync.make_tiled_tma_atom(
+                cpasync.CopyBulkTensorTileG2SOp(),
+                input_values,
+                tma_smem_layout,
+                tma_cta_tiler,
+            )
+        else:
+            tma_atom, tma_tensor = None, None
+
+        self.filtered_topk_kernel(
+            input_values,
+            indices,
+            extra_buffer,
+            seqlen,
+            output_indices,
+            output_values,
+            tma_atom,
+            tma_tensor,
+        ).launch(
+            grid=blocks,
+            block=(self.num_threads_per_cta, 1, 1),
+            cluster=cluster,
+            stream=stream,
+            use_pdl=True,
+            min_blocks_per_mp=min_blocks_per_mp,
+            # Outside large-occupancy the grid gives at most 1 block/SM, so ask
+            # for the smallest carveout (0) and let the driver pick a tier that
+            # fits one block instead of starving L1 for memory it cannot use.
+            preferred_smem_carveout=None if self._large_occupancy else 0,
+        )
+        return
+
+
+def _next_positive_power_of_2(x: int) -> int:
+    """Round up to the next power of 2 (returns x if already a power of 2)."""
+    if x <= 0:
+        return 1
+    return 1 << (x - 1).bit_length()
+
+
+_TORCH_TO_CUTLASS_DTYPE = {
+    torch.float16: cutlass.Float16,
+    torch.bfloat16: cutlass.BFloat16,
+    torch.float32: cutlass.Float32,
+}
+
+
+def _bucket_num_cols(num_cols: int) -> int:
+    """Bucket num_cols to the next power of 2 for compilation caching.
+
+    This reduces recompilations when num_cols changes slightly (e.g.,
+    KV cache length growing each decode step). Safe because num_cols
+    only affects compile-time config; actual data access is bounded
+    by seq_lens.
+    """
+    return _next_positive_power_of_2(num_cols)
+
+
+# This function is used for integration of framework, e.g. trtllm.
+compiled_filter_topk_dict = {}
+
+_TOPK_DECODE_WRAPPER_MODES = (
+    "single-cta",
+    "single-pass-multi-cta",
+    "multi-pass-multi-cta",
+)
+_SM100_MAX_CLUSTER_SIZE = 16
+
+
+def auto_cluster_size(
+    num_tokens: int,
+    num_rows: int,
+    is_fp32: bool,
+    num_sms: int | None = None,
+) -> int:
+    """Choose a one-pass cluster size."""
+    num_sms = num_sms or _get_num_sms()
+    peak = (
+        1
+        if num_tokens <= 8192 or (is_fp32 and num_tokens <= 16384)
+        else 4
+        if num_tokens <= 32768
+        else 8
+        if num_tokens <= 131072
+        else 16
+    )
+    occupancy = (
+        16
+        if num_rows <= 4
+        else 8
+        if num_rows <= 8
+        else 4
+        if num_rows <= 32
+        else 2
+        if num_rows <= 64
+        else 1
+        if num_rows <= num_sms
+        else 2
+        if num_tokens >= 262144
+        else 1
+    )
+    return min(peak, occupancy, _SM100_MAX_CLUSTER_SIZE)
+
+
+class _TopKDecodeLaunch:
+    """A compiled top-k launch and its preallocated runtime workspace."""
+
+    def __init__(
+        self,
+        launcher,
+        arguments: testing.JitArguments,
+        output_indices: torch.Tensor,
+        output_values: torch.Tensor | None,
+        workspace_tensors: tuple[torch.Tensor | None, ...],
+    ):
+        self.launcher = launcher
+        self.arguments = arguments
+        self.output_indices = output_indices
+        self.output_values = output_values
+        self.workspace_bytes = sum(
+            tensor.numel() * tensor.element_size()
+            for tensor in workspace_tensors
+            if tensor is not None
+        )
+
+    def run(self) -> tuple[torch.Tensor, torch.Tensor | None]:
+        self.launcher(*self.arguments.args, **self.arguments.kwargs)
+        return self.output_indices, self.output_values
+
+
+def _prepare_one_pass_topk(
+    input_values,
+    seq_lens,
+    top_k,
+    next_n,
+    cluster_size: int | None = None,
+    return_val=True,
+    num_copy_bits=256,
+    overflow_policy: str = "REREAD",
+    cache_smem_values: bool | None = None,
+    unroll_factor: int | None = None,
+    enable_tma_load: bool | None = None,
+    enable_tma_load_p3: bool | None = None,
+    spill_capacity: int | None = None,
+    spill_budget_bytes: int | None = None,
+):
+    torch_dtype = input_values.dtype
+    dtype = _TORCH_TO_CUTLASS_DTYPE[torch_dtype]
+    num_rows, num_cols = input_values.shape
+    bucketed_num_cols = _bucket_num_cols(num_cols)
+
+    if cluster_size is None:
+        cluster_size = auto_cluster_size(
+            num_cols,
+            num_rows,
+            dtype == cutlass.Float32,
+        )
+    if cluster_size <= 0 or cluster_size > _SM100_MAX_CLUSTER_SIZE:
+        raise ValueError(
+            f"cluster_size must be in [1, {_SM100_MAX_CLUSTER_SIZE}], "
+            f"got {cluster_size}"
+        )
+
+    single_pass_multi_cta = cluster_size > 1
+    large_occupancy = not single_pass_multi_cta and num_rows > _get_num_sms()
+    architecture, large_occupancy_min_blocks_per_mp = get_topk_architecture_config()
+    min_blocks_per_mp = large_occupancy_min_blocks_per_mp if large_occupancy else 1
+    chunk_size_per_cta = (
+        math.ceil(bucketed_num_cols / cluster_size) if single_pass_multi_cta else None
+    )
+
+    # Arch-gated tuned defaults (None == "use the tuned default for this arch").
+    # Rubin: SMEM value caching on + bytes-in-flight auto unroll. Blackwell:
+    # baseline (caching off, no unroll), keeping SM100 non-regressing.
+    is_rubin = architecture in _RUBIN_TOPK_ARCHITECTURES
+    if cache_smem_values is None:
+        cache_smem_values = is_rubin
+    if unroll_factor is None:
+        unroll_factor = 0 if is_rubin else 1
+
+    # async-TMA auto-enable (large-occupancy single-CTA path only): the tuned default
+    # (fp32 on Rubin at large N) fires only when the actual num_cols meets the TMA
+    # row-stride alignment -- divisible by 16 // dtype_bytes (fp32 -> 4, fp16/bf16 -> 8)
+    # -- so non-conforming shapes fall back to LDG instead of the descriptor ValueError.
+    # Env vars still force TMA regardless. Resolved flags go into the compile key so the
+    # same bucketed shape with different divisibility does not collide.
+    _tma_div = 16 // (dtype.width // 8)
+    _tma_ok = large_occupancy and not single_pass_multi_cta
+    _tuned_tma = (
+        tma_tuned_default(dtype, architecture, bucketed_num_cols)
+        and (num_cols % _tma_div == 0)
+        # TMA aliases the candidate buffer; REREAD_ALWAYS allocates none, so the
+        # auto default must skip it (env-forced TMA still hits the explicit guard).
+        and overflow_policy != "REREAD_ALWAYS"
+    )
+    _enable_tma_load = _tma_ok and auto_tma_load(enable_tma_load, _tuned_tma)
+    _enable_tma_load_p3 = _tma_ok and auto_tma_load(enable_tma_load_p3, _tuned_tma)
+
+    key = (
+        "single-pass-multi-cta" if single_pass_multi_cta else "single-cta",
+        dtype,
+        bucketed_num_cols,
+        top_k,
+        next_n,
+        return_val,
+        num_copy_bits,
+        cluster_size if single_pass_multi_cta else None,
+        chunk_size_per_cta,
+        large_occupancy,
+        overflow_policy,
+        cache_smem_values,
+        unroll_factor,
+        _enable_tma_load,
+        _enable_tma_load_p3,
+    )
+    if key not in compiled_filter_topk_dict:
+        n_rows = cute.sym_int()
+        _tma_on = _enable_tma_load or _enable_tma_load_p3
+        n_cols = cute.sym_int(divisibility=_tma_div) if _tma_on else cute.sym_int()
+        n_batch = cute.sym_int()
+        input_fake = cute.runtime.make_fake_compact_tensor(
+            dtype, (n_rows, n_cols), stride_order=(1, 0), assumed_align=32
+        )
+        if overflow_policy in ("GMEM_SPILL", "BOUNDED_SPILL"):
+            buffer_fake = cute.runtime.make_fake_compact_tensor(
+                cutlass.Int32,
+                (cute.sym_int(), cute.sym_int(), cute.sym_int()),
+                stride_order=(2, 1, 0),
+                assumed_align=32,
+            )
+        else:
+            buffer_fake = None
+        seqlen_fake = cute.runtime.make_fake_compact_tensor(
+            cute.Int32,
+            (n_batch,),
+            stride_order=(0,),
+        )
+        output_indices_fake = cute.runtime.make_fake_compact_tensor(
+            cutlass.Int32,
+            (n_rows, top_k),
+            stride_order=(1, 0),
+        )
+        if return_val:
+            output_values_fake = cute.runtime.make_fake_compact_tensor(
+                dtype,
+                (n_rows, top_k),
+                stride_order=(1, 0),
+            )
+        else:
+            output_values_fake = None
+        fake_stream = cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=True)
+
+        if single_pass_multi_cta:
+            filtered_topk_func = FilteredTopKKernelVarlenDecode(
+                dtype,
+                bucketed_num_cols,
+                top_k,
+                next_n,
+                num_copy_bits=num_copy_bits,
+                return_val=return_val,
+                chunk_size_per_cta=chunk_size_per_cta,
+                num_ctas_per_row=cluster_size,
+                overflow_policy=overflow_policy,
+                cache_smem_values=cache_smem_values,
+                single_pass_multi_cta=True,
+                architecture=architecture,
+                unroll_factor=unroll_factor,
+            )
+        else:
+            filtered_topk_func = FilteredTopKKernelVarlenDecode(
+                dtype,
+                bucketed_num_cols,
+                top_k,
+                next_n,
+                num_copy_bits=num_copy_bits,
+                return_val=return_val,
+                large_occupancy=large_occupancy,
+                target_blocks_per_sm=min_blocks_per_mp,
+                overflow_policy=overflow_policy,
+                cache_smem_values=cache_smem_values,
+                architecture=architecture,
+                unroll_factor=unroll_factor,
+                # num_cols-divisibility-gated resolution from above (explicit so the
+                # kernel does not re-resolve the tuned default from bucketed_num_cols).
+                enable_tma_load=_enable_tma_load,
+                enable_tma_load_p3=_enable_tma_load_p3,
+            )
+
+        compiled_kernel = cute.compile(
+            filtered_topk_func,
+            input_fake,
+            None,  # indices_fake: unused in this path; pass None to match runtime
+            buffer_fake,
+            seqlen_fake,
+            output_indices_fake,
+            output_values_fake,
+            stream=fake_stream,
+            min_blocks_per_mp=min_blocks_per_mp,
+            options="--enable-tvm-ffi",
+        )
+        compiled_filter_topk_dict[key] = compiled_kernel
+    else:
+        compiled_kernel = compiled_filter_topk_dict[key]
+
+    output_indices_torch = torch.empty(
+        num_rows, top_k, dtype=torch.int32, device="cuda"
+    )
+    if return_val:
+        output_values_torch = torch.empty(
+            num_rows, top_k, dtype=torch_dtype, device="cuda"
+        )
+    else:
+        output_values_torch = None
+
+    if overflow_policy == "GMEM_SPILL":
+        buffer_numbers = 2 if dtype == cutlass.Float32 else 1
+        buffer_rows = num_rows * cluster_size if single_pass_multi_cta else num_rows
+        buffer_cols = chunk_size_per_cta if single_pass_multi_cta else num_cols
+        buffer_torch = torch.empty(
+            buffer_rows,
+            buffer_numbers,
+            buffer_cols,
+            dtype=torch.int32,
+            device="cuda",
+        )
+    elif overflow_policy == "BOUNDED_SPILL":
+        # Size-capped spill buffer: last dim = G, host-chosen via spill_capacity
+        # and/or a total-byte budget (stricter wins); kernel reads buffer.shape[1].
+        buffer_numbers = 2 if dtype == cutlass.Float32 else 1
+        buffer_rows = num_rows * cluster_size if single_pass_multi_cta else num_rows
+        _bs_cap = chunk_size_per_cta if single_pass_multi_cta else num_cols
+        if spill_capacity is not None:
+            # Fail fast on a degenerate cap instead of silently clamping (0/negative
+            # is meaningless -- use overflow_policy=REREAD for no GMEM tier).
+            assert spill_capacity >= 1, (
+                f"spill_capacity must be >= 1, got {spill_capacity}; use "
+                "overflow_policy=REREAD for no GMEM spill tier."
+            )
+            _bs_cap = min(_bs_cap, int(spill_capacity))
+        if spill_budget_bytes is not None:
+            _bytes_per_g = buffer_rows * buffer_numbers * 4
+            assert spill_budget_bytes >= _bytes_per_g, (
+                f"spill_budget_bytes ({spill_budget_bytes}) too small to fit even "
+                f"one candidate per row; need >= {_bytes_per_g} bytes."
+            )
+            _bs_cap = min(_bs_cap, int(spill_budget_bytes) // _bytes_per_g)
+        buffer_torch = torch.empty(
+            buffer_rows,
+            buffer_numbers,
+            _bs_cap,
+            dtype=torch.int32,
+            device="cuda",
+        )
+    else:
+        buffer_torch = None
+
+    return _TopKDecodeLaunch(
+        compiled_kernel,
+        testing.JitArguments(
+            input_values,
+            None,  # indices, used for merge blocks kernel of the multi-cta.
+            buffer_torch,
+            seq_lens,
+            output_indices_torch,
+            output_values_torch,
+        ),
+        output_indices_torch,
+        output_values_torch,
+        (
+            input_values,
+            buffer_torch,
+            seq_lens,
+            output_indices_torch,
+            output_values_torch,
+        ),
+    )
+
+
+def cute_dsl_radix_filter_topk_wrapper(
+    input_values,
+    seq_lens,
+    top_k,
+    next_n,
+    return_val=True,
+    num_copy_bits=256,
+    overflow_policy: str = "REREAD",
+    cache_smem_values: bool | None = None,
+    cluster_size: int | None = None,
+    unroll_factor: int | None = None,
+    enable_tma_load: bool | None = None,
+    enable_tma_load_p3: bool | None = None,
+    spill_capacity: int | None = None,
+    spill_budget_bytes: int | None = None,
+):
+    """Compile and launch the one-pass decode wrapper.
+
+    ``cluster_size=None`` selects the cluster size automatically. A resolved size
+    of one uses the ordinary single-CTA setup.
+
+    ``cache_smem_values`` / ``unroll_factor`` / ``enable_tma_load`` /
+    ``enable_tma_load_p3`` default to ``None`` = the tuned best config for the
+    detected arch (Rubin: SMEM caching + auto unroll; async-TMA for fp32 large-occ
+    at N >= 131072). Pass explicit values to override for tuning.
+    """
+    return _prepare_one_pass_topk(
+        input_values,
+        seq_lens,
+        top_k,
+        next_n,
+        cluster_size=cluster_size,
+        return_val=return_val,
+        num_copy_bits=num_copy_bits,
+        overflow_policy=overflow_policy,
+        cache_smem_values=cache_smem_values,
+        unroll_factor=unroll_factor,
+        enable_tma_load=enable_tma_load,
+        enable_tma_load_p3=enable_tma_load_p3,
+        spill_capacity=spill_capacity,
+        spill_budget_bytes=spill_budget_bytes,
+    ).run()
+
+
+def _prepare_multi_pass_multi_cta_topk(
+    input_values,
+    seq_lens,
+    top_k,
+    next_n,
+    return_val=True,
+    num_copy_bits=256,
+    chunk_size_per_cta=16384,
+    overflow_policy: str = "REREAD",
+    cache_smem_values: bool | None = None,
+    unroll_factor: int | None = None,
+    spill_capacity: int | None = None,
+    spill_budget_bytes: int | None = None,
+):
+    torch_dtype = input_values.dtype
+    dtype = _TORCH_TO_CUTLASS_DTYPE[torch_dtype]
+    num_rows, num_cols = input_values.shape
+    bucketed_num_cols = _bucket_num_cols(num_cols)
+
+    large_occupancy = num_rows > _get_num_sms()
+    architecture, large_occupancy_min_blocks_per_mp = get_topk_architecture_config()
+    min_blocks_per_mp = large_occupancy_min_blocks_per_mp if large_occupancy else 1
+
+    # Arch-gated tuned defaults (None == "use the tuned default for this arch").
+    is_rubin = architecture in _RUBIN_TOPK_ARCHITECTURES
+    if cache_smem_values is None:
+        cache_smem_values = is_rubin
+    if unroll_factor is None:
+        unroll_factor = 0 if is_rubin else 1
+
+    # Note: don't forget num_cols, which means the maximum columns.
+    enable_multi_cta = True
+    num_ctas_per_row = math.ceil(num_cols / chunk_size_per_cta)
+    key = (
+        "multi-pass-multi-cta",
+        dtype,
+        bucketed_num_cols,
+        top_k,
+        next_n,
+        return_val,
+        num_copy_bits,
+        large_occupancy,
+        enable_multi_cta,
+        chunk_size_per_cta,
+        num_ctas_per_row,
+        overflow_policy,
+        cache_smem_values,
+        unroll_factor,
+    )
+    if key not in compiled_filter_topk_dict:
+        # Create fake tensors for compilation
+        n_rows = cute.sym_int()
+        n_cols = cute.sym_int()
+        n_batch = cute.sym_int()
+        input_fake = cute.runtime.make_fake_compact_tensor(
+            dtype, (n_rows, n_cols), stride_order=(1, 0), assumed_align=32
+        )
+        # Shared buffer for both kernels: only needed when policy spills to GMEM
+        if overflow_policy in ("GMEM_SPILL", "BOUNDED_SPILL"):
+            buffer_fake = cute.runtime.make_fake_compact_tensor(
+                cutlass.Int32,
+                (cute.sym_int(), cute.sym_int(), cute.sym_int()),
+                stride_order=(2, 1, 0),
+                assumed_align=32,
+            )
+        else:
+            buffer_fake = None
+        seqlen_fake = cute.runtime.make_fake_compact_tensor(
+            cute.Int32,
+            (n_batch,),
+            stride_order=(0,),
+        )
+        # The first stage writes a dynamic-width candidate list for the merge stage.
+        n_first_output_cols = cute.sym_int()
+        first_kernel_output_indices_fake = cute.runtime.make_fake_compact_tensor(
+            cutlass.Int32,
+            (n_rows, n_first_output_cols),
+            stride_order=(1, 0),
+        )
+        first_kernel_output_values_fake = cute.runtime.make_fake_compact_tensor(
+            dtype,
+            (n_rows, n_first_output_cols),
+            stride_order=(1, 0),
+            assumed_align=32,
+        )
+        fake_stream = cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=True)
+
+        filtered_topk_func_first = FilteredTopKKernelVarlenDecode(
+            dtype,
+            chunk_size_per_cta,  # num_cols
+            top_k,
+            next_n,
+            num_copy_bits=num_copy_bits,
+            # for the first kernel, it must return values.
+            return_val=True,
+            large_occupancy=large_occupancy,
+            enable_multi_cta=True,
+            chunk_size_per_cta=chunk_size_per_cta,
+            num_ctas_per_row=num_ctas_per_row,
+            merge_blocks=False,
+            overflow_policy=overflow_policy,
+            cache_smem_values=cache_smem_values,
+            target_blocks_per_sm=min_blocks_per_mp,
+            architecture=architecture,
+            unroll_factor=unroll_factor,
+        )
+        # Compile the kernel
+        compiled_kernel_first = cute.compile(
+            filtered_topk_func_first,
+            input_fake,
+            None,  # indices_fake: unused in this path; pass None to match runtime
+            buffer_fake,
+            seqlen_fake,
+            # output_indices_fake,
+            # output_values_fake,
+            first_kernel_output_indices_fake,
+            first_kernel_output_values_fake,
+            stream=fake_stream,
+            min_blocks_per_mp=min_blocks_per_mp,
+            options="--enable-tvm-ffi",
+        )
+
+        # The merge stage consumes the first stage's candidate indices.
+        indices_fake = cute.runtime.make_fake_compact_tensor(
+            cutlass.Int32,
+            (n_rows, n_first_output_cols),
+            stride_order=(1, 0),
+        )
+        output_indices_fake = cute.runtime.make_fake_compact_tensor(
+            cutlass.Int32,
+            (n_rows, top_k),
+            stride_order=(1, 0),
+        )
+        if return_val:
+            output_values_fake = cute.runtime.make_fake_compact_tensor(
+                dtype,
+                (n_rows, top_k),
+                stride_order=(1, 0),
+            )
+        else:
+            output_values_fake = None
+        filtered_topk_func_second = FilteredTopKKernelVarlenDecode(
+            dtype,
+            num_ctas_per_row * top_k,  # num_cols
+            top_k,
+            next_n,
+            num_copy_bits=num_copy_bits,
+            return_val=return_val,
+            large_occupancy=large_occupancy,
+            enable_multi_cta=False,
+            # chunk_size_per_cta=chunk_size_per_cta, # no use
+            # num_ctas_per_row=1, # no use
+            merge_blocks=True,
+            overflow_policy=overflow_policy,
+            cache_smem_values=cache_smem_values,
+            target_blocks_per_sm=min_blocks_per_mp,
+            architecture=architecture,
+            unroll_factor=unroll_factor,
+        )
+        # Compile the kernel
+        compiled_kernel_second = cute.compile(
+            filtered_topk_func_second,
+            input_fake,
+            indices_fake,
+            buffer_fake,
+            seqlen_fake,
+            output_indices_fake,
+            output_values_fake,
+            stream=fake_stream,
+            min_blocks_per_mp=min_blocks_per_mp,
+            options="--enable-tvm-ffi",
+        )
+
+        compiled_filter_topk_dict[key] = (compiled_kernel_first, compiled_kernel_second)
+    else:
+        compiled_kernel_first, compiled_kernel_second = compiled_filter_topk_dict[key]
+
+    first_kernel_output_indices_torch = torch.empty(
+        num_rows, num_ctas_per_row * top_k, dtype=torch.int32, device="cuda"
+    )
+    first_kernel_output_values_torch = torch.empty(
+        num_rows, num_ctas_per_row * top_k, dtype=torch_dtype, device="cuda"
+    )
+    output_indices_torch = torch.empty(
+        num_rows, top_k, dtype=torch.int32, device="cuda"
+    )
+    if return_val:
+        output_values_torch = torch.empty(
+            num_rows, top_k, dtype=torch_dtype, device="cuda"
+        )
+    else:
+        output_values_torch = None
+
+    if overflow_policy == "GMEM_SPILL":
+        buffer_numbers = 2 if dtype == cutlass.Float32 else 1
+        buffer_torch = torch.empty(
+            num_rows * num_ctas_per_row,
+            buffer_numbers,
+            max(chunk_size_per_cta, num_ctas_per_row * top_k),
+            dtype=torch.int32,
+            device="cuda",
+        )
+    elif overflow_policy == "BOUNDED_SPILL":
+        # Size-capped spill buffer (last dim = G); host caps G via spill_capacity
+        # and/or spill_budget_bytes (stricter wins). Kernel reads buffer.shape[1].
+        buffer_numbers = 2 if dtype == cutlass.Float32 else 1
+        _bs_rows = num_rows * num_ctas_per_row
+        _bs_cap = max(chunk_size_per_cta, num_ctas_per_row * top_k)
+        if spill_capacity is not None:
+            assert spill_capacity >= 1, (
+                f"spill_capacity must be >= 1, got {spill_capacity}; use "
+                "overflow_policy=REREAD for no GMEM spill tier."
+            )
+            _bs_cap = min(_bs_cap, int(spill_capacity))
+        if spill_budget_bytes is not None:
+            _bytes_per_g = _bs_rows * buffer_numbers * 4
+            assert spill_budget_bytes >= _bytes_per_g, (
+                f"spill_budget_bytes ({spill_budget_bytes}) too small to fit even "
+                f"one candidate per row; need >= {_bytes_per_g} bytes."
+            )
+            _bs_cap = min(_bs_cap, int(spill_budget_bytes) // _bytes_per_g)
+        buffer_torch = torch.empty(
+            _bs_rows,
+            buffer_numbers,
+            _bs_cap,
+            dtype=torch.int32,
+            device="cuda",
+        )
+    else:
+        buffer_torch = None
+
+    def launch_multi_pass(
+        first_kernel_args: testing.JitArguments,
+        second_kernel_args: testing.JitArguments,
+    ):
+        compiled_kernel_first(
+            *first_kernel_args.args,
+            **first_kernel_args.kwargs,
+        )
+        compiled_kernel_second(
+            *second_kernel_args.args,
+            **second_kernel_args.kwargs,
+        )
+
+    first_kernel_args = testing.JitArguments(
+        input_values,
+        None,  # indices, used for merge blocks kernel of the multi-cta.
+        buffer_torch,
+        seq_lens,
+        first_kernel_output_indices_torch,
+        first_kernel_output_values_torch,
+    )
+    second_kernel_args = testing.JitArguments(
+        first_kernel_output_values_torch,
+        first_kernel_output_indices_torch,
+        buffer_torch,
+        seq_lens,
+        output_indices_torch,
+        output_values_torch,
+    )
+    return _TopKDecodeLaunch(
+        launch_multi_pass,
+        testing.JitArguments(first_kernel_args, second_kernel_args),
+        output_indices_torch,
+        output_values_torch,
+        (
+            input_values,
+            buffer_torch,
+            seq_lens,
+            first_kernel_output_indices_torch,
+            first_kernel_output_values_torch,
+            output_indices_torch,
+            output_values_torch,
+        ),
+    )
+
+
+def cute_dsl_radix_filter_topk_multi_cta_wrapper(
+    input_values,
+    seq_lens,
+    top_k,
+    next_n,
+    return_val=True,
+    num_copy_bits=256,
+    chunk_size_per_cta=None,
+    overflow_policy: str = "REREAD",
+    cache_smem_values: bool | None = None,
+    unroll_factor: int | None = None,
+):
+    """Compile and launch the two-pass multi-CTA decode wrapper.
+
+    ``cache_smem_values`` / ``unroll_factor`` default to ``None``, which selects
+    the tuned best configuration for the detected architecture (Rubin: SMEM value
+    caching + bytes-in-flight auto unroll; Blackwell: baseline).
+    """
+    if chunk_size_per_cta is None:
+        chunk_size_per_cta = _multi_pass_chunk_size(top_k)
+
+    return _prepare_multi_pass_multi_cta_topk(
+        input_values,
+        seq_lens,
+        top_k,
+        next_n,
+        return_val,
+        num_copy_bits,
+        chunk_size_per_cta,
+        overflow_policy,
+        cache_smem_values,
+        unroll_factor,
+    ).run()
+
+
+def _multi_pass_chunk_size(top_k: int) -> int:
+    """Choose a first-stage chunk that can emit top_k candidates."""
+    return max(8192, _next_positive_power_of_2(top_k))
+
+
+def _run_topk_decode_wrapper(
+    input_values,
+    seq_lens,
+    top_k,
+    next_n,
+    wrapper_mode,
+    cluster_size,
+    return_val,
+    num_copy_bits,
+    overflow_policy,
+    cache_smem_values,
+    unroll_factor,
+    enable_tma_load=None,
+    enable_tma_load_p3=None,
+    spill_capacity=None,
+    spill_budget_bytes=None,
+):
+    if wrapper_mode != "multi-pass-multi-cta":
+        return cute_dsl_radix_filter_topk_wrapper(
+            input_values,
+            seq_lens,
+            top_k,
+            next_n,
+            return_val=return_val,
+            num_copy_bits=num_copy_bits,
+            overflow_policy=overflow_policy,
+            cache_smem_values=cache_smem_values,
+            cluster_size=1 if wrapper_mode == "single-cta" else cluster_size,
+            unroll_factor=unroll_factor,
+            enable_tma_load=enable_tma_load,
+            enable_tma_load_p3=enable_tma_load_p3,
+            spill_capacity=spill_capacity,
+            spill_budget_bytes=spill_budget_bytes,
+        )
+    return cute_dsl_radix_filter_topk_multi_cta_wrapper(
+        input_values,
+        seq_lens,
+        top_k,
+        next_n,
+        return_val,
+        num_copy_bits,
+        _multi_pass_chunk_size(top_k),
+        overflow_policy,
+        cache_smem_values,
+        unroll_factor,
+    )
+
+
+def _prepare_topk_decode_wrapper(
+    input_values,
+    seq_lens,
+    top_k,
+    next_n,
+    wrapper_mode,
+    cluster_size,
+    return_val,
+    num_copy_bits,
+    overflow_policy,
+    cache_smem_values,
+    unroll_factor,
+    enable_tma_load=None,
+    enable_tma_load_p3=None,
+    spill_capacity=None,
+    spill_budget_bytes=None,
+):
+    if wrapper_mode != "multi-pass-multi-cta":
+        return _prepare_one_pass_topk(
+            input_values,
+            seq_lens,
+            top_k,
+            next_n,
+            cluster_size=1 if wrapper_mode == "single-cta" else cluster_size,
+            return_val=return_val,
+            num_copy_bits=num_copy_bits,
+            overflow_policy=overflow_policy,
+            cache_smem_values=cache_smem_values,
+            unroll_factor=unroll_factor,
+            enable_tma_load=enable_tma_load,
+            enable_tma_load_p3=enable_tma_load_p3,
+            spill_capacity=spill_capacity,
+            spill_budget_bytes=spill_budget_bytes,
+        )
+    return _prepare_multi_pass_multi_cta_topk(
+        input_values,
+        seq_lens,
+        top_k,
+        next_n,
+        return_val,
+        num_copy_bits,
+        _multi_pass_chunk_size(top_k),
+        overflow_policy,
+        cache_smem_values,
+        unroll_factor,
+    )
+
+
+def generate_seq_lens(batch_size, num_tokens):
+    """Draw decode sequence lengths uniformly from [1, num_tokens].
+
+    A sizeable fraction of rows therefore ends up shorter than top_k, which is
+    the degenerate extent the kernel must still handle correctly.
+    """
+    return torch.randint(
+        1, num_tokens + 1, (batch_size,), dtype=torch.int32, device="cuda"
+    )
+
+
+def run_filtered_topk_decode(
+    dtype: type[cutlass.Numeric],
+    batch_size: int,
+    max_num_cols: int,
+    top_k: int,
+    next_n: int,
+    num_copy_bits: int = 256,
+    return_val: bool = True,
+    do_ref_check: bool = True,
+    do_benchmark: bool = False,
+    warmup_iterations: int = 10,
+    iterations: int = 100,
+    use_cold_l2: bool = True,
+    print_verbose: bool = True,
+    overflow_policy: str = "GMEM_SPILL",
+    cache_smem_values: bool = False,
+    variable_lengths: bool = True,
+    wrapper_mode: str = "single-cta",
+    cluster_size: int | None = None,
+    unroll_factor: int | None = None,
+    enable_tma_load: bool | None = None,
+    enable_tma_load_p3: bool | None = None,
+    spill_capacity: int | None = None,
+    spill_budget_bytes: int | None = None,
+) -> None:
+    """Run correctness checks and benchmarks through one decode wrapper."""
+    if wrapper_mode not in _TOPK_DECODE_WRAPPER_MODES:
+        raise ValueError(
+            f"wrapper_mode must be one of {_TOPK_DECODE_WRAPPER_MODES}, "
+            f"got {wrapper_mode!r}"
+        )
+    if print_verbose:
+        print("=" * 60)
+        print("Launching Blackwell Filtered TopK Test")
+        print("-" * 60)
+        print(f"Data Types & Precision: {dtype}")
+        print(f"    Input matrix: {dtype}")
+        print(f"    Output indices: {cutlass.Int32}")
+        print(f"    Output values: {dtype}")
+        print(
+            f"Input dimensions (batch_size, max_num_cols, top_k): {batch_size, max_num_cols, top_k}"
+        )
+        print(f"    batch_size: {batch_size}")
+        print(f"    next_n: {next_n}")
+        print(f"    max_num_cols: {max_num_cols}")
+        print(f"    top_k: {top_k}")
+        print(f"    num_copy_bits: {num_copy_bits}")
+        print(f"    return_val: {return_val}")
+        print(f"    variable_lengths: {variable_lengths}")
+        print(f"    wrapper_mode: {wrapper_mode}")
+        if wrapper_mode == "single-pass-multi-cta":
+            print(
+                f"    cluster_size: {'auto' if cluster_size is None else cluster_size}"
+            )
+        elif wrapper_mode == "multi-pass-multi-cta":
+            print(f"    chunk_size_per_cta: {_multi_pass_chunk_size(top_k)}")
+        print(f"Do reference checking: {do_ref_check}")
+        print(f"Do benchmark: {do_benchmark}")
+        print(f"Warmup iterations: {warmup_iterations}")
+        print(f"Iterations: {iterations}")
+        print(f"Use cold L2: {use_cold_l2}")
+        print("=" * 60)
+
+    if not torch.cuda.is_available():
+        raise RuntimeError("GPU is required to run this example!")
+
+    seed = 1111
+    torch.manual_seed(seed)
+    torch.cuda.manual_seed(seed)
+
+    # Set input data
+    # num_gen_tokens is the number of rows in the input tensor
+    torch.cuda.synchronize()
+    num_gen_tokens = batch_size * next_n  # Use the same variable name as dsa.py
+    row_starts = torch.zeros(num_gen_tokens, dtype=torch.int32, device="cuda")
+    row_indices = torch.arange(num_gen_tokens, device="cuda") // next_n
+    next_n_offset = torch.arange(num_gen_tokens, device="cuda") % next_n
+
+    # max_num_cols is the maximum col length in the input tensor
+    if variable_lengths:
+        # clamp(min=next_n) keeps the row_ends arithmetic below well formed and
+        # is a no-op for next_n == 1.
+        seq_lens = generate_seq_lens(batch_size, max_num_cols).clamp(min=next_n)
+    else:
+        seq_lens = torch.full(
+            (batch_size,), max_num_cols, dtype=torch.int32, device="cuda"
+        )
+    row_ends = seq_lens[row_indices] - next_n + next_n_offset + 1
+    row_ends = row_ends.to(torch.int32)
+
+    def create_input_tensor() -> torch.Tensor:
+        input_tensor = create_random_logits(
+            row_starts,
+            row_ends,
+            torch_dtype(dtype),
+            seed,
+        )
+        if input_tensor.shape[1] == max_num_cols:
+            return input_tensor
+
+        padded_input = torch.full(
+            (num_gen_tokens, max_num_cols),
+            float("-inf"),
+            dtype=torch_dtype(dtype),
+            device="cuda",
+        )
+        padded_input[:, : input_tensor.shape[1]] = input_tensor
+        return padded_input
+
+    input_torch = create_input_tensor()
+    output_indices_torch, output_values_torch = _run_topk_decode_wrapper(
+        input_torch,
+        seq_lens,
+        top_k,
+        next_n,
+        wrapper_mode,
+        cluster_size,
+        return_val,
+        num_copy_bits,
+        overflow_policy,
+        cache_smem_values,
+        unroll_factor,
+        enable_tma_load,
+        enable_tma_load_p3,
+        spill_capacity,
+        spill_budget_bytes,
+    )
+
+    if do_ref_check:
+        torch.cuda.synchronize()
+        torch_indices = run_reference_top_k(input_torch, row_starts, row_ends, top_k)
+        assert compare_top_k_results(
+            input_torch,
+            output_indices_torch,
+            torch_indices,
+            row_starts,
+            row_ends,
+            top_k,
+        ), f"{wrapper_mode} results don't match torch.topk"
+
+        if return_val:
+            valid_mask = output_indices_torch != -1
+            output_rows = torch.arange(num_gen_tokens, device="cuda")[:, None]
+            output_rows = output_rows.expand_as(output_indices_torch)
+            absolute_indices = output_indices_torch + row_starts[:, None]
+            expected_values = input_torch[
+                output_rows[valid_mask],
+                absolute_indices[valid_mask],
+            ]
+            assert torch.allclose(
+                output_values_torch[valid_mask],
+                expected_values,
+                rtol=1e-5,
+                atol=1e-5,
+            ), f"{wrapper_mode} returned values that do not match its indices"
+            assert torch.isneginf(output_values_torch[~valid_mask]).all(), (
+                f"{wrapper_mode} did not write -inf for invalid outputs"
+            )
+
+        if print_verbose:
+            print(f"{wrapper_mode}: PASSED")
+
+    if do_benchmark:
+        torch.cuda.synchronize()
+        benchmark_launch = _prepare_topk_decode_wrapper(
+            input_torch,
+            seq_lens,
+            top_k,
+            next_n,
+            wrapper_mode,
+            cluster_size,
+            return_val,
+            num_copy_bits,
+            overflow_policy,
+            cache_smem_values,
+            unroll_factor,
+            enable_tma_load,
+            enable_tma_load_p3,
+            spill_capacity,
+            spill_budget_bytes,
+        )
+        use_prepared_workspace = True
+
+        def generate_inputs() -> testing.JitArguments:
+            nonlocal use_prepared_workspace
+            if use_prepared_workspace:
+                use_prepared_workspace = False
+                return benchmark_launch.arguments
+
+            input_tensor = create_input_tensor()
+            return _prepare_topk_decode_wrapper(
+                input_tensor,
+                seq_lens.clone(),
+                top_k,
+                next_n,
+                wrapper_mode,
+                cluster_size,
+                return_val,
+                num_copy_bits,
+                overflow_policy,
+                cache_smem_values,
+                unroll_factor,
+                enable_tma_load,
+                enable_tma_load_p3,
+                spill_capacity,
+                spill_budget_bytes,
+            ).arguments
+
+        workspace_count = (
+            testing.get_workspace_count(
+                benchmark_launch.workspace_bytes,
+                warmup_iterations,
+                iterations,
+            )
+            if use_cold_l2
+            else 1
+        )
+        if print_verbose:
+            print(f"Workspace count: {workspace_count}")
+        torch_stream = torch.cuda.Stream()
+        benchmark_stream = cuda.CUstream(torch_stream.cuda_stream)
+        with torch.cuda.stream(torch_stream):
+            time = testing.benchmark(
+                benchmark_launch.launcher,
+                workspace_generator=generate_inputs,
+                workspace_count=workspace_count,
+                warmup_iterations=warmup_iterations,
+                iterations=iterations,
+                use_cuda_graphs=True,
+                stream=benchmark_stream,
+            )
+        if print_verbose:
+            print(f"Time: {time} us")
+        print(f"{wrapper_mode}-{dtype}-{batch_size}-{max_num_cols}-{top_k} {time}")
+    torch.cuda.synchronize()
+
+
+def run_topk_decode(
+    dtype: type[cutlass.Numeric],
+    batch_size: int,
+    max_num_cols: int,
+    top_k: int,
+    next_n: int,
+    num_copy_bits: int = 256,
+    return_val: bool = True,
+    do_ref_check: bool = True,
+    do_benchmark: bool = False,
+    warmup_iterations: int = 10,
+    iterations: int = 100,
+    use_cold_l2: bool = True,
+    overflow_policy: str = "GMEM_SPILL",
+    cache_smem_values: bool = False,
+    variable_lengths: bool = True,
+    wrapper_mode: str = "single-cta",
+    cluster_size: int | None = None,
+    unroll_factor: int | None = None,
+    enable_tma_load: bool | None = None,
+    enable_tma_load_p3: bool | None = None,
+    spill_capacity: int | None = None,
+    spill_budget_bytes: int | None = None,
+) -> None:
+    run_filtered_topk_decode(
+        dtype=dtype,
+        batch_size=batch_size,
+        max_num_cols=max_num_cols,
+        top_k=top_k,
+        next_n=next_n,
+        num_copy_bits=num_copy_bits,
+        return_val=return_val,
+        do_ref_check=do_ref_check,
+        do_benchmark=do_benchmark,
+        warmup_iterations=warmup_iterations,
+        iterations=iterations,
+        use_cold_l2=use_cold_l2,
+        overflow_policy=overflow_policy,
+        cache_smem_values=cache_smem_values,
+        variable_lengths=variable_lengths,
+        wrapper_mode=wrapper_mode,
+        cluster_size=cluster_size,
+        unroll_factor=unroll_factor,
+        enable_tma_load=enable_tma_load,
+        enable_tma_load_p3=enable_tma_load_p3,
+        spill_capacity=spill_capacity,
+        spill_budget_bytes=spill_budget_bytes,
+    )
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="Blackwell CuTE DSL filtered top-k decode benchmark."
+    )
+    parser.add_argument(
+        "--dtype",
+        type=cutlass.dtype,
+        default=cutlass.Float32,
+        choices=[cutlass.Float32, cutlass.Float16, cutlass.BFloat16],
+        help="Data type of the input matrix",
+    )
+    parser.add_argument(
+        "--batch_size",
+        type=int,
+        default=16,
+        help="batch_size",
+    )
+    parser.add_argument("--max_num_cols", type=int, default=4096, help="max_num_cols")
+    parser.add_argument("--next_n", type=int, default=3, help="next_n")
+    parser.add_argument("--top_k", type=int, default=2048, help="top_k")
+    parser.add_argument(
+        "--num_copy_bits",
+        type=int,
+        default=256,
+        help="num_copy_bits, used for vectorization",
+    )
+    parser.add_argument(
+        "--return_val",
+        action="store_true",
+        default=False,
+        help="Return values",
+    )
+    parser.add_argument(
+        "--wrapper-mode",
+        "--wrapper_mode",
+        choices=_TOPK_DECODE_WRAPPER_MODES,
+        default="single-cta",
+        help="Decode wrapper implementation to run",
+    )
+    parser.add_argument(
+        "--cluster-size",
+        "--cluster_size",
+        type=int,
+        default=None,
+        help=(
+            "CTA cluster size for single-pass-multi-cta; automatically selected "
+            f"when omitted (maximum {_SM100_MAX_CLUSTER_SIZE})"
+        ),
+    )
+    parser.add_argument(
+        "--do_ref_check",
+        action="store_true",
+        default=False,
+        help="Do reference checking",
+    )
+    parser.add_argument(
+        "--benchmark",
+        "--do_benchmark",
+        dest="do_benchmark",
+        action="store_true",
+        default=False,
+        help="Run the benchmark",
+    )
+    parser.add_argument(
+        "--warmup",
+        "--warmup_iterations",
+        dest="warmup_iterations",
+        type=int,
+        default=10,
+        help="Warmup iterations",
+    )
+    parser.add_argument("--iterations", type=int, default=100, help="Iterations")
+    parser.add_argument(
+        "--no-cold-l2",
+        dest="use_cold_l2",
+        action="store_false",
+        help="Disable cold L2 cache simulation",
+    )
+    parser.add_argument(
+        "--use_cold_l2",
+        dest="use_cold_l2",
+        action="store_true",
+        help=argparse.SUPPRESS,
+    )
+    parser.set_defaults(use_cold_l2=True)
+    parser.add_argument(
+        "--overflow_policy",
+        type=str,
+        default="GMEM_SPILL",
+        choices=["GMEM_SPILL", "TRUNCATE", "REREAD", "REREAD_ALWAYS", "BOUNDED_SPILL"],
+        help="Overflow policy when candidates exceed SMEM capacity",
+    )
+    parser.add_argument(
+        "--spill_capacity",
+        type=int,
+        default=None,
+        help="BOUNDED_SPILL: per-row GMEM candidate capacity G (upper bound)",
+    )
+    parser.add_argument(
+        "--spill_budget_bytes",
+        type=int,
+        default=None,
+        help="BOUNDED_SPILL: total GMEM scratch byte budget; caps G to fit the budget",
+    )
+    parser.add_argument(
+        "--cache_smem_values",
+        action="store_true",
+        default=False,
+        help="Cache ordered values alongside indices in SMEM to avoid re-reading from GMEM in refinement rounds",
+    )
+    parser.add_argument(
+        "--length_mode",
+        "--length-mode",
+        dest="length_mode",
+        type=str,
+        default="fixlen",
+        choices=["fixlen", "varlen"],
+        help=(
+            "Sequence length distribution: fixlen gives every sequence "
+            "max_num_cols; varlen draws seq_lens uniformly from "
+            "[1, max_num_cols], so many rows end up shorter than top_k"
+        ),
+    )
+
+    def _parse_unroll_factor(value):
+        # "auto" -> None: pick the arch-tuned default (Rubin: bytes-in-flight
+        # auto; Blackwell: baseline uf=1). Otherwise an explicit 1/2/4/8.
+        if value == "auto":
+            return None
+        try:
+            iv = int(value)
+        except ValueError:
+            iv = None
+        if iv not in (1, 2, 4, 8):
+            raise argparse.ArgumentTypeError(
+                f"--unroll_factor must be 'auto' or one of 1,2,4,8; got {value!r}"
+            )
+        return iv
+
+    parser.add_argument(
+        "--unroll_factor",
+        "--unroll-factor",
+        dest="unroll_factor",
+        type=_parse_unroll_factor,
+        default=None,
+        metavar="{auto,1,2,4,8}",
+        help=(
+            "load-instruction unroll factor for the coarse/filter input scans. Default 'auto' "
+            "picks the arch-tuned factor (bytes-in-flight on Rubin, baseline uf=1 "
+            "on Blackwell). 1 = original baseline (1-in-flight while); 2/4/8 "
+            "overlap that many loads for memory-level parallelism"
+        ),
+    )
+
+    def _parse_tma(value):
+        # auto -> None (tuned default: async-TMA for fp32 large-occ at N>=131072).
+        return {"auto": None, "on": True, "off": False}[value]
+
+    parser.add_argument(
+        "--enable_tma_load",
+        "--enable-tma-load",
+        dest="enable_tma_load",
+        type=_parse_tma,
+        default=None,
+        metavar="{auto,on,off}",
+        help="p1 async-TMA load (large-occupancy path only). auto = tuned default.",
+    )
+    parser.add_argument(
+        "--enable_tma_load_p3",
+        "--enable-tma-load-p3",
+        dest="enable_tma_load_p3",
+        type=_parse_tma,
+        default=None,
+        metavar="{auto,on,off}",
+        help="p3 async-TMA load (large-occupancy path only). auto = tuned default.",
+    )
+
+    args = parser.parse_args()
+    run_topk_decode(
+        variable_lengths=(args.length_mode == "varlen"),
+        dtype=args.dtype,
+        batch_size=args.batch_size,
+        max_num_cols=args.max_num_cols,
+        top_k=args.top_k,
+        next_n=args.next_n,
+        num_copy_bits=args.num_copy_bits,
+        return_val=args.return_val,
+        do_ref_check=args.do_ref_check,
+        do_benchmark=args.do_benchmark,
+        warmup_iterations=args.warmup_iterations,
+        iterations=args.iterations,
+        use_cold_l2=args.use_cold_l2,
+        overflow_policy=args.overflow_policy,
+        spill_capacity=args.spill_capacity,
+        spill_budget_bytes=args.spill_budget_bytes,
+        cache_smem_values=args.cache_smem_values,
+        wrapper_mode=args.wrapper_mode,
+        cluster_size=args.cluster_size,
+        unroll_factor=args.unroll_factor,
+        enable_tma_load=args.enable_tma_load,
+        enable_tma_load_p3=args.enable_tma_load_p3,
+    )

--- a/flashinfer/topk_varlen/kernels/filtered_topk_decode.py
+++ b/flashinfer/topk_varlen/kernels/filtered_topk_decode.py
@@ -784,6 +784,8 @@ def _prepare_one_pass_topk(
     enable_tma_load_p3: bool | None = None,
     spill_capacity: int | None = None,
     spill_budget_bytes: int | None = None,
+    out_indices=None,
+    out_values=None,
 ):
     torch_dtype = input_values.dtype
     dtype = _TORCH_TO_CUTLASS_DTYPE[torch_dtype]
@@ -959,13 +961,37 @@ def _prepare_one_pass_topk(
     else:
         compiled_kernel = compiled_filter_topk_dict[key]
 
-    output_indices_torch = torch.empty(
-        num_rows, top_k, dtype=torch.int32, device="cuda"
-    )
-    if return_val:
-        output_values_torch = torch.empty(
-            num_rows, top_k, dtype=torch_dtype, device="cuda"
+    # Kernel-writable destinations. Caller-provided buffers are used
+    # directly (the kernel writes every slot, including -1 / -inf padding,
+    # so no stale data survives); otherwise allocate on the INPUT device --
+    # not the ambient one -- so multi-GPU callers get outputs next to their
+    # data. DIVERGENCE FROM UPSTREAM (internal-only allocation), after
+    # review (flashinfer PR #4621): threading the buffers through avoids a
+    # full num_rows x top_k allocate+copy per public call and gives
+    # CUDA-graph users stable destinations.
+    def _as_out(buf, dtype_, what):
+        if buf is None:
+            return None
+        if not (buf.is_cuda and buf.dtype == dtype_):
+            raise ValueError(f"{what} must be a CUDA {dtype_} tensor")
+        if buf.numel() != num_rows * top_k or not buf.is_contiguous():
+            raise ValueError(
+                f"{what} must be contiguous with numel == num_rows * top_k "
+                f"({num_rows * top_k}), got numel={buf.numel()}"
+            )
+        return buf.view(num_rows, top_k)
+
+    output_indices_torch = _as_out(out_indices, torch.int32, "out_indices")
+    if output_indices_torch is None:
+        output_indices_torch = torch.empty(
+            num_rows, top_k, dtype=torch.int32, device=input_values.device
         )
+    if return_val:
+        output_values_torch = _as_out(out_values, torch_dtype, "out_values")
+        if output_values_torch is None:
+            output_values_torch = torch.empty(
+                num_rows, top_k, dtype=torch_dtype, device=input_values.device
+            )
     else:
         output_values_torch = None
 
@@ -1048,6 +1074,8 @@ def cute_dsl_radix_filter_topk_wrapper(
     enable_tma_load_p3: bool | None = None,
     spill_capacity: int | None = None,
     spill_budget_bytes: int | None = None,
+    out_indices=None,
+    out_values=None,
 ):
     """Compile and launch the one-pass decode wrapper.
 
@@ -1074,6 +1102,8 @@ def cute_dsl_radix_filter_topk_wrapper(
         enable_tma_load_p3=enable_tma_load_p3,
         spill_capacity=spill_capacity,
         spill_budget_bytes=spill_budget_bytes,
+        out_indices=out_indices,
+        out_values=out_values,
     ).run()
 
 

--- a/flashinfer/topk_varlen/kernels/filtered_topk_decode.py
+++ b/flashinfer/topk_varlen/kernels/filtered_topk_decode.py
@@ -863,8 +863,17 @@ def _prepare_one_pass_topk(
         _tma_on = _enable_tma_load or _enable_tma_load_p3
         n_cols = cute.sym_int(divisibility=_tma_div) if _tma_on else cute.sym_int()
         n_batch = cute.sym_int()
-        input_fake = cute.runtime.make_fake_compact_tensor(
-            dtype, (n_rows, n_cols), stride_order=(1, 0), assumed_align=32
+        # Symbolic leading stride: a padded row view (stride0 > n_cols, e.g.
+        # a framework's score buffer sliced to the vocab width) is part of
+        # the declared ABI, zero-copy. Inner stride stays 1 and the base
+        # stays 32-byte aligned; the public wrapper materializes inputs
+        # violating those. DIVERGENCE FROM UPSTREAM (compact-only fake),
+        # after review (flashinfer PR #4621).
+        input_fake = cute.runtime.make_fake_tensor(
+            dtype,
+            (n_rows, n_cols),
+            stride=(cute.sym_int64(), 1),
+            assumed_align=32,
         )
         if overflow_policy in ("GMEM_SPILL", "BOUNDED_SPILL"):
             buffer_fake = cute.runtime.make_fake_compact_tensor(
@@ -1123,8 +1132,17 @@ def _prepare_multi_pass_multi_cta_topk(
         n_rows = cute.sym_int()
         n_cols = cute.sym_int()
         n_batch = cute.sym_int()
-        input_fake = cute.runtime.make_fake_compact_tensor(
-            dtype, (n_rows, n_cols), stride_order=(1, 0), assumed_align=32
+        # Symbolic leading stride: a padded row view (stride0 > n_cols, e.g.
+        # a framework's score buffer sliced to the vocab width) is part of
+        # the declared ABI, zero-copy. Inner stride stays 1 and the base
+        # stays 32-byte aligned; the public wrapper materializes inputs
+        # violating those. DIVERGENCE FROM UPSTREAM (compact-only fake),
+        # after review (flashinfer PR #4621).
+        input_fake = cute.runtime.make_fake_tensor(
+            dtype,
+            (n_rows, n_cols),
+            stride=(cute.sym_int64(), 1),
+            assumed_align=32,
         )
         # Shared buffer for both kernels: only needed when policy spills to GMEM
         if overflow_policy in ("GMEM_SPILL", "BOUNDED_SPILL"):

--- a/flashinfer/topk_varlen/kernels/filtered_topk_decode.py
+++ b/flashinfer/topk_varlen/kernels/filtered_topk_decode.py
@@ -1077,6 +1077,17 @@ def cute_dsl_radix_filter_topk_wrapper(
     ).run()
 
 
+# KNOWN LIMITATION (flashinfer PR #4621 review): the merge stage scans the
+# fixed num_ctas_per_row * top_k candidate width, which includes stage-one
+# padding. Padded (-1, -inf) entries and genuinely valid -inf elements have
+# identical radix keys, so when a row contains valid -inf values among its
+# top-k, the merge can emit -1 for slots that had valid candidates. A correct
+# fix needs either a pad encoding that sorts strictly below -inf (which would
+# change the shared trivial-branch padding and the -inf output contract) or
+# index-aware masking in the shared hot scan loops -- both cross-stage
+# redesigns belonging upstream. This path is NOT reachable from
+# flashinfer's public top_k_varlen (the wrapper uses the one-pass path
+# exclusively); do not route public traffic here until fixed.
 def _prepare_multi_pass_multi_cta_topk(
     input_values,
     seq_lens,

--- a/flashinfer/topk_varlen/kernels/filtered_topk_decode.py
+++ b/flashinfer/topk_varlen/kernels/filtered_topk_decode.py
@@ -80,6 +80,48 @@ def _get_num_sms(device: torch.device | None = None) -> int:
     return cache[idx]
 
 
+def _compile_cc(device: torch.device) -> str:
+    """Compute-capability tag for the compile cache keys (e.g. ``"sm100"``).
+
+    Both the in-process dict and the on-disk artifact are architecture
+    specific (SMEM sizing, occupancy config, cluster limits), so identical
+    shapes compiled on one GPU must not be reused on a different architecture
+    in the same process. DIVERGENCE FROM UPSTREAM, after review (flashinfer
+    PR #4621).
+    """
+    major, minor = torch.cuda.get_device_capability(device)
+    return f"sm{major}{minor}"
+
+
+def _persistent_compile(kernel_name: str, compile_fn):
+    """Route a ``cute.compile`` through FlashInfer's persistent JIT cache.
+
+    ``build_and_load_cute_dsl_kernel`` adds what a bare ``cute.compile``
+    lacks: an on-disk artifact keyed by architecture and DSL version,
+    cross-process locking, source-hash invalidation over the three files this
+    kernel is built from, and ``FLASHINFER_DISABLE_JIT`` support -- without it
+    every new process (e.g. each SGLang worker) recompiles on first use.
+    DIVERGENCE FROM UPSTREAM, after review (flashinfer PR #4621).
+    """
+    from ...jit.cute_dsl_core import build_and_load_cute_dsl_kernel  # noqa: PLC0415
+
+    from . import block_scan as _block_scan  # noqa: PLC0415
+    from . import filtered_topk_util as _util  # noqa: PLC0415
+
+    return build_and_load_cute_dsl_kernel(
+        "radix_filter_topk",
+        kernel_name,
+        compile_fn,
+        extra_key_files=(__file__, _util.__file__, _block_scan.__file__),
+    )
+
+
+def _kernel_name_from_key(key: tuple) -> str:
+    """Filename-safe specialization name derived from a compile-cache key."""
+    raw = "_".join(str(k) for k in key)
+    return "".join(ch if (ch.isalnum() or ch in "._") else "-" for ch in raw)
+
+
 """
 A high-performance topk kernel example based on radix-based filter algorithm for
 the NVIDIA Blackwell SM100 architecture based on CuTe DSL.
@@ -799,6 +841,7 @@ def _prepare_one_pass_topk(
     _enable_tma_load_p3 = _tma_ok and auto_tma_load(enable_tma_load_p3, _tuned_tma)
 
     key = (
+        _compile_cc(input_values.device),
         "single-pass-multi-cta" if single_pass_multi_cta else "single-cta",
         dtype,
         bucketed_num_cols,
@@ -888,17 +931,20 @@ def _prepare_one_pass_topk(
                 enable_tma_load_p3=_enable_tma_load_p3,
             )
 
-        compiled_kernel = cute.compile(
-            filtered_topk_func,
-            input_fake,
-            None,  # indices_fake: unused in this path; pass None to match runtime
-            buffer_fake,
-            seqlen_fake,
-            output_indices_fake,
-            output_values_fake,
-            stream=fake_stream,
-            min_blocks_per_mp=min_blocks_per_mp,
-            options="--enable-tvm-ffi",
+        compiled_kernel = _persistent_compile(
+            _kernel_name_from_key(key),
+            lambda: cute.compile(
+                filtered_topk_func,
+                input_fake,
+                None,  # indices_fake: unused in this path
+                buffer_fake,
+                seqlen_fake,
+                output_indices_fake,
+                output_values_fake,
+                stream=fake_stream,
+                min_blocks_per_mp=min_blocks_per_mp,
+                options="--enable-tvm-ffi",
+            ),
         )
         compiled_filter_topk_dict[key] = compiled_kernel
     else:
@@ -1056,6 +1102,7 @@ def _prepare_multi_pass_multi_cta_topk(
     enable_multi_cta = True
     num_ctas_per_row = math.ceil(num_cols / chunk_size_per_cta)
     key = (
+        _compile_cc(input_values.device),
         "multi-pass-multi-cta",
         dtype,
         bucketed_num_cols,
@@ -1128,20 +1175,21 @@ def _prepare_multi_pass_multi_cta_topk(
             architecture=architecture,
             unroll_factor=unroll_factor,
         )
-        # Compile the kernel
-        compiled_kernel_first = cute.compile(
-            filtered_topk_func_first,
-            input_fake,
-            None,  # indices_fake: unused in this path; pass None to match runtime
-            buffer_fake,
-            seqlen_fake,
-            # output_indices_fake,
-            # output_values_fake,
-            first_kernel_output_indices_fake,
-            first_kernel_output_values_fake,
-            stream=fake_stream,
-            min_blocks_per_mp=min_blocks_per_mp,
-            options="--enable-tvm-ffi",
+        # Compile the kernel (persistently cached; see _persistent_compile)
+        compiled_kernel_first = _persistent_compile(
+            _kernel_name_from_key(key) + "_p1",
+            lambda: cute.compile(
+                filtered_topk_func_first,
+                input_fake,
+                None,  # indices_fake: unused in this path
+                buffer_fake,
+                seqlen_fake,
+                first_kernel_output_indices_fake,
+                first_kernel_output_values_fake,
+                stream=fake_stream,
+                min_blocks_per_mp=min_blocks_per_mp,
+                options="--enable-tvm-ffi",
+            ),
         )
 
         # The merge stage consumes the first stage's candidate indices.
@@ -1181,18 +1229,21 @@ def _prepare_multi_pass_multi_cta_topk(
             architecture=architecture,
             unroll_factor=unroll_factor,
         )
-        # Compile the kernel
-        compiled_kernel_second = cute.compile(
-            filtered_topk_func_second,
-            input_fake,
-            indices_fake,
-            buffer_fake,
-            seqlen_fake,
-            output_indices_fake,
-            output_values_fake,
-            stream=fake_stream,
-            min_blocks_per_mp=min_blocks_per_mp,
-            options="--enable-tvm-ffi",
+        # Compile the kernel (persistently cached; see _persistent_compile)
+        compiled_kernel_second = _persistent_compile(
+            _kernel_name_from_key(key) + "_p2",
+            lambda: cute.compile(
+                filtered_topk_func_second,
+                input_fake,
+                indices_fake,
+                buffer_fake,
+                seqlen_fake,
+                output_indices_fake,
+                output_values_fake,
+                stream=fake_stream,
+                min_blocks_per_mp=min_blocks_per_mp,
+                options="--enable-tvm-ffi",
+            ),
         )
 
         compiled_filter_topk_dict[key] = (compiled_kernel_first, compiled_kernel_second)

--- a/flashinfer/topk_varlen/kernels/filtered_topk_decode.py
+++ b/flashinfer/topk_varlen/kernels/filtered_topk_decode.py
@@ -58,11 +58,26 @@ from .filtered_topk_util import (
 )
 
 
-def _get_num_sms() -> int:
-    """Return the number of SMs on the current device (cached)."""
-    if not hasattr(_get_num_sms, "_value"):
-        _get_num_sms._value = torch.cuda.get_device_properties().multi_processor_count
-    return _get_num_sms._value
+def _get_num_sms(device: torch.device | None = None) -> int:
+    """Return the number of SMs on ``device`` (default: current), cached.
+
+    Cached PER DEVICE: a single process-wide scalar would pin the first
+    caller's SM count and silently mis-size the persistent grid and the
+    large-occupancy mode decision for every later call on a different GPU of a
+    heterogeneous host. Call sites that have a tensor in scope pass its
+    device. DIVERGENCE FROM UPSTREAM (single ambient-device scalar), after
+    review (flashinfer PR #4621).
+    """
+    if device is not None and device.index is not None:
+        idx = device.index
+    else:
+        idx = torch.cuda.current_device()
+    cache = getattr(_get_num_sms, "_values", None)
+    if cache is None:
+        cache = _get_num_sms._values = {}
+    if idx not in cache:
+        cache[idx] = torch.cuda.get_device_properties(idx).multi_processor_count
+    return cache[idx]
 
 
 """
@@ -738,6 +753,7 @@ def _prepare_one_pass_topk(
             num_cols,
             num_rows,
             dtype == cutlass.Float32,
+            num_sms=_get_num_sms(input_values.device),
         )
     if cluster_size <= 0 or cluster_size > _SM100_MAX_CLUSTER_SIZE:
         raise ValueError(
@@ -746,7 +762,9 @@ def _prepare_one_pass_topk(
         )
 
     single_pass_multi_cta = cluster_size > 1
-    large_occupancy = not single_pass_multi_cta and num_rows > _get_num_sms()
+    large_occupancy = not single_pass_multi_cta and num_rows > _get_num_sms(
+        input_values.device
+    )
     architecture, large_occupancy_min_blocks_per_mp = get_topk_architecture_config()
     min_blocks_per_mp = large_occupancy_min_blocks_per_mp if large_occupancy else 1
     chunk_size_per_cta = (
@@ -1023,7 +1041,7 @@ def _prepare_multi_pass_multi_cta_topk(
     num_rows, num_cols = input_values.shape
     bucketed_num_cols = _bucket_num_cols(num_cols)
 
-    large_occupancy = num_rows > _get_num_sms()
+    large_occupancy = num_rows > _get_num_sms(input_values.device)
     architecture, large_occupancy_min_blocks_per_mp = get_topk_architecture_config()
     min_blocks_per_mp = large_occupancy_min_blocks_per_mp if large_occupancy else 1
 

--- a/flashinfer/topk_varlen/kernels/filtered_topk_decode.py
+++ b/flashinfer/topk_varlen/kernels/filtered_topk_decode.py
@@ -835,12 +835,32 @@ def _prepare_one_pass_topk(
     _tuned_tma = (
         tma_tuned_default(dtype, architecture, bucketed_num_cols)
         and (num_cols % _tma_div == 0)
+        # With the symbolic leading stride, num_cols divisibility alone no
+        # longer proves the TMA row stride is 16-byte aligned: a padded view
+        # (stride(0) > num_cols) can carry a misaligned byte stride that
+        # cuTensorMapEncodeTiled rejects. The auto default therefore also
+        # requires an aligned leading stride and falls back to LDG otherwise.
+        # DIVERGENCE FROM UPSTREAM (compact-only fake), after review
+        # (flashinfer PR #4621).
+        and (input_values.stride(0) % _tma_div == 0)
         # TMA aliases the candidate buffer; REREAD_ALWAYS allocates none, so the
         # auto default must skip it (env-forced TMA still hits the explicit guard).
         and overflow_policy != "REREAD_ALWAYS"
     )
     _enable_tma_load = _tma_ok and auto_tma_load(enable_tma_load, _tuned_tma)
     _enable_tma_load_p3 = _tma_ok and auto_tma_load(enable_tma_load_p3, _tuned_tma)
+    if (_enable_tma_load or _enable_tma_load_p3) and (
+        input_values.stride(0) % _tma_div != 0
+    ):
+        # Only reachable when TMA is forced explicitly (argument or env var):
+        # fail fast with an actionable message instead of the opaque
+        # cuTensorMapEncodeTiled error from inside the launch.
+        raise ValueError(
+            f"TMA load requires the input leading stride to be 16-byte "
+            f"aligned (divisible by {_tma_div} elements for this dtype); got "
+            f"stride(0)={input_values.stride(0)}. Disable enable_tma_load or "
+            f"pass a compact/aligned input."
+        )
 
     key = (
         _compile_cc(input_values.device),
@@ -869,12 +889,18 @@ def _prepare_one_pass_topk(
         # a framework's score buffer sliced to the vocab width) is part of
         # the declared ABI, zero-copy. Inner stride stays 1 and the base
         # stays 32-byte aligned; the public wrapper materializes inputs
-        # violating those. DIVERGENCE FROM UPSTREAM (compact-only fake),
-        # after review (flashinfer PR #4621).
+        # violating those. When TMA is enabled the leading stride also
+        # declares the 16-byte divisibility the descriptor needs, so a
+        # misaligned runtime stride is rejected at argument check rather
+        # than inside cuTensorMapEncodeTiled. DIVERGENCE FROM UPSTREAM
+        # (compact-only fake), after review (flashinfer PR #4621).
         input_fake = cute.runtime.make_fake_tensor(
             dtype,
             (n_rows, n_cols),
-            stride=(cute.sym_int64(), 1),
+            stride=(
+                cute.sym_int64(divisibility=_tma_div) if _tma_on else cute.sym_int64(),
+                1,
+            ),
             assumed_align=32,
         )
         if overflow_policy in ("GMEM_SPILL", "BOUNDED_SPILL"):

--- a/flashinfer/topk_varlen/kernels/filtered_topk_decode.py
+++ b/flashinfer/topk_varlen/kernels/filtered_topk_decode.py
@@ -93,6 +93,21 @@ def _compile_cc(device: torch.device) -> str:
     return f"sm{major}{minor}"
 
 
+def _dsl_gpu_arch(device: torch.device) -> str:
+    """Explicit ``cute.compile`` target for *device* (e.g. ``"sm_100a"``).
+
+    Without an explicit ``--gpu-arch``, the DSL resolves its target from the
+    process-ambient device, which can disagree with the INPUT tensor's device
+    on a multi-GPU host (e.g. cutlass imported while cuda:0 is current, input
+    on cuda:1): the kernel then compiles for the wrong architecture even
+    under ``torch.cuda.device(input.device)``, failing in ptxas at best and
+    persisting a wrong-arch artifact under the right-arch module directory at
+    worst. DIVERGENCE FROM UPSTREAM, after review (flashinfer PR #4621).
+    """
+    major, minor = torch.cuda.get_device_capability(device)
+    return f"sm_{major}{minor}{'a' if major >= 9 else ''}"
+
+
 def _persistent_compile(kernel_name: str, compile_fn):
     """Route a ``cute.compile`` through FlashInfer's persistent JIT cache.
 
@@ -980,7 +995,7 @@ def _prepare_one_pass_topk(
                 output_values_fake,
                 stream=fake_stream,
                 min_blocks_per_mp=min_blocks_per_mp,
-                options="--enable-tvm-ffi",
+                options=f"--enable-tvm-ffi --gpu-arch={_dsl_gpu_arch(input_values.device)}",
             ),
         )
         compiled_filter_topk_dict[key] = compiled_kernel
@@ -1273,7 +1288,7 @@ def _prepare_multi_pass_multi_cta_topk(
                 first_kernel_output_values_fake,
                 stream=fake_stream,
                 min_blocks_per_mp=min_blocks_per_mp,
-                options="--enable-tvm-ffi",
+                options=f"--enable-tvm-ffi --gpu-arch={_dsl_gpu_arch(input_values.device)}",
             ),
         )
 
@@ -1327,7 +1342,7 @@ def _prepare_multi_pass_multi_cta_topk(
                 output_values_fake,
                 stream=fake_stream,
                 min_blocks_per_mp=min_blocks_per_mp,
-                options="--enable-tvm-ffi",
+                options=f"--enable-tvm-ffi --gpu-arch={_dsl_gpu_arch(input_values.device)}",
             ),
         )
 

--- a/flashinfer/topk_varlen/kernels/filtered_topk_decode.py
+++ b/flashinfer/topk_varlen/kernels/filtered_topk_decode.py
@@ -877,6 +877,46 @@ def _prepare_one_pass_topk(
             f"pass a compact/aligned input."
         )
 
+    # Kernel-writable destinations. Caller-provided buffers are used
+    # directly (the kernel writes every slot, including -1 / -inf padding,
+    # so no stale data survives); otherwise allocate on the INPUT device --
+    # not the ambient one -- so multi-GPU callers get outputs next to their
+    # data. DIVERGENCE FROM UPSTREAM (internal-only allocation), after
+    # review (flashinfer PR #4621): threading the buffers through avoids a
+    # full num_rows x top_k allocate+copy per public call and gives
+    # CUDA-graph users stable destinations.
+    def _as_out(buf, dtype_, what):
+        if buf is None:
+            return None
+        if not (buf.is_cuda and buf.dtype == dtype_):
+            raise ValueError(f"{what} must be a CUDA {dtype_} tensor")
+        if buf.device != input_values.device:
+            raise ValueError(
+                f"{what} must be on the input device {input_values.device}, "
+                f"got {buf.device}; the kernel launches on the input's device "
+                f"and cannot write a foreign-device buffer"
+            )
+        if buf.numel() != num_rows * top_k or not buf.is_contiguous():
+            raise ValueError(
+                f"{what} must be contiguous with numel == num_rows * top_k "
+                f"({num_rows * top_k}), got numel={buf.numel()}"
+            )
+        return buf.view(num_rows, top_k)
+
+    output_indices_torch = _as_out(out_indices, torch.int32, "out_indices")
+    if output_indices_torch is None:
+        output_indices_torch = torch.empty(
+            num_rows, top_k, dtype=torch.int32, device=input_values.device
+        )
+    if return_val:
+        output_values_torch = _as_out(out_values, torch_dtype, "out_values")
+        if output_values_torch is None:
+            output_values_torch = torch.empty(
+                num_rows, top_k, dtype=torch_dtype, device=input_values.device
+            )
+    else:
+        output_values_torch = None
+
     key = (
         _compile_cc(input_values.device),
         "single-pass-multi-cta" if single_pass_multi_cta else "single-cta",
@@ -1001,40 +1041,6 @@ def _prepare_one_pass_topk(
         compiled_filter_topk_dict[key] = compiled_kernel
     else:
         compiled_kernel = compiled_filter_topk_dict[key]
-
-    # Kernel-writable destinations. Caller-provided buffers are used
-    # directly (the kernel writes every slot, including -1 / -inf padding,
-    # so no stale data survives); otherwise allocate on the INPUT device --
-    # not the ambient one -- so multi-GPU callers get outputs next to their
-    # data. DIVERGENCE FROM UPSTREAM (internal-only allocation), after
-    # review (flashinfer PR #4621): threading the buffers through avoids a
-    # full num_rows x top_k allocate+copy per public call and gives
-    # CUDA-graph users stable destinations.
-    def _as_out(buf, dtype_, what):
-        if buf is None:
-            return None
-        if not (buf.is_cuda and buf.dtype == dtype_):
-            raise ValueError(f"{what} must be a CUDA {dtype_} tensor")
-        if buf.numel() != num_rows * top_k or not buf.is_contiguous():
-            raise ValueError(
-                f"{what} must be contiguous with numel == num_rows * top_k "
-                f"({num_rows * top_k}), got numel={buf.numel()}"
-            )
-        return buf.view(num_rows, top_k)
-
-    output_indices_torch = _as_out(out_indices, torch.int32, "out_indices")
-    if output_indices_torch is None:
-        output_indices_torch = torch.empty(
-            num_rows, top_k, dtype=torch.int32, device=input_values.device
-        )
-    if return_val:
-        output_values_torch = _as_out(out_values, torch_dtype, "out_values")
-        if output_values_torch is None:
-            output_values_torch = torch.empty(
-                num_rows, top_k, dtype=torch_dtype, device=input_values.device
-            )
-    else:
-        output_values_torch = None
 
     if overflow_policy == "GMEM_SPILL":
         buffer_numbers = 2 if dtype == cutlass.Float32 else 1

--- a/flashinfer/topk_varlen/kernels/filtered_topk_util.py
+++ b/flashinfer/topk_varlen/kernels/filtered_topk_util.py
@@ -328,7 +328,7 @@ class FilteredTopKKernelVarlen:
                                    the stored set.  Non-exact (may output fewer than
                                    top_k indices when the threshold bin is dense).  No
                                    extra_buffer needed.  Requires
-                                   top_k <= filtered_topk_smem_input_size.
+                                   top_k < filtered_topk_smem_input_size.
                 "REREAD_ALWAYS" -- Skip SMEM collection entirely in the coarse pass;
                                    always perform a second GMEM scan to collect
                                    threshold-bin candidates.  Exact result.  No
@@ -536,12 +536,19 @@ class FilteredTopKKernelVarlen:
                     self.enable_tma_load_p3 = False
 
         _needs_extra = self.max_num_cols > self.filtered_topk_smem_input_size
+        # STRICT bound (top_k < S, not <=): the fine-threshold search selects
+        # the bin where the inclusive cumulative count strictly exceeds
+        # topk_remaining. Truncation to exactly S == top_k candidates makes
+        # the total cumulative count equal top_k, so no bin qualifies, no
+        # threshold is selected, and refinement consumes stale control state.
+        # DIVERGENCE FROM UPSTREAM (<= bound), after review (flashinfer
+        # PR #4621).
         if (
             overflow_policy == "TRUNCATE"
-            and self.top_k > self.filtered_topk_smem_input_size
+            and self.top_k >= self.filtered_topk_smem_input_size
         ):
             raise ValueError(
-                f"TRUNCATE overflow_policy requires top_k ({self.top_k}) <= "
+                f"TRUNCATE overflow_policy requires top_k ({self.top_k}) < "
                 "filtered_topk_smem_input_size "
                 f"({self.filtered_topk_smem_input_size}); use REREAD or GMEM_SPILL."
             )

--- a/flashinfer/topk_varlen/kernels/filtered_topk_util.py
+++ b/flashinfer/topk_varlen/kernels/filtered_topk_util.py
@@ -1,0 +1,3366 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+# list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+# Vendored from the NVIDIA dynamic-kernel-generator (DKG) repository,
+# cutlass_ir/compiler/python/examples/CuTeDSL/cute/blackwell/kernel/top_k/filtered_top_k_varlen_util.py
+# at DKG master b45e50a7336 (merge request !25590, "[CuTeDSL] Adapt radix top-k to
+# Rubin arch").
+#
+# Changes from upstream are limited to: this header, removal of DKG-internal
+# release markers, and import rewrites to flashinfer-relative paths. The kernel
+# algorithm is unmodified so upstream fixes can be re-applied by re-vendoring.
+
+import math
+import os
+
+import cutlass
+import cutlass.cute as cute
+import cutlass.pipeline as pipeline
+import torch
+from cutlass._mlir.dialects import llvm
+from cutlass.cute.typing import Int32 as CuteInt32
+from cutlass.cute.typing import Pointer as CutePointer
+from cutlass.cutlass_dsl import T, dsl_user_op
+
+from .block_scan import block_prefix_sum_kernel, fence_acq_rel_cta
+
+# Dev-only IKET phase timing. Off by default so the baseline IR is untouched.
+# Enable with `TOPK_IKET=1` AND compile with the iket option
+# (`CUTE_DSL_COMPILER_OPT=iket`); then run under `run-iket ... profile`.
+# When off, no iket ops are traced into the kernel IR at all.
+_TOPK_IKET = os.environ.get("TOPK_IKET", "0") == "1"
+if _TOPK_IKET:
+    import cutlass.cute.experimental.iket as _iket
+
+
+_LARGE_OCCUPANCY_MIN_BLOCKS_PER_MP = {
+    (10, 0): 4,
+    (10, 3): 4,
+    (10, 7): 2,
+    (10, 9): 2,
+}
+# 228 KiB SMEM / 108 KiB L1 tier in Rubin's 336 KiB unified pool.
+_RUBIN_TOPK_ARCHITECTURES = ("sm_107", "sm_109")
+# TODO: for tma_load=on and smem_cache_value=true,
+# there're no L1 data flows. So we could increase SMEM carveout to the max SMEM size
+# and make the candidate buffer larger.
+_RUBIN_TOPK_SMEM_CARVEOUT_BYTES = 228 * 1024
+_SMEM_ALIGNMENT_BYTES = 128
+_SMEM_RUNTIME_RESERVE_BYTES = 1024
+
+# --- async-TMA load (p1 coarse histogram + p3 coarse filter) enable knob ---
+#
+# Routing the input scans through async-TMA (cp.async.bulk / UTMALDG) staging is a
+# tuning knob (all of fp32/fp16/bf16 are correct with it on), shared by the prefill
+# and decode large-occupancy wrappers. From an on-vs-off sweep (Rubin sm_107):
+#   fp32       : load-bound at large N -> WINS for N >= _TMA_MIN_NUM_COLS (-13..-15%).
+#   fp16/bf16  : NOT load-bound (2-byte L1-cached re-reads) -> loses across ~all N.
+# So the tuned-on set is "fp32 on Rubin with N >= _TMA_MIN_NUM_COLS". The enable also
+# requires a 16-byte-aligned num_cols and non-REREAD_ALWAYS (resolved in _prepare).
+# Override per call via enable_tma_load(_p3) params / --enable_tma_load {auto,on,off}.
+# fp32 TMA wins at/above this bucketed context length under fixlen AND varlen.
+_TMA_MIN_NUM_COLS = 131072
+
+
+def tma_tuned_default(dtype, architecture, max_num_cols) -> bool:
+    """Tuned async-TMA-load default: fp32 on Rubin with a large-enough context
+    (max_num_cols >= _TMA_MIN_NUM_COLS), per the win-region sweep above. fp16/bf16 and
+    small contexts stay on the LDG baseline."""
+    return (
+        dtype == cutlass.Float32
+        and architecture in _RUBIN_TOPK_ARCHITECTURES
+        and max_num_cols >= _TMA_MIN_NUM_COLS
+    )
+
+
+def auto_tma_load(explicit, tuned_default: bool) -> bool:
+    """Resolve a TMA-load enable flag: an explicit True/False wins; None -> the
+    tuned default (the shipped auto behaviour)."""
+    return tuned_default if explicit is None else bool(explicit)
+
+
+def _align_smem_bytes(size: int) -> int:
+    return (size + _SMEM_ALIGNMENT_BYTES - 1) & -_SMEM_ALIGNMENT_BYTES
+
+
+def get_topk_architecture_config(
+    compute_capability: tuple[int, int] | None = None,
+) -> tuple[str, int]:
+    """Return the filtered top-k resource policy for an architecture.
+
+    Args:
+        compute_capability: A ``(major, minor)`` CUDA compute capability. When
+            ``None``, the current CUDA device's capability is queried.
+
+    Returns:
+        A ``(arch, min_blocks_per_mp)`` tuple, where ``arch`` is the
+        ``"sm_<major><minor>"`` string and ``min_blocks_per_mp`` is the
+        large-occupancy launch bound for that architecture.
+
+    Raises:
+        ValueError: If ``compute_capability`` is not a supported top-k
+            architecture (not present in ``_LARGE_OCCUPANCY_MIN_BLOCKS_PER_MP``).
+    """
+    if compute_capability is None:
+        device = torch.cuda.current_device()
+        compute_capability = torch.cuda.get_device_capability(device)
+    try:
+        min_blocks_per_mp = _LARGE_OCCUPANCY_MIN_BLOCKS_PER_MP[compute_capability]
+    except KeyError as error:
+        major, minor = compute_capability
+        raise ValueError(
+            f"Unsupported top-k architecture: sm_{major}{minor}"
+        ) from error
+    major, minor = compute_capability
+    return f"sm_{major}{minor}", min_blocks_per_mp
+
+
+def get_large_occupancy_min_blocks_per_mp(
+    compute_capability: tuple[int, int] | None = None,
+) -> int:
+    """Return the legal large-occupancy launch bound for an architecture."""
+    return get_topk_architecture_config(compute_capability)[1]
+
+
+# Bytes-in-flight per SM needed to saturate HBM for a read-dominated scan.
+# Rubin (HBM4) needs ~128 KiB/SM vs Blackwell's ~64 KiB/SM -- 2x, from ~2.55x
+# bandwidth * ~1.29x higher static latency (Little's Law). See GCA study
+# "Minimum Bytes in Flight to saturate HBM bandwidth" (page 3120051050).
+_RUBIN_READ_BYTES_IN_FLIGHT_TARGET = 128 * 1024
+
+
+def auto_unroll_factor(
+    max_num_cols: int,
+    num_threads_per_cta: int,
+    blocks_per_sm: int,
+    vec_size: int,
+    elem_bytes: int,
+    target_bytes_in_flight: int = _RUBIN_READ_BYTES_IN_FLIGHT_TARGET,
+) -> int:
+    """Auto load-instruction unroll for the input scans: pick the factor that fills
+    ``target_bytes_in_flight`` per SM, clamped to a register-safe factor and to
+    the scan length actually available.
+
+        bytes_in_flight/SM = blocks_per_sm * num_threads_per_cta * uf * bytes/load
+
+    The public wrappers pass this so callers get the tuned default without
+    hand-picking ``unroll_factor``.
+    """
+    bytes_per_load = vec_size * elem_bytes
+    threads_per_sm = blocks_per_sm * num_threads_per_cta
+    # ceil-div: smallest uf that reaches the target.
+    uf_target = -(-target_bytes_in_flight // (threads_per_sm * bytes_per_load))
+    # Register budget: 65536 regs/SM split across threads_per_sm sets regs/thread.
+    # The cap keys on threads_per_sm (not blocks_per_sm) because that is what fixes
+    # the budget: >=1024 threads/SM => <=64 regs/thread (Rubin 2x512 *or* 1x1024),
+    # validated that uf>2 spills there -> cap 2. <=512 threads/SM gives >=128
+    # regs/thread, room for uf=4 (validated on under-subscribed 256/512-thread
+    # decode). This is the conservative choice; a 1-block/SM CTA that still runs
+    # 1024 threads is as register-tight as the 2-block case, so it must also cap 2.
+    uf_cap = 2 if threads_per_sm >= 1024 else 4
+    # Cannot overlap more iterations than the per-CTA scan actually has.
+    step_vec = num_threads_per_cta * vec_size
+    big_iters_bound = max(1, max_num_cols // step_vec)
+    raw = min(uf_target, uf_cap, big_iters_bound)
+    # Snap down to a validated power-of-two unroll count.
+    return max(a for a in (1, 2, 4, 8) if a <= raw)
+
+
+@dsl_user_op
+def atomic_add(dst_ptr: CutePointer, val: CuteInt32, *, loc=None, ip=None) -> CuteInt32:
+    """Atomically add an Int32 value through a CuTe DSL pointer."""
+    return cute.arch.atomic_add(
+        ptr=dst_ptr.llvm_ptr,
+        val=val,
+        sem="relaxed",
+        scope="sys",
+        loc=loc,
+        ip=ip,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Cluster DSMEM primitives (inline PTX) — used only by the single-pass
+# multi-CTA (radix-filter) path. Defined locally to avoid a circular import
+# with single_pass_multi_cta_radix_topk_cluster (which imports this module).
+# ---------------------------------------------------------------------------
+@dsl_user_op
+def _mapa_shared_cluster(
+    smem_ptr: CutePointer, peer_rank: CuteInt32, *, loc=None, ip=None
+) -> CuteInt32:
+    """Map a local SMEM address to a peer CTA's SMEM in cluster address space.
+
+    PTX: mapa.shared::cluster.u32 $0, $1, $2;
+    """
+    smem_ptr_i32 = smem_ptr.toint(loc=loc, ip=ip).ir_value()
+    return cutlass.Int32(
+        llvm.inline_asm(
+            T.i32(),
+            [smem_ptr_i32, peer_rank.ir_value(loc=loc, ip=ip)],
+            "mapa.shared::cluster.u32 $0, $1, $2;",
+            "=r,r,r",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+            loc=loc,
+            ip=ip,
+        )
+    )
+
+
+@cute.jit
+def mapa_shared_cluster(smem_ptr, peer_rank):
+    """Map a local SMEM address to a peer CTA's SMEM in cluster address space."""
+    return _mapa_shared_cluster(smem_ptr, peer_rank)
+
+
+@dsl_user_op
+def _ld_shared_cluster_i32(mapped_addr: CuteInt32, *, loc=None, ip=None) -> CuteInt32:
+    """Load an int32 from a cluster SMEM address.
+
+    PTX: ld.shared::cluster.u32 $0, [$1];
+    """
+    return cutlass.Int32(
+        llvm.inline_asm(
+            T.i32(),
+            [mapped_addr.ir_value(loc=loc, ip=ip)],
+            "ld.shared::cluster.u32 $0, [$1];",
+            "=r,r",
+            has_side_effects=True,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+            loc=loc,
+            ip=ip,
+        )
+    )
+
+
+@cute.jit
+def ld_shared_cluster_i32(mapped_addr):
+    """Load an int32 from a cluster SMEM address."""
+    return _ld_shared_cluster_i32(mapped_addr)
+
+
+"""
+top-k varlen utils. could be used by prefill and decode phase.
+"""
+
+
+def half_as_ushort(half_val):
+    """Interpret FP16 value as uint16 bit pattern"""
+    return llvm.bitcast(cutlass.Uint16.mlir_type, half_val.ir_value())
+
+
+def float_as_uint32(float_val):
+    """Interpret FP32 value as uint32 bit pattern"""
+    return llvm.bitcast(cutlass.Uint32.mlir_type, float_val.ir_value())
+
+
+class FilteredTopKKernelVarlen:
+    def __init__(
+        self,
+        dtype: cutlass.Numeric,
+        max_num_cols: int,
+        top_k: int,
+        num_copy_bits: int = 256,
+        return_val: bool = True,
+        enable_multi_cta: bool = False,
+        chunk_size_per_cta: int = 16384,
+        num_ctas_per_row: int = 1,
+        merge_blocks: bool = False,
+        overflow_policy: str = "REREAD",
+        num_threads_override: int = 0,
+        cache_smem_values: bool = False,
+        single_pass_multi_cta: bool = False,
+        architecture: str = "sm_100",
+        unroll_factor: int = 4,
+        enable_tma_load: bool = False,
+        tma_num_stages: int = 4,
+        enable_tma_load_p3: bool = False,
+        tma_num_stages_p3: int = 2,
+    ):
+        """
+        Args:
+            architecture: Target SM string (e.g. "sm_100", "sm_107", "sm_109")
+                used to select architecture-specific SMEM sizing, occupancy
+                launch bounds, and copy/atomic paths.
+            unroll_factor: load-instruction unroll factor for the coarse/filter input scans,
+                one of 1/2/4/8 (1 = the original 1-in-flight baseline). ``0`` is
+                the "auto" sentinel that subclasses resolve to a concrete factor
+                via ``auto_unroll_factor`` before the kernel body is built.
+            overflow_policy: Controls behavior when threshold-bin candidates exceed the
+                SMEM input buffer (filtered_topk_smem_input_size).  Only takes effect
+                when max_num_cols > filtered_topk_smem_input_size; otherwise all policies
+                are equivalent and no extra cost is incurred.
+
+                "GMEM_SPILL"    -- Spill excess candidates to a pre-allocated GMEM
+                                   extra_buffer.  Exact result.  Requires caller to
+                                   allocate extra_buffer proportional to batch size;
+                                   may OOM at large batch.
+                "TRUNCATE"      -- Discard candidates that overflow SMEM.  Only
+                                   retained candidates contribute to the refinement
+                                   histogram, so refinement operates consistently on
+                                   the stored set.  Non-exact (may output fewer than
+                                   top_k indices when the threshold bin is dense).  No
+                                   extra_buffer needed.  Requires
+                                   top_k <= filtered_topk_smem_input_size.
+                "REREAD_ALWAYS" -- Skip SMEM collection entirely in the coarse pass;
+                                   always perform a second GMEM scan to collect
+                                   threshold-bin candidates.  Exact result.  No
+                                   extra_buffer needed; costs one extra GMEM read per
+                                   row unconditionally.
+                "REREAD"        -- Optimistic: attempt SMEM collection first.  If
+                                   overflow is detected at runtime (s_overflow_flag),
+                                   fall back to a REREAD_ALWAYS-style second GMEM scan.
+                                   Exact result.  No extra_buffer needed; pays the
+                                   extra GMEM read only when overflow actually occurs.
+                "BOUNDED_SPILL" -- 3-tier graceful degrade keyed on the runtime
+                                   candidate count: fits in SMEM (S) -> spill the
+                                   overflow to a size-capped GMEM extra_buffer of
+                                   host-chosen per-row capacity G -> if even G is
+                                   exceeded, s_overflow_flag triggers the REREAD
+                                   second GMEM scan.  Exact result.  Like GMEM_SPILL
+                                   but the extra_buffer is bounded to O(G) instead
+                                   of O(max_num_cols), so it cannot OOM at large
+                                   batch/context.  G is set by the caller via
+                                   spill_capacity (per-row candidate count) and/or
+                                   spill_budget_bytes (total HBM budget; the stricter
+                                   of the two wins) and is read by the kernel from
+                                   the extra_buffer's own extent, so a single
+                                   compiled kernel serves any G.
+        """
+        self.dtype = dtype
+        self.max_num_cols = max_num_cols
+        self.top_k = top_k
+        self.num_copy_bits = num_copy_bits
+        self.enable_multi_cta = enable_multi_cta
+        self.chunk_size_per_cta = chunk_size_per_cta
+        self.num_ctas_per_row = num_ctas_per_row
+        self.merge_blocks = merge_blocks
+        self.overflow_policy = overflow_policy
+        # Single-pass multi-CTA (radix-filter cluster) mode. Compile-time flag;
+        # when False all cluster branches are const-folded away (single-CTA path
+        # keeps identical SASS). Reuses chunk_size_per_cta / num_ctas_per_row for
+        # chunk partitioning (num_ctas_per_row == ctas_per_group / cluster size).
+        self.single_pass_multi_cta = single_pass_multi_cta
+        # load-instruction unroll factor for the coarse/filter input scans (memory-level
+        # parallelism). A counted cutlass.range(big_iters, unroll=unroll_factor)
+        # overlaps `unroll_factor` loads vs the 1-in-flight `while`.
+        # unroll_factor == 1 reproduces the original (unmodified) baseline;
+        # 2/4/8 are tuning points (4 profiled long_scoreboard -40%,
+        # occupancy/registers neutral). REREAD path only.
+        # unroll_factor == 0 is the "auto" sentinel: subclasses resolve it to a
+        # concrete factor via auto_unroll_factor() once num_threads_per_cta /
+        # vec_size are known, before the kernel body (which reads
+        # self.unroll_factor) is built.
+        assert unroll_factor in (0, 1, 2, 4, 8), (
+            f"unroll_factor must be one of 0 (auto), 1, 2, 4, 8; got {unroll_factor}"
+        )
+        self.unroll_factor = unroll_factor
+
+        # Stage 0 prototype: async TMA (cp.async.bulk / UTMALDG) load for the
+        # coarse-histogram vecscan, gated by enable_tma_load so the baseline (all
+        # archs) keeps the synchronous LDG path untouched. tma_num_stages is the
+        # ring depth (tunable/sweepable), sizing the bytes-in-flight vs the SMEM
+        # staging carved from the candidate buffer (see _compute_* sizing). The
+        # lever targets the #1 stall: global-load latency (long_scoreboard ~40%).
+        assert tma_num_stages >= 1, f"tma_num_stages must be >= 1; got {tma_num_stages}"
+        self.enable_tma_load = enable_tma_load
+        self.tma_num_stages = tma_num_stages
+        # Stage-1 prototype: async-TMA load for the p3 coarse-filter vecscan.
+        # fp32 only (nbuf==2 double-buffer -> the idle candidate buffer 1 can be
+        # aliased as staging with no candidate shrink). Independent switch from
+        # enable_tma_load (p1). tma_num_stages_p3 is capped by buffer-1 capacity.
+        assert tma_num_stages_p3 >= 1, (
+            f"tma_num_stages_p3 must be >= 1; got {tma_num_stages_p3}"
+        )
+        self.enable_tma_load_p3 = enable_tma_load_p3
+        self.tma_num_stages_p3 = tma_num_stages_p3
+        assert overflow_policy in (
+            "GMEM_SPILL",
+            "TRUNCATE",
+            "REREAD_ALWAYS",
+            "REREAD",
+            "BOUNDED_SPILL",
+        ), f"Unknown overflow_policy: {overflow_policy}"
+
+        # Bound the shared-memory index staging to the supported range.
+        if top_k <= 0 or top_k > 16384:
+            raise ValueError(
+                f"top_k must be in range [1, 16384], got {top_k}. "
+                "Maximum supported top_k is 16384 for Blackwell architecture."
+            )
+
+        # s_indices only needs top_k slots; size to top_k to save SMEM. Still
+        # referenced by the prefill kernel (filtered_top_k_prefill_varlen.py).
+        self.filtered_topk_max_k = top_k
+        # 8 bits for radix-based filter.
+        self.radix = 256
+
+        if cutlass.const_expr(self.dtype == cutlass.Float32):
+            self.num_buffer_smem_input_idx = 2
+        else:
+            self.num_buffer_smem_input_idx = 1
+
+        # 65536 is the max index value for uint16.
+        # SP multi-CTA reuses the same chunk partitioning as 2-pass multi-CTA.
+        if cutlass.const_expr(enable_multi_cta or single_pass_multi_cta):
+            self.per_row_max_num_cols = chunk_size_per_cta * num_ctas_per_row
+        else:
+            self.per_row_max_num_cols = self.max_num_cols
+
+        if cutlass.const_expr(self.per_row_max_num_cols <= 65536):
+            self.index_type = cutlass.Uint16
+        else:
+            self.index_type = cutlass.Uint32
+
+        self.vec_size = num_copy_bits // dtype.width
+        if cutlass.const_expr(
+            dtype not in [cutlass.Float32, cute.BFloat16, cutlass.Float16]
+        ):
+            raise ValueError(f"Unsupported dtype: {dtype}")
+
+        if num_threads_override > 0:
+            self.num_threads_per_cta = num_threads_override
+        elif cutlass.const_expr(dtype == cutlass.Float32):
+            if self.max_num_cols >= self.vec_size * 1024:
+                self.num_threads_per_cta = 1024
+            else:
+                if cutlass.const_expr(
+                    self.max_num_cols > 2048 and self.max_num_cols < 8192
+                ):
+                    self.num_threads_per_cta = 512
+                else:
+                    self.num_threads_per_cta = 256
+        else:
+            if self.max_num_cols >= 43008:
+                self.num_threads_per_cta = 1024
+            else:
+                if cutlass.const_expr(
+                    self.max_num_cols > 4096 and self.max_num_cols < 43008
+                ):
+                    self.num_threads_per_cta = 512
+                else:
+                    self.num_threads_per_cta = 256
+
+        # radix-based filter parameters — set before _compute_smem_input_size() so
+        # ordered_type.width is available in the SMEM budget formula.
+        if cutlass.const_expr(dtype == cutlass.Float32):
+            self.ordered_type = cute.Uint32
+            self.first_refine_shift = 24
+            self.num_refine_rounds = 4
+        elif cutlass.const_expr(dtype in [cutlass.Float16, cute.BFloat16]):
+            self.ordered_type = cute.Uint16
+            self.first_refine_shift = 0
+            self.num_refine_rounds = 1
+
+        self.cache_smem_values = cache_smem_values
+        self.architecture = architecture
+
+        # Adaptive async-TMA staging depth. A row spans at most
+        # `max_num_cols // tile_cols` full TMA tiles, so provisioning more ring
+        # stages than that is pure waste -- and for a small context it makes the
+        # staging ring (n_stages * tile_bytes) larger than the candidate buffer it
+        # aliases, which the capacity guards below would (correctly) reject. Cap the
+        # stage counts at the tile count so the ring always fits the aliased buffer
+        # with no extra SMEM; a context smaller than one tile has no aligned middle
+        # to TMA at all, so disable that path (the scalar edge scan covers the row).
+        # Resolved here, before sizing/guards, so every downstream use (asserts,
+        # _compute_rubin_smem_input_size, the caller's allocations, and the build
+        # loops) reads the capped value. Large contexts (>= configured stages) are
+        # unchanged. Must run after num_threads_per_cta / vec_size are set.
+        _tma_tile_cols = self.num_threads_per_cta * self.vec_size
+        _max_tma_tiles = self.max_num_cols // _tma_tile_cols
+        if self.enable_tma_load:
+            self.tma_num_stages = min(self.tma_num_stages, _max_tma_tiles)
+            if self.tma_num_stages < 1:
+                self.enable_tma_load = False
+        if self.enable_tma_load_p3:
+            self.tma_num_stages_p3 = min(self.tma_num_stages_p3, _max_tma_tiles)
+            if self.tma_num_stages_p3 < 1:
+                self.enable_tma_load_p3 = False
+
+        # num_threads_per_cta must be set before _compute_smem_input_size() since
+        # _compute_smem_input_size_for_occupancy() uses it to derive num_warps.
+        self.filtered_topk_smem_input_size = self._compute_smem_input_size()
+
+        # Second adaptive pass (needs S): the staging ring aliases a candidate
+        # region -- p1 aliases the whole candidate buffer (nbuf * S * slot); p3 on
+        # fp32 aliases the idle buffer 1 (S * slot). Cap the depth so the ring fits
+        # that region; if even one stage does not fit (a tiny context whose aliased
+        # buffer is smaller than a single tile), disable the path -- such a context
+        # is not load-bound and its LDG / scalar-edge scan already covers the row.
+        # REREAD_ALWAYS (no candidate buffer to alias) is handled by the explicit
+        # guard below, not here. (self.enable_reread_always is derived later in
+        # __init__, so test the policy directly.)
+        if self.overflow_policy != "REREAD_ALWAYS":
+            _idx_sz = 2 if self.index_type == cutlass.Uint16 else 4
+            _val_sz = self.ordered_type.width // 8 if self.cache_smem_values else 0
+            _slot = _idx_sz + _val_sz
+            _tile_bytes = _tma_tile_cols * (self.dtype.width // 8)
+            _S = self.filtered_topk_smem_input_size
+            if self.enable_tma_load:
+                _p1_fit = (self.num_buffer_smem_input_idx * _S * _slot) // _tile_bytes
+                self.tma_num_stages = min(self.tma_num_stages, _p1_fit)
+                if self.tma_num_stages < 1:
+                    self.enable_tma_load = False
+            if self.enable_tma_load_p3 and self.num_buffer_smem_input_idx == 2:
+                _p3_fit = (_S * _slot) // _tile_bytes
+                self.tma_num_stages_p3 = min(self.tma_num_stages_p3, _p3_fit)
+                if self.tma_num_stages_p3 < 1:
+                    self.enable_tma_load_p3 = False
+
+        _needs_extra = self.max_num_cols > self.filtered_topk_smem_input_size
+        if (
+            overflow_policy == "TRUNCATE"
+            and self.top_k > self.filtered_topk_smem_input_size
+        ):
+            raise ValueError(
+                f"TRUNCATE overflow_policy requires top_k ({self.top_k}) <= "
+                "filtered_topk_smem_input_size "
+                f"({self.filtered_topk_smem_input_size}); use REREAD or GMEM_SPILL."
+            )
+        self.enable_gmem_store = (overflow_policy == "GMEM_SPILL") and _needs_extra
+        self.enable_truncate = (overflow_policy == "TRUNCATE") and _needs_extra
+        self.enable_reread_always = overflow_policy == "REREAD_ALWAYS"
+        self.enable_reread = (overflow_policy == "REREAD") and _needs_extra
+        # BOUNDED_SPILL: spill overflow candidates to a size-capped GMEM buffer
+        # (host-chosen capacity G, passed as spill_capacity); when even G is
+        # exceeded, fall back to the REREAD second-scan via s_overflow_flag. A
+        # graceful 3-tier degrade (SMEM -> bounded GMEM -> reread) with bounded
+        # extra_buffer, unlike GMEM_SPILL whose buffer is O(max_num_cols).
+        self.enable_bounded_spill = (
+            overflow_policy == "BOUNDED_SPILL"
+        ) and _needs_extra
+
+        self.return_val = return_val
+        # Subclasses set to True to subtract row_start from absolute indices before
+        # writing output (used in prefill where row_start may be non-zero).
+        self.subtract_row_start_on_output = False
+
+        if cutlass.const_expr(self.enable_tma_load):
+            # The async-TMA staging ring aliases the candidate buffer(s)
+            # (s_input_idx [+ s_input_val], both unused during the p1 coarse
+            # histogram and contiguous in SMEM). Fail loudly if the ring cannot fit
+            # inside that region -- otherwise the TMA writes would silently spill
+            # past the candidate buffers into s_overflow_flag / s_last_remain /
+            # s_warp_sums and corrupt them.
+            if self.enable_reread_always:
+                # TODO: allocate a dedicated SMEM staging ring (carved from the
+                # per-CTA budget) instead of requiring a candidate buffer to alias.
+                # That would lift this restriction and also support REREAD_ALWAYS,
+                # at the cost of extra SMEM (candidate shrink / occupancy tradeoff).
+                raise ValueError(
+                    "enable_tma_load needs a candidate buffer to alias as the TMA "
+                    "staging ring, but overflow_policy=REREAD_ALWAYS allocates none."
+                )
+            idx_sz = 2 if self.index_type == cutlass.Uint16 else 4
+            val_sz = self.ordered_type.width // 8 if self.cache_smem_values else 0
+            alias_bytes = (
+                self.num_buffer_smem_input_idx
+                * (idx_sz + val_sz)
+                * self.filtered_topk_smem_input_size
+            )
+            tile_bytes = (
+                self.num_threads_per_cta * self.vec_size * (self.dtype.width // 8)
+            )
+            staging_bytes = self.tma_num_stages * tile_bytes
+            if staging_bytes > alias_bytes:
+                raise ValueError(
+                    f"enable_tma_load: TMA staging ring ({staging_bytes} B = "
+                    f"{self.tma_num_stages} stages x {tile_bytes} B) exceeds the "
+                    f"aliasable candidate buffer ({alias_bytes} B; "
+                    f"S={self.filtered_topk_smem_input_size}, "
+                    f"cache_smem_values={self.cache_smem_values}). Reduce "
+                    f"tma_num_stages or enable value caching / raise top_k."
+                )
+
+        if cutlass.const_expr(self.enable_tma_load_p3):
+            # p3 coarse-filter async-TMA. fp32 (nbuf==2): alias the IDLE candidate
+            # buffer 1 -> zero extra SMEM (merged layout when cache on; buffer-major
+            # idx-only when cache off; slot padded to 128 B). fp16/bf16 (nbuf==1): no
+            # idle buffer, so a dedicated staging is carved from the budget (S shrinks;
+            # reserved in _compute_rubin_smem_input_size). Needs a candidate buffer.
+            if self.enable_reread_always:
+                raise ValueError(
+                    "enable_tma_load_p3 needs a candidate buffer for the filter, but "
+                    "overflow_policy=REREAD_ALWAYS allocates none."
+                )
+            idx_sz = 2 if self.index_type == cutlass.Uint16 else 4
+            val_sz = self.ordered_type.width // 8 if self.cache_smem_values else 0
+            S = self.filtered_topk_smem_input_size
+            tile_bytes = (
+                self.num_threads_per_cta * self.vec_size * (self.dtype.width // 8)
+            )
+            p3_staging_bytes = self.tma_num_stages_p3 * tile_bytes
+            if cutlass.const_expr(self.num_buffer_smem_input_idx == 2):
+                # fp32: alias idle candidate buffer 1; check it fits.
+                if self.cache_smem_values and (S * idx_sz) % 4 != 0:
+                    raise ValueError(
+                        f"enable_tma_load_p3: S*idx_sz ({S}*{idx_sz}) must be 4-aligned "
+                        "for the merged candidate layout."
+                    )
+                buf1_bytes = S * (idx_sz + val_sz)  # idle candidate buffer 1
+                if p3_staging_bytes > buf1_bytes:
+                    raise ValueError(
+                        f"enable_tma_load_p3: p3 staging ({p3_staging_bytes} B) exceeds "
+                        f"the idle candidate buffer 1 ({buf1_bytes} B; S={S}, "
+                        f"idx_sz={idx_sz}). Reduce tma_num_stages_p3."
+                    )
+
+    def _compute_smem_input_size(self) -> int:
+        return self._compute_smem_input_size_for_occupancy(target_blocks_per_sm=1)
+
+    def _compute_rubin_smem_input_size(self, target_blocks_per_sm: int) -> int:
+        """Compute candidate capacity from Rubin's selected SMEM carveout tier."""
+        if self.overflow_policy == "REREAD_ALWAYS":
+            return 0
+
+        smem_capacity = cutlass.memory.get_smem_capacity_in_bytes(self.architecture)
+        per_cta_budget = min(
+            smem_capacity,
+            _RUBIN_TOPK_SMEM_CARVEOUT_BYTES // target_blocks_per_sm
+            - _SMEM_RUNTIME_RESERVE_BYTES,
+        )
+
+        idx_sz = 2 if self.index_type == cutlass.Uint16 else 4
+        # counter, threshold, num_input, last_remain, and warp_sums each
+        # occupy one 128-byte slot.
+        fixed_smem = (
+            _align_smem_bytes((self.radix + 1) * 4)
+            + 5 * _SMEM_ALIGNMENT_BYTES
+            + _align_smem_bytes(self.top_k * idx_sz)
+        )
+        if self.overflow_policy in ("GMEM_SPILL", "REREAD"):
+            fixed_smem += _SMEM_ALIGNMENT_BYTES
+        if self.overflow_policy == "BOUNDED_SPILL":
+            # BOUNDED_SPILL allocates BOTH g_num_input and s_overflow_flag.
+            fixed_smem += 2 * _SMEM_ALIGNMENT_BYTES
+        if self.single_pass_multi_cta:
+            fixed_smem += _align_smem_bytes((self.radix + 1) * 4)
+        if self.enable_tma_load:
+            # p1 staging ring aliases the candidate buffer (no extra ring bytes), but
+            # its per-stage mbarriers are a dedicated allocation -> reserve them (else
+            # at 2 CTAs/SM with S at capacity the SMEM over-subscribes -> launch fault).
+            fixed_smem += _align_smem_bytes(2 * self.tma_num_stages * 8)
+        # NOTE: the p1 async-TMA staging ring is NOT reserved here -- it aliases the
+        # candidate buffer (s_input_idx), unused during the coarse histogram (p1), so
+        # S is unchanged. Likewise p3 on fp32 (nbuf==2) aliases the idle candidate
+        # buffer 1. But fp16/bf16 p3 (nbuf==1) has no idle buffer, so its staging is a
+        # dedicated carve -- reserve it here (S shrinks accordingly; fp16 S is large
+        # so no extra REREAD).
+        if self.enable_tma_load_p3 and self.num_buffer_smem_input_idx == 1:
+            _p3_tile_bytes = _align_smem_bytes(
+                self.num_threads_per_cta * self.vec_size * (self.dtype.width // 8)
+            )
+            fixed_smem += self.tma_num_stages_p3 * _p3_tile_bytes
+            fixed_smem += _align_smem_bytes(2 * self.tma_num_stages_p3 * 8)
+        elif self.enable_tma_load_p3 and self.num_buffer_smem_input_idx == 2:
+            # fp32 p3: the staging ring aliases the idle candidate buffer 1 (no extra
+            # bytes), but its per-stage mbarriers are a dedicated allocation -> reserve
+            # them here. (The buffer-major candidate layout also pads each buffer to
+            # 128 B; the capacity alignment below makes S*slot 128-aligned so that
+            # padding is zero -- otherwise the actual allocation exceeds this budget by
+            # nbuf*64 B and, at 2 CTAs/SM, over-subscribes SMEM into a launch fault.)
+            fixed_smem += _align_smem_bytes(2 * self.tma_num_stages_p3 * 8)
+
+        val_sz = self.ordered_type.width // 8 if self.cache_smem_values else 0
+        candidate_bytes = self.num_buffer_smem_input_idx * (idx_sz + val_sz)
+        candidate_capacity = (per_cta_budget - fixed_smem) // candidate_bytes
+        # Fixed allocations must fit inside the per-CTA budget. A non-positive
+        # capacity means the candidate buffer cannot exist at all (a zero-length
+        # SMEM buffer is as broken as a negative size), so fail loudly instead of
+        # emitting a degenerate SMEM size downstream. This is a hard invariant --
+        # unreachable for the supported archs (target_blocks_per_sm in {1, 2}).
+        if candidate_capacity <= 0:
+            raise ValueError(
+                f"filtered top-k: fixed SMEM ({fixed_smem} B) exceeds the per-CTA "
+                f"budget ({per_cta_budget} B); cannot size the candidate buffer "
+                f"(arch={self.architecture}, top_k={self.top_k}, "
+                f"target_blocks_per_sm={target_blocks_per_sm})."
+            )
+        # Make each candidate buffer a 128B multiple to avoid unbudgeted padding.
+        if self.enable_tma_load_p3 and self.num_buffer_smem_input_idx == 2:
+            # p3 uses the buffer-major layout, which pads EACH buffer's slot
+            # (S * (idx_sz + val_sz)) up to 128 B independently. Align S so that slot
+            # is already a 128 B multiple -> the padding is zero and the allocation
+            # matches the candidate_bytes budgeted above (else 2 CTAs/SM over-subscribe
+            # SMEM and the launch faults).
+            slot = idx_sz + val_sz
+            capacity_alignment = _SMEM_ALIGNMENT_BYTES // math.gcd(
+                slot, _SMEM_ALIGNMENT_BYTES
+            )
+        else:
+            capacity_alignment = _SMEM_ALIGNMENT_BYTES // (
+                2 * self.num_buffer_smem_input_idx
+            )
+        candidate_capacity -= candidate_capacity % capacity_alignment
+        return min(candidate_capacity, self.max_num_cols)
+
+    def _compute_smem_input_size_for_occupancy(self, target_blocks_per_sm: int) -> int:
+        """Compute candidate capacity for the requested resident CTA count.
+
+        Rubin accounts for its selected SMEM tier and fixed allocations.
+        Blackwell preserves the tuned 128 KiB candidate-only budget.
+        """
+        # Fail fast: both the Rubin and Blackwell paths below floor-divide the
+        # per-CTA SMEM budget by target_blocks_per_sm, so a zero/negative value
+        # would raise an opaque ZeroDivisionError (or size the buffer negatively)
+        # deep in the sizing math instead of here. Unreachable for the supported
+        # launch bounds (>= 1); kept as a hard invariant at the point of use.
+        if target_blocks_per_sm < 1:
+            raise ValueError(
+                f"target_blocks_per_sm must be >= 1, got {target_blocks_per_sm}"
+            )
+        if self.architecture in _RUBIN_TOPK_ARCHITECTURES:
+            return self._compute_rubin_smem_input_size(target_blocks_per_sm)
+
+        idx_sz = 2 if self.index_type == cutlass.Uint16 else 4
+        if not self.cache_smem_values:
+            # cache_smem_values=False: reserve ~104 KB L1 for load-instruction caching.
+            INPUT_IDX_BUDGET_BASE = 128 * 1024  # 128 KB at 1 block/SM
+            input_idx_budget = INPUT_IDX_BUDGET_BASE // target_blocks_per_sm
+            if self.overflow_policy == "BOUNDED_SPILL":
+                # reserve the g_num_input + s_overflow_flag SMEM slots (both
+                # allocated only for BOUNDED_SPILL) so the candidate buffer does
+                # not over-subscribe SMEM at >1 CTA/SM.
+                input_idx_budget -= 2 * _SMEM_ALIGNMENT_BYTES
+            max_S = input_idx_budget // (self.num_buffer_smem_input_idx * idx_sz)
+        else:
+            # cache_smem_values=True: same 128 KB budget as csv=False, with slot_sz
+            # = idx_sz + val_sz so SMEM per block stays ~38 KB at target=4 → L1
+            # unchanged. A device-budget formula that maximises S (→4864 for fp32)
+            # was tried but caused 5-9% regressions on large-num_tokens single-CTA
+            # configs; root cause not yet confirmed, kept in git history.
+            INPUT_IDX_BUDGET_BASE = 128 * 1024  # 128 KB at 1 block/SM
+            input_idx_budget = INPUT_IDX_BUDGET_BASE // target_blocks_per_sm
+            if self.overflow_policy == "BOUNDED_SPILL":
+                # reserve the g_num_input + s_overflow_flag SMEM slots (both
+                # allocated only for BOUNDED_SPILL) so the candidate buffer does
+                # not over-subscribe SMEM at >1 CTA/SM.
+                input_idx_budget -= 2 * _SMEM_ALIGNMENT_BYTES
+            val_sz = self.ordered_type.width // 8  # fp32→Uint32=4B, fp16/bf16→Uint16=2B
+            slot_sz = idx_sz + val_sz
+            max_S = input_idx_budget // (self.num_buffer_smem_input_idx * slot_sz)
+        return min(max_S, self.max_num_cols)
+
+    @cute.jit
+    def to_coarse_key(self, x):
+        """Convert to coarse 8-bit key for histogram"""
+
+        if cutlass.const_expr(self.dtype == cutlass.Float32):
+            # Convert to FP16 and extract high 8 bits
+            h = x.to(cutlass.Float16)
+            bits = half_as_ushort(h)
+
+            key = cutlass.Uint16(0)
+
+            # extract the sign bit
+            # key = (bits & 0x8000) ? bits : ~bits & 0x7fff;
+            if bits & 0x8000:
+                key = cutlass.Uint16(bits)
+            else:
+                key = (bits ^ cutlass.Uint16(0xFFFF)) & cutlass.Uint16(0x7FFF)
+
+            # high 8 bits
+            return cute.Uint8((key >> 8) & 0xFF)
+        else:
+            # For half/bfloat16, extract high 8 bits directly
+            bits = half_as_ushort(x)
+
+            key = cute.Uint16(0)
+            if bits & 0x8000:
+                key = cutlass.Uint16(bits)
+            else:
+                key = (bits ^ cutlass.Uint16(0xFFFF)) & cutlass.Uint16(0x7FFF)
+            # high 8 bits
+            return cute.Uint8((key >> 8) & 0xFF)
+
+    @cute.jit
+    def to_ordered(self, x):
+        """Convert to ordered integer for comparison"""
+        if cutlass.const_expr(self.dtype == cutlass.Float32):
+            bits = float_as_uint32(x)
+
+            key = cutlass.Uint32(0)
+            if bits & 0x80000000:
+                key = cutlass.Uint32(bits)
+            else:
+                key = (bits ^ cutlass.Uint32(0xFFFFFFFF)) & cutlass.Uint32(0x7FFFFFFF)
+            return cute.Uint32(key)
+        else:
+            bits = half_as_ushort(x)
+
+            key = cute.Uint16(0)
+            if bits & 0x8000:
+                key = cutlass.Uint16(bits)
+            else:
+                key = (bits ^ cute.Uint16(0xFFFF)) & cute.Uint16(0x7FFF)
+            return cute.Uint16(key)
+
+    @cute.jit
+    def to_ordered_and_coarse(self, x):
+        """Return (ordered, coarse_key) for x.
+        For bf16/fp16, shares the half_as_ushort + sign-flip computation.
+        For fp32, the two transforms differ (fp32->fp16 truncation vs full 32-bit
+        sign-flip), so both are computed independently.
+        """
+        if cutlass.const_expr(self.dtype == cutlass.Float32):
+            return self.to_ordered(x), self.to_coarse_key(x)
+        else:
+            ordered = self.to_ordered(x)
+            coarse_shift = cutlass.const_expr(
+                self.ordered_type.width - int(math.log2(self.radix))
+            )
+            coarse = cute.Uint8(
+                (ordered >> self.ordered_type(coarse_shift)) & self.ordered_type(0xFF)
+            )
+            return ordered, coarse
+
+    @cute.jit
+    def _collect_below_threshold_coarse(
+        self,
+        tidx,
+        threshold_bin,
+        s_counter,
+        s_indices,
+        _copy_atom,
+        scan_frag,
+        _aligned_base,
+        vec_start,
+        aligned_size,
+        score,
+        row_start,
+        prologue_elems,
+        left_start,
+        left_size,
+    ):
+        """Collect all indices with coarse bin < threshold_bin from GMEM, then barrier."""
+        val_one = cutlass.Int32(1)
+        _elem_bytes = self.dtype.width // 8
+        _align_bytes = self.num_copy_bits // 8
+        _step_vec = self.num_threads_per_cta * self.vec_size
+        vec_size = self.vec_size
+        # load-instruction unroll (unroll_factor) for the REREAD 2nd-scan collect, matching
+        # the coarse/filter scans. unroll_factor 1 == original while.
+        ic0 = tidx * cutlass.Int32(vec_size)
+        big_iters = cutlass.Int32(0)
+        if aligned_size > ic0 + cutlass.Int32(vec_size - 1):
+            big_iters = (aligned_size - ic0 - cutlass.Int32(vec_size)) // cutlass.Int32(
+                _step_vec
+            ) + cutlass.Int32(1)
+        for _k in cutlass.range(big_iters, unroll=self.unroll_factor):
+            ic = ic0 + _k * cutlass.Int32(_step_vec)
+            cute.copy(
+                _copy_atom,
+                cute.make_tensor(
+                    cute.make_ptr(
+                        self.dtype,
+                        _aligned_base + cutlass.Int64(ic) * cutlass.Int64(_elem_bytes),
+                        cute.AddressSpace.gmem,
+                        assumed_align=_align_bytes,
+                    ),
+                    cute.make_layout((vec_size,)),
+                ),
+                scan_frag,
+            )
+            for j in cutlass.range_constexpr(vec_size):
+                bin_val = self.to_coarse_key(scan_frag[j])
+                if bin_val < threshold_bin:
+                    pos = atomic_add(s_counter.iterator, val_one)
+                    s_indices[pos] = self.index_type(vec_start + ic + cutlass.Int32(j))
+
+        for j in range(tidx, prologue_elems, self.num_threads_per_cta):
+            col_idx = cutlass.Int32(row_start + j)
+            raw = score[col_idx]
+            bin_val = self.to_coarse_key(raw)
+            if bin_val < threshold_bin:
+                pos = atomic_add(s_counter.iterator, val_one)
+                s_indices[pos] = self.index_type(col_idx)
+
+        for j in range(tidx, left_size, self.num_threads_per_cta):
+            col_idx = cutlass.Int32(left_start + j)
+            raw = score[col_idx]
+            bin_val = self.to_coarse_key(raw)
+            if bin_val < threshold_bin:
+                pos = atomic_add(s_counter.iterator, val_one)
+                s_indices[pos] = self.index_type(col_idx)
+
+        cute.arch.barrier()
+
+    @cute.jit
+    def _collect_below_threshold_refine(
+        self,
+        tidx,
+        threshold,
+        offset,
+        num_input,
+        r_idx,
+        s_input_idx,
+        s_input_val,
+        score,
+        s_counter,
+        s_indices,
+        cur_g_num_input,
+        buffer,
+    ):
+        """Collect all indices with refined bin < threshold from SMEM (and GMEM buffer), then barrier."""
+        val_one = cutlass.Int32(1)
+        for i in range(tidx, num_input, self.num_threads_per_cta):
+            idx = s_input_idx[r_idx, i]
+            idx = cutlass.Int32(cutlass.Uint32(idx))
+            if cutlass.const_expr(self.cache_smem_values):
+                bin_val = (self.ordered_type(s_input_val[r_idx, i]) >> offset) & 0xFF
+            else:
+                bin_val = (self.to_ordered(score[idx]) >> offset) & 0xFF
+            if bin_val < threshold:
+                pos = atomic_add(s_counter.iterator, val_one)
+                s_indices[pos] = self.index_type(idx)
+        if cutlass.const_expr(self.enable_gmem_store or self.enable_bounded_spill):
+            for i in range(tidx, cur_g_num_input, self.num_threads_per_cta):
+                idx = buffer[r_idx, i]
+                bin_val = (self.to_ordered(score[idx]) >> offset) & 0xFF
+                if bin_val < threshold:
+                    pos = atomic_add(s_counter.iterator, val_one)
+                    s_indices[pos] = self.index_type(idx)
+        cute.arch.barrier()
+
+    @cute.jit
+    def _filter_and_histogram_per_elem_coarse(
+        self,
+        bin_val,
+        threshold_bin,
+        idx,
+        raw_input,
+        s_counter,
+        s_indices,
+        s_input_idx,
+        s_input_val,
+        s_num_input,
+        s_histogram,
+        g_num_input,
+        buffer,
+        s_overflow_flag,
+    ):
+        """Per-element if/elif handler for the coarse filter pass.
+
+        bin_val < threshold_bin  → write to s_indices.
+        bin_val == threshold_bin → store to s_input_idx (+ optional buffer) and
+                                   update s_histogram for the next refinement round.
+        """
+        val_one = cutlass.Int32(1)
+        if bin_val < threshold_bin:
+            pos = atomic_add(s_counter.iterator, val_one)
+            s_indices[pos] = idx
+        elif bin_val == threshold_bin:
+            if cutlass.const_expr(self.enable_gmem_store):
+                # Hoist ordered before the pos < S check so s_input_val can be written inside it.
+                ordered = self.to_ordered(raw_input)
+                pos = atomic_add(s_num_input.iterator, val_one)
+                if pos < self.filtered_topk_smem_input_size:
+                    s_input_idx[0, pos] = idx
+                    if cutlass.const_expr(self.cache_smem_values):
+                        s_input_val[0, pos] = ordered
+                else:
+                    buffer_pos = atomic_add(g_num_input.iterator, val_one)
+                    buffer[0, buffer_pos] = cutlass.Int32(cutlass.Uint32(idx))
+                sub_bin = (ordered >> self.first_refine_shift) & 0xFF
+                atomic_add(s_histogram.iterator + cutlass.Int32(sub_bin), val_one)
+            elif cutlass.const_expr(self.enable_bounded_spill):
+                # Like GMEM_SPILL, but the GMEM buffer is size-capped at
+                # G = its own extent (buffer.shape[1]); once even G is full,
+                # set s_overflow_flag so the refine loop falls back to the
+                # REREAD second scan (tier 3). 3-tier degrade
+                # SMEM -> bounded GMEM -> reread, keeping extra_buffer O(G)
+                # instead of GMEM_SPILL's O(max_num_cols).
+                ordered = self.to_ordered(raw_input)
+                pos = atomic_add(s_num_input.iterator, val_one)
+                if pos < self.filtered_topk_smem_input_size:
+                    s_input_idx[0, pos] = idx
+                    if cutlass.const_expr(self.cache_smem_values):
+                        s_input_val[0, pos] = ordered
+                else:
+                    buffer_pos = atomic_add(g_num_input.iterator, val_one)
+                    if buffer_pos < cute.size(buffer.shape, [1]):
+                        buffer[0, buffer_pos] = cutlass.Int32(cutlass.Uint32(idx))
+                    else:
+                        atomic_add(s_overflow_flag.iterator, val_one)
+                sub_bin = (ordered >> self.first_refine_shift) & 0xFF
+                atomic_add(s_histogram.iterator + cutlass.Int32(sub_bin), val_one)
+            elif cutlass.const_expr(self.enable_truncate):
+                if cutlass.const_expr(self.dtype == cutlass.Float32):
+                    ordered = cutlass.Uint32(0)
+                    sub_bin = cutlass.Uint32(0)
+                else:
+                    ordered = cutlass.Uint16(0)
+                    sub_bin = cutlass.Int32(0)
+                pos = atomic_add(s_num_input.iterator, val_one)
+                if pos < self.filtered_topk_smem_input_size:
+                    s_input_idx[0, pos] = idx
+                    ordered = self.to_ordered(raw_input)
+                    if cutlass.const_expr(self.cache_smem_values):
+                        s_input_val[0, pos] = ordered
+                    sub_bin = (ordered >> self.first_refine_shift) & 0xFF
+                    atomic_add(s_histogram.iterator + cutlass.Int32(sub_bin), val_one)
+            elif cutlass.const_expr(self.enable_reread):
+                # Hoist ordered before the pos < S check so s_input_val can be written inside it.
+                ordered = self.to_ordered(raw_input)
+                pos = atomic_add(s_num_input.iterator, val_one)
+                if pos < self.filtered_topk_smem_input_size:
+                    s_input_idx[0, pos] = idx
+                    if cutlass.const_expr(self.cache_smem_values):
+                        s_input_val[0, pos] = ordered
+                else:
+                    # Use atomic_add (not plain store) to avoid concurrent non-atomic writes
+                    # from multiple threads to the same SMEM address.  Any non-zero value
+                    # means overflow; the did_overflow check uses != 0.
+                    atomic_add(s_overflow_flag.iterator, val_one)
+                sub_bin = (ordered >> self.first_refine_shift) & 0xFF
+                atomic_add(s_histogram.iterator + cutlass.Int32(sub_bin), val_one)
+            else:
+                # Hoist ordered before the pos < S check so s_input_val can be written inside it.
+                ordered = self.to_ordered(raw_input)
+                if cutlass.const_expr(not self.enable_reread_always):
+                    pos = atomic_add(s_num_input.iterator, val_one)
+                    if pos < self.filtered_topk_smem_input_size:
+                        s_input_idx[0, pos] = idx
+                        if cutlass.const_expr(self.cache_smem_values):
+                            s_input_val[0, pos] = ordered
+                sub_bin = (ordered >> self.first_refine_shift) & 0xFF
+                atomic_add(s_histogram.iterator + cutlass.Int32(sub_bin), val_one)
+
+    @cute.jit
+    def _filter_and_histogram_per_elem_refine(
+        self,
+        bin_val,
+        threshold,
+        idx_int32,
+        ordered_val,
+        offset,
+        r_idx,
+        is_last_round,
+        s_counter,
+        s_indices,
+        s_input_idx,
+        s_input_val,
+        s_num_input,
+        s_histogram,
+        s_last_remain,
+        g_num_input,
+        buffer,
+    ):
+        """Per-element if/elif handler for refinement rounds.
+
+        idx_int32   – Int32 column index, used for score lookup and buffer writes.
+        ordered_val – pre-computed self.to_ordered(raw_input); avoids recomputing
+                      it for sub_bin extraction when bin_val == threshold.
+
+        bin_val < threshold  → write to s_indices.
+        bin_val == threshold → last round: s_last_remain countdown;
+                               otherwise: store to s_input_idx[r_idx^1] (+ optional
+                               buffer) and update s_histogram for the next round.
+        """
+        val_one = cutlass.Int32(1)
+        val_one_negative = cutlass.Int32(-1)
+        idx = self.index_type(idx_int32)
+        if bin_val < threshold:
+            pos = atomic_add(s_counter.iterator, val_one)
+            s_indices[pos] = idx
+        elif bin_val == threshold:
+            if is_last_round:
+                cur_pos = atomic_add(s_last_remain.iterator, val_one_negative)
+                if cur_pos > 0:
+                    s_indices[self.top_k - cur_pos] = idx
+            else:
+                cur_pos = atomic_add(s_num_input.iterator + (r_idx ^ 1), val_one)
+                if cutlass.const_expr(
+                    self.enable_gmem_store or self.enable_bounded_spill
+                ):
+                    if cur_pos < self.filtered_topk_smem_input_size:
+                        s_input_idx[r_idx ^ 1, cur_pos] = idx
+                        if cutlass.const_expr(self.cache_smem_values):
+                            s_input_val[r_idx ^ 1, cur_pos] = ordered_val
+                    else:
+                        buffer_pos = atomic_add(
+                            g_num_input.iterator + (r_idx ^ 1), val_one
+                        )
+                        buffer[r_idx ^ 1, buffer_pos] = idx_int32
+                    sub_bin = (ordered_val >> (offset - 8)) & 0xFF
+                    atomic_add(s_histogram.iterator + cutlass.Int32(sub_bin), val_one)
+                else:
+                    if cutlass.const_expr(self.dtype == cutlass.Float32):
+                        sub_bin = cutlass.Uint32(0)
+                    else:
+                        sub_bin = cutlass.Int32(0)
+                    if cur_pos < self.filtered_topk_smem_input_size:
+                        s_input_idx[r_idx ^ 1, cur_pos] = idx
+                        if cutlass.const_expr(self.cache_smem_values):
+                            s_input_val[r_idx ^ 1, cur_pos] = ordered_val
+                        sub_bin = (ordered_val >> (offset - 8)) & 0xFF
+                        atomic_add(
+                            s_histogram.iterator + cutlass.Int32(sub_bin), val_one
+                        )
+
+    @cute.jit
+    def _filter_and_histogram_coarse(
+        self,
+        tidx,
+        threshold_bin,
+        s_counter,
+        s_indices,
+        s_input_idx,
+        s_input_val,
+        s_num_input,
+        s_histogram,
+        g_num_input,
+        buffer,
+        _copy_atom,
+        scan_frag,
+        _aligned_base,
+        vec_start,
+        aligned_size,
+        score,
+        row_start,
+        prologue_elems,
+        left_start,
+        left_size,
+        s_overflow_flag,
+        tma_atom=None,
+        tma_tensor=None,
+        s_tma_stage_p3=None,
+        s_tma_mbar_p3=None,
+        bidx=0,
+    ):
+        """Reset histogram, filter all input elements through three loops, then barrier.
+
+        Covers vec-aligned GMEM, prologue scalar, and left scalar segments. When
+        enable_tma_load_p3, the vec-aligned segment is loaded via an async-TMA ring
+        (aliasing the idle candidate buffer 1) instead of synchronous LDG.
+        """
+        _elem_bytes = self.dtype.width // 8
+        _align_bytes = self.num_copy_bits // 8
+        _step_vec = self.num_threads_per_cta * self.vec_size
+        _ik_f3_clear = self._iket_begin("f3_clear")
+        cute.arch.barrier()
+        for _hi in range(tidx, self.radix + 1, self.num_threads_per_cta):
+            s_histogram[_hi] = 0
+        cute.arch.barrier()
+        self._iket_end(_ik_f3_clear)
+
+        _ik_f3_vec = self._iket_begin("f3_vecscan")
+        if cutlass.const_expr(self.enable_tma_load_p3):
+            # Row-native async-TMA filter over the whole row (subsumes prologue/left,
+            # gated off below). Staging aliases the idle candidate buffer 1.
+            self._build_coarse_filter_tma(
+                tidx,
+                threshold_bin,
+                tma_atom,
+                tma_tensor,
+                s_tma_stage_p3,
+                s_tma_mbar_p3,
+                bidx,
+                row_start,
+                left_start + left_size - row_start,
+                score,
+                s_counter,
+                s_indices,
+                s_input_idx,
+                s_input_val,
+                s_num_input,
+                s_histogram,
+                g_num_input,
+                buffer,
+                s_overflow_flag,
+            )
+        else:
+            vec_size = self.vec_size
+            # load-instruction unroll (unroll_factor): a counted range over the
+            # full-vec trip count overlaps loads vs the 1-in-flight while (1 ==
+            # orig); the scalar prologue/left loops below cover the remainder.
+            ic0 = tidx * cutlass.Int32(vec_size)
+            big_iters = cutlass.Int32(0)
+            if aligned_size > ic0 + cutlass.Int32(vec_size - 1):
+                big_iters = (
+                    aligned_size - ic0 - cutlass.Int32(vec_size)
+                ) // cutlass.Int32(_step_vec) + cutlass.Int32(1)
+            for _k in cutlass.range(big_iters, unroll=self.unroll_factor):
+                ic = ic0 + _k * cutlass.Int32(_step_vec)
+                cute.copy(
+                    _copy_atom,
+                    cute.make_tensor(
+                        cute.make_ptr(
+                            self.dtype,
+                            _aligned_base
+                            + cutlass.Int64(ic) * cutlass.Int64(_elem_bytes),
+                            cute.AddressSpace.gmem,
+                            assumed_align=_align_bytes,
+                        ),
+                        cute.make_layout((vec_size,)),
+                    ),
+                    scan_frag,
+                )
+                for j in cutlass.range_constexpr(vec_size):
+                    raw_input = scan_frag[j]
+                    bin_val = self.to_coarse_key(raw_input)
+                    idx = self.index_type(vec_start + ic + cutlass.Int32(j))
+                    self._filter_and_histogram_per_elem_coarse(
+                        bin_val,
+                        threshold_bin,
+                        idx,
+                        raw_input,
+                        s_counter,
+                        s_indices,
+                        s_input_idx,
+                        s_input_val,
+                        s_num_input,
+                        s_histogram,
+                        g_num_input,
+                        buffer,
+                        s_overflow_flag,
+                    )
+        self._iket_end(_ik_f3_vec)
+
+        _ik_f3_tail = self._iket_begin("f3_scalartail")
+        # The TMA filter path already scans the whole row (its own sub-tile edges);
+        # skip the LDG prologue/left when enable_tma_load_p3 to avoid double-counting.
+        if cutlass.const_expr(not self.enable_tma_load_p3):
+            for j in range(tidx, prologue_elems, self.num_threads_per_cta):
+                col_idx = cutlass.Int32(row_start + j)
+                raw = score[col_idx]
+                bin_val = self.to_coarse_key(raw)
+                idx = self.index_type(col_idx)
+                self._filter_and_histogram_per_elem_coarse(
+                    bin_val,
+                    threshold_bin,
+                    idx,
+                    raw,
+                    s_counter,
+                    s_indices,
+                    s_input_idx,
+                    s_input_val,
+                    s_num_input,
+                    s_histogram,
+                    g_num_input,
+                    buffer,
+                    s_overflow_flag,
+                )
+
+            for j in range(tidx, left_size, self.num_threads_per_cta):
+                col_idx = cutlass.Int32(left_start + j)
+                raw = score[col_idx]
+                bin_val = self.to_coarse_key(raw)
+                idx = self.index_type(col_idx)
+                self._filter_and_histogram_per_elem_coarse(
+                    bin_val,
+                    threshold_bin,
+                    idx,
+                    raw,
+                    s_counter,
+                    s_indices,
+                    s_input_idx,
+                    s_input_val,
+                    s_num_input,
+                    s_histogram,
+                    g_num_input,
+                    buffer,
+                    s_overflow_flag,
+                )
+        self._iket_end(_ik_f3_tail)
+
+        _ik_f3_bar = self._iket_begin("f3_finalbar")
+        fence_acq_rel_cta()
+        cute.arch.barrier()
+        self._iket_end(_ik_f3_bar)
+
+    @cute.jit
+    def _reread_always_per_elem_output(
+        self,
+        include_threshold,
+        raw,
+        col_idx,
+        threshold_bin,
+        T2,
+        offset,
+        chain_mask,
+        chain_prefix,
+        s_counter,
+        s_indices,
+        s_last_remain,
+    ):
+        """Per-element handler for REREAD_ALWAYS output scan.
+        include_threshold is a compile-time bool.
+        chain_mask is a DSL Int32 runtime value; chain_prefix is a runtime DSL
+        ordered_type value. Both carry accumulated prior-round constraints.
+        When chain_mask == 0 (round 0), ordered & 0 == 0 is always True.
+        """
+        ordered, coarse = self.to_ordered_and_coarse(raw)
+        if coarse == threshold_bin:
+            passes_chain = (ordered & self.ordered_type(chain_mask)) == chain_prefix
+            if passes_chain:
+                bin_val = (ordered >> offset) & 0xFF
+                idx = self.index_type(col_idx)
+                val_one = cutlass.Int32(1)
+                if bin_val < T2:
+                    pos = atomic_add(s_counter.iterator, val_one)
+                    s_indices[pos] = idx
+                elif cutlass.const_expr(include_threshold):
+                    if bin_val == T2:
+                        cur_pos = atomic_add(s_last_remain.iterator, cutlass.Int32(-1))
+                        if cur_pos > 0:
+                            s_indices[self.top_k - cur_pos] = idx
+
+    @cute.jit
+    def _reread_always_per_elem_combined(
+        self,
+        raw,
+        col_idx,
+        threshold_bin,
+        T2,
+        offset,
+        chain_mask,
+        chain_prefix,
+        s_counter,
+        s_indices,
+        s_histogram,
+    ):
+        """Per-element handler for REREAD_ALWAYS non-last-round combined scan.
+        chain_mask is a DSL Int32 runtime value; chain_prefix is a runtime DSL
+        ordered_type value. Both carry accumulated prior-round constraints.
+        For elements passing coarse + chain filters:
+          bin_val < T2  → write col_idx to s_indices (definitely top-K).
+          bin_val == T2 → histogram at (ordered >> (offset - 8)) & 0xFF.
+        """
+        ordered, coarse = self.to_ordered_and_coarse(raw)
+        if coarse == threshold_bin:
+            passes_chain = (ordered & self.ordered_type(chain_mask)) == chain_prefix
+            if passes_chain:
+                bin_val = (ordered >> offset) & 0xFF
+                val_one = cutlass.Int32(1)
+                if bin_val < T2:
+                    pos = atomic_add(s_counter.iterator, val_one)
+                    s_indices[pos] = self.index_type(col_idx)
+                elif bin_val == T2:
+                    next_sub_bin = (ordered >> (offset - 8)) & 0xFF
+                    atomic_add(
+                        s_histogram.iterator + cutlass.Int32(next_sub_bin), val_one
+                    )
+
+    @cute.jit
+    def _reread_always_gmem_output_scan(
+        self,
+        include_threshold,
+        tidx,
+        threshold_bin,
+        T2,
+        offset,
+        chain_mask,
+        chain_prefix,
+        score,
+        s_counter,
+        s_indices,
+        s_last_remain,
+        _copy_atom,
+        scan_frag,
+        _aligned_base,
+        vec_start,
+        aligned_size,
+        row_start,
+        prologue_elems,
+        left_start,
+        left_size,
+    ):
+        """GMEM scan for REREAD_ALWAYS output phase.
+        include_threshold is a compile-time bool.
+        chain_mask is a DSL Int32 runtime value; chain_prefix is a runtime DSL
+        ordered_type value — both carry prior-round constraints.
+        Scans all three GMEM segments and writes qualifying indices to s_indices.
+        Ends with cute.arch.barrier() to sync all writes before Phase 3.
+        """
+        _elem_bytes = self.dtype.width // 8
+        _align_bytes = self.num_copy_bits // 8
+        _step_vec = self.num_threads_per_cta * self.vec_size
+        vec_size = self.vec_size
+
+        # load-instruction unroll (unroll_factor) for the REREAD_ALWAYS output rescan.
+        ic0 = tidx * cutlass.Int32(vec_size)
+        big_iters = cutlass.Int32(0)
+        if aligned_size > ic0 + cutlass.Int32(vec_size - 1):
+            big_iters = (aligned_size - ic0 - cutlass.Int32(vec_size)) // cutlass.Int32(
+                _step_vec
+            ) + cutlass.Int32(1)
+        for _k in cutlass.range(big_iters, unroll=self.unroll_factor):
+            ic = ic0 + _k * cutlass.Int32(_step_vec)
+            cute.copy(
+                _copy_atom,
+                cute.make_tensor(
+                    cute.make_ptr(
+                        self.dtype,
+                        _aligned_base + cutlass.Int64(ic) * cutlass.Int64(_elem_bytes),
+                        cute.AddressSpace.gmem,
+                        assumed_align=_align_bytes,
+                    ),
+                    cute.make_layout((vec_size,)),
+                ),
+                scan_frag,
+            )
+            for j in cutlass.range_constexpr(vec_size):
+                col_idx = cutlass.Int32(vec_start + ic + cutlass.Int32(j))
+                self._reread_always_per_elem_output(
+                    include_threshold,
+                    scan_frag[j],
+                    col_idx,
+                    threshold_bin,
+                    T2,
+                    offset,
+                    chain_mask,
+                    chain_prefix,
+                    s_counter,
+                    s_indices,
+                    s_last_remain,
+                )
+
+        for j in range(tidx, prologue_elems, self.num_threads_per_cta):
+            col_idx = cutlass.Int32(row_start + j)
+            raw = score[col_idx]
+            self._reread_always_per_elem_output(
+                include_threshold,
+                raw,
+                col_idx,
+                threshold_bin,
+                T2,
+                offset,
+                chain_mask,
+                chain_prefix,
+                s_counter,
+                s_indices,
+                s_last_remain,
+            )
+
+        for j in range(tidx, left_size, self.num_threads_per_cta):
+            col_idx = cutlass.Int32(left_start + j)
+            raw = score[col_idx]
+            self._reread_always_per_elem_output(
+                include_threshold,
+                raw,
+                col_idx,
+                threshold_bin,
+                T2,
+                offset,
+                chain_mask,
+                chain_prefix,
+                s_counter,
+                s_indices,
+                s_last_remain,
+            )
+
+        cute.arch.barrier()
+
+    @cute.jit
+    def _reread_always_gmem_combined_scan(
+        self,
+        tidx,
+        threshold_bin,
+        T2,
+        offset,
+        chain_mask,
+        chain_prefix,
+        score,
+        s_counter,
+        s_indices,
+        s_histogram,
+        _copy_atom,
+        scan_frag,
+        _aligned_base,
+        vec_start,
+        aligned_size,
+        row_start,
+        prologue_elems,
+        left_start,
+        left_size,
+    ):
+        """GMEM scan for REREAD_ALWAYS non-last rounds: reset histogram, output < T2
+        elements, and build histogram for the next round.
+        chain_mask is a DSL Int32 runtime value; chain_prefix is a runtime DSL
+        ordered_type value — both carry prior-round constraints.
+        Ends with fence_acq_rel_cta() + cute.arch.barrier().
+        Returns updated chain_prefix (runtime DSL value); caller updates chain_mask
+        via | (cutlass.Int32(0xFF) << offset).
+        """
+        _elem_bytes = self.dtype.width // 8
+        _align_bytes = self.num_copy_bits // 8
+        _step_vec = self.num_threads_per_cta * self.vec_size
+        vec_size = self.vec_size
+
+        # Barrier before clearing s_histogram: ensures all threads have already
+        # read s_histogram[threshold-1] to update topk_remaining in the caller
+        # before any thread starts zeroing it here.
+        cute.arch.barrier()
+        for _hi in range(tidx, self.radix + 1, self.num_threads_per_cta):
+            s_histogram[_hi] = 0
+        cute.arch.barrier()
+
+        # load-instruction unroll (unroll_factor) for the REREAD_ALWAYS combined rescan.
+        ic0 = tidx * cutlass.Int32(vec_size)
+        big_iters = cutlass.Int32(0)
+        if aligned_size > ic0 + cutlass.Int32(vec_size - 1):
+            big_iters = (aligned_size - ic0 - cutlass.Int32(vec_size)) // cutlass.Int32(
+                _step_vec
+            ) + cutlass.Int32(1)
+        for _k in cutlass.range(big_iters, unroll=self.unroll_factor):
+            ic = ic0 + _k * cutlass.Int32(_step_vec)
+            cute.copy(
+                _copy_atom,
+                cute.make_tensor(
+                    cute.make_ptr(
+                        self.dtype,
+                        _aligned_base + cutlass.Int64(ic) * cutlass.Int64(_elem_bytes),
+                        cute.AddressSpace.gmem,
+                        assumed_align=_align_bytes,
+                    ),
+                    cute.make_layout((vec_size,)),
+                ),
+                scan_frag,
+            )
+            for j in cutlass.range_constexpr(vec_size):
+                col_idx = cutlass.Int32(vec_start + ic + cutlass.Int32(j))
+                self._reread_always_per_elem_combined(
+                    scan_frag[j],
+                    col_idx,
+                    threshold_bin,
+                    T2,
+                    offset,
+                    chain_mask,
+                    chain_prefix,
+                    s_counter,
+                    s_indices,
+                    s_histogram,
+                )
+
+        for j in range(tidx, prologue_elems, self.num_threads_per_cta):
+            col_idx = cutlass.Int32(row_start + j)
+            raw = score[col_idx]
+            self._reread_always_per_elem_combined(
+                raw,
+                col_idx,
+                threshold_bin,
+                T2,
+                offset,
+                chain_mask,
+                chain_prefix,
+                s_counter,
+                s_indices,
+                s_histogram,
+            )
+
+        for j in range(tidx, left_size, self.num_threads_per_cta):
+            col_idx = cutlass.Int32(left_start + j)
+            raw = score[col_idx]
+            self._reread_always_per_elem_combined(
+                raw,
+                col_idx,
+                threshold_bin,
+                T2,
+                offset,
+                chain_mask,
+                chain_prefix,
+                s_counter,
+                s_indices,
+                s_histogram,
+            )
+
+        fence_acq_rel_cta()
+        cute.arch.barrier()
+
+        # Return updated chain_prefix (runtime DSL value).
+        # Caller updates chain_mask via | (cutlass.Int32(0xFF) << offset).
+        return chain_prefix | self.ordered_type(
+            self.ordered_type(T2) << self.ordered_type(offset)
+        )
+
+    @cute.jit
+    def _reread_gmem_rescan(
+        self,
+        topk_remaining,
+        is_last_round,
+        tidx,
+        threshold_bin,
+        threshold,
+        offset,
+        chain_mask,
+        chain_prefix,
+        score,
+        s_counter,
+        s_indices,
+        s_last_remain,
+        s_histogram,
+        _copy_atom,
+        scan_frag,
+        _aligned_base,
+        vec_start,
+        aligned_size,
+        row_start,
+        prologue_elems,
+        left_start,
+        left_size,
+    ):
+        """GMEM re-scan phase shared by REREAD_ALWAYS and REREAD-overflow paths.
+
+        Returns (run_next_round, chain_mask, chain_prefix).
+        """
+        run_next_round = True
+        if topk_remaining == 0:
+            self._reread_always_gmem_output_scan(
+                False,
+                tidx,
+                threshold_bin,
+                threshold,
+                offset,
+                chain_mask,
+                chain_prefix,
+                score,
+                s_counter,
+                s_indices,
+                s_last_remain,
+                _copy_atom,
+                scan_frag,
+                _aligned_base,
+                vec_start,
+                aligned_size,
+                row_start,
+                prologue_elems,
+                left_start,
+                left_size,
+            )
+            run_next_round = False
+        else:
+            if is_last_round:
+                self._reread_always_gmem_output_scan(
+                    True,
+                    tidx,
+                    threshold_bin,
+                    threshold,
+                    offset,
+                    chain_mask,
+                    chain_prefix,
+                    score,
+                    s_counter,
+                    s_indices,
+                    s_last_remain,
+                    _copy_atom,
+                    scan_frag,
+                    _aligned_base,
+                    vec_start,
+                    aligned_size,
+                    row_start,
+                    prologue_elems,
+                    left_start,
+                    left_size,
+                )
+            else:
+                chain_prefix = self._reread_always_gmem_combined_scan(
+                    tidx,
+                    threshold_bin,
+                    threshold,
+                    offset,
+                    chain_mask,
+                    chain_prefix,
+                    score,
+                    s_counter,
+                    s_indices,
+                    s_histogram,
+                    _copy_atom,
+                    scan_frag,
+                    _aligned_base,
+                    vec_start,
+                    aligned_size,
+                    row_start,
+                    prologue_elems,
+                    left_start,
+                    left_size,
+                )
+                chain_mask = chain_mask | (cutlass.Int32(0xFF) << cutlass.Int32(offset))
+        return run_next_round, chain_mask, chain_prefix
+
+    @cute.jit
+    def _filter_and_histogram_refine(
+        self,
+        tidx,
+        threshold,
+        offset,
+        r_idx,
+        is_last_round,
+        num_input,
+        cur_g_num_input,
+        score,
+        s_counter,
+        s_indices,
+        s_input_idx,
+        s_input_val,
+        s_num_input,
+        s_histogram,
+        s_last_remain,
+        g_num_input,
+        buffer,
+    ):
+        """Reset histogram, filter all threshold-bucket elements, then barrier.
+
+        Covers SMEM s_input_idx loop and optional GMEM buffer loop.
+        """
+        cute.arch.barrier()
+        for _hi in range(tidx, self.radix + 1, self.num_threads_per_cta):
+            s_histogram[_hi] = 0
+        cute.arch.barrier()
+
+        for i in range(tidx, num_input, self.num_threads_per_cta):
+            idx_tmp = s_input_idx[r_idx, i]
+            idx_int32 = cutlass.Int32(cutlass.Uint32(idx_tmp))
+            if cutlass.const_expr(self.cache_smem_values):
+                ordered_val = self.ordered_type(s_input_val[r_idx, i])
+            else:
+                raw_input = score[idx_int32]
+                ordered_val = self.to_ordered(raw_input)
+            bin_val = (ordered_val >> offset) & 0xFF
+            self._filter_and_histogram_per_elem_refine(
+                bin_val,
+                threshold,
+                idx_int32,
+                ordered_val,
+                offset,
+                r_idx,
+                is_last_round,
+                s_counter,
+                s_indices,
+                s_input_idx,
+                s_input_val,
+                s_num_input,
+                s_histogram,
+                s_last_remain,
+                g_num_input,
+                buffer,
+            )
+
+        if cutlass.const_expr(self.enable_gmem_store or self.enable_bounded_spill):
+            cute.arch.barrier()
+            for i in range(tidx, cur_g_num_input, self.num_threads_per_cta):
+                idx_int32 = buffer[r_idx, i]
+                raw_input = score[idx_int32]
+                ordered_val = self.to_ordered(raw_input)
+                bin_val = (ordered_val >> offset) & 0xFF
+                self._filter_and_histogram_per_elem_refine(
+                    bin_val,
+                    threshold,
+                    idx_int32,
+                    ordered_val,
+                    offset,
+                    r_idx,
+                    is_last_round,
+                    s_counter,
+                    s_indices,
+                    s_input_idx,
+                    s_input_val,
+                    s_num_input,
+                    s_histogram,
+                    s_last_remain,
+                    g_num_input,
+                    buffer,
+                )
+            fence_acq_rel_cta()
+        cute.arch.barrier()
+
+    @cute.jit
+    def prefix_sum_and_find_threshold_coarse(
+        self,
+        tidx,
+        s_histogram,
+        s_warp_sums,
+        num_warps,
+        s_threshold_bin_id,
+        s_num_input,
+        s_counter,
+        s_last_remain,
+        topk_remaining,
+        g_num_input,
+        s_num_input_idx=0,
+    ):
+        if cutlass.const_expr(self.radix <= self.num_threads_per_cta):
+            previous = 0
+            if tidx < cutlass.Int32(self.radix):
+                val = s_histogram[tidx]
+                val, total_sum = block_prefix_sum_kernel(
+                    val, s_warp_sums, tidx, self.radix, num_warps, barrier_id=1
+                )
+                s_histogram[tidx] = val
+                # sync among self.radix threads
+                cute.arch.barrier(barrier_id=1, number_of_threads=self.radix)
+
+                if tidx > 0:
+                    previous = s_histogram[tidx - 1]
+                if previous <= topk_remaining and s_histogram[tidx] > topk_remaining:
+                    s_threshold_bin_id[0] = tidx
+                    s_num_input[s_num_input_idx] = 0
+                    if cutlass.const_expr(
+                        self.enable_gmem_store or self.enable_bounded_spill
+                    ):
+                        g_num_input[s_num_input_idx] = 0
+                    s_counter[0] = 0
+            # sync among all threads in a cta.
+            cute.arch.barrier()
+        else:
+            assert self.radix % self.num_threads_per_cta == 0
+            previous_sum = 0
+            val = 0
+            total_sum = 0
+            for i in range(tidx, self.radix, self.num_threads_per_cta):
+                val = s_histogram[i]
+                val, total_sum = block_prefix_sum_kernel(
+                    val,
+                    s_warp_sums,
+                    tidx,
+                    self.num_threads_per_cta,
+                    num_warps,
+                    barrier_id=2,
+                    need_total_sum=True,
+                )
+                s_histogram[i] = val + previous_sum
+                previous_sum = previous_sum + total_sum
+            # sync among all threads in a cta.
+            cute.arch.barrier()
+
+            previous = 0
+            run_loop = True
+            if tidx > 0:
+                previous = s_histogram[tidx - 1]
+            if previous <= topk_remaining and s_histogram[tidx] > topk_remaining:
+                s_threshold_bin_id[0] = tidx
+                s_num_input[s_num_input_idx] = 0
+                if cutlass.const_expr(
+                    self.enable_gmem_store or self.enable_bounded_spill
+                ):
+                    g_num_input[s_num_input_idx] = 0
+                # the difference between coarse and fine-grained.
+                s_counter[0] = 0
+                run_loop = False
+
+            if run_loop:
+                run_next_loop = True
+                for i in range(
+                    tidx + self.num_threads_per_cta,
+                    self.radix,
+                    self.num_threads_per_cta,
+                ):
+                    if run_next_loop:
+                        previous = s_histogram[i - 1]
+                        if (
+                            previous <= topk_remaining
+                            and s_histogram[i] > topk_remaining
+                        ):
+                            s_threshold_bin_id[0] = i
+                            s_num_input[s_num_input_idx] = 0
+                            if cutlass.const_expr(
+                                self.enable_gmem_store or self.enable_bounded_spill
+                            ):
+                                g_num_input[s_num_input_idx] = 0
+                            # the difference between coarse and fine-grained.
+                            s_counter[0] = 0
+                            run_next_loop = False
+            # sync among all threads in a cta.
+            cute.arch.barrier()
+
+    @cute.jit
+    def prefix_sum_and_find_threshold_fine_grained(
+        self,
+        tidx,
+        s_histogram,
+        s_warp_sums,
+        num_warps,
+        s_threshold_bin_id,
+        s_num_input,
+        s_counter,
+        s_last_remain,
+        topk_remaining,
+        g_num_input,
+        s_num_input_idx=0,
+    ):
+        if cutlass.const_expr(self.radix <= self.num_threads_per_cta):
+            previous = 0
+            if tidx < cutlass.Int32(self.radix):
+                val = s_histogram[tidx]
+                val, total_sum = block_prefix_sum_kernel(
+                    val, s_warp_sums, tidx, self.radix, num_warps, barrier_id=1
+                )
+                s_histogram[tidx] = val
+                # sync
+                cute.arch.barrier(barrier_id=1, number_of_threads=self.radix)
+
+                if tidx > 0:
+                    previous = s_histogram[tidx - 1]
+                if previous <= topk_remaining and s_histogram[tidx] > topk_remaining:
+                    s_threshold_bin_id[0] = tidx
+                    s_num_input[s_num_input_idx] = 0
+                    if cutlass.const_expr(
+                        self.enable_gmem_store or self.enable_bounded_spill
+                    ):
+                        g_num_input[s_num_input_idx] = 0
+                    # the first difference between coarse and fine-grained.
+                    s_last_remain[0] = topk_remaining - previous
+            cute.arch.barrier()
+        else:
+            assert self.radix % self.num_threads_per_cta == 0
+            previous_sum = 0
+            val = 0
+            total_sum = 0
+            for i in range(tidx, self.radix, self.num_threads_per_cta):
+                val = s_histogram[i]
+                val, total_sum = block_prefix_sum_kernel(
+                    val,
+                    s_warp_sums,
+                    tidx,
+                    self.num_threads_per_cta,
+                    num_warps,
+                    barrier_id=2,
+                    need_total_sum=True,
+                )
+                s_histogram[i] = val + previous_sum
+                previous_sum = previous_sum + total_sum
+            # sync among all threads in a cta.
+            cute.arch.barrier()
+
+            previous = 0
+            run_loop = True
+            if tidx > 0:
+                previous = s_histogram[tidx - 1]
+            if previous <= topk_remaining and s_histogram[tidx] > topk_remaining:
+                s_threshold_bin_id[0] = tidx
+                s_num_input[s_num_input_idx] = 0
+                if cutlass.const_expr(
+                    self.enable_gmem_store or self.enable_bounded_spill
+                ):
+                    g_num_input[s_num_input_idx] = 0
+                # the difference between coarse and fine-grained.
+                s_last_remain[0] = topk_remaining - previous
+                run_loop = False
+            if run_loop:
+                run_next_loop = True
+                for i in range(
+                    tidx + self.num_threads_per_cta,
+                    self.radix,
+                    self.num_threads_per_cta,
+                ):
+                    if run_next_loop:
+                        previous = s_histogram[i - 1]
+                        if (
+                            previous <= topk_remaining
+                            and s_histogram[i] > topk_remaining
+                        ):
+                            s_threshold_bin_id[0] = i
+                            s_num_input[s_num_input_idx] = 0
+                            if cutlass.const_expr(
+                                self.enable_gmem_store or self.enable_bounded_spill
+                            ):
+                                g_num_input[s_num_input_idx] = 0
+                            # the difference between coarse and fine-grained.
+                            s_last_remain[0] = topk_remaining - previous
+                            run_next_loop = False
+            # sync among all threads in a cta.
+            cute.arch.barrier()
+
+    @cute.jit
+    def _cluster_reduce_histogram(self, tidx, s_histogram, s_hist_merged):
+        """DSMEM histogram reduction for the single-pass multi-CTA path.
+
+        Each thread sums bin ``my_bin`` across all peer CTAs' LOCAL
+        ``s_histogram`` (including self) via cluster DSMEM and writes the total
+        to the SEPARATE ``s_hist_merged`` buffer.  Never writes in-place: a peer
+        may still be reading our ``s_histogram`` via DSMEM.
+
+        The caller owns the surrounding barriers::
+
+            cluster_arrive(); cluster_wait()           # publish local histograms
+            _cluster_reduce_histogram(...)
+            cute.arch.barrier()                        # s_hist_merged ready (intra-CTA)
+            <prefix sum on s_hist_merged>
+            cluster_arrive_relaxed(); cluster_wait()   # peers done reading before rebuild
+
+        The two arrives differ on purpose: the publish one is non-relaxed
+        ``cluster_arrive`` (release fence, so the s_histogram stores are visible
+        to a peer's ld.shared::cluster; relaxed would risk stale reads — cf. GVR
+        fix bc6d0e83a3), while the post-read one is relaxed (the peer reads
+        drained into s_hist_merged before the intra-CTA barrier, so it is a
+        liveness-only WAR barrier).
+
+        Only bins ``0 .. radix-1`` are merged; the ``radix`` guard slot is not
+        read by the prefix-sum helpers.
+        """
+        for my_bin in range(tidx, self.radix, self.num_threads_per_cta):
+            acc = cutlass.Int32(0)
+            local_ptr = s_histogram.iterator + cutlass.Int32(my_bin)
+            for peer in cutlass.range_constexpr(self.num_ctas_per_row):
+                remote = mapa_shared_cluster(local_ptr, cutlass.Int32(peer))
+                acc = acc + ld_shared_cluster_i32(remote)
+            s_hist_merged[my_bin] = acc
+
+    @cute.jit
+    def _cluster_collect(
+        self,
+        tidx,
+        s_indices,
+        s_counter,
+        s_last_remain,
+        s_prefix,
+        cta_in_group,
+        topk_remaining,
+        output_indices_row,
+        score,
+        output_values_row,
+    ):
+        """Unified DSMEM prefix-scan output collection (Path A + Path B).
+
+        ``s_prefix`` is a per-CTA scratch (reuses ``s_histogram``; needs >= 4
+        int32 slots): [0]=group-1 count, [1]=group-2 count, [2]/[3]=computed
+        exclusive offsets.  ``s_indices`` already holds this CTA's local
+        group-1 at [0, s_counter) and group-2 at [top_k-topk_remaining, ...),
+        filled by the reused Path A/B collection.
+
+        Decode-only: indices are absolute column indices, written directly.
+        """
+        num_threads = self.num_threads_per_cta
+        # 1. Publish this CTA's group-1 / group-2 counts.
+        #    group-2 count = topk_remaining - max(0, s_last_remain[0]); s_last_remain
+        #    starts at the final topk_remaining and is decremented per group-2 write.
+        if tidx == 0:
+            s_prefix[0] = s_counter[0]
+            slr = s_last_remain[0]
+            if slr < cutlass.Int32(0):
+                slr = cutlass.Int32(0)
+            s_prefix[1] = topk_remaining - slr
+        cute.arch.cluster_arrive()
+        cute.arch.cluster_wait()
+
+        # 2. Exclusive prefix over peers p < cta_in_group (thread 0 computes).
+        if tidx == 0:
+            eo1 = cutlass.Int32(0)
+            eo2 = cutlass.Int32(0)
+            p0 = s_prefix.iterator + cutlass.Int32(0)
+            p1 = s_prefix.iterator + cutlass.Int32(1)
+            for peer in cutlass.range_constexpr(self.num_ctas_per_row):
+                if cutlass.Int32(peer) < cta_in_group:
+                    eo1 = eo1 + ld_shared_cluster_i32(
+                        mapa_shared_cluster(p0, cutlass.Int32(peer))
+                    )
+                    eo2 = eo2 + ld_shared_cluster_i32(
+                        mapa_shared_cluster(p1, cutlass.Int32(peer))
+                    )
+            s_prefix[2] = eo1
+            s_prefix[3] = eo2
+        cute.arch.barrier()
+        # Liveness barrier before exit: relaxed (peer s_prefix reads already drained).
+        cute.arch.cluster_arrive_relaxed()
+        cute.arch.cluster_wait()
+
+        exclusive_offset_1 = s_prefix[2]
+        exclusive_offset_2 = s_prefix[3]
+        group1_total = self.top_k - topk_remaining
+        group2_count = s_prefix[1]
+        local_g1 = s_counter[0]
+
+        # 3. group-1: s_indices[0 .. s_counter-1] -> output[exclusive_offset_1 + i]
+        for i in range(tidx, local_g1, num_threads):
+            idx = cutlass.Int32(cutlass.Uint32(s_indices[i]))
+            pos = exclusive_offset_1 + i
+            output_indices_row[pos] = idx
+            if cutlass.const_expr(self.return_val):
+                output_values_row[pos] = score[idx]
+
+        # 4. group-2: s_indices[top_k-topk_remaining + i] -> output[group1_total + eo2 + i]
+        #    (Path A: group2_count == 0, loop is a no-op)
+        for i in range(tidx, group2_count, num_threads):
+            pos = group1_total + exclusive_offset_2 + i
+            if pos < self.top_k:
+                src = self.top_k - topk_remaining + i
+                idx = cutlass.Int32(cutlass.Uint32(s_indices[src]))
+                output_indices_row[pos] = idx
+                if cutlass.const_expr(self.return_val):
+                    output_values_row[pos] = score[idx]
+
+    @cute.jit
+    def _phase3_writeback(
+        self, tidx, row_start, s_indices, score, indices, dst, dst_values
+    ):
+        """Write the selected top-k from s_indices (+ values) back to GMEM output.
+
+        Extracted verbatim from filtered_topk_kernel_per_row (no logic change) so the
+        single-pass multi-CTA path can dispatch between this and a cluster collector.
+        """
+        # Phase 3: Output phase
+        output_vector_width = 2 if self.top_k % 2 == 0 else 1
+        vecsize_out = cutlass.const_expr(
+            min(
+                self.top_k,
+                cute.ceil_div(self.top_k, self.num_threads_per_cta),
+                self.num_copy_bits // self.dtype.width,
+                # Limit stores to the output vector width supported by the dtype.
+                output_vector_width,
+            )
+        )
+        assert self.top_k % vecsize_out == 0
+
+        nvec_per_thread = cutlass.const_expr(
+            cute.ceil_div(self.top_k, vecsize_out * self.num_threads_per_cta)
+        )
+        topk_vals = cute.make_rmem_tensor((vecsize_out, nvec_per_thread), self.dtype)
+        topk_indices = cute.make_rmem_tensor(
+            (vecsize_out, nvec_per_thread), cutlass.Int32
+        )
+
+        stride = self.num_threads_per_cta * vecsize_out
+        for i in cutlass.range(nvec_per_thread, unroll_full=True):
+            idx = i * stride + tidx % self.num_threads_per_cta * vecsize_out
+            if idx < self.top_k:
+                for v in cutlass.range(vecsize_out, unroll_full=True):
+                    index_raw = s_indices[idx + v]
+                    index = cutlass.Int32(cutlass.Uint32(index_raw))
+                    if cutlass.const_expr(self.return_val):
+                        topk_vals[v, i] = score[index]
+                    if cutlass.const_expr(self.merge_blocks):
+                        topk_indices[v, i] = indices[index]
+                    elif cutlass.const_expr(self.subtract_row_start_on_output):
+                        topk_indices[v, i] = index - cutlass.Int32(row_start)
+                    else:
+                        topk_indices[v, i] = index
+        # [atom, rest_vec]
+        mIndices_store = cute.tiled_divide(dst, (vecsize_out,))
+        if cutlass.const_expr(self.return_val):
+            mValues_store = cute.tiled_divide(dst_values, (vecsize_out,))
+        # i represents the index of the vector in the output.
+        for i in cutlass.range(cute.size(topk_vals.shape, [1]), unroll_full=True):
+            col = i * self.num_threads_per_cta + tidx % self.num_threads_per_cta
+            if col < self.top_k // vecsize_out:
+                cute.autovec_copy(topk_indices[None, i], mIndices_store[None, col])
+                if cutlass.const_expr(self.return_val):
+                    cute.autovec_copy(topk_vals[None, i], mValues_store[None, col])
+
+    def _iket_begin(self, name):
+        """Open an IKET phase range (dev-only; no-op unless TOPK_IKET=1)."""
+        if cutlass.const_expr(_TOPK_IKET):
+            return _iket.range_start(name)
+        return None
+
+    def _iket_end(self, token):
+        """Close the IKET phase range opened by _iket_begin (dev-only)."""
+        if cutlass.const_expr(_TOPK_IKET):
+            _iket.range_end(token)
+
+    @cute.jit
+    def _build_coarse_histogram_tma(
+        self,
+        tidx,
+        s_histogram,
+        val_one,
+        tma_atom,
+        tma_tensor,
+        s_tma_stage,
+        s_tma_mbar,
+        bidx,
+        row_start,
+        length,
+        score,
+    ):
+        """Row-native async-TMA (cp.async.bulk / UTMALDG) coarse-histogram build.
+
+        Covers the WHOLE row [row_start, row_end): the tile-aligned middle
+        [tma_start, tma_end) is loaded GMEM->SMEM through a tma_num_stages ring
+        (hiding global-load latency, the #1 stall ~40%), and the two sub-tile edges
+        [row_start, tma_start) + [tma_end, row_end) are scanned with scalar LDG
+        (each < tile_cols columns; zero iterations when the row is tile-aligned).
+        TMA needs only tile_cols alignment from column 0 -- it does NOT use the LDG
+        vec_start/prologue/left decomposition, so the caller must skip the scalar
+        prologue/left when enable_tma_load (this method already covers them).
+        """
+        vec_size = self.vec_size
+        tile_cols = self.num_threads_per_cta * vec_size
+        n_stages = self.tma_num_stages
+        tile_bytes = tile_cols * (self.dtype.width // 8)
+        num_warps_cta = self.num_threads_per_cta // 32
+        tile_cols_i32 = cutlass.Int32(tile_cols)
+
+        # Largest tile_cols-aligned sub-range [tma_start, tma_end) inside the row.
+        row_end = row_start + length
+        tma_start = (
+            (row_start + tile_cols_i32 - cutlass.Int32(1)) // tile_cols_i32
+        ) * tile_cols_i32
+        tma_end = (row_end // tile_cols_i32) * tile_cols_i32
+        num_tiles = cutlass.Int32(0)
+        if tma_end > tma_start:
+            num_tiles = (tma_end - tma_start) // tile_cols_i32
+        else:
+            # No full tile fits: collapse so the head edge below scans the whole row.
+            tma_start = row_end
+            tma_end = row_end
+        col_tile_base = tma_start // tile_cols_i32
+
+        warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx())
+
+        # PipelineTmaAsync ring: warp 0 is the sole producer (issues cp.async.bulk
+        # via block_copy); all warps are consumers. The pipeline manages the
+        # full/empty mbarrier counts + phases (hand-rolling them is incorrect for
+        # multi-warp -- consumer needs num_warps arrivals, not 1).
+        pipe = pipeline.PipelineTmaAsync.create(
+            barrier_storage=s_tma_mbar,
+            num_stages=n_stages,
+            producer_group=pipeline.CooperativeGroup(pipeline.Agent.Thread),
+            consumer_group=pipeline.CooperativeGroup(
+                pipeline.Agent.Thread, num_warps_cta
+            ),
+            tx_count=tile_bytes,
+        )
+        prod = pipeline.make_pipeline_state(
+            pipeline.PipelineUserType.Producer, n_stages
+        )
+        cons = pipeline.make_pipeline_state(
+            pipeline.PipelineUserType.Consumer, n_stages
+        )
+
+        # ((1, tile_cols), num_rows, num_col_tiles). col_tile_base is tile-aligned
+        # by construction, so the tile index maps to exact columns.
+        gTiled = cute.local_tile(tma_tensor, (1, tile_cols), (None, None))
+
+        # Prologue: warp 0 fills the ring (guard each stage against short rows).
+        if warp_idx == 0:
+            for _i in cutlass.range_constexpr(n_stages):
+                if cutlass.Int32(_i) < num_tiles:
+                    pipe.producer_acquire(prod)
+                    gtile = gTiled[None, None, bidx, col_tile_base + cutlass.Int32(_i)]
+                    stile = s_tma_stage[prod.index, None, None]
+                    cutlass.block.block_copy(
+                        tma_atom,
+                        cute.group_modes(gtile, 0, 2),
+                        cute.group_modes(stile, 0, 2),
+                        tma_bar_ptr=pipe.producer_get_barrier(prod),
+                    )
+                    pipe.producer_commit(prod)
+                    prod.advance()
+
+        # Main loop: all threads fold a tile into the histogram; warp 0 refills the
+        # stage n_stages tiles ahead so loads stay in flight over the atomics.
+        # Unroll interleaves consecutive tiles' consume+key-compute for ILP and to
+        # hide the per-tile pipeline wait.
+        for t in cutlass.range(num_tiles, unroll=2):
+            pipe.consumer_wait(cons)
+            stage = cons.index
+            col0 = tidx * cutlass.Int32(vec_size)
+            # Vectorized SMEM read of the thread's contiguous vec_size chunk (one
+            # LDS.128x2 instead of vec_size scalar LDS -> cuts short_scoreboard).
+            s_row = s_tma_stage[stage, 0, None]
+            frag = cute.make_rmem_tensor((vec_size,), self.dtype)
+            cute.autovec_copy(
+                cute.make_tensor(s_row.iterator + col0, cute.make_layout((vec_size,))),
+                frag,
+            )
+            for j in cutlass.range_constexpr(vec_size):
+                bin_val = self.to_coarse_key(frag[j])
+                atomic_add(s_histogram.iterator + cutlass.Int32(bin_val), val_one)
+            pipe.consumer_release(cons)
+            cons.advance()
+            if warp_idx == 0:
+                t_next = t + cutlass.Int32(n_stages)
+                if t_next < num_tiles:
+                    pipe.producer_acquire(prod)
+                    gtile = gTiled[None, None, bidx, col_tile_base + t_next]
+                    stile = s_tma_stage[prod.index, None, None]
+                    cutlass.block.block_copy(
+                        tma_atom,
+                        cute.group_modes(gtile, 0, 2),
+                        cute.group_modes(stile, 0, 2),
+                        tma_bar_ptr=pipe.producer_get_barrier(prod),
+                    )
+                    pipe.producer_commit(prod)
+                    prod.advance()
+
+        # --- scalar sub-tile edges (LDG), placed AFTER the TMA issue so warp 0's
+        # prefetch starts immediately instead of blocking behind these loads.
+        # head [row_start, tma_start):
+        head_size = tma_start - row_start
+        for j in range(tidx, head_size, self.num_threads_per_cta):
+            c = cutlass.Int32(row_start + j)
+            bin_val = self.to_coarse_key(score[c])
+            atomic_add(s_histogram.iterator + cutlass.Int32(bin_val), val_one)
+        # tail [tma_end, row_end):
+        tail_size = row_end - tma_end
+        for j in range(tidx, tail_size, self.num_threads_per_cta):
+            c = cutlass.Int32(tma_end + j)
+            bin_val = self.to_coarse_key(score[c])
+            atomic_add(s_histogram.iterator + cutlass.Int32(bin_val), val_one)
+
+    @cute.jit
+    def _build_coarse_filter_tma(
+        self,
+        tidx,
+        threshold_bin,
+        tma_atom,
+        tma_tensor,
+        s_tma_stage,
+        s_tma_mbar,
+        bidx,
+        row_start,
+        length,
+        score,
+        s_counter,
+        s_indices,
+        s_input_idx,
+        s_input_val,
+        s_num_input,
+        s_histogram,
+        g_num_input,
+        buffer,
+        s_overflow_flag,
+    ):
+        """Row-native async-TMA coarse FILTER over [row_start, row_end).
+
+        Same ring as _build_coarse_histogram_tma but the per-element consume is the
+        branchy filter (_filter_and_histogram_per_elem_coarse) instead of a histogram
+        atomic. Staging aliases the idle candidate buffer 1 (fp32 nbuf==2). Covers the
+        whole row; caller must skip the scalar prologue/left when enable_tma_load_p3.
+        """
+        vec_size = self.vec_size
+        tile_cols = self.num_threads_per_cta * vec_size
+        n_stages = self.tma_num_stages_p3
+        tile_bytes = tile_cols * (self.dtype.width // 8)
+        num_warps_cta = self.num_threads_per_cta // 32
+        tile_cols_i32 = cutlass.Int32(tile_cols)
+
+        row_end = row_start + length
+        tma_start = (
+            (row_start + tile_cols_i32 - cutlass.Int32(1)) // tile_cols_i32
+        ) * tile_cols_i32
+        tma_end = (row_end // tile_cols_i32) * tile_cols_i32
+        num_tiles = cutlass.Int32(0)
+        if tma_end > tma_start:
+            num_tiles = (tma_end - tma_start) // tile_cols_i32
+        else:
+            tma_start = row_end
+            tma_end = row_end
+        col_tile_base = tma_start // tile_cols_i32
+
+        warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx())
+        pipe = pipeline.PipelineTmaAsync.create(
+            barrier_storage=s_tma_mbar,
+            num_stages=n_stages,
+            producer_group=pipeline.CooperativeGroup(pipeline.Agent.Thread),
+            consumer_group=pipeline.CooperativeGroup(
+                pipeline.Agent.Thread, num_warps_cta
+            ),
+            tx_count=tile_bytes,
+        )
+        prod = pipeline.make_pipeline_state(
+            pipeline.PipelineUserType.Producer, n_stages
+        )
+        cons = pipeline.make_pipeline_state(
+            pipeline.PipelineUserType.Consumer, n_stages
+        )
+        gTiled = cute.local_tile(tma_tensor, (1, tile_cols), (None, None))
+
+        if warp_idx == 0:
+            for _i in cutlass.range_constexpr(n_stages):
+                if cutlass.Int32(_i) < num_tiles:
+                    pipe.producer_acquire(prod)
+                    gtile = gTiled[None, None, bidx, col_tile_base + cutlass.Int32(_i)]
+                    stile = s_tma_stage[prod.index, None, None]
+                    cutlass.block.block_copy(
+                        tma_atom,
+                        cute.group_modes(gtile, 0, 2),
+                        cute.group_modes(stile, 0, 2),
+                        tma_bar_ptr=pipe.producer_get_barrier(prod),
+                    )
+                    pipe.producer_commit(prod)
+                    prod.advance()
+
+        for t in cutlass.range(num_tiles, unroll=2):
+            pipe.consumer_wait(cons)
+            stage = cons.index
+            col0 = tidx * cutlass.Int32(vec_size)
+            base_col = tma_start + t * tile_cols_i32 + col0
+            s_row = s_tma_stage[stage, 0, None]
+            frag = cute.make_rmem_tensor((vec_size,), self.dtype)
+            cute.autovec_copy(
+                cute.make_tensor(s_row.iterator + col0, cute.make_layout((vec_size,))),
+                frag,
+            )
+            for j in cutlass.range_constexpr(vec_size):
+                raw_input = frag[j]
+                bin_val = self.to_coarse_key(raw_input)
+                idx = self.index_type(base_col + cutlass.Int32(j))
+                self._filter_and_histogram_per_elem_coarse(
+                    bin_val,
+                    threshold_bin,
+                    idx,
+                    raw_input,
+                    s_counter,
+                    s_indices,
+                    s_input_idx,
+                    s_input_val,
+                    s_num_input,
+                    s_histogram,
+                    g_num_input,
+                    buffer,
+                    s_overflow_flag,
+                )
+            pipe.consumer_release(cons)
+            cons.advance()
+            if warp_idx == 0:
+                t_next = t + cutlass.Int32(n_stages)
+                if t_next < num_tiles:
+                    pipe.producer_acquire(prod)
+                    gtile = gTiled[None, None, bidx, col_tile_base + t_next]
+                    stile = s_tma_stage[prod.index, None, None]
+                    cutlass.block.block_copy(
+                        tma_atom,
+                        cute.group_modes(gtile, 0, 2),
+                        cute.group_modes(stile, 0, 2),
+                        tma_bar_ptr=pipe.producer_get_barrier(prod),
+                    )
+                    pipe.producer_commit(prod)
+                    prod.advance()
+
+        # scalar sub-tile edges (LDG), after the TMA issue so prefetch isn't blocked.
+        head_size = tma_start - row_start
+        for j in range(tidx, head_size, self.num_threads_per_cta):
+            c = cutlass.Int32(row_start + j)
+            raw = score[c]
+            self._filter_and_histogram_per_elem_coarse(
+                self.to_coarse_key(raw),
+                threshold_bin,
+                self.index_type(c),
+                raw,
+                s_counter,
+                s_indices,
+                s_input_idx,
+                s_input_val,
+                s_num_input,
+                s_histogram,
+                g_num_input,
+                buffer,
+                s_overflow_flag,
+            )
+        tail_size = row_end - tma_end
+        for j in range(tidx, tail_size, self.num_threads_per_cta):
+            c = cutlass.Int32(tma_end + j)
+            raw = score[c]
+            self._filter_and_histogram_per_elem_coarse(
+                self.to_coarse_key(raw),
+                threshold_bin,
+                self.index_type(c),
+                raw,
+                s_counter,
+                s_indices,
+                s_input_idx,
+                s_input_val,
+                s_num_input,
+                s_histogram,
+                g_num_input,
+                buffer,
+                s_overflow_flag,
+            )
+
+    @cute.jit
+    def filtered_topk_kernel_per_row(
+        self,
+        input: cute.Tensor,
+        # gmem, used for the merge blocks kernel.
+        input_indices: cute.Tensor,
+        extra_buffer: cute.Tensor,
+        output_indices: cute.Tensor,
+        output_values: cute.Tensor,
+        row_start: int,
+        length: int,
+        bidx: int,
+        s_histogram,
+        s_counter,
+        s_threshold_bin_id,
+        s_num_input,
+        g_num_input,
+        s_indices,
+        s_input_idx,
+        s_input_val,
+        s_last_remain,
+        num_warps,
+        s_warp_sums,
+        s_overflow_flag,
+        need_cluster_sync=False,
+        s_hist_merged=None,
+        cta_in_group=0,
+        tma_atom=None,
+        tma_tensor=None,
+        s_tma_stage=None,
+        s_tma_mbar=None,
+        s_tma_stage_p3=None,
+        s_tma_mbar_p3=None,
+    ):
+        """CuTe DSL implementation of TopK kernel based on radix-based filter algorithm.
+
+        Single-pass multi-CTA (radix-filter cluster) extras — only live when
+        ``self.single_pass_multi_cta`` is True (const-folded away otherwise):
+          - ``need_cluster_sync`` (runtime): True for cluster cooperation
+            (needed_ctas >= 2), False for the solo fast path.
+          - ``s_hist_merged``: separate DSMEM merge target (radix+1 int32).
+          - ``cta_in_group``: this CTA's rank within its cluster.
+        """
+        # # Thread and block indexing
+        tidx, _, _ = cute.arch.thread_idx()
+
+        score = input[bidx, None]
+        if cutlass.const_expr(self.merge_blocks):
+            indices = input_indices[bidx, None]
+        else:
+            indices = None
+        if cutlass.const_expr(self.enable_multi_cta):
+            dst = output_indices
+            if cutlass.const_expr(self.return_val):
+                dst_values = output_values
+            else:
+                dst_values = None
+        else:
+            dst = output_indices[bidx, None]
+            if cutlass.const_expr(self.return_val):
+                dst_values = output_values[bidx, None]
+            else:
+                dst_values = None
+        # Note, for multi-cta version, each ctas must have its own extra_buffer.
+        buffer = None
+        if cutlass.const_expr(self.enable_gmem_store or self.enable_bounded_spill):
+            if cutlass.const_expr(self.single_pass_multi_cta):
+                # Per-CTA spill buffer: (num_rows * ctas_per_group, ...). bidx has
+                # already been set to row_id by the decode kernel.
+                buffer = extra_buffer[
+                    bidx * self.num_ctas_per_row + cta_in_group, None, None
+                ]
+            elif cutlass.const_expr(self.enable_multi_cta):
+                grid_dim_x, grid_dim_y, _ = cute.arch.grid_dim()
+                bidx_val, bidy_val, _ = cute.arch.block_idx()
+                buffer_row_id = bidx_val * grid_dim_y + bidy_val
+                buffer = extra_buffer[buffer_row_id, None, None]
+            else:
+                buffer = extra_buffer[bidx, None, None]
+
+        # for initial scalar load part.
+        row_ptr = score.iterator + row_start
+        row_addr_u64 = row_ptr.toint()
+
+        # 256/8 = 32bytes
+        align_bytes = self.num_copy_bits // 8
+        # fp32: 4bytes
+        elem_bytes = self.dtype.width // 8
+
+        misalign = row_addr_u64 % align_bytes
+        fix_bytes = cutlass.Int64(0)
+        if misalign != 0:
+            fix_bytes = align_bytes - misalign
+
+        prologue_elems = cutlass.Int32(fix_bytes // elem_bytes)
+
+        # SP multi-CTA cluster mode: an empty chunk (chunk_start >= eff_len ->
+        # length <= 0) must scan NOTHING. Otherwise the prologue/left loops
+        # (bounded by alignment, not length) would read -inf padding past the
+        # row end and corrupt the DSMEM-merged histogram. Clamp so the total
+        # scanned == max(length, 0). Guarded under const_expr so single-CTA /
+        # 2-pass codegen is unchanged (there length > top_k in this branch).
+        if cutlass.const_expr(self.single_pass_multi_cta):
+            _len_nonneg = length
+            if _len_nonneg < 0:
+                _len_nonneg = cutlass.Int32(0)
+            if prologue_elems > _len_nonneg:
+                prologue_elems = _len_nonneg
+            remaining = _len_nonneg - prologue_elems
+        else:
+            remaining = length - prologue_elems
+        aligned_size = (remaining // self.vec_size) * self.vec_size
+        left_size = remaining - aligned_size
+
+        vec_start = row_start + prologue_elems
+        left_start = vec_start + aligned_size
+
+        # GVR-style direct GMEM load constants (all Python ints, compile-time).
+        # Loop bounds computed from runtime aligned_size so threads past the
+        # actual row end execute zero iterations — no OOB waste for short rows.
+        vec_size = self.vec_size
+        _elem_bytes = self.dtype.width // 8
+        _align_bytes = self.num_copy_bits // 8
+        _step_vec = self.num_threads_per_cta * self.vec_size
+        # Byte address of the aligned portion start for this row (score[vec_start]).
+        _aligned_base = (score.iterator + vec_start).toint()
+        _copy_atom = cute.make_copy_atom(
+            cute.nvgpu.CopyG2ROp(),
+            self.dtype,
+            num_bits_per_copy=self.num_copy_bits,
+        )
+
+        scan_frag = cute.make_rmem_tensor((vec_size,), self.dtype)
+
+        # Trivial case: length <= top_k. In SP multi-CTA cluster mode this
+        # per-chunk shortcut is unsafe (a CTA taking it would skip the cluster
+        # barriers -> deadlock, and emit its whole chunk as the row's top-k);
+        # force the full radix path so every CTA cooperates.
+        take_trivial = length <= self.top_k
+        if cutlass.const_expr(self.single_pass_multi_cta):
+            if need_cluster_sync:
+                take_trivial = False
+        if take_trivial:
+            for i in range(tidx, self.top_k, self.num_threads_per_cta):
+                if i < length:
+                    if cutlass.const_expr(self.enable_multi_cta):
+                        dst[i] = i + row_start
+                    elif cutlass.const_expr(self.merge_blocks):
+                        dst[i] = indices[i]
+                    else:
+                        dst[i] = i
+                    if cutlass.const_expr(self.return_val):
+                        # dst[i] is a local index i; its value lives at the
+                        # absolute column row_start + i (row_start may be
+                        # non-zero for prefill). enable_multi_cta writes the
+                        # absolute index but reads the same absolute column.
+                        dst_values[i] = score[i + row_start]
+                else:
+                    dst[i] = -1
+                    if cutlass.const_expr(self.return_val):
+                        dst_values[i] = dst_values.element_type(
+                            dst_values.element_type.inf * dst_values.element_type(-1.0)
+                        )
+        else:
+            topk_remaining = self.top_k
+
+            val_one = cutlass.Int32(1)
+
+            _ik_hist = self._iket_begin("p1_histogram")
+            _ik_h1_clear = self._iket_begin("h1_clear")
+            # Stage 1: Coarse histogram.
+            # Use a strided loop so every bin is cleared even when
+            # num_threads_per_cta < radix (e.g. 128 < 256).
+            for _hi in range(tidx, self.radix + 1, self.num_threads_per_cta):
+                s_histogram[_hi] = 0
+            if cutlass.const_expr(self.enable_reread):
+                if tidx == 0:
+                    s_overflow_flag[0] = 0
+            cute.arch.barrier()
+            self._iket_end(_ik_h1_clear)
+
+            _ik_h1_vec = self._iket_begin("h1_vecscan")
+            if cutlass.const_expr(self.enable_tma_load):
+                # Stage 0: row-native async-TMA build over the WHOLE row (tile-aligned
+                # middle via TMA + scalar sub-tile edges). It subsumes the scalar
+                # prologue/left below, which are gated off for enable_tma_load.
+                self._build_coarse_histogram_tma(
+                    tidx,
+                    s_histogram,
+                    val_one,
+                    tma_atom,
+                    tma_tensor,
+                    s_tma_stage,
+                    s_tma_mbar,
+                    bidx,
+                    row_start,
+                    length,
+                    score,
+                )
+            else:
+                # 1.1 Build histogram -- load-instruction unroll (unroll_factor):
+                # counted range overlaps loads vs the 1-in-flight while (1 == orig).
+                ic0 = tidx * cutlass.Int32(vec_size)
+                big_iters = cutlass.Int32(0)
+                if aligned_size > ic0 + cutlass.Int32(vec_size - 1):
+                    big_iters = (
+                        aligned_size - ic0 - cutlass.Int32(vec_size)
+                    ) // cutlass.Int32(_step_vec) + cutlass.Int32(1)
+                for _k in cutlass.range(big_iters, unroll=self.unroll_factor):
+                    ic = ic0 + _k * cutlass.Int32(_step_vec)
+                    cute.copy(
+                        _copy_atom,
+                        cute.make_tensor(
+                            cute.make_ptr(
+                                self.dtype,
+                                _aligned_base
+                                + cutlass.Int64(ic) * cutlass.Int64(_elem_bytes),
+                                cute.AddressSpace.gmem,
+                                assumed_align=_align_bytes,
+                            ),
+                            cute.make_layout((vec_size,)),
+                        ),
+                        scan_frag,
+                    )
+                    for j in cutlass.range_constexpr(vec_size):
+                        bin_val = self.to_coarse_key(scan_frag[j])
+                        atomic_add(
+                            s_histogram.iterator + cutlass.Int32(bin_val), val_one
+                        )
+            self._iket_end(_ik_h1_vec)
+
+            _ik_h1_tail = self._iket_begin("h1_scalartail")
+            # The scalar prologue/left cover the LDG vec-alignment edges. The TMA
+            # path already scans the whole row (its own sub-tile edges), so skip
+            # these to avoid double-counting when enable_tma_load.
+            if cutlass.const_expr(not self.enable_tma_load):
+                # for initial scalar load part.
+                for j in range(tidx, prologue_elems, self.num_threads_per_cta):
+                    col_idx = cutlass.Int32(row_start + j)
+                    raw = score[col_idx]
+                    bin_val = self.to_coarse_key(raw)
+                    atomic_add(
+                        s_histogram.iterator + cutlass.Int32(bin_val),
+                        val_one,
+                    )
+
+                # for left part (left_size)
+                for j in range(tidx, left_size, self.num_threads_per_cta):
+                    col_idx = cutlass.Int32(left_start + j)
+                    raw = score[col_idx]
+                    bin_val = self.to_coarse_key(raw)
+                    atomic_add(
+                        s_histogram.iterator + cutlass.Int32(bin_val),
+                        val_one,
+                    )
+            self._iket_end(_ik_h1_tail)
+
+            _ik_h1_bar = self._iket_begin("h1_finalbar")
+            cute.arch.barrier()
+            self._iket_end(_ik_h1_bar)
+            self._iket_end(_ik_hist)
+
+            _ik_prefix = self._iket_begin("p2_prefix_threshold")
+            # 1.2 and 1.3  Suffix sum to find threshold and find threshold bin.
+            # SP multi-CTA cluster: DSMEM-merge peer histograms into s_hist_merged
+            # first, then prefix-sum the merged buffer. The prefix-sum / threshold
+            # subtraction are duplicated per branch (rather than selecting the
+            # buffer into a variable) because the DSL cannot phi-merge two distinct
+            # tensors across a runtime `if`. threshold_bin (a shared SMEM scalar)
+            # is read straight-line; only the buffer read in the -= differs.
+            if cutlass.const_expr(self.single_pass_multi_cta):
+                if need_cluster_sync:
+                    cute.arch.cluster_arrive()
+                    cute.arch.cluster_wait()
+                    self._cluster_reduce_histogram(tidx, s_histogram, s_hist_merged)
+                    cute.arch.barrier()
+                    self.prefix_sum_and_find_threshold_coarse(
+                        tidx,
+                        s_hist_merged,
+                        s_warp_sums,
+                        num_warps,
+                        s_threshold_bin_id,
+                        s_num_input,
+                        s_counter,
+                        s_last_remain,
+                        topk_remaining,
+                        g_num_input,
+                        s_num_input_idx=0,
+                    )
+                    # WAR barrier: relaxed (peer reads already drained, see docstring).
+                    cute.arch.cluster_arrive_relaxed()
+                    cute.arch.cluster_wait()
+                else:
+                    self.prefix_sum_and_find_threshold_coarse(
+                        tidx,
+                        s_histogram,
+                        s_warp_sums,
+                        num_warps,
+                        s_threshold_bin_id,
+                        s_num_input,
+                        s_counter,
+                        s_last_remain,
+                        topk_remaining,
+                        g_num_input,
+                        s_num_input_idx=0,
+                    )
+            else:
+                self.prefix_sum_and_find_threshold_coarse(
+                    tidx,
+                    s_histogram,
+                    s_warp_sums,
+                    num_warps,
+                    s_threshold_bin_id,
+                    s_num_input,
+                    s_counter,
+                    s_last_remain,
+                    topk_remaining,
+                    g_num_input,
+                    s_num_input_idx=0,
+                )
+
+            threshold_bin = s_threshold_bin_id[0]
+            if threshold_bin > 0:
+                if cutlass.const_expr(self.single_pass_multi_cta):
+                    if need_cluster_sync:
+                        topk_remaining -= s_hist_merged[threshold_bin - 1]
+                    else:
+                        topk_remaining -= s_histogram[threshold_bin - 1]
+                else:
+                    topk_remaining -= s_histogram[threshold_bin - 1]
+
+            self._iket_end(_ik_prefix)
+
+            # 1.4 Collect indices
+            if topk_remaining == 0:
+                _ik_collect = self._iket_begin("p3_collect")
+                self._collect_below_threshold_coarse(
+                    tidx,
+                    threshold_bin,
+                    s_counter,
+                    s_indices,
+                    _copy_atom,
+                    scan_frag,
+                    _aligned_base,
+                    vec_start,
+                    aligned_size,
+                    score,
+                    row_start,
+                    prologue_elems,
+                    left_start,
+                    left_size,
+                )
+                self._iket_end(_ik_collect)
+            else:
+                _ik_filter = self._iket_begin("p3_filter")
+                self._filter_and_histogram_coarse(
+                    tidx,
+                    threshold_bin,
+                    s_counter,
+                    s_indices,
+                    s_input_idx,
+                    s_input_val,
+                    s_num_input,
+                    s_histogram,
+                    g_num_input,
+                    buffer,
+                    _copy_atom,
+                    scan_frag,
+                    _aligned_base,
+                    vec_start,
+                    aligned_size,
+                    score,
+                    row_start,
+                    prologue_elems,
+                    left_start,
+                    left_size,
+                    s_overflow_flag,
+                    tma_atom=tma_atom,
+                    tma_tensor=tma_tensor,
+                    s_tma_stage_p3=s_tma_stage_p3,
+                    s_tma_mbar_p3=s_tma_mbar_p3,
+                    bidx=bidx,
+                )
+                self._iket_end(_ik_filter)
+
+                _ik_refine = self._iket_begin("p4_refine")
+                # Phase 2: Refinement rounds
+                # chain_mask (DSL Int32) and chain_prefix (runtime DSL ordered_type)
+                # accumulate prior-round constraints for REREAD_ALWAYS / REREAD overflow
+                # fallback. chain_mask is Int32 so it survives DSL phi-merge across the
+                # dynamic loop.
+                chain_mask = cutlass.Int32(0)
+                chain_prefix = self.ordered_type(0)
+                # REREAD: read overflow flag once before the loop; runtime bool that
+                # selects SMEM refinement (no overflow) vs GMEM re-scan (overflow).
+                # Visibility of s_overflow_flag[0] is guaranteed by the fence_acq_rel_cta()
+                # + barrier() at the end of _filter_and_histogram_coarse above; no additional
+                # barrier is needed here.  If that function's terminal barrier is ever moved
+                # to the call site, a barrier must be inserted before this read.
+                if cutlass.const_expr(self.enable_reread or self.enable_bounded_spill):
+                    did_overflow = s_overflow_flag[0] != 0
+                run_next_round = True
+                for round in range(self.num_refine_rounds):
+                    if run_next_round:
+                        r_idx = round % 2
+                        _ik_round = self._iket_begin(f"p4_refine_r{round}")
+
+                        # SP multi-CTA cluster: DSMEM-merge peer histograms before
+                        # the per-round prefix sum (same shape as the coarse site;
+                        # duplicated per branch to avoid a tensor phi-merge).
+                        if cutlass.const_expr(self.single_pass_multi_cta):
+                            if need_cluster_sync:
+                                cute.arch.cluster_arrive()
+                                cute.arch.cluster_wait()
+                                self._cluster_reduce_histogram(
+                                    tidx, s_histogram, s_hist_merged
+                                )
+                                cute.arch.barrier()
+                                self.prefix_sum_and_find_threshold_fine_grained(
+                                    tidx,
+                                    s_hist_merged,
+                                    s_warp_sums,
+                                    num_warps,
+                                    s_threshold_bin_id,
+                                    s_num_input,
+                                    s_counter,
+                                    s_last_remain,
+                                    topk_remaining,
+                                    g_num_input,
+                                    s_num_input_idx=r_idx ^ 1,
+                                )
+                                # WAR barrier: relaxed (peer reads already drained).
+                                cute.arch.cluster_arrive_relaxed()
+                                cute.arch.cluster_wait()
+                            else:
+                                self.prefix_sum_and_find_threshold_fine_grained(
+                                    tidx,
+                                    s_histogram,
+                                    s_warp_sums,
+                                    num_warps,
+                                    s_threshold_bin_id,
+                                    s_num_input,
+                                    s_counter,
+                                    s_last_remain,
+                                    topk_remaining,
+                                    g_num_input,
+                                    s_num_input_idx=r_idx ^ 1,
+                                )
+                        else:
+                            self.prefix_sum_and_find_threshold_fine_grained(
+                                tidx,
+                                s_histogram,
+                                s_warp_sums,
+                                num_warps,
+                                s_threshold_bin_id,
+                                s_num_input,
+                                s_counter,
+                                s_last_remain,
+                                topk_remaining,
+                                g_num_input,
+                                s_num_input_idx=r_idx ^ 1,
+                            )
+                        threshold = s_threshold_bin_id[0]
+                        if threshold > 0:
+                            if cutlass.const_expr(self.single_pass_multi_cta):
+                                if need_cluster_sync:
+                                    topk_remaining -= s_hist_merged[threshold - 1]
+                                else:
+                                    topk_remaining -= s_histogram[threshold - 1]
+                            else:
+                                topk_remaining -= s_histogram[threshold - 1]
+                        offset = self.first_refine_shift - round * 8
+                        is_last_round = round == self.num_refine_rounds - 1
+
+                        if cutlass.const_expr(self.enable_reread_always):
+                            run_next_round, chain_mask, chain_prefix = (
+                                self._reread_gmem_rescan(
+                                    topk_remaining,
+                                    is_last_round,
+                                    tidx,
+                                    threshold_bin,
+                                    threshold,
+                                    offset,
+                                    chain_mask,
+                                    chain_prefix,
+                                    score,
+                                    s_counter,
+                                    s_indices,
+                                    s_last_remain,
+                                    s_histogram,
+                                    _copy_atom,
+                                    scan_frag,
+                                    _aligned_base,
+                                    vec_start,
+                                    aligned_size,
+                                    row_start,
+                                    prologue_elems,
+                                    left_start,
+                                    left_size,
+                                )
+                            )
+                        elif cutlass.const_expr(self.enable_reread):
+                            if did_overflow:
+                                # Overflow fallback: REREAD_ALWAYS-style GMEM re-scan.
+                                run_next_round, chain_mask, chain_prefix = (
+                                    self._reread_gmem_rescan(
+                                        topk_remaining,
+                                        is_last_round,
+                                        tidx,
+                                        threshold_bin,
+                                        threshold,
+                                        offset,
+                                        chain_mask,
+                                        chain_prefix,
+                                        score,
+                                        s_counter,
+                                        s_indices,
+                                        s_last_remain,
+                                        s_histogram,
+                                        _copy_atom,
+                                        scan_frag,
+                                        _aligned_base,
+                                        vec_start,
+                                        aligned_size,
+                                        row_start,
+                                        prologue_elems,
+                                        left_start,
+                                        left_size,
+                                    )
+                                )
+                            else:
+                                # No overflow: SMEM-based refinement (same as GMEM_SPILL).
+                                num_input = min(
+                                    s_num_input[r_idx],
+                                    self.filtered_topk_smem_input_size,
+                                )
+                                cur_g_num_input = cutlass.Int32(0)
+                                if topk_remaining == 0:
+                                    self._collect_below_threshold_refine(
+                                        tidx,
+                                        threshold,
+                                        offset,
+                                        num_input,
+                                        r_idx,
+                                        s_input_idx,
+                                        s_input_val,
+                                        score,
+                                        s_counter,
+                                        s_indices,
+                                        cur_g_num_input,
+                                        None,
+                                    )
+                                    run_next_round = False
+                                else:
+                                    self._filter_and_histogram_refine(
+                                        tidx,
+                                        threshold,
+                                        offset,
+                                        r_idx,
+                                        is_last_round,
+                                        num_input,
+                                        cur_g_num_input,
+                                        score,
+                                        s_counter,
+                                        s_indices,
+                                        s_input_idx,
+                                        s_input_val,
+                                        s_num_input,
+                                        s_histogram,
+                                        s_last_remain,
+                                        None,
+                                        None,
+                                    )
+                        elif cutlass.const_expr(self.enable_bounded_spill):
+                            # BOUNDED_SPILL: did_overflow means even the
+                            # size-capped GMEM buffer filled -> REREAD-style
+                            # re-scan (tier 3). Otherwise the candidates fit in
+                            # SMEM + bounded GMEM -> GMEM_SPILL-style refine.
+                            if did_overflow:
+                                run_next_round, chain_mask, chain_prefix = (
+                                    self._reread_gmem_rescan(
+                                        topk_remaining,
+                                        is_last_round,
+                                        tidx,
+                                        threshold_bin,
+                                        threshold,
+                                        offset,
+                                        chain_mask,
+                                        chain_prefix,
+                                        score,
+                                        s_counter,
+                                        s_indices,
+                                        s_last_remain,
+                                        s_histogram,
+                                        _copy_atom,
+                                        scan_frag,
+                                        _aligned_base,
+                                        vec_start,
+                                        aligned_size,
+                                        row_start,
+                                        prologue_elems,
+                                        left_start,
+                                        left_size,
+                                    )
+                                )
+                            else:
+                                num_input = min(
+                                    s_num_input[r_idx],
+                                    self.filtered_topk_smem_input_size,
+                                )
+                                cur_g_num_input = g_num_input[r_idx]
+                                if topk_remaining == 0:
+                                    self._collect_below_threshold_refine(
+                                        tidx,
+                                        threshold,
+                                        offset,
+                                        num_input,
+                                        r_idx,
+                                        s_input_idx,
+                                        s_input_val,
+                                        score,
+                                        s_counter,
+                                        s_indices,
+                                        cur_g_num_input,
+                                        buffer,
+                                    )
+                                    run_next_round = False
+                                else:
+                                    self._filter_and_histogram_refine(
+                                        tidx,
+                                        threshold,
+                                        offset,
+                                        r_idx,
+                                        is_last_round,
+                                        num_input,
+                                        cur_g_num_input,
+                                        score,
+                                        s_counter,
+                                        s_indices,
+                                        s_input_idx,
+                                        s_input_val,
+                                        s_num_input,
+                                        s_histogram,
+                                        s_last_remain,
+                                        g_num_input,
+                                        buffer,
+                                    )
+                        else:
+                            num_input = min(
+                                s_num_input[r_idx], self.filtered_topk_smem_input_size
+                            )
+                            cur_g_num_input = cutlass.Int32(0)
+                            if cutlass.const_expr(self.enable_gmem_store):
+                                cur_g_num_input = g_num_input[r_idx]
+
+                            if topk_remaining == 0:
+                                self._collect_below_threshold_refine(
+                                    tidx,
+                                    threshold,
+                                    offset,
+                                    num_input,
+                                    r_idx,
+                                    s_input_idx,
+                                    s_input_val,
+                                    score,
+                                    s_counter,
+                                    s_indices,
+                                    cur_g_num_input,
+                                    buffer,
+                                )
+                                run_next_round = False
+                            else:
+                                self._filter_and_histogram_refine(
+                                    tidx,
+                                    threshold,
+                                    offset,
+                                    r_idx,
+                                    is_last_round,
+                                    num_input,
+                                    cur_g_num_input,
+                                    score,
+                                    s_counter,
+                                    s_indices,
+                                    s_input_idx,
+                                    s_input_val,
+                                    s_num_input,
+                                    s_histogram,
+                                    s_last_remain,
+                                    g_num_input,
+                                    buffer,
+                                )
+                        self._iket_end(_ik_round)
+                self._iket_end(_ik_refine)
+
+            _ik_out = self._iket_begin("p5_output")
+            # Phase 3: Output phase.
+            # SP multi-CTA cluster: collect via DSMEM prefix scan (each CTA
+            # writes only its slice). Solo / single-CTA: full-row writeback.
+            if cutlass.const_expr(self.single_pass_multi_cta):
+                if need_cluster_sync:
+                    self._cluster_collect(
+                        tidx,
+                        s_indices,
+                        s_counter,
+                        s_last_remain,
+                        s_histogram,
+                        cta_in_group,
+                        topk_remaining,
+                        dst,
+                        score,
+                        dst_values,
+                    )
+                else:
+                    self._phase3_writeback(
+                        tidx, row_start, s_indices, score, indices, dst, dst_values
+                    )
+            else:
+                self._phase3_writeback(
+                    tidx, row_start, s_indices, score, indices, dst, dst_values
+                )
+            self._iket_end(_ik_out)
+
+
+def create_random_logits(
+    row_starts: torch.Tensor,
+    row_ends: torch.Tensor,
+    dtype: torch.dtype,
+    seed: int,
+    pad_to_vec_size: bool = False,
+    vec_size: int = 8,
+) -> torch.Tensor:
+    """Create random logits tensor for testing.
+
+    Args:
+        row_starts: Tensor of shape (num_rows,) indicating the start position of each row
+        row_ends: Tensor of shape (num_rows,) indicating the end position (exclusive) of each row
+        dtype: Data type for the logits tensor
+        seed: Random seed for reproducibility
+
+    Returns:
+        Tensor of shape (num_rows, max_row_length) with random values and -inf padding
+    """
+    torch.manual_seed(seed)
+    torch.cuda.manual_seed(seed)
+    num_rows = row_starts.shape[0]
+    max_len = int(row_ends.max().item())
+    if pad_to_vec_size:
+        max_len = (max_len + vec_size - 1) // vec_size * vec_size
+
+    # Generate random logits
+    logits = torch.randn(num_rows, max_len, dtype=dtype, device="cuda")
+
+    # Vectorized masking: set positions outside [row_start, row_end) to -inf
+    col_indices = torch.arange(max_len, device="cuda").unsqueeze(0)  # (1, max_len)
+    mask_lo = col_indices < row_starts.unsqueeze(1)  # positions before row_start
+    mask_hi = col_indices >= row_ends.unsqueeze(1)  # positions at or after row_end
+    mask = mask_lo | mask_hi  # positions outside valid range
+    logits[mask] = float("-inf")
+
+    return logits
+
+
+def run_reference_top_k(
+    logits: torch.Tensor,
+    row_starts: torch.Tensor,
+    row_ends: torch.Tensor,
+    index_topk: int,
+) -> torch.Tensor:
+    """Return local top-k indices for each ``[row_start, row_end)`` span."""
+    num_selected = min(index_topk, logits.shape[1])
+    absolute_indices = logits.topk(num_selected, dim=-1).indices
+    valid = (absolute_indices >= row_starts[:, None]) & (
+        absolute_indices < row_ends[:, None]
+    )
+    local_indices = absolute_indices - row_starts[:, None]
+    return local_indices.masked_fill(~valid, -1)
+
+
+def compare_top_k_results(
+    logits: torch.Tensor,
+    cuda_indices: torch.Tensor,
+    torch_indices: torch.Tensor,
+    row_starts: torch.Tensor,
+    row_ends: torch.Tensor,
+    top_k: int,
+    tolerance: float = 1e-5,
+) -> bool:
+    """
+    Compare results from CUDA top_k_per_row with torch.topk.
+    Handles different shapes and -1 placeholders in cuda_indices.
+
+    Args:
+        logits: Input logits tensor [num_rows, vocab_size]
+        cuda_indices: CUDA implementation output [num_rows, cuda_k], may contain -1
+        torch_indices: PyTorch reference output [num_rows, torch_k], may contain -1
+        row_starts: Start positions for each row [num_rows]
+        row_ends: End positions for each row [num_rows]
+        top_k: Target top-k value
+        tolerance: Tolerance for floating point comparison
+
+    Returns:
+        True if results match within tolerance, False otherwise
+    """
+    num_rows = cuda_indices.shape[0]
+
+    # Calculate valid lengths for each row (vectorized)
+    row_lengths = row_ends - row_starts
+
+    # For each row, compare only the valid indices (non -1)
+    for row_idx in range(num_rows):
+        row_len = row_lengths[row_idx].item()
+        expected_valid = min(row_len, top_k)
+
+        # Get valid indices from both implementations (filter out -1)
+        cuda_row = cuda_indices[row_idx]
+        torch_row = torch_indices[row_idx]
+
+        # Filter out -1 (invalid) indices
+        cuda_valid_mask = cuda_row != -1
+        torch_valid_mask = torch_row != -1
+
+        cuda_valid = cuda_row[cuda_valid_mask]
+        torch_valid = torch_row[torch_valid_mask]
+
+        # Check if the number of valid indices matches
+        if cuda_valid.shape[0] != torch_valid.shape[0]:
+            print(
+                f"Row {row_idx}: Different number of valid indices - "
+                f"CUDA: {cuda_valid.shape[0]}, PyTorch: {torch_valid.shape[0]}"
+            )
+            return False
+
+        if cuda_valid.shape[0] != expected_valid:
+            print(
+                f"Row {row_idx}: Expected {expected_valid} valid indices, got {cuda_valid.shape[0]}"
+            )
+            return False
+
+        # If no valid indices, continue
+        if cuda_valid.shape[0] == 0:
+            continue
+
+        # Gather the corresponding logit values
+        row_start = row_starts[row_idx].item()
+        logits_row = logits[row_idx]
+
+        # Adjust indices to absolute positions (add row_start offset)
+        cuda_abs_indices = cuda_valid + row_start
+        torch_abs_indices = torch_valid + row_start
+
+        # Get logit values for the selected indices
+        cuda_values = logits_row[cuda_abs_indices]
+        torch_values = logits_row[torch_abs_indices]
+
+        # Sort both value arrays in descending order
+        cuda_values_sorted, _ = torch.sort(cuda_values, descending=True)
+        torch_values_sorted, _ = torch.sort(torch_values, descending=True)
+
+        # Compare sorted values
+        if not torch.allclose(
+            cuda_values_sorted, torch_values_sorted, rtol=tolerance, atol=tolerance
+        ):
+            # Additional debug: check if sets are identical
+            cuda_set = set(cuda_valid.cpu().tolist())
+            torch_set = set(torch_valid.cpu().tolist())
+            print(
+                f"row_idx: {row_idx}, row_len: {row_len}, expected_valid: {expected_valid}"
+            )
+            print(f"cuda_values_sorted: {cuda_values_sorted}")
+            print(f"torch_values_sorted: {torch_values_sorted}")
+            if cuda_set != torch_set:
+                print("  Different indices selected:")
+                print(f"    Only in CUDA: {cuda_set - torch_set}")
+                print(f"    Only in Torch: {torch_set - cuda_set}")
+
+            return False
+
+    return True

--- a/flashinfer/topk_varlen/kernels/filtered_topk_util.py
+++ b/flashinfer/topk_varlen/kernels/filtered_topk_util.py
@@ -2582,21 +2582,26 @@ class FilteredTopKKernelVarlen:
 
         prologue_elems = cutlass.Int32(fix_bytes // elem_bytes)
 
-        # SP multi-CTA cluster mode: an empty chunk (chunk_start >= eff_len ->
-        # length <= 0) must scan NOTHING. Otherwise the prologue/left loops
-        # (bounded by alignment, not length) would read -inf padding past the
-        # row end and corrupt the DSMEM-merged histogram. Clamp so the total
-        # scanned == max(length, 0). Guarded under const_expr so single-CTA /
-        # 2-pass codegen is unchanged (there length > top_k in this branch).
-        if cutlass.const_expr(self.single_pass_multi_cta):
-            _len_nonneg = length
-            if _len_nonneg < 0:
-                _len_nonneg = cutlass.Int32(0)
-            if prologue_elems > _len_nonneg:
-                prologue_elems = _len_nonneg
-            remaining = _len_nonneg - prologue_elems
-        else:
-            remaining = length - prologue_elems
+        # Clamp so the total scanned == max(length, 0), in EVERY mode.
+        # prologue_elems is derived from address alignment alone, so on a short
+        # misaligned row (top_k < length < prologue span) the scalar prologue
+        # would otherwise scan past the row's valid length: out-of-range
+        # elements enter the coarse histogram (indices beyond `length` can be
+        # emitted as top-k results) and the final row can read past the
+        # allocation. The earlier `length > top_k` argument for the unclamped
+        # modes only bounds length below by top_k, not by the prologue span.
+        # SP multi-CTA additionally needs this for empty chunks (chunk_start >=
+        # eff_len -> length <= 0 must scan NOTHING, or the prologue/left loops
+        # read -inf padding and corrupt the DSMEM-merged histogram).
+        # DIVERGENCE FROM UPSTREAM: upstream gates this clamp under
+        # const_expr(single_pass_multi_cta); generalized here after review
+        # (flashinfer PR #4621). Two predicated ops in per-row setup code.
+        _len_nonneg = length
+        if _len_nonneg < 0:
+            _len_nonneg = cutlass.Int32(0)
+        if prologue_elems > _len_nonneg:
+            prologue_elems = _len_nonneg
+        remaining = _len_nonneg - prologue_elems
         aligned_size = (remaining // self.vec_size) * self.vec_size
         left_size = remaining - aligned_size
 

--- a/flashinfer/topk_varlen/kernels/filtered_topk_util.py
+++ b/flashinfer/topk_varlen/kernels/filtered_topk_util.py
@@ -2673,7 +2673,14 @@ class FilteredTopKKernelVarlen:
             # num_threads_per_cta < radix (e.g. 128 < 256).
             for _hi in range(tidx, self.radix + 1, self.num_threads_per_cta):
                 s_histogram[_hi] = 0
-            if cutlass.const_expr(self.enable_reread):
+            # Initialize for EVERY policy that consumes the flag: the reader
+            # below gates on (enable_reread or enable_bounded_spill), and the
+            # spill path atomically increments it on overflow -- clearing it
+            # only for REREAD left BOUNDED_SPILL reading stale shared memory,
+            # which can select the non-overflow refinement with a candidate
+            # count larger than the bounded buffer. DIVERGENCE FROM UPSTREAM
+            # (REREAD-only clear), after review (flashinfer PR #4621).
+            if cutlass.const_expr(self.enable_reread or self.enable_bounded_spill):
                 if tidx == 0:
                     s_overflow_flag[0] = 0
             cute.arch.barrier()

--- a/flashinfer/topk_varlen/topk_varlen.py
+++ b/flashinfer/topk_varlen/topk_varlen.py
@@ -1094,13 +1094,18 @@ def _run_radix_filter(
         cute_dsl_radix_filter_topk_wrapper,
     )
 
-    idx, val = cute_dsl_radix_filter_topk_wrapper(
-        logits,
-        seq_lens,
-        top_k,
-        next_n,
-        return_val=return_output_values,
-    )
+    # Compile and launch under the input tensor's device: the persistent JIT
+    # cache tags artifacts by the CURRENT device's architecture, and the
+    # kernel launches on the current stream, so both must agree with where
+    # the data lives on a multi-GPU host.
+    with torch.cuda.device(logits.device):
+        idx, val = cute_dsl_radix_filter_topk_wrapper(
+            logits,
+            seq_lens,
+            top_k,
+            next_n,
+            return_val=return_output_values,
+        )
 
     if out_indices is not None and out_indices.data_ptr() != idx.data_ptr():
         out_indices.copy_(idx)

--- a/flashinfer/topk_varlen/topk_varlen.py
+++ b/flashinfer/topk_varlen/topk_varlen.py
@@ -224,11 +224,16 @@ def _top_k_varlen_heuristic(
     call this function with positional args on the skip_check=True path without
     raising TypeError.  Mirrors the pattern used by _heuristic_func_mm_fp4.
     """
-    return [
-        b
-        for b in ("gvr", "radix", "radix_filter", "radix_cutlass")
-        if b in suitable_backends
-    ]
+    # "radix_filter" is deliberately absent: its checker accepts a strict
+    # subset of radix's configurations and its CC list is a subset of
+    # radix's, so listed after radix it could never be chosen (a dead
+    # entry), and listed before radix it would regress the small-row and
+    # small-batch regions where radix wins. Making it auto-selectable needs
+    # a shape/architecture-aware crossover rule (it wins at large N --
+    # roughly N >= 64K with enough rows on SM100, wider on SM107); until
+    # that rule exists it is explicit-only, as documented in the module
+    # docstring.
+    return [b for b in ("gvr", "radix", "radix_cutlass") if b in suitable_backends]
 
 
 # ---------------------------------------------------------------------------

--- a/flashinfer/topk_varlen/topk_varlen.py
+++ b/flashinfer/topk_varlen/topk_varlen.py
@@ -1310,6 +1310,23 @@ def top_k_varlen(
     """
     assert logits.is_cuda and logits.dim() == 2, "logits must be a 2-D CUDA tensor"
     assert seq_lens.is_cuda and seq_lens.dim() == 1 and seq_lens.dtype == torch.int32
+    # Grouped-row ABI, shared by every backend: row r belongs to sequence
+    # r // next_n, so seq_lens must hold exactly one entry per group. Validated
+    # here (not in the per-backend checkers) because a violation is a silent
+    # device-side OOB read of seq_lens or a wrong grouping in every backend,
+    # and the API body still runs under skip_check=True. Real exceptions, not
+    # asserts: this must hold under `python -O` too.
+    if next_n < 1:
+        raise ValueError(f"next_n must be >= 1, got {next_n}")
+    if logits.shape[0] != seq_lens.shape[0] * next_n:
+        raise ValueError(
+            f"logits has {logits.shape[0]} rows but seq_lens has "
+            f"{seq_lens.shape[0]} entries with next_n={next_n}: expected "
+            f"seq_lens.shape[0] * next_n == logits.shape[0] "
+            f"(= {seq_lens.shape[0] * next_n}). Rows are grouped as "
+            f"row // next_n -> sequence; for per-row lengths pass next_n=1 "
+            f"with one seq_lens entry per row."
+        )
 
     if backend == "auto":
         backend = top_k_varlen.suitable_auto_backends[0]

--- a/flashinfer/topk_varlen/topk_varlen.py
+++ b/flashinfer/topk_varlen/topk_varlen.py
@@ -24,9 +24,11 @@ Backend choices
 ---------------
 ``"radix"``          — CuTe DSL single-pass multi-CTA radix top-K; native
                        varlen support (no logit masking). Requires Blackwell
-                       (sm_100+) and nvidia-cutlass-dsl. No ``pre_idx`` needed.
+                       (sm_100+, incl. Rubin sm_107) and nvidia-cutlass-dsl.
+                       No ``pre_idx`` needed.
 ``"gvr"``            — GVR (Guess-Verify-Refine) load-balance kernel.
-                       Requires Blackwell (sm_100+), nvidia-cutlass-dsl, and a
+                       Requires a datacentre Blackwell-class GPU (sm_100/103,
+                       or Rubin sm_107), nvidia-cutlass-dsl, and a
                        ``pre_idx`` hint from the previous decode step.
 ``"radix_cutlass"``  — masked-radix fallback; masks logits to ``seq_lens`` then
                        calls the FlashInfer CUTLASS radix top-K.  Runs on any GPU.
@@ -66,22 +68,59 @@ from ..utils import (
 # ---------------------------------------------------------------------------
 
 # All SM tiers FlashInfer ships kernels for.
-_ALL_CCS = [75, 80, 86, 89, 90, 100, 103, 110, 120, 121]
+_ALL_CCS = [75, 80, 86, 89, 90, 100, 103, 107, 110, 120, 121]
 
 # CuTe DSL radix backend: all Blackwell-plus tiers.
-_BLACKWELL_PLUS_CCS = [100, 103, 110, 120, 121]
+#
+# Rubin (SM107) runs the Blackwell CuTe-DSL kernels as-is: they use only
+# family-portable ops (block/warp scans, ``cute.arch.barrier``,
+# ``shuffle_sync_up``, ``warp_redux_sync``, griddepcontrol) with no
+# arch-specific ``tcgen05``/block-scaled MMA, so the DSL compiles them for
+# ``sm_107a`` natively. ``_cute_dsl_supports_arch`` below keeps a DSL that
+# predates the device from being selected.
+_BLACKWELL_PLUS_CCS = [100, 103, 107, 110, 120, 121]
 
-# GVR is B200-class only (SM100/103). The non-LB (cluster_size=1) GVR CuTe-DSL
-# kernel fails to build on sm_120a: libNVVM rejects the generated device IR
-# (verified on an RTX 5080), so consumer Blackwell (SM120/121) can't use GVR
-# even without load balancing. The LB path additionally needs cluster_size=4
-# programmatic multicast, which SM120/121's 1×1×1 cluster shape lacks. radix
+# GVR is B200-class only (SM100/103/107). The non-LB (cluster_size=1) GVR
+# CuTe-DSL kernel fails to build on sm_120a: libNVVM rejects the generated
+# device IR (verified on an RTX 5080), so consumer Blackwell (SM120/121) can't
+# use GVR even without load balancing. The LB path additionally needs
+# cluster_size=4 programmatic multicast, which SM120/121's 1×1×1 cluster shape
+# lacks. Rubin keeps both (datacentre cluster shape, same PTX surface). radix
 # serves SM110+.
-_GVR_CCS = [100, 103]
+_GVR_CCS = [100, 103, 107]
 
 # ---------------------------------------------------------------------------
 # Backend requirement checkers
 # ---------------------------------------------------------------------------
+
+
+@functools.cache
+def _cute_dsl_supports_arch(major: int, minor: int) -> bool:
+    """Whether the installed CuTe DSL can target this compute capability.
+
+    The compute-capability lists above say which tiers FlashInfer *has* kernels
+    for; this says whether the *installed* DSL can emit code for the device. The
+    two differ on new silicon: a DSL release predating Rubin resolves ``sm_107a``
+    to a ``KeyError`` deep inside ``cute.compile``. Consulting this here makes
+    ``backend="auto"`` fall back to ``radix_cutlass`` instead, and makes
+    ``is_backend_supported`` report the truth. Mirrors
+    ``flashinfer.norm._cute_dsl_supports_arch``.
+    """
+    try:
+        from ..cute_dsl.utils import is_cute_dsl_arch_supported
+
+        return is_cute_dsl_arch_supported(major, minor)
+    except Exception:
+        # Never let the capability probe itself break top-k dispatch.
+        return True
+
+
+def _cute_dsl_ready(device: torch.device) -> bool:
+    """``True`` when the CuTe-DSL backends are usable on ``device``."""
+    if not _CUTE_DSL_AVAILABLE:
+        return False
+    major, minor = torch.cuda.get_device_capability(device)
+    return _cute_dsl_supports_arch(major, minor)
 
 
 @supported_compute_capability(_ALL_CCS)
@@ -123,7 +162,7 @@ def _gvr_top_k_varlen_check(
     Used by backend="auto" routing: returning False here causes the heuristic to
     fall back to radix or radix_cutlass rather than reaching GVR and crashing.
     """
-    if not (_CUTE_DSL_AVAILABLE and pre_idx is not None):
+    if not (_cute_dsl_ready(logits.device) and pre_idx is not None):
         return False
     # GvrParams only has entries for top_k in {512, 1024, 2048}; other values
     # raise inside the kernel's __init__ during compilation.
@@ -870,8 +909,8 @@ def _radix_top_k_varlen_check(
     load_balance=True,
     workspace=None,
 ):
-    """CuTe DSL multi-CTA radix: Blackwell only, no pre_idx required."""
-    return _CUTE_DSL_AVAILABLE
+    """CuTe DSL multi-CTA radix: Blackwell-plus only, no pre_idx required."""
+    return _cute_dsl_ready(logits.device)
 
 
 def _run_radix(
@@ -1039,7 +1078,8 @@ def top_k_varlen(
         Backend to use.  Default ``"auto"``.
 
         ``"radix"``         — CuTe DSL single-pass multi-CTA radix top-K
-                              (Blackwell sm_100+; native varlen, no ``pre_idx``,
+                              (Blackwell sm_100+ incl. Rubin sm_107; native
+                              varlen, no ``pre_idx``,
                               no logit masking).
         ``"gvr"``           — GVR kernel (Blackwell sm_100+ only; requires
                               ``pre_idx``). ``load_balance`` selects the LB vs

--- a/flashinfer/topk_varlen/topk_varlen.py
+++ b/flashinfer/topk_varlen/topk_varlen.py
@@ -113,8 +113,17 @@ def _cute_dsl_supports_arch(major: int, minor: int) -> bool:
     for; this says whether the *installed* DSL can emit code for the device. The
     two differ on new silicon: a DSL release predating Rubin resolves ``sm_107a``
     to a ``KeyError`` deep inside ``cute.compile``. Consulting this here makes
-    ``backend="auto"`` fall back to ``radix_cutlass`` instead, and makes
-    ``is_backend_supported`` report the truth. Mirrors
+    ``backend="auto"`` fall back to ``radix_cutlass`` instead of crashing, and
+    an explicit ``backend=`` request fail at dispatch with a clear error.
+
+    Note the introspection helper ``top_k_varlen.is_backend_supported`` does
+    NOT consult this (or any) runtime probe: it answers the *static* question
+    -- is the backend registered and does FlashInfer ship a kernel for this
+    compute capability -- from the registration dict and the CC lists alone.
+    Environment gates (installed-DSL arch support, the ``cutlass.memory``
+    requirement of ``radix_filter``) apply only at call time, through the
+    per-backend checkers. A True from ``is_backend_supported`` therefore does
+    not guarantee a call will be accepted in this environment. Mirrors
     ``flashinfer.norm._cute_dsl_supports_arch``.
     """
     try:

--- a/flashinfer/topk_varlen/topk_varlen.py
+++ b/flashinfer/topk_varlen/topk_varlen.py
@@ -35,6 +35,7 @@ Backend choices
 ``"radix_filter"``   — filtered-radix (coarse histogram → filter → on-chip
                        refine); hint-free like ``"radix"``, large-N specialist.
                        Datacentre Blackwell-class (sm_100/103/107) only;
+                       requires nvidia-cutlass-dsl >= 4.8 (see below);
                        opt-in — never chosen by ``"auto"``.
 ``"auto"``           — GVR (if pre_idx provided) > radix (Blackwell) >
                        radix_cutlass (default).
@@ -1035,10 +1036,15 @@ _RADIX_FILTER_DTYPES = (torch.float32, torch.float16, torch.bfloat16)
 def _radix_filter_kernel_dsl_ok() -> bool:
     """Whether the installed CuTe DSL has the APIs the vendored kernel uses.
 
-    The vendored files target the ``cutlass.memory`` namespace (``SmemAllocator``,
-    ``get_smem_capacity_in_bytes``), which exists only in DSL releases newer than
-    this repo's minimum pin -- on the pinned floor the kernel raises
-    ``AttributeError`` from inside ``cute.compile``. Unlike the arch probe above,
+    The vendored kernels require **nvidia-cutlass-dsl >= 4.8**. They use the
+    ``cutlass.memory`` namespace (``SmemAllocator``,
+    ``get_smem_capacity_in_bytes``); 4.7.x exposes those APIs under
+    ``cutlass.utils`` instead, lacks the sm_107 architecture/capacity
+    metadata the Rubin sizing needs, and predates the ``cutlass.block``
+    namespace the TMA path uses -- so a 4.7 "compatibility alias" would not
+    actually run these kernels, and this repo's minimum DSL pin is older
+    still. On such environments the kernel would raise ``AttributeError``
+    from inside ``cute.compile``. Unlike the arch probe above,
     this one fails CLOSED: without the module the kernel definitely cannot run,
     so reporting unsupported (clean fallback / clean dispatch error) is strictly
     better than the deferred crash.

--- a/flashinfer/topk_varlen/topk_varlen.py
+++ b/flashinfer/topk_varlen/topk_varlen.py
@@ -1094,6 +1094,17 @@ def _run_radix_filter(
         cute_dsl_radix_filter_topk_wrapper,
     )
 
+    # The kernel ABI declares a symbolic leading stride (padded row views are
+    # zero-copy) but requires a unit inner stride and a 32-byte-aligned base
+    # for its vectorized loads; anything else previously failed late with an
+    # opaque FFI alignment error. Materialize only the genuinely unsupported
+    # layouts (rare: transposed/gathered views, or a base sliced off
+    # alignment -- torch allocations themselves are 256-byte aligned).
+    if logits.stride(-1) != 1 or (logits.data_ptr() % 32) != 0:
+        logits = logits.contiguous()
+        if (logits.data_ptr() % 32) != 0:
+            logits = logits.clone()
+
     # Compile and launch under the input tensor's device: the persistent JIT
     # cache tags artifacts by the CURRENT device's architecture, and the
     # kernel launches on the current stream, so both must agree with where

--- a/flashinfer/topk_varlen/topk_varlen.py
+++ b/flashinfer/topk_varlen/topk_varlen.py
@@ -32,6 +32,10 @@ Backend choices
                        ``pre_idx`` hint from the previous decode step.
 ``"radix_cutlass"``  — masked-radix fallback; masks logits to ``seq_lens`` then
                        calls the FlashInfer CUTLASS radix top-K.  Runs on any GPU.
+``"radix_filter"``   — filtered-radix (coarse histogram → filter → on-chip
+                       refine); hint-free like ``"radix"``, large-N specialist.
+                       Datacentre Blackwell-class (sm_100/103/107) only;
+                       opt-in — never chosen by ``"auto"``.
 ``"auto"``           — GVR (if pre_idx provided) > radix (Blackwell) >
                        radix_cutlass (default).
 """
@@ -88,6 +92,13 @@ _BLACKWELL_PLUS_CCS = [100, 103, 107, 110, 120, 121]
 # lacks. Rubin keeps both (datacentre cluster shape, same PTX surface). radix
 # serves SM110+.
 _GVR_CCS = [100, 103, 107]
+
+# DKG filtered-radix backend (vendored CuTe-DSL kernel, see
+# kernels/filtered_topk_util.py). Upstream's own arch table
+# ``_LARGE_OCCUPANCY_MIN_BLOCKS_PER_MP`` covers sm_100/103/107/109. 109 is left
+# out here because the shipped CuTe DSL has no ``sm_109`` entry in
+# ``SMEM_CAPACITY_MAP``, so sizing raises before the kernel ever compiles.
+_RADIX_FILTER_CCS = [100, 103, 107]
 
 # ---------------------------------------------------------------------------
 # Backend requirement checkers
@@ -204,7 +215,11 @@ def _top_k_varlen_heuristic(
     call this function with positional args on the skip_check=True path without
     raising TypeError.  Mirrors the pattern used by _heuristic_func_mm_fp4.
     """
-    return [b for b in ("gvr", "radix", "radix_cutlass") if b in suitable_backends]
+    return [
+        b
+        for b in ("gvr", "radix", "radix_filter", "radix_cutlass")
+        if b in suitable_backends
+    ]
 
 
 # ---------------------------------------------------------------------------
@@ -996,6 +1011,108 @@ def _run_radix(
 
 
 # ---------------------------------------------------------------------------
+# Internal: DKG filtered-radix (`radix_filter`) backend implementation
+# ---------------------------------------------------------------------------
+
+_RADIX_FILTER_DTYPES = (torch.float32, torch.float16, torch.bfloat16)
+
+
+@functools.cache
+def _radix_filter_kernel_dsl_ok() -> bool:
+    """Whether the installed CuTe DSL has the APIs the vendored kernel uses.
+
+    The vendored files target the ``cutlass.memory`` namespace (``SmemAllocator``,
+    ``get_smem_capacity_in_bytes``), which exists only in DSL releases newer than
+    this repo's minimum pin -- on the pinned floor the kernel raises
+    ``AttributeError`` from inside ``cute.compile``. Unlike the arch probe above,
+    this one fails CLOSED: without the module the kernel definitely cannot run,
+    so reporting unsupported (clean fallback / clean dispatch error) is strictly
+    better than the deferred crash.
+    """
+    try:
+        import cutlass.memory  # noqa: F401, PLC0415
+
+        return hasattr(cutlass.memory, "SmemAllocator") and hasattr(
+            cutlass.memory, "get_smem_capacity_in_bytes"
+        )
+    except Exception:
+        return False
+
+
+@supported_compute_capability(_RADIX_FILTER_CCS)
+def _radix_filter_top_k_varlen_check(
+    logits,
+    seq_lens,
+    top_k,
+    pre_idx=None,
+    compress_ratio=1,
+    next_n=1,
+    return_values=False,
+    out_indices=None,
+    out_values=None,
+    backend="auto",
+    load_balance=True,
+    workspace=None,
+):
+    """Return True only when the vendored DKG kernel covers this configuration.
+
+    Upstream's decode wrapper has no ``compress_ratio`` and no ``pre_idx``
+    parameter at all, so those are hard exclusions rather than tuning knobs --
+    returning False here makes ``backend="auto"`` fall through to a backend that
+    does implement them instead of silently ignoring the argument.
+    """
+    if not _cute_dsl_ready(logits.device):
+        return False
+    if not _radix_filter_kernel_dsl_ok():
+        return False
+    if compress_ratio != 1:
+        return False
+    if logits.dtype not in _RADIX_FILTER_DTYPES:
+        return False
+    return True
+
+
+def _run_radix_filter(
+    logits: torch.Tensor,
+    seq_lens: torch.Tensor,
+    top_k: int,
+    next_n: int,
+    compress_ratio: int,
+    return_output_values: bool,
+    out_indices: torch.Tensor,
+    out_values: Optional[torch.Tensor],
+) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:
+    """DKG filtered-radix (coarse histogram -> filter -> refine) decode top-k.
+
+    The upstream wrapper's contract already matches this API: it takes the
+    ``(batch * next_n, N)`` logits and the ``(batch,)`` int32 ``seq_lens``, and
+    returns row-relative indices padded with ``-1``. It allocates its own
+    outputs, so ``out_indices``/``out_values`` are filled by copy when the
+    caller supplied them.
+    """
+    from .kernels.filtered_topk_decode import (  # noqa: PLC0415
+        cute_dsl_radix_filter_topk_wrapper,
+    )
+
+    idx, val = cute_dsl_radix_filter_topk_wrapper(
+        logits,
+        seq_lens,
+        top_k,
+        next_n,
+        return_val=return_output_values,
+    )
+
+    if out_indices is not None and out_indices.data_ptr() != idx.data_ptr():
+        out_indices.copy_(idx)
+        idx = out_indices
+    if return_output_values and out_values is not None and val is not None:
+        if out_values.data_ptr() != val.data_ptr():
+            out_values.copy_(val)
+            val = out_values
+    return idx, (val if return_output_values else None)
+
+
+# ---------------------------------------------------------------------------
 # Public API: top_k_varlen
 # ---------------------------------------------------------------------------
 
@@ -1005,6 +1122,7 @@ def _run_radix(
         "radix": _radix_top_k_varlen_check,
         "gvr": _gvr_top_k_varlen_check,
         "radix_cutlass": _radix_cutlass_top_k_varlen_check,
+        "radix_filter": _radix_filter_top_k_varlen_check,
     },
     heuristic_func=_top_k_varlen_heuristic,
 )
@@ -1019,7 +1137,7 @@ def top_k_varlen(
     return_values: bool = False,
     out_indices: Optional[torch.Tensor] = None,
     out_values: Optional[torch.Tensor] = None,
-    backend: Literal["radix", "gvr", "radix_cutlass", "auto"] = "auto",
+    backend: Literal["radix", "gvr", "radix_cutlass", "radix_filter", "auto"] = "auto",
     load_balance: bool = True,
     workspace: Optional[dict] = None,
 ) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:
@@ -1231,10 +1349,21 @@ def top_k_varlen(
             out_indices,
             out_values,
         )
+    elif backend == "radix_filter":
+        out_i, out_v = _run_radix_filter(
+            logits,
+            seq_lens,
+            top_k,
+            next_n,
+            compress_ratio,
+            return_values,
+            out_indices,
+            out_values,
+        )
     else:
         raise ValueError(
             f"Unknown backend: {backend!r}. "
-            f"Expected 'radix', 'gvr', or 'radix_cutlass'."
+            f"Expected 'radix', 'gvr', 'radix_cutlass', or 'radix_filter'."
         )
 
     return out_i, out_v

--- a/flashinfer/topk_varlen/topk_varlen.py
+++ b/flashinfer/topk_varlen/topk_varlen.py
@@ -1106,7 +1106,18 @@ def _run_radix_filter(
 
     The upstream wrapper's contract already matches this API: it takes the
     ``(batch * next_n, N)`` logits and the ``(batch,)`` int32 ``seq_lens``, and
-    returns row-relative indices padded with ``-1``. It allocates its own
+    returns row-relative indices padded with ``-1``.
+
+    Integration boundary (vs. the fused sparse-attention interface): this
+    backend produces ROW-RELATIVE TOP-K INDICES ONLY. It does not fuse the
+    page-table translation, does not take ``row_starts`` /
+    ``page_table_row_starts`` / ``row_to_batch``, offers no deterministic
+    tie-breaking, and has no ``dsa_graph_safe`` mode -- all of which
+    :func:`flashinfer.top_k_page_table_transform` provides in one fused
+    launch. A consumer of that interface can substitute this backend for
+    ordinary decode only by adding a separate index-transform launch, and
+    cannot substitute it at all where ``row_starts``-based ragged/extend
+    semantics or deterministic ties are required. It allocates its own
     outputs, so ``out_indices``/``out_values`` are filled by copy when the
     caller supplied them.
     """

--- a/flashinfer/topk_varlen/topk_varlen.py
+++ b/flashinfer/topk_varlen/topk_varlen.py
@@ -1124,21 +1124,24 @@ def _run_radix_filter(
     # kernel launches on the current stream, so both must agree with where
     # the data lives on a multi-GPU host.
     with torch.cuda.device(logits.device):
+        # Caller-supplied buffers are threaded through to the kernel launch, so
+        # the kernel writes them directly: no per-call output allocation, no
+        # num_rows x top_k device copy, and CUDA-graph users keep stable
+        # destinations across replays.
         idx, val = cute_dsl_radix_filter_topk_wrapper(
             logits,
             seq_lens,
             top_k,
             next_n,
             return_val=return_output_values,
+            out_indices=out_indices,
+            out_values=out_values if return_output_values else None,
         )
 
-    if out_indices is not None and out_indices.data_ptr() != idx.data_ptr():
-        out_indices.copy_(idx)
-        idx = out_indices
-    if return_output_values and out_values is not None and val is not None:
-        if out_values.data_ptr() != val.data_ptr():
-            out_values.copy_(val)
-            val = out_values
+    if out_indices is not None:
+        idx = out_indices  # same storage; preserve the caller's shape/object
+    if return_output_values and out_values is not None:
+        val = out_values
     return idx, (val if return_output_values else None)
 
 

--- a/flashinfer/topk_varlen/topk_varlen.py
+++ b/flashinfer/topk_varlen/topk_varlen.py
@@ -1078,12 +1078,19 @@ def _radix_filter_top_k_varlen_check(
 
     Upstream's decode wrapper has no ``compress_ratio`` and no ``pre_idx``
     parameter at all, so those are hard exclusions rather than tuning knobs --
-    returning False here makes ``backend="auto"`` fall through to a backend that
-    does implement them instead of silently ignoring the argument.
+    returning False here makes an explicit ``backend="radix_filter"`` call fail
+    at backend validation instead of silently ignoring the argument or failing
+    deep inside the kernel constructor.
     """
     if not _cute_dsl_ready(logits.device):
         return False
     if not _radix_filter_kernel_dsl_ok():
+        return False
+    if pre_idx is not None:
+        return False
+    # Vendored kernel bound: FilteredTopKKernelVarlen rejects top_k outside
+    # [1, 16384]; enforce it here so the failure is a backend-validation error.
+    if not 1 <= top_k <= 16384:
         return False
     if compress_ratio != 1:
         return False

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -133,6 +133,15 @@ exclude = [
   "flashinfer/gemm/kernels/dense_blockscaled_gemm_sm107.py",
   "flashinfer/fused_moe/cute_dsl/rubin/blockscaled_contiguous_gather_grouped_gemm_swiglu_fusion.py",
   "flashinfer/fused_moe/cute_dsl/rubin/blockscaled_contiguous_grouped_gemm_finalize_fusion.py",
+  # DKG filtered top-k kernels, vendored verbatim from dynamic-kernel-generator
+  # (see the provenance header in each file). Kept byte-faithful so upstream
+  # fixes can be re-applied by re-vendoring. The two reported errors are typing
+  # artifacts, not defects: `_get_num_sms` memoises via a function attribute,
+  # and `compiled_filter_topk_dict` is an untyped dict holding two distinct key
+  # shapes that cannot collide (each leads with a different wrapper-mode string
+  # and they differ in length).
+  "flashinfer/topk_varlen/kernels/filtered_topk_util.py",
+  "flashinfer/topk_varlen/kernels/filtered_topk_decode.py",
   "build/",
 ]
 

--- a/tests/topk_varlen/test_radix_filter.py
+++ b/tests/topk_varlen/test_radix_filter.py
@@ -148,3 +148,48 @@ def test_compile_uses_persistent_jit_cache():
     )
     objs = [o for d in module_dirs for o in d.glob("*.o")]
     assert objs, f"module dir {module_dirs} contains no exported kernel objects"
+
+
+def test_strided_and_misaligned_inputs():
+    """Padded row views are zero-copy ABI; misaligned bases are materialized.
+
+    A framework score buffer sliced to the vocab width (leading stride wider
+    than the row) must produce identical results to the compact tensor -- the
+    kernel ABI now declares a symbolic leading stride, so this pins declared
+    behavior rather than an accident of the runtime. A base pointer sliced off
+    32-byte alignment previously failed late with an opaque FFI alignment
+    error; the wrapper now materializes it.
+
+    Regression for PR #4621 review (strided/offset input ABI).
+    """
+    device = torch.device("cuda")
+    _skip_unless_radix_filter(device)
+
+    torch.manual_seed(11)
+    B, N, k = 4, 8192, 512
+    seq_lens = torch.full((B,), N, dtype=torch.int32, device=device)
+
+    # Padded view: rows 1+ distinguish the true stride from a compact
+    # misinterpretation (row 0 is at offset 0 either way).
+    buf = torch.randn(B, 2 * N, dtype=torch.float32, device=device)
+    view = buf[:, :N]
+    assert not view.is_contiguous()
+    idx, _ = flashinfer.top_k_varlen(view, seq_lens, k, backend="radix_filter")
+    idx = idx.view(B, k)
+    for b in range(B):
+        sel = idx[b][idx[b] >= 0]
+        kth = torch.topk(view[b], k).values.min()
+        assert bool((view[b][sel.long()] >= kth - 1e-4).all()), (
+            f"row {b}: padded-view results do not match the view's own data"
+        )
+
+    # Misaligned base: previously an opaque late ValueError from the FFI.
+    base = torch.randn(B * N + 1, dtype=torch.float32, device=device)
+    mis = base[1:].view(B, N)
+    assert mis.data_ptr() % 32 != 0
+    idx, _ = flashinfer.top_k_varlen(mis, seq_lens, k, backend="radix_filter")
+    idx = idx.view(B, k)
+    for b in range(B):
+        sel = idx[b][idx[b] >= 0]
+        kth = torch.topk(mis[b], k).values.min()
+        assert bool((mis[b][sel.long()] >= kth - 1e-4).all())

--- a/tests/topk_varlen/test_radix_filter.py
+++ b/tests/topk_varlen/test_radix_filter.py
@@ -267,3 +267,31 @@ def test_bounded_spill_policy_correctness():
         assert sel.numel() == k and sel.unique().numel() == k
         kth = torch.topk(logits[b], k).values.min()
         assert bool((logits[b][sel.long()] >= kth - 1e-4).all()), f"row {b}"
+
+
+@pytest.mark.parametrize("backend", ["radix_filter", "radix", "radix_cutlass"])
+def test_next_n_group_abi_validated(backend):
+    """next_n < 1 and row/group mismatches must fail fast at the API.
+
+    Every backend maps row r to sequence r // next_n, so next_n == 0 divides
+    by zero and logits.shape[0] != seq_lens.numel() * next_n silently reads
+    seq_lens out of bounds on device (or applies the wrong grouping) -- easy
+    to hit for an adapter that supplies expanded per-row lengths. Message-
+    matched so the pre-fix behavior (a deeper, different error or silent
+    corruption) cannot satisfy the test.
+
+    Regression for PR #4621 review (grouped next_n ABI validation).
+    """
+    device = torch.device("cuda")
+    if backend == "radix_filter":
+        _skip_unless_radix_filter(device)
+
+    logits = torch.randn(5, 4096, dtype=torch.float32, device=device)
+    seq_lens = torch.full((2,), 4096, dtype=torch.int32, device=device)
+
+    with pytest.raises(ValueError, match=r"next_n must be >= 1"):
+        flashinfer.top_k_varlen(logits, seq_lens, 512, next_n=0, backend=backend)
+
+    # 5 rows cannot be 2 groups of next_n=2.
+    with pytest.raises(ValueError, match=r"row // next_n"):
+        flashinfer.top_k_varlen(logits, seq_lens, 512, next_n=2, backend=backend)

--- a/tests/topk_varlen/test_radix_filter.py
+++ b/tests/topk_varlen/test_radix_filter.py
@@ -285,6 +285,14 @@ def test_next_n_group_abi_validated(backend):
     device = torch.device("cuda")
     if backend == "radix_filter":
         _skip_unless_radix_filter(device)
+    else:
+        # @backend_requirement rejects an unregistered backend/CC combination
+        # before the API body's next_n validation can run.
+        cc = get_compute_capability(device)
+        if not flashinfer.top_k_varlen.is_backend_supported(
+            backend, cc[0] * 10 + cc[1]
+        ):
+            pytest.skip(f"{backend} not supported on SM{cc[0]}{cc[1]}")
 
     logits = torch.randn(5, 4096, dtype=torch.float32, device=device)
     seq_lens = torch.full((2,), 4096, dtype=torch.int32, device=device)
@@ -330,7 +338,9 @@ def test_out_buffers_written_in_place():
         out_values=out_v,
         backend="radix_filter",
     )
-    with profile(activities=[ProfilerActivity.CPU, ProfilerActivity.CUDA]) as prof:
+    # CPU activity alone records aten::copy_ at dispatch level; CUDA activity
+    # would pull in CUPTI, which is not stable on every pre-release stack.
+    with profile(activities=[ProfilerActivity.CPU]) as prof:
         idx, vals = flashinfer.top_k_varlen(
             logits,
             seq_lens,

--- a/tests/topk_varlen/test_radix_filter.py
+++ b/tests/topk_varlen/test_radix_filter.py
@@ -295,3 +295,61 @@ def test_next_n_group_abi_validated(backend):
     # 5 rows cannot be 2 groups of next_n=2.
     with pytest.raises(ValueError, match=r"row // next_n"):
         flashinfer.top_k_varlen(logits, seq_lens, 512, next_n=2, backend=backend)
+
+
+def test_out_buffers_written_in_place():
+    """Caller-supplied out_indices/out_values must be kernel destinations.
+
+    Previously the wrapper always allocated its own outputs and the public
+    path copied into the caller's buffers -- an extra num_rows x top_k
+    allocation and D2D copy per call, and unstable destinations for CUDA
+    graphs. The profiler assertion has teeth: the old path launches
+    aten::copy_, the threaded path launches none.
+
+    Regression for PR #4621 review (out-buffer threading).
+    """
+    device = torch.device("cuda")
+    _skip_unless_radix_filter(device)
+
+    from torch.profiler import ProfilerActivity, profile
+
+    torch.manual_seed(13)
+    B, N, k = 8, 16384, 1024
+    logits = torch.randn(B, N, dtype=torch.float32, device=device)
+    seq_lens = torch.full((B,), N, dtype=torch.int32, device=device)
+    out_i = torch.empty(B * k, dtype=torch.int32, device=device)
+    out_v = torch.empty(B * k, dtype=torch.float32, device=device)
+
+    # warm-up (compile outside the profiled region)
+    flashinfer.top_k_varlen(
+        logits,
+        seq_lens,
+        k,
+        return_values=True,
+        out_indices=out_i,
+        out_values=out_v,
+        backend="radix_filter",
+    )
+    with profile(activities=[ProfilerActivity.CPU, ProfilerActivity.CUDA]) as prof:
+        idx, vals = flashinfer.top_k_varlen(
+            logits,
+            seq_lens,
+            k,
+            return_values=True,
+            out_indices=out_i,
+            out_values=out_v,
+            backend="radix_filter",
+        )
+        torch.cuda.synchronize()
+
+    assert idx.data_ptr() == out_i.data_ptr()
+    assert vals is not None and vals.data_ptr() == out_v.data_ptr()
+    copies = [e.key for e in prof.key_averages() if "aten::copy_" in e.key]
+    assert not copies, f"output copy still present: {copies}"
+
+    # and the results in the caller's buffers are correct
+    oi = out_i.view(B, k)
+    for b in range(B):
+        sel = oi[b][oi[b] >= 0]
+        kth = torch.topk(logits[b], k).values.min()
+        assert bool((logits[b][sel.long()] >= kth - 1e-4).all())

--- a/tests/topk_varlen/test_radix_filter.py
+++ b/tests/topk_varlen/test_radix_filter.py
@@ -225,3 +225,45 @@ def test_truncate_policy_rejects_topk_equal_to_smem_capacity():
     FilteredTopKKernelVarlen(
         cutlass.Float32, 1 << 20, S - 256, overflow_policy="TRUNCATE"
     )
+
+
+def test_bounded_spill_policy_correctness():
+    """BOUNDED_SPILL must clear the overflow flag it consumes.
+
+    The overflow flag was initialized only for REREAD while BOUNDED_SPILL both
+    increments and reads it; stale shared memory could select the
+    non-overflow refinement with more candidates than the bounded buffer.
+    Exercises the kernel-level wrapper (the public API pins REREAD) with a
+    spill capacity small enough that rows overflow into the reread fallback,
+    checked against a torch reference. Note: the unfixed behavior depends on
+    residual SMEM contents, so this is functional coverage of the fixed path
+    rather than a deterministic reproduction of the stale read.
+
+    Regression for PR #4621 review (overflow-flag initialization).
+    """
+    device = torch.device("cuda")
+    _skip_unless_radix_filter(device)
+
+    from flashinfer.topk_varlen.kernels.filtered_topk_decode import (
+        cute_dsl_radix_filter_topk_wrapper,
+    )
+
+    torch.manual_seed(5)
+    B, N, k = 8, 65536, 2048
+    logits = torch.randn(B, N, dtype=torch.float32, device=device)
+    seq_lens = torch.full((B,), N, dtype=torch.int32, device=device)
+    idx, _ = cute_dsl_radix_filter_topk_wrapper(
+        logits,
+        seq_lens,
+        k,
+        1,
+        return_val=False,
+        overflow_policy="BOUNDED_SPILL",
+        spill_capacity=k + 256,  # small: forces overflow -> reread fallback
+    )
+    idx = idx.view(B, k)
+    for b in range(B):
+        sel = idx[b][idx[b] >= 0]
+        assert sel.numel() == k and sel.unique().numel() == k
+        kth = torch.topk(logits[b], k).values.min()
+        assert bool((logits[b][sel.long()] >= kth - 1e-4).all()), f"row {b}"

--- a/tests/topk_varlen/test_radix_filter.py
+++ b/tests/topk_varlen/test_radix_filter.py
@@ -20,6 +20,19 @@ import flashinfer
 from flashinfer.utils import get_compute_capability
 
 
+def _radix_filter_dsl_ok() -> bool:
+    """Dynamic probe: does the installed CuTe DSL support the vendored kernels?
+
+    is_backend_supported() is static (registration + CC lists only), so it
+    stays True on a supported arch even when nvidia-cutlass-dsl < 4.8 -- and
+    the API then rejects every call via the backend's fail-closed DSL check.
+    Tests must skip on such environments, not fail.
+    """
+    from flashinfer.topk_varlen.topk_varlen import _radix_filter_kernel_dsl_ok
+
+    return _radix_filter_kernel_dsl_ok()
+
+
 def _skip_unless_radix_filter(device: torch.device) -> None:
     cc = get_compute_capability(device)
     if cc[0] * 10 + cc[1] not in (100, 103, 107):
@@ -28,6 +41,8 @@ def _skip_unless_radix_filter(device: torch.device) -> None:
         "radix_filter", cc[0] * 10 + cc[1]
     ):
         pytest.skip("radix_filter not supported in this environment")
+    if not _radix_filter_dsl_ok():
+        pytest.skip("radix_filter requires nvidia-cutlass-dsl >= 4.8")
 
 
 @pytest.mark.parametrize(
@@ -104,6 +119,9 @@ def test_num_sms_cache_is_per_device():
 
     Regression for PR #4621 review (per-device SM-count cache).
     """
+    if not _radix_filter_dsl_ok():
+        pytest.skip("radix_filter kernels require nvidia-cutlass-dsl >= 4.8")
+
     from flashinfer.topk_varlen.kernels.filtered_topk_decode import _get_num_sms
 
     if torch.cuda.device_count() < 2:
@@ -205,7 +223,8 @@ def test_truncate_policy_rejects_topk_equal_to_smem_capacity():
 
     Regression for PR #4621 review (TRUNCATE boundary).
     """
-    pytest.importorskip("cutlass")
+    if not _radix_filter_dsl_ok():
+        pytest.skip("radix_filter kernels require nvidia-cutlass-dsl >= 4.8")
     import cutlass
 
     from flashinfer.topk_varlen.kernels.filtered_topk_util import (

--- a/tests/topk_varlen/test_radix_filter.py
+++ b/tests/topk_varlen/test_radix_filter.py
@@ -116,3 +116,35 @@ def test_num_sms_cache_is_per_device():
             f"device {i}: cached SM count {got} != actual {expected} -- "
             f"the cache is not keyed by device"
         )
+
+
+def test_compile_uses_persistent_jit_cache():
+    """radix_filter compiles must go through FlashInfer's persistent JIT cache.
+
+    A bare ``cute.compile`` keeps the kernel only in process memory: every new
+    process (e.g. each serving worker) recompiles on first use, and nothing
+    honors architecture/DSL/source invalidation or FLASHINFER_DISABLE_JIT.
+    After one call through the public API, the exported artifact must exist in
+    the on-disk module directory (tagged by compile architecture). Fails on
+    the unrouted code, which writes no artifact.
+
+    Regression for PR #4621 review (persistent JIT routing + arch in key).
+    """
+    device = torch.device("cuda")
+    _skip_unless_radix_filter(device)
+
+    from flashinfer.jit import env as jit_env
+
+    torch.manual_seed(3)
+    logits = torch.randn(4, 8192, dtype=torch.float32, device=device)
+    seq_lens = torch.full((4,), 8192, dtype=torch.int32, device=device)
+    flashinfer.top_k_varlen(logits, seq_lens, 512, backend="radix_filter")
+
+    module_dirs = list(jit_env.FLASHINFER_JIT_DIR.glob("radix_filter_topk_*_cute_dsl"))
+    assert module_dirs, (
+        f"no radix_filter_topk module directory under "
+        f"{jit_env.FLASHINFER_JIT_DIR} -- compiles are not routed through the "
+        f"persistent JIT cache"
+    )
+    objs = [o for d in module_dirs for o in d.glob("*.o")]
+    assert objs, f"module dir {module_dirs} contains no exported kernel objects"

--- a/tests/topk_varlen/test_radix_filter.py
+++ b/tests/topk_varlen/test_radix_filter.py
@@ -91,3 +91,28 @@ def test_short_misaligned_rows(dtype, N):
         ref = torch.topk(logits[b, :n].float(), top_k).values
         got = torch.sort(vals[b].float(), descending=True).values
         torch.testing.assert_close(got, ref, atol=1e-2, rtol=1e-2)
+
+
+def test_num_sms_cache_is_per_device():
+    """The SM-count memo must be keyed by device, not first-caller-wins.
+
+    On a heterogeneous multi-GPU host, a process-wide scalar would pin the
+    first device's SM count and mis-size the persistent grid / occupancy-mode
+    decision for every other GPU. Host-only (no kernels launched), so it runs
+    on any multi-GPU box; it has real teeth wherever the visible devices have
+    differing SM counts (the unfixed code returns one count for all devices).
+
+    Regression for PR #4621 review (per-device SM-count cache).
+    """
+    from flashinfer.topk_varlen.kernels.filtered_topk_decode import _get_num_sms
+
+    if torch.cuda.device_count() < 2:
+        pytest.skip("needs >= 2 visible CUDA devices")
+
+    for i in range(torch.cuda.device_count()):
+        expected = torch.cuda.get_device_properties(i).multi_processor_count
+        got = _get_num_sms(torch.device("cuda", i))
+        assert got == expected, (
+            f"device {i}: cached SM count {got} != actual {expected} -- "
+            f"the cache is not keyed by device"
+        )

--- a/tests/topk_varlen/test_radix_filter.py
+++ b/tests/topk_varlen/test_radix_filter.py
@@ -1,0 +1,93 @@
+# Copyright (c) 2025 by FlashInfer team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Focused regression tests for the `radix_filter` top-k backend."""
+
+import pytest
+import torch
+
+import flashinfer
+from flashinfer.utils import get_compute_capability
+
+
+def _skip_unless_radix_filter(device: torch.device) -> None:
+    cc = get_compute_capability(device)
+    if cc[0] * 10 + cc[1] not in (100, 103, 107):
+        pytest.skip("radix_filter requires SM100/SM103/SM107")
+    if not flashinfer.top_k_varlen.is_backend_supported(
+        "radix_filter", cc[0] * 10 + cc[1]
+    ):
+        pytest.skip("radix_filter not supported in this environment")
+
+
+@pytest.mark.parametrize(
+    "dtype,N",
+    [
+        # Row stride (N * element_size) deliberately NOT a multiple of the
+        # kernel's 32-byte copy alignment, so successive rows start at varying
+        # misalignments and the scalar prologue spans up to 7 (fp32) or 15
+        # (fp16/bf16) elements.
+        (torch.float32, 101),
+        (torch.float16, 105),
+        (torch.bfloat16, 105),
+    ],
+)
+def test_short_misaligned_rows(dtype, N):
+    """Short misaligned rows must not scan past their valid length.
+
+    ``prologue_elems`` is derived from address alignment alone; on a row with
+    ``top_k < seq_len < prologue span`` an unclamped prologue reads elements
+    beyond ``seq_len`` into the coarse histogram, so indices past the row's
+    valid length can be emitted as top-k results (and the final row can read
+    past the allocation). Elements beyond each row's length are planted with a
+    large sentinel so any over-read is guaranteed to surface in the output
+    rather than depending on random values.
+
+    Regression for PR #4621 review (prologue clamp in every mode).
+    """
+    device = torch.device("cuda")
+    _skip_unless_radix_filter(device)
+
+    torch.manual_seed(7)
+    top_k = 4
+    # Lengths straddle the maximum possible prologue span, all > top_k so the
+    # trivial-case shortcut cannot mask the scan path. Kept at 5/6 so that for
+    # every tested (dtype, N) at least one row has prologue span > length
+    # (e.g. fp32/N=101: row 5 starts 4 bytes past a 32-byte boundary, giving a
+    # 7-element prologue against a 6-element row).
+    lens = [5, 6, 5, 6, 5, 6, 5, 6]
+    B = len(lens)
+    logits = torch.randn(B, N, dtype=dtype, device=device)
+    seq_lens = torch.tensor(lens, dtype=torch.int32, device=device)
+    # Sentinel: anything the kernel reads beyond a row's valid length would
+    # dominate the top-k and show up as an out-of-range index.
+    for b, n in enumerate(lens):
+        logits[b, n:] = 100.0
+
+    idx, vals = flashinfer.top_k_varlen(
+        logits, seq_lens, top_k, return_values=True, backend="radix_filter"
+    )
+    idx = idx.view(B, top_k)
+    vals = vals.view(B, top_k)
+
+    for b, n in enumerate(lens):
+        sel = idx[b][idx[b] >= 0]
+        assert sel.numel() == top_k, f"row {b}: expected {top_k} indices"
+        assert int(sel.max()) < n, (
+            f"row {b} (len={n}): index {int(sel.max())} beyond the valid "
+            f"length -- the prologue scanned past the row"
+        )
+        assert sel.unique().numel() == sel.numel()
+        ref = torch.topk(logits[b, :n].float(), top_k).values
+        got = torch.sort(vals[b].float(), descending=True).values
+        torch.testing.assert_close(got, ref, atol=1e-2, rtol=1e-2)

--- a/tests/topk_varlen/test_radix_filter.py
+++ b/tests/topk_varlen/test_radix_filter.py
@@ -193,3 +193,35 @@ def test_strided_and_misaligned_inputs():
         sel = idx[b][idx[b] >= 0]
         kth = torch.topk(mis[b], k).values.min()
         assert bool((mis[b][sel.long()] >= kth - 1e-4).all())
+
+
+def test_truncate_policy_rejects_topk_equal_to_smem_capacity():
+    """TRUNCATE must require top_k strictly below the SMEM candidate capacity.
+
+    The fine-threshold search selects the bin whose inclusive cumulative count
+    STRICTLY exceeds the remaining k; truncation to exactly top_k candidates
+    makes the total equal k, so no bin qualifies and refinement consumes stale
+    control state. Host-only (constructor validation; nothing is compiled).
+
+    Regression for PR #4621 review (TRUNCATE boundary).
+    """
+    pytest.importorskip("cutlass")
+    import cutlass
+
+    from flashinfer.topk_varlen.kernels.filtered_topk_util import (
+        FilteredTopKKernelVarlen,
+    )
+
+    probe = FilteredTopKKernelVarlen(cutlass.Float32, 1 << 20, 512)
+    S = probe.filtered_topk_smem_input_size
+    assert S >= 512
+
+    # Equality must now be rejected up front...
+    with pytest.raises(ValueError, match=r"requires top_k \(\d+\) <"):
+        FilteredTopKKernelVarlen(
+            cutlass.Float32, 1 << 20, S, overflow_policy="TRUNCATE"
+        )
+    # ...while strictly-below remains accepted.
+    FilteredTopKKernelVarlen(
+        cutlass.Float32, 1 << 20, S - 256, overflow_policy="TRUNCATE"
+    )

--- a/tests/topk_varlen/test_radix_filter.py
+++ b/tests/topk_varlen/test_radix_filter.py
@@ -490,3 +490,47 @@ def test_tma_auto_falls_back_on_misaligned_stride():
         assert sel.numel() == k and sel.unique().numel() == k
         kth = torch.topk(view[b], k).values.min()
         assert bool((view[b][sel.long()] >= kth - 1e-4).all()), f"row {b}"
+
+
+def test_out_buffers_foreign_device_rejected():
+    """Caller out-buffers on a different device than the input must be rejected.
+
+    The kernel launches on input_values.device; a foreign-device buffer passes
+    dtype/shape validation but hands the kernel a pointer it cannot legally
+    write. No pre-fix teeth run here on purpose: executing the unfixed path
+    performs a cross-device write that can poison the CUDA context, so this
+    is functional coverage of the rejection only.
+
+    Regression for PR #4621 review round 2 (out-buffer device validation).
+    """
+    if torch.cuda.device_count() < 2:
+        pytest.skip("needs >= 2 visible CUDA devices")
+
+    in_dev = None
+    for i in range(torch.cuda.device_count()):
+        d = torch.device("cuda", i)
+        cc = get_compute_capability(d)
+        if cc[0] * 10 + cc[1] in (100, 103, 107):
+            in_dev = d
+            break
+    if in_dev is None:
+        pytest.skip("no radix_filter-capable device visible")
+    _skip_unless_radix_filter(in_dev)
+    other = torch.device("cuda", (in_dev.index + 1) % torch.cuda.device_count())
+
+    B, N, k = 4, 4096, 512
+    logits = torch.randn(B, N, dtype=torch.float32, device=in_dev)
+    seq_lens = torch.full((B,), N, dtype=torch.int32, device=in_dev)
+    foreign = torch.empty(B * k, dtype=torch.int32, device=other)
+
+    with (
+        torch.cuda.device(in_dev),
+        pytest.raises(ValueError, match=r"input device"),
+    ):
+        flashinfer.top_k_varlen(
+            logits,
+            seq_lens,
+            k,
+            backend="radix_filter",
+            out_indices=foreign,
+        )

--- a/tests/topk_varlen/test_radix_filter.py
+++ b/tests/topk_varlen/test_radix_filter.py
@@ -382,3 +382,83 @@ def test_out_buffers_written_in_place():
         sel = oi[b][oi[b] >= 0]
         kth = torch.topk(logits[b], k).values.min()
         assert bool((logits[b][sel.long()] >= kth - 1e-4).all())
+
+
+def test_tma_forced_on_misaligned_stride_fails_fast():
+    """Forced TMA with a 16-byte-misaligned leading stride must fail fast.
+
+    With the symbolic leading stride, num_cols divisibility no longer implies
+    the row byte-stride alignment cuTensorMapEncodeTiled requires; a padded
+    view (stride(0) = N + 1) previously reached the descriptor and failed with
+    an opaque error after compiling. Now the wrapper raises an actionable
+    ValueError before compilation. Runs on any radix_filter arch because
+    enable_tma_load=True bypasses the tuned default.
+
+    Regression for PR #4621 review round 2 (TMA stride gate).
+    """
+    device = torch.device("cuda")
+    _skip_unless_radix_filter(device)
+
+    from flashinfer.topk_varlen.kernels.filtered_topk_decode import (
+        _get_num_sms,
+        cute_dsl_radix_filter_topk_wrapper,
+    )
+
+    sms = _get_num_sms(device)
+    B, N, k = sms + 2, 4096, 512  # rows > SMs => large-occupancy TMA path
+    base = torch.randn(B, N + 1, dtype=torch.float32, device=device)
+    view = base[:, :N]
+    assert view.stride(0) % 4 != 0  # fp32 _tma_div == 4
+    seq_lens = torch.full((B,), N, dtype=torch.int32, device=device)
+
+    with pytest.raises(ValueError, match=r"16-byte"):
+        cute_dsl_radix_filter_topk_wrapper(
+            view,
+            seq_lens,
+            k,
+            1,
+            return_val=False,
+            cluster_size=1,
+            enable_tma_load=True,
+        )
+
+
+def test_tma_auto_falls_back_on_misaligned_stride():
+    """The tuned auto-TMA default must fall back to LDG on misaligned strides.
+
+    On the arch where the tuned default fires (fp32, Rubin, large N,
+    rows > SMs), a padded view with stride(0) % 4 != 0 previously auto-enabled
+    TMA and failed inside cuTensorMapEncodeTiled; the stride-aware gate keeps
+    the call on the LDG path, which must produce correct top-k.
+
+    Regression for PR #4621 review round 2 (TMA stride gate, auto path).
+    """
+    device = torch.device("cuda")
+    _skip_unless_radix_filter(device)
+
+    import cutlass
+
+    from flashinfer.topk_varlen.kernels.filtered_topk_util import (
+        get_topk_architecture_config,
+        tma_tuned_default,
+    )
+
+    architecture, _ = get_topk_architecture_config()
+    if not tma_tuned_default(cutlass.Float32, architecture, 131072):
+        pytest.skip("async-TMA tuned default not active on this arch")
+
+    torch.manual_seed(23)
+    sms = torch.cuda.get_device_properties(device).multi_processor_count
+    B, N, k = sms + 2, 131072, 2048
+    base = torch.randn(B, N + 1, dtype=torch.float32, device=device)
+    view = base[:, :N]
+    assert view.stride(0) % 4 != 0
+    seq_lens = torch.full((B,), N, dtype=torch.int32, device=device)
+
+    idx, _ = flashinfer.top_k_varlen(view, seq_lens, k, backend="radix_filter")
+    idx = idx.view(B, k)
+    for b in (0, B // 2, B - 1):
+        sel = idx[b][idx[b] >= 0]
+        assert sel.numel() == k and sel.unique().numel() == k
+        kth = torch.topk(view[b], k).values.min()
+        assert bool((view[b][sel.long()] >= kth - 1e-4).all()), f"row {b}"

--- a/tests/topk_varlen/test_radix_filter.py
+++ b/tests/topk_varlen/test_radix_filter.py
@@ -534,3 +534,53 @@ def test_out_buffers_foreign_device_rejected():
             backend="radix_filter",
             out_indices=foreign,
         )
+
+
+@pytest.mark.xfail(
+    strict=False,
+    reason="upstream DKG multi-pass merge scans the padded candidate width; "
+    "padded (-1, -inf) entries tie with genuinely valid -inf elements, so "
+    "slots that should hold valid indices can come back as -1. strict=False "
+    "because the leak depends on tie-collection order, which is not "
+    "deterministic across runs/architectures. Preserved as xfail until the "
+    "upstream fix lands (see the PR #4621 review thread).",
+)
+def test_multipass_merge_padding_vs_valid_neg_inf():
+    """xfail: multi-pass merge can emit -1 despite >= k valid elements.
+
+    Two chunks per row (N = 2 * 16384) with a nearly-empty second chunk
+    (1 valid element < k), so stage one pads that chunk's candidate list
+    with k - 1 (-1, -inf) entries; only 8 values are finite and the rest of
+    the row is genuinely valid -inf. The row length (16385) exceeds k, so
+    every output slot must be a valid index -- but padded and valid -inf
+    candidates share a radix key, and the merge's fixed-width scan selects
+    pads (measured ~1087/2048 slots on SM100 with this shape; a fully-valid
+    second chunk produces no padding, which is why that case passes). Three
+    seeds are tried because tie-collection order varies run to run. NOT
+    reachable from public top_k_varlen.
+    """
+    device = torch.device("cuda")
+    _skip_unless_radix_filter(device)
+
+    from flashinfer.topk_varlen.kernels.filtered_topk_decode import (
+        cute_dsl_radix_filter_topk_multi_cta_wrapper,
+    )
+
+    B, N, k = 2, 32768, 1024
+    total_neg = 0
+    for trial in range(3):
+        vals = torch.full((B, N), float("-inf"), dtype=torch.float32, device=device)
+        vals[:, :8] = torch.arange(
+            8 + trial, trial, -1, dtype=torch.float32, device=device
+        )
+        # 16384 + 1: the second chunk holds one valid element < k, forcing
+        # k - 1 stage-one pads into the merge width. Total valid still >= k.
+        seq_lens = torch.full((B,), 16384 + 1, dtype=torch.int32, device=device)
+        idx, _ = cute_dsl_radix_filter_topk_multi_cta_wrapper(
+            vals, seq_lens, k, 1, return_val=False
+        )
+        total_neg += int((idx.view(B, k) < 0).sum())
+    assert total_neg == 0, (
+        "merge emitted padded -1 for rows with >= k valid elements: "
+        f"{total_neg} invalid slots across 3 trials"
+    )

--- a/tests/topk_varlen/test_radix_filter.py
+++ b/tests/topk_varlen/test_radix_filter.py
@@ -384,6 +384,34 @@ def test_out_buffers_written_in_place():
         assert bool((logits[b][sel.long()] >= kth - 1e-4).all())
 
 
+def test_checker_rejects_pre_idx_and_oob_top_k():
+    """Explicit radix_filter calls must fail backend validation, not deeper.
+
+    The checker docstring advertises pre_idx as a hard exclusion and the
+    vendored kernel only supports top_k in [1, 16384], but neither was
+    enforced: a non-None pre_idx was silently ignored (the kernel ran without
+    the hint) and an oversized top_k surfaced as the kernel constructor's
+    ValueError instead of a backend-validation error. Message-matched to the
+    @backend_requirement rejection so the pre-fix behaviors cannot pass.
+
+    Regression for PR #4621 review round 2 (checker constraints).
+    """
+    device = torch.device("cuda")
+    _skip_unless_radix_filter(device)
+
+    torch.manual_seed(21)
+    logits = torch.randn(8, 32768, dtype=torch.float32, device=device)
+    seq_lens = torch.full((8,), 32768, dtype=torch.int32, device=device)
+
+    pre = torch.zeros(8, 4096, dtype=torch.int32, device=device)
+    with pytest.raises(ValueError, match=r"Problem size is not supported"):
+        flashinfer.top_k_varlen(
+            logits, seq_lens, 1024, pre_idx=pre, backend="radix_filter"
+        )
+    with pytest.raises(ValueError, match=r"Problem size is not supported"):
+        flashinfer.top_k_varlen(logits, seq_lens, 16385, backend="radix_filter")
+
+
 def test_tma_forced_on_misaligned_stride_fails_fast():
     """Forced TMA with a 16-byte-misaligned leading stride must fail fast.
 


### PR DESCRIPTION
## 📌 Description

Two changes to `top_k_varlen`: make the existing backends work on Rubin (SM107), and add a fourth backend ported from DKG.

### 1. Enable `top_k_varlen` on Rubin (SM107)

`top_k_varlen` refused *every* backend on SM107 — including `radix_cutlass`, the plain CUTLASS fallback that has nothing Blackwell-specific about it. The compute-capability sets attached to the backend checkers simply had no `107` entry, so dispatch raised `BackendSupportedError` before any kernel ran.

No kernel changes were needed. The CuTe-DSL kernels use only family-portable operations, and the DSL already knows `sm_107a`, so they compile for Rubin as-is. This adds `107` to the capability lists.

It also adds a small probe distinguishing two questions that used to be conflated: *"does FlashInfer ship a kernel for this tier?"* (the capability lists) versus *"can the installed CuTe DSL emit code for this device?"*. They differ on new silicon — a DSL predating Rubin fails on `sm_107a` deep inside `cute.compile`. Consulting the second makes `backend="auto"` fall back cleanly instead of crashing, and makes `is_backend_supported` tell the truth.

Result on SM107: **5 passed / 43 failed / 67 skipped → 115 passed.**

### 2. Add the DKG filtered-radix kernel as a `radix_filter` backend

Vendors the filtered top-k kernel from the NVIDIA dynamic-kernel-generator repo (MR !25590, *"[CuTeDSL] Adapt radix top-k to Rubin arch"*).

All three CuTe-DSL backends solve the same problem — find the k-th largest value, then keep everything above it — and all three do it by histogramming the high bits rather than sorting. They differ in **what they hold in shared memory while narrowing**:

- **`radix`** stages a chunk of the *raw row* in SMEM; all CTAs merge histograms each round to agree on a global pivot.
- **`radix_filter`** (new) stages only the *survivors*. It streams the row twice — once to histogram, once to collect the elements landing in the threshold bin — then refines within that candidate set on-chip, never touching DRAM again.
- **`gvr`** skips the search when it can: it guesses a threshold from the previous decode step's indices, verifies, and refines. It needs a `pre_idx` hint; the other two don't.

So `radix_filter` is a sibling of `radix` — hint-free, same input contract, directly interchangeable — rather than an alternative to `gvr`.

The practical consequence of staging survivors instead of input is that `radix_filter`'s SMEM pressure scales with *how many elements fall in the threshold bin* rather than with a chunk size it can shrink at will. That is why it alone carries overflow policies, and why it is the backend most sensitive to a device's SMEM capacity.

Two notes on the port:

- The vendored files are byte-faithful to upstream apart from the provenance header, removal of DKG-internal release markers, and import rewrites, so upstream fixes can be re-applied by re-vendoring. They are excluded from mypy in the same way as the other vendored CuTe-DSL kernels.
- Upstream's wrapper has no `compress_ratio` and no `pre_idx` parameter, so the checker declares those unsupported rather than silently ignoring them — `backend="auto"` then falls through to a backend that implements them.

- The backend checker also probes for the `cutlass.memory` namespace the vendored kernel requires; that API postdates the repo's minimum nvidia-cutlass-dsl pin, and without the probe the kernel dies with an `AttributeError` inside `cute.compile` on the pinned floor. The probe fails closed, so older DSLs get a clean unsupported verdict and `backend="auto"` is unaffected.

## 🔍 Related Issues

DKG merge request !25590 (`dlarch-fastkernels/dynamic-kernel-generator`).

## 🚀 Pull Request Checklist

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

Every suite exercising the `top_k_varlen` API passes on **both** SM100 and SM107, with identical counts: `tests/topk_varlen` 115 passed, its `-k gvr` subset 11 passed, `tests/trace/test_top_k_varlen_reference_correctness.py` 2 passed, and the trace-template suites (consistency 714, registry 4, init 373) passing on both.

Also checked against an independent per-row `torch.topk` reference that shares no code with the kernels — verifying index count, range, uniqueness, and that every selected value clears the true k-th largest — across all four backends, fp32/fp16/bf16, fixed and variable lengths, and N up to 262144: **0 failures on either arch**.

The SM107 enablement was additionally verified across seven GPUs (SM80, SM89, SM90, SM100 ×2, SM107, SM120) with zero failures; non-datacentre parts are unchanged.

## Reviewer Notes

Performance characterisation is deliberately left out of this description — the numbers need more validation before I'd want them relied on, and I'll follow up separately.



### Positioning vs the fused page-table path (from review)

Review measurement (B200, fp32, k=2048, page_size=1) compared `radix_filter` via `top_k_varlen` plus a gather-based page-table transform against the existing fused `top_k_page_table_transform(dsa_graph_safe=True)`. The fused path wins most of the decode regime; `radix_filter` only pulls ahead at large N with enough rows (up to 1.77x end-to-end at 256 rows x 262K). The raw radix/GVR comparisons in this PR therefore do **not** establish an end-to-end win over the fused path for ordinary decode shapes. The backend lands here as an opt-in selection engine; the justified follow-up is wiring it in **under** the fused dispatcher for the large-N regime rather than substituting it at the adapter level.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Rubin GPUs and expanded compatibility across Blackwell and Rubin datacentre platforms.
  * Added a filtered top-k backend for variable-length workloads, with automatic selection and validation.
  * Improved top-k performance through architecture-aware tuning, shared-memory optimization, and multi-CTA execution.
  * Added configurable overflow handling and efficient execution for larger workloads.
  * Added graceful fallback when the installed CuTe DSL version is unsupported.
* **Documentation**
  * Updated backend documentation with Rubin support and filtered top-k usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->