### PR TITLE
fix(mla): SM90 MLA launch failure and PV descriptor bug at head_dim_kpe=128

### DIFF
--- a/include/flashinfer/attention/mla_hopper.cuh
+++ b/include/flashinfer/attention/mla_hopper.cuh
@@ -527,8 +527,20 @@ __device__ __forceinline__ void compute_mla_pv(typename KTraits::SharedStorage* 
       make_smem_desc<KTraits::SWIZZLE_MODE_P, /*leading_byte_offset=*/16,
                      /*stride_byte_offset=*/KTraits::CTA_TILE_KV * 16, typename KTraits::DTypeQ>(
           smem_storage->kv_o_smem[stage_idx].p);
+  // V (= CKV) is the MN-major B operand of the PV WGMMA.
+  //   leading_byte_offset = stride between adjacent core-matrix groups along MN
+  //                       = 8 rows * (one swizzle atom row) = 8 * 128 B = 1024 B
+  //                         for the k128B swizzle. This is a property of the
+  //                         swizzle atom only -- it does NOT depend on
+  //                         CTA_TILE_KV. Writing it as CTA_TILE_KV * 16 happens
+  //                         to give the right answer at CTA_TILE_KV == 64 and
+  //                         silently corrupts PV for any other tile.
+  //   stride_byte_offset  = stride between adjacent core-matrix groups along K
+  //                       = 8 rows * HEAD_DIM_CKV elems * 2 B = HEAD_DIM_CKV * 16.
+  constexpr uint32_t CKV_SWIZZLE_ATOM_BYTES =
+      (KTraits::SWIZZLE_MODE_CKV == SwizzleMode::k128B) ? 8 * 128 : 8 * 64;
   auto desc_ckv = make_smem_desc<KTraits::SWIZZLE_MODE_CKV,
-                                 /*leading_byte_offset=*/KTraits::CTA_TILE_KV * 16,
+                                 /*leading_byte_offset=*/CKV_SWIZZLE_ATOM_BYTES,
                                  /*stride_byte_offset=*/KTraits::HEAD_DIM_CKV * 16, KVDescType>(
       ckv_base + warp_group_idx * 8 * (KTraits::HEAD_DIM_CKV / 2));
   warpgroup_fence_frag<KTraits::NUM_REGS_O_FRAG>(o_frag);
@@ -1282,18 +1294,42 @@ cudaError_t BatchMLAPageAttentionHopper(Params params, uint32_t num_blks_x, uint
   }
   constexpr bool CAUSAL = MASK_MODE == MaskMode::kCausal;
 
-  // get GPU shared memory size
+  // get GPU shared memory size. cudaDevAttrMaxSharedMemoryPerBlockOptin is the
+  // ceiling cudaFuncSetAttribute(cudaFuncAttributeMaxDynamicSharedMemorySize)
+  // will accept; asking for more returns cudaErrorInvalidValue.
   int device;
-  int smem_limit_per_sm;
+  int smem_limit_per_block;
   cudaGetDevice(&device);
-  cudaDeviceGetAttribute(&smem_limit_per_sm, cudaDevAttrMaxSharedMemoryPerMultiprocessor, device);
+  FLASHINFER_CUDA_CALL(cudaDeviceGetAttribute(&smem_limit_per_block,
+                                              cudaDevAttrMaxSharedMemoryPerBlockOptin, device));
 
-  // NUM_STAGES=2 for both paths. The FP8 KV path fits within the 228KB/SM
-  // budget by sharing a single (non-per-stage) `o` writeback overlay across
-  // the whole data path, freeing up room for the BF16 dequant staging buffers.
-  constexpr uint32_t NUM_STAGES = 2;
+  // The FP8 KV path fits within the 228KB/SM budget by sharing a single
+  // (non-per-stage) `o` writeback overlay across the whole data path, freeing
+  // up room for the BF16 dequant staging buffers.
   constexpr uint32_t CTA_TILE_Q = 64;
-  constexpr uint32_t CTA_TILE_KV = 64;
+
+  // Opt-in dynamic shared memory ceiling on every SM90 part: 227KB.
+  constexpr size_t SM90_MAX_DYN_SMEM = 227 * 1024;
+
+  // Pick the largest CTA_TILE_KV whose SharedStorage fits under the SM90
+  // opt-in dynamic shared memory limit. At CTA_TILE_KV=64 the per-stage KV tile
+  // is CTA_TILE_KV*(HEAD_DIM_CKV + max(HEAD_DIM_KPE, CTA_TILE_Q))*sizeof(DTypeKV);
+  // for bf16 HEAD_DIM_CKV=512 that is
+  //   HEAD_DIM_KPE=  0 -> 213856 B  (fits)
+  //   HEAD_DIM_KPE= 64 -> 222048 B  (fits)
+  //   HEAD_DIM_KPE=128 -> 246624 B  (OVER the 232448 B limit)
+  // so HEAD_DIM_KPE=128 must step down to CTA_TILE_KV=32 (164704 B). Without
+  // this, cudaFuncSetAttribute below fails with cudaErrorInvalidValue and the
+  // kernel never launches.
+  // NUM_STAGES=3 at CTA_TILE_KV=32 also fits (205696 B) but measured identically
+  // (1.497 vs 1.498 ms at b400/kv8192) -- the kernel is bandwidth bound here --
+  // so keep the smaller, better-tested NUM_STAGES=2.
+  constexpr uint32_t NUM_STAGES = 2;
+  using KTraitsTileKV64 =
+      hopper::HopperKernelTraits<CAUSAL, NUM_STAGES, HEAD_DIM_CKV, HEAD_DIM_KPE, CTA_TILE_Q,
+                                 /*CTA_TILE_KV_=*/64, DTypeQ, DTypeKV, DTypeO, IdType>;
+  constexpr uint32_t CTA_TILE_KV =
+      sizeof(typename KTraitsTileKV64::SharedStorage) <= SM90_MAX_DYN_SMEM ? 64 : 32;
 
   using KTraits =
       hopper::HopperKernelTraits<CAUSAL, NUM_STAGES, HEAD_DIM_CKV, HEAD_DIM_KPE, CTA_TILE_Q,
@@ -1301,6 +1337,19 @@ cudaError_t BatchMLAPageAttentionHopper(Params params, uint32_t num_blks_x, uint
   dim3 nblks(num_blks_x, num_blks_y);
   dim3 nthrs(KTraits::NUM_THREADS);
   size_t smem_size = sizeof(typename KTraits::SharedStorage);
+
+  if (smem_size > static_cast<size_t>(smem_limit_per_block)) {
+    // Nothing in the supported tile table fits; fail loudly instead of
+    // surfacing an opaque "invalid argument" from cudaFuncSetAttribute.
+    std::ostringstream err;
+    err << "BatchMLAPageAttentionHopper: shared memory required (" << smem_size
+        << " B) exceeds the device limit (" << smem_limit_per_block
+        << " B) for HEAD_DIM_CKV=" << HEAD_DIM_CKV << ", HEAD_DIM_KPE=" << HEAD_DIM_KPE
+        << ", CTA_TILE_Q=" << CTA_TILE_Q << ", CTA_TILE_KV=" << CTA_TILE_KV
+        << ", NUM_STAGES=" << NUM_STAGES;
+    FLASHINFER_ERROR(err.str());
+    return cudaErrorNotSupported;
+  }
 
   auto kernel = hopper::BatchMLAPageAttentionHopperKernel<KTraits, Params>;
   void* args[] = {(void*)&params};


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

The SM90 (Hopper) MLA kernel cannot launch at `head_dim_ckv=512, head_dim_kpe=128, bf16`. The run fails with:

```
Failed to run MLA, error: invalid argument
```

This PR fixes that, plus a latent WGMMA descriptor bug that had to be fixed first to make the tile size variable.

### Root cause 1 — shared memory overflow at launch

`BatchMLAPageAttentionHopper` queries `smem_limit_per_sm` and then **never uses it**; `NUM_STAGES=2`, `CTA_TILE_Q=64` and `CTA_TILE_KV=64` are hardcoded. At `ckv=512, kpe=128, bf16`, `sizeof(SharedStorage)` is 246,624 B, which exceeds the H100/H200 opt-in dynamic shared memory cap of 232,448 B (227 KB) by 14,176 B. `cudaFuncSetAttribute(cudaFuncAttributeMaxDynamicSharedMemorySize)` therefore returns `cudaErrorInvalidValue`, and the failure surfaces as the opaque "invalid argument" above.

The per-stage KV tile is `PerStageKV = ckv[64*512*2] + union{ kpe[64*KPE*2], p[64*64*2] }`, giving (bf16, `ckv=512`, `CTA_TILE_KV=64`):

| `head_dim_kpe` | `sizeof(SharedStorage)` | vs 232,448 B cap |
| --- | --- | --- |
| 0 | 213,856 B | fits |
| 64 | 222,048 B | fits |
| **128** | **246,624 B** | **over by 14,176 B** |

Two other escapes were evaluated and rejected. `NUM_STAGES=1` deadlocks: warpgroup 0 runs `ProducerConsumer` with `consumer_arv_count=256` and ends up waiting on its own later consumer release. `CTA_TILE_KV=16` produces a zero-length `ckv_offset` array. `CTA_TILE_KV=32` is the working step-down (164,704 B).

### Root cause 2 — PV WGMMA descriptor is only accidentally correct at tile 64

`compute_mla_pv` builds the V (MN-major) B-operand descriptor with:

```cpp
/*leading_byte_offset=*/KTraits::CTA_TILE_KV * 16
```

For an MN-major operand, `leading_byte_offset` is the stride between adjacent core-matrix groups **along MN**, which for the `k128B` swizzle is one swizzle atom: 8 rows × 128 B = **1024 B**. That is a property of the swizzle atom alone and does not depend on `CTA_TILE_KV`. The existing expression evaluates to `64 * 16 = 1024` — the right answer, for the wrong reason.

So this is a **provable no-op at `CTA_TILE_KV=64`**, i.e. for every configuration reachable on `main` today. But it silently corrupts PV at any other tile size, which is exactly what the shared memory fix needs. Measured at `CTA_TILE_KV=32`: `max_abs_err` 0.46 against a 0.34-magnitude signal before the descriptor fix, 1.2e-3 after.

### The fix

1. Set the V descriptor's `leading_byte_offset` to the swizzle-atom constant (`8 * 128` for `k128B`, `8 * 64` otherwise) instead of `CTA_TILE_KV * 16`, with a comment explaining why it is swizzle-derived. No-op at tile 64; correct at every tile.
2. Query `cudaDevAttrMaxSharedMemoryPerBlockOptin` — the actual ceiling `cudaFuncSetAttribute` will accept — and select `CTA_TILE_KV = 64` when `SharedStorage` fits, else `32`, resolved at compile time via `constexpr`. If nothing fits, raise an explicit error naming the configuration and both byte counts rather than surfacing "invalid argument".

`NUM_STAGES=3` at `CTA_TILE_KV=32` also fits (205,696 B) and measured identically (1.497 vs 1.498 ms at b400/kv8192 — the kernel is bandwidth bound here), so this keeps the smaller, better-tested `NUM_STAGES=2`.

### Blast radius

Only **bf16 `kpe=128`** changes tile size. Everything else still selects `CTA_TILE_KV=64` and is bit-identical:

| config | `sizeof(SharedStorage)` | selected tile |
| --- | --- | --- |
| bf16 `kpe=0` | 213,856 B | 64 (unchanged) |
| bf16 `kpe=64` | 222,048 B | 64 (unchanged) |
| bf16 `kpe=128` | 246,624 B → 164,704 B | **32 (new)** |
| fp8 `kpe=64` | 230,208 B | 64 (unchanged, 2,240 B headroom) |
| fp8 `kpe=128` | fits | 64 (unchanged) |

Planner-compatible: every `kv_len_limit` value `MLAPlan` produces is divisible by 32, so the smaller tile does not violate any planner assumption.

This unblocks Gemma-4-style **hd512 K==V attention served as MLA** (`ckv=512, kpe=128`), which is unreachable on `main` today.

## 🔍 Related Issues

None filed — reporting and fixing together.

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually and fixed any reported issues.

> Note: I ran `pre-commit run --files include/flashinfer/attention/mla_hopper.cuh` (the only changed file) rather than `--all-files`. All hooks pass, including `clang-format` at the pinned v19.1.1. One continuation-alignment nit in my own added lines was found and fixed.

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

> Being explicit rather than checking these off: I have **not** run the repo's unit test suite, and this PR adds no new test. The verification below is from direct correctness and timing runs against an fp32 oracle on H200 hardware. I'd suggest a `head_dim_kpe=128` case belongs in the MLA test matrix — glad to add one to this PR if you want it here, and glad to run the existing MLA tests if you tell me which target is the relevant one.

**Hardware:** H200 NVL (SM90), CUDA 12.9, driver 575.57.08.

Correctness against an fp32 oracle at `ckv=512, kpe=128, bf16`:

| case | max_abs_err | max_rel_err |
| --- | --- | --- |
| decode | 0.00141 | 0.00425 |
| mixed causal | 0.0098 | 0.0028 |

These match the `kpe=64` and `kpe=0` controls that already worked on `main`, so the new tile size is not costing accuracy.

Performance: decode at b400/kv8192 runs in **1.498 ms**.

## Reviewer Notes

- The descriptor change (item 1) is the part worth the closest look. My claim is that `leading_byte_offset` for an MN-major operand is a pure function of the swizzle mode, and that `CTA_TILE_KV * 16` matching it at tile 64 is a coincidence. If that reasoning is wrong, the shared memory fix needs a different approach — but the change is inert on `main` either way, since tile 64 is the only value reachable today.
- I picked "step down `CTA_TILE_KV`" over "raise `NUM_STAGES` and shrink elsewhere" because it is the smallest change that keeps every currently working configuration bit-identical. If you'd rather see a general tile-selection table (e.g. also covering future `ckv`/`kpe` combinations) I'm happy to restructure it.
- `SM90_MAX_DYN_SMEM` is written as a `constexpr size_t` of 227 KB because the tile choice must be a compile-time constant, while the runtime `cudaDevAttrMaxSharedMemoryPerBlockOptin` query is used for the explicit error check. If you'd prefer that constant sourced differently, let me know.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved attention kernel configuration for devices with varying dynamic shared-memory limits.
  * Added validation for supported shared-memory configurations.
  * Unsupported configurations now return a clear not-supported error instead of proceeding with an invalid setup.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->