### PR TITLE
fix: Make GPU-direct RDMA capability configurable for local TRT-LLM IPC

### DIFF
--- a/flashinfer/comm/mnnvl.py
+++ b/flashinfer/comm/mnnvl.py
@@ -738,6 +738,7 @@ class SymmDeviceMemory:
         comm_backend_for_handle_transfer: Optional[CommBackend] = None,
         enable_multicast: bool = True,
         allocate_signal_pads: bool = True,
+        gpu_direct_rdma_capable: bool = True,
     ):
         cu_device = checkCudaErrors(cuda.cuDeviceGet(device_idx))
 
@@ -765,6 +766,7 @@ class SymmDeviceMemory:
         self.allocation_size = 0
         self.comm_backend = comm_backend_for_handle_transfer or MPIBackend()
         self._enable_multicast = enable_multicast
+        self._gpu_direct_rdma_capable = gpu_direct_rdma_capable
 
         # CUDA memory handles and pointers
         self.mc_ptr = 0  # CUdeviceptr mMcPtr
@@ -1002,7 +1004,9 @@ class SymmDeviceMemory:
             cuda.CUmemLocationType.CU_MEM_LOCATION_TYPE_DEVICE
         )
         allocation_prop.location.id = self.device_idx
-        allocation_prop.allocFlags.gpuDirectRDMACapable = 1
+        allocation_prop.allocFlags.gpuDirectRDMACapable = int(
+            self._gpu_direct_rdma_capable
+        )
 
         # Get allocation granularity
         alloc_granularity = checkCudaErrors(

--- a/flashinfer/comm/trtllm_ar.py
+++ b/flashinfer/comm/trtllm_ar.py
@@ -693,6 +693,9 @@ def trtllm_create_ipc_workspace_for_all_reduce_fusion(
                 comm_backend_for_handle_transfer=comm_backend,
                 enable_multicast=False,
                 allocate_signal_pads=False,
+                # Local TRT-LLM IPC does not require GDR, which is
+                # unavailable on consumer Blackwell GPUs.
+                gpu_direct_rdma_capable=False,
             )
             ptrs = handle.get_buffer_ptrs_host()
             symm_refs.append(handle)


### PR DESCRIPTION
 <!-- .github/pull_request_template.md -->

  ## 📌 Description

  This PR makes the `gpuDirectRDMACapable` allocation property configurable for symmetric device memory.

  Previously, `SymmDeviceMemory` unconditionally set `gpuDirectRDMACapable=1`. This assumption is invalid for local TRT-LLM IPC on consumer Blackwell GPUs, such as SM120, where GPUDirect RDMA may be unavailable while local CUDA IPC remains supported.

  This change:

  - Adds an optional `gpu_direct_rdma_capable` parameter to `SymmDeviceMemory`.
  - Preserves the existing behavior by defaulting the parameter to `True`.
  - Disables the GDR requirement only for the local TRT-LLM IPC workspace.
  - Keeps multicast configuration and MNNVL behavior unchanged.
  - Does not change FlashInfer backend selection or the `auto` fallback logic.
  - Keeps the API backward compatible for existing callers.

  ### Downstream vLLM Integration

  This change is used by a downstream vLLM integration that enables the existing FlashInfer TRT-LLM fused all-reduce path on consumer Blackwell GPUs.

  The vLLM integration uses the installed FlashInfer package and does not compile or patch FlashInfer. Without this allocator fix, local TRT-LLM IPC workspace initialization fails because `gpuDirectRDMACapable=1` is unsupported on these GPUs, causing vLLM to disable the FlashInfer all-reduce path and fall back to another all-reduce backend.

  ## 🔍 Related Issues

  N/A

  ## 🚀 Pull Request Checklist

  Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

  ### ✅ Pre-commit Checks

  - [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
  - [x] I have installed the hooks with `pre-commit install`.
  - [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

  > If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

  ## 🧪 Tests

  - [x] Existing communication tests pass.
  - [x] Local TRT-LLM all-reduce workspace initialization was verified on SM120 consumer GPUs.
  - [x] Existing MNNVL/multicast paths were verified to retain their previous behavior.
  - [x] All tests are passing (`unittest`, etc.).

  ## Reviewer Notes

  The default value preserves the original GDR allocation behavior, while the local TRT-LLM IPC path explicitly sets it to `False` because that path does not require GPUDirect RDMA.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved communication memory allocation for systems without GPU-direct RDMA support.
  * Updated all-reduce workspace allocation to use compatible settings, improving reliability across supported hardware configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->