### PR TITLE
[perf] split TRT-LLM Gen routing kernels to reduce compile time

### DIFF
--- a/csrc/fused_moe/trtllm_backend/trtllm_fused_moe_routing_common.cu
+++ b/csrc/fused_moe/trtllm_backend/trtllm_fused_moe_routing_common.cu
@@ -23,7 +23,7 @@ namespace routingCustom {
 // Forward declarations of launch functions.
 // Block/DynBlock/Cluster return whether a compiled tier covered (numExperts, topK)
 // and the kernel was actually launched; the definitions live in
-// trtllm_fused_moe_routing_custom.cu. Keep these signatures in sync (the return
+// trtllm_fused_moe_routing_custom.cuh. Keep these signatures in sync (the return
 // type is not part of the mangled name, so a mismatch would silently be UB).
 bool launchBlockKernel(Data const& data, void* stream);
 bool launchDynBlockKernel(Data const& data, uint32_t numThreadsHist, void* stream);

--- a/csrc/fused_moe/trtllm_backend/trtllm_fused_moe_routing_custom.cuh
+++ b/csrc/fused_moe/trtllm_backend/trtllm_fused_moe_routing_custom.cuh
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-// Custom routing: entry point, kernel definitions, and launch wrappers.
+// Custom routing implementation included by the per-family translation units.
 //
 // Kernel inventory:
 //   1. routingIndicesBlockKernel      — single-block fused kernel (≤4 tokens)
@@ -36,6 +36,31 @@
 
 namespace moe::dev::routing {
 namespace routingCustom {
+
+#if (defined(FLASHINFER_ROUTING_CUSTOM_BLOCK_GROUP) +   \
+     defined(FLASHINFER_ROUTING_CUSTOM_CLUSTER_SMALL) + \
+     defined(FLASHINFER_ROUTING_CUSTOM_CLUSTER_LARGE) + \
+     defined(FLASHINFER_ROUTING_CUSTOM_ENTRY)) != 1
+#error "Define exactly one FLASHINFER_ROUTING_CUSTOM_* translation-unit selector"
+#endif
+
+bool launchBlockKernel(Data const& data, void* stream);
+bool launchDynBlockKernel(Data const& data, uint32_t numThreadsHist, void* stream);
+bool launchClusterKernelBlockDim256(Data const& data, void* stream);
+bool launchClusterKernelBlockDim512(Data const& data, void* stream);
+bool launchClusterKernelBlockDim1024(Data const& data, void* stream);
+bool launchClusterKernel(Data const& data, void* stream);
+bool launchHistogramScoresKernel(Data const& data, uint32_t maxNumBlocks, uint32_t numThreadsHist,
+                                 void* stream);
+bool launchBlockScoresKernel(Data const& data, void* stream);
+void launchCoopKernel(Data const& data, int numBlocksCoop, uint32_t numThreadsHist, void* stream);
+void launchInitExpertCounts(Data const& data, uint32_t numThreadsHist, void* stream);
+void launchHistogramKernel(Data const& data, int numBlocksHistogram, uint32_t numThreadsHist,
+                           void* stream);
+void launchOffsetsKernel(Data const& data, int numBlocksOffsets, uint32_t numThreadsHist,
+                         void* stream);
+
+#if defined(FLASHINFER_ROUTING_CUSTOM_BLOCK_GROUP)
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 //
@@ -645,6 +670,8 @@ bool launchDynBlockKernel(Data const& data, uint32_t numThreadsHist, void* strea
   return queryPolicyHasCompiledTier(data);
 }
 
+#endif  // defined(FLASHINFER_ROUTING_CUSTOM_BLOCK_GROUP)
+
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // 2. Cluster kernel — single-cluster fused kernel for ≤256 tokens (SM90+).
@@ -659,6 +686,9 @@ static constexpr int MaxNumTokensClusterScores256 =
     NumBlocksPerCluster * (ClusterBlockDim256 / WarpSize);
 static constexpr int MaxNumTokensClusterScores512 =
     NumBlocksPerCluster * (ClusterBlockDim512 / WarpSize);
+
+#if defined(FLASHINFER_ROUTING_CUSTOM_CLUSTER_SMALL) || \
+    defined(FLASHINFER_ROUTING_CUSTOM_CLUSTER_LARGE)
 
 template <typename TierT, typename TierListT>
 struct PrependTier;
@@ -843,29 +873,19 @@ bool launchClusterKernelForBlockDim(Data const& data, void* stream) {
   return dispatched;
 }
 
-// Returns whether a compiled tier covered the runtime (numExperts, topK) and the
-// kernel was actually launched (see launchBlockKernel).
-bool launchClusterKernel(Data const& data, void* stream) {
-  // Use the wider cluster only for permutation-only launches in the bounded high-expert/high-TopK
-  // range. Score-to-TopK fused clusters retain the general capacity-based dispatch.
-  bool const useWidePermutationCluster =
-      data.mPtrScores == nullptr &&
-      topk::isInHighExpertLaneOwnedTopKRange(data.mNumExperts, data.mTopK) &&
-      data.mNumTokens >= 32 && data.mNumTokens <= 64;
-  if (useWidePermutationCluster) {
-    return launchClusterKernelForBlockDim<ClusterBlockDim512>(data, stream);
-  }
+// Returns whether the cluster tier dispatch found a covering tier and launched a kernel.
+#if defined(FLASHINFER_ROUTING_CUSTOM_CLUSTER_SMALL)
+bool launchClusterKernelBlockDim256(Data const& data, void* stream) {
+  return launchClusterKernelForBlockDim<ClusterBlockDim256>(data, stream);
+}
 
-  // Each warp owns one token, so the reduced-thread cluster variants have lower token capacity.
-  // Use them only where the requested token count fits; otherwise keep the original 1024-thread
-  // launch.
-  if (data.mNumTokens <= MaxNumTokensClusterScores256) {
-    return launchClusterKernelForBlockDim<ClusterBlockDim256>(data, stream);
-  }
-  if (data.mNumTokens <= MaxNumTokensClusterScores512) {
-    return launchClusterKernelForBlockDim<ClusterBlockDim512>(data, stream);
-  }
+bool launchClusterKernelBlockDim512(Data const& data, void* stream) {
+  return launchClusterKernelForBlockDim<ClusterBlockDim512>(data, stream);
+}
+#endif  // defined(FLASHINFER_ROUTING_CUSTOM_CLUSTER_SMALL)
 
+#if defined(FLASHINFER_ROUTING_CUSTOM_CLUSTER_LARGE)
+bool launchClusterKernelBlockDim1024(Data const& data, void* stream) {
   bool const useNoOpSoftmaxScores = data.mPtrScores != nullptr &&
                                     data.mPreprocessType == RoutingPreprocessType::None &&
                                     data.mPostprocessType == RoutingPostprocessType::Softmax;
@@ -878,6 +898,36 @@ bool launchClusterKernel(Data const& data, void* stream) {
                         /*smemSize=*/0,  // No dynamic smem
                         stream);
   return queryPolicyHasCompiledTier(data);
+}
+#endif  // defined(FLASHINFER_ROUTING_CUSTOM_CLUSTER_LARGE)
+
+#endif  // FLASHINFER_ROUTING_CUSTOM_CLUSTER_SMALL || FLASHINFER_ROUTING_CUSTOM_CLUSTER_LARGE
+
+#if defined(FLASHINFER_ROUTING_CUSTOM_ENTRY)
+
+// Returns whether a compiled tier covered the runtime (numExperts, topK) and the
+// kernel was actually launched (see launchBlockKernel).
+bool launchClusterKernel(Data const& data, void* stream) {
+  // Use the wider cluster only for permutation-only launches in the bounded high-expert/high-TopK
+  // range. Score-to-TopK fused clusters retain the general capacity-based dispatch.
+  bool const useWidePermutationCluster =
+      data.mPtrScores == nullptr &&
+      topk::isInHighExpertLaneOwnedTopKRange(data.mNumExperts, data.mTopK) &&
+      data.mNumTokens >= 32 && data.mNumTokens <= 64;
+  if (useWidePermutationCluster) {
+    return launchClusterKernelBlockDim512(data, stream);
+  }
+
+  // Each warp owns one token, so the reduced-thread cluster variants have lower token capacity.
+  // Use them only where the requested token count fits; otherwise keep the original 1024-thread
+  // launch.
+  if (data.mNumTokens <= MaxNumTokensClusterScores256) {
+    return launchClusterKernelBlockDim256(data, stream);
+  }
+  if (data.mNumTokens <= MaxNumTokensClusterScores512) {
+    return launchClusterKernelBlockDim512(data, stream);
+  }
+  return launchClusterKernelBlockDim1024(data, stream);
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -1778,6 +1828,8 @@ void run(Data const& data, void* stream) {
     }
   }
 }
+
+#endif  // defined(FLASHINFER_ROUTING_CUSTOM_ENTRY)
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 

--- a/csrc/fused_moe/trtllm_backend/trtllm_fused_moe_routing_custom_block.cu
+++ b/csrc/fused_moe/trtllm_backend/trtllm_fused_moe_routing_custom_block.cu
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#define FLASHINFER_ROUTING_CUSTOM_BLOCK_GROUP
+#include "trtllm_fused_moe_routing_custom.cuh"

--- a/csrc/fused_moe/trtllm_backend/trtllm_fused_moe_routing_custom_cluster.cu
+++ b/csrc/fused_moe/trtllm_backend/trtllm_fused_moe_routing_custom_cluster.cu
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#define FLASHINFER_ROUTING_CUSTOM_CLUSTER_SMALL
+#include "trtllm_fused_moe_routing_custom.cuh"

--- a/csrc/fused_moe/trtllm_backend/trtllm_fused_moe_routing_custom_cluster_large.cu
+++ b/csrc/fused_moe/trtllm_backend/trtllm_fused_moe_routing_custom_cluster_large.cu
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#define FLASHINFER_ROUTING_CUSTOM_CLUSTER_LARGE
+#include "trtllm_fused_moe_routing_custom.cuh"

--- a/csrc/fused_moe/trtllm_backend/trtllm_fused_moe_routing_custom_entry.cu
+++ b/csrc/fused_moe/trtllm_backend/trtllm_fused_moe_routing_custom_entry.cu
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#define FLASHINFER_ROUTING_CUSTOM_ENTRY
+#include "trtllm_fused_moe_routing_custom.cuh"

--- a/flashinfer/jit/fused_moe.py
+++ b/flashinfer/jit/fused_moe.py
@@ -313,7 +313,13 @@ def gen_trtllm_gen_fused_moe_sm100_module(enable_rubin: bool = False) -> JitSpec
             jit_env.FLASHINFER_CSRC_DIR
             / "fused_moe/trtllm_backend/trtllm_fused_moe_routing_llama4.cu",
             jit_env.FLASHINFER_CSRC_DIR
-            / "fused_moe/trtllm_backend/trtllm_fused_moe_routing_custom.cu",
+            / "fused_moe/trtllm_backend/trtllm_fused_moe_routing_custom_block.cu",
+            jit_env.FLASHINFER_CSRC_DIR
+            / "fused_moe/trtllm_backend/trtllm_fused_moe_routing_custom_cluster.cu",
+            jit_env.FLASHINFER_CSRC_DIR
+            / "fused_moe/trtllm_backend/trtllm_fused_moe_routing_custom_cluster_large.cu",
+            jit_env.FLASHINFER_CSRC_DIR
+            / "fused_moe/trtllm_backend/trtllm_fused_moe_routing_custom_entry.cu",
             jit_env.FLASHINFER_CSRC_DIR
             / "fused_moe/trtllm_backend/trtllm_fused_moe_routing_common.cu",
             jit_env.FLASHINFER_CSRC_DIR

--- a/flashinfer/jit/moe_utils.py
+++ b/flashinfer/jit/moe_utils.py
@@ -99,7 +99,13 @@ def gen_moe_utils_module() -> JitSpec:
             jit_env.FLASHINFER_CSRC_DIR
             / "fused_moe/trtllm_backend/trtllm_fused_moe_routing_deepseek.cu",
             jit_env.FLASHINFER_CSRC_DIR
-            / "fused_moe/trtllm_backend/trtllm_fused_moe_routing_custom.cu",
+            / "fused_moe/trtllm_backend/trtllm_fused_moe_routing_custom_block.cu",
+            jit_env.FLASHINFER_CSRC_DIR
+            / "fused_moe/trtllm_backend/trtllm_fused_moe_routing_custom_cluster.cu",
+            jit_env.FLASHINFER_CSRC_DIR
+            / "fused_moe/trtllm_backend/trtllm_fused_moe_routing_custom_cluster_large.cu",
+            jit_env.FLASHINFER_CSRC_DIR
+            / "fused_moe/trtllm_backend/trtllm_fused_moe_routing_custom_entry.cu",
             jit_env.FLASHINFER_CSRC_DIR
             / "fused_moe/trtllm_backend/trtllm_fused_moe_routing_common.cu",
         ],

--- a/tests/moe/test_trtllm_gen_fused_moe.py
+++ b/tests/moe/test_trtllm_gen_fused_moe.py
@@ -1249,7 +1249,7 @@ def test_tier_1024_experts_routing(
 
 
 # num_tokens is chosen to straddle the dispatch thresholds in routingCustom::run
-# (see trtllm_fused_moe_routing_custom.cu):
+# (see trtllm_fused_moe_routing_custom.cuh):
 #   - tokens == 8  : dyn-block kernel path (tokens <= DynBlockKernelMaxNumTokens=16,
 #                    numExperts <= DynBlockKernelMaxNumExperts=512)
 #   - tokens == 32 : block-per-token "split" path on the single-cluster kernel

--- a/tests/moe/test_trtllm_gen_routed_fused_moe.py
+++ b/tests/moe/test_trtllm_gen_routed_fused_moe.py
@@ -1366,7 +1366,7 @@ def test_fp8_block_scale_moe_routing_replay(
 
 # Each (num_tokens, num_experts) entry is chosen to land in exactly one of the
 # five top-K kernels in `routing_custom.cu`. See the dispatch logic comment in
-# `trtllm_fused_moe_routing_custom.cu` (around the `useSplitTopKPath` block):
+# `trtllm_fused_moe_routing_custom.cuh` (around the `useSplitTopKPath` block):
 #
 #   * BlockKernel             : num_tokens <= 4
 #   * DynBlockKernel          : 5 <= num_tokens <= 16  (num_experts <= 512)


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

Split the monolithic TRT-LLM Gen custom-routing CUDA source into four explicit translation units:

- block, cooperative-block, and dynamic-block kernels
- cluster kernels using 256/512 threads
- cluster kernels using 1024 threads
- histogram/block-score kernels, cooperative helpers, and the public entry point

The monolithic routing CUDA source was a JIT compile bottleneck. Splitting it into four translation units lets Ninja compile the routing kernel groups in parallel.

On B300 (SM103a, CUDA 13.0, `MAX_JOBS=4`), clean routing compile time dropped from 710.5s to 226.1–226.4s: 3.14x faster and 68.2% less wall time.

Runtime validation used the 176 routing shapes from #4152 across NoOp+Softmax, Softmax+SumNormalize, and SigmoidBias+ScaledSumNormalize. Two full, reverse-capture-order sweeps produced 14,080 samples. Perf is on par and no regression.

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see the [pre-commit documentation](https://pre-commit.com/).

Targeted `pre-commit run --files ...` passed for all changed files. `git diff --check` and Python syntax checks also passed.

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

