### PR TITLE
feat(cudnn): expose FP8 output scaling (o_scale) and amax outputs in cudnn prefill

### DIFF
--- a/flashinfer/cudnn/prefill.py
+++ b/flashinfer/cudnn/prefill.py
@@ -1,4 +1,5 @@
 import functools
+import warnings
 from enum import Enum
 from typing import Optional
 
@@ -69,6 +70,75 @@ def _get_dummy_scale_tensor(device: torch.device):
     return t
 
 
+_FP8_DTYPES = (torch.float8_e4m3fn, torch.float8_e5m2)
+
+
+def _check_fp8_scale_args(
+    q_dtype: torch.dtype,
+    o_data_type: torch.dtype,
+    q_scale: Optional[torch.Tensor],
+    k_scale: Optional[torch.Tensor],
+    v_scale: Optional[torch.Tensor],
+    o_scale: Optional[torch.Tensor],
+    amax_s: Optional[torch.Tensor],
+    amax_o: Optional[torch.Tensor],
+) -> None:
+    """Validate the fp8-only scale/amax arguments against the query dtype.
+
+    With a non-fp8 query, raises ValueError for an fp8 ``o_data_type`` (a
+    non-fp8 graph cannot quantize its output: it produces NaN garbage) and for
+    the fp8-output-only arguments ``o_scale``/``amax_s``/``amax_o``.  The
+    long-standing ``q_scale``/``k_scale``/``v_scale`` arguments only warn:
+    they were always silently ignored on non-fp8 graphs and callers pass them
+    unconditionally.  With an fp8 query, warns when an fp8 output is requested
+    without ``o_scale``: the output is then emitted with unit scale and
+    saturates at the fp8 dtype maximum (448 for e4m3).
+    """
+    if q_dtype not in _FP8_DTYPES:
+        if o_data_type in _FP8_DTYPES:
+            raise ValueError(
+                f"o_data_type={o_data_type} requires an fp8 query dtype "
+                f"(torch.float8_e4m3fn or torch.float8_e5m2), got {q_dtype}: "
+                "non-fp8 graphs cannot quantize their output"
+            )
+        rejected = [
+            name
+            for name, t in (
+                ("o_scale", o_scale),
+                ("amax_s", amax_s),
+                ("amax_o", amax_o),
+            )
+            if t is not None
+        ]
+        if rejected:
+            raise ValueError(
+                f"{', '.join(rejected)} require(s) an fp8 query dtype "
+                f"(torch.float8_e4m3fn or torch.float8_e5m2), got {q_dtype}"
+            )
+        ignored = [
+            name
+            for name, t in (
+                ("q_scale", q_scale),
+                ("k_scale", k_scale),
+                ("v_scale", v_scale),
+            )
+            if t is not None
+        ]
+        if ignored:
+            warnings.warn(
+                f"{', '.join(ignored)} are only consumed by fp8 graphs and "
+                f"are ignored for query dtype {q_dtype}",
+                stacklevel=3,
+            )
+    elif o_data_type in _FP8_DTYPES and o_scale is None:
+        warnings.warn(
+            "o_data_type is fp8 but o_scale was not provided; the output is "
+            "emitted with unit scale and saturates at the fp8 dtype maximum "
+            "(448 for e4m3). Pass o_scale to quantize the output.",
+            stacklevel=3,
+        )
+
+
 def _create_cudnn_handle(stream: torch.cuda.Stream):
     global _cudnn_handle
 
@@ -137,6 +207,8 @@ def _sdpa_prefill_key_fn(
     out: Optional[torch.Tensor] = None,
     lse: Optional[torch.Tensor] = None,
     o_data_type: Optional[torch.dtype] = None,
+    return_amax_s: bool = False,
+    return_amax_o: bool = False,
 ):
     if actual_seq_lens_q is not None:
         graph_b = actual_seq_lens_q.shape[0]
@@ -150,10 +222,13 @@ def _sdpa_prefill_key_fn(
     elif q.dim() == 4:
         h_qo, d_qk = q.shape[1], q.shape[3]
 
+    # h_kv/d_vo mirror the builder, which reads them from v_cache: d_vo can
+    # differ from d_qk (e.g. DeepSeek's 192/128 split), so keying them off
+    # k_cache would let same-shape calls differing only in d_vo share a graph.
     if v_cache.dim() == 3:
-        h_kv, d_vo = k_cache.shape[1], k_cache.shape[2]
-    elif k_cache.dim() == 4:
-        h_kv, d_vo = k_cache.shape[1], k_cache.shape[3]
+        h_kv, d_vo = v_cache.shape[1], v_cache.shape[2]
+    elif v_cache.dim() == 4:
+        h_kv, d_vo = v_cache.shape[1], v_cache.shape[3]
 
     if block_tables is not None:
         page_size = k_cache.shape[2]
@@ -161,7 +236,12 @@ def _sdpa_prefill_key_fn(
     key = (
         graph_b,
         q.dim(),
+        # I/O data types are baked into the built graph independently of each
+        # other; a replayed graph would silently reinterpret a buffer as the
+        # first caller's dtype (mirrors _sdpa_decode_key_fn).
         q.dtype,
+        k_cache.dtype,
+        v_cache.dtype,
         k_cache.dim(),
         max_token_seq_q,
         max_sequence_kv,
@@ -169,15 +249,61 @@ def _sdpa_prefill_key_fn(
         d_qk,
         h_kv,
         d_vo,
-        block_tables is not None,
+        # Buffer layouts are baked into the graph tensors: q/k/v strides
+        # always, and the full cache shapes when paged (4-D caches use
+        # dim=cache.shape verbatim). 3-D packed caches are dimensioned by
+        # graph_b/max_sequence_kv instead, so their varying token counts must
+        # stay out of the key.
+        tuple(q.stride()),
+        tuple(k_cache.stride()),
+        tuple(v_cache.stride()),
+        tuple(k_cache.shape) if k_cache.dim() == 4 else None,
+        tuple(v_cache.shape) if v_cache.dim() == 4 else None,
+        # The block table's dims/strides/dtype are baked via tensor_like: a
+        # same-batch table with a different pages-per-seq width must not share
+        # a graph (the replay would walk rows with the stale row stride).
+        tuple(block_tables.shape) if block_tables is not None else None,
+        block_tables.dtype if block_tables is not None else None,
         return_lse,
         bottom_right_causal_mask,
         page_size,
+        # Presence of the seq-len tensors changes the padding-mask wiring and
+        # presence of each batch_offsets_* adds a ragged-offset input; missing
+        # UIDs raise at execute, but extra ones are silently dropped (e.g. a
+        # dense-Stats graph replayed for a ragged-stats call would write the
+        # LSE dense), so every presence flag must key the cache.
+        actual_seq_lens_q is not None,
+        actual_seq_lens_kv is not None,
         cu_seq_lens_q is not None,
+        cu_seq_lens_kv is not None,
+        batch_offsets_q is not None,
+        batch_offsets_o is not None,
+        batch_offsets_k is not None,
+        batch_offsets_v is not None,
+        batch_offsets_stats is not None,
+        # Integer aux tensors are bound via tensor_like, which bakes their
+        # dtypes (an int64 buffer bound to a graph built for int32 would be
+        # silently read as int32).
+        actual_seq_lens_q.dtype if actual_seq_lens_q is not None else None,
+        actual_seq_lens_kv.dtype if actual_seq_lens_kv is not None else None,
+        cu_seq_lens_q.dtype if cu_seq_lens_q is not None else None,
+        cu_seq_lens_kv.dtype if cu_seq_lens_kv is not None else None,
+        batch_offsets_q.dtype if batch_offsets_q is not None else None,
+        batch_offsets_o.dtype if batch_offsets_o is not None else None,
+        batch_offsets_k.dtype if batch_offsets_k is not None else None,
+        batch_offsets_v.dtype if batch_offsets_v is not None else None,
+        batch_offsets_stats.dtype if batch_offsets_stats is not None else None,
         # attn_scale is baked into the built graph as a compile-time constant
         # (see _build_prefill_graph); omitting it here silently replays a
         # stale-scale graph for any same-shape call with a different scale.
         scale,
+        # o_data_type is baked into the built graph via set_data_type on O,
+        # and return_amax_s/return_amax_o change which amax tensors are graph
+        # outputs; all three must key the cache or a same-shape call would
+        # replay a structurally different graph.
+        o_data_type if o_data_type is not None else q.dtype,
+        return_amax_s,
+        return_amax_o,
     )
     return key
 
@@ -209,6 +335,8 @@ if CUDNN_AVAILABLE:
         out: Optional[torch.Tensor] = None,
         lse: Optional[torch.Tensor] = None,
         o_data_type: Optional[torch.dtype] = None,
+        return_amax_s: bool = False,
+        return_amax_o: bool = False,
     ):
         handle = _create_cudnn_handle(torch.cuda.current_stream(q.device))
 
@@ -554,10 +682,10 @@ if CUDNN_AVAILABLE:
                     ),
                 )
 
