### PR TITLE
feat(kda): add SM120a CuTe DSL prefill backend

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -13,11 +13,11 @@ small-BH cases through the same cold-L2 CUPTI path.
 ## Overview
 
 This framework provides tools to:
-- Benchmark FlashInfer's Attention, GEMM, MOE, Norm, Quantization, Sampling, RoPE, Mamba, and GDN API performance from different kernel backends such as FlashAttention2/3, cuDNN, cuBLAS, CUTLASS, PrimTS, CuTe-DSL, TensorRT-LLM, and Triton
+- Benchmark FlashInfer's Attention, GEMM, MOE, Norm, Quantization, Sampling, RoPE, Mamba, GDN, and KDA API performance from different kernel backends such as FlashAttention2/3, cuDNN, cuBLAS, CUTLASS, PrimTS, CuTe-DSL, TensorRT-LLM, and Triton
 - Compare performance across different configurations
 - Batch performance test multiple test cases
 
-Currently supports testing attention, gemm, fused MOE, normalization, quantization, sampling, RoPE, Mamba, and GDN (Gated Delta Net) APIs:
+Currently supports testing attention, gemm, fused MOE, normalization, quantization, sampling, RoPE, Mamba, GDN (Gated Delta Net), and KDA APIs:
 - Attention:
     - `BatchDecodeWithPagedKVCacheWrapper` - Decode attention with paged KV cache.
         - Also supports computationally similar `cudnn_batch_decode_with_kv_cache` and `trtllm_batch_decode_with_kv_cache`.
@@ -92,6 +92,8 @@ Currently supports testing attention, gemm, fused MOE, normalization, quantizati
     - `gated_delta_rule_decode` - Single-token (T=1) gated delta rule decode. `--state_layout` selects between `gated_delta_rule_decode_pretranspose` ([B, HV, V, K] state, default) and `gated_delta_rule_decode` ([B, HV, K, V] state). `--state_dtype bfloat16` selects the BF16 state kernels (head_size=128, pretranspose only). Backends: `flashinfer` (CuTe-DSL) and `triton` (reference).
     - `gated_delta_rule_mtp` - Multi-token (T>=2) gated delta rule for speculative-decoding verification, with a state pool + indices. `--state_dtype float32` uses `gated_delta_rule_mtp`; `--state_dtype bfloat16` uses the BF16 MTP kernel via `gated_delta_rule_decode_pretranspose`. Backends: `flashinfer`, `triton`.
     - `chunk_gated_delta_rule` - Chunked GDN prefill over varlen sequences (uniform per-sequence length `--s_qo`). Backends: `flashinfer` (SM90 C++ / SM100 CuTe-DSL) and `fla` (flash-linear-attention Triton baseline, perf-only).
+- KDA (SM120a):
+    - `recurrent_kda_prefill` - Ordinary multi-token recurrent KDA prefill with fixed or packed inputs. Backends: `flashinfer` (automatic variant policy), `flashinfer-decomp`, `flashinfer-fused`, and optional external `cutekda` / `flash-kda` baselines.
 
 ## Quick Start
 ### Single Test Run
@@ -568,6 +570,7 @@ Legend:
 | **gated_delta_rule_decode** |  |  |  |  | flashinfer, triton | flashinfer, triton | flashinfer, triton | triton |
 | **gated_delta_rule_mtp** |  |  |  |  | flashinfer, triton | flashinfer, triton | flashinfer, triton | triton |
 | **chunk_gated_delta_rule** |  |  |  |  | flashinfer, fla | flashinfer, fla | flashinfer, fla |  |
+| **recurrent_kda_prefill** |  |  |  |  |  |  |  | flashinfer, flashinfer-decomp, flashinfer-fused, cutekda, flash-kda |
 
 Backend Legend:
 - fa2: FlashAttention2
@@ -588,3 +591,5 @@ Backend Legend:
 - allreduce: AllReduce fusion communication (requires mpirun, Blackwell SM10.0+ with MNNVL)
 - triton: Triton reference kernels (used for Mamba selective_state_update and GDN decode/MTP)
 - fla: flash-linear-attention Triton kernels (GDN prefill baseline)
+- flashinfer-decomp / flashinfer-fused: pinned SM120 KDA prefill variants
+- cutekda / flash-kda: optional external SM120 KDA prefill baselines

--- a/benchmarks/flashinfer_benchmark.py
+++ b/benchmarks/flashinfer_benchmark.py
@@ -71,6 +71,11 @@ def run_test(args):
         from routines.gdn import run_gdn_test
 
         res = run_gdn_test(args)
+
+    elif args.routine in benchmark_apis["kda"]:
+        from routines.kda import run_kda_test
+
+        res = run_kda_test(args)
     elif args.routine in benchmark_apis["sparse_attention"]:
         from routines.sparse_attention import run_sparse_attention_test
 
@@ -129,6 +134,7 @@ def parse_args(line=sys.argv[1:]):
         + list(benchmark_apis["rope"])
         + list(benchmark_apis["mamba"])
         + list(benchmark_apis["gdn"])
+        + list(benchmark_apis["kda"])
         + list(benchmark_apis["sparse_attention"])
         + list(benchmark_apis["topk_varlen"]),
     )
@@ -291,6 +297,11 @@ def parse_args(line=sys.argv[1:]):
         from routines.gdn import parse_gdn_args
 
         args = parse_gdn_args(line, parser)
+
+    elif args.routine in benchmark_apis["kda"]:
+        from routines.kda import parse_kda_args
+
+        args = parse_kda_args(line, parser)
     elif args.routine in benchmark_apis["sparse_attention"]:
         from routines.sparse_attention import parse_sparse_attention_args
 

--- a/benchmarks/routines/flashinfer_benchmark_utils.py
+++ b/benchmarks/routines/flashinfer_benchmark_utils.py
@@ -153,6 +153,17 @@ output_column_dict = {
         "update_state",
         "use_qk_l2norm",
     ],
+    "kda": [
+        # Which variant the policy chose, and whether this device's thresholds
+        # were measured or inherited from another SM count. A time taken under
+        # fallback thresholds is not a time taken under tuned ones, and no
+        # other column distinguishes them.
+        "kda_variant",
+        "kda_variant_policy",
+        "sm_count",
+        "packed",
+        "has_initial_state",
+    ],
     "msa": [
         "topk",
         "max_k_tiles",
@@ -198,6 +209,7 @@ full_output_columns = (
     + output_column_dict["rope"]
     + output_column_dict["mamba"]
     + output_column_dict["gdn"]
+    + output_column_dict["kda"]
     + output_column_dict["msa"]
     + output_column_dict["general"]
 )
@@ -300,6 +312,9 @@ benchmark_apis = {
         "gated_delta_rule_decode",
         "gated_delta_rule_mtp",
         "chunk_gated_delta_rule",
+    ],
+    "kda": [
+        "recurrent_kda_prefill",
     ],
     "sparse_attention": [
         "MSAProxyScore",
@@ -1070,6 +1085,28 @@ routine_cc_to_supported_backends = {
         "10.3": ["flashinfer", "fla"],
         "11.0": [],
         "12.0": [],
+        "12.1": [],
+    },
+    # KDA prefill on SM120a only. The SM100-family Cake prefill backend is a
+    # different kernel with a different contract and is not benchmarked here;
+    # listing it under 10.0/10.3 would put two unrelated implementations in one
+    # column.
+    "recurrent_kda_prefill": {
+        "7.5": [],
+        "8.0": [],
+        "8.6": [],
+        "8.9": [],
+        "9.0": [],
+        "10.0": [],
+        "10.3": [],
+        "11.0": [],
+        "12.0": [
+            "flashinfer",
+            "flashinfer-decomp",
+            "flashinfer-fused",
+            "cutekda",
+            "flash-kda",
+        ],
         "12.1": [],
     },
 }

--- a/benchmarks/routines/kda.py
+++ b/benchmarks/routines/kda.py
@@ -1,0 +1,641 @@
+"""
+Copyright (c) 2026 by FlashInfer team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from collections import defaultdict
+
+import numpy as np
+import torch
+
+import flashinfer
+from flashinfer.testing.utils import bench_gpu_time
+
+from .flashinfer_benchmark_utils import (
+    dtype_str_to_torch_dtype,
+    filter_backends_by_compute_capability,
+    get_device,
+    is_close_stats,
+    print_perf_metrics,
+)
+
+HEAD_DIM = 128
+
+#: Backends this routine can time. All of them run the same shapes, the same
+#: timing method, the same stream and the same pre-allocated output and
+#: final-state buffers -- which is the only way the numbers can be divided by
+#: one another afterwards.
+#:
+#: ``flashinfer`` is the public entry point with its own variant policy;
+#: ``flashinfer-decomp`` and ``flashinfer-fused`` pin one variant each, so a
+#: report can show what the policy chose *and* what it declined.
+#:
+#: ``cutekda`` and ``flash-kda`` are external and optional. They are imported
+#: only when asked for and only if already installed, they are never a
+#: dependency of this file, and a missing one is an explicit skip rather than a
+#: silent omission -- a comparison table with a quietly absent baseline is
+#: worse than one with a gap in it.
+_FLASHINFER_BACKENDS = ("flashinfer", "flashinfer-decomp", "flashinfer-fused")
+_EXTERNAL_BACKENDS = ("cutekda", "flash-kda")
+
+
+def run_kda_test(args):
+    """Route a KDA benchmark case to its routine."""
+    if args.routine == "recurrent_kda_prefill":
+        return testRecurrentKDAPrefill(args)
+    raise ValueError(f"Unsupported routine: {args.routine}")
+
+
+def parse_kda_args(line, parser):
+    """Parse the KDA-specific arguments.
+
+    Args:
+        line: Command line arguments
+        parser: ArgumentParser already populated with the shared arguments
+
+    Returns:
+        Parsed argument namespace
+    """
+    parser.add_argument(
+        "--batch_size",
+        type=int,
+        required=True,
+        help="Number of sequences.",
+    )
+    parser.add_argument(
+        "--s_qo",
+        type=int,
+        required=True,
+        help="Tokens per sequence. With --packed the sequences are packed into "
+        "one [1, B * T, H, 128] activation and given explicit offsets; "
+        "without it they are a fixed [B, T, H, 128] batch.",
+    )
+    parser.add_argument(
+        "--num_q_heads",
+        type=int,
+        default=16,
+        help="Number of heads. KDA is equal-head: H == HV.",
+    )
+    parser.add_argument(
+        "--head_size",
+        type=int,
+        default=HEAD_DIM,
+        help="Head dimension. Fixed at 128 for this backend.",
+    )
+    parser.add_argument(
+        "--input_dtype",
+        type=str,
+        default="bfloat16",
+        choices=["bfloat16"],
+        help="Data type for q/k/v/g/beta. The first published version is "
+        "bfloat16 only.",
+    )
+    parser.add_argument(
+        "--state_dtype",
+        type=str,
+        default="bfloat16",
+        choices=["bfloat16"],
+        help="Recurrent state dtype.",
+    )
+    parser.add_argument(
+        "--packed",
+        action="store_true",
+        help="Use packed varlen input with explicit cu_seqlens.",
+    )
+    parser.add_argument(
+        "--offsets_dtype",
+        type=str,
+        default="int32",
+        choices=["int32", "int64"],
+        help="cu_seqlens dtype for packed input. Both are accepted by the "
+        "public API; the backend consumes a canonical int32 copy either way.",
+    )
+    parser.add_argument(
+        "--has_initial_state",
+        action="store_true",
+        help="Pass a bfloat16 initial state, updated in place.",
+    )
+    parser.add_argument(
+        "--lower_bound",
+        type=float,
+        default=-5.0,
+        help="Gate lower bound. Must be in [-5.0, 0.0).",
+    )
+    parser.add_argument(
+        "--backends",
+        type=str,
+        required=False,
+        nargs="+",
+        default=["flashinfer"],
+        choices=list(_FLASHINFER_BACKENDS) + list(_EXTERNAL_BACKENDS),
+        help="Backends to benchmark. 'flashinfer' is the public entry point "
+        "with its own variant policy; '-decomp'/'-fused' pin one variant each. "
+        "'cutekda' and 'flash-kda' are external baselines, benchmarked only "
+        "when already installed and never a dependency of this file.",
+    )
+    return parser.parse_args(line)
+
+
+def kda_prefill_flops(total_tokens: int, num_heads: int, head_size: int) -> float:
+    """Matmul FLOPs of one KDA prefill.
+
+    Three [K, V] rank-updates and projections per token per head, each
+    ``2 * K * V``: the state read for the prediction, the state update, and the
+    output projection. The gate and the normalization are elementwise and do
+    not move this number.
+    """
+    return 3.0 * 2.0 * total_tokens * num_heads * head_size * head_size
+
+
+def kda_prefill_bytes(
+    total_tokens: int,
+    num_seqs: int,
+    num_heads: int,
+    head_size: int,
+    input_dtype: torch.dtype,
+    has_initial_state: bool,
+    output_final_state: bool,
+) -> float:
+    """Compulsory DRAM traffic: activations in, output out, state either way.
+
+    Compulsory, not achieved: the chunk factors the decomposed variant writes
+    and reads back are not here, because whether they reach DRAM at all is a
+    property of the schedule rather than of the problem, and counting them
+    would make the two variants incomparable on a bytes-per-second column.
+    """
+    element = torch.finfo(input_dtype).bits // 8
+    # q, k, v, g in; out out.
+    activations = 5.0 * total_tokens * num_heads * head_size * element
+    # beta in.
+    activations += total_tokens * num_heads * element
+    state_slabs = (1 if has_initial_state else 0) + (1 if output_final_state else 0)
+    state = state_slabs * num_seqs * num_heads * head_size * head_size * element
+    return activations + state
+
+
+def _make_inputs(args, device):
+    """Inputs matching the SM120 KDA prefill contract."""
+    input_dtype = dtype_str_to_torch_dtype(args.input_dtype)
+    num_seqs = args.batch_size
+    seq_len = args.s_qo
+    num_heads = args.num_q_heads
+    head_size = args.head_size
+
+    if args.packed:
+        batch, tokens = 1, num_seqs * seq_len
+        offsets_dtype = torch.int32 if args.offsets_dtype == "int32" else torch.int64
+        cu_seqlens = torch.arange(
+            0, tokens + 1, seq_len, dtype=offsets_dtype, device=device
+        )
+    else:
+        batch, tokens = num_seqs, seq_len
+        cu_seqlens = None
+
+    shape = (batch, tokens, num_heads, head_size)
+
+    def normalized():
+        raw = torch.randn(shape, dtype=torch.float32, device=device)
+        return torch.nn.functional.normalize(raw, p=2.0, dim=-1).to(input_dtype)
+
+    inputs = {
+        "q": normalized(),
+        "k": normalized(),
+        "v": torch.randn(shape, dtype=torch.float32, device=device).to(input_dtype),
+        "g": (0.1 * torch.randn(shape, dtype=torch.float32, device=device)).to(
+            input_dtype
+        ),
+        "beta": torch.randn(
+            (batch, tokens, num_heads), dtype=torch.float32, device=device
+        ).to(input_dtype),
+        "A_log": 0.1 * torch.randn(num_heads, dtype=torch.float32, device=device),
+        "dt_bias": 0.1
+        * torch.randn((num_heads, head_size), dtype=torch.float32, device=device),
+        "cu_seqlens": cu_seqlens,
+    }
+    if args.has_initial_state:
+        inputs["initial_state"] = (
+            0.1
+            * torch.randn(
+                (num_seqs, num_heads, head_size, head_size),
+                dtype=torch.float32,
+                device=device,
+            )
+        ).to(torch.bfloat16)
+    else:
+        inputs["initial_state"] = None
+    return inputs
+
+
+def _reference_prefill(inputs, args, device):
+    """Token-serial reference, for the optional refcheck.
+
+    Deliberately the public-contract reference and not either kernel's own: two
+    references that share a derivation cannot disagree, so a check against one
+    of the implementations would confirm nothing.
+    """
+    q = inputs["q"]
+    batch, tokens, num_heads, head_dim = q.shape
+    scale = head_dim**-0.5
+    normalize = torch.nn.functional.normalize
+
+    q_flat = normalize(q.float(), dim=-1).reshape(-1, num_heads, head_dim)
+    k_flat = normalize(inputs["k"].float(), dim=-1).reshape(-1, num_heads, head_dim)
+    v_flat = inputs["v"].float().reshape(-1, num_heads, head_dim)
+    g_flat = inputs["g"].float().reshape(-1, num_heads, head_dim)
+    beta_flat = torch.sigmoid(inputs["beta"].float().reshape(-1, num_heads))
+
+    decay = torch.exp(
+        args.lower_bound
+        * torch.sigmoid(
+            torch.exp(inputs["A_log"]).reshape(1, num_heads, 1)
+            * (g_flat + inputs["dt_bias"].reshape(1, num_heads, head_dim))
+        )
+    )
+
+    if inputs["cu_seqlens"] is None:
+        offsets = [index * tokens for index in range(batch + 1)]
+    else:
+        offsets = [int(value) for value in inputs["cu_seqlens"].tolist()]
+
+    if inputs["initial_state"] is None:
+        state = torch.zeros(
+            (len(offsets) - 1, num_heads, head_dim, head_dim),
+            dtype=torch.bfloat16,
+            device=device,
+        )
+    else:
+        state = inputs["initial_state"].clone()
+
+    out = torch.empty_like(q_flat)
+    for sequence in range(len(offsets) - 1):
+        for token in range(offsets[sequence], offsets[sequence + 1]):
+            decayed = state[sequence].float() * decay[token].unsqueeze(1)
+            predicted = torch.einsum("hk,hvk->hv", k_flat[token], decayed)
+            residual = beta_flat[token].unsqueeze(-1) * (v_flat[token] - predicted)
+            updated = decayed + residual.unsqueeze(-1) * k_flat[token].unsqueeze(1)
+            state[sequence] = updated.to(torch.bfloat16)
+            out[token] = (
+                scale
+                * torch.einsum("hk,hvk->hv", q_flat[token], state[sequence].float())
+            ).to(torch.bfloat16)
+    return out.reshape_as(q), state
+
+
+def _flashinfer_runner(inputs, args, output, final_state, variant):
+    """A zero-argument callable running one FlashInfer backend.
+
+    ``variant is None`` is the public entry point, policy and all. The other
+    two go through the internal entry so a report can show what the policy
+    chose and what it declined; they are not a second public API.
+    """
+    if variant is None:
+
+        def call():
+            flashinfer.recurrent_kda(
+                q=inputs["q"],
+                k=inputs["k"],
+                v=inputs["v"],
+                g=inputs["g"],
+                beta=inputs["beta"],
+                A_log=inputs["A_log"],
+                dt_bias=inputs["dt_bias"],
+                use_qk_l2norm_in_kernel=True,
+                use_gate_in_kernel=True,
+                beta_is_logit=True,
+                lower_bound=args.lower_bound,
+                cu_seqlens=inputs["cu_seqlens"],
+                initial_state=inputs["initial_state"],
+                output_final_state=final_state is not None,
+                output=output,
+            )
+
+        return call
+
+    # Note on what the row above measures against the ones below.  The public
+    # entry takes `output_final_state: bool` and has no parameter for a state
+    # buffer, so with no `initial_state` it allocates one per call while the
+    # direct variants below write into a preallocated tensor.  That is a real
+    # difference between the two APIs, not an artifact of this harness, and it
+    # is left visible rather than papered over -- with `--has_initial_state`
+    # both paths update the same buffer in place and the comparison is exact.
+
+    from flashinfer.kda_kernels import sm120_prefill
+
+    def call():
+        sm120_prefill.run_kda_prefill_sm120(
+            q=inputs["q"],
+            k=inputs["k"],
+            v=inputs["v"],
+            g=inputs["g"],
+            beta=inputs["beta"],
+            A_log=inputs["A_log"],
+            dt_bias=inputs["dt_bias"],
+            lower_bound=args.lower_bound,
+            cu_seqlens=inputs["cu_seqlens"],
+            initial_state=inputs["initial_state"],
+            final_state=final_state,
+            output=output,
+            variant=variant,
+        )
+
+    return call
+
+
+def _external_runner(backend, inputs, args, output, final_state):
+    """A callable for an external baseline, or ``None`` if it is not installed.
+
+    Both baselines write the caller's ``output`` and ``final_state`` in place,
+    exactly as the FlashInfer path does. A baseline timed without the state
+    store would not be measuring the same operation, and dividing by it would
+    overstate the speedup by however much that store costs.
+    """
+    scale = args.head_size**-0.5
+    if backend == "cutekda":
+        try:
+            import cute_kda
+        except ImportError:
+            return None
+
+        def call():
+            cute_kda.fwd(
+                inputs["q"],
+                inputs["k"],
+                inputs["v"],
+                inputs["g"],
+                inputs["beta"],
+                scale,
+                output,
+                inputs["A_log"],
+                inputs["dt_bias"],
+                args.lower_bound,
+                inputs["initial_state"],
+                final_state,
+                inputs["cu_seqlens"],
+            )
+
+        return call
+
+    if backend == "flash-kda":
+        try:
+            import flash_kda
+        except ImportError:
+            return None
+
+        def call():
+            flash_kda.fwd(
+                inputs["q"],
+                inputs["k"],
+                inputs["v"],
+                inputs["g"],
+                inputs["beta"],
+                scale,
+                output,
+                inputs["A_log"],
+                inputs["dt_bias"],
+                args.lower_bound,
+                inputs["initial_state"],
+                final_state,
+                inputs["cu_seqlens"],
+            )
+
+        return call
+
+    return None
+
+
+def testRecurrentKDAPrefill(args):
+    """Time SM120 ordinary multi-token KDA prefill.
+
+    Every backend gets the same tensors, the same stream, the same
+    pre-allocated ``output`` and ``final_state``, and the same timing method.
+    Compilation, descriptor construction, metadata preparation and the first
+    launch all happen before the timed region, so what is measured is the
+    steady-state call a serving loop makes rather than the first one it ever
+    made.
+
+    Returns:
+        list[dict]: one row per backend.
+    """
+    if args.verbose >= 1:
+        print("[INFO] Running testRecurrentKDAPrefill")
+        print(f"[INFO] FlashInfer version: {flashinfer.__version__}")
+
+    device = get_device(args)
+    if args.generate_repro_command:
+        print(
+            f"[INFO] To reproduce this test case, run the following command: "
+            f"{args.repro_command}"
+        )
+
+    backends = args.backends[:]
+    num_seqs = args.batch_size
+    seq_len = args.s_qo
+    num_heads = args.num_q_heads
+    head_size = args.head_size
+    run_refcheck = args.refcheck
+    res = []
+
+    if head_size != HEAD_DIM:
+        print(f"[ERROR] KDA prefill is fixed at head_size={HEAD_DIM}. Exiting.")
+        return res
+
+    backends = filter_backends_by_compute_capability(backends, args.routine, device)
+    for backend in list(backends):
+        if backend in _EXTERNAL_BACKENDS:
+            if _external_runner(backend, {}, args, None, None) is None:
+                # Deliberately not silent: a comparison table with a quietly
+                # absent baseline reads as "we measured against it".
+                print(
+                    f"[WARNING] the {backend} baseline is not installed in this "
+                    f"environment. Skipping it; the report must say so."
+                )
+                backends.remove(backend)
+    if len(backends) == 0:
+        print("[ERROR] No backends to test. Exiting.")
+        return res
+
+    input_dtype = dtype_str_to_torch_dtype(args.input_dtype)
+    total_tokens = num_seqs * seq_len
+
+    inputs = _make_inputs(args, device)
+    output = torch.empty_like(inputs["v"])
+    output_final_state = True
+    final_state = (
+        inputs["initial_state"]
+        if inputs["initial_state"] is not None
+        else torch.empty(
+            (num_seqs, num_heads, head_size, head_size),
+            dtype=torch.bfloat16,
+            device=device,
+        )
+    )
+
+    # Which variant the policy picks, and whether this device's thresholds were
+    # measured or inherited. A time quoted under fallback thresholds is not a
+    # time quoted under tuned ones, and nothing else in the output says which.
+    selected_variant = ""
+    policy_source = ""
+    sm_count = torch.cuda.get_device_properties(device).multi_processor_count
+    try:
+        from flashinfer.kda_kernels import sm120_prefill
+
+        selected_variant = sm120_prefill.choose_variant(
+            num_seqs, num_heads, seq_len, sm_count=sm_count
+        )
+        profile_key, _ = sm120_prefill.auto_profile(sm_count)
+        policy_source = "tuned" if profile_key == sm_count else "fallback"
+        if args.verbose >= 1:
+            print(f"[INFO] {sm120_prefill.describe_variant_policy(sm_count)}")
+    except Exception as exc:  # noqa: BLE001 -- reporting only
+        if args.verbose >= 1:
+            print(f"[WARNING] could not read the SM120 variant policy: {exc}")
+
+    reference_output = None
+    if run_refcheck:
+        reference_output, _ = _reference_prefill(inputs, args, device)
+
+    if args.verbose >= 2:
+        print(f"[VVERBOSE] {inputs['q'].shape = }, {inputs['q'].dtype = }")
+        print(f"[VVERBOSE] {inputs['cu_seqlens'] = }")
+
+    backend_times = {backend: [] for backend in backends}
+    outputs = {}
+
+    # KDA updates the recurrent state in place: `final_state` *is*
+    # `initial_state` whenever the caller supplies one.  Without a snapshot the
+    # first backend's warmup rewrites the state every later backend starts
+    # from, so the second one is not solving the same problem as the first --
+    # which shows up as a performance difference that is not one, and as a
+    # refcheck failure under --has_initial_state that blames the wrong backend.
+    initial_state_snapshot = (
+        inputs["initial_state"].clone() if inputs["initial_state"] is not None else None
+    )
+
+    for backend in backends:
+        if backend in _FLASHINFER_BACKENDS:
+            variant = {
+                "flashinfer": None,
+                "flashinfer-decomp": "decomp",
+                "flashinfer-fused": "fused",
+            }[backend]
+            runner = _flashinfer_runner(inputs, args, output, final_state, variant)
+        else:
+            runner = _external_runner(backend, inputs, args, output, final_state)
+        if runner is None:
+            continue
+
+        # Warm up outside the timed region: the first call compiles, builds
+        # descriptors and reads the offsets on the host, none of which a
+        # steady-state call repeats.
+        try:
+            if initial_state_snapshot is not None:
+                inputs["initial_state"].copy_(initial_state_snapshot)
+            runner()
+            torch.cuda.synchronize()
+        except Exception as exc:  # noqa: BLE001 -- reported and skipped
+            print(f"[ERROR] backend {backend} failed to run: {exc}")
+            continue
+
+        outputs[backend] = output.clone()
+        if initial_state_snapshot is not None:
+            inputs["initial_state"].copy_(initial_state_snapshot)
+        backend_times[backend] = bench_gpu_time(
+            fn=runner,
+            dry_run_iters=args.dry_run_iters,
+            repeat_iters=args.num_iters,
+            enable_cupti=args.use_cupti,
+            # CUDA-event timing, not graph-replay timing, and not because graphs
+            # do not work here -- they do, and the test suite captures every
+            # published combination. They need a protocol this harness cannot
+            # follow: a caller-owned RecurrentKDAPrefillWorkspace, warmed
+            # eagerly on the *capture* stream with the exact tensors, then a
+            # sync before capture. ``bench_gpu_time`` owns the stream and warms
+            # on its own, so a capture from here starts cold on a stream the
+            # backend has never seen, and the first thing it needs is an
+            # allocation. Timing the eager path is the honest measurement of
+            # what this harness is actually able to set up.
+            use_cuda_graph=False,
+        )
+
+    if run_refcheck and reference_output is not None:
+        rtol, atol = 1e-2, 1e-2
+        for backend, tested in outputs.items():
+            (
+                num_different_elements,
+                num_elements,
+                num_different_elements_percentage,
+            ) = is_close_stats(
+                reference_output.float(), tested.float(), rtol=rtol, atol=atol
+            )
+            mismatch_threshold_pct = 0.01
+            if num_different_elements_percentage > mismatch_threshold_pct:
+                print(
+                    f"[ERROR] Output tensor mismatch from backend {backend}: "
+                    f"{num_different_elements}/{num_elements} "
+                    f"({num_different_elements_percentage:.4f}%) elements differ "
+                    f"(threshold: {mismatch_threshold_pct}%)"
+                )
+                if not args.allow_output_mismatch:
+                    raise AssertionError(
+                        f"[ERROR] Backend {backend} output mismatch with "
+                        f"{num_different_elements} elements"
+                    )
+            elif args.verbose >= 1:
+                print(f"[REFCHECK] Backend {backend}: PASSED")
+
+    problem_flops = kda_prefill_flops(total_tokens, num_heads, head_size)
+    problem_bytes = kda_prefill_bytes(
+        total_tokens,
+        num_seqs,
+        num_heads,
+        head_size,
+        input_dtype,
+        inputs["initial_state"] is not None,
+        output_final_state,
+    )
+
+    for backend in backends:
+        if len(backend_times[backend]) == 0:
+            continue
+        median_time = np.median(backend_times[backend])
+        std_time = np.std(backend_times[backend])
+        tflops = problem_flops / (10**9 * median_time)
+        tb_per_sec = problem_bytes / (10**9 * median_time)
+
+        print_perf_metrics(backend, median_time, std_time, tflops, tb_per_sec)
+
+        if args.output_path is not None:
+            cur_res = defaultdict(str)
+            cur_res["routine"] = args.routine
+            cur_res["median_time"] = median_time
+            cur_res["std_time"] = std_time
+            cur_res["tflops"] = tflops
+            cur_res["tb_per_sec"] = tb_per_sec
+            cur_res["backend"] = backend
+            cur_res["batch_size"] = num_seqs
+            cur_res["s_qo"] = seq_len
+            cur_res["num_q_heads"] = num_heads
+            cur_res["head_size"] = head_size
+            cur_res["input_dtype"] = str(input_dtype)
+            cur_res["state_dtype"] = args.state_dtype
+            cur_res["packed"] = args.packed
+            cur_res["has_initial_state"] = args.has_initial_state
+            cur_res["kda_variant"] = (
+                selected_variant if backend == "flashinfer" else backend
+            )
+            cur_res["kda_variant_policy"] = policy_source
+            cur_res["sm_count"] = sm_count
+            cur_res["case_tag"] = args.case_tag
+            res.append(cur_res)
+    return res

--- a/docs/api/kda.rst
+++ b/docs/api/kda.rst
@@ -6,7 +6,11 @@ flashinfer.kda
 Phase-neutral recurrent Kimi Delta Attention (KDA) facade. The public
 ``recurrent_kda`` entry point keeps decode and speculative decode on
 ``flashinfer.kda_decode`` while dispatching eligible ordinary multi-token
-prefill to the optimized backend described in :ref:`apikda_prefill`.
+prefill to the optimized backend described in :ref:`apikda_prefill`. Which
+prefill backend that is depends on the device: SM100a and SM103a use the frozen
+FlashKDA-compatible kernels, SM120a uses a CuTe-DSL backend of its own. The two
+architecture sets are disjoint, so the public signature and every call outside
+the eligible prefill subset are unaffected either way.
 
 .. currentmodule:: flashinfer.kda
 

--- a/docs/api/kda_prefill.rst
+++ b/docs/api/kda_prefill.rst
@@ -194,3 +194,132 @@ directly in place by the frozen kernel. Head counts that are not divisible by
 eight capture the beta copy into workspace-owned storage padded to the next
 eight-head boundary before the frozen launch. The public beta and state shapes
 keep the caller's original head count.
+
+SM120a prefill subset
+---------------------
+
+Compute capability 12.0 devices select their own prefill backend,
+``flashinfer.kda_kernels.sm120_prefill``. It is CuTe DSL like the BT=16 backend
+above and shares no code and no device with it, nor with Cake: those two are
+CC 10.0 and 10.3 and this one is CC 12.0, so at most one of the three can be
+eligible for any call, and adding this one cannot change which kernel an SM100
+or SM103 call receives. Nothing about the public API changes — the entry point
+is still :func:`flashinfer.kda.recurrent_kda`, and no argument names the
+architecture.
+
+``backend`` selects an implementation family, not an architecture name. On a
+CC 12.0 device both ``"auto"`` and ``"cute-dsl"`` may reach this backend; the
+dispatcher tries it before the SM100-family CuTe DSL prefill path. An explicit
+``"cake"`` request never probes or runs SM120. If the Cake prefill predicate
+does not support that ordinary multi-token prefill call, the request is
+refused rather than silently executed by another backend.
+
+``recurrent_kda`` uses it only when every condition below holds:
+
+* the device has compute capability 12.0, *and* the installed CuTe DSL and
+  CUDA toolkit can natively target ``sm_120a``. A family-conditional fallback
+  target is refused rather than accepted, because the kernels are written
+  against architecture-specific instructions;
+* input is ordinary multi-token prefill: fixed ``T > 1``, or packed input
+  whose total token count exceeds its number of sequences;
+* Q, K, V and G are contiguous BF16 ``[B,T,H,128]`` tensors sharing one head
+  count, and beta is contiguous BF16 ``[B,T,H]``. GQA and ``V != K`` are not
+  supported;
+* the output fits an INT32 extent: ``T_total * H * 128 <= 2**31 - 1``, which is
+  16383 tokens at H=1024 and no constraint at ordinary head counts. Larger is
+  refused with the backend's own error, because the two things that stop there
+  — a device index built in INT32, and the DSL packing a memref extent as one —
+  otherwise fail as a silent negative offset and as a compile-time overflow
+  naming no tensor;
+* ``A_log`` is contiguous FP32 ``[H]``, and ``dt_bias`` is contiguous FP32
+  ``[H,128]`` or flattened ``[H*128]``;
+* ``use_qk_l2norm_in_kernel=True``, ``use_gate_in_kernel=True``,
+  ``beta_is_logit=True``, and ``lower_bound`` is in ``[-5.0, 0.0)``. The bound
+  exists because the safe gate's worst-case chunk prefix reaches a reciprocal
+  approximation's cliff at about ``-5.4585``;
+* ``initial_state``, if given, is a contiguous BF16 ``[N,H,128,128]`` tensor.
+  A state pool with ``ssm_state_indices`` is not supported;
+* ``output``, if given, is contiguous BF16 with V's shape and does not overlap
+  any input in GMEM;
+* speculative decode, ``seq_order``, prefill checkpoints, committed-state
+  sources and FP32 gate or state are not enabled.
+
+Under ``backend="auto"``, calls outside that subset continue through the
+existing dispatcher. An explicit ``backend="cute-dsl"`` ordinary multi-token
+prefill request is refused when neither CuTe DSL prefill implementation is
+eligible. T=1 decode and speculative decode are not rerouted by this backend.
+
+Two variants, chosen per shape
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The backend has two implementations of the same contract. ``decomp`` runs a
+chunk-parallel prepare and a serial recurrence, issued through one compiled
+host entry; ``fused`` does both in a single kernel. They agree numerically, so
+the choice between them is a performance one and is made from a measured
+table keyed on the device's SM count — not on its name, which is not a stable
+unique selector.
+
+Thresholds exist for the 110-SM, 156-SM and 188-SM parts, measured on each.
+They do not agree: the 110-SM part switches to the fused kernel at CTA 128 and
+the other two at 144, because at CTA 128 with short sequences the larger parts
+still prefer the decomposed kernel and the smallest one does not. Any other
+CC 12.0 device uses the 156-SM thresholds as a labelled fallback. A benchmark
+run reports which case applies, so a number taken on an unprofiled card cannot
+be read as tuned.
+
+State and graph semantics
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+State semantics match the SM100-family path: a supplied ``initial_state`` is
+updated in place whether or not ``output_final_state`` is set, and the second
+return value is ``None`` when it is not set. Without an initial state, a BF16
+final state is allocated only when ``output_final_state=True``.
+
+CUDA graph capture requires a caller-owned ``RecurrentKDAPrefillWorkspace`` and
+a preallocated ``output``, warmed eagerly on the capture stream with the exact
+tensors and then synchronized before capture. The warm call is where every
+compile, descriptor build, metadata table and allocation happens; capture
+performs none of them and a cold capture is refused rather than silently
+degraded. Both offsets dtypes are accepted for packed capture; eager warmup
+populates a workspace-owned canonical int32 buffer. The offset *values* must
+stay fixed for the graph's lifetime. Changing them requires a fresh eager
+warmup and capture. Q, K, V, G, beta and state contents may change freely at
+unchanged addresses.
+
+The offsets contract is not only a capture one. Validating ``cu_seqlens``
+needs a device-to-host read, so what is derived from it — the sequence
+lengths, the canonical int32 copy, and the decomposed variant's chunk tables —
+is cached against the tensor's address and version counter rather than read
+again on every call. Under ``torch.inference_mode`` a tensor has no version
+counter, so refilling an offsets buffer in place with a different segmentation
+is not detectable and the stale tables are reused, silently computing against
+the previous sequence boundaries. Use a different tensor for a different
+segmentation, or call
+``flashinfer.kda_kernels.sm120_prefill.clear_kda_prefill_sm120_caches()``
+after refilling one in place. This applies to eager calls as much as to
+captured ones.
+
+A workspace binds to one variant, one stream and one call signature on first
+use, and once it has participated in a capture it cannot be used again.
+
+What the caches hold
+~~~~~~~~~~~~~~~~~~~~
+
+A warm call is a memo lookup, and the memo addresses the caller's buffers: the
+descriptors carry their base addresses and the flat views wrap them. Those
+buffers therefore stay allocated for as long as the entry lives, which is what
+makes reusing the entry safe — an allocator that had recycled the address would
+otherwise hand the kernel someone else's memory.
+
+The retention scales with the number of *distinct buffer sets* a process
+rotates through, not with the number of calls. On a 110-SM part at
+``[1, 1024, 8, 128]`` one set holds about 14.5 MiB, and eight rotating sets
+about 73 MiB. Reuse one set and it stays at one set's worth forever.
+
+The entry ceilings are not a memory budget and lowering them does not trade
+speed for memory: below the ceiling the retention is the same whatever the
+ceiling is, and above it every call rebuilds its plan — about 7.3 ms against a
+100 microsecond hit on that part. A deployment that needs the memory back
+should rotate fewer buffer sets, or call
+``flashinfer.kda_kernels.sm120_prefill.clear_kda_prefill_sm120_caches()``,
+which releases all of it.

--- a/flashinfer/kda.py
+++ b/flashinfer/kda.py
@@ -34,6 +34,7 @@ from . import kda_prefill as _kda_prefill
 from . import kda_prefill_cute as _kda_prefill_cute
 from .api_logging import flashinfer_api
 from .trace.templates.kda import recurrent_kda_trace
+from .utils import get_compute_capability
 
 
 @flashinfer_api(trace=recurrent_kda_trace)
@@ -75,11 +76,12 @@ def recurrent_kda(
     This is the public API layer for the CuTe DSL implementation in
     ``flashinfer.kda_kernels.recurrent_kda``. It supports single-token decode,
     fused speculative decode, GQA, optional cu_seqlens packing, and the same
-    gate modes as the backend implementation. On SM100a (B200/GB200) and
-    SM103a (B300/GB300), the FlashKDA-compatible subset of ordinary multi-token
-    prefill can use either the frozen Cake schedules or the source-level CuTe
-    DSL BT=16 kernel. ``backend="auto"`` prefers CuTe DSL for supported plain
-    prefill contracts and keeps Cake as the feature-complete fallback.
+    gate modes as the backend implementation. On SM120a, eligible ordinary
+    multi-token prefill uses the architecture-specific CuTe DSL backend. On
+    SM100a (B200/GB200) and SM103a (B300/GB300), the FlashKDA-compatible subset
+    can use either the frozen Cake schedules or the source-level CuTe DSL BT=16
+    kernel. ``backend="auto"`` prefers CuTe DSL for supported plain prefill
+    contracts and keeps Cake as the feature-complete fallback.
 
     Args:
         q (torch.Tensor):
@@ -186,7 +188,7 @@ def recurrent_kda(
             bins.
             Fixed-layout prefill and decode calls must leave it as ``None``.
         prefill_workspace (Optional[RecurrentKDAPrefillWorkspace]):
-            Caller-owned workspace for SM100-family prefill backends.
+            Caller-owned workspace for SM100-family and SM120 prefill backends.
             It is optional for eager execution and required for CUDA graph
             capture. Warm it eagerly with the exact tensors on the capture
             stream before capture. Use one workspace per captured
@@ -207,10 +209,11 @@ def recurrent_kda(
             must be divisible by 32. SGLang normally uses 64 or a larger
             cache-page-aligned multiple.
         backend (Literal["auto", "cute-dsl", "cake"]):
-            Implementation backend. ``"auto"`` selects the ported BT=16
-            CuTe DSL kernel for supported ordinary multi-token prefill,
-            including state checkpoints, and otherwise falls back to an
-            exported frozen Cake specialization.
+            Implementation backend. ``"auto"`` selects the architecture-
+            appropriate CuTe DSL kernel for supported ordinary multi-token
+            prefill, including the SM120 backend and SM100-family state
+            checkpoints, and otherwise falls back to an exported frozen Cake
+            specialization.
             ``"cake"`` and ``"cute-dsl"`` select those backends strictly.
 
     Returns:
@@ -228,6 +231,71 @@ def recurrent_kda(
         raise ValueError(
             f"backend must be 'auto', 'cute-dsl', or 'cake', got {backend!r}"
         )
+
+    # SM120 is an architecture-specific CuTe DSL implementation. Try it before
+    # the SM100-family CuTe DSL path, whose eligibility check rejects SM120.
+    sm120_rejection: Optional[str] = None
+    if backend in ("auto", "cute-dsl"):
+        sm120_prefill_kwargs = dict(
+            q=q,
+            k=k,
+            v=v,
+            g=g,
+            beta=beta,
+            A_log=A_log,
+            dt_bias=dt_bias,
+            scale=scale,
+            initial_state=initial_state,
+            use_qk_l2norm_in_kernel=use_qk_l2norm_in_kernel,
+            use_gate_in_kernel=use_gate_in_kernel,
+            lower_bound=lower_bound,
+            cu_seqlens=cu_seqlens,
+            ssm_state_indices=ssm_state_indices,
+            num_spec_tokens=num_spec_tokens,
+            num_accepted_tokens=num_accepted_tokens,
+            output=output,
+            initial_state_source=initial_state_source,
+            initial_state_indices=initial_state_indices,
+            beta_is_logit=beta_is_logit,
+            seq_order=seq_order,
+            prefill_workspace=prefill_workspace,
+            state_checkpoints=state_checkpoints,
+            checkpoint_cu_starts=checkpoint_cu_starts,
+            checkpoint_every_n_tokens=checkpoint_every_n_tokens,
+        )
+        if _kda_prefill._sm120_kda_prefill_is_eligible(**sm120_prefill_kwargs):
+            assert A_log is not None
+            assert dt_bias is not None
+            assert lower_bound is not None
+            return _kda_prefill._run_sm120_kda_prefill(
+                q=q,
+                k=k,
+                v=v,
+                g=g,
+                beta=beta,
+                A_log=A_log,
+                dt_bias=dt_bias,
+                scale=scale,
+                initial_state=initial_state,
+                output_final_state=output_final_state,
+                lower_bound=lower_bound,
+                cu_seqlens=cu_seqlens,
+                output=output,
+                prefill_workspace=prefill_workspace,
+            )
+        if (
+            backend == "cute-dsl"
+            and q.is_cuda
+            and get_compute_capability(q.device) == (12, 0)
+        ):
+            # Recorded, not raised: a decode or any other call this backend does
+            # not take must keep falling through exactly as before.  It is used
+            # only where the CC 10.0/10.3 block already refuses an explicit
+            # request, which on this architecture can only answer with the
+            # contract when the reason is known right here.
+            sm120_rejection = _kda_prefill._sm120_kda_prefill_rejection_reason(
+                **sm120_prefill_kwargs
+            )
 
     is_plain_prefill = _kda_prefill._is_plain_multi_token_prefill(
         q, cu_seqlens, num_spec_tokens
@@ -263,6 +331,10 @@ def recurrent_kda(
             raise ValueError(
                 "backend='cute-dsl' does not support this recurrent_kda "
                 "prefill contract"
+                if sm120_rejection is None
+                else "backend='cute-dsl' selects the SM120 prefill backend on "
+                "a CC 12.0 device, and it does not support this call: "
+                + sm120_rejection
             )
         if cute_dsl_eligible:
             assert A_log is not None
@@ -362,7 +434,7 @@ def recurrent_kda(
     if prefill_workspace is not None:
         raise ValueError(
             "prefill_workspace is only supported by eligible ordinary "
-            "SM100-family prefill backends"
+            "multi-token prefill backends"
         )
     if seq_order is not None:
         raise ValueError(
@@ -400,6 +472,11 @@ def recurrent_kda(
 
 class RecurrentKDAPrefillWrapper:
     """Plan-and-run wrapper for packed recurrent-KDA prefill.
+
+    Compute capability 10.0 and 10.3 only.  ``run`` forces ``backend="cute-dsl"``
+    and always passes the ``seq_order`` it planned, and the CC 12.0 backend
+    supports neither, so a CC 12.0 caller should use
+    :func:`flashinfer.kda.recurrent_kda` directly.
 
     ``plan`` runs outside CUDA Graph capture.  It reads ``cu_seqlens`` on the
     host, builds a stable descending-length sequence order and cumulative chunk

--- a/flashinfer/kda_kernels/__init__.py
+++ b/flashinfer/kda_kernels/__init__.py
@@ -26,7 +26,10 @@ Exported:
 - run_recurrent_kda: Recurrent KDA standard decode and speculative decode backend
 - run_fused_kda_decode: Fused Kimi K3 conv, recurrent KDA, and RMSNorm backend
 - run_packed_kda_decode: Packed Kimi K3 T=1 recurrent decode backend
+- run_kda_prefill_sm120: SM120a ordinary multi-token prefill backend
 """
+
+from typing import Optional
 
 import torch as _torch
 
@@ -66,11 +69,45 @@ except (ImportError, RuntimeError):
     run_recurrent_kda = None  # type: ignore
     recurrent_kda = None  # type: ignore
 
+# SM120a ordinary multi-token prefill. Optional in exactly the same way as the
+# CuTe DSL decode backend above: a CPU-only import, an SM100 box, or a missing
+# CuTe DSL leaves the three symbols ``None`` and the dispatcher falls through to
+# the existing backends.
+#
+# Only ImportError and RuntimeError are caught. A SyntaxError, AttributeError or
+# AssertionError from inside the package is a defect in this repository, and
+# swallowing it here would disguise a broken backend as an unavailable one --
+# the failure would then surface as "SM120 prefill silently never selected",
+# which is far harder to diagnose than the traceback.
+#
+# The original exception is kept: eligibility returns False without it, but a
+# caller who reaches ``_run_sm120_kda_prefill`` gets a clear error chained to
+# the real cause rather than a bare "unavailable".
+_kda_sm120_import_error: Optional[BaseException] = None
+
+try:
+    from .sm120_prefill import (
+        can_implement_kda_prefill_sm120,
+        clear_kda_prefill_sm120_caches,
+        run_kda_prefill_sm120,
+    )
+
+    _has_kda_prefill_sm120 = True
+except (ImportError, RuntimeError) as _kda_sm120_error:  # pragma: no cover
+    _kda_sm120_import_error = _kda_sm120_error
+    _has_kda_prefill_sm120 = False
+    can_implement_kda_prefill_sm120 = None  # type: ignore
+    clear_kda_prefill_sm120_caches = None  # type: ignore
+    run_kda_prefill_sm120 = None  # type: ignore
+
 __all__ = [
+    "can_implement_kda_prefill_sm120",
+    "clear_kda_prefill_sm120_caches",
     "fused_kda_decode",
     "packed_kda_decode",
     "recurrent_kda",
     "run_fused_kda_decode",
+    "run_kda_prefill_sm120",
     "run_packed_kda_decode",
     "run_recurrent_kda",
 ]

--- a/flashinfer/kda_kernels/sm120_prefill/__init__.py
+++ b/flashinfer/kda_kernels/sm120_prefill/__init__.py
@@ -1,0 +1,722 @@
+# Copyright (c) 2025 by FlashInfer team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""SM120 KDA prefill: the stable internal entry point, and the variant choice.
+
+This is a facade with no compilation side effects.  Importing it -- on a CPU,
+on an SM100 box, or with the optional CuTe DSL stack missing -- loads no device
+code and builds nothing.  The device modules are imported only once a call has
+been validated and a variant chosen, which is what makes
+``import flashinfer`` free for a caller that never runs KDA prefill on SM120.
+
+Three names leave this package::
+
+    can_implement_kda_prefill_sm120   fail-closed predicate, no side effects
+    run_kda_prefill_sm120             the call
+    clear_kda_prefill_sm120_caches    drop everything both variants hold
+
+``flashinfer/kda_prefill.py`` reaches them through
+:mod:`flashinfer.kda_kernels`, never by importing this package directly, and
+nothing outside FlashInfer is expected to import it at all: the public entry
+point is :func:`flashinfer.recurrent_kda`.  There is no ``sm120`` in any public
+name -- the architecture appears in module paths, in the guard, and in the
+compile cache key, and nowhere a caller has to type.
+
+Two variants implement the same contract:
+
+``decomp``
+    a chunk-parallel prepare and a serial recurrence, issued through one
+    compiled host entry.
+
+``fused``
+    one kernel that does both.
+
+They agree numerically -- on the 67-shape suite they match to the last bit on
+20 of 24 tail cells -- so the choice between them is a performance one, and
+:func:`choose_variant` makes it from a measured table rather than a formula.
+"""
+
+from __future__ import annotations
+
+import functools
+import threading
+import weakref
+from collections import OrderedDict
+from typing import TYPE_CHECKING, Any, NamedTuple, Optional
+
+import torch
+
+from .runtime import (
+    DK,
+    DV,
+    LOWER_BOUND_RANGE,
+    SM120_CAPABILITY,
+    KDAPrefillValidationError,
+    SM120PrefillResources,
+    UnsupportedArchitectureError,
+    canonical_offsets,
+    current_stream_ptr,
+    resource_cache_token,
+    sm120a_available,
+    tensor_identity,
+    tensor_layout_identity,
+    validate_inputs,
+)
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from .runtime import CanonicalInputs
+
+__all__ = [
+    "can_implement_kda_prefill_sm120",
+    "clear_kda_prefill_sm120_caches",
+    "run_kda_prefill_sm120",
+]
+
+#: The variants :func:`run_kda_prefill_sm120` can dispatch to.  ``"auto"``
+#: resolves to one of the other two before anything is launched.
+VARIANTS = ("decomp", "fused", "auto")
+
+DEFAULT_VARIANT = "auto"
+
+
+# ---------------------------------------------------------------------------
+# Variant choice.
+#
+# Deliberately a table rather than a formula.  The obvious formula -- scale the
+# CTA term by SM count -- is an untested assumption: it presumes the crossover
+# is set purely by how many waves the grid takes, when the measured data also
+# turns on H and T, which have nothing to do with SM count.
+#
+# **Keyed on SM count, not on the device name.**  A name is not a stable unique
+# selector and can collide across devices.  SM count is also the better key on
+# the merits -- the CTA term is a statement about a grid against the machine's
+# width.
+# ---------------------------------------------------------------------------
+
+
+class AutoProfile(NamedTuple):
+    """Thresholds for one device.  See :data:`AUTO_PROFILES`."""
+
+    #: Heads at or above which the fused variant wins regardless of T, or
+    #: ``None`` where the measured data needs no such term.  ``None`` means
+    #: "not used", where a large int would read as a threshold someone
+    #: measured.
+    heads: Optional[int]
+    #: Per-sequence length at or below which it wins regardless of H.
+    tokens: Optional[int]
+    #: Decomp CTA count (``2 * batch * heads``) at or above which it wins.
+    ctas: Optional[int]
+    #: Human name for the device, for reporting.  Not used for matching.
+    device: str
+    #: Where the numbers came from, printed by :func:`describe_variant_policy`.
+    source: str
+
+
+AUTO_PROFILES: dict[int, AutoProfile] = {
+    # Each row is fitted independently. The 156-SM and 188-SM sweeps both place
+    # the crossover at T <= 32 or CTA >= 144; keeping two rows records that both
+    # devices were measured rather than treating one as an inferred fallback.
+    156: AutoProfile(
+        heads=None,
+        tokens=32,
+        ctas=144,
+        device="156-SM SM120 part",
+        source="147-shape fit, 156 SMs",
+    ),
+    188: AutoProfile(
+        heads=None,
+        tokens=32,
+        ctas=144,
+        device="188-SM SM120 part",
+        source="147-shape fit, 188 SMs",
+    ),
+    # The 110-SM fit crosses one measured CTA step earlier.
+    110: AutoProfile(
+        heads=None,
+        tokens=32,
+        ctas=128,
+        device="110-SM SM120 part",
+        source="67-shape sweep + FlashInfer's twelve, 74 shapes, 110 SMs",
+    ),
+}
+
+#: Used for any CC 12.0 device without a row above.
+#:
+#: A fallback, not a claim.  These are the only thresholds anyone has measured,
+#: so they are better than a guess and worse than a measurement;
+#: :func:`describe_variant_policy` says which case a given machine is in, so a
+#: number taken on an unprofiled card cannot quietly be read as tuned.
+FALLBACK_AUTO_PROFILE = 156
+
+
+def _device_index(device) -> Optional[int]:
+    """``device``'s index, the current device's, or ``None`` without a driver.
+
+    Resolved here rather than inside :func:`_sm_count`, which is keyed on what
+    it is handed: caching "whichever device happened to be current the first
+    time" under a ``None`` key would keep answering for that one after a
+    ``set_device``.
+    """
+    if isinstance(device, int):
+        return device
+    if device is not None:
+        index = torch.device(device).index
+        if index is not None:
+            return index
+    try:
+        return torch.cuda.current_device()
+    except Exception:  # noqa: BLE001 -- an absent driver is not an error here
+        return None
+
+
+@functools.lru_cache(maxsize=8)
+def _sm_count(index: Optional[int]) -> int:
+    """That device's SM count, asked once per device.
+
+    ``get_device_properties`` is a driver query, and a device's SM count cannot
+    change under a live process -- so asking per call is measurable overhead on
+    a path that runs before every launch.  ``-1`` on a host with no driver,
+    which is what keeps the host-only selector tests working.
+
+    The index is the input's device, not device 0.  A host can hold two CC 12.0
+    parts with different SM counts, and the rows of the table above disagree
+    between them -- reading device 0 would apply the 110-SM thresholds to every
+    call on a 188-SM card, and nothing in the output would say so.
+    """
+    if index is None:
+        return -1
+    try:
+        return torch.cuda.get_device_properties(index).multi_processor_count
+    except Exception:  # noqa: BLE001 -- an absent driver is not an error here
+        return -1
+
+
+def auto_profile(
+    sm_count: Optional[int] = None, device=None
+) -> tuple[int, AutoProfile]:
+    """``(profile_key, profile)`` for a device, falling back where unmeasured.
+
+    ``sm_count`` defaults to ``device``'s and ``device`` to the current one; on
+    a host without either the fallback is returned, which is what keeps the
+    host-only tests from needing a driver.
+    """
+    if sm_count is None:
+        sm_count = _sm_count(_device_index(device))
+    if sm_count in AUTO_PROFILES:
+        return sm_count, AUTO_PROFILES[sm_count]
+    return FALLBACK_AUTO_PROFILE, AUTO_PROFILES[FALLBACK_AUTO_PROFILE]
+
+
+def describe_variant_policy(sm_count: Optional[int] = None, device=None) -> str:
+    """One line naming the thresholds in force and whether this device set them.
+
+    Print it in any report that quotes a time from ``auto``: a number taken
+    under fallback thresholds is not a number taken under tuned ones, and
+    nothing else in the output distinguishes them.
+    """
+    name = "<no CUDA device>"
+    if sm_count is None:
+        index = _device_index(device)
+        try:
+            name = torch.cuda.get_device_properties(index).name
+            sm_count = _sm_count(index)
+        except Exception:  # noqa: BLE001
+            sm_count = -1
+    else:
+        name = "<given>"
+    key, profile = auto_profile(sm_count)
+    tuned = key == sm_count
+    device_name = f"{name}, {sm_count} SMs" if sm_count > 0 else name
+    terms = []
+    if profile.heads is not None:
+        terms.append(f"H>={profile.heads}")
+    if profile.tokens is not None:
+        terms.append(f"T<={profile.tokens}")
+    if profile.ctas is not None:
+        terms.append(f"CTA>={profile.ctas}")
+    provenance = (
+        "measured on this device"
+        if tuned
+        else f"FALLBACK from the {key}-SM {profile.device}"
+    )
+    return (
+        f"variant=auto on {device_name!r}: {' or '.join(terms)} -> fused  "
+        f"[{provenance}; {profile.source}]"
+    )
+
+
+def choose_variant(
+    batch: int,
+    heads: int,
+    tokens: int,
+    sm_count: Optional[int] = None,
+    device=None,
+) -> str:
+    """Which variant the measured table says is faster for this shape.
+
+    ``tokens`` is the per-sequence length, not the packed total: the table was
+    measured on equal-length sequences and the CTA count is what varies with
+    ``batch``.  For a ragged batch the caller passes the *longest* sequence --
+    the recurrence is serial within a sequence, so the longest one sets the
+    critical path, and a batch containing a 130 behaves like a 130 rather than
+    like the 27 its lengths average to.
+
+    Returns ``"decomp"`` or ``"fused"``, never ``"auto"``.
+    """
+    _, profile = auto_profile(sm_count, device)
+    # The recurrence issues one CTA per (sequence, DV half), so the decomp grid
+    # is twice batch*heads.  The fused kernel issues one per (sequence, head);
+    # both grow the same way, and the threshold is expressed in the decomp
+    # units the sweep tabulated.
+    ctas = 2 * batch * heads
+    # A ``None`` threshold is a condition this device's data did not need, not
+    # a condition that is always true.
+    if profile.heads is not None and heads >= profile.heads:
+        return "fused"
+    if profile.tokens is not None and tokens <= profile.tokens:
+        return "fused"
+    if profile.ctas is not None and ctas >= profile.ctas:
+        return "fused"
+    return "decomp"
+
+
+# ---------------------------------------------------------------------------
+# Lazy variant import.
+#
+# Nothing above this line touches the CuTe DSL.  The import below is the first
+# thing that does, and it happens only after a call has been validated and a
+# variant chosen -- so a process that imports FlashInfer and never runs SM120
+# KDA prefill never pays for it, and a CPU-only import cannot fail here.
+# ---------------------------------------------------------------------------
+
+_MODULES: dict[str, Any] = {}
+_MODULES_LOCK = threading.RLock()
+
+
+def _variant_module(name: str):
+    module = _MODULES.get(name)
+    if module is not None:
+        return module
+    with _MODULES_LOCK:
+        module = _MODULES.get(name)
+        if module is None:
+            if name == "decomp":
+                from . import decomp  # noqa: PLC0415
+
+                module = decomp
+            elif name == "fused":
+                from . import fused  # noqa: PLC0415
+
+                module = fused
+            else:
+                raise ValueError(
+                    f"unknown variant {name!r}; expected one of {VARIANTS}"
+                )
+            _MODULES[name] = module
+    return module
+
+
+# ---------------------------------------------------------------------------
+# The backend ABI.
+# ---------------------------------------------------------------------------
+
+
+def can_implement_kda_prefill_sm120(**kwargs) -> bool:
+    """Can this backend run this call?  Fail-closed, and free of side effects.
+
+    Allocates nothing, launches nothing, compiles nothing and does not
+    synchronize, so the public dispatcher can call it on every request.  The
+    structural argument checks belong to ``flashinfer/kda_prefill.py`` and have
+    already run by the time this is reached; what is decided here is the one
+    question that needs this package: whether the device is CC 12.0 *and* the
+    installed CuTe DSL and CUDA toolkit can natively build ``sm_120a``.
+
+    Both variants share that gate.  A device where only a family-conditional
+    target is available is refused outright rather than allowed to run one
+    variant at a target the other cannot use.
+    """
+    q = kwargs.get("q")
+    if not isinstance(q, torch.Tensor) or not q.is_cuda:
+        return False
+    return sm120a_available(q.device)
+
+
+def run_kda_prefill_sm120(
+    *,
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor,
+    beta: torch.Tensor,
+    A_log: torch.Tensor,
+    dt_bias: torch.Tensor,
+    scale: Optional[float] = None,
+    lower_bound: float,
+    initial_state: Optional[torch.Tensor] = None,
+    final_state: Optional[torch.Tensor] = None,
+    cu_seqlens: Optional[torch.Tensor] = None,
+    output: Optional[torch.Tensor] = None,
+    variant: str = DEFAULT_VARIANT,
+    safe_gate: bool = True,
+    resources: Optional[SM120PrefillResources] = None,
+) -> tuple[torch.Tensor, Optional[torch.Tensor]]:
+    """Run SM120 KDA prefill and return ``(output, final_state)``.
+
+    This is the *backend* ABI, and it deliberately is not the public one.
+    ``initial_state`` is read-only and ``final_state`` is written; passing the
+    same tensor as both is the exact alias the kernels' schedules prove safe,
+    and passing ``final_state=None`` means "do not store a state at all", which
+    the kernels implement by skipping the store rather than by writing a buffer
+    nobody asked for.
+
+    The public contract -- where a supplied ``initial_state`` is updated in
+    place whether or not the caller asked for a final state -- is one level up,
+    in ``flashinfer/kda_prefill.py``.  Keeping the split here is what lets a
+    cross-implementation A/B compare like with like: the comparison path has
+    exactly this ABI, so a harness can hand both paths the same two tensors and
+    a difference in the result is a difference in the kernels.
+
+    ``resources`` is the SM120 half of a caller-owned
+    :class:`~flashinfer.kda_prefill.RecurrentKDAPrefillWorkspace`.  Passing one
+    is what makes CUDA graph capture possible: it gives the canonical metadata,
+    the scratch and the descriptors a lifetime that outlives this module's
+    caches, which replay needs because it never re-enters Python.
+    """
+    if variant not in VARIANTS:
+        raise ValueError(f"variant must be one of {VARIANTS}, got {variant!r}")
+
+    out = output if output is not None else torch.empty_like(v)
+    resolved_scale = float(scale) if scale is not None else DK**-0.5
+
+    tensors = (
+        q,
+        k,
+        v,
+        g,
+        beta,
+        out,
+        A_log,
+        dt_bias,
+        initial_state,
+        final_state,
+        cu_seqlens,
+    )
+    scalars = (resolved_scale, float(lower_bound), variant, bool(safe_gate))
+
+    resolved = _resolved_call(q.device, tensors, scalars, resources)
+    if resolved is not None:
+        # The whole host path already ran for these exact tensors: replay the
+        # plan it produced rather than walking eleven tensors again to find it.
+        # The executor is stored already bound, so this is one call rather than
+        # a dict lookup and an attribute fetch -- which is measurable when the
+        # kernel it precedes is nine microseconds long.
+        # `bind` is not repeated here: the memo key already carries the
+        # variant, the stream and every tensor's identity, so the only state
+        # that can have changed since it was bound is capture -- which happens
+        # after a launch, not during one, and is what makes the workspace spent.
+        if resources is not None and resources.captured:
+            raise RuntimeError(
+                "this RecurrentKDAPrefillWorkspace has already participated in "
+                "a CUDA graph capture and cannot be reused; create another one"
+            )
+        execute, plan = resolved
+        execute(plan, initial_state, final_state)
+        return out, final_state
+
+    info = validate_inputs(
+        q,
+        k,
+        v,
+        g,
+        beta,
+        out,
+        A_log,
+        dt_bias,
+        scale=resolved_scale,
+        lower_bound=float(lower_bound),
+        initial_state=initial_state,
+        final_state=final_state,
+        cu_seqlens=cu_seqlens,
+    )
+    offsets = canonical_offsets(
+        cu_seqlens,
+        batch=info.batch,
+        tokens=info.tokens_per_sequence,
+        total_tokens=info.total_tokens,
+        device=q.device,
+    )
+    chosen = _resolve_variant(
+        variant, info, offsets, safe_gate, resources, device=q.device
+    )
+
+    if resources is not None:
+        # Pin the workspace to this variant, stream and shape before anything
+        # writes to it.  The state machine has been here since the backend
+        # landed and nothing called it, so every constraint it encodes was
+        # unenforced: a workspace already spent on a capture could be driven
+        # again from eager Python, and one workspace could be shared across two
+        # streams or two variants with the second silently overwriting scratch
+        # the first had not finished reading.
+        resources.bind(
+            variant=chosen,
+            stream_ptr=current_stream_ptr(q.device),
+            signature=(
+                tuple(tensor_layout_identity(t) for t in tensors),
+                (resolved_scale, float(lower_bound), bool(safe_gate)),
+            ),
+        )
+
+    module = _variant_module(chosen)
+    plan = module.run(
+        q=q,
+        k=k,
+        v=v,
+        g=g,
+        beta=beta,
+        out=out,
+        A_log=A_log,
+        dt_bias=dt_bias,
+        scale=resolved_scale,
+        lower_bound=float(lower_bound),
+        initial_state=initial_state,
+        final_state=final_state,
+        cu_seqlens=cu_seqlens,
+        info=info,
+        offsets=offsets,
+        resources=resources,
+        safe_gate=safe_gate,
+    )
+    _remember_call(q.device, tensors, scalars, resources, (module.execute, plan))
+    return out, final_state
+
+
+# ---------------------------------------------------------------------------
+# The facade's own fast path.
+#
+# Validation, offset canonicalization and the variant choice are all pure
+# functions of the tensors' addresses, shapes, dtypes and versions plus the
+# scalars -- and all three are expensive enough to matter. Measured on this
+# backend before this memo existed: +0.11 ms of host time on *every* call,
+# which is invisible next to a 1 ms kernel and 12x the whole call at
+# B=1 T=16 H=4. The variants' own plan caches did not help, because this work
+# happens before they are reached.
+#
+# The three costs, in order of size:
+#
+# * ``validate_inputs`` walks eleven tensors and the full alias matrix;
+# * ``canonical_offsets`` goes through a per-device cache whose *hit* path
+#   issues ``wait_event`` and ``record_stream`` -- driver calls, not dict
+#   lookups;
+# * ``choose_variant`` asked the driver for the device's SM count once per
+#   call, which is a property that cannot change under a live process.
+#
+# The stream is in the key even though none of the three results depend on it.
+# That is deliberate: the offsets cache's ``wait_event`` is what orders a
+# consumer on a new stream against the buffer's creation, and memoizing past it
+# would skip that edge the first time a second stream appeared.
+# ---------------------------------------------------------------------------
+
+#: One entry per distinct buffer set and workspace; a serving loop needs one.
+#: Each value carries weak references to the key tensors so an allocator-reused
+#: address cannot turn a different tensor object into a stale plan hit.
+#: Its values carry the variants' plan objects, so it retains what they retain;
+#: see ``CALL_PLAN_MAX_ENTRIES`` for the measurements behind the number.
+RESOLVED_CALL_MAX_ENTRIES = 16
+
+#: Serializes the two mutating paths through ``_RESOLVED``.  Reentrant on
+#: purpose: dropping an entry releases its weak referents, and their ``_purge``
+#: callbacks run on the releasing thread and take this lock again.
+#:
+#: The ``_RESOLVED_LAST`` fast path deliberately stays outside it.  That global
+#: holds an immutable tuple, so reading it is one atomic load, and it is the
+#: path a warm serving loop takes before a nine-microsecond kernel.
+_RESOLVED_LOCK = threading.RLock()
+_RESOLVED: "OrderedDict[tuple, tuple]" = OrderedDict()
+
+#: The previous call, compared by object identity and the complete tensor
+#: identity before the key is built.  Object identity alone is insufficient:
+#: ``tensor.data = other`` keeps the Python object and can replace its storage
+#: and layout without a readable version bump under ``inference_mode``.
+_RESOLVED_LAST: Optional[tuple] = None
+
+
+def _resolved_key(device, tensors, scalars, resources) -> tuple:
+    # The stream of the *inputs'* device.  Asked with no argument the handle is
+    # the current device's, which is not the one the launch uses: a plan bakes
+    # ``torch.cuda.current_stream(q.device)`` into its argument tuple, so a
+    # process holding tensors on cuda:1 while cuda:0 is current would key two
+    # different cuda:1 streams onto one entry and reuse a plan bound to the
+    # first of them.
+    return (
+        tuple(tensor_identity(t) for t in tensors),
+        scalars,
+        resource_cache_token(resources),
+        current_stream_ptr(device),
+    )
+
+
+def _resolved_call(device, tensors, scalars, resources):
+    """The memoized ``(execute, plan)`` for this call, or ``None`` on a miss.
+
+    Written with explicit loops and early returns rather than ``all(...)`` over
+    generator expressions.  That reads worse and costs less: this runs before
+    every launch, and at the smallest supported shape the kernel it precedes is
+    nine microseconds long, so two generator frames per call are visible in a
+    paired benchmark.
+    """
+    last = _RESOLVED_LAST
+    if last is not None:
+        (
+            last_refs,
+            last_identities,
+            last_scalars,
+            last_resources,
+            last_stream,
+            value,
+        ) = last
+        if (
+            last_scalars == scalars
+            and last_resources is resource_cache_token(resources)
+            and last_stream == current_stream_ptr(device)
+        ):
+            for index, tensor in enumerate(tensors):
+                # Weak, for the same reason the LRU below is: this entry
+                # outlives the call, and eleven strong references to q, k, v, g
+                # and out would keep one whole activation set off the caching
+                # allocator until the next call replaced it.
+                ref = last_refs[index]
+                if ref is None:
+                    if tensor is not None:
+                        break
+                elif ref() is not tensor:
+                    break
+                if tensor_identity(tensor) != last_identities[index]:
+                    break
+            else:
+                return value
+
+    key = _resolved_key(device, tensors, scalars, resources)
+    with _RESOLVED_LOCK:
+        entry = _RESOLVED.get(key)
+        if entry is None:
+            return None
+
+        _token, refs, value = entry
+        for ref, tensor in zip(refs, tensors, strict=True):
+            if ref is None:
+                if tensor is not None:
+                    break
+            elif ref() is not tensor:
+                break
+        else:
+            _RESOLVED.move_to_end(key)
+            return value
+
+        # The identity key matched only because an address was recycled.
+        # Remove the stale entry now; its weakref callback may not have run.
+        _RESOLVED.pop(key, None)
+    return None
+
+
+def _remember_call(device, tensors, scalars, resources, value) -> None:
+    global _RESOLVED_LAST
+    _RESOLVED_LAST = (
+        tuple(None if t is None else weakref.ref(t) for t in tensors),
+        tuple(tensor_identity(t) for t in tensors),
+        scalars,
+        resource_cache_token(resources),
+        current_stream_ptr(device),
+        value,
+    )
+    key = _resolved_key(device, tensors, scalars, resources)
+    token = object()
+
+    def _purge(_ref, _key=key, _token=token):
+        with _RESOLVED_LOCK:
+            entry = _RESOLVED.get(_key)
+            if entry is not None and entry[0] is _token:
+                _RESOLVED.pop(_key, None)
+
+    refs = tuple(
+        None if tensor is None else weakref.ref(tensor, _purge) for tensor in tensors
+    )
+    with _RESOLVED_LOCK:
+        _RESOLVED[key] = (token, refs, value)
+        while len(_RESOLVED) > RESOLVED_CALL_MAX_ENTRIES:
+            _RESOLVED.popitem(last=False)
+
+
+def _resolve_variant(variant, info, offsets, safe_gate, resources, device=None) -> str:
+    """Turn ``"auto"`` into a concrete variant, once, and remember it.
+
+    A workspace that has already chosen keeps its choice: the selection is part
+    of the captured signature, and re-deciding it during replay is not possible
+    anyway -- replay does not run this code.  Re-deciding it between warmup and
+    capture would be worse, because it would silently record a different kernel
+    than the one the warmup proved.
+    """
+    if resources is not None and resources.variant is not None:
+        if variant != "auto" and variant != resources.variant:
+            raise KDAPrefillValidationError(
+                "RecurrentKDAPrefillWorkspace is already bound to variant "
+                f"{resources.variant!r}, so it cannot run requested variant "
+                f"{variant!r}; create a separate workspace"
+            )
+        chosen = resources.variant
+    elif variant != "auto":
+        chosen = variant
+    elif not safe_gate:
+        # Only one variant implements the unbounded gate, so the shape rule has
+        # nothing left to choose between.  Stated here rather than left to
+        # produce a confusing refusal from the decomp branch.
+        chosen = "fused"
+    else:
+        chosen = choose_variant(
+            offsets.sequences or info.batch,
+            info.heads,
+            offsets.longest_sequence if offsets.lengths else info.tokens_per_sequence,
+            device=device,
+        )
+
+    if not safe_gate and chosen == "decomp":
+        raise KDAPrefillValidationError(
+            "the decomp variant does not support safe_gate=False; pass "
+            "variant='fused' or leave it on auto"
+        )
+    return chosen
+
+
+def clear_kda_prefill_sm120_caches() -> None:
+    """Drop every cache this backend holds, in both variants and the runtime.
+
+    Only clears a variant that has actually been imported: asking for the
+    others would compile nothing but would import device modules a process may
+    have deliberately never loaded.
+
+    Deliberately does not drop graph pins.  A live CUDA graph reads its
+    captured resources at their captured addresses, and freeing those is not
+    something a cache-clear should be able to do by accident.
+    """
+    from .runtime import clear_shared_caches  # noqa: PLC0415
+
+    global _RESOLVED_LAST
+    with _RESOLVED_LOCK:
+        _RESOLVED.clear()
+    _RESOLVED_LAST = None
+    _sm_count.cache_clear()
+    with _MODULES_LOCK:
+        modules = tuple(_MODULES.values())
+    for module in modules:
+        module.clear_caches()
+    clear_shared_caches()

--- a/flashinfer/kda_kernels/sm120_prefill/decomp.py
+++ b/flashinfer/kda_kernels/sm120_prefill/decomp.py
@@ -1,0 +1,5596 @@
+# Copyright (c) 2025 - 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+
+# 1. Redistributions of source code must retain the above copyright notice, this
+# list of conditions and the following disclaimer.
+
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+
+# 3. Neither the name of the copyright holder nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+"""SM120 KDA prefill, decomposed: a chunk-parallel prepare and a serial recurrence.
+
+Two device kernels issued through one compiled host entry::
+
+    prepare
+        |-- Q/K L2 normalization
+        |-- gate activation and prefix scan
+        +-- Kd/Qd/Ak/Aq/GTotal materialization
+
+    recurrence
+        |-- consume the chunk factors
+        |-- carry a [128, 128] state in sequence order
+        |-- write the output
+        +-- update and store the final state
+
+Everything this variant owns lives here: its SMEM images and swizzles, its
+inline PTX, its TMA descriptors, both device kernels, the combined compiled
+entry, its ``cu_chunks``/``chunk_to_seq`` metadata, its prepare scratch, its
+descriptor and call-plan caches, and its current-stream launch.  Only the
+mechanisms this variant shares with :mod:`.fused` -- bounded caches, capture
+detection, canonical INT32 offsets, the workspace resource slot and the
+``sm_120a`` target check -- come from :mod:`.runtime`.
+
+The single file is deliberate.  The sections below were nine modules and the
+split cost more than it bought: a chunk size, an SMEM offset and a barrier id
+are one decision each, read by both the host plan and the device kernel, and
+holding them apart made every one of them an import.  What does NOT belong
+here is anything :mod:`.fused` also needs, which is why ``runtime.py`` exists
+and why nothing in this file imports ``fused``.
+
+Chunk size 16, the SMEM arena offsets, the swizzles, the barrier arena, the
+grid, the chunks-per-CTA policy, the rounding boundaries and the state ABI are
+fixed implementation choices shared by the host plan, device code and tests.
+"""
+
+from __future__ import annotations
+
+import ctypes
+import threading
+import weakref
+from collections import OrderedDict
+from dataclasses import dataclass, field
+
+import cutlass
+import cutlass.cute as cute
+import cutlass.utils
+import torch
+from cuda.bindings import driver as cuda_driver
+from cutlass._mlir.dialects import llvm
+from cutlass.cutlass_dsl import dsl_user_op
+
+from .runtime import (
+    GRAPH_PINS,
+    NO_VERSION,
+    BoundedDeviceCache,
+    IdentityCache,
+    KDAPrefillValidationError,
+    assert_tvm_ffi_dispatched,
+    build_kernel,
+    capturing,
+    check_flat_output_range,
+    current_stream_ptr,
+    flat_view,
+    is_exact_alias,
+    max_grid_dims,
+    record_stream_once,
+    resource_cache_token,
+    require_sm120a,
+    sm120a_compile_options,
+    tensor_identity,
+    tensor_version,
+    upload_bytes,
+)
+
+
+# --------------------------------------------------------------------------
+# Section 1: canonical SMEM and global index mappings
+#
+# These are the decomp variant's images.  The fused variant computes
+# its own in its own file: the two agree on the S128 construction and
+# disagree on which logical shape it is applied to, so they are not
+# one helper with two callers.
+# --------------------------------------------------------------------------
+
+BT = 16
+DK = 128
+#: Value dimension.  Equal to ``DK`` for the shapes this backend supports, but
+#: the recurrence addresses the two independently -- a CTA owns all ``DK`` keys
+#: and only ``DV_HALF`` of the values.
+DV = 128
+DV_HALF = DV // 2
+
+# raw_bf16_s128: 2 segments x 128 bytes, 8-element (16 byte) groups.
+BF16_SEGMENT_ELEMS = 64
+BF16_GROUP_ELEMS = 8
+BF16_SEGMENTS = DK // BF16_SEGMENT_ELEMS
+BF16_SEGMENT_STRIDE = BT * BF16_SEGMENT_ELEMS  # 1024 elements
+BF16_ROW_XOR_MASK = BF16_SEGMENT_ELEMS // BF16_GROUP_ELEMS - 1  # 7
+
+# raw_f32_s128: 4 segments x 128 bytes, 4-element (16 byte) groups.
+F32_SEGMENT_ELEMS = 32
+F32_GROUP_ELEMS = 4
+F32_SEGMENTS = DK // F32_SEGMENT_ELEMS
+F32_SEGMENT_STRIDE = BT * F32_SEGMENT_ELEMS  # 512 elements
+F32_ROW_XOR_MASK = F32_SEGMENT_ELEMS // F32_GROUP_ELEMS - 1  # 7
+
+# Constant coordinate permutations.
+KR_AK_TOKEN_XOR = BT // 2  # 8, token-row permutation for the Ak.T image
+PAIRWISE_COL_XOR = 8  # column permutation of the 16x16 pairwise image
+PAIRWISE_ROW_STRIDE = 16
+
+# Byte sizes of one staged tile.
+RAW_BF16_STAGE_ELEMS = BT * DK  # 2048 BF16 -> 4096 bytes
+RAW_F32_STAGE_ELEMS = BT * DK  # 2048 FP32 -> 8192 bytes
+PAIRWISE_STAGE_ELEMS = BT * BT  # 256 BF16 -> 512 bytes
+
+
+def raw_bf16_s128(token, dim):
+    """Physical BF16 element index of logical ``(token, dim)``.
+
+    Used for raw Q, raw K, ``Ki``, ``Kd`` and ``Qd``.  ``Kd``/``Qd`` carry no
+    feature permutation, so they share this image with the
+    raw stages and with ``Ki``.
+    """
+    segment = dim // BF16_SEGMENT_ELEMS
+    local = dim - segment * BF16_SEGMENT_ELEMS
+    group = local // BF16_GROUP_ELEMS
+    inner = local - group * BF16_GROUP_ELEMS
+    return (
+        segment * BF16_SEGMENT_STRIDE
+        + token * BF16_SEGMENT_ELEMS
+        + (group ^ (token & BF16_ROW_XOR_MASK)) * BF16_GROUP_ELEMS
+        + inner
+    )
+
+
+def raw_f32_s128(token, dim):
+    """Physical FP32 element index of logical ``(token, dim)``.
+
+    The single FP32 image in the kernel: TMA destination for raw ``G`` and,
+    after the gate scan, in-place storage for FP32 ``exp_g`` at the very same
+    addresses.
+    """
+    segment = dim // F32_SEGMENT_ELEMS
+    local = dim - segment * F32_SEGMENT_ELEMS
+    group = local // F32_GROUP_ELEMS
+    inner = local - group * F32_GROUP_ELEMS
+    return (
+        segment * F32_SEGMENT_STRIDE
+        + token * F32_SEGMENT_ELEMS
+        + (group ^ (token & F32_ROW_XOR_MASK)) * F32_GROUP_ELEMS
+        + inner
+    )
+
+
+def kr_ak_bf16_s128(token, dim):
+    """Physical BF16 element index used to publish ``Ak.T``.
+
+    The ``token ^ 8`` permutation is what produces the ``ws_ak[c, j ^ 8, d]``
+    global image.  Because the swizzle is applied at row ``token ^ 8``, the two
+    2048-byte halves of the stage still map to feature ranges ``[0,64)`` and
+    ``[64,128)``, which is what lets warps 1 and 3 recycle the halves
+    independently.
+    """
+    return raw_bf16_s128(token ^ KR_AK_TOKEN_XOR, dim)
+
+
+def pairwise_sw32(row, col):
+    """Physical BF16 element index of a 16x16 pairwise tile element."""
+    storage_col = col ^ PAIRWISE_COL_XOR
+    byte_offset = 2 * (row * PAIRWISE_ROW_STRIDE + storage_col)
+    return (byte_offset ^ (((byte_offset >> 7) & 1) << 4)) // 2
+
+
+# Backwards-compatible alias used by the workspace pack/unpack helpers and by
+# the design's ``ws_aq[c, pair_idx(i, j)]``.
+pair_idx = pairwise_sw32
+
+
+# ---------------------------------------------------------------------------
+# Native m16n8k16 fragment maps.
+#
+# These are fixed by the PTX ISA.  They are restated here so no consumer has to
+# rediscover them and so the unit tests can enumerate them.  ``g = lane >> 2``
+# and ``q = lane & 3`` throughout.
+# ---------------------------------------------------------------------------
+
+
+def mma_a_coords(lane, reg):
+    """Logical ``(row, col)`` of the two BF16 halves in A register ``reg``."""
+    g = lane >> 2
+    q = lane & 3
+    row = g + 8 * (reg & 1)
+    col = 2 * q + 8 * (reg >> 1)
+    return ((row, col), (row, col + 1))
+
+
+def mma_b_coords(lane, reg):
+    """Logical ``(k, n)`` of the two BF16 halves in B register ``reg``."""
+    g = lane >> 2
+    q = lane & 3
+    k = 2 * q + 8 * reg
+    return ((k, g), (k + 1, g))
+
+
+def mma_c_coord(lane, n_block, reg):
+    """Logical ``(row, col)`` of FP32 accumulator register ``reg``."""
+    g = lane >> 2
+    q = lane & 3
+    row = g + 8 * (reg >> 1)
+    col = 8 * n_block + 2 * q + (reg & 1)
+    return (row, col)
+
+
+def ldmatrix_a_coord(lane):
+    """Row/col of the 16-byte row segment lane ``lane`` feeds to an A load.
+
+    The row half is keyed
+    on **bit 3** of the lane.
+    """
+    matrix_id = lane >> 3
+    row = (lane & 7) + (8 if (matrix_id & 1) else 0)
+    col = 8 if (matrix_id >> 1) else 0
+    return (row, col)
+
+
+def ldmatrix_b_coord(lane):
+    """Row/col of the 16-byte row segment lane ``lane`` feeds to a B load.
+
+    The row half is keyed
+    on **bit 4** of the lane, unlike the A rule; using the A rule here silently
+    transposes the operand.
+    """
+    matrix_id = lane >> 3
+    row = (lane & 7) + (8 if (lane >> 4) else 0)
+    col = 8 if (matrix_id & 1) else 0
+    return (row, col)
+
+
+def stmatrix_coord(lane):
+    """Row/col of the 16-byte row segment lane ``lane`` feeds to an x4 store.
+
+    Same tile/row convention as ``ldmatrix.x4`` and the same quadrant order as
+    the **A** fragment.
+    """
+    matrix_id = lane >> 3
+    row = (lane & 7) + (8 if (matrix_id & 1) else 0)
+    col = 8 if (matrix_id >= 2) else 0
+    return (row, col)
+
+
+#: ``movmatrix`` register order for converting an A-layout fragment into the B
+#: layout of the *same* matrix: transpose each 8x8 quadrant, identity order.
+MOVMATRIX_A_TO_B = (0, 1, 2, 3)
+
+#: ``movmatrix`` register order for converting an A-layout fragment into the
+#: A layout of the *transposed* matrix: quadrants (1,0) and (0,1) exchange, so
+#: registers 1 and 2 swap.
+MOVMATRIX_A_TO_AT = (0, 2, 1, 3)
+
+
+# ---------------------------------------------------------------------------
+# Recurrence images.
+#
+# The recurrence reuses ``raw_bf16_s128`` unchanged for its Kd/Qd/Ak stages and
+# ``pairwise_sw32`` unchanged for Aq; the three images below are new.  Every one
+# is the same S128 construction -- 128-byte segments, 16-byte groups, group
+# index XORed with the low bits of the segment row -- applied to a different
+# logical shape, so ``_s128_index`` states it once.
+# ---------------------------------------------------------------------------
+
+#: ``Kd``/``Qd``/``Ak`` land in the existing raw BF16 image; the recurrence
+#: spells it ``factor_idx`` because its rows are chunk tokens, not raw tokens.
+factor_idx = raw_bf16_s128
+
+#: The V/output half is 64 values wide, so it has one 128-byte segment per row.
+VO_ROW_ELEMS = DV_HALF  # 64 BF16 = 128 B
+VO_STAGE_ELEMS = BT * VO_ROW_ELEMS  # 1024 BF16 = 2048 B
+
+#: Physical rows of one value in the state image, by element width.  The state
+#: is stored ``[V, K]`` and read logically as ``[K, V]``,
+#: so one value spans 128 keys = 2 BF16 or 4 FP32 128-byte segments.
+STATE_BF16_ROWS_PER_VALUE = DK // BF16_SEGMENT_ELEMS  # 2
+STATE_F32_ROWS_PER_VALUE = DK // F32_SEGMENT_ELEMS  # 4
+STATE_BF16_ELEMS = DV_HALF * DK  # 8192 BF16 = 16 KiB
+STATE_F32_ELEMS = DV_HALF * DK  # 8192 FP32 = 32 KiB
+
+
+def _s128_index(row, column, segment_elems, group_elems):
+    """S128 element index of ``column`` within 128-byte row ``row``.
+
+    ``row`` here is the *segment* row -- the unit the swizzle XOR keys on -- not
+    a logical matrix row.  The three recurrence images differ only in what they
+    call a segment row and how they split a logical coordinate into one.
+    """
+    group = column // group_elems
+    inner = column - group * group_elems
+    return (
+        row * segment_elems
+        + (group ^ (row & (segment_elems // group_elems - 1))) * group_elems
+        + inner
+    )
+
+
+def vo_idx(row, v_local):
+    """Physical BF16 index of ``(token row, value)`` in a V/output half stage.
+
+    ``v_local`` is in ``[0, 64)`` and is the CTA-local value, so the two DV
+    halves address byte-identical stages at different global coordinates.
+    """
+    return _s128_index(row, v_local, VO_ROW_ELEMS, BF16_GROUP_ELEMS)
+
+
+def state_bf16_idx(v_local, k):
+    """Physical BF16 index of logical ``H[k][v]`` in the persistent state.
+
+    The unswizzled address function is ``state_idx(k, v) = v * 128 + k`` (plan
+    Section 12.2 Q1): physical ``[V, K]`` row-major *and* logical ``[K, V]``
+    column-major at once, which is what lets an external ``[V, K]`` state half
+    land by TMA with no transpose and still be read as ``H[K, V]`` by the MMA.
+    """
+    segment = k // BF16_SEGMENT_ELEMS
+    local = k - segment * BF16_SEGMENT_ELEMS
+    line = STATE_BF16_ROWS_PER_VALUE * v_local + segment
+    return _s128_index(line, local, BF16_SEGMENT_ELEMS, BF16_GROUP_ELEMS)
+
+
+def state_f32_idx(v_local, k):
+    """Physical FP32 index of ``state[v][k]`` in the conversion buffer.
+
+    Only the external-state boundary uses this image: an FP32 initial state
+    lands here and is rounded into the BF16 state, and an FP32 final state is
+    widened back into it after the pipeline drains.
+    """
+    segment = k // F32_SEGMENT_ELEMS
+    local = k - segment * F32_SEGMENT_ELEMS
+    line = STATE_F32_ROWS_PER_VALUE * v_local + segment
+    return _s128_index(line, local, F32_SEGMENT_ELEMS, F32_GROUP_ELEMS)
+
+
+def gt_idx(k):
+    """``GTotal`` is a contiguous FP32 ``[128]`` record with no swizzle."""
+    return k
+
+
+def state_half_rows(dv_half, *, fp32: bool = False) -> int:
+    """First tensor-map row of DV half ``dv_half``.
+
+    The state descriptors encode each 128-byte segment as the tensor map's
+    inner mode, so the half's coordinate is a row index and not a value index.
+    """
+    per_value = STATE_F32_ROWS_PER_VALUE if fp32 else STATE_BF16_ROWS_PER_VALUE
+    return dv_half * per_value * DV_HALF
+
+
+def vo_global_index(token, head, heads, dv_half, v_local):
+    """Flat element index of ``out[0, token, head, 64 * dv_half + v_local]``.
+
+    The partial-output tail stores through this map with 16-byte vectors (plan
+    Section 8.2); the full path never needs it, because TMA addresses the same
+    element through the descriptor instead.
+    """
+    return (token * heads + head) * DV + dv_half * DV_HALF + v_local
+
+
+# ---------------------------------------------------------------------------
+# Native N=8 fragment maps.
+#
+# The prepare kernel only ever issues logical m16n16k16 steps, so its maps are
+# written per n-block.  The recurrence's N is the eight value columns a warp
+# owns, which is exactly one native MMA, so the accumulator map below drops the
+# n-block term rather than pinning it to zero at every call site.
+# ---------------------------------------------------------------------------
+
+#: Value columns one compute warp owns.
+WARP_VALUES = 8
+#: Compute warps per CTA; ``COMPUTE_WARPS * WARP_VALUES == DV_HALF``.
+COMPUTE_WARPS = DV_HALF // WARP_VALUES
+
+
+def mma_n8_c_coord(lane, reg):
+    """``(row, col)`` of accumulator register ``reg`` in a native N=8 MMA."""
+    return mma_c_coord(lane, 0, reg)
+
+
+def state_x2_ptr(lane, kb, v_base):
+    """SMEM index lane ``lane`` addresses for a state 16x8 ``ldmatrix.x2``.
+
+    The same 16 addresses serve both state reads .2: without
+    ``.trans`` they produce the MMA **B** operand of ``Kd @ H`` and ``Qd @ H``,
+    and with ``.trans`` they produce the **C** view the state update needs.  The
+    two passes therefore differ only in one instruction modifier, which is why
+    the second pass can reload from SMEM instead of keeping eight fragments
+    live.  Lanes 16-31 are ignored by an x2 copy.
+    """
+    matrix = (lane // 8) & 1
+    row = lane - (lane // 8) * 8
+    return state_bf16_idx(v_base + row, kb * BT + 8 * matrix)
+
+
+def vo_x2_ptr(lane, v_base):
+    """SMEM index lane ``lane`` addresses for a V/output 16x8 ``ldmatrix.x2``.
+
+    Non-transposed in both directions: the stage is token-major and the C tile's
+    rows are tokens, so the loaded V and the stored output share this map.
+    """
+    matrix = (lane // 8) & 1
+    row = (lane - (lane // 8) * 8) + 8 * matrix
+    return vo_idx(row, v_base)
+
+
+def packed_c_reg_coords(lane, reg):
+    """Logical ``(row, col)`` of the two halves of packed C register ``reg``.
+
+    A 16x8 C tile is four FP32 accumulator registers, but only two b32 registers
+    once rounded to BF16, and an x2 matrix copy moves exactly those two.  Packed
+    register ``reg`` is the pair ``(2 * reg, 2 * reg + 1)``, which is one C row
+    and two adjacent columns -- so the ``ldmatrix``/``stmatrix`` halves line up
+    with the accumulator without any lane shuffle.
+
+    This is the register map for the V load, the output store, and the
+    ``.trans`` state read alike: :func:`vo_x2_ptr` and :func:`state_x2_ptr`
+    already absorb the orientation difference, so only the instruction's
+    ``.trans`` modifier changes between them.
+    """
+    return (mma_n8_c_coord(lane, 2 * reg), mma_n8_c_coord(lane, 2 * reg + 1))
+
+
+def factor_a_fragment_ptr(lane, kb):
+    """SMEM index lane ``lane`` addresses for a ``Kd``/``Qd`` A-operand x4 load.
+
+    Both stages are token-major, which is the A operand's orientation already,
+    so this is the plain (non-transposed) x4 map at key block ``kb``.
+    """
+    matrix_id = lane // 8
+    row = (lane - matrix_id * 8) + 8 * (matrix_id - (matrix_id // 2) * 2)
+    col = kb * BT + 8 * (matrix_id // 2)
+    return factor_idx(row, col)
+
+
+def pairwise_a_fragment_ptr(lane):
+    """SMEM index lane ``lane`` addresses for the ``Aq`` A-operand x4 load."""
+    matrix_id = lane // 8
+    row = (lane - matrix_id * 8) + 8 * (matrix_id - (matrix_id // 2) * 2)
+    col = 8 * (matrix_id // 2)
+    return pairwise_sw32(row, col)
+
+
+def ak_a_fragment_ptr(lane, kb):
+    """SMEM index lane ``lane`` addresses for the ``Ak`` A-operand x4 trans.
+
+    ``Ak`` is published by prepare as ``Ak.T`` with a ``token ^ 8`` row
+    permutation, so the stage holds ``[token][key]`` while the MMA wants
+    ``[key][token]``.  ``ldmatrix.x4.trans`` supplies the transpose, and the
+    four returned registers are ``(a0, a1, a2, a3)`` directly -- plan
+    Section 7.1 forbids permuting them afterwards.
+    """
+    matrix_id = lane // 8
+    row8 = lane - matrix_id * 8
+    logical_j = (matrix_id // 2) * 8 + row8
+    key = kb * BT + (matrix_id - (matrix_id // 2) * 2) * 8
+    return factor_idx(logical_j ^ KR_AK_TOKEN_XOR, key)
+
+
+#: ``movmatrix`` register order converting the BF16 residual from the C layout
+#: it is computed in to the B layout the Aq/Ak MMAs consume: transpose each
+#: packed 8x8 quadrant in place, keeping the register index.
+MOVMATRIX_C_TO_B = (0, 1)
+
+
+#: ``cute.make_swizzle`` takes the design's **byte**-unit parameters, not
+#: the element-unit ones.  A composed layout's swizzle is applied to the byte
+#: offset, so both S128 images spell as ``Swizzle<3,4,3>`` regardless of element
+#: width -- ``<3,3,3>`` (BF16) and ``<3,2,3>`` (FP32) are the element-unit
+#: spellings of the *same* images and are wrong as arguments here.  Checked
+#: against the arithmetic formulas in ``test_layouts``.
+SWIZZLE_S128_BYTES = (3, 4, 3)
+SWIZZLE_SW32_BYTES = (1, 4, 3)
+
+
+def make_cute_layouts():
+    """Build the three CuTe composed layouts .
+
+    ``raw_bf16`` and ``raw_f32`` are what ``make_tiled_tma_atom`` consumes, so
+    they must reproduce :func:`raw_bf16_s128` and :func:`raw_f32_s128` exactly.
+
+    ``pairwise`` carries the SW32 swizzle only.  :func:`pairwise_sw32` also
+    permutes the column by ``^ PAIRWISE_COL_XOR``, which is not expressible as
+    a CuTe layout, so this object is *not* a complete model of that image.  No
+    TMA descriptor uses it: the design has warp 2 store ``Aq`` directly.
+
+    Imported lazily so that host-only consumers (workspace helpers, layout unit
+    tests) do not need the CUTLASS DSL installed.
+    """
+    import cutlass.cute as cute
+
+    raw_bf16 = cute.make_composed_layout(
+        cute.make_swizzle(*SWIZZLE_S128_BYTES),
+        0,
+        cute.make_layout(
+            (BT, (BF16_SEGMENT_ELEMS, BF16_SEGMENTS)),
+            stride=(BF16_SEGMENT_ELEMS, (1, BF16_SEGMENT_STRIDE)),
+        ),
+    )
+    raw_f32 = cute.make_composed_layout(
+        cute.make_swizzle(*SWIZZLE_S128_BYTES),
+        0,
+        cute.make_layout(
+            (BT, (F32_SEGMENT_ELEMS, F32_SEGMENTS)),
+            stride=(F32_SEGMENT_ELEMS, (1, F32_SEGMENT_STRIDE)),
+        ),
+    )
+    pairwise = cute.make_composed_layout(
+        cute.make_swizzle(*SWIZZLE_SW32_BYTES),
+        0,
+        cute.make_layout((BT, BT), stride=(PAIRWISE_ROW_STRIDE, 1)),
+    )
+    return raw_bf16, raw_f32, pairwise
+
+
+# --------------------------------------------------------------------------
+# Section 2: CuTe DSL names that moved between releases
+#
+# An import rather than a module-level getattr: the DSL's AST
+# preprocessor replays a traced module's imports into the tracing
+# scope and nothing else.
+# --------------------------------------------------------------------------
+
+#: 4.7 renamed ``make_fragment`` to ``make_rmem_tensor``; the signature
+#: ``(layout_or_shape, dtype, *, loc=None, ip=None) -> Tensor`` is unchanged,
+#: so one alias covers every call site.
+make_rmem_tensor = getattr(cute, "make_rmem_tensor", None) or cute.make_fragment
+
+
+# --------------------------------------------------------------------------
+# Section 3: inline PTX the decomp kernels issue
+# --------------------------------------------------------------------------
+
+
+@dsl_user_op
+def ldmatrix_x4(smem_ptr, *, loc=None, ip=None):
+    """``ldmatrix.sync.aligned.m8n8.x4.shared.b16`` -> four b32 registers."""
+    from cutlass._mlir.extras import types as _T
+
+    struct = llvm.inline_asm(
+        llvm.StructType.get_literal([_T.IntegerType.get_signless(32)] * 4),
+        [smem_ptr.toint(loc=loc, ip=ip).ir_value(loc=loc, ip=ip)],
+        "ldmatrix.sync.aligned.m8n8.x4.shared.b16 {$0, $1, $2, $3}, [$4];",
+        "=r,=r,=r,=r,r",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+    return tuple(
+        cutlass.Int32(
+            llvm.extractvalue(
+                _T.IntegerType.get_signless(32), struct, [i], loc=loc, ip=ip
+            )
+        )
+        for i in range(4)
+    )
+
+
+def _ldmatrix(count: str, trans: str, smem_ptr, num: int, *, loc=None, ip=None):
+    from cutlass._mlir.extras import types as _T
+
+    outs = ", ".join(f"${i}" for i in range(num))
+    struct = llvm.inline_asm(
+        llvm.StructType.get_literal([_T.IntegerType.get_signless(32)] * num),
+        [smem_ptr.toint(loc=loc, ip=ip).ir_value(loc=loc, ip=ip)],
+        f"ldmatrix.sync.aligned.m8n8{count}{trans}.shared.b16 {{{outs}}}, [${num}];",
+        ",".join(["=r"] * num) + ",r",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+    return tuple(
+        cutlass.Int32(
+            llvm.extractvalue(
+                _T.IntegerType.get_signless(32), struct, [i], loc=loc, ip=ip
+            )
+        )
+        for i in range(num)
+    )
+
+
+@dsl_user_op
+def ldmatrix_x2(smem_ptr, *, loc=None, ip=None):
+    """``ldmatrix.sync.aligned.m8n8.x2.shared.b16`` -> two b32 registers.
+
+    the state's MMA **B** operand and the V tile
+    both load through this.  Only lanes 0-15 supply addresses.
+    """
+    return _ldmatrix(".x2", "", smem_ptr, 2, loc=loc, ip=ip)
+
+
+@dsl_user_op
+def ldmatrix_x2_trans(smem_ptr, *, loc=None, ip=None):
+    """``ldmatrix.sync.aligned.m8n8.x2.trans.shared.b16`` -> two b32 registers.
+
+    Same addresses as :func:`ldmatrix_x2`, read down the memory columns instead
+    of across its rows.  That is what turns the physical ``[V, K]`` state into
+    the logical ``[K, V]`` C tile the state update accumulates into.
+    """
+    return _ldmatrix(".x2", ".trans", smem_ptr, 2, loc=loc, ip=ip)
+
+
+@dsl_user_op
+def ldmatrix_x4_trans(smem_ptr, *, loc=None, ip=None):
+    """``ldmatrix.sync.aligned.m8n8.x4.trans.shared.b16`` -> four b32 registers.
+
+    The ``Ak`` A operand: prepare publishes ``Ak.T`` with a ``token ^ 8`` row
+    permutation, and the pointer map of ``layouts.ak_a_fragment_ptr`` plus this
+    instruction produce the logical ``[key, token]`` fragment with no register
+    permutation afterwards.
+    """
+    return _ldmatrix(".x4", ".trans", smem_ptr, 4, loc=loc, ip=ip)
+
+
+def _stmatrix(count: str, trans: str, smem_ptr, regs, *, loc=None, ip=None):
+    ins = ", ".join(f"${i + 1}" for i in range(len(regs)))
+    llvm.inline_asm(
+        None,
+        [
+            smem_ptr.toint(loc=loc, ip=ip).ir_value(loc=loc, ip=ip),
+            *[cutlass.Int32(r).ir_value(loc=loc, ip=ip) for r in regs],
+        ],
+        f"stmatrix.sync.aligned.m8n8{count}{trans}.shared.b16 [$0], {{{ins}}};",
+        ",".join(["r"] * (len(regs) + 1)),
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+
+
+@dsl_user_op
+def stmatrix_x2(smem_ptr, r0, r1, *, loc=None, ip=None):
+    """``stmatrix.sync.aligned.m8n8.x2.shared.b16``: the output half store."""
+    _stmatrix(".x2", "", smem_ptr, (r0, r1), loc=loc, ip=ip)
+
+
+@dsl_user_op
+def stmatrix_x2_trans(smem_ptr, r0, r1, *, loc=None, ip=None):
+    """``stmatrix.sync.aligned.m8n8.x2.trans.shared.b16``: the state write-back.
+
+    Exactly inverts :func:`ldmatrix_x2_trans` against the same pointer map, so
+    the state update reads and writes the identical 16x8 block of one warp's
+    value columns.
+    """
+    _stmatrix(".x2", ".trans", smem_ptr, (r0, r1), loc=loc, ip=ip)
+
+
+@dsl_user_op
+def stmatrix_x4(smem_ptr, r0, r1, r2, r3, *, loc=None, ip=None):
+    """``stmatrix.sync.aligned.m8n8.x4.shared.b16`` from four b32 registers."""
+
+    llvm.inline_asm(
+        None,
+        [
+            smem_ptr.toint(loc=loc, ip=ip).ir_value(loc=loc, ip=ip),
+            cutlass.Int32(r0).ir_value(loc=loc, ip=ip),
+            cutlass.Int32(r1).ir_value(loc=loc, ip=ip),
+            cutlass.Int32(r2).ir_value(loc=loc, ip=ip),
+            cutlass.Int32(r3).ir_value(loc=loc, ip=ip),
+        ],
+        "stmatrix.sync.aligned.m8n8.x4.shared.b16 [$0], {$1, $2, $3, $4};",
+        "r,r,r,r,r",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+
+
+@dsl_user_op
+def movmatrix_b16(value, *, loc=None, ip=None):
+    """``movmatrix.sync.aligned.m8n8.trans.b16``: transpose one 8x8 b16 tile."""
+    from cutlass._mlir.extras import types as _T
+
+    return cutlass.Int32(
+        llvm.inline_asm(
+            _T.IntegerType.get_signless(32),
+            [cutlass.Int32(value).ir_value(loc=loc, ip=ip)],
+            "movmatrix.sync.aligned.m8n8.trans.b16 $0, $1;",
+            "=r,r",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+            loc=loc,
+            ip=ip,
+        )
+    )
+
+
+def _mma_m16n8k16(
+    kind: str, a0, a1, a2, a3, b0, b1, c0, c1, c2, c3, *, loc=None, ip=None
+):
+    from cutlass._mlir.extras import types as _T
+
+    struct = llvm.inline_asm(
+        llvm.StructType.get_literal([_T.F32Type.get()] * 4),
+        [
+            cutlass.Int32(a0).ir_value(loc=loc, ip=ip),
+            cutlass.Int32(a1).ir_value(loc=loc, ip=ip),
+            cutlass.Int32(a2).ir_value(loc=loc, ip=ip),
+            cutlass.Int32(a3).ir_value(loc=loc, ip=ip),
+            cutlass.Int32(b0).ir_value(loc=loc, ip=ip),
+            cutlass.Int32(b1).ir_value(loc=loc, ip=ip),
+            cutlass.Float32(c0).ir_value(loc=loc, ip=ip),
+            cutlass.Float32(c1).ir_value(loc=loc, ip=ip),
+            cutlass.Float32(c2).ir_value(loc=loc, ip=ip),
+            cutlass.Float32(c3).ir_value(loc=loc, ip=ip),
+        ],
+        f"mma.sync.aligned.m16n8k16.row.col.f32.{kind}.{kind}.f32 "
+        "{$0, $1, $2, $3}, {$4, $5, $6, $7}, {$8, $9}, {$10, $11, $12, $13};",
+        "=f,=f,=f,=f,r,r,r,r,r,r,f,f,f,f",
+        has_side_effects=False,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+    return tuple(
+        cutlass.Float32(
+            llvm.extractvalue(_T.F32Type.get(), struct, [i], loc=loc, ip=ip)
+        )
+        for i in range(4)
+    )
+
+
+@dsl_user_op
+def mma_m16n8k16_bf16(a0, a1, a2, a3, b0, b1, c0, c1, c2, c3, *, loc=None, ip=None):
+    """``mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32``."""
+
+    return _mma_m16n8k16("bf16", a0, a1, a2, a3, b0, b1, c0, c1, c2, c3, loc=loc, ip=ip)
+
+
+@dsl_user_op
+def mma_m16n8k16_f16(a0, a1, a2, a3, b0, b1, c0, c1, c2, c3, *, loc=None, ip=None):
+    """``mma.sync.aligned.m16n8k16.row.col.f32.f16.f16.f32``."""
+
+    return _mma_m16n8k16("f16", a0, a1, a2, a3, b0, b1, c0, c1, c2, c3, loc=loc, ip=ip)
+
+
+@dsl_user_op
+def pack_bf16x2(lo: cutlass.Float32, hi: cutlass.Float32, *, loc=None, ip=None):
+    """Round two FP32 values to BF16 and pack them into one b32 register.
+
+    ``cvt.rn.bf16x2.f32 d, hi, lo`` places ``lo`` in the low half.
+    """
+    from cutlass._mlir.extras import types as _T
+
+    return cutlass.Int32(
+        llvm.inline_asm(
+            _T.IntegerType.get_signless(32),
+            [
+                cutlass.Float32(hi).ir_value(loc=loc, ip=ip),
+                cutlass.Float32(lo).ir_value(loc=loc, ip=ip),
+            ],
+            "cvt.rn.bf16x2.f32 $0, $1, $2;",
+            "=r,f,f",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+            loc=loc,
+            ip=ip,
+        )
+    )
+
+
+@dsl_user_op
+def pack_f16x2(lo: cutlass.Float32, hi: cutlass.Float32, *, loc=None, ip=None):
+    """Round two FP32 values to FP16 and pack them into one b32 register.
+
+    The FP16 twin of :func:`pack_bf16x2`, with the same half ordering:
+    ``cvt.rn.f16x2.f32 d, hi, lo`` places ``lo`` in the low half.  Used by the
+    inverse chain, whose operands are FP16 regardless of the kernel's input
+    dtype -- FP16's 10-bit significand against BF16's 7 is worth 4-8x there,
+    and the chain is the one stage where the extra bits survive.
+    """
+    from cutlass._mlir.extras import types as _T
+
+    return cutlass.Int32(
+        llvm.inline_asm(
+            _T.IntegerType.get_signless(32),
+            [
+                cutlass.Float32(hi).ir_value(loc=loc, ip=ip),
+                cutlass.Float32(lo).ir_value(loc=loc, ip=ip),
+            ],
+            "cvt.rn.f16x2.f32 $0, $1, $2;",
+            "=r,f,f",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+            loc=loc,
+            ip=ip,
+        )
+    )
+
+
+@dsl_user_op
+def mul_bf16x2(a, b, *, loc=None, ip=None):
+    """Packed BF16 multiply of two b32 registers, rounding each product."""
+    from cutlass._mlir.extras import types as _T
+
+    return cutlass.Int32(
+        llvm.inline_asm(
+            _T.IntegerType.get_signless(32),
+            [
+                cutlass.Int32(a).ir_value(loc=loc, ip=ip),
+                cutlass.Int32(b).ir_value(loc=loc, ip=ip),
+            ],
+            "mul.rn.bf16x2 $0, $1, $2;",
+            "=r,r,r",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+            loc=loc,
+            ip=ip,
+        )
+    )
+
+
+@dsl_user_op
+def sub_bf16x2(a, b, *, loc=None, ip=None):
+    """Packed BF16 subtract of two b32 registers, rounding each difference.
+
+    the design builds the residual with this rather than with
+    FP32 arithmetic: both operands are already BF16, so the exact difference is
+    representable and a single ``sub.rn`` reproduces the contract's
+    ``BF16(V - X)`` boundary for two values at once.
+    """
+    from cutlass._mlir.extras import types as _T
+
+    return cutlass.Int32(
+        llvm.inline_asm(
+            _T.IntegerType.get_signless(32),
+            [
+                cutlass.Int32(a).ir_value(loc=loc, ip=ip),
+                cutlass.Int32(b).ir_value(loc=loc, ip=ip),
+            ],
+            "sub.rn.bf16x2 $0, $1, $2;",
+            "=r,r,r",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+            loc=loc,
+            ip=ip,
+        )
+    )
+
+
+@dsl_user_op
+def unpack_bf16x2(value, *, loc=None, ip=None):
+    """Widen a packed BF16 pair to two FP32, low half first.
+
+    The state's decay term is ``FP32(GTotal) * FP32(H_bf16)``,
+    so the reloaded BF16 state has to reach the FP32 accumulator; this is the
+    widening, and it recovers nothing the entry rounding already discarded.
+    """
+    from cutlass._mlir.extras import types as _T
+
+    struct = llvm.inline_asm(
+        llvm.StructType.get_literal([_T.F32Type.get()] * 2),
+        [cutlass.Int32(value).ir_value(loc=loc, ip=ip)],
+        "{ .reg .b16 lo, hi;"
+        "  mov.b32 {lo, hi}, $2;"
+        "  cvt.f32.bf16 $0, lo; cvt.f32.bf16 $1, hi; }",
+        "=f,=f,r",
+        has_side_effects=False,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+    return tuple(
+        cutlass.Float32(
+            llvm.extractvalue(_T.F32Type.get(), struct, [i], loc=loc, ip=ip)
+        )
+        for i in range(2)
+    )
+
+
+@dsl_user_op
+def cvt_bf16x2_to_f16x2(value, *, loc=None, ip=None):
+    """Re-round a packed BF16 pair through FP16 (for an FP16 inverse chain)."""
+    from cutlass._mlir.extras import types as _T
+
+    return cutlass.Int32(
+        llvm.inline_asm(
+            _T.IntegerType.get_signless(32),
+            [cutlass.Int32(value).ir_value(loc=loc, ip=ip)],
+            "{ .reg .b16 lo, hi; .reg .f32 flo, fhi;"
+            "  mov.b32 {lo, hi}, $1;"
+            "  cvt.f32.bf16 flo, lo; cvt.f32.bf16 fhi, hi;"
+            "  cvt.rn.f16x2.f32 $0, fhi, flo; }",
+            "=r,r",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+            loc=loc,
+            ip=ip,
+        )
+    )
+
+
+@dsl_user_op
+def cp_async_16(smem_ptr, gmem_ptr, src_bytes, *, loc=None, ip=None):
+    """``cp.async.cg.shared.global`` of 16 bytes.
+
+    ``src_bytes`` is the PTX src-size operand: pass 16 for a real copy and 0 to
+    have the hardware zero-fill the destination instead.  That is exactly what
+    an out-of-range tail row needs, so no separate tail-clear pass is required.
+    """
+    from cutlass._mlir.dialects import llvm
+
+    llvm.inline_asm(
+        None,
+        [
+            smem_ptr.toint(loc=loc, ip=ip).ir_value(loc=loc, ip=ip),
+            gmem_ptr.toint(loc=loc, ip=ip).ir_value(loc=loc, ip=ip),
+            cutlass.Int32(src_bytes).ir_value(loc=loc, ip=ip),
+        ],
+        "cp.async.cg.shared.global [$0], [$1], 16, $2;",
+        "r,l,r",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+
+
+# ---------------------------------------------------------------------------
+# TMA
+#
+# The public wheel's TMA path (cpasync.make_tiled_tma_atom + cute.copy)
+# compiles but its copy never completes on sm_120, and the API this is
+# written against lowers to MLIR ops the wheel does not ship.  The instruction
+# itself is fine on this hardware, so issue it directly.  Descriptors come from
+# cuTensorMapEncodeTiled on the host and live in device memory; the kernel gets
+# their addresses as Int64 scalars.
+# ---------------------------------------------------------------------------
+
+
+@dsl_user_op
+def fence_tensormap_acquire(desc_addr, *, loc=None, ip=None):
+    """Publish a host-written tensor map to the tensormap proxy.
+
+    The descriptor is written by the host and read by the TMA unit through a
+    different proxy, so the kernel has to acquire it before first use.
+    """
+    llvm.inline_asm(
+        None,
+        [cutlass.Int64(desc_addr).ir_value(loc=loc, ip=ip)],
+        "fence.proxy.tensormap::generic.acquire.gpu [$0], 128;",
+        "l",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+
+
+@dsl_user_op
+def tma_load_3d(smem_ptr, desc_addr, mbar_ptr, c0, c1, c2, *, loc=None, ip=None):
+    """One ``cp.async.bulk.tensor.3d`` box, global to shared.
+
+    ``shared::cta`` rather than ``shared::cluster``: sm_120 has no thread block
+    clusters, and this is the form that works.  Completion is
+    reported to ``mbar_ptr`` as transaction bytes, so the consumer waits on the
+    mbarrier rather than on a commit group.
+    """
+    llvm.inline_asm(
+        None,
+        [
+            smem_ptr.toint(loc=loc, ip=ip).ir_value(loc=loc, ip=ip),
+            cutlass.Int64(desc_addr).ir_value(loc=loc, ip=ip),
+            mbar_ptr.toint(loc=loc, ip=ip).ir_value(loc=loc, ip=ip),
+            cutlass.Int32(c0).ir_value(loc=loc, ip=ip),
+            cutlass.Int32(c1).ir_value(loc=loc, ip=ip),
+            cutlass.Int32(c2).ir_value(loc=loc, ip=ip),
+        ],
+        "cp.async.bulk.tensor.3d.shared::cta.global.tile.mbarrier::complete_tx::bytes"
+        " [$0], [$1, {$3, $4, $5}], [$2];",
+        "r,l,r,r,r,r",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+
+
+@dsl_user_op
+def tma_store_3d(desc_addr, smem_ptr, c0, c1, c2, *, loc=None, ip=None):
+    """One ``cp.async.bulk.tensor.3d`` box, shared to global.
+
+    Stores have no mbarrier; they are tracked with bulk commit groups, and the
+    ``read`` wait below is what releases the source SMEM for reuse.
+    """
+    llvm.inline_asm(
+        None,
+        [
+            cutlass.Int64(desc_addr).ir_value(loc=loc, ip=ip),
+            smem_ptr.toint(loc=loc, ip=ip).ir_value(loc=loc, ip=ip),
+            cutlass.Int32(c0).ir_value(loc=loc, ip=ip),
+            cutlass.Int32(c1).ir_value(loc=loc, ip=ip),
+            cutlass.Int32(c2).ir_value(loc=loc, ip=ip),
+        ],
+        "cp.async.bulk.tensor.3d.global.shared::cta.tile.bulk_group"
+        " [$0, {$2, $3, $4}], [$1];",
+        "l,r,r,r,r",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+
+
+@dsl_user_op
+def tma_store_commit_group(*, loc=None, ip=None):
+    """Close the current bulk-store group."""
+    llvm.inline_asm(
+        None,
+        [],
+        "cp.async.bulk.commit_group;",
+        "",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+
+
+@dsl_user_op
+def tma_store_wait_read(keep: int, *, loc=None, ip=None):
+    """Wait until at most ``keep`` bulk-store groups still hold their source.
+
+    ``.read`` is a source-SMEM reuse guarantee, not a claim that the store is
+    globally visible (step 8 of the design).
+    """
+    llvm.inline_asm(
+        None,
+        [],
+        f"cp.async.bulk.wait_group.read {keep};",
+        "",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+
+
+# --------------------------------------------------------------------------
+# Section 4: the prepare workspace and this variant's chunk metadata
+#
+# The chunk-to-sequence map and the packed factor arena exist because
+# prepare is chunk-parallel; the fused variant runs one CTA per
+# (sequence, head) and needs neither, so neither is shared.  What both
+# variants do need -- a validated canonical INT32 ``cu_seqlens`` -- comes
+# from ``runtime.canonical_offsets`` instead, and this section derives
+# ``cu_chunks``/``chunk_to_seq`` from it.
+# --------------------------------------------------------------------------
+
+CHUNK = BT
+DIMENSION = DK
+
+REGION_ALIGNMENT = 256
+
+#: 3 * 4096 (Kd, Qd, Ak) + 512 (Aq) + 512 (GTotal)
+BYTES_PER_HEAD_CHUNK = (
+    3 * (CHUNK * DIMENSION * 2) + (CHUNK * CHUNK * 2) + (DIMENSION * 4)
+)
+assert BYTES_PER_HEAD_CHUNK == 13312
+
+
+def _align_up(value: int, alignment: int) -> int:
+    return (value + alignment - 1) // alignment * alignment
+
+
+def chunks_for_lengths(lengths) -> list[int]:
+    """``ceil_div(len, 16)`` per sequence."""
+    return [(int(length) + CHUNK - 1) // CHUNK for length in lengths]
+
+
+def total_chunks_for_lengths(lengths) -> int:
+    """Exact total chunk count; zero-length sequences contribute zero chunks."""
+    return sum(chunks_for_lengths(lengths))
+
+
+@dataclass(frozen=True)
+class PrepareWorkspace:
+    """Typed views over one packed ``uint8`` storage tensor."""
+
+    storage: torch.Tensor
+    kd: torch.Tensor
+    qd: torch.Tensor
+    ak: torch.Tensor
+    aq: torch.Tensor
+    g_total: torch.Tensor
+    heads: int
+    total_chunks: int
+    # A decomp forward is a compound enqueue: prepare writes this workspace,
+    # then recurrence consumes it.  CUDA orders individual launches submitted
+    # to one stream, but two host threads can interleave those two-launch
+    # sequences.  Every plan that owns this workspace therefore shares this
+    # host lock and holds it until both launches have been submitted.
+    launch_lock: threading.Lock = field(
+        default_factory=threading.Lock, repr=False, compare=False
+    )
+
+    def tensors(self) -> dict[str, torch.Tensor]:
+        return {
+            "kd": self.kd,
+            "qd": self.qd,
+            "ak": self.ak,
+            "aq": self.aq,
+            "g_total": self.g_total,
+        }
+
+
+def prepare_region_offsets(heads: int, total_chunks: int) -> dict[str, tuple[int, int]]:
+    """Return ``{name: (byte_offset, byte_size)}`` in physical arena order."""
+    if heads <= 0:
+        raise ValueError(f"heads must be positive, got {heads}")
+    if total_chunks < 0:
+        raise ValueError(f"total_chunks must be non-negative, got {total_chunks}")
+
+    rows = heads * total_chunks * CHUNK
+    vector_bytes = rows * DIMENSION * 2
+    aq_bytes = heads * total_chunks * (CHUNK * CHUNK) * 2
+    gt_bytes = heads * total_chunks * DIMENSION * 4
+
+    offsets: dict[str, tuple[int, int]] = {}
+    cursor = 0
+    for name, size in (
+        ("kd", vector_bytes),
+        ("qd", vector_bytes),
+        ("ak", vector_bytes),
+        ("aq", aq_bytes),
+        ("g_total", gt_bytes),
+    ):
+        cursor = _align_up(cursor, REGION_ALIGNMENT)
+        offsets[name] = (cursor, size)
+        cursor += size
+    return offsets
+
+
+def prepare_workspace_size(heads: int, total_chunks: int) -> int:
+    """Total bytes of the packed prepare workspace."""
+    offsets = prepare_region_offsets(heads, total_chunks)
+    last_offset, last_size = offsets["g_total"]
+    return _align_up(last_offset + last_size, REGION_ALIGNMENT)
+
+
+def partition_prepare_workspace(
+    storage: torch.Tensor, heads: int, total_chunks: int
+) -> PrepareWorkspace:
+    """Carve the five typed physical views out of one ``uint8`` storage."""
+    if storage.dtype != torch.uint8:
+        raise TypeError(f"workspace storage must be uint8, got {storage.dtype}")
+    if storage.ndim != 1:
+        raise ValueError("workspace storage must be 1-D")
+    if not storage.is_contiguous():
+        raise ValueError("workspace storage must be contiguous")
+
+    required = prepare_workspace_size(heads, total_chunks)
+    if storage.numel() < required:
+        raise ValueError(
+            f"workspace storage has {storage.numel()} bytes, need {required}"
+        )
+    # Region offsets are 256-byte aligned relative to the base, so the regions
+    # are absolutely aligned only when the base is.  The CUDA caching allocator
+    # always returns >=256-byte-aligned blocks, which is what the TMA
+    # descriptors need; host allocations are a testing convenience and are not
+    # held to that.
+    if storage.is_cuda and storage.data_ptr() % REGION_ALIGNMENT:
+        raise ValueError(
+            f"workspace storage must be {REGION_ALIGNMENT}-byte aligned, "
+            f"got offset {storage.data_ptr() % REGION_ALIGNMENT}"
+        )
+
+    offsets = prepare_region_offsets(heads, total_chunks)
+    rows = total_chunks * CHUNK
+
+    def view(name: str, dtype: torch.dtype, shape: tuple[int, ...]) -> torch.Tensor:
+        offset, size = offsets[name]
+        raw = storage[offset : offset + size]
+        return raw.view(dtype).view(shape)
+
+    return PrepareWorkspace(
+        storage=storage,
+        kd=view("kd", torch.bfloat16, (1, heads, rows, DIMENSION)),
+        qd=view("qd", torch.bfloat16, (1, heads, rows, DIMENSION)),
+        ak=view("ak", torch.bfloat16, (1, heads, rows, DIMENSION)),
+        aq=view("aq", torch.bfloat16, (1, heads, total_chunks, CHUNK * CHUNK)),
+        g_total=view("g_total", torch.float32, (1, heads, total_chunks, DIMENSION)),
+        heads=heads,
+        total_chunks=total_chunks,
+    )
+
+
+def allocate_prepare_workspace(
+    heads: int, total_chunks: int, device: torch.device | str
+) -> PrepareWorkspace:
+    size = prepare_workspace_size(heads, total_chunks)
+    raw = torch.empty(size + REGION_ALIGNMENT, dtype=torch.uint8, device=device)
+    pad = (-raw.data_ptr()) % REGION_ALIGNMENT
+    storage = raw[pad : pad + size]
+    return partition_prepare_workspace(storage, heads, total_chunks)
+
+
+#: One entry per (heads, total_chunks, stream) in flight.  A handful of shapes
+#: on one or two streams is the normal case; the bound keeps a workload that
+#: varies its chunk count from pinning every size it ever saw.
+PREPARE_WORKSPACE_MAX_ENTRIES = 8
+
+#: Reused scratch, keyed by shape *and stream*.  ``fwd`` allocated a fresh
+#: workspace on every call, which measured 35 us against 20 us of actual kernel
+#: time -- the allocation cost more than the work.
+#:
+#: The stream is part of the key on purpose.  This buffer is written, not read,
+#: so two forwards running concurrently on different streams must not share
+#: one: unlike the descriptor caches, a wait_event on the entry would order the
+#: reader against its *creation*, not against the previous writer.  Giving each
+#: stream its own workspace removes the race rather than trying to order it.
+_WORKSPACES = BoundedDeviceCache(
+    "prepare-workspace", max_entries=PREPARE_WORKSPACE_MAX_ENTRIES
+)
+# ``BoundedDeviceCache`` deliberately handles device lifetime rather than
+# compound get-or-create atomicity.  Serialize that compound operation here so
+# two host threads using the same CUDA stream receive the same workspace and,
+# critically, the same launch lock.
+_WORKSPACES_CACHE_LOCK = threading.Lock()
+
+
+def acquire_prepare_workspace(
+    heads: int, total_chunks: int, device: torch.device | str
+) -> PrepareWorkspace:
+    """A workspace for this shape, reused across calls on the same stream."""
+    device = torch.device(device) if isinstance(device, str) else device
+    stream = (
+        torch.cuda.current_stream(device).cuda_stream
+        if device.type == "cuda" and torch.cuda.is_available()
+        else 0
+    )
+    key = (heads, total_chunks, stream)
+    with _WORKSPACES_CACHE_LOCK:
+        hit = _WORKSPACES.get(device, key)
+        if hit is not None:
+            return hit
+        made = allocate_prepare_workspace(heads, total_chunks, device)
+        return _WORKSPACES.put(device, key, made, storages=(made.storage,))
+
+
+def clear_prepare_workspaces(device: torch.device | int | None = None) -> None:
+    with _WORKSPACES_CACHE_LOCK:
+        _WORKSPACES.clear(device)
+
+
+# ---------------------------------------------------------------------------
+# Sequence metadata, cached by contents and device of ``cu_seqlens``.
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ChunkMetadata:
+    """Canonical INT32 device metadata, plus the host copies used to validate.
+
+    whatever dtype the caller passes, both kernels index with
+    INT32 on the device, so there is one canonical form and no second kernel
+    specialization.  Prepare uses all three device tensors; the recurrence uses
+    only ``cu_seqlens`` and ``cu_chunks``.
+    """
+
+    cu_seqlens: torch.Tensor  # INT32 [N + 1]
+    cu_chunks: torch.Tensor  # INT32 [N + 1]
+    chunk_to_seq: torch.Tensor  # INT32 [total_chunks]
+    cu_seqlens_host: tuple[int, ...]
+    cu_chunks_host: tuple[int, ...]
+    total_chunks: int
+    sequence_count: int
+
+    def device_tensors(self) -> tuple[torch.Tensor, ...]:
+        return (self.cu_seqlens, self.cu_chunks, self.chunk_to_seq)
+
+
+#: 64 entries per device and 64 MiB of device payload,
+#: whichever binds first.
+METADATA_MAX_ENTRIES = 64
+METADATA_MAX_BYTES = 64 * 1024 * 1024
+
+_META_CONTENT = BoundedDeviceCache(
+    "chunk-metadata",
+    max_entries=METADATA_MAX_ENTRIES,
+    max_bytes=METADATA_MAX_BYTES,
+)
+_META_IDENTITY = IdentityCache()
+
+
+def _build_metadata(host: list[int], device: torch.device) -> ChunkMetadata:
+    lengths = [b - a for a, b in zip(host, host[1:], strict=False)]
+    per_sequence = chunks_for_lengths(lengths)
+    cu = [0]
+    for count in per_sequence:
+        cu.append(cu[-1] + count)
+
+    chunk_to_seq: list[int] = []
+    for index, count in enumerate(per_sequence):
+        chunk_to_seq.extend([index] * count)
+
+    def i32(values):
+        return torch.tensor(values, dtype=torch.int32, device=device)
+
+    return ChunkMetadata(
+        cu_seqlens=i32(host),
+        cu_chunks=i32(cu),
+        chunk_to_seq=i32(chunk_to_seq),
+        cu_seqlens_host=tuple(host),
+        cu_chunks_host=tuple(cu),
+        total_chunks=cu[-1],
+        sequence_count=len(per_sequence),
+    )
+
+
+def chunk_metadata(cu_seqlens: torch.Tensor) -> ChunkMetadata:
+    """Build (or reuse) the canonical INT32 metadata for ``cu_seqlens``.
+
+    A content miss copies ``cu_seqlens`` to the host, which synchronizes; that is
+    unavoidable, because the chunk counts are not knowable otherwise.  The
+    identity cache remembers only the bounded cache key -- same tensor object,
+    unmutated -- so every device-payload hit still performs the bounded cache's
+    stream ordering and updates its LRU position.
+    """
+    if cu_seqlens.ndim != 1 or cu_seqlens.numel() < 2:
+        raise ValueError("cu_seqlens must have shape [N + 1]")
+    if cu_seqlens.dtype not in (torch.int32, torch.int64):
+        raise TypeError(f"cu_seqlens must be int32 or int64, got {cu_seqlens.dtype}")
+
+    device = cu_seqlens.device
+    cached_key = _META_IDENTITY.get(cu_seqlens)
+    if cached_key is not None:
+        cached = _META_CONTENT.get(device, cached_key)
+        if cached is not None:
+            return cached
+
+    host = cu_seqlens.detach().to("cpu", torch.int64).tolist()
+    if host[0] != 0:
+        raise ValueError(f"cu_seqlens[0] must be 0, got {host[0]}")
+    if any(b < a for a, b in zip(host, host[1:], strict=False)):
+        raise ValueError("cu_seqlens must be non-decreasing")
+
+    key = (tuple(host),)
+    meta = _META_CONTENT.get(device, key)
+    if meta is None:
+        meta = _build_metadata(host, device)
+        _META_CONTENT.put(device, key, meta, meta.device_tensors())
+    _META_IDENTITY.put(cu_seqlens, key)
+    return meta
+
+
+def metadata_cache_stats(device: torch.device | int):
+    return _META_CONTENT.stats(device)
+
+
+def clear_metadata_cache() -> None:
+    _META_CONTENT.clear()
+    _META_IDENTITY.clear()
+
+
+# ==========================================================================
+
+
+# --------------------------------------------------------------------------
+# Section 5: TMA descriptors
+# --------------------------------------------------------------------------
+
+#: Elements per 128-byte S128 segment, by element size.
+
+DESCRIPTOR_BYTES = 128
+#: Q, K, G, Kd, Qd, Ak.
+NUM_TENSOR_MAPS = 6
+
+#: 64 descriptor sets per device, LRU, for each cache.
+DESCRIPTOR_MAX_ENTRIES = 64
+
+#: Swizzle names accepted by :func:`encode_tensor_map`.  The recurrence needs
+#: ``"NONE"`` for the two 512-byte records that prepare already laid out (plan
+#: Section 12.2 Q2); everything else lands in the S128 image.
+SWIZZLES = ("128B", "NONE")
+
+
+# ---------------------------------------------------------------------------
+# Shared: the encoder, the specification type, and the one geometry both
+# kernels address.
+# ---------------------------------------------------------------------------
+
+
+def encode_tensor_map(
+    dtype: torch.dtype,
+    base_ptr: int,
+    global_dim,
+    strides_bytes,
+    box_dim,
+    *,
+    swizzle: str = "128B",
+) -> bytes:
+    """Encode one ``cuTensorMapEncodeTiled`` descriptor as 128 raw bytes.
+
+    Shared by prepare and the recurrence.  Every map fixes ``interleave=NONE``,
+    unit element strides, 128-byte L2 promotion and ``OOB_FILL_NONE``; only the
+    dtype, geometry and swizzle vary.
+    """
+    import cuda.bindings.driver as drv
+
+    if dtype is torch.bfloat16:
+        tma_dtype = drv.CUtensorMapDataType.CU_TENSOR_MAP_DATA_TYPE_BFLOAT16
+    elif dtype is torch.float32:
+        tma_dtype = drv.CUtensorMapDataType.CU_TENSOR_MAP_DATA_TYPE_FLOAT32
+    else:
+        raise ValueError(f"unsupported TMA element type {dtype}")
+    if swizzle not in SWIZZLES:
+        raise ValueError(f"swizzle must be one of {SWIZZLES}, got {swizzle!r}")
+
+    swizzle_enum = (
+        drv.CUtensorMapSwizzle.CU_TENSOR_MAP_SWIZZLE_128B
+        if swizzle == "128B"
+        else drv.CUtensorMapSwizzle.CU_TENSOR_MAP_SWIZZLE_NONE
+    )
+
+    rank = len(global_dim)
+    err, tmap = drv.cuTensorMapEncodeTiled(
+        tma_dtype,
+        rank,
+        base_ptr,
+        [drv.cuuint64_t(d) for d in global_dim],
+        [drv.cuuint64_t(s) for s in strides_bytes],
+        [drv.cuuint32_t(b) for b in box_dim],
+        [drv.cuuint32_t(1)] * rank,
+        drv.CUtensorMapInterleave.CU_TENSOR_MAP_INTERLEAVE_NONE,
+        swizzle_enum,
+        drv.CUtensorMapL2promotion.CU_TENSOR_MAP_L2_PROMOTION_L2_128B,
+        drv.CUtensorMapFloatOOBfill.CU_TENSOR_MAP_FLOAT_OOB_FILL_NONE,
+    )
+    if int(err) != 0:
+        raise RuntimeError(f"cuTensorMapEncodeTiled failed: {err}")
+    # cuda-python wraps the descriptor, so take its address via getPtr().
+    return bytes(ctypes.string_at(tmap.getPtr(), DESCRIPTOR_BYTES))
+
+
+@dataclass(frozen=True)
+class TensorMapSpec:
+    """Everything ``cuTensorMapEncodeTiled`` is given, and nothing else.
+
+    Two roles that produce equal specs are the same descriptor.  ``role`` is
+    deliberately absent from the comparison; it is carried alongside.
+    """
+
+    dtype: torch.dtype
+    base_ptr: int
+    global_dim: tuple[int, ...]
+    global_stride_bytes: tuple[int, ...]
+    box_dim: tuple[int, ...]
+    swizzle: str
+
+    def validate(self) -> None:
+        """Check the alignment rules a wrong descriptor would otherwise hide."""
+        element_bytes = 2 if self.dtype is torch.bfloat16 else 4
+        if self.base_ptr % 16:
+            raise ValueError(
+                f"TMA global base must be 16-byte aligned, got {self.base_ptr}"
+            )
+        inner_bytes = self.box_dim[0] * element_bytes
+        limit = 128 if self.swizzle == "128B" else 512
+        if inner_bytes % 16 or inner_bytes > limit:
+            raise ValueError(
+                f"TMA inner box is {inner_bytes} B; must be a multiple of 16 "
+                f"and at most {limit} for swizzle {self.swizzle}"
+            )
+        for extent in self.box_dim:
+            if not 1 <= extent <= 256:
+                raise ValueError(f"TMA box extent {extent} outside [1, 256]")
+        for stride in self.global_stride_bytes:
+            if stride % 16:
+                raise ValueError(f"TMA global stride {stride} is not 16-byte aligned")
+        for dim, box in zip(self.global_dim, self.box_dim, strict=True):
+            if dim <= 0:
+                raise ValueError(f"TMA global dim {dim} must be positive")
+            if box > dim and box != self.box_dim[1]:
+                # A box may exceed a degenerate outer dim only through the row
+                # mode, which the tail path relies on; the inner and plane modes
+                # must fit.
+                raise ValueError(f"TMA box {box} exceeds global dim {dim}")
+
+    def encode(self) -> bytes:
+        return encode_tensor_map(
+            self.dtype,
+            self.base_ptr,
+            self.global_dim,
+            self.global_stride_bytes,
+            self.box_dim,
+            swizzle=self.swizzle,
+        )
+
+
+def _spec_fields(geometry: dict) -> dict:
+    """Rename :func:`factor_slab_geometry`'s keys for :class:`TensorMapSpec`.
+
+    The encoder takes ``strides_bytes``; the spec dataclass calls the same
+    field ``global_stride_bytes``.  One adapter beats two copies of the tuple.
+    """
+    return dict(
+        global_dim=geometry["global_dim"],
+        global_stride_bytes=geometry["strides_bytes"],
+        box_dim=geometry["box_dim"],
+    )
+
+
+def factor_slab_geometry(rows: int, heads: int, element_bytes: int = 2) -> dict:
+    """The one description of the fused Kd/Qd/Ak slab, as ``(DK, rows, 3H)``.
+
+    The three regions are the same geometry, the same dtype and exactly
+    adjacent -- ``prepare_region_offsets`` aligns each to 256 bytes and every
+    region size is a multiple of it, so no padding is inserted -- which makes
+    them 3H planes of one tensor rather than three tensors.  Plane ``r*H + h``
+    is region ``r`` (0=Kd, 1=Qd, 2=Ak) of head ``h``.
+
+    prepare writes through this and the recurrence reads through it, and the
+    fused entry passes prepare's encoded descriptor to both kernels, so the two
+    sides cannot be allowed to disagree about it.  Defining it once is what
+    makes that structural rather than a comment asking for care.
+    """
+    return dict(
+        global_dim=(DK, rows, 3 * heads),
+        strides_bytes=(DK * element_bytes, DK * rows * element_bytes),
+        box_dim=(BF16_SEGMENT_ELEMS, BT, 1),
+    )
+
+
+# ---------------------------------------------------------------------------
+# prepare: Q, K, G and the fused factor slab.
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class TensorMapSet:
+    """One device buffer holding all six descriptors, plus their addresses."""
+
+    storage: torch.Tensor
+    q: int
+    k: int
+    g: int
+    #: Kd, Qd and Ak share one descriptor over 3H planes; see _factor_map.
+    factor: int
+
+
+def _encode(
+    dtype: torch.dtype, base_ptr: int, global_dim, strides_bytes, box_dim
+) -> bytes:
+    """Prepare's S128-only shorthand for :func:`encode_tensor_map`."""
+    return encode_tensor_map(dtype, base_ptr, global_dim, strides_bytes, box_dim)
+
+
+def _activation_map(t: torch.Tensor, total_tokens: int, heads: int, segment_elems: int):
+    """Key-major ``(DK, T_total, H)`` view of contiguous ``[1, T, H, DK]``."""
+    esz = t.element_size()
+    return _encode(
+        t.dtype,
+        t.data_ptr(),
+        global_dim=(DK, total_tokens, heads),
+        strides_bytes=(heads * DK * esz, DK * esz),
+        box_dim=(segment_elems, BT, 1),
+    )
+
+
+def _factor_map(ws_kd: torch.Tensor, rows: int, heads: int):
+    """One descriptor over Kd, Qd and Ak as ``(DK, rows, 3H)``.
+
+    The three regions are the same geometry, the same dtype and exactly
+    adjacent -- ``prepare_region_offsets`` aligns each to 256 bytes and every
+    region size is a multiple of it, so no padding is inserted -- which makes
+    them 3H planes of one tensor rather than three tensors.  Plane ``r*H + h``
+    is region ``r`` (0=Kd, 1=Qd, 2=Ak) of head ``h``.
+
+    Geometry comes from :func:`factor_slab_geometry`, which the recurrence's
+    ``"factor"`` role uses too -- the fused ``fwd`` entry hands *this* encoded
+    descriptor to both kernels, so they cannot be allowed to disagree about it.
+    Fusing the three regions also drops prepare's per-chunk
+    ``fence_tensormap_acquire`` from three to one.
+    """
+    return _encode(
+        ws_kd.dtype,
+        ws_kd.data_ptr(),
+        **factor_slab_geometry(rows, heads, ws_kd.element_size()),
+    )
+
+
+#: the design requires the prepare cache to carry the same event / LRU /
+#: lifetime contract as the recurrence one; a plain dict keyed on addresses grew
+#: without bound and never ordered a cross-stream hit against its own upload.
+_TENSOR_MAP_CACHE = BoundedDeviceCache(
+    "prepare-descriptors", max_entries=DESCRIPTOR_MAX_ENTRIES
+)
+
+
+def prepare_descriptor_cache_stats(device):
+    return _TENSOR_MAP_CACHE.stats(device)
+
+
+def clear_prepare_descriptor_cache() -> None:
+    _TENSOR_MAP_CACHE.clear()
+
+
+def build_tensor_maps(
+    *,
+    q: torch.Tensor,
+    k: torch.Tensor,
+    g: torch.Tensor,
+    ws_kd: torch.Tensor,
+    ws_qd: torch.Tensor,
+    ws_ak: torch.Tensor,
+    total_tokens: int,
+    total_chunks: int,
+    heads: int,
+) -> TensorMapSet:
+    """Build (and cache) the six The descriptors.
+
+    Encoding six descriptors and copying them to the device costs far more than
+    a launch, so the set is cached on the tensor addresses and shape.  The
+    benchmark reuses its buffers, so this is a hit after the first call.
+    """
+    rows = total_chunks * BT
+    # A 128-byte S128 segment is 32 FP32 or 64 BF16, so G's box follows its
+    # dtype; _encode already picks the TMA element type from it.
+    g_segment_elems = (
+        F32_SEGMENT_ELEMS if g.dtype is torch.float32 else BF16_SEGMENT_ELEMS
+    )
+    key = (
+        q.data_ptr(),
+        k.data_ptr(),
+        g.data_ptr(),
+        g.dtype,
+        ws_kd.data_ptr(),
+        ws_qd.data_ptr(),
+        ws_ak.data_ptr(),
+        total_tokens,
+        rows,
+        heads,
+    )
+    hit = _TENSOR_MAP_CACHE.get(q.device, key)
+    if hit is not None:
+        return hit
+
+    blobs = [
+        _activation_map(q, total_tokens, heads, BF16_SEGMENT_ELEMS),
+        _activation_map(k, total_tokens, heads, BF16_SEGMENT_ELEMS),
+        _activation_map(g, total_tokens, heads, g_segment_elems),
+        _factor_map(ws_kd, rows, heads),
+    ]
+    packed = bytearray()
+    for b in blobs:
+        packed += b
+    storage = upload_bytes(packed, q.device)
+    if storage.data_ptr() % 64 != 0:
+        raise RuntimeError("tensor map storage must be 64-byte aligned")
+
+    base = storage.data_ptr()
+    maps = TensorMapSet(
+        storage=storage,
+        q=base + 0 * DESCRIPTOR_BYTES,
+        k=base + 1 * DESCRIPTOR_BYTES,
+        g=base + 2 * DESCRIPTOR_BYTES,
+        factor=base + 3 * DESCRIPTOR_BYTES,
+    )
+    return _TENSOR_MAP_CACHE.put(q.device, key, maps, (storage,))
+
+
+# ---------------------------------------------------------------------------
+# recurrence (the design-7.4): seven roles, at most seven descriptors.
+#
+# The specifications are plain data and need no CUDA context, so the geometry,
+# the factor-plane coordinates and the exact-alias reuse count are all testable
+# on the host; encoding and upload happen separately.
+# ---------------------------------------------------------------------------
+
+
+#: Descriptor roles, in the order they are packed into the upload buffer.
+ROLES = ("factor", "aq", "gt", "v", "out", "state_in", "state_out")
+
+#: Plane order inside the fused factor descriptor.
+FACTOR_PLANES = ("kd", "qd", "ak")
+
+
+def factor_plane(factor: str, head: int, heads: int) -> int:
+    """``Kd -> head``, ``Qd -> H + head``, ``Ak -> 2H + head``."""
+    return FACTOR_PLANES.index(factor) * heads + head
+
+
+def assert_factor_regions_are_fused(workspace, heads: int, total_chunks: int) -> None:
+    """Refuse a workspace whose Kd/Qd/Ak are not one contiguous BF16 slab.
+
+    the design requires this rather than a fallback: a temporary
+    per-factor descriptor would silently change the descriptor count and the
+    coordinates the kernel is compiled against.
+    """
+    stride = heads * total_chunks * BT * DK * 2
+    base = workspace.kd.data_ptr()
+    for index, name in enumerate(("qd", "ak"), start=1):
+        got = getattr(workspace, name).data_ptr()
+        want = base + index * stride
+        if got != want:
+            raise ValueError(
+                f"prepare workspace region {name} is at {got}, expected "
+                f"{want} ({index} x {stride} B after Kd); the recurrence's "
+                "fused factor descriptor requires Kd/Qd/Ak to be adjacent"
+            )
+
+
+def recurrence_tensor_map_specs(
+    *,
+    kd_ptr: int,
+    aq_ptr: int,
+    gt_ptr: int,
+    v_ptr: int,
+    out_ptr: int,
+    heads: int,
+    total_tokens: int,
+    total_chunks: int,
+    sequences: int,
+    state_in_ptr: int | None = None,
+    state_out_ptr: int | None = None,
+    state_dtype: torch.dtype | None = None,
+) -> dict[str, TensorMapSpec]:
+    """Build the the design / 7.3 specifications as plain data."""
+    rows = BT * total_chunks
+    specs: dict[str, TensorMapSpec] = {
+        # Kd/Qd/Ak fused: 3H planes of R rows of 128 BF16 keys.  The geometry
+        # is prepare's -- literally the same function -- because the fused
+        # entry gives prepare's encoded descriptor to this kernel as well.
+        "factor": TensorMapSpec(
+            dtype=torch.bfloat16,
+            base_ptr=kd_ptr,
+            swizzle="128B",
+            **_spec_fields(factor_slab_geometry(rows, heads)),
+        ),
+        # The 16x16 pairwise record prepare already wrote in its SW32 image:
+        # moved verbatim, so no second swizzle is applied here.
+        "aq": TensorMapSpec(
+            dtype=torch.bfloat16,
+            base_ptr=aq_ptr,
+            global_dim=(BT * BT, total_chunks, heads),
+            global_stride_bytes=(BT * BT * 2, total_chunks * BT * BT * 2),
+            box_dim=(BT * BT, 1, 1),
+            swizzle="NONE",
+        ),
+        "gt": TensorMapSpec(
+            dtype=torch.float32,
+            base_ptr=gt_ptr,
+            global_dim=(DK, total_chunks, heads),
+            global_stride_bytes=(DK * 4, total_chunks * DK * 4),
+            box_dim=(DK, 1, 1),
+            swizzle="NONE",
+        ),
+    }
+    # V and out are the same geometry over [1, T, H, 128]; when they are also
+    # the same storage they collapse to one descriptor by equality.
+    activation = dict(
+        dtype=torch.bfloat16,
+        global_dim=(DV, total_tokens, heads),
+        global_stride_bytes=(heads * DV * 2, DV * 2),
+        box_dim=(DV_HALF, BT, 1),
+        swizzle="128B",
+    )
+    specs["v"] = TensorMapSpec(base_ptr=v_ptr, **activation)
+    specs["out"] = TensorMapSpec(base_ptr=out_ptr, **activation)
+
+    if state_in_ptr is not None or state_out_ptr is not None:
+        if state_dtype is None:
+            raise ValueError("state_dtype is required when a state is present")
+        state = _state_spec_fields(state_dtype, sequences * heads)
+        if state_in_ptr is not None:
+            specs["state_in"] = TensorMapSpec(base_ptr=state_in_ptr, **state)
+        if state_out_ptr is not None:
+            specs["state_out"] = TensorMapSpec(base_ptr=state_out_ptr, **state)
+
+    for spec in specs.values():
+        spec.validate()
+    return specs
+
+
+def _state_spec_fields(state_dtype: torch.dtype, planes: int) -> dict:
+    """one full-tile instruction moves a whole state half.
+
+    The unswizzled state address is ``v * 128 + k``, so a 128-byte S128 segment
+    is 64 BF16 or 32 FP32 and the descriptor's inner mode *is* that segment.  The
+    row mode then counts segments, which is why a DV half starts at row 128
+    (BF16) or 256 (FP32) rather than at value 64.
+    """
+    if state_dtype is torch.bfloat16:
+        inner, rows_per_value = BF16_SEGMENT_ELEMS, STATE_BF16_ROWS_PER_VALUE
+        element_bytes = 2
+    elif state_dtype is torch.float32:
+        inner, rows_per_value = F32_SEGMENT_ELEMS, STATE_F32_ROWS_PER_VALUE
+        element_bytes = 4
+    else:
+        raise ValueError(f"unsupported state dtype {state_dtype}")
+    rows = rows_per_value * DV
+    return dict(
+        dtype=state_dtype,
+        global_dim=(inner, rows, planes),
+        global_stride_bytes=(inner * element_bytes, rows * inner * element_bytes),
+        box_dim=(inner, rows // 2, 1),
+        swizzle="128B",
+    )
+
+
+def state_box_bytes(state_dtype: torch.dtype) -> int:
+    """Transaction bytes of one state-half TMA (16 KiB BF16, 32 KiB FP32)."""
+    fields = _state_spec_fields(state_dtype, 1)
+    element_bytes = 2 if state_dtype is torch.bfloat16 else 4
+    return fields["box_dim"][0] * fields["box_dim"][1] * element_bytes
+
+
+def unique_descriptors(specs: dict[str, TensorMapSpec]) -> list[TensorMapSpec]:
+    """Distinct descriptors, in first-use order; equality *is* exact alias."""
+    seen: list[TensorMapSpec] = []
+    for role in ROLES:
+        spec = specs.get(role)
+        if spec is not None and spec not in seen:
+            seen.append(spec)
+    return seen
+
+
+def descriptor_count(specs: dict[str, TensorMapSpec]) -> int:
+    return len(unique_descriptors(specs))
+
+
+@dataclass(frozen=True)
+class RecurrenceTensorMaps:
+    """Device addresses of each role's descriptor, plus the backing storage."""
+
+    storage: torch.Tensor
+    addresses: dict[str, int]
+
+    def address(self, role: str) -> int:
+        """Descriptor address, or 0 for a role this launch does not use."""
+        return self.addresses.get(role, 0)
+
+
+def build_recurrence_tensor_maps(
+    specs: dict[str, TensorMapSpec], device: torch.device
+) -> RecurrenceTensorMaps:
+    """Encode the distinct descriptors and upload them as one device buffer."""
+    distinct = unique_descriptors(specs)
+    packed = bytearray()
+    for spec in distinct:
+        packed += spec.encode()
+    storage = upload_bytes(packed, device)
+    if storage.data_ptr() % 64:
+        raise RuntimeError("tensor map storage must be 64-byte aligned")
+
+    base = storage.data_ptr()
+    slot = {spec: base + i * DESCRIPTOR_BYTES for i, spec in enumerate(distinct)}
+    return RecurrenceTensorMaps(
+        storage=storage,
+        addresses={role: slot[spec] for role, spec in specs.items()},
+    )
+
+
+#: 64 descriptor sets per device, LRU.  The key is every
+#: field of every role's specification, so a buffer that moves, changes shape
+#: or changes swizzle is a different entry rather than a stale hit.
+_DESCRIPTORS = BoundedDeviceCache(
+    "recurrence-descriptors", max_entries=DESCRIPTOR_MAX_ENTRIES
+)
+
+
+def descriptor_cache_key(specs: dict[str, TensorMapSpec]) -> tuple:
+    return tuple((role, specs[role]) for role in ROLES if role in specs)
+
+
+def get_recurrence_tensor_maps(
+    specs: dict[str, TensorMapSpec], device: torch.device
+) -> RecurrenceTensorMaps:
+    """Cached :func:`build_recurrence_tensor_maps`.
+
+    Encoding seven descriptors and copying 896 bytes to the device costs far
+    more than the launch itself, so a steady-state call must hit.  A hit on
+    another stream waits on the upload event; it never synchronizes the host.
+    """
+    key = descriptor_cache_key(specs)
+    hit = _DESCRIPTORS.get(device, key)
+    if hit is not None:
+        return hit
+    maps = build_recurrence_tensor_maps(specs, device)
+    return _DESCRIPTORS.put(device, key, maps, (maps.storage,))
+
+
+def recurrence_descriptor_cache_stats(device: torch.device | int):
+    return _DESCRIPTORS.stats(device)
+
+
+def clear_recurrence_descriptor_cache() -> None:
+    _DESCRIPTORS.clear()
+
+
+# --------------------------------------------------------------------------
+# Section 6: recurrence host plan, arena and grid
+# --------------------------------------------------------------------------
+
+# --- Warp roles ------------------------------------------
+
+LOAD_WARP = COMPUTE_WARPS  # 8
+STORE_WARP = COMPUTE_WARPS + 1  # 9
+REC_WARPS = COMPUTE_WARPS + 2  # 10
+REC_THREADS = REC_WARPS * 32  # 320
+#: Value columns one compute warp owns for the whole kernel.
+
+# --- Ring depths -----------------------------------------
+
+INPUT_STAGES = 5
+OUTPUT_STAGES = 2
+
+# --- Input stage layout ----------------------------------
+
+STAGE_KD = 0
+STAGE_QD = 4096
+STAGE_AK = 8192
+STAGE_AQ = 12288
+STAGE_GT = 12800
+STAGE_V = 13312
+INPUT_STAGE_BYTES = 15360
+
+#: One ``arrive_and_expect_tx`` covers all nine loads of a stage.
+INPUT_STAGE_TX_BYTES = INPUT_STAGE_BYTES
+#: 2 Kd + 2 Qd + 2 Ak + 1 Aq + 1 GTotal + 1 V.
+INPUT_TMA_INSTRUCTIONS = 9
+
+OUTPUT_STAGE_BYTES = BT * DV_HALF * 2  # 2048
+
+# --- Arena -----------------------------------------------
+
+SMEM_STATE = 0
+STATE_BYTES = DV_HALF * DK * 2  # 16384
+SMEM_INPUT = SMEM_STATE + STATE_BYTES  # 16384
+SMEM_OUTPUT = SMEM_INPUT + INPUT_STAGES * INPUT_STAGE_BYTES  # 93184
+REC_SMEM_BARRIERS = SMEM_OUTPUT + OUTPUT_STAGES * OUTPUT_STAGE_BYTES  # 97280
+
+MBAR_INPUT_READY = 0
+MBAR_INPUT_CONSUMED = MBAR_INPUT_READY + INPUT_STAGES * 8  # 40
+MBAR_OUTPUT_READY = MBAR_INPUT_CONSUMED + INPUT_STAGES * 8  # 80
+MBAR_OUTPUT_CONSUMED = MBAR_OUTPUT_READY + OUTPUT_STAGES * 8  # 96
+MBAR_STATE_READY = MBAR_OUTPUT_CONSUMED + OUTPUT_STAGES * 8  # 112
+BARRIER_BYTES = MBAR_STATE_READY + 8  # 120
+NUM_BARRIERS = BARRIER_BYTES // 8  # 15
+
+SMEM_RAW_END = REC_SMEM_BARRIERS + BARRIER_BYTES  # 97400
+
+#: the design fixes the launch size at 97,536 B and calls it the 128-byte
+#: alignment of 97,400.  Rounding 97,400 up to 128 is 97,408; 97,536 is the
+#: round-up to **256**, which is what the plan's own two other statements say --
+#: "120 B barrier and the trailing alignment together take 256 B" and "3,840 B
+#: remain against the 101,376 B ceiling".  The barrier arena therefore owns a
+#: full 256-byte block, and 97,536 is the number the resource gate checks.
+SMEM_ALIGNMENT = 256
+SMEM_DYNAMIC_BYTES = (
+    (SMEM_RAW_END + SMEM_ALIGNMENT - 1) // SMEM_ALIGNMENT * SMEM_ALIGNMENT
+)  # 97536
+
+#: The FP32 external-state conversion buffer borrows the head of the pipeline
+#: union.  It is live only before the input ring starts and after it drains, so
+#: it does not raise the peak.
+SMEM_STATE_F32 = SMEM_INPUT
+STATE_F32_BYTES = DV_HALF * DK * 4  # 32768
+
+#: CC 12.0 per-CTA shared memory, and the driver's own per-CTA overhead.  The
+#: launch parameter excludes the driver's share; residency does not.
+REC_SMEM_PER_CTA_BYTES = 99 * 1024  # 101376
+REC_SMEM_PER_SM_BYTES = 100 * 1024  # 102400
+REC_DRIVER_SMEM_PER_BLOCK_BYTES = 1024
+MIN_BLOCKS_PER_MP = 1
+
+# --- Arrival counts --------------------------------------
+
+INPUT_READY_ARRIVALS = 1  # completed by transaction bytes
+INPUT_CONSUMED_ARRIVALS = COMPUTE_WARPS  # one per compute warp, not per thread
+OUTPUT_READY_ARRIVALS = COMPUTE_WARPS
+OUTPUT_CONSUMED_ARRIVALS = 1
+STATE_READY_ARRIVALS = 1
+
+
+def smem_regions() -> dict[str, tuple[int, int]]:
+    """``{name: (offset, bytes)}`` for every region of the fixed arena."""
+    regions: dict[str, tuple[int, int]] = {"state": (SMEM_STATE, STATE_BYTES)}
+    for stage in range(INPUT_STAGES):
+        regions[f"input{stage}"] = (
+            SMEM_INPUT + stage * INPUT_STAGE_BYTES,
+            INPUT_STAGE_BYTES,
+        )
+    for stage in range(OUTPUT_STAGES):
+        regions[f"output{stage}"] = (
+            SMEM_OUTPUT + stage * OUTPUT_STAGE_BYTES,
+            OUTPUT_STAGE_BYTES,
+        )
+    regions["barriers"] = (REC_SMEM_BARRIERS, BARRIER_BYTES)
+    return regions
+
+
+def input_stage_base(stage: int) -> int:
+    return SMEM_INPUT + stage * INPUT_STAGE_BYTES
+
+
+def output_stage_base(stage: int) -> int:
+    return SMEM_OUTPUT + stage * OUTPUT_STAGE_BYTES
+
+
+# ---------------------------------------------------------------------------
+# Ring phase equations.
+#
+# Written with ``//``, ``*``, ``-`` and ``^`` only so the same bodies evaluate
+# for Python ``int`` on the host and ``cutlass.Int32`` on the device.
+# ---------------------------------------------------------------------------
+
+
+def input_stage(chunk):
+    return chunk - (chunk // INPUT_STAGES) * INPUT_STAGES
+
+
+def input_generation(chunk):
+    return chunk // INPUT_STAGES
+
+
+def input_ready_parity(chunk):
+    """Compute warps: pass once the slot's TMA has landed ``ig + 1`` times."""
+    return input_generation(chunk) & 1
+
+
+def input_consumed_parity(chunk):
+    """Load warp: pass once all 8 compute warps have released the slot ``ig``
+    times.  Generation 0 passes against the initial phase with no seeding."""
+    return 1 ^ (input_generation(chunk) & 1)
+
+
+def output_stage(chunk):
+    return chunk - (chunk // OUTPUT_STAGES) * OUTPUT_STAGES
+
+
+def output_generation(chunk):
+    return chunk // OUTPUT_STAGES
+
+
+def output_ready_parity(chunk):
+    """Store warp: pass once all 8 compute warps have filled the slot."""
+    return output_generation(chunk) & 1
+
+
+def output_consumed_parity(chunk):
+    """Compute warps: pass once the store warp has finished reading the slot."""
+    return 1 ^ (output_generation(chunk) & 1)
+
+
+# ---------------------------------------------------------------------------
+# Launch geometry
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class RecurrencePlan:
+    """Everything the recurrence launch needs, with nothing launched yet."""
+
+    tensor_maps: object
+    sequences: int
+    has_state_in: bool
+    has_state_out: bool
+    state_dtype: torch.dtype | None
+
+
+def recurrence_grid(sequences: int, heads: int) -> tuple[int, int, int]:
+    """``(2N, H, 1)``: one CTA per ``(sequence, head, DV half)``, DV fastest.
+
+    The DV half must be the fastest-varying block coordinate.  The two halves
+    of one head read the *same* Kd/Qd/Ak/Aq/GTotal -- only V and the output
+    differ -- and L2 serves the second reader entirely: at H=64 the kernel's
+    DRAM read is 572.9 MB against 570.4 MB of unique bytes, where re-reading
+    the factors per half would be 1006.6 MB.  That reuse needs the two halves
+    *co-resident*, and shared memory pins the recurrence at one CTA per SM, so
+    co-resident means "in the same wave", which means "adjacent".
+
+    The old ``(N, 2H, 1)`` issued blocks in the order ``seq + N * (2 * head +
+    dv_half)``, separating the halves of a head by ``N`` blocks.  Past ``2N >
+    SMs`` some pairs straddle a wave boundary and past ``N >= SMs`` all of them
+    do: the first wave is every ``dv_half = 0`` CTA and the second is every
+    ``dv_half = 1`` CTA, so every factor is read from DRAM twice.  Measured on
+    a 188-SM SM120 device at T=2048, holding the work fixed and only
+    refactoring ``P = N * H``:
+
+        P=188 as 188x1 -> 573.7 us, L2 hit 0.07%, DRAM read 745.4 MB
+        P=188 as  94x2 -> 382.1 us, L2 hit 37.7%, DRAM read 425.1 MB
+
+    and at P=94 -- one wave, where the halves land together either way -- all
+    four factorizations of P agree to within 3%, which is what makes the wave
+    boundary and not the tensor shape the cause.
+
+    ``(2N, H, 1)`` rather than ``(2, NH, 1)`` because ``maxGridSize[1]`` is
+    65,535 and ``N * H`` overflows it well inside the supported range, while
+    ``2N`` sits in ``maxGridSize[0] = 2^31 - 1`` and ``H`` is small.  Rather
+    than ``(2H, N, 1)`` -- which also pairs the halves -- because a wave should
+    cover one head's sequences, not one sequence's heads: the latter costs 4%
+    at B=4, H=96 (197.7 us against 205.2 us).  That keeps the traversal order
+    ``(N, 2H, 1)`` already had; only the DV half moves.
+    """
+    return (2 * sequences, heads, 1)
+
+
+def dv_half_of(block_x: int) -> int:
+    return block_x & 1
+
+
+def seq_of(block_x: int) -> int:
+    return block_x >> 1
+
+
+def head_of(block_y: int) -> int:
+    return block_y
+
+
+# ---------------------------------------------------------------------------
+# Host validation and launch
+# ---------------------------------------------------------------------------
+
+INT32_MAX = 2**31 - 1
+
+
+def checked_i32(name: str, value) -> int:
+    """Reject anything that would not survive the device's INT32 indexing.
+
+    the design requires every derived extent to be checked on the host
+    before any workspace, descriptor or launch exists, rather than relying on a
+    device cast to truncate silently.
+    """
+    number = int(value)
+    if number < 0 or number > INT32_MAX:
+        raise ValueError(f"{name} must fit in a non-negative INT32, got {number}")
+    return number
+
+
+def check_recurrence_ranges(
+    *,
+    total_tokens: int,
+    total_chunks: int,
+    sequences: int,
+    heads: int,
+    cu_seqlens_host: list[int],
+    cu_chunks_host: list[int],
+    device: torch.device,
+) -> None:
+    """Check every index the recurrence derives, before anything is allocated."""
+    checked_i32("T_total", total_tokens)
+    checked_i32("total_chunks", total_chunks)
+    checked_i32("R = 16 * total_chunks", BT * total_chunks)
+    checked_i32("N", sequences)
+    checked_i32("H", heads)
+    checked_i32("2 * H", 2 * heads)
+    checked_i32("3 * H", 3 * heads)
+    checked_i32("N * H", sequences * heads)
+    # grid[0] = 2N is a block coordinate the kernel halves back into a
+    # sequence, so it is a derived extent like any other.
+    checked_i32("2 * N", 2 * sequences)
+    for index, value in enumerate(cu_seqlens_host):
+        checked_i32(f"cu_seqlens[{index}]", value)
+    for index, value in enumerate(cu_chunks_host):
+        checked_i32(f"cu_chunks[{index}]", value)
+    if total_tokens:
+        checked_i32("max token_base + 15", total_tokens - 1 + BT)
+    if total_chunks:
+        checked_i32("max 16 * gchunk + 15", BT * (total_chunks - 1) + BT - 1)
+        checked_i32("max factor plane", 3 * heads - 1)
+        # The flat output is bounded by its element count rather than by its
+        # largest index: the DSL packs a memref extent as INT32, so it stops one
+        # element before the index does.  Shared with ``fused``, which reaches
+        # the same limit through the same store.
+        check_flat_output_range(total_tokens, heads)
+
+    grid = recurrence_grid(sequences, heads)
+    limits = max_grid_dims(device)
+    for axis, (extent, limit) in enumerate(zip(grid[:2], limits, strict=False)):
+        if extent > limit:
+            raise ValueError(
+                f"grid[{axis}] = {extent} exceeds maxGridSize[{axis}] = {limit}"
+            )
+
+
+def validate_state(
+    state: torch.Tensor | None,
+    name: str,
+    *,
+    sequences: int,
+    heads: int,
+    device: torch.device,
+) -> None:
+    if state is None:
+        return
+    shape = (sequences, heads, DV, DK)
+    if tuple(state.shape) != shape:
+        raise ValueError(f"{name} must have shape {shape}, got {tuple(state.shape)}")
+    if state.dtype not in (torch.bfloat16, torch.float32):
+        raise TypeError(f"{name} must be bfloat16 or float32, got {state.dtype}")
+    if not state.is_cuda or state.device != device:
+        raise ValueError(f"{name} must be a CUDA tensor on {device}")
+    if not state.is_contiguous():
+        raise ValueError(f"{name} must be contiguous")
+
+
+def launch_recurrence(
+    *,
+    workspace,
+    v: torch.Tensor,
+    out: torch.Tensor,
+    cu_seqlens_i32: torch.Tensor,
+    cu_chunks_i32: torch.Tensor,
+    cu_seqlens_host: list[int],
+    cu_chunks_host: list[int],
+    heads: int,
+    total_tokens: int,
+    total_chunks: int,
+    initial_state: torch.Tensor | None = None,
+    final_state: torch.Tensor | None = None,
+    stream=None,
+    plan_only: bool = False,
+) -> RecurrencePlan | None:
+    """Run the recurrence in place over ``out`` and the optional final state.
+
+    With ``plan_only``, do every host-side step -- validation, descriptor
+    encoding, stream recording -- and return the result instead of launching.
+    ``fwd`` uses that to hand both kernels to one compiled entry, so the
+    Python/compiled boundary is crossed once per forward rather than twice.
+
+    Private: the design keeps ``fwd`` as the only public entry point.  The
+    caller is responsible for the public ABI checks; what is enforced here is
+    what the *kernel* depends on -- the fused factor slab, the state geometry
+    and the INT32 index ranges.
+    """
+
+    device = v.device
+    require_sm120a(device)
+    sequences = len(cu_seqlens_host) - 1
+
+    if total_chunks == 0:
+        # the caller must take the host state-only fast path
+        # before any descriptor exists.  A zero-extent factor descriptor is not
+        # encodable, so failing here is the honest outcome rather than a
+        # silently degenerate launch.
+        raise ValueError(
+            "launch_recurrence requires total_chunks == 0 to be handled by the "
+            "host state-only fast path"
+        )
+
+    check_recurrence_ranges(
+        total_tokens=total_tokens,
+        total_chunks=total_chunks,
+        sequences=sequences,
+        heads=heads,
+        cu_seqlens_host=cu_seqlens_host,
+        cu_chunks_host=cu_chunks_host,
+        device=device,
+    )
+    validate_state(
+        initial_state, "initial_state", sequences=sequences, heads=heads, device=device
+    )
+    validate_state(
+        final_state, "final_state", sequences=sequences, heads=heads, device=device
+    )
+    if initial_state is not None and final_state is not None:
+        if initial_state.dtype != final_state.dtype:
+            raise TypeError(
+                "initial_state and final_state must share a dtype, got "
+                f"{initial_state.dtype} and {final_state.dtype}"
+            )
+    assert_factor_regions_are_fused(workspace, heads, total_chunks)
+
+    state_dtype = None
+    if initial_state is not None:
+        state_dtype = initial_state.dtype
+    elif final_state is not None:
+        state_dtype = final_state.dtype
+
+    specs = recurrence_tensor_map_specs(
+        kd_ptr=workspace.kd.data_ptr(),
+        aq_ptr=workspace.aq.data_ptr(),
+        gt_ptr=workspace.g_total.data_ptr(),
+        v_ptr=v.data_ptr(),
+        out_ptr=out.data_ptr(),
+        heads=heads,
+        total_tokens=total_tokens,
+        total_chunks=total_chunks,
+        sequences=sequences,
+        state_in_ptr=None if initial_state is None else initial_state.data_ptr(),
+        state_out_ptr=None if final_state is None else final_state.data_ptr(),
+        state_dtype=state_dtype,
+    )
+    tensor_maps = get_recurrence_tensor_maps(specs, device)
+
+    # every buffer this raw launch touches is recorded on the
+    # current stream, exact aliases once, so the allocator cannot hand a block
+    # back while the kernel is still reading it.
+    record_stream_once(
+        (
+            v,
+            out,
+            workspace.storage,
+            cu_seqlens_i32,
+            cu_chunks_i32,
+            initial_state,
+            final_state,
+            tensor_maps.storage,
+        ),
+        torch.cuda.current_stream(device),
+    )
+
+    plan = RecurrencePlan(
+        tensor_maps=tensor_maps,
+        sequences=sequences,
+        has_state_in=initial_state is not None,
+        has_state_out=final_state is not None,
+        state_dtype=state_dtype,
+    )
+    if plan_only:
+        return plan
+
+    launch_recurrence_device(
+        out=out,
+        cu_seqlens_i32=cu_seqlens_i32,
+        cu_chunks_i32=cu_chunks_i32,
+        tensor_maps=tensor_maps,
+        heads=heads,
+        sequences=sequences,
+        has_state_in=initial_state is not None,
+        has_state_out=final_state is not None,
+        state_dtype=state_dtype,
+        stream=stream,
+    )
+    return None
+
+
+# --------------------------------------------------------------------------
+# Section 7: prepare host plan, arena and residency
+# --------------------------------------------------------------------------
+
+PREP_WARPS = 4
+PREP_THREADS = PREP_WARPS * 32
+
+#: CPC 2 is the measured optimum on sm_120, the supported target:
+#:
+#:   fixed_h96   1: 971.20us   2: 960.00us   3: 965.12us   4: 974.94us
+#:   fixed_h64   1: 630.11us   2: 623.84us   3: 631.17us   4: 633.79us
+#:
+#: Depth 2 is where the chunk prefetch first pays -- DRAM utilisation 90.51%
+#: to 91.27%, CTA count halved -- and past 2 the extra CTA-wide barriers cost
+#: more than the overlap wins.
+DEFAULT_PREP_CHUNKS_PER_CTA = 2
+
+#: The optimum moves with the memory system, so the default follows the device.
+#: sm_120 saturates DRAM at ~90%, where extra chunks buy nothing and only add
+#: barriers.  sm_90 (H20) sits at ~40%, where the prefetch has room to pay:
+#:
+#:   H20 fixed_h64   1: 903.9   2: 550.4   3: 506.6   4: 486.3   5: 508.1us
+#:   H20 fixed_h96   2: 808.9   3: 741.0   4: 722.2   5: 783.6   6: 1100us
+#:
+#: 4 is the peak on both H20 cases and 5 is already past it; by 8 instruction
+#: issue has collapsed under the unrolled chunk loop.
+#:
+#: sm_100 (B200) behaves like sm_90, not like sm_120 -- it also has bandwidth
+#: to spare relative to this kernel, so the prefetch keeps paying past depth 2:
+#:
+#:   B200 fixed_h96   1: 1112.5   2: 560.4   3: 449.0   4: 424.2us
+#:   B200 fixed_h64   1:  662.9   2: 361.8   3: 300.4   4: 288.2us
+#:
+#: Falling back to the sm_120 value of 2 there cost 1.32x on h96 and 1.26x on
+#: h64, which is a large part of why the first B200 measurements were *slower*
+#: than FlashKDA -- a default tuned for one memory system silently applied to
+#: another.
+#:
+#: sm_90 and sm_100 are experiments and not targets (see target.py); their
+#: entries here only make those measurements reproducible without an explicit
+#: chunks_per_cta, and nothing in the test matrix exercises them.
+DEFAULT_PREP_CHUNKS_PER_CTA_BY_CAPABILITY = {
+    (12, 0): 2,
+    (10, 0): 4,
+    (9, 0): 4,
+}
+
+#: log2(e); the gate is evaluated in the log2 domain.
+_LOG2_E = 1.4426950408889634
+
+SUPPORTED_PREP_CHUNKS_PER_CTA = (1, 2, 3, 4)
+SUPPORTED_MIN_BLOCKS_PER_SM = (1, 2, 3)
+
+# --- SMEM arena byte offsets -------------------------------
+# Layout when Ki and QK have their own stages, i.e. CPC > 1.
+SMEM_KD_THEN_AK = 0
+SMEM_QD = 4096
+SMEM_Q_RAW = 8192
+SMEM_K_RAW = 12288
+SMEM_GATE_EXPG = 16384
+SMEM_KI = 24576
+SMEM_AINV = 28672
+SMEM_GAMMA_BF16 = 29184
+SMEM_BETA_ACT = 29440
+PREP_SMEM_BARRIERS = 29568
+SMEM_QK = 29616
+SMEM_ARENA_BYTES = 30128
+
+#: Six 64-bit mbarriers inside the 48-byte barrier arena.
+PREP_MBAR_TMA0 = PREP_SMEM_BARRIERS + 0
+PREP_MBAR_TMA1 = PREP_SMEM_BARRIERS + 8
+PREP_MBAR_K_HALF_READY = PREP_SMEM_BARRIERS + 16
+PREP_MBAR_K_FULL_READY = PREP_SMEM_BARRIERS + 24
+PREP_MBAR_RAW_RELEASED = PREP_SMEM_BARRIERS + 32
+PREP_MBAR_PAIRWISE_READY = PREP_SMEM_BARRIERS + 40
+
+#: Expected TMA load bytes per chunk: Q 4096 + K 4096 + G 8192.
+TMA_LOAD_BYTES_PER_CHUNK = 16384
+#: Same with the opt-in BF16 G: only G moves, 8192 -> 4096.  The SMEM stage
+#: stays 8192 bytes either way, because it is overwritten by FP32 ``exp_g``.
+TMA_LOAD_BYTES_PER_CHUNK_G_BF16 = 12288
+
+#: CC 12.0 shared-memory limits.
+PREP_SMEM_PER_SM_BYTES = 100 * 1024
+PREP_SMEM_PER_CTA_BYTES = 99 * 1024
+#: Static SMEM does not need the ``cudaFuncSetAttribute`` opt-in below 48 KiB.
+STATIC_SMEM_LIMIT_BYTES = 48 * 1024
+
+#: The driver adds 1024 bytes per CTA on top of the arena (NCU: "Driver Shared
+#: Memory Per Block 1.02 Kbyte"), so the residency thresholds are on
+#: arena + PREP_DRIVER_SMEM_PER_BLOCK_BYTES, not on the arena alone.  A fourth
+#: resident CTA therefore needs the arena at 102400/4 - 1024 = 24,576 B.
+#:
+#: Aliasing Ki onto the dead raw Q stage and QK onto raw K was tried and
+#: reverted: it reaches 25,520 B, still 944 B short of four CTAs, and cost
+#: 0.3-2.0% because Ki and Q sharing an address stops the compiler reordering
+#: the Kd/Ki/Qd loop.  Getting to 24,576 needs a structural change, not another
+#: alias -- gamma is live through that loop and beta from the prologue, so
+#: neither can move onto a raw stage.
+PREP_DRIVER_SMEM_PER_BLOCK_BYTES = 1024
+SMEM_FOR_FOUR_CTAS = PREP_SMEM_PER_SM_BYTES // 4 - PREP_DRIVER_SMEM_PER_BLOCK_BYTES
+
+#: A four-CTA arena is reachable -- at CPC == 1, Qd over raw Q plus Ki over raw
+#: K frees 8192 B and lands here, with NCU confirming four resident CTAs and
+#: 32.9% achieved occupancy.  It was measured and not kept: it is 0.24-2.36%
+#: slower, because the kernel is at ~90% of peak DRAM and the extra warps have
+#: nothing to issue, while every CTA-wide rendezvous gets longer.  Occupancy is
+#: not this kernel's constraint; bytes are.
+SMEM_ARENA_BYTES_FOUR_CTA = SMEM_ARENA_BYTES - 2 * 4096
+
+
+@dataclass(frozen=True)
+class PrepareConfig:
+    """Compile-time configuration; part of the compile cache key."""
+
+    safe_gate: bool
+    chunks_per_cta: int = DEFAULT_PREP_CHUNKS_PER_CTA
+    min_blocks_per_sm: int = 1
+
+    def __post_init__(self) -> None:
+        if self.chunks_per_cta not in SUPPORTED_PREP_CHUNKS_PER_CTA:
+            raise ValueError(
+                f"PREP_CHUNKS_PER_CTA must be one of "
+                f"{SUPPORTED_PREP_CHUNKS_PER_CTA}, got {self.chunks_per_cta}"
+            )
+        if self.min_blocks_per_sm not in SUPPORTED_MIN_BLOCKS_PER_SM:
+            raise ValueError(
+                f"MIN_BLOCKS_PER_SM must be one of "
+                f"{SUPPORTED_MIN_BLOCKS_PER_SM}, got {self.min_blocks_per_sm}"
+            )
+
+    def cache_key(self, capability: tuple[int, int]) -> tuple:
+        return (
+            capability,
+            self.safe_gate,
+            torch.bfloat16,  # INV_MMA_DTYPE, the design
+            self.chunks_per_cta,
+            self.min_blocks_per_sm,
+        )
+
+
+def default_chunks_per_cta_for(capability: tuple[int, int]) -> int:
+    """Measured optimum for an architecture; the sm_120 value if unknown."""
+    return DEFAULT_PREP_CHUNKS_PER_CTA_BY_CAPABILITY.get(
+        (capability[0], capability[1]), DEFAULT_PREP_CHUNKS_PER_CTA
+    )
+
+
+def default_chunks_per_cta(device=None) -> int:
+    """Measured optimum for ``device``, falling back when there is no GPU."""
+    if not torch.cuda.is_available():
+        return DEFAULT_PREP_CHUNKS_PER_CTA
+    return default_chunks_per_cta_for(torch.cuda.get_device_capability(device))
+
+
+def max_resident_ctas_from_smem(arena_bytes: int | None = None) -> int:
+    """SMEM-side residency ceiling.
+
+    Counts the driver's own per-CTA shared memory, without which this
+    overestimates: 25,520 B looks like four CTAs and measures three.
+    """
+    if arena_bytes is None:
+        arena_bytes = SMEM_ARENA_BYTES
+    return PREP_SMEM_PER_SM_BYTES // (arena_bytes + PREP_DRIVER_SMEM_PER_BLOCK_BYTES)
+
+
+def uses_dynamic_smem(arena_bytes: int = SMEM_ARENA_BYTES) -> bool:
+    """Whether the arena needs the >48 KiB dynamic-SMEM opt-in."""
+    return arena_bytes > STATIC_SMEM_LIMIT_BYTES
+
+
+# ---------------------------------------------------------------------------
+# Device-side index helpers.
+#
+# Written with ``//``, ``*``, ``+``, ``-`` and ``^`` only, so the same bodies
+# evaluate for Python ``int`` on the host and ``cutlass.Int32`` on the device.
+# They mirror Section 1 exactly.
+# ---------------------------------------------------------------------------
+
+raw_bf16_index = raw_bf16_s128
+raw_f32_index = raw_f32_s128
+kr_ak_index = kr_ak_bf16_s128
+pairwise_index = pairwise_sw32
+
+
+# ---------------------------------------------------------------------------
+# Key-major global views
+# ---------------------------------------------------------------------------
+
+
+def activation_layout_strides(total_tokens: int, heads: int):
+    """Strides of the CuTe view of contiguous ``[1, T_total, H, 128]``."""
+    return (1, DK * heads, DK, DK * total_tokens * heads)
+
+
+def workspace_layout_strides(total_chunks: int, heads: int):
+    """Strides of the CuTe view of contiguous ``[1, H, total_chunks*16, 128]``."""
+    rows = total_chunks * BT
+    return (1, DK, DK * rows, DK * rows * heads)
+
+
+def prepare_grid(total_chunks: int, heads: int, chunks_per_cta: int):
+    """``(grid.x, grid.y, grid.z)``; the host must not launch with grid.x == 0."""
+    return ((total_chunks + chunks_per_cta - 1) // chunks_per_cta, heads, 1)
+
+
+def chunks_in_cta(total_chunks: int, block_x: int, chunks_per_cta: int) -> int:
+    """CTA-uniform loop bound ``my_chunks``."""
+    base = block_x * chunks_per_cta
+    return max(0, min(chunks_per_cta, total_chunks - base))
+
+
+def tma_slot_and_phase(local_chunk: int) -> tuple[int, int, int, int]:
+    """``(tma_slot, tma_wait_phase, compute_wait_phase, beta_stage)``."""
+    return (
+        local_chunk & 1,
+        (local_chunk >> 1) & 1,
+        local_chunk & 1,
+        local_chunk & 1,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Launch
+# ---------------------------------------------------------------------------
+
+
+#: Destination buffer for ``exp2(A_log * log2e)``, one per ``(A_log, stream)``.
+#:
+#: This caches the *allocation*, not the computation.  Caching the result and
+#: skipping the arithmetic was tried and is wrong under ``torch.cuda.graph``: a
+#: cache hit during capture means the ``exp2`` is never recorded, so the graph
+#: reads a frozen buffer and a later in-place update to ``A_log`` -- an
+#: optimizer step -- replays with stale values and no error.  Writing into a
+#: reused buffer keeps the kernel in the stream, so capture records it and
+#: replay stays correct, while still avoiding the per-call allocation.
+_A_LOG_EXP: dict[tuple[int, int], tuple[weakref.ref, torch.Tensor, int]] = {}
+
+
+def _purge_for(key):
+    def _purge(_ref, _key=key):
+        _A_LOG_EXP.pop(_key, None)
+
+    return _purge
+
+
+def _a_log_exp_key(a_log: torch.Tensor) -> tuple[int, int]:
+    """Tensor identity plus the stream that will consume the writable buffer."""
+    stream = (
+        torch.cuda.current_stream(a_log.device).cuda_stream
+        if a_log.is_cuda and torch.cuda.is_available()
+        else 0
+    )
+    return id(a_log), stream
+
+
+def a_log_exp_for(
+    a_log: torch.Tensor,
+    log2e: float,
+    *,
+    out: torch.Tensor | None = None,
+    key: tuple[int, int] | None = None,
+) -> torch.Tensor:
+    """``exp2(a_log * log2e)`` in FP32, written into a reused buffer.
+
+    Keyed on a weak reference to ``a_log`` and on the current CUDA stream, so a
+    freed parameter drops its buffers and two streams never write the same
+    scratch concurrently.  ``out`` lets a cached launch plan refresh the exact
+    buffer whose pointer is baked into its argument tuple, even if the cache
+    was cleared or another plan replaced its entry.
+
+    ``key`` lets a caller that already knows its stream skip recomputing it.
+    :func:`_a_log_exp_key` asks the driver on every call, and neither half is
+    cheap: ``torch.cuda.current_stream()`` builds a Stream object through
+    several Python frames, and ``torch.cuda.is_available()`` reaches
+    ``os.getenv`` by way of nvml.  Measured on a 188-SM SM120 device, that pair
+    cost 5.0-5.5 us per call on the four shapes whose kernels are too short to
+    hide it -- 23.2 us to 28.7 us on ``fk-fixed-h32-t256`` -- and nothing at
+    all above ``multiwave``, where the launch queue absorbs it.  A cached launch
+    plan is pinned to one stream and one ``A_log`` by construction, so for that
+    caller the key is a constant and belongs in the plan.
+    """
+    if key is None:
+        key = _a_log_exp_key(a_log)
+    cached = _A_LOG_EXP.get(key)
+    if cached is not None:
+        ref, buffer, version = cached
+        if ref() is a_log:
+            if out is None:
+                out = buffer
+            # `exp2(a_log * log2e)` is two dispatches and two kernels, measured
+            # at 9.3 us against 2.2 us of device time.  It only has to run when
+            # a_log has actually changed, and an optimizer step bumps the
+            # version counter.  A tensor with no counter -- anything created
+            # under inference_mode -- is rejected explicitly, so it recomputes
+            # rather than trusting an identity it cannot check.  The sentinel
+            # compares equal to itself, so testing it by value would not do
+            # that.
+            #
+            # Never skip inside a capture: the graph replays only what it
+            # recorded, so leaving exp2 out of it means a later parameter update
+            # is silently ignored on replay.  That exact bug shipped once.
+            if (
+                out is buffer
+                and version is not NO_VERSION
+                and version == tensor_version(a_log)
+                and not capturing()
+            ):
+                return out
+        else:
+            _A_LOG_EXP.pop(key, None)
+
+    if out is None:
+        out = torch.empty_like(a_log, dtype=torch.float32)
+
+    torch.exp2(a_log.float() * log2e, out=out)
+    _A_LOG_EXP[key] = (
+        weakref.ref(a_log, _purge_for(key)),
+        out,
+        tensor_version(a_log),
+    )
+    return out
+
+
+def clear_launch_caches() -> None:
+    """Drop the ``A_log`` cache; for tests that assert on recomputation."""
+    _A_LOG_EXP.clear()
+
+
+@dataclass(frozen=True)
+class PreparePlan:
+    """Prepare's host-side work, done but not launched."""
+
+    tensor_maps: object
+    a_log_exp: torch.Tensor
+    grid_x: int
+
+
+def prepare_launch_plan(
+    *,
+    q,
+    k,
+    g,
+    A_log,
+    workspace,
+    total_tokens: int,
+    total_chunks: int,
+    heads: int,
+    config: PrepareConfig,
+) -> PreparePlan:
+    """Encode prepare's descriptors and derive its grid, without launching.
+
+    ``fwd`` needs these before it can hand both kernels to one compiled entry.
+    Everything here is cached on the buffer addresses, so a steady-state call
+    re-encodes nothing.
+    """
+
+    return PreparePlan(
+        tensor_maps=build_tensor_maps(
+            q=q,
+            k=k,
+            g=g,
+            ws_kd=workspace.kd,
+            ws_qd=workspace.qd,
+            ws_ak=workspace.ak,
+            total_tokens=total_tokens,
+            total_chunks=total_chunks,
+            heads=heads,
+        ),
+        a_log_exp=a_log_exp_for(A_log, _LOG2_E),
+        grid_x=(total_chunks + config.chunks_per_cta - 1) // config.chunks_per_cta,
+    )
+
+
+def launch_prepare(
+    *,
+    q: torch.Tensor,
+    k: torch.Tensor,
+    g: torch.Tensor,
+    beta: torch.Tensor,
+    scale: float,
+    A_log: torch.Tensor,
+    dt_bias: torch.Tensor,
+    lower_bound: float,
+    workspace: PrepareWorkspace,
+    cu_seqlens: torch.Tensor,
+    config: PrepareConfig | None = None,
+) -> None:
+    """Write the five prepare outputs into ``workspace`` in place."""
+    require_sm120a(q.device)
+    config = config or PrepareConfig(
+        safe_gate=True, chunks_per_cta=default_chunks_per_cta(q.device)
+    )
+
+    meta = chunk_metadata(cu_seqlens)
+    if meta.total_chunks == 0:
+        # return without launching; grid.x == 0 is invalid.
+        return
+
+    launch_prepare_device(
+        q=q,
+        k=k,
+        g=g,
+        beta=beta,
+        a_log_exp=a_log_exp_for(A_log, LOG2_E),
+        dt_bias=dt_bias,
+        # Narrowed once when the metadata was built.  ``cu_seqlens.to(int32)``
+        # here would allocate on every call whenever the caller holds INT64,
+        # which is the common case.
+        cu_seqlens=meta.cu_seqlens,
+        cu_chunks=meta.cu_chunks,
+        chunk_to_seq=meta.chunk_to_seq,
+        workspace=workspace,
+        scale=float(scale),
+        lower_bound=float(lower_bound),
+        heads=q.shape[2],
+        total_tokens=q.shape[1],
+        total_chunks=meta.total_chunks,
+        config=config,
+    )
+
+
+# --------------------------------------------------------------------------
+# Section 8: the prepare device kernel
+# --------------------------------------------------------------------------
+
+#: The inverse is computed as two 8x8 block inverses plus one coupling term
+#:; this is the block split, not a tunable.
+HALF_BT = BT // 2
+PREPARE_DEVICE_THREADS = 128
+PREPARE_DEVICE_WARPS = 4
+
+BF16_SEG_ELEMS = BF16_SEGMENT_ELEMS  # 64
+BF16_SEG_STRIDE = BF16_SEGMENT_STRIDE  # 1024
+F32_SEG_ELEMS = F32_SEGMENT_ELEMS  # 32
+F32_SEG_STRIDE = F32_SEGMENT_STRIDE  # 512
+
+#: Q 4096 + K 4096 + G, and G is the only term that moves with its dtype.
+TMA_TX_BYTES_G_FP32 = 16384
+TMA_TX_BYTES_G_BF16 = 12288
+
+# The barrier arena, as 8-byte slot indices.
+MBAR_SLOT_TMA0 = 0
+MBAR_SLOT_TMA1 = 1
+MBAR_SLOT_K_HALF_READY = 2
+MBAR_SLOT_K_FULL_READY = 3
+MBAR_SLOT_RAW_RELEASED = 4
+MBAR_SLOT_PAIRWISE_READY = 5
+
+PREFIX_FLOOR = -126.0
+NORM_SS_FLOOR = 1.0e-24
+LOG2_E = 1.4426950408889634
+
+
+# ---------------------------------------------------------------------------
+# Device index helpers (mirror Section 1)
+# ---------------------------------------------------------------------------
+
+
+@cute.jit
+def raw_bf16_idx(token, dim):
+    seg = dim // BF16_SEG_ELEMS
+    local = dim - seg * BF16_SEG_ELEMS
+    group = local // 8
+    inner = local - group * 8
+    return (
+        seg * BF16_SEG_STRIDE
+        + token * BF16_SEG_ELEMS
+        + (group ^ (token & 7)) * 8
+        + inner
+    )
+
+
+@cute.jit
+def raw_f32_idx(token, dim):
+    seg = dim // F32_SEG_ELEMS
+    local = dim - seg * F32_SEG_ELEMS
+    group = local // 4
+    inner = local - group * 4
+    return (
+        seg * F32_SEG_STRIDE + token * F32_SEG_ELEMS + (group ^ (token & 7)) * 4 + inner
+    )
+
+
+@cute.jit
+def raw_g_idx(token, dim, G_FP32: cutlass.Constexpr):
+    """SMEM index of ``G[token, dim]``, in whichever image its dtype implies.
+
+    FP32 ``G`` gets its own 4-segment S128 image; BF16 ``G`` is byte-identical
+    in shape to Q and K, so it simply reuses theirs.  Both are 128-byte
+    segments -- only the element count per segment differs.
+    """
+    if cutlass.const_expr(G_FP32):
+        return raw_f32_idx(token, dim)
+    return raw_bf16_idx(token, dim)
+
+
+@cute.jit
+def kr_ak_idx(token, dim):
+    return raw_bf16_idx(token ^ 8, dim)
+
+
+@cute.jit
+def prepare_pair_idx(row, col):
+    storage_col = col ^ 8
+    byte_offset = 2 * (row * 16 + storage_col)
+    return (byte_offset ^ (((byte_offset >> 7) & 1) << 4)) // 2
+
+
+@cute.jit
+def warp_row_sum_8(value: cutlass.Float32) -> cutlass.Float32:
+    """Reduce the eight lanes that cooperate on one token row."""
+    value = value + cutlass.Float32(cute.arch.shuffle_sync_bfly(value, offset=4))
+    value = value + cutlass.Float32(cute.arch.shuffle_sync_bfly(value, offset=2))
+    return value + cutlass.Float32(cute.arch.shuffle_sync_bfly(value, offset=1))
+
+
+@cute.jit
+def bf16_round(x: cutlass.Float32) -> cutlass.Float32:
+    return x.to(cutlass.BFloat16).to(cutlass.Float32)
+
+
+def f16_round(x: cutlass.Float32) -> cutlass.Float32:
+    """Round through FP16, the inverse chain's operand dtype (Section 8.2)."""
+    return x.to(cutlass.Float16).to(cutlass.Float32)
+
+
+# ---------------------------------------------------------------------------
+# Fragment helpers
+# ---------------------------------------------------------------------------
+
+
+@cute.jit
+def load_a_fragment(smem, token_base, dim_base, lane):
+    """A-operand ``ldmatrix.x4``."""
+    matrix_id = lane // 8
+    row = token_base + (lane % 8) + 8 * (matrix_id % 2)
+    col = dim_base + 8 * (matrix_id // 2)
+    return ldmatrix_x4(smem + raw_bf16_idx(row, col))
+
+
+@cute.jit
+def load_b_fragment(smem, dim_base, lane):
+    """B-operand ``ldmatrix.x4``.
+
+    The row half is keyed on bit 4 of the lane, not bit 3.
+    """
+    matrix_id = lane // 8
+    row = (lane % 8) + 8 * (lane // 16)
+    col = dim_base + 8 * (matrix_id % 2)
+    return ldmatrix_x4(smem + raw_bf16_idx(row, col))
+
+
+@cute.jit
+def load_pairwise_a_fragment(smem, lane):
+    """Load a 16x16 pairwise tile in A layout."""
+    matrix_id = lane // 8
+    row = (lane % 8) + 8 * (matrix_id % 2)
+    col = 8 * (matrix_id // 2)
+    return ldmatrix_x4(smem + prepare_pair_idx(row, col))
+
+
+@cute.jit
+def a_to_b(a0, a1, a2, a3):
+    """A layout -> B layout of the same matrix; identity register order."""
+    return (
+        movmatrix_b16(a0),
+        movmatrix_b16(a1),
+        movmatrix_b16(a2),
+        movmatrix_b16(a3),
+    )
+
+
+@cute.jit
+def a_to_a_transposed(a0, a1, a2, a3):
+    """A layout -> A layout of the transpose; registers 1 and 2 swap."""
+    return (
+        movmatrix_b16(a0),
+        movmatrix_b16(a2),
+        movmatrix_b16(a1),
+        movmatrix_b16(a3),
+    )
+
+
+@cute.jit
+def mma_16x16(a0, a1, a2, a3, b0, b1, b2, b3, c):
+    """One logical m16n16k16 step: two native N=8 MMAs."""
+    n0 = mma_m16n8k16_bf16(a0, a1, a2, a3, b0, b1, c[0], c[1], c[2], c[3])
+    n1 = mma_m16n8k16_bf16(a0, a1, a2, a3, b2, b3, c[4], c[5], c[6], c[7])
+    return (n0[0], n0[1], n0[2], n0[3], n1[0], n1[1], n1[2], n1[3])
+
+
+@cute.jit
+def mma_16x16_f16(a0, a1, a2, a3, b0, b1, b2, b3, c):
+    """``mma_16x16`` with FP16 operands, for the inverse (Section 8.2).
+
+    Same shape, same accumulator width, same two native N=8 issues -- only the
+    operand dtype differs, so this costs exactly what the BF16 form costs.
+    """
+    n0 = mma_m16n8k16_f16(a0, a1, a2, a3, b0, b1, c[0], c[1], c[2], c[3])
+    n1 = mma_m16n8k16_f16(a0, a1, a2, a3, b2, b3, c[4], c[5], c[6], c[7])
+    return (n0[0], n0[1], n0[2], n0[3], n1[0], n1[1], n1[2], n1[3])
+
+
+@cute.jit
+def acc_to_a_fragment(c):
+    """Register-local accumulator -> A-layout pack."""
+    return (
+        pack_bf16x2(c[0], c[1]),
+        pack_bf16x2(c[2], c[3]),
+        pack_bf16x2(c[4], c[5]),
+        pack_bf16x2(c[6], c[7]),
+    )
+
+
+@cute.jit
+def acc_to_a_fragment_f16(c):
+    """As :func:`acc_to_a_fragment`, packing FP16 instead of BF16.
+
+    ``movmatrix.b16`` in :func:`a_to_b` is dtype-blind, so the A->B step is
+    shared with the BF16 path unchanged.
+    """
+    return (
+        pack_f16x2(c[0], c[1]),
+        pack_f16x2(c[2], c[3]),
+        pack_f16x2(c[4], c[5]),
+        pack_f16x2(c[6], c[7]),
+    )
+
+
+@cute.jit
+def ZERO8():
+    """Eight zeroed FP32 accumulator slots."""
+    z = cutlass.Float32(0.0)
+    return (z, z, z, z, z, z, z, z)
+
+
+@cute.jit
+def kk_half(lhs_ptr, ki_ptr, lane, half, c):
+    """``lhs @ Ki.T`` over the four K=16 phases of head-dimension half ``half``.
+
+    Split so warp 0 can start K blocks 0-3 on ``k_half_ready`` and only wait
+    for ``k_full_ready`` before blocks 4-7 (step 5 of the design).
+    """
+    for j in cutlass.range_constexpr(4):
+        d0 = (half * 4 + j) * 16
+        a0, a1, a2, a3 = load_a_fragment(lhs_ptr, 0, d0, lane)
+        b0, b1, b2, b3 = load_b_fragment(ki_ptr, d0, lane)
+        c = mma_16x16(a0, a1, a2, a3, b0, b1, b2, b3, c)
+    return c
+
+
+@cute.jit
+def kk_over_dk(lhs_ptr, ki_ptr, lane):
+    """``lhs @ Ki.T`` over all eight K=16 phases of the head dimension."""
+    return kk_half(lhs_ptr, ki_ptr, lane, 1, kk_half(lhs_ptr, ki_ptr, lane, 0, ZERO8()))
+
+
+@cute.jit
+def prepare_stmatrix_coord(lane):
+    """Row/col of the 16-byte row segment lane ``lane`` feeds to stmatrix.x4.
+
+    Same quadrant order as the A fragment.
+    """
+    matrix_id = lane // 8
+    row = (lane - matrix_id * 8) + 8 * (matrix_id - (matrix_id // 2) * 2)
+    col = 8 * (matrix_id // 2)
+    return row, col
+
+
+@cute.jit
+def acc_coord(lane, slot):
+    """``(row, col)`` of accumulator slot ``slot`` in ``[0, 8)``."""
+    n_block = slot // 4
+    reg = slot - n_block * 4
+    row = (lane // 4) + 8 * (reg // 2)
+    col = 8 * n_block + 2 * (lane % 4) + (reg % 2)
+    return row, col
+
+
+@cute.jit
+def issue_chunk_tma(
+    desc_q,
+    desc_k,
+    desc_g,
+    p_q,
+    p_k,
+    p_g,
+    mbar,
+    token_base,
+    head,
+    G_FP32: cutlass.Constexpr,
+):
+    """Issue one chunk's Q/K/G as TMA boxes.
+
+    Two Q, two K, and G in four boxes at FP32 or two at BF16, all against
+    ``mbar``: 4096 + 4096 + 8192 or 4096 bytes.  A single elected lane issues
+    the lot, which is the whole point of TMA here -- the ``cp.async`` version
+    this replaces needed 64 threads to move the same bytes, so it could not be
+    confined to one warp the way step 6 of the design describes.
+
+    Coordinates are ``(segment * segment_elems, token_base, head)`` against the
+    key-major descriptors of Section 7.1.
+    """
+    for seg in cutlass.range_constexpr(BF16_SEGMENTS):
+        c0 = seg * BF16_SEG_ELEMS
+        tma_load_3d(p_q + seg * BF16_SEG_STRIDE, desc_q, mbar, c0, token_base, head)
+        tma_load_3d(p_k + seg * BF16_SEG_STRIDE, desc_k, mbar, c0, token_base, head)
+    if cutlass.const_expr(G_FP32):
+        for seg in cutlass.range_constexpr(F32_SEGMENTS):
+            c0 = seg * F32_SEG_ELEMS
+            tma_load_3d(p_g + seg * F32_SEG_STRIDE, desc_g, mbar, c0, token_base, head)
+    else:
+        for seg in cutlass.range_constexpr(BF16_SEGMENTS):
+            c0 = seg * BF16_SEG_ELEMS
+            tma_load_3d(p_g + seg * BF16_SEG_STRIDE, desc_g, mbar, c0, token_base, head)
+
+
+@cute.jit
+def clear_tail_rows(p_q, p_k, p_g, valid_rows, tidx, G_FP32: cutlass.Constexpr):
+    """Zero the invalid rows of the raw stages.
+
+    TMA only zero-fills coordinates outside the *tensor*, and a short chunk sits
+    mid-tensor: the rows past ``valid_rows`` belong to the next sequence in the
+    packed layout, so TMA faithfully loads real data there.  The ``cp.async``
+    version this replaces got the zeros for free by passing src-size 0.
+
+    Same 16-byte task map as the loads, so the writes stay one vector wide.
+    """
+    for rep in cutlass.range_constexpr(2):
+        slot = tidx + rep * PREPARE_DEVICE_THREADS
+        row = slot // 16
+        d0 = (slot - row * 16) * 8
+        if row >= valid_rows:
+            zero8 = make_rmem_tensor(8, cutlass.BFloat16)
+            for i in cutlass.range_constexpr(8):
+                zero8[i] = cutlass.BFloat16(0.0)
+            bidx = raw_bf16_idx(row, d0)
+            store_vec8_bf16(p_q, bidx, zero8)
+            store_vec8_bf16(p_k, bidx, zero8)
+
+    if cutlass.const_expr(G_FP32):
+        for rep in cutlass.range_constexpr(4):
+            slot = tidx + rep * PREPARE_DEVICE_THREADS
+            row = slot // 32
+            d0 = (slot - row * 32) * 4
+            if row >= valid_rows:
+                zero4 = make_rmem_tensor(4, cutlass.Float32)
+                for i in cutlass.range_constexpr(4):
+                    zero4[i] = cutlass.Float32(0.0)
+                cute.autovec_copy(zero4, vec_at(p_g, raw_f32_idx(row, d0), 4))
+    else:
+        # BF16 G is the same 4096-byte image as Q and K, so it takes the same
+        # two-rep, 16-byte task map rather than the FP32 four-rep one.
+        for rep in cutlass.range_constexpr(2):
+            slot = tidx + rep * PREPARE_DEVICE_THREADS
+            row = slot // 16
+            d0 = (slot - row * 16) * 8
+            if row >= valid_rows:
+                zero8 = make_rmem_tensor(8, cutlass.BFloat16)
+                for i in cutlass.range_constexpr(8):
+                    zero8[i] = cutlass.BFloat16(0.0)
+                store_vec8_bf16(p_g, raw_bf16_idx(row, d0), zero8)
+
+
+@cute.jit
+def warp_arrive(mbar, lane):
+    """One arrival per warp on a 4-warp mbarrier.
+
+    ``mbarrier.arrive`` counts per thread, so a whole warp arriving would
+    overshoot an arrival count of ``PREPARE_DEVICE_WARPS``.  The warp synchronization before
+    the elected arrival is what makes the other 31 lanes' shared-memory stores
+    visible to whoever observes the arrival; the arrival itself carries release
+    semantics at CTA scope for the electing lane.
+    """
+    cute.arch.sync_warp()
+    if lane == 0:
+        cute.arch.mbarrier_arrive(mbar)
+
+
+@cute.jit
+def load_beta_stage(gbeta, smem_beta, stage, token_base, valid_rows, head, lane, heads):
+    """Activate one chunk's 16 beta logits into beta stage ``stage``.
+
+    the design double-buffers ``smem_beta_act`` so that this strided
+    column read out of ``[T, H]`` -- which cannot coalesce, one sector per
+    token -- is issued a full chunk before the values are needed, instead of
+    stalling the whole CTA at a barrier behind its DRAM latency.
+    """
+    if lane < BT:
+        bv = cutlass.Float32(0.0)
+        if lane < valid_rows:
+            logit = cutlass.Float32(gbeta[(token_base + lane) * heads + head])
+            half = cutlass.Float32(0.5)
+            # Stored as FP32, unrounded.  The activated value has exactly two
+            # consumers: the strict-lower scale, which is an FP32 multiply, and
+            # the AINV column scale, which packs to BF16 itself.  Rounding here
+            # is invisible to the second and only lossy to the first, at the
+            # cost of two F2F conversions per lane (measured).
+            bv = (
+                cutlass.Float32(cute.math.tanh(logit * half, fastmath=True)) * half
+                + half
+            )
+        smem_beta[stage * BT + lane] = bv
+
+
+@cute.jit
+def vec_at(ptr, idx, elems):
+    """``ptr + idx`` as an ``elems``-long tensor, keeping the pointer alignment.
+
+    ``Pointer.__add__`` lowers the pointer's ``alignment`` attribute to one
+    element whenever the offset is dynamic -- even for ``ptr + 8 * dyn``, since
+    it does not reason about the multiplier.  ``autovec_copy`` honours that
+    attribute, so without this every 8-element BF16 access lowers to eight
+    ``STG.E.U16`` / ``STS.U16`` instructions instead of one 128-bit access.
+
+    Every index reaching this helper is a multiple of ``elems`` by
+    construction: ``raw_bf16_s128`` and ``raw_f32_s128`` only add multiples of
+    the 8- or 4-element group once ``dim`` is group-aligned (their ``inner``
+    term is then zero), the workspace row bases are multiples of ``DK``, and
+    the Section 7.4 ``Aq`` pair starts are even.  Stating that divisor costs no
+    instructions -- it is a compile-time constraint, not a round-up.
+    """
+    return cute.make_tensor(
+        ptr + cute.assume(cutlass.Int32(idx), divby=elems), cute.make_layout(elems)
+    )
+
+
+@cute.jit
+def vec8_bf16(ptr, idx):
+    """Load 8 contiguous BF16 (16 bytes) into a register fragment."""
+    frag = make_rmem_tensor(8, cutlass.BFloat16)
+    cute.autovec_copy(vec_at(ptr, idx, 8), frag)
+    return frag
+
+
+@cute.jit
+def vec4_f32(ptr, idx):
+    """Load 4 contiguous FP32 (16 bytes) into a register fragment."""
+    frag = make_rmem_tensor(4, cutlass.Float32)
+    cute.autovec_copy(vec_at(ptr, idx, 4), frag)
+    return frag
+
+
+@cute.jit
+def store_vec8_bf16(ptr, idx, frag):
+    """Store an 8-element BF16 fragment as one 16-byte access."""
+    cute.autovec_copy(frag, vec_at(ptr, idx, 8))
+
+
+# ---------------------------------------------------------------------------
+# Kernel
+# ---------------------------------------------------------------------------
+
+
+@cute.kernel
+def prepare_kernel(
+    gq: cute.Tensor,
+    gk: cute.Tensor,
+    gg: cute.Tensor,
+    gbeta: cute.Tensor,
+    ga_log_exp: cute.Tensor,
+    gdt: cute.Tensor,
+    gcu_seqlens: cute.Tensor,
+    gcu_chunks: cute.Tensor,
+    gchunk_to_seq: cute.Tensor,
+    ws_kd: cute.Tensor,
+    ws_qd: cute.Tensor,
+    ws_ak: cute.Tensor,
+    ws_aq: cute.Tensor,
+    ws_gt: cute.Tensor,
+    desc_q: cutlass.Int64,
+    desc_k: cutlass.Int64,
+    desc_g: cutlass.Int64,
+    desc_factor: cutlass.Int64,
+    SCALE: cutlass.Float32,
+    GATE_SCALE_LOG2: cutlass.Float32,
+    TOTAL_CHUNKS: cutlass.Int32,
+    heads: cutlass.Int32,
+    SAFE_GATE: cutlass.Constexpr,
+    CPC: cutlass.Constexpr,
+    G_FP32: cutlass.Constexpr,
+) -> None:
+    tidx, _, _ = cute.arch.thread_idx()
+    bidx, bidy, _ = cute.arch.block_idx()
+    warp_id = cute.arch.make_warp_uniform(cute.arch.warp_idx())
+    lane = tidx % 32
+    head = bidy
+
+    alloc = cutlass.utils.SmemAllocator()
+    p_kd = alloc.allocate_array(cutlass.BFloat16, BT * DK)
+    # Four resident CTAs are reachable and were measured: at CPC == 1 the raw
+    # Q and K stages are dead after the Kd/Ki/Qd loop, so Qd can overwrite Q
+    # and Ki can overwrite K -- correct without added synchronization, since
+    # (my_token, d0) -> thread is a bijection and each thread rewrites exactly
+    # what it read.  That frees 8192 B, giving 21,936 B and occupancy_limit
+    # shared_mem == 4, achieved occupancy 32.9%.
+    #
+    # It measures SLOWER everywhere: +0.24% h96 FP32, +1.58% h96 BF16, +1.64%
+    # h64 FP32, +2.36% h64 BF16, with barrier stall roughly doubling (2.837 ->
+    # 4.945) and warps_eligible essentially flat (0.158 -> 0.164).  Occupancy
+    # was never the constraint: the kernel sits at ~90% of peak DRAM, so extra
+    # warps have nothing to issue and four CTAs merely lengthen every CTA-wide
+    # rendezvous.  Kept unaliased.
+    p_qd = alloc.allocate_array(cutlass.BFloat16, BT * DK)
+    p_q = alloc.allocate_array(cutlass.BFloat16, BT * DK)
+    p_k = alloc.allocate_array(cutlass.BFloat16, BT * DK)
+    p_g = alloc.allocate_array(cutlass.Float32, BT * DK)
+    p_ki = alloc.allocate_array(cutlass.BFloat16, BT * DK)
+    p_ainv = alloc.allocate_array(cutlass.BFloat16, BT * BT)
+    p_gamma = alloc.allocate_array(cutlass.BFloat16, DK)
+    # the design gives smem_beta_act 128 bytes: two 16-float stages, so a
+    # chunk's beta is loaded and activated one chunk ahead of its use.
+    p_beta = alloc.allocate_array(cutlass.Float32, 2 * BT)
+    p_bar = alloc.allocate_array(cutlass.Int64, 6)
+    p_qk = alloc.allocate_array(cutlass.BFloat16, BT * BT)
+
+    # Pointers feed ldmatrix; the flat tensor views give dynamic scalar access.
+    smem_g = cute.make_tensor(p_g, cute.make_layout(BT * DK))
+    # A BF16 view of the same 8192-byte stage.  With BF16 ``G`` the raw input
+    # is the 4096-byte Q/K image living in its first half; the stage is then
+    # overwritten in full by FP32 ``exp_g``, which is why the arena cannot
+    # simply shrink and why the two must not overlap in time (see the extra
+    # barrier before the writeback below).  Unused when ``G`` is FP32.
+    p_g_bf16 = cute.recast_ptr(p_g, dtype=cutlass.BFloat16)
+    smem_g_bf16 = cute.make_tensor(p_g_bf16, cute.make_layout(BT * DK))
+    # Trace-time selection: which view the raw G load and tail-clear address.
+    p_g_raw = p_g if cutlass.const_expr(G_FP32) else p_g_bf16
+    G_TX = TMA_TX_BYTES_G_FP32 if cutlass.const_expr(G_FP32) else TMA_TX_BYTES_G_BF16
+    smem_ainv = cute.make_tensor(p_ainv, cute.make_layout(BT * BT))
+    smem_gamma = cute.make_tensor(p_gamma, cute.make_layout(DK))
+    smem_beta = cute.make_tensor(p_beta, cute.make_layout(2 * BT))
+    smem_qk = cute.make_tensor(p_qk, cute.make_layout(BT * BT))
+
+    # The barrier arena.  The two input barriers alternate by
+    # chunk parity so that reusing one two chunks later toggles its phase.
+    mbar_tma0 = p_bar + MBAR_SLOT_TMA0
+    mbar_tma1 = p_bar + MBAR_SLOT_TMA1
+    mbar_k_half = p_bar + MBAR_SLOT_K_HALF_READY
+    mbar_k_full = p_bar + MBAR_SLOT_K_FULL_READY
+    mbar_raw_released = p_bar + MBAR_SLOT_RAW_RELEASED
+    mbar_pairwise = p_bar + MBAR_SLOT_PAIRWISE_READY
+    if warp_id == 0:
+        if lane == 0:
+            cute.arch.mbarrier_init(mbar_tma0, 1)
+            cute.arch.mbarrier_init(mbar_tma1, 1)
+            cute.arch.mbarrier_init(mbar_k_half, PREPARE_DEVICE_WARPS)
+            cute.arch.mbarrier_init(mbar_k_full, PREPARE_DEVICE_WARPS)
+            cute.arch.mbarrier_init(mbar_raw_released, PREPARE_DEVICE_WARPS)
+            cute.arch.mbarrier_init(mbar_pairwise, 1)
+            cute.arch.mbarrier_init_fence()
+            fence_tensormap_acquire(desc_q)
+            fence_tensormap_acquire(desc_k)
+            fence_tensormap_acquire(desc_g)
+            # One acquire, not three: Kd/Qd/Ak are 3H planes of one map.
+            fence_tensormap_acquire(desc_factor)
+    # step 1 of the design: nothing may arrive or wait before the
+    # initialized state is published.
+    cute.arch.barrier()
+
+    cta_chunk_base = bidx * CPC
+    my_chunks = TOTAL_CHUNKS - cta_chunk_base
+    if my_chunks > CPC:
+        my_chunks = cutlass.Int32(CPC)
+
+    dt_value = cutlass.Float32(gdt[head * DK + tidx])
+    alog = cutlass.Float32(ga_log_exp[head])
+    row_in_warp = lane // 8
+    lane_in_row = lane % 8
+    my_token = warp_id * 4 + row_in_warp
+    q4 = lane % 4
+
+    # Prologue: start the first chunk's copies before entering the loop.
+    seq0 = cutlass.Int32(gchunk_to_seq[cta_chunk_base])
+    lc0 = cta_chunk_base - cutlass.Int32(gcu_chunks[seq0])
+    tb0 = cutlass.Int32(gcu_seqlens[seq0]) + lc0 * BT
+    vr0 = cutlass.Int32(gcu_seqlens[seq0 + 1]) - tb0
+    if vr0 > BT:
+        vr0 = cutlass.Int32(BT)
+    if warp_id == 0:
+        if lane == 0:
+            cute.arch.mbarrier_arrive_and_expect_tx(mbar_tma0, G_TX)
+            issue_chunk_tma(
+                desc_q,
+                desc_k,
+                desc_g,
+                p_q,
+                p_k,
+                p_g_raw,
+                mbar_tma0,
+                tb0,
+                head,
+                G_FP32,
+            )
+        load_beta_stage(gbeta, smem_beta, 0, tb0, vr0, head, lane, heads)
+
+    for lc in cutlass.range_constexpr(CPC):
+        if lc < my_chunks:
+            gchunk = cta_chunk_base + lc
+            seq = cutlass.Int32(gchunk_to_seq[gchunk])
+            local_c = gchunk - cutlass.Int32(gcu_chunks[seq])
+            seq_start = cutlass.Int32(gcu_seqlens[seq])
+            seq_end = cutlass.Int32(gcu_seqlens[seq + 1])
+            token_base = seq_start + local_c * BT
+            valid_rows = seq_end - token_base
+            if valid_rows > BT:
+                valid_rows = cutlass.Int32(BT)
+
+            # ---- wait for this chunk's input TMA, publish the stage -----
+            # the two barrier objects alternate, so each is
+            # reused every other chunk and its phase toggles then.
+            beta_stage = lc & 1
+            tma_wait_phase = (lc >> 1) & 1
+            if cutlass.const_expr(lc & 1):
+                cute.arch.mbarrier_wait(mbar_tma1, tma_wait_phase)
+            else:
+                cute.arch.mbarrier_wait(mbar_tma0, tma_wait_phase)
+
+            # Section 7.3: a short chunk sits mid-tensor, so TMA loaded the
+            # next sequence's rows rather than zeros.  Clear them before the
+            # barrier that publishes the stage.
+            if valid_rows < BT:
+                clear_tail_rows(p_q, p_k, p_g_raw, valid_rows, tidx, G_FP32)
+            cute.arch.barrier()
+
+            # ---- gate prefix --------------------------
+            gate_regs = [cutlass.Float32(0.0) for _ in range(BT)]
+            for r in cutlass.range_constexpr(BT):
+                if cutlass.const_expr(G_FP32):
+                    raw = smem_g[raw_f32_idx(r, tidx)]
+                else:
+                    raw = cutlass.Float32(smem_g_bf16[raw_bf16_idx(r, tidx)])
+                inc = cutlass.Float32(0.0)
+                if r < valid_rows:
+                    x = raw + dt_value
+                    if cutlass.const_expr(SAFE_GATE):
+                        half = cutlass.Float32(0.5)
+                        sig = (
+                            cutlass.Float32(
+                                cute.math.tanh(alog * x * half, fastmath=True)
+                            )
+                            * half
+                            + half
+                        )
+                        inc = GATE_SCALE_LOG2 * sig
+                    else:
+                        sp = cutlass.Float32(0.0)
+                        if x > cutlass.Float32(20.0):
+                            sp = x * cutlass.Float32(LOG2_E)
+                        else:
+                            sp = cutlass.Float32(
+                                cute.math.log2(
+                                    cutlass.Float32(1.0)
+                                    + cutlass.Float32(cute.math.exp(x, fastmath=True)),
+                                    fastmath=True,
+                                )
+                            )
+                        inc = -alog * sp
+                gate_regs[r] = inc
+
+            acc = cutlass.Float32(0.0)
+            for p in cutlass.range_constexpr(BT // 2):
+                r0 = p * 2
+                g0 = gate_regs[r0]
+                g1 = gate_regs[r0 + 1]
+                prefix0 = acc + g0
+                prefix1 = acc + (g0 + g1)
+                gate_regs[r0] = prefix0
+                gate_regs[r0 + 1] = prefix1
+                acc = prefix1
+
+            for r in cutlass.range_constexpr(BT):
+                pv = gate_regs[r]
+                if pv < cutlass.Float32(PREFIX_FLOOR):
+                    pv = cutlass.Float32(PREFIX_FLOOR)
+                gate_regs[r] = cutlass.Float32(cute.math.exp2(pv, fastmath=True))
+
+            gamma = gate_regs[BT - 1]
+            ws_gt[(head * TOTAL_CHUNKS + gchunk) * DK + tidx] = gamma
+            smem_gamma[tidx] = gamma.to(cutlass.BFloat16)
+            if cutlass.const_expr(not G_FP32):
+                # The FP32 exp_g image about to be written spans all 8192 bytes
+                # of the stage; the BF16 raw G it overwrites occupied only the
+                # first 4096, in a different index map.  A thread's write can
+                # therefore land on a raw element another thread has not read
+                # yet, so the read loop above must be complete CTA-wide first.
+                # With FP32 G the two maps coincide and each thread rewrites
+                # exactly the addresses it read, so no barrier is needed.
+                cute.arch.barrier()
+            for r in cutlass.range_constexpr(BT):
+                smem_g[raw_f32_idx(r, tidx)] = gate_regs[r]
+            cute.arch.barrier()
+
+            # ---- norm + Kd/Ki/Qd --------------------
+            # Every SMEM and global access below is 16 bytes wide.  The 8
+            # features a lane owns are contiguous and 16-byte aligned under
+            # raw_bf16_s128, and exp_g is read as 2 x float4 because 8
+            # consecutive FP32 are two separate 4-element runs whose order
+            # depends on the token parity.
+            q_ss = cutlass.Float32(0.0)
+            k_ss = cutlass.Float32(0.0)
+            for h in cutlass.range_constexpr(2):
+                d0 = 64 * h + 8 * lane_in_row
+                fq = vec8_bf16(p_q, raw_bf16_idx(my_token, d0))
+                fk = vec8_bf16(p_k, raw_bf16_idx(my_token, d0))
+                for i in cutlass.range_constexpr(8):
+                    qv = cutlass.Float32(fq[i])
+                    kv = cutlass.Float32(fk[i])
+                    q_ss = q_ss + qv * qv
+                    k_ss = k_ss + kv * kv
+            q_ss = warp_row_sum_8(q_ss)
+            k_ss = warp_row_sum_8(k_ss)
+
+            q_inv = cutlass.Float32(0.0)
+            k_inv = cutlass.Float32(0.0)
+            if my_token < valid_rows:
+                qf = q_ss
+                if qf < cutlass.Float32(NORM_SS_FLOOR):
+                    qf = cutlass.Float32(NORM_SS_FLOOR)
+                kf = k_ss
+                if kf < cutlass.Float32(NORM_SS_FLOOR):
+                    kf = cutlass.Float32(NORM_SS_FLOOR)
+                q_inv = cutlass.Float32(cute.math.rsqrt(qf, fastmath=True))
+                k_inv = cutlass.Float32(cute.math.rsqrt(kf, fastmath=True))
+
+            s16 = bf16_round(SCALE)
+            for h in cutlass.range_constexpr(2):
+                d0 = 64 * h + 8 * lane_in_row
+                bidx = raw_bf16_idx(my_token, d0)
+                fq = vec8_bf16(p_q, bidx)
+                fk = vec8_bf16(p_k, bidx)
+                fg0 = vec4_f32(p_g, raw_f32_idx(my_token, d0))
+                fg1 = vec4_f32(p_g, raw_f32_idx(my_token, d0 + 4))
+
+                o_kd = make_rmem_tensor(8, cutlass.BFloat16)
+                o_ki = make_rmem_tensor(8, cutlass.BFloat16)
+                o_qd = make_rmem_tensor(8, cutlass.BFloat16)
+                for j in cutlass.range_constexpr(4):
+                    i = 0 + j
+                    eg = fg0[j]
+                    kv = cutlass.Float32(fk[i]) * k_inv
+                    kd_v = bf16_round(bf16_round(kv) * bf16_round(eg))
+                    ki_v = bf16_round(kv * cutlass.Float32(cute.arch.rcp_approx(eg)))
+                    qv = bf16_round(cutlass.Float32(fq[i]) * q_inv)
+                    qd_v = bf16_round(bf16_round(qv * bf16_round(eg)) * s16)
+                    o_kd[i] = kd_v.to(cutlass.BFloat16)
+                    o_ki[i] = ki_v.to(cutlass.BFloat16)
+                    o_qd[i] = qd_v.to(cutlass.BFloat16)
+
+                for j in cutlass.range_constexpr(4):
+                    i = 4 + j
+                    eg = fg1[j]
+                    kv = cutlass.Float32(fk[i]) * k_inv
+                    kd_v = bf16_round(bf16_round(kv) * bf16_round(eg))
+                    ki_v = bf16_round(kv * cutlass.Float32(cute.arch.rcp_approx(eg)))
+                    qv = bf16_round(cutlass.Float32(fq[i]) * q_inv)
+                    qd_v = bf16_round(bf16_round(qv * bf16_round(eg)) * s16)
+                    o_kd[i] = kd_v.to(cutlass.BFloat16)
+                    o_ki[i] = ki_v.to(cutlass.BFloat16)
+                    o_qd[i] = qd_v.to(cutlass.BFloat16)
+
+                store_vec8_bf16(p_kd, bidx, o_kd)
+                store_vec8_bf16(p_ki, bidx, o_ki)
+                store_vec8_bf16(p_qd, bidx, o_qd)
+                # step 5 of the design: signal each Kd/Ki half the moment it
+                # is in SMEM.  Kd and Qd leave for global by TMA later, read
+                # straight out of these same images (Section 7.4), so there is
+                # no separate global store here any more.
+                if cutlass.const_expr(h == 0):
+                    warp_arrive(mbar_k_half, lane)
+                else:
+                    warp_arrive(mbar_k_full, lane)
+
+            # This warp is done with raw Q/K/exp-g and with Qd (Section 12.3
+            # step 5); the raw stages may be overwritten once all four arrive.
+            warp_arrive(mbar_raw_released, lane)
+            phase = lc & 1
+
+            # ---- warp 0: KK -> L -> AINV ------------------------------
+            if warp_id == 0:
+                cute.arch.mbarrier_wait(mbar_k_half, phase)
+                c = kk_half(p_kd, p_ki, lane, 0, ZERO8())
+                cute.arch.mbarrier_wait(mbar_k_full, phase)
+                c = kk_half(p_kd, p_ki, lane, 1, c)
+                masked = [cutlass.Float32(0.0) for _ in range(8)]
+                for slot in cutlass.range_constexpr(8):
+                    row, col = acc_coord(lane, slot)
+                    v = cutlass.Float32(0.0)
+                    if row > col:
+                        v = c[slot] * smem_beta[beta_stage * BT + row]
+                    masked[slot] = v
+
+                # Blockwise 8x8 inverse.  With D the block
+                # diagonal of L and A21 its one off-diagonal block:
+                #
+                #   Binv = (I - D)(I + D^2)(I + D^4)   exact, blocks nilpotent
+                #                                      at 8, so 3 factors
+                #   AINV = Binv - Binv @ A21 @ Binv    exact, (Binv @ A21)^2 = 0
+                #
+                # Six MMAs, the same count as the 16x16 Neumann chain this
+                # replaces, and one fewer pack/round stage -- but it never
+                # forms a power above D^4 of an 8x8 block, where the Neumann
+                # chain built L^8 of the full matrix and cancelled it away.
+                # Operands are FP16, not BF16 (Section 8.2).
+                d = [cutlass.Float32(0.0) for _ in range(8)]
+                a21 = [cutlass.Float32(0.0) for _ in range(8)]
+                for slot in cutlass.range_constexpr(8):
+                    row, col = acc_coord(lane, slot)
+                    if (row < HALF_BT) == (col < HALF_BT):
+                        d[slot] = masked[slot]
+                    elif row >= HALF_BT:
+                        a21[slot] = masked[slot]
+
+                dp = acc_to_a_fragment_f16(tuple(d))
+                pows = []
+                for _ in cutlass.range_constexpr(2):
+                    pb = a_to_b(dp[0], dp[1], dp[2], dp[3])
+                    sq = mma_16x16_f16(
+                        dp[0], dp[1], dp[2], dp[3], pb[0], pb[1], pb[2], pb[3], ZERO8()
+                    )
+                    dp = acc_to_a_fragment_f16(sq)
+                    pows.append(dp)
+
+                # binv = (I - D) (I + D^2) (I + D^4), as a running accumulator:
+                # every D^k here is a power of a strict-lower matrix and so has
+                # a zero diagonal, which makes R(I + D^k) == I + R(D^k) and
+                # therefore MMA(x, I + D^k) == x + MMA(x, D^k).  Materializing
+                # I + D^k instead would cost a second pack per step in the
+                # issue-bound warp-0 region -- measured at +0.85% on fixed_h96.
+                binv = [cutlass.Float32(0.0) for _ in range(8)]
+                for slot in cutlass.range_constexpr(8):
+                    row, col = acc_coord(lane, slot)
+                    eye = cutlass.Float32(0.0)
+                    if row == col:
+                        eye = cutlass.Float32(1.0)
+                    binv[slot] = eye - f16_round(d[slot])
+
+                for step in cutlass.range_constexpr(2):
+                    lhs = acc_to_a_fragment_f16(tuple(binv))
+                    pf = pows[step]
+                    pb = a_to_b(pf[0], pf[1], pf[2], pf[3])
+                    prod = mma_16x16_f16(
+                        lhs[0],
+                        lhs[1],
+                        lhs[2],
+                        lhs[3],
+                        pb[0],
+                        pb[1],
+                        pb[2],
+                        pb[3],
+                        ZERO8(),
+                    )
+                    for slot in cutlass.range_constexpr(8):
+                        binv[slot] = f16_round(binv[slot]) + prod[slot]
+
+                # x21 = -(Binv @ A21) @ Binv, written into the lower-left block.
+                bf = acc_to_a_fragment_f16(tuple(binv))
+                af = acc_to_a_fragment_f16(tuple(a21))
+                ab = a_to_b(af[0], af[1], af[2], af[3])
+                t1 = mma_16x16_f16(
+                    bf[0], bf[1], bf[2], bf[3], ab[0], ab[1], ab[2], ab[3], ZERO8()
+                )
+                tf = acc_to_a_fragment_f16(t1)
+                bb = a_to_b(bf[0], bf[1], bf[2], bf[3])
+                x21 = mma_16x16_f16(
+                    tf[0], tf[1], tf[2], tf[3], bb[0], bb[1], bb[2], bb[3], ZERO8()
+                )
+
+                for slot in cutlass.range_constexpr(8):
+                    row, col = acc_coord(lane, slot)
+                    v = binv[slot]
+                    if row >= HALF_BT and col < HALF_BT:
+                        v = -x21[slot]
+                    smem_ainv[prepare_pair_idx(row, col)] = bf16_round(v).to(
+                        cutlass.BFloat16
+                    )
+                # step 7 of the design.  This arrival publishes AINV and
+                # also proves warp 0 is done reading smem_kd_then_ak, which is
+                # what lets warps 1 and 3 overwrite their Kd half with Ak.
+                warp_arrive(mbar_pairwise, lane)
+
+            # ---- warp 2: causal QK, staged through SMEM ---------------
+            if warp_id == 2:
+                cute.arch.mbarrier_wait(mbar_k_full, phase)
+                c = kk_over_dk(p_qd, p_ki, lane)
+                for slot in cutlass.range_constexpr(8):
+                    row, col = acc_coord(lane, slot)
+                    v = cutlass.Float32(0.0)
+                    if row >= col:
+                        v = c[slot]
+                    smem_qk[prepare_pair_idx(row, col)] = bf16_round(v).to(
+                        cutlass.BFloat16
+                    )
+                # smem_qk is produced and consumed by this warp alone.
+                cute.arch.sync_warp()
+
+            # ---- warp 1: release the raw stages, then prefetch ----------
+            # step 6 of the design, now literal: one elected lane issues
+            # the whole 16 KB, so only warp 1 stops for the prefetch.  The
+            # cp.async version needed 64 threads and had to borrow warp 3 too.
+            if warp_id == 1:
+                cute.arch.mbarrier_wait(mbar_raw_released, phase)
+                # publish the ordinary Kd stores to the async
+                # shared proxy before the TMA engine reads them, and converge
+                # the warp so lane 0 speaks for all 32 lanes' writes.
+                cute.arch.fence_view_async_shared()
+                cute.arch.sync_warp()
+                if lane == 0:
+                    tma_store_3d(desc_factor, p_kd, 0, gchunk * BT, head)
+                    tma_store_commit_group()
+                if lc + 1 < CPC:
+                    if lc + 1 < my_chunks:
+                        nchunk = gchunk + 1
+                        nseq = cutlass.Int32(gchunk_to_seq[nchunk])
+                        nlc = nchunk - cutlass.Int32(gcu_chunks[nseq])
+                        ntb = cutlass.Int32(gcu_seqlens[nseq]) + nlc * BT
+                        nvr = cutlass.Int32(gcu_seqlens[nseq + 1]) - ntb
+                        if nvr > BT:
+                            nvr = cutlass.Int32(BT)
+                        if lane == 0:
+                            if cutlass.const_expr((lc + 1) & 1):
+                                cute.arch.mbarrier_arrive_and_expect_tx(mbar_tma1, G_TX)
+                                issue_chunk_tma(
+                                    desc_q,
+                                    desc_k,
+                                    desc_g,
+                                    p_q,
+                                    p_k,
+                                    p_g_raw,
+                                    mbar_tma1,
+                                    ntb,
+                                    head,
+                                    G_FP32,
+                                )
+                            else:
+                                cute.arch.mbarrier_arrive_and_expect_tx(mbar_tma0, G_TX)
+                                issue_chunk_tma(
+                                    desc_q,
+                                    desc_k,
+                                    desc_g,
+                                    p_q,
+                                    p_k,
+                                    p_g_raw,
+                                    mbar_tma0,
+                                    ntb,
+                                    head,
+                                    G_FP32,
+                                )
+                        load_beta_stage(
+                            gbeta,
+                            smem_beta,
+                            (lc + 1) & 1,
+                            ntb,
+                            nvr,
+                            head,
+                            lane,
+                            heads,
+                        )
+            elif warp_id == 3:
+                # Warp 3 no longer issues any of the prefetch, but it still
+                # acquires raw_operands_released: that is what makes the other
+                # warps' Ki stores visible to its Ak path below, without
+                # relying on a chained release/acquire through warp 0.
+                cute.arch.mbarrier_wait(mbar_raw_released, phase)
+                cute.arch.fence_view_async_shared()
+                cute.arch.sync_warp()
+                if lane == 0:
+                    # Section 7.4: Kd segment 1 plus both Qd segments, one group.
+                    tma_store_3d(
+                        desc_factor,
+                        p_kd + BF16_SEG_STRIDE,
+                        BF16_SEG_ELEMS,
+                        gchunk * BT,
+                        head,
+                    )
+                    tma_store_3d(desc_factor, p_qd, 0, gchunk * BT, heads + head)
+                    tma_store_3d(
+                        desc_factor,
+                        p_qd + BF16_SEG_STRIDE,
+                        BF16_SEG_ELEMS,
+                        gchunk * BT,
+                        heads + head,
+                    )
+                    tma_store_commit_group()
+
+            # ---- AINV_beta, then Aq (warp 2) and Ak (warps 1 and 3) ---
+            # pairwise_ready is a plain release/acquire pair on smem_ainv, whose
+            # only writer is warp 0.  The Ki that warps 1 and 3 read below is
+            # covered without leaning on chained visibility: warp 2 acquired
+            # k_full_ready directly, and warps 1 and 3 acquired
+            # raw_operands_released, on which every warp arrives after its
+            # k_full_ready arrival and therefore after its Ki stores.
+            if warp_id != 0:
+                cute.arch.mbarrier_wait(mbar_pairwise, phase)
+                ai = load_pairwise_a_fragment(p_ainv, lane)
+                bst = beta_stage * BT
+                blo = pack_bf16x2(smem_beta[bst + 2 * q4], smem_beta[bst + 2 * q4 + 1])
+                bhi = pack_bf16x2(
+                    smem_beta[bst + 2 * q4 + 8], smem_beta[bst + 2 * q4 + 9]
+                )
+                ab0 = mul_bf16x2(ai[0], blo)
+                ab1 = mul_bf16x2(ai[1], blo)
+                ab2 = mul_bf16x2(ai[2], bhi)
+                ab3 = mul_bf16x2(ai[3], bhi)
+
+                if warp_id == 2:
+                    bb = a_to_b(ab0, ab1, ab2, ab3)
+                    qk_a = load_pairwise_a_fragment(p_qk, lane)
+                    aq = mma_16x16(
+                        qk_a[0],
+                        qk_a[1],
+                        qk_a[2],
+                        qk_a[3],
+                        bb[0],
+                        bb[1],
+                        bb[2],
+                        bb[3],
+                        ZERO8(),
+                    )
+                    base = (head * TOTAL_CHUNKS + gchunk) * (BT * BT)
+                    # the design.  Stage through SMEM so the global
+                    # store is one contiguous 16-byte run per lane.  Direct
+                    # stores cannot be: prepare_pair_idx swaps the column halves
+                    # (col ^ 8), so one store instruction only ever fills half
+                    # of each row's 32 bytes, spraying 128 B over 8 sectors.
+                    # The four instructions did tile the 512 B exactly, but L1
+                    # does not merge across instructions, so 32 sectors left
+                    # the SM where 16 would do.  Measured, fixed_h96: STG 8 ->
+                    # 5 instructions per chunk, L1 request 48 -> 32 sectors,
+                    # and the kernel's whole L1->L2 write becomes 654.31 MB
+                    # against a native output of 49,152 x 13,312 = 654,311,424
+                    # B -- exactly 1.000x.
+                    #
+                    # smem_qk is free here: warp 2 owns it alone and has just
+                    # consumed it into qk_a, so this costs no shared memory.
+                    cute.arch.sync_warp()
+                    aqf = acc_to_a_fragment(aq)
+                    srow, scol = prepare_stmatrix_coord(lane)
+                    stmatrix_x4(
+                        p_qk + prepare_pair_idx(srow, scol),
+                        aqf[0],
+                        aqf[1],
+                        aqf[2],
+                        aqf[3],
+                    )
+                    cute.arch.sync_warp()
+                    cute.autovec_copy(
+                        vec8_bf16(p_qk, lane * 8),
+                        vec_at(ws_aq.iterator, base + lane * 8, 8),
+                    )
+
+                else:
+                    # Section 12.3 step 8: pairwise_ready above proved warp 0 is
+                    # done reading smem_kd_then_ak; this waits for the warp's own
+                    # Kd TMA store to have finished *reading* its half, which is
+                    # the other half of the condition for overwriting it.  The
+                    # warp synchronization joins the two before any lane writes.
+                    if lane == 0:
+                        tma_store_wait_read(0)
+                    cute.arch.sync_warp()
+
+                    at0, at1, at2, at3 = a_to_a_transposed(ab0, ab1, ab2, ab3)
+                    tile_base = 0
+                    if warp_id == 3:
+                        tile_base = 4
+                    for t in cutlass.range_constexpr(4):
+                        d0 = (tile_base + t) * 16
+                        ki0, ki1, ki2, ki3 = load_a_fragment(p_ki, 0, d0, lane)
+                        gl = pack_bf16x2(
+                            cutlass.Float32(smem_gamma[d0 + 2 * q4]),
+                            cutlass.Float32(smem_gamma[d0 + 2 * q4 + 1]),
+                        )
+                        gh = pack_bf16x2(
+                            cutlass.Float32(smem_gamma[d0 + 2 * q4 + 8]),
+                            cutlass.Float32(smem_gamma[d0 + 2 * q4 + 9]),
+                        )
+                        kb = a_to_b(
+                            mul_bf16x2(ki0, gl),
+                            mul_bf16x2(ki1, gl),
+                            mul_bf16x2(ki2, gh),
+                            mul_bf16x2(ki3, gh),
+                        )
+                        akc = mma_16x16(
+                            at0, at1, at2, at3, kb[0], kb[1], kb[2], kb[3], ZERO8()
+                        )
+                        # publish Ak.T with stmatrix.x4 through
+                        # the row-^8 image, into the Kd stage that is now dead.
+                        # Warp 1 owns d < 64 -> bytes [0,2048), warp 3 the rest.
+                        akf = acc_to_a_fragment(akc)
+                        srow, scol = prepare_stmatrix_coord(lane)
+                        stmatrix_x4(
+                            p_kd + kr_ak_idx(srow, d0 + scol),
+                            akf[0],
+                            akf[1],
+                            akf[2],
+                            akf[3],
+                        )
+
+                    # Section 7.4: each store warp moves its own Ak segment.
+                    # This is what removes the CTA barrier and the 128-thread
+                    # re-read the vector-store version needed -- the warp that
+                    # produced the half is the warp that ships it.
+                    cute.arch.fence_view_async_shared()
+                    cute.arch.sync_warp()
+                    if lane == 0:
+                        seg = tile_base // 4
+                        tma_store_3d(
+                            desc_factor,
+                            p_kd + seg * BF16_SEG_STRIDE,
+                            seg * BF16_SEG_ELEMS,
+                            gchunk * BT,
+                            2 * heads + head,  # Ak is plane region 2
+                        )
+                        tma_store_commit_group()
+                        # Section 12.3 step 8: the source stage cannot be reused
+                        # until the store has read it.
+                        tma_store_wait_read(0)
+
+            # Chunk recycle (Section 12.3 step 9).
+            cute.arch.barrier()
+
+
+@cute.jit
+def _prepare_entry(
+    gq: cute.Tensor,
+    gk: cute.Tensor,
+    gg: cute.Tensor,
+    gbeta: cute.Tensor,
+    ga_log_exp: cute.Tensor,
+    gdt: cute.Tensor,
+    gcu_seqlens: cute.Tensor,
+    gcu_chunks: cute.Tensor,
+    gchunk_to_seq: cute.Tensor,
+    ws_kd: cute.Tensor,
+    ws_qd: cute.Tensor,
+    ws_ak: cute.Tensor,
+    ws_aq: cute.Tensor,
+    ws_gt: cute.Tensor,
+    desc_q: cutlass.Int64,
+    desc_k: cutlass.Int64,
+    desc_g: cutlass.Int64,
+    desc_factor: cutlass.Int64,
+    scale: cutlass.Float32,
+    gate_scale_log2: cutlass.Float32,
+    total_chunks: cutlass.Int32,
+    heads: cutlass.Int32,
+    grid_x: cutlass.Int32,
+    stream,
+    SAFE_GATE: cutlass.Constexpr,
+    CPC: cutlass.Constexpr,
+    G_FP32: cutlass.Constexpr,
+):
+    prepare_kernel(
+        gq,
+        gk,
+        gg,
+        gbeta,
+        ga_log_exp,
+        gdt,
+        gcu_seqlens,
+        gcu_chunks,
+        gchunk_to_seq,
+        ws_kd,
+        ws_qd,
+        ws_ak,
+        ws_aq,
+        ws_gt,
+        desc_q,
+        desc_k,
+        desc_g,
+        desc_factor,
+        scale,
+        gate_scale_log2,
+        total_chunks,
+        heads,
+        SAFE_GATE,
+        CPC,
+        G_FP32,
+    ).launch(
+        grid=(grid_x, heads, 1),
+        block=(PREPARE_DEVICE_THREADS, 1, 1),
+        stream=stream,
+    )
+
+
+_PREPARE_DEVICE_CACHE: dict = {}
+
+
+def _flat(t: torch.Tensor):
+    """Flat CuTe view, cached on the address (see :func:`~.runtime.flat_view`)."""
+    return flat_view(t, align=16)
+
+
+def launch_prepare_device(
+    *,
+    q,
+    k,
+    g,
+    beta,
+    a_log_exp,
+    dt_bias,
+    cu_seqlens,
+    cu_chunks,
+    chunk_to_seq,
+    workspace,
+    scale,
+    lower_bound,
+    heads,
+    total_tokens,
+    total_chunks,
+    config,
+):
+    import cuda.bindings.driver as cuda_driver
+
+    grid_x = (total_chunks + config.chunks_per_cta - 1) // config.chunks_per_cta
+    # The tensors' device, not the current one; see fused/launch.py.
+    stream = cuda_driver.CUstream(torch.cuda.current_stream(q.device).cuda_stream)
+
+    # Cached on the buffer addresses, so a steady-state launch does not pay for
+    # encoding descriptors.
+    tmaps = build_tensor_maps(
+        q=q,
+        k=k,
+        g=g,
+        ws_kd=workspace.kd,
+        ws_qd=workspace.qd,
+        ws_ak=workspace.ak,
+        total_tokens=total_tokens,
+        total_chunks=total_chunks,
+        heads=heads,
+    )
+
+    args = (
+        _flat(q),
+        _flat(k),
+        _flat(g),
+        _flat(beta),
+        _flat(a_log_exp),
+        _flat(dt_bias),
+        _flat(cu_seqlens),
+        _flat(cu_chunks),
+        _flat(chunk_to_seq),
+        _flat(workspace.kd),
+        _flat(workspace.qd),
+        _flat(workspace.ak),
+        _flat(workspace.aq),
+        _flat(workspace.g_total),
+        cutlass.Int64(tmaps.q),
+        cutlass.Int64(tmaps.k),
+        cutlass.Int64(tmaps.g),
+        cutlass.Int64(tmaps.factor),
+        cutlass.Float32(scale),
+        cutlass.Float32(lower_bound * LOG2_E),
+        cutlass.Int32(total_chunks),
+        cutlass.Int32(heads),
+        cutlass.Int32(grid_x),
+        stream,
+    )
+    g_fp32 = g.dtype is torch.float32
+    # Device is part of the in-process key because a loaded callable is tied to
+    # its CUDA context. Heads and grid remain runtime values.
+    key = (
+        q.device.index,
+        bool(config.safe_gate),
+        int(config.chunks_per_cta),
+        g_fp32,
+    )
+    compiled = _PREPARE_DEVICE_CACHE.get(key)
+    if compiled is None:
+        with torch.cuda.device(q.device):
+            compiled = cute.compile(
+                _prepare_entry,
+                *args,
+                bool(config.safe_gate),
+                int(config.chunks_per_cta),
+                g_fp32,
+            )
+        _PREPARE_DEVICE_CACHE[key] = compiled
+    compiled(*args)
+
+
+# --------------------------------------------------------------------------
+# Section 9: the recurrence device kernel
+# --------------------------------------------------------------------------
+
+# Absolute imports only: the DSL's AST preprocessor re-executes this module's
+# import list when it traces a ``@cute.jit`` body, and it cannot resolve a
+# relative ``from . import x``.
+
+KEY_BLOCKS = DK // BT  # 8
+
+# Barrier slots as Int64 indices into the arena.
+BAR_IN_READY = MBAR_INPUT_READY // 8  # 0
+BAR_IN_CONSUMED = MBAR_INPUT_CONSUMED // 8  # 5
+BAR_OUT_READY = MBAR_OUTPUT_READY // 8  # 10
+BAR_OUT_CONSUMED = MBAR_OUTPUT_CONSUMED // 8  # 12
+BAR_STATE = MBAR_STATE_READY // 8  # 14
+
+#: One 128-byte S128 segment of a factor tile, in BF16 elements.
+FACTOR_SEGMENT_ELEMS = BF16_SEGMENT_STRIDE  # 1024
+
+#: 16-byte tasks covering the whole state half, for the conversion and clear
+#: passes.  1024 tasks over 320 threads is four rounds with a bound check; this
+#: runs once per kernel, not per chunk.
+STATE_TASKS = DV_HALF * (DK // 8)  # 1024
+STATE_TASK_ROUNDS = (STATE_TASKS + REC_THREADS - 1) // REC_THREADS  # 4
+
+
+# ---------------------------------------------------------------------------
+# Small DSL helpers
+# ---------------------------------------------------------------------------
+
+
+@cute.jit
+def store_vec4_f32(ptr, idx, frag):
+    cute.autovec_copy(frag, vec_at(ptr, idx, 4))
+
+
+@cute.jit
+def zero_acc4():
+    z = cutlass.Float32(0.0)
+    return (z, z, z, z)
+
+
+@cute.jit
+def mma_n8(a, b, c):
+    """One native ``m16n8k16``: A is four registers, B two, C four."""
+    return mma_m16n8k16_bf16(a[0], a[1], a[2], a[3], b[0], b[1], c[0], c[1], c[2], c[3])
+
+
+# ---------------------------------------------------------------------------
+# State entry and exit
+# ---------------------------------------------------------------------------
+
+
+@cute.jit
+def clear_state(p_state, tidx):
+    """Zero the persistent BF16 state with every CTA thread."""
+    zeros = make_rmem_tensor(8, cutlass.BFloat16)
+    for i in cutlass.range_constexpr(8):
+        zeros[i] = cutlass.BFloat16(0.0)
+    for rep in cutlass.range_constexpr(STATE_TASK_ROUNDS):
+        task = tidx + rep * REC_THREADS
+        if task < STATE_TASKS:
+            v_local = task // (DK // 8)
+            k0 = (task - v_local * (DK // 8)) * 8
+            store_vec8_bf16(p_state, state_bf16_idx(v_local, k0), zeros)
+
+
+@cute.jit
+def state_f32_to_bf16(p_state, p_state_f32, tidx):
+    """Round the FP32 landing buffer into the BF16 persistent state.
+
+    even an FP32 external state crosses this boundary, because
+    the state carried between chunks is BF16 by contract.
+    """
+    for rep in cutlass.range_constexpr(STATE_TASK_ROUNDS):
+        task = tidx + rep * REC_THREADS
+        if task < STATE_TASKS:
+            v_local = task // (DK // 8)
+            k0 = (task - v_local * (DK // 8)) * 8
+            # The FP32 image groups four elements, so eight keys are two
+            # separate aligned float4 runs whose order depends on the row.
+            lo = vec4_f32(p_state_f32, state_f32_idx(v_local, k0))
+            hi = vec4_f32(p_state_f32, state_f32_idx(v_local, k0 + 4))
+            out = make_rmem_tensor(8, cutlass.BFloat16)
+            for i in cutlass.range_constexpr(4):
+                out[i] = lo[i].to(cutlass.BFloat16)
+                out[4 + i] = hi[i].to(cutlass.BFloat16)
+            store_vec8_bf16(p_state, state_bf16_idx(v_local, k0), out)
+
+
+@cute.jit
+def state_bf16_to_f32(p_state, p_state_f32, tidx):
+    """Widen the BF16 state into the FP32 buffer an FP32 final state stores."""
+    for rep in cutlass.range_constexpr(STATE_TASK_ROUNDS):
+        task = tidx + rep * REC_THREADS
+        if task < STATE_TASKS:
+            v_local = task // (DK // 8)
+            k0 = (task - v_local * (DK // 8)) * 8
+            src = vec8_bf16(p_state, state_bf16_idx(v_local, k0))
+            lo = make_rmem_tensor(4, cutlass.Float32)
+            hi = make_rmem_tensor(4, cutlass.Float32)
+            for i in cutlass.range_constexpr(4):
+                lo[i] = cutlass.Float32(src[i])
+                hi[i] = cutlass.Float32(src[4 + i])
+            store_vec4_f32(p_state_f32, state_f32_idx(v_local, k0), lo)
+            store_vec4_f32(p_state_f32, state_f32_idx(v_local, k0 + 4), hi)
+
+
+# ---------------------------------------------------------------------------
+# Kernel
+# ---------------------------------------------------------------------------
+
+
+@cute.kernel
+def recurrence_kernel(
+    gout: cute.Tensor,
+    gcu_seqlens: cute.Tensor,
+    gcu_chunks: cute.Tensor,
+    desc_factor: cutlass.Int64,
+    desc_aq: cutlass.Int64,
+    desc_gt: cutlass.Int64,
+    desc_v: cutlass.Int64,
+    desc_out: cutlass.Int64,
+    desc_state_in: cutlass.Int64,
+    desc_state_out: cutlass.Int64,
+    heads: cutlass.Int32,
+    HAS_STATE_IN: cutlass.Constexpr,
+    HAS_STATE_OUT: cutlass.Constexpr,
+    STATE_FP32: cutlass.Constexpr,
+) -> None:
+    tidx, _, _ = cute.arch.thread_idx()
+    bidx, bidy, _ = cute.arch.block_idx()
+    warp_id = cute.arch.make_warp_uniform(cute.arch.warp_idx())
+    lane = tidx % 32
+
+    # x = 2 * seq + dv_half, y = head (recurrence_grid): the DV half is the
+    # fastest-varying coordinate, so the two halves of a head are adjacent
+    # blocks and share a wave, which is what lets L2 serve the second one's
+    # factor loads.  Everything coarser keeps the order (N, 2H, 1) had.
+    seq = bidx >> 1
+    dv_half = bidx - seq * 2
+    head = bidy
+
+    # --- fixed arena ------------------------------------
+    # One allocation of exactly SMEM_DYNAMIC_BYTES, so the launch parameter is
+    # the plan's number and every address is a compile-time constant offset.
+    alloc = cutlass.utils.SmemAllocator()
+    p_base = alloc.allocate(SMEM_DYNAMIC_BYTES, 1024)
+    p16 = cute.recast_ptr(p_base, dtype=cutlass.BFloat16)
+    p32 = cute.recast_ptr(p_base, dtype=cutlass.Float32)
+    p64 = cute.recast_ptr(p_base, dtype=cutlass.Int64)
+
+    p_state = p16 + (SMEM_STATE // 2)
+    p_state_f32 = p32 + (SMEM_STATE_F32 // 4)
+    p_bar = p64 + (REC_SMEM_BARRIERS // 8)
+
+    if warp_id == 0:
+        if lane == 0:
+            for s in cutlass.range_constexpr(INPUT_STAGES):
+                cute.arch.mbarrier_init(p_bar + BAR_IN_READY + s, INPUT_READY_ARRIVALS)
+                cute.arch.mbarrier_init(
+                    p_bar + BAR_IN_CONSUMED + s, INPUT_CONSUMED_ARRIVALS
+                )
+            for s in cutlass.range_constexpr(OUTPUT_STAGES):
+                cute.arch.mbarrier_init(
+                    p_bar + BAR_OUT_READY + s, OUTPUT_READY_ARRIVALS
+                )
+                cute.arch.mbarrier_init(
+                    p_bar + BAR_OUT_CONSUMED + s, OUTPUT_CONSUMED_ARRIVALS
+                )
+            cute.arch.mbarrier_init(p_bar + BAR_STATE, STATE_READY_ARRIVALS)
+            cute.arch.mbarrier_init_fence()
+            fence_tensormap_acquire(desc_factor)
+            fence_tensormap_acquire(desc_aq)
+            fence_tensormap_acquire(desc_gt)
+            fence_tensormap_acquire(desc_v)
+            fence_tensormap_acquire(desc_out)
+            if cutlass.const_expr(HAS_STATE_IN):
+                fence_tensormap_acquire(desc_state_in)
+            if cutlass.const_expr(HAS_STATE_OUT):
+                fence_tensormap_acquire(desc_state_out)
+    cute.arch.barrier()
+
+    # --- sequence coordinates ---------------------------
+    token_start = cutlass.Int32(gcu_seqlens[seq])
+    token_end = cutlass.Int32(gcu_seqlens[seq + 1])
+    chunk_base = cutlass.Int32(gcu_chunks[seq])
+    num_chunks = cutlass.Int32(gcu_chunks[seq + 1]) - chunk_base
+    state_plane = seq * heads + head
+
+    # --- initial state ----------------------------------
+    if cutlass.const_expr(HAS_STATE_IN):
+        if cutlass.const_expr(STATE_FP32):
+            if warp_id == 0:
+                if lane == 0:
+                    cute.arch.mbarrier_arrive_and_expect_tx(
+                        p_bar + BAR_STATE, DV_HALF * DK * 4
+                    )
+                    tma_load_3d(
+                        p_state_f32,
+                        desc_state_in,
+                        p_bar + BAR_STATE,
+                        0,
+                        dv_half * (STATE_F32_ROWS_PER_VALUE * DV_HALF),
+                        state_plane,
+                    )
+            cute.arch.mbarrier_wait(p_bar + BAR_STATE, 0)
+            state_f32_to_bf16(p_state, p_state_f32, tidx)
+        else:
+            if warp_id == 0:
+                if lane == 0:
+                    cute.arch.mbarrier_arrive_and_expect_tx(
+                        p_bar + BAR_STATE, DV_HALF * DK * 2
+                    )
+                    tma_load_3d(
+                        p_state,
+                        desc_state_in,
+                        p_bar + BAR_STATE,
+                        0,
+                        dv_half * (STATE_BF16_ROWS_PER_VALUE * DV_HALF),
+                        state_plane,
+                    )
+            cute.arch.mbarrier_wait(p_bar + BAR_STATE, 0)
+    else:
+        clear_state(p_state, tidx)
+    cute.arch.barrier()
+
+    # --- roles ---------------------------------
+    if warp_id < COMPUTE_WARPS:
+        v_base = warp_id * WARP_VALUES
+        # The state lives in registers for the whole kernel, read from shared
+        # memory once here and written back once after the chunk loop.  Sixteen
+        # packed BF16 registers per lane hold this warp's [128 key, 8 value]
+        # slice, which is warp-private -- ``v_base`` is ``warp_id *
+        # WARP_VALUES`` and no warp ever addresses another's columns -- so
+        # nothing here needs a cross-warp exchange.
+        #
+        # It replaces 24 shared-memory instructions per chunk per warp (eight
+        # ``ldmatrix_x2`` in pass 1, eight ``ldmatrix_x2_trans`` and eight
+        # ``stmatrix_x2_trans`` in pass 2) with 16 ``movmatrix``.  The
+        # ``.trans`` read is the C view, which is the layout pass 2 accumulates
+        # in; pass 1 wants the B operand and gets it with one ``movmatrix`` per
+        # register.  ``tests/test_recurrence_layouts.py`` enumerates that
+        # equality, 64 of 64.
+        h_state: tuple = ()
+        for kb in cutlass.range_constexpr(KEY_BLOCKS):
+            lo, hi = ldmatrix_x2_trans(p_state + state_x2_ptr(lane, kb, v_base))
+            h_state = h_state + (lo, hi)
+
+        for c in range(num_chunks):
+            in_stage = input_stage(c)
+            out_stage = output_stage(c)
+            stage16 = (SMEM_INPUT // 2) + in_stage * (INPUT_STAGE_BYTES // 2)
+            p_kd = p16 + (stage16 + STAGE_KD // 2)
+            p_qd = p16 + (stage16 + STAGE_QD // 2)
+            p_ak = p16 + (stage16 + STAGE_AK // 2)
+            p_aq = p16 + (stage16 + STAGE_AQ // 2)
+            p_v = p16 + (stage16 + STAGE_V // 2)
+            smem_gt = cute.make_tensor(
+                p32
+                + ((SMEM_INPUT + STAGE_GT) // 4 + in_stage * (INPUT_STAGE_BYTES // 4)),
+                cute.make_layout(DK),
+            )
+            p_out = p16 + ((SMEM_OUTPUT // 2) + out_stage * (OUTPUT_STAGE_BYTES // 2))
+
+            token_base = token_start + c * BT
+            valid_rows = token_end - token_base
+            if valid_rows > BT:
+                valid_rows = cutlass.Int32(BT)
+
+            # The nine IKET ranges below -- five here, two on the producer, two
+            # on the store warp -- are emitted only under the research build; see
+            # the research tracing hooks.  They split a chunk into stall and
+            # work for each role, which is what NCU cannot show.
+            cute.arch.mbarrier_wait(
+                p_bar + BAR_IN_READY + in_stage, input_ready_parity(c)
+            )
+
+            # ---- pass 1: X = Kd @ H and O = Qd @ H --------------------------
+            # One state B fragment per key block feeds both MMAs, and nothing
+            # writes the state until pass 2, so the fragment can be dropped
+            # immediately after use.
+            acc_x = zero_acc4()
+            acc_o = zero_acc4()
+            for kb in cutlass.range_constexpr(KEY_BLOCKS):
+                # C -> B is a within-tile 8x8 transpose, one instruction per
+                # packed register, and the fragment is fresh rather than
+                # aliased onto ``h_state``: aliasing an MMA operand onto
+                # persistent state registers is what made engine's equivalent
+                # probe spill.
+                b = (
+                    movmatrix_b16(h_state[2 * kb]),
+                    movmatrix_b16(h_state[2 * kb + 1]),
+                )
+                acc_x = mma_n8(
+                    ldmatrix_x4(p_kd + factor_a_fragment_ptr(lane, kb)), b, acc_x
+                )
+                acc_o = mma_n8(
+                    ldmatrix_x4(p_qd + factor_a_fragment_ptr(lane, kb)), b, acc_o
+                )
+
+            # ---- residual -------------------------
+            # Both halves of a packed C register are the same token row, so the
+            # tail mask is one predicate per register.  An invalid row selects an
+            # exact packed BF16 zero instead of subtracting a V that belongs to
+            # the next sequence.
+
+            v_lo, v_hi = ldmatrix_x2(p_v + vo_x2_ptr(lane, v_base))
+            row_lo = lane // 4
+            res_lo = cutlass.Int32(0)
+            res_hi = cutlass.Int32(0)
+            if row_lo < valid_rows:
+                res_lo = sub_bf16x2(v_lo, pack_bf16x2(acc_x[0], acc_x[1]))
+            if row_lo + 8 < valid_rows:
+                res_hi = sub_bf16x2(v_hi, pack_bf16x2(acc_x[2], acc_x[3]))
+            # C layout -> B layout: transpose each packed 8x8 quadrant in place.
+            res_b = (movmatrix_b16(res_lo), movmatrix_b16(res_hi))
+
+            # ---- O += Aq @ R, into the same FP32 accumulator ----------------
+            acc_o = mma_n8(
+                ldmatrix_x4(p_aq + pairwise_a_fragment_ptr(lane)), res_b, acc_o
+            )
+
+            # ---- publish the output before the state update -----------------
+            cute.arch.mbarrier_wait(
+                p_bar + BAR_OUT_CONSUMED + out_stage, output_consumed_parity(c)
+            )
+            stmatrix_x2(
+                p_out + vo_x2_ptr(lane, v_base),
+                pack_bf16x2(acc_o[0], acc_o[1]),
+                pack_bf16x2(acc_o[2], acc_o[3]),
+            )
+            warp_arrive(p_bar + BAR_OUT_READY + out_stage, lane)
+
+            # ---- pass 2: H_next = Diag(GTotal) H + Ak @ R -------------------
+            # The same addresses as pass 1, read with ``.trans`` so the state
+            # arrives already in the accumulator's layout.  Each warp writes
+            # only its own value columns, and pass 1 is complete, so the update
+            # is safe in place.
+            next_state: tuple = ()
+            for kb in cutlass.range_constexpr(KEY_BLOCKS):
+                h0, h1 = unpack_bf16x2(h_state[2 * kb])
+                h2, h3 = unpack_bf16x2(h_state[2 * kb + 1])
+                decay_lo = cutlass.Float32(smem_gt[kb * BT + row_lo])
+                decay_hi = cutlass.Float32(smem_gt[kb * BT + row_lo + 8])
+                acc_s = (
+                    decay_lo * h0,
+                    decay_lo * h1,
+                    decay_hi * h2,
+                    decay_hi * h3,
+                )
+                acc_s = mma_n8(
+                    ldmatrix_x4_trans(p_ak + ak_a_fragment_ptr(lane, kb)),
+                    res_b,
+                    acc_s,
+                )
+                next_state = next_state + (
+                    pack_bf16x2(acc_s[0], acc_s[1]),
+                    pack_bf16x2(acc_s[2], acc_s[3]),
+                )
+            h_state = next_state
+
+            warp_arrive(p_bar + BAR_IN_CONSUMED + in_stage, lane)
+
+        # The final-state path below reads the state from shared memory with all
+        # 320 threads, so the compute warps publish their registers first.  The
+        # converging barrier after this branch is what orders it.
+        for kb in cutlass.range_constexpr(KEY_BLOCKS):
+            stmatrix_x2_trans(
+                p_state + state_x2_ptr(lane, kb, v_base),
+                h_state[2 * kb],
+                h_state[2 * kb + 1],
+            )
+
+    elif warp_id == LOAD_WARP:
+        for c in range(num_chunks):
+            in_stage = input_stage(c)
+            cute.arch.mbarrier_wait(
+                p_bar + BAR_IN_CONSUMED + in_stage, input_consumed_parity(c)
+            )
+
+            if lane == 0:
+                gchunk = chunk_base + c
+                token_base = token_start + c * BT
+                factor_row = gchunk * BT
+                stage16 = SMEM_INPUT // 2 + in_stage * (INPUT_STAGE_BYTES // 2)
+                mbar = p_bar + BAR_IN_READY + in_stage
+                cute.arch.mbarrier_arrive_and_expect_tx(mbar, INPUT_STAGE_TX_BYTES)
+                # Nine instructions, one completion barrier, 15,360 bytes.
+                for factor in cutlass.range_constexpr(3):
+                    plane = factor * heads + head
+                    dst = stage16 + (STAGE_KD // 2) + factor * (4096 // 2)
+                    for segment in cutlass.range_constexpr(BF16_SEGMENTS):
+                        tma_load_3d(
+                            p16 + (dst + segment * FACTOR_SEGMENT_ELEMS),
+                            desc_factor,
+                            mbar,
+                            segment * BF16_SEGMENT_ELEMS,
+                            factor_row,
+                            plane,
+                        )
+                tma_load_3d(
+                    p16 + (stage16 + STAGE_AQ // 2),
+                    desc_aq,
+                    mbar,
+                    0,
+                    gchunk,
+                    head,
+                )
+                tma_load_3d(
+                    p32
+                    + (
+                        (SMEM_INPUT + STAGE_GT) // 4
+                        + in_stage * (INPUT_STAGE_BYTES // 4)
+                    ),
+                    desc_gt,
+                    mbar,
+                    0,
+                    gchunk,
+                    head,
+                )
+                tma_load_3d(
+                    p16 + (stage16 + STAGE_V // 2),
+                    desc_v,
+                    mbar,
+                    dv_half * DV_HALF,
+                    token_base,
+                    head,
+                )
+
+    else:
+        for c in range(num_chunks):
+            out_stage = output_stage(c)
+            p_out = p16 + ((SMEM_OUTPUT // 2) + out_stage * (OUTPUT_STAGE_BYTES // 2))
+            token_base = token_start + c * BT
+            valid_rows = token_end - token_base
+            if valid_rows > BT:
+                valid_rows = cutlass.Int32(BT)
+
+            cute.arch.mbarrier_wait(
+                p_bar + BAR_OUT_READY + out_stage, output_ready_parity(c)
+            )
+
+            if valid_rows == BT:
+                # The full path: the stage is released only after
+                # the store has read it, not when it is merely committed.
+                cute.arch.fence_view_async_shared()
+                cute.arch.sync_warp()
+                if lane == 0:
+                    tma_store_3d(desc_out, p_out, dv_half * DV_HALF, token_base, head)
+                    tma_store_commit_group()
+                    tma_store_wait_read(0)
+                    cute.arch.mbarrier_arrive(p_bar + BAR_OUT_CONSUMED + out_stage)
+            else:
+                # Tail path: the whole warp stores 16-byte vectors, and no TMA,
+                # fence, commit or wait-group is involved.
+                for rep in cutlass.range_constexpr(4):
+                    task = lane + rep * 32
+                    if task < valid_rows * 8:
+                        row = task // 8
+                        vec = task - row * 8
+                        frag = vec8_bf16(p_out, vo_idx(row, vec * 8))
+                        store_vec8_bf16(
+                            gout.iterator,
+                            vo_global_index(
+                                token_base + row, head, heads, dv_half, vec * 8
+                            ),
+                            frag,
+                        )
+                cute.arch.sync_warp()
+                if lane == 0:
+                    cute.arch.mbarrier_arrive(p_bar + BAR_OUT_CONSUMED + out_stage)
+
+    # --- final state handoff ----------------------------
+    # All three roles converge here: the loads are issued, the last state update
+    # is written, and every output store has completed its ``wait_group.read``.
+    cute.arch.barrier()
+    if cutlass.const_expr(HAS_STATE_OUT):
+        if cutlass.const_expr(STATE_FP32):
+            state_bf16_to_f32(p_state, p_state_f32, tidx)
+            cute.arch.barrier()
+            if warp_id == STORE_WARP:
+                cute.arch.fence_view_async_shared()
+                cute.arch.sync_warp()
+                if lane == 0:
+                    tma_store_3d(
+                        desc_state_out,
+                        p_state_f32,
+                        0,
+                        dv_half * (STATE_F32_ROWS_PER_VALUE * DV_HALF),
+                        state_plane,
+                    )
+                    tma_store_commit_group()
+                    tma_store_wait_read(0)
+        else:
+            if warp_id == STORE_WARP:
+                cute.arch.fence_view_async_shared()
+                cute.arch.sync_warp()
+                if lane == 0:
+                    tma_store_3d(
+                        desc_state_out,
+                        p_state,
+                        0,
+                        dv_half * (STATE_BF16_ROWS_PER_VALUE * DV_HALF),
+                        state_plane,
+                    )
+                    tma_store_commit_group()
+                    tma_store_wait_read(0)
+
+
+@cute.jit
+def _recurrence_entry(
+    gout: cute.Tensor,
+    gcu_seqlens: cute.Tensor,
+    gcu_chunks: cute.Tensor,
+    desc_factor: cutlass.Int64,
+    desc_aq: cutlass.Int64,
+    desc_gt: cutlass.Int64,
+    desc_v: cutlass.Int64,
+    desc_out: cutlass.Int64,
+    desc_state_in: cutlass.Int64,
+    desc_state_out: cutlass.Int64,
+    heads: cutlass.Int32,
+    grid_x: cutlass.Int32,
+    grid_y: cutlass.Int32,
+    stream,
+    HAS_STATE_IN: cutlass.Constexpr,
+    HAS_STATE_OUT: cutlass.Constexpr,
+    STATE_FP32: cutlass.Constexpr,
+):
+    recurrence_kernel(
+        gout,
+        gcu_seqlens,
+        gcu_chunks,
+        desc_factor,
+        desc_aq,
+        desc_gt,
+        desc_v,
+        desc_out,
+        desc_state_in,
+        desc_state_out,
+        heads,
+        HAS_STATE_IN,
+        HAS_STATE_OUT,
+        STATE_FP32,
+    ).launch(
+        grid=(grid_x, grid_y, 1),
+        block=(REC_THREADS, 1, 1),
+        smem=SMEM_DYNAMIC_BYTES,
+        min_blocks_per_mp=MIN_BLOCKS_PER_MP,
+        stream=stream,
+    )
+
+
+#: Per-device compile cache. H, T, N and grid dimensions remain runtime values.
+_RECURRENCE_DEVICE_CACHE: dict = {}
+
+
+def clear_compile_cache() -> None:
+    _RECURRENCE_DEVICE_CACHE.clear()
+
+
+def launch_recurrence_device(
+    *,
+    out: torch.Tensor,
+    cu_seqlens_i32: torch.Tensor,
+    cu_chunks_i32: torch.Tensor,
+    tensor_maps,
+    heads: int,
+    sequences: int,
+    has_state_in: bool,
+    has_state_out: bool,
+    state_dtype: torch.dtype | None,
+    stream=None,
+) -> None:
+    """Compile (or reuse) and launch the recurrence kernel."""
+    import cuda.bindings.driver as cuda_driver
+
+    if stream is None:
+        # The tensors' device, not the current one; see fused/launch.py.
+        stream = cuda_driver.CUstream(torch.cuda.current_stream(out.device).cuda_stream)
+
+    state_fp32 = state_dtype is torch.float32
+    grid = recurrence_grid(sequences, heads)
+    args = (
+        _flat(out),
+        _flat(cu_seqlens_i32),
+        _flat(cu_chunks_i32),
+        cutlass.Int64(tensor_maps.address("factor")),
+        cutlass.Int64(tensor_maps.address("aq")),
+        cutlass.Int64(tensor_maps.address("gt")),
+        cutlass.Int64(tensor_maps.address("v")),
+        cutlass.Int64(tensor_maps.address("out")),
+        cutlass.Int64(tensor_maps.address("state_in")),
+        cutlass.Int64(tensor_maps.address("state_out")),
+        cutlass.Int32(heads),
+        cutlass.Int32(grid[0]),
+        cutlass.Int32(grid[1]),
+        stream,
+    )
+    key = (
+        out.device.index,
+        torch.cuda.get_device_capability(out.device),
+        bool(has_state_in),
+        bool(has_state_out),
+        state_dtype,
+    )
+    compiled = _RECURRENCE_DEVICE_CACHE.get(key)
+    if compiled is None:
+        with torch.cuda.device(out.device):
+            compiled = cute.compile(
+                _recurrence_entry,
+                *args,
+                bool(has_state_in),
+                bool(has_state_out),
+                bool(state_fp32),
+            )
+        _RECURRENCE_DEVICE_CACHE[key] = compiled
+    compiled(*args)
+
+
+# --------------------------------------------------------------------------
+# Section 10: one compiled host entry that launches both kernels
+# --------------------------------------------------------------------------
+
+# The DSL's AST preprocessor replays this module's module-level imports
+# into the tracing scope when it compiles the jit below.  Both kernels and
+# every helper they reach now live in this one file, so there is nothing
+# left for it to resolve except the third-party imports at the top and the
+# handful of names from ``runtime``.
+
+
+@cute.jit
+def _fwd_entry(
+    # --- prepare inputs ---
+    gq: cute.Tensor,
+    gk: cute.Tensor,
+    gg: cute.Tensor,
+    gbeta: cute.Tensor,
+    ga_log_exp: cute.Tensor,
+    gdt: cute.Tensor,
+    # --- shared metadata: packed once, used by both ---
+    gcu_seqlens: cute.Tensor,
+    gcu_chunks: cute.Tensor,
+    gchunk_to_seq: cute.Tensor,
+    # --- workspace ---
+    ws_kd: cute.Tensor,
+    ws_qd: cute.Tensor,
+    ws_ak: cute.Tensor,
+    ws_aq: cute.Tensor,
+    ws_gt: cute.Tensor,
+    # --- recurrence output ---
+    gout: cute.Tensor,
+    # --- descriptors; desc_factor is shared, prepare writes it and the
+    #     recurrence reads it ---
+    desc_q: cutlass.Int64,
+    desc_k: cutlass.Int64,
+    desc_g: cutlass.Int64,
+    desc_factor: cutlass.Int64,
+    desc_aq: cutlass.Int64,
+    desc_gt: cutlass.Int64,
+    desc_v: cutlass.Int64,
+    desc_out: cutlass.Int64,
+    desc_state_in: cutlass.Int64,
+    desc_state_out: cutlass.Int64,
+    # --- scalars ---
+    scale: cutlass.Float32,
+    gate_scale_log2: cutlass.Float32,
+    total_chunks: cutlass.Int32,
+    heads: cutlass.Int32,
+    prep_grid_x: cutlass.Int32,
+    rec_grid_x: cutlass.Int32,
+    rec_grid_y: cutlass.Int32,
+    stream,
+    # --- specializations ---
+    SAFE_GATE: cutlass.Constexpr,
+    CPC: cutlass.Constexpr,
+    G_FP32: cutlass.Constexpr,
+    HAS_STATE_IN: cutlass.Constexpr,
+    HAS_STATE_OUT: cutlass.Constexpr,
+    STATE_FP32: cutlass.Constexpr,
+):
+    """Both launches, in order, on one stream.
+
+    Ordering is the caller's stream, not an event: recurrence reads the factors
+    prepare writes, and same-stream launches are already ordered. An optional
+    second stream measured slower because co-resident overlap needs a flag ring.
+    """
+    prepare_kernel(
+        gq,
+        gk,
+        gg,
+        gbeta,
+        ga_log_exp,
+        gdt,
+        gcu_seqlens,
+        gcu_chunks,
+        gchunk_to_seq,
+        ws_kd,
+        ws_qd,
+        ws_ak,
+        ws_aq,
+        ws_gt,
+        desc_q,
+        desc_k,
+        desc_g,
+        desc_factor,
+        scale,
+        gate_scale_log2,
+        total_chunks,
+        heads,
+        SAFE_GATE,
+        CPC,
+        G_FP32,
+    ).launch(
+        grid=(prep_grid_x, heads, 1),
+        block=(PREPARE_DEVICE_THREADS, 1, 1),
+        stream=stream,
+    )
+
+    recurrence_kernel(
+        gout,
+        gcu_seqlens,
+        gcu_chunks,
+        desc_factor,
+        desc_aq,
+        desc_gt,
+        desc_v,
+        desc_out,
+        desc_state_in,
+        desc_state_out,
+        heads,
+        HAS_STATE_IN,
+        HAS_STATE_OUT,
+        STATE_FP32,
+    ).launch(
+        grid=(rec_grid_x, rec_grid_y, 1),
+        block=(REC_THREADS, 1, 1),
+        smem=SMEM_DYNAMIC_BYTES,
+        min_blocks_per_mp=MIN_BLOCKS_PER_MP,
+        stream=stream,
+    )
+
+
+def entry_kernel_name(key: tuple) -> str:
+    """The persistent cache's specialization name for a combined-entry key.
+
+    Every compile-time parameter and nothing else, spelled so that a directory
+    listing answers "which specializations did this run build?".
+    """
+    safe_gate, chunks_per_cta, g_fp32, state_in, state_out, state_fp32 = key
+    return "decomp_" + "_".join(
+        (
+            "safegate" if safe_gate else "rawgate",
+            f"cpc{int(chunks_per_cta)}",
+            "gfp32" if g_fp32 else "gbf16",
+            "si" if state_in else "nosi",
+            "so" if state_out else "noso",
+            "statefp32" if state_fp32 else "statebf16",
+        )
+    )
+
+
+#: Keyed by CUDA device and specialization; heads and grids are runtime values.
+_FWD_ENTRY_CACHE: dict = {}
+
+
+def clear_fwd_cache() -> None:
+    _FWD_ENTRY_CACHE.clear()
+
+
+class FwdCall:
+    """A packed argument tuple and the compiled entry that takes it.
+
+    Everything in ``args`` is either a scalar fixed by the shape or a device
+    tensor whose address the caller keeps alive, so a repeated call with the
+    same buffers can skip the whole host path and go straight to ``run``.  The
+    one thing that must not be frozen is ``a_log_exp``: its *buffer* is reused
+    but its contents are recomputed per call, since ``A_log`` is a parameter an
+    optimizer updates between steps.  ``run`` therefore refreshes it and only
+    then launches -- freezing it is precisely how the result cache broke under
+    graph capture once already.
+    """
+
+    __slots__ = (
+        "args",
+        "compiled",
+        "a_log",
+        "a_log_exp",
+        "gate_scale_log2",
+        "launch_lock",
+        "_a_log_key",
+        "_keepalive",
+    )
+
+    def __init__(
+        self,
+        args,
+        compiled,
+        a_log,
+        a_log_exp,
+        gate_scale_log2,
+        launch_lock,
+        keepalive=(),
+    ):
+        self.args = args
+        self.compiled = compiled
+        self.a_log = a_log
+        self.a_log_exp = a_log_exp
+        self.gate_scale_log2 = gate_scale_log2
+        self.launch_lock = launch_lock
+        # This plan is pinned to one stream -- ``_fwd_identity`` keys on it, and
+        # replaying a plan from another stream is already refused -- and to one
+        # ``A_log``, which it holds a reference to.  Its ``_A_LOG_EXP`` key is
+        # therefore a constant, and recomputing it per call cost 5.0-5.5 us of
+        # driver and ``os.getenv`` traffic on shapes short enough to notice.
+        # See :func:`a_log_exp_for` for the measurement.
+
+        self._a_log_key = None if a_log is None else _a_log_exp_key(a_log)
+        # The descriptor addresses in ``args`` are raw integers into buffers
+        # owned by the descriptor caches.  Clearing one of those caches -- which
+        # a test does deliberately, and eviction does on its own -- would free
+        # the storage and leave this plan pointing at nothing.  Holding the
+        # owners here keeps a cached plan self-sufficient.
+        self._keepalive = keepalive
+
+    def run(self) -> None:
+        # The lock spans the refresh plus the whole compiled host entry.  The
+        # latter returns only after prepare and recurrence have both been
+        # submitted, so another host thread cannot enqueue a prepare between
+        # this call's prepare and recurrence while sharing the workspace.
+        with self.launch_lock:
+            # Internal profiling callers may pass an already-refreshed buffer
+            # without its source tensor.  They still need the workspace lock;
+            # only the refresh is conditional.
+            if self.a_log is not None:
+                a_log_exp_for(
+                    self.a_log, LOG2_E, out=self.a_log_exp, key=self._a_log_key
+                )
+            self.compiled(*self.args)
+
+
+def launch_fwd(
+    *,
+    q,
+    k,
+    g,
+    beta,
+    a_log_exp,
+    dt_bias,
+    cu_seqlens,
+    cu_chunks,
+    chunk_to_seq,
+    workspace,
+    out,
+    prep_tmaps,
+    rec_tmaps,
+    scale,
+    gate_scale_log2,
+    total_chunks,
+    heads,
+    prep_grid_x,
+    rec_grid_x,
+    rec_grid_y,
+    safe_gate,
+    chunks_per_cta,
+    g_fp32,
+    has_state_in,
+    has_state_out,
+    state_fp32,
+    a_log=None,
+    build_only: bool = False,
+):
+    """Pack once, cross the boundary once, launch both.
+
+    With ``build_only`` the packed :class:`FwdCall` is returned instead of being
+    run, so ``fwd`` can cache it and skip the host path on the next call with
+    the same buffers.
+    """
+    # The tensors' device, not the current one; see fused/launch.py.
+    stream = cuda_driver.CUstream(torch.cuda.current_stream(out.device).cuda_stream)
+
+    args = (
+        flat_view(q),
+        flat_view(k),
+        flat_view(g),
+        flat_view(beta),
+        flat_view(a_log_exp),
+        flat_view(dt_bias),
+        flat_view(cu_seqlens),
+        flat_view(cu_chunks),
+        flat_view(chunk_to_seq),
+        flat_view(workspace.kd),
+        flat_view(workspace.qd),
+        flat_view(workspace.ak),
+        flat_view(workspace.aq),
+        flat_view(workspace.g_total),
+        flat_view(out),
+        cutlass.Int64(prep_tmaps.q),
+        cutlass.Int64(prep_tmaps.k),
+        cutlass.Int64(prep_tmaps.g),
+        # One descriptor, shared: prepare writes the factor slab through it and
+        # the recurrence reads through it.  The two encodings were already
+        # identical -- (DK, rows, 3H), 128B swizzle -- so this is the reuse and
+        # not a coincidence.
+        cutlass.Int64(prep_tmaps.factor),
+        # The recurrence keys its descriptors by role and returns 0 for a role
+        # this launch does not use, which is how the optional state maps work.
+        cutlass.Int64(rec_tmaps.address("aq")),
+        cutlass.Int64(rec_tmaps.address("gt")),
+        cutlass.Int64(rec_tmaps.address("v")),
+        cutlass.Int64(rec_tmaps.address("out")),
+        cutlass.Int64(rec_tmaps.address("state_in")),
+        cutlass.Int64(rec_tmaps.address("state_out")),
+        cutlass.Float32(scale),
+        cutlass.Float32(gate_scale_log2),
+        cutlass.Int32(total_chunks),
+        cutlass.Int32(heads),
+        cutlass.Int32(prep_grid_x),
+        cutlass.Int32(rec_grid_x),
+        cutlass.Int32(rec_grid_y),
+        stream,
+    )
+    key = (
+        bool(safe_gate),
+        int(chunks_per_cta),
+        bool(g_fp32),
+        bool(has_state_in),
+        bool(has_state_out),
+        bool(state_fp32),
+    )
+    cache_key = (out.device.index, *key)
+    compiled = _FWD_ENTRY_CACHE.get(cache_key)
+    if compiled is None:
+        # ``--enable-tvm-ffi`` is a *compile option*, not the
+        # ``CUTE_DSL_ENABLE_TVM_FFI`` env var.  The env var makes the runtime
+        # reject every argument that is not int/float/bool or does not expose
+        # ``__tvm_ffi_object__``, and it never gets that far: the DSL casts an
+        # argument to its annotated Numeric type before the check, so a native
+        # int arrives as ``cutlass.Int64`` anyway.
+        #
+        # It is not optional here either way -- the persistent cache reloads
+        # its artifacts with ``enable_tvm_ffi=True``.
+        def _compile():
+            # Subscript, not ``options=``: the keyword form silently drops
+            # EnableTVMFFI and hands back a ctypes-marshalled callable.
+            compiled = cute.compile[sm120a_compile_options()](_fwd_entry, *args, *key)
+            return assert_tvm_ffi_dispatched(compiled, entry_kernel_name(key))
+
+        compiled = build_kernel(
+            entry_kernel_name(key),
+            _compile,
+            device=out.device,
+            key_files=(__file__,),
+        )
+        _FWD_ENTRY_CACHE[cache_key] = compiled
+    call = FwdCall(
+        args,
+        compiled,
+        a_log,
+        a_log_exp,
+        gate_scale_log2,
+        workspace.launch_lock,
+        keepalive=(prep_tmaps, rec_tmaps, workspace, a_log_exp),
+    )
+    if build_only:
+        return call
+    call.run()
+    return None
+
+
+# --------------------------------------------------------------------------
+# Section 11: the host path
+#
+# Everything between the backend ABI and the compiled entry -- the chunk
+# tables, the factor arena, descriptor encoding, argument marshalling -- is a
+# pure function of the tensors' addresses, shapes, dtypes and versions plus two
+# floats.  A caller workspace additionally changes ownership and addresses of
+# metadata and writable scratch, so both cache layers distinguish its stable
+# identity.  In a serving loop none of those change between steps, which is why
+# it is all cached: two layers, cheapest first, and a third that is not a cache
+# at all but the caller's workspace.
+#
+# 1. :func:`_fast_path` compares object identity against the previous call.
+#    Same object means same address, shape, dtype, device and contiguity, so
+#    only in-place mutation is left to check.
+# 2. :data:`_CALL_PLANS` is an LRU on the full identity key, for callers that
+#    alternate between a few buffer sets.
+# 3. A :class:`~.runtime.SM120PrefillResources` supplied by the caller owns the
+#    metadata, the arena and the descriptors for the lifetime of a CUDA graph.
+#    Replay never re-enters Python, so nothing could renew an LRU position;
+#    binding them to a workspace is what gives them a lifetime that outlives
+#    this module's caches.
+#
+# The stream is in both keys.  A compiled entry bakes the ``CUstream`` it was
+# built on into its argument tuple, so replaying a plan built on another stream
+# would launch work correctly ordered against the wrong stream.  It is also
+# what makes a capture -- which runs on its own stream -- miss and rebuild
+# rather than replay the default stream's plan.
+# --------------------------------------------------------------------------
+
+#: One entry per distinct set of buffers a caller uses; a serving loop that
+#: reuses its activations needs exactly one.  Bounded so a workload cycling
+#: through many buffers cannot pin every plan it ever built.
+#:
+#: 16 is a ceiling on *how many rotating buffer sets stay fast*, not a memory
+#: budget, and lowering it does not trade speed for memory -- it buys nothing
+#: until the workload exceeds it and then costs everything.  Measured on the
+#: 110-SM part at ``[1, 1024, 8, 128]``, rotating N buffer sets:
+#:
+#: ===  ==================  ==================
+#: cap  N = 4               N = 8
+#: ===  ==================  ==================
+#: 16   101 us / 40.6 MiB   116 us / 72.7 MiB
+#: 4    105 us / 40.6 MiB   7145 us / 40.6 MiB
+#: 2    7670 us / 24.6 MiB  7546 us / 24.6 MiB
+#: ===  ==================  ==================
+#:
+#: Below the cap the retention is identical whatever the cap is; at the cap the
+#: hit becomes a rebuild, and a rebuild is ~7.3 ms against a ~100 us hit.  A
+#: deployment that needs the memory back should reduce how many buffer sets it
+#: rotates, or call ``clear_kda_prefill_sm120_caches()``; shrinking this number
+#: only moves the same allocation into a 70x slower path.
+CALL_PLAN_MAX_ENTRIES = 16
+_CALL_PLANS: OrderedDict = OrderedDict()
+
+#: The previous call's tensors, versions, scalars, workspace, stream and plan. Strong
+#: references, one slot: keying on ``id()`` would be unsound, since a freed
+#: tensor's id can be reused by a different one and the plan would then be
+#: handed to the wrong buffers.
+_LAST: tuple | None = None
+
+#: Marks "this call has no chunks at all", so the zero-token path is reached on
+#: a plan hit without re-deriving the metadata that proves it.
+_STATE_ONLY = object()
+
+#: Serializes the cache-miss path: plan construction, descriptor encoding and
+#: the compile behind it.
+#:
+#: The launch lock below is not enough on its own, and the reason is worth
+#: recording. Four host threads issuing the same shape share one factor arena
+#: and one launch lock, so their *enqueues* interleave correctly -- but a cold
+#: build is not an enqueue. It encodes descriptors, writes shared scratch and
+#: calls into the CuTe DSL compiler, none of which is re-entrant: the legacy
+#: implementation, given the same four threads, does not produce wrong numbers
+#: so much as raise ``_fwd_entry() requires a code object with 0 free vars`` and
+#: "Please start a session before accessing session data" from inside the DSL.
+#: Measured here, the first thread's output was wrong in 1515 of 32768 elements
+#: while the other three were exact -- the signature of the builder racing its
+#: own build.
+#:
+#: A module-level lock is the right shape for that. It is taken only on a miss,
+#: so a serving loop that reuses its buffers never sees it, and the two cache
+#: layers in front of it are checked before it is acquired.
+_BUILD_LOCK = threading.RLock()
+
+
+def clear_caches() -> None:
+    """Drop every cache this variant owns."""
+    global _LAST
+    _CALL_PLANS.clear()
+    _LAST = None
+    clear_prepare_workspaces()
+    clear_metadata_cache()
+    clear_prepare_descriptor_cache()
+    clear_recurrence_descriptor_cache()
+    clear_launch_caches()
+    clear_compile_cache()
+    clear_fwd_cache()
+
+
+def call_plan_stats() -> dict:
+    return {"plans": len(_CALL_PLANS), "last_call_warm": _LAST is not None}
+
+
+def _identity(device, tensors, scale, lower_bound, resources) -> tuple:
+    # The stream of the *inputs'* device: ``launch_recurrence`` bakes
+    # ``torch.cuda.current_stream(q.device)`` into the plan's argument tuple,
+    # so a key built from the current device's stream would let two streams on
+    # the input's device share one entry and reuse the first one's plan.
+    return (
+        tuple(tensor_identity(t) for t in tensors),
+        float(scale),
+        float(lower_bound),
+        resource_cache_token(resources),
+        current_stream_ptr(device),
+    )
+
+
+def _fast_path(device, tensors, scale, lower_bound, resources):
+    """The previous call's plan if this call is identical to it, else ``None``."""
+    if _LAST is None:
+        return None
+    (
+        last_tensors,
+        last_versions,
+        last_scalars,
+        last_resources,
+        last_stream,
+        plan,
+    ) = _LAST
+    if last_scalars != (float(scale), float(lower_bound)):
+        return None
+    if last_resources is not resource_cache_token(resources):
+        return None
+    if last_stream != current_stream_ptr(device):
+        return None
+    if len(last_tensors) != len(tensors):
+        return None
+    for ref, tensor in zip(last_tensors, tensors, strict=True):
+        if ref is None:
+            if tensor is not None:
+                return None
+        elif ref() is not tensor:
+            return None
+    for tensor, version in zip(tensors, last_versions, strict=True):
+        if tensor is not None and tensor_version(tensor) != version:
+            return None
+    return plan
+
+
+def _remember(device, tensors, scale, lower_bound, resources, plan) -> None:
+    global _LAST
+    # Weak, like the plan LRU above: this entry outlives the call, and strong
+    # references to q, k, v, g and out would hold one whole activation set off
+    # the caching allocator until the next call replaced it.
+    _LAST = (
+        tuple(None if t is None else weakref.ref(t) for t in tensors),
+        tuple(None if t is None else tensor_version(t) for t in tensors),
+        (float(scale), float(lower_bound)),
+        resource_cache_token(resources),
+        current_stream_ptr(device),
+        plan,
+    )
+
+
+def _remember_plan(key, value) -> None:
+    _CALL_PLANS[key] = value
+    while len(_CALL_PLANS) > CALL_PLAN_MAX_ENTRIES:
+        _CALL_PLANS.popitem(last=False)
+
+
+def _state_only(initial_state, final_state) -> None:
+    """No chunks, so nothing but the state ABI is left.
+
+    Nothing here may allocate a workspace, encode a descriptor, upload metadata
+    or consult the compile cache.  It is real work the caller expects on every
+    call, so a plan hit redoes it rather than skipping it.
+    """
+    if final_state is None:
+        return
+    if initial_state is None:
+        final_state.zero_()
+        return
+    if is_exact_alias(initial_state, final_state):
+        return
+    final_state.copy_(initial_state)
+
+
+# --------------------------------------------------------------------------
+# Chunk tables and the factor arena.
+#
+# Both are derived from the canonical offsets ``runtime`` already validated, so
+# neither re-reads the device.  When the caller supplies a workspace they are
+# built into it once, at eager warmup, and frozen: a captured graph records the
+# addresses, and growing or reallocating either afterwards would leave replay
+# reading a stale pointer.
+# --------------------------------------------------------------------------
+
+
+def chunk_tables(offsets, device, resources=None) -> ChunkMetadata:
+    """``cu_chunks`` and ``chunk_to_seq`` for these offsets.
+
+    Without a workspace this is the process-wide content-keyed cache, which is
+    right for eager use.  With one, the tables live in the workspace at a
+    fixed address for as long as it does.
+    """
+    host = list(offsets.host)
+    per_sequence = chunks_for_lengths(offsets.lengths)
+    cu = [0]
+    for count in per_sequence:
+        cu.append(cu[-1] + count)
+    chunk_to_seq: list[int] = []
+    for index, count in enumerate(per_sequence):
+        chunk_to_seq.extend([index] * count)
+    total_chunks = cu[-1]
+
+    if resources is None:
+        if capturing():
+            # Without a workspace there is nowhere to put tables that a replay
+            # can read, so this path would allocate -- and the error torch
+            # raises for that ("Cannot copy between CPU and CUDA tensors during
+            # CUDA graph capture") names the symptom rather than the cause.
+            raise RuntimeError(
+                "CUDA graph capture of this backend needs a caller-owned "
+                "RecurrentKDAPrefillWorkspace, warmed eagerly on the capture "
+                "stream with the same tensors; capturing without one would "
+                "have to allocate the chunk tables inside the graph"
+            )
+        return _build_metadata(host, device)
+
+    signature = (tuple(host), tuple(cu))
+    cached = resources.chunk_signature_matches(signature)
+    if cached is not None:
+        return cached
+
+    if capturing():
+        raise RuntimeError(
+            "CUDA graph capture cannot build this variant's chunk tables; warm "
+            "the workspace with one eager call on the same offsets first"
+        )
+
+    cu_seqlens_i32 = resources.ensure_capacity("cu_seqlens_i32", len(host), torch.int32)
+    cu_chunks_i32 = resources.ensure_capacity("cu_chunks_i32", len(cu), torch.int32)
+    chunk_to_seq_i32 = resources.ensure_capacity(
+        "chunk_to_seq_i32", max(len(chunk_to_seq), 1), torch.int32
+    )[: len(chunk_to_seq)]
+    cu_seqlens_i32.copy_(torch.tensor(host, dtype=torch.int32))
+    cu_chunks_i32.copy_(torch.tensor(cu, dtype=torch.int32))
+    if chunk_to_seq:
+        chunk_to_seq_i32.copy_(torch.tensor(chunk_to_seq, dtype=torch.int32))
+
+    meta = ChunkMetadata(
+        cu_seqlens=cu_seqlens_i32,
+        cu_chunks=cu_chunks_i32,
+        chunk_to_seq=chunk_to_seq_i32,
+        cu_seqlens_host=tuple(host),
+        cu_chunks_host=tuple(cu),
+        total_chunks=total_chunks,
+        sequence_count=len(per_sequence),
+    )
+    resources.freeze_chunk_tables(signature, meta)
+    return meta
+
+
+def factor_arena(heads: int, total_chunks: int, device, resources=None):
+    """The packed prepare workspace for this shape.
+
+    ``acquire_prepare_workspace`` keys on ``(heads, total_chunks, stream)``
+    because the arena is *written*, not read: two forwards on different streams
+    must not share one, and a ``wait_event`` on the entry would order the
+    reader against its creation rather than against the previous writer.  A
+    caller-supplied workspace is already per-stream by construction, so it
+    holds exactly one.
+    """
+    if resources is None:
+        return acquire_prepare_workspace(heads, total_chunks, device)
+    return resources.scratch_arena(
+        (heads, total_chunks),
+        lambda: allocate_prepare_workspace(heads, total_chunks, device),
+    )
+
+
+# --------------------------------------------------------------------------
+# The entry point.
+# --------------------------------------------------------------------------
+
+
+def run(
+    *,
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor,
+    beta: torch.Tensor,
+    out: torch.Tensor,
+    A_log: torch.Tensor,
+    dt_bias: torch.Tensor,
+    scale: float,
+    lower_bound: float,
+    initial_state: torch.Tensor | None = None,
+    final_state: torch.Tensor | None = None,
+    cu_seqlens: torch.Tensor | None = None,
+    info,
+    offsets,
+    resources=None,
+    safe_gate: bool = True,
+) -> None:
+    """Launch the decomposed prefill, writing ``out`` and ``final_state``.
+
+    ``info`` and ``offsets`` come from :mod:`.runtime`: the facade validates
+    and canonicalizes once, so this is not a second validation pass.  What is
+    checked here is what *this schedule* depends on and the fused one does not
+    -- the fused factor slab, the state geometry and the INT32 index ranges.
+
+    ``safe_gate=False`` is refused rather than ignored: this variant does not
+    implement the unbounded gate, and accepting the argument would report a
+    numerical configuration the launch never used.
+    """
+    if not safe_gate:
+        raise KDAPrefillValidationError(
+            "the decomp variant does not support safe_gate=False; use the fused variant"
+        )
+
+    tensors = (
+        q,
+        k,
+        v,
+        g,
+        beta,
+        out,
+        A_log,
+        dt_bias,
+        initial_state,
+        final_state,
+        cu_seqlens,
+    )
+
+    plan = _fast_path(q.device, tensors, scale, lower_bound, resources)
+    if plan is None:
+        key = _identity(q.device, tensors, scale, lower_bound, resources)
+        # Everything from here to the launch is the miss path, and it is taken
+        # under one lock: two threads building concurrently share a factor
+        # arena, a descriptor cache and a DSL compiler session, and none of the
+        # three tolerates it.
+        with _BUILD_LOCK:
+            plan = _CALL_PLANS.get(key)
+            if plan is not None:
+                _CALL_PLANS.move_to_end(key)
+            else:
+                plan = _build_plan(
+                    q=q,
+                    k=k,
+                    v=v,
+                    g=g,
+                    beta=beta,
+                    out=out,
+                    A_log=A_log,
+                    dt_bias=dt_bias,
+                    scale=scale,
+                    lower_bound=lower_bound,
+                    initial_state=initial_state,
+                    final_state=final_state,
+                    info=info,
+                    offsets=offsets,
+                    resources=resources,
+                )
+                _remember_plan(key, plan)
+            _remember(q.device, tensors, scale, lower_bound, resources, plan)
+
+    execute(plan, initial_state, final_state)
+    return plan
+
+
+def execute(plan, initial_state, final_state) -> None:
+    """Run an already-resolved plan.
+
+    Split out so the facade, which has its own memo on the same tensor
+    identities, does not have to repeat the comparison this module's fast path
+    would do to find the same plan again. Two layers each walking eleven
+    tensors cost about 6 us per call -- nothing against a 1 ms kernel, and a
+    third of the whole call at B=1 T=16 H=4.
+    """
+    if plan is _STATE_ONLY:
+        # Real work the caller expects on every call, so a hit redoes it.
+        _state_only(initial_state, final_state)
+        return
+    plan.run()
+
+
+def _build_plan(
+    *,
+    q,
+    k,
+    v,
+    g,
+    beta,
+    out,
+    A_log,
+    dt_bias,
+    scale,
+    lower_bound,
+    initial_state,
+    final_state,
+    info,
+    offsets,
+    resources,
+):
+    """The full host path: tables, arena, descriptors, argument marshalling."""
+    device = q.device
+    require_sm120a(device)
+
+    if info.total_tokens == 0:
+        return _STATE_ONLY
+
+    # Fixed ``[B, T, ...]`` reshapes to packed ``[1, B * T, ...]`` as a view.
+    # ``reshape`` on a contiguous tensor never copies, which matters: a copy of
+    # ``out`` would silently drop the caller's writes.
+    if info.input_mode == "fixed":
+        pq, pk, pv, pg, pout, pbeta = (
+            t.reshape(1, t.shape[0] * t.shape[1], *t.shape[2:])
+            for t in (q, k, v, g, out, beta)
+        )
+    else:
+        pq, pk, pv, pg, pout, pbeta = q, k, v, g, out, beta
+
+    meta = chunk_tables(offsets, device, resources)
+    if meta.total_chunks == 0:
+        return _STATE_ONLY
+
+    heads = info.heads
+    total_tokens = pq.shape[1]
+    check_recurrence_ranges(
+        total_tokens=total_tokens,
+        total_chunks=meta.total_chunks,
+        sequences=meta.sequence_count,
+        heads=heads,
+        cu_seqlens_host=list(meta.cu_seqlens_host),
+        cu_chunks_host=list(meta.cu_chunks_host),
+        device=device,
+    )
+
+    workspace = factor_arena(heads, meta.total_chunks, device, resources)
+    config = PrepareConfig(
+        safe_gate=True,
+        # Follow the measured per-architecture optimum.  The dataclass default
+        # pins every device to the sm_120 value.
+        chunks_per_cta=default_chunks_per_cta(device),
+    )
+
+    # Do both kernels' host-side work, then hand them to ONE compiled entry.
+    # Two separate launches crossed the Python/compiled boundary twice per
+    # forward and rebuilt their argument tuples each time, which is per-launch
+    # rather than per-token and therefore flat in T.
+    recurrence_plan = launch_recurrence(
+        workspace=workspace,
+        v=pv,
+        out=pout,
+        cu_seqlens_i32=meta.cu_seqlens,
+        cu_chunks_i32=meta.cu_chunks,
+        cu_seqlens_host=list(meta.cu_seqlens_host),
+        cu_chunks_host=list(meta.cu_chunks_host),
+        heads=heads,
+        total_tokens=total_tokens,
+        total_chunks=meta.total_chunks,
+        initial_state=initial_state,
+        final_state=final_state,
+        plan_only=True,
+    )
+    prep = prepare_launch_plan(
+        q=pq,
+        k=pk,
+        g=pg,
+        A_log=A_log,
+        workspace=workspace,
+        total_tokens=total_tokens,
+        total_chunks=meta.total_chunks,
+        heads=heads,
+        config=config,
+    )
+    rec_grid = recurrence_grid(recurrence_plan.sequences, heads)
+    call = launch_fwd(
+        a_log=A_log,
+        build_only=True,
+        q=pq,
+        k=pk,
+        g=pg,
+        beta=pbeta,
+        a_log_exp=prep.a_log_exp,
+        dt_bias=dt_bias,
+        cu_seqlens=meta.cu_seqlens,
+        cu_chunks=meta.cu_chunks,
+        chunk_to_seq=meta.chunk_to_seq,
+        workspace=workspace,
+        out=pout,
+        prep_tmaps=prep.tensor_maps,
+        rec_tmaps=recurrence_plan.tensor_maps,
+        scale=float(scale),
+        gate_scale_log2=float(lower_bound) * LOG2_E,
+        total_chunks=meta.total_chunks,
+        heads=heads,
+        prep_grid_x=prep.grid_x,
+        rec_grid_x=rec_grid[0],
+        rec_grid_y=rec_grid[1],
+        safe_gate=True,
+        chunks_per_cta=config.chunks_per_cta,
+        g_fp32=pg.dtype is torch.float32,
+        has_state_in=recurrence_plan.has_state_in,
+        has_state_out=recurrence_plan.has_state_out,
+        state_fp32=recurrence_plan.state_dtype is torch.float32,
+    )
+
+    if resources is not None:
+        # Replay never re-enters Python, so everything the capture recorded has
+        # to stay alive at its captured address for the workspace's lifetime.
+        resources.pin(
+            call,
+            call.compiled,
+            prep.tensor_maps,
+            recurrence_plan.tensor_maps,
+            workspace,
+            prep.a_log_exp,
+            meta,
+            offsets,
+            offsets.canonical,
+            offsets.source,
+        )
+    elif capturing():
+        # A capture without a workspace has nowhere to put the pins, so they go
+        # to the process-wide table.  Deliberately for the process lifetime:
+        # an eviction that left a replayed graph reading a dangling device
+        # pointer fails far from its cause and only sometimes.
+        GRAPH_PINS.pin(
+            (id(call), id(workspace)),
+            call,
+            call.compiled,
+            prep.tensor_maps,
+            recurrence_plan.tensor_maps,
+            workspace,
+            meta,
+            offsets,
+        )
+    return call
+
+
+__all__ = [
+    "CALL_PLAN_MAX_ENTRIES",
+    "ChunkMetadata",
+    "PrepareConfig",
+    "PrepareWorkspace",
+    "call_plan_stats",
+    "chunk_tables",
+    "clear_caches",
+    "default_chunks_per_cta",
+    "factor_arena",
+    "recurrence_grid",
+    "execute",
+    "run",
+]

--- a/flashinfer/kda_kernels/sm120_prefill/fused.py
+++ b/flashinfer/kda_kernels/sm120_prefill/fused.py
@@ -1,0 +1,4577 @@
+# Copyright (c) 2025 - 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+
+# 1. Redistributions of source code must retain the above copyright notice, this
+# list of conditions and the following disclaimer.
+
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+
+# 3. Neither the name of the copyright holder nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+"""SM120 KDA prefill, fused: one kernel does prepare and recurrence together.
+
+A 512-thread CTA per (sequence, head), with the warp roles, SMEM arena and
+barrier schedule the sections below define.  Where :mod:`.decomp` materializes
+chunk factors to a workspace and reads them back, this variant keeps them in
+shared memory and never leaves the kernel.
+
+Everything this variant owns lives here: its CTA topology, its SMEM images and
+swizzles, its inline PTX, its TMA descriptors, the device kernel, the compiled
+entry, its descriptor and call-plan caches, and its current-stream launch.
+Only the mechanisms it shares with :mod:`.decomp` come from :mod:`.runtime`.
+
+The two variants are not folded together and do not import one another.  Their
+layouts, PTX helpers and descriptor encodings diverged far enough that a shared
+spelling would be a shared name over two different meanings -- the fused
+``pairwise_a_ptr`` and the decomp ``pairwise_a_fragment_ptr`` address different
+images -- and the plan is explicit that a same-named helper whose
+specialization, rounding or barrier ownership differs stays in its variant.
+
+The 512-thread CTA topology, the warp role ownership, the SMEM arena, the gate
+numeric boundaries and the state/output alias contract are fixed implementation
+choices shared by the host plan, device code and tests.
+"""
+
+import ctypes
+import os
+import threading
+import weakref
+from collections import OrderedDict
+from dataclasses import dataclass
+from typing import Any
+
+import cutlass
+import cutlass.cute as cute
+import cutlass.utils
+import torch
+from cutlass._mlir.dialects import llvm
+from cutlass.cutlass_dsl import dsl_user_op
+
+from .runtime import (
+    GRAPH_PINS,
+    SM120_CODE_TARGET,
+    BoundedDeviceCache,
+    KDAPrefillValidationError,
+    assert_tvm_ffi_dispatched,
+    build_kernel,
+    capturing,
+    check_flat_output_range,
+    current_stream_ptr,
+    flat_view,
+    is_exact_alias,
+    max_grid_dims,
+    resource_cache_token,
+    require_sm120a,
+    sm120a_compile_options,
+    tensor_identity,
+    tensor_version,
+)
+
+
+# --------------------------------------------------------------------------
+# Section 1: CTA topology, SMEM arena and barrier ids
+# --------------------------------------------------------------------------
+
+# ---------------------------------------------------------------------------
+# Target
+# ---------------------------------------------------------------------------
+
+#: The kernel guards on this exactly; other capabilities do not fall back here.
+DEVICE_CC = (12, 0)
+
+#: Production code target.  ``setmaxnreg`` requires an architecture-specific
+#: Blackwell target, so plain ``sm_120`` cannot build a releasable kernel
+#:.  This string is part of the compile cache key.
+CODE_TARGET = "sm_120a"
+
+# ---------------------------------------------------------------------------
+# Problem geometry
+# ---------------------------------------------------------------------------
+
+BT = 16
+DK = 128
+DV = 128
+
+# ---------------------------------------------------------------------------
+# CTA shape and warp ownership
+# ---------------------------------------------------------------------------
+
+THREADS = 512
+WARPS = 16
+
+#: W0-W3 gate/norm/materialize, and produce Ak.T.
+PREPARE_WARPS = 4
+#: W4-W11, each permanently owning 16 value columns of the recurrent state.
+RECURRENCE_WARPS = 8
+RECURRENCE_WARP0 = 4
+#: Value columns one recurrence warp owns; ``RECURRENCE_WARPS * 16 == DV``.
+WARP_VALUES = DV // RECURRENCE_WARPS  # 16
+
+#: Service warps.
+TMA_WARP = 12
+QK_WARP = 13
+IO_WARP = 14
+INV_WARP = 15
+
+#: Key dimensions one prepare warp owns: ``[32 * p, 32 * p + 32)``.
+PREPARE_WARP_DIMS = DK // PREPARE_WARPS  # 32
+
+#: ``m16n8k16`` steps of one ``[16, 128] @ [128, *]`` reduction.
+KEY_BLOCKS = DK // BT  # 8
+
+# ---------------------------------------------------------------------------
+# Warpgroup register budgets -- REQUESTED, NOT GRANTED
+#
+# These four numbers describe the redistribution the design asks for.  It does
+# not currently happen -- but not for the reason recorded here earlier, and the
+# real reason is addressable.
+#
+# The DSL is not at fault.  Dumped at all three levels, on 4.3 and 4.7 alike,
+# the MLIR carries three ``setmaxregister`` ops and the PTX carries three
+# ``setmaxnreg`` instructions with exactly the immediates below -- 120, 64, 160.
+# They vanish between PTX and SASS, and ptxas says why:
+#
+#     (C7508) Potential Performance Loss: 'setmaxnreg' ignored;
+#             unable to determine register count at entry.
+#
+# Not "unsupported on this target".  sm_120a *does* have the instruction; it is
+# spelled ``USETMAXREG.DEALLOC.CTAPOOL`` / ``USETMAXREG.TRY_ALLOC.CTAPOOL``
+# rather than Hopper's ``SETMAXNREG``, which is why an earlier search of this
+# kernel's SASS for the Hopper mnemonic returned a confident zero.  Feed ptxas
+# a minimal kernel with ``.maxnreg 128`` and both forms appear in the SASS.
+#
+# What our PTX lacks is that entry bound: it carries ``.reqntid`` from the block
+# size and no ``.maxnreg``, so ptxas cannot compute the post-dec/inc budget and
+# drops the request.  See the ``min_blocks_per_mp`` note below -- that is the
+# one knob the DSL exposes that would supply it, and the measurement recorded
+# there was taken while ``setmaxnreg`` was silently a no-op, so it does not yet
+# say what the pair of them does together.
+#
+# Until the bound is supplied, every warp gets ``LAUNCH_MAXNREG`` and nothing
+# else.  The consequence is not cosmetic: a recurrence warp holds 96 registers
+# of state (h32's 64 plus h16's 32) inside 128, leaving ~32 to work in, and
+# ptxas spills four of them once per chunk.  Those four instructions are 0.1% of
+# the instruction count and 93.8% of the L1TEX sector requests, because local
+# memory is per-thread and a warp's 32 lanes land on 32 separate sectors.
+#
+# Raising these constants alone does nothing -- three variants that
+# redistributed the 1,024 registers the budget leaves free measured
+# byte-identical spill, which is exactly what a dropped instruction predicts.
+WG0_MAXNREG = 120  # W0-W3   prepare
+WG1_MAXNREG = 160  # W4-W7   recurrence
+WG2_MAXNREG = 160  # W8-W11  recurrence
+WG3_MAXNREG = 64  # W12-W15 TMA, QK/Aq, I/O, KK/inverse
+
+#: Registers the launch reserves per thread before redistribution.
+LAUNCH_MAXNREG = 128
+
+#: What the requested split would have cost, kept only so the test that pins
+#: it against the pool keeps meaning something.  The *actual* allocation is
+#: uniform: ``THREADS * LAUNCH_MAXNREG == 512 * 128 == 65,536``, the whole file.
+CTA_REGISTER_BUDGET = (
+    4 * WG0_MAXNREG + 4 * WG1_MAXNREG + 4 * WG2_MAXNREG + 4 * WG3_MAXNREG
+) * 32
+
+#: The allocation that actually happens, every warp alike.
+CTA_REGISTERS_ACTUAL = THREADS * LAUNCH_MAXNREG
+CTA_REGISTER_POOL = 65536
+
+# ---------------------------------------------------------------------------
+# SMEM arena
+# ---------------------------------------------------------------------------
+
+MAIN_SLOTS = 3
+MAIN_SLOT_BYTES = 16384
+V_STAGES = 3
+V_STAGE_BYTES = 4096
+
+MAIN_OFFSET = 0
+V_STAGE_OFFSET = MAIN_SLOTS * MAIN_SLOT_BYTES  # 49152
+CONTROL_OFFSET = V_STAGE_OFFSET + V_STAGES * V_STAGE_BYTES  # 61440
+CONTROL_BYTES = 1024
+
+DYNAMIC_SMEM_BYTES = CONTROL_OFFSET + CONTROL_BYTES  # 62464
+
+#: SM120's per-CTA opt-in maximum.  The arena deliberately leaves 38,912 B
+#: unused rather than adding a fourth main_slot.
+SM120_SMEM_LIMIT = 101376
+
+#: The design target and the acceptance result alike -- but deliberately *not*
+#: passed to the launch as ``min_blocks_per_mp``.
+#:
+#: ``__launch_bounds__(512, 1)`` tells ptxas it may use at most 65,536 / 512 =
+#: 128 registers per thread.  Measured on GB202: constraining it costs 6,457
+#: local-memory instructions against 240 without, so it stays off.
+#:
+#: The original reasoning here was that the bound would defeat
+#: ``setmaxnreg.inc``.  Read again, that has it backwards: an entry register
+#: count is the *precondition* for ``setmaxnreg`` rather than an obstacle to it,
+#: and this is the only knob the DSL offers that supplies one.
+#:
+#: That pairing has now been measured, and it settles the question against the
+#: split.  With ``min_blocks_per_mp=1`` the PTX gains ``.minnctapersm``, ptxas
+#: stops reporting C7508, and three ``USETMAXREG.*.CTAPOOL`` appear in the SASS:
+#: the manual 120/64/160 split is honoured, exactly as designed.  It is also
+#: 1.23x to 1.72x slower, median 1.62x, on seven shapes, bit-identical output,
+#: 68/68 GPU tests passing.
+#:
+#: The SASS says why.  ``setmaxnreg`` moves a *runtime* hardware budget, but
+#: ptxas assigns register *numbers* statically, once, for a kernel body that all
+#: sixteen warps enter.  It must therefore satisfy the smallest warpgroup, and
+#: WG3 asks for 64 -- so the whole kernel is compiled into 61 registers and
+#: spills, 241 LDL and 148 STL against zero without the bound.  The recurrence
+#: warps' extra registers exist at runtime and are unreachable, because nothing
+#: was ever numbered above R61.
+#:
+#: This is the real obstacle, and it is structural rather than a missing flag:
+#: warp-specialized register redistribution needs ptxas to compile per-role
+#: register footprints, which one function entered by every role does not give
+#: it.  The bound stays off.
+#:
+#: Worth noting separately: the shipped build does not spill at all.  DSL 4.7
+#: compiles this kernel to R123 with zero LDL and zero STL, 4.3 to R125 with one
+#: LDL and three STL.  The spill this note used to be about is gone.
+#:
+#: Dropping the bound costs no occupancy.  62,464 B of dynamic shared memory
+#: already limits this kernel to one CTA per SM on its own, which NCU confirms
+#: (``launch__occupancy_limit_shared_mem == 1``).
+MIN_BLOCKS_PER_MP = 1
+
+# ---------------------------------------------------------------------------
+# Main main_slot phases, relative to ``16384 * main_slot``
+# ---------------------------------------------------------------------------
+
+SLOT_Q = 0  # Qraw -> Qd -> O
+SLOT_K = 4096  # Kraw -> Kd
+SLOT_G_LO = 8192  # raw G / E lower -> Ki -> Ak.T
+SLOT_G_HI = 12288  # raw G / E upper -> factor records
+
+#: Aliases naming the phase a consumer actually addresses.
+SLOT_QD = SLOT_Q
+SLOT_OUT = SLOT_Q
+SLOT_KD = SLOT_K
+SLOT_KI = SLOT_G_LO
+SLOT_AKT = SLOT_G_LO
+
+#: Factor records, written only once all four prepare warps have captured E.
+SLOT_AINV_BETA = 12288  # [16, 16] BF16 SW32, 512 B
+SLOT_AQ = 12800  # [16, 16] BF16 SW32, 512 B
+SLOT_GTOTAL = 13312  # [128]    FP32,      512 B
+SLOT_RESERVED = 13824  # production must not touch [13824, 16384)
+
+# ---------------------------------------------------------------------------
+# Control arena, relative to CONTROL_OFFSET
+# ---------------------------------------------------------------------------
+
+#: 128 B per main_slot: 16 FP32 q_inv then 16 FP32 k_inv.
+SCRATCH_OFFSET = 0
+SCRATCH_SLOT_BYTES = 128
+SCRATCH_K_INV = 64
+
+BARRIER_OFFSET = 384
+
+#: ``(relative byte offset, arrival count)``; ``None`` marks a transaction
+#: barrier, which is initialized with an arrival count of 1 and completed by
+#: ``arrive_expect_tx``.  Every event but ``state_io`` has one object per main_slot.
+BAR_QKG_READY = 384
+BAR_V_READY = 408
+BAR_MATERIALIZED = 432
+BAR_QK_DONE = 456
+BAR_AINV_READY = 480
+BAR_AQ_READY = 504
+BAR_AK_READY = 528
+BAR_PROJECTION_DONE = 552
+BAR_R_FORMED = 576
+BAR_OUTPUT_READY = 600
+BAR_OUTPUT_READ_DONE = 624
+BAR_STATE_DONE = 648
+BAR_STATE_IO = 672
+BAR_RESERVED = 680
+
+#: Arrival counts.  Transaction barriers take 1.
+ARRIVALS_TX = 1
+ARRIVALS_PREPARE = PREPARE_WARPS  # 4
+ARRIVALS_RECURRENCE = RECURRENCE_WARPS  # 8
+ARRIVALS_SINGLE = 1
+
+#: ``(name, byte offset, arrivals, per-main_slot)`` .3 table order.
+BARRIER_TABLE = (
+    ("qkg_ready", BAR_QKG_READY, ARRIVALS_TX, True),
+    ("v_ready", BAR_V_READY, ARRIVALS_TX, True),
+    ("materialized", BAR_MATERIALIZED, ARRIVALS_PREPARE, True),
+    ("qk_done", BAR_QK_DONE, ARRIVALS_SINGLE, True),
+    ("ainv_ready", BAR_AINV_READY, ARRIVALS_SINGLE, True),
+    ("aq_ready", BAR_AQ_READY, ARRIVALS_SINGLE, True),
+    ("ak_ready", BAR_AK_READY, ARRIVALS_PREPARE, True),
+    ("projection_done", BAR_PROJECTION_DONE, ARRIVALS_RECURRENCE, True),
+    ("r_formed", BAR_R_FORMED, ARRIVALS_RECURRENCE, True),
+    ("output_ready", BAR_OUTPUT_READY, ARRIVALS_RECURRENCE, True),
+    ("output_read_done", BAR_OUTPUT_READ_DONE, ARRIVALS_SINGLE, True),
+    ("state_done", BAR_STATE_DONE, ARRIVALS_RECURRENCE, True),
+    ("state_io", BAR_STATE_IO, ARRIVALS_TX, False),
+)
+
+#: The prepare group's named barrier: ``bar.sync 1, 128``.
+PREPARE_BARRIER_ID = 1
+PREPARE_BARRIER_THREADS = PREPARE_WARPS * 32  # 128
+
+# ---------------------------------------------------------------------------
+# TMA transaction bytes
+# ---------------------------------------------------------------------------
+
+#: Q and K are two 4096-byte boxes each; G is 8192 B at FP32 and 4096 B at BF16.
+QKG_TX_BYTES_G_FP32 = 4096 + 4096 + 8192  # 16384
+QKG_TX_BYTES_G_BF16 = 4096 + 4096 + 4096  # 12288
+V_TX_BYTES = 4096
+
+#: BF16 boundary state is 2 x 16 KiB; FP32 is 4 x 16 KiB one window at a time.
+STATE_BF16_TX_BYTES = 32768
+STATE_F32_WINDOW_TX_BYTES = 16384
+STATE_F32_WINDOWS = 4
+
+# ---------------------------------------------------------------------------
+# Numeric constants
+# ---------------------------------------------------------------------------
+
+LOG2_E = 1.4426950408889634
+PREFIX_FLOOR = -126.0
+NORM_FLOOR = 1.0e-24
+SOFTPLUS_CUT = 20.0
+
+#: ``lower_bound`` is validated against this closed interval, not compiled in.
+LOWER_BOUND_RANGE = (-5.0, 0.0)
+
+# ---------------------------------------------------------------------------
+# Three-main_slot phase algebra
+# ---------------------------------------------------------------------------
+
+
+def main_slot(chunk: int) -> int:
+    """Main main_slot and V stage index of chunk ``chunk``.
+
+    Spelled without ``%`` so the identical expression evaluates for a Python
+    ``int`` on the host and for a ``cutlass.Int32`` on the device.
+    """
+    return chunk - MAIN_SLOTS * (chunk // MAIN_SLOTS)
+
+
+def generation(chunk: int) -> int:
+    """How many times chunk ``chunk``'s main_slot has been used before it."""
+    return chunk // MAIN_SLOTS
+
+
+def ready_parity(chunk: int) -> int:
+    """Phase a *consumer* waits on for chunk ``chunk``'s events.
+
+    ``mbarrier_wait(bar, p)`` passes when the barrier's current phase differs
+    from ``p``, so one wait per generation alternates 0, 1, 0, ...
+    """
+    return (chunk // MAIN_SLOTS) & 1
+
+
+def reuse_parity(chunk: int) -> int:
+    """Phase a *producer* waits on before overwriting chunk ``chunk``'s main_slot.
+
+    Generation 0 yields 1, which passes immediately against a freshly
+    initialized phase-0 barrier.  That is what lets W12 run one uniform loop
+    from ``c = 0`` with no prologue special case.
+    """
+    return 1 ^ ((chunk // MAIN_SLOTS) & 1)
+
+
+def chunks_for_seqlen(seqlen: int) -> int:
+    return (seqlen + BT - 1) // BT
+
+
+def grid(sequences: int, heads: int) -> tuple[int, int, int]:
+    """One CTA per ``(sequence, head)``."""
+    return (sequences, heads, 1)
+
+
+# --------------------------------------------------------------------------
+# Section 2: SMEM images and fragment maps
+# --------------------------------------------------------------------------
+
+# ---------------------------------------------------------------------------
+# S128 image parameters
+# ---------------------------------------------------------------------------
+
+#: A 128-byte segment is 64 BF16 or 32 FP32; a 16-byte group is 8 or 4.
+BF16_SEGMENT_ELEMS = 64
+BF16_GROUP_ELEMS = 8
+BF16_SEGMENTS = DK // BF16_SEGMENT_ELEMS  # 2
+BF16_SEGMENT_STRIDE = BT * BF16_SEGMENT_ELEMS  # 1024 elements
+
+F32_SEGMENT_ELEMS = 32
+F32_GROUP_ELEMS = 4
+F32_SEGMENTS = DK // F32_SEGMENT_ELEMS  # 4
+F32_SEGMENT_STRIDE = BT * F32_SEGMENT_ELEMS  # 512 elements
+
+#: Constant coordinate permutations.  A constant XOR of a *coordinate* is not
+#: expressible as a CuTe ``Swizzle`` (which only folds higher offset bits into
+#: lower ones), so these stay explicit transforms outside the layout objects.
+AK_TOKEN_XOR = BT // 2  # 8
+PAIRWISE_COL_XOR = 8
+PAIRWISE_ROW_STRIDE = BT
+
+#: Rows of the state image one value spans, by element width.
+STATE_BF16_ROWS_PER_VALUE = DK // BF16_SEGMENT_ELEMS  # 2
+STATE_F32_ROWS_PER_VALUE = DK // F32_SEGMENT_ELEMS  # 4
+
+#: Value columns one FP32 boundary window carries.
+STATE_F32_WINDOW_VALUES = 32
+
+SWIZZLE_S128_BYTES = (3, 4, 3)
+SWIZZLE_SW32_BYTES = (1, 4, 3)
+
+
+# ---------------------------------------------------------------------------
+# Section 4.1-4.5: SMEM images
+# ---------------------------------------------------------------------------
+
+
+def raw_bf16_s128(row, dim):
+    """BF16 element index of logical ``(row, dim)`` in a ``[16, 128]`` tile.
+
+    The image behind Q, K, V, Qd, Kd, Ki and O.  Byte-unit
+    swizzle ``Swizzle<3, 4, 3>``.
+    """
+    segment = dim // BF16_SEGMENT_ELEMS
+    local = dim - segment * BF16_SEGMENT_ELEMS
+    group = local // BF16_GROUP_ELEMS
+    inner = local - group * BF16_GROUP_ELEMS
+    return (
+        segment * BF16_SEGMENT_STRIDE
+        + row * BF16_SEGMENT_ELEMS
+        + (group ^ (row & 7)) * BF16_GROUP_ELEMS
+        + inner
+    )
+
+
+def raw_f32_s128(row, dim):
+    """FP32 element index of logical ``(row, dim)``.
+
+    Raw ``G`` lands here.  ``E`` overwrites the same region but no longer at the
+    same addresses -- see :func:`gate_e_f32` -- which is why the rendezvous
+    between the gate's reads and its stores is now unconditional.
+    """
+    segment = dim // F32_SEGMENT_ELEMS
+    local = dim - segment * F32_SEGMENT_ELEMS
+    group = local // F32_GROUP_ELEMS
+    inner = local - group * F32_GROUP_ELEMS
+    return (
+        segment * F32_SEGMENT_STRIDE
+        + row * F32_SEGMENT_ELEMS
+        + (group ^ (row & 7)) * F32_GROUP_ELEMS
+        + inner
+    )
+
+
+def pairwise_sw32(row, col):
+    """BF16 element index of a ``[16, 16]`` pairwise tile.
+
+    Carries ``AinvBeta`` and ``Aq``.  The ``col ^ 8`` term is a coordinate
+    permutation applied before the SW32 swizzle.
+    """
+    storage_col = col ^ PAIRWISE_COL_XOR
+    byte0 = 2 * (PAIRWISE_ROW_STRIDE * row + storage_col)
+    return (byte0 ^ (((byte0 >> 7) & 1) << 4)) // 2
+
+
+def ak_t_s128(token, key):
+    """BF16 element index of ``Ak.T[token, key]``.
+
+    ``Ak`` is logically ``[K, token] = [128, 16]`` and is published transposed
+    with a ``token ^ 8`` row permutation.  That permutation is what lets the
+    recurrence recover the ``[key, token]`` A operand with a single
+    ``ldmatrix.x4.trans`` and no register shuffle afterwards.
+    """
+    return raw_bf16_s128(token ^ AK_TOKEN_XOR, key)
+
+
+def state_bf16_idx(v, k):
+    """BF16 element index of external state ``[V, K]`` element ``(v, k)``.
+
+    ``v`` is the CTA-global value in ``[0, 128)``: the two
+    16 KiB halves are main slots 0 and 1, which are adjacent, so one index
+    function spans both.  The unswizzled address is ``v * 128 + k`` -- physical
+    ``[V, K]`` row-major and logical ``[K, V]`` column-major at once, which is
+    what lets an external ``[V, K]`` state land by TMA with no transpose and
+    still be read as ``H[K, V]``.
+    """
+    segment = k // BF16_SEGMENT_ELEMS
+    local = k - segment * BF16_SEGMENT_ELEMS
+    line = STATE_BF16_ROWS_PER_VALUE * v + segment
+    group = local // BF16_GROUP_ELEMS
+    inner = local - group * BF16_GROUP_ELEMS
+    return line * BF16_SEGMENT_ELEMS + (group ^ (line & 7)) * BF16_GROUP_ELEMS + inner
+
+
+def state_f32_window_idx(v_local, k):
+    """FP32 element index within one 32-value boundary window.
+
+    ``v_local`` is in ``[0, 32)``; window ``w`` carries
+    values ``[32 * w, 32 * w + 32)`` and occupies main slot 0 alone.
+    """
+    segment = k // F32_SEGMENT_ELEMS
+    local = k - segment * F32_SEGMENT_ELEMS
+    line = STATE_F32_ROWS_PER_VALUE * v_local + segment
+    group = local // F32_GROUP_ELEMS
+    inner = local - group * F32_GROUP_ELEMS
+    return line * F32_SEGMENT_ELEMS + (group ^ (line & 7)) * F32_GROUP_ELEMS + inner
+
+
+def gtotal_idx(k):
+    """``GTotal`` is a contiguous FP32 ``[128]`` record with no swizzle."""
+    return k
+
+
+# ---------------------------------------------------------------------------
+# Section 4.6: H register layout
+# ---------------------------------------------------------------------------
+
+
+def h32_idx(kb, nb, reg):
+    """Flat index of FP32 master-state register ``(kb, nb, reg)``, 64 per lane."""
+    return (kb * 2 + nb) * 4 + reg
+
+
+def h16_idx(kb, nb, reg):
+    """Flat index of packed BF16 state register ``(kb, nb, reg)``, 32 per lane."""
+    return (kb * 2 + nb) * 2 + reg
+
+
+def h32_coord(lane, kb, nb, reg, v_base):
+    """Logical ``(k, v)`` of FP32 state register ``(kb, nb, reg)``.
+
+    The native C map of an ``m16n8k16`` tile whose rows are keys and whose
+    columns are the eight values at ``v_base + 8 * nb``.
+    """
+    g = lane >> 2
+    q = lane & 3
+    k = kb * BT + g + 8 * (reg >> 1)
+    v = v_base + 8 * nb + 2 * q + (reg & 1)
+    return (k, v)
+
+
+def h16_pair_coords(lane, kb, nb, reg, v_base):
+    """The two ``(k, v)`` coordinates packed into H16 register ``reg``.
+
+    H16 register ``reg`` holds ``pack(c[2 * reg], c[2 * reg + 1])``, which is
+    one key row and two adjacent values.
+    """
+    return (
+        h32_coord(lane, kb, nb, 2 * reg, v_base),
+        h32_coord(lane, kb, nb, 2 * reg + 1, v_base),
+    )
+
+
+def h_b_coords(lane, kb, nb, reg, v_base):
+    """The two ``(k, v)`` coordinates of B register ``reg`` after ``movmatrix``.
+
+    ``movmatrix.sync.aligned.m8n8.trans.b16`` on each of the
+    two packed H16 registers is a bitwise C-to-B conversion, so no rounding
+    happens here and the projection reads the state the MMA's B operand wants.
+    """
+    g = lane >> 2
+    q = lane & 3
+    k = kb * BT + 2 * q + 8 * reg
+    v = v_base + 8 * nb + g
+    return ((k, v), (k + 1, v))
+
+
+# ---------------------------------------------------------------------------
+# Transposed recurrence (H as the MMA A operand)
+#
+# The projection consumes H as a B operand, and a C-to-B conversion is a
+# cross-lane transpose -- ``movmatrix`` per register, the largest single
+# consumer of the LSU pipe.  C-to-A, by contrast, keeps the M axis and is a
+# pure within-lane repack, which ``pack_a_bf16`` already does for free.
+#
+# Transposing the whole recurrence moves H into the A slot: the accumulator
+# becomes ``(M = value, N = key)``, so ``pack`` alone lands the A fragment and
+# the transpose disappears.  Every other operand becomes a B read from SMEM,
+# which is a pointer-map change at identical instruction count.
+# ---------------------------------------------------------------------------
+
+#: Key columns one transposed accumulator tile carries; 16 tiles span DK.
+HT_TILE_KEYS = 8
+HT_TILES = DK // HT_TILE_KEYS  # 16
+
+
+def h32t_idx(kt, reg):
+    """Flat index of transposed FP32 state register ``(kt, reg)``, 64 per lane."""
+    return kt * 4 + reg
+
+
+def h16t_idx(kt, reg):
+    """Flat index of transposed packed BF16 register ``(kt, reg)``, 32 per lane."""
+    return kt * 2 + reg
+
+
+def h32t_coord(lane, kt, reg, v_base):
+    """Logical ``(k, v)`` of transposed FP32 state register ``(kt, reg)``.
+
+    The native C map of an ``m16n8k16`` tile whose rows are *values* and whose
+    columns are the eight keys at ``8 * kt`` -- the transpose of
+    :func:`h32_coord`.
+    """
+    g = lane >> 2
+    q = lane & 3
+    v = v_base + g + 8 * (reg >> 1)
+    k = HT_TILE_KEYS * kt + 2 * q + (reg & 1)
+    return (k, v)
+
+
+def h16t_pair_coords(lane, kt, reg, v_base):
+    """The two ``(k, v)`` coordinates packed into transposed H16 register."""
+    return (
+        h32t_coord(lane, kt, 2 * reg, v_base),
+        h32t_coord(lane, kt, 2 * reg + 1, v_base),
+    )
+
+
+def h_a_reg(j, r):
+    """H16 register holding A-fragment register ``r`` of key block ``j``.
+
+    The whole point of the transpose: this is a *selection*, not a conversion.
+    Tiles ``2j`` and ``2j + 1`` supply K = 16, and their four packed registers
+    already sit in A-fragment order, so the four are simply ``4j`` to ``4j + 3``.
+    """
+    return 4 * j + r
+
+
+#: GTotal values one lane takes in the cooperative load, and the tiles they
+#: then serve by shuffle.
+GTOTAL_GROUP = DK // 32  # 4
+
+
+def gtotal_group_key(lane, group):
+    """Key whose GTotal ``lane`` holds after the cooperative load of ``group``."""
+    return 32 * group + lane
+
+
+def gtotal_shuffle_source(lane, kt, half):
+    """Lane holding the GTotal that ``lane`` needs for tile ``kt``, half ``half``.
+
+    The transposed accumulator puts key on the column axis, so a lane's pair is
+    fixed by ``q = lane & 3`` and no pair is reused across tiles -- 32 values
+    per lane where the un-transposed form needed 16, all of it redundant, since
+    the warp still reads the same 128 unique values.  Loading them once
+    cooperatively and shuffling costs four fully coalesced loads instead of
+    sixteen scattered ones.
+
+    The source *register* is warp-uniform by construction (each group is one
+    register); only the source lane varies, which is what makes the exchange
+    expressible at all.
+    """
+    return 8 * (kt - GTOTAL_GROUP * (kt // GTOTAL_GROUP)) + 2 * (lane & 3) + half
+
+
+def ak_b_ptr(lane, j):
+    """``Ak.T`` ``ldmatrix.x4.trans`` producing the ``[token, key]`` B operand.
+
+    :func:`ak_a_ptr` delivers the A operand the un-transposed recurrence wants;
+    the transposed one needs Ak as B, and the image is contiguous in key while
+    a B register wants two adjacent *tokens*, hence ``.trans``.
+    """
+    r = lane >> 3
+    token = lane - 8 * r
+    return raw_bf16_s128((token + 8 * (r & 1)) ^ AK_TOKEN_XOR, BT * j + 8 * (r >> 1))
+
+
+def state_x2t_ptr(lane, kt, value_base):
+    """Boundary-state ``ldmatrix.x2`` / ``stmatrix.x2``, transposed recurrence.
+
+    No ``.trans``, unlike :func:`state_x2_ptr`.  The image is physically
+    ``[V, K]`` and the transposed C tile wants one value and two adjacent keys,
+    which is the image's own contiguous direction -- the transpose that the
+    un-transposed recurrence needed here disappears with it.
+    """
+    matrix = (lane // 8) & 1
+    v = value_base + (lane - (lane // 8) * 8) + 8 * matrix
+    return state_bf16_idx(v, HT_TILE_KEYS * kt)
+
+
+def pairwise_b_ptr(lane):
+    """``Aq.T`` / ``AinvBeta.T`` ``ldmatrix.x4`` producing the MMA B operand.
+
+    No ``.trans``: a B register wants two adjacent ``k`` at one ``n``, which in
+    ``Aq.T`` is two adjacent *columns* of ``Aq`` at one row, and the pairwise
+    image is contiguous in column.  Only the addressed rows differ from
+    :func:`pairwise_a_ptr`.
+    """
+    m = lane >> 3
+    return pairwise_sw32((lane - 8 * m) + 8 * (m >> 1), 8 * (m & 1))
+
+
+def vo_x2t_ptr(lane, value_base, nb):
+    """V ``ldmatrix.x2.trans`` / O ``stmatrix.x2.trans``, transposed recurrence.
+
+    Eight tokens each supply eight contiguous values; ``.trans`` turns that into
+    rows of values and columns of tokens, which is the transposed C tile's
+    shape.  ``nb`` selects the eight tokens.
+    """
+    matrix = (lane // 8) & 1
+    row = lane - (lane // 8) * 8
+    return raw_bf16_s128(HT_TILE_KEYS * nb + row, value_base + 8 * matrix)
+
+
+# ---------------------------------------------------------------------------
+# Section 9.1: native m16n8k16 fragment coordinates
+# ---------------------------------------------------------------------------
+
+
+def mma_a_coords(lane, reg):
+    """Logical ``(row, k)`` of the two 16-bit halves in A register ``reg``."""
+    g = lane >> 2
+    q = lane & 3
+    row = g + 8 * (reg & 1)
+    k = 2 * q + 8 * (reg >> 1)
+    return ((row, k), (row, k + 1))
+
+
+def mma_b_coords(lane, reg):
+    """Logical ``(k, n)`` of the two 16-bit halves in B register ``reg``."""
+    g = lane >> 2
+    q = lane & 3
+    k = 2 * q + 8 * reg
+    return ((k, g), (k + 1, g))
+
+
+def mma_c_coord(lane, reg, n_base=0):
+    """Logical ``(row, n)`` of FP32 accumulator register ``reg``."""
+    g = lane >> 2
+    q = lane & 3
+    return (g + 8 * (reg >> 1), n_base + 2 * q + (reg & 1))
+
+
+def mma_c16_coord(lane, slot):
+    """``(row, col)`` of slot ``slot`` in a logical N=16 accumulator.
+
+    Slots 0-3 are the low N=8 half and 4-7 the high half, matching the order
+    two native MMAs write them.
+    """
+    nb = slot // 4
+    return mma_c_coord(lane, slot - nb * 4, 8 * nb)
+
+
+# ---------------------------------------------------------------------------
+# Section 9.2: SMEM pointer maps
+#
+# ``factor_a_ptr`` and ``ki_b_ptr`` are NOT the same lane map.  The A map takes
+# its row half from ``m & 1`` and its column half from ``m >> 1``; the B map
+# takes the row half from lane bit 4 and the column half from lane bit 3.  Using
+# the A map with a ``.trans`` modifier in place of the B map silently
+# transposes the operand, which is why the two are separate functions and why
+# the plan pins an exhaustive probe on the difference.
+# ---------------------------------------------------------------------------
+
+
+def factor_a_ptr(lane, kb):
+    """Qd/Kd ``ldmatrix.x4`` A operand; also the matching ``stmatrix.x4``."""
+    m = lane // 8
+    row = (lane - m * 8) + 8 * (m & 1)
+    col = BT * kb + 8 * (m >> 1)
+    return raw_bf16_s128(row, col)
+
+
+def ki_b_ptr(lane, kb):
+    """Ki ``ldmatrix.x4`` (no ``.trans``) producing the MMA B operand."""
+    m = lane // 8
+    row = (lane - m * 8) + 8 * (lane // 16)
+    col = BT * kb + 8 * (m & 1)
+    return raw_bf16_s128(row, col)
+
+
+def pairwise_a_ptr(lane):
+    """AinvBeta / Aq ``ldmatrix.x4`` A operand."""
+    m = lane // 8
+    row = (lane - m * 8) + 8 * (m & 1)
+    col = 8 * (m >> 1)
+    return pairwise_sw32(row, col)
+
+
+#: ``stmatrix.x4`` of a pairwise tile addresses the same 16 rows as the load.
+pairwise_store_ptr = pairwise_a_ptr
+
+
+def ak_a_ptr(lane, kb):
+    """Ak.T ``ldmatrix.x4.trans`` producing the ``[key, token]`` A operand."""
+    m = lane // 8
+    logical_t = 8 * (m >> 1) + (lane - m * 8)
+    key = BT * kb + 8 * (m & 1)
+    return raw_bf16_s128(logical_t ^ AK_TOKEN_XOR, key)
+
+
+def ak_store_ptr(lane, key_base):
+    """``stmatrix.x4`` of one ``[16, 16]`` Ak.T tile at ``key_base``."""
+    m = lane // 8
+    token = (lane - m * 8) + 8 * (m & 1)
+    key = key_base + 8 * (m >> 1)
+    return ak_t_s128(token, key)
+
+
+def vo_x2_ptr(lane, value_base):
+    """V ``ldmatrix.x2`` / O ``stmatrix.x2`` over a ``[16, 8]`` value block.
+
+    Non-transposed in both directions: the stage is token-major and the C
+    tile's rows are tokens, so the load and the store share this map.
+    """
+    matrix = (lane // 8) & 1
+    token = (lane - (lane // 8) * 8) + 8 * matrix
+    return raw_bf16_s128(token, value_base)
+
+
+def state_x2_ptr(lane, kb, value_base):
+    """Boundary-state ``ldmatrix.x2.trans`` / ``stmatrix.x2.trans`` map.
+
+    The state image is physically ``[V, K]``; ``.trans`` turns those 16 rows
+    into the ``[K, V]`` C tile the registers hold, so the prologue load and the
+    epilogue store use one map and differ only in instruction direction.  Lanes
+    16-31 are ignored by an x2 copy.
+    """
+    matrix = (lane // 8) & 1
+    v = value_base + (lane - (lane // 8) * 8)
+    key = BT * kb + 8 * matrix
+    return state_bf16_idx(v, key)
+
+
+def state_f32_window_reg_coord(lane, kb, nb, reg, local_v_base):
+    """``(v_local, k)`` an FP32 boundary window read/writes for H32 ``reg``.
+
+    the FP32 boundary has no matrix-copy path, so
+    each lane addresses its four accumulator elements individually through
+    :func:`state_f32_window_idx`.
+    """
+    g = lane >> 2
+    q = lane & 3
+    k = BT * kb + g + 8 * (reg >> 1)
+    v_local = local_v_base + 8 * nb + 2 * q + (reg & 1)
+    return (v_local, k)
+
+
+# ---------------------------------------------------------------------------
+# Section 3.5: prepare-warp ownership
+# ---------------------------------------------------------------------------
+
+
+def gate_owner_dim(warp, lane):
+    """Key dimension whose 16 gate values and ``GTotal`` lane ``lane`` owns."""
+    return 32 * warp + lane
+
+
+def norm_row(warp, lane):
+    """Token row lane ``lane`` of prepare warp ``warp`` helps normalize."""
+    return 4 * warp + (lane // 8)
+
+
+def norm_dims(lane):
+    """The 16 feature indices a norm lane squares, in accumulation order.
+
+    The order is part of the contract: the FP32 sum is not reassociated, so a
+    different traversal is a different number.
+    """
+    lane_in_row = lane & 7
+    return [8 * lane_in_row + i for i in range(8)] + [
+        64 + 8 * lane_in_row + i for i in range(8)
+    ]
+
+
+def materialize_coords(warp, lane, j, nb, r):
+    """``(t0, t1, key)`` of materializer B register ``2 * nb + r``.
+
+    The materializer does *not* keep the gate stage's
+    "lane ``l`` owns dimension ``32p + l``" mapping: it forms the MMA **B**
+    fragment of Qd/Kd/Ki/Kr directly, so its lane coordinates are the B map's.
+    The four ``(nb, r)`` combinations cover one ``[16, 16]`` tile exactly once,
+    and ``j`` selects which of the warp's two key tiles.
+    """
+    g = lane >> 2
+    q = lane & 3
+    t0 = 2 * q + 8 * r
+    key = 32 * warp + BT * j + 8 * nb + g
+    return (t0, t0 + 1, key)
+
+
+#: Elements of the E image one vector access covers, and the groups per row.
+E_GROUP_ELEMS = 4
+E_GROUPS = BT // E_GROUP_ELEMS  # 4
+
+
+def gate_e_group_xor(key):
+    """Token-group permutation of ``key`` in the E image.
+
+    Two *separated* key bit pairs, not one.  The store's phase holds eight
+    consecutive keys and the load's holds four keys eight apart, and a
+    permutation driven by ``key & 3`` alone leaves whichever of the two it does
+    not address two-way conflicted.  Folding ``key >> 2`` in as well is what
+    makes both conflict-free at once.
+    """
+    return (key ^ (key >> 2)) & 3
+
+
+def gate_e_f32(key, token):
+    """FP32 element index of E at ``(key, token)`` in a ``[128, 16]`` tile.
+
+    E is *transposed* relative to the raw G image it overwrites: raw G arrives
+    from TMA as ``[token, key]`` because that is what TMA lands, but both sides
+    of E's exchange walk along ``token`` -- the gate owns one key and writes
+    sixteen tokens, the materializer wants two adjacent tokens at one key.  A
+    ``[key, token]`` image makes each side contiguous, turning sixteen scalar
+    stores into four vector ones and sixteen scalar loads into eight pair
+    loads.
+
+    The permutation above is a constant XOR of a *coordinate*, like
+    :data:`AK_TOKEN_XOR`, not a CuTe ``Swizzle``.  ``token``'s low two bits are
+    left alone so a token pair ``(t, t + 1)`` with even ``t`` stays adjacent,
+    which is what the materializer's pair load requires.
+
+    Total size is ``128 * 16 * 4 = 8192`` bytes, exactly ``SLOT_G_LO``: the
+    conflict-free form needs no padding.
+    """
+    group = token // E_GROUP_ELEMS
+    inner = token - group * E_GROUP_ELEMS
+    return BT * key + E_GROUP_ELEMS * (group ^ gate_e_group_xor(key)) + inner
+
+
+def materialize_b_ptr(warp, lane, j):
+    """Raw Q/K ``ldmatrix.x4.trans`` delivering :func:`materialize_coords`.
+
+    The materializer's four registers are the native B fragment of the warp's
+    ``[16, 16]`` key tile ``j``: register ``2 * nb + r`` holds tokens
+    ``2 * (lane & 3) + 8 * r`` and ``+1`` at key ``8 * nb + (lane >> 2)``.  A
+    B fragment over a ``[token, key]`` image is what ``.trans`` produces, so
+    the whole tile is one instruction per factor rather than eight scalar
+    loads per register.
+
+    The eight elements each addressed row contributes are keys ``base`` to
+    ``base + 7`` of one token, and :func:`raw_bf16_s128` is contiguous in
+    ``dim`` inside an eight-aligned group, so the S128 swizzle is absorbed
+    entirely into the row address -- unlike :func:`ak_a_ptr`, no coordinate
+    XOR is needed.
+    """
+    reg = lane >> 3
+    row = lane - 8 * reg
+    nb = reg >> 1
+    r = reg - 2 * nb
+    return raw_bf16_s128(8 * r + row, 32 * warp + BT * j + 8 * nb)
+
+
+def kr_b_coords(warp, lane, j, nb, r):
+    """The two ``(token, key)`` coordinates of Kr B register ``2 * nb + r``.
+
+    Identical to :func:`materialize_coords`; named separately because plan
+    Section 9.3 pins the Kr B-fragment mapping as its own contract -- Kr is the
+    one factor that is never published to SMEM, so this map is the only
+    definition of where its values live.
+    """
+    t0, t1, key = materialize_coords(warp, lane, j, nb, r)
+    return ((t0, key), (t1, key))
+
+
+# ---------------------------------------------------------------------------
+# Section 9.3: fixed register permutations
+# ---------------------------------------------------------------------------
+
+#: A-layout -> B-layout of the same matrix: transpose each 8x8 quadrant.
+MOVMATRIX_A_TO_B = (0, 1, 2, 3)
+
+#: A-layout -> A-layout of the transpose: the off-diagonal quadrants exchange.
+MOVMATRIX_A_TO_AT = (0, 2, 1, 3)
+
+#: C-layout -> B-layout of a packed 16x8 tile (H16 and the residual R).
+MOVMATRIX_C_TO_B = (0, 1)
+
+#: Quadrant order of the packed A fragment the inverse chain works in
+#:: top-left, bottom-left, top-right, bottom-right.
+INVERSE_FRAG_QUADRANTS = ("TL", "BL", "TR", "BR")
+
+
+# ---------------------------------------------------------------------------
+# Global element indices
+# ---------------------------------------------------------------------------
+
+
+def out_global_index(token, head, heads, dim):
+    """Flat element index of ``out[0, token, head, dim]``.
+
+    Only the tail output path needs this; a full chunk is stored by TMA, which
+    addresses the same elements through its descriptor.
+    """
+    return (token * heads + head) * DV + dim
+
+
+def beta_global_index(token, head, heads):
+    """Flat element index of ``beta[0, token, head]``."""
+    return token * heads + head
+
+
+# ---------------------------------------------------------------------------
+# CuTe layout objects (TMA descriptors only)
+# ---------------------------------------------------------------------------
+
+
+def make_cute_layouts():
+    """Build the three composed layouts the images above describe.
+
+    Imported lazily so host-only consumers -- the layout tests, the reference
+    and the validation matrix -- do not need the CUTLASS DSL installed.
+    """
+    import cutlass.cute as cute
+
+    raw_bf16 = cute.make_composed_layout(
+        cute.make_swizzle(*SWIZZLE_S128_BYTES),
+        0,
+        cute.make_layout(
+            (BT, (BF16_SEGMENT_ELEMS, BF16_SEGMENTS)),
+            stride=(BF16_SEGMENT_ELEMS, (1, BF16_SEGMENT_STRIDE)),
+        ),
+    )
+    raw_f32 = cute.make_composed_layout(
+        cute.make_swizzle(*SWIZZLE_S128_BYTES),
+        0,
+        cute.make_layout(
+            (BT, (F32_SEGMENT_ELEMS, F32_SEGMENTS)),
+            stride=(F32_SEGMENT_ELEMS, (1, F32_SEGMENT_STRIDE)),
+        ),
+    )
+    pairwise = cute.make_composed_layout(
+        cute.make_swizzle(*SWIZZLE_SW32_BYTES),
+        0,
+        cute.make_layout((BT, BT), stride=(PAIRWISE_ROW_STRIDE, 1)),
+    )
+    return raw_bf16, raw_f32, pairwise
+
+
+# --------------------------------------------------------------------------
+# Section 3: inline PTX the fused kernel issues
+# --------------------------------------------------------------------------
+
+# ---------------------------------------------------------------------------
+# Matrix copies
+# ---------------------------------------------------------------------------
+
+
+def _ldmatrix(count: str, trans: str, smem_ptr, num: int, *, loc=None, ip=None):
+    from cutlass._mlir.extras import types as _T
+
+    outs = ", ".join(f"${i}" for i in range(num))
+    struct = llvm.inline_asm(
+        llvm.StructType.get_literal([_T.IntegerType.get_signless(32)] * num),
+        [smem_ptr.toint(loc=loc, ip=ip).ir_value(loc=loc, ip=ip)],
+        f"ldmatrix.sync.aligned.m8n8{count}{trans}.shared.b16 {{{outs}}}, [${num}];",
+        ",".join(["=r"] * num) + ",r",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+    return tuple(
+        cutlass.Int32(
+            llvm.extractvalue(
+                _T.IntegerType.get_signless(32), struct, [i], loc=loc, ip=ip
+            )
+        )
+        for i in range(num)
+    )
+
+
+@dsl_user_op
+def ldmatrix_x4(smem_ptr, *, loc=None, ip=None):
+    """``ldmatrix.sync.aligned.m8n8.x4.shared.b16`` -> four b32.
+
+    Qd/Kd A operands, the Ki B operand and the pairwise tiles.  Which of those
+    it produces is entirely a property of the pointer map it is given.
+    """
+    return _ldmatrix(".x4", "", smem_ptr, 4, loc=loc, ip=ip)
+
+
+@dsl_user_op
+def ldmatrix_x4_trans(smem_ptr, *, loc=None, ip=None):
+    """``ldmatrix...x4.trans``: Ak.T -> the ``[key, token]`` Ak A operand."""
+    return _ldmatrix(".x4", ".trans", smem_ptr, 4, loc=loc, ip=ip)
+
+
+@dsl_user_op
+def ldmatrix_x2(smem_ptr, *, loc=None, ip=None):
+    """``ldmatrix...x2``: one ``[16, 8]`` V tile.  Only lanes 0-15 address."""
+    return _ldmatrix(".x2", "", smem_ptr, 2, loc=loc, ip=ip)
+
+
+@dsl_user_op
+def ldmatrix_x2_trans(smem_ptr, *, loc=None, ip=None):
+    """``ldmatrix...x2.trans``: the boundary state's C-layout view.
+
+    The physical state image is ``[V, K]``; reading down its columns is what
+    turns it into the ``[K, V]`` accumulator layout H32/H16 are held in.
+    """
+    return _ldmatrix(".x2", ".trans", smem_ptr, 2, loc=loc, ip=ip)
+
+
+def _stmatrix(count: str, trans: str, smem_ptr, regs, *, loc=None, ip=None):
+    ins = ", ".join(f"${i + 1}" for i in range(len(regs)))
+    llvm.inline_asm(
+        None,
+        [
+            smem_ptr.toint(loc=loc, ip=ip).ir_value(loc=loc, ip=ip),
+            *[cutlass.Int32(r).ir_value(loc=loc, ip=ip) for r in regs],
+        ],
+        f"stmatrix.sync.aligned.m8n8{count}{trans}.shared.b16 [$0], {{{ins}}};",
+        ",".join(["r"] * (len(regs) + 1)),
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+
+
+@dsl_user_op
+def stmatrix_x4(smem_ptr, r0, r1, r2, r3, *, loc=None, ip=None):
+    """``stmatrix...x4``: Qd/Kd/Ki publication, AinvBeta, Aq and Ak.T."""
+    _stmatrix(".x4", "", smem_ptr, (r0, r1, r2, r3), loc=loc, ip=ip)
+
+
+@dsl_user_op
+def stmatrix_x4_trans(smem_ptr, r0, r1, r2, r3, *, loc=None, ip=None):
+    """``stmatrix...x4.trans``: publish a B-layout fragment to the A image.
+
+    The transpose the store performs is per 8x8 tile with the register order
+    unchanged, which is exactly :func:`~...kernel.a_to_b`'s
+    ``MOVMATRIX_A_TO_B = (0, 1, 2, 3)``.  Using this instead costs four
+    ``movmatrix`` less per factor and lands the same image; the equality is
+    checked against the host store model in the layout tests.
+    """
+    _stmatrix(".x4", ".trans", smem_ptr, (r0, r1, r2, r3), loc=loc, ip=ip)
+
+
+@dsl_user_op
+def stmatrix_x2(smem_ptr, r0, r1, *, loc=None, ip=None):
+    """``stmatrix...x2``: the output tile."""
+    _stmatrix(".x2", "", smem_ptr, (r0, r1), loc=loc, ip=ip)
+
+
+@dsl_user_op
+def stmatrix_x2_trans(smem_ptr, r0, r1, *, loc=None, ip=None):
+    """``stmatrix...x2.trans``: exactly inverts :func:`ldmatrix_x2_trans`."""
+    _stmatrix(".x2", ".trans", smem_ptr, (r0, r1), loc=loc, ip=ip)
+
+
+@dsl_user_op
+def fresh_b32(value, *, loc=None, ip=None):
+    """A byte-identity ``prmt.b32``: same value, a *different* register.
+
+    This computes nothing.  It exists to keep the MMA's operand register
+    distinct from the persistent H16 state register, and removing it is a
+    measured 4% regression, not a cleanup.
+
+    The transposed recurrence hands H16 straight to the MMA as its A operand.
+    Without an intervening value, ptxas must satisfy the MMA's register
+    constraints on registers that are live across the entire kernel, and with
+    96 of a recurrence warp's 160 registers already pinned to h32/h16 it
+    resolves that by spilling -- measured, ``LDL`` rises 6.3x and the kernel
+    slows by 4.0%.  Standing this instruction in the same place keeps spill
+    unchanged and gains 4.2%.
+
+    ``prmt`` rather than ``mov`` because ptxas folds an identity move; the
+    byte-permute survives, which the opcode counts confirm.
+    """
+    from cutlass._mlir.extras import types as _T
+
+    return cutlass.Int32(
+        llvm.inline_asm(
+            _T.IntegerType.get_signless(32),
+            [cutlass.Int32(value).ir_value(loc=loc, ip=ip)],
+            "prmt.b32 $0, $1, $1, 0x3210;",
+            "=r,r",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+            loc=loc,
+            ip=ip,
+        )
+    )
+
+
+@dsl_user_op
+def movmatrix_b16(value, *, loc=None, ip=None):
+    """``movmatrix.sync.aligned.m8n8.trans.b16``: transpose one packed 8x8.
+
+    Bit-exact: this moves 16-bit lanes between registers and never rounds, which
+    is what makes the H16 C-to-B conversion free of a second rounding boundary.
+    """
+    from cutlass._mlir.extras import types as _T
+
+    return cutlass.Int32(
+        llvm.inline_asm(
+            _T.IntegerType.get_signless(32),
+            [cutlass.Int32(value).ir_value(loc=loc, ip=ip)],
+            "movmatrix.sync.aligned.m8n8.trans.b16 $0, $1;",
+            "=r,r",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+            loc=loc,
+            ip=ip,
+        )
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tensor Core
+# ---------------------------------------------------------------------------
+
+
+def _mma_m16n8k16(
+    kind: str, a0, a1, a2, a3, b0, b1, c0, c1, c2, c3, *, loc=None, ip=None
+):
+    from cutlass._mlir.extras import types as _T
+
+    struct = llvm.inline_asm(
+        llvm.StructType.get_literal([_T.F32Type.get()] * 4),
+        [
+            cutlass.Int32(a0).ir_value(loc=loc, ip=ip),
+            cutlass.Int32(a1).ir_value(loc=loc, ip=ip),
+            cutlass.Int32(a2).ir_value(loc=loc, ip=ip),
+            cutlass.Int32(a3).ir_value(loc=loc, ip=ip),
+            cutlass.Int32(b0).ir_value(loc=loc, ip=ip),
+            cutlass.Int32(b1).ir_value(loc=loc, ip=ip),
+            cutlass.Float32(c0).ir_value(loc=loc, ip=ip),
+            cutlass.Float32(c1).ir_value(loc=loc, ip=ip),
+            cutlass.Float32(c2).ir_value(loc=loc, ip=ip),
+            cutlass.Float32(c3).ir_value(loc=loc, ip=ip),
+        ],
+        f"mma.sync.aligned.m16n8k16.row.col.f32.{kind}.{kind}.f32 "
+        "{$0, $1, $2, $3}, {$4, $5, $6, $7}, {$8, $9}, {$10, $11, $12, $13};",
+        "=f,=f,=f,=f,r,r,r,r,r,r,f,f,f,f",
+        has_side_effects=False,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+    return tuple(
+        cutlass.Float32(
+            llvm.extractvalue(_T.F32Type.get(), struct, [i], loc=loc, ip=ip)
+        )
+        for i in range(4)
+    )
+
+
+@dsl_user_op
+def mma_m16n8k16_bf16(a0, a1, a2, a3, b0, b1, c0, c1, c2, c3, *, loc=None, ip=None):
+    """``mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32``: every BF16 MMA."""
+    return _mma_m16n8k16("bf16", a0, a1, a2, a3, b0, b1, c0, c1, c2, c3, loc=loc, ip=ip)
+
+
+@dsl_user_op
+def mma_m16n8k16_f16(a0, a1, a2, a3, b0, b1, c0, c1, c2, c3, *, loc=None, ip=None):
+    """``...f32.f16.f16.f32``: the blockwise inverse's twelve MMAs, and only those."""
+    return _mma_m16n8k16("f16", a0, a1, a2, a3, b0, b1, c0, c1, c2, c3, loc=loc, ip=ip)
+
+
+# ---------------------------------------------------------------------------
+# Packed conversion and arithmetic
+# ---------------------------------------------------------------------------
+
+
+def _pack(instr: str, lo, hi, *, loc=None, ip=None):
+    from cutlass._mlir.extras import types as _T
+
+    return cutlass.Int32(
+        llvm.inline_asm(
+            _T.IntegerType.get_signless(32),
+            [
+                cutlass.Float32(hi).ir_value(loc=loc, ip=ip),
+                cutlass.Float32(lo).ir_value(loc=loc, ip=ip),
+            ],
+            f"{instr} $0, $1, $2;",
+            "=r,f,f",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+            loc=loc,
+            ip=ip,
+        )
+    )
+
+
+@dsl_user_op
+def pack_bf16x2(lo, hi, *, loc=None, ip=None):
+    """``cvt.rn.bf16x2.f32``; ``lo`` lands in the low half."""
+    return _pack("cvt.rn.bf16x2.f32", lo, hi, loc=loc, ip=ip)
+
+
+@dsl_user_op
+def pack_f16x2(lo, hi, *, loc=None, ip=None):
+    """``cvt.rn.f16x2.f32``; ``lo`` lands in the low half.
+
+    The inverse chain's pack.  it must not go through BF16
+    first -- the three extra significand bits are the point.
+    """
+    return _pack("cvt.rn.f16x2.f32", lo, hi, loc=loc, ip=ip)
+
+
+def _binary_packed(instr: str, a, b, *, loc=None, ip=None):
+    from cutlass._mlir.extras import types as _T
+
+    return cutlass.Int32(
+        llvm.inline_asm(
+            _T.IntegerType.get_signless(32),
+            [
+                cutlass.Int32(a).ir_value(loc=loc, ip=ip),
+                cutlass.Int32(b).ir_value(loc=loc, ip=ip),
+            ],
+            f"{instr} $0, $1, $2;",
+            "=r,r,r",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+            loc=loc,
+            ip=ip,
+        )
+    )
+
+
+@dsl_user_op
+def mul_bf16x2(a, b, *, loc=None, ip=None):
+    """``mul.rn.bf16x2``: two BF16 products, each rounded once."""
+    return _binary_packed("mul.rn.bf16x2", a, b, loc=loc, ip=ip)
+
+
+@dsl_user_op
+def sub_bf16x2(a, b, *, loc=None, ip=None):
+    """``sub.rn.bf16x2``: the residual ``BF16(V - X)`` for two tokens at once."""
+    return _binary_packed("sub.rn.bf16x2", a, b, loc=loc, ip=ip)
+
+
+@dsl_user_op
+def unpack_bf16x2(value, *, loc=None, ip=None):
+    """Widen a packed BF16 pair to two FP32, low half first."""
+    from cutlass._mlir.extras import types as _T
+
+    struct = llvm.inline_asm(
+        llvm.StructType.get_literal([_T.F32Type.get()] * 2),
+        [cutlass.Int32(value).ir_value(loc=loc, ip=ip)],
+        "{ .reg .b16 lo, hi;"
+        "  mov.b32 {lo, hi}, $2;"
+        "  cvt.f32.bf16 $0, lo; cvt.f32.bf16 $1, hi; }",
+        "=f,=f,r",
+        has_side_effects=False,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+    return tuple(
+        cutlass.Float32(
+            llvm.extractvalue(_T.F32Type.get(), struct, [i], loc=loc, ip=ip)
+        )
+        for i in range(2)
+    )
+
+
+@dsl_user_op
+def rcp_approx_ftz(x, *, loc=None, ip=None):
+    """``rcp.approx.ftz.f32``: used for ``1 / E`` when forming Ki, and nowhere else.
+
+    ``.ftz`` flushes subnormal *inputs* to zero, so ``E < 2^-126`` would return
+    ``+Inf`` and ``0 * Inf`` would poison a whole KK row.  The
+    :data:`PREFIX_FLOOR` clamp on the gate
+    prefix is what keeps ``E`` at or above the smallest normal, which is why
+    that clamp is not optional.
+    """
+    from cutlass._mlir.extras import types as _T
+
+    return cutlass.Float32(
+        llvm.inline_asm(
+            _T.F32Type.get(),
+            [cutlass.Float32(x).ir_value(loc=loc, ip=ip)],
+            "rcp.approx.ftz.f32 $0, $1;",
+            "=f,f",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+            loc=loc,
+            ip=ip,
+        )
+    )
+
+
+# ---------------------------------------------------------------------------
+# Barriers
+# ---------------------------------------------------------------------------
+
+
+@dsl_user_op
+def mbarrier_test_wait_parity(mbar_ptr, phase, *, loc=None, ip=None):
+    """``mbarrier.test_wait.parity.acquire.cta``: a single non-blocking probe.
+
+    the design allows this in the first-ready loop and forbids
+    ``try_wait``, which may suspend the warp for up to 10,000,000 ns.  The
+    result only *selects* a branch; the chosen branch still performs the real
+    32-lane acquire, because a broadcast predicate gives the other 31 lanes no
+    visibility of the producer's shared-memory stores.
+
+    Branch-free on purpose: an inline-asm label would have to be unique per
+    expansion, and ``selp`` costs less than getting that wrong.
+    """
+    from cutlass._mlir.extras import types as _T
+
+    return cutlass.Boolean(
+        cutlass.Int32(
+            llvm.inline_asm(
+                _T.IntegerType.get_signless(32),
+                [
+                    mbar_ptr.toint(loc=loc, ip=ip).ir_value(loc=loc, ip=ip),
+                    cutlass.Int32(phase).ir_value(loc=loc, ip=ip),
+                ],
+                "{ .reg .pred p;"
+                "  mbarrier.test_wait.parity.acquire.cta.shared::cta.b64"
+                " p, [$1], $2;"
+                "  selp.b32 $0, 1, 0, p; }",
+                "=r,r,r",
+                has_side_effects=True,
+                is_align_stack=False,
+                asm_dialect=llvm.AsmDialect.AD_ATT,
+                loc=loc,
+                ip=ip,
+            )
+        )
+        != cutlass.Int32(0)
+    )
+
+
+# ---------------------------------------------------------------------------
+# Register redistribution
+# ---------------------------------------------------------------------------
+
+
+#: DSL 4.7 renamed these and deprecated the old spellings; 4.3 only has the old
+#: ones.  Resolve once at import so the tree builds on both without emitting a
+#: DeprecationWarning per traced call site under 4.7.  Both spellings lower to
+#: the same op -- which on ``sm_120a`` is dropped entirely, see
+#: Section 1.
+_REG_DEC = (
+    getattr(cute.arch, "setmaxregister_decrease", None)
+    or cute.arch.warpgroup_reg_dealloc
+)
+_REG_INC = (
+    getattr(cute.arch, "setmaxregister_increase", None) or cute.arch.warpgroup_reg_alloc
+)
+
+
+@dsl_user_op
+def setmaxnreg_dec(count: int, *, loc=None, ip=None):
+    """``setmaxnreg.dec.sync.aligned.u32``.
+
+    A warpgroup instruction: every warp of the four must reach this with the
+    same immediate.  The caller is responsible for that -- nothing here can
+    check it, and a per-role call is silently wrong rather than an error.
+    """
+    _REG_DEC(count, loc=loc, ip=ip)
+
+
+@dsl_user_op
+def setmaxnreg_inc(count: int, *, loc=None, ip=None):
+    """``setmaxnreg.inc.sync.aligned.u32``; see :func:`setmaxnreg_dec`."""
+    _REG_INC(count, loc=loc, ip=ip)
+
+
+# ---------------------------------------------------------------------------
+# TMA
+# ---------------------------------------------------------------------------
+
+
+@dsl_user_op
+def fence_tensormap_acquire(desc_addr, *, loc=None, ip=None):
+    """``fence.proxy.tensormap::generic.acquire.gpu [desc], 128``.
+
+    The descriptor is written by the host and read by the TMA unit through a
+    different proxy, so the kernel must acquire it before first use.
+    """
+    llvm.inline_asm(
+        None,
+        [cutlass.Int64(desc_addr).ir_value(loc=loc, ip=ip)],
+        "fence.proxy.tensormap::generic.acquire.gpu [$0], 128;",
+        "l",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+
+
+@dsl_user_op
+def tma_load_3d(smem_ptr, desc_addr, mbar_ptr, c0, c1, c2, *, loc=None, ip=None):
+    """One ``cp.async.bulk.tensor.3d`` box, global to shared.
+
+    ``shared::cta``, not ``shared::cluster``: SM120 has no thread block
+    clusters.  Completion is reported to ``mbar_ptr`` as transaction bytes, so
+    the consumer waits on the mbarrier rather than on a commit group.
+    """
+    llvm.inline_asm(
+        None,
+        [
+            smem_ptr.toint(loc=loc, ip=ip).ir_value(loc=loc, ip=ip),
+            cutlass.Int64(desc_addr).ir_value(loc=loc, ip=ip),
+            mbar_ptr.toint(loc=loc, ip=ip).ir_value(loc=loc, ip=ip),
+            cutlass.Int32(c0).ir_value(loc=loc, ip=ip),
+            cutlass.Int32(c1).ir_value(loc=loc, ip=ip),
+            cutlass.Int32(c2).ir_value(loc=loc, ip=ip),
+        ],
+        "cp.async.bulk.tensor.3d.shared::cta.global.tile"
+        ".mbarrier::complete_tx::bytes [$0], [$1, {$3, $4, $5}], [$2];",
+        "r,l,r,r,r,r",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+
+
+@dsl_user_op
+def tma_store_3d(desc_addr, smem_ptr, c0, c1, c2, *, loc=None, ip=None):
+    """One ``cp.async.bulk.tensor.3d`` box, shared to global.
+
+    Stores carry no mbarrier; they are tracked with bulk commit groups, and
+    :func:`tma_store_wait_read` is what releases the source SMEM.
+    """
+    llvm.inline_asm(
+        None,
+        [
+            cutlass.Int64(desc_addr).ir_value(loc=loc, ip=ip),
+            smem_ptr.toint(loc=loc, ip=ip).ir_value(loc=loc, ip=ip),
+            cutlass.Int32(c0).ir_value(loc=loc, ip=ip),
+            cutlass.Int32(c1).ir_value(loc=loc, ip=ip),
+            cutlass.Int32(c2).ir_value(loc=loc, ip=ip),
+        ],
+        "cp.async.bulk.tensor.3d.global.shared::cta.tile.bulk_group"
+        " [$0, {$2, $3, $4}], [$1];",
+        "l,r,r,r,r",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+
+
+@dsl_user_op
+def tma_store_commit_group(*, loc=None, ip=None):
+    """``cp.async.bulk.commit_group``."""
+    llvm.inline_asm(
+        None,
+        [],
+        "cp.async.bulk.commit_group;",
+        "",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+
+
+@dsl_user_op
+def tma_store_wait_read(keep: int, *, loc=None, ip=None):
+    """``cp.async.bulk.wait_group.read``: a source-reuse guarantee.
+
+    It does not claim the store is globally visible, only that the TMA engine
+    has finished *reading* the SMEM it came from -- which is exactly the
+    condition for recycling the slot.
+    """
+    llvm.inline_asm(
+        None,
+        [],
+        f"cp.async.bulk.wait_group.read {keep};",
+        "",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+
+
+# --------------------------------------------------------------------------
+# Section 4: TMA descriptors
+# --------------------------------------------------------------------------
+
+DESCRIPTOR_BYTES = 128
+DESCRIPTOR_ALIGN = 64
+GLOBAL_BASE_ALIGN = 16
+
+#: the design fixes this order; the launch path indexes uploads by it.
+DESCRIPTOR_ROLES = ("q", "k", "g", "v", "out", "state_in", "state_out")
+
+_TMA_DTYPES = {
+    torch.bfloat16: "CU_TENSOR_MAP_DATA_TYPE_BFLOAT16",
+    torch.float32: "CU_TENSOR_MAP_DATA_TYPE_FLOAT32",
+}
+
+
+@dataclass(frozen=True)
+class TensorMapSpec:
+    """One descriptor's complete encoder configuration.
+
+    Only the fields below vary between roles; everything else in the encoder
+    call is fixed by the design and is not representable as a difference.
+    """
+
+    dtype: torch.dtype
+    base: int
+    global_dims: tuple[int, ...]
+    global_stride_bytes: tuple[int, ...]
+    box_dims: tuple[int, ...]
+    #: Present so the cache key and the equality test cover them, even though
+    #: the contract pins all three.
+    element_strides: tuple[int, ...] = (1, 1, 1)
+    interleave: str = "NONE"
+    swizzle: str = "128B"
+    l2_promotion: str = "128B"
+    oob_fill: str = "NONE"
+
+    @property
+    def rank(self) -> int:
+        return len(self.global_dims)
+
+    @property
+    def element_size(self) -> int:
+        return torch.empty(0, dtype=self.dtype).element_size()
+
+    @property
+    def box_bytes(self) -> int:
+        n = 1
+        for b in self.box_dims:
+            n *= b
+        return n * self.element_size
+
+    def key(self, device) -> tuple:
+        """Full cache key: device plus every encoder field."""
+        index = device.index if isinstance(device, torch.device) else device
+        return (
+            index,
+            self.base,
+            self.dtype,
+            self.rank,
+            self.global_dims,
+            self.global_stride_bytes,
+            self.box_dims,
+            self.element_strides,
+            self.interleave,
+            self.swizzle,
+            self.l2_promotion,
+            self.oob_fill,
+        )
+
+    def validate(self) -> None:
+        """Check what the driver will not.
+
+        The driver rejects some of this itself, but with an error that names a
+        parameter index rather than a role, and it accepts a misaligned global
+        base outright -- the corruption from that shows up as wrong numbers in
+        one head, far from here.
+        """
+        if self.rank != 3:
+            raise ValueError(f"TMA rank must be 3, got {self.rank}")
+        if self.base % GLOBAL_BASE_ALIGN:
+            raise ValueError(
+                f"TMA global base must be {GLOBAL_BASE_ALIGN}-byte aligned, "
+                f"got {self.base:#x}"
+            )
+        if any(d <= 0 for d in self.global_dims):
+            raise ValueError(
+                f"TMA global dims must be positive, got {self.global_dims}"
+            )
+        if len(self.global_stride_bytes) != self.rank - 1:
+            raise ValueError(
+                "TMA global strides cover dimensions 1..rank-1 only, got "
+                f"{len(self.global_stride_bytes)} for rank {self.rank}"
+            )
+        for s in self.global_stride_bytes:
+            if s <= 0 or s % GLOBAL_BASE_ALIGN:
+                raise ValueError(
+                    f"TMA global strides must be positive and "
+                    f"{GLOBAL_BASE_ALIGN}-byte aligned, got {self.global_stride_bytes}"
+                )
+        if len(self.box_dims) != self.rank:
+            raise ValueError(f"TMA box must have rank {self.rank}")
+        if any(not 1 <= b <= 256 for b in self.box_dims):
+            raise ValueError(
+                f"TMA box extents must be in [1, 256], got {self.box_dims}"
+            )
+        inner_bytes = self.box_dims[0] * self.element_size
+        if inner_bytes != 128:
+            raise ValueError(
+                f"a 128B-swizzled inner box must be exactly 128 bytes, "
+                f"got {inner_bytes}"
+            )
+        if self.dtype not in _TMA_DTYPES:
+            raise ValueError(f"unsupported TMA element type {self.dtype}")
+
+    def encode(self) -> bytes:
+        """Encode this spec as its 128 raw descriptor bytes."""
+        import cuda.bindings.driver as drv
+
+        self.validate()
+        return _encode_tiled(drv, self)
+
+
+def _encode_tiled(drv, spec: TensorMapSpec) -> bytes:
+    err, tmap = drv.cuTensorMapEncodeTiled(
+        getattr(drv.CUtensorMapDataType, _TMA_DTYPES[spec.dtype]),
+        spec.rank,
+        spec.base,
+        [drv.cuuint64_t(d) for d in spec.global_dims],
+        [drv.cuuint64_t(s) for s in spec.global_stride_bytes],
+        [drv.cuuint32_t(b) for b in spec.box_dims],
+        [drv.cuuint32_t(e) for e in spec.element_strides],
+        drv.CUtensorMapInterleave.CU_TENSOR_MAP_INTERLEAVE_NONE,
+        drv.CUtensorMapSwizzle.CU_TENSOR_MAP_SWIZZLE_128B,
+        drv.CUtensorMapL2promotion.CU_TENSOR_MAP_L2_PROMOTION_L2_128B,
+        drv.CUtensorMapFloatOOBfill.CU_TENSOR_MAP_FLOAT_OOB_FILL_NONE,
+    )
+    if int(err) != 0:
+        raise RuntimeError(f"cuTensorMapEncodeTiled failed: {err}")
+    # cuda-python wraps the descriptor, so take its address via getPtr().
+    return bytes(ctypes.string_at(tmap.getPtr(), DESCRIPTOR_BYTES))
+
+
+# ---------------------------------------------------------------------------
+# Section 6.1: activations
+# ---------------------------------------------------------------------------
+
+
+def activation_spec(t: torch.Tensor, total_tokens: int, heads: int) -> TensorMapSpec:
+    """Key-major ``(128, T_total, H)`` view of contiguous ``[1, T, H, 128]``.
+
+    A 128-byte S128 segment is 64 BF16 or 32 FP32, so the box's inner extent
+    follows the dtype: Q/K/V/out and BF16 ``G`` take two boxes per tile, FP32
+    ``G`` four.
+    """
+    esz = t.element_size()
+    segment = BF16_SEGMENT_ELEMS if esz == 2 else F32_SEGMENT_ELEMS
+    return TensorMapSpec(
+        dtype=t.dtype,
+        base=t.data_ptr(),
+        global_dims=(DK, total_tokens, heads),
+        global_stride_bytes=(heads * DK * esz, DK * esz),
+        box_dims=(segment, BT, 1),
+    )
+
+
+def activation_segments(dtype: torch.dtype) -> int:
+    """Boxes one ``[16, 128]`` tile takes: 2 at BF16, 4 at FP32."""
+    return 2 if dtype is torch.bfloat16 else 4
+
+
+def activation_segment_elems(dtype: torch.dtype) -> int:
+    return BF16_SEGMENT_ELEMS if dtype is torch.bfloat16 else F32_SEGMENT_ELEMS
+
+
+# ---------------------------------------------------------------------------
+# Section 6.2: state boundary
+# ---------------------------------------------------------------------------
+
+
+def state_spec(t: torch.Tensor, sequences: int, heads: int) -> TensorMapSpec:
+    """External ``[N, H, 128, 128]`` state as ``(inner, lines, plane)``.
+
+    The third dimension flattens ``(seq, head)`` into ``plane = seq * H + head``.
+    The second counts 128-byte *lines*, not values: one value spans two BF16 or
+    four FP32 segments, which is exactly the ``state_bf16_idx`` /
+    ``state_f32_window_idx`` row index.  That is what lets the external
+    ``[V, K]`` image land by TMA with no transpose and still be read as
+    ``H[K, V]`` by the MMA.
+
+    One descriptor serves both the prologue load and the epilogue store; the
+    direction is decided by the PTX instruction alone.
+    """
+    esz = t.element_size()
+    if esz == 2:
+        segment, rows_per_value = BF16_SEGMENT_ELEMS, STATE_BF16_ROWS_PER_VALUE
+    else:
+        segment, rows_per_value = F32_SEGMENT_ELEMS, STATE_F32_ROWS_PER_VALUE
+    lines = rows_per_value * DK
+    return TensorMapSpec(
+        dtype=t.dtype,
+        base=t.data_ptr(),
+        global_dims=(segment, lines, sequences * heads),
+        global_stride_bytes=(segment * esz, DK * DK * esz),
+        box_dims=(segment, lines // state_calls(t.dtype), 1),
+    )
+
+
+def state_calls(dtype: torch.dtype) -> int:
+    """TMA calls one state plane takes: 2 at BF16 (16 KiB each), 4 at FP32."""
+    return 2 if dtype is torch.bfloat16 else 4
+
+
+def state_box_rows(dtype: torch.dtype) -> int:
+    """Line rows one state box covers: 128 either way, at 16 KiB per box."""
+    rows_per_value = (
+        STATE_BF16_ROWS_PER_VALUE
+        if dtype is torch.bfloat16
+        else STATE_F32_ROWS_PER_VALUE
+    )
+    return rows_per_value * DK // state_calls(dtype)
+
+
+# ---------------------------------------------------------------------------
+# Upload
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class TensorMapUpload:
+    """A device buffer of descriptors plus each role's address.
+
+    ``storage`` is kept as a strong reference: the addresses below are raw
+    device pointers, and letting the tensor die would leave the kernel reading
+    freed memory on the next launch.
+    """
+
+    storage: torch.Tensor
+    addresses: dict[str, int]
+    specs: dict[str, TensorMapSpec]
+
+    def address(self, role: str) -> int:
+        """Descriptor address of ``role``, or 0 when the role is absent.
+
+        Zero is the kernel's "no descriptor" sentinel: an absent state has no
+        ``fence.proxy.tensormap`` and no copy, both under ``const_expr``
+        branches, so the address is never dereferenced.
+        """
+        return self.addresses.get(role, 0)
+
+
+def build_upload(specs: dict[str, TensorMapSpec], device) -> TensorMapUpload:
+    """Encode, deduplicate and upload the descriptors for one launch.
+
+    Deduplication is by full spec equality, which is exactly the design's
+    rule: ``v is out`` and an exact state in/out alias produce identical specs
+    and share one descriptor, while anything that differs in a single encoder
+    field gets its own.  Direction is still decided by the PTX instruction, so
+    sharing a descriptor between a load and a store is safe.
+    """
+    blobs: list[bytes] = []
+    slot_of: dict[TensorMapSpec, int] = {}
+    role_slot: dict[str, int] = {}
+    for role in DESCRIPTOR_ROLES:
+        spec = specs.get(role)
+        if spec is None:
+            continue
+        slot = slot_of.get(spec)
+        if slot is None:
+            slot = len(blobs)
+            slot_of[spec] = slot
+            blobs.append(spec.encode())
+        role_slot[role] = slot
+
+    if not blobs:
+        empty = torch.empty(0, dtype=torch.uint8, device=device)
+        return TensorMapUpload(storage=empty, addresses={}, specs=dict(specs))
+
+    packed = bytearray()
+    for blob in blobs:
+        packed += blob
+    storage = torch.frombuffer(bytes(packed), dtype=torch.uint8).clone().to(device)
+    base = storage.data_ptr()
+    if base % DESCRIPTOR_ALIGN:
+        raise RuntimeError(
+            f"TMA descriptor storage must be {DESCRIPTOR_ALIGN}-byte aligned, "
+            f"got {base:#x}"
+        )
+    addresses = {
+        role: base + slot * DESCRIPTOR_BYTES for role, slot in role_slot.items()
+    }
+    return TensorMapUpload(storage=storage, addresses=addresses, specs=dict(specs))
+
+
+# --------------------------------------------------------------------------
+# Section 5: the fused device kernel
+# --------------------------------------------------------------------------
+
+#: Barrier arena indices, in 8-byte units from the start of dynamic SMEM.
+_BAR = CONTROL_OFFSET // 8
+BAR_QKG = _BAR + BAR_QKG_READY // 8
+BAR_V = _BAR + BAR_V_READY // 8
+BAR_MAT = _BAR + BAR_MATERIALIZED // 8
+BAR_QKD = _BAR + BAR_QK_DONE // 8
+BAR_AINV = _BAR + BAR_AINV_READY // 8
+BAR_AQ = _BAR + BAR_AQ_READY // 8
+BAR_AK = _BAR + BAR_AK_READY // 8
+BAR_PROJ = _BAR + BAR_PROJECTION_DONE // 8
+BAR_RFORM = _BAR + BAR_R_FORMED // 8
+BAR_OUTR = _BAR + BAR_OUTPUT_READY // 8
+BAR_OUTD = _BAR + BAR_OUTPUT_READ_DONE // 8
+BAR_STATED = _BAR + BAR_STATE_DONE // 8
+BAR_STATEIO = _BAR + BAR_STATE_IO // 8
+
+#: Element strides of one main slot / V stage, by view width.
+SLOT16 = MAIN_SLOT_BYTES // 2  # 8192 BF16
+SLOT32 = MAIN_SLOT_BYTES // 4  # 4096 FP32
+VSTAGE16 = V_STAGE_BYTES // 2  # 2048 BF16
+V_BASE16 = V_STAGE_OFFSET // 2  # 24576
+CTRL32 = CONTROL_OFFSET // 4  # 15360
+
+#: Quadrant slot pairs of an N=16 accumulator: TL, BL, TR, BR (plan Sec. 2.2).
+QUAD_TL = (0, 1)
+QUAD_BL = (2, 3)
+QUAD_TR = (4, 5)
+QUAD_BR = (6, 7)
+DIAGONAL_SLOTS = QUAD_TL + QUAD_BR
+
+
+# ---------------------------------------------------------------------------
+# Small DSL helpers
+# ---------------------------------------------------------------------------
+
+
+@cute.jit
+def vec_at(ptr, idx, elems):
+    """``ptr + idx`` as an ``elems``-long tensor, keeping 16-byte access width.
+
+    ``Pointer.__add__`` drops the alignment attribute for any dynamic offset --
+    even ``ptr + 8 * dyn``, since it does not reason about the multiplier -- and
+    ``autovec_copy`` honours that attribute.  Without the divisibility claim
+    every 8-element BF16 access lowers to eight scalar ones.  Each index
+    reaching this helper is a multiple of ``elems`` by construction, which the
+    layout tests check exhaustively.
+    """
+    return cute.make_tensor(
+        ptr + cute.assume(cutlass.Int32(idx), divby=elems), cute.make_layout(elems)
+    )
+
+
+@cute.jit
+def vec8_bf16(ptr, idx):
+    frag = cute.make_rmem_tensor(8, cutlass.BFloat16)
+    cute.autovec_copy(vec_at(ptr, idx, 8), frag)
+    return frag
+
+
+@cute.jit
+def zero_vec8_bf16(ptr, idx):
+    zeros = cute.make_rmem_tensor(8, cutlass.BFloat16)
+    for i in cutlass.range_constexpr(8):
+        zeros[i] = cutlass.BFloat16(0.0)
+    cute.autovec_copy(zeros, vec_at(ptr, idx, 8))
+
+
+@cute.jit
+def store_vec4_f32(ptr, idx, values, base):
+    """``values[base:base + 4]`` to ``ptr + idx`` as one 16-byte store."""
+    vec = cute.make_rmem_tensor(4, cutlass.Float32)
+    for i in cutlass.range_constexpr(4):
+        vec[i] = values[base + i]
+    cute.autovec_copy(vec, vec_at(ptr, idx, 4))
+
+
+@cute.jit
+def load_vec2_f32(ptr, idx):
+    """Two adjacent FP32 at ``ptr + idx`` as one 8-byte load."""
+    frag = cute.make_rmem_tensor(2, cutlass.Float32)
+    cute.autovec_copy(vec_at(ptr, idx, 2), frag)
+    return frag
+
+
+@cute.jit
+def zero_vec4_f32(ptr, idx):
+    zeros = cute.make_rmem_tensor(4, cutlass.Float32)
+    for i in cutlass.range_constexpr(4):
+        zeros[i] = cutlass.Float32(0.0)
+    cute.autovec_copy(zeros, vec_at(ptr, idx, 4))
+
+
+@cute.jit
+def bf16_round(x):
+    """R16: ``cvt.rn.bf16.f32`` widened back to FP32."""
+    return x.to(cutlass.BFloat16).to(cutlass.Float32)
+
+
+@cute.jit
+def f16_round(x):
+    """R_F16: FP32 -> FP16 -> FP32, the inverse chain's boundary."""
+    return x.to(cutlass.Float16).to(cutlass.Float32)
+
+
+@cute.jit
+def zero4():
+    z = cutlass.Float32(0.0)
+    return (z, z, z, z)
+
+
+@cute.jit
+def zero8():
+    z = cutlass.Float32(0.0)
+    return (z, z, z, z, z, z, z, z)
+
+
+@cute.jit
+def mma_n8(a, b, c):
+    """One native ``m16n8k16``: A is four registers, B two, C four."""
+    return mma_m16n8k16_bf16(a[0], a[1], a[2], a[3], b[0], b[1], c[0], c[1], c[2], c[3])
+
+
+@cute.jit
+def mma_16x16(a, b, c):
+    """One logical ``m16n16k16``: the N=8 low half, then the high half.
+
+    the design fixes that order and forbids any rounding between the two
+    halves or inside the K reduction.
+    """
+    n0 = mma_m16n8k16_bf16(a[0], a[1], a[2], a[3], b[0], b[1], c[0], c[1], c[2], c[3])
+    n1 = mma_m16n8k16_bf16(a[0], a[1], a[2], a[3], b[2], b[3], c[4], c[5], c[6], c[7])
+    return (n0[0], n0[1], n0[2], n0[3], n1[0], n1[1], n1[2], n1[3])
+
+
+@cute.jit
+def mma_16x16_f16(a, b, c):
+    """:func:`mma_16x16` with FP16 operands: the twelve inverse MMAs."""
+    n0 = mma_m16n8k16_f16(a[0], a[1], a[2], a[3], b[0], b[1], c[0], c[1], c[2], c[3])
+    n1 = mma_m16n8k16_f16(a[0], a[1], a[2], a[3], b[2], b[3], c[4], c[5], c[6], c[7])
+    return (n0[0], n0[1], n0[2], n0[3], n1[0], n1[1], n1[2], n1[3])
+
+
+@cute.jit
+def a_to_b(f):
+    """A-layout -> B-layout of the same matrix; register order unchanged."""
+    return (
+        movmatrix_b16(f[0]),
+        movmatrix_b16(f[1]),
+        movmatrix_b16(f[2]),
+        movmatrix_b16(f[3]),
+    )
+
+
+@cute.jit
+def a_to_at(f):
+    """A-layout -> A-layout of the transpose; registers 1 and 2 swap.
+
+    The one place a register swap is allowed: it is a matrix
+    transpose, not a relabelling.
+    """
+    return (
+        movmatrix_b16(f[0]),
+        movmatrix_b16(f[2]),
+        movmatrix_b16(f[1]),
+        movmatrix_b16(f[3]),
+    )
+
+
+@cute.jit
+def pack_a_bf16(c):
+    """N=16 FP32 accumulator -> BF16 A-layout fragment."""
+    return (
+        pack_bf16x2(c[0], c[1]),
+        pack_bf16x2(c[2], c[3]),
+        pack_bf16x2(c[4], c[5]),
+        pack_bf16x2(c[6], c[7]),
+    )
+
+
+@cute.jit
+def pack_a_f16(c):
+    """N=16 FP32 accumulator -> FP16 A-layout fragment (``pack16``)."""
+    return (
+        pack_f16x2(c[0], c[1]),
+        pack_f16x2(c[2], c[3]),
+        pack_f16x2(c[4], c[5]),
+        pack_f16x2(c[6], c[7]),
+    )
+
+
+@cute.jit
+def warp_arrive(mbar, lane):
+    """One arrival per warp on a warp-counted barrier.
+
+    ``mbarrier.arrive`` counts per thread, so 32 lanes arriving would overshoot
+    a count of 4 or 8.  The warp synchronization before the elected arrival is
+    what makes the other 31 lanes' shared-memory stores visible to whoever
+    observes it; the arrival itself carries release semantics at CTA scope.
+    """
+    cute.arch.sync_warp()
+    if lane == 0:
+        cute.arch.mbarrier_arrive(mbar)
+
+
+@cute.jit
+def clamp_rows(token_end, token_base):
+    """``min(16, token_end - token_base)``."""
+    v = token_end - token_base
+    if v > BT:
+        v = cutlass.Int32(BT)
+    return v
+
+
+@cute.jit
+def prepare_rendezvous():
+    """The prepare group's named barrier, ``bar.sync 1, 128``.
+
+    W0-W3 are the only group that uses it and they materialize one chunk at a
+    time, so all four of a chunk's rendezvous points reuse the same id in
+    sequence rather than needing four mbarriers.
+    """
+    cute.arch.barrier(
+        barrier_id=PREPARE_BARRIER_ID,
+        number_of_threads=PREPARE_BARRIER_THREADS,
+    )
+
+
+# ---------------------------------------------------------------------------
+# W15: blockwise inverse
+# ---------------------------------------------------------------------------
+
+
+@cute.jit
+def blockwise_inverse(l_acc, lane):
+    """``(I + L)^-1`` from a strict-lower FP32 accumulator, as a BF16 A fragment.
+
+    Twelve native FP16 MMAs.  ``l_acc`` holds BF16-rounded strict-lower values
+    in the N=16 accumulator layout; the result is ``Ainv`` in A layout with an
+    exactly zero top-right quadrant.
+
+    Both update steps must be a product against an exact-zero C followed by a
+    *separate* FP32 scalar add of the re-rounded seed.  Passing the seed as the
+    MMA's C operand saves an instruction and changes the result, so plan
+    Section 2.2 forbids it.  ``B0 = I - D`` likewise comes from the widened
+    BF16 diagonal of ``L``, not from the already-FP16-rounded ``D``.
+    """
+    zero_r = cutlass.Int32(0)
+
+    # D is the block *diagonal* of L -- the two 8x8 blocks -- and A21hat its
+    # single lower-left block.  Keeping the other quadrants exactly zero is
+    # what makes the chain's nilpotency argument hold.
+    d_f16 = (
+        pack_f16x2(l_acc[0], l_acc[1]),
+        zero_r,
+        zero_r,
+        pack_f16x2(l_acc[6], l_acc[7]),
+    )
+    a21_f16 = (zero_r, pack_f16x2(l_acc[2], l_acc[3]), zero_r, zero_r)
+
+    d2_f16 = pack_a_f16(mma_16x16_f16(d_f16, a_to_b(d_f16), zero8()))
+
+    b0 = [cutlass.Float32(0.0) for _ in range(8)]
+    for s in cutlass.range_constexpr(8):
+        if cutlass.const_expr(s in DIAGONAL_SLOTS):
+            row, col = mma_c16_coord(lane, s)
+            eye = cutlass.Float32(0.0)
+            if row == col:
+                eye = cutlass.Float32(1.0)
+            b0[s] = f16_round(eye - l_acc[s])
+
+    b1_prod = mma_16x16_f16(pack_a_f16(tuple(b0)), a_to_b(d2_f16), zero8())
+    b1 = [b0[s] + b1_prod[s] for s in range(8)]
+
+    d4_f16 = pack_a_f16(mma_16x16_f16(d2_f16, a_to_b(d2_f16), zero8()))
+
+    binv_prod = mma_16x16_f16(pack_a_f16(tuple(b1)), a_to_b(d4_f16), zero8())
+    binv = [f16_round(b1[s]) + binv_prod[s] for s in range(8)]
+
+    # Binv is block diagonal by construction, so a diagonal-only fragment is
+    # exact rather than a truncation.
+    binv_packed = pack_a_f16(tuple(binv))
+    binv_f16 = (binv_packed[0], zero_r, zero_r, binv_packed[3])
+
+    t1 = mma_16x16_f16(binv_f16, a_to_b(a21_f16), zero8())
+    # T1 = Binv @ A21hat is lower-left only.  Negating before the FP16 round is
+    # exact either way; doing it here keeps the pack to one instruction.
+    t1n_f16 = (zero_r, pack_f16x2(-t1[2], -t1[3]), zero_r, zero_r)
+    x21 = mma_16x16_f16(t1n_f16, a_to_b(binv_f16), zero8())
+
+    return (
+        pack_bf16x2(binv[0], binv[1]),
+        pack_bf16x2(x21[2], x21[3]),
+        zero_r,
+        pack_bf16x2(binv[6], binv[7]),
+    )
+
+
+# ---------------------------------------------------------------------------
+# W0-W3: prepare
+# ---------------------------------------------------------------------------
+
+
+@cute.jit
+def clear_tail_rows(p_q, p_k, p_g_raw, valid_rows, tidx, G_FP32: cutlass.Constexpr):
+    """Zero the invalid rows of the raw stages.
+
+    TMA only zero-fills coordinates outside the *tensor*, and a short chunk
+    sits mid-tensor: the rows past ``valid_rows`` hold the next sequence's
+    tokens, so the copy faithfully loaded real data there.  The task map
+    matches the loads' 16-byte width so the writes stay one vector wide.
+    """
+    for rep in cutlass.range_constexpr(2):
+        task = tidx + rep * PREPARE_BARRIER_THREADS
+        row = task // BT
+        d0 = (task - row * BT) * 8
+        if row >= valid_rows:
+            idx = raw_bf16_s128(row, d0)
+            zero_vec8_bf16(p_q, idx)
+            zero_vec8_bf16(p_k, idx)
+
+    if cutlass.const_expr(G_FP32):
+        for rep in cutlass.range_constexpr(4):
+            task = tidx + rep * PREPARE_BARRIER_THREADS
+            row = task // 32
+            d0 = (task - row * 32) * 4
+            if row >= valid_rows:
+                zero_vec4_f32(p_g_raw, raw_f32_s128(row, d0))
+    else:
+        for rep in cutlass.range_constexpr(2):
+            task = tidx + rep * PREPARE_BARRIER_THREADS
+            row = task // BT
+            d0 = (task - row * BT) * 8
+            if row >= valid_rows:
+                zero_vec8_bf16(p_g_raw, raw_bf16_s128(row, d0))
+
+
+@cute.jit
+def gate_column(
+    smem_e,
+    smem_g_bf16,
+    dim,
+    dt_value,
+    a_val,
+    gate_scale_log2,
+    valid_rows,
+    G_FP32: cutlass.Constexpr,
+    SAFE_GATE: cutlass.Constexpr,
+):
+    """The 16 gate values of one key dimension, as ``E = exp2(clamped prefix)``.
+
+    Three things here are contract, not style: the
+    invalid-row mask selects an exact ``+0.0`` *increment* -- zeroing raw ``G``
+    is not enough, because ``dt_bias`` still produces a non-zero increment; the
+    scan uses the pairwise bracketing rather than a plain running sum; and the
+    clamp happens after the complete scan and before ``exp2``.
+    """
+    regs = [cutlass.Float32(0.0) for _ in range(BT)]
+    for r in cutlass.range_constexpr(BT):
+        if cutlass.const_expr(G_FP32):
+            raw = smem_e[raw_f32_s128(r, dim)]
+        else:
+            raw = cutlass.Float32(smem_g_bf16[raw_bf16_s128(r, dim)])
+        inc = cutlass.Float32(0.0)
+        if r < valid_rows:
+            x = raw + dt_value
+            if cutlass.const_expr(SAFE_GATE):
+                half = cutlass.Float32(0.5)
+                sig = (
+                    cutlass.Float32(cute.math.tanh(a_val * x * half, fastmath=True))
+                    * half
+                    + half
+                )
+                inc = gate_scale_log2 * sig
+            else:
+                sp = cutlass.Float32(0.0)
+                if x > cutlass.Float32(SOFTPLUS_CUT):
+                    sp = x * cutlass.Float32(LOG2_E)
+                else:
+                    sp = cutlass.Float32(
+                        cute.math.log2(
+                            cutlass.Float32(1.0)
+                            + cutlass.Float32(cute.math.exp(x, fastmath=True)),
+                            fastmath=True,
+                        )
+                    )
+                inc = -a_val * sp
+        regs[r] = inc
+
+    acc = cutlass.Float32(0.0)
+    for p in cutlass.range_constexpr(BT // 2):
+        g0 = regs[2 * p]
+        g1 = regs[2 * p + 1]
+        first = acc + g0
+        second = acc + (g0 + g1)
+        regs[2 * p] = first
+        regs[2 * p + 1] = second
+        acc = second
+
+    for r in cutlass.range_constexpr(BT):
+        pv = regs[r]
+        if pv < cutlass.Float32(PREFIX_FLOOR):
+            pv = cutlass.Float32(PREFIX_FLOOR)
+        regs[r] = cutlass.Float32(cute.math.exp2(pv, fastmath=True))
+    return regs
+
+
+@cute.jit
+def row_sum_8(value):
+    """Reduce the eight lanes that cooperate on one token row.
+
+    the design pins the butterfly offsets to 4 -> 2 -> 1 and each step to
+    a single FP32 add.  A tree or vector reduction reassociates, which is a
+    different number.
+    """
+    value = value + cutlass.Float32(cute.arch.shuffle_sync_bfly(value, offset=4))
+    value = value + cutlass.Float32(cute.arch.shuffle_sync_bfly(value, offset=2))
+    return value + cutlass.Float32(cute.arch.shuffle_sync_bfly(value, offset=1))
+
+
+@cute.jit
+def prepare_head(
+    c,
+    p16,
+    p32,
+    p64,
+    tidx,
+    dim,
+    dt_value,
+    a_val,
+    gate_scale_log2,
+    token_start,
+    token_end,
+    G_FP32: cutlass.Constexpr,
+    SAFE_GATE: cutlass.Constexpr,
+):
+    """Chunk ``c``'s gate column: wait for raw Q/K/G, clear its tail, scan it.
+
+    This is the stage the pipeline moves.  It is everything from ``qkg_ready``
+    up to and including ``gate_column`` -- 51 MUFU, the longest dependent chain
+    in prepare -- and it depends on nothing the previous chunk produces, which
+    is what makes it hoistable ahead of the previous chunk's ``ainv_ready``
+    wait.  It returns the whole column because ``e_col`` is the only thing the
+    rest of the chunk needs from it; ``gt_owned`` is its last element.
+    """
+    s = main_slot(c)
+    pr = ready_parity(c)
+    s16 = s * SLOT16
+    s32 = s * SLOT32
+    valid_rows = clamp_rows(token_end, token_start + c * BT)
+
+    p_q = p16 + s16
+    p_k = p16 + (s16 + SLOT_K // 2)
+    p_g_bf16 = p16 + (s16 + SLOT_G_LO // 2)
+    p_e = p32 + (s32 + SLOT_G_LO // 4)
+
+    smem_e = cute.make_tensor(p_e, cute.make_layout(BT * DK))
+    smem_g_bf16 = cute.make_tensor(p_g_bf16, cute.make_layout(BT * DK))
+    p_g_raw = p_e if cutlass.const_expr(G_FP32) else p_g_bf16
+
+    cute.arch.mbarrier_wait(p64 + (BAR_QKG + s), pr)
+    if valid_rows < BT:
+        clear_tail_rows(p_q, p_k, p_g_raw, valid_rows, tidx, G_FP32)
+    # Rendezvous 1: raw operands are readable only once every tail row of
+    # every stage has been cleared.
+    prepare_rendezvous()
+
+    return gate_column(
+        smem_e,
+        smem_g_bf16,
+        dim,
+        dt_value,
+        a_val,
+        gate_scale_log2,
+        valid_rows,
+        G_FP32,
+        SAFE_GATE,
+    )
+
+
+@cute.jit
+def prepare_body(
+    c,
+    e_col,
+    p16,
+    p32,
+    p64,
+    lane,
+    p,
+    dim,
+    norm_token,
+    lane_in_row,
+    q_reg,
+    packed_scale,
+    token_start,
+    token_end,
+):
+    """Publish E, normalize, and materialize Qd/Kd/Ki; hand Kr to the tail.
+
+    Everything here belongs to chunk ``c`` alone and ends at
+    ``materialized``.  ``kr_b`` is returned rather than stored because Kr is
+    the one factor that never reaches SMEM -- it stays in the B layout it was
+    built in until the tail multiplies it by AinvBeta.
+    """
+    s = main_slot(c)
+    s16 = s * SLOT16
+    s32 = s * SLOT32
+    valid_rows = clamp_rows(token_end, token_start + c * BT)
+
+    p_q = p16 + s16
+    p_k = p16 + (s16 + SLOT_K // 2)
+    p_ki = p16 + (s16 + SLOT_KI // 2)
+    p_e = p32 + (s32 + SLOT_G_LO // 4)
+    smem_gt = cute.make_tensor(p32 + (s32 + SLOT_GTOTAL // 4), cute.make_layout(DK))
+    scratch = cute.make_tensor(
+        p32 + (CTRL32 + s * (SCRATCH_SLOT_BYTES // 4)), cute.make_layout(32)
+    )
+    gt_owned = e_col[BT - 1]
+
+    # Rendezvous 2: one lane's E store can land on a raw element another
+    # lane has not read yet.  This used to be skipped for FP32 G, where the
+    # E map and the raw map coincided and each lane rewrote exactly what it
+    # read.  E is transposed now, so the two maps no longer coincide for
+    # either width and the barrier is unconditional -- one `bar.sync 1, 128`
+    # per chunk, bought for twenty fewer shared accesses per warp.
+    prepare_rendezvous()
+    for grp in cutlass.range_constexpr(E_GROUPS):
+        store_vec4_f32(
+            p_e,
+            gate_e_f32(dim, E_GROUP_ELEMS * grp),
+            e_col,
+            E_GROUP_ELEMS * grp,
+        )
+
+    # --- norm: four token rows per warp, eight lanes per row ---------------
+    q_ss = cutlass.Float32(0.0)
+    k_ss = cutlass.Float32(0.0)
+    for h in cutlass.range_constexpr(2):
+        base = raw_bf16_s128(norm_token, 64 * h + 8 * lane_in_row)
+        fq = vec8_bf16(p_q, base)
+        fk = vec8_bf16(p_k, base)
+        for i in cutlass.range_constexpr(8):
+            qv = cutlass.Float32(fq[i])
+            kv = cutlass.Float32(fk[i])
+            q_ss = q_ss + qv * qv
+            k_ss = k_ss + kv * kv
+    q_ss = row_sum_8(q_ss)
+    k_ss = row_sum_8(k_ss)
+    # All eight lanes hold the reduced value; only the row's lane 0 stores.
+    if lane_in_row == 0:
+        q_inv = cutlass.Float32(0.0)
+        k_inv = cutlass.Float32(0.0)
+        if norm_token < valid_rows:
+            qf = q_ss
+            if qf < cutlass.Float32(NORM_FLOOR):
+                qf = cutlass.Float32(NORM_FLOOR)
+            kf = k_ss
+            if kf < cutlass.Float32(NORM_FLOOR):
+                kf = cutlass.Float32(NORM_FLOOR)
+            q_inv = cutlass.Float32(cute.math.rsqrt(qf, fastmath=True))
+            k_inv = cutlass.Float32(cute.math.rsqrt(kf, fastmath=True))
+        scratch[norm_token] = q_inv
+        scratch[BT + norm_token] = k_inv
+
+    # Rendezvous 3: E and the norm scratch are published together.  The
+    # norm's row owners are not the dimension owners that read them back,
+    # which is exactly why q_inv/k_inv need shared scratch at all.
+    prepare_rendezvous()
+
+    # --- capture E at the materializer's own coordinates -------------------
+    e_cap = [cutlass.Float32(0.0) for _ in range(16)]
+    for j in cutlass.range_constexpr(2):
+        for nb in cutlass.range_constexpr(2):
+            for r in cutlass.range_constexpr(2):
+                t0, _t1, key = materialize_coords(p, lane, j, nb, r)
+                idx = ((j * 2 + nb) * 2 + r) * 2
+                # ``t0`` is even and ``t1 = t0 + 1``, so the pair never
+                # straddles a group boundary and one load covers both.
+                pair = load_vec2_f32(p_e, gate_e_f32(key, t0))
+                e_cap[idx] = pair[0]
+                e_cap[idx + 1] = pair[1]
+    # t0/t1 depend only on (q, r), so eight scalar reads cover all tiles.
+    q_inv_t = [
+        scratch[2 * q_reg],
+        scratch[2 * q_reg + 1],
+        scratch[2 * q_reg + 8],
+        scratch[2 * q_reg + 9],
+    ]
+    k_inv_t = [
+        scratch[BT + 2 * q_reg],
+        scratch[BT + 2 * q_reg + 1],
+        scratch[BT + 2 * q_reg + 8],
+        scratch[BT + 2 * q_reg + 9],
+    ]
+
+    # Rendezvous 4: every prepare warp now holds its whole E set in
+    # registers, so E's bytes may be overwritten by Ki and factor records.
+    prepare_rendezvous()
+    smem_gt[dim] = gt_owned
+
+    kr_b = [cutlass.Int32(0) for _ in range(8)]
+    for j in cutlass.range_constexpr(2):
+        kd_b = [cutlass.Int32(0) for _ in range(4)]
+        ki_b = [cutlass.Int32(0) for _ in range(4)]
+        qd_b = [cutlass.Int32(0) for _ in range(4)]
+        # The whole [16, 16] tile in one instruction per factor: the
+        # materializer's coordinates *are* the native B fragment, which is
+        # what `.trans` delivers over a [token, key] image.  Both tiles are
+        # read before this iteration's factor stores overwrite them, and
+        # the two j values address disjoint key halves, so hoisting the
+        # loads above the stores is safe for j = 1 as well.
+        k_raw = ldmatrix_x4_trans(p_k + materialize_b_ptr(p, lane, j))
+        q_raw = ldmatrix_x4_trans(p_q + materialize_b_ptr(p, lane, j))
+        for nb in cutlass.range_constexpr(2):
+            for r in cutlass.range_constexpr(2):
+                # Only the key is still needed as a coordinate -- the two
+                # token rows are now implicit in the fragment the tile load
+                # delivered -- but it comes from the same map, because the
+                # shuffle below depends on it agreeing with the gate's
+                # ownership.
+                key = materialize_coords(p, lane, j, nb, r)[2]
+                idx = ((j * 2 + nb) * 2 + r) * 2
+                e0 = e_cap[idx]
+                e1 = e_cap[idx + 1]
+                qi0 = q_inv_t[2 * r]
+                qi1 = q_inv_t[2 * r + 1]
+                ki0 = k_inv_t[2 * r]
+                ki1 = k_inv_t[2 * r + 1]
+
+                # `cvt.f32.bf16` is the same widening the scalar load's
+                # Float32() did, and it is exact, so the products below are
+                # the same FP32 numbers as before.
+                kv0, kv1 = unpack_bf16x2(k_raw[2 * nb + r])
+                kn0 = kv0 * ki0
+                kn1 = kv1 * ki1
+                e16 = pack_bf16x2(e0, e1)
+                kd_b[2 * nb + r] = mul_bf16x2(pack_bf16x2(kn0, kn1), e16)
+                ki_b[2 * nb + r] = pack_bf16x2(
+                    kn0 * rcp_approx_ftz(e0), kn1 * rcp_approx_ftz(e1)
+                )
+                qv0, qv1 = unpack_bf16x2(q_raw[2 * nb + r])
+                qn16 = pack_bf16x2(qv0 * qi0, qv1 * qi1)
+                qd_b[2 * nb + r] = mul_bf16x2(mul_bf16x2(qn16, e16), packed_scale)
+
+                # GTotal of ``key`` belongs to its gate owner, which is a
+                # different lane than the one materializing this element.
+                gt16 = bf16_round(
+                    cutlass.Float32(cute.arch.shuffle_sync(gt_owned, key - 32 * p))
+                )
+                kr_b[4 * j + 2 * nb + r] = mul_bf16x2(
+                    ki_b[2 * nb + r], pack_bf16x2(gt16, gt16)
+                )
+
+        # B layout -> A layout rides the store: `stmatrix.x4.trans`
+        # transposes each 8x8 tile with the register order unchanged, which
+        # is what the three `a_to_b` calls used to spend twelve movmatrix
+        # doing.  Kr alone stays in the B layout it was built in and never
+        # reaches SMEM.
+        store_at = factor_a_ptr(lane, 2 * p + j)
+        stmatrix_x4_trans(p_q + store_at, qd_b[0], qd_b[1], qd_b[2], qd_b[3])
+        stmatrix_x4_trans(p_k + store_at, kd_b[0], kd_b[1], kd_b[2], kd_b[3])
+        stmatrix_x4_trans(p_ki + store_at, ki_b[0], ki_b[1], ki_b[2], ki_b[3])
+
+    warp_arrive(p64 + (BAR_MAT + s), lane)
+    return kr_b
+
+
+@cute.jit
+def prepare_tail(c, kr_b, p16, p64, lane, p):
+    """``Ak.T = AinvBeta.T * Kr``, once W15 publishes the inverse.
+
+    The wait here is the 7.5% window the pipeline exists to fill: whatever the
+    caller schedules between ``prepare_body`` and this call runs while W15 is
+    still inverting.
+    """
+    s = main_slot(c)
+    pr = ready_parity(c)
+    p_ki = p16 + (s * SLOT16 + SLOT_KI // 2)
+    p_ainvb = p16 + (s * SLOT16 + SLOT_AINV_BETA // 2)
+
+    cute.arch.mbarrier_wait(p64 + (BAR_AINV + s), pr)
+    ainvb_t = a_to_at(ldmatrix_x4(p_ainvb + pairwise_a_ptr(lane)))
+    for tile in cutlass.range_constexpr(2):
+        acc = mma_16x16(
+            ainvb_t,
+            (
+                kr_b[4 * tile],
+                kr_b[4 * tile + 1],
+                kr_b[4 * tile + 2],
+                kr_b[4 * tile + 3],
+            ),
+            zero8(),
+        )
+        frag = pack_a_bf16(acc)
+        if cutlass.const_expr(tile == 0):
+            # Ki dies for W13 at qk_done and for W15 at ainv_ready; both
+            # are required before the first byte of Ak.T lands on it.  This
+            # is usually already satisfied, but the wait may not be elided
+            # on that assumption.
+            cute.arch.mbarrier_wait(p64 + (BAR_QKD + s), pr)
+        stmatrix_x4(
+            p_ki + ak_store_ptr(lane, 32 * p + BT * tile),
+            frag[0],
+            frag[1],
+            frag[2],
+            frag[3],
+        )
+    warp_arrive(p64 + (BAR_AK + s), lane)
+
+
+@cute.jit
+def prepare_role(
+    ga_log,
+    gdt,
+    p16,
+    p32,
+    p64,
+    tidx,
+    lane,
+    warp_id,
+    head,
+    token_start,
+    token_end,
+    num_chunks,
+    scale,
+    gate_scale_log2,
+    G_FP32: cutlass.Constexpr,
+    SAFE_GATE: cutlass.Constexpr,
+):
+    """Gate, normalize, materialize Qd/Kd/Ki, retain Kr, then publish Ak.T.
+
+    A prepare warp uses three different ownerships inside one chunk, and they
+    do not compose into "warp p owns 32 dimensions": the gate is one dimension
+    per lane, the norm is one token row per eight lanes, and the materializer
+    works in the MMA **B** fragment's coordinates.  Conflating them is the
+    easiest way to get this stage subtly wrong.
+
+    The chunk is split into ``prepare_head`` / ``prepare_body`` /
+    ``prepare_tail`` so the head can be software-pipelined one chunk ahead of
+    the tail's ``ainv_ready`` wait; see the comment on the loop below.
+    """
+    p = warp_id
+    dim = gate_owner_dim(p, lane)
+    dt_value = cutlass.Float32(gdt[head * DK + dim])
+
+    # ``a = exp2(A_log * log2e)``, computed once by lane 0 and broadcast.
+    a_seed = cutlass.Float32(0.0)
+    if lane == 0:
+        a_seed = cutlass.Float32(
+            cute.math.exp2(
+                cutlass.Float32(ga_log[head]) * cutlass.Float32(LOG2_E),
+                fastmath=True,
+            )
+        )
+    a_val = cutlass.Float32(cute.arch.shuffle_sync(a_seed, 0))
+
+    s16_scale = bf16_round(scale)
+    packed_scale = pack_bf16x2(s16_scale, s16_scale)
+
+    norm_token = norm_row(p, lane)
+    lane_in_row = lane & 7
+    q_reg = lane & 3
+
+    # --- the software pipeline -------------------------------------------
+    #
+    # ``head(c + 1)`` is issued before ``tail(c)``, so the gate's exp2 chain
+    # for the next chunk runs while W15 is still inverting this one.  The
+    # shape is the textbook one -- prologue, ``n - 1`` steady-state
+    # iterations, epilogue -- and deliberately contains no runtime predicate:
+    # an earlier attempt guarded the hoisted head with
+    # ``if c + 1 < num_chunks``, and that dynamic ``if`` was the entire source
+    # of its trouble.  Drawing the loop boundary here needs none.
+    #
+    # ``e_col`` (16 FP32) is the only value carried across the iteration
+    # boundary, and ``kr_b`` (8 packed pairs) the only one live across the
+    # hoisted head.  Both fit: ~82 registers are free at the ``ainv_ready``
+    # wait, because Qd/Kd/Ki have just gone to SMEM.
+    #
+    # The guard is required and is not the predicate that caused the earlier
+    # trouble.  A packed varlen batch may contain a zero-length sequence, and
+    # such a block runs with ``num_chunks == 0``.  Every other role spells its
+    # work as ``for c in range(num_chunks)``, which is simply empty then; this
+    # role no longer does, because the prologue sits outside the loop.  An
+    # unguarded prologue waits on ``qkg_ready`` for a chunk W12's own empty
+    # loop will never produce, and W0-W3 hang there forever.  ``last`` would
+    # also be -1 and index a slot that does not exist.
+    #
+    # Unlike ``if c + 1 < num_chunks`` inside the loop, this carries nothing
+    # across the branch: the whole pipeline is on one side and the block has
+    # no work at all on the other.
+    if num_chunks > 0:
+        e_col = prepare_head(
+            cutlass.Int32(0),
+            p16,
+            p32,
+            p64,
+            tidx,
+            dim,
+            dt_value,
+            a_val,
+            gate_scale_log2,
+            token_start,
+            token_end,
+            G_FP32,
+            SAFE_GATE,
+        )
+        for c in range(num_chunks - 1):
+            kr_b = prepare_body(
+                c,
+                e_col,
+                p16,
+                p32,
+                p64,
+                lane,
+                p,
+                dim,
+                norm_token,
+                lane_in_row,
+                q_reg,
+                packed_scale,
+                token_start,
+                token_end,
+            )
+            e_col = prepare_head(
+                c + 1,
+                p16,
+                p32,
+                p64,
+                tidx,
+                dim,
+                dt_value,
+                a_val,
+                gate_scale_log2,
+                token_start,
+                token_end,
+                G_FP32,
+                SAFE_GATE,
+            )
+            prepare_tail(c, kr_b, p16, p64, lane, p)
+
+        last = num_chunks - 1
+        kr_b = prepare_body(
+            last,
+            e_col,
+            p16,
+            p32,
+            p64,
+            lane,
+            p,
+            dim,
+            norm_token,
+            lane_in_row,
+            q_reg,
+            packed_scale,
+            token_start,
+            token_end,
+        )
+        prepare_tail(last, kr_b, p16, p64, lane, p)
+
+
+# ---------------------------------------------------------------------------
+# W12: TMA producer
+# ---------------------------------------------------------------------------
+
+
+@cute.jit
+def tma_role(
+    p16,
+    p32,
+    p64,
+    lane,
+    head,
+    token_start,
+    num_chunks,
+    desc_q,
+    desc_k,
+    desc_g,
+    desc_v,
+    G_FP32: cutlass.Constexpr,
+):
+    """Prefetch Q/K/G and V three chunks ahead, against independent barriers.
+
+    Generation 0's reuse parity is 1, which passes immediately on a freshly
+    initialized phase-0 barrier, so this is one uniform loop from ``c = 0``
+    with no prologue special case: the first three iterations fall straight
+    through and only ``c >= 3`` is throttled by the release of slot ``c - 3``.
+
+    All three release conditions are required and none subsumes another:
+    ``r_formed`` frees the V stage, ``output_read_done`` the output half of the
+    main slot, and ``state_done`` the Ak.T and GTotal records.
+
+    Q/K/G and V share this issue point but not their barrier: making V's
+    visibility depend on ``qkg_ready`` would stall the residual behind factors
+    it does not need.
+    """
+    qkg_tx = QKG_TX_BYTES_G_FP32 if cutlass.const_expr(G_FP32) else QKG_TX_BYTES_G_BF16
+    for c in range(num_chunks):
+        s = main_slot(c)
+        rp = reuse_parity(c)
+        if lane == 0:
+            cute.arch.mbarrier_wait(p64 + (BAR_RFORM + s), rp)
+            cute.arch.mbarrier_wait(p64 + (BAR_OUTD + s), rp)
+            cute.arch.mbarrier_wait(p64 + (BAR_STATED + s), rp)
+
+            token_base = token_start + c * BT
+            s16 = s * SLOT16
+            p_q = p16 + s16
+            p_k = p16 + (s16 + SLOT_K // 2)
+            mbar = p64 + (BAR_QKG + s)
+            cute.arch.mbarrier_arrive_and_expect_tx(mbar, qkg_tx)
+            for seg in cutlass.range_constexpr(2):
+                c0 = seg * BF16_SEGMENT_ELEMS
+                off = seg * BF16_SEGMENT_STRIDE
+                tma_load_3d(p_q + off, desc_q, mbar, c0, token_base, head)
+                tma_load_3d(p_k + off, desc_k, mbar, c0, token_base, head)
+            if cutlass.const_expr(G_FP32):
+                p_g = p32 + (s * SLOT32 + SLOT_G_LO // 4)
+                for seg in cutlass.range_constexpr(4):
+                    tma_load_3d(
+                        p_g + seg * F32_SEGMENT_STRIDE,
+                        desc_g,
+                        mbar,
+                        seg * F32_SEGMENT_ELEMS,
+                        token_base,
+                        head,
+                    )
+            else:
+                p_g = p16 + (s16 + SLOT_G_LO // 2)
+                for seg in cutlass.range_constexpr(2):
+                    tma_load_3d(
+                        p_g + seg * BF16_SEGMENT_STRIDE,
+                        desc_g,
+                        mbar,
+                        seg * BF16_SEGMENT_ELEMS,
+                        token_base,
+                        head,
+                    )
+
+            vbar = p64 + (BAR_V + s)
+            p_v = p16 + (V_BASE16 + s * VSTAGE16)
+            cute.arch.mbarrier_arrive_and_expect_tx(vbar, V_TX_BYTES)
+            for seg in cutlass.range_constexpr(2):
+                tma_load_3d(
+                    p_v + seg * BF16_SEGMENT_STRIDE,
+                    desc_v,
+                    vbar,
+                    seg * BF16_SEGMENT_ELEMS,
+                    token_base,
+                    head,
+                )
+
+
+# ---------------------------------------------------------------------------
+# W13: QK and Aq
+# ---------------------------------------------------------------------------
+
+
+@cute.jit
+def qk_role(p16, p64, lane, num_chunks):
+    """Causal ``QK = tril(Qd @ Ki.T)``, then ``Aq = QK @ AinvBeta``.
+
+    ``QK_A`` stays in registers across the wait for ``ainv_ready``; staging it
+    through SMEM would need a region the arena does not have.  ``qk_done`` is
+    released as soon as ``Ki`` has been read, long before ``Aq`` exists,
+    because W0-W3 need it to start overwriting ``Ki`` with ``Ak.T``.
+    """
+    for c in range(num_chunks):
+        s = main_slot(c)
+        pr = ready_parity(c)
+        s16 = s * SLOT16
+        p_qd = p16 + s16
+        p_ki = p16 + (s16 + SLOT_KI // 2)
+        p_ainvb = p16 + (s16 + SLOT_AINV_BETA // 2)
+        p_aq = p16 + (s16 + SLOT_AQ // 2)
+
+        cute.arch.mbarrier_wait(p64 + (BAR_MAT + s), pr)
+        acc = zero8()
+        for kb in cutlass.range_constexpr(KEY_BLOCKS):
+            acc = mma_16x16(
+                ldmatrix_x4(p_qd + factor_a_ptr(lane, kb)),
+                ldmatrix_x4(p_ki + ki_b_ptr(lane, kb)),
+                acc,
+            )
+        masked = [cutlass.Float32(0.0) for _ in range(8)]
+        for slot in cutlass.range_constexpr(8):
+            row, col = mma_c16_coord(lane, slot)
+            v = cutlass.Float32(0.0)
+            if row >= col:
+                v = acc[slot]
+            masked[slot] = bf16_round(v)
+        qk_a = pack_a_bf16(tuple(masked))
+        warp_arrive(p64 + (BAR_QKD + s), lane)
+
+        cute.arch.mbarrier_wait(p64 + (BAR_AINV + s), pr)
+        ainvb_b = a_to_b(ldmatrix_x4(p_ainvb + pairwise_a_ptr(lane)))
+        frag = pack_a_bf16(mma_16x16(qk_a, ainvb_b, zero8()))
+        stmatrix_x4(p_aq + pairwise_store_ptr(lane), frag[0], frag[1], frag[2], frag[3])
+        warp_arrive(p64 + (BAR_AQ + s), lane)
+
+
+# ---------------------------------------------------------------------------
+# W15: beta, KK and the blockwise inverse
+# ---------------------------------------------------------------------------
+
+
+@cute.jit
+def inverse_role(
+    gbeta, p16, p64, lane, head, heads, token_start, token_end, num_chunks
+):
+    """Activate beta, form ``L``, invert ``I + L`` and publish ``AinvBeta``.
+
+    Beta gets no shared memory: each lane holds at most one activated FP32
+    value and every row or column access is a ``shuffle_sync``.  An invalid
+    token's activated beta must be an exact ``+0.0`` -- it scales a whole
+    strict-lower row, so anything else leaks the tail into ``Ainv``.
+    """
+    for c in range(num_chunks):
+        s = main_slot(c)
+        pr = ready_parity(c)
+        s16 = s * SLOT16
+        p_kd = p16 + (s16 + SLOT_KD // 2)
+        p_ki = p16 + (s16 + SLOT_KI // 2)
+        p_ainvb = p16 + (s16 + SLOT_AINV_BETA // 2)
+        token_base = token_start + c * BT
+        valid_rows = clamp_rows(token_end, token_base)
+
+        # Issued before the wait: this is a strided column read out of [T, H]
+        # that cannot coalesce, so it should be in flight during the KK loop.
+        beta_owned = cutlass.Float32(0.0)
+        if lane < BT:
+            if lane < valid_rows:
+                logit = cutlass.Float32(
+                    gbeta[beta_global_index(token_base + lane, head, heads)]
+                )
+                half = cutlass.Float32(0.5)
+                beta_owned = (
+                    cutlass.Float32(cute.math.tanh(logit * half, fastmath=True)) * half
+                    + half
+                )
+
+        cute.arch.mbarrier_wait(p64 + (BAR_MAT + s), pr)
+        acc = zero8()
+        for kb in cutlass.range_constexpr(KEY_BLOCKS):
+            acc = mma_16x16(
+                ldmatrix_x4(p_kd + factor_a_ptr(lane, kb)),
+                ldmatrix_x4(p_ki + ki_b_ptr(lane, kb)),
+                acc,
+            )
+
+        # A lane's eight accumulator slots occupy only two distinct rows, so
+        # two shuffles cover the whole strict-lower scale.
+        g_reg = lane >> 2
+        q_reg = lane & 3
+        beta_lo_row = cutlass.Float32(cute.arch.shuffle_sync(beta_owned, g_reg))
+        beta_hi_row = cutlass.Float32(cute.arch.shuffle_sync(beta_owned, g_reg + 8))
+        l_acc = [cutlass.Float32(0.0) for _ in range(8)]
+        for slot in cutlass.range_constexpr(8):
+            row, col = mma_c16_coord(lane, slot)
+            brow = beta_lo_row if cutlass.const_expr((slot & 3) < 2) else beta_hi_row
+            v = cutlass.Float32(0.0)
+            if row > col:
+                v = bf16_round(acc[slot] * brow)
+            l_acc[slot] = v
+
+        ainv_a = blockwise_inverse(tuple(l_acc), lane)
+
+        beta_lo = pack_bf16x2(
+            cutlass.Float32(cute.arch.shuffle_sync(beta_owned, 2 * q_reg)),
+            cutlass.Float32(cute.arch.shuffle_sync(beta_owned, 2 * q_reg + 1)),
+        )
+        beta_hi = pack_bf16x2(
+            cutlass.Float32(cute.arch.shuffle_sync(beta_owned, 2 * q_reg + 8)),
+            cutlass.Float32(cute.arch.shuffle_sync(beta_owned, 2 * q_reg + 9)),
+        )
+        stmatrix_x4(
+            p_ainvb + pairwise_store_ptr(lane),
+            mul_bf16x2(ainv_a[0], beta_lo),
+            mul_bf16x2(ainv_a[1], beta_lo),
+            mul_bf16x2(ainv_a[2], beta_hi),
+            mul_bf16x2(ainv_a[3], beta_hi),
+        )
+        warp_arrive(p64 + (BAR_AINV + s), lane)
+
+
+# ---------------------------------------------------------------------------
+# W14: output store
+# ---------------------------------------------------------------------------
+
+
+@cute.jit
+def io_role(
+    gout, p16, p64, lane, head, heads, token_start, token_end, num_chunks, desc_out
+):
+    """Publish each chunk's output, then release the slot.
+
+    A partial chunk must not go out by TMA: the box is 16 rows wide, and in a
+    packed sequence the rows past ``valid_rows`` belong to the *next* sequence,
+    so a full-tile store would overwrite output another CTA owns.
+
+    ``output_read_done`` is released only after the store has *read* its source
+    -- ``wait_group.read``, not merely ``commit`` -- because that is the
+    condition for W12 to overwrite the slot.
+    """
+    for c in range(num_chunks):
+        s = main_slot(c)
+        pr = ready_parity(c)
+        p_out = p16 + s * SLOT16
+        token_base = token_start + c * BT
+        valid_rows = clamp_rows(token_end, token_base)
+
+        cute.arch.mbarrier_wait(p64 + (BAR_OUTR + s), pr)
+        if valid_rows == BT:
+            cute.arch.fence_view_async_shared()
+            cute.arch.sync_warp()
+            if lane == 0:
+                for seg in cutlass.range_constexpr(2):
+                    tma_store_3d(
+                        desc_out,
+                        p_out + seg * BF16_SEGMENT_STRIDE,
+                        seg * BF16_SEGMENT_ELEMS,
+                        token_base,
+                        head,
+                    )
+                tma_store_commit_group()
+                tma_store_wait_read(0)
+        else:
+            for rep in cutlass.range_constexpr(8):
+                task = lane + rep * 32
+                if task < valid_rows * BT:
+                    row = task // BT
+                    d0 = (task - row * BT) * 8
+                    frag = vec8_bf16(p_out, raw_bf16_s128(row, d0))
+                    cute.autovec_copy(
+                        frag,
+                        vec_at(
+                            gout.iterator,
+                            out_global_index(token_base + row, head, heads, d0),
+                            8,
+                        ),
+                    )
+            cute.arch.sync_warp()
+        warp_arrive(p64 + (BAR_OUTD + s), lane)
+
+
+# ---------------------------------------------------------------------------
+# W4-W11: recurrence
+# ---------------------------------------------------------------------------
+
+
+@cute.jit
+def h_branch(p_akt, smem_gt, h32, h16, res_a, lane, bar_ak, bar_state, parity):
+    """``H.T = H.T Diag(GTotal) + R.T @ Ak.T``, in place, tile by tile.
+
+    The transposed form: the accumulator's rows are values and its columns are
+    keys, so ``pack_bf16x2`` alone leaves H16 in the A-fragment order the
+    projection wants and no ``movmatrix`` is needed anywhere.
+
+    GTotal now indexes the *column* axis, so a lane needs the two adjacent keys
+    of each tile rather than two rows shared across both value blocks -- 32
+    values per lane instead of 16.  They are loaded as scalars, not as a pair:
+    the live range is what matters here, not the instruction count, and a
+    16-byte or 8-byte load imposes a register-pair alignment this warp has
+    already been measured unable to afford.
+
+    The blocking wait is the real acquire: the first-ready probe only *chose*
+    this branch, and a broadcast predicate gives the other 31 lanes no
+    visibility of the Ak.T stores they are about to read.
+    """
+    cute.arch.mbarrier_wait(bar_ak, parity)
+    # GTotal cooperatively: one fully coalesced scalar load per 32 keys covers
+    # four tiles for the whole warp -- four wavefronts per chunk instead of one
+    # per tile -- and a shuffle hands each lane the two it holds.  The source
+    # register is warp-uniform (there is only one), which is what makes the
+    # exchange expressible; only the source lane varies.
+    gt_grp = [cutlass.Float32(0.0) for _ in range(GTOTAL_GROUP)]
+    for i in cutlass.range_constexpr(GTOTAL_GROUP):
+        gt_grp[i] = cutlass.Float32(smem_gt[gtotal_group_key(lane, i)])
+    for j in cutlass.range_constexpr(KEY_BLOCKS):
+        ak_b = ldmatrix_x4_trans(p_akt + ak_b_ptr(lane, j))
+        for nb in cutlass.range_constexpr(2):
+            kt = 2 * j + nb
+            grp = kt // GTOTAL_GROUP
+            gt0 = cutlass.Float32(
+                cute.arch.shuffle_sync(gt_grp[grp], gtotal_shuffle_source(lane, kt, 0))
+            )
+            gt1 = cutlass.Float32(
+                cute.arch.shuffle_sync(gt_grp[grp], gtotal_shuffle_source(lane, kt, 1))
+            )
+            i0 = h32t_idx(kt, 0)
+            acc = mma_n8(
+                res_a,
+                (ak_b[2 * nb], ak_b[2 * nb + 1]),
+                (
+                    gt0 * h32[i0],
+                    gt1 * h32[i0 + 1],
+                    gt0 * h32[i0 + 2],
+                    gt1 * h32[i0 + 3],
+                ),
+            )
+            for r in cutlass.range_constexpr(4):
+                h32[i0 + r] = acc[r]
+            j0 = h16t_idx(kt, 0)
+            h16[j0] = pack_bf16x2(acc[0], acc[1])
+            h16[j0 + 1] = pack_bf16x2(acc[2], acc[3])
+    warp_arrive(bar_state, lane)
+
+
+@cute.jit
+def o_branch(
+    p_out, p_aq, o_acc, res_a, lane, v_base, bar_aq, bar_proj, bar_out, parity
+):
+    """``O.T = H.T @ Qd.T + R.T @ Aq.T``, into the projection's own FP32 bank.
+
+    ``projection_done`` is waited on here not because ``Aq`` needs it, but
+    because the output overwrites ``Qd``: it transitively proves every
+    recurrence warp and W13 have finished reading that region.
+
+    The store is ``.trans``: the accumulator is ``[value, token]`` while the
+    output image is token-major, and the transpose rides the store for free.
+    """
+    cute.arch.mbarrier_wait(bar_aq, parity)
+    cute.arch.mbarrier_wait(bar_proj, parity)
+    aq_b = ldmatrix_x4(p_aq + pairwise_b_ptr(lane))
+    for nb in cutlass.range_constexpr(2):
+        acc = mma_n8(res_a, (aq_b[2 * nb], aq_b[2 * nb + 1]), o_acc[nb])
+        stmatrix_x2_trans(
+            p_out + vo_x2t_ptr(lane, v_base, nb),
+            pack_bf16x2(acc[0], acc[1]),
+            pack_bf16x2(acc[2], acc[3]),
+        )
+    warp_arrive(bar_out, lane)
+
+
+@cute.jit
+def recurrence_role(
+    p16, p32, p64, h32, h16, lane, rec_id, token_start, token_end, num_chunks
+):
+    """Projection, residual, then the O and H branches in first-ready order.
+
+    Transposed throughout: the accumulators are ``[value, token]`` and H is the
+    MMA's A operand, so no C-to-B conversion happens anywhere in this warp.
+    """
+    v_base = rec_id * WARP_VALUES
+    q = lane & 3
+
+    for c in range(num_chunks):
+        s = main_slot(c)
+        pr = ready_parity(c)
+        s16 = s * SLOT16
+        s32 = s * SLOT32
+        p_out = p16 + s16
+        p_qd = p_out
+        p_kd = p16 + (s16 + SLOT_KD // 2)
+        p_akt = p16 + (s16 + SLOT_AKT // 2)
+        p_aq = p16 + (s16 + SLOT_AQ // 2)
+        p_v = p16 + (V_BASE16 + s * VSTAGE16)
+        smem_gt = cute.make_tensor(p32 + (s32 + SLOT_GTOTAL // 4), cute.make_layout(DK))
+        token_base = token_start + c * BT
+        valid_rows = clamp_rows(token_end, token_base)
+
+        cute.arch.mbarrier_wait(p64 + (BAR_MAT + s), pr)
+
+        # --- projection: H.T is the A operand, straight out of H16 ----------
+        # `h_a_reg` is a selection, not a conversion: key block j's A fragment
+        # is h16[4j..4j+3] already.  `fresh_b32` computes nothing -- it keeps
+        # the MMA's operand off the persistent state registers, which is worth
+        # 8 percentage points; see its docstring.
+        x_acc = [zero4(), zero4()]
+        o_acc = [zero4(), zero4()]
+        for j in cutlass.range_constexpr(KEY_BLOCKS):
+            kd_b = ldmatrix_x4(p_kd + ki_b_ptr(lane, j))
+            qd_b = ldmatrix_x4(p_qd + ki_b_ptr(lane, j))
+            h_a = (
+                fresh_b32(h16[h_a_reg(j, 0)]),
+                fresh_b32(h16[h_a_reg(j, 1)]),
+                fresh_b32(h16[h_a_reg(j, 2)]),
+                fresh_b32(h16[h_a_reg(j, 3)]),
+            )
+            for nb in cutlass.range_constexpr(2):
+                x_acc[nb] = mma_n8(h_a, (kd_b[2 * nb], kd_b[2 * nb + 1]), x_acc[nb])
+                o_acc[nb] = mma_n8(h_a, (qd_b[2 * nb], qd_b[2 * nb + 1]), o_acc[nb])
+        warp_arrive(p64 + (BAR_PROJ + s), lane)
+
+        # --- residual -------------------------------------------------------
+        # A packed register now holds one value and *two adjacent tokens*, so
+        # the tail is no longer one predicate per register: the two halves can
+        # straddle `valid_rows`.  The mask is applied after the subtract and
+        # leaves an exact packed zero on an invalid token, which is what the
+        # contract requires -- V is not tail-cleared in prepare, so its rows
+        # past `valid_rows` hold the next sequence's tokens.
+        cute.arch.mbarrier_wait(p64 + (BAR_V + s), pr)
+        res_a = [cutlass.Int32(0) for _ in range(4)]
+        for nb in cutlass.range_constexpr(2):
+            v_lo, v_hi = ldmatrix_x2_trans(p_v + vo_x2t_ptr(lane, v_base, nb))
+            t0 = 8 * nb + 2 * q
+            mask = cutlass.Int32(0)
+            if t0 < valid_rows:
+                mask = mask | cutlass.Int32(0x0000FFFF)
+            if t0 + 1 < valid_rows:
+                mask = mask | cutlass.Int32(0xFFFF0000)
+            res_a[2 * nb] = (
+                cutlass.Int32(sub_bf16x2(v_lo, pack_bf16x2(x_acc[nb][0], x_acc[nb][1])))
+                & mask
+            )
+            res_a[2 * nb + 1] = (
+                cutlass.Int32(sub_bf16x2(v_hi, pack_bf16x2(x_acc[nb][2], x_acc[nb][3])))
+                & mask
+            )
+        warp_arrive(p64 + (BAR_RFORM + s), lane)
+
+        # --- first-ready branch selection -------------
+        # The two branches share no data, so whichever factor lands first can
+        # run.  Only lane 0 probes, with TEST rather than TRY -- a try-wait
+        # would suspend the warp for up to 10 ms and turn a scheduling hint
+        # into a stall -- and the result is broadcast so the branch stays
+        # warp-uniform.  H wins a tie: it is the next chunk's projection
+        # dependency, while O can still overlap W14's store.
+        bar_ak = p64 + (BAR_AK + s)
+        bar_aq = p64 + (BAR_AQ + s)
+        bar_proj = p64 + (BAR_PROJ + s)
+        sel = cutlass.Int32(0)
+        while sel == 0:
+            flags = cutlass.Int32(0)
+            if lane == 0:
+                if mbarrier_test_wait_parity(bar_ak, pr):
+                    flags = flags + 1
+                if mbarrier_test_wait_parity(bar_aq, pr):
+                    if mbarrier_test_wait_parity(bar_proj, pr):
+                        flags = flags + 2
+            flags = cutlass.Int32(cute.arch.shuffle_sync(flags, 0))
+            if (flags & 1) != 0:
+                sel = cutlass.Int32(1)
+            elif (flags & 2) != 0:
+                sel = cutlass.Int32(2)
+
+        bar_state = p64 + (BAR_STATED + s)
+        bar_out = p64 + (BAR_OUTR + s)
+        if sel == 1:
+            h_branch(p_akt, smem_gt, h32, h16, res_a, lane, bar_ak, bar_state, pr)
+            o_branch(
+                p_out,
+                p_aq,
+                o_acc,
+                res_a,
+                lane,
+                v_base,
+                bar_aq,
+                bar_proj,
+                bar_out,
+                pr,
+            )
+        else:
+            o_branch(
+                p_out,
+                p_aq,
+                o_acc,
+                res_a,
+                lane,
+                v_base,
+                bar_aq,
+                bar_proj,
+                bar_out,
+                pr,
+            )
+            h_branch(p_akt, smem_gt, h32, h16, res_a, lane, bar_ak, bar_state, pr)
+
+
+# ---------------------------------------------------------------------------
+# State boundary
+#
+# The prologue and epilogue are mirrored into the recurrence and service
+# halves.  Each pair issues the SAME number of ``cta_barrier`` calls -- 1 / 1 /
+# 5 for an absent / BF16 / FP32 initial state and 1 / 2 / 9 for the final one
+# -- which is what makes a CTA-wide barrier legal from two divergent program
+# points.  Changing one half without the other deadlocks the CTA.
+# ---------------------------------------------------------------------------
+
+
+@cute.jit
+def state_window_view(p32):
+    """Main slot 0 as a flat FP32 window: 4096 elements, exactly 16 KiB."""
+    return cute.make_tensor(p32, cute.make_layout(SLOT32))
+
+
+@cute.jit
+def load_state_window(h32, h16, p32, lane, local_v_base):
+    """Read one FP32 boundary window into H32, then derive H16.
+
+    The FP32 image has no matrix-copy path -- ``ldmatrix`` is 16-bit only -- so
+    each lane addresses its four accumulator elements individually.
+    """
+    window = state_window_view(p32)
+    for kt in cutlass.range_constexpr(HT_TILES):
+        i0 = h32t_idx(kt, 0)
+        for r in cutlass.range_constexpr(4):
+            k, v_local = h32t_coord(lane, kt, r, local_v_base)
+            h32[i0 + r] = window[state_f32_window_idx(v_local, k)]
+        j0 = h16t_idx(kt, 0)
+        h16[j0] = pack_bf16x2(h32[i0], h32[i0 + 1])
+        h16[j0 + 1] = pack_bf16x2(h32[i0 + 2], h32[i0 + 3])
+
+
+@cute.jit
+def store_state_window(h32, p32, lane, local_v_base):
+    """Write H32 back into one FP32 boundary window."""
+    window = state_window_view(p32)
+    for kt in cutlass.range_constexpr(HT_TILES):
+        i0 = h32t_idx(kt, 0)
+        for r in cutlass.range_constexpr(4):
+            k, v_local = h32t_coord(lane, kt, r, local_v_base)
+            window[state_f32_window_idx(v_local, k)] = h32[i0 + r]
+
+
+@cute.jit
+def state_prologue_recurrence(
+    h32,
+    h16,
+    p16,
+    p32,
+    p64,
+    warp_id,
+    lane,
+    v_base,
+    HAS_STATE_IN: cutlass.Constexpr,
+    STATE_FP32: cutlass.Constexpr,
+):
+    """Bring the external state into registers (step 3 of the design)."""
+    if cutlass.const_expr(not HAS_STATE_IN):
+        for i in cutlass.range_constexpr(64):
+            h32[i] = cutlass.Float32(0.0)
+        for i in cutlass.range_constexpr(32):
+            h16[i] = cutlass.Int32(0)
+    elif cutlass.const_expr(STATE_FP32):
+        # Four 32-value windows through main slot 0, one at a time: two
+        # recurrence warps own each, and no two windows are ever live together.
+        for w in cutlass.range_constexpr(STATE_F32_WINDOWS):
+            cute.arch.mbarrier_wait(p64 + BAR_STATEIO, w & 1)
+            if warp_id == RECURRENCE_WARP0 + 2 * w:
+                load_state_window(h32, h16, p32, lane, 0)
+            if warp_id == RECURRENCE_WARP0 + 2 * w + 1:
+                load_state_window(h32, h16, p32, lane, WARP_VALUES)
+            cute.arch.barrier()
+    else:
+        # One 32 KiB transaction over main slots 0 and 1; ``state_bf16_idx``
+        # spans both because they are adjacent.
+        cute.arch.mbarrier_wait(p64 + BAR_STATEIO, 0)
+        for kt in cutlass.range_constexpr(HT_TILES):
+            c0, c1 = ldmatrix_x2(p16 + state_x2t_ptr(lane, kt, v_base))
+            j0 = h16t_idx(kt, 0)
+            h16[j0] = c0
+            h16[j0 + 1] = c1
+            f0, f1 = unpack_bf16x2(c0)
+            f2, f3 = unpack_bf16x2(c1)
+            i0 = h32t_idx(kt, 0)
+            h32[i0] = f0
+            h32[i0 + 1] = f1
+            h32[i0 + 2] = f2
+            h32[i0 + 3] = f3
+    cute.arch.barrier()
+
+
+@cute.jit
+def state_prologue_service(
+    p16,
+    p32,
+    p64,
+    warp_id,
+    lane,
+    state_plane,
+    desc_state_in,
+    HAS_STATE_IN: cutlass.Constexpr,
+    STATE_FP32: cutlass.Constexpr,
+):
+    """The service half of :func:`state_prologue_recurrence`: W14 issues the TMA."""
+    if cutlass.const_expr(not HAS_STATE_IN):
+        pass
+    elif cutlass.const_expr(STATE_FP32):
+        for w in cutlass.range_constexpr(STATE_F32_WINDOWS):
+            if warp_id == IO_WARP:
+                if lane == 0:
+                    cute.arch.mbarrier_arrive_and_expect_tx(
+                        p64 + BAR_STATEIO, STATE_F32_WINDOW_TX_BYTES
+                    )
+                    tma_load_3d(
+                        p32,
+                        desc_state_in,
+                        p64 + BAR_STATEIO,
+                        0,
+                        128 * w,
+                        state_plane,
+                    )
+            cute.arch.mbarrier_wait(p64 + BAR_STATEIO, w & 1)
+            cute.arch.barrier()
+    else:
+        if warp_id == IO_WARP:
+            if lane == 0:
+                cute.arch.mbarrier_arrive_and_expect_tx(
+                    p64 + BAR_STATEIO, STATE_BF16_TX_BYTES
+                )
+                for h in cutlass.range_constexpr(2):
+                    tma_load_3d(
+                        p16 + h * SLOT16,
+                        desc_state_in,
+                        p64 + BAR_STATEIO,
+                        0,
+                        128 * h,
+                        state_plane,
+                    )
+        cute.arch.mbarrier_wait(p64 + BAR_STATEIO, 0)
+    cute.arch.barrier()
+
+
+@cute.jit
+def state_epilogue_recurrence(
+    h32,
+    h16,
+    p16,
+    p32,
+    warp_id,
+    lane,
+    v_base,
+    HAS_STATE_OUT: cutlass.Constexpr,
+    STATE_FP32: cutlass.Constexpr,
+):
+    """Stage the register state back out."""
+    cute.arch.barrier()
+    if cutlass.const_expr(HAS_STATE_OUT):
+        if cutlass.const_expr(STATE_FP32):
+            for w in cutlass.range_constexpr(STATE_F32_WINDOWS):
+                if warp_id == RECURRENCE_WARP0 + 2 * w:
+                    store_state_window(h32, p32, lane, 0)
+                if warp_id == RECURRENCE_WARP0 + 2 * w + 1:
+                    store_state_window(h32, p32, lane, WARP_VALUES)
+                cute.arch.barrier()
+                cute.arch.barrier()
+        else:
+            for kt in cutlass.range_constexpr(HT_TILES):
+                j0 = h16t_idx(kt, 0)
+                stmatrix_x2(
+                    p16 + state_x2t_ptr(lane, kt, v_base),
+                    h16[j0],
+                    h16[j0 + 1],
+                )
+            cute.arch.barrier()
+
+
+@cute.jit
+def state_epilogue_service(
+    p16,
+    p32,
+    warp_id,
+    lane,
+    state_plane,
+    desc_state_out,
+    HAS_STATE_OUT: cutlass.Constexpr,
+    STATE_FP32: cutlass.Constexpr,
+):
+    """The service half of :func:`state_epilogue_recurrence`.
+
+    The CTA barrier before the fence is what orders the recurrence warps'
+    ordinary stores; the fence then publishes them to the async proxy for the
+    TMA engine, which reads through a different one.
+    """
+    cute.arch.barrier()
+    if cutlass.const_expr(HAS_STATE_OUT):
+        if cutlass.const_expr(STATE_FP32):
+            for w in cutlass.range_constexpr(STATE_F32_WINDOWS):
+                cute.arch.barrier()
+                if warp_id == IO_WARP:
+                    cute.arch.fence_view_async_shared()
+                    cute.arch.sync_warp()
+                    if lane == 0:
+                        tma_store_3d(desc_state_out, p32, 0, 128 * w, state_plane)
+                        tma_store_commit_group()
+                        # The next window overwrites main slot 0, so the source
+                        # read has to be complete before the barrier below.
+                        tma_store_wait_read(0)
+                cute.arch.barrier()
+        else:
+            cute.arch.barrier()
+            if warp_id == IO_WARP:
+                cute.arch.fence_view_async_shared()
+                cute.arch.sync_warp()
+                if lane == 0:
+                    for h in cutlass.range_constexpr(2):
+                        tma_store_3d(
+                            desc_state_out,
+                            p16 + h * SLOT16,
+                            0,
+                            128 * h,
+                            state_plane,
+                        )
+                    tma_store_commit_group()
+                    tma_store_wait_read(0)
+
+
+# ---------------------------------------------------------------------------
+# Kernel
+# ---------------------------------------------------------------------------
+
+
+@cute.kernel
+def fused_kda_kernel(
+    gout: cute.Tensor,
+    gbeta: cute.Tensor,
+    ga_log: cute.Tensor,
+    gdt: cute.Tensor,
+    gcu_seqlens: cute.Tensor,
+    desc_q: cutlass.Int64,
+    desc_k: cutlass.Int64,
+    desc_g: cutlass.Int64,
+    desc_v: cutlass.Int64,
+    desc_out: cutlass.Int64,
+    desc_state_in: cutlass.Int64,
+    desc_state_out: cutlass.Int64,
+    scale: cutlass.Float32,
+    gate_scale_log2: cutlass.Float32,
+    heads: cutlass.Int32,
+    G_FP32: cutlass.Constexpr,
+    SAFE_GATE: cutlass.Constexpr,
+    HAS_STATE_IN: cutlass.Constexpr,
+    HAS_STATE_OUT: cutlass.Constexpr,
+    STATE_FP32: cutlass.Constexpr,
+) -> None:
+    tidx, _, _ = cute.arch.thread_idx()
+    seq, head, _ = cute.arch.block_idx()
+    warp_id = cute.arch.make_warp_uniform(cute.arch.warp_idx())
+    lane = tidx % 32
+
+    # --- fixed arena ------------------------------------
+    # One allocation of exactly DYNAMIC_SMEM_BYTES, so the launch parameter is
+    # the plan's number and every region base is a compile-time constant.
+    alloc = cutlass.utils.SmemAllocator()
+    p_base = alloc.allocate(DYNAMIC_SMEM_BYTES, 1024)
+    p16 = cute.recast_ptr(p_base, dtype=cutlass.BFloat16)
+    p32 = cute.recast_ptr(p_base, dtype=cutlass.Float32)
+    p64 = cute.recast_ptr(p_base, dtype=cutlass.Int64)
+
+    if warp_id == TMA_WARP:
+        if lane == 0:
+            for s in cutlass.range_constexpr(MAIN_SLOTS):
+                cute.arch.mbarrier_init(p64 + (BAR_QKG + s), ARRIVALS_TX)
+                cute.arch.mbarrier_init(p64 + (BAR_V + s), ARRIVALS_TX)
+                cute.arch.mbarrier_init(p64 + (BAR_MAT + s), ARRIVALS_PREPARE)
+                cute.arch.mbarrier_init(p64 + (BAR_QKD + s), ARRIVALS_SINGLE)
+                cute.arch.mbarrier_init(p64 + (BAR_AINV + s), ARRIVALS_SINGLE)
+                cute.arch.mbarrier_init(p64 + (BAR_AQ + s), ARRIVALS_SINGLE)
+                cute.arch.mbarrier_init(p64 + (BAR_AK + s), ARRIVALS_PREPARE)
+                cute.arch.mbarrier_init(p64 + (BAR_PROJ + s), ARRIVALS_RECURRENCE)
+                cute.arch.mbarrier_init(p64 + (BAR_RFORM + s), ARRIVALS_RECURRENCE)
+                cute.arch.mbarrier_init(p64 + (BAR_OUTR + s), ARRIVALS_RECURRENCE)
+                cute.arch.mbarrier_init(p64 + (BAR_OUTD + s), ARRIVALS_SINGLE)
+                cute.arch.mbarrier_init(p64 + (BAR_STATED + s), ARRIVALS_RECURRENCE)
+            cute.arch.mbarrier_init(p64 + BAR_STATEIO, ARRIVALS_TX)
+            cute.arch.mbarrier_init_fence()
+            fence_tensormap_acquire(desc_q)
+            fence_tensormap_acquire(desc_k)
+            fence_tensormap_acquire(desc_g)
+            fence_tensormap_acquire(desc_v)
+            fence_tensormap_acquire(desc_out)
+            if cutlass.const_expr(HAS_STATE_IN):
+                fence_tensormap_acquire(desc_state_in)
+            if cutlass.const_expr(HAS_STATE_OUT):
+                fence_tensormap_acquire(desc_state_out)
+    # Nothing may arrive on or wait for a barrier before its state is published.
+    cute.arch.barrier()
+
+    # --- warpgroup register redistribution --------------
+    # setmaxnreg is a warpgroup instruction: all four warps of a group must
+    # execute the same action with the same immediate at the same point.  The
+    # decreases have to land -- and be observed CTA-wide -- before any increase,
+    # or the pool is momentarily oversubscribed.
+    if warp_id < PREPARE_WARPS:
+        setmaxnreg_dec(WG0_MAXNREG)
+    if warp_id >= TMA_WARP:
+        setmaxnreg_dec(WG3_MAXNREG)
+    cute.arch.barrier()
+    if warp_id >= RECURRENCE_WARP0:
+        if warp_id < TMA_WARP:
+            setmaxnreg_inc(WG1_MAXNREG)
+    cute.arch.barrier()
+
+    # --- sequence coordinates ---------------------------
+    token_start = cutlass.Int32(gcu_seqlens[seq])
+    token_end = cutlass.Int32(gcu_seqlens[seq + 1])
+    num_chunks = (token_end - token_start + (BT - 1)) // BT
+    state_plane = seq * heads + head
+
+    # A zero-length sequence enters no chunk loop but still runs the state
+    # prologue and epilogue, so its final state is its initial one.
+    if warp_id >= RECURRENCE_WARP0 and warp_id < TMA_WARP:
+        rec_id = warp_id - RECURRENCE_WARP0
+        v_base = rec_id * WARP_VALUES
+        # Declared here, not in the common region: their 96 values would
+        # otherwise be live across the service warps' code and ptxas could not
+        # prove the 64-register budget for WG3.
+        h32 = cute.make_rmem_tensor(64, cutlass.Float32)
+        h16 = cute.make_rmem_tensor(32, cutlass.Int32)
+        state_prologue_recurrence(
+            h32,
+            h16,
+            p16,
+            p32,
+            p64,
+            warp_id,
+            lane,
+            v_base,
+            HAS_STATE_IN,
+            STATE_FP32,
+        )
+        recurrence_role(
+            p16,
+            p32,
+            p64,
+            h32,
+            h16,
+            lane,
+            rec_id,
+            token_start,
+            token_end,
+            num_chunks,
+        )
+        state_epilogue_recurrence(
+            h32, h16, p16, p32, warp_id, lane, v_base, HAS_STATE_OUT, STATE_FP32
+        )
+    else:
+        state_prologue_service(
+            p16,
+            p32,
+            p64,
+            warp_id,
+            lane,
+            state_plane,
+            desc_state_in,
+            HAS_STATE_IN,
+            STATE_FP32,
+        )
+        if warp_id < PREPARE_WARPS:
+            prepare_role(
+                ga_log,
+                gdt,
+                p16,
+                p32,
+                p64,
+                tidx,
+                lane,
+                warp_id,
+                head,
+                token_start,
+                token_end,
+                num_chunks,
+                scale,
+                gate_scale_log2,
+                G_FP32,
+                SAFE_GATE,
+            )
+        elif warp_id == TMA_WARP:
+            tma_role(
+                p16,
+                p32,
+                p64,
+                lane,
+                head,
+                token_start,
+                num_chunks,
+                desc_q,
+                desc_k,
+                desc_g,
+                desc_v,
+                G_FP32,
+            )
+        elif warp_id == QK_WARP:
+            qk_role(p16, p64, lane, num_chunks)
+        elif warp_id == IO_WARP:
+            io_role(
+                gout,
+                p16,
+                p64,
+                lane,
+                head,
+                heads,
+                token_start,
+                token_end,
+                num_chunks,
+                desc_out,
+            )
+        else:
+            inverse_role(
+                gbeta,
+                p16,
+                p64,
+                lane,
+                head,
+                heads,
+                token_start,
+                token_end,
+                num_chunks,
+            )
+        state_epilogue_service(
+            p16,
+            p32,
+            warp_id,
+            lane,
+            state_plane,
+            desc_state_out,
+            HAS_STATE_OUT,
+            STATE_FP32,
+        )
+
+
+# --------------------------------------------------------------------------
+# Section 6: compiled entry, descriptor cache and launch
+# --------------------------------------------------------------------------
+
+#: Devices already proven to be CC 12.0.  ``get_device_capability`` is a driver
+
+
+@dataclass(frozen=True)
+class KernelKey:
+    """the design's ordered compile key.  Fields may not be merged."""
+
+    device: int
+    device_cc: tuple[int, int]
+    code_target: str
+    g_dtype: torch.dtype
+    safe_gate: bool
+    state_dtype: torch.dtype | None
+    has_initial_state: bool
+    has_final_state: bool
+    input_mode: str
+
+    def __post_init__(self) -> None:
+        has_state = self.has_initial_state or self.has_final_state
+        if has_state != (self.state_dtype is not None):
+            raise ValueError(
+                "state_dtype must be present exactly when a state is present: "
+                f"initial={self.has_initial_state}, final={self.has_final_state}, "
+                f"dtype={self.state_dtype}"
+            )
+        if self.input_mode not in ("fixed", "packed"):
+            raise ValueError(f"unknown input mode {self.input_mode!r}")
+
+
+_KERNEL_CACHE: dict[KernelKey, object] = {}
+_DESCRIPTOR_CACHE = BoundedDeviceCache("kda-descriptors")
+
+
+def clear_kernel_caches() -> None:
+    """Drop the compile and descriptor caches.
+
+    Not the whole variant: :func:`clear_caches` below does that.  This is the
+    device-side half, which a test that wants a cold compile needs on its own.
+    """
+    _KERNEL_CACHE.clear()
+    _DESCRIPTOR_CACHE.clear()
+
+
+def kernel_cache_size() -> int:
+    return len(_KERNEL_CACHE)
+
+
+def descriptor_cache_stats(device):
+    return _DESCRIPTOR_CACHE.stats(device)
+
+
+def build_descriptors(
+    *,
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor,
+    out: torch.Tensor,
+    initial_state: torch.Tensor | None,
+    final_state: torch.Tensor | None,
+    total_tokens: int,
+    sequences: int,
+    heads: int,
+) -> TensorMapUpload:
+    """Encode (or reuse) the seven The descriptors."""
+    specs: dict[str, TensorMapSpec] = {
+        "q": activation_spec(q, total_tokens, heads),
+        "k": activation_spec(k, total_tokens, heads),
+        "g": activation_spec(g, total_tokens, heads),
+        "v": activation_spec(v, total_tokens, heads),
+        "out": activation_spec(out, total_tokens, heads),
+    }
+    if initial_state is not None:
+        specs["state_in"] = state_spec(initial_state, sequences, heads)
+    if final_state is not None:
+        specs["state_out"] = state_spec(final_state, sequences, heads)
+
+    device = q.device
+    key = tuple(
+        (role, specs[role].key(device)) for role in DESCRIPTOR_ROLES if role in specs
+    )
+    hit = _DESCRIPTOR_CACHE.get(device, key)
+    if hit is not None:
+        return hit
+    if capturing():
+        raise RuntimeError(
+            "CUDA graph capture requires a TMA descriptor cache hit; run one "
+            "eager fwd with the same tensors before capturing"
+        )
+    upload = build_upload(specs, device)
+    return _DESCRIPTOR_CACHE.put(device, key, upload, (upload.storage,))
+
+
+def descriptor_cache_key(specs: dict[str, TensorMapSpec], device) -> tuple:
+    """The key :func:`build_descriptors` would use.  For capture pre-checks."""
+    return tuple(
+        (role, specs[role].key(device)) for role in DESCRIPTOR_ROLES if role in specs
+    )
+
+
+#: The traced entry, built on first use.  ``@cute.jit`` decoration is not free
+#: and the result is a constant, so rebuilding it per call was pure waste.
+_ENTRY: tuple | None = None
+
+
+#: Whether to hand ptxas an entry register count, which is the precondition for
+#: the manual W0-W15 register split to survive to SASS at all.
+#:
+#: ``min_blocks_per_mp=1`` compiles to ``__launch_bounds__(512, 1)``, from which
+#: ptxas derives 65,536 / 512 = 128 registers per thread at entry.  That is not
+#: the final allocation -- it is the baseline the three ``setmaxnreg``
+#: instructions move away from, down to 120 and 64 and up to 160.  Without it
+#: ptxas reports ``(C7508) 'setmaxnreg' ignored; unable to determine register
+#: count at entry`` and holds every warp at 128, which is the uniform split the
+#: design does not want.
+#:
+#: Off by default until the pairing is measured: the bound acting *alone*, with
+#: the redistribution still dropped, was measured at 6,457 local-memory
+#: instructions against 240 (see :mod:`config`).  Set ``KDA_LAUNCH_BOUNDS=1`` to
+#: build the other variant.
+_LAUNCH_BOUNDS = (
+    {"min_blocks_per_mp": 1} if os.environ.get("KDA_LAUNCH_BOUNDS") == "1" else {}
+)
+
+
+def _entry_module():
+    """Import the device kernel lazily and build the entry once.
+
+    Host-only consumers -- validation, metadata, the layout tests -- must not
+    need the CUTLASS DSL installed, and importing it costs seconds, so this
+    stays out of module import.  The memo is what keeps it off the hot path.
+
+    This is also why this module must not carry ``from __future__ import
+    annotations``.  ``cutlass`` is a local of this function, not a module
+    global, so ``_fused_entry``'s parameter annotations below can only be
+    resolved as real objects at ``def`` time.  Postponed annotations would
+    leave them as the strings ``"cutlass.Int64"`` and friends, and the DSL
+    resolves a jit function's signature with ``inspect.get_annotations(...,
+    eval_str=True)``, which evaluates them against this module's globals --
+    where ``cutlass`` is not bound.  DSL 4.3 never looked; 4.7 does, and every
+    GPU test failed with ``NameError: name 'cutlass' is not defined`` raised
+    from inside ``inspect``.
+    """
+    global _ENTRY
+    if _ENTRY is not None:
+        return _ENTRY
+    import cutlass
+    import cutlass.cute as cute
+
+    @cute.jit
+    def _fused_entry(
+        gout,
+        gbeta,
+        ga_log,
+        gdt,
+        gcu_seqlens,
+        desc_q: cutlass.Int64,
+        desc_k: cutlass.Int64,
+        desc_g: cutlass.Int64,
+        desc_v: cutlass.Int64,
+        desc_out: cutlass.Int64,
+        desc_state_in: cutlass.Int64,
+        desc_state_out: cutlass.Int64,
+        scale: cutlass.Float32,
+        gate_scale_log2: cutlass.Float32,
+        heads: cutlass.Int32,
+        grid_x: cutlass.Int32,
+        grid_y: cutlass.Int32,
+        stream,
+        G_FP32: cutlass.Constexpr,
+        SAFE_GATE: cutlass.Constexpr,
+        HAS_STATE_IN: cutlass.Constexpr,
+        HAS_STATE_OUT: cutlass.Constexpr,
+        STATE_FP32: cutlass.Constexpr,
+    ):
+        fused_kda_kernel(
+            gout,
+            gbeta,
+            ga_log,
+            gdt,
+            gcu_seqlens,
+            desc_q,
+            desc_k,
+            desc_g,
+            desc_v,
+            desc_out,
+            desc_state_in,
+            desc_state_out,
+            scale,
+            gate_scale_log2,
+            heads,
+            G_FP32,
+            SAFE_GATE,
+            HAS_STATE_IN,
+            HAS_STATE_OUT,
+            STATE_FP32,
+        ).launch(
+            grid=(grid_x, grid_y, 1),
+            block=(THREADS, 1, 1),
+            smem=DYNAMIC_SMEM_BYTES,
+            stream=stream,
+            **_LAUNCH_BOUNDS,
+        )
+
+    _ENTRY = (cutlass, cute, _fused_entry)
+    return _ENTRY
+
+
+@dataclass(frozen=True)
+class LaunchPlan:
+    """Everything a repeated launch needs, minus the launch itself.
+
+    The whole host path is a pure function of the tensors' addresses, shapes,
+    dtypes and the two scalars, so on a training loop that reuses its buffers
+    this can be built once and replayed.  ``descriptors`` is held by strong
+    reference: the argument tuple carries raw device addresses into it, and
+    letting the upload die would leave the kernel reading freed memory.
+
+    ``stream`` is baked into ``args``, which is why the cache above this must
+    key on it -- replaying a plan from another stream would launch against the
+    wrong one, correctly ordered against the wrong work.
+    """
+
+    key: KernelKey
+    descriptors: TensorMapUpload
+    compiled: Any
+    args: tuple
+
+    def run(self) -> None:
+        self.compiled(*self.args)
+
+
+def prepare_launch(
+    *,
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor,
+    beta: torch.Tensor,
+    out: torch.Tensor,
+    A_log: torch.Tensor,
+    dt_bias: torch.Tensor,
+    cu_seqlens_i32: torch.Tensor,
+    scale: float,
+    lower_bound: float,
+    sequences: int,
+    heads: int,
+    total_tokens: int,
+    initial_state: torch.Tensor | None,
+    final_state: torch.Tensor | None,
+    state_dtype: torch.dtype | None,
+    safe_gate: bool,
+    input_mode: str,
+    stream=None,
+) -> LaunchPlan:
+    """Compile (or reuse) and assemble everything one fused forward needs.
+
+    Does not launch.  Splitting this from the launch is what lets the caller
+    memoize it; it also keeps the graph-capture guards -- which must run on a
+    cold cache -- on the path that actually builds things.
+    """
+    import cuda.bindings.driver as cuda_driver
+
+    require_sm120a(q.device)
+    # ``out_global_index`` feeds ``vec_at``, which casts to ``Int32``, and the
+    # DSL packs the flat view's extent as INT32 as well -- so the shape is
+    # bounded here, before anything is allocated.  This half had no such check
+    # at all, and the wrapped index is not an error but a negative offset.
+    check_flat_output_range(total_tokens, heads)
+    cutlass, _cute, entry = _entry_module()
+
+    if stream is None:
+        # The tensors' device, not the current one.  torch.cuda.current_stream()
+        # with no argument returns the *current* device's stream, so with the
+        # inputs on cuda:1 and cuda:0 current it hands a device-0 handle to a
+        # device-1 launch -- invalid resource handle at best, silently wrong
+        # stream ordering at worst, and neither is visible at the call site.
+        stream = cuda_driver.CUstream(torch.cuda.current_stream(q.device).cuda_stream)
+
+    descriptors = build_descriptors(
+        q=q,
+        k=k,
+        v=v,
+        g=g,
+        out=out,
+        initial_state=initial_state,
+        final_state=final_state,
+        total_tokens=total_tokens,
+        sequences=sequences,
+        heads=heads,
+    )
+
+    grid_x, grid_y, _ = grid(sequences, heads)
+    # grid_y is the head count, and nothing upstream bounds it against the
+    # device.  The decomposed variant checks its own grid (recurrence.py); this
+    # one did not, so a call with more heads than maxGridSize[1] -- 65535 on
+    # every current part, against 2^31-1 on axis 0 -- reached the driver and
+    # failed there.  A short, stateless call at H = 65536 fits in memory
+    # perfectly well, so nothing else would have stopped it.
+
+    limits = max_grid_dims(q.device)
+    for axis, (extent, limit) in enumerate(zip((grid_x, grid_y), limits, strict=False)):
+        if extent > limit:
+            raise ValueError(
+                f"grid[{axis}] = {extent} exceeds maxGridSize[{axis}] = {limit}"
+            )
+    # ``lower_bound * log2e`` is computed once in Python double and cast once,
+    # so the device never repeats the conversion and lower_bound stays out of
+    # the compile key.
+    args = (
+        flat_view(out),
+        flat_view(beta),
+        flat_view(A_log),
+        flat_view(dt_bias),
+        flat_view(cu_seqlens_i32),
+        cutlass.Int64(descriptors.address("q")),
+        cutlass.Int64(descriptors.address("k")),
+        cutlass.Int64(descriptors.address("g")),
+        cutlass.Int64(descriptors.address("v")),
+        cutlass.Int64(descriptors.address("out")),
+        cutlass.Int64(descriptors.address("state_in")),
+        cutlass.Int64(descriptors.address("state_out")),
+        cutlass.Float32(scale),
+        cutlass.Float32(lower_bound * LOG2_E),
+        cutlass.Int32(heads),
+        cutlass.Int32(grid_x),
+        cutlass.Int32(grid_y),
+        stream,
+    )
+    constexprs = (
+        g.dtype is torch.float32,
+        bool(safe_gate),
+        initial_state is not None,
+        final_state is not None,
+        state_dtype is torch.float32,
+    )
+
+    key = KernelKey(
+        device=(
+            q.device.index
+            if q.device.index is not None
+            else torch.cuda.current_device()
+        ),
+        device_cc=DEVICE_CC,
+        code_target=CODE_TARGET,
+        g_dtype=g.dtype,
+        safe_gate=bool(safe_gate),
+        state_dtype=state_dtype,
+        has_initial_state=initial_state is not None,
+        has_final_state=final_state is not None,
+        input_mode=input_mode,
+    )
+    compiled = _KERNEL_CACHE.get(key)
+    if compiled is None:
+        if capturing():
+            raise RuntimeError(
+                "CUDA graph capture cannot compile; run one eager fwd with the "
+                "same KernelKey before capturing"
+            )
+
+        def _compile():
+            import cutlass.cute as cute
+
+            # Subscript, not ``options=``: the keyword form silently drops
+            # EnableTVMFFI and hands back a ctypes-marshalled callable.
+            compiled = cute.compile[sm120a_compile_options()](entry, *args, *constexprs)
+            return assert_tvm_ffi_dispatched(compiled, kernel_name(key))
+
+        # The specialization name carries every compile-time parameter and
+        # nothing that varies per call: a tensor address or a runtime shape
+        # here would be a cache that never hits.
+        compiled = build_kernel(
+            kernel_name(key), _compile, device=q.device, key_files=(__file__,)
+        )
+        _KERNEL_CACHE[key] = compiled
+    return LaunchPlan(key=key, descriptors=descriptors, compiled=compiled, args=args)
+
+
+def launch_fused(**kwargs) -> tuple[KernelKey, TensorMapUpload, object]:
+    """Prepare and launch in one step.  Used by tests and one-shot callers."""
+    plan = prepare_launch(**kwargs)
+    plan.run()
+    return plan.key, plan.descriptors, plan.compiled
+
+
+# --------------------------------------------------------------------------
+# Code target and specialization naming.
+#
+# The kernel is written against ``sm_120a``'s architecture-specific instruction
+# set, so the target is a contract rather than a coincidence of whatever the
+# DSL detected.  It is stated as an explicit compile option, never by writing
+# ``CUTE_DSL_ARCH``; ``runtime.build_kernel`` refuses to write an artifact if
+# the persistent cache resolves a different target than the one asked for.
+# --------------------------------------------------------------------------
+
+
+def code_target() -> str:
+    """The code target this variant compiles for.  For reports and cache keys."""
+    return SM120_CODE_TARGET
+
+
+def kernel_name(key: "KernelKey") -> str:
+    """The persistent cache's specialization name for ``key``.
+
+    Every compile-time parameter and nothing else.  Deliberately readable: it
+    is the name of a directory entry someone will have to recognize when asking
+    which specializations a run built.
+    """
+    if key.state_dtype is None:
+        state = "nostate"
+    elif key.state_dtype is torch.float32:
+        state = "statefp32"
+    else:
+        state = "statebf16"
+    return "fused_" + "_".join(
+        (
+            "gfp32" if key.g_dtype is torch.float32 else "gbf16",
+            "safegate" if key.safe_gate else "rawgate",
+            state,
+            "si" if key.has_initial_state else "nosi",
+            "so" if key.has_final_state else "noso",
+            key.input_mode,
+        )
+    )
+
+
+# --------------------------------------------------------------------------
+# Section 7: the host path
+#
+# Structurally the same idea as the decomposed variant's: an LRU on a
+# tensor- and workspace-identity key, an object-identity fast path in front of
+# it, a state-only shortcut, and the stream in the key because a plan bakes its
+# ``CUstream`` into the argument tuple.
+#
+# The two are not folded together, and the difference is load-bearing rather
+# than stylistic.  This half carries ``safe_gate``, which the other refuses
+# outright; it has one descriptor set where the other has two plus a shared
+# factor slab; and it has no chunk tables at all, because a fused CTA owns a
+# whole (sequence, head) and never needs a chunk-to-sequence map.  A merged
+# "call plan cache" would have to carry the union of those and branch on the
+# variant at every step, which is the same code with an extra way to be wrong.
+#
+# Three things are deliberately not cached, because caching them would be wrong
+# rather than merely slow:
+#
+# * the zero-token state copy, which is real work the caller expects on every
+#   call -- the plan records that it is a state-only call and redoes it;
+# * anything derived from tensor *contents*;
+# * plans across streams, for the reason above.
+# --------------------------------------------------------------------------
+
+#: One entry per distinct set of buffers a caller uses; a serving loop that
+#: reuses its activations needs exactly one.
+
+#: 16 is a ceiling on *how many rotating buffer sets stay fast*, not a memory
+#: budget, and lowering it does not trade speed for memory -- it buys nothing
+#: until the workload exceeds it and then costs everything.  Measured on the
+#: 110-SM part at ``[1, 1024, 8, 128]``, rotating N buffer sets:
+#:
+#: ===  ==================  ==================
+#: cap  N = 4               N = 8
+#: ===  ==================  ==================
+#: 16   101 us / 40.6 MiB   116 us / 72.7 MiB
+#: 4    105 us / 40.6 MiB   7145 us / 40.6 MiB
+#: 2    7670 us / 24.6 MiB  7546 us / 24.6 MiB
+#: ===  ==================  ==================
+#:
+#: Below the cap the retention is identical whatever the cap is; at the cap the
+#: hit becomes a rebuild, and a rebuild is ~7.3 ms against a ~100 us hit.  A
+#: deployment that needs the memory back should reduce how many buffer sets it
+#: rotates, or call ``clear_kda_prefill_sm120_caches()``; shrinking this number
+#: only moves the same allocation into a 70x slower path.
+CALL_PLAN_MAX_ENTRIES = 16
+_CALL_PLANS: OrderedDict = OrderedDict()
+
+#: The previous call's tensors, versions, scalars, workspace, stream and plan. Strong
+#: references, one slot: keying on ``id()`` would be unsound, since a freed
+#: tensor's id can be reused by a different one and the plan would then be
+#: handed to the wrong buffers, and weak references would cost a dereference
+#: per tensor to save pinning a single call's worth.
+_LAST: tuple | None = None
+
+#: Marks "this call has no tokens", so the zero-token path is reached on a plan
+#: hit without re-deriving the metadata that proves it.
+_STATE_ONLY = object()
+
+#: Serializes the cache-miss path: plan construction, descriptor encoding and
+#: the compile behind it.
+#:
+#: The launch lock below is not enough on its own, and the reason is worth
+#: recording. Four host threads issuing the same shape share one factor arena
+#: and one launch lock, so their *enqueues* interleave correctly -- but a cold
+#: build is not an enqueue. It encodes descriptors, writes shared scratch and
+#: calls into the CuTe DSL compiler, none of which is re-entrant: the legacy
+#: implementation, given the same four threads, does not produce wrong numbers
+#: so much as raise ``_fwd_entry() requires a code object with 0 free vars`` and
+#: "Please start a session before accessing session data" from inside the DSL.
+#: Measured here, the first thread's output was wrong in 1515 of 32768 elements
+#: while the other three were exact -- the signature of the builder racing its
+#: own build.
+#:
+#: A module-level lock is the right shape for that. It is taken only on a miss,
+#: so a serving loop that reuses its buffers never sees it, and the two cache
+#: layers in front of it are checked before it is acquired.
+_BUILD_LOCK = threading.RLock()
+
+
+def clear_caches() -> None:
+    """Drop every cache this variant owns."""
+    global _LAST
+    _CALL_PLANS.clear()
+    _LAST = None
+    clear_kernel_caches()
+
+
+def call_plan_stats() -> dict:
+    return {"plans": len(_CALL_PLANS), "last_call_warm": _LAST is not None}
+
+
+def _identity(device, tensors, scale, lower_bound, safe_gate, resources) -> tuple:
+    # The stream of the *inputs'* device: ``prepare_launch`` bakes
+    # ``torch.cuda.current_stream(q.device)`` into the plan's argument tuple,
+    # so a key built from the current device's stream would let two streams on
+    # the input's device share one entry and reuse the first one's plan.
+    return (
+        tuple(tensor_identity(t) for t in tensors),
+        float(scale),
+        float(lower_bound),
+        bool(safe_gate),
+        resource_cache_token(resources),
+        current_stream_ptr(device),
+    )
+
+
+def _fast_path(device, tensors, scale, lower_bound, safe_gate, resources):
+    """The previous call's plan if this call is identical to it, else ``None``."""
+    if _LAST is None:
+        return None
+    (
+        last_tensors,
+        last_versions,
+        last_scalars,
+        last_resources,
+        last_stream,
+        plan,
+    ) = _LAST
+    if last_scalars != (float(scale), float(lower_bound), bool(safe_gate)):
+        return None
+    if last_resources is not resource_cache_token(resources):
+        return None
+    if last_stream != current_stream_ptr(device):
+        return None
+    if len(last_tensors) != len(tensors):
+        return None
+    for ref, tensor in zip(last_tensors, tensors, strict=True):
+        if ref is None:
+            if tensor is not None:
+                return None
+        elif ref() is not tensor:
+            return None
+    for tensor, version in zip(tensors, last_versions, strict=True):
+        if tensor is not None and tensor_version(tensor) != version:
+            return None
+    return plan
+
+
+def _remember(device, tensors, scale, lower_bound, safe_gate, resources, plan) -> None:
+    global _LAST
+    # Weak, like the plan LRU above: this entry outlives the call, and strong
+    # references to q, k, v, g and out would hold one whole activation set off
+    # the caching allocator until the next call replaced it.
+    _LAST = (
+        tuple(None if t is None else weakref.ref(t) for t in tensors),
+        tuple(None if t is None else tensor_version(t) for t in tensors),
+        (float(scale), float(lower_bound), bool(safe_gate)),
+        resource_cache_token(resources),
+        current_stream_ptr(device),
+        plan,
+    )
+
+
+def _state_only(initial_state, final_state) -> None:
+    """The zero-token path.
+
+    No kernel launches and no zero-extent descriptor is built: a TensorMap with
+    a zero global dimension is invalid, and there is nothing for it to describe.
+    """
+    if final_state is None:
+        return
+    if initial_state is None:
+        final_state.zero_()
+        return
+    if is_exact_alias(initial_state, final_state):
+        return
+    final_state.copy_(initial_state)
+
+
+def _packed(t: torch.Tensor | None) -> torch.Tensor | None:
+    """Fixed ``[B, T, ...]`` -> packed ``[1, B * T, ...]``, as a view.
+
+    ``reshape`` on a contiguous tensor never copies, which matters here: a copy
+    of ``out`` would silently drop the caller's writes.
+    """
+    if t is None:
+        return None
+    return t.reshape(1, t.shape[0] * t.shape[1], *t.shape[2:])
+
+
+def run(
+    *,
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor,
+    beta: torch.Tensor,
+    out: torch.Tensor,
+    A_log: torch.Tensor,
+    dt_bias: torch.Tensor,
+    scale: float,
+    lower_bound: float,
+    initial_state: torch.Tensor | None = None,
+    final_state: torch.Tensor | None = None,
+    cu_seqlens: torch.Tensor | None = None,
+    info,
+    offsets,
+    resources=None,
+    safe_gate: bool = True,
+) -> None:
+    """Launch the fused prefill, writing ``out`` and ``final_state`` in place.
+
+    ``info`` and ``offsets`` come from :mod:`.runtime`: the facade validates and
+    canonicalizes once, so this is not a second validation pass.
+    """
+    tensors = (
+        q,
+        k,
+        v,
+        g,
+        beta,
+        out,
+        A_log,
+        dt_bias,
+        initial_state,
+        final_state,
+        cu_seqlens,
+    )
+
+    plan = _fast_path(q.device, tensors, scale, lower_bound, safe_gate, resources)
+    if plan is None:
+        key = _identity(q.device, tensors, scale, lower_bound, safe_gate, resources)
+        # See ``_BUILD_LOCK``: the miss path is not re-entrant, and the two
+        # cache layers in front of it mean a warm caller never reaches it.
+        with _BUILD_LOCK:
+            plan = _CALL_PLANS.get(key)
+            if plan is not None:
+                _CALL_PLANS.move_to_end(key)
+            else:
+                plan = _build_plan(
+                    q=q,
+                    k=k,
+                    v=v,
+                    g=g,
+                    beta=beta,
+                    out=out,
+                    A_log=A_log,
+                    dt_bias=dt_bias,
+                    scale=scale,
+                    lower_bound=lower_bound,
+                    initial_state=initial_state,
+                    final_state=final_state,
+                    cu_seqlens=cu_seqlens,
+                    info=info,
+                    offsets=offsets,
+                    resources=resources,
+                    safe_gate=safe_gate,
+                )
+                _CALL_PLANS[key] = plan
+                while len(_CALL_PLANS) > CALL_PLAN_MAX_ENTRIES:
+                    _CALL_PLANS.popitem(last=False)
+            _remember(q.device, tensors, scale, lower_bound, safe_gate, resources, plan)
+
+    execute(plan, initial_state, final_state)
+    return plan
+
+
+def execute(plan, initial_state, final_state) -> None:
+    """Run an already-resolved plan.
+
+    Split out so the facade, which has its own memo on the same tensor
+    identities, does not have to repeat the comparison this module's fast path
+    would do to find the same plan again. Two layers each walking eleven
+    tensors cost about 6 us per call -- nothing against a 1 ms kernel, and a
+    third of the whole call at B=1 T=16 H=4.
+    """
+    if plan is _STATE_ONLY:
+        # Real work the caller expects on every call, so a hit redoes it.
+        _state_only(initial_state, final_state)
+        return
+    plan.run()
+
+
+def _build_plan(
+    *,
+    q,
+    k,
+    v,
+    g,
+    beta,
+    out,
+    A_log,
+    dt_bias,
+    scale,
+    lower_bound,
+    initial_state,
+    final_state,
+    cu_seqlens,
+    info,
+    offsets,
+    resources,
+    safe_gate,
+):
+    """The full host path: canonicalize, encode descriptors, marshal arguments.
+
+    Everything that must run on a cold cache -- and therefore every
+    graph-capture guard -- lives here.
+    """
+    require_sm120a(q.device)
+
+    if info.total_tokens == 0:
+        return _STATE_ONLY
+
+    if info.input_mode == "fixed":
+        pq, pk, pv, pg = (_packed(t) for t in (q, k, v, g))
+        pbeta = _packed(beta)
+        pout = _packed(out)
+    else:
+        if capturing() and cu_seqlens.dtype is not torch.int32:
+            # Even a previously converted INT64 tensor is refused *without a
+            # workspace*: replay would reuse the canonical buffer without
+            # re-validating the source, so the two could drift apart with
+            # nothing to detect it.  With a workspace the canonical buffer is
+            # the workspace's own and replay copies into it, which is what
+            # makes INT64 packed capture supportable at all.
+            if resources is None or resources.cu_seqlens_i32 is None:
+                raise RuntimeError(
+                    "CUDA graph capture of INT64 packed offsets needs an "
+                    "explicit RecurrentKDAPrefillWorkspace warmed on the same "
+                    f"offsets; got {cu_seqlens.dtype} with no workspace"
+                )
+        pq, pk, pv, pg, pbeta, pout = q, k, v, g, beta, out
+
+    if offsets.sequences != info.sequences:
+        raise KDAPrefillValidationError(
+            f"cu_seqlens describes {offsets.sequences} sequences but the state "
+            f"shapes describe {info.sequences}"
+        )
+
+    cu_seqlens_i32 = _stable_offsets(offsets, resources)
+
+    plan = prepare_launch(
+        q=pq,
+        k=pk,
+        v=pv,
+        g=pg,
+        beta=pbeta,
+        out=pout,
+        A_log=A_log,
+        dt_bias=dt_bias,
+        cu_seqlens_i32=cu_seqlens_i32,
+        scale=float(scale),
+        lower_bound=float(lower_bound),
+        sequences=info.sequences,
+        heads=info.heads,
+        total_tokens=info.total_tokens,
+        initial_state=initial_state,
+        final_state=final_state,
+        state_dtype=info.state_dtype,
+        safe_gate=bool(safe_gate),
+        input_mode=info.input_mode,
+    )
+
+    if resources is not None:
+        # Replay never re-enters Python, so everything the capture recorded has
+        # to stay alive at its captured address for the workspace's lifetime.
+        resources.pin(
+            plan,
+            plan.compiled,
+            plan.descriptors,
+            plan.descriptors.storage,
+            offsets,
+            offsets.canonical,
+            offsets.source,
+            cu_seqlens_i32,
+        )
+    elif capturing():
+        # A capture without a workspace has nowhere to put the pins, so they go
+        # to the process-wide table.  Deliberately for the process lifetime: an
+        # eviction that left a replayed graph reading a dangling device pointer
+        # fails far from its cause and only sometimes.
+        GRAPH_PINS.pin(
+            (plan.key, id(plan.descriptors)),
+            plan.compiled,
+            plan.descriptors,
+            plan.descriptors.storage,
+            offsets,
+            offsets.canonical,
+            offsets.source,
+        )
+    return plan
+
+
+def _stable_offsets(offsets, resources):
+    """The INT32 offsets the kernel reads, at an address replay can rely on.
+
+    Without a workspace this is whatever ``runtime`` canonicalized. With one,
+    eager warmup copies into a fixed-address workspace buffer that remains
+    valid for graph replay; the documented capture contract keeps offset values
+    unchanged for that graph's lifetime.
+    """
+    if resources is None:
+        return offsets.canonical
+    buffer = resources.ensure_capacity(
+        "cu_seqlens_i32", offsets.canonical.numel(), torch.int32
+    )
+    buffer.copy_(offsets.canonical)
+    return buffer
+
+
+def dynamic_smem_bytes() -> int:
+    """The launch's dynamic shared-memory size, for host-side resource checks."""
+    return DYNAMIC_SMEM_BYTES
+
+
+__all__ = [
+    "CALL_PLAN_MAX_ENTRIES",
+    "KernelKey",
+    "LaunchPlan",
+    "call_plan_stats",
+    "clear_caches",
+    "clear_kernel_caches",
+    "code_target",
+    "dynamic_smem_bytes",
+    "kernel_name",
+    "execute",
+    "run",
+]

--- a/flashinfer/kda_kernels/sm120_prefill/runtime.py
+++ b/flashinfer/kda_kernels/sm120_prefill/runtime.py
@@ -1,0 +1,1795 @@
+# Copyright (c) 2025 - 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+
+# 1. Redistributions of source code must retain the above copyright notice, this
+# list of conditions and the following disclaimer.
+
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+
+# 3. Neither the name of the copyright holder nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+"""The one thing ``decomp`` and ``fused`` share.
+
+Both variants implement the same operation and neither can see the other, so
+anything they both consume has to live somewhere neither owns.  That is this
+module, and the bar for entering it is deliberately high: a helper belongs here
+only when both variants call it, it means the same thing to both, its lifetime
+is the same for both, and a unit test can pin it without a device kernel.
+
+What that admits:
+
+* the canonical launch description and the shape/dtype/alias validation that
+  produces it, plus the error type both raise;
+* the exact ``sm_120a`` target check, expressed through
+  :mod:`flashinfer.cute_dsl.utils` and never by writing ``CUTE_DSL_ARCH``;
+* the bounded per-device cache, the capture probe, tensor identity, pinned
+  descriptor staging and the cache statistics -- the *containers*, not the
+  cache instances, which stay with the variant that keys them;
+* canonical INT32 ``cu_seqlens``, the workspace resource slot, the graph
+  stream/signature binding and the resource lifetime that goes with it;
+* the naming convention for :func:`~flashinfer.jit.build_and_load_cute_dsl_kernel`.
+
+What it excludes, and why the exclusion is not cosmetic: every layout, swizzle,
+TMA descriptor, PTX helper and device kernel.  The two variants have helpers
+with matching names -- both have a ``raw_bf16_s128``, both have a pairwise
+image -- and the images are not the same, because the shapes they index are
+not the same.  Hoisting one and letting the other call it would be a silent
+numerical change, so neither is hoisted.
+
+Nothing here imports ``decomp`` or ``fused``, and importing this module loads
+no device code and compiles nothing.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import math
+import os
+import threading
+from collections import OrderedDict
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+import torch
+
+# ---------------------------------------------------------------------------
+# Shape constants and scalars both variants agree on.
+#
+# These are properties of the operation, not of either schedule: KDA prefill on
+# this backend is equal-head, 128-wide in both K and V.  The chunk size, the
+# SMEM arena and every swizzle are schedule properties and live with their
+# variant.
+# ---------------------------------------------------------------------------
+
+#: Key dimension.  Fixed; the eligibility predicate rejects anything else.
+DK = 128
+
+#: Value dimension.  Equal to :data:`DK` for every shape this backend supports.
+DV = 128
+
+#: log2(e).  The gate is evaluated in the log2 domain by both variants.
+LOG2_E = 1.4426950408889634
+
+#: The safe gate's worst-case chunk prefix is ``16 * lower_bound * log2e``,
+#: which reaches the ``rcp.approx.ftz`` cliff at ``lower_bound == -5.4585``.
+#: The supported range keeps a real margin below that.  This direct backend ABI
+#: also accepts the degenerate zero gate; the public ``recurrent_kda`` selector
+#: deliberately requires a strictly negative bound.
+LOWER_BOUND_RANGE = (-5.0, 0.0)
+
+#: Base alignment every tensor a TensorMap describes must satisfy.  The driver
+#: accepts a misaligned base and the corruption surfaces as wrong numbers in
+#: one head, far from the call that caused it.
+GLOBAL_BASE_ALIGN = 16
+
+INT32_MAX = 2**31 - 1
+
+#: Inputs that are only ever read, so overlaps among them are legal.
+READ_ONLY_ROLES = ("q", "k", "v", "g", "beta", "A_log", "dt_bias")
+
+
+class KDAPrefillValidationError(ValueError):
+    """Raised for any violation of the SM120 backend ABI.
+
+    A ``ValueError`` subclass rather than a bare one so a caller can tell a
+    contract violation from an unrelated failure, and so the public adapter in
+    ``flashinfer/kda_prefill.py`` can let it propagate unchanged.
+    """
+
+
+class UnsupportedArchitectureError(RuntimeError):
+    """Raised when the SM120 backend is asked to run on another target."""
+
+
+# ---------------------------------------------------------------------------
+# Architecture and compile target.
+#
+# Two separate questions, and conflating them is how a report ends up naming a
+# target the artifact does not have:
+#
+#   1. is the *device* compute capability 12.0?
+#   2. can the installed CuTe DSL and CUDA toolkit compile and load ``sm_120a``
+#      natively -- not a family-conditional ``sm_120f`` fallback?
+#
+# Both must hold.  Neither is answered by mutating ``CUTE_DSL_ARCH``: the DSL
+# captures its default target when ``cutlass`` is first imported, so a write
+# here would not retarget an already-imported DSL, and a write before import
+# would change every other CuTe-DSL kernel in the process.
+# ---------------------------------------------------------------------------
+
+SM120_CAPABILITY = (12, 0)
+
+#: The code target both variants compile for.  Spelled once; the persistent
+#: cache's own arch resolution is checked against it before any build.
+SM120_CODE_TARGET = "sm_120a"
+
+
+def _capability(device: torch.device | None = None) -> tuple[int, int]:
+    from ...utils import get_compute_capability
+
+    if device is None:
+        device = torch.device("cuda", torch.cuda.current_device())
+    return get_compute_capability(device)
+
+
+def sm120a_available(device: torch.device | None = None) -> bool:
+    """Can this process compile and run ``sm_120a`` on ``device``?
+
+    A fail-closed predicate: it allocates nothing, launches nothing and
+    synchronizes with nothing, so the eligibility path can call it.  Anything
+    unexpected -- no driver, no DSL, an ``Arch`` enum that does not know
+    ``sm_120a`` -- reads as "no".
+    """
+    if not torch.cuda.is_available():
+        return False
+    try:
+        if _capability(device) != SM120_CAPABILITY:
+            return False
+        from ...cute_dsl.utils import is_cute_dsl_arch_supported
+        from ...utils import is_sm120a_supported
+
+        if not is_sm120a_supported(
+            device or torch.device("cuda", torch.cuda.current_device())
+        ):
+            return False
+        # native_only: a family-conditional ``sm_120f`` target is not what this
+        # backend compiles for, and accepting it would produce an artifact
+        # named sm_120a that is not.
+        return is_cute_dsl_arch_supported(*SM120_CAPABILITY, native_only=True)
+    except Exception:  # noqa: BLE001 -- an unavailable backend is not an error
+        return False
+
+
+def require_sm120a(device: torch.device | str | int | None = None) -> None:
+    """Raise unless ``device`` is CC 12.0 and ``sm_120a`` is buildable."""
+    if not torch.cuda.is_available():
+        raise UnsupportedArchitectureError(
+            "the SM120 KDA prefill backend requires a CUDA device"
+        )
+    normalized = (
+        None
+        if device is None
+        else torch.device(device)
+        if not isinstance(device, int)
+        else torch.device("cuda", device)
+    )
+    capability = _capability(normalized)
+    if capability != SM120_CAPABILITY:
+        major, minor = capability
+        raise UnsupportedArchitectureError(
+            f"the SM120 KDA prefill backend requires compute capability 12.0, "
+            f"got sm_{major}{minor}"
+        )
+    if not sm120a_available(normalized):
+        raise UnsupportedArchitectureError(
+            f"the installed CuTe DSL and CUDA toolkit cannot natively target "
+            f"{SM120_CODE_TARGET} on this device"
+        )
+
+
+def sm120a_compile_options(enable_tvm_ffi: bool = True) -> tuple:
+    """``cute.compile`` options pinning the code target to ``sm_120a``.
+
+    An explicit :class:`cute.GPUArch` rather than an environment variable, for
+    the reason above.  ``EnableTVMFFI`` is not optional either: it selects the
+    argument-marshalling ABI, and the slow one costs about 4x of the host path.
+
+    **These must be passed with ``cute.compile[options](...)``, not
+    ``cute.compile(..., options=options)``.** The keyword form accepts the
+    tuple and silently ignores ``EnableTVMFFI``: it yields a
+    ``CudaDialectJitCompiledFunction``, which marshals every argument through
+    ``ctypes.addressof``, where the subscript form yields a
+    ``TVMFFIJitCompiledFunctionWithKwargs``. Measured on this backend, that
+    mistake cost 82 us of host time per call against 17.5 us -- invisible
+    against a 1 ms kernel and 4x the entire call at B=1 T=16 H=4.
+    :func:`assert_tvm_ffi_dispatched` exists so it cannot happen quietly again.
+    """
+    import cutlass.cute as cute
+
+    options: tuple = (cute.GPUArch(SM120_CODE_TARGET),)
+    if enable_tvm_ffi:
+        options = (cute.EnableTVMFFI(True),) + options
+    return options
+
+
+def assert_tvm_ffi_dispatched(compiled, kernel_name: str):
+    """Refuse a compiled entry that fell back to the ctypes argument path.
+
+    The fallback is not an error the DSL reports -- it produces a working
+    callable that is simply several times slower to invoke, which is the kind
+    of regression that gets attributed to the kernel months later. Checking the
+    type is cheap and happens once per specialization.
+    """
+    compiled_type = type(compiled)
+    known_tvm_ffi_types = {
+        "TVMFFIJitCompiledFunction",
+        "TVMFFIJitCompiledFunctionWithKwargs",
+    }
+    if (
+        compiled_type.__module__.endswith("tvm_ffi_provider")
+        or compiled_type.__name__ in known_tvm_ffi_types
+    ):
+        return compiled
+    raise RuntimeError(
+        f"the compiled entry for {kernel_name!r} is a "
+        f"{compiled_type.__name__}, not a TVM-FFI callable: the compile "
+        f"options did not take. Pass them as cute.compile[options](...) -- the "
+        f"options= keyword accepts EnableTVMFFI and ignores it."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Persistent JIT.
+#
+# The op namespace is fixed and distinct from every other KDA entry point, so
+# a cross-implementation A/B cannot reuse another implementation's cached
+# artifact and misreport reuse as agreement.
+# ---------------------------------------------------------------------------
+
+#: Logical compile namespace.  Bumping the suffix invalidates every artifact.
+JIT_MODULE_NAME = "flashinfer-kda-prefill-sm120-v1"
+
+
+def _assert_cache_target_matches() -> None:
+    """The persistent cache's arch must be the one we asked ``cute`` for.
+
+    ``JitSpecCuteDsl`` derives its module directory and its ``meta.json`` arch
+    from ``CUTE_DSL_ARCH`` or the current device's capability.  We pass an
+    explicit ``GPUArch(sm_120a)``, so if those two ever disagree the artifact
+    on disk is named for one target and built for another -- the exact failure
+    the plan forbids.  Checking is cheap; guessing is not recoverable.
+    """
+    from ...jit.cute_dsl_core import _get_compile_arch
+
+    resolved = _get_compile_arch()
+    expected = SM120_CODE_TARGET.replace("_", "")
+    if resolved != expected:
+        raise UnsupportedArchitectureError(
+            f"the CuTe-DSL persistent cache resolves its target to "
+            f"{resolved!r} while this backend compiles for {expected!r}; "
+            f"refusing to write an artifact whose name does not describe it "
+            f"(unset CUTE_DSL_ARCH to let it follow the device)"
+        )
+
+
+def _module_key_files() -> tuple:
+    """Every source file whose content should invalidate this module.
+
+    All four package files, for both variants, and deliberately the *same*
+    tuple for every kernel in the namespace.  ``JitSpecCuteDsl`` writes one
+    ``meta.json`` per module directory and wipes the directory whenever a
+    kernel arrives with a different source hash -- so passing each variant only
+    its own file made ``decomp`` and ``fused`` invalidate each other on every
+    alternation, which a benchmark sees as a recompile per switch and a
+    correctness A/B sees as a cold build every time.
+    """
+    here = os.path.dirname(os.path.abspath(__file__))
+    return tuple(
+        os.path.join(here, name)
+        for name in ("runtime.py", "decomp.py", "fused.py", "__init__.py")
+    )
+
+
+def build_kernel(kernel_name: str, compile_fn, *, device, key_files=()):
+    """Compile through FlashInfer's persistent CuTe-DSL cache.
+
+    ``kernel_name`` is the specialization -- variant, dtype presence flags and
+    every other compile-time parameter, and nothing that varies per call.  A
+    tensor address or a runtime shape in this string is a cache that never
+    hits.  ``key_files`` is accepted and ignored: invalidation is a property of
+    the module namespace, not of one kernel in it, so it always uses
+    :func:`_module_key_files`.
+
+    Falls back to a plain in-process ``compile_fn()`` when the persistent path
+    raises.  That is a real possibility rather than defensive coding: whether
+    ``export_to_c`` can round-trip a given compiled object is a property of the
+    pinned CuTe DSL, not of this code.  When it cannot, the kernel still
+    compiles and still runs -- only the cross-process cache is lost, and
+    :func:`persistent_cache_status` says so rather than leaving a warning in a
+    log for someone to notice.
+    """
+    # JitSpecCuteDsl derives its cache arch, loads the object module and runs a
+    # cold compile against the current CUDA context.  The public API accepts a
+    # tensor on a non-current device, so all three operations must happen under
+    # the input tensor's device guard rather than whichever device the caller
+    # happened to leave current.
+    with torch.cuda.device(device):
+        _assert_cache_target_matches()
+        from ...jit.cute_dsl_core import build_and_load_cute_dsl_kernel
+
+        del key_files
+        try:
+            return build_and_load_cute_dsl_kernel(
+                JIT_MODULE_NAME,
+                kernel_name,
+                compile_fn,
+                extra_key_files=_module_key_files(),
+            )
+        except Exception as exc:  # noqa: BLE001 -- see the docstring
+            _record_persistent_cache_failure(kernel_name, exc)
+            return compile_fn()
+
+
+def persistent_cache_status() -> dict:
+    """Whether a compiled kernel can actually survive this process.
+
+    Reported rather than assumed, because on some pinned CuTe DSL releases it
+    cannot.  ``JitSpecCuteDsl`` exports with
+    ``export_to_c(path, function_name=...)`` and reloads the result as a
+    TVM-FFI callable; a DSL whose ``export_to_c`` takes
+    ``(file_path, file_name, function_prefix)`` and emits a plain C entry
+    satisfies neither half.  FlashInfer degrades gracefully when that happens
+    -- it keeps the in-process kernel and logs a warning -- so nothing breaks,
+    but every process pays a cold compile and no amount of reading the cache
+    directory reveals why.
+
+    ``supported`` is False exactly when the export signature does not match.
+    The check is static: it inspects the signature and compiles nothing.
+    """
+    status = {
+        "module": JIT_MODULE_NAME,
+        "supported": False,
+        "reason": "",
+        "failures": dict(_PERSISTENT_CACHE_FAILURES),
+    }
+    try:
+        import inspect
+
+        from cutlass.base_dsl.dsl import JitCompiledFunction
+
+        parameters = inspect.signature(JitCompiledFunction.export_to_c).parameters
+        if "function_name" in parameters:
+            status["supported"] = True
+        else:
+            status["reason"] = (
+                "the installed CuTe DSL exports with "
+                f"export_to_c{inspect.signature(JitCompiledFunction.export_to_c)}, "
+                "which FlashInfer's persistent CuTe-DSL cache does not call; "
+                "kernels compile in-process every run"
+            )
+    except Exception as exc:  # noqa: BLE001 -- reporting only
+        status["reason"] = f"could not inspect the DSL export API: {exc}"
+    return status
+
+
+_PERSISTENT_CACHE_FAILURES: "OrderedDict[str, str]" = OrderedDict()
+
+
+def _record_persistent_cache_failure(kernel_name: str, exc: BaseException) -> None:
+    _PERSISTENT_CACHE_FAILURES[kernel_name] = f"{type(exc).__name__}: {exc}"
+    while len(_PERSISTENT_CACHE_FAILURES) > 32:
+        _PERSISTENT_CACHE_FAILURES.popitem(last=False)
+
+
+def persistent_cache_unavailable_reason(kernel_name: str) -> Optional[str]:
+    """Why ``kernel_name`` fell back to an in-process compile, if it did."""
+    return _PERSISTENT_CACHE_FAILURES.get(kernel_name)
+
+
+# ---------------------------------------------------------------------------
+# Capture probe and stream-correct cache lifetime.
+#
+# Cached device payloads -- TMA descriptor sets, chunk metadata, canonical
+# INT32 offsets -- are read asynchronously by a kernel, so they need three
+# properties, and the same three for both variants.
+#
+# **Bounded.**  Per device, with an entry ceiling and optionally a payload
+# ceiling.  Whichever binds first evicts from the LRU tail.  An unbounded cache
+# keyed on tensor addresses is a leak with a slow fuse.
+#
+# **Stream-correct on the way in.**  The upload happens on whichever stream
+# created the entry, so a later hit on another stream issues ``wait_event``
+# before reading it.  That is a device-side ordering edge, not a host
+# synchronization.
+#
+# **Stream-correct on the way out.**  Eviction never synchronizes; every hit
+# calls ``record_stream``, so the allocator waits for the streams that used the
+# block before reclaiming it.
+# ---------------------------------------------------------------------------
+
+
+def capturing() -> bool:
+    """Is the current stream inside a CUDA graph capture?
+
+    Both cross-stream primitives below are illegal there: ``cudaStreamWaitEvent``
+    on an event recorded outside the capture, and ``record_stream``, which is a
+    caching-allocator operation with no graph representation.  Either
+    invalidates the capture, and the failure surfaces later as "operation
+    failed due to a previous error during capture" rather than at the call.
+
+    Skipping them is correct, not a workaround.  A capture replays only work it
+    recorded, so an entry it reads was already live and reachable when the
+    capture began: there is no other stream to order against and no lifetime
+    for the allocator to extend.
+    """
+    return torch.cuda.is_available() and torch.cuda.is_current_stream_capturing()
+
+
+def record_stream_once(tensors, stream) -> None:
+    """``record_stream`` each distinct CUDA storage exactly once.
+
+    Exact aliases -- ``out`` with ``v``, ``initial_state`` with
+    ``final_state`` -- are recorded once rather than once per name.
+    """
+    seen: set[int] = set()
+    for tensor in tensors:
+        if tensor is None or not tensor.is_cuda:
+            continue
+        key = tensor.untyped_storage().data_ptr()
+        if key in seen:
+            continue
+        seen.add(key)
+        tensor.record_stream(stream)
+
+
+@dataclass
+class _Entry:
+    value: Any
+    storages: tuple
+    #: ``None`` for a CPU payload: there is no upload to order against, and the
+    #: host-only paths must not require a driver.
+    event: Any
+    nbytes: int
+
+
+@dataclass
+class CacheStats:
+    entries: int = 0
+    bytes: int = 0
+    hits: int = 0
+    misses: int = 0
+    evictions: int = 0
+
+
+#: Default entry ceiling for a per-device cache.
+#:
+#: Descriptor entries keep their source tensors addressable, so this bounds a
+#: retention as well as a size.  See :data:`FLAT_VIEW_MAX_ENTRIES`: the caches
+#: are redundant retainers and only bind together.
+MAX_ENTRIES = 64
+
+
+class BoundedDeviceCache:
+    """LRU cache of device payloads, one bucket per CUDA device.
+
+    Every mutating path holds :attr:`_lock`.  The individual dict operations are
+    atomic under the GIL, but the pairs are not -- a ``get`` plus its
+    ``move_to_end``, or an insert racing the eviction loop -- and this runs on
+    the pre-launch host path, which ``flashinfer/kda_prefill.py`` reaches with
+    no lock of its own whenever the caller passes no workspace.  Reentrant
+    because evicting an entry drops its storages, and a weakref callback on the
+    releasing thread can come back through this class.
+    """
+
+    #: Bucket index standing for "not a CUDA device".
+    CPU_BUCKET = -1
+
+    def __init__(
+        self,
+        name: str,
+        *,
+        max_entries: int = MAX_ENTRIES,
+        max_bytes: Optional[int] = None,
+    ):
+        if max_entries < 1:
+            raise ValueError(f"{name}: max_entries must be positive")
+        self.name = name
+        self.max_entries = max_entries
+        self.max_bytes = max_bytes
+        self._buckets: dict = {}
+        self._stats: dict = {}
+        self._lock = threading.RLock()
+
+    @classmethod
+    def _index(cls, device) -> int:
+        if isinstance(device, int):
+            return device
+        if device.type != "cuda":
+            return cls.CPU_BUCKET
+        if device.index is None:
+            return torch.cuda.current_device()
+        return device.index
+
+    def _bucket(self, index: int):
+        return self._buckets.setdefault(index, OrderedDict())
+
+    def stats(self, device) -> CacheStats:
+        return self._stats.setdefault(self._index(device), CacheStats())
+
+    def _evict(self, index: int) -> None:
+        bucket = self._bucket(index)
+        stats = self.stats(index)
+        while bucket and (
+            len(bucket) > self.max_entries
+            or (self.max_bytes is not None and stats.bytes > self.max_bytes)
+        ):
+            _, entry = bucket.popitem(last=False)
+            stats.bytes -= entry.nbytes
+            stats.evictions += 1
+            # No synchronization: the recorded streams are what make the
+            # allocator wait for any launch still reading the block.
+        stats.entries = len(bucket)
+
+    def get(self, device, key) -> Any:
+        index = self._index(device)
+        with self._lock:
+            bucket = self._bucket(index)
+            stats = self.stats(index)
+            entry = bucket.get(key)
+            if entry is None:
+                stats.misses += 1
+                return None
+            bucket.move_to_end(key)
+            stats.hits += 1
+        if entry.event is not None and not capturing():
+            stream = torch.cuda.current_stream(index)
+            # Cheap and correct on the creating stream too: an event recorded
+            # on the same stream is already satisfied.
+            stream.wait_event(entry.event)
+            record_stream_once(entry.storages, stream)
+        return entry.value
+
+    def put(self, device, key, value: Any, storages: tuple = ()) -> Any:
+        index = self._index(device)
+        event = None
+        if index != self.CPU_BUCKET and torch.cuda.is_available() and not capturing():
+            event = torch.cuda.Event()
+            event.record(torch.cuda.current_stream(index))
+        nbytes = sum(t.numel() * t.element_size() for t in storages)
+        with self._lock:
+            bucket = self._bucket(index)
+            stats = self.stats(index)
+            if key in bucket:
+                stats.bytes -= bucket.pop(key).nbytes
+            bucket[key] = _Entry(
+                value=value, storages=tuple(storages), event=event, nbytes=nbytes
+            )
+            stats.bytes += nbytes
+            self._evict(index)
+        return value
+
+    def contains(self, device, key) -> bool:
+        """Membership without touching LRU order, hit counts or streams.
+
+        The graph-capture warmth check needs to ask "is this already warm?"
+        without the side effects a real hit has.
+        """
+        with self._lock:
+            return key in self._bucket(self._index(device))
+
+    def clear(self, device=None) -> None:
+        """Drop entries without synchronizing."""
+        with self._lock:
+            if device is None:
+                self._buckets.clear()
+                self._stats.clear()
+                return
+            index = self._index(device)
+            self._buckets.pop(index, None)
+            self._stats.pop(index, None)
+
+
+class GraphResourcePins:
+    """Strong references to anything a CUDA graph captured.
+
+    From the start of capture until the graph is destroyed, the compiled
+    artifact, the descriptor storage, the canonical offsets and the validation
+    record must stay alive at their captured addresses.  Replay never re-enters
+    Python, so no hook could renew an LRU position: the only safe policy is to
+    leave the LRU.
+
+    Ownership is the caller's workspace, not this process-wide table -- see
+    :class:`SM120PrefillResources`.  This exists for the pins that outlive an
+    individual workspace, and it deliberately never shrinks.
+    """
+
+    def __init__(self) -> None:
+        self._pinned: dict = {}
+
+    def pin(self, key, *objects) -> None:
+        existing = self._pinned.get(key, ())
+        self._pinned[key] = existing + tuple(o for o in objects if o is not None)
+
+    def is_pinned(self, key) -> bool:
+        return key in self._pinned
+
+    def __len__(self) -> int:
+        return len(self._pinned)
+
+    def clear(self) -> None:
+        """Drop every pin.  For tests only -- a live graph makes this unsafe."""
+        self._pinned.clear()
+
+
+#: The single process-wide pin table.
+GRAPH_PINS = GraphResourcePins()
+
+
+@dataclass
+class IdentityCache:
+    """Weak-reference lookup keyed on ``(id, version)`` of a source tensor.
+
+    Validating ``cu_seqlens`` needs a device-to-host copy, which synchronizes.
+    A caller passing the same tensor object every step must not pay that again,
+    and must still see a rebuild if the tensor is mutated in place -- hence the
+    version check alongside the weak reference.  Values must be lightweight
+    secondary-cache keys: retaining the source tensor or a device payload here
+    would defeat the weak reference and bypass the bounded cache's stream
+    ordering and eviction policy.
+    """
+
+    _entries: dict = field(default_factory=dict)
+
+    def get(self, tensor: torch.Tensor):
+        cached = self._entries.get(id(tensor))
+        if cached is None:
+            return None
+        ref, version, value = cached
+        if ref() is tensor and version == tensor_version(tensor):
+            return value
+        self._entries.pop(id(tensor), None)
+        return None
+
+    def put(self, tensor: torch.Tensor, value) -> None:
+        import weakref
+
+        key = id(tensor)
+
+        def _purge(_ref, _key=key):
+            self._entries.pop(_key, None)
+
+        self._entries[key] = (
+            weakref.ref(tensor, _purge),
+            tensor_version(tensor),
+            value,
+        )
+
+    def drop(self, predicate) -> None:
+        for key in [k for k, (_, _, v) in self._entries.items() if predicate(v)]:
+            self._entries.pop(key, None)
+
+    def clear(self) -> None:
+        self._entries.clear()
+
+
+# ---------------------------------------------------------------------------
+# Flat CuTe views of torch tensors, cached on the address they describe.
+#
+# Every launch converts its tensors with ``from_dlpack(t.reshape(-1))``, and at
+# ~5 us each that is tens of microseconds per launch on tensors whose addresses
+# have not moved.  The conversion is a pure function of (pointer, element
+# count, dtype, alignment), so keying on exactly those four is sound. With
+# ``enable_tvm_ffi=True``, the CuTe view owns a TVM-FFI DLPack consumer object;
+# that object keeps the reshaped tensor's storage alive until the view is
+# evicted. The allocator therefore cannot recycle a live entry's address, and
+# the LRU below bounds that retention.
+# ---------------------------------------------------------------------------
+
+#: Bounded so a workload cycling through many buffers cannot grow it without
+#: limit.  A forward touches ~25 tensors, so this holds several shapes' worth.
+#:
+#: One of three caches that can hold a buffer alive -- the others are the plan
+#: memo and :data:`MAX_ENTRIES` -- and any one of them is enough.  Measured:
+#: lowering this alone changes the retention by nothing at all, because the
+#: plan memo still has the tensors; the three only bind together.
+FLAT_VIEW_MAX_ENTRIES = 256
+
+_FLAT_VIEWS: "OrderedDict[tuple, Any]" = OrderedDict()
+_FLAT_STATS = {"hits": 0, "misses": 0}
+
+#: Held on the miss path only.  ``flat_view`` runs once per tensor per launch --
+#: five times before a kernel that can be nine microseconds long -- so a lock on
+#: the hit path is measurable where one on the miss path is not.  The hit path
+#: is two C-level dict operations, each atomic under the GIL: the worst a race
+#: can do there is evict an entry that was just touched, which costs one rebuild
+#: and no correctness.  ``_FLAT_STATS`` is advisory for the same reason; its
+#: increments are not atomic and are not read by anything that decides.
+_FLAT_VIEWS_LOCK = threading.RLock()
+
+
+def _require_tvm_ffi() -> None:
+    """``apache-tvm-ffi`` is not optional for this backend.
+
+    The persistent cache reloads artifacts with
+    ``load_module(..., enable_tvm_ffi=True)``, and the compiled entry rejects
+    a view built without it (``'_Tensor' object has no attribute
+    '_tvm_ffi_tensor'``).  Falling back to the ctypes argument path would cost
+    ~3.3x of the host path silently, which is the kind of regression that gets
+    attributed to the kernel months later.
+    """
+    if importlib.util.find_spec("tvm_ffi") is None:
+        raise RuntimeError(
+            "the SM120 KDA prefill backend requires `apache-tvm-ffi`, which "
+            "FlashInfer already depends on; reinstall the package"
+        )
+
+
+def flat_view(tensor: torch.Tensor, *, align: int = 16):
+    """``from_dlpack(tensor.reshape(-1))``, reused when the address repeats.
+
+    The returned TVM-FFI view retains the reshape's storage under DLPack's
+    consumer-ownership contract, so each cached entry pins one allocation.
+    :data:`FLAT_VIEW_MAX_ENTRIES` bounds that retention.
+
+    Safe inside ``torch.cuda.graph``: a dict lookup and, on a miss, the same
+    conversion the caller would have done anyway.  It issues no CUDA work and
+    records no events, unlike :class:`BoundedDeviceCache`.
+    """
+    if not tensor.is_contiguous():
+        raise KDAPrefillValidationError(
+            "flat_view requires a contiguous tensor; reshaping a strided "
+            "tensor would create a copy at a different address"
+        )
+
+    from cutlass.cute.runtime import from_dlpack
+
+    key = (tensor.data_ptr(), tensor.numel(), tensor.dtype, align)
+    hit = _FLAT_VIEWS.get(key)
+    if hit is not None:
+        _FLAT_VIEWS.move_to_end(key)
+        _FLAT_STATS["hits"] += 1
+        return hit
+
+    _FLAT_STATS["misses"] += 1
+    _require_tvm_ffi()
+    view = from_dlpack(tensor.reshape(-1), assumed_align=align, enable_tvm_ffi=True)
+    # Under tvm-ffi the extent is part of the compiled entry's signature, so a
+    # plan compiled for one sequence length would reject the next.  Keying the
+    # compile cache on shape would fix the error and reintroduce one compile
+    # per length; marking the single flat dimension dynamic keeps one entry.
+    view = view.mark_layout_dynamic()
+    with _FLAT_VIEWS_LOCK:
+        _FLAT_VIEWS[key] = view
+        while len(_FLAT_VIEWS) > FLAT_VIEW_MAX_ENTRIES:
+            _FLAT_VIEWS.popitem(last=False)
+    return view
+
+
+def flat_view_stats() -> dict:
+    return dict(_FLAT_STATS, entries=len(_FLAT_VIEWS))
+
+
+def clear_flat_views() -> None:
+    with _FLAT_VIEWS_LOCK:
+        _FLAT_VIEWS.clear()
+        _FLAT_STATS.update(hits=0, misses=0)
+
+
+# ---------------------------------------------------------------------------
+# Capture-safe descriptor upload.
+#
+# A descriptor build copies from pageable host memory, which is a 0.0 us memcpy
+# outside a capture and fatal inside one:
+#
+#     RuntimeError: Cannot copy between CPU and CUDA tensors during CUDA graph
+#     capture unless the CPU tensor is pinned.
+#
+# A descriptor build is supposed to be a cache miss only, but a capture runs on
+# its own stream, so anything keyed by stream misses exactly when it matters.
+# Staging through pinned memory makes the upload legal either way.
+# ---------------------------------------------------------------------------
+
+#: Pinned staging buffers, one per size, each paired with the event that says
+#: its last upload has been read.  Descriptor blobs are a few hundred bytes and
+#: come in a handful of sizes, so this stays tiny.
+#:
+#: The event is what makes the reuse safe.  A ``non_blocking`` copy out of
+#: pinned memory returns before the transfer runs -- it is queued behind
+#: whatever else is on the stream, which in a busy loop is milliseconds -- so
+#: refilling the buffer for the next descriptor build would overwrite bytes the
+#: DMA has not read yet, and the descriptor that reached the device would be a
+#: mix of two.  Two builds of one size is the common case rather than a corner:
+#: the sizes are a function of the descriptor count, so any two cold calls of
+#: the same shape collide.  Waiting here costs nothing a steady state pays,
+#: because a build is a cache miss only.
+_PINNED_STAGING: dict = {}
+_PINNED_STAGING_LOCK = threading.RLock()
+
+#: Staging buffers whose upload was captured into a CUDA graph.  A captured H2D
+#: node reads its source at *replay*, so such a buffer can never be refilled --
+#: no host wait exists to place before a replay.  It leaves the pool instead and
+#: is held for the process's lifetime; the alternative is a graph that uploads
+#: whichever descriptor was built last.
+_CAPTURED_STAGING: list = []
+
+
+def upload_bytes(payload, device: torch.device) -> torch.Tensor:
+    """Copy ``payload`` to ``device`` in a way a graph capture accepts."""
+    size = len(payload)
+    if device.type != "cuda" or not torch.cuda.is_available():
+        # No device to pin against and no capture to be safe for.
+        return torch.frombuffer(bytearray(payload), dtype=torch.uint8).clone()
+    # Keep ownership from checkout through publication.  Two cold builds of
+    # the same descriptor size otherwise both see an empty slot and the later
+    # publication orphans the earlier buffer while its H2D copy is in flight.
+    with _PINNED_STAGING_LOCK:
+        entry = _PINNED_STAGING.pop(size, None)
+        if entry is None:
+            staging = torch.empty(size, dtype=torch.uint8, pin_memory=True)
+        else:
+            staging, pending = entry
+            if pending is not None:
+                pending.synchronize()
+        # frombuffer needs a writable buffer; bytes is not one.
+        staging.copy_(torch.frombuffer(bytearray(payload), dtype=torch.uint8))
+        out = torch.empty(size, dtype=torch.uint8, device=device)
+        out.copy_(staging, non_blocking=True)
+        if capturing():
+            _CAPTURED_STAGING.append(staging)
+            return out
+        event = torch.cuda.Event()
+        event.record(torch.cuda.current_stream(device))
+        _PINNED_STAGING[size] = (staging, event)
+        return out
+
+
+def clear_pinned_staging() -> None:
+    """Drain and drop the pool; captured buffers remain pinned for replay."""
+    with _PINNED_STAGING_LOCK:
+        for _staging, pending in _PINNED_STAGING.values():
+            if pending is not None:
+                pending.synchronize()
+        _PINNED_STAGING.clear()
+
+
+# ---------------------------------------------------------------------------
+# Storage-range aliasing.
+#
+# Aliasing is decided on byte ranges, not on storage identity: two tensors can
+# share a storage object and never overlap, and two tensors from different
+# allocations can be views of one block.
+# ---------------------------------------------------------------------------
+
+
+def storage_interval(tensor: Optional[torch.Tensor]):
+    """``[data_ptr, data_ptr + numel * element_size)``; ``None`` when empty.
+
+    Every tensor reaching this point is contiguous, so the interval is exactly
+    the bytes the tensor owns.  A zero-element tensor owns nothing and cannot
+    alias anything.
+    """
+    if tensor is None or tensor.numel() == 0:
+        return None
+    start = tensor.data_ptr()
+    return (start, start + tensor.numel() * tensor.element_size())
+
+
+def intervals_overlap(a, b) -> bool:
+    if a is None or b is None:
+        return False
+    return a[0] < b[1] and b[0] < a[1]
+
+
+def is_exact_alias(x: Optional[torch.Tensor], y: Optional[torch.Tensor]) -> bool:
+    """Same bytes, dtype, shape and stride -- the only reuse either variant allows."""
+    if x is None or y is None:
+        return False
+    return (
+        storage_interval(x) == storage_interval(y)
+        and x.dtype == y.dtype
+        and x.shape == y.shape
+        and x.stride() == y.stride()
+    )
+
+
+# Moved here from the decomposed variant: both variants have to check their
+# grid against the device, so the helper that asks the driver belongs with
+# the other shared device queries rather than inside one of them.
+_GRID_LIMITS: dict[int, tuple[int, int]] = {}
+
+
+def max_grid_dims(device: torch.device) -> tuple[int, int]:
+    """``(maxGridSize[0], maxGridSize[1])`` for ``device``.
+
+    ``torch.cuda.get_device_properties`` does not expose the grid limits, so
+    this goes to the driver, and caches: plan Section 9.2 runs the check on
+    every launch, before anything is allocated.
+    """
+    index = torch.cuda.current_device() if device.index is None else device.index
+    cached = _GRID_LIMITS.get(index)
+    if cached is not None:
+        return cached
+
+    import cuda.bindings.driver as drv
+
+    attributes = (
+        drv.CUdevice_attribute.CU_DEVICE_ATTRIBUTE_MAX_GRID_DIM_X,
+        drv.CUdevice_attribute.CU_DEVICE_ATTRIBUTE_MAX_GRID_DIM_Y,
+    )
+    values = []
+    for attribute in attributes:
+        err, value = drv.cuDeviceGetAttribute(attribute, index)
+        if int(err) != 0:
+            raise RuntimeError(f"cuDeviceGetAttribute failed: {err}")
+        values.append(int(value))
+    limits = (values[0], values[1])
+    _GRID_LIMITS[index] = limits
+    return limits
+
+
+def check_tma_base_alignment(named: dict) -> None:
+    """Every tensor a TensorMap describes must have a 16-byte-aligned base."""
+    for name in ("q", "k", "v", "g", "out", "initial_state", "final_state"):
+        tensor = named.get(name)
+        if tensor is None or tensor.numel() == 0:
+            continue
+        if tensor.data_ptr() % GLOBAL_BASE_ALIGN:
+            raise KDAPrefillValidationError(
+                f"{name} must be {GLOBAL_BASE_ALIGN}-byte aligned for TMA, got "
+                f"{tensor.data_ptr():#x}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# The canonical launch description.
+#
+# Both variants accept the same public arguments and reduce them to the same
+# facts before doing anything variant-specific.  Producing that reduction once
+# is what keeps the two from disagreeing about, say, whether a zero-token call
+# has zero sequences or one.
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class CanonicalInputs:
+    """What the validated arguments say about the launch."""
+
+    input_mode: str
+    batch: int
+    tokens_per_sequence: int
+    sequences: int
+    heads: int
+    total_tokens: int
+    g_fp32: bool
+    state_dtype: Optional[torch.dtype]
+    has_initial_state: bool
+    has_final_state: bool
+    out_aliases_v: bool
+
+
+def _require(condition: bool, message: str) -> None:
+    if not condition:
+        raise KDAPrefillValidationError(message)
+
+
+def _check_device_and_contiguity(named: dict) -> torch.device:
+    present = {n: t for n, t in named.items() if t is not None}
+    _require(bool(present), "no tensors supplied")
+    devices = {n: t.device for n, t in present.items()}
+    first_name, device = next(iter(devices.items()))
+    _require(device.type == "cuda", f"{first_name} must be on a CUDA device")
+    for name, dev in devices.items():
+        _require(
+            dev == device,
+            f"all tensors must share one CUDA device: {first_name} is on "
+            f"{device}, {name} is on {dev}",
+        )
+    for name, tensor in present.items():
+        _require(tensor.is_contiguous(), f"{name} must be contiguous")
+    return device
+
+
+def _check_dtypes(named: dict) -> None:
+    for name in ("q", "k", "v", "out"):
+        tensor = named[name]
+        _require(
+            tensor.dtype is torch.bfloat16, f"{name} must be BF16, got {tensor.dtype}"
+        )
+    _require(
+        named["g"].dtype in (torch.bfloat16, torch.float32),
+        f"g must be BF16 or FP32, got {named['g'].dtype}",
+    )
+    _require(
+        named["beta"].dtype is torch.bfloat16,
+        f"beta must be BF16, got {named['beta'].dtype}",
+    )
+    for name in ("A_log", "dt_bias"):
+        _require(
+            named[name].dtype is torch.float32,
+            f"{name} must be FP32, got {named[name].dtype}",
+        )
+
+
+def _check_aliasing(named: dict, out_aliases_v: bool) -> None:
+    """Refuse every overlap except the two the kernels' schedules prove safe.
+
+    ``out`` may alias ``v``, since a chunk's output is published only after
+    that chunk's V has been loaded and consumed; ``initial_state`` may alias
+    ``final_state``, since all initial loads finish before the chunk loop and
+    the final store happens after it drains.  Both are *exact* aliases only: a
+    partial overlap is refused, because the overwrite proof covers exactly the
+    exact-alias case and nothing else.
+
+    Read-only inputs may overlap each other freely -- a caller broadcasting one
+    buffer into several of them is fine.  The moment ``out`` aliases ``v``,
+    though, ``out`` still has to be disjoint from all the others.
+    """
+    out = named["out"]
+    out_range = storage_interval(out)
+
+    for name in READ_ONLY_ROLES + ("cu_seqlens", "initial_state", "final_state"):
+        other = named.get(name)
+        if other is None:
+            continue
+        if name == "v" and out_aliases_v:
+            continue
+        _require(
+            not intervals_overlap(out_range, storage_interval(other)),
+            f"out must not overlap {name}; only an exact alias with v is allowed",
+        )
+
+    initial = named.get("initial_state")
+    final = named.get("final_state")
+    if initial is not None and final is not None:
+        _require(
+            initial.dtype == final.dtype,
+            "initial_state and final_state must have the same dtype, got "
+            f"{initial.dtype} and {final.dtype}",
+        )
+        if not is_exact_alias(initial, final):
+            _require(
+                not intervals_overlap(
+                    storage_interval(initial), storage_interval(final)
+                ),
+                "initial_state and final_state may only alias exactly; a "
+                "partial overlap is rejected",
+            )
+
+    for state_name in ("initial_state", "final_state"):
+        state = named.get(state_name)
+        if state is None:
+            continue
+        state_range = storage_interval(state)
+        for other_name in READ_ONLY_ROLES + ("cu_seqlens",):
+            other = named.get(other_name)
+            if other is None:
+                continue
+            _require(
+                not intervals_overlap(state_range, storage_interval(other)),
+                f"{state_name} must not overlap {other_name}",
+            )
+
+
+def check_flat_output_range(total_tokens: int, heads: int) -> None:
+    """Refuse a shape whose flat output does not fit in an INT32 extent.
+
+    Two things need this bound and they disagree by exactly one element, so the
+    tighter of the two is what is checked:
+
+    * The tail store writes a partial chunk element-wise through ``(token * H +
+      head) * DV + d``, built and consumed as INT32 on the device.  That needs
+      the largest *index*, ``T_total * H * DV - 1``, to fit.  Full chunks go
+      out through TMA, which addresses the same elements through a descriptor.
+    * The CuTe DSL packs a memref descriptor's extents as INT32 when the flat
+      view of the output crosses into the compiled entry, so it needs the
+      *count* to fit -- one more than the largest index.
+
+    The second is the binding one, and it was measured rather than assumed: at
+    exactly 2**31 elements the DSL raises ``OverflowError: Value overflow:
+    2147483648 exceeds range of l`` out of ``build_memref_desc``, which names
+    neither the tensor nor the shape that caused it.  So the count is the
+    bound, and both failures are refused here where the shape is still in hand:
+    the wrapped index would write far below the buffer without saying anything,
+    and the DSL error arrives at compile time with nothing a caller can act on.
+    """
+    elements = total_tokens * heads * DV
+    if elements > INT32_MAX:
+        raise KDAPrefillValidationError(
+            f"the flat output would hold {elements} elements, which does not "
+            f"fit in a non-negative INT32 (T_total={total_tokens}, H={heads}, "
+            f"DV={DV}); the largest T_total at this head count is "
+            f"{INT32_MAX // (heads * DV)}"
+        )
+
+
+def validate_inputs(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor,
+    beta: torch.Tensor,
+    out: torch.Tensor,
+    A_log: torch.Tensor,
+    dt_bias: torch.Tensor,
+    *,
+    scale: float,
+    lower_bound: float,
+    initial_state: Optional[torch.Tensor] = None,
+    final_state: Optional[torch.Tensor] = None,
+    cu_seqlens: Optional[torch.Tensor] = None,
+) -> CanonicalInputs:
+    """Validate the backend ABI and describe the canonical launch.
+
+    Everything here is checked before a single byte moves, and none of it reads
+    element values, so the result is a pure function of shapes, dtypes,
+    devices, addresses and two floats -- which is what makes it cacheable.
+    """
+    named = {
+        "q": q,
+        "k": k,
+        "v": v,
+        "g": g,
+        "beta": beta,
+        "out": out,
+        "A_log": A_log,
+        "dt_bias": dt_bias,
+        "cu_seqlens": cu_seqlens,
+        "initial_state": initial_state,
+        "final_state": final_state,
+    }
+    _check_device_and_contiguity(named)
+    _check_dtypes(named)
+
+    for name in ("q", "k", "v", "g"):
+        tensor = named[name]
+        _require(tensor.dim() == 4, f"{name} must be rank 4, got {tensor.dim()}")
+    _require(
+        tuple(q.shape) == tuple(k.shape) == tuple(g.shape),
+        "q, k and g must have identical shapes, got "
+        f"{tuple(q.shape)}, {tuple(k.shape)}, {tuple(g.shape)}",
+    )
+    _require(
+        tuple(v.shape) == tuple(q.shape),
+        f"v must have q's shape, got {tuple(v.shape)} against {tuple(q.shape)}",
+    )
+    _require(q.shape[3] == DK, f"the key dimension is fixed at {DK}, got {q.shape[3]}")
+    _require(
+        v.shape[3] == DV, f"the value dimension is fixed at {DV}, got {v.shape[3]}"
+    )
+    _require(
+        tuple(beta.shape) == tuple(q.shape[:3]),
+        f"beta must be q without its last dimension, got {tuple(beta.shape)} "
+        f"against {tuple(q.shape[:3])}",
+    )
+    _require(
+        tuple(out.shape) == tuple(v.shape) and out.dtype == v.dtype,
+        "out must have v's shape and dtype, got "
+        f"{tuple(out.shape)}/{out.dtype} against {tuple(v.shape)}/{v.dtype}",
+    )
+
+    batch, tokens, heads = q.shape[0], q.shape[1], q.shape[2]
+    _require(heads > 0, f"H must be positive, got {heads}")
+    _require(
+        tuple(A_log.shape) == (heads,),
+        f"A_log must be [H] = [{heads}], got {tuple(A_log.shape)}",
+    )
+    _require(
+        tuple(dt_bias.shape) == (heads, DK),
+        f"dt_bias must be [H, {DK}] = [{heads}, {DK}], got {tuple(dt_bias.shape)}",
+    )
+
+    if cu_seqlens is None:
+        input_mode = "fixed"
+        _require(batch >= 0, f"fixed mode needs B >= 0, got {batch}")
+        _require(tokens >= 0, f"fixed mode needs T >= 0, got {tokens}")
+        sequences = batch
+        total_tokens = batch * tokens
+    else:
+        input_mode = "packed"
+        _require(
+            batch == 1,
+            f"packed mode needs the leading dimension to be exactly 1, got {batch}",
+        )
+        _require(tokens >= 0, f"packed mode needs T_total >= 0, got {tokens}")
+        _require(
+            cu_seqlens.dtype in (torch.int32, torch.int64),
+            f"cu_seqlens must be INT32 or INT64, got {cu_seqlens.dtype}",
+        )
+        _require(cu_seqlens.dim() == 1, "cu_seqlens must be 1-D")
+        _require(
+            cu_seqlens.numel() >= 2,
+            f"cu_seqlens must have N + 1 >= 2 entries, got {cu_seqlens.numel()}",
+        )
+        sequences = cu_seqlens.numel() - 1
+        total_tokens = tokens
+
+    state_dtype: Optional[torch.dtype] = None
+    for name in ("initial_state", "final_state"):
+        state = named[name]
+        if state is None:
+            continue
+        _require(
+            state.dtype in (torch.bfloat16, torch.float32),
+            f"{name} must be BF16 or FP32, got {state.dtype}",
+        )
+        _require(
+            tuple(state.shape) == (sequences, heads, DV, DK),
+            f"{name} must be [N, H, {DV}, {DK}] = "
+            f"[{sequences}, {heads}, {DV}, {DK}], got {tuple(state.shape)}",
+        )
+    if initial_state is not None:
+        state_dtype = initial_state.dtype
+    elif final_state is not None:
+        state_dtype = final_state.dtype
+
+    _require(math.isfinite(float(scale)), f"scale must be finite, got {scale}")
+    _require(
+        math.isfinite(float(lower_bound)),
+        f"lower_bound must be finite, got {lower_bound}",
+    )
+    low, high = LOWER_BOUND_RANGE
+    _require(
+        low <= float(lower_bound) <= high,
+        f"lower_bound must be in [{low}, {high}], got {lower_bound}",
+    )
+
+    check_tma_base_alignment(named)
+    out_aliases_v = is_exact_alias(out, v)
+    if not out_aliases_v:
+        _require(
+            not intervals_overlap(storage_interval(out), storage_interval(v)),
+            "out may alias v only exactly (same base, dtype, shape and stride)",
+        )
+    _check_aliasing(named, out_aliases_v)
+
+    return CanonicalInputs(
+        input_mode=input_mode,
+        batch=batch,
+        tokens_per_sequence=tokens,
+        sequences=sequences,
+        heads=heads,
+        total_tokens=total_tokens,
+        g_fp32=g.dtype is torch.float32,
+        state_dtype=state_dtype,
+        has_initial_state=initial_state is not None,
+        has_final_state=final_state is not None,
+        out_aliases_v=out_aliases_v,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Canonical INT32 offsets.
+#
+# The device kernels take exactly one metadata tensor: a device INT32
+# ``cu_seqlens`` of length ``N + 1``.  Everything the two public input modes
+# differ by is resolved before launch:
+#
+# * **fixed** ``[B, T, H, 128]`` becomes ``arange(0, (B + 1) * T, T)``;
+# * **packed varlen** validates the caller's ``cu_seqlens`` and, for INT64,
+#   converts it -- *after* the range check, never before.  Narrowing first and
+#   checking the narrowed value cannot detect the overflow it just caused.
+#
+# Validation reads the offsets on the host, which synchronizes.  That is why
+# the result is cached on the source tensor's identity *and* version: a caller
+# passing the same tensor every step pays once, and an in-place mutation still
+# invalidates.  Inside a capture the read is illegal, so a miss there is an
+# error rather than something to work around.
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class CanonicalOffsets:
+    """A validated canonical INT32 ``cu_seqlens`` and what produced it.
+
+    ``source`` and ``canonical`` are both strong references.  Keeping the
+    source alive is not redundant: the cache key contains its ``data_ptr``, and
+    an allocator that freed it and handed the same address to an unrelated
+    tensor would otherwise produce a false hit.
+    """
+
+    key: tuple
+    source: torch.Tensor
+    canonical: torch.Tensor
+    sequences: int
+    total_tokens: int
+    lengths: tuple
+    #: Host copy of the offsets themselves, so a variant can derive its own
+    #: metadata (chunk counts, task bins) without a second synchronization.
+    host: tuple
+
+    @property
+    def longest_sequence(self) -> int:
+        return max(self.lengths, default=0)
+
+
+_PACKED_OFFSETS = BoundedDeviceCache("kda-sm120-packed-offsets")
+_FIXED_OFFSETS = BoundedDeviceCache("kda-sm120-fixed-offsets")
+
+
+def _packed_key(cu_seqlens: torch.Tensor, total_tokens: int) -> tuple:
+    device = cu_seqlens.device
+    return (
+        device.type,
+        device.index,
+        cu_seqlens.data_ptr(),
+        cu_seqlens.dtype,
+        tuple(cu_seqlens.shape),
+        tensor_version(cu_seqlens),
+        total_tokens,
+    )
+
+
+def validate_packed_offsets(
+    cu_seqlens: torch.Tensor, total_tokens: int
+) -> CanonicalOffsets:
+    """Validate and canonicalize a packed ``cu_seqlens``."""
+    if cu_seqlens.device.type != "cuda":
+        raise KDAPrefillValidationError("cu_seqlens must live on a CUDA device")
+    if not cu_seqlens.is_contiguous():
+        raise KDAPrefillValidationError("cu_seqlens must be contiguous")
+    if cu_seqlens.dim() != 1:
+        raise KDAPrefillValidationError(
+            f"cu_seqlens must be 1-D, got shape {tuple(cu_seqlens.shape)}"
+        )
+    if cu_seqlens.dtype not in (torch.int32, torch.int64):
+        raise KDAPrefillValidationError(
+            f"cu_seqlens must be INT32 or INT64, got {cu_seqlens.dtype}"
+        )
+    if cu_seqlens.numel() < 2:
+        raise KDAPrefillValidationError(
+            f"cu_seqlens must have N + 1 >= 2 entries, got {cu_seqlens.numel()}"
+        )
+
+    key = _packed_key(cu_seqlens, total_tokens)
+    hit = _PACKED_OFFSETS.get(cu_seqlens.device, key)
+    if hit is not None:
+        return hit
+    if capturing():
+        raise RuntimeError(
+            "CUDA graph capture cannot validate cu_seqlens: it needs a "
+            "device-to-host copy.  Warm the workspace with one eager call "
+            "using the same offsets tensor before capturing"
+        )
+
+    # One synchronizing read, on the caller's dtype.  INT64 is checked here and
+    # narrowed only afterwards.
+    host = cu_seqlens.detach().cpu().tolist()
+    if host[0] != 0:
+        raise KDAPrefillValidationError(f"cu_seqlens must start at 0, got {host[0]}")
+    if host[-1] != total_tokens:
+        raise KDAPrefillValidationError(
+            f"cu_seqlens must end at T_total={total_tokens}, got {host[-1]}"
+        )
+    lengths = []
+    for i in range(len(host) - 1):
+        length = host[i + 1] - host[i]
+        if length < 0:
+            raise KDAPrefillValidationError(
+                f"cu_seqlens must be non-decreasing; entry {i + 1} "
+                f"({host[i + 1]}) is below entry {i} ({host[i]})"
+            )
+        lengths.append(length)
+    if not 0 <= host[-1] <= INT32_MAX:
+        raise KDAPrefillValidationError(
+            f"T_total={host[-1]} does not fit in a non-negative INT32"
+        )
+
+    canonical = (
+        cu_seqlens if cu_seqlens.dtype is torch.int32 else cu_seqlens.to(torch.int32)
+    )
+    record = CanonicalOffsets(
+        key=key,
+        source=cu_seqlens,
+        canonical=canonical,
+        sequences=len(host) - 1,
+        total_tokens=total_tokens,
+        lengths=tuple(lengths),
+        host=tuple(host),
+    )
+    _PACKED_OFFSETS.put(cu_seqlens.device, key, record, (canonical,))
+    return record
+
+
+def fixed_offsets(batch: int, tokens: int, device) -> CanonicalOffsets:
+    """Canonical offsets for fixed mode: ``arange(0, (B + 1) * T, T)``.
+
+    ``T == 0`` builds an explicit zero tensor of length ``B + 1`` rather than
+    calling ``arange`` with a zero step, which raises.
+    """
+    if batch < 0:
+        raise KDAPrefillValidationError(f"fixed mode needs B >= 0, got {batch}")
+    if tokens < 0:
+        raise KDAPrefillValidationError(f"fixed mode needs T >= 0, got {tokens}")
+    total_tokens = batch * tokens
+    if total_tokens > INT32_MAX:
+        raise KDAPrefillValidationError(
+            f"B * T = {total_tokens} does not fit in a non-negative INT32"
+        )
+
+    key = (device.type, device.index, batch, tokens)
+    hit = _FIXED_OFFSETS.get(device, key)
+    if hit is not None:
+        return hit
+    if capturing():
+        raise RuntimeError(
+            "CUDA graph capture cannot allocate canonical offsets; warm the "
+            "workspace with one eager call at the same (B, T) before capturing"
+        )
+
+    if tokens == 0:
+        canonical = torch.zeros(batch + 1, dtype=torch.int32, device=device)
+    else:
+        canonical = torch.arange(
+            0, (batch + 1) * tokens, tokens, dtype=torch.int32, device=device
+        )
+    record = CanonicalOffsets(
+        key=key,
+        source=canonical,
+        canonical=canonical,
+        sequences=batch,
+        total_tokens=total_tokens,
+        lengths=(tokens,) * batch,
+        host=tuple(range(0, (batch + 1) * tokens, tokens))
+        if tokens
+        else (0,) * (batch + 1),
+    )
+    return _FIXED_OFFSETS.put(device, key, record, (canonical,))
+
+
+def canonical_offsets(
+    cu_seqlens: Optional[torch.Tensor],
+    *,
+    batch: int,
+    tokens: int,
+    total_tokens: int,
+    device,
+) -> CanonicalOffsets:
+    """The one entry point both variants use to reach canonical INT32 offsets."""
+    if cu_seqlens is None:
+        return fixed_offsets(batch, tokens, device)
+    return validate_packed_offsets(cu_seqlens, total_tokens)
+
+
+def offsets_cache_stats(device) -> dict:
+    return {
+        "packed": _PACKED_OFFSETS.stats(device),
+        "fixed": _FIXED_OFFSETS.stats(device),
+    }
+
+
+def clear_offsets_caches() -> None:
+    _PACKED_OFFSETS.clear()
+    _FIXED_OFFSETS.clear()
+
+
+# ---------------------------------------------------------------------------
+# The workspace resource slot.
+#
+# ``RecurrentKDAPrefillWorkspace`` is the only public workspace, and it is
+# shared with the SM100-family Cake backend.  This is what a workspace holds
+# *for* this backend, created lazily on the first eager warmup so a Cake-only
+# caller pays one ``None`` field and never imports CuTe DSL.
+#
+# Once a workspace enters capture, everything about it freezes: the backend,
+# the variant, the stream, the tensor addresses, the shapes, the strides, the
+# dtypes, the capacity and the packed metadata signature.  A bound workspace is
+# not reusable by another backend, another graph, another stream or a Python
+# eager call -- a caller needing another signature creates another workspace.
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class SM120PrefillResources:
+    """Per-workspace SM120 state, composed into the public workspace.
+
+    Deliberately a plain container: the pieces it holds are built by whichever
+    variant is bound, and it exists so the *lifetime* of those pieces is the
+    workspace's rather than a process-global cache's.  A CUDA graph replays
+    without re-entering Python, so anything it captured has to stay alive at
+    its captured address for as long as the graph does; that is what this owns.
+    """
+
+    device: torch.device
+    #: Stable identity for process-wide plan caches.  Using ``id(self)`` would
+    #: let Python reuse a destroyed workspace's address while its cache entry
+    #: still exists, and omitting the workspace would let two live workspaces
+    #: share captured buffers and descriptors.
+    cache_token: object = field(
+        default_factory=object, init=False, repr=False, compare=False
+    )
+    #: Serializes the whole launch sequence.  The decomp variant enqueues two
+    #: kernels that share a scratch arena, so a second host thread must not
+    #: interleave its own prepare between this call's prepare and recurrence.
+    lock: threading.Lock = field(default_factory=threading.Lock, repr=False)
+
+    #: The canonical INT32 offsets buffer replay copies into.  Allocated at
+    #: warmup and grown only there.
+    cu_seqlens_i32: Optional[torch.Tensor] = None
+    #: Decomp's chunk tables, frozen at warmup.  ``None`` for fused.
+    cu_chunks_i32: Optional[torch.Tensor] = None
+    chunk_to_seq_i32: Optional[torch.Tensor] = None
+    #: Decomp's factor arena.
+    scratch: Any = None
+    #: Stable final-state scratch for ``initial_state=None,
+    #: output_final_state=True``, which cannot allocate during capture.
+    state_scratch: Optional[torch.Tensor] = None
+    #: Descriptor storage and any other object a captured graph reads.
+    pins: tuple = ()
+
+    #: What this workspace is bound to.  Set on first use and then immutable.
+    variant: Optional[str] = None
+    stream_ptr: Optional[int] = None
+    signature: Optional[tuple] = None
+    captured: bool = False
+
+    def bind(self, *, variant: str, stream_ptr: int, signature: tuple) -> None:
+        """Pin this workspace to one variant, stream and call signature."""
+        if self.captured:
+            raise RuntimeError(
+                "this RecurrentKDAPrefillWorkspace has already participated in "
+                "a CUDA graph capture and cannot be reused; create another one"
+            )
+        for name, current, incoming in (
+            ("variant", self.variant, variant),
+            ("stream", self.stream_ptr, stream_ptr),
+            ("call signature", self.signature, signature),
+        ):
+            if current is not None and current != incoming:
+                raise RuntimeError(
+                    f"RecurrentKDAPrefillWorkspace is bound to a different "
+                    f"{name} ({current!r} against {incoming!r}); create a "
+                    f"separate workspace for it"
+                )
+        self.variant = variant
+        self.stream_ptr = stream_ptr
+        self.signature = signature
+
+    def pin(self, *objects) -> None:
+        """Hold strong references for the lifetime of this workspace."""
+        self.pins = self.pins + tuple(o for o in objects if o is not None)
+
+    def ensure_capacity(
+        self, name: str, elements: int, dtype: torch.dtype
+    ) -> torch.Tensor:
+        """A buffer of at least ``elements``, grown only outside capture.
+
+        Monotonic on purpose: shrinking would move an address a captured graph
+        already recorded.
+        """
+        current = getattr(self, name)
+        if current is not None and current.numel() >= elements:
+            return current[:elements]
+        if capturing():
+            raise RuntimeError(
+                f"CUDA graph capture cannot grow the workspace's {name} buffer; "
+                f"warm it eagerly at this size first"
+            )
+        grown = torch.empty(elements, dtype=dtype, device=self.device)
+        setattr(self, name, grown)
+        return grown
+
+    # -- the decomposed variant's frozen tables ---------------------------- #
+    #
+    # Held here rather than in a module-level cache for the reason every other
+    # graph resource is: replay reads them at the addresses capture recorded,
+    # and an LRU that evicted one would leave a live graph reading freed
+    # memory.  The signature is the offsets themselves, so a caller that
+    # changes its sequence lengths gets a rebuild -- eagerly, or an error if it
+    # tries during capture.
+
+    _chunk_signature: Optional[tuple] = None
+    _chunk_tables: Any = None
+    _arena_shape: Optional[tuple] = None
+    _arena: Any = None
+
+    def chunk_signature_matches(self, signature: tuple):
+        """The frozen chunk tables iff they were built for ``signature``."""
+        if self._chunk_signature == signature:
+            return self._chunk_tables
+        return None
+
+    def freeze_chunk_tables(self, signature: tuple, tables: Any) -> None:
+        self._chunk_signature = signature
+        self._chunk_tables = tables
+
+    def scratch_arena(self, shape: tuple, factory):
+        """A variant's scratch, allocated once per shape and held here.
+
+        ``factory`` builds it; this module never learns what it is.  That
+        inversion is the point -- the container owns the *lifetime*, which is
+        what a captured graph needs, and the variant owns the *contents*, which
+        is what neither variant can share with the other.  A ``runtime`` that
+        imported a variant to build this would be the reverse dependency the
+        package layout exists to prevent.
+        """
+        if self._arena_shape == shape and self._arena is not None:
+            return self._arena
+        if capturing():
+            raise RuntimeError(
+                "CUDA graph capture cannot allocate workspace scratch; warm "
+                "the workspace with one eager call at this shape first"
+            )
+        self._arena = factory()
+        self._arena_shape = shape
+        return self._arena
+
+
+def current_stream_ptr(device: Optional[torch.device] = None) -> int:
+    """The current CUDA stream's raw handle.
+
+    Only ever compared, never dereferenced.  ``torch.cuda.current_stream()``
+    builds a Stream object through five Python frames, which is measurable once
+    the rest of the host path is memoized, so the raw accessor is used where
+    this torch provides it.
+    """
+    if not torch.cuda.is_available():
+        return 0
+    if _raw_stream is not None:
+        index = torch.cuda.current_device() if device is None else device.index
+        return _raw_stream(torch.cuda.current_device() if index is None else index)
+    return torch.cuda.current_stream(device).cuda_stream
+
+
+try:  # pragma: no cover - exercised by whichever branch this torch provides
+    from torch._C import _cuda_getCurrentRawStream as _raw_stream
+except ImportError:  # pragma: no cover
+    _raw_stream = None
+
+
+#: Stands for "this tensor does not track a version counter", which is the
+#: case for every tensor created under ``torch.inference_mode()``.
+NO_VERSION = object()
+
+
+def tensor_version(tensor: torch.Tensor):
+    """``tensor._version``, or :data:`NO_VERSION` where it does not exist.
+
+    Reading ``_version`` on an inference tensor raises ``RuntimeError:
+    Inference tensors do not track version counter``, and ``inference_mode`` is
+    how serving actually calls this backend -- so a cache that reads it
+    unguarded works in a benchmark and fails in production.
+
+    The consequence is worth stating rather than hiding. The version guards
+    against an in-place edit at an unchanged address; without it, a cached
+    entry for such a tensor cannot be invalidated by content. For the
+    activations that does not matter: a call plan is a function of addresses,
+    shapes and dtypes, and their contents are *expected* to change between
+    calls. It matters for ``cu_seqlens``, whose values are read on the host --
+    so under ``inference_mode`` those values are a caller contract, exactly as
+    they already are for the SM100-family backend. A caller who refills an
+    offsets buffer in place must either use a different buffer or call
+    ``clear_kda_prefill_sm120_caches()``.
+    """
+    try:
+        return tensor._version
+    except RuntimeError:
+        return NO_VERSION
+
+
+def tensor_identity(tensor: Optional[torch.Tensor]):
+    """What a call-plan key can distinguish about ``tensor``.
+
+    The version is included so an in-place write invalidates the entry where it
+    can be observed at all; see :func:`tensor_version` for what happens when it
+    cannot.
+    """
+    if tensor is None:
+        return None
+    return (
+        tensor.data_ptr(),
+        tensor.shape,
+        tensor.dtype,
+        tensor.device,
+        tensor.is_contiguous(),
+        tensor_version(tensor),
+    )
+
+
+def tensor_layout_identity(tensor: Optional[torch.Tensor]):
+    """The address and layout a bound workspace freezes.
+
+    Tensor contents may change between graph replays, so the version counter
+    is deliberately excluded.  A different tensor allocation or layout is a
+    different capture signature even when its logical shape is unchanged.
+    """
+    if tensor is None:
+        return None
+    return (
+        tensor.data_ptr(),
+        tuple(tensor.shape),
+        tuple(tensor.stride()),
+        tensor.dtype,
+        tensor.device,
+    )
+
+
+def resource_cache_token(resources: Optional[SM120PrefillResources]):
+    """Stable plan-cache identity for a caller-owned workspace."""
+    return None if resources is None else resources.cache_token
+
+
+def clear_shared_caches() -> None:
+    """Drop everything this module holds.  Tests, and callers freeing buffers.
+
+    Deliberately does not touch :data:`GRAPH_PINS`: a live graph makes that
+    unsafe, and the caller that knows its graphs are gone can clear it itself.
+    """
+    clear_offsets_caches()
+    clear_flat_views()
+    clear_pinned_staging()
+
+
+__all__ = [
+    "DK",
+    "DV",
+    "GLOBAL_BASE_ALIGN",
+    "GRAPH_PINS",
+    "INT32_MAX",
+    "JIT_MODULE_NAME",
+    "LOG2_E",
+    "LOWER_BOUND_RANGE",
+    "MAX_ENTRIES",
+    "READ_ONLY_ROLES",
+    "SM120_CAPABILITY",
+    "SM120_CODE_TARGET",
+    "BoundedDeviceCache",
+    "CacheStats",
+    "CanonicalInputs",
+    "CanonicalOffsets",
+    "GraphResourcePins",
+    "IdentityCache",
+    "KDAPrefillValidationError",
+    "SM120PrefillResources",
+    "UnsupportedArchitectureError",
+    "build_kernel",
+    "canonical_offsets",
+    "capturing",
+    "check_tma_base_alignment",
+    "clear_flat_views",
+    "clear_offsets_caches",
+    "clear_pinned_staging",
+    "clear_shared_caches",
+    "check_flat_output_range",
+    "current_stream_ptr",
+    "fixed_offsets",
+    "flat_view",
+    "flat_view_stats",
+    "intervals_overlap",
+    "is_exact_alias",
+    "offsets_cache_stats",
+    "persistent_cache_status",
+    "persistent_cache_unavailable_reason",
+    "record_stream_once",
+    "resource_cache_token",
+    "require_sm120a",
+    "sm120a_available",
+    "assert_tvm_ffi_dispatched",
+    "sm120a_compile_options",
+    "storage_interval",
+    "NO_VERSION",
+    "max_grid_dims",
+    "tensor_identity",
+    "tensor_layout_identity",
+    "tensor_version",
+    "upload_bytes",
+    "validate_inputs",
+    "validate_packed_offsets",
+]

--- a/flashinfer/kda_prefill.py
+++ b/flashinfer/kda_prefill.py
@@ -100,6 +100,20 @@ class _RecurrentKDAPrefillWorkspaceBase:
         self._packed_metadata: Optional[_PackedTaskMetadata] = None
         self._bound_stream_ptr: Optional[int] = None
         self._captured = False
+        # The SM120 backend's per-workspace state, created on first use by
+        # ``_sm120_prefill_resources``. A Cake-only caller carries this one
+        # ``None`` field and never imports CuTe DSL; composing rather than
+        # subclassing keeps ``RecurrentKDAPrefillWorkspace`` the single public
+        # workspace type while letting each backend own the buffers only it
+        # understands.
+        self._sm120_state: Optional[object] = None
+        #: Guards the creation of ``_sm120_state``.  Two threads reaching a
+        #: workspace's first SM120 call would otherwise both read ``None`` and
+        #: both construct: one assignment wins and the loser runs against an
+        #: orphan with its own lock, its own scratch and its own capture flag,
+        #: so nothing serializes the launch sequence, device memory doubles,
+        #: and a capture is recorded where no one will look for it.
+        self._sm120_state_lock = threading.Lock()
 
 
 class RecurrentKDAPrefillWorkspace(_RecurrentKDAPrefillWorkspaceBase):
@@ -109,12 +123,13 @@ class RecurrentKDAPrefillWorkspace(_RecurrentKDAPrefillWorkspaceBase):
     :func:`flashinfer.kda.recurrent_kda` invocation on the graph's CUDA
     device. Warm it by invoking that function eagerly with the exact tensors
     and capture stream, then synchronize that stream before capture. The
-    workspace owns optional final-state scratch for calls without an initial
-    state, beta padding, and schedule-specific M64/M128-N32/M128-N16 TMA
-    descriptor storage and small-BH packet-ring storage for the lifetime of
-    the graph. Persistent M128 is an
-    eager-only B200/GB200 route; explicit workspaces use direct M128 or M64 so graph
-    capture never synchronizes sequence lengths to construct host task bins.
+    workspace owns optional final-state scratch, backend metadata, TMA
+    descriptors, and schedule-specific scratch for the lifetime of the graph.
+    On SM100-family devices this includes beta padding, M64/M128-N32/M128-N16
+    descriptor storage and small-BH packet-ring storage. Persistent M128 is an
+    eager-only B200/GB200 route; explicit workspaces use direct M128 or M64 so
+    graph capture never synchronizes sequence lengths to construct host task
+    bins.
 
     A workspace binds to its first stream. Once it participates in capture it
     cannot be passed to Python again, either eagerly or in another capture.
@@ -144,6 +159,13 @@ def _is_plain_multi_token_prefill(
         return False
     num_sequences = cu_seqlens.numel() - 1
     return num_sequences > 0 and q.shape[1] > num_sequences
+
+
+#: TMA's base-address requirement, mirrored here so backend selection and
+#: backend validation cannot drift apart.  The backend owns the real constant
+#: (``runtime.GLOBAL_BASE_ALIGN``); a test asserts the two agree, because a
+#: silent divergence turns a fallback into an exception.
+_SM120_TMA_BASE_ALIGN = 16
 
 
 def _is_contiguous_cuda_tensor(
@@ -1509,4 +1531,477 @@ def _run_flash_kda_prefill(
     if checkpoint_every_n_tokens:
         assert state_checkpoints is not None
         return (*result, state_checkpoints)
+    return result
+
+
+# ===========================================================================
+# SM120a ordinary multi-token prefill.
+#
+# A second prefill backend beside the frozen SM100-family Cake one above, on a
+# disjoint set of architectures: Cake takes compute capability 10.0 and 10.3,
+# this takes 12.0, and no device is eligible for both.  So the two do not
+# compete, and adding this one cannot change which kernel an SM100 call gets.
+#
+# The split of responsibility follows the Cake half exactly.  This file owns
+# the public contract -- the structural checks, the output and state
+# adaptation, the workspace shell -- and knows nothing about CuTe DSL.  The
+# kernels, their caches and their variant choice live in
+# ``flashinfer.kda_kernels.sm120_prefill`` and are reached only through the
+# optional facade in ``flashinfer.kda_kernels``, so a CPU-only import, an
+# SM100 box or a missing CuTe DSL leaves this a no-op rather than an error.
+# ===========================================================================
+
+_SM120_KDA_SUPPORTED_COMPUTE_CAPABILITIES = {(12, 0)}
+
+#: The gate's supported range. The safe gate's worst-case chunk prefix is
+#: ``16 * lower_bound * log2e``, which reaches the ``rcp.approx.ftz`` cliff at
+#: ``lower_bound == -5.4585``; this keeps a real margin below that.  The public
+#: API also excludes ``0.0`` because it is the degenerate zero gate; the direct
+#: backend ABI accepts it for internal use, but public dispatch remains strict.
+_SM120_KDA_LOWER_BOUND_MIN = -5.0
+
+
+def _sm120_kda_prefill_rejection_reason(
+    *,
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor,
+    beta: torch.Tensor,
+    A_log: Optional[torch.Tensor],
+    dt_bias: Optional[torch.Tensor],
+    scale: Optional[float],
+    initial_state: Optional[torch.Tensor],
+    use_qk_l2norm_in_kernel: bool,
+    use_gate_in_kernel: bool,
+    lower_bound: Optional[float],
+    cu_seqlens: Optional[torch.Tensor],
+    ssm_state_indices: Optional[torch.Tensor],
+    num_spec_tokens: Optional[int],
+    num_accepted_tokens: Optional[torch.Tensor],
+    output: Optional[torch.Tensor],
+    initial_state_source: Optional[torch.Tensor],
+    initial_state_indices: Optional[torch.Tensor],
+    beta_is_logit: bool,
+    seq_order: Optional[torch.Tensor],
+    prefill_workspace: Optional[RecurrentKDAPrefillWorkspace],
+    state_checkpoints: Optional[torch.Tensor],
+    checkpoint_cu_starts: Optional[torch.Tensor],
+    checkpoint_every_n_tokens: int,
+) -> Optional[str]:
+    """Why this call cannot use the SM120 backend, or ``None`` if it can.
+
+    Structural only: shapes, dtypes, devices, strides, alignment and the
+    handful of flags whose values are host-side. It reads no tensor contents,
+    launches nothing, allocates nothing and never synchronizes, so the
+    dispatcher can afford to call it on every request and a graph capture can
+    call it too.
+
+    ``cu_seqlens``'s *values* -- starting at zero, non-decreasing, ending at
+    the token count -- are deliberately not checked here. Reading them needs a
+    device-to-host copy, which synchronizes and is illegal during capture; the
+    backend validates them once during eager warmup and caches the result on
+    the tensor's identity and version instead.
+
+    A string rather than a bool because the same predicate serves two callers
+    with opposite needs: the dispatcher wants "eligible or not" and discards
+    the reason, while a caller who forced this backend wants to be told which
+    of thirty conditions it missed.
+    """
+    if not _is_plain_multi_token_prefill(q, cu_seqlens, num_spec_tokens):
+        return "not an ordinary multi-token prefill"
+    if num_accepted_tokens is not None:
+        return "num_accepted_tokens is a speculative-decode argument"
+    if initial_state_source is not None or initial_state_indices is not None:
+        return "initial_state_source/initial_state_indices are unsupported"
+    if ssm_state_indices is not None:
+        return "ssm_state_indices (state pooling) is unsupported"
+    if seq_order is not None:
+        return "seq_order is unsupported"
+    if (
+        checkpoint_every_n_tokens != 0
+        or state_checkpoints is not None
+        or checkpoint_cu_starts is not None
+    ):
+        return "prefill state checkpoints are unsupported"
+    if not use_qk_l2norm_in_kernel:
+        return "use_qk_l2norm_in_kernel=False is unsupported"
+    if not use_gate_in_kernel:
+        return "use_gate_in_kernel=False is unsupported"
+    if not beta_is_logit:
+        return "beta_is_logit=False is unsupported"
+    if lower_bound is None or not math.isfinite(float(lower_bound)):
+        return "lower_bound must be a finite negative float"
+    if not _SM120_KDA_LOWER_BOUND_MIN <= float(lower_bound) < 0.0:
+        return (
+            f"lower_bound must be in [{_SM120_KDA_LOWER_BOUND_MIN}, 0.0), got "
+            f"{lower_bound}"
+        )
+    if scale is not None and not math.isfinite(float(scale)):
+        return "scale must be finite"
+
+    if not q.is_cuda:
+        return "q must be a CUDA tensor"
+    if (
+        get_compute_capability(q.device)
+        not in _SM120_KDA_SUPPORTED_COMPUTE_CAPABILITIES
+    ):
+        return "device compute capability is not 12.0"
+
+    device = q.device
+    if not _is_contiguous_cuda_tensor(q, dtype=torch.bfloat16, device=device):
+        return "q must be a contiguous CUDA bfloat16 tensor"
+    if q.ndim != 4:
+        return "q must be rank 4"
+    batch_size, tokens, num_heads, head_dim = q.shape
+    if head_dim != _FLASH_KDA_HEAD_DIM:
+        return f"the head dimension is fixed at {_FLASH_KDA_HEAD_DIM}"
+    if num_heads <= 0 or batch_size <= 0:
+        return "B and H must be positive"
+    for name, tensor in (("k", k), ("v", v), ("g", g)):
+        if not _is_contiguous_cuda_tensor(tensor, dtype=torch.bfloat16, device=device):
+            return f"{name} must be a contiguous CUDA bfloat16 tensor"
+        if tensor.shape != q.shape:
+            return f"{name} must have q's shape; GQA and V != K are unsupported"
+    if not _is_contiguous_cuda_tensor(
+        beta, dtype=torch.bfloat16, device=device
+    ) or beta.shape != (batch_size, tokens, num_heads):
+        return "beta must be a contiguous CUDA bfloat16 [B, T, H] tensor"
+
+    if not _is_contiguous_cuda_tensor(
+        A_log, dtype=torch.float32, device=device
+    ) or A_log.shape != (num_heads,):
+        return "A_log must be a contiguous CUDA float32 [H] tensor"
+    if not _is_contiguous_cuda_tensor(dt_bias, dtype=torch.float32, device=device):
+        return "dt_bias must be a contiguous CUDA float32 tensor"
+    if dt_bias.numel() != num_heads * _FLASH_KDA_HEAD_DIM or dt_bias.ndim not in (
+        1,
+        2,
+    ):
+        return f"dt_bias must hold H * {_FLASH_KDA_HEAD_DIM} float32 values"
+    if dt_bias.ndim == 2 and dt_bias.shape != (num_heads, _FLASH_KDA_HEAD_DIM):
+        return f"a rank-2 dt_bias must be [H, {_FLASH_KDA_HEAD_DIM}]"
+
+    if cu_seqlens is None:
+        num_sequences = batch_size
+    else:
+        if batch_size != 1:
+            return "packed input needs a leading dimension of exactly 1"
+        if (
+            not cu_seqlens.is_cuda
+            or cu_seqlens.device != device
+            or cu_seqlens.dtype not in (torch.int32, torch.int64)
+            or cu_seqlens.ndim != 1
+            or not cu_seqlens.is_contiguous()
+        ):
+            return "cu_seqlens must be a contiguous CUDA int32/int64 [N + 1] tensor"
+        num_sequences = cu_seqlens.numel() - 1
+        if num_sequences <= 0 or tokens <= num_sequences:
+            return "packed input needs more tokens than sequences"
+
+    if initial_state is not None:
+        if not _is_contiguous_cuda_tensor(
+            initial_state, dtype=torch.bfloat16, device=device
+        ):
+            return "initial_state must be a contiguous CUDA bfloat16 tensor"
+        if tuple(initial_state.shape) != (
+            num_sequences,
+            num_heads,
+            _FLASH_KDA_HEAD_DIM,
+            _FLASH_KDA_HEAD_DIM,
+        ):
+            return (
+                f"initial_state must be [N, H, {_FLASH_KDA_HEAD_DIM}, "
+                f"{_FLASH_KDA_HEAD_DIM}]; a state pool is unsupported"
+            )
+
+    if output is not None:
+        if (
+            not _is_contiguous_cuda_tensor(output, dtype=torch.bfloat16, device=device)
+            or output.shape != v.shape
+        ):
+            return "output must be a contiguous CUDA bfloat16 tensor with v's shape"
+        # The backend's own ABI would accept an exact ``out``/``v`` alias, and
+        # the kernel's schedule proves it safe. The public contract does not:
+        # ``recurrent_kda`` promises a caller that ``output`` and its inputs are
+        # distinct buffers, and quietly honouring an alias here would make that
+        # promise depend on which architecture the call landed on.
+        if _check_sm120_output_overlaps(
+            output, (q, k, v, g, beta, A_log, dt_bias, initial_state)
+        ):
+            return "output must not overlap any input in GMEM"
+
+    # TMA describes q, k, v, g, output and the states, and a TensorMap requires
+    # a 16-byte-aligned base.  The backend validates this too, but validation
+    # raises where a rejection reason falls back -- and contiguity does not
+    # imply alignment: `base[1:].view(...)` on a bfloat16 buffer is contiguous
+    # and starts two bytes in.  Without this the dispatcher would select SM120
+    # for such a tensor and the caller would get an exception from descriptor
+    # construction instead of the SM100 path that would have run it.
+    for name, tensor in (
+        ("q", q),
+        ("k", k),
+        ("v", v),
+        ("g", g),
+        ("output", output),
+        ("initial_state", initial_state),
+    ):
+        if (
+            isinstance(tensor, torch.Tensor)
+            and tensor.numel()
+            and tensor.data_ptr() % _SM120_TMA_BASE_ALIGN
+        ):
+            return f"{name} must be {_SM120_TMA_BASE_ALIGN}-byte aligned for TMA"
+
+    if prefill_workspace is not None and prefill_workspace.device != device:
+        return "prefill_workspace was created for a different device"
+    return None
+
+
+def _check_sm120_output_overlaps(output: torch.Tensor, inputs) -> bool:
+    """Does ``output`` share any bytes with an input?
+
+    Byte ranges, not storage identity: two tensors can share a storage object
+    and never overlap, and two tensors from different allocations can be views
+    of one block.
+    """
+    for tensor in inputs:
+        if tensor is None or tensor.numel() == 0:
+            continue
+        if _storage_ranges_overlap(output, tensor):
+            return True
+    return False
+
+
+def _sm120_kda_prefill_is_eligible(**kwargs) -> bool:
+    """Whether the SM120 backend should take this call.
+
+    Two stages, cheapest and most self-contained first. The structural checks
+    above use only torch, so they run without importing anything from the
+    kernel package; only once they pass is the optional backend consulted at
+    all, and that question -- can this process natively build ``sm_120a``? --
+    is the one thing this file cannot answer for itself.
+
+    Fail-closed throughout: a missing CuTe DSL, an unbuildable target or a
+    facade that failed to import all read as "not eligible", and the call falls
+    through to the existing backends.
+    """
+    if _sm120_kda_prefill_rejection_reason(**kwargs) is not None:
+        return False
+    from . import kda_kernels
+
+    can_implement = kda_kernels.can_implement_kda_prefill_sm120
+    return can_implement is not None and can_implement(**kwargs)
+
+
+def _sm120_prefill_resources(
+    workspace: Optional[RecurrentKDAPrefillWorkspace],
+    device: torch.device,
+):
+    """The SM120 half of a caller's workspace, created on first use.
+
+    A Cake-only caller never reaches this, so their workspace carries one
+    ``None`` field and never imports CuTe DSL. Composition rather than a second
+    public workspace class: ``RecurrentKDAPrefillWorkspace`` stays the only
+    workspace a caller constructs, and which backend it ends up bound to is an
+    implementation detail of the call it was warmed on.
+    """
+    if workspace is None:
+        return None
+    resources = workspace._sm120_state
+    if resources is not None:
+        # Double-checked: the warm path never takes the lock, and the object it
+        # reads is only ever published once.
+        return resources
+    with workspace._sm120_state_lock:
+        resources = workspace._sm120_state
+        if resources is None:
+            from .kda_kernels.sm120_prefill.runtime import SM120PrefillResources
+
+            resources = SM120PrefillResources(device=device)
+            workspace._sm120_state = resources
+    return resources
+
+
+def _sm120_final_state_scratch(sequences: int, heads: int, device, resources):
+    """A bfloat16 final state for a call that supplied no initial state.
+
+    Eagerly this is a fresh allocation. Under capture it cannot be -- allocating
+    inside a graph is precisely what the workspace exists to avoid -- so the
+    buffer comes from the workspace and keeps its address for as long as the
+    workspace lives.
+    """
+    shape = (sequences, heads, _FLASH_KDA_HEAD_DIM, _FLASH_KDA_HEAD_DIM)
+    if resources is None:
+        return torch.empty(shape, dtype=torch.bfloat16, device=device)
+    scratch = resources.state_scratch
+    if scratch is not None and tuple(scratch.shape) == shape:
+        return scratch
+    if torch.cuda.is_current_stream_capturing():
+        raise RuntimeError(
+            "CUDA graph capture cannot allocate the final-state scratch; warm "
+            "the workspace with one eager call at this shape first"
+        )
+    resources.state_scratch = torch.empty(shape, dtype=torch.bfloat16, device=device)
+    return resources.state_scratch
+
+
+def _run_sm120_kda_prefill(
+    *,
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor,
+    beta: torch.Tensor,
+    A_log: torch.Tensor,
+    dt_bias: torch.Tensor,
+    scale: Optional[float],
+    initial_state: Optional[torch.Tensor],
+    output_final_state: bool,
+    lower_bound: float,
+    cu_seqlens: Optional[torch.Tensor],
+    output: Optional[torch.Tensor],
+    prefill_workspace: Optional[RecurrentKDAPrefillWorkspace],
+) -> tuple[torch.Tensor, Optional[torch.Tensor]]:
+    """Run the SM120 backend and adapt its result to the public contract.
+
+    The state semantics are the public ones, not the backend's:
+
+    * a supplied ``initial_state`` is updated in place whether or not
+      ``output_final_state`` is set -- that is what the caller's buffer is for;
+    * with ``output_final_state=False`` the second return value is ``None``
+      even so, because returning a state the caller did not ask for would be a
+      different contract than the one they called;
+    * without an initial state but with ``output_final_state=True`` a bfloat16
+      final state is allocated, or taken from the workspace when one is bound.
+    """
+    if output is None and torch.cuda.is_current_stream_capturing():
+        raise RuntimeError(
+            "CUDA graph capture requires a preallocated output tensor for "
+            "recurrent_kda prefill"
+        )
+
+    from . import kda_kernels
+
+    run = kda_kernels.run_kda_prefill_sm120
+    if run is None:
+        raise RuntimeError(
+            "the SM120 KDA CuTe DSL prefill backend is unavailable"
+        ) from kda_kernels._kda_sm120_import_error
+
+    # ``[H * 128]`` adapts with a no-copy view; the backend's ABI is ``[H, 128]``.
+    if dt_bias.ndim == 1:
+        dt_bias = dt_bias.view(q.shape[2], _FLASH_KDA_HEAD_DIM)
+
+    if prefill_workspace is not None and prefill_workspace._captured:
+        # Check the shared shell before creating its SM120 state: it may have
+        # been spent by a captured Cake call that never needed these resources.
+        raise RuntimeError(
+            "RecurrentKDAPrefillWorkspace has participated in CUDA graph "
+            "capture and cannot be reused or mutated; create another one"
+        )
+
+    resources = _sm120_prefill_resources(prefill_workspace, q.device)
+
+    out = output if output is not None else torch.empty_like(v)
+    num_sequences = q.shape[0] if cu_seqlens is None else cu_seqlens.numel() - 1
+
+    def _resolve_final_state():
+        """The public state contract, applied here rather than in the backend.
+
+        The backend's ABI is the kernels' own -- ``initial_state`` read,
+        ``final_state`` written, the exact alias between them allowed -- and the
+        public promise is a different one: a supplied initial state is updated
+        in place, whether or not a final state was requested. Aliasing the two
+        is how that promise is kept, and doing it here preserves the backend's
+        direct validation ABI.
+
+        Callable rather than a value because the workspace branch resolves it
+        under ``resources.lock``: the middle case can *replace* workspace-owned
+        scratch, and doing that outside the hold that guards the spent flag lets
+        a second thread drop the buffer a first thread's live graph reads at its
+        captured address.
+        """
+        if initial_state is not None:
+            return initial_state
+        if output_final_state:
+            return _sm120_final_state_scratch(
+                num_sequences, q.shape[2], q.device, resources
+            )
+        # Nothing to store: the kernels skip the state write entirely rather
+        # than filling a buffer the caller will not read.
+        return None
+
+    def _launch(final_state):
+        run(
+            q=q,
+            k=k,
+            v=v,
+            g=g,
+            beta=beta,
+            A_log=A_log,
+            dt_bias=dt_bias,
+            scale=scale,
+            lower_bound=float(lower_bound),
+            initial_state=initial_state,
+            final_state=final_state,
+            cu_seqlens=cu_seqlens,
+            output=out,
+            resources=resources,
+        )
+        # ``output_final_state=False`` returns None even when a state was
+        # updated in place: returning it because it happens to exist would be a
+        # different contract than the one the caller asked for.
+        return out, (final_state if output_final_state else None)
+
+    if resources is None:
+        # Refuse capture here, at the outermost adapter, rather than relying on
+        # the guards further down.  Those sit on cache *misses* -- the
+        # device-to-host read for cu_seqlens, the canonical-offsets allocation
+        # -- so a warm cache walks straight past them and the capture succeeds.
+        #
+        # It must not.  Without an explicit workspace, the descriptors and
+        # scratch a capture records belong to a bounded LRU, and the graph holds
+        # their raw addresses.  Nothing pins them: the next distinct shape can
+        # evict the entry, and clear_kda_prefill_sm120_caches() drops it
+        # outright.  Replay then reads freed memory, arbitrarily far from the
+        # call that captured it, and the symptom is wrong output rather than an
+        # error.  An explicit workspace is what makes those addresses the
+        # caller's to keep alive.
+        if torch.cuda.is_current_stream_capturing():
+            raise RuntimeError(
+                "CUDA graph capture of the SM120 KDA prefill backend requires "
+                "an explicit workspace: without one the graph would record "
+                "addresses owned by an evictable cache. Pass a plan's "
+                "workspace, and warm it with one eager call on the capture "
+                "stream before capturing."
+            )
+        return _launch(_resolve_final_state())
+
+    # The workspace serializes its own launch sequence: the decomposed variant
+    # enqueues two kernels that share one scratch arena, and two host threads
+    # interleaving those pairs would have the second prepare overwrite factors
+    # the first recurrence has not read yet.
+    #
+    # One hold covers the spent check, the scratch resolution and the launch.
+    # Split, they race each other: a thread that read ``captured`` as False can
+    # replace ``state_scratch`` after another thread's capture has recorded the
+    # old buffer's address, and two threads wanting different state shapes can
+    # each install their own, leaving the loser holding a ``final_state`` the
+    # workspace no longer owns. The backend re-checks the flag, which orders the
+    # launches, but it cannot undo a replacement that already happened.
+    with resources.lock:
+        if resources.captured:
+            raise RuntimeError(
+                "RecurrentKDAPrefillWorkspace has participated in CUDA graph "
+                "capture and cannot be reused or mutated; create another one"
+            )
+        result = _launch(_resolve_final_state())
+        if torch.cuda.is_current_stream_capturing():
+            # A workspace that has been captured is spent: replay reads its
+            # buffers at the addresses capture recorded, and handing it back to
+            # Python -- eagerly or for a second capture -- would let those
+            # addresses move under a live graph.
+            resources.captured = True
+            prefill_workspace._captured = True
     return result

--- a/tests/kda/test_recurrent_kda_prefill_sm120.py
+++ b/tests/kda/test_recurrent_kda_prefill_sm120.py
@@ -1,0 +1,2031 @@
+# Copyright (c) 2025 by FlashInfer team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""SM120a ordinary multi-token prefill, through the public API.
+
+Two layers, and the split matters. Most of the file drives
+:func:`flashinfer.recurrent_kda` -- the whole chain from the public signature
+through eligibility, dispatch, output and state adaptation to the kernel --
+because a backend that is correct but never selected is a backend that does not
+work. A smaller set pins ``decomp`` and ``fused`` individually through the
+internal entry point, since ``auto`` picks one per shape and a suite that only
+went through ``auto`` would leave whichever variant the runner's SM count does
+not choose entirely untested.
+
+The reference is deliberately self-contained and deliberately slow: a
+token-serial recurrence in float32, rounding to bfloat16 at exactly the points
+the public ABI rounds. It fixes the *contract*, not the schedule, so it is not
+an implementation-shaped reference and it must not be replaced by one -- two
+references that share a derivation cannot disagree, which is the whole reason
+for having a second one.
+
+On a runner that is not SM120a everything here still collects, the host-only
+eligibility and facade cases still run, and the kernel cases skip with a reason
+that names what was missing.
+"""
+
+from __future__ import annotations
+
+import gc
+import os
+import random
+import threading
+import weakref
+from types import SimpleNamespace
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+import flashinfer
+from flashinfer.utils import get_compute_capability, is_sm120a_supported
+
+HEAD_DIM = 128
+
+#: Elementwise tolerance against the reference below, as
+#: ``abs(got - ref) <= ATOL + RTOL * abs(ref)``.
+#:
+#: Output and final state get their own numbers on purpose, and the state's are
+#: looser for a reason that is worth writing down rather than discovering
+#: again. The reference here is *contract*-shaped: it walks tokens one at a
+#: time and rounds to bfloat16 where the public ABI does. The kernels are
+#: chunk-shaped: they accumulate a chunk in float32 and round at the chunk
+#: boundary. Both are correct implementations of the same contract and they do
+#: not associate identically, so a state element that has absorbed 128 tokens
+#: can land one or two bfloat16 ULP apart -- measured at 3.9e-3 on ~5 of
+#: 196608 elements at magnitude 0.26, which is exactly 2 ULP there.
+#:
+#: The numbers below admit about three times that and nothing more. They are
+#: not a way to make a failure go away: the same kernels agree *bitwise* with
+#: the standalone implementation used during validation, and their float64
+#: error is identical to that implementation's, so anything this would newly
+#: catch is a change in the kernel rather than in the rounding.
+OUTPUT_RTOL, OUTPUT_ATOL = 1.0e-2, 1.0e-3
+STATE_RTOL, STATE_ATOL = 2.0e-2, 6.0e-3
+
+#: Overridable so a CI failure can be reproduced exactly.
+SEED = int(os.environ.get("SEED", "0"))
+
+
+def _seed_everything(seed: int) -> None:
+    random.seed(seed)
+    torch.manual_seed(seed)
+    if torch.cuda.is_available():
+        torch.cuda.manual_seed_all(seed)
+
+
+def _skip_if_not_sm120() -> None:
+    if not torch.cuda.is_available():
+        pytest.skip("SM120a KDA prefill requires CUDA")
+    if get_compute_capability(torch.device("cuda")) != (12, 0):
+        pytest.skip("SM120 KDA prefill requires compute capability 12.0")
+    if not is_sm120a_supported(torch.device("cuda")):
+        pytest.skip("SM120 KDA prefill requires a CUDA toolkit with sm_120a support")
+    from flashinfer.kda_kernels import can_implement_kda_prefill_sm120
+
+    if can_implement_kda_prefill_sm120 is None:
+        pytest.skip("the SM120 KDA prefill backend failed to import")
+
+
+def _sm120_prefill():
+    """The internal package, for the variant-pinned cases."""
+    from flashinfer.kda_kernels import sm120_prefill
+
+    return sm120_prefill
+
+
+# ---------------------------------------------------------------------------
+# Inputs and reference
+# ---------------------------------------------------------------------------
+
+
+def _make_inputs_sm120(
+    *,
+    seq_lens,
+    num_heads: int,
+    packed: bool,
+    initial_state: bool = False,
+    seed: int = 0,
+    offsets_dtype: torch.dtype = torch.int32,
+):
+    """Inputs matching the SM120 contract: bfloat16 throughout, equal heads.
+
+    ``q`` and ``k`` are pre-normalized because the kernel L2-normalizes them
+    itself; feeding already-unit rows keeps the reference's normalization from
+    being the thing under test.
+    """
+    _seed_everything(seed)
+    if packed:
+        batch_size = 1
+        seq_len = sum(seq_lens)
+    else:
+        if len(set(seq_lens)) != 1:
+            raise ValueError("fixed inputs require equal sequence lengths")
+        batch_size = len(seq_lens)
+        seq_len = seq_lens[0]
+
+    shape = (batch_size, seq_len, num_heads, HEAD_DIM)
+
+    def normalized():
+        raw = torch.randn(shape, dtype=torch.float32, device="cuda")
+        return F.normalize(raw, p=2, dim=-1).to(torch.bfloat16)
+
+    q = normalized()
+    k = normalized()
+    v = torch.randn(shape, dtype=torch.float32, device="cuda").to(torch.bfloat16)
+    g = (0.1 * torch.randn(shape, dtype=torch.float32, device="cuda")).to(
+        torch.bfloat16
+    )
+    beta = torch.randn(
+        (batch_size, seq_len, num_heads), dtype=torch.float32, device="cuda"
+    ).to(torch.bfloat16)
+    A_log = 0.1 * torch.randn(num_heads, dtype=torch.float32, device="cuda")
+    dt_bias = 0.1 * torch.randn(
+        (num_heads, HEAD_DIM), dtype=torch.float32, device="cuda"
+    )
+
+    offsets = [0]
+    for length in seq_lens:
+        offsets.append(offsets[-1] + length)
+
+    state = None
+    if initial_state:
+        state = (
+            0.1
+            * torch.randn(
+                (len(seq_lens), num_heads, HEAD_DIM, HEAD_DIM),
+                dtype=torch.float32,
+                device="cuda",
+            )
+        ).to(torch.bfloat16)
+
+    return {
+        "q": q,
+        "k": k,
+        "v": v,
+        "g": g,
+        "beta": beta,
+        "A_log": A_log,
+        "dt_bias": dt_bias,
+        "initial_state": state,
+        "cu_seqlens": (
+            torch.tensor(offsets, dtype=offsets_dtype, device="cuda")
+            if packed
+            else None
+        ),
+        "seq_lens": list(seq_lens),
+    }
+
+
+def _reference_kda_prefill(inputs, *, lower_bound=-5.0, scale=None):
+    """Token-serial KDA prefill, rounding where the public ABI rounds.
+
+    The state crosses a bfloat16 boundary once per token and the output once
+    per row; everything between is float32. That is the contract the kernel
+    implements, and reproducing it here is what makes the comparison a test of
+    the kernel rather than of bfloat16.
+    """
+    q = inputs["q"]
+    batch_size, seq_len, num_heads, head_dim = q.shape
+    scale = head_dim**-0.5 if scale is None else scale
+
+    q_flat = F.normalize(q.float(), dim=-1).reshape(-1, num_heads, head_dim)
+    k_flat = F.normalize(inputs["k"].float(), dim=-1).reshape(-1, num_heads, head_dim)
+    v_flat = inputs["v"].float().reshape(-1, num_heads, head_dim)
+    g_flat = inputs["g"].float().reshape(-1, num_heads, head_dim)
+    beta_flat = torch.sigmoid(inputs["beta"].float().reshape(-1, num_heads))
+
+    gate = lower_bound * torch.sigmoid(
+        torch.exp(inputs["A_log"]).reshape(1, num_heads, 1)
+        * (g_flat + inputs["dt_bias"].reshape(1, num_heads, head_dim))
+    )
+    decay = torch.exp(gate)
+
+    if inputs["cu_seqlens"] is None:
+        offsets = [index * seq_len for index in range(batch_size + 1)]
+    else:
+        offsets = [int(value) for value in inputs["cu_seqlens"].tolist()]
+
+    if inputs["initial_state"] is None:
+        state = torch.zeros(
+            (len(offsets) - 1, num_heads, head_dim, head_dim),
+            dtype=torch.bfloat16,
+            device=q.device,
+        )
+    else:
+        state = inputs["initial_state"].clone()
+
+    out = torch.empty_like(q_flat)
+    for sequence in range(len(offsets) - 1):
+        for token in range(offsets[sequence], offsets[sequence + 1]):
+            state_f32 = state[sequence].float()
+            decayed = state_f32 * decay[token].unsqueeze(1)
+            predicted = torch.einsum("hk,hvk->hv", k_flat[token], decayed)
+            residual = beta_flat[token].unsqueeze(-1) * (v_flat[token] - predicted)
+            updated = decayed + residual.unsqueeze(-1) * k_flat[token].unsqueeze(1)
+            state[sequence] = updated.to(torch.bfloat16)
+            projected = torch.einsum(
+                "hk,hvk->hv", q_flat[token], state[sequence].float()
+            )
+            out[token] = (scale * projected).to(torch.bfloat16)
+    return out.reshape_as(q), state
+
+
+def _assert_elementwise(got, want, name, *, rtol, atol):
+    """Compare with a per-element allowance and report the worst offender.
+
+    ``torch.testing.assert_close`` would do the comparison; it would not say
+    *which* element failed or by how much relative to its own allowance, and on
+    a [1, 4096, 96, 128] tensor that is the difference between a diagnosable
+    failure and a rerun.
+    """
+    a, b = got.float(), want.float()
+    assert a.shape == b.shape, f"{name}: {tuple(a.shape)} vs {tuple(b.shape)}"
+    assert not torch.isnan(a).any(), f"{name} has NaN"
+    assert not torch.isinf(a).any(), f"{name} has Inf"
+    tolerance = atol + rtol * b.abs()
+    bad = (a - b).abs() > tolerance
+    if bool(bad.any()):
+        index = tuple(int(i) for i in torch.nonzero(bad)[0])
+        raise AssertionError(
+            f"{name}: {int(bad.sum())} of {a.numel()} outside tolerance; "
+            f"max_abs={(a - b).abs().max().item():.3e} "
+            f"max_normalized={((a - b).abs() / tolerance).max().item():.3e} "
+            f"first at {index} got={a[index].item():.6e} ref={b[index].item():.6e}"
+        )
+
+
+def _call(inputs, **overrides):
+    """Public-API call with this file's fixed gate settings."""
+    kwargs = dict(
+        q=inputs["q"],
+        k=inputs["k"],
+        v=inputs["v"],
+        g=inputs["g"],
+        beta=inputs["beta"],
+        A_log=inputs["A_log"],
+        dt_bias=inputs["dt_bias"],
+        use_qk_l2norm_in_kernel=True,
+        use_gate_in_kernel=True,
+        beta_is_logit=True,
+        lower_bound=-5.0,
+        cu_seqlens=inputs["cu_seqlens"],
+        initial_state=inputs["initial_state"],
+    )
+    kwargs.update(overrides)
+    return flashinfer.recurrent_kda(**kwargs)
+
+
+# ===========================================================================
+# Eligibility. Host-only where it can be: an SM120 predicate must be testable
+# without an SM120 device, or it can only be tested on the machine that least
+# needs the answer.
+# ===========================================================================
+
+
+@pytest.fixture
+def as_sm120_host(monkeypatch):
+    """Make CPU tensors look like SM120 CUDA tensors to the predicate.
+
+    Everything the rejection reason checks after the device is structural and
+    device-independent, but the device check runs first -- so without this the
+    thirty structural conditions could only be exercised on the one machine
+    that least needs them checked.
+    """
+    from flashinfer import kda_prefill
+
+    monkeypatch.setattr(kda_prefill, "get_compute_capability", lambda device: (12, 0))
+    monkeypatch.setattr(
+        kda_prefill,
+        "_is_contiguous_cuda_tensor",
+        lambda tensor, *, dtype, device: (
+            isinstance(tensor, torch.Tensor)
+            and tensor.dtype == dtype
+            and tensor.is_contiguous()
+        ),
+    )
+    monkeypatch.setattr(torch.Tensor, "is_cuda", property(lambda self: True))
+    return kda_prefill
+
+
+def _eligibility_kwargs(**overrides):
+    """A structurally valid CPU-tensor call, for the rejection-reason tests.
+
+    CPU tensors are the point: everything except the device check is structural
+    and runs anywhere, so this exercises thirty conditions on a laptop.
+    """
+    heads = 2
+    tokens = 16
+    shape = (1, tokens, heads, HEAD_DIM)
+    kwargs = dict(
+        q=torch.zeros(shape, dtype=torch.bfloat16),
+        k=torch.zeros(shape, dtype=torch.bfloat16),
+        v=torch.zeros(shape, dtype=torch.bfloat16),
+        g=torch.zeros(shape, dtype=torch.bfloat16),
+        beta=torch.zeros((1, tokens, heads), dtype=torch.bfloat16),
+        A_log=torch.zeros(heads),
+        dt_bias=torch.zeros((heads, HEAD_DIM)),
+        scale=None,
+        initial_state=None,
+        use_qk_l2norm_in_kernel=True,
+        use_gate_in_kernel=True,
+        lower_bound=-5.0,
+        cu_seqlens=None,
+        ssm_state_indices=None,
+        num_spec_tokens=None,
+        num_accepted_tokens=None,
+        output=None,
+        initial_state_source=None,
+        initial_state_indices=None,
+        beta_is_logit=True,
+        seq_order=None,
+        prefill_workspace=None,
+        state_checkpoints=None,
+        checkpoint_cu_starts=None,
+        checkpoint_every_n_tokens=0,
+    )
+    kwargs.update(overrides)
+    return kwargs
+
+
+@pytest.mark.parametrize("backend", ["auto", "cute-dsl"])
+def test_public_sm120_dispatch_uses_cute_dsl_backend(monkeypatch, backend):
+    """SM120 is selected by both automatic and explicit CuTe DSL routing."""
+    from flashinfer import kda_prefill
+
+    sentinel = (object(), object())
+    monkeypatch.setattr(
+        kda_prefill,
+        "_sm120_kda_prefill_is_eligible",
+        lambda **kwargs: True,
+    )
+    monkeypatch.setattr(
+        kda_prefill,
+        "_run_sm120_kda_prefill",
+        lambda **kwargs: sentinel,
+    )
+
+    assert (
+        flashinfer.recurrent_kda(**_eligibility_kwargs(), backend=backend) is sentinel
+    )
+
+
+def test_public_sm120_dispatch_preserves_explicit_cake(monkeypatch):
+    """An explicit Cake request must not probe or run the SM120 CuTe DSL path."""
+    from flashinfer import kda_prefill
+
+    sentinel = (object(), object())
+    monkeypatch.setattr(
+        kda_prefill,
+        "_sm120_kda_prefill_is_eligible",
+        lambda **kwargs: pytest.fail("backend='cake' must not probe SM120 CuTe DSL"),
+    )
+    monkeypatch.setattr(
+        kda_prefill,
+        "_flash_kda_prefill_is_eligible",
+        lambda **kwargs: True,
+    )
+    monkeypatch.setattr(
+        kda_prefill,
+        "_run_flash_kda_prefill",
+        lambda **kwargs: sentinel,
+    )
+
+    assert flashinfer.recurrent_kda(**_eligibility_kwargs(), backend="cake") is sentinel
+
+
+def test_public_sm120_capture_requires_preallocated_output(monkeypatch):
+    """All recurrent prefill backends share one graph-stable output contract."""
+    from flashinfer import kda_prefill
+
+    call = _eligibility_kwargs()
+    monkeypatch.setattr(torch.cuda, "is_current_stream_capturing", lambda: True)
+    with pytest.raises(
+        RuntimeError, match=r"capture requires a preallocated output tensor"
+    ):
+        kda_prefill._run_sm120_kda_prefill(
+            q=call["q"],
+            k=call["k"],
+            v=call["v"],
+            g=call["g"],
+            beta=call["beta"],
+            A_log=call["A_log"],
+            dt_bias=call["dt_bias"],
+            scale=call["scale"],
+            initial_state=call["initial_state"],
+            output_final_state=False,
+            lower_bound=call["lower_bound"],
+            cu_seqlens=call["cu_seqlens"],
+            output=None,
+            prefill_workspace=None,
+        )
+
+
+@pytest.mark.parametrize(
+    "overrides,expected",
+    [
+        ({"num_spec_tokens": 2}, "ordinary multi-token prefill"),
+        ({"num_accepted_tokens": torch.zeros(1)}, "speculative-decode"),
+        ({"ssm_state_indices": torch.zeros(1, dtype=torch.int32)}, "state pooling"),
+        ({"seq_order": torch.zeros(1, dtype=torch.int32)}, "seq_order"),
+        ({"checkpoint_every_n_tokens": 64}, "checkpoint"),
+        ({"use_qk_l2norm_in_kernel": False}, "use_qk_l2norm_in_kernel"),
+        ({"use_gate_in_kernel": False}, "use_gate_in_kernel"),
+        ({"beta_is_logit": False}, "beta_is_logit"),
+        ({"lower_bound": None}, "lower_bound"),
+        ({"lower_bound": -6.0}, "lower_bound"),
+        ({"lower_bound": 0.0}, "lower_bound"),
+        ({"scale": float("inf")}, "scale"),
+    ],
+)
+def test_sm120_rejection_reason_names_the_condition(overrides, expected):
+    """Every refusal says which condition it was, in words a caller can act on."""
+    from flashinfer import kda_prefill
+
+    reason = kda_prefill._sm120_kda_prefill_rejection_reason(
+        **_eligibility_kwargs(**overrides)
+    )
+    assert reason is not None
+    assert expected in reason
+
+
+def test_sm120_rejects_fixed_single_token():
+    """``T=1`` is decode, and decode is not this backend's."""
+    from flashinfer import kda_prefill
+
+    shape = (1, 1, 2, HEAD_DIM)
+    reason = kda_prefill._sm120_kda_prefill_rejection_reason(
+        **_eligibility_kwargs(
+            q=torch.zeros(shape, dtype=torch.bfloat16),
+            k=torch.zeros(shape, dtype=torch.bfloat16),
+            v=torch.zeros(shape, dtype=torch.bfloat16),
+            g=torch.zeros(shape, dtype=torch.bfloat16),
+            beta=torch.zeros((1, 1, 2), dtype=torch.bfloat16),
+        )
+    )
+    assert reason is not None
+
+
+def test_sm120_rejects_gqa_and_wrong_head_dim(as_sm120_host):
+    """GQA and D != 128 are refused: this backend is equal-head and 128-wide."""
+    kda_prefill = as_sm120_host
+    heads, tokens = 4, 16
+    q = torch.zeros((1, tokens, heads, HEAD_DIM), dtype=torch.bfloat16)
+    v_gqa = torch.zeros((1, tokens, heads // 2, HEAD_DIM), dtype=torch.bfloat16)
+    reason = kda_prefill._sm120_kda_prefill_rejection_reason(
+        **_eligibility_kwargs(
+            q=q,
+            k=q,
+            v=v_gqa,
+            g=q,
+            beta=torch.zeros((1, tokens, heads), dtype=torch.bfloat16),
+            A_log=torch.zeros(heads),
+            dt_bias=torch.zeros((heads, HEAD_DIM)),
+        )
+    )
+    assert reason is not None and "GQA" in reason
+
+    narrow = torch.zeros((1, tokens, heads, 64), dtype=torch.bfloat16)
+    reason = kda_prefill._sm120_kda_prefill_rejection_reason(
+        **_eligibility_kwargs(
+            q=narrow,
+            k=narrow,
+            v=narrow,
+            g=narrow,
+            beta=torch.zeros((1, tokens, heads), dtype=torch.bfloat16),
+            A_log=torch.zeros(heads),
+            dt_bias=torch.zeros((heads, HEAD_DIM)),
+        )
+    )
+    assert reason is not None and "head dimension" in reason
+
+
+def test_sm120_rejects_float32_gate_and_state(as_sm120_host):
+    """The first version publishes bfloat16 only, for both ``g`` and the state."""
+    kda_prefill = as_sm120_host
+    reason = kda_prefill._sm120_kda_prefill_rejection_reason(
+        **_eligibility_kwargs(g=torch.zeros((1, 16, 2, HEAD_DIM)))
+    )
+    assert reason is not None and "g must be" in reason
+
+    reason = kda_prefill._sm120_kda_prefill_rejection_reason(
+        **_eligibility_kwargs(
+            initial_state=torch.zeros((1, 2, HEAD_DIM, HEAD_DIM), dtype=torch.float32)
+        )
+    )
+    assert reason is not None and "initial_state" in reason
+
+
+def test_sm120_accepts_the_supported_shape_on_a_mocked_device(as_sm120_host):
+    """The structural half passes on a call that differs only by device.
+
+    Mocked rather than skipped: the question "does the predicate accept a valid
+    call?" has nothing to do with which GPU is in the box, and a CI fleet with
+    no SM120 runner would otherwise never ask it.
+    """
+    assert (
+        as_sm120_host._sm120_kda_prefill_rejection_reason(**_eligibility_kwargs())
+        is None
+    )
+
+
+@pytest.mark.parametrize("tokens", [2, 15, 16, 17])
+def test_sm120_accepts_short_ordinary_prefill(tokens, as_sm120_host):
+    """A short ``T`` is prefill unless it carries spec-decode metadata.
+
+    The distinction is the metadata, not the length: a short prompt is an
+    ordinary prefill, and refusing it because speculative decode happens to use
+    similar lengths would give up real shapes for nothing.
+    """
+    kda_prefill = as_sm120_host
+    heads = 2
+    shape = (1, tokens, heads, HEAD_DIM)
+    kwargs = _eligibility_kwargs(
+        q=torch.zeros(shape, dtype=torch.bfloat16),
+        k=torch.zeros(shape, dtype=torch.bfloat16),
+        v=torch.zeros(shape, dtype=torch.bfloat16),
+        g=torch.zeros(shape, dtype=torch.bfloat16),
+        beta=torch.zeros((1, tokens, heads), dtype=torch.bfloat16),
+    )
+    assert kda_prefill._sm120_kda_prefill_rejection_reason(**kwargs) is None
+
+    kwargs["num_spec_tokens"] = tokens - 1
+    assert kda_prefill._sm120_kda_prefill_rejection_reason(**kwargs) is not None
+
+
+def test_sm120_is_not_eligible_on_other_architectures(as_sm120_host, monkeypatch):
+    """SM100 and SM103 keep Cake; nothing here can take a call from them."""
+    for capability in ((10, 0), (10, 3), (9, 0)):
+        monkeypatch.setattr(
+            as_sm120_host, "get_compute_capability", lambda device, c=capability: c
+        )
+        reason = as_sm120_host._sm120_kda_prefill_rejection_reason(
+            **_eligibility_kwargs()
+        )
+        assert reason is not None and "compute capability" in reason
+
+
+def test_sm120_facade_imports_without_device_code():
+    """Importing the facade must not load a device module or compile anything.
+
+    This is what makes ``import flashinfer`` cheap for the majority of callers
+    who never run KDA prefill on SM120, and it is easy to lose: one
+    module-level ``from . import decomp`` would undo it and nothing else in the
+    suite would notice.
+    """
+    import sys
+
+    from flashinfer import kda_kernels
+
+    assert hasattr(kda_kernels, "can_implement_kda_prefill_sm120")
+    loaded = {name for name in sys.modules if "sm120_prefill" in name}
+    assert "flashinfer.kda_kernels.sm120_prefill.decomp" not in loaded
+    assert "flashinfer.kda_kernels.sm120_prefill.fused" not in loaded
+
+
+def test_sm120_can_implement_is_fail_closed_on_cpu():
+    """A CPU tensor is not eligible, and asking costs nothing."""
+    from flashinfer.kda_kernels import can_implement_kda_prefill_sm120
+
+    if can_implement_kda_prefill_sm120 is None:
+        pytest.skip("SM120 backend unavailable")
+    assert not can_implement_kda_prefill_sm120(q=torch.zeros(1, 2, 1, HEAD_DIM))
+
+
+def test_sm120_variant_policy_reports_tuned_or_fallback():
+    """The policy line must say whether this device's thresholds were measured.
+
+    A time quoted under fallback thresholds is not a time quoted under tuned
+    ones, and nothing else in a benchmark's output distinguishes them.
+    """
+    sm120_prefill = _sm120_prefill()
+
+    tuned = sm120_prefill.describe_variant_policy(156)
+    assert "measured on this device" in tuned
+
+    fallback = sm120_prefill.describe_variant_policy(999)
+    assert "FALLBACK" in fallback
+
+
+def test_sm120_variant_choice_is_a_pure_function_of_shape():
+    """``choose_variant`` needs no device, so its table can be tested anywhere."""
+    sm120_prefill = _sm120_prefill()
+    choose = sm120_prefill.choose_variant
+
+    # Every measured row, at the CTA value on each side of its own threshold.
+    # Written as a table rather than as prose assertions because the previous
+    # version described `H >= 96 or T <= 48 or CTA >= 512` -- thresholds two
+    # re-fits out of date -- and still passed, since none of its cases sat near
+    # a boundary that had moved.
+    #
+    # (sm_count, cta_threshold): the profile's own CTA line.
+    for sm_count, threshold in ((110, 128), (156, 144), (188, 144)):
+        # CTA = 2 * batch * heads, so batch = threshold // (2 * heads) puts the
+        # shape exactly on the line, and one less batch puts it just under.
+        heads = 8
+        on = threshold // (2 * heads)
+        assert choose(on, heads, 1024, sm_count=sm_count) == "fused", sm_count
+        assert choose(on - 1, heads, 1024, sm_count=sm_count) == "decomp", sm_count
+
+        # The tokens term is 32 on every row, and it fires independently of CTA.
+        assert choose(1, 1, 32, sm_count=sm_count) == "fused", sm_count
+        assert choose(1, 1, 33, sm_count=sm_count) == "decomp", sm_count
+
+        # No row has a heads term, and it cannot be tested through `choose`:
+        # CTA is 2 * batch * heads, so the smallest CTA any H >= 96 shape can
+        # have is 192, already over every threshold above.  That is the reason
+        # the term is None -- it could never fire -- so assert the field.
+        assert sm120_prefill.AUTO_PROFILES[sm_count].heads is None, sm_count
+
+    # The two larger parts sit at 144 and the 110-SM part at 128, so CTA 128
+    # separates them.  This is the case the re-fit turned on, and the one a
+    # single shared row would get wrong.
+    assert choose(8, 8, 1024, sm_count=110) == "fused"  # CTA 128 >= 128
+    assert choose(8, 8, 1024, sm_count=156) == "decomp"  # CTA 128 < 144
+    assert choose(8, 8, 1024, sm_count=188) == "decomp"
+
+    # CTA 144 is the shape FlashInfer benchmarks (six sequences, H=12) and the
+    # reason the threshold moved off 192.  All three rows must take it now.
+    for sm_count in (110, 156, 188):
+        assert choose(6, 12, 8192, sm_count=sm_count) == "fused", sm_count
+
+    # An unmeasured SM count falls back rather than extrapolating.
+    assert choose(1, 96, 1024, sm_count=999) == choose(1, 96, 1024, sm_count=156)
+
+
+def test_sm120_bound_workspace_rejects_an_explicit_variant_change():
+    """A bound workspace must not silently ignore a later explicit variant."""
+    sm120_prefill = _sm120_prefill()
+    resources = SimpleNamespace(variant="decomp")
+
+    assert (
+        sm120_prefill._resolve_variant("auto", None, None, True, resources, device=None)
+        == "decomp"
+    )
+    with pytest.raises(ValueError, match=r"already bound.*decomp.*fused"):
+        sm120_prefill._resolve_variant(
+            "fused", None, None, True, resources, device=None
+        )
+
+
+def test_sm120_resolved_cache_rejects_a_recycled_tensor_identity(monkeypatch):
+    """An address-key match is not enough when the owning tensor changed."""
+    sm120_prefill = _sm120_prefill()
+    sm120_prefill._RESOLVED.clear()
+    sm120_prefill._RESOLVED_LAST = None
+    monkeypatch.setattr(sm120_prefill, "current_stream_ptr", lambda device: 7)
+    # Simulate two allocations receiving the same address and layout without
+    # depending on the CPU allocator to recycle one during the test.
+    monkeypatch.setattr(
+        sm120_prefill,
+        "tensor_identity",
+        lambda tensor: None if tensor is None else ("recycled-address",),
+    )
+
+    first = torch.zeros(1)
+    second = torch.zeros(1)
+    scalars = (1.0, -5.0, "auto", True)
+    value = (object(), object())
+    try:
+        sm120_prefill._remember_call(
+            torch.device("cpu"), (first, None), scalars, None, value
+        )
+        assert (
+            sm120_prefill._resolved_call(
+                torch.device("cpu"), (first, None), scalars, None
+            )
+            is value
+        )
+        assert (
+            sm120_prefill._resolved_call(
+                torch.device("cpu"), (second, None), scalars, None
+            )
+            is None
+        )
+        assert not sm120_prefill._RESOLVED
+    finally:
+        sm120_prefill._RESOLVED.clear()
+        sm120_prefill._RESOLVED_LAST = None
+
+
+def test_sm120_resolved_fast_path_rejects_rebound_inference_storage(monkeypatch):
+    """Rebinding ``.data`` must invalidate the one-entry facade fast path."""
+    sm120_prefill = _sm120_prefill()
+    sm120_prefill._RESOLVED.clear()
+    sm120_prefill._RESOLVED_LAST = None
+    monkeypatch.setattr(sm120_prefill, "current_stream_ptr", lambda device: 7)
+
+    scalars = (1.0, -5.0, "auto", True)
+    value = (object(), object())
+    try:
+        with torch.inference_mode():
+            tensor = torch.zeros(1)
+            replacement = torch.ones(2)
+            sm120_prefill._remember_call(
+                torch.device("cpu"), (tensor, None), scalars, None, value
+            )
+            assert (
+                sm120_prefill._resolved_call(
+                    torch.device("cpu"), (tensor, None), scalars, None
+                )
+                is value
+            )
+
+            tensor.data = replacement
+            assert (
+                sm120_prefill._resolved_call(
+                    torch.device("cpu"), (tensor, None), scalars, None
+                )
+                is None
+            )
+    finally:
+        sm120_prefill._RESOLVED.clear()
+        sm120_prefill._RESOLVED_LAST = None
+
+
+def test_sm120_flat_output_range_is_checked_on_the_host():
+    """The flat output is bounded before a launch, not after it.
+
+    Two limits meet one element apart. The tail store writes a partial chunk
+    element-wise through ``(token * H + head) * DV + d``, which the device
+    builds and consumes as INT32, so it needs the largest *index* -- ``T_total *
+    H * DV - 1`` -- to fit. The DSL packs the flat view's extent as INT32 when
+    it crosses into the compiled entry, so it needs the *count*. The count is
+    therefore the bound, and it is the one asserted here: on hardware the shape
+    one element inside the index limit does not launch, it raises
+    ``OverflowError: Value overflow: 2147483648 exceeds range of l`` out of
+    ``build_memref_desc``, which names neither the tensor nor the shape.
+    """
+    from flashinfer.kda_kernels.sm120_prefill import runtime
+
+    heads = 1024
+    largest_tokens = runtime.INT32_MAX // (heads * runtime.DV)
+    assert largest_tokens * heads * runtime.DV <= runtime.INT32_MAX
+    assert (largest_tokens + 1) * heads * runtime.DV > runtime.INT32_MAX
+
+    runtime.check_flat_output_range(largest_tokens, heads)
+    # A state-only call has no store, so it has nothing to bound.
+    runtime.check_flat_output_range(0, heads)
+
+    # One token more is the count the DSL cannot pack; two more is the index
+    # the device cannot build. Both are the backend's error, not a stray one.
+    for excess in (1, 2):
+        with pytest.raises(runtime.KDAPrefillValidationError, match="INT32"):
+            runtime.check_flat_output_range(largest_tokens + excess, heads)
+
+
+def test_sm120_variant_policy_reads_the_input_device(monkeypatch):
+    """A host holding two CC 12.0 parts must not drive both from one row.
+
+    The measured rows disagree at CTA 128: the 110-SM part takes the fused
+    kernel there and the 188-SM part takes the decomposed one. Reading device 0
+    would apply the wrong row to every call on the other card, and the only
+    symptom is a time nobody can attribute.
+    """
+    sm120_prefill = _sm120_prefill()
+
+    def get_device_properties(device):
+        index = device if isinstance(device, int) else torch.device(device).index
+        return SimpleNamespace(
+            multi_processor_count=110 if index == 0 else 188,
+            name=f"<part {index}>",
+        )
+
+    sm120_prefill._sm_count.cache_clear()
+    monkeypatch.setattr(torch.cuda, "get_device_properties", get_device_properties)
+    monkeypatch.setattr(torch.cuda, "current_device", lambda: 0)
+    try:
+        choose = sm120_prefill.choose_variant
+        # CTA = 2 * batch * heads = 128: on the 110-SM row's threshold and
+        # under the 188-SM row's.
+        assert choose(8, 8, 1024, device=torch.device("cuda", 0)) == "fused"
+        assert choose(8, 8, 1024, device=torch.device("cuda", 1)) == "decomp"
+        # No device named still means the current one.
+        assert choose(8, 8, 1024) == "fused"
+        # And the policy line names the card it actually read.
+        assert "188 SMs" in sm120_prefill.describe_variant_policy(
+            device=torch.device("cuda", 1)
+        )
+    finally:
+        sm120_prefill._sm_count.cache_clear()
+
+
+def test_sm120_pinned_staging_carries_the_event_it_reuses_against():
+    """A descriptor build may not refill a buffer whose transfer is pending.
+
+    ``upload_bytes`` copies out of one pinned buffer per size with
+    ``non_blocking=True``, so the transfer is queued rather than finished when
+    it returns. Two cold builds of one size are ordinary rather than a corner --
+    the size is a function of the descriptor count, so any two cold calls of a
+    shape collide -- and without the event the second one's host-side refill
+    overwrites bytes the first one's DMA has not read yet, which reaches the
+    device as a descriptor made of two.
+
+    The event is what that costs, so the event is what is asserted: the byte
+    comparison below would pass on the racing version too, most of the time,
+    which is exactly why it cannot be the guard.
+    """
+    _skip_if_not_sm120()
+    from flashinfer.kda_kernels.sm120_prefill import runtime
+
+    device = torch.device("cuda")
+    first_payload = bytes(range(128)) * 2
+    second_payload = bytes(reversed(range(128))) * 2
+
+    runtime.clear_pinned_staging()
+    first = runtime.upload_bytes(first_payload, device)
+    staging, event = runtime._PINNED_STAGING[len(first_payload)]
+    assert event is not None, "the pooled buffer must carry its upload's event"
+
+    second = runtime.upload_bytes(second_payload, device)
+    pooled, _ = runtime._PINNED_STAGING[len(second_payload)]
+    assert pooled is staging, "one buffer per size is the point of the pool"
+
+    torch.cuda.synchronize()
+    assert bytes(first.cpu().tolist()) == first_payload
+    assert bytes(second.cpu().tolist()) == second_payload
+
+
+def test_sm120_clear_pinned_staging_waits_for_pending_uploads():
+    """Cache clearing cannot drop a pinned buffer before its H2D completes."""
+    from flashinfer.kda_kernels.sm120_prefill import runtime
+
+    class Pending:
+        synchronized = False
+
+        def synchronize(self):
+            self.synchronized = True
+
+    pending = Pending()
+    runtime.clear_pinned_staging()
+    runtime._PINNED_STAGING[17] = (object(), pending)
+    try:
+        runtime.clear_pinned_staging()
+        assert pending.synchronized
+        assert not runtime._PINNED_STAGING
+    finally:
+        runtime._PINNED_STAGING.clear()
+
+
+def test_sm120_tma_alignment_constant_matches_the_runtime():
+    """The adapter's alignment gate and the descriptor's must be one number.
+
+    ``flashinfer/kda_prefill.py`` refuses a misaligned base before the backend
+    is reached; ``TensorMapSpec.validate`` refuses it again at the descriptor.
+    They are separate constants in separate modules, and nothing but this
+    assertion stops one from drifting -- which would turn a clear refusal into
+    a driver error a long way from its cause.
+    """
+    from flashinfer import kda_prefill
+    from flashinfer.kda_kernels.sm120_prefill import runtime
+
+    assert kda_prefill._SM120_TMA_BASE_ALIGN == runtime.GLOBAL_BASE_ALIGN
+
+
+def test_sm120_call_memos_hold_weak_references():
+    """The three per-call memos may not be what keeps a caller's buffers alive.
+
+    Each is keyed on tensor identity, and the obvious way to re-check that
+    identity on the next call is to hold the tensors. Holding them puts one
+    whole activation set -- q, k, v, g and out -- into steady-state device
+    memory and keeps those blocks away from the caching allocator until the
+    next call replaces them. The LRU behind each memo already used weak
+    references; the fast paths in the facade and in both variants did not.
+
+    Structural rather than an allocator measurement, and deliberately so: a
+    live plan legitimately retains the buffers its descriptors and views
+    address, at the C level where ``gc`` cannot see it, so a byte count here
+    would be measuring the plan cache instead of these memos.
+    """
+    _skip_if_not_sm120()
+    sm120_prefill = _sm120_prefill()
+
+    inputs = _make_inputs_sm120(seq_lens=[64], num_heads=4, packed=False, seed=SEED)
+    _call(inputs)
+
+    memos = {"facade": sm120_prefill._RESOLVED_LAST}
+    for name, module in sm120_prefill._MODULES.items():
+        memos[name] = module._LAST
+    assert any(memo is not None for memo in memos.values()), "no memo was written"
+
+    for name, memo in memos.items():
+        if memo is None:
+            continue
+        for held in memo[0]:
+            assert held is None or isinstance(held, weakref.ref), (
+                f"the {name} memo holds a strong reference: {type(held).__name__}"
+            )
+
+
+def test_sm120_cache_clear_iterates_a_module_snapshot(monkeypatch):
+    """A variant published during cleanup cannot invalidate the iteration."""
+    sm120_prefill = _sm120_prefill()
+    cleared = []
+    late = SimpleNamespace(clear_caches=lambda: cleared.append("late"))
+
+    def clear_first():
+        cleared.append("first")
+        sm120_prefill._MODULES["late"] = late
+
+    monkeypatch.setattr(
+        sm120_prefill,
+        "_MODULES",
+        {"first": SimpleNamespace(clear_caches=clear_first)},
+    )
+    sm120_prefill.clear_kda_prefill_sm120_caches()
+
+    assert cleared == ["first"]
+    assert sm120_prefill._MODULES["late"] is late
+
+
+def test_sm120_workspace_resources_are_created_once_under_threads():
+    """Two first calls on one workspace must not each build their own state.
+
+    The loser of that race would run against an orphan: its own lock, so
+    nothing serializes the launch sequence the lock exists for; its own scratch,
+    so device memory doubles; and its own capture flag, so a capture is recorded
+    where nobody will look for it.
+    """
+    _skip_if_not_sm120()
+    from flashinfer import kda_prefill
+
+    workspace = kda_prefill.RecurrentKDAPrefillWorkspace(torch.device("cuda"))
+    threads_count = 8
+    barrier = threading.Barrier(threads_count)
+    seen: list = []
+    lock = threading.Lock()
+
+    def _create():
+        barrier.wait()
+        resources = kda_prefill._sm120_prefill_resources(workspace, workspace.device)
+        with lock:
+            seen.append(resources)
+
+    threads = [threading.Thread(target=_create) for _ in range(threads_count)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert len(seen) == threads_count
+    assert all(resources is seen[0] for resources in seen)
+    assert seen[0] is workspace._sm120_state
+
+
+def test_sm120_spent_workspace_check_and_scratch_share_one_hold():
+    """A spent workspace must be refused before its scratch can be replaced.
+
+    The check and the replacement are two steps on one object, so splitting
+    them across the lock leaves a window: a thread that read the flag as False
+    can install a new ``state_scratch`` after another thread's capture has
+    already recorded the old buffer's address, and the replay then reads a
+    buffer the workspace no longer references. The backend re-checks the flag,
+    which orders the launches, but it cannot undo a replacement.
+
+    Driven through the public API from several threads because that is the only
+    way the two steps interleave at all; the assertion is that the refusal wins
+    every time, whichever thread gets there first.
+    """
+    _skip_if_not_sm120()
+    from flashinfer import kda_prefill
+
+    workspace = kda_prefill.RecurrentKDAPrefillWorkspace(torch.device("cuda"))
+    inputs = _make_inputs_sm120(seq_lens=[64], num_heads=4, packed=False, seed=SEED)
+    output = torch.empty_like(inputs["v"])
+    _call(inputs, output=output, prefill_workspace=workspace, output_final_state=True)
+
+    resources = workspace._sm120_state
+    assert resources is not None
+    scratch = resources.state_scratch
+
+    # Spend it exactly as a capture would, then let several threads in at once.
+    resources.captured = True
+    workspace._captured = True
+
+    threads_count = 8
+    barrier = threading.Barrier(threads_count)
+    outcomes: list = []
+    guard = threading.Lock()
+
+    def _reuse():
+        barrier.wait()
+        try:
+            _call(
+                inputs,
+                output=output,
+                prefill_workspace=workspace,
+                output_final_state=True,
+            )
+            result = "accepted"
+        except RuntimeError as exc:
+            result = "refused" if "capture" in str(exc) else f"other: {exc}"
+        with guard:
+            outcomes.append(result)
+
+    threads = [threading.Thread(target=_reuse) for _ in range(threads_count)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert outcomes == ["refused"] * threads_count, outcomes
+    assert resources.state_scratch is scratch, "a refused call replaced the scratch"
+
+
+def test_sm120_cute_dsl_request_does_not_intercept_a_non_prefill_call():
+    """Declining a call may not change where that call goes.
+
+    This backend records why it declined so that an explicit ``"cute-dsl"``
+    request can be answered accurately further down, and recording is all it
+    may do: decode reaches the same dispatcher, and answering there would take
+    a call the decode path owns. Compared against ``auto`` rather than asserted
+    absolutely, because what decode makes of these tensors is not the subject --
+    only that naming a backend did not reroute it.
+    """
+    _skip_if_not_sm120()
+    inputs = _make_inputs_sm120(seq_lens=[1], num_heads=4, packed=False, seed=SEED)
+
+    def outcome(backend):
+        try:
+            _call(inputs, backend=backend)
+        except Exception as exc:  # noqa: BLE001 -- the type and text are the assertion
+            return type(exc).__name__, str(exc)
+        return "ok", ""
+
+    assert outcome("cute-dsl") == outcome("auto")
+
+
+def test_sm120_cute_dsl_request_names_the_reason_this_backend_refused():
+    """``backend="cute-dsl"`` on CC 12.0 must say what it could not support.
+
+    The CC 10.0/10.3 block below this backend answers such a request with a
+    message about the *contract*, which on this architecture names neither the
+    argument at fault nor the architecture that refused it.
+    """
+    _skip_if_not_sm120()
+
+    inputs = _make_inputs_sm120(seq_lens=[64], num_heads=4, packed=False, seed=SEED)
+    seq_order = torch.zeros(1, dtype=torch.int32, device=inputs["q"].device)
+    with pytest.raises(ValueError, match="seq_order"):
+        _call(inputs, backend="cute-dsl", seq_order=seq_order)
+
+
+# ===========================================================================
+# Correctness through the public API.
+# ===========================================================================
+
+
+@torch.inference_mode()
+@pytest.mark.parametrize("seq_lens", [[16], [17], [15], [64], [65], [63], [128]])
+@pytest.mark.parametrize("num_heads", [2, 8])
+@pytest.mark.parametrize("has_initial_state", [False, True])
+def test_recurrent_kda_prefill_sm120_fixed_matches_reference(
+    seq_lens, num_heads, has_initial_state
+):
+    """Fixed-length input, every chunk-boundary case around 16 and 64."""
+    _skip_if_not_sm120()
+    inputs = _make_inputs_sm120(
+        seq_lens=seq_lens,
+        num_heads=num_heads,
+        packed=False,
+        initial_state=has_initial_state,
+        seed=SEED,
+    )
+    expected_out, expected_state = _reference_kda_prefill(inputs)
+
+    out, state = _call(inputs, output_final_state=True)
+
+    _assert_elementwise(out, expected_out, "output", rtol=OUTPUT_RTOL, atol=OUTPUT_ATOL)
+    assert state is not None
+    _assert_elementwise(
+        state, expected_state, "final_state", rtol=STATE_RTOL, atol=STATE_ATOL
+    )
+
+
+@torch.inference_mode()
+@pytest.mark.parametrize(
+    "seq_lens", [[16], [15, 32, 65], [1, 16, 129], [17, 17], [64, 1, 33]]
+)
+@pytest.mark.parametrize("offsets_dtype", [torch.int32, torch.int64])
+@pytest.mark.parametrize("has_initial_state", [False, True])
+def test_recurrent_kda_prefill_sm120_packed_matches_reference(
+    seq_lens, offsets_dtype, has_initial_state
+):
+    """Packed varlen, mixed lengths, and both offsets dtypes the API accepts."""
+    _skip_if_not_sm120()
+    inputs = _make_inputs_sm120(
+        seq_lens=seq_lens,
+        num_heads=4,
+        packed=True,
+        initial_state=has_initial_state,
+        seed=SEED,
+        offsets_dtype=offsets_dtype,
+    )
+    expected_out, expected_state = _reference_kda_prefill(inputs)
+
+    out, state = _call(inputs, output_final_state=True)
+
+    _assert_elementwise(out, expected_out, "output", rtol=OUTPUT_RTOL, atol=OUTPUT_ATOL)
+    assert state is not None
+    _assert_elementwise(
+        state, expected_state, "final_state", rtol=STATE_RTOL, atol=STATE_ATOL
+    )
+
+
+@torch.inference_mode()
+@pytest.mark.parametrize("variant", ["decomp", "fused"])
+@pytest.mark.parametrize("packed", [False, True])
+def test_recurrent_kda_prefill_sm120_variants_match_reference(variant, packed):
+    """Each variant on its own, so neither is left untested by ``auto``.
+
+    ``auto`` picks one per shape, and which one depends on the runner's SM
+    count -- so a suite that only entered through ``auto`` would silently test
+    one variant on one machine and the other on another.
+    """
+    _skip_if_not_sm120()
+    sm120_prefill = _sm120_prefill()
+
+    seq_lens = [17, 33] if packed else [64, 64]
+    inputs = _make_inputs_sm120(
+        seq_lens=seq_lens, num_heads=4, packed=packed, initial_state=True, seed=SEED
+    )
+    expected_out, expected_state = _reference_kda_prefill(inputs)
+
+    out = torch.empty_like(inputs["v"])
+    state = inputs["initial_state"]
+    sm120_prefill.run_kda_prefill_sm120(
+        q=inputs["q"],
+        k=inputs["k"],
+        v=inputs["v"],
+        g=inputs["g"],
+        beta=inputs["beta"],
+        A_log=inputs["A_log"],
+        dt_bias=inputs["dt_bias"],
+        lower_bound=-5.0,
+        initial_state=state,
+        final_state=state,
+        cu_seqlens=inputs["cu_seqlens"],
+        output=out,
+        variant=variant,
+    )
+
+    _assert_elementwise(out, expected_out, "output", rtol=OUTPUT_RTOL, atol=OUTPUT_ATOL)
+    _assert_elementwise(
+        state, expected_state, "final_state", rtol=STATE_RTOL, atol=STATE_ATOL
+    )
+
+
+@torch.inference_mode()
+@pytest.mark.parametrize("variant", ["decomp", "fused"])
+@pytest.mark.parametrize("exact_alias", [False, True])
+def test_recurrent_kda_prefill_sm120_zero_tokens_preserves_fp32_state(
+    variant, exact_alias
+):
+    """Both backend variants implement the same state-only ABI."""
+    _skip_if_not_sm120()
+    heads = 2
+    shape = (1, 0, heads, HEAD_DIM)
+    q = torch.empty(shape, dtype=torch.bfloat16, device="cuda")
+    initial = torch.randn(
+        (1, heads, HEAD_DIM, HEAD_DIM), dtype=torch.float32, device="cuda"
+    )
+    expected = initial.clone()
+    final = initial if exact_alias else torch.empty_like(initial)
+
+    _sm120_prefill().run_kda_prefill_sm120(
+        q=q,
+        k=torch.empty_like(q),
+        v=torch.empty_like(q),
+        g=torch.empty_like(q),
+        beta=torch.empty((1, 0, heads), dtype=torch.bfloat16, device="cuda"),
+        A_log=torch.zeros(heads, dtype=torch.float32, device="cuda"),
+        dt_bias=torch.zeros((heads, HEAD_DIM), dtype=torch.float32, device="cuda"),
+        lower_bound=-5.0,
+        initial_state=initial,
+        final_state=final,
+        output=torch.empty_like(q),
+        variant=variant,
+    )
+
+    torch.testing.assert_close(final, expected, rtol=0.0, atol=0.0)
+
+
+@torch.inference_mode()
+def test_recurrent_kda_prefill_sm120_auto_enters_the_sm120_backend(monkeypatch):
+    """``auto`` through the public API really reaches this backend.
+
+    Asserted with a spy rather than inferred from a timing or from the answer
+    being right: both would also be true if the call had quietly fallen through
+    to another implementation, which is the failure worth catching.
+    """
+    _skip_if_not_sm120()
+    sm120_prefill = _sm120_prefill()
+
+    seen = []
+    original = sm120_prefill.choose_variant
+
+    def spy(*args, **kwargs):
+        chosen = original(*args, **kwargs)
+        seen.append(chosen)
+        return chosen
+
+    monkeypatch.setattr(sm120_prefill, "choose_variant", spy)
+
+    inputs = _make_inputs_sm120(seq_lens=[64], num_heads=4, packed=False, seed=SEED)
+    out, _ = _call(inputs, output_final_state=False)
+
+    assert seen, "the SM120 auto selector was never consulted"
+    assert seen[0] in ("decomp", "fused")
+    assert out.shape == inputs["v"].shape
+
+
+@torch.inference_mode()
+def test_recurrent_kda_prefill_sm120_state_return_follows_the_public_contract():
+    """State semantics: updated in place always, returned only when asked."""
+    _skip_if_not_sm120()
+    inputs = _make_inputs_sm120(
+        seq_lens=[48], num_heads=4, packed=False, initial_state=True, seed=SEED
+    )
+    expected_out, expected_state = _reference_kda_prefill(inputs)
+
+    initial = inputs["initial_state"]
+    before = initial.clone()
+
+    out, returned = _call(inputs, output_final_state=False)
+
+    # Updated in place: that is what the caller's buffer is for.
+    assert not torch.equal(initial, before)
+    _assert_elementwise(
+        initial, expected_state, "in-place state", rtol=STATE_RTOL, atol=STATE_ATOL
+    )
+    # ...and still not returned, because the caller did not ask for it.
+    assert returned is None
+    _assert_elementwise(out, expected_out, "output", rtol=OUTPUT_RTOL, atol=OUTPUT_ATOL)
+
+
+@torch.inference_mode()
+def test_recurrent_kda_prefill_sm120_allocates_a_final_state_when_asked():
+    """No initial state, ``output_final_state=True`` -> a fresh bfloat16 state."""
+    _skip_if_not_sm120()
+    inputs = _make_inputs_sm120(seq_lens=[32, 48], num_heads=4, packed=True, seed=SEED)
+    expected_out, expected_state = _reference_kda_prefill(inputs)
+
+    out, state = _call(inputs, output_final_state=True)
+
+    assert state is not None
+    assert state.dtype is torch.bfloat16
+    assert state.shape == (2, 4, HEAD_DIM, HEAD_DIM)
+    _assert_elementwise(out, expected_out, "output", rtol=OUTPUT_RTOL, atol=OUTPUT_ATOL)
+    _assert_elementwise(
+        state, expected_state, "final_state", rtol=STATE_RTOL, atol=STATE_ATOL
+    )
+
+
+@torch.inference_mode()
+def test_recurrent_kda_prefill_sm120_writes_the_caller_output_buffer():
+    """A caller-provided ``output`` is written in place and returned as-is."""
+    _skip_if_not_sm120()
+    inputs = _make_inputs_sm120(seq_lens=[64], num_heads=4, packed=False, seed=SEED)
+    expected_out, _ = _reference_kda_prefill(inputs)
+
+    provided = torch.empty_like(inputs["v"])
+    out, _ = _call(inputs, output=provided, output_final_state=False)
+
+    assert out is provided
+    _assert_elementwise(out, expected_out, "output", rtol=OUTPUT_RTOL, atol=OUTPUT_ATOL)
+
+
+@torch.inference_mode()
+def test_recurrent_kda_prefill_sm120_does_not_modify_read_only_inputs():
+    """Nothing the caller passed as an input comes back changed."""
+    _skip_if_not_sm120()
+    inputs = _make_inputs_sm120(seq_lens=[33, 64], num_heads=4, packed=True, seed=SEED)
+    snapshots = {
+        name: inputs[name].clone()
+        for name in ("q", "k", "v", "g", "beta", "A_log", "dt_bias", "cu_seqlens")
+    }
+
+    _call(inputs, output_final_state=True)
+
+    for name, before in snapshots.items():
+        assert torch.equal(inputs[name], before), f"{name} was modified"
+
+
+@torch.inference_mode()
+def test_recurrent_kda_prefill_sm120_chained_state_stays_bounded():
+    """Feeding each call's final state into the next must not blow up.
+
+    Long-chain drift is the failure a single-call comparison cannot see: a
+    small per-token state error that a chunked schedule accumulates differently
+    than a serial one shows up only after many chunks, and by then it looks
+    like a tolerance problem rather than a schedule one.
+    """
+    _skip_if_not_sm120()
+    inputs = _make_inputs_sm120(
+        seq_lens=[128], num_heads=4, packed=False, initial_state=True, seed=SEED
+    )
+    state = inputs["initial_state"]
+    reference_state = state.clone()
+
+    errors = []
+    for step in range(6):
+        step_inputs = _make_inputs_sm120(
+            seq_lens=[128], num_heads=4, packed=False, seed=SEED + step
+        )
+        step_inputs["initial_state"] = state
+        expected_out, expected_state = _reference_kda_prefill(
+            {**step_inputs, "initial_state": reference_state}
+        )
+        out, _ = _call(step_inputs, output_final_state=False)
+        reference_state = expected_state
+        errors.append((out.float() - expected_out.float()).abs().max().item())
+
+    # Not a fixed threshold on the last step: the question is whether the error
+    # *grows with chain length*, which a per-step bound cannot answer.
+    assert errors[-1] <= max(errors[0], OUTPUT_ATOL) * 4.0, (
+        f"state error grew with recurrence length: {errors}"
+    )
+    for step, error in enumerate(errors):
+        assert error < 0.5, f"step {step} diverged: {errors}"
+
+
+@torch.inference_mode()
+def test_recurrent_kda_prefill_sm120_on_a_non_default_stream():
+    """A non-default stream must be used, not merely tolerated.
+
+    The plan caches key on the stream because a compiled entry bakes its
+    ``CUstream`` into its argument tuple; a plan replayed from another stream
+    would launch work correctly ordered against the wrong stream, and the
+    numbers would still be right most of the time.
+    """
+    _skip_if_not_sm120()
+    inputs = _make_inputs_sm120(seq_lens=[64], num_heads=4, packed=False, seed=SEED)
+    expected_out, expected_state = _reference_kda_prefill(inputs)
+
+    stream = torch.cuda.Stream()
+    with torch.cuda.stream(stream):
+        out, state = _call(inputs, output_final_state=True)
+    stream.synchronize()
+
+    _assert_elementwise(out, expected_out, "output", rtol=OUTPUT_RTOL, atol=OUTPUT_ATOL)
+    _assert_elementwise(
+        state, expected_state, "final_state", rtol=STATE_RTOL, atol=STATE_ATOL
+    )
+
+
+@torch.inference_mode()
+def test_recurrent_kda_prefill_sm120_repeated_calls_agree():
+    """The same inputs twice give the same answer, cold cache and warm.
+
+    The second call takes the plan cache's fast path and the first does not, so
+    a disagreement here means the cached plan and the freshly built one are not
+    the same launch.
+    """
+    _skip_if_not_sm120()
+    inputs = _make_inputs_sm120(seq_lens=[17, 48], num_heads=4, packed=True, seed=SEED)
+
+    first_out, first_state = _call(inputs, output_final_state=True)
+    first_out = first_out.clone()
+    first_state = first_state.clone()
+
+    second_out, second_state = _call(inputs, output_final_state=True)
+
+    assert torch.equal(first_out, second_out)
+    assert torch.equal(first_state, second_state)
+
+
+@torch.inference_mode()
+def test_recurrent_kda_prefill_sm120_concurrent_calls_are_serialized():
+    """Two host threads on one stream must not interleave a decomp launch pair.
+
+    The decomposed variant enqueues prepare and then recurrence against one
+    scratch arena. CUDA orders launches within a stream, but nothing orders two
+    Python threads submitting those pairs, so without a lock the second
+    prepare can overwrite factors the first recurrence has not read.
+    """
+    _skip_if_not_sm120()
+    sm120_prefill = _sm120_prefill()
+
+    inputs = _make_inputs_sm120(seq_lens=[64], num_heads=4, packed=False, seed=SEED)
+    expected_out, _ = _reference_kda_prefill(inputs)
+
+    results = []
+    errors = []
+
+    def worker():
+        # ``inference_mode`` is thread-local. The tensors above were created
+        # inside it on this test's thread, and writing to one from a thread
+        # that is not in inference mode raises -- so each worker enters it,
+        # which is also what a real serving thread does.
+        try:
+            with torch.inference_mode():
+                out = torch.empty_like(inputs["v"])
+                sm120_prefill.run_kda_prefill_sm120(
+                    q=inputs["q"],
+                    k=inputs["k"],
+                    v=inputs["v"],
+                    g=inputs["g"],
+                    beta=inputs["beta"],
+                    A_log=inputs["A_log"],
+                    dt_bias=inputs["dt_bias"],
+                    lower_bound=-5.0,
+                    cu_seqlens=None,
+                    output=out,
+                    variant="decomp",
+                )
+            results.append(out)
+        except Exception as exc:  # noqa: BLE001 -- reported below
+            errors.append(exc)
+
+    threads = [threading.Thread(target=worker) for _ in range(4)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+    torch.cuda.synchronize()
+
+    assert not errors, errors
+    for out in results:
+        _assert_elementwise(
+            out, expected_out, "concurrent output", rtol=OUTPUT_RTOL, atol=OUTPUT_ATOL
+        )
+
+
+# ===========================================================================
+# CUDA graph capture and replay.
+# ===========================================================================
+
+
+def _warm_and_capture(inputs, *, workspace, output, state, variant=None):
+    """Eager warmup on the capture stream, then capture. Returns the graph.
+
+    The order is the contract: warm with the exact tensors and stream, sync,
+    then capture. Anything the capture would have had to build -- a compile, a
+    descriptor, an allocation, a host read of the offsets -- has to have
+    happened during the warmup, because none of it is legal inside.
+    """
+    sm120_prefill = _sm120_prefill()
+    stream = torch.cuda.Stream()
+
+    def call():
+        kwargs = dict(
+            q=inputs["q"],
+            k=inputs["k"],
+            v=inputs["v"],
+            g=inputs["g"],
+            beta=inputs["beta"],
+            A_log=inputs["A_log"],
+            dt_bias=inputs["dt_bias"],
+            lower_bound=-5.0,
+            initial_state=inputs["initial_state"],
+            final_state=state,
+            cu_seqlens=inputs["cu_seqlens"],
+            output=output,
+            resources=workspace,
+        )
+        if variant is not None:
+            kwargs["variant"] = variant
+        return sm120_prefill.run_kda_prefill_sm120(**kwargs)
+
+    with torch.cuda.stream(stream):
+        call()
+    stream.synchronize()
+    torch.cuda.synchronize()
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph, stream=stream):
+        call()
+    return graph
+
+
+@torch.inference_mode()
+@pytest.mark.parametrize("variant", ["decomp", "fused", None])
+@pytest.mark.parametrize("packed", [False, True])
+@pytest.mark.parametrize("offsets_dtype", [torch.int32, torch.int64])
+def test_recurrent_kda_prefill_sm120_graph_replay_matches_eager(
+    variant, packed, offsets_dtype
+):
+    """Every published combination captures, replays and agrees with eager.
+
+    ``variant=None`` is ``auto``, which must resolve once during warmup and
+    keep its answer: re-deciding between warmup and capture would record a
+    different kernel than the one the warmup proved.
+    """
+    _skip_if_not_sm120()
+    if not packed and offsets_dtype is torch.int64:
+        pytest.skip("fixed input has no caller offsets tensor")
+
+    from flashinfer.kda_kernels.sm120_prefill.runtime import SM120PrefillResources
+
+    seq_lens = [17, 47] if packed else [64, 64]
+    inputs = _make_inputs_sm120(
+        seq_lens=seq_lens,
+        num_heads=4,
+        packed=packed,
+        initial_state=True,
+        seed=SEED,
+        offsets_dtype=offsets_dtype,
+    )
+    expected_out, expected_state = _reference_kda_prefill(inputs)
+
+    eager_state = inputs["initial_state"].clone()
+    eager_out = torch.empty_like(inputs["v"])
+    _sm120_prefill().run_kda_prefill_sm120(
+        q=inputs["q"],
+        k=inputs["k"],
+        v=inputs["v"],
+        g=inputs["g"],
+        beta=inputs["beta"],
+        A_log=inputs["A_log"],
+        dt_bias=inputs["dt_bias"],
+        lower_bound=-5.0,
+        initial_state=eager_state,
+        final_state=eager_state,
+        cu_seqlens=inputs["cu_seqlens"],
+        output=eager_out,
+        **({} if variant is None else {"variant": variant}),
+    )
+    torch.cuda.synchronize()
+
+    workspace = SM120PrefillResources(device=inputs["q"].device)
+    graph_out = torch.empty_like(inputs["v"])
+    graph = _warm_and_capture(
+        inputs,
+        workspace=workspace,
+        output=graph_out,
+        state=inputs["initial_state"],
+        variant=variant,
+    )
+
+    # Reset the state so replay does the same work the eager call did.
+    inputs["initial_state"].copy_(
+        _make_inputs_sm120(
+            seq_lens=seq_lens,
+            num_heads=4,
+            packed=packed,
+            initial_state=True,
+            seed=SEED,
+            offsets_dtype=offsets_dtype,
+        )["initial_state"]
+    )
+    graph.replay()
+    torch.cuda.synchronize()
+
+    _assert_elementwise(
+        graph_out, eager_out, "graph vs eager output", rtol=0.0, atol=0.0
+    )
+    _assert_elementwise(
+        graph_out, expected_out, "graph output", rtol=OUTPUT_RTOL, atol=OUTPUT_ATOL
+    )
+    _assert_elementwise(
+        inputs["initial_state"],
+        expected_state,
+        "graph final_state",
+        rtol=STATE_RTOL,
+        atol=STATE_ATOL,
+    )
+
+
+@torch.inference_mode()
+@pytest.mark.parametrize("variant", ["decomp", "fused"])
+def test_recurrent_kda_prefill_sm120_plan_is_isolated_per_workspace(variant):
+    """A plan built for one workspace must never populate another one.
+
+    Plans embed workspace-owned offsets, descriptors and (for decomp) writable
+    scratch.  Reusing the first workspace's plan for a second workspace leaves
+    the second empty and can make two captured graphs share mutable storage.
+    """
+    _skip_if_not_sm120()
+    from flashinfer.kda_kernels.sm120_prefill.runtime import SM120PrefillResources
+
+    sm120_prefill = _sm120_prefill()
+    sm120_prefill.clear_kda_prefill_sm120_caches()
+    inputs = _make_inputs_sm120(seq_lens=[17, 33], num_heads=4, packed=True, seed=SEED)
+    output = torch.empty_like(inputs["v"])
+    call = dict(
+        q=inputs["q"],
+        k=inputs["k"],
+        v=inputs["v"],
+        g=inputs["g"],
+        beta=inputs["beta"],
+        A_log=inputs["A_log"],
+        dt_bias=inputs["dt_bias"],
+        lower_bound=-5.0,
+        cu_seqlens=inputs["cu_seqlens"],
+        output=output,
+        variant=variant,
+    )
+    first = SM120PrefillResources(device=inputs["q"].device)
+    second = SM120PrefillResources(device=inputs["q"].device)
+
+    sm120_prefill.run_kda_prefill_sm120(**call, resources=first)
+    sm120_prefill.run_kda_prefill_sm120(**call, resources=second)
+
+    assert first.cu_seqlens_i32 is not None
+    assert second.cu_seqlens_i32 is not None
+    assert first.cu_seqlens_i32.data_ptr() != second.cu_seqlens_i32.data_ptr()
+    assert first.pins
+    assert second.pins
+    if variant == "decomp":
+        assert first._arena is not None
+        assert second._arena is not None
+        assert first._arena.storage.data_ptr() != second._arena.storage.data_ptr()
+
+    # A workspace freezes addresses and layouts, not merely logical shapes.
+    changed = dict(call)
+    changed["q"] = inputs["q"].clone()
+    with pytest.raises(RuntimeError, match="call signature"):
+        sm120_prefill.run_kda_prefill_sm120(**changed, resources=second)
+
+
+@torch.inference_mode()
+def test_recurrent_kda_prefill_sm120_cold_capture_is_refused():
+    """Capturing without a warmup fails loudly rather than silently degrading.
+
+    A cold cache inside a capture would have to compile, allocate or
+    synchronize; every one of those turns a capture-time mistake into a
+    replay-time corruption that surfaces far from its cause.
+    """
+    _skip_if_not_sm120()
+    from flashinfer.kda_kernels.sm120_prefill.runtime import SM120PrefillResources
+
+    sm120_prefill = _sm120_prefill()
+    sm120_prefill.clear_kda_prefill_sm120_caches()
+
+    inputs = _make_inputs_sm120(seq_lens=[33, 31], num_heads=4, packed=True, seed=SEED)
+    workspace = SM120PrefillResources(device=inputs["q"].device)
+    out = torch.empty_like(inputs["v"])
+
+    stream = torch.cuda.Stream()
+    torch.cuda.synchronize()
+    graph = torch.cuda.CUDAGraph()
+    with (
+        pytest.raises(
+            RuntimeError, match=r"CUDA graph capture cannot validate cu_seqlens"
+        ),
+        torch.cuda.graph(graph, stream=stream),
+    ):
+        sm120_prefill.run_kda_prefill_sm120(
+            q=inputs["q"],
+            k=inputs["k"],
+            v=inputs["v"],
+            g=inputs["g"],
+            beta=inputs["beta"],
+            A_log=inputs["A_log"],
+            dt_bias=inputs["dt_bias"],
+            lower_bound=-5.0,
+            cu_seqlens=inputs["cu_seqlens"],
+            output=out,
+            resources=workspace,
+        )
+    torch.cuda.synchronize()
+
+
+@torch.inference_mode()
+def test_recurrent_kda_prefill_sm120_workspace_refuses_a_second_binding():
+    """One workspace, one variant, one stream, one signature.
+
+    A workspace that has been captured holds addresses a live graph reads.
+    Letting it serve another call -- another variant, another stream, or plain
+    eager Python -- would let those addresses move underneath the graph.
+    """
+    _skip_if_not_sm120()
+    from flashinfer.kda_kernels.sm120_prefill.runtime import SM120PrefillResources
+
+    workspace = SM120PrefillResources(device=torch.device("cuda", 0))
+    workspace.bind(variant="decomp", stream_ptr=1, signature=("a",))
+    workspace.bind(variant="decomp", stream_ptr=1, signature=("a",))  # idempotent
+
+    with pytest.raises(RuntimeError, match="variant"):
+        workspace.bind(variant="fused", stream_ptr=1, signature=("a",))
+    with pytest.raises(RuntimeError, match="stream"):
+        workspace.bind(variant="decomp", stream_ptr=2, signature=("a",))
+    with pytest.raises(RuntimeError, match="call signature"):
+        workspace.bind(variant="decomp", stream_ptr=1, signature=("b",))
+
+    workspace.captured = True
+    with pytest.raises(RuntimeError, match="already participated"):
+        workspace.bind(variant="decomp", stream_ptr=1, signature=("a",))
+
+
+def test_sm120_spent_workspace_is_rejected_before_scratch_mutation(monkeypatch):
+    """A rejected reuse cannot release storage still read by a live graph."""
+    from flashinfer import kda_kernels, kda_prefill
+
+    scratch = SimpleNamespace(shape=(1,))
+    resources = SimpleNamespace(
+        captured=True,
+        state_scratch=scratch,
+        lock=threading.Lock(),
+    )
+    workspace = SimpleNamespace(_captured=False, _sm120_state=resources)
+
+    def reject_late(**kwargs):
+        raise RuntimeError("workspace participated in capture and cannot be reused")
+
+    monkeypatch.setattr(kda_kernels, "run_kda_prefill_sm120", reject_late)
+    shape = (2, 2, 2, HEAD_DIM)
+    q = torch.zeros(shape, dtype=torch.bfloat16)
+
+    def run(candidate):
+        return kda_prefill._run_sm120_kda_prefill(
+            q=q,
+            k=q.clone(),
+            v=q.clone(),
+            g=q.clone(),
+            beta=torch.zeros(shape[:-1], dtype=torch.bfloat16),
+            A_log=torch.zeros(shape[2], dtype=torch.float32),
+            dt_bias=torch.zeros((shape[2], HEAD_DIM), dtype=torch.float32),
+            scale=None,
+            initial_state=None,
+            output_final_state=True,
+            lower_bound=-5.0,
+            cu_seqlens=None,
+            output=None,
+            prefill_workspace=candidate,
+        )
+
+    with pytest.raises(RuntimeError, match=r"capture.*cannot be reused"):
+        run(workspace)
+    assert resources.state_scratch is scratch
+
+    # The shared workspace may instead have been spent by Cake, before it ever
+    # acquired SM120 resources. Reject before even creating that state.
+    cake_workspace = SimpleNamespace(_captured=True, _sm120_state=None)
+    with pytest.raises(RuntimeError, match=r"capture.*cannot be reused"):
+        run(cake_workspace)
+    assert cake_workspace._sm120_state is None
+
+
+@torch.inference_mode()
+def test_recurrent_kda_prefill_sm120_workspace_capacity_only_grows():
+    """Workspace buffers grow eagerly and never shrink.
+
+    Shrinking would move an address a captured graph already recorded, so the
+    monotonicity is a correctness property rather than an allocator nicety.
+    """
+    _skip_if_not_sm120()
+    from flashinfer.kda_kernels.sm120_prefill.runtime import SM120PrefillResources
+
+    workspace = SM120PrefillResources(device=torch.device("cuda", 0))
+    big = workspace.ensure_capacity("cu_seqlens_i32", 64, torch.int32)
+    base = big.data_ptr()
+    small = workspace.ensure_capacity("cu_seqlens_i32", 8, torch.int32)
+    assert small.numel() == 8
+    assert small.data_ptr() == base
+    grown = workspace.ensure_capacity("cu_seqlens_i32", 256, torch.int32)
+    assert grown.numel() == 256
+
+
+# ===========================================================================
+# Runtime unit tests that need no device.
+# ===========================================================================
+
+
+@pytest.mark.parametrize(
+    "class_name",
+    ["TVMFFIJitCompiledFunction", "TVMFFIJitCompiledFunctionWithKwargs"],
+)
+def test_sm120_tvm_ffi_dispatch_accepts_known_types_after_module_move(class_name):
+    """Known provider types remain valid if a newer DSL moves their module."""
+    from flashinfer.kda_kernels.sm120_prefill import runtime
+
+    compiled_type = type(class_name, (), {"__module__": "renamed.provider"})
+    compiled = compiled_type()
+    assert runtime.assert_tvm_ffi_dispatched(compiled, "test-kernel") is compiled
+
+
+def test_sm120_tvm_ffi_dispatch_rejects_the_ctypes_fallback():
+    """The compatibility fallback must not admit the slow ctypes callable."""
+    from flashinfer.kda_kernels.sm120_prefill import runtime
+
+    compiled_type = type(
+        "CudaDialectJitCompiledFunction", (), {"__module__": "renamed.provider"}
+    )
+    with pytest.raises(RuntimeError, match=r"not a TVM-FFI callable"):
+        runtime.assert_tvm_ffi_dispatched(compiled_type(), "test-kernel")
+
+
+def test_sm120_flat_view_rejects_noncontiguous_tensors_before_conversion():
+    """A reshape copy must not silently replace the address being described."""
+    from flashinfer.kda_kernels.sm120_prefill import runtime
+
+    tensor = torch.zeros((2, 3)).T
+    assert not tensor.is_contiguous()
+    with pytest.raises(runtime.KDAPrefillValidationError, match=r"contiguous"):
+        runtime.flat_view(tensor)
+
+
+def test_sm120_runtime_version_is_readable_under_inference_mode():
+    """Cache keys must not read ``_version`` unguarded.
+
+    Every tensor created under ``torch.inference_mode()`` refuses that read --
+    ``RuntimeError: Inference tensors do not track version counter`` -- and
+    inference mode is how serving calls this backend. A call-plan cache that
+    reads it unguarded therefore works in every benchmark and fails in the
+    deployment it exists for. This is a regression test for exactly that: the
+    whole correctness half of this file runs under ``inference_mode``, but a
+    failure there reads as a numerical problem rather than as this.
+    """
+    from flashinfer.kda_kernels.sm120_prefill import runtime
+
+    normal = torch.zeros(4)
+    assert runtime.tensor_version(normal) == normal._version
+    assert runtime.tensor_identity(normal) is not None
+
+    with torch.inference_mode():
+        inference = torch.zeros(4)
+        assert runtime.tensor_version(inference) is runtime.NO_VERSION
+        # ...and the identity a cache key is built from still works.
+        identity = runtime.tensor_identity(inference)
+        assert identity[-1] is runtime.NO_VERSION
+        # A sentinel that compares equal to itself keeps the plan cache usable;
+        # what it cannot do is notice an in-place edit, which is why the
+        # offsets values are a documented caller contract in this mode.
+        assert runtime.tensor_identity(inference) == identity
+
+
+def test_sm120_runtime_alias_rules():
+    """Exact aliases are recognized; partial overlaps are not aliases."""
+    from flashinfer.kda_kernels.sm120_prefill import runtime
+
+    base = torch.zeros(64, dtype=torch.bfloat16)
+    a = base[:32]
+    b = base[:32]
+    assert runtime.is_exact_alias(a, b)
+    assert runtime.intervals_overlap(
+        runtime.storage_interval(a), runtime.storage_interval(base[16:48])
+    )
+    assert not runtime.is_exact_alias(a, base[16:48])
+    assert not runtime.intervals_overlap(
+        runtime.storage_interval(base[:16]), runtime.storage_interval(base[16:32])
+    )
+    # A zero-element tensor owns no bytes, so it cannot overlap anything...
+    assert runtime.storage_interval(base[:0]) is None
+    assert not runtime.intervals_overlap(
+        runtime.storage_interval(base[:0]), runtime.storage_interval(base)
+    )
+    # ...and two of them are trivially the same (empty) range. That reads as an
+    # exact alias, which is the harmless answer: the only thing the caller does
+    # with it is skip an overwrite check on a buffer with nothing to overwrite.
+    assert runtime.is_exact_alias(base[:0], base[:0])
+
+
+def test_sm120_runtime_bounded_cache_evicts_from_the_lru_tail():
+    """The cache is bounded; the oldest entry is the one that goes."""
+    from flashinfer.kda_kernels.sm120_prefill import runtime
+
+    cache = runtime.BoundedDeviceCache("test", max_entries=2)
+    device = torch.device("cpu")
+    cache.put(device, "a", 1)
+    cache.put(device, "b", 2)
+    assert cache.get(device, "a") == 1  # refreshes a's position
+    cache.put(device, "c", 3)
+    assert cache.get(device, "b") is None
+    assert cache.get(device, "a") == 1
+    assert cache.get(device, "c") == 3
+    assert cache.stats(device).evictions == 1
+
+
+def test_sm120_runtime_refuses_a_mismatched_persistent_cache_target(monkeypatch):
+    """An artifact must not be named for a target it was not built for.
+
+    This is the failure mode the explicit compile option exists to prevent:
+    ``JitSpecCuteDsl`` names its module directory from ``CUTE_DSL_ARCH`` or the
+    device, while the kernel is compiled for whatever option we passed. If
+    those disagree, the on-disk artifact claims one target and contains
+    another, and the next process loads it believing the name.
+    """
+    from flashinfer.kda_kernels.sm120_prefill import runtime
+
+    monkeypatch.setattr(
+        "flashinfer.jit.cute_dsl_core._get_compile_arch", lambda: "sm100a"
+    )
+    with pytest.raises(runtime.UnsupportedArchitectureError, match="sm120a"):
+        runtime._assert_cache_target_matches()
+
+
+def test_sm120_runtime_build_kernel_uses_the_input_device(monkeypatch):
+    """Cold compile and persistent-cache lookup run under the tensor's device."""
+    from flashinfer.jit import cute_dsl_core
+    from flashinfer.kda_kernels.sm120_prefill import runtime
+
+    active_devices = []
+    entered_devices = []
+
+    class DeviceGuard:
+        def __init__(self, device):
+            self.device = torch.device(device)
+
+        def __enter__(self):
+            active_devices.append(self.device)
+            entered_devices.append(self.device)
+
+        def __exit__(self, exc_type, exc, traceback):
+            active_devices.pop()
+
+    monkeypatch.setattr(runtime.torch.cuda, "device", DeviceGuard)
+    monkeypatch.setattr(
+        cute_dsl_core,
+        "_get_compile_arch",
+        lambda: "sm120a" if active_devices else "sm100a",
+    )
+    monkeypatch.setattr(
+        cute_dsl_core,
+        "build_and_load_cute_dsl_kernel",
+        lambda _module, _kernel, compile_fn, extra_key_files=(): compile_fn(),
+    )
+
+    compiled = object()
+    assert (
+        runtime.build_kernel(
+            "device-guard-test", lambda: compiled, device=torch.device("cuda", 1)
+        )
+        is compiled
+    )
+    assert entered_devices == [torch.device("cuda", 1)]
+
+
+def test_sm120_runtime_offsets_reject_malformed_metadata():
+    """Offsets content is validated, with an error that says what was wrong."""
+    from flashinfer.kda_kernels.sm120_prefill import runtime
+
+    if not torch.cuda.is_available():
+        pytest.skip("offsets validation needs a CUDA tensor")
+
+    good = torch.tensor([0, 4, 10], dtype=torch.int32, device="cuda")
+    try:
+        record = runtime.validate_packed_offsets(good, 10)
+        assert record.sequences == 2
+        assert record.lengths == (4, 6)
+        assert record.longest_sequence == 6
+
+        with pytest.raises(runtime.KDAPrefillValidationError, match="start at 0"):
+            runtime.validate_packed_offsets(
+                torch.tensor([1, 4, 10], dtype=torch.int32, device="cuda"), 10
+            )
+        with pytest.raises(runtime.KDAPrefillValidationError, match="end at"):
+            runtime.validate_packed_offsets(good, 11)
+        with pytest.raises(runtime.KDAPrefillValidationError, match="non-decreasing"):
+            runtime.validate_packed_offsets(
+                torch.tensor([0, 8, 4], dtype=torch.int32, device="cuda"), 4
+            )
+    finally:
+        runtime.clear_offsets_caches()
+
+
+def test_sm120_runtime_packed_offsets_hits_the_ordered_lru(monkeypatch):
+    """An identity hit must not bypass the cache event or LRU accounting."""
+    from flashinfer.kda_kernels.sm120_prefill import runtime
+
+    if not torch.cuda.is_available():
+        pytest.skip("offsets validation needs a CUDA tensor")
+
+    runtime.clear_offsets_caches()
+    offsets = torch.tensor([0, 4, 10], dtype=torch.int64, device="cuda")
+    record = runtime.validate_packed_offsets(offsets, 10)
+    calls = []
+    original_get = runtime._PACKED_OFFSETS.get
+
+    def tracked_get(device, key):
+        calls.append((device, key))
+        return original_get(device, key)
+
+    monkeypatch.setattr(runtime._PACKED_OFFSETS, "get", tracked_get)
+    try:
+        assert runtime.validate_packed_offsets(offsets, 10) is record
+        assert len(calls) == 1
+    finally:
+        runtime.clear_offsets_caches()
+
+
+def test_sm120_runtime_packed_offsets_eviction_releases_the_source():
+    """The identity memo must not keep bounded-cache payloads alive forever."""
+    from flashinfer.kda_kernels.sm120_prefill import runtime
+
+    if not torch.cuda.is_available():
+        pytest.skip("offsets validation needs a CUDA tensor")
+
+    runtime.clear_offsets_caches()
+    sources = []
+    try:
+        for _ in range(runtime._PACKED_OFFSETS.max_entries + 1):
+            offsets = torch.tensor([0, 1], dtype=torch.int64, device="cuda")
+            sources.append(weakref.ref(offsets))
+            record = runtime.validate_packed_offsets(offsets, 1)
+        del offsets, record
+        torch.cuda.synchronize()
+        gc.collect()
+        assert sources[0]() is None
+    finally:
+        runtime.clear_offsets_caches()


### PR DESCRIPTION
## 📌 Description

Add a CuTe DSL backend for ordinary multi-token recurrent KDA prefill on
SM120, in `flashinfer/kda_kernels/sm120_prefill/`.

- Route eligible fixed and packed ordinary prefill through it from
  `recurrent_kda`. No new public API name and no argument names the
  architecture: shape, dtype, device, and backend contract decide. Under
  `backend="auto"`, calls outside the supported subset continue through the
  existing dispatcher.
- Reuse the existing `backend="cute-dsl"` selection for SM120. `auto` and
  `cute-dsl` may select this architecture-specific implementation, while an
  explicit `backend="cake"` never probes or runs it and remains a strict Cake
  request.
- Ship two kernels behind one contract. `decomp` runs prepare and recurrence
  as two launches sharing one scratch arena; `fused` runs one CTA per
  (sequence, head). Neither is faster everywhere, so the choice is made per
  call from a measured table.
- Key that table on SM count, not device name, because the latter is not a
  stable unique selector. Thresholds are 110 SM: `T <= 32 or CTA >= 128`;
  156 and 188 SM: `T <= 32 or CTA >= 144`.
  `describe_variant_policy` reports whether a device has its own measured row.
- Stay disjoint from the other prefill backends by compute capability: this
  implementation is CC 12.0, while Cake and the BT=16 CuTe DSL prefill backend
  are CC 10.0 and 10.3.
- Support CUDA graph capture through a caller-owned workspace. Compilation,
  descriptor construction, metadata tables, and allocation happen during
  eager warmup; cold capture is refused.
- Bound the flat output at `T_total * H * 128 <= 2**31 - 1` on the host. This
  protects both the tail store's INT32 index and the DSL memref extent.

### Performance

Measured against MoonshotAI/FlashKDA through the public `recurrent_kda` API on
a 110-SM SM120 device, with `--refcheck` enabled. Timing uses CUDA events
because CUPTI was unavailable. All runs use H=12, BF16, fixed layout, and no
initial state. `auto` is the variant selected by the measured policy.

```bash
for batch_tokens in 1:512 1:8192 8:1024 32:512 6:8192 8:8192; do
    batch=${batch_tokens%:*}
    tokens=${batch_tokens#*:}
    python benchmarks/flashinfer_benchmark.py \
        --routine recurrent_kda_prefill \
        --backends flashinfer flashinfer-decomp flashinfer-fused flash-kda \
        --batch_size "$batch" --s_qo "$tokens" --num_q_heads 12 --refcheck
done
```

| Case | auto | FlashInfer | FlashKDA | Speedup |
|---|---|---:|---:|---:|
| B1 T512 | decomp | 0.037 | 0.086 | 2.29x |
| B1 T8192 | decomp | 0.445 | 1.805 | 4.06x |
| B8 T1024 | fused | 0.130 | 0.416 | 3.20x |
| B32 T512 | fused | 0.270 | 0.824 | 3.05x |
| B6 T8192 | fused | 0.784 | 2.788 | 3.55x |
| B8 T8192 | fused | 0.881 | 3.164 | 3.59x |

Times are milliseconds. FlashInfer wins 6 of 6; the geometric mean is
**3.239x**, and the worst case is 2.29x. At B8 T8192, pinned `decomp` is 2.162
ms and pinned `fused` is 0.881 ms, which demonstrates why per-shape selection
is needed.

The 156-SM and 188-SM SM120 devices were last measured at `8401e91c` on
other hosts: geometric means of
2.977x and 3.001x over the same six cases. Those results are from an older
commit on different machines and are not directly comparable to the table
above.

The auto-policy thresholds come from independent FlashInfer variant sweeps:
74 shapes on the 110-SM part and 147 shapes each on the 156-SM and 188-SM
parts. A separate 127-shape comparison against FlashKDA found 127/127 shapes
faster, with geometric-mean speedups of 2.258x, 2.164x, and 2.193x on the
110-SM, 156-SM, and 188-SM parts respectively. The 127-shape comparison is not
the source of the threshold-fit row counts.

The changes after these benchmark runs are host-side dispatch, compile-device
scoping, zero-token state handling, documentation, comments, and tests. The
timed device kernels and hot launch path are unchanged.

### Accuracy

On all three parts, 127/127 shapes pass a 5e-2 gate against an FP64 reference.
The largest disagreement is 1.03e-2 against the reference and 1.56e-2 against
FlashKDA. 247 cross-implementation comparisons are bitwise identical.

## 🔍 Related Issues

N/A.

## 🚀 Pull Request Checklist

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or
  used my preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and
  fixed any reported issues.

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.), run on a 110-SM SM120 device at
  this head rather than at an earlier one.

- `tests/kda/test_recurrent_kda_prefill_sm120.py`: **126 passed, 3 skipped**.
  The file covers eligibility (host-only where it can be), the variant table,
  correctness against a contract-shaped reference, the public state and output
  contract, graph capture and replay, and the runtime's caches.
- `tests/kda/` whole directory: **338 passed, 229 skipped**; the skips are the
  CC 10.0/10.3 architecture gates.
- Final changed-file checks pass: `git diff --check`, `compileall`, and the
  complete `pre-commit run --all-files` hook set, including mypy and Ruff.
- The INT32 bound was checked on hardware: at H=1024, 16383 tokens runs and
  16384 is refused.

## Reviewer Notes

Review should focus on eligibility and dispatch, the variant table, workspace
and graph semantics, runtime caches, and these integration fixes:

- Explicit `backend="cake"` skips the SM120 CuTe DSL path; only `auto` and
  `cute-dsl` may select it.
- Launch streams, plan keys, cold compilation, persistent-cache target
  detection, and in-process compiled-callable caches are scoped to the input
  tensor's CUDA device.
- The variant policy reads the called device's SM count rather than device 0.
- A bound workspace rejects an explicit variant that differs from its warmed
  variant instead of silently ignoring the request.
- The decomp and fused zero-token paths now preserve an FP32 initial state with
  identical semantics, including exact aliasing.
- Capture without an explicit workspace is refused at the public adapter.
- `SM120PrefillResources.bind` is called so its captured-signature constraints
  are enforced.
- Backend selection checks TMA's 16-byte base-address alignment.
- The `A_log` memo handles tensors without a readable version counter.
- The fused variant validates its grid against `maxGridSize[1]`.
- Descriptor staging buffers are not refilled while an asynchronous upload may
  still be reading them.
- The benchmark clones `initial_state` per backend because KDA updates it in
  place.
- The per-call memos -- the facade's and both variants' -- held strong
  references to the caller's tensors, so one whole activation set stayed off
  the caching allocator until the next call replaced it. They hold weak
  references now, as the plan LRU behind them already did.
- The process-global caches are serialized. `BoundedDeviceCache`, the flat-view
  cache and the resolved-call memo mutate module state on a path that runs
  without the workspace lock whenever the caller passes none, and the pairs are
  not atomic even though the individual dict operations are: a hit and its
  `move_to_end`, an insert racing the eviction loop. The single-load fast paths
  stay outside the locks on purpose, and say so.
- A workspace's SM120 resources were created without a lock, so two first calls
  on one workspace could each build their own. The loser ran against an orphan:
  its lock serialized nothing, its scratch doubled the device memory, and its
  capture flag was set where nobody would read it.
- `backend="cute-dsl"` on a CC 12.0 device was answered by the CC 10.0/10.3
  block, which can only name the contract when the reason is architecture-
  specific and already known. The SM120 refusal now carries its reason to that
  raise. It is recorded rather than raised where it is found, so a decode --
  which reaches the same dispatcher -- still falls through untouched.
- `_SM120_TMA_BASE_ALIGN` and `runtime.GLOBAL_BASE_ALIGN` are one number in two
  modules, and now a test says so.
- The spent-workspace check and the scratch it guards now share one hold of
  `resources.lock`. Split across the lock they raced each other: a thread that
  read the flag as False could replace `state_scratch` after another thread's
  capture had already recorded the old buffer's address, and two threads
  wanting different state shapes could each install their own, leaving the
  loser with a `final_state` the workspace no longer owns. The backend
  re-checks the flag, which orders the launches, but it cannot undo a
  replacement that already happened.

With that, every mutable state in the package has an owner: `resources.lock`
for the workspace's fields, `_sm120_state_lock` for creating them, `_BUILD_LOCK`
for the plan and compile caches, a per-instance lock for each
`BoundedDeviceCache`, and module locks for the flat views, the pinned staging
and the resolved-call memo. The single-load fast paths stay outside their locks
on purpose and say why.

A warm call's memo addresses the caller's buffers, so those buffers stay
allocated while the entry lives -- which is what makes reusing the entry safe,
since an allocator that had recycled the address would otherwise hand the
kernel someone else's memory. It scales with the number of distinct buffer sets
a process rotates through rather than with the number of calls: at
`[1, 1024, 8, 128]` on the 110-SM part one set holds about 14.5 MiB and eight
rotating sets about 73 MiB.

The entry ceilings are documented rather than lowered, because measurement says
lowering them buys nothing. Below a ceiling the retention is identical whatever
the ceiling is; above it every call rebuilds its plan, about 7.3 ms against a
100 microsecond hit. Three caches can each hold a buffer alive and only bind
together, so lowering one alone changes nothing at all. The constants now carry
that table, and the public page says what to do instead.

Under `inference_mode`, a tensor may have no readable version counter, so
refilling an offsets buffer in place cannot reliably invalidate derived host
metadata. Fixed offset values for a warmed/captured workspace are therefore a
documented caller contract.