-                amax_s.set_uid(UIDs.S_AMAX_UID.value).set_output(False).set_dim(
+                amax_s.set_uid(UIDs.S_AMAX_UID.value).set_output(return_amax_s).set_dim(
                     (1, 1, 1, 1)
                 ).set_stride((1, 1, 1, 1)).set_data_type(cudnn.data_type.FLOAT)
-                amax_o.set_uid(UIDs.O_AMAX_UID.value).set_output(False).set_dim(
+                amax_o.set_uid(UIDs.O_AMAX_UID.value).set_output(return_amax_o).set_dim(
                     (1, 1, 1, 1)
                 ).set_stride((1, 1, 1, 1)).set_data_type(cudnn.data_type.FLOAT)
 
@@ -629,6 +757,9 @@ def _batch_prefill_with_kv_cache(
     q_scale: Optional[torch.Tensor] = None,
     k_scale: Optional[torch.Tensor] = None,
     v_scale: Optional[torch.Tensor] = None,
+    o_scale: Optional[torch.Tensor] = None,
+    amax_s: Optional[torch.Tensor] = None,
+    amax_o: Optional[torch.Tensor] = None,
     batch_offsets_q: Optional[torch.Tensor] = None,
     batch_offsets_o: Optional[torch.Tensor] = None,
     batch_offsets_k: Optional[torch.Tensor] = None,
@@ -638,6 +769,9 @@ def _batch_prefill_with_kv_cache(
     lse: Optional[torch.Tensor] = None,
     o_data_type: Optional[torch.dtype] = None,
 ) -> tuple[torch.Tensor, torch.Tensor]:
+    # fp8 argument validation lives in cudnn_batch_prefill_with_kv_cache (this
+    # function's only caller); validating here again would emit the o_scale
+    # UserWarning twice per call.
     graph, tensors = _build_prefill_graph(
         q=q,
         k_cache=k_cache,
@@ -660,6 +794,8 @@ def _batch_prefill_with_kv_cache(
         out=out,
         lse=lse,
         o_data_type=o_data_type,
+        return_amax_s=amax_s is not None,
+        return_amax_o=amax_o is not None,
     )
 
     var_map = {
@@ -700,16 +836,31 @@ def _batch_prefill_with_kv_cache(
         if batch_offsets_stats is not None:
             var_map[UIDs.RAGGED_STATS_UID.value] = batch_offsets_stats
 
-    if q_scale is not None:
+    # fp8 graphs contain all six scale tensors unconditionally (built from
+    # q.dtype in _build_prefill_graph), so binding is keyed on the dtype, not
+    # on which scales the caller passed: user tensors when given, the dummy
+    # 1.0 otherwise. The amax UIDs are graph outputs only when requested
+    # (return_amax_s/return_amax_o above).
+    if q.dtype in _FP8_DTYPES:
         dummy_scale_tensor = _get_dummy_scale_tensor(q.device)
-        var_map[UIDs.Q_SCALE_UID.value] = q_scale
+        var_map[UIDs.Q_SCALE_UID.value] = (
+            q_scale if q_scale is not None else dummy_scale_tensor
+        )
+        var_map[UIDs.K_SCALE_UID.value] = (
+            k_scale if k_scale is not None else dummy_scale_tensor
+        )
+        var_map[UIDs.V_SCALE_UID.value] = (
+            v_scale if v_scale is not None else dummy_scale_tensor
+        )
         var_map[UIDs.S_SCALE_UID.value] = dummy_scale_tensor
         var_map[UIDs.S_DESCALE_UID.value] = dummy_scale_tensor
-        var_map[UIDs.O_SCALE_UID.value] = dummy_scale_tensor
-    if k_scale is not None:
-        var_map[UIDs.K_SCALE_UID.value] = k_scale
-    if v_scale is not None:
-        var_map[UIDs.V_SCALE_UID.value] = v_scale
+        var_map[UIDs.O_SCALE_UID.value] = (
+            o_scale if o_scale is not None else dummy_scale_tensor
+        )
+        if amax_s is not None:
+            var_map[UIDs.S_AMAX_UID.value] = amax_s
+        if amax_o is not None:
+            var_map[UIDs.O_AMAX_UID.value] = amax_o
 
     handle = _create_cudnn_handle(torch.cuda.current_stream(q.device))
     graph.execute(var_map, workspace=workspace_buffer, handle=handle)
@@ -738,6 +889,9 @@ def cudnn_batch_prefill_with_kv_cache(
     q_scale: Optional[torch.Tensor] = None,
     k_scale: Optional[torch.Tensor] = None,
     v_scale: Optional[torch.Tensor] = None,
+    o_scale: Optional[torch.Tensor] = None,
+    amax_s: Optional[torch.Tensor] = None,
+    amax_o: Optional[torch.Tensor] = None,
     batch_offsets_q: Optional[torch.Tensor] = None,
     batch_offsets_o: Optional[torch.Tensor] = None,
     batch_offsets_k: Optional[torch.Tensor] = None,
@@ -797,10 +951,31 @@ def cudnn_batch_prefill_with_kv_cache(
         cubin backend).
     q_scale : Optional[torch.Tensor]
         FP8 dequantization scale for the query, shape ``(1, 1, 1, 1)`` on GPU.
+        Ignored (with a warning) for a non-fp8 ``q``.
     k_scale : Optional[torch.Tensor]
         FP8 dequantization scale for the key, shape ``(1, 1, 1, 1)`` on GPU.
+        Ignored (with a warning) for a non-fp8 ``q``.
     v_scale : Optional[torch.Tensor]
         FP8 dequantization scale for the value, shape ``(1, 1, 1, 1)`` on GPU.
+        Ignored (with a warning) for a non-fp8 ``q``.
+    o_scale : Optional[torch.Tensor]
+        FP8 quantization scale for the output, shape ``(1, 1, 1, 1)``, fp32,
+        on GPU.  Multiplied into the output before conversion to an fp8
+        ``o_data_type``; defaults to 1.0 (unit scale, which saturates e4m3 at
+        448).  Only valid with an fp8 ``q`` on the cuDNN graph backend (the
+        cubin fallback raises ``NotImplementedError``).
+    amax_s : Optional[torch.Tensor]
+        Optional pre-allocated fp32 output buffer, shape ``(1, 1, 1, 1)`` on
+        GPU, written in place with the absolute maximum of the post-softmax
+        matrix (for delayed-scaling recipes).  Only valid with an fp8 ``q`` on
+        the cuDNN graph backend (the cubin fallback raises
+        ``NotImplementedError``).
+    amax_o : Optional[torch.Tensor]
+        Optional pre-allocated fp32 output buffer, shape ``(1, 1, 1, 1)`` on
+        GPU, written in place with the absolute maximum of the output before
+        ``o_scale`` quantization (for delayed-scaling recipes).  Only valid
+        with an fp8 ``q`` on the cuDNN graph backend (the cubin fallback
+        raises ``NotImplementedError``).
     batch_offsets_q : Optional[torch.Tensor]
         Cumulative per-request start offsets into the packed query tensor,
         shape ``(batch_size + 1,)``, int32, on GPU, in the units given by
@@ -840,8 +1015,9 @@ def cudnn_batch_prefill_with_kv_cache(
         otherwise FlashInfer scales them to element units internally.
     out : Optional[torch.Tensor]
         Pre-allocated output tensor, shape
-        ``(total_qo_tokens, num_heads_qo, head_dim_vo)``.  Allocated internally
-        when ``None``.
+        ``(total_qo_tokens, num_heads_qo, head_dim_vo)`` with dtype
+        ``o_data_type`` (``q.dtype`` when ``o_data_type`` is ``None``).
+        Allocated internally when ``None``.
     lse : Optional[torch.Tensor]
         Pre-allocated LSE tensor, shape
         ``(batch_size, max_token_per_sequence, num_heads_qo)``.  Allocated
@@ -852,7 +1028,9 @@ def cudnn_batch_prefill_with_kv_cache(
         Optional cuDNN backend selector (e.g. ``"cubin"``).  When ``None``,
         autodetects based on cuDNN availability.
     o_data_type : Optional[torch.dtype]
-        Optional output dtype; defaults to ``q.dtype``.
+        Optional output dtype; defaults to ``q.dtype``.  An fp8 output dtype
+        is only valid with an fp8 ``q`` (non-fp8 graphs cannot quantize their
+        output).
 
     Returns
     -------
@@ -876,6 +1054,17 @@ def cudnn_batch_prefill_with_kv_cache(
         raise ValueError(
             f"batch_offsets_units must be 'elements' or 'tokens', got {batch_offsets_units!r}"
         )
+
+    _check_fp8_scale_args(
+        q.dtype,
+        o_data_type if o_data_type is not None else q.dtype,
+        q_scale,
+        k_scale,
+        v_scale,
+        o_scale,
+        amax_s,
+        amax_o,
+    )
 
     # actual_seq_lens_q/kv may be omitted only when they are derivable from
     # token-unit indptrs (the direct path consumes the indptrs as-is; the
@@ -928,6 +1117,14 @@ def cudnn_batch_prefill_with_kv_cache(
     if out is None:
         out_shape = (num_tokens, h_qo, d_vo)
         out = torch.empty(out_shape, device=q.device, dtype=o_data_type)
+    elif out.dtype != o_data_type:
+        # The graph declares O with o_data_type and execute binds a raw
+        # pointer, so a mismatched buffer would be filled with reinterpreted
+        # bytes without any error.
+        raise ValueError(
+            f"out.dtype ({out.dtype}) must match o_data_type ({o_data_type}); "
+            "the graph writes the output in o_data_type"
+        )
 
     if batch_offsets_units == "tokens":
         # Convenience feature to allow user to set just batch_offsets_{q,k} if desired.
@@ -967,6 +1164,9 @@ def cudnn_batch_prefill_with_kv_cache(
             q_scale=q_scale,
             k_scale=k_scale,
             v_scale=v_scale,
+            o_scale=o_scale,
+            amax_s=amax_s,
+            amax_o=amax_o,
             out=out,
             lse=lse,
             o_data_type=o_data_type,
@@ -1035,6 +1235,11 @@ def cudnn_batch_prefill_with_kv_cache(
             batch_offsets_stats=batch_offsets_stats,
         )
     else:
+        if o_scale is not None or amax_s is not None or amax_o is not None:
+            raise NotImplementedError(
+                "o_scale/amax_s/amax_o require the cuDNN graph backend; they "
+                "are not supported by the fallback cubin prefill path"
+            )
         if actual_seq_lens_q is None or actual_seq_lens_kv is None:
             raise ValueError(
                 "the cubin backend requires actual_seq_lens_q and actual_seq_lens_kv"

--- a/flashinfer/cudnn/prefill.py
+++ b/flashinfer/cudnn/prefill.py
@@ -80,14 +80,13 @@ def _check_fp8_scale_args(
     k_scale: Optional[torch.Tensor],
     v_scale: Optional[torch.Tensor],
     o_scale: Optional[torch.Tensor],
-    amax_s: Optional[torch.Tensor],
     amax_o: Optional[torch.Tensor],
 ) -> None:
     """Validate the fp8-only scale/amax arguments against the query dtype.
 
     With a non-fp8 query, raises ValueError for an fp8 ``o_data_type`` (a
     non-fp8 graph cannot quantize its output: it produces NaN garbage) and for
-    the fp8-output-only arguments ``o_scale``/``amax_s``/``amax_o``.  The
+    the fp8-output-only arguments ``o_scale``/``amax_o``.  The
     long-standing ``q_scale``/``k_scale``/``v_scale`` arguments only warn:
     they were always silently ignored on non-fp8 graphs and callers pass them
     unconditionally.  With an fp8 query, warns when an fp8 output is requested
@@ -105,7 +104,6 @@ def _check_fp8_scale_args(
             name
             for name, t in (
                 ("o_scale", o_scale),
-                ("amax_s", amax_s),
                 ("amax_o", amax_o),
             )
             if t is not None
@@ -207,7 +205,6 @@ def _sdpa_prefill_key_fn(
     out: Optional[torch.Tensor] = None,
     lse: Optional[torch.Tensor] = None,
     o_data_type: Optional[torch.dtype] = None,
-    return_amax_s: bool = False,
     return_amax_o: bool = False,
 ):
     if actual_seq_lens_q is not None:
@@ -298,11 +295,10 @@ def _sdpa_prefill_key_fn(
         # stale-scale graph for any same-shape call with a different scale.
         scale,
         # o_data_type is baked into the built graph via set_data_type on O,
-        # and return_amax_s/return_amax_o change which amax tensors are graph
-        # outputs; all three must key the cache or a same-shape call would
+        # and return_amax_o changes whether the amax tensor is a graph
+        # output; both must key the cache or a same-shape call would
         # replay a structurally different graph.
         o_data_type if o_data_type is not None else q.dtype,
-        return_amax_s,
         return_amax_o,
     )
     return key
@@ -335,7 +331,6 @@ if CUDNN_AVAILABLE:
         out: Optional[torch.Tensor] = None,
         lse: Optional[torch.Tensor] = None,
         o_data_type: Optional[torch.dtype] = None,
-        return_amax_s: bool = False,
         return_amax_o: bool = False,
     ):
         handle = _create_cudnn_handle(torch.cuda.current_stream(q.device))
@@ -682,7 +677,7 @@ if CUDNN_AVAILABLE:
                     ),
                 )
 
-                amax_s.set_uid(UIDs.S_AMAX_UID.value).set_output(return_amax_s).set_dim(
+                amax_s.set_uid(UIDs.S_AMAX_UID.value).set_output(False).set_dim(
                     (1, 1, 1, 1)
                 ).set_stride((1, 1, 1, 1)).set_data_type(cudnn.data_type.FLOAT)
                 amax_o.set_uid(UIDs.O_AMAX_UID.value).set_output(return_amax_o).set_dim(
@@ -758,7 +753,6 @@ def _batch_prefill_with_kv_cache(
     k_scale: Optional[torch.Tensor] = None,
     v_scale: Optional[torch.Tensor] = None,
     o_scale: Optional[torch.Tensor] = None,
-    amax_s: Optional[torch.Tensor] = None,
     amax_o: Optional[torch.Tensor] = None,
     batch_offsets_q: Optional[torch.Tensor] = None,
     batch_offsets_o: Optional[torch.Tensor] = None,
@@ -794,7 +788,6 @@ def _batch_prefill_with_kv_cache(
         out=out,
         lse=lse,
         o_data_type=o_data_type,
-        return_amax_s=amax_s is not None,
         return_amax_o=amax_o is not None,
     )
 
@@ -839,8 +832,8 @@ def _batch_prefill_with_kv_cache(
     # fp8 graphs contain all six scale tensors unconditionally (built from
     # q.dtype in _build_prefill_graph), so binding is keyed on the dtype, not
     # on which scales the caller passed: user tensors when given, the dummy
-    # 1.0 otherwise. The amax UIDs are graph outputs only when requested
-    # (return_amax_s/return_amax_o above).
+    # 1.0 otherwise. The amax_o UID is a graph output only when requested
+    # (return_amax_o above).
     if q.dtype in _FP8_DTYPES:
         dummy_scale_tensor = _get_dummy_scale_tensor(q.device)
         var_map[UIDs.Q_SCALE_UID.value] = (
@@ -857,8 +850,6 @@ def _batch_prefill_with_kv_cache(
         var_map[UIDs.O_SCALE_UID.value] = (
             o_scale if o_scale is not None else dummy_scale_tensor
         )
-        if amax_s is not None:
-            var_map[UIDs.S_AMAX_UID.value] = amax_s
         if amax_o is not None:
             var_map[UIDs.O_AMAX_UID.value] = amax_o
 
@@ -890,7 +881,6 @@ def cudnn_batch_prefill_with_kv_cache(
     k_scale: Optional[torch.Tensor] = None,
     v_scale: Optional[torch.Tensor] = None,
     o_scale: Optional[torch.Tensor] = None,
-    amax_s: Optional[torch.Tensor] = None,
     amax_o: Optional[torch.Tensor] = None,
     batch_offsets_q: Optional[torch.Tensor] = None,
     batch_offsets_o: Optional[torch.Tensor] = None,
@@ -964,12 +954,6 @@ def cudnn_batch_prefill_with_kv_cache(
         ``o_data_type``; defaults to 1.0 (unit scale, which saturates e4m3 at
         448).  Only valid with an fp8 ``q`` on the cuDNN graph backend (the
         cubin fallback raises ``NotImplementedError``).
-    amax_s : Optional[torch.Tensor]
-        Optional pre-allocated fp32 output buffer, shape ``(1, 1, 1, 1)`` on
-        GPU, written in place with the absolute maximum of the post-softmax
-        matrix (for delayed-scaling recipes).  Only valid with an fp8 ``q`` on
-        the cuDNN graph backend (the cubin fallback raises
-        ``NotImplementedError``).
     amax_o : Optional[torch.Tensor]
         Optional pre-allocated fp32 output buffer, shape ``(1, 1, 1, 1)`` on
         GPU, written in place with the absolute maximum of the output before
@@ -1062,7 +1046,6 @@ def cudnn_batch_prefill_with_kv_cache(
         k_scale,
         v_scale,
         o_scale,
-        amax_s,
         amax_o,
     )
 
@@ -1165,7 +1148,6 @@ def cudnn_batch_prefill_with_kv_cache(
             k_scale=k_scale,
             v_scale=v_scale,
             o_scale=o_scale,
-            amax_s=amax_s,
             amax_o=amax_o,
             out=out,
             lse=lse,
@@ -1235,9 +1217,9 @@ def cudnn_batch_prefill_with_kv_cache(
             batch_offsets_stats=batch_offsets_stats,
         )
     else:
-        if o_scale is not None or amax_s is not None or amax_o is not None:
+        if o_scale is not None or amax_o is not None:
             raise NotImplementedError(
-                "o_scale/amax_s/amax_o require the cuDNN graph backend; they "
+                "o_scale/amax_o require the cuDNN graph backend; they "
                 "are not supported by the fallback cubin prefill path"
             )
         if actual_seq_lens_q is None or actual_seq_lens_kv is None:

--- a/flashinfer/prefill.py
+++ b/flashinfer/prefill.py
@@ -2645,6 +2645,7 @@ class BatchPrefillWithPagedKVCacheWrapper:
         *args,
         k_scale: Optional[float] = None,
         v_scale: Optional[float] = None,
+        o_scale: Optional[Union[float, torch.Tensor]] = None,
         out: Optional[torch.Tensor] = None,
         lse: Optional[torch.Tensor] = None,
         return_lse: Literal[False] = False,
@@ -2665,6 +2666,7 @@ class BatchPrefillWithPagedKVCacheWrapper:
         *args,
         k_scale: Optional[float] = None,
         v_scale: Optional[float] = None,
+        o_scale: Optional[Union[float, torch.Tensor]] = None,
         out: Optional[torch.Tensor] = None,
         lse: Optional[torch.Tensor] = None,
         return_lse: Literal[True] = True,
@@ -2686,6 +2688,7 @@ class BatchPrefillWithPagedKVCacheWrapper:
         q_scale: Optional[Union[float, torch.Tensor]] = None,
         k_scale: Optional[Union[float, torch.Tensor]] = None,
         v_scale: Optional[Union[float, torch.Tensor]] = None,
+        o_scale: Optional[Union[float, torch.Tensor]] = None,
         out: Optional[torch.Tensor] = None,
         lse: Optional[torch.Tensor] = None,
         return_lse: bool = False,
@@ -2725,6 +2728,15 @@ class BatchPrefillWithPagedKVCacheWrapper:
             The calibration scale of key for fp8 or nvfp4 input, if not provided, will be set to ``1.0``.
         v_scale : Optional[Union[float, torch.Tensor]]
             The calibration scale of value for fp8 or nvfp4 input, if not provided, will be set to ``1.0``.
+        o_scale : Optional[Union[float, torch.Tensor]]
+            The quantization scale of the output: the output is multiplied by
+            ``o_scale`` before conversion to an fp8 ``o_data_type`` (unit scale
+            saturates e4m3 at 448).  If not provided, will be set to ``1.0``.
+            Floats are converted internally to the ``(1, 1, 1, 1)`` fp32 GPU
+            tensor cuDNN expects; pass such a tensor directly to avoid the
+            per-call copy (e.g. under CUDA graph capture).  Only supported by
+            the cudnn backend (with an fp8 ``q``); other backends raise
+            ``NotImplementedError`` when it is set.
         out : Optional[torch.Tensor]
             The output tensor, if not provided, will be allocated internally.
         lse : Optional[torch.Tensor]
@@ -2802,6 +2814,12 @@ class BatchPrefillWithPagedKVCacheWrapper:
                     f"For paged prefill, q must have shape [total_tokens, num_heads, head_dim] "
                     f"where total_tokens = qo_indptr[-1]."
                 )
+
+        if o_scale is not None and self._backend != "cudnn":
+            raise NotImplementedError(
+                f"o_scale is only supported by the cudnn backend on the paged "
+                f"prefill path, got backend={self._backend!r}"
+            )
 
         if self._backend == "cute-dsl":
             if q_scale is not None or k_scale is not None or v_scale is not None:
@@ -2955,6 +2973,14 @@ class BatchPrefillWithPagedKVCacheWrapper:
             if self._seq_lens_kv is not None and self._seq_lens_kv.dim() == 1:
                 self._seq_lens_kv = self._seq_lens_kv.reshape(self._batch_size, 1, 1, 1)
 
+            if o_scale is not None and not isinstance(o_scale, torch.Tensor):
+                # cudnn_batch_prefill_with_kv_cache takes o_scale as a
+                # (1, 1, 1, 1) fp32 GPU tensor; floats are converted here,
+                # tensors pass through as-is.
+                o_scale = torch.tensor(
+                    o_scale, device=q.device, dtype=torch.float32
+                ).reshape(1, 1, 1, 1)
+
             cudnn_batch_prefill_with_kv_cache(
                 q,
                 k_cache,  # Need to be changed
@@ -2971,6 +2997,7 @@ class BatchPrefillWithPagedKVCacheWrapper:
                 q_scale=q_scale,
                 k_scale=k_scale,
                 v_scale=v_scale,
+                o_scale=o_scale,
                 batch_offsets_q=self._qo_indptr_buf,
                 batch_offsets_o=self._qo_indptr_buf,
                 out=out,
@@ -3972,7 +3999,7 @@ class BatchPrefillWithRaggedKVCacheWrapper:
         q_scale: Optional[float] = None,
         k_scale: Optional[float] = None,
         v_scale: Optional[float] = None,
-        o_scale: Optional[float] = None,
+        o_scale: Optional[Union[float, torch.Tensor]] = None,
         out: Optional[torch.Tensor] = None,
         lse: Optional[torch.Tensor] = None,
         return_lse: bool = False,
@@ -4000,8 +4027,17 @@ class BatchPrefillWithRaggedKVCacheWrapper:
             The calibration scale of fp8 or nvfp4 key, if not provided, will be set to ``1.0``.
         v_scale: Optional[float]
             The calibration scale of fp8 or nvfp4 value, if not provided, will be set to ``1.0``.
-        o_scale: Optional[float]
-            The calibration scale of output, if not provided, will be set to ``1.0``.
+        o_scale: Optional[Union[float, torch.Tensor]]
+            The quantization scale of the output: the output is multiplied by
+            ``o_scale`` before conversion to an fp8 output dtype (unit scale
+            saturates e4m3 at 448).  If not provided, will be set to ``1.0``.
+            Consumed by the cutlass (float only) and cudnn backends; for the
+            cudnn backend floats are converted internally to the
+            ``(1, 1, 1, 1)`` fp32 GPU tensor cuDNN expects — pass such a
+            tensor directly to avoid the per-call copy (e.g. under CUDA graph
+            capture).  The cute-dsl backend rejects it with
+            ``NotImplementedError``; the remaining backends (fa2/fa3,
+            fmha_v2) silently ignore it, so the output is emitted unscaled.
         out : Optional[torch.Tensor]
             The output tensor, if not provided, will be allocated internally.
         lse : Optional[torch.Tensor]
@@ -4244,6 +4280,14 @@ class BatchPrefillWithRaggedKVCacheWrapper:
             if self._seq_lens_kv is not None and self._seq_lens_kv.dim() == 1:
                 self._seq_lens_kv = self._seq_lens_kv.reshape(batch_size, 1, 1, 1)
 
+            if o_scale is not None and not isinstance(o_scale, torch.Tensor):
+                # cudnn_batch_prefill_with_kv_cache takes o_scale as a
+                # (1, 1, 1, 1) fp32 GPU tensor; floats are converted here,
+                # tensors pass through as-is.
+                o_scale = torch.tensor(
+                    o_scale, device=q.device, dtype=torch.float32
+                ).reshape(1, 1, 1, 1)
+
             cudnn_batch_prefill_with_kv_cache(
                 q,
                 k,
@@ -4259,6 +4303,7 @@ class BatchPrefillWithRaggedKVCacheWrapper:
                 q_scale=q_scale,
                 k_scale=k_scale,
                 v_scale=v_scale,
+                o_scale=o_scale,
                 batch_offsets_q=self._qo_indptr_buf,
                 batch_offsets_k=self._kv_indptr_buf,
                 batch_offsets_v=self._v_indptr_buf,
@@ -4266,6 +4311,11 @@ class BatchPrefillWithRaggedKVCacheWrapper:
                 is_cuda_graph_compatible=self._use_cuda_graph,
                 out=out,
                 lse=lse,
+                # The graph's O dtype must match the buffer actually bound
+                # (out is always allocated/validated above); without this an
+                # fp8 q with a non-fp8 out would build an fp8-O graph around
+                # a wider buffer.
+                o_data_type=out.dtype,
             )
 
             return (out, lse) if return_lse else out

--- a/tests/attention/test_cudnn_prefill.py
+++ b/tests/attention/test_cudnn_prefill.py
@@ -523,7 +523,7 @@ def _make_fp8_prefill_inputs(
 @pytest.mark.parametrize("causal", [False, True])
 @pytest.mark.parametrize("paged", [True, False])
 def test_cudnn_prefill_fp8_output_scaling(o_scale_value, causal, paged):
-    """FP8 output path: o_scale quantizes O and amax_s/amax_o are written."""
+    """FP8 output path: o_scale quantizes O and amax_o is written."""
     device = "cuda:0"
     _skip_unless_fp8_prefill_supported(device)
 
@@ -548,14 +548,12 @@ def test_cudnn_prefill_fp8_output_scaling(o_scale_value, causal, paged):
     o_scale = torch.tensor(o_scale_value, device=device, dtype=torch.float32).reshape(
         1, 1, 1, 1
     )
-    amax_s = torch.full((1, 1, 1, 1), -1.0, device=device, dtype=torch.float32)
     amax_o = torch.full((1, 1, 1, 1), -1.0, device=device, dtype=torch.float32)
     out_fp8, _ = cudnn_batch_prefill_with_kv_cache(
         **run_kwargs,
         causal=causal,
         o_data_type=torch.float8_e4m3fn,
         o_scale=o_scale,
-        amax_s=amax_s,
         amax_o=amax_o,
     )
     assert out_fp8.dtype == torch.float8_e4m3fn
@@ -576,8 +574,6 @@ def test_cudnn_prefill_fp8_output_scaling(o_scale_value, causal, paged):
         atol=1e-3,
         rtol=5e-2,
     )
-    # amax_s is the absolute maximum of the post-softmax matrix, in (0, 1].
-    assert 0.0 < amax_s.item() <= 1.0 + 1e-3
 
 
 def test_cudnn_prefill_fp8_output_scale_prevents_saturation():
@@ -644,7 +640,7 @@ def test_cudnn_prefill_fp8_output_scale_prevents_saturation():
 def test_cudnn_prefill_fp8_args_rejected_on_non_fp8():
     """fp8-output arguments raise for non-fp8 q; q/k/v_scale only warn.
 
-    ``o_scale``/``amax_s``/``amax_o`` (and an fp8 ``o_data_type``) are new and
+    ``o_scale``/``amax_o`` (and an fp8 ``o_data_type``) are new and
     meaningless on a non-fp8 graph, so they hard-fail.  The long-standing
     ``q_scale``/``k_scale``/``v_scale`` arguments were always silently ignored
     on non-fp8 graphs and callers pass them unconditionally, so they must keep
@@ -672,7 +668,7 @@ def test_cudnn_prefill_fp8_args_rejected_on_non_fp8():
         return_lse=False,
     )
 
-    for name in ("o_scale", "amax_s", "amax_o"):
+    for name in ("o_scale", "amax_o"):
         with pytest.raises(ValueError, match="fp8 query dtype"):
             cudnn_batch_prefill_with_kv_cache(
                 q, k_cache, v_cache, **run_kwargs, **{name: scale_tensor}
@@ -790,7 +786,7 @@ def test_sdpa_prefill_key_fn_discriminates_baked_attributes():
 
 
 def test_cudnn_prefill_fp8_out_args_require_graph_backend():
-    """The cubin fallback cannot honor o_scale/amax_s/amax_o: it must raise
+    """The cubin fallback cannot honor o_scale/amax_o: it must raise
     NotImplementedError instead of silently ignoring them."""
     device = "cuda:0"
     s = 8

--- a/tests/attention/test_cudnn_prefill.py
+++ b/tests/attention/test_cudnn_prefill.py
@@ -1,9 +1,12 @@
+import warnings
+
 import pytest
 import torch
 
 import flashinfer
 import cudnn
 
+from flashinfer.cudnn import cudnn_batch_prefill_with_kv_cache
 from flashinfer.utils import get_compute_capability
 
 
@@ -223,10 +226,10 @@ def test_cudnn_prefill_fp8(
             f"cuDNN FP8 prefill is not supported on compute capability {major}, skipping test"
         )
 
-    # TODO: Remove this xfail once cuDNN fixes FP8 prefill on Blackwell
-    pytest.xfail(
-        "cuDNN FP8 prefill has known issues on Blackwell; expected to be fixed in a subsequent cuDNN release"
-    )
+    if cudnn.backend_version() < 92600:
+        pytest.xfail(
+            "cuDNN FP8 prefill has known issues on Blackwell before cuDNN 9.26"
+        )
 
     actual_seq_lens_q = torch.randint(
         1, s_qo + 1, (batch_size, 1, 1, 1), dtype=torch.int32, device=device
@@ -395,3 +398,427 @@ def test_cudnn_prefill_fp8(
     output_ref = wrapper.run(q, kv_cache)
 
     torch.testing.assert_close(output, output_ref, atol=1e-2, rtol=1e-2)
+
+
+def _skip_unless_fp8_prefill_supported(device):
+    if cudnn.backend_version() < 92600:
+        pytest.skip("cuDNN FP8 prefill needs backend 9.26+, skipping test")
+    major, _ = get_compute_capability(torch.device(device))
+    if major != 10:
+        pytest.skip(
+            f"cuDNN FP8 prefill is not supported on compute capability {major}, skipping test"
+        )
+
+
+def _make_fp8_prefill_inputs(
+    batch_size,
+    s_qo,
+    s_kv,
+    page_size,
+    num_kv_heads,
+    num_qo_heads,
+    head_dim,
+    device,
+    paged=True,
+):
+    """Random fp8 e4m3 prefill inputs for direct cudnn_batch_prefill_with_kv_cache calls.
+
+    Returns a kwargs dict (fp8 q / fp8 kv caches, descales, seq lens,
+    element-unit batch offsets, workspace) missing only causal / o_data_type /
+    o_scale / amax_* arguments.  ``paged=True`` builds a 4-D paged KV cache
+    with block tables (``page_size`` pages); ``paged=False`` builds packed 3-D
+    KV caches addressed via element-unit batch_offsets_k/v.
+    """
+    actual_seq_lens_q = torch.randint(
+        1, s_qo + 1, (batch_size, 1, 1, 1), dtype=torch.int32, device=device
+    )
+    actual_seq_lens_kv = torch.randint(
+        s_qo, s_kv + 1, (batch_size, 1, 1, 1), dtype=torch.int32, device=device
+    )
+
+    cumsum_s_qo = torch.sum(actual_seq_lens_q)
+    q = torch.randn(
+        cumsum_s_qo, num_qo_heads, head_dim, device=device, dtype=torch.bfloat16
+    )
+    q_scale = torch.tensor(
+        q.float().abs().amax().item() / 256, device=device, dtype=torch.float32
+    ).reshape(1, 1, 1, 1)
+    q_fp8 = (q.float() / q_scale.item()).to(torch.float8_e4m3fn)
+
+    if paged:
+        num_pages_per_seq = (s_kv + page_size - 1) // page_size
+        total_num_pages = num_pages_per_seq * batch_size
+        k_cache = torch.randn(
+            total_num_pages,
+            num_kv_heads,
+            page_size,
+            head_dim,
+            device=device,
+            dtype=torch.float32,
+        )
+    else:
+        total_kv_tokens = int(torch.sum(actual_seq_lens_kv))
+        k_cache = torch.randn(
+            total_kv_tokens, num_kv_heads, head_dim, device=device, dtype=torch.float32
+        )
+    v_cache = torch.randn_like(k_cache)
+    k_scale = (k_cache.abs().amax() / 256).reshape(1, 1, 1, 1)
+    v_scale = (v_cache.abs().amax() / 256).reshape(1, 1, 1, 1)
+    # .item() rather than tensor division: broadcasting against the
+    # (1, 1, 1, 1) scale would silently promote a 3-D non-paged cache to 4-D.
+    k_cache_fp8 = (k_cache / k_scale.item()).to(torch.float8_e4m3fn)
+    v_cache_fp8 = (v_cache / v_scale.item()).to(torch.float8_e4m3fn)
+
+    batch_offsets_q = (
+        torch.cat(
+            [
+                torch.zeros(1, dtype=torch.int64, device=device),
+                torch.cumsum(actual_seq_lens_q.view(-1), dim=0),
+            ]
+        )
+        * num_qo_heads
+        * head_dim
+    ).int()
+
+    workspace_buffer = torch.empty(128 * 1024 * 1024, dtype=torch.int8, device=device)
+
+    run_kwargs = dict(
+        q=q_fp8,
+        k_cache=k_cache_fp8,
+        v_cache=v_cache_fp8,
+        scale=float(1.0 / (head_dim**0.5)),
+        workspace_buffer=workspace_buffer,
+        max_token_per_sequence=s_qo,
+        max_sequence_kv=s_kv,
+        actual_seq_lens_q=actual_seq_lens_q,
+        actual_seq_lens_kv=actual_seq_lens_kv,
+        return_lse=False,
+        q_scale=q_scale,
+        k_scale=k_scale,
+        v_scale=v_scale,
+        batch_offsets_q=batch_offsets_q,
+        batch_offsets_o=batch_offsets_q,
+    )
+    if paged:
+        run_kwargs["block_tables"] = torch.arange(
+            total_num_pages, dtype=torch.int32, device=device
+        ).reshape(batch_size, num_pages_per_seq)
+    else:
+        batch_offsets_kv = (
+            torch.cat(
+                [
+                    torch.zeros(1, dtype=torch.int64, device=device),
+                    torch.cumsum(actual_seq_lens_kv.view(-1), dim=0),
+                ]
+            )
+            * num_kv_heads
+            * head_dim
+        ).int()
+        run_kwargs["batch_offsets_k"] = batch_offsets_kv
+        run_kwargs["batch_offsets_v"] = batch_offsets_kv
+    return run_kwargs
+
+
+@pytest.mark.parametrize("o_scale_value", [4.0, 1.0 / 16.0])
+@pytest.mark.parametrize("causal", [False, True])
+@pytest.mark.parametrize("paged", [True, False])
+def test_cudnn_prefill_fp8_output_scaling(o_scale_value, causal, paged):
+    """FP8 output path: o_scale quantizes O and amax_s/amax_o are written."""
+    device = "cuda:0"
+    _skip_unless_fp8_prefill_supported(device)
+
+    torch.manual_seed(2)
+    run_kwargs = _make_fp8_prefill_inputs(
+        batch_size=4,
+        s_qo=32,
+        s_kv=64,
+        page_size=16,
+        num_kv_heads=4,
+        num_qo_heads=4,
+        head_dim=128,
+        device=device,
+        paged=paged,
+    )
+
+    # Reference: identical fp8 compute, bf16 output (no output quantization).
+    out_ref, _ = cudnn_batch_prefill_with_kv_cache(
+        **run_kwargs, causal=causal, o_data_type=torch.bfloat16
+    )
+
+    o_scale = torch.tensor(o_scale_value, device=device, dtype=torch.float32).reshape(
+        1, 1, 1, 1
+    )
+    amax_s = torch.full((1, 1, 1, 1), -1.0, device=device, dtype=torch.float32)
+    amax_o = torch.full((1, 1, 1, 1), -1.0, device=device, dtype=torch.float32)
+    out_fp8, _ = cudnn_batch_prefill_with_kv_cache(
+        **run_kwargs,
+        causal=causal,
+        o_data_type=torch.float8_e4m3fn,
+        o_scale=o_scale,
+        amax_s=amax_s,
+        amax_o=amax_o,
+    )
+    assert out_fp8.dtype == torch.float8_e4m3fn
+
+    # Dequantized output must match the pre-quantization reference; the atol
+    # floor covers e4m3's subnormal grid (2^-9) mapped back through o_scale.
+    torch.testing.assert_close(
+        out_fp8.float() / o_scale_value,
+        out_ref.float(),
+        atol=2**-9 / o_scale_value + 5e-3,
+        rtol=1e-1,
+    )
+
+    # amax_o is the absolute maximum of O before o_scale quantization.
+    torch.testing.assert_close(
+        amax_o.reshape(()),
+        out_ref.float().abs().amax(),
+        atol=1e-3,
+        rtol=5e-2,
+    )
+    # amax_s is the absolute maximum of the post-softmax matrix, in (0, 1].
+    assert 0.0 < amax_s.item() <= 1.0 + 1e-3
+
+
+def test_cudnn_prefill_fp8_output_scale_prevents_saturation():
+    """o_scale < 1 keeps an O that overflows e4m3 (|O| > 448) representable."""
+    device = "cuda:0"
+    _skip_unless_fp8_prefill_supported(device)
+
+    torch.manual_seed(3)
+    run_kwargs = _make_fp8_prefill_inputs(
+        batch_size=2,
+        s_qo=8,
+        s_kv=16,
+        page_size=8,
+        num_kv_heads=1,
+        num_qo_heads=4,
+        head_dim=128,
+        device=device,
+    )
+    # Constant V = 512 makes every pre-quantization output element 512
+    # (softmax weights sum to 1), which exceeds the e4m3 maximum of 448.
+    # 512 / v_scale = 256, exactly representable in e4m3.
+    run_kwargs["v_cache"] = torch.full_like(
+        run_kwargs["v_cache"], 256.0, dtype=torch.float32
+    ).to(torch.float8_e4m3fn)
+    run_kwargs["v_scale"] = torch.tensor(
+        2.0, device=device, dtype=torch.float32
+    ).reshape(1, 1, 1, 1)
+
+    # Without o_scale the fp8 output is emitted unit-scaled (with a warning)
+    # and saturates at the e4m3 maximum: the customer bug.
+    with pytest.warns(UserWarning, match="o_scale"):
+        out_sat, _ = cudnn_batch_prefill_with_kv_cache(
+            **run_kwargs, causal=False, o_data_type=torch.float8_e4m3fn
+        )
+    sat_amax = out_sat.float().abs().amax().item()
+    assert 447.0 <= sat_amax <= 448.0, (
+        f"unit-scaled fp8 output should saturate at the e4m3 max, got {sat_amax}"
+    )
+
+    # With o_scale = 1/16 the stored values are 512/16 = 32 and dequantization
+    # recovers magnitudes beyond the e4m3 maximum.
+    o_scale_value = 1.0 / 16.0
+    o_scale = torch.tensor(o_scale_value, device=device, dtype=torch.float32).reshape(
+        1, 1, 1, 1
+    )
+    amax_o = torch.full((1, 1, 1, 1), -1.0, device=device, dtype=torch.float32)
+    out_scaled, _ = cudnn_batch_prefill_with_kv_cache(
+        **run_kwargs,
+        causal=False,
+        o_data_type=torch.float8_e4m3fn,
+        o_scale=o_scale,
+        amax_o=amax_o,
+    )
+    dequant = out_scaled.float() / o_scale_value
+    assert dequant.abs().amax().item() > 448.0
+    torch.testing.assert_close(
+        dequant, torch.full_like(dequant, 512.0), atol=0.0, rtol=5e-2
+    )
+    torch.testing.assert_close(
+        amax_o.reshape(()), torch.tensor(512.0, device=device), atol=0.0, rtol=5e-2
+    )
+
+
+def test_cudnn_prefill_fp8_args_rejected_on_non_fp8():
+    """fp8-output arguments raise for non-fp8 q; q/k/v_scale only warn.
+
+    ``o_scale``/``amax_s``/``amax_o`` (and an fp8 ``o_data_type``) are new and
+    meaningless on a non-fp8 graph, so they hard-fail.  The long-standing
+    ``q_scale``/``k_scale``/``v_scale`` arguments were always silently ignored
+    on non-fp8 graphs and callers pass them unconditionally, so they must keep
+    working (with a warning), not raise.
+    """
+    device = "cuda:0"
+    s = 8
+    num_heads = 4
+    head_dim = 128
+    q = torch.randn(s, num_heads, head_dim, device=device, dtype=torch.bfloat16)
+    k_cache = torch.randn_like(q)
+    v_cache = torch.randn_like(q)
+    seq_lens = torch.full((1, 1, 1, 1), s, dtype=torch.int32, device=device)
+    workspace_buffer = torch.empty(128 * 1024 * 1024, dtype=torch.int8, device=device)
+    scale_tensor = torch.ones(1, 1, 1, 1, device=device, dtype=torch.float32)
+
+    run_kwargs = dict(
+        scale=float(1.0 / (head_dim**0.5)),
+        workspace_buffer=workspace_buffer,
+        max_token_per_sequence=s,
+        max_sequence_kv=s,
+        actual_seq_lens_q=seq_lens,
+        actual_seq_lens_kv=seq_lens,
+        causal=False,
+        return_lse=False,
+    )
+
+    for name in ("o_scale", "amax_s", "amax_o"):
+        with pytest.raises(ValueError, match="fp8 query dtype"):
+            cudnn_batch_prefill_with_kv_cache(
+                q, k_cache, v_cache, **run_kwargs, **{name: scale_tensor}
+            )
+
+    with pytest.raises(ValueError, match="fp8 query dtype"):
+        cudnn_batch_prefill_with_kv_cache(
+            q, k_cache, v_cache, **run_kwargs, o_data_type=torch.float8_e4m3fn
+        )
+
+    with pytest.warns(UserWarning, match="ignored"):
+        out, _ = cudnn_batch_prefill_with_kv_cache(
+            q,
+            k_cache,
+            v_cache,
+            **run_kwargs,
+            q_scale=scale_tensor,
+            k_scale=scale_tensor,
+            v_scale=scale_tensor,
+        )
+    assert out.dtype == torch.bfloat16
+
+
+def test_cudnn_prefill_fp8_missing_o_scale_warns_once():
+    """The o_scale-missing warning fires exactly once per public call.
+
+    The fp8 argument validation lives only in the public entry point; a
+    second call site in _batch_prefill_with_kv_cache would emit the warning
+    twice per call (the two frames defeat warnings' per-location dedup).
+    """
+    device = "cuda:0"
+    _skip_unless_fp8_prefill_supported(device)
+
+    torch.manual_seed(4)
+    run_kwargs = _make_fp8_prefill_inputs(
+        batch_size=2,
+        s_qo=8,
+        s_kv=16,
+        page_size=8,
+        num_kv_heads=1,
+        num_qo_heads=4,
+        head_dim=128,
+        device=device,
+    )
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        cudnn_batch_prefill_with_kv_cache(
+            **run_kwargs, causal=False, o_data_type=torch.float8_e4m3fn
+        )
+    o_scale_warnings = [w for w in caught if "o_scale" in str(w.message)]
+    assert len(o_scale_warnings) == 1, o_scale_warnings
+
+
+def test_sdpa_prefill_key_fn_discriminates_baked_attributes():
+    """Attributes _build_prefill_graph bakes into a graph must key the cache.
+
+    Uses meta tensors: the key fn is pure Python, so this needs no GPU and
+    pins the graph-cache collisions (KV dtype, v_cache-derived d_vo, block
+    table width, ragged-offset presence, aux int dtypes, strides) that would
+    silently replay a structurally different graph.
+    """
+    from flashinfer.cudnn.prefill import _sdpa_prefill_key_fn
+
+    b, h, s_q, s_kv, d = 4, 8, 32, 64, 128
+    page_size = 16
+    pages_per_seq = s_kv // page_size
+    num_pages = b * pages_per_seq
+
+    def meta(*shape, dtype=torch.bfloat16):
+        return torch.empty(*shape, device="meta", dtype=dtype)
+
+    def make_kwargs(**overrides):
+        kwargs = dict(
+            q=meta(b * s_q, h, d),
+            k_cache=meta(num_pages, h, page_size, d),
+            v_cache=meta(num_pages, h, page_size, d),
+            scale=1.0 / (d**0.5),
+            max_token_seq_q=s_q,
+            max_sequence_kv=s_kv,
+            actual_seq_lens_q=meta(b, 1, 1, 1, dtype=torch.int32),
+            actual_seq_lens_kv=meta(b, 1, 1, 1, dtype=torch.int32),
+            block_tables=meta(b, pages_per_seq, dtype=torch.int32),
+        )
+        kwargs.update(overrides)
+        return kwargs
+
+    base = _sdpa_prefill_key_fn(**make_kwargs())
+    assert base == _sdpa_prefill_key_fn(**make_kwargs())
+
+    variants = {
+        "kv dtype": make_kwargs(
+            k_cache=meta(num_pages, h, page_size, d, dtype=torch.float16),
+            v_cache=meta(num_pages, h, page_size, d, dtype=torch.float16),
+        ),
+        "v_cache d_vo": make_kwargs(v_cache=meta(num_pages, h, page_size, d // 2)),
+        "block table width": make_kwargs(
+            block_tables=meta(b, 2 * pages_per_seq, dtype=torch.int32)
+        ),
+        "seq-lens dtype": make_kwargs(
+            actual_seq_lens_kv=meta(b, 1, 1, 1, dtype=torch.int64)
+        ),
+        "ragged offsets": make_kwargs(
+            batch_offsets_q=meta(b + 1, dtype=torch.int32),
+            batch_offsets_o=meta(b + 1, dtype=torch.int32),
+        ),
+        "kv strides": make_kwargs(
+            k_cache=meta(num_pages, page_size, h, d).permute(0, 2, 1, 3),
+            v_cache=meta(num_pages, page_size, h, d).permute(0, 2, 1, 3),
+        ),
+    }
+    for name, kwargs in variants.items():
+        assert _sdpa_prefill_key_fn(**kwargs) != base, (
+            f"cache key must change when {name} changes"
+        )
+
+
+def test_cudnn_prefill_fp8_out_args_require_graph_backend():
+    """The cubin fallback cannot honor o_scale/amax_s/amax_o: it must raise
+    NotImplementedError instead of silently ignoring them."""
+    device = "cuda:0"
+    s = 8
+    num_heads = 4
+    head_dim = 128
+    q = torch.randn(s, num_heads, head_dim, device=device, dtype=torch.bfloat16).to(
+        torch.float8_e4m3fn
+    )
+    k_cache = torch.randn_like(q, dtype=torch.bfloat16).to(torch.float8_e4m3fn)
+    v_cache = torch.randn_like(q, dtype=torch.bfloat16).to(torch.float8_e4m3fn)
+    seq_lens = torch.full((1, 1, 1, 1), s, dtype=torch.int32, device=device)
+    workspace_buffer = torch.empty(128 * 1024 * 1024, dtype=torch.int8, device=device)
+    o_scale = torch.ones(1, 1, 1, 1, device=device, dtype=torch.float32)
+
+    with pytest.raises(NotImplementedError, match="graph backend"):
+        cudnn_batch_prefill_with_kv_cache(
+            q,
+            k_cache,
+            v_cache,
+            float(1.0 / (head_dim**0.5)),
+            workspace_buffer,
+            max_token_per_sequence=s,
+            max_sequence_kv=s,
+            actual_seq_lens_q=seq_lens,
+            actual_seq_lens_kv=seq_lens,
+            causal=False,
+            return_lse=True,
+            o_scale=o_scale,
+            o_data_type=torch.float8_e4m3fn,
+            backend="cubin",
+        )

--- a/tests/attention/test_cudnn_wrapper_oscale.py
+++ b/tests/attention/test_cudnn_wrapper_oscale.py
@@ -1,0 +1,425 @@
+"""o_scale plumbing tests for BatchPrefillWith{Ragged,Paged}KVCacheWrapper.run.
+
+FlashInfer issue #4224 stage 2: both wrappers must forward ``o_scale`` to
+``cudnn_batch_prefill_with_kv_cache`` so an fp8 output can be quantized
+(without it, an fp8 ``o_data_type`` is emitted unit-scaled and saturates at
+the e4m3 maximum of 448).  Both wrappers support the fp8 cudnn path via
+``plan(..., q_data_type=fp8)`` (the paged path is exercised end-to-end by
+``test_cudnn_prefill_fp8`` already), so both get dequantization coverage
+here: the dequantized fp8 output must match a reference computed by the
+identical fp8 graph with a bf16 output, which isolates output quantization
+from input-quantization error.  The bf16 reference itself is cross-checked
+against an fa2 bf16 wrapper.  ``o_scale`` is exercised both as a float
+(converted internally to the ``(1, 1, 1, 1)`` fp32 GPU tensor cuDNN expects)
+and as such a tensor passed through as-is.
+
+The ragged fp8 runs pass ``out`` explicitly: the ragged wrapper's internal
+allocation coerces fp8 inputs to a bf16 output, so an fp8 output buffer
+(validated against the planned ``o_data_type``) must be supplied by the
+caller.
+
+Two rejection tests need no fp8 support: non-cudnn paged backends must raise
+``NotImplementedError`` when ``o_scale`` is set, and a non-fp8 cudnn run must
+surface ``cudnn_batch_prefill_with_kv_cache``'s ValueError (proof the
+argument actually reaches the cudnn call).
+"""
+
+import pytest
+import torch
+
+import cudnn
+import flashinfer
+from flashinfer.utils import get_compute_capability
+
+
+def _skip_unless_fp8_prefill_supported(device):
+    if cudnn.backend_version() < 92600:
+        pytest.skip("cuDNN FP8 prefill needs backend 9.26+, skipping test")
+    major, _ = get_compute_capability(torch.device(device))
+    if major != 10:
+        pytest.skip(
+            f"cuDNN FP8 prefill is not supported on compute capability {major}, "
+            "skipping test"
+        )
+
+
+def _as_o_scale_arg(o_scale_value, o_scale_form, device):
+    """o_scale in the two forms the wrappers accept: float or (1,1,1,1) tensor."""
+    if o_scale_form == "float":
+        return o_scale_value
+    return torch.tensor(o_scale_value, device=device, dtype=torch.float32).reshape(
+        1, 1, 1, 1
+    )
+
+
+def _quantize_e4m3(x):
+    """Quantize to e4m3 with an amax/256 descale; returns (x_fp8, scale (1,1,1,1))."""
+    scale = (x.float().abs().amax() / 256).reshape(1, 1, 1, 1)
+    x_fp8 = (x.float() / scale.item()).to(torch.float8_e4m3fn)
+    return x_fp8, scale
+
+
+@pytest.mark.parametrize("o_scale_value", [4.0, 1.0 / 16.0])
+@pytest.mark.parametrize("o_scale_form", ["float", "tensor"])
+@pytest.mark.parametrize("causal", [False, True])
+def test_ragged_wrapper_fp8_o_scale(o_scale_value, o_scale_form, causal):
+    """Ragged wrapper end-to-end: fp8 q/k/v, fp8 output quantized by o_scale."""
+    device = "cuda:0"
+    _skip_unless_fp8_prefill_supported(device)
+
+    torch.manual_seed(5)
+    batch_size, s_qo, s_kv = 4, 32, 64
+    num_qo_heads = num_kv_heads = 4
+    head_dim = 128
+
+    actual_seq_lens_q = torch.randint(
+        1, s_qo + 1, (batch_size, 1, 1, 1), dtype=torch.int32, device=device
+    )
+    actual_seq_lens_kv = torch.randint(
+        s_qo, s_kv + 1, (batch_size, 1, 1, 1), dtype=torch.int32, device=device
+    )
+    total_q = int(actual_seq_lens_q.sum())
+    total_kv = int(actual_seq_lens_kv.sum())
+
+    q = torch.randn(
+        total_q, num_qo_heads, head_dim, device=device, dtype=torch.bfloat16
+    )
+    k = (
+        torch.randn(
+            total_kv, num_kv_heads, head_dim, device=device, dtype=torch.bfloat16
+        )
+        * 0.05
+    )
+    v = (
+        torch.randn(
+            total_kv, num_kv_heads, head_dim, device=device, dtype=torch.bfloat16
+        )
+        * 0.05
+    )
+    q_fp8, q_scale = _quantize_e4m3(q)
+    k_fp8, k_scale = _quantize_e4m3(k)
+    v_fp8, v_scale = _quantize_e4m3(v)
+
+    zero = torch.zeros(1, dtype=torch.int64, device=device)
+    qo_indptr_tok = torch.cat([zero, torch.cumsum(actual_seq_lens_q.view(-1), 0)]).int()
+    kv_indptr_tok = torch.cat(
+        [zero, torch.cumsum(actual_seq_lens_kv.view(-1), 0)]
+    ).int()
+    # The cudnn ragged path takes element-unit indptrs.
+    q_indptr = qo_indptr_tok * num_qo_heads * head_dim
+    kv_indptr = kv_indptr_tok * num_kv_heads * head_dim
+
+    scale = float(1.0 / (head_dim**0.5))
+    workspace_buffer = torch.empty(128 * 1024 * 1024, dtype=torch.int8, device=device)
+
+    def _plan_cudnn(o_data_type):
+        wrapper = flashinfer.BatchPrefillWithRaggedKVCacheWrapper(
+            workspace_buffer, "NHD", backend="cudnn"
+        )
+        wrapper.plan(
+            q_indptr,
+            kv_indptr,
+            num_qo_heads=num_qo_heads,
+            num_kv_heads=num_kv_heads,
+            head_dim_qk=head_dim,
+            causal=causal,
+            sm_scale=scale,
+            q_data_type=torch.float8_e4m3fn,
+            kv_data_type=torch.float8_e4m3fn,
+            o_data_type=o_data_type,
+            seq_lens=actual_seq_lens_kv,
+            seq_lens_q=actual_seq_lens_q,
+            max_token_per_sequence=s_qo,
+            max_sequence_kv=s_kv,
+        )
+        return wrapper
+
+    # Reference: identical fp8 compute, bf16 output (no output quantization).
+    out_ref = _plan_cudnn(torch.bfloat16).run(
+        q_fp8, k_fp8, v_fp8, q_scale=q_scale, k_scale=k_scale, v_scale=v_scale
+    )
+    assert out_ref.dtype == torch.bfloat16
+    assert out_ref.float().abs().amax() > 0
+
+    # Cross-check the reference against a bf16 fa2 wrapper so a garbage fp8
+    # graph cannot self-validate.
+    wrapper_ref = flashinfer.BatchPrefillWithRaggedKVCacheWrapper(
+        torch.empty(128 * 1024 * 1024, dtype=torch.uint8, device=device), "NHD"
+    )
+    wrapper_ref.plan(
+        qo_indptr_tok,
+        kv_indptr_tok,
+        num_qo_heads,
+        num_kv_heads,
+        head_dim,
+        causal=causal,
+        sm_scale=scale,
+        q_data_type=torch.bfloat16,
+        kv_data_type=torch.bfloat16,
+    )
+    out_fa2 = wrapper_ref.run(q, k, v)
+    torch.testing.assert_close(out_ref, out_fa2, atol=1e-2, rtol=1e-2)
+
+    out_fp8_buf = torch.empty(
+        total_q, num_qo_heads, head_dim, device=device, dtype=torch.float8_e4m3fn
+    )
+    out_fp8 = _plan_cudnn(torch.float8_e4m3fn).run(
+        q_fp8,
+        k_fp8,
+        v_fp8,
+        q_scale=q_scale,
+        k_scale=k_scale,
+        v_scale=v_scale,
+        o_scale=_as_o_scale_arg(o_scale_value, o_scale_form, device),
+        out=out_fp8_buf,
+    )
+    assert out_fp8.dtype == torch.float8_e4m3fn
+
+    # Dequantized output must match the pre-quantization reference; the atol
+    # floor covers e4m3's subnormal grid (2^-9) mapped back through o_scale.
+    torch.testing.assert_close(
+        out_fp8.float() / o_scale_value,
+        out_ref.float(),
+        atol=2**-9 / o_scale_value + 5e-3,
+        rtol=1e-1,
+    )
+
+
+@pytest.mark.parametrize("o_scale_value", [4.0, 1.0 / 16.0])
+@pytest.mark.parametrize("o_scale_form", ["float", "tensor"])
+@pytest.mark.parametrize("causal", [False, True])
+def test_paged_wrapper_fp8_o_scale(o_scale_value, o_scale_form, causal):
+    """Paged wrapper end-to-end: fp8 q + fp8 paged KV, fp8 output via o_scale."""
+    device = "cuda:0"
+    _skip_unless_fp8_prefill_supported(device)
+
+    torch.manual_seed(6)
+    batch_size, s_qo, s_kv, page_size = 4, 32, 64, 16
+    num_qo_heads = num_kv_heads = 4
+    head_dim = 128
+
+    actual_seq_lens_q = torch.randint(
+        1, s_qo + 1, (batch_size, 1, 1, 1), dtype=torch.int32, device=device
+    )
+    actual_seq_lens_kv = torch.randint(
+        s_qo, s_kv + 1, (batch_size, 1, 1, 1), dtype=torch.int32, device=device
+    )
+    total_q = int(actual_seq_lens_q.sum())
+
+    q = torch.randn(
+        total_q, num_qo_heads, head_dim, device=device, dtype=torch.bfloat16
+    )
+    q_fp8, q_scale = _quantize_e4m3(q)
+
+    num_pages_per_seq = (s_kv + page_size - 1) // page_size
+    total_num_pages = num_pages_per_seq * batch_size
+    kv_cache = (
+        torch.randn(
+            total_num_pages,
+            2,
+            num_kv_heads,
+            page_size,
+            head_dim,
+            device=device,
+            dtype=torch.bfloat16,
+        )
+        * 0.05
+    )
+    k_cache = kv_cache[:, 0]
+    v_cache = kv_cache[:, 1]
+    k_cache_fp8, k_scale = _quantize_e4m3(k_cache)
+    v_cache_fp8, v_scale = _quantize_e4m3(v_cache)
+
+    zero = torch.zeros(1, dtype=torch.int64, device=device)
+    qo_indptr_tok = torch.cat([zero, torch.cumsum(actual_seq_lens_q.view(-1), 0)]).int()
+    # The cudnn paged path takes element-unit q offsets.
+    q_indptr = qo_indptr_tok * num_qo_heads * head_dim
+    kv_indptr = torch.cat(
+        [
+            zero,
+            torch.cumsum((actual_seq_lens_kv.view(-1) + page_size - 1) // page_size, 0),
+        ]
+    ).int()
+    kv_indices = torch.zeros(int(kv_indptr[-1]), device=device, dtype=torch.int32)
+    for i in range(batch_size):
+        start_idx, end_idx = int(kv_indptr[i]), int(kv_indptr[i + 1])
+        kv_indices[start_idx:end_idx] = torch.arange(
+            i * num_pages_per_seq,
+            i * num_pages_per_seq + (end_idx - start_idx),
+            device=device,
+        )
+    kv_last_page_len = torch.where(
+        actual_seq_lens_kv.flatten() % page_size == 0,
+        torch.full((batch_size,), page_size, device=device),
+        actual_seq_lens_kv.flatten() % page_size,
+    ).int()
+    block_tables = torch.arange(
+        total_num_pages, dtype=torch.int32, device=device
+    ).reshape(batch_size, num_pages_per_seq)
+
+    scale = float(1.0 / (head_dim**0.5))
+    workspace_buffer = torch.empty(128 * 1024 * 1024, dtype=torch.int8, device=device)
+
+    def _plan_cudnn(o_data_type):
+        # The cudnn wrapper only accepts the "NHD" layout string; the caches
+        # are passed as an explicit (k, v) tuple whose (pages, heads,
+        # page_size, dim) strides the cudnn graph reads directly, so the
+        # layout string is inert here (mirrors test_cudnn_prefill_fp8).
+        wrapper = flashinfer.BatchPrefillWithPagedKVCacheWrapper(
+            workspace_buffer, "NHD", backend="cudnn"
+        )
+        wrapper.plan(
+            q_indptr,
+            kv_indptr,
+            kv_indices,
+            kv_last_page_len,
+            num_qo_heads,
+            num_kv_heads,
+            head_dim,
+            page_size,
+            causal=causal,
+            sm_scale=scale,
+            q_data_type=torch.float8_e4m3fn,
+            kv_data_type=torch.float8_e4m3fn,
+            o_data_type=o_data_type,
+            seq_lens=actual_seq_lens_kv,
+            seq_lens_q=actual_seq_lens_q,
+            max_token_per_sequence=s_qo,
+            max_sequence_kv=s_kv,
+            block_tables=block_tables,
+        )
+        return wrapper
+
+    # Reference: identical fp8 compute, bf16 output (no output quantization).
+    out_ref = _plan_cudnn(torch.bfloat16).run(
+        q_fp8,
+        (k_cache_fp8, v_cache_fp8),
+        q_scale=q_scale,
+        k_scale=k_scale,
+        v_scale=v_scale,
+    )
+    assert out_ref.dtype == torch.bfloat16
+    assert out_ref.float().abs().amax() > 0
+
+    # Cross-check the reference against a bf16 fa2 wrapper so a garbage fp8
+    # graph cannot self-validate.
+    wrapper_ref = flashinfer.BatchPrefillWithPagedKVCacheWrapper(
+        torch.empty(128 * 1024 * 1024, dtype=torch.uint8, device=device),
+        "HND",
+        backend="fa2",
+    )
+    wrapper_ref.plan(
+        qo_indptr_tok,
+        kv_indptr,
+        kv_indices,
+        kv_last_page_len,
+        num_qo_heads,
+        num_kv_heads,
+        head_dim,
+        page_size,
+        causal=causal,
+        sm_scale=scale,
+        q_data_type=torch.bfloat16,
+    )
+    out_fa2 = wrapper_ref.run(q, kv_cache)
+    torch.testing.assert_close(out_ref, out_fa2, atol=1e-2, rtol=1e-2)
+
+    # fp8 output allocated internally from the planned o_data_type.
+    out_fp8 = _plan_cudnn(torch.float8_e4m3fn).run(
+        q_fp8,
+        (k_cache_fp8, v_cache_fp8),
+        q_scale=q_scale,
+        k_scale=k_scale,
+        v_scale=v_scale,
+        o_scale=_as_o_scale_arg(o_scale_value, o_scale_form, device),
+    )
+    assert out_fp8.dtype == torch.float8_e4m3fn
+
+    # Dequantized output must match the pre-quantization reference; the atol
+    # floor covers e4m3's subnormal grid (2^-9) mapped back through o_scale.
+    torch.testing.assert_close(
+        out_fp8.float() / o_scale_value,
+        out_ref.float(),
+        atol=2**-9 / o_scale_value + 5e-3,
+        rtol=1e-1,
+    )
+
+
+def test_paged_wrapper_o_scale_rejected_on_non_cudnn():
+    """Non-cudnn paged backends must reject o_scale with NotImplementedError."""
+    device = "cuda:0"
+    s, page_size = 8, 8
+    num_heads, head_dim = 4, 128
+
+    q = torch.randn(s, num_heads, head_dim, device=device, dtype=torch.bfloat16)
+    kv_cache = torch.randn(
+        1, 2, page_size, num_heads, head_dim, device=device, dtype=torch.bfloat16
+    )
+    qo_indptr = torch.tensor([0, s], dtype=torch.int32, device=device)
+    kv_indptr = torch.tensor([0, 1], dtype=torch.int32, device=device)
+    kv_indices = torch.tensor([0], dtype=torch.int32, device=device)
+    kv_last_page_len = torch.tensor([s], dtype=torch.int32, device=device)
+
+    wrapper = flashinfer.BatchPrefillWithPagedKVCacheWrapper(
+        torch.empty(128 * 1024 * 1024, dtype=torch.uint8, device=device),
+        "NHD",
+        backend="fa2",
+    )
+    wrapper.plan(
+        qo_indptr,
+        kv_indptr,
+        kv_indices,
+        kv_last_page_len,
+        num_heads,
+        num_heads,
+        head_dim,
+        page_size,
+        causal=False,
+        q_data_type=torch.bfloat16,
+    )
+    with pytest.raises(NotImplementedError, match="o_scale"):
+        wrapper.run(q, kv_cache, o_scale=1.0)
+
+
+def test_ragged_wrapper_o_scale_reaches_cudnn_validation():
+    """o_scale with a non-fp8 q must surface the cudnn call's ValueError.
+
+    cudnn_batch_prefill_with_kv_cache validates fp8-only arguments before any
+    graph work, so this needs neither backend 9.26 nor SM100 -- and it proves
+    the ragged wrapper actually forwards o_scale to the cudnn call.
+    """
+    device = "cuda:0"
+    batch_size, s = 1, 8
+    num_heads, head_dim = 4, 128
+
+    q = torch.randn(s, num_heads, head_dim, device=device, dtype=torch.bfloat16)
+    k = torch.randn_like(q)
+    v = torch.randn_like(q)
+    seq_lens = torch.full((batch_size, 1, 1, 1), s, dtype=torch.int32, device=device)
+    indptr = (
+        torch.tensor([0, s], dtype=torch.int64, device=device) * num_heads * head_dim
+    ).int()
+
+    wrapper = flashinfer.BatchPrefillWithRaggedKVCacheWrapper(
+        torch.empty(128 * 1024 * 1024, dtype=torch.int8, device=device),
+        "NHD",
+        backend="cudnn",
+    )
+    wrapper.plan(
+        indptr,
+        indptr,
+        num_qo_heads=num_heads,
+        num_kv_heads=num_heads,
+        head_dim_qk=head_dim,
+        causal=False,
+        sm_scale=float(1.0 / (head_dim**0.5)),
+        q_data_type=torch.bfloat16,
+        kv_data_type=torch.bfloat16,
+        o_data_type=torch.bfloat16,
+        seq_lens=seq_lens,
+        seq_lens_q=seq_lens,
+        max_token_per_sequence=s,
+        max_sequence_kv=s,
+    )
+    with pytest.raises(ValueError, match="fp8 query dtype"):
+        wrapper.run(q, k, v, o_scale=2.0)


### PR DESCRIPTION
## 📌 Description

Wires up the FP8 output-scaling support that the cuDNN `sdpa_fp8` graph already provides but the FlashInfer Python layer left disconnected: `scale_o` was bound to a constant 1.0 and the amax outputs were built with `set_output(False)`. As a result, requesting an FP8 `o_data_type` silently emitted unit-scaled FP8 that saturates at the e4m3 max (448) with no error and no calibration signal.

Changes in `flashinfer/cudnn/prefill.py`:
- New keyword-only args on `cudnn_batch_prefill_with_kv_cache`: `o_scale` (quantization scale applied to O before FP8 conversion, `(1,1,1,1)` fp32 GPU tensor) and `amax_o` (optional pre-allocated `(1,1,1,1)` fp32 output buffer written in place with the absolute maximum of O before `o_scale` quantization, for delayed-scaling recipes — CUDA-graph friendly; return signature unchanged). The post-softmax `amax_s` is intentionally **not** exposed (no consumer needs it); the graph-internal tensor stays a non-output.
- FP8 scale binding is now driven by `q.dtype` (all six scale UIDs always bound for fp8 q, user tensor or a cached dummy 1.0) instead of `q_scale is not None`.
- Graph-cache key hardening in `_sdpa_prefill_key_fn`: `o_data_type`, the amax output flag, `k_cache`/`v_cache` dtypes, `v_cache`-derived dims, block-table shape/dtype, seq-len/offset presence flags, and buffer strides are now part of the key. Each of these is baked into the built graph, so two same-shape calls differing only in one of them must not replay the same cached graph.
- `warnings.warn` when `o_data_type` is fp8 and no `o_scale` is given (the silent-saturation case); `ValueError` when the new fp8-only args are passed with non-fp8 q (pre-existing `q/k/v_scale` misuse keeps working, with a warning, for backward compatibility).

Changes in `flashinfer/prefill.py`:
- `BatchPrefillWithRaggedKVCacheWrapper.run` already accepted `o_scale` but the cudnn branch silently dropped it — now forwarded (floats converted to the `(1,1,1,1)` fp32 tensor cuDNN expects; the cudnn call also gets `o_data_type=out.dtype` so the graph's O dtype always matches the bound buffer).
- `BatchPrefillWithPagedKVCacheWrapper.run` gains keyword-only `o_scale` with the same handling; explicit `NotImplementedError` on backends that would silently ignore it.

Test updates:
- The unconditional "cuDNN FP8 prefill has known issues on Blackwell" `pytest.xfail` is now gated on `cudnn.backend_version() < 92600`: FP8 prefill works on SM100 with cuDNN ≥ 9.26, so the 288 previously-xfailed cases actually run (and pass) there.
- New tests: dequantized-output match vs a bf16-output reference across paged/non-paged × causal × `o_scale` ∈ {4.0, 1/16}; a saturation test proving unit scale clamps a 512-magnitude output to 448 while `o_scale=1/16` recovers it exactly with `amax_o = 512`; validation-error coverage; end-to-end wrapper coverage in new `tests/attention/test_cudnn_wrapper_oscale.py` (18 cases, both wrappers, float and tensor `o_scale` forms, cross-checked against an fa2 bf16 reference).

## 🔍 Related Issues

Closes #4224. Related context: #3178 (classifies the cuDNN backend as "wiring needed" for FP8 output scale).

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

(Hooks were run pinned to the repo config via `uvx pre-commit run --files <changed files>` — all hooks pass.)

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

Verified on SM100 (B200-class, cc 10.0) with cuDNN backend 9.26 + cudnn-frontend 1.27: `tests/attention/test_cudnn_prefill.py` full file 589 passed / 0 failed (includes the 288 formerly-xfailed FP8 cases); after the amax_s removal, the fp8 selection + `tests/attention/test_cudnn_wrapper_oscale.py` re-ran at 316 passed / 0 failed. Regression runs of `test_cudnn_graph_cache_key.py`, `test_cudnn_prefill_token_indptr.py`, and `test_cudnn_prefill_paged_cu_seqlens.py` (164 passed).

## Reviewer Notes

- The amax buffer is caller-allocated and written in place rather than returned, to stay CUDA-graph capturable and keep the `(out, lse)` return signature stable.
- FlashInfer's `q_scale`/`k_scale`/`v_scale` are semantically *descales* (fed to cuDNN `descale_q/k/v`); `o_scale` is a *quantization* scale on O — the docstrings spell this out.
- The graph-cache-key additions fix latent stale-graph-replay hazards that predate this PR (e.g. same-shape calls differing only in `o_data_type`); they are included here because the new options widen the space of same-shape-different-graph calls.

AI-assisted (Claude Code), reviewed and tested end-to-end on hardware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added FP8 output scaling support for paged and ragged prefill workflows.
  * Added optional output amax reporting for FP8 cuDNN execution.
  * Output scales can now be provided as numeric values or tensors.
  * Improved support for paged and non-paged sequence-length formats.

* **Bug Fixes**
  * Prevented incompatible cached execution graphs from being reused.
  * Added validation and clearer warnings for unsupported FP8 configurations and backends.
  * Improved output dtype handling and reduced FP8 saturation risks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->