### PR TITLE
feat(cake_kda): add paired recurrent training for SM100a and SM103a

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,9 +18,10 @@
 # periodically (sm100/cutedsl_megamoe, sm90/pull_style_cutedsl_megakernel);
 # excluded from all hooks so formatting/lint churn doesn't block syncs.
 # The shim/ layers next to them are ours and stay checked.
-# The Cake selective-state CUDA/host trees are byte-faithful generated exports;
-# their SHA-256 digests are checked by the JIT manifest and must not be rewritten.
-exclude: ^(?:csrc/cake_selective_state_update/(?:cuda|host)/|flashinfer/moe_ep/kernel_src/(?:cutedsl_megamoe|sm90/pull_style_cutedsl_megakernel)/src/)
+# The selective-state CUDA/host trees and frozen KDA fallback sources are
+# byte-faithful generated exports; their SHA-256 digests are checked by the JIT
+# manifest and must not be rewritten.
+exclude: ^(?:csrc/cake_selective_state_update/(?:cuda|host)/|csrc/kda/training_fallback_pointer_sm_(?:100a|103a)\.cu|flashinfer/moe_ep/kernel_src/(?:cutedsl_megamoe|sm90/pull_style_cutedsl_megakernel)/src/)
 
 repos:
   # Standard hooks

--- a/benchmarks/bench_recurrent_kda_backward.py
+++ b/benchmarks/bench_recurrent_kda_backward.py
@@ -1,0 +1,218 @@
+# Copyright (c) 2026 by FlashInfer team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""CUPTI benchmark for the public recurrent-KDA backward API.
+
+The timed scope includes forward-tape reconstruction, all backward kernels,
+required workspace resets, and all eight gradients. Allocation, JIT loading,
+packed-offset validation, metadata construction, and TMA descriptor
+preparation happen during untimed warmup. Every measurement uses cold L2.
+"""
+
+import argparse
+import json
+import math
+from dataclasses import dataclass
+from pathlib import Path
+
+import numpy as np
+import torch
+
+from flashinfer.kda_backward import (
+    RecurrentKDABackwardWorkspace,
+    recurrent_kda_backward,
+)
+from flashinfer.testing import bench_gpu_time
+from flashinfer.utils import get_compute_capability
+
+
+@dataclass(frozen=True)
+class Case:
+    name: str
+    seq_lens: tuple[int, ...]
+    num_heads: int
+    packed: bool
+    seed: int
+
+
+PERFORMANCE_CASES = (
+    Case("fixed_t4096_h32", (4096,), 32, False, 409632),
+    Case("fixed_t8192_h96", (8192,), 96, False, 819296),
+    Case(
+        "packed_mixed_h96",
+        (1300, 547, 2048, 963, 271, 3063),
+        96,
+        True,
+        819206,
+    ),
+    Case("packed_1024x8_h96", (1024,) * 8, 96, True, 819208),
+)
+
+
+def _offsets(seq_lens: tuple[int, ...]) -> tuple[int, ...]:
+    result = [0]
+    for length in seq_lens:
+        result.append(result[-1] + length)
+    return tuple(result)
+
+
+def _make_inputs(case: Case) -> dict:
+    device = torch.device("cuda")
+    generator = torch.Generator(device=device).manual_seed(case.seed)
+    total_tokens = sum(case.seq_lens)
+    token_shape = (1, total_tokens, case.num_heads, 128)
+    state_shape = (len(case.seq_lens), case.num_heads, 128, 128)
+
+    def bf16(shape, multiplier=1.0):
+        return (
+            torch.randn(
+                shape,
+                generator=generator,
+                device=device,
+                dtype=torch.float32,
+            )
+            * multiplier
+        ).to(torch.bfloat16)
+
+    return {
+        "q": bf16(token_shape),
+        "k": bf16(token_shape),
+        "v": bf16(token_shape),
+        "g": bf16(token_shape, 0.1),
+        "beta": bf16(token_shape[:-1]),
+        "A_log": torch.log(
+            torch.rand(
+                (case.num_heads,),
+                generator=generator,
+                device=device,
+                dtype=torch.float32,
+            )
+            + 1.0
+        ),
+        "dt_bias": torch.randn(
+            (case.num_heads, 128),
+            generator=generator,
+            device=device,
+            dtype=torch.float32,
+        )
+        * 0.1,
+        "initial_state": torch.randn(
+            state_shape,
+            generator=generator,
+            device=device,
+            dtype=torch.float32,
+        )
+        * 0.02,
+        "do": bf16(token_shape, 0.1),
+        "dfinal_state": torch.randn(
+            state_shape,
+            generator=generator,
+            device=device,
+            dtype=torch.float32,
+        )
+        * 0.1,
+        "cu_seqlens": (
+            torch.tensor(_offsets(case.seq_lens), dtype=torch.int64, device=device)
+            if case.packed
+            else None
+        ),
+    }
+
+
+def _make_outputs(inputs: dict) -> tuple[torch.Tensor, ...]:
+    return (
+        torch.empty_like(inputs["q"]),
+        torch.empty_like(inputs["q"]),
+        torch.empty_like(inputs["q"]),
+        torch.empty_like(inputs["q"]),
+        torch.empty_like(inputs["beta"]),
+        torch.empty_like(inputs["A_log"]),
+        torch.empty_like(inputs["dt_bias"]),
+        torch.empty_like(inputs["initial_state"]),
+    )
+
+
+def _measure(case: Case, warmup_ms: int, bench_ms: int) -> dict:
+    inputs = _make_inputs(case)
+    outputs = _make_outputs(inputs)
+    workspace = RecurrentKDABackwardWorkspace("cuda")
+
+    def run():
+        return recurrent_kda_backward(
+            **inputs,
+            workspace=workspace,
+            out=outputs,
+            scale=1.0 / math.sqrt(128),
+            lower_bound=-5.0,
+        )
+
+    run()
+    torch.cuda.synchronize()
+    measurements = bench_gpu_time(
+        run,
+        enable_cupti=True,
+        cold_l2_cache=True,
+        use_cuda_graph=False,
+        dry_run_time_ms=warmup_ms,
+        repeat_time_ms=bench_ms,
+    )
+    samples_ms = [float(value) for value in measurements]
+    return {
+        "case": case.name,
+        "seq_lens": list(case.seq_lens),
+        "num_heads": case.num_heads,
+        "total_tokens": sum(case.seq_lens),
+        "median_ms": float(np.median(samples_ms)),
+        "min_ms": min(samples_ms),
+        "samples_ms": samples_ms,
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--case",
+        action="append",
+        choices=tuple(case.name for case in PERFORMANCE_CASES),
+        help="Run one case; repeat the option to select multiple cases.",
+    )
+    parser.add_argument("--warmup-ms", type=int, default=25)
+    parser.add_argument("--bench-ms", type=int, default=100)
+    parser.add_argument("--json", type=Path)
+    args = parser.parse_args()
+
+    if args.warmup_ms <= 0 or args.bench_ms <= 0:
+        parser.error("--warmup-ms and --bench-ms must be positive")
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA is required")
+    if get_compute_capability(torch.device("cuda")) not in {(10, 0), (10, 3)}:
+        raise RuntimeError("recurrent-KDA backward benchmark requires SM100a or SM103a")
+
+    selected = set(args.case or (case.name for case in PERFORMANCE_CASES))
+    results = [
+        _measure(case, args.warmup_ms, args.bench_ms)
+        for case in PERFORMANCE_CASES
+        if case.name in selected
+    ]
+    for result in results:
+        print(
+            f"{result['case']}: {result['median_ms']:.4f} ms "
+            f"(min {result['min_ms']:.4f} ms)"
+        )
+    if args.json is not None:
+        args.json.write_text(json.dumps(results, indent=2) + "\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/bench_recurrent_kda_training.py
+++ b/benchmarks/bench_recurrent_kda_training.py
@@ -1,0 +1,433 @@
+# Copyright (c) 2026 by FlashInfer team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+"""Cold-L2 CUPTI benchmark for the paired recurrent-KDA training API.
+
+The forward timing includes the exact checkpoint-producing route plus the
+full-FP32-state recurrence that produces the public final state. Its token
+output is private on C16 and public on C32; row-split directly produces both
+public outputs. The backward timing consumes the already-saved context and
+therefore excludes forward recomputation.
+"""
+
+import argparse
+import json
+import math
+import os
+import platform
+import subprocess
+import warnings
+from dataclasses import dataclass
+from importlib.metadata import version as distribution_version
+from pathlib import Path
+
+import numpy as np
+import torch
+
+from flashinfer.kda_training import (
+    recurrent_kda_training_backward,
+    recurrent_kda_training_forward,
+)
+from flashinfer.testing import bench_gpu_time
+from flashinfer.utils import get_compute_capability
+
+
+@dataclass(frozen=True)
+class _Shape:
+    seq_lens: tuple[int, ...]
+    num_qk_heads: int
+    num_v_heads: int
+    seed: int
+
+
+_PRIMARY_SHAPES = {
+    "packed_1024x8_h96": _Shape((1024,) * 8, 96, 96, 819208),
+    "portfolio_01_hq4_hv8_t32768": _Shape((3200,) * 9 + (3968,), 4, 8, 24001),
+    "portfolio_02_hq2_hv8_t18432": _Shape((2000,) * 8 + (2432,), 2, 8, 24002),
+    "portfolio_03_hq4_hv4_t32768": _Shape((2656,) * 11 + (3552,), 4, 4, 24003),
+    "portfolio_04_hq2_hv4_t18432": _Shape((1648,) * 10 + (1952,), 2, 4, 24004),
+    "portfolio_05_hq4_hv8_t18432": _Shape((2000,) * 8 + (2432,), 4, 8, 24005),
+    "portfolio_06_hq2_hv8_t32768": _Shape((3200,) * 9 + (3968,), 2, 8, 24006),
+    "portfolio_07_hq2_hv4_t18432": _Shape((2000,) * 8 + (2432,), 2, 4, 24007),
+    "portfolio_08_hq4_hv4_t18432": _Shape((1648,) * 10 + (1952,), 4, 4, 24008),
+    "portfolio_09_hq2_hv8_t32768": _Shape((2656,) * 11 + (3552,), 2, 8, 24009),
+    "portfolio_10_hq4_hv8_t18432": _Shape((1648,) * 10 + (1952,), 4, 8, 24010),
+    "portfolio_11_hq4_hv4_t32768": _Shape((3200,) * 9 + (3968,), 4, 4, 24011),
+    "portfolio_12_hq2_hv4_t32768": _Shape((2656,) * 11 + (3552,), 2, 4, 24012),
+    "portfolio_13_hq4_hv4_t18432": _Shape((2000,) * 8 + (2432,), 4, 4, 24013),
+    "portfolio_14_hq2_hv4_t32768": _Shape((3200,) * 9 + (3968,), 2, 4, 24014),
+    "portfolio_15_hq4_hv8_t32768": _Shape((2656,) * 11 + (3552,), 4, 8, 24015),
+    "portfolio_16_hq2_hv8_t18432": _Shape((1648,) * 10 + (1952,), 2, 8, 24016),
+}
+
+_FALLBACK_SHAPES = {
+    "fallback_grouped_c32_mixed": _Shape((17, 33, 65), 4, 8, 24005),
+    "fallback_row_split_mixed": _Shape((17, 33), 1, 1, 24018),
+    "fallback_high_head_c32_mixed": _Shape((17, 33), 16, 16, 24017),
+}
+
+_SHAPES = _PRIMARY_SHAPES | _FALLBACK_SHAPES
+_PRIMARY_SHAPE_NAMES = tuple(_PRIMARY_SHAPES)
+
+_FLA_BASELINE_COMMIT = "97bcb883dafd3fa5b859917184e4abfb1c4e8a71"
+
+
+def _require_timing_dependencies() -> tuple[str, str]:
+    try:
+        from cupti import cupti  # noqa: F401
+        import elftools  # noqa: F401
+    except Exception as error:
+        raise RuntimeError(
+            "the recurrent KDA training benchmark requires a working "
+            "cupti-python installation"
+        ) from error
+    cupti_version = distribution_version("cupti-python")
+    pyelftools_version = distribution_version("pyelftools")
+    if cupti_version != "13.3.1" or pyelftools_version != "0.32":
+        raise RuntimeError(
+            "the reportable benchmark requires cupti-python 13.3.1 and "
+            f"pyelftools 0.32, got {cupti_version} and {pyelftools_version}"
+        )
+    return cupti_version, pyelftools_version
+
+
+def _make_inputs(shape: _Shape, seed: int) -> dict[str, torch.Tensor]:
+    generator = torch.Generator(device="cuda").manual_seed(seed)
+    total_tokens = sum(shape.seq_lens)
+    qk_shape = (1, total_tokens, shape.num_qk_heads, 128)
+    value_shape = (1, total_tokens, shape.num_v_heads, 128)
+    state_shape = (len(shape.seq_lens), shape.num_v_heads, 128, 128)
+
+    def bf16(shape, multiplier=1.0):
+        return (torch.randn(shape, generator=generator, device="cuda") * multiplier).to(
+            torch.bfloat16
+        )
+
+    return {
+        "q": bf16(qk_shape),
+        "k": bf16(qk_shape),
+        "v": bf16(value_shape),
+        "g": bf16(value_shape, 0.1),
+        "beta": bf16(value_shape[:-1]),
+        "A_log": torch.log(
+            torch.rand((shape.num_v_heads,), generator=generator, device="cuda") + 1.0
+        ),
+        "dt_bias": torch.randn(
+            (shape.num_v_heads, 128), generator=generator, device="cuda"
+        )
+        * 0.1,
+        "initial_state": torch.randn(state_shape, generator=generator, device="cuda")
+        * 0.02,
+        "cu_seqlens": torch.tensor(
+            [0, *torch.tensor(shape.seq_lens).cumsum(0).tolist()],
+            dtype=torch.int64,
+            device="cuda",
+        ),
+        "do": bf16(value_shape, 0.1),
+        "dfinal_state": torch.randn(state_shape, generator=generator, device="cuda")
+        * 0.1,
+    }
+
+
+def _median_ms(fn, warmup_ms: int, bench_ms: int) -> tuple[float, list[float]]:
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "error",
+            message=r".*Falling back to CUDA events.*",
+            category=UserWarning,
+        )
+        measurements = bench_gpu_time(
+            fn,
+            enable_cupti=True,
+            cold_l2_cache=True,
+            use_cuda_graph=False,
+            dry_run_time_ms=warmup_ms,
+            repeat_time_ms=bench_ms,
+        )
+    samples = [float(value) for value in measurements]
+    return float(np.median(samples)), samples
+
+
+def _prepare_fla_full_dag(inputs):
+    os.environ["FLA_FLASH_KDA"] = "0"
+    import fla
+    from fla.ops.kda import chunk_kda
+
+    fla_commit = subprocess.run(
+        ["git", "-C", str(Path(fla.__file__).resolve().parent), "rev-parse", "HEAD"],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    if fla_commit != _FLA_BASELINE_COMMIT:
+        raise RuntimeError(
+            "the reportable benchmark requires pinned FLA commit "
+            f"{_FLA_BASELINE_COMMIT}, got {fla_commit}"
+        )
+    for diff_args in (("diff", "--quiet"), ("diff", "--cached", "--quiet")):
+        status = subprocess.run(
+            ["git", "-C", str(Path(fla.__file__).resolve().parent), *diff_args],
+            check=False,
+        ).returncode
+        if status != 0:
+            raise RuntimeError("the pinned FLA checkout has tracked modifications")
+
+    names = ("q", "k", "v", "g", "beta", "A_log", "dt_bias", "initial_state")
+    leaves = {
+        name: inputs[name].detach().clone().requires_grad_(True) for name in names
+    }
+    leaves["dt_bias"] = (
+        inputs["dt_bias"].detach().reshape(-1).clone().requires_grad_(True)
+    )
+    cu_seqlens_cpu = inputs["cu_seqlens"].detach().cpu()
+
+    def run_fla_full_dag():
+        output, final_state = chunk_kda(
+            leaves["q"],
+            leaves["k"],
+            leaves["v"],
+            leaves["g"],
+            leaves["beta"],
+            scale=1.0 / math.sqrt(128),
+            initial_state=leaves["initial_state"],
+            output_final_state=True,
+            use_qk_l2norm_in_kernel=True,
+            use_gate_in_kernel=True,
+            use_beta_sigmoid_in_kernel=True,
+            safe_gate=True,
+            lower_bound=-5.0,
+            state_v_first=True,
+            cu_seqlens=inputs["cu_seqlens"],
+            cu_seqlens_cpu=cu_seqlens_cpu,
+            A_log=leaves["A_log"],
+            dt_bias=leaves["dt_bias"],
+            chunk_size=32,
+        )
+        return torch.autograd.grad(
+            (output, final_state),
+            tuple(leaves[name] for name in names),
+            grad_outputs=(inputs["do"], inputs["dfinal_state"]),
+        )
+
+    return run_fla_full_dag, getattr(fla, "__version__", "unknown"), fla_commit
+
+
+def _benchmark_shape(
+    name: str,
+    shape: _Shape,
+    seed: int,
+    *,
+    warmup_ms: int,
+    bench_ms: int,
+    skip_fla: bool,
+    cupti_version: str,
+    pyelftools_version: str,
+) -> dict:
+    inputs = _make_inputs(shape, seed)
+    output = torch.empty_like(inputs["v"])
+    final_state = torch.empty_like(inputs["initial_state"])
+    output, final_state, context = recurrent_kda_training_forward(
+        inputs["q"],
+        inputs["k"],
+        inputs["v"],
+        inputs["g"],
+        inputs["beta"],
+        inputs["A_log"],
+        inputs["dt_bias"],
+        inputs["initial_state"],
+        inputs["cu_seqlens"],
+        out=output,
+        final_state_out=final_state,
+    )
+    gradients = (
+        torch.empty_like(inputs["q"]),
+        torch.empty_like(inputs["k"]),
+        torch.empty_like(inputs["v"]),
+        torch.empty_like(inputs["g"]),
+        torch.empty_like(inputs["beta"]),
+        torch.empty_like(inputs["A_log"]),
+        torch.empty_like(inputs["dt_bias"]),
+        torch.empty_like(inputs["initial_state"]),
+    )
+    recurrent_kda_training_backward(
+        context, inputs["do"], inputs["dfinal_state"], out=gradients
+    )
+    torch.cuda.synchronize()
+
+    def run_forward():
+        return recurrent_kda_training_forward(
+            inputs["q"],
+            inputs["k"],
+            inputs["v"],
+            inputs["g"],
+            inputs["beta"],
+            inputs["A_log"],
+            inputs["dt_bias"],
+            inputs["initial_state"],
+            inputs["cu_seqlens"],
+            out=output,
+            final_state_out=final_state,
+            context_out=context,
+        )
+
+    def run_backward():
+        return recurrent_kda_training_backward(
+            context, inputs["do"], inputs["dfinal_state"], out=gradients
+        )
+
+    def run_full_dag():
+        recurrent_kda_training_forward(
+            inputs["q"],
+            inputs["k"],
+            inputs["v"],
+            inputs["g"],
+            inputs["beta"],
+            inputs["A_log"],
+            inputs["dt_bias"],
+            inputs["initial_state"],
+            inputs["cu_seqlens"],
+            out=output,
+            final_state_out=final_state,
+            context_out=context,
+        )
+        return recurrent_kda_training_backward(
+            context, inputs["do"], inputs["dfinal_state"], out=gradients
+        )
+
+    forward_ms, forward_samples = _median_ms(run_forward, warmup_ms, bench_ms)
+    backward_ms, backward_samples = _median_ms(run_backward, warmup_ms, bench_ms)
+    full_dag_ms, full_dag_samples = _median_ms(run_full_dag, warmup_ms, bench_ms)
+    result = {
+        "shape": name,
+        "suite": "primary" if name in _PRIMARY_SHAPES else "fallback",
+        "seed": seed,
+        "seq_lens": list(shape.seq_lens),
+        "total_tokens": sum(shape.seq_lens),
+        "num_sequences": len(shape.seq_lens),
+        "num_qk_heads": shape.num_qk_heads,
+        "num_v_heads": shape.num_v_heads,
+        "route": context._route.tag,
+        "forward_median_ms": forward_ms,
+        "backward_median_ms": backward_ms,
+        "full_dag_median_ms": full_dag_ms,
+        "forward_samples_ms": forward_samples,
+        "backward_samples_ms": backward_samples,
+        "full_dag_samples_ms": full_dag_samples,
+        "forward_uses_private_fp32_final_state_recurrence": True,
+        "backward_recomputes_forward": False,
+        "cupti_python": cupti_version,
+        "pyelftools": pyelftools_version,
+        "timing_backend": "CUPTI activity",
+        "cold_l2_cache": True,
+        "cuda_graph": False,
+        "cuda_event_fallback": False,
+        "warmup_ms": warmup_ms,
+        "bench_ms": bench_ms,
+        "forward_sample_count": len(forward_samples),
+        "backward_sample_count": len(backward_samples),
+        "full_dag_sample_count": len(full_dag_samples),
+        "fla_baseline_skipped": skip_fla,
+        "reportable": not skip_fla,
+    }
+    if not skip_fla:
+        fla_full_dag, fla_version, fla_commit = _prepare_fla_full_dag(inputs)
+        fla_full_dag_ms, fla_full_dag_samples = _median_ms(
+            fla_full_dag, warmup_ms, bench_ms
+        )
+        delta_ms = full_dag_ms - fla_full_dag_ms
+        result.update(
+            {
+                "fla_full_dag_median_ms": fla_full_dag_ms,
+                "fla_full_dag_samples_ms": fla_full_dag_samples,
+                "full_dag_delta_ms_vs_fla": delta_ms,
+                "full_dag_delta_percent_vs_fla": 100.0 * delta_ms / fla_full_dag_ms,
+                "full_dag_speedup_vs_fla": fla_full_dag_ms / full_dag_ms,
+                "fla_chunk_size": 32,
+                "fla_flash_kda": os.environ["FLA_FLASH_KDA"],
+                "fla_version": fla_version,
+                "fla_commit": fla_commit,
+                "fla_full_dag_sample_count": len(fla_full_dag_samples),
+            }
+        )
+    return result
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--warmup-ms", type=int, default=25)
+    parser.add_argument("--bench-ms", type=int, default=100)
+    parser.add_argument(
+        "--seed", type=int, help="override the fixed seed for every selected shape"
+    )
+    parser.add_argument(
+        "--shape",
+        action="append",
+        choices=tuple(_SHAPES),
+        help="benchmark one named shape; repeat to select multiple shapes",
+    )
+    parser.add_argument(
+        "--all-shapes",
+        action="store_true",
+        help="benchmark the required H96 row and all 16 production portfolio rows",
+    )
+    parser.add_argument("--json", type=Path)
+    parser.add_argument(
+        "--skip-fla", action="store_true", help="skip the pinned FLA full-DAG peer"
+    )
+    args = parser.parse_args()
+    if args.all_shapes and args.shape:
+        parser.error("--all-shapes and --shape are mutually exclusive")
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA is required")
+    device = torch.device("cuda")
+    capability = get_compute_capability(device)
+    if capability not in {(10, 0), (10, 3)}:
+        raise RuntimeError("the training benchmark requires SM100a or SM103a")
+    cupti_version, pyelftools_version = _require_timing_dependencies()
+    names = (
+        list(_PRIMARY_SHAPE_NAMES)
+        if args.all_shapes
+        else (args.shape or ["packed_1024x8_h96"])
+    )
+    results = [
+        _benchmark_shape(
+            name,
+            _SHAPES[name],
+            _SHAPES[name].seed if args.seed is None else args.seed,
+            warmup_ms=args.warmup_ms,
+            bench_ms=args.bench_ms,
+            skip_fla=args.skip_fla,
+            cupti_version=cupti_version,
+            pyelftools_version=pyelftools_version,
+        )
+        for name in names
+    ]
+    report = {
+        "gpu": torch.cuda.get_device_name(device),
+        "compute_capability": list(capability),
+        "target": "sm_100a" if capability == (10, 0) else "sm_103a",
+        "host_architecture": platform.machine(),
+        "timing_backend": "CUPTI activity",
+        "cupti_python": cupti_version,
+        "pyelftools": pyelftools_version,
+        "cold_l2_cache": True,
+        "cuda_graph": False,
+        "cuda_event_fallback": False,
+        "warmup_ms": args.warmup_ms,
+        "bench_ms": args.bench_ms,
+        "fla_baseline_skipped": args.skip_fla,
+        "reportable": not args.skip_fla,
+        "results": results,
+    }
+    print(json.dumps(report, indent=2))
+    if args.json is not None:
+        args.json.write_text(json.dumps(report, indent=2) + "\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/csrc/kda/flashkda_backward.cu
+++ b/csrc/kda/flashkda_backward.cu
@@ -1,0 +1,8352 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Frozen generated FlashKDA backward bundle for exact SM103a.
+// Raw generated body SHA256: a2e40e9e246f1fe5d9fbef1cee469293936821cc3e5b15f315a554b01f55d5c5
+// Normalized generated SHA256: 456a7ffd07e71c4d33d0257ca64ed6993e4aa160b69a6b93f60535f5b4de4984
+// clang-format off
+// BEGIN FROZEN GENERATED BODY
+typedef unsigned char      uint8_t;
+typedef unsigned short     uint16_t;
+typedef unsigned int       uint32_t;
+typedef unsigned long long uint64_t;
+typedef signed int         int32_t;
+typedef short int          int16_t;
+struct __align__(128) FlashKDATensorMap { uint64_t opaque[16]; };
+template <int N>
+struct __align__(128) FlashKDATensorMapPack { FlashKDATensorMap maps[N]; };
+
+typedef struct __align__(64) { uint64_t opaque[16]; } CUtensorMap;
+
+#include <cuda_bf16.h>
+
+#include <math_constants.h>
+
+__device__ __forceinline__ uint32_t elect_sync() {
+    uint32_t pred = 0;
+    asm volatile(
+        "{\n\t"
+        ".reg .pred %%px;\n\t"
+        "elect.sync _|%%px, %1;\n\t"
+        "@%%px mov.s32 %0, 1;\n\t"
+        "}\n"
+        : "+r"(pred)
+        : "r"(0xFFFFFFFF));
+    return pred;
+}
+
+__device__ __forceinline__ void mbarrier_init(int mbar_addr, int count) {
+    asm volatile("mbarrier.init.shared::cta.b64 [%0], %1;"
+        :: "r"(mbar_addr), "r"(count));
+}
+
+__device__ __forceinline__ uint32_t mbarrier_try_wait(int mbar_addr, int phase) {
+    uint32_t token;
+    asm volatile(
+        "{\n\t"
+        ".reg .pred P1;\n\t"
+        "mbarrier.try_wait.parity.acquire.cta.shared::cta.b64"
+        " P1, [%1], %2;\n\t"
+        "selp.u32 %0, 1, 0, P1;\n\t"
+        "}\n"
+        : "=r"(token)
+        : "r"(mbar_addr), "r"(phase) : "memory");
+    return token;
+}
+
+__device__ __forceinline__ uint32_t mbarrier_try_wait_cluster(int mbar_addr, int phase) {
+    uint32_t token;
+    asm volatile(
+        "{\n\t"
+        ".reg .pred P1;\n\t"
+        "mbarrier.try_wait.parity.acquire.cluster.shared::cta.b64"
+        " P1, [%1], %2;\n\t"
+        "selp.u32 %0, 1, 0, P1;\n\t"
+        "}\n"
+        : "=r"(token)
+        : "r"(mbar_addr), "r"(phase) : "memory");
+    return token;
+}
+
+__device__ __forceinline__ void mbarrier_wait(int mbar_addr, int phase) {
+    uint32_t ticks = 0x989680;
+    asm volatile(
+        "{\n\t"
+        ".reg .pred P1;\n\t"
+        "LAB_WAIT:\n\t"
+        "mbarrier.try_wait.parity.acquire.cta.shared::cta.b64"
+        " P1, [%0], %1, %2;\n\t"
+        "@P1 bra.uni DONE;\n\t"
+        "bra.uni LAB_WAIT;\n\t"
+        "DONE:\n\t"
+        "}\n"
+        :: "r"(mbar_addr), "r"(phase), "r"(ticks) : "memory");
+}
+
+__device__ __forceinline__ void mbarrier_wait_cluster(int mbar_addr, int phase) {
+    uint32_t ticks = 0x989680;
+    asm volatile(
+        "{\n\t"
+        ".reg .pred P1;\n\t"
+        "LAB_WAIT_CLUSTER:\n\t"
+        "mbarrier.try_wait.parity.acquire.cluster.shared::cta.b64"
+        " P1, [%0], %1, %2;\n\t"
+        "@P1 bra.uni DONE_CLUSTER;\n\t"
+        "bra.uni LAB_WAIT_CLUSTER;\n\t"
+        "DONE_CLUSTER:\n\t"
+        "}\n"
+        :: "r"(mbar_addr), "r"(phase), "r"(ticks) : "memory");
+}
+
+__device__ __forceinline__ void mbarrier_wait_token(int mbar_addr, int phase, uint32_t token) {
+    if (token == 0) {
+        mbarrier_wait(mbar_addr, phase);
+    }
+}
+
+__device__ __forceinline__ void mbarrier_wait_token_cluster(int mbar_addr, int phase, uint32_t token) {
+    if (token == 0) {
+        mbarrier_wait_cluster(mbar_addr, phase);
+    }
+}
+
+__device__ __forceinline__ void tcgen05_mma_f16(
+    int taddr, uint64_t a_desc, uint64_t b_desc,
+    uint32_t i_desc, int enable_input_d) {
+    asm volatile(
+        "{\n\t"
+        ".reg .pred p;\n\t"
+        "setp.ne.b32 p, %4, 0;\n\t"
+        "tcgen05.mma.cta_group::1.kind::f16 [%0], %1, %2, %3, p;\n\t"
+        "}\n"
+        :: "r"(taddr), "l"(a_desc), "l"(b_desc),
+           "r"(i_desc), "r"(enable_input_d));
+}
+
+__device__ __forceinline__ uint64_t desc_encode(uint64_t x) {
+    return (x & 0x3FFFFULL) >> 4ULL;
+}
+
+__device__ __forceinline__ void mma_ts_step(
+    int taddr_out, int taddr_a, int b_lo, uint32_t b_dhi,
+    uint32_t i_desc, int enable_d) {
+    asm volatile(
+        "{\n\t"
+        ".reg .pred leader, p;\n\t"
+        ".reg .b32 dhi;\n\t"
+        ".reg .b64 db;\n\t"
+        "elect.sync _|leader, 0xFFFFFFFF;\n\t"
+        "setp.ne.b32 p, %5, 0;\n\t"
+        "mov.b32 dhi, %3;\n\t"
+        "mov.b64 db, {%2, dhi};\n\t"
+        "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [%1], db, %4, p;\n\t"
+        "}\n"
+        :: "r"(taddr_out), "r"(taddr_a), "r"(b_lo), "r"(b_dhi),
+           "r"(i_desc), "r"(enable_d));
+}
+
+__device__ __forceinline__ void elect_commit(int mbar_addr) {
+    asm volatile(
+        "{\n\t"
+        ".reg .pred leader;\n\t"
+        "elect.sync _|leader, 0xFFFFFFFF;\n\t"
+        "@leader tcgen05.commit.cta_group::1.mbarrier::arrive::one"
+        ".shared::cluster.b64 [%0];\n\t"
+        "}\n"
+        :: "r"(mbar_addr));
+}
+
+__device__ __forceinline__ void mbarrier_arrive(int mbar_addr) {
+    asm volatile(
+        "mbarrier.arrive.release.cta.shared::cta.b64 _, [%0];"
+        :: "r"(mbar_addr) : "memory");
+}
+
+__device__ __forceinline__ void mbarrier_arrive_expect_tx(int mbar_addr, uint32_t bytes) {
+    asm volatile(
+        "mbarrier.arrive.expect_tx.release.cta.shared::cta.b64 _, [%0], %1;"
+        :: "r"(mbar_addr), "r"(bytes) : "memory");
+}
+
+__device__ __forceinline__ void tmem_ld_x32(float* dst, int tmem_addr) {
+    asm volatile(
+        "tcgen05.ld.sync.aligned.32x32b.x32.b32"
+        " {%0, %1, %2, %3, %4, %5, %6, %7,"
+        "  %8, %9, %10, %11, %12, %13, %14, %15,"
+        "  %16, %17, %18, %19, %20, %21, %22, %23,"
+        "  %24, %25, %26, %27, %28, %29, %30, %31}, [%32];"
+        : "=f"(dst[0]),  "=f"(dst[1]),  "=f"(dst[2]),  "=f"(dst[3]),
+          "=f"(dst[4]),  "=f"(dst[5]),  "=f"(dst[6]),  "=f"(dst[7]),
+          "=f"(dst[8]),  "=f"(dst[9]),  "=f"(dst[10]), "=f"(dst[11]),
+          "=f"(dst[12]), "=f"(dst[13]), "=f"(dst[14]), "=f"(dst[15]),
+          "=f"(dst[16]), "=f"(dst[17]), "=f"(dst[18]), "=f"(dst[19]),
+          "=f"(dst[20]), "=f"(dst[21]), "=f"(dst[22]), "=f"(dst[23]),
+          "=f"(dst[24]), "=f"(dst[25]), "=f"(dst[26]), "=f"(dst[27]),
+          "=f"(dst[28]), "=f"(dst[29]), "=f"(dst[30]), "=f"(dst[31])
+        : "r"(tmem_addr));
+}
+
+__device__ __forceinline__ void tmem_ld_x16(float* dst, int tmem_addr) {
+    asm volatile(
+        "tcgen05.ld.sync.aligned.32x32b.x16.b32"
+        " {%0, %1, %2, %3, %4, %5, %6, %7,"
+        "  %8, %9, %10, %11, %12, %13, %14, %15}, [%16];"
+        : "=f"(dst[0]),  "=f"(dst[1]),  "=f"(dst[2]),  "=f"(dst[3]),
+          "=f"(dst[4]),  "=f"(dst[5]),  "=f"(dst[6]),  "=f"(dst[7]),
+          "=f"(dst[8]),  "=f"(dst[9]),  "=f"(dst[10]), "=f"(dst[11]),
+          "=f"(dst[12]), "=f"(dst[13]), "=f"(dst[14]), "=f"(dst[15])
+        : "r"(tmem_addr));
+}
+
+__device__ __forceinline__ void tmem_st_x32_f32(int tmem_addr, const float* src) {
+    asm volatile(
+        "tcgen05.st.sync.aligned.32x32b.x32.b32"
+        " [%0], {%1, %2, %3, %4, %5, %6, %7, %8,"
+        "  %9, %10, %11, %12, %13, %14, %15, %16,"
+        "  %17, %18, %19, %20, %21, %22, %23, %24,"
+        "  %25, %26, %27, %28, %29, %30, %31, %32};"
+        :: "r"(tmem_addr),
+           "f"(src[0]),  "f"(src[1]),  "f"(src[2]),  "f"(src[3]),
+           "f"(src[4]),  "f"(src[5]),  "f"(src[6]),  "f"(src[7]),
+           "f"(src[8]),  "f"(src[9]),  "f"(src[10]), "f"(src[11]),
+           "f"(src[12]), "f"(src[13]), "f"(src[14]), "f"(src[15]),
+           "f"(src[16]), "f"(src[17]), "f"(src[18]), "f"(src[19]),
+           "f"(src[20]), "f"(src[21]), "f"(src[22]), "f"(src[23]),
+           "f"(src[24]), "f"(src[25]), "f"(src[26]), "f"(src[27]),
+           "f"(src[28]), "f"(src[29]), "f"(src[30]), "f"(src[31]));
+}
+
+__device__ __forceinline__ float approx_exp2(float x) {
+    float y;
+    asm("ex2.approx.ftz.f32 %0, %1;" : "=f"(y) : "f"(x));
+    return y;
+}
+
+__device__ __forceinline__ void fma_f32x2_inplace(float2* a, float2 b, float2 c) {
+    unsigned long long r;
+    asm("fma.rn.ftz.f32x2 %0, %1, %2, %3;"
+        : "=l"(r)
+        : "l"(*(unsigned long long*)a), "l"(*(unsigned long long*)&b),
+          "l"(*(unsigned long long*)&c));
+    *(unsigned long long*)a = r;
+}
+
+__device__ __forceinline__ void mul_f32x2_inplace(float2* a, float2 b) {
+    asm("mul.rn.ftz.f32x2 %0, %0, %1;"
+        : "+l"(*(unsigned long long*)a) : "l"(*(unsigned long long*)&b));
+}
+
+__device__ __forceinline__ void add_f32x2_inplace(float2* a, float2 b) {
+    asm("add.rn.ftz.f32x2 %0, %0, %1;"
+        : "+l"(*(unsigned long long*)a) : "l"(*(unsigned long long*)&b));
+}
+
+__device__ __forceinline__ void sub_f32x2_inplace(float2* a, float2 b) {
+    asm("sub.rn.ftz.f32x2 %0, %0, %1;"
+        : "+l"(*(unsigned long long*)a) : "l"(*(unsigned long long*)&b));
+}
+
+__device__ __forceinline__ float2 add_f32x2(float2 a, float2 b) {
+    float2 r;
+    asm("add.rn.ftz.f32x2 %0, %1, %2;"
+        : "=l"(*(unsigned long long*)&r)
+        : "l"(*(unsigned long long*)&a), "l"(*(unsigned long long*)&b));
+    return r;
+}
+
+__device__ __forceinline__ float2 sub_f32x2(float2 a, float2 b) {
+    float2 r;
+    asm("sub.rn.ftz.f32x2 %0, %1, %2;"
+        : "=l"(*(unsigned long long*)&r)
+        : "l"(*(unsigned long long*)&a), "l"(*(unsigned long long*)&b));
+    return r;
+}
+
+__device__ __forceinline__ void fma_scale_x32(
+    float* sv, const float2* scale2, const float2* neg_max2)
+{
+    float2* sv_2 = reinterpret_cast<float2*>(sv);
+
+#pragma unroll
+
+for (int j = 0; j < 16; j++)
+        fma_f32x2_inplace(&sv_2[j], *scale2, *neg_max2);
+}
+
+__device__ __forceinline__ float2 fma_f32x2(float2 a, float2 b, float2 c) {
+    float2 r;
+    asm("fma.rn.ftz.f32x2 %0, %1, %2, %3;"
+        : "=l"(*(unsigned long long*)&r)
+        : "l"(*(unsigned long long*)&a), "l"(*(unsigned long long*)&b),
+          "l"(*(unsigned long long*)&c));
+    return r;
+}
+
+__device__ __forceinline__ float2 fma_sub_f32x2(float2 a, float2 b, float2 c) {
+    float2 r;
+    asm volatile("{\n\t"
+        ".reg .f32 _c0, _c1;\n\t"
+        ".reg .b64 _neg_c;\n\t"
+        "mov.b64 {_c0, _c1}, %3;\n\t"
+        "neg.f32 _c0, _c0;\n\t"
+        "neg.f32 _c1, _c1;\n\t"
+        "mov.b64 _neg_c, {_c0, _c1};\n\t"
+        "fma.rn.ftz.f32x2 %0, %1, %2, _neg_c;\n\t"
+        "}\n"
+        : "=l"(*(unsigned long long*)&r)
+        : "l"(*(unsigned long long*)&a), "l"(*(unsigned long long*)&b),
+          "l"(*(unsigned long long*)&c));
+    return r;
+}
+
+__device__ __forceinline__ float2 mul_f32x2(float2 a, float2 b) {
+    float2 r;
+    asm("mul.rn.ftz.f32x2 %0, %1, %2;"
+        : "=l"(*(unsigned long long*)&r)
+        : "l"(*(unsigned long long*)&a), "l"(*(unsigned long long*)&b));
+    return r;
+}
+
+// ex2_emulation_f32x2 defined in softmax_frag_exp2_cast helper (or standalone)
+
+__device__ __forceinline__ void elect_commit2(int mbar_addr0, int mbar_addr1) {
+    asm volatile(
+        "{\n\t"
+        ".reg .pred leader;\n\t"
+        "elect.sync _|leader, 0xFFFFFFFF;\n\t"
+        "@leader tcgen05.commit.cta_group::1.mbarrier::arrive::one"
+        ".shared::cluster.b64 [%0];\n\t"
+        "@leader tcgen05.commit.cta_group::1.mbarrier::arrive::one"
+        ".shared::cluster.b64 [%1];\n\t"
+        "}\n"
+        :: "r"(mbar_addr0), "r"(mbar_addr1) : "memory");
+}
+
+__device__ __forceinline__ void fence_async_shared() {
+    asm volatile("fence.proxy.async.shared::cta;" ::: "memory");
+}
+
+__device__ __forceinline__ uint64_t make_smem_desc(int addr) {
+    const int SBO = 1024;
+    return desc_encode(addr)
+         | (desc_encode(SBO) << 32ULL)
+         | (1ULL << 46ULL)
+         | (2ULL << 61ULL);
+}
+
+__device__ __forceinline__ void tma_3d_gmem2smem(
+    int dst, const void *tmap_ptr, int x, int y, int z, int mbar_addr) {
+    asm volatile(
+        "cp.async.bulk.tensor.3d.shared::cta.global"
+        ".mbarrier::complete_tx::bytes"
+        " [%0], [%1, {%2, %3, %4}], [%5];"
+        :: "r"(dst), "l"(tmap_ptr), "r"(x), "r"(y), "r"(z),
+           "r"(mbar_addr) : "memory");
+}
+
+__device__ __forceinline__ void tma_2d_gmem2smem(
+    int dst, const void *tmap_ptr, int x, int y, int mbar_addr) {
+    asm volatile(
+        "cp.async.bulk.tensor.2d.shared::cta.global"
+        ".mbarrier::complete_tx::bytes"
+        " [%0], [%1, {%2, %3}], [%4];"
+        :: "r"(dst), "l"(tmap_ptr), "r"(x), "r"(y),
+           "r"(mbar_addr) : "memory");
+}
+
+__device__ __forceinline__ void tma_4d_gmem2smem(
+    int dst, const void *tmap_ptr, int x, int y, int z, int w, int mbar_addr) {
+    asm volatile(
+        "cp.async.bulk.tensor.4d.shared::cta.global"
+        ".mbarrier::complete_tx::bytes"
+        " [%0], [%1, {%2, %3, %4, %5}], [%6];"
+        :: "r"(dst), "l"(tmap_ptr), "r"(x), "r"(y), "r"(z), "r"(w),
+           "r"(mbar_addr) : "memory");
+}
+
+__device__ __forceinline__ void tma_store_4d(
+    const void *tmap, int x, int y, int z, int w, unsigned smem_addr) {
+    asm volatile(
+        "cp.async.bulk.tensor.4d.global.shared::cta.tile.bulk_group"
+        " [%0, {%1, %2, %3, %4}], [%5];"
+        :: "l"(tmap), "r"(x), "r"(y), "r"(z), "r"(w), "r"(smem_addr) : "memory");
+}
+
+__device__ __forceinline__ void tcgen05_commit(int mbar_addr) {
+    asm volatile(
+        "tcgen05.commit.cta_group::1.mbarrier::arrive::one"
+        ".shared::cluster.b64 [%0];"
+        :: "r"(mbar_addr) : "memory");
+}
+
+__device__ __forceinline__ void tmem_st_x8_u32(int addr, const uint32_t* src) {
+    asm volatile(
+        "tcgen05.st.sync.aligned.32x32b.x8.b32"
+        " [%0], {%1,%2,%3,%4,%5,%6,%7,%8};"
+        :: "r"(addr),
+           "r"(src[0]), "r"(src[1]), "r"(src[2]), "r"(src[3]),
+           "r"(src[4]), "r"(src[5]), "r"(src[6]), "r"(src[7]));
+}
+
+__device__ __forceinline__ uint32_t make_warp_uniform(uint32_t val) {
+    uint32_t result;
+    asm volatile("shfl.sync.idx.b32 %0, %1, 0, 0x1f, 0xffffffff;"
+        : "=r"(result) : "r"(val));
+    return result;
+}
+
+__device__ __forceinline__ void tmem_ld_x16_wait(float* dst, int addr) {
+    tmem_ld_x16(dst, addr);
+    asm volatile("tcgen05.wait::ld.sync.aligned;");
+}
+
+__device__ __forceinline__ float approx_rcp(float x) {
+    float y;
+    asm("rcp.approx.ftz.f32 %0, %1;" : "=f"(y) : "f"(x));
+    return y;
+}
+
+__device__ __forceinline__ void tmem_ld_x8(float* dst, int tmem_addr) {
+    asm volatile(
+        "tcgen05.ld.sync.aligned.32x32b.x8.b32"
+        " {%0, %1, %2, %3, %4, %5, %6, %7}, [%8];"
+        : "=f"(dst[0]), "=f"(dst[1]), "=f"(dst[2]), "=f"(dst[3]),
+          "=f"(dst[4]), "=f"(dst[5]), "=f"(dst[6]), "=f"(dst[7])
+        : "r"(tmem_addr));
+}
+
+__device__ __forceinline__ void tmem_ld_x8_wait(float* dst, int addr) {
+    tmem_ld_x8(dst, addr);
+    asm volatile("tcgen05.wait::ld.sync.aligned;");
+}
+
+#define FLASHKDA_INF CUDART_INF_F
+#define NUM_MAIN_STAGES 1
+#define THREADS 32
+#define D 128
+
+extern "C" {
+
+__global__ __launch_bounds__(32) void
+kernel_flashkda_backward_preprocess(__nv_bfloat16* __restrict__ q, __nv_bfloat16* __restrict__ k, __nv_bfloat16* __restrict__ g, __nv_bfloat16* __restrict__ beta, float* __restrict__ A_log, float* __restrict__ dt_bias, float* __restrict__ q_norm, float* __restrict__ k_norm, float* __restrict__ decay, float* __restrict__ beta_active, int total_tokens, int num_heads, float lower_bound)
+{
+    const int tid = threadIdx.x;
+    const int warp = make_warp_uniform(tid / 32);
+    const int lane = tid % 32;
+
+
+    const int bid = blockIdx.x;
+    const int num_bids = gridDim.x;
+
+    // === Task calls (dependency order) ===
+    int token = blockIdx.x;
+    int head = blockIdx.y;
+    int elem = lane * 4;
+    long long base = ((long long)token * (long long)num_heads + (long long)head) * (long long)D;
+    float q_frag[4];
+    float k_frag[4];
+    float g_frag[4];
+    {
+        uint2 _vld_0;
+        _vld_0 = *reinterpret_cast<const uint2*>(q + base + (long long)elem);
+        uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0);
+        #pragma unroll
+        for (int _pair = 0; _pair < 2; _pair++) {
+            asm volatile(
+                "{\n\t"
+                "shl.b32 %0, %2, 16;\n\t"
+                "and.b32 %1, %2, 0xffff0000;\n\t"
+                "}\n"
+                : "=f"((&q_frag[0 + _pair * 2])[0]), "=f"((&q_frag[0 + _pair * 2])[1])
+                : "r"(_vpairs_0[_pair]));
+        }
+    }
+    {
+        uint2 _vld_1;
+        _vld_1 = *reinterpret_cast<const uint2*>(k + base + (long long)elem);
+        uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1);
+        #pragma unroll
+        for (int _pair = 0; _pair < 2; _pair++) {
+            asm volatile(
+                "{\n\t"
+                "shl.b32 %0, %2, 16;\n\t"
+                "and.b32 %1, %2, 0xffff0000;\n\t"
+                "}\n"
+                : "=f"((&k_frag[0 + _pair * 2])[0]), "=f"((&k_frag[0 + _pair * 2])[1])
+                : "r"(_vpairs_1[_pair]));
+        }
+    }
+    {
+        uint2 _vld_2;
+        _vld_2 = *reinterpret_cast<const uint2*>(g + base + (long long)elem);
+        uint32_t* _vpairs_2 = reinterpret_cast<uint32_t*>(&_vld_2);
+        #pragma unroll
+        for (int _pair = 0; _pair < 2; _pair++) {
+            asm volatile(
+                "{\n\t"
+                "shl.b32 %0, %2, 16;\n\t"
+                "and.b32 %1, %2, 0xffff0000;\n\t"
+                "}\n"
+                : "=f"((&g_frag[0 + _pair * 2])[0]), "=f"((&g_frag[0 + _pair * 2])[1])
+                : "r"(_vpairs_2[_pair]));
+        }
+    }
+    float q_sq = 0.0f;
+    float k_sq = 0.0f;
+    #pragma unroll
+    for (int i = 0; i < 4; i++) {
+        float _fma_0 = __fmaf_rn(q_frag[i], q_frag[i], q_sq);
+        q_sq = _fma_0;
+        float _fma_1 = __fmaf_rn(k_frag[i], k_frag[i], k_sq);
+        k_sq = _fma_1;
+    }
+    float _warp_reduce_0 = q_sq;
+    #pragma unroll
+    for (int offset = 16; offset > 0; offset >>= 1)
+        _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
+    q_sq = _warp_reduce_0;
+    float _warp_reduce_1 = k_sq;
+    #pragma unroll
+    for (int offset = 16; offset > 0; offset >>= 1)
+        _warp_reduce_1 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_1, offset);
+    k_sq = _warp_reduce_1;
+    float _rsqrt_0 = rsqrtf(q_sq + 1e-06f);
+    float q_inv = _rsqrt_0;
+    float _rsqrt_1 = rsqrtf(k_sq + 1e-06f);
+    float k_inv = _rsqrt_1;
+    float _expf_0 = __expf(A_log[head]);
+    float gate_a = _expf_0;
+    #pragma unroll
+    for (int i2 = 0; i2 < 4; i2++) {
+        int dim = elem + i2;
+        float biased = g_frag[i2] + dt_bias[head * D + dim];
+        float _expf_1 = __expf((-gate_a) * biased);
+        float gate_sigmoid = 1.0f / (1.0f + _expf_1);
+        q_norm[base + (long long)dim] = q_frag[i2] * q_inv;
+        k_norm[base + (long long)dim] = k_frag[i2] * k_inv;
+        float _expf_2 = __expf(lower_bound * gate_sigmoid);
+        decay[base + (long long)dim] = _expf_2;
+    }
+    if (lane == 0) {
+        long long beta_index = (long long)token * (long long)num_heads + (long long)head;
+        float beta_raw = (float)beta[beta_index];
+        float _expf_3 = __expf(-beta_raw);
+        beta_active[beta_index] = 1.0f / (1.0f + _expf_3);
+    }
+}
+
+} // extern "C"
+
+#undef D
+#undef FLASHKDA_INF
+#undef NUM_MAIN_STAGES
+#undef THREADS
+
+#define FLASHKDA_INF CUDART_INF_F
+#define NUM_MAIN_STAGES 1
+#define THREADS 32
+#define D 128
+#define V 128
+
+extern "C" {
+
+__global__ __launch_bounds__(32) void
+kernel_flashkda_backward_checkpoint(float* __restrict__ k_norm, float* __restrict__ decay, float* __restrict__ beta_active, __nv_bfloat16* __restrict__ v, float* __restrict__ initial_state, long long* __restrict__ cu_seqlens, float* __restrict__ checkpoint, int num_sequences, int num_heads)
+{
+    const int tid = threadIdx.x;
+    const int warp = make_warp_uniform(tid / 32);
+    const int lane = tid % 32;
+
+
+    const int bid = blockIdx.x;
+    const int num_bids = gridDim.x;
+
+    // === Task calls (dependency order) ===
+    int work = blockIdx.x;
+    int rows_per_sequence = num_heads * V;
+    int sequence = work / rows_per_sequence;
+    int remainder = work - sequence * rows_per_sequence;
+    int head = remainder / V;
+    int value_row = remainder - head * V;
+    int elem = lane * 4;
+    long long bos = cu_seqlens[sequence];
+    long long eos = cu_seqlens[sequence + 1];
+    long long state_base = (((long long)sequence * (long long)num_heads + (long long)head) * (long long)V + (long long)value_row) * (long long)D;
+    float state[4];
+    {
+        float4 _v4 = *reinterpret_cast<const float4*>(initial_state + state_base + (long long)elem);
+        state[0 + 0] = _v4.x;
+        state[0 + 1] = _v4.y;
+        state[0 + 2] = _v4.z;
+        state[0 + 3] = _v4.w;
+    }
+    #pragma unroll 1
+    for (long long token = bos; token < eos; token++) {
+        long long token_base = (token * (long long)num_heads + (long long)head) * (long long)D;
+        float k_frag[4];
+        float d_frag[4];
+        {
+            float4 _v4 = *reinterpret_cast<const float4*>(k_norm + token_base + (long long)elem);
+            k_frag[0 + 0] = _v4.x;
+            k_frag[0 + 1] = _v4.y;
+            k_frag[0 + 2] = _v4.z;
+            k_frag[0 + 3] = _v4.w;
+        }
+        {
+            float4 _v4 = *reinterpret_cast<const float4*>(decay + token_base + (long long)elem);
+            d_frag[0 + 0] = _v4.x;
+            d_frag[0 + 1] = _v4.y;
+            d_frag[0 + 2] = _v4.z;
+            d_frag[0 + 3] = _v4.w;
+        }
+        float pred = 0.0f;
+        float decayed[4];
+        #pragma unroll
+        for (int i = 0; i < 4; i++) {
+            decayed[i] = state[i] * d_frag[i];
+            float _fma_0 = __fmaf_rn(k_frag[i], decayed[i], pred);
+            pred = _fma_0;
+        }
+        float _warp_reduce_0 = pred;
+        #pragma unroll
+        for (int offset = 16; offset > 0; offset >>= 1)
+            _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
+        pred = _warp_reduce_0;
+        long long beta_index = token * (long long)num_heads + (long long)head;
+        long long value_index = token_base + (long long)value_row;
+        float residual = beta_active[beta_index] * ((float)v[value_index] - pred);
+        long long checkpoint_base = ((token * (long long)num_heads + (long long)head) * (long long)V + (long long)value_row) * (long long)D;
+        #pragma unroll
+        for (int i2 = 0; i2 < 4; i2++) {
+            float _fma_1 = __fmaf_rn(residual, k_frag[i2], decayed[i2]);
+            state[i2] = _fma_1;
+            checkpoint[checkpoint_base + (long long)elem + (long long)i2] = state[i2];
+        }
+    }
+}
+
+} // extern "C"
+
+#undef D
+#undef FLASHKDA_INF
+#undef NUM_MAIN_STAGES
+#undef THREADS
+#undef V
+
+#define FLASHKDA_INF CUDART_INF_F
+#define NUM_MAIN_STAGES 1
+#define THREADS 32
+#define D 128
+#define V 128
+
+extern "C" {
+
+__global__ __launch_bounds__(32) void
+kernel_flashkda_backward_reverse_rows(float* __restrict__ q_norm, float* __restrict__ k_norm, float* __restrict__ decay, float* __restrict__ beta_active, __nv_bfloat16* __restrict__ v, __nv_bfloat16* __restrict__ do_, float* __restrict__ initial_state, float* __restrict__ dfinal_state, long long* __restrict__ cu_seqlens, float* __restrict__ checkpoint, float* __restrict__ dq_normalized, float* __restrict__ dk_normalized, float* __restrict__ dlog_decay, float* __restrict__ dbeta_active, __nv_bfloat16* __restrict__ dv, float* __restrict__ dinitial_state, int num_sequences, int num_heads, float scale)
+{
+    const int tid = threadIdx.x;
+    const int warp = make_warp_uniform(tid / 32);
+    const int lane = tid % 32;
+
+
+    const int bid = blockIdx.x;
+    const int num_bids = gridDim.x;
+
+    // === Task calls (dependency order) ===
+    int work = blockIdx.x;
+    int rows_per_sequence = num_heads * V;
+    int sequence = work / rows_per_sequence;
+    int remainder = work - sequence * rows_per_sequence;
+    int head = remainder / V;
+    int value_row = remainder - head * V;
+    int elem = lane * 4;
+    long long bos = cu_seqlens[sequence];
+    long long eos = cu_seqlens[sequence + 1];
+    long long sequence_length = eos - bos;
+    long long state_base = (((long long)sequence * (long long)num_heads + (long long)head) * (long long)V + (long long)value_row) * (long long)D;
+    float dstate[4];
+    {
+        float4 _v4 = *reinterpret_cast<const float4*>(dfinal_state + state_base + (long long)elem);
+        dstate[0 + 0] = _v4.x;
+        dstate[0 + 1] = _v4.y;
+        dstate[0 + 2] = _v4.z;
+        dstate[0 + 3] = _v4.w;
+    }
+    #pragma unroll 1
+    for (long long reverse_step = 0; reverse_step < sequence_length; reverse_step++) {
+        long long token = eos - 1 - reverse_step;
+        long long token_base = (token * (long long)num_heads + (long long)head) * (long long)D;
+        long long checkpoint_base = ((token * (long long)num_heads + (long long)head) * (long long)V + (long long)value_row) * (long long)D;
+        long long previous_base = checkpoint_base - (long long)num_heads * (long long)V * (long long)D;
+        if (token == bos) {
+            previous_base = state_base;
+        }
+        float q_frag[4];
+        float k_frag[4];
+        float d_frag[4];
+        float state_now[4];
+        float state_prev[4];
+        {
+            float4 _v4 = *reinterpret_cast<const float4*>(q_norm + token_base + (long long)elem);
+            q_frag[0 + 0] = _v4.x;
+            q_frag[0 + 1] = _v4.y;
+            q_frag[0 + 2] = _v4.z;
+            q_frag[0 + 3] = _v4.w;
+        }
+        {
+            float4 _v4 = *reinterpret_cast<const float4*>(k_norm + token_base + (long long)elem);
+            k_frag[0 + 0] = _v4.x;
+            k_frag[0 + 1] = _v4.y;
+            k_frag[0 + 2] = _v4.z;
+            k_frag[0 + 3] = _v4.w;
+        }
+        {
+            float4 _v4 = *reinterpret_cast<const float4*>(decay + token_base + (long long)elem);
+            d_frag[0 + 0] = _v4.x;
+            d_frag[0 + 1] = _v4.y;
+            d_frag[0 + 2] = _v4.z;
+            d_frag[0 + 3] = _v4.w;
+        }
+        {
+            float4 _v4 = *reinterpret_cast<const float4*>(checkpoint + checkpoint_base + (long long)elem);
+            state_now[0 + 0] = _v4.x;
+            state_now[0 + 1] = _v4.y;
+            state_now[0 + 2] = _v4.z;
+            state_now[0 + 3] = _v4.w;
+        }
+        if (token == bos) {
+            {
+                float4 _v4 = *reinterpret_cast<const float4*>(initial_state + previous_base + (long long)elem);
+                state_prev[0 + 0] = _v4.x;
+                state_prev[0 + 1] = _v4.y;
+                state_prev[0 + 2] = _v4.z;
+                state_prev[0 + 3] = _v4.w;
+            }
+        } else {
+            {
+                float4 _v4 = *reinterpret_cast<const float4*>(checkpoint + previous_base + (long long)elem);
+                state_prev[0 + 0] = _v4.x;
+                state_prev[0 + 1] = _v4.y;
+                state_prev[0 + 2] = _v4.z;
+                state_prev[0 + 3] = _v4.w;
+            }
+        }
+        long long value_index = token_base + (long long)value_row;
+        float output_adjoint = (float)do_[value_index];
+        float pred = 0.0f;
+        #pragma unroll
+        for (int i = 0; i < 4; i++) {
+            float _fma_0 = __fmaf_rn(scale * output_adjoint, q_frag[i], dstate[i]);
+            dstate[i] = _fma_0;
+            float _fma_1 = __fmaf_rn(k_frag[i], state_prev[i] * d_frag[i], pred);
+            pred = _fma_1;
+        }
+        float _warp_reduce_0 = pred;
+        #pragma unroll
+        for (int offset = 16; offset > 0; offset >>= 1)
+            _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
+        pred = _warp_reduce_0;
+        float dr = 0.0f;
+        #pragma unroll
+        for (int i2 = 0; i2 < 4; i2++) {
+            float _fma_2 = __fmaf_rn(dstate[i2], k_frag[i2], dr);
+            dr = _fma_2;
+        }
+        float _warp_reduce_1 = dr;
+        #pragma unroll
+        for (int offset = 16; offset > 0; offset >>= 1)
+            _warp_reduce_1 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_1, offset);
+        dr = _warp_reduce_1;
+        long long beta_index = token * (long long)num_heads + (long long)head;
+        float beta_value = beta_active[beta_index];
+        float value_raw = (float)v[value_index];
+        float residual = beta_value * (value_raw - pred);
+        float dpred = (-dr) * beta_value;
+        #pragma unroll
+        for (int i3 = 0; i3 < 4; i3++) {
+            long long dim_index = token_base + (long long)elem + (long long)i3;
+            float decayed_state = state_prev[i3] * d_frag[i3];
+            float _fma_3 = __fmaf_rn(dpred, k_frag[i3], dstate[i3]);
+            float d_p = _fma_3;
+            float _fma_4 = __fmaf_rn(dpred, decayed_state, residual * dstate[i3]);
+            float d_k = _fma_4;
+            atomicAdd(&dq_normalized[dim_index], scale * output_adjoint * state_now[i3]);
+            atomicAdd(&dk_normalized[dim_index], d_k);
+            atomicAdd(&dlog_decay[dim_index], d_p * state_prev[i3] * d_frag[i3]);
+            dstate[i3] = d_p * d_frag[i3];
+        }
+        if (lane == 0) {
+            atomicAdd(&dbeta_active[beta_index], dr * (value_raw - pred));
+            __nv_bfloat16 _cvt_bf16_0 = __float2bfloat16(dr * beta_value);
+            dv[value_index] = _cvt_bf16_0;
+        }
+    }
+    #pragma unroll
+    for (int i4 = 0; i4 < 4; i4++) {
+        dinitial_state[state_base + (long long)elem + (long long)i4] = dstate[i4];
+    }
+}
+
+} // extern "C"
+
+#undef D
+#undef FLASHKDA_INF
+#undef NUM_MAIN_STAGES
+#undef THREADS
+#undef V
+
+#define FLASHKDA_INF CUDART_INF_F
+#define NUM_MAIN_STAGES 1
+#define THREADS 32
+#define D 128
+
+extern "C" {
+
+__global__ __launch_bounds__(32) void
+kernel_flashkda_backward_finalize_tokens(__nv_bfloat16* __restrict__ q, __nv_bfloat16* __restrict__ k, __nv_bfloat16* __restrict__ g, float* __restrict__ beta_active, float* __restrict__ A_log, float* __restrict__ dt_bias, float* __restrict__ q_norm, float* __restrict__ k_norm, float* __restrict__ dq_normalized, float* __restrict__ dk_normalized, float* __restrict__ gate_common, float* __restrict__ dbeta_active, __nv_bfloat16* __restrict__ dq, __nv_bfloat16* __restrict__ dk, __nv_bfloat16* __restrict__ dg, __nv_bfloat16* __restrict__ dbeta, int num_heads, float lower_bound)
+{
+    const int tid = threadIdx.x;
+    const int warp = make_warp_uniform(tid / 32);
+    const int lane = tid % 32;
+
+
+    const int bid = blockIdx.x;
+    const int num_bids = gridDim.x;
+
+    // === Task calls (dependency order) ===
+    int token = blockIdx.x;
+    int head = blockIdx.y;
+    int elem = lane * 4;
+    long long base = ((long long)token * (long long)num_heads + (long long)head) * (long long)D;
+    float q_raw[4];
+    float k_raw[4];
+    float g_raw[4];
+    float qn[4];
+    float kn[4];
+    float dqn[4];
+    float dkn[4];
+    float dlog[4];
+    {
+        uint2 _vld_0;
+        _vld_0 = *reinterpret_cast<const uint2*>(q + base + (long long)elem);
+        uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0);
+        #pragma unroll
+        for (int _pair = 0; _pair < 2; _pair++) {
+            asm volatile(
+                "{\n\t"
+                "shl.b32 %0, %2, 16;\n\t"
+                "and.b32 %1, %2, 0xffff0000;\n\t"
+                "}\n"
+                : "=f"((&q_raw[0 + _pair * 2])[0]), "=f"((&q_raw[0 + _pair * 2])[1])
+                : "r"(_vpairs_0[_pair]));
+        }
+    }
+    {
+        uint2 _vld_1;
+        _vld_1 = *reinterpret_cast<const uint2*>(k + base + (long long)elem);
+        uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1);
+        #pragma unroll
+        for (int _pair = 0; _pair < 2; _pair++) {
+            asm volatile(
+                "{\n\t"
+                "shl.b32 %0, %2, 16;\n\t"
+                "and.b32 %1, %2, 0xffff0000;\n\t"
+                "}\n"
+                : "=f"((&k_raw[0 + _pair * 2])[0]), "=f"((&k_raw[0 + _pair * 2])[1])
+                : "r"(_vpairs_1[_pair]));
+        }
+    }
+    {
+        uint2 _vld_2;
+        _vld_2 = *reinterpret_cast<const uint2*>(g + base + (long long)elem);
+        uint32_t* _vpairs_2 = reinterpret_cast<uint32_t*>(&_vld_2);
+        #pragma unroll
+        for (int _pair = 0; _pair < 2; _pair++) {
+            asm volatile(
+                "{\n\t"
+                "shl.b32 %0, %2, 16;\n\t"
+                "and.b32 %1, %2, 0xffff0000;\n\t"
+                "}\n"
+                : "=f"((&g_raw[0 + _pair * 2])[0]), "=f"((&g_raw[0 + _pair * 2])[1])
+                : "r"(_vpairs_2[_pair]));
+        }
+    }
+    {
+        float4 _v4 = *reinterpret_cast<const float4*>(q_norm + base + (long long)elem);
+        qn[0 + 0] = _v4.x;
+        qn[0 + 1] = _v4.y;
+        qn[0 + 2] = _v4.z;
+        qn[0 + 3] = _v4.w;
+    }
+    {
+        float4 _v4 = *reinterpret_cast<const float4*>(k_norm + base + (long long)elem);
+        kn[0 + 0] = _v4.x;
+        kn[0 + 1] = _v4.y;
+        kn[0 + 2] = _v4.z;
+        kn[0 + 3] = _v4.w;
+    }
+    {
+        float4 _v4 = *reinterpret_cast<const float4*>(dq_normalized + base + (long long)elem);
+        dqn[0 + 0] = _v4.x;
+        dqn[0 + 1] = _v4.y;
+        dqn[0 + 2] = _v4.z;
+        dqn[0 + 3] = _v4.w;
+    }
+    {
+        float4 _v4 = *reinterpret_cast<const float4*>(dk_normalized + base + (long long)elem);
+        dkn[0 + 0] = _v4.x;
+        dkn[0 + 1] = _v4.y;
+        dkn[0 + 2] = _v4.z;
+        dkn[0 + 3] = _v4.w;
+    }
+    {
+        float4 _v4 = *reinterpret_cast<const float4*>(gate_common + base + (long long)elem);
+        dlog[0 + 0] = _v4.x;
+        dlog[0 + 1] = _v4.y;
+        dlog[0 + 2] = _v4.z;
+        dlog[0 + 3] = _v4.w;
+    }
+    float q_sq = 0.0f;
+    float k_sq = 0.0f;
+    float q_dot = 0.0f;
+    float k_dot = 0.0f;
+    #pragma unroll
+    for (int i = 0; i < 4; i++) {
+        float _fma_0 = __fmaf_rn(q_raw[i], q_raw[i], q_sq);
+        q_sq = _fma_0;
+        float _fma_1 = __fmaf_rn(k_raw[i], k_raw[i], k_sq);
+        k_sq = _fma_1;
+        float _fma_2 = __fmaf_rn(dqn[i], qn[i], q_dot);
+        q_dot = _fma_2;
+        float _fma_3 = __fmaf_rn(dkn[i], kn[i], k_dot);
+        k_dot = _fma_3;
+    }
+    float _warp_reduce_0 = q_sq;
+    #pragma unroll
+    for (int offset = 16; offset > 0; offset >>= 1)
+        _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
+    q_sq = _warp_reduce_0;
+    float _warp_reduce_1 = k_sq;
+    #pragma unroll
+    for (int offset = 16; offset > 0; offset >>= 1)
+        _warp_reduce_1 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_1, offset);
+    k_sq = _warp_reduce_1;
+    float _warp_reduce_2 = q_dot;
+    #pragma unroll
+    for (int offset = 16; offset > 0; offset >>= 1)
+        _warp_reduce_2 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_2, offset);
+    q_dot = _warp_reduce_2;
+    float _warp_reduce_3 = k_dot;
+    #pragma unroll
+    for (int offset = 16; offset > 0; offset >>= 1)
+        _warp_reduce_3 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_3, offset);
+    k_dot = _warp_reduce_3;
+    float _rsqrt_0 = rsqrtf(q_sq + 1e-06f);
+    float q_inv = _rsqrt_0;
+    float _rsqrt_1 = rsqrtf(k_sq + 1e-06f);
+    float k_inv = _rsqrt_1;
+    float _expf_0 = __expf(A_log[head]);
+    float gate_a = _expf_0;
+    #pragma unroll
+    for (int i2 = 0; i2 < 4; i2++) {
+        int dim = elem + i2;
+        long long index = base + (long long)dim;
+        float biased = g_raw[i2] + dt_bias[head * D + dim];
+        float _expf_1 = __expf((-gate_a) * biased);
+        float gate_sigmoid = 1.0f / (1.0f + _expf_1);
+        float common = dlog[i2] * lower_bound * gate_sigmoid * (1.0f - gate_sigmoid) * gate_a;
+        __nv_bfloat16 _cvt_bf16_0 = __float2bfloat16(q_inv * (dqn[i2] - qn[i2] * q_dot));
+        dq[index] = _cvt_bf16_0;
+        __nv_bfloat16 _cvt_bf16_1 = __float2bfloat16(k_inv * (dkn[i2] - kn[i2] * k_dot));
+        dk[index] = _cvt_bf16_1;
+        __nv_bfloat16 _cvt_bf16_2 = __float2bfloat16(common);
+        dg[index] = _cvt_bf16_2;
+        gate_common[index] = common;
+    }
+    if (lane == 0) {
+        long long beta_index = (long long)token * (long long)num_heads + (long long)head;
+        float beta_sigmoid = beta_active[beta_index];
+        __nv_bfloat16 _cvt_bf16_3 = __float2bfloat16(dbeta_active[beta_index] * beta_sigmoid * (1.0f - beta_sigmoid));
+        dbeta[beta_index] = _cvt_bf16_3;
+    }
+}
+
+} // extern "C"
+
+#undef D
+#undef FLASHKDA_INF
+#undef NUM_MAIN_STAGES
+#undef THREADS
+
+#define FLASHKDA_INF CUDART_INF_F
+#define NUM_MAIN_STAGES 1
+#define SMEM_SMEM_DA_OFF 0
+#define SMEM_SMEM_DA_STAGE_BYTES 16
+#define SMEM_SMEM_DA_STRIDE 16
+#define SMEM_TOTAL 128
+#define THREADS 128
+#define D 128
+
+extern "C" {
+
+__global__ __launch_bounds__(128) void
+kernel_flashkda_backward_gate_reduce_split(float* __restrict__ gate_common, __nv_bfloat16* __restrict__ g, float* __restrict__ dt_bias, float* __restrict__ dA_log, float* __restrict__ ddt_bias, int total_tokens, int num_heads, int tokens_per_split)
+{
+    const int tid = threadIdx.x;
+    const int warp = make_warp_uniform(tid / 32);
+    const int lane = tid % 32;
+
+    extern __shared__ __align__(1024) char smem_raw[];
+    int smem;
+    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+
+    const int bid = blockIdx.x;
+    const int num_bids = gridDim.x;
+
+    // Kernel setup ops
+    float* smem_dA = reinterpret_cast<float*>(smem_raw + 0);
+    const int smem_dA_addr = smem + 0;
+
+    // === Task calls (dependency order) ===
+    int head = blockIdx.x;
+    int split = blockIdx.y;
+    int dim = tid;
+    int token_start = split * tokens_per_split;
+    int token_end = token_start + tokens_per_split;
+    if (token_end > total_tokens) {
+        token_end = total_tokens;
+    }
+    float bias = dt_bias[head * D + dim];
+    float ddt_sum = 0.0f;
+    float dA_sum = 0.0f;
+    #pragma unroll 4
+    for (int token = token_start; token < token_end; token++) {
+        long long index = ((long long)token * (long long)num_heads + (long long)head) * (long long)D + (long long)dim;
+        float common = gate_common[index];
+        ddt_sum += common;
+        float _fma_0 = __fmaf_rn(common, (float)g[index] + bias, dA_sum);
+        dA_sum = _fma_0;
+    }
+    atomicAdd(&ddt_bias[head * D + dim], ddt_sum);
+    float _warp_reduce_0 = dA_sum;
+    #pragma unroll
+    for (int offset = 16; offset > 0; offset >>= 1)
+        _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
+    dA_sum = _warp_reduce_0;
+    if (lane == 0) {
+        smem_dA[warp] = dA_sum;
+    }
+    __syncthreads();
+    if (warp == 0) {
+        if (elect_sync()) {
+            atomicAdd(&dA_log[head], smem_dA[0] + smem_dA[1] + smem_dA[2] + smem_dA[3]);
+        }
+    }
+}
+
+} // extern "C"
+
+#undef D
+#undef FLASHKDA_INF
+#undef NUM_MAIN_STAGES
+#undef SMEM_SMEM_DA_OFF
+#undef SMEM_SMEM_DA_STAGE_BYTES
+#undef SMEM_SMEM_DA_STRIDE
+#undef SMEM_TOTAL
+#undef THREADS
+#undef smem_dA_addr
+
+#define FLASHKDA_INF CUDART_INF_F
+#define TMEM_NCOLS 256
+#define TMEM_TMEM_STATE_OFFSET 64
+#define TMEM_TMEM_STATE_INP_OFFSET 0
+#define TMEM_TMEM_U_ACC_OFFSET 224
+#define TMEM_TMEM_U2_INP_OFFSET 224
+#define TMEM_TMEM_U2_ACC_OFFSET 0
+#define TMEM_TMEM_OUT_OFFSET 192
+#define TMEM_TMEM_STATE_OUT_OFFSET 64
+#define NUM_CHUNK_PIPE_STAGES 5
+#define SMEM_SMEM_QD_OFF 1024
+#define SMEM_SMEM_QD_STAGE_BYTES 8192
+#define SMEM_SMEM_QD_STRIDE 41984
+#define SMEM_SMEM_G_RAW_OFF 1024
+#define SMEM_SMEM_G_RAW_STAGE_BYTES 8192
+#define SMEM_SMEM_G_RAW_STRIDE 41984
+#define SMEM_SMEM_G_RAW_ALL_OFF 1024
+#define SMEM_SMEM_G_RAW_ALL_STAGE_BYTES 176128
+#define SMEM_SMEM_G_RAW_ALL_STRIDE 176128
+#define SMEM_SMEM_KD_OFF 9216
+#define SMEM_SMEM_KD_STAGE_BYTES 8192
+#define SMEM_SMEM_KD_STRIDE 41984
+#define SMEM_SMEM_Q_RAW_PREFETCH_OFF 17408
+#define SMEM_SMEM_Q_RAW_PREFETCH_STAGE_BYTES 8192
+#define SMEM_SMEM_Q_RAW_PREFETCH_STRIDE 41984
+#define SMEM_SMEM_FINAL_TRANS_OFF 17408
+#define SMEM_SMEM_FINAL_TRANS_STAGE_BYTES 12288
+#define SMEM_SMEM_FINAL_TRANS_STRIDE 41984
+#define SMEM_SMEM_KR_TRANS_OFF 17408
+#define SMEM_SMEM_KR_TRANS_STAGE_BYTES 8192
+#define SMEM_SMEM_KR_TRANS_STRIDE 41984
+#define SMEM_SMEM_MQK_TRANS_OFF 25600
+#define SMEM_SMEM_MQK_TRANS_STAGE_BYTES 2048
+#define SMEM_SMEM_MQK_TRANS_STRIDE 41984
+#define SMEM_SMEM_INV_OFF 29696
+#define SMEM_SMEM_INV_STAGE_BYTES 2048
+#define SMEM_SMEM_INV_STRIDE 41984
+#define SMEM_SMEM_V_OFF 32384
+#define SMEM_SMEM_V_STAGE_BYTES 8192
+#define SMEM_SMEM_V_STRIDE 41984
+#define SMEM_SMEM_KI_OFF 17408
+#define SMEM_SMEM_KI_STAGE_BYTES 8192
+#define SMEM_SMEM_KI_STRIDE 41984
+#define SMEM_SMEM_GATE_OFF 25600
+#define SMEM_SMEM_GATE_STAGE_BYTES 16384
+#define SMEM_SMEM_GATE_STRIDE 41984
+#define SMEM_SMEM_BETA_RAW_OFF 41984
+#define SMEM_SMEM_BETA_RAW_STAGE_BYTES 512
+#define SMEM_SMEM_BETA_RAW_STRIDE 41984
+#define SMEM_SMEM_INV_WORK_OFF 32384
+#define SMEM_SMEM_INV_WORK_STAGE_BYTES 4096
+#define SMEM_SMEM_INV_WORK_STRIDE 41984
+#define SMEM_SMEM_OUT_OFF 210944
+#define SMEM_SMEM_OUT_STAGE_BYTES 8192
+#define SMEM_SMEM_OUT_STRIDE 8192
+#define SMEM_SMEM_RESTORE_FACTOR_ALL_OFF 41984
+#define SMEM_SMEM_RESTORE_FACTOR_ALL_STAGE_BYTES 168452
+#define SMEM_SMEM_RESTORE_FACTOR_ALL_STRIDE 168452
+#define SMEM_SMEM_GT_PREFIX_ALL_OFF 41472
+#define SMEM_SMEM_GT_PREFIX_ALL_STAGE_BYTES 168448
+#define SMEM_SMEM_GT_PREFIX_ALL_STRIDE 168448
+#define SMEM_SMEM_GT_ALL_OFF 31744
+#define SMEM_SMEM_GT_ALL_STAGE_BYTES 168448
+#define SMEM_SMEM_GT_ALL_STRIDE 168448
+#define SMEM_SMEM_PREP_BETA_ALL_OFF 42500
+#define SMEM_SMEM_PREP_BETA_ALL_STAGE_BYTES 168064
+#define SMEM_SMEM_PREP_BETA_ALL_STRIDE 168064
+#define SMEM_SMEM_GATE_RATE_ALL_OFF 42628
+#define SMEM_SMEM_GATE_RATE_ALL_STAGE_BYTES 167940
+#define SMEM_SMEM_GATE_RATE_ALL_STRIDE 167940
+#define SMEM_SMEM_V_ALL_OFF 32384
+#define SMEM_SMEM_V_ALL_STAGE_BYTES 176128
+#define SMEM_SMEM_V_ALL_STRIDE 176128
+#define SMEM_SMEM_GATE_ALL_OFF 25600
+#define SMEM_SMEM_GATE_ALL_STAGE_BYTES 184320
+#define SMEM_SMEM_GATE_ALL_STRIDE 184320
+#define SMEM_SMEM_STATE_CHECKPOINT_NEEDED_OFF 227328
+#define SMEM_SMEM_STATE_CHECKPOINT_NEEDED_STAGE_BYTES 80
+#define SMEM_SMEM_STATE_CHECKPOINT_NEEDED_STRIDE 80
+#define SMEM_TOTAL 227456
+#define THREADS 1024
+#define STORE_BACKWARD_TAPE 1
+#define STORE_E_TAPE 0
+
+extern "C" {
+
+__global__ __launch_bounds__(1024) void
+kernel_flashkda_bf16_fused_m128(__nv_bfloat16* __restrict__ q, FlashKDATensorMap const* q_tma, __nv_bfloat16* __restrict__ k, FlashKDATensorMap const* k_tma, __nv_bfloat16* __restrict__ v, FlashKDATensorMap const* v_tma, __nv_bfloat16* __restrict__ g, FlashKDATensorMap const* g_tma, __nv_bfloat16* __restrict__ beta, FlashKDATensorMap const* beta_tma, float* __restrict__ A_log, float* __restrict__ dt_bias, long long* __restrict__ cu_seqlens, int* __restrict__ seq_order, __nv_bfloat16* __restrict__ initial_state, __nv_bfloat16* __restrict__ out, FlashKDATensorMap const* out_tma, __nv_bfloat16* __restrict__ final_state, int num_heads, int use_initial_state, int store_final_state, float scale, float lower_bound, unsigned long long state_indices_addr, unsigned long long state_checkpoints_addr, unsigned long long checkpoint_cu_starts_addr, long long beta_token_stride, long long state_slot_stride, int use_state_indices, int checkpoint_every_n_tokens, long long* __restrict__ cu_chunk_offsets, __nv_bfloat16* __restrict__ chunk_state, unsigned int* __restrict__ state_checkpoint_needed, __nv_bfloat16* __restrict__ tape_qd, __nv_bfloat16* __restrict__ tape_kd, __nv_bfloat16* __restrict__ tape_kr, __nv_bfloat16* __restrict__ tape_j, float* __restrict__ tape_restore_factor, __nv_bfloat16* __restrict__ tape_e, __nv_bfloat16* __restrict__ tape_x, __nv_bfloat16* __restrict__ tape_r, float* __restrict__ norm_inv_out, __nv_bfloat16* __restrict__ decay_out, float* __restrict__ beta_active_out, float* __restrict__ initial_state_f32, unsigned int* __restrict__ zero_workspace, int zero_words)
+{
+    const int tid = threadIdx.x;
+    const int warp = make_warp_uniform(tid / 32);
+    const int lane = tid % 32;
+
+    extern __shared__ __align__(1024) char smem_raw[];
+    int smem;
+    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+
+    const int bid = blockIdx.x;
+    const int num_bids = gridDim.x;
+    if (tid == 0) {
+        asm volatile("fence.proxy.tensormap::generic.acquire.sys [%0], 128;" :: "l"((uint64_t)(q_tma)) : "memory");
+        asm volatile("fence.proxy.tensormap::generic.acquire.sys [%0], 128;" :: "l"((uint64_t)(k_tma)) : "memory");
+        asm volatile("fence.proxy.tensormap::generic.acquire.sys [%0], 128;" :: "l"((uint64_t)(v_tma)) : "memory");
+        asm volatile("fence.proxy.tensormap::generic.acquire.sys [%0], 128;" :: "l"((uint64_t)(g_tma)) : "memory");
+        asm volatile("fence.proxy.tensormap::generic.acquire.sys [%0], 128;" :: "l"((uint64_t)(beta_tma)) : "memory");
+        asm volatile("fence.proxy.tensormap::generic.acquire.sys [%0], 128;" :: "l"((uint64_t)(out_tma)) : "memory");
+    }
+    __syncthreads();
+
+
+    // Kernel setup ops
+    __nv_bfloat16* smem_qd = reinterpret_cast<__nv_bfloat16*>(smem_raw + 1024);
+    const int smem_qd_addr = smem + 1024;
+    __nv_bfloat16* smem_g_raw = reinterpret_cast<__nv_bfloat16*>(smem_raw + 1024);
+    const int smem_g_raw_addr = smem + 1024;
+    __nv_bfloat16* smem_g_raw_all = reinterpret_cast<__nv_bfloat16*>(smem_raw + 1024);
+    const int smem_g_raw_all_addr = smem + 1024;
+    __nv_bfloat16* smem_kd = reinterpret_cast<__nv_bfloat16*>(smem_raw + 9216);
+    const int smem_kd_addr = smem + 9216;
+    __nv_bfloat16* smem_q_raw_prefetch = reinterpret_cast<__nv_bfloat16*>(smem_raw + 17408);
+    const int smem_q_raw_prefetch_addr = smem + 17408;
+    __nv_bfloat16* smem_final_trans = reinterpret_cast<__nv_bfloat16*>(smem_raw + 17408);
+    const int smem_final_trans_addr = smem + 17408;
+    __nv_bfloat16* smem_kr_trans = reinterpret_cast<__nv_bfloat16*>(smem_raw + 17408);
+    const int smem_kr_trans_addr = smem + 17408;
+    __nv_bfloat16* smem_mqk_trans = reinterpret_cast<__nv_bfloat16*>(smem_raw + 25600);
+    const int smem_mqk_trans_addr = smem + 25600;
+    __nv_bfloat16* smem_inv = reinterpret_cast<__nv_bfloat16*>(smem_raw + 29696);
+    const int smem_inv_addr = smem + 29696;
+    __nv_bfloat16* smem_v = reinterpret_cast<__nv_bfloat16*>(smem_raw + 32384);
+    const int smem_v_addr = smem + 32384;
+    __nv_bfloat16* smem_ki = reinterpret_cast<__nv_bfloat16*>(smem_raw + 17408);
+    const int smem_ki_addr = smem + 17408;
+    float* smem_gate = reinterpret_cast<float*>(smem_raw + 25600);
+    const int smem_gate_addr = smem + 25600;
+    __nv_bfloat16* smem_beta_raw = reinterpret_cast<__nv_bfloat16*>(smem_raw + 41984);
+    const int smem_beta_raw_addr = smem + 41984;
+    __nv_bfloat16* smem_inv_work = reinterpret_cast<__nv_bfloat16*>(smem_raw + 32384);
+    const int smem_inv_work_addr = smem + 32384;
+    __nv_bfloat16* smem_out = reinterpret_cast<__nv_bfloat16*>(smem_raw + 210944);
+    const int smem_out_addr = smem + 210944;
+    float* smem_restore_factor_all = reinterpret_cast<float*>(smem_raw + 41984);
+    const int smem_restore_factor_all_addr = smem + 41984;
+    float* smem_gt_prefix_all = reinterpret_cast<float*>(smem_raw + 41472);
+    const int smem_gt_prefix_all_addr = smem + 41472;
+    float* smem_gt_all = reinterpret_cast<float*>(smem_raw + 31744);
+    const int smem_gt_all_addr = smem + 31744;
+    float* smem_prep_beta_all = reinterpret_cast<float*>(smem_raw + 42500);
+    const int smem_prep_beta_all_addr = smem + 42500;
+    float* smem_gate_rate_all = reinterpret_cast<float*>(smem_raw + 42628);
+    const int smem_gate_rate_all_addr = smem + 42628;
+    __nv_bfloat16* smem_v_all = reinterpret_cast<__nv_bfloat16*>(smem_raw + 32384);
+    const int smem_v_all_addr = smem + 32384;
+    float* smem_gate_all = reinterpret_cast<float*>(smem_raw + 25600);
+    const int smem_gate_all_addr = smem + 25600;
+    unsigned int* smem_state_checkpoint_needed = reinterpret_cast<unsigned int*>(smem_raw + 227328);
+    const int smem_state_checkpoint_needed_addr = smem + 227328;
+
+    // Mbarrier init (19 groups, 87 barriers)
+    // Mbarriers at smem_raw[0..696)
+
+    if (warp == 0) {
+        uint32_t leader = elect_sync();
+        if (leader) {
+            // --- pipeline 'chunk_pipe' ---
+            // qk_full: 5 barriers, init_count=1
+            mbarrier_init(smem + 0, 1);
+            mbarrier_init(smem + 8, 1);
+            mbarrier_init(smem + 16, 1);
+            mbarrier_init(smem + 24, 1);
+            mbarrier_init(smem + 32, 1);
+            // tape_ready: 5 barriers, init_count=1
+            mbarrier_init(smem + 40, 1);
+            mbarrier_init(smem + 48, 1);
+            mbarrier_init(smem + 56, 1);
+            mbarrier_init(smem + 64, 1);
+            mbarrier_init(smem + 72, 1);
+            // tape_free: 5 barriers, init_count=2
+            mbarrier_init(smem + 80, 2);
+            mbarrier_init(smem + 88, 2);
+            mbarrier_init(smem + 96, 2);
+            mbarrier_init(smem + 104, 2);
+            mbarrier_init(smem + 112, 2);
+            // gate_raw_full: 5 barriers, init_count=1
+            mbarrier_init(smem + 120, 1);
+            mbarrier_init(smem + 128, 1);
+            mbarrier_init(smem + 136, 1);
+            mbarrier_init(smem + 144, 1);
+            mbarrier_init(smem + 152, 1);
+            // qk_raw_full: 5 barriers, init_count=1
+            mbarrier_init(smem + 160, 1);
+            mbarrier_init(smem + 168, 1);
+            mbarrier_init(smem + 176, 1);
+            mbarrier_init(smem + 184, 1);
+            mbarrier_init(smem + 192, 1);
+            // v_full: 5 barriers, init_count=1
+            mbarrier_init(smem + 200, 1);
+            mbarrier_init(smem + 208, 1);
+            mbarrier_init(smem + 216, 1);
+            mbarrier_init(smem + 224, 1);
+            mbarrier_init(smem + 232, 1);
+            // v_free: 5 barriers, init_count=4
+            mbarrier_init(smem + 240, 4);
+            mbarrier_init(smem + 248, 4);
+            mbarrier_init(smem + 256, 4);
+            mbarrier_init(smem + 264, 4);
+            mbarrier_init(smem + 272, 4);
+            // smem_free: 5 barriers, init_count=1
+            mbarrier_init(smem + 280, 1);
+            mbarrier_init(smem + 288, 1);
+            mbarrier_init(smem + 296, 1);
+            mbarrier_init(smem + 304, 1);
+            mbarrier_init(smem + 312, 1);
+            // raw_inputs_free: 5 barriers, init_count=1
+            mbarrier_init(smem + 320, 1);
+            mbarrier_init(smem + 328, 1);
+            mbarrier_init(smem + 336, 1);
+            mbarrier_init(smem + 344, 1);
+            mbarrier_init(smem + 352, 1);
+            // state_inp_ready: 5 barriers, init_count=4
+            mbarrier_init(smem + 360, 4);
+            mbarrier_init(smem + 368, 4);
+            mbarrier_init(smem + 376, 4);
+            mbarrier_init(smem + 384, 4);
+            mbarrier_init(smem + 392, 4);
+            // old_out_ready: 5 barriers, init_count=1
+            mbarrier_init(smem + 400, 1);
+            mbarrier_init(smem + 408, 1);
+            mbarrier_init(smem + 416, 1);
+            mbarrier_init(smem + 424, 1);
+            mbarrier_init(smem + 432, 1);
+            // u_inp_ready: 5 barriers, init_count=4
+            mbarrier_init(smem + 440, 4);
+            mbarrier_init(smem + 448, 4);
+            mbarrier_init(smem + 456, 4);
+            mbarrier_init(smem + 464, 4);
+            mbarrier_init(smem + 472, 4);
+            // u2_acc_ready: 5 barriers, init_count=1
+            mbarrier_init(smem + 480, 1);
+            mbarrier_init(smem + 488, 1);
+            mbarrier_init(smem + 496, 1);
+            mbarrier_init(smem + 504, 1);
+            mbarrier_init(smem + 512, 1);
+            // u2_inp_ready: 5 barriers, init_count=4
+            mbarrier_init(smem + 520, 4);
+            mbarrier_init(smem + 528, 4);
+            mbarrier_init(smem + 536, 4);
+            mbarrier_init(smem + 544, 4);
+            mbarrier_init(smem + 552, 4);
+            // final_ready: 5 barriers, init_count=1
+            mbarrier_init(smem + 560, 1);
+            mbarrier_init(smem + 568, 1);
+            mbarrier_init(smem + 576, 1);
+            mbarrier_init(smem + 584, 1);
+            mbarrier_init(smem + 592, 1);
+            // out_empty: 1 barriers, init_count=1
+            mbarrier_init(smem + 600, 1);
+            // tmem_dealloc_ready: 1 barriers, init_count=2
+            mbarrier_init(smem + 608, 2);
+            // prep_diag_ready: 5 barriers, init_count=2
+            mbarrier_init(smem + 616, 2);
+            mbarrier_init(smem + 624, 2);
+            mbarrier_init(smem + 632, 2);
+            mbarrier_init(smem + 640, 2);
+            mbarrier_init(smem + 648, 2);
+            // prep_inv16_ready: 5 barriers, init_count=2
+            mbarrier_init(smem + 656, 2);
+            mbarrier_init(smem + 664, 2);
+            mbarrier_init(smem + 672, 2);
+            mbarrier_init(smem + 680, 2);
+            mbarrier_init(smem + 688, 2);
+            asm volatile("fence.mbarrier_init.release.cluster;");
+        }
+    }
+
+    __syncwarp();
+
+    // TMEM alloc (256 columns, 256 used)
+    volatile int* tmem_addr_storage = (volatile int*)(smem_raw + 696);
+    if (warp == 0) {
+        int _tmem_hold = smem + 696;
+        asm volatile("tcgen05.alloc.cta_group::1.sync.aligned.shared::cta.b32 [%0], %1;" :: "r"(_tmem_hold), "r"(256) : "memory");
+        asm volatile("tcgen05.relinquish_alloc_permit.cta_group::1.sync.aligned;");
+    }
+
+    __syncthreads();
+    asm volatile("tcgen05.fence::after_thread_sync;");
+
+    const int mbar_base = smem;
+    #define qk_full_addr (mbar_base + 0)
+    #define tape_ready_addr (mbar_base + 40)
+    #define tape_free_addr (mbar_base + 80)
+    #define gate_raw_full_addr (mbar_base + 120)
+    #define qk_raw_full_addr (mbar_base + 160)
+    #define v_full_addr (mbar_base + 200)
+    #define v_free_addr (mbar_base + 240)
+    #define smem_free_addr (mbar_base + 280)
+    #define raw_inputs_free_addr (mbar_base + 320)
+    #define state_inp_ready_addr (mbar_base + 360)
+    #define old_out_ready_addr (mbar_base + 400)
+    #define u_inp_ready_addr (mbar_base + 440)
+    #define u2_acc_ready_addr (mbar_base + 480)
+    #define u2_inp_ready_addr (mbar_base + 520)
+    #define final_ready_addr (mbar_base + 560)
+    #define out_empty_addr (mbar_base + 600)
+    #define tmem_dealloc_ready_addr (mbar_base + 608)
+    #define prep_diag_ready_addr (mbar_base + 616)
+    #define prep_inv16_ready_addr (mbar_base + 656)
+    const int taddr = tmem_addr_storage[0];
+
+    // Kernel post-init ops
+    const int tmem_tmem_state = taddr + 64;
+    const int tmem_tmem_state_inp = taddr;
+    const int tmem_tmem_u_acc = taddr + 224;
+    const int tmem_tmem_u2_inp = taddr + 224;
+    const int tmem_tmem_u2_acc = taddr;
+    const int tmem_tmem_out = taddr + 192;
+    const int tmem_tmem_state_out = taddr + 64;
+
+    // ---- Register redistribution for WGs split across roles ----
+    // Dec phase frees registers before any WG attempts inc.
+    if (warp >= 8 && warp <= 11) {
+        asm volatile("setmaxnreg.dec.sync.aligned.u32 48;");
+    }
+
+    // ---- Role: compute ----
+    if (warp <= 3) {
+        asm volatile("setmaxnreg.inc.sync.aligned.u32 168;");
+        { // compute_main
+            int task_idx = blockIdx.x;
+            int seq_idx = seq_order[task_idx / num_heads];
+            int head_idx = task_idx % num_heads;
+            long long bos = cu_seqlens[seq_idx];
+            long long eos = cu_seqlens[seq_idx + 1];
+            int seq_len = (int)(eos - bos);
+            int num_chunks = (seq_len + 32 - 1) / 32;
+            int num_sequences = num_bids / num_heads;
+            long long total_chunks = cu_chunk_offsets[num_sequences];
+            long long fallback_head = total_chunks * (long long)num_heads + (long long)seq_idx * (long long)num_heads + (long long)head_idx;
+            int warp_in_wg = warp % 4;
+            const int tmem_row_base = warp_in_wg * 32 << 16;
+            int state_row = warp_in_wg * 32 + lane;
+            int warp_id_in_role = (warp - 0);
+            int compute_local_warp = warp_id_in_role;
+            long long state_base = (((long long)seq_idx * (long long)num_heads + (long long)head_idx) * 128 + (long long)state_row) * 128;
+            #pragma unroll
+            for (int state_col_block = 0; state_col_block < 4; state_col_block++) {
+                float state_frag[32];
+                state_frag[0] = 0.0f;
+                state_frag[1] = 0.0f;
+                state_frag[2] = 0.0f;
+                state_frag[3] = 0.0f;
+                state_frag[4] = 0.0f;
+                state_frag[5] = 0.0f;
+                state_frag[6] = 0.0f;
+                state_frag[7] = 0.0f;
+                state_frag[8] = 0.0f;
+                state_frag[9] = 0.0f;
+                state_frag[10] = 0.0f;
+                state_frag[11] = 0.0f;
+                state_frag[12] = 0.0f;
+                state_frag[13] = 0.0f;
+                state_frag[14] = 0.0f;
+                state_frag[15] = 0.0f;
+                state_frag[16] = 0.0f;
+                state_frag[17] = 0.0f;
+                state_frag[18] = 0.0f;
+                state_frag[19] = 0.0f;
+                state_frag[20] = 0.0f;
+                state_frag[21] = 0.0f;
+                state_frag[22] = 0.0f;
+                state_frag[23] = 0.0f;
+                state_frag[24] = 0.0f;
+                state_frag[25] = 0.0f;
+                state_frag[26] = 0.0f;
+                state_frag[27] = 0.0f;
+                state_frag[28] = 0.0f;
+                state_frag[29] = 0.0f;
+                state_frag[30] = 0.0f;
+                state_frag[31] = 0.0f;
+                if (use_initial_state != 0) {
+                    {
+                        float initial_values[8];
+                        #pragma unroll
+                        for (int initial_quarter = 0; initial_quarter < 4; initial_quarter++) {
+                            {
+                                unsigned _ldv8_0_0;
+                                unsigned _ldv8_0_1;
+                                unsigned _ldv8_0_2;
+                                unsigned _ldv8_0_3;
+                                unsigned _ldv8_0_4;
+                                unsigned _ldv8_0_5;
+                                unsigned _ldv8_0_6;
+                                unsigned _ldv8_0_7;
+                                asm volatile(
+                                    "ld.global.v8.b32 {%0, %1, %2, %3, %4, %5, %6, %7}, [%8];"
+                                    : "=r"(_ldv8_0_0), "=r"(_ldv8_0_1), "=r"(_ldv8_0_2), "=r"(_ldv8_0_3), "=r"(_ldv8_0_4), "=r"(_ldv8_0_5), "=r"(_ldv8_0_6), "=r"(_ldv8_0_7) : "l"((const void*)(initial_state_f32 + (state_base + (long long)(state_col_block * 32) + (long long)(initial_quarter * 8)))) : "memory");
+                                initial_values[0 + 0] = __uint_as_float(_ldv8_0_0);
+                                initial_values[0 + 1] = __uint_as_float(_ldv8_0_1);
+                                initial_values[0 + 2] = __uint_as_float(_ldv8_0_2);
+                                initial_values[0 + 3] = __uint_as_float(_ldv8_0_3);
+                                initial_values[0 + 4] = __uint_as_float(_ldv8_0_4);
+                                initial_values[0 + 5] = __uint_as_float(_ldv8_0_5);
+                                initial_values[0 + 6] = __uint_as_float(_ldv8_0_6);
+                                initial_values[0 + 7] = __uint_as_float(_ldv8_0_7);
+                            }
+                            #pragma unroll
+                            for (int initial_item = 0; initial_item < 8; initial_item++) {
+                                __nv_bfloat16 _cvt_bf16_0 = __float2bfloat16(initial_values[initial_item]);
+                                float _cvt_f32_2 = __bfloat162float(_cvt_bf16_0);
+                                state_frag[initial_quarter * 8 + initial_item] = _cvt_f32_2;
+                            }
+                        }
+                    }
+                }
+                tmem_st_x32_f32(taddr + 64 + (unsigned int)tmem_row_base + (unsigned int)(state_col_block * 32), state_frag);
+            }
+            asm volatile("tcgen05.wait::st.sync.aligned;" ::: "memory");
+            {
+                if (compute_local_warp == 0) {
+                    if (elect_sync()) {
+                        long long first_chunk_head = cu_chunk_offsets[seq_idx] * (long long)num_heads + (long long)head_idx;
+                        state_checkpoint_needed[first_chunk_head] = 0;
+                        state_checkpoint_needed[fallback_head] = 0;
+                    }
+                }
+            }
+            unsigned int compute_stage = 0;
+            unsigned int _phase_qk_full = 0;
+            unsigned int _phase_v_full = 0;
+            unsigned int _phase_old_out_ready = 0;
+            unsigned int _phase_u2_acc_ready = 0;
+            unsigned int _phase_final_ready = 0;
+            #pragma unroll 1
+            for (int chunk_idx = 0; chunk_idx < num_chunks; chunk_idx++) {
+                mbarrier_wait(qk_full_addr + (compute_stage) * 8, _phase_qk_full);
+                #pragma unroll 1
+                for (int state_col_block_1 = 0; state_col_block_1 < 4; state_col_block_1++) {
+                    int state_addr = taddr + 64 + (unsigned int)tmem_row_base + (unsigned int)(state_col_block_1 * 32);
+                    float _tmem_load_1[32];
+                    tmem_ld_x32(&_tmem_load_1[0], state_addr);
+                    asm volatile("tcgen05.wait::ld.sync.aligned;");
+                    uint32_t _tmem_load_1_bf16[16];
+                    #pragma unroll
+                    for (int _lp = 0; _lp < 16; _lp++) {
+                        __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(_tmem_load_1[_lp*2 + 0], _tmem_load_1[_lp*2+1 + 0]));
+                        _tmem_load_1_bf16[_lp] = *(uint32_t*)&_bf2;
+                    }
+                    asm volatile(
+                        "tcgen05.st.sync.aligned.32x32b.x16.b32"
+                        " [%0], {%1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15, %16};"
+                        :: "r"(taddr + (unsigned int)tmem_row_base + (unsigned int)(state_col_block_1 * 16)), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_1_bf16[0])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_1_bf16[1])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_1_bf16[2])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_1_bf16[3])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_1_bf16[4])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_1_bf16[5])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_1_bf16[6])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_1_bf16[7])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_1_bf16[8])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_1_bf16[9])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_1_bf16[10])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_1_bf16[11])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_1_bf16[12])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_1_bf16[13])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_1_bf16[14])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_1_bf16[15]))
+                        : "memory");
+                    float state_scale[16];
+                    #pragma unroll
+                    for (int state_half = 0; state_half < 2; state_half++) {
+                        #pragma unroll
+                        for (int state_col = 0; state_col < 16; state_col++) {
+                            state_scale[state_col] = smem_gt_all[compute_stage * 10496 + (unsigned int)(state_col_block_1 * 32) + (unsigned int)(state_half * 16) + (unsigned int)state_col];
+                        }
+                        #pragma unroll
+                        for (int _ls = 0; _ls < 8; _ls++)
+                            mul_f32x2_inplace(&reinterpret_cast<float2*>((_tmem_load_1 + state_half * 16))[_ls], reinterpret_cast<const float2*>(state_scale)[_ls]);
+                    }
+                    tmem_st_x32_f32(state_addr, _tmem_load_1);
+                }
+                asm volatile("tcgen05.wait::st.sync.aligned;" ::: "memory");
+                if (elect_sync()) {
+                    mbarrier_arrive(state_inp_ready_addr + (compute_stage) * 8);
+                }
+                mbarrier_wait(v_full_addr + (compute_stage) * 8, _phase_v_full);
+                mbarrier_wait(old_out_ready_addr + (compute_stage) * 8, _phase_old_out_ready);
+                float _tmem_load_2[32];
+                tmem_ld_x32(&_tmem_load_2[0], taddr + 224 + (unsigned int)tmem_row_base);
+                asm volatile("tcgen05.wait::ld.sync.aligned;");
+                long long chunk_global_e = cu_chunk_offsets[seq_idx] + (long long)chunk_idx;
+                long long tape_ex_base = ((chunk_global_e * (long long)num_heads + (long long)head_idx) * 128 + (long long)state_row) * 32;
+                #pragma unroll
+                for (int residual_half = 0; residual_half < 2; residual_half++) {
+                    float residual_v[16];
+                    float residual_beta[16];
+                    #pragma unroll
+                    for (int residual_col = 0; residual_col < 16; residual_col++) {
+                        int token_col = residual_half * 16 + residual_col;
+                        __nv_bfloat16 v_value = smem_v_all[compute_stage * 20992 + (unsigned int)(token_col * 128) + (unsigned int)state_row];
+                        float _cvt_f32_3 = __bfloat162float(v_value);
+                        residual_v[residual_col] = _cvt_f32_3;
+                        residual_beta[residual_col] = smem_prep_beta_all[compute_stage * 10496 + (unsigned int)token_col];
+                    }
+                    #pragma unroll
+                    for (int _ls = 0; _ls < 8; _ls++)
+                        sub_f32x2_inplace(&reinterpret_cast<float2*>(residual_v)[_ls], reinterpret_cast<const float2*>((_tmem_load_2 + residual_half * 16))[_ls]);
+                    #pragma unroll
+                    for (int _ls = 0; _ls < 8; _ls++)
+                        mul_f32x2_inplace(&reinterpret_cast<float2*>(residual_v)[_ls], reinterpret_cast<const float2*>(residual_beta)[_ls]);
+                    {
+                        {
+                            __nv_bfloat162 _pk[4];
+                            _pk[0] = __floats2bfloat162_rn(residual_v[0 + 0], residual_v[0 + 1]);
+                            _pk[1] = __floats2bfloat162_rn(residual_v[0 + 2], residual_v[0 + 3]);
+                            _pk[2] = __floats2bfloat162_rn(residual_v[0 + 4], residual_v[0 + 5]);
+                            _pk[3] = __floats2bfloat162_rn(residual_v[0 + 6], residual_v[0 + 7]);
+                            *reinterpret_cast<uint4*>(&((__nv_bfloat16*)(tape_x + (tape_ex_base + (long long)(residual_half * 16))))[0]) = *reinterpret_cast<uint4*>(&_pk[0]);
+                        }
+                        {
+                            __nv_bfloat162 _pk[4];
+                            _pk[0] = __floats2bfloat162_rn(residual_v[8 + 0], residual_v[8 + 1]);
+                            _pk[1] = __floats2bfloat162_rn(residual_v[8 + 2], residual_v[8 + 3]);
+                            _pk[2] = __floats2bfloat162_rn(residual_v[8 + 4], residual_v[8 + 5]);
+                            _pk[3] = __floats2bfloat162_rn(residual_v[8 + 6], residual_v[8 + 7]);
+                            *reinterpret_cast<uint4*>(&((__nv_bfloat16*)(tape_x + (tape_ex_base + (long long)(residual_half * 16) + 8)))[0]) = *reinterpret_cast<uint4*>(&_pk[0]);
+                        }
+                    }
+                    uint32_t residual_v_bf16[8];
+                    #pragma unroll
+                    for (int _lp = 0; _lp < 8; _lp++) {
+                        __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(residual_v[_lp*2 + 0], residual_v[_lp*2+1 + 0]));
+                        residual_v_bf16[_lp] = *(uint32_t*)&_bf2;
+                    }
+                    tmem_st_x8_u32(taddr + 224 + (unsigned int)tmem_row_base + (unsigned int)(residual_half * 8), (const uint32_t*)residual_v_bf16);
+                }
+                asm volatile("tcgen05.wait::st.sync.aligned;" ::: "memory");
+                if (elect_sync()) {
+                    mbarrier_arrive(v_free_addr + (compute_stage) * 8);
+                    mbarrier_arrive(u_inp_ready_addr + (compute_stage) * 8);
+                }
+                mbarrier_wait(u2_acc_ready_addr + (compute_stage) * 8, _phase_u2_acc_ready);
+                float _tmem_load_3[32];
+                tmem_ld_x32(&_tmem_load_3[0], taddr + (unsigned int)tmem_row_base);
+                asm volatile("tcgen05.wait::ld.sync.aligned;");
+                {
+                    long long chunk_global_r = cu_chunk_offsets[seq_idx] + (long long)chunk_idx;
+                    long long tape_r_base = ((chunk_global_r * (long long)num_heads + (long long)head_idx) * 128 + (long long)state_row) * 32;
+                    #pragma unroll
+                    for (int tape_r_vec = 0; tape_r_vec < 4; tape_r_vec++) {
+                        {
+                            __nv_bfloat162 _pk[4];
+                            _pk[0] = __floats2bfloat162_rn(_tmem_load_3[tape_r_vec * 8 + 0], _tmem_load_3[tape_r_vec * 8 + 1]);
+                            _pk[1] = __floats2bfloat162_rn(_tmem_load_3[tape_r_vec * 8 + 2], _tmem_load_3[tape_r_vec * 8 + 3]);
+                            _pk[2] = __floats2bfloat162_rn(_tmem_load_3[tape_r_vec * 8 + 4], _tmem_load_3[tape_r_vec * 8 + 5]);
+                            _pk[3] = __floats2bfloat162_rn(_tmem_load_3[tape_r_vec * 8 + 6], _tmem_load_3[tape_r_vec * 8 + 7]);
+                            *reinterpret_cast<uint4*>(&((__nv_bfloat16*)(tape_r + (tape_r_base + (long long)(tape_r_vec * 8))))[0]) = *reinterpret_cast<uint4*>(&_pk[0]);
+                        }
+                    }
+                }
+                uint32_t _tmem_load_3_bf16[16];
+                #pragma unroll
+                for (int _lp = 0; _lp < 16; _lp++) {
+                    __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(_tmem_load_3[_lp*2 + 0], _tmem_load_3[_lp*2+1 + 0]));
+                    _tmem_load_3_bf16[_lp] = *(uint32_t*)&_bf2;
+                }
+                asm volatile(
+                    "tcgen05.st.sync.aligned.32x32b.x16.b32"
+                    " [%0], {%1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15, %16};"
+                    :: "r"(taddr + 224 + (unsigned int)tmem_row_base), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_3_bf16[0])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_3_bf16[1])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_3_bf16[2])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_3_bf16[3])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_3_bf16[4])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_3_bf16[5])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_3_bf16[6])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_3_bf16[7])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_3_bf16[8])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_3_bf16[9])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_3_bf16[10])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_3_bf16[11])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_3_bf16[12])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_3_bf16[13])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_3_bf16[14])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_3_bf16[15]))
+                    : "memory");
+                asm volatile("tcgen05.wait::st.sync.aligned;" ::: "memory");
+                if (elect_sync()) {
+                    mbarrier_arrive(u2_inp_ready_addr + (compute_stage) * 8);
+                }
+                mbarrier_wait(final_ready_addr + (compute_stage) * 8, _phase_final_ready);
+                {
+                    if (num_chunks > chunk_idx + 1) {
+                        int checkpoint_needed = smem_state_checkpoint_needed[compute_stage * 4] != 0 || smem_state_checkpoint_needed[compute_stage * 4 + 1] != 0 || smem_state_checkpoint_needed[compute_stage * 4 + 2] != 0 || smem_state_checkpoint_needed[compute_stage * 4 + 3] != 0;
+                        if (compute_local_warp == 0) {
+                            if (elect_sync()) {
+                                long long chunk_global_next = cu_chunk_offsets[seq_idx] + (long long)chunk_idx + 1;
+                                state_checkpoint_needed[chunk_global_next * (long long)num_heads + (long long)head_idx] = (unsigned int)checkpoint_needed;
+                                if (checkpoint_needed != 0) {
+                                    state_checkpoint_needed[fallback_head] = 1;
+                                }
+                            }
+                        }
+                    }
+                    if (compute_local_warp == 0) {
+                        if (elect_sync()) {
+                            mbarrier_arrive(smem_free_addr + (compute_stage) * 8);
+                        }
+                    }
+                }
+                compute_stage += 1;
+                if (compute_stage == 5) { compute_stage = 0; _phase_qk_full ^= 1; _phase_v_full ^= 1; _phase_old_out_ready ^= 1; _phase_u2_acc_ready ^= 1; _phase_final_ready ^= 1; }
+            }
+            if (store_final_state != 0) {
+                #pragma unroll
+                for (int state_col_block_2 = 0; state_col_block_2 < 4; state_col_block_2++) {
+                    float _tmem_load_5[32];
+                    tmem_ld_x32(&_tmem_load_5[0], taddr + 64 + (unsigned int)tmem_row_base + (unsigned int)(state_col_block_2 * 32));
+                    asm volatile("tcgen05.wait::ld.sync.aligned;");
+                    {
+                        __nv_bfloat162 _pk[8];
+                        _pk[0] = __floats2bfloat162_rn(_tmem_load_5[0 + 0], _tmem_load_5[0 + 1]);
+                        _pk[1] = __floats2bfloat162_rn(_tmem_load_5[0 + 2], _tmem_load_5[0 + 3]);
+                        _pk[2] = __floats2bfloat162_rn(_tmem_load_5[0 + 4], _tmem_load_5[0 + 5]);
+                        _pk[3] = __floats2bfloat162_rn(_tmem_load_5[0 + 6], _tmem_load_5[0 + 7]);
+                        _pk[4] = __floats2bfloat162_rn(_tmem_load_5[0 + 8], _tmem_load_5[0 + 9]);
+                        _pk[5] = __floats2bfloat162_rn(_tmem_load_5[0 + 10], _tmem_load_5[0 + 11]);
+                        _pk[6] = __floats2bfloat162_rn(_tmem_load_5[0 + 12], _tmem_load_5[0 + 13]);
+                        _pk[7] = __floats2bfloat162_rn(_tmem_load_5[0 + 14], _tmem_load_5[0 + 15]);
+                        *reinterpret_cast<uint4*>(&((__nv_bfloat16*)(final_state + (state_base + (long long)(state_col_block_2 * 32))))[0]) = *reinterpret_cast<uint4*>(&_pk[0]);
+                        *reinterpret_cast<uint4*>(&((__nv_bfloat16*)(final_state + (state_base + (long long)(state_col_block_2 * 32))))[8]) = *reinterpret_cast<uint4*>(&_pk[4]);
+                    }
+                    {
+                        __nv_bfloat162 _pk[8];
+                        _pk[0] = __floats2bfloat162_rn(_tmem_load_5[16 + 0], _tmem_load_5[16 + 1]);
+                        _pk[1] = __floats2bfloat162_rn(_tmem_load_5[16 + 2], _tmem_load_5[16 + 3]);
+                        _pk[2] = __floats2bfloat162_rn(_tmem_load_5[16 + 4], _tmem_load_5[16 + 5]);
+                        _pk[3] = __floats2bfloat162_rn(_tmem_load_5[16 + 6], _tmem_load_5[16 + 7]);
+                        _pk[4] = __floats2bfloat162_rn(_tmem_load_5[16 + 8], _tmem_load_5[16 + 9]);
+                        _pk[5] = __floats2bfloat162_rn(_tmem_load_5[16 + 10], _tmem_load_5[16 + 11]);
+                        _pk[6] = __floats2bfloat162_rn(_tmem_load_5[16 + 12], _tmem_load_5[16 + 13]);
+                        _pk[7] = __floats2bfloat162_rn(_tmem_load_5[16 + 14], _tmem_load_5[16 + 15]);
+                        *reinterpret_cast<uint4*>(&((__nv_bfloat16*)(final_state + (state_base + (long long)(state_col_block_2 * 32) + 16)))[0]) = *reinterpret_cast<uint4*>(&_pk[0]);
+                        *reinterpret_cast<uint4*>(&((__nv_bfloat16*)(final_state + (state_base + (long long)(state_col_block_2 * 32) + 16)))[8]) = *reinterpret_cast<uint4*>(&_pk[4]);
+                    }
+                }
+            }
+            asm volatile("barrier.sync 9, 128;" ::: "memory");
+            if (compute_local_warp == 0) {
+                if (elect_sync()) {
+                    mbarrier_arrive(tmem_dealloc_ready_addr);
+                }
+            }
+        }
+    }
+    // ---- Role: epilogue ----
+    if (warp >= 4 && warp <= 7) {
+        asm volatile("setmaxnreg.dec.sync.aligned.u32 48;");
+        { // epilogue_main
+            int task_idx_1 = blockIdx.x;
+            int seq_idx_1 = seq_order[task_idx_1 / num_heads];
+            int head_idx_1 = task_idx_1 % num_heads;
+            long long bos_1 = cu_seqlens[seq_idx_1];
+            long long eos_1 = cu_seqlens[seq_idx_1 + 1];
+            int seq_len_1 = (int)(eos_1 - bos_1);
+            int num_chunks_1 = (seq_len_1 + 32 - 1) / 32;
+            int warp_id_in_role_1 = (warp - 4);
+            int epilogue_local_warp = warp_id_in_role_1;
+            int warp_in_wg_1 = warp % 4;
+            const int tmem_row_base_1 = warp_in_wg_1 * 32 << 16;
+            int state_row_1 = warp_in_wg_1 * 32 + lane;
+            unsigned int epilogue_stage = 0;
+            unsigned int output_stage = 0;
+            int epilogue_chunks = num_chunks_1;
+            {
+                epilogue_chunks = 0;
+            }
+            unsigned int _phase_final_ready_1 = 0;
+            #pragma unroll 1
+            for (int chunk_idx_1 = 0; chunk_idx_1 < epilogue_chunks; chunk_idx_1++) {
+                int chunk_is_full = ((seq_len_1 >= (chunk_idx_1 + 1) * 32) ? 1 : 0);
+                if (chunk_is_full != 0) {
+                    mbarrier_wait(final_ready_addr + (epilogue_stage) * 8, _phase_final_ready_1);
+                    float _tmem_load_6[16];
+                    asm volatile(
+                        "tcgen05.ld.sync.aligned.16x256b.x4.b32"
+                        " {%0, %1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15}, [%16];"
+                        : "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_6[0])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_6[1])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_6[2])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_6[3])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_6[4])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_6[5])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_6[6])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_6[7])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_6[8])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_6[9])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_6[10])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_6[11])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_6[12])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_6[13])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_6[14])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_6[15]))
+                        : "r"(taddr + 192 + (unsigned int)tmem_row_base_1)
+                        : "memory");
+                    float _tmem_load_7[16];
+                    asm volatile(
+                        "tcgen05.ld.sync.aligned.16x256b.x4.b32"
+                        " {%0, %1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15}, [%16];"
+                        : "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_7[0])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_7[1])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_7[2])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_7[3])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_7[4])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_7[5])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_7[6])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_7[7])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_7[8])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_7[9])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_7[10])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_7[11])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_7[12])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_7[13])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_7[14])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_7[15]))
+                        : "r"(taddr + 192 + (unsigned int)tmem_row_base_1 + 1048576)
+                        : "memory");
+                    asm volatile("tcgen05.wait::ld.sync.aligned;" ::: "memory");
+                    asm volatile("barrier.sync 8, 128;" ::: "memory");
+                    if (epilogue_local_warp == 0) {
+                        if (elect_sync()) {
+                            mbarrier_arrive(out_empty_addr);
+                        }
+                    }
+                    if (epilogue_local_warp == 0) {
+                        if (chunk_idx_1 >= 2) {
+                            asm volatile("cp.async.bulk.wait_group.read 1;");
+                        }
+                    }
+                    asm volatile("barrier.sync 8, 128;" ::: "memory");
+                    int out_stage_addr = smem_out_addr + output_stage * 8192;
+                    #pragma unroll
+                    for (int dim_half = 0; dim_half < 2; dim_half++) {
+                        unsigned int out_packed[8];
+                        if (dim_half == 0) {
+                            #pragma unroll
+                            for (int _lp = 0; _lp < 8; _lp++) {
+                                __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(_tmem_load_6[_lp*2 + 0], _tmem_load_6[_lp*2+1 + 0]));
+                                out_packed[_lp] = *(uint32_t*)&_bf2;
+                            }
+                        } else {
+                            #pragma unroll
+                            for (int _lp = 0; _lp < 8; _lp++) {
+                                __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(_tmem_load_7[_lp*2 + 0], _tmem_load_7[_lp*2+1 + 0]));
+                                out_packed[_lp] = *(uint32_t*)&_bf2;
+                            }
+                        }
+                        #pragma unroll
+                        for (int token_group = 0; token_group < 2; token_group++) {
+                            int mtx_idx = lane / 8;
+                            int row_addr = lane & 7;
+                            int dim_base = epilogue_local_warp * 32 + dim_half * 16 + (mtx_idx & 1) * 8;
+                            int token_base = token_group * 16 + mtx_idx / 2 * 8;
+                            int token_addr = token_base + row_addr;
+                            int token_pair = token_addr / 2;
+                            int token_parity = token_addr & 1;
+                            int raw_row = token_pair + dim_base / 64 * 16;
+                            int raw_col = (dim_base & 63 ^ (token_pair & 3) << 4 ^ token_parity << 3) + token_parity * 64;
+                            int stsm_offset = (raw_row * 128 + raw_col) * 2;
+                            const int pack_base = token_group * 4;
+                            uint32_t _stmatrix_addr_0 = static_cast<uint32_t>((unsigned long long)(out_stage_addr + stsm_offset));
+                            asm volatile("stmatrix.sync.aligned.m8n8.x4.trans.shared.b16 [%0], {%1, %2, %3, %4};\n"
+                                :: "r"(_stmatrix_addr_0), "r"(*reinterpret_cast<const uint32_t*>(&out_packed[pack_base])), "r"(*reinterpret_cast<const uint32_t*>(&out_packed[pack_base + 1])), "r"(*reinterpret_cast<const uint32_t*>(&out_packed[pack_base + 2])), "r"(*reinterpret_cast<const uint32_t*>(&out_packed[pack_base + 3]))
+                                : "memory");
+                        }
+                    }
+                    asm volatile("fence.proxy.async.shared::cta;" ::: "memory");
+                    asm volatile("barrier.sync 8, 128;" ::: "memory");
+                    if (epilogue_local_warp == 0) {
+                        if (elect_sync()) {
+                            tma_store_4d(out_tma, 0, (int)(bos_1 + (long long)(chunk_idx_1 * 32)), head_idx_1, 0, smem_out_addr + output_stage * 8192);
+                        }
+                        asm volatile("cp.async.bulk.commit_group;");
+                    }
+                    output_stage = output_stage ^ 1;
+                } else {
+                    mbarrier_wait(final_ready_addr + (epilogue_stage) * 8, _phase_final_ready_1);
+                    float _tmem_load_8[32];
+                    tmem_ld_x32(&_tmem_load_8[0], taddr + 192 + (unsigned int)tmem_row_base_1);
+                    asm volatile("tcgen05.wait::ld.sync.aligned;" ::: "memory");
+                    asm volatile("barrier.sync 8, 128;" ::: "memory");
+                    if (epilogue_local_warp == 0) {
+                        if (elect_sync()) {
+                            mbarrier_arrive(out_empty_addr);
+                        }
+                    }
+                    #pragma unroll
+                    for (int token_col_1 = 0; token_col_1 < 32; token_col_1++) {
+                        long long out_token = bos_1 + (long long)(chunk_idx_1 * 32 + token_col_1);
+                        if (out_token < eos_1) {
+                            long long out_idx = (out_token * (long long)num_heads + (long long)head_idx_1) * 128 + (long long)state_row_1;
+                            out[out_idx] = _tmem_load_8[token_col_1];
+                        }
+                    }
+                }
+                epilogue_stage += 1;
+                if (epilogue_stage == 5) { epilogue_stage = 0; _phase_final_ready_1 ^= 1; }
+            }
+            if (epilogue_local_warp == 0) {
+                if (elect_sync()) {
+                    mbarrier_arrive(tmem_dealloc_ready_addr);
+                }
+            }
+        }
+    }
+    // ---- Role: mma ----
+    if (warp == 9) {
+        { // mma_main
+            int task_idx_2 = blockIdx.x;
+            int seq_idx_2 = seq_order[task_idx_2 / num_heads];
+            long long bos_2 = cu_seqlens[seq_idx_2];
+            long long eos_2 = cu_seqlens[seq_idx_2 + 1];
+            int seq_len_2 = (int)(eos_2 - bos_2);
+            int num_chunks_2 = (seq_len_2 + 32 - 1) / 32;
+            unsigned int mma_stage = 0;
+            unsigned int _phase_qk_full_1 = 0;
+            unsigned int _phase_state_inp_ready = 0;
+            unsigned int _phase_out_empty_0 = 1;
+            unsigned int _phase_u_inp_ready = 0;
+            unsigned int _phase_u2_inp_ready = 0;
+            unsigned int _phase_final_ready_2 = 0;
+            #pragma unroll 1
+            for (int _chunk_idx = 0; _chunk_idx < num_chunks_2; _chunk_idx++) {
+                mbarrier_wait(qk_full_addr + (mma_stage) * 8, _phase_qk_full_1);
+                mbarrier_wait(state_inp_ready_addr + (mma_stage) * 8, _phase_state_inp_ready);
+                int _mma_b_lo_1 = make_warp_uniform((((smem_kd_addr) >> 4) & 0x3FFF) + (mma_stage) * 2624);
+                asm volatile(
+                    "{\n\t"
+                    ".reg .pred leader, p0, p1;\n\t"
+                    ".reg .b32 dhi, blo, id;\n\t"
+                    ".reg .b64 db;\n\t"
+                    "elect.sync _|leader, 0xFFFFFFFF;\n\t"
+                    "setp.ne.b32 p0, %3, 0;\n\t"
+                    "setp.ne.b32 p1, 1, 0;\n\t"
+                    ""
+                    "mov.b32 dhi, 0x40004040;\n\t"
+                    "mov.b32 id, 134743184;\n\t"
+                    "mov.b32 blo, %1;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [%2], db, id, p0;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [%2 + 8], db, id, p1;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [%2 + 16], db, id, p1;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [%2 + 24], db, id, p1;\n\t"
+                    "add.u32 blo, blo, 250;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [%2 + 32], db, id, p1;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [%2 + 40], db, id, p1;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [%2 + 48], db, id, p1;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [%2 + 56], db, id, p1;\n\t"
+                    "}\n"
+                    :: "r"(tmem_tmem_u_acc), "r"(_mma_b_lo_1), "r"(tmem_tmem_state_inp), "r"(0));
+                elect_commit2(old_out_ready_addr + (mma_stage) * 8, raw_inputs_free_addr + (mma_stage) * 8);
+                mbarrier_wait(u_inp_ready_addr + (mma_stage) * 8, _phase_u_inp_ready);
+                int _mma_b_lo_2 = make_warp_uniform((((smem_inv_addr) >> 4) & 0x3FFF) + (mma_stage) * 2624);
+                asm volatile(
+                    "{\n\t"
+                    ".reg .pred leader, p0, p1;\n\t"
+                    ".reg .b32 dhi, blo, id;\n\t"
+                    ".reg .b64 db;\n\t"
+                    "elect.sync _|leader, 0xFFFFFFFF;\n\t"
+                    "setp.ne.b32 p0, %3, 0;\n\t"
+                    "setp.ne.b32 p1, 1, 0;\n\t"
+                    ""
+                    "mov.b32 dhi, 0xC0004010;\n\t"
+                    "mov.b32 id, 134743184;\n\t"
+                    "mov.b32 blo, %1;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [%2], db, id, p0;\n\t"
+                    "add.u32 blo, blo, 64;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [%2 + 8], db, id, p1;\n\t"
+                    "}\n"
+                    :: "r"(tmem_tmem_u2_acc), "r"(_mma_b_lo_2), "r"(tmem_tmem_u2_inp), "r"(0));
+                elect_commit(u2_acc_ready_addr + (mma_stage) * 8);
+                mbarrier_wait(u2_inp_ready_addr + (mma_stage) * 8, _phase_u2_inp_ready);
+                int _mma_b_lo_3 = make_warp_uniform(((((smem_final_trans_addr) >> 4) & 0x3FFF) | 0x1000000) + (mma_stage) * 2624);
+                asm volatile(
+                    "{\n\t"
+                    ".reg .pred leader, p0, p1;\n\t"
+                    ".reg .b32 dhi, blo, id;\n\t"
+                    ".reg .b64 db;\n\t"
+                    "elect.sync _|leader, 0xFFFFFFFF;\n\t"
+                    "setp.ne.b32 p0, %3, 0;\n\t"
+                    "setp.ne.b32 p1, 1, 0;\n\t"
+                    ""
+                    "mov.b32 dhi, 0x40004040;\n\t"
+                    "mov.b32 id, 136905872;\n\t"
+                    "mov.b32 blo, %1;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [%2], db, id, p0;\n\t"
+                    "add.u32 blo, blo, 128;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [%2 + 8], db, id, p1;\n\t"
+                    "}\n"
+                    :: "r"(tmem_tmem_state_out), "r"(_mma_b_lo_3), "r"(tmem_tmem_u2_inp), "r"(1));
+                elect_commit(final_ready_addr + (mma_stage) * 8);
+                {
+                    mbarrier_wait(final_ready_addr + (mma_stage) * 8, _phase_final_ready_2);
+                }
+                mma_stage += 1;
+                if (mma_stage == 5) { mma_stage = 0; _phase_qk_full_1 ^= 1; _phase_state_inp_ready ^= 1; _phase_u_inp_ready ^= 1; _phase_u2_inp_ready ^= 1; _phase_final_ready_2 ^= 1; }
+            }
+            unsigned int _phase_tmem_dealloc_ready_0 = 0;
+            mbarrier_wait(tmem_dealloc_ready_addr, _phase_tmem_dealloc_ready_0);
+            _phase_tmem_dealloc_ready_0 ^= 1;
+            int _tmem_dealloc_addr = *((volatile int*)tmem_addr_storage);
+            asm volatile("tcgen05.dealloc.cta_group::1.sync.aligned.b32 %0, %1;" :: "r"(_tmem_dealloc_addr), "r"(256));
+        }
+    }
+    // ---- Role: tape ----
+    if (warp >= 10 && warp <= 11) {
+        { // tape_main
+            unsigned int _phase_tape_ready = 0;
+            {
+                int task_idx_3 = blockIdx.x;
+                int seq_idx_3 = seq_order[task_idx_3 / num_heads];
+                int head_idx_2 = task_idx_3 % num_heads;
+                long long bos_3 = cu_seqlens[seq_idx_3];
+                long long eos_3 = cu_seqlens[seq_idx_3 + 1];
+                int seq_len_3 = (int)(eos_3 - bos_3);
+                int num_chunks_3 = (seq_len_3 + 32 - 1) / 32;
+                int warp_id_in_role_2 = (warp - 10);
+                int tape_tid = warp_id_in_role_2 * 32 + lane;
+                int zero_stride = num_bids * 64;
+                #pragma unroll 1
+                for (int zero_item = task_idx_3 * 64 + tape_tid; zero_item < zero_words; zero_item += zero_stride) {
+                    zero_workspace[zero_item] = 0;
+                }
+                unsigned int tape_stage = 0;
+                #pragma unroll 1
+                for (int chunk_idx_2 = 0; chunk_idx_2 < num_chunks_3; chunk_idx_2++) {
+                    mbarrier_wait(tape_ready_addr + (tape_stage) * 8, _phase_tape_ready);
+                    long long chunk_global = cu_chunk_offsets[seq_idx_3] + (long long)chunk_idx_2;
+                    long long tape_vec_base = (chunk_global * (long long)num_heads + (long long)head_idx_2) * 32 * 128;
+                    #pragma unroll
+                    for (int tape_pass = 0; tape_pass < 8; tape_pass++) {
+                        int tape_item = tape_pass * 64 + tape_tid;
+                        int tape_row = tape_item / 16;
+                        int tape_segment = tape_item % 16;
+                        float tape_kr_values[8];
+                        unsigned int packed[4];
+                        asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                            : "=r"(*reinterpret_cast<uint32_t*>(&packed[0])), "=r"(*reinterpret_cast<uint32_t*>(&packed[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&packed[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&packed[(0) + 3]))
+                            : "r"((smem_kr_trans_addr + tape_stage * 41984 + (unsigned int)(tape_segment * 8 / 64 * 4096 + tape_row * 128 + tape_segment * 8 % 64 * 2 ^ (tape_segment * 8 / 64 * 4096 + tape_row * 128 + tape_segment * 8 % 64 * 2 >> 7 & 7) << 4))));
+                        float packed_f32[8];
+                        #pragma unroll
+                        for (int _pair = 0; _pair < 4; _pair++) {
+                            asm volatile(
+                                "{\n\t"
+                                "shl.b32 %0, %2, 16;\n\t"
+                                "and.b32 %1, %2, 0xffff0000;\n\t"
+                                "}\n"
+                                : "=f"((&packed_f32[_pair * 2])[0]), "=f"((&packed_f32[_pair * 2])[1])
+                                : "r"(packed[_pair]));
+                        }
+                        #pragma unroll
+                        for (int value_idx = 0; value_idx < 8; value_idx++) {
+                            tape_kr_values[value_idx] = packed_f32[value_idx];
+                        }
+                        long long tape_index = tape_vec_base + (long long)tape_row * 128 + (long long)(tape_segment * 8);
+                        {
+                            __nv_bfloat162 _pk[4];
+                            _pk[0] = __floats2bfloat162_rn(tape_kr_values[0 + 0], tape_kr_values[0 + 1]);
+                            _pk[1] = __floats2bfloat162_rn(tape_kr_values[0 + 2], tape_kr_values[0 + 3]);
+                            _pk[2] = __floats2bfloat162_rn(tape_kr_values[0 + 4], tape_kr_values[0 + 5]);
+                            _pk[3] = __floats2bfloat162_rn(tape_kr_values[0 + 6], tape_kr_values[0 + 7]);
+                            *reinterpret_cast<uint4*>(&((__nv_bfloat16*)(tape_kr + tape_index))[0]) = *reinterpret_cast<uint4*>(&_pk[0]);
+                        }
+                    }
+                    long long tape_j_base = (chunk_global * (long long)num_heads + (long long)head_idx_2) * 32 * 32;
+                    #pragma unroll
+                    for (int tape_j_pass = 0; tape_j_pass < 2; tape_j_pass++) {
+                        int tape_j_item = tape_j_pass * 64 + tape_tid;
+                        int tape_j_row = tape_j_item / 4;
+                        int tape_j_segment = tape_j_item % 4;
+                        float tape_j_values[8];
+                        unsigned int packed_1[4];
+                        asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                            : "=r"(*reinterpret_cast<uint32_t*>(&packed_1[0])), "=r"(*reinterpret_cast<uint32_t*>(&packed_1[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&packed_1[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&packed_1[(0) + 3]))
+                            : "r"((smem_inv_addr + tape_stage * 41984 + (unsigned int)(tape_j_segment * 8 / 16 * 1024 + tape_j_row * 32 + tape_j_segment * 8 % 16 * 2 ^ (tape_j_segment * 8 / 16 * 1024 + tape_j_row * 32 + tape_j_segment * 8 % 16 * 2 >> 7 & 1) << 4))));
+                        float packed_f32_1[8];
+                        #pragma unroll
+                        for (int _pair = 0; _pair < 4; _pair++) {
+                            asm volatile(
+                                "{\n\t"
+                                "shl.b32 %0, %2, 16;\n\t"
+                                "and.b32 %1, %2, 0xffff0000;\n\t"
+                                "}\n"
+                                : "=f"((&packed_f32_1[_pair * 2])[0]), "=f"((&packed_f32_1[_pair * 2])[1])
+                                : "r"(packed_1[_pair]));
+                        }
+                        #pragma unroll
+                        for (int value_idx_1 = 0; value_idx_1 < 8; value_idx_1++) {
+                            tape_j_values[value_idx_1] = packed_f32_1[value_idx_1];
+                        }
+                        {
+                            __nv_bfloat162 _pk[4];
+                            _pk[0] = __floats2bfloat162_rn(tape_j_values[0 + 0], tape_j_values[0 + 1]);
+                            _pk[1] = __floats2bfloat162_rn(tape_j_values[0 + 2], tape_j_values[0 + 3]);
+                            _pk[2] = __floats2bfloat162_rn(tape_j_values[0 + 4], tape_j_values[0 + 5]);
+                            _pk[3] = __floats2bfloat162_rn(tape_j_values[0 + 6], tape_j_values[0 + 7]);
+                            *reinterpret_cast<uint4*>(&((__nv_bfloat16*)(tape_j + (tape_j_base + (long long)tape_j_row * 32 + (long long)(tape_j_segment * 8))))[0]) = *reinterpret_cast<uint4*>(&_pk[0]);
+                        }
+                    }
+                    if (elect_sync()) {
+                        mbarrier_arrive(tape_free_addr + (tape_stage) * 8);
+                    }
+                    tape_stage += 1;
+                    if (tape_stage == 5) { tape_stage = 0; _phase_tape_ready ^= 1; }
+                }
+            }
+        }
+    }
+    // ---- Role: prep ----
+    if (warp >= 12 && warp <= 31) {
+        asm volatile("setmaxnreg.dec.sync.aligned.u32 48;");
+        { // prep_main
+            int task_idx_4 = blockIdx.x;
+            int seq_idx_4 = seq_order[task_idx_4 / num_heads];
+            int head_idx_3 = task_idx_4 % num_heads;
+            long long bos_4 = cu_seqlens[seq_idx_4];
+            long long eos_4 = cu_seqlens[seq_idx_4 + 1];
+            int seq_len_4 = (int)(eos_4 - bos_4);
+            int num_chunks_4 = (seq_len_4 + 32 - 1) / 32;
+            int instance_id = (warp - 12) / 4;
+            int prep_instance = instance_id;
+            int warp_id_in_role_3 = (warp - 12);
+            int prep_local_warp = warp_id_in_role_3 - prep_instance * 4;
+            int prep_tid = prep_local_warp * 32 + lane;
+            int num_prep_iters = (num_chunks_4 + 4 - prep_instance) / 5;
+            unsigned int prep_stage = (unsigned int)prep_instance;
+            int gate_rate_stage_f32 = prep_instance * 10496;
+            if (prep_tid == 0) {
+                float _expf_0 = __expf(A_log[head_idx_3]);
+                smem_gate_rate_all[gate_rate_stage_f32] = _expf_0;
+            }
+            asm volatile("barrier.sync %0, 128;" :: "r"(10 + prep_instance) : "memory");
+            unsigned int _phase_raw_inputs_free = 1;
+            unsigned int _phase_gate_raw_full = 0;
+            unsigned int _phase_smem_free = 1;
+            unsigned int _phase_v_free = 1;
+            unsigned int _phase_qk_raw_full = 0;
+            unsigned int _phase_prep_diag_ready = 0;
+            unsigned int _phase_prep_inv16_ready = 0;
+            unsigned int _phase_tape_free = 1;
+            #pragma unroll 1
+            for (int prep_iter = 0; prep_iter < num_prep_iters; prep_iter++) {
+                int chunk_idx_3 = prep_iter * 5 + prep_instance;
+                int stage_f32 = prep_stage * 10496;
+                int stage_bf16 = prep_stage * 20992;
+                int chunk_is_full_1 = ((seq_len_4 >= (chunk_idx_3 + 1) * 32) ? 1 : 0);
+                float early_beta_value = 0.0f;
+                float early_gate0 = 0.0f;
+                if (chunk_is_full_1 != 0 || prep_iter != 0) {
+                    mbarrier_wait(raw_inputs_free_addr + (prep_stage) * 8, _phase_raw_inputs_free);
+                }
+                if (chunk_is_full_1 != 0) {
+                    if (prep_local_warp == 0) {
+                        if (elect_sync()) {
+                            mbarrier_arrive_expect_tx(gate_raw_full_addr + (prep_stage) * 8, 8704);
+                            tma_3d_gmem2smem(smem_g_raw_addr + prep_stage * 41984, g_tma, 0, head_idx_3, (int)(bos_4 + (long long)(chunk_idx_3 * 32)), gate_raw_full_addr + (prep_stage) * 8);
+                            tma_2d_gmem2smem(smem_beta_raw_addr + prep_stage * 41984, beta_tma, head_idx_3 / 8 * 8, (int)(bos_4 + (long long)(chunk_idx_3 * 32)), gate_raw_full_addr + (prep_stage) * 8);
+                            mbarrier_arrive_expect_tx(qk_raw_full_addr + (prep_stage) * 8, 16384);
+                            tma_4d_gmem2smem(smem_kd_addr + prep_stage * 41984, k_tma, 0, (int)(bos_4 + (long long)(chunk_idx_3 * 32)), head_idx_3, 0, qk_raw_full_addr + (prep_stage) * 8);
+                        }
+                    }
+                    mbarrier_wait(gate_raw_full_addr + (prep_stage) * 8, _phase_gate_raw_full);
+                    if (prep_local_warp == 2 && lane < 32) {
+                        unsigned int beta_raw_pair[1];
+                        asm volatile("ld.shared.b32 %0, [%1];" : "=r"(*reinterpret_cast<uint32_t*>(&beta_raw_pair[0])) : "r"(smem_beta_raw_addr + prep_stage * 41984 + (unsigned int)(lane * 16) + (unsigned int)(head_idx_3 % 8 / 2 * 4)));
+                        float beta_raw_pair_f32[2];
+                        #pragma unroll
+                        for (int _pair = 0; _pair < 1; _pair++) {
+                            asm volatile(
+                                "{\n\t"
+                                "shl.b32 %0, %2, 16;\n\t"
+                                "and.b32 %1, %2, 0xffff0000;\n\t"
+                                "}\n"
+                                : "=f"((&beta_raw_pair_f32[_pair * 2])[0]), "=f"((&beta_raw_pair_f32[_pair * 2])[1])
+                                : "r"(beta_raw_pair[_pair]));
+                        }
+                        float beta_logit = beta_raw_pair_f32[0];
+                        if (head_idx_3 % 2 != 0) {
+                            beta_logit = beta_raw_pair_f32[1];
+                        }
+                        float _tanh_approx_0;
+                        asm volatile("tanh.approx.f32 %0, %1;" : "=f"(_tanh_approx_0) : "f"(beta_logit * 0.5f));
+                        early_beta_value = _tanh_approx_0 * 0.5f + 0.5f;
+                    }
+                    if (prep_tid < 128) {
+                        float early_gate_rate = smem_gate_rate_all[stage_f32];
+                        float early_gate_bias = dt_bias[head_idx_3 * 128 + prep_tid];
+                        __nv_bfloat16 early_gate_raw = smem_g_raw_all[stage_bf16 + prep_tid];
+                        float _cvt_f32_0 = __bfloat162float(early_gate_raw);
+                        float early_gate_arg = early_gate_rate * (_cvt_f32_0 + early_gate_bias);
+                        float _tanh_approx_1;
+                        asm volatile("tanh.approx.f32 %0, %1;" : "=f"(_tanh_approx_1) : "f"(early_gate_arg * 0.5f));
+                        float early_gate_sigmoid = _tanh_approx_1 * 0.5f + 0.5f;
+                        early_gate0 = lower_bound * 1.4426950408889634f * early_gate_sigmoid;
+                    }
+                }
+                mbarrier_wait(smem_free_addr + (prep_stage) * 8, _phase_smem_free);
+                mbarrier_wait(v_free_addr + (prep_stage) * 8, _phase_v_free);
+                if (chunk_is_full_1 != 0) {
+                    if (prep_local_warp == 0) {
+                        if (elect_sync()) {
+                            tma_4d_gmem2smem(smem_q_raw_prefetch_addr + prep_stage * 41984, q_tma, 0, (int)(bos_4 + (long long)(chunk_idx_3 * 32)), head_idx_3, 0, qk_raw_full_addr + (prep_stage) * 8);
+                        }
+                    }
+                }
+                if (chunk_is_full_1 == 0) {
+                    #pragma unroll
+                    for (int gate_load_pass = 0; gate_load_pass < 4; gate_load_pass++) {
+                        int gate_load_item = gate_load_pass * 128 + prep_tid;
+                        int gate_load_row = gate_load_item / 16;
+                        int gate_load_segment = gate_load_item % 16;
+                        long long gate_load_token = bos_4 + (long long)(chunk_idx_3 * 32 + gate_load_row);
+                        long long gate_load_base = (gate_load_token * (long long)num_heads + (long long)head_idx_3) * 128 + (long long)(gate_load_segment * 8);
+                        asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16, %2;"
+                            :: "r"(smem_g_raw_addr + prep_stage * 41984 + (unsigned int)(gate_load_item * 16)), "l"(g + gate_load_base), "r"((gate_load_token < eos_4) ? 16 : 0));
+                    }
+                }
+                if (chunk_is_full_1 == 0) {
+                    asm volatile("cp.async.commit_group;");
+                    asm volatile("cp.async.wait_group 0;");
+                    asm volatile("barrier.sync %0, 128;" :: "r"(10 + prep_instance) : "memory");
+                }
+                if (prep_local_warp == 2 && lane < 32) {
+                    long long beta_token = bos_4 + (long long)(chunk_idx_3 * 32 + lane);
+                    float beta_value = early_beta_value;
+                    if (chunk_is_full_1 == 0) {
+                        if (beta_token < eos_4) {
+                            float beta_logit_1 = (float)beta[beta_token * (long long)num_heads + (long long)head_idx_3];
+                            float _tanh_approx_2;
+                            asm volatile("tanh.approx.f32 %0, %1;" : "=f"(_tanh_approx_2) : "f"(beta_logit_1 * 0.5f));
+                            beta_value = _tanh_approx_2 * 0.5f + 0.5f;
+                        }
+                    }
+                    smem_prep_beta_all[stage_f32 + lane] = beta_value;
+                    {
+                        if (beta_token < eos_4) {
+                            beta_active_out[beta_token * (long long)num_heads + (long long)head_idx_3] = beta_value;
+                        }
+                    }
+                }
+                if (prep_tid < 128) {
+                    int gate_col = prep_tid;
+                    float gate_rate = smem_gate_rate_all[stage_f32];
+                    float gate_bias = dt_bias[head_idx_3 * 128 + gate_col];
+                    float prefix_log2 = 0.0f;
+                    for (int gate_row = 0; gate_row < 32; gate_row++) {
+                        long long gate_token = bos_4 + (long long)(chunk_idx_3 * 32 + gate_row);
+                        float gate_log2 = 0.0f;
+                        int gate_needs_compute = 1;
+                        if (gate_row == 0) {
+                            if (chunk_is_full_1 != 0) {
+                                gate_log2 = early_gate0;
+                                gate_needs_compute = 0;
+                            }
+                        }
+                        if (gate_needs_compute != 0) {
+                            if (gate_token < eos_4) {
+                                __nv_bfloat16 gate_raw = smem_g_raw_all[stage_bf16 + gate_row * 128 + gate_col];
+                                float _cvt_f32_1 = __bfloat162float(gate_raw);
+                                float gate_arg = gate_rate * (_cvt_f32_1 + gate_bias);
+                                float _tanh_approx_3;
+                                asm volatile("tanh.approx.f32 %0, %1;" : "=f"(_tanh_approx_3) : "f"(gate_arg * 0.5f));
+                                float gate_sigmoid = _tanh_approx_3 * 0.5f + 0.5f;
+                                gate_log2 = lower_bound * 1.4426950408889634f * gate_sigmoid;
+                            }
+                        }
+                        prefix_log2 += gate_log2;
+                        smem_gate_all[stage_f32 + gate_row * 128 + gate_col] = prefix_log2;
+                    }
+                }
+                asm volatile("barrier.sync %0, 128;" :: "r"(10 + prep_instance) : "memory");
+                if (chunk_is_full_1 != 0) {
+                    mbarrier_wait(qk_raw_full_addr + (prep_stage) * 8, _phase_qk_raw_full);
+                }
+                if (prep_tid < 128) {
+                    float total_log2 = smem_gt_prefix_all[stage_f32 + prep_tid];
+                    float _exp2_0 = approx_exp2(total_log2 - lower_bound * 1.4426950408889634f * 16.0f);
+                    float restore_factor_value = _exp2_0;
+                    smem_restore_factor_all[stage_f32 + prep_tid] = restore_factor_value;
+                    {
+                        long long chunk_global_restore = cu_chunk_offsets[seq_idx_4] + (long long)chunk_idx_3;
+                        tape_restore_factor[(chunk_global_restore * (long long)num_heads + (long long)head_idx_3) * 128 + (long long)prep_tid] = restore_factor_value;
+                        int _vote_0 = __any_sync(0xFFFFFFFF, num_chunks_4 > chunk_idx_3 + 1 && total_log2 > -30.0f);
+                        int warp_slow = _vote_0;
+                        if (lane == 0) {
+                            smem_state_checkpoint_needed[prep_stage * 4 + (unsigned int)prep_local_warp] = (unsigned int)warp_slow;
+                        }
+                    }
+                }
+                if (prep_tid == 0) {
+                    float _exp2_1 = approx_exp2(lower_bound * 1.4426950408889634f * 16.0f);
+                    smem_restore_factor_all[stage_f32 + 128] = _exp2_1;
+                }
+                #pragma unroll 1
+                for (int work_pass = 0; work_pass < 4; work_pass++) {
+                    int work_item = work_pass * 128 + prep_tid;
+                    int row = work_item / 16;
+                    int segment = work_item % 16;
+                    long long token = bos_4 + (long long)(chunk_idx_3 * 32 + row);
+                    int token_valid = ((token < eos_4) ? 1 : 0);
+                    long long gmem_base = (token * (long long)num_heads + (long long)head_idx_3) * 128 + (long long)(segment * 8);
+                    float q_raw_vec[8];
+                    float k_raw_vec[8];
+                    q_raw_vec[0] = 0.0f;
+                    q_raw_vec[1] = 0.0f;
+                    q_raw_vec[2] = 0.0f;
+                    q_raw_vec[3] = 0.0f;
+                    q_raw_vec[4] = 0.0f;
+                    q_raw_vec[5] = 0.0f;
+                    q_raw_vec[6] = 0.0f;
+                    q_raw_vec[7] = 0.0f;
+                    k_raw_vec[0] = 0.0f;
+                    k_raw_vec[1] = 0.0f;
+                    k_raw_vec[2] = 0.0f;
+                    k_raw_vec[3] = 0.0f;
+                    k_raw_vec[4] = 0.0f;
+                    k_raw_vec[5] = 0.0f;
+                    k_raw_vec[6] = 0.0f;
+                    k_raw_vec[7] = 0.0f;
+                    if (chunk_is_full_1 != 0) {
+                        unsigned int packed_2[4];
+                        asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                            : "=r"(*reinterpret_cast<uint32_t*>(&packed_2[0])), "=r"(*reinterpret_cast<uint32_t*>(&packed_2[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&packed_2[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&packed_2[(0) + 3]))
+                            : "r"((smem_q_raw_prefetch_addr + prep_stage * 41984 + (unsigned int)(segment * 8 / 64 * 4096 + row * 128 + segment * 8 % 64 * 2 ^ (segment * 8 / 64 * 4096 + row * 128 + segment * 8 % 64 * 2 >> 7 & 7) << 4))));
+                        float packed_f32_2[8];
+                        #pragma unroll
+                        for (int _pair = 0; _pair < 4; _pair++) {
+                            asm volatile(
+                                "{\n\t"
+                                "shl.b32 %0, %2, 16;\n\t"
+                                "and.b32 %1, %2, 0xffff0000;\n\t"
+                                "}\n"
+                                : "=f"((&packed_f32_2[_pair * 2])[0]), "=f"((&packed_f32_2[_pair * 2])[1])
+                                : "r"(packed_2[_pair]));
+                        }
+                        #pragma unroll
+                        for (int value_idx_2 = 0; value_idx_2 < 8; value_idx_2++) {
+                            q_raw_vec[value_idx_2] = packed_f32_2[value_idx_2];
+                        }
+                        unsigned int packed_0[4];
+                        asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                            : "=r"(*reinterpret_cast<uint32_t*>(&packed_0[0])), "=r"(*reinterpret_cast<uint32_t*>(&packed_0[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&packed_0[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&packed_0[(0) + 3]))
+                            : "r"((smem_kd_addr + prep_stage * 41984 + (unsigned int)(segment * 8 / 64 * 4096 + row * 128 + segment * 8 % 64 * 2 ^ (segment * 8 / 64 * 4096 + row * 128 + segment * 8 % 64 * 2 >> 7 & 7) << 4))));
+                        float packed_0_f32[8];
+                        #pragma unroll
+                        for (int _pair = 0; _pair < 4; _pair++) {
+                            asm volatile(
+                                "{\n\t"
+                                "shl.b32 %0, %2, 16;\n\t"
+                                "and.b32 %1, %2, 0xffff0000;\n\t"
+                                "}\n"
+                                : "=f"((&packed_0_f32[_pair * 2])[0]), "=f"((&packed_0_f32[_pair * 2])[1])
+                                : "r"(packed_0[_pair]));
+                        }
+                        #pragma unroll
+                        for (int value_idx_3 = 0; value_idx_3 < 8; value_idx_3++) {
+                            k_raw_vec[value_idx_3] = packed_0_f32[value_idx_3];
+                        }
+                    } else if (token_valid != 0) {
+                        {
+                            const uint4* _vptr_0 = reinterpret_cast<const uint4*>(q + gmem_base);
+                            uint4 _vld_0[1];
+                            #pragma unroll
+                            for (int _blk = 0; _blk < 1; _blk++) {
+                                _vld_0[_blk] = _vptr_0[_blk];
+                                uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
+                                #pragma unroll
+                                for (int _pair = 0; _pair < 4; _pair++) {
+                                    asm volatile(
+                                        "{\n\t"
+                                        "shl.b32 %0, %2, 16;\n\t"
+                                        "and.b32 %1, %2, 0xffff0000;\n\t"
+                                        "}\n"
+                                        : "=f"((&q_raw_vec[0 + _blk * 8 + _pair * 2])[0]), "=f"((&q_raw_vec[0 + _blk * 8 + _pair * 2])[1])
+                                        : "r"(_vpairs_0[_pair]));
+                                }
+                            }
+                        }
+                        {
+                            const uint4* _vptr_1 = reinterpret_cast<const uint4*>(k + gmem_base);
+                            uint4 _vld_1[1];
+                            #pragma unroll
+                            for (int _blk = 0; _blk < 1; _blk++) {
+                                _vld_1[_blk] = _vptr_1[_blk];
+                                uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
+                                #pragma unroll
+                                for (int _pair = 0; _pair < 4; _pair++) {
+                                    asm volatile(
+                                        "{\n\t"
+                                        "shl.b32 %0, %2, 16;\n\t"
+                                        "and.b32 %1, %2, 0xffff0000;\n\t"
+                                        "}\n"
+                                        : "=f"((&k_raw_vec[0 + _blk * 8 + _pair * 2])[0]), "=f"((&k_raw_vec[0 + _blk * 8 + _pair * 2])[1])
+                                        : "r"(_vpairs_1[_pair]));
+                                }
+                            }
+                        }
+                    }
+                    float q_sum = 0.0f;
+                    float k_sum = 0.0f;
+                    for (int elem_in_segment = 0; elem_in_segment < 8; elem_in_segment++) {
+                        float q_raw = q_raw_vec[elem_in_segment];
+                        float k_raw = k_raw_vec[elem_in_segment];
+                        float _fma_0 = __fmaf_rn(q_raw, q_raw, q_sum);
+                        q_sum = _fma_0;
+                        float _fma_1 = __fmaf_rn(k_raw, k_raw, k_sum);
+                        k_sum = _fma_1;
+                    }
+                    float _shfl_xor_0 = __shfl_xor_sync(0xFFFFFFFF, q_sum, 8);
+                    q_sum += _shfl_xor_0;
+                    float _shfl_xor_1 = __shfl_xor_sync(0xFFFFFFFF, k_sum, 8);
+                    k_sum += _shfl_xor_1;
+                    float _shfl_xor_2 = __shfl_xor_sync(0xFFFFFFFF, q_sum, 4);
+                    q_sum += _shfl_xor_2;
+                    float _shfl_xor_3 = __shfl_xor_sync(0xFFFFFFFF, k_sum, 4);
+                    k_sum += _shfl_xor_3;
+                    float _shfl_xor_4 = __shfl_xor_sync(0xFFFFFFFF, q_sum, 2);
+                    q_sum += _shfl_xor_4;
+                    float _shfl_xor_5 = __shfl_xor_sync(0xFFFFFFFF, k_sum, 2);
+                    k_sum += _shfl_xor_5;
+                    float _shfl_xor_6 = __shfl_xor_sync(0xFFFFFFFF, q_sum, 1);
+                    q_sum += _shfl_xor_6;
+                    float _shfl_xor_7 = __shfl_xor_sync(0xFFFFFFFF, k_sum, 1);
+                    k_sum += _shfl_xor_7;
+                    float _rsqrt_0 = rsqrtf(q_sum + 1e-06f);
+                    float q_inv = _rsqrt_0;
+                    float _rsqrt_1 = rsqrtf(k_sum + 1e-06f);
+                    float k_inv = _rsqrt_1;
+                    const float2 _scale2_2 = {q_inv, q_inv};
+                    #pragma unroll
+                    for (int _ls = 0; _ls < 4; _ls++)
+                        mul_f32x2_inplace(&reinterpret_cast<float2*>(q_raw_vec)[_ls], _scale2_2);
+                    const float2 _scale2_3 = {k_inv, k_inv};
+                    #pragma unroll
+                    for (int _ls = 0; _ls < 4; _ls++)
+                        mul_f32x2_inplace(&reinterpret_cast<float2*>(k_raw_vec)[_ls], _scale2_3);
+                    {
+                        if (token_valid != 0) {
+                            if (segment == 0) {
+                                float norm_pair[2];
+                                norm_pair[0] = q_inv;
+                                norm_pair[1] = k_inv;
+                                {
+                                    float2 _v2 = make_float2(norm_pair[0 + 0], norm_pair[0 + 1]);
+                                    *reinterpret_cast<float2*>(norm_inv_out + (token * (long long)num_heads + (long long)head_idx_3) * 2) = _v2;
+                                }
+                            }
+                        }
+                    }
+                    float qd_vec[8];
+                    float kd_vec[8];
+                    float ki_vec[8];
+                    for (int elem_in_segment_1 = 0; elem_in_segment_1 < 8; elem_in_segment_1++) {
+                        int col = segment * 8 + elem_in_segment_1;
+                        float prefix = smem_gate_all[stage_f32 + row * 128 + col];
+                        float common_log2 = lower_bound * 1.4426950408889634f * 16.0f;
+                        float _exp2_2 = approx_exp2(prefix - common_log2);
+                        float decay = _exp2_2;
+                        qd_vec[elem_in_segment_1] = decay;
+                        kd_vec[elem_in_segment_1] = decay;
+                        ki_vec[elem_in_segment_1] = k_raw_vec[elem_in_segment_1] / decay;
+                    }
+                    {
+                        if (token_valid != 0) {
+                            {
+                                __nv_bfloat162 _pk[4];
+                                _pk[0] = __floats2bfloat162_rn(qd_vec[0 + 0], qd_vec[0 + 1]);
+                                _pk[1] = __floats2bfloat162_rn(qd_vec[0 + 2], qd_vec[0 + 3]);
+                                _pk[2] = __floats2bfloat162_rn(qd_vec[0 + 4], qd_vec[0 + 5]);
+                                _pk[3] = __floats2bfloat162_rn(qd_vec[0 + 6], qd_vec[0 + 7]);
+                                *reinterpret_cast<uint4*>(&((__nv_bfloat16*)(decay_out))[gmem_base + 0]) = *reinterpret_cast<uint4*>(&_pk[0]);
+                            }
+                        }
+                    }
+                    #pragma unroll
+                    for (int _ls = 0; _ls < 4; _ls++)
+                        mul_f32x2_inplace(&reinterpret_cast<float2*>(qd_vec)[_ls], reinterpret_cast<const float2*>(q_raw_vec)[_ls]);
+                    const float2 _scale2_4 = {scale, scale};
+                    #pragma unroll
+                    for (int _ls = 0; _ls < 4; _ls++)
+                        mul_f32x2_inplace(&reinterpret_cast<float2*>(qd_vec)[_ls], _scale2_4);
+                    #pragma unroll
+                    for (int _ls = 0; _ls < 4; _ls++)
+                        mul_f32x2_inplace(&reinterpret_cast<float2*>(kd_vec)[_ls], reinterpret_cast<const float2*>(k_raw_vec)[_ls]);
+                    unsigned int packed_3[4];
+                    #pragma unroll
+                    for (int _lp = 0; _lp < 4; _lp++) {
+                        __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(qd_vec[_lp*2 + 0], qd_vec[_lp*2+1 + 0]));
+                        packed_3[_lp] = *(uint32_t*)&_bf2;
+                    }
+                    #pragma unroll
+                    for (int word = 0; word < 4; word++) {
+                        asm volatile("st.shared.b32 [%0], %1;" :: "r"((smem_qd_addr + prep_stage * 41984 + (unsigned int)(segment * 8 / 64 * 4096 + row * 128 + segment * 8 % 64 * 2 ^ (segment * 8 / 64 * 4096 + row * 128 + segment * 8 % 64 * 2 >> 7 & 7) << 4)) + (unsigned int)(word * 4)), "r"((packed_3[word])));
+                    }
+                    unsigned int packed_0_1[4];
+                    #pragma unroll
+                    for (int _lp = 0; _lp < 4; _lp++) {
+                        __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(kd_vec[_lp*2 + 0], kd_vec[_lp*2+1 + 0]));
+                        packed_0_1[_lp] = *(uint32_t*)&_bf2;
+                    }
+                    #pragma unroll
+                    for (int word_1 = 0; word_1 < 4; word_1++) {
+                        asm volatile("st.shared.b32 [%0], %1;" :: "r"((smem_kd_addr + prep_stage * 41984 + (unsigned int)(segment * 8 / 64 * 4096 + row * 128 + segment * 8 % 64 * 2 ^ (segment * 8 / 64 * 4096 + row * 128 + segment * 8 % 64 * 2 >> 7 & 7) << 4)) + (unsigned int)(word_1 * 4)), "r"((packed_0_1[word_1])));
+                    }
+                    unsigned int packed_1_1[4];
+                    #pragma unroll
+                    for (int _lp = 0; _lp < 4; _lp++) {
+                        __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(ki_vec[_lp*2 + 0], ki_vec[_lp*2+1 + 0]));
+                        packed_1_1[_lp] = *(uint32_t*)&_bf2;
+                    }
+                    #pragma unroll
+                    for (int word_2 = 0; word_2 < 4; word_2++) {
+                        asm volatile("st.shared.b32 [%0], %1;" :: "r"((smem_ki_addr + prep_stage * 41984 + (unsigned int)(segment * 8 / 64 * 4096 + row * 128 + segment * 8 % 64 * 2 ^ (segment * 8 / 64 * 4096 + row * 128 + segment * 8 % 64 * 2 >> 7 & 7) << 4)) + (unsigned int)(word_2 * 4)), "r"((packed_1_1[word_2])));
+                    }
+                }
+                asm volatile("barrier.sync %0, 128;" :: "r"(10 + prep_instance) : "memory");
+                unsigned int a_frag[4];
+                unsigned int b_frag[4];
+                float acc[8];
+                {
+                    int pair_row_base = prep_local_warp / 2 * 16;
+                    int pair_col_base = prep_local_warp % 2 * 16;
+                    if (pair_row_base >= pair_col_base) {
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(a_frag[0]), "=r"(a_frag[1]), "=r"(a_frag[2]), "=r"(a_frag[3])
+                            : "r"(smem_kd_addr + prep_stage * 41984 + (unsigned int)((lane / 16 / 8 * 256 + (pair_row_base + lane % 16) * 8 + (lane / 16 % 8 * 16 ^ (pair_row_base + lane % 16 & 7) << 4) / 16) * 16))
+                            : "memory");
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(b_frag[0]), "=r"(b_frag[1]), "=r"(b_frag[2]), "=r"(b_frag[3])
+                            : "r"(smem_ki_addr + prep_stage * 41984 + (unsigned int)((lane % 16 / 8 / 8 * 256 + (pair_col_base + 8 * (lane / 16) + lane % 8) * 8 + (lane % 16 / 8 % 8 * 16 ^ (pair_col_base + 8 * (lane / 16) + lane % 8 & 7) << 4) / 16) * 16))
+                            : "memory");
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {0f00000000, 0f00000000, 0f00000000, 0f00000000};\n"
+                            : "=f"(acc[0]), "=f"(acc[1]), "=f"(acc[2]), "=f"(acc[3])
+                            : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[0]), "r"(b_frag[1]));
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {0f00000000, 0f00000000, 0f00000000, 0f00000000};\n"
+                            : "=f"(acc[4]), "=f"(acc[(4) + 1]), "=f"(acc[(4) + 2]), "=f"(acc[(4) + 3])
+                            : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[2]), "r"(b_frag[(2) + 1]));
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(a_frag[0]), "=r"(a_frag[1]), "=r"(a_frag[2]), "=r"(a_frag[3])
+                            : "r"(smem_kd_addr + prep_stage * 41984 + (unsigned int)((lane / 16 / 8 * 256 + (pair_row_base + lane % 16) * 8 + (lane / 16 % 8 * 16 ^ (pair_row_base + lane % 16 & 7) << 4) / 16 ^ 2) * 16))
+                            : "memory");
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(b_frag[0]), "=r"(b_frag[1]), "=r"(b_frag[2]), "=r"(b_frag[3])
+                            : "r"(smem_ki_addr + prep_stage * 41984 + (unsigned int)(((lane % 16 / 8 / 8 * 256 + (pair_col_base + 8 * (lane / 16) + lane % 8) * 8 + (lane % 16 / 8 % 8 * 16 ^ (pair_col_base + 8 * (lane / 16) + lane % 8 & 7) << 4) / 16 + 256 ^ 2) - 256) * 16))
+                            : "memory");
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                            : "+f"(acc[0]), "+f"(acc[1]), "+f"(acc[2]), "+f"(acc[3])
+                            : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[0]), "r"(b_frag[1]));
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                            : "+f"(acc[4]), "+f"(acc[(4) + 1]), "+f"(acc[(4) + 2]), "+f"(acc[(4) + 3])
+                            : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[2]), "r"(b_frag[(2) + 1]));
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(a_frag[0]), "=r"(a_frag[1]), "=r"(a_frag[2]), "=r"(a_frag[3])
+                            : "r"(smem_kd_addr + prep_stage * 41984 + (unsigned int)((lane / 16 / 8 * 256 + (pair_row_base + lane % 16) * 8 + (lane / 16 % 8 * 16 ^ (pair_row_base + lane % 16 & 7) << 4) / 16 ^ 2 ^ 6) * 16))
+                            : "memory");
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(b_frag[0]), "=r"(b_frag[1]), "=r"(b_frag[2]), "=r"(b_frag[3])
+                            : "r"(smem_ki_addr + prep_stage * 41984 + (unsigned int)((((lane % 16 / 8 / 8 * 256 + (pair_col_base + 8 * (lane / 16) + lane % 8) * 8 + (lane % 16 / 8 % 8 * 16 ^ (pair_col_base + 8 * (lane / 16) + lane % 8 & 7) << 4) / 16 + 256 ^ 2) - 256 + 256 ^ 6) - 256) * 16))
+                            : "memory");
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                            : "+f"(acc[0]), "+f"(acc[1]), "+f"(acc[2]), "+f"(acc[3])
+                            : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[0]), "r"(b_frag[1]));
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                            : "+f"(acc[4]), "+f"(acc[(4) + 1]), "+f"(acc[(4) + 2]), "+f"(acc[(4) + 3])
+                            : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[2]), "r"(b_frag[(2) + 1]));
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(a_frag[0]), "=r"(a_frag[1]), "=r"(a_frag[2]), "=r"(a_frag[3])
+                            : "r"(smem_kd_addr + prep_stage * 41984 + (unsigned int)((lane / 16 / 8 * 256 + (pair_row_base + lane % 16) * 8 + (lane / 16 % 8 * 16 ^ (pair_row_base + lane % 16 & 7) << 4) / 16 ^ 2 ^ 6 ^ 2) * 16))
+                            : "memory");
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(b_frag[0]), "=r"(b_frag[1]), "=r"(b_frag[2]), "=r"(b_frag[3])
+                            : "r"(smem_ki_addr + prep_stage * 41984 + (unsigned int)(((((lane % 16 / 8 / 8 * 256 + (pair_col_base + 8 * (lane / 16) + lane % 8) * 8 + (lane % 16 / 8 % 8 * 16 ^ (pair_col_base + 8 * (lane / 16) + lane % 8 & 7) << 4) / 16 + 256 ^ 2) - 256 + 256 ^ 6) - 256 + 256 ^ 2) - 256) * 16))
+                            : "memory");
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                            : "+f"(acc[0]), "+f"(acc[1]), "+f"(acc[2]), "+f"(acc[3])
+                            : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[0]), "r"(b_frag[1]));
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                            : "+f"(acc[4]), "+f"(acc[(4) + 1]), "+f"(acc[(4) + 2]), "+f"(acc[(4) + 3])
+                            : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[2]), "r"(b_frag[(2) + 1]));
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(a_frag[0]), "=r"(a_frag[1]), "=r"(a_frag[2]), "=r"(a_frag[3])
+                            : "r"(smem_kd_addr + prep_stage * 41984 + (unsigned int)(((lane / 16 / 8 * 256 + (pair_row_base + lane % 16) * 8 + (lane / 16 % 8 * 16 ^ (pair_row_base + lane % 16 & 7) << 4) / 16 ^ 2 ^ 6 ^ 2 ^ 6) + 256) * 16))
+                            : "memory");
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(b_frag[0]), "=r"(b_frag[1]), "=r"(b_frag[2]), "=r"(b_frag[3])
+                            : "r"(smem_ki_addr + prep_stage * 41984 + (unsigned int)((((((lane % 16 / 8 / 8 * 256 + (pair_col_base + 8 * (lane / 16) + lane % 8) * 8 + (lane % 16 / 8 % 8 * 16 ^ (pair_col_base + 8 * (lane / 16) + lane % 8 & 7) << 4) / 16 + 256 ^ 2) - 256 + 256 ^ 6) - 256 + 256 ^ 2) - 256 + 256 ^ 6) + 256 - 256) * 16))
+                            : "memory");
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                            : "+f"(acc[0]), "+f"(acc[1]), "+f"(acc[2]), "+f"(acc[3])
+                            : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[0]), "r"(b_frag[1]));
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                            : "+f"(acc[4]), "+f"(acc[(4) + 1]), "+f"(acc[(4) + 2]), "+f"(acc[(4) + 3])
+                            : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[2]), "r"(b_frag[(2) + 1]));
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(a_frag[0]), "=r"(a_frag[1]), "=r"(a_frag[2]), "=r"(a_frag[3])
+                            : "r"(smem_kd_addr + prep_stage * 41984 + (unsigned int)(((lane / 16 / 8 * 256 + (pair_row_base + lane % 16) * 8 + (lane / 16 % 8 * 16 ^ (pair_row_base + lane % 16 & 7) << 4) / 16 ^ 2 ^ 6 ^ 2 ^ 6) + 256 ^ 2) * 16))
+                            : "memory");
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(b_frag[0]), "=r"(b_frag[1]), "=r"(b_frag[2]), "=r"(b_frag[3])
+                            : "r"(smem_ki_addr + prep_stage * 41984 + (unsigned int)(((((((lane % 16 / 8 / 8 * 256 + (pair_col_base + 8 * (lane / 16) + lane % 8) * 8 + (lane % 16 / 8 % 8 * 16 ^ (pair_col_base + 8 * (lane / 16) + lane % 8 & 7) << 4) / 16 + 256 ^ 2) - 256 + 256 ^ 6) - 256 + 256 ^ 2) - 256 + 256 ^ 6) + 256 - 256 + 256 ^ 2) - 256) * 16))
+                            : "memory");
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                            : "+f"(acc[0]), "+f"(acc[1]), "+f"(acc[2]), "+f"(acc[3])
+                            : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[0]), "r"(b_frag[1]));
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                            : "+f"(acc[4]), "+f"(acc[(4) + 1]), "+f"(acc[(4) + 2]), "+f"(acc[(4) + 3])
+                            : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[2]), "r"(b_frag[(2) + 1]));
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(a_frag[0]), "=r"(a_frag[1]), "=r"(a_frag[2]), "=r"(a_frag[3])
+                            : "r"(smem_kd_addr + prep_stage * 41984 + (unsigned int)(((lane / 16 / 8 * 256 + (pair_row_base + lane % 16) * 8 + (lane / 16 % 8 * 16 ^ (pair_row_base + lane % 16 & 7) << 4) / 16 ^ 2 ^ 6 ^ 2 ^ 6) + 256 ^ 2 ^ 6) * 16))
+                            : "memory");
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(b_frag[0]), "=r"(b_frag[1]), "=r"(b_frag[2]), "=r"(b_frag[3])
+                            : "r"(smem_ki_addr + prep_stage * 41984 + (unsigned int)((((((((lane % 16 / 8 / 8 * 256 + (pair_col_base + 8 * (lane / 16) + lane % 8) * 8 + (lane % 16 / 8 % 8 * 16 ^ (pair_col_base + 8 * (lane / 16) + lane % 8 & 7) << 4) / 16 + 256 ^ 2) - 256 + 256 ^ 6) - 256 + 256 ^ 2) - 256 + 256 ^ 6) + 256 - 256 + 256 ^ 2) - 256 + 256 ^ 6) - 256) * 16))
+                            : "memory");
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                            : "+f"(acc[0]), "+f"(acc[1]), "+f"(acc[2]), "+f"(acc[3])
+                            : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[0]), "r"(b_frag[1]));
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                            : "+f"(acc[4]), "+f"(acc[(4) + 1]), "+f"(acc[(4) + 2]), "+f"(acc[(4) + 3])
+                            : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[2]), "r"(b_frag[(2) + 1]));
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(a_frag[0]), "=r"(a_frag[1]), "=r"(a_frag[2]), "=r"(a_frag[3])
+                            : "r"(smem_kd_addr + prep_stage * 41984 + (unsigned int)(((lane / 16 / 8 * 256 + (pair_row_base + lane % 16) * 8 + (lane / 16 % 8 * 16 ^ (pair_row_base + lane % 16 & 7) << 4) / 16 ^ 2 ^ 6 ^ 2 ^ 6) + 256 ^ 2 ^ 6 ^ 2) * 16))
+                            : "memory");
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(b_frag[0]), "=r"(b_frag[1]), "=r"(b_frag[2]), "=r"(b_frag[3])
+                            : "r"(smem_ki_addr + prep_stage * 41984 + (unsigned int)(((((((((lane % 16 / 8 / 8 * 256 + (pair_col_base + 8 * (lane / 16) + lane % 8) * 8 + (lane % 16 / 8 % 8 * 16 ^ (pair_col_base + 8 * (lane / 16) + lane % 8 & 7) << 4) / 16 + 256 ^ 2) - 256 + 256 ^ 6) - 256 + 256 ^ 2) - 256 + 256 ^ 6) + 256 - 256 + 256 ^ 2) - 256 + 256 ^ 6) - 256 + 256 ^ 2) - 256) * 16))
+                            : "memory");
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                            : "+f"(acc[0]), "+f"(acc[1]), "+f"(acc[2]), "+f"(acc[3])
+                            : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[0]), "r"(b_frag[1]));
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                            : "+f"(acc[4]), "+f"(acc[(4) + 1]), "+f"(acc[(4) + 2]), "+f"(acc[(4) + 3])
+                            : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[2]), "r"(b_frag[(2) + 1]));
+                        int row0 = pair_row_base + lane / 4;
+                        int row1 = row0 + 8;
+                        int col0 = pair_col_base + lane % 4 * 2;
+                        float beta0 = smem_prep_beta_all[stage_f32 + row0];
+                        float beta1 = smem_prep_beta_all[stage_f32 + row1];
+                        float seed[8];
+                        seed[0] = 0.0f;
+                        seed[1] = 0.0f;
+                        seed[2] = 0.0f;
+                        seed[3] = 0.0f;
+                        seed[4] = 0.0f;
+                        seed[5] = 0.0f;
+                        seed[6] = 0.0f;
+                        seed[7] = 0.0f;
+                        if (row0 > col0) {
+                            seed[0] = acc[0] * beta0;
+                        }
+                        if (row0 > col0 + 1) {
+                            seed[1] = acc[1] * beta0;
+                        }
+                        if (row1 > col0) {
+                            seed[2] = acc[2] * beta1;
+                        }
+                        if (row1 > col0 + 1) {
+                            seed[3] = acc[3] * beta1;
+                        }
+                        if (row0 > col0 + 8) {
+                            seed[4] = acc[4] * beta0;
+                        }
+                        if (row0 > col0 + 9) {
+                            seed[5] = acc[5] * beta0;
+                        }
+                        if (row1 > col0 + 8) {
+                            seed[6] = acc[6] * beta1;
+                        }
+                        if (row1 > col0 + 9) {
+                            seed[7] = acc[7] * beta1;
+                        }
+                        unsigned int seed_packed[4];
+                        #pragma unroll
+                        for (int _lp = 0; _lp < 4; _lp++) {
+                            __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(seed[_lp*2 + 0], seed[_lp*2+1 + 0]));
+                            seed_packed[_lp] = *(uint32_t*)&_bf2;
+                        }
+                        int seed_lane_row = lane % 16;
+                        int seed_lane_col = lane / 16 * 8;
+                        int byte_off = (int)prep_stage * 41984 + (pair_row_base + seed_lane_row) * 128 + (pair_col_base + seed_lane_col) * 2;
+                        int swizzled_off = byte_off ^ (byte_off >> 7 & 7) << 4;
+                        int seed_addr = smem_inv_work_addr + (unsigned int)swizzled_off;
+                        uint32_t _stmatrix_addr_5 = static_cast<uint32_t>((unsigned long long)seed_addr);
+                        asm volatile("stmatrix.sync.aligned.m8n8.x4.shared.b16 [%0], {%1, %2, %3, %4};\n"
+                            :: "r"(_stmatrix_addr_5), "r"(*reinterpret_cast<const uint32_t*>(&seed_packed[0])), "r"(*reinterpret_cast<const uint32_t*>(&seed_packed[1])), "r"(*reinterpret_cast<const uint32_t*>(&seed_packed[2])), "r"(*reinterpret_cast<const uint32_t*>(&seed_packed[3]))
+                            : "memory");
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(a_frag[0]), "=r"(a_frag[1]), "=r"(a_frag[2]), "=r"(a_frag[3])
+                            : "r"(smem_qd_addr + prep_stage * 41984 + (unsigned int)((lane / 16 / 8 * 256 + (pair_row_base + lane % 16) * 8 + (lane / 16 % 8 * 16 ^ (pair_row_base + lane % 16 & 7) << 4) / 16) * 16))
+                            : "memory");
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(b_frag[0]), "=r"(b_frag[1]), "=r"(b_frag[2]), "=r"(b_frag[3])
+                            : "r"(smem_ki_addr + prep_stage * 41984 + (unsigned int)((lane % 16 / 8 / 8 * 256 + (pair_col_base + 8 * (lane / 16) + lane % 8) * 8 + (lane % 16 / 8 % 8 * 16 ^ (pair_col_base + 8 * (lane / 16) + lane % 8 & 7) << 4) / 16) * 16))
+                            : "memory");
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {0f00000000, 0f00000000, 0f00000000, 0f00000000};\n"
+                            : "=f"(acc[0]), "=f"(acc[1]), "=f"(acc[2]), "=f"(acc[3])
+                            : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[0]), "r"(b_frag[1]));
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {0f00000000, 0f00000000, 0f00000000, 0f00000000};\n"
+                            : "=f"(acc[4]), "=f"(acc[(4) + 1]), "=f"(acc[(4) + 2]), "=f"(acc[(4) + 3])
+                            : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[2]), "r"(b_frag[(2) + 1]));
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(a_frag[0]), "=r"(a_frag[1]), "=r"(a_frag[2]), "=r"(a_frag[3])
+                            : "r"(smem_qd_addr + prep_stage * 41984 + (unsigned int)((lane / 16 / 8 * 256 + (pair_row_base + lane % 16) * 8 + (lane / 16 % 8 * 16 ^ (pair_row_base + lane % 16 & 7) << 4) / 16 ^ 2) * 16))
+                            : "memory");
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(b_frag[0]), "=r"(b_frag[1]), "=r"(b_frag[2]), "=r"(b_frag[3])
+                            : "r"(smem_ki_addr + prep_stage * 41984 + (unsigned int)(((lane % 16 / 8 / 8 * 256 + (pair_col_base + 8 * (lane / 16) + lane % 8) * 8 + (lane % 16 / 8 % 8 * 16 ^ (pair_col_base + 8 * (lane / 16) + lane % 8 & 7) << 4) / 16 + 256 ^ 2) - 256) * 16))
+                            : "memory");
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                            : "+f"(acc[0]), "+f"(acc[1]), "+f"(acc[2]), "+f"(acc[3])
+                            : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[0]), "r"(b_frag[1]));
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                            : "+f"(acc[4]), "+f"(acc[(4) + 1]), "+f"(acc[(4) + 2]), "+f"(acc[(4) + 3])
+                            : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[2]), "r"(b_frag[(2) + 1]));
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(a_frag[0]), "=r"(a_frag[1]), "=r"(a_frag[2]), "=r"(a_frag[3])
+                            : "r"(smem_qd_addr + prep_stage * 41984 + (unsigned int)((lane / 16 / 8 * 256 + (pair_row_base + lane % 16) * 8 + (lane / 16 % 8 * 16 ^ (pair_row_base + lane % 16 & 7) << 4) / 16 ^ 2 ^ 6) * 16))
+                            : "memory");
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(b_frag[0]), "=r"(b_frag[1]), "=r"(b_frag[2]), "=r"(b_frag[3])
+                            : "r"(smem_ki_addr + prep_stage * 41984 + (unsigned int)((((lane % 16 / 8 / 8 * 256 + (pair_col_base + 8 * (lane / 16) + lane % 8) * 8 + (lane % 16 / 8 % 8 * 16 ^ (pair_col_base + 8 * (lane / 16) + lane % 8 & 7) << 4) / 16 + 256 ^ 2) - 256 + 256 ^ 6) - 256) * 16))
+                            : "memory");
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                            : "+f"(acc[0]), "+f"(acc[1]), "+f"(acc[2]), "+f"(acc[3])
+                            : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[0]), "r"(b_frag[1]));
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                            : "+f"(acc[4]), "+f"(acc[(4) + 1]), "+f"(acc[(4) + 2]), "+f"(acc[(4) + 3])
+                            : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[2]), "r"(b_frag[(2) + 1]));
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(a_frag[0]), "=r"(a_frag[1]), "=r"(a_frag[2]), "=r"(a_frag[3])
+                            : "r"(smem_qd_addr + prep_stage * 41984 + (unsigned int)((lane / 16 / 8 * 256 + (pair_row_base + lane % 16) * 8 + (lane / 16 % 8 * 16 ^ (pair_row_base + lane % 16 & 7) << 4) / 16 ^ 2 ^ 6 ^ 2) * 16))
+                            : "memory");
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(b_frag[0]), "=r"(b_frag[1]), "=r"(b_frag[2]), "=r"(b_frag[3])
+                            : "r"(smem_ki_addr + prep_stage * 41984 + (unsigned int)(((((lane % 16 / 8 / 8 * 256 + (pair_col_base + 8 * (lane / 16) + lane % 8) * 8 + (lane % 16 / 8 % 8 * 16 ^ (pair_col_base + 8 * (lane / 16) + lane % 8 & 7) << 4) / 16 + 256 ^ 2) - 256 + 256 ^ 6) - 256 + 256 ^ 2) - 256) * 16))
+                            : "memory");
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                            : "+f"(acc[0]), "+f"(acc[1]), "+f"(acc[2]), "+f"(acc[3])
+                            : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[0]), "r"(b_frag[1]));
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                            : "+f"(acc[4]), "+f"(acc[(4) + 1]), "+f"(acc[(4) + 2]), "+f"(acc[(4) + 3])
+                            : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[2]), "r"(b_frag[(2) + 1]));
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(a_frag[0]), "=r"(a_frag[1]), "=r"(a_frag[2]), "=r"(a_frag[3])
+                            : "r"(smem_qd_addr + prep_stage * 41984 + (unsigned int)(((lane / 16 / 8 * 256 + (pair_row_base + lane % 16) * 8 + (lane / 16 % 8 * 16 ^ (pair_row_base + lane % 16 & 7) << 4) / 16 ^ 2 ^ 6 ^ 2 ^ 6) + 256) * 16))
+                            : "memory");
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(b_frag[0]), "=r"(b_frag[1]), "=r"(b_frag[2]), "=r"(b_frag[3])
+                            : "r"(smem_ki_addr + prep_stage * 41984 + (unsigned int)((((((lane % 16 / 8 / 8 * 256 + (pair_col_base + 8 * (lane / 16) + lane % 8) * 8 + (lane % 16 / 8 % 8 * 16 ^ (pair_col_base + 8 * (lane / 16) + lane % 8 & 7) << 4) / 16 + 256 ^ 2) - 256 + 256 ^ 6) - 256 + 256 ^ 2) - 256 + 256 ^ 6) + 256 - 256) * 16))
+                            : "memory");
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                            : "+f"(acc[0]), "+f"(acc[1]), "+f"(acc[2]), "+f"(acc[3])
+                            : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[0]), "r"(b_frag[1]));
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                            : "+f"(acc[4]), "+f"(acc[(4) + 1]), "+f"(acc[(4) + 2]), "+f"(acc[(4) + 3])
+                            : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[2]), "r"(b_frag[(2) + 1]));
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(a_frag[0]), "=r"(a_frag[1]), "=r"(a_frag[2]), "=r"(a_frag[3])
+                            : "r"(smem_qd_addr + prep_stage * 41984 + (unsigned int)(((lane / 16 / 8 * 256 + (pair_row_base + lane % 16) * 8 + (lane / 16 % 8 * 16 ^ (pair_row_base + lane % 16 & 7) << 4) / 16 ^ 2 ^ 6 ^ 2 ^ 6) + 256 ^ 2) * 16))
+                            : "memory");
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(b_frag[0]), "=r"(b_frag[1]), "=r"(b_frag[2]), "=r"(b_frag[3])
+                            : "r"(smem_ki_addr + prep_stage * 41984 + (unsigned int)(((((((lane % 16 / 8 / 8 * 256 + (pair_col_base + 8 * (lane / 16) + lane % 8) * 8 + (lane % 16 / 8 % 8 * 16 ^ (pair_col_base + 8 * (lane / 16) + lane % 8 & 7) << 4) / 16 + 256 ^ 2) - 256 + 256 ^ 6) - 256 + 256 ^ 2) - 256 + 256 ^ 6) + 256 - 256 + 256 ^ 2) - 256) * 16))
+                            : "memory");
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                            : "+f"(acc[0]), "+f"(acc[1]), "+f"(acc[2]), "+f"(acc[3])
+                            : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[0]), "r"(b_frag[1]));
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                            : "+f"(acc[4]), "+f"(acc[(4) + 1]), "+f"(acc[(4) + 2]), "+f"(acc[(4) + 3])
+                            : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[2]), "r"(b_frag[(2) + 1]));
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(a_frag[0]), "=r"(a_frag[1]), "=r"(a_frag[2]), "=r"(a_frag[3])
+                            : "r"(smem_qd_addr + prep_stage * 41984 + (unsigned int)(((lane / 16 / 8 * 256 + (pair_row_base + lane % 16) * 8 + (lane / 16 % 8 * 16 ^ (pair_row_base + lane % 16 & 7) << 4) / 16 ^ 2 ^ 6 ^ 2 ^ 6) + 256 ^ 2 ^ 6) * 16))
+                            : "memory");
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(b_frag[0]), "=r"(b_frag[1]), "=r"(b_frag[2]), "=r"(b_frag[3])
+                            : "r"(smem_ki_addr + prep_stage * 41984 + (unsigned int)((((((((lane % 16 / 8 / 8 * 256 + (pair_col_base + 8 * (lane / 16) + lane % 8) * 8 + (lane % 16 / 8 % 8 * 16 ^ (pair_col_base + 8 * (lane / 16) + lane % 8 & 7) << 4) / 16 + 256 ^ 2) - 256 + 256 ^ 6) - 256 + 256 ^ 2) - 256 + 256 ^ 6) + 256 - 256 + 256 ^ 2) - 256 + 256 ^ 6) - 256) * 16))
+                            : "memory");
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                            : "+f"(acc[0]), "+f"(acc[1]), "+f"(acc[2]), "+f"(acc[3])
+                            : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[0]), "r"(b_frag[1]));
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                            : "+f"(acc[4]), "+f"(acc[(4) + 1]), "+f"(acc[(4) + 2]), "+f"(acc[(4) + 3])
+                            : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[2]), "r"(b_frag[(2) + 1]));
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(a_frag[0]), "=r"(a_frag[1]), "=r"(a_frag[2]), "=r"(a_frag[3])
+                            : "r"(smem_qd_addr + prep_stage * 41984 + (unsigned int)(((lane / 16 / 8 * 256 + (pair_row_base + lane % 16) * 8 + (lane / 16 % 8 * 16 ^ (pair_row_base + lane % 16 & 7) << 4) / 16 ^ 2 ^ 6 ^ 2 ^ 6) + 256 ^ 2 ^ 6 ^ 2) * 16))
+                            : "memory");
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(b_frag[0]), "=r"(b_frag[1]), "=r"(b_frag[2]), "=r"(b_frag[3])
+                            : "r"(smem_ki_addr + prep_stage * 41984 + (unsigned int)(((((((((lane % 16 / 8 / 8 * 256 + (pair_col_base + 8 * (lane / 16) + lane % 8) * 8 + (lane % 16 / 8 % 8 * 16 ^ (pair_col_base + 8 * (lane / 16) + lane % 8 & 7) << 4) / 16 + 256 ^ 2) - 256 + 256 ^ 6) - 256 + 256 ^ 2) - 256 + 256 ^ 6) + 256 - 256 + 256 ^ 2) - 256 + 256 ^ 6) - 256 + 256 ^ 2) - 256) * 16))
+                            : "memory");
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                            : "+f"(acc[0]), "+f"(acc[1]), "+f"(acc[2]), "+f"(acc[3])
+                            : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[0]), "r"(b_frag[1]));
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                            : "+f"(acc[4]), "+f"(acc[(4) + 1]), "+f"(acc[(4) + 2]), "+f"(acc[(4) + 3])
+                            : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[2]), "r"(b_frag[(2) + 1]));
+                    } else {
+                        acc[0] = 0.0f;
+                        acc[1] = 0.0f;
+                        acc[2] = 0.0f;
+                        acc[3] = 0.0f;
+                        acc[4] = 0.0f;
+                        acc[5] = 0.0f;
+                        acc[6] = 0.0f;
+                        acc[7] = 0.0f;
+                    }
+                    int row0_1 = pair_row_base + lane / 4;
+                    int row1_1 = row0_1 + 8;
+                    int col0_1 = pair_col_base + lane % 4 * 2;
+                    float mqk[8];
+                    mqk[0] = 0.0f;
+                    mqk[1] = 0.0f;
+                    mqk[2] = 0.0f;
+                    mqk[3] = 0.0f;
+                    mqk[4] = 0.0f;
+                    mqk[5] = 0.0f;
+                    mqk[6] = 0.0f;
+                    mqk[7] = 0.0f;
+                    if (row0_1 >= col0_1) {
+                        mqk[0] = acc[0];
+                    }
+                    if (row0_1 >= col0_1 + 1) {
+                        mqk[1] = acc[1];
+                    }
+                    if (row1_1 >= col0_1) {
+                        mqk[2] = acc[2];
+                    }
+                    if (row1_1 >= col0_1 + 1) {
+                        mqk[3] = acc[3];
+                    }
+                    if (row0_1 >= col0_1 + 8) {
+                        mqk[4] = acc[4];
+                    }
+                    if (row0_1 >= col0_1 + 9) {
+                        mqk[5] = acc[5];
+                    }
+                    if (row1_1 >= col0_1 + 8) {
+                        mqk[6] = acc[6];
+                    }
+                    if (row1_1 >= col0_1 + 9) {
+                        mqk[7] = acc[7];
+                    }
+                    unsigned int mqk_packed[4];
+                    #pragma unroll
+                    for (int _lp = 0; _lp < 4; _lp++) {
+                        __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(mqk[_lp*2 + 0], mqk[_lp*2+1 + 0]));
+                        mqk_packed[_lp] = *(uint32_t*)&_bf2;
+                    }
+                    #pragma unroll
+                    for (int publish_pair = 0; publish_pair < 2; publish_pair++) {
+                        int publish_row = pair_col_base + publish_pair * 8 + (lane & 7);
+                        int publish_col = 128 + pair_row_base + lane / 8 * 8;
+                        uint32_t _stmatrix_addr_6 = static_cast<uint32_t>((unsigned long long)(smem_final_trans_addr + prep_stage * 41984 + (unsigned int)(publish_col / 64 * 4096 + publish_row * 128 + publish_col % 64 * 2 ^ (publish_col / 64 * 4096 + publish_row * 128 + publish_col % 64 * 2 >> 7 & 7) << 4)));
+                        asm volatile("stmatrix.sync.aligned.m8n8.x2.trans.shared.b16 [%0], {%1, %2};\n"
+                            :: "r"(_stmatrix_addr_6), "r"(*reinterpret_cast<const uint32_t*>(&mqk_packed[publish_pair * 2])), "r"(*reinterpret_cast<const uint32_t*>(&mqk_packed[publish_pair * 2 + 1]))
+                            : "memory");
+                    }
+                }
+                asm volatile("barrier.sync %0, 128;" :: "r"(10 + prep_instance) : "memory");
+                long long tape_scaled_base = 0;
+                {
+                    long long chunk_global_scaled = cu_chunk_offsets[seq_idx_4] + (long long)chunk_idx_3;
+                    tape_scaled_base = (chunk_global_scaled * (long long)num_heads + (long long)head_idx_3) * 32 * 128;
+                }
+                if (prep_tid < 128) {
+                    float total_log2_1 = smem_gt_prefix_all[stage_f32 + prep_tid];
+                    float _exp2_3 = approx_exp2(total_log2_1);
+                    smem_gt_all[stage_f32 + prep_tid] = _exp2_3;
+                }
+                {
+                    if (prep_local_warp >= 2) {
+                        int stage_f32_0 = prep_stage * 10496;
+                        float restore_scale = smem_restore_factor_all[stage_f32_0 + 128];
+                        float restore_factor[8];
+                        int restore_segment = lane & 15;
+                        #pragma unroll
+                        for (int restore_elem = 0; restore_elem < 8; restore_elem++) {
+                            int restore_col = restore_segment * 8 + restore_elem;
+                            restore_factor[restore_elem] = smem_restore_factor_all[stage_f32_0 + restore_col];
+                        }
+                        #pragma unroll 1
+                        for (int restore_pass = 0; restore_pass < 6; restore_pass++) {
+                            int restore_row = 8 + (prep_local_warp - 2) * 12 + restore_pass * 2 + (lane >> 4);
+                            float restore_qd_values[8];
+                            float restore_kd_values[8];
+                            float restore_ki_values[8];
+                            unsigned int packed_4[4];
+                            asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                                : "=r"(*reinterpret_cast<uint32_t*>(&packed_4[0])), "=r"(*reinterpret_cast<uint32_t*>(&packed_4[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&packed_4[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&packed_4[(0) + 3]))
+                                : "r"((smem_qd_addr + prep_stage * 41984 + (unsigned int)(restore_segment * 8 / 64 * 4096 + restore_row * 128 + restore_segment * 8 % 64 * 2 ^ (restore_segment * 8 / 64 * 4096 + restore_row * 128 + restore_segment * 8 % 64 * 2 >> 7 & 7) << 4))));
+                            float packed_f32_3[8];
+                            #pragma unroll
+                            for (int _pair = 0; _pair < 4; _pair++) {
+                                asm volatile(
+                                    "{\n\t"
+                                    "shl.b32 %0, %2, 16;\n\t"
+                                    "and.b32 %1, %2, 0xffff0000;\n\t"
+                                    "}\n"
+                                    : "=f"((&packed_f32_3[_pair * 2])[0]), "=f"((&packed_f32_3[_pair * 2])[1])
+                                    : "r"(packed_4[_pair]));
+                            }
+                            #pragma unroll
+                            for (int value_idx_4 = 0; value_idx_4 < 8; value_idx_4++) {
+                                restore_qd_values[value_idx_4] = packed_f32_3[value_idx_4];
+                            }
+                            unsigned int packed_0_2[4];
+                            asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                                : "=r"(*reinterpret_cast<uint32_t*>(&packed_0_2[0])), "=r"(*reinterpret_cast<uint32_t*>(&packed_0_2[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&packed_0_2[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&packed_0_2[(0) + 3]))
+                                : "r"((smem_kd_addr + prep_stage * 41984 + (unsigned int)(restore_segment * 8 / 64 * 4096 + restore_row * 128 + restore_segment * 8 % 64 * 2 ^ (restore_segment * 8 / 64 * 4096 + restore_row * 128 + restore_segment * 8 % 64 * 2 >> 7 & 7) << 4))));
+                            float packed_0_f32_1[8];
+                            #pragma unroll
+                            for (int _pair = 0; _pair < 4; _pair++) {
+                                asm volatile(
+                                    "{\n\t"
+                                    "shl.b32 %0, %2, 16;\n\t"
+                                    "and.b32 %1, %2, 0xffff0000;\n\t"
+                                    "}\n"
+                                    : "=f"((&packed_0_f32_1[_pair * 2])[0]), "=f"((&packed_0_f32_1[_pair * 2])[1])
+                                    : "r"(packed_0_2[_pair]));
+                            }
+                            #pragma unroll
+                            for (int value_idx_5 = 0; value_idx_5 < 8; value_idx_5++) {
+                                restore_kd_values[value_idx_5] = packed_0_f32_1[value_idx_5];
+                            }
+                            unsigned int packed_1_2[4];
+                            asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                                : "=r"(*reinterpret_cast<uint32_t*>(&packed_1_2[0])), "=r"(*reinterpret_cast<uint32_t*>(&packed_1_2[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&packed_1_2[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&packed_1_2[(0) + 3]))
+                                : "r"((smem_ki_addr + prep_stage * 41984 + (unsigned int)(restore_segment * 8 / 64 * 4096 + restore_row * 128 + restore_segment * 8 % 64 * 2 ^ (restore_segment * 8 / 64 * 4096 + restore_row * 128 + restore_segment * 8 % 64 * 2 >> 7 & 7) << 4))));
+                            float packed_1_f32[8];
+                            #pragma unroll
+                            for (int _pair = 0; _pair < 4; _pair++) {
+                                asm volatile(
+                                    "{\n\t"
+                                    "shl.b32 %0, %2, 16;\n\t"
+                                    "and.b32 %1, %2, 0xffff0000;\n\t"
+                                    "}\n"
+                                    : "=f"((&packed_1_f32[_pair * 2])[0]), "=f"((&packed_1_f32[_pair * 2])[1])
+                                    : "r"(packed_1_2[_pair]));
+                            }
+                            #pragma unroll
+                            for (int value_idx_6 = 0; value_idx_6 < 8; value_idx_6++) {
+                                restore_ki_values[value_idx_6] = packed_1_f32[value_idx_6];
+                            }
+                            {
+                                long long tape_scaled_index = tape_scaled_base + (long long)restore_row * 128 + (long long)(restore_segment * 8);
+                                {
+                                    __nv_bfloat162 _pk[4];
+                                    _pk[0] = __floats2bfloat162_rn(restore_qd_values[0 + 0], restore_qd_values[0 + 1]);
+                                    _pk[1] = __floats2bfloat162_rn(restore_qd_values[0 + 2], restore_qd_values[0 + 3]);
+                                    _pk[2] = __floats2bfloat162_rn(restore_qd_values[0 + 4], restore_qd_values[0 + 5]);
+                                    _pk[3] = __floats2bfloat162_rn(restore_qd_values[0 + 6], restore_qd_values[0 + 7]);
+                                    *reinterpret_cast<uint4*>(&((__nv_bfloat16*)(tape_qd + tape_scaled_index))[0]) = *reinterpret_cast<uint4*>(&_pk[0]);
+                                }
+                                {
+                                    __nv_bfloat162 _pk[4];
+                                    _pk[0] = __floats2bfloat162_rn(restore_kd_values[0 + 0], restore_kd_values[0 + 1]);
+                                    _pk[1] = __floats2bfloat162_rn(restore_kd_values[0 + 2], restore_kd_values[0 + 3]);
+                                    _pk[2] = __floats2bfloat162_rn(restore_kd_values[0 + 4], restore_kd_values[0 + 5]);
+                                    _pk[3] = __floats2bfloat162_rn(restore_kd_values[0 + 6], restore_kd_values[0 + 7]);
+                                    *reinterpret_cast<uint4*>(&((__nv_bfloat16*)(tape_kd + tape_scaled_index))[0]) = *reinterpret_cast<uint4*>(&_pk[0]);
+                                }
+                            }
+                            float restore_kr_values[8];
+                            #pragma unroll
+                            for (int restore_elem_1 = 0; restore_elem_1 < 8; restore_elem_1++) {
+                                restore_kr_values[restore_elem_1] = restore_ki_values[restore_elem_1] * restore_factor[restore_elem_1];
+                            }
+                            const float2 _scale2_7 = {restore_scale, restore_scale};
+                            #pragma unroll
+                            for (int _ls = 0; _ls < 4; _ls++)
+                                mul_f32x2_inplace(&reinterpret_cast<float2*>(restore_qd_values)[_ls], _scale2_7);
+                            const float2 _scale2_8 = {restore_scale, restore_scale};
+                            #pragma unroll
+                            for (int _ls = 0; _ls < 4; _ls++)
+                                mul_f32x2_inplace(&reinterpret_cast<float2*>(restore_kd_values)[_ls], _scale2_8);
+                            unsigned int packed_2_1[4];
+                            #pragma unroll
+                            for (int _lp = 0; _lp < 4; _lp++) {
+                                __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(restore_kd_values[_lp*2 + 0], restore_kd_values[_lp*2+1 + 0]));
+                                packed_2_1[_lp] = *(uint32_t*)&_bf2;
+                            }
+                            #pragma unroll
+                            for (int word_3 = 0; word_3 < 4; word_3++) {
+                                asm volatile("st.shared.b32 [%0], %1;" :: "r"((smem_kd_addr + prep_stage * 41984 + (unsigned int)(restore_segment * 8 / 64 * 4096 + restore_row * 128 + restore_segment * 8 % 64 * 2 ^ (restore_segment * 8 / 64 * 4096 + restore_row * 128 + restore_segment * 8 % 64 * 2 >> 7 & 7) << 4)) + (unsigned int)(word_3 * 4)), "r"((packed_2_1[word_3])));
+                            }
+                            unsigned int packed_3_1[4];
+                            #pragma unroll
+                            for (int _lp = 0; _lp < 4; _lp++) {
+                                __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(restore_kr_values[_lp*2 + 0], restore_kr_values[_lp*2+1 + 0]));
+                                packed_3_1[_lp] = *(uint32_t*)&_bf2;
+                            }
+                            #pragma unroll
+                            for (int word_4 = 0; word_4 < 4; word_4++) {
+                                asm volatile("st.shared.b32 [%0], %1;" :: "r"((smem_kr_trans_addr + prep_stage * 41984 + (unsigned int)(restore_segment * 8 / 64 * 4096 + restore_row * 128 + restore_segment * 8 % 64 * 2 ^ (restore_segment * 8 / 64 * 4096 + restore_row * 128 + restore_segment * 8 % 64 * 2 >> 7 & 7) << 4)) + (unsigned int)(word_4 * 4)), "r"((packed_3_1[word_4])));
+                            }
+                        }
+                    } else if (prep_local_warp == 1) {
+                        int stage_f32_0_1 = prep_stage * 10496;
+                        float restore_scale_1 = smem_restore_factor_all[stage_f32_0_1 + 128];
+                        float restore_factor_1[8];
+                        int restore_segment_1 = lane & 15;
+                        #pragma unroll
+                        for (int restore_elem_2 = 0; restore_elem_2 < 8; restore_elem_2++) {
+                            int restore_col_1 = restore_segment_1 * 8 + restore_elem_2;
+                            restore_factor_1[restore_elem_2] = smem_restore_factor_all[stage_f32_0_1 + restore_col_1];
+                        }
+                        #pragma unroll 1
+                        for (int restore_pass_1 = 0; restore_pass_1 < 4; restore_pass_1++) {
+                            int restore_row_1 = restore_pass_1 * 2 + (lane >> 4);
+                            float restore_qd_values_1[8];
+                            float restore_kd_values_1[8];
+                            float restore_ki_values_1[8];
+                            unsigned int packed_5[4];
+                            asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                                : "=r"(*reinterpret_cast<uint32_t*>(&packed_5[0])), "=r"(*reinterpret_cast<uint32_t*>(&packed_5[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&packed_5[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&packed_5[(0) + 3]))
+                                : "r"((smem_qd_addr + prep_stage * 41984 + (unsigned int)(restore_segment_1 * 8 / 64 * 4096 + restore_row_1 * 128 + restore_segment_1 * 8 % 64 * 2 ^ (restore_segment_1 * 8 / 64 * 4096 + restore_row_1 * 128 + restore_segment_1 * 8 % 64 * 2 >> 7 & 7) << 4))));
+                            float packed_f32_4[8];
+                            #pragma unroll
+                            for (int _pair = 0; _pair < 4; _pair++) {
+                                asm volatile(
+                                    "{\n\t"
+                                    "shl.b32 %0, %2, 16;\n\t"
+                                    "and.b32 %1, %2, 0xffff0000;\n\t"
+                                    "}\n"
+                                    : "=f"((&packed_f32_4[_pair * 2])[0]), "=f"((&packed_f32_4[_pair * 2])[1])
+                                    : "r"(packed_5[_pair]));
+                            }
+                            #pragma unroll
+                            for (int value_idx_7 = 0; value_idx_7 < 8; value_idx_7++) {
+                                restore_qd_values_1[value_idx_7] = packed_f32_4[value_idx_7];
+                            }
+                            unsigned int packed_0_3[4];
+                            asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                                : "=r"(*reinterpret_cast<uint32_t*>(&packed_0_3[0])), "=r"(*reinterpret_cast<uint32_t*>(&packed_0_3[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&packed_0_3[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&packed_0_3[(0) + 3]))
+                                : "r"((smem_kd_addr + prep_stage * 41984 + (unsigned int)(restore_segment_1 * 8 / 64 * 4096 + restore_row_1 * 128 + restore_segment_1 * 8 % 64 * 2 ^ (restore_segment_1 * 8 / 64 * 4096 + restore_row_1 * 128 + restore_segment_1 * 8 % 64 * 2 >> 7 & 7) << 4))));
+                            float packed_0_f32_2[8];
+                            #pragma unroll
+                            for (int _pair = 0; _pair < 4; _pair++) {
+                                asm volatile(
+                                    "{\n\t"
+                                    "shl.b32 %0, %2, 16;\n\t"
+                                    "and.b32 %1, %2, 0xffff0000;\n\t"
+                                    "}\n"
+                                    : "=f"((&packed_0_f32_2[_pair * 2])[0]), "=f"((&packed_0_f32_2[_pair * 2])[1])
+                                    : "r"(packed_0_3[_pair]));
+                            }
+                            #pragma unroll
+                            for (int value_idx_8 = 0; value_idx_8 < 8; value_idx_8++) {
+                                restore_kd_values_1[value_idx_8] = packed_0_f32_2[value_idx_8];
+                            }
+                            unsigned int packed_1_3[4];
+                            asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                                : "=r"(*reinterpret_cast<uint32_t*>(&packed_1_3[0])), "=r"(*reinterpret_cast<uint32_t*>(&packed_1_3[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&packed_1_3[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&packed_1_3[(0) + 3]))
+                                : "r"((smem_ki_addr + prep_stage * 41984 + (unsigned int)(restore_segment_1 * 8 / 64 * 4096 + restore_row_1 * 128 + restore_segment_1 * 8 % 64 * 2 ^ (restore_segment_1 * 8 / 64 * 4096 + restore_row_1 * 128 + restore_segment_1 * 8 % 64 * 2 >> 7 & 7) << 4))));
+                            float packed_1_f32_1[8];
+                            #pragma unroll
+                            for (int _pair = 0; _pair < 4; _pair++) {
+                                asm volatile(
+                                    "{\n\t"
+                                    "shl.b32 %0, %2, 16;\n\t"
+                                    "and.b32 %1, %2, 0xffff0000;\n\t"
+                                    "}\n"
+                                    : "=f"((&packed_1_f32_1[_pair * 2])[0]), "=f"((&packed_1_f32_1[_pair * 2])[1])
+                                    : "r"(packed_1_3[_pair]));
+                            }
+                            #pragma unroll
+                            for (int value_idx_9 = 0; value_idx_9 < 8; value_idx_9++) {
+                                restore_ki_values_1[value_idx_9] = packed_1_f32_1[value_idx_9];
+                            }
+                            {
+                                long long tape_scaled_index_1 = tape_scaled_base + (long long)restore_row_1 * 128 + (long long)(restore_segment_1 * 8);
+                                {
+                                    __nv_bfloat162 _pk[4];
+                                    _pk[0] = __floats2bfloat162_rn(restore_qd_values_1[0 + 0], restore_qd_values_1[0 + 1]);
+                                    _pk[1] = __floats2bfloat162_rn(restore_qd_values_1[0 + 2], restore_qd_values_1[0 + 3]);
+                                    _pk[2] = __floats2bfloat162_rn(restore_qd_values_1[0 + 4], restore_qd_values_1[0 + 5]);
+                                    _pk[3] = __floats2bfloat162_rn(restore_qd_values_1[0 + 6], restore_qd_values_1[0 + 7]);
+                                    *reinterpret_cast<uint4*>(&((__nv_bfloat16*)(tape_qd + tape_scaled_index_1))[0]) = *reinterpret_cast<uint4*>(&_pk[0]);
+                                }
+                                {
+                                    __nv_bfloat162 _pk[4];
+                                    _pk[0] = __floats2bfloat162_rn(restore_kd_values_1[0 + 0], restore_kd_values_1[0 + 1]);
+                                    _pk[1] = __floats2bfloat162_rn(restore_kd_values_1[0 + 2], restore_kd_values_1[0 + 3]);
+                                    _pk[2] = __floats2bfloat162_rn(restore_kd_values_1[0 + 4], restore_kd_values_1[0 + 5]);
+                                    _pk[3] = __floats2bfloat162_rn(restore_kd_values_1[0 + 6], restore_kd_values_1[0 + 7]);
+                                    *reinterpret_cast<uint4*>(&((__nv_bfloat16*)(tape_kd + tape_scaled_index_1))[0]) = *reinterpret_cast<uint4*>(&_pk[0]);
+                                }
+                            }
+                            float restore_kr_values_1[8];
+                            #pragma unroll
+                            for (int restore_elem_3 = 0; restore_elem_3 < 8; restore_elem_3++) {
+                                restore_kr_values_1[restore_elem_3] = restore_ki_values_1[restore_elem_3] * restore_factor_1[restore_elem_3];
+                            }
+                            const float2 _scale2_9 = {restore_scale_1, restore_scale_1};
+                            #pragma unroll
+                            for (int _ls = 0; _ls < 4; _ls++)
+                                mul_f32x2_inplace(&reinterpret_cast<float2*>(restore_qd_values_1)[_ls], _scale2_9);
+                            const float2 _scale2_10 = {restore_scale_1, restore_scale_1};
+                            #pragma unroll
+                            for (int _ls = 0; _ls < 4; _ls++)
+                                mul_f32x2_inplace(&reinterpret_cast<float2*>(restore_kd_values_1)[_ls], _scale2_10);
+                            unsigned int packed_2_2[4];
+                            #pragma unroll
+                            for (int _lp = 0; _lp < 4; _lp++) {
+                                __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(restore_kd_values_1[_lp*2 + 0], restore_kd_values_1[_lp*2+1 + 0]));
+                                packed_2_2[_lp] = *(uint32_t*)&_bf2;
+                            }
+                            #pragma unroll
+                            for (int word_5 = 0; word_5 < 4; word_5++) {
+                                asm volatile("st.shared.b32 [%0], %1;" :: "r"((smem_kd_addr + prep_stage * 41984 + (unsigned int)(restore_segment_1 * 8 / 64 * 4096 + restore_row_1 * 128 + restore_segment_1 * 8 % 64 * 2 ^ (restore_segment_1 * 8 / 64 * 4096 + restore_row_1 * 128 + restore_segment_1 * 8 % 64 * 2 >> 7 & 7) << 4)) + (unsigned int)(word_5 * 4)), "r"((packed_2_2[word_5])));
+                            }
+                            unsigned int packed_3_2[4];
+                            #pragma unroll
+                            for (int _lp = 0; _lp < 4; _lp++) {
+                                __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(restore_kr_values_1[_lp*2 + 0], restore_kr_values_1[_lp*2+1 + 0]));
+                                packed_3_2[_lp] = *(uint32_t*)&_bf2;
+                            }
+                            #pragma unroll
+                            for (int word_6 = 0; word_6 < 4; word_6++) {
+                                asm volatile("st.shared.b32 [%0], %1;" :: "r"((smem_kr_trans_addr + prep_stage * 41984 + (unsigned int)(restore_segment_1 * 8 / 64 * 4096 + restore_row_1 * 128 + restore_segment_1 * 8 % 64 * 2 ^ (restore_segment_1 * 8 / 64 * 4096 + restore_row_1 * 128 + restore_segment_1 * 8 % 64 * 2 >> 7 & 7) << 4)) + (unsigned int)(word_6 * 4)), "r"((packed_3_2[word_6])));
+                            }
+                        }
+                    }
+                }
+                if (prep_local_warp == 0) {
+                    int inverse_row = lane;
+                    int diag_block = inverse_row / 8;
+                    int lane_in_diag = lane & 7;
+                    float inv_row[8];
+                    {
+                        unsigned int packed_6[4];
+                        int byte_off_1 = (int)prep_stage * 41984 + inverse_row * 128 + diag_block * 8 * 2;
+                        int swizzled_off_1 = byte_off_1 ^ (byte_off_1 >> 7 & 7) << 4;
+                        asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                            : "=r"(*reinterpret_cast<uint32_t*>(&packed_6[0])), "=r"(*reinterpret_cast<uint32_t*>(&packed_6[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&packed_6[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&packed_6[(0) + 3]))
+                            : "r"(smem_inv_work_addr + (unsigned int)swizzled_off_1));
+                        float packed_f32_5[8];
+                        #pragma unroll
+                        for (int _pair = 0; _pair < 4; _pair++) {
+                            asm volatile(
+                                "{\n\t"
+                                "shl.b32 %0, %2, 16;\n\t"
+                                "and.b32 %1, %2, 0xffff0000;\n\t"
+                                "}\n"
+                                : "=f"((&packed_f32_5[_pair * 2])[0]), "=f"((&packed_f32_5[_pair * 2])[1])
+                                : "r"(packed_6[_pair]));
+                        }
+                        #pragma unroll
+                        for (int value_idx_10 = 0; value_idx_10 < 8; value_idx_10++) {
+                            inv_row[value_idx_10] = packed_f32_5[value_idx_10];
+                        }
+                    }
+                    #pragma unroll
+                    for (int diag_elem = 0; diag_elem < 8; diag_elem++) {
+                        if (lane_in_diag == diag_elem) {
+                            inv_row[diag_elem] = 1.0f;
+                        }
+                    }
+                    int diag_group_base = lane - lane_in_diag;
+                    #pragma unroll
+                    for (int src_row = 0; src_row < 7; src_row++) {
+                        float row_scale = -inv_row[src_row];
+                        #pragma unroll
+                        for (int prev_col = 0; prev_col < src_row; prev_col++) {
+                            int pivot_lane = diag_group_base + src_row;
+                            float _shfl_0 = __shfl_sync(0xFFFFFFFF, inv_row[prev_col], pivot_lane);
+                            float pivot = _shfl_0;
+                            if (lane_in_diag > src_row) {
+                                float _fma_2 = __fmaf_rn(row_scale, pivot, inv_row[prev_col]);
+                                inv_row[prev_col] = _fma_2;
+                            }
+                        }
+                        if (lane_in_diag > src_row) {
+                            inv_row[src_row] = row_scale;
+                        }
+                    }
+                    {
+                        unsigned int packed_7[4];
+                        #pragma unroll
+                        for (int _lp = 0; _lp < 4; _lp++) {
+                            __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(inv_row[_lp*2 + 0], inv_row[_lp*2+1 + 0]));
+                            packed_7[_lp] = *(uint32_t*)&_bf2;
+                        }
+                        int byte_off_2 = (int)prep_stage * 41984 + inverse_row * 128 + diag_block * 8 * 2;
+                        int swizzled_off_2 = byte_off_2 ^ (byte_off_2 >> 7 & 7) << 4;
+                        #pragma unroll
+                        for (int word_7 = 0; word_7 < 4; word_7++) {
+                            asm volatile("st.shared.b32 [%0], %1;" :: "r"(smem_inv_work_addr + (unsigned int)swizzled_off_2 + (unsigned int)(word_7 * 4)), "r"((packed_7[word_7])));
+                        }
+                    }
+                }
+                if (prep_local_warp < 2) {
+                    __syncwarp();
+                    if (elect_sync()) {
+                        mbarrier_arrive(prep_diag_ready_addr + (prep_stage) * 8);
+                    }
+                    mbarrier_wait(prep_diag_ready_addr + (prep_stage) * 8, _phase_prep_diag_ready);
+                }
+                {
+                    if (prep_local_warp < 2) {
+                        int lane_row = lane & 7;
+                        int byte_off_3 = (int)prep_stage * 41984 + (prep_local_warp * 16 + 8 + lane_row) * 128 + (prep_local_warp * 16 + 8) * 2;
+                        int swizzled_off_3 = byte_off_3 ^ (byte_off_3 >> 7 & 7) << 4;
+                        int d_addr = smem_inv_work_addr + (unsigned int)swizzled_off_3;
+                        int byte_off_0 = (int)prep_stage * 41984 + (prep_local_warp * 16 + 8 + lane_row) * 128 + prep_local_warp * 16 * 2;
+                        int swizzled_off_1_1 = byte_off_0 ^ (byte_off_0 >> 7 & 7) << 4;
+                        int c_addr = smem_inv_work_addr + (unsigned int)swizzled_off_1_1;
+                        int byte_off_2_1 = (int)prep_stage * 41984 + (prep_local_warp * 16 + lane_row) * 128 + prep_local_warp * 16 * 2;
+                        int swizzled_off_3_1 = byte_off_2_1 ^ (byte_off_2_1 >> 7 & 7) << 4;
+                        int a_addr = smem_inv_work_addr + (unsigned int)swizzled_off_3_1;
+                        unsigned int d_frag[2];
+                        unsigned int c_frag[1];
+                        float dc_acc[4];
+                        unsigned int dc_bf16[2];
+                        unsigned int inv_a_frag[1];
+                        float o_acc[4];
+                        unsigned int o_bf16[2];
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x1.shared.b16 {%0}, [%1];\n"
+                            : "=r"(d_frag[0])
+                            : "r"(d_addr)
+                            : "memory");
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x1.shared.b16 {%0}, [%1];\n"
+                            : "=r"(d_frag[1])
+                            : "r"(d_addr)
+                            : "memory");
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x1.trans.shared.b16 {%0}, [%1];\n"
+                            : "=r"(c_frag[0])
+                            : "r"(c_addr)
+                            : "memory");
+                        asm volatile("mma.sync.aligned.m16n8k8.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5}, {%6}, {0f00000000, 0f00000000, 0f00000000, 0f00000000};\n"
+                            : "=f"(dc_acc[0]), "=f"(dc_acc[1]), "=f"(dc_acc[2]), "=f"(dc_acc[3])
+                            : "r"(d_frag[0]), "r"(d_frag[1]), "r"(c_frag[0]));
+                        const float2 _scale2_11 = {-1.0f, -1.0f};
+                        #pragma unroll
+                        for (int _ls = 0; _ls < 2; _ls++)
+                            mul_f32x2_inplace(&reinterpret_cast<float2*>(dc_acc)[_ls], _scale2_11);
+                        #pragma unroll
+                        for (int _lp = 0; _lp < 2; _lp++) {
+                            __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(dc_acc[_lp*2 + 0], dc_acc[_lp*2+1 + 0]));
+                            dc_bf16[_lp] = *(uint32_t*)&_bf2;
+                        }
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x1.trans.shared.b16 {%0}, [%1];\n"
+                            : "=r"(inv_a_frag[0])
+                            : "r"(a_addr)
+                            : "memory");
+                        asm volatile("mma.sync.aligned.m16n8k8.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5}, {%6}, {0f00000000, 0f00000000, 0f00000000, 0f00000000};\n"
+                            : "=f"(o_acc[0]), "=f"(o_acc[1]), "=f"(o_acc[2]), "=f"(o_acc[3])
+                            : "r"(dc_bf16[0]), "r"(dc_bf16[1]), "r"(inv_a_frag[0]));
+                        #pragma unroll
+                        for (int _lp = 0; _lp < 2; _lp++) {
+                            __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(o_acc[_lp*2 + 0], o_acc[_lp*2+1 + 0]));
+                            o_bf16[_lp] = *(uint32_t*)&_bf2;
+                        }
+                        int byte_off_4 = (int)prep_stage * 41984 + (prep_local_warp * 16 + 8 + lane_row) * 128 + prep_local_warp * 16 * 2;
+                        int swizzled_off_5 = byte_off_4 ^ (byte_off_4 >> 7 & 7) << 4;
+                        int o_addr = smem_inv_work_addr + (unsigned int)swizzled_off_5;
+                        uint32_t _stmatrix_addr_12 = static_cast<uint32_t>((unsigned long long)o_addr);
+                        asm volatile("stmatrix.sync.aligned.m8n8.x1.shared.b16 [%0], {%1};\n"
+                            :: "r"(_stmatrix_addr_12), "r"(*reinterpret_cast<const uint32_t*>(&o_bf16[0]))
+                            : "memory");
+                        __syncwarp();
+                        if (elect_sync()) {
+                            mbarrier_arrive(prep_inv16_ready_addr + (prep_stage) * 8);
+                        }
+                        mbarrier_wait(prep_inv16_ready_addr + (prep_stage) * 8, _phase_prep_inv16_ready);
+                    }
+                }
+                {
+                    if (prep_local_warp == 0) {
+                        int lane_row_1 = lane % 16;
+                        int lane_col = lane / 16 * 8;
+                        int byte_off_5 = (int)prep_stage * 41984 + (16 + lane_row_1) * 128 + (16 + lane_col) * 2;
+                        int swizzled_off_4 = byte_off_5 ^ (byte_off_5 >> 7 & 7) << 4;
+                        int d_addr_1 = smem_inv_work_addr + (unsigned int)swizzled_off_4;
+                        int byte_off_0_1 = (int)prep_stage * 41984 + (16 + lane_row_1) * 128 + lane_col * 2;
+                        int swizzled_off_1_2 = byte_off_0_1 ^ (byte_off_0_1 >> 7 & 7) << 4;
+                        int c_addr_1 = smem_inv_work_addr + (unsigned int)swizzled_off_1_2;
+                        int byte_off_2_2 = (int)prep_stage * 41984 + lane_row_1 * 128 + lane_col * 2;
+                        int swizzled_off_3_2 = byte_off_2_2 ^ (byte_off_2_2 >> 7 & 7) << 4;
+                        int a_addr_1 = smem_inv_work_addr + (unsigned int)swizzled_off_3_2;
+                        unsigned int d32_frag[4];
+                        unsigned int c32_frag[4];
+                        float dc32_acc[8];
+                        unsigned int dc32_bf16[4];
+                        unsigned int a32_frag[4];
+                        float o32_acc[8];
+                        unsigned int o32_bf16[4];
+                        unsigned int zero32_bf16[4];
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(d32_frag[0]), "=r"(d32_frag[1]), "=r"(d32_frag[2]), "=r"(d32_frag[3])
+                            : "r"(d_addr_1)
+                            : "memory");
+                        int d_publish_addr = (smem_inv_addr + prep_stage * 41984 + (unsigned int)((16 + lane_col) / 16 * 1024 + (16 + lane_row_1) * 32 + (16 + lane_col) % 16 * 2 ^ ((16 + lane_col) / 16 * 1024 + (16 + lane_row_1) * 32 + (16 + lane_col) % 16 * 2 >> 7 & 1) << 4));
+                        uint32_t _stmatrix_addr_13 = static_cast<uint32_t>((unsigned long long)d_publish_addr);
+                        asm volatile("stmatrix.sync.aligned.m8n8.x4.shared.b16 [%0], {%1, %2, %3, %4};\n"
+                            :: "r"(_stmatrix_addr_13), "r"(*reinterpret_cast<const uint32_t*>(&d32_frag[0])), "r"(*reinterpret_cast<const uint32_t*>(&d32_frag[1])), "r"(*reinterpret_cast<const uint32_t*>(&d32_frag[2])), "r"(*reinterpret_cast<const uint32_t*>(&d32_frag[3]))
+                            : "memory");
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.trans.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(c32_frag[0]), "=r"(c32_frag[1]), "=r"(c32_frag[2]), "=r"(c32_frag[3])
+                            : "r"(c_addr_1)
+                            : "memory");
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {0f00000000, 0f00000000, 0f00000000, 0f00000000};\n"
+                            : "=f"(dc32_acc[0]), "=f"(dc32_acc[1]), "=f"(dc32_acc[2]), "=f"(dc32_acc[3])
+                            : "r"(d32_frag[0]), "r"(d32_frag[1]), "r"(d32_frag[2]), "r"(d32_frag[3]), "r"(c32_frag[0]), "r"(c32_frag[1]));
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {0f00000000, 0f00000000, 0f00000000, 0f00000000};\n"
+                            : "=f"(dc32_acc[4]), "=f"(dc32_acc[(4) + 1]), "=f"(dc32_acc[(4) + 2]), "=f"(dc32_acc[(4) + 3])
+                            : "r"(d32_frag[0]), "r"(d32_frag[1]), "r"(d32_frag[2]), "r"(d32_frag[3]), "r"(c32_frag[2]), "r"(c32_frag[(2) + 1]));
+                        const float2 _scale2_14 = {-1.0f, -1.0f};
+                        #pragma unroll
+                        for (int _ls = 0; _ls < 4; _ls++)
+                            mul_f32x2_inplace(&reinterpret_cast<float2*>(dc32_acc)[_ls], _scale2_14);
+                        #pragma unroll
+                        for (int _lp = 0; _lp < 4; _lp++) {
+                            __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(dc32_acc[_lp*2 + 0], dc32_acc[_lp*2+1 + 0]));
+                            dc32_bf16[_lp] = *(uint32_t*)&_bf2;
+                        }
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.trans.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(a32_frag[0]), "=r"(a32_frag[1]), "=r"(a32_frag[2]), "=r"(a32_frag[3])
+                            : "r"(a_addr_1)
+                            : "memory");
+                        int a_publish_addr = (smem_inv_addr + prep_stage * 41984 + (unsigned int)(lane_col / 16 * 1024 + lane_row_1 * 32 + lane_col % 16 * 2 ^ (lane_col / 16 * 1024 + lane_row_1 * 32 + lane_col % 16 * 2 >> 7 & 1) << 4));
+                        uint32_t _stmatrix_addr_15 = static_cast<uint32_t>((unsigned long long)a_publish_addr);
+                        asm volatile("stmatrix.sync.aligned.m8n8.x4.trans.shared.b16 [%0], {%1, %2, %3, %4};\n"
+                            :: "r"(_stmatrix_addr_15), "r"(*reinterpret_cast<const uint32_t*>(&a32_frag[0])), "r"(*reinterpret_cast<const uint32_t*>(&a32_frag[1])), "r"(*reinterpret_cast<const uint32_t*>(&a32_frag[2])), "r"(*reinterpret_cast<const uint32_t*>(&a32_frag[3]))
+                            : "memory");
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {0f00000000, 0f00000000, 0f00000000, 0f00000000};\n"
+                            : "=f"(o32_acc[0]), "=f"(o32_acc[1]), "=f"(o32_acc[2]), "=f"(o32_acc[3])
+                            : "r"(dc32_bf16[0]), "r"(dc32_bf16[1]), "r"(dc32_bf16[2]), "r"(dc32_bf16[3]), "r"(a32_frag[0]), "r"(a32_frag[1]));
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {0f00000000, 0f00000000, 0f00000000, 0f00000000};\n"
+                            : "=f"(o32_acc[4]), "=f"(o32_acc[(4) + 1]), "=f"(o32_acc[(4) + 2]), "=f"(o32_acc[(4) + 3])
+                            : "r"(dc32_bf16[0]), "r"(dc32_bf16[1]), "r"(dc32_bf16[2]), "r"(dc32_bf16[3]), "r"(a32_frag[2]), "r"(a32_frag[(2) + 1]));
+                        #pragma unroll
+                        for (int _lp = 0; _lp < 4; _lp++) {
+                            __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(o32_acc[_lp*2 + 0], o32_acc[_lp*2+1 + 0]));
+                            o32_bf16[_lp] = *(uint32_t*)&_bf2;
+                        }
+                        int o_publish_addr = (smem_inv_addr + prep_stage * 41984 + (unsigned int)(lane_col / 16 * 1024 + (16 + lane_row_1) * 32 + lane_col % 16 * 2 ^ (lane_col / 16 * 1024 + (16 + lane_row_1) * 32 + lane_col % 16 * 2 >> 7 & 1) << 4));
+                        uint32_t _stmatrix_addr_16 = static_cast<uint32_t>((unsigned long long)o_publish_addr);
+                        asm volatile("stmatrix.sync.aligned.m8n8.x4.shared.b16 [%0], {%1, %2, %3, %4};\n"
+                            :: "r"(_stmatrix_addr_16), "r"(*reinterpret_cast<const uint32_t*>(&o32_bf16[0])), "r"(*reinterpret_cast<const uint32_t*>(&o32_bf16[1])), "r"(*reinterpret_cast<const uint32_t*>(&o32_bf16[2])), "r"(*reinterpret_cast<const uint32_t*>(&o32_bf16[3]))
+                            : "memory");
+                        #pragma unroll
+                        for (int zero_word = 0; zero_word < 4; zero_word++) {
+                            zero32_bf16[zero_word] = 0;
+                        }
+                        int zero_publish_addr = (smem_inv_addr + prep_stage * 41984 + (unsigned int)((16 + lane_col) / 16 * 1024 + lane_row_1 * 32 + (16 + lane_col) % 16 * 2 ^ ((16 + lane_col) / 16 * 1024 + lane_row_1 * 32 + (16 + lane_col) % 16 * 2 >> 7 & 1) << 4));
+                        uint32_t _stmatrix_addr_17 = static_cast<uint32_t>((unsigned long long)zero_publish_addr);
+                        asm volatile("stmatrix.sync.aligned.m8n8.x4.shared.b16 [%0], {%1, %2, %3, %4};\n"
+                            :: "r"(_stmatrix_addr_17), "r"(*reinterpret_cast<const uint32_t*>(&zero32_bf16[0])), "r"(*reinterpret_cast<const uint32_t*>(&zero32_bf16[1])), "r"(*reinterpret_cast<const uint32_t*>(&zero32_bf16[2])), "r"(*reinterpret_cast<const uint32_t*>(&zero32_bf16[3]))
+                            : "memory");
+                    }
+                }
+                asm volatile("fence.proxy.async.shared::cta;" ::: "memory");
+                asm volatile("barrier.sync %0, 128;" :: "r"(10 + prep_instance) : "memory");
+                if (prep_local_warp == 0) {
+                    if (elect_sync()) {
+                        mbarrier_arrive(qk_full_addr + (prep_stage) * 8);
+                        {
+                            mbarrier_arrive(tape_ready_addr + (prep_stage) * 8);
+                        }
+                    }
+                }
+                {
+                    mbarrier_wait(tape_free_addr + (prep_stage) * 8, _phase_tape_free);
+                }
+                if (chunk_is_full_1 != 0) {
+                    if (prep_local_warp == 0) {
+                        if (elect_sync()) {
+                            mbarrier_arrive_expect_tx(v_full_addr + (prep_stage) * 8, 8192);
+                            tma_3d_gmem2smem(smem_v_addr + prep_stage * 41984, v_tma, 0, head_idx_3, (int)(bos_4 + (long long)(chunk_idx_3 * 32)), v_full_addr + (prep_stage) * 8);
+                        }
+                    }
+                } else {
+                    #pragma unroll
+                    for (int v_load_iter = 0; v_load_iter < 4; v_load_iter++) {
+                        int v_item = v_load_iter * 128 + prep_tid;
+                        int row_1 = v_item / 16;
+                        int segment_1 = v_item % 16;
+                        long long token_1 = bos_4 + (long long)(chunk_idx_3 * 32 + row_1);
+                        int token_valid_1 = ((token_1 < eos_4) ? 1 : 0);
+                        long long v_src = (token_1 * (long long)num_heads + (long long)head_idx_3) * 128 + (long long)(segment_1 * 8);
+                        asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16, %2;"
+                            :: "r"(smem_v_addr + prep_stage * 41984 + (unsigned int)((row_1 * 128 + segment_1 * 8) * 2)), "l"(v + v_src), "r"((token_valid_1 != 0) ? 16 : 0));
+                    }
+                    asm volatile("cp.async.commit_group;");
+                    asm volatile("cp.async.wait_group 0;");
+                    asm volatile("barrier.sync %0, 128;" :: "r"(10 + prep_instance) : "memory");
+                    if (prep_local_warp == 0) {
+                        if (elect_sync()) {
+                            asm volatile("fence.proxy.async.shared::cta;" ::: "memory");
+                            mbarrier_arrive(v_full_addr + (prep_stage) * 8);
+                        }
+                    }
+                }
+                for (int _advance = 0; _advance < 5; _advance++) {
+                    prep_stage += 1;
+                    if (prep_stage == 5) { prep_stage = 0; _phase_raw_inputs_free ^= 1; _phase_gate_raw_full ^= 1; _phase_smem_free ^= 1; _phase_v_free ^= 1; _phase_qk_raw_full ^= 1; _phase_prep_diag_ready ^= 1; _phase_prep_inv16_ready ^= 1; _phase_tape_free ^= 1; }
+                }
+            }
+        }
+    }
+
+    // Cleanup
+}
+
+} // extern "C"
+
+#undef FLASHKDA_INF
+#undef NUM_CHUNK_PIPE_STAGES
+#undef SMEM_SMEM_BETA_RAW_OFF
+#undef SMEM_SMEM_BETA_RAW_STAGE_BYTES
+#undef SMEM_SMEM_BETA_RAW_STRIDE
+#undef SMEM_SMEM_FINAL_TRANS_OFF
+#undef SMEM_SMEM_FINAL_TRANS_STAGE_BYTES
+#undef SMEM_SMEM_FINAL_TRANS_STRIDE
+#undef SMEM_SMEM_GATE_ALL_OFF
+#undef SMEM_SMEM_GATE_ALL_STAGE_BYTES
+#undef SMEM_SMEM_GATE_ALL_STRIDE
+#undef SMEM_SMEM_GATE_OFF
+#undef SMEM_SMEM_GATE_RATE_ALL_OFF
+#undef SMEM_SMEM_GATE_RATE_ALL_STAGE_BYTES
+#undef SMEM_SMEM_GATE_RATE_ALL_STRIDE
+#undef SMEM_SMEM_GATE_STAGE_BYTES
+#undef SMEM_SMEM_GATE_STRIDE
+#undef SMEM_SMEM_GT_ALL_OFF
+#undef SMEM_SMEM_GT_ALL_STAGE_BYTES
+#undef SMEM_SMEM_GT_ALL_STRIDE
+#undef SMEM_SMEM_GT_PREFIX_ALL_OFF
+#undef SMEM_SMEM_GT_PREFIX_ALL_STAGE_BYTES
+#undef SMEM_SMEM_GT_PREFIX_ALL_STRIDE
+#undef SMEM_SMEM_G_RAW_ALL_OFF
+#undef SMEM_SMEM_G_RAW_ALL_STAGE_BYTES
+#undef SMEM_SMEM_G_RAW_ALL_STRIDE
+#undef SMEM_SMEM_G_RAW_OFF
+#undef SMEM_SMEM_G_RAW_STAGE_BYTES
+#undef SMEM_SMEM_G_RAW_STRIDE
+#undef SMEM_SMEM_INV_OFF
+#undef SMEM_SMEM_INV_STAGE_BYTES
+#undef SMEM_SMEM_INV_STRIDE
+#undef SMEM_SMEM_INV_WORK_OFF
+#undef SMEM_SMEM_INV_WORK_STAGE_BYTES
+#undef SMEM_SMEM_INV_WORK_STRIDE
+#undef SMEM_SMEM_KD_OFF
+#undef SMEM_SMEM_KD_STAGE_BYTES
+#undef SMEM_SMEM_KD_STRIDE
+#undef SMEM_SMEM_KI_OFF
+#undef SMEM_SMEM_KI_STAGE_BYTES
+#undef SMEM_SMEM_KI_STRIDE
+#undef SMEM_SMEM_KR_TRANS_OFF
+#undef SMEM_SMEM_KR_TRANS_STAGE_BYTES
+#undef SMEM_SMEM_KR_TRANS_STRIDE
+#undef SMEM_SMEM_MQK_TRANS_OFF
+#undef SMEM_SMEM_MQK_TRANS_STAGE_BYTES
+#undef SMEM_SMEM_MQK_TRANS_STRIDE
+#undef SMEM_SMEM_OUT_OFF
+#undef SMEM_SMEM_OUT_STAGE_BYTES
+#undef SMEM_SMEM_OUT_STRIDE
+#undef SMEM_SMEM_PREP_BETA_ALL_OFF
+#undef SMEM_SMEM_PREP_BETA_ALL_STAGE_BYTES
+#undef SMEM_SMEM_PREP_BETA_ALL_STRIDE
+#undef SMEM_SMEM_QD_OFF
+#undef SMEM_SMEM_QD_STAGE_BYTES
+#undef SMEM_SMEM_QD_STRIDE
+#undef SMEM_SMEM_Q_RAW_PREFETCH_OFF
+#undef SMEM_SMEM_Q_RAW_PREFETCH_STAGE_BYTES
+#undef SMEM_SMEM_Q_RAW_PREFETCH_STRIDE
+#undef SMEM_SMEM_RESTORE_FACTOR_ALL_OFF
+#undef SMEM_SMEM_RESTORE_FACTOR_ALL_STAGE_BYTES
+#undef SMEM_SMEM_RESTORE_FACTOR_ALL_STRIDE
+#undef SMEM_SMEM_STATE_CHECKPOINT_NEEDED_OFF
+#undef SMEM_SMEM_STATE_CHECKPOINT_NEEDED_STAGE_BYTES
+#undef SMEM_SMEM_STATE_CHECKPOINT_NEEDED_STRIDE
+#undef SMEM_SMEM_V_ALL_OFF
+#undef SMEM_SMEM_V_ALL_STAGE_BYTES
+#undef SMEM_SMEM_V_ALL_STRIDE
+#undef SMEM_SMEM_V_OFF
+#undef SMEM_SMEM_V_STAGE_BYTES
+#undef SMEM_SMEM_V_STRIDE
+#undef SMEM_TOTAL
+#undef STORE_BACKWARD_TAPE
+#undef STORE_E_TAPE
+#undef THREADS
+#undef TMEM_NCOLS
+#undef TMEM_TMEM_OUT_OFFSET
+#undef TMEM_TMEM_STATE_INP_OFFSET
+#undef TMEM_TMEM_STATE_OFFSET
+#undef TMEM_TMEM_STATE_OUT_OFFSET
+#undef TMEM_TMEM_U2_ACC_OFFSET
+#undef TMEM_TMEM_U2_INP_OFFSET
+#undef TMEM_TMEM_U_ACC_OFFSET
+#undef final_ready_addr
+#undef gate_raw_full_addr
+#undef old_out_ready_addr
+#undef out_empty_addr
+#undef prep_diag_ready_addr
+#undef prep_inv16_ready_addr
+#undef qk_full_addr
+#undef qk_raw_full_addr
+#undef raw_inputs_free_addr
+#undef smem_beta_raw_addr
+#undef smem_final_trans_addr
+#undef smem_free_addr
+#undef smem_g_raw_addr
+#undef smem_g_raw_all_addr
+#undef smem_gate_addr
+#undef smem_gate_all_addr
+#undef smem_gate_rate_all_addr
+#undef smem_gt_all_addr
+#undef smem_gt_prefix_all_addr
+#undef smem_inv_addr
+#undef smem_inv_work_addr
+#undef smem_kd_addr
+#undef smem_ki_addr
+#undef smem_kr_trans_addr
+#undef smem_mqk_trans_addr
+#undef smem_out_addr
+#undef smem_prep_beta_all_addr
+#undef smem_q_raw_prefetch_addr
+#undef smem_qd_addr
+#undef smem_restore_factor_all_addr
+#undef smem_state_checkpoint_needed_addr
+#undef smem_v_addr
+#undef smem_v_all_addr
+#undef state_inp_ready_addr
+#undef tape_free_addr
+#undef tape_ready_addr
+#undef tmem_dealloc_ready_addr
+#undef u2_acc_ready_addr
+#undef u2_inp_ready_addr
+#undef u_inp_ready_addr
+#undef v_free_addr
+#undef v_full_addr
+
+#define FLASHKDA_INF CUDART_INF_F
+#define NUM_MAIN_STAGES 1
+#define SMEM_ANY_FALLBACK_OFF 0
+#define SMEM_ANY_FALLBACK_STAGE_BYTES 4
+#define SMEM_ANY_FALLBACK_STRIDE 4
+#define SMEM_TOTAL 128
+#define THREADS 256
+#define C 32
+#define K 128
+#define V 128
+
+extern "C" {
+
+__global__ __launch_bounds__(256) void
+kernel_flashkda_backward_state_checkpoint_fallback_c32(long long* __restrict__ cu_seqlens, long long* __restrict__ cu_chunk_offsets, unsigned int* __restrict__ state_checkpoint_needed, float* __restrict__ initial_state, __nv_bfloat16* __restrict__ tape_kr, float* __restrict__ tape_restore_factor, __nv_bfloat16* __restrict__ tape_r, __nv_bfloat16* __restrict__ chunk_state, int num_sequences, int num_heads, float lower_bound)
+{
+    const int tid = threadIdx.x;
+    const int warp = make_warp_uniform(tid / 32);
+    const int lane = tid % 32;
+
+    extern __shared__ __align__(1024) char smem_raw[];
+    int smem;
+    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+
+    const int bid = blockIdx.x;
+    const int num_bids = gridDim.x;
+
+    // Kernel setup ops
+    unsigned int* any_fallback = reinterpret_cast<unsigned int*>(smem_raw + 0);
+    const int any_fallback_addr = smem + 0;
+
+    // === Task calls (dependency order) ===
+    long long total_chunks = cu_chunk_offsets[num_sequences];
+    int num_tasks = num_sequences * num_heads;
+    if (tid == 0) {
+        any_fallback[0] = 0;
+    }
+    asm volatile("barrier.sync 1, 256;" ::: "memory");
+    #pragma unroll 1
+    for (int scan_task = tid; scan_task < num_tasks; scan_task += 256) {
+        if (state_checkpoint_needed[total_chunks * (long long)num_heads + (long long)scan_task] != 0) {
+            atomicAdd(&any_fallback[0], 1);
+        }
+    }
+    asm volatile("barrier.sync 2, 256;" ::: "memory");
+    if (any_fallback[0] != 0) {
+        #pragma unroll 1
+        for (int task = 0; task < num_tasks; task++) {
+            int sequence = task / num_heads;
+            int head = task - sequence * num_heads;
+            unsigned int head_fallback_needed = state_checkpoint_needed[total_chunks * (long long)num_heads + (long long)task];
+            if (head_fallback_needed != 0) {
+                long long bos = cu_seqlens[sequence];
+                long long eos = cu_seqlens[sequence + 1];
+                int num_chunks = ((int)(eos - bos) + C - 1) / C;
+                int key_base = lane * 4;
+                long long initial_base = ((long long)sequence * (long long)num_heads + (long long)head) * (long long)V * (long long)K;
+                float _expf_0 = __expf(lower_bound * (float)(C / 2));
+                float common_decay = _expf_0;
+                int warp_id_in_role = (warp - 0);
+                #pragma unroll 1
+                for (int value_row = warp_id_in_role; value_row < V; value_row += 8) {
+                    float state[4];
+                    long long initial_row_base = initial_base + (long long)value_row * (long long)K + (long long)key_base;
+                    {
+                        float4 _v4 = *reinterpret_cast<const float4*>(initial_state + initial_row_base);
+                        state[0 + 0] = _v4.x;
+                        state[0 + 1] = _v4.y;
+                        state[0 + 2] = _v4.z;
+                        state[0 + 3] = _v4.w;
+                    }
+                    #pragma unroll
+                    for (int key_elem = 0; key_elem < 4; key_elem++) {
+                        __nv_bfloat16 _cvt_bf16_0 = __float2bfloat16(state[key_elem]);
+                        float _cvt_f32_0 = __bfloat162float(_cvt_bf16_0);
+                        state[key_elem] = _cvt_f32_0;
+                    }
+                    #pragma unroll 1
+                    for (int local_chunk = 0; local_chunk < num_chunks; local_chunk++) {
+                        long long chunk_global = cu_chunk_offsets[sequence] + (long long)local_chunk;
+                        long long chunk_head = chunk_global * (long long)num_heads + (long long)head;
+                        long long restore_base = chunk_head * (long long)K + (long long)key_base;
+                        float restore_values[4];
+                        {
+                            float4 _v4 = *reinterpret_cast<const float4*>(tape_restore_factor + restore_base);
+                            restore_values[0 + 0] = _v4.x;
+                            restore_values[0 + 1] = _v4.y;
+                            restore_values[0 + 2] = _v4.z;
+                            restore_values[0 + 3] = _v4.w;
+                        }
+                        #pragma unroll
+                        for (int key_elem2 = 0; key_elem2 < 4; key_elem2++) {
+                            state[key_elem2] = state[key_elem2] * (restore_values[key_elem2] * common_decay);
+                        }
+                        long long kr_base = chunk_head * (long long)C * (long long)K + (long long)key_base;
+                        long long r_base = (chunk_head * (long long)V + (long long)value_row) * (long long)C;
+                        #pragma unroll
+                        for (int token_local = 0; token_local < C; token_local++) {
+                            float kr_values[4];
+                            {
+                                uint2 _vld_2;
+                                _vld_2 = *reinterpret_cast<const uint2*>(tape_kr + kr_base + (long long)(token_local * K));
+                                uint32_t* _vpairs_2 = reinterpret_cast<uint32_t*>(&_vld_2);
+                                #pragma unroll
+                                for (int _pair = 0; _pair < 2; _pair++) {
+                                    asm volatile(
+                                        "{\n\t"
+                                        "shl.b32 %0, %2, 16;\n\t"
+                                        "and.b32 %1, %2, 0xffff0000;\n\t"
+                                        "}\n"
+                                        : "=f"((&kr_values[0 + _pair * 2])[0]), "=f"((&kr_values[0 + _pair * 2])[1])
+                                        : "r"(_vpairs_2[_pair]));
+                                }
+                            }
+                            float r_value = (float)tape_r[r_base + (long long)token_local];
+                            #pragma unroll
+                            for (int key_elem3 = 0; key_elem3 < 4; key_elem3++) {
+                                float _fma_0 = __fmaf_rn(r_value, kr_values[key_elem3], state[key_elem3]);
+                                state[key_elem3] = _fma_0;
+                            }
+                        }
+                        if (num_chunks > local_chunk + 1) {
+                            long long next_chunk_global = chunk_global + 1;
+                            long long next_chunk_head = next_chunk_global * (long long)num_heads + (long long)head;
+                            if (state_checkpoint_needed[next_chunk_head] != 0) {
+                                long long checkpoint_base = (next_chunk_head * (long long)V + (long long)value_row) * (long long)K + (long long)key_base;
+                                {
+                                    uint2 _pk2;
+                                    __nv_bfloat162* _pk = reinterpret_cast<__nv_bfloat162*>(&_pk2);
+                                    _pk[0] = __floats2bfloat162_rn(state[0 + 0], state[0 + 1]);
+                                    _pk[1] = __floats2bfloat162_rn(state[0 + 2], state[0 + 3]);
+                                    *reinterpret_cast<uint2*>(&((__nv_bfloat16*)(chunk_state + checkpoint_base))[0]) = _pk2;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+} // extern "C"
+
+#undef C
+#undef K
+#undef FLASHKDA_INF
+#undef NUM_MAIN_STAGES
+#undef SMEM_ANY_FALLBACK_OFF
+#undef SMEM_ANY_FALLBACK_STAGE_BYTES
+#undef SMEM_ANY_FALLBACK_STRIDE
+#undef SMEM_TOTAL
+#undef THREADS
+#undef V
+#undef any_fallback_addr
+
+#define FLASHKDA_INF CUDART_INF_F
+#define TMEM_NCOLS 256
+#define TMEM_TMEM_DH_OFFSET 64
+#define TMEM_TMEM_DH_INP_OFFSET 0
+#define TMEM_TMEM_DO_INITIAL_OFFSET 224
+#define TMEM_TMEM_DO_FINAL_OFFSET 0
+#define TMEM_TMEM_DR_OFFSET 192
+#define TMEM_TMEM_DR_INP_OFFSET 192
+#define TMEM_TMEM_DX_OFFSET 224
+#define TMEM_TMEM_DE_INP_OFFSET 224
+#define NUM_REVERSE_PIPE_STAGES 1
+#define SMEM_SMEM_QD_OFF 1024
+#define SMEM_SMEM_QD_STAGE_BYTES 8192
+#define SMEM_SMEM_QD_STRIDE 8192
+#define SMEM_SMEM_QD_TRANS_OFF 1024
+#define SMEM_SMEM_QD_TRANS_STAGE_BYTES 8192
+#define SMEM_SMEM_QD_TRANS_STRIDE 8192
+#define SMEM_SMEM_KD_OFF 9216
+#define SMEM_SMEM_KD_STAGE_BYTES 8192
+#define SMEM_SMEM_KD_STRIDE 8192
+#define SMEM_SMEM_KD_TRANS_OFF 9216
+#define SMEM_SMEM_KD_TRANS_STAGE_BYTES 8192
+#define SMEM_SMEM_KD_TRANS_STRIDE 8192
+#define SMEM_SMEM_KR_OFF 17408
+#define SMEM_SMEM_KR_STAGE_BYTES 8192
+#define SMEM_SMEM_KR_STRIDE 8192
+#define SMEM_SMEM_KI_OFF 25600
+#define SMEM_SMEM_KI_STAGE_BYTES 8192
+#define SMEM_SMEM_KI_STRIDE 8192
+#define SMEM_SMEM_J_OFF 33792
+#define SMEM_SMEM_J_STAGE_BYTES 2048
+#define SMEM_SMEM_J_STRIDE 2048
+#define SMEM_SMEM_J_TRANS_OFF 33792
+#define SMEM_SMEM_J_TRANS_STAGE_BYTES 2048
+#define SMEM_SMEM_J_TRANS_STRIDE 2048
+#define SMEM_SMEM_N_OFF 35840
+#define SMEM_SMEM_N_STAGE_BYTES 2048
+#define SMEM_SMEM_N_STRIDE 2048
+#define SMEM_TOTAL 37888
+#define THREADS 288
+
+extern "C" {
+
+__global__ __launch_bounds__(288) void
+kernel_flashkda_backward_boundary_c32_tcgen_m64(__nv_bfloat16* __restrict__ do_, float* __restrict__ dfinal_state, float* __restrict__ beta_active, long long* __restrict__ cu_seqlens, long long* __restrict__ cu_chunk_offsets, int* __restrict__ seq_order, __nv_bfloat16* __restrict__ tape_qd, __nv_bfloat16* __restrict__ tape_kd, __nv_bfloat16* __restrict__ tape_kr, __nv_bfloat16* __restrict__ tape_j, float* __restrict__ tape_restore_factor, __nv_bfloat16* __restrict__ chunk_dh, __nv_bfloat16* __restrict__ chunk_dr, __nv_bfloat16* __restrict__ chunk_dx, float* __restrict__ dinitial_state, unsigned int* __restrict__ boundary_ready, int num_heads, int publish_ready, float lower_bound)
+{
+    const int tid = threadIdx.x;
+    const int warp = make_warp_uniform(tid / 32);
+    const int lane = tid % 32;
+
+    extern __shared__ __align__(1024) char smem_raw[];
+    int smem;
+    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+
+    const int bid = blockIdx.x;
+    const int num_bids = gridDim.x;
+
+    // Kernel setup ops
+    __nv_bfloat16* smem_qd = reinterpret_cast<__nv_bfloat16*>(smem_raw + 1024);
+    const int smem_qd_addr = smem + 1024;
+    __nv_bfloat16* smem_qd_trans = reinterpret_cast<__nv_bfloat16*>(smem_raw + 1024);
+    const int smem_qd_trans_addr = smem + 1024;
+    __nv_bfloat16* smem_kd = reinterpret_cast<__nv_bfloat16*>(smem_raw + 9216);
+    const int smem_kd_addr = smem + 9216;
+    __nv_bfloat16* smem_kd_trans = reinterpret_cast<__nv_bfloat16*>(smem_raw + 9216);
+    const int smem_kd_trans_addr = smem + 9216;
+    __nv_bfloat16* smem_kr = reinterpret_cast<__nv_bfloat16*>(smem_raw + 17408);
+    const int smem_kr_addr = smem + 17408;
+    __nv_bfloat16* smem_ki = reinterpret_cast<__nv_bfloat16*>(smem_raw + 25600);
+    const int smem_ki_addr = smem + 25600;
+    __nv_bfloat16* smem_j = reinterpret_cast<__nv_bfloat16*>(smem_raw + 33792);
+    const int smem_j_addr = smem + 33792;
+    __nv_bfloat16* smem_j_trans = reinterpret_cast<__nv_bfloat16*>(smem_raw + 33792);
+    const int smem_j_trans_addr = smem + 33792;
+    __nv_bfloat16* smem_n = reinterpret_cast<__nv_bfloat16*>(smem_raw + 35840);
+    const int smem_n_addr = smem + 35840;
+
+    // Mbarrier init (9 groups, 9 barriers)
+    // Mbarriers at smem_raw[0..72)
+
+    if (warp == 0) {
+        uint32_t leader = elect_sync();
+        if (leader) {
+            // --- pipeline 'reverse_pipe' ---
+            // prep_ready: 1 barriers, init_count=1
+            mbarrier_init(smem + 0, 1);
+            // smem_free: 1 barriers, init_count=1
+            mbarrier_init(smem + 8, 1);
+            // inputs_ready: 1 barriers, init_count=4
+            mbarrier_init(smem + 16, 4);
+            // dr_ready: 1 barriers, init_count=1
+            mbarrier_init(smem + 24, 1);
+            // dr_inp_ready: 1 barriers, init_count=4
+            mbarrier_init(smem + 32, 4);
+            // dx_ready: 1 barriers, init_count=1
+            mbarrier_init(smem + 40, 1);
+            // de_inp_ready: 1 barriers, init_count=4
+            mbarrier_init(smem + 48, 4);
+            // dh_ready: 1 barriers, init_count=1
+            mbarrier_init(smem + 56, 1);
+            // compute_done: 1 barriers, init_count=4
+            mbarrier_init(smem + 64, 4);
+            asm volatile("fence.mbarrier_init.release.cluster;");
+        }
+    }
+
+    __syncwarp();
+
+    // TMEM alloc (256 columns, 256 used)
+    volatile int* tmem_addr_storage = (volatile int*)(smem_raw + 72);
+    if (warp == 0) {
+        int _tmem_hold = smem + 72;
+        asm volatile("tcgen05.alloc.cta_group::1.sync.aligned.shared::cta.b32 [%0], %1;" :: "r"(_tmem_hold), "r"(256) : "memory");
+        asm volatile("tcgen05.relinquish_alloc_permit.cta_group::1.sync.aligned;");
+    }
+
+    __syncthreads();
+    asm volatile("tcgen05.fence::after_thread_sync;");
+
+    const int mbar_base = smem;
+    #define prep_ready_addr (mbar_base + 0)
+    #define smem_free_addr (mbar_base + 8)
+    #define inputs_ready_addr (mbar_base + 16)
+    #define dr_ready_addr (mbar_base + 24)
+    #define dr_inp_ready_addr (mbar_base + 32)
+    #define dx_ready_addr (mbar_base + 40)
+    #define de_inp_ready_addr (mbar_base + 48)
+    #define dh_ready_addr (mbar_base + 56)
+    #define compute_done_addr (mbar_base + 64)
+    const int taddr = tmem_addr_storage[0];
+
+    // Kernel post-init ops
+    const int tmem_tmem_dh = taddr + 64;
+    const int tmem_tmem_dh_inp = taddr;
+    const int tmem_tmem_do_initial = taddr + 224;
+    const int tmem_tmem_do_final = taddr;
+    const int tmem_tmem_dr = taddr + 192;
+    const int tmem_tmem_dr_inp = taddr + 192;
+    const int tmem_tmem_dx = taddr + 224;
+    const int tmem_tmem_de_inp = taddr + 224;
+
+    // ---- Register redistribution for WGs split across roles ----
+    // Dec phase frees registers before any WG attempts inc.
+    if (warp >= 8 && warp <= 11) {
+        asm volatile("setmaxnreg.dec.sync.aligned.u32 112;");
+    }
+
+    // ---- Role: compute ----
+    if (warp <= 3) {
+        asm volatile("setmaxnreg.inc.sync.aligned.u32 224;");
+        { // compute_main
+            int split_task_idx = blockIdx.x;
+            int task_idx = split_task_idx / 2;
+            int value_split_idx = split_task_idx % 2;
+            int value_row_offset = value_split_idx * 64;
+            int seq_idx = seq_order[task_idx / num_heads];
+            int head_idx = task_idx % num_heads;
+            long long bos = cu_seqlens[seq_idx];
+            long long eos = cu_seqlens[seq_idx + 1];
+            int seq_len = (int)(eos - bos);
+            int num_chunks = (seq_len + 32 - 1) / 32;
+            int lane_quad = lane & 3;
+            int warp_in_wg = warp % 4;
+            int local_row_top = warp_in_wg * 16 + lane / 4;
+            int local_row_bot = local_row_top + 8;
+            int state_row_top = value_row_offset + local_row_top;
+            int state_row_bot = value_row_offset + local_row_bot;
+            const int tmem_row_base = warp_in_wg * 32 << 16;
+            long long state_head_base = ((long long)seq_idx * (long long)num_heads + (long long)head_idx) * 128 * 128;
+            long long state_base_top = state_head_base + (long long)state_row_top * 128;
+            long long state_base_bot = state_head_base + (long long)state_row_bot * 128;
+            #pragma unroll
+            for (int state_col_half = 0; state_col_half < 2; state_col_half++) {
+                float state_values[32];
+                #pragma unroll
+                for (int state_col_group = 0; state_col_group < 8; state_col_group++) {
+                    int state_col_pair = state_col_half * 64 + state_col_group * 8 + lane_quad * 2;
+                    const int state_reg_base = state_col_group * 4;
+                    state_values[state_reg_base] = dfinal_state[state_base_top + (long long)state_col_pair];
+                    state_values[state_reg_base + 1] = dfinal_state[state_base_top + (long long)state_col_pair + 1];
+                    state_values[state_reg_base + 2] = dfinal_state[state_base_bot + (long long)state_col_pair];
+                    state_values[state_reg_base + 3] = dfinal_state[state_base_bot + (long long)state_col_pair + 1];
+                }
+                asm volatile(
+                    "tcgen05.st.sync.aligned.16x256b.x8.b32"
+                    " [%0], {%1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15, %16, %17, %18, %19, %20, %21, %22, %23, %24, %25, %26, %27, %28, %29, %30, %31, %32};"
+                    :: "r"(taddr + 64 + (unsigned int)tmem_row_base + (unsigned int)(state_col_half * 64)), "r"(*reinterpret_cast<const uint32_t*>(&state_values[0])), "r"(*reinterpret_cast<const uint32_t*>(&state_values[1])), "r"(*reinterpret_cast<const uint32_t*>(&state_values[2])), "r"(*reinterpret_cast<const uint32_t*>(&state_values[3])), "r"(*reinterpret_cast<const uint32_t*>(&state_values[4])), "r"(*reinterpret_cast<const uint32_t*>(&state_values[5])), "r"(*reinterpret_cast<const uint32_t*>(&state_values[6])), "r"(*reinterpret_cast<const uint32_t*>(&state_values[7])), "r"(*reinterpret_cast<const uint32_t*>(&state_values[8])), "r"(*reinterpret_cast<const uint32_t*>(&state_values[9])), "r"(*reinterpret_cast<const uint32_t*>(&state_values[10])), "r"(*reinterpret_cast<const uint32_t*>(&state_values[11])), "r"(*reinterpret_cast<const uint32_t*>(&state_values[12])), "r"(*reinterpret_cast<const uint32_t*>(&state_values[13])), "r"(*reinterpret_cast<const uint32_t*>(&state_values[14])), "r"(*reinterpret_cast<const uint32_t*>(&state_values[15])), "r"(*reinterpret_cast<const uint32_t*>(&state_values[16])), "r"(*reinterpret_cast<const uint32_t*>(&state_values[17])), "r"(*reinterpret_cast<const uint32_t*>(&state_values[18])), "r"(*reinterpret_cast<const uint32_t*>(&state_values[19])), "r"(*reinterpret_cast<const uint32_t*>(&state_values[20])), "r"(*reinterpret_cast<const uint32_t*>(&state_values[21])), "r"(*reinterpret_cast<const uint32_t*>(&state_values[22])), "r"(*reinterpret_cast<const uint32_t*>(&state_values[23])), "r"(*reinterpret_cast<const uint32_t*>(&state_values[24])), "r"(*reinterpret_cast<const uint32_t*>(&state_values[25])), "r"(*reinterpret_cast<const uint32_t*>(&state_values[26])), "r"(*reinterpret_cast<const uint32_t*>(&state_values[27])), "r"(*reinterpret_cast<const uint32_t*>(&state_values[28])), "r"(*reinterpret_cast<const uint32_t*>(&state_values[29])), "r"(*reinterpret_cast<const uint32_t*>(&state_values[30])), "r"(*reinterpret_cast<const uint32_t*>(&state_values[31]))
+                    : "memory");
+            }
+            asm volatile("tcgen05.wait::st.sync.aligned;" ::: "memory");
+            asm volatile("griddepcontrol.launch_dependents;" ::: "memory");
+            unsigned int compute_stage = 0;
+            float _exp2_0 = approx_exp2(lower_bound * 1.4426950408889634f * 16.0f);
+            float common_factor = _exp2_0;
+            unsigned int _phase_prep_ready = 0;
+            unsigned int _phase_dr_ready = 0;
+            unsigned int _phase_dx_ready = 0;
+            unsigned int _phase_dh_ready = 0;
+            #pragma unroll 1
+            for (int reverse_chunk = 0; reverse_chunk < num_chunks; reverse_chunk++) {
+                mbarrier_wait(prep_ready_addr + (compute_stage) * 8, _phase_prep_ready);
+                int chunk_idx = num_chunks - 1 - reverse_chunk;
+                long long chunk_global = cu_chunk_offsets[seq_idx] + (long long)chunk_idx;
+                long long chunk_start = bos + (long long)chunk_idx * 32;
+                float do_values[16];
+                do_values[0] = 0.0f;
+                do_values[1] = 0.0f;
+                do_values[2] = 0.0f;
+                do_values[3] = 0.0f;
+                do_values[4] = 0.0f;
+                do_values[5] = 0.0f;
+                do_values[6] = 0.0f;
+                do_values[7] = 0.0f;
+                do_values[8] = 0.0f;
+                do_values[9] = 0.0f;
+                do_values[10] = 0.0f;
+                do_values[11] = 0.0f;
+                do_values[12] = 0.0f;
+                do_values[13] = 0.0f;
+                do_values[14] = 0.0f;
+                do_values[15] = 0.0f;
+                #pragma unroll
+                for (int token_group = 0; token_group < 4; token_group++) {
+                    int token_pair = token_group * 8 + lane_quad * 2;
+                    const int token_reg_base = token_group * 4;
+                    long long token0 = chunk_start + (long long)token_pair;
+                    long long token1 = token0 + 1;
+                    if (token0 < eos) {
+                        long long token_head0 = (token0 * (long long)num_heads + (long long)head_idx) * 128;
+                        do_values[token_reg_base] = (float)do_[token_head0 + (long long)state_row_top];
+                        do_values[token_reg_base + 2] = (float)do_[token_head0 + (long long)state_row_bot];
+                    }
+                    if (token1 < eos) {
+                        long long token_head1 = (token1 * (long long)num_heads + (long long)head_idx) * 128;
+                        do_values[token_reg_base + 1] = (float)do_[token_head1 + (long long)state_row_top];
+                        do_values[token_reg_base + 3] = (float)do_[token_head1 + (long long)state_row_bot];
+                    }
+                }
+                uint32_t do_values_bf16[8];
+                #pragma unroll
+                for (int _lp = 0; _lp < 8; _lp++) {
+                    __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(do_values[_lp*2 + 0], do_values[_lp*2+1 + 0]));
+                    do_values_bf16[_lp] = *(uint32_t*)&_bf2;
+                }
+                asm volatile(
+                    "tcgen05.st.sync.aligned.16x128b.x4.b32"
+                    " [%0], {%1, %2, %3, %4, %5, %6, %7, %8};"
+                    :: "r"(taddr + 224 + (unsigned int)tmem_row_base), "r"(*reinterpret_cast<const uint32_t*>(&do_values_bf16[0])), "r"(*reinterpret_cast<const uint32_t*>(&do_values_bf16[1])), "r"(*reinterpret_cast<const uint32_t*>(&do_values_bf16[2])), "r"(*reinterpret_cast<const uint32_t*>(&do_values_bf16[3])), "r"(*reinterpret_cast<const uint32_t*>(&do_values_bf16[4])), "r"(*reinterpret_cast<const uint32_t*>(&do_values_bf16[5])), "r"(*reinterpret_cast<const uint32_t*>(&do_values_bf16[6])), "r"(*reinterpret_cast<const uint32_t*>(&do_values_bf16[7]))
+                    : "memory");
+                long long chunk_state_head_base = (chunk_global * (long long)num_heads + (long long)head_idx) * 128 * 128;
+                long long chunk_dh_base_top = chunk_state_head_base + (long long)state_row_top * 128;
+                long long chunk_dh_base_bot = chunk_state_head_base + (long long)state_row_bot * 128;
+                long long restore_base = (chunk_global * (long long)num_heads + (long long)head_idx) * 128;
+                #pragma unroll
+                for (int state_col_half2 = 0; state_col_half2 < 2; state_col_half2++) {
+                    float _tmem_load_0[32];
+                    asm volatile(
+                        "tcgen05.ld.sync.aligned.16x256b.x8.b32"
+                        " {%0, %1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15, %16, %17, %18, %19, %20, %21, %22, %23, %24, %25, %26, %27, %28, %29, %30, %31}, [%32];"
+                        : "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_0[0])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_0[1])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_0[2])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_0[3])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_0[4])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_0[5])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_0[6])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_0[7])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_0[8])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_0[9])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_0[10])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_0[11])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_0[12])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_0[13])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_0[14])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_0[15])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_0[16])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_0[17])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_0[18])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_0[19])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_0[20])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_0[21])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_0[22])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_0[23])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_0[24])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_0[25])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_0[26])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_0[27])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_0[28])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_0[29])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_0[30])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_0[31]))
+                        : "r"(taddr + 64 + (unsigned int)tmem_row_base + (unsigned int)(state_col_half2 * 64))
+                        : "memory");
+                    asm volatile("tcgen05.wait::ld.sync.aligned;");
+                    #pragma unroll
+                    for (int state_col_group2 = 0; state_col_group2 < 8; state_col_group2++) {
+                        int state_col_pair2 = state_col_half2 * 64 + state_col_group2 * 8 + lane_quad * 2;
+                        const int state_reg_base2 = state_col_group2 * 4;
+                        chunk_dh[chunk_dh_base_top + (long long)state_col_pair2] = _tmem_load_0[state_reg_base2];
+                        chunk_dh[chunk_dh_base_top + (long long)state_col_pair2 + 1] = _tmem_load_0[state_reg_base2 + 1];
+                        chunk_dh[chunk_dh_base_bot + (long long)state_col_pair2] = _tmem_load_0[state_reg_base2 + 2];
+                        chunk_dh[chunk_dh_base_bot + (long long)state_col_pair2 + 1] = _tmem_load_0[state_reg_base2 + 3];
+                    }
+                    uint32_t _tmem_load_0_bf16[16];
+                    #pragma unroll
+                    for (int _lp = 0; _lp < 16; _lp++) {
+                        __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(_tmem_load_0[_lp*2 + 0], _tmem_load_0[_lp*2+1 + 0]));
+                        _tmem_load_0_bf16[_lp] = *(uint32_t*)&_bf2;
+                    }
+                    asm volatile(
+                        "tcgen05.st.sync.aligned.16x128b.x8.b32"
+                        " [%0], {%1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15, %16};"
+                        :: "r"(taddr + (unsigned int)tmem_row_base + (unsigned int)(state_col_half2 * 32)), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0_bf16[0])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0_bf16[1])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0_bf16[2])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0_bf16[3])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0_bf16[4])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0_bf16[5])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0_bf16[6])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0_bf16[7])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0_bf16[8])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0_bf16[9])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0_bf16[10])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0_bf16[11])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0_bf16[12])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0_bf16[13])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0_bf16[14])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0_bf16[15]))
+                        : "memory");
+                    #pragma unroll
+                    for (int restore_group = 0; restore_group < 8; restore_group++) {
+                        int restore_col_pair = state_col_half2 * 64 + restore_group * 8 + lane_quad * 2;
+                        const int restore_reg_base = restore_group * 4;
+                        float restore0 = tape_restore_factor[restore_base + (long long)restore_col_pair];
+                        float restore1 = tape_restore_factor[restore_base + (long long)restore_col_pair + 1];
+                        _tmem_load_0[restore_reg_base] = _tmem_load_0[restore_reg_base] * restore0;
+                        _tmem_load_0[restore_reg_base + 1] = _tmem_load_0[restore_reg_base + 1] * restore1;
+                        _tmem_load_0[restore_reg_base + 2] = _tmem_load_0[restore_reg_base + 2] * restore0;
+                        _tmem_load_0[restore_reg_base + 3] = _tmem_load_0[restore_reg_base + 3] * restore1;
+                    }
+                    asm volatile(
+                        "tcgen05.st.sync.aligned.16x256b.x8.b32"
+                        " [%0], {%1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15, %16, %17, %18, %19, %20, %21, %22, %23, %24, %25, %26, %27, %28, %29, %30, %31, %32};"
+                        :: "r"(taddr + 64 + (unsigned int)tmem_row_base + (unsigned int)(state_col_half2 * 64)), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0[0])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0[1])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0[2])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0[3])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0[4])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0[5])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0[6])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0[7])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0[8])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0[9])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0[10])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0[11])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0[12])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0[13])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0[14])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0[15])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0[16])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0[17])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0[18])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0[19])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0[20])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0[21])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0[22])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0[23])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0[24])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0[25])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0[26])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0[27])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0[28])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0[29])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0[30])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0[31]))
+                        : "memory");
+                }
+                asm volatile("tcgen05.wait::st.sync.aligned;" ::: "memory");
+                if (elect_sync()) {
+                    mbarrier_arrive(inputs_ready_addr + (compute_stage) * 8);
+                }
+                mbarrier_wait(dr_ready_addr + (compute_stage) * 8, _phase_dr_ready);
+                float _tmem_load_1[16];
+                asm volatile(
+                    "tcgen05.ld.sync.aligned.16x256b.x4.b32"
+                    " {%0, %1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15}, [%16];"
+                    : "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_1[0])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_1[1])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_1[2])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_1[3])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_1[4])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_1[5])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_1[6])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_1[7])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_1[8])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_1[9])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_1[10])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_1[11])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_1[12])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_1[13])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_1[14])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_1[15]))
+                    : "r"(taddr + 192 + (unsigned int)tmem_row_base)
+                    : "memory");
+                asm volatile("tcgen05.wait::ld.sync.aligned;");
+                long long chunk_value_head_base = (chunk_global * (long long)num_heads + (long long)head_idx) * 128 * 32;
+                long long dr_tape_base_top = chunk_value_head_base + (long long)state_row_top * 32;
+                long long dr_tape_base_bot = chunk_value_head_base + (long long)state_row_bot * 32;
+                #pragma unroll
+                for (int dr_group = 0; dr_group < 4; dr_group++) {
+                    int dr_col_pair = dr_group * 8 + lane_quad * 2;
+                    const int dr_reg_base = dr_group * 4;
+                    chunk_dr[dr_tape_base_top + (long long)dr_col_pair] = _tmem_load_1[dr_reg_base];
+                    chunk_dr[dr_tape_base_top + (long long)dr_col_pair + 1] = _tmem_load_1[dr_reg_base + 1];
+                    chunk_dr[dr_tape_base_bot + (long long)dr_col_pair] = _tmem_load_1[dr_reg_base + 2];
+                    chunk_dr[dr_tape_base_bot + (long long)dr_col_pair + 1] = _tmem_load_1[dr_reg_base + 3];
+                }
+                uint32_t _tmem_load_1_bf16[8];
+                #pragma unroll
+                for (int _lp = 0; _lp < 8; _lp++) {
+                    __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(_tmem_load_1[_lp*2 + 0], _tmem_load_1[_lp*2+1 + 0]));
+                    _tmem_load_1_bf16[_lp] = *(uint32_t*)&_bf2;
+                }
+                asm volatile(
+                    "tcgen05.st.sync.aligned.16x128b.x4.b32"
+                    " [%0], {%1, %2, %3, %4, %5, %6, %7, %8};"
+                    :: "r"(taddr + 192 + (unsigned int)tmem_row_base), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_1_bf16[0])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_1_bf16[1])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_1_bf16[2])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_1_bf16[3])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_1_bf16[4])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_1_bf16[5])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_1_bf16[6])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_1_bf16[7]))
+                    : "memory");
+                asm volatile(
+                    "tcgen05.st.sync.aligned.16x128b.x4.b32"
+                    " [%0], {%1, %2, %3, %4, %5, %6, %7, %8};"
+                    :: "r"(taddr + (unsigned int)tmem_row_base), "r"(*reinterpret_cast<const uint32_t*>(&do_values_bf16[0])), "r"(*reinterpret_cast<const uint32_t*>(&do_values_bf16[1])), "r"(*reinterpret_cast<const uint32_t*>(&do_values_bf16[2])), "r"(*reinterpret_cast<const uint32_t*>(&do_values_bf16[3])), "r"(*reinterpret_cast<const uint32_t*>(&do_values_bf16[4])), "r"(*reinterpret_cast<const uint32_t*>(&do_values_bf16[5])), "r"(*reinterpret_cast<const uint32_t*>(&do_values_bf16[6])), "r"(*reinterpret_cast<const uint32_t*>(&do_values_bf16[7]))
+                    : "memory");
+                asm volatile("tcgen05.wait::st.sync.aligned;" ::: "memory");
+                if (elect_sync()) {
+                    mbarrier_arrive(dr_inp_ready_addr + (compute_stage) * 8);
+                }
+                mbarrier_wait(dx_ready_addr + (compute_stage) * 8, _phase_dx_ready);
+                float _tmem_load_2[16];
+                asm volatile(
+                    "tcgen05.ld.sync.aligned.16x256b.x4.b32"
+                    " {%0, %1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15}, [%16];"
+                    : "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_2[0])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_2[1])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_2[2])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_2[3])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_2[4])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_2[5])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_2[6])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_2[7])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_2[8])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_2[9])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_2[10])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_2[11])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_2[12])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_2[13])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_2[14])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_2[15]))
+                    : "r"(taddr + 224 + (unsigned int)tmem_row_base)
+                    : "memory");
+                asm volatile("tcgen05.wait::ld.sync.aligned;");
+                #pragma unroll
+                for (int dx_group = 0; dx_group < 4; dx_group++) {
+                    int dx_col_pair = dx_group * 8 + lane_quad * 2;
+                    const int dx_reg_base = dx_group * 4;
+                    chunk_dx[dr_tape_base_top + (long long)dx_col_pair] = _tmem_load_2[dx_reg_base];
+                    chunk_dx[dr_tape_base_top + (long long)dx_col_pair + 1] = _tmem_load_2[dx_reg_base + 1];
+                    chunk_dx[dr_tape_base_bot + (long long)dx_col_pair] = _tmem_load_2[dx_reg_base + 2];
+                    chunk_dx[dr_tape_base_bot + (long long)dx_col_pair + 1] = _tmem_load_2[dx_reg_base + 3];
+                    float beta0 = 0.0f;
+                    float beta1 = 0.0f;
+                    long long beta_token0 = chunk_start + (long long)dx_col_pair;
+                    long long beta_token1 = beta_token0 + 1;
+                    if (beta_token0 < eos) {
+                        beta0 = beta_active[beta_token0 * (long long)num_heads + (long long)head_idx];
+                    }
+                    if (beta_token1 < eos) {
+                        beta1 = beta_active[beta_token1 * (long long)num_heads + (long long)head_idx];
+                    }
+                    _tmem_load_2[dx_reg_base] = _tmem_load_2[dx_reg_base] * (-beta0);
+                    _tmem_load_2[dx_reg_base + 1] = _tmem_load_2[dx_reg_base + 1] * (-beta1);
+                    _tmem_load_2[dx_reg_base + 2] = _tmem_load_2[dx_reg_base + 2] * (-beta0);
+                    _tmem_load_2[dx_reg_base + 3] = _tmem_load_2[dx_reg_base + 3] * (-beta1);
+                }
+                uint32_t _tmem_load_2_bf16[8];
+                #pragma unroll
+                for (int _lp = 0; _lp < 8; _lp++) {
+                    __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(_tmem_load_2[_lp*2 + 0], _tmem_load_2[_lp*2+1 + 0]));
+                    _tmem_load_2_bf16[_lp] = *(uint32_t*)&_bf2;
+                }
+                asm volatile(
+                    "tcgen05.st.sync.aligned.16x128b.x4.b32"
+                    " [%0], {%1, %2, %3, %4, %5, %6, %7, %8};"
+                    :: "r"(taddr + 224 + (unsigned int)tmem_row_base), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_2_bf16[0])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_2_bf16[1])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_2_bf16[2])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_2_bf16[3])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_2_bf16[4])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_2_bf16[5])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_2_bf16[6])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_2_bf16[7]))
+                    : "memory");
+                asm volatile("tcgen05.wait::st.sync.aligned;" ::: "memory");
+                if (elect_sync()) {
+                    mbarrier_arrive(de_inp_ready_addr + (compute_stage) * 8);
+                }
+                if (publish_ready != 0) {
+                    __threadfence();
+                    asm volatile("barrier.sync 9, 128;" ::: "memory");
+                    if (warp == 0) {
+                        if (elect_sync()) {
+                            {
+                                unsigned int* _gc_p = reinterpret_cast<unsigned int*>(boundary_ready) + (chunk_global * (long long)num_heads + (long long)head_idx);
+                                unsigned int _gc_old;
+                                asm volatile("atom.release.gpu.global.add.u32 %0, [%1], 1;" : "=r"(_gc_old) : "l"(_gc_p) : "memory");
+                            }
+                        }
+                    }
+                }
+                mbarrier_wait(dh_ready_addr + (compute_stage) * 8, _phase_dh_ready);
+                #pragma unroll
+                for (int state_col_half3 = 0; state_col_half3 < 2; state_col_half3++) {
+                    float _tmem_load_3[32];
+                    asm volatile(
+                        "tcgen05.ld.sync.aligned.16x256b.x8.b32"
+                        " {%0, %1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15, %16, %17, %18, %19, %20, %21, %22, %23, %24, %25, %26, %27, %28, %29, %30, %31}, [%32];"
+                        : "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[0])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[1])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[2])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[3])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[4])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[5])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[6])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[7])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[8])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[9])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[10])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[11])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[12])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[13])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[14])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[15])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[16])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[17])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[18])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[19])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[20])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[21])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[22])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[23])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[24])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[25])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[26])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[27])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[28])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[29])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[30])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[31]))
+                        : "r"(taddr + 64 + (unsigned int)tmem_row_base + (unsigned int)(state_col_half3 * 64))
+                        : "memory");
+                    asm volatile("tcgen05.wait::ld.sync.aligned;");
+                    const float2 _scale2_0 = {common_factor, common_factor};
+                    #pragma unroll
+                    for (int _ls = 0; _ls < 16; _ls++)
+                        mul_f32x2_inplace(&reinterpret_cast<float2*>(_tmem_load_3)[_ls], _scale2_0);
+                    asm volatile(
+                        "tcgen05.st.sync.aligned.16x256b.x8.b32"
+                        " [%0], {%1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15, %16, %17, %18, %19, %20, %21, %22, %23, %24, %25, %26, %27, %28, %29, %30, %31, %32};"
+                        :: "r"(taddr + 64 + (unsigned int)tmem_row_base + (unsigned int)(state_col_half3 * 64)), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_3[0])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_3[1])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_3[2])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_3[3])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_3[4])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_3[5])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_3[6])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_3[7])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_3[8])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_3[9])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_3[10])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_3[11])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_3[12])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_3[13])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_3[14])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_3[15])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_3[16])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_3[17])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_3[18])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_3[19])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_3[20])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_3[21])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_3[22])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_3[23])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_3[24])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_3[25])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_3[26])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_3[27])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_3[28])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_3[29])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_3[30])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_3[31]))
+                        : "memory");
+                }
+                asm volatile("tcgen05.wait::st.sync.aligned;" ::: "memory");
+                compute_stage += 1;
+                if (compute_stage == 1) { compute_stage = 0; _phase_prep_ready ^= 1; _phase_dr_ready ^= 1; _phase_dx_ready ^= 1; _phase_dh_ready ^= 1; }
+            }
+            #pragma unroll
+            for (int final_half = 0; final_half < 2; final_half++) {
+                float _tmem_load_4[32];
+                asm volatile(
+                    "tcgen05.ld.sync.aligned.16x256b.x8.b32"
+                    " {%0, %1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15, %16, %17, %18, %19, %20, %21, %22, %23, %24, %25, %26, %27, %28, %29, %30, %31}, [%32];"
+                    : "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_4[0])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_4[1])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_4[2])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_4[3])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_4[4])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_4[5])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_4[6])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_4[7])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_4[8])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_4[9])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_4[10])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_4[11])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_4[12])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_4[13])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_4[14])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_4[15])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_4[16])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_4[17])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_4[18])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_4[19])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_4[20])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_4[21])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_4[22])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_4[23])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_4[24])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_4[25])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_4[26])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_4[27])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_4[28])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_4[29])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_4[30])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_4[31]))
+                    : "r"(taddr + 64 + (unsigned int)tmem_row_base + (unsigned int)(final_half * 64))
+                    : "memory");
+                asm volatile("tcgen05.wait::ld.sync.aligned;");
+                #pragma unroll
+                for (int final_group = 0; final_group < 8; final_group++) {
+                    int final_col_pair = final_half * 64 + final_group * 8 + lane_quad * 2;
+                    const int final_reg_base = final_group * 4;
+                    dinitial_state[state_base_top + (long long)final_col_pair] = _tmem_load_4[final_reg_base];
+                    dinitial_state[state_base_top + (long long)final_col_pair + 1] = _tmem_load_4[final_reg_base + 1];
+                    dinitial_state[state_base_bot + (long long)final_col_pair] = _tmem_load_4[final_reg_base + 2];
+                    dinitial_state[state_base_bot + (long long)final_col_pair + 1] = _tmem_load_4[final_reg_base + 3];
+                }
+            }
+            if (elect_sync()) {
+                mbarrier_arrive(compute_done_addr);
+            }
+        }
+    }
+    // ---- Role: prep ----
+    if (warp >= 4 && warp <= 7) {
+        asm volatile("setmaxnreg.dec.sync.aligned.u32 112;");
+        { // prep_main
+            int split_task_idx_1 = blockIdx.x;
+            int task_idx_1 = split_task_idx_1 / 2;
+            int seq_idx_1 = seq_order[task_idx_1 / num_heads];
+            int head_idx_1 = task_idx_1 % num_heads;
+            long long bos_1 = cu_seqlens[seq_idx_1];
+            long long eos_1 = cu_seqlens[seq_idx_1 + 1];
+            int seq_len_1 = (int)(eos_1 - bos_1);
+            int num_chunks_1 = (seq_len_1 + 32 - 1) / 32;
+            int warp_id_in_role = (warp - 4);
+            int prep_tid = warp_id_in_role * 32 + lane;
+            int prep_local_warp = warp_id_in_role;
+            unsigned int prep_stage = 0;
+            unsigned int _phase_smem_free = 1;
+            #pragma unroll 1
+            for (int reverse_chunk_1 = 0; reverse_chunk_1 < num_chunks_1; reverse_chunk_1++) {
+                mbarrier_wait(smem_free_addr + (prep_stage) * 8, _phase_smem_free);
+                int chunk_idx_1 = num_chunks_1 - 1 - reverse_chunk_1;
+                long long chunk_global_1 = cu_chunk_offsets[seq_idx_1] + (long long)chunk_idx_1;
+                long long tape_vec_base = (chunk_global_1 * (long long)num_heads + (long long)head_idx_1) * 32 * 128;
+                long long restore_base_1 = (chunk_global_1 * (long long)num_heads + (long long)head_idx_1) * 128;
+                #pragma unroll
+                for (int load_pass = 0; load_pass < 4; load_pass++) {
+                    int item = load_pass * 128 + prep_tid;
+                    int row = item / 16;
+                    int segment = item % 16;
+                    long long index = tape_vec_base + (long long)row * 128 + (long long)(segment * 8);
+                    float qd_values[8];
+                    float kd_values[8];
+                    float kr_values[8];
+                    float ki_values[8];
+                    {
+                        const uint4* _vptr_0 = reinterpret_cast<const uint4*>(tape_qd + index);
+                        uint4 _vld_0[1];
+                        #pragma unroll
+                        for (int _blk = 0; _blk < 1; _blk++) {
+                            _vld_0[_blk] = _vptr_0[_blk];
+                            uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
+                            #pragma unroll
+                            for (int _pair = 0; _pair < 4; _pair++) {
+                                asm volatile(
+                                    "{\n\t"
+                                    "shl.b32 %0, %2, 16;\n\t"
+                                    "and.b32 %1, %2, 0xffff0000;\n\t"
+                                    "}\n"
+                                    : "=f"((&qd_values[0 + _blk * 8 + _pair * 2])[0]), "=f"((&qd_values[0 + _blk * 8 + _pair * 2])[1])
+                                    : "r"(_vpairs_0[_pair]));
+                            }
+                        }
+                    }
+                    {
+                        const uint4* _vptr_1 = reinterpret_cast<const uint4*>(tape_kd + index);
+                        uint4 _vld_1[1];
+                        #pragma unroll
+                        for (int _blk = 0; _blk < 1; _blk++) {
+                            _vld_1[_blk] = _vptr_1[_blk];
+                            uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
+                            #pragma unroll
+                            for (int _pair = 0; _pair < 4; _pair++) {
+                                asm volatile(
+                                    "{\n\t"
+                                    "shl.b32 %0, %2, 16;\n\t"
+                                    "and.b32 %1, %2, 0xffff0000;\n\t"
+                                    "}\n"
+                                    : "=f"((&kd_values[0 + _blk * 8 + _pair * 2])[0]), "=f"((&kd_values[0 + _blk * 8 + _pair * 2])[1])
+                                    : "r"(_vpairs_1[_pair]));
+                            }
+                        }
+                    }
+                    {
+                        const uint4* _vptr_2 = reinterpret_cast<const uint4*>(tape_kr + index);
+                        uint4 _vld_2[1];
+                        #pragma unroll
+                        for (int _blk = 0; _blk < 1; _blk++) {
+                            _vld_2[_blk] = _vptr_2[_blk];
+                            uint32_t* _vpairs_2 = reinterpret_cast<uint32_t*>(&_vld_2[_blk]);
+                            #pragma unroll
+                            for (int _pair = 0; _pair < 4; _pair++) {
+                                asm volatile(
+                                    "{\n\t"
+                                    "shl.b32 %0, %2, 16;\n\t"
+                                    "and.b32 %1, %2, 0xffff0000;\n\t"
+                                    "}\n"
+                                    : "=f"((&kr_values[0 + _blk * 8 + _pair * 2])[0]), "=f"((&kr_values[0 + _blk * 8 + _pair * 2])[1])
+                                    : "r"(_vpairs_2[_pair]));
+                            }
+                        }
+                    }
+                    #pragma unroll
+                    for (int elem = 0; elem < 8; elem++) {
+                        float factor = tape_restore_factor[restore_base_1 + (long long)(segment * 8) + (long long)elem];
+                        ki_values[elem] = kr_values[elem] / factor;
+                    }
+                    unsigned int packed[4];
+                    #pragma unroll
+                    for (int _lp = 0; _lp < 4; _lp++) {
+                        __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(qd_values[_lp*2 + 0], qd_values[_lp*2+1 + 0]));
+                        packed[_lp] = *(uint32_t*)&_bf2;
+                    }
+                    #pragma unroll
+                    for (int word = 0; word < 4; word++) {
+                        asm volatile("st.shared.b32 [%0], %1;" :: "r"((smem_qd_addr + (unsigned int)(segment * 8 / 64 * 4096 + row * 128 + segment * 8 % 64 * 2 ^ (segment * 8 / 64 * 4096 + row * 128 + segment * 8 % 64 * 2 >> 7 & 7) << 4)) + (unsigned int)(word * 4)), "r"((packed[word])));
+                    }
+                    unsigned int packed_0[4];
+                    #pragma unroll
+                    for (int _lp = 0; _lp < 4; _lp++) {
+                        __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(kd_values[_lp*2 + 0], kd_values[_lp*2+1 + 0]));
+                        packed_0[_lp] = *(uint32_t*)&_bf2;
+                    }
+                    #pragma unroll
+                    for (int word_1 = 0; word_1 < 4; word_1++) {
+                        asm volatile("st.shared.b32 [%0], %1;" :: "r"((smem_kd_addr + (unsigned int)(segment * 8 / 64 * 4096 + row * 128 + segment * 8 % 64 * 2 ^ (segment * 8 / 64 * 4096 + row * 128 + segment * 8 % 64 * 2 >> 7 & 7) << 4)) + (unsigned int)(word_1 * 4)), "r"((packed_0[word_1])));
+                    }
+                    unsigned int packed_1[4];
+                    #pragma unroll
+                    for (int _lp = 0; _lp < 4; _lp++) {
+                        __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(kr_values[_lp*2 + 0], kr_values[_lp*2+1 + 0]));
+                        packed_1[_lp] = *(uint32_t*)&_bf2;
+                    }
+                    #pragma unroll
+                    for (int word_2 = 0; word_2 < 4; word_2++) {
+                        asm volatile("st.shared.b32 [%0], %1;" :: "r"((smem_kr_addr + (unsigned int)(segment * 8 / 64 * 4096 + row * 128 + segment * 8 % 64 * 2 ^ (segment * 8 / 64 * 4096 + row * 128 + segment * 8 % 64 * 2 >> 7 & 7) << 4)) + (unsigned int)(word_2 * 4)), "r"((packed_1[word_2])));
+                    }
+                    unsigned int packed_2[4];
+                    #pragma unroll
+                    for (int _lp = 0; _lp < 4; _lp++) {
+                        __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(ki_values[_lp*2 + 0], ki_values[_lp*2+1 + 0]));
+                        packed_2[_lp] = *(uint32_t*)&_bf2;
+                    }
+                    #pragma unroll
+                    for (int word_3 = 0; word_3 < 4; word_3++) {
+                        asm volatile("st.shared.b32 [%0], %1;" :: "r"((smem_ki_addr + (unsigned int)(segment * 8 / 64 * 4096 + row * 128 + segment * 8 % 64 * 2 ^ (segment * 8 / 64 * 4096 + row * 128 + segment * 8 % 64 * 2 >> 7 & 7) << 4)) + (unsigned int)(word_3 * 4)), "r"((packed_2[word_3])));
+                    }
+                }
+                int j_row = prep_tid / 4;
+                int j_segment = prep_tid % 4;
+                float j_values[8];
+                long long j_base = (chunk_global_1 * (long long)num_heads + (long long)head_idx_1) * 32 * 32;
+                {
+                    const uint4* _vptr_3 = reinterpret_cast<const uint4*>(tape_j + j_base + (long long)j_row * 32 + (long long)(j_segment * 8));
+                    uint4 _vld_3[1];
+                    #pragma unroll
+                    for (int _blk = 0; _blk < 1; _blk++) {
+                        _vld_3[_blk] = _vptr_3[_blk];
+                        uint32_t* _vpairs_3 = reinterpret_cast<uint32_t*>(&_vld_3[_blk]);
+                        #pragma unroll
+                        for (int _pair = 0; _pair < 4; _pair++) {
+                            asm volatile(
+                                "{\n\t"
+                                "shl.b32 %0, %2, 16;\n\t"
+                                "and.b32 %1, %2, 0xffff0000;\n\t"
+                                "}\n"
+                                : "=f"((&j_values[0 + _blk * 8 + _pair * 2])[0]), "=f"((&j_values[0 + _blk * 8 + _pair * 2])[1])
+                                : "r"(_vpairs_3[_pair]));
+                        }
+                    }
+                }
+                unsigned int packed_3[4];
+                #pragma unroll
+                for (int _lp = 0; _lp < 4; _lp++) {
+                    __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(j_values[_lp*2 + 0], j_values[_lp*2+1 + 0]));
+                    packed_3[_lp] = *(uint32_t*)&_bf2;
+                }
+                #pragma unroll
+                for (int word_4 = 0; word_4 < 4; word_4++) {
+                    asm volatile("st.shared.b32 [%0], %1;" :: "r"((smem_j_addr + (unsigned int)(j_segment * 8 / 16 * 1024 + j_row * 32 + j_segment * 8 % 16 * 2 ^ (j_segment * 8 / 16 * 1024 + j_row * 32 + j_segment * 8 % 16 * 2 >> 7 & 1) << 4)) + (unsigned int)(word_4 * 4)), "r"((packed_3[word_4])));
+                }
+                asm volatile("fence.proxy.async.shared::cta;" ::: "memory");
+                asm volatile("barrier.sync 8, 128;" ::: "memory");
+                int row_base = prep_local_warp / 2 * 16;
+                int col_base = prep_local_warp % 2 * 16;
+                unsigned int a_frag[4];
+                unsigned int b_frag[4];
+                float acc[8];
+                if (row_base <= col_base) {
+                    asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                        : "=r"(a_frag[0]), "=r"(a_frag[1]), "=r"(a_frag[2]), "=r"(a_frag[3])
+                        : "r"(smem_ki_addr + (unsigned int)((lane / 16 / 8 * 256 + (row_base + lane % 16) * 8 + (lane / 16 % 8 * 16 ^ (row_base + lane % 16 & 7) << 4) / 16) * 16))
+                        : "memory");
+                    asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                        : "=r"(b_frag[0]), "=r"(b_frag[1]), "=r"(b_frag[2]), "=r"(b_frag[3])
+                        : "r"(smem_qd_addr + (unsigned int)((lane % 16 / 8 / 8 * 256 + (col_base + 8 * (lane / 16) + lane % 8) * 8 + (lane % 16 / 8 % 8 * 16 ^ (col_base + 8 * (lane / 16) + lane % 8 & 7) << 4) / 16) * 16))
+                        : "memory");
+                    asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {0f00000000, 0f00000000, 0f00000000, 0f00000000};\n"
+                        : "=f"(acc[0]), "=f"(acc[1]), "=f"(acc[2]), "=f"(acc[3])
+                        : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[0]), "r"(b_frag[1]));
+                    asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {0f00000000, 0f00000000, 0f00000000, 0f00000000};\n"
+                        : "=f"(acc[4]), "=f"(acc[(4) + 1]), "=f"(acc[(4) + 2]), "=f"(acc[(4) + 3])
+                        : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[2]), "r"(b_frag[(2) + 1]));
+                    asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                        : "=r"(a_frag[0]), "=r"(a_frag[1]), "=r"(a_frag[2]), "=r"(a_frag[3])
+                        : "r"(smem_ki_addr + (unsigned int)((lane / 16 / 8 * 256 + (row_base + lane % 16) * 8 + (lane / 16 % 8 * 16 ^ (row_base + lane % 16 & 7) << 4) / 16 ^ 2) * 16))
+                        : "memory");
+                    asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                        : "=r"(b_frag[0]), "=r"(b_frag[1]), "=r"(b_frag[2]), "=r"(b_frag[3])
+                        : "r"(smem_qd_addr + (unsigned int)(((lane % 16 / 8 / 8 * 256 + (col_base + 8 * (lane / 16) + lane % 8) * 8 + (lane % 16 / 8 % 8 * 16 ^ (col_base + 8 * (lane / 16) + lane % 8 & 7) << 4) / 16 + 256 ^ 2) - 256) * 16))
+                        : "memory");
+                    asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                        : "+f"(acc[0]), "+f"(acc[1]), "+f"(acc[2]), "+f"(acc[3])
+                        : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[0]), "r"(b_frag[1]));
+                    asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                        : "+f"(acc[4]), "+f"(acc[(4) + 1]), "+f"(acc[(4) + 2]), "+f"(acc[(4) + 3])
+                        : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[2]), "r"(b_frag[(2) + 1]));
+                    asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                        : "=r"(a_frag[0]), "=r"(a_frag[1]), "=r"(a_frag[2]), "=r"(a_frag[3])
+                        : "r"(smem_ki_addr + (unsigned int)((lane / 16 / 8 * 256 + (row_base + lane % 16) * 8 + (lane / 16 % 8 * 16 ^ (row_base + lane % 16 & 7) << 4) / 16 ^ 2 ^ 6) * 16))
+                        : "memory");
+                    asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                        : "=r"(b_frag[0]), "=r"(b_frag[1]), "=r"(b_frag[2]), "=r"(b_frag[3])
+                        : "r"(smem_qd_addr + (unsigned int)((((lane % 16 / 8 / 8 * 256 + (col_base + 8 * (lane / 16) + lane % 8) * 8 + (lane % 16 / 8 % 8 * 16 ^ (col_base + 8 * (lane / 16) + lane % 8 & 7) << 4) / 16 + 256 ^ 2) - 256 + 256 ^ 6) - 256) * 16))
+                        : "memory");
+                    asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                        : "+f"(acc[0]), "+f"(acc[1]), "+f"(acc[2]), "+f"(acc[3])
+                        : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[0]), "r"(b_frag[1]));
+                    asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                        : "+f"(acc[4]), "+f"(acc[(4) + 1]), "+f"(acc[(4) + 2]), "+f"(acc[(4) + 3])
+                        : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[2]), "r"(b_frag[(2) + 1]));
+                    asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                        : "=r"(a_frag[0]), "=r"(a_frag[1]), "=r"(a_frag[2]), "=r"(a_frag[3])
+                        : "r"(smem_ki_addr + (unsigned int)((lane / 16 / 8 * 256 + (row_base + lane % 16) * 8 + (lane / 16 % 8 * 16 ^ (row_base + lane % 16 & 7) << 4) / 16 ^ 2 ^ 6 ^ 2) * 16))
+                        : "memory");
+                    asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                        : "=r"(b_frag[0]), "=r"(b_frag[1]), "=r"(b_frag[2]), "=r"(b_frag[3])
+                        : "r"(smem_qd_addr + (unsigned int)(((((lane % 16 / 8 / 8 * 256 + (col_base + 8 * (lane / 16) + lane % 8) * 8 + (lane % 16 / 8 % 8 * 16 ^ (col_base + 8 * (lane / 16) + lane % 8 & 7) << 4) / 16 + 256 ^ 2) - 256 + 256 ^ 6) - 256 + 256 ^ 2) - 256) * 16))
+                        : "memory");
+                    asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                        : "+f"(acc[0]), "+f"(acc[1]), "+f"(acc[2]), "+f"(acc[3])
+                        : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[0]), "r"(b_frag[1]));
+                    asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                        : "+f"(acc[4]), "+f"(acc[(4) + 1]), "+f"(acc[(4) + 2]), "+f"(acc[(4) + 3])
+                        : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[2]), "r"(b_frag[(2) + 1]));
+                    asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                        : "=r"(a_frag[0]), "=r"(a_frag[1]), "=r"(a_frag[2]), "=r"(a_frag[3])
+                        : "r"(smem_ki_addr + (unsigned int)(((lane / 16 / 8 * 256 + (row_base + lane % 16) * 8 + (lane / 16 % 8 * 16 ^ (row_base + lane % 16 & 7) << 4) / 16 ^ 2 ^ 6 ^ 2 ^ 6) + 256) * 16))
+                        : "memory");
+                    asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                        : "=r"(b_frag[0]), "=r"(b_frag[1]), "=r"(b_frag[2]), "=r"(b_frag[3])
+                        : "r"(smem_qd_addr + (unsigned int)((((((lane % 16 / 8 / 8 * 256 + (col_base + 8 * (lane / 16) + lane % 8) * 8 + (lane % 16 / 8 % 8 * 16 ^ (col_base + 8 * (lane / 16) + lane % 8 & 7) << 4) / 16 + 256 ^ 2) - 256 + 256 ^ 6) - 256 + 256 ^ 2) - 256 + 256 ^ 6) + 256 - 256) * 16))
+                        : "memory");
+                    asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                        : "+f"(acc[0]), "+f"(acc[1]), "+f"(acc[2]), "+f"(acc[3])
+                        : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[0]), "r"(b_frag[1]));
+                    asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                        : "+f"(acc[4]), "+f"(acc[(4) + 1]), "+f"(acc[(4) + 2]), "+f"(acc[(4) + 3])
+                        : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[2]), "r"(b_frag[(2) + 1]));
+                    asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                        : "=r"(a_frag[0]), "=r"(a_frag[1]), "=r"(a_frag[2]), "=r"(a_frag[3])
+                        : "r"(smem_ki_addr + (unsigned int)(((lane / 16 / 8 * 256 + (row_base + lane % 16) * 8 + (lane / 16 % 8 * 16 ^ (row_base + lane % 16 & 7) << 4) / 16 ^ 2 ^ 6 ^ 2 ^ 6) + 256 ^ 2) * 16))
+                        : "memory");
+                    asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                        : "=r"(b_frag[0]), "=r"(b_frag[1]), "=r"(b_frag[2]), "=r"(b_frag[3])
+                        : "r"(smem_qd_addr + (unsigned int)(((((((lane % 16 / 8 / 8 * 256 + (col_base + 8 * (lane / 16) + lane % 8) * 8 + (lane % 16 / 8 % 8 * 16 ^ (col_base + 8 * (lane / 16) + lane % 8 & 7) << 4) / 16 + 256 ^ 2) - 256 + 256 ^ 6) - 256 + 256 ^ 2) - 256 + 256 ^ 6) + 256 - 256 + 256 ^ 2) - 256) * 16))
+                        : "memory");
+                    asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                        : "+f"(acc[0]), "+f"(acc[1]), "+f"(acc[2]), "+f"(acc[3])
+                        : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[0]), "r"(b_frag[1]));
+                    asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                        : "+f"(acc[4]), "+f"(acc[(4) + 1]), "+f"(acc[(4) + 2]), "+f"(acc[(4) + 3])
+                        : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[2]), "r"(b_frag[(2) + 1]));
+                    asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                        : "=r"(a_frag[0]), "=r"(a_frag[1]), "=r"(a_frag[2]), "=r"(a_frag[3])
+                        : "r"(smem_ki_addr + (unsigned int)(((lane / 16 / 8 * 256 + (row_base + lane % 16) * 8 + (lane / 16 % 8 * 16 ^ (row_base + lane % 16 & 7) << 4) / 16 ^ 2 ^ 6 ^ 2 ^ 6) + 256 ^ 2 ^ 6) * 16))
+                        : "memory");
+                    asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                        : "=r"(b_frag[0]), "=r"(b_frag[1]), "=r"(b_frag[2]), "=r"(b_frag[3])
+                        : "r"(smem_qd_addr + (unsigned int)((((((((lane % 16 / 8 / 8 * 256 + (col_base + 8 * (lane / 16) + lane % 8) * 8 + (lane % 16 / 8 % 8 * 16 ^ (col_base + 8 * (lane / 16) + lane % 8 & 7) << 4) / 16 + 256 ^ 2) - 256 + 256 ^ 6) - 256 + 256 ^ 2) - 256 + 256 ^ 6) + 256 - 256 + 256 ^ 2) - 256 + 256 ^ 6) - 256) * 16))
+                        : "memory");
+                    asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                        : "+f"(acc[0]), "+f"(acc[1]), "+f"(acc[2]), "+f"(acc[3])
+                        : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[0]), "r"(b_frag[1]));
+                    asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                        : "+f"(acc[4]), "+f"(acc[(4) + 1]), "+f"(acc[(4) + 2]), "+f"(acc[(4) + 3])
+                        : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[2]), "r"(b_frag[(2) + 1]));
+                    asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                        : "=r"(a_frag[0]), "=r"(a_frag[1]), "=r"(a_frag[2]), "=r"(a_frag[3])
+                        : "r"(smem_ki_addr + (unsigned int)(((lane / 16 / 8 * 256 + (row_base + lane % 16) * 8 + (lane / 16 % 8 * 16 ^ (row_base + lane % 16 & 7) << 4) / 16 ^ 2 ^ 6 ^ 2 ^ 6) + 256 ^ 2 ^ 6 ^ 2) * 16))
+                        : "memory");
+                    asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                        : "=r"(b_frag[0]), "=r"(b_frag[1]), "=r"(b_frag[2]), "=r"(b_frag[3])
+                        : "r"(smem_qd_addr + (unsigned int)(((((((((lane % 16 / 8 / 8 * 256 + (col_base + 8 * (lane / 16) + lane % 8) * 8 + (lane % 16 / 8 % 8 * 16 ^ (col_base + 8 * (lane / 16) + lane % 8 & 7) << 4) / 16 + 256 ^ 2) - 256 + 256 ^ 6) - 256 + 256 ^ 2) - 256 + 256 ^ 6) + 256 - 256 + 256 ^ 2) - 256 + 256 ^ 6) - 256 + 256 ^ 2) - 256) * 16))
+                        : "memory");
+                    asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                        : "+f"(acc[0]), "+f"(acc[1]), "+f"(acc[2]), "+f"(acc[3])
+                        : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[0]), "r"(b_frag[1]));
+                    asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                        : "+f"(acc[4]), "+f"(acc[(4) + 1]), "+f"(acc[(4) + 2]), "+f"(acc[(4) + 3])
+                        : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[2]), "r"(b_frag[(2) + 1]));
+                } else {
+                    acc[0] = 0.0f;
+                    acc[1] = 0.0f;
+                    acc[2] = 0.0f;
+                    acc[3] = 0.0f;
+                    acc[4] = 0.0f;
+                    acc[5] = 0.0f;
+                    acc[6] = 0.0f;
+                    acc[7] = 0.0f;
+                }
+                int row0 = row_base + lane / 4;
+                int row1 = row0 + 8;
+                int col0 = col_base + lane % 4 * 2;
+                float values[8];
+                values[0] = 0.0f;
+                values[1] = 0.0f;
+                values[2] = 0.0f;
+                values[3] = 0.0f;
+                values[4] = 0.0f;
+                values[5] = 0.0f;
+                values[6] = 0.0f;
+                values[7] = 0.0f;
+                if (row0 <= col0) {
+                    values[0] = acc[0];
+                }
+                if (row0 <= col0 + 1) {
+                    values[1] = acc[1];
+                }
+                if (row1 <= col0) {
+                    values[2] = acc[2];
+                }
+                if (row1 <= col0 + 1) {
+                    values[3] = acc[3];
+                }
+                if (row0 <= col0 + 8) {
+                    values[4] = acc[4];
+                }
+                if (row0 <= col0 + 9) {
+                    values[5] = acc[5];
+                }
+                if (row1 <= col0 + 8) {
+                    values[6] = acc[6];
+                }
+                if (row1 <= col0 + 9) {
+                    values[7] = acc[7];
+                }
+                unsigned int packed_0_1[4];
+                #pragma unroll
+                for (int _lp = 0; _lp < 4; _lp++) {
+                    __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(values[_lp*2 + 0], values[_lp*2+1 + 0]));
+                    packed_0_1[_lp] = *(uint32_t*)&_bf2;
+                }
+                int lane_row = lane % 16;
+                int lane_col = lane / 16 * 8;
+                uint32_t _stmatrix_addr_4 = static_cast<uint32_t>((unsigned long long)(smem_n_addr + (unsigned int)((col_base + lane_col) / 16 * 1024 + (row_base + lane_row) * 32 + (col_base + lane_col) % 16 * 2 ^ ((col_base + lane_col) / 16 * 1024 + (row_base + lane_row) * 32 + (col_base + lane_col) % 16 * 2 >> 7 & 1) << 4)));
+                asm volatile("stmatrix.sync.aligned.m8n8.x4.shared.b16 [%0], {%1, %2, %3, %4};\n"
+                    :: "r"(_stmatrix_addr_4), "r"(*reinterpret_cast<const uint32_t*>(&packed_0_1[0])), "r"(*reinterpret_cast<const uint32_t*>(&packed_0_1[1])), "r"(*reinterpret_cast<const uint32_t*>(&packed_0_1[2])), "r"(*reinterpret_cast<const uint32_t*>(&packed_0_1[3]))
+                    : "memory");
+                asm volatile("fence.proxy.async.shared::cta;" ::: "memory");
+                asm volatile("barrier.sync 8, 128;" ::: "memory");
+                if (prep_local_warp == 0) {
+                    if (elect_sync()) {
+                        mbarrier_arrive(prep_ready_addr + (prep_stage) * 8);
+                    }
+                }
+                prep_stage += 1;
+                if (prep_stage == 1) { prep_stage = 0; _phase_smem_free ^= 1; }
+            }
+        }
+    }
+    // ---- Role: mma ----
+    if (warp == 8) {
+        { // mma_main
+            int split_task_idx_2 = blockIdx.x;
+            int task_idx_2 = split_task_idx_2 / 2;
+            int seq_idx_2 = seq_order[task_idx_2 / num_heads];
+            long long eos_2 = cu_seqlens[seq_idx_2 + 1];
+            long long bos_2 = cu_seqlens[seq_idx_2];
+            int seq_len_2 = (int)(eos_2 - bos_2);
+            int num_chunks_2 = (seq_len_2 + 32 - 1) / 32;
+            unsigned int mma_stage = 0;
+            unsigned int _phase_prep_ready_1 = 0;
+            unsigned int _phase_inputs_ready = 0;
+            unsigned int _phase_dr_inp_ready = 0;
+            unsigned int _phase_de_inp_ready = 0;
+            #pragma unroll 1
+            for (int _reverse_chunk = 0; _reverse_chunk < num_chunks_2; _reverse_chunk++) {
+                mbarrier_wait(prep_ready_addr + (mma_stage) * 8, _phase_prep_ready_1);
+                mbarrier_wait(inputs_ready_addr + (mma_stage) * 8, _phase_inputs_ready);
+                int _mma_b_lo_0 = make_warp_uniform(((smem_n_addr) >> 4) & 0x3FFF);
+                asm volatile(
+                    "{\n\t"
+                    ".reg .pred leader, p0, p1;\n\t"
+                    ".reg .b32 dhi, blo, id;\n\t"
+                    ".reg .b64 db;\n\t"
+                    "elect.sync _|leader, 0xFFFFFFFF;\n\t"
+                    "setp.ne.b32 p0, %3, 0;\n\t"
+                    "setp.ne.b32 p1, 1, 0;\n\t"
+                    ""
+                    "mov.b32 dhi, 0xC0004010;\n\t"
+                    "mov.b32 id, 67634320;\n\t"
+                    "mov.b32 blo, %1;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [%2], db, id, p0;\n\t"
+                    "add.u32 blo, blo, 64;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [%2 + 8], db, id, p1;\n\t"
+                    "}\n"
+                    :: "r"(tmem_tmem_dr), "r"(_mma_b_lo_0), "r"(tmem_tmem_do_initial), "r"(0));
+                int _mma_b_lo_1 = make_warp_uniform(((smem_kr_addr) >> 4) & 0x3FFF);
+                asm volatile(
+                    "{\n\t"
+                    ".reg .pred leader, p0, p1;\n\t"
+                    ".reg .b32 dhi, blo, id;\n\t"
+                    ".reg .b64 db;\n\t"
+                    "elect.sync _|leader, 0xFFFFFFFF;\n\t"
+                    "setp.ne.b32 p0, %3, 0;\n\t"
+                    "setp.ne.b32 p1, 1, 0;\n\t"
+                    ""
+                    "mov.b32 dhi, 0x40004040;\n\t"
+                    "mov.b32 id, 67634320;\n\t"
+                    "mov.b32 blo, %1;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [%2], db, id, p0;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [%2 + 8], db, id, p1;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [%2 + 16], db, id, p1;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [%2 + 24], db, id, p1;\n\t"
+                    "add.u32 blo, blo, 250;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [%2 + 32], db, id, p1;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [%2 + 40], db, id, p1;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [%2 + 48], db, id, p1;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [%2 + 56], db, id, p1;\n\t"
+                    "}\n"
+                    :: "r"(tmem_tmem_dr), "r"(_mma_b_lo_1), "r"(tmem_tmem_dh_inp), "r"(1));
+                elect_commit(dr_ready_addr + (mma_stage) * 8);
+                mbarrier_wait(dr_inp_ready_addr + (mma_stage) * 8, _phase_dr_inp_ready);
+                int _mma_b_lo_2 = make_warp_uniform((((smem_j_trans_addr) >> 4) & 0x3FFF) | 0x400000);
+                asm volatile(
+                    "{\n\t"
+                    ".reg .pred leader, p0, p1;\n\t"
+                    ".reg .b32 dhi, blo, id;\n\t"
+                    ".reg .b64 db;\n\t"
+                    "elect.sync _|leader, 0xFFFFFFFF;\n\t"
+                    "setp.ne.b32 p0, %3, 0;\n\t"
+                    "setp.ne.b32 p1, 1, 0;\n\t"
+                    ""
+                    "mov.b32 dhi, 0xC0004010;\n\t"
+                    "mov.b32 id, 67699856;\n\t"
+                    "mov.b32 blo, %1;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [%2], db, id, p0;\n\t"
+                    "add.u32 blo, blo, 32;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [%2 + 8], db, id, p1;\n\t"
+                    "}\n"
+                    :: "r"(tmem_tmem_dx), "r"(_mma_b_lo_2), "r"(tmem_tmem_dr_inp), "r"(0));
+                elect_commit(dx_ready_addr + (mma_stage) * 8);
+                mbarrier_wait(de_inp_ready_addr + (mma_stage) * 8, _phase_de_inp_ready);
+                int _mma_b_lo_3 = make_warp_uniform((((smem_qd_trans_addr) >> 4) & 0x3FFF) | 0x1000000);
+                asm volatile(
+                    "{\n\t"
+                    ".reg .pred leader, p0, p1;\n\t"
+                    ".reg .b32 dhi, blo, id;\n\t"
+                    ".reg .b64 db;\n\t"
+                    "elect.sync _|leader, 0xFFFFFFFF;\n\t"
+                    "setp.ne.b32 p0, %3, 0;\n\t"
+                    "setp.ne.b32 p1, 1, 0;\n\t"
+                    ""
+                    "mov.b32 dhi, 0x40004040;\n\t"
+                    "mov.b32 id, 69272720;\n\t"
+                    "mov.b32 blo, %1;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [%2], db, id, p0;\n\t"
+                    "add.u32 blo, blo, 128;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [%2 + 8], db, id, p1;\n\t"
+                    "}\n"
+                    :: "r"(tmem_tmem_dh), "r"(_mma_b_lo_3), "r"(tmem_tmem_do_final), "r"(1));
+                int _mma_b_lo_4 = make_warp_uniform((((smem_kd_trans_addr) >> 4) & 0x3FFF) | 0x1000000);
+                asm volatile(
+                    "{\n\t"
+                    ".reg .pred leader, p0, p1;\n\t"
+                    ".reg .b32 dhi, blo, id;\n\t"
+                    ".reg .b64 db;\n\t"
+                    "elect.sync _|leader, 0xFFFFFFFF;\n\t"
+                    "setp.ne.b32 p0, %3, 0;\n\t"
+                    "setp.ne.b32 p1, 1, 0;\n\t"
+                    ""
+                    "mov.b32 dhi, 0x40004040;\n\t"
+                    "mov.b32 id, 69272720;\n\t"
+                    "mov.b32 blo, %1;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [%2], db, id, p0;\n\t"
+                    "add.u32 blo, blo, 128;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [%2 + 8], db, id, p1;\n\t"
+                    "}\n"
+                    :: "r"(tmem_tmem_dh), "r"(_mma_b_lo_4), "r"(tmem_tmem_de_inp), "r"(1));
+                elect_commit2(dh_ready_addr + (mma_stage) * 8, smem_free_addr + (mma_stage) * 8);
+                mma_stage += 1;
+                if (mma_stage == 1) { mma_stage = 0; _phase_prep_ready_1 ^= 1; _phase_inputs_ready ^= 1; _phase_dr_inp_ready ^= 1; _phase_de_inp_ready ^= 1; }
+            }
+            unsigned int _phase_compute_done_0 = 0;
+            mbarrier_wait(compute_done_addr, _phase_compute_done_0);
+            _phase_compute_done_0 ^= 1;
+            int _tmem_dealloc_addr = *((volatile int*)tmem_addr_storage);
+            asm volatile("tcgen05.dealloc.cta_group::1.sync.aligned.b32 %0, %1;" :: "r"(_tmem_dealloc_addr), "r"(256));
+        }
+    }
+
+    // Cleanup
+}
+
+} // extern "C"
+
+#undef FLASHKDA_INF
+#undef NUM_REVERSE_PIPE_STAGES
+#undef SMEM_SMEM_J_OFF
+#undef SMEM_SMEM_J_STAGE_BYTES
+#undef SMEM_SMEM_J_STRIDE
+#undef SMEM_SMEM_J_TRANS_OFF
+#undef SMEM_SMEM_J_TRANS_STAGE_BYTES
+#undef SMEM_SMEM_J_TRANS_STRIDE
+#undef SMEM_SMEM_KD_OFF
+#undef SMEM_SMEM_KD_STAGE_BYTES
+#undef SMEM_SMEM_KD_STRIDE
+#undef SMEM_SMEM_KD_TRANS_OFF
+#undef SMEM_SMEM_KD_TRANS_STAGE_BYTES
+#undef SMEM_SMEM_KD_TRANS_STRIDE
+#undef SMEM_SMEM_KI_OFF
+#undef SMEM_SMEM_KI_STAGE_BYTES
+#undef SMEM_SMEM_KI_STRIDE
+#undef SMEM_SMEM_KR_OFF
+#undef SMEM_SMEM_KR_STAGE_BYTES
+#undef SMEM_SMEM_KR_STRIDE
+#undef SMEM_SMEM_N_OFF
+#undef SMEM_SMEM_N_STAGE_BYTES
+#undef SMEM_SMEM_N_STRIDE
+#undef SMEM_SMEM_QD_OFF
+#undef SMEM_SMEM_QD_STAGE_BYTES
+#undef SMEM_SMEM_QD_STRIDE
+#undef SMEM_SMEM_QD_TRANS_OFF
+#undef SMEM_SMEM_QD_TRANS_STAGE_BYTES
+#undef SMEM_SMEM_QD_TRANS_STRIDE
+#undef SMEM_TOTAL
+#undef THREADS
+#undef TMEM_NCOLS
+#undef TMEM_TMEM_DE_INP_OFFSET
+#undef TMEM_TMEM_DH_INP_OFFSET
+#undef TMEM_TMEM_DH_OFFSET
+#undef TMEM_TMEM_DO_FINAL_OFFSET
+#undef TMEM_TMEM_DO_INITIAL_OFFSET
+#undef TMEM_TMEM_DR_INP_OFFSET
+#undef TMEM_TMEM_DR_OFFSET
+#undef TMEM_TMEM_DX_OFFSET
+#undef compute_done_addr
+#undef de_inp_ready_addr
+#undef dh_ready_addr
+#undef dr_inp_ready_addr
+#undef dr_ready_addr
+#undef dx_ready_addr
+#undef inputs_ready_addr
+#undef prep_ready_addr
+#undef smem_free_addr
+#undef smem_j_addr
+#undef smem_j_trans_addr
+#undef smem_kd_addr
+#undef smem_kd_trans_addr
+#undef smem_ki_addr
+#undef smem_kr_addr
+#undef smem_n_addr
+#undef smem_qd_addr
+#undef smem_qd_trans_addr
+
+#define FLASHKDA_INF CUDART_INF_F
+#define TMEM_NCOLS 256
+#define TMEM_TMEM_DH_OFFSET 64
+#define TMEM_TMEM_DH_INP_OFFSET 0
+#define TMEM_TMEM_DO_INITIAL_OFFSET 224
+#define TMEM_TMEM_DO_FINAL_OFFSET 0
+#define TMEM_TMEM_DR_OFFSET 192
+#define TMEM_TMEM_DR_INP_OFFSET 192
+#define TMEM_TMEM_DX_OFFSET 224
+#define TMEM_TMEM_DE_INP_OFFSET 224
+#define NUM_PREP_PIPE_STAGES 2
+#define NUM_REVERSE_PIPE_STAGES 1
+#define SMEM_SMEM_QD_OFF 1024
+#define SMEM_SMEM_QD_STAGE_BYTES 8192
+#define SMEM_SMEM_QD_STRIDE 36864
+#define SMEM_SMEM_QD_TRANS_OFF 1024
+#define SMEM_SMEM_QD_TRANS_STAGE_BYTES 8192
+#define SMEM_SMEM_QD_TRANS_STRIDE 36864
+#define SMEM_SMEM_KD_OFF 9216
+#define SMEM_SMEM_KD_STAGE_BYTES 8192
+#define SMEM_SMEM_KD_STRIDE 36864
+#define SMEM_SMEM_KD_TRANS_OFF 9216
+#define SMEM_SMEM_KD_TRANS_STAGE_BYTES 8192
+#define SMEM_SMEM_KD_TRANS_STRIDE 36864
+#define SMEM_SMEM_KR_OFF 17408
+#define SMEM_SMEM_KR_STAGE_BYTES 8192
+#define SMEM_SMEM_KR_STRIDE 36864
+#define SMEM_SMEM_KI_OFF 25600
+#define SMEM_SMEM_KI_STAGE_BYTES 8192
+#define SMEM_SMEM_KI_STRIDE 36864
+#define SMEM_SMEM_J_OFF 33792
+#define SMEM_SMEM_J_STAGE_BYTES 2048
+#define SMEM_SMEM_J_STRIDE 36864
+#define SMEM_SMEM_J_TRANS_OFF 33792
+#define SMEM_SMEM_J_TRANS_STAGE_BYTES 2048
+#define SMEM_SMEM_J_TRANS_STRIDE 36864
+#define SMEM_SMEM_N_OFF 35840
+#define SMEM_SMEM_N_STAGE_BYTES 2048
+#define SMEM_SMEM_N_STRIDE 36864
+#define SMEM_TOTAL 74752
+#define THREADS 512
+
+extern "C" {
+
+__global__ __launch_bounds__(512) void
+kernel_flashkda_backward_boundary_c32_tcgen(__nv_bfloat16* __restrict__ do_, float* __restrict__ dfinal_state, float* __restrict__ beta_active, long long* __restrict__ cu_seqlens, long long* __restrict__ cu_chunk_offsets, int* __restrict__ seq_order, __nv_bfloat16* __restrict__ tape_qd, __nv_bfloat16* __restrict__ tape_kd, __nv_bfloat16* __restrict__ tape_kr, __nv_bfloat16* __restrict__ tape_j, float* __restrict__ tape_restore_factor, __nv_bfloat16* __restrict__ chunk_dh, __nv_bfloat16* __restrict__ chunk_dr, __nv_bfloat16* __restrict__ chunk_dx, unsigned int* __restrict__ boundary_ready, float* __restrict__ dinitial_state, int num_heads, int publish_ready, float lower_bound)
+{
+    const int tid = threadIdx.x;
+    const int warp = make_warp_uniform(tid / 32);
+    const int lane = tid % 32;
+
+    extern __shared__ __align__(1024) char smem_raw[];
+    int smem;
+    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+
+    const int bid = blockIdx.x;
+    const int num_bids = gridDim.x;
+
+    // Kernel setup ops
+    __nv_bfloat16* smem_qd = reinterpret_cast<__nv_bfloat16*>(smem_raw + 1024);
+    const int smem_qd_addr = smem + 1024;
+    __nv_bfloat16* smem_qd_trans = reinterpret_cast<__nv_bfloat16*>(smem_raw + 1024);
+    const int smem_qd_trans_addr = smem + 1024;
+    __nv_bfloat16* smem_kd = reinterpret_cast<__nv_bfloat16*>(smem_raw + 9216);
+    const int smem_kd_addr = smem + 9216;
+    __nv_bfloat16* smem_kd_trans = reinterpret_cast<__nv_bfloat16*>(smem_raw + 9216);
+    const int smem_kd_trans_addr = smem + 9216;
+    __nv_bfloat16* smem_kr = reinterpret_cast<__nv_bfloat16*>(smem_raw + 17408);
+    const int smem_kr_addr = smem + 17408;
+    __nv_bfloat16* smem_ki = reinterpret_cast<__nv_bfloat16*>(smem_raw + 25600);
+    const int smem_ki_addr = smem + 25600;
+    __nv_bfloat16* smem_j = reinterpret_cast<__nv_bfloat16*>(smem_raw + 33792);
+    const int smem_j_addr = smem + 33792;
+    __nv_bfloat16* smem_j_trans = reinterpret_cast<__nv_bfloat16*>(smem_raw + 33792);
+    const int smem_j_trans_addr = smem + 33792;
+    __nv_bfloat16* smem_n = reinterpret_cast<__nv_bfloat16*>(smem_raw + 35840);
+    const int smem_n_addr = smem + 35840;
+
+    // Mbarrier init (8 groups, 10 barriers)
+    // Mbarriers at smem_raw[0..80)
+
+    if (warp == 0) {
+        uint32_t leader = elect_sync();
+        if (leader) {
+            // --- pipeline 'prep_pipe' ---
+            // smem_free: 2 barriers, init_count=1
+            mbarrier_init(smem + 0, 1);
+            mbarrier_init(smem + 8, 1);
+            // prep_ready: 2 barriers, init_count=1
+            mbarrier_init(smem + 16, 1);
+            mbarrier_init(smem + 24, 1);
+            // --- pipeline 'reverse_pipe' ---
+            // dr_ready: 1 barriers, init_count=1
+            mbarrier_init(smem + 32, 1);
+            // dr_inp_ready: 1 barriers, init_count=1
+            mbarrier_init(smem + 40, 1);
+            // dx_ready: 1 barriers, init_count=1
+            mbarrier_init(smem + 48, 1);
+            // de_inp_ready: 1 barriers, init_count=1
+            mbarrier_init(smem + 56, 1);
+            // dh_ready: 1 barriers, init_count=1
+            mbarrier_init(smem + 64, 1);
+            // owners_done: 1 barriers, init_count=12
+            mbarrier_init(smem + 72, 12);
+            asm volatile("fence.mbarrier_init.release.cluster;");
+        }
+    }
+
+    __syncwarp();
+
+    // TMEM alloc (256 columns, 256 used)
+    volatile int* tmem_addr_storage = (volatile int*)(smem_raw + 80);
+    if (warp == 0) {
+        int _tmem_hold = smem + 80;
+        asm volatile("tcgen05.alloc.cta_group::1.sync.aligned.shared::cta.b32 [%0], %1;" :: "r"(_tmem_hold), "r"(256) : "memory");
+        asm volatile("tcgen05.relinquish_alloc_permit.cta_group::1.sync.aligned;");
+    }
+
+    __syncthreads();
+    asm volatile("tcgen05.fence::after_thread_sync;");
+
+    const int mbar_base = smem;
+    #define smem_free_addr (mbar_base + 0)
+    #define prep_ready_addr (mbar_base + 16)
+    #define dr_ready_addr (mbar_base + 32)
+    #define dr_inp_ready_addr (mbar_base + 40)
+    #define dx_ready_addr (mbar_base + 48)
+    #define de_inp_ready_addr (mbar_base + 56)
+    #define dh_ready_addr (mbar_base + 64)
+    #define owners_done_addr (mbar_base + 72)
+    const int taddr = tmem_addr_storage[0];
+
+    // Kernel post-init ops
+    const int tmem_tmem_dh = taddr + 64;
+    const int tmem_tmem_dh_inp = taddr;
+    const int tmem_tmem_do_initial = taddr + 224;
+    const int tmem_tmem_do_final = taddr;
+    const int tmem_tmem_dr = taddr + 192;
+    const int tmem_tmem_dr_inp = taddr + 192;
+    const int tmem_tmem_dx = taddr + 224;
+    const int tmem_tmem_de_inp = taddr + 224;
+
+    // ---- Role: state ----
+    if (warp <= 3) {
+        asm volatile("setmaxnreg.dec.sync.aligned.u32 80;");
+        { // state_main
+            int task_idx = blockIdx.x;
+            int seq_idx = seq_order[task_idx / num_heads];
+            int head_idx = task_idx % num_heads;
+            long long bos = cu_seqlens[seq_idx];
+            long long eos = cu_seqlens[seq_idx + 1];
+            int seq_len = (int)(eos - bos);
+            int num_chunks = (seq_len + 32 - 1) / 32;
+            int warp_id_in_role = (warp - 0);
+            int state_row = warp_id_in_role * 32 + lane;
+            int tmem_row_base = warp_id_in_role * 32 << 16;
+            long long state_base = (((long long)seq_idx * (long long)num_heads + (long long)head_idx) * 128 + (long long)state_row) * 128;
+            #pragma unroll
+            for (int state_block = 0; state_block < 4; state_block++) {
+                float state_values[32];
+                #pragma unroll
+                for (int state_vec = 0; state_vec < 4; state_vec++) {
+                    {
+                        unsigned _ldv8_0_0;
+                        unsigned _ldv8_0_1;
+                        unsigned _ldv8_0_2;
+                        unsigned _ldv8_0_3;
+                        unsigned _ldv8_0_4;
+                        unsigned _ldv8_0_5;
+                        unsigned _ldv8_0_6;
+                        unsigned _ldv8_0_7;
+                        asm volatile(
+                            "ld.global.v8.b32 {%0, %1, %2, %3, %4, %5, %6, %7}, [%8];"
+                            : "=r"(_ldv8_0_0), "=r"(_ldv8_0_1), "=r"(_ldv8_0_2), "=r"(_ldv8_0_3), "=r"(_ldv8_0_4), "=r"(_ldv8_0_5), "=r"(_ldv8_0_6), "=r"(_ldv8_0_7) : "l"((const void*)(dfinal_state + (state_base + (long long)(state_block * 32) + (long long)(state_vec * 8)))) : "memory");
+                        state_values[state_vec * 8 + 0] = __uint_as_float(_ldv8_0_0);
+                        state_values[state_vec * 8 + 1] = __uint_as_float(_ldv8_0_1);
+                        state_values[state_vec * 8 + 2] = __uint_as_float(_ldv8_0_2);
+                        state_values[state_vec * 8 + 3] = __uint_as_float(_ldv8_0_3);
+                        state_values[state_vec * 8 + 4] = __uint_as_float(_ldv8_0_4);
+                        state_values[state_vec * 8 + 5] = __uint_as_float(_ldv8_0_5);
+                        state_values[state_vec * 8 + 6] = __uint_as_float(_ldv8_0_6);
+                        state_values[state_vec * 8 + 7] = __uint_as_float(_ldv8_0_7);
+                    }
+                }
+                tmem_st_x32_f32(taddr + 64 + (unsigned int)tmem_row_base + (unsigned int)(state_block * 32), state_values);
+            }
+            asm volatile("tcgen05.wait::st.sync.aligned;" ::: "memory");
+            asm volatile("griddepcontrol.launch_dependents;" ::: "memory");
+            unsigned int state_stage = 0;
+            unsigned int issue_smem_stage = 0;
+            float _exp2_0 = approx_exp2(lower_bound * 1.4426950408889634f * 16.0f);
+            float common_factor = _exp2_0;
+            unsigned int _phase_prep_ready = 0;
+            unsigned int _phase_dr_inp_ready = 0;
+            unsigned int _phase_de_inp_ready = 0;
+            unsigned int _phase_dh_ready = 0;
+            #pragma unroll 1
+            for (int reverse_chunk = 0; reverse_chunk < num_chunks; reverse_chunk++) {
+                int chunk_idx = num_chunks - 1 - reverse_chunk;
+                long long chunk_global = cu_chunk_offsets[seq_idx] + (long long)chunk_idx;
+                long long chunk_dh_base = ((chunk_global * (long long)num_heads + (long long)head_idx) * 128 + (long long)state_row) * 128;
+                long long restore_base = (chunk_global * (long long)num_heads + (long long)head_idx) * 128;
+                #pragma unroll
+                for (int state_block2 = 0; state_block2 < 4; state_block2++) {
+                    float _tmem_load_0[32];
+                    tmem_ld_x32(&_tmem_load_0[0], taddr + 64 + (unsigned int)tmem_row_base + (unsigned int)(state_block2 * 32));
+                    asm volatile("tcgen05.wait::ld.sync.aligned;");
+                    if (reverse_chunk != 0) {
+                        const float2 _scale2_1 = {common_factor, common_factor};
+                        #pragma unroll
+                        for (int _ls = 0; _ls < 16; _ls++)
+                            mul_f32x2_inplace(&reinterpret_cast<float2*>(_tmem_load_0)[_ls], _scale2_1);
+                    }
+                    #pragma unroll
+                    for (int dh_store_vec = 0; dh_store_vec < 4; dh_store_vec++) {
+                        {
+                            __nv_bfloat162 _pk[4];
+                            _pk[0] = __floats2bfloat162_rn(_tmem_load_0[dh_store_vec * 8 + 0], _tmem_load_0[dh_store_vec * 8 + 1]);
+                            _pk[1] = __floats2bfloat162_rn(_tmem_load_0[dh_store_vec * 8 + 2], _tmem_load_0[dh_store_vec * 8 + 3]);
+                            _pk[2] = __floats2bfloat162_rn(_tmem_load_0[dh_store_vec * 8 + 4], _tmem_load_0[dh_store_vec * 8 + 5]);
+                            _pk[3] = __floats2bfloat162_rn(_tmem_load_0[dh_store_vec * 8 + 6], _tmem_load_0[dh_store_vec * 8 + 7]);
+                            *reinterpret_cast<uint4*>(&((__nv_bfloat16*)(chunk_dh + (chunk_dh_base + (long long)(state_block2 * 32) + (long long)(dh_store_vec * 8))))[0]) = *reinterpret_cast<uint4*>(&_pk[0]);
+                        }
+                    }
+                    uint32_t _tmem_load_0_bf16[16];
+                    #pragma unroll
+                    for (int _lp = 0; _lp < 16; _lp++) {
+                        __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(_tmem_load_0[_lp*2 + 0], _tmem_load_0[_lp*2+1 + 0]));
+                        _tmem_load_0_bf16[_lp] = *(uint32_t*)&_bf2;
+                    }
+                    asm volatile(
+                        "tcgen05.st.sync.aligned.32x32b.x16.b32"
+                        " [%0], {%1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15, %16};"
+                        :: "r"(taddr + (unsigned int)tmem_row_base + (unsigned int)(state_block2 * 16)), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0_bf16[0])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0_bf16[1])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0_bf16[2])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0_bf16[3])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0_bf16[4])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0_bf16[5])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0_bf16[6])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0_bf16[7])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0_bf16[8])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0_bf16[9])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0_bf16[10])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0_bf16[11])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0_bf16[12])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0_bf16[13])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0_bf16[14])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0_bf16[15]))
+                        : "memory");
+                    float restore_lane = tape_restore_factor[restore_base + (long long)(state_block2 * 32) + (long long)lane];
+                    #pragma unroll
+                    for (int restore_elem = 0; restore_elem < 32; restore_elem++) {
+                        float _shfl_0 = __shfl_sync(0xFFFFFFFF, restore_lane, restore_elem);
+                        _tmem_load_0[restore_elem] = _tmem_load_0[restore_elem] * _shfl_0;
+                    }
+                    tmem_st_x32_f32(taddr + 64 + (unsigned int)tmem_row_base + (unsigned int)(state_block2 * 32), _tmem_load_0);
+                }
+                asm volatile("tcgen05.wait::st.sync.aligned;" ::: "memory");
+                asm volatile("barrier.sync 9, 384;" ::: "memory");
+                if (warp_id_in_role == 0) {
+                    mbarrier_wait(prep_ready_addr + (issue_smem_stage) * 8, _phase_prep_ready);
+                    int _mma_b_lo_0 = make_warp_uniform((((smem_n_addr) >> 4) & 0x3FFF) + (issue_smem_stage) * 2304);
+                    asm volatile(
+                    "{\n\t"
+                    ".reg .pred leader, p0, p1;\n\t"
+                    ".reg .b32 dhi, blo, id;\n\t"
+                    ".reg .b64 db;\n\t"
+                    "elect.sync _|leader, 0xFFFFFFFF;\n\t"
+                    "setp.ne.b32 p0, %3, 0;\n\t"
+                    "setp.ne.b32 p1, 1, 0;\n\t"
+                    ""
+                    "mov.b32 dhi, 0xC0004010;\n\t"
+                    "mov.b32 id, 134743184;\n\t"
+                    "mov.b32 blo, %1;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [%2], db, id, p0;\n\t"
+                    "add.u32 blo, blo, 64;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [%2 + 8], db, id, p1;\n\t"
+                    "}\n"
+                    :: "r"(tmem_tmem_dr), "r"(_mma_b_lo_0), "r"(tmem_tmem_do_initial), "r"(0));
+                    int _mma_b_lo_1 = make_warp_uniform((((smem_kr_addr) >> 4) & 0x3FFF) + (issue_smem_stage) * 2304);
+                    asm volatile(
+                    "{\n\t"
+                    ".reg .pred leader, p0, p1;\n\t"
+                    ".reg .b32 dhi, blo, id;\n\t"
+                    ".reg .b64 db;\n\t"
+                    "elect.sync _|leader, 0xFFFFFFFF;\n\t"
+                    "setp.ne.b32 p0, %3, 0;\n\t"
+                    "setp.ne.b32 p1, 1, 0;\n\t"
+                    ""
+                    "mov.b32 dhi, 0x40004040;\n\t"
+                    "mov.b32 id, 134743184;\n\t"
+                    "mov.b32 blo, %1;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [%2], db, id, p0;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [%2 + 8], db, id, p1;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [%2 + 16], db, id, p1;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [%2 + 24], db, id, p1;\n\t"
+                    "add.u32 blo, blo, 250;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [%2 + 32], db, id, p1;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [%2 + 40], db, id, p1;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [%2 + 48], db, id, p1;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [%2 + 56], db, id, p1;\n\t"
+                    "}\n"
+                    :: "r"(tmem_tmem_dr), "r"(_mma_b_lo_1), "r"(tmem_tmem_dh_inp), "r"(1));
+                    elect_commit(dr_ready_addr + (state_stage) * 8);
+                    mbarrier_wait(dr_inp_ready_addr + (state_stage) * 8, _phase_dr_inp_ready);
+                    int _mma_b_lo_2 = make_warp_uniform(((((smem_j_trans_addr) >> 4) & 0x3FFF) | 0x400000) + (issue_smem_stage) * 2304);
+                    asm volatile(
+                    "{\n\t"
+                    ".reg .pred leader, p0, p1;\n\t"
+                    ".reg .b32 dhi, blo, id;\n\t"
+                    ".reg .b64 db;\n\t"
+                    "elect.sync _|leader, 0xFFFFFFFF;\n\t"
+                    "setp.ne.b32 p0, %3, 0;\n\t"
+                    "setp.ne.b32 p1, 1, 0;\n\t"
+                    ""
+                    "mov.b32 dhi, 0xC0004010;\n\t"
+                    "mov.b32 id, 134808720;\n\t"
+                    "mov.b32 blo, %1;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [%2], db, id, p0;\n\t"
+                    "add.u32 blo, blo, 32;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [%2 + 8], db, id, p1;\n\t"
+                    "}\n"
+                    :: "r"(tmem_tmem_dx), "r"(_mma_b_lo_2), "r"(tmem_tmem_dr_inp), "r"(0));
+                    elect_commit(dx_ready_addr + (state_stage) * 8);
+                    mbarrier_wait(de_inp_ready_addr + (state_stage) * 8, _phase_de_inp_ready);
+                    int _mma_b_lo_3 = make_warp_uniform(((((smem_qd_trans_addr) >> 4) & 0x3FFF) | 0x1000000) + (issue_smem_stage) * 2304);
+                    asm volatile(
+                    "{\n\t"
+                    ".reg .pred leader, p0, p1;\n\t"
+                    ".reg .b32 dhi, blo, id;\n\t"
+                    ".reg .b64 db;\n\t"
+                    "elect.sync _|leader, 0xFFFFFFFF;\n\t"
+                    "setp.ne.b32 p0, %3, 0;\n\t"
+                    "setp.ne.b32 p1, 1, 0;\n\t"
+                    ""
+                    "mov.b32 dhi, 0x40004040;\n\t"
+                    "mov.b32 id, 136381584;\n\t"
+                    "mov.b32 blo, %1;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [%2], db, id, p0;\n\t"
+                    "add.u32 blo, blo, 128;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [%2 + 8], db, id, p1;\n\t"
+                    "}\n"
+                    :: "r"(tmem_tmem_dh), "r"(_mma_b_lo_3), "r"(tmem_tmem_do_final), "r"(1));
+                    int _mma_b_lo_4 = make_warp_uniform(((((smem_kd_trans_addr) >> 4) & 0x3FFF) | 0x1000000) + (issue_smem_stage) * 2304);
+                    asm volatile(
+                    "{\n\t"
+                    ".reg .pred leader, p0, p1;\n\t"
+                    ".reg .b32 dhi, blo, id;\n\t"
+                    ".reg .b64 db;\n\t"
+                    "elect.sync _|leader, 0xFFFFFFFF;\n\t"
+                    "setp.ne.b32 p0, %3, 0;\n\t"
+                    "setp.ne.b32 p1, 1, 0;\n\t"
+                    ""
+                    "mov.b32 dhi, 0x40004040;\n\t"
+                    "mov.b32 id, 136381584;\n\t"
+                    "mov.b32 blo, %1;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [%2], db, id, p0;\n\t"
+                    "add.u32 blo, blo, 128;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [%2 + 8], db, id, p1;\n\t"
+                    "}\n"
+                    :: "r"(tmem_tmem_dh), "r"(_mma_b_lo_4), "r"(tmem_tmem_de_inp), "r"(1));
+                    elect_commit2(dh_ready_addr + (state_stage) * 8, smem_free_addr + (issue_smem_stage) * 8);
+                    issue_smem_stage += 1;
+                    if (issue_smem_stage == 2) { issue_smem_stage = 0; _phase_prep_ready ^= 1; }
+                }
+                if (publish_ready != 0) {
+                    asm volatile("barrier.sync 12, 128;" ::: "memory");
+                    if (warp_id_in_role == 0) {
+                        if (elect_sync()) {
+                            {
+                                unsigned int* _gc_p = reinterpret_cast<unsigned int*>(boundary_ready) + (chunk_global * (long long)num_heads + (long long)head_idx);
+                                unsigned int _gc_old;
+                                asm volatile("atom.release.gpu.global.add.u32 %0, [%1], 1;" : "=r"(_gc_old) : "l"(_gc_p) : "memory");
+                            }
+                        }
+                    }
+                }
+                mbarrier_wait(dh_ready_addr + (state_stage) * 8, _phase_dh_ready);
+                state_stage += 1;
+                if (state_stage == 1) { state_stage = 0; _phase_dr_inp_ready ^= 1; _phase_de_inp_ready ^= 1; _phase_dh_ready ^= 1; }
+            }
+            #pragma unroll
+            for (int final_block = 0; final_block < 4; final_block++) {
+                float _tmem_load_1[32];
+                tmem_ld_x32(&_tmem_load_1[0], taddr + 64 + (unsigned int)tmem_row_base + (unsigned int)(final_block * 32));
+                asm volatile("tcgen05.wait::ld.sync.aligned;");
+                const float2 _scale2_2 = {common_factor, common_factor};
+                #pragma unroll
+                for (int _ls = 0; _ls < 16; _ls++)
+                    mul_f32x2_inplace(&reinterpret_cast<float2*>(_tmem_load_1)[_ls], _scale2_2);
+                #pragma unroll
+                for (int final_vec = 0; final_vec < 4; final_vec++) {
+                    {
+                        unsigned _stv8_3_0 = __float_as_uint(_tmem_load_1[final_vec * 8 + 0]);
+                        unsigned _stv8_3_1 = __float_as_uint(_tmem_load_1[final_vec * 8 + 1]);
+                        unsigned _stv8_3_2 = __float_as_uint(_tmem_load_1[final_vec * 8 + 2]);
+                        unsigned _stv8_3_3 = __float_as_uint(_tmem_load_1[final_vec * 8 + 3]);
+                        unsigned _stv8_3_4 = __float_as_uint(_tmem_load_1[final_vec * 8 + 4]);
+                        unsigned _stv8_3_5 = __float_as_uint(_tmem_load_1[final_vec * 8 + 5]);
+                        unsigned _stv8_3_6 = __float_as_uint(_tmem_load_1[final_vec * 8 + 6]);
+                        unsigned _stv8_3_7 = __float_as_uint(_tmem_load_1[final_vec * 8 + 7]);
+                        asm volatile(
+                            "st.global.v8.b32 [%0], {%1, %2, %3, %4, %5, %6, %7, %8};"
+                            :: "l"((void*)(dinitial_state + (state_base + (long long)(final_block * 32) + (long long)(final_vec * 8)) + (0))), "r"(_stv8_3_0), "r"(_stv8_3_1), "r"(_stv8_3_2), "r"(_stv8_3_3), "r"(_stv8_3_4), "r"(_stv8_3_5), "r"(_stv8_3_6), "r"(_stv8_3_7) : "memory");
+                    }
+                }
+            }
+            if (elect_sync()) {
+                mbarrier_arrive(owners_done_addr);
+            }
+        }
+    }
+    // ---- Role: prep ----
+    if (warp >= 4 && warp <= 7) {
+        asm volatile("setmaxnreg.dec.sync.aligned.u32 80;");
+        { // prep_main
+            int task_idx_1 = blockIdx.x;
+            int seq_idx_1 = seq_order[task_idx_1 / num_heads];
+            int head_idx_1 = task_idx_1 % num_heads;
+            long long bos_1 = cu_seqlens[seq_idx_1];
+            long long eos_1 = cu_seqlens[seq_idx_1 + 1];
+            int seq_len_1 = (int)(eos_1 - bos_1);
+            int num_chunks_1 = (seq_len_1 + 32 - 1) / 32;
+            int warp_id_in_role_1 = (warp - 4);
+            int prep_tid = warp_id_in_role_1 * 32 + lane;
+            int prep_local_warp = warp_id_in_role_1;
+            unsigned int prep_stage = 0;
+            unsigned int _phase_smem_free = 1;
+            #pragma unroll 1
+            for (int reverse_chunk_1 = 0; reverse_chunk_1 < num_chunks_1; reverse_chunk_1++) {
+                mbarrier_wait(smem_free_addr + (prep_stage) * 8, _phase_smem_free);
+                int chunk_idx_1 = num_chunks_1 - 1 - reverse_chunk_1;
+                long long chunk_global_1 = cu_chunk_offsets[seq_idx_1] + (long long)chunk_idx_1;
+                long long tape_vec_base = (chunk_global_1 * (long long)num_heads + (long long)head_idx_1) * 32 * 128;
+                long long restore_base_1 = (chunk_global_1 * (long long)num_heads + (long long)head_idx_1) * 128;
+                #pragma unroll
+                for (int load_pass = 0; load_pass < 4; load_pass++) {
+                    int item = load_pass * 128 + prep_tid;
+                    int row = item / 16;
+                    int segment = item % 16;
+                    long long index = tape_vec_base + (long long)row * 128 + (long long)(segment * 8);
+                    float qd_values[8];
+                    float kd_values[8];
+                    float kr_values[8];
+                    float ki_values[8];
+                    {
+                        const uint4* _vptr_0 = reinterpret_cast<const uint4*>(tape_qd + index);
+                        uint4 _vld_0[1];
+                        #pragma unroll
+                        for (int _blk = 0; _blk < 1; _blk++) {
+                            _vld_0[_blk] = _vptr_0[_blk];
+                            uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
+                            #pragma unroll
+                            for (int _pair = 0; _pair < 4; _pair++) {
+                                asm volatile(
+                                    "{\n\t"
+                                    "shl.b32 %0, %2, 16;\n\t"
+                                    "and.b32 %1, %2, 0xffff0000;\n\t"
+                                    "}\n"
+                                    : "=f"((&qd_values[0 + _blk * 8 + _pair * 2])[0]), "=f"((&qd_values[0 + _blk * 8 + _pair * 2])[1])
+                                    : "r"(_vpairs_0[_pair]));
+                            }
+                        }
+                    }
+                    {
+                        const uint4* _vptr_1 = reinterpret_cast<const uint4*>(tape_kd + index);
+                        uint4 _vld_1[1];
+                        #pragma unroll
+                        for (int _blk = 0; _blk < 1; _blk++) {
+                            _vld_1[_blk] = _vptr_1[_blk];
+                            uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
+                            #pragma unroll
+                            for (int _pair = 0; _pair < 4; _pair++) {
+                                asm volatile(
+                                    "{\n\t"
+                                    "shl.b32 %0, %2, 16;\n\t"
+                                    "and.b32 %1, %2, 0xffff0000;\n\t"
+                                    "}\n"
+                                    : "=f"((&kd_values[0 + _blk * 8 + _pair * 2])[0]), "=f"((&kd_values[0 + _blk * 8 + _pair * 2])[1])
+                                    : "r"(_vpairs_1[_pair]));
+                            }
+                        }
+                    }
+                    {
+                        const uint4* _vptr_2 = reinterpret_cast<const uint4*>(tape_kr + index);
+                        uint4 _vld_2[1];
+                        #pragma unroll
+                        for (int _blk = 0; _blk < 1; _blk++) {
+                            _vld_2[_blk] = _vptr_2[_blk];
+                            uint32_t* _vpairs_2 = reinterpret_cast<uint32_t*>(&_vld_2[_blk]);
+                            #pragma unroll
+                            for (int _pair = 0; _pair < 4; _pair++) {
+                                asm volatile(
+                                    "{\n\t"
+                                    "shl.b32 %0, %2, 16;\n\t"
+                                    "and.b32 %1, %2, 0xffff0000;\n\t"
+                                    "}\n"
+                                    : "=f"((&kr_values[0 + _blk * 8 + _pair * 2])[0]), "=f"((&kr_values[0 + _blk * 8 + _pair * 2])[1])
+                                    : "r"(_vpairs_2[_pair]));
+                            }
+                        }
+                    }
+                    #pragma unroll
+                    for (int elem = 0; elem < 8; elem++) {
+                        float factor = tape_restore_factor[restore_base_1 + (long long)(segment * 8) + (long long)elem];
+                        ki_values[elem] = kr_values[elem] / factor;
+                    }
+                    unsigned int packed[4];
+                    #pragma unroll
+                    for (int _lp = 0; _lp < 4; _lp++) {
+                        __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(qd_values[_lp*2 + 0], qd_values[_lp*2+1 + 0]));
+                        packed[_lp] = *(uint32_t*)&_bf2;
+                    }
+                    #pragma unroll
+                    for (int word = 0; word < 4; word++) {
+                        asm volatile("st.shared.b32 [%0], %1;" :: "r"((smem_qd_addr + prep_stage * 36864 + (unsigned int)(segment * 8 / 64 * 4096 + row * 128 + segment * 8 % 64 * 2 ^ (segment * 8 / 64 * 4096 + row * 128 + segment * 8 % 64 * 2 >> 7 & 7) << 4)) + (unsigned int)(word * 4)), "r"((packed[word])));
+                    }
+                    unsigned int packed_0[4];
+                    #pragma unroll
+                    for (int _lp = 0; _lp < 4; _lp++) {
+                        __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(kd_values[_lp*2 + 0], kd_values[_lp*2+1 + 0]));
+                        packed_0[_lp] = *(uint32_t*)&_bf2;
+                    }
+                    #pragma unroll
+                    for (int word_1 = 0; word_1 < 4; word_1++) {
+                        asm volatile("st.shared.b32 [%0], %1;" :: "r"((smem_kd_addr + prep_stage * 36864 + (unsigned int)(segment * 8 / 64 * 4096 + row * 128 + segment * 8 % 64 * 2 ^ (segment * 8 / 64 * 4096 + row * 128 + segment * 8 % 64 * 2 >> 7 & 7) << 4)) + (unsigned int)(word_1 * 4)), "r"((packed_0[word_1])));
+                    }
+                    unsigned int packed_1[4];
+                    #pragma unroll
+                    for (int _lp = 0; _lp < 4; _lp++) {
+                        __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(kr_values[_lp*2 + 0], kr_values[_lp*2+1 + 0]));
+                        packed_1[_lp] = *(uint32_t*)&_bf2;
+                    }
+                    #pragma unroll
+                    for (int word_2 = 0; word_2 < 4; word_2++) {
+                        asm volatile("st.shared.b32 [%0], %1;" :: "r"((smem_kr_addr + prep_stage * 36864 + (unsigned int)(segment * 8 / 64 * 4096 + row * 128 + segment * 8 % 64 * 2 ^ (segment * 8 / 64 * 4096 + row * 128 + segment * 8 % 64 * 2 >> 7 & 7) << 4)) + (unsigned int)(word_2 * 4)), "r"((packed_1[word_2])));
+                    }
+                    unsigned int packed_2[4];
+                    #pragma unroll
+                    for (int _lp = 0; _lp < 4; _lp++) {
+                        __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(ki_values[_lp*2 + 0], ki_values[_lp*2+1 + 0]));
+                        packed_2[_lp] = *(uint32_t*)&_bf2;
+                    }
+                    #pragma unroll
+                    for (int word_3 = 0; word_3 < 4; word_3++) {
+                        asm volatile("st.shared.b32 [%0], %1;" :: "r"((smem_ki_addr + prep_stage * 36864 + (unsigned int)(segment * 8 / 64 * 4096 + row * 128 + segment * 8 % 64 * 2 ^ (segment * 8 / 64 * 4096 + row * 128 + segment * 8 % 64 * 2 >> 7 & 7) << 4)) + (unsigned int)(word_3 * 4)), "r"((packed_2[word_3])));
+                    }
+                }
+                int j_row = prep_tid / 4;
+                int j_segment = prep_tid % 4;
+                float j_values[8];
+                long long j_base = (chunk_global_1 * (long long)num_heads + (long long)head_idx_1) * 32 * 32;
+                {
+                    const uint4* _vptr_3 = reinterpret_cast<const uint4*>(tape_j + j_base + (long long)j_row * 32 + (long long)(j_segment * 8));
+                    uint4 _vld_3[1];
+                    #pragma unroll
+                    for (int _blk = 0; _blk < 1; _blk++) {
+                        _vld_3[_blk] = _vptr_3[_blk];
+                        uint32_t* _vpairs_3 = reinterpret_cast<uint32_t*>(&_vld_3[_blk]);
+                        #pragma unroll
+                        for (int _pair = 0; _pair < 4; _pair++) {
+                            asm volatile(
+                                "{\n\t"
+                                "shl.b32 %0, %2, 16;\n\t"
+                                "and.b32 %1, %2, 0xffff0000;\n\t"
+                                "}\n"
+                                : "=f"((&j_values[0 + _blk * 8 + _pair * 2])[0]), "=f"((&j_values[0 + _blk * 8 + _pair * 2])[1])
+                                : "r"(_vpairs_3[_pair]));
+                        }
+                    }
+                }
+                unsigned int packed_3[4];
+                #pragma unroll
+                for (int _lp = 0; _lp < 4; _lp++) {
+                    __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(j_values[_lp*2 + 0], j_values[_lp*2+1 + 0]));
+                    packed_3[_lp] = *(uint32_t*)&_bf2;
+                }
+                #pragma unroll
+                for (int word_4 = 0; word_4 < 4; word_4++) {
+                    asm volatile("st.shared.b32 [%0], %1;" :: "r"((smem_j_addr + prep_stage * 36864 + (unsigned int)(j_segment * 8 / 16 * 1024 + j_row * 32 + j_segment * 8 % 16 * 2 ^ (j_segment * 8 / 16 * 1024 + j_row * 32 + j_segment * 8 % 16 * 2 >> 7 & 1) << 4)) + (unsigned int)(word_4 * 4)), "r"((packed_3[word_4])));
+                }
+                asm volatile("fence.proxy.async.shared::cta;" ::: "memory");
+                asm volatile("barrier.sync 8, 128;" ::: "memory");
+                int row_base = prep_local_warp / 2 * 16;
+                int col_base = prep_local_warp % 2 * 16;
+                unsigned int a_frag[4];
+                unsigned int b_frag[4];
+                float acc[8];
+                if (row_base <= col_base) {
+                    asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                        : "=r"(a_frag[0]), "=r"(a_frag[1]), "=r"(a_frag[2]), "=r"(a_frag[3])
+                        : "r"(smem_ki_addr + prep_stage * 36864 + (unsigned int)((lane / 16 / 8 * 256 + (row_base + lane % 16) * 8 + (lane / 16 % 8 * 16 ^ (row_base + lane % 16 & 7) << 4) / 16) * 16))
+                        : "memory");
+                    asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                        : "=r"(b_frag[0]), "=r"(b_frag[1]), "=r"(b_frag[2]), "=r"(b_frag[3])
+                        : "r"(smem_qd_addr + prep_stage * 36864 + (unsigned int)((lane % 16 / 8 / 8 * 256 + (col_base + 8 * (lane / 16) + lane % 8) * 8 + (lane % 16 / 8 % 8 * 16 ^ (col_base + 8 * (lane / 16) + lane % 8 & 7) << 4) / 16) * 16))
+                        : "memory");
+                    asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {0f00000000, 0f00000000, 0f00000000, 0f00000000};\n"
+                        : "=f"(acc[0]), "=f"(acc[1]), "=f"(acc[2]), "=f"(acc[3])
+                        : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[0]), "r"(b_frag[1]));
+                    asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {0f00000000, 0f00000000, 0f00000000, 0f00000000};\n"
+                        : "=f"(acc[4]), "=f"(acc[(4) + 1]), "=f"(acc[(4) + 2]), "=f"(acc[(4) + 3])
+                        : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[2]), "r"(b_frag[(2) + 1]));
+                    asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                        : "=r"(a_frag[0]), "=r"(a_frag[1]), "=r"(a_frag[2]), "=r"(a_frag[3])
+                        : "r"(smem_ki_addr + prep_stage * 36864 + (unsigned int)((lane / 16 / 8 * 256 + (row_base + lane % 16) * 8 + (lane / 16 % 8 * 16 ^ (row_base + lane % 16 & 7) << 4) / 16 ^ 2) * 16))
+                        : "memory");
+                    asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                        : "=r"(b_frag[0]), "=r"(b_frag[1]), "=r"(b_frag[2]), "=r"(b_frag[3])
+                        : "r"(smem_qd_addr + prep_stage * 36864 + (unsigned int)(((lane % 16 / 8 / 8 * 256 + (col_base + 8 * (lane / 16) + lane % 8) * 8 + (lane % 16 / 8 % 8 * 16 ^ (col_base + 8 * (lane / 16) + lane % 8 & 7) << 4) / 16 + 256 ^ 2) - 256) * 16))
+                        : "memory");
+                    asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                        : "+f"(acc[0]), "+f"(acc[1]), "+f"(acc[2]), "+f"(acc[3])
+                        : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[0]), "r"(b_frag[1]));
+                    asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                        : "+f"(acc[4]), "+f"(acc[(4) + 1]), "+f"(acc[(4) + 2]), "+f"(acc[(4) + 3])
+                        : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[2]), "r"(b_frag[(2) + 1]));
+                    asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                        : "=r"(a_frag[0]), "=r"(a_frag[1]), "=r"(a_frag[2]), "=r"(a_frag[3])
+                        : "r"(smem_ki_addr + prep_stage * 36864 + (unsigned int)((lane / 16 / 8 * 256 + (row_base + lane % 16) * 8 + (lane / 16 % 8 * 16 ^ (row_base + lane % 16 & 7) << 4) / 16 ^ 2 ^ 6) * 16))
+                        : "memory");
+                    asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                        : "=r"(b_frag[0]), "=r"(b_frag[1]), "=r"(b_frag[2]), "=r"(b_frag[3])
+                        : "r"(smem_qd_addr + prep_stage * 36864 + (unsigned int)((((lane % 16 / 8 / 8 * 256 + (col_base + 8 * (lane / 16) + lane % 8) * 8 + (lane % 16 / 8 % 8 * 16 ^ (col_base + 8 * (lane / 16) + lane % 8 & 7) << 4) / 16 + 256 ^ 2) - 256 + 256 ^ 6) - 256) * 16))
+                        : "memory");
+                    asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                        : "+f"(acc[0]), "+f"(acc[1]), "+f"(acc[2]), "+f"(acc[3])
+                        : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[0]), "r"(b_frag[1]));
+                    asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                        : "+f"(acc[4]), "+f"(acc[(4) + 1]), "+f"(acc[(4) + 2]), "+f"(acc[(4) + 3])
+                        : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[2]), "r"(b_frag[(2) + 1]));
+                    asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                        : "=r"(a_frag[0]), "=r"(a_frag[1]), "=r"(a_frag[2]), "=r"(a_frag[3])
+                        : "r"(smem_ki_addr + prep_stage * 36864 + (unsigned int)((lane / 16 / 8 * 256 + (row_base + lane % 16) * 8 + (lane / 16 % 8 * 16 ^ (row_base + lane % 16 & 7) << 4) / 16 ^ 2 ^ 6 ^ 2) * 16))
+                        : "memory");
+                    asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                        : "=r"(b_frag[0]), "=r"(b_frag[1]), "=r"(b_frag[2]), "=r"(b_frag[3])
+                        : "r"(smem_qd_addr + prep_stage * 36864 + (unsigned int)(((((lane % 16 / 8 / 8 * 256 + (col_base + 8 * (lane / 16) + lane % 8) * 8 + (lane % 16 / 8 % 8 * 16 ^ (col_base + 8 * (lane / 16) + lane % 8 & 7) << 4) / 16 + 256 ^ 2) - 256 + 256 ^ 6) - 256 + 256 ^ 2) - 256) * 16))
+                        : "memory");
+                    asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                        : "+f"(acc[0]), "+f"(acc[1]), "+f"(acc[2]), "+f"(acc[3])
+                        : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[0]), "r"(b_frag[1]));
+                    asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                        : "+f"(acc[4]), "+f"(acc[(4) + 1]), "+f"(acc[(4) + 2]), "+f"(acc[(4) + 3])
+                        : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[2]), "r"(b_frag[(2) + 1]));
+                    asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                        : "=r"(a_frag[0]), "=r"(a_frag[1]), "=r"(a_frag[2]), "=r"(a_frag[3])
+                        : "r"(smem_ki_addr + prep_stage * 36864 + (unsigned int)(((lane / 16 / 8 * 256 + (row_base + lane % 16) * 8 + (lane / 16 % 8 * 16 ^ (row_base + lane % 16 & 7) << 4) / 16 ^ 2 ^ 6 ^ 2 ^ 6) + 256) * 16))
+                        : "memory");
+                    asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                        : "=r"(b_frag[0]), "=r"(b_frag[1]), "=r"(b_frag[2]), "=r"(b_frag[3])
+                        : "r"(smem_qd_addr + prep_stage * 36864 + (unsigned int)((((((lane % 16 / 8 / 8 * 256 + (col_base + 8 * (lane / 16) + lane % 8) * 8 + (lane % 16 / 8 % 8 * 16 ^ (col_base + 8 * (lane / 16) + lane % 8 & 7) << 4) / 16 + 256 ^ 2) - 256 + 256 ^ 6) - 256 + 256 ^ 2) - 256 + 256 ^ 6) + 256 - 256) * 16))
+                        : "memory");
+                    asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                        : "+f"(acc[0]), "+f"(acc[1]), "+f"(acc[2]), "+f"(acc[3])
+                        : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[0]), "r"(b_frag[1]));
+                    asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                        : "+f"(acc[4]), "+f"(acc[(4) + 1]), "+f"(acc[(4) + 2]), "+f"(acc[(4) + 3])
+                        : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[2]), "r"(b_frag[(2) + 1]));
+                    asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                        : "=r"(a_frag[0]), "=r"(a_frag[1]), "=r"(a_frag[2]), "=r"(a_frag[3])
+                        : "r"(smem_ki_addr + prep_stage * 36864 + (unsigned int)(((lane / 16 / 8 * 256 + (row_base + lane % 16) * 8 + (lane / 16 % 8 * 16 ^ (row_base + lane % 16 & 7) << 4) / 16 ^ 2 ^ 6 ^ 2 ^ 6) + 256 ^ 2) * 16))
+                        : "memory");
+                    asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                        : "=r"(b_frag[0]), "=r"(b_frag[1]), "=r"(b_frag[2]), "=r"(b_frag[3])
+                        : "r"(smem_qd_addr + prep_stage * 36864 + (unsigned int)(((((((lane % 16 / 8 / 8 * 256 + (col_base + 8 * (lane / 16) + lane % 8) * 8 + (lane % 16 / 8 % 8 * 16 ^ (col_base + 8 * (lane / 16) + lane % 8 & 7) << 4) / 16 + 256 ^ 2) - 256 + 256 ^ 6) - 256 + 256 ^ 2) - 256 + 256 ^ 6) + 256 - 256 + 256 ^ 2) - 256) * 16))
+                        : "memory");
+                    asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                        : "+f"(acc[0]), "+f"(acc[1]), "+f"(acc[2]), "+f"(acc[3])
+                        : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[0]), "r"(b_frag[1]));
+                    asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                        : "+f"(acc[4]), "+f"(acc[(4) + 1]), "+f"(acc[(4) + 2]), "+f"(acc[(4) + 3])
+                        : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[2]), "r"(b_frag[(2) + 1]));
+                    asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                        : "=r"(a_frag[0]), "=r"(a_frag[1]), "=r"(a_frag[2]), "=r"(a_frag[3])
+                        : "r"(smem_ki_addr + prep_stage * 36864 + (unsigned int)(((lane / 16 / 8 * 256 + (row_base + lane % 16) * 8 + (lane / 16 % 8 * 16 ^ (row_base + lane % 16 & 7) << 4) / 16 ^ 2 ^ 6 ^ 2 ^ 6) + 256 ^ 2 ^ 6) * 16))
+                        : "memory");
+                    asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                        : "=r"(b_frag[0]), "=r"(b_frag[1]), "=r"(b_frag[2]), "=r"(b_frag[3])
+                        : "r"(smem_qd_addr + prep_stage * 36864 + (unsigned int)((((((((lane % 16 / 8 / 8 * 256 + (col_base + 8 * (lane / 16) + lane % 8) * 8 + (lane % 16 / 8 % 8 * 16 ^ (col_base + 8 * (lane / 16) + lane % 8 & 7) << 4) / 16 + 256 ^ 2) - 256 + 256 ^ 6) - 256 + 256 ^ 2) - 256 + 256 ^ 6) + 256 - 256 + 256 ^ 2) - 256 + 256 ^ 6) - 256) * 16))
+                        : "memory");
+                    asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                        : "+f"(acc[0]), "+f"(acc[1]), "+f"(acc[2]), "+f"(acc[3])
+                        : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[0]), "r"(b_frag[1]));
+                    asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                        : "+f"(acc[4]), "+f"(acc[(4) + 1]), "+f"(acc[(4) + 2]), "+f"(acc[(4) + 3])
+                        : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[2]), "r"(b_frag[(2) + 1]));
+                    asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                        : "=r"(a_frag[0]), "=r"(a_frag[1]), "=r"(a_frag[2]), "=r"(a_frag[3])
+                        : "r"(smem_ki_addr + prep_stage * 36864 + (unsigned int)(((lane / 16 / 8 * 256 + (row_base + lane % 16) * 8 + (lane / 16 % 8 * 16 ^ (row_base + lane % 16 & 7) << 4) / 16 ^ 2 ^ 6 ^ 2 ^ 6) + 256 ^ 2 ^ 6 ^ 2) * 16))
+                        : "memory");
+                    asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                        : "=r"(b_frag[0]), "=r"(b_frag[1]), "=r"(b_frag[2]), "=r"(b_frag[3])
+                        : "r"(smem_qd_addr + prep_stage * 36864 + (unsigned int)(((((((((lane % 16 / 8 / 8 * 256 + (col_base + 8 * (lane / 16) + lane % 8) * 8 + (lane % 16 / 8 % 8 * 16 ^ (col_base + 8 * (lane / 16) + lane % 8 & 7) << 4) / 16 + 256 ^ 2) - 256 + 256 ^ 6) - 256 + 256 ^ 2) - 256 + 256 ^ 6) + 256 - 256 + 256 ^ 2) - 256 + 256 ^ 6) - 256 + 256 ^ 2) - 256) * 16))
+                        : "memory");
+                    asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                        : "+f"(acc[0]), "+f"(acc[1]), "+f"(acc[2]), "+f"(acc[3])
+                        : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[0]), "r"(b_frag[1]));
+                    asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                        : "+f"(acc[4]), "+f"(acc[(4) + 1]), "+f"(acc[(4) + 2]), "+f"(acc[(4) + 3])
+                        : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[2]), "r"(b_frag[(2) + 1]));
+                } else {
+                    acc[0] = 0.0f;
+                    acc[1] = 0.0f;
+                    acc[2] = 0.0f;
+                    acc[3] = 0.0f;
+                    acc[4] = 0.0f;
+                    acc[5] = 0.0f;
+                    acc[6] = 0.0f;
+                    acc[7] = 0.0f;
+                }
+                int row0 = row_base + lane / 4;
+                int row1 = row0 + 8;
+                int col0 = col_base + lane % 4 * 2;
+                float values[8];
+                values[0] = 0.0f;
+                values[1] = 0.0f;
+                values[2] = 0.0f;
+                values[3] = 0.0f;
+                values[4] = 0.0f;
+                values[5] = 0.0f;
+                values[6] = 0.0f;
+                values[7] = 0.0f;
+                if (row0 <= col0) {
+                    values[0] = acc[0];
+                }
+                if (row0 <= col0 + 1) {
+                    values[1] = acc[1];
+                }
+                if (row1 <= col0) {
+                    values[2] = acc[2];
+                }
+                if (row1 <= col0 + 1) {
+                    values[3] = acc[3];
+                }
+                if (row0 <= col0 + 8) {
+                    values[4] = acc[4];
+                }
+                if (row0 <= col0 + 9) {
+                    values[5] = acc[5];
+                }
+                if (row1 <= col0 + 8) {
+                    values[6] = acc[6];
+                }
+                if (row1 <= col0 + 9) {
+                    values[7] = acc[7];
+                }
+                unsigned int packed_0_1[4];
+                #pragma unroll
+                for (int _lp = 0; _lp < 4; _lp++) {
+                    __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(values[_lp*2 + 0], values[_lp*2+1 + 0]));
+                    packed_0_1[_lp] = *(uint32_t*)&_bf2;
+                }
+                int lane_row = lane % 16;
+                int lane_col = lane / 16 * 8;
+                uint32_t _stmatrix_addr_4 = static_cast<uint32_t>((unsigned long long)(smem_n_addr + prep_stage * 36864 + (unsigned int)((col_base + lane_col) / 16 * 1024 + (row_base + lane_row) * 32 + (col_base + lane_col) % 16 * 2 ^ ((col_base + lane_col) / 16 * 1024 + (row_base + lane_row) * 32 + (col_base + lane_col) % 16 * 2 >> 7 & 1) << 4)));
+                asm volatile("stmatrix.sync.aligned.m8n8.x4.shared.b16 [%0], {%1, %2, %3, %4};\n"
+                    :: "r"(_stmatrix_addr_4), "r"(*reinterpret_cast<const uint32_t*>(&packed_0_1[0])), "r"(*reinterpret_cast<const uint32_t*>(&packed_0_1[1])), "r"(*reinterpret_cast<const uint32_t*>(&packed_0_1[2])), "r"(*reinterpret_cast<const uint32_t*>(&packed_0_1[3]))
+                    : "memory");
+                asm volatile("fence.proxy.async.shared::cta;" ::: "memory");
+                asm volatile("barrier.sync 8, 128;" ::: "memory");
+                if (prep_local_warp == 2) {
+                    if (elect_sync()) {
+                        mbarrier_arrive(prep_ready_addr + (prep_stage) * 8);
+                    }
+                }
+                prep_stage += 1;
+                if (prep_stage == 2) { prep_stage = 0; _phase_smem_free ^= 1; }
+            }
+            unsigned int _phase_owners_done_0 = 0;
+            if (prep_local_warp == 2) {
+                mbarrier_wait(owners_done_addr, _phase_owners_done_0);
+                _phase_owners_done_0 ^= 1;
+                int _tmem_dealloc_addr = *((volatile int*)tmem_addr_storage);
+                asm volatile("tcgen05.dealloc.cta_group::1.sync.aligned.b32 %0, %1;" :: "r"(_tmem_dealloc_addr), "r"(256));
+            }
+        }
+    }
+    // ---- Role: high_token ----
+    if (warp >= 8 && warp <= 11) {
+        asm volatile("setmaxnreg.dec.sync.aligned.u32 80;");
+        { // high_token_main
+            int task_idx_2 = blockIdx.x;
+            int seq_idx_2 = seq_order[task_idx_2 / num_heads];
+            int head_idx_2 = task_idx_2 % num_heads;
+            long long bos_2 = cu_seqlens[seq_idx_2];
+            long long eos_2 = cu_seqlens[seq_idx_2 + 1];
+            int seq_len_2 = (int)(eos_2 - bos_2);
+            int num_chunks_2 = (seq_len_2 + 32 - 1) / 32;
+            const int token_offset = 16;
+            unsigned int token_stage = 0;
+            unsigned int _phase_dr_ready = 0;
+            unsigned int _phase_dx_ready = 0;
+            unsigned int _phase_dh_ready_1 = 0;
+            #pragma unroll 1
+            for (int reverse_chunk_2 = 0; reverse_chunk_2 < num_chunks_2; reverse_chunk_2++) {
+                int chunk_idx_2 = num_chunks_2 - 1 - reverse_chunk_2;
+                long long chunk_global_2 = cu_chunk_offsets[seq_idx_2] + (long long)chunk_idx_2;
+                long long chunk_start = bos_2 + (long long)chunk_idx_2 * 32;
+                float do_values[16];
+                do_values[0] = 0.0f;
+                do_values[1] = 0.0f;
+                do_values[2] = 0.0f;
+                do_values[3] = 0.0f;
+                do_values[4] = 0.0f;
+                do_values[5] = 0.0f;
+                do_values[6] = 0.0f;
+                do_values[7] = 0.0f;
+                do_values[8] = 0.0f;
+                do_values[9] = 0.0f;
+                do_values[10] = 0.0f;
+                do_values[11] = 0.0f;
+                do_values[12] = 0.0f;
+                do_values[13] = 0.0f;
+                do_values[14] = 0.0f;
+                do_values[15] = 0.0f;
+                #pragma unroll
+                for (int row_pass = 0; row_pass < 1; row_pass++) {
+                    int warp_id_in_role_2 = (warp - 8);
+                    int state_row_1 = (warp_id_in_role_2 + row_pass) * 32 + lane;
+                    #pragma unroll
+                    for (int token_local = 0; token_local < 16; token_local++) {
+                        int token_col = token_offset + token_local;
+                        long long token_idx = chunk_start + (long long)token_col;
+                        if (token_idx < eos_2) {
+                            do_values[row_pass * 16 + token_local] = (float)do_[(token_idx * (long long)num_heads + (long long)head_idx_2) * 128 + (long long)state_row_1];
+                        }
+                    }
+                }
+                uint32_t do_values_bf16[8];
+                #pragma unroll
+                for (int _lp = 0; _lp < 8; _lp++) {
+                    __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(do_values[_lp*2 + 0], do_values[_lp*2+1 + 0]));
+                    do_values_bf16[_lp] = *(uint32_t*)&_bf2;
+                }
+                #pragma unroll
+                for (int row_pass2 = 0; row_pass2 < 1; row_pass2++) {
+                    int warp_id_in_role_3 = (warp - 8);
+                    int row_group = warp_id_in_role_3 + row_pass2;
+                    int tmem_row_base_1 = row_group * 32 << 16;
+                    tmem_st_x8_u32(taddr + 224 + (unsigned int)tmem_row_base_1 + (unsigned int)(token_offset / 2), (const uint32_t*)(do_values_bf16 + row_pass2 * 8));
+                }
+                asm volatile("tcgen05.wait::st.sync.aligned;" ::: "memory");
+                asm volatile("barrier.sync 9, 384;" ::: "memory");
+                mbarrier_wait(dr_ready_addr + (token_stage) * 8, _phase_dr_ready);
+                #pragma unroll
+                for (int dr_row_pass = 0; dr_row_pass < 1; dr_row_pass++) {
+                    int warp_id_in_role_4 = (warp - 8);
+                    int row_group2 = warp_id_in_role_4 + dr_row_pass;
+                    int state_row2 = row_group2 * 32 + lane;
+                    int tmem_row_base2 = row_group2 * 32 << 16;
+                    float _tmem_load_4[16];
+                    tmem_ld_x16(&_tmem_load_4[0], taddr + 192 + (unsigned int)tmem_row_base2 + (unsigned int)token_offset);
+                    asm volatile("tcgen05.wait::ld.sync.aligned;");
+                    long long dr_tape_base = ((chunk_global_2 * (long long)num_heads + (long long)head_idx_2) * 128 + (long long)state_row2) * 32;
+                    #pragma unroll
+                    for (int dr_store_vec = 0; dr_store_vec < 2; dr_store_vec++) {
+                        {
+                            __nv_bfloat162 _pk[4];
+                            _pk[0] = __floats2bfloat162_rn(_tmem_load_4[dr_store_vec * 8 + 0], _tmem_load_4[dr_store_vec * 8 + 1]);
+                            _pk[1] = __floats2bfloat162_rn(_tmem_load_4[dr_store_vec * 8 + 2], _tmem_load_4[dr_store_vec * 8 + 3]);
+                            _pk[2] = __floats2bfloat162_rn(_tmem_load_4[dr_store_vec * 8 + 4], _tmem_load_4[dr_store_vec * 8 + 5]);
+                            _pk[3] = __floats2bfloat162_rn(_tmem_load_4[dr_store_vec * 8 + 6], _tmem_load_4[dr_store_vec * 8 + 7]);
+                            *reinterpret_cast<uint4*>(&((__nv_bfloat16*)(chunk_dr + (dr_tape_base + (long long)token_offset + (long long)(dr_store_vec * 8))))[0]) = *reinterpret_cast<uint4*>(&_pk[0]);
+                        }
+                    }
+                    uint32_t _tmem_load_4_bf16[8];
+                    #pragma unroll
+                    for (int _lp = 0; _lp < 8; _lp++) {
+                        __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(_tmem_load_4[_lp*2 + 0], _tmem_load_4[_lp*2+1 + 0]));
+                        _tmem_load_4_bf16[_lp] = *(uint32_t*)&_bf2;
+                    }
+                    tmem_st_x8_u32(taddr + 192 + (unsigned int)tmem_row_base2 + (unsigned int)(token_offset / 2), (const uint32_t*)_tmem_load_4_bf16);
+                    tmem_st_x8_u32(taddr + (unsigned int)tmem_row_base2 + (unsigned int)(token_offset / 2), (const uint32_t*)(do_values_bf16 + dr_row_pass * 8));
+                }
+                asm volatile("tcgen05.wait::st.sync.aligned;" ::: "memory");
+                asm volatile("barrier.sync 10, 256;" ::: "memory");
+                mbarrier_wait(dx_ready_addr + (token_stage) * 8, _phase_dx_ready);
+                long long beta_token = chunk_start + (long long)lane;
+                float beta_lane = 0.0f;
+                if (beta_token < eos_2) {
+                    beta_lane = beta_active[beta_token * (long long)num_heads + (long long)head_idx_2];
+                }
+                #pragma unroll
+                for (int dx_row_pass = 0; dx_row_pass < 1; dx_row_pass++) {
+                    int warp_id_in_role_5 = (warp - 8);
+                    int row_group3 = warp_id_in_role_5 + dx_row_pass;
+                    int state_row3 = row_group3 * 32 + lane;
+                    int tmem_row_base3 = row_group3 * 32 << 16;
+                    float _tmem_load_5[16];
+                    tmem_ld_x16(&_tmem_load_5[0], taddr + 224 + (unsigned int)tmem_row_base3 + (unsigned int)token_offset);
+                    asm volatile("tcgen05.wait::ld.sync.aligned;");
+                    long long dx_tape_base = ((chunk_global_2 * (long long)num_heads + (long long)head_idx_2) * 128 + (long long)state_row3) * 32;
+                    #pragma unroll
+                    for (int dx_store_vec = 0; dx_store_vec < 2; dx_store_vec++) {
+                        {
+                            __nv_bfloat162 _pk[4];
+                            _pk[0] = __floats2bfloat162_rn(_tmem_load_5[dx_store_vec * 8 + 0], _tmem_load_5[dx_store_vec * 8 + 1]);
+                            _pk[1] = __floats2bfloat162_rn(_tmem_load_5[dx_store_vec * 8 + 2], _tmem_load_5[dx_store_vec * 8 + 3]);
+                            _pk[2] = __floats2bfloat162_rn(_tmem_load_5[dx_store_vec * 8 + 4], _tmem_load_5[dx_store_vec * 8 + 5]);
+                            _pk[3] = __floats2bfloat162_rn(_tmem_load_5[dx_store_vec * 8 + 6], _tmem_load_5[dx_store_vec * 8 + 7]);
+                            *reinterpret_cast<uint4*>(&((__nv_bfloat16*)(chunk_dx + (dx_tape_base + (long long)token_offset + (long long)(dx_store_vec * 8))))[0]) = *reinterpret_cast<uint4*>(&_pk[0]);
+                        }
+                    }
+                    #pragma unroll
+                    for (int token_local2 = 0; token_local2 < 16; token_local2++) {
+                        int token_col2 = token_offset + token_local2;
+                        float _shfl_2 = __shfl_sync(0xFFFFFFFF, beta_lane, token_col2);
+                        float beta_value = _shfl_2;
+                        _tmem_load_5[token_local2] = _tmem_load_5[token_local2] * (-beta_value);
+                    }
+                    uint32_t _tmem_load_5_bf16[8];
+                    #pragma unroll
+                    for (int _lp = 0; _lp < 8; _lp++) {
+                        __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(_tmem_load_5[_lp*2 + 0], _tmem_load_5[_lp*2+1 + 0]));
+                        _tmem_load_5_bf16[_lp] = *(uint32_t*)&_bf2;
+                    }
+                    tmem_st_x8_u32(taddr + 224 + (unsigned int)tmem_row_base3 + (unsigned int)(token_offset / 2), (const uint32_t*)_tmem_load_5_bf16);
+                }
+                asm volatile("tcgen05.wait::st.sync.aligned;" ::: "memory");
+                asm volatile("barrier.sync 11, 256;" ::: "memory");
+                if (publish_ready != 0) {
+                    asm volatile("barrier.sync 14, 128;" ::: "memory");
+                    int warp_id_in_role_6 = (warp - 8);
+                    if (warp_id_in_role_6 == 0) {
+                        if (elect_sync()) {
+                            {
+                                unsigned int* _gc_p = reinterpret_cast<unsigned int*>(boundary_ready) + (chunk_global_2 * (long long)num_heads + (long long)head_idx_2);
+                                unsigned int _gc_old;
+                                asm volatile("atom.release.gpu.global.add.u32 %0, [%1], 1;" : "=r"(_gc_old) : "l"(_gc_p) : "memory");
+                            }
+                        }
+                    }
+                }
+                mbarrier_wait(dh_ready_addr + (token_stage) * 8, _phase_dh_ready_1);
+                token_stage += 1;
+                if (token_stage == 1) { token_stage = 0; _phase_dr_ready ^= 1; _phase_dx_ready ^= 1; _phase_dh_ready_1 ^= 1; }
+            }
+            if (elect_sync()) {
+                mbarrier_arrive(owners_done_addr);
+            }
+        }
+    }
+    // ---- Role: low_token ----
+    if (warp >= 12 && warp <= 15) {
+        asm volatile("setmaxnreg.dec.sync.aligned.u32 80;");
+        { // low_token_main
+            int task_idx_3 = blockIdx.x;
+            int seq_idx_3 = seq_order[task_idx_3 / num_heads];
+            int head_idx_3 = task_idx_3 % num_heads;
+            long long bos_3 = cu_seqlens[seq_idx_3];
+            long long eos_3 = cu_seqlens[seq_idx_3 + 1];
+            int seq_len_3 = (int)(eos_3 - bos_3);
+            int num_chunks_3 = (seq_len_3 + 32 - 1) / 32;
+            int warp_id_in_role_7 = (warp - 12);
+            int state_row_2 = warp_id_in_role_7 * 32 + lane;
+            int tmem_row_base_2 = warp_id_in_role_7 * 32 << 16;
+            unsigned int low_token_stage = 0;
+            unsigned int _phase_dr_ready_1 = 0;
+            unsigned int _phase_dx_ready_1 = 0;
+            unsigned int _phase_dh_ready_2 = 0;
+            #pragma unroll 1
+            for (int reverse_chunk_3 = 0; reverse_chunk_3 < num_chunks_3; reverse_chunk_3++) {
+                int chunk_idx_3 = num_chunks_3 - 1 - reverse_chunk_3;
+                long long chunk_global_3 = cu_chunk_offsets[seq_idx_3] + (long long)chunk_idx_3;
+                long long chunk_start_1 = bos_3 + (long long)chunk_idx_3 * 32;
+                float do_values_1[16];
+                do_values_1[0] = 0.0f;
+                do_values_1[1] = 0.0f;
+                do_values_1[2] = 0.0f;
+                do_values_1[3] = 0.0f;
+                do_values_1[4] = 0.0f;
+                do_values_1[5] = 0.0f;
+                do_values_1[6] = 0.0f;
+                do_values_1[7] = 0.0f;
+                do_values_1[8] = 0.0f;
+                do_values_1[9] = 0.0f;
+                do_values_1[10] = 0.0f;
+                do_values_1[11] = 0.0f;
+                do_values_1[12] = 0.0f;
+                do_values_1[13] = 0.0f;
+                do_values_1[14] = 0.0f;
+                do_values_1[15] = 0.0f;
+                #pragma unroll
+                for (int token_col_1 = 0; token_col_1 < 16; token_col_1++) {
+                    long long token_idx_1 = chunk_start_1 + (long long)token_col_1;
+                    if (token_idx_1 < eos_3) {
+                        do_values_1[token_col_1] = (float)do_[(token_idx_1 * (long long)num_heads + (long long)head_idx_3) * 128 + (long long)state_row_2];
+                    }
+                }
+                uint32_t do_values_bf16_1[8];
+                #pragma unroll
+                for (int _lp = 0; _lp < 8; _lp++) {
+                    __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(do_values_1[_lp*2 + 0], do_values_1[_lp*2+1 + 0]));
+                    do_values_bf16_1[_lp] = *(uint32_t*)&_bf2;
+                }
+                tmem_st_x8_u32(taddr + 224 + (unsigned int)tmem_row_base_2, (const uint32_t*)do_values_bf16_1);
+                asm volatile("tcgen05.wait::st.sync.aligned;" ::: "memory");
+                asm volatile("barrier.sync 9, 384;" ::: "memory");
+                mbarrier_wait(dr_ready_addr + (low_token_stage) * 8, _phase_dr_ready_1);
+                float _tmem_load_2[16];
+                tmem_ld_x16(&_tmem_load_2[0], taddr + 192 + (unsigned int)tmem_row_base_2);
+                asm volatile("tcgen05.wait::ld.sync.aligned;");
+                long long dr_tape_base_1 = ((chunk_global_3 * (long long)num_heads + (long long)head_idx_3) * 128 + (long long)state_row_2) * 32;
+                #pragma unroll
+                for (int dr_store_vec_1 = 0; dr_store_vec_1 < 2; dr_store_vec_1++) {
+                    {
+                        __nv_bfloat162 _pk[4];
+                        _pk[0] = __floats2bfloat162_rn(_tmem_load_2[dr_store_vec_1 * 8 + 0], _tmem_load_2[dr_store_vec_1 * 8 + 1]);
+                        _pk[1] = __floats2bfloat162_rn(_tmem_load_2[dr_store_vec_1 * 8 + 2], _tmem_load_2[dr_store_vec_1 * 8 + 3]);
+                        _pk[2] = __floats2bfloat162_rn(_tmem_load_2[dr_store_vec_1 * 8 + 4], _tmem_load_2[dr_store_vec_1 * 8 + 5]);
+                        _pk[3] = __floats2bfloat162_rn(_tmem_load_2[dr_store_vec_1 * 8 + 6], _tmem_load_2[dr_store_vec_1 * 8 + 7]);
+                        *reinterpret_cast<uint4*>(&((__nv_bfloat16*)(chunk_dr + (dr_tape_base_1 + (long long)(dr_store_vec_1 * 8))))[0]) = *reinterpret_cast<uint4*>(&_pk[0]);
+                    }
+                }
+                uint32_t _tmem_load_2_bf16[8];
+                #pragma unroll
+                for (int _lp = 0; _lp < 8; _lp++) {
+                    __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(_tmem_load_2[_lp*2 + 0], _tmem_load_2[_lp*2+1 + 0]));
+                    _tmem_load_2_bf16[_lp] = *(uint32_t*)&_bf2;
+                }
+                tmem_st_x8_u32(taddr + 192 + (unsigned int)tmem_row_base_2, (const uint32_t*)_tmem_load_2_bf16);
+                tmem_st_x8_u32(taddr + (unsigned int)tmem_row_base_2, (const uint32_t*)do_values_bf16_1);
+                asm volatile("tcgen05.wait::st.sync.aligned;" ::: "memory");
+                asm volatile("barrier.sync 10, 256;" ::: "memory");
+                if (warp_id_in_role_7 == 0) {
+                    if (elect_sync()) {
+                        mbarrier_arrive(dr_inp_ready_addr + (low_token_stage) * 8);
+                    }
+                }
+                mbarrier_wait(dx_ready_addr + (low_token_stage) * 8, _phase_dx_ready_1);
+                float _tmem_load_3[16];
+                tmem_ld_x16(&_tmem_load_3[0], taddr + 224 + (unsigned int)tmem_row_base_2);
+                asm volatile("tcgen05.wait::ld.sync.aligned;");
+                #pragma unroll
+                for (int dx_store_vec_1 = 0; dx_store_vec_1 < 2; dx_store_vec_1++) {
+                    {
+                        __nv_bfloat162 _pk[4];
+                        _pk[0] = __floats2bfloat162_rn(_tmem_load_3[dx_store_vec_1 * 8 + 0], _tmem_load_3[dx_store_vec_1 * 8 + 1]);
+                        _pk[1] = __floats2bfloat162_rn(_tmem_load_3[dx_store_vec_1 * 8 + 2], _tmem_load_3[dx_store_vec_1 * 8 + 3]);
+                        _pk[2] = __floats2bfloat162_rn(_tmem_load_3[dx_store_vec_1 * 8 + 4], _tmem_load_3[dx_store_vec_1 * 8 + 5]);
+                        _pk[3] = __floats2bfloat162_rn(_tmem_load_3[dx_store_vec_1 * 8 + 6], _tmem_load_3[dx_store_vec_1 * 8 + 7]);
+                        *reinterpret_cast<uint4*>(&((__nv_bfloat16*)(chunk_dx + (dr_tape_base_1 + (long long)(dx_store_vec_1 * 8))))[0]) = *reinterpret_cast<uint4*>(&_pk[0]);
+                    }
+                }
+                long long beta_token_1 = chunk_start_1 + (long long)lane;
+                float beta_lane_1 = 0.0f;
+                if (beta_token_1 < eos_3) {
+                    beta_lane_1 = beta_active[beta_token_1 * (long long)num_heads + (long long)head_idx_3];
+                }
+                #pragma unroll
+                for (int token_col2_1 = 0; token_col2_1 < 16; token_col2_1++) {
+                    float _shfl_1 = __shfl_sync(0xFFFFFFFF, beta_lane_1, token_col2_1);
+                    float beta_value_1 = _shfl_1;
+                    _tmem_load_3[token_col2_1] = _tmem_load_3[token_col2_1] * (-beta_value_1);
+                }
+                uint32_t _tmem_load_3_bf16[8];
+                #pragma unroll
+                for (int _lp = 0; _lp < 8; _lp++) {
+                    __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(_tmem_load_3[_lp*2 + 0], _tmem_load_3[_lp*2+1 + 0]));
+                    _tmem_load_3_bf16[_lp] = *(uint32_t*)&_bf2;
+                }
+                tmem_st_x8_u32(taddr + 224 + (unsigned int)tmem_row_base_2, (const uint32_t*)_tmem_load_3_bf16);
+                asm volatile("tcgen05.wait::st.sync.aligned;" ::: "memory");
+                asm volatile("barrier.sync 11, 256;" ::: "memory");
+                if (warp_id_in_role_7 == 0) {
+                    if (elect_sync()) {
+                        mbarrier_arrive(de_inp_ready_addr + (low_token_stage) * 8);
+                    }
+                }
+                if (publish_ready != 0) {
+                    asm volatile("barrier.sync 13, 128;" ::: "memory");
+                    if (warp_id_in_role_7 == 0) {
+                        if (elect_sync()) {
+                            {
+                                unsigned int* _gc_p = reinterpret_cast<unsigned int*>(boundary_ready) + (chunk_global_3 * (long long)num_heads + (long long)head_idx_3);
+                                unsigned int _gc_old;
+                                asm volatile("atom.release.gpu.global.add.u32 %0, [%1], 1;" : "=r"(_gc_old) : "l"(_gc_p) : "memory");
+                            }
+                        }
+                    }
+                }
+                mbarrier_wait(dh_ready_addr + (low_token_stage) * 8, _phase_dh_ready_2);
+                low_token_stage += 1;
+                if (low_token_stage == 1) { low_token_stage = 0; _phase_dr_ready_1 ^= 1; _phase_dx_ready_1 ^= 1; _phase_dh_ready_2 ^= 1; }
+            }
+            if (elect_sync()) {
+                mbarrier_arrive(owners_done_addr);
+            }
+        }
+    }
+
+    // Cleanup
+}
+
+} // extern "C"
+
+#undef FLASHKDA_INF
+#undef NUM_PREP_PIPE_STAGES
+#undef NUM_REVERSE_PIPE_STAGES
+#undef SMEM_SMEM_J_OFF
+#undef SMEM_SMEM_J_STAGE_BYTES
+#undef SMEM_SMEM_J_STRIDE
+#undef SMEM_SMEM_J_TRANS_OFF
+#undef SMEM_SMEM_J_TRANS_STAGE_BYTES
+#undef SMEM_SMEM_J_TRANS_STRIDE
+#undef SMEM_SMEM_KD_OFF
+#undef SMEM_SMEM_KD_STAGE_BYTES
+#undef SMEM_SMEM_KD_STRIDE
+#undef SMEM_SMEM_KD_TRANS_OFF
+#undef SMEM_SMEM_KD_TRANS_STAGE_BYTES
+#undef SMEM_SMEM_KD_TRANS_STRIDE
+#undef SMEM_SMEM_KI_OFF
+#undef SMEM_SMEM_KI_STAGE_BYTES
+#undef SMEM_SMEM_KI_STRIDE
+#undef SMEM_SMEM_KR_OFF
+#undef SMEM_SMEM_KR_STAGE_BYTES
+#undef SMEM_SMEM_KR_STRIDE
+#undef SMEM_SMEM_N_OFF
+#undef SMEM_SMEM_N_STAGE_BYTES
+#undef SMEM_SMEM_N_STRIDE
+#undef SMEM_SMEM_QD_OFF
+#undef SMEM_SMEM_QD_STAGE_BYTES
+#undef SMEM_SMEM_QD_STRIDE
+#undef SMEM_SMEM_QD_TRANS_OFF
+#undef SMEM_SMEM_QD_TRANS_STAGE_BYTES
+#undef SMEM_SMEM_QD_TRANS_STRIDE
+#undef SMEM_TOTAL
+#undef THREADS
+#undef TMEM_NCOLS
+#undef TMEM_TMEM_DE_INP_OFFSET
+#undef TMEM_TMEM_DH_INP_OFFSET
+#undef TMEM_TMEM_DH_OFFSET
+#undef TMEM_TMEM_DO_FINAL_OFFSET
+#undef TMEM_TMEM_DO_INITIAL_OFFSET
+#undef TMEM_TMEM_DR_INP_OFFSET
+#undef TMEM_TMEM_DR_OFFSET
+#undef TMEM_TMEM_DX_OFFSET
+#undef de_inp_ready_addr
+#undef dh_ready_addr
+#undef dr_inp_ready_addr
+#undef dr_ready_addr
+#undef dx_ready_addr
+#undef owners_done_addr
+#undef prep_ready_addr
+#undef smem_free_addr
+#undef smem_j_addr
+#undef smem_j_trans_addr
+#undef smem_kd_addr
+#undef smem_kd_trans_addr
+#undef smem_ki_addr
+#undef smem_kr_addr
+#undef smem_n_addr
+#undef smem_qd_addr
+#undef smem_qd_trans_addr
+
+#define FLASHKDA_INF CUDART_INF_F
+#define TMEM_NCOLS 496
+#define TMEM_TMEM_A_DH_OFFSET 0
+#define TMEM_TMEM_A_STATE_OFFSET 64
+#define TMEM_TMEM_A_K_OFFSET 128
+#define TMEM_TMEM_A_Q_OFFSET 144
+#define TMEM_TMEM_A_I_OFFSET 160
+#define TMEM_TMEM_DKR_OFFSET 176
+#define TMEM_TMEM_DI_OFFSET 208
+#define TMEM_TMEM_DQ_LOCAL_OFFSET 240
+#define TMEM_TMEM_DQ_BOUNDARY_OFFSET 272
+#define TMEM_TMEM_DK_LOCAL_OFFSET 304
+#define TMEM_TMEM_DK_BOUNDARY_OFFSET 336
+#define TMEM_TMEM_RECON_KR_OFFSET 64
+#define TMEM_TMEM_RECON_STATE_OFFSET 368
+#define NUM_MAIN_STAGES 1
+#define SMEM_S_K_OFF 1024
+#define SMEM_S_K_STAGE_BYTES 8192
+#define SMEM_S_K_STRIDE 8192
+#define SMEM_S_I_OFF 9216
+#define SMEM_S_I_STAGE_BYTES 8192
+#define SMEM_S_I_STRIDE 8192
+#define SMEM_S_DOT_OFF 17408
+#define SMEM_S_DOT_STAGE_BYTES 8192
+#define SMEM_S_DOT_STRIDE 8192
+#define SMEM_S_RT_OFF 25600
+#define SMEM_S_RT_STAGE_BYTES 8192
+#define SMEM_S_RT_STRIDE 8192
+#define SMEM_S_DRT_OFF 33792
+#define SMEM_S_DRT_STAGE_BYTES 8192
+#define SMEM_S_DRT_STRIDE 8192
+#define SMEM_S_X_OFF 41984
+#define SMEM_S_X_STAGE_BYTES 8192
+#define SMEM_S_X_STRIDE 8192
+#define SMEM_S_DET_OFF 50176
+#define SMEM_S_DET_STAGE_BYTES 8192
+#define SMEM_S_DET_STRIDE 8192
+#define SMEM_S_DOT_TC_OFF 58368
+#define SMEM_S_DOT_TC_STAGE_BYTES 8192
+#define SMEM_S_DOT_TC_STRIDE 8192
+#define SMEM_S_RT_TC_OFF 66560
+#define SMEM_S_RT_TC_STAGE_BYTES 8192
+#define SMEM_S_RT_TC_STRIDE 8192
+#define SMEM_S_DET_TC_OFF 74752
+#define SMEM_S_DET_TC_STAGE_BYTES 8192
+#define SMEM_S_DET_TC_STRIDE 8192
+#define SMEM_S_J_OFF 82944
+#define SMEM_S_J_STAGE_BYTES 2048
+#define SMEM_S_J_STRIDE 2048
+#define SMEM_S_M_OFF 84992
+#define SMEM_S_M_STAGE_BYTES 2048
+#define SMEM_S_M_STRIDE 2048
+#define SMEM_S_DJ_OFF 89088
+#define SMEM_S_DJ_STAGE_BYTES 2048
+#define SMEM_S_DJ_STRIDE 2048
+#define SMEM_S_TMP_OFF 91136
+#define SMEM_S_TMP_STAGE_BYTES 2048
+#define SMEM_S_TMP_STRIDE 2048
+#define SMEM_S_DF_OFF 93184
+#define SMEM_S_DF_STAGE_BYTES 2048
+#define SMEM_S_DF_STRIDE 2048
+#define SMEM_S_DO_STAGE_OFF 89088
+#define SMEM_S_DO_STAGE_STAGE_BYTES 8192
+#define SMEM_S_DO_STAGE_STRIDE 8192
+#define SMEM_S_DN_TC_OFF 97280
+#define SMEM_S_DN_TC_STAGE_BYTES 2048
+#define SMEM_S_DN_TC_STRIDE 2048
+#define SMEM_S_DNT_TC_OFF 99328
+#define SMEM_S_DNT_TC_STAGE_BYTES 2048
+#define SMEM_S_DNT_TC_STRIDE 2048
+#define SMEM_S_DM_TC_OFF 101376
+#define SMEM_S_DM_TC_STAGE_BYTES 2048
+#define SMEM_S_DM_TC_STRIDE 2048
+#define SMEM_S_DMT_TC_OFF 103424
+#define SMEM_S_DMT_TC_STAGE_BYTES 2048
+#define SMEM_S_DMT_TC_STRIDE 2048
+#define SMEM_S_DBETA_PARTIAL_OFF 105472
+#define SMEM_S_DBETA_PARTIAL_STAGE_BYTES 512
+#define SMEM_S_DBETA_PARTIAL_STRIDE 512
+#define SMEM_S_Q_OFF 105984
+#define SMEM_S_Q_STAGE_BYTES 8192
+#define SMEM_S_Q_STRIDE 8192
+#define SMEM_S_PREV_R_TC_OFF 114176
+#define SMEM_S_PREV_R_TC_STAGE_BYTES 8192
+#define SMEM_S_PREV_R_TC_STRIDE 8192
+#define SMEM_S_DH_STAGE_OFF 122368
+#define SMEM_S_DH_STAGE_STAGE_BYTES 32768
+#define SMEM_S_DH_STAGE_STRIDE 32768
+#define SMEM_S_STABLE_DKR_OFF 17408
+#define SMEM_S_STABLE_DKR_STAGE_BYTES 16384
+#define SMEM_S_STABLE_DKR_STRIDE 16384
+#define SMEM_S_STABLE_DELTA_OFF 33792
+#define SMEM_S_STABLE_DELTA_STAGE_BYTES 16384
+#define SMEM_S_STABLE_DELTA_STRIDE 16384
+#define SMEM_S_STABLE_BASE_OFF 50176
+#define SMEM_S_STABLE_BASE_STAGE_BYTES 16384
+#define SMEM_S_STABLE_BASE_STRIDE 16384
+#define SMEM_S_MIDDLE_BASE_SUFFIX_OFF 122368
+#define SMEM_S_MIDDLE_BASE_SUFFIX_STAGE_BYTES 512
+#define SMEM_S_MIDDLE_BASE_SUFFIX_STRIDE 512
+#define SMEM_S_HIGH_BASE_SUFFIX_OFF 122880
+#define SMEM_S_HIGH_BASE_SUFFIX_STAGE_BYTES 512
+#define SMEM_S_HIGH_BASE_SUFFIX_STRIDE 512
+#define SMEM_TOTAL 155136
+#define THREADS 384
+
+extern "C" {
+
+__global__ __launch_bounds__(384) void
+kernel_flashkda_backward_local_c32_tcgen(__nv_bfloat16* __restrict__ do_, float* __restrict__ beta_active, long long* __restrict__ cu_seqlens, int* __restrict__ consumer_chunk_order, int* __restrict__ chunk_sequence, int* __restrict__ chunk_index, __nv_bfloat16* __restrict__ chunk_state, unsigned int* __restrict__ state_checkpoint_needed, float* __restrict__ initial_state, __nv_bfloat16* __restrict__ tape_qd, __nv_bfloat16* __restrict__ tape_kd, __nv_bfloat16* __restrict__ tape_kr, __nv_bfloat16* __restrict__ tape_j, float* __restrict__ tape_restore_factor, __nv_bfloat16* __restrict__ tape_e, __nv_bfloat16* __restrict__ tape_x, __nv_bfloat16* __restrict__ tape_r, __nv_bfloat16* __restrict__ chunk_dh, __nv_bfloat16* __restrict__ chunk_dr, __nv_bfloat16* __restrict__ chunk_dx, unsigned int* __restrict__ boundary_ready, __nv_bfloat16* __restrict__ grad_qd, __nv_bfloat16* __restrict__ grad_kd, __nv_bfloat16* __restrict__ grad_ki, float* __restrict__ dlog_decay, float* __restrict__ dbeta_active, __nv_bfloat16* __restrict__ dv, int num_heads, int boundary_ready_target, float lower_bound)
+{
+    const int tid = threadIdx.x;
+    const int warp = make_warp_uniform(tid / 32);
+    const int lane = tid % 32;
+
+    extern __shared__ __align__(1024) char smem_raw[];
+    int smem;
+    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+
+    const int bid = blockIdx.x;
+    const int num_bids = gridDim.x;
+
+    // Kernel setup ops
+    __nv_bfloat16* s_k = reinterpret_cast<__nv_bfloat16*>(smem_raw + 1024);
+    const int s_k_addr = smem + 1024;
+    __nv_bfloat16* s_i = reinterpret_cast<__nv_bfloat16*>(smem_raw + 9216);
+    const int s_i_addr = smem + 9216;
+    __nv_bfloat16* s_dot = reinterpret_cast<__nv_bfloat16*>(smem_raw + 17408);
+    const int s_dot_addr = smem + 17408;
+    __nv_bfloat16* s_rt = reinterpret_cast<__nv_bfloat16*>(smem_raw + 25600);
+    const int s_rt_addr = smem + 25600;
+    __nv_bfloat16* s_drt = reinterpret_cast<__nv_bfloat16*>(smem_raw + 33792);
+    const int s_drt_addr = smem + 33792;
+    __nv_bfloat16* s_x = reinterpret_cast<__nv_bfloat16*>(smem_raw + 41984);
+    const int s_x_addr = smem + 41984;
+    __nv_bfloat16* s_det = reinterpret_cast<__nv_bfloat16*>(smem_raw + 50176);
+    const int s_det_addr = smem + 50176;
+    __nv_bfloat16* s_dot_tc = reinterpret_cast<__nv_bfloat16*>(smem_raw + 58368);
+    const int s_dot_tc_addr = smem + 58368;
+    __nv_bfloat16* s_rt_tc = reinterpret_cast<__nv_bfloat16*>(smem_raw + 66560);
+    const int s_rt_tc_addr = smem + 66560;
+    __nv_bfloat16* s_det_tc = reinterpret_cast<__nv_bfloat16*>(smem_raw + 74752);
+    const int s_det_tc_addr = smem + 74752;
+    __nv_bfloat16* s_j = reinterpret_cast<__nv_bfloat16*>(smem_raw + 82944);
+    const int s_j_addr = smem + 82944;
+    __nv_bfloat16* s_m = reinterpret_cast<__nv_bfloat16*>(smem_raw + 84992);
+    const int s_m_addr = smem + 84992;
+    __nv_bfloat16* s_dj = reinterpret_cast<__nv_bfloat16*>(smem_raw + 89088);
+    const int s_dj_addr = smem + 89088;
+    __nv_bfloat16* s_tmp = reinterpret_cast<__nv_bfloat16*>(smem_raw + 91136);
+    const int s_tmp_addr = smem + 91136;
+    __nv_bfloat16* s_df = reinterpret_cast<__nv_bfloat16*>(smem_raw + 93184);
+    const int s_df_addr = smem + 93184;
+    __nv_bfloat16* s_do_stage = reinterpret_cast<__nv_bfloat16*>(smem_raw + 89088);
+    const int s_do_stage_addr = smem + 89088;
+    __nv_bfloat16* s_dn_tc = reinterpret_cast<__nv_bfloat16*>(smem_raw + 97280);
+    const int s_dn_tc_addr = smem + 97280;
+    __nv_bfloat16* s_dnt_tc = reinterpret_cast<__nv_bfloat16*>(smem_raw + 99328);
+    const int s_dnt_tc_addr = smem + 99328;
+    __nv_bfloat16* s_dm_tc = reinterpret_cast<__nv_bfloat16*>(smem_raw + 101376);
+    const int s_dm_tc_addr = smem + 101376;
+    __nv_bfloat16* s_dmt_tc = reinterpret_cast<__nv_bfloat16*>(smem_raw + 103424);
+    const int s_dmt_tc_addr = smem + 103424;
+    float* s_dbeta_partial = reinterpret_cast<float*>(smem_raw + 105472);
+    const int s_dbeta_partial_addr = smem + 105472;
+    __nv_bfloat16* s_q = reinterpret_cast<__nv_bfloat16*>(smem_raw + 105984);
+    const int s_q_addr = smem + 105984;
+    __nv_bfloat16* s_prev_r_tc = reinterpret_cast<__nv_bfloat16*>(smem_raw + 114176);
+    const int s_prev_r_tc_addr = smem + 114176;
+    __nv_bfloat16* s_dh_stage = reinterpret_cast<__nv_bfloat16*>(smem_raw + 122368);
+    const int s_dh_stage_addr = smem + 122368;
+    float* s_stable_dkr = reinterpret_cast<float*>(smem_raw + 17408);
+    const int s_stable_dkr_addr = smem + 17408;
+    float* s_stable_delta = reinterpret_cast<float*>(smem_raw + 33792);
+    const int s_stable_delta_addr = smem + 33792;
+    float* s_stable_base = reinterpret_cast<float*>(smem_raw + 50176);
+    const int s_stable_base_addr = smem + 50176;
+    float* s_middle_base_suffix = reinterpret_cast<float*>(smem_raw + 122368);
+    const int s_middle_base_suffix_addr = smem + 122368;
+    float* s_high_base_suffix = reinterpret_cast<float*>(smem_raw + 122880);
+    const int s_high_base_suffix_addr = smem + 122880;
+
+    // Mbarrier init (15 groups, 15 barriers)
+    // Mbarriers at smem_raw[0..120)
+
+    if (warp == 0) {
+        uint32_t leader = elect_sync();
+        if (leader) {
+            // prep_ready: 1 barriers, init_count=1
+            mbarrier_init(smem + 0, 1);
+            // boundary_local_ready: 1 barriers, init_count=1
+            mbarrier_init(smem + 8, 1);
+            // dbeta_done: 1 barriers, init_count=4
+            mbarrier_init(smem + 16, 4);
+            // qki_ready: 1 barriers, init_count=1
+            mbarrier_init(smem + 24, 1);
+            // qki_tc_ready: 1 barriers, init_count=4
+            mbarrier_init(smem + 32, 4);
+            // dv_ready: 1 barriers, init_count=1
+            mbarrier_init(smem + 40, 1);
+            // value_tc_ready: 1 barriers, init_count=3
+            mbarrier_init(smem + 48, 3);
+            // dh_ready: 1 barriers, init_count=1
+            mbarrier_init(smem + 56, 1);
+            // state_tc_ready: 1 barriers, init_count=4
+            mbarrier_init(smem + 64, 4);
+            // recon_inputs_ready: 1 barriers, init_count=4
+            mbarrier_init(smem + 72, 4);
+            // recon_output_ready: 1 barriers, init_count=1
+            mbarrier_init(smem + 80, 1);
+            // a_ready: 1 barriers, init_count=4
+            mbarrier_init(smem + 88, 4);
+            // first_outputs_ready: 1 barriers, init_count=1
+            mbarrier_init(smem + 96, 1);
+            // outputs_ready: 1 barriers, init_count=1
+            mbarrier_init(smem + 104, 1);
+            // epilogue_done: 1 barriers, init_count=4
+            mbarrier_init(smem + 112, 4);
+            asm volatile("fence.mbarrier_init.release.cluster;");
+        }
+    }
+
+    __syncwarp();
+
+    // TMEM alloc (512 columns, 496 used)
+    volatile int* tmem_addr_storage = (volatile int*)(smem_raw + 120);
+    if (warp == 0) {
+        int _tmem_hold = smem + 120;
+        asm volatile("tcgen05.alloc.cta_group::1.sync.aligned.shared::cta.b32 [%0], %1;" :: "r"(_tmem_hold), "r"(512) : "memory");
+        asm volatile("tcgen05.relinquish_alloc_permit.cta_group::1.sync.aligned;");
+    }
+
+    __syncthreads();
+    asm volatile("tcgen05.fence::after_thread_sync;");
+
+    const int mbar_base = smem;
+    #define prep_ready_addr (mbar_base + 0)
+    #define boundary_local_ready_addr (mbar_base + 8)
+    #define dbeta_done_addr (mbar_base + 16)
+    #define qki_ready_addr (mbar_base + 24)
+    #define qki_tc_ready_addr (mbar_base + 32)
+    #define dv_ready_addr (mbar_base + 40)
+    #define value_tc_ready_addr (mbar_base + 48)
+    #define dh_ready_addr (mbar_base + 56)
+    #define state_tc_ready_addr (mbar_base + 64)
+    #define recon_inputs_ready_addr (mbar_base + 72)
+    #define recon_output_ready_addr (mbar_base + 80)
+    #define a_ready_addr (mbar_base + 88)
+    #define first_outputs_ready_addr (mbar_base + 96)
+    #define outputs_ready_addr (mbar_base + 104)
+    #define epilogue_done_addr (mbar_base + 112)
+    const int taddr = tmem_addr_storage[0];
+
+    // Kernel post-init ops
+    const int tmem_tmem_a_dh = taddr;
+    const int tmem_tmem_a_state = taddr + 64;
+    const int tmem_tmem_a_k = taddr + 128;
+    const int tmem_tmem_a_q = taddr + 144;
+    const int tmem_tmem_a_i = taddr + 160;
+    const int tmem_tmem_dkr = taddr + 176;
+    const int tmem_tmem_di = taddr + 208;
+    const int tmem_tmem_dq_local = taddr + 240;
+    const int tmem_tmem_dq_boundary = taddr + 272;
+    const int tmem_tmem_dk_local = taddr + 304;
+    const int tmem_tmem_dk_boundary = taddr + 336;
+    const int tmem_tmem_recon_kr = taddr + 64;
+    const int tmem_tmem_recon_state = taddr + 368;
+
+    // ---- Role: prep ----
+    if (warp <= 3) {
+        asm volatile("setmaxnreg.inc.sync.aligned.u32 208;");
+        { // prep_main
+            int ordered_chunk = blockIdx.x / num_heads;
+            int chunk_global = consumer_chunk_order[ordered_chunk];
+            int head = blockIdx.x - ordered_chunk * num_heads;
+            int sequence = chunk_sequence[chunk_global];
+            int local_chunk = chunk_index[chunk_global];
+            long long bos = cu_seqlens[sequence];
+            long long eos = cu_seqlens[sequence + 1];
+            long long chunk_start = bos + (long long)local_chunk * 32;
+            long long chunk_head = (long long)chunk_global * (long long)num_heads + (long long)head;
+            int warp_id_in_role = (warp - 0);
+            int prep_tid = warp_id_in_role * 32 + lane;
+            long long token_key_base = chunk_head * 32 * 128;
+            long long state_base = chunk_head * 128 * 128;
+            long long restore_base = chunk_head * 128;
+            int restore_key_col = prep_tid * 2 % 128;
+            float _vec_load_0[2];
+            {
+                float2 _v2_0 = *reinterpret_cast<const float2*>(tape_restore_factor + restore_base + (long long)restore_key_col);
+                _vec_load_0[0] = _v2_0.x;
+                _vec_load_0[0 + 1] = _v2_0.y;
+            }
+            float _rcp_0 = approx_rcp(_vec_load_0[0]);
+            float inv_restore0 = _rcp_0;
+            float _rcp_1 = approx_rcp(_vec_load_0[1]);
+            float inv_restore1 = _rcp_1;
+            #pragma unroll
+            for (int key_copy_pass = 0; key_copy_pass < 4; key_copy_pass++) {
+                int key_copy_item = key_copy_pass * 128 * 8 + prep_tid * 8;
+                asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
+                    :: "r"(s_k_addr + (unsigned int)((key_copy_item * 2 ^ (key_copy_item * 2 >> 8 & 7) << 4) / 2 * 2)), "l"(tape_kd + (token_key_base + (long long)key_copy_item)));
+                asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
+                    :: "r"(s_q_addr + (unsigned int)((key_copy_item * 2 ^ (key_copy_item * 2 >> 8 & 7) << 4) / 2 * 2)), "l"(tape_qd + (token_key_base + (long long)key_copy_item)));
+            }
+            asm volatile("cp.async.commit_group;");
+            #pragma unroll
+            for (int key_pass = 0; key_pass < 16; key_pass++) {
+                int item = key_pass * 256 + prep_tid * 2;
+                float _vec_load_1[2];
+                {
+                    uint32_t _bf16x2_bits_1;
+                    _bf16x2_bits_1 = *reinterpret_cast<const uint32_t*>(tape_kr + token_key_base + (long long)item);
+                    asm volatile(
+                        "{\n\t"
+                        "shl.b32 %0, %2, 16;\n\t"
+                        "and.b32 %1, %2, 0xffff0000;\n\t"
+                        "}\n"
+                        : "=f"((&_vec_load_1[0])[0]), "=f"((&_vec_load_1[0])[1])
+                        : "r"(_bf16x2_bits_1));
+                }
+                float i_values[2];
+                unsigned int i_packed[1];
+                i_values[0] = _vec_load_1[0] * inv_restore0;
+                i_values[1] = _vec_load_1[1] * inv_restore1;
+                #pragma unroll
+                for (int _lp = 0; _lp < 1; _lp++) {
+                    __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(i_values[_lp*2 + 0], i_values[_lp*2+1 + 0]));
+                    i_packed[_lp] = *(uint32_t*)&_bf2;
+                }
+                asm volatile("st.shared.b32 [%0], %1;" :: "r"(s_i_addr + (unsigned int)((item * 2 ^ (item * 2 >> 8 & 7) << 4) / 2 * 2)), "r"((i_packed[0])));
+            }
+            asm volatile("cp.async.wait_group 0;");
+            asm volatile("barrier.sync 8, 128;" ::: "memory");
+            if (warp_id_in_role == 0) {
+                if (elect_sync()) {
+                    mbarrier_arrive(qki_ready_addr);
+                }
+            }
+            long long j_base = chunk_head * 32 * 32;
+            #pragma unroll
+            for (int j_pass = 0; j_pass < 8; j_pass++) {
+                int item_1 = j_pass * 128 + prep_tid;
+                s_j[(item_1 * 2 ^ (item_1 * 2 >> 7 & 7) << 4) / 2] = tape_j[j_base + (long long)item_1];
+            }
+            long long token_value_base = chunk_head * 128 * 32;
+            #pragma unroll
+            for (int value_copy_pass = 0; value_copy_pass < 4; value_copy_pass++) {
+                int value_copy_item = value_copy_pass * 128 * 8 + prep_tid * 8;
+                int value_copy_dst = (value_copy_item * 2 ^ (value_copy_item * 2 >> 7 & 7) << 4) / 2 * 2;
+                asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
+                    :: "r"(s_x_addr + (unsigned int)value_copy_dst), "l"(tape_x + (token_value_base + (long long)value_copy_item)));
+                asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
+                    :: "r"(s_rt_addr + (unsigned int)value_copy_dst), "l"(tape_r + (token_value_base + (long long)value_copy_item)));
+            }
+            asm volatile("cp.async.commit_group;");
+            int tile = warp_id_in_role;
+            int row_base = tile / 2 * 16;
+            int col_base = tile % 2 * 16;
+            float acc[8];
+            int lane_matrix = lane / 8;
+            int lane_row8 = lane & 7;
+            #pragma unroll
+            for (int kk = 0; kk < 128; kk += 16) {
+                unsigned int a_plain[4];
+                unsigned int a_trans[4];
+                unsigned int b_plain[4];
+                unsigned int b_trans[4];
+                {
+                    int a_row = row_base + lane_row8 + (lane_matrix & 1) * 8;
+                    int a_col = kk + lane_matrix / 2 * 8;
+                    asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                        : "=r"(a_plain[0]), "=r"(a_plain[1]), "=r"(a_plain[2]), "=r"(a_plain[3])
+                        : "r"(s_k_addr + (unsigned int)(((1) ? ((a_row * 128 + a_col) * 2 ^ ((a_row * 128 + a_col) * 2 >> 8 & 7) << 4) / 2 : ((a_row * 128 + a_col) * 2 ^ ((a_row * 128 + a_col) * 2 >> 7 & 7) << 4) / 2) * 2))
+                        : "memory");
+                }
+                {
+                    #pragma unroll
+                    for (int n_half = 0; n_half < 2; n_half++) {
+                        int b_row = col_base + n_half * 8 + lane_row8;
+                        int b_col = kk + lane / 8 * 8;
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x2.shared.b16 {%0, %1}, [%2];\n"
+                            : "=r"(b_plain[n_half * 2]), "=r"(b_plain[n_half * 2 + 1])
+                            : "r"(s_i_addr + (unsigned int)(((1) ? ((b_row * 128 + b_col) * 2 ^ ((b_row * 128 + b_col) * 2 >> 8 & 7) << 4) / 2 : ((b_row * 128 + b_col) * 2 ^ ((b_row * 128 + b_col) * 2 >> 7 & 7) << 4) / 2) * 2))
+                            : "memory");
+                    }
+                }
+                {
+                    {
+                        {
+                            asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%10, %11, %12, %13};\n"
+                                : "=f"(acc[0]), "=f"(acc[1]), "=f"(acc[2]), "=f"(acc[3])
+                                : "r"(a_plain[0]), "r"(a_plain[1]), "r"(a_plain[2]), "r"(a_plain[3]), "r"(b_plain[0]), "r"(b_plain[1]), "f"(((kk == 0) ? 0.0f : acc[0])), "f"(((kk == 0) ? 0.0f : acc[1])), "f"(((kk == 0) ? 0.0f : acc[2])), "f"(((kk == 0) ? 0.0f : acc[3])));
+                            asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%10, %11, %12, %13};\n"
+                                : "=f"(acc[4]), "=f"(acc[(4) + 1]), "=f"(acc[(4) + 2]), "=f"(acc[(4) + 3])
+                                : "r"(a_plain[0]), "r"(a_plain[1]), "r"(a_plain[2]), "r"(a_plain[3]), "r"(b_plain[2]), "r"(b_plain[(2) + 1]), "f"(((kk == 0) ? 0.0f : acc[4])), "f"(((kk == 0) ? 0.0f : acc[(4) + 1])), "f"(((kk == 0) ? 0.0f : acc[(4) + 2])), "f"(((kk == 0) ? 0.0f : acc[(4) + 3])));
+                        }
+                    }
+                }
+            }
+            int frag_row = lane / 4;
+            int frag_col = (lane & 3) * 2;
+            #pragma unroll
+            for (int n_half_1 = 0; n_half_1 < 2; n_half_1++) {
+                int frag = n_half_1 * 4;
+                int row0 = row_base + frag_row;
+                int row1 = row0 + 8;
+                int col0 = col_base + n_half_1 * 8 + frag_col;
+                float pair[2];
+                unsigned int packed[1];
+                pair[0] = acc[frag];
+                pair[1] = acc[frag + 1];
+                #pragma unroll
+                for (int _lp = 0; _lp < 1; _lp++) {
+                    __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(pair[_lp*2 + 0], pair[_lp*2+1 + 0]));
+                    packed[_lp] = *(uint32_t*)&_bf2;
+                }
+                asm volatile("st.shared.b32 [%0], %1;" :: "r"(s_m_addr + (unsigned int)(((row0 * 32 + col0) * 2 ^ ((row0 * 32 + col0) * 2 >> 7 & 7) << 4) / 2 * 2)), "r"((packed[0])));
+                pair[0] = acc[frag + 2];
+                pair[1] = acc[frag + 3];
+                #pragma unroll
+                for (int _lp = 0; _lp < 1; _lp++) {
+                    __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(pair[_lp*2 + 0], pair[_lp*2+1 + 0]));
+                    packed[_lp] = *(uint32_t*)&_bf2;
+                }
+                asm volatile("st.shared.b32 [%0], %1;" :: "r"(s_m_addr + (unsigned int)(((row1 * 32 + col0) * 2 ^ ((row1 * 32 + col0) * 2 >> 7 & 7) << 4) / 2 * 2)), "r"((packed[0])));
+            }
+            asm volatile("barrier.sync 8, 128;" ::: "memory");
+            if (boundary_ready_target != 0) {
+                if (warp_id_in_role == 0) {
+                    {
+                        unsigned int* _gca_p = reinterpret_cast<unsigned int*>(boundary_ready) + (chunk_head);
+                        while (true) {
+                            unsigned int _gca_v;
+                            asm volatile("ld.acquire.gpu.global.u32 %0, [%1];" : "=r"(_gca_v) : "l"(_gca_p));
+                            if (_gca_v >= (unsigned int)(boundary_ready_target)) break;
+                        }
+                    }
+                }
+                asm volatile("barrier.sync 8, 128;" ::: "memory");
+            }
+            if (warp_id_in_role == 0) {
+                if (elect_sync()) {
+                    mbarrier_arrive(boundary_local_ready_addr);
+                }
+            }
+            #pragma unroll
+            for (int dh_copy_pass = 0; dh_copy_pass < 16; dh_copy_pass++) {
+                int dh_copy_item = dh_copy_pass * 128 * 8 + prep_tid * 8;
+                asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
+                    :: "r"(s_dh_stage_addr + (unsigned int)((dh_copy_item * 2 ^ (dh_copy_item * 2 >> 7 & 7) << 4) / 2 * 2)), "l"(chunk_dh + (state_base + (long long)dh_copy_item)));
+            }
+            asm volatile("cp.async.commit_group;");
+            #pragma unroll
+            for (int boundary_copy_pass = 0; boundary_copy_pass < 4; boundary_copy_pass++) {
+                int boundary_copy_item = boundary_copy_pass * 128 * 8 + prep_tid * 8;
+                int boundary_copy_dst = (boundary_copy_item * 2 ^ (boundary_copy_item * 2 >> 7 & 7) << 4) / 2 * 2;
+                asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
+                    :: "r"(s_dot_addr + (unsigned int)boundary_copy_dst), "l"(chunk_dx + (token_value_base + (long long)boundary_copy_item)));
+            }
+            asm volatile("cp.async.commit_group;");
+            asm volatile("cp.async.wait_group 2;");
+            asm volatile("barrier.sync 8, 128;" ::: "memory");
+            int value_token = lane;
+            long long value_token_global = chunk_start + (long long)value_token;
+            float value_beta = 0.0f;
+            if (value_token_global < eos) {
+                value_beta = beta_active[value_token_global * (long long)num_heads + (long long)head];
+            }
+            #pragma unroll
+            for (int value_segment = 0; value_segment < 4; value_segment++) {
+                int tc_segment = warp_id_in_role * 4 + value_segment;
+                float r_values[8];
+                #pragma unroll
+                for (int value_elem = 0; value_elem < 8; value_elem++) {
+                    int value_row = tc_segment * 8 + value_elem;
+                    int value_major_item = value_row * 32 + value_token;
+                    __nv_bfloat16 r_value = s_rt[(value_major_item * 2 ^ (value_major_item * 2 >> 7 & 7) << 4) / 2];
+                    float _cvt_f32_0 = __bfloat162float(r_value);
+                    r_values[value_elem] = _cvt_f32_0;
+                }
+                unsigned int packed_1[4];
+                #pragma unroll
+                for (int _lp = 0; _lp < 4; _lp++) {
+                    __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(r_values[_lp*2 + 0], r_values[_lp*2+1 + 0]));
+                    packed_1[_lp] = *(uint32_t*)&_bf2;
+                }
+                asm volatile("st.shared.v4.b32 [%0], {%1,%2,%3,%4};" :: "r"(s_rt_tc_addr + ((s_rt_tc_addr + (unsigned int)(tc_segment * 8 / 64 * 4096 + value_token * 128 + tc_segment * 8 % 64 * 2 ^ (tc_segment * 8 / 64 * 4096 + value_token * 128 + tc_segment * 8 % 64 * 2 >> 7 & 7) << 4)) - s_rt_tc_addr)), "r"(packed_1[0]), "r"(packed_1[1]), "r"(packed_1[2]), "r"(packed_1[3]) : "memory");
+            }
+            asm volatile("cp.async.wait_group 1;");
+            asm volatile("barrier.sync 8, 128;" ::: "memory");
+            if (warp_id_in_role == 0) {
+                if (elect_sync()) {
+                    mbarrier_arrive(dh_ready_addr);
+                }
+            }
+            asm volatile("cp.async.wait_group 0;");
+            asm volatile("barrier.sync 8, 128;" ::: "memory");
+            #pragma unroll
+            for (int value_segment_1 = 0; value_segment_1 < 4; value_segment_1++) {
+                int tc_segment_1 = warp_id_in_role * 4 + value_segment_1;
+                float det_values[8];
+                #pragma unroll
+                for (int value_elem_1 = 0; value_elem_1 < 8; value_elem_1++) {
+                    int value_row_1 = tc_segment_1 * 8 + value_elem_1;
+                    int value_major_item_1 = value_row_1 * 32 + value_token;
+                    __nv_bfloat16 dx_value = s_dot[(value_major_item_1 * 2 ^ (value_major_item_1 * 2 >> 7 & 7) << 4) / 2];
+                    int det_group = tc_segment_1 * 2 + value_elem_1 / 4;
+                    s_det[value_row_1 * 32 + (value_token ^ det_group)] = dx_value;
+                    float _cvt_f32_1 = __bfloat162float(dx_value);
+                    det_values[value_elem_1] = _cvt_f32_1 * value_beta;
+                }
+                unsigned int packed_2[4];
+                #pragma unroll
+                for (int _lp = 0; _lp < 4; _lp++) {
+                    __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(det_values[_lp*2 + 0], det_values[_lp*2+1 + 0]));
+                    packed_2[_lp] = *(uint32_t*)&_bf2;
+                }
+                asm volatile("st.shared.v4.b32 [%0], {%1,%2,%3,%4};" :: "r"(s_det_tc_addr + ((s_det_tc_addr + (unsigned int)(tc_segment_1 * 8 / 64 * 4096 + value_token * 128 + tc_segment_1 * 8 % 64 * 2 ^ (tc_segment_1 * 8 / 64 * 4096 + value_token * 128 + tc_segment_1 * 8 % 64 * 2 >> 7 & 7) << 4)) - s_det_tc_addr)), "r"(packed_2[0]), "r"(packed_2[1]), "r"(packed_2[2]), "r"(packed_2[3]) : "memory");
+            }
+            asm volatile("barrier.sync 8, 128;" ::: "memory");
+            asm volatile("fence.proxy.async.shared::cta;" ::: "memory");
+            if (warp_id_in_role == 0) {
+                if (elect_sync()) {
+                    mbarrier_arrive(dv_ready_addr);
+                }
+            }
+            unsigned int _phase_value_tc_ready_0 = 0;
+            mbarrier_wait(value_tc_ready_addr, _phase_value_tc_ready_0);
+            _phase_value_tc_ready_0 ^= 1;
+            asm volatile("barrier.sync 8, 128;" ::: "memory");
+            int lane_matrix_0 = lane / 8;
+            int lane_row8_1 = lane & 7;
+            #pragma unroll
+            for (int kk_1 = 0; kk_1 < 128; kk_1 += 16) {
+                unsigned int a_plain_1[4];
+                unsigned int a_trans_1[4];
+                unsigned int b_plain_1[4];
+                unsigned int b_trans_1[4];
+                {
+                    int a_row_1 = kk_1 + lane_row8_1 + lane_matrix_0 / 2 * 8;
+                    int a_col_1 = row_base + (lane_matrix_0 & 1) * 8;
+                    asm volatile("ldmatrix.sync.aligned.m8n8.x4.trans.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                        : "=r"(a_trans_1[0]), "=r"(a_trans_1[1]), "=r"(a_trans_1[2]), "=r"(a_trans_1[3])
+                        : "r"(s_rt_addr + (unsigned int)(((0) ? ((a_row_1 * 32 + a_col_1) * 2 ^ ((a_row_1 * 32 + a_col_1) * 2 >> 8 & 7) << 4) / 2 : ((a_row_1 * 32 + a_col_1) * 2 ^ ((a_row_1 * 32 + a_col_1) * 2 >> 7 & 7) << 4) / 2) * 2))
+                        : "memory");
+                }
+                {
+                    #pragma unroll
+                    for (int n_half_2 = 0; n_half_2 < 2; n_half_2++) {
+                        int b_row_1 = col_base + n_half_2 * 8 + lane_row8_1;
+                        int b_col_1 = kk_1 + lane / 8 * 8;
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x2.shared.b16 {%0, %1}, [%2];\n"
+                            : "=r"(b_plain_1[n_half_2 * 2]), "=r"(b_plain_1[n_half_2 * 2 + 1])
+                            : "r"(s_do_stage_addr + (unsigned int)(((1) ? ((b_row_1 * 128 + b_col_1) * 2 ^ ((b_row_1 * 128 + b_col_1) * 2 >> 8 & 7) << 4) / 2 : ((b_row_1 * 128 + b_col_1) * 2 ^ ((b_row_1 * 128 + b_col_1) * 2 >> 7 & 7) << 4) / 2) * 2))
+                            : "memory");
+                    }
+                }
+                {
+                    {
+                        {
+                            asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%10, %11, %12, %13};\n"
+                                : "=f"(acc[0]), "=f"(acc[1]), "=f"(acc[2]), "=f"(acc[3])
+                                : "r"(a_trans_1[0]), "r"(a_trans_1[1]), "r"(a_trans_1[2]), "r"(a_trans_1[3]), "r"(b_plain_1[0]), "r"(b_plain_1[1]), "f"(((kk_1 == 0) ? 0.0f : acc[0])), "f"(((kk_1 == 0) ? 0.0f : acc[1])), "f"(((kk_1 == 0) ? 0.0f : acc[2])), "f"(((kk_1 == 0) ? 0.0f : acc[3])));
+                            asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%10, %11, %12, %13};\n"
+                                : "=f"(acc[4]), "=f"(acc[(4) + 1]), "=f"(acc[(4) + 2]), "=f"(acc[(4) + 3])
+                                : "r"(a_trans_1[0]), "r"(a_trans_1[1]), "r"(a_trans_1[2]), "r"(a_trans_1[3]), "r"(b_plain_1[2]), "r"(b_plain_1[(2) + 1]), "f"(((kk_1 == 0) ? 0.0f : acc[4])), "f"(((kk_1 == 0) ? 0.0f : acc[(4) + 1])), "f"(((kk_1 == 0) ? 0.0f : acc[(4) + 2])), "f"(((kk_1 == 0) ? 0.0f : acc[(4) + 3])));
+                        }
+                    }
+                }
+            }
+            float dn_values[8];
+            dn_values[0] = 0.0f;
+            dn_values[1] = 0.0f;
+            dn_values[2] = 0.0f;
+            dn_values[3] = 0.0f;
+            dn_values[4] = 0.0f;
+            dn_values[5] = 0.0f;
+            dn_values[6] = 0.0f;
+            dn_values[7] = 0.0f;
+            int dn_row0 = row_base + lane / 4;
+            int dn_row1 = dn_row0 + 8;
+            int dn_col0 = col_base + (lane & 3) * 2;
+            if (dn_row0 <= dn_col0) {
+                dn_values[0] = acc[0];
+            }
+            if (dn_row0 <= dn_col0 + 1) {
+                dn_values[1] = acc[1];
+            }
+            if (dn_row1 <= dn_col0) {
+                dn_values[2] = acc[2];
+            }
+            if (dn_row1 <= dn_col0 + 1) {
+                dn_values[3] = acc[3];
+            }
+            if (dn_row0 <= dn_col0 + 8) {
+                dn_values[4] = acc[4];
+            }
+            if (dn_row0 <= dn_col0 + 9) {
+                dn_values[5] = acc[5];
+            }
+            if (dn_row1 <= dn_col0 + 8) {
+                dn_values[6] = acc[6];
+            }
+            if (dn_row1 <= dn_col0 + 9) {
+                dn_values[7] = acc[7];
+            }
+            unsigned int packed_3[4];
+            #pragma unroll
+            for (int _lp = 0; _lp < 4; _lp++) {
+                __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(dn_values[_lp*2 + 0], dn_values[_lp*2+1 + 0]));
+                packed_3[_lp] = *(uint32_t*)&_bf2;
+            }
+            int direct_row = row_base + lane % 16;
+            int direct_col = col_base + lane / 16 * 8;
+            uint32_t _stmatrix_addr_2 = static_cast<uint32_t>((unsigned long long)(s_dnt_tc_addr + (unsigned int)(direct_col / 16 * 1024 + direct_row * 32 + direct_col % 16 * 2 ^ (direct_col / 16 * 1024 + direct_row * 32 + direct_col % 16 * 2 >> 7 & 1) << 4)));
+            asm volatile("stmatrix.sync.aligned.m8n8.x4.shared.b16 [%0], {%1, %2, %3, %4};\n"
+                :: "r"(_stmatrix_addr_2), "r"(*reinterpret_cast<const uint32_t*>(&packed_3[0])), "r"(*reinterpret_cast<const uint32_t*>(&packed_3[1])), "r"(*reinterpret_cast<const uint32_t*>(&packed_3[2])), "r"(*reinterpret_cast<const uint32_t*>(&packed_3[3]))
+                : "memory");
+            #pragma unroll
+            for (int publish_pair = 0; publish_pair < 2; publish_pair++) {
+                int transpose_row = col_base + publish_pair * 8 + (lane & 7);
+                int transpose_col = row_base + lane / 8 * 8;
+                uint32_t _stmatrix_addr_3 = static_cast<uint32_t>((unsigned long long)(s_dn_tc_addr + (unsigned int)(transpose_col / 16 * 1024 + transpose_row * 32 + transpose_col % 16 * 2 ^ (transpose_col / 16 * 1024 + transpose_row * 32 + transpose_col % 16 * 2 >> 7 & 1) << 4)));
+                asm volatile("stmatrix.sync.aligned.m8n8.x2.trans.shared.b16 [%0], {%1, %2};\n"
+                    :: "r"(_stmatrix_addr_3), "r"(*reinterpret_cast<const uint32_t*>(&packed_3[publish_pair * 2])), "r"(*reinterpret_cast<const uint32_t*>(&packed_3[publish_pair * 2 + 1]))
+                    : "memory");
+            }
+            int lane_matrix_2 = lane / 8;
+            int lane_row8_3 = lane & 7;
+            #pragma unroll
+            for (int kk_2 = 0; kk_2 < 128; kk_2 += 16) {
+                unsigned int a_plain_2[4];
+                unsigned int a_trans_2[4];
+                unsigned int b_plain_2[4];
+                unsigned int b_trans_2[4];
+                {
+                    int a_row_2 = kk_2 + lane_row8_3 + lane_matrix_2 / 2 * 8;
+                    int a_col_2 = row_base + (lane_matrix_2 & 1) * 8;
+                    asm volatile("ldmatrix.sync.aligned.m8n8.x4.trans.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                        : "=r"(a_trans_2[0]), "=r"(a_trans_2[1]), "=r"(a_trans_2[2]), "=r"(a_trans_2[3])
+                        : "r"(s_drt_addr + (unsigned int)(((0) ? ((a_row_2 * 32 + a_col_2) * 2 ^ ((a_row_2 * 32 + a_col_2) * 2 >> 8 & 7) << 4) / 2 : ((a_row_2 * 32 + a_col_2) * 2 ^ ((a_row_2 * 32 + a_col_2) * 2 >> 7 & 7) << 4) / 2) * 2))
+                        : "memory");
+                }
+                {
+                    #pragma unroll
+                    for (int n_half_3 = 0; n_half_3 < 2; n_half_3++) {
+                        int b_row_2 = kk_2 + lane % 16;
+                        int b_col_2 = col_base + n_half_3 * 8;
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x2.trans.shared.b16 {%0, %1}, [%2];\n"
+                            : "=r"(b_trans_2[n_half_3 * 2]), "=r"(b_trans_2[n_half_3 * 2 + 1])
+                            : "r"(s_x_addr + (unsigned int)(((0) ? ((b_row_2 * 32 + b_col_2) * 2 ^ ((b_row_2 * 32 + b_col_2) * 2 >> 8 & 7) << 4) / 2 : ((b_row_2 * 32 + b_col_2) * 2 ^ ((b_row_2 * 32 + b_col_2) * 2 >> 7 & 7) << 4) / 2) * 2))
+                            : "memory");
+                    }
+                }
+                {
+                    {
+                        {
+                            asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%10, %11, %12, %13};\n"
+                                : "=f"(acc[0]), "=f"(acc[1]), "=f"(acc[2]), "=f"(acc[3])
+                                : "r"(a_trans_2[0]), "r"(a_trans_2[1]), "r"(a_trans_2[2]), "r"(a_trans_2[3]), "r"(b_trans_2[0]), "r"(b_trans_2[1]), "f"(((kk_2 == 0) ? 0.0f : acc[0])), "f"(((kk_2 == 0) ? 0.0f : acc[1])), "f"(((kk_2 == 0) ? 0.0f : acc[2])), "f"(((kk_2 == 0) ? 0.0f : acc[3])));
+                            asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%10, %11, %12, %13};\n"
+                                : "=f"(acc[4]), "=f"(acc[(4) + 1]), "=f"(acc[(4) + 2]), "=f"(acc[(4) + 3])
+                                : "r"(a_trans_2[0]), "r"(a_trans_2[1]), "r"(a_trans_2[2]), "r"(a_trans_2[3]), "r"(b_trans_2[2]), "r"(b_trans_2[(2) + 1]), "f"(((kk_2 == 0) ? 0.0f : acc[4])), "f"(((kk_2 == 0) ? 0.0f : acc[(4) + 1])), "f"(((kk_2 == 0) ? 0.0f : acc[(4) + 2])), "f"(((kk_2 == 0) ? 0.0f : acc[(4) + 3])));
+                        }
+                    }
+                }
+            }
+            int frag_row_4 = lane / 4;
+            int frag_col_5 = (lane & 3) * 2;
+            #pragma unroll
+            for (int n_half_4 = 0; n_half_4 < 2; n_half_4++) {
+                int frag_1 = n_half_4 * 4;
+                int row0_1 = row_base + frag_row_4;
+                int row1_1 = row0_1 + 8;
+                int col0_1 = col_base + n_half_4 * 8 + frag_col_5;
+                float pair_1[2];
+                unsigned int packed_0[1];
+                pair_1[0] = acc[frag_1];
+                pair_1[1] = acc[frag_1 + 1];
+                #pragma unroll
+                for (int _lp = 0; _lp < 1; _lp++) {
+                    __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(pair_1[_lp*2 + 0], pair_1[_lp*2+1 + 0]));
+                    packed_0[_lp] = *(uint32_t*)&_bf2;
+                }
+                asm volatile("st.shared.b32 [%0], %1;" :: "r"(s_dj_addr + (unsigned int)(((row0_1 * 32 + col0_1) * 2 ^ ((row0_1 * 32 + col0_1) * 2 >> 7 & 7) << 4) / 2 * 2)), "r"((packed_0[0])));
+                pair_1[0] = acc[frag_1 + 2];
+                pair_1[1] = acc[frag_1 + 3];
+                #pragma unroll
+                for (int _lp = 0; _lp < 1; _lp++) {
+                    __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(pair_1[_lp*2 + 0], pair_1[_lp*2+1 + 0]));
+                    packed_0[_lp] = *(uint32_t*)&_bf2;
+                }
+                asm volatile("st.shared.b32 [%0], %1;" :: "r"(s_dj_addr + (unsigned int)(((row1_1 * 32 + col0_1) * 2 ^ ((row1_1 * 32 + col0_1) * 2 >> 7 & 7) << 4) / 2 * 2)), "r"((packed_0[0])));
+            }
+            asm volatile("barrier.sync 8, 128;" ::: "memory");
+            #pragma unroll
+            for (int mask_pass = 0; mask_pass < 8; mask_pass++) {
+                int item_2 = mask_pass * 128 + prep_tid;
+                int row = item_2 / 32;
+                int col = item_2 % 32;
+                if (row <= col) {
+                    s_m[(item_2 * 2 ^ (item_2 * 2 >> 7 & 7) << 4) / 2] = 0.0f;
+                }
+            }
+            asm volatile("barrier.sync 8, 128;" ::: "memory");
+            int lane_matrix_6 = lane / 8;
+            int lane_row8_7 = lane & 7;
+            #pragma unroll
+            for (int kk_3 = 0; kk_3 < 32; kk_3 += 16) {
+                unsigned int a_plain_3[4];
+                unsigned int a_trans_3[4];
+                unsigned int b_plain_3[4];
+                unsigned int b_trans_3[4];
+                {
+                    int a_row_3 = kk_3 + lane_row8_7 + lane_matrix_6 / 2 * 8;
+                    int a_col_3 = row_base + (lane_matrix_6 & 1) * 8;
+                    asm volatile("ldmatrix.sync.aligned.m8n8.x4.trans.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                        : "=r"(a_trans_3[0]), "=r"(a_trans_3[1]), "=r"(a_trans_3[2]), "=r"(a_trans_3[3])
+                        : "r"(s_j_addr + (unsigned int)(((0) ? ((a_row_3 * 32 + a_col_3) * 2 ^ ((a_row_3 * 32 + a_col_3) * 2 >> 8 & 7) << 4) / 2 : ((a_row_3 * 32 + a_col_3) * 2 ^ ((a_row_3 * 32 + a_col_3) * 2 >> 7 & 7) << 4) / 2) * 2))
+                        : "memory");
+                }
+                {
+                    #pragma unroll
+                    for (int n_half_5 = 0; n_half_5 < 2; n_half_5++) {
+                        int b_row_3 = kk_3 + lane % 16;
+                        int b_col_3 = col_base + n_half_5 * 8;
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x2.trans.shared.b16 {%0, %1}, [%2];\n"
+                            : "=r"(b_trans_3[n_half_5 * 2]), "=r"(b_trans_3[n_half_5 * 2 + 1])
+                            : "r"(s_dj_addr + (unsigned int)(((0) ? ((b_row_3 * 32 + b_col_3) * 2 ^ ((b_row_3 * 32 + b_col_3) * 2 >> 8 & 7) << 4) / 2 : ((b_row_3 * 32 + b_col_3) * 2 ^ ((b_row_3 * 32 + b_col_3) * 2 >> 7 & 7) << 4) / 2) * 2))
+                            : "memory");
+                    }
+                }
+                {
+                    {
+                        {
+                            asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%10, %11, %12, %13};\n"
+                                : "=f"(acc[0]), "=f"(acc[1]), "=f"(acc[2]), "=f"(acc[3])
+                                : "r"(a_trans_3[0]), "r"(a_trans_3[1]), "r"(a_trans_3[2]), "r"(a_trans_3[3]), "r"(b_trans_3[0]), "r"(b_trans_3[1]), "f"(((kk_3 == 0) ? 0.0f : acc[0])), "f"(((kk_3 == 0) ? 0.0f : acc[1])), "f"(((kk_3 == 0) ? 0.0f : acc[2])), "f"(((kk_3 == 0) ? 0.0f : acc[3])));
+                            asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%10, %11, %12, %13};\n"
+                                : "=f"(acc[4]), "=f"(acc[(4) + 1]), "=f"(acc[(4) + 2]), "=f"(acc[(4) + 3])
+                                : "r"(a_trans_3[0]), "r"(a_trans_3[1]), "r"(a_trans_3[2]), "r"(a_trans_3[3]), "r"(b_trans_3[2]), "r"(b_trans_3[(2) + 1]), "f"(((kk_3 == 0) ? 0.0f : acc[4])), "f"(((kk_3 == 0) ? 0.0f : acc[(4) + 1])), "f"(((kk_3 == 0) ? 0.0f : acc[(4) + 2])), "f"(((kk_3 == 0) ? 0.0f : acc[(4) + 3])));
+                        }
+                    }
+                }
+            }
+            int frag_row_8 = lane / 4;
+            int frag_col_9 = (lane & 3) * 2;
+            #pragma unroll
+            for (int n_half_6 = 0; n_half_6 < 2; n_half_6++) {
+                int frag_2 = n_half_6 * 4;
+                int row0_2 = row_base + frag_row_8;
+                int row1_2 = row0_2 + 8;
+                int col0_2 = col_base + n_half_6 * 8 + frag_col_9;
+                float pair_2[2];
+                unsigned int packed_0_1[1];
+                pair_2[0] = acc[frag_2];
+                pair_2[1] = acc[frag_2 + 1];
+                #pragma unroll
+                for (int _lp = 0; _lp < 1; _lp++) {
+                    __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(pair_2[_lp*2 + 0], pair_2[_lp*2+1 + 0]));
+                    packed_0_1[_lp] = *(uint32_t*)&_bf2;
+                }
+                asm volatile("st.shared.b32 [%0], %1;" :: "r"(s_tmp_addr + (unsigned int)(((row0_2 * 32 + col0_2) * 2 ^ ((row0_2 * 32 + col0_2) * 2 >> 7 & 7) << 4) / 2 * 2)), "r"((packed_0_1[0])));
+                pair_2[0] = acc[frag_2 + 2];
+                pair_2[1] = acc[frag_2 + 3];
+                #pragma unroll
+                for (int _lp = 0; _lp < 1; _lp++) {
+                    __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(pair_2[_lp*2 + 0], pair_2[_lp*2+1 + 0]));
+                    packed_0_1[_lp] = *(uint32_t*)&_bf2;
+                }
+                asm volatile("st.shared.b32 [%0], %1;" :: "r"(s_tmp_addr + (unsigned int)(((row1_2 * 32 + col0_2) * 2 ^ ((row1_2 * 32 + col0_2) * 2 >> 7 & 7) << 4) / 2 * 2)), "r"((packed_0_1[0])));
+            }
+            asm volatile("barrier.sync 8, 128;" ::: "memory");
+            int lane_matrix_10 = lane / 8;
+            int lane_row8_11 = lane & 7;
+            #pragma unroll
+            for (int kk_4 = 0; kk_4 < 32; kk_4 += 16) {
+                unsigned int a_plain_4[4];
+                unsigned int a_trans_4[4];
+                unsigned int b_plain_4[4];
+                unsigned int b_trans_4[4];
+                {
+                    int a_row_4 = row_base + lane_row8_11 + (lane_matrix_10 & 1) * 8;
+                    int a_col_4 = kk_4 + lane_matrix_10 / 2 * 8;
+                    asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                        : "=r"(a_plain_4[0]), "=r"(a_plain_4[1]), "=r"(a_plain_4[2]), "=r"(a_plain_4[3])
+                        : "r"(s_tmp_addr + (unsigned int)(((0) ? ((a_row_4 * 32 + a_col_4) * 2 ^ ((a_row_4 * 32 + a_col_4) * 2 >> 8 & 7) << 4) / 2 : ((a_row_4 * 32 + a_col_4) * 2 ^ ((a_row_4 * 32 + a_col_4) * 2 >> 7 & 7) << 4) / 2) * 2))
+                        : "memory");
+                }
+                {
+                    #pragma unroll
+                    for (int n_half_7 = 0; n_half_7 < 2; n_half_7++) {
+                        int b_row_4 = col_base + n_half_7 * 8 + lane_row8_11;
+                        int b_col_4 = kk_4 + lane / 8 * 8;
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x2.shared.b16 {%0, %1}, [%2];\n"
+                            : "=r"(b_plain_4[n_half_7 * 2]), "=r"(b_plain_4[n_half_7 * 2 + 1])
+                            : "r"(s_j_addr + (unsigned int)(((0) ? ((b_row_4 * 32 + b_col_4) * 2 ^ ((b_row_4 * 32 + b_col_4) * 2 >> 8 & 7) << 4) / 2 : ((b_row_4 * 32 + b_col_4) * 2 ^ ((b_row_4 * 32 + b_col_4) * 2 >> 7 & 7) << 4) / 2) * 2))
+                            : "memory");
+                    }
+                }
+                {
+                    {
+                        {
+                            asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%10, %11, %12, %13};\n"
+                                : "=f"(acc[0]), "=f"(acc[1]), "=f"(acc[2]), "=f"(acc[3])
+                                : "r"(a_plain_4[0]), "r"(a_plain_4[1]), "r"(a_plain_4[2]), "r"(a_plain_4[3]), "r"(b_plain_4[0]), "r"(b_plain_4[1]), "f"(((kk_4 == 0) ? 0.0f : acc[0])), "f"(((kk_4 == 0) ? 0.0f : acc[1])), "f"(((kk_4 == 0) ? 0.0f : acc[2])), "f"(((kk_4 == 0) ? 0.0f : acc[3])));
+                            asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%10, %11, %12, %13};\n"
+                                : "=f"(acc[4]), "=f"(acc[(4) + 1]), "=f"(acc[(4) + 2]), "=f"(acc[(4) + 3])
+                                : "r"(a_plain_4[0]), "r"(a_plain_4[1]), "r"(a_plain_4[2]), "r"(a_plain_4[3]), "r"(b_plain_4[2]), "r"(b_plain_4[(2) + 1]), "f"(((kk_4 == 0) ? 0.0f : acc[4])), "f"(((kk_4 == 0) ? 0.0f : acc[(4) + 1])), "f"(((kk_4 == 0) ? 0.0f : acc[(4) + 2])), "f"(((kk_4 == 0) ? 0.0f : acc[(4) + 3])));
+                        }
+                    }
+                }
+            }
+            const float2 _scale2_4 = {-1.0f, -1.0f};
+            #pragma unroll
+            for (int _ls = 0; _ls < 4; _ls++)
+                mul_f32x2_inplace(&reinterpret_cast<float2*>(acc)[_ls], _scale2_4);
+            int frag_row_12 = lane / 4;
+            int frag_col_13 = (lane & 3) * 2;
+            #pragma unroll
+            for (int n_half_8 = 0; n_half_8 < 2; n_half_8++) {
+                int frag_3 = n_half_8 * 4;
+                int row0_3 = row_base + frag_row_12;
+                int row1_3 = row0_3 + 8;
+                int col0_3 = col_base + n_half_8 * 8 + frag_col_13;
+                float pair_3[2];
+                unsigned int packed_0_2[1];
+                pair_3[0] = acc[frag_3];
+                pair_3[1] = acc[frag_3 + 1];
+                #pragma unroll
+                for (int _lp = 0; _lp < 1; _lp++) {
+                    __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(pair_3[_lp*2 + 0], pair_3[_lp*2+1 + 0]));
+                    packed_0_2[_lp] = *(uint32_t*)&_bf2;
+                }
+                asm volatile("st.shared.b32 [%0], %1;" :: "r"(s_df_addr + (unsigned int)(((row0_3 * 32 + col0_3) * 2 ^ ((row0_3 * 32 + col0_3) * 2 >> 7 & 7) << 4) / 2 * 2)), "r"((packed_0_2[0])));
+                pair_3[0] = acc[frag_3 + 2];
+                pair_3[1] = acc[frag_3 + 3];
+                #pragma unroll
+                for (int _lp = 0; _lp < 1; _lp++) {
+                    __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(pair_3[_lp*2 + 0], pair_3[_lp*2+1 + 0]));
+                    packed_0_2[_lp] = *(uint32_t*)&_bf2;
+                }
+                asm volatile("st.shared.b32 [%0], %1;" :: "r"(s_df_addr + (unsigned int)(((row1_3 * 32 + col0_3) * 2 ^ ((row1_3 * 32 + col0_3) * 2 >> 7 & 7) << 4) / 2 * 2)), "r"((packed_0_2[0])));
+            }
+            float _shfl_0 = __shfl_sync(0xFFFFFFFF, value_beta, dn_row0);
+            float dm_beta0 = _shfl_0;
+            float _shfl_1 = __shfl_sync(0xFFFFFFFF, value_beta, dn_row1);
+            float dm_beta1 = _shfl_1;
+            float dm_values[8];
+            dm_values[0] = 0.0f;
+            dm_values[1] = 0.0f;
+            dm_values[2] = 0.0f;
+            dm_values[3] = 0.0f;
+            dm_values[4] = 0.0f;
+            dm_values[5] = 0.0f;
+            dm_values[6] = 0.0f;
+            dm_values[7] = 0.0f;
+            if (dn_row0 > dn_col0) {
+                __nv_bfloat16 _cvt_bf16_0 = __float2bfloat16(acc[0]);
+                float _cvt_f32_2 = __bfloat162float(_cvt_bf16_0);
+                dm_values[0] = _cvt_f32_2 * dm_beta0;
+            }
+            if (dn_row0 > dn_col0 + 1) {
+                __nv_bfloat16 _cvt_bf16_1 = __float2bfloat16(acc[1]);
+                float _cvt_f32_3 = __bfloat162float(_cvt_bf16_1);
+                dm_values[1] = _cvt_f32_3 * dm_beta0;
+            }
+            if (dn_row1 > dn_col0) {
+                __nv_bfloat16 _cvt_bf16_2 = __float2bfloat16(acc[2]);
+                float _cvt_f32_4 = __bfloat162float(_cvt_bf16_2);
+                dm_values[2] = _cvt_f32_4 * dm_beta1;
+            }
+            if (dn_row1 > dn_col0 + 1) {
+                __nv_bfloat16 _cvt_bf16_3 = __float2bfloat16(acc[3]);
+                float _cvt_f32_5 = __bfloat162float(_cvt_bf16_3);
+                dm_values[3] = _cvt_f32_5 * dm_beta1;
+            }
+            if (dn_row0 > dn_col0 + 8) {
+                __nv_bfloat16 _cvt_bf16_4 = __float2bfloat16(acc[4]);
+                float _cvt_f32_6 = __bfloat162float(_cvt_bf16_4);
+                dm_values[4] = _cvt_f32_6 * dm_beta0;
+            }
+            if (dn_row0 > dn_col0 + 9) {
+                __nv_bfloat16 _cvt_bf16_5 = __float2bfloat16(acc[5]);
+                float _cvt_f32_7 = __bfloat162float(_cvt_bf16_5);
+                dm_values[5] = _cvt_f32_7 * dm_beta0;
+            }
+            if (dn_row1 > dn_col0 + 8) {
+                __nv_bfloat16 _cvt_bf16_6 = __float2bfloat16(acc[6]);
+                float _cvt_f32_8 = __bfloat162float(_cvt_bf16_6);
+                dm_values[6] = _cvt_f32_8 * dm_beta1;
+            }
+            if (dn_row1 > dn_col0 + 9) {
+                __nv_bfloat16 _cvt_bf16_7 = __float2bfloat16(acc[7]);
+                float _cvt_f32_9 = __bfloat162float(_cvt_bf16_7);
+                dm_values[7] = _cvt_f32_9 * dm_beta1;
+            }
+            unsigned int packed_14[4];
+            #pragma unroll
+            for (int _lp = 0; _lp < 4; _lp++) {
+                __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(dm_values[_lp*2 + 0], dm_values[_lp*2+1 + 0]));
+                packed_14[_lp] = *(uint32_t*)&_bf2;
+            }
+            int direct_row_15 = row_base + lane % 16;
+            int direct_col_16 = col_base + lane / 16 * 8;
+            uint32_t _stmatrix_addr_5 = static_cast<uint32_t>((unsigned long long)(s_dmt_tc_addr + (unsigned int)(direct_col_16 / 16 * 1024 + direct_row_15 * 32 + direct_col_16 % 16 * 2 ^ (direct_col_16 / 16 * 1024 + direct_row_15 * 32 + direct_col_16 % 16 * 2 >> 7 & 1) << 4)));
+            asm volatile("stmatrix.sync.aligned.m8n8.x4.shared.b16 [%0], {%1, %2, %3, %4};\n"
+                :: "r"(_stmatrix_addr_5), "r"(*reinterpret_cast<const uint32_t*>(&packed_14[0])), "r"(*reinterpret_cast<const uint32_t*>(&packed_14[1])), "r"(*reinterpret_cast<const uint32_t*>(&packed_14[2])), "r"(*reinterpret_cast<const uint32_t*>(&packed_14[3]))
+                : "memory");
+            #pragma unroll
+            for (int publish_pair_1 = 0; publish_pair_1 < 2; publish_pair_1++) {
+                int transpose_row_1 = col_base + publish_pair_1 * 8 + (lane & 7);
+                int transpose_col_1 = row_base + lane / 8 * 8;
+                uint32_t _stmatrix_addr_6 = static_cast<uint32_t>((unsigned long long)(s_dm_tc_addr + (unsigned int)(transpose_col_1 / 16 * 1024 + transpose_row_1 * 32 + transpose_col_1 % 16 * 2 ^ (transpose_col_1 / 16 * 1024 + transpose_row_1 * 32 + transpose_col_1 % 16 * 2 >> 7 & 1) << 4)));
+                asm volatile("stmatrix.sync.aligned.m8n8.x2.trans.shared.b16 [%0], {%1, %2};\n"
+                    :: "r"(_stmatrix_addr_6), "r"(*reinterpret_cast<const uint32_t*>(&packed_14[publish_pair_1 * 2])), "r"(*reinterpret_cast<const uint32_t*>(&packed_14[publish_pair_1 * 2 + 1]))
+                    : "memory");
+            }
+            asm volatile("fence.proxy.async.shared::cta;" ::: "memory");
+            asm volatile("barrier.sync 8, 128;" ::: "memory");
+            if (warp_id_in_role == 0) {
+                if (elect_sync()) {
+                    mbarrier_arrive(prep_ready_addr);
+                }
+            }
+            int token_col = lane;
+            float db_partial = 0.0f;
+            float inv_value_beta = 0.0f;
+            if (value_beta != 0.0f) {
+                float _rcp_2 = approx_rcp(value_beta);
+                inv_value_beta = _rcp_2;
+            }
+            #pragma unroll
+            for (int value_local = 0; value_local < 32; value_local++) {
+                int value_row_2 = warp_id_in_role * 32 + value_local;
+                long long tape_item = token_value_base + (long long)(value_row_2 * 32) + (long long)token_col;
+                int value_major_item_2 = value_row_2 * 32 + token_col;
+                __nv_bfloat16 x_value = s_x[(value_major_item_2 * 2 ^ (value_major_item_2 * 2 >> 7 & 7) << 4) / 2];
+                float _cvt_f32_10 = __bfloat162float(x_value);
+                float recovered_e = _cvt_f32_10 * inv_value_beta;
+                float _fma_0 = __fmaf_rn((float)chunk_dx[tape_item], recovered_e, db_partial);
+                db_partial = _fma_0;
+            }
+            int db_matrix_item = token_col * 32 + warp_id_in_role * 8;
+            unsigned int db_df_packed[4];
+            unsigned int db_m_packed[4];
+            asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                : "=r"(*reinterpret_cast<uint32_t*>(&db_df_packed[0])), "=r"(*reinterpret_cast<uint32_t*>(&db_df_packed[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&db_df_packed[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&db_df_packed[(0) + 3]))
+                : "r"(s_df_addr + (unsigned int)((db_matrix_item * 2 ^ (db_matrix_item * 2 >> 7 & 7) << 4) / 2 * 2)));
+            asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                : "=r"(*reinterpret_cast<uint32_t*>(&db_m_packed[0])), "=r"(*reinterpret_cast<uint32_t*>(&db_m_packed[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&db_m_packed[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&db_m_packed[(0) + 3]))
+                : "r"(s_m_addr + (unsigned int)((db_matrix_item * 2 ^ (db_matrix_item * 2 >> 7 & 7) << 4) / 2 * 2)));
+            float db_df_packed_f32[8];
+            #pragma unroll
+            for (int _pair = 0; _pair < 4; _pair++) {
+                asm volatile(
+                    "{\n\t"
+                    "shl.b32 %0, %2, 16;\n\t"
+                    "and.b32 %1, %2, 0xffff0000;\n\t"
+                    "}\n"
+                    : "=f"((&db_df_packed_f32[_pair * 2])[0]), "=f"((&db_df_packed_f32[_pair * 2])[1])
+                    : "r"(db_df_packed[_pair]));
+            }
+            float db_m_packed_f32[8];
+            #pragma unroll
+            for (int _pair = 0; _pair < 4; _pair++) {
+                asm volatile(
+                    "{\n\t"
+                    "shl.b32 %0, %2, 16;\n\t"
+                    "and.b32 %1, %2, 0xffff0000;\n\t"
+                    "}\n"
+                    : "=f"((&db_m_packed_f32[_pair * 2])[0]), "=f"((&db_m_packed_f32[_pair * 2])[1])
+                    : "r"(db_m_packed[_pair]));
+            }
+            #pragma unroll
+            for (int col_local = 0; col_local < 8; col_local++) {
+                float _fma_1 = __fmaf_rn(db_df_packed_f32[col_local], db_m_packed_f32[col_local], db_partial);
+                db_partial = _fma_1;
+            }
+            s_dbeta_partial[warp_id_in_role * 32 + token_col] = db_partial;
+            asm volatile("barrier.sync 8, 128;" ::: "memory");
+            if (warp_id_in_role == 0) {
+                float db_value = s_dbeta_partial[token_col] + s_dbeta_partial[32 + token_col] + s_dbeta_partial[64 + token_col] + s_dbeta_partial[96 + token_col];
+                long long token = chunk_start + (long long)token_col;
+                if (token < eos) {
+                    dbeta_active[token * (long long)num_heads + (long long)head] = db_value;
+                }
+                if (elect_sync()) {
+                    mbarrier_arrive(dbeta_done_addr);
+                }
+            }
+            int prep_key_row = prep_tid;
+            const int prep_tmem_row_base = warp_id_in_role * 32 << 16;
+            float prep_restore = tape_restore_factor[restore_base + (long long)prep_key_row];
+            float prep_kr_prefetch = (float)tape_kr[token_key_base + 2048 + (long long)prep_key_row];
+            unsigned int _phase_first_outputs_ready_0 = 0;
+            mbarrier_wait(first_outputs_ready_addr, _phase_first_outputs_ready_0);
+            _phase_first_outputs_ready_0 ^= 1;
+            long long prep_out_base = chunk_head * 32 * 128;
+            long long prep_chunk_end = chunk_start + 32;
+            if (prep_chunk_end > eos) {
+                prep_chunk_end = eos;
+            }
+            int prep_chunk_length = (int)(prep_chunk_end - chunk_start);
+            float _exp2_0 = approx_exp2(lower_bound * 1.4426950408889634f * 16.0f);
+            float prep_common_factor = _exp2_0;
+            const int prep_token_offset = 16;
+            float _tmem_load_0[8];
+            tmem_ld_x8(&_tmem_load_0[0], taddr + 176 + (unsigned int)prep_tmem_row_base + (unsigned int)prep_token_offset);
+            #pragma unroll
+            for (int prep_token_local_early = 0; prep_token_local_early < 8; prep_token_local_early++) {
+                int prep_token_out_early = prep_token_offset + prep_token_local_early;
+                float prep_kr_value_early = prep_kr_prefetch;
+                if (prep_token_local_early != 0) {
+                    prep_kr_value_early = (float)tape_kr[token_key_base + (long long)(prep_token_out_early * 128) + (long long)prep_key_row];
+                }
+                int prep_stable_index_early = prep_token_out_early * 128 + prep_key_row;
+                s_stable_dkr[prep_stable_index_early] = _tmem_load_0[prep_token_local_early] * prep_kr_value_early;
+                _tmem_load_0[prep_token_local_early] = _tmem_load_0[prep_token_local_early] * prep_restore;
+            }
+            unsigned int _phase_outputs_ready_0 = 0;
+            mbarrier_wait(outputs_ready_addr, _phase_outputs_ready_0);
+            _phase_outputs_ready_0 ^= 1;
+            float _tmem_load_1[8];
+            tmem_ld_x8(&_tmem_load_1[0], taddr + 208 + (unsigned int)prep_tmem_row_base + (unsigned int)prep_token_offset);
+            asm volatile("tcgen05.wait::ld.sync.aligned;");
+            #pragma unroll
+            for (int prep_token_local = 0; prep_token_local < 8; prep_token_local++) {
+                int prep_token_out = prep_token_offset + prep_token_local;
+                long long prep_out_index = prep_out_base + (long long)(prep_token_out * 128) + (long long)prep_key_row;
+                int prep_shared_index = prep_token_out * 128 + prep_key_row;
+                __nv_bfloat16 prep_i_value_bf16 = s_i[(prep_shared_index * 2 ^ (prep_shared_index * 2 >> 8 & 7) << 4) / 2];
+                float _cvt_f32_11 = __bfloat162float(prep_i_value_bf16);
+                float prep_i_value = _cvt_f32_11;
+                grad_ki[prep_out_index] = _tmem_load_1[prep_token_local] + _tmem_load_0[prep_token_local];
+                _tmem_load_1[prep_token_local] = _tmem_load_1[prep_token_local] * prep_i_value;
+            }
+            float _tmem_load_2[8];
+            tmem_ld_x8(&_tmem_load_2[0], taddr + 240 + (unsigned int)prep_tmem_row_base + (unsigned int)prep_token_offset);
+            float _tmem_load_3[8];
+            tmem_ld_x8(&_tmem_load_3[0], taddr + 272 + (unsigned int)prep_tmem_row_base + (unsigned int)prep_token_offset);
+            asm volatile("tcgen05.wait::ld.sync.aligned;");
+            #pragma unroll
+            for (int prep_token_local2 = 0; prep_token_local2 < 8; prep_token_local2++) {
+                int prep_token_out2 = prep_token_offset + prep_token_local2;
+                long long prep_out_index2 = prep_out_base + (long long)(prep_token_out2 * 128) + (long long)prep_key_row;
+                int prep_shared_index2 = prep_token_out2 * 128 + prep_key_row;
+                __nv_bfloat16 prep_q_value_bf16 = s_q[(prep_shared_index2 * 2 ^ (prep_shared_index2 * 2 >> 8 & 7) << 4) / 2];
+                float _cvt_f32_12 = __bfloat162float(prep_q_value_bf16);
+                float prep_q_value = _cvt_f32_12;
+                _tmem_load_3[prep_token_local2] = _tmem_load_3[prep_token_local2] * prep_common_factor;
+                float _fma_2 = __fmaf_rn(-_tmem_load_2[prep_token_local2], prep_q_value, _tmem_load_1[prep_token_local2]);
+                _tmem_load_1[prep_token_local2] = _fma_2;
+                _tmem_load_0[prep_token_local2] = _tmem_load_3[prep_token_local2] * prep_q_value;
+                grad_qd[prep_out_index2] = _tmem_load_2[prep_token_local2] + _tmem_load_3[prep_token_local2];
+            }
+            unsigned int _phase_dbeta_done_0 = 0;
+            mbarrier_wait(dbeta_done_addr, _phase_dbeta_done_0);
+            _phase_dbeta_done_0 ^= 1;
+            float _tmem_load_4[8];
+            tmem_ld_x8(&_tmem_load_4[0], taddr + 304 + (unsigned int)prep_tmem_row_base + (unsigned int)prep_token_offset);
+            float _tmem_load_5[8];
+            tmem_ld_x8(&_tmem_load_5[0], taddr + 336 + (unsigned int)prep_tmem_row_base + (unsigned int)prep_token_offset);
+            asm volatile("tcgen05.wait::ld.sync.aligned;");
+            float prep_middle_base_suffix = 0.0f;
+            #pragma unroll
+            for (int prep_token_local3 = 0; prep_token_local3 < 8; prep_token_local3++) {
+                int prep_token_out3 = prep_token_offset + prep_token_local3;
+                long long prep_out_index3 = prep_out_base + (long long)(prep_token_out3 * 128) + (long long)prep_key_row;
+                int prep_shared_index3 = prep_token_out3 * 128 + prep_key_row;
+                __nv_bfloat16 prep_k_value_bf16 = s_k[(prep_shared_index3 * 2 ^ (prep_shared_index3 * 2 >> 8 & 7) << 4) / 2];
+                float _cvt_f32_13 = __bfloat162float(prep_k_value_bf16);
+                float prep_k_value = _cvt_f32_13;
+                _tmem_load_5[prep_token_local3] = _tmem_load_5[prep_token_local3] * (-prep_common_factor);
+                float _fma_3 = __fmaf_rn(-_tmem_load_4[prep_token_local3], prep_k_value, _tmem_load_1[prep_token_local3]);
+                _tmem_load_1[prep_token_local3] = _fma_3;
+                float prep_base_value = _tmem_load_0[prep_token_local3] + _tmem_load_5[prep_token_local3] * prep_k_value;
+                int prep_stable_index3 = prep_token_out3 * 128 + prep_key_row;
+                s_stable_delta[prep_stable_index3] = _tmem_load_1[prep_token_local3];
+                s_stable_base[prep_stable_index3] = prep_base_value;
+                if (prep_token_out3 < prep_chunk_length) {
+                    prep_middle_base_suffix += prep_base_value;
+                }
+                grad_kd[prep_out_index3] = _tmem_load_4[prep_token_local3] + _tmem_load_5[prep_token_local3];
+            }
+            s_middle_base_suffix[prep_key_row] = prep_middle_base_suffix;
+            asm volatile("barrier.sync 10, 384;" ::: "memory");
+        }
+    }
+    // ---- Role: epilogue ----
+    if (warp >= 4 && warp <= 7) {
+        asm volatile("setmaxnreg.inc.sync.aligned.u32 208;");
+        { // epilogue_main
+            int ordered_chunk_1 = blockIdx.x / num_heads;
+            int chunk_global_1 = consumer_chunk_order[ordered_chunk_1];
+            int head_1 = blockIdx.x - ordered_chunk_1 * num_heads;
+            int sequence_1 = chunk_sequence[chunk_global_1];
+            int local_chunk_1 = chunk_index[chunk_global_1];
+            long long bos_1 = cu_seqlens[sequence_1];
+            long long eos_1 = cu_seqlens[sequence_1 + 1];
+            long long chunk_start_1 = bos_1 + (long long)local_chunk_1 * 32;
+            long long chunk_head_1 = (long long)chunk_global_1 * (long long)num_heads + (long long)head_1;
+            int warp_id_in_role_1 = (warp - 4);
+            int key_row = warp_id_in_role_1 * 32 + lane;
+            const int tmem_row_base = warp_id_in_role_1 * 32 << 16;
+            long long token_key_base_1 = chunk_head_1 * 32 * 128;
+            long long state_base_1 = chunk_head_1 * 128 * 128;
+            long long restore_base_1 = chunk_head_1 * 128;
+            long long initial_state_base = ((long long)sequence_1 * (long long)num_heads + (long long)head_1) * 128 * 128;
+            int checkpoint_needed = 0;
+            if (local_chunk_1 != 0) {
+                checkpoint_needed = state_checkpoint_needed[chunk_head_1] != 0;
+            }
+            float restore = tape_restore_factor[restore_base_1 + (long long)key_row];
+            float gate_constant = 0.0f;
+            unsigned int _phase_recon_output_ready_0 = 0;
+            if (local_chunk_1 == 0) {
+                #pragma unroll
+                for (int value_block = 0; value_block < 128; value_block += 16) {
+                    float state_values[16];
+                    #pragma unroll
+                    for (int value_elem_2 = 0; value_elem_2 < 16; value_elem_2++) {
+                        __nv_bfloat16 _cvt_bf16_8 = __float2bfloat16(initial_state[initial_state_base + (long long)((value_block + value_elem_2) * 128) + (long long)key_row]);
+                        float _cvt_f32_14 = __bfloat162float(_cvt_bf16_8);
+                        state_values[value_elem_2] = _cvt_f32_14;
+                    }
+                    uint32_t state_values_bf16[8];
+                    #pragma unroll
+                    for (int _lp = 0; _lp < 8; _lp++) {
+                        __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(state_values[_lp*2 + 0], state_values[_lp*2+1 + 0]));
+                        state_values_bf16[_lp] = *(uint32_t*)&_bf2;
+                    }
+                    tmem_st_x8_u32(taddr + 64 + (unsigned int)tmem_row_base + (unsigned int)(value_block / 2), (const uint32_t*)state_values_bf16);
+                }
+            } else if (checkpoint_needed != 0) {
+                #pragma unroll
+                for (int value_block_1 = 0; value_block_1 < 128; value_block_1 += 16) {
+                    float state_values_1[16];
+                    #pragma unroll
+                    for (int value_elem_3 = 0; value_elem_3 < 16; value_elem_3++) {
+                        state_values_1[value_elem_3] = (float)chunk_state[state_base_1 + (long long)((value_block_1 + value_elem_3) * 128) + (long long)key_row];
+                    }
+                    uint32_t state_values_bf16_1[8];
+                    #pragma unroll
+                    for (int _lp = 0; _lp < 8; _lp++) {
+                        __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(state_values_1[_lp*2 + 0], state_values_1[_lp*2+1 + 0]));
+                        state_values_bf16_1[_lp] = *(uint32_t*)&_bf2;
+                    }
+                    tmem_st_x8_u32(taddr + 64 + (unsigned int)tmem_row_base + (unsigned int)(value_block_1 / 2), (const uint32_t*)state_values_bf16_1);
+                }
+            } else {
+                long long prev_chunk_head = (long long)(chunk_global_1 - 1) * (long long)num_heads + (long long)head_1;
+                long long prev_token_key_base = prev_chunk_head * 32 * 128;
+                long long prev_value_token_base = prev_chunk_head * 128 * 32;
+                #pragma unroll
+                for (int token_half_state = 0; token_half_state < 2; token_half_state++) {
+                    int token_offset_state = token_half_state * 16;
+                    float kr_values[16];
+                    #pragma unroll
+                    for (int token_local_state = 0; token_local_state < 16; token_local_state++) {
+                        int token_col_state = token_offset_state + token_local_state;
+                        kr_values[token_local_state] = (float)tape_kr[prev_token_key_base + (long long)token_col_state * 128 + (long long)key_row];
+                    }
+                    uint32_t kr_values_bf16[8];
+                    #pragma unroll
+                    for (int _lp = 0; _lp < 8; _lp++) {
+                        __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(kr_values[_lp*2 + 0], kr_values[_lp*2+1 + 0]));
+                        kr_values_bf16[_lp] = *(uint32_t*)&_bf2;
+                    }
+                    tmem_st_x8_u32(taddr + 64 + (unsigned int)tmem_row_base + (unsigned int)(token_half_state * 8), (const uint32_t*)kr_values_bf16);
+                }
+                #pragma unroll
+                for (int prev_r_segment = 0; prev_r_segment < 4; prev_r_segment++) {
+                    float prev_r_values[8];
+                    {
+                        const uint4* _vptr_0 = reinterpret_cast<const uint4*>(tape_r + prev_value_token_base + (long long)key_row * 32 + (long long)(prev_r_segment * 8));
+                        uint4 _vld_0[1];
+                        #pragma unroll
+                        for (int _blk = 0; _blk < 1; _blk++) {
+                            _vld_0[_blk] = _vptr_0[_blk];
+                            uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
+                            #pragma unroll
+                            for (int _pair = 0; _pair < 4; _pair++) {
+                                asm volatile(
+                                    "{\n\t"
+                                    "shl.b32 %0, %2, 16;\n\t"
+                                    "and.b32 %1, %2, 0xffff0000;\n\t"
+                                    "}\n"
+                                    : "=f"((&prev_r_values[0 + _blk * 8 + _pair * 2])[0]), "=f"((&prev_r_values[0 + _blk * 8 + _pair * 2])[1])
+                                    : "r"(_vpairs_0[_pair]));
+                            }
+                        }
+                    }
+                    unsigned int packed_4[4];
+                    #pragma unroll
+                    for (int _lp = 0; _lp < 4; _lp++) {
+                        __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(prev_r_values[_lp*2 + 0], prev_r_values[_lp*2+1 + 0]));
+                        packed_4[_lp] = *(uint32_t*)&_bf2;
+                    }
+                    #pragma unroll
+                    for (int word = 0; word < 4; word++) {
+                        asm volatile("st.shared.b32 [%0], %1;" :: "r"((s_prev_r_tc_addr + (unsigned int)(prev_r_segment * 8 / 16 * 4096 + key_row * 32 + prev_r_segment * 8 % 16 * 2 ^ (prev_r_segment * 8 / 16 * 4096 + key_row * 32 + prev_r_segment * 8 % 16 * 2 >> 7 & 1) << 4)) + (unsigned int)(word * 4)), "r"((packed_4[word])));
+                    }
+                }
+                asm volatile("fence.proxy.async.shared::cta;" ::: "memory");
+                asm volatile("tcgen05.wait::st.sync.aligned;" ::: "memory");
+                if (elect_sync()) {
+                    mbarrier_arrive(recon_inputs_ready_addr);
+                }
+                mbarrier_wait(recon_output_ready_addr, _phase_recon_output_ready_0);
+                _phase_recon_output_ready_0 ^= 1;
+                #pragma unroll
+                for (int value_block_2 = 0; value_block_2 < 128; value_block_2 += 16) {
+                    float _tmem_load_6[16];
+                    tmem_ld_x16(&_tmem_load_6[0], taddr + 368 + (unsigned int)tmem_row_base + (unsigned int)value_block_2);
+                    asm volatile("tcgen05.wait::ld.sync.aligned;" ::: "memory");
+                    uint32_t _tmem_load_6_bf16[8];
+                    #pragma unroll
+                    for (int _lp = 0; _lp < 8; _lp++) {
+                        __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(_tmem_load_6[_lp*2 + 0], _tmem_load_6[_lp*2+1 + 0]));
+                        _tmem_load_6_bf16[_lp] = *(uint32_t*)&_bf2;
+                    }
+                    tmem_st_x8_u32(taddr + 64 + (unsigned int)tmem_row_base + (unsigned int)(value_block_2 / 2), (const uint32_t*)_tmem_load_6_bf16);
+                }
+            }
+            asm volatile("tcgen05.wait::st.sync.aligned;" ::: "memory");
+            if (elect_sync()) {
+                mbarrier_arrive(state_tc_ready_addr);
+            }
+            unsigned int _phase_qki_ready_0 = 0;
+            mbarrier_wait(qki_ready_addr, _phase_qki_ready_0);
+            _phase_qki_ready_0 ^= 1;
+            #pragma unroll
+            for (int token_half_ki = 0; token_half_ki < 2; token_half_ki++) {
+                int token_offset_ki = token_half_ki * 16;
+                float ki_values[16];
+                #pragma unroll
+                for (int token_local_k = 0; token_local_k < 16; token_local_k++) {
+                    int token_col_k = token_offset_ki + token_local_k;
+                    int shared_index_k = token_col_k * 128 + key_row;
+                    ki_values[token_local_k] = s_k[(shared_index_k * 2 ^ (shared_index_k * 2 >> 8 & 7) << 4) / 2];
+                }
+                uint32_t ki_values_bf16[8];
+                #pragma unroll
+                for (int _lp = 0; _lp < 8; _lp++) {
+                    __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(ki_values[_lp*2 + 0], ki_values[_lp*2+1 + 0]));
+                    ki_values_bf16[_lp] = *(uint32_t*)&_bf2;
+                }
+                tmem_st_x8_u32(taddr + 128 + (unsigned int)tmem_row_base + (unsigned int)(token_half_ki * 8), (const uint32_t*)ki_values_bf16);
+                #pragma unroll
+                for (int token_local_q = 0; token_local_q < 16; token_local_q++) {
+                    int token_col_q = token_offset_ki + token_local_q;
+                    int shared_index_q = token_col_q * 128 + key_row;
+                    ki_values[token_local_q] = s_q[(shared_index_q * 2 ^ (shared_index_q * 2 >> 8 & 7) << 4) / 2];
+                }
+                uint32_t ki_values_bf16_0[8];
+                #pragma unroll
+                for (int _lp = 0; _lp < 8; _lp++) {
+                    __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(ki_values[_lp*2 + 0], ki_values[_lp*2+1 + 0]));
+                    ki_values_bf16_0[_lp] = *(uint32_t*)&_bf2;
+                }
+                tmem_st_x8_u32(taddr + 144 + (unsigned int)tmem_row_base + (unsigned int)(token_half_ki * 8), (const uint32_t*)ki_values_bf16_0);
+                #pragma unroll
+                for (int token_local_i = 0; token_local_i < 16; token_local_i++) {
+                    int token_col_i = token_offset_ki + token_local_i;
+                    int shared_index_i = token_col_i * 128 + key_row;
+                    ki_values[token_local_i] = s_i[(shared_index_i * 2 ^ (shared_index_i * 2 >> 8 & 7) << 4) / 2];
+                }
+                uint32_t ki_values_bf16_1[8];
+                #pragma unroll
+                for (int _lp = 0; _lp < 8; _lp++) {
+                    __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(ki_values[_lp*2 + 0], ki_values[_lp*2+1 + 0]));
+                    ki_values_bf16_1[_lp] = *(uint32_t*)&_bf2;
+                }
+                tmem_st_x8_u32(taddr + 160 + (unsigned int)tmem_row_base + (unsigned int)(token_half_ki * 8), (const uint32_t*)ki_values_bf16_1);
+            }
+            asm volatile("tcgen05.wait::st.sync.aligned;" ::: "memory");
+            if (elect_sync()) {
+                mbarrier_arrive(qki_tc_ready_addr);
+            }
+            if (boundary_ready_target != 0) {
+                if (warp_id_in_role_1 == 0) {
+                    {
+                        unsigned int* _gca_p = reinterpret_cast<unsigned int*>(boundary_ready) + (chunk_head_1);
+                        while (true) {
+                            unsigned int _gca_v;
+                            asm volatile("ld.acquire.gpu.global.u32 %0, [%1];" : "=r"(_gca_v) : "l"(_gca_p));
+                            if (_gca_v >= (unsigned int)(boundary_ready_target)) break;
+                        }
+                    }
+                }
+                asm volatile("barrier.sync 9, 128;" ::: "memory");
+            }
+            unsigned int _phase_dh_ready_0 = 0;
+            mbarrier_wait(dh_ready_addr, _phase_dh_ready_0);
+            _phase_dh_ready_0 ^= 1;
+            if (local_chunk_1 == 0) {
+                #pragma unroll
+                for (int value_block2 = 0; value_block2 < 128; value_block2 += 16) {
+                    float dh_values[16];
+                    #pragma unroll
+                    for (int value_elem2 = 0; value_elem2 < 16; value_elem2++) {
+                        int value_row_3 = value_block2 + value_elem2;
+                        __nv_bfloat16 _cvt_bf16_9 = __float2bfloat16(initial_state[initial_state_base + (long long)(value_row_3 * 128) + (long long)key_row]);
+                        float _cvt_f32_15 = __bfloat162float(_cvt_bf16_9);
+                        float state_value = _cvt_f32_15;
+                        __nv_bfloat16 dh_value = s_dh_stage[((value_row_3 * 128 + key_row) * 2 ^ ((value_row_3 * 128 + key_row) * 2 >> 7 & 7) << 4) / 2];
+                        float _cvt_f32_16 = __bfloat162float(dh_value);
+                        dh_values[value_elem2] = _cvt_f32_16;
+                        float _fma_4 = __fmaf_rn(dh_values[value_elem2], state_value, gate_constant);
+                        gate_constant = _fma_4;
+                    }
+                    uint32_t dh_values_bf16[8];
+                    #pragma unroll
+                    for (int _lp = 0; _lp < 8; _lp++) {
+                        __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(dh_values[_lp*2 + 0], dh_values[_lp*2+1 + 0]));
+                        dh_values_bf16[_lp] = *(uint32_t*)&_bf2;
+                    }
+                    tmem_st_x8_u32(taddr + (unsigned int)tmem_row_base + (unsigned int)(value_block2 / 2), (const uint32_t*)dh_values_bf16);
+                }
+            } else if (checkpoint_needed != 0) {
+                #pragma unroll
+                for (int value_block2_1 = 0; value_block2_1 < 128; value_block2_1 += 16) {
+                    float dh_values_1[16];
+                    #pragma unroll
+                    for (int value_elem2_1 = 0; value_elem2_1 < 16; value_elem2_1++) {
+                        int value_row_4 = value_block2_1 + value_elem2_1;
+                        float state_value_1 = (float)chunk_state[state_base_1 + (long long)(value_row_4 * 128) + (long long)key_row];
+                        __nv_bfloat16 dh_value_1 = s_dh_stage[((value_row_4 * 128 + key_row) * 2 ^ ((value_row_4 * 128 + key_row) * 2 >> 7 & 7) << 4) / 2];
+                        float _cvt_f32_17 = __bfloat162float(dh_value_1);
+                        dh_values_1[value_elem2_1] = _cvt_f32_17;
+                        float _fma_5 = __fmaf_rn(dh_values_1[value_elem2_1], state_value_1, gate_constant);
+                        gate_constant = _fma_5;
+                    }
+                    uint32_t dh_values_bf16_1[8];
+                    #pragma unroll
+                    for (int _lp = 0; _lp < 8; _lp++) {
+                        __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(dh_values_1[_lp*2 + 0], dh_values_1[_lp*2+1 + 0]));
+                        dh_values_bf16_1[_lp] = *(uint32_t*)&_bf2;
+                    }
+                    tmem_st_x8_u32(taddr + (unsigned int)tmem_row_base + (unsigned int)(value_block2_1 / 2), (const uint32_t*)dh_values_bf16_1);
+                }
+            } else {
+                #pragma unroll
+                for (int value_block2_2 = 0; value_block2_2 < 128; value_block2_2 += 16) {
+                    float _tmem_load_7[16];
+                    tmem_ld_x16(&_tmem_load_7[0], taddr + 368 + (unsigned int)tmem_row_base + (unsigned int)value_block2_2);
+                    asm volatile("tcgen05.wait::ld.sync.aligned;" ::: "memory");
+                    float dh_values_2[16];
+                    #pragma unroll
+                    for (int value_elem2_2 = 0; value_elem2_2 < 16; value_elem2_2++) {
+                        int value_row_5 = value_block2_2 + value_elem2_2;
+                        __nv_bfloat16 dh_value_2 = s_dh_stage[((value_row_5 * 128 + key_row) * 2 ^ ((value_row_5 * 128 + key_row) * 2 >> 7 & 7) << 4) / 2];
+                        float _cvt_f32_18 = __bfloat162float(dh_value_2);
+                        dh_values_2[value_elem2_2] = _cvt_f32_18;
+                        float _fma_6 = __fmaf_rn(dh_values_2[value_elem2_2], _tmem_load_7[value_elem2_2], gate_constant);
+                        gate_constant = _fma_6;
+                    }
+                    uint32_t dh_values_bf16_2[8];
+                    #pragma unroll
+                    for (int _lp = 0; _lp < 8; _lp++) {
+                        __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(dh_values_2[_lp*2 + 0], dh_values_2[_lp*2+1 + 0]));
+                        dh_values_bf16_2[_lp] = *(uint32_t*)&_bf2;
+                    }
+                    tmem_st_x8_u32(taddr + (unsigned int)tmem_row_base + (unsigned int)(value_block2_2 / 2), (const uint32_t*)dh_values_bf16_2);
+                }
+            }
+            asm volatile("tcgen05.wait::st.sync.aligned;" ::: "memory");
+            float _exp2_1 = approx_exp2(lower_bound * 1.4426950408889634f * 16.0f);
+            float common_factor = _exp2_1;
+            gate_constant *= common_factor * restore;
+            if (elect_sync()) {
+                mbarrier_arrive(a_ready_addr);
+            }
+            float kr_prefetch = (float)tape_kr[token_key_base_1 + (long long)key_row];
+            unsigned int _phase_first_outputs_ready_0_1 = 0;
+            mbarrier_wait(first_outputs_ready_addr, _phase_first_outputs_ready_0_1);
+            _phase_first_outputs_ready_0_1 ^= 1;
+            long long out_base = chunk_head_1 * 32 * 128;
+            float base_suffix = 0.0f;
+            long long chunk_end = chunk_start_1 + 32;
+            if (chunk_end > eos_1) {
+                chunk_end = eos_1;
+            }
+            int chunk_length = (int)(chunk_end - chunk_start_1);
+            unsigned int _phase_outputs_ready_0_1 = 0;
+            unsigned int _phase_dbeta_done_0_1 = 0;
+            #pragma unroll
+            for (int token_half = 0; token_half < 1; token_half++) {
+                int token_offset = token_half * 16;
+                float _tmem_load_8[16];
+                tmem_ld_x16(&_tmem_load_8[0], taddr + 176 + (unsigned int)tmem_row_base + (unsigned int)token_offset);
+                #pragma unroll
+                for (int token_local_early = 0; token_local_early < 16; token_local_early++) {
+                    int token_out_early = token_offset + token_local_early;
+                    float kr_value_early = kr_prefetch;
+                    if (token_local_early != 0) {
+                        kr_value_early = (float)tape_kr[token_key_base_1 + (long long)(token_out_early * 128) + (long long)key_row];
+                    }
+                    int stable_index_early = token_out_early * 128 + key_row;
+                    s_stable_dkr[stable_index_early] = _tmem_load_8[token_local_early] * kr_value_early;
+                    _tmem_load_8[token_local_early] = _tmem_load_8[token_local_early] * restore;
+                }
+                mbarrier_wait(outputs_ready_addr, _phase_outputs_ready_0_1);
+                _phase_outputs_ready_0_1 ^= 1;
+                float _tmem_load_9[16];
+                tmem_ld_x16(&_tmem_load_9[0], taddr + 208 + (unsigned int)tmem_row_base + (unsigned int)token_offset);
+                asm volatile("tcgen05.wait::ld.sync.aligned;");
+                #pragma unroll
+                for (int token_local = 0; token_local < 16; token_local++) {
+                    int token_out = token_offset + token_local;
+                    long long out_index = out_base + (long long)(token_out * 128) + (long long)key_row;
+                    int shared_index = token_out * 128 + key_row;
+                    __nv_bfloat16 i_value_bf16 = s_i[(shared_index * 2 ^ (shared_index * 2 >> 8 & 7) << 4) / 2];
+                    float _cvt_f32_19 = __bfloat162float(i_value_bf16);
+                    float i_value = _cvt_f32_19;
+                    grad_ki[out_index] = _tmem_load_9[token_local] + _tmem_load_8[token_local];
+                    _tmem_load_9[token_local] = _tmem_load_9[token_local] * i_value;
+                }
+                float _tmem_load_10[16];
+                tmem_ld_x16(&_tmem_load_10[0], taddr + 240 + (unsigned int)tmem_row_base + (unsigned int)token_offset);
+                float _tmem_load_11[16];
+                tmem_ld_x16(&_tmem_load_11[0], taddr + 272 + (unsigned int)tmem_row_base + (unsigned int)token_offset);
+                asm volatile("tcgen05.wait::ld.sync.aligned;");
+                #pragma unroll
+                for (int token_local2 = 0; token_local2 < 16; token_local2++) {
+                    int token_out2 = token_offset + token_local2;
+                    long long out_index_1 = out_base + (long long)(token_out2 * 128) + (long long)key_row;
+                    int shared_index2 = token_out2 * 128 + key_row;
+                    __nv_bfloat16 q_value_bf16 = s_q[(shared_index2 * 2 ^ (shared_index2 * 2 >> 8 & 7) << 4) / 2];
+                    float _cvt_f32_20 = __bfloat162float(q_value_bf16);
+                    float q_value = _cvt_f32_20;
+                    _tmem_load_11[token_local2] = _tmem_load_11[token_local2] * common_factor;
+                    float _fma_7 = __fmaf_rn(-_tmem_load_10[token_local2], q_value, _tmem_load_9[token_local2]);
+                    _tmem_load_9[token_local2] = _fma_7;
+                    _tmem_load_8[token_local2] = _tmem_load_11[token_local2] * q_value;
+                    grad_qd[out_index_1] = _tmem_load_10[token_local2] + _tmem_load_11[token_local2];
+                }
+                mbarrier_wait(dbeta_done_addr, _phase_dbeta_done_0_1);
+                _phase_dbeta_done_0_1 ^= 1;
+                float _tmem_load_12[16];
+                tmem_ld_x16(&_tmem_load_12[0], taddr + 304 + (unsigned int)tmem_row_base + (unsigned int)token_offset);
+                float _tmem_load_13[16];
+                tmem_ld_x16(&_tmem_load_13[0], taddr + 336 + (unsigned int)tmem_row_base + (unsigned int)token_offset);
+                asm volatile("tcgen05.wait::ld.sync.aligned;");
+                #pragma unroll
+                for (int token_local3 = 0; token_local3 < 16; token_local3++) {
+                    int token_out3 = token_offset + token_local3;
+                    long long out_index_2 = out_base + (long long)(token_out3 * 128) + (long long)key_row;
+                    int shared_index3 = token_out3 * 128 + key_row;
+                    __nv_bfloat16 k_value_bf16 = s_k[(shared_index3 * 2 ^ (shared_index3 * 2 >> 8 & 7) << 4) / 2];
+                    float _cvt_f32_21 = __bfloat162float(k_value_bf16);
+                    float k_value = _cvt_f32_21;
+                    _tmem_load_13[token_local3] = _tmem_load_13[token_local3] * (-common_factor);
+                    float _fma_8 = __fmaf_rn(-_tmem_load_12[token_local3], k_value, _tmem_load_9[token_local3]);
+                    _tmem_load_9[token_local3] = _fma_8;
+                    float base_value = _tmem_load_8[token_local3] + _tmem_load_13[token_local3] * k_value;
+                    int stable_index3 = token_out3 * 128 + key_row;
+                    s_stable_delta[stable_index3] = _tmem_load_9[token_local3];
+                    s_stable_base[stable_index3] = base_value;
+                    if (token_out3 < chunk_length) {
+                        base_suffix += base_value;
+                    }
+                    grad_kd[out_index_2] = _tmem_load_12[token_local3] + _tmem_load_13[token_local3];
+                }
+            }
+            asm volatile("barrier.sync 10, 384;" ::: "memory");
+            base_suffix += s_middle_base_suffix[key_row] + s_high_base_suffix[key_row];
+            float prefix_dkr = 0.0f;
+            float crossing = 0.0f;
+            #pragma unroll 4
+            for (int gate_token = 0; gate_token < chunk_length; gate_token++) {
+                int stable_index = gate_token * 128 + key_row;
+                long long token_1 = chunk_start_1 + (long long)gate_token;
+                long long dlog_index = (token_1 * (long long)num_heads + (long long)head_1) * 128 + (long long)key_row;
+                dlog_decay[dlog_index] = base_suffix + gate_constant + (prefix_dkr + crossing);
+                crossing += s_stable_delta[stable_index];
+                prefix_dkr += s_stable_dkr[stable_index];
+                base_suffix -= s_stable_base[stable_index];
+            }
+            if (elect_sync()) {
+                mbarrier_arrive(epilogue_done_addr);
+            }
+        }
+    }
+    // ---- Role: mma ----
+    if (warp >= 8 && warp <= 11) {
+        asm volatile("setmaxnreg.dec.sync.aligned.u32 96;");
+        { // mma_main
+            int ordered_chunk_2 = blockIdx.x / num_heads;
+            int chunk_global_2 = consumer_chunk_order[ordered_chunk_2];
+            int local_chunk_2 = chunk_index[chunk_global_2];
+            int head_2 = blockIdx.x - ordered_chunk_2 * num_heads;
+            long long chunk_head_2 = (long long)chunk_global_2 * (long long)num_heads + (long long)head_2;
+            int warp_id_in_role_2 = (warp - 8);
+            unsigned int _phase_boundary_local_ready_0 = 0;
+            unsigned int _phase_dv_ready_0 = 0;
+            if (warp_id_in_role_2 != 0) {
+                mbarrier_wait(boundary_local_ready_addr, _phase_boundary_local_ready_0);
+                _phase_boundary_local_ready_0 ^= 1;
+                int sequence_do = chunk_sequence[chunk_global_2];
+                long long eos_do = cu_seqlens[sequence_do + 1];
+                long long chunk_start_do = cu_seqlens[sequence_do] + (long long)local_chunk_2 * 32;
+                int do_tid = (warp_id_in_role_2 - 1) * 32 + lane;
+                #pragma unroll 1
+                for (int do_group = do_tid; do_group < 512; do_group += 96) {
+                    int do_token_col = do_group / 16;
+                    int do_segment = do_group % 16;
+                    long long token_do = chunk_start_do + (long long)do_token_col;
+                    int do_rowmajor_item = do_token_col * 128 + do_segment * 8;
+                    asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16, %2;"
+                        :: "r"(s_do_stage_addr + (unsigned int)((do_rowmajor_item * 2 ^ (do_rowmajor_item * 2 >> 8 & 7) << 4) / 2 * 2)), "l"(do_ + ((token_do * (long long)num_heads + (long long)head_2) * 128 + (long long)(do_segment * 8))), "r"((token_do < eos_do) ? 16 : 0));
+                }
+                long long token_value_base_do = chunk_head_2 * 128 * 32;
+                #pragma unroll 1
+                for (int dr_group = do_tid; dr_group < 512; dr_group += 96) {
+                    int dr_copy_item = dr_group * 8;
+                    asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
+                        :: "r"(s_drt_addr + (unsigned int)((dr_copy_item * 2 ^ (dr_copy_item * 2 >> 7 & 7) << 4) / 2 * 2)), "l"(chunk_dr + (token_value_base_do + (long long)dr_copy_item)));
+                }
+                asm volatile("cp.async.commit_group;");
+                asm volatile("cp.async.wait_group 0;");
+                #pragma unroll 1
+                for (int do_relay_group = do_tid; do_relay_group < 512; do_relay_group += 96) {
+                    int do_relay_token_col = do_relay_group / 16;
+                    int do_relay_segment = do_relay_group % 16;
+                    int do_relay_rowmajor_item = do_relay_token_col * 128 + do_relay_segment * 8;
+                    unsigned int do_packed[4];
+                    asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                        : "=r"(*reinterpret_cast<uint32_t*>(&do_packed[0])), "=r"(*reinterpret_cast<uint32_t*>(&do_packed[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&do_packed[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&do_packed[(0) + 3]))
+                        : "r"(s_do_stage_addr + (unsigned int)((do_relay_rowmajor_item * 2 ^ (do_relay_rowmajor_item * 2 >> 8 & 7) << 4) / 2 * 2)));
+                    asm volatile("st.shared.v4.b32 [%0], {%1,%2,%3,%4};" :: "r"(s_dot_tc_addr + ((s_dot_tc_addr + (unsigned int)(do_relay_segment * 8 / 64 * 4096 + do_relay_token_col * 128 + do_relay_segment * 8 % 64 * 2 ^ (do_relay_segment * 8 / 64 * 4096 + do_relay_token_col * 128 + do_relay_segment * 8 % 64 * 2 >> 7 & 7) << 4)) - s_dot_tc_addr)), "r"(do_packed[0]), "r"(do_packed[1]), "r"(do_packed[2]), "r"(do_packed[3]) : "memory");
+                }
+                asm volatile("fence.proxy.async.shared::cta;" ::: "memory");
+                if (elect_sync()) {
+                    mbarrier_arrive(value_tc_ready_addr);
+                }
+                mbarrier_wait(dv_ready_addr, _phase_dv_ready_0);
+                _phase_dv_ready_0 ^= 1;
+                int sequence_dv = chunk_sequence[chunk_global_2];
+                long long eos_dv = cu_seqlens[sequence_dv + 1];
+                long long chunk_start_dv = cu_seqlens[sequence_dv] + (long long)local_chunk_2 * 32;
+                int dv_tid = (warp_id_in_role_2 - 1) * 32 + lane;
+                #pragma unroll 1
+                for (int dv_group = dv_tid; dv_group < 512; dv_group += 96) {
+                    int dv_token_col = dv_group / 16;
+                    int dv_segment = dv_group % 16;
+                    long long token_dv = chunk_start_dv + (long long)dv_token_col;
+                    float beta_value_dv = 0.0f;
+                    if (token_dv < eos_dv) {
+                        beta_value_dv = beta_active[token_dv * (long long)num_heads + (long long)head_2];
+                    }
+                    float dv_values[8];
+                    #pragma unroll
+                    for (int value_elem_dv = 0; value_elem_dv < 8; value_elem_dv++) {
+                        int value_row_dv = dv_segment * 8 + value_elem_dv;
+                        int det_group_dv = dv_segment * 2 + value_elem_dv / 4;
+                        float dx_value_dv = s_det[value_row_dv * 32 + (dv_token_col ^ det_group_dv)];
+                        dv_values[value_elem_dv] = dx_value_dv * beta_value_dv;
+                    }
+                    if (token_dv < eos_dv) {
+                        {
+                            __nv_bfloat162 _pk[4];
+                            _pk[0] = __floats2bfloat162_rn(dv_values[0 + 0], dv_values[0 + 1]);
+                            _pk[1] = __floats2bfloat162_rn(dv_values[0 + 2], dv_values[0 + 3]);
+                            _pk[2] = __floats2bfloat162_rn(dv_values[0 + 4], dv_values[0 + 5]);
+                            _pk[3] = __floats2bfloat162_rn(dv_values[0 + 6], dv_values[0 + 7]);
+                            *reinterpret_cast<uint4*>(&((__nv_bfloat16*)(dv + ((token_dv * (long long)num_heads + (long long)head_2) * 128 + (long long)(dv_segment * 8))))[0]) = *reinterpret_cast<uint4*>(&_pk[0]);
+                        }
+                    }
+                }
+                if (elect_sync()) {
+                    mbarrier_arrive(dbeta_done_addr);
+                }
+            }
+            unsigned int _phase_recon_inputs_ready_0 = 0;
+            unsigned int _phase_state_tc_ready_0 = 0;
+            unsigned int _phase_value_tc_ready_0_1 = 0;
+            unsigned int _phase_a_ready_0 = 0;
+            unsigned int _phase_prep_ready_0 = 0;
+            unsigned int _phase_qki_tc_ready_0 = 0;
+            if (warp_id_in_role_2 == 0) {
+                if (local_chunk_2 != 0) {
+                    if (state_checkpoint_needed[chunk_head_2] == 0) {
+                        mbarrier_wait(recon_inputs_ready_addr, _phase_recon_inputs_ready_0);
+                        _phase_recon_inputs_ready_0 ^= 1;
+                        int _mma_b_lo_0 = make_warp_uniform(((s_prev_r_tc_addr) >> 4) & 0x3FFF);
+                        asm volatile(
+                    "{\n\t"
+                    ".reg .pred leader, p0, p1;\n\t"
+                    ".reg .b32 dhi, blo, id;\n\t"
+                    ".reg .b64 db;\n\t"
+                    "elect.sync _|leader, 0xFFFFFFFF;\n\t"
+                    "setp.ne.b32 p0, %3, 0;\n\t"
+                    "setp.ne.b32 p1, 1, 0;\n\t"
+                    ""
+                    "mov.b32 dhi, 0xC0004010;\n\t"
+                    "mov.b32 id, 136316048;\n\t"
+                    "mov.b32 blo, %1;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [%2], db, id, p0;\n\t"
+                    "add.u32 blo, blo, 256;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [%2 + 8], db, id, p1;\n\t"
+                    "}\n"
+                    :: "r"(tmem_tmem_recon_state), "r"(_mma_b_lo_0), "r"(tmem_tmem_recon_kr), "r"(0));
+                        elect_commit(recon_output_ready_addr);
+                    }
+                }
+                mbarrier_wait(dv_ready_addr, _phase_dv_ready_0);
+                _phase_dv_ready_0 ^= 1;
+                mbarrier_wait(state_tc_ready_addr, _phase_state_tc_ready_0);
+                _phase_state_tc_ready_0 ^= 1;
+                int _mma_b_lo_1 = make_warp_uniform(((s_det_tc_addr) >> 4) & 0x3FFF);
+                asm volatile(
+                    "{\n\t"
+                    ".reg .pred leader, p0, p1;\n\t"
+                    ".reg .b32 dhi, blo, id;\n\t"
+                    ".reg .b64 db;\n\t"
+                    "elect.sync _|leader, 0xFFFFFFFF;\n\t"
+                    "setp.ne.b32 p0, %3, 0;\n\t"
+                    "setp.ne.b32 p1, 1, 0;\n\t"
+                    ""
+                    "mov.b32 dhi, 0x40004040;\n\t"
+                    "mov.b32 id, 134743184;\n\t"
+                    "mov.b32 blo, %1;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [%2], db, id, p0;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [%2 + 8], db, id, p1;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [%2 + 16], db, id, p1;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [%2 + 24], db, id, p1;\n\t"
+                    "add.u32 blo, blo, 250;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [%2 + 32], db, id, p1;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [%2 + 40], db, id, p1;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [%2 + 48], db, id, p1;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [%2 + 56], db, id, p1;\n\t"
+                    "}\n"
+                    :: "r"(tmem_tmem_dk_boundary), "r"(_mma_b_lo_1), "r"(tmem_tmem_a_state), "r"(0));
+                mbarrier_wait(value_tc_ready_addr, _phase_value_tc_ready_0_1);
+                _phase_value_tc_ready_0_1 ^= 1;
+                int _mma_b_lo_2 = make_warp_uniform(((s_dot_tc_addr) >> 4) & 0x3FFF);
+                asm volatile(
+                    "{\n\t"
+                    ".reg .pred leader, p0, p1;\n\t"
+                    ".reg .b32 dhi, blo, id;\n\t"
+                    ".reg .b64 db;\n\t"
+                    "elect.sync _|leader, 0xFFFFFFFF;\n\t"
+                    "setp.ne.b32 p0, %3, 0;\n\t"
+                    "setp.ne.b32 p1, 1, 0;\n\t"
+                    ""
+                    "mov.b32 dhi, 0x40004040;\n\t"
+                    "mov.b32 id, 134743184;\n\t"
+                    "mov.b32 blo, %1;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [%2], db, id, p0;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [%2 + 8], db, id, p1;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [%2 + 16], db, id, p1;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [%2 + 24], db, id, p1;\n\t"
+                    "add.u32 blo, blo, 250;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [%2 + 32], db, id, p1;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [%2 + 40], db, id, p1;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [%2 + 48], db, id, p1;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [%2 + 56], db, id, p1;\n\t"
+                    "}\n"
+                    :: "r"(tmem_tmem_dq_boundary), "r"(_mma_b_lo_2), "r"(tmem_tmem_a_state), "r"(0));
+                mbarrier_wait(a_ready_addr, _phase_a_ready_0);
+                _phase_a_ready_0 ^= 1;
+                int _mma_b_lo_3 = make_warp_uniform(((s_rt_tc_addr) >> 4) & 0x3FFF);
+                asm volatile(
+                    "{\n\t"
+                    ".reg .pred leader, p0, p1;\n\t"
+                    ".reg .b32 dhi, blo, id;\n\t"
+                    ".reg .b64 db;\n\t"
+                    "elect.sync _|leader, 0xFFFFFFFF;\n\t"
+                    "setp.ne.b32 p0, %3, 0;\n\t"
+                    "setp.ne.b32 p1, 1, 0;\n\t"
+                    ""
+                    "mov.b32 dhi, 0x40004040;\n\t"
+                    "mov.b32 id, 134743184;\n\t"
+                    "mov.b32 blo, %1;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [%2], db, id, p0;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [%2 + 8], db, id, p1;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [%2 + 16], db, id, p1;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [%2 + 24], db, id, p1;\n\t"
+                    "add.u32 blo, blo, 250;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [%2 + 32], db, id, p1;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [%2 + 40], db, id, p1;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [%2 + 48], db, id, p1;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [%2 + 56], db, id, p1;\n\t"
+                    "}\n"
+                    :: "r"(tmem_tmem_dkr), "r"(_mma_b_lo_3), "r"(tmem_tmem_a_dh), "r"(0));
+                elect_commit(first_outputs_ready_addr);
+                mbarrier_wait(prep_ready_addr, _phase_prep_ready_0);
+                _phase_prep_ready_0 ^= 1;
+                mbarrier_wait(qki_tc_ready_addr, _phase_qki_tc_ready_0);
+                _phase_qki_tc_ready_0 ^= 1;
+                int _mma_b_lo_4 = make_warp_uniform(((s_dm_tc_addr) >> 4) & 0x3FFF);
+                asm volatile(
+                    "{\n\t"
+                    ".reg .pred leader, p0, p1;\n\t"
+                    ".reg .b32 dhi, blo, id;\n\t"
+                    ".reg .b64 db;\n\t"
+                    "elect.sync _|leader, 0xFFFFFFFF;\n\t"
+                    "setp.ne.b32 p0, %3, 0;\n\t"
+                    "setp.ne.b32 p1, 1, 0;\n\t"
+                    ""
+                    "mov.b32 dhi, 0xC0004010;\n\t"
+                    "mov.b32 id, 134743184;\n\t"
+                    "mov.b32 blo, %1;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [%2], db, id, p0;\n\t"
+                    "add.u32 blo, blo, 64;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [%2 + 8], db, id, p1;\n\t"
+                    "}\n"
+                    :: "r"(tmem_tmem_di), "r"(_mma_b_lo_4), "r"(tmem_tmem_a_k), "r"(0));
+                int _mma_b_lo_5 = make_warp_uniform(((s_dnt_tc_addr) >> 4) & 0x3FFF);
+                asm volatile(
+                    "{\n\t"
+                    ".reg .pred leader, p0, p1;\n\t"
+                    ".reg .b32 dhi, blo, id;\n\t"
+                    ".reg .b64 db;\n\t"
+                    "elect.sync _|leader, 0xFFFFFFFF;\n\t"
+                    "setp.ne.b32 p0, %3, 0;\n\t"
+                    "setp.ne.b32 p1, 1, 0;\n\t"
+                    ""
+                    "mov.b32 dhi, 0xC0004010;\n\t"
+                    "mov.b32 id, 134743184;\n\t"
+                    "mov.b32 blo, %1;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [%2], db, id, p0;\n\t"
+                    "add.u32 blo, blo, 64;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [%2 + 8], db, id, p1;\n\t"
+                    "}\n"
+                    :: "r"(tmem_tmem_di), "r"(_mma_b_lo_5), "r"(tmem_tmem_a_q), "r"(1));
+                int _mma_b_lo_6 = make_warp_uniform(((s_dn_tc_addr) >> 4) & 0x3FFF);
+                asm volatile(
+                    "{\n\t"
+                    ".reg .pred leader, p0, p1;\n\t"
+                    ".reg .b32 dhi, blo, id;\n\t"
+                    ".reg .b64 db;\n\t"
+                    "elect.sync _|leader, 0xFFFFFFFF;\n\t"
+                    "setp.ne.b32 p0, %3, 0;\n\t"
+                    "setp.ne.b32 p1, 1, 0;\n\t"
+                    ""
+                    "mov.b32 dhi, 0xC0004010;\n\t"
+                    "mov.b32 id, 134743184;\n\t"
+                    "mov.b32 blo, %1;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [%2], db, id, p0;\n\t"
+                    "add.u32 blo, blo, 64;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [%2 + 8], db, id, p1;\n\t"
+                    "}\n"
+                    :: "r"(tmem_tmem_dq_local), "r"(_mma_b_lo_6), "r"(tmem_tmem_a_i), "r"(0));
+                int _mma_b_lo_7 = make_warp_uniform(((s_dmt_tc_addr) >> 4) & 0x3FFF);
+                asm volatile(
+                    "{\n\t"
+                    ".reg .pred leader, p0, p1;\n\t"
+                    ".reg .b32 dhi, blo, id;\n\t"
+                    ".reg .b64 db;\n\t"
+                    "elect.sync _|leader, 0xFFFFFFFF;\n\t"
+                    "setp.ne.b32 p0, %3, 0;\n\t"
+                    "setp.ne.b32 p1, 1, 0;\n\t"
+                    ""
+                    "mov.b32 dhi, 0xC0004010;\n\t"
+                    "mov.b32 id, 134743184;\n\t"
+                    "mov.b32 blo, %1;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [%2], db, id, p0;\n\t"
+                    "add.u32 blo, blo, 64;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [%2 + 8], db, id, p1;\n\t"
+                    "}\n"
+                    :: "r"(tmem_tmem_dk_local), "r"(_mma_b_lo_7), "r"(tmem_tmem_a_i), "r"(0));
+                elect_commit(outputs_ready_addr);
+            }
+            int key_row_1 = warp_id_in_role_2 * 32 + lane;
+            long long restore_base_2 = chunk_head_2 * 128;
+            float restore_1 = tape_restore_factor[restore_base_2 + (long long)key_row_1];
+            long long token_key_base_2 = chunk_head_2 * 32 * 128;
+            float kr_prefetch_1 = (float)tape_kr[token_key_base_2 + 3072 + (long long)key_row_1];
+            unsigned int _phase_first_outputs_ready_0_2 = 0;
+            mbarrier_wait(first_outputs_ready_addr, _phase_first_outputs_ready_0_2);
+            _phase_first_outputs_ready_0_2 ^= 1;
+            int sequence_2 = chunk_sequence[chunk_global_2];
+            long long bos_2 = cu_seqlens[sequence_2];
+            long long eos_2 = cu_seqlens[sequence_2 + 1];
+            long long chunk_start_2 = bos_2 + (long long)local_chunk_2 * 32;
+            long long chunk_end_1 = chunk_start_2 + 32;
+            if (chunk_end_1 > eos_2) {
+                chunk_end_1 = eos_2;
+            }
+            int chunk_length_1 = (int)(chunk_end_1 - chunk_start_2);
+            const int tmem_row_base_1 = warp_id_in_role_2 * 32 << 16;
+            long long out_base_1 = chunk_head_2 * 32 * 128;
+            float _exp2_2 = approx_exp2(lower_bound * 1.4426950408889634f * 16.0f);
+            float common_factor_1 = _exp2_2;
+            const int token_offset_1 = 24;
+            float _tmem_load_14[8];
+            tmem_ld_x8(&_tmem_load_14[0], taddr + 176 + (unsigned int)tmem_row_base_1 + (unsigned int)token_offset_1);
+            #pragma unroll
+            for (int token_local_early_1 = 0; token_local_early_1 < 8; token_local_early_1++) {
+                int token_out_early_1 = token_offset_1 + token_local_early_1;
+                float kr_value_early_1 = kr_prefetch_1;
+                if (token_local_early_1 != 0) {
+                    kr_value_early_1 = (float)tape_kr[token_key_base_2 + (long long)(token_out_early_1 * 128) + (long long)key_row_1];
+                }
+                int stable_index_early_1 = token_out_early_1 * 128 + key_row_1;
+                s_stable_dkr[stable_index_early_1] = _tmem_load_14[token_local_early_1] * kr_value_early_1;
+                _tmem_load_14[token_local_early_1] = _tmem_load_14[token_local_early_1] * restore_1;
+            }
+            unsigned int _phase_outputs_ready_0_2 = 0;
+            mbarrier_wait(outputs_ready_addr, _phase_outputs_ready_0_2);
+            _phase_outputs_ready_0_2 ^= 1;
+            float _tmem_load_15[8];
+            tmem_ld_x8(&_tmem_load_15[0], taddr + 208 + (unsigned int)tmem_row_base_1 + (unsigned int)token_offset_1);
+            asm volatile("tcgen05.wait::ld.sync.aligned;");
+            #pragma unroll
+            for (int token_local_1 = 0; token_local_1 < 8; token_local_1++) {
+                int token_out_1 = token_offset_1 + token_local_1;
+                long long out_index_3 = out_base_1 + (long long)(token_out_1 * 128) + (long long)key_row_1;
+                int shared_index_1 = token_out_1 * 128 + key_row_1;
+                __nv_bfloat16 i_value_bf16_1 = s_i[(shared_index_1 * 2 ^ (shared_index_1 * 2 >> 8 & 7) << 4) / 2];
+                float _cvt_f32_22 = __bfloat162float(i_value_bf16_1);
+                float i_value_1 = _cvt_f32_22;
+                grad_ki[out_index_3] = _tmem_load_15[token_local_1] + _tmem_load_14[token_local_1];
+                _tmem_load_15[token_local_1] = _tmem_load_15[token_local_1] * i_value_1;
+            }
+            float _tmem_load_16[8];
+            tmem_ld_x8(&_tmem_load_16[0], taddr + 240 + (unsigned int)tmem_row_base_1 + (unsigned int)token_offset_1);
+            float _tmem_load_17[8];
+            tmem_ld_x8(&_tmem_load_17[0], taddr + 272 + (unsigned int)tmem_row_base_1 + (unsigned int)token_offset_1);
+            asm volatile("tcgen05.wait::ld.sync.aligned;");
+            #pragma unroll
+            for (int token_local2_1 = 0; token_local2_1 < 8; token_local2_1++) {
+                int token_out2_1 = token_offset_1 + token_local2_1;
+                long long out_index_4 = out_base_1 + (long long)(token_out2_1 * 128) + (long long)key_row_1;
+                int shared_index2_1 = token_out2_1 * 128 + key_row_1;
+                __nv_bfloat16 q_value_bf16_1 = s_q[(shared_index2_1 * 2 ^ (shared_index2_1 * 2 >> 8 & 7) << 4) / 2];
+                float _cvt_f32_23 = __bfloat162float(q_value_bf16_1);
+                float q_value_1 = _cvt_f32_23;
+                _tmem_load_17[token_local2_1] = _tmem_load_17[token_local2_1] * common_factor_1;
+                float _fma_9 = __fmaf_rn(-_tmem_load_16[token_local2_1], q_value_1, _tmem_load_15[token_local2_1]);
+                _tmem_load_15[token_local2_1] = _fma_9;
+                _tmem_load_14[token_local2_1] = _tmem_load_17[token_local2_1] * q_value_1;
+                grad_qd[out_index_4] = _tmem_load_16[token_local2_1] + _tmem_load_17[token_local2_1];
+            }
+            unsigned int _phase_dbeta_done_0_2 = 0;
+            mbarrier_wait(dbeta_done_addr, _phase_dbeta_done_0_2);
+            _phase_dbeta_done_0_2 ^= 1;
+            float _tmem_load_18[8];
+            tmem_ld_x8(&_tmem_load_18[0], taddr + 304 + (unsigned int)tmem_row_base_1 + (unsigned int)token_offset_1);
+            float _tmem_load_19[8];
+            tmem_ld_x8(&_tmem_load_19[0], taddr + 336 + (unsigned int)tmem_row_base_1 + (unsigned int)token_offset_1);
+            asm volatile("tcgen05.wait::ld.sync.aligned;");
+            float high_base_suffix = 0.0f;
+            #pragma unroll
+            for (int token_local3_1 = 0; token_local3_1 < 8; token_local3_1++) {
+                int token_out3_1 = token_offset_1 + token_local3_1;
+                long long out_index_5 = out_base_1 + (long long)(token_out3_1 * 128) + (long long)key_row_1;
+                int shared_index3_1 = token_out3_1 * 128 + key_row_1;
+                __nv_bfloat16 k_value_bf16_1 = s_k[(shared_index3_1 * 2 ^ (shared_index3_1 * 2 >> 8 & 7) << 4) / 2];
+                float _cvt_f32_24 = __bfloat162float(k_value_bf16_1);
+                float k_value_1 = _cvt_f32_24;
+                _tmem_load_19[token_local3_1] = _tmem_load_19[token_local3_1] * (-common_factor_1);
+                float _fma_10 = __fmaf_rn(-_tmem_load_18[token_local3_1], k_value_1, _tmem_load_15[token_local3_1]);
+                _tmem_load_15[token_local3_1] = _fma_10;
+                float base_value_1 = _tmem_load_14[token_local3_1] + _tmem_load_19[token_local3_1] * k_value_1;
+                int stable_index3_1 = token_out3_1 * 128 + key_row_1;
+                s_stable_delta[stable_index3_1] = _tmem_load_15[token_local3_1];
+                s_stable_base[stable_index3_1] = base_value_1;
+                if (token_out3_1 < chunk_length_1) {
+                    high_base_suffix += base_value_1;
+                }
+                grad_kd[out_index_5] = _tmem_load_18[token_local3_1] + _tmem_load_19[token_local3_1];
+            }
+            s_high_base_suffix[key_row_1] = high_base_suffix;
+            asm volatile("barrier.sync 10, 384;" ::: "memory");
+            unsigned int _phase_epilogue_done_0 = 0;
+            mbarrier_wait(epilogue_done_addr, _phase_epilogue_done_0);
+            _phase_epilogue_done_0 ^= 1;
+            if (warp_id_in_role_2 == 0) {
+                int _tmem_dealloc_addr = *((volatile int*)tmem_addr_storage);
+                asm volatile("tcgen05.dealloc.cta_group::1.sync.aligned.b32 %0, %1;" :: "r"(_tmem_dealloc_addr), "r"(512));
+            }
+        }
+    }
+
+    // Cleanup
+}
+
+} // extern "C"
+
+#undef FLASHKDA_INF
+#undef NUM_MAIN_STAGES
+#undef SMEM_S_DBETA_PARTIAL_OFF
+#undef SMEM_S_DBETA_PARTIAL_STAGE_BYTES
+#undef SMEM_S_DBETA_PARTIAL_STRIDE
+#undef SMEM_S_DET_OFF
+#undef SMEM_S_DET_STAGE_BYTES
+#undef SMEM_S_DET_STRIDE
+#undef SMEM_S_DET_TC_OFF
+#undef SMEM_S_DET_TC_STAGE_BYTES
+#undef SMEM_S_DET_TC_STRIDE
+#undef SMEM_S_DF_OFF
+#undef SMEM_S_DF_STAGE_BYTES
+#undef SMEM_S_DF_STRIDE
+#undef SMEM_S_DH_STAGE_OFF
+#undef SMEM_S_DH_STAGE_STAGE_BYTES
+#undef SMEM_S_DH_STAGE_STRIDE
+#undef SMEM_S_DJ_OFF
+#undef SMEM_S_DJ_STAGE_BYTES
+#undef SMEM_S_DJ_STRIDE
+#undef SMEM_S_DMT_TC_OFF
+#undef SMEM_S_DMT_TC_STAGE_BYTES
+#undef SMEM_S_DMT_TC_STRIDE
+#undef SMEM_S_DM_TC_OFF
+#undef SMEM_S_DM_TC_STAGE_BYTES
+#undef SMEM_S_DM_TC_STRIDE
+#undef SMEM_S_DNT_TC_OFF
+#undef SMEM_S_DNT_TC_STAGE_BYTES
+#undef SMEM_S_DNT_TC_STRIDE
+#undef SMEM_S_DN_TC_OFF
+#undef SMEM_S_DN_TC_STAGE_BYTES
+#undef SMEM_S_DN_TC_STRIDE
+#undef SMEM_S_DOT_OFF
+#undef SMEM_S_DOT_STAGE_BYTES
+#undef SMEM_S_DOT_STRIDE
+#undef SMEM_S_DOT_TC_OFF
+#undef SMEM_S_DOT_TC_STAGE_BYTES
+#undef SMEM_S_DOT_TC_STRIDE
+#undef SMEM_S_DO_STAGE_OFF
+#undef SMEM_S_DO_STAGE_STAGE_BYTES
+#undef SMEM_S_DO_STAGE_STRIDE
+#undef SMEM_S_DRT_OFF
+#undef SMEM_S_DRT_STAGE_BYTES
+#undef SMEM_S_DRT_STRIDE
+#undef SMEM_S_HIGH_BASE_SUFFIX_OFF
+#undef SMEM_S_HIGH_BASE_SUFFIX_STAGE_BYTES
+#undef SMEM_S_HIGH_BASE_SUFFIX_STRIDE
+#undef SMEM_S_I_OFF
+#undef SMEM_S_I_STAGE_BYTES
+#undef SMEM_S_I_STRIDE
+#undef SMEM_S_J_OFF
+#undef SMEM_S_J_STAGE_BYTES
+#undef SMEM_S_J_STRIDE
+#undef SMEM_S_K_OFF
+#undef SMEM_S_K_STAGE_BYTES
+#undef SMEM_S_K_STRIDE
+#undef SMEM_S_MIDDLE_BASE_SUFFIX_OFF
+#undef SMEM_S_MIDDLE_BASE_SUFFIX_STAGE_BYTES
+#undef SMEM_S_MIDDLE_BASE_SUFFIX_STRIDE
+#undef SMEM_S_M_OFF
+#undef SMEM_S_M_STAGE_BYTES
+#undef SMEM_S_M_STRIDE
+#undef SMEM_S_PREV_R_TC_OFF
+#undef SMEM_S_PREV_R_TC_STAGE_BYTES
+#undef SMEM_S_PREV_R_TC_STRIDE
+#undef SMEM_S_Q_OFF
+#undef SMEM_S_Q_STAGE_BYTES
+#undef SMEM_S_Q_STRIDE
+#undef SMEM_S_RT_OFF
+#undef SMEM_S_RT_STAGE_BYTES
+#undef SMEM_S_RT_STRIDE
+#undef SMEM_S_RT_TC_OFF
+#undef SMEM_S_RT_TC_STAGE_BYTES
+#undef SMEM_S_RT_TC_STRIDE
+#undef SMEM_S_STABLE_BASE_OFF
+#undef SMEM_S_STABLE_BASE_STAGE_BYTES
+#undef SMEM_S_STABLE_BASE_STRIDE
+#undef SMEM_S_STABLE_DELTA_OFF
+#undef SMEM_S_STABLE_DELTA_STAGE_BYTES
+#undef SMEM_S_STABLE_DELTA_STRIDE
+#undef SMEM_S_STABLE_DKR_OFF
+#undef SMEM_S_STABLE_DKR_STAGE_BYTES
+#undef SMEM_S_STABLE_DKR_STRIDE
+#undef SMEM_S_TMP_OFF
+#undef SMEM_S_TMP_STAGE_BYTES
+#undef SMEM_S_TMP_STRIDE
+#undef SMEM_S_X_OFF
+#undef SMEM_S_X_STAGE_BYTES
+#undef SMEM_S_X_STRIDE
+#undef SMEM_TOTAL
+#undef THREADS
+#undef TMEM_NCOLS
+#undef TMEM_TMEM_A_DH_OFFSET
+#undef TMEM_TMEM_A_I_OFFSET
+#undef TMEM_TMEM_A_K_OFFSET
+#undef TMEM_TMEM_A_Q_OFFSET
+#undef TMEM_TMEM_A_STATE_OFFSET
+#undef TMEM_TMEM_DI_OFFSET
+#undef TMEM_TMEM_DKR_OFFSET
+#undef TMEM_TMEM_DK_BOUNDARY_OFFSET
+#undef TMEM_TMEM_DK_LOCAL_OFFSET
+#undef TMEM_TMEM_DQ_BOUNDARY_OFFSET
+#undef TMEM_TMEM_DQ_LOCAL_OFFSET
+#undef TMEM_TMEM_RECON_KR_OFFSET
+#undef TMEM_TMEM_RECON_STATE_OFFSET
+#undef a_ready_addr
+#undef boundary_local_ready_addr
+#undef dbeta_done_addr
+#undef dh_ready_addr
+#undef dv_ready_addr
+#undef epilogue_done_addr
+#undef first_outputs_ready_addr
+#undef outputs_ready_addr
+#undef prep_ready_addr
+#undef qki_ready_addr
+#undef qki_tc_ready_addr
+#undef recon_inputs_ready_addr
+#undef recon_output_ready_addr
+#undef s_dbeta_partial_addr
+#undef s_det_addr
+#undef s_det_tc_addr
+#undef s_df_addr
+#undef s_dh_stage_addr
+#undef s_dj_addr
+#undef s_dm_tc_addr
+#undef s_dmt_tc_addr
+#undef s_dn_tc_addr
+#undef s_dnt_tc_addr
+#undef s_do_stage_addr
+#undef s_dot_addr
+#undef s_dot_tc_addr
+#undef s_drt_addr
+#undef s_high_base_suffix_addr
+#undef s_i_addr
+#undef s_j_addr
+#undef s_k_addr
+#undef s_m_addr
+#undef s_middle_base_suffix_addr
+#undef s_prev_r_tc_addr
+#undef s_q_addr
+#undef s_rt_addr
+#undef s_rt_tc_addr
+#undef s_stable_base_addr
+#undef s_stable_delta_addr
+#undef s_stable_dkr_addr
+#undef s_tmp_addr
+#undef s_x_addr
+#undef state_tc_ready_addr
+#undef value_tc_ready_addr
+
+#define FLASHKDA_INF CUDART_INF_F
+#define NUM_MAIN_STAGES 1
+#define THREADS 128
+
+extern "C" {
+
+__global__ __launch_bounds__(128) void
+kernel_flashkda_backward_map_finalize_c32(__nv_bfloat16* __restrict__ decay, __nv_bfloat16* __restrict__ q, __nv_bfloat16* __restrict__ k, float* __restrict__ norm_inv, __nv_bfloat16* __restrict__ g, float* __restrict__ beta_active, float* __restrict__ A_log, float* __restrict__ dt_bias, long long* __restrict__ cu_seqlens, int* __restrict__ chunk_sequence, int* __restrict__ chunk_index, int* __restrict__ chunk_pair_start, __nv_bfloat16* __restrict__ grad_qd, __nv_bfloat16* __restrict__ grad_kd, __nv_bfloat16* __restrict__ grad_ki, float* __restrict__ dlog_decay, float* __restrict__ dbeta_active, __nv_bfloat16* __restrict__ dq, __nv_bfloat16* __restrict__ dk, __nv_bfloat16* __restrict__ dg, __nv_bfloat16* __restrict__ dbeta, float* __restrict__ dA_log, float* __restrict__ ddt_bias, int num_pair_heads, int num_heads, float scale, float lower_bound)
+{
+    const int tid = threadIdx.x;
+    const int warp = make_warp_uniform(tid / 32);
+    const int lane = tid % 32;
+
+
+    const int bid = blockIdx.x;
+    const int num_bids = gridDim.x;
+
+    // === Task calls (dependency order) ===
+    int block_type = blockIdx.x & 3;
+    int task_group = blockIdx.x / 4;
+    int warp_id_in_role = (warp - 0);
+    int pair_task = task_group * 4 + warp_id_in_role;
+    int gate_task = task_group * 8 + (block_type - 2) * 4 + warp_id_in_role;
+    int gate_pair_task = gate_task / 2;
+    int gate_pair_chunk = gate_task - gate_pair_task * 2;
+    if (block_type == 0 && pair_task < num_pair_heads) {
+        int pair = pair_task / num_heads;
+        int head = pair_task - pair * num_heads;
+        int first_chunk = chunk_pair_start[pair];
+        int sequence = chunk_sequence[first_chunk];
+        int first_local_chunk = chunk_index[first_chunk];
+        long long bos = cu_seqlens[sequence];
+        long long eos = cu_seqlens[sequence + 1];
+        int subwarp = lane / 16;
+        int sub_lane = lane - subwarp * 16;
+        int elem = sub_lane * 8;
+        #pragma unroll
+        for (int pair_chunk = 0; pair_chunk < 2; pair_chunk++) {
+            int chunk_global = first_chunk + pair_chunk;
+            int local_chunk = first_local_chunk + pair_chunk;
+            long long chunk_start = bos + (long long)local_chunk * 32;
+            if (chunk_start < eos) {
+                long long chunk_end = chunk_start + 32;
+                if (chunk_end > eos) {
+                    chunk_end = eos;
+                }
+                int chunk_length = (int)(chunk_end - chunk_start);
+                long long chunk_head = (long long)chunk_global * (long long)num_heads + (long long)head;
+                long long tape_base = chunk_head * 32 * 128;
+                #pragma unroll 2
+                for (int token_pair = 0; token_pair < chunk_length; token_pair += 2) {
+                    int token_col = token_pair + subwarp;
+                    long long token = chunk_start + (long long)token_col;
+                    long long token_base = (token * (long long)num_heads + (long long)head) * 128;
+                    long long index = token_base + (long long)elem;
+                    long long tape_index = tape_base + (long long)(token_col * 128) + (long long)elem;
+                    float decay_values[8];
+                    float grad_values[8];
+                    float q_values[8];
+                    float q_inv_lane = 0.0f;
+                    if (token_col < chunk_length) {
+                        {
+                            const uint4* _vptr_0 = reinterpret_cast<const uint4*>(decay + index);
+                            uint4 _vld_0[1];
+                            #pragma unroll
+                            for (int _blk = 0; _blk < 1; _blk++) {
+                                _vld_0[_blk] = _vptr_0[_blk];
+                                uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
+                                #pragma unroll
+                                for (int _pair = 0; _pair < 4; _pair++) {
+                                    asm volatile(
+                                        "{\n\t"
+                                        "shl.b32 %0, %2, 16;\n\t"
+                                        "and.b32 %1, %2, 0xffff0000;\n\t"
+                                        "}\n"
+                                        : "=f"((&decay_values[0 + _blk * 8 + _pair * 2])[0]), "=f"((&decay_values[0 + _blk * 8 + _pair * 2])[1])
+                                        : "r"(_vpairs_0[_pair]));
+                                }
+                            }
+                        }
+                        {
+                            const uint4* _vptr_1 = reinterpret_cast<const uint4*>(grad_qd + tape_index);
+                            uint4 _vld_1[1];
+                            #pragma unroll
+                            for (int _blk = 0; _blk < 1; _blk++) {
+                                _vld_1[_blk] = _vptr_1[_blk];
+                                uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
+                                #pragma unroll
+                                for (int _pair = 0; _pair < 4; _pair++) {
+                                    asm volatile(
+                                        "{\n\t"
+                                        "shl.b32 %0, %2, 16;\n\t"
+                                        "and.b32 %1, %2, 0xffff0000;\n\t"
+                                        "}\n"
+                                        : "=f"((&grad_values[0 + _blk * 8 + _pair * 2])[0]), "=f"((&grad_values[0 + _blk * 8 + _pair * 2])[1])
+                                        : "r"(_vpairs_1[_pair]));
+                                }
+                            }
+                        }
+                        {
+                            const uint4* _vptr_2 = reinterpret_cast<const uint4*>(q + index);
+                            uint4 _vld_2[1];
+                            #pragma unroll
+                            for (int _blk = 0; _blk < 1; _blk++) {
+                                _vld_2[_blk] = _vptr_2[_blk];
+                                uint32_t* _vpairs_2 = reinterpret_cast<uint32_t*>(&_vld_2[_blk]);
+                                #pragma unroll
+                                for (int _pair = 0; _pair < 4; _pair++) {
+                                    asm volatile(
+                                        "{\n\t"
+                                        "shl.b32 %0, %2, 16;\n\t"
+                                        "and.b32 %1, %2, 0xffff0000;\n\t"
+                                        "}\n"
+                                        : "=f"((&q_values[0 + _blk * 8 + _pair * 2])[0]), "=f"((&q_values[0 + _blk * 8 + _pair * 2])[1])
+                                        : "r"(_vpairs_2[_pair]));
+                                }
+                            }
+                        }
+                        if (sub_lane == 0) {
+                            long long norm_base = (token * (long long)num_heads + (long long)head) * 2;
+                            q_inv_lane = norm_inv[norm_base];
+                        }
+                    }
+                    float _shfl_0 = __shfl_sync(0xFFFFFFFF, q_inv_lane, subwarp * 16);
+                    float q_inv = _shfl_0;
+                    float q_dot = 0.0f;
+                    if (token_col < chunk_length) {
+                        #pragma unroll
+                        for (int map_i = 0; map_i < 8; map_i++) {
+                            grad_values[map_i] = grad_values[map_i] * (decay_values[map_i] * scale);
+                            __nv_bfloat16 _cvt_bf16_0 = __float2bfloat16(q_values[map_i] * q_inv);
+                            q_values[map_i] = _cvt_bf16_0;
+                            float _fma_0 = __fmaf_rn(grad_values[map_i], q_values[map_i], q_dot);
+                            q_dot = _fma_0;
+                        }
+                    }
+                    float _shfl_xor_0 = __shfl_xor_sync(0xFFFFFFFF, q_dot, 8);
+                    q_dot += _shfl_xor_0;
+                    float _shfl_xor_1 = __shfl_xor_sync(0xFFFFFFFF, q_dot, 4);
+                    q_dot += _shfl_xor_1;
+                    float _shfl_xor_2 = __shfl_xor_sync(0xFFFFFFFF, q_dot, 2);
+                    q_dot += _shfl_xor_2;
+                    float _shfl_xor_3 = __shfl_xor_sync(0xFFFFFFFF, q_dot, 1);
+                    q_dot += _shfl_xor_3;
+                    if (token_col < chunk_length) {
+                        #pragma unroll
+                        for (int pullback_i = 0; pullback_i < 8; pullback_i++) {
+                            grad_values[pullback_i] = q_inv * (grad_values[pullback_i] - q_values[pullback_i] * q_dot);
+                        }
+                        {
+                            __nv_bfloat162 _pk[4];
+                            _pk[0] = __floats2bfloat162_rn(grad_values[0 + 0], grad_values[0 + 1]);
+                            _pk[1] = __floats2bfloat162_rn(grad_values[0 + 2], grad_values[0 + 3]);
+                            _pk[2] = __floats2bfloat162_rn(grad_values[0 + 4], grad_values[0 + 5]);
+                            _pk[3] = __floats2bfloat162_rn(grad_values[0 + 6], grad_values[0 + 7]);
+                            *reinterpret_cast<uint4*>(&((__nv_bfloat16*)(dq))[index + 0]) = *reinterpret_cast<uint4*>(&_pk[0]);
+                        }
+                    }
+                }
+            }
+        }
+    }
+    if (block_type == 1 && pair_task < num_pair_heads) {
+        int pair_1 = pair_task / num_heads;
+        int head_1 = pair_task - pair_1 * num_heads;
+        int first_chunk_1 = chunk_pair_start[pair_1];
+        int sequence_1 = chunk_sequence[first_chunk_1];
+        int first_local_chunk_1 = chunk_index[first_chunk_1];
+        long long bos_1 = cu_seqlens[sequence_1];
+        long long eos_1 = cu_seqlens[sequence_1 + 1];
+        int subwarp_1 = lane / 16;
+        int sub_lane_1 = lane - subwarp_1 * 16;
+        int elem_1 = sub_lane_1 * 8;
+        #pragma unroll
+        for (int pair_chunk_1 = 0; pair_chunk_1 < 2; pair_chunk_1++) {
+            int chunk_global_1 = first_chunk_1 + pair_chunk_1;
+            int local_chunk_1 = first_local_chunk_1 + pair_chunk_1;
+            long long chunk_start_1 = bos_1 + (long long)local_chunk_1 * 32;
+            if (chunk_start_1 < eos_1) {
+                long long chunk_end_1 = chunk_start_1 + 32;
+                if (chunk_end_1 > eos_1) {
+                    chunk_end_1 = eos_1;
+                }
+                int chunk_length_1 = (int)(chunk_end_1 - chunk_start_1);
+                long long chunk_head_1 = (long long)chunk_global_1 * (long long)num_heads + (long long)head_1;
+                long long tape_base_1 = chunk_head_1 * 32 * 128;
+                #pragma unroll 2
+                for (int token_pair_1 = 0; token_pair_1 < chunk_length_1; token_pair_1 += 2) {
+                    int token_col_1 = token_pair_1 + subwarp_1;
+                    long long token_1 = chunk_start_1 + (long long)token_col_1;
+                    long long token_base_1 = (token_1 * (long long)num_heads + (long long)head_1) * 128;
+                    long long index_1 = token_base_1 + (long long)elem_1;
+                    long long tape_index_1 = tape_base_1 + (long long)(token_col_1 * 128) + (long long)elem_1;
+                    float decay_values_1[8];
+                    float grad_k_values[8];
+                    float grad_i_values[8];
+                    float k_values[8];
+                    float k_inv_lane = 0.0f;
+                    if (token_col_1 < chunk_length_1) {
+                        {
+                            const uint4* _vptr_3 = reinterpret_cast<const uint4*>(decay + index_1);
+                            uint4 _vld_3[1];
+                            #pragma unroll
+                            for (int _blk = 0; _blk < 1; _blk++) {
+                                _vld_3[_blk] = _vptr_3[_blk];
+                                uint32_t* _vpairs_3 = reinterpret_cast<uint32_t*>(&_vld_3[_blk]);
+                                #pragma unroll
+                                for (int _pair = 0; _pair < 4; _pair++) {
+                                    asm volatile(
+                                        "{\n\t"
+                                        "shl.b32 %0, %2, 16;\n\t"
+                                        "and.b32 %1, %2, 0xffff0000;\n\t"
+                                        "}\n"
+                                        : "=f"((&decay_values_1[0 + _blk * 8 + _pair * 2])[0]), "=f"((&decay_values_1[0 + _blk * 8 + _pair * 2])[1])
+                                        : "r"(_vpairs_3[_pair]));
+                                }
+                            }
+                        }
+                        {
+                            const uint4* _vptr_4 = reinterpret_cast<const uint4*>(grad_kd + tape_index_1);
+                            uint4 _vld_4[1];
+                            #pragma unroll
+                            for (int _blk = 0; _blk < 1; _blk++) {
+                                _vld_4[_blk] = _vptr_4[_blk];
+                                uint32_t* _vpairs_4 = reinterpret_cast<uint32_t*>(&_vld_4[_blk]);
+                                #pragma unroll
+                                for (int _pair = 0; _pair < 4; _pair++) {
+                                    asm volatile(
+                                        "{\n\t"
+                                        "shl.b32 %0, %2, 16;\n\t"
+                                        "and.b32 %1, %2, 0xffff0000;\n\t"
+                                        "}\n"
+                                        : "=f"((&grad_k_values[0 + _blk * 8 + _pair * 2])[0]), "=f"((&grad_k_values[0 + _blk * 8 + _pair * 2])[1])
+                                        : "r"(_vpairs_4[_pair]));
+                                }
+                            }
+                        }
+                        {
+                            const uint4* _vptr_5 = reinterpret_cast<const uint4*>(grad_ki + tape_index_1);
+                            uint4 _vld_5[1];
+                            #pragma unroll
+                            for (int _blk = 0; _blk < 1; _blk++) {
+                                _vld_5[_blk] = _vptr_5[_blk];
+                                uint32_t* _vpairs_5 = reinterpret_cast<uint32_t*>(&_vld_5[_blk]);
+                                #pragma unroll
+                                for (int _pair = 0; _pair < 4; _pair++) {
+                                    asm volatile(
+                                        "{\n\t"
+                                        "shl.b32 %0, %2, 16;\n\t"
+                                        "and.b32 %1, %2, 0xffff0000;\n\t"
+                                        "}\n"
+                                        : "=f"((&grad_i_values[0 + _blk * 8 + _pair * 2])[0]), "=f"((&grad_i_values[0 + _blk * 8 + _pair * 2])[1])
+                                        : "r"(_vpairs_5[_pair]));
+                                }
+                            }
+                        }
+                        {
+                            const uint4* _vptr_6 = reinterpret_cast<const uint4*>(k + index_1);
+                            uint4 _vld_6[1];
+                            #pragma unroll
+                            for (int _blk = 0; _blk < 1; _blk++) {
+                                _vld_6[_blk] = _vptr_6[_blk];
+                                uint32_t* _vpairs_6 = reinterpret_cast<uint32_t*>(&_vld_6[_blk]);
+                                #pragma unroll
+                                for (int _pair = 0; _pair < 4; _pair++) {
+                                    asm volatile(
+                                        "{\n\t"
+                                        "shl.b32 %0, %2, 16;\n\t"
+                                        "and.b32 %1, %2, 0xffff0000;\n\t"
+                                        "}\n"
+                                        : "=f"((&k_values[0 + _blk * 8 + _pair * 2])[0]), "=f"((&k_values[0 + _blk * 8 + _pair * 2])[1])
+                                        : "r"(_vpairs_6[_pair]));
+                                }
+                            }
+                        }
+                        if (sub_lane_1 == 0) {
+                            long long norm_base_1 = (token_1 * (long long)num_heads + (long long)head_1) * 2;
+                            k_inv_lane = norm_inv[norm_base_1 + 1];
+                        }
+                    }
+                    float _shfl_1 = __shfl_sync(0xFFFFFFFF, k_inv_lane, subwarp_1 * 16);
+                    float k_inv = _shfl_1;
+                    float k_dot = 0.0f;
+                    if (token_col_1 < chunk_length_1) {
+                        #pragma unroll
+                        for (int map_i_1 = 0; map_i_1 < 8; map_i_1++) {
+                            float _rcp_0 = approx_rcp(decay_values_1[map_i_1]);
+                            grad_k_values[map_i_1] = grad_i_values[map_i_1] * _rcp_0 + grad_k_values[map_i_1] * decay_values_1[map_i_1];
+                            __nv_bfloat16 _cvt_bf16_1 = __float2bfloat16(k_values[map_i_1] * k_inv);
+                            k_values[map_i_1] = _cvt_bf16_1;
+                            float _fma_1 = __fmaf_rn(grad_k_values[map_i_1], k_values[map_i_1], k_dot);
+                            k_dot = _fma_1;
+                        }
+                    }
+                    float _shfl_xor_4 = __shfl_xor_sync(0xFFFFFFFF, k_dot, 8);
+                    k_dot += _shfl_xor_4;
+                    float _shfl_xor_5 = __shfl_xor_sync(0xFFFFFFFF, k_dot, 4);
+                    k_dot += _shfl_xor_5;
+                    float _shfl_xor_6 = __shfl_xor_sync(0xFFFFFFFF, k_dot, 2);
+                    k_dot += _shfl_xor_6;
+                    float _shfl_xor_7 = __shfl_xor_sync(0xFFFFFFFF, k_dot, 1);
+                    k_dot += _shfl_xor_7;
+                    if (token_col_1 < chunk_length_1) {
+                        #pragma unroll
+                        for (int pullback_i_1 = 0; pullback_i_1 < 8; pullback_i_1++) {
+                            grad_k_values[pullback_i_1] = k_inv * (grad_k_values[pullback_i_1] - k_values[pullback_i_1] * k_dot);
+                        }
+                        {
+                            __nv_bfloat162 _pk[4];
+                            _pk[0] = __floats2bfloat162_rn(grad_k_values[0 + 0], grad_k_values[0 + 1]);
+                            _pk[1] = __floats2bfloat162_rn(grad_k_values[0 + 2], grad_k_values[0 + 3]);
+                            _pk[2] = __floats2bfloat162_rn(grad_k_values[0 + 4], grad_k_values[0 + 5]);
+                            _pk[3] = __floats2bfloat162_rn(grad_k_values[0 + 6], grad_k_values[0 + 7]);
+                            *reinterpret_cast<uint4*>(&((__nv_bfloat16*)(dk))[index_1 + 0]) = *reinterpret_cast<uint4*>(&_pk[0]);
+                        }
+                    }
+                }
+            }
+        }
+    }
+    if (block_type >= 2 && gate_pair_task < num_pair_heads) {
+        int pair_2 = gate_pair_task / num_heads;
+        int head_2 = gate_pair_task - pair_2 * num_heads;
+        int first_chunk_2 = chunk_pair_start[pair_2];
+        int sequence_2 = chunk_sequence[first_chunk_2];
+        int first_local_chunk_2 = chunk_index[first_chunk_2];
+        long long bos_2 = cu_seqlens[sequence_2];
+        long long eos_2 = cu_seqlens[sequence_2 + 1];
+        int elem_2 = lane * 4;
+        int pair_chunk_2 = gate_pair_chunk;
+        int local_chunk_2 = first_local_chunk_2 + pair_chunk_2;
+        long long chunk_start_2 = bos_2 + (long long)local_chunk_2 * 32;
+        long long chunk_end_2 = chunk_start_2 + 32;
+        if (chunk_end_2 > eos_2) {
+            chunk_end_2 = eos_2;
+        }
+        float gate_a_lane = 0.0f;
+        if (lane == 0) {
+            float _expf_0 = __expf(A_log[head_2]);
+            gate_a_lane = _expf_0;
+        }
+        float _shfl_2 = __shfl_sync(0xFFFFFFFF, gate_a_lane, 0);
+        float gate_a = _shfl_2;
+        float gate_scale = lower_bound * gate_a;
+        float bias[4];
+        float ddt_sum[4];
+        float dA_sum[4];
+        #pragma unroll
+        for (int init_i = 0; init_i < 4; init_i++) {
+            bias[init_i] = dt_bias[head_2 * 128 + elem_2 + init_i];
+            ddt_sum[init_i] = 0.0f;
+            dA_sum[init_i] = 0.0f;
+        }
+        if (chunk_start_2 < eos_2) {
+            int chunk_length_2 = (int)(chunk_end_2 - chunk_start_2);
+            #pragma unroll 2
+            for (int token_col_2 = 0; token_col_2 < chunk_length_2; token_col_2++) {
+                long long token_2 = chunk_start_2 + (long long)token_col_2;
+                long long token_base_2 = (token_2 * (long long)num_heads + (long long)head_2) * 128;
+                long long index_2 = token_base_2 + (long long)elem_2;
+                float g_values[4];
+                float dlog_values[4];
+                float output_values[4];
+                {
+                    uint2 _vld_7;
+                    _vld_7 = *reinterpret_cast<const uint2*>(g + index_2);
+                    uint32_t* _vpairs_7 = reinterpret_cast<uint32_t*>(&_vld_7);
+                    #pragma unroll
+                    for (int _pair = 0; _pair < 2; _pair++) {
+                        asm volatile(
+                            "{\n\t"
+                            "shl.b32 %0, %2, 16;\n\t"
+                            "and.b32 %1, %2, 0xffff0000;\n\t"
+                            "}\n"
+                            : "=f"((&g_values[0 + _pair * 2])[0]), "=f"((&g_values[0 + _pair * 2])[1])
+                            : "r"(_vpairs_7[_pair]));
+                    }
+                }
+                {
+                    float4 _v4 = *reinterpret_cast<const float4*>(dlog_decay + index_2);
+                    dlog_values[0 + 0] = _v4.x;
+                    dlog_values[0 + 1] = _v4.y;
+                    dlog_values[0 + 2] = _v4.z;
+                    dlog_values[0 + 3] = _v4.w;
+                }
+                #pragma unroll
+                for (int gate_i = 0; gate_i < 4; gate_i++) {
+                    float biased = g_values[gate_i] + bias[gate_i];
+                    float _expf_1 = __expf((-gate_a) * biased);
+                    float sigmoid = 1.0f / (1.0f + _expf_1);
+                    float common = dlog_values[gate_i] * gate_scale * sigmoid * (1.0f - sigmoid);
+                    output_values[gate_i] = common;
+                    ddt_sum[gate_i] = ddt_sum[gate_i] + common;
+                    float _fma_2 = __fmaf_rn(common, biased, dA_sum[gate_i]);
+                    dA_sum[gate_i] = _fma_2;
+                }
+                {
+                    uint2 _pk2;
+                    __nv_bfloat162* _pk = reinterpret_cast<__nv_bfloat162*>(&_pk2);
+                    _pk[0] = __floats2bfloat162_rn(output_values[0 + 0], output_values[0 + 1]);
+                    _pk[1] = __floats2bfloat162_rn(output_values[0 + 2], output_values[0 + 3]);
+                    *reinterpret_cast<uint2*>(&((__nv_bfloat16*)(dg))[index_2]) = _pk2;
+                }
+                if (lane == 0) {
+                    long long beta_index = token_2 * (long long)num_heads + (long long)head_2;
+                    float beta_sigmoid = beta_active[beta_index];
+                    __nv_bfloat16 _cvt_bf16_2 = __float2bfloat16(dbeta_active[beta_index] * beta_sigmoid * (1.0f - beta_sigmoid));
+                    dbeta[beta_index] = _cvt_bf16_2;
+                }
+            }
+            #pragma unroll
+            for (int publish_i = 0; publish_i < 4; publish_i++) {
+                atomicAdd(&ddt_bias[head_2 * 128 + elem_2 + publish_i], ddt_sum[publish_i]);
+            }
+            float head_dA = 0.0f;
+            #pragma unroll
+            for (int reduce_i = 0; reduce_i < 4; reduce_i++) {
+                head_dA += dA_sum[reduce_i];
+            }
+            float _warp_reduce_0 = head_dA;
+            #pragma unroll
+            for (int offset = 16; offset > 0; offset >>= 1)
+                _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
+            head_dA = _warp_reduce_0;
+            if (lane == 0) {
+                atomicAdd(&dA_log[head_2], head_dA);
+            }
+        }
+    }
+}
+
+} // extern "C"
+
+#undef FLASHKDA_INF
+#undef NUM_MAIN_STAGES
+#undef THREADS
+
+// END FROZEN GENERATED BODY
+// clang-format on

--- a/csrc/kda/flashkda_backward_binding.cu
+++ b/csrc/kda/flashkda_backward_binding.cu
@@ -1,0 +1,876 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <initializer_list>
+
+#include "flashkda_binding_common.cuh"
+
+// The frozen bundle is standalone CUDA and intentionally declares its own
+// fixed-width and tensor-map carrier types.  Keep those declarations isolated
+// from CUDA's host headers while retaining one translation unit for all eleven
+// kernels and the TVM FFI binding.
+#define uint8_t flashkda_backward_generated_uint8_t
+#define uint16_t flashkda_backward_generated_uint16_t
+#define uint32_t flashkda_backward_generated_uint32_t
+#define uint64_t flashkda_backward_generated_uint64_t
+#define int32_t flashkda_backward_generated_int32_t
+#define int16_t flashkda_backward_generated_int16_t
+#define FlashKDATensorMap flashkda_backward_generated_FlashKDATensorMap
+#define FlashKDATensorMapPack flashkda_backward_generated_FlashKDATensorMapPack
+#define CUtensorMap flashkda_backward_generated_CUtensorMap
+#include "flashkda_backward.cu"
+#undef CUtensorMap
+#undef FlashKDATensorMapPack
+#undef FlashKDATensorMap
+#undef uint8_t
+#undef uint16_t
+#undef uint32_t
+#undef uint64_t
+#undef int32_t
+#undef int16_t
+
+namespace flashinfer {
+namespace flash_kda_backward {
+
+using flash_kda::CheckCuda;
+using flash_kda::CheckCudaTensor;
+using flash_kda::CheckDtype;
+using flash_kda::CheckDynamicSmemCapacity;
+using flash_kda::CheckFlashKDATarget;
+using flash_kda::CheckNoOverlap;
+using flash_kda::EncodeTmaPointers;
+using flash_kda::TmaPointers;
+
+constexpr int64_t kHeadDim = 128;
+constexpr int64_t kChunkTokens = 32;
+constexpr int64_t kLowGateTokensPerSplit = 128;
+constexpr int32_t kTapeThreads = 1024;
+constexpr int32_t kTapeSmemBytes = 227456;
+constexpr int32_t kFallbackThreads = 256;
+constexpr int32_t kFallbackSmemBytes = 128;
+constexpr int32_t kBoundaryM64Threads = 288;
+constexpr int32_t kBoundaryM64SmemBytes = 37888;
+constexpr int32_t kBoundaryM128Threads = 512;
+constexpr int32_t kBoundaryM128SmemBytes = 74752;
+constexpr int32_t kLocalThreads = 384;
+constexpr int32_t kLocalSmemBytes = 155136;
+constexpr int32_t kMapFinalizeThreads = 128;
+
+struct NamedTensor {
+  const TensorView* tensor;
+  const char* name;
+};
+
+inline void CheckTensor(const TensorView& tensor, const char* name, int32_t device_id,
+                        DLDataType dtype) {
+  CheckCudaTensor(tensor, name, device_id);
+  CheckDtype(tensor, name, dtype);
+}
+
+inline void CheckShape(const TensorView& actual, const TensorView& expected, const char* name,
+                       const char* expected_name) {
+  TVM_FFI_ICHECK(actual.ndim() == expected.ndim())
+      << name << " must have the same rank as " << expected_name;
+  for (int32_t dim = 0; dim < actual.ndim(); ++dim) {
+    TVM_FFI_ICHECK(actual.size(dim) == expected.size(dim))
+        << name << " must have the same shape as " << expected_name;
+  }
+}
+
+inline void Check1D(const TensorView& tensor, const char* name, int64_t elements) {
+  TVM_FFI_ICHECK(tensor.ndim() == 1 && tensor.numel() == elements)
+      << name << " must be one-dimensional with " << elements << " elements";
+}
+
+inline void Check2D(const TensorView& tensor, const char* name, int64_t dim0, int64_t dim1) {
+  TVM_FFI_ICHECK(tensor.ndim() == 2 && tensor.size(0) == dim0 && tensor.size(1) == dim1)
+      << name << " must have shape [" << dim0 << ", " << dim1 << "]";
+}
+
+inline void Check3D(const TensorView& tensor, const char* name, int64_t dim0, int64_t dim1,
+                    int64_t dim2) {
+  TVM_FFI_ICHECK(tensor.ndim() == 3 && tensor.size(0) == dim0 && tensor.size(1) == dim1 &&
+                 tensor.size(2) == dim2)
+      << name << " must have shape [" << dim0 << ", " << dim1 << ", " << dim2 << "]";
+}
+
+inline void Check4D(const TensorView& tensor, const char* name, int64_t dim0, int64_t dim1,
+                    int64_t dim2, int64_t dim3) {
+  TVM_FFI_ICHECK(tensor.ndim() == 4 && tensor.size(0) == dim0 && tensor.size(1) == dim1 &&
+                 tensor.size(2) == dim2 && tensor.size(3) == dim3)
+      << name << " must have shape [" << dim0 << ", " << dim1 << ", " << dim2 << ", " << dim3
+      << "]";
+}
+
+inline void CheckPairwiseDisjoint(std::initializer_list<NamedTensor> tensors) {
+  for (auto lhs = tensors.begin(); lhs != tensors.end(); ++lhs) {
+    for (auto rhs = lhs + 1; rhs != tensors.end(); ++rhs) {
+      TVM_FFI_ICHECK(lhs->tensor->data_ptr() != rhs->tensor->data_ptr())
+          << lhs->name << " and " << rhs->name << " must not alias";
+      CheckNoOverlap(*lhs->tensor, lhs->name, *rhs->tensor, rhs->name);
+    }
+  }
+}
+
+inline void CheckDisjointFrom(const TensorView& tensor, const char* name,
+                              std::initializer_list<NamedTensor> others) {
+  for (const NamedTensor& other : others) {
+    TVM_FFI_ICHECK(tensor.data_ptr() != other.tensor->data_ptr())
+        << name << " and " << other.name << " must not alias";
+    CheckNoOverlap(tensor, name, *other.tensor, other.name);
+  }
+}
+
+enum class CanonicalShape : int32_t {
+  kInvalid = -1,
+  kFixedT17H1 = 0,
+  kPackedT115N3H4 = 1,
+  kFixedT17H16 = 2,
+  kFixedT1024H4 = 3,
+  kFixedT4096H32 = 4,
+  kFixedT8192H96 = 5,
+  kPackedT8192N6H96 = 6,
+  kPackedT8192N8H96 = 7,
+};
+
+inline CanonicalShape ResolveCanonicalShape(const TensorView& q, int64_t num_sequences,
+                                            int64_t num_heads) {
+  if (q.ndim() != 4 || q.size(0) != 1 || q.size(2) != num_heads || q.size(3) != kHeadDim) {
+    return CanonicalShape::kInvalid;
+  }
+  const int64_t tokens = q.size(1);
+  if (tokens == 17 && num_sequences == 1 && num_heads == 1) {
+    return CanonicalShape::kFixedT17H1;
+  }
+  if (tokens == 115 && num_sequences == 3 && num_heads == 4) {
+    return CanonicalShape::kPackedT115N3H4;
+  }
+  if (tokens == 17 && num_sequences == 1 && num_heads == 16) {
+    return CanonicalShape::kFixedT17H16;
+  }
+  if (tokens == 1024 && num_sequences == 1 && num_heads == 4) {
+    return CanonicalShape::kFixedT1024H4;
+  }
+  if (tokens == 4096 && num_sequences == 1 && num_heads == 32) {
+    return CanonicalShape::kFixedT4096H32;
+  }
+  if (tokens == 8192 && num_sequences == 1 && num_heads == 96) {
+    return CanonicalShape::kFixedT8192H96;
+  }
+  if (tokens == 8192 && num_sequences == 6 && num_heads == 96) {
+    return CanonicalShape::kPackedT8192N6H96;
+  }
+  if (tokens == 8192 && num_sequences == 8 && num_heads == 96) {
+    return CanonicalShape::kPackedT8192N8H96;
+  }
+  return CanonicalShape::kInvalid;
+}
+
+__global__ void ValidateCanonicalCuSeqlens(const long long* cu_seqlens, CanonicalShape shape) {
+  if (blockIdx.x != 0 || threadIdx.x != 0) {
+    return;
+  }
+  bool valid = false;
+  switch (shape) {
+    case CanonicalShape::kFixedT17H1:
+    case CanonicalShape::kFixedT17H16:
+      valid = cu_seqlens[0] == 0 && cu_seqlens[1] == 17;
+      break;
+    case CanonicalShape::kPackedT115N3H4:
+      valid =
+          cu_seqlens[0] == 0 && cu_seqlens[1] == 17 && cu_seqlens[2] == 50 && cu_seqlens[3] == 115;
+      break;
+    case CanonicalShape::kFixedT1024H4:
+      valid = cu_seqlens[0] == 0 && cu_seqlens[1] == 1024;
+      break;
+    case CanonicalShape::kFixedT4096H32:
+      valid = cu_seqlens[0] == 0 && cu_seqlens[1] == 4096;
+      break;
+    case CanonicalShape::kFixedT8192H96:
+      valid = cu_seqlens[0] == 0 && cu_seqlens[1] == 8192;
+      break;
+    case CanonicalShape::kPackedT8192N6H96:
+      valid = cu_seqlens[0] == 0 && cu_seqlens[1] == 1300 && cu_seqlens[2] == 1847 &&
+              cu_seqlens[3] == 3895 && cu_seqlens[4] == 4858 && cu_seqlens[5] == 5129 &&
+              cu_seqlens[6] == 8192;
+      break;
+    case CanonicalShape::kPackedT8192N8H96:
+      valid = true;
+#pragma unroll
+      for (int32_t index = 0; index <= 8; ++index) {
+        valid = valid && cu_seqlens[index] == static_cast<long long>(index) * 1024;
+      }
+      break;
+    case CanonicalShape::kInvalid:
+      break;
+  }
+  if (!valid) {
+    asm volatile("trap;");
+  }
+}
+
+inline void LaunchCuSeqlensValidation(const TensorView& cu_seqlens, CanonicalShape shape,
+                                      cudaStream_t stream) {
+  ValidateCanonicalCuSeqlens<<<1, 1, 0, stream>>>(
+      reinterpret_cast<const long long*>(cu_seqlens.data_ptr()), shape);
+  CheckCuda(cudaGetLastError(), "ValidateCanonicalCuSeqlens launch");
+}
+
+inline int64_t CheckCommonContractInputs(const TensorView& q, const TensorView& k,
+                                         const TensorView& v, const TensorView& g,
+                                         const TensorView& beta, const TensorView& A_log,
+                                         const TensorView& dt_bias, const TensorView& initial_state,
+                                         const TensorView& do_, const TensorView& dfinal_state,
+                                         const TensorView& cu_seqlens, int64_t num_sequences,
+                                         int64_t num_heads, double scale, double lower_bound,
+                                         bool high_path) {
+  TVM_FFI_ICHECK(num_sequences > 0 && num_sequences <= std::numeric_limits<int32_t>::max())
+      << "num_sequences must be in the positive int32 range";
+  const bool supported_heads = high_path ? (num_heads == 16 || num_heads == 32 || num_heads == 96)
+                                         : (num_heads == 1 || num_heads == 4);
+  TVM_FFI_ICHECK(supported_heads) << (high_path ? "run_high requires H in {16, 32, 96}"
+                                                : "run_low requires H in {1, 4}");
+  constexpr double kRequiredScale = 0.08838834764831843;
+  TVM_FFI_ICHECK(std::isfinite(scale) && scale == kRequiredScale)
+      << "FlashKDA backward fixes scale=1/sqrt(128)";
+  TVM_FFI_ICHECK(std::isfinite(lower_bound) && lower_bound == -5.0)
+      << "FlashKDA backward fixes lower_bound=-5.0";
+
+  const int32_t device_id = q.device().device_id;
+  for (const auto& named :
+       {NamedTensor{&q, "q"}, NamedTensor{&k, "k"}, NamedTensor{&v, "v"}, NamedTensor{&g, "g"},
+        NamedTensor{&beta, "beta"}, NamedTensor{&do_, "do"}}) {
+    CheckTensor(*named.tensor, named.name, device_id, dl_bfloat16);
+  }
+  for (const auto& named :
+       {NamedTensor{&A_log, "A_log"}, NamedTensor{&dt_bias, "dt_bias"},
+        NamedTensor{&initial_state, "initial_state"}, NamedTensor{&dfinal_state, "dfinal_state"}}) {
+    CheckTensor(*named.tensor, named.name, device_id, dl_float32);
+  }
+  CheckTensor(cu_seqlens, "cu_seqlens", device_id, dl_int64);
+
+  TVM_FFI_ICHECK(ResolveCanonicalShape(q, num_sequences, num_heads) != CanonicalShape::kInvalid)
+      << "q is outside the eight canonical FlashKDA backward shapes";
+  CheckShape(k, q, "k", "q");
+  CheckShape(v, q, "v", "q");
+  CheckShape(g, q, "g", "q");
+  CheckShape(do_, q, "do", "q");
+  TVM_FFI_ICHECK(beta.ndim() == q.ndim() - 1) << "beta must remove only q's trailing K dimension";
+  for (int32_t dim = 0; dim < beta.ndim(); ++dim) {
+    TVM_FFI_ICHECK(beta.size(dim) == q.size(dim))
+        << "beta must match q's leading [batch, tokens, heads] shape";
+  }
+  TVM_FFI_ICHECK(A_log.ndim() == 1 && A_log.numel() == num_heads) << "A_log must have shape [H]";
+  TVM_FFI_ICHECK(dt_bias.ndim() == 2 && dt_bias.size(0) == num_heads && dt_bias.size(1) == kHeadDim)
+      << "dt_bias must have shape [H, 128]";
+  Check4D(initial_state, "initial_state", num_sequences, num_heads, kHeadDim, kHeadDim);
+  CheckShape(dfinal_state, initial_state, "dfinal_state", "initial_state");
+  Check1D(cu_seqlens, "cu_seqlens", num_sequences + 1);
+
+  const int64_t total_tokens = q.numel() / (num_heads * kHeadDim);
+  TVM_FFI_ICHECK(total_tokens > 0 && total_tokens <= std::numeric_limits<int32_t>::max())
+      << "total_tokens must be in the positive int32 range";
+  return total_tokens;
+}
+
+inline void CheckExactBlackwellTarget(int32_t device_id) {
+  CheckFlashKDATarget(device_id);
+  int major = 0;
+  int minor = 0;
+  CheckCuda(cudaDeviceGetAttribute(&major, cudaDevAttrComputeCapabilityMajor, device_id),
+            "cudaDeviceGetAttribute(major)");
+  CheckCuda(cudaDeviceGetAttribute(&minor, cudaDevAttrComputeCapabilityMinor, device_id),
+            "cudaDeviceGetAttribute(minor)");
+  TVM_FFI_ICHECK(major == 10 && minor == FLASHINFER_FLASH_KDA_TARGET_MINOR)
+      << "FlashKDA backward module targets exact compute capability 10."
+      << FLASHINFER_FLASH_KDA_TARGET_MINOR << ", got " << major << "." << minor;
+}
+
+inline uint32_t CheckedGridX(int64_t grid_x, const char* name) {
+  TVM_FFI_ICHECK(grid_x > 0 && grid_x <= std::numeric_limits<uint32_t>::max())
+      << name << " grid.x is out of range: " << grid_x;
+  return static_cast<uint32_t>(grid_x);
+}
+
+template <typename Kernel>
+inline void ConfigureDynamicSmem(Kernel kernel, int32_t smem_bytes, int32_t device_id,
+                                 const char* name) {
+  CheckDynamicSmemCapacity(device_id, smem_bytes);
+  CheckCuda(cudaFuncSetAttribute(reinterpret_cast<const void*>(kernel),
+                                 cudaFuncAttributeMaxDynamicSharedMemorySize, smem_bytes),
+            name);
+}
+
+void RunLow(TensorView q, TensorView k, TensorView v, TensorView g, TensorView beta,
+            TensorView A_log, TensorView dt_bias, TensorView initial_state, TensorView do_,
+            TensorView dfinal_state, TensorView cu_seqlens, TensorView q_norm, TensorView k_norm,
+            TensorView decay, TensorView beta_active, TensorView checkpoint,
+            TensorView dq_normalized, TensorView dk_normalized, TensorView dlog_decay,
+            TensorView dbeta_active, TensorView dq, TensorView dk, TensorView dv, TensorView dg,
+            TensorView dbeta, TensorView dA_log, TensorView ddt_bias, TensorView dinitial_state,
+            int64_t num_sequences, int64_t num_heads, double scale, double lower_bound,
+            int64_t cuda_stream) {
+  TVM_FFI_ICHECK(cuda_stream >= 0) << "cuda_stream must be a non-negative stream handle";
+  TVM_FFI_ICHECK(q.device().device_type == kDLCUDA) << "q must be a CUDA tensor";
+  const int32_t device_id = q.device().device_id;
+  ffi::CUDADeviceGuard device_guard(device_id);
+  CheckExactBlackwellTarget(device_id);
+  const int64_t total_tokens =
+      CheckCommonContractInputs(q, k, v, g, beta, A_log, dt_bias, initial_state, do_, dfinal_state,
+                                cu_seqlens, num_sequences, num_heads, scale, lower_bound, false);
+
+  for (const auto& named :
+       {NamedTensor{&q_norm, "q_norm"}, NamedTensor{&k_norm, "k_norm"},
+        NamedTensor{&decay, "decay"}, NamedTensor{&beta_active, "beta_active"},
+        NamedTensor{&checkpoint, "checkpoint"}, NamedTensor{&dq_normalized, "dq_normalized"},
+        NamedTensor{&dk_normalized, "dk_normalized"}, NamedTensor{&dlog_decay, "dlog_decay"},
+        NamedTensor{&dbeta_active, "dbeta_active"}, NamedTensor{&dA_log, "dA_log"},
+        NamedTensor{&ddt_bias, "ddt_bias"}, NamedTensor{&dinitial_state, "dinitial_state"}}) {
+    CheckTensor(*named.tensor, named.name, device_id, dl_float32);
+  }
+  for (const auto& named : {NamedTensor{&dq, "dq"}, NamedTensor{&dk, "dk"}, NamedTensor{&dv, "dv"},
+                            NamedTensor{&dg, "dg"}, NamedTensor{&dbeta, "dbeta"}}) {
+    CheckTensor(*named.tensor, named.name, device_id, dl_bfloat16);
+  }
+
+  for (const auto& named :
+       {NamedTensor{&q_norm, "q_norm"}, NamedTensor{&k_norm, "k_norm"},
+        NamedTensor{&decay, "decay"}, NamedTensor{&dq_normalized, "dq_normalized"},
+        NamedTensor{&dk_normalized, "dk_normalized"}, NamedTensor{&dlog_decay, "dlog_decay"}}) {
+    Check3D(*named.tensor, named.name, total_tokens, num_heads, kHeadDim);
+  }
+  Check2D(beta_active, "beta_active", total_tokens, num_heads);
+  Check2D(dbeta_active, "dbeta_active", total_tokens, num_heads);
+  Check4D(checkpoint, "checkpoint", total_tokens, num_heads, kHeadDim, kHeadDim);
+  for (const auto& named : {NamedTensor{&dq, "dq"}, NamedTensor{&dk, "dk"}, NamedTensor{&dv, "dv"},
+                            NamedTensor{&dg, "dg"}}) {
+    CheckShape(*named.tensor, q, named.name, "q");
+  }
+  CheckShape(dbeta, beta, "dbeta", "beta");
+  CheckShape(dA_log, A_log, "dA_log", "A_log");
+  CheckShape(ddt_bias, dt_bias, "ddt_bias", "dt_bias");
+  CheckShape(dinitial_state, initial_state, "dinitial_state", "initial_state");
+
+  CheckPairwiseDisjoint({
+      {&q, "q"},
+      {&k, "k"},
+      {&v, "v"},
+      {&g, "g"},
+      {&beta, "beta"},
+      {&A_log, "A_log"},
+      {&dt_bias, "dt_bias"},
+      {&initial_state, "initial_state"},
+      {&do_, "do"},
+      {&dfinal_state, "dfinal_state"},
+      {&cu_seqlens, "cu_seqlens"},
+      {&q_norm, "q_norm"},
+      {&k_norm, "k_norm"},
+      {&decay, "decay"},
+      {&beta_active, "beta_active"},
+      {&checkpoint, "checkpoint"},
+      {&dq_normalized, "dq_normalized"},
+      {&dk_normalized, "dk_normalized"},
+      {&dlog_decay, "dlog_decay"},
+      {&dbeta_active, "dbeta_active"},
+      {&dq, "dq"},
+      {&dk, "dk"},
+      {&dv, "dv"},
+      {&dg, "dg"},
+      {&dbeta, "dbeta"},
+      {&dA_log, "dA_log"},
+      {&ddt_bias, "ddt_bias"},
+      {&dinitial_state, "dinitial_state"},
+  });
+
+  const cudaStream_t stream = reinterpret_cast<cudaStream_t>(static_cast<uintptr_t>(cuda_stream));
+  LaunchCuSeqlensValidation(cu_seqlens, ResolveCanonicalShape(q, num_sequences, num_heads), stream);
+  for (const NamedTensor& named :
+       {NamedTensor{&dq_normalized, "dq_normalized"}, NamedTensor{&dk_normalized, "dk_normalized"},
+        NamedTensor{&dlog_decay, "dlog_decay"}, NamedTensor{&dbeta_active, "dbeta_active"},
+        NamedTensor{&dA_log, "dA_log"}, NamedTensor{&ddt_bias, "ddt_bias"}}) {
+    CheckCuda(
+        cudaMemsetAsync(named.tensor->data_ptr(), 0, named.tensor->numel() * sizeof(float), stream),
+        named.name);
+  }
+
+  const dim3 preprocess_grid(CheckedGridX(total_tokens, "preprocess"),
+                             CheckedGridX(num_heads, "preprocess"), 1);
+  kernel_flashkda_backward_preprocess<<<preprocess_grid, 32, 0, stream>>>(
+      reinterpret_cast<__nv_bfloat16*>(q.data_ptr()),
+      reinterpret_cast<__nv_bfloat16*>(k.data_ptr()),
+      reinterpret_cast<__nv_bfloat16*>(g.data_ptr()),
+      reinterpret_cast<__nv_bfloat16*>(beta.data_ptr()), reinterpret_cast<float*>(A_log.data_ptr()),
+      reinterpret_cast<float*>(dt_bias.data_ptr()), reinterpret_cast<float*>(q_norm.data_ptr()),
+      reinterpret_cast<float*>(k_norm.data_ptr()), reinterpret_cast<float*>(decay.data_ptr()),
+      reinterpret_cast<float*>(beta_active.data_ptr()), static_cast<int32_t>(total_tokens),
+      static_cast<int32_t>(num_heads), static_cast<float>(lower_bound));
+  CheckCuda(cudaGetLastError(), "kernel_flashkda_backward_preprocess launch");
+
+  const int64_t row_grid_x = num_sequences * num_heads * kHeadDim;
+  kernel_flashkda_backward_checkpoint<<<CheckedGridX(row_grid_x, "checkpoint"), 32, 0, stream>>>(
+      reinterpret_cast<float*>(k_norm.data_ptr()), reinterpret_cast<float*>(decay.data_ptr()),
+      reinterpret_cast<float*>(beta_active.data_ptr()),
+      reinterpret_cast<__nv_bfloat16*>(v.data_ptr()),
+      reinterpret_cast<float*>(initial_state.data_ptr()),
+      reinterpret_cast<long long*>(cu_seqlens.data_ptr()),
+      reinterpret_cast<float*>(checkpoint.data_ptr()), static_cast<int32_t>(num_sequences),
+      static_cast<int32_t>(num_heads));
+  CheckCuda(cudaGetLastError(), "kernel_flashkda_backward_checkpoint launch");
+
+  kernel_flashkda_backward_reverse_rows<<<CheckedGridX(row_grid_x, "reverse_rows"), 32, 0,
+                                          stream>>>(
+      reinterpret_cast<float*>(q_norm.data_ptr()), reinterpret_cast<float*>(k_norm.data_ptr()),
+      reinterpret_cast<float*>(decay.data_ptr()), reinterpret_cast<float*>(beta_active.data_ptr()),
+      reinterpret_cast<__nv_bfloat16*>(v.data_ptr()),
+      reinterpret_cast<__nv_bfloat16*>(do_.data_ptr()),
+      reinterpret_cast<float*>(initial_state.data_ptr()),
+      reinterpret_cast<float*>(dfinal_state.data_ptr()),
+      reinterpret_cast<long long*>(cu_seqlens.data_ptr()),
+      reinterpret_cast<float*>(checkpoint.data_ptr()),
+      reinterpret_cast<float*>(dq_normalized.data_ptr()),
+      reinterpret_cast<float*>(dk_normalized.data_ptr()),
+      reinterpret_cast<float*>(dlog_decay.data_ptr()),
+      reinterpret_cast<float*>(dbeta_active.data_ptr()),
+      reinterpret_cast<__nv_bfloat16*>(dv.data_ptr()),
+      reinterpret_cast<float*>(dinitial_state.data_ptr()), static_cast<int32_t>(num_sequences),
+      static_cast<int32_t>(num_heads), static_cast<float>(scale));
+  CheckCuda(cudaGetLastError(), "kernel_flashkda_backward_reverse_rows launch");
+
+  kernel_flashkda_backward_finalize_tokens<<<preprocess_grid, 32, 0, stream>>>(
+      reinterpret_cast<__nv_bfloat16*>(q.data_ptr()),
+      reinterpret_cast<__nv_bfloat16*>(k.data_ptr()),
+      reinterpret_cast<__nv_bfloat16*>(g.data_ptr()),
+      reinterpret_cast<float*>(beta_active.data_ptr()), reinterpret_cast<float*>(A_log.data_ptr()),
+      reinterpret_cast<float*>(dt_bias.data_ptr()), reinterpret_cast<float*>(q_norm.data_ptr()),
+      reinterpret_cast<float*>(k_norm.data_ptr()),
+      reinterpret_cast<float*>(dq_normalized.data_ptr()),
+      reinterpret_cast<float*>(dk_normalized.data_ptr()),
+      reinterpret_cast<float*>(dlog_decay.data_ptr()),
+      reinterpret_cast<float*>(dbeta_active.data_ptr()),
+      reinterpret_cast<__nv_bfloat16*>(dq.data_ptr()),
+      reinterpret_cast<__nv_bfloat16*>(dk.data_ptr()),
+      reinterpret_cast<__nv_bfloat16*>(dg.data_ptr()),
+      reinterpret_cast<__nv_bfloat16*>(dbeta.data_ptr()), static_cast<int32_t>(num_heads),
+      static_cast<float>(lower_bound));
+  CheckCuda(cudaGetLastError(), "kernel_flashkda_backward_finalize_tokens launch");
+
+  ConfigureDynamicSmem(kernel_flashkda_backward_gate_reduce_split, 128, device_id,
+                       "cudaFuncSetAttribute(gate_reduce_split)");
+  const int64_t gate_splits = (total_tokens + kLowGateTokensPerSplit - 1) / kLowGateTokensPerSplit;
+  const dim3 gate_grid(CheckedGridX(num_heads, "gate_reduce_split"),
+                       CheckedGridX(gate_splits, "gate_reduce_split"), 1);
+  kernel_flashkda_backward_gate_reduce_split<<<gate_grid, 128, 128, stream>>>(
+      reinterpret_cast<float*>(dlog_decay.data_ptr()),
+      reinterpret_cast<__nv_bfloat16*>(g.data_ptr()), reinterpret_cast<float*>(dt_bias.data_ptr()),
+      reinterpret_cast<float*>(dA_log.data_ptr()), reinterpret_cast<float*>(ddt_bias.data_ptr()),
+      static_cast<int32_t>(total_tokens), static_cast<int32_t>(num_heads),
+      static_cast<int32_t>(kLowGateTokensPerSplit));
+  CheckCuda(cudaGetLastError(), "kernel_flashkda_backward_gate_reduce_split launch");
+}
+
+void RunHigh(TensorView q, TensorView k, TensorView v, TensorView g, TensorView beta,
+             TensorView beta_tma, TensorView A_log, TensorView dt_bias, TensorView initial_state,
+             TensorView do_, TensorView dfinal_state, TensorView cu_seqlens, TensorView seq_order,
+             TensorView cu_chunk_offsets, TensorView consumer_chunk_order,
+             TensorView chunk_sequence, TensorView chunk_index, TensorView chunk_pair_start,
+             TensorView descriptor_storage, TensorView forward_out, TensorView forward_final,
+             TensorView chunk_state, TensorView state_checkpoint_needed, TensorView tape_qd,
+             TensorView tape_kd, TensorView tape_kr, TensorView tape_j,
+             TensorView tape_restore_factor, TensorView tape_e, TensorView tape_x,
+             TensorView tape_r, TensorView norm_inv, TensorView decay, TensorView beta_active,
+             TensorView zero_workspace, TensorView chunk_dh, TensorView chunk_dr,
+             TensorView chunk_dx, TensorView grad_qd, TensorView grad_kd, TensorView grad_ki,
+             TensorView dlog_decay, TensorView dbeta_active, TensorView dq, TensorView dk,
+             TensorView dv, TensorView dg, TensorView dbeta, TensorView dA_log, TensorView ddt_bias,
+             TensorView dinitial_state, int64_t prepare_descriptors, int64_t num_sequences,
+             int64_t num_heads, double scale, double lower_bound, int64_t cuda_stream) {
+  TVM_FFI_ICHECK(cuda_stream >= 0) << "cuda_stream must be a non-negative stream handle";
+  TVM_FFI_ICHECK(prepare_descriptors == 0 || prepare_descriptors == 1)
+      << "prepare_descriptors must be 0 or 1";
+  TVM_FFI_ICHECK(q.device().device_type == kDLCUDA) << "q must be a CUDA tensor";
+  const int32_t device_id = q.device().device_id;
+  ffi::CUDADeviceGuard device_guard(device_id);
+  CheckExactBlackwellTarget(device_id);
+  const int64_t total_tokens =
+      CheckCommonContractInputs(q, k, v, g, beta, A_log, dt_bias, initial_state, do_, dfinal_state,
+                                cu_seqlens, num_sequences, num_heads, scale, lower_bound, true);
+  const int64_t total_chunks = chunk_sequence.numel();
+  const int64_t total_pairs = chunk_pair_start.numel();
+  TVM_FFI_ICHECK(total_chunks > 0 && total_chunks <= std::numeric_limits<int32_t>::max())
+      << "total_chunks must be in the positive int32 range";
+  TVM_FFI_ICHECK(total_pairs > 0 && total_pairs <= std::numeric_limits<int32_t>::max())
+      << "total_pairs must be in the positive int32 range";
+
+  for (const auto& named : {NamedTensor{&beta_tma, "beta_tma"},
+                            NamedTensor{&forward_out, "forward_out"},
+                            NamedTensor{&forward_final, "forward_final"},
+                            NamedTensor{&chunk_state, "chunk_state"},
+                            NamedTensor{&tape_qd, "tape_qd"},
+                            NamedTensor{&tape_kd, "tape_kd"},
+                            NamedTensor{&tape_kr, "tape_kr"},
+                            NamedTensor{&tape_j, "tape_j"},
+                            NamedTensor{&tape_e, "tape_e"},
+                            NamedTensor{&tape_x, "tape_x"},
+                            NamedTensor{&tape_r, "tape_r"},
+                            NamedTensor{&decay, "decay"},
+                            NamedTensor{&chunk_dh, "chunk_dh"},
+                            NamedTensor{&chunk_dr, "chunk_dr"},
+                            NamedTensor{&chunk_dx, "chunk_dx"},
+                            NamedTensor{&grad_qd, "grad_qd"},
+                            NamedTensor{&grad_kd, "grad_kd"},
+                            NamedTensor{&grad_ki, "grad_ki"},
+                            NamedTensor{&dq, "dq"},
+                            NamedTensor{&dk, "dk"},
+                            NamedTensor{&dv, "dv"},
+                            NamedTensor{&dg, "dg"},
+                            NamedTensor{&dbeta, "dbeta"}}) {
+    CheckTensor(*named.tensor, named.name, device_id, dl_bfloat16);
+  }
+  for (const auto& named :
+       {NamedTensor{&tape_restore_factor, "tape_restore_factor"},
+        NamedTensor{&norm_inv, "norm_inv"}, NamedTensor{&beta_active, "beta_active"},
+        NamedTensor{&dlog_decay, "dlog_decay"}, NamedTensor{&dbeta_active, "dbeta_active"},
+        NamedTensor{&dA_log, "dA_log"}, NamedTensor{&ddt_bias, "ddt_bias"},
+        NamedTensor{&dinitial_state, "dinitial_state"}}) {
+    CheckTensor(*named.tensor, named.name, device_id, dl_float32);
+  }
+  for (const auto& named :
+       {NamedTensor{&seq_order, "seq_order"},
+        NamedTensor{&consumer_chunk_order, "consumer_chunk_order"},
+        NamedTensor{&chunk_sequence, "chunk_sequence"}, NamedTensor{&chunk_index, "chunk_index"},
+        NamedTensor{&chunk_pair_start, "chunk_pair_start"}}) {
+    CheckTensor(*named.tensor, named.name, device_id, dl_int32);
+  }
+  CheckTensor(cu_chunk_offsets, "cu_chunk_offsets", device_id, dl_int64);
+  CheckTensor(descriptor_storage, "descriptor_storage", device_id, dl_uint8);
+  CheckTensor(state_checkpoint_needed, "state_checkpoint_needed", device_id, dl_uint32);
+  CheckTensor(zero_workspace, "zero_workspace", device_id, dl_uint32);
+
+  Check1D(seq_order, "seq_order", num_sequences);
+  Check1D(cu_chunk_offsets, "cu_chunk_offsets", num_sequences + 1);
+  Check1D(consumer_chunk_order, "consumer_chunk_order", total_chunks);
+  Check1D(chunk_sequence, "chunk_sequence", total_chunks);
+  Check1D(chunk_index, "chunk_index", total_chunks);
+  Check1D(chunk_pair_start, "chunk_pair_start", total_pairs);
+  Check1D(state_checkpoint_needed, "state_checkpoint_needed",
+          (total_chunks + num_sequences) * num_heads);
+  TVM_FFI_ICHECK(descriptor_storage.ndim() == 1 &&
+                 descriptor_storage.numel() >=
+                     static_cast<int64_t>(flash_kda::kDescriptorStorageBytes))
+      << "descriptor_storage must provide at least 768 bytes";
+  TVM_FFI_ICHECK(reinterpret_cast<uintptr_t>(descriptor_storage.data_ptr()) %
+                     flash_kda::kTensorMapAlignment ==
+                 0)
+      << "descriptor_storage must be 64-byte aligned";
+
+  Check3D(forward_out, "forward_out", total_tokens, num_heads, kHeadDim);
+  Check4D(forward_final, "forward_final", num_sequences, num_heads, kHeadDim, kHeadDim);
+  Check4D(chunk_state, "chunk_state", total_chunks, num_heads, kHeadDim, kHeadDim);
+  for (const auto& named : {NamedTensor{&tape_qd, "tape_qd"}, NamedTensor{&tape_kd, "tape_kd"},
+                            NamedTensor{&tape_kr, "tape_kr"}, NamedTensor{&grad_qd, "grad_qd"},
+                            NamedTensor{&grad_kd, "grad_kd"}, NamedTensor{&grad_ki, "grad_ki"}}) {
+    Check4D(*named.tensor, named.name, total_chunks, num_heads, kChunkTokens, kHeadDim);
+  }
+  Check4D(tape_j, "tape_j", total_chunks, num_heads, kChunkTokens, kChunkTokens);
+  Check3D(tape_restore_factor, "tape_restore_factor", total_chunks, num_heads, kHeadDim);
+  for (const auto& named : {NamedTensor{&tape_e, "tape_e"}, NamedTensor{&tape_x, "tape_x"},
+                            NamedTensor{&tape_r, "tape_r"}, NamedTensor{&chunk_dr, "chunk_dr"},
+                            NamedTensor{&chunk_dx, "chunk_dx"}}) {
+    Check4D(*named.tensor, named.name, total_chunks, num_heads, kHeadDim, kChunkTokens);
+  }
+  Check4D(chunk_dh, "chunk_dh", total_chunks, num_heads, kHeadDim, kHeadDim);
+  Check3D(norm_inv, "norm_inv", total_tokens, num_heads, 2);
+  Check3D(decay, "decay", total_tokens, num_heads, kHeadDim);
+  Check2D(beta_active, "beta_active", total_tokens, num_heads);
+  Check3D(dlog_decay, "dlog_decay", total_tokens, num_heads, kHeadDim);
+  Check2D(dbeta_active, "dbeta_active", total_tokens, num_heads);
+  for (const auto& named : {NamedTensor{&dq, "dq"}, NamedTensor{&dk, "dk"}, NamedTensor{&dv, "dv"},
+                            NamedTensor{&dg, "dg"}}) {
+    CheckShape(*named.tensor, q, named.name, "q");
+  }
+  CheckShape(dbeta, beta, "dbeta", "beta");
+  CheckShape(dA_log, A_log, "dA_log", "A_log");
+  CheckShape(ddt_bias, dt_bias, "ddt_bias", "dt_bias");
+  CheckShape(dinitial_state, initial_state, "dinitial_state", "initial_state");
+
+  const int64_t beta_tma_rows = std::max<int64_t>(total_tokens, kChunkTokens);
+  TVM_FFI_ICHECK(beta_tma.ndim() == 2 && beta_tma.size(0) == beta_tma_rows &&
+                 beta_tma.size(1) == num_heads)
+      << "beta_tma must have shape [max(total_tokens, 32), H]";
+  const bool beta_tma_aliases_beta = beta_tma.data_ptr() == beta.data_ptr();
+  TVM_FFI_ICHECK((total_tokens >= kChunkTokens && beta_tma_aliases_beta) ||
+                 (total_tokens < kChunkTokens && !beta_tma_aliases_beta))
+      << "beta_tma must exactly alias beta for T>=32 and use padded disjoint storage for T<32";
+
+  TVM_FFI_ICHECK(tape_e.data_ptr() == tape_x.data_ptr() && tape_e.numel() == tape_x.numel())
+      << "the tcgen local route requires tape_e to exactly alias tape_x";
+  const int64_t zero_words = total_chunks * num_heads;
+  Check1D(zero_workspace, "zero_workspace", zero_words);
+
+  const std::initializer_list<NamedTensor> disjoint = {
+      {&q, "q"},
+      {&k, "k"},
+      {&v, "v"},
+      {&g, "g"},
+      {&beta, "beta"},
+      {&A_log, "A_log"},
+      {&dt_bias, "dt_bias"},
+      {&initial_state, "initial_state"},
+      {&do_, "do"},
+      {&dfinal_state, "dfinal_state"},
+      {&cu_seqlens, "cu_seqlens"},
+      {&seq_order, "seq_order"},
+      {&cu_chunk_offsets, "cu_chunk_offsets"},
+      {&consumer_chunk_order, "consumer_chunk_order"},
+      {&chunk_sequence, "chunk_sequence"},
+      {&chunk_index, "chunk_index"},
+      {&chunk_pair_start, "chunk_pair_start"},
+      {&descriptor_storage, "descriptor_storage"},
+      {&forward_out, "forward_out"},
+      {&forward_final, "forward_final"},
+      {&chunk_state, "chunk_state"},
+      {&state_checkpoint_needed, "state_checkpoint_needed"},
+      {&tape_qd, "tape_qd"},
+      {&tape_kd, "tape_kd"},
+      {&tape_kr, "tape_kr"},
+      {&tape_j, "tape_j"},
+      {&tape_restore_factor, "tape_restore_factor"},
+      {&tape_x, "tape_x_and_e"},
+      {&tape_r, "tape_r"},
+      {&norm_inv, "norm_inv"},
+      {&decay, "decay"},
+      {&beta_active, "beta_active"},
+      {&zero_workspace, "zero_workspace"},
+      {&chunk_dh, "chunk_dh"},
+      {&chunk_dr, "chunk_dr"},
+      {&chunk_dx, "chunk_dx"},
+      {&grad_qd, "grad_qd"},
+      {&grad_kd, "grad_kd"},
+      {&grad_ki, "grad_ki"},
+      {&dlog_decay, "dlog_decay"},
+      {&dbeta_active, "dbeta_active"},
+      {&dq, "dq"},
+      {&dk, "dk"},
+      {&dv, "dv"},
+      {&dg, "dg"},
+      {&dbeta, "dbeta"},
+      {&dA_log, "dA_log"},
+      {&ddt_bias, "ddt_bias"},
+      {&dinitial_state, "dinitial_state"},
+  };
+  CheckPairwiseDisjoint(disjoint);
+  if (!beta_tma_aliases_beta) {
+    CheckDisjointFrom(beta_tma, "beta_tma", disjoint);
+  }
+
+  const cudaStream_t stream = reinterpret_cast<cudaStream_t>(static_cast<uintptr_t>(cuda_stream));
+  LaunchCuSeqlensValidation(cu_seqlens, ResolveCanonicalShape(q, num_sequences, num_heads), stream);
+  CheckCuda(cudaMemsetAsync(dA_log.data_ptr(), 0, dA_log.numel() * sizeof(float), stream),
+            "clear dA_log");
+  CheckCuda(cudaMemsetAsync(ddt_bias.data_ptr(), 0, ddt_bias.numel() * sizeof(float), stream),
+            "clear ddt_bias");
+  if (!beta_tma_aliases_beta) {
+    CheckCuda(
+        cudaMemcpyAsync(beta_tma.data_ptr(), beta.data_ptr(), beta.numel() * sizeof(__nv_bfloat16),
+                        cudaMemcpyDeviceToDevice, stream),
+        "copy beta into padded beta_tma");
+  }
+  const TmaPointers tma = EncodeTmaPointers<128, 32>(
+      q, k, v, g, beta_tma, forward_out, descriptor_storage, prepare_descriptors, stream);
+
+  ConfigureDynamicSmem(kernel_flashkda_bf16_fused_m128, kTapeSmemBytes, device_id,
+                       "cudaFuncSetAttribute(backward tape)");
+  const dim3 tape_grid(CheckedGridX(num_sequences * num_heads, "backward tape"), 1, 1);
+  kernel_flashkda_bf16_fused_m128<<<tape_grid, kTapeThreads, kTapeSmemBytes, stream>>>(
+      reinterpret_cast<__nv_bfloat16*>(q.data_ptr()),
+      reinterpret_cast<flashkda_backward_generated_FlashKDATensorMap const*>(tma.q),
+      reinterpret_cast<__nv_bfloat16*>(k.data_ptr()),
+      reinterpret_cast<flashkda_backward_generated_FlashKDATensorMap const*>(tma.k),
+      reinterpret_cast<__nv_bfloat16*>(v.data_ptr()),
+      reinterpret_cast<flashkda_backward_generated_FlashKDATensorMap const*>(tma.v),
+      reinterpret_cast<__nv_bfloat16*>(g.data_ptr()),
+      reinterpret_cast<flashkda_backward_generated_FlashKDATensorMap const*>(tma.g),
+      reinterpret_cast<__nv_bfloat16*>(beta.data_ptr()),
+      reinterpret_cast<flashkda_backward_generated_FlashKDATensorMap const*>(tma.beta),
+      reinterpret_cast<float*>(A_log.data_ptr()), reinterpret_cast<float*>(dt_bias.data_ptr()),
+      reinterpret_cast<long long*>(cu_seqlens.data_ptr()),
+      reinterpret_cast<int*>(seq_order.data_ptr()), reinterpret_cast<__nv_bfloat16*>(q.data_ptr()),
+      reinterpret_cast<__nv_bfloat16*>(forward_out.data_ptr()),
+      reinterpret_cast<flashkda_backward_generated_FlashKDATensorMap const*>(tma.out),
+      reinterpret_cast<__nv_bfloat16*>(forward_final.data_ptr()), static_cast<int32_t>(num_heads),
+      1, 0, static_cast<float>(scale), static_cast<float>(lower_bound), 0ULL, 0ULL, 0ULL, 0LL, 0LL,
+      0, 0, reinterpret_cast<long long*>(cu_chunk_offsets.data_ptr()),
+      reinterpret_cast<__nv_bfloat16*>(chunk_state.data_ptr()),
+      reinterpret_cast<unsigned int*>(state_checkpoint_needed.data_ptr()),
+      reinterpret_cast<__nv_bfloat16*>(tape_qd.data_ptr()),
+      reinterpret_cast<__nv_bfloat16*>(tape_kd.data_ptr()),
+      reinterpret_cast<__nv_bfloat16*>(tape_kr.data_ptr()),
+      reinterpret_cast<__nv_bfloat16*>(tape_j.data_ptr()),
+      reinterpret_cast<float*>(tape_restore_factor.data_ptr()),
+      reinterpret_cast<__nv_bfloat16*>(tape_e.data_ptr()),
+      reinterpret_cast<__nv_bfloat16*>(tape_x.data_ptr()),
+      reinterpret_cast<__nv_bfloat16*>(tape_r.data_ptr()),
+      reinterpret_cast<float*>(norm_inv.data_ptr()),
+      reinterpret_cast<__nv_bfloat16*>(decay.data_ptr()),
+      reinterpret_cast<float*>(beta_active.data_ptr()),
+      reinterpret_cast<float*>(initial_state.data_ptr()),
+      reinterpret_cast<unsigned int*>(zero_workspace.data_ptr()), static_cast<int32_t>(zero_words));
+  CheckCuda(cudaGetLastError(), "kernel_flashkda_bf16_fused_m128 backward tape launch");
+
+  ConfigureDynamicSmem(kernel_flashkda_backward_state_checkpoint_fallback_c32, kFallbackSmemBytes,
+                       device_id, "cudaFuncSetAttribute(state checkpoint fallback)");
+  kernel_flashkda_backward_state_checkpoint_fallback_c32<<<1, kFallbackThreads, kFallbackSmemBytes,
+                                                           stream>>>(
+      reinterpret_cast<long long*>(cu_seqlens.data_ptr()),
+      reinterpret_cast<long long*>(cu_chunk_offsets.data_ptr()),
+      reinterpret_cast<unsigned int*>(state_checkpoint_needed.data_ptr()),
+      reinterpret_cast<float*>(initial_state.data_ptr()),
+      reinterpret_cast<__nv_bfloat16*>(tape_kr.data_ptr()),
+      reinterpret_cast<float*>(tape_restore_factor.data_ptr()),
+      reinterpret_cast<__nv_bfloat16*>(tape_r.data_ptr()),
+      reinterpret_cast<__nv_bfloat16*>(chunk_state.data_ptr()), static_cast<int32_t>(num_sequences),
+      static_cast<int32_t>(num_heads), static_cast<float>(lower_bound));
+  CheckCuda(cudaGetLastError(), "kernel_flashkda_backward_state_checkpoint_fallback_c32 launch");
+
+  const bool split_boundary = num_heads <= 64;
+  const int32_t boundary_ready_target = split_boundary ? 2 : 3;
+  const uint32_t boundary_grid_x =
+      CheckedGridX(num_sequences * num_heads * (split_boundary ? 2 : 1), "boundary");
+  if (split_boundary) {
+    ConfigureDynamicSmem(kernel_flashkda_backward_boundary_c32_tcgen_m64, kBoundaryM64SmemBytes,
+                         device_id, "cudaFuncSetAttribute(boundary M64)");
+    kernel_flashkda_backward_boundary_c32_tcgen_m64<<<boundary_grid_x, kBoundaryM64Threads,
+                                                      kBoundaryM64SmemBytes, stream>>>(
+        reinterpret_cast<__nv_bfloat16*>(do_.data_ptr()),
+        reinterpret_cast<float*>(dfinal_state.data_ptr()),
+        reinterpret_cast<float*>(beta_active.data_ptr()),
+        reinterpret_cast<long long*>(cu_seqlens.data_ptr()),
+        reinterpret_cast<long long*>(cu_chunk_offsets.data_ptr()),
+        reinterpret_cast<int*>(seq_order.data_ptr()),
+        reinterpret_cast<__nv_bfloat16*>(tape_qd.data_ptr()),
+        reinterpret_cast<__nv_bfloat16*>(tape_kd.data_ptr()),
+        reinterpret_cast<__nv_bfloat16*>(tape_kr.data_ptr()),
+        reinterpret_cast<__nv_bfloat16*>(tape_j.data_ptr()),
+        reinterpret_cast<float*>(tape_restore_factor.data_ptr()),
+        reinterpret_cast<__nv_bfloat16*>(chunk_dh.data_ptr()),
+        reinterpret_cast<__nv_bfloat16*>(chunk_dr.data_ptr()),
+        reinterpret_cast<__nv_bfloat16*>(chunk_dx.data_ptr()),
+        reinterpret_cast<float*>(dinitial_state.data_ptr()),
+        reinterpret_cast<unsigned int*>(zero_workspace.data_ptr()), static_cast<int32_t>(num_heads),
+        1, static_cast<float>(lower_bound));
+    CheckCuda(cudaGetLastError(), "kernel_flashkda_backward_boundary_c32_tcgen_m64 launch");
+  } else {
+    ConfigureDynamicSmem(kernel_flashkda_backward_boundary_c32_tcgen, kBoundaryM128SmemBytes,
+                         device_id, "cudaFuncSetAttribute(boundary M128)");
+    kernel_flashkda_backward_boundary_c32_tcgen<<<boundary_grid_x, kBoundaryM128Threads,
+                                                  kBoundaryM128SmemBytes, stream>>>(
+        reinterpret_cast<__nv_bfloat16*>(do_.data_ptr()),
+        reinterpret_cast<float*>(dfinal_state.data_ptr()),
+        reinterpret_cast<float*>(beta_active.data_ptr()),
+        reinterpret_cast<long long*>(cu_seqlens.data_ptr()),
+        reinterpret_cast<long long*>(cu_chunk_offsets.data_ptr()),
+        reinterpret_cast<int*>(seq_order.data_ptr()),
+        reinterpret_cast<__nv_bfloat16*>(tape_qd.data_ptr()),
+        reinterpret_cast<__nv_bfloat16*>(tape_kd.data_ptr()),
+        reinterpret_cast<__nv_bfloat16*>(tape_kr.data_ptr()),
+        reinterpret_cast<__nv_bfloat16*>(tape_j.data_ptr()),
+        reinterpret_cast<float*>(tape_restore_factor.data_ptr()),
+        reinterpret_cast<__nv_bfloat16*>(chunk_dh.data_ptr()),
+        reinterpret_cast<__nv_bfloat16*>(chunk_dr.data_ptr()),
+        reinterpret_cast<__nv_bfloat16*>(chunk_dx.data_ptr()),
+        reinterpret_cast<unsigned int*>(zero_workspace.data_ptr()),
+        reinterpret_cast<float*>(dinitial_state.data_ptr()), static_cast<int32_t>(num_heads), 1,
+        static_cast<float>(lower_bound));
+    CheckCuda(cudaGetLastError(), "kernel_flashkda_backward_boundary_c32_tcgen launch");
+  }
+
+  ConfigureDynamicSmem(kernel_flashkda_backward_local_c32_tcgen, kLocalSmemBytes, device_id,
+                       "cudaFuncSetAttribute(local tcgen)");
+  cudaLaunchAttribute local_attr[1];
+  local_attr[0].id = cudaLaunchAttributeProgrammaticStreamSerialization;
+  local_attr[0].val.programmaticStreamSerializationAllowed = 1;
+  cudaLaunchConfig_t local_config{};
+  local_config.gridDim = dim3(CheckedGridX(total_chunks * num_heads, "local"), 1, 1);
+  local_config.blockDim = dim3(kLocalThreads, 1, 1);
+  local_config.dynamicSmemBytes = kLocalSmemBytes;
+  local_config.stream = stream;
+  local_config.attrs = local_attr;
+  local_config.numAttrs = 1;
+  CheckCuda(cudaLaunchKernelEx(&local_config, kernel_flashkda_backward_local_c32_tcgen,
+                               reinterpret_cast<__nv_bfloat16*>(do_.data_ptr()),
+                               reinterpret_cast<float*>(beta_active.data_ptr()),
+                               reinterpret_cast<long long*>(cu_seqlens.data_ptr()),
+                               reinterpret_cast<int*>(consumer_chunk_order.data_ptr()),
+                               reinterpret_cast<int*>(chunk_sequence.data_ptr()),
+                               reinterpret_cast<int*>(chunk_index.data_ptr()),
+                               reinterpret_cast<__nv_bfloat16*>(chunk_state.data_ptr()),
+                               reinterpret_cast<unsigned int*>(state_checkpoint_needed.data_ptr()),
+                               reinterpret_cast<float*>(initial_state.data_ptr()),
+                               reinterpret_cast<__nv_bfloat16*>(tape_qd.data_ptr()),
+                               reinterpret_cast<__nv_bfloat16*>(tape_kd.data_ptr()),
+                               reinterpret_cast<__nv_bfloat16*>(tape_kr.data_ptr()),
+                               reinterpret_cast<__nv_bfloat16*>(tape_j.data_ptr()),
+                               reinterpret_cast<float*>(tape_restore_factor.data_ptr()),
+                               reinterpret_cast<__nv_bfloat16*>(tape_e.data_ptr()),
+                               reinterpret_cast<__nv_bfloat16*>(tape_x.data_ptr()),
+                               reinterpret_cast<__nv_bfloat16*>(tape_r.data_ptr()),
+                               reinterpret_cast<__nv_bfloat16*>(chunk_dh.data_ptr()),
+                               reinterpret_cast<__nv_bfloat16*>(chunk_dr.data_ptr()),
+                               reinterpret_cast<__nv_bfloat16*>(chunk_dx.data_ptr()),
+                               reinterpret_cast<unsigned int*>(zero_workspace.data_ptr()),
+                               reinterpret_cast<__nv_bfloat16*>(grad_qd.data_ptr()),
+                               reinterpret_cast<__nv_bfloat16*>(grad_kd.data_ptr()),
+                               reinterpret_cast<__nv_bfloat16*>(grad_ki.data_ptr()),
+                               reinterpret_cast<float*>(dlog_decay.data_ptr()),
+                               reinterpret_cast<float*>(dbeta_active.data_ptr()),
+                               reinterpret_cast<__nv_bfloat16*>(dv.data_ptr()),
+                               static_cast<int32_t>(num_heads), boundary_ready_target,
+                               static_cast<float>(lower_bound)),
+            "cudaLaunchKernelEx(kernel_flashkda_backward_local_c32_tcgen)");
+
+  const int64_t num_pair_heads = total_pairs * num_heads;
+  const uint32_t finalize_grid = CheckedGridX(((num_pair_heads + 3) / 4) * 4, "map_finalize");
+  kernel_flashkda_backward_map_finalize_c32<<<finalize_grid, kMapFinalizeThreads, 0, stream>>>(
+      reinterpret_cast<__nv_bfloat16*>(decay.data_ptr()),
+      reinterpret_cast<__nv_bfloat16*>(q.data_ptr()),
+      reinterpret_cast<__nv_bfloat16*>(k.data_ptr()), reinterpret_cast<float*>(norm_inv.data_ptr()),
+      reinterpret_cast<__nv_bfloat16*>(g.data_ptr()),
+      reinterpret_cast<float*>(beta_active.data_ptr()), reinterpret_cast<float*>(A_log.data_ptr()),
+      reinterpret_cast<float*>(dt_bias.data_ptr()),
+      reinterpret_cast<long long*>(cu_seqlens.data_ptr()),
+      reinterpret_cast<int*>(chunk_sequence.data_ptr()),
+      reinterpret_cast<int*>(chunk_index.data_ptr()),
+      reinterpret_cast<int*>(chunk_pair_start.data_ptr()),
+      reinterpret_cast<__nv_bfloat16*>(grad_qd.data_ptr()),
+      reinterpret_cast<__nv_bfloat16*>(grad_kd.data_ptr()),
+      reinterpret_cast<__nv_bfloat16*>(grad_ki.data_ptr()),
+      reinterpret_cast<float*>(dlog_decay.data_ptr()),
+      reinterpret_cast<float*>(dbeta_active.data_ptr()),
+      reinterpret_cast<__nv_bfloat16*>(dq.data_ptr()),
+      reinterpret_cast<__nv_bfloat16*>(dk.data_ptr()),
+      reinterpret_cast<__nv_bfloat16*>(dg.data_ptr()),
+      reinterpret_cast<__nv_bfloat16*>(dbeta.data_ptr()),
+      reinterpret_cast<float*>(dA_log.data_ptr()), reinterpret_cast<float*>(ddt_bias.data_ptr()),
+      static_cast<int32_t>(num_pair_heads), static_cast<int32_t>(num_heads),
+      static_cast<float>(scale), static_cast<float>(lower_bound));
+  CheckCuda(cudaGetLastError(), "kernel_flashkda_backward_map_finalize_c32 launch");
+}
+
+}  // namespace flash_kda_backward
+}  // namespace flashinfer
+
+TVM_FFI_DLL_EXPORT_TYPED_FUNC(run_low, flashinfer::flash_kda_backward::RunLow);
+TVM_FFI_DLL_EXPORT_TYPED_FUNC(run_high, flashinfer::flash_kda_backward::RunHigh);

--- a/csrc/kda/flashkda_backward_v483.cu
+++ b/csrc/kda/flashkda_backward_v483.cu
@@ -1,0 +1,6657 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Frozen generated FlashKDA C16 forward/backward bundle for exact SM100a and SM103a.
+// Generated body SHA256: 557696812b1a911362c23788de765a2cec33f08e798cd3ff89136adadcc8775d
+// clang-format off
+// BEGIN FROZEN GENERATED BODY
+typedef signed char        int8_t;
+typedef unsigned char      uint8_t;
+typedef unsigned short     uint16_t;
+typedef unsigned int       uint32_t;
+typedef unsigned long long uint64_t;
+typedef signed int         int32_t;
+typedef short int          int16_t;
+struct __align__(128) FlashKDATensorMap { uint64_t opaque[16]; };
+template <int N>
+struct __align__(128) FlashKDATensorMapPack { FlashKDATensorMap maps[N]; };
+
+typedef struct __align__(64) { uint64_t opaque[16]; } CUtensorMap;
+
+#include <cuda_bf16.h>
+
+#include <math_constants.h>
+
+__device__ __forceinline__ uint32_t elect_sync() {
+    uint32_t pred = 0;
+    asm volatile(
+        "{\n\t"
+        ".reg .pred %%px;\n\t"
+        "elect.sync _|%%px, %1;\n\t"
+        "@%%px mov.s32 %0, 1;\n\t"
+        "}\n"
+        : "+r"(pred)
+        : "r"(0xFFFFFFFF));
+    return pred;
+}
+
+__device__ __forceinline__ void mbarrier_init(int mbar_addr, int count) {
+    asm volatile("mbarrier.init.shared::cta.b64 [%0], %1;"
+        :: "r"(mbar_addr), "r"(count));
+}
+
+__device__ __forceinline__ uint32_t mbarrier_try_wait(int mbar_addr, int phase) {
+    uint32_t token;
+    asm volatile(
+        "{\n\t"
+        ".reg .pred P1;\n\t"
+        "mbarrier.try_wait.parity.acquire.cta.shared::cta.b64"
+        " P1, [%1], %2;\n\t"
+        "selp.u32 %0, 1, 0, P1;\n\t"
+        "}\n"
+        : "=r"(token)
+        : "r"(mbar_addr), "r"(phase) : "memory");
+    return token;
+}
+
+__device__ __forceinline__ uint32_t mbarrier_try_wait_cluster(int mbar_addr, int phase) {
+    uint32_t token;
+    asm volatile(
+        "{\n\t"
+        ".reg .pred P1;\n\t"
+        "mbarrier.try_wait.parity.acquire.cluster.shared::cta.b64"
+        " P1, [%1], %2;\n\t"
+        "selp.u32 %0, 1, 0, P1;\n\t"
+        "}\n"
+        : "=r"(token)
+        : "r"(mbar_addr), "r"(phase) : "memory");
+    return token;
+}
+
+__device__ __forceinline__ void mbarrier_wait(int mbar_addr, int phase) {
+    uint32_t ticks = 0x989680;
+    asm volatile(
+        "{\n\t"
+        ".reg .pred P1;\n\t"
+        "LAB_WAIT:\n\t"
+        "mbarrier.try_wait.parity.acquire.cta.shared::cta.b64"
+        " P1, [%0], %1, %2;\n\t"
+        "@P1 bra.uni DONE;\n\t"
+        "bra.uni LAB_WAIT;\n\t"
+        "DONE:\n\t"
+        "}\n"
+        :: "r"(mbar_addr), "r"(phase), "r"(ticks) : "memory");
+}
+
+__device__ __forceinline__ void mbarrier_wait_cluster(int mbar_addr, int phase) {
+    uint32_t ticks = 0x989680;
+    asm volatile(
+        "{\n\t"
+        ".reg .pred P1;\n\t"
+        "LAB_WAIT_CLUSTER:\n\t"
+        "mbarrier.try_wait.parity.acquire.cluster.shared::cta.b64"
+        " P1, [%0], %1, %2;\n\t"
+        "@P1 bra.uni DONE_CLUSTER;\n\t"
+        "bra.uni LAB_WAIT_CLUSTER;\n\t"
+        "DONE_CLUSTER:\n\t"
+        "}\n"
+        :: "r"(mbar_addr), "r"(phase), "r"(ticks) : "memory");
+}
+
+__device__ __forceinline__ void mbarrier_wait_token(int mbar_addr, int phase, uint32_t token) {
+    if (token == 0) {
+        mbarrier_wait(mbar_addr, phase);
+    }
+}
+
+__device__ __forceinline__ void mbarrier_wait_token_cluster(int mbar_addr, int phase, uint32_t token) {
+    if (token == 0) {
+        mbarrier_wait_cluster(mbar_addr, phase);
+    }
+}
+
+__device__ __forceinline__ void tcgen05_mma_f16(
+    int taddr, uint64_t a_desc, uint64_t b_desc,
+    uint32_t i_desc, int enable_input_d) {
+    asm volatile(
+        "{\n\t"
+        ".reg .pred p;\n\t"
+        "setp.ne.b32 p, %4, 0;\n\t"
+        "tcgen05.mma.cta_group::1.kind::f16 [%0], %1, %2, %3, p;\n\t"
+        "}\n"
+        :: "r"(taddr), "l"(a_desc), "l"(b_desc),
+           "r"(i_desc), "r"(enable_input_d));
+}
+
+__device__ __forceinline__ uint64_t desc_encode(uint64_t x) {
+    return (x & 0x3FFFFULL) >> 4ULL;
+}
+
+__device__ __forceinline__ void mma_ts_step(
+    int taddr_out, int taddr_a, int b_lo, uint32_t b_dhi,
+    uint32_t i_desc, int enable_d) {
+    asm volatile(
+        "{\n\t"
+        ".reg .pred leader, p;\n\t"
+        ".reg .b32 dhi;\n\t"
+        ".reg .b64 db;\n\t"
+        "elect.sync _|leader, 0xFFFFFFFF;\n\t"
+        "setp.ne.b32 p, %5, 0;\n\t"
+        "mov.b32 dhi, %3;\n\t"
+        "mov.b64 db, {%2, dhi};\n\t"
+        "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [%1], db, %4, p;\n\t"
+        "}\n"
+        :: "r"(taddr_out), "r"(taddr_a), "r"(b_lo), "r"(b_dhi),
+           "r"(i_desc), "r"(enable_d));
+}
+
+__device__ __forceinline__ void elect_commit(int mbar_addr) {
+    asm volatile(
+        "{\n\t"
+        ".reg .pred leader;\n\t"
+        "elect.sync _|leader, 0xFFFFFFFF;\n\t"
+        "@leader tcgen05.commit.cta_group::1.mbarrier::arrive::one"
+        ".shared::cluster.b64 [%0];\n\t"
+        "}\n"
+        :: "r"(mbar_addr));
+}
+
+__device__ __forceinline__ void mbarrier_arrive(int mbar_addr) {
+    asm volatile(
+        "mbarrier.arrive.release.cta.shared::cta.b64 _, [%0];"
+        :: "r"(mbar_addr) : "memory");
+}
+
+__device__ __forceinline__ void mbarrier_arrive_expect_tx(int mbar_addr, uint32_t bytes) {
+    asm volatile(
+        "mbarrier.arrive.expect_tx.release.cta.shared::cta.b64 _, [%0], %1;"
+        :: "r"(mbar_addr), "r"(bytes) : "memory");
+}
+
+__device__ __forceinline__ void tmem_ld_x32(float* dst, int tmem_addr) {
+    asm volatile(
+        "tcgen05.ld.sync.aligned.32x32b.x32.b32"
+        " {%0, %1, %2, %3, %4, %5, %6, %7,"
+        "  %8, %9, %10, %11, %12, %13, %14, %15,"
+        "  %16, %17, %18, %19, %20, %21, %22, %23,"
+        "  %24, %25, %26, %27, %28, %29, %30, %31}, [%32];"
+        : "=f"(dst[0]),  "=f"(dst[1]),  "=f"(dst[2]),  "=f"(dst[3]),
+          "=f"(dst[4]),  "=f"(dst[5]),  "=f"(dst[6]),  "=f"(dst[7]),
+          "=f"(dst[8]),  "=f"(dst[9]),  "=f"(dst[10]), "=f"(dst[11]),
+          "=f"(dst[12]), "=f"(dst[13]), "=f"(dst[14]), "=f"(dst[15]),
+          "=f"(dst[16]), "=f"(dst[17]), "=f"(dst[18]), "=f"(dst[19]),
+          "=f"(dst[20]), "=f"(dst[21]), "=f"(dst[22]), "=f"(dst[23]),
+          "=f"(dst[24]), "=f"(dst[25]), "=f"(dst[26]), "=f"(dst[27]),
+          "=f"(dst[28]), "=f"(dst[29]), "=f"(dst[30]), "=f"(dst[31])
+        : "r"(tmem_addr));
+}
+
+__device__ __forceinline__ void tmem_ld_x16(float* dst, int tmem_addr) {
+    asm volatile(
+        "tcgen05.ld.sync.aligned.32x32b.x16.b32"
+        " {%0, %1, %2, %3, %4, %5, %6, %7,"
+        "  %8, %9, %10, %11, %12, %13, %14, %15}, [%16];"
+        : "=f"(dst[0]),  "=f"(dst[1]),  "=f"(dst[2]),  "=f"(dst[3]),
+          "=f"(dst[4]),  "=f"(dst[5]),  "=f"(dst[6]),  "=f"(dst[7]),
+          "=f"(dst[8]),  "=f"(dst[9]),  "=f"(dst[10]), "=f"(dst[11]),
+          "=f"(dst[12]), "=f"(dst[13]), "=f"(dst[14]), "=f"(dst[15])
+        : "r"(tmem_addr));
+}
+
+__device__ __forceinline__ void tmem_st_x32_f32(int tmem_addr, const float* src) {
+    asm volatile(
+        "tcgen05.st.sync.aligned.32x32b.x32.b32"
+        " [%0], {%1, %2, %3, %4, %5, %6, %7, %8,"
+        "  %9, %10, %11, %12, %13, %14, %15, %16,"
+        "  %17, %18, %19, %20, %21, %22, %23, %24,"
+        "  %25, %26, %27, %28, %29, %30, %31, %32};"
+        :: "r"(tmem_addr),
+           "f"(src[0]),  "f"(src[1]),  "f"(src[2]),  "f"(src[3]),
+           "f"(src[4]),  "f"(src[5]),  "f"(src[6]),  "f"(src[7]),
+           "f"(src[8]),  "f"(src[9]),  "f"(src[10]), "f"(src[11]),
+           "f"(src[12]), "f"(src[13]), "f"(src[14]), "f"(src[15]),
+           "f"(src[16]), "f"(src[17]), "f"(src[18]), "f"(src[19]),
+           "f"(src[20]), "f"(src[21]), "f"(src[22]), "f"(src[23]),
+           "f"(src[24]), "f"(src[25]), "f"(src[26]), "f"(src[27]),
+           "f"(src[28]), "f"(src[29]), "f"(src[30]), "f"(src[31]));
+}
+
+__device__ __forceinline__ float approx_exp2(float x) {
+    float y;
+    asm("ex2.approx.ftz.f32 %0, %1;" : "=f"(y) : "f"(x));
+    return y;
+}
+
+__device__ __forceinline__ float approx_rcp(float x) {
+    float y;
+    asm("rcp.approx.ftz.f32 %0, %1;" : "=f"(y) : "f"(x));
+    return y;
+}
+
+__device__ __forceinline__ float max_noftz(float a, float b) {
+    float c;
+    asm("max.f32 %0, %1, %2;" : "=f"(c) : "f"(a), "f"(b));
+    return c;
+}
+
+__device__ __forceinline__ void fma_f32x2_inplace(float2* a, float2 b, float2 c) {
+    unsigned long long r;
+    asm("fma.rn.ftz.f32x2 %0, %1, %2, %3;"
+        : "=l"(r)
+        : "l"(*(unsigned long long*)a), "l"(*(unsigned long long*)&b),
+          "l"(*(unsigned long long*)&c));
+    *(unsigned long long*)a = r;
+}
+
+__device__ __forceinline__ void mul_f32x2_inplace(float2* a, float2 b) {
+    asm("mul.rn.ftz.f32x2 %0, %0, %1;"
+        : "+l"(*(unsigned long long*)a) : "l"(*(unsigned long long*)&b));
+}
+
+__device__ __forceinline__ void add_f32x2_inplace(float2* a, float2 b) {
+    asm("add.rn.ftz.f32x2 %0, %0, %1;"
+        : "+l"(*(unsigned long long*)a) : "l"(*(unsigned long long*)&b));
+}
+
+__device__ __forceinline__ void sub_f32x2_inplace(float2* a, float2 b) {
+    asm("sub.rn.ftz.f32x2 %0, %0, %1;"
+        : "+l"(*(unsigned long long*)a) : "l"(*(unsigned long long*)&b));
+}
+
+__device__ __forceinline__ float2 add_f32x2(float2 a, float2 b) {
+    float2 r;
+    asm("add.rn.ftz.f32x2 %0, %1, %2;"
+        : "=l"(*(unsigned long long*)&r)
+        : "l"(*(unsigned long long*)&a), "l"(*(unsigned long long*)&b));
+    return r;
+}
+
+__device__ __forceinline__ float2 sub_f32x2(float2 a, float2 b) {
+    float2 r;
+    asm("sub.rn.ftz.f32x2 %0, %1, %2;"
+        : "=l"(*(unsigned long long*)&r)
+        : "l"(*(unsigned long long*)&a), "l"(*(unsigned long long*)&b));
+    return r;
+}
+
+__device__ __forceinline__ void fma_scale_x32(
+    float* sv, const float2* scale2, const float2* neg_max2)
+{
+    float2* sv_2 = reinterpret_cast<float2*>(sv);
+
+#pragma unroll
+
+for (int j = 0; j < 16; j++)
+        fma_f32x2_inplace(&sv_2[j], *scale2, *neg_max2);
+}
+
+__device__ __forceinline__ float2 fma_f32x2(float2 a, float2 b, float2 c) {
+    float2 r;
+    asm("fma.rn.ftz.f32x2 %0, %1, %2, %3;"
+        : "=l"(*(unsigned long long*)&r)
+        : "l"(*(unsigned long long*)&a), "l"(*(unsigned long long*)&b),
+          "l"(*(unsigned long long*)&c));
+    return r;
+}
+
+__device__ __forceinline__ float2 fma_sub_f32x2(float2 a, float2 b, float2 c) {
+    float2 r;
+    asm volatile("{\n\t"
+        ".reg .f32 _c0, _c1;\n\t"
+        ".reg .b64 _neg_c;\n\t"
+        "mov.b64 {_c0, _c1}, %3;\n\t"
+        "neg.f32 _c0, _c0;\n\t"
+        "neg.f32 _c1, _c1;\n\t"
+        "mov.b64 _neg_c, {_c0, _c1};\n\t"
+        "fma.rn.ftz.f32x2 %0, %1, %2, _neg_c;\n\t"
+        "}\n"
+        : "=l"(*(unsigned long long*)&r)
+        : "l"(*(unsigned long long*)&a), "l"(*(unsigned long long*)&b),
+          "l"(*(unsigned long long*)&c));
+    return r;
+}
+
+__device__ __forceinline__ float2 mul_f32x2(float2 a, float2 b) {
+    float2 r;
+    asm("mul.rn.ftz.f32x2 %0, %1, %2;"
+        : "=l"(*(unsigned long long*)&r)
+        : "l"(*(unsigned long long*)&a), "l"(*(unsigned long long*)&b));
+    return r;
+}
+
+// ex2_emulation_f32x2 defined in softmax_frag_exp2_cast helper (or standalone)
+
+__device__ __forceinline__ void elect_commit2(int mbar_addr0, int mbar_addr1) {
+    asm volatile(
+        "{\n\t"
+        ".reg .pred leader;\n\t"
+        "elect.sync _|leader, 0xFFFFFFFF;\n\t"
+        "@leader tcgen05.commit.cta_group::1.mbarrier::arrive::one"
+        ".shared::cluster.b64 [%0];\n\t"
+        "@leader tcgen05.commit.cta_group::1.mbarrier::arrive::one"
+        ".shared::cluster.b64 [%1];\n\t"
+        "}\n"
+        :: "r"(mbar_addr0), "r"(mbar_addr1) : "memory");
+}
+
+__device__ __forceinline__ void fence_async_shared() {
+    asm volatile("fence.proxy.async.shared::cta;" ::: "memory");
+}
+
+__device__ __forceinline__ uint64_t make_smem_desc(int addr) {
+    const int SBO = 1024;
+    return desc_encode(addr)
+         | (desc_encode(SBO) << 32ULL)
+         | (1ULL << 46ULL)
+         | (2ULL << 61ULL);
+}
+
+__device__ __forceinline__ void tma_3d_gmem2smem(
+    int dst, const void *tmap_ptr, int x, int y, int z, int mbar_addr) {
+    asm volatile(
+        "cp.async.bulk.tensor.3d.shared::cta.global"
+        ".mbarrier::complete_tx::bytes"
+        " [%0], [%1, {%2, %3, %4}], [%5];"
+        :: "r"(dst), "l"(tmap_ptr), "r"(x), "r"(y), "r"(z),
+           "r"(mbar_addr) : "memory");
+}
+
+__device__ __forceinline__ void tma_4d_gmem2smem(
+    int dst, const void *tmap_ptr, int x, int y, int z, int w, int mbar_addr) {
+    asm volatile(
+        "cp.async.bulk.tensor.4d.shared::cta.global"
+        ".mbarrier::complete_tx::bytes"
+        " [%0], [%1, {%2, %3, %4, %5}], [%6];"
+        :: "r"(dst), "l"(tmap_ptr), "r"(x), "r"(y), "r"(z), "r"(w),
+           "r"(mbar_addr) : "memory");
+}
+
+__device__ __forceinline__ void tma_store_3d(
+    const void *tmap, int x, int y, int z, unsigned smem_addr) {
+    asm volatile(
+        "cp.async.bulk.tensor.3d.global.shared::cta.tile.bulk_group"
+        " [%0, {%1, %2, %3}], [%4];"
+        :: "l"(tmap), "r"(x), "r"(y), "r"(z), "r"(smem_addr) : "memory");
+}
+
+__device__ __forceinline__ void tma_store_4d(
+    const void *tmap, int x, int y, int z, int w, unsigned smem_addr) {
+    asm volatile(
+        "cp.async.bulk.tensor.4d.global.shared::cta.tile.bulk_group"
+        " [%0, {%1, %2, %3, %4}], [%5];"
+        :: "l"(tmap), "r"(x), "r"(y), "r"(z), "r"(w), "r"(smem_addr) : "memory");
+}
+
+__device__ __forceinline__ void tcgen05_commit(int mbar_addr) {
+    asm volatile(
+        "tcgen05.commit.cta_group::1.mbarrier::arrive::one"
+        ".shared::cluster.b64 [%0];"
+        :: "r"(mbar_addr) : "memory");
+}
+
+__device__ __forceinline__ void tmem_ld_x8(float* dst, int tmem_addr) {
+    asm volatile(
+        "tcgen05.ld.sync.aligned.32x32b.x8.b32"
+        " {%0, %1, %2, %3, %4, %5, %6, %7}, [%8];"
+        : "=f"(dst[0]), "=f"(dst[1]), "=f"(dst[2]), "=f"(dst[3]),
+          "=f"(dst[4]), "=f"(dst[5]), "=f"(dst[6]), "=f"(dst[7])
+        : "r"(tmem_addr));
+}
+
+__device__ __forceinline__ void tmem_st_x8_u32(int addr, const uint32_t* src) {
+    asm volatile(
+        "tcgen05.st.sync.aligned.32x32b.x8.b32"
+        " [%0], {%1,%2,%3,%4,%5,%6,%7,%8};"
+        :: "r"(addr),
+           "r"(src[0]), "r"(src[1]), "r"(src[2]), "r"(src[3]),
+           "r"(src[4]), "r"(src[5]), "r"(src[6]), "r"(src[7]));
+}
+
+__device__ __forceinline__ uint32_t make_warp_uniform(uint32_t val) {
+    uint32_t result;
+    asm volatile("shfl.sync.idx.b32 %0, %1, 0, 0x1f, 0xffffffff;"
+        : "=r"(result) : "r"(val));
+    return result;
+}
+
+__device__ __forceinline__ void mma_ss_step(
+    int a_lo, int b_lo, int taddr, uint32_t i_desc, int enable_d,
+    uint32_t a_dhi, uint32_t b_dhi) {
+    asm volatile(
+        "{\n\t"
+        ".reg .pred leader, p;\n\t"
+        ".reg .b32 adhi, bdhi;\n\t"
+        ".reg .b64 da, db;\n\t"
+        "elect.sync _|leader, 0xFFFFFFFF;\n\t"
+        "setp.ne.b32 p, %4, 0;\n\t"
+        "mov.b32 adhi, %5;\n\t"
+        "mov.b32 bdhi, %6;\n\t"
+        "mov.b64 da, {%0, adhi};\n\t"
+        "mov.b64 db, {%1, bdhi};\n\t"
+        "@leader tcgen05.mma.cta_group::1.kind::f16 [%2], da, db, %3, p;\n\t"
+        "}\n"
+        :: "r"(a_lo), "r"(b_lo), "r"(taddr), "r"(i_desc), "r"(enable_d), "r"(a_dhi), "r"(b_dhi));
+}
+
+__device__ __forceinline__ void tma_2d_gmem2smem(
+    int dst, const void *tmap_ptr, int x, int y, int mbar_addr) {
+    asm volatile(
+        "cp.async.bulk.tensor.2d.shared::cta.global"
+        ".mbarrier::complete_tx::bytes"
+        " [%0], [%1, {%2, %3}], [%4];"
+        :: "r"(dst), "l"(tmap_ptr), "r"(x), "r"(y),
+           "r"(mbar_addr) : "memory");
+}
+
+#define FLASH_KDA_INF CUDART_INF_F
+#define TMEM_NCOLS 272
+#define TMEM_TMEM_STATE_OFFSET 0
+#define TMEM_TMEM_STATE_INP_OFFSET 128
+#define TMEM_TMEM_Q_STATE_OFFSET 192
+#define TMEM_TMEM_STATE_K_OFFSET 224
+#define TMEM_TMEM_U_ACC_OFFSET 240
+#define TMEM_TMEM_Y_INP_OFFSET 256
+#define TMEM_TMEM_U_INP_OFFSET 264
+#define NUM_SCHED_PIPE_STAGES 8
+#define NUM_RAW_PIPE_STAGES 5
+#define NUM_RAW_BAR_PIPE_STAGES 6
+#define NUM_DECAY_PIPE_STAGES 2
+#define NUM_INTERMEDIATE_PIPE_STAGES 2
+#define NUM_DIAG_PIPE_STAGES 4
+#define NUM_STATE_PIPE_STAGES 1
+#define NUM_O_PIPE_STAGES 2
+#define NUM_CHECKPOINT_PIPE_STAGES 2
+#define SMEM_SMEM_Q_OFF 1024
+#define SMEM_SMEM_Q_STAGE_BYTES 4096
+#define SMEM_SMEM_Q_STRIDE 4096
+#define SMEM_SMEM_K_OFF 21504
+#define SMEM_SMEM_K_STAGE_BYTES 4096
+#define SMEM_SMEM_K_STRIDE 4096
+#define SMEM_SMEM_V_OFF 41984
+#define SMEM_SMEM_V_STAGE_BYTES 4096
+#define SMEM_SMEM_V_STRIDE 4096
+#define SMEM_SMEM_G_OFF 62464
+#define SMEM_SMEM_G_STAGE_BYTES 8192
+#define SMEM_SMEM_G_STRIDE 8192
+#define SMEM_SMEM_BETA_OFF 103424
+#define SMEM_SMEM_BETA_STAGE_BYTES 32
+#define SMEM_SMEM_BETA_STRIDE 32
+#define SMEM_SMEM_BETA_ALL_OFF 103424
+#define SMEM_SMEM_BETA_ALL_STAGE_BYTES 192
+#define SMEM_SMEM_BETA_ALL_STRIDE 192
+#define SMEM_SMEM_K_INV_OFF 104448
+#define SMEM_SMEM_K_INV_STAGE_BYTES 4096
+#define SMEM_SMEM_K_INV_STRIDE 4096
+#define SMEM_SMEM_K_DECAY_OFF 112640
+#define SMEM_SMEM_K_DECAY_STAGE_BYTES 4096
+#define SMEM_SMEM_K_DECAY_STRIDE 4096
+#define SMEM_SMEM_Q_DECAY_OFF 120832
+#define SMEM_SMEM_Q_DECAY_STAGE_BYTES 4096
+#define SMEM_SMEM_Q_DECAY_STRIDE 4096
+#define SMEM_SMEM_K_RESTORE_OFF 129024
+#define SMEM_SMEM_K_RESTORE_STAGE_BYTES 4096
+#define SMEM_SMEM_K_RESTORE_STRIDE 4096
+#define SMEM_SMEM_K_RESTORE_MN_OFF 129024
+#define SMEM_SMEM_K_RESTORE_MN_STAGE_BYTES 4096
+#define SMEM_SMEM_K_RESTORE_MN_STRIDE 4096
+#define SMEM_SMEM_TINV_OFF 137216
+#define SMEM_SMEM_TINV_STAGE_BYTES 512
+#define SMEM_SMEM_TINV_STRIDE 1024
+#define SMEM_SMEM_A_OFF 137728
+#define SMEM_SMEM_A_STAGE_BYTES 512
+#define SMEM_SMEM_A_STRIDE 1024
+#define SMEM_SMEM_TINV_MN_OFF 137216
+#define SMEM_SMEM_TINV_MN_STAGE_BYTES 512
+#define SMEM_SMEM_TINV_MN_STRIDE 1024
+#define SMEM_SMEM_A_MN_OFF 137728
+#define SMEM_SMEM_A_MN_STAGE_BYTES 512
+#define SMEM_SMEM_A_MN_STRIDE 1024
+#define SMEM_SMEM_STATE_DIAG_OFF 139264
+#define SMEM_SMEM_STATE_DIAG_STAGE_BYTES 512
+#define SMEM_SMEM_STATE_DIAG_STRIDE 512
+#define SMEM_SMEM_O_OFF 155648
+#define SMEM_SMEM_O_STAGE_BYTES 4096
+#define SMEM_SMEM_O_STRIDE 4096
+#define SMEM_SMEM_CHECKPOINT_OFF 163840
+#define SMEM_SMEM_CHECKPOINT_STAGE_BYTES 32768
+#define SMEM_SMEM_CHECKPOINT_STRIDE 32768
+#define SMEM_TINV_SCRATCH_OFF 229376
+#define SMEM_TINV_SCRATCH_STAGE_BYTES 512
+#define SMEM_TINV_SCRATCH_STRIDE 512
+#define SMEM_SCHED_SLOT_OFF 229888
+#define SMEM_SCHED_SLOT_STAGE_BYTES 4
+#define SMEM_SCHED_SLOT_STRIDE 4
+#define SMEM_SMEM_Q_ALL_OFF 1024
+#define SMEM_SMEM_Q_ALL_STAGE_BYTES 20480
+#define SMEM_SMEM_Q_ALL_STRIDE 20480
+#define SMEM_SMEM_K_ALL_OFF 21504
+#define SMEM_SMEM_K_ALL_STAGE_BYTES 20480
+#define SMEM_SMEM_K_ALL_STRIDE 20480
+#define SMEM_SMEM_G_ALL_OFF 62464
+#define SMEM_SMEM_G_ALL_STAGE_BYTES 40960
+#define SMEM_SMEM_G_ALL_STRIDE 40960
+#define SMEM_SMEM_V_ALL_OFF 41984
+#define SMEM_SMEM_V_ALL_STAGE_BYTES 20480
+#define SMEM_SMEM_V_ALL_STRIDE 20480
+#define SMEM_SMEM_O_ALL_OFF 155648
+#define SMEM_SMEM_O_ALL_STAGE_BYTES 8192
+#define SMEM_SMEM_O_ALL_STRIDE 8192
+#define SMEM_TOTAL 230016
+#define THREADS 512
+#define USE_INITIAL_STATE 1
+#define STORE_FINAL_STATE 0
+#define ENABLE_CHECKPOINTS 1
+#define STORE_BETA_ACTIVE 1
+#define G_INPUT_BF16 1
+
+
+__device__ __forceinline__ unsigned int __as_u32(float v) {
+    unsigned int u;
+    asm("mov.b32 %0, %1;" : "=r"(u) : "f"(v));
+    return u;
+}
+__device__ __forceinline__ unsigned int __as_u32(__nv_bfloat162 v) {
+    return *reinterpret_cast<const unsigned int*>(&v);
+}
+__device__ __forceinline__ unsigned int __as_u32(unsigned int v) { return v; }
+__device__ __forceinline__ unsigned int __as_u32(int v) {
+    unsigned int u;
+    asm("mov.b32 %0, %1;" : "=r"(u) : "r"(v));
+    return u;
+}
+
+__device__ __forceinline__ __nv_bfloat162 __as_bf16x2(unsigned int v) {
+    __nv_bfloat162_raw raw;
+    raw.x = static_cast<unsigned short>(v);
+    raw.y = static_cast<unsigned short>(v >> 16);
+    return __nv_bfloat162(raw);
+}
+
+extern "C" {
+
+__global__ __launch_bounds__(512, 1) void
+kernel_flashkda_forward_checkpoint_c16(unsigned int* __restrict__ dynamic_counter, FlashKDATensorMap const* q_tma, FlashKDATensorMap const* k_tma, FlashKDATensorMap const* v_tma, FlashKDATensorMap const* g_tma, __nv_bfloat16* __restrict__ g, FlashKDATensorMap const* out_tma, FlashKDATensorMap const* checkpoint_tma, __nv_bfloat16* __restrict__ beta, __nv_bfloat16* __restrict__ beta_active_out, float* __restrict__ A_log, float* __restrict__ dt_bias, long long* __restrict__ cu_seqlens, long long* __restrict__ checkpoint_cu_starts, int* __restrict__ work_items, float* __restrict__ initial_state, __nv_bfloat16* __restrict__ final_state, int total_work_items, int uniform_work_items, int num_heads, int checkpoint_every_n_tokens, float scale, float lower_bound)
+{
+    const int tid = threadIdx.x;
+    const int warp = make_warp_uniform(tid / 32);
+    const int lane = tid % 32;
+
+    extern __shared__ __align__(1024) char smem_raw[];
+    int smem;
+    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+
+    const int bid = blockIdx.x;
+    const int num_bids = gridDim.x;
+    if (tid == 0) {
+        asm volatile("fence.proxy.tensormap::generic.acquire.sys [%0], 128;" :: "l"((uint64_t)(q_tma)) : "memory");
+        asm volatile("fence.proxy.tensormap::generic.acquire.sys [%0], 128;" :: "l"((uint64_t)(k_tma)) : "memory");
+        asm volatile("fence.proxy.tensormap::generic.acquire.sys [%0], 128;" :: "l"((uint64_t)(v_tma)) : "memory");
+        asm volatile("fence.proxy.tensormap::generic.acquire.sys [%0], 128;" :: "l"((uint64_t)(g_tma)) : "memory");
+        asm volatile("fence.proxy.tensormap::generic.acquire.sys [%0], 128;" :: "l"((uint64_t)(out_tma)) : "memory");
+        asm volatile("fence.proxy.tensormap::generic.acquire.sys [%0], 128;" :: "l"((uint64_t)(checkpoint_tma)) : "memory");
+    }
+    __syncthreads();
+
+
+    // Kernel setup ops
+    __nv_bfloat16* smem_q = reinterpret_cast<__nv_bfloat16*>(smem_raw + 1024);
+    const int smem_q_addr = smem + 1024;
+    __nv_bfloat16* smem_k = reinterpret_cast<__nv_bfloat16*>(smem_raw + 21504);
+    const int smem_k_addr = smem + 21504;
+    __nv_bfloat16* smem_v = reinterpret_cast<__nv_bfloat16*>(smem_raw + 41984);
+    const int smem_v_addr = smem + 41984;
+    float* smem_g = reinterpret_cast<float*>(smem_raw + 62464);
+    const int smem_g_addr = smem + 62464;
+    __nv_bfloat16* smem_beta = reinterpret_cast<__nv_bfloat16*>(smem_raw + 103424);
+    const int smem_beta_addr = smem + 103424;
+    __nv_bfloat16* smem_beta_all = reinterpret_cast<__nv_bfloat16*>(smem_raw + 103424);
+    const int smem_beta_all_addr = smem + 103424;
+    __nv_bfloat16* smem_k_inv = reinterpret_cast<__nv_bfloat16*>(smem_raw + 104448);
+    const int smem_k_inv_addr = smem + 104448;
+    __nv_bfloat16* smem_k_decay = reinterpret_cast<__nv_bfloat16*>(smem_raw + 112640);
+    const int smem_k_decay_addr = smem + 112640;
+    __nv_bfloat16* smem_q_decay = reinterpret_cast<__nv_bfloat16*>(smem_raw + 120832);
+    const int smem_q_decay_addr = smem + 120832;
+    __nv_bfloat16* smem_k_restore = reinterpret_cast<__nv_bfloat16*>(smem_raw + 129024);
+    const int smem_k_restore_addr = smem + 129024;
+    __nv_bfloat16* smem_k_restore_mn = reinterpret_cast<__nv_bfloat16*>(smem_raw + 129024);
+    const int smem_k_restore_mn_addr = smem + 129024;
+    __nv_bfloat16* smem_tinv = reinterpret_cast<__nv_bfloat16*>(smem_raw + 137216);
+    const int smem_tinv_addr = smem + 137216;
+    __nv_bfloat16* smem_a = reinterpret_cast<__nv_bfloat16*>(smem_raw + 137728);
+    const int smem_a_addr = smem + 137728;
+    __nv_bfloat16* smem_tinv_mn = reinterpret_cast<__nv_bfloat16*>(smem_raw + 137216);
+    const int smem_tinv_mn_addr = smem + 137216;
+    __nv_bfloat16* smem_a_mn = reinterpret_cast<__nv_bfloat16*>(smem_raw + 137728);
+    const int smem_a_mn_addr = smem + 137728;
+    __nv_bfloat16* smem_state_diag = reinterpret_cast<__nv_bfloat16*>(smem_raw + 139264);
+    const int smem_state_diag_addr = smem + 139264;
+    __nv_bfloat16* smem_o = reinterpret_cast<__nv_bfloat16*>(smem_raw + 155648);
+    const int smem_o_addr = smem + 155648;
+    __nv_bfloat16* smem_checkpoint = reinterpret_cast<__nv_bfloat16*>(smem_raw + 163840);
+    const int smem_checkpoint_addr = smem + 163840;
+    __nv_bfloat16* tinv_scratch = reinterpret_cast<__nv_bfloat16*>(smem_raw + 229376);
+    const int tinv_scratch_addr = smem + 229376;
+    unsigned int* sched_slot = reinterpret_cast<unsigned int*>(smem_raw + 229888);
+    const int sched_slot_addr = smem + 229888;
+    __nv_bfloat16* smem_q_all = reinterpret_cast<__nv_bfloat16*>(smem_raw + 1024);
+    const int smem_q_all_addr = smem + 1024;
+    __nv_bfloat16* smem_k_all = reinterpret_cast<__nv_bfloat16*>(smem_raw + 21504);
+    const int smem_k_all_addr = smem + 21504;
+    float* smem_g_all = reinterpret_cast<float*>(smem_raw + 62464);
+    const int smem_g_all_addr = smem + 62464;
+    __nv_bfloat16* smem_v_all = reinterpret_cast<__nv_bfloat16*>(smem_raw + 41984);
+    const int smem_v_all_addr = smem + 41984;
+    __nv_bfloat16* smem_o_all = reinterpret_cast<__nv_bfloat16*>(smem_raw + 155648);
+    const int smem_o_all_addr = smem + 155648;
+
+    // Mbarrier init (37 groups, 116 barriers)
+    // Mbarriers at smem_raw[0..928)
+
+    if (warp == 0) {
+        uint32_t leader = elect_sync();
+        if (leader) {
+            // --- pipeline 'sched_pipe' ---
+            // sched_ready: 8 barriers, init_count=1
+            mbarrier_init(smem + 0, 1);
+            mbarrier_init(smem + 8, 1);
+            mbarrier_init(smem + 16, 1);
+            mbarrier_init(smem + 24, 1);
+            mbarrier_init(smem + 32, 1);
+            mbarrier_init(smem + 40, 1);
+            mbarrier_init(smem + 48, 1);
+            mbarrier_init(smem + 56, 1);
+            // sched_done: 8 barriers, init_count=15
+            mbarrier_init(smem + 64, 15);
+            mbarrier_init(smem + 72, 15);
+            mbarrier_init(smem + 80, 15);
+            mbarrier_init(smem + 88, 15);
+            mbarrier_init(smem + 96, 15);
+            mbarrier_init(smem + 104, 15);
+            mbarrier_init(smem + 112, 15);
+            mbarrier_init(smem + 120, 15);
+            // --- pipeline 'raw_bar_pipe' ---
+            // q_ready: 6 barriers, init_count=1
+            mbarrier_init(smem + 128, 1);
+            mbarrier_init(smem + 136, 1);
+            mbarrier_init(smem + 144, 1);
+            mbarrier_init(smem + 152, 1);
+            mbarrier_init(smem + 160, 1);
+            mbarrier_init(smem + 168, 1);
+            // k_ready: 6 barriers, init_count=1
+            mbarrier_init(smem + 176, 1);
+            mbarrier_init(smem + 184, 1);
+            mbarrier_init(smem + 192, 1);
+            mbarrier_init(smem + 200, 1);
+            mbarrier_init(smem + 208, 1);
+            mbarrier_init(smem + 216, 1);
+            // v_ready: 6 barriers, init_count=1
+            mbarrier_init(smem + 224, 1);
+            mbarrier_init(smem + 232, 1);
+            mbarrier_init(smem + 240, 1);
+            mbarrier_init(smem + 248, 1);
+            mbarrier_init(smem + 256, 1);
+            mbarrier_init(smem + 264, 1);
+            // g_ready: 6 barriers, init_count=1
+            mbarrier_init(smem + 272, 1);
+            mbarrier_init(smem + 280, 1);
+            mbarrier_init(smem + 288, 1);
+            mbarrier_init(smem + 296, 1);
+            mbarrier_init(smem + 304, 1);
+            mbarrier_init(smem + 312, 1);
+            // --- pipeline 'raw_pipe' ---
+            // q_done: 5 barriers, init_count=128
+            mbarrier_init(smem + 320, 128);
+            mbarrier_init(smem + 328, 128);
+            mbarrier_init(smem + 336, 128);
+            mbarrier_init(smem + 344, 128);
+            mbarrier_init(smem + 352, 128);
+            // k_done: 5 barriers, init_count=128
+            mbarrier_init(smem + 360, 128);
+            mbarrier_init(smem + 368, 128);
+            mbarrier_init(smem + 376, 128);
+            mbarrier_init(smem + 384, 128);
+            mbarrier_init(smem + 392, 128);
+            // g_done: 5 barriers, init_count=128
+            mbarrier_init(smem + 400, 128);
+            mbarrier_init(smem + 408, 128);
+            mbarrier_init(smem + 416, 128);
+            mbarrier_init(smem + 424, 128);
+            mbarrier_init(smem + 432, 128);
+            // v_done: 5 barriers, init_count=128
+            mbarrier_init(smem + 440, 128);
+            mbarrier_init(smem + 448, 128);
+            mbarrier_init(smem + 456, 128);
+            mbarrier_init(smem + 464, 128);
+            mbarrier_init(smem + 472, 128);
+            // --- pipeline 'raw_bar_pipe' ---
+            // beta_ready: 6 barriers, init_count=32
+            mbarrier_init(smem + 480, 32);
+            mbarrier_init(smem + 488, 32);
+            mbarrier_init(smem + 496, 32);
+            mbarrier_init(smem + 504, 32);
+            mbarrier_init(smem + 512, 32);
+            mbarrier_init(smem + 520, 32);
+            // beta_done: 6 barriers, init_count=160
+            mbarrier_init(smem + 528, 160);
+            mbarrier_init(smem + 536, 160);
+            mbarrier_init(smem + 544, 160);
+            mbarrier_init(smem + 552, 160);
+            mbarrier_init(smem + 560, 160);
+            mbarrier_init(smem + 568, 160);
+            // --- pipeline 'decay_pipe' ---
+            // k_decay_inv_ready: 2 barriers, init_count=128
+            mbarrier_init(smem + 576, 128);
+            mbarrier_init(smem + 584, 128);
+            // --- pipeline 'diag_pipe' ---
+            // qk_scale_ready: 4 barriers, init_count=128
+            mbarrier_init(smem + 592, 128);
+            mbarrier_init(smem + 600, 128);
+            mbarrier_init(smem + 608, 128);
+            mbarrier_init(smem + 616, 128);
+            // --- pipeline 'decay_pipe' ---
+            // decay_tcgen_done: 2 barriers, init_count=1
+            mbarrier_init(smem + 624, 1);
+            mbarrier_init(smem + 632, 1);
+            // decay_super_done: 2 barriers, init_count=64
+            mbarrier_init(smem + 640, 64);
+            mbarrier_init(smem + 648, 64);
+            // k_restore_done: 2 barriers, init_count=1
+            mbarrier_init(smem + 656, 1);
+            mbarrier_init(smem + 664, 1);
+            // --- pipeline 'diag_pipe' ---
+            // state_diag_done: 4 barriers, init_count=1
+            mbarrier_init(smem + 672, 1);
+            mbarrier_init(smem + 680, 1);
+            mbarrier_init(smem + 688, 1);
+            mbarrier_init(smem + 696, 1);
+            // --- pipeline 'intermediate_pipe' ---
+            // tinv_ready: 2 barriers, init_count=32
+            mbarrier_init(smem + 704, 32);
+            mbarrier_init(smem + 712, 32);
+            // tinv_done: 2 barriers, init_count=1
+            mbarrier_init(smem + 720, 1);
+            mbarrier_init(smem + 728, 1);
+            // a_ready: 2 barriers, init_count=32
+            mbarrier_init(smem + 736, 32);
+            mbarrier_init(smem + 744, 32);
+            // a_done: 2 barriers, init_count=1
+            mbarrier_init(smem + 752, 1);
+            mbarrier_init(smem + 760, 1);
+            // --- pipeline 'state_pipe' ---
+            // state_inp_ready: 1 barriers, init_count=128
+            mbarrier_init(smem + 768, 128);
+            // state_read_done: 1 barriers, init_count=128
+            mbarrier_init(smem + 776, 128);
+            // state_acc_done: 1 barriers, init_count=1
+            mbarrier_init(smem + 784, 1);
+            // state_k_ready: 1 barriers, init_count=1
+            mbarrier_init(smem + 792, 1);
+            // y_inp_ready: 1 barriers, init_count=128
+            mbarrier_init(smem + 800, 128);
+            // u_acc_ready: 1 barriers, init_count=1
+            mbarrier_init(smem + 808, 1);
+            // u_inp_ready: 1 barriers, init_count=128
+            mbarrier_init(smem + 816, 128);
+            // o_acc_ready: 1 barriers, init_count=1
+            mbarrier_init(smem + 824, 1);
+            // --- pipeline 'o_pipe' ---
+            // o_acc_done: 2 barriers, init_count=128
+            mbarrier_init(smem + 832, 128);
+            mbarrier_init(smem + 840, 128);
+            // o_tma_ready: 2 barriers, init_count=128
+            mbarrier_init(smem + 848, 128);
+            mbarrier_init(smem + 856, 128);
+            // o_tma_done: 2 barriers, init_count=32
+            mbarrier_init(smem + 864, 32);
+            mbarrier_init(smem + 872, 32);
+            // --- pipeline 'checkpoint_pipe' ---
+            // checkpoint_ready: 2 barriers, init_count=128
+            mbarrier_init(smem + 880, 128);
+            mbarrier_init(smem + 888, 128);
+            // checkpoint_done: 2 barriers, init_count=32
+            mbarrier_init(smem + 896, 32);
+            mbarrier_init(smem + 904, 32);
+            // consumers_done: 1 barriers, init_count=15
+            mbarrier_init(smem + 912, 15);
+            // cleanup_ready: 1 barriers, init_count=1
+            mbarrier_init(smem + 920, 1);
+            asm volatile("fence.mbarrier_init.release.cluster;");
+        }
+    }
+
+    __syncwarp();
+
+    // TMEM alloc (512 columns, 272 used)
+    volatile int* tmem_addr_storage = (volatile int*)(smem_raw + 928);
+    if (warp == 13) {
+        int _tmem_hold = smem + 928;
+        asm volatile("tcgen05.alloc.cta_group::1.sync.aligned.shared::cta.b32 [%0], %1;" :: "r"(_tmem_hold), "r"(512) : "memory");
+        asm volatile("tcgen05.relinquish_alloc_permit.cta_group::1.sync.aligned;");
+    }
+
+    __syncthreads();
+    asm volatile("tcgen05.fence::after_thread_sync;");
+
+    const int mbar_base = smem;
+    #define sched_ready_addr (mbar_base + 0)
+    #define sched_done_addr (mbar_base + 64)
+    #define q_ready_addr (mbar_base + 128)
+    #define k_ready_addr (mbar_base + 176)
+    #define v_ready_addr (mbar_base + 224)
+    #define g_ready_addr (mbar_base + 272)
+    #define q_done_addr (mbar_base + 320)
+    #define k_done_addr (mbar_base + 360)
+    #define g_done_addr (mbar_base + 400)
+    #define v_done_addr (mbar_base + 440)
+    #define beta_ready_addr (mbar_base + 480)
+    #define beta_done_addr (mbar_base + 528)
+    #define k_decay_inv_ready_addr (mbar_base + 576)
+    #define qk_scale_ready_addr (mbar_base + 592)
+    #define decay_tcgen_done_addr (mbar_base + 624)
+    #define decay_super_done_addr (mbar_base + 640)
+    #define k_restore_done_addr (mbar_base + 656)
+    #define state_diag_done_addr (mbar_base + 672)
+    #define tinv_ready_addr (mbar_base + 704)
+    #define tinv_done_addr (mbar_base + 720)
+    #define a_ready_addr (mbar_base + 736)
+    #define a_done_addr (mbar_base + 752)
+    #define state_inp_ready_addr (mbar_base + 768)
+    #define state_read_done_addr (mbar_base + 776)
+    #define state_acc_done_addr (mbar_base + 784)
+    #define state_k_ready_addr (mbar_base + 792)
+    #define y_inp_ready_addr (mbar_base + 800)
+    #define u_acc_ready_addr (mbar_base + 808)
+    #define u_inp_ready_addr (mbar_base + 816)
+    #define o_acc_ready_addr (mbar_base + 824)
+    #define o_acc_done_addr (mbar_base + 832)
+    #define o_tma_ready_addr (mbar_base + 848)
+    #define o_tma_done_addr (mbar_base + 864)
+    #define checkpoint_ready_addr (mbar_base + 880)
+    #define checkpoint_done_addr (mbar_base + 896)
+    #define consumers_done_addr (mbar_base + 912)
+    #define cleanup_ready_addr (mbar_base + 920)
+    const int taddr = tmem_addr_storage[0];
+
+    // Kernel post-init ops
+    const int tmem_tmem_state = taddr;
+    const int tmem_tmem_state_inp = taddr + 128;
+    const int tmem_tmem_q_state = taddr + 192;
+    const int tmem_tmem_state_k = taddr + 224;
+    const int tmem_tmem_u_acc = taddr + 240;
+    const int tmem_tmem_y_inp = taddr + 256;
+    const int tmem_tmem_u_inp = taddr + 264;
+
+    // ---- Register redistribution for WGs split across roles ----
+    // Dec phase frees registers before any WG attempts inc.
+    if (warp >= 12 && warp <= 15) {
+        asm volatile("setmaxnreg.dec.sync.aligned.u32 56;");
+    }
+
+    // ---- Role: cg0 ----
+    if (warp <= 7) {
+        asm volatile("setmaxnreg.inc.sync.aligned.u32 160;");
+        { // cg0_main
+            unsigned int sched_stage_cg0 = 0;
+            int cumulative_chunk_cg0 = 0;
+            int instance_id = (warp - 0) / 4;
+            int cg0_instance = instance_id;
+            int warp_id_in_role = (warp - 0);
+            int cg0_local_warp = warp_id_in_role - cg0_instance * 4;
+            int cg0_tid = cg0_local_warp * 32 + lane;
+            unsigned int _phase_sched_ready = 0;
+            #pragma unroll 1
+            for (int _ = 0; _ < total_work_items + 1; _++) {
+                mbarrier_wait(sched_ready_addr + (sched_stage_cg0) * 8, _phase_sched_ready);
+                unsigned int slot[1];
+                asm volatile("ld.shared.b32 %0, [%1];" : "=r"(*reinterpret_cast<uint32_t*>(&slot[0])) : "r"(sched_slot_addr + sched_stage_cg0 * 4));
+                unsigned int tile_cg0 = slot[0];
+                if (elect_sync()) {
+                    mbarrier_arrive(sched_done_addr + (sched_stage_cg0) * 8);
+                }
+                sched_stage_cg0 += 1;
+                if (sched_stage_cg0 == 8) { sched_stage_cg0 = 0; _phase_sched_ready ^= 1; }
+                if (tile_cg0 >= (unsigned int)total_work_items) {
+                    break;
+                }
+                int item_base_cg0 = (int)tile_cg0 * 8;
+                int _vec_load_2[4];
+                {
+                    int4 _iv4 = *reinterpret_cast<const int4*>(work_items + item_base_cg0 + 4);
+                    _vec_load_2[0 + 0] = _iv4.x;
+                    _vec_load_2[0 + 1] = _iv4.y;
+                    _vec_load_2[0 + 2] = _iv4.z;
+                    _vec_load_2[0 + 3] = _iv4.w;
+                }
+                int head_cg0 = work_items[item_base_cg0 + 1];
+                int wend_cg0 = work_items[item_base_cg0 + 3];
+                int cstart_cg0 = _vec_load_2[0];
+                long long bos_cg0 = (long long)_vec_load_2[2];
+                long long eos_cg0 = (long long)_vec_load_2[3];
+                int chunks_cg0 = wend_cg0 - cstart_cg0;
+                float _expf_0 = __expf(A_log[head_cg0]);
+                float gate_rate_cg0 = _expf_0;
+                float gate_bias_cg0 = dt_bias[head_cg0 * 128 + cg0_tid];
+                asm volatile("barrier.sync 10, 256;" ::: "memory");
+                int first_cumulative_cg0 = cumulative_chunk_cg0 + cg0_instance;
+                int raw_stage_cg0 = first_cumulative_cg0 % 5;
+                int raw_bar_stage_cg0 = first_cumulative_cg0 % 6;
+                int decay_stage_cg0 = first_cumulative_cg0 % 2;
+                int diag_stage_cg0 = first_cumulative_cg0 % 4;
+                int raw_bar_phase_cg0 = first_cumulative_cg0 / 6 & 1;
+                int decay_free_phase_cg0 = first_cumulative_cg0 / 2 + 1 & 1;
+                int diag_free_phase_cg0 = first_cumulative_cg0 / 4 + 1 & 1;
+                #pragma unroll 1
+                for (int chunk_cg0 = cg0_instance; chunk_cg0 < chunks_cg0; chunk_cg0 += 2) {
+                    int cumulative_cg0 = cumulative_chunk_cg0 + chunk_cg0;
+                    int logical_chunk_cg0 = cstart_cg0 + chunk_cg0;
+                    if (cg0_local_warp == 0) {
+                        mbarrier_wait(beta_done_addr + (raw_bar_stage_cg0) * 8, (unsigned int)(cumulative_cg0 / 6 + 1 & 1));
+                        if (lane < 16) {
+                            long long beta_token_cg0 = bos_cg0 + (long long)logical_chunk_cg0 * 16 + (long long)lane;
+                            float beta_value_cg0 = 0.0f;
+                            if (beta_token_cg0 < eos_cg0) {
+                                float beta_logit_cg0 = (float)beta[beta_token_cg0 * (long long)num_heads + (long long)head_cg0];
+                                float _tanh_approx_0;
+                                asm volatile("tanh.approx.f32 %0, %1;" : "=f"(_tanh_approx_0) : "f"(beta_logit_cg0 * 0.5f));
+                                beta_value_cg0 = _tanh_approx_0 * 0.5f + 0.5f;
+                            }
+                            __nv_bfloat16 _cvt_bf16_0 = __float2bfloat16(beta_value_cg0);
+                            __nv_bfloat16 beta_active_cg0 = _cvt_bf16_0;
+                            smem_beta_all[(int)raw_bar_stage_cg0 * 16 + lane] = beta_active_cg0;
+                            if (STORE_BETA_ACTIVE != 0 && beta_token_cg0 < eos_cg0) {
+                                beta_active_out[beta_token_cg0 * (long long)num_heads + (long long)head_cg0] = beta_active_cg0;
+                            }
+                        }
+                        mbarrier_arrive(beta_ready_addr + (raw_bar_stage_cg0) * 8);
+                    }
+                    mbarrier_wait(g_ready_addr + (raw_bar_stage_cg0) * 8, raw_bar_phase_cg0);
+                    float gate_raw_cg0[16];
+                    float gate_log_cg0[16];
+                    float gate_prefix_regs_cg0[16];
+                    #pragma unroll
+                    for (int token_gate_cg0 = 0; token_gate_cg0 < 16; token_gate_cg0++) {
+                        {
+                            long long gate_token_cg0 = bos_cg0 + (long long)logical_chunk_cg0 * 16 + (long long)token_gate_cg0;
+                            gate_raw_cg0[token_gate_cg0] = (float)g[(gate_token_cg0 * (long long)num_heads + (long long)head_cg0) * 128 + (long long)cg0_tid];
+                        }
+                    }
+                    #pragma unroll
+                    for (int gate_row_cg0 = 0; gate_row_cg0 < 16; gate_row_cg0++) {
+                        float gate_arg_cg0 = gate_rate_cg0 * (gate_raw_cg0[gate_row_cg0] + gate_bias_cg0);
+                        float _tanh_approx_1;
+                        asm volatile("tanh.approx.f32 %0, %1;" : "=f"(_tanh_approx_1) : "f"(gate_arg_cg0 * 0.5f));
+                        float gate_value_cg0 = _tanh_approx_1 * 0.5f + 0.5f;
+                        long long valid_gate_cg0 = bos_cg0 + (long long)logical_chunk_cg0 * 16 + (long long)gate_row_cg0;
+                        gate_log_cg0[gate_row_cg0] = 0.0f;
+                        if (valid_gate_cg0 < eos_cg0) {
+                            gate_log_cg0[gate_row_cg0] = lower_bound * 1.4426950408889634f * gate_value_cg0;
+                        }
+                    }
+                    float gate_prefix_cg0 = 0.0f;
+                    #pragma unroll
+                    for (int gate_pair_idx_cg0 = 0; gate_pair_idx_cg0 < 8; gate_pair_idx_cg0++) {
+                        int gate_row0_cg0 = gate_pair_idx_cg0 * 2;
+                        int gate_row1_cg0 = gate_row0_cg0 + 1;
+                        float2 _f2_0 = make_float2(gate_prefix_cg0, gate_log_cg0[gate_row0_cg0]);
+                        float2 _f2_1 = make_float2(gate_log_cg0[gate_row0_cg0], gate_log_cg0[gate_row1_cg0]);
+                        float2 gate_pair_sum_cg0 = add_f32x2(_f2_0, _f2_1);
+                        gate_prefix_regs_cg0[gate_row0_cg0] = gate_pair_sum_cg0.x;
+                        gate_prefix_cg0 += gate_pair_sum_cg0.y;
+                        gate_prefix_regs_cg0[gate_row1_cg0] = gate_prefix_cg0;
+                    }
+                    float gate_last_cg0 = 1.0f;
+                    #pragma unroll
+                    for (int token_gate_cg0_1 = 0; token_gate_cg0_1 < 16; token_gate_cg0_1++) {
+                        float _exp2_0 = approx_exp2(gate_prefix_regs_cg0[token_gate_cg0_1]);
+                        gate_last_cg0 = _exp2_0;
+                        int segment = cg0_tid / 32;
+                        int segment_col = cg0_tid - segment * 32;
+                        int swizzled_col = segment_col ^ (token_gate_cg0_1 & 7) * 4;
+                        smem_g_all[raw_stage_cg0 * 16 * 128 + segment * 16 * 32 + token_gate_cg0_1 * 32 + swizzled_col] = gate_last_cg0;
+                    }
+                    mbarrier_wait(state_diag_done_addr + (diag_stage_cg0) * 8, diag_free_phase_cg0);
+                    int diag_block_cg0 = cg0_tid / 16;
+                    int diag_coord_cg0 = cg0_tid - diag_block_cg0 * 16;
+                    int diag_storage_stage_cg0 = (int)diag_stage_cg0 * 8 + diag_block_cg0;
+                    if (cumulative_cg0 < 4) {
+                        #pragma unroll
+                        for (int diag_half_cg0 = 0; diag_half_cg0 < 2; diag_half_cg0++) {
+                            asm volatile("st.shared.v4.b32 [%0], {%1,%2,%3,%4};" :: "r"((smem_state_diag_addr + (unsigned int)(diag_storage_stage_cg0 * 512) + (unsigned int)(diag_half_cg0 * 8 / 16 * 512 + diag_coord_cg0 * 32 + diag_half_cg0 * 8 % 16 * 2 ^ (diag_half_cg0 * 8 / 16 * 512 + diag_coord_cg0 * 32 + diag_half_cg0 * 8 % 16 * 2 >> 7 & 1) << 4))), "r"(0), "r"(0), "r"(0), "r"(0) : "memory");
+                        }
+                    }
+                    {
+                        __nv_bfloat16 _bval_0 = __float2bfloat16_rn(gate_last_cg0);
+                        uint16_t _bits_0 = *(uint16_t*)&_bval_0;
+                        uint32_t _addr_0 = static_cast<uint32_t>((smem_state_diag_addr + (unsigned int)(diag_storage_stage_cg0 * 512) + (unsigned int)(diag_coord_cg0 / 16 * 512 + diag_coord_cg0 * 32 + diag_coord_cg0 % 16 * 2 ^ (diag_coord_cg0 / 16 * 512 + diag_coord_cg0 * 32 + diag_coord_cg0 % 16 * 2 >> 7 & 1) << 4)));
+                        asm volatile("st.shared.b16 [%0], %1;" :: "r"(_addr_0), "h"(_bits_0) : "memory");
+                    }
+                    if (cg0_instance == 0) {
+                        asm volatile("barrier.sync 8, 128;" ::: "memory");
+                    } else {
+                        asm volatile("barrier.sync 9, 128;" ::: "memory");
+                    }
+                    mbarrier_wait(q_ready_addr + (raw_bar_stage_cg0) * 8, raw_bar_phase_cg0);
+                    mbarrier_wait(k_ready_addr + (raw_bar_stage_cg0) * 8, raw_bar_phase_cg0);
+                    int decay_row_cg0 = cg0_local_warp * 4 + lane / 8;
+                    int decay_lane_cg0 = lane & 7;
+                    float q_values_cg0[16];
+                    float k_values_cg0[16];
+                    float2 _f2_2 = make_float2(0.0f, 0.0f);
+                    float2 qk_sq_even_cg0 = _f2_2;
+                    float2 _f2_3 = make_float2(0.0f, 0.0f);
+                    float2 qk_sq_odd_cg0 = _f2_3;
+                    #pragma unroll
+                    for (int dim_half_cg0 = 0; dim_half_cg0 < 2; dim_half_cg0++) {
+                        int dim_base_cg0 = dim_half_cg0 * 64 + decay_lane_cg0 * 8;
+                        unsigned int q_words_cg0[4];
+                        unsigned int k_words_cg0[4];
+                        int segment_1 = dim_base_cg0 / 64;
+                        int segment_col_1 = dim_base_cg0 - segment_1 * 64;
+                        int swizzled_col_1 = segment_col_1 ^ (decay_row_cg0 & 7) * 8;
+                        int raw_index_cg0 = raw_stage_cg0 * 16 * 128 + segment_1 * 16 * 64 + decay_row_cg0 * 64 + swizzled_col_1;
+                        asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                            : "=r"(*reinterpret_cast<uint32_t*>(&q_words_cg0[0])), "=r"(*reinterpret_cast<uint32_t*>(&q_words_cg0[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&q_words_cg0[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&q_words_cg0[(0) + 3]))
+                            : "r"(smem_q_all_addr + (unsigned int)(raw_index_cg0 * 2)));
+                        asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                            : "=r"(*reinterpret_cast<uint32_t*>(&k_words_cg0[0])), "=r"(*reinterpret_cast<uint32_t*>(&k_words_cg0[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&k_words_cg0[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&k_words_cg0[(0) + 3]))
+                            : "r"(smem_k_all_addr + (unsigned int)(raw_index_cg0 * 2)));
+                        float q_words_cg0_f32[8];
+                        #pragma unroll
+                        for (int _pair = 0; _pair < 4; _pair++) {
+                            asm volatile(
+                                "{\n\t"
+                                "shl.b32 %0, %2, 16;\n\t"
+                                "and.b32 %1, %2, 0xffff0000;\n\t"
+                                "}\n"
+                                : "=f"((&q_words_cg0_f32[_pair * 2])[0]), "=f"((&q_words_cg0_f32[_pair * 2])[1])
+                                : "r"(q_words_cg0[_pair]));
+                        }
+                        float k_words_cg0_f32[8];
+                        #pragma unroll
+                        for (int _pair = 0; _pair < 4; _pair++) {
+                            asm volatile(
+                                "{\n\t"
+                                "shl.b32 %0, %2, 16;\n\t"
+                                "and.b32 %1, %2, 0xffff0000;\n\t"
+                                "}\n"
+                                : "=f"((&k_words_cg0_f32[_pair * 2])[0]), "=f"((&k_words_cg0_f32[_pair * 2])[1])
+                                : "r"(k_words_cg0[_pair]));
+                        }
+                        #pragma unroll
+                        for (int dim_local_cg0 = 0; dim_local_cg0 < 8; dim_local_cg0++) {
+                            int reg_cg0 = dim_half_cg0 * 8 + dim_local_cg0;
+                            q_values_cg0[reg_cg0] = q_words_cg0_f32[dim_local_cg0];
+                            k_values_cg0[reg_cg0] = k_words_cg0_f32[dim_local_cg0];
+                        }
+                        #pragma unroll
+                        for (int dim_pair_sq_cg0 = 0; dim_pair_sq_cg0 < 4; dim_pair_sq_cg0++) {
+                            int even_reg_cg0 = dim_half_cg0 * 8 + dim_pair_sq_cg0 * 2;
+                            int odd_reg_cg0 = even_reg_cg0 + 1;
+                            float2 _f2_4 = make_float2(q_values_cg0[even_reg_cg0], k_values_cg0[even_reg_cg0]);
+                            float2 qk_even_cg0 = _f2_4;
+                            float2 _f2_5 = make_float2(q_values_cg0[odd_reg_cg0], k_values_cg0[odd_reg_cg0]);
+                            float2 qk_odd_cg0 = _f2_5;
+                            qk_sq_even_cg0 = fma_f32x2(qk_even_cg0, qk_even_cg0, qk_sq_even_cg0);
+                            qk_sq_odd_cg0 = fma_f32x2(qk_odd_cg0, qk_odd_cg0, qk_sq_odd_cg0);
+                        }
+                    }
+                    float q_sq_cg0 = qk_sq_even_cg0.x + qk_sq_odd_cg0.x;
+                    float k_sq_cg0 = qk_sq_even_cg0.y + qk_sq_odd_cg0.y;
+                    float _shfl_xor_0 = __shfl_xor_sync(0xFFFFFFFF, q_sq_cg0, 4);
+                    q_sq_cg0 += _shfl_xor_0;
+                    float _shfl_xor_1 = __shfl_xor_sync(0xFFFFFFFF, k_sq_cg0, 4);
+                    k_sq_cg0 += _shfl_xor_1;
+                    float _shfl_xor_2 = __shfl_xor_sync(0xFFFFFFFF, q_sq_cg0, 2);
+                    q_sq_cg0 += _shfl_xor_2;
+                    float _shfl_xor_3 = __shfl_xor_sync(0xFFFFFFFF, k_sq_cg0, 2);
+                    k_sq_cg0 += _shfl_xor_3;
+                    float _shfl_xor_4 = __shfl_xor_sync(0xFFFFFFFF, q_sq_cg0, 1);
+                    q_sq_cg0 += _shfl_xor_4;
+                    float _shfl_xor_5 = __shfl_xor_sync(0xFFFFFFFF, k_sq_cg0, 1);
+                    k_sq_cg0 += _shfl_xor_5;
+                    float _max_0 = max_noftz(q_sq_cg0, 1e-12f);
+                    float _rsqrt_0 = rsqrtf(_max_0);
+                    float q_inv_norm_cg0 = _rsqrt_0;
+                    float _max_1 = max_noftz(k_sq_cg0, 1e-12f);
+                    float _rsqrt_1 = rsqrtf(_max_1);
+                    float k_inv_norm_cg0 = _rsqrt_1;
+                    float exp_g_regs_cg0[16];
+                    float exp_g_last_regs_cg0[16];
+                    #pragma unroll
+                    for (int dim_half_prefix_cg0 = 0; dim_half_prefix_cg0 < 2; dim_half_prefix_cg0++) {
+                        int dim_base_prefix_cg0 = dim_half_prefix_cg0 * 64 + decay_lane_cg0 * 8;
+                        #pragma unroll
+                        for (int f32_group_cg0 = 0; f32_group_cg0 < 2; f32_group_cg0++) {
+                            int f32_dim_base_cg0 = dim_base_prefix_cg0 + f32_group_cg0 * 4;
+                            unsigned int exp_g_words_cg0[4];
+                            unsigned int exp_g_last_words_cg0[4];
+                            int segment_2 = f32_dim_base_cg0 / 32;
+                            int segment_col_2 = f32_dim_base_cg0 - segment_2 * 32;
+                            int swizzled_col_2 = segment_col_2 ^ (decay_row_cg0 & 7) * 4;
+                            int exp_g_index_cg0 = raw_stage_cg0 * 16 * 128 + segment_2 * 16 * 32 + decay_row_cg0 * 32 + swizzled_col_2;
+                            int segment_0 = f32_dim_base_cg0 / 32;
+                            int segment_col_1_1 = f32_dim_base_cg0 - segment_0 * 32;
+                            int swizzled_col_2_1 = segment_col_1_1 ^ 28;
+                            int exp_g_last_index_cg0 = raw_stage_cg0 * 16 * 128 + segment_0 * 16 * 32 + 480 + swizzled_col_2_1;
+                            asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                                : "=r"(*reinterpret_cast<uint32_t*>(&exp_g_words_cg0[0])), "=r"(*reinterpret_cast<uint32_t*>(&exp_g_words_cg0[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&exp_g_words_cg0[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&exp_g_words_cg0[(0) + 3]))
+                                : "r"(smem_g_all_addr + (unsigned int)(exp_g_index_cg0 * 4)));
+                            asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                                : "=r"(*reinterpret_cast<uint32_t*>(&exp_g_last_words_cg0[0])), "=r"(*reinterpret_cast<uint32_t*>(&exp_g_last_words_cg0[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&exp_g_last_words_cg0[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&exp_g_last_words_cg0[(0) + 3]))
+                                : "r"(smem_g_all_addr + (unsigned int)(exp_g_last_index_cg0 * 4)));
+                            #pragma unroll
+                            for (int prefix_word_cg0 = 0; prefix_word_cg0 < 4; prefix_word_cg0++) {
+                                int prefix_reg_cg0 = dim_half_prefix_cg0 * 8 + f32_group_cg0 * 4 + prefix_word_cg0;
+                                exp_g_regs_cg0[prefix_reg_cg0] = __uint_as_float(exp_g_words_cg0[prefix_word_cg0]);
+                                exp_g_last_regs_cg0[prefix_reg_cg0] = __uint_as_float(exp_g_last_words_cg0[prefix_word_cg0]);
+                            }
+                        }
+                    }
+                    __nv_bfloat162 k_inv_pairs_all_cg0[8];
+                    float2 _f2_6 = make_float2(k_inv_norm_cg0, k_inv_norm_cg0);
+                    float2 k_inv_norm_pair_cg0 = _f2_6;
+                    #pragma unroll
+                    for (int dim_half_k_cg0 = 0; dim_half_k_cg0 < 2; dim_half_k_cg0++) {
+                        int dim_base_k_cg0 = dim_half_k_cg0 * 64 + decay_lane_cg0 * 8;
+                        unsigned int k_decay_words_cg0[4];
+                        #pragma unroll
+                        for (int dim_pair_k_cg0 = 0; dim_pair_k_cg0 < 4; dim_pair_k_cg0++) {
+                            int dim_local0_k_cg0 = dim_pair_k_cg0 * 2;
+                            int dim_local1_k_cg0 = dim_local0_k_cg0 + 1;
+                            int reg_k0_cg0 = dim_half_k_cg0 * 8 + dim_local0_k_cg0;
+                            int reg_k1_cg0 = reg_k0_cg0 + 1;
+                            float prefix_k0_cg0 = exp_g_regs_cg0[reg_k0_cg0];
+                            float prefix_k1_cg0 = exp_g_regs_cg0[reg_k1_cg0];
+                            float2 _f2_7 = make_float2(k_values_cg0[reg_k0_cg0], k_values_cg0[reg_k1_cg0]);
+                            float2 k_norm_pair_cg0 = mul_f32x2(_f2_7, k_inv_norm_pair_cg0);
+                            __nv_bfloat162 _bf16x2_0 = __float22bfloat162_rn(make_float2(k_norm_pair_cg0.x, k_norm_pair_cg0.y));
+                            __nv_bfloat162 k_norm_bf16x2_cg0 = _bf16x2_0;
+                            __nv_bfloat162 _bf16x2_1 = __float22bfloat162_rn(make_float2(prefix_k0_cg0, prefix_k1_cg0));
+                            __nv_bfloat162 prefix_bf16x2_cg0 = _bf16x2_1;
+                            float _rcp_0 = approx_rcp(prefix_k0_cg0);
+                            float _rcp_1 = approx_rcp(prefix_k1_cg0);
+                            __nv_bfloat162 _bf16x2_2 = __float22bfloat162_rn(make_float2(_rcp_0, _rcp_1));
+                            __nv_bfloat162 reciprocal_bf16x2_cg0 = _bf16x2_2;
+                            __nv_bfloat162 k_inv_bf16x2_cg0 = k_norm_bf16x2_cg0 * reciprocal_bf16x2_cg0;
+                            __nv_bfloat162 k_decay_bf16x2_cg0 = k_norm_bf16x2_cg0 * prefix_bf16x2_cg0;
+                            int k_word_cg0 = dim_half_k_cg0 * 4 + dim_pair_k_cg0;
+                            k_inv_pairs_all_cg0[k_word_cg0] = k_inv_bf16x2_cg0;
+                            k_decay_words_cg0[dim_pair_k_cg0] = __as_u32(k_decay_bf16x2_cg0);
+                        }
+                        if (dim_half_k_cg0 == 0) {
+                            mbarrier_wait(decay_super_done_addr + (decay_stage_cg0) * 8, decay_free_phase_cg0);
+                            mbarrier_wait(decay_tcgen_done_addr + (decay_stage_cg0) * 8, decay_free_phase_cg0);
+                        }
+                        asm volatile("st.shared.v4.b32 [%0], {%1,%2,%3,%4};" :: "r"((smem_k_inv_addr + (unsigned int)(decay_stage_cg0 * 4096) + (unsigned int)(dim_base_k_cg0 / 64 * 2048 + decay_row_cg0 * 128 + dim_base_k_cg0 % 64 * 2 ^ (dim_base_k_cg0 / 64 * 2048 + decay_row_cg0 * 128 + dim_base_k_cg0 % 64 * 2 >> 7 & 7) << 4))), "r"(__as_u32(k_inv_pairs_all_cg0[dim_half_k_cg0 * 4])), "r"(__as_u32(k_inv_pairs_all_cg0[dim_half_k_cg0 * 4 + 1])), "r"(__as_u32(k_inv_pairs_all_cg0[dim_half_k_cg0 * 4 + 2])), "r"(__as_u32(k_inv_pairs_all_cg0[dim_half_k_cg0 * 4 + 3])) : "memory");
+                        asm volatile("st.shared.v4.b32 [%0], {%1,%2,%3,%4};" :: "r"((smem_k_decay_addr + (unsigned int)(decay_stage_cg0 * 4096) + (unsigned int)(dim_base_k_cg0 / 64 * 2048 + decay_row_cg0 * 128 + dim_base_k_cg0 % 64 * 2 ^ (dim_base_k_cg0 / 64 * 2048 + decay_row_cg0 * 128 + dim_base_k_cg0 % 64 * 2 >> 7 & 7) << 4))), "r"(k_decay_words_cg0[0]), "r"(k_decay_words_cg0[1]), "r"(k_decay_words_cg0[2]), "r"(k_decay_words_cg0[3]) : "memory");
+                    }
+                    asm volatile("fence.proxy.async.shared::cta;" ::: "memory");
+                    mbarrier_arrive(k_decay_inv_ready_addr + (decay_stage_cg0) * 8);
+                    mbarrier_arrive(q_done_addr + (raw_stage_cg0) * 8);
+                    mbarrier_arrive(k_done_addr + (raw_stage_cg0) * 8);
+                    mbarrier_arrive(g_done_addr + (raw_stage_cg0) * 8);
+                    float2 _f2_8 = make_float2(q_inv_norm_cg0, q_inv_norm_cg0);
+                    float2 q_inv_pair_cg0 = _f2_8;
+                    #pragma unroll
+                    for (int dim_half_q_cg0 = 0; dim_half_q_cg0 < 2; dim_half_q_cg0++) {
+                        int dim_base_q_cg0 = dim_half_q_cg0 * 64 + decay_lane_cg0 * 8;
+                        unsigned int q_decay_words_cg0[4];
+                        #pragma unroll
+                        for (int dim_pair_q_cg0 = 0; dim_pair_q_cg0 < 4; dim_pair_q_cg0++) {
+                            int dim_local0_q_cg0 = dim_pair_q_cg0 * 2;
+                            int dim_local1_q_cg0 = dim_local0_q_cg0 + 1;
+                            int reg_q0_cg0 = dim_half_q_cg0 * 8 + dim_local0_q_cg0;
+                            int reg_q1_cg0 = reg_q0_cg0 + 1;
+                            float2 _f2_9 = make_float2(q_values_cg0[reg_q0_cg0], q_values_cg0[reg_q1_cg0]);
+                            float2 q_norm_pair_cg0 = mul_f32x2(_f2_9, q_inv_pair_cg0);
+                            __nv_bfloat162 _bf16x2_3 = __float22bfloat162_rn(make_float2(q_norm_pair_cg0.x, q_norm_pair_cg0.y));
+                            __nv_bfloat162 q_norm_bf16x2_cg0 = _bf16x2_3;
+                            __nv_bfloat162 _bf16x2_4 = __float22bfloat162_rn(make_float2(exp_g_regs_cg0[reg_q0_cg0], exp_g_regs_cg0[reg_q1_cg0]));
+                            __nv_bfloat162 q_prefix_bf16x2_cg0 = _bf16x2_4;
+                            __nv_bfloat162 q_decay_bf16x2_cg0 = q_norm_bf16x2_cg0 * q_prefix_bf16x2_cg0;
+                            q_decay_words_cg0[dim_pair_q_cg0] = __as_u32(q_decay_bf16x2_cg0);
+                        }
+                        asm volatile("st.shared.v4.b32 [%0], {%1,%2,%3,%4};" :: "r"((smem_q_decay_addr + (unsigned int)(decay_stage_cg0 * 4096) + (unsigned int)(dim_base_q_cg0 / 64 * 2048 + decay_row_cg0 * 128 + dim_base_q_cg0 % 64 * 2 ^ (dim_base_q_cg0 / 64 * 2048 + decay_row_cg0 * 128 + dim_base_q_cg0 % 64 * 2 >> 7 & 7) << 4))), "r"(q_decay_words_cg0[0]), "r"(q_decay_words_cg0[1]), "r"(q_decay_words_cg0[2]), "r"(q_decay_words_cg0[3]) : "memory");
+                    }
+                    mbarrier_wait(k_restore_done_addr + (decay_stage_cg0) * 8, decay_free_phase_cg0);
+                    #pragma unroll
+                    for (int dim_half_restore_cg0 = 0; dim_half_restore_cg0 < 2; dim_half_restore_cg0++) {
+                        int dim_base_restore_cg0 = dim_half_restore_cg0 * 64 + decay_lane_cg0 * 8;
+                        unsigned int k_restore_words_cg0[4];
+                        #pragma unroll
+                        for (int dim_pair_restore_cg0 = 0; dim_pair_restore_cg0 < 4; dim_pair_restore_cg0++) {
+                            int dim_local0_restore_cg0 = dim_pair_restore_cg0 * 2;
+                            int dim_local1_restore_cg0 = dim_local0_restore_cg0 + 1;
+                            int reg_restore0_cg0 = dim_half_restore_cg0 * 8 + dim_local0_restore_cg0;
+                            int reg_restore1_cg0 = reg_restore0_cg0 + 1;
+                            int restore_word_cg0 = dim_half_restore_cg0 * 4 + dim_pair_restore_cg0;
+                            __nv_bfloat162 _bf16x2_5 = __float22bfloat162_rn(make_float2(exp_g_last_regs_cg0[reg_restore0_cg0], exp_g_last_regs_cg0[reg_restore1_cg0]));
+                            __nv_bfloat162 k_restore_bf16x2_cg0 = k_inv_pairs_all_cg0[restore_word_cg0] * _bf16x2_5;
+                            k_restore_words_cg0[dim_pair_restore_cg0] = __as_u32(k_restore_bf16x2_cg0);
+                        }
+                        asm volatile("st.shared.v4.b32 [%0], {%1,%2,%3,%4};" :: "r"((smem_k_restore_addr + (unsigned int)(decay_stage_cg0 * 4096) + (unsigned int)(dim_base_restore_cg0 / 64 * 2048 + decay_row_cg0 * 128 + dim_base_restore_cg0 % 64 * 2 ^ (dim_base_restore_cg0 / 64 * 2048 + decay_row_cg0 * 128 + dim_base_restore_cg0 % 64 * 2 >> 7 & 7) << 4))), "r"(k_restore_words_cg0[0]), "r"(k_restore_words_cg0[1]), "r"(k_restore_words_cg0[2]), "r"(k_restore_words_cg0[3]) : "memory");
+                    }
+                    asm volatile("fence.proxy.async.shared::cta;" ::: "memory");
+                    mbarrier_arrive(qk_scale_ready_addr + (diag_stage_cg0) * 8);
+                    raw_stage_cg0 += 2;
+                    if (raw_stage_cg0 >= 5) {
+                        raw_stage_cg0 -= 5;
+                    }
+                    raw_bar_stage_cg0 += 2;
+                    if (raw_bar_stage_cg0 >= 6) {
+                        raw_bar_stage_cg0 -= 6;
+                        raw_bar_phase_cg0 ^= 1;
+                    }
+                    decay_free_phase_cg0 ^= 1;
+                    diag_stage_cg0 += 2;
+                    if (diag_stage_cg0 >= 4) {
+                        diag_stage_cg0 -= 4;
+                        diag_free_phase_cg0 ^= 1;
+                    }
+                }
+                cumulative_chunk_cg0 += chunks_cg0;
+            }
+            if (elect_sync()) {
+                mbarrier_arrive(consumers_done_addr);
+            }
+        }
+    }
+    // ---- Role: cg1 ----
+    if (warp >= 8 && warp <= 11) {
+        asm volatile("setmaxnreg.inc.sync.aligned.u32 136;");
+        { // cg1_main
+            unsigned int sched_stage_cg1 = 0;
+            int cumulative_chunk_cg1 = 0;
+            int warp_in_wg = warp % 4;
+            int value_row_cg1 = warp_in_wg * 32 + lane;
+            int value_dim_base_cg1 = warp_in_wg * 32;
+            const int tmem_row_base_cg1 = warp_in_wg * 32 << 16;
+            int ov_token_cg1 = lane / 16 * 8 + (lane & 7);
+            int ov_col_cg1 = (lane / 8 & 1) * 8;
+            unsigned int _phase_sched_ready_1 = 0;
+            #pragma unroll 1
+            for (int __1 = 0; __1 < total_work_items + 1; __1++) {
+                mbarrier_wait(sched_ready_addr + (sched_stage_cg1) * 8, _phase_sched_ready_1);
+                unsigned int slot_1[1];
+                asm volatile("ld.shared.b32 %0, [%1];" : "=r"(*reinterpret_cast<uint32_t*>(&slot_1[0])) : "r"(sched_slot_addr + sched_stage_cg1 * 4));
+                unsigned int tile_cg1 = slot_1[0];
+                if (elect_sync()) {
+                    mbarrier_arrive(sched_done_addr + (sched_stage_cg1) * 8);
+                }
+                sched_stage_cg1 += 1;
+                if (sched_stage_cg1 == 8) { sched_stage_cg1 = 0; _phase_sched_ready_1 ^= 1; }
+                if (tile_cg1 >= (unsigned int)total_work_items) {
+                    break;
+                }
+                int item_base_cg1 = (int)tile_cg1 * 8;
+                int _vec_load_4[4];
+                {
+                    int4 _iv4 = *reinterpret_cast<const int4*>(work_items + item_base_cg1);
+                    _vec_load_4[0 + 0] = _iv4.x;
+                    _vec_load_4[0 + 1] = _iv4.y;
+                    _vec_load_4[0 + 2] = _iv4.z;
+                    _vec_load_4[0 + 3] = _iv4.w;
+                }
+                int _vec_load_5[4];
+                {
+                    int4 _iv4 = *reinterpret_cast<const int4*>(work_items + item_base_cg1 + 4);
+                    _vec_load_5[0 + 0] = _iv4.x;
+                    _vec_load_5[0 + 1] = _iv4.y;
+                    _vec_load_5[0 + 2] = _iv4.z;
+                    _vec_load_5[0 + 3] = _iv4.w;
+                }
+                int seq_cg1 = _vec_load_4[0];
+                int head_cg1 = _vec_load_4[1];
+                int wstart_cg1 = _vec_load_4[2];
+                int wend_cg1 = _vec_load_4[3];
+                int cstart_cg1 = _vec_load_5[0];
+                int chunks_cg1 = wend_cg1 - cstart_cg1;
+                long long state_base_cg1 = (((long long)seq_cg1 * (long long)num_heads + (long long)head_cg1) * 128 + (long long)value_row_cg1) * 128;
+                #pragma unroll
+                for (int state_block_cg1 = 0; state_block_cg1 < 4; state_block_cg1++) {
+                    float state_init_cg1[32];
+                    state_init_cg1[0] = 0.0f;
+                    state_init_cg1[1] = 0.0f;
+                    state_init_cg1[2] = 0.0f;
+                    state_init_cg1[3] = 0.0f;
+                    state_init_cg1[4] = 0.0f;
+                    state_init_cg1[5] = 0.0f;
+                    state_init_cg1[6] = 0.0f;
+                    state_init_cg1[7] = 0.0f;
+                    state_init_cg1[8] = 0.0f;
+                    state_init_cg1[9] = 0.0f;
+                    state_init_cg1[10] = 0.0f;
+                    state_init_cg1[11] = 0.0f;
+                    state_init_cg1[12] = 0.0f;
+                    state_init_cg1[13] = 0.0f;
+                    state_init_cg1[14] = 0.0f;
+                    state_init_cg1[15] = 0.0f;
+                    state_init_cg1[16] = 0.0f;
+                    state_init_cg1[17] = 0.0f;
+                    state_init_cg1[18] = 0.0f;
+                    state_init_cg1[19] = 0.0f;
+                    state_init_cg1[20] = 0.0f;
+                    state_init_cg1[21] = 0.0f;
+                    state_init_cg1[22] = 0.0f;
+                    state_init_cg1[23] = 0.0f;
+                    state_init_cg1[24] = 0.0f;
+                    state_init_cg1[25] = 0.0f;
+                    state_init_cg1[26] = 0.0f;
+                    state_init_cg1[27] = 0.0f;
+                    state_init_cg1[28] = 0.0f;
+                    state_init_cg1[29] = 0.0f;
+                    state_init_cg1[30] = 0.0f;
+                    state_init_cg1[31] = 0.0f;
+                    if (USE_INITIAL_STATE != 0 && cstart_cg1 == 0) {
+                        #pragma unroll
+                        for (int state_vec_cg1 = 0; state_vec_cg1 < 4; state_vec_cg1++) {
+                            {
+                                unsigned _ldv8_0_0;
+                                unsigned _ldv8_0_1;
+                                unsigned _ldv8_0_2;
+                                unsigned _ldv8_0_3;
+                                unsigned _ldv8_0_4;
+                                unsigned _ldv8_0_5;
+                                unsigned _ldv8_0_6;
+                                unsigned _ldv8_0_7;
+                                asm volatile(
+                                    "ld.global.v8.b32 {%0, %1, %2, %3, %4, %5, %6, %7}, [%8];"
+                                    : "=r"(_ldv8_0_0), "=r"(_ldv8_0_1), "=r"(_ldv8_0_2), "=r"(_ldv8_0_3), "=r"(_ldv8_0_4), "=r"(_ldv8_0_5), "=r"(_ldv8_0_6), "=r"(_ldv8_0_7) : "l"((const void*)(initial_state + (state_base_cg1 + (long long)(state_block_cg1 * 32) + (long long)(state_vec_cg1 * 8)))) : "memory");
+                                state_init_cg1[state_vec_cg1 * 8 + 0] = __uint_as_float(_ldv8_0_0);
+                                state_init_cg1[state_vec_cg1 * 8 + 1] = __uint_as_float(_ldv8_0_1);
+                                state_init_cg1[state_vec_cg1 * 8 + 2] = __uint_as_float(_ldv8_0_2);
+                                state_init_cg1[state_vec_cg1 * 8 + 3] = __uint_as_float(_ldv8_0_3);
+                                state_init_cg1[state_vec_cg1 * 8 + 4] = __uint_as_float(_ldv8_0_4);
+                                state_init_cg1[state_vec_cg1 * 8 + 5] = __uint_as_float(_ldv8_0_5);
+                                state_init_cg1[state_vec_cg1 * 8 + 6] = __uint_as_float(_ldv8_0_6);
+                                state_init_cg1[state_vec_cg1 * 8 + 7] = __uint_as_float(_ldv8_0_7);
+                            }
+                        }
+                        #pragma unroll
+                        for (int state_elem_cg1 = 0; state_elem_cg1 < 32; state_elem_cg1++) {
+                            __nv_bfloat16 _cvt_bf16_1 = __float2bfloat16(state_init_cg1[state_elem_cg1]);
+                            float _cvt_f32_2 = __bfloat162float(_cvt_bf16_1);
+                            state_init_cg1[state_elem_cg1] = _cvt_f32_2;
+                        }
+                    }
+                    tmem_st_x32_f32(taddr + (unsigned int)tmem_row_base_cg1 + (unsigned int)(state_block_cg1 * 32), state_init_cg1);
+                }
+                asm volatile("tcgen05.wait::st.sync.aligned;" ::: "memory");
+                if (chunks_cg1 > 0) {
+                    int cumulative_cg1 = cumulative_chunk_cg1;
+                    unsigned int raw_stage_cg1 = (unsigned int)(cumulative_cg1 % 5);
+                    unsigned int raw_bar_stage_cg1 = (unsigned int)(cumulative_cg1 % 6);
+                    unsigned int o_stage_cg1 = (unsigned int)(cumulative_cg1 % 2);
+                    unsigned int checkpoint_stage_cg1 = (unsigned int)(cumulative_cg1 % 2);
+                    unsigned int state_phase_cg1 = (unsigned int)(cumulative_cg1 & 1);
+                    float _tmem_load_0[128];
+                    tmem_ld_x16(&_tmem_load_0[0], taddr + (unsigned int)tmem_row_base_cg1);
+                    tmem_ld_x16(&_tmem_load_0[16], taddr + (unsigned int)tmem_row_base_cg1 + 16);
+                    tmem_ld_x16(&_tmem_load_0[32], taddr + (unsigned int)tmem_row_base_cg1 + 32);
+                    tmem_ld_x16(&_tmem_load_0[48], taddr + (unsigned int)tmem_row_base_cg1 + 48);
+                    tmem_ld_x16(&_tmem_load_0[64], taddr + (unsigned int)tmem_row_base_cg1 + 64);
+                    tmem_ld_x16(&_tmem_load_0[80], taddr + (unsigned int)tmem_row_base_cg1 + 80);
+                    tmem_ld_x16(&_tmem_load_0[96], taddr + (unsigned int)tmem_row_base_cg1 + 96);
+                    tmem_ld_x16(&_tmem_load_0[112], taddr + (unsigned int)tmem_row_base_cg1 + 112);
+                    asm volatile("tcgen05.wait::ld.sync.aligned;" ::: "memory");
+                    {
+                        mbarrier_wait(checkpoint_done_addr + (checkpoint_stage_cg1) * 8, (unsigned int)(cumulative_cg1 / 2 + 1 & 1));
+                    }
+                    unsigned int state_words_cg1[8];
+                    #pragma unroll
+                    for (int _lp = 0; _lp < 8; _lp++) {
+                        __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(_tmem_load_0[_lp*2 + 0], _tmem_load_0[_lp*2+1 + 0]));
+                        state_words_cg1[_lp] = *(uint32_t*)&_bf2;
+                    }
+                    tmem_st_x8_u32(taddr + 128 + (unsigned int)tmem_row_base_cg1, (const uint32_t*)state_words_cg1);
+                    {
+                        asm volatile("st.shared.v4.b32 [%0], {%1,%2,%3,%4};" :: "r"((smem_checkpoint_addr + checkpoint_stage_cg1 * 32768 + (unsigned int)(value_row_cg1 * 128 ^ (value_row_cg1 * 128 >> 7 & 7) << 4))), "r"(state_words_cg1[0]), "r"(state_words_cg1[1]), "r"(state_words_cg1[2]), "r"(state_words_cg1[3]) : "memory");
+                        asm volatile("st.shared.v4.b32 [%0], {%1,%2,%3,%4};" :: "r"((smem_checkpoint_addr + checkpoint_stage_cg1 * 32768 + (unsigned int)(value_row_cg1 * 128 + 16 ^ (value_row_cg1 * 128 + 16 >> 7 & 7) << 4))), "r"(state_words_cg1[4]), "r"(state_words_cg1[5]), "r"(state_words_cg1[6]), "r"(state_words_cg1[7]) : "memory");
+                    }
+                    #pragma unroll
+                    for (int _lp = 0; _lp < 8; _lp++) {
+                        __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(_tmem_load_0[_lp*2 + 16], _tmem_load_0[_lp*2+1 + 16]));
+                        state_words_cg1[_lp] = *(uint32_t*)&_bf2;
+                    }
+                    tmem_st_x8_u32(taddr + 128 + (unsigned int)tmem_row_base_cg1 + 8, (const uint32_t*)state_words_cg1);
+                    {
+                        asm volatile("st.shared.v4.b32 [%0], {%1,%2,%3,%4};" :: "r"((smem_checkpoint_addr + checkpoint_stage_cg1 * 32768 + (unsigned int)(value_row_cg1 * 128 + 32 ^ (value_row_cg1 * 128 + 32 >> 7 & 7) << 4))), "r"(state_words_cg1[0]), "r"(state_words_cg1[1]), "r"(state_words_cg1[2]), "r"(state_words_cg1[3]) : "memory");
+                        asm volatile("st.shared.v4.b32 [%0], {%1,%2,%3,%4};" :: "r"((smem_checkpoint_addr + checkpoint_stage_cg1 * 32768 + (unsigned int)(value_row_cg1 * 128 + 48 ^ (value_row_cg1 * 128 + 48 >> 7 & 7) << 4))), "r"(state_words_cg1[4]), "r"(state_words_cg1[5]), "r"(state_words_cg1[6]), "r"(state_words_cg1[7]) : "memory");
+                    }
+                    #pragma unroll
+                    for (int _lp = 0; _lp < 8; _lp++) {
+                        __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(_tmem_load_0[_lp*2 + 32], _tmem_load_0[_lp*2+1 + 32]));
+                        state_words_cg1[_lp] = *(uint32_t*)&_bf2;
+                    }
+                    tmem_st_x8_u32(taddr + 128 + (unsigned int)tmem_row_base_cg1 + 16, (const uint32_t*)state_words_cg1);
+                    {
+                        asm volatile("st.shared.v4.b32 [%0], {%1,%2,%3,%4};" :: "r"((smem_checkpoint_addr + checkpoint_stage_cg1 * 32768 + (unsigned int)(value_row_cg1 * 128 + 64 ^ (value_row_cg1 * 128 + 64 >> 7 & 7) << 4))), "r"(state_words_cg1[0]), "r"(state_words_cg1[1]), "r"(state_words_cg1[2]), "r"(state_words_cg1[3]) : "memory");
+                        asm volatile("st.shared.v4.b32 [%0], {%1,%2,%3,%4};" :: "r"((smem_checkpoint_addr + checkpoint_stage_cg1 * 32768 + (unsigned int)(value_row_cg1 * 128 + 80 ^ (value_row_cg1 * 128 + 80 >> 7 & 7) << 4))), "r"(state_words_cg1[4]), "r"(state_words_cg1[5]), "r"(state_words_cg1[6]), "r"(state_words_cg1[7]) : "memory");
+                    }
+                    #pragma unroll
+                    for (int _lp = 0; _lp < 8; _lp++) {
+                        __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(_tmem_load_0[_lp*2 + 48], _tmem_load_0[_lp*2+1 + 48]));
+                        state_words_cg1[_lp] = *(uint32_t*)&_bf2;
+                    }
+                    tmem_st_x8_u32(taddr + 128 + (unsigned int)tmem_row_base_cg1 + 24, (const uint32_t*)state_words_cg1);
+                    {
+                        asm volatile("st.shared.v4.b32 [%0], {%1,%2,%3,%4};" :: "r"((smem_checkpoint_addr + checkpoint_stage_cg1 * 32768 + (unsigned int)(value_row_cg1 * 128 + 96 ^ (value_row_cg1 * 128 + 96 >> 7 & 7) << 4))), "r"(state_words_cg1[0]), "r"(state_words_cg1[1]), "r"(state_words_cg1[2]), "r"(state_words_cg1[3]) : "memory");
+                        asm volatile("st.shared.v4.b32 [%0], {%1,%2,%3,%4};" :: "r"((smem_checkpoint_addr + checkpoint_stage_cg1 * 32768 + (unsigned int)(value_row_cg1 * 128 + 112 ^ (value_row_cg1 * 128 + 112 >> 7 & 7) << 4))), "r"(state_words_cg1[4]), "r"(state_words_cg1[5]), "r"(state_words_cg1[6]), "r"(state_words_cg1[7]) : "memory");
+                    }
+                    #pragma unroll
+                    for (int _lp = 0; _lp < 8; _lp++) {
+                        __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(_tmem_load_0[_lp*2 + 64], _tmem_load_0[_lp*2+1 + 64]));
+                        state_words_cg1[_lp] = *(uint32_t*)&_bf2;
+                    }
+                    tmem_st_x8_u32(taddr + 128 + (unsigned int)tmem_row_base_cg1 + 32, (const uint32_t*)state_words_cg1);
+                    {
+                        asm volatile("st.shared.v4.b32 [%0], {%1,%2,%3,%4};" :: "r"((smem_checkpoint_addr + checkpoint_stage_cg1 * 32768 + (unsigned int)(16384 + value_row_cg1 * 128 ^ (16384 + value_row_cg1 * 128 >> 7 & 7) << 4))), "r"(state_words_cg1[0]), "r"(state_words_cg1[1]), "r"(state_words_cg1[2]), "r"(state_words_cg1[3]) : "memory");
+                        asm volatile("st.shared.v4.b32 [%0], {%1,%2,%3,%4};" :: "r"((smem_checkpoint_addr + checkpoint_stage_cg1 * 32768 + (unsigned int)(16384 + value_row_cg1 * 128 + 16 ^ (16384 + value_row_cg1 * 128 + 16 >> 7 & 7) << 4))), "r"(state_words_cg1[4]), "r"(state_words_cg1[5]), "r"(state_words_cg1[6]), "r"(state_words_cg1[7]) : "memory");
+                    }
+                    #pragma unroll
+                    for (int _lp = 0; _lp < 8; _lp++) {
+                        __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(_tmem_load_0[_lp*2 + 80], _tmem_load_0[_lp*2+1 + 80]));
+                        state_words_cg1[_lp] = *(uint32_t*)&_bf2;
+                    }
+                    tmem_st_x8_u32(taddr + 128 + (unsigned int)tmem_row_base_cg1 + 40, (const uint32_t*)state_words_cg1);
+                    {
+                        asm volatile("st.shared.v4.b32 [%0], {%1,%2,%3,%4};" :: "r"((smem_checkpoint_addr + checkpoint_stage_cg1 * 32768 + (unsigned int)(16384 + value_row_cg1 * 128 + 32 ^ (16384 + value_row_cg1 * 128 + 32 >> 7 & 7) << 4))), "r"(state_words_cg1[0]), "r"(state_words_cg1[1]), "r"(state_words_cg1[2]), "r"(state_words_cg1[3]) : "memory");
+                        asm volatile("st.shared.v4.b32 [%0], {%1,%2,%3,%4};" :: "r"((smem_checkpoint_addr + checkpoint_stage_cg1 * 32768 + (unsigned int)(16384 + value_row_cg1 * 128 + 48 ^ (16384 + value_row_cg1 * 128 + 48 >> 7 & 7) << 4))), "r"(state_words_cg1[4]), "r"(state_words_cg1[5]), "r"(state_words_cg1[6]), "r"(state_words_cg1[7]) : "memory");
+                    }
+                    #pragma unroll
+                    for (int _lp = 0; _lp < 8; _lp++) {
+                        __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(_tmem_load_0[_lp*2 + 96], _tmem_load_0[_lp*2+1 + 96]));
+                        state_words_cg1[_lp] = *(uint32_t*)&_bf2;
+                    }
+                    tmem_st_x8_u32(taddr + 128 + (unsigned int)tmem_row_base_cg1 + 48, (const uint32_t*)state_words_cg1);
+                    {
+                        asm volatile("st.shared.v4.b32 [%0], {%1,%2,%3,%4};" :: "r"((smem_checkpoint_addr + checkpoint_stage_cg1 * 32768 + (unsigned int)(16384 + value_row_cg1 * 128 + 64 ^ (16384 + value_row_cg1 * 128 + 64 >> 7 & 7) << 4))), "r"(state_words_cg1[0]), "r"(state_words_cg1[1]), "r"(state_words_cg1[2]), "r"(state_words_cg1[3]) : "memory");
+                        asm volatile("st.shared.v4.b32 [%0], {%1,%2,%3,%4};" :: "r"((smem_checkpoint_addr + checkpoint_stage_cg1 * 32768 + (unsigned int)(16384 + value_row_cg1 * 128 + 80 ^ (16384 + value_row_cg1 * 128 + 80 >> 7 & 7) << 4))), "r"(state_words_cg1[4]), "r"(state_words_cg1[5]), "r"(state_words_cg1[6]), "r"(state_words_cg1[7]) : "memory");
+                    }
+                    #pragma unroll
+                    for (int _lp = 0; _lp < 8; _lp++) {
+                        __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(_tmem_load_0[_lp*2 + 112], _tmem_load_0[_lp*2+1 + 112]));
+                        state_words_cg1[_lp] = *(uint32_t*)&_bf2;
+                    }
+                    tmem_st_x8_u32(taddr + 128 + (unsigned int)tmem_row_base_cg1 + 56, (const uint32_t*)state_words_cg1);
+                    {
+                        asm volatile("st.shared.v4.b32 [%0], {%1,%2,%3,%4};" :: "r"((smem_checkpoint_addr + checkpoint_stage_cg1 * 32768 + (unsigned int)(16384 + value_row_cg1 * 128 + 96 ^ (16384 + value_row_cg1 * 128 + 96 >> 7 & 7) << 4))), "r"(state_words_cg1[0]), "r"(state_words_cg1[1]), "r"(state_words_cg1[2]), "r"(state_words_cg1[3]) : "memory");
+                        asm volatile("st.shared.v4.b32 [%0], {%1,%2,%3,%4};" :: "r"((smem_checkpoint_addr + checkpoint_stage_cg1 * 32768 + (unsigned int)(16384 + value_row_cg1 * 128 + 112 ^ (16384 + value_row_cg1 * 128 + 112 >> 7 & 7) << 4))), "r"(state_words_cg1[4]), "r"(state_words_cg1[5]), "r"(state_words_cg1[6]), "r"(state_words_cg1[7]) : "memory");
+                    }
+                    asm volatile("tcgen05.wait::st.sync.aligned;" ::: "memory");
+                    mbarrier_arrive(state_inp_ready_addr);
+                    {
+                        asm volatile("fence.proxy.async.shared::cta;" ::: "memory");
+                        mbarrier_arrive(state_read_done_addr);
+                        mbarrier_arrive(checkpoint_ready_addr + (checkpoint_stage_cg1) * 8);
+                    }
+                    mbarrier_wait(v_ready_addr + (raw_bar_stage_cg1) * 8, (unsigned int)(cumulative_cg1 / 6 & 1));
+                    mbarrier_wait(beta_ready_addr + (raw_bar_stage_cg1) * 8, (unsigned int)(cumulative_cg1 / 6 & 1));
+                    mbarrier_wait(state_k_ready_addr, state_phase_cg1);
+                    float _tmem_load_3[8];
+                    asm volatile(
+                        "tcgen05.ld.sync.aligned.16x256b.x2.b32"
+                        " {%0, %1, %2, %3, %4, %5, %6, %7}, [%8];"
+                        : "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[0])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[1])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[2])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[3])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[4])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[5])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[6])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[7]))
+                        : "r"(taddr + 224 + (unsigned int)tmem_row_base_cg1)
+                        : "memory");
+                    float _tmem_load_4[8];
+                    asm volatile(
+                        "tcgen05.ld.sync.aligned.16x256b.x2.b32"
+                        " {%0, %1, %2, %3, %4, %5, %6, %7}, [%8];"
+                        : "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_4[0])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_4[1])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_4[2])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_4[3])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_4[4])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_4[5])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_4[6])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_4[7]))
+                        : "r"(taddr + 224 + (unsigned int)tmem_row_base_cg1 + 1048576)
+                        : "memory");
+                    unsigned int raw_v_words_lo_cg1[4];
+                    unsigned int raw_v_words_hi_cg1[4];
+                    int segment_3 = (value_dim_base_cg1 + ov_col_cg1) / 64;
+                    int segment_col_3 = value_dim_base_cg1 + ov_col_cg1 - segment_3 * 64;
+                    int swizzled_col_3 = segment_col_3 ^ (ov_token_cg1 & 7) * 8;
+                    asm volatile("ldmatrix.sync.aligned.m8n8.x4.trans.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                        : "=r"(raw_v_words_lo_cg1[0]), "=r"(raw_v_words_lo_cg1[1]), "=r"(raw_v_words_lo_cg1[2]), "=r"(raw_v_words_lo_cg1[3])
+                        : "r"(smem_v_all_addr + (raw_stage_cg1 * 16 * 128 + (unsigned int)(segment_3 * 16 * 64) + (unsigned int)(ov_token_cg1 * 64) + (unsigned int)swizzled_col_3) * 2)
+                        : "memory");
+                    int segment_0_1 = (value_dim_base_cg1 + 16 + ov_col_cg1) / 64;
+                    int segment_col_1_2 = value_dim_base_cg1 + 16 + ov_col_cg1 - segment_0_1 * 64;
+                    int swizzled_col_2_2 = segment_col_1_2 ^ (ov_token_cg1 & 7) * 8;
+                    asm volatile("ldmatrix.sync.aligned.m8n8.x4.trans.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                        : "=r"(raw_v_words_hi_cg1[0]), "=r"(raw_v_words_hi_cg1[1]), "=r"(raw_v_words_hi_cg1[2]), "=r"(raw_v_words_hi_cg1[3])
+                        : "r"(smem_v_all_addr + (raw_stage_cg1 * 16 * 128 + (unsigned int)(segment_0_1 * 16 * 64) + (unsigned int)(ov_token_cg1 * 64) + (unsigned int)swizzled_col_2_2) * 2)
+                        : "memory");
+                    asm volatile("tcgen05.wait::ld.sync.aligned;" ::: "memory");
+                    __nv_bfloat162 beta_pairs_cg1[4];
+                    #pragma unroll
+                    for (int beta_reg_cg1 = 0; beta_reg_cg1 < 4; beta_reg_cg1++) {
+                        int beta_packed_col_cg1 = beta_reg_cg1 / 2 * 4 + (lane & 3);
+                        int beta_token0_cg1 = beta_packed_col_cg1 * 2;
+                        int beta_token1_cg1 = beta_token0_cg1 + 1;
+                        __nv_bfloat16 beta0_cg1 = smem_beta_all[(int)raw_bar_stage_cg1 * 16 + beta_token0_cg1];
+                        __nv_bfloat16 beta1_cg1 = smem_beta_all[(int)raw_bar_stage_cg1 * 16 + beta_token1_cg1];
+                        float _cvt_f32_3 = __bfloat162float(beta0_cg1);
+                        float _cvt_f32_4 = __bfloat162float(beta1_cg1);
+                        __nv_bfloat162 _bf16x2_6 = __float22bfloat162_rn(make_float2(_cvt_f32_3, _cvt_f32_4));
+                        beta_pairs_cg1[beta_reg_cg1] = _bf16x2_6;
+                    }
+                    unsigned int y_words_lo_cg1[4];
+                    unsigned int y_words_hi_cg1[4];
+                    #pragma unroll
+                    for (int rhs_reg_cg1 = 0; rhs_reg_cg1 < 4; rhs_reg_cg1++) {
+                        int rhs_raw_matrix_cg1 = rhs_reg_cg1;
+                        int rhs_frag_pair_cg1 = rhs_reg_cg1 * 2;
+                        __nv_bfloat162 _bf16x2_7 = __float22bfloat162_rn(make_float2(_tmem_load_3[rhs_frag_pair_cg1], _tmem_load_3[rhs_frag_pair_cg1 + 1]));
+                        __nv_bfloat162 _bf16x2_8 = __float22bfloat162_rn(make_float2(_tmem_load_4[rhs_frag_pair_cg1], _tmem_load_4[rhs_frag_pair_cg1 + 1]));
+                        uint32_t _bf16x2_sub_0;
+                        asm volatile("sub.rn.bf16x2 %0, %1, %2;" : "=r"(_bf16x2_sub_0) : "r"(raw_v_words_lo_cg1[rhs_raw_matrix_cg1]), "r"(__as_u32(_bf16x2_7)));
+                        uint32_t _bf16x2_sub_1;
+                        asm volatile("sub.rn.bf16x2 %0, %1, %2;" : "=r"(_bf16x2_sub_1) : "r"(raw_v_words_hi_cg1[rhs_raw_matrix_cg1]), "r"(__as_u32(_bf16x2_8)));
+                        __nv_bfloat162 rhs_diff_pair_lo_cg1 = __as_bf16x2(_bf16x2_sub_0);
+                        __nv_bfloat162 rhs_diff_pair_hi_cg1 = __as_bf16x2(_bf16x2_sub_1);
+                        __nv_bfloat162 y_pair_lo_cg1 = beta_pairs_cg1[rhs_reg_cg1] * rhs_diff_pair_lo_cg1;
+                        __nv_bfloat162 y_pair_hi_cg1 = beta_pairs_cg1[rhs_reg_cg1] * rhs_diff_pair_hi_cg1;
+                        y_words_lo_cg1[rhs_reg_cg1] = __as_u32(y_pair_lo_cg1);
+                        y_words_hi_cg1[rhs_reg_cg1] = __as_u32(y_pair_hi_cg1);
+                    }
+                    asm volatile(
+                        "tcgen05.st.sync.aligned.16x128b.x2.b32"
+                        " [%0], {%1, %2, %3, %4};"
+                        :: "r"(taddr + 256 + (unsigned int)tmem_row_base_cg1), "r"(*reinterpret_cast<const uint32_t*>(&y_words_lo_cg1[0])), "r"(*reinterpret_cast<const uint32_t*>(&y_words_lo_cg1[1])), "r"(*reinterpret_cast<const uint32_t*>(&y_words_lo_cg1[2])), "r"(*reinterpret_cast<const uint32_t*>(&y_words_lo_cg1[3]))
+                        : "memory");
+                    asm volatile(
+                        "tcgen05.st.sync.aligned.16x128b.x2.b32"
+                        " [%0], {%1, %2, %3, %4};"
+                        :: "r"(taddr + 256 + (unsigned int)tmem_row_base_cg1 + 1048576), "r"(*reinterpret_cast<const uint32_t*>(&y_words_hi_cg1[0])), "r"(*reinterpret_cast<const uint32_t*>(&y_words_hi_cg1[1])), "r"(*reinterpret_cast<const uint32_t*>(&y_words_hi_cg1[2])), "r"(*reinterpret_cast<const uint32_t*>(&y_words_hi_cg1[3]))
+                        : "memory");
+                    asm volatile("tcgen05.wait::st.sync.aligned;" ::: "memory");
+                    mbarrier_arrive(v_done_addr + (raw_stage_cg1) * 8);
+                    mbarrier_arrive(beta_done_addr + (raw_bar_stage_cg1) * 8);
+                    mbarrier_arrive(y_inp_ready_addr);
+                    mbarrier_wait(u_acc_ready_addr, state_phase_cg1);
+                    float _tmem_load_5[16];
+                    tmem_ld_x16(&_tmem_load_5[0], taddr + 240 + (unsigned int)tmem_row_base_cg1);
+                    asm volatile("tcgen05.wait::ld.sync.aligned;" ::: "memory");
+                    unsigned int u_words_cg1[8];
+                    #pragma unroll
+                    for (int _lp = 0; _lp < 8; _lp++) {
+                        __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(_tmem_load_5[_lp*2 + 0], _tmem_load_5[_lp*2+1 + 0]));
+                        u_words_cg1[_lp] = *(uint32_t*)&_bf2;
+                    }
+                    tmem_st_x8_u32(taddr + 264 + (unsigned int)tmem_row_base_cg1, (const uint32_t*)u_words_cg1);
+                    asm volatile("tcgen05.wait::st.sync.aligned;" ::: "memory");
+                    mbarrier_arrive(u_inp_ready_addr);
+                }
+                #pragma unroll 1
+                for (int chunk_cg1 = 1; chunk_cg1 < chunks_cg1; chunk_cg1++) {
+                    int cumulative_cg1_1 = cumulative_chunk_cg1 + chunk_cg1;
+                    unsigned int raw_stage_cg1_1 = (unsigned int)(cumulative_cg1_1 % 5);
+                    unsigned int raw_bar_stage_cg1_1 = (unsigned int)(cumulative_cg1_1 % 6);
+                    unsigned int o_stage_cg1_1 = (unsigned int)(cumulative_cg1_1 % 2);
+                    unsigned int checkpoint_stage_cg1_1 = (unsigned int)(cumulative_cg1_1 % 2);
+                    unsigned int state_phase_cg1_1 = (unsigned int)(cumulative_cg1_1 & 1);
+                    {
+                        mbarrier_wait(state_acc_done_addr, (unsigned int)(cumulative_cg1_1 - 1 & 1));
+                    }
+                    float _tmem_load_6[128];
+                    tmem_ld_x16(&_tmem_load_6[0], taddr + (unsigned int)tmem_row_base_cg1);
+                    tmem_ld_x16(&_tmem_load_6[16], taddr + (unsigned int)tmem_row_base_cg1 + 16);
+                    tmem_ld_x16(&_tmem_load_6[32], taddr + (unsigned int)tmem_row_base_cg1 + 32);
+                    tmem_ld_x16(&_tmem_load_6[48], taddr + (unsigned int)tmem_row_base_cg1 + 48);
+                    tmem_ld_x16(&_tmem_load_6[64], taddr + (unsigned int)tmem_row_base_cg1 + 64);
+                    tmem_ld_x16(&_tmem_load_6[80], taddr + (unsigned int)tmem_row_base_cg1 + 80);
+                    tmem_ld_x16(&_tmem_load_6[96], taddr + (unsigned int)tmem_row_base_cg1 + 96);
+                    tmem_ld_x16(&_tmem_load_6[112], taddr + (unsigned int)tmem_row_base_cg1 + 112);
+                    asm volatile("tcgen05.wait::ld.sync.aligned;" ::: "memory");
+                    {
+                        mbarrier_wait(checkpoint_done_addr + (checkpoint_stage_cg1_1) * 8, (unsigned int)(cumulative_cg1_1 / 2 + 1 & 1));
+                    }
+                    unsigned int state_words_cg1_1[8];
+                    #pragma unroll
+                    for (int _lp = 0; _lp < 8; _lp++) {
+                        __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(_tmem_load_6[_lp*2 + 0], _tmem_load_6[_lp*2+1 + 0]));
+                        state_words_cg1_1[_lp] = *(uint32_t*)&_bf2;
+                    }
+                    tmem_st_x8_u32(taddr + 128 + (unsigned int)tmem_row_base_cg1, (const uint32_t*)state_words_cg1_1);
+                    {
+                        asm volatile("st.shared.v4.b32 [%0], {%1,%2,%3,%4};" :: "r"((smem_checkpoint_addr + checkpoint_stage_cg1_1 * 32768 + (unsigned int)(value_row_cg1 * 128 ^ (value_row_cg1 * 128 >> 7 & 7) << 4))), "r"(state_words_cg1_1[0]), "r"(state_words_cg1_1[1]), "r"(state_words_cg1_1[2]), "r"(state_words_cg1_1[3]) : "memory");
+                        asm volatile("st.shared.v4.b32 [%0], {%1,%2,%3,%4};" :: "r"((smem_checkpoint_addr + checkpoint_stage_cg1_1 * 32768 + (unsigned int)(value_row_cg1 * 128 + 16 ^ (value_row_cg1 * 128 + 16 >> 7 & 7) << 4))), "r"(state_words_cg1_1[4]), "r"(state_words_cg1_1[5]), "r"(state_words_cg1_1[6]), "r"(state_words_cg1_1[7]) : "memory");
+                    }
+                    #pragma unroll
+                    for (int _lp = 0; _lp < 8; _lp++) {
+                        __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(_tmem_load_6[_lp*2 + 16], _tmem_load_6[_lp*2+1 + 16]));
+                        state_words_cg1_1[_lp] = *(uint32_t*)&_bf2;
+                    }
+                    tmem_st_x8_u32(taddr + 128 + (unsigned int)tmem_row_base_cg1 + 8, (const uint32_t*)state_words_cg1_1);
+                    {
+                        asm volatile("st.shared.v4.b32 [%0], {%1,%2,%3,%4};" :: "r"((smem_checkpoint_addr + checkpoint_stage_cg1_1 * 32768 + (unsigned int)(value_row_cg1 * 128 + 32 ^ (value_row_cg1 * 128 + 32 >> 7 & 7) << 4))), "r"(state_words_cg1_1[0]), "r"(state_words_cg1_1[1]), "r"(state_words_cg1_1[2]), "r"(state_words_cg1_1[3]) : "memory");
+                        asm volatile("st.shared.v4.b32 [%0], {%1,%2,%3,%4};" :: "r"((smem_checkpoint_addr + checkpoint_stage_cg1_1 * 32768 + (unsigned int)(value_row_cg1 * 128 + 48 ^ (value_row_cg1 * 128 + 48 >> 7 & 7) << 4))), "r"(state_words_cg1_1[4]), "r"(state_words_cg1_1[5]), "r"(state_words_cg1_1[6]), "r"(state_words_cg1_1[7]) : "memory");
+                    }
+                    #pragma unroll
+                    for (int _lp = 0; _lp < 8; _lp++) {
+                        __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(_tmem_load_6[_lp*2 + 32], _tmem_load_6[_lp*2+1 + 32]));
+                        state_words_cg1_1[_lp] = *(uint32_t*)&_bf2;
+                    }
+                    tmem_st_x8_u32(taddr + 128 + (unsigned int)tmem_row_base_cg1 + 16, (const uint32_t*)state_words_cg1_1);
+                    {
+                        asm volatile("st.shared.v4.b32 [%0], {%1,%2,%3,%4};" :: "r"((smem_checkpoint_addr + checkpoint_stage_cg1_1 * 32768 + (unsigned int)(value_row_cg1 * 128 + 64 ^ (value_row_cg1 * 128 + 64 >> 7 & 7) << 4))), "r"(state_words_cg1_1[0]), "r"(state_words_cg1_1[1]), "r"(state_words_cg1_1[2]), "r"(state_words_cg1_1[3]) : "memory");
+                        asm volatile("st.shared.v4.b32 [%0], {%1,%2,%3,%4};" :: "r"((smem_checkpoint_addr + checkpoint_stage_cg1_1 * 32768 + (unsigned int)(value_row_cg1 * 128 + 80 ^ (value_row_cg1 * 128 + 80 >> 7 & 7) << 4))), "r"(state_words_cg1_1[4]), "r"(state_words_cg1_1[5]), "r"(state_words_cg1_1[6]), "r"(state_words_cg1_1[7]) : "memory");
+                    }
+                    #pragma unroll
+                    for (int _lp = 0; _lp < 8; _lp++) {
+                        __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(_tmem_load_6[_lp*2 + 48], _tmem_load_6[_lp*2+1 + 48]));
+                        state_words_cg1_1[_lp] = *(uint32_t*)&_bf2;
+                    }
+                    tmem_st_x8_u32(taddr + 128 + (unsigned int)tmem_row_base_cg1 + 24, (const uint32_t*)state_words_cg1_1);
+                    {
+                        asm volatile("st.shared.v4.b32 [%0], {%1,%2,%3,%4};" :: "r"((smem_checkpoint_addr + checkpoint_stage_cg1_1 * 32768 + (unsigned int)(value_row_cg1 * 128 + 96 ^ (value_row_cg1 * 128 + 96 >> 7 & 7) << 4))), "r"(state_words_cg1_1[0]), "r"(state_words_cg1_1[1]), "r"(state_words_cg1_1[2]), "r"(state_words_cg1_1[3]) : "memory");
+                        asm volatile("st.shared.v4.b32 [%0], {%1,%2,%3,%4};" :: "r"((smem_checkpoint_addr + checkpoint_stage_cg1_1 * 32768 + (unsigned int)(value_row_cg1 * 128 + 112 ^ (value_row_cg1 * 128 + 112 >> 7 & 7) << 4))), "r"(state_words_cg1_1[4]), "r"(state_words_cg1_1[5]), "r"(state_words_cg1_1[6]), "r"(state_words_cg1_1[7]) : "memory");
+                    }
+                    #pragma unroll
+                    for (int _lp = 0; _lp < 8; _lp++) {
+                        __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(_tmem_load_6[_lp*2 + 64], _tmem_load_6[_lp*2+1 + 64]));
+                        state_words_cg1_1[_lp] = *(uint32_t*)&_bf2;
+                    }
+                    tmem_st_x8_u32(taddr + 128 + (unsigned int)tmem_row_base_cg1 + 32, (const uint32_t*)state_words_cg1_1);
+                    {
+                        asm volatile("st.shared.v4.b32 [%0], {%1,%2,%3,%4};" :: "r"((smem_checkpoint_addr + checkpoint_stage_cg1_1 * 32768 + (unsigned int)(16384 + value_row_cg1 * 128 ^ (16384 + value_row_cg1 * 128 >> 7 & 7) << 4))), "r"(state_words_cg1_1[0]), "r"(state_words_cg1_1[1]), "r"(state_words_cg1_1[2]), "r"(state_words_cg1_1[3]) : "memory");
+                        asm volatile("st.shared.v4.b32 [%0], {%1,%2,%3,%4};" :: "r"((smem_checkpoint_addr + checkpoint_stage_cg1_1 * 32768 + (unsigned int)(16384 + value_row_cg1 * 128 + 16 ^ (16384 + value_row_cg1 * 128 + 16 >> 7 & 7) << 4))), "r"(state_words_cg1_1[4]), "r"(state_words_cg1_1[5]), "r"(state_words_cg1_1[6]), "r"(state_words_cg1_1[7]) : "memory");
+                    }
+                    #pragma unroll
+                    for (int _lp = 0; _lp < 8; _lp++) {
+                        __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(_tmem_load_6[_lp*2 + 80], _tmem_load_6[_lp*2+1 + 80]));
+                        state_words_cg1_1[_lp] = *(uint32_t*)&_bf2;
+                    }
+                    tmem_st_x8_u32(taddr + 128 + (unsigned int)tmem_row_base_cg1 + 40, (const uint32_t*)state_words_cg1_1);
+                    {
+                        asm volatile("st.shared.v4.b32 [%0], {%1,%2,%3,%4};" :: "r"((smem_checkpoint_addr + checkpoint_stage_cg1_1 * 32768 + (unsigned int)(16384 + value_row_cg1 * 128 + 32 ^ (16384 + value_row_cg1 * 128 + 32 >> 7 & 7) << 4))), "r"(state_words_cg1_1[0]), "r"(state_words_cg1_1[1]), "r"(state_words_cg1_1[2]), "r"(state_words_cg1_1[3]) : "memory");
+                        asm volatile("st.shared.v4.b32 [%0], {%1,%2,%3,%4};" :: "r"((smem_checkpoint_addr + checkpoint_stage_cg1_1 * 32768 + (unsigned int)(16384 + value_row_cg1 * 128 + 48 ^ (16384 + value_row_cg1 * 128 + 48 >> 7 & 7) << 4))), "r"(state_words_cg1_1[4]), "r"(state_words_cg1_1[5]), "r"(state_words_cg1_1[6]), "r"(state_words_cg1_1[7]) : "memory");
+                    }
+                    #pragma unroll
+                    for (int _lp = 0; _lp < 8; _lp++) {
+                        __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(_tmem_load_6[_lp*2 + 96], _tmem_load_6[_lp*2+1 + 96]));
+                        state_words_cg1_1[_lp] = *(uint32_t*)&_bf2;
+                    }
+                    tmem_st_x8_u32(taddr + 128 + (unsigned int)tmem_row_base_cg1 + 48, (const uint32_t*)state_words_cg1_1);
+                    {
+                        asm volatile("st.shared.v4.b32 [%0], {%1,%2,%3,%4};" :: "r"((smem_checkpoint_addr + checkpoint_stage_cg1_1 * 32768 + (unsigned int)(16384 + value_row_cg1 * 128 + 64 ^ (16384 + value_row_cg1 * 128 + 64 >> 7 & 7) << 4))), "r"(state_words_cg1_1[0]), "r"(state_words_cg1_1[1]), "r"(state_words_cg1_1[2]), "r"(state_words_cg1_1[3]) : "memory");
+                        asm volatile("st.shared.v4.b32 [%0], {%1,%2,%3,%4};" :: "r"((smem_checkpoint_addr + checkpoint_stage_cg1_1 * 32768 + (unsigned int)(16384 + value_row_cg1 * 128 + 80 ^ (16384 + value_row_cg1 * 128 + 80 >> 7 & 7) << 4))), "r"(state_words_cg1_1[4]), "r"(state_words_cg1_1[5]), "r"(state_words_cg1_1[6]), "r"(state_words_cg1_1[7]) : "memory");
+                    }
+                    #pragma unroll
+                    for (int _lp = 0; _lp < 8; _lp++) {
+                        __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(_tmem_load_6[_lp*2 + 112], _tmem_load_6[_lp*2+1 + 112]));
+                        state_words_cg1_1[_lp] = *(uint32_t*)&_bf2;
+                    }
+                    tmem_st_x8_u32(taddr + 128 + (unsigned int)tmem_row_base_cg1 + 56, (const uint32_t*)state_words_cg1_1);
+                    {
+                        asm volatile("st.shared.v4.b32 [%0], {%1,%2,%3,%4};" :: "r"((smem_checkpoint_addr + checkpoint_stage_cg1_1 * 32768 + (unsigned int)(16384 + value_row_cg1 * 128 + 96 ^ (16384 + value_row_cg1 * 128 + 96 >> 7 & 7) << 4))), "r"(state_words_cg1_1[0]), "r"(state_words_cg1_1[1]), "r"(state_words_cg1_1[2]), "r"(state_words_cg1_1[3]) : "memory");
+                        asm volatile("st.shared.v4.b32 [%0], {%1,%2,%3,%4};" :: "r"((smem_checkpoint_addr + checkpoint_stage_cg1_1 * 32768 + (unsigned int)(16384 + value_row_cg1 * 128 + 112 ^ (16384 + value_row_cg1 * 128 + 112 >> 7 & 7) << 4))), "r"(state_words_cg1_1[4]), "r"(state_words_cg1_1[5]), "r"(state_words_cg1_1[6]), "r"(state_words_cg1_1[7]) : "memory");
+                    }
+                    asm volatile("tcgen05.wait::st.sync.aligned;" ::: "memory");
+                    mbarrier_arrive(state_inp_ready_addr);
+                    {
+                        asm volatile("fence.proxy.async.shared::cta;" ::: "memory");
+                        mbarrier_arrive(state_read_done_addr);
+                        mbarrier_arrive(checkpoint_ready_addr + (checkpoint_stage_cg1_1) * 8);
+                    }
+                    {
+                        int previous_event_cg1 = cumulative_cg1_1 - 1;
+                        unsigned int previous_o_stage_cg1 = (unsigned int)(previous_event_cg1 % 2);
+                        mbarrier_wait(o_acc_ready_addr, (unsigned int)(previous_event_cg1 & 1));
+                        mbarrier_wait(o_tma_done_addr + (previous_o_stage_cg1) * 8, (unsigned int)(previous_event_cg1 / 2 + 1 & 1));
+                        int output_col_cg1 = 192 + (int)previous_o_stage_cg1 * 16;
+                        float _tmem_load_7[8];
+                        asm volatile(
+                            "tcgen05.ld.sync.aligned.16x256b.x2.b32"
+                            " {%0, %1, %2, %3, %4, %5, %6, %7}, [%8];"
+                            : "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_7[0])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_7[1])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_7[2])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_7[3])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_7[4])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_7[5])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_7[6])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_7[7]))
+                            : "r"(taddr + (unsigned int)output_col_cg1 + (unsigned int)tmem_row_base_cg1)
+                            : "memory");
+                        float _tmem_load_8[8];
+                        asm volatile(
+                            "tcgen05.ld.sync.aligned.16x256b.x2.b32"
+                            " {%0, %1, %2, %3, %4, %5, %6, %7}, [%8];"
+                            : "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_8[0])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_8[1])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_8[2])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_8[3])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_8[4])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_8[5])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_8[6])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_8[7]))
+                            : "r"(taddr + (unsigned int)output_col_cg1 + (unsigned int)tmem_row_base_cg1 + 1048576)
+                            : "memory");
+                        const float2 _scale2_1 = {scale, scale};
+                        #pragma unroll
+                        for (int _ls = 0; _ls < 4; _ls++)
+                            mul_f32x2_inplace(&reinterpret_cast<float2*>(_tmem_load_7)[_ls], _scale2_1);
+                        const float2 _scale2_2 = {scale, scale};
+                        #pragma unroll
+                        for (int _ls = 0; _ls < 4; _ls++)
+                            mul_f32x2_inplace(&reinterpret_cast<float2*>(_tmem_load_8)[_ls], _scale2_2);
+                        uint32_t _tmem_load_7_bf16[4];
+                        #pragma unroll
+                        for (int _lp = 0; _lp < 4; _lp++) {
+                            __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(_tmem_load_7[_lp*2 + 0], _tmem_load_7[_lp*2+1 + 0]));
+                            _tmem_load_7_bf16[_lp] = *(uint32_t*)&_bf2;
+                        }
+                        uint32_t _tmem_load_8_bf16[4];
+                        #pragma unroll
+                        for (int _lp = 0; _lp < 4; _lp++) {
+                            __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(_tmem_load_8[_lp*2 + 0], _tmem_load_8[_lp*2+1 + 0]));
+                            _tmem_load_8_bf16[_lp] = *(uint32_t*)&_bf2;
+                        }
+                        int segment_4 = (value_dim_base_cg1 + ov_col_cg1) / 64;
+                        int segment_col_4 = value_dim_base_cg1 + ov_col_cg1 - segment_4 * 64;
+                        int swizzled_col_4 = segment_col_4 ^ (ov_token_cg1 & 7) * 8;
+                        int segment_0_2 = (value_dim_base_cg1 + 16 + ov_col_cg1) / 64;
+                        int segment_col_1_3 = value_dim_base_cg1 + 16 + ov_col_cg1 - segment_0_2 * 64;
+                        int swizzled_col_2_3 = segment_col_1_3 ^ (ov_token_cg1 & 7) * 8;
+                        uint32_t _stmatrix_addr_3 = static_cast<uint32_t>((unsigned long long)(smem_o_all_addr + (unsigned int)(((int)previous_o_stage_cg1 * 16 * 128 + segment_4 * 16 * 64 + ov_token_cg1 * 64 + swizzled_col_4) * 2)));
+                        asm volatile("stmatrix.sync.aligned.m8n8.x4.trans.shared.b16 [%0], {%1, %2, %3, %4};\n"
+                            :: "r"(_stmatrix_addr_3), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_7_bf16[0])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_7_bf16[1])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_7_bf16[2])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_7_bf16[3]))
+                            : "memory");
+                        uint32_t _stmatrix_addr_4 = static_cast<uint32_t>((unsigned long long)(smem_o_all_addr + (unsigned int)(((int)previous_o_stage_cg1 * 16 * 128 + segment_0_2 * 16 * 64 + ov_token_cg1 * 64 + swizzled_col_2_3) * 2)));
+                        asm volatile("stmatrix.sync.aligned.m8n8.x4.trans.shared.b16 [%0], {%1, %2, %3, %4};\n"
+                            :: "r"(_stmatrix_addr_4), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_8_bf16[0])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_8_bf16[1])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_8_bf16[2])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_8_bf16[3]))
+                            : "memory");
+                        mbarrier_arrive(o_acc_done_addr + (previous_o_stage_cg1) * 8);
+                        asm volatile("fence.proxy.async.shared::cta;" ::: "memory");
+                        mbarrier_arrive(o_tma_ready_addr + (previous_o_stage_cg1) * 8);
+                    }
+                    mbarrier_wait(v_ready_addr + (raw_bar_stage_cg1_1) * 8, (unsigned int)(cumulative_cg1_1 / 6 & 1));
+                    mbarrier_wait(beta_ready_addr + (raw_bar_stage_cg1_1) * 8, (unsigned int)(cumulative_cg1_1 / 6 & 1));
+                    mbarrier_wait(state_k_ready_addr, state_phase_cg1_1);
+                    float _tmem_load_9[8];
+                    asm volatile(
+                        "tcgen05.ld.sync.aligned.16x256b.x2.b32"
+                        " {%0, %1, %2, %3, %4, %5, %6, %7}, [%8];"
+                        : "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_9[0])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_9[1])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_9[2])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_9[3])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_9[4])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_9[5])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_9[6])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_9[7]))
+                        : "r"(taddr + 224 + (unsigned int)tmem_row_base_cg1)
+                        : "memory");
+                    float _tmem_load_10[8];
+                    asm volatile(
+                        "tcgen05.ld.sync.aligned.16x256b.x2.b32"
+                        " {%0, %1, %2, %3, %4, %5, %6, %7}, [%8];"
+                        : "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_10[0])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_10[1])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_10[2])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_10[3])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_10[4])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_10[5])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_10[6])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_10[7]))
+                        : "r"(taddr + 224 + (unsigned int)tmem_row_base_cg1 + 1048576)
+                        : "memory");
+                    unsigned int raw_v_words_lo_cg1_1[4];
+                    unsigned int raw_v_words_hi_cg1_1[4];
+                    int segment_5 = (value_dim_base_cg1 + ov_col_cg1) / 64;
+                    int segment_col_5 = value_dim_base_cg1 + ov_col_cg1 - segment_5 * 64;
+                    int swizzled_col_5 = segment_col_5 ^ (ov_token_cg1 & 7) * 8;
+                    asm volatile("ldmatrix.sync.aligned.m8n8.x4.trans.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                        : "=r"(raw_v_words_lo_cg1_1[0]), "=r"(raw_v_words_lo_cg1_1[1]), "=r"(raw_v_words_lo_cg1_1[2]), "=r"(raw_v_words_lo_cg1_1[3])
+                        : "r"(smem_v_all_addr + (raw_stage_cg1_1 * 16 * 128 + (unsigned int)(segment_5 * 16 * 64) + (unsigned int)(ov_token_cg1 * 64) + (unsigned int)swizzled_col_5) * 2)
+                        : "memory");
+                    int segment_0_3 = (value_dim_base_cg1 + 16 + ov_col_cg1) / 64;
+                    int segment_col_1_4 = value_dim_base_cg1 + 16 + ov_col_cg1 - segment_0_3 * 64;
+                    int swizzled_col_2_4 = segment_col_1_4 ^ (ov_token_cg1 & 7) * 8;
+                    asm volatile("ldmatrix.sync.aligned.m8n8.x4.trans.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                        : "=r"(raw_v_words_hi_cg1_1[0]), "=r"(raw_v_words_hi_cg1_1[1]), "=r"(raw_v_words_hi_cg1_1[2]), "=r"(raw_v_words_hi_cg1_1[3])
+                        : "r"(smem_v_all_addr + (raw_stage_cg1_1 * 16 * 128 + (unsigned int)(segment_0_3 * 16 * 64) + (unsigned int)(ov_token_cg1 * 64) + (unsigned int)swizzled_col_2_4) * 2)
+                        : "memory");
+                    asm volatile("tcgen05.wait::ld.sync.aligned;" ::: "memory");
+                    __nv_bfloat162 beta_pairs_cg1_1[4];
+                    #pragma unroll
+                    for (int beta_reg_cg1_1 = 0; beta_reg_cg1_1 < 4; beta_reg_cg1_1++) {
+                        int beta_packed_col_cg1_1 = beta_reg_cg1_1 / 2 * 4 + (lane & 3);
+                        int beta_token0_cg1_1 = beta_packed_col_cg1_1 * 2;
+                        int beta_token1_cg1_1 = beta_token0_cg1_1 + 1;
+                        __nv_bfloat16 beta0_cg1_1 = smem_beta_all[(int)raw_bar_stage_cg1_1 * 16 + beta_token0_cg1_1];
+                        __nv_bfloat16 beta1_cg1_1 = smem_beta_all[(int)raw_bar_stage_cg1_1 * 16 + beta_token1_cg1_1];
+                        float _cvt_f32_5 = __bfloat162float(beta0_cg1_1);
+                        float _cvt_f32_6 = __bfloat162float(beta1_cg1_1);
+                        __nv_bfloat162 _bf16x2_9 = __float22bfloat162_rn(make_float2(_cvt_f32_5, _cvt_f32_6));
+                        beta_pairs_cg1_1[beta_reg_cg1_1] = _bf16x2_9;
+                    }
+                    unsigned int y_words_lo_cg1_1[4];
+                    unsigned int y_words_hi_cg1_1[4];
+                    #pragma unroll
+                    for (int rhs_reg_cg1_1 = 0; rhs_reg_cg1_1 < 4; rhs_reg_cg1_1++) {
+                        int rhs_raw_matrix_cg1_1 = rhs_reg_cg1_1;
+                        int rhs_frag_pair_cg1_1 = rhs_reg_cg1_1 * 2;
+                        __nv_bfloat162 _bf16x2_10 = __float22bfloat162_rn(make_float2(_tmem_load_9[rhs_frag_pair_cg1_1], _tmem_load_9[rhs_frag_pair_cg1_1 + 1]));
+                        __nv_bfloat162 _bf16x2_11 = __float22bfloat162_rn(make_float2(_tmem_load_10[rhs_frag_pair_cg1_1], _tmem_load_10[rhs_frag_pair_cg1_1 + 1]));
+                        uint32_t _bf16x2_sub_2;
+                        asm volatile("sub.rn.bf16x2 %0, %1, %2;" : "=r"(_bf16x2_sub_2) : "r"(raw_v_words_lo_cg1_1[rhs_raw_matrix_cg1_1]), "r"(__as_u32(_bf16x2_10)));
+                        uint32_t _bf16x2_sub_3;
+                        asm volatile("sub.rn.bf16x2 %0, %1, %2;" : "=r"(_bf16x2_sub_3) : "r"(raw_v_words_hi_cg1_1[rhs_raw_matrix_cg1_1]), "r"(__as_u32(_bf16x2_11)));
+                        __nv_bfloat162 rhs_diff_pair_lo_cg1_1 = __as_bf16x2(_bf16x2_sub_2);
+                        __nv_bfloat162 rhs_diff_pair_hi_cg1_1 = __as_bf16x2(_bf16x2_sub_3);
+                        __nv_bfloat162 y_pair_lo_cg1_1 = beta_pairs_cg1_1[rhs_reg_cg1_1] * rhs_diff_pair_lo_cg1_1;
+                        __nv_bfloat162 y_pair_hi_cg1_1 = beta_pairs_cg1_1[rhs_reg_cg1_1] * rhs_diff_pair_hi_cg1_1;
+                        y_words_lo_cg1_1[rhs_reg_cg1_1] = __as_u32(y_pair_lo_cg1_1);
+                        y_words_hi_cg1_1[rhs_reg_cg1_1] = __as_u32(y_pair_hi_cg1_1);
+                    }
+                    asm volatile(
+                        "tcgen05.st.sync.aligned.16x128b.x2.b32"
+                        " [%0], {%1, %2, %3, %4};"
+                        :: "r"(taddr + 256 + (unsigned int)tmem_row_base_cg1), "r"(*reinterpret_cast<const uint32_t*>(&y_words_lo_cg1_1[0])), "r"(*reinterpret_cast<const uint32_t*>(&y_words_lo_cg1_1[1])), "r"(*reinterpret_cast<const uint32_t*>(&y_words_lo_cg1_1[2])), "r"(*reinterpret_cast<const uint32_t*>(&y_words_lo_cg1_1[3]))
+                        : "memory");
+                    asm volatile(
+                        "tcgen05.st.sync.aligned.16x128b.x2.b32"
+                        " [%0], {%1, %2, %3, %4};"
+                        :: "r"(taddr + 256 + (unsigned int)tmem_row_base_cg1 + 1048576), "r"(*reinterpret_cast<const uint32_t*>(&y_words_hi_cg1_1[0])), "r"(*reinterpret_cast<const uint32_t*>(&y_words_hi_cg1_1[1])), "r"(*reinterpret_cast<const uint32_t*>(&y_words_hi_cg1_1[2])), "r"(*reinterpret_cast<const uint32_t*>(&y_words_hi_cg1_1[3]))
+                        : "memory");
+                    asm volatile("tcgen05.wait::st.sync.aligned;" ::: "memory");
+                    mbarrier_arrive(v_done_addr + (raw_stage_cg1_1) * 8);
+                    mbarrier_arrive(beta_done_addr + (raw_bar_stage_cg1_1) * 8);
+                    mbarrier_arrive(y_inp_ready_addr);
+                    mbarrier_wait(u_acc_ready_addr, state_phase_cg1_1);
+                    float _tmem_load_11[16];
+                    tmem_ld_x16(&_tmem_load_11[0], taddr + 240 + (unsigned int)tmem_row_base_cg1);
+                    asm volatile("tcgen05.wait::ld.sync.aligned;" ::: "memory");
+                    unsigned int u_words_cg1_1[8];
+                    #pragma unroll
+                    for (int _lp = 0; _lp < 8; _lp++) {
+                        __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(_tmem_load_11[_lp*2 + 0], _tmem_load_11[_lp*2+1 + 0]));
+                        u_words_cg1_1[_lp] = *(uint32_t*)&_bf2;
+                    }
+                    tmem_st_x8_u32(taddr + 264 + (unsigned int)tmem_row_base_cg1, (const uint32_t*)u_words_cg1_1);
+                    asm volatile("tcgen05.wait::st.sync.aligned;" ::: "memory");
+                    mbarrier_arrive(u_inp_ready_addr);
+                }
+                if (chunks_cg1 > 0) {
+                    int final_event_cg1 = cumulative_chunk_cg1 + chunks_cg1 - 1;
+                    unsigned int final_o_stage_cg1 = (unsigned int)(final_event_cg1 % 2);
+                    mbarrier_wait(state_acc_done_addr, (unsigned int)(final_event_cg1 & 1));
+                    mbarrier_wait(o_acc_ready_addr, (unsigned int)(final_event_cg1 & 1));
+                    mbarrier_wait(o_tma_done_addr + (final_o_stage_cg1) * 8, (unsigned int)(final_event_cg1 / 2 + 1 & 1));
+                    int output_col_cg1_1 = 192 + (int)final_o_stage_cg1 * 16;
+                    float _tmem_load_12[8];
+                    asm volatile(
+                        "tcgen05.ld.sync.aligned.16x256b.x2.b32"
+                        " {%0, %1, %2, %3, %4, %5, %6, %7}, [%8];"
+                        : "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_12[0])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_12[1])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_12[2])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_12[3])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_12[4])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_12[5])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_12[6])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_12[7]))
+                        : "r"(taddr + (unsigned int)output_col_cg1_1 + (unsigned int)tmem_row_base_cg1)
+                        : "memory");
+                    float _tmem_load_13[8];
+                    asm volatile(
+                        "tcgen05.ld.sync.aligned.16x256b.x2.b32"
+                        " {%0, %1, %2, %3, %4, %5, %6, %7}, [%8];"
+                        : "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_13[0])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_13[1])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_13[2])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_13[3])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_13[4])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_13[5])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_13[6])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_13[7]))
+                        : "r"(taddr + (unsigned int)output_col_cg1_1 + (unsigned int)tmem_row_base_cg1 + 1048576)
+                        : "memory");
+                    const float2 _scale2_5 = {scale, scale};
+                    #pragma unroll
+                    for (int _ls = 0; _ls < 4; _ls++)
+                        mul_f32x2_inplace(&reinterpret_cast<float2*>(_tmem_load_12)[_ls], _scale2_5);
+                    const float2 _scale2_6 = {scale, scale};
+                    #pragma unroll
+                    for (int _ls = 0; _ls < 4; _ls++)
+                        mul_f32x2_inplace(&reinterpret_cast<float2*>(_tmem_load_13)[_ls], _scale2_6);
+                    uint32_t _tmem_load_12_bf16[4];
+                    #pragma unroll
+                    for (int _lp = 0; _lp < 4; _lp++) {
+                        __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(_tmem_load_12[_lp*2 + 0], _tmem_load_12[_lp*2+1 + 0]));
+                        _tmem_load_12_bf16[_lp] = *(uint32_t*)&_bf2;
+                    }
+                    uint32_t _tmem_load_13_bf16[4];
+                    #pragma unroll
+                    for (int _lp = 0; _lp < 4; _lp++) {
+                        __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(_tmem_load_13[_lp*2 + 0], _tmem_load_13[_lp*2+1 + 0]));
+                        _tmem_load_13_bf16[_lp] = *(uint32_t*)&_bf2;
+                    }
+                    int segment_6 = (value_dim_base_cg1 + ov_col_cg1) / 64;
+                    int segment_col_6 = value_dim_base_cg1 + ov_col_cg1 - segment_6 * 64;
+                    int swizzled_col_6 = segment_col_6 ^ (ov_token_cg1 & 7) * 8;
+                    int segment_0_4 = (value_dim_base_cg1 + 16 + ov_col_cg1) / 64;
+                    int segment_col_1_5 = value_dim_base_cg1 + 16 + ov_col_cg1 - segment_0_4 * 64;
+                    int swizzled_col_2_5 = segment_col_1_5 ^ (ov_token_cg1 & 7) * 8;
+                    uint32_t _stmatrix_addr_7 = static_cast<uint32_t>((unsigned long long)(smem_o_all_addr + (unsigned int)(((int)final_o_stage_cg1 * 16 * 128 + segment_6 * 16 * 64 + ov_token_cg1 * 64 + swizzled_col_6) * 2)));
+                    asm volatile("stmatrix.sync.aligned.m8n8.x4.trans.shared.b16 [%0], {%1, %2, %3, %4};\n"
+                        :: "r"(_stmatrix_addr_7), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_12_bf16[0])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_12_bf16[1])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_12_bf16[2])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_12_bf16[3]))
+                        : "memory");
+                    uint32_t _stmatrix_addr_8 = static_cast<uint32_t>((unsigned long long)(smem_o_all_addr + (unsigned int)(((int)final_o_stage_cg1 * 16 * 128 + segment_0_4 * 16 * 64 + ov_token_cg1 * 64 + swizzled_col_2_5) * 2)));
+                    asm volatile("stmatrix.sync.aligned.m8n8.x4.trans.shared.b16 [%0], {%1, %2, %3, %4};\n"
+                        :: "r"(_stmatrix_addr_8), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_13_bf16[0])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_13_bf16[1])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_13_bf16[2])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_13_bf16[3]))
+                        : "memory");
+                    mbarrier_arrive(o_acc_done_addr + (final_o_stage_cg1) * 8);
+                    asm volatile("fence.proxy.async.shared::cta;" ::: "memory");
+                    mbarrier_arrive(o_tma_ready_addr + (final_o_stage_cg1) * 8);
+                }
+                cumulative_chunk_cg1 += chunks_cg1;
+            }
+            if (elect_sync()) {
+                mbarrier_arrive(consumers_done_addr);
+            }
+        }
+    }
+    // ---- Role: super_mma ----
+    if (warp == 12) {
+        { // super_mma_main
+            unsigned int sched_stage_super = 0;
+            int cumulative_chunk_super = 0;
+            int lhs_row_super = lane % 8 + (lane / 8 & 1) * 8;
+            int lhs_col_super = lane / 16 * 8;
+            int rhs_row_super = lane % 8 + lane / 16 * 8;
+            int rhs_col_super = (lane / 8 & 1) * 8;
+            unsigned int _phase_sched_ready_2 = 0;
+            #pragma unroll 1
+            for (int __2 = 0; __2 < total_work_items + 1; __2++) {
+                mbarrier_wait(sched_ready_addr + (sched_stage_super) * 8, _phase_sched_ready_2);
+                unsigned int slot_2[1];
+                asm volatile("ld.shared.b32 %0, [%1];" : "=r"(*reinterpret_cast<uint32_t*>(&slot_2[0])) : "r"(sched_slot_addr + sched_stage_super * 4));
+                unsigned int tile_super = slot_2[0];
+                if (elect_sync()) {
+                    mbarrier_arrive(sched_done_addr + (sched_stage_super) * 8);
+                }
+                sched_stage_super += 1;
+                if (sched_stage_super == 8) { sched_stage_super = 0; _phase_sched_ready_2 ^= 1; }
+                if (tile_super >= (unsigned int)total_work_items) {
+                    break;
+                }
+                int item_base_super = (int)tile_super * 8;
+                int chunks_super = work_items[item_base_super + 3] - work_items[item_base_super + 4];
+                #pragma unroll 1
+                for (int chunk_super = 0; chunk_super < chunks_super; chunk_super++) {
+                    int cumulative_super = cumulative_chunk_super + chunk_super;
+                    unsigned int decay_stage_super = (unsigned int)(cumulative_super % 2);
+                    unsigned int raw_bar_stage_super = (unsigned int)(cumulative_super % 6);
+                    unsigned int intermediate_stage_super = (unsigned int)(cumulative_super % 2);
+                    mbarrier_wait(k_decay_inv_ready_addr + (decay_stage_super) * 8, (unsigned int)(cumulative_super / 2 & 1));
+                    mbarrier_wait(beta_ready_addr + (raw_bar_stage_super) * 8, (unsigned int)(cumulative_super / 6 & 1));
+                    mbarrier_wait(tinv_done_addr + (intermediate_stage_super) * 8, (unsigned int)(cumulative_super / 2 + 1 & 1));
+                    float kk_acc_super[8];
+                    #pragma unroll
+                    for (int k_block_super = 0; k_block_super < 8; k_block_super++) {
+                        unsigned int a_frag_super[4];
+                        unsigned int b_frag_super[4];
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(a_frag_super[0]), "=r"(a_frag_super[1]), "=r"(a_frag_super[2]), "=r"(a_frag_super[3])
+                            : "r"((smem_k_decay_addr + decay_stage_super * 4096 + (unsigned int)((k_block_super * 16 + lhs_col_super) / 64 * 2048 + lhs_row_super * 128 + (k_block_super * 16 + lhs_col_super) % 64 * 2 ^ ((k_block_super * 16 + lhs_col_super) / 64 * 2048 + lhs_row_super * 128 + (k_block_super * 16 + lhs_col_super) % 64 * 2 >> 7 & 7) << 4)))
+                            : "memory");
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(b_frag_super[0]), "=r"(b_frag_super[1]), "=r"(b_frag_super[2]), "=r"(b_frag_super[3])
+                            : "r"((smem_k_inv_addr + decay_stage_super * 4096 + (unsigned int)((k_block_super * 16 + rhs_col_super) / 64 * 2048 + rhs_row_super * 128 + (k_block_super * 16 + rhs_col_super) % 64 * 2 ^ ((k_block_super * 16 + rhs_col_super) / 64 * 2048 + rhs_row_super * 128 + (k_block_super * 16 + rhs_col_super) % 64 * 2 >> 7 & 7) << 4)))
+                            : "memory");
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%10, %11, %12, %13};\n"
+                            : "=f"(kk_acc_super[0]), "=f"(kk_acc_super[1]), "=f"(kk_acc_super[2]), "=f"(kk_acc_super[3])
+                            : "r"(a_frag_super[0]), "r"(a_frag_super[1]), "r"(a_frag_super[2]), "r"(a_frag_super[3]), "r"(b_frag_super[0]), "r"(b_frag_super[1]), "f"(((k_block_super == 0) ? 0.0f : kk_acc_super[0])), "f"(((k_block_super == 0) ? 0.0f : kk_acc_super[1])), "f"(((k_block_super == 0) ? 0.0f : kk_acc_super[2])), "f"(((k_block_super == 0) ? 0.0f : kk_acc_super[3])));
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%10, %11, %12, %13};\n"
+                            : "=f"(kk_acc_super[4]), "=f"(kk_acc_super[(4) + 1]), "=f"(kk_acc_super[(4) + 2]), "=f"(kk_acc_super[(4) + 3])
+                            : "r"(a_frag_super[0]), "r"(a_frag_super[1]), "r"(a_frag_super[2]), "r"(a_frag_super[3]), "r"(b_frag_super[2]), "r"(b_frag_super[(2) + 1]), "f"(((k_block_super == 0) ? 0.0f : kk_acc_super[4])), "f"(((k_block_super == 0) ? 0.0f : kk_acc_super[(4) + 1])), "f"(((k_block_super == 0) ? 0.0f : kk_acc_super[(4) + 2])), "f"(((k_block_super == 0) ? 0.0f : kk_acc_super[(4) + 3])));
+                    }
+                    int beta_stage_base_super = (int)raw_bar_stage_super * 16;
+                    __nv_bfloat16 beta_lo_bf_super = smem_beta_all[beta_stage_base_super + lane / 4];
+                    __nv_bfloat16 beta_hi_bf_super = smem_beta_all[beta_stage_base_super + lane / 4 + 8];
+                    float _cvt_f32_0 = __bfloat162float(beta_lo_bf_super);
+                    float beta_lo_super = _cvt_f32_0;
+                    float _cvt_f32_1 = __bfloat162float(beta_hi_bf_super);
+                    float beta_hi_super = _cvt_f32_1;
+                    float l_values_super[8];
+                    float tinv_acc_super[8];
+                    #pragma unroll
+                    for (int accum_super = 0; accum_super < 8; accum_super++) {
+                        int row_super = lane / 4 + accum_super % 4 / 2 * 8;
+                        int col_super = accum_super / 4 * 8 + (lane & 3) * 2 + (accum_super & 1);
+                        l_values_super[accum_super] = 0.0f;
+                        if (row_super > col_super) {
+                            float beta_scale_super = beta_lo_super;
+                            if (accum_super % 4 >= 2) {
+                                beta_scale_super = beta_hi_super;
+                            }
+                            l_values_super[accum_super] = kk_acc_super[accum_super] * beta_scale_super;
+                        }
+                        tinv_acc_super[accum_super] = -l_values_super[accum_super];
+                        if (row_super == col_super) {
+                            tinv_acc_super[accum_super] = 1.0f;
+                        }
+                    }
+                    unsigned int lpow_words_super[4];
+                    unsigned int lpow_trans_super[4];
+                    #pragma unroll
+                    for (int _lp = 0; _lp < 4; _lp++) {
+                        __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(l_values_super[_lp*2 + 0], l_values_super[_lp*2+1 + 0]));
+                        lpow_words_super[_lp] = *(uint32_t*)&_bf2;
+                    }
+                    int store_row_super = lane % 16;
+                    int store_col_super = lane / 16 * 8;
+                    int linear = store_row_super * 16 + store_col_super;
+                    uint32_t _stmatrix_addr_0 = static_cast<uint32_t>((unsigned long long)(tinv_scratch_addr + (unsigned int)((linear ^ (linear >> 6 & 1) * 8) * 2)));
+                    asm volatile("stmatrix.sync.aligned.m8n8.x4.shared.b16 [%0], {%1, %2, %3, %4};\n"
+                        :: "r"(_stmatrix_addr_0), "r"(*reinterpret_cast<const uint32_t*>(&lpow_words_super[0])), "r"(*reinterpret_cast<const uint32_t*>(&lpow_words_super[1])), "r"(*reinterpret_cast<const uint32_t*>(&lpow_words_super[2])), "r"(*reinterpret_cast<const uint32_t*>(&lpow_words_super[3]))
+                        : "memory");
+                    __syncwarp();
+                    int load_row_super = lane % 16;
+                    #pragma unroll
+                    for (int load_half_super = 0; load_half_super < 2; load_half_super++) {
+                        int linear_0 = load_row_super * 16 + load_half_super * 8;
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x2.trans.shared.b16 {%0, %1}, [%2];\n"
+                            : "=r"(lpow_trans_super[load_half_super * 2]), "=r"(lpow_trans_super[load_half_super * 2 + 1])
+                            : "r"(tinv_scratch_addr + (unsigned int)((linear_0 ^ (linear_0 >> 6 & 1) * 8) * 2))
+                            : "memory");
+                    }
+                    #pragma unroll
+                    for (int neumann_super = 0; neumann_super < 3; neumann_super++) {
+                        float square_acc_super[8];
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%10, %11, %12, %13};\n"
+                            : "=f"(square_acc_super[0]), "=f"(square_acc_super[1]), "=f"(square_acc_super[2]), "=f"(square_acc_super[3])
+                            : "r"(lpow_words_super[0]), "r"(lpow_words_super[1]), "r"(lpow_words_super[2]), "r"(lpow_words_super[3]), "r"(lpow_trans_super[0]), "r"(lpow_trans_super[1]), "f"(0.0f), "f"(0.0f), "f"(0.0f), "f"(0.0f));
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%10, %11, %12, %13};\n"
+                            : "=f"(square_acc_super[4]), "=f"(square_acc_super[(4) + 1]), "=f"(square_acc_super[(4) + 2]), "=f"(square_acc_super[(4) + 3])
+                            : "r"(lpow_words_super[0]), "r"(lpow_words_super[1]), "r"(lpow_words_super[2]), "r"(lpow_words_super[3]), "r"(lpow_trans_super[2]), "r"(lpow_trans_super[(2) + 1]), "f"(0.0f), "f"(0.0f), "f"(0.0f), "f"(0.0f));
+                        #pragma unroll
+                        for (int _lp = 0; _lp < 4; _lp++) {
+                            __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(square_acc_super[_lp*2 + 0], square_acc_super[_lp*2+1 + 0]));
+                            lpow_words_super[_lp] = *(uint32_t*)&_bf2;
+                        }
+                        int store_row_super_0 = lane % 16;
+                        int store_col_super_1 = lane / 16 * 8;
+                        int linear_2 = store_row_super_0 * 16 + store_col_super_1;
+                        uint32_t _stmatrix_addr_1 = static_cast<uint32_t>((unsigned long long)(tinv_scratch_addr + (unsigned int)((linear_2 ^ (linear_2 >> 6 & 1) * 8) * 2)));
+                        asm volatile("stmatrix.sync.aligned.m8n8.x4.shared.b16 [%0], {%1, %2, %3, %4};\n"
+                            :: "r"(_stmatrix_addr_1), "r"(*reinterpret_cast<const uint32_t*>(&lpow_words_super[0])), "r"(*reinterpret_cast<const uint32_t*>(&lpow_words_super[1])), "r"(*reinterpret_cast<const uint32_t*>(&lpow_words_super[2])), "r"(*reinterpret_cast<const uint32_t*>(&lpow_words_super[3]))
+                            : "memory");
+                        __syncwarp();
+                        int load_row_super_3 = lane % 16;
+                        #pragma unroll
+                        for (int load_half_super_1 = 0; load_half_super_1 < 2; load_half_super_1++) {
+                            int linear_0_1 = load_row_super_3 * 16 + load_half_super_1 * 8;
+                            asm volatile("ldmatrix.sync.aligned.m8n8.x2.trans.shared.b16 {%0, %1}, [%2];\n"
+                                : "=r"(lpow_trans_super[load_half_super_1 * 2]), "=r"(lpow_trans_super[load_half_super_1 * 2 + 1])
+                                : "r"(tinv_scratch_addr + (unsigned int)((linear_0_1 ^ (linear_0_1 >> 6 & 1) * 8) * 2))
+                                : "memory");
+                        }
+                        unsigned int tinv_words_super[4];
+                        #pragma unroll
+                        for (int _lp = 0; _lp < 4; _lp++) {
+                            __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(tinv_acc_super[_lp*2 + 0], tinv_acc_super[_lp*2+1 + 0]));
+                            tinv_words_super[_lp] = *(uint32_t*)&_bf2;
+                        }
+                        float update_acc_super[8];
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%10, %11, %12, %13};\n"
+                            : "=f"(update_acc_super[0]), "=f"(update_acc_super[1]), "=f"(update_acc_super[2]), "=f"(update_acc_super[3])
+                            : "r"(tinv_words_super[0]), "r"(tinv_words_super[1]), "r"(tinv_words_super[2]), "r"(tinv_words_super[3]), "r"(lpow_trans_super[0]), "r"(lpow_trans_super[1]), "f"(0.0f), "f"(0.0f), "f"(0.0f), "f"(0.0f));
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%10, %11, %12, %13};\n"
+                            : "=f"(update_acc_super[4]), "=f"(update_acc_super[(4) + 1]), "=f"(update_acc_super[(4) + 2]), "=f"(update_acc_super[(4) + 3])
+                            : "r"(tinv_words_super[0]), "r"(tinv_words_super[1]), "r"(tinv_words_super[2]), "r"(tinv_words_super[3]), "r"(lpow_trans_super[2]), "r"(lpow_trans_super[(2) + 1]), "f"(0.0f), "f"(0.0f), "f"(0.0f), "f"(0.0f));
+                        float tinv_words_super_f32[8];
+                        #pragma unroll
+                        for (int _pair = 0; _pair < 4; _pair++) {
+                            asm volatile(
+                                "{\n\t"
+                                "shl.b32 %0, %2, 16;\n\t"
+                                "and.b32 %1, %2, 0xffff0000;\n\t"
+                                "}\n"
+                                : "=f"((&tinv_words_super_f32[_pair * 2])[0]), "=f"((&tinv_words_super_f32[_pair * 2])[1])
+                                : "r"(tinv_words_super[_pair]));
+                        }
+                        #pragma unroll
+                        for (int update_super = 0; update_super < 8; update_super++) {
+                            tinv_acc_super[update_super] = tinv_words_super_f32[update_super] + update_acc_super[update_super];
+                        }
+                    }
+                    unsigned int tinv_publish_super[4];
+                    #pragma unroll
+                    for (int _lp = 0; _lp < 4; _lp++) {
+                        __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(tinv_acc_super[_lp*2 + 0], tinv_acc_super[_lp*2+1 + 0]));
+                        tinv_publish_super[_lp] = *(uint32_t*)&_bf2;
+                    }
+                    uint32_t _stmatrix_addr_2 = static_cast<uint32_t>((unsigned long long)(smem_tinv_addr + intermediate_stage_super * 1024 + (unsigned int)(lane / 16 * 8 / 16 * 512 + lane % 16 * 32 + lane / 16 * 8 % 16 * 2 ^ (lane / 16 * 8 / 16 * 512 + lane % 16 * 32 + lane / 16 * 8 % 16 * 2 >> 7 & 1) << 4)));
+                    asm volatile("stmatrix.sync.aligned.m8n8.x4.shared.b16 [%0], {%1, %2, %3, %4};\n"
+                        :: "r"(_stmatrix_addr_2), "r"(*reinterpret_cast<const uint32_t*>(&tinv_publish_super[0])), "r"(*reinterpret_cast<const uint32_t*>(&tinv_publish_super[1])), "r"(*reinterpret_cast<const uint32_t*>(&tinv_publish_super[2])), "r"(*reinterpret_cast<const uint32_t*>(&tinv_publish_super[3]))
+                        : "memory");
+                    asm volatile("fence.proxy.async.shared::cta;" ::: "memory");
+                    mbarrier_arrive(tinv_ready_addr + (intermediate_stage_super) * 8);
+                    mbarrier_arrive(beta_done_addr + (raw_bar_stage_super) * 8);
+                    mbarrier_arrive(decay_super_done_addr + (decay_stage_super) * 8);
+                }
+                cumulative_chunk_super += chunks_super;
+            }
+            if (elect_sync()) {
+                mbarrier_arrive(consumers_done_addr);
+            }
+        }
+    }
+    // ---- Role: tcgen ----
+    if (warp == 13) {
+        { // tcgen_main
+            float tmem_seed_tcgen[1];
+            tmem_seed_tcgen[0] = 0.0f;
+            asm volatile(
+                "tcgen05.st.sync.aligned.32x32b.x1.b32"
+                " [%0], {%1};"
+                :: "r"(taddr), "r"(*reinterpret_cast<const uint32_t*>(&tmem_seed_tcgen[0]))
+                : "memory");
+            asm volatile("tcgen05.wait::st.sync.aligned;" ::: "memory");
+            unsigned int sched_stage_tcgen = 0;
+            int cumulative_chunk_tcgen = 0;
+            unsigned int _phase_sched_ready_3 = 0;
+            #pragma unroll 1
+            for (int __3 = 0; __3 < total_work_items + 1; __3++) {
+                mbarrier_wait(sched_ready_addr + (sched_stage_tcgen) * 8, _phase_sched_ready_3);
+                unsigned int slot_3[1];
+                asm volatile("ld.shared.b32 %0, [%1];" : "=r"(*reinterpret_cast<uint32_t*>(&slot_3[0])) : "r"(sched_slot_addr + sched_stage_tcgen * 4));
+                unsigned int tile_tcgen = slot_3[0];
+                if (elect_sync()) {
+                    mbarrier_arrive(sched_done_addr + (sched_stage_tcgen) * 8);
+                }
+                sched_stage_tcgen += 1;
+                if (sched_stage_tcgen == 8) { sched_stage_tcgen = 0; _phase_sched_ready_3 ^= 1; }
+                if (tile_tcgen >= (unsigned int)total_work_items) {
+                    break;
+                }
+                int item_base_tcgen = (int)tile_tcgen * 8;
+                int chunks_tcgen = work_items[item_base_tcgen + 3] - work_items[item_base_tcgen + 4];
+                #pragma unroll 1
+                for (int chunk_tcgen = 0; chunk_tcgen < chunks_tcgen; chunk_tcgen++) {
+                    int cumulative_tcgen = cumulative_chunk_tcgen + chunk_tcgen;
+                    unsigned int state_phase_tcgen = (unsigned int)(cumulative_tcgen & 1);
+                    unsigned int decay_stage_tcgen = (unsigned int)(cumulative_tcgen % 2);
+                    unsigned int diag_stage_tcgen = (unsigned int)(cumulative_tcgen % 4);
+                    unsigned int intermediate_stage_tcgen = (unsigned int)(cumulative_tcgen % 2);
+                    unsigned int o_stage_tcgen = (unsigned int)(cumulative_tcgen % 2);
+                    mbarrier_wait(k_decay_inv_ready_addr + (decay_stage_tcgen) * 8, (unsigned int)(cumulative_tcgen / 2 & 1));
+                    mbarrier_wait(state_inp_ready_addr, state_phase_tcgen);
+                    int _mma_b_lo_0 = make_warp_uniform((((smem_k_decay_addr) >> 4) & 0x3FFF) + (decay_stage_tcgen) * 256);
+                    asm volatile(
+                    "{\n\t"
+                    ".reg .pred leader, p0, p1;\n\t"
+                    ".reg .b32 dhi, blo, ta, id;\n\t"
+                    ".reg .b64 db;\n\t"
+                    "elect.sync _|leader, 0xFFFFFFFF;\n\t"
+                    "setp.ne.b32 p0, %3, 0;\n\t"
+                    "setp.ne.b32 p1, 1, 0;\n\t"
+                    ""
+                    "mov.b32 dhi, 0x40004040;\n\t"
+                    "mov.b32 id, 134481040;\n\t"
+                    "mov.b32 ta, %2;\n\t"
+                    "mov.b32 blo, %1;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p0;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 122;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "}\n"
+                    :: "r"(tmem_tmem_state_k), "r"(_mma_b_lo_0), "r"(tmem_tmem_state_inp), "r"(0));
+                    elect_commit(state_k_ready_addr);
+                    mbarrier_wait(qk_scale_ready_addr + (diag_stage_tcgen) * 8, (unsigned int)(cumulative_tcgen / 4 & 1));
+                    mbarrier_wait(o_acc_done_addr + (o_stage_tcgen) * 8, (unsigned int)(cumulative_tcgen / 2 + 1 & 1));
+                    int _mma_b_lo_1 = make_warp_uniform((((smem_q_decay_addr) >> 4) & 0x3FFF) + (decay_stage_tcgen) * 256);
+                    asm volatile(
+                    "{\n\t"
+                    ".reg .pred leader, p0, p1;\n\t"
+                    ".reg .b32 dhi, blo, ta, id;\n\t"
+                    ".reg .b64 db;\n\t"
+                    "elect.sync _|leader, 0xFFFFFFFF;\n\t"
+                    "setp.ne.b32 p0, %3, 0;\n\t"
+                    "setp.ne.b32 p1, 1, 0;\n\t"
+                    ""
+                    "mov.b32 dhi, 0x40004040;\n\t"
+                    "mov.b32 id, 134481040;\n\t"
+                    "mov.b32 ta, %2;\n\t"
+                    "mov.b32 blo, %1;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p0;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 122;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "}\n"
+                    :: "r"((tmem_tmem_q_state + ((int)o_stage_tcgen * 16))), "r"(_mma_b_lo_1), "r"(tmem_tmem_state_inp), "r"(0));
+                    elect_commit(decay_tcgen_done_addr + (decay_stage_tcgen) * 8);
+                    {
+                        mbarrier_wait(state_read_done_addr, state_phase_tcgen);
+                    }
+                    #pragma unroll
+                    for (int diag_block_tcgen = 0; diag_block_tcgen < 8; diag_block_tcgen++) {
+                        int _mma_b_lo_2 = make_warp_uniform((((smem_state_diag_addr) >> 4) & 0x3FFF) + ((int)diag_stage_tcgen * 8 + diag_block_tcgen) * 32);
+                        mma_ts_step((tmem_tmem_state + (diag_block_tcgen * 16)), tmem_tmem_state_inp + diag_block_tcgen * 8, _mma_b_lo_2, 0xC0004010, 134481040, 0);
+                    }
+                    elect_commit(state_diag_done_addr + (diag_stage_tcgen) * 8);
+                    mbarrier_wait(tinv_ready_addr + (intermediate_stage_tcgen) * 8, (unsigned int)(cumulative_tcgen / 2 & 1));
+                    mbarrier_wait(y_inp_ready_addr, state_phase_tcgen);
+                    int _mma_b_lo_3 = make_warp_uniform(((((smem_tinv_mn_addr) >> 4) & 0x3FFF) | 0x200000) + (intermediate_stage_tcgen) * 64);
+                    mma_ts_step(tmem_tmem_u_acc, tmem_tmem_y_inp, _mma_b_lo_3, 0xC0004010, 134546576, 0);
+                    elect_commit2(tinv_done_addr + (intermediate_stage_tcgen) * 8, u_acc_ready_addr);
+                    mbarrier_wait(u_inp_ready_addr, state_phase_tcgen);
+                    int _mma_b_lo_4 = make_warp_uniform(((((smem_k_restore_mn_addr) >> 4) & 0x3FFF) | 0x800000) + (decay_stage_tcgen) * 256);
+                    mma_ts_step(tmem_tmem_state, tmem_tmem_u_inp, _mma_b_lo_4, 0x40004040, 136381584, 1);
+                    elect_commit2(k_restore_done_addr + (decay_stage_tcgen) * 8, state_acc_done_addr);
+                    mbarrier_wait(a_ready_addr + (intermediate_stage_tcgen) * 8, (unsigned int)(cumulative_tcgen / 2 & 1));
+                    int _mma_b_lo_5 = make_warp_uniform(((((smem_a_mn_addr) >> 4) & 0x3FFF) | 0x200000) + (intermediate_stage_tcgen) * 64);
+                    mma_ts_step((tmem_tmem_q_state + ((int)o_stage_tcgen * 16)), tmem_tmem_u_inp, _mma_b_lo_5, 0xC0004010, 134546576, 1);
+                    elect_commit2(o_acc_ready_addr, a_done_addr + (intermediate_stage_tcgen) * 8);
+                }
+                cumulative_chunk_tcgen += chunks_tcgen;
+            }
+            if (elect_sync()) {
+                mbarrier_arrive(consumers_done_addr);
+            }
+            unsigned int _phase_cleanup_ready_0 = 0;
+            mbarrier_wait(cleanup_ready_addr, _phase_cleanup_ready_0);
+            _phase_cleanup_ready_0 ^= 1;
+            int _tmem_dealloc_addr = *((volatile int*)tmem_addr_storage);
+            asm volatile("tcgen05.dealloc.cta_group::1.sync.aligned.b32 %0, %1;" :: "r"(_tmem_dealloc_addr), "r"(512));
+        }
+    }
+    // ---- Role: tma ----
+    if (warp == 14) {
+        { // tma_main
+            unsigned int sched_stage_tma = 0;
+            int cumulative_chunk_tma = 0;
+            unsigned int _phase_sched_done = 1;
+            if (elect_sync()) {
+                #pragma unroll 1
+                for (int sched_iter_tma = 0; sched_iter_tma < total_work_items + 1; sched_iter_tma++) {
+                    mbarrier_wait(sched_done_addr + (sched_stage_tma) * 8, _phase_sched_done);
+                    unsigned int tile_tma = blockIdx.x;
+                    if (uniform_work_items != 0) {
+                        tile_tma = (unsigned int)blockIdx.x + (unsigned int)sched_iter_tma * (unsigned int)gridDim.x;
+                    } else if (sched_iter_tma > 0) {
+                        unsigned int _atomic_old_0 = atomicAdd(dynamic_counter, 1);
+                        tile_tma = (unsigned int)gridDim.x + _atomic_old_0;
+                    }
+                    asm volatile("st.shared.b32 [%0], %1;" :: "r"(sched_slot_addr + sched_stage_tma * 4), "r"(tile_tma));
+                    mbarrier_arrive(sched_ready_addr + (sched_stage_tma) * 8);
+                    sched_stage_tma += 1;
+                    if (sched_stage_tma == 8) { sched_stage_tma = 0; _phase_sched_done ^= 1; }
+                    if (tile_tma >= (unsigned int)total_work_items) {
+                        break;
+                    }
+                    int item_base_tma = (int)tile_tma * 8;
+                    int _vec_load_0[4];
+                    {
+                        int4 _iv4 = *reinterpret_cast<const int4*>(work_items + item_base_tma);
+                        _vec_load_0[0 + 0] = _iv4.x;
+                        _vec_load_0[0 + 1] = _iv4.y;
+                        _vec_load_0[0 + 2] = _iv4.z;
+                        _vec_load_0[0 + 3] = _iv4.w;
+                    }
+                    int _vec_load_1[4];
+                    {
+                        int4 _iv4 = *reinterpret_cast<const int4*>(work_items + item_base_tma + 4);
+                        _vec_load_1[0 + 0] = _iv4.x;
+                        _vec_load_1[0 + 1] = _iv4.y;
+                        _vec_load_1[0 + 2] = _iv4.z;
+                        _vec_load_1[0 + 3] = _iv4.w;
+                    }
+                    int head_tma = _vec_load_0[1];
+                    int wend_tma = _vec_load_0[3];
+                    int cstart_tma = _vec_load_1[0];
+                    long long bos_tma = (long long)_vec_load_1[2];
+                    int chunks_tma = wend_tma - cstart_tma;
+                    #pragma unroll 1
+                    for (int chunk_tma = 0; chunk_tma < chunks_tma; chunk_tma++) {
+                        int cumulative_tma = cumulative_chunk_tma + chunk_tma;
+                        unsigned int raw_stage_tma = (unsigned int)(cumulative_tma % 5);
+                        unsigned int raw_bar_stage_tma = (unsigned int)(cumulative_tma % 6);
+                        unsigned int raw_done_phase_tma = (unsigned int)(cumulative_tma / 5 + 1 & 1);
+                        mbarrier_wait(q_done_addr + (raw_stage_tma) * 8, raw_done_phase_tma);
+                        mbarrier_wait(k_done_addr + (raw_stage_tma) * 8, raw_done_phase_tma);
+                        mbarrier_wait(v_done_addr + (raw_stage_tma) * 8, raw_done_phase_tma);
+                        mbarrier_wait(g_done_addr + (raw_stage_tma) * 8, raw_done_phase_tma);
+                        mbarrier_arrive_expect_tx(q_ready_addr + (raw_bar_stage_tma) * 8, 4096);
+                        mbarrier_arrive_expect_tx(k_ready_addr + (raw_bar_stage_tma) * 8, 4096);
+                        mbarrier_arrive_expect_tx(v_ready_addr + (raw_bar_stage_tma) * 8, 4096);
+                        {
+                            mbarrier_arrive(g_ready_addr + (raw_bar_stage_tma) * 8);
+                        }
+                        int logical_chunk_tma = cstart_tma + chunk_tma;
+                        int token_tma = (int)(bos_tma + (long long)logical_chunk_tma * 16);
+                        #pragma unroll
+                        for (int segment_tma = 0; segment_tma < 2; segment_tma++) {
+                            int segment_offset_tma = segment_tma * 16 * 64 * 2;
+                            int segment_dim_tma = segment_tma * 64;
+                            tma_3d_gmem2smem(smem_q_addr + raw_stage_tma * 4096 + (unsigned int)segment_offset_tma, q_tma, segment_dim_tma, head_tma, token_tma, q_ready_addr + (raw_bar_stage_tma) * 8);
+                            tma_3d_gmem2smem(smem_k_addr + raw_stage_tma * 4096 + (unsigned int)segment_offset_tma, k_tma, segment_dim_tma, head_tma, token_tma, k_ready_addr + (raw_bar_stage_tma) * 8);
+                            tma_3d_gmem2smem(smem_v_addr + raw_stage_tma * 4096 + (unsigned int)segment_offset_tma, v_tma, segment_dim_tma, head_tma, token_tma, v_ready_addr + (raw_bar_stage_tma) * 8);
+                        }
+                    }
+                    cumulative_chunk_tma += chunks_tma;
+                }
+            }
+            unsigned int _phase_consumers_done_0 = 0;
+            mbarrier_wait(consumers_done_addr, _phase_consumers_done_0);
+            _phase_consumers_done_0 ^= 1;
+            if (elect_sync()) {
+                mbarrier_arrive(cleanup_ready_addr);
+            }
+        }
+    }
+    // ---- Role: epilogue ----
+    if (warp == 15) {
+        { // epilogue_main
+            unsigned int sched_stage_epi = 0;
+            int cumulative_chunk_epi = 0;
+            int lhs_row_epi = lane % 8 + (lane / 8 & 1) * 8;
+            int lhs_col_epi = lane / 16 * 8;
+            int rhs_row_epi = lane % 8 + lane / 16 * 8;
+            int rhs_col_epi = (lane / 8 & 1) * 8;
+            unsigned int _phase_sched_ready_4 = 0;
+            #pragma unroll 1
+            for (int __4 = 0; __4 < total_work_items + 1; __4++) {
+                mbarrier_wait(sched_ready_addr + (sched_stage_epi) * 8, _phase_sched_ready_4);
+                unsigned int slot_4[1];
+                asm volatile("ld.shared.b32 %0, [%1];" : "=r"(*reinterpret_cast<uint32_t*>(&slot_4[0])) : "r"(sched_slot_addr + sched_stage_epi * 4));
+                unsigned int tile_epi = slot_4[0];
+                if (elect_sync()) {
+                    mbarrier_arrive(sched_done_addr + (sched_stage_epi) * 8);
+                }
+                sched_stage_epi += 1;
+                if (sched_stage_epi == 8) { sched_stage_epi = 0; _phase_sched_ready_4 ^= 1; }
+                if (tile_epi >= (unsigned int)total_work_items) {
+                    break;
+                }
+                int item_base_epi = (int)tile_epi * 8;
+                int _vec_load_3[4];
+                {
+                    int4 _iv4 = *reinterpret_cast<const int4*>(work_items + item_base_epi);
+                    _vec_load_3[0 + 0] = _iv4.x;
+                    _vec_load_3[0 + 1] = _iv4.y;
+                    _vec_load_3[0 + 2] = _iv4.z;
+                    _vec_load_3[0 + 3] = _iv4.w;
+                }
+                int seq_epi = _vec_load_3[0];
+                int head_epi = _vec_load_3[1];
+                int wstart_epi = _vec_load_3[2];
+                int wend_epi = _vec_load_3[3];
+                int cstart_epi = work_items[item_base_epi + 4];
+                long long bos_epi = (long long)work_items[item_base_epi + 6];
+                int chunks_epi = wend_epi - cstart_epi;
+                long long checkpoint_base_epi = checkpoint_cu_starts[seq_epi];
+                if (ENABLE_CHECKPOINTS != 0 && chunks_epi > 0 && wstart_epi == 0) {
+                    int checkpoint_event_epi = cumulative_chunk_epi;
+                    unsigned int checkpoint_stage_epi = (unsigned int)(checkpoint_event_epi % 2);
+                    mbarrier_wait(checkpoint_ready_addr + (checkpoint_stage_epi) * 8, (unsigned int)(checkpoint_event_epi / 2 & 1));
+                    if (elect_sync()) {
+                        #pragma unroll
+                        for (int segment_checkpoint_epi = 0; segment_checkpoint_epi < 2; segment_checkpoint_epi++) {
+                            tma_store_4d(checkpoint_tma, segment_checkpoint_epi * 64, 0, head_epi, checkpoint_base_epi, smem_checkpoint_addr + checkpoint_stage_epi * 32768 + (unsigned int)(segment_checkpoint_epi * 128 * 64 * 2));
+                        }
+                    }
+                    asm volatile("cp.async.bulk.commit_group;");
+                    asm volatile("cp.async.bulk.wait_group.read 0;");
+                    mbarrier_arrive(checkpoint_done_addr + (checkpoint_stage_epi) * 8);
+                }
+                #pragma unroll 1
+                for (int chunk_epi = 0; chunk_epi < chunks_epi; chunk_epi++) {
+                    int cumulative_epi = cumulative_chunk_epi + chunk_epi;
+                    int logical_chunk_epi = cstart_epi + chunk_epi;
+                    unsigned int decay_stage_epi = (unsigned int)(cumulative_epi % 2);
+                    unsigned int diag_stage_epi = (unsigned int)(cumulative_epi % 4);
+                    unsigned int intermediate_stage_epi = (unsigned int)(cumulative_epi % 2);
+                    mbarrier_wait(qk_scale_ready_addr + (diag_stage_epi) * 8, (unsigned int)(cumulative_epi / 4 & 1));
+                    mbarrier_wait(a_done_addr + (intermediate_stage_epi) * 8, (unsigned int)(cumulative_epi / 2 + 1 & 1));
+                    float a_acc_epi[8];
+                    #pragma unroll
+                    for (int k_block_epi = 0; k_block_epi < 8; k_block_epi++) {
+                        unsigned int a_frag_epi[4];
+                        unsigned int b_frag_epi[4];
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(a_frag_epi[0]), "=r"(a_frag_epi[1]), "=r"(a_frag_epi[2]), "=r"(a_frag_epi[3])
+                            : "r"((smem_q_decay_addr + decay_stage_epi * 4096 + (unsigned int)((k_block_epi * 16 + lhs_col_epi) / 64 * 2048 + lhs_row_epi * 128 + (k_block_epi * 16 + lhs_col_epi) % 64 * 2 ^ ((k_block_epi * 16 + lhs_col_epi) / 64 * 2048 + lhs_row_epi * 128 + (k_block_epi * 16 + lhs_col_epi) % 64 * 2 >> 7 & 7) << 4)))
+                            : "memory");
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(b_frag_epi[0]), "=r"(b_frag_epi[1]), "=r"(b_frag_epi[2]), "=r"(b_frag_epi[3])
+                            : "r"((smem_k_inv_addr + decay_stage_epi * 4096 + (unsigned int)((k_block_epi * 16 + rhs_col_epi) / 64 * 2048 + rhs_row_epi * 128 + (k_block_epi * 16 + rhs_col_epi) % 64 * 2 ^ ((k_block_epi * 16 + rhs_col_epi) / 64 * 2048 + rhs_row_epi * 128 + (k_block_epi * 16 + rhs_col_epi) % 64 * 2 >> 7 & 7) << 4)))
+                            : "memory");
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%10, %11, %12, %13};\n"
+                            : "=f"(a_acc_epi[0]), "=f"(a_acc_epi[1]), "=f"(a_acc_epi[2]), "=f"(a_acc_epi[3])
+                            : "r"(a_frag_epi[0]), "r"(a_frag_epi[1]), "r"(a_frag_epi[2]), "r"(a_frag_epi[3]), "r"(b_frag_epi[0]), "r"(b_frag_epi[1]), "f"(((k_block_epi == 0) ? 0.0f : a_acc_epi[0])), "f"(((k_block_epi == 0) ? 0.0f : a_acc_epi[1])), "f"(((k_block_epi == 0) ? 0.0f : a_acc_epi[2])), "f"(((k_block_epi == 0) ? 0.0f : a_acc_epi[3])));
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%10, %11, %12, %13};\n"
+                            : "=f"(a_acc_epi[4]), "=f"(a_acc_epi[(4) + 1]), "=f"(a_acc_epi[(4) + 2]), "=f"(a_acc_epi[(4) + 3])
+                            : "r"(a_frag_epi[0]), "r"(a_frag_epi[1]), "r"(a_frag_epi[2]), "r"(a_frag_epi[3]), "r"(b_frag_epi[2]), "r"(b_frag_epi[(2) + 1]), "f"(((k_block_epi == 0) ? 0.0f : a_acc_epi[4])), "f"(((k_block_epi == 0) ? 0.0f : a_acc_epi[(4) + 1])), "f"(((k_block_epi == 0) ? 0.0f : a_acc_epi[(4) + 2])), "f"(((k_block_epi == 0) ? 0.0f : a_acc_epi[(4) + 3])));
+                    }
+                    float a_values_epi[8];
+                    #pragma unroll
+                    for (int accum_epi = 0; accum_epi < 8; accum_epi++) {
+                        int row_epi = lane / 4 + accum_epi % 4 / 2 * 8;
+                        int col_epi = accum_epi / 4 * 8 + (lane & 3) * 2 + (accum_epi & 1);
+                        a_values_epi[accum_epi] = 0.0f;
+                        if (row_epi >= col_epi) {
+                            a_values_epi[accum_epi] = a_acc_epi[accum_epi];
+                        }
+                    }
+                    unsigned int a_words_epi[4];
+                    #pragma unroll
+                    for (int _lp = 0; _lp < 4; _lp++) {
+                        __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(a_values_epi[_lp*2 + 0], a_values_epi[_lp*2+1 + 0]));
+                        a_words_epi[_lp] = *(uint32_t*)&_bf2;
+                    }
+                    uint32_t _stmatrix_addr_0 = static_cast<uint32_t>((unsigned long long)(smem_a_addr + intermediate_stage_epi * 1024 + (unsigned int)(lane / 16 * 8 / 16 * 512 + lane % 16 * 32 + lane / 16 * 8 % 16 * 2 ^ (lane / 16 * 8 / 16 * 512 + lane % 16 * 32 + lane / 16 * 8 % 16 * 2 >> 7 & 1) << 4)));
+                    asm volatile("stmatrix.sync.aligned.m8n8.x4.shared.b16 [%0], {%1, %2, %3, %4};\n"
+                        :: "r"(_stmatrix_addr_0), "r"(*reinterpret_cast<const uint32_t*>(&a_words_epi[0])), "r"(*reinterpret_cast<const uint32_t*>(&a_words_epi[1])), "r"(*reinterpret_cast<const uint32_t*>(&a_words_epi[2])), "r"(*reinterpret_cast<const uint32_t*>(&a_words_epi[3]))
+                        : "memory");
+                    asm volatile("fence.proxy.async.shared::cta;" ::: "memory");
+                    mbarrier_arrive(a_ready_addr + (intermediate_stage_epi) * 8);
+                    mbarrier_arrive(decay_super_done_addr + (decay_stage_epi) * 8);
+                    if (chunk_epi > 0) {
+                        {
+                            int checkpoint_event_loop_epi = cumulative_epi;
+                            unsigned int checkpoint_stage_loop_epi = (unsigned int)(checkpoint_event_loop_epi % 2);
+                            mbarrier_wait(checkpoint_ready_addr + (checkpoint_stage_loop_epi) * 8, (unsigned int)(checkpoint_event_loop_epi / 2 & 1));
+                            if (elect_sync()) {
+                                #pragma unroll
+                                for (int checkpoint_segment_loop_epi = 0; checkpoint_segment_loop_epi < 2; checkpoint_segment_loop_epi++) {
+                                    tma_store_4d(checkpoint_tma, checkpoint_segment_loop_epi * 64, 0, head_epi, checkpoint_base_epi + (long long)logical_chunk_epi, smem_checkpoint_addr + checkpoint_stage_loop_epi * 32768 + (unsigned int)(checkpoint_segment_loop_epi * 128 * 64 * 2));
+                                }
+                            }
+                            asm volatile("cp.async.bulk.commit_group;");
+                            asm volatile("cp.async.bulk.wait_group.read 0;");
+                            mbarrier_arrive(checkpoint_done_addr + (checkpoint_stage_loop_epi) * 8);
+                        }
+                        int output_event_epi = cumulative_epi - 1;
+                        unsigned int output_stage_epi = (unsigned int)(output_event_epi % 2);
+                        mbarrier_wait(o_tma_ready_addr + (output_stage_epi) * 8, (unsigned int)(output_event_epi / 2 & 1));
+                        if (elect_sync()) {
+                            #pragma unroll
+                            for (int output_segment_epi = 0; output_segment_epi < 2; output_segment_epi++) {
+                                tma_store_3d(out_tma, output_segment_epi * 64, head_epi, (int)(bos_epi + (long long)(logical_chunk_epi - 1) * 16), smem_o_addr + output_stage_epi * 4096 + (unsigned int)(output_segment_epi * 16 * 64 * 2));
+                            }
+                        }
+                        asm volatile("cp.async.bulk.commit_group;");
+                        asm volatile("cp.async.bulk.wait_group.read 0;");
+                        mbarrier_arrive(o_tma_done_addr + (output_stage_epi) * 8);
+                    }
+                }
+                if (chunks_epi > 0) {
+                    int last_event_epi = cumulative_chunk_epi + chunks_epi - 1;
+                    unsigned int last_o_stage_epi = (unsigned int)(last_event_epi % 2);
+                    mbarrier_wait(o_tma_ready_addr + (last_o_stage_epi) * 8, (unsigned int)(last_event_epi / 2 & 1));
+                    if (elect_sync()) {
+                        #pragma unroll
+                        for (int last_segment_epi = 0; last_segment_epi < 2; last_segment_epi++) {
+                            tma_store_3d(out_tma, last_segment_epi * 64, head_epi, (int)(bos_epi + (long long)(wend_epi - 1) * 16), smem_o_addr + last_o_stage_epi * 4096 + (unsigned int)(last_segment_epi * 16 * 64 * 2));
+                        }
+                    }
+                    asm volatile("cp.async.bulk.commit_group;");
+                    asm volatile("cp.async.bulk.wait_group.read 0;");
+                    mbarrier_arrive(o_tma_done_addr + (last_o_stage_epi) * 8);
+                }
+                cumulative_chunk_epi += chunks_epi;
+            }
+            if (elect_sync()) {
+                mbarrier_arrive(consumers_done_addr);
+            }
+        }
+    }
+
+    // Cleanup
+}
+
+} // extern "C"
+
+#undef ENABLE_CHECKPOINTS
+#undef G_INPUT_BF16
+#undef FLASH_KDA_INF
+#undef NUM_CHECKPOINT_PIPE_STAGES
+#undef NUM_DECAY_PIPE_STAGES
+#undef NUM_DIAG_PIPE_STAGES
+#undef NUM_INTERMEDIATE_PIPE_STAGES
+#undef NUM_O_PIPE_STAGES
+#undef NUM_RAW_BAR_PIPE_STAGES
+#undef NUM_RAW_PIPE_STAGES
+#undef NUM_SCHED_PIPE_STAGES
+#undef NUM_STATE_PIPE_STAGES
+#undef SMEM_SCHED_SLOT_OFF
+#undef SMEM_SCHED_SLOT_STAGE_BYTES
+#undef SMEM_SCHED_SLOT_STRIDE
+#undef SMEM_SMEM_A_MN_OFF
+#undef SMEM_SMEM_A_MN_STAGE_BYTES
+#undef SMEM_SMEM_A_MN_STRIDE
+#undef SMEM_SMEM_A_OFF
+#undef SMEM_SMEM_A_STAGE_BYTES
+#undef SMEM_SMEM_A_STRIDE
+#undef SMEM_SMEM_BETA_ALL_OFF
+#undef SMEM_SMEM_BETA_ALL_STAGE_BYTES
+#undef SMEM_SMEM_BETA_ALL_STRIDE
+#undef SMEM_SMEM_BETA_OFF
+#undef SMEM_SMEM_BETA_STAGE_BYTES
+#undef SMEM_SMEM_BETA_STRIDE
+#undef SMEM_SMEM_CHECKPOINT_OFF
+#undef SMEM_SMEM_CHECKPOINT_STAGE_BYTES
+#undef SMEM_SMEM_CHECKPOINT_STRIDE
+#undef SMEM_SMEM_G_ALL_OFF
+#undef SMEM_SMEM_G_ALL_STAGE_BYTES
+#undef SMEM_SMEM_G_ALL_STRIDE
+#undef SMEM_SMEM_G_OFF
+#undef SMEM_SMEM_G_STAGE_BYTES
+#undef SMEM_SMEM_G_STRIDE
+#undef SMEM_SMEM_K_ALL_OFF
+#undef SMEM_SMEM_K_ALL_STAGE_BYTES
+#undef SMEM_SMEM_K_ALL_STRIDE
+#undef SMEM_SMEM_K_DECAY_OFF
+#undef SMEM_SMEM_K_DECAY_STAGE_BYTES
+#undef SMEM_SMEM_K_DECAY_STRIDE
+#undef SMEM_SMEM_K_INV_OFF
+#undef SMEM_SMEM_K_INV_STAGE_BYTES
+#undef SMEM_SMEM_K_INV_STRIDE
+#undef SMEM_SMEM_K_OFF
+#undef SMEM_SMEM_K_RESTORE_MN_OFF
+#undef SMEM_SMEM_K_RESTORE_MN_STAGE_BYTES
+#undef SMEM_SMEM_K_RESTORE_MN_STRIDE
+#undef SMEM_SMEM_K_RESTORE_OFF
+#undef SMEM_SMEM_K_RESTORE_STAGE_BYTES
+#undef SMEM_SMEM_K_RESTORE_STRIDE
+#undef SMEM_SMEM_K_STAGE_BYTES
+#undef SMEM_SMEM_K_STRIDE
+#undef SMEM_SMEM_O_ALL_OFF
+#undef SMEM_SMEM_O_ALL_STAGE_BYTES
+#undef SMEM_SMEM_O_ALL_STRIDE
+#undef SMEM_SMEM_O_OFF
+#undef SMEM_SMEM_O_STAGE_BYTES
+#undef SMEM_SMEM_O_STRIDE
+#undef SMEM_SMEM_Q_ALL_OFF
+#undef SMEM_SMEM_Q_ALL_STAGE_BYTES
+#undef SMEM_SMEM_Q_ALL_STRIDE
+#undef SMEM_SMEM_Q_DECAY_OFF
+#undef SMEM_SMEM_Q_DECAY_STAGE_BYTES
+#undef SMEM_SMEM_Q_DECAY_STRIDE
+#undef SMEM_SMEM_Q_OFF
+#undef SMEM_SMEM_Q_STAGE_BYTES
+#undef SMEM_SMEM_Q_STRIDE
+#undef SMEM_SMEM_STATE_DIAG_OFF
+#undef SMEM_SMEM_STATE_DIAG_STAGE_BYTES
+#undef SMEM_SMEM_STATE_DIAG_STRIDE
+#undef SMEM_SMEM_TINV_MN_OFF
+#undef SMEM_SMEM_TINV_MN_STAGE_BYTES
+#undef SMEM_SMEM_TINV_MN_STRIDE
+#undef SMEM_SMEM_TINV_OFF
+#undef SMEM_SMEM_TINV_STAGE_BYTES
+#undef SMEM_SMEM_TINV_STRIDE
+#undef SMEM_SMEM_V_ALL_OFF
+#undef SMEM_SMEM_V_ALL_STAGE_BYTES
+#undef SMEM_SMEM_V_ALL_STRIDE
+#undef SMEM_SMEM_V_OFF
+#undef SMEM_SMEM_V_STAGE_BYTES
+#undef SMEM_SMEM_V_STRIDE
+#undef SMEM_TINV_SCRATCH_OFF
+#undef SMEM_TINV_SCRATCH_STAGE_BYTES
+#undef SMEM_TINV_SCRATCH_STRIDE
+#undef SMEM_TOTAL
+#undef STORE_BETA_ACTIVE
+#undef STORE_FINAL_STATE
+#undef THREADS
+#undef TMEM_NCOLS
+#undef TMEM_TMEM_Q_STATE_OFFSET
+#undef TMEM_TMEM_STATE_INP_OFFSET
+#undef TMEM_TMEM_STATE_K_OFFSET
+#undef TMEM_TMEM_STATE_OFFSET
+#undef TMEM_TMEM_U_ACC_OFFSET
+#undef TMEM_TMEM_U_INP_OFFSET
+#undef TMEM_TMEM_Y_INP_OFFSET
+#undef USE_INITIAL_STATE
+#undef a_done_addr
+#undef a_ready_addr
+#undef beta_done_addr
+#undef beta_ready_addr
+#undef checkpoint_done_addr
+#undef checkpoint_ready_addr
+#undef cleanup_ready_addr
+#undef consumers_done_addr
+#undef decay_super_done_addr
+#undef decay_tcgen_done_addr
+#undef g_done_addr
+#undef g_ready_addr
+#undef k_decay_inv_ready_addr
+#undef k_done_addr
+#undef k_ready_addr
+#undef k_restore_done_addr
+#undef o_acc_done_addr
+#undef o_acc_ready_addr
+#undef o_tma_done_addr
+#undef o_tma_ready_addr
+#undef q_done_addr
+#undef q_ready_addr
+#undef qk_scale_ready_addr
+#undef sched_done_addr
+#undef sched_ready_addr
+#undef sched_slot_addr
+#undef smem_a_addr
+#undef smem_a_mn_addr
+#undef smem_beta_addr
+#undef smem_beta_all_addr
+#undef smem_checkpoint_addr
+#undef smem_g_addr
+#undef smem_g_all_addr
+#undef smem_k_addr
+#undef smem_k_all_addr
+#undef smem_k_decay_addr
+#undef smem_k_inv_addr
+#undef smem_k_restore_addr
+#undef smem_k_restore_mn_addr
+#undef smem_o_addr
+#undef smem_o_all_addr
+#undef smem_q_addr
+#undef smem_q_all_addr
+#undef smem_q_decay_addr
+#undef smem_state_diag_addr
+#undef smem_tinv_addr
+#undef smem_tinv_mn_addr
+#undef smem_v_addr
+#undef smem_v_all_addr
+#undef state_acc_done_addr
+#undef state_diag_done_addr
+#undef state_inp_ready_addr
+#undef state_k_ready_addr
+#undef state_read_done_addr
+#undef tinv_done_addr
+#undef tinv_ready_addr
+#undef tinv_scratch_addr
+#undef u_acc_ready_addr
+#undef u_inp_ready_addr
+#undef v_done_addr
+#undef v_ready_addr
+#undef y_inp_ready_addr
+
+#define FLASH_KDA_INF CUDART_INF_F
+#define TMEM_NCOLS 512
+#define TMEM_FLASHKDA_BWD_PERSISTENT_C16_ENVELOPE_OFFSET 0
+#define TMEM_FLASHKDA_BWD_PERSISTENT_C16_Y_OFFSET 432
+#define TMEM_FLASHKDA_BWD_PERSISTENT_C16_U_OFFSET 336
+#define TMEM_FLASHKDA_BWD_PERSISTENT_C16_DU_OFFSET 352
+#define TMEM_FLASHKDA_BWD_PERSISTENT_C16_STATE_K_OFFSET 320
+#define TMEM_FLASHKDA_BWD_PERSISTENT_C16_DU_INP_OFFSET 440
+#define TMEM_FLASHKDA_BWD_PERSISTENT_C16_DY_OFFSET 320
+#define TMEM_FLASHKDA_BWD_PERSISTENT_C16_NEG_DY_OFFSET 432
+#define TMEM_FLASHKDA_BWD_PERSISTENT_C16_DO_INP_OFFSET 440
+#define TMEM_FLASHKDA_BWD_PERSISTENT_C16_DSTATE_OFFSET 0
+#define TMEM_FLASHKDA_BWD_PERSISTENT_C16_DSTATE_INP_OFFSET 128
+#define TMEM_FLASHKDA_BWD_PERSISTENT_C16_DK_RESTORE_OFFSET 416
+#define TMEM_FLASHKDA_BWD_PERSISTENT_C16_DQ_OFFSET 368
+#define TMEM_FLASHKDA_BWD_PERSISTENT_C16_DK_DECAY_OFFSET 384
+#define TMEM_FLASHKDA_BWD_PERSISTENT_C16_DK_INV_OFFSET 400
+#define NUM_SCHED_PIPE_STAGES 8
+#define NUM_RAW_PIPE_STAGES 2
+#define NUM_OPERAND_PIPE_STAGES 2
+#define NUM_INTERMEDIATE_PIPE_STAGES 2
+#define NUM_TCGEN_DATA_PIPE_STAGES 1
+#define NUM_DSTATE_RECURRENCE_PIPE_STAGES 1
+#define NUM_U_SMEM_PIPE_STAGES 1
+#define NUM_DSTATE_SMEM_PIPE_STAGES 1
+#define NUM_BOUNDARY_PIPE_STAGES 1
+#define NUM_BOUNDARY_LOCAL_GRAD_PIPE_STAGES 1
+#define NUM_DK_RESTORE_PIPE_STAGES 1
+#define NUM_DY_SMEM_PIPE_STAGES 1
+#define NUM_BETA_DY_SMEM_PIPE_STAGES 2
+#define NUM_DBETA_M_PIPE_STAGES 1
+#define NUM_LOCAL_GRAD_PIPE_STAGES 1
+#define NUM_QK_RAW_PIPE_STAGES 4
+#define NUM_G_PREFIX_PIPE_STAGES 2
+#define NUM_STATE_SMEM_PIPE_STAGES 2
+#define SMEM_STATE_OPERAND_OFF 1024
+#define SMEM_STATE_OPERAND_STAGE_BYTES 32768
+#define SMEM_STATE_OPERAND_STRIDE 32768
+#define SMEM_STATE_OPERAND_MN_OFF 1024
+#define SMEM_STATE_OPERAND_MN_STAGE_BYTES 32768
+#define SMEM_STATE_OPERAND_MN_STRIDE 32768
+#define SMEM_STATE_PANEL_OFF 1024
+#define SMEM_STATE_PANEL_STAGE_BYTES 16384
+#define SMEM_STATE_PANEL_STRIDE 16384
+#define SMEM_STATE_OPERAND_ALL_OFF 1024
+#define SMEM_STATE_OPERAND_ALL_STAGE_BYTES 65536
+#define SMEM_STATE_OPERAND_ALL_STRIDE 65536
+#define SMEM_WORK_ITEM_OFF 230368
+#define SMEM_WORK_ITEM_STAGE_BYTES 4
+#define SMEM_WORK_ITEM_STRIDE 4
+#define SMEM_RAW_Q_OFF 66560
+#define SMEM_RAW_Q_STAGE_BYTES 4096
+#define SMEM_RAW_Q_STRIDE 4096
+#define SMEM_RAW_K_OFF 74752
+#define SMEM_RAW_K_STAGE_BYTES 4096
+#define SMEM_RAW_K_STRIDE 4096
+#define SMEM_RAW_G_OFF 82944
+#define SMEM_RAW_G_STAGE_BYTES 4096
+#define SMEM_RAW_G_STRIDE 4096
+#define SMEM_RAW_DO_OFF 91136
+#define SMEM_RAW_DO_STAGE_BYTES 4096
+#define SMEM_RAW_DO_STRIDE 4096
+#define SMEM_RAW_DO_AMAJ_OFF 91136
+#define SMEM_RAW_DO_AMAJ_STAGE_BYTES 4096
+#define SMEM_RAW_DO_AMAJ_STRIDE 4096
+#define SMEM_RAW_V_OFF 99328
+#define SMEM_RAW_V_STAGE_BYTES 4096
+#define SMEM_RAW_V_STRIDE 4096
+#define SMEM_BETA_DY_SMEM_OFF 107520
+#define SMEM_BETA_DY_SMEM_STAGE_BYTES 4096
+#define SMEM_BETA_DY_SMEM_STRIDE 4096
+#define SMEM_RAW_V_ALL_OFF 99328
+#define SMEM_RAW_V_ALL_STAGE_BYTES 8192
+#define SMEM_RAW_V_ALL_STRIDE 8192
+#define SMEM_BETA_SMEM_OFF 220160
+#define SMEM_BETA_SMEM_STAGE_BYTES 256
+#define SMEM_BETA_SMEM_STRIDE 256
+#define SMEM_BETA_SMEM_ALL_OFF 220160
+#define SMEM_BETA_SMEM_ALL_STAGE_BYTES 512
+#define SMEM_BETA_SMEM_ALL_STRIDE 512
+#define SMEM_DBETA_M_SMEM_OFF 220672
+#define SMEM_DBETA_M_SMEM_STAGE_BYTES 64
+#define SMEM_DBETA_M_SMEM_STRIDE 64
+#define SMEM_DBETA_RED_SMEM_OFF 220736
+#define SMEM_DBETA_RED_SMEM_STAGE_BYTES 256
+#define SMEM_DBETA_RED_SMEM_STRIDE 256
+#define SMEM_QK_NORM_SMEM_OFF 220992
+#define SMEM_QK_NORM_SMEM_STAGE_BYTES 128
+#define SMEM_QK_NORM_SMEM_STRIDE 128
+#define SMEM_QK_NORM_SMEM_ALL_OFF 220992
+#define SMEM_QK_NORM_SMEM_ALL_STAGE_BYTES 512
+#define SMEM_QK_NORM_SMEM_ALL_STRIDE 512
+#define SMEM_QK_RED_SMEM_OFF 221504
+#define SMEM_QK_RED_SMEM_STAGE_BYTES 256
+#define SMEM_QK_RED_SMEM_STRIDE 256
+#define SMEM_RAW_DO_ALL_OFF 91136
+#define SMEM_RAW_DO_ALL_STAGE_BYTES 8192
+#define SMEM_RAW_DO_ALL_STRIDE 8192
+#define SMEM_RAW_Q_ALL_OFF 66560
+#define SMEM_RAW_Q_ALL_STAGE_BYTES 8192
+#define SMEM_RAW_Q_ALL_STRIDE 8192
+#define SMEM_RAW_K_ALL_OFF 74752
+#define SMEM_RAW_K_ALL_STAGE_BYTES 8192
+#define SMEM_RAW_K_ALL_STRIDE 8192
+#define SMEM_RAW_G_ALL_OFF 82944
+#define SMEM_RAW_G_ALL_STAGE_BYTES 8192
+#define SMEM_RAW_G_ALL_STRIDE 8192
+#define SMEM_G_PREFIX_OFF 115712
+#define SMEM_G_PREFIX_STAGE_BYTES 8192
+#define SMEM_G_PREFIX_STRIDE 8192
+#define SMEM_G_PREFIX_ALL_OFF 115712
+#define SMEM_G_PREFIX_ALL_STAGE_BYTES 16384
+#define SMEM_G_PREFIX_ALL_STRIDE 16384
+#define SMEM_K_INV_OPERAND_OFF 132096
+#define SMEM_K_INV_OPERAND_STAGE_BYTES 4096
+#define SMEM_K_INV_OPERAND_STRIDE 4096
+#define SMEM_K_INV_LEAD16_OFF 132096
+#define SMEM_K_INV_LEAD16_STAGE_BYTES 4096
+#define SMEM_K_INV_LEAD16_STRIDE 4096
+#define SMEM_K_INV_AMAJ_OFF 132096
+#define SMEM_K_INV_AMAJ_STAGE_BYTES 4096
+#define SMEM_K_INV_AMAJ_STRIDE 4096
+#define SMEM_K_DECAY_OPERAND_OFF 140288
+#define SMEM_K_DECAY_OPERAND_STAGE_BYTES 4096
+#define SMEM_K_DECAY_OPERAND_STRIDE 4096
+#define SMEM_K_DECAY_LEAD16_OFF 140288
+#define SMEM_K_DECAY_LEAD16_STAGE_BYTES 4096
+#define SMEM_K_DECAY_LEAD16_STRIDE 4096
+#define SMEM_K_DECAY_TRANS_OFF 140288
+#define SMEM_K_DECAY_TRANS_STAGE_BYTES 4096
+#define SMEM_K_DECAY_TRANS_STRIDE 4096
+#define SMEM_Q_DECAY_OPERAND_OFF 148480
+#define SMEM_Q_DECAY_OPERAND_STAGE_BYTES 4096
+#define SMEM_Q_DECAY_OPERAND_STRIDE 4096
+#define SMEM_Q_DECAY_TRANS_OFF 148480
+#define SMEM_Q_DECAY_TRANS_STAGE_BYTES 4096
+#define SMEM_Q_DECAY_TRANS_STRIDE 4096
+#define SMEM_K_RESTORE_OPERAND_OFF 156672
+#define SMEM_K_RESTORE_OPERAND_STAGE_BYTES 4096
+#define SMEM_K_RESTORE_OPERAND_STRIDE 4096
+#define SMEM_K_RESTORE_LEAD16_OFF 156672
+#define SMEM_K_RESTORE_LEAD16_STAGE_BYTES 4096
+#define SMEM_K_RESTORE_LEAD16_STRIDE 4096
+#define SMEM_K_INV_ALL_OFF 132096
+#define SMEM_K_INV_ALL_STAGE_BYTES 8192
+#define SMEM_K_INV_ALL_STRIDE 8192
+#define SMEM_K_DECAY_ALL_OFF 140288
+#define SMEM_K_DECAY_ALL_STAGE_BYTES 8192
+#define SMEM_K_DECAY_ALL_STRIDE 8192
+#define SMEM_Q_DECAY_ALL_OFF 148480
+#define SMEM_Q_DECAY_ALL_STAGE_BYTES 8192
+#define SMEM_Q_DECAY_ALL_STRIDE 8192
+#define SMEM_K_RESTORE_ALL_OFF 156672
+#define SMEM_K_RESTORE_ALL_STAGE_BYTES 8192
+#define SMEM_K_RESTORE_ALL_STRIDE 8192
+#define SMEM_TINV_SCRATCH_OFF 164864
+#define SMEM_TINV_SCRATCH_STAGE_BYTES 512
+#define SMEM_TINV_SCRATCH_STRIDE 512
+#define SMEM_INTERMEDIATE_A_OFF 165376
+#define SMEM_INTERMEDIATE_A_STAGE_BYTES 512
+#define SMEM_INTERMEDIATE_A_STRIDE 2560
+#define SMEM_INTERMEDIATE_TINV_OFF 165888
+#define SMEM_INTERMEDIATE_TINV_STAGE_BYTES 512
+#define SMEM_INTERMEDIATE_TINV_STRIDE 2560
+#define SMEM_INTERMEDIATE_DA_OFF 166400
+#define SMEM_INTERMEDIATE_DA_STAGE_BYTES 512
+#define SMEM_INTERMEDIATE_DA_STRIDE 2560
+#define SMEM_INTERMEDIATE_DM_OFF 166912
+#define SMEM_INTERMEDIATE_DM_STAGE_BYTES 512
+#define SMEM_INTERMEDIATE_DM_STRIDE 2560
+#define SMEM_INTERMEDIATE_NDM_OFF 167424
+#define SMEM_INTERMEDIATE_NDM_STAGE_BYTES 512
+#define SMEM_INTERMEDIATE_NDM_STRIDE 2560
+#define SMEM_INTERMEDIATE_A_MN_OFF 165376
+#define SMEM_INTERMEDIATE_A_MN_STAGE_BYTES 512
+#define SMEM_INTERMEDIATE_A_MN_STRIDE 2560
+#define SMEM_INTERMEDIATE_TINV_MN_OFF 165888
+#define SMEM_INTERMEDIATE_TINV_MN_STAGE_BYTES 512
+#define SMEM_INTERMEDIATE_TINV_MN_STRIDE 2560
+#define SMEM_INTERMEDIATE_DA_MN_OFF 166400
+#define SMEM_INTERMEDIATE_DA_MN_STAGE_BYTES 512
+#define SMEM_INTERMEDIATE_DA_MN_STRIDE 2560
+#define SMEM_INTERMEDIATE_NDM_MN_OFF 167424
+#define SMEM_INTERMEDIATE_NDM_MN_STAGE_BYTES 512
+#define SMEM_INTERMEDIATE_NDM_MN_STRIDE 2560
+#define SMEM_STATE_SCALE_DIAG_OFF 170496
+#define SMEM_STATE_SCALE_DIAG_STAGE_BYTES 512
+#define SMEM_STATE_SCALE_DIAG_STRIDE 512
+#define SMEM_U_SMEM_OFF 179200
+#define SMEM_U_SMEM_STAGE_BYTES 4096
+#define SMEM_U_SMEM_STRIDE 4096
+#define SMEM_U_SMEM_ALL_OFF 179200
+#define SMEM_U_SMEM_ALL_STAGE_BYTES 4096
+#define SMEM_U_SMEM_ALL_STRIDE 4096
+#define SMEM_U_LEAD16_OFF 179200
+#define SMEM_U_LEAD16_STAGE_BYTES 4096
+#define SMEM_U_LEAD16_STRIDE 4096
+#define SMEM_DSTATE_SMEM_OFF 183296
+#define SMEM_DSTATE_SMEM_STAGE_BYTES 32768
+#define SMEM_DSTATE_SMEM_STRIDE 32768
+#define SMEM_DSTATE_SMEM_MN_OFF 183296
+#define SMEM_DSTATE_SMEM_MN_STAGE_BYTES 32768
+#define SMEM_DSTATE_SMEM_MN_STRIDE 32768
+#define SMEM_DSTATE_SMEM_ALL_OFF 183296
+#define SMEM_DSTATE_SMEM_ALL_STAGE_BYTES 32768
+#define SMEM_DSTATE_SMEM_ALL_STRIDE 32768
+#define SMEM_DY_SMEM_OFF 216064
+#define SMEM_DY_SMEM_STAGE_BYTES 4096
+#define SMEM_DY_SMEM_STRIDE 4096
+#define SMEM_DY_SMEM_ALL_OFF 216064
+#define SMEM_DY_SMEM_ALL_STAGE_BYTES 4096
+#define SMEM_DY_SMEM_ALL_STRIDE 4096
+#define SMEM_DEBUG_DU_SMEM_OFF 221760
+#define SMEM_DEBUG_DU_SMEM_STAGE_BYTES 4096
+#define SMEM_DEBUG_DU_SMEM_STRIDE 4096
+#define SMEM_DEBUG_DU_SMEM_ALL_OFF 221760
+#define SMEM_DEBUG_DU_SMEM_ALL_STAGE_BYTES 4096
+#define SMEM_DEBUG_DU_SMEM_ALL_STRIDE 4096
+#define SMEM_BOUNDARY_STATE_SMEM_OFF 221760
+#define SMEM_BOUNDARY_STATE_SMEM_STAGE_BYTES 512
+#define SMEM_BOUNDARY_STATE_SMEM_STRIDE 512
+#define SMEM_TOTAL 230400
+#define THREADS 512
+#define validate_outputs 0
+#define USE_DSTATE_IN 1
+
+extern "C" {
+
+__global__ __launch_bounds__(512, 1) void
+kernel_flashkda_backward_persistent_c16(unsigned int* __restrict__ dynamic_counter, FlashKDATensorMap const* q_tma, FlashKDATensorMap const* k_tma, FlashKDATensorMap const* g_tma, FlashKDATensorMap const* do_tma, FlashKDATensorMap const* v_tma, FlashKDATensorMap const* state_tma, float* __restrict__ dfinal_state, FlashKDATensorMap const* dv_tma, __nv_bfloat16* __restrict__ dq_out, __nv_bfloat16* __restrict__ dk_out, float* __restrict__ dgate_out, float* __restrict__ dgate_boundary_out, float* __restrict__ dinitial_state, float* __restrict__ A_log, float* __restrict__ dt_bias, FlashKDATensorMap const* beta_tma, float* __restrict__ dbeta, long long* __restrict__ cu_seqlens, int* __restrict__ work_items, unsigned int* __restrict__ visits, float* __restrict__ observed, float* __restrict__ raw_observed, float* __restrict__ gate_observed, float* __restrict__ operand_observed, float* __restrict__ kk_observed, float* __restrict__ tinv_observed, float* __restrict__ a_observed, float* __restrict__ tcgen_observed, float* __restrict__ dstate_observed, float* __restrict__ dk_restore_observed, float* __restrict__ da_observed, float* __restrict__ dm_observed, float* __restrict__ local_grad_observed, float* __restrict__ assembled_grad_observed, int total_work_items, int uniform_work_items, int observed_chunks, int num_heads, int enable_kk, int enable_tinv, float scale, float lower_bound)
+{
+    const int tid = threadIdx.x;
+    const int warp = make_warp_uniform(tid / 32);
+    const int lane = tid % 32;
+
+    extern __shared__ __align__(1024) char smem_raw[];
+    int smem;
+    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+
+    const int bid = blockIdx.x;
+    const int num_bids = gridDim.x;
+    if (tid == 0) {
+        asm volatile("fence.proxy.tensormap::generic.acquire.sys [%0], 128;" :: "l"((uint64_t)(q_tma)) : "memory");
+        asm volatile("fence.proxy.tensormap::generic.acquire.sys [%0], 128;" :: "l"((uint64_t)(k_tma)) : "memory");
+        asm volatile("fence.proxy.tensormap::generic.acquire.sys [%0], 128;" :: "l"((uint64_t)(g_tma)) : "memory");
+        asm volatile("fence.proxy.tensormap::generic.acquire.sys [%0], 128;" :: "l"((uint64_t)(do_tma)) : "memory");
+        asm volatile("fence.proxy.tensormap::generic.acquire.sys [%0], 128;" :: "l"((uint64_t)(v_tma)) : "memory");
+        asm volatile("fence.proxy.tensormap::generic.acquire.sys [%0], 128;" :: "l"((uint64_t)(state_tma)) : "memory");
+        asm volatile("fence.proxy.tensormap::generic.acquire.sys [%0], 128;" :: "l"((uint64_t)(dv_tma)) : "memory");
+        asm volatile("fence.proxy.tensormap::generic.acquire.sys [%0], 128;" :: "l"((uint64_t)(beta_tma)) : "memory");
+    }
+    __syncthreads();
+
+
+    // Kernel setup ops
+    __nv_bfloat16* state_operand = reinterpret_cast<__nv_bfloat16*>(smem_raw + 1024);
+    const int state_operand_addr = smem + 1024;
+    __nv_bfloat16* state_operand_mn = reinterpret_cast<__nv_bfloat16*>(smem_raw + 1024);
+    const int state_operand_mn_addr = smem + 1024;
+    __nv_bfloat16* state_panel = reinterpret_cast<__nv_bfloat16*>(smem_raw + 1024);
+    const int state_panel_addr = smem + 1024;
+    __nv_bfloat16* state_operand_all = reinterpret_cast<__nv_bfloat16*>(smem_raw + 1024);
+    const int state_operand_all_addr = smem + 1024;
+    unsigned int* work_item = reinterpret_cast<unsigned int*>(smem_raw + 230368);
+    const int work_item_addr = smem + 230368;
+    __nv_bfloat16* raw_q = reinterpret_cast<__nv_bfloat16*>(smem_raw + 66560);
+    const int raw_q_addr = smem + 66560;
+    __nv_bfloat16* raw_k = reinterpret_cast<__nv_bfloat16*>(smem_raw + 74752);
+    const int raw_k_addr = smem + 74752;
+    __nv_bfloat16* raw_g = reinterpret_cast<__nv_bfloat16*>(smem_raw + 82944);
+    const int raw_g_addr = smem + 82944;
+    __nv_bfloat16* raw_do = reinterpret_cast<__nv_bfloat16*>(smem_raw + 91136);
+    const int raw_do_addr = smem + 91136;
+    __nv_bfloat16* raw_do_amaj = reinterpret_cast<__nv_bfloat16*>(smem_raw + 91136);
+    const int raw_do_amaj_addr = smem + 91136;
+    __nv_bfloat16* raw_v = reinterpret_cast<__nv_bfloat16*>(smem_raw + 99328);
+    const int raw_v_addr = smem + 99328;
+    __nv_bfloat16* beta_dy_smem = reinterpret_cast<__nv_bfloat16*>(smem_raw + 107520);
+    const int beta_dy_smem_addr = smem + 107520;
+    __nv_bfloat16* raw_v_all = reinterpret_cast<__nv_bfloat16*>(smem_raw + 99328);
+    const int raw_v_all_addr = smem + 99328;
+    __nv_bfloat16* beta_smem = reinterpret_cast<__nv_bfloat16*>(smem_raw + 220160);
+    const int beta_smem_addr = smem + 220160;
+    __nv_bfloat16* beta_smem_all = reinterpret_cast<__nv_bfloat16*>(smem_raw + 220160);
+    const int beta_smem_all_addr = smem + 220160;
+    float* dbeta_m_smem = reinterpret_cast<float*>(smem_raw + 220672);
+    const int dbeta_m_smem_addr = smem + 220672;
+    float* dbeta_red_smem = reinterpret_cast<float*>(smem_raw + 220736);
+    const int dbeta_red_smem_addr = smem + 220736;
+    float* qk_norm_smem = reinterpret_cast<float*>(smem_raw + 220992);
+    const int qk_norm_smem_addr = smem + 220992;
+    float* qk_norm_smem_all = reinterpret_cast<float*>(smem_raw + 220992);
+    const int qk_norm_smem_all_addr = smem + 220992;
+    float* qk_red_smem = reinterpret_cast<float*>(smem_raw + 221504);
+    const int qk_red_smem_addr = smem + 221504;
+    __nv_bfloat16* raw_do_all = reinterpret_cast<__nv_bfloat16*>(smem_raw + 91136);
+    const int raw_do_all_addr = smem + 91136;
+    __nv_bfloat16* raw_q_all = reinterpret_cast<__nv_bfloat16*>(smem_raw + 66560);
+    const int raw_q_all_addr = smem + 66560;
+    __nv_bfloat16* raw_k_all = reinterpret_cast<__nv_bfloat16*>(smem_raw + 74752);
+    const int raw_k_all_addr = smem + 74752;
+    __nv_bfloat16* raw_g_all = reinterpret_cast<__nv_bfloat16*>(smem_raw + 82944);
+    const int raw_g_all_addr = smem + 82944;
+    float* g_prefix = reinterpret_cast<float*>(smem_raw + 115712);
+    const int g_prefix_addr = smem + 115712;
+    float* g_prefix_all = reinterpret_cast<float*>(smem_raw + 115712);
+    const int g_prefix_all_addr = smem + 115712;
+    __nv_bfloat16* k_inv_operand = reinterpret_cast<__nv_bfloat16*>(smem_raw + 132096);
+    const int k_inv_operand_addr = smem + 132096;
+    __nv_bfloat16* k_inv_lead16 = reinterpret_cast<__nv_bfloat16*>(smem_raw + 132096);
+    const int k_inv_lead16_addr = smem + 132096;
+    __nv_bfloat16* k_inv_amaj = reinterpret_cast<__nv_bfloat16*>(smem_raw + 132096);
+    const int k_inv_amaj_addr = smem + 132096;
+    __nv_bfloat16* k_decay_operand = reinterpret_cast<__nv_bfloat16*>(smem_raw + 140288);
+    const int k_decay_operand_addr = smem + 140288;
+    __nv_bfloat16* k_decay_lead16 = reinterpret_cast<__nv_bfloat16*>(smem_raw + 140288);
+    const int k_decay_lead16_addr = smem + 140288;
+    __nv_bfloat16* k_decay_trans = reinterpret_cast<__nv_bfloat16*>(smem_raw + 140288);
+    const int k_decay_trans_addr = smem + 140288;
+    __nv_bfloat16* q_decay_operand = reinterpret_cast<__nv_bfloat16*>(smem_raw + 148480);
+    const int q_decay_operand_addr = smem + 148480;
+    __nv_bfloat16* q_decay_trans = reinterpret_cast<__nv_bfloat16*>(smem_raw + 148480);
+    const int q_decay_trans_addr = smem + 148480;
+    __nv_bfloat16* k_restore_operand = reinterpret_cast<__nv_bfloat16*>(smem_raw + 156672);
+    const int k_restore_operand_addr = smem + 156672;
+    __nv_bfloat16* k_restore_lead16 = reinterpret_cast<__nv_bfloat16*>(smem_raw + 156672);
+    const int k_restore_lead16_addr = smem + 156672;
+    __nv_bfloat16* k_inv_all = reinterpret_cast<__nv_bfloat16*>(smem_raw + 132096);
+    const int k_inv_all_addr = smem + 132096;
+    __nv_bfloat16* k_decay_all = reinterpret_cast<__nv_bfloat16*>(smem_raw + 140288);
+    const int k_decay_all_addr = smem + 140288;
+    __nv_bfloat16* q_decay_all = reinterpret_cast<__nv_bfloat16*>(smem_raw + 148480);
+    const int q_decay_all_addr = smem + 148480;
+    __nv_bfloat16* k_restore_all = reinterpret_cast<__nv_bfloat16*>(smem_raw + 156672);
+    const int k_restore_all_addr = smem + 156672;
+    __nv_bfloat16* tinv_scratch = reinterpret_cast<__nv_bfloat16*>(smem_raw + 164864);
+    const int tinv_scratch_addr = smem + 164864;
+    __nv_bfloat16* intermediate_a = reinterpret_cast<__nv_bfloat16*>(smem_raw + 165376);
+    const int intermediate_a_addr = smem + 165376;
+    __nv_bfloat16* intermediate_tinv = reinterpret_cast<__nv_bfloat16*>(smem_raw + 165888);
+    const int intermediate_tinv_addr = smem + 165888;
+    __nv_bfloat16* intermediate_da = reinterpret_cast<__nv_bfloat16*>(smem_raw + 166400);
+    const int intermediate_da_addr = smem + 166400;
+    __nv_bfloat16* intermediate_dm = reinterpret_cast<__nv_bfloat16*>(smem_raw + 166912);
+    const int intermediate_dm_addr = smem + 166912;
+    __nv_bfloat16* intermediate_ndm = reinterpret_cast<__nv_bfloat16*>(smem_raw + 167424);
+    const int intermediate_ndm_addr = smem + 167424;
+    __nv_bfloat16* intermediate_a_mn = reinterpret_cast<__nv_bfloat16*>(smem_raw + 165376);
+    const int intermediate_a_mn_addr = smem + 165376;
+    __nv_bfloat16* intermediate_tinv_mn = reinterpret_cast<__nv_bfloat16*>(smem_raw + 165888);
+    const int intermediate_tinv_mn_addr = smem + 165888;
+    __nv_bfloat16* intermediate_da_mn = reinterpret_cast<__nv_bfloat16*>(smem_raw + 166400);
+    const int intermediate_da_mn_addr = smem + 166400;
+    __nv_bfloat16* intermediate_ndm_mn = reinterpret_cast<__nv_bfloat16*>(smem_raw + 167424);
+    const int intermediate_ndm_mn_addr = smem + 167424;
+    __nv_bfloat16* state_scale_diag = reinterpret_cast<__nv_bfloat16*>(smem_raw + 170496);
+    const int state_scale_diag_addr = smem + 170496;
+    __nv_bfloat16* u_smem = reinterpret_cast<__nv_bfloat16*>(smem_raw + 179200);
+    const int u_smem_addr = smem + 179200;
+    __nv_bfloat16* u_smem_all = reinterpret_cast<__nv_bfloat16*>(smem_raw + 179200);
+    const int u_smem_all_addr = smem + 179200;
+    __nv_bfloat16* u_lead16 = reinterpret_cast<__nv_bfloat16*>(smem_raw + 179200);
+    const int u_lead16_addr = smem + 179200;
+    __nv_bfloat16* dstate_smem = reinterpret_cast<__nv_bfloat16*>(smem_raw + 183296);
+    const int dstate_smem_addr = smem + 183296;
+    __nv_bfloat16* dstate_smem_mn = reinterpret_cast<__nv_bfloat16*>(smem_raw + 183296);
+    const int dstate_smem_mn_addr = smem + 183296;
+    __nv_bfloat16* dstate_smem_all = reinterpret_cast<__nv_bfloat16*>(smem_raw + 183296);
+    const int dstate_smem_all_addr = smem + 183296;
+    __nv_bfloat16* dy_smem = reinterpret_cast<__nv_bfloat16*>(smem_raw + 216064);
+    const int dy_smem_addr = smem + 216064;
+    __nv_bfloat16* dy_smem_all = reinterpret_cast<__nv_bfloat16*>(smem_raw + 216064);
+    const int dy_smem_all_addr = smem + 216064;
+    __nv_bfloat16* debug_du_smem = reinterpret_cast<__nv_bfloat16*>(smem_raw + 221760);
+    const int debug_du_smem_addr = smem + 221760;
+    __nv_bfloat16* debug_du_smem_all = reinterpret_cast<__nv_bfloat16*>(smem_raw + 221760);
+    const int debug_du_smem_all_addr = smem + 221760;
+    float* boundary_state_smem = reinterpret_cast<float*>(smem_raw + 221760);
+    const int boundary_state_smem_addr = smem + 221760;
+
+    // Mbarrier init (50 groups, 89 barriers)
+    // Mbarriers at smem_raw[0..712)
+
+    if (warp == 0) {
+        uint32_t leader = elect_sync();
+        if (leader) {
+            // --- pipeline 'sched_pipe' ---
+            // sched_ready: 8 barriers, init_count=1
+            mbarrier_init(smem + 0, 1);
+            mbarrier_init(smem + 8, 1);
+            mbarrier_init(smem + 16, 1);
+            mbarrier_init(smem + 24, 1);
+            mbarrier_init(smem + 32, 1);
+            mbarrier_init(smem + 40, 1);
+            mbarrier_init(smem + 48, 1);
+            mbarrier_init(smem + 56, 1);
+            // sched_done: 8 barriers, init_count=15
+            mbarrier_init(smem + 64, 15);
+            mbarrier_init(smem + 72, 15);
+            mbarrier_init(smem + 80, 15);
+            mbarrier_init(smem + 88, 15);
+            mbarrier_init(smem + 96, 15);
+            mbarrier_init(smem + 104, 15);
+            mbarrier_init(smem + 112, 15);
+            mbarrier_init(smem + 120, 15);
+            // --- pipeline 'raw_pipe' ---
+            // raw_ready: 2 barriers, init_count=1
+            mbarrier_init(smem + 128, 1);
+            mbarrier_init(smem + 136, 1);
+            // raw_done: 2 barriers, init_count=165
+            mbarrier_init(smem + 144, 165);
+            mbarrier_init(smem + 152, 165);
+            // --- pipeline 'g_prefix_pipe' ---
+            // g_prefix_ready: 2 barriers, init_count=128
+            mbarrier_init(smem + 160, 128);
+            mbarrier_init(smem + 168, 128);
+            // g_prefix_done: 2 barriers, init_count=128
+            mbarrier_init(smem + 176, 128);
+            mbarrier_init(smem + 184, 128);
+            // --- pipeline 'state_smem_pipe' ---
+            // state_ready: 2 barriers, init_count=1
+            mbarrier_init(smem + 192, 1);
+            mbarrier_init(smem + 200, 1);
+            // state_slot_done: 2 barriers, init_count=1
+            mbarrier_init(smem + 208, 1);
+            mbarrier_init(smem + 216, 1);
+            // state_cg2_done: 2 barriers, init_count=128
+            mbarrier_init(smem + 224, 128);
+            mbarrier_init(smem + 232, 128);
+            // state_k_ready: 2 barriers, init_count=1
+            mbarrier_init(smem + 240, 1);
+            mbarrier_init(smem + 248, 1);
+            // state_k_done: 2 barriers, init_count=4
+            mbarrier_init(smem + 256, 4);
+            mbarrier_init(smem + 264, 4);
+            // --- pipeline 'operand_pipe' ---
+            // k_decay_inv_ready: 2 barriers, init_count=128
+            mbarrier_init(smem + 272, 128);
+            mbarrier_init(smem + 280, 128);
+            // q_decay_k_restore_ready: 2 barriers, init_count=128
+            mbarrier_init(smem + 288, 128);
+            mbarrier_init(smem + 296, 128);
+            // decay_done: 2 barriers, init_count=1
+            mbarrier_init(smem + 304, 1);
+            mbarrier_init(smem + 312, 1);
+            // --- pipeline 'intermediate_pipe' ---
+            // tinv_ready: 2 barriers, init_count=32
+            mbarrier_init(smem + 320, 32);
+            mbarrier_init(smem + 328, 32);
+            // a_ready: 2 barriers, init_count=32
+            mbarrier_init(smem + 336, 32);
+            mbarrier_init(smem + 344, 32);
+            // da_ready: 2 barriers, init_count=32
+            mbarrier_init(smem + 352, 32);
+            mbarrier_init(smem + 360, 32);
+            // dm_ready: 2 barriers, init_count=32
+            mbarrier_init(smem + 368, 32);
+            mbarrier_init(smem + 376, 32);
+            // intermediate_done: 2 barriers, init_count=1
+            mbarrier_init(smem + 384, 1);
+            mbarrier_init(smem + 392, 1);
+            // --- pipeline 'tcgen_data_pipe' ---
+            // tcgen_inputs_ready: 1 barriers, init_count=4
+            mbarrier_init(smem + 400, 4);
+            // tcgen_inputs_done: 1 barriers, init_count=1
+            mbarrier_init(smem + 408, 1);
+            // tcgen_products_ready: 1 barriers, init_count=1
+            mbarrier_init(smem + 416, 1);
+            // tcgen_products_done: 1 barriers, init_count=4
+            mbarrier_init(smem + 424, 4);
+            // du_inp_ready: 1 barriers, init_count=4
+            mbarrier_init(smem + 432, 4);
+            // dy_ready: 1 barriers, init_count=1
+            mbarrier_init(smem + 440, 1);
+            // dy_done: 1 barriers, init_count=4
+            mbarrier_init(smem + 448, 4);
+            // neg_dy_ready: 1 barriers, init_count=4
+            mbarrier_init(smem + 456, 4);
+            // dstate_ready: 1 barriers, init_count=1
+            mbarrier_init(smem + 464, 1);
+            // --- pipeline 'dstate_recurrence_pipe' ---
+            // dstate_inp_ready: 1 barriers, init_count=4
+            mbarrier_init(smem + 472, 4);
+            // --- pipeline 'tcgen_data_pipe' ---
+            // dstate_done: 1 barriers, init_count=8
+            mbarrier_init(smem + 480, 8);
+            // --- pipeline 'u_smem_pipe' ---
+            // u_smem_ready: 1 barriers, init_count=4
+            mbarrier_init(smem + 488, 4);
+            // --- pipeline 'dy_smem_pipe' ---
+            // dy_smem_ready: 1 barriers, init_count=4
+            mbarrier_init(smem + 496, 4);
+            // --- pipeline 'beta_dy_smem_pipe' ---
+            // beta_dy_smem_ready: 2 barriers, init_count=4
+            mbarrier_init(smem + 504, 4);
+            mbarrier_init(smem + 512, 4);
+            // beta_dy_smem_done: 2 barriers, init_count=2
+            mbarrier_init(smem + 520, 2);
+            mbarrier_init(smem + 528, 2);
+            // --- pipeline 'dbeta_m_pipe' ---
+            // dbeta_m_ready: 1 barriers, init_count=1
+            mbarrier_init(smem + 536, 1);
+            // dbeta_m_done: 1 barriers, init_count=1
+            mbarrier_init(smem + 544, 1);
+            // --- pipeline 'dstate_smem_pipe' ---
+            // dstate_smem_ready: 1 barriers, init_count=4
+            mbarrier_init(smem + 552, 4);
+            // dstate_smem_done: 1 barriers, init_count=1
+            mbarrier_init(smem + 560, 1);
+            // --- pipeline 'boundary_pipe' ---
+            // boundary_smem_ready: 1 barriers, init_count=4
+            mbarrier_init(smem + 568, 4);
+            // boundary_state_ready: 1 barriers, init_count=4
+            mbarrier_init(smem + 576, 4);
+            // boundary_acc_ready: 1 barriers, init_count=1
+            mbarrier_init(smem + 584, 1);
+            // --- pipeline 'boundary_local_grad_pipe' ---
+            // boundary_local_grad_free: 1 barriers, init_count=4
+            mbarrier_init(smem + 592, 4);
+            // --- pipeline 'dk_restore_pipe' ---
+            // dk_restore_ready: 1 barriers, init_count=1
+            mbarrier_init(smem + 600, 1);
+            // dk_restore_done: 1 barriers, init_count=4
+            mbarrier_init(smem + 608, 4);
+            // --- pipeline 'local_grad_pipe' ---
+            // local_grad_ready: 1 barriers, init_count=1
+            mbarrier_init(smem + 616, 1);
+            // local_grad_done: 1 barriers, init_count=4
+            mbarrier_init(smem + 624, 4);
+            // --- pipeline 'qk_raw_pipe' ---
+            // qk_raw_ready: 4 barriers, init_count=128
+            mbarrier_init(smem + 632, 128);
+            mbarrier_init(smem + 640, 128);
+            mbarrier_init(smem + 648, 128);
+            mbarrier_init(smem + 656, 128);
+            // qk_raw_done: 4 barriers, init_count=128
+            mbarrier_init(smem + 664, 128);
+            mbarrier_init(smem + 672, 128);
+            mbarrier_init(smem + 680, 128);
+            mbarrier_init(smem + 688, 128);
+            // consumers_done: 1 barriers, init_count=15
+            mbarrier_init(smem + 696, 15);
+            // cleanup_ready: 1 barriers, init_count=1
+            mbarrier_init(smem + 704, 1);
+            asm volatile("fence.mbarrier_init.release.cluster;");
+        }
+    }
+
+    __syncwarp();
+
+    // TMEM alloc (512 columns, 512 used)
+    volatile int* tmem_addr_storage = (volatile int*)(smem_raw + 712);
+    if (warp == 13) {
+        int _tmem_hold = smem + 712;
+        asm volatile("tcgen05.alloc.cta_group::1.sync.aligned.shared::cta.b32 [%0], %1;" :: "r"(_tmem_hold), "r"(512) : "memory");
+        asm volatile("tcgen05.relinquish_alloc_permit.cta_group::1.sync.aligned;");
+    }
+
+    __syncthreads();
+    asm volatile("tcgen05.fence::after_thread_sync;");
+
+    const int mbar_base = smem;
+    #define sched_ready_addr (mbar_base + 0)
+    #define sched_done_addr (mbar_base + 64)
+    #define raw_ready_addr (mbar_base + 128)
+    #define raw_done_addr (mbar_base + 144)
+    #define g_prefix_ready_addr (mbar_base + 160)
+    #define g_prefix_done_addr (mbar_base + 176)
+    #define state_ready_addr (mbar_base + 192)
+    #define state_slot_done_addr (mbar_base + 208)
+    #define state_cg2_done_addr (mbar_base + 224)
+    #define state_k_ready_addr (mbar_base + 240)
+    #define state_k_done_addr (mbar_base + 256)
+    #define k_decay_inv_ready_addr (mbar_base + 272)
+    #define q_decay_k_restore_ready_addr (mbar_base + 288)
+    #define decay_done_addr (mbar_base + 304)
+    #define tinv_ready_addr (mbar_base + 320)
+    #define a_ready_addr (mbar_base + 336)
+    #define da_ready_addr (mbar_base + 352)
+    #define dm_ready_addr (mbar_base + 368)
+    #define intermediate_done_addr (mbar_base + 384)
+    #define tcgen_inputs_ready_addr (mbar_base + 400)
+    #define tcgen_inputs_done_addr (mbar_base + 408)
+    #define tcgen_products_ready_addr (mbar_base + 416)
+    #define tcgen_products_done_addr (mbar_base + 424)
+    #define du_inp_ready_addr (mbar_base + 432)
+    #define dy_ready_addr (mbar_base + 440)
+    #define dy_done_addr (mbar_base + 448)
+    #define neg_dy_ready_addr (mbar_base + 456)
+    #define dstate_ready_addr (mbar_base + 464)
+    #define dstate_inp_ready_addr (mbar_base + 472)
+    #define dstate_done_addr (mbar_base + 480)
+    #define u_smem_ready_addr (mbar_base + 488)
+    #define dy_smem_ready_addr (mbar_base + 496)
+    #define beta_dy_smem_ready_addr (mbar_base + 504)
+    #define beta_dy_smem_done_addr (mbar_base + 520)
+    #define dbeta_m_ready_addr (mbar_base + 536)
+    #define dbeta_m_done_addr (mbar_base + 544)
+    #define dstate_smem_ready_addr (mbar_base + 552)
+    #define dstate_smem_done_addr (mbar_base + 560)
+    #define boundary_smem_ready_addr (mbar_base + 568)
+    #define boundary_state_ready_addr (mbar_base + 576)
+    #define boundary_acc_ready_addr (mbar_base + 584)
+    #define boundary_local_grad_free_addr (mbar_base + 592)
+    #define dk_restore_ready_addr (mbar_base + 600)
+    #define dk_restore_done_addr (mbar_base + 608)
+    #define local_grad_ready_addr (mbar_base + 616)
+    #define local_grad_done_addr (mbar_base + 624)
+    #define qk_raw_ready_addr (mbar_base + 632)
+    #define qk_raw_done_addr (mbar_base + 664)
+    #define consumers_done_addr (mbar_base + 696)
+    #define cleanup_ready_addr (mbar_base + 704)
+    const int taddr = tmem_addr_storage[0];
+
+    // Kernel post-init ops
+    const int tmem_flashkda_bwd_persistent_c16_envelope = taddr;
+    const int tmem_flashkda_bwd_persistent_c16_y = taddr + 432;
+    const int tmem_flashkda_bwd_persistent_c16_u = taddr + 336;
+    const int tmem_flashkda_bwd_persistent_c16_du = taddr + 352;
+    const int tmem_flashkda_bwd_persistent_c16_state_k = taddr + 320;
+    const int tmem_flashkda_bwd_persistent_c16_du_inp = taddr + 440;
+    const int tmem_flashkda_bwd_persistent_c16_dy = taddr + 320;
+    const int tmem_flashkda_bwd_persistent_c16_neg_dy = taddr + 432;
+    const int tmem_flashkda_bwd_persistent_c16_do_inp = taddr + 440;
+    const int tmem_flashkda_bwd_persistent_c16_dstate = taddr;
+    const int tmem_flashkda_bwd_persistent_c16_dstate_inp = taddr + 128;
+    const int tmem_flashkda_bwd_persistent_c16_dk_restore = taddr + 416;
+    const int tmem_flashkda_bwd_persistent_c16_dq = taddr + 368;
+    const int tmem_flashkda_bwd_persistent_c16_dk_decay = taddr + 384;
+    const int tmem_flashkda_bwd_persistent_c16_dk_inv = taddr + 400;
+
+    // ---- Register redistribution for WGs split across roles ----
+    // Dec phase frees registers before any WG attempts inc.
+    if (warp >= 12 && warp <= 15) {
+        asm volatile("setmaxnreg.dec.sync.aligned.u32 56;");
+    }
+
+    // ---- Role: compute0 ----
+    if (warp <= 3) {
+        asm volatile("setmaxnreg.inc.sync.aligned.u32 144;");
+        { // compute0_main
+            unsigned int sched_stage0 = 0;
+            unsigned int raw_stage0 = 0;
+            unsigned int operand_stage0 = 0;
+            unsigned int qk_raw_stage0 = 0;
+            unsigned int g_prefix_stage0 = 0;
+            int warp_id_in_role = (warp - 0);
+            const int tmem_row_base0 = warp_id_in_role * 32 << 16;
+            unsigned int _phase_sched_ready = 0;
+            unsigned int _phase_raw_ready = 0;
+            unsigned int _phase_g_prefix_done = 1;
+            unsigned int _phase_qk_raw_done = 1;
+            unsigned int _phase_decay_done = 1;
+            #pragma unroll 1
+            for (int _ = 0; _ < total_work_items; _++) {
+                mbarrier_wait(sched_ready_addr + (sched_stage0) * 8, _phase_sched_ready);
+                unsigned int ticket_words[1];
+                asm volatile("ld.shared.b32 %0, [%1];" : "=r"(*reinterpret_cast<uint32_t*>(&ticket_words[0])) : "r"(work_item_addr + sched_stage0 * 4));
+                unsigned int tile0 = ticket_words[0];
+                if (elect_sync()) {
+                    mbarrier_arrive(sched_done_addr + (sched_stage0) * 8);
+                }
+                sched_stage0 += 1;
+                if (sched_stage0 == 8) { sched_stage0 = 0; _phase_sched_ready ^= 1; }
+                if (tile0 >= (unsigned int)total_work_items) {
+                    break;
+                }
+                int item_base0 = (int)tile0 * 5;
+                int head0 = work_items[item_base0 + 1];
+                int write_start0 = work_items[item_base0 + 2];
+                int write_end0 = work_items[item_base0 + 3];
+                int compute_end0 = work_items[item_base0 + 4];
+                int role_tid0 = warp_id_in_role * 32 + lane;
+                float raw_sum0 = 0.0f;
+                float gate_sum0 = 0.0f;
+                float _expf_0 = __expf(A_log[head0]);
+                float gate_rate0 = _expf_0;
+                float gate_bias0 = dt_bias[head0 * 128 + role_tid0];
+                #pragma unroll 1
+                for (int reverse0 = 0; reverse0 < compute_end0 - write_start0; reverse0++) {
+                    mbarrier_wait(raw_ready_addr + (raw_stage0) * 8, _phase_raw_ready);
+                    mbarrier_wait(g_prefix_done_addr + (g_prefix_stage0) * 8, _phase_g_prefix_done);
+                    float gate_prefix0 = 0.0f;
+                    float gate_last0 = 0.0f;
+                    float q_raw_values0[16];
+                    float k_raw_values0[16];
+                    #pragma unroll
+                    for (int token0 = 0; token0 < 16; token0++) {
+                        int segment = role_tid0 / 64;
+                        int segment_col = role_tid0 - segment * 64;
+                        int swizzled_col = segment_col ^ (token0 & 7) * 8;
+                        int raw_index0 = (int)raw_stage0 * 16 * 128 + segment * 16 * 64 + token0 * 64 + swizzled_col;
+                        __nv_bfloat16 raw_q_value0 = raw_q_all[raw_index0];
+                        __nv_bfloat16 raw_k_value0 = raw_k_all[raw_index0];
+                        __nv_bfloat16 raw_g_value0 = raw_g_all[raw_index0];
+                        float _cvt_f32_0 = __bfloat162float(raw_q_value0);
+                        q_raw_values0[token0] = _cvt_f32_0;
+                        float _cvt_f32_1 = __bfloat162float(raw_k_value0);
+                        k_raw_values0[token0] = _cvt_f32_1;
+                        float _cvt_f32_2 = __bfloat162float(raw_q_value0);
+                        float _cvt_f32_3 = __bfloat162float(raw_k_value0);
+                        float _cvt_f32_4 = __bfloat162float(raw_g_value0);
+                        raw_sum0 += _cvt_f32_2 + _cvt_f32_3 + _cvt_f32_4;
+                        float _cvt_f32_5 = __bfloat162float(raw_g_value0);
+                        float gate_arg0 = gate_rate0 * (_cvt_f32_5 + gate_bias0);
+                        float _tanh_approx_0;
+                        asm volatile("tanh.approx.f32 %0, %1;" : "=f"(_tanh_approx_0) : "f"(gate_arg0 * 0.5f));
+                        float gate_sigmoid0 = _tanh_approx_0 * 0.5f + 0.5f;
+                        gate_prefix0 += lower_bound * 1.4426950408889634f * gate_sigmoid0;
+                        float _exp2_0 = approx_exp2(gate_prefix0);
+                        float gate_exp0 = _exp2_0;
+                        gate_last0 = gate_exp0;
+                        gate_sum0 += gate_exp0;
+                        int segment_0 = role_tid0 / 32;
+                        int segment_col_1 = role_tid0 - segment_0 * 32;
+                        int swizzled_col_2 = segment_col_1 ^ (token0 & 7) * 4;
+                        g_prefix_all[(int)raw_stage0 * 16 * 128 + segment_0 * 16 * 32 + token0 * 32 + swizzled_col_2] = gate_exp0;
+                    }
+                    asm volatile("fence.proxy.async.shared::cta;" ::: "memory");
+                    mbarrier_arrive(g_prefix_ready_addr + (g_prefix_stage0) * 8);
+                    unsigned int q_raw_words0[8];
+                    unsigned int k_raw_words0[8];
+                    #pragma unroll
+                    for (int _lp = 0; _lp < 8; _lp++) {
+                        __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(q_raw_values0[_lp*2 + 0], q_raw_values0[_lp*2+1 + 0]));
+                        q_raw_words0[_lp] = *(uint32_t*)&_bf2;
+                    }
+                    #pragma unroll
+                    for (int _lp = 0; _lp < 8; _lp++) {
+                        __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(k_raw_values0[_lp*2 + 0], k_raw_values0[_lp*2+1 + 0]));
+                        k_raw_words0[_lp] = *(uint32_t*)&_bf2;
+                    }
+                    mbarrier_wait(qk_raw_done_addr + (qk_raw_stage0) * 8, _phase_qk_raw_done);
+                    tmem_st_x8_u32(taddr + 448 + qk_raw_stage0 % 4 * 8 + (unsigned int)tmem_row_base0, (const uint32_t*)q_raw_words0);
+                    tmem_st_x8_u32(taddr + 480 + qk_raw_stage0 % 4 * 8 + (unsigned int)tmem_row_base0, (const uint32_t*)k_raw_words0);
+                    asm volatile("tcgen05.wait::st.sync.aligned;" ::: "memory");
+                    mbarrier_arrive(qk_raw_ready_addr + (qk_raw_stage0) * 8);
+                    asm volatile("barrier.sync 8, 128;" ::: "memory");
+                    mbarrier_wait(decay_done_addr + (operand_stage0) * 8, _phase_decay_done);
+                    int state_scale_block0 = role_tid0 / 16;
+                    int state_scale_row0 = role_tid0 - state_scale_block0 * 16;
+                    float state_scale_values0[16];
+                    state_scale_values0[0] = 0.0f;
+                    state_scale_values0[1] = 0.0f;
+                    state_scale_values0[2] = 0.0f;
+                    state_scale_values0[3] = 0.0f;
+                    state_scale_values0[4] = 0.0f;
+                    state_scale_values0[5] = 0.0f;
+                    state_scale_values0[6] = 0.0f;
+                    state_scale_values0[7] = 0.0f;
+                    state_scale_values0[8] = 0.0f;
+                    state_scale_values0[9] = 0.0f;
+                    state_scale_values0[10] = 0.0f;
+                    state_scale_values0[11] = 0.0f;
+                    state_scale_values0[12] = 0.0f;
+                    state_scale_values0[13] = 0.0f;
+                    state_scale_values0[14] = 0.0f;
+                    state_scale_values0[15] = 0.0f;
+                    state_scale_values0[state_scale_row0] = gate_last0;
+                    unsigned int state_scale_words0[8];
+                    #pragma unroll
+                    for (int _lp = 0; _lp < 8; _lp++) {
+                        __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(state_scale_values0[_lp*2 + 0], state_scale_values0[_lp*2+1 + 0]));
+                        state_scale_words0[_lp] = *(uint32_t*)&_bf2;
+                    }
+                    int state_scale_stage0 = (int)operand_stage0 * 8 + state_scale_block0;
+                    asm volatile("st.shared.v4.b32 [%0], {%1,%2,%3,%4};" :: "r"((state_scale_diag_addr + (unsigned int)(state_scale_stage0 * 512) + (unsigned int)(state_scale_row0 * 32 ^ (state_scale_row0 * 32 >> 7 & 1) << 4))), "r"(state_scale_words0[0]), "r"(state_scale_words0[1]), "r"(state_scale_words0[2]), "r"(state_scale_words0[3]) : "memory");
+                    asm volatile("st.shared.v4.b32 [%0], {%1,%2,%3,%4};" :: "r"((state_scale_diag_addr + (unsigned int)(state_scale_stage0 * 512) + (unsigned int)(state_scale_row0 * 32 + 16 ^ (state_scale_row0 * 32 + 16 >> 7 & 1) << 4))), "r"(state_scale_words0[4]), "r"(state_scale_words0[5]), "r"(state_scale_words0[6]), "r"(state_scale_words0[7]) : "memory");
+                    int decay_row0 = warp_id_in_role * 4 + lane / 8;
+                    int decay_lane0 = lane & 7;
+                    float q_row0[16];
+                    float k_row0[16];
+                    float q_sq0 = 0.0f;
+                    float k_sq0 = 0.0f;
+                    #pragma unroll
+                    for (int dim_half0 = 0; dim_half0 < 2; dim_half0++) {
+                        int dim_base0 = dim_half0 * 64 + decay_lane0 * 8;
+                        unsigned int q_words0[4];
+                        unsigned int k_words0[4];
+                        int segment_1 = dim_base0 / 64;
+                        int segment_col_2 = dim_base0 - segment_1 * 64;
+                        int swizzled_col_1 = segment_col_2 ^ (decay_row0 & 7) * 8;
+                        int qk_index0 = (int)raw_stage0 * 16 * 128 + segment_1 * 16 * 64 + decay_row0 * 64 + swizzled_col_1;
+                        asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                            : "=r"(*reinterpret_cast<uint32_t*>(&q_words0[0])), "=r"(*reinterpret_cast<uint32_t*>(&q_words0[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&q_words0[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&q_words0[(0) + 3]))
+                            : "r"(raw_q_all_addr + (unsigned int)(qk_index0 * 2)));
+                        asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                            : "=r"(*reinterpret_cast<uint32_t*>(&k_words0[0])), "=r"(*reinterpret_cast<uint32_t*>(&k_words0[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&k_words0[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&k_words0[(0) + 3]))
+                            : "r"(raw_k_all_addr + (unsigned int)(qk_index0 * 2)));
+                        float q_words0_f32[8];
+                        #pragma unroll
+                        for (int _pair = 0; _pair < 4; _pair++) {
+                            asm volatile(
+                                "{\n\t"
+                                "shl.b32 %0, %2, 16;\n\t"
+                                "and.b32 %1, %2, 0xffff0000;\n\t"
+                                "}\n"
+                                : "=f"((&q_words0_f32[_pair * 2])[0]), "=f"((&q_words0_f32[_pair * 2])[1])
+                                : "r"(q_words0[_pair]));
+                        }
+                        float k_words0_f32[8];
+                        #pragma unroll
+                        for (int _pair = 0; _pair < 4; _pair++) {
+                            asm volatile(
+                                "{\n\t"
+                                "shl.b32 %0, %2, 16;\n\t"
+                                "and.b32 %1, %2, 0xffff0000;\n\t"
+                                "}\n"
+                                : "=f"((&k_words0_f32[_pair * 2])[0]), "=f"((&k_words0_f32[_pair * 2])[1])
+                                : "r"(k_words0[_pair]));
+                        }
+                        #pragma unroll
+                        for (int dim_local0 = 0; dim_local0 < 8; dim_local0++) {
+                            int row_reg0 = dim_half0 * 8 + dim_local0;
+                            q_row0[row_reg0] = q_words0_f32[dim_local0];
+                            k_row0[row_reg0] = k_words0_f32[dim_local0];
+                            float _fma_0 = __fmaf_rn(q_row0[row_reg0], q_row0[row_reg0], q_sq0);
+                            q_sq0 = _fma_0;
+                            float _fma_1 = __fmaf_rn(k_row0[row_reg0], k_row0[row_reg0], k_sq0);
+                            k_sq0 = _fma_1;
+                        }
+                    }
+                    float _shfl_xor_0 = __shfl_xor_sync(0xFFFFFFFF, q_sq0, 4);
+                    q_sq0 += _shfl_xor_0;
+                    float _shfl_xor_1 = __shfl_xor_sync(0xFFFFFFFF, q_sq0, 2);
+                    q_sq0 += _shfl_xor_1;
+                    float _shfl_xor_2 = __shfl_xor_sync(0xFFFFFFFF, q_sq0, 1);
+                    q_sq0 += _shfl_xor_2;
+                    float _shfl_xor_3 = __shfl_xor_sync(0xFFFFFFFF, k_sq0, 4);
+                    k_sq0 += _shfl_xor_3;
+                    float _shfl_xor_4 = __shfl_xor_sync(0xFFFFFFFF, k_sq0, 2);
+                    k_sq0 += _shfl_xor_4;
+                    float _shfl_xor_5 = __shfl_xor_sync(0xFFFFFFFF, k_sq0, 1);
+                    k_sq0 += _shfl_xor_5;
+                    float _rsqrt_0 = rsqrtf(q_sq0 + 1e-06f);
+                    float q_inv_norm0 = _rsqrt_0;
+                    float _rsqrt_1 = rsqrtf(k_sq0 + 1e-06f);
+                    float k_inv_norm0 = _rsqrt_1;
+                    if (decay_lane0 == 0) {
+                        int qk_norm_stage_base0 = (int)(qk_raw_stage0 % 4) * 2 * 16;
+                        qk_norm_smem_all[qk_norm_stage_base0 + decay_row0] = q_inv_norm0;
+                        qk_norm_smem_all[qk_norm_stage_base0 + 16 + decay_row0] = k_inv_norm0;
+                    }
+                    #pragma unroll
+                    for (int dim_half1 = 0; dim_half1 < 2; dim_half1++) {
+                        int dim_base1 = dim_half1 * 64 + decay_lane0 * 8;
+                        float k_inv_values0[8];
+                        float k_decay_values0[8];
+                        float q_decay_values0[8];
+                        float k_restore_values0[8];
+                        #pragma unroll
+                        for (int dim_local1 = 0; dim_local1 < 8; dim_local1++) {
+                            int row_reg1 = dim_half1 * 8 + dim_local1;
+                            int dim1 = dim_base1 + dim_local1;
+                            int segment_2 = dim1 / 32;
+                            int segment_col_3 = dim1 - segment_2 * 32;
+                            int swizzled_col_3 = segment_col_3 ^ (decay_row0 & 7) * 4;
+                            int prefix_index0 = (int)raw_stage0 * 16 * 128 + segment_2 * 16 * 32 + decay_row0 * 32 + swizzled_col_3;
+                            int segment_0_1 = dim1 / 32;
+                            int segment_col_1_1 = dim1 - segment_0_1 * 32;
+                            int swizzled_col_2_1 = segment_col_1_1 ^ 28;
+                            int prefix_last_index0 = (int)raw_stage0 * 16 * 128 + segment_0_1 * 16 * 32 + 480 + swizzled_col_2_1;
+                            float prefix0 = g_prefix_all[prefix_index0];
+                            float prefix_last0 = g_prefix_all[prefix_last_index0];
+                            __nv_bfloat16 _cvt_bf16_0 = __float2bfloat16(q_row0[row_reg1] * q_inv_norm0 * scale);
+                            __nv_bfloat16 q_norm0 = _cvt_bf16_0;
+                            __nv_bfloat16 _cvt_bf16_1 = __float2bfloat16(k_row0[row_reg1] * k_inv_norm0);
+                            __nv_bfloat16 k_norm0 = _cvt_bf16_1;
+                            float _cvt_f32_6 = __bfloat162float(k_norm0);
+                            float _rcp_0 = approx_rcp(prefix0);
+                            __nv_bfloat16 _cvt_bf16_2 = __float2bfloat16(_cvt_f32_6 * _rcp_0);
+                            __nv_bfloat16 k_inv_value0 = _cvt_bf16_2;
+                            float _cvt_f32_7 = __bfloat162float(k_inv_value0);
+                            k_inv_values0[dim_local1] = _cvt_f32_7;
+                            float _cvt_f32_9 = __bfloat162float(k_norm0);
+                            __nv_bfloat16 _cvt_bf16_3 = __float2bfloat16(_cvt_f32_9 * prefix0);
+                            __nv_bfloat16 k_decay_value0 = _cvt_bf16_3;
+                            float _cvt_f32_10 = __bfloat162float(k_decay_value0);
+                            k_decay_values0[dim_local1] = _cvt_f32_10;
+                            float _cvt_f32_11 = __bfloat162float(q_norm0);
+                            __nv_bfloat16 _cvt_bf16_4 = __float2bfloat16(_cvt_f32_11 * prefix0);
+                            __nv_bfloat16 q_decay_value0 = _cvt_bf16_4;
+                            float _cvt_f32_12 = __bfloat162float(q_decay_value0);
+                            q_decay_values0[dim_local1] = _cvt_f32_12;
+                            float _cvt_f32_13 = __bfloat162float(k_norm0);
+                            float _rcp_1 = approx_rcp(prefix0);
+                            __nv_bfloat16 _cvt_bf16_5 = __float2bfloat16(_cvt_f32_13 * prefix_last0 * _rcp_1);
+                            __nv_bfloat16 k_restore_value0 = _cvt_bf16_5;
+                            float _cvt_f32_14 = __bfloat162float(k_restore_value0);
+                            k_restore_values0[dim_local1] = _cvt_f32_14;
+                        }
+                        unsigned int k_inv_words0[4];
+                        unsigned int k_decay_words0[4];
+                        unsigned int q_decay_words0[4];
+                        unsigned int k_restore_words0[4];
+                        #pragma unroll
+                        for (int _lp = 0; _lp < 4; _lp++) {
+                            __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(k_inv_values0[_lp*2 + 0], k_inv_values0[_lp*2+1 + 0]));
+                            k_inv_words0[_lp] = *(uint32_t*)&_bf2;
+                        }
+                        #pragma unroll
+                        for (int _lp = 0; _lp < 4; _lp++) {
+                            __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(k_decay_values0[_lp*2 + 0], k_decay_values0[_lp*2+1 + 0]));
+                            k_decay_words0[_lp] = *(uint32_t*)&_bf2;
+                        }
+                        #pragma unroll
+                        for (int _lp = 0; _lp < 4; _lp++) {
+                            __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(q_decay_values0[_lp*2 + 0], q_decay_values0[_lp*2+1 + 0]));
+                            q_decay_words0[_lp] = *(uint32_t*)&_bf2;
+                        }
+                        #pragma unroll
+                        for (int _lp = 0; _lp < 4; _lp++) {
+                            __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(k_restore_values0[_lp*2 + 0], k_restore_values0[_lp*2+1 + 0]));
+                            k_restore_words0[_lp] = *(uint32_t*)&_bf2;
+                        }
+                        int segment_3 = dim_base1 / 64;
+                        int segment_col_4 = dim_base1 - segment_3 * 64;
+                        int swizzled_col_4 = segment_col_4 ^ (decay_row0 & 7) * 8;
+                        int operand_index0 = (int)operand_stage0 * 16 * 128 + segment_3 * 16 * 64 + decay_row0 * 64 + swizzled_col_4;
+                        int operand_addr0 = operand_index0 * 2;
+                        asm volatile("st.shared.v4.b32 [%0], {%1,%2,%3,%4};" :: "r"(k_inv_all_addr + (unsigned int)operand_addr0), "r"(k_inv_words0[0]), "r"(k_inv_words0[1]), "r"(k_inv_words0[2]), "r"(k_inv_words0[3]) : "memory");
+                        asm volatile("st.shared.v4.b32 [%0], {%1,%2,%3,%4};" :: "r"(k_decay_all_addr + (unsigned int)operand_addr0), "r"(k_decay_words0[0]), "r"(k_decay_words0[1]), "r"(k_decay_words0[2]), "r"(k_decay_words0[3]) : "memory");
+                        asm volatile("st.shared.v4.b32 [%0], {%1,%2,%3,%4};" :: "r"(q_decay_all_addr + (unsigned int)operand_addr0), "r"(q_decay_words0[0]), "r"(q_decay_words0[1]), "r"(q_decay_words0[2]), "r"(q_decay_words0[3]) : "memory");
+                        asm volatile("st.shared.v4.b32 [%0], {%1,%2,%3,%4};" :: "r"(k_restore_all_addr + (unsigned int)operand_addr0), "r"(k_restore_words0[0]), "r"(k_restore_words0[1]), "r"(k_restore_words0[2]), "r"(k_restore_words0[3]) : "memory");
+                    }
+                    asm volatile("fence.proxy.async.shared::cta;" ::: "memory");
+                    mbarrier_arrive(k_decay_inv_ready_addr + (operand_stage0) * 8);
+                    mbarrier_arrive(q_decay_k_restore_ready_addr + (operand_stage0) * 8);
+                    mbarrier_arrive(raw_done_addr + (raw_stage0) * 8);
+                    raw_stage0 += 1;
+                    if (raw_stage0 == 2) { raw_stage0 = 0; _phase_raw_ready ^= 1; }
+                    operand_stage0 += 1;
+                    if (operand_stage0 == 2) { operand_stage0 = 0; _phase_decay_done ^= 1; }
+                    qk_raw_stage0 += 1;
+                    if (qk_raw_stage0 == 4) { qk_raw_stage0 = 0; _phase_qk_raw_done ^= 1; }
+                    g_prefix_stage0 += 1;
+                    if (g_prefix_stage0 == 2) { g_prefix_stage0 = 0; _phase_g_prefix_done ^= 1; }
+                }
+            }
+            if (elect_sync()) {
+                mbarrier_arrive(consumers_done_addr);
+            }
+        }
+    }
+    // ---- Role: compute1 ----
+    if (warp >= 4 && warp <= 7) {
+        asm volatile("setmaxnreg.inc.sync.aligned.u32 168;");
+        { // compute1_main
+            unsigned int sched_stage1 = 0;
+            unsigned int raw_stage1 = 0;
+            unsigned int state_smem_stage1 = 0;
+            unsigned int tcgen_data_stage1 = 0;
+            unsigned int dstate_smem_stage1 = 0;
+            unsigned int beta_dy_smem_stage1 = 0;
+            unsigned int dbeta_m_stage1 = 0;
+            unsigned int boundary_stage1 = 0;
+            int dstate_smem_slot_acquired1 = 0;
+            int warp_id_in_role_1 = (warp - 4);
+            int value_dim_base1 = warp_id_in_role_1 * 32;
+            int role_tid1 = warp_id_in_role_1 * 32 + lane;
+            int ov_token1 = lane / 16 * 8 + (lane & 7);
+            int ov_col1 = (lane / 8 & 1) * 8;
+            const int tmem_row_base1 = warp_id_in_role_1 * 32 << 16;
+            unsigned int _phase_sched_ready_1 = 0;
+            unsigned int _phase_dstate_smem_done = 1;
+            unsigned int _phase_tcgen_inputs_done = 1;
+            unsigned int _phase_raw_ready_1 = 0;
+            unsigned int _phase_state_k_ready = 0;
+            unsigned int _phase_tcgen_products_ready = 0;
+            unsigned int _phase_dy_ready = 0;
+            unsigned int _phase_beta_dy_smem_done = 1;
+            unsigned int _phase_dbeta_m_ready = 0;
+            unsigned int _phase_dstate_ready = 0;
+            unsigned int _phase_boundary_acc_ready = 0;
+            #pragma unroll 1
+            for (int __1 = 0; __1 < total_work_items; __1++) {
+                mbarrier_wait(sched_ready_addr + (sched_stage1) * 8, _phase_sched_ready_1);
+                unsigned int ticket_words_1[1];
+                asm volatile("ld.shared.b32 %0, [%1];" : "=r"(*reinterpret_cast<uint32_t*>(&ticket_words_1[0])) : "r"(work_item_addr + sched_stage1 * 4));
+                unsigned int tile1 = ticket_words_1[0];
+                if (elect_sync()) {
+                    mbarrier_arrive(sched_done_addr + (sched_stage1) * 8);
+                }
+                sched_stage1 += 1;
+                if (sched_stage1 == 8) { sched_stage1 = 0; _phase_sched_ready_1 ^= 1; }
+                if (tile1 >= (unsigned int)total_work_items) {
+                    break;
+                }
+                int item_base1 = (int)tile1 * 5;
+                int sequence1 = work_items[item_base1];
+                int head1 = work_items[item_base1 + 1];
+                int write_start1 = work_items[item_base1 + 2];
+                int write_end1 = work_items[item_base1 + 3];
+                int compute_end1 = work_items[item_base1 + 4];
+                float checksum_sum1 = 0.0f;
+                long long bos1 = cu_seqlens[sequence1];
+                long long eos1 = cu_seqlens[sequence1 + 1];
+                int sequence_chunks1 = (int)((eos1 - bos1) / 16);
+                int seed_dfinal1 = (int)(compute_end1 == sequence_chunks1);
+                if (dstate_smem_slot_acquired1 == 0) {
+                    mbarrier_wait(dstate_smem_done_addr + (dstate_smem_stage1) * 8, _phase_dstate_smem_done);
+                }
+                #pragma unroll
+                for (int dstate_init_block1 = 0; dstate_init_block1 < 4; dstate_init_block1++) {
+                    float dstate_init_values1[32];
+                    dstate_init_values1[0] = 0.0f;
+                    dstate_init_values1[1] = 0.0f;
+                    dstate_init_values1[2] = 0.0f;
+                    dstate_init_values1[3] = 0.0f;
+                    dstate_init_values1[4] = 0.0f;
+                    dstate_init_values1[5] = 0.0f;
+                    dstate_init_values1[6] = 0.0f;
+                    dstate_init_values1[7] = 0.0f;
+                    dstate_init_values1[8] = 0.0f;
+                    dstate_init_values1[9] = 0.0f;
+                    dstate_init_values1[10] = 0.0f;
+                    dstate_init_values1[11] = 0.0f;
+                    dstate_init_values1[12] = 0.0f;
+                    dstate_init_values1[13] = 0.0f;
+                    dstate_init_values1[14] = 0.0f;
+                    dstate_init_values1[15] = 0.0f;
+                    dstate_init_values1[16] = 0.0f;
+                    dstate_init_values1[17] = 0.0f;
+                    dstate_init_values1[18] = 0.0f;
+                    dstate_init_values1[19] = 0.0f;
+                    dstate_init_values1[20] = 0.0f;
+                    dstate_init_values1[21] = 0.0f;
+                    dstate_init_values1[22] = 0.0f;
+                    dstate_init_values1[23] = 0.0f;
+                    dstate_init_values1[24] = 0.0f;
+                    dstate_init_values1[25] = 0.0f;
+                    dstate_init_values1[26] = 0.0f;
+                    dstate_init_values1[27] = 0.0f;
+                    dstate_init_values1[28] = 0.0f;
+                    dstate_init_values1[29] = 0.0f;
+                    dstate_init_values1[30] = 0.0f;
+                    dstate_init_values1[31] = 0.0f;
+                    if (USE_DSTATE_IN != 0 && seed_dfinal1 != 0) {
+                        long long dstate_init_base1 = (((long long)sequence1 * (long long)num_heads + (long long)head1) * 128 + (long long)role_tid1) * 128 + (long long)(dstate_init_block1 * 32);
+                        #pragma unroll
+                        for (int dstate_init_vec1 = 0; dstate_init_vec1 < 4; dstate_init_vec1++) {
+                            {
+                                unsigned _ldv8_0_0;
+                                unsigned _ldv8_0_1;
+                                unsigned _ldv8_0_2;
+                                unsigned _ldv8_0_3;
+                                unsigned _ldv8_0_4;
+                                unsigned _ldv8_0_5;
+                                unsigned _ldv8_0_6;
+                                unsigned _ldv8_0_7;
+                                asm volatile(
+                                    "ld.global.v8.b32 {%0, %1, %2, %3, %4, %5, %6, %7}, [%8];"
+                                    : "=r"(_ldv8_0_0), "=r"(_ldv8_0_1), "=r"(_ldv8_0_2), "=r"(_ldv8_0_3), "=r"(_ldv8_0_4), "=r"(_ldv8_0_5), "=r"(_ldv8_0_6), "=r"(_ldv8_0_7) : "l"((const void*)(dfinal_state + (dstate_init_base1 + (long long)(dstate_init_vec1 * 8)))) : "memory");
+                                dstate_init_values1[dstate_init_vec1 * 8 + 0] = __uint_as_float(_ldv8_0_0);
+                                dstate_init_values1[dstate_init_vec1 * 8 + 1] = __uint_as_float(_ldv8_0_1);
+                                dstate_init_values1[dstate_init_vec1 * 8 + 2] = __uint_as_float(_ldv8_0_2);
+                                dstate_init_values1[dstate_init_vec1 * 8 + 3] = __uint_as_float(_ldv8_0_3);
+                                dstate_init_values1[dstate_init_vec1 * 8 + 4] = __uint_as_float(_ldv8_0_4);
+                                dstate_init_values1[dstate_init_vec1 * 8 + 5] = __uint_as_float(_ldv8_0_5);
+                                dstate_init_values1[dstate_init_vec1 * 8 + 6] = __uint_as_float(_ldv8_0_6);
+                                dstate_init_values1[dstate_init_vec1 * 8 + 7] = __uint_as_float(_ldv8_0_7);
+                            }
+                        }
+                    }
+                    tmem_st_x32_f32(taddr + (unsigned int)(dstate_init_block1 * 32) + (unsigned int)tmem_row_base1, dstate_init_values1);
+                    uint32_t dstate_init_values1_bf16[16];
+                    #pragma unroll
+                    for (int _lp = 0; _lp < 16; _lp++) {
+                        __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(dstate_init_values1[_lp*2 + 0], dstate_init_values1[_lp*2+1 + 0]));
+                        dstate_init_values1_bf16[_lp] = *(uint32_t*)&_bf2;
+                    }
+                    asm volatile(
+                        "tcgen05.st.sync.aligned.32x32b.x16.b32"
+                        " [%0], {%1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15, %16};"
+                        :: "r"(taddr + 128 + (unsigned int)(dstate_init_block1 * 16) + (unsigned int)tmem_row_base1), "r"(*reinterpret_cast<const uint32_t*>(&dstate_init_values1_bf16[0])), "r"(*reinterpret_cast<const uint32_t*>(&dstate_init_values1_bf16[1])), "r"(*reinterpret_cast<const uint32_t*>(&dstate_init_values1_bf16[2])), "r"(*reinterpret_cast<const uint32_t*>(&dstate_init_values1_bf16[3])), "r"(*reinterpret_cast<const uint32_t*>(&dstate_init_values1_bf16[4])), "r"(*reinterpret_cast<const uint32_t*>(&dstate_init_values1_bf16[5])), "r"(*reinterpret_cast<const uint32_t*>(&dstate_init_values1_bf16[6])), "r"(*reinterpret_cast<const uint32_t*>(&dstate_init_values1_bf16[7])), "r"(*reinterpret_cast<const uint32_t*>(&dstate_init_values1_bf16[8])), "r"(*reinterpret_cast<const uint32_t*>(&dstate_init_values1_bf16[9])), "r"(*reinterpret_cast<const uint32_t*>(&dstate_init_values1_bf16[10])), "r"(*reinterpret_cast<const uint32_t*>(&dstate_init_values1_bf16[11])), "r"(*reinterpret_cast<const uint32_t*>(&dstate_init_values1_bf16[12])), "r"(*reinterpret_cast<const uint32_t*>(&dstate_init_values1_bf16[13])), "r"(*reinterpret_cast<const uint32_t*>(&dstate_init_values1_bf16[14])), "r"(*reinterpret_cast<const uint32_t*>(&dstate_init_values1_bf16[15]))
+                        : "memory");
+                    #pragma unroll
+                    for (int dstate_init_atom1 = 0; dstate_init_atom1 < 4; dstate_init_atom1++) {
+                        int dstate_init_col1 = dstate_init_block1 * 32 + dstate_init_atom1 * 8;
+                        int segment_4 = dstate_init_col1 / 64;
+                        int segment_col_5 = dstate_init_col1 - segment_4 * 64;
+                        int swizzled_col_5 = segment_col_5 ^ (role_tid1 & 7) * 8;
+                        int dstate_init_smem_index1 = segment_4 * 128 * 64 + role_tid1 * 64 + swizzled_col_5;
+                        asm volatile("st.shared.v4.b32 [%0], {%1,%2,%3,%4};" :: "r"(dstate_smem_all_addr + (unsigned int)(dstate_init_smem_index1 * 2)), "r"(dstate_init_values1_bf16[dstate_init_atom1 * 4]), "r"(dstate_init_values1_bf16[dstate_init_atom1 * 4 + 1]), "r"(dstate_init_values1_bf16[dstate_init_atom1 * 4 + 2]), "r"(dstate_init_values1_bf16[dstate_init_atom1 * 4 + 3]) : "memory");
+                    }
+                }
+                asm volatile("tcgen05.wait::st.sync.aligned;" ::: "memory");
+                asm volatile("fence.proxy.async.shared::cta;" ::: "memory");
+                if (elect_sync()) {
+                    mbarrier_arrive(dstate_inp_ready_addr);
+                    mbarrier_arrive(dstate_smem_ready_addr + (dstate_smem_stage1) * 8);
+                }
+                dstate_smem_stage1 += 1;
+                if (dstate_smem_stage1 == 1) { dstate_smem_stage1 = 0; _phase_dstate_smem_done ^= 1; }
+                dstate_smem_slot_acquired1 = 0;
+                #pragma unroll 1
+                for (int reverse1 = 0; reverse1 < compute_end1 - write_start1; reverse1++) {
+                    mbarrier_wait(tcgen_inputs_done_addr + (tcgen_data_stage1) * 8, _phase_tcgen_inputs_done);
+                    mbarrier_wait(raw_ready_addr + (raw_stage1) * 8, _phase_raw_ready_1);
+                    int beta_lane_token1 = (lane & 3) * 2;
+                    int beta_stage_base1 = (int)(raw_stage1 % 2) * 16 * 8;
+                    int beta_head1 = head1 % 8;
+                    __nv_bfloat16 beta_c0_bf1 = beta_smem_all[beta_stage_base1 + beta_lane_token1 * 8 + beta_head1];
+                    __nv_bfloat16 beta_c1_bf1 = beta_smem_all[beta_stage_base1 + (beta_lane_token1 + 1) * 8 + beta_head1];
+                    __nv_bfloat16 beta_c8_bf1 = beta_smem_all[beta_stage_base1 + (beta_lane_token1 + 8) * 8 + beta_head1];
+                    __nv_bfloat16 beta_c9_bf1 = beta_smem_all[beta_stage_base1 + (beta_lane_token1 + 9) * 8 + beta_head1];
+                    float _cvt_f32_15 = __bfloat162float(beta_c0_bf1);
+                    float beta_c0_1 = _cvt_f32_15;
+                    float _cvt_f32_16 = __bfloat162float(beta_c1_bf1);
+                    float beta_c1_1 = _cvt_f32_16;
+                    float _cvt_f32_17 = __bfloat162float(beta_c8_bf1);
+                    float beta_c8_1 = _cvt_f32_17;
+                    float _cvt_f32_18 = __bfloat162float(beta_c9_bf1);
+                    float beta_c9_1 = _cvt_f32_18;
+                    float beta_values1[4];
+                    beta_values1[0] = beta_c8_1;
+                    beta_values1[1] = beta_c9_1;
+                    beta_values1[2] = beta_c0_1;
+                    beta_values1[3] = beta_c1_1;
+                    unsigned int beta_words1[2];
+                    #pragma unroll
+                    for (int _lp = 0; _lp < 2; _lp++) {
+                        __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(beta_values1[_lp*2 + 0], beta_values1[_lp*2+1 + 0]));
+                        beta_words1[_lp] = *(uint32_t*)&_bf2;
+                    }
+                    mbarrier_wait(state_k_ready_addr + (state_smem_stage1) * 8, _phase_state_k_ready);
+                    float _tmem_load_0[8];
+                    asm volatile(
+                        "tcgen05.ld.sync.aligned.16x256b.x2.b32"
+                        " {%0, %1, %2, %3, %4, %5, %6, %7}, [%8];"
+                        : "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_0[0])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_0[1])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_0[2])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_0[3])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_0[4])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_0[5])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_0[6])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_0[7]))
+                        : "r"(taddr + 320 + (unsigned int)tmem_row_base1)
+                        : "memory");
+                    float _tmem_load_1[8];
+                    asm volatile(
+                        "tcgen05.ld.sync.aligned.16x256b.x2.b32"
+                        " {%0, %1, %2, %3, %4, %5, %6, %7}, [%8];"
+                        : "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_1[0])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_1[1])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_1[2])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_1[3])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_1[4])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_1[5])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_1[6])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_1[7]))
+                        : "r"(taddr + 320 + (unsigned int)tmem_row_base1 + 1048576)
+                        : "memory");
+                    asm volatile("tcgen05.wait::ld.sync.aligned;" ::: "memory");
+                    if (elect_sync()) {
+                        mbarrier_arrive(state_k_done_addr + (state_smem_stage1) * 8);
+                    }
+                    uint32_t _tmem_load_0_bf16[4];
+                    #pragma unroll
+                    for (int _lp = 0; _lp < 4; _lp++) {
+                        __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(_tmem_load_0[_lp*2 + 0], _tmem_load_0[_lp*2+1 + 0]));
+                        _tmem_load_0_bf16[_lp] = *(uint32_t*)&_bf2;
+                    }
+                    uint32_t _tmem_load_1_bf16[4];
+                    #pragma unroll
+                    for (int _lp = 0; _lp < 4; _lp++) {
+                        __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(_tmem_load_1[_lp*2 + 0], _tmem_load_1[_lp*2+1 + 0]));
+                        _tmem_load_1_bf16[_lp] = *(uint32_t*)&_bf2;
+                    }
+                    unsigned int v_fragment_lo1[4];
+                    unsigned int v_fragment_hi1[4];
+                    int segment_5 = (value_dim_base1 + ov_col1) / 64;
+                    int segment_col_6 = value_dim_base1 + ov_col1 - segment_5 * 64;
+                    int swizzled_col_6 = segment_col_6 ^ (ov_token1 & 7) * 8;
+                    unsigned int v_addr_lo1 = raw_v_all_addr + (unsigned int)(((int)raw_stage1 * 16 * 128 + segment_5 * 16 * 64 + ov_token1 * 64 + swizzled_col_6) * 2);
+                    int segment_0_2 = (value_dim_base1 + 16 + ov_col1) / 64;
+                    int segment_col_1_2 = value_dim_base1 + 16 + ov_col1 - segment_0_2 * 64;
+                    int swizzled_col_2_2 = segment_col_1_2 ^ (ov_token1 & 7) * 8;
+                    unsigned int v_addr_hi1 = raw_v_all_addr + (unsigned int)(((int)raw_stage1 * 16 * 128 + segment_0_2 * 16 * 64 + ov_token1 * 64 + swizzled_col_2_2) * 2);
+                    int segment_3_1 = (value_dim_base1 + ov_col1) / 64;
+                    int segment_col_4_1 = value_dim_base1 + ov_col1 - segment_3_1 * 64;
+                    int swizzled_col_5_1 = segment_col_4_1 ^ (ov_token1 & 7) * 8;
+                    unsigned int do_addr_lo1 = raw_do_all_addr + (unsigned int)(((int)raw_stage1 * 16 * 128 + segment_3_1 * 16 * 64 + ov_token1 * 64 + swizzled_col_5_1) * 2);
+                    int segment_6 = (value_dim_base1 + 16 + ov_col1) / 64;
+                    int segment_col_7 = value_dim_base1 + 16 + ov_col1 - segment_6 * 64;
+                    int swizzled_col_8 = segment_col_7 ^ (ov_token1 & 7) * 8;
+                    unsigned int do_addr_hi1 = raw_do_all_addr + (unsigned int)(((int)raw_stage1 * 16 * 128 + segment_6 * 16 * 64 + ov_token1 * 64 + swizzled_col_8) * 2);
+                    asm volatile("ldmatrix.sync.aligned.m8n8.x4.trans.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                        : "=r"(v_fragment_lo1[0]), "=r"(v_fragment_lo1[1]), "=r"(v_fragment_lo1[2]), "=r"(v_fragment_lo1[3])
+                        : "r"(v_addr_lo1)
+                        : "memory");
+                    asm volatile("ldmatrix.sync.aligned.m8n8.x4.trans.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                        : "=r"(v_fragment_hi1[0]), "=r"(v_fragment_hi1[1]), "=r"(v_fragment_hi1[2]), "=r"(v_fragment_hi1[3])
+                        : "r"(v_addr_hi1)
+                        : "memory");
+                    unsigned int do_fragment_lo1[4];
+                    unsigned int do_fragment_hi1[4];
+                    asm volatile("ldmatrix.sync.aligned.m8n8.x4.trans.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                        : "=r"(do_fragment_lo1[0]), "=r"(do_fragment_lo1[1]), "=r"(do_fragment_lo1[2]), "=r"(do_fragment_lo1[3])
+                        : "r"(do_addr_lo1)
+                        : "memory");
+                    asm volatile("ldmatrix.sync.aligned.m8n8.x4.trans.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                        : "=r"(do_fragment_hi1[0]), "=r"(do_fragment_hi1[1]), "=r"(do_fragment_hi1[2]), "=r"(do_fragment_hi1[3])
+                        : "r"(do_addr_hi1)
+                        : "memory");
+                    unsigned int diff_words_lo1[4];
+                    unsigned int diff_words_hi1[4];
+                    __nv_bfloat162 y_pairs_lo1[4];
+                    __nv_bfloat162 y_pairs_hi1[4];
+                    unsigned int y_words_lo1[4];
+                    unsigned int y_words_hi1[4];
+                    unsigned int do_words_lo1[4];
+                    unsigned int do_words_hi1[4];
+                    #pragma unroll
+                    for (int y_reg1 = 0; y_reg1 < 4; y_reg1++) {
+                        const int raw_reg1 = (1 - y_reg1 / 2) * 2 + (y_reg1 & 1);
+                        const int out_reg1 = y_reg1 ^ 2;
+                        uint32_t _bf16x2_sub_0;
+                        asm volatile("sub.rn.bf16x2 %0, %1, %2;" : "=r"(_bf16x2_sub_0) : "r"(v_fragment_lo1[raw_reg1]), "r"(_tmem_load_0_bf16[out_reg1]));
+                        diff_words_lo1[out_reg1] = _bf16x2_sub_0;
+                        uint32_t _bf16x2_sub_1;
+                        asm volatile("sub.rn.bf16x2 %0, %1, %2;" : "=r"(_bf16x2_sub_1) : "r"(v_fragment_hi1[raw_reg1]), "r"(_tmem_load_1_bf16[out_reg1]));
+                        diff_words_hi1[out_reg1] = _bf16x2_sub_1;
+                        y_pairs_lo1[out_reg1] = reinterpret_cast<__nv_bfloat162*>(diff_words_lo1 + out_reg1)[0] * reinterpret_cast<__nv_bfloat162*>(beta_words1 + y_reg1 / 2)[0];
+                        y_pairs_hi1[out_reg1] = reinterpret_cast<__nv_bfloat162*>(diff_words_hi1 + out_reg1)[0] * reinterpret_cast<__nv_bfloat162*>(beta_words1 + y_reg1 / 2)[0];
+                        y_words_lo1[out_reg1] = reinterpret_cast<unsigned int*>(y_pairs_lo1 + out_reg1)[0];
+                        y_words_hi1[out_reg1] = reinterpret_cast<unsigned int*>(y_pairs_hi1 + out_reg1)[0];
+                        do_words_lo1[out_reg1] = do_fragment_lo1[raw_reg1];
+                        do_words_hi1[out_reg1] = do_fragment_hi1[raw_reg1];
+                    }
+                    asm volatile(
+                        "tcgen05.st.sync.aligned.16x128b.x2.b32"
+                        " [%0], {%1, %2, %3, %4};"
+                        :: "r"(taddr + 432 + (unsigned int)tmem_row_base1), "r"(*reinterpret_cast<const uint32_t*>(&y_words_lo1[0])), "r"(*reinterpret_cast<const uint32_t*>(&y_words_lo1[1])), "r"(*reinterpret_cast<const uint32_t*>(&y_words_lo1[2])), "r"(*reinterpret_cast<const uint32_t*>(&y_words_lo1[3]))
+                        : "memory");
+                    asm volatile(
+                        "tcgen05.st.sync.aligned.16x128b.x2.b32"
+                        " [%0], {%1, %2, %3, %4};"
+                        :: "r"(taddr + 432 + (unsigned int)tmem_row_base1 + 1048576), "r"(*reinterpret_cast<const uint32_t*>(&y_words_hi1[0])), "r"(*reinterpret_cast<const uint32_t*>(&y_words_hi1[1])), "r"(*reinterpret_cast<const uint32_t*>(&y_words_hi1[2])), "r"(*reinterpret_cast<const uint32_t*>(&y_words_hi1[3]))
+                        : "memory");
+                    asm volatile(
+                        "tcgen05.st.sync.aligned.16x128b.x2.b32"
+                        " [%0], {%1, %2, %3, %4};"
+                        :: "r"(taddr + 440 + (unsigned int)tmem_row_base1), "r"(*reinterpret_cast<const uint32_t*>(&do_words_lo1[0])), "r"(*reinterpret_cast<const uint32_t*>(&do_words_lo1[1])), "r"(*reinterpret_cast<const uint32_t*>(&do_words_lo1[2])), "r"(*reinterpret_cast<const uint32_t*>(&do_words_lo1[3]))
+                        : "memory");
+                    asm volatile(
+                        "tcgen05.st.sync.aligned.16x128b.x2.b32"
+                        " [%0], {%1, %2, %3, %4};"
+                        :: "r"(taddr + 440 + (unsigned int)tmem_row_base1 + 1048576), "r"(*reinterpret_cast<const uint32_t*>(&do_words_hi1[0])), "r"(*reinterpret_cast<const uint32_t*>(&do_words_hi1[1])), "r"(*reinterpret_cast<const uint32_t*>(&do_words_hi1[2])), "r"(*reinterpret_cast<const uint32_t*>(&do_words_hi1[3]))
+                        : "memory");
+                    asm volatile("tcgen05.wait::st.sync.aligned;" ::: "memory");
+                    if (elect_sync()) {
+                        mbarrier_arrive(tcgen_inputs_ready_addr + (tcgen_data_stage1) * 8);
+                        mbarrier_arrive(raw_done_addr + (raw_stage1) * 8);
+                    }
+                    mbarrier_wait(tcgen_products_ready_addr + (tcgen_data_stage1) * 8, _phase_tcgen_products_ready);
+                    float _tmem_load_2[8];
+                    asm volatile(
+                        "tcgen05.ld.sync.aligned.16x256b.x2.b32"
+                        " {%0, %1, %2, %3, %4, %5, %6, %7}, [%8];"
+                        : "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_2[0])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_2[1])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_2[2])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_2[3])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_2[4])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_2[5])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_2[6])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_2[7]))
+                        : "r"(taddr + 336 + (unsigned int)tmem_row_base1)
+                        : "memory");
+                    float _tmem_load_3[8];
+                    asm volatile(
+                        "tcgen05.ld.sync.aligned.16x256b.x2.b32"
+                        " {%0, %1, %2, %3, %4, %5, %6, %7}, [%8];"
+                        : "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[0])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[1])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[2])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[3])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[4])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[5])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[6])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[7]))
+                        : "r"(taddr + 336 + (unsigned int)tmem_row_base1 + 1048576)
+                        : "memory");
+                    asm volatile("tcgen05.wait::ld.sync.aligned;" ::: "memory");
+                    uint32_t _tmem_load_2_bf16[4];
+                    #pragma unroll
+                    for (int _lp = 0; _lp < 4; _lp++) {
+                        __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(_tmem_load_2[_lp*2 + 0], _tmem_load_2[_lp*2+1 + 0]));
+                        _tmem_load_2_bf16[_lp] = *(uint32_t*)&_bf2;
+                    }
+                    uint32_t _tmem_load_3_bf16[4];
+                    #pragma unroll
+                    for (int _lp = 0; _lp < 4; _lp++) {
+                        __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(_tmem_load_3[_lp*2 + 0], _tmem_load_3[_lp*2+1 + 0]));
+                        _tmem_load_3_bf16[_lp] = *(uint32_t*)&_bf2;
+                    }
+                    int segment_9 = (value_dim_base1 + ov_col1) / 64;
+                    int segment_col_10 = value_dim_base1 + ov_col1 - segment_9 * 64;
+                    int swizzled_col_11 = segment_col_10 ^ (ov_token1 & 7) * 8;
+                    unsigned int u_addr_lo1 = u_smem_addr + (unsigned int)((segment_9 * 16 * 64 + ov_token1 * 64 + swizzled_col_11) * 2);
+                    int segment_12 = (value_dim_base1 + 16 + ov_col1) / 64;
+                    int segment_col_13 = value_dim_base1 + 16 + ov_col1 - segment_12 * 64;
+                    int swizzled_col_14 = segment_col_13 ^ (ov_token1 & 7) * 8;
+                    unsigned int u_addr_hi1 = u_smem_addr + (unsigned int)((segment_12 * 16 * 64 + ov_token1 * 64 + swizzled_col_14) * 2);
+                    uint32_t _stmatrix_addr_1 = static_cast<uint32_t>((unsigned long long)u_addr_lo1);
+                    asm volatile("stmatrix.sync.aligned.m8n8.x4.trans.shared.b16 [%0], {%1, %2, %3, %4};\n"
+                        :: "r"(_stmatrix_addr_1), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_2_bf16[0])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_2_bf16[1])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_2_bf16[2])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_2_bf16[3]))
+                        : "memory");
+                    uint32_t _stmatrix_addr_2 = static_cast<uint32_t>((unsigned long long)u_addr_hi1);
+                    asm volatile("stmatrix.sync.aligned.m8n8.x4.trans.shared.b16 [%0], {%1, %2, %3, %4};\n"
+                        :: "r"(_stmatrix_addr_2), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_3_bf16[0])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_3_bf16[1])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_3_bf16[2])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_3_bf16[3]))
+                        : "memory");
+                    asm volatile("fence.proxy.async.shared::cta;" ::: "memory");
+                    if (elect_sync()) {
+                        mbarrier_arrive(u_smem_ready_addr);
+                    }
+                    float _tmem_load_4[8];
+                    asm volatile(
+                        "tcgen05.ld.sync.aligned.16x256b.x2.b32"
+                        " {%0, %1, %2, %3, %4, %5, %6, %7}, [%8];"
+                        : "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_4[0])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_4[1])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_4[2])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_4[3])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_4[4])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_4[5])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_4[6])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_4[7]))
+                        : "r"(taddr + 352 + (unsigned int)tmem_row_base1)
+                        : "memory");
+                    float _tmem_load_5[8];
+                    asm volatile(
+                        "tcgen05.ld.sync.aligned.16x256b.x2.b32"
+                        " {%0, %1, %2, %3, %4, %5, %6, %7}, [%8];"
+                        : "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_5[0])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_5[1])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_5[2])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_5[3])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_5[4])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_5[5])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_5[6])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_5[7]))
+                        : "r"(taddr + 352 + (unsigned int)tmem_row_base1 + 1048576)
+                        : "memory");
+                    asm volatile("tcgen05.wait::ld.sync.aligned;" ::: "memory");
+                    checksum_sum1 += _tmem_load_2[0] + _tmem_load_4[0];
+                    uint32_t _tmem_load_4_bf16[4];
+                    #pragma unroll
+                    for (int _lp = 0; _lp < 4; _lp++) {
+                        __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(_tmem_load_4[_lp*2 + 0], _tmem_load_4[_lp*2+1 + 0]));
+                        _tmem_load_4_bf16[_lp] = *(uint32_t*)&_bf2;
+                    }
+                    uint32_t _tmem_load_5_bf16[4];
+                    #pragma unroll
+                    for (int _lp = 0; _lp < 4; _lp++) {
+                        __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(_tmem_load_5[_lp*2 + 0], _tmem_load_5[_lp*2+1 + 0]));
+                        _tmem_load_5_bf16[_lp] = *(uint32_t*)&_bf2;
+                    }
+                    asm volatile(
+                        "tcgen05.st.sync.aligned.16x128b.x2.b32"
+                        " [%0], {%1, %2, %3, %4};"
+                        :: "r"(taddr + 440 + (unsigned int)tmem_row_base1), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_4_bf16[0])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_4_bf16[1])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_4_bf16[2])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_4_bf16[3]))
+                        : "memory");
+                    asm volatile(
+                        "tcgen05.st.sync.aligned.16x128b.x2.b32"
+                        " [%0], {%1, %2, %3, %4};"
+                        :: "r"(taddr + 440 + (unsigned int)tmem_row_base1 + 1048576), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_5_bf16[0])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_5_bf16[1])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_5_bf16[2])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_5_bf16[3]))
+                        : "memory");
+                    asm volatile("tcgen05.wait::st.sync.aligned;" ::: "memory");
+                    if (elect_sync()) {
+                        mbarrier_arrive(du_inp_ready_addr + (tcgen_data_stage1) * 8);
+                        mbarrier_arrive(tcgen_products_done_addr + (tcgen_data_stage1) * 8);
+                    }
+                    mbarrier_wait(dy_ready_addr + (tcgen_data_stage1) * 8, _phase_dy_ready);
+                    float _tmem_load_6[8];
+                    asm volatile(
+                        "tcgen05.ld.sync.aligned.16x256b.x2.b32"
+                        " {%0, %1, %2, %3, %4, %5, %6, %7}, [%8];"
+                        : "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_6[0])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_6[1])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_6[2])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_6[3])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_6[4])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_6[5])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_6[6])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_6[7]))
+                        : "r"(taddr + 320 + (unsigned int)tmem_row_base1)
+                        : "memory");
+                    float _tmem_load_7[8];
+                    asm volatile(
+                        "tcgen05.ld.sync.aligned.16x256b.x2.b32"
+                        " {%0, %1, %2, %3, %4, %5, %6, %7}, [%8];"
+                        : "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_7[0])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_7[1])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_7[2])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_7[3])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_7[4])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_7[5])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_7[6])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_7[7]))
+                        : "r"(taddr + 320 + (unsigned int)tmem_row_base1 + 1048576)
+                        : "memory");
+                    asm volatile("tcgen05.wait::ld.sync.aligned;" ::: "memory");
+                    float diff_words_lo1_f32[8];
+                    #pragma unroll
+                    for (int _pair = 0; _pair < 4; _pair++) {
+                        asm volatile(
+                            "{\n\t"
+                            "shl.b32 %0, %2, 16;\n\t"
+                            "and.b32 %1, %2, 0xffff0000;\n\t"
+                            "}\n"
+                            : "=f"((&diff_words_lo1_f32[_pair * 2])[0]), "=f"((&diff_words_lo1_f32[_pair * 2])[1])
+                            : "r"(diff_words_lo1[_pair]));
+                    }
+                    float diff_words_hi1_f32[8];
+                    #pragma unroll
+                    for (int _pair = 0; _pair < 4; _pair++) {
+                        asm volatile(
+                            "{\n\t"
+                            "shl.b32 %0, %2, 16;\n\t"
+                            "and.b32 %1, %2, 0xffff0000;\n\t"
+                            "}\n"
+                            : "=f"((&diff_words_hi1_f32[_pair * 2])[0]), "=f"((&diff_words_hi1_f32[_pair * 2])[1])
+                            : "r"(diff_words_hi1[_pair]));
+                    }
+                    float dbeta_partial1[4];
+                    dbeta_partial1[0] = 0.0f;
+                    dbeta_partial1[1] = 0.0f;
+                    dbeta_partial1[2] = 0.0f;
+                    dbeta_partial1[3] = 0.0f;
+                    #pragma unroll
+                    for (int dbeta_pair1 = 0; dbeta_pair1 < 4; dbeta_pair1++) {
+                        const int dbeta_elem1 = dbeta_pair1 * 2;
+                        const int dbeta_slot_lo1 = 2 * (dbeta_pair1 / 2);
+                        const int dbeta_slot_hi1 = dbeta_slot_lo1 + 1;
+                        dbeta_partial1[dbeta_slot_lo1] = dbeta_partial1[dbeta_slot_lo1] + _tmem_load_6[dbeta_elem1] * diff_words_lo1_f32[dbeta_elem1] + _tmem_load_7[dbeta_elem1] * diff_words_hi1_f32[dbeta_elem1];
+                        dbeta_partial1[dbeta_slot_hi1] = dbeta_partial1[dbeta_slot_hi1] + _tmem_load_6[dbeta_elem1 + 1] * diff_words_lo1_f32[dbeta_elem1 + 1] + _tmem_load_7[dbeta_elem1 + 1] * diff_words_hi1_f32[dbeta_elem1 + 1];
+                    }
+                    uint32_t _tmem_load_6_bf16[4];
+                    #pragma unroll
+                    for (int _lp = 0; _lp < 4; _lp++) {
+                        __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(_tmem_load_6[_lp*2 + 0], _tmem_load_6[_lp*2+1 + 0]));
+                        _tmem_load_6_bf16[_lp] = *(uint32_t*)&_bf2;
+                    }
+                    uint32_t _tmem_load_7_bf16[4];
+                    #pragma unroll
+                    for (int _lp = 0; _lp < 4; _lp++) {
+                        __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(_tmem_load_7[_lp*2 + 0], _tmem_load_7[_lp*2+1 + 0]));
+                        _tmem_load_7_bf16[_lp] = *(uint32_t*)&_bf2;
+                    }
+                    int segment_15 = (value_dim_base1 + ov_col1) / 64;
+                    int segment_col_16 = value_dim_base1 + ov_col1 - segment_15 * 64;
+                    int swizzled_col_17 = segment_col_16 ^ (ov_token1 & 7) * 8;
+                    unsigned int dy_addr_lo1 = dy_smem_addr + (unsigned int)((segment_15 * 16 * 64 + ov_token1 * 64 + swizzled_col_17) * 2);
+                    int segment_18 = (value_dim_base1 + 16 + ov_col1) / 64;
+                    int segment_col_19 = value_dim_base1 + 16 + ov_col1 - segment_18 * 64;
+                    int swizzled_col_20 = segment_col_19 ^ (ov_token1 & 7) * 8;
+                    unsigned int dy_addr_hi1 = dy_smem_addr + (unsigned int)((segment_18 * 16 * 64 + ov_token1 * 64 + swizzled_col_20) * 2);
+                    uint32_t _stmatrix_addr_3 = static_cast<uint32_t>((unsigned long long)dy_addr_lo1);
+                    asm volatile("stmatrix.sync.aligned.m8n8.x4.trans.shared.b16 [%0], {%1, %2, %3, %4};\n"
+                        :: "r"(_stmatrix_addr_3), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_6_bf16[0])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_6_bf16[1])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_6_bf16[2])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_6_bf16[3]))
+                        : "memory");
+                    uint32_t _stmatrix_addr_4 = static_cast<uint32_t>((unsigned long long)dy_addr_hi1);
+                    asm volatile("stmatrix.sync.aligned.m8n8.x4.trans.shared.b16 [%0], {%1, %2, %3, %4};\n"
+                        :: "r"(_stmatrix_addr_4), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_7_bf16[0])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_7_bf16[1])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_7_bf16[2])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_7_bf16[3]))
+                        : "memory");
+                    asm volatile("fence.proxy.async.shared::cta;" ::: "memory");
+                    if (elect_sync()) {
+                        mbarrier_arrive(dy_smem_ready_addr);
+                    }
+                    #pragma unroll
+                    for (int beta_dy_pair1 = 0; beta_dy_pair1 < 4; beta_dy_pair1++) {
+                        const int beta_dy_elem1 = beta_dy_pair1 * 2;
+                        float beta_dy_lo1 = beta_c0_1;
+                        float beta_dy_hi1 = beta_c1_1;
+                        if (beta_dy_pair1 >= 2) {
+                            beta_dy_lo1 = beta_c8_1;
+                            beta_dy_hi1 = beta_c9_1;
+                        }
+                        _tmem_load_6[beta_dy_elem1] = _tmem_load_6[beta_dy_elem1] * beta_dy_lo1;
+                        _tmem_load_6[beta_dy_elem1 + 1] = _tmem_load_6[beta_dy_elem1 + 1] * beta_dy_hi1;
+                        _tmem_load_7[beta_dy_elem1] = _tmem_load_7[beta_dy_elem1] * beta_dy_lo1;
+                        _tmem_load_7[beta_dy_elem1 + 1] = _tmem_load_7[beta_dy_elem1 + 1] * beta_dy_hi1;
+                    }
+                    uint32_t _tmem_load_6_bf16_21[4];
+                    #pragma unroll
+                    for (int _lp = 0; _lp < 4; _lp++) {
+                        __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(_tmem_load_6[_lp*2 + 0], _tmem_load_6[_lp*2+1 + 0]));
+                        _tmem_load_6_bf16_21[_lp] = *(uint32_t*)&_bf2;
+                    }
+                    uint32_t _tmem_load_7_bf16_22[4];
+                    #pragma unroll
+                    for (int _lp = 0; _lp < 4; _lp++) {
+                        __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(_tmem_load_7[_lp*2 + 0], _tmem_load_7[_lp*2+1 + 0]));
+                        _tmem_load_7_bf16_22[_lp] = *(uint32_t*)&_bf2;
+                    }
+                    int segment_23 = (value_dim_base1 + ov_col1) / 64;
+                    int segment_col_24 = value_dim_base1 + ov_col1 - segment_23 * 64;
+                    int swizzled_col_25 = segment_col_24 ^ (ov_token1 & 7) * 8;
+                    unsigned int beta_dy_addr_lo1 = beta_dy_smem_addr + beta_dy_smem_stage1 * 4096 + (unsigned int)((segment_23 * 16 * 64 + ov_token1 * 64 + swizzled_col_25) * 2);
+                    int segment_26 = (value_dim_base1 + 16 + ov_col1) / 64;
+                    int segment_col_27 = value_dim_base1 + 16 + ov_col1 - segment_26 * 64;
+                    int swizzled_col_28 = segment_col_27 ^ (ov_token1 & 7) * 8;
+                    unsigned int beta_dy_addr_hi1 = beta_dy_smem_addr + beta_dy_smem_stage1 * 4096 + (unsigned int)((segment_26 * 16 * 64 + ov_token1 * 64 + swizzled_col_28) * 2);
+                    mbarrier_wait(beta_dy_smem_done_addr + (beta_dy_smem_stage1) * 8, _phase_beta_dy_smem_done);
+                    uint32_t _stmatrix_addr_5 = static_cast<uint32_t>((unsigned long long)beta_dy_addr_lo1);
+                    asm volatile("stmatrix.sync.aligned.m8n8.x4.trans.shared.b16 [%0], {%1, %2, %3, %4};\n"
+                        :: "r"(_stmatrix_addr_5), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_6_bf16_21[0])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_6_bf16_21[1])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_6_bf16_21[2])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_6_bf16_21[3]))
+                        : "memory");
+                    uint32_t _stmatrix_addr_6 = static_cast<uint32_t>((unsigned long long)beta_dy_addr_hi1);
+                    asm volatile("stmatrix.sync.aligned.m8n8.x4.trans.shared.b16 [%0], {%1, %2, %3, %4};\n"
+                        :: "r"(_stmatrix_addr_6), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_7_bf16_22[0])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_7_bf16_22[1])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_7_bf16_22[2])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_7_bf16_22[3]))
+                        : "memory");
+                    asm volatile("fence.proxy.async.shared::cta;" ::: "memory");
+                    if (elect_sync()) {
+                        mbarrier_arrive(beta_dy_smem_ready_addr + (beta_dy_smem_stage1) * 8);
+                    }
+                    beta_dy_smem_stage1 += 1;
+                    if (beta_dy_smem_stage1 == 2) { beta_dy_smem_stage1 = 0; _phase_beta_dy_smem_done ^= 1; }
+                    const float2 _scale2_7 = {-1.0f, -1.0f};
+                    #pragma unroll
+                    for (int _ls = 0; _ls < 4; _ls++)
+                        mul_f32x2_inplace(&reinterpret_cast<float2*>(_tmem_load_6)[_ls], _scale2_7);
+                    const float2 _scale2_8 = {-1.0f, -1.0f};
+                    #pragma unroll
+                    for (int _ls = 0; _ls < 4; _ls++)
+                        mul_f32x2_inplace(&reinterpret_cast<float2*>(_tmem_load_7)[_ls], _scale2_8);
+                    uint32_t _tmem_load_6_bf16_29[4];
+                    #pragma unroll
+                    for (int _lp = 0; _lp < 4; _lp++) {
+                        __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(_tmem_load_6[_lp*2 + 0], _tmem_load_6[_lp*2+1 + 0]));
+                        _tmem_load_6_bf16_29[_lp] = *(uint32_t*)&_bf2;
+                    }
+                    uint32_t _tmem_load_7_bf16_30[4];
+                    #pragma unroll
+                    for (int _lp = 0; _lp < 4; _lp++) {
+                        __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(_tmem_load_7[_lp*2 + 0], _tmem_load_7[_lp*2+1 + 0]));
+                        _tmem_load_7_bf16_30[_lp] = *(uint32_t*)&_bf2;
+                    }
+                    asm volatile(
+                        "tcgen05.st.sync.aligned.16x128b.x2.b32"
+                        " [%0], {%1, %2, %3, %4};"
+                        :: "r"(taddr + 432 + (unsigned int)tmem_row_base1), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_6_bf16_29[0])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_6_bf16_29[1])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_6_bf16_29[2])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_6_bf16_29[3]))
+                        : "memory");
+                    asm volatile(
+                        "tcgen05.st.sync.aligned.16x128b.x2.b32"
+                        " [%0], {%1, %2, %3, %4};"
+                        :: "r"(taddr + 432 + (unsigned int)tmem_row_base1 + 1048576), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_7_bf16_30[0])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_7_bf16_30[1])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_7_bf16_30[2])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_7_bf16_30[3]))
+                        : "memory");
+                    asm volatile("tcgen05.wait::st.sync.aligned;" ::: "memory");
+                    if (elect_sync()) {
+                        mbarrier_arrive(neg_dy_ready_addr + (tcgen_data_stage1) * 8);
+                        mbarrier_arrive(dy_done_addr + (tcgen_data_stage1) * 8);
+                    }
+                    #pragma unroll
+                    for (int dbeta_slot1 = 0; dbeta_slot1 < 4; dbeta_slot1++) {
+                        float _shfl_xor_6 = __shfl_xor_sync(0xFFFFFFFF, dbeta_partial1[dbeta_slot1], 4);
+                        dbeta_partial1[dbeta_slot1] = dbeta_partial1[dbeta_slot1] + _shfl_xor_6;
+                        float _shfl_xor_7 = __shfl_xor_sync(0xFFFFFFFF, dbeta_partial1[dbeta_slot1], 8);
+                        dbeta_partial1[dbeta_slot1] = dbeta_partial1[dbeta_slot1] + _shfl_xor_7;
+                        float _shfl_xor_8 = __shfl_xor_sync(0xFFFFFFFF, dbeta_partial1[dbeta_slot1], 16);
+                        dbeta_partial1[dbeta_slot1] = dbeta_partial1[dbeta_slot1] + _shfl_xor_8;
+                    }
+                    if (lane < 4) {
+                        #pragma unroll
+                        for (int dbeta_slot1_1 = 0; dbeta_slot1_1 < 4; dbeta_slot1_1++) {
+                            int dbeta_token_slot1 = (lane & 3) * 2 + (dbeta_slot1_1 & 1) + 8 * (dbeta_slot1_1 / 2);
+                            dbeta_red_smem[warp_id_in_role_1 * 16 + dbeta_token_slot1] = dbeta_partial1[dbeta_slot1_1];
+                        }
+                    }
+                    asm volatile("barrier.sync 9, 128;" ::: "memory");
+                    mbarrier_wait(dbeta_m_ready_addr + (dbeta_m_stage1) * 8, _phase_dbeta_m_ready);
+                    if (role_tid1 < 16) {
+                        float dbeta_value1 = dbeta_m_smem[role_tid1];
+                        #pragma unroll
+                        for (int dbeta_warp1 = 0; dbeta_warp1 < 4; dbeta_warp1++) {
+                            float dbeta_part1 = dbeta_red_smem[dbeta_warp1 * 16 + role_tid1];
+                            dbeta_value1 += dbeta_part1;
+                        }
+                        int dbeta_chunk1 = compute_end1 - 1 - reverse1;
+                        long long dbeta_token1 = bos1 + (long long)dbeta_chunk1 * 16 + (long long)role_tid1;
+                        if (dbeta_chunk1 < write_end1) {
+                            dbeta[dbeta_token1 * (long long)num_heads + (long long)head1] = dbeta_value1;
+                        }
+                    }
+                    asm volatile("barrier.sync 9, 128;" ::: "memory");
+                    if (warp_id_in_role_1 == 0) {
+                        if (elect_sync()) {
+                            mbarrier_arrive(dbeta_m_done_addr + (dbeta_m_stage1) * 8);
+                        }
+                    }
+                    dbeta_m_stage1 += 1;
+                    if (dbeta_m_stage1 == 1) { dbeta_m_stage1 = 0; _phase_dbeta_m_ready ^= 1; }
+                    mbarrier_wait(dstate_ready_addr + (tcgen_data_stage1) * 8, _phase_dstate_ready);
+                    mbarrier_wait(dstate_smem_done_addr + (dstate_smem_stage1) * 8, _phase_dstate_smem_done);
+                    dstate_smem_slot_acquired1 = 1;
+                    int boundary_chunk1 = compute_end1 - 1 - reverse1;
+                    long long boundary_checkpoint1 = bos1 / 16 + (long long)boundary_chunk1;
+                    #pragma unroll
+                    for (int dstate_block1 = 0; dstate_block1 < 4; dstate_block1++) {
+                        float _tmem_load_8[32];
+                        tmem_ld_x32(&_tmem_load_8[0], taddr + (unsigned int)(dstate_block1 * 32) + (unsigned int)tmem_row_base1);
+                        asm volatile("tcgen05.wait::ld.sync.aligned;" ::: "memory");
+                        uint32_t _tmem_load_8_bf16[16];
+                        #pragma unroll
+                        for (int _lp = 0; _lp < 16; _lp++) {
+                            __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(_tmem_load_8[_lp*2 + 0], _tmem_load_8[_lp*2+1 + 0]));
+                            _tmem_load_8_bf16[_lp] = *(uint32_t*)&_bf2;
+                        }
+                        if (reverse1 + 1 < compute_end1 - write_start1) {
+                            asm volatile(
+                                "tcgen05.st.sync.aligned.32x32b.x16.b32"
+                                " [%0], {%1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15, %16};"
+                                :: "r"(taddr + 128 + (unsigned int)(dstate_block1 * 16) + (unsigned int)tmem_row_base1), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_8_bf16[0])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_8_bf16[1])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_8_bf16[2])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_8_bf16[3])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_8_bf16[4])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_8_bf16[5])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_8_bf16[6])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_8_bf16[7])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_8_bf16[8])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_8_bf16[9])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_8_bf16[10])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_8_bf16[11])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_8_bf16[12])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_8_bf16[13])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_8_bf16[14])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_8_bf16[15]))
+                                : "memory");
+                        }
+                        #pragma unroll
+                        for (int dstate_atom1 = 0; dstate_atom1 < 4; dstate_atom1++) {
+                            int dstate_col_base1 = dstate_block1 * 32 + dstate_atom1 * 8;
+                            int segment_1_1 = dstate_col_base1 / 64;
+                            int segment_col_2_1 = dstate_col_base1 - segment_1_1 * 64;
+                            int swizzled_col_3_1 = segment_col_2_1 ^ (role_tid1 & 7) * 8;
+                            int dstate_smem_index1 = segment_1_1 * 128 * 64 + role_tid1 * 64 + swizzled_col_3_1;
+                            asm volatile("st.shared.v4.b32 [%0], {%1,%2,%3,%4};" :: "r"(dstate_smem_all_addr + (unsigned int)(dstate_smem_index1 * 2)), "r"(_tmem_load_8_bf16[dstate_atom1 * 4]), "r"(_tmem_load_8_bf16[dstate_atom1 * 4 + 1]), "r"(_tmem_load_8_bf16[dstate_atom1 * 4 + 2]), "r"(_tmem_load_8_bf16[dstate_atom1 * 4 + 3]) : "memory");
+                        }
+                        if (write_start1 == 0 && compute_end1 == sequence_chunks1 && reverse1 + 1 == compute_end1 - write_start1) {
+                            long long dinitial_base1 = (((long long)sequence1 * (long long)num_heads + (long long)head1) * 128 + (long long)role_tid1) * 128 + (long long)(dstate_block1 * 32);
+                            #pragma unroll
+                            for (int dinitial_vec1 = 0; dinitial_vec1 < 4; dinitial_vec1++) {
+                                {
+                                    unsigned _stv8_9_0 = __float_as_uint(_tmem_load_8[dinitial_vec1 * 8 + 0]);
+                                    unsigned _stv8_9_1 = __float_as_uint(_tmem_load_8[dinitial_vec1 * 8 + 1]);
+                                    unsigned _stv8_9_2 = __float_as_uint(_tmem_load_8[dinitial_vec1 * 8 + 2]);
+                                    unsigned _stv8_9_3 = __float_as_uint(_tmem_load_8[dinitial_vec1 * 8 + 3]);
+                                    unsigned _stv8_9_4 = __float_as_uint(_tmem_load_8[dinitial_vec1 * 8 + 4]);
+                                    unsigned _stv8_9_5 = __float_as_uint(_tmem_load_8[dinitial_vec1 * 8 + 5]);
+                                    unsigned _stv8_9_6 = __float_as_uint(_tmem_load_8[dinitial_vec1 * 8 + 6]);
+                                    unsigned _stv8_9_7 = __float_as_uint(_tmem_load_8[dinitial_vec1 * 8 + 7]);
+                                    asm volatile(
+                                        "st.global.v8.b32 [%0], {%1, %2, %3, %4, %5, %6, %7, %8};"
+                                        :: "l"((void*)(dinitial_state + (dinitial_base1 + (long long)(dinitial_vec1 * 8)))), "r"(_stv8_9_0), "r"(_stv8_9_1), "r"(_stv8_9_2), "r"(_stv8_9_3), "r"(_stv8_9_4), "r"(_stv8_9_5), "r"(_stv8_9_6), "r"(_stv8_9_7) : "memory");
+                                }
+                            }
+                        }
+                    }
+                    asm volatile("tcgen05.wait::st.sync.aligned;" ::: "memory");
+                    asm volatile("barrier.sync 9, 128;" ::: "memory");
+                    asm volatile("fence.proxy.async.shared::cta;" ::: "memory");
+                    if (elect_sync()) {
+                        mbarrier_arrive(boundary_smem_ready_addr + (boundary_stage1) * 8);
+                    }
+                    float boundary_diag_pair1[2];
+                    #pragma unroll
+                    for (int boundary_diag_block1 = 0; boundary_diag_block1 < 2; boundary_diag_block1++) {
+                        int boundary_channel_base1 = warp_id_in_role_1 * 32 + boundary_diag_block1 * 16;
+                        float boundary_diag_acc1[8];
+                        #pragma unroll
+                        for (int boundary_k1 = 0; boundary_k1 < 128; boundary_k1 += 16) {
+                            unsigned int boundary_a_frag1[4];
+                            unsigned int boundary_b_frag1[4];
+                            int boundary_lane_matrix1 = lane / 8;
+                            int boundary_lane_row1 = lane & 7;
+                            int boundary_a_row1 = boundary_k1 + boundary_lane_row1 + boundary_lane_matrix1 / 2 * 8;
+                            int boundary_a_col1 = boundary_channel_base1 + (boundary_lane_matrix1 & 1) * 8;
+                            int segment_1_2 = boundary_a_col1 / 64;
+                            int segment_col_2_2 = boundary_a_col1 - segment_1_2 * 64;
+                            int swizzled_col_3_2 = segment_col_2_2 ^ (boundary_a_row1 & 7) * 8;
+                            asm volatile("ldmatrix.sync.aligned.m8n8.x4.trans.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                                : "=r"(boundary_a_frag1[0]), "=r"(boundary_a_frag1[1]), "=r"(boundary_a_frag1[2]), "=r"(boundary_a_frag1[3])
+                                : "r"(state_operand_all_addr + (unsigned int)(((int)state_smem_stage1 * 128 * 128 + (segment_1_2 * 128 * 64 + boundary_a_row1 * 64 + swizzled_col_3_2)) * 2))
+                                : "memory");
+                            #pragma unroll
+                            for (int boundary_n_half1 = 0; boundary_n_half1 < 2; boundary_n_half1++) {
+                                int boundary_b_row1 = boundary_k1 + lane % 16;
+                                int boundary_b_col1 = boundary_channel_base1 + boundary_n_half1 * 8;
+                                int segment_2_1 = boundary_b_col1 / 64;
+                                int segment_col_3_1 = boundary_b_col1 - segment_2_1 * 64;
+                                int swizzled_col_4_1 = segment_col_3_1 ^ (boundary_b_row1 & 7) * 8;
+                                asm volatile("ldmatrix.sync.aligned.m8n8.x2.trans.shared.b16 {%0, %1}, [%2];\n"
+                                    : "=r"(boundary_b_frag1[boundary_n_half1 * 2]), "=r"(boundary_b_frag1[boundary_n_half1 * 2 + 1])
+                                    : "r"(dstate_smem_all_addr + (unsigned int)((segment_2_1 * 128 * 64 + boundary_b_row1 * 64 + swizzled_col_4_1) * 2))
+                                    : "memory");
+                            }
+                            asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%10, %11, %12, %13};\n"
+                                : "=f"(boundary_diag_acc1[0]), "=f"(boundary_diag_acc1[1]), "=f"(boundary_diag_acc1[2]), "=f"(boundary_diag_acc1[3])
+                                : "r"(boundary_a_frag1[0]), "r"(boundary_a_frag1[1]), "r"(boundary_a_frag1[2]), "r"(boundary_a_frag1[3]), "r"(boundary_b_frag1[0]), "r"(boundary_b_frag1[1]), "f"(((boundary_k1 == 0) ? 0.0f : boundary_diag_acc1[0])), "f"(((boundary_k1 == 0) ? 0.0f : boundary_diag_acc1[1])), "f"(((boundary_k1 == 0) ? 0.0f : boundary_diag_acc1[2])), "f"(((boundary_k1 == 0) ? 0.0f : boundary_diag_acc1[3])));
+                            asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%10, %11, %12, %13};\n"
+                                : "=f"(boundary_diag_acc1[4]), "=f"(boundary_diag_acc1[(4) + 1]), "=f"(boundary_diag_acc1[(4) + 2]), "=f"(boundary_diag_acc1[(4) + 3])
+                                : "r"(boundary_a_frag1[0]), "r"(boundary_a_frag1[1]), "r"(boundary_a_frag1[2]), "r"(boundary_a_frag1[3]), "r"(boundary_b_frag1[2]), "r"(boundary_b_frag1[(2) + 1]), "f"(((boundary_k1 == 0) ? 0.0f : boundary_diag_acc1[4])), "f"(((boundary_k1 == 0) ? 0.0f : boundary_diag_acc1[(4) + 1])), "f"(((boundary_k1 == 0) ? 0.0f : boundary_diag_acc1[(4) + 2])), "f"(((boundary_k1 == 0) ? 0.0f : boundary_diag_acc1[(4) + 3])));
+                        }
+                        float boundary_diag_lo1 = boundary_diag_acc1[0];
+                        float boundary_diag_hi1 = boundary_diag_acc1[6];
+                        if ((lane / 4 & 1) != 0) {
+                            boundary_diag_lo1 = boundary_diag_acc1[1];
+                            boundary_diag_hi1 = boundary_diag_acc1[7];
+                        }
+                        int boundary_target_row1 = lane & 15;
+                        int boundary_source_lane1 = (boundary_target_row1 & 7) * 4 + (boundary_target_row1 & 7) / 2;
+                        float _shfl_0 = __shfl_sync(0xFFFFFFFF, boundary_diag_lo1, boundary_source_lane1);
+                        float boundary_diag_lower1 = _shfl_0;
+                        float _shfl_1 = __shfl_sync(0xFFFFFFFF, boundary_diag_hi1, boundary_source_lane1);
+                        float boundary_diag_upper1 = _shfl_1;
+                        boundary_diag_pair1[boundary_diag_block1] = boundary_diag_lower1;
+                        if (boundary_target_row1 >= 8) {
+                            boundary_diag_pair1[boundary_diag_block1] = boundary_diag_upper1;
+                        }
+                    }
+                    float dgate_last_state1 = boundary_diag_pair1[0];
+                    if (lane >= 16) {
+                        dgate_last_state1 = boundary_diag_pair1[1];
+                    }
+                    boundary_state_smem[role_tid1] = dgate_last_state1;
+                    asm volatile("fence.proxy.async.shared::cta;" ::: "memory");
+                    if (elect_sync()) {
+                        mbarrier_arrive(boundary_state_ready_addr + (boundary_stage1) * 8);
+                    }
+                    if (reverse1 + 1 < compute_end1 - write_start1) {
+                        if (elect_sync()) {
+                            mbarrier_arrive(dstate_inp_ready_addr);
+                            mbarrier_arrive(dstate_smem_ready_addr + (dstate_smem_stage1) * 8);
+                        }
+                        dstate_smem_stage1 += 1;
+                        if (dstate_smem_stage1 == 1) { dstate_smem_stage1 = 0; _phase_dstate_smem_done ^= 1; }
+                        dstate_smem_slot_acquired1 = 0;
+                    }
+                    if (boundary_chunk1 < write_end1) {
+                        long long boundary_output_index1 = (boundary_checkpoint1 * (long long)num_heads + (long long)head1) * 128 + (long long)role_tid1;
+                        dgate_boundary_out[boundary_output_index1] = dgate_last_state1;
+                    }
+                    mbarrier_wait(boundary_acc_ready_addr + (boundary_stage1) * 8, _phase_boundary_acc_ready);
+                    if (elect_sync()) {
+                        mbarrier_arrive(dstate_done_addr + (tcgen_data_stage1) * 8);
+                    }
+                    boundary_stage1 += 1;
+                    if (boundary_stage1 == 1) { boundary_stage1 = 0; _phase_boundary_acc_ready ^= 1; }
+                    raw_stage1 += 1;
+                    if (raw_stage1 == 2) { raw_stage1 = 0; _phase_raw_ready_1 ^= 1; }
+                    state_smem_stage1 += 1;
+                    if (state_smem_stage1 == 2) { state_smem_stage1 = 0; _phase_state_k_ready ^= 1; }
+                    tcgen_data_stage1 += 1;
+                    if (tcgen_data_stage1 == 1) { tcgen_data_stage1 = 0; _phase_tcgen_inputs_done ^= 1; _phase_tcgen_products_ready ^= 1; _phase_dy_ready ^= 1; _phase_dstate_ready ^= 1; }
+                }
+                if (validate_outputs != 0 && role_tid1 == 0) {
+                    observed[tile1] = checksum_sum1;
+                }
+            }
+            if (elect_sync()) {
+                mbarrier_arrive(consumers_done_addr);
+            }
+        }
+    }
+    // ---- Role: compute2 ----
+    if (warp >= 8 && warp <= 11) {
+        asm volatile("setmaxnreg.inc.sync.aligned.u32 144;");
+        { // compute2_main
+            unsigned int sched_stage2 = 0;
+            unsigned int dk_restore_stage2 = 0;
+            unsigned int local_grad_stage2 = 0;
+            unsigned int qk_raw_stage2 = 0;
+            unsigned int g_prefix_stage2 = 0;
+            unsigned int state_smem_stage2 = 0;
+            unsigned int boundary_stage2 = 0;
+            int warp_id_in_role_2 = (warp - 8);
+            int role_tid2 = warp_id_in_role_2 * 32 + lane;
+            const int tmem_row_base2 = warp_id_in_role_2 * 32 << 16;
+            unsigned int _phase_sched_ready_2 = 0;
+            unsigned int _phase_qk_raw_ready = 0;
+            unsigned int _phase_g_prefix_ready = 0;
+            unsigned int _phase_state_ready = 0;
+            unsigned int _phase_local_grad_ready = 0;
+            unsigned int _phase_boundary_acc_ready_1 = 0;
+            unsigned int _phase_boundary_state_ready = 0;
+            unsigned int _phase_dk_restore_ready = 0;
+            #pragma unroll 1
+            for (int __2 = 0; __2 < total_work_items; __2++) {
+                mbarrier_wait(sched_ready_addr + (sched_stage2) * 8, _phase_sched_ready_2);
+                unsigned int ticket_words_2[1];
+                asm volatile("ld.shared.b32 %0, [%1];" : "=r"(*reinterpret_cast<uint32_t*>(&ticket_words_2[0])) : "r"(work_item_addr + sched_stage2 * 4));
+                unsigned int tile2 = ticket_words_2[0];
+                if (elect_sync()) {
+                    mbarrier_arrive(sched_done_addr + (sched_stage2) * 8);
+                }
+                sched_stage2 += 1;
+                if (sched_stage2 == 8) { sched_stage2 = 0; _phase_sched_ready_2 ^= 1; }
+                if (tile2 >= (unsigned int)total_work_items) {
+                    break;
+                }
+                int item_base2 = (int)tile2 * 5;
+                int sequence2 = work_items[item_base2];
+                int head2 = work_items[item_base2 + 1];
+                int write_start2 = work_items[item_base2 + 2];
+                int write_end2 = work_items[item_base2 + 3];
+                int compute_end2 = work_items[item_base2 + 4];
+                long long bos2 = cu_seqlens[sequence2];
+                #pragma unroll 1
+                for (int reverse2 = 0; reverse2 < compute_end2 - write_start2; reverse2++) {
+                    mbarrier_wait(qk_raw_ready_addr + (qk_raw_stage2) * 8, _phase_qk_raw_ready);
+                    mbarrier_wait(g_prefix_ready_addr + (g_prefix_stage2) * 8, _phase_g_prefix_ready);
+                    mbarrier_wait(state_ready_addr + (state_smem_stage2) * 8, _phase_state_ready);
+                    int norm_stage_base2 = (int)(qk_raw_stage2 % 4) * 2 * 16;
+                    float eg_values2[16];
+                    #pragma unroll
+                    for (int token_gate2 = 0; token_gate2 < 16; token_gate2++) {
+                        int segment_7 = role_tid2 / 32;
+                        int segment_col_8 = role_tid2 - segment_7 * 32;
+                        int swizzled_col_7 = segment_col_8 ^ (token_gate2 & 7) * 4;
+                        eg_values2[token_gate2] = g_prefix_all[(int)g_prefix_stage2 * 16 * 128 + segment_7 * 16 * 32 + token_gate2 * 32 + swizzled_col_7];
+                    }
+                    mbarrier_arrive(g_prefix_done_addr + (g_prefix_stage2) * 8);
+                    mbarrier_wait(local_grad_ready_addr + (local_grad_stage2) * 8, _phase_local_grad_ready);
+                    asm volatile("tcgen05.fence::after_thread_sync;");
+                    float _tmem_load_9[16];
+                    tmem_ld_x16(&_tmem_load_9[0], taddr + 368 + (unsigned int)tmem_row_base2);
+                    float _tmem_load_10[16];
+                    tmem_ld_x16(&_tmem_load_10[0], taddr + 384 + (unsigned int)tmem_row_base2);
+                    float _tmem_load_11[16];
+                    tmem_ld_x16(&_tmem_load_11[0], taddr + 400 + (unsigned int)tmem_row_base2);
+                    asm volatile("tcgen05.wait::ld.sync.aligned;" ::: "memory");
+                    asm volatile("tcgen05.fence::before_thread_sync;");
+                    if (elect_sync()) {
+                        mbarrier_arrive(local_grad_done_addr + (local_grad_stage2) * 8);
+                        mbarrier_arrive(boundary_local_grad_free_addr + (local_grad_stage2) * 8);
+                        mbarrier_arrive(dstate_done_addr + (local_grad_stage2) * 8);
+                    }
+                    mbarrier_wait(boundary_acc_ready_addr + (boundary_stage2) * 8, _phase_boundary_acc_ready_1);
+                    mbarrier_wait(boundary_state_ready_addr + (boundary_stage2) * 8, _phase_boundary_state_ready);
+                    float dgate_last_state2 = boundary_state_smem[role_tid2];
+                    boundary_stage2 += 1;
+                    if (boundary_stage2 == 1) { boundary_stage2 = 0; _phase_boundary_acc_ready_1 ^= 1; _phase_boundary_state_ready ^= 1; }
+                    mbarrier_arrive(state_cg2_done_addr + (state_smem_stage2) * 8);
+                    float2 dgate_last_restore_acc2[2];
+                    #pragma unroll
+                    for (int restore_acc_init2 = 0; restore_acc_init2 < 2; restore_acc_init2++) {
+                        float2 _f2_0 = make_float2(0.0f, 0.0f);
+                        dgate_last_restore_acc2[restore_acc_init2] = _f2_0;
+                    }
+                    #pragma unroll
+                    for (int token_pair2 = 0; token_pair2 < 8; token_pair2++) {
+                        const int token_scale0_2 = token_pair2 * 2;
+                        const int token_scale1_2 = token_scale0_2 + 1;
+                        float eg0_2 = eg_values2[token_scale0_2];
+                        float eg1_2 = eg_values2[token_scale1_2];
+                        float2 _f2_1 = make_float2(_tmem_load_9[token_scale0_2], _tmem_load_9[token_scale1_2]);
+                        float2 _f2_2 = make_float2(eg0_2 * scale, eg1_2 * scale);
+                        float2 dq_pair2 = mul_f32x2(_f2_1, _f2_2);
+                        float2 _f2_3 = make_float2(-eg0_2, -eg1_2);
+                        float2 _f2_4 = make_float2(_tmem_load_10[token_scale0_2], _tmem_load_10[token_scale1_2]);
+                        float2 dk_decay_pair2 = mul_f32x2(_f2_3, _f2_4);
+                        float2 _f2_5 = make_float2(_tmem_load_11[token_scale0_2], _tmem_load_11[token_scale1_2]);
+                        float _rcp_2 = approx_rcp(eg0_2);
+                        float _rcp_3 = approx_rcp(eg1_2);
+                        float2 _f2_6 = make_float2(_rcp_2, _rcp_3);
+                        float2 dk_inv_pair2 = fma_f32x2(_f2_5, _f2_6, dk_decay_pair2);
+                        _tmem_load_9[token_scale0_2] = dq_pair2.x;
+                        _tmem_load_9[token_scale1_2] = dq_pair2.y;
+                        _tmem_load_10[token_scale0_2] = dk_decay_pair2.x;
+                        _tmem_load_10[token_scale1_2] = dk_decay_pair2.y;
+                        _tmem_load_11[token_scale0_2] = dk_inv_pair2.x;
+                        _tmem_load_11[token_scale1_2] = dk_inv_pair2.y;
+                    }
+                    unsigned int raw_words_bits2[8];
+                    float q_raw_values2[16];
+                    float k_raw_values2[16];
+                    float _tmem_load_12[8];
+                    tmem_ld_x8(&_tmem_load_12[0], taddr + 480 + qk_raw_stage2 % 4 * 8 + (unsigned int)tmem_row_base2);
+                    asm volatile("tcgen05.wait::ld.sync.aligned;" ::: "memory");
+                    raw_words_bits2[0] = __as_u32(_tmem_load_12[0]);
+                    raw_words_bits2[1] = __as_u32(_tmem_load_12[1]);
+                    raw_words_bits2[2] = __as_u32(_tmem_load_12[2]);
+                    raw_words_bits2[3] = __as_u32(_tmem_load_12[3]);
+                    raw_words_bits2[4] = __as_u32(_tmem_load_12[4]);
+                    raw_words_bits2[5] = __as_u32(_tmem_load_12[5]);
+                    raw_words_bits2[6] = __as_u32(_tmem_load_12[6]);
+                    raw_words_bits2[7] = __as_u32(_tmem_load_12[7]);
+                    #pragma unroll
+                    for (int _pair = 0; _pair < 8; _pair++) {
+                        asm volatile(
+                            "{\n\t"
+                            "shl.b32 %0, %2, 16;\n\t"
+                            "and.b32 %1, %2, 0xffff0000;\n\t"
+                            "}\n"
+                            : "=f"((&k_raw_values2[_pair * 2])[0]), "=f"((&k_raw_values2[_pair * 2])[1])
+                            : "r"(raw_words_bits2[_pair]));
+                    }
+                    if (USE_DSTATE_IN != 0 || reverse2 > 0) {
+                        mbarrier_wait(dk_restore_ready_addr + (dk_restore_stage2) * 8, _phase_dk_restore_ready);
+                        asm volatile("tcgen05.fence::after_thread_sync;");
+                        float _tmem_load_13[16];
+                        tmem_ld_x16(&_tmem_load_13[0], taddr + 416 + (unsigned int)tmem_row_base2);
+                        asm volatile("tcgen05.wait::ld.sync.aligned;" ::: "memory");
+                        #pragma unroll
+                        for (int dk_pair2 = 0; dk_pair2 < 8; dk_pair2++) {
+                            const int dk_col0_2 = dk_pair2 * 2;
+                            const int dk_col1_2 = dk_col0_2 + 1;
+                            float _rcp_4 = approx_rcp(eg_values2[dk_col0_2]);
+                            float restore_scale0_2 = eg_values2[15] * _rcp_4;
+                            float _rcp_5 = approx_rcp(eg_values2[dk_col1_2]);
+                            float restore_scale1_2 = eg_values2[15] * _rcp_5;
+                            float2 _f2_7 = make_float2(restore_scale0_2, restore_scale1_2);
+                            float2 _f2_8 = make_float2(_tmem_load_13[dk_col0_2], _tmem_load_13[dk_col1_2]);
+                            float2 restore_hat_pair2 = mul_f32x2(_f2_7, _f2_8);
+                            float2 _f2_9 = make_float2(_tmem_load_11[dk_col0_2], _tmem_load_11[dk_col1_2]);
+                            float2 dk_inv_restore_pair2 = add_f32x2(_f2_9, restore_hat_pair2);
+                            _tmem_load_11[dk_col0_2] = dk_inv_restore_pair2.x;
+                            _tmem_load_11[dk_col1_2] = dk_inv_restore_pair2.y;
+                            float k_restore_norm0_2 = qk_norm_smem_all[norm_stage_base2 + 16 + dk_col0_2];
+                            float k_restore_norm1_2 = qk_norm_smem_all[norm_stage_base2 + 16 + dk_col1_2];
+                            float2 _f2_10 = make_float2(k_raw_values2[dk_col0_2], k_raw_values2[dk_col1_2]);
+                            float2 _f2_11 = make_float2(k_restore_norm0_2, k_restore_norm1_2);
+                            float2 k_normalized_pair2 = mul_f32x2(_f2_10, _f2_11);
+                            float2 restore_gate_pair2 = mul_f32x2(k_normalized_pair2, restore_hat_pair2);
+                            const int restore_acc_index2 = dk_pair2 % 2;
+                            dgate_last_restore_acc2[restore_acc_index2] = add_f32x2(dgate_last_restore_acc2[restore_acc_index2], restore_gate_pair2);
+                        }
+                        if (elect_sync()) {
+                            mbarrier_arrive(dk_restore_done_addr + (dk_restore_stage2) * 8);
+                        }
+                        dk_restore_stage2 += 1;
+                        if (dk_restore_stage2 == 1) { dk_restore_stage2 = 0; _phase_dk_restore_ready ^= 1; }
+                    }
+                    float _tmem_load_14[8];
+                    tmem_ld_x8(&_tmem_load_14[0], taddr + 448 + qk_raw_stage2 % 4 * 8 + (unsigned int)tmem_row_base2);
+                    asm volatile("tcgen05.wait::ld.sync.aligned;" ::: "memory");
+                    raw_words_bits2[0] = __as_u32(_tmem_load_14[0]);
+                    raw_words_bits2[1] = __as_u32(_tmem_load_14[1]);
+                    raw_words_bits2[2] = __as_u32(_tmem_load_14[2]);
+                    raw_words_bits2[3] = __as_u32(_tmem_load_14[3]);
+                    raw_words_bits2[4] = __as_u32(_tmem_load_14[4]);
+                    raw_words_bits2[5] = __as_u32(_tmem_load_14[5]);
+                    raw_words_bits2[6] = __as_u32(_tmem_load_14[6]);
+                    raw_words_bits2[7] = __as_u32(_tmem_load_14[7]);
+                    #pragma unroll
+                    for (int _pair = 0; _pair < 8; _pair++) {
+                        asm volatile(
+                            "{\n\t"
+                            "shl.b32 %0, %2, 16;\n\t"
+                            "and.b32 %1, %2, 0xffff0000;\n\t"
+                            "}\n"
+                            : "=f"((&q_raw_values2[_pair * 2])[0]), "=f"((&q_raw_values2[_pair * 2])[1])
+                            : "r"(raw_words_bits2[_pair]));
+                    }
+                    float dgate_last_restore2 = dgate_last_restore_acc2[0].x + dgate_last_restore_acc2[0].y + (dgate_last_restore_acc2[1].x + dgate_last_restore_acc2[1].y);
+                    #pragma unroll
+                    for (int gate_pair2 = 0; gate_pair2 < 8; gate_pair2++) {
+                        const int gate_token0_2 = gate_pair2 * 2;
+                        const int gate_token1_2 = gate_token0_2 + 1;
+                        float q_gate_norm0_2 = qk_norm_smem_all[norm_stage_base2 + gate_token0_2];
+                        float q_gate_norm1_2 = qk_norm_smem_all[norm_stage_base2 + gate_token1_2];
+                        float k_gate_norm0_2 = qk_norm_smem_all[norm_stage_base2 + 16 + gate_token0_2];
+                        float k_gate_norm1_2 = qk_norm_smem_all[norm_stage_base2 + 16 + gate_token1_2];
+                        float2 _f2_12 = make_float2(q_raw_values2[gate_token0_2], q_raw_values2[gate_token1_2]);
+                        float2 _f2_13 = make_float2(q_gate_norm0_2, q_gate_norm1_2);
+                        float2 q_normalized_pair2 = mul_f32x2(_f2_12, _f2_13);
+                        float2 _f2_14 = make_float2(k_raw_values2[gate_token0_2], k_raw_values2[gate_token1_2]);
+                        float2 _f2_15 = make_float2(k_gate_norm0_2, k_gate_norm1_2);
+                        float2 k_normalized_pair2_1 = mul_f32x2(_f2_14, _f2_15);
+                        float2 _f2_16 = make_float2(2.0f, 2.0f);
+                        float2 _f2_17 = make_float2(_tmem_load_10[gate_token0_2], _tmem_load_10[gate_token1_2]);
+                        float2 _f2_18 = make_float2(_tmem_load_11[gate_token0_2], _tmem_load_11[gate_token1_2]);
+                        float2 gate_residual_pair2 = fma_sub_f32x2(_f2_16, _f2_17, _f2_18);
+                        float2 _f2_19 = make_float2(_tmem_load_9[gate_token0_2], _tmem_load_9[gate_token1_2]);
+                        float2 dgate_pair2 = fma_f32x2(k_normalized_pair2_1, gate_residual_pair2, mul_f32x2(q_normalized_pair2, _f2_19));
+                        _tmem_load_10[gate_token0_2] = dgate_pair2.x;
+                        _tmem_load_10[gate_token1_2] = dgate_pair2.y;
+                    }
+                    _tmem_load_10[15] = _tmem_load_10[15] + dgate_last_restore2;
+                    if (USE_DSTATE_IN != 0 || reverse2 > 0) {
+                        _tmem_load_10[15] = _tmem_load_10[15] + eg_values2[15] * dgate_last_state2;
+                    }
+                    #pragma unroll
+                    for (int gate_suffix2 = 15; gate_suffix2 >= 0; gate_suffix2--) {
+                        _tmem_load_10[gate_suffix2 - 1] = _tmem_load_10[gate_suffix2 - 1] + _tmem_load_10[gate_suffix2];
+                    }
+                    float anchored_dgate2 = dgate_last_state2;
+                    #pragma unroll
+                    for (int gate_reconcile2 = 0; gate_reconcile2 < 8; gate_reconcile2++) {
+                        float suffix_here2 = _tmem_load_10[gate_reconcile2];
+                        float suffix_next2 = _tmem_load_10[gate_reconcile2 + 1];
+                        _tmem_load_10[gate_reconcile2] = anchored_dgate2;
+                        anchored_dgate2 -= suffix_here2 - suffix_next2;
+                    }
+                    float _tmem_load_15[8];
+                    tmem_ld_x8(&_tmem_load_15[0], taddr + 448 + qk_raw_stage2 % 4 * 8 + (unsigned int)tmem_row_base2);
+                    asm volatile("tcgen05.wait::ld.sync.aligned;" ::: "memory");
+                    raw_words_bits2[0] = __as_u32(_tmem_load_15[0]);
+                    raw_words_bits2[1] = __as_u32(_tmem_load_15[1]);
+                    raw_words_bits2[2] = __as_u32(_tmem_load_15[2]);
+                    raw_words_bits2[3] = __as_u32(_tmem_load_15[3]);
+                    raw_words_bits2[4] = __as_u32(_tmem_load_15[4]);
+                    raw_words_bits2[5] = __as_u32(_tmem_load_15[5]);
+                    raw_words_bits2[6] = __as_u32(_tmem_load_15[6]);
+                    raw_words_bits2[7] = __as_u32(_tmem_load_15[7]);
+                    #pragma unroll
+                    for (int _pair = 0; _pair < 8; _pair++) {
+                        asm volatile(
+                            "{\n\t"
+                            "shl.b32 %0, %2, 16;\n\t"
+                            "and.b32 %1, %2, 0xffff0000;\n\t"
+                            "}\n"
+                            : "=f"((&q_raw_values2[_pair * 2])[0]), "=f"((&q_raw_values2[_pair * 2])[1])
+                            : "r"(raw_words_bits2[_pair]));
+                    }
+                    float dot_values2[16];
+                    #pragma unroll
+                    for (int qdot_pair2 = 0; qdot_pair2 < 8; qdot_pair2++) {
+                        const int qdot_token0_2 = qdot_pair2 * 2;
+                        const int qdot_token1_2 = qdot_token0_2 + 1;
+                        float qdot_norm0_2 = qk_norm_smem_all[norm_stage_base2 + qdot_token0_2];
+                        float qdot_norm1_2 = qk_norm_smem_all[norm_stage_base2 + qdot_token1_2];
+                        float2 _f2_20 = make_float2(_tmem_load_9[qdot_token0_2], _tmem_load_9[qdot_token1_2]);
+                        float2 _f2_21 = make_float2(q_raw_values2[qdot_token0_2], q_raw_values2[qdot_token1_2]);
+                        float2 _f2_22 = make_float2(qdot_norm0_2, qdot_norm1_2);
+                        float2 qdot_pair_value2 = mul_f32x2(_f2_20, mul_f32x2(_f2_21, _f2_22));
+                        dot_values2[qdot_token0_2] = qdot_pair_value2.x;
+                        dot_values2[qdot_token1_2] = qdot_pair_value2.y;
+                        #pragma unroll
+                        for (int qdot_step2 = 0; qdot_step2 < 5; qdot_step2++) {
+                            const int qdot_delta2 = 16 >> qdot_step2;
+                            float _shfl_xor_9 = __shfl_xor_sync(0xFFFFFFFF, dot_values2[qdot_token0_2], qdot_delta2);
+                            float qdot_shuffle0_2 = _shfl_xor_9;
+                            float _shfl_xor_10 = __shfl_xor_sync(0xFFFFFFFF, dot_values2[qdot_token1_2], qdot_delta2);
+                            float qdot_shuffle1_2 = _shfl_xor_10;
+                            float2 _f2_23 = make_float2(dot_values2[qdot_token0_2], dot_values2[qdot_token1_2]);
+                            float2 _f2_24 = make_float2(qdot_shuffle0_2, qdot_shuffle1_2);
+                            qdot_pair_value2 = add_f32x2(_f2_23, _f2_24);
+                            dot_values2[qdot_token0_2] = qdot_pair_value2.x;
+                            dot_values2[qdot_token1_2] = qdot_pair_value2.y;
+                        }
+                    }
+                    if (lane == 0) {
+                        #pragma unroll
+                        for (int qdot_store2 = 0; qdot_store2 < 16; qdot_store2++) {
+                            qk_red_smem[warp_id_in_role_2 * 16 + qdot_store2] = dot_values2[qdot_store2];
+                        }
+                    }
+                    asm volatile("barrier.sync 10, 128;" ::: "memory");
+                    #pragma unroll
+                    for (int qproj_pair2 = 0; qproj_pair2 < 8; qproj_pair2++) {
+                        const int qproj_token0_2 = qproj_pair2 * 2;
+                        const int qproj_token1_2 = qproj_token0_2 + 1;
+                        float2 _f2_25 = make_float2(0.0f, 0.0f);
+                        float2 qdot_total_pair2 = _f2_25;
+                        #pragma unroll
+                        for (int qdot_warp2 = 0; qdot_warp2 < 4; qdot_warp2++) {
+                            float qdot_total0_2 = qk_red_smem[qdot_warp2 * 16 + qproj_token0_2];
+                            float qdot_total1_2 = qk_red_smem[qdot_warp2 * 16 + qproj_token1_2];
+                            float2 _f2_26 = make_float2(qdot_total0_2, qdot_total1_2);
+                            qdot_total_pair2 = add_f32x2(qdot_total_pair2, _f2_26);
+                        }
+                        float qproj_norm0_2 = qk_norm_smem_all[norm_stage_base2 + qproj_token0_2];
+                        float qproj_norm1_2 = qk_norm_smem_all[norm_stage_base2 + qproj_token1_2];
+                        float2 _f2_27 = make_float2(qproj_norm0_2, qproj_norm1_2);
+                        float2 qproj_norm_pair2 = _f2_27;
+                        float2 _f2_28 = make_float2(q_raw_values2[qproj_token0_2], q_raw_values2[qproj_token1_2]);
+                        float2 qproj_correction_pair2 = mul_f32x2(mul_f32x2(_f2_28, qproj_norm_pair2), qdot_total_pair2);
+                        float2 _f2_29 = make_float2(_tmem_load_9[qproj_token0_2], _tmem_load_9[qproj_token1_2]);
+                        float2 qproj_result_pair2 = mul_f32x2(sub_f32x2(_f2_29, qproj_correction_pair2), qproj_norm_pair2);
+                        _tmem_load_9[qproj_token0_2] = qproj_result_pair2.x;
+                        _tmem_load_9[qproj_token1_2] = qproj_result_pair2.y;
+                    }
+                    asm volatile("barrier.sync 10, 128;" ::: "memory");
+                    float _tmem_load_16[8];
+                    tmem_ld_x8(&_tmem_load_16[0], taddr + 480 + qk_raw_stage2 % 4 * 8 + (unsigned int)tmem_row_base2);
+                    asm volatile("tcgen05.wait::ld.sync.aligned;" ::: "memory");
+                    raw_words_bits2[0] = __as_u32(_tmem_load_16[0]);
+                    raw_words_bits2[1] = __as_u32(_tmem_load_16[1]);
+                    raw_words_bits2[2] = __as_u32(_tmem_load_16[2]);
+                    raw_words_bits2[3] = __as_u32(_tmem_load_16[3]);
+                    raw_words_bits2[4] = __as_u32(_tmem_load_16[4]);
+                    raw_words_bits2[5] = __as_u32(_tmem_load_16[5]);
+                    raw_words_bits2[6] = __as_u32(_tmem_load_16[6]);
+                    raw_words_bits2[7] = __as_u32(_tmem_load_16[7]);
+                    #pragma unroll
+                    for (int _pair = 0; _pair < 8; _pair++) {
+                        asm volatile(
+                            "{\n\t"
+                            "shl.b32 %0, %2, 16;\n\t"
+                            "and.b32 %1, %2, 0xffff0000;\n\t"
+                            "}\n"
+                            : "=f"((&k_raw_values2[_pair * 2])[0]), "=f"((&k_raw_values2[_pair * 2])[1])
+                            : "r"(raw_words_bits2[_pair]));
+                    }
+                    #pragma unroll
+                    for (int kdot_pair2 = 0; kdot_pair2 < 8; kdot_pair2++) {
+                        const int kdot_token0_2 = kdot_pair2 * 2;
+                        const int kdot_token1_2 = kdot_token0_2 + 1;
+                        float kdot_norm0_2 = qk_norm_smem_all[norm_stage_base2 + 16 + kdot_token0_2];
+                        float kdot_norm1_2 = qk_norm_smem_all[norm_stage_base2 + 16 + kdot_token1_2];
+                        float2 _f2_30 = make_float2(_tmem_load_11[kdot_token0_2], _tmem_load_11[kdot_token1_2]);
+                        float2 _f2_31 = make_float2(k_raw_values2[kdot_token0_2], k_raw_values2[kdot_token1_2]);
+                        float2 _f2_32 = make_float2(kdot_norm0_2, kdot_norm1_2);
+                        float2 kdot_pair_value2 = mul_f32x2(_f2_30, mul_f32x2(_f2_31, _f2_32));
+                        dot_values2[kdot_token0_2] = kdot_pair_value2.x;
+                        dot_values2[kdot_token1_2] = kdot_pair_value2.y;
+                        #pragma unroll
+                        for (int kdot_step2 = 0; kdot_step2 < 5; kdot_step2++) {
+                            const int kdot_delta2 = 16 >> kdot_step2;
+                            float _shfl_xor_11 = __shfl_xor_sync(0xFFFFFFFF, dot_values2[kdot_token0_2], kdot_delta2);
+                            float kdot_shuffle0_2 = _shfl_xor_11;
+                            float _shfl_xor_12 = __shfl_xor_sync(0xFFFFFFFF, dot_values2[kdot_token1_2], kdot_delta2);
+                            float kdot_shuffle1_2 = _shfl_xor_12;
+                            float2 _f2_33 = make_float2(dot_values2[kdot_token0_2], dot_values2[kdot_token1_2]);
+                            float2 _f2_34 = make_float2(kdot_shuffle0_2, kdot_shuffle1_2);
+                            kdot_pair_value2 = add_f32x2(_f2_33, _f2_34);
+                            dot_values2[kdot_token0_2] = kdot_pair_value2.x;
+                            dot_values2[kdot_token1_2] = kdot_pair_value2.y;
+                        }
+                    }
+                    if (lane == 0) {
+                        #pragma unroll
+                        for (int kdot_store2 = 0; kdot_store2 < 16; kdot_store2++) {
+                            qk_red_smem[warp_id_in_role_2 * 16 + kdot_store2] = dot_values2[kdot_store2];
+                        }
+                    }
+                    asm volatile("barrier.sync 10, 128;" ::: "memory");
+                    #pragma unroll
+                    for (int kproj_pair2 = 0; kproj_pair2 < 8; kproj_pair2++) {
+                        const int kproj_token0_2 = kproj_pair2 * 2;
+                        const int kproj_token1_2 = kproj_token0_2 + 1;
+                        float2 _f2_35 = make_float2(0.0f, 0.0f);
+                        float2 kdot_total_pair2 = _f2_35;
+                        #pragma unroll
+                        for (int kdot_warp2 = 0; kdot_warp2 < 4; kdot_warp2++) {
+                            float kdot_total0_2 = qk_red_smem[kdot_warp2 * 16 + kproj_token0_2];
+                            float kdot_total1_2 = qk_red_smem[kdot_warp2 * 16 + kproj_token1_2];
+                            float2 _f2_36 = make_float2(kdot_total0_2, kdot_total1_2);
+                            kdot_total_pair2 = add_f32x2(kdot_total_pair2, _f2_36);
+                        }
+                        float kproj_norm0_2 = qk_norm_smem_all[norm_stage_base2 + 16 + kproj_token0_2];
+                        float kproj_norm1_2 = qk_norm_smem_all[norm_stage_base2 + 16 + kproj_token1_2];
+                        float2 _f2_37 = make_float2(kproj_norm0_2, kproj_norm1_2);
+                        float2 kproj_norm_pair2 = _f2_37;
+                        float2 _f2_38 = make_float2(k_raw_values2[kproj_token0_2], k_raw_values2[kproj_token1_2]);
+                        float2 kproj_correction_pair2 = mul_f32x2(mul_f32x2(_f2_38, kproj_norm_pair2), kdot_total_pair2);
+                        float2 _f2_39 = make_float2(_tmem_load_11[kproj_token0_2], _tmem_load_11[kproj_token1_2]);
+                        float2 kproj_result_pair2 = mul_f32x2(sub_f32x2(_f2_39, kproj_correction_pair2), kproj_norm_pair2);
+                        _tmem_load_11[kproj_token0_2] = kproj_result_pair2.x;
+                        _tmem_load_11[kproj_token1_2] = kproj_result_pair2.y;
+                    }
+                    asm volatile("barrier.sync 10, 128;" ::: "memory");
+                    int output_chunk2 = compute_end2 - 1 - reverse2;
+                    long long output_token_base2 = bos2 + (long long)output_chunk2 * 16;
+                    if (output_chunk2 < write_end2) {
+                        #pragma unroll
+                        for (int output_token2 = 0; output_token2 < 16; output_token2++) {
+                            long long output_index2 = ((output_token_base2 + (long long)output_token2) * (long long)num_heads + (long long)head2) * 128 + (long long)role_tid2;
+                            __nv_bfloat16 _cvt_bf16_6 = __float2bfloat16(_tmem_load_9[output_token2]);
+                            dq_out[output_index2] = _cvt_bf16_6;
+                            __nv_bfloat16 _cvt_bf16_7 = __float2bfloat16(_tmem_load_11[output_token2]);
+                            dk_out[output_index2] = _cvt_bf16_7;
+                            dgate_out[output_index2] = _tmem_load_10[output_token2];
+                        }
+                    }
+                    mbarrier_arrive(qk_raw_done_addr + (qk_raw_stage2) * 8);
+                    local_grad_stage2 += 1;
+                    if (local_grad_stage2 == 1) { local_grad_stage2 = 0; _phase_local_grad_ready ^= 1; }
+                    qk_raw_stage2 += 1;
+                    if (qk_raw_stage2 == 4) { qk_raw_stage2 = 0; _phase_qk_raw_ready ^= 1; }
+                    g_prefix_stage2 += 1;
+                    if (g_prefix_stage2 == 2) { g_prefix_stage2 = 0; _phase_g_prefix_ready ^= 1; }
+                    state_smem_stage2 += 1;
+                    if (state_smem_stage2 == 2) { state_smem_stage2 = 0; _phase_state_ready ^= 1; }
+                }
+            }
+            if (elect_sync()) {
+                mbarrier_arrive(consumers_done_addr);
+            }
+        }
+    }
+    // ---- Role: super_mma ----
+    if (warp == 12) {
+        { // super_mma_main
+            unsigned int sched_stage3 = 0;
+            unsigned int raw_stage3 = 0;
+            unsigned int operand_stage3 = 0;
+            unsigned int intermediate_stage3 = 0;
+            unsigned int u_smem_stage3 = 0;
+            unsigned int dy_smem_stage3 = 0;
+            unsigned int dbeta_m_stage3 = 0;
+            int lhs_row3 = lane % 8 + (lane / 8 & 1) * 8;
+            int lhs_col_offset3 = lane / 16 * 8;
+            int rhs_row3 = lane % 8 + lane / 16 * 8;
+            int rhs_col_offset3 = (lane / 8 & 1) * 8;
+            unsigned int _phase_sched_ready_3 = 0;
+            unsigned int _phase_raw_ready_2 = 0;
+            unsigned int _phase_k_decay_inv_ready = 0;
+            unsigned int _phase_intermediate_done = 1;
+            unsigned int _phase_u_smem_ready = 0;
+            unsigned int _phase_dy_smem_ready = 0;
+            unsigned int _phase_dbeta_m_done = 1;
+            #pragma unroll 1
+            for (int __3 = 0; __3 < total_work_items; __3++) {
+                mbarrier_wait(sched_ready_addr + (sched_stage3) * 8, _phase_sched_ready_3);
+                unsigned int ticket_words_3[1];
+                asm volatile("ld.shared.b32 %0, [%1];" : "=r"(*reinterpret_cast<uint32_t*>(&ticket_words_3[0])) : "r"(work_item_addr + sched_stage3 * 4));
+                unsigned int tile3 = ticket_words_3[0];
+                if (elect_sync()) {
+                    mbarrier_arrive(sched_done_addr + (sched_stage3) * 8);
+                }
+                sched_stage3 += 1;
+                if (sched_stage3 == 8) { sched_stage3 = 0; _phase_sched_ready_3 ^= 1; }
+                if (tile3 >= (unsigned int)total_work_items) {
+                    break;
+                }
+                int item_base3 = (int)tile3 * 5;
+                int head3 = work_items[item_base3 + 1];
+                int write_start3 = work_items[item_base3 + 2];
+                int write_end3 = work_items[item_base3 + 3];
+                int compute_end3 = work_items[item_base3 + 4];
+                float kk_sum3[8];
+                kk_sum3[0] = 0.0f;
+                kk_sum3[1] = 0.0f;
+                kk_sum3[2] = 0.0f;
+                kk_sum3[3] = 0.0f;
+                kk_sum3[4] = 0.0f;
+                kk_sum3[5] = 0.0f;
+                kk_sum3[6] = 0.0f;
+                kk_sum3[7] = 0.0f;
+                float tinv_sum3[8];
+                tinv_sum3[0] = 0.0f;
+                tinv_sum3[1] = 0.0f;
+                tinv_sum3[2] = 0.0f;
+                tinv_sum3[3] = 0.0f;
+                tinv_sum3[4] = 0.0f;
+                tinv_sum3[5] = 0.0f;
+                tinv_sum3[6] = 0.0f;
+                tinv_sum3[7] = 0.0f;
+                #pragma unroll 1
+                for (int reverse3 = 0; reverse3 < compute_end3 - write_start3; reverse3++) {
+                    mbarrier_wait(raw_ready_addr + (raw_stage3) * 8, _phase_raw_ready_2);
+                    int beta_stage_base3 = (int)(raw_stage3 % 2) * 16 * 8;
+                    int beta_head3 = head3 % 8;
+                    int beta_row_lo3 = lane / 4;
+                    int beta_row_hi3 = beta_row_lo3 + 8;
+                    __nv_bfloat16 beta_lo_bf3 = beta_smem_all[beta_stage_base3 + beta_row_lo3 * 8 + beta_head3];
+                    __nv_bfloat16 beta_hi_bf3 = beta_smem_all[beta_stage_base3 + beta_row_hi3 * 8 + beta_head3];
+                    float _cvt_f32_22 = __bfloat162float(beta_lo_bf3);
+                    float beta_lo3 = _cvt_f32_22;
+                    float _cvt_f32_23 = __bfloat162float(beta_hi_bf3);
+                    float beta_hi3 = _cvt_f32_23;
+                    mbarrier_wait(k_decay_inv_ready_addr + (operand_stage3) * 8, _phase_k_decay_inv_ready);
+                    float kk_acc3[8];
+                    kk_acc3[0] = 0.0f;
+                    kk_acc3[1] = 0.0f;
+                    kk_acc3[2] = 0.0f;
+                    kk_acc3[3] = 0.0f;
+                    kk_acc3[4] = 0.0f;
+                    kk_acc3[5] = 0.0f;
+                    kk_acc3[6] = 0.0f;
+                    kk_acc3[7] = 0.0f;
+                    mbarrier_wait(intermediate_done_addr + (intermediate_stage3) * 8, _phase_intermediate_done);
+                    if (enable_kk != 0) {
+                        #pragma unroll
+                        for (int k_block3 = 0; k_block3 < 8; k_block3++) {
+                            int a_col3 = k_block3 * 16 + lhs_col_offset3;
+                            int b_col3 = k_block3 * 16 + rhs_col_offset3;
+                            unsigned int a_frag3[4];
+                            unsigned int b_frag3[4];
+                            int segment_8 = a_col3 / 64;
+                            int segment_col_9 = a_col3 - segment_8 * 64;
+                            int swizzled_col_9 = segment_col_9 ^ (lhs_row3 & 7) * 8;
+                            asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                                : "=r"(a_frag3[0]), "=r"(a_frag3[1]), "=r"(a_frag3[2]), "=r"(a_frag3[3])
+                                : "r"(k_decay_all_addr + (unsigned int)(((int)operand_stage3 * 16 * 128 + segment_8 * 16 * 64 + lhs_row3 * 64 + swizzled_col_9) * 2))
+                                : "memory");
+                            int segment_0_3 = b_col3 / 64;
+                            int segment_col_1_3 = b_col3 - segment_0_3 * 64;
+                            int swizzled_col_2_3 = segment_col_1_3 ^ (rhs_row3 & 7) * 8;
+                            asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                                : "=r"(b_frag3[0]), "=r"(b_frag3[1]), "=r"(b_frag3[2]), "=r"(b_frag3[3])
+                                : "r"(k_inv_all_addr + (unsigned int)(((int)operand_stage3 * 16 * 128 + segment_0_3 * 16 * 64 + rhs_row3 * 64 + swizzled_col_2_3) * 2))
+                                : "memory");
+                            asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%10, %11, %12, %13};\n"
+                                : "=f"(kk_acc3[0]), "=f"(kk_acc3[1]), "=f"(kk_acc3[2]), "=f"(kk_acc3[3])
+                                : "r"(a_frag3[0]), "r"(a_frag3[1]), "r"(a_frag3[2]), "r"(a_frag3[3]), "r"(b_frag3[0]), "r"(b_frag3[1]), "f"(((k_block3 == 0) ? 0.0f : kk_acc3[0])), "f"(((k_block3 == 0) ? 0.0f : kk_acc3[1])), "f"(((k_block3 == 0) ? 0.0f : kk_acc3[2])), "f"(((k_block3 == 0) ? 0.0f : kk_acc3[3])));
+                            asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%10, %11, %12, %13};\n"
+                                : "=f"(kk_acc3[4]), "=f"(kk_acc3[(4) + 1]), "=f"(kk_acc3[(4) + 2]), "=f"(kk_acc3[(4) + 3])
+                                : "r"(a_frag3[0]), "r"(a_frag3[1]), "r"(a_frag3[2]), "r"(a_frag3[3]), "r"(b_frag3[2]), "r"(b_frag3[(2) + 1]), "f"(((k_block3 == 0) ? 0.0f : kk_acc3[4])), "f"(((k_block3 == 0) ? 0.0f : kk_acc3[(4) + 1])), "f"(((k_block3 == 0) ? 0.0f : kk_acc3[(4) + 2])), "f"(((k_block3 == 0) ? 0.0f : kk_acc3[(4) + 3])));
+                        }
+                        #pragma unroll
+                        for (int accum3 = 0; accum3 < 8; accum3++) {
+                            kk_sum3[accum3] = kk_sum3[accum3] + kk_acc3[accum3];
+                        }
+                        if (enable_tinv != 0) {
+                            float l_values3[8];
+                            float tinv_acc3[8];
+                            #pragma unroll
+                            for (int accum_t3 = 0; accum_t3 < 8; accum_t3++) {
+                                int accum_row3 = lane / 4 + accum_t3 % 4 / 2 * 8;
+                                int accum_col3 = accum_t3 / 4 * 8 + (lane & 3) * 2 + (accum_t3 & 1);
+                                l_values3[accum_t3] = 0.0f;
+                                if (accum_row3 > accum_col3) {
+                                    float beta_scale3 = beta_lo3;
+                                    if (accum_t3 % 4 >= 2) {
+                                        beta_scale3 = beta_hi3;
+                                    }
+                                    l_values3[accum_t3] = kk_acc3[accum_t3] * beta_scale3;
+                                }
+                                tinv_acc3[accum_t3] = -l_values3[accum_t3];
+                                if (accum_row3 == accum_col3) {
+                                    tinv_acc3[accum_t3] = 1.0f;
+                                }
+                            }
+                            unsigned int lpow_words3[4];
+                            unsigned int lpow_trans3[4];
+                            #pragma unroll
+                            for (int _lp = 0; _lp < 4; _lp++) {
+                                __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(l_values3[_lp*2 + 0], l_values3[_lp*2+1 + 0]));
+                                lpow_words3[_lp] = *(uint32_t*)&_bf2;
+                            }
+                            int store_row3 = lane % 16;
+                            int store_col3 = lane / 16 * 8;
+                            int linear = store_row3 * 16 + store_col3;
+                            uint32_t _stmatrix_addr_0 = static_cast<uint32_t>((unsigned long long)(tinv_scratch_addr + (unsigned int)((linear ^ (linear >> 6 & 1) * 8) * 2)));
+                            asm volatile("stmatrix.sync.aligned.m8n8.x4.shared.b16 [%0], {%1, %2, %3, %4};\n"
+                                :: "r"(_stmatrix_addr_0), "r"(*reinterpret_cast<const uint32_t*>(&lpow_words3[0])), "r"(*reinterpret_cast<const uint32_t*>(&lpow_words3[1])), "r"(*reinterpret_cast<const uint32_t*>(&lpow_words3[2])), "r"(*reinterpret_cast<const uint32_t*>(&lpow_words3[3]))
+                                : "memory");
+                            __syncwarp();
+                            int load_row3 = lane % 16;
+                            #pragma unroll
+                            for (int n_half3 = 0; n_half3 < 2; n_half3++) {
+                                int load_col3 = n_half3 * 8;
+                                int linear_0 = load_row3 * 16 + load_col3;
+                                asm volatile("ldmatrix.sync.aligned.m8n8.x2.trans.shared.b16 {%0, %1}, [%2];\n"
+                                    : "=r"(lpow_trans3[n_half3 * 2]), "=r"(lpow_trans3[n_half3 * 2 + 1])
+                                    : "r"(tinv_scratch_addr + (unsigned int)((linear_0 ^ (linear_0 >> 6 & 1) * 8) * 2))
+                                    : "memory");
+                            }
+                            #pragma unroll
+                            for (int neumann_round3 = 0; neumann_round3 < 3; neumann_round3++) {
+                                float square_acc3[8];
+                                asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%10, %11, %12, %13};\n"
+                                    : "=f"(square_acc3[0]), "=f"(square_acc3[1]), "=f"(square_acc3[2]), "=f"(square_acc3[3])
+                                    : "r"(lpow_words3[0]), "r"(lpow_words3[1]), "r"(lpow_words3[2]), "r"(lpow_words3[3]), "r"(lpow_trans3[0]), "r"(lpow_trans3[1]), "f"(0.0f), "f"(0.0f), "f"(0.0f), "f"(0.0f));
+                                asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%10, %11, %12, %13};\n"
+                                    : "=f"(square_acc3[4]), "=f"(square_acc3[(4) + 1]), "=f"(square_acc3[(4) + 2]), "=f"(square_acc3[(4) + 3])
+                                    : "r"(lpow_words3[0]), "r"(lpow_words3[1]), "r"(lpow_words3[2]), "r"(lpow_words3[3]), "r"(lpow_trans3[2]), "r"(lpow_trans3[(2) + 1]), "f"(0.0f), "f"(0.0f), "f"(0.0f), "f"(0.0f));
+                                #pragma unroll
+                                for (int _lp = 0; _lp < 4; _lp++) {
+                                    __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(square_acc3[_lp*2 + 0], square_acc3[_lp*2+1 + 0]));
+                                    lpow_words3[_lp] = *(uint32_t*)&_bf2;
+                                }
+                                int store_row3_0 = lane % 16;
+                                int store_col3_1 = lane / 16 * 8;
+                                int linear_2 = store_row3_0 * 16 + store_col3_1;
+                                uint32_t _stmatrix_addr_1 = static_cast<uint32_t>((unsigned long long)(tinv_scratch_addr + (unsigned int)((linear_2 ^ (linear_2 >> 6 & 1) * 8) * 2)));
+                                asm volatile("stmatrix.sync.aligned.m8n8.x4.shared.b16 [%0], {%1, %2, %3, %4};\n"
+                                    :: "r"(_stmatrix_addr_1), "r"(*reinterpret_cast<const uint32_t*>(&lpow_words3[0])), "r"(*reinterpret_cast<const uint32_t*>(&lpow_words3[1])), "r"(*reinterpret_cast<const uint32_t*>(&lpow_words3[2])), "r"(*reinterpret_cast<const uint32_t*>(&lpow_words3[3]))
+                                    : "memory");
+                                __syncwarp();
+                                int load_row3_3 = lane % 16;
+                                #pragma unroll
+                                for (int n_half3_1 = 0; n_half3_1 < 2; n_half3_1++) {
+                                    int load_col3_1 = n_half3_1 * 8;
+                                    int linear_0_1 = load_row3_3 * 16 + load_col3_1;
+                                    asm volatile("ldmatrix.sync.aligned.m8n8.x2.trans.shared.b16 {%0, %1}, [%2];\n"
+                                        : "=r"(lpow_trans3[n_half3_1 * 2]), "=r"(lpow_trans3[n_half3_1 * 2 + 1])
+                                        : "r"(tinv_scratch_addr + (unsigned int)((linear_0_1 ^ (linear_0_1 >> 6 & 1) * 8) * 2))
+                                        : "memory");
+                                }
+                                unsigned int tinv_words3[4];
+                                #pragma unroll
+                                for (int _lp = 0; _lp < 4; _lp++) {
+                                    __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(tinv_acc3[_lp*2 + 0], tinv_acc3[_lp*2+1 + 0]));
+                                    tinv_words3[_lp] = *(uint32_t*)&_bf2;
+                                }
+                                float update_acc3[8];
+                                asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%10, %11, %12, %13};\n"
+                                    : "=f"(update_acc3[0]), "=f"(update_acc3[1]), "=f"(update_acc3[2]), "=f"(update_acc3[3])
+                                    : "r"(tinv_words3[0]), "r"(tinv_words3[1]), "r"(tinv_words3[2]), "r"(tinv_words3[3]), "r"(lpow_trans3[0]), "r"(lpow_trans3[1]), "f"(0.0f), "f"(0.0f), "f"(0.0f), "f"(0.0f));
+                                asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%10, %11, %12, %13};\n"
+                                    : "=f"(update_acc3[4]), "=f"(update_acc3[(4) + 1]), "=f"(update_acc3[(4) + 2]), "=f"(update_acc3[(4) + 3])
+                                    : "r"(tinv_words3[0]), "r"(tinv_words3[1]), "r"(tinv_words3[2]), "r"(tinv_words3[3]), "r"(lpow_trans3[2]), "r"(lpow_trans3[(2) + 1]), "f"(0.0f), "f"(0.0f), "f"(0.0f), "f"(0.0f));
+                                float tinv_words3_f32[8];
+                                #pragma unroll
+                                for (int _pair = 0; _pair < 4; _pair++) {
+                                    asm volatile(
+                                        "{\n\t"
+                                        "shl.b32 %0, %2, 16;\n\t"
+                                        "and.b32 %1, %2, 0xffff0000;\n\t"
+                                        "}\n"
+                                        : "=f"((&tinv_words3_f32[_pair * 2])[0]), "=f"((&tinv_words3_f32[_pair * 2])[1])
+                                        : "r"(tinv_words3[_pair]));
+                                }
+                                #pragma unroll
+                                for (int accum_u3 = 0; accum_u3 < 8; accum_u3++) {
+                                    tinv_acc3[accum_u3] = tinv_words3_f32[accum_u3] + update_acc3[accum_u3];
+                                }
+                            }
+                            #pragma unroll
+                            for (int accum_s3 = 0; accum_s3 < 8; accum_s3++) {
+                                tinv_sum3[accum_s3] = tinv_sum3[accum_s3] + tinv_acc3[accum_s3];
+                            }
+                            unsigned int tinv_publish_words3[4];
+                            #pragma unroll
+                            for (int _lp = 0; _lp < 4; _lp++) {
+                                __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(tinv_acc3[_lp*2 + 0], tinv_acc3[_lp*2+1 + 0]));
+                                tinv_publish_words3[_lp] = *(uint32_t*)&_bf2;
+                            }
+                            int publish_row3 = lane % 16;
+                            int publish_col3 = lane / 16 * 8;
+                            uint32_t _stmatrix_addr_2 = static_cast<uint32_t>((unsigned long long)(intermediate_tinv_addr + intermediate_stage3 * 2560 + (unsigned int)(publish_col3 / 16 * 512 + publish_row3 * 32 + publish_col3 % 16 * 2 ^ (publish_col3 / 16 * 512 + publish_row3 * 32 + publish_col3 % 16 * 2 >> 7 & 1) << 4)));
+                            asm volatile("stmatrix.sync.aligned.m8n8.x4.shared.b16 [%0], {%1, %2, %3, %4};\n"
+                                :: "r"(_stmatrix_addr_2), "r"(*reinterpret_cast<const uint32_t*>(&tinv_publish_words3[0])), "r"(*reinterpret_cast<const uint32_t*>(&tinv_publish_words3[1])), "r"(*reinterpret_cast<const uint32_t*>(&tinv_publish_words3[2])), "r"(*reinterpret_cast<const uint32_t*>(&tinv_publish_words3[3]))
+                                : "memory");
+                        }
+                    }
+                    asm volatile("fence.proxy.async.shared::cta;" ::: "memory");
+                    mbarrier_arrive(tinv_ready_addr + (intermediate_stage3) * 8);
+                    mbarrier_wait(u_smem_ready_addr + (u_smem_stage3) * 8, _phase_u_smem_ready);
+                    mbarrier_wait(dy_smem_ready_addr + (dy_smem_stage3) * 8, _phase_dy_smem_ready);
+                    float dm_acc3[8];
+                    #pragma unroll
+                    for (int k_block_dm3 = 0; k_block_dm3 < 8; k_block_dm3++) {
+                        int a_col_dm3 = k_block_dm3 * 16 + lhs_col_offset3;
+                        int b_col_dm3 = k_block_dm3 * 16 + rhs_col_offset3;
+                        unsigned int dy_frag3[4];
+                        unsigned int u_frag3[4];
+                        int segment_10 = a_col_dm3 / 64;
+                        int segment_col_11 = a_col_dm3 - segment_10 * 64;
+                        int swizzled_col_10 = segment_col_11 ^ (lhs_row3 & 7) * 8;
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(dy_frag3[0]), "=r"(dy_frag3[1]), "=r"(dy_frag3[2]), "=r"(dy_frag3[3])
+                            : "r"(dy_smem_all_addr + (unsigned int)((segment_10 * 16 * 64 + lhs_row3 * 64 + swizzled_col_10) * 2))
+                            : "memory");
+                        int segment_0_4 = b_col_dm3 / 64;
+                        int segment_col_1_4 = b_col_dm3 - segment_0_4 * 64;
+                        int swizzled_col_2_4 = segment_col_1_4 ^ (rhs_row3 & 7) * 8;
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(u_frag3[0]), "=r"(u_frag3[1]), "=r"(u_frag3[2]), "=r"(u_frag3[3])
+                            : "r"(u_smem_addr + (unsigned int)((segment_0_4 * 16 * 64 + rhs_row3 * 64 + swizzled_col_2_4) * 2))
+                            : "memory");
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%10, %11, %12, %13};\n"
+                            : "=f"(dm_acc3[0]), "=f"(dm_acc3[1]), "=f"(dm_acc3[2]), "=f"(dm_acc3[3])
+                            : "r"(dy_frag3[0]), "r"(dy_frag3[1]), "r"(dy_frag3[2]), "r"(dy_frag3[3]), "r"(u_frag3[0]), "r"(u_frag3[1]), "f"(((k_block_dm3 == 0) ? 0.0f : dm_acc3[0])), "f"(((k_block_dm3 == 0) ? 0.0f : dm_acc3[1])), "f"(((k_block_dm3 == 0) ? 0.0f : dm_acc3[2])), "f"(((k_block_dm3 == 0) ? 0.0f : dm_acc3[3])));
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%10, %11, %12, %13};\n"
+                            : "=f"(dm_acc3[4]), "=f"(dm_acc3[(4) + 1]), "=f"(dm_acc3[(4) + 2]), "=f"(dm_acc3[(4) + 3])
+                            : "r"(dy_frag3[0]), "r"(dy_frag3[1]), "r"(dy_frag3[2]), "r"(dy_frag3[3]), "r"(u_frag3[2]), "r"(u_frag3[(2) + 1]), "f"(((k_block_dm3 == 0) ? 0.0f : dm_acc3[4])), "f"(((k_block_dm3 == 0) ? 0.0f : dm_acc3[(4) + 1])), "f"(((k_block_dm3 == 0) ? 0.0f : dm_acc3[(4) + 2])), "f"(((k_block_dm3 == 0) ? 0.0f : dm_acc3[(4) + 3])));
+                    }
+                    float dm_strict3[8];
+                    float ndm_strict3[8];
+                    #pragma unroll
+                    for (int accum_dm3 = 0; accum_dm3 < 8; accum_dm3++) {
+                        int dm_row3 = lane / 4 + accum_dm3 % 4 / 2 * 8;
+                        int dm_col3 = accum_dm3 / 4 * 8 + (lane & 3) * 2 + (accum_dm3 & 1);
+                        dm_strict3[accum_dm3] = 0.0f;
+                        if (dm_row3 > dm_col3) {
+                            float beta_dm_scale3 = beta_lo3;
+                            if (accum_dm3 % 4 >= 2) {
+                                beta_dm_scale3 = beta_hi3;
+                            }
+                            dm_strict3[accum_dm3] = dm_acc3[accum_dm3] * beta_dm_scale3;
+                        }
+                        ndm_strict3[accum_dm3] = -dm_strict3[accum_dm3];
+                    }
+                    unsigned int dm_words3[4];
+                    unsigned int ndm_words3[4];
+                    #pragma unroll
+                    for (int _lp = 0; _lp < 4; _lp++) {
+                        __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(dm_strict3[_lp*2 + 0], dm_strict3[_lp*2+1 + 0]));
+                        dm_words3[_lp] = *(uint32_t*)&_bf2;
+                    }
+                    #pragma unroll
+                    for (int _lp = 0; _lp < 4; _lp++) {
+                        __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(ndm_strict3[_lp*2 + 0], ndm_strict3[_lp*2+1 + 0]));
+                        ndm_words3[_lp] = *(uint32_t*)&_bf2;
+                    }
+                    int dm_publish_row3 = lane % 16;
+                    int dm_publish_col3 = lane / 16 * 8;
+                    uint32_t _stmatrix_addr_3 = static_cast<uint32_t>((unsigned long long)(intermediate_dm_addr + intermediate_stage3 * 2560 + (unsigned int)(dm_publish_col3 / 16 * 512 + dm_publish_row3 * 32 + dm_publish_col3 % 16 * 2 ^ (dm_publish_col3 / 16 * 512 + dm_publish_row3 * 32 + dm_publish_col3 % 16 * 2 >> 7 & 1) << 4)));
+                    asm volatile("stmatrix.sync.aligned.m8n8.x4.shared.b16 [%0], {%1, %2, %3, %4};\n"
+                        :: "r"(_stmatrix_addr_3), "r"(*reinterpret_cast<const uint32_t*>(&dm_words3[0])), "r"(*reinterpret_cast<const uint32_t*>(&dm_words3[1])), "r"(*reinterpret_cast<const uint32_t*>(&dm_words3[2])), "r"(*reinterpret_cast<const uint32_t*>(&dm_words3[3]))
+                        : "memory");
+                    uint32_t _stmatrix_addr_4 = static_cast<uint32_t>((unsigned long long)(intermediate_ndm_addr + intermediate_stage3 * 2560 + (unsigned int)(dm_publish_col3 / 16 * 512 + dm_publish_row3 * 32 + dm_publish_col3 % 16 * 2 ^ (dm_publish_col3 / 16 * 512 + dm_publish_row3 * 32 + dm_publish_col3 % 16 * 2 >> 7 & 1) << 4)));
+                    asm volatile("stmatrix.sync.aligned.m8n8.x4.shared.b16 [%0], {%1, %2, %3, %4};\n"
+                        :: "r"(_stmatrix_addr_4), "r"(*reinterpret_cast<const uint32_t*>(&ndm_words3[0])), "r"(*reinterpret_cast<const uint32_t*>(&ndm_words3[1])), "r"(*reinterpret_cast<const uint32_t*>(&ndm_words3[2])), "r"(*reinterpret_cast<const uint32_t*>(&ndm_words3[3]))
+                        : "memory");
+                    asm volatile("fence.proxy.async.shared::cta;" ::: "memory");
+                    mbarrier_arrive(dm_ready_addr + (intermediate_stage3) * 8);
+                    float dbeta_m_lo3 = 0.0f;
+                    float dbeta_m_hi3 = 0.0f;
+                    #pragma unroll
+                    for (int dbeta_accum3 = 0; dbeta_accum3 < 8; dbeta_accum3++) {
+                        int dbeta_row3 = lane / 4 + dbeta_accum3 % 4 / 2 * 8;
+                        int dbeta_col3 = dbeta_accum3 / 4 * 8 + (lane & 3) * 2 + (dbeta_accum3 & 1);
+                        float dbeta_m_part3 = 0.0f;
+                        if (dbeta_row3 > dbeta_col3) {
+                            dbeta_m_part3 = dm_acc3[dbeta_accum3] * kk_acc3[dbeta_accum3];
+                        }
+                        if (dbeta_accum3 % 4 < 2) {
+                            dbeta_m_lo3 += dbeta_m_part3;
+                        } else {
+                            dbeta_m_hi3 += dbeta_m_part3;
+                        }
+                    }
+                    float _shfl_xor_13 = __shfl_xor_sync(0xFFFFFFFF, dbeta_m_lo3, 1);
+                    dbeta_m_lo3 += _shfl_xor_13;
+                    float _shfl_xor_14 = __shfl_xor_sync(0xFFFFFFFF, dbeta_m_lo3, 2);
+                    dbeta_m_lo3 += _shfl_xor_14;
+                    float _shfl_xor_15 = __shfl_xor_sync(0xFFFFFFFF, dbeta_m_hi3, 1);
+                    dbeta_m_hi3 += _shfl_xor_15;
+                    float _shfl_xor_16 = __shfl_xor_sync(0xFFFFFFFF, dbeta_m_hi3, 2);
+                    dbeta_m_hi3 += _shfl_xor_16;
+                    mbarrier_wait(dbeta_m_done_addr + (dbeta_m_stage3) * 8, _phase_dbeta_m_done);
+                    if (lane % 4 == 0) {
+                        dbeta_m_smem[beta_row_lo3] = -dbeta_m_lo3;
+                        dbeta_m_smem[beta_row_hi3] = -dbeta_m_hi3;
+                    }
+                    asm volatile("fence.proxy.async.shared::cta;" ::: "memory");
+                    if (elect_sync()) {
+                        mbarrier_arrive(dbeta_m_ready_addr + (dbeta_m_stage3) * 8);
+                    }
+                    dbeta_m_stage3 += 1;
+                    if (dbeta_m_stage3 == 1) { dbeta_m_stage3 = 0; _phase_dbeta_m_done ^= 1; }
+                    raw_stage3 += 1;
+                    if (raw_stage3 == 2) { raw_stage3 = 0; _phase_raw_ready_2 ^= 1; }
+                    operand_stage3 += 1;
+                    if (operand_stage3 == 2) { operand_stage3 = 0; _phase_k_decay_inv_ready ^= 1; }
+                    intermediate_stage3 += 1;
+                    if (intermediate_stage3 == 2) { intermediate_stage3 = 0; _phase_intermediate_done ^= 1; }
+                    u_smem_stage3 += 1;
+                    if (u_smem_stage3 == 1) { u_smem_stage3 = 0; _phase_u_smem_ready ^= 1; }
+                    dy_smem_stage3 += 1;
+                    if (dy_smem_stage3 == 1) { dy_smem_stage3 = 0; _phase_dy_smem_ready ^= 1; }
+                }
+                if (validate_outputs != 0 && enable_kk != 0) {
+                    int row_lo3 = lane / 4;
+                    int col_pair3 = (lane & 3) * 2;
+                    #pragma unroll
+                    for (int accum4 = 0; accum4 < 8; accum4++) {
+                        int output_row3 = row_lo3 + accum4 % 4 / 2 * 8;
+                        int output_col3 = accum4 / 4 * 8 + col_pair3 + (accum4 & 1);
+                        kk_observed[(long long)tile3 * 16 * 16 + (long long)output_row3 * 16 + (long long)output_col3] = kk_sum3[accum4];
+                        if (enable_tinv != 0) {
+                            tinv_observed[(long long)tile3 * 16 * 16 + (long long)output_row3 * 16 + (long long)output_col3] = tinv_sum3[accum4];
+                        }
+                    }
+                }
+            }
+            if (elect_sync()) {
+                mbarrier_arrive(consumers_done_addr);
+            }
+        }
+    }
+    // ---- Role: tcgen ----
+    if (warp == 13) {
+        { // tcgen_main
+            float tmem_seed[1];
+            tmem_seed[0] = 0.0f;
+            asm volatile(
+                "tcgen05.st.sync.aligned.32x32b.x1.b32"
+                " [%0], {%1};"
+                :: "r"(taddr), "r"(*reinterpret_cast<const uint32_t*>(&tmem_seed[0]))
+                : "memory");
+            asm volatile("tcgen05.wait::st.sync.aligned;" ::: "memory");
+            unsigned int sched_stage4 = 0;
+            unsigned int raw_stage4 = 0;
+            unsigned int state_smem_stage4 = 0;
+            unsigned int operand_stage4 = 0;
+            unsigned int intermediate_stage4 = 0;
+            unsigned int tcgen_data_stage4 = 0;
+            unsigned int dstate_recurrence_stage4 = 0;
+            unsigned int u_smem_stage4 = 0;
+            unsigned int dstate_smem_stage4 = 0;
+            unsigned int dk_restore_stage4 = 0;
+            unsigned int local_grad_stage4 = 0;
+            unsigned int beta_dy_smem_stage4 = 0;
+            unsigned int boundary_stage4 = 0;
+            unsigned int boundary_local_grad_stage4 = 0;
+            unsigned int _phase_sched_ready_4 = 0;
+            unsigned int _phase_dstate_done = 1;
+            unsigned int _phase_local_grad_done = 1;
+            unsigned int _phase_k_decay_inv_ready_1 = 0;
+            unsigned int _phase_state_k_done = 1;
+            unsigned int _phase_state_ready_1 = 0;
+            unsigned int _phase_raw_ready_3 = 0;
+            unsigned int _phase_q_decay_k_restore_ready = 0;
+            unsigned int _phase_tinv_ready = 0;
+            unsigned int _phase_a_ready = 0;
+            unsigned int _phase_tcgen_inputs_ready = 0;
+            unsigned int _phase_tcgen_products_done = 1;
+            unsigned int _phase_dy_done = 1;
+            unsigned int _phase_dstate_inp_ready = 0;
+            unsigned int _phase_tcgen_products_ready_1 = 0;
+            unsigned int _phase_du_inp_ready = 0;
+            unsigned int _phase_u_smem_ready_1 = 0;
+            unsigned int _phase_dstate_smem_ready = 0;
+            unsigned int _phase_dk_restore_done = 1;
+            unsigned int _phase_dy_ready_1 = 0;
+            unsigned int _phase_neg_dy_ready = 0;
+            unsigned int _phase_dstate_ready_1 = 0;
+            unsigned int _phase_beta_dy_smem_ready = 0;
+            unsigned int _phase_da_ready = 0;
+            unsigned int _phase_dm_ready = 0;
+            unsigned int _phase_boundary_smem_ready = 0;
+            unsigned int _phase_boundary_local_grad_free = 0;
+            #pragma unroll 1
+            for (int __4 = 0; __4 < total_work_items; __4++) {
+                mbarrier_wait(sched_ready_addr + (sched_stage4) * 8, _phase_sched_ready_4);
+                unsigned int ticket_words_4[1];
+                asm volatile("ld.shared.b32 %0, [%1];" : "=r"(*reinterpret_cast<uint32_t*>(&ticket_words_4[0])) : "r"(work_item_addr + sched_stage4 * 4));
+                unsigned int tile4 = ticket_words_4[0];
+                if (elect_sync()) {
+                    mbarrier_arrive(sched_done_addr + (sched_stage4) * 8);
+                }
+                sched_stage4 += 1;
+                if (sched_stage4 == 8) { sched_stage4 = 0; _phase_sched_ready_4 ^= 1; }
+                if (tile4 >= (unsigned int)total_work_items) {
+                    break;
+                }
+                int item_base4 = (int)tile4 * 5;
+                int write_start4 = work_items[item_base4 + 2];
+                int write_end4 = work_items[item_base4 + 3];
+                int compute_end4 = work_items[item_base4 + 4];
+                float operand_sums4[16];
+                operand_sums4[0] = 0.0f;
+                operand_sums4[1] = 0.0f;
+                operand_sums4[2] = 0.0f;
+                operand_sums4[3] = 0.0f;
+                operand_sums4[4] = 0.0f;
+                operand_sums4[5] = 0.0f;
+                operand_sums4[6] = 0.0f;
+                operand_sums4[7] = 0.0f;
+                operand_sums4[8] = 0.0f;
+                operand_sums4[9] = 0.0f;
+                operand_sums4[10] = 0.0f;
+                operand_sums4[11] = 0.0f;
+                operand_sums4[12] = 0.0f;
+                operand_sums4[13] = 0.0f;
+                operand_sums4[14] = 0.0f;
+                operand_sums4[15] = 0.0f;
+                #pragma unroll 1
+                for (int reverse4 = 0; reverse4 < compute_end4 - write_start4; reverse4++) {
+                    mbarrier_wait(dstate_done_addr + (tcgen_data_stage4) * 8, _phase_dstate_done);
+                    mbarrier_wait(local_grad_done_addr + (local_grad_stage4) * 8, _phase_local_grad_done);
+                    asm volatile("tcgen05.fence::after_thread_sync;");
+                    mbarrier_wait(k_decay_inv_ready_addr + (operand_stage4) * 8, _phase_k_decay_inv_ready_1);
+                    mbarrier_wait(state_k_done_addr + (state_smem_stage4) * 8, _phase_state_k_done);
+                    mbarrier_wait(state_ready_addr + (state_smem_stage4) * 8, _phase_state_ready_1);
+                    mbarrier_wait(raw_ready_addr + (raw_stage4) * 8, _phase_raw_ready_3);
+                    int _mma_a_lo_0 = make_warp_uniform((((state_operand_addr) >> 4) & 0x3FFF) + (state_smem_stage4) * 2048);
+                    int _mma_b_lo_0 = make_warp_uniform((((k_decay_lead16_addr) >> 4) & 0x3FFF) + (operand_stage4) * 256);
+                    asm volatile(
+                    "{\n\t"
+                    ".reg .pred leader, p0, p1;\n\t"
+                    ".reg .b32 adhi, bdhi, alo, blo, id;\n\t"
+                    ".reg .b64 da, db;\n\t"
+                    "elect.sync _|leader, 0xFFFFFFFF;\n\t"
+                    "setp.ne.b32 p0, %3, 0;\n\t"
+                    "setp.ne.b32 p1, 1, 0;\n\t"
+                    ""
+                    "mov.b32 adhi, 0x40004040;\n\t"
+                    "mov.b32 bdhi, 0x40004040;\n\t"
+                    "mov.b32 id, 134481040;\n\t"
+                    "mov.b32 alo, %0;\n\t"
+                    "mov.b32 blo, %1;\n\t"
+                    "mov.b64 da, {alo, adhi};\n\t"
+                    "mov.b64 db, {blo, bdhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%2], da, db, id, p0;\n\t"
+                    "add.u32 alo, alo, 2;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 da, {alo, adhi};\n\t"
+                    "mov.b64 db, {blo, bdhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%2], da, db, id, p1;\n\t"
+                    "add.u32 alo, alo, 2;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 da, {alo, adhi};\n\t"
+                    "mov.b64 db, {blo, bdhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%2], da, db, id, p1;\n\t"
+                    "add.u32 alo, alo, 2;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 da, {alo, adhi};\n\t"
+                    "mov.b64 db, {blo, bdhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%2], da, db, id, p1;\n\t"
+                    "add.u32 alo, alo, 1018;\n\t"
+                    "add.u32 blo, blo, 122;\n\t"
+                    "mov.b64 da, {alo, adhi};\n\t"
+                    "mov.b64 db, {blo, bdhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%2], da, db, id, p1;\n\t"
+                    "add.u32 alo, alo, 2;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 da, {alo, adhi};\n\t"
+                    "mov.b64 db, {blo, bdhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%2], da, db, id, p1;\n\t"
+                    "add.u32 alo, alo, 2;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 da, {alo, adhi};\n\t"
+                    "mov.b64 db, {blo, bdhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%2], da, db, id, p1;\n\t"
+                    "add.u32 alo, alo, 2;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 da, {alo, adhi};\n\t"
+                    "mov.b64 db, {blo, bdhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%2], da, db, id, p1;\n\t"
+                    "}\n"
+                    :: "r"(_mma_a_lo_0), "r"(_mma_b_lo_0), "r"(tmem_flashkda_bwd_persistent_c16_state_k), "r"(0));
+                    int _mma_a_lo_1 = make_warp_uniform(((((state_operand_mn_addr) >> 4) & 0x3FFF) | 0x4000000) + (state_smem_stage4) * 2048);
+                    int _mma_b_lo_1 = make_warp_uniform(((((raw_do_addr) >> 4) & 0x3FFF) | 0x800000) + (raw_stage4) * 256);
+                    asm volatile(
+                    "{\n\t"
+                    ".reg .pred leader, p0, p1;\n\t"
+                    ".reg .b32 adhi, bdhi, alo, blo, id;\n\t"
+                    ".reg .b64 da, db;\n\t"
+                    "elect.sync _|leader, 0xFFFFFFFF;\n\t"
+                    "setp.ne.b32 p0, %3, 0;\n\t"
+                    "setp.ne.b32 p1, 1, 0;\n\t"
+                    ""
+                    "mov.b32 adhi, 0x40004040;\n\t"
+                    "mov.b32 bdhi, 0x40004040;\n\t"
+                    "mov.b32 id, 134513808;\n\t"
+                    "mov.b32 alo, %0;\n\t"
+                    "mov.b32 blo, %1;\n\t"
+                    "mov.b64 da, {alo, adhi};\n\t"
+                    "mov.b64 db, {blo, bdhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%2], da, db, id, p0;\n\t"
+                    "add.u32 alo, alo, 128;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 da, {alo, adhi};\n\t"
+                    "mov.b64 db, {blo, bdhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%2], da, db, id, p1;\n\t"
+                    "add.u32 alo, alo, 128;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 da, {alo, adhi};\n\t"
+                    "mov.b64 db, {blo, bdhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%2], da, db, id, p1;\n\t"
+                    "add.u32 alo, alo, 128;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 da, {alo, adhi};\n\t"
+                    "mov.b64 db, {blo, bdhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%2], da, db, id, p1;\n\t"
+                    "add.u32 alo, alo, 128;\n\t"
+                    "add.u32 blo, blo, 122;\n\t"
+                    "mov.b64 da, {alo, adhi};\n\t"
+                    "mov.b64 db, {blo, bdhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%2], da, db, id, p1;\n\t"
+                    "add.u32 alo, alo, 128;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 da, {alo, adhi};\n\t"
+                    "mov.b64 db, {blo, bdhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%2], da, db, id, p1;\n\t"
+                    "add.u32 alo, alo, 128;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 da, {alo, adhi};\n\t"
+                    "mov.b64 db, {blo, bdhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%2], da, db, id, p1;\n\t"
+                    "add.u32 alo, alo, 128;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 da, {alo, adhi};\n\t"
+                    "mov.b64 db, {blo, bdhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%2], da, db, id, p1;\n\t"
+                    "}\n"
+                    :: "r"(_mma_a_lo_1), "r"(_mma_b_lo_1), "r"(tmem_flashkda_bwd_persistent_c16_dq), "r"(0));
+                    elect_commit(state_k_ready_addr + (state_smem_stage4) * 8);
+                    mbarrier_wait(q_decay_k_restore_ready_addr + (operand_stage4) * 8, _phase_q_decay_k_restore_ready);
+                    mbarrier_wait(tinv_ready_addr + (intermediate_stage4) * 8, _phase_tinv_ready);
+                    mbarrier_wait(a_ready_addr + (intermediate_stage4) * 8, _phase_a_ready);
+                    mbarrier_wait(tcgen_inputs_ready_addr + (tcgen_data_stage4) * 8, _phase_tcgen_inputs_ready);
+                    mbarrier_wait(tcgen_products_done_addr + (tcgen_data_stage4) * 8, _phase_tcgen_products_done);
+                    mbarrier_wait(dy_done_addr + (tcgen_data_stage4) * 8, _phase_dy_done);
+                    mbarrier_wait(dstate_inp_ready_addr + (dstate_recurrence_stage4) * 8, _phase_dstate_inp_ready);
+                    if (USE_DSTATE_IN != 0 || reverse4 > 0) {
+                        #pragma unroll
+                        for (int dstate_block4 = 0; dstate_block4 < 8; dstate_block4++) {
+                            int _mma_b_lo_2 = make_warp_uniform((((state_scale_diag_addr) >> 4) & 0x3FFF) + ((int)operand_stage4 * 8 + dstate_block4) * 32);
+                            mma_ts_step((tmem_flashkda_bwd_persistent_c16_dstate + (dstate_block4 * 16)), tmem_flashkda_bwd_persistent_c16_dstate_inp + dstate_block4 * 8, _mma_b_lo_2, 0xC0004010, 134481040, 0);
+                        }
+                        int _mma_b_lo_3 = make_warp_uniform((((k_restore_lead16_addr) >> 4) & 0x3FFF) + (operand_stage4) * 256);
+                        asm volatile(
+                    "{\n\t"
+                    ".reg .pred leader, p0, p1;\n\t"
+                    ".reg .b32 dhi, blo, ta, id;\n\t"
+                    ".reg .b64 db;\n\t"
+                    "elect.sync _|leader, 0xFFFFFFFF;\n\t"
+                    "setp.ne.b32 p0, %3, 0;\n\t"
+                    "setp.ne.b32 p1, 1, 0;\n\t"
+                    ""
+                    "mov.b32 dhi, 0x40004040;\n\t"
+                    "mov.b32 id, 134481040;\n\t"
+                    "mov.b32 ta, %2;\n\t"
+                    "mov.b32 blo, %1;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p0;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 122;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "}\n"
+                    :: "r"(tmem_flashkda_bwd_persistent_c16_du), "r"(_mma_b_lo_3), "r"(tmem_flashkda_bwd_persistent_c16_dstate_inp), "r"(0));
+                    }
+                    dstate_recurrence_stage4 += 1;
+                    if (dstate_recurrence_stage4 == 1) { dstate_recurrence_stage4 = 0; _phase_dstate_inp_ready ^= 1; }
+                    int _mma_b_lo_4 = make_warp_uniform(((((q_decay_trans_addr) >> 4) & 0x3FFF) | 0x800000) + (operand_stage4) * 256);
+                    mma_ts_step(tmem_flashkda_bwd_persistent_c16_dstate, tmem_flashkda_bwd_persistent_c16_do_inp, _mma_b_lo_4, 0x40004040, 136381584, ((reverse4 == 0 && USE_DSTATE_IN == 0) ? 0 : 1));
+                    int _mma_b_lo_5 = make_warp_uniform((((intermediate_tinv_addr) >> 4) & 0x3FFF) + (intermediate_stage4) * 160);
+                    mma_ts_step(tmem_flashkda_bwd_persistent_c16_u, tmem_flashkda_bwd_persistent_c16_y, _mma_b_lo_5, 0xC0004010, 134481040, 0);
+                    int _mma_a_lo_6 = make_warp_uniform(((((raw_do_amaj_addr) >> 4) & 0x3FFF) | 0x800000) + (raw_stage4) * 256);
+                    int _mma_b_lo_6 = make_warp_uniform(((((intermediate_a_mn_addr) >> 4) & 0x3FFF) | 0x200000) + (intermediate_stage4) * 160);
+                    asm volatile(
+                    "{\n\t"
+                    ".reg .pred leader, p0, p1;\n\t"
+                    ".reg .b32 adhi, bdhi, alo, blo, id;\n\t"
+                    ".reg .b64 da, db;\n\t"
+                    "elect.sync _|leader, 0xFFFFFFFF;\n\t"
+                    "setp.ne.b32 p0, %3, 0;\n\t"
+                    "setp.ne.b32 p1, 1, 0;\n\t"
+                    ""
+                    "mov.b32 adhi, 0x40004040;\n\t"
+                    "mov.b32 bdhi, 0xC0004010;\n\t"
+                    "mov.b32 id, 134579344;\n\t"
+                    "mov.b32 alo, %0;\n\t"
+                    "mov.b32 blo, %1;\n\t"
+                    "mov.b64 da, {alo, adhi};\n\t"
+                    "mov.b64 db, {blo, bdhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%2], da, db, id, p0;\n\t"
+                    "}\n"
+                    :: "r"(_mma_a_lo_6), "r"(_mma_b_lo_6), "r"(tmem_flashkda_bwd_persistent_c16_du), "r"(((reverse4 == 0 && USE_DSTATE_IN == 0) ? 0 : 1)));
+                    elect_commit(tcgen_products_ready_addr + (tcgen_data_stage4) * 8);
+                    mbarrier_wait(tcgen_products_ready_addr + (tcgen_data_stage4) * 8, _phase_tcgen_products_ready_1);
+                    mbarrier_wait(du_inp_ready_addr + (tcgen_data_stage4) * 8, _phase_du_inp_ready);
+                    int _mma_b_lo_7 = make_warp_uniform(((((intermediate_tinv_mn_addr) >> 4) & 0x3FFF) | 0x200000) + (intermediate_stage4) * 160);
+                    mma_ts_step(tmem_flashkda_bwd_persistent_c16_dy, tmem_flashkda_bwd_persistent_c16_du_inp, _mma_b_lo_7, 0xC0004010, 134546576, 0);
+                    elect_commit(dy_ready_addr + (tcgen_data_stage4) * 8);
+                    mbarrier_wait(u_smem_ready_addr + (u_smem_stage4) * 8, _phase_u_smem_ready_1);
+                    if (USE_DSTATE_IN != 0 || reverse4 > 0) {
+                        mbarrier_wait(dstate_smem_ready_addr + (dstate_smem_stage4) * 8, _phase_dstate_smem_ready);
+                        mbarrier_wait(dk_restore_done_addr + (dk_restore_stage4) * 8, _phase_dk_restore_done);
+                        int _mma_a_lo_8 = make_warp_uniform((((dstate_smem_mn_addr) >> 4) & 0x3FFF) | 0x4000000);
+                        int _mma_b_lo_8 = make_warp_uniform((((u_lead16_addr) >> 4) & 0x3FFF) | 0x800000);
+                        asm volatile(
+                    "{\n\t"
+                    ".reg .pred leader, p0, p1;\n\t"
+                    ".reg .b32 adhi, bdhi, alo, blo, id;\n\t"
+                    ".reg .b64 da, db;\n\t"
+                    "elect.sync _|leader, 0xFFFFFFFF;\n\t"
+                    "setp.ne.b32 p0, %3, 0;\n\t"
+                    "setp.ne.b32 p1, 1, 0;\n\t"
+                    ""
+                    "mov.b32 adhi, 0x40004040;\n\t"
+                    "mov.b32 bdhi, 0x40004040;\n\t"
+                    "mov.b32 id, 134513808;\n\t"
+                    "mov.b32 alo, %0;\n\t"
+                    "mov.b32 blo, %1;\n\t"
+                    "mov.b64 da, {alo, adhi};\n\t"
+                    "mov.b64 db, {blo, bdhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%2], da, db, id, p0;\n\t"
+                    "add.u32 alo, alo, 128;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 da, {alo, adhi};\n\t"
+                    "mov.b64 db, {blo, bdhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%2], da, db, id, p1;\n\t"
+                    "add.u32 alo, alo, 128;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 da, {alo, adhi};\n\t"
+                    "mov.b64 db, {blo, bdhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%2], da, db, id, p1;\n\t"
+                    "add.u32 alo, alo, 128;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 da, {alo, adhi};\n\t"
+                    "mov.b64 db, {blo, bdhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%2], da, db, id, p1;\n\t"
+                    "add.u32 alo, alo, 128;\n\t"
+                    "add.u32 blo, blo, 122;\n\t"
+                    "mov.b64 da, {alo, adhi};\n\t"
+                    "mov.b64 db, {blo, bdhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%2], da, db, id, p1;\n\t"
+                    "add.u32 alo, alo, 128;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 da, {alo, adhi};\n\t"
+                    "mov.b64 db, {blo, bdhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%2], da, db, id, p1;\n\t"
+                    "add.u32 alo, alo, 128;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 da, {alo, adhi};\n\t"
+                    "mov.b64 db, {blo, bdhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%2], da, db, id, p1;\n\t"
+                    "add.u32 alo, alo, 128;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 da, {alo, adhi};\n\t"
+                    "mov.b64 db, {blo, bdhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%2], da, db, id, p1;\n\t"
+                    "}\n"
+                    :: "r"(_mma_a_lo_8), "r"(_mma_b_lo_8), "r"(tmem_flashkda_bwd_persistent_c16_dk_restore), "r"(0));
+                        elect_commit2(dk_restore_ready_addr + (dk_restore_stage4) * 8, dstate_smem_done_addr + (dstate_smem_stage4) * 8);
+                        dstate_smem_stage4 += 1;
+                        if (dstate_smem_stage4 == 1) { dstate_smem_stage4 = 0; _phase_dstate_smem_ready ^= 1; }
+                        dk_restore_stage4 += 1;
+                        if (dk_restore_stage4 == 1) { dk_restore_stage4 = 0; _phase_dk_restore_done ^= 1; }
+                    }
+                    u_smem_stage4 += 1;
+                    if (u_smem_stage4 == 1) { u_smem_stage4 = 0; _phase_u_smem_ready_1 ^= 1; }
+                    mbarrier_wait(dy_ready_addr + (tcgen_data_stage4) * 8, _phase_dy_ready_1);
+                    mbarrier_wait(neg_dy_ready_addr + (tcgen_data_stage4) * 8, _phase_neg_dy_ready);
+                    int _mma_b_lo_9 = make_warp_uniform(((((k_decay_trans_addr) >> 4) & 0x3FFF) | 0x800000) + (operand_stage4) * 256);
+                    mma_ts_step(tmem_flashkda_bwd_persistent_c16_dstate, tmem_flashkda_bwd_persistent_c16_neg_dy, _mma_b_lo_9, 0x40004040, 136381584, 1);
+                    elect_commit(dstate_ready_addr + (tcgen_data_stage4) * 8);
+                    mbarrier_wait(dstate_ready_addr + (tcgen_data_stage4) * 8, _phase_dstate_ready_1);
+                    mbarrier_wait(beta_dy_smem_ready_addr + (beta_dy_smem_stage4) * 8, _phase_beta_dy_smem_ready);
+                    int _mma_a_lo_10 = make_warp_uniform((((state_operand_addr) >> 4) & 0x3FFF) + (state_smem_stage4) * 2048);
+                    int _mma_b_lo_10 = make_warp_uniform((((beta_dy_smem_addr) >> 4) & 0x3FFF) + (beta_dy_smem_stage4) * 256);
+                    asm volatile(
+                    "{\n\t"
+                    ".reg .pred leader, p0, p1;\n\t"
+                    ".reg .b32 adhi, bdhi, alo, blo, id;\n\t"
+                    ".reg .b64 da, db;\n\t"
+                    "elect.sync _|leader, 0xFFFFFFFF;\n\t"
+                    "setp.ne.b32 p0, %3, 0;\n\t"
+                    "setp.ne.b32 p1, 1, 0;\n\t"
+                    ""
+                    "mov.b32 adhi, 0x40004040;\n\t"
+                    "mov.b32 bdhi, 0x40004040;\n\t"
+                    "mov.b32 id, 134481040;\n\t"
+                    "mov.b32 alo, %0;\n\t"
+                    "mov.b32 blo, %1;\n\t"
+                    "mov.b64 da, {alo, adhi};\n\t"
+                    "mov.b64 db, {blo, bdhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%2], da, db, id, p0;\n\t"
+                    "add.u32 alo, alo, 2;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 da, {alo, adhi};\n\t"
+                    "mov.b64 db, {blo, bdhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%2], da, db, id, p1;\n\t"
+                    "add.u32 alo, alo, 2;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 da, {alo, adhi};\n\t"
+                    "mov.b64 db, {blo, bdhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%2], da, db, id, p1;\n\t"
+                    "add.u32 alo, alo, 2;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 da, {alo, adhi};\n\t"
+                    "mov.b64 db, {blo, bdhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%2], da, db, id, p1;\n\t"
+                    "add.u32 alo, alo, 1018;\n\t"
+                    "add.u32 blo, blo, 122;\n\t"
+                    "mov.b64 da, {alo, adhi};\n\t"
+                    "mov.b64 db, {blo, bdhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%2], da, db, id, p1;\n\t"
+                    "add.u32 alo, alo, 2;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 da, {alo, adhi};\n\t"
+                    "mov.b64 db, {blo, bdhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%2], da, db, id, p1;\n\t"
+                    "add.u32 alo, alo, 2;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 da, {alo, adhi};\n\t"
+                    "mov.b64 db, {blo, bdhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%2], da, db, id, p1;\n\t"
+                    "add.u32 alo, alo, 2;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 da, {alo, adhi};\n\t"
+                    "mov.b64 db, {blo, bdhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%2], da, db, id, p1;\n\t"
+                    "}\n"
+                    :: "r"(_mma_a_lo_10), "r"(_mma_b_lo_10), "r"(tmem_flashkda_bwd_persistent_c16_dk_decay), "r"(0));
+                    mbarrier_wait(da_ready_addr + (intermediate_stage4) * 8, _phase_da_ready);
+                    mbarrier_wait(dm_ready_addr + (intermediate_stage4) * 8, _phase_dm_ready);
+                    int _mma_a_lo_11 = make_warp_uniform(((((q_decay_trans_addr) >> 4) & 0x3FFF) | 0x800000) + (operand_stage4) * 256);
+                    int _mma_b_lo_11 = make_warp_uniform(((((intermediate_da_mn_addr) >> 4) & 0x3FFF) | 0x200000) + (intermediate_stage4) * 160);
+                    asm volatile(
+                    "{\n\t"
+                    ".reg .pred leader, p0, p1;\n\t"
+                    ".reg .b32 adhi, bdhi, alo, blo, id;\n\t"
+                    ".reg .b64 da, db;\n\t"
+                    "elect.sync _|leader, 0xFFFFFFFF;\n\t"
+                    "setp.ne.b32 p0, %3, 0;\n\t"
+                    "setp.ne.b32 p1, 1, 0;\n\t"
+                    ""
+                    "mov.b32 adhi, 0x40004040;\n\t"
+                    "mov.b32 bdhi, 0xC0004010;\n\t"
+                    "mov.b32 id, 134579344;\n\t"
+                    "mov.b32 alo, %0;\n\t"
+                    "mov.b32 blo, %1;\n\t"
+                    "mov.b64 da, {alo, adhi};\n\t"
+                    "mov.b64 db, {blo, bdhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%2], da, db, id, p0;\n\t"
+                    "}\n"
+                    :: "r"(_mma_a_lo_11), "r"(_mma_b_lo_11), "r"(tmem_flashkda_bwd_persistent_c16_dk_inv), "r"(0));
+                    int _mma_a_lo_12 = make_warp_uniform(((((k_inv_amaj_addr) >> 4) & 0x3FFF) | 0x800000) + (operand_stage4) * 256);
+                    int _mma_b_lo_12 = make_warp_uniform(((((intermediate_da_addr) >> 4) & 0x3FFF) | 0x200000) + (intermediate_stage4) * 160);
+                    asm volatile(
+                    "{\n\t"
+                    ".reg .pred leader, p0, p1;\n\t"
+                    ".reg .b32 adhi, bdhi, alo, blo, id;\n\t"
+                    ".reg .b64 da, db;\n\t"
+                    "elect.sync _|leader, 0xFFFFFFFF;\n\t"
+                    "setp.ne.b32 p0, %3, 0;\n\t"
+                    "setp.ne.b32 p1, 1, 0;\n\t"
+                    ""
+                    "mov.b32 adhi, 0x40004040;\n\t"
+                    "mov.b32 bdhi, 0xC0004010;\n\t"
+                    "mov.b32 id, 134513808;\n\t"
+                    "mov.b32 alo, %0;\n\t"
+                    "mov.b32 blo, %1;\n\t"
+                    "mov.b64 da, {alo, adhi};\n\t"
+                    "mov.b64 db, {blo, bdhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%2], da, db, id, p0;\n\t"
+                    "}\n"
+                    :: "r"(_mma_a_lo_12), "r"(_mma_b_lo_12), "r"(tmem_flashkda_bwd_persistent_c16_dq), "r"(1));
+                    int _mma_a_lo_13 = make_warp_uniform(((((k_decay_trans_addr) >> 4) & 0x3FFF) | 0x800000) + (operand_stage4) * 256);
+                    int _mma_b_lo_13 = make_warp_uniform(((((intermediate_ndm_mn_addr) >> 4) & 0x3FFF) | 0x200000) + (intermediate_stage4) * 160);
+                    asm volatile(
+                    "{\n\t"
+                    ".reg .pred leader, p0, p1;\n\t"
+                    ".reg .b32 adhi, bdhi, alo, blo, id;\n\t"
+                    ".reg .b64 da, db;\n\t"
+                    "elect.sync _|leader, 0xFFFFFFFF;\n\t"
+                    "setp.ne.b32 p0, %3, 0;\n\t"
+                    "setp.ne.b32 p1, 1, 0;\n\t"
+                    ""
+                    "mov.b32 adhi, 0x40004040;\n\t"
+                    "mov.b32 bdhi, 0xC0004010;\n\t"
+                    "mov.b32 id, 134579344;\n\t"
+                    "mov.b32 alo, %0;\n\t"
+                    "mov.b32 blo, %1;\n\t"
+                    "mov.b64 da, {alo, adhi};\n\t"
+                    "mov.b64 db, {blo, bdhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%2], da, db, id, p0;\n\t"
+                    "}\n"
+                    :: "r"(_mma_a_lo_13), "r"(_mma_b_lo_13), "r"(tmem_flashkda_bwd_persistent_c16_dk_inv), "r"(1));
+                    int _mma_a_lo_14 = make_warp_uniform(((((k_inv_amaj_addr) >> 4) & 0x3FFF) | 0x800000) + (operand_stage4) * 256);
+                    int _mma_b_lo_14 = make_warp_uniform(((((intermediate_dm_addr) >> 4) & 0x3FFF) | 0x200000) + (intermediate_stage4) * 160);
+                    asm volatile(
+                    "{\n\t"
+                    ".reg .pred leader, p0, p1;\n\t"
+                    ".reg .b32 adhi, bdhi, alo, blo, id;\n\t"
+                    ".reg .b64 da, db;\n\t"
+                    "elect.sync _|leader, 0xFFFFFFFF;\n\t"
+                    "setp.ne.b32 p0, %3, 0;\n\t"
+                    "setp.ne.b32 p1, 1, 0;\n\t"
+                    ""
+                    "mov.b32 adhi, 0x40004040;\n\t"
+                    "mov.b32 bdhi, 0xC0004010;\n\t"
+                    "mov.b32 id, 134513808;\n\t"
+                    "mov.b32 alo, %0;\n\t"
+                    "mov.b32 blo, %1;\n\t"
+                    "mov.b64 da, {alo, adhi};\n\t"
+                    "mov.b64 db, {blo, bdhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%2], da, db, id, p0;\n\t"
+                    "}\n"
+                    :: "r"(_mma_a_lo_14), "r"(_mma_b_lo_14), "r"(tmem_flashkda_bwd_persistent_c16_dk_decay), "r"(1));
+                    elect_commit(local_grad_ready_addr + (local_grad_stage4) * 8);
+                    elect_commit(beta_dy_smem_done_addr + (beta_dy_smem_stage4) * 8);
+                    mbarrier_wait(boundary_smem_ready_addr + (boundary_stage4) * 8, _phase_boundary_smem_ready);
+                    mbarrier_wait(boundary_local_grad_free_addr + (boundary_local_grad_stage4) * 8, _phase_boundary_local_grad_free);
+                    int _mma_a_lo_15 = make_warp_uniform((((dstate_smem_mn_addr) >> 4) & 0x3FFF) | 0x4000000);
+                    int _mma_b_lo_15 = make_warp_uniform((((u_lead16_addr) >> 4) & 0x3FFF) | 0x800000);
+                    asm volatile(
+                    "{\n\t"
+                    ".reg .pred leader, p0, p1;\n\t"
+                    ".reg .b32 adhi, bdhi, alo, blo, id;\n\t"
+                    ".reg .b64 da, db;\n\t"
+                    "elect.sync _|leader, 0xFFFFFFFF;\n\t"
+                    "setp.ne.b32 p0, %3, 0;\n\t"
+                    "setp.ne.b32 p1, 1, 0;\n\t"
+                    ""
+                    "mov.b32 adhi, 0x40004040;\n\t"
+                    "mov.b32 bdhi, 0x40004040;\n\t"
+                    "mov.b32 id, 134513808;\n\t"
+                    "mov.b32 alo, %0;\n\t"
+                    "mov.b32 blo, %1;\n\t"
+                    "mov.b64 da, {alo, adhi};\n\t"
+                    "mov.b64 db, {blo, bdhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%2], da, db, id, p0;\n\t"
+                    "add.u32 alo, alo, 128;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 da, {alo, adhi};\n\t"
+                    "mov.b64 db, {blo, bdhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%2], da, db, id, p1;\n\t"
+                    "add.u32 alo, alo, 128;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 da, {alo, adhi};\n\t"
+                    "mov.b64 db, {blo, bdhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%2], da, db, id, p1;\n\t"
+                    "add.u32 alo, alo, 128;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 da, {alo, adhi};\n\t"
+                    "mov.b64 db, {blo, bdhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%2], da, db, id, p1;\n\t"
+                    "add.u32 alo, alo, 128;\n\t"
+                    "add.u32 blo, blo, 122;\n\t"
+                    "mov.b64 da, {alo, adhi};\n\t"
+                    "mov.b64 db, {blo, bdhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%2], da, db, id, p1;\n\t"
+                    "add.u32 alo, alo, 128;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 da, {alo, adhi};\n\t"
+                    "mov.b64 db, {blo, bdhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%2], da, db, id, p1;\n\t"
+                    "add.u32 alo, alo, 128;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 da, {alo, adhi};\n\t"
+                    "mov.b64 db, {blo, bdhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%2], da, db, id, p1;\n\t"
+                    "add.u32 alo, alo, 128;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 da, {alo, adhi};\n\t"
+                    "mov.b64 db, {blo, bdhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%2], da, db, id, p1;\n\t"
+                    "}\n"
+                    :: "r"(_mma_a_lo_15), "r"(_mma_b_lo_15), "r"(tmem_flashkda_bwd_persistent_c16_dk_decay), "r"(0));
+                    elect_commit2(boundary_acc_ready_addr + (boundary_stage4) * 8, state_slot_done_addr + (state_smem_stage4) * 8);
+                    boundary_stage4 += 1;
+                    if (boundary_stage4 == 1) { boundary_stage4 = 0; _phase_boundary_smem_ready ^= 1; }
+                    boundary_local_grad_stage4 += 1;
+                    if (boundary_local_grad_stage4 == 1) { boundary_local_grad_stage4 = 0; _phase_boundary_local_grad_free ^= 1; }
+                    local_grad_stage4 += 1;
+                    if (local_grad_stage4 == 1) { local_grad_stage4 = 0; _phase_local_grad_done ^= 1; }
+                    beta_dy_smem_stage4 += 1;
+                    if (beta_dy_smem_stage4 == 2) { beta_dy_smem_stage4 = 0; _phase_beta_dy_smem_ready ^= 1; }
+                    if (elect_sync()) {
+                        mbarrier_arrive(tcgen_inputs_done_addr + (tcgen_data_stage4) * 8);
+                        mbarrier_arrive(raw_done_addr + (raw_stage4) * 8);
+                        mbarrier_arrive(intermediate_done_addr + (intermediate_stage4) * 8);
+                        mbarrier_arrive(decay_done_addr + (operand_stage4) * 8);
+                    }
+                    operand_stage4 += 1;
+                    if (operand_stage4 == 2) { operand_stage4 = 0; _phase_k_decay_inv_ready_1 ^= 1; _phase_q_decay_k_restore_ready ^= 1; }
+                    raw_stage4 += 1;
+                    if (raw_stage4 == 2) { raw_stage4 = 0; _phase_raw_ready_3 ^= 1; }
+                    state_smem_stage4 += 1;
+                    if (state_smem_stage4 == 2) { state_smem_stage4 = 0; _phase_state_k_done ^= 1; _phase_state_ready_1 ^= 1; }
+                    intermediate_stage4 += 1;
+                    if (intermediate_stage4 == 2) { intermediate_stage4 = 0; _phase_tinv_ready ^= 1; _phase_a_ready ^= 1; _phase_da_ready ^= 1; _phase_dm_ready ^= 1; }
+                    tcgen_data_stage4 += 1;
+                    if (tcgen_data_stage4 == 1) { tcgen_data_stage4 = 0; _phase_dstate_done ^= 1; _phase_tcgen_inputs_ready ^= 1; _phase_tcgen_products_done ^= 1; _phase_dy_done ^= 1; _phase_tcgen_products_ready_1 ^= 1; _phase_du_inp_ready ^= 1; _phase_dy_ready_1 ^= 1; _phase_neg_dy_ready ^= 1; _phase_dstate_ready_1 ^= 1; }
+                }
+            }
+            if (elect_sync()) {
+                mbarrier_arrive(consumers_done_addr);
+            }
+            unsigned int _phase_cleanup_ready_0 = 0;
+            mbarrier_wait(cleanup_ready_addr, _phase_cleanup_ready_0);
+            _phase_cleanup_ready_0 ^= 1;
+            int _tmem_dealloc_addr = *((volatile int*)tmem_addr_storage);
+            asm volatile("tcgen05.dealloc.cta_group::1.sync.aligned.b32 %0, %1;" :: "r"(_tmem_dealloc_addr), "r"(512));
+        }
+    }
+    // ---- Role: tma ----
+    if (warp == 14) {
+        { // tma_main
+            unsigned int sched_stage6 = 0;
+            unsigned int raw_stage6 = 0;
+            unsigned int state_smem_stage6 = 0;
+            unsigned int _phase_sched_done = 1;
+            unsigned int _phase_state_slot_done = 1;
+            unsigned int _phase_state_cg2_done = 1;
+            unsigned int _phase_raw_done = 1;
+            if (elect_sync()) {
+                #pragma unroll 1
+                for (int sched_iter6 = 0; sched_iter6 < total_work_items; sched_iter6++) {
+                    mbarrier_wait(sched_done_addr + (sched_stage6) * 8, _phase_sched_done);
+                    unsigned int tile6 = blockIdx.x;
+                    if (uniform_work_items != 0) {
+                        tile6 = (unsigned int)blockIdx.x + (unsigned int)sched_iter6 * (unsigned int)gridDim.x;
+                    } else {
+                        unsigned int _atomic_old_0 = atomicAdd(dynamic_counter, 1);
+                        tile6 = _atomic_old_0;
+                    }
+                    asm volatile("st.shared.b32 [%0], %1;" :: "r"(work_item_addr + sched_stage6 * 4), "r"(tile6));
+                    mbarrier_arrive(sched_ready_addr + (sched_stage6) * 8);
+                    sched_stage6 += 1;
+                    if (sched_stage6 == 8) { sched_stage6 = 0; _phase_sched_done ^= 1; }
+                    if (tile6 >= (unsigned int)total_work_items) {
+                        break;
+                    }
+                    int item_base6 = (int)tile6 * 5;
+                    int sequence6 = work_items[item_base6];
+                    int head6 = work_items[item_base6 + 1];
+                    int write_start6 = work_items[item_base6 + 2];
+                    int write_end6 = work_items[item_base6 + 3];
+                    int compute_end6 = work_items[item_base6 + 4];
+                    long long bos6 = cu_seqlens[sequence6];
+                    #pragma unroll 1
+                    for (int reverse6 = 0; reverse6 < compute_end6 - write_start6; reverse6++) {
+                        int chunk6 = compute_end6 - 1 - reverse6;
+                        int token6 = (int)(bos6 + (long long)chunk6 * 16);
+                        int checkpoint6 = sequence6 * observed_chunks + chunk6;
+                        mbarrier_wait(state_slot_done_addr + (state_smem_stage6) * 8, _phase_state_slot_done);
+                        mbarrier_wait(state_cg2_done_addr + (state_smem_stage6) * 8, _phase_state_cg2_done);
+                        mbarrier_arrive_expect_tx(state_ready_addr + (state_smem_stage6) * 8, 32768);
+                        #pragma unroll
+                        for (int state_segment6 = 0; state_segment6 < 2; state_segment6++) {
+                            tma_4d_gmem2smem(state_panel_addr + (state_smem_stage6 % 2 * 2 + (unsigned int)state_segment6) * 16384, state_tma, state_segment6 * 64, 0, head6, checkpoint6, state_ready_addr + (state_smem_stage6) * 8);
+                        }
+                        state_smem_stage6 += 1;
+                        if (state_smem_stage6 == 2) { state_smem_stage6 = 0; _phase_state_slot_done ^= 1; _phase_state_cg2_done ^= 1; }
+                        mbarrier_wait(raw_done_addr + (raw_stage6) * 8, _phase_raw_done);
+                        mbarrier_arrive_expect_tx(raw_ready_addr + (raw_stage6) * 8, 20736);
+                        tma_2d_gmem2smem(beta_smem_addr + raw_stage6 * 256, beta_tma, head6 / 8 * 8, token6, raw_ready_addr + (raw_stage6) * 8);
+                        #pragma unroll
+                        for (int raw_segment6 = 0; raw_segment6 < 2; raw_segment6++) {
+                            int raw_segment_offset6 = raw_segment6 * 16 * 64 * 2;
+                            int raw_channel6 = raw_segment6 * 64;
+                            tma_3d_gmem2smem(raw_q_addr + raw_stage6 * 4096 + (unsigned int)raw_segment_offset6, q_tma, raw_channel6, head6, token6, raw_ready_addr + (raw_stage6) * 8);
+                            tma_3d_gmem2smem(raw_k_addr + raw_stage6 * 4096 + (unsigned int)raw_segment_offset6, k_tma, raw_channel6, head6, token6, raw_ready_addr + (raw_stage6) * 8);
+                            tma_3d_gmem2smem(raw_g_addr + raw_stage6 * 4096 + (unsigned int)raw_segment_offset6, g_tma, raw_channel6, head6, token6, raw_ready_addr + (raw_stage6) * 8);
+                            tma_3d_gmem2smem(raw_do_addr + raw_stage6 * 4096 + (unsigned int)raw_segment_offset6, do_tma, raw_channel6, head6, token6, raw_ready_addr + (raw_stage6) * 8);
+                            tma_3d_gmem2smem(raw_v_addr + raw_stage6 * 4096 + (unsigned int)raw_segment_offset6, v_tma, raw_channel6, head6, token6, raw_ready_addr + (raw_stage6) * 8);
+                        }
+                        raw_stage6 += 1;
+                        if (raw_stage6 == 2) { raw_stage6 = 0; _phase_raw_done ^= 1; }
+                    }
+                }
+            }
+            unsigned int _phase_consumers_done_0 = 0;
+            mbarrier_wait(consumers_done_addr, _phase_consumers_done_0);
+            _phase_consumers_done_0 ^= 1;
+            if (elect_sync()) {
+                mbarrier_arrive(cleanup_ready_addr);
+            }
+        }
+    }
+    // ---- Role: epilogue ----
+    if (warp == 15) {
+        { // epilogue_main
+            unsigned int sched_stage5 = 0;
+            unsigned int raw_stage5 = 0;
+            unsigned int operand_stage5 = 0;
+            unsigned int intermediate_stage5 = 0;
+            unsigned int u_smem_stage5 = 0;
+            unsigned int dv_stage5 = 0;
+            int lhs_row5 = lane % 8 + (lane / 8 & 1) * 8;
+            int lhs_col_offset5 = lane / 16 * 8;
+            int rhs_row5 = lane % 8 + lane / 16 * 8;
+            int rhs_col_offset5 = (lane / 8 & 1) * 8;
+            unsigned int _phase_sched_ready_5 = 0;
+            unsigned int _phase_q_decay_k_restore_ready_1 = 0;
+            unsigned int _phase_raw_ready_4 = 0;
+            unsigned int _phase_intermediate_done_1 = 1;
+            unsigned int _phase_beta_dy_smem_ready_1 = 0;
+            unsigned int _phase_u_smem_ready_2 = 0;
+            #pragma unroll 1
+            for (int __5 = 0; __5 < total_work_items; __5++) {
+                mbarrier_wait(sched_ready_addr + (sched_stage5) * 8, _phase_sched_ready_5);
+                unsigned int ticket_words_5[1];
+                asm volatile("ld.shared.b32 %0, [%1];" : "=r"(*reinterpret_cast<uint32_t*>(&ticket_words_5[0])) : "r"(work_item_addr + sched_stage5 * 4));
+                unsigned int tile5 = ticket_words_5[0];
+                if (elect_sync()) {
+                    mbarrier_arrive(sched_done_addr + (sched_stage5) * 8);
+                }
+                sched_stage5 += 1;
+                if (sched_stage5 == 8) { sched_stage5 = 0; _phase_sched_ready_5 ^= 1; }
+                if (tile5 >= (unsigned int)total_work_items) {
+                    break;
+                }
+                int item_base5 = (int)tile5 * 5;
+                int sequence5 = work_items[item_base5];
+                int head5 = work_items[item_base5 + 1];
+                int write_start5 = work_items[item_base5 + 2];
+                int write_end5 = work_items[item_base5 + 3];
+                int compute_end5 = work_items[item_base5 + 4];
+                long long bos5 = cu_seqlens[sequence5];
+                float a_sum5[8];
+                a_sum5[0] = 0.0f;
+                a_sum5[1] = 0.0f;
+                a_sum5[2] = 0.0f;
+                a_sum5[3] = 0.0f;
+                a_sum5[4] = 0.0f;
+                a_sum5[5] = 0.0f;
+                a_sum5[6] = 0.0f;
+                a_sum5[7] = 0.0f;
+                #pragma unroll 1
+                for (int reverse5 = 0; reverse5 < compute_end5 - write_start5; reverse5++) {
+                    mbarrier_wait(q_decay_k_restore_ready_addr + (operand_stage5) * 8, _phase_q_decay_k_restore_ready_1);
+                    mbarrier_wait(raw_ready_addr + (raw_stage5) * 8, _phase_raw_ready_4);
+                    int dv_chunk5 = compute_end5 - 1 - reverse5;
+                    int dv_token5 = (int)(bos5 + (long long)dv_chunk5 * 16);
+                    mbarrier_wait(intermediate_done_addr + (intermediate_stage5) * 8, _phase_intermediate_done_1);
+                    float a_acc5[8];
+                    #pragma unroll
+                    for (int k_block5 = 0; k_block5 < 8; k_block5++) {
+                        int a_col5 = k_block5 * 16 + lhs_col_offset5;
+                        int b_col5 = k_block5 * 16 + rhs_col_offset5;
+                        unsigned int a_frag5[4];
+                        unsigned int b_frag5[4];
+                        int segment_11 = a_col5 / 64;
+                        int segment_col_12 = a_col5 - segment_11 * 64;
+                        int swizzled_col_12 = segment_col_12 ^ (lhs_row5 & 7) * 8;
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(a_frag5[0]), "=r"(a_frag5[1]), "=r"(a_frag5[2]), "=r"(a_frag5[3])
+                            : "r"(q_decay_all_addr + (unsigned int)(((int)operand_stage5 * 16 * 128 + segment_11 * 16 * 64 + lhs_row5 * 64 + swizzled_col_12) * 2))
+                            : "memory");
+                        int segment_0_5 = b_col5 / 64;
+                        int segment_col_1_5 = b_col5 - segment_0_5 * 64;
+                        int swizzled_col_2_5 = segment_col_1_5 ^ (rhs_row5 & 7) * 8;
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(b_frag5[0]), "=r"(b_frag5[1]), "=r"(b_frag5[2]), "=r"(b_frag5[3])
+                            : "r"(k_inv_all_addr + (unsigned int)(((int)operand_stage5 * 16 * 128 + segment_0_5 * 16 * 64 + rhs_row5 * 64 + swizzled_col_2_5) * 2))
+                            : "memory");
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%10, %11, %12, %13};\n"
+                            : "=f"(a_acc5[0]), "=f"(a_acc5[1]), "=f"(a_acc5[2]), "=f"(a_acc5[3])
+                            : "r"(a_frag5[0]), "r"(a_frag5[1]), "r"(a_frag5[2]), "r"(a_frag5[3]), "r"(b_frag5[0]), "r"(b_frag5[1]), "f"(((k_block5 == 0) ? 0.0f : a_acc5[0])), "f"(((k_block5 == 0) ? 0.0f : a_acc5[1])), "f"(((k_block5 == 0) ? 0.0f : a_acc5[2])), "f"(((k_block5 == 0) ? 0.0f : a_acc5[3])));
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%10, %11, %12, %13};\n"
+                            : "=f"(a_acc5[4]), "=f"(a_acc5[(4) + 1]), "=f"(a_acc5[(4) + 2]), "=f"(a_acc5[(4) + 3])
+                            : "r"(a_frag5[0]), "r"(a_frag5[1]), "r"(a_frag5[2]), "r"(a_frag5[3]), "r"(b_frag5[2]), "r"(b_frag5[(2) + 1]), "f"(((k_block5 == 0) ? 0.0f : a_acc5[4])), "f"(((k_block5 == 0) ? 0.0f : a_acc5[(4) + 1])), "f"(((k_block5 == 0) ? 0.0f : a_acc5[(4) + 2])), "f"(((k_block5 == 0) ? 0.0f : a_acc5[(4) + 3])));
+                    }
+                    float a_values5[8];
+                    #pragma unroll
+                    for (int accum5 = 0; accum5 < 8; accum5++) {
+                        int accum_row5 = lane / 4 + accum5 % 4 / 2 * 8;
+                        int accum_col5 = accum5 / 4 * 8 + (lane & 3) * 2 + (accum5 & 1);
+                        a_values5[accum5] = 0.0f;
+                        if (accum_row5 >= accum_col5) {
+                            a_values5[accum5] = a_acc5[accum5];
+                        }
+                        a_sum5[accum5] = a_sum5[accum5] + a_values5[accum5];
+                    }
+                    unsigned int a_words5[4];
+                    #pragma unroll
+                    for (int _lp = 0; _lp < 4; _lp++) {
+                        __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(a_values5[_lp*2 + 0], a_values5[_lp*2+1 + 0]));
+                        a_words5[_lp] = *(uint32_t*)&_bf2;
+                    }
+                    int publish_row5 = lane % 16;
+                    int publish_col5 = lane / 16 * 8;
+                    uint32_t _stmatrix_addr_0 = static_cast<uint32_t>((unsigned long long)(intermediate_a_addr + intermediate_stage5 * 2560 + (unsigned int)(publish_col5 / 16 * 512 + publish_row5 * 32 + publish_col5 % 16 * 2 ^ (publish_col5 / 16 * 512 + publish_row5 * 32 + publish_col5 % 16 * 2 >> 7 & 1) << 4)));
+                    asm volatile("stmatrix.sync.aligned.m8n8.x4.shared.b16 [%0], {%1, %2, %3, %4};\n"
+                        :: "r"(_stmatrix_addr_0), "r"(*reinterpret_cast<const uint32_t*>(&a_words5[0])), "r"(*reinterpret_cast<const uint32_t*>(&a_words5[1])), "r"(*reinterpret_cast<const uint32_t*>(&a_words5[2])), "r"(*reinterpret_cast<const uint32_t*>(&a_words5[3]))
+                        : "memory");
+                    asm volatile("fence.proxy.async.shared::cta;" ::: "memory");
+                    mbarrier_arrive(a_ready_addr + (intermediate_stage5) * 8);
+                    mbarrier_wait(beta_dy_smem_ready_addr + (dv_stage5) * 8, _phase_beta_dy_smem_ready_1);
+                    if (dv_chunk5 < write_end5) {
+                        if (elect_sync()) {
+                            #pragma unroll
+                            for (int dv_segment5 = 0; dv_segment5 < 2; dv_segment5++) {
+                                tma_store_3d(dv_tma, dv_segment5 * 64, head5, dv_token5, beta_dy_smem_addr + dv_stage5 * 4096 + (unsigned int)(dv_segment5 * 16 * 64 * 2));
+                            }
+                        }
+                    }
+                    asm volatile("cp.async.bulk.commit_group;");
+                    mbarrier_wait(u_smem_ready_addr + (u_smem_stage5) * 8, _phase_u_smem_ready_2);
+                    float da_acc5[8];
+                    #pragma unroll
+                    for (int k_block_da5 = 0; k_block_da5 < 8; k_block_da5++) {
+                        int a_col_da5 = k_block_da5 * 16 + lhs_col_offset5;
+                        int b_col_da5 = k_block_da5 * 16 + rhs_col_offset5;
+                        unsigned int do_frag5[4];
+                        unsigned int u_frag5[4];
+                        int segment_13 = a_col_da5 / 64;
+                        int segment_col_14 = a_col_da5 - segment_13 * 64;
+                        int swizzled_col_13 = segment_col_14 ^ (lhs_row5 & 7) * 8;
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(do_frag5[0]), "=r"(do_frag5[1]), "=r"(do_frag5[2]), "=r"(do_frag5[3])
+                            : "r"(raw_do_all_addr + (unsigned int)(((int)raw_stage5 * 16 * 128 + segment_13 * 16 * 64 + lhs_row5 * 64 + swizzled_col_13) * 2))
+                            : "memory");
+                        int segment_0_6 = b_col_da5 / 64;
+                        int segment_col_1_6 = b_col_da5 - segment_0_6 * 64;
+                        int swizzled_col_2_6 = segment_col_1_6 ^ (rhs_row5 & 7) * 8;
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(u_frag5[0]), "=r"(u_frag5[1]), "=r"(u_frag5[2]), "=r"(u_frag5[3])
+                            : "r"(u_smem_addr + (unsigned int)((segment_0_6 * 16 * 64 + rhs_row5 * 64 + swizzled_col_2_6) * 2))
+                            : "memory");
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%10, %11, %12, %13};\n"
+                            : "=f"(da_acc5[0]), "=f"(da_acc5[1]), "=f"(da_acc5[2]), "=f"(da_acc5[3])
+                            : "r"(do_frag5[0]), "r"(do_frag5[1]), "r"(do_frag5[2]), "r"(do_frag5[3]), "r"(u_frag5[0]), "r"(u_frag5[1]), "f"(((k_block_da5 == 0) ? 0.0f : da_acc5[0])), "f"(((k_block_da5 == 0) ? 0.0f : da_acc5[1])), "f"(((k_block_da5 == 0) ? 0.0f : da_acc5[2])), "f"(((k_block_da5 == 0) ? 0.0f : da_acc5[3])));
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%10, %11, %12, %13};\n"
+                            : "=f"(da_acc5[4]), "=f"(da_acc5[(4) + 1]), "=f"(da_acc5[(4) + 2]), "=f"(da_acc5[(4) + 3])
+                            : "r"(do_frag5[0]), "r"(do_frag5[1]), "r"(do_frag5[2]), "r"(do_frag5[3]), "r"(u_frag5[2]), "r"(u_frag5[(2) + 1]), "f"(((k_block_da5 == 0) ? 0.0f : da_acc5[4])), "f"(((k_block_da5 == 0) ? 0.0f : da_acc5[(4) + 1])), "f"(((k_block_da5 == 0) ? 0.0f : da_acc5[(4) + 2])), "f"(((k_block_da5 == 0) ? 0.0f : da_acc5[(4) + 3])));
+                    }
+                    asm volatile("fence.proxy.async.shared::cta;" ::: "memory");
+                    mbarrier_arrive(raw_done_addr + (raw_stage5) * 8);
+                    float da_values5[8];
+                    #pragma unroll
+                    for (int accum_da5 = 0; accum_da5 < 8; accum_da5++) {
+                        int da_row5 = lane / 4 + accum_da5 % 4 / 2 * 8;
+                        int da_col5 = accum_da5 / 4 * 8 + (lane & 3) * 2 + (accum_da5 & 1);
+                        da_values5[accum_da5] = 0.0f;
+                        if (da_row5 >= da_col5) {
+                            da_values5[accum_da5] = da_acc5[accum_da5];
+                        }
+                    }
+                    unsigned int da_words5[4];
+                    #pragma unroll
+                    for (int _lp = 0; _lp < 4; _lp++) {
+                        __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(da_values5[_lp*2 + 0], da_values5[_lp*2+1 + 0]));
+                        da_words5[_lp] = *(uint32_t*)&_bf2;
+                    }
+                    uint32_t _stmatrix_addr_1 = static_cast<uint32_t>((unsigned long long)(intermediate_da_addr + intermediate_stage5 * 2560 + (unsigned int)(publish_col5 / 16 * 512 + publish_row5 * 32 + publish_col5 % 16 * 2 ^ (publish_col5 / 16 * 512 + publish_row5 * 32 + publish_col5 % 16 * 2 >> 7 & 1) << 4)));
+                    asm volatile("stmatrix.sync.aligned.m8n8.x4.shared.b16 [%0], {%1, %2, %3, %4};\n"
+                        :: "r"(_stmatrix_addr_1), "r"(*reinterpret_cast<const uint32_t*>(&da_words5[0])), "r"(*reinterpret_cast<const uint32_t*>(&da_words5[1])), "r"(*reinterpret_cast<const uint32_t*>(&da_words5[2])), "r"(*reinterpret_cast<const uint32_t*>(&da_words5[3]))
+                        : "memory");
+                    asm volatile("fence.proxy.async.shared::cta;" ::: "memory");
+                    mbarrier_arrive(da_ready_addr + (intermediate_stage5) * 8);
+                    asm volatile("cp.async.bulk.wait_group 0;");
+                    if (elect_sync()) {
+                        mbarrier_arrive(beta_dy_smem_done_addr + (dv_stage5) * 8);
+                    }
+                    dv_stage5 += 1;
+                    if (dv_stage5 == 2) { dv_stage5 = 0; _phase_beta_dy_smem_ready_1 ^= 1; }
+                    raw_stage5 += 1;
+                    if (raw_stage5 == 2) { raw_stage5 = 0; _phase_raw_ready_4 ^= 1; }
+                    operand_stage5 += 1;
+                    if (operand_stage5 == 2) { operand_stage5 = 0; _phase_q_decay_k_restore_ready_1 ^= 1; }
+                    intermediate_stage5 += 1;
+                    if (intermediate_stage5 == 2) { intermediate_stage5 = 0; _phase_intermediate_done_1 ^= 1; }
+                    u_smem_stage5 += 1;
+                    if (u_smem_stage5 == 1) { u_smem_stage5 = 0; _phase_u_smem_ready_2 ^= 1; }
+                }
+            }
+            if (elect_sync()) {
+                mbarrier_arrive(consumers_done_addr);
+            }
+        }
+    }
+
+    // Cleanup
+}
+
+} // extern "C"
+
+#undef FLASH_KDA_INF
+#undef NUM_BETA_DY_SMEM_PIPE_STAGES
+#undef NUM_BOUNDARY_LOCAL_GRAD_PIPE_STAGES
+#undef NUM_BOUNDARY_PIPE_STAGES
+#undef NUM_DBETA_M_PIPE_STAGES
+#undef NUM_DK_RESTORE_PIPE_STAGES
+#undef NUM_DSTATE_RECURRENCE_PIPE_STAGES
+#undef NUM_DSTATE_SMEM_PIPE_STAGES
+#undef NUM_DY_SMEM_PIPE_STAGES
+#undef NUM_G_PREFIX_PIPE_STAGES
+#undef NUM_INTERMEDIATE_PIPE_STAGES
+#undef NUM_LOCAL_GRAD_PIPE_STAGES
+#undef NUM_OPERAND_PIPE_STAGES
+#undef NUM_QK_RAW_PIPE_STAGES
+#undef NUM_RAW_PIPE_STAGES
+#undef NUM_SCHED_PIPE_STAGES
+#undef NUM_STATE_SMEM_PIPE_STAGES
+#undef NUM_TCGEN_DATA_PIPE_STAGES
+#undef NUM_U_SMEM_PIPE_STAGES
+#undef SMEM_BETA_DY_SMEM_OFF
+#undef SMEM_BETA_DY_SMEM_STAGE_BYTES
+#undef SMEM_BETA_DY_SMEM_STRIDE
+#undef SMEM_BETA_SMEM_ALL_OFF
+#undef SMEM_BETA_SMEM_ALL_STAGE_BYTES
+#undef SMEM_BETA_SMEM_ALL_STRIDE
+#undef SMEM_BETA_SMEM_OFF
+#undef SMEM_BETA_SMEM_STAGE_BYTES
+#undef SMEM_BETA_SMEM_STRIDE
+#undef SMEM_BOUNDARY_STATE_SMEM_OFF
+#undef SMEM_BOUNDARY_STATE_SMEM_STAGE_BYTES
+#undef SMEM_BOUNDARY_STATE_SMEM_STRIDE
+#undef SMEM_DBETA_M_SMEM_OFF
+#undef SMEM_DBETA_M_SMEM_STAGE_BYTES
+#undef SMEM_DBETA_M_SMEM_STRIDE
+#undef SMEM_DBETA_RED_SMEM_OFF
+#undef SMEM_DBETA_RED_SMEM_STAGE_BYTES
+#undef SMEM_DBETA_RED_SMEM_STRIDE
+#undef SMEM_DEBUG_DU_SMEM_ALL_OFF
+#undef SMEM_DEBUG_DU_SMEM_ALL_STAGE_BYTES
+#undef SMEM_DEBUG_DU_SMEM_ALL_STRIDE
+#undef SMEM_DEBUG_DU_SMEM_OFF
+#undef SMEM_DEBUG_DU_SMEM_STAGE_BYTES
+#undef SMEM_DEBUG_DU_SMEM_STRIDE
+#undef SMEM_DSTATE_SMEM_ALL_OFF
+#undef SMEM_DSTATE_SMEM_ALL_STAGE_BYTES
+#undef SMEM_DSTATE_SMEM_ALL_STRIDE
+#undef SMEM_DSTATE_SMEM_MN_OFF
+#undef SMEM_DSTATE_SMEM_MN_STAGE_BYTES
+#undef SMEM_DSTATE_SMEM_MN_STRIDE
+#undef SMEM_DSTATE_SMEM_OFF
+#undef SMEM_DSTATE_SMEM_STAGE_BYTES
+#undef SMEM_DSTATE_SMEM_STRIDE
+#undef SMEM_DY_SMEM_ALL_OFF
+#undef SMEM_DY_SMEM_ALL_STAGE_BYTES
+#undef SMEM_DY_SMEM_ALL_STRIDE
+#undef SMEM_DY_SMEM_OFF
+#undef SMEM_DY_SMEM_STAGE_BYTES
+#undef SMEM_DY_SMEM_STRIDE
+#undef SMEM_G_PREFIX_ALL_OFF
+#undef SMEM_G_PREFIX_ALL_STAGE_BYTES
+#undef SMEM_G_PREFIX_ALL_STRIDE
+#undef SMEM_G_PREFIX_OFF
+#undef SMEM_G_PREFIX_STAGE_BYTES
+#undef SMEM_G_PREFIX_STRIDE
+#undef SMEM_INTERMEDIATE_A_MN_OFF
+#undef SMEM_INTERMEDIATE_A_MN_STAGE_BYTES
+#undef SMEM_INTERMEDIATE_A_MN_STRIDE
+#undef SMEM_INTERMEDIATE_A_OFF
+#undef SMEM_INTERMEDIATE_A_STAGE_BYTES
+#undef SMEM_INTERMEDIATE_A_STRIDE
+#undef SMEM_INTERMEDIATE_DA_MN_OFF
+#undef SMEM_INTERMEDIATE_DA_MN_STAGE_BYTES
+#undef SMEM_INTERMEDIATE_DA_MN_STRIDE
+#undef SMEM_INTERMEDIATE_DA_OFF
+#undef SMEM_INTERMEDIATE_DA_STAGE_BYTES
+#undef SMEM_INTERMEDIATE_DA_STRIDE
+#undef SMEM_INTERMEDIATE_DM_OFF
+#undef SMEM_INTERMEDIATE_DM_STAGE_BYTES
+#undef SMEM_INTERMEDIATE_DM_STRIDE
+#undef SMEM_INTERMEDIATE_NDM_MN_OFF
+#undef SMEM_INTERMEDIATE_NDM_MN_STAGE_BYTES
+#undef SMEM_INTERMEDIATE_NDM_MN_STRIDE
+#undef SMEM_INTERMEDIATE_NDM_OFF
+#undef SMEM_INTERMEDIATE_NDM_STAGE_BYTES
+#undef SMEM_INTERMEDIATE_NDM_STRIDE
+#undef SMEM_INTERMEDIATE_TINV_MN_OFF
+#undef SMEM_INTERMEDIATE_TINV_MN_STAGE_BYTES
+#undef SMEM_INTERMEDIATE_TINV_MN_STRIDE
+#undef SMEM_INTERMEDIATE_TINV_OFF
+#undef SMEM_INTERMEDIATE_TINV_STAGE_BYTES
+#undef SMEM_INTERMEDIATE_TINV_STRIDE
+#undef SMEM_K_DECAY_ALL_OFF
+#undef SMEM_K_DECAY_ALL_STAGE_BYTES
+#undef SMEM_K_DECAY_ALL_STRIDE
+#undef SMEM_K_DECAY_LEAD16_OFF
+#undef SMEM_K_DECAY_LEAD16_STAGE_BYTES
+#undef SMEM_K_DECAY_LEAD16_STRIDE
+#undef SMEM_K_DECAY_OPERAND_OFF
+#undef SMEM_K_DECAY_OPERAND_STAGE_BYTES
+#undef SMEM_K_DECAY_OPERAND_STRIDE
+#undef SMEM_K_DECAY_TRANS_OFF
+#undef SMEM_K_DECAY_TRANS_STAGE_BYTES
+#undef SMEM_K_DECAY_TRANS_STRIDE
+#undef SMEM_K_INV_ALL_OFF
+#undef SMEM_K_INV_ALL_STAGE_BYTES
+#undef SMEM_K_INV_ALL_STRIDE
+#undef SMEM_K_INV_AMAJ_OFF
+#undef SMEM_K_INV_AMAJ_STAGE_BYTES
+#undef SMEM_K_INV_AMAJ_STRIDE
+#undef SMEM_K_INV_LEAD16_OFF
+#undef SMEM_K_INV_LEAD16_STAGE_BYTES
+#undef SMEM_K_INV_LEAD16_STRIDE
+#undef SMEM_K_INV_OPERAND_OFF
+#undef SMEM_K_INV_OPERAND_STAGE_BYTES
+#undef SMEM_K_INV_OPERAND_STRIDE
+#undef SMEM_K_RESTORE_ALL_OFF
+#undef SMEM_K_RESTORE_ALL_STAGE_BYTES
+#undef SMEM_K_RESTORE_ALL_STRIDE
+#undef SMEM_K_RESTORE_LEAD16_OFF
+#undef SMEM_K_RESTORE_LEAD16_STAGE_BYTES
+#undef SMEM_K_RESTORE_LEAD16_STRIDE
+#undef SMEM_K_RESTORE_OPERAND_OFF
+#undef SMEM_K_RESTORE_OPERAND_STAGE_BYTES
+#undef SMEM_K_RESTORE_OPERAND_STRIDE
+#undef SMEM_QK_NORM_SMEM_ALL_OFF
+#undef SMEM_QK_NORM_SMEM_ALL_STAGE_BYTES
+#undef SMEM_QK_NORM_SMEM_ALL_STRIDE
+#undef SMEM_QK_NORM_SMEM_OFF
+#undef SMEM_QK_NORM_SMEM_STAGE_BYTES
+#undef SMEM_QK_NORM_SMEM_STRIDE
+#undef SMEM_QK_RED_SMEM_OFF
+#undef SMEM_QK_RED_SMEM_STAGE_BYTES
+#undef SMEM_QK_RED_SMEM_STRIDE
+#undef SMEM_Q_DECAY_ALL_OFF
+#undef SMEM_Q_DECAY_ALL_STAGE_BYTES
+#undef SMEM_Q_DECAY_ALL_STRIDE
+#undef SMEM_Q_DECAY_OPERAND_OFF
+#undef SMEM_Q_DECAY_OPERAND_STAGE_BYTES
+#undef SMEM_Q_DECAY_OPERAND_STRIDE
+#undef SMEM_Q_DECAY_TRANS_OFF
+#undef SMEM_Q_DECAY_TRANS_STAGE_BYTES
+#undef SMEM_Q_DECAY_TRANS_STRIDE
+#undef SMEM_RAW_DO_ALL_OFF
+#undef SMEM_RAW_DO_ALL_STAGE_BYTES
+#undef SMEM_RAW_DO_ALL_STRIDE
+#undef SMEM_RAW_DO_AMAJ_OFF
+#undef SMEM_RAW_DO_AMAJ_STAGE_BYTES
+#undef SMEM_RAW_DO_AMAJ_STRIDE
+#undef SMEM_RAW_DO_OFF
+#undef SMEM_RAW_DO_STAGE_BYTES
+#undef SMEM_RAW_DO_STRIDE
+#undef SMEM_RAW_G_ALL_OFF
+#undef SMEM_RAW_G_ALL_STAGE_BYTES
+#undef SMEM_RAW_G_ALL_STRIDE
+#undef SMEM_RAW_G_OFF
+#undef SMEM_RAW_G_STAGE_BYTES
+#undef SMEM_RAW_G_STRIDE
+#undef SMEM_RAW_K_ALL_OFF
+#undef SMEM_RAW_K_ALL_STAGE_BYTES
+#undef SMEM_RAW_K_ALL_STRIDE
+#undef SMEM_RAW_K_OFF
+#undef SMEM_RAW_K_STAGE_BYTES
+#undef SMEM_RAW_K_STRIDE
+#undef SMEM_RAW_Q_ALL_OFF
+#undef SMEM_RAW_Q_ALL_STAGE_BYTES
+#undef SMEM_RAW_Q_ALL_STRIDE
+#undef SMEM_RAW_Q_OFF
+#undef SMEM_RAW_Q_STAGE_BYTES
+#undef SMEM_RAW_Q_STRIDE
+#undef SMEM_RAW_V_ALL_OFF
+#undef SMEM_RAW_V_ALL_STAGE_BYTES
+#undef SMEM_RAW_V_ALL_STRIDE
+#undef SMEM_RAW_V_OFF
+#undef SMEM_RAW_V_STAGE_BYTES
+#undef SMEM_RAW_V_STRIDE
+#undef SMEM_STATE_OPERAND_ALL_OFF
+#undef SMEM_STATE_OPERAND_ALL_STAGE_BYTES
+#undef SMEM_STATE_OPERAND_ALL_STRIDE
+#undef SMEM_STATE_OPERAND_MN_OFF
+#undef SMEM_STATE_OPERAND_MN_STAGE_BYTES
+#undef SMEM_STATE_OPERAND_MN_STRIDE
+#undef SMEM_STATE_OPERAND_OFF
+#undef SMEM_STATE_OPERAND_STAGE_BYTES
+#undef SMEM_STATE_OPERAND_STRIDE
+#undef SMEM_STATE_PANEL_OFF
+#undef SMEM_STATE_PANEL_STAGE_BYTES
+#undef SMEM_STATE_PANEL_STRIDE
+#undef SMEM_STATE_SCALE_DIAG_OFF
+#undef SMEM_STATE_SCALE_DIAG_STAGE_BYTES
+#undef SMEM_STATE_SCALE_DIAG_STRIDE
+#undef SMEM_TINV_SCRATCH_OFF
+#undef SMEM_TINV_SCRATCH_STAGE_BYTES
+#undef SMEM_TINV_SCRATCH_STRIDE
+#undef SMEM_TOTAL
+#undef SMEM_U_LEAD16_OFF
+#undef SMEM_U_LEAD16_STAGE_BYTES
+#undef SMEM_U_LEAD16_STRIDE
+#undef SMEM_U_SMEM_ALL_OFF
+#undef SMEM_U_SMEM_ALL_STAGE_BYTES
+#undef SMEM_U_SMEM_ALL_STRIDE
+#undef SMEM_U_SMEM_OFF
+#undef SMEM_U_SMEM_STAGE_BYTES
+#undef SMEM_U_SMEM_STRIDE
+#undef SMEM_WORK_ITEM_OFF
+#undef SMEM_WORK_ITEM_STAGE_BYTES
+#undef SMEM_WORK_ITEM_STRIDE
+#undef THREADS
+#undef TMEM_FLASHKDA_BWD_PERSISTENT_C16_DK_DECAY_OFFSET
+#undef TMEM_FLASHKDA_BWD_PERSISTENT_C16_DK_INV_OFFSET
+#undef TMEM_FLASHKDA_BWD_PERSISTENT_C16_DK_RESTORE_OFFSET
+#undef TMEM_FLASHKDA_BWD_PERSISTENT_C16_DO_INP_OFFSET
+#undef TMEM_FLASHKDA_BWD_PERSISTENT_C16_DQ_OFFSET
+#undef TMEM_FLASHKDA_BWD_PERSISTENT_C16_DSTATE_INP_OFFSET
+#undef TMEM_FLASHKDA_BWD_PERSISTENT_C16_DSTATE_OFFSET
+#undef TMEM_FLASHKDA_BWD_PERSISTENT_C16_DU_INP_OFFSET
+#undef TMEM_FLASHKDA_BWD_PERSISTENT_C16_DU_OFFSET
+#undef TMEM_FLASHKDA_BWD_PERSISTENT_C16_DY_OFFSET
+#undef TMEM_FLASHKDA_BWD_PERSISTENT_C16_ENVELOPE_OFFSET
+#undef TMEM_FLASHKDA_BWD_PERSISTENT_C16_NEG_DY_OFFSET
+#undef TMEM_FLASHKDA_BWD_PERSISTENT_C16_STATE_K_OFFSET
+#undef TMEM_FLASHKDA_BWD_PERSISTENT_C16_U_OFFSET
+#undef TMEM_FLASHKDA_BWD_PERSISTENT_C16_Y_OFFSET
+#undef TMEM_NCOLS
+#undef USE_DSTATE_IN
+#undef a_ready_addr
+#undef beta_dy_smem_addr
+#undef beta_dy_smem_done_addr
+#undef beta_dy_smem_ready_addr
+#undef beta_smem_addr
+#undef beta_smem_all_addr
+#undef boundary_acc_ready_addr
+#undef boundary_local_grad_free_addr
+#undef boundary_smem_ready_addr
+#undef boundary_state_ready_addr
+#undef boundary_state_smem_addr
+#undef cleanup_ready_addr
+#undef consumers_done_addr
+#undef da_ready_addr
+#undef dbeta_m_done_addr
+#undef dbeta_m_ready_addr
+#undef dbeta_m_smem_addr
+#undef dbeta_red_smem_addr
+#undef debug_du_smem_addr
+#undef debug_du_smem_all_addr
+#undef decay_done_addr
+#undef dk_restore_done_addr
+#undef dk_restore_ready_addr
+#undef dm_ready_addr
+#undef dstate_done_addr
+#undef dstate_inp_ready_addr
+#undef dstate_ready_addr
+#undef dstate_smem_addr
+#undef dstate_smem_all_addr
+#undef dstate_smem_done_addr
+#undef dstate_smem_mn_addr
+#undef dstate_smem_ready_addr
+#undef du_inp_ready_addr
+#undef dy_done_addr
+#undef dy_ready_addr
+#undef dy_smem_addr
+#undef dy_smem_all_addr
+#undef dy_smem_ready_addr
+#undef g_prefix_addr
+#undef g_prefix_all_addr
+#undef g_prefix_done_addr
+#undef g_prefix_ready_addr
+#undef intermediate_a_addr
+#undef intermediate_a_mn_addr
+#undef intermediate_da_addr
+#undef intermediate_da_mn_addr
+#undef intermediate_dm_addr
+#undef intermediate_done_addr
+#undef intermediate_ndm_addr
+#undef intermediate_ndm_mn_addr
+#undef intermediate_tinv_addr
+#undef intermediate_tinv_mn_addr
+#undef k_decay_all_addr
+#undef k_decay_inv_ready_addr
+#undef k_decay_lead16_addr
+#undef k_decay_operand_addr
+#undef k_decay_trans_addr
+#undef k_inv_all_addr
+#undef k_inv_amaj_addr
+#undef k_inv_lead16_addr
+#undef k_inv_operand_addr
+#undef k_restore_all_addr
+#undef k_restore_lead16_addr
+#undef k_restore_operand_addr
+#undef local_grad_done_addr
+#undef local_grad_ready_addr
+#undef neg_dy_ready_addr
+#undef q_decay_all_addr
+#undef q_decay_k_restore_ready_addr
+#undef q_decay_operand_addr
+#undef q_decay_trans_addr
+#undef qk_norm_smem_addr
+#undef qk_norm_smem_all_addr
+#undef qk_raw_done_addr
+#undef qk_raw_ready_addr
+#undef qk_red_smem_addr
+#undef raw_do_addr
+#undef raw_do_all_addr
+#undef raw_do_amaj_addr
+#undef raw_done_addr
+#undef raw_g_addr
+#undef raw_g_all_addr
+#undef raw_k_addr
+#undef raw_k_all_addr
+#undef raw_q_addr
+#undef raw_q_all_addr
+#undef raw_ready_addr
+#undef raw_v_addr
+#undef raw_v_all_addr
+#undef sched_done_addr
+#undef sched_ready_addr
+#undef state_cg2_done_addr
+#undef state_k_done_addr
+#undef state_k_ready_addr
+#undef state_operand_addr
+#undef state_operand_all_addr
+#undef state_operand_mn_addr
+#undef state_panel_addr
+#undef state_ready_addr
+#undef state_scale_diag_addr
+#undef state_slot_done_addr
+#undef tcgen_inputs_done_addr
+#undef tcgen_inputs_ready_addr
+#undef tcgen_products_done_addr
+#undef tcgen_products_ready_addr
+#undef tinv_ready_addr
+#undef tinv_scratch_addr
+#undef u_lead16_addr
+#undef u_smem_addr
+#undef u_smem_all_addr
+#undef u_smem_ready_addr
+#undef validate_outputs
+#undef work_item_addr
+
+#define FLASH_KDA_INF CUDART_INF_F
+#define NUM_MAIN_STAGES 1
+#define SMEM_PARTIAL_A_OFF 0
+#define SMEM_PARTIAL_A_STAGE_BYTES 2048
+#define SMEM_PARTIAL_A_STRIDE 2048
+#define SMEM_PARTIAL_DT_OFF 2048
+#define SMEM_PARTIAL_DT_STAGE_BYTES 2048
+#define SMEM_PARTIAL_DT_STRIDE 2048
+#define SMEM_TOTAL 4096
+#define THREADS 128
+
+extern "C" {
+
+__global__ __launch_bounds__(128) void
+kernel_flashkda_backward_param_reduce_c16_partial(__nv_bfloat16* __restrict__ g, __nv_bfloat16* __restrict__ beta_active, float* __restrict__ A_log, float* __restrict__ dt_bias, float* __restrict__ dlog_decay, float* __restrict__ dlog_boundary, float* __restrict__ dbeta_active, __nv_bfloat16* __restrict__ dg, __nv_bfloat16* __restrict__ dbeta, float* __restrict__ gate_part_a, float* __restrict__ gate_part_dt, int total_tokens, int num_heads, int slice_len, float lower_bound)
+{
+    const int tid = threadIdx.x;
+    const int warp = make_warp_uniform(tid / 32);
+    const int lane = tid % 32;
+
+    extern __shared__ __align__(1024) char smem_raw[];
+    int smem;
+    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+
+    const int bid = blockIdx.x;
+    const int num_bids = gridDim.x;
+
+    // Kernel setup ops
+    float* partial_a = reinterpret_cast<float*>(smem_raw + 0);
+    const int partial_a_addr = smem + 0;
+    float* partial_dt = reinterpret_cast<float*>(smem_raw + 2048);
+    const int partial_dt_addr = smem + 2048;
+
+    // === Task calls (dependency order) ===
+    int stripe = blockIdx.x;
+    int head = blockIdx.y;
+    int warp_0 = warp;
+    int dim0 = lane * 4;
+    float _expf_0 = __expf(A_log[head]);
+    float gate_rate = _expf_0;
+    float bias[4];
+    float acc_a[4];
+    float acc_dt[4];
+    #pragma unroll
+    for (int q0 = 0; q0 < 4; q0++) {
+        bias[q0] = dt_bias[head * 128 + dim0 + q0];
+        acc_a[q0] = 0.0f;
+        acc_dt[q0] = 0.0f;
+    }
+    int token_begin = stripe * slice_len;
+    int token_end = token_begin + slice_len;
+    if (token_end > total_tokens) {
+        token_end = total_tokens;
+    }
+    #pragma unroll 1
+    for (int token = token_begin + warp_0; token < token_end; token += 4) {
+        long long gate_index = ((long long)token * (long long)num_heads + (long long)head) * 128 + (long long)dim0;
+        float dgate_frag[4];
+        float gate_frag[4];
+        float dg_frag[4];
+        {
+            float4 _v4 = *reinterpret_cast<const float4*>(dlog_decay + gate_index);
+            dgate_frag[0 + 0] = _v4.x;
+            dgate_frag[0 + 1] = _v4.y;
+            dgate_frag[0 + 2] = _v4.z;
+            dgate_frag[0 + 3] = _v4.w;
+        }
+        if (token % 16 == 0) {
+            long long boundary_index = ((long long)token / 16 * (long long)num_heads + (long long)head) * 128 + (long long)dim0;
+            {
+                float4 _v4 = *reinterpret_cast<const float4*>(dlog_boundary + boundary_index);
+                dgate_frag[0 + 0] = _v4.x;
+                dgate_frag[0 + 1] = _v4.y;
+                dgate_frag[0 + 2] = _v4.z;
+                dgate_frag[0 + 3] = _v4.w;
+            }
+            {
+                float4 _v4 = make_float4(dgate_frag[0 + 0], dgate_frag[0 + 1], dgate_frag[0 + 2], dgate_frag[0 + 3]);
+                *reinterpret_cast<float4*>(dlog_decay + gate_index) = _v4;
+            }
+        }
+        {
+            uint2 _vld_2;
+            _vld_2 = *reinterpret_cast<const uint2*>(g + gate_index);
+            uint32_t* _vpairs_2 = reinterpret_cast<uint32_t*>(&_vld_2);
+            #pragma unroll
+            for (int _pair = 0; _pair < 2; _pair++) {
+                asm volatile(
+                    "{\n\t"
+                    "shl.b32 %0, %2, 16;\n\t"
+                    "and.b32 %1, %2, 0xffff0000;\n\t"
+                    "}\n"
+                    : "=f"((&gate_frag[0 + _pair * 2])[0]), "=f"((&gate_frag[0 + _pair * 2])[1])
+                    : "r"(_vpairs_2[_pair]));
+            }
+        }
+        #pragma unroll
+        for (int q1 = 0; q1 < 4; q1++) {
+            float biased = gate_frag[q1] + bias[q1];
+            float z = gate_rate * biased;
+            float _tanh_approx_0;
+            asm volatile("tanh.approx.f32 %0, %1;" : "=f"(_tanh_approx_0) : "f"(z * 0.5f));
+            float gate_sigmoid = _tanh_approx_0 * 0.5f + 0.5f;
+            float sigmoid_prime = gate_sigmoid * (1.0f - gate_sigmoid);
+            float weighted = dgate_frag[q1] * lower_bound * sigmoid_prime;
+            float raw = weighted * gate_rate;
+            float _fma_0 = __fmaf_rn(weighted, z, acc_a[q1]);
+            acc_a[q1] = _fma_0;
+            acc_dt[q1] = acc_dt[q1] + raw;
+            dg_frag[q1] = raw;
+        }
+        {
+            __nv_bfloat162 _pk = __floats2bfloat162_rn(dg_frag[0 + 0], dg_frag[0 + 1]);
+            *reinterpret_cast<__nv_bfloat162*>(&((__nv_bfloat16*)(dg))[gate_index]) = _pk;
+        }
+        {
+            __nv_bfloat162 _pk = __floats2bfloat162_rn(dg_frag[2 + 0], dg_frag[2 + 1]);
+            *reinterpret_cast<__nv_bfloat162*>(&((__nv_bfloat16*)(dg))[gate_index + 2]) = _pk;
+        }
+    }
+    #pragma unroll
+    for (int q2 = 0; q2 < 4; q2++) {
+        partial_a[warp_0 * 128 + dim0 + q2] = acc_a[q2];
+        partial_dt[warp_0 * 128 + dim0 + q2] = acc_dt[q2];
+    }
+    __syncthreads();
+    if (warp_0 == 0) {
+        #pragma unroll
+        for (int q3 = 0; q3 < 4; q3++) {
+            int dim = dim0 + q3;
+            int base = (stripe * num_heads + head) * 128 + dim;
+            gate_part_a[base] = partial_a[dim] + partial_a[128 + dim] + partial_a[256 + dim] + partial_a[384 + dim];
+            gate_part_dt[base] = partial_dt[dim] + partial_dt[128 + dim] + partial_dt[256 + dim] + partial_dt[384 + dim];
+        }
+    }
+    int beta_token = token_begin + tid;
+    if (beta_token < token_end) {
+        long long beta_index = (long long)beta_token * (long long)num_heads + (long long)head;
+        float beta_value = (float)beta_active[beta_index];
+        __nv_bfloat16 _cvt_bf16_0 = __float2bfloat16(dbeta_active[beta_index] * beta_value * (1.0f - beta_value));
+        dbeta[beta_index] = _cvt_bf16_0;
+    }
+}
+
+} // extern "C"
+
+#undef FLASH_KDA_INF
+#undef NUM_MAIN_STAGES
+#undef SMEM_PARTIAL_A_OFF
+#undef SMEM_PARTIAL_A_STAGE_BYTES
+#undef SMEM_PARTIAL_A_STRIDE
+#undef SMEM_PARTIAL_DT_OFF
+#undef SMEM_PARTIAL_DT_STAGE_BYTES
+#undef SMEM_PARTIAL_DT_STRIDE
+#undef SMEM_TOTAL
+#undef THREADS
+#undef partial_a_addr
+#undef partial_dt_addr
+
+#define FLASH_KDA_INF CUDART_INF_F
+#define NUM_MAIN_STAGES 1
+#define SMEM_WARP_A_OFF 0
+#define SMEM_WARP_A_STAGE_BYTES 16
+#define SMEM_WARP_A_STRIDE 16
+#define SMEM_TOTAL 128
+#define THREADS 128
+
+extern "C" {
+
+__global__ __launch_bounds__(128) void
+kernel_flashkda_backward_param_reduce_c16_finish(float* __restrict__ gate_part_a, float* __restrict__ gate_part_dt, float* __restrict__ dA_log, float* __restrict__ ddt_bias, int num_heads)
+{
+    const int tid = threadIdx.x;
+    const int warp = make_warp_uniform(tid / 32);
+    const int lane = tid % 32;
+
+    extern __shared__ __align__(1024) char smem_raw[];
+    int smem;
+    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+
+    const int bid = blockIdx.x;
+    const int num_bids = gridDim.x;
+
+    // Kernel setup ops
+    float* warp_a = reinterpret_cast<float*>(smem_raw + 0);
+    const int warp_a_addr = smem + 0;
+
+    // === Task calls (dependency order) ===
+    int head = blockIdx.x;
+    int dim = tid;
+    float a8[8];
+    float dt8[8];
+    #pragma unroll
+    for (int j0 = 0; j0 < 8; j0++) {
+        a8[j0] = 0.0f;
+        dt8[j0] = 0.0f;
+    }
+    #pragma unroll 1
+    for (int chain = 0; chain < 16; chain++) {
+        #pragma unroll
+        for (int j1 = 0; j1 < 8; j1++) {
+            int part_index = ((chain * 8 + j1) * num_heads + head) * 128 + dim;
+            a8[j1] = a8[j1] + gate_part_a[part_index];
+            dt8[j1] = dt8[j1] + gate_part_dt[part_index];
+        }
+    }
+    float p0a = a8[0] + a8[1];
+    float p1a = a8[2] + a8[3];
+    float p2a = a8[4] + a8[5];
+    float p3a = a8[6] + a8[7];
+    float p0dt = dt8[0] + dt8[1];
+    float p1dt = dt8[2] + dt8[3];
+    float p2dt = dt8[4] + dt8[5];
+    float p3dt = dt8[6] + dt8[7];
+    float col_a = p0a + p1a + (p2a + p3a);
+    float col_dt = p0dt + p1dt + (p2dt + p3dt);
+    ddt_bias[head * 128 + dim] = col_dt;
+    float _warp_reduce_0 = col_a;
+    #pragma unroll
+    for (int offset = 16; offset > 0; offset >>= 1)
+        _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
+    col_a = _warp_reduce_0;
+    if (lane == 0) {
+        warp_a[warp] = col_a;
+    }
+    __syncthreads();
+    if (warp == 0) {
+        if (elect_sync()) {
+            dA_log[head] = warp_a[0] + warp_a[1] + warp_a[2] + warp_a[3];
+        }
+    }
+}
+
+} // extern "C"
+
+#undef FLASH_KDA_INF
+#undef NUM_MAIN_STAGES
+#undef SMEM_TOTAL
+#undef SMEM_WARP_A_OFF
+#undef SMEM_WARP_A_STAGE_BYTES
+#undef SMEM_WARP_A_STRIDE
+#undef THREADS
+#undef warp_a_addr
+
+// END FROZEN GENERATED BODY
+// clang-format on

--- a/csrc/kda/flashkda_backward_v483_binding.cu
+++ b/csrc/kda/flashkda_backward_v483_binding.cu
@@ -1,0 +1,301 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+#include "flashkda_binding_common.cuh"
+
+#define uint8_t flashkda_v483_generated_uint8_t
+#define uint16_t flashkda_v483_generated_uint16_t
+#define uint32_t flashkda_v483_generated_uint32_t
+#define uint64_t flashkda_v483_generated_uint64_t
+#define int32_t flashkda_v483_generated_int32_t
+#define int16_t flashkda_v483_generated_int16_t
+#define FlashKDATensorMap flashkda_v483_generated_FlashKDATensorMap
+#define FlashKDATensorMapPack flashkda_v483_generated_FlashKDATensorMapPack
+#define CUtensorMap flashkda_v483_generated_CUtensorMap
+#include "flashkda_backward_v483.cu"
+#undef CUtensorMap
+#undef FlashKDATensorMapPack
+#undef FlashKDATensorMap
+#undef uint8_t
+#undef uint16_t
+#undef uint32_t
+#undef uint64_t
+#undef int32_t
+#undef int16_t
+
+namespace flashinfer {
+namespace flash_kda_backward_v483 {
+
+using flash_kda::CheckCuda;
+using flash_kda::CheckCudaTensor;
+using flash_kda::CheckDtype;
+using flash_kda::CheckDynamicSmemCapacity;
+using flash_kda::CheckFlashKDATarget;
+
+constexpr int64_t kTokens = 8192;
+constexpr int64_t kSequences = 8;
+constexpr int64_t kHeads = 96;
+constexpr int64_t kHeadDim = 128;
+constexpr int64_t kChunks = 512;
+constexpr int64_t kWorkItems = kSequences * kHeads;
+constexpr size_t kTensorMapCount = 8;
+constexpr size_t kDescriptorBytes = kTensorMapCount * sizeof(CUtensorMap);
+constexpr int32_t kBackwardSmemBytes = 230400;
+
+inline void CheckTensor(const TensorView& tensor, const char* name, int32_t device_id,
+                        DLDataType dtype) {
+  CheckCudaTensor(tensor, name, device_id);
+  CheckDtype(tensor, name, dtype);
+}
+
+inline void CheckNumel(const TensorView& tensor, const char* name, int64_t numel) {
+  TVM_FFI_ICHECK(tensor.numel() == numel) << name << " must contain " << numel << " elements";
+}
+
+inline CUtensorMap EncodeTokenTensor(const TensorView& tensor, const char* name) {
+  uint64_t global_dim[3] = {kHeadDim, kHeads, kTokens};
+  uint64_t global_strides[2] = {kHeadDim * sizeof(__nv_bfloat16),
+                                kHeadDim * kHeads * sizeof(__nv_bfloat16)};
+  uint32_t box_dim[3] = {64, 1, 16};
+  uint32_t elem_strides[3] = {1, 1, 1};
+  CUtensorMap map{};
+  const CUresult result = cuTensorMapEncodeTiled(
+      &map, CU_TENSOR_MAP_DATA_TYPE_BFLOAT16, 3, tensor.data_ptr(), global_dim, global_strides,
+      box_dim, elem_strides, CU_TENSOR_MAP_INTERLEAVE_NONE, CU_TENSOR_MAP_SWIZZLE_128B,
+      CU_TENSOR_MAP_L2_PROMOTION_NONE, CU_TENSOR_MAP_FLOAT_OOB_FILL_NONE);
+  TVM_FFI_ICHECK(result == CUDA_SUCCESS)
+      << "cuTensorMapEncodeTiled failed for " << name << " with CUresult=" << int(result);
+  return map;
+}
+
+inline CUtensorMap EncodeStateTensor(const TensorView& tensor) {
+  uint64_t global_dim[4] = {kHeadDim, kHeadDim, kHeads, kChunks};
+  uint64_t global_strides[3] = {kHeadDim * sizeof(__nv_bfloat16),
+                                kHeadDim * kHeadDim * sizeof(__nv_bfloat16),
+                                kHeadDim * kHeadDim * kHeads * sizeof(__nv_bfloat16)};
+  uint32_t box_dim[4] = {64, 128, 1, 1};
+  uint32_t elem_strides[4] = {1, 1, 1, 1};
+  CUtensorMap map{};
+  const CUresult result = cuTensorMapEncodeTiled(
+      &map, CU_TENSOR_MAP_DATA_TYPE_BFLOAT16, 4, tensor.data_ptr(), global_dim, global_strides,
+      box_dim, elem_strides, CU_TENSOR_MAP_INTERLEAVE_NONE, CU_TENSOR_MAP_SWIZZLE_128B,
+      CU_TENSOR_MAP_L2_PROMOTION_NONE, CU_TENSOR_MAP_FLOAT_OOB_FILL_NONE);
+  TVM_FFI_ICHECK(result == CUDA_SUCCESS)
+      << "cuTensorMapEncodeTiled failed for state checkpoints with CUresult=" << int(result);
+  return map;
+}
+
+inline CUtensorMap EncodeBetaTensor(const TensorView& tensor) {
+  uint64_t global_dim[2] = {kHeads, kTokens};
+  uint64_t global_strides[1] = {kHeads * sizeof(__nv_bfloat16)};
+  uint32_t box_dim[2] = {8, 16};
+  uint32_t elem_strides[2] = {1, 1};
+  CUtensorMap map{};
+  const CUresult result = cuTensorMapEncodeTiled(
+      &map, CU_TENSOR_MAP_DATA_TYPE_BFLOAT16, 2, tensor.data_ptr(), global_dim, global_strides,
+      box_dim, elem_strides, CU_TENSOR_MAP_INTERLEAVE_NONE, CU_TENSOR_MAP_SWIZZLE_NONE,
+      CU_TENSOR_MAP_L2_PROMOTION_NONE, CU_TENSOR_MAP_FLOAT_OOB_FILL_NONE);
+  TVM_FFI_ICHECK(result == CUDA_SUCCESS)
+      << "cuTensorMapEncodeTiled failed for beta with CUresult=" << int(result);
+  return map;
+}
+
+struct TensorMapWords {
+  uint64_t words[kDescriptorBytes / sizeof(uint64_t)];
+};
+
+static __global__ void PublishTensorMaps(uint64_t* destination, TensorMapWords source) {
+  if (threadIdx.x < kDescriptorBytes / sizeof(uint64_t)) {
+    destination[threadIdx.x] = source.words[threadIdx.x];
+  }
+}
+
+struct TmaPointers {
+  void* q;
+  void* k;
+  void* v;
+  void* g;
+  void* do_;
+  void* state;
+  void* dv;
+  void* beta;
+};
+
+inline TmaPointers PrepareTensorMaps(const TensorView& q, const TensorView& k, const TensorView& v,
+                                     const TensorView& g, const TensorView& do_,
+                                     const TensorView& state, const TensorView& dv,
+                                     const TensorView& beta, const TensorView& descriptor_storage,
+                                     int64_t prepare_descriptors, cudaStream_t stream) {
+  if (prepare_descriptors != 0) {
+    cudaStreamCaptureStatus capture_status = cudaStreamCaptureStatusNone;
+    CheckCuda(cudaStreamIsCapturing(stream, &capture_status), "cudaStreamIsCapturing");
+    TVM_FFI_ICHECK(capture_status == cudaStreamCaptureStatusNone)
+        << "C16 descriptors must be warmed before CUDA graph capture";
+    const std::array<CUtensorMap, kTensorMapCount> maps = {
+        EncodeTokenTensor(q, "q"),   EncodeTokenTensor(k, "k"),    EncodeTokenTensor(v, "v"),
+        EncodeTokenTensor(g, "g"),   EncodeTokenTensor(do_, "do"), EncodeStateTensor(state),
+        EncodeTokenTensor(dv, "dv"), EncodeBetaTensor(beta),
+    };
+    TensorMapWords words{};
+    std::memcpy(words.words, maps.data(), sizeof(maps));
+    PublishTensorMaps<<<1, kDescriptorBytes / sizeof(uint64_t), 0, stream>>>(
+        reinterpret_cast<uint64_t*>(descriptor_storage.data_ptr()), words);
+    CheckCuda(cudaGetLastError(), "PublishTensorMaps launch");
+  }
+  auto* bytes = static_cast<unsigned char*>(descriptor_storage.data_ptr());
+  constexpr size_t stride = sizeof(CUtensorMap);
+  return {bytes + 0 * stride, bytes + 1 * stride, bytes + 2 * stride, bytes + 3 * stride,
+          bytes + 4 * stride, bytes + 5 * stride, bytes + 6 * stride, bytes + 7 * stride};
+}
+
+template <typename Kernel>
+inline void ConfigureDynamicSmem(Kernel kernel, int32_t bytes, int32_t device_id,
+                                 const char* name) {
+  CheckDynamicSmemCapacity(device_id, bytes);
+  CheckCuda(cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, bytes), name);
+}
+
+void RunC16Backward(TensorView q, TensorView k, TensorView v, TensorView g, TensorView A_log,
+                    TensorView dt_bias, TensorView do_, TensorView dfinal_state,
+                    TensorView cu_seqlens, TensorView backward_work_items,
+                    TensorView descriptor_storage, TensorView state_checkpoints,
+                    TensorView beta_active, TensorView dlog_decay, TensorView dlog_boundary,
+                    TensorView dbeta_active, TensorView gate_part_a, TensorView gate_part_dt,
+                    TensorView counter, TensorView dummy_u32, TensorView dummy_f32, TensorView dq,
+                    TensorView dk, TensorView dv, TensorView dg, TensorView dbeta,
+                    TensorView dA_log, TensorView ddt_bias, TensorView dinitial_state,
+                    int64_t prepare_descriptors, int64_t num_sequences, int64_t num_heads,
+                    double scale, double lower_bound, int64_t cuda_stream) {
+  TVM_FFI_ICHECK(q.device().device_type == kDLCUDA) << "q must be a CUDA tensor";
+  const int32_t device_id = q.device().device_id;
+  ffi::CUDADeviceGuard device_guard(device_id);
+  CheckFlashKDATarget(device_id);
+  TVM_FFI_ICHECK(num_sequences == kSequences && num_heads == kHeads)
+      << "the C16 route requires eight sequences and 96 heads";
+  TVM_FFI_ICHECK(prepare_descriptors == 0 || prepare_descriptors == 1);
+  TVM_FFI_ICHECK(std::abs(scale - 1.0 / std::sqrt(128.0)) <= 1e-15)
+      << "the C16 route fixes scale=1/sqrt(128)";
+  TVM_FFI_ICHECK(lower_bound == -5.0) << "the C16 route fixes lower_bound=-5.0";
+
+  for (const auto& named : std::initializer_list<std::pair<TensorView*, const char*>>{
+           {&q, "q"},
+           {&k, "k"},
+           {&v, "v"},
+           {&g, "g"},
+           {&do_, "do"},
+           {&state_checkpoints, "state_checkpoints"},
+           {&beta_active, "beta_active"},
+           {&dq, "dq"},
+           {&dk, "dk"},
+           {&dv, "dv"},
+           {&dg, "dg"},
+           {&dbeta, "dbeta"}}) {
+    CheckTensor(*named.first, named.second, device_id, dl_bfloat16);
+  }
+  for (const auto& named : std::initializer_list<std::pair<TensorView*, const char*>>{
+           {&A_log, "A_log"},
+           {&dt_bias, "dt_bias"},
+           {&dfinal_state, "dfinal_state"},
+           {&dlog_decay, "dlog_decay"},
+           {&dlog_boundary, "dlog_boundary"},
+           {&dbeta_active, "dbeta_active"},
+           {&gate_part_a, "gate_part_a"},
+           {&gate_part_dt, "gate_part_dt"},
+           {&dummy_f32, "dummy_f32"},
+           {&dA_log, "dA_log"},
+           {&ddt_bias, "ddt_bias"},
+           {&dinitial_state, "dinitial_state"}}) {
+    CheckTensor(*named.first, named.second, device_id, dl_float32);
+  }
+  CheckTensor(cu_seqlens, "cu_seqlens", device_id, dl_int64);
+  CheckTensor(backward_work_items, "backward_work_items", device_id, dl_int32);
+  CheckTensor(counter, "counter", device_id, dl_uint32);
+  CheckTensor(dummy_u32, "dummy_u32", device_id, dl_uint32);
+  CheckTensor(descriptor_storage, "descriptor_storage", device_id, dl_uint8);
+  CheckNumel(q, "q", kTokens * kHeads * kHeadDim);
+  CheckNumel(state_checkpoints, "state_checkpoints", kChunks * kHeads * kHeadDim * kHeadDim);
+  CheckNumel(backward_work_items, "backward_work_items", kWorkItems * 5);
+  TVM_FFI_ICHECK(descriptor_storage.numel() >= static_cast<int64_t>(kDescriptorBytes));
+  TVM_FFI_ICHECK(reinterpret_cast<uintptr_t>(descriptor_storage.data_ptr()) % 64 == 0);
+
+  const cudaStream_t stream = reinterpret_cast<cudaStream_t>(static_cast<uintptr_t>(cuda_stream));
+  const TmaPointers tma = PrepareTensorMaps(q, k, v, g, do_, state_checkpoints, dv, beta_active,
+                                            descriptor_storage, prepare_descriptors, stream);
+  int resident_ctas = 0;
+  CheckCuda(cudaDeviceGetAttribute(&resident_ctas, cudaDevAttrMultiProcessorCount, device_id),
+            "cudaDeviceGetAttribute(multiProcessorCount)");
+  const dim3 persistent_grid(std::min<int64_t>(kWorkItems, resident_ctas), 1, 1);
+
+  ConfigureDynamicSmem(kernel_flashkda_backward_persistent_c16, kBackwardSmemBytes, device_id,
+                       "cudaFuncSetAttribute(C16 backward)");
+  kernel_flashkda_backward_persistent_c16<<<persistent_grid, 512, kBackwardSmemBytes, stream>>>(
+      reinterpret_cast<unsigned int*>(counter.data_ptr()),
+      reinterpret_cast<flashkda_v483_generated_FlashKDATensorMap const*>(tma.q),
+      reinterpret_cast<flashkda_v483_generated_FlashKDATensorMap const*>(tma.k),
+      reinterpret_cast<flashkda_v483_generated_FlashKDATensorMap const*>(tma.g),
+      reinterpret_cast<flashkda_v483_generated_FlashKDATensorMap const*>(tma.do_),
+      reinterpret_cast<flashkda_v483_generated_FlashKDATensorMap const*>(tma.v),
+      reinterpret_cast<flashkda_v483_generated_FlashKDATensorMap const*>(tma.state),
+      reinterpret_cast<float*>(dfinal_state.data_ptr()),
+      reinterpret_cast<flashkda_v483_generated_FlashKDATensorMap const*>(tma.dv),
+      reinterpret_cast<__nv_bfloat16*>(dq.data_ptr()),
+      reinterpret_cast<__nv_bfloat16*>(dk.data_ptr()),
+      reinterpret_cast<float*>(dlog_decay.data_ptr()),
+      reinterpret_cast<float*>(dlog_boundary.data_ptr()),
+      reinterpret_cast<float*>(dinitial_state.data_ptr()),
+      reinterpret_cast<float*>(A_log.data_ptr()), reinterpret_cast<float*>(dt_bias.data_ptr()),
+      reinterpret_cast<flashkda_v483_generated_FlashKDATensorMap const*>(tma.beta),
+      reinterpret_cast<float*>(dbeta_active.data_ptr()),
+      reinterpret_cast<long long*>(cu_seqlens.data_ptr()),
+      reinterpret_cast<int*>(backward_work_items.data_ptr()),
+      reinterpret_cast<unsigned int*>(dummy_u32.data_ptr()),
+      reinterpret_cast<float*>(dummy_f32.data_ptr()),
+      reinterpret_cast<float*>(dummy_f32.data_ptr()),
+      reinterpret_cast<float*>(dummy_f32.data_ptr()),
+      reinterpret_cast<float*>(dummy_f32.data_ptr()),
+      reinterpret_cast<float*>(dummy_f32.data_ptr()),
+      reinterpret_cast<float*>(dummy_f32.data_ptr()),
+      reinterpret_cast<float*>(dummy_f32.data_ptr()),
+      reinterpret_cast<float*>(dummy_f32.data_ptr()),
+      reinterpret_cast<float*>(dummy_f32.data_ptr()),
+      reinterpret_cast<float*>(dummy_f32.data_ptr()),
+      reinterpret_cast<float*>(dummy_f32.data_ptr()),
+      reinterpret_cast<float*>(dummy_f32.data_ptr()),
+      reinterpret_cast<float*>(dummy_f32.data_ptr()),
+      reinterpret_cast<float*>(dummy_f32.data_ptr()), kWorkItems, 1, 64, kHeads, 1, 1,
+      static_cast<float>(scale), static_cast<float>(lower_bound));
+  CheckCuda(cudaGetLastError(), "C16 backward launch");
+
+  kernel_flashkda_backward_param_reduce_c16_partial<<<dim3(128, kHeads, 1), 128, 4096, stream>>>(
+      reinterpret_cast<__nv_bfloat16*>(g.data_ptr()),
+      reinterpret_cast<__nv_bfloat16*>(beta_active.data_ptr()),
+      reinterpret_cast<float*>(A_log.data_ptr()), reinterpret_cast<float*>(dt_bias.data_ptr()),
+      reinterpret_cast<float*>(dlog_decay.data_ptr()),
+      reinterpret_cast<float*>(dlog_boundary.data_ptr()),
+      reinterpret_cast<float*>(dbeta_active.data_ptr()),
+      reinterpret_cast<__nv_bfloat16*>(dg.data_ptr()),
+      reinterpret_cast<__nv_bfloat16*>(dbeta.data_ptr()),
+      reinterpret_cast<float*>(gate_part_a.data_ptr()),
+      reinterpret_cast<float*>(gate_part_dt.data_ptr()), kTokens, kHeads, 64,
+      static_cast<float>(lower_bound));
+  CheckCuda(cudaGetLastError(), "C16 parameter partial launch");
+  kernel_flashkda_backward_param_reduce_c16_finish<<<kHeads, 128, 16, stream>>>(
+      reinterpret_cast<float*>(gate_part_a.data_ptr()),
+      reinterpret_cast<float*>(gate_part_dt.data_ptr()),
+      reinterpret_cast<float*>(dA_log.data_ptr()), reinterpret_cast<float*>(ddt_bias.data_ptr()),
+      kHeads);
+  CheckCuda(cudaGetLastError(), "C16 parameter finish launch");
+}
+
+}  // namespace flash_kda_backward_v483
+}  // namespace flashinfer
+
+TVM_FFI_DLL_EXPORT_TYPED_FUNC(run_c16_backward,
+                              flashinfer::flash_kda_backward_v483::RunC16Backward);

--- a/csrc/kda/flashkda_bf16_fused_m128_n16_checkpoint.cu
+++ b/csrc/kda/flashkda_bf16_fused_m128_n16_checkpoint.cu
@@ -1,0 +1,3883 @@
+typedef signed char int8_t;
+typedef unsigned char uint8_t;
+typedef unsigned short uint16_t;
+typedef unsigned int uint32_t;
+typedef unsigned long long uint64_t;
+typedef signed int int32_t;
+typedef short int int16_t;
+struct __align__(128) LoomTensorMap {
+  uint64_t opaque[16];
+};
+template <int N>
+struct __align__(128) LoomTensorMapPack {
+  LoomTensorMap maps[N];
+};
+
+typedef struct __align__(64) {
+  uint64_t opaque[16];
+} CUtensorMap;
+
+#include <cuda_bf16.h>
+#include <math_constants.h>
+
+__device__ __forceinline__ uint32_t elect_sync() {
+  uint32_t pred = 0;
+  asm volatile(
+      "{\n\t"
+      ".reg .pred %%px;\n\t"
+      "elect.sync _|%%px, %1;\n\t"
+      "@%%px mov.s32 %0, 1;\n\t"
+      "}\n"
+      : "+r"(pred)
+      : "r"(0xFFFFFFFF));
+  return pred;
+}
+
+__device__ __forceinline__ void mbarrier_init(int mbar_addr, int count) {
+  asm volatile("mbarrier.init.shared::cta.b64 [%0], %1;" ::"r"(mbar_addr), "r"(count));
+}
+
+__device__ __forceinline__ uint32_t mbarrier_try_wait(int mbar_addr, int phase) {
+  uint32_t token;
+  asm volatile(
+      "{\n\t"
+      ".reg .pred P1;\n\t"
+      "mbarrier.try_wait.parity.acquire.cta.shared::cta.b64"
+      " P1, [%1], %2;\n\t"
+      "selp.u32 %0, 1, 0, P1;\n\t"
+      "}\n"
+      : "=r"(token)
+      : "r"(mbar_addr), "r"(phase)
+      : "memory");
+  return token;
+}
+
+__device__ __forceinline__ uint32_t mbarrier_try_wait_cluster(int mbar_addr, int phase) {
+  uint32_t token;
+  asm volatile(
+      "{\n\t"
+      ".reg .pred P1;\n\t"
+      "mbarrier.try_wait.parity.acquire.cluster.shared::cta.b64"
+      " P1, [%1], %2;\n\t"
+      "selp.u32 %0, 1, 0, P1;\n\t"
+      "}\n"
+      : "=r"(token)
+      : "r"(mbar_addr), "r"(phase)
+      : "memory");
+  return token;
+}
+
+__device__ __forceinline__ void mbarrier_wait(int mbar_addr, int phase) {
+  uint32_t ticks = 0x989680;
+  asm volatile(
+      "{\n\t"
+      ".reg .pred P1;\n\t"
+      "LAB_WAIT:\n\t"
+      "mbarrier.try_wait.parity.acquire.cta.shared::cta.b64"
+      " P1, [%0], %1, %2;\n\t"
+      "@P1 bra.uni DONE;\n\t"
+      "bra.uni LAB_WAIT;\n\t"
+      "DONE:\n\t"
+      "}\n" ::"r"(mbar_addr),
+      "r"(phase), "r"(ticks)
+      : "memory");
+}
+
+__device__ __forceinline__ void mbarrier_wait_cluster(int mbar_addr, int phase) {
+  uint32_t ticks = 0x989680;
+  asm volatile(
+      "{\n\t"
+      ".reg .pred P1;\n\t"
+      "LAB_WAIT_CLUSTER:\n\t"
+      "mbarrier.try_wait.parity.acquire.cluster.shared::cta.b64"
+      " P1, [%0], %1, %2;\n\t"
+      "@P1 bra.uni DONE_CLUSTER;\n\t"
+      "bra.uni LAB_WAIT_CLUSTER;\n\t"
+      "DONE_CLUSTER:\n\t"
+      "}\n" ::"r"(mbar_addr),
+      "r"(phase), "r"(ticks)
+      : "memory");
+}
+
+__device__ __forceinline__ void mbarrier_wait_token(int mbar_addr, int phase, uint32_t token) {
+  if (token == 0) {
+    mbarrier_wait(mbar_addr, phase);
+  }
+}
+
+__device__ __forceinline__ void mbarrier_wait_token_cluster(int mbar_addr, int phase,
+                                                            uint32_t token) {
+  if (token == 0) {
+    mbarrier_wait_cluster(mbar_addr, phase);
+  }
+}
+
+__device__ __forceinline__ void tcgen05_mma_f16(int taddr, uint64_t a_desc, uint64_t b_desc,
+                                                uint32_t i_desc, int enable_input_d) {
+  asm volatile(
+      "{\n\t"
+      ".reg .pred p;\n\t"
+      "setp.ne.b32 p, %4, 0;\n\t"
+      "tcgen05.mma.cta_group::1.kind::f16 [%0], %1, %2, %3, p;\n\t"
+      "}\n" ::"r"(taddr),
+      "l"(a_desc), "l"(b_desc), "r"(i_desc), "r"(enable_input_d));
+}
+
+__device__ __forceinline__ uint64_t desc_encode(uint64_t x) { return (x & 0x3FFFFULL) >> 4ULL; }
+
+__device__ __forceinline__ void mma_ts_step(int taddr_out, int taddr_a, int b_lo, uint32_t b_dhi,
+                                            uint32_t i_desc, int enable_d) {
+  asm volatile(
+      "{\n\t"
+      ".reg .pred leader, p;\n\t"
+      ".reg .b32 dhi;\n\t"
+      ".reg .b64 db;\n\t"
+      "elect.sync _|leader, 0xFFFFFFFF;\n\t"
+      "setp.ne.b32 p, %5, 0;\n\t"
+      "mov.b32 dhi, %3;\n\t"
+      "mov.b64 db, {%2, dhi};\n\t"
+      "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [%1], db, %4, p;\n\t"
+      "}\n" ::"r"(taddr_out),
+      "r"(taddr_a), "r"(b_lo), "r"(b_dhi), "r"(i_desc), "r"(enable_d));
+}
+
+__device__ __forceinline__ void elect_commit(int mbar_addr) {
+  asm volatile(
+      "{\n\t"
+      ".reg .pred leader;\n\t"
+      "elect.sync _|leader, 0xFFFFFFFF;\n\t"
+      "@leader tcgen05.commit.cta_group::1.mbarrier::arrive::one"
+      ".shared::cluster.b64 [%0];\n\t"
+      "}\n" ::"r"(mbar_addr));
+}
+
+__device__ __forceinline__ void mbarrier_arrive(int mbar_addr) {
+  asm volatile("mbarrier.arrive.release.cta.shared::cta.b64 _, [%0];" ::"r"(mbar_addr) : "memory");
+}
+
+__device__ __forceinline__ void mbarrier_arrive_expect_tx(int mbar_addr, uint32_t bytes) {
+  asm volatile(
+      "mbarrier.arrive.expect_tx.release.cta.shared::cta.b64 _, [%0], %1;" ::"r"(mbar_addr),
+      "r"(bytes)
+      : "memory");
+}
+
+__device__ __forceinline__ void tmem_ld_x32(float* dst, int tmem_addr) {
+  asm volatile(
+      "tcgen05.ld.sync.aligned.32x32b.x32.b32"
+      " {%0, %1, %2, %3, %4, %5, %6, %7,"
+      "  %8, %9, %10, %11, %12, %13, %14, %15,"
+      "  %16, %17, %18, %19, %20, %21, %22, %23,"
+      "  %24, %25, %26, %27, %28, %29, %30, %31}, [%32];"
+      : "=f"(dst[0]), "=f"(dst[1]), "=f"(dst[2]), "=f"(dst[3]), "=f"(dst[4]), "=f"(dst[5]),
+        "=f"(dst[6]), "=f"(dst[7]), "=f"(dst[8]), "=f"(dst[9]), "=f"(dst[10]), "=f"(dst[11]),
+        "=f"(dst[12]), "=f"(dst[13]), "=f"(dst[14]), "=f"(dst[15]), "=f"(dst[16]), "=f"(dst[17]),
+        "=f"(dst[18]), "=f"(dst[19]), "=f"(dst[20]), "=f"(dst[21]), "=f"(dst[22]), "=f"(dst[23]),
+        "=f"(dst[24]), "=f"(dst[25]), "=f"(dst[26]), "=f"(dst[27]), "=f"(dst[28]), "=f"(dst[29]),
+        "=f"(dst[30]), "=f"(dst[31])
+      : "r"(tmem_addr));
+}
+
+__device__ __forceinline__ void tmem_ld_x16(float* dst, int tmem_addr) {
+  asm volatile(
+      "tcgen05.ld.sync.aligned.32x32b.x16.b32"
+      " {%0, %1, %2, %3, %4, %5, %6, %7,"
+      "  %8, %9, %10, %11, %12, %13, %14, %15}, [%16];"
+      : "=f"(dst[0]), "=f"(dst[1]), "=f"(dst[2]), "=f"(dst[3]), "=f"(dst[4]), "=f"(dst[5]),
+        "=f"(dst[6]), "=f"(dst[7]), "=f"(dst[8]), "=f"(dst[9]), "=f"(dst[10]), "=f"(dst[11]),
+        "=f"(dst[12]), "=f"(dst[13]), "=f"(dst[14]), "=f"(dst[15])
+      : "r"(tmem_addr));
+}
+
+__device__ __forceinline__ void tmem_st_x32_f32(int tmem_addr, const float* src) {
+  asm volatile(
+      "tcgen05.st.sync.aligned.32x32b.x32.b32"
+      " [%0], {%1, %2, %3, %4, %5, %6, %7, %8,"
+      "  %9, %10, %11, %12, %13, %14, %15, %16,"
+      "  %17, %18, %19, %20, %21, %22, %23, %24,"
+      "  %25, %26, %27, %28, %29, %30, %31, %32};" ::"r"(tmem_addr),
+      "f"(src[0]), "f"(src[1]), "f"(src[2]), "f"(src[3]), "f"(src[4]), "f"(src[5]), "f"(src[6]),
+      "f"(src[7]), "f"(src[8]), "f"(src[9]), "f"(src[10]), "f"(src[11]), "f"(src[12]), "f"(src[13]),
+      "f"(src[14]), "f"(src[15]), "f"(src[16]), "f"(src[17]), "f"(src[18]), "f"(src[19]),
+      "f"(src[20]), "f"(src[21]), "f"(src[22]), "f"(src[23]), "f"(src[24]), "f"(src[25]),
+      "f"(src[26]), "f"(src[27]), "f"(src[28]), "f"(src[29]), "f"(src[30]), "f"(src[31]));
+}
+
+__device__ __forceinline__ float approx_exp2(float x) {
+  float y;
+  asm("ex2.approx.ftz.f32 %0, %1;" : "=f"(y) : "f"(x));
+  return y;
+}
+
+__device__ __forceinline__ float approx_rcp(float x) {
+  float y;
+  asm("rcp.approx.ftz.f32 %0, %1;" : "=f"(y) : "f"(x));
+  return y;
+}
+
+__device__ __forceinline__ float max_noftz(float a, float b) {
+  float c;
+  asm("max.f32 %0, %1, %2;" : "=f"(c) : "f"(a), "f"(b));
+  return c;
+}
+
+__device__ __forceinline__ void ex2_emulation_f32x2(float* x0_ptr, float* x1_ptr) {
+  const float c0 = 1.0f, c1 = 0.695146143436431884765625f;
+  const float c2 = 0.227564394474029541015625f, c3 = 0.077119089663028717041015625f;
+  const float magic = 12582912.0f;
+  float x0 = max_noftz(*x0_ptr, -127.0f), x1 = max_noftz(*x1_ptr, -127.0f);
+  float2 xc2 = make_float2(x0, x1), magic2 = make_float2(magic, magic);
+  float2 xr2;
+  asm("add.rm.ftz.f32x2 %0, %1, %2;"
+      : "=l"(*(unsigned long long*)&xr2)
+      : "l"(*(unsigned long long*)&xc2), "l"(*(unsigned long long*)&magic2));
+  float2 c3_2 = make_float2(c3, c3), c2_2 = make_float2(c2, c2);
+  float2 c1_2 = make_float2(c1, c1), c0_2 = make_float2(c0, c0);
+  float2 xrb2, xfrac2;
+  asm("sub.rn.ftz.f32x2 %0, %1, %2;"
+      : "=l"(*(unsigned long long*)&xrb2)
+      : "l"(*(unsigned long long*)&xr2), "l"(*(unsigned long long*)&magic2));
+  asm("sub.rn.ftz.f32x2 %0, %1, %2;"
+      : "=l"(*(unsigned long long*)&xfrac2)
+      : "l"(*(unsigned long long*)&xc2), "l"(*(unsigned long long*)&xrb2));
+  float2 poly2;
+  asm("fma.rn.ftz.f32x2 %0, %1, %2, %3;"
+      : "=l"(*(unsigned long long*)&poly2)
+      : "l"(*(unsigned long long*)&c3_2), "l"(*(unsigned long long*)&xfrac2),
+        "l"(*(unsigned long long*)&c2_2));
+  asm("fma.rn.ftz.f32x2 %0, %1, %2, %3;"
+      : "=l"(*(unsigned long long*)&poly2)
+      : "l"(*(unsigned long long*)&poly2), "l"(*(unsigned long long*)&xfrac2),
+        "l"(*(unsigned long long*)&c1_2));
+  asm("fma.rn.ftz.f32x2 %0, %1, %2, %3;"
+      : "=l"(*(unsigned long long*)&poly2)
+      : "l"(*(unsigned long long*)&poly2), "l"(*(unsigned long long*)&xfrac2),
+        "l"(*(unsigned long long*)&c0_2));
+  int x0r_i, x1r_i, p0_i, p1_i;
+  asm("mov.b64 {%0, %1}, %2;" : "=r"(x0r_i), "=r"(x1r_i) : "l"(*(unsigned long long*)&xr2));
+  asm("mov.b64 {%0, %1}, %2;" : "=r"(p0_i), "=r"(p1_i) : "l"(*(unsigned long long*)&poly2));
+  float r0, r1;
+  asm("mov.b32 %0, %1;" : "=f"(r0) : "r"((x0r_i << 23) + p0_i));
+  asm("mov.b32 %0, %1;" : "=f"(r1) : "r"((x1r_i << 23) + p1_i));
+  *x0_ptr = r0;
+  *x1_ptr = r1;
+}
+
+__device__ __forceinline__ void softmax_frag_exp2_cast(float* sv, uint32_t* pv, int use_emu) {
+#pragma unroll
+
+  for (int j = 0; j < 16; j++) {
+    if (use_emu && j >= 12)
+      ex2_emulation_f32x2(&sv[j * 2], &sv[j * 2 + 1]);
+    else {
+      sv[j * 2] = approx_exp2(sv[j * 2]);
+      sv[j * 2 + 1] = approx_exp2(sv[j * 2 + 1]);
+    }
+  }
+
+  for (int j = 0; j < 16; j++) {
+    __nv_bfloat162 bf = __float22bfloat162_rn({sv[j * 2], sv[j * 2 + 1]});
+    pv[j] = reinterpret_cast<uint32_t&>(bf);
+  }
+}
+
+__device__ __forceinline__ void fma_f32x2_inplace(float2* a, float2 b, float2 c) {
+  unsigned long long r;
+  asm("fma.rn.ftz.f32x2 %0, %1, %2, %3;"
+      : "=l"(r)
+      : "l"(*(unsigned long long*)a), "l"(*(unsigned long long*)&b), "l"(*(unsigned long long*)&c));
+  *(unsigned long long*)a = r;
+}
+
+__device__ __forceinline__ void mul_f32x2_inplace(float2* a, float2 b) {
+  asm("mul.rn.ftz.f32x2 %0, %0, %1;"
+      : "+l"(*(unsigned long long*)a)
+      : "l"(*(unsigned long long*)&b));
+}
+
+__device__ __forceinline__ void add_f32x2_inplace(float2* a, float2 b) {
+  asm("add.rn.ftz.f32x2 %0, %0, %1;"
+      : "+l"(*(unsigned long long*)a)
+      : "l"(*(unsigned long long*)&b));
+}
+
+__device__ __forceinline__ void sub_f32x2_inplace(float2* a, float2 b) {
+  asm("sub.rn.ftz.f32x2 %0, %0, %1;"
+      : "+l"(*(unsigned long long*)a)
+      : "l"(*(unsigned long long*)&b));
+}
+
+__device__ __forceinline__ float2 add_f32x2(float2 a, float2 b) {
+  float2 r;
+  asm("add.rn.ftz.f32x2 %0, %1, %2;"
+      : "=l"(*(unsigned long long*)&r)
+      : "l"(*(unsigned long long*)&a), "l"(*(unsigned long long*)&b));
+  return r;
+}
+
+__device__ __forceinline__ float2 sub_f32x2(float2 a, float2 b) {
+  float2 r;
+  asm("sub.rn.ftz.f32x2 %0, %1, %2;"
+      : "=l"(*(unsigned long long*)&r)
+      : "l"(*(unsigned long long*)&a), "l"(*(unsigned long long*)&b));
+  return r;
+}
+
+__device__ __forceinline__ void fma_scale_x32(float* sv, const float2* scale2,
+                                              const float2* neg_max2) {
+  float2* sv_2 = reinterpret_cast<float2*>(sv);
+
+  for (int j = 0; j < 16; j++) fma_f32x2_inplace(&sv_2[j], *scale2, *neg_max2);
+}
+
+__device__ __forceinline__ float2 fma_f32x2(float2 a, float2 b, float2 c) {
+  float2 r;
+  asm("fma.rn.ftz.f32x2 %0, %1, %2, %3;"
+      : "=l"(*(unsigned long long*)&r)
+      : "l"(*(unsigned long long*)&a), "l"(*(unsigned long long*)&b),
+        "l"(*(unsigned long long*)&c));
+  return r;
+}
+
+__device__ __forceinline__ float2 fma_sub_f32x2(float2 a, float2 b, float2 c) {
+  float2 r;
+  asm volatile(
+      "{\n\t"
+      ".reg .f32 _c0, _c1;\n\t"
+      ".reg .b64 _neg_c;\n\t"
+      "mov.b64 {_c0, _c1}, %3;\n\t"
+      "neg.f32 _c0, _c0;\n\t"
+      "neg.f32 _c1, _c1;\n\t"
+      "mov.b64 _neg_c, {_c0, _c1};\n\t"
+      "fma.rn.ftz.f32x2 %0, %1, %2, _neg_c;\n\t"
+      "}\n"
+      : "=l"(*(unsigned long long*)&r)
+      : "l"(*(unsigned long long*)&a), "l"(*(unsigned long long*)&b),
+        "l"(*(unsigned long long*)&c));
+  return r;
+}
+
+__device__ __forceinline__ float2 mul_f32x2(float2 a, float2 b) {
+  float2 r;
+  asm("mul.rn.ftz.f32x2 %0, %1, %2;"
+      : "=l"(*(unsigned long long*)&r)
+      : "l"(*(unsigned long long*)&a), "l"(*(unsigned long long*)&b));
+  return r;
+}
+
+// ex2_emulation_f32x2 defined in softmax_frag_exp2_cast helper (or standalone)
+
+__device__ __forceinline__ void elect_commit2(int mbar_addr0, int mbar_addr1) {
+  asm volatile(
+      "{\n\t"
+      ".reg .pred leader;\n\t"
+      "elect.sync _|leader, 0xFFFFFFFF;\n\t"
+      "@leader tcgen05.commit.cta_group::1.mbarrier::arrive::one"
+      ".shared::cluster.b64 [%0];\n\t"
+      "@leader tcgen05.commit.cta_group::1.mbarrier::arrive::one"
+      ".shared::cluster.b64 [%1];\n\t"
+      "}\n" ::"r"(mbar_addr0),
+      "r"(mbar_addr1)
+      : "memory");
+}
+
+__device__ __forceinline__ void fence_async_shared() {
+  asm volatile("fence.proxy.async.shared::cta;" ::: "memory");
+}
+
+__device__ __forceinline__ uint64_t make_smem_desc(int addr) {
+  const int SBO = 1024;
+  return desc_encode(addr) | (desc_encode(SBO) << 32ULL) | (1ULL << 46ULL) | (2ULL << 61ULL);
+}
+
+__device__ __forceinline__ void tma_3d_gmem2smem(int dst, const void* tmap_ptr, int x, int y, int z,
+                                                 int mbar_addr) {
+  asm volatile(
+      "cp.async.bulk.tensor.3d.shared::cta.global"
+      ".mbarrier::complete_tx::bytes"
+      " [%0], [%1, {%2, %3, %4}], [%5];" ::"r"(dst),
+      "l"(tmap_ptr), "r"(x), "r"(y), "r"(z), "r"(mbar_addr)
+      : "memory");
+}
+
+__device__ __forceinline__ void tma_2d_gmem2smem(int dst, const void* tmap_ptr, int x, int y,
+                                                 int mbar_addr) {
+  asm volatile(
+      "cp.async.bulk.tensor.2d.shared::cta.global"
+      ".mbarrier::complete_tx::bytes"
+      " [%0], [%1, {%2, %3}], [%4];" ::"r"(dst),
+      "l"(tmap_ptr), "r"(x), "r"(y), "r"(mbar_addr)
+      : "memory");
+}
+
+__device__ __forceinline__ void tma_4d_gmem2smem(int dst, const void* tmap_ptr, int x, int y, int z,
+                                                 int w, int mbar_addr) {
+  asm volatile(
+      "cp.async.bulk.tensor.4d.shared::cta.global"
+      ".mbarrier::complete_tx::bytes"
+      " [%0], [%1, {%2, %3, %4, %5}], [%6];" ::"r"(dst),
+      "l"(tmap_ptr), "r"(x), "r"(y), "r"(z), "r"(w), "r"(mbar_addr)
+      : "memory");
+}
+
+__device__ __forceinline__ void tma_store_4d(const void* tmap, int x, int y, int z, int w,
+                                             unsigned smem_addr) {
+  asm volatile(
+      "cp.async.bulk.tensor.4d.global.shared::cta.tile.bulk_group"
+      " [%0, {%1, %2, %3, %4}], [%5];" ::"l"(tmap),
+      "r"(x), "r"(y), "r"(z), "r"(w), "r"(smem_addr)
+      : "memory");
+}
+
+__device__ __forceinline__ void tcgen05_commit(int mbar_addr) {
+  asm volatile(
+      "tcgen05.commit.cta_group::1.mbarrier::arrive::one"
+      ".shared::cluster.b64 [%0];" ::"r"(mbar_addr)
+      : "memory");
+}
+
+__device__ __forceinline__ void tmem_ld_x8(float* dst, int tmem_addr) {
+  asm volatile(
+      "tcgen05.ld.sync.aligned.32x32b.x8.b32"
+      " {%0, %1, %2, %3, %4, %5, %6, %7}, [%8];"
+      : "=f"(dst[0]), "=f"(dst[1]), "=f"(dst[2]), "=f"(dst[3]), "=f"(dst[4]), "=f"(dst[5]),
+        "=f"(dst[6]), "=f"(dst[7])
+      : "r"(tmem_addr));
+}
+
+__device__ __forceinline__ void tmem_st_x8_u32(int addr, const uint32_t* src) {
+  asm volatile(
+      "tcgen05.st.sync.aligned.32x32b.x8.b32"
+      " [%0], {%1,%2,%3,%4,%5,%6,%7,%8};" ::"r"(addr),
+      "r"(src[0]), "r"(src[1]), "r"(src[2]), "r"(src[3]), "r"(src[4]), "r"(src[5]), "r"(src[6]),
+      "r"(src[7]));
+}
+
+__device__ __forceinline__ uint32_t make_warp_uniform(uint32_t val) {
+  uint32_t result;
+  asm volatile("shfl.sync.idx.b32 %0, %1, 0, 0x1f, 0xffffffff;" : "=r"(result) : "r"(val));
+  return result;
+}
+
+#define LOOM_INF CUDART_INF_F
+#define TMEM_NCOLS 240
+#define TMEM_TMEM_STATE_OFFSET 64
+#define TMEM_TMEM_STATE_INP_OFFSET 0
+#define TMEM_TMEM_U_ACC_OFFSET 224
+#define TMEM_TMEM_U2_INP_OFFSET 224
+#define TMEM_TMEM_U2_ACC_OFFSET 208
+#define TMEM_TMEM_OUT_OFFSET 192
+#define TMEM_TMEM_STATE_OUT_OFFSET 64
+#define NUM_CHUNK_PIPE_STAGES 5
+#define NUM_CHECKPOINT_PIPE_STAGES 2
+#define SMEM_SMEM_QD_OFF 1024
+#define SMEM_SMEM_QD_STAGE_BYTES 4096
+#define SMEM_SMEM_QD_STRIDE 21504
+#define SMEM_SMEM_G_RAW_OFF 1024
+#define SMEM_SMEM_G_RAW_STAGE_BYTES 4096
+#define SMEM_SMEM_G_RAW_STRIDE 21504
+#define SMEM_SMEM_G_RAW_ALL_OFF 1024
+#define SMEM_SMEM_G_RAW_ALL_STAGE_BYTES 90112
+#define SMEM_SMEM_G_RAW_ALL_STRIDE 90112
+#define SMEM_SMEM_KD_OFF 5120
+#define SMEM_SMEM_KD_STAGE_BYTES 4096
+#define SMEM_SMEM_KD_STRIDE 21504
+#define SMEM_SMEM_Q_RAW_PREFETCH_OFF 9216
+#define SMEM_SMEM_Q_RAW_PREFETCH_STAGE_BYTES 4096
+#define SMEM_SMEM_Q_RAW_PREFETCH_STRIDE 21504
+#define SMEM_SMEM_FINAL_TRANS_OFF 9216
+#define SMEM_SMEM_FINAL_TRANS_STAGE_BYTES 6144
+#define SMEM_SMEM_FINAL_TRANS_STRIDE 21504
+#define SMEM_SMEM_KR_TRANS_OFF 9216
+#define SMEM_SMEM_KR_TRANS_STAGE_BYTES 4096
+#define SMEM_SMEM_KR_TRANS_STRIDE 21504
+#define SMEM_SMEM_MQK_TRANS_OFF 13312
+#define SMEM_SMEM_MQK_TRANS_STAGE_BYTES 512
+#define SMEM_SMEM_MQK_TRANS_STRIDE 21504
+#define SMEM_SMEM_INV_OFF 15360
+#define SMEM_SMEM_INV_STAGE_BYTES 512
+#define SMEM_SMEM_INV_STRIDE 21504
+#define SMEM_SMEM_V_OFF 16512
+#define SMEM_SMEM_V_STAGE_BYTES 4096
+#define SMEM_SMEM_V_STRIDE 21504
+#define SMEM_SMEM_SHORT_N32_V_OFF 87040
+#define SMEM_SMEM_SHORT_N32_V_STAGE_BYTES 16384
+#define SMEM_SMEM_SHORT_N32_V_STRIDE 16384
+#define SMEM_SMEM_KI_OFF 9216
+#define SMEM_SMEM_KI_STAGE_BYTES 4096
+#define SMEM_SMEM_KI_STRIDE 21504
+#define SMEM_SMEM_GATE_OFF 13312
+#define SMEM_SMEM_GATE_STAGE_BYTES 8192
+#define SMEM_SMEM_GATE_STRIDE 21504
+#define SMEM_SMEM_BETA_RAW_OFF 21504
+#define SMEM_SMEM_BETA_RAW_STAGE_BYTES 256
+#define SMEM_SMEM_BETA_RAW_STRIDE 21504
+#define SMEM_SMEM_BETA_RAW_ALL_OFF 21504
+#define SMEM_SMEM_BETA_RAW_ALL_STAGE_BYTES 86272
+#define SMEM_SMEM_BETA_RAW_ALL_STRIDE 86272
+#define SMEM_SMEM_INV_WORK_OFF 16512
+#define SMEM_SMEM_INV_WORK_STAGE_BYTES 4096
+#define SMEM_SMEM_INV_WORK_STRIDE 21504
+#define SMEM_SMEM_OUT_OFF 108544
+#define SMEM_SMEM_OUT_STAGE_BYTES 4096
+#define SMEM_SMEM_OUT_STRIDE 4096
+#define SMEM_SMEM_CHECKPOINT_OFF 117760
+#define SMEM_SMEM_CHECKPOINT_STAGE_BYTES 32768
+#define SMEM_SMEM_CHECKPOINT_STRIDE 32768
+#define SMEM_SMEM_RESTORE_FACTOR_ALL_OFF 21504
+#define SMEM_SMEM_RESTORE_FACTOR_ALL_STAGE_BYTES 86532
+#define SMEM_SMEM_RESTORE_FACTOR_ALL_STRIDE 86532
+#define SMEM_SMEM_GT_PREFIX_ALL_OFF 20992
+#define SMEM_SMEM_GT_PREFIX_ALL_STAGE_BYTES 86528
+#define SMEM_SMEM_GT_PREFIX_ALL_STRIDE 86528
+#define SMEM_SMEM_GT_ALL_OFF 15872
+#define SMEM_SMEM_GT_ALL_STAGE_BYTES 86528
+#define SMEM_SMEM_GT_ALL_STRIDE 86528
+#define SMEM_SMEM_PREP_BETA_ALL_OFF 22020
+#define SMEM_SMEM_PREP_BETA_ALL_STAGE_BYTES 86080
+#define SMEM_SMEM_PREP_BETA_ALL_STRIDE 86080
+#define SMEM_SMEM_PREP_BETA_BF16_ALL_OFF 22020
+#define SMEM_SMEM_PREP_BETA_BF16_ALL_STAGE_BYTES 86048
+#define SMEM_SMEM_PREP_BETA_BF16_ALL_STRIDE 86048
+#define SMEM_SMEM_PREP_BETA_U32_ALL_OFF 22020
+#define SMEM_SMEM_PREP_BETA_U32_ALL_STAGE_BYTES 86048
+#define SMEM_SMEM_PREP_BETA_U32_ALL_STRIDE 86048
+#define SMEM_SMEM_GATE_RATE_ALL_OFF 22084
+#define SMEM_SMEM_GATE_RATE_ALL_STAGE_BYTES 86020
+#define SMEM_SMEM_GATE_RATE_ALL_STRIDE 86020
+#define SMEM_SMEM_GATE_BIAS_ALL_OFF 116816
+#define SMEM_SMEM_GATE_BIAS_ALL_STAGE_BYTES 512
+#define SMEM_SMEM_GATE_BIAS_ALL_STRIDE 512
+#define SMEM_SMEM_V_ALL_OFF 16512
+#define SMEM_SMEM_V_ALL_STAGE_BYTES 90112
+#define SMEM_SMEM_V_ALL_STRIDE 90112
+#define SMEM_SMEM_GATE_ALL_OFF 13312
+#define SMEM_SMEM_GATE_ALL_STAGE_BYTES 94208
+#define SMEM_SMEM_GATE_ALL_STRIDE 94208
+#define SMEM_SMEM_STATE_CHECKPOINT_NEEDED_OFF 116736
+#define SMEM_SMEM_STATE_CHECKPOINT_NEEDED_STAGE_BYTES 80
+#define SMEM_SMEM_STATE_CHECKPOINT_NEEDED_STRIDE 80
+#define SMEM_SMEM_WORK_ITEM_WARP_MAX_OFF 116736
+#define SMEM_SMEM_WORK_ITEM_WARP_MAX_STAGE_BYTES 16
+#define SMEM_SMEM_WORK_ITEM_WARP_MAX_STRIDE 16
+#define SMEM_SMEM_WORK_ITEM_COMPUTE_START_OFF 116752
+#define SMEM_SMEM_WORK_ITEM_COMPUTE_START_STAGE_BYTES 4
+#define SMEM_SMEM_WORK_ITEM_COMPUTE_START_STRIDE 4
+#define SMEM_SMEM_WORK_ITEM_RESOLVED_OFF 116756
+#define SMEM_SMEM_WORK_ITEM_RESOLVED_STAGE_BYTES 4
+#define SMEM_SMEM_WORK_ITEM_RESOLVED_STRIDE 4
+#define SMEM_TOTAL 183296
+#define STORE_BACKWARD_TAPE 0
+#define STORE_E_TAPE 1
+#define SPLIT_WORK_ITEMS 0
+
+extern "C" {
+
+__global__ __launch_bounds__(1024) void kernel_flashkda_bf16_fused_m128(
+    __nv_bfloat16* __restrict__ q, LoomTensorMap const* q_tma, __nv_bfloat16* __restrict__ k,
+    LoomTensorMap const* k_tma, __nv_bfloat16* __restrict__ v, LoomTensorMap const* v_tma,
+    __nv_bfloat16* __restrict__ g, LoomTensorMap const* g_tma, __nv_bfloat16* __restrict__ beta,
+    LoomTensorMap const* beta_tma, float* __restrict__ A_log, float* __restrict__ dt_bias,
+    long long* __restrict__ cu_seqlens, int* __restrict__ seq_order,
+    __nv_bfloat16* __restrict__ initial_state, __nv_bfloat16* __restrict__ out,
+    LoomTensorMap const* out_tma, __nv_bfloat16* __restrict__ final_state, int num_heads,
+    int use_initial_state, int store_final_state, float scale, float lower_bound,
+    unsigned long long state_indices_addr, unsigned long long state_checkpoints_addr,
+    unsigned long long checkpoint_cu_starts_addr, long long beta_token_stride,
+    long long state_slot_stride, int use_state_indices, int checkpoint_every_n_tokens,
+    long long* __restrict__ cu_chunk_offsets, __nv_bfloat16* __restrict__ chunk_state,
+    unsigned int* __restrict__ state_checkpoint_needed, __nv_bfloat16* __restrict__ tape_qd,
+    __nv_bfloat16* __restrict__ tape_kd, __nv_bfloat16* __restrict__ tape_kr,
+    __nv_bfloat16* __restrict__ tape_j, float* __restrict__ tape_restore_factor,
+    __nv_bfloat16* __restrict__ tape_e, __nv_bfloat16* __restrict__ tape_x,
+    __nv_bfloat16* __restrict__ tape_r, float* __restrict__ norm_inv_out,
+    __nv_bfloat16* __restrict__ decay_out, float* __restrict__ beta_active_out,
+    float* __restrict__ initial_state_f32, unsigned int* __restrict__ zero_workspace,
+    int zero_words, int num_sequences, LoomTensorMap const* state_checkpoints_tma) {
+  const int tid = threadIdx.x;
+  const int warp = make_warp_uniform(tid / 32);
+  const int lane = tid % 32;
+
+  extern __shared__ __align__(1024) char smem_raw[];
+  int smem;
+  smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+
+  const int bid = blockIdx.x;
+  const int num_bids = gridDim.x;
+  if (warp == 8 && lane == 0) {
+    asm volatile("fence.proxy.tensormap::generic.acquire.sys [%0], 128;" ::"l"((uint64_t)(q_tma))
+                 : "memory");
+    asm volatile("fence.proxy.tensormap::generic.acquire.sys [%0], 128;" ::"l"((uint64_t)(k_tma))
+                 : "memory");
+    asm volatile("fence.proxy.tensormap::generic.acquire.sys [%0], 128;" ::"l"((uint64_t)(v_tma))
+                 : "memory");
+    asm volatile("fence.proxy.tensormap::generic.acquire.sys [%0], 128;" ::"l"((uint64_t)(g_tma))
+                 : "memory");
+    asm volatile("fence.proxy.tensormap::generic.acquire.sys [%0], 128;" ::"l"((uint64_t)(beta_tma))
+                 : "memory");
+    asm volatile("fence.proxy.tensormap::generic.acquire.sys [%0], 128;" ::"l"((uint64_t)(out_tma))
+                 : "memory");
+    asm volatile("fence.proxy.tensormap::generic.acquire.sys [%0], 128;" ::"l"(
+                     (uint64_t)(state_checkpoints_tma))
+                 : "memory");
+  }
+
+  // Kernel setup ops
+  __nv_bfloat16* smem_qd = reinterpret_cast<__nv_bfloat16*>(smem_raw + 1024);
+  const int smem_qd_addr = smem + 1024;
+  __nv_bfloat16* smem_g_raw = reinterpret_cast<__nv_bfloat16*>(smem_raw + 1024);
+  const int smem_g_raw_addr = smem + 1024;
+  __nv_bfloat16* smem_g_raw_all = reinterpret_cast<__nv_bfloat16*>(smem_raw + 1024);
+  const int smem_g_raw_all_addr = smem + 1024;
+  __nv_bfloat16* smem_kd = reinterpret_cast<__nv_bfloat16*>(smem_raw + 5120);
+  const int smem_kd_addr = smem + 5120;
+  __nv_bfloat16* smem_q_raw_prefetch = reinterpret_cast<__nv_bfloat16*>(smem_raw + 9216);
+  const int smem_q_raw_prefetch_addr = smem + 9216;
+  __nv_bfloat16* smem_final_trans = reinterpret_cast<__nv_bfloat16*>(smem_raw + 9216);
+  const int smem_final_trans_addr = smem + 9216;
+  __nv_bfloat16* smem_kr_trans = reinterpret_cast<__nv_bfloat16*>(smem_raw + 9216);
+  const int smem_kr_trans_addr = smem + 9216;
+  __nv_bfloat16* smem_mqk_trans = reinterpret_cast<__nv_bfloat16*>(smem_raw + 13312);
+  const int smem_mqk_trans_addr = smem + 13312;
+  __nv_bfloat16* smem_inv = reinterpret_cast<__nv_bfloat16*>(smem_raw + 15360);
+  const int smem_inv_addr = smem + 15360;
+  __nv_bfloat16* smem_v = reinterpret_cast<__nv_bfloat16*>(smem_raw + 16512);
+  const int smem_v_addr = smem + 16512;
+  __nv_bfloat16* smem_short_n32_v = reinterpret_cast<__nv_bfloat16*>(smem_raw + 87040);
+  const int smem_short_n32_v_addr = smem + 87040;
+  __nv_bfloat16* smem_ki = reinterpret_cast<__nv_bfloat16*>(smem_raw + 9216);
+  const int smem_ki_addr = smem + 9216;
+  float* smem_gate = reinterpret_cast<float*>(smem_raw + 13312);
+  const int smem_gate_addr = smem + 13312;
+  __nv_bfloat16* smem_beta_raw = reinterpret_cast<__nv_bfloat16*>(smem_raw + 21504);
+  const int smem_beta_raw_addr = smem + 21504;
+  __nv_bfloat16* smem_beta_raw_all = reinterpret_cast<__nv_bfloat16*>(smem_raw + 21504);
+  const int smem_beta_raw_all_addr = smem + 21504;
+  __nv_bfloat16* smem_inv_work = reinterpret_cast<__nv_bfloat16*>(smem_raw + 16512);
+  const int smem_inv_work_addr = smem + 16512;
+  __nv_bfloat16* smem_out = reinterpret_cast<__nv_bfloat16*>(smem_raw + 108544);
+  const int smem_out_addr = smem + 108544;
+  __nv_bfloat16* smem_checkpoint = reinterpret_cast<__nv_bfloat16*>(smem_raw + 117760);
+  const int smem_checkpoint_addr = smem + 117760;
+  float* smem_restore_factor_all = reinterpret_cast<float*>(smem_raw + 21504);
+  const int smem_restore_factor_all_addr = smem + 21504;
+  float* smem_gt_prefix_all = reinterpret_cast<float*>(smem_raw + 20992);
+  const int smem_gt_prefix_all_addr = smem + 20992;
+  float* smem_gt_all = reinterpret_cast<float*>(smem_raw + 15872);
+  const int smem_gt_all_addr = smem + 15872;
+  float* smem_prep_beta_all = reinterpret_cast<float*>(smem_raw + 22020);
+  const int smem_prep_beta_all_addr = smem + 22020;
+  __nv_bfloat16* smem_prep_beta_bf16_all = reinterpret_cast<__nv_bfloat16*>(smem_raw + 22020);
+  const int smem_prep_beta_bf16_all_addr = smem + 22020;
+  unsigned int* smem_prep_beta_u32_all = reinterpret_cast<unsigned int*>(smem_raw + 22020);
+  const int smem_prep_beta_u32_all_addr = smem + 22020;
+  float* smem_gate_rate_all = reinterpret_cast<float*>(smem_raw + 22084);
+  const int smem_gate_rate_all_addr = smem + 22084;
+  float* smem_gate_bias_all = reinterpret_cast<float*>(smem_raw + 116816);
+  const int smem_gate_bias_all_addr = smem + 116816;
+  __nv_bfloat16* smem_v_all = reinterpret_cast<__nv_bfloat16*>(smem_raw + 16512);
+  const int smem_v_all_addr = smem + 16512;
+  float* smem_gate_all = reinterpret_cast<float*>(smem_raw + 13312);
+  const int smem_gate_all_addr = smem + 13312;
+  unsigned int* smem_state_checkpoint_needed = reinterpret_cast<unsigned int*>(smem_raw + 116736);
+  const int smem_state_checkpoint_needed_addr = smem + 116736;
+  float* smem_work_item_warp_max = reinterpret_cast<float*>(smem_raw + 116736);
+  const int smem_work_item_warp_max_addr = smem + 116736;
+  int* smem_work_item_compute_start = reinterpret_cast<int*>(smem_raw + 116752);
+  const int smem_work_item_compute_start_addr = smem + 116752;
+  unsigned int* smem_work_item_resolved = reinterpret_cast<unsigned int*>(smem_raw + 116756);
+  const int smem_work_item_resolved_addr = smem + 116756;
+
+  // Mbarrier init (25 groups, 107 barriers)
+  // Mbarriers at smem_raw[0..856)
+
+  if (warp == 10) {
+    // --- pipeline 'chunk_pipe' ---
+    // qk_full: 5 barriers, init_count=1
+    // gate_raw_full: 5 barriers, init_count=1
+    // qk_raw_full: 5 barriers, init_count=1
+    // v_full: 5 barriers, init_count=1
+    // v_free: 5 barriers, init_count=4
+    // smem_free: 5 barriers, init_count=4
+    // raw_inputs_free: 5 barriers, init_count=1
+    // state_inp_ready: 5 barriers, init_count=4
+    // state_inp_left_ready: 5 barriers, init_count=4
+    // old_out_ready: 5 barriers, init_count=1
+    // u_inp_ready: 5 barriers, init_count=4
+    // u2_acc_ready: 5 barriers, init_count=1
+    // u2_inp_ready: 5 barriers, init_count=4
+    // final_ready: 5 barriers, init_count=1
+    // out_empty: 1 barriers, init_count=1
+    // tmem_dealloc_ready: 1 barriers, init_count=2
+    // --- pipeline 'checkpoint_pipe' ---
+    // checkpoint_ready: 2 barriers, init_count=4
+    // checkpoint_free: 2 barriers, init_count=1
+    // --- pipeline 'chunk_pipe' ---
+    // prep_diag_ready: 5 barriers, init_count=2
+    // prep_inv16_ready: 5 barriers, init_count=2
+    // work_item_ready: 1 barriers, init_count=1
+    // aux_pairwise_inputs_ready: 5 barriers, init_count=1
+    // aux_pairwise_consumed: 5 barriers, init_count=1
+    // aux_inverse_ready: 5 barriers, init_count=1
+    // short_beta_ready: 5 barriers, init_count=1
+    // Warp-cooperative initialization, grouped by equal arrival count.
+    for (int _bar = lane; _bar < 20; _bar += 32) {
+      mbarrier_init(smem + 0 + _bar * 8, 1);
+    }
+    for (int _bar = lane; _bar < 10; _bar += 32) {
+      mbarrier_init(smem + 160 + _bar * 8, 4);
+    }
+    for (int _bar = lane; _bar < 5; _bar += 32) {
+      mbarrier_init(smem + 240 + _bar * 8, 1);
+    }
+    for (int _bar = lane; _bar < 10; _bar += 32) {
+      mbarrier_init(smem + 280 + _bar * 8, 4);
+    }
+    for (int _bar = lane; _bar < 5; _bar += 32) {
+      mbarrier_init(smem + 360 + _bar * 8, 1);
+    }
+    for (int _bar = lane; _bar < 5; _bar += 32) {
+      mbarrier_init(smem + 400 + _bar * 8, 4);
+    }
+    for (int _bar = lane; _bar < 5; _bar += 32) {
+      mbarrier_init(smem + 440 + _bar * 8, 1);
+    }
+    for (int _bar = lane; _bar < 5; _bar += 32) {
+      mbarrier_init(smem + 480 + _bar * 8, 4);
+    }
+    for (int _bar = lane; _bar < 6; _bar += 32) {
+      mbarrier_init(smem + 520 + _bar * 8, 1);
+    }
+    for (int _bar = lane; _bar < 1; _bar += 32) {
+      mbarrier_init(smem + 568 + _bar * 8, 2);
+    }
+    for (int _bar = lane; _bar < 2; _bar += 32) {
+      mbarrier_init(smem + 576 + _bar * 8, 4);
+    }
+    for (int _bar = lane; _bar < 2; _bar += 32) {
+      mbarrier_init(smem + 592 + _bar * 8, 1);
+    }
+    for (int _bar = lane; _bar < 10; _bar += 32) {
+      mbarrier_init(smem + 608 + _bar * 8, 2);
+    }
+    for (int _bar = lane; _bar < 21; _bar += 32) {
+      mbarrier_init(smem + 688 + _bar * 8, 1);
+    }
+    asm volatile("fence.mbarrier_init.release.cluster;");
+  }
+
+  __syncwarp();
+
+  // TMEM alloc (256 columns, 240 used)
+  volatile int* tmem_addr_storage = (volatile int*)(smem_raw + 856);
+  if (warp == 0) {
+    int _tmem_hold = smem + 856;
+    asm volatile(
+        "tcgen05.alloc.cta_group::1.sync.aligned.shared::cta.b32 [%0], %1;" ::"r"(_tmem_hold),
+        "r"(256)
+        : "memory");
+    asm volatile("tcgen05.relinquish_alloc_permit.cta_group::1.sync.aligned;");
+  }
+
+  __syncthreads();
+  asm volatile("tcgen05.fence::after_thread_sync;");
+
+  const int mbar_base = smem;
+#define qk_full_addr (mbar_base + 0)
+#define gate_raw_full_addr (mbar_base + 40)
+#define qk_raw_full_addr (mbar_base + 80)
+#define v_full_addr (mbar_base + 120)
+#define v_free_addr (mbar_base + 160)
+#define smem_free_addr (mbar_base + 200)
+#define raw_inputs_free_addr (mbar_base + 240)
+#define state_inp_ready_addr (mbar_base + 280)
+#define state_inp_left_ready_addr (mbar_base + 320)
+#define old_out_ready_addr (mbar_base + 360)
+#define u_inp_ready_addr (mbar_base + 400)
+#define u2_acc_ready_addr (mbar_base + 440)
+#define u2_inp_ready_addr (mbar_base + 480)
+#define final_ready_addr (mbar_base + 520)
+#define out_empty_addr (mbar_base + 560)
+#define tmem_dealloc_ready_addr (mbar_base + 568)
+#define checkpoint_ready_addr (mbar_base + 576)
+#define checkpoint_free_addr (mbar_base + 592)
+#define prep_diag_ready_addr (mbar_base + 608)
+#define prep_inv16_ready_addr (mbar_base + 648)
+#define work_item_ready_addr (mbar_base + 688)
+#define aux_pairwise_inputs_ready_addr (mbar_base + 696)
+#define aux_pairwise_consumed_addr (mbar_base + 736)
+#define aux_inverse_ready_addr (mbar_base + 776)
+#define short_beta_ready_addr (mbar_base + 816)
+  const int taddr = tmem_addr_storage[0];
+
+  // Kernel post-init ops
+  const int tmem_tmem_state = taddr + 64;
+  const int tmem_tmem_state_inp = taddr;
+  const int tmem_tmem_u_acc = taddr + 224;
+  const int tmem_tmem_u2_inp = taddr + 224;
+  const int tmem_tmem_u2_acc = taddr + 208;
+  const int tmem_tmem_out = taddr + 192;
+  const int tmem_tmem_state_out = taddr + 64;
+
+  // ---- Register redistribution for WGs split across roles ----
+  // Dec phase frees registers before any WG attempts inc.
+  if (warp >= 8 && warp <= 11) {
+    asm volatile("setmaxnreg.dec.sync.aligned.u32 48;");
+  }
+
+  // ---- Role: compute ----
+  if (warp <= 3) {
+    asm volatile("setmaxnreg.inc.sync.aligned.u32 168;");
+    {  // compute_main
+      int task_idx = blockIdx.x;
+      int warp_id_in_role = (warp - 0);
+      int compute_local_warp = warp_id_in_role;
+      int warp_in_wg = warp % 4;
+      int state_row = warp_in_wg * 32 + lane;
+      int split_compute_start = 0;
+      int seq_idx = seq_order[task_idx / num_heads];
+      int head_idx = task_idx % num_heads;
+      long long bos = cu_seqlens[seq_idx];
+      long long eos = cu_seqlens[seq_idx + 1];
+      int num_chunks = ((int)(eos - bos) + 16 - 1) / 16;
+      int seq_len = (int)(eos - bos);
+      int num_chunks_0 = (seq_len + 16 - 1) / 16;
+      long long total_chunks = cu_chunk_offsets[num_sequences];
+      long long fallback_head = total_chunks * (long long)num_heads +
+                                (long long)seq_idx * (long long)num_heads + (long long)head_idx;
+      const int tmem_row_base = warp_in_wg * 32 << 16;
+      long long state_base =
+          (((long long)seq_idx * (long long)num_heads + (long long)head_idx) * 128 +
+           (long long)state_row) *
+          128;
+      {
+        int state_slot = seq_idx;
+        if (use_state_indices != 0) {
+          state_slot = reinterpret_cast<int*>(state_indices_addr)[seq_idx];
+        }
+        state_base = (long long)state_slot * state_slot_stride +
+                     ((long long)head_idx * 128 + (long long)state_row) * 128;
+      }
+#pragma unroll
+      for (int state_col_block = 0; state_col_block < 4; state_col_block++) {
+        float state_frag[32];
+        state_frag[0] = 0.0f;
+        state_frag[1] = 0.0f;
+        state_frag[2] = 0.0f;
+        state_frag[3] = 0.0f;
+        state_frag[4] = 0.0f;
+        state_frag[5] = 0.0f;
+        state_frag[6] = 0.0f;
+        state_frag[7] = 0.0f;
+        state_frag[8] = 0.0f;
+        state_frag[9] = 0.0f;
+        state_frag[10] = 0.0f;
+        state_frag[11] = 0.0f;
+        state_frag[12] = 0.0f;
+        state_frag[13] = 0.0f;
+        state_frag[14] = 0.0f;
+        state_frag[15] = 0.0f;
+        state_frag[16] = 0.0f;
+        state_frag[17] = 0.0f;
+        state_frag[18] = 0.0f;
+        state_frag[19] = 0.0f;
+        state_frag[20] = 0.0f;
+        state_frag[21] = 0.0f;
+        state_frag[22] = 0.0f;
+        state_frag[23] = 0.0f;
+        state_frag[24] = 0.0f;
+        state_frag[25] = 0.0f;
+        state_frag[26] = 0.0f;
+        state_frag[27] = 0.0f;
+        state_frag[28] = 0.0f;
+        state_frag[29] = 0.0f;
+        state_frag[30] = 0.0f;
+        state_frag[31] = 0.0f;
+        if (use_initial_state != 0) {
+          {
+            {
+              const void* _v8p_0 =
+                  (const void*)(initial_state + (state_base + (long long)(state_col_block * 32)));
+              uint32_t _v8_0_0[8];
+              asm volatile("ld.global.v8.b32 {%0, %1, %2, %3, %4, %5, %6, %7}, [%8];"
+                           : "=r"(_v8_0_0[0]), "=r"(_v8_0_0[1]), "=r"(_v8_0_0[2]), "=r"(_v8_0_0[3]),
+                             "=r"(_v8_0_0[4]), "=r"(_v8_0_0[5]), "=r"(_v8_0_0[6]), "=r"(_v8_0_0[7])
+                           : "l"((const char*)_v8p_0 + 0)
+                           : "memory");
+              asm volatile(
+                  "{\n\t"
+                  "shl.b32 %0, %2, 16;\n\t"
+                  "and.b32 %1, %2, 0xffff0000;\n\t"
+                  "}\n"
+                  : "=f"((&state_frag[0 + 0])[0]), "=f"((&state_frag[0 + 0])[1])
+                  : "r"(_v8_0_0[0]));
+              asm volatile(
+                  "{\n\t"
+                  "shl.b32 %0, %2, 16;\n\t"
+                  "and.b32 %1, %2, 0xffff0000;\n\t"
+                  "}\n"
+                  : "=f"((&state_frag[0 + 2])[0]), "=f"((&state_frag[0 + 2])[1])
+                  : "r"(_v8_0_0[1]));
+              asm volatile(
+                  "{\n\t"
+                  "shl.b32 %0, %2, 16;\n\t"
+                  "and.b32 %1, %2, 0xffff0000;\n\t"
+                  "}\n"
+                  : "=f"((&state_frag[0 + 4])[0]), "=f"((&state_frag[0 + 4])[1])
+                  : "r"(_v8_0_0[2]));
+              asm volatile(
+                  "{\n\t"
+                  "shl.b32 %0, %2, 16;\n\t"
+                  "and.b32 %1, %2, 0xffff0000;\n\t"
+                  "}\n"
+                  : "=f"((&state_frag[0 + 6])[0]), "=f"((&state_frag[0 + 6])[1])
+                  : "r"(_v8_0_0[3]));
+              asm volatile(
+                  "{\n\t"
+                  "shl.b32 %0, %2, 16;\n\t"
+                  "and.b32 %1, %2, 0xffff0000;\n\t"
+                  "}\n"
+                  : "=f"((&state_frag[0 + 8])[0]), "=f"((&state_frag[0 + 8])[1])
+                  : "r"(_v8_0_0[4]));
+              asm volatile(
+                  "{\n\t"
+                  "shl.b32 %0, %2, 16;\n\t"
+                  "and.b32 %1, %2, 0xffff0000;\n\t"
+                  "}\n"
+                  : "=f"((&state_frag[0 + 10])[0]), "=f"((&state_frag[0 + 10])[1])
+                  : "r"(_v8_0_0[5]));
+              asm volatile(
+                  "{\n\t"
+                  "shl.b32 %0, %2, 16;\n\t"
+                  "and.b32 %1, %2, 0xffff0000;\n\t"
+                  "}\n"
+                  : "=f"((&state_frag[0 + 12])[0]), "=f"((&state_frag[0 + 12])[1])
+                  : "r"(_v8_0_0[6]));
+              asm volatile(
+                  "{\n\t"
+                  "shl.b32 %0, %2, 16;\n\t"
+                  "and.b32 %1, %2, 0xffff0000;\n\t"
+                  "}\n"
+                  : "=f"((&state_frag[0 + 14])[0]), "=f"((&state_frag[0 + 14])[1])
+                  : "r"(_v8_0_0[7]));
+              uint32_t _v8_0_1[8];
+              asm volatile("ld.global.v8.b32 {%0, %1, %2, %3, %4, %5, %6, %7}, [%8];"
+                           : "=r"(_v8_0_1[0]), "=r"(_v8_0_1[1]), "=r"(_v8_0_1[2]), "=r"(_v8_0_1[3]),
+                             "=r"(_v8_0_1[4]), "=r"(_v8_0_1[5]), "=r"(_v8_0_1[6]), "=r"(_v8_0_1[7])
+                           : "l"((const char*)_v8p_0 + 32)
+                           : "memory");
+              asm volatile(
+                  "{\n\t"
+                  "shl.b32 %0, %2, 16;\n\t"
+                  "and.b32 %1, %2, 0xffff0000;\n\t"
+                  "}\n"
+                  : "=f"((&state_frag[0 + 16])[0]), "=f"((&state_frag[0 + 16])[1])
+                  : "r"(_v8_0_1[0]));
+              asm volatile(
+                  "{\n\t"
+                  "shl.b32 %0, %2, 16;\n\t"
+                  "and.b32 %1, %2, 0xffff0000;\n\t"
+                  "}\n"
+                  : "=f"((&state_frag[0 + 18])[0]), "=f"((&state_frag[0 + 18])[1])
+                  : "r"(_v8_0_1[1]));
+              asm volatile(
+                  "{\n\t"
+                  "shl.b32 %0, %2, 16;\n\t"
+                  "and.b32 %1, %2, 0xffff0000;\n\t"
+                  "}\n"
+                  : "=f"((&state_frag[0 + 20])[0]), "=f"((&state_frag[0 + 20])[1])
+                  : "r"(_v8_0_1[2]));
+              asm volatile(
+                  "{\n\t"
+                  "shl.b32 %0, %2, 16;\n\t"
+                  "and.b32 %1, %2, 0xffff0000;\n\t"
+                  "}\n"
+                  : "=f"((&state_frag[0 + 22])[0]), "=f"((&state_frag[0 + 22])[1])
+                  : "r"(_v8_0_1[3]));
+              asm volatile(
+                  "{\n\t"
+                  "shl.b32 %0, %2, 16;\n\t"
+                  "and.b32 %1, %2, 0xffff0000;\n\t"
+                  "}\n"
+                  : "=f"((&state_frag[0 + 24])[0]), "=f"((&state_frag[0 + 24])[1])
+                  : "r"(_v8_0_1[4]));
+              asm volatile(
+                  "{\n\t"
+                  "shl.b32 %0, %2, 16;\n\t"
+                  "and.b32 %1, %2, 0xffff0000;\n\t"
+                  "}\n"
+                  : "=f"((&state_frag[0 + 26])[0]), "=f"((&state_frag[0 + 26])[1])
+                  : "r"(_v8_0_1[5]));
+              asm volatile(
+                  "{\n\t"
+                  "shl.b32 %0, %2, 16;\n\t"
+                  "and.b32 %1, %2, 0xffff0000;\n\t"
+                  "}\n"
+                  : "=f"((&state_frag[0 + 28])[0]), "=f"((&state_frag[0 + 28])[1])
+                  : "r"(_v8_0_1[6]));
+              asm volatile(
+                  "{\n\t"
+                  "shl.b32 %0, %2, 16;\n\t"
+                  "and.b32 %1, %2, 0xffff0000;\n\t"
+                  "}\n"
+                  : "=f"((&state_frag[0 + 30])[0]), "=f"((&state_frag[0 + 30])[1])
+                  : "r"(_v8_0_1[7]));
+            }
+          }
+        }
+        tmem_st_x32_f32(
+            taddr + 64 + (unsigned int)tmem_row_base + (unsigned int)(state_col_block * 32),
+            state_frag);
+      }
+      asm volatile("tcgen05.wait::st.sync.aligned;" ::: "memory");
+      {
+      }
+      unsigned int compute_stage = 0;
+      unsigned int checkpoint_stage_compute = 0;
+      unsigned int _phase_checkpoint_free = 1;
+      unsigned int _phase_qk_full = 0;
+      unsigned int _phase_v_full = 0;
+      unsigned int _phase_old_out_ready = 0;
+      unsigned int _phase_u2_acc_ready = 0;
+      unsigned int _phase_final_ready = 0;
+#pragma unroll 1
+      for (int chunk_idx = 0; chunk_idx < num_chunks_0; chunk_idx++) {
+        int chunk_global_local = chunk_idx;
+        int owned_chunk = chunk_global_local >= 0 && chunk_global_local < num_chunks;
+        int checkpoint_token_entering = chunk_idx * 16;
+        int checkpoint_entering = checkpoint_every_n_tokens != 0 &&
+                                  checkpoint_token_entering % checkpoint_every_n_tokens == 0;
+        if (checkpoint_entering != 0) {
+          mbarrier_wait(checkpoint_free_addr + (checkpoint_stage_compute) * 8,
+                        _phase_checkpoint_free);
+        }
+        float state_panel0[32];
+        float state_panel1[32];
+        float state_panel2[32];
+        float state_panel3[32];
+        unsigned int state_packed0[16];
+        unsigned int state_packed1[16];
+        unsigned int state_packed2[16];
+        unsigned int state_packed3[16];
+        mbarrier_wait(qk_full_addr + (compute_stage) * 8, _phase_qk_full);
+#pragma unroll 1
+        for (int state_col_block_1 = 0; state_col_block_1 < ((1) ? 4 : 3); state_col_block_1++) {
+          int state_addr =
+              taddr + 64 + (unsigned int)tmem_row_base + (unsigned int)(state_col_block_1 * 32);
+          float _tmem_load_1[32];
+          tmem_ld_x32(&_tmem_load_1[0], state_addr);
+          uint32_t _tmem_load_1_bf16[16];
+#pragma unroll
+          for (int _lp = 0; _lp < 16; _lp++) {
+            __nv_bfloat162 _bf2 = __float22bfloat162_rn(
+                make_float2(_tmem_load_1[_lp * 2 + 0], _tmem_load_1[_lp * 2 + 1 + 0]));
+            _tmem_load_1_bf16[_lp] = *(uint32_t*)&_bf2;
+          }
+          asm volatile(
+              "tcgen05.st.sync.aligned.32x32b.x16.b32"
+              " [%0], {%1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15, %16};" ::
+                  "r"(taddr + (unsigned int)tmem_row_base + (unsigned int)(state_col_block_1 * 16)),
+              "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_1_bf16[0])),
+              "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_1_bf16[1])),
+              "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_1_bf16[2])),
+              "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_1_bf16[3])),
+              "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_1_bf16[4])),
+              "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_1_bf16[5])),
+              "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_1_bf16[6])),
+              "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_1_bf16[7])),
+              "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_1_bf16[8])),
+              "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_1_bf16[9])),
+              "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_1_bf16[10])),
+              "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_1_bf16[11])),
+              "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_1_bf16[12])),
+              "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_1_bf16[13])),
+              "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_1_bf16[14])),
+              "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_1_bf16[15])));
+          if (checkpoint_entering != 0) {
+#pragma unroll
+            for (int checkpoint_vec = 0; checkpoint_vec < 4; checkpoint_vec++) {
+              int checkpoint_addr =
+                  (smem_checkpoint_addr + checkpoint_stage_compute * 32768 +
+                   (unsigned int)((state_col_block_1 * 32 + checkpoint_vec * 8) / 64 * 16384 +
+                                      state_row * 128 +
+                                      (state_col_block_1 * 32 + checkpoint_vec * 8) % 64 * 2 ^
+                                  ((state_col_block_1 * 32 + checkpoint_vec * 8) / 64 * 16384 +
+                                           state_row * 128 +
+                                           (state_col_block_1 * 32 + checkpoint_vec * 8) % 64 * 2 >>
+                                       7 &
+                                   7) << 4));
+              asm volatile("st.shared.v4.b32 [%0], {%1,%2,%3,%4};" ::"r"(checkpoint_addr),
+                           "r"(_tmem_load_1_bf16[checkpoint_vec * 4]),
+                           "r"(_tmem_load_1_bf16[checkpoint_vec * 4 + 1]),
+                           "r"(_tmem_load_1_bf16[checkpoint_vec * 4 + 2]),
+                           "r"(_tmem_load_1_bf16[checkpoint_vec * 4 + 3])
+                           : "memory");
+            }
+          }
+          float state_scale[16];
+#pragma unroll
+          for (int state_half = 0; state_half < 2; state_half++) {
+#pragma unroll
+            for (int state_col = 0; state_col < 16; state_col++) {
+              state_scale[state_col] =
+                  smem_restore_factor_all[compute_stage * 5376 +
+                                          (unsigned int)(state_col_block_1 * 32) +
+                                          (unsigned int)(state_half * 16) +
+                                          (unsigned int)state_col];
+            }
+#pragma unroll
+            for (int _ls = 0; _ls < 8; _ls++)
+              mul_f32x2_inplace(&reinterpret_cast<float2*>((_tmem_load_1 + state_half * 16))[_ls],
+                                reinterpret_cast<const float2*>(state_scale)[_ls]);
+          }
+          tmem_st_x32_f32(state_addr, _tmem_load_1);
+          {
+            if (state_col_block_1 == 1) {
+              asm volatile("tcgen05.wait::st.sync.aligned;" ::: "memory");
+              if (elect_sync()) {
+                mbarrier_arrive(state_inp_left_ready_addr + (compute_stage) * 8);
+              }
+            }
+          }
+        }
+        int state_tail_addr = taddr + 64 + (unsigned int)tmem_row_base + 96;
+        float state_tail_frag[32];
+        unsigned int state_tail_packed[16];
+        asm volatile("tcgen05.wait::st.sync.aligned;" ::: "memory");
+        if (checkpoint_entering != 0) {
+          asm volatile("fence.proxy.async.shared::cta;" ::: "memory");
+          if (elect_sync()) {
+            mbarrier_arrive(checkpoint_ready_addr + (checkpoint_stage_compute) * 8);
+          }
+        }
+        if (elect_sync()) {
+          mbarrier_arrive(state_inp_ready_addr + (compute_stage) * 8);
+        }
+        if (checkpoint_entering != 0) {
+          checkpoint_stage_compute += 1;
+          if (checkpoint_stage_compute == 2) {
+            checkpoint_stage_compute = 0;
+            _phase_checkpoint_free ^= 1;
+          }
+        }
+        mbarrier_wait(v_full_addr + (compute_stage) * 8, _phase_v_full);
+        unsigned int v_prefetch_bits[8];
+        {
+          int v_stage_addr = smem_v_addr + compute_stage * 21504;
+#pragma unroll
+          for (int residual_row_half = 0; residual_row_half < 2; residual_row_half++) {
+#pragma unroll
+            for (int token_group = 0; token_group < 2; token_group++) {
+              const int v_prefetch_reg_base = residual_row_half * 4 + token_group * 2;
+              int v_ld_matrix = lane / 8 & 1;
+              int v_ld_token = token_group * 8 + (lane & 7);
+              int v_ld_panel = warp_in_wg / 2;
+              int v_ld_row = warp_in_wg % 2 * 32 + residual_row_half * 16 + v_ld_matrix * 8;
+              int v_ld_row_addr = v_stage_addr + v_ld_panel * 16 * 64 * 2 + v_ld_token * 64 * 2;
+              int v_ld_addr = (v_ld_row_addr + (v_ld_row * 2 ^ (v_ld_row_addr >> 7 & 7) << 4));
+              asm volatile("ldmatrix.sync.aligned.m8n8.x2.trans.shared.b16 {%0, %1}, [%2];\n"
+                           : "=r"(v_prefetch_bits[v_prefetch_reg_base]),
+                             "=r"(v_prefetch_bits[v_prefetch_reg_base + 1])
+                           : "r"(v_ld_addr)
+                           : "memory");
+            }
+          }
+        }
+        mbarrier_wait(old_out_ready_addr + (compute_stage) * 8, _phase_old_out_ready);
+        float _tmem_load_2[16];
+        tmem_ld_x16(&_tmem_load_2[0], taddr + 224 + (unsigned int)tmem_row_base);
+        long long chunk_global_e = cu_chunk_offsets[seq_idx] + (long long)chunk_global_local;
+        long long tape_ex_base =
+            ((chunk_global_e * (long long)num_heads + (long long)head_idx) * 128 +
+             (long long)state_row) *
+            16;
+#pragma unroll
+        for (int residual_half = 0; residual_half < 1; residual_half++) {
+          float residual_v[16];
+          float residual_beta[16];
+#pragma unroll
+          for (int residual_col = 0; residual_col < 16; residual_col++) {
+            int token_col = residual_half * 16 + residual_col;
+          }
+          {
+#pragma unroll
+            for (int residual_row_half_1 = 0; residual_row_half_1 < 2; residual_row_half_1++) {
+              float _tmem_load_3[16];
+              asm volatile(
+                  "tcgen05.ld.sync.aligned.16x256b.x4.b32"
+                  " {%0, %1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15}, [%16];"
+                  : "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[0])),
+                    "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[1])),
+                    "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[2])),
+                    "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[3])),
+                    "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[4])),
+                    "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[5])),
+                    "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[6])),
+                    "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[7])),
+                    "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[8])),
+                    "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[9])),
+                    "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[10])),
+                    "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[11])),
+                    "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[12])),
+                    "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[13])),
+                    "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[14])),
+                    "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[15]))
+                  : "r"(taddr + 224 + (unsigned int)tmem_row_base +
+                        (unsigned int)(residual_row_half_1 * 1048576)));
+              uint32_t _tmem_load_3_bf16[8];
+#pragma unroll
+              for (int _lp = 0; _lp < 8; _lp++) {
+                __nv_bfloat162 _bf2 = __float22bfloat162_rn(
+                    make_float2(_tmem_load_3[_lp * 2 + 0], _tmem_load_3[_lp * 2 + 1 + 0]));
+                _tmem_load_3_bf16[_lp] = *(uint32_t*)&_bf2;
+              }
+              unsigned int residual_packed[4];
+#pragma unroll
+              for (int token_group_1 = 0; token_group_1 < 2; token_group_1++) {
+                const int residual_pack_base = token_group_1 * 2;
+                unsigned int beta_pair = smem_prep_beta_u32_all[compute_stage * 5376 +
+                                                                (unsigned int)(token_group_1 * 4) +
+                                                                (unsigned int)(lane & 3)];
+#pragma unroll
+                for (int residual_matrix = 0; residual_matrix < 2; residual_matrix++) {
+                  const int residual_pair = residual_pack_base + residual_matrix;
+                  const int v_prefetch_pair = residual_row_half_1 * 4 + residual_pair;
+                  uint32_t _bf16x2_sub_0;
+                  asm volatile("sub.rn.bf16x2 %0, %1, %2;"
+                               : "=r"(_bf16x2_sub_0)
+                               : "r"(v_prefetch_bits[v_prefetch_pair]),
+                                 "r"(_tmem_load_3_bf16[residual_pair]));
+                  unsigned int residual_pair_delta = _bf16x2_sub_0;
+                  uint32_t _bf16x2_mul_0;
+                  asm volatile("mul.rn.bf16x2 %0, %1, %2;"
+                               : "=r"(_bf16x2_mul_0)
+                               : "r"(residual_pair_delta), "r"(beta_pair));
+                  residual_packed[residual_pair] = _bf16x2_mul_0;
+                }
+              }
+              asm volatile(
+                  "tcgen05.st.sync.aligned.16x128b.x2.b32"
+                  " [%0], {%1, %2, %3, %4};" ::"r"(taddr + 224 + (unsigned int)tmem_row_base +
+                                                   (unsigned int)(residual_row_half_1 * 1048576)),
+                  "r"(*reinterpret_cast<const uint32_t*>(&residual_packed[0])),
+                  "r"(*reinterpret_cast<const uint32_t*>(&residual_packed[1])),
+                  "r"(*reinterpret_cast<const uint32_t*>(&residual_packed[2])),
+                  "r"(*reinterpret_cast<const uint32_t*>(&residual_packed[3])));
+            }
+          }
+          if (STORE_BACKWARD_TAPE != 0 && STORE_E_TAPE != 0 && owned_chunk != 0) {
+            {
+              __nv_bfloat162 _pk[4];
+              _pk[0] = __floats2bfloat162_rn(residual_v[0 + 0], residual_v[0 + 1]);
+              _pk[1] = __floats2bfloat162_rn(residual_v[0 + 2], residual_v[0 + 3]);
+              _pk[2] = __floats2bfloat162_rn(residual_v[0 + 4], residual_v[0 + 5]);
+              _pk[3] = __floats2bfloat162_rn(residual_v[0 + 6], residual_v[0 + 7]);
+              *reinterpret_cast<uint4*>(&(
+                  (__nv_bfloat16*)(tape_e + (tape_ex_base + (long long)(residual_half * 16))))[0]) =
+                  *reinterpret_cast<uint4*>(&_pk[0]);
+            }
+            {
+              __nv_bfloat162 _pk[4];
+              _pk[0] = __floats2bfloat162_rn(residual_v[8 + 0], residual_v[8 + 1]);
+              _pk[1] = __floats2bfloat162_rn(residual_v[8 + 2], residual_v[8 + 3]);
+              _pk[2] = __floats2bfloat162_rn(residual_v[8 + 4], residual_v[8 + 5]);
+              _pk[3] = __floats2bfloat162_rn(residual_v[8 + 6], residual_v[8 + 7]);
+              *reinterpret_cast<uint4*>(
+                  &((__nv_bfloat16*)(tape_e + (tape_ex_base + (long long)(residual_half * 16) +
+                                               8)))[0]) = *reinterpret_cast<uint4*>(&_pk[0]);
+            }
+          }
+        }
+        asm volatile("tcgen05.wait::st.sync.aligned;" ::: "memory");
+        if (elect_sync()) {
+          mbarrier_arrive(v_free_addr + (compute_stage) * 8);
+          mbarrier_arrive(u_inp_ready_addr + (compute_stage) * 8);
+        }
+        mbarrier_wait(u2_acc_ready_addr + (compute_stage) * 8, _phase_u2_acc_ready);
+        float _tmem_load_4[16];
+        tmem_ld_x16(&_tmem_load_4[0], taddr + 208 + (unsigned int)tmem_row_base);
+        if (STORE_BACKWARD_TAPE != 0 && owned_chunk != 0) {
+          long long chunk_global_r = cu_chunk_offsets[seq_idx] + (long long)chunk_global_local;
+          long long tape_r_base =
+              ((chunk_global_r * (long long)num_heads + (long long)head_idx) * 128 +
+               (long long)state_row) *
+              16;
+#pragma unroll
+          for (int tape_r_vec = 0; tape_r_vec < 4; tape_r_vec++) {
+            {
+              __nv_bfloat162 _pk[4];
+              _pk[0] = __floats2bfloat162_rn(_tmem_load_4[tape_r_vec * 8 + 0],
+                                             _tmem_load_4[tape_r_vec * 8 + 1]);
+              _pk[1] = __floats2bfloat162_rn(_tmem_load_4[tape_r_vec * 8 + 2],
+                                             _tmem_load_4[tape_r_vec * 8 + 3]);
+              _pk[2] = __floats2bfloat162_rn(_tmem_load_4[tape_r_vec * 8 + 4],
+                                             _tmem_load_4[tape_r_vec * 8 + 5]);
+              _pk[3] = __floats2bfloat162_rn(_tmem_load_4[tape_r_vec * 8 + 6],
+                                             _tmem_load_4[tape_r_vec * 8 + 7]);
+              *reinterpret_cast<uint4*>(
+                  &((__nv_bfloat16*)(tape_r + (tape_r_base + (long long)(tape_r_vec * 8))))[0]) =
+                  *reinterpret_cast<uint4*>(&_pk[0]);
+            }
+          }
+        }
+        uint32_t _tmem_load_4_bf16[8];
+#pragma unroll
+        for (int _lp = 0; _lp < 8; _lp++) {
+          __nv_bfloat162 _bf2 = __float22bfloat162_rn(
+              make_float2(_tmem_load_4[_lp * 2 + 0], _tmem_load_4[_lp * 2 + 1 + 0]));
+          _tmem_load_4_bf16[_lp] = *(uint32_t*)&_bf2;
+        }
+        tmem_st_x8_u32(taddr + 224 + (unsigned int)tmem_row_base,
+                       (const uint32_t*)_tmem_load_4_bf16);
+        asm volatile("tcgen05.wait::st.sync.aligned;" ::: "memory");
+        if (elect_sync()) {
+          mbarrier_arrive(u2_inp_ready_addr + (compute_stage) * 8);
+        }
+        mbarrier_wait(final_ready_addr + (compute_stage) * 8, _phase_final_ready);
+        if (elect_sync()) {
+          mbarrier_arrive(smem_free_addr + (compute_stage) * 8);
+        }
+        {
+          int checkpoint_token = (chunk_idx + 1) * 16;
+        }
+        compute_stage += 1;
+        if (compute_stage == 5) {
+          compute_stage = 0;
+          _phase_qk_full ^= 1;
+          _phase_v_full ^= 1;
+          _phase_old_out_ready ^= 1;
+          _phase_u2_acc_ready ^= 1;
+          _phase_final_ready ^= 1;
+        }
+      }
+      if (store_final_state != 0) {
+#pragma unroll
+        for (int state_col_block_2 = 0; state_col_block_2 < 4; state_col_block_2++) {
+          float _tmem_load_6[32];
+          tmem_ld_x32(&_tmem_load_6[0], taddr + 64 + (unsigned int)tmem_row_base +
+                                            (unsigned int)(state_col_block_2 * 32));
+          {
+            __nv_bfloat162 _pk[8];
+            _pk[0] = __floats2bfloat162_rn(_tmem_load_6[0 + 0], _tmem_load_6[0 + 1]);
+            _pk[1] = __floats2bfloat162_rn(_tmem_load_6[0 + 2], _tmem_load_6[0 + 3]);
+            _pk[2] = __floats2bfloat162_rn(_tmem_load_6[0 + 4], _tmem_load_6[0 + 5]);
+            _pk[3] = __floats2bfloat162_rn(_tmem_load_6[0 + 6], _tmem_load_6[0 + 7]);
+            _pk[4] = __floats2bfloat162_rn(_tmem_load_6[0 + 8], _tmem_load_6[0 + 9]);
+            _pk[5] = __floats2bfloat162_rn(_tmem_load_6[0 + 10], _tmem_load_6[0 + 11]);
+            _pk[6] = __floats2bfloat162_rn(_tmem_load_6[0 + 12], _tmem_load_6[0 + 13]);
+            _pk[7] = __floats2bfloat162_rn(_tmem_load_6[0 + 14], _tmem_load_6[0 + 15]);
+            *reinterpret_cast<uint4*>(
+                &((__nv_bfloat16*)(final_state +
+                                   (state_base + (long long)(state_col_block_2 * 32))))[0]) =
+                *reinterpret_cast<uint4*>(&_pk[0]);
+            *reinterpret_cast<uint4*>(
+                &((__nv_bfloat16*)(final_state +
+                                   (state_base + (long long)(state_col_block_2 * 32))))[8]) =
+                *reinterpret_cast<uint4*>(&_pk[4]);
+          }
+          {
+            __nv_bfloat162 _pk[8];
+            _pk[0] = __floats2bfloat162_rn(_tmem_load_6[16 + 0], _tmem_load_6[16 + 1]);
+            _pk[1] = __floats2bfloat162_rn(_tmem_load_6[16 + 2], _tmem_load_6[16 + 3]);
+            _pk[2] = __floats2bfloat162_rn(_tmem_load_6[16 + 4], _tmem_load_6[16 + 5]);
+            _pk[3] = __floats2bfloat162_rn(_tmem_load_6[16 + 6], _tmem_load_6[16 + 7]);
+            _pk[4] = __floats2bfloat162_rn(_tmem_load_6[16 + 8], _tmem_load_6[16 + 9]);
+            _pk[5] = __floats2bfloat162_rn(_tmem_load_6[16 + 10], _tmem_load_6[16 + 11]);
+            _pk[6] = __floats2bfloat162_rn(_tmem_load_6[16 + 12], _tmem_load_6[16 + 13]);
+            _pk[7] = __floats2bfloat162_rn(_tmem_load_6[16 + 14], _tmem_load_6[16 + 15]);
+            *reinterpret_cast<uint4*>(
+                &((__nv_bfloat16*)(final_state + (state_base + (long long)(state_col_block_2 * 32) +
+                                                  16)))[0]) = *reinterpret_cast<uint4*>(&_pk[0]);
+            *reinterpret_cast<uint4*>(
+                &((__nv_bfloat16*)(final_state + (state_base + (long long)(state_col_block_2 * 32) +
+                                                  16)))[8]) = *reinterpret_cast<uint4*>(&_pk[4]);
+          }
+        }
+      }
+      asm volatile("barrier.sync 9, 128;" ::: "memory");
+      if (compute_local_warp == 0) {
+        if (elect_sync()) {
+          mbarrier_arrive(tmem_dealloc_ready_addr);
+        }
+      }
+    }
+  }
+  // ---- Role: epilogue ----
+  if (warp >= 4 && warp <= 7) {
+    asm volatile("setmaxnreg.dec.sync.aligned.u32 48;");
+    {  // epilogue_main
+      int task_idx_1 = blockIdx.x;
+      int split_compute_start_1 = 0;
+      unsigned int _phase_work_item_ready_0 = 0;
+      int seq_idx_1 = seq_order[task_idx_1 / num_heads];
+      int head_idx_1 = task_idx_1 % num_heads;
+      long long bos_1 = cu_seqlens[seq_idx_1];
+      long long eos_1 = cu_seqlens[seq_idx_1 + 1];
+      int num_chunks_1 = ((int)(eos_1 - bos_1) + 16 - 1) / 16;
+      int seq_len_1 = (int)(eos_1 - bos_1);
+      int num_chunks_0_1 = (seq_len_1 + 16 - 1) / 16;
+      int warp_id_in_role_1 = (warp - 4);
+      int epilogue_local_warp = warp_id_in_role_1;
+      int warp_in_wg_1 = warp % 4;
+      const int tmem_row_base_1 = warp_in_wg_1 * 32 << 16;
+      int state_row_1 = warp_in_wg_1 * 32 + lane;
+      unsigned int epilogue_stage = 0;
+      unsigned int output_stage = 0;
+      unsigned int checkpoint_stage_epilogue = 0;
+      int epilogue_chunks = num_chunks_0_1;
+      unsigned int _phase_checkpoint_ready = 0;
+      unsigned int _phase_final_ready_1 = 0;
+#pragma unroll 1
+      for (int chunk_idx_1 = 0; chunk_idx_1 < epilogue_chunks; chunk_idx_1++) {
+        int checkpoint_token_epilogue = chunk_idx_1 * 16;
+        int checkpoint_entering_epilogue =
+            checkpoint_every_n_tokens != 0 &&
+            checkpoint_token_epilogue % checkpoint_every_n_tokens == 0;
+        if (checkpoint_entering_epilogue != 0) {
+          mbarrier_wait(checkpoint_ready_addr + (checkpoint_stage_epilogue) * 8,
+                        _phase_checkpoint_ready);
+          if (epilogue_local_warp == 0) {
+            long long checkpoint_idx_epilogue =
+                reinterpret_cast<long long*>(checkpoint_cu_starts_addr)[seq_idx_1] +
+                (long long)(checkpoint_token_epilogue / checkpoint_every_n_tokens);
+            if (elect_sync()) {
+#pragma unroll
+              for (int checkpoint_segment = 0; checkpoint_segment < 2; checkpoint_segment++) {
+                tma_store_4d(state_checkpoints_tma, checkpoint_segment * 64, 0, head_idx_1,
+                             checkpoint_idx_epilogue,
+                             smem_checkpoint_addr + checkpoint_stage_epilogue * 32768 +
+                                 (unsigned int)(checkpoint_segment * 128 * 64 * 2));
+              }
+            }
+            asm volatile("cp.async.bulk.commit_group;");
+            asm volatile("cp.async.bulk.wait_group.read 0;");
+            if (elect_sync()) {
+              mbarrier_arrive(checkpoint_free_addr + (checkpoint_stage_epilogue) * 8);
+            }
+          }
+          checkpoint_stage_epilogue += 1;
+          if (checkpoint_stage_epilogue == 2) {
+            checkpoint_stage_epilogue = 0;
+            _phase_checkpoint_ready ^= 1;
+          }
+        }
+        int chunk_is_full = ((seq_len_1 >= (chunk_idx_1 + 1) * 16) ? 1 : 0);
+        if (chunk_is_full != 0) {
+          mbarrier_wait(final_ready_addr + (epilogue_stage) * 8, _phase_final_ready_1);
+          float _tmem_load_7[8];
+          asm volatile(
+              "tcgen05.ld.sync.aligned.16x256b.x2.b32"
+              " {%0, %1, %2, %3, %4, %5, %6, %7}, [%8];"
+              : "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_7[0])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_7[1])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_7[2])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_7[3])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_7[4])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_7[5])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_7[6])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_7[7]))
+              : "r"(taddr + 192 + (unsigned int)tmem_row_base_1));
+          float _tmem_load_8[8];
+          asm volatile(
+              "tcgen05.ld.sync.aligned.16x256b.x2.b32"
+              " {%0, %1, %2, %3, %4, %5, %6, %7}, [%8];"
+              : "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_8[0])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_8[1])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_8[2])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_8[3])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_8[4])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_8[5])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_8[6])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_8[7]))
+              : "r"(taddr + 192 + (unsigned int)tmem_row_base_1 + 1048576));
+          asm volatile("tcgen05.wait::ld.sync.aligned;" ::: "memory");
+          asm volatile("barrier.sync 8, 128;" ::: "memory");
+          if (epilogue_local_warp == 0) {
+            if (elect_sync()) {
+              mbarrier_arrive(out_empty_addr);
+            }
+          }
+          if (epilogue_local_warp == 0) {
+            if (chunk_idx_1 >= 2) {
+              asm volatile("cp.async.bulk.wait_group.read 1;");
+            }
+          }
+          asm volatile("barrier.sync 8, 128;" ::: "memory");
+          int out_stage_addr = smem_out_addr + output_stage * 4096;
+#pragma unroll
+          for (int dim_half = 0; dim_half < 2; dim_half++) {
+            unsigned int out_packed[8];
+            if (dim_half == 0) {
+#pragma unroll
+              for (int _lp = 0; _lp < 4; _lp++) {
+                __nv_bfloat162 _bf2 = __float22bfloat162_rn(
+                    make_float2(_tmem_load_7[_lp * 2 + 0], _tmem_load_7[_lp * 2 + 1 + 0]));
+                out_packed[_lp] = *(uint32_t*)&_bf2;
+              }
+            } else {
+#pragma unroll
+              for (int _lp = 0; _lp < 4; _lp++) {
+                __nv_bfloat162 _bf2 = __float22bfloat162_rn(
+                    make_float2(_tmem_load_8[_lp * 2 + 0], _tmem_load_8[_lp * 2 + 1 + 0]));
+                out_packed[_lp] = *(uint32_t*)&_bf2;
+              }
+            }
+#pragma unroll
+            for (int token_group_2 = 0; token_group_2 < 1; token_group_2++) {
+              int mtx_idx = lane / 8;
+              int row_addr = lane & 7;
+              int dim_base = epilogue_local_warp * 32 + dim_half * 16 + (mtx_idx & 1) * 8;
+              int token_base = token_group_2 * 16 + mtx_idx / 2 * 8;
+              int token_addr = token_base + row_addr;
+              int token_pair = token_addr / 2;
+              int token_parity = token_addr & 1;
+              int raw_row = token_pair + dim_base / 64 * 8;
+              int raw_col =
+                  (dim_base & 63 ^ (token_pair & 3) << 4 ^ token_parity << 3) + token_parity * 64;
+              int stsm_offset = (raw_row * 128 + raw_col) * 2;
+              const int pack_base = token_group_2 * 4;
+              uint32_t _stmatrix_addr_0 =
+                  static_cast<uint32_t>((unsigned long long)(out_stage_addr + stsm_offset));
+              asm volatile(
+                  "stmatrix.sync.aligned.m8n8.x4.trans.shared.b16 [%0], {%1, %2, %3, %4};\n" ::"r"(
+                      _stmatrix_addr_0),
+                  "r"(*reinterpret_cast<const uint32_t*>(&out_packed[pack_base])),
+                  "r"(*reinterpret_cast<const uint32_t*>(&out_packed[pack_base + 1])),
+                  "r"(*reinterpret_cast<const uint32_t*>(&out_packed[pack_base + 2])),
+                  "r"(*reinterpret_cast<const uint32_t*>(&out_packed[pack_base + 3]))
+                  : "memory");
+            }
+          }
+          asm volatile("fence.proxy.async.shared::cta;" ::: "memory");
+          asm volatile("barrier.sync 8, 128;" ::: "memory");
+          if (epilogue_local_warp == 0) {
+            if (elect_sync()) {
+              tma_store_4d(out_tma, 0, (int)(bos_1 + (long long)(chunk_idx_1 * 16)), head_idx_1, 0,
+                           smem_out_addr + output_stage * 4096);
+            }
+            asm volatile("cp.async.bulk.commit_group;");
+          }
+          output_stage = output_stage ^ 1;
+        } else {
+          mbarrier_wait(final_ready_addr + (epilogue_stage) * 8, _phase_final_ready_1);
+          float _tmem_load_9[16];
+          tmem_ld_x16(&_tmem_load_9[0], taddr + 192 + (unsigned int)tmem_row_base_1);
+          asm volatile("tcgen05.wait::ld.sync.aligned;" ::: "memory");
+          asm volatile("barrier.sync 8, 128;" ::: "memory");
+          if (epilogue_local_warp == 0) {
+            if (elect_sync()) {
+              mbarrier_arrive(out_empty_addr);
+            }
+          }
+#pragma unroll
+          for (int token_col_1 = 0; token_col_1 < 16; token_col_1++) {
+            long long out_token = bos_1 + (long long)(chunk_idx_1 * 16 + token_col_1);
+            if (out_token < eos_1) {
+              long long out_idx = (out_token * (long long)num_heads + (long long)head_idx_1) * 128 +
+                                  (long long)state_row_1;
+              out[out_idx] = _tmem_load_9[token_col_1];
+            }
+          }
+        }
+        epilogue_stage += 1;
+        if (epilogue_stage == 5) {
+          epilogue_stage = 0;
+          _phase_final_ready_1 ^= 1;
+        }
+      }
+      {
+        if (epilogue_local_warp == 0) {
+          asm volatile("cp.async.bulk.wait_group 0;");
+        }
+        asm volatile("barrier.sync 8, 128;" ::: "memory");
+      }
+      if (epilogue_local_warp == 0) {
+        if (elect_sync()) {
+          mbarrier_arrive(tmem_dealloc_ready_addr);
+        }
+      }
+    }
+  }
+  // ---- Role: beta_prefetch ----
+  if (warp == 8) {
+    {  // beta_prefetch_main
+    }
+  }
+  // ---- Role: aux_mma ----
+  if (warp >= 10 && warp <= 11) {
+    {  // aux_mma_main
+      unsigned int _phase_aux_pairwise_inputs_ready = 0;
+      {
+        int task_idx_2 = blockIdx.x;
+        int seq_idx_2 = seq_order[task_idx_2 / num_heads];
+        long long bos_2 = cu_seqlens[seq_idx_2];
+        long long eos_2 = cu_seqlens[seq_idx_2 + 1];
+        int seq_len_2 = (int)(eos_2 - bos_2);
+        int num_chunks_2 = (seq_len_2 + 16 - 1) / 16;
+        int instance_id = (warp - 10) / 1;
+        int aux_instance = instance_id;
+        int num_aux_iters = (num_chunks_2 + 1 - aux_instance) / 2;
+        unsigned int aux_stage = (unsigned int)aux_instance;
+#pragma unroll 1
+        for (int aux_iter = 0; aux_iter < num_aux_iters; aux_iter++) {
+          int chunk_idx_2 = aux_iter * 2 + aux_instance;
+          int stage_f32 = aux_stage * 5376;
+          mbarrier_wait(aux_pairwise_inputs_ready_addr + (aux_stage) * 8,
+                        _phase_aux_pairwise_inputs_ready);
+          unsigned int a_frag[4];
+          unsigned int b_frag[4];
+          float acc[8];
+          asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                       : "=r"(a_frag[0]), "=r"(a_frag[1]), "=r"(a_frag[2]), "=r"(a_frag[3])
+                       : "r"(smem_kd_addr + aux_stage * 21504 +
+                             (unsigned int)((lane / 16 / 8 * 128 + lane % 16 * 8 +
+                                             (lane / 16 % 8 * 16 ^ (lane % 16 & 7) << 4) / 16) *
+                                            16))
+                       : "memory");
+          asm volatile(
+              "ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+              : "=r"(b_frag[0]), "=r"(b_frag[1]), "=r"(b_frag[2]), "=r"(b_frag[3])
+              : "r"(
+                  smem_ki_addr + aux_stage * 21504 +
+                  (unsigned int)((lane % 16 / 8 / 8 * 128 + (8 * (lane / 16) + lane % 8) * 8 +
+                                  (lane % 16 / 8 % 8 * 16 ^ (8 * (lane / 16) + lane % 8 & 7) << 4) /
+                                      16) *
+                                 16))
+              : "memory");
+          asm volatile(
+              "mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, "
+              "%7}, {%8, %9}, {%10, %11, %12, %13};\n"
+              : "=f"(acc[0]), "=f"(acc[1]), "=f"(acc[2]), "=f"(acc[3])
+              : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[0]),
+                "r"(b_frag[1]), "f"(0.0f), "f"(0.0f), "f"(0.0f), "f"(0.0f));
+          asm volatile(
+              "mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, "
+              "%7}, {%8, %9}, {%10, %11, %12, %13};\n"
+              : "=f"(acc[4]), "=f"(acc[(4) + 1]), "=f"(acc[(4) + 2]), "=f"(acc[(4) + 3])
+              : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[2]),
+                "r"(b_frag[(2) + 1]), "f"(0.0f), "f"(0.0f), "f"(0.0f), "f"(0.0f));
+          asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                       : "=r"(a_frag[0]), "=r"(a_frag[1]), "=r"(a_frag[2]), "=r"(a_frag[3])
+                       : "r"(smem_kd_addr + aux_stage * 21504 +
+                             (unsigned int)((lane / 16 / 8 * 128 + lane % 16 * 8 +
+                                                 (lane / 16 % 8 * 16 ^ (lane % 16 & 7) << 4) / 16 ^
+                                             2) *
+                                            16))
+                       : "memory");
+          asm volatile(
+              "ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+              : "=r"(b_frag[0]), "=r"(b_frag[1]), "=r"(b_frag[2]), "=r"(b_frag[3])
+              : "r"(smem_ki_addr + aux_stage * 21504 +
+                    (unsigned int)(((lane % 16 / 8 / 8 * 128 + (8 * (lane / 16) + lane % 8) * 8 +
+                                         (lane % 16 / 8 % 8 * 16 ^ (8 * (lane / 16) + lane % 8 & 7)
+                                                                       << 4) /
+                                             16 +
+                                         256 ^
+                                     2) -
+                                    256) *
+                                   16))
+              : "memory");
+          asm volatile(
+              "mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, "
+              "%7}, {%8, %9}, {%0, %1, %2, %3};\n"
+              : "+f"(acc[0]), "+f"(acc[1]), "+f"(acc[2]), "+f"(acc[3])
+              : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[0]),
+                "r"(b_frag[1]));
+          asm volatile(
+              "mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, "
+              "%7}, {%8, %9}, {%0, %1, %2, %3};\n"
+              : "+f"(acc[4]), "+f"(acc[(4) + 1]), "+f"(acc[(4) + 2]), "+f"(acc[(4) + 3])
+              : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[2]),
+                "r"(b_frag[(2) + 1]));
+          asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                       : "=r"(a_frag[0]), "=r"(a_frag[1]), "=r"(a_frag[2]), "=r"(a_frag[3])
+                       : "r"(smem_kd_addr + aux_stage * 21504 +
+                             (unsigned int)((lane / 16 / 8 * 128 + lane % 16 * 8 +
+                                                 (lane / 16 % 8 * 16 ^ (lane % 16 & 7) << 4) / 16 ^
+                                             2 ^ 6) *
+                                            16))
+                       : "memory");
+          asm volatile(
+              "ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+              : "=r"(b_frag[0]), "=r"(b_frag[1]), "=r"(b_frag[2]), "=r"(b_frag[3])
+              : "r"(smem_ki_addr + aux_stage * 21504 +
+                    (unsigned int)((((lane % 16 / 8 / 8 * 128 + (8 * (lane / 16) + lane % 8) * 8 +
+                                          (lane % 16 / 8 % 8 * 16 ^ (8 * (lane / 16) + lane % 8 & 7)
+                                                                        << 4) /
+                                              16 +
+                                          256 ^
+                                      2) -
+                                         256 + 256 ^
+                                     6) -
+                                    256) *
+                                   16))
+              : "memory");
+          asm volatile(
+              "mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, "
+              "%7}, {%8, %9}, {%0, %1, %2, %3};\n"
+              : "+f"(acc[0]), "+f"(acc[1]), "+f"(acc[2]), "+f"(acc[3])
+              : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[0]),
+                "r"(b_frag[1]));
+          asm volatile(
+              "mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, "
+              "%7}, {%8, %9}, {%0, %1, %2, %3};\n"
+              : "+f"(acc[4]), "+f"(acc[(4) + 1]), "+f"(acc[(4) + 2]), "+f"(acc[(4) + 3])
+              : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[2]),
+                "r"(b_frag[(2) + 1]));
+          asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                       : "=r"(a_frag[0]), "=r"(a_frag[1]), "=r"(a_frag[2]), "=r"(a_frag[3])
+                       : "r"(smem_kd_addr + aux_stage * 21504 +
+                             (unsigned int)((lane / 16 / 8 * 128 + lane % 16 * 8 +
+                                                 (lane / 16 % 8 * 16 ^ (lane % 16 & 7) << 4) / 16 ^
+                                             2 ^ 6 ^ 2) *
+                                            16))
+                       : "memory");
+          asm volatile(
+              "ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+              : "=r"(b_frag[0]), "=r"(b_frag[1]), "=r"(b_frag[2]), "=r"(b_frag[3])
+              : "r"(smem_ki_addr + aux_stage * 21504 +
+                    (unsigned int)(((((lane % 16 / 8 / 8 * 128 + (8 * (lane / 16) + lane % 8) * 8 +
+                                           (lane % 16 / 8 % 8 * 16 ^
+                                            (8 * (lane / 16) + lane % 8 & 7) << 4) /
+                                               16 +
+                                           256 ^
+                                       2) -
+                                          256 + 256 ^
+                                      6) -
+                                         256 + 256 ^
+                                     2) -
+                                    256) *
+                                   16))
+              : "memory");
+          asm volatile(
+              "mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, "
+              "%7}, {%8, %9}, {%0, %1, %2, %3};\n"
+              : "+f"(acc[0]), "+f"(acc[1]), "+f"(acc[2]), "+f"(acc[3])
+              : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[0]),
+                "r"(b_frag[1]));
+          asm volatile(
+              "mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, "
+              "%7}, {%8, %9}, {%0, %1, %2, %3};\n"
+              : "+f"(acc[4]), "+f"(acc[(4) + 1]), "+f"(acc[(4) + 2]), "+f"(acc[(4) + 3])
+              : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[2]),
+                "r"(b_frag[(2) + 1]));
+          asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                       : "=r"(a_frag[0]), "=r"(a_frag[1]), "=r"(a_frag[2]), "=r"(a_frag[3])
+                       : "r"(smem_kd_addr + aux_stage * 21504 +
+                             (unsigned int)(((lane / 16 / 8 * 128 + lane % 16 * 8 +
+                                                  (lane / 16 % 8 * 16 ^ (lane % 16 & 7) << 4) / 16 ^
+                                              2 ^ 6 ^ 2 ^ 6) +
+                                             128) *
+                                            16))
+                       : "memory");
+          asm volatile(
+              "ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+              : "=r"(b_frag[0]), "=r"(b_frag[1]), "=r"(b_frag[2]), "=r"(b_frag[3])
+              : "r"(smem_ki_addr + aux_stage * 21504 +
+                    (unsigned int)((((((lane % 16 / 8 / 8 * 128 + (8 * (lane / 16) + lane % 8) * 8 +
+                                            (lane % 16 / 8 % 8 * 16 ^
+                                             (8 * (lane / 16) + lane % 8 & 7) << 4) /
+                                                16 +
+                                            256 ^
+                                        2) -
+                                           256 + 256 ^
+                                       6) -
+                                          256 + 256 ^
+                                      2) -
+                                         256 + 256 ^
+                                     6) +
+                                    128 - 256) *
+                                   16))
+              : "memory");
+          asm volatile(
+              "mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, "
+              "%7}, {%8, %9}, {%0, %1, %2, %3};\n"
+              : "+f"(acc[0]), "+f"(acc[1]), "+f"(acc[2]), "+f"(acc[3])
+              : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[0]),
+                "r"(b_frag[1]));
+          asm volatile(
+              "mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, "
+              "%7}, {%8, %9}, {%0, %1, %2, %3};\n"
+              : "+f"(acc[4]), "+f"(acc[(4) + 1]), "+f"(acc[(4) + 2]), "+f"(acc[(4) + 3])
+              : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[2]),
+                "r"(b_frag[(2) + 1]));
+          asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                       : "=r"(a_frag[0]), "=r"(a_frag[1]), "=r"(a_frag[2]), "=r"(a_frag[3])
+                       : "r"(smem_kd_addr + aux_stage * 21504 +
+                             (unsigned int)(((lane / 16 / 8 * 128 + lane % 16 * 8 +
+                                                  (lane / 16 % 8 * 16 ^ (lane % 16 & 7) << 4) / 16 ^
+                                              2 ^ 6 ^ 2 ^ 6) +
+                                                 128 ^
+                                             2) *
+                                            16))
+                       : "memory");
+          asm volatile(
+              "ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+              : "=r"(b_frag[0]), "=r"(b_frag[1]), "=r"(b_frag[2]), "=r"(b_frag[3])
+              : "r"(
+                  smem_ki_addr + aux_stage * 21504 +
+                  (unsigned int)(((((((lane % 16 / 8 / 8 * 128 + (8 * (lane / 16) + lane % 8) * 8 +
+                                           (lane % 16 / 8 % 8 * 16 ^
+                                            (8 * (lane / 16) + lane % 8 & 7) << 4) /
+                                               16 +
+                                           256 ^
+                                       2) -
+                                          256 + 256 ^
+                                      6) -
+                                         256 + 256 ^
+                                     2) -
+                                        256 + 256 ^
+                                    6) +
+                                       128 - 256 + 256 ^
+                                   2) -
+                                  256) *
+                                 16))
+              : "memory");
+          asm volatile(
+              "mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, "
+              "%7}, {%8, %9}, {%0, %1, %2, %3};\n"
+              : "+f"(acc[0]), "+f"(acc[1]), "+f"(acc[2]), "+f"(acc[3])
+              : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[0]),
+                "r"(b_frag[1]));
+          asm volatile(
+              "mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, "
+              "%7}, {%8, %9}, {%0, %1, %2, %3};\n"
+              : "+f"(acc[4]), "+f"(acc[(4) + 1]), "+f"(acc[(4) + 2]), "+f"(acc[(4) + 3])
+              : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[2]),
+                "r"(b_frag[(2) + 1]));
+          asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                       : "=r"(a_frag[0]), "=r"(a_frag[1]), "=r"(a_frag[2]), "=r"(a_frag[3])
+                       : "r"(smem_kd_addr + aux_stage * 21504 +
+                             (unsigned int)(((lane / 16 / 8 * 128 + lane % 16 * 8 +
+                                                  (lane / 16 % 8 * 16 ^ (lane % 16 & 7) << 4) / 16 ^
+                                              2 ^ 6 ^ 2 ^ 6) +
+                                                 128 ^
+                                             2 ^ 6) *
+                                            16))
+                       : "memory");
+          asm volatile(
+              "ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+              : "=r"(b_frag[0]), "=r"(b_frag[1]), "=r"(b_frag[2]), "=r"(b_frag[3])
+              : "r"(
+                  smem_ki_addr + aux_stage * 21504 +
+                  (unsigned int)((((((((lane % 16 / 8 / 8 * 128 + (8 * (lane / 16) + lane % 8) * 8 +
+                                            (lane % 16 / 8 % 8 * 16 ^
+                                             (8 * (lane / 16) + lane % 8 & 7) << 4) /
+                                                16 +
+                                            256 ^
+                                        2) -
+                                           256 + 256 ^
+                                       6) -
+                                          256 + 256 ^
+                                      2) -
+                                         256 + 256 ^
+                                     6) +
+                                        128 - 256 + 256 ^
+                                    2) -
+                                       256 + 256 ^
+                                   6) -
+                                  256) *
+                                 16))
+              : "memory");
+          asm volatile(
+              "mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, "
+              "%7}, {%8, %9}, {%0, %1, %2, %3};\n"
+              : "+f"(acc[0]), "+f"(acc[1]), "+f"(acc[2]), "+f"(acc[3])
+              : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[0]),
+                "r"(b_frag[1]));
+          asm volatile(
+              "mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, "
+              "%7}, {%8, %9}, {%0, %1, %2, %3};\n"
+              : "+f"(acc[4]), "+f"(acc[(4) + 1]), "+f"(acc[(4) + 2]), "+f"(acc[(4) + 3])
+              : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[2]),
+                "r"(b_frag[(2) + 1]));
+          asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                       : "=r"(a_frag[0]), "=r"(a_frag[1]), "=r"(a_frag[2]), "=r"(a_frag[3])
+                       : "r"(smem_kd_addr + aux_stage * 21504 +
+                             (unsigned int)(((lane / 16 / 8 * 128 + lane % 16 * 8 +
+                                                  (lane / 16 % 8 * 16 ^ (lane % 16 & 7) << 4) / 16 ^
+                                              2 ^ 6 ^ 2 ^ 6) +
+                                                 128 ^
+                                             2 ^ 6 ^ 2) *
+                                            16))
+                       : "memory");
+          asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                       : "=r"(b_frag[0]), "=r"(b_frag[1]), "=r"(b_frag[2]), "=r"(b_frag[3])
+                       : "r"(smem_ki_addr + aux_stage * 21504 +
+                             (unsigned int)(((((((((lane % 16 / 8 / 8 * 128 +
+                                                        (8 * (lane / 16) + lane % 8) * 8 +
+                                                        (lane % 16 / 8 % 8 * 16 ^
+                                                         (8 * (lane / 16) + lane % 8 & 7) << 4) /
+                                                            16 +
+                                                        256 ^
+                                                    2) -
+                                                       256 + 256 ^
+                                                   6) -
+                                                      256 + 256 ^
+                                                  2) -
+                                                     256 + 256 ^
+                                                 6) +
+                                                    128 - 256 + 256 ^
+                                                2) -
+                                                   256 + 256 ^
+                                               6) -
+                                                  256 + 256 ^
+                                              2) -
+                                             256) *
+                                            16))
+                       : "memory");
+          asm volatile(
+              "mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, "
+              "%7}, {%8, %9}, {%0, %1, %2, %3};\n"
+              : "+f"(acc[0]), "+f"(acc[1]), "+f"(acc[2]), "+f"(acc[3])
+              : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[0]),
+                "r"(b_frag[1]));
+          asm volatile(
+              "mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, "
+              "%7}, {%8, %9}, {%0, %1, %2, %3};\n"
+              : "+f"(acc[4]), "+f"(acc[(4) + 1]), "+f"(acc[(4) + 2]), "+f"(acc[(4) + 3])
+              : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[2]),
+                "r"(b_frag[(2) + 1]));
+          float inverse_values[8];
+          int row0 = lane / 4;
+          int row1 = row0 + 8;
+          int col0 = lane % 4 * 2;
+          float beta0 = 0.0f;
+          float beta1 = 0.0f;
+          {
+            __nv_bfloat16 beta0_bf16 = smem_prep_beta_bf16_all[stage_f32 * 2 + row0];
+            __nv_bfloat16 beta1_bf16 = smem_prep_beta_bf16_all[stage_f32 * 2 + row1];
+            float _cvt_f32_14 = __bfloat162float(beta0_bf16);
+            beta0 = _cvt_f32_14;
+            float _cvt_f32_15 = __bfloat162float(beta1_bf16);
+            beta1 = _cvt_f32_15;
+          }
+          float l_values[8];
+          l_values[0] = 0.0f;
+          l_values[1] = 0.0f;
+          l_values[2] = 0.0f;
+          l_values[3] = 0.0f;
+          l_values[4] = 0.0f;
+          l_values[5] = 0.0f;
+          l_values[6] = 0.0f;
+          l_values[7] = 0.0f;
+          if (row0 > col0) {
+            __nv_bfloat16 _cvt_bf16_6 = __float2bfloat16(acc[0] * beta0);
+            float _cvt_f32_16 = __bfloat162float(_cvt_bf16_6);
+            l_values[0] = _cvt_f32_16;
+          }
+          if (row0 > col0 + 1) {
+            __nv_bfloat16 _cvt_bf16_7 = __float2bfloat16(acc[1] * beta0);
+            float _cvt_f32_17 = __bfloat162float(_cvt_bf16_7);
+            l_values[1] = _cvt_f32_17;
+          }
+          if (row1 > col0) {
+            __nv_bfloat16 _cvt_bf16_8 = __float2bfloat16(acc[2] * beta1);
+            float _cvt_f32_18 = __bfloat162float(_cvt_bf16_8);
+            l_values[2] = _cvt_f32_18;
+          }
+          if (row1 > col0 + 1) {
+            __nv_bfloat16 _cvt_bf16_9 = __float2bfloat16(acc[3] * beta1);
+            float _cvt_f32_19 = __bfloat162float(_cvt_bf16_9);
+            l_values[3] = _cvt_f32_19;
+          }
+          if (row0 > col0 + 8) {
+            __nv_bfloat16 _cvt_bf16_10 = __float2bfloat16(acc[4] * beta0);
+            float _cvt_f32_20 = __bfloat162float(_cvt_bf16_10);
+            l_values[4] = _cvt_f32_20;
+          }
+          if (row0 > col0 + 9) {
+            __nv_bfloat16 _cvt_bf16_11 = __float2bfloat16(acc[5] * beta0);
+            float _cvt_f32_21 = __bfloat162float(_cvt_bf16_11);
+            l_values[5] = _cvt_f32_21;
+          }
+          if (row1 > col0 + 8) {
+            __nv_bfloat16 _cvt_bf16_12 = __float2bfloat16(acc[6] * beta1);
+            float _cvt_f32_22 = __bfloat162float(_cvt_bf16_12);
+            l_values[6] = _cvt_f32_22;
+          }
+          if (row1 > col0 + 9) {
+            __nv_bfloat16 _cvt_bf16_13 = __float2bfloat16(acc[7] * beta1);
+            float _cvt_f32_23 = __bfloat162float(_cvt_bf16_13);
+            l_values[7] = _cvt_f32_23;
+          }
+          unsigned int l_frag[4];
+#pragma unroll
+          for (int _lp = 0; _lp < 4; _lp++) {
+            __half2 _h2 =
+                __float22half2_rn(make_float2(l_values[_lp * 2 + 0], l_values[_lp * 2 + 1 + 0]));
+            l_frag[_lp] = *(uint32_t*)&_h2;
+          }
+          unsigned int allmma_d_frag[4];
+          allmma_d_frag[0] = 0;
+          allmma_d_frag[1] = 0;
+          allmma_d_frag[2] = 0;
+          allmma_d_frag[3] = 0;
+          allmma_d_frag[0] = l_frag[0];
+          allmma_d_frag[3] = l_frag[3];
+          float n_values[8];
+          n_values[0] = 0.0f;
+          n_values[1] = 0.0f;
+          n_values[2] = 0.0f;
+          n_values[3] = 0.0f;
+          n_values[4] = 0.0f;
+          n_values[5] = 0.0f;
+          n_values[6] = 0.0f;
+          n_values[7] = 0.0f;
+          n_values[0] = -l_values[0];
+          n_values[1] = -l_values[1];
+          n_values[6] = -l_values[6];
+          n_values[7] = -l_values[7];
+          if (row0 == col0) {
+            n_values[0] = n_values[0] + 1.0f;
+          }
+          if (row0 == col0 + 1) {
+            n_values[1] = n_values[1] + 1.0f;
+          }
+          if (row1 == col0) {
+            n_values[2] = n_values[2] + 1.0f;
+          }
+          if (row1 == col0 + 1) {
+            n_values[3] = n_values[3] + 1.0f;
+          }
+          if (row0 == col0 + 8) {
+            n_values[4] = n_values[4] + 1.0f;
+          }
+          if (row0 == col0 + 9) {
+            n_values[5] = n_values[5] + 1.0f;
+          }
+          if (row1 == col0 + 8) {
+            n_values[6] = n_values[6] + 1.0f;
+          }
+          if (row1 == col0 + 9) {
+            n_values[7] = n_values[7] + 1.0f;
+          }
+          unsigned int n_frag[4];
+          unsigned int low_word[1];
+          unsigned int high_word[1];
+#pragma unroll
+          for (int _lp = 0; _lp < 1; _lp++) {
+            __half2 _h2 =
+                __float22half2_rn(make_float2(n_values[_lp * 2 + 0], n_values[_lp * 2 + 1 + 0]));
+            low_word[_lp] = *(uint32_t*)&_h2;
+          }
+#pragma unroll
+          for (int _lp = 0; _lp < 1; _lp++) {
+            __half2 _h2 =
+                __float22half2_rn(make_float2(n_values[_lp * 2 + 6], n_values[_lp * 2 + 1 + 6]));
+            high_word[_lp] = *(uint32_t*)&_h2;
+          }
+          n_frag[0] = 0;
+          n_frag[1] = 0;
+          n_frag[2] = 0;
+          n_frag[3] = 0;
+          n_frag[0] = low_word[0];
+          n_frag[3] = high_word[0];
+          float product[8];
+          unsigned int rhs_trans_frag[4];
+#pragma unroll
+          for (int word = 0; word < 4; word++) {
+            asm volatile("movmatrix.sync.aligned.m8n8.trans.b16 %0, %1;\n"
+                         : "=r"(rhs_trans_frag[word])
+                         : "r"(allmma_d_frag[word]));
+          }
+          asm volatile(
+              "mma.sync.aligned.m16n8k16.row.col.f32.f16.f16.f32 {%0, %1, %2, %3}, {%4, %5, %6, "
+              "%7}, {%8, %9}, {%10, %11, %12, %13};\n"
+              : "=f"(product[0]), "=f"(product[1]), "=f"(product[2]), "=f"(product[3])
+              : "r"(allmma_d_frag[0]), "r"(allmma_d_frag[1]), "r"(allmma_d_frag[2]),
+                "r"(allmma_d_frag[3]), "r"(rhs_trans_frag[0]), "r"(rhs_trans_frag[1]), "f"(0.0f),
+                "f"(0.0f), "f"(0.0f), "f"(0.0f));
+          asm volatile(
+              "mma.sync.aligned.m16n8k16.row.col.f32.f16.f16.f32 {%0, %1, %2, %3}, {%4, %5, %6, "
+              "%7}, {%8, %9}, {%10, %11, %12, %13};\n"
+              : "=f"(product[4]), "=f"(product[(4) + 1]), "=f"(product[(4) + 2]),
+                "=f"(product[(4) + 3])
+              : "r"(allmma_d_frag[0]), "r"(allmma_d_frag[1]), "r"(allmma_d_frag[2]),
+                "r"(allmma_d_frag[3]), "r"(rhs_trans_frag[2]), "r"(rhs_trans_frag[(2) + 1]),
+                "f"(0.0f), "f"(0.0f), "f"(0.0f), "f"(0.0f));
+          unsigned int d2_frag[4];
+          unsigned int low_word_0[1];
+          unsigned int high_word_1[1];
+#pragma unroll
+          for (int _lp = 0; _lp < 1; _lp++) {
+            __half2 _h2 =
+                __float22half2_rn(make_float2(product[_lp * 2 + 0], product[_lp * 2 + 1 + 0]));
+            low_word_0[_lp] = *(uint32_t*)&_h2;
+          }
+#pragma unroll
+          for (int _lp = 0; _lp < 1; _lp++) {
+            __half2 _h2 =
+                __float22half2_rn(make_float2(product[_lp * 2 + 6], product[_lp * 2 + 1 + 6]));
+            high_word_1[_lp] = *(uint32_t*)&_h2;
+          }
+          d2_frag[0] = 0;
+          d2_frag[1] = 0;
+          d2_frag[2] = 0;
+          d2_frag[3] = 0;
+          d2_frag[0] = low_word_0[0];
+          d2_frag[3] = high_word_1[0];
+          unsigned int rhs_trans_frag_2[4];
+#pragma unroll
+          for (int word_1 = 0; word_1 < 4; word_1++) {
+            asm volatile("movmatrix.sync.aligned.m8n8.trans.b16 %0, %1;\n"
+                         : "=r"(rhs_trans_frag_2[word_1])
+                         : "r"(d2_frag[word_1]));
+          }
+          asm volatile(
+              "mma.sync.aligned.m16n8k16.row.col.f32.f16.f16.f32 {%0, %1, %2, %3}, {%4, %5, %6, "
+              "%7}, {%8, %9}, {%10, %11, %12, %13};\n"
+              : "=f"(product[0]), "=f"(product[1]), "=f"(product[2]), "=f"(product[3])
+              : "r"(n_frag[0]), "r"(n_frag[1]), "r"(n_frag[2]), "r"(n_frag[3]),
+                "r"(rhs_trans_frag_2[0]), "r"(rhs_trans_frag_2[1]), "f"(0.0f), "f"(0.0f), "f"(0.0f),
+                "f"(0.0f));
+          asm volatile(
+              "mma.sync.aligned.m16n8k16.row.col.f32.f16.f16.f32 {%0, %1, %2, %3}, {%4, %5, %6, "
+              "%7}, {%8, %9}, {%10, %11, %12, %13};\n"
+              : "=f"(product[4]), "=f"(product[(4) + 1]), "=f"(product[(4) + 2]),
+                "=f"(product[(4) + 3])
+              : "r"(n_frag[0]), "r"(n_frag[1]), "r"(n_frag[2]), "r"(n_frag[3]),
+                "r"(rhs_trans_frag_2[2]), "r"(rhs_trans_frag_2[(2) + 1]), "f"(0.0f), "f"(0.0f),
+                "f"(0.0f), "f"(0.0f));
+#pragma unroll
+          for (int value_idx = 0; value_idx < 8; value_idx++) {
+            n_values[value_idx] = n_values[value_idx] + product[value_idx];
+          }
+          unsigned int low_word_3[1];
+          unsigned int high_word_4[1];
+#pragma unroll
+          for (int _lp = 0; _lp < 1; _lp++) {
+            __half2 _h2 =
+                __float22half2_rn(make_float2(n_values[_lp * 2 + 0], n_values[_lp * 2 + 1 + 0]));
+            low_word_3[_lp] = *(uint32_t*)&_h2;
+          }
+#pragma unroll
+          for (int _lp = 0; _lp < 1; _lp++) {
+            __half2 _h2 =
+                __float22half2_rn(make_float2(n_values[_lp * 2 + 6], n_values[_lp * 2 + 1 + 6]));
+            high_word_4[_lp] = *(uint32_t*)&_h2;
+          }
+          n_frag[0] = 0;
+          n_frag[1] = 0;
+          n_frag[2] = 0;
+          n_frag[3] = 0;
+          n_frag[0] = low_word_3[0];
+          n_frag[3] = high_word_4[0];
+          unsigned int rhs_trans_frag_5[4];
+#pragma unroll
+          for (int word_2 = 0; word_2 < 4; word_2++) {
+            asm volatile("movmatrix.sync.aligned.m8n8.trans.b16 %0, %1;\n"
+                         : "=r"(rhs_trans_frag_5[word_2])
+                         : "r"(d2_frag[word_2]));
+          }
+          asm volatile(
+              "mma.sync.aligned.m16n8k16.row.col.f32.f16.f16.f32 {%0, %1, %2, %3}, {%4, %5, %6, "
+              "%7}, {%8, %9}, {%10, %11, %12, %13};\n"
+              : "=f"(product[0]), "=f"(product[1]), "=f"(product[2]), "=f"(product[3])
+              : "r"(d2_frag[0]), "r"(d2_frag[1]), "r"(d2_frag[2]), "r"(d2_frag[3]),
+                "r"(rhs_trans_frag_5[0]), "r"(rhs_trans_frag_5[1]), "f"(0.0f), "f"(0.0f), "f"(0.0f),
+                "f"(0.0f));
+          asm volatile(
+              "mma.sync.aligned.m16n8k16.row.col.f32.f16.f16.f32 {%0, %1, %2, %3}, {%4, %5, %6, "
+              "%7}, {%8, %9}, {%10, %11, %12, %13};\n"
+              : "=f"(product[4]), "=f"(product[(4) + 1]), "=f"(product[(4) + 2]),
+                "=f"(product[(4) + 3])
+              : "r"(d2_frag[0]), "r"(d2_frag[1]), "r"(d2_frag[2]), "r"(d2_frag[3]),
+                "r"(rhs_trans_frag_5[2]), "r"(rhs_trans_frag_5[(2) + 1]), "f"(0.0f), "f"(0.0f),
+                "f"(0.0f), "f"(0.0f));
+          unsigned int d4_frag[4];
+          unsigned int low_word_6[1];
+          unsigned int high_word_7[1];
+#pragma unroll
+          for (int _lp = 0; _lp < 1; _lp++) {
+            __half2 _h2 =
+                __float22half2_rn(make_float2(product[_lp * 2 + 0], product[_lp * 2 + 1 + 0]));
+            low_word_6[_lp] = *(uint32_t*)&_h2;
+          }
+#pragma unroll
+          for (int _lp = 0; _lp < 1; _lp++) {
+            __half2 _h2 =
+                __float22half2_rn(make_float2(product[_lp * 2 + 6], product[_lp * 2 + 1 + 6]));
+            high_word_7[_lp] = *(uint32_t*)&_h2;
+          }
+          d4_frag[0] = 0;
+          d4_frag[1] = 0;
+          d4_frag[2] = 0;
+          d4_frag[3] = 0;
+          d4_frag[0] = low_word_6[0];
+          d4_frag[3] = high_word_7[0];
+          unsigned int rhs_trans_frag_8[4];
+#pragma unroll
+          for (int word_3 = 0; word_3 < 4; word_3++) {
+            asm volatile("movmatrix.sync.aligned.m8n8.trans.b16 %0, %1;\n"
+                         : "=r"(rhs_trans_frag_8[word_3])
+                         : "r"(d4_frag[word_3]));
+          }
+          asm volatile(
+              "mma.sync.aligned.m16n8k16.row.col.f32.f16.f16.f32 {%0, %1, %2, %3}, {%4, %5, %6, "
+              "%7}, {%8, %9}, {%10, %11, %12, %13};\n"
+              : "=f"(product[0]), "=f"(product[1]), "=f"(product[2]), "=f"(product[3])
+              : "r"(n_frag[0]), "r"(n_frag[1]), "r"(n_frag[2]), "r"(n_frag[3]),
+                "r"(rhs_trans_frag_8[0]), "r"(rhs_trans_frag_8[1]), "f"(0.0f), "f"(0.0f), "f"(0.0f),
+                "f"(0.0f));
+          asm volatile(
+              "mma.sync.aligned.m16n8k16.row.col.f32.f16.f16.f32 {%0, %1, %2, %3}, {%4, %5, %6, "
+              "%7}, {%8, %9}, {%10, %11, %12, %13};\n"
+              : "=f"(product[4]), "=f"(product[(4) + 1]), "=f"(product[(4) + 2]),
+                "=f"(product[(4) + 3])
+              : "r"(n_frag[0]), "r"(n_frag[1]), "r"(n_frag[2]), "r"(n_frag[3]),
+                "r"(rhs_trans_frag_8[2]), "r"(rhs_trans_frag_8[(2) + 1]), "f"(0.0f), "f"(0.0f),
+                "f"(0.0f), "f"(0.0f));
+#pragma unroll
+          for (int value_idx_1 = 0; value_idx_1 < 8; value_idx_1++) {
+            n_values[value_idx_1] = n_values[value_idx_1] + product[value_idx_1];
+          }
+          unsigned int binv_frag[4];
+          binv_frag[0] = 0;
+          binv_frag[1] = 0;
+          binv_frag[2] = 0;
+          binv_frag[3] = 0;
+          binv_frag[0] = n_frag[0];
+          binv_frag[3] = n_frag[3];
+          unsigned int a21_frag[4];
+          a21_frag[0] = 0;
+          a21_frag[1] = 0;
+          a21_frag[2] = 0;
+          a21_frag[3] = 0;
+          a21_frag[1] = l_frag[1];
+          unsigned int rhs_trans_frag_9[4];
+#pragma unroll
+          for (int word_4 = 0; word_4 < 4; word_4++) {
+            asm volatile("movmatrix.sync.aligned.m8n8.trans.b16 %0, %1;\n"
+                         : "=r"(rhs_trans_frag_9[word_4])
+                         : "r"(a21_frag[word_4]));
+          }
+          asm volatile(
+              "mma.sync.aligned.m16n8k16.row.col.f32.f16.f16.f32 {%0, %1, %2, %3}, {%4, %5, %6, "
+              "%7}, {%8, %9}, {%10, %11, %12, %13};\n"
+              : "=f"(product[0]), "=f"(product[1]), "=f"(product[2]), "=f"(product[3])
+              : "r"(binv_frag[0]), "r"(binv_frag[1]), "r"(binv_frag[2]), "r"(binv_frag[3]),
+                "r"(rhs_trans_frag_9[0]), "r"(rhs_trans_frag_9[1]), "f"(0.0f), "f"(0.0f), "f"(0.0f),
+                "f"(0.0f));
+          asm volatile(
+              "mma.sync.aligned.m16n8k16.row.col.f32.f16.f16.f32 {%0, %1, %2, %3}, {%4, %5, %6, "
+              "%7}, {%8, %9}, {%10, %11, %12, %13};\n"
+              : "=f"(product[4]), "=f"(product[(4) + 1]), "=f"(product[(4) + 2]),
+                "=f"(product[(4) + 3])
+              : "r"(binv_frag[0]), "r"(binv_frag[1]), "r"(binv_frag[2]), "r"(binv_frag[3]),
+                "r"(rhs_trans_frag_9[2]), "r"(rhs_trans_frag_9[(2) + 1]), "f"(0.0f), "f"(0.0f),
+                "f"(0.0f), "f"(0.0f));
+          float correction_values[2];
+          correction_values[0] = -product[2];
+          correction_values[1] = -product[3];
+          unsigned int correction_word[1];
+#pragma unroll
+          for (int _lp = 0; _lp < 1; _lp++) {
+            __half2 _h2 = __float22half2_rn(
+                make_float2(correction_values[_lp * 2 + 0], correction_values[_lp * 2 + 1 + 0]));
+            correction_word[_lp] = *(uint32_t*)&_h2;
+          }
+          unsigned int correction_frag[4];
+          correction_frag[0] = 0;
+          correction_frag[1] = 0;
+          correction_frag[2] = 0;
+          correction_frag[3] = 0;
+          correction_frag[1] = correction_word[0];
+          unsigned int rhs_trans_frag_10[4];
+#pragma unroll
+          for (int word_5 = 0; word_5 < 4; word_5++) {
+            asm volatile("movmatrix.sync.aligned.m8n8.trans.b16 %0, %1;\n"
+                         : "=r"(rhs_trans_frag_10[word_5])
+                         : "r"(binv_frag[word_5]));
+          }
+          asm volatile(
+              "mma.sync.aligned.m16n8k16.row.col.f32.f16.f16.f32 {%0, %1, %2, %3}, {%4, %5, %6, "
+              "%7}, {%8, %9}, {%10, %11, %12, %13};\n"
+              : "=f"(product[0]), "=f"(product[1]), "=f"(product[2]), "=f"(product[3])
+              : "r"(correction_frag[0]), "r"(correction_frag[1]), "r"(correction_frag[2]),
+                "r"(correction_frag[3]), "r"(rhs_trans_frag_10[0]), "r"(rhs_trans_frag_10[1]),
+                "f"(0.0f), "f"(0.0f), "f"(0.0f), "f"(0.0f));
+          asm volatile(
+              "mma.sync.aligned.m16n8k16.row.col.f32.f16.f16.f32 {%0, %1, %2, %3}, {%4, %5, %6, "
+              "%7}, {%8, %9}, {%10, %11, %12, %13};\n"
+              : "=f"(product[4]), "=f"(product[(4) + 1]), "=f"(product[(4) + 2]),
+                "=f"(product[(4) + 3])
+              : "r"(correction_frag[0]), "r"(correction_frag[1]), "r"(correction_frag[2]),
+                "r"(correction_frag[3]), "r"(rhs_trans_frag_10[2]), "r"(rhs_trans_frag_10[(2) + 1]),
+                "f"(0.0f), "f"(0.0f), "f"(0.0f), "f"(0.0f));
+          n_values[2] = product[2];
+          n_values[3] = product[3];
+#pragma unroll
+          for (int value_idx_2 = 0; value_idx_2 < 8; value_idx_2++) {
+            inverse_values[value_idx_2] = n_values[value_idx_2];
+          }
+          unsigned int inverse_packed[4];
+#pragma unroll
+          for (int _lp = 0; _lp < 4; _lp++) {
+            __nv_bfloat162 _bf2 = __float22bfloat162_rn(
+                make_float2(inverse_values[_lp * 2 + 0], inverse_values[_lp * 2 + 1 + 0]));
+            inverse_packed[_lp] = *(uint32_t*)&_bf2;
+          }
+          int inverse_lane_row = lane % 16;
+          int inverse_lane_col = lane / 16 * 8;
+          int byte_off = (int)aux_stage * 21504 + inverse_lane_row * 128 + inverse_lane_col * 2;
+          int swizzled_off = byte_off ^ (byte_off >> 7 & 7) << 4;
+          int inverse_work_addr = smem_inv_work_addr + (unsigned int)swizzled_off;
+          uint32_t _stmatrix_addr_0 = static_cast<uint32_t>((unsigned long long)inverse_work_addr);
+          asm volatile("stmatrix.sync.aligned.m8n8.x4.shared.b16 [%0], {%1, %2, %3, %4};\n" ::"r"(
+                           _stmatrix_addr_0),
+                       "r"(*reinterpret_cast<const uint32_t*>(&inverse_packed[0])),
+                       "r"(*reinterpret_cast<const uint32_t*>(&inverse_packed[1])),
+                       "r"(*reinterpret_cast<const uint32_t*>(&inverse_packed[2])),
+                       "r"(*reinterpret_cast<const uint32_t*>(&inverse_packed[3]))
+                       : "memory");
+          asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                       : "=r"(a_frag[0]), "=r"(a_frag[1]), "=r"(a_frag[2]), "=r"(a_frag[3])
+                       : "r"(smem_qd_addr + aux_stage * 21504 +
+                             (unsigned int)((lane / 16 / 8 * 128 + lane % 16 * 8 +
+                                             (lane / 16 % 8 * 16 ^ (lane % 16 & 7) << 4) / 16) *
+                                            16))
+                       : "memory");
+          asm volatile(
+              "ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+              : "=r"(b_frag[0]), "=r"(b_frag[1]), "=r"(b_frag[2]), "=r"(b_frag[3])
+              : "r"(
+                  smem_ki_addr + aux_stage * 21504 +
+                  (unsigned int)((lane % 16 / 8 / 8 * 128 + (8 * (lane / 16) + lane % 8) * 8 +
+                                  (lane % 16 / 8 % 8 * 16 ^ (8 * (lane / 16) + lane % 8 & 7) << 4) /
+                                      16) *
+                                 16))
+              : "memory");
+          asm volatile(
+              "mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, "
+              "%7}, {%8, %9}, {%10, %11, %12, %13};\n"
+              : "=f"(acc[0]), "=f"(acc[1]), "=f"(acc[2]), "=f"(acc[3])
+              : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[0]),
+                "r"(b_frag[1]), "f"(0.0f), "f"(0.0f), "f"(0.0f), "f"(0.0f));
+          asm volatile(
+              "mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, "
+              "%7}, {%8, %9}, {%10, %11, %12, %13};\n"
+              : "=f"(acc[4]), "=f"(acc[(4) + 1]), "=f"(acc[(4) + 2]), "=f"(acc[(4) + 3])
+              : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[2]),
+                "r"(b_frag[(2) + 1]), "f"(0.0f), "f"(0.0f), "f"(0.0f), "f"(0.0f));
+          asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                       : "=r"(a_frag[0]), "=r"(a_frag[1]), "=r"(a_frag[2]), "=r"(a_frag[3])
+                       : "r"(smem_qd_addr + aux_stage * 21504 +
+                             (unsigned int)((lane / 16 / 8 * 128 + lane % 16 * 8 +
+                                                 (lane / 16 % 8 * 16 ^ (lane % 16 & 7) << 4) / 16 ^
+                                             2) *
+                                            16))
+                       : "memory");
+          asm volatile(
+              "ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+              : "=r"(b_frag[0]), "=r"(b_frag[1]), "=r"(b_frag[2]), "=r"(b_frag[3])
+              : "r"(smem_ki_addr + aux_stage * 21504 +
+                    (unsigned int)(((lane % 16 / 8 / 8 * 128 + (8 * (lane / 16) + lane % 8) * 8 +
+                                         (lane % 16 / 8 % 8 * 16 ^ (8 * (lane / 16) + lane % 8 & 7)
+                                                                       << 4) /
+                                             16 +
+                                         256 ^
+                                     2) -
+                                    256) *
+                                   16))
+              : "memory");
+          asm volatile(
+              "mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, "
+              "%7}, {%8, %9}, {%0, %1, %2, %3};\n"
+              : "+f"(acc[0]), "+f"(acc[1]), "+f"(acc[2]), "+f"(acc[3])
+              : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[0]),
+                "r"(b_frag[1]));
+          asm volatile(
+              "mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, "
+              "%7}, {%8, %9}, {%0, %1, %2, %3};\n"
+              : "+f"(acc[4]), "+f"(acc[(4) + 1]), "+f"(acc[(4) + 2]), "+f"(acc[(4) + 3])
+              : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[2]),
+                "r"(b_frag[(2) + 1]));
+          asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                       : "=r"(a_frag[0]), "=r"(a_frag[1]), "=r"(a_frag[2]), "=r"(a_frag[3])
+                       : "r"(smem_qd_addr + aux_stage * 21504 +
+                             (unsigned int)((lane / 16 / 8 * 128 + lane % 16 * 8 +
+                                                 (lane / 16 % 8 * 16 ^ (lane % 16 & 7) << 4) / 16 ^
+                                             2 ^ 6) *
+                                            16))
+                       : "memory");
+          asm volatile(
+              "ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+              : "=r"(b_frag[0]), "=r"(b_frag[1]), "=r"(b_frag[2]), "=r"(b_frag[3])
+              : "r"(smem_ki_addr + aux_stage * 21504 +
+                    (unsigned int)((((lane % 16 / 8 / 8 * 128 + (8 * (lane / 16) + lane % 8) * 8 +
+                                          (lane % 16 / 8 % 8 * 16 ^ (8 * (lane / 16) + lane % 8 & 7)
+                                                                        << 4) /
+                                              16 +
+                                          256 ^
+                                      2) -
+                                         256 + 256 ^
+                                     6) -
+                                    256) *
+                                   16))
+              : "memory");
+          asm volatile(
+              "mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, "
+              "%7}, {%8, %9}, {%0, %1, %2, %3};\n"
+              : "+f"(acc[0]), "+f"(acc[1]), "+f"(acc[2]), "+f"(acc[3])
+              : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[0]),
+                "r"(b_frag[1]));
+          asm volatile(
+              "mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, "
+              "%7}, {%8, %9}, {%0, %1, %2, %3};\n"
+              : "+f"(acc[4]), "+f"(acc[(4) + 1]), "+f"(acc[(4) + 2]), "+f"(acc[(4) + 3])
+              : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[2]),
+                "r"(b_frag[(2) + 1]));
+          asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                       : "=r"(a_frag[0]), "=r"(a_frag[1]), "=r"(a_frag[2]), "=r"(a_frag[3])
+                       : "r"(smem_qd_addr + aux_stage * 21504 +
+                             (unsigned int)((lane / 16 / 8 * 128 + lane % 16 * 8 +
+                                                 (lane / 16 % 8 * 16 ^ (lane % 16 & 7) << 4) / 16 ^
+                                             2 ^ 6 ^ 2) *
+                                            16))
+                       : "memory");
+          asm volatile(
+              "ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+              : "=r"(b_frag[0]), "=r"(b_frag[1]), "=r"(b_frag[2]), "=r"(b_frag[3])
+              : "r"(smem_ki_addr + aux_stage * 21504 +
+                    (unsigned int)(((((lane % 16 / 8 / 8 * 128 + (8 * (lane / 16) + lane % 8) * 8 +
+                                           (lane % 16 / 8 % 8 * 16 ^
+                                            (8 * (lane / 16) + lane % 8 & 7) << 4) /
+                                               16 +
+                                           256 ^
+                                       2) -
+                                          256 + 256 ^
+                                      6) -
+                                         256 + 256 ^
+                                     2) -
+                                    256) *
+                                   16))
+              : "memory");
+          asm volatile(
+              "mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, "
+              "%7}, {%8, %9}, {%0, %1, %2, %3};\n"
+              : "+f"(acc[0]), "+f"(acc[1]), "+f"(acc[2]), "+f"(acc[3])
+              : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[0]),
+                "r"(b_frag[1]));
+          asm volatile(
+              "mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, "
+              "%7}, {%8, %9}, {%0, %1, %2, %3};\n"
+              : "+f"(acc[4]), "+f"(acc[(4) + 1]), "+f"(acc[(4) + 2]), "+f"(acc[(4) + 3])
+              : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[2]),
+                "r"(b_frag[(2) + 1]));
+          asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                       : "=r"(a_frag[0]), "=r"(a_frag[1]), "=r"(a_frag[2]), "=r"(a_frag[3])
+                       : "r"(smem_qd_addr + aux_stage * 21504 +
+                             (unsigned int)(((lane / 16 / 8 * 128 + lane % 16 * 8 +
+                                                  (lane / 16 % 8 * 16 ^ (lane % 16 & 7) << 4) / 16 ^
+                                              2 ^ 6 ^ 2 ^ 6) +
+                                             128) *
+                                            16))
+                       : "memory");
+          asm volatile(
+              "ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+              : "=r"(b_frag[0]), "=r"(b_frag[1]), "=r"(b_frag[2]), "=r"(b_frag[3])
+              : "r"(smem_ki_addr + aux_stage * 21504 +
+                    (unsigned int)((((((lane % 16 / 8 / 8 * 128 + (8 * (lane / 16) + lane % 8) * 8 +
+                                            (lane % 16 / 8 % 8 * 16 ^
+                                             (8 * (lane / 16) + lane % 8 & 7) << 4) /
+                                                16 +
+                                            256 ^
+                                        2) -
+                                           256 + 256 ^
+                                       6) -
+                                          256 + 256 ^
+                                      2) -
+                                         256 + 256 ^
+                                     6) +
+                                    128 - 256) *
+                                   16))
+              : "memory");
+          asm volatile(
+              "mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, "
+              "%7}, {%8, %9}, {%0, %1, %2, %3};\n"
+              : "+f"(acc[0]), "+f"(acc[1]), "+f"(acc[2]), "+f"(acc[3])
+              : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[0]),
+                "r"(b_frag[1]));
+          asm volatile(
+              "mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, "
+              "%7}, {%8, %9}, {%0, %1, %2, %3};\n"
+              : "+f"(acc[4]), "+f"(acc[(4) + 1]), "+f"(acc[(4) + 2]), "+f"(acc[(4) + 3])
+              : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[2]),
+                "r"(b_frag[(2) + 1]));
+          asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                       : "=r"(a_frag[0]), "=r"(a_frag[1]), "=r"(a_frag[2]), "=r"(a_frag[3])
+                       : "r"(smem_qd_addr + aux_stage * 21504 +
+                             (unsigned int)(((lane / 16 / 8 * 128 + lane % 16 * 8 +
+                                                  (lane / 16 % 8 * 16 ^ (lane % 16 & 7) << 4) / 16 ^
+                                              2 ^ 6 ^ 2 ^ 6) +
+                                                 128 ^
+                                             2) *
+                                            16))
+                       : "memory");
+          asm volatile(
+              "ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+              : "=r"(b_frag[0]), "=r"(b_frag[1]), "=r"(b_frag[2]), "=r"(b_frag[3])
+              : "r"(
+                  smem_ki_addr + aux_stage * 21504 +
+                  (unsigned int)(((((((lane % 16 / 8 / 8 * 128 + (8 * (lane / 16) + lane % 8) * 8 +
+                                           (lane % 16 / 8 % 8 * 16 ^
+                                            (8 * (lane / 16) + lane % 8 & 7) << 4) /
+                                               16 +
+                                           256 ^
+                                       2) -
+                                          256 + 256 ^
+                                      6) -
+                                         256 + 256 ^
+                                     2) -
+                                        256 + 256 ^
+                                    6) +
+                                       128 - 256 + 256 ^
+                                   2) -
+                                  256) *
+                                 16))
+              : "memory");
+          asm volatile(
+              "mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, "
+              "%7}, {%8, %9}, {%0, %1, %2, %3};\n"
+              : "+f"(acc[0]), "+f"(acc[1]), "+f"(acc[2]), "+f"(acc[3])
+              : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[0]),
+                "r"(b_frag[1]));
+          asm volatile(
+              "mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, "
+              "%7}, {%8, %9}, {%0, %1, %2, %3};\n"
+              : "+f"(acc[4]), "+f"(acc[(4) + 1]), "+f"(acc[(4) + 2]), "+f"(acc[(4) + 3])
+              : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[2]),
+                "r"(b_frag[(2) + 1]));
+          asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                       : "=r"(a_frag[0]), "=r"(a_frag[1]), "=r"(a_frag[2]), "=r"(a_frag[3])
+                       : "r"(smem_qd_addr + aux_stage * 21504 +
+                             (unsigned int)(((lane / 16 / 8 * 128 + lane % 16 * 8 +
+                                                  (lane / 16 % 8 * 16 ^ (lane % 16 & 7) << 4) / 16 ^
+                                              2 ^ 6 ^ 2 ^ 6) +
+                                                 128 ^
+                                             2 ^ 6) *
+                                            16))
+                       : "memory");
+          asm volatile(
+              "ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+              : "=r"(b_frag[0]), "=r"(b_frag[1]), "=r"(b_frag[2]), "=r"(b_frag[3])
+              : "r"(
+                  smem_ki_addr + aux_stage * 21504 +
+                  (unsigned int)((((((((lane % 16 / 8 / 8 * 128 + (8 * (lane / 16) + lane % 8) * 8 +
+                                            (lane % 16 / 8 % 8 * 16 ^
+                                             (8 * (lane / 16) + lane % 8 & 7) << 4) /
+                                                16 +
+                                            256 ^
+                                        2) -
+                                           256 + 256 ^
+                                       6) -
+                                          256 + 256 ^
+                                      2) -
+                                         256 + 256 ^
+                                     6) +
+                                        128 - 256 + 256 ^
+                                    2) -
+                                       256 + 256 ^
+                                   6) -
+                                  256) *
+                                 16))
+              : "memory");
+          asm volatile(
+              "mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, "
+              "%7}, {%8, %9}, {%0, %1, %2, %3};\n"
+              : "+f"(acc[0]), "+f"(acc[1]), "+f"(acc[2]), "+f"(acc[3])
+              : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[0]),
+                "r"(b_frag[1]));
+          asm volatile(
+              "mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, "
+              "%7}, {%8, %9}, {%0, %1, %2, %3};\n"
+              : "+f"(acc[4]), "+f"(acc[(4) + 1]), "+f"(acc[(4) + 2]), "+f"(acc[(4) + 3])
+              : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[2]),
+                "r"(b_frag[(2) + 1]));
+          asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                       : "=r"(a_frag[0]), "=r"(a_frag[1]), "=r"(a_frag[2]), "=r"(a_frag[3])
+                       : "r"(smem_qd_addr + aux_stage * 21504 +
+                             (unsigned int)(((lane / 16 / 8 * 128 + lane % 16 * 8 +
+                                                  (lane / 16 % 8 * 16 ^ (lane % 16 & 7) << 4) / 16 ^
+                                              2 ^ 6 ^ 2 ^ 6) +
+                                                 128 ^
+                                             2 ^ 6 ^ 2) *
+                                            16))
+                       : "memory");
+          asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                       : "=r"(b_frag[0]), "=r"(b_frag[1]), "=r"(b_frag[2]), "=r"(b_frag[3])
+                       : "r"(smem_ki_addr + aux_stage * 21504 +
+                             (unsigned int)(((((((((lane % 16 / 8 / 8 * 128 +
+                                                        (8 * (lane / 16) + lane % 8) * 8 +
+                                                        (lane % 16 / 8 % 8 * 16 ^
+                                                         (8 * (lane / 16) + lane % 8 & 7) << 4) /
+                                                            16 +
+                                                        256 ^
+                                                    2) -
+                                                       256 + 256 ^
+                                                   6) -
+                                                      256 + 256 ^
+                                                  2) -
+                                                     256 + 256 ^
+                                                 6) +
+                                                    128 - 256 + 256 ^
+                                                2) -
+                                                   256 + 256 ^
+                                               6) -
+                                                  256 + 256 ^
+                                              2) -
+                                             256) *
+                                            16))
+                       : "memory");
+          asm volatile(
+              "mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, "
+              "%7}, {%8, %9}, {%0, %1, %2, %3};\n"
+              : "+f"(acc[0]), "+f"(acc[1]), "+f"(acc[2]), "+f"(acc[3])
+              : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[0]),
+                "r"(b_frag[1]));
+          asm volatile(
+              "mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, "
+              "%7}, {%8, %9}, {%0, %1, %2, %3};\n"
+              : "+f"(acc[4]), "+f"(acc[(4) + 1]), "+f"(acc[(4) + 2]), "+f"(acc[(4) + 3])
+              : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[2]),
+                "r"(b_frag[(2) + 1]));
+          int row0_11 = lane / 4;
+          int row1_12 = row0_11 + 8;
+          int col0_13 = lane % 4 * 2;
+          float mqk[8];
+          mqk[0] = 0.0f;
+          mqk[1] = 0.0f;
+          mqk[2] = 0.0f;
+          mqk[3] = 0.0f;
+          mqk[4] = 0.0f;
+          mqk[5] = 0.0f;
+          mqk[6] = 0.0f;
+          mqk[7] = 0.0f;
+          if (row0_11 >= col0_13) {
+            mqk[0] = acc[0];
+          }
+          if (row0_11 >= col0_13 + 1) {
+            mqk[1] = acc[1];
+          }
+          if (row1_12 >= col0_13) {
+            mqk[2] = acc[2];
+          }
+          if (row1_12 >= col0_13 + 1) {
+            mqk[3] = acc[3];
+          }
+          if (row0_11 >= col0_13 + 8) {
+            mqk[4] = acc[4];
+          }
+          if (row0_11 >= col0_13 + 9) {
+            mqk[5] = acc[5];
+          }
+          if (row1_12 >= col0_13 + 8) {
+            mqk[6] = acc[6];
+          }
+          if (row1_12 >= col0_13 + 9) {
+            mqk[7] = acc[7];
+          }
+          unsigned int mqk_packed[4];
+#pragma unroll
+          for (int _lp = 0; _lp < 4; _lp++) {
+            __nv_bfloat162 _bf2 =
+                __float22bfloat162_rn(make_float2(mqk[_lp * 2 + 0], mqk[_lp * 2 + 1 + 0]));
+            mqk_packed[_lp] = *(uint32_t*)&_bf2;
+          }
+#pragma unroll
+          for (int publish_pair = 0; publish_pair < 2; publish_pair++) {
+            int publish_row = publish_pair * 8 + (lane & 7);
+            int publish_col = lane / 8 * 8;
+            uint32_t _stmatrix_addr_1 = static_cast<uint32_t>(
+                (unsigned long long)(smem_mqk_trans_addr + aux_stage * 21504 +
+                                     (unsigned int)(publish_col / 16 * 512 + publish_row * 32 +
+                                                        publish_col % 16 * 2 ^
+                                                    (publish_col / 16 * 512 + publish_row * 32 +
+                                                             publish_col % 16 * 2 >>
+                                                         7 &
+                                                     1) << 4)));
+            asm volatile("stmatrix.sync.aligned.m8n8.x2.trans.shared.b16 [%0], {%1, %2};\n" ::"r"(
+                             _stmatrix_addr_1),
+                         "r"(*reinterpret_cast<const uint32_t*>(&mqk_packed[publish_pair * 2])),
+                         "r"(*reinterpret_cast<const uint32_t*>(&mqk_packed[publish_pair * 2 + 1]))
+                         : "memory");
+          }
+          __syncwarp();
+          if (elect_sync()) {
+            asm volatile("fence.proxy.async.shared::cta;" ::: "memory");
+            mbarrier_arrive(aux_pairwise_consumed_addr + (aux_stage) * 8);
+          }
+          int lane_row = lane % 16;
+          int lane_col = lane / 16 * 8;
+          int byte_off_14 = (int)aux_stage * 21504 + lane_row * 128 + lane_col * 2;
+          int swizzled_off_15 = byte_off_14 ^ (byte_off_14 >> 7 & 7) << 4;
+          int inv16_addr = smem_inv_work_addr + (unsigned int)swizzled_off_15;
+          unsigned int inv16_frag[4];
+          asm volatile("ldmatrix.sync.aligned.m8n8.x4.trans.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                       : "=r"(inv16_frag[0]), "=r"(inv16_frag[1]), "=r"(inv16_frag[2]),
+                         "=r"(inv16_frag[3])
+                       : "r"(inv16_addr)
+                       : "memory");
+          int inv16_publish_addr =
+              (smem_inv_addr + aux_stage * 21504 +
+               (unsigned int)(lane_col / 16 * 512 + lane_row * 32 + lane_col % 16 * 2 ^
+                              (lane_col / 16 * 512 + lane_row * 32 + lane_col % 16 * 2 >> 7 & 1)
+                                  << 4));
+          uint32_t _stmatrix_addr_2 = static_cast<uint32_t>((unsigned long long)inv16_publish_addr);
+          asm volatile(
+              "stmatrix.sync.aligned.m8n8.x4.trans.shared.b16 [%0], {%1, %2, %3, %4};\n" ::"r"(
+                  _stmatrix_addr_2),
+              "r"(*reinterpret_cast<const uint32_t*>(&inv16_frag[0])),
+              "r"(*reinterpret_cast<const uint32_t*>(&inv16_frag[1])),
+              "r"(*reinterpret_cast<const uint32_t*>(&inv16_frag[2])),
+              "r"(*reinterpret_cast<const uint32_t*>(&inv16_frag[3]))
+              : "memory");
+          __syncwarp();
+          if (elect_sync()) {
+            asm volatile("fence.proxy.async.shared::cta;" ::: "memory");
+            mbarrier_arrive(qk_full_addr + (aux_stage) * 8);
+            mbarrier_arrive(aux_inverse_ready_addr + (aux_stage) * 8);
+          }
+          aux_stage += 1;
+          if (aux_stage == 5) {
+            aux_stage = 0;
+            _phase_aux_pairwise_inputs_ready ^= 1;
+          }
+          aux_stage += 1;
+          if (aux_stage == 5) {
+            aux_stage = 0;
+            _phase_aux_pairwise_inputs_ready ^= 1;
+          }
+        }
+      }
+      unsigned int _phase_work_item_ready_0_1 = 0;
+    }
+  }
+  // ---- Role: mma ----
+  if (warp == 9) {
+    {  // mma_main
+      int task_idx_3 = blockIdx.x;
+      int split_compute_start_2 = 0;
+      unsigned int _phase_work_item_ready_0_2 = 0;
+      int seq_idx_3 = seq_order[task_idx_3 / num_heads];
+      int head_idx_2 = task_idx_3 % num_heads;
+      long long bos_3 = cu_seqlens[seq_idx_3];
+      long long eos_3 = cu_seqlens[seq_idx_3 + 1];
+      int num_chunks_3 = ((int)(eos_3 - bos_3) + 16 - 1) / 16;
+      int seq_len_3 = (int)(eos_3 - bos_3);
+      int num_chunks_0_2 = (seq_len_3 + 16 - 1) / 16;
+      unsigned int mma_stage = 0;
+      unsigned int _phase_qk_full_1 = 0;
+      unsigned int _phase_out_empty_0 = 1;
+      unsigned int _phase_state_inp_left_ready = 0;
+      unsigned int _phase_state_inp_ready = 0;
+      unsigned int _phase_u_inp_ready = 0;
+      unsigned int _phase_u2_inp_ready = 0;
+      unsigned int _phase_final_ready_2 = 0;
+#pragma unroll 1
+      for (int _chunk_idx = 0; _chunk_idx < num_chunks_0_2; _chunk_idx++) {
+        mbarrier_wait(qk_full_addr + (mma_stage) * 8, _phase_qk_full_1);
+        {
+          mbarrier_wait(out_empty_addr, _phase_out_empty_0);
+          _phase_out_empty_0 ^= 1;
+        }
+        {
+          mbarrier_wait(state_inp_left_ready_addr + (mma_stage) * 8, _phase_state_inp_left_ready);
+          int _mma_b_lo_0 =
+              make_warp_uniform((((smem_kd_addr) >> 4) & 0x3FFF) + (mma_stage) * 1344);
+          asm volatile(
+              "{\n\t"
+              ".reg .pred leader, p0, p1;\n\t"
+              ".reg .b32 dhi, blo, ta, id;\n\t"
+              ".reg .b64 db;\n\t"
+              "elect.sync _|leader, 0xFFFFFFFF;\n\t"
+              "setp.ne.b32 p0, %3, 0;\n\t"
+              "setp.ne.b32 p1, 1, 0;\n\t"
+              ""
+              "mov.b32 dhi, 0x40004040;\n\t"
+              "mov.b32 id, 134481040;\n\t"
+              "mov.b32 ta, %2;\n\t"
+              "mov.b32 blo, %1;\n\t"
+              "mov.b64 db, {blo, dhi};\n\t"
+              "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p0;\n\t"
+              "add.u32 ta, ta, 8;\n\t"
+              "add.u32 blo, blo, 2;\n\t"
+              "mov.b64 db, {blo, dhi};\n\t"
+              "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+              "add.u32 ta, ta, 8;\n\t"
+              "add.u32 blo, blo, 2;\n\t"
+              "mov.b64 db, {blo, dhi};\n\t"
+              "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+              "add.u32 ta, ta, 8;\n\t"
+              "add.u32 blo, blo, 2;\n\t"
+              "mov.b64 db, {blo, dhi};\n\t"
+              "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+              "}\n" ::"r"(tmem_tmem_u_acc),
+              "r"(_mma_b_lo_0), "r"(tmem_tmem_state_inp), "r"(0));
+          mbarrier_wait(state_inp_ready_addr + (mma_stage) * 8, _phase_state_inp_ready);
+          int _mma_b_lo_1 =
+              make_warp_uniform((((smem_kd_addr) >> 4) & 0x3FFF) + (mma_stage) * 1344);
+          asm volatile(
+              "{\n\t"
+              ".reg .pred leader, p0, p1;\n\t"
+              ".reg .b32 dhi, blo, ta, id;\n\t"
+              ".reg .b64 db;\n\t"
+              "elect.sync _|leader, 0xFFFFFFFF;\n\t"
+              "setp.ne.b32 p0, %3, 0;\n\t"
+              "setp.ne.b32 p1, 1, 0;\n\t"
+              ""
+              "mov.b32 dhi, 0x40004040;\n\t"
+              "mov.b32 id, 134481040;\n\t"
+              "add.u32 ta, %2, 32;\n\t"
+              "add.u32 blo, %1, 128;\n\t"
+              "mov.b64 db, {blo, dhi};\n\t"
+              "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p0;\n\t"
+              "add.u32 ta, ta, 8;\n\t"
+              "add.u32 blo, blo, 2;\n\t"
+              "mov.b64 db, {blo, dhi};\n\t"
+              "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+              "add.u32 ta, ta, 8;\n\t"
+              "add.u32 blo, blo, 2;\n\t"
+              "mov.b64 db, {blo, dhi};\n\t"
+              "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+              "add.u32 ta, ta, 8;\n\t"
+              "add.u32 blo, blo, 2;\n\t"
+              "mov.b64 db, {blo, dhi};\n\t"
+              "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+              "}\n" ::"r"(tmem_tmem_u_acc),
+              "r"(_mma_b_lo_1), "r"(tmem_tmem_state_inp), "r"(1));
+          {
+            int _mma_b_lo_2 =
+                make_warp_uniform((((smem_qd_addr) >> 4) & 0x3FFF) + (mma_stage) * 1344);
+            asm volatile(
+                "{\n\t"
+                ".reg .pred leader, p0, p1;\n\t"
+                ".reg .b32 dhi, blo, ta, id;\n\t"
+                ".reg .b64 db;\n\t"
+                "elect.sync _|leader, 0xFFFFFFFF;\n\t"
+                "setp.ne.b32 p0, %3, 0;\n\t"
+                "setp.ne.b32 p1, 1, 0;\n\t"
+                ""
+                "mov.b32 dhi, 0x40004040;\n\t"
+                "mov.b32 id, 134481040;\n\t"
+                "mov.b32 ta, %2;\n\t"
+                "mov.b32 blo, %1;\n\t"
+                "mov.b64 db, {blo, dhi};\n\t"
+                "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p0;\n\t"
+                "add.u32 ta, ta, 8;\n\t"
+                "add.u32 blo, blo, 2;\n\t"
+                "mov.b64 db, {blo, dhi};\n\t"
+                "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                "add.u32 ta, ta, 8;\n\t"
+                "add.u32 blo, blo, 2;\n\t"
+                "mov.b64 db, {blo, dhi};\n\t"
+                "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                "add.u32 ta, ta, 8;\n\t"
+                "add.u32 blo, blo, 2;\n\t"
+                "mov.b64 db, {blo, dhi};\n\t"
+                "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                "add.u32 ta, ta, 8;\n\t"
+                "add.u32 blo, blo, 122;\n\t"
+                "mov.b64 db, {blo, dhi};\n\t"
+                "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                "add.u32 ta, ta, 8;\n\t"
+                "add.u32 blo, blo, 2;\n\t"
+                "mov.b64 db, {blo, dhi};\n\t"
+                "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                "add.u32 ta, ta, 8;\n\t"
+                "add.u32 blo, blo, 2;\n\t"
+                "mov.b64 db, {blo, dhi};\n\t"
+                "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                "add.u32 ta, ta, 8;\n\t"
+                "add.u32 blo, blo, 2;\n\t"
+                "mov.b64 db, {blo, dhi};\n\t"
+                "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                "}\n" ::"r"(tmem_tmem_out),
+                "r"(_mma_b_lo_2), "r"(tmem_tmem_state_inp), "r"(0));
+          }
+        }
+        {
+          elect_commit2(old_out_ready_addr + (mma_stage) * 8,
+                        raw_inputs_free_addr + (mma_stage) * 8);
+        }
+        mbarrier_wait(u_inp_ready_addr + (mma_stage) * 8, _phase_u_inp_ready);
+        int _mma_b_lo_7 = make_warp_uniform((((smem_inv_addr) >> 4) & 0x3FFF) + (mma_stage) * 1344);
+        mma_ts_step(tmem_tmem_u2_acc, tmem_tmem_u2_inp, _mma_b_lo_7, 0xC0004010, 134481040, 0);
+        elect_commit(u2_acc_ready_addr + (mma_stage) * 8);
+        mbarrier_wait(u2_inp_ready_addr + (mma_stage) * 8, _phase_u2_inp_ready);
+        int _mma_b_lo_8 = make_warp_uniform(((((smem_kr_trans_addr) >> 4) & 0x3FFF) | 0x800000) +
+                                            (mma_stage) * 1344);
+        mma_ts_step(tmem_tmem_state, tmem_tmem_u2_inp, _mma_b_lo_8, 0x40004040, 136381584, 1);
+        int _mma_b_lo_9 = make_warp_uniform(((((smem_mqk_trans_addr) >> 4) & 0x3FFF) | 0x200000) +
+                                            (mma_stage) * 1344);
+        mma_ts_step(tmem_tmem_out, tmem_tmem_u2_inp, _mma_b_lo_9, 0xC0004010, 134546576, 1);
+        elect_commit(final_ready_addr + (mma_stage) * 8);
+        mma_stage += 1;
+        if (mma_stage == 5) {
+          mma_stage = 0;
+          _phase_qk_full_1 ^= 1;
+          _phase_state_inp_left_ready ^= 1;
+          _phase_state_inp_ready ^= 1;
+          _phase_u_inp_ready ^= 1;
+          _phase_u2_inp_ready ^= 1;
+          _phase_final_ready_2 ^= 1;
+        }
+      }
+      unsigned int _phase_tmem_dealloc_ready_0 = 0;
+      mbarrier_wait(tmem_dealloc_ready_addr, _phase_tmem_dealloc_ready_0);
+      _phase_tmem_dealloc_ready_0 ^= 1;
+      int _tmem_dealloc_addr = *((volatile int*)tmem_addr_storage);
+      asm volatile(
+          "tcgen05.dealloc.cta_group::1.sync.aligned.b32 %0, %1;" ::"r"(_tmem_dealloc_addr),
+          "r"(256));
+    }
+  }
+  // ---- Role: prep ----
+  if (warp >= 12 && warp <= 31) {
+    asm volatile("setmaxnreg.dec.sync.aligned.u32 48;");
+    {  // prep_main
+      int task_idx_4 = blockIdx.x;
+      int split_compute_start_3 = 0;
+      unsigned int _phase_work_item_ready_0_3 = 0;
+      int seq_idx_4 = seq_order[task_idx_4 / num_heads];
+      int head_idx_3 = task_idx_4 % num_heads;
+      long long bos_4 = cu_seqlens[seq_idx_4];
+      long long eos_4 = cu_seqlens[seq_idx_4 + 1];
+      int num_chunks_4 = ((int)(eos_4 - bos_4) + 16 - 1) / 16;
+      int seq_len_4 = (int)(eos_4 - bos_4);
+      int num_chunks_0_3 = (seq_len_4 + 16 - 1) / 16;
+      int instance_id_1 = (warp - 12) / 4;
+      int prep_instance = instance_id_1;
+      int warp_id_in_role_2 = (warp - 12);
+      int prep_local_warp = warp_id_in_role_2 - prep_instance * 4;
+      int prep_tid = prep_local_warp * 32 + lane;
+      int num_prep_iters = (num_chunks_0_3 + 5 - 1 - prep_instance) / 5;
+      unsigned int prep_stage = (unsigned int)prep_instance;
+      int gate_rate_stage_f32 = prep_instance * 5376;
+      int prep_global_tid = warp_id_in_role_2 * 32 + lane;
+      if (prep_tid == 0) {
+        float _expf_0 = __expf(A_log[head_idx_3]);
+        smem_gate_rate_all[gate_rate_stage_f32] = _expf_0;
+      }
+      if (prep_global_tid < 128) {
+        smem_gate_bias_all[prep_global_tid] = dt_bias[head_idx_3 * 128 + prep_global_tid];
+      }
+      asm volatile("barrier.sync 15, 640;" ::: "memory");
+      unsigned int _phase_raw_inputs_free = 1;
+      unsigned int _phase_gate_raw_full = 0;
+      unsigned int _phase_smem_free = 1;
+      unsigned int _phase_v_free = 1;
+      unsigned int _phase_qk_raw_full = 0;
+      unsigned int _phase_short_beta_ready = 0;
+      unsigned int _phase_aux_pairwise_consumed = 0;
+      unsigned int _phase_prep_diag_ready = 0;
+      unsigned int _phase_prep_inv16_ready = 0;
+      unsigned int _phase_aux_inverse_ready = 0;
+#pragma unroll 1
+      for (int prep_iter = 0; prep_iter < num_prep_iters; prep_iter++) {
+        int chunk_idx_3 = prep_iter * 5 + prep_instance;
+        int chunk_global_local_1 = chunk_idx_3;
+        int owned_chunk_1 = chunk_global_local_1 >= 0 && chunk_global_local_1 < num_chunks_4;
+        int stage_f32_1 = prep_stage * 5376;
+        int stage_bf16 = prep_stage * 10752;
+        int chunk_is_full_1 = ((seq_len_4 >= (chunk_idx_3 + 1) * 16) ? 1 : 0);
+        float early_beta_value = 0.0f;
+        float early_gate0 = 0.0f;
+        if (chunk_is_full_1 != 0 || prep_iter != 0) {
+          mbarrier_wait(raw_inputs_free_addr + (prep_stage) * 8, _phase_raw_inputs_free);
+        }
+        if (chunk_is_full_1 != 0) {
+          if (prep_local_warp == 0) {
+            if (elect_sync()) {
+              mbarrier_arrive_expect_tx(gate_raw_full_addr + (prep_stage) * 8, 4352);
+              tma_3d_gmem2smem(smem_g_raw_addr + prep_stage * 21504, g_tma, 0, head_idx_3,
+                               (int)(bos_4 + (long long)(chunk_idx_3 * 16)),
+                               gate_raw_full_addr + (prep_stage) * 8);
+              {
+                tma_2d_gmem2smem(smem_beta_raw_addr + prep_stage * 21504, beta_tma,
+                                 ((0) ? 0 : head_idx_3 / 8 * 8),
+                                 (int)(((0) ? (bos_4 + (long long)(chunk_idx_3 * 16)) / 2
+                                            : bos_4 + (long long)(chunk_idx_3 * 16))),
+                                 gate_raw_full_addr + (prep_stage) * 8);
+              }
+              mbarrier_arrive_expect_tx(qk_raw_full_addr + (prep_stage) * 8, 8192);
+              tma_4d_gmem2smem(smem_kd_addr + prep_stage * 21504, k_tma, 0,
+                               (int)(bos_4 + (long long)(chunk_idx_3 * 16)), head_idx_3, 0,
+                               qk_raw_full_addr + (prep_stage) * 8);
+            }
+          }
+          mbarrier_wait(gate_raw_full_addr + (prep_stage) * 8, _phase_gate_raw_full);
+          if (prep_local_warp == 2 && lane < 16) {
+            float beta_logit = 0.0f;
+            {
+              {
+                unsigned int beta_raw_pair[1];
+                asm volatile("ld.shared.b32 %0, [%1];"
+                             : "=r"(*reinterpret_cast<uint32_t*>(&beta_raw_pair[0]))
+                             : "r"(smem_beta_raw_addr + prep_stage * 21504 +
+                                   (unsigned int)(lane * 16) +
+                                   (unsigned int)(head_idx_3 % 8 / 2 * 4)));
+                float beta_raw_pair_f32[2];
+#pragma unroll
+                for (int _pair = 0; _pair < 1; _pair++) {
+                  asm volatile(
+                      "{\n\t"
+                      "shl.b32 %0, %2, 16;\n\t"
+                      "and.b32 %1, %2, 0xffff0000;\n\t"
+                      "}\n"
+                      : "=f"((&beta_raw_pair_f32[_pair * 2])[0]),
+                        "=f"((&beta_raw_pair_f32[_pair * 2])[1])
+                      : "r"(beta_raw_pair[_pair]));
+                }
+                beta_logit = beta_raw_pair_f32[0];
+                if (head_idx_3 % 2 != 0) {
+                  beta_logit = beta_raw_pair_f32[1];
+                }
+              }
+            }
+            float _tanh_approx_1;
+            asm volatile("tanh.approx.f32 %0, %1;" : "=f"(_tanh_approx_1) : "f"(beta_logit * 0.5f));
+            early_beta_value = _tanh_approx_1 * 0.5f + 0.5f;
+          }
+          {
+            if (prep_tid < 128) {
+              float early_gate_rate = smem_gate_rate_all[stage_f32_1];
+              float early_gate_bias = smem_gate_bias_all[prep_tid];
+              __nv_bfloat16 early_gate_raw = smem_g_raw_all[stage_bf16 + prep_tid];
+              float _cvt_f32_1 = __bfloat162float(early_gate_raw);
+              float early_gate_arg = early_gate_rate * (_cvt_f32_1 + early_gate_bias);
+              float _tanh_approx_2;
+              asm volatile("tanh.approx.f32 %0, %1;"
+                           : "=f"(_tanh_approx_2)
+                           : "f"(early_gate_arg * 0.5f));
+              float early_gate_sigmoid = _tanh_approx_2 * 0.5f + 0.5f;
+              early_gate0 = lower_bound * 1.4426950408889634f * early_gate_sigmoid;
+            }
+          }
+        }
+        mbarrier_wait(smem_free_addr + (prep_stage) * 8, _phase_smem_free);
+        mbarrier_wait(v_free_addr + (prep_stage) * 8, _phase_v_free);
+        if (chunk_is_full_1 != 0) {
+          if (prep_local_warp == 0) {
+            if (elect_sync()) {
+              tma_4d_gmem2smem(smem_q_raw_prefetch_addr + prep_stage * 21504, q_tma, 0,
+                               (int)(bos_4 + (long long)(chunk_idx_3 * 16)), head_idx_3, 0,
+                               qk_raw_full_addr + (prep_stage) * 8);
+            }
+          }
+        }
+        if (chunk_is_full_1 == 0) {
+#pragma unroll
+          for (int gate_load_pass = 0; gate_load_pass < 2; gate_load_pass++) {
+            int gate_load_item = gate_load_pass * 128 + prep_tid;
+            int gate_load_row = gate_load_item / 16;
+            int gate_load_segment = gate_load_item % 16;
+            long long gate_load_token = bos_4 + (long long)(chunk_idx_3 * 16 + gate_load_row);
+            long long gate_load_base =
+                (gate_load_token * (long long)num_heads + (long long)head_idx_3) * 128 +
+                (long long)(gate_load_segment * 8);
+            asm volatile(
+                "cp.async.cg.shared::cta.global [%0], [%1], 16, %2;" ::"r"(
+                    smem_g_raw_addr + prep_stage * 21504 + (unsigned int)(gate_load_item * 16)),
+                "l"(g + gate_load_base), "r"((gate_load_token < eos_4) ? 16 : 0));
+            int q_tail_addr =
+                (smem_q_raw_prefetch_addr + prep_stage * 21504 +
+                 (unsigned int)(gate_load_segment * 8 / 64 * 2048 + gate_load_row * 128 +
+                                    gate_load_segment * 8 % 64 * 2 ^
+                                (gate_load_segment * 8 / 64 * 2048 + gate_load_row * 128 +
+                                         gate_load_segment * 8 % 64 * 2 >>
+                                     7 &
+                                 7) << 4));
+            asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16, %2;" ::"r"(q_tail_addr),
+                         "l"(q + gate_load_base), "r"((gate_load_token < eos_4) ? 16 : 0));
+            int k_tail_addr =
+                (smem_kd_addr + prep_stage * 21504 +
+                 (unsigned int)(gate_load_segment * 8 / 64 * 2048 + gate_load_row * 128 +
+                                    gate_load_segment * 8 % 64 * 2 ^
+                                (gate_load_segment * 8 / 64 * 2048 + gate_load_row * 128 +
+                                         gate_load_segment * 8 % 64 * 2 >>
+                                     7 &
+                                 7) << 4));
+            asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16, %2;" ::"r"(k_tail_addr),
+                         "l"(k + gate_load_base), "r"((gate_load_token < eos_4) ? 16 : 0));
+          }
+        }
+        if (chunk_is_full_1 == 0) {
+          asm volatile("cp.async.commit_group;");
+          asm volatile("cp.async.wait_group 0;");
+          asm volatile("barrier.sync %0, 128;" ::"r"(10 + prep_instance) : "memory");
+        }
+        if (prep_local_warp == 2 && lane < 16) {
+          long long beta_token = bos_4 + (long long)(chunk_idx_3 * 16 + lane);
+          float beta_value = early_beta_value;
+          if (chunk_is_full_1 == 0) {
+            if (beta_token < eos_4) {
+              float beta_logit_1 =
+                  (float)beta[beta_token * (long long)num_heads + (long long)head_idx_3];
+              {
+                beta_logit_1 = (float)beta[beta_token * beta_token_stride + (long long)head_idx_3];
+              }
+              float _tanh_approx_3;
+              asm volatile("tanh.approx.f32 %0, %1;"
+                           : "=f"(_tanh_approx_3)
+                           : "f"(beta_logit_1 * 0.5f));
+              beta_value = _tanh_approx_3 * 0.5f + 0.5f;
+            }
+          }
+          {
+            __nv_bfloat16 _cvt_bf16_0 = __float2bfloat16(beta_value);
+            smem_prep_beta_bf16_all[stage_bf16 + lane] = _cvt_bf16_0;
+          }
+        }
+        if (prep_tid < 128) {
+          int gate_col = prep_tid;
+          float gate_rate = smem_gate_rate_all[stage_f32_1];
+          float gate_bias = smem_gate_bias_all[gate_col];
+          float prefix_log2 = 0.0f;
+          {
+            for (int gate_row = 0; gate_row < 16; gate_row++) {
+              long long gate_token = bos_4 + (long long)(chunk_idx_3 * 16 + gate_row);
+              float gate_log2 = 0.0f;
+              int gate_needs_compute = 1;
+              if (gate_row == 0) {
+                if (chunk_is_full_1 != 0) {
+                  gate_log2 = early_gate0;
+                  gate_needs_compute = 0;
+                }
+              }
+              if (gate_needs_compute != 0) {
+                if (gate_token < eos_4) {
+                  __nv_bfloat16 gate_raw = smem_g_raw_all[stage_bf16 + gate_row * 128 + gate_col];
+                  float _cvt_f32_7 = __bfloat162float(gate_raw);
+                  float gate_arg = gate_rate * (_cvt_f32_7 + gate_bias);
+                  float _tanh_approx_8;
+                  asm volatile("tanh.approx.f32 %0, %1;"
+                               : "=f"(_tanh_approx_8)
+                               : "f"(gate_arg * 0.5f));
+                  float gate_sigmoid = _tanh_approx_8 * 0.5f + 0.5f;
+                  gate_log2 = lower_bound * 1.4426950408889634f * gate_sigmoid;
+                }
+              }
+              prefix_log2 += gate_log2;
+              smem_gate_all[stage_f32_1 + gate_row * 128 + gate_col] = prefix_log2;
+            }
+          }
+        }
+        asm volatile("barrier.sync %0, 128;" ::"r"(10 + prep_instance) : "memory");
+        if (chunk_is_full_1 != 0) {
+          mbarrier_wait(qk_raw_full_addr + (prep_stage) * 8, _phase_qk_raw_full);
+        }
+        if (prep_tid < 128) {
+          float total_log2 = smem_gt_prefix_all[stage_f32_1 + prep_tid];
+          float _exp2_0 = approx_exp2(total_log2);
+          float restore_factor_value = _exp2_0;
+          smem_restore_factor_all[stage_f32_1 + prep_tid] = restore_factor_value;
+        }
+        if (prep_tid == 0) {
+          float _exp2_1 = approx_exp2(lower_bound * 1.4426950408889634f * 8.0f);
+          smem_restore_factor_all[stage_f32_1 + 128] = _exp2_1;
+        }
+#pragma unroll 1
+        for (int work_pass = 0; work_pass < 2; work_pass++) {
+          int work_item = work_pass * 128 + prep_tid;
+          int row = work_item / 16;
+          int segment = work_item % 16;
+          long long token = bos_4 + (long long)(chunk_idx_3 * 16 + row);
+          int token_valid = ((token < eos_4) ? 1 : 0);
+          long long gmem_base = (token * (long long)num_heads + (long long)head_idx_3) * 128 +
+                                (long long)(segment * 8);
+          float q_raw_vec[8];
+          float k_raw_vec[8];
+          unsigned int packed[4];
+          asm volatile(
+              "ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+              : "=r"(*reinterpret_cast<uint32_t*>(&packed[0])),
+                "=r"(*reinterpret_cast<uint32_t*>(&packed[(0) + 1])),
+                "=r"(*reinterpret_cast<uint32_t*>(&packed[(0) + 2])),
+                "=r"(*reinterpret_cast<uint32_t*>(&packed[(0) + 3]))
+              : "r"(
+                  (smem_q_raw_prefetch_addr + prep_stage * 21504 +
+                   (unsigned int)(segment * 8 / 64 * 2048 + row * 128 + segment * 8 % 64 * 2 ^
+                                  (segment * 8 / 64 * 2048 + row * 128 + segment * 8 % 64 * 2 >> 7 &
+                                   7) << 4))));
+          float packed_f32[8];
+#pragma unroll
+          for (int _pair = 0; _pair < 4; _pair++) {
+            asm volatile(
+                "{\n\t"
+                "shl.b32 %0, %2, 16;\n\t"
+                "and.b32 %1, %2, 0xffff0000;\n\t"
+                "}\n"
+                : "=f"((&packed_f32[_pair * 2])[0]), "=f"((&packed_f32[_pair * 2])[1])
+                : "r"(packed[_pair]));
+          }
+#pragma unroll
+          for (int value_idx_3 = 0; value_idx_3 < 8; value_idx_3++) {
+            q_raw_vec[value_idx_3] = packed_f32[value_idx_3];
+          }
+          unsigned int packed_0[4];
+          asm volatile(
+              "ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+              : "=r"(*reinterpret_cast<uint32_t*>(&packed_0[0])),
+                "=r"(*reinterpret_cast<uint32_t*>(&packed_0[(0) + 1])),
+                "=r"(*reinterpret_cast<uint32_t*>(&packed_0[(0) + 2])),
+                "=r"(*reinterpret_cast<uint32_t*>(&packed_0[(0) + 3]))
+              : "r"(
+                  (smem_kd_addr + prep_stage * 21504 +
+                   (unsigned int)(segment * 8 / 64 * 2048 + row * 128 + segment * 8 % 64 * 2 ^
+                                  (segment * 8 / 64 * 2048 + row * 128 + segment * 8 % 64 * 2 >> 7 &
+                                   7) << 4))));
+          float packed_0_f32[8];
+#pragma unroll
+          for (int _pair = 0; _pair < 4; _pair++) {
+            asm volatile(
+                "{\n\t"
+                "shl.b32 %0, %2, 16;\n\t"
+                "and.b32 %1, %2, 0xffff0000;\n\t"
+                "}\n"
+                : "=f"((&packed_0_f32[_pair * 2])[0]), "=f"((&packed_0_f32[_pair * 2])[1])
+                : "r"(packed_0[_pair]));
+          }
+#pragma unroll
+          for (int value_idx_4 = 0; value_idx_4 < 8; value_idx_4++) {
+            k_raw_vec[value_idx_4] = packed_0_f32[value_idx_4];
+          }
+          float q_sum = 0.0f;
+          float k_sum = 0.0f;
+          for (int elem_in_segment = 0; elem_in_segment < 8; elem_in_segment++) {
+            float q_raw = q_raw_vec[elem_in_segment];
+            float k_raw = k_raw_vec[elem_in_segment];
+            float _fma_0 = __fmaf_rn(q_raw, q_raw, q_sum);
+            q_sum = _fma_0;
+            float _fma_1 = __fmaf_rn(k_raw, k_raw, k_sum);
+            k_sum = _fma_1;
+          }
+          float _shfl_xor_0 = __shfl_xor_sync(0xFFFFFFFF, q_sum, 8);
+          q_sum += _shfl_xor_0;
+          float _shfl_xor_1 = __shfl_xor_sync(0xFFFFFFFF, k_sum, 8);
+          k_sum += _shfl_xor_1;
+          float _shfl_xor_2 = __shfl_xor_sync(0xFFFFFFFF, q_sum, 4);
+          q_sum += _shfl_xor_2;
+          float _shfl_xor_3 = __shfl_xor_sync(0xFFFFFFFF, k_sum, 4);
+          k_sum += _shfl_xor_3;
+          float _shfl_xor_4 = __shfl_xor_sync(0xFFFFFFFF, q_sum, 2);
+          q_sum += _shfl_xor_4;
+          float _shfl_xor_5 = __shfl_xor_sync(0xFFFFFFFF, k_sum, 2);
+          k_sum += _shfl_xor_5;
+          float _shfl_xor_6 = __shfl_xor_sync(0xFFFFFFFF, q_sum, 1);
+          q_sum += _shfl_xor_6;
+          float _shfl_xor_7 = __shfl_xor_sync(0xFFFFFFFF, k_sum, 1);
+          k_sum += _shfl_xor_7;
+          float _rsqrt_0 = rsqrtf(q_sum + 1e-06f);
+          float q_inv = _rsqrt_0;
+          float _rsqrt_1 = rsqrtf(k_sum + 1e-06f);
+          float k_inv = _rsqrt_1;
+          const float2 _scale2_0 = {q_inv, q_inv};
+#pragma unroll
+          for (int _ls = 0; _ls < 4; _ls++)
+            mul_f32x2_inplace(&reinterpret_cast<float2*>(q_raw_vec)[_ls], _scale2_0);
+          const float2 _scale2_1 = {k_inv, k_inv};
+#pragma unroll
+          for (int _ls = 0; _ls < 4; _ls++)
+            mul_f32x2_inplace(&reinterpret_cast<float2*>(k_raw_vec)[_ls], _scale2_1);
+          float qd_vec[8];
+          float kd_vec[8];
+          float ki_vec[8];
+          for (int elem_in_segment_1 = 0; elem_in_segment_1 < 8; elem_in_segment_1++) {
+            int col = segment * 8 + elem_in_segment_1;
+            float prefix = smem_gate_all[stage_f32_1 + row * 128 + col];
+            float common_log2 = smem_gate_all[stage_f32_1 + 1024 + col];
+            float _exp2_2 = approx_exp2(prefix - common_log2);
+            float decay = _exp2_2;
+            qd_vec[elem_in_segment_1] = decay;
+            kd_vec[elem_in_segment_1] = decay;
+            ki_vec[elem_in_segment_1] = k_raw_vec[elem_in_segment_1] / decay;
+          }
+#pragma unroll
+          for (int _ls = 0; _ls < 4; _ls++)
+            mul_f32x2_inplace(&reinterpret_cast<float2*>(qd_vec)[_ls],
+                              reinterpret_cast<const float2*>(q_raw_vec)[_ls]);
+          {
+            const float2 _scale2_2 = {scale, scale};
+#pragma unroll
+            for (int _ls = 0; _ls < 4; _ls++)
+              mul_f32x2_inplace(&reinterpret_cast<float2*>(qd_vec)[_ls], _scale2_2);
+          }
+#pragma unroll
+          for (int _ls = 0; _ls < 4; _ls++)
+            mul_f32x2_inplace(&reinterpret_cast<float2*>(kd_vec)[_ls],
+                              reinterpret_cast<const float2*>(k_raw_vec)[_ls]);
+          __nv_bfloat16 _cvt_bf16_2 = __float2bfloat16(scale);
+          float _cvt_f32_8 = __bfloat162float(_cvt_bf16_2);
+          float n16_decay_values[8];
+          float n16_inv_decay_values[8];
+          n16_decay_values[0] = smem_gate_all[stage_f32_1 + row * 128 + segment * 8];
+          n16_decay_values[1] = smem_gate_all[stage_f32_1 + row * 128 + (segment * 8 + 1)];
+          n16_decay_values[2] = smem_gate_all[stage_f32_1 + row * 128 + (segment * 8 + 2)];
+          n16_decay_values[3] = smem_gate_all[stage_f32_1 + row * 128 + (segment * 8 + 3)];
+          n16_decay_values[4] = smem_gate_all[stage_f32_1 + row * 128 + (segment * 8 + 4)];
+          n16_decay_values[5] = smem_gate_all[stage_f32_1 + row * 128 + (segment * 8 + 5)];
+          n16_decay_values[6] = smem_gate_all[stage_f32_1 + row * 128 + (segment * 8 + 6)];
+          n16_decay_values[7] = smem_gate_all[stage_f32_1 + row * 128 + (segment * 8 + 7)];
+          uint32_t n16_decay_values_bf16[4];
+#pragma unroll
+          for (int _fe = 0; _fe < 4; _fe++) {
+            n16_decay_values[0 + _fe * 2] = approx_exp2(n16_decay_values[0 + _fe * 2]);
+            n16_decay_values[0 + _fe * 2 + 1] = approx_exp2(n16_decay_values[0 + _fe * 2 + 1]);
+            __nv_bfloat162 _bf2 = __float22bfloat162_rn(
+                make_float2(n16_decay_values[0 + _fe * 2], n16_decay_values[0 + _fe * 2 + 1]));
+            n16_decay_values_bf16[0 + _fe] = *(uint32_t*)&_bf2;
+          }
+#pragma unroll
+          for (int _pair = 0; _pair < 4; _pair++) {
+            asm volatile(
+                "{\n\t"
+                "shl.b32 %0, %2, 16;\n\t"
+                "and.b32 %1, %2, 0xffff0000;\n\t"
+                "}\n"
+                : "=f"((&n16_decay_values[_pair * 2])[0]), "=f"((&n16_decay_values[_pair * 2])[1])
+                : "r"(n16_decay_values_bf16[_pair]));
+          }
+          float _rcp_0 = approx_rcp(n16_decay_values[0]);
+          n16_inv_decay_values[0] = _rcp_0;
+          float _rcp_1 = approx_rcp(n16_decay_values[1]);
+          n16_inv_decay_values[1] = _rcp_1;
+          float _rcp_2 = approx_rcp(n16_decay_values[2]);
+          n16_inv_decay_values[2] = _rcp_2;
+          float _rcp_3 = approx_rcp(n16_decay_values[3]);
+          n16_inv_decay_values[3] = _rcp_3;
+          float _rcp_4 = approx_rcp(n16_decay_values[4]);
+          n16_inv_decay_values[4] = _rcp_4;
+          float _rcp_5 = approx_rcp(n16_decay_values[5]);
+          n16_inv_decay_values[5] = _rcp_5;
+          float _rcp_6 = approx_rcp(n16_decay_values[6]);
+          n16_inv_decay_values[6] = _rcp_6;
+          float _rcp_7 = approx_rcp(n16_decay_values[7]);
+          n16_inv_decay_values[7] = _rcp_7;
+          uint32_t q_raw_vec_bf16[4];
+#pragma unroll
+          for (int _lp = 0; _lp < 4; _lp++) {
+            __nv_bfloat162 _bf2 = __float22bfloat162_rn(
+                make_float2(q_raw_vec[_lp * 2 + 0], q_raw_vec[_lp * 2 + 1 + 0]));
+            q_raw_vec_bf16[_lp] = *(uint32_t*)&_bf2;
+          }
+#pragma unroll
+          for (int _pair = 0; _pair < 4; _pair++) {
+            asm volatile(
+                "{\n\t"
+                "shl.b32 %0, %2, 16;\n\t"
+                "and.b32 %1, %2, 0xffff0000;\n\t"
+                "}\n"
+                : "=f"((&qd_vec[_pair * 2])[0]), "=f"((&qd_vec[_pair * 2])[1])
+                : "r"(q_raw_vec_bf16[_pair]));
+          }
+          uint32_t k_raw_vec_bf16[4];
+#pragma unroll
+          for (int _lp = 0; _lp < 4; _lp++) {
+            __nv_bfloat162 _bf2 = __float22bfloat162_rn(
+                make_float2(k_raw_vec[_lp * 2 + 0], k_raw_vec[_lp * 2 + 1 + 0]));
+            k_raw_vec_bf16[_lp] = *(uint32_t*)&_bf2;
+          }
+#pragma unroll
+          for (int _pair = 0; _pair < 4; _pair++) {
+            asm volatile(
+                "{\n\t"
+                "shl.b32 %0, %2, 16;\n\t"
+                "and.b32 %1, %2, 0xffff0000;\n\t"
+                "}\n"
+                : "=f"((&kd_vec[_pair * 2])[0]), "=f"((&kd_vec[_pair * 2])[1])
+                : "r"(k_raw_vec_bf16[_pair]));
+          }
+#pragma unroll
+          for (int _pair = 0; _pair < 4; _pair++) {
+            asm volatile(
+                "{\n\t"
+                "shl.b32 %0, %2, 16;\n\t"
+                "and.b32 %1, %2, 0xffff0000;\n\t"
+                "}\n"
+                : "=f"((&ki_vec[_pair * 2])[0]), "=f"((&ki_vec[_pair * 2])[1])
+                : "r"(k_raw_vec_bf16[_pair]));
+          }
+#pragma unroll
+          for (int _ls = 0; _ls < 4; _ls++)
+            mul_f32x2_inplace(&reinterpret_cast<float2*>(qd_vec)[_ls],
+                              reinterpret_cast<const float2*>(n16_decay_values)[_ls]);
+          uint32_t qd_vec_bf16[4];
+#pragma unroll
+          for (int _lp = 0; _lp < 4; _lp++) {
+            __nv_bfloat162 _bf2 =
+                __float22bfloat162_rn(make_float2(qd_vec[_lp * 2 + 0], qd_vec[_lp * 2 + 1 + 0]));
+            qd_vec_bf16[_lp] = *(uint32_t*)&_bf2;
+          }
+#pragma unroll
+          for (int _pair = 0; _pair < 4; _pair++) {
+            asm volatile(
+                "{\n\t"
+                "shl.b32 %0, %2, 16;\n\t"
+                "and.b32 %1, %2, 0xffff0000;\n\t"
+                "}\n"
+                : "=f"((&qd_vec[_pair * 2])[0]), "=f"((&qd_vec[_pair * 2])[1])
+                : "r"(qd_vec_bf16[_pair]));
+          }
+          const float2 _scale2_3 = {_cvt_f32_8, _cvt_f32_8};
+#pragma unroll
+          for (int _ls = 0; _ls < 4; _ls++)
+            mul_f32x2_inplace(&reinterpret_cast<float2*>(qd_vec)[_ls], _scale2_3);
+          uint32_t qd_vec_bf16_1[4];
+#pragma unroll
+          for (int _lp = 0; _lp < 4; _lp++) {
+            __nv_bfloat162 _bf2 =
+                __float22bfloat162_rn(make_float2(qd_vec[_lp * 2 + 0], qd_vec[_lp * 2 + 1 + 0]));
+            qd_vec_bf16_1[_lp] = *(uint32_t*)&_bf2;
+          }
+#pragma unroll
+          for (int _pair = 0; _pair < 4; _pair++) {
+            asm volatile(
+                "{\n\t"
+                "shl.b32 %0, %2, 16;\n\t"
+                "and.b32 %1, %2, 0xffff0000;\n\t"
+                "}\n"
+                : "=f"((&qd_vec[_pair * 2])[0]), "=f"((&qd_vec[_pair * 2])[1])
+                : "r"(qd_vec_bf16_1[_pair]));
+          }
+#pragma unroll
+          for (int _ls = 0; _ls < 4; _ls++)
+            mul_f32x2_inplace(&reinterpret_cast<float2*>(kd_vec)[_ls],
+                              reinterpret_cast<const float2*>(n16_decay_values)[_ls]);
+          uint32_t kd_vec_bf16[4];
+#pragma unroll
+          for (int _lp = 0; _lp < 4; _lp++) {
+            __nv_bfloat162 _bf2 =
+                __float22bfloat162_rn(make_float2(kd_vec[_lp * 2 + 0], kd_vec[_lp * 2 + 1 + 0]));
+            kd_vec_bf16[_lp] = *(uint32_t*)&_bf2;
+          }
+#pragma unroll
+          for (int _pair = 0; _pair < 4; _pair++) {
+            asm volatile(
+                "{\n\t"
+                "shl.b32 %0, %2, 16;\n\t"
+                "and.b32 %1, %2, 0xffff0000;\n\t"
+                "}\n"
+                : "=f"((&kd_vec[_pair * 2])[0]), "=f"((&kd_vec[_pair * 2])[1])
+                : "r"(kd_vec_bf16[_pair]));
+          }
+#pragma unroll
+          for (int _ls = 0; _ls < 4; _ls++)
+            mul_f32x2_inplace(&reinterpret_cast<float2*>(ki_vec)[_ls],
+                              reinterpret_cast<const float2*>(n16_inv_decay_values)[_ls]);
+          uint32_t ki_vec_bf16[4];
+#pragma unroll
+          for (int _lp = 0; _lp < 4; _lp++) {
+            __nv_bfloat162 _bf2 =
+                __float22bfloat162_rn(make_float2(ki_vec[_lp * 2 + 0], ki_vec[_lp * 2 + 1 + 0]));
+            ki_vec_bf16[_lp] = *(uint32_t*)&_bf2;
+          }
+#pragma unroll
+          for (int _pair = 0; _pair < 4; _pair++) {
+            asm volatile(
+                "{\n\t"
+                "shl.b32 %0, %2, 16;\n\t"
+                "and.b32 %1, %2, 0xffff0000;\n\t"
+                "}\n"
+                : "=f"((&ki_vec[_pair * 2])[0]), "=f"((&ki_vec[_pair * 2])[1])
+                : "r"(ki_vec_bf16[_pair]));
+          }
+          unsigned int packed_2[4];
+#pragma unroll
+          for (int _lp = 0; _lp < 4; _lp++) {
+            __nv_bfloat162 _bf2 =
+                __float22bfloat162_rn(make_float2(qd_vec[_lp * 2 + 0], qd_vec[_lp * 2 + 1 + 0]));
+            packed_2[_lp] = *(uint32_t*)&_bf2;
+          }
+#pragma unroll
+          for (int word_6 = 0; word_6 < 4; word_6++) {
+            asm volatile(
+                "st.shared.b32 [%0], %1;" ::"r"(
+                    (smem_qd_addr + prep_stage * 21504 +
+                     (unsigned int)(segment * 8 / 64 * 2048 + row * 128 + segment * 8 % 64 * 2 ^
+                                    (segment * 8 / 64 * 2048 + row * 128 + segment * 8 % 64 * 2 >>
+                                         7 &
+                                     7) << 4)) +
+                    (unsigned int)(word_6 * 4)),
+                "r"((packed_2[word_6])));
+          }
+          unsigned int packed_3[4];
+#pragma unroll
+          for (int _lp = 0; _lp < 4; _lp++) {
+            __nv_bfloat162 _bf2 =
+                __float22bfloat162_rn(make_float2(kd_vec[_lp * 2 + 0], kd_vec[_lp * 2 + 1 + 0]));
+            packed_3[_lp] = *(uint32_t*)&_bf2;
+          }
+#pragma unroll
+          for (int word_7 = 0; word_7 < 4; word_7++) {
+            asm volatile(
+                "st.shared.b32 [%0], %1;" ::"r"(
+                    (smem_kd_addr + prep_stage * 21504 +
+                     (unsigned int)(segment * 8 / 64 * 2048 + row * 128 + segment * 8 % 64 * 2 ^
+                                    (segment * 8 / 64 * 2048 + row * 128 + segment * 8 % 64 * 2 >>
+                                         7 &
+                                     7) << 4)) +
+                    (unsigned int)(word_7 * 4)),
+                "r"((packed_3[word_7])));
+          }
+          unsigned int packed_4[4];
+#pragma unroll
+          for (int _lp = 0; _lp < 4; _lp++) {
+            __nv_bfloat162 _bf2 =
+                __float22bfloat162_rn(make_float2(ki_vec[_lp * 2 + 0], ki_vec[_lp * 2 + 1 + 0]));
+            packed_4[_lp] = *(uint32_t*)&_bf2;
+          }
+#pragma unroll
+          for (int word_8 = 0; word_8 < 4; word_8++) {
+            asm volatile(
+                "st.shared.b32 [%0], %1;" ::"r"(
+                    (smem_ki_addr + prep_stage * 21504 +
+                     (unsigned int)(segment * 8 / 64 * 2048 + row * 128 + segment * 8 % 64 * 2 ^
+                                    (segment * 8 / 64 * 2048 + row * 128 + segment * 8 % 64 * 2 >>
+                                         7 &
+                                     7) << 4)) +
+                    (unsigned int)(word_8 * 4)),
+                "r"((packed_4[word_8])));
+          }
+        }
+        asm volatile("barrier.sync %0, 128;" ::"r"(10 + prep_instance) : "memory");
+        {
+          if (prep_local_warp == 0) {
+            if (elect_sync()) {
+              asm volatile("fence.proxy.async.shared::cta;" ::: "memory");
+              mbarrier_arrive(aux_pairwise_inputs_ready_addr + (prep_stage) * 8);
+            }
+          }
+        }
+        unsigned int a_frag_1[4];
+        unsigned int b_frag_1[4];
+        float acc_1[8];
+        long long tape_scaled_base = 0;
+        {
+          mbarrier_wait(aux_pairwise_consumed_addr + (prep_stage) * 8,
+                        _phase_aux_pairwise_consumed);
+        }
+        {
+          int stage_f32_0 = prep_stage * 5376;
+          int restore_segment = lane & 15;
+#pragma unroll 1
+          for (int restore_k_pass = 0; restore_k_pass < 2; restore_k_pass++) {
+            int restore_row = prep_local_warp * 4 + restore_k_pass * 2 + (lane >> 4);
+            float restore_ki_values[8];
+            float restore_kr_values[8];
+            unsigned int packed_1[4];
+            asm volatile(
+                "ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                : "=r"(*reinterpret_cast<uint32_t*>(&packed_1[0])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&packed_1[(0) + 1])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&packed_1[(0) + 2])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&packed_1[(0) + 3]))
+                : "r"((smem_ki_addr + prep_stage * 21504 +
+                       (unsigned int)(restore_segment * 8 / 64 * 2048 + restore_row * 128 +
+                                          restore_segment * 8 % 64 * 2 ^
+                                      (restore_segment * 8 / 64 * 2048 + restore_row * 128 +
+                                               restore_segment * 8 % 64 * 2 >>
+                                           7 &
+                                       7) << 4))));
+            float packed_f32_1[8];
+#pragma unroll
+            for (int _pair = 0; _pair < 4; _pair++) {
+              asm volatile(
+                  "{\n\t"
+                  "shl.b32 %0, %2, 16;\n\t"
+                  "and.b32 %1, %2, 0xffff0000;\n\t"
+                  "}\n"
+                  : "=f"((&packed_f32_1[_pair * 2])[0]), "=f"((&packed_f32_1[_pair * 2])[1])
+                  : "r"(packed_1[_pair]));
+            }
+#pragma unroll
+            for (int value_idx_5 = 0; value_idx_5 < 8; value_idx_5++) {
+              restore_ki_values[value_idx_5] = packed_f32_1[value_idx_5];
+            }
+#pragma unroll
+            for (int restore_elem = 0; restore_elem < 8; restore_elem++) {
+              int restore_col = restore_segment * 8 + restore_elem;
+              __nv_bfloat16 _cvt_bf16_3 = __float2bfloat16(restore_ki_values[restore_elem]);
+              float _cvt_f32_11 = __bfloat162float(_cvt_bf16_3);
+              float restore_ki_carrier = _cvt_f32_11;
+              float restore_total = smem_restore_factor_all[stage_f32_0 + restore_col];
+              __nv_bfloat16 _cvt_bf16_4 = __float2bfloat16(restore_total);
+              float _cvt_f32_12 = __bfloat162float(_cvt_bf16_4);
+              float restore_total_carrier = _cvt_f32_12;
+              __nv_bfloat16 _cvt_bf16_5 =
+                  __float2bfloat16(restore_ki_carrier * restore_total_carrier);
+              float _cvt_f32_13 = __bfloat162float(_cvt_bf16_5);
+              restore_kr_values[restore_elem] = _cvt_f32_13;
+            }
+            unsigned int packed_0_1[4];
+#pragma unroll
+            for (int _lp = 0; _lp < 4; _lp++) {
+              __nv_bfloat162 _bf2 = __float22bfloat162_rn(
+                  make_float2(restore_kr_values[_lp * 2 + 0], restore_kr_values[_lp * 2 + 1 + 0]));
+              packed_0_1[_lp] = *(uint32_t*)&_bf2;
+            }
+#pragma unroll
+            for (int word_9 = 0; word_9 < 4; word_9++) {
+              asm volatile(
+                  "st.shared.b32 [%0], %1;" ::"r"(
+                      (smem_kr_trans_addr + prep_stage * 21504 +
+                       (unsigned int)(restore_segment * 8 / 64 * 2048 + restore_row * 128 +
+                                          restore_segment * 8 % 64 * 2 ^
+                                      (restore_segment * 8 / 64 * 2048 + restore_row * 128 +
+                                               restore_segment * 8 % 64 * 2 >>
+                                           7 &
+                                       7) << 4)) +
+                      (unsigned int)(word_9 * 4)),
+                  "r"((packed_0_1[word_9])));
+            }
+          }
+        }
+        {
+          mbarrier_wait(aux_inverse_ready_addr + (prep_stage) * 8, _phase_aux_inverse_ready);
+        }
+        asm volatile("fence.proxy.async.shared::cta;" ::: "memory");
+        asm volatile("barrier.sync %0, 128;" ::"r"(10 + prep_instance) : "memory");
+        if (prep_local_warp == 0) {
+          if (elect_sync()) {
+          }
+        }
+        if (chunk_is_full_1 != 0) {
+          if (prep_local_warp == 0) {
+            if (elect_sync()) {
+              mbarrier_arrive_expect_tx(v_full_addr + (prep_stage) * 8, 4096);
+              {
+                int v_token = (int)(bos_4 + (long long)(chunk_idx_3 * 16));
+                tma_4d_gmem2smem(smem_v_addr + prep_stage * 21504, v_tma, 0, head_idx_3, v_token, 0,
+                                 v_full_addr + (prep_stage) * 8);
+                tma_4d_gmem2smem(smem_v_addr + prep_stage * 21504 + 2048, v_tma, 0, head_idx_3,
+                                 v_token, 1, v_full_addr + (prep_stage) * 8);
+              }
+            }
+          }
+        } else {
+#pragma unroll
+          for (int v_load_iter = 0; v_load_iter < 2; v_load_iter++) {
+            int v_item = v_load_iter * 128 + prep_tid;
+            int row_1 = v_item / 16;
+            int segment_1 = v_item % 16;
+            long long token_1 = bos_4 + (long long)(chunk_idx_3 * 16 + row_1);
+            int token_valid_1 = ((token_1 < eos_4) ? 1 : 0);
+            long long v_src = (token_1 * (long long)num_heads + (long long)head_idx_3) * 128 +
+                              (long long)(segment_1 * 8);
+            int v_dst = smem_v_addr + prep_stage * 21504 +
+                        (unsigned int)((row_1 * 128 + segment_1 * 8) * 2);
+            {
+              int v_panel = segment_1 / 8;
+              int v_panel_segment = segment_1 % 8;
+              int v_row_addr = smem_v_addr + prep_stage * 21504 +
+                               (unsigned int)(v_panel * 16 * 64 * 2) +
+                               (unsigned int)(row_1 * 64 * 2);
+              v_dst = (v_row_addr + (v_panel_segment * 8 * 2 ^ (v_row_addr >> 7 & 7) << 4));
+            }
+            asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16, %2;" ::"r"(v_dst),
+                         "l"(v + v_src), "r"((token_valid_1 != 0) ? 16 : 0));
+          }
+          asm volatile("cp.async.commit_group;");
+          asm volatile("cp.async.wait_group 0;");
+          asm volatile("barrier.sync %0, 128;" ::"r"(10 + prep_instance) : "memory");
+          if (prep_local_warp == 0) {
+            if (elect_sync()) {
+              asm volatile("fence.proxy.async.shared::cta;" ::: "memory");
+              mbarrier_arrive(v_full_addr + (prep_stage) * 8);
+            }
+          }
+        }
+        for (int _advance = 0; _advance < 5; _advance++) {
+          prep_stage += 1;
+          if (prep_stage == 5) {
+            prep_stage = 0;
+            _phase_raw_inputs_free ^= 1;
+            _phase_gate_raw_full ^= 1;
+            _phase_smem_free ^= 1;
+            _phase_v_free ^= 1;
+            _phase_qk_raw_full ^= 1;
+            _phase_short_beta_ready ^= 1;
+            _phase_aux_pairwise_consumed ^= 1;
+            _phase_prep_diag_ready ^= 1;
+            _phase_prep_inv16_ready ^= 1;
+            _phase_aux_inverse_ready ^= 1;
+          }
+        }
+      }
+    }
+  }
+
+  // Cleanup
+}
+
+}  // extern "C"
+
+#undef LOOM_INF
+#undef NUM_CHECKPOINT_PIPE_STAGES
+#undef NUM_CHUNK_PIPE_STAGES
+#undef SMEM_SMEM_BETA_RAW_ALL_OFF
+#undef SMEM_SMEM_BETA_RAW_ALL_STAGE_BYTES
+#undef SMEM_SMEM_BETA_RAW_ALL_STRIDE
+#undef SMEM_SMEM_BETA_RAW_OFF
+#undef SMEM_SMEM_BETA_RAW_STAGE_BYTES
+#undef SMEM_SMEM_BETA_RAW_STRIDE
+#undef SMEM_SMEM_CHECKPOINT_OFF
+#undef SMEM_SMEM_CHECKPOINT_STAGE_BYTES
+#undef SMEM_SMEM_CHECKPOINT_STRIDE
+#undef SMEM_SMEM_FINAL_TRANS_OFF
+#undef SMEM_SMEM_FINAL_TRANS_STAGE_BYTES
+#undef SMEM_SMEM_FINAL_TRANS_STRIDE
+#undef SMEM_SMEM_GATE_ALL_OFF
+#undef SMEM_SMEM_GATE_ALL_STAGE_BYTES
+#undef SMEM_SMEM_GATE_ALL_STRIDE
+#undef SMEM_SMEM_GATE_BIAS_ALL_OFF
+#undef SMEM_SMEM_GATE_BIAS_ALL_STAGE_BYTES
+#undef SMEM_SMEM_GATE_BIAS_ALL_STRIDE
+#undef SMEM_SMEM_GATE_OFF
+#undef SMEM_SMEM_GATE_RATE_ALL_OFF
+#undef SMEM_SMEM_GATE_RATE_ALL_STAGE_BYTES
+#undef SMEM_SMEM_GATE_RATE_ALL_STRIDE
+#undef SMEM_SMEM_GATE_STAGE_BYTES
+#undef SMEM_SMEM_GATE_STRIDE
+#undef SMEM_SMEM_GT_ALL_OFF
+#undef SMEM_SMEM_GT_ALL_STAGE_BYTES
+#undef SMEM_SMEM_GT_ALL_STRIDE
+#undef SMEM_SMEM_GT_PREFIX_ALL_OFF
+#undef SMEM_SMEM_GT_PREFIX_ALL_STAGE_BYTES
+#undef SMEM_SMEM_GT_PREFIX_ALL_STRIDE
+#undef SMEM_SMEM_G_RAW_ALL_OFF
+#undef SMEM_SMEM_G_RAW_ALL_STAGE_BYTES
+#undef SMEM_SMEM_G_RAW_ALL_STRIDE
+#undef SMEM_SMEM_G_RAW_OFF
+#undef SMEM_SMEM_G_RAW_STAGE_BYTES
+#undef SMEM_SMEM_G_RAW_STRIDE
+#undef SMEM_SMEM_INV_OFF
+#undef SMEM_SMEM_INV_STAGE_BYTES
+#undef SMEM_SMEM_INV_STRIDE
+#undef SMEM_SMEM_INV_WORK_OFF
+#undef SMEM_SMEM_INV_WORK_STAGE_BYTES
+#undef SMEM_SMEM_INV_WORK_STRIDE
+#undef SMEM_SMEM_KD_OFF
+#undef SMEM_SMEM_KD_STAGE_BYTES
+#undef SMEM_SMEM_KD_STRIDE
+#undef SMEM_SMEM_KI_OFF
+#undef SMEM_SMEM_KI_STAGE_BYTES
+#undef SMEM_SMEM_KI_STRIDE
+#undef SMEM_SMEM_KR_TRANS_OFF
+#undef SMEM_SMEM_KR_TRANS_STAGE_BYTES
+#undef SMEM_SMEM_KR_TRANS_STRIDE
+#undef SMEM_SMEM_MQK_TRANS_OFF
+#undef SMEM_SMEM_MQK_TRANS_STAGE_BYTES
+#undef SMEM_SMEM_MQK_TRANS_STRIDE
+#undef SMEM_SMEM_OUT_OFF
+#undef SMEM_SMEM_OUT_STAGE_BYTES
+#undef SMEM_SMEM_OUT_STRIDE
+#undef SMEM_SMEM_PREP_BETA_ALL_OFF
+#undef SMEM_SMEM_PREP_BETA_ALL_STAGE_BYTES
+#undef SMEM_SMEM_PREP_BETA_ALL_STRIDE
+#undef SMEM_SMEM_PREP_BETA_BF16_ALL_OFF
+#undef SMEM_SMEM_PREP_BETA_BF16_ALL_STAGE_BYTES
+#undef SMEM_SMEM_PREP_BETA_BF16_ALL_STRIDE
+#undef SMEM_SMEM_PREP_BETA_U32_ALL_OFF
+#undef SMEM_SMEM_PREP_BETA_U32_ALL_STAGE_BYTES
+#undef SMEM_SMEM_PREP_BETA_U32_ALL_STRIDE
+#undef SMEM_SMEM_QD_OFF
+#undef SMEM_SMEM_QD_STAGE_BYTES
+#undef SMEM_SMEM_QD_STRIDE
+#undef SMEM_SMEM_Q_RAW_PREFETCH_OFF
+#undef SMEM_SMEM_Q_RAW_PREFETCH_STAGE_BYTES
+#undef SMEM_SMEM_Q_RAW_PREFETCH_STRIDE
+#undef SMEM_SMEM_RESTORE_FACTOR_ALL_OFF
+#undef SMEM_SMEM_RESTORE_FACTOR_ALL_STAGE_BYTES
+#undef SMEM_SMEM_RESTORE_FACTOR_ALL_STRIDE
+#undef SMEM_SMEM_SHORT_N32_V_OFF
+#undef SMEM_SMEM_SHORT_N32_V_STAGE_BYTES
+#undef SMEM_SMEM_SHORT_N32_V_STRIDE
+#undef SMEM_SMEM_STATE_CHECKPOINT_NEEDED_OFF
+#undef SMEM_SMEM_STATE_CHECKPOINT_NEEDED_STAGE_BYTES
+#undef SMEM_SMEM_STATE_CHECKPOINT_NEEDED_STRIDE
+#undef SMEM_SMEM_V_ALL_OFF
+#undef SMEM_SMEM_V_ALL_STAGE_BYTES
+#undef SMEM_SMEM_V_ALL_STRIDE
+#undef SMEM_SMEM_V_OFF
+#undef SMEM_SMEM_V_STAGE_BYTES
+#undef SMEM_SMEM_V_STRIDE
+#undef SMEM_SMEM_WORK_ITEM_COMPUTE_START_OFF
+#undef SMEM_SMEM_WORK_ITEM_COMPUTE_START_STAGE_BYTES
+#undef SMEM_SMEM_WORK_ITEM_COMPUTE_START_STRIDE
+#undef SMEM_SMEM_WORK_ITEM_RESOLVED_OFF
+#undef SMEM_SMEM_WORK_ITEM_RESOLVED_STAGE_BYTES
+#undef SMEM_SMEM_WORK_ITEM_RESOLVED_STRIDE
+#undef SMEM_SMEM_WORK_ITEM_WARP_MAX_OFF
+#undef SMEM_SMEM_WORK_ITEM_WARP_MAX_STAGE_BYTES
+#undef SMEM_SMEM_WORK_ITEM_WARP_MAX_STRIDE
+#undef SMEM_TOTAL
+#undef SPLIT_WORK_ITEMS
+#undef STORE_BACKWARD_TAPE
+#undef STORE_E_TAPE
+#undef TMEM_NCOLS
+#undef TMEM_TMEM_OUT_OFFSET
+#undef TMEM_TMEM_STATE_INP_OFFSET
+#undef TMEM_TMEM_STATE_OFFSET
+#undef TMEM_TMEM_STATE_OUT_OFFSET
+#undef TMEM_TMEM_U2_ACC_OFFSET
+#undef TMEM_TMEM_U2_INP_OFFSET
+#undef TMEM_TMEM_U_ACC_OFFSET
+#undef aux_inverse_ready_addr
+#undef aux_pairwise_consumed_addr
+#undef aux_pairwise_inputs_ready_addr
+#undef checkpoint_free_addr
+#undef checkpoint_ready_addr
+#undef final_ready_addr
+#undef gate_raw_full_addr
+#undef old_out_ready_addr
+#undef out_empty_addr
+#undef prep_diag_ready_addr
+#undef prep_inv16_ready_addr
+#undef qk_full_addr
+#undef qk_raw_full_addr
+#undef raw_inputs_free_addr
+#undef short_beta_ready_addr
+#undef smem_beta_raw_addr
+#undef smem_beta_raw_all_addr
+#undef smem_checkpoint_addr
+#undef smem_final_trans_addr
+#undef smem_free_addr
+#undef smem_g_raw_addr
+#undef smem_g_raw_all_addr
+#undef smem_gate_addr
+#undef smem_gate_all_addr
+#undef smem_gate_bias_all_addr
+#undef smem_gate_rate_all_addr
+#undef smem_gt_all_addr
+#undef smem_gt_prefix_all_addr
+#undef smem_inv_addr
+#undef smem_inv_work_addr
+#undef smem_kd_addr
+#undef smem_ki_addr
+#undef smem_kr_trans_addr
+#undef smem_mqk_trans_addr
+#undef smem_out_addr
+#undef smem_prep_beta_all_addr
+#undef smem_prep_beta_bf16_all_addr
+#undef smem_prep_beta_u32_all_addr
+#undef smem_q_raw_prefetch_addr
+#undef smem_qd_addr
+#undef smem_restore_factor_all_addr
+#undef smem_short_n32_v_addr
+#undef smem_state_checkpoint_needed_addr
+#undef smem_v_addr
+#undef smem_v_all_addr
+#undef smem_work_item_compute_start_addr
+#undef smem_work_item_resolved_addr
+#undef smem_work_item_warp_max_addr
+#undef state_inp_left_ready_addr
+#undef state_inp_ready_addr
+#undef tmem_dealloc_ready_addr
+#undef u2_acc_ready_addr
+#undef u2_inp_ready_addr
+#undef u_inp_ready_addr
+#undef v_free_addr
+#undef v_full_addr
+#undef work_item_ready_addr

--- a/csrc/kda/flashkda_bf16_fused_m128_n16_checkpoint_binding.cu
+++ b/csrc/kda/flashkda_bf16_fused_m128_n16_checkpoint_binding.cu
@@ -1,0 +1,209 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+#include "flashkda_binding_common.cuh"
+
+#define uint8_t flashkda_checkpoint_generated_uint8_t
+#define uint16_t flashkda_checkpoint_generated_uint16_t
+#define uint32_t flashkda_checkpoint_generated_uint32_t
+#define uint64_t flashkda_checkpoint_generated_uint64_t
+#define int32_t flashkda_checkpoint_generated_int32_t
+#define int16_t flashkda_checkpoint_generated_int16_t
+#define LoomTensorMap flashkda_checkpoint_generated_LoomTensorMap
+#define LoomTensorMapPack flashkda_checkpoint_generated_LoomTensorMapPack
+#define CUtensorMap flashkda_checkpoint_generated_CUtensorMap
+#include "flashkda_bf16_fused_m128_n16_checkpoint.cu"
+#undef CUtensorMap
+#undef LoomTensorMapPack
+#undef LoomTensorMap
+#undef uint8_t
+#undef uint16_t
+#undef uint32_t
+#undef uint64_t
+#undef int32_t
+#undef int16_t
+
+namespace flashinfer {
+namespace flash_kda {
+
+constexpr int32_t kCheckpointThreads = 1024;
+constexpr int32_t kCheckpointSmemBytes = 183296;
+
+struct CheckpointMapWords {
+  uint64_t words[sizeof(CUtensorMap) / sizeof(uint64_t)];
+};
+
+static __global__ void PublishCheckpointMap(uint64_t* destination, CheckpointMapWords source) {
+  if (threadIdx.x < sizeof(CUtensorMap) / sizeof(uint64_t)) {
+    destination[threadIdx.x] = source.words[threadIdx.x];
+  }
+}
+
+inline CUtensorMap EncodeCheckpointValueTma(const TensorView& tensor) {
+  TVM_FFI_ICHECK(tensor.ndim() >= 2) << "v must have at least two dimensions";
+  TVM_FFI_ICHECK(tensor.stride(tensor.ndim() - 1) == 1) << "v must have unit innermost stride";
+  const int64_t d1 = tensor.size(tensor.ndim() - 1);
+  const int64_t d2 = tensor.size(tensor.ndim() - 2);
+  TVM_FFI_ICHECK(d1 > 0 && d2 > 0 && d1 % 64 == 0)
+      << "v trailing dimensions cannot encode the checkpoint N16 TMA box";
+  const int64_t outer2 = tensor.numel() / (d1 * d2);
+  uint64_t global_dim[4] = {64, static_cast<uint64_t>(d2), static_cast<uint64_t>(outer2),
+                            static_cast<uint64_t>(d1 / 64)};
+  uint64_t global_strides[3] = {static_cast<uint64_t>(d1 * sizeof(__nv_bfloat16)),
+                                static_cast<uint64_t>(d1 * d2 * sizeof(__nv_bfloat16)),
+                                64 * sizeof(__nv_bfloat16)};
+  uint32_t box_dim[4] = {64, 1, 16, 1};
+  uint32_t elem_strides[4] = {1, 1, 1, 1};
+  CUtensorMap map{};
+  const CUresult result = cuTensorMapEncodeTiled(
+      &map, CU_TENSOR_MAP_DATA_TYPE_BFLOAT16, 4, tensor.data_ptr(), global_dim, global_strides,
+      box_dim, elem_strides, CU_TENSOR_MAP_INTERLEAVE_NONE, CU_TENSOR_MAP_SWIZZLE_128B,
+      CU_TENSOR_MAP_L2_PROMOTION_NONE, CU_TENSOR_MAP_FLOAT_OOB_FILL_NONE);
+  TVM_FFI_ICHECK(result == CUDA_SUCCESS)
+      << "cuTensorMapEncodeTiled failed for checkpoint N16 v with CUresult=" << int(result);
+  return map;
+}
+
+inline CUtensorMap EncodeCheckpointTma(const TensorView& tensor) {
+  const int64_t checkpoints = tensor.size(0);
+  const int64_t heads = tensor.size(1);
+  uint64_t global_dim[4] = {128, 128, static_cast<uint64_t>(heads),
+                            static_cast<uint64_t>(checkpoints)};
+  uint64_t global_strides[3] = {128 * sizeof(__nv_bfloat16), 128 * 128 * sizeof(__nv_bfloat16),
+                                static_cast<uint64_t>(heads) * 128 * 128 * sizeof(__nv_bfloat16)};
+  uint32_t box_dim[4] = {64, 128, 1, 1};
+  uint32_t elem_strides[4] = {1, 1, 1, 1};
+  CUtensorMap map{};
+  const CUresult result = cuTensorMapEncodeTiled(
+      &map, CU_TENSOR_MAP_DATA_TYPE_BFLOAT16, 4, tensor.data_ptr(), global_dim, global_strides,
+      box_dim, elem_strides, CU_TENSOR_MAP_INTERLEAVE_NONE, CU_TENSOR_MAP_SWIZZLE_128B,
+      CU_TENSOR_MAP_L2_PROMOTION_NONE, CU_TENSOR_MAP_FLOAT_OOB_FILL_NONE);
+  TVM_FFI_ICHECK(result == CUDA_SUCCESS)
+      << "cuTensorMapEncodeTiled failed for state checkpoints with CUresult=" << int(result);
+  return map;
+}
+
+void RunM128N16Checkpoint(TensorView q, TensorView k, TensorView v, TensorView g, TensorView beta,
+                          TensorView beta_tma, TensorView A_log, TensorView dt_bias,
+                          TensorView cu_seqlens, TensorView seq_order, TensorView state_indices,
+                          TensorView initial_state, TensorView out, TensorView final_state,
+                          TensorView state_checkpoints, TensorView checkpoint_cu_starts,
+                          TensorView descriptor_storage, int64_t prepare_descriptors,
+                          int64_t num_heads, int64_t beta_token_stride, int64_t state_slot_stride,
+                          int64_t use_state_indices, int64_t use_initial_state,
+                          int64_t store_final_state, int64_t checkpoint_every_n_tokens,
+                          double scale, double lower_bound, int64_t cuda_stream) {
+  TVM_FFI_ICHECK(cuda_stream >= 0) << "cuda_stream must be a non-negative stream handle";
+  TVM_FFI_ICHECK(checkpoint_every_n_tokens > 0 && checkpoint_every_n_tokens % 16 == 0)
+      << "checkpoint_every_n_tokens must be a positive multiple of 16";
+  TVM_FFI_ICHECK(q.device().device_type == kDLCUDA) << "q must be a CUDA tensor";
+  const int32_t device_id = q.device().device_id;
+  ffi::CUDADeviceGuard device_guard(device_id);
+  CheckFlashKDATarget(device_id);
+
+  const int64_t unchecked_num_seqs = cu_seqlens.numel() - 1;
+  const int64_t state_pool_slots = ResolveAndCheckServingStatePool(
+      state_indices, initial_state, final_state, device_id, unchecked_num_seqs, num_heads,
+      state_slot_stride, use_state_indices, use_initial_state, store_final_state);
+  const int64_t num_seqs = CheckCommonInputs(
+      q, k, v, g, beta, beta_tma, A_log, dt_bias, cu_seqlens, seq_order, initial_state, out,
+      final_state, descriptor_storage, prepare_descriptors, num_heads, use_initial_state,
+      store_final_state, scale, lower_bound, true, state_pool_slots);
+  TVM_FFI_ICHECK(descriptor_storage.numel() >= 7 * static_cast<int64_t>(sizeof(CUtensorMap)))
+      << "checkpoint N16 descriptor_storage must provide at least 896 bytes";
+  TVM_FFI_ICHECK(beta_token_stride == beta.stride(beta.ndim() - 2))
+      << "beta_token_stride must match beta's physical token stride";
+  CheckServingCheckpointInputs(state_checkpoints, checkpoint_cu_starts, device_id, num_seqs,
+                               num_heads, checkpoint_every_n_tokens, 16);
+  CheckServingAuxiliaryNoOverlap(state_indices, state_checkpoints, checkpoint_cu_starts, q, k, v, g,
+                                 beta, beta_tma, A_log, dt_bias, cu_seqlens, seq_order,
+                                 initial_state, out, final_state, descriptor_storage,
+                                 use_state_indices, checkpoint_every_n_tokens);
+
+  constexpr int32_t kSmemBytes = kCheckpointSmemBytes;
+  CheckDynamicSmemCapacity(device_id, kSmemBytes);
+  CheckCuda(cudaFuncSetAttribute(kernel_flashkda_bf16_fused_m128,
+                                 cudaFuncAttributeMaxDynamicSharedMemorySize, kSmemBytes),
+            "cudaFuncSetAttribute(checkpoint N16)");
+  const int64_t grid_x_i64 = num_seqs * num_heads;
+  TVM_FFI_ICHECK(grid_x_i64 > 0 && grid_x_i64 <= std::numeric_limits<uint32_t>::max())
+      << "checkpoint N16 FlashKDA grid.x is out of range: " << grid_x_i64;
+  const dim3 grid(static_cast<uint32_t>(grid_x_i64), 1, 1);
+  const dim3 block(kCheckpointThreads, 1, 1);
+  const cudaStream_t stream = reinterpret_cast<cudaStream_t>(static_cast<uintptr_t>(cuda_stream));
+  const TmaPointers tma = EncodeTmaPointers<128, 16>(q, k, v, g, beta_tma, out, descriptor_storage,
+                                                     prepare_descriptors, stream);
+  auto* descriptor_bytes = static_cast<unsigned char*>(descriptor_storage.data_ptr());
+  if (prepare_descriptors != 0) {
+    const CUtensorMap value_map = EncodeCheckpointValueTma(v);
+    CheckpointMapWords value_words{};
+    std::memcpy(value_words.words, &value_map, sizeof(value_map));
+    PublishCheckpointMap<<<1, sizeof(CUtensorMap) / sizeof(uint64_t), 0, stream>>>(
+        reinterpret_cast<uint64_t*>(descriptor_bytes + 2 * sizeof(CUtensorMap)), value_words);
+    CheckCuda(cudaGetLastError(), "PublishCheckpointValueMap launch");
+    const CUtensorMap checkpoint_map = EncodeCheckpointTma(state_checkpoints);
+    CheckpointMapWords words{};
+    std::memcpy(words.words, &checkpoint_map, sizeof(checkpoint_map));
+    PublishCheckpointMap<<<1, sizeof(CUtensorMap) / sizeof(uint64_t), 0, stream>>>(
+        reinterpret_cast<uint64_t*>(descriptor_bytes + 6 * sizeof(CUtensorMap)), words);
+    CheckCuda(cudaGetLastError(), "PublishCheckpointMap launch");
+  }
+  PackBetaForTmaIfNeeded(beta, beta_tma, num_heads, beta_token_stride, stream);
+
+  kernel_flashkda_bf16_fused_m128<<<grid, block, kSmemBytes, stream>>>(
+      reinterpret_cast<__nv_bfloat16*>(q.data_ptr()),
+      reinterpret_cast<flashkda_checkpoint_generated_LoomTensorMap const*>(tma.q),
+      reinterpret_cast<__nv_bfloat16*>(k.data_ptr()),
+      reinterpret_cast<flashkda_checkpoint_generated_LoomTensorMap const*>(tma.k),
+      reinterpret_cast<__nv_bfloat16*>(v.data_ptr()),
+      reinterpret_cast<flashkda_checkpoint_generated_LoomTensorMap const*>(tma.v),
+      reinterpret_cast<__nv_bfloat16*>(g.data_ptr()),
+      reinterpret_cast<flashkda_checkpoint_generated_LoomTensorMap const*>(tma.g),
+      reinterpret_cast<__nv_bfloat16*>(beta.data_ptr()),
+      reinterpret_cast<flashkda_checkpoint_generated_LoomTensorMap const*>(tma.beta),
+      reinterpret_cast<float*>(A_log.data_ptr()), reinterpret_cast<float*>(dt_bias.data_ptr()),
+      reinterpret_cast<long long*>(cu_seqlens.data_ptr()),
+      reinterpret_cast<int*>(seq_order.data_ptr()),
+      reinterpret_cast<__nv_bfloat16*>(initial_state.data_ptr()),
+      reinterpret_cast<__nv_bfloat16*>(out.data_ptr()),
+      reinterpret_cast<flashkda_checkpoint_generated_LoomTensorMap const*>(tma.out),
+      reinterpret_cast<__nv_bfloat16*>(final_state.data_ptr()), static_cast<int32_t>(num_heads),
+      static_cast<int32_t>(use_initial_state), static_cast<int32_t>(store_final_state),
+      static_cast<float>(scale), static_cast<float>(lower_bound),
+      static_cast<unsigned long long>(reinterpret_cast<uintptr_t>(state_indices.data_ptr())),
+      static_cast<unsigned long long>(reinterpret_cast<uintptr_t>(state_checkpoints.data_ptr())),
+      static_cast<unsigned long long>(reinterpret_cast<uintptr_t>(checkpoint_cu_starts.data_ptr())),
+      static_cast<int64_t>(beta_token_stride), static_cast<int64_t>(state_slot_stride),
+      static_cast<int32_t>(use_state_indices), static_cast<int32_t>(checkpoint_every_n_tokens),
+      reinterpret_cast<long long*>(checkpoint_cu_starts.data_ptr()),
+      reinterpret_cast<__nv_bfloat16*>(state_checkpoints.data_ptr()),
+      reinterpret_cast<unsigned int*>(descriptor_storage.data_ptr()),
+      reinterpret_cast<__nv_bfloat16*>(state_checkpoints.data_ptr()),
+      reinterpret_cast<__nv_bfloat16*>(state_checkpoints.data_ptr()),
+      reinterpret_cast<__nv_bfloat16*>(state_checkpoints.data_ptr()),
+      reinterpret_cast<__nv_bfloat16*>(state_checkpoints.data_ptr()),
+      reinterpret_cast<float*>(A_log.data_ptr()),
+      reinterpret_cast<__nv_bfloat16*>(state_checkpoints.data_ptr()),
+      reinterpret_cast<__nv_bfloat16*>(state_checkpoints.data_ptr()),
+      reinterpret_cast<__nv_bfloat16*>(state_checkpoints.data_ptr()),
+      reinterpret_cast<float*>(A_log.data_ptr()),
+      reinterpret_cast<__nv_bfloat16*>(state_checkpoints.data_ptr()),
+      reinterpret_cast<float*>(A_log.data_ptr()), reinterpret_cast<float*>(A_log.data_ptr()),
+      reinterpret_cast<unsigned int*>(descriptor_storage.data_ptr()), 0,
+      static_cast<int32_t>(num_seqs),
+      reinterpret_cast<flashkda_checkpoint_generated_LoomTensorMap const*>(
+          descriptor_bytes + 6 * sizeof(CUtensorMap)));
+  CheckCuda(cudaGetLastError(), "checkpoint N16 FlashKDA launch");
+}
+
+}  // namespace flash_kda
+}  // namespace flashinfer
+
+TVM_FFI_DLL_EXPORT_TYPED_FUNC(run, flashinfer::flash_kda::RunM128N16Checkpoint);

--- a/csrc/kda/flashkda_binding_common.cuh
+++ b/csrc/kda/flashkda_binding_common.cuh
@@ -147,7 +147,8 @@ inline void CheckNoPartialOverlapOrExactAlias(const TensorView& lhs, const char*
 
 #if defined(FLASHINFER_FLASH_KDA_TARGET_MINOR)
 constexpr int kFlashKDATargetMinor = FLASHINFER_FLASH_KDA_TARGET_MINOR;
-static_assert(kFlashKDATargetMinor == 0, "legacy exact FlashKDA target must be SM100a");
+static_assert(kFlashKDATargetMinor == 0 || kFlashKDATargetMinor == 3,
+              "exact FlashKDA target must be SM100a or SM103a");
 #else
 constexpr int kFlashKDATargetFamily = FLASHINFER_FLASH_KDA_TARGET_FAMILY;
 static_assert(kFlashKDATargetFamily == 100, "FlashKDA family target must be SM100f");
@@ -433,11 +434,14 @@ inline int64_t ResolveAndCheckServingStatePool(
 inline void CheckServingCheckpointInputs(const TensorView& state_checkpoints,
                                          const TensorView& checkpoint_cu_starts, int32_t device_id,
                                          int64_t num_seqs, int64_t num_heads,
-                                         int64_t checkpoint_every_n_tokens) {
+                                         int64_t checkpoint_every_n_tokens,
+                                         int64_t checkpoint_token_granularity = 32) {
+  TVM_FFI_ICHECK(checkpoint_token_granularity > 0)
+      << "checkpoint_token_granularity must be positive";
   TVM_FFI_ICHECK(checkpoint_every_n_tokens >= 0 &&
                  checkpoint_every_n_tokens <= std::numeric_limits<int32_t>::max() &&
-                 checkpoint_every_n_tokens % 32 == 0)
-      << "checkpoint_every_n_tokens must be zero or a multiple of 32";
+                 checkpoint_every_n_tokens % checkpoint_token_granularity == 0)
+      << "checkpoint_every_n_tokens must be zero or a multiple of " << checkpoint_token_granularity;
   if (checkpoint_every_n_tokens == 0) {
     return;
   }
@@ -502,10 +506,13 @@ inline void CheckServingAuxiliaryNoOverlap(
 inline void PackBetaForTmaIfNeeded(const TensorView& beta, const TensorView& beta_tma,
                                    int64_t num_heads, int64_t beta_token_stride,
                                    cudaStream_t stream) {
-  // Full chunks TMA-load an eight-head beta box, so any partial final group
-  // needs a materialized row padded to the next eight-head boundary.
+  // Full chunks TMA-load an eight-head, ChunkTokens-row beta box.  A distinct
+  // beta_tma allocation therefore needs materialization even when only its
+  // token extent, rather than its head extent, is padded.
   const int64_t padded_num_heads = beta_tma.size(beta_tma.ndim() - 1);
-  if (padded_num_heads == num_heads) {
+  const TensorByteRange beta_range = GetTensorByteRange(beta, "beta");
+  const TensorByteRange beta_tma_range = GetTensorByteRange(beta_tma, "beta_tma");
+  if (beta_range.begin == beta_tma_range.begin && beta_range.end == beta_tma_range.end) {
     return;
   }
   const int64_t token_count = beta.numel() / num_heads;

--- a/csrc/kda/flashkda_training_aux.cu
+++ b/csrc/kda/flashkda_training_aux.cu
@@ -1,0 +1,689 @@
+typedef signed char int8_t;
+typedef unsigned char uint8_t;
+typedef unsigned short uint16_t;
+typedef unsigned int uint32_t;
+typedef unsigned long long uint64_t;
+typedef signed int int32_t;
+typedef short int int16_t;
+struct __align__(128) LoomTensorMap {
+  uint64_t opaque[16];
+};
+template <int N>
+struct __align__(128) LoomTensorMapPack {
+  LoomTensorMap maps[N];
+};
+
+typedef struct __align__(64) {
+  uint64_t opaque[16];
+} CUtensorMap;
+
+#include <cuda_bf16.h>
+
+__device__ __forceinline__ int make_warp_uniform(int x) {
+  int result;
+  asm volatile("shfl.sync.idx.b32 %0, %1, 0, 0x1F, 0xFFFFFFFF;" : "=r"(result) : "r"(x));
+  return result;
+}
+
+#include <math_constants.h>
+
+__device__ __forceinline__ uint32_t elect_sync() {
+  uint32_t pred = 0;
+  asm volatile(
+      "{\n\t"
+      ".reg .pred %%px;\n\t"
+      "elect.sync _|%%px, %1;\n\t"
+      "@%%px mov.s32 %0, 1;\n\t"
+      "}\n"
+      : "+r"(pred)
+      : "r"(0xFFFFFFFF));
+  return pred;
+}
+
+#define LOOM_INF CUDART_INF_F
+#define NUM_MAIN_STAGES 1
+#define SMEM_WARP_MAXIMA_OFF 0
+#define SMEM_WARP_MAXIMA_STAGE_BYTES 32
+#define SMEM_WARP_MAXIMA_STRIDE 32
+#define SMEM_WARMUP_OFF 32
+#define SMEM_WARMUP_STAGE_BYTES 8
+#define SMEM_WARMUP_STRIDE 8
+#define SMEM_TOTAL 128
+#define THREADS 128
+
+extern "C" {
+
+__global__ __launch_bounds__(128) void kernel_flashkda_refine_forgetting_horizons(
+    __nv_bfloat16* __restrict__ g, float* __restrict__ A_log, float* __restrict__ dt_bias,
+    int* __restrict__ work_items, int* __restrict__ boundaries,
+    unsigned int* __restrict__ persistent_counters, int num_heads, float lower_bound,
+    float log2_threshold) {
+  const int tid = threadIdx.x;
+  const int warp = make_warp_uniform(tid / 32);
+  const int lane = tid % 32;
+
+  extern __shared__ __align__(1024) char smem_raw[];
+  int smem;
+  smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+
+  const int bid = blockIdx.x;
+  const int num_bids = gridDim.x;
+
+  // Kernel setup ops
+  float* warp_maxima = reinterpret_cast<float*>(smem_raw + 0);
+  const int warp_maxima_addr = smem + 0;
+  int* warmup = reinterpret_cast<int*>(smem_raw + 32);
+  const int warmup_addr = smem + 32;
+
+  // === Task calls (dependency order) ===
+  int boundary = blockIdx.x;
+  if (boundary == 0 && tid < num_heads + 2) {
+    persistent_counters[tid] = 0;
+  }
+  int previous_row = boundaries[boundary * 2];
+  int next_row = boundaries[boundary * 2 + 1];
+  int previous_base = previous_row * 8;
+  int next_base = next_row * 8;
+  int head = work_items[previous_base + 1];
+  int cut = work_items[previous_base + 3];
+  int bos = work_items[previous_base + 6];
+  int eos = work_items[previous_base + 7];
+  int num_chunks = (eos - bos) / 16;
+  int channel = tid;
+  float _expf_0 = __expf(A_log[head]);
+  float gate_rate = _expf_0;
+  float gate_bias = dt_bias[head * 128 + channel];
+  float left_sum = 0.0f;
+  float right_sum = 0.0f;
+  if (tid == 0) {
+    warmup[0] = 0;
+    warmup[1] = 0;
+  }
+  __syncthreads();
+#pragma unroll 1
+  for (int depth = 0; depth < 32; depth++) {
+    if (warmup[0] == 0) {
+      int left_chunk = cut - 1 - depth;
+      if (left_chunk >= 0) {
+#pragma unroll
+        for (int sample = 0; sample < 4; sample++) {
+          int left_token = bos + left_chunk * 16 + sample * 4;
+          long long left_index =
+              ((long long)left_token * (long long)num_heads + (long long)head) * 128 +
+              (long long)channel;
+          float _tanh_approx_0;
+          asm volatile("tanh.approx.f32 %0, %1;"
+                       : "=f"(_tanh_approx_0)
+                       : "f"(gate_rate * ((float)g[left_index] + gate_bias) * 0.5f));
+          float left_sigmoid = _tanh_approx_0 * 0.5f + 0.5f;
+          left_sum += lower_bound * 1.4426950408889634f * left_sigmoid;
+        }
+      }
+    }
+    if (warmup[1] == 0) {
+      int right_chunk = cut + depth;
+      if (right_chunk < num_chunks) {
+#pragma unroll
+        for (int sample_1 = 0; sample_1 < 4; sample_1++) {
+          int right_token = bos + right_chunk * 16 + sample_1 * 4;
+          long long right_index =
+              ((long long)right_token * (long long)num_heads + (long long)head) * 128 +
+              (long long)channel;
+          float _tanh_approx_1;
+          asm volatile("tanh.approx.f32 %0, %1;"
+                       : "=f"(_tanh_approx_1)
+                       : "f"(gate_rate * ((float)g[right_index] + gate_bias) * 0.5f));
+          float right_sigmoid = _tanh_approx_1 * 0.5f + 0.5f;
+          right_sum += lower_bound * 1.4426950408889634f * right_sigmoid;
+        }
+      }
+    }
+    float left_max = left_sum;
+    float right_max = right_sum;
+    float _shfl_xor_0 = __shfl_xor_sync(0xFFFFFFFF, left_max, 16);
+    float left_other1 = _shfl_xor_0;
+    float _shfl_xor_1 = __shfl_xor_sync(0xFFFFFFFF, right_max, 16);
+    float right_other1 = _shfl_xor_1;
+    if (left_other1 > left_max) {
+      left_max = left_other1;
+    }
+    if (right_other1 > right_max) {
+      right_max = right_other1;
+    }
+    float _shfl_xor_2 = __shfl_xor_sync(0xFFFFFFFF, left_max, 8);
+    float left_other2 = _shfl_xor_2;
+    float _shfl_xor_3 = __shfl_xor_sync(0xFFFFFFFF, right_max, 8);
+    float right_other2 = _shfl_xor_3;
+    if (left_other2 > left_max) {
+      left_max = left_other2;
+    }
+    if (right_other2 > right_max) {
+      right_max = right_other2;
+    }
+    float _shfl_xor_4 = __shfl_xor_sync(0xFFFFFFFF, left_max, 4);
+    float left_other3 = _shfl_xor_4;
+    float _shfl_xor_5 = __shfl_xor_sync(0xFFFFFFFF, right_max, 4);
+    float right_other3 = _shfl_xor_5;
+    if (left_other3 > left_max) {
+      left_max = left_other3;
+    }
+    if (right_other3 > right_max) {
+      right_max = right_other3;
+    }
+    float _shfl_xor_6 = __shfl_xor_sync(0xFFFFFFFF, left_max, 2);
+    float left_other4 = _shfl_xor_6;
+    float _shfl_xor_7 = __shfl_xor_sync(0xFFFFFFFF, right_max, 2);
+    float right_other4 = _shfl_xor_7;
+    if (left_other4 > left_max) {
+      left_max = left_other4;
+    }
+    if (right_other4 > right_max) {
+      right_max = right_other4;
+    }
+    float _shfl_xor_8 = __shfl_xor_sync(0xFFFFFFFF, left_max, 1);
+    float left_other5 = _shfl_xor_8;
+    float _shfl_xor_9 = __shfl_xor_sync(0xFFFFFFFF, right_max, 1);
+    float right_other5 = _shfl_xor_9;
+    if (left_other5 > left_max) {
+      left_max = left_other5;
+    }
+    if (right_other5 > right_max) {
+      right_max = right_other5;
+    }
+    if (lane == 0) {
+      warp_maxima[warp * 2] = left_max;
+      warp_maxima[warp * 2 + 1] = right_max;
+    }
+    __syncthreads();
+    if (tid == 0) {
+      float cta_left_max = warp_maxima[0];
+      float cta_right_max = warp_maxima[1];
+#pragma unroll
+      for (int reduce_warp = 1; reduce_warp < 4; reduce_warp++) {
+        float warp_left = warp_maxima[reduce_warp * 2];
+        float warp_right = warp_maxima[reduce_warp * 2 + 1];
+        if (warp_left > cta_left_max) {
+          cta_left_max = warp_left;
+        }
+        if (warp_right > cta_right_max) {
+          cta_right_max = warp_right;
+        }
+      }
+      if (warmup[0] == 0 && cta_left_max <= log2_threshold) {
+        warmup[0] = depth + 1;
+      }
+      if (warmup[1] == 0 && cta_right_max <= log2_threshold) {
+        warmup[1] = depth + 1;
+      }
+    }
+    __syncthreads();
+  }
+  if (tid == 0) {
+    int left_warmup = warmup[0];
+    int right_warmup = warmup[1];
+    int cstart = 0;
+    int cend = num_chunks;
+    if (left_warmup != 0) {
+      cstart = cut - left_warmup;
+    }
+    if (right_warmup != 0) {
+      cend = cut + right_warmup;
+    }
+    work_items[next_base + 4] = cstart;
+    work_items[previous_base + 5] = cend;
+  }
+}
+
+}  // extern "C"
+
+#undef LOOM_INF
+#undef NUM_MAIN_STAGES
+#undef SMEM_TOTAL
+#undef SMEM_WARMUP_OFF
+#undef SMEM_WARMUP_STAGE_BYTES
+#undef SMEM_WARMUP_STRIDE
+#undef SMEM_WARP_MAXIMA_OFF
+#undef SMEM_WARP_MAXIMA_STAGE_BYTES
+#undef SMEM_WARP_MAXIMA_STRIDE
+#undef THREADS
+#undef warmup_addr
+#undef warp_maxima_addr
+
+#define LOOM_INF CUDART_INF_F
+#define NUM_MAIN_STAGES 1
+#define SMEM_PARTIAL_A_OFF 0
+#define SMEM_PARTIAL_A_STAGE_BYTES 2048
+#define SMEM_PARTIAL_A_STRIDE 2048
+#define SMEM_PARTIAL_DT_OFF 2048
+#define SMEM_PARTIAL_DT_STAGE_BYTES 2048
+#define SMEM_PARTIAL_DT_STRIDE 2048
+#define SMEM_FINISH_FLAG_OFF 4096
+#define SMEM_FINISH_FLAG_STAGE_BYTES 4
+#define SMEM_FINISH_FLAG_STRIDE 4
+#define SMEM_TOTAL 4224
+#define THREADS 128
+
+extern "C" {
+
+__global__ __launch_bounds__(128) void kernel_flashkda_backward_param_reduce_c16_partial(
+    __nv_bfloat16* __restrict__ g, __nv_bfloat16* __restrict__ beta_active,
+    float* __restrict__ A_log, float* __restrict__ dt_bias, float* __restrict__ dlog_decay,
+    float* __restrict__ dlog_boundary, float* __restrict__ dbeta_active,
+    __nv_bfloat16* __restrict__ dg, __nv_bfloat16* __restrict__ dbeta,
+    float* __restrict__ gate_part_a, float* __restrict__ gate_part_dt,
+    unsigned int* __restrict__ gate_finish_counters, float* __restrict__ dA_log,
+    float* __restrict__ ddt_bias, int total_tokens, int num_heads, int beta_active_stride,
+    int slice_len, float lower_bound) {
+  const int tid = threadIdx.x;
+  const int warp = make_warp_uniform(tid / 32);
+  const int lane = tid % 32;
+
+  extern __shared__ __align__(1024) char smem_raw[];
+  int smem;
+  smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+
+  const int bid = blockIdx.x;
+  const int num_bids = gridDim.x;
+
+  // Kernel setup ops
+  float* partial_a = reinterpret_cast<float*>(smem_raw + 0);
+  const int partial_a_addr = smem + 0;
+  float* partial_dt = reinterpret_cast<float*>(smem_raw + 2048);
+  const int partial_dt_addr = smem + 2048;
+  int* finish_flag = reinterpret_cast<int*>(smem_raw + 4096);
+  const int finish_flag_addr = smem + 4096;
+
+  // === Task calls (dependency order) ===
+  int stripe = blockIdx.x;
+  int head = blockIdx.y;
+  int warp_0 = warp;
+  int dim0 = lane * 4;
+  float _expf_0 = __expf(A_log[head]);
+  float gate_rate = _expf_0;
+  float bias[4];
+  float acc_a[4];
+  float acc_dt[4];
+#pragma unroll
+  for (int q0 = 0; q0 < 4; q0++) {
+    bias[q0] = dt_bias[head * 128 + dim0 + q0];
+    acc_a[q0] = 0.0f;
+    acc_dt[q0] = 0.0f;
+  }
+  int token_begin = stripe * slice_len;
+  int token_end = token_begin + slice_len;
+  if (token_end > total_tokens) {
+    token_end = total_tokens;
+  }
+#pragma unroll 1
+  for (int token = token_begin + warp_0; token < token_end; token += 4) {
+    long long gate_index =
+        ((long long)token * (long long)num_heads + (long long)head) * 128 + (long long)dim0;
+    float dgate_frag[4];
+    float gate_frag[4];
+    float dg_frag[4];
+    {
+      float4 _v4 = *reinterpret_cast<const float4*>(dlog_decay + gate_index);
+      dgate_frag[0 + 0] = _v4.x;
+      dgate_frag[0 + 1] = _v4.y;
+      dgate_frag[0 + 2] = _v4.z;
+      dgate_frag[0 + 3] = _v4.w;
+    }
+    if (token % 16 == 0) {
+      long long boundary_index =
+          ((long long)token / 16 * (long long)num_heads + (long long)head) * 128 + (long long)dim0;
+      {
+        float4 _v4 = *reinterpret_cast<const float4*>(dlog_boundary + boundary_index);
+        dgate_frag[0 + 0] = _v4.x;
+        dgate_frag[0 + 1] = _v4.y;
+        dgate_frag[0 + 2] = _v4.z;
+        dgate_frag[0 + 3] = _v4.w;
+      }
+      {
+        float4 _v4 =
+            make_float4(dgate_frag[0 + 0], dgate_frag[0 + 1], dgate_frag[0 + 2], dgate_frag[0 + 3]);
+        *reinterpret_cast<float4*>(dlog_decay + gate_index) = _v4;
+      }
+    }
+    {
+      uint2 _vld_2;
+      _vld_2 = *reinterpret_cast<const uint2*>(g + gate_index);
+      uint32_t* _vpairs_2 = reinterpret_cast<uint32_t*>(&_vld_2);
+#pragma unroll
+      for (int _pair = 0; _pair < 2; _pair++) {
+        asm volatile(
+            "{\n\t"
+            "shl.b32 %0, %2, 16;\n\t"
+            "and.b32 %1, %2, 0xffff0000;\n\t"
+            "}\n"
+            : "=f"((&gate_frag[0 + _pair * 2])[0]), "=f"((&gate_frag[0 + _pair * 2])[1])
+            : "r"(_vpairs_2[_pair]));
+      }
+    }
+#pragma unroll
+    for (int q1 = 0; q1 < 4; q1++) {
+      float biased = gate_frag[q1] + bias[q1];
+      float z = gate_rate * biased;
+      float _tanh_approx_0;
+      asm volatile("tanh.approx.f32 %0, %1;" : "=f"(_tanh_approx_0) : "f"(z * 0.5f));
+      float gate_sigmoid = _tanh_approx_0 * 0.5f + 0.5f;
+      float sigmoid_prime = gate_sigmoid * (1.0f - gate_sigmoid);
+      float weighted = dgate_frag[q1] * lower_bound * sigmoid_prime;
+      float raw = weighted * gate_rate;
+      float _fma_0 = __fmaf_rn(weighted, z, acc_a[q1]);
+      acc_a[q1] = _fma_0;
+      __nv_bfloat16 _cvt_bf16_0 = __float2bfloat16(raw);
+      float _cvt_f32_0 = __bfloat162float(_cvt_bf16_0);
+      acc_dt[q1] = acc_dt[q1] + _cvt_f32_0;
+      dg_frag[q1] = raw;
+    }
+    {
+      __nv_bfloat162 _pk = __floats2bfloat162_rn(dg_frag[0 + 0], dg_frag[0 + 1]);
+      *reinterpret_cast<__nv_bfloat162*>(&((__nv_bfloat16*)(dg))[gate_index]) = _pk;
+    }
+    {
+      __nv_bfloat162 _pk = __floats2bfloat162_rn(dg_frag[2 + 0], dg_frag[2 + 1]);
+      *reinterpret_cast<__nv_bfloat162*>(&((__nv_bfloat16*)(dg))[gate_index + 2]) = _pk;
+    }
+  }
+#pragma unroll
+  for (int q2 = 0; q2 < 4; q2++) {
+    partial_a[warp_0 * 128 + dim0 + q2] = acc_a[q2];
+    partial_dt[warp_0 * 128 + dim0 + q2] = acc_dt[q2];
+  }
+  __syncthreads();
+  if (warp_0 == 0) {
+#pragma unroll
+    for (int q3 = 0; q3 < 4; q3++) {
+      int dim = dim0 + q3;
+      int base = (stripe * num_heads + head) * 128 + dim;
+      gate_part_a[base] =
+          partial_a[dim] + partial_a[128 + dim] + partial_a[256 + dim] + partial_a[384 + dim];
+      gate_part_dt[base] =
+          partial_dt[dim] + partial_dt[128 + dim] + partial_dt[256 + dim] + partial_dt[384 + dim];
+    }
+  }
+#pragma unroll 1
+  for (int beta_token = token_begin + tid; beta_token < token_end; beta_token += 128) {
+    long long beta_index = (long long)beta_token * (long long)num_heads + (long long)head;
+    long long beta_active_index =
+        (long long)beta_token * (long long)beta_active_stride + (long long)head;
+    float beta_value = (float)beta_active[beta_active_index];
+    __nv_bfloat16 _cvt_bf16_1 =
+        __float2bfloat16(dbeta_active[beta_index] * beta_value * (1.0f - beta_value));
+    dbeta[beta_index] = _cvt_bf16_1;
+  }
+  __threadfence();
+  __syncthreads();
+  if (tid == 0) {
+    unsigned int _atomic_old_0 = atomicAdd(&gate_finish_counters[head], 1);
+    unsigned int old_count = _atomic_old_0;
+    finish_flag[0] = ((old_count + 1 == 128) ? 1 : 0);
+  }
+  __syncthreads();
+  if (finish_flag[0] != 0) {
+    __threadfence();
+    int dim_1 = tid;
+    float a8[8];
+    float dt8[8];
+#pragma unroll
+    for (int j0 = 0; j0 < 8; j0++) {
+      a8[j0] = 0.0f;
+      dt8[j0] = 0.0f;
+    }
+#pragma unroll 1
+    for (int chain = 0; chain < 16; chain++) {
+#pragma unroll
+      for (int j1 = 0; j1 < 8; j1++) {
+        int part_index = ((chain * 8 + j1) * num_heads + head) * 128 + dim_1;
+        a8[j1] = a8[j1] + gate_part_a[part_index];
+        dt8[j1] = dt8[j1] + gate_part_dt[part_index];
+      }
+    }
+    float p0a = a8[0] + a8[1];
+    float p1a = a8[2] + a8[3];
+    float p2a = a8[4] + a8[5];
+    float p3a = a8[6] + a8[7];
+    float p0dt = dt8[0] + dt8[1];
+    float p1dt = dt8[2] + dt8[3];
+    float p2dt = dt8[4] + dt8[5];
+    float p3dt = dt8[6] + dt8[7];
+    float col_a = p0a + p1a + (p2a + p3a);
+    float col_dt = p0dt + p1dt + (p2dt + p3dt);
+    __nv_bfloat16 _cvt_bf16_2 = __float2bfloat16(col_dt);
+    float _cvt_f32_1 = __bfloat162float(_cvt_bf16_2);
+    ddt_bias[head * 128 + dim_1] = _cvt_f32_1;
+    float _warp_reduce_0 = col_a;
+#pragma unroll
+    for (int offset = 16; offset > 0; offset >>= 1)
+      _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
+    col_a = _warp_reduce_0;
+    if (lane == 0) {
+      partial_a[warp] = col_a;
+    }
+    __syncthreads();
+    if (warp == 0) {
+      if (elect_sync()) {
+        dA_log[head] = partial_a[0] + partial_a[1] + partial_a[2] + partial_a[3];
+      }
+    }
+  }
+}
+
+}  // extern "C"
+
+#undef LOOM_INF
+#undef NUM_MAIN_STAGES
+#undef SMEM_FINISH_FLAG_OFF
+#undef SMEM_FINISH_FLAG_STAGE_BYTES
+#undef SMEM_FINISH_FLAG_STRIDE
+#undef SMEM_PARTIAL_A_OFF
+#undef SMEM_PARTIAL_A_STAGE_BYTES
+#undef SMEM_PARTIAL_A_STRIDE
+#undef SMEM_PARTIAL_DT_OFF
+#undef SMEM_PARTIAL_DT_STAGE_BYTES
+#undef SMEM_PARTIAL_DT_STRIDE
+#undef SMEM_TOTAL
+#undef THREADS
+#undef finish_flag_addr
+#undef partial_a_addr
+#undef partial_dt_addr
+
+#define LOOM_INF CUDART_INF_F
+#define NUM_MAIN_STAGES 1
+#define THREADS 128
+
+extern "C" {
+
+__global__ __launch_bounds__(128) void kernel_flashkda_grouped_qk_expand(
+    __nv_bfloat16* __restrict__ q, __nv_bfloat16* __restrict__ k,
+    __nv_bfloat16* __restrict__ q_value_heads, __nv_bfloat16* __restrict__ k_value_heads,
+    int total_tokens, int num_qk_heads, int num_v_heads) {
+  const int tid = threadIdx.x;
+  const int warp = make_warp_uniform(tid / 32);
+  const int lane = tid % 32;
+
+  const int bid = blockIdx.x;
+  const int num_bids = gridDim.x;
+
+  // === Task calls (dependency order) ===
+  int token_begin = blockIdx.x * 32;
+  int value_head = blockIdx.y;
+  int channel = tid;
+  int group_size = num_v_heads / num_qk_heads;
+  int qk_head = value_head / group_size;
+#pragma unroll
+  for (int token_local = 0; token_local < 32; token_local++) {
+    int token = token_begin + token_local;
+    if (token < total_tokens) {
+      long long source_index =
+          ((long long)token * (long long)num_qk_heads + (long long)qk_head) * 128 +
+          (long long)channel;
+      long long output_index =
+          ((long long)token * (long long)num_v_heads + (long long)value_head) * 128 +
+          (long long)channel;
+      q_value_heads[output_index] = q[source_index];
+      k_value_heads[output_index] = k[source_index];
+    }
+  }
+}
+
+}  // extern "C"
+
+#undef LOOM_INF
+#undef NUM_MAIN_STAGES
+#undef THREADS
+
+#define LOOM_INF CUDART_INF_F
+#define NUM_MAIN_STAGES 1
+#define THREADS 128
+
+extern "C" {
+
+__global__ __launch_bounds__(128) void kernel_flashkda_grouped_qk_reduce(
+    __nv_bfloat16* __restrict__ dq_value_heads, __nv_bfloat16* __restrict__ dk_value_heads,
+    __nv_bfloat16* __restrict__ dq, __nv_bfloat16* __restrict__ dk, int total_tokens,
+    int num_qk_heads, int num_v_heads) {
+  const int tid = threadIdx.x;
+  const int warp = make_warp_uniform(tid / 32);
+  const int lane = tid % 32;
+
+  const int bid = blockIdx.x;
+  const int num_bids = gridDim.x;
+
+  // === Task calls (dependency order) ===
+  int token_local = tid / 8;
+  int channel_base = tid % 8 * 16;
+  int token = blockIdx.x * 16 + token_local;
+  int qk_head = blockIdx.y;
+  int group_size = num_v_heads / num_qk_heads;
+  int value_head_begin = qk_head * group_size;
+  if (token < total_tokens) {
+    float dq_sum[16];
+    float dk_sum[16];
+    dq_sum[0] = 0.0f;
+    dq_sum[1] = 0.0f;
+    dq_sum[2] = 0.0f;
+    dq_sum[3] = 0.0f;
+    dq_sum[4] = 0.0f;
+    dq_sum[5] = 0.0f;
+    dq_sum[6] = 0.0f;
+    dq_sum[7] = 0.0f;
+    dq_sum[8] = 0.0f;
+    dq_sum[9] = 0.0f;
+    dq_sum[10] = 0.0f;
+    dq_sum[11] = 0.0f;
+    dq_sum[12] = 0.0f;
+    dq_sum[13] = 0.0f;
+    dq_sum[14] = 0.0f;
+    dq_sum[15] = 0.0f;
+    dk_sum[0] = 0.0f;
+    dk_sum[1] = 0.0f;
+    dk_sum[2] = 0.0f;
+    dk_sum[3] = 0.0f;
+    dk_sum[4] = 0.0f;
+    dk_sum[5] = 0.0f;
+    dk_sum[6] = 0.0f;
+    dk_sum[7] = 0.0f;
+    dk_sum[8] = 0.0f;
+    dk_sum[9] = 0.0f;
+    dk_sum[10] = 0.0f;
+    dk_sum[11] = 0.0f;
+    dk_sum[12] = 0.0f;
+    dk_sum[13] = 0.0f;
+    dk_sum[14] = 0.0f;
+    dk_sum[15] = 0.0f;
+#pragma unroll 1
+    for (int group_head = 0; group_head < group_size; group_head++) {
+      int value_head = value_head_begin + group_head;
+      long long source_index =
+          ((long long)token * (long long)num_v_heads + (long long)value_head) * 128 +
+          (long long)channel_base;
+      float _vec_load_0[16];
+      {
+        const uint4* _vptr_0 = reinterpret_cast<const uint4*>(dq_value_heads + source_index);
+        uint4 _vld_0[2];
+#pragma unroll
+        for (int _blk = 0; _blk < 2; _blk++) {
+          _vld_0[_blk] = _vptr_0[_blk];
+          uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
+#pragma unroll
+          for (int _pair = 0; _pair < 4; _pair++) {
+            asm volatile(
+                "{\n\t"
+                "shl.b32 %0, %2, 16;\n\t"
+                "and.b32 %1, %2, 0xffff0000;\n\t"
+                "}\n"
+                : "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[0]),
+                  "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[1])
+                : "r"(_vpairs_0[_pair]));
+          }
+        }
+      }
+      float _vec_load_1[16];
+      {
+        const uint4* _vptr_1 = reinterpret_cast<const uint4*>(dk_value_heads + source_index);
+        uint4 _vld_1[2];
+#pragma unroll
+        for (int _blk = 0; _blk < 2; _blk++) {
+          _vld_1[_blk] = _vptr_1[_blk];
+          uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
+#pragma unroll
+          for (int _pair = 0; _pair < 4; _pair++) {
+            asm volatile(
+                "{\n\t"
+                "shl.b32 %0, %2, 16;\n\t"
+                "and.b32 %1, %2, 0xffff0000;\n\t"
+                "}\n"
+                : "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[0]),
+                  "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[1])
+                : "r"(_vpairs_1[_pair]));
+          }
+        }
+      }
+#pragma unroll
+      for (int channel_local = 0; channel_local < 16; channel_local++) {
+        dq_sum[channel_local] = dq_sum[channel_local] + _vec_load_0[channel_local];
+        dk_sum[channel_local] = dk_sum[channel_local] + _vec_load_1[channel_local];
+      }
+    }
+    long long output_index =
+        ((long long)token * (long long)num_qk_heads + (long long)qk_head) * 128 +
+        (long long)channel_base;
+    {
+      __nv_bfloat162 _pk[8];
+      _pk[0] = __floats2bfloat162_rn(dq_sum[0 + 0], dq_sum[0 + 1]);
+      _pk[1] = __floats2bfloat162_rn(dq_sum[0 + 2], dq_sum[0 + 3]);
+      _pk[2] = __floats2bfloat162_rn(dq_sum[0 + 4], dq_sum[0 + 5]);
+      _pk[3] = __floats2bfloat162_rn(dq_sum[0 + 6], dq_sum[0 + 7]);
+      _pk[4] = __floats2bfloat162_rn(dq_sum[0 + 8], dq_sum[0 + 9]);
+      _pk[5] = __floats2bfloat162_rn(dq_sum[0 + 10], dq_sum[0 + 11]);
+      _pk[6] = __floats2bfloat162_rn(dq_sum[0 + 12], dq_sum[0 + 13]);
+      _pk[7] = __floats2bfloat162_rn(dq_sum[0 + 14], dq_sum[0 + 15]);
+      *reinterpret_cast<uint4*>(&((__nv_bfloat16*)(dq))[output_index + 0]) =
+          *reinterpret_cast<uint4*>(&_pk[0]);
+      *reinterpret_cast<uint4*>(&((__nv_bfloat16*)(dq))[output_index + 8]) =
+          *reinterpret_cast<uint4*>(&_pk[4]);
+    }
+    {
+      __nv_bfloat162 _pk[8];
+      _pk[0] = __floats2bfloat162_rn(dk_sum[0 + 0], dk_sum[0 + 1]);
+      _pk[1] = __floats2bfloat162_rn(dk_sum[0 + 2], dk_sum[0 + 3]);
+      _pk[2] = __floats2bfloat162_rn(dk_sum[0 + 4], dk_sum[0 + 5]);
+      _pk[3] = __floats2bfloat162_rn(dk_sum[0 + 6], dk_sum[0 + 7]);
+      _pk[4] = __floats2bfloat162_rn(dk_sum[0 + 8], dk_sum[0 + 9]);
+      _pk[5] = __floats2bfloat162_rn(dk_sum[0 + 10], dk_sum[0 + 11]);
+      _pk[6] = __floats2bfloat162_rn(dk_sum[0 + 12], dk_sum[0 + 13]);
+      _pk[7] = __floats2bfloat162_rn(dk_sum[0 + 14], dk_sum[0 + 15]);
+      *reinterpret_cast<uint4*>(&((__nv_bfloat16*)(dk))[output_index + 0]) =
+          *reinterpret_cast<uint4*>(&_pk[0]);
+      *reinterpret_cast<uint4*>(&((__nv_bfloat16*)(dk))[output_index + 8]) =
+          *reinterpret_cast<uint4*>(&_pk[4]);
+    }
+  }
+}
+
+}  // extern "C"
+
+#undef LOOM_INF
+#undef NUM_MAIN_STAGES
+#undef THREADS

--- a/csrc/kda/flashkda_training_c16.cu
+++ b/csrc/kda/flashkda_training_c16.cu
@@ -1,0 +1,7859 @@
+typedef signed char int8_t;
+typedef unsigned char uint8_t;
+typedef unsigned short uint16_t;
+typedef unsigned int uint32_t;
+typedef unsigned long long uint64_t;
+typedef signed int int32_t;
+typedef short int int16_t;
+struct __align__(128) LoomTensorMap {
+  uint64_t opaque[16];
+};
+
+typedef struct __align__(64) {
+  uint64_t opaque[16];
+} CUtensorMap;
+
+#include <cuda_bf16.h>
+
+__device__ __forceinline__ unsigned int __as_u32(float v) {
+  unsigned int u;
+  asm("mov.b32 %0, %1;" : "=r"(u) : "f"(v));
+  return u;
+}
+__device__ __forceinline__ unsigned int __as_u32(__nv_bfloat162 v) {
+  return *reinterpret_cast<const unsigned int*>(&v);
+}
+__device__ __forceinline__ unsigned int __as_u32(unsigned int v) { return v; }
+__device__ __forceinline__ unsigned int __as_u32(int v) {
+  unsigned int u;
+  asm("mov.b32 %0, %1;" : "=r"(u) : "r"(v));
+  return u;
+}
+
+__device__ __forceinline__ __nv_bfloat162 __as_bf16x2(unsigned int v) {
+  __nv_bfloat162_raw raw;
+  raw.x = static_cast<unsigned short>(v);
+  raw.y = static_cast<unsigned short>(v >> 16);
+  return __nv_bfloat162(raw);
+}
+
+#include <math_constants.h>
+
+__device__ __forceinline__ uint32_t elect_sync() {
+  uint32_t pred = 0;
+  asm volatile(
+      "{\n\t"
+      ".reg .pred %%px;\n\t"
+      "elect.sync _|%%px, %1;\n\t"
+      "@%%px mov.s32 %0, 1;\n\t"
+      "}\n"
+      : "+r"(pred)
+      : "r"(0xFFFFFFFF));
+  return pred;
+}
+
+__device__ __forceinline__ void mbarrier_init(int mbar_addr, int count) {
+  asm volatile("mbarrier.init.shared::cta.b64 [%0], %1;" ::"r"(mbar_addr), "r"(count));
+}
+
+__device__ __forceinline__ uint32_t mbarrier_try_wait(int mbar_addr, int phase) {
+  uint32_t token;
+  asm volatile(
+      "{\n\t"
+      ".reg .pred P1;\n\t"
+      "mbarrier.try_wait.parity.acquire.cta.shared::cta.b64"
+      " P1, [%1], %2;\n\t"
+      "selp.u32 %0, 1, 0, P1;\n\t"
+      "}\n"
+      : "=r"(token)
+      : "r"(mbar_addr), "r"(phase)
+      : "memory");
+  return token;
+}
+
+__device__ __forceinline__ uint32_t mbarrier_try_wait_cluster(int mbar_addr, int phase) {
+  uint32_t token;
+  asm volatile(
+      "{\n\t"
+      ".reg .pred P1;\n\t"
+      "mbarrier.try_wait.parity.acquire.cluster.shared::cta.b64"
+      " P1, [%1], %2;\n\t"
+      "selp.u32 %0, 1, 0, P1;\n\t"
+      "}\n"
+      : "=r"(token)
+      : "r"(mbar_addr), "r"(phase)
+      : "memory");
+  return token;
+}
+
+__device__ __forceinline__ void mbarrier_wait(int mbar_addr, int phase) {
+  uint32_t ticks = 0x989680;
+  asm volatile(
+      "{\n\t"
+      ".reg .pred P1;\n\t"
+      "LAB_WAIT:\n\t"
+      "mbarrier.try_wait.parity.acquire.cta.shared::cta.b64"
+      " P1, [%0], %1, %2;\n\t"
+      "@P1 bra.uni DONE;\n\t"
+      "bra.uni LAB_WAIT;\n\t"
+      "DONE:\n\t"
+      "}\n" ::"r"(mbar_addr),
+      "r"(phase), "r"(ticks)
+      : "memory");
+}
+
+__device__ __forceinline__ void mbarrier_wait_cluster(int mbar_addr, int phase) {
+  uint32_t ticks = 0x989680;
+  asm volatile(
+      "{\n\t"
+      ".reg .pred P1;\n\t"
+      "LAB_WAIT_CLUSTER:\n\t"
+      "mbarrier.try_wait.parity.acquire.cluster.shared::cta.b64"
+      " P1, [%0], %1, %2;\n\t"
+      "@P1 bra.uni DONE_CLUSTER;\n\t"
+      "bra.uni LAB_WAIT_CLUSTER;\n\t"
+      "DONE_CLUSTER:\n\t"
+      "}\n" ::"r"(mbar_addr),
+      "r"(phase), "r"(ticks)
+      : "memory");
+}
+
+__device__ __forceinline__ void mbarrier_wait_token(int mbar_addr, int phase, uint32_t token) {
+  if (token == 0) {
+    mbarrier_wait(mbar_addr, phase);
+  }
+}
+
+__device__ __forceinline__ void mbarrier_wait_token_cluster(int mbar_addr, int phase,
+                                                            uint32_t token) {
+  if (token == 0) {
+    mbarrier_wait_cluster(mbar_addr, phase);
+  }
+}
+
+__device__ __forceinline__ void tcgen05_mma_f16(int taddr, uint64_t a_desc, uint64_t b_desc,
+                                                uint32_t i_desc, int enable_input_d) {
+  asm volatile(
+      "{\n\t"
+      ".reg .pred p;\n\t"
+      "setp.ne.b32 p, %4, 0;\n\t"
+      "tcgen05.mma.cta_group::1.kind::f16 [%0], %1, %2, %3, p;\n\t"
+      "}\n" ::"r"(taddr),
+      "l"(a_desc), "l"(b_desc), "r"(i_desc), "r"(enable_input_d));
+}
+
+__device__ __forceinline__ uint64_t desc_encode(uint64_t x) { return (x & 0x3FFFFULL) >> 4ULL; }
+
+__device__ __forceinline__ void mma_ts_step(int taddr_out, int taddr_a, int b_lo, uint32_t b_dhi,
+                                            uint32_t i_desc, int enable_d) {
+  asm volatile(
+      "{\n\t"
+      ".reg .pred leader, p;\n\t"
+      ".reg .b32 dhi;\n\t"
+      ".reg .b64 db;\n\t"
+      "elect.sync _|leader, 0xFFFFFFFF;\n\t"
+      "setp.ne.b32 p, %5, 0;\n\t"
+      "mov.b32 dhi, %3;\n\t"
+      "mov.b64 db, {%2, dhi};\n\t"
+      "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [%1], db, %4, p;\n\t"
+      "}\n" ::"r"(taddr_out),
+      "r"(taddr_a), "r"(b_lo), "r"(b_dhi), "r"(i_desc), "r"(enable_d));
+}
+
+__device__ __forceinline__ void elect_commit(int mbar_addr) {
+  asm volatile(
+      "{\n\t"
+      ".reg .pred leader;\n\t"
+      "elect.sync _|leader, 0xFFFFFFFF;\n\t"
+      "@leader tcgen05.commit.cta_group::1.mbarrier::arrive::one"
+      ".shared::cluster.b64 [%0];\n\t"
+      "}\n" ::"r"(mbar_addr));
+}
+
+__device__ __forceinline__ void mbarrier_arrive(int mbar_addr) {
+  asm volatile("mbarrier.arrive.release.cta.shared::cta.b64 _, [%0];" ::"r"(mbar_addr) : "memory");
+}
+
+__device__ __forceinline__ void mbarrier_arrive_expect_tx(int mbar_addr, uint32_t bytes) {
+  asm volatile(
+      "mbarrier.arrive.expect_tx.release.cta.shared::cta.b64 _, [%0], %1;" ::"r"(mbar_addr),
+      "r"(bytes)
+      : "memory");
+}
+
+__device__ __forceinline__ void tmem_ld_x32(float* dst, int tmem_addr) {
+  asm volatile(
+      "tcgen05.ld.sync.aligned.32x32b.x32.b32"
+      " {%0, %1, %2, %3, %4, %5, %6, %7,"
+      "  %8, %9, %10, %11, %12, %13, %14, %15,"
+      "  %16, %17, %18, %19, %20, %21, %22, %23,"
+      "  %24, %25, %26, %27, %28, %29, %30, %31}, [%32];"
+      : "=f"(dst[0]), "=f"(dst[1]), "=f"(dst[2]), "=f"(dst[3]), "=f"(dst[4]), "=f"(dst[5]),
+        "=f"(dst[6]), "=f"(dst[7]), "=f"(dst[8]), "=f"(dst[9]), "=f"(dst[10]), "=f"(dst[11]),
+        "=f"(dst[12]), "=f"(dst[13]), "=f"(dst[14]), "=f"(dst[15]), "=f"(dst[16]), "=f"(dst[17]),
+        "=f"(dst[18]), "=f"(dst[19]), "=f"(dst[20]), "=f"(dst[21]), "=f"(dst[22]), "=f"(dst[23]),
+        "=f"(dst[24]), "=f"(dst[25]), "=f"(dst[26]), "=f"(dst[27]), "=f"(dst[28]), "=f"(dst[29]),
+        "=f"(dst[30]), "=f"(dst[31])
+      : "r"(tmem_addr));
+}
+
+__device__ __forceinline__ void tmem_ld_x16(float* dst, int tmem_addr) {
+  asm volatile(
+      "tcgen05.ld.sync.aligned.32x32b.x16.b32"
+      " {%0, %1, %2, %3, %4, %5, %6, %7,"
+      "  %8, %9, %10, %11, %12, %13, %14, %15}, [%16];"
+      : "=f"(dst[0]), "=f"(dst[1]), "=f"(dst[2]), "=f"(dst[3]), "=f"(dst[4]), "=f"(dst[5]),
+        "=f"(dst[6]), "=f"(dst[7]), "=f"(dst[8]), "=f"(dst[9]), "=f"(dst[10]), "=f"(dst[11]),
+        "=f"(dst[12]), "=f"(dst[13]), "=f"(dst[14]), "=f"(dst[15])
+      : "r"(tmem_addr));
+}
+
+__device__ __forceinline__ void tmem_st_x32_f32(int tmem_addr, const float* src) {
+  asm volatile(
+      "tcgen05.st.sync.aligned.32x32b.x32.b32"
+      " [%0], {%1, %2, %3, %4, %5, %6, %7, %8,"
+      "  %9, %10, %11, %12, %13, %14, %15, %16,"
+      "  %17, %18, %19, %20, %21, %22, %23, %24,"
+      "  %25, %26, %27, %28, %29, %30, %31, %32};" ::"r"(tmem_addr),
+      "f"(src[0]), "f"(src[1]), "f"(src[2]), "f"(src[3]), "f"(src[4]), "f"(src[5]), "f"(src[6]),
+      "f"(src[7]), "f"(src[8]), "f"(src[9]), "f"(src[10]), "f"(src[11]), "f"(src[12]), "f"(src[13]),
+      "f"(src[14]), "f"(src[15]), "f"(src[16]), "f"(src[17]), "f"(src[18]), "f"(src[19]),
+      "f"(src[20]), "f"(src[21]), "f"(src[22]), "f"(src[23]), "f"(src[24]), "f"(src[25]),
+      "f"(src[26]), "f"(src[27]), "f"(src[28]), "f"(src[29]), "f"(src[30]), "f"(src[31]));
+}
+
+__device__ __forceinline__ float approx_exp2(float x) {
+  float y;
+  asm("ex2.approx.ftz.f32 %0, %1;" : "=f"(y) : "f"(x));
+  return y;
+}
+
+__device__ __forceinline__ float approx_rcp(float x) {
+  float y;
+  asm("rcp.approx.ftz.f32 %0, %1;" : "=f"(y) : "f"(x));
+  return y;
+}
+
+__device__ __forceinline__ float max_noftz(float a, float b) {
+  float c;
+  asm("max.f32 %0, %1, %2;" : "=f"(c) : "f"(a), "f"(b));
+  return c;
+}
+
+__device__ __forceinline__ void fma_f32x2_inplace(float2* a, float2 b, float2 c) {
+  unsigned long long r;
+  asm("fma.rn.ftz.f32x2 %0, %1, %2, %3;"
+      : "=l"(r)
+      : "l"(*(unsigned long long*)a), "l"(*(unsigned long long*)&b), "l"(*(unsigned long long*)&c));
+  *(unsigned long long*)a = r;
+}
+
+__device__ __forceinline__ void mul_f32x2_inplace(float2* a, float2 b) {
+  asm("mul.rn.ftz.f32x2 %0, %0, %1;"
+      : "+l"(*(unsigned long long*)a)
+      : "l"(*(unsigned long long*)&b));
+}
+
+__device__ __forceinline__ void add_f32x2_inplace(float2* a, float2 b) {
+  asm("add.rn.ftz.f32x2 %0, %0, %1;"
+      : "+l"(*(unsigned long long*)a)
+      : "l"(*(unsigned long long*)&b));
+}
+
+__device__ __forceinline__ void sub_f32x2_inplace(float2* a, float2 b) {
+  asm("sub.rn.ftz.f32x2 %0, %0, %1;"
+      : "+l"(*(unsigned long long*)a)
+      : "l"(*(unsigned long long*)&b));
+}
+
+__device__ __forceinline__ float2 add_f32x2(float2 a, float2 b) {
+  float2 r;
+  asm("add.rn.ftz.f32x2 %0, %1, %2;"
+      : "=l"(*(unsigned long long*)&r)
+      : "l"(*(unsigned long long*)&a), "l"(*(unsigned long long*)&b));
+  return r;
+}
+
+__device__ __forceinline__ float2 sub_f32x2(float2 a, float2 b) {
+  float2 r;
+  asm("sub.rn.ftz.f32x2 %0, %1, %2;"
+      : "=l"(*(unsigned long long*)&r)
+      : "l"(*(unsigned long long*)&a), "l"(*(unsigned long long*)&b));
+  return r;
+}
+
+__device__ __forceinline__ void fma_scale_x32(float* sv, const float2* scale2,
+                                              const float2* neg_max2) {
+  float2* sv_2 = reinterpret_cast<float2*>(sv);
+
+#pragma unroll
+
+  for (int j = 0; j < 16; j++) fma_f32x2_inplace(&sv_2[j], *scale2, *neg_max2);
+}
+
+__device__ __forceinline__ float2 fma_f32x2(float2 a, float2 b, float2 c) {
+  float2 r;
+  asm("fma.rn.ftz.f32x2 %0, %1, %2, %3;"
+      : "=l"(*(unsigned long long*)&r)
+      : "l"(*(unsigned long long*)&a), "l"(*(unsigned long long*)&b),
+        "l"(*(unsigned long long*)&c));
+  return r;
+}
+
+__device__ __forceinline__ float2 fma_sub_f32x2(float2 a, float2 b, float2 c) {
+  float2 r;
+  asm volatile(
+      "{\n\t"
+      ".reg .f32 _c0, _c1;\n\t"
+      ".reg .b64 _neg_c;\n\t"
+      "mov.b64 {_c0, _c1}, %3;\n\t"
+      "neg.f32 _c0, _c0;\n\t"
+      "neg.f32 _c1, _c1;\n\t"
+      "mov.b64 _neg_c, {_c0, _c1};\n\t"
+      "fma.rn.ftz.f32x2 %0, %1, %2, _neg_c;\n\t"
+      "}\n"
+      : "=l"(*(unsigned long long*)&r)
+      : "l"(*(unsigned long long*)&a), "l"(*(unsigned long long*)&b),
+        "l"(*(unsigned long long*)&c));
+  return r;
+}
+
+__device__ __forceinline__ float2 mul_f32x2(float2 a, float2 b) {
+  float2 r;
+  asm("mul.rn.ftz.f32x2 %0, %1, %2;"
+      : "=l"(*(unsigned long long*)&r)
+      : "l"(*(unsigned long long*)&a), "l"(*(unsigned long long*)&b));
+  return r;
+}
+
+// ex2_emulation_f32x2 defined in softmax_frag_exp2_cast helper (or standalone)
+
+__device__ __forceinline__ void elect_commit2(int mbar_addr0, int mbar_addr1) {
+  asm volatile(
+      "{\n\t"
+      ".reg .pred leader;\n\t"
+      "elect.sync _|leader, 0xFFFFFFFF;\n\t"
+      "@leader tcgen05.commit.cta_group::1.mbarrier::arrive::one"
+      ".shared::cluster.b64 [%0];\n\t"
+      "@leader tcgen05.commit.cta_group::1.mbarrier::arrive::one"
+      ".shared::cluster.b64 [%1];\n\t"
+      "}\n" ::"r"(mbar_addr0),
+      "r"(mbar_addr1)
+      : "memory");
+}
+
+__device__ __forceinline__ void fence_async_shared() {
+  asm volatile("fence.proxy.async.shared::cta;" ::: "memory");
+}
+
+__device__ __forceinline__ uint64_t make_smem_desc(int addr) {
+  const int SBO = 1024;
+  return desc_encode(addr) | (desc_encode(SBO) << 32ULL) | (1ULL << 46ULL) | (2ULL << 61ULL);
+}
+
+__device__ __forceinline__ void tma_3d_gmem2smem(int dst, const void* tmap_ptr, int x, int y, int z,
+                                                 int mbar_addr) {
+  asm volatile(
+      "cp.async.bulk.tensor.3d.shared::cta.global"
+      ".mbarrier::complete_tx::bytes"
+      " [%0], [%1, {%2, %3, %4}], [%5];" ::"r"(dst),
+      "l"(tmap_ptr), "r"(x), "r"(y), "r"(z), "r"(mbar_addr)
+      : "memory");
+}
+
+__device__ __forceinline__ void tma_4d_gmem2smem(int dst, const void* tmap_ptr, int x, int y, int z,
+                                                 int w, int mbar_addr) {
+  asm volatile(
+      "cp.async.bulk.tensor.4d.shared::cta.global"
+      ".mbarrier::complete_tx::bytes"
+      " [%0], [%1, {%2, %3, %4, %5}], [%6];" ::"r"(dst),
+      "l"(tmap_ptr), "r"(x), "r"(y), "r"(z), "r"(w), "r"(mbar_addr)
+      : "memory");
+}
+
+__device__ __forceinline__ void tma_store_3d(const void* tmap, int x, int y, int z,
+                                             unsigned smem_addr) {
+  asm volatile(
+      "cp.async.bulk.tensor.3d.global.shared::cta.tile.bulk_group"
+      " [%0, {%1, %2, %3}], [%4];" ::"l"(tmap),
+      "r"(x), "r"(y), "r"(z), "r"(smem_addr)
+      : "memory");
+}
+
+__device__ __forceinline__ void tma_store_4d(const void* tmap, int x, int y, int z, int w,
+                                             unsigned smem_addr) {
+  asm volatile(
+      "cp.async.bulk.tensor.4d.global.shared::cta.tile.bulk_group"
+      " [%0, {%1, %2, %3, %4}], [%5];" ::"l"(tmap),
+      "r"(x), "r"(y), "r"(z), "r"(w), "r"(smem_addr)
+      : "memory");
+}
+
+__device__ __forceinline__ void tcgen05_commit(int mbar_addr) {
+  asm volatile(
+      "tcgen05.commit.cta_group::1.mbarrier::arrive::one"
+      ".shared::cluster.b64 [%0];" ::"r"(mbar_addr)
+      : "memory");
+}
+
+__device__ __forceinline__ void tmem_ld_x8(float* dst, int tmem_addr) {
+  asm volatile(
+      "tcgen05.ld.sync.aligned.32x32b.x8.b32"
+      " {%0, %1, %2, %3, %4, %5, %6, %7}, [%8];"
+      : "=f"(dst[0]), "=f"(dst[1]), "=f"(dst[2]), "=f"(dst[3]), "=f"(dst[4]), "=f"(dst[5]),
+        "=f"(dst[6]), "=f"(dst[7])
+      : "r"(tmem_addr));
+}
+
+__device__ __forceinline__ void tmem_st_x8_u32(int addr, const uint32_t* src) {
+  asm volatile(
+      "tcgen05.st.sync.aligned.32x32b.x8.b32"
+      " [%0], {%1,%2,%3,%4,%5,%6,%7,%8};" ::"r"(addr),
+      "r"(src[0]), "r"(src[1]), "r"(src[2]), "r"(src[3]), "r"(src[4]), "r"(src[5]), "r"(src[6]),
+      "r"(src[7]));
+}
+
+__device__ __forceinline__ uint32_t make_warp_uniform(uint32_t val) {
+  uint32_t result;
+  asm volatile("shfl.sync.idx.b32 %0, %1, 0, 0x1f, 0xffffffff;" : "=r"(result) : "r"(val));
+  return result;
+}
+
+__device__ __forceinline__ void mma_ss_step(int a_lo, int b_lo, int taddr, uint32_t i_desc,
+                                            int enable_d, uint32_t a_dhi, uint32_t b_dhi) {
+  asm volatile(
+      "{\n\t"
+      ".reg .pred leader, p;\n\t"
+      ".reg .b32 adhi, bdhi;\n\t"
+      ".reg .b64 da, db;\n\t"
+      "elect.sync _|leader, 0xFFFFFFFF;\n\t"
+      "setp.ne.b32 p, %4, 0;\n\t"
+      "mov.b32 adhi, %5;\n\t"
+      "mov.b32 bdhi, %6;\n\t"
+      "mov.b64 da, {%0, adhi};\n\t"
+      "mov.b64 db, {%1, bdhi};\n\t"
+      "@leader tcgen05.mma.cta_group::1.kind::f16 [%2], da, db, %3, p;\n\t"
+      "}\n" ::"r"(a_lo),
+      "r"(b_lo), "r"(taddr), "r"(i_desc), "r"(enable_d), "r"(a_dhi), "r"(b_dhi));
+}
+
+__device__ __forceinline__ void tma_2d_gmem2smem(int dst, const void* tmap_ptr, int x, int y,
+                                                 int mbar_addr) {
+  asm volatile(
+      "cp.async.bulk.tensor.2d.shared::cta.global"
+      ".mbarrier::complete_tx::bytes"
+      " [%0], [%1, {%2, %3}], [%4];" ::"r"(dst),
+      "l"(tmap_ptr), "r"(x), "r"(y), "r"(mbar_addr)
+      : "memory");
+}
+
+#define LOOM_INF CUDART_INF_F
+#define TMEM_NCOLS 272
+#define TMEM_TMEM_STATE_OFFSET 0
+#define TMEM_TMEM_STATE_INP_OFFSET 128
+#define TMEM_TMEM_Q_STATE_OFFSET 192
+#define TMEM_TMEM_STATE_K_OFFSET 224
+#define TMEM_TMEM_U_ACC_OFFSET 240
+#define TMEM_TMEM_Y_INP_OFFSET 256
+#define TMEM_TMEM_U_INP_OFFSET 264
+#define NUM_SCHED_PIPE_STAGES 8
+#define NUM_RAW_PIPE_STAGES 5
+#define NUM_RAW_BAR_PIPE_STAGES 6
+#define NUM_DECAY_PIPE_STAGES 2
+#define NUM_INTERMEDIATE_PIPE_STAGES 2
+#define NUM_DIAG_PIPE_STAGES 4
+#define NUM_STATE_PIPE_STAGES 1
+#define NUM_O_PIPE_STAGES 2
+#define NUM_CHECKPOINT_PIPE_STAGES 2
+#define SMEM_SMEM_Q_OFF 1024
+#define SMEM_SMEM_Q_STAGE_BYTES 4096
+#define SMEM_SMEM_Q_STRIDE 4096
+#define SMEM_SMEM_K_OFF 21504
+#define SMEM_SMEM_K_STAGE_BYTES 4096
+#define SMEM_SMEM_K_STRIDE 4096
+#define SMEM_SMEM_V_OFF 41984
+#define SMEM_SMEM_V_STAGE_BYTES 4096
+#define SMEM_SMEM_V_STRIDE 4096
+#define SMEM_SMEM_G_OFF 62464
+#define SMEM_SMEM_G_STAGE_BYTES 8192
+#define SMEM_SMEM_G_STRIDE 8192
+#define SMEM_SMEM_BETA_OFF 103424
+#define SMEM_SMEM_BETA_STAGE_BYTES 32
+#define SMEM_SMEM_BETA_STRIDE 32
+#define SMEM_SMEM_BETA_ALL_OFF 103424
+#define SMEM_SMEM_BETA_ALL_STAGE_BYTES 192
+#define SMEM_SMEM_BETA_ALL_STRIDE 192
+#define SMEM_SMEM_K_INV_OFF 104448
+#define SMEM_SMEM_K_INV_STAGE_BYTES 4096
+#define SMEM_SMEM_K_INV_STRIDE 4096
+#define SMEM_SMEM_K_DECAY_OFF 112640
+#define SMEM_SMEM_K_DECAY_STAGE_BYTES 4096
+#define SMEM_SMEM_K_DECAY_STRIDE 4096
+#define SMEM_SMEM_Q_DECAY_OFF 120832
+#define SMEM_SMEM_Q_DECAY_STAGE_BYTES 4096
+#define SMEM_SMEM_Q_DECAY_STRIDE 4096
+#define SMEM_SMEM_K_RESTORE_OFF 129024
+#define SMEM_SMEM_K_RESTORE_STAGE_BYTES 4096
+#define SMEM_SMEM_K_RESTORE_STRIDE 4096
+#define SMEM_SMEM_K_RESTORE_MN_OFF 129024
+#define SMEM_SMEM_K_RESTORE_MN_STAGE_BYTES 4096
+#define SMEM_SMEM_K_RESTORE_MN_STRIDE 4096
+#define SMEM_SMEM_TINV_OFF 137216
+#define SMEM_SMEM_TINV_STAGE_BYTES 512
+#define SMEM_SMEM_TINV_STRIDE 1024
+#define SMEM_SMEM_A_OFF 137728
+#define SMEM_SMEM_A_STAGE_BYTES 512
+#define SMEM_SMEM_A_STRIDE 1024
+#define SMEM_SMEM_TINV_MN_OFF 137216
+#define SMEM_SMEM_TINV_MN_STAGE_BYTES 512
+#define SMEM_SMEM_TINV_MN_STRIDE 1024
+#define SMEM_SMEM_A_MN_OFF 137728
+#define SMEM_SMEM_A_MN_STAGE_BYTES 512
+#define SMEM_SMEM_A_MN_STRIDE 1024
+#define SMEM_SMEM_STATE_DIAG_OFF 139264
+#define SMEM_SMEM_STATE_DIAG_STAGE_BYTES 512
+#define SMEM_SMEM_STATE_DIAG_STRIDE 512
+#define SMEM_SMEM_O_OFF 155648
+#define SMEM_SMEM_O_STAGE_BYTES 4096
+#define SMEM_SMEM_O_STRIDE 4096
+#define SMEM_SMEM_CHECKPOINT_OFF 163840
+#define SMEM_SMEM_CHECKPOINT_STAGE_BYTES 32768
+#define SMEM_SMEM_CHECKPOINT_STRIDE 32768
+#define SMEM_TINV_SCRATCH_OFF 229376
+#define SMEM_TINV_SCRATCH_STAGE_BYTES 512
+#define SMEM_TINV_SCRATCH_STRIDE 512
+#define SMEM_SCHED_SLOT_OFF 229888
+#define SMEM_SCHED_SLOT_STAGE_BYTES 4
+#define SMEM_SCHED_SLOT_STRIDE 4
+#define SMEM_SMEM_Q_ALL_OFF 1024
+#define SMEM_SMEM_Q_ALL_STAGE_BYTES 20480
+#define SMEM_SMEM_Q_ALL_STRIDE 20480
+#define SMEM_SMEM_K_ALL_OFF 21504
+#define SMEM_SMEM_K_ALL_STAGE_BYTES 20480
+#define SMEM_SMEM_K_ALL_STRIDE 20480
+#define SMEM_SMEM_G_ALL_OFF 62464
+#define SMEM_SMEM_G_ALL_STAGE_BYTES 40960
+#define SMEM_SMEM_G_ALL_STRIDE 40960
+#define SMEM_SMEM_V_ALL_OFF 41984
+#define SMEM_SMEM_V_ALL_STAGE_BYTES 20480
+#define SMEM_SMEM_V_ALL_STRIDE 20480
+#define SMEM_SMEM_O_ALL_OFF 155648
+#define SMEM_SMEM_O_ALL_STAGE_BYTES 8192
+#define SMEM_SMEM_O_ALL_STRIDE 8192
+#define SMEM_TOTAL 230016
+#define THREADS 512
+#define USE_INITIAL_STATE 1
+#define STORE_FINAL_STATE 0
+#define ENABLE_CHECKPOINTS 1
+#define STORE_BETA_ACTIVE 1
+#define G_INPUT_BF16 1
+
+extern "C" {
+
+__global__ __launch_bounds__(512, 1) void kernel_flashkda_forward_checkpoint_c16(
+    unsigned int* __restrict__ dynamic_counter, const __grid_constant__ CUtensorMap q_tma,
+    const __grid_constant__ CUtensorMap k_tma, const __grid_constant__ CUtensorMap v_tma,
+    const __grid_constant__ CUtensorMap g_tma, __nv_bfloat16* __restrict__ g,
+    const __grid_constant__ CUtensorMap out_tma, const __grid_constant__ CUtensorMap checkpoint_tma,
+    __nv_bfloat16* __restrict__ beta, __nv_bfloat16* __restrict__ beta_active_out,
+    float* __restrict__ A_log, float* __restrict__ dt_bias, long long* __restrict__ cu_seqlens,
+    long long* __restrict__ checkpoint_cu_starts, int* __restrict__ work_items,
+    float* __restrict__ initial_state, __nv_bfloat16* __restrict__ final_state,
+    int total_work_items, int uniform_work_items, int num_qk_heads, int num_heads,
+    int beta_active_stride, int checkpoint_every_n_tokens, float scale, float lower_bound) {
+  const int tid = threadIdx.x;
+  const int warp = make_warp_uniform(tid / 32);
+  const int lane = tid % 32;
+
+  extern __shared__ __align__(1024) char smem_raw[];
+  int smem;
+  smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+
+  const int bid = blockIdx.x;
+  const int num_bids = gridDim.x;
+
+  // Kernel setup ops
+  __nv_bfloat16* smem_q = reinterpret_cast<__nv_bfloat16*>(smem_raw + 1024);
+  const int smem_q_addr = smem + 1024;
+  __nv_bfloat16* smem_k = reinterpret_cast<__nv_bfloat16*>(smem_raw + 21504);
+  const int smem_k_addr = smem + 21504;
+  __nv_bfloat16* smem_v = reinterpret_cast<__nv_bfloat16*>(smem_raw + 41984);
+  const int smem_v_addr = smem + 41984;
+  float* smem_g = reinterpret_cast<float*>(smem_raw + 62464);
+  const int smem_g_addr = smem + 62464;
+  __nv_bfloat16* smem_beta = reinterpret_cast<__nv_bfloat16*>(smem_raw + 103424);
+  const int smem_beta_addr = smem + 103424;
+  __nv_bfloat16* smem_beta_all = reinterpret_cast<__nv_bfloat16*>(smem_raw + 103424);
+  const int smem_beta_all_addr = smem + 103424;
+  __nv_bfloat16* smem_k_inv = reinterpret_cast<__nv_bfloat16*>(smem_raw + 104448);
+  const int smem_k_inv_addr = smem + 104448;
+  __nv_bfloat16* smem_k_decay = reinterpret_cast<__nv_bfloat16*>(smem_raw + 112640);
+  const int smem_k_decay_addr = smem + 112640;
+  __nv_bfloat16* smem_q_decay = reinterpret_cast<__nv_bfloat16*>(smem_raw + 120832);
+  const int smem_q_decay_addr = smem + 120832;
+  __nv_bfloat16* smem_k_restore = reinterpret_cast<__nv_bfloat16*>(smem_raw + 129024);
+  const int smem_k_restore_addr = smem + 129024;
+  __nv_bfloat16* smem_k_restore_mn = reinterpret_cast<__nv_bfloat16*>(smem_raw + 129024);
+  const int smem_k_restore_mn_addr = smem + 129024;
+  __nv_bfloat16* smem_tinv = reinterpret_cast<__nv_bfloat16*>(smem_raw + 137216);
+  const int smem_tinv_addr = smem + 137216;
+  __nv_bfloat16* smem_a = reinterpret_cast<__nv_bfloat16*>(smem_raw + 137728);
+  const int smem_a_addr = smem + 137728;
+  __nv_bfloat16* smem_tinv_mn = reinterpret_cast<__nv_bfloat16*>(smem_raw + 137216);
+  const int smem_tinv_mn_addr = smem + 137216;
+  __nv_bfloat16* smem_a_mn = reinterpret_cast<__nv_bfloat16*>(smem_raw + 137728);
+  const int smem_a_mn_addr = smem + 137728;
+  __nv_bfloat16* smem_state_diag = reinterpret_cast<__nv_bfloat16*>(smem_raw + 139264);
+  const int smem_state_diag_addr = smem + 139264;
+  __nv_bfloat16* smem_o = reinterpret_cast<__nv_bfloat16*>(smem_raw + 155648);
+  const int smem_o_addr = smem + 155648;
+  __nv_bfloat16* smem_checkpoint = reinterpret_cast<__nv_bfloat16*>(smem_raw + 163840);
+  const int smem_checkpoint_addr = smem + 163840;
+  __nv_bfloat16* tinv_scratch = reinterpret_cast<__nv_bfloat16*>(smem_raw + 229376);
+  const int tinv_scratch_addr = smem + 229376;
+  unsigned int* sched_slot = reinterpret_cast<unsigned int*>(smem_raw + 229888);
+  const int sched_slot_addr = smem + 229888;
+  __nv_bfloat16* smem_q_all = reinterpret_cast<__nv_bfloat16*>(smem_raw + 1024);
+  const int smem_q_all_addr = smem + 1024;
+  __nv_bfloat16* smem_k_all = reinterpret_cast<__nv_bfloat16*>(smem_raw + 21504);
+  const int smem_k_all_addr = smem + 21504;
+  float* smem_g_all = reinterpret_cast<float*>(smem_raw + 62464);
+  const int smem_g_all_addr = smem + 62464;
+  __nv_bfloat16* smem_v_all = reinterpret_cast<__nv_bfloat16*>(smem_raw + 41984);
+  const int smem_v_all_addr = smem + 41984;
+  __nv_bfloat16* smem_o_all = reinterpret_cast<__nv_bfloat16*>(smem_raw + 155648);
+  const int smem_o_all_addr = smem + 155648;
+
+  // Mbarrier init (37 groups, 116 barriers)
+  // Mbarriers at smem_raw[0..928)
+
+  if (warp == 0) {
+    uint32_t leader = elect_sync();
+    if (leader) {
+      // --- pipeline 'sched_pipe' ---
+      // sched_ready: 8 barriers, init_count=1
+      mbarrier_init(smem + 0, 1);
+      mbarrier_init(smem + 8, 1);
+      mbarrier_init(smem + 16, 1);
+      mbarrier_init(smem + 24, 1);
+      mbarrier_init(smem + 32, 1);
+      mbarrier_init(smem + 40, 1);
+      mbarrier_init(smem + 48, 1);
+      mbarrier_init(smem + 56, 1);
+      // sched_done: 8 barriers, init_count=15
+      mbarrier_init(smem + 64, 15);
+      mbarrier_init(smem + 72, 15);
+      mbarrier_init(smem + 80, 15);
+      mbarrier_init(smem + 88, 15);
+      mbarrier_init(smem + 96, 15);
+      mbarrier_init(smem + 104, 15);
+      mbarrier_init(smem + 112, 15);
+      mbarrier_init(smem + 120, 15);
+      // --- pipeline 'raw_bar_pipe' ---
+      // q_ready: 6 barriers, init_count=1
+      mbarrier_init(smem + 128, 1);
+      mbarrier_init(smem + 136, 1);
+      mbarrier_init(smem + 144, 1);
+      mbarrier_init(smem + 152, 1);
+      mbarrier_init(smem + 160, 1);
+      mbarrier_init(smem + 168, 1);
+      // k_ready: 6 barriers, init_count=1
+      mbarrier_init(smem + 176, 1);
+      mbarrier_init(smem + 184, 1);
+      mbarrier_init(smem + 192, 1);
+      mbarrier_init(smem + 200, 1);
+      mbarrier_init(smem + 208, 1);
+      mbarrier_init(smem + 216, 1);
+      // v_ready: 6 barriers, init_count=1
+      mbarrier_init(smem + 224, 1);
+      mbarrier_init(smem + 232, 1);
+      mbarrier_init(smem + 240, 1);
+      mbarrier_init(smem + 248, 1);
+      mbarrier_init(smem + 256, 1);
+      mbarrier_init(smem + 264, 1);
+      // g_ready: 6 barriers, init_count=1
+      mbarrier_init(smem + 272, 1);
+      mbarrier_init(smem + 280, 1);
+      mbarrier_init(smem + 288, 1);
+      mbarrier_init(smem + 296, 1);
+      mbarrier_init(smem + 304, 1);
+      mbarrier_init(smem + 312, 1);
+      // --- pipeline 'raw_pipe' ---
+      // q_done: 5 barriers, init_count=128
+      mbarrier_init(smem + 320, 128);
+      mbarrier_init(smem + 328, 128);
+      mbarrier_init(smem + 336, 128);
+      mbarrier_init(smem + 344, 128);
+      mbarrier_init(smem + 352, 128);
+      // k_done: 5 barriers, init_count=128
+      mbarrier_init(smem + 360, 128);
+      mbarrier_init(smem + 368, 128);
+      mbarrier_init(smem + 376, 128);
+      mbarrier_init(smem + 384, 128);
+      mbarrier_init(smem + 392, 128);
+      // g_done: 5 barriers, init_count=128
+      mbarrier_init(smem + 400, 128);
+      mbarrier_init(smem + 408, 128);
+      mbarrier_init(smem + 416, 128);
+      mbarrier_init(smem + 424, 128);
+      mbarrier_init(smem + 432, 128);
+      // v_done: 5 barriers, init_count=128
+      mbarrier_init(smem + 440, 128);
+      mbarrier_init(smem + 448, 128);
+      mbarrier_init(smem + 456, 128);
+      mbarrier_init(smem + 464, 128);
+      mbarrier_init(smem + 472, 128);
+      // --- pipeline 'raw_bar_pipe' ---
+      // beta_ready: 6 barriers, init_count=32
+      mbarrier_init(smem + 480, 32);
+      mbarrier_init(smem + 488, 32);
+      mbarrier_init(smem + 496, 32);
+      mbarrier_init(smem + 504, 32);
+      mbarrier_init(smem + 512, 32);
+      mbarrier_init(smem + 520, 32);
+      // beta_done: 6 barriers, init_count=160
+      mbarrier_init(smem + 528, 160);
+      mbarrier_init(smem + 536, 160);
+      mbarrier_init(smem + 544, 160);
+      mbarrier_init(smem + 552, 160);
+      mbarrier_init(smem + 560, 160);
+      mbarrier_init(smem + 568, 160);
+      // --- pipeline 'decay_pipe' ---
+      // k_decay_inv_ready: 2 barriers, init_count=128
+      mbarrier_init(smem + 576, 128);
+      mbarrier_init(smem + 584, 128);
+      // --- pipeline 'diag_pipe' ---
+      // qk_scale_ready: 4 barriers, init_count=128
+      mbarrier_init(smem + 592, 128);
+      mbarrier_init(smem + 600, 128);
+      mbarrier_init(smem + 608, 128);
+      mbarrier_init(smem + 616, 128);
+      // --- pipeline 'decay_pipe' ---
+      // decay_tcgen_done: 2 barriers, init_count=1
+      mbarrier_init(smem + 624, 1);
+      mbarrier_init(smem + 632, 1);
+      // decay_super_done: 2 barriers, init_count=64
+      mbarrier_init(smem + 640, 64);
+      mbarrier_init(smem + 648, 64);
+      // k_restore_done: 2 barriers, init_count=1
+      mbarrier_init(smem + 656, 1);
+      mbarrier_init(smem + 664, 1);
+      // --- pipeline 'diag_pipe' ---
+      // state_diag_done: 4 barriers, init_count=1
+      mbarrier_init(smem + 672, 1);
+      mbarrier_init(smem + 680, 1);
+      mbarrier_init(smem + 688, 1);
+      mbarrier_init(smem + 696, 1);
+      // --- pipeline 'intermediate_pipe' ---
+      // tinv_ready: 2 barriers, init_count=32
+      mbarrier_init(smem + 704, 32);
+      mbarrier_init(smem + 712, 32);
+      // tinv_done: 2 barriers, init_count=1
+      mbarrier_init(smem + 720, 1);
+      mbarrier_init(smem + 728, 1);
+      // a_ready: 2 barriers, init_count=32
+      mbarrier_init(smem + 736, 32);
+      mbarrier_init(smem + 744, 32);
+      // a_done: 2 barriers, init_count=1
+      mbarrier_init(smem + 752, 1);
+      mbarrier_init(smem + 760, 1);
+      // --- pipeline 'state_pipe' ---
+      // state_inp_ready: 1 barriers, init_count=128
+      mbarrier_init(smem + 768, 128);
+      // state_read_done: 1 barriers, init_count=128
+      mbarrier_init(smem + 776, 128);
+      // state_acc_done: 1 barriers, init_count=1
+      mbarrier_init(smem + 784, 1);
+      // state_k_ready: 1 barriers, init_count=1
+      mbarrier_init(smem + 792, 1);
+      // y_inp_ready: 1 barriers, init_count=128
+      mbarrier_init(smem + 800, 128);
+      // u_acc_ready: 1 barriers, init_count=1
+      mbarrier_init(smem + 808, 1);
+      // u_inp_ready: 1 barriers, init_count=128
+      mbarrier_init(smem + 816, 128);
+      // o_acc_ready: 1 barriers, init_count=1
+      mbarrier_init(smem + 824, 1);
+      // --- pipeline 'o_pipe' ---
+      // o_acc_done: 2 barriers, init_count=128
+      mbarrier_init(smem + 832, 128);
+      mbarrier_init(smem + 840, 128);
+      // o_tma_ready: 2 barriers, init_count=128
+      mbarrier_init(smem + 848, 128);
+      mbarrier_init(smem + 856, 128);
+      // o_tma_done: 2 barriers, init_count=32
+      mbarrier_init(smem + 864, 32);
+      mbarrier_init(smem + 872, 32);
+      // --- pipeline 'checkpoint_pipe' ---
+      // checkpoint_ready: 2 barriers, init_count=128
+      mbarrier_init(smem + 880, 128);
+      mbarrier_init(smem + 888, 128);
+      // checkpoint_done: 2 barriers, init_count=32
+      mbarrier_init(smem + 896, 32);
+      mbarrier_init(smem + 904, 32);
+      // consumers_done: 1 barriers, init_count=15
+      mbarrier_init(smem + 912, 15);
+      // cleanup_ready: 1 barriers, init_count=1
+      mbarrier_init(smem + 920, 1);
+      asm volatile("fence.mbarrier_init.release.cluster;");
+    }
+  }
+
+  __syncwarp();
+
+  // TMEM alloc (512 columns, 272 used)
+  volatile int* tmem_addr_storage = (volatile int*)(smem_raw + 928);
+  if (warp == 13) {
+    int _tmem_hold = smem + 928;
+    asm volatile(
+        "tcgen05.alloc.cta_group::1.sync.aligned.shared::cta.b32 [%0], %1;" ::"r"(_tmem_hold),
+        "r"(512)
+        : "memory");
+    asm volatile("tcgen05.relinquish_alloc_permit.cta_group::1.sync.aligned;");
+  }
+
+  __syncthreads();
+  asm volatile("tcgen05.fence::after_thread_sync;");
+
+  const int mbar_base = smem;
+#define sched_ready_addr (mbar_base + 0)
+#define sched_done_addr (mbar_base + 64)
+#define q_ready_addr (mbar_base + 128)
+#define k_ready_addr (mbar_base + 176)
+#define v_ready_addr (mbar_base + 224)
+#define g_ready_addr (mbar_base + 272)
+#define q_done_addr (mbar_base + 320)
+#define k_done_addr (mbar_base + 360)
+#define g_done_addr (mbar_base + 400)
+#define v_done_addr (mbar_base + 440)
+#define beta_ready_addr (mbar_base + 480)
+#define beta_done_addr (mbar_base + 528)
+#define k_decay_inv_ready_addr (mbar_base + 576)
+#define qk_scale_ready_addr (mbar_base + 592)
+#define decay_tcgen_done_addr (mbar_base + 624)
+#define decay_super_done_addr (mbar_base + 640)
+#define k_restore_done_addr (mbar_base + 656)
+#define state_diag_done_addr (mbar_base + 672)
+#define tinv_ready_addr (mbar_base + 704)
+#define tinv_done_addr (mbar_base + 720)
+#define a_ready_addr (mbar_base + 736)
+#define a_done_addr (mbar_base + 752)
+#define state_inp_ready_addr (mbar_base + 768)
+#define state_read_done_addr (mbar_base + 776)
+#define state_acc_done_addr (mbar_base + 784)
+#define state_k_ready_addr (mbar_base + 792)
+#define y_inp_ready_addr (mbar_base + 800)
+#define u_acc_ready_addr (mbar_base + 808)
+#define u_inp_ready_addr (mbar_base + 816)
+#define o_acc_ready_addr (mbar_base + 824)
+#define o_acc_done_addr (mbar_base + 832)
+#define o_tma_ready_addr (mbar_base + 848)
+#define o_tma_done_addr (mbar_base + 864)
+#define checkpoint_ready_addr (mbar_base + 880)
+#define checkpoint_done_addr (mbar_base + 896)
+#define consumers_done_addr (mbar_base + 912)
+#define cleanup_ready_addr (mbar_base + 920)
+  const int taddr = tmem_addr_storage[0];
+
+  // Kernel post-init ops
+  const int tmem_tmem_state = taddr;
+  const int tmem_tmem_state_inp = taddr + 128;
+  const int tmem_tmem_q_state = taddr + 192;
+  const int tmem_tmem_state_k = taddr + 224;
+  const int tmem_tmem_u_acc = taddr + 240;
+  const int tmem_tmem_y_inp = taddr + 256;
+  const int tmem_tmem_u_inp = taddr + 264;
+
+  // ---- Register redistribution for WGs split across roles ----
+  // Dec phase frees registers before any WG attempts inc.
+  if (warp >= 12 && warp <= 15) {
+    asm volatile("setmaxnreg.dec.sync.aligned.u32 56;");
+  }
+
+  // ---- Role: cg0 ----
+  if (warp <= 7) {
+    asm volatile("setmaxnreg.inc.sync.aligned.u32 160;");
+    {  // cg0_main
+      unsigned int sched_stage_cg0 = 0;
+      int cumulative_chunk_cg0 = 0;
+      int instance_id = (warp - 0) / 4;
+      int cg0_instance = instance_id;
+      int warp_id_in_role = (warp - 0);
+      int cg0_local_warp = warp_id_in_role - cg0_instance * 4;
+      int cg0_tid = cg0_local_warp * 32 + lane;
+      unsigned int _phase_sched_ready = 0;
+#pragma unroll 1
+      for (int _ = 0; _ < total_work_items + 1; _++) {
+        mbarrier_wait(sched_ready_addr + (sched_stage_cg0) * 8, _phase_sched_ready);
+        unsigned int slot[1];
+        asm volatile("ld.shared.b32 %0, [%1];"
+                     : "=r"(*reinterpret_cast<uint32_t*>(&slot[0]))
+                     : "r"(sched_slot_addr + sched_stage_cg0 * 4));
+        unsigned int tile_cg0 = slot[0];
+        if (elect_sync()) {
+          mbarrier_arrive(sched_done_addr + (sched_stage_cg0) * 8);
+        }
+        sched_stage_cg0 += 1;
+        if (sched_stage_cg0 == 8) {
+          sched_stage_cg0 = 0;
+          _phase_sched_ready ^= 1;
+        }
+        if (tile_cg0 >= (unsigned int)total_work_items) {
+          break;
+        }
+        int item_base_cg0 = (int)tile_cg0 * 8;
+        int _vec_load_2[4];
+        {
+          int4 _iv4 = *reinterpret_cast<const int4*>(work_items + item_base_cg0 + 4);
+          _vec_load_2[0 + 0] = _iv4.x;
+          _vec_load_2[0 + 1] = _iv4.y;
+          _vec_load_2[0 + 2] = _iv4.z;
+          _vec_load_2[0 + 3] = _iv4.w;
+        }
+        int head_cg0 = work_items[item_base_cg0 + 1];
+        int wend_cg0 = work_items[item_base_cg0 + 3];
+        int cstart_cg0 = _vec_load_2[0];
+        long long bos_cg0 = (long long)_vec_load_2[2];
+        long long eos_cg0 = (long long)_vec_load_2[3];
+        int chunks_cg0 = wend_cg0 - cstart_cg0;
+        float _expf_0 = __expf(A_log[head_cg0]);
+        float gate_rate_cg0 = _expf_0;
+        float gate_bias_cg0 = dt_bias[head_cg0 * 128 + cg0_tid];
+        asm volatile("barrier.sync 10, 256;" ::: "memory");
+        int first_cumulative_cg0 = cumulative_chunk_cg0 + cg0_instance;
+        int raw_stage_cg0 = first_cumulative_cg0 % 5;
+        int raw_bar_stage_cg0 = first_cumulative_cg0 % 6;
+        int decay_stage_cg0 = first_cumulative_cg0 % 2;
+        int diag_stage_cg0 = first_cumulative_cg0 % 4;
+        int raw_bar_phase_cg0 = first_cumulative_cg0 / 6 & 1;
+        int decay_free_phase_cg0 = first_cumulative_cg0 / 2 + 1 & 1;
+        int diag_free_phase_cg0 = first_cumulative_cg0 / 4 + 1 & 1;
+#pragma unroll 1
+        for (int chunk_cg0 = cg0_instance; chunk_cg0 < chunks_cg0; chunk_cg0 += 2) {
+          int cumulative_cg0 = cumulative_chunk_cg0 + chunk_cg0;
+          int logical_chunk_cg0 = cstart_cg0 + chunk_cg0;
+          if (cg0_local_warp == 0) {
+            mbarrier_wait(beta_done_addr + (raw_bar_stage_cg0) * 8,
+                          (unsigned int)(cumulative_cg0 / 6 + 1 & 1));
+            if (lane < 16) {
+              long long beta_token_cg0 =
+                  bos_cg0 + (long long)logical_chunk_cg0 * 16 + (long long)lane;
+              float beta_value_cg0 = 0.0f;
+              if (beta_token_cg0 < eos_cg0) {
+                float beta_logit_cg0 =
+                    (float)beta[beta_token_cg0 * (long long)num_heads + (long long)head_cg0];
+                float _tanh_approx_0;
+                asm volatile("tanh.approx.f32 %0, %1;"
+                             : "=f"(_tanh_approx_0)
+                             : "f"(beta_logit_cg0 * 0.5f));
+                beta_value_cg0 = _tanh_approx_0 * 0.5f + 0.5f;
+              }
+              __nv_bfloat16 _cvt_bf16_0 = __float2bfloat16(beta_value_cg0);
+              __nv_bfloat16 beta_active_cg0 = _cvt_bf16_0;
+              smem_beta_all[(int)raw_bar_stage_cg0 * 16 + lane] = beta_active_cg0;
+              if (STORE_BETA_ACTIVE != 0 && beta_token_cg0 < eos_cg0) {
+                beta_active_out[beta_token_cg0 * (long long)beta_active_stride +
+                                (long long)head_cg0] = beta_active_cg0;
+              }
+            }
+            mbarrier_arrive(beta_ready_addr + (raw_bar_stage_cg0) * 8);
+          }
+          mbarrier_wait(g_ready_addr + (raw_bar_stage_cg0) * 8, raw_bar_phase_cg0);
+          float gate_raw_cg0[16];
+          float gate_log_cg0[16];
+          float gate_prefix_regs_cg0[16];
+#pragma unroll
+          for (int token_gate_cg0 = 0; token_gate_cg0 < 16; token_gate_cg0++) {
+            {
+              long long gate_token_cg0 =
+                  bos_cg0 + (long long)logical_chunk_cg0 * 16 + (long long)token_gate_cg0;
+              gate_raw_cg0[token_gate_cg0] =
+                  (float)g[(gate_token_cg0 * (long long)num_heads + (long long)head_cg0) * 128 +
+                           (long long)cg0_tid];
+            }
+          }
+#pragma unroll
+          for (int gate_row_cg0 = 0; gate_row_cg0 < 16; gate_row_cg0++) {
+            float gate_arg_cg0 = gate_rate_cg0 * (gate_raw_cg0[gate_row_cg0] + gate_bias_cg0);
+            float _tanh_approx_1;
+            asm volatile("tanh.approx.f32 %0, %1;"
+                         : "=f"(_tanh_approx_1)
+                         : "f"(gate_arg_cg0 * 0.5f));
+            float gate_value_cg0 = _tanh_approx_1 * 0.5f + 0.5f;
+            long long valid_gate_cg0 =
+                bos_cg0 + (long long)logical_chunk_cg0 * 16 + (long long)gate_row_cg0;
+            gate_log_cg0[gate_row_cg0] = 0.0f;
+            if (valid_gate_cg0 < eos_cg0) {
+              gate_log_cg0[gate_row_cg0] = lower_bound * 1.4426950408889634f * gate_value_cg0;
+            }
+          }
+          float gate_prefix_cg0 = 0.0f;
+#pragma unroll
+          for (int gate_pair_idx_cg0 = 0; gate_pair_idx_cg0 < 8; gate_pair_idx_cg0++) {
+            int gate_row0_cg0 = gate_pair_idx_cg0 * 2;
+            int gate_row1_cg0 = gate_row0_cg0 + 1;
+            float2 _f2_0 = make_float2(gate_prefix_cg0, gate_log_cg0[gate_row0_cg0]);
+            float2 _f2_1 = make_float2(gate_log_cg0[gate_row0_cg0], gate_log_cg0[gate_row1_cg0]);
+            float2 gate_pair_sum_cg0 = add_f32x2(_f2_0, _f2_1);
+            gate_prefix_regs_cg0[gate_row0_cg0] = gate_pair_sum_cg0.x;
+            gate_prefix_cg0 += gate_pair_sum_cg0.y;
+            gate_prefix_regs_cg0[gate_row1_cg0] = gate_prefix_cg0;
+          }
+          float gate_last_cg0 = 1.0f;
+#pragma unroll
+          for (int token_gate_cg0_1 = 0; token_gate_cg0_1 < 16; token_gate_cg0_1++) {
+            float _exp2_0 = approx_exp2(gate_prefix_regs_cg0[token_gate_cg0_1]);
+            gate_last_cg0 = _exp2_0;
+            int segment = cg0_tid / 32;
+            int segment_col = cg0_tid - segment * 32;
+            int swizzled_col = segment_col ^ (token_gate_cg0_1 & 7) * 4;
+            smem_g_all[raw_stage_cg0 * 16 * 128 + segment * 16 * 32 + token_gate_cg0_1 * 32 +
+                       swizzled_col] = gate_last_cg0;
+          }
+          mbarrier_wait(state_diag_done_addr + (diag_stage_cg0) * 8, diag_free_phase_cg0);
+          int diag_block_cg0 = cg0_tid / 16;
+          int diag_coord_cg0 = cg0_tid - diag_block_cg0 * 16;
+          int diag_storage_stage_cg0 = (int)diag_stage_cg0 * 8 + diag_block_cg0;
+          if (cumulative_cg0 < 4) {
+#pragma unroll
+            for (int diag_half_cg0 = 0; diag_half_cg0 < 2; diag_half_cg0++) {
+              asm volatile("st.shared.v4.b32 [%0], {%1,%2,%3,%4};" ::"r"((
+                               smem_state_diag_addr + (unsigned int)(diag_storage_stage_cg0 * 512) +
+                               (unsigned int)(diag_half_cg0 * 8 / 16 * 512 + diag_coord_cg0 * 32 +
+                                                  diag_half_cg0 * 8 % 16 * 2 ^
+                                              (diag_half_cg0 * 8 / 16 * 512 + diag_coord_cg0 * 32 +
+                                                       diag_half_cg0 * 8 % 16 * 2 >>
+                                                   7 &
+                                               1) << 4))),
+                           "r"(0), "r"(0), "r"(0), "r"(0)
+                           : "memory");
+            }
+          }
+          {
+            __nv_bfloat16 _bval_0 = __float2bfloat16_rn(gate_last_cg0);
+            uint16_t _bits_0 = *(uint16_t*)&_bval_0;
+            uint32_t _addr_0 = static_cast<uint32_t>(
+                (smem_state_diag_addr + (unsigned int)(diag_storage_stage_cg0 * 512) +
+                 (unsigned int)(diag_coord_cg0 / 16 * 512 + diag_coord_cg0 * 32 +
+                                    diag_coord_cg0 % 16 * 2 ^
+                                (diag_coord_cg0 / 16 * 512 + diag_coord_cg0 * 32 +
+                                         diag_coord_cg0 % 16 * 2 >>
+                                     7 &
+                                 1) << 4)));
+            asm volatile("st.shared.b16 [%0], %1;" ::"r"(_addr_0), "h"(_bits_0) : "memory");
+          }
+          if (cg0_instance == 0) {
+            asm volatile("barrier.sync 8, 128;" ::: "memory");
+          } else {
+            asm volatile("barrier.sync 9, 128;" ::: "memory");
+          }
+          mbarrier_wait(q_ready_addr + (raw_bar_stage_cg0) * 8, raw_bar_phase_cg0);
+          mbarrier_wait(k_ready_addr + (raw_bar_stage_cg0) * 8, raw_bar_phase_cg0);
+          int decay_row_cg0 = cg0_local_warp * 4 + lane / 8;
+          int decay_lane_cg0 = lane & 7;
+          float q_values_cg0[16];
+          float k_values_cg0[16];
+          float2 _f2_2 = make_float2(0.0f, 0.0f);
+          float2 qk_sq_even_cg0 = _f2_2;
+          float2 _f2_3 = make_float2(0.0f, 0.0f);
+          float2 qk_sq_odd_cg0 = _f2_3;
+#pragma unroll
+          for (int dim_half_cg0 = 0; dim_half_cg0 < 2; dim_half_cg0++) {
+            int dim_base_cg0 = dim_half_cg0 * 64 + decay_lane_cg0 * 8;
+            unsigned int q_words_cg0[4];
+            unsigned int k_words_cg0[4];
+            int segment_1 = dim_base_cg0 / 64;
+            int segment_col_1 = dim_base_cg0 - segment_1 * 64;
+            int swizzled_col_1 = segment_col_1 ^ (decay_row_cg0 & 7) * 8;
+            int raw_index_cg0 = raw_stage_cg0 * 16 * 128 + segment_1 * 16 * 64 +
+                                decay_row_cg0 * 64 + swizzled_col_1;
+            asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                         : "=r"(*reinterpret_cast<uint32_t*>(&q_words_cg0[0])),
+                           "=r"(*reinterpret_cast<uint32_t*>(&q_words_cg0[(0) + 1])),
+                           "=r"(*reinterpret_cast<uint32_t*>(&q_words_cg0[(0) + 2])),
+                           "=r"(*reinterpret_cast<uint32_t*>(&q_words_cg0[(0) + 3]))
+                         : "r"(smem_q_all_addr + (unsigned int)(raw_index_cg0 * 2)));
+            asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                         : "=r"(*reinterpret_cast<uint32_t*>(&k_words_cg0[0])),
+                           "=r"(*reinterpret_cast<uint32_t*>(&k_words_cg0[(0) + 1])),
+                           "=r"(*reinterpret_cast<uint32_t*>(&k_words_cg0[(0) + 2])),
+                           "=r"(*reinterpret_cast<uint32_t*>(&k_words_cg0[(0) + 3]))
+                         : "r"(smem_k_all_addr + (unsigned int)(raw_index_cg0 * 2)));
+            float q_words_cg0_f32[8];
+#pragma unroll
+            for (int _pair = 0; _pair < 4; _pair++) {
+              asm volatile(
+                  "{\n\t"
+                  "shl.b32 %0, %2, 16;\n\t"
+                  "and.b32 %1, %2, 0xffff0000;\n\t"
+                  "}\n"
+                  : "=f"((&q_words_cg0_f32[_pair * 2])[0]), "=f"((&q_words_cg0_f32[_pair * 2])[1])
+                  : "r"(q_words_cg0[_pair]));
+            }
+            float k_words_cg0_f32[8];
+#pragma unroll
+            for (int _pair = 0; _pair < 4; _pair++) {
+              asm volatile(
+                  "{\n\t"
+                  "shl.b32 %0, %2, 16;\n\t"
+                  "and.b32 %1, %2, 0xffff0000;\n\t"
+                  "}\n"
+                  : "=f"((&k_words_cg0_f32[_pair * 2])[0]), "=f"((&k_words_cg0_f32[_pair * 2])[1])
+                  : "r"(k_words_cg0[_pair]));
+            }
+#pragma unroll
+            for (int dim_local_cg0 = 0; dim_local_cg0 < 8; dim_local_cg0++) {
+              int reg_cg0 = dim_half_cg0 * 8 + dim_local_cg0;
+              q_values_cg0[reg_cg0] = q_words_cg0_f32[dim_local_cg0];
+              k_values_cg0[reg_cg0] = k_words_cg0_f32[dim_local_cg0];
+            }
+#pragma unroll
+            for (int dim_pair_sq_cg0 = 0; dim_pair_sq_cg0 < 4; dim_pair_sq_cg0++) {
+              int even_reg_cg0 = dim_half_cg0 * 8 + dim_pair_sq_cg0 * 2;
+              int odd_reg_cg0 = even_reg_cg0 + 1;
+              float2 _f2_4 = make_float2(q_values_cg0[even_reg_cg0], k_values_cg0[even_reg_cg0]);
+              float2 qk_even_cg0 = _f2_4;
+              float2 _f2_5 = make_float2(q_values_cg0[odd_reg_cg0], k_values_cg0[odd_reg_cg0]);
+              float2 qk_odd_cg0 = _f2_5;
+              qk_sq_even_cg0 = fma_f32x2(qk_even_cg0, qk_even_cg0, qk_sq_even_cg0);
+              qk_sq_odd_cg0 = fma_f32x2(qk_odd_cg0, qk_odd_cg0, qk_sq_odd_cg0);
+            }
+          }
+          float q_sq_cg0 = qk_sq_even_cg0.x + qk_sq_odd_cg0.x;
+          float k_sq_cg0 = qk_sq_even_cg0.y + qk_sq_odd_cg0.y;
+          float _shfl_xor_0 = __shfl_xor_sync(0xFFFFFFFF, q_sq_cg0, 4);
+          q_sq_cg0 += _shfl_xor_0;
+          float _shfl_xor_1 = __shfl_xor_sync(0xFFFFFFFF, k_sq_cg0, 4);
+          k_sq_cg0 += _shfl_xor_1;
+          float _shfl_xor_2 = __shfl_xor_sync(0xFFFFFFFF, q_sq_cg0, 2);
+          q_sq_cg0 += _shfl_xor_2;
+          float _shfl_xor_3 = __shfl_xor_sync(0xFFFFFFFF, k_sq_cg0, 2);
+          k_sq_cg0 += _shfl_xor_3;
+          float _shfl_xor_4 = __shfl_xor_sync(0xFFFFFFFF, q_sq_cg0, 1);
+          q_sq_cg0 += _shfl_xor_4;
+          float _shfl_xor_5 = __shfl_xor_sync(0xFFFFFFFF, k_sq_cg0, 1);
+          k_sq_cg0 += _shfl_xor_5;
+          float _max_0 = max_noftz(q_sq_cg0, 1e-12f);
+          float _rsqrt_0 = rsqrtf(_max_0);
+          float q_inv_norm_cg0 = _rsqrt_0;
+          float _max_1 = max_noftz(k_sq_cg0, 1e-12f);
+          float _rsqrt_1 = rsqrtf(_max_1);
+          float k_inv_norm_cg0 = _rsqrt_1;
+          float exp_g_regs_cg0[16];
+          float exp_g_last_regs_cg0[16];
+#pragma unroll
+          for (int dim_half_prefix_cg0 = 0; dim_half_prefix_cg0 < 2; dim_half_prefix_cg0++) {
+            int dim_base_prefix_cg0 = dim_half_prefix_cg0 * 64 + decay_lane_cg0 * 8;
+#pragma unroll
+            for (int f32_group_cg0 = 0; f32_group_cg0 < 2; f32_group_cg0++) {
+              int f32_dim_base_cg0 = dim_base_prefix_cg0 + f32_group_cg0 * 4;
+              unsigned int exp_g_words_cg0[4];
+              unsigned int exp_g_last_words_cg0[4];
+              int segment_2 = f32_dim_base_cg0 / 32;
+              int segment_col_2 = f32_dim_base_cg0 - segment_2 * 32;
+              int swizzled_col_2 = segment_col_2 ^ (decay_row_cg0 & 7) * 4;
+              int exp_g_index_cg0 = raw_stage_cg0 * 16 * 128 + segment_2 * 16 * 32 +
+                                    decay_row_cg0 * 32 + swizzled_col_2;
+              int segment_0 = f32_dim_base_cg0 / 32;
+              int segment_col_1_1 = f32_dim_base_cg0 - segment_0 * 32;
+              int swizzled_col_2_1 = segment_col_1_1 ^ 28;
+              int exp_g_last_index_cg0 =
+                  raw_stage_cg0 * 16 * 128 + segment_0 * 16 * 32 + 480 + swizzled_col_2_1;
+              asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                           : "=r"(*reinterpret_cast<uint32_t*>(&exp_g_words_cg0[0])),
+                             "=r"(*reinterpret_cast<uint32_t*>(&exp_g_words_cg0[(0) + 1])),
+                             "=r"(*reinterpret_cast<uint32_t*>(&exp_g_words_cg0[(0) + 2])),
+                             "=r"(*reinterpret_cast<uint32_t*>(&exp_g_words_cg0[(0) + 3]))
+                           : "r"(smem_g_all_addr + (unsigned int)(exp_g_index_cg0 * 4)));
+              asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                           : "=r"(*reinterpret_cast<uint32_t*>(&exp_g_last_words_cg0[0])),
+                             "=r"(*reinterpret_cast<uint32_t*>(&exp_g_last_words_cg0[(0) + 1])),
+                             "=r"(*reinterpret_cast<uint32_t*>(&exp_g_last_words_cg0[(0) + 2])),
+                             "=r"(*reinterpret_cast<uint32_t*>(&exp_g_last_words_cg0[(0) + 3]))
+                           : "r"(smem_g_all_addr + (unsigned int)(exp_g_last_index_cg0 * 4)));
+#pragma unroll
+              for (int prefix_word_cg0 = 0; prefix_word_cg0 < 4; prefix_word_cg0++) {
+                int prefix_reg_cg0 = dim_half_prefix_cg0 * 8 + f32_group_cg0 * 4 + prefix_word_cg0;
+                exp_g_regs_cg0[prefix_reg_cg0] = __uint_as_float(exp_g_words_cg0[prefix_word_cg0]);
+                exp_g_last_regs_cg0[prefix_reg_cg0] =
+                    __uint_as_float(exp_g_last_words_cg0[prefix_word_cg0]);
+              }
+            }
+          }
+          __nv_bfloat162 k_inv_pairs_all_cg0[8];
+          float2 _f2_6 = make_float2(k_inv_norm_cg0, k_inv_norm_cg0);
+          float2 k_inv_norm_pair_cg0 = _f2_6;
+#pragma unroll
+          for (int dim_half_k_cg0 = 0; dim_half_k_cg0 < 2; dim_half_k_cg0++) {
+            int dim_base_k_cg0 = dim_half_k_cg0 * 64 + decay_lane_cg0 * 8;
+            unsigned int k_decay_words_cg0[4];
+#pragma unroll
+            for (int dim_pair_k_cg0 = 0; dim_pair_k_cg0 < 4; dim_pair_k_cg0++) {
+              int dim_local0_k_cg0 = dim_pair_k_cg0 * 2;
+              int dim_local1_k_cg0 = dim_local0_k_cg0 + 1;
+              int reg_k0_cg0 = dim_half_k_cg0 * 8 + dim_local0_k_cg0;
+              int reg_k1_cg0 = reg_k0_cg0 + 1;
+              float prefix_k0_cg0 = exp_g_regs_cg0[reg_k0_cg0];
+              float prefix_k1_cg0 = exp_g_regs_cg0[reg_k1_cg0];
+              float2 _f2_7 = make_float2(k_values_cg0[reg_k0_cg0], k_values_cg0[reg_k1_cg0]);
+              float2 k_norm_pair_cg0 = mul_f32x2(_f2_7, k_inv_norm_pair_cg0);
+              __nv_bfloat162 _bf16x2_0 =
+                  __float22bfloat162_rn(make_float2(k_norm_pair_cg0.x, k_norm_pair_cg0.y));
+              __nv_bfloat162 k_norm_bf16x2_cg0 = _bf16x2_0;
+              __nv_bfloat162 _bf16x2_1 =
+                  __float22bfloat162_rn(make_float2(prefix_k0_cg0, prefix_k1_cg0));
+              __nv_bfloat162 prefix_bf16x2_cg0 = _bf16x2_1;
+              float _rcp_0 = approx_rcp(prefix_k0_cg0);
+              float _rcp_1 = approx_rcp(prefix_k1_cg0);
+              __nv_bfloat162 _bf16x2_2 = __float22bfloat162_rn(make_float2(_rcp_0, _rcp_1));
+              __nv_bfloat162 reciprocal_bf16x2_cg0 = _bf16x2_2;
+              __nv_bfloat162 k_inv_bf16x2_cg0 = k_norm_bf16x2_cg0 * reciprocal_bf16x2_cg0;
+              __nv_bfloat162 k_decay_bf16x2_cg0 = k_norm_bf16x2_cg0 * prefix_bf16x2_cg0;
+              int k_word_cg0 = dim_half_k_cg0 * 4 + dim_pair_k_cg0;
+              k_inv_pairs_all_cg0[k_word_cg0] = k_inv_bf16x2_cg0;
+              k_decay_words_cg0[dim_pair_k_cg0] = __as_u32(k_decay_bf16x2_cg0);
+            }
+            if (dim_half_k_cg0 == 0) {
+              mbarrier_wait(decay_super_done_addr + (decay_stage_cg0) * 8, decay_free_phase_cg0);
+              mbarrier_wait(decay_tcgen_done_addr + (decay_stage_cg0) * 8, decay_free_phase_cg0);
+            }
+            asm volatile("st.shared.v4.b32 [%0], {%1,%2,%3,%4};" ::"r"(
+                             (smem_k_inv_addr + (unsigned int)(decay_stage_cg0 * 4096) +
+                              (unsigned int)(dim_base_k_cg0 / 64 * 2048 + decay_row_cg0 * 128 +
+                                                 dim_base_k_cg0 % 64 * 2 ^
+                                             (dim_base_k_cg0 / 64 * 2048 + decay_row_cg0 * 128 +
+                                                      dim_base_k_cg0 % 64 * 2 >>
+                                                  7 &
+                                              7) << 4))),
+                         "r"(__as_u32(k_inv_pairs_all_cg0[dim_half_k_cg0 * 4])),
+                         "r"(__as_u32(k_inv_pairs_all_cg0[dim_half_k_cg0 * 4 + 1])),
+                         "r"(__as_u32(k_inv_pairs_all_cg0[dim_half_k_cg0 * 4 + 2])),
+                         "r"(__as_u32(k_inv_pairs_all_cg0[dim_half_k_cg0 * 4 + 3]))
+                         : "memory");
+            asm volatile("st.shared.v4.b32 [%0], {%1,%2,%3,%4};" ::"r"(
+                             (smem_k_decay_addr + (unsigned int)(decay_stage_cg0 * 4096) +
+                              (unsigned int)(dim_base_k_cg0 / 64 * 2048 + decay_row_cg0 * 128 +
+                                                 dim_base_k_cg0 % 64 * 2 ^
+                                             (dim_base_k_cg0 / 64 * 2048 + decay_row_cg0 * 128 +
+                                                      dim_base_k_cg0 % 64 * 2 >>
+                                                  7 &
+                                              7) << 4))),
+                         "r"(k_decay_words_cg0[0]), "r"(k_decay_words_cg0[1]),
+                         "r"(k_decay_words_cg0[2]), "r"(k_decay_words_cg0[3])
+                         : "memory");
+          }
+          asm volatile("fence.proxy.async.shared::cta;" ::: "memory");
+          mbarrier_arrive(k_decay_inv_ready_addr + (decay_stage_cg0) * 8);
+          mbarrier_arrive(q_done_addr + (raw_stage_cg0) * 8);
+          mbarrier_arrive(k_done_addr + (raw_stage_cg0) * 8);
+          mbarrier_arrive(g_done_addr + (raw_stage_cg0) * 8);
+          float2 _f2_8 = make_float2(q_inv_norm_cg0, q_inv_norm_cg0);
+          float2 q_inv_pair_cg0 = _f2_8;
+#pragma unroll
+          for (int dim_half_q_cg0 = 0; dim_half_q_cg0 < 2; dim_half_q_cg0++) {
+            int dim_base_q_cg0 = dim_half_q_cg0 * 64 + decay_lane_cg0 * 8;
+            unsigned int q_decay_words_cg0[4];
+#pragma unroll
+            for (int dim_pair_q_cg0 = 0; dim_pair_q_cg0 < 4; dim_pair_q_cg0++) {
+              int dim_local0_q_cg0 = dim_pair_q_cg0 * 2;
+              int dim_local1_q_cg0 = dim_local0_q_cg0 + 1;
+              int reg_q0_cg0 = dim_half_q_cg0 * 8 + dim_local0_q_cg0;
+              int reg_q1_cg0 = reg_q0_cg0 + 1;
+              float2 _f2_9 = make_float2(q_values_cg0[reg_q0_cg0], q_values_cg0[reg_q1_cg0]);
+              float2 q_norm_pair_cg0 = mul_f32x2(_f2_9, q_inv_pair_cg0);
+              __nv_bfloat162 _bf16x2_3 =
+                  __float22bfloat162_rn(make_float2(q_norm_pair_cg0.x, q_norm_pair_cg0.y));
+              __nv_bfloat162 q_norm_bf16x2_cg0 = _bf16x2_3;
+              __nv_bfloat162 _bf16x2_4 = __float22bfloat162_rn(
+                  make_float2(exp_g_regs_cg0[reg_q0_cg0], exp_g_regs_cg0[reg_q1_cg0]));
+              __nv_bfloat162 q_prefix_bf16x2_cg0 = _bf16x2_4;
+              __nv_bfloat162 q_decay_bf16x2_cg0 = q_norm_bf16x2_cg0 * q_prefix_bf16x2_cg0;
+              q_decay_words_cg0[dim_pair_q_cg0] = __as_u32(q_decay_bf16x2_cg0);
+            }
+            asm volatile("st.shared.v4.b32 [%0], {%1,%2,%3,%4};" ::"r"(
+                             (smem_q_decay_addr + (unsigned int)(decay_stage_cg0 * 4096) +
+                              (unsigned int)(dim_base_q_cg0 / 64 * 2048 + decay_row_cg0 * 128 +
+                                                 dim_base_q_cg0 % 64 * 2 ^
+                                             (dim_base_q_cg0 / 64 * 2048 + decay_row_cg0 * 128 +
+                                                      dim_base_q_cg0 % 64 * 2 >>
+                                                  7 &
+                                              7) << 4))),
+                         "r"(q_decay_words_cg0[0]), "r"(q_decay_words_cg0[1]),
+                         "r"(q_decay_words_cg0[2]), "r"(q_decay_words_cg0[3])
+                         : "memory");
+          }
+          mbarrier_wait(k_restore_done_addr + (decay_stage_cg0) * 8, decay_free_phase_cg0);
+#pragma unroll
+          for (int dim_half_restore_cg0 = 0; dim_half_restore_cg0 < 2; dim_half_restore_cg0++) {
+            int dim_base_restore_cg0 = dim_half_restore_cg0 * 64 + decay_lane_cg0 * 8;
+            unsigned int k_restore_words_cg0[4];
+#pragma unroll
+            for (int dim_pair_restore_cg0 = 0; dim_pair_restore_cg0 < 4; dim_pair_restore_cg0++) {
+              int dim_local0_restore_cg0 = dim_pair_restore_cg0 * 2;
+              int dim_local1_restore_cg0 = dim_local0_restore_cg0 + 1;
+              int reg_restore0_cg0 = dim_half_restore_cg0 * 8 + dim_local0_restore_cg0;
+              int reg_restore1_cg0 = reg_restore0_cg0 + 1;
+              int restore_word_cg0 = dim_half_restore_cg0 * 4 + dim_pair_restore_cg0;
+              __nv_bfloat162 _bf16x2_5 = __float22bfloat162_rn(make_float2(
+                  exp_g_last_regs_cg0[reg_restore0_cg0], exp_g_last_regs_cg0[reg_restore1_cg0]));
+              __nv_bfloat162 k_restore_bf16x2_cg0 =
+                  k_inv_pairs_all_cg0[restore_word_cg0] * _bf16x2_5;
+              k_restore_words_cg0[dim_pair_restore_cg0] = __as_u32(k_restore_bf16x2_cg0);
+            }
+            asm volatile(
+                "st.shared.v4.b32 [%0], {%1,%2,%3,%4};" ::"r"(
+                    (smem_k_restore_addr + (unsigned int)(decay_stage_cg0 * 4096) +
+                     (unsigned int)(dim_base_restore_cg0 / 64 * 2048 + decay_row_cg0 * 128 +
+                                        dim_base_restore_cg0 % 64 * 2 ^
+                                    (dim_base_restore_cg0 / 64 * 2048 + decay_row_cg0 * 128 +
+                                             dim_base_restore_cg0 % 64 * 2 >>
+                                         7 &
+                                     7) << 4))),
+                "r"(k_restore_words_cg0[0]), "r"(k_restore_words_cg0[1]),
+                "r"(k_restore_words_cg0[2]), "r"(k_restore_words_cg0[3])
+                : "memory");
+          }
+          asm volatile("fence.proxy.async.shared::cta;" ::: "memory");
+          mbarrier_arrive(qk_scale_ready_addr + (diag_stage_cg0) * 8);
+          raw_stage_cg0 += 2;
+          if (raw_stage_cg0 >= 5) {
+            raw_stage_cg0 -= 5;
+          }
+          raw_bar_stage_cg0 += 2;
+          if (raw_bar_stage_cg0 >= 6) {
+            raw_bar_stage_cg0 -= 6;
+            raw_bar_phase_cg0 ^= 1;
+          }
+          decay_free_phase_cg0 ^= 1;
+          diag_stage_cg0 += 2;
+          if (diag_stage_cg0 >= 4) {
+            diag_stage_cg0 -= 4;
+            diag_free_phase_cg0 ^= 1;
+          }
+        }
+        cumulative_chunk_cg0 += chunks_cg0;
+      }
+      if (elect_sync()) {
+        mbarrier_arrive(consumers_done_addr);
+      }
+    }
+  }
+  // ---- Role: cg1 ----
+  if (warp >= 8 && warp <= 11) {
+    asm volatile("setmaxnreg.inc.sync.aligned.u32 136;");
+    {  // cg1_main
+      unsigned int sched_stage_cg1 = 0;
+      int cumulative_chunk_cg1 = 0;
+      int warp_in_wg = warp % 4;
+      int value_row_cg1 = warp_in_wg * 32 + lane;
+      int value_dim_base_cg1 = warp_in_wg * 32;
+      const int tmem_row_base_cg1 = warp_in_wg * 32 << 16;
+      int ov_token_cg1 = lane / 16 * 8 + (lane & 7);
+      int ov_col_cg1 = (lane / 8 & 1) * 8;
+      unsigned int _phase_sched_ready_1 = 0;
+#pragma unroll 1
+      for (int __1 = 0; __1 < total_work_items + 1; __1++) {
+        mbarrier_wait(sched_ready_addr + (sched_stage_cg1) * 8, _phase_sched_ready_1);
+        unsigned int slot_1[1];
+        asm volatile("ld.shared.b32 %0, [%1];"
+                     : "=r"(*reinterpret_cast<uint32_t*>(&slot_1[0]))
+                     : "r"(sched_slot_addr + sched_stage_cg1 * 4));
+        unsigned int tile_cg1 = slot_1[0];
+        if (elect_sync()) {
+          mbarrier_arrive(sched_done_addr + (sched_stage_cg1) * 8);
+        }
+        sched_stage_cg1 += 1;
+        if (sched_stage_cg1 == 8) {
+          sched_stage_cg1 = 0;
+          _phase_sched_ready_1 ^= 1;
+        }
+        if (tile_cg1 >= (unsigned int)total_work_items) {
+          break;
+        }
+        int item_base_cg1 = (int)tile_cg1 * 8;
+        int _vec_load_4[4];
+        {
+          int4 _iv4 = *reinterpret_cast<const int4*>(work_items + item_base_cg1);
+          _vec_load_4[0 + 0] = _iv4.x;
+          _vec_load_4[0 + 1] = _iv4.y;
+          _vec_load_4[0 + 2] = _iv4.z;
+          _vec_load_4[0 + 3] = _iv4.w;
+        }
+        int _vec_load_5[4];
+        {
+          int4 _iv4 = *reinterpret_cast<const int4*>(work_items + item_base_cg1 + 4);
+          _vec_load_5[0 + 0] = _iv4.x;
+          _vec_load_5[0 + 1] = _iv4.y;
+          _vec_load_5[0 + 2] = _iv4.z;
+          _vec_load_5[0 + 3] = _iv4.w;
+        }
+        int seq_cg1 = _vec_load_4[0];
+        int head_cg1 = _vec_load_4[1];
+        int wstart_cg1 = _vec_load_4[2];
+        int wend_cg1 = _vec_load_4[3];
+        int cstart_cg1 = _vec_load_5[0];
+        int chunks_cg1 = wend_cg1 - cstart_cg1;
+        long long state_base_cg1 =
+            (((long long)seq_cg1 * (long long)num_heads + (long long)head_cg1) * 128 +
+             (long long)value_row_cg1) *
+            128;
+#pragma unroll
+        for (int state_block_cg1 = 0; state_block_cg1 < 4; state_block_cg1++) {
+          float state_init_cg1[32];
+          state_init_cg1[0] = 0.0f;
+          state_init_cg1[1] = 0.0f;
+          state_init_cg1[2] = 0.0f;
+          state_init_cg1[3] = 0.0f;
+          state_init_cg1[4] = 0.0f;
+          state_init_cg1[5] = 0.0f;
+          state_init_cg1[6] = 0.0f;
+          state_init_cg1[7] = 0.0f;
+          state_init_cg1[8] = 0.0f;
+          state_init_cg1[9] = 0.0f;
+          state_init_cg1[10] = 0.0f;
+          state_init_cg1[11] = 0.0f;
+          state_init_cg1[12] = 0.0f;
+          state_init_cg1[13] = 0.0f;
+          state_init_cg1[14] = 0.0f;
+          state_init_cg1[15] = 0.0f;
+          state_init_cg1[16] = 0.0f;
+          state_init_cg1[17] = 0.0f;
+          state_init_cg1[18] = 0.0f;
+          state_init_cg1[19] = 0.0f;
+          state_init_cg1[20] = 0.0f;
+          state_init_cg1[21] = 0.0f;
+          state_init_cg1[22] = 0.0f;
+          state_init_cg1[23] = 0.0f;
+          state_init_cg1[24] = 0.0f;
+          state_init_cg1[25] = 0.0f;
+          state_init_cg1[26] = 0.0f;
+          state_init_cg1[27] = 0.0f;
+          state_init_cg1[28] = 0.0f;
+          state_init_cg1[29] = 0.0f;
+          state_init_cg1[30] = 0.0f;
+          state_init_cg1[31] = 0.0f;
+          if (USE_INITIAL_STATE != 0 && cstart_cg1 == 0) {
+#pragma unroll
+            for (int state_vec_cg1 = 0; state_vec_cg1 < 4; state_vec_cg1++) {
+              {
+                unsigned _ldv8_0_0;
+                unsigned _ldv8_0_1;
+                unsigned _ldv8_0_2;
+                unsigned _ldv8_0_3;
+                unsigned _ldv8_0_4;
+                unsigned _ldv8_0_5;
+                unsigned _ldv8_0_6;
+                unsigned _ldv8_0_7;
+                asm volatile(
+                    "ld.global.v8.b32 {%0, %1, %2, %3, %4, %5, %6, %7}, [%8];"
+                    : "=r"(_ldv8_0_0), "=r"(_ldv8_0_1), "=r"(_ldv8_0_2), "=r"(_ldv8_0_3),
+                      "=r"(_ldv8_0_4), "=r"(_ldv8_0_5), "=r"(_ldv8_0_6), "=r"(_ldv8_0_7)
+                    : "l"((const void*)(initial_state +
+                                        (state_base_cg1 + (long long)(state_block_cg1 * 32) +
+                                         (long long)(state_vec_cg1 * 8))))
+                    : "memory");
+                state_init_cg1[state_vec_cg1 * 8 + 0] = __uint_as_float(_ldv8_0_0);
+                state_init_cg1[state_vec_cg1 * 8 + 1] = __uint_as_float(_ldv8_0_1);
+                state_init_cg1[state_vec_cg1 * 8 + 2] = __uint_as_float(_ldv8_0_2);
+                state_init_cg1[state_vec_cg1 * 8 + 3] = __uint_as_float(_ldv8_0_3);
+                state_init_cg1[state_vec_cg1 * 8 + 4] = __uint_as_float(_ldv8_0_4);
+                state_init_cg1[state_vec_cg1 * 8 + 5] = __uint_as_float(_ldv8_0_5);
+                state_init_cg1[state_vec_cg1 * 8 + 6] = __uint_as_float(_ldv8_0_6);
+                state_init_cg1[state_vec_cg1 * 8 + 7] = __uint_as_float(_ldv8_0_7);
+              }
+            }
+#pragma unroll
+            for (int state_elem_cg1 = 0; state_elem_cg1 < 32; state_elem_cg1++) {
+              __nv_bfloat16 _cvt_bf16_1 = __float2bfloat16(state_init_cg1[state_elem_cg1]);
+              float _cvt_f32_2 = __bfloat162float(_cvt_bf16_1);
+              state_init_cg1[state_elem_cg1] = _cvt_f32_2;
+            }
+          }
+          tmem_st_x32_f32(
+              taddr + (unsigned int)tmem_row_base_cg1 + (unsigned int)(state_block_cg1 * 32),
+              state_init_cg1);
+        }
+        asm volatile("tcgen05.wait::st.sync.aligned;" ::: "memory");
+        if (chunks_cg1 > 0) {
+          int cumulative_cg1 = cumulative_chunk_cg1;
+          unsigned int raw_stage_cg1 = (unsigned int)(cumulative_cg1 % 5);
+          unsigned int raw_bar_stage_cg1 = (unsigned int)(cumulative_cg1 % 6);
+          unsigned int o_stage_cg1 = (unsigned int)(cumulative_cg1 % 2);
+          unsigned int checkpoint_stage_cg1 = (unsigned int)(cumulative_cg1 % 2);
+          unsigned int state_phase_cg1 = (unsigned int)(cumulative_cg1 & 1);
+          float _tmem_load_0[128];
+          tmem_ld_x16(&_tmem_load_0[0], taddr + (unsigned int)tmem_row_base_cg1);
+          tmem_ld_x16(&_tmem_load_0[16], taddr + (unsigned int)tmem_row_base_cg1 + 16);
+          tmem_ld_x16(&_tmem_load_0[32], taddr + (unsigned int)tmem_row_base_cg1 + 32);
+          tmem_ld_x16(&_tmem_load_0[48], taddr + (unsigned int)tmem_row_base_cg1 + 48);
+          tmem_ld_x16(&_tmem_load_0[64], taddr + (unsigned int)tmem_row_base_cg1 + 64);
+          tmem_ld_x16(&_tmem_load_0[80], taddr + (unsigned int)tmem_row_base_cg1 + 80);
+          tmem_ld_x16(&_tmem_load_0[96], taddr + (unsigned int)tmem_row_base_cg1 + 96);
+          tmem_ld_x16(&_tmem_load_0[112], taddr + (unsigned int)tmem_row_base_cg1 + 112);
+          asm volatile("tcgen05.wait::ld.sync.aligned;" ::: "memory");
+          {
+            mbarrier_wait(checkpoint_done_addr + (checkpoint_stage_cg1) * 8,
+                          (unsigned int)(cumulative_cg1 / 2 + 1 & 1));
+          }
+          unsigned int state_words_cg1[8];
+#pragma unroll
+          for (int _lp = 0; _lp < 8; _lp++) {
+            __nv_bfloat162 _bf2 = __float22bfloat162_rn(
+                make_float2(_tmem_load_0[_lp * 2 + 0], _tmem_load_0[_lp * 2 + 1 + 0]));
+            state_words_cg1[_lp] = *(uint32_t*)&_bf2;
+          }
+          tmem_st_x8_u32(taddr + 128 + (unsigned int)tmem_row_base_cg1,
+                         (const uint32_t*)state_words_cg1);
+          {
+            asm volatile(
+                "st.shared.v4.b32 [%0], {%1,%2,%3,%4};" ::"r"(
+                    (smem_checkpoint_addr + checkpoint_stage_cg1 * 32768 +
+                     (unsigned int)(value_row_cg1 * 128 ^ (value_row_cg1 * 128 >> 7 & 7) << 4))),
+                "r"(state_words_cg1[0]), "r"(state_words_cg1[1]), "r"(state_words_cg1[2]),
+                "r"(state_words_cg1[3])
+                : "memory");
+            asm volatile("st.shared.v4.b32 [%0], {%1,%2,%3,%4};" ::"r"(
+                             (smem_checkpoint_addr + checkpoint_stage_cg1 * 32768 +
+                              (unsigned int)(value_row_cg1 * 128 + 16 ^
+                                             (value_row_cg1 * 128 + 16 >> 7 & 7) << 4))),
+                         "r"(state_words_cg1[4]), "r"(state_words_cg1[5]), "r"(state_words_cg1[6]),
+                         "r"(state_words_cg1[7])
+                         : "memory");
+          }
+#pragma unroll
+          for (int _lp = 0; _lp < 8; _lp++) {
+            __nv_bfloat162 _bf2 = __float22bfloat162_rn(
+                make_float2(_tmem_load_0[_lp * 2 + 16], _tmem_load_0[_lp * 2 + 1 + 16]));
+            state_words_cg1[_lp] = *(uint32_t*)&_bf2;
+          }
+          tmem_st_x8_u32(taddr + 128 + (unsigned int)tmem_row_base_cg1 + 8,
+                         (const uint32_t*)state_words_cg1);
+          {
+            asm volatile("st.shared.v4.b32 [%0], {%1,%2,%3,%4};" ::"r"(
+                             (smem_checkpoint_addr + checkpoint_stage_cg1 * 32768 +
+                              (unsigned int)(value_row_cg1 * 128 + 32 ^
+                                             (value_row_cg1 * 128 + 32 >> 7 & 7) << 4))),
+                         "r"(state_words_cg1[0]), "r"(state_words_cg1[1]), "r"(state_words_cg1[2]),
+                         "r"(state_words_cg1[3])
+                         : "memory");
+            asm volatile("st.shared.v4.b32 [%0], {%1,%2,%3,%4};" ::"r"(
+                             (smem_checkpoint_addr + checkpoint_stage_cg1 * 32768 +
+                              (unsigned int)(value_row_cg1 * 128 + 48 ^
+                                             (value_row_cg1 * 128 + 48 >> 7 & 7) << 4))),
+                         "r"(state_words_cg1[4]), "r"(state_words_cg1[5]), "r"(state_words_cg1[6]),
+                         "r"(state_words_cg1[7])
+                         : "memory");
+          }
+#pragma unroll
+          for (int _lp = 0; _lp < 8; _lp++) {
+            __nv_bfloat162 _bf2 = __float22bfloat162_rn(
+                make_float2(_tmem_load_0[_lp * 2 + 32], _tmem_load_0[_lp * 2 + 1 + 32]));
+            state_words_cg1[_lp] = *(uint32_t*)&_bf2;
+          }
+          tmem_st_x8_u32(taddr + 128 + (unsigned int)tmem_row_base_cg1 + 16,
+                         (const uint32_t*)state_words_cg1);
+          {
+            asm volatile("st.shared.v4.b32 [%0], {%1,%2,%3,%4};" ::"r"(
+                             (smem_checkpoint_addr + checkpoint_stage_cg1 * 32768 +
+                              (unsigned int)(value_row_cg1 * 128 + 64 ^
+                                             (value_row_cg1 * 128 + 64 >> 7 & 7) << 4))),
+                         "r"(state_words_cg1[0]), "r"(state_words_cg1[1]), "r"(state_words_cg1[2]),
+                         "r"(state_words_cg1[3])
+                         : "memory");
+            asm volatile("st.shared.v4.b32 [%0], {%1,%2,%3,%4};" ::"r"(
+                             (smem_checkpoint_addr + checkpoint_stage_cg1 * 32768 +
+                              (unsigned int)(value_row_cg1 * 128 + 80 ^
+                                             (value_row_cg1 * 128 + 80 >> 7 & 7) << 4))),
+                         "r"(state_words_cg1[4]), "r"(state_words_cg1[5]), "r"(state_words_cg1[6]),
+                         "r"(state_words_cg1[7])
+                         : "memory");
+          }
+#pragma unroll
+          for (int _lp = 0; _lp < 8; _lp++) {
+            __nv_bfloat162 _bf2 = __float22bfloat162_rn(
+                make_float2(_tmem_load_0[_lp * 2 + 48], _tmem_load_0[_lp * 2 + 1 + 48]));
+            state_words_cg1[_lp] = *(uint32_t*)&_bf2;
+          }
+          tmem_st_x8_u32(taddr + 128 + (unsigned int)tmem_row_base_cg1 + 24,
+                         (const uint32_t*)state_words_cg1);
+          {
+            asm volatile("st.shared.v4.b32 [%0], {%1,%2,%3,%4};" ::"r"(
+                             (smem_checkpoint_addr + checkpoint_stage_cg1 * 32768 +
+                              (unsigned int)(value_row_cg1 * 128 + 96 ^
+                                             (value_row_cg1 * 128 + 96 >> 7 & 7) << 4))),
+                         "r"(state_words_cg1[0]), "r"(state_words_cg1[1]), "r"(state_words_cg1[2]),
+                         "r"(state_words_cg1[3])
+                         : "memory");
+            asm volatile("st.shared.v4.b32 [%0], {%1,%2,%3,%4};" ::"r"(
+                             (smem_checkpoint_addr + checkpoint_stage_cg1 * 32768 +
+                              (unsigned int)(value_row_cg1 * 128 + 112 ^
+                                             (value_row_cg1 * 128 + 112 >> 7 & 7) << 4))),
+                         "r"(state_words_cg1[4]), "r"(state_words_cg1[5]), "r"(state_words_cg1[6]),
+                         "r"(state_words_cg1[7])
+                         : "memory");
+          }
+#pragma unroll
+          for (int _lp = 0; _lp < 8; _lp++) {
+            __nv_bfloat162 _bf2 = __float22bfloat162_rn(
+                make_float2(_tmem_load_0[_lp * 2 + 64], _tmem_load_0[_lp * 2 + 1 + 64]));
+            state_words_cg1[_lp] = *(uint32_t*)&_bf2;
+          }
+          tmem_st_x8_u32(taddr + 128 + (unsigned int)tmem_row_base_cg1 + 32,
+                         (const uint32_t*)state_words_cg1);
+          {
+            asm volatile("st.shared.v4.b32 [%0], {%1,%2,%3,%4};" ::"r"(
+                             (smem_checkpoint_addr + checkpoint_stage_cg1 * 32768 +
+                              (unsigned int)(16384 + value_row_cg1 * 128 ^
+                                             (16384 + value_row_cg1 * 128 >> 7 & 7) << 4))),
+                         "r"(state_words_cg1[0]), "r"(state_words_cg1[1]), "r"(state_words_cg1[2]),
+                         "r"(state_words_cg1[3])
+                         : "memory");
+            asm volatile("st.shared.v4.b32 [%0], {%1,%2,%3,%4};" ::"r"(
+                             (smem_checkpoint_addr + checkpoint_stage_cg1 * 32768 +
+                              (unsigned int)(16384 + value_row_cg1 * 128 + 16 ^
+                                             (16384 + value_row_cg1 * 128 + 16 >> 7 & 7) << 4))),
+                         "r"(state_words_cg1[4]), "r"(state_words_cg1[5]), "r"(state_words_cg1[6]),
+                         "r"(state_words_cg1[7])
+                         : "memory");
+          }
+#pragma unroll
+          for (int _lp = 0; _lp < 8; _lp++) {
+            __nv_bfloat162 _bf2 = __float22bfloat162_rn(
+                make_float2(_tmem_load_0[_lp * 2 + 80], _tmem_load_0[_lp * 2 + 1 + 80]));
+            state_words_cg1[_lp] = *(uint32_t*)&_bf2;
+          }
+          tmem_st_x8_u32(taddr + 128 + (unsigned int)tmem_row_base_cg1 + 40,
+                         (const uint32_t*)state_words_cg1);
+          {
+            asm volatile("st.shared.v4.b32 [%0], {%1,%2,%3,%4};" ::"r"(
+                             (smem_checkpoint_addr + checkpoint_stage_cg1 * 32768 +
+                              (unsigned int)(16384 + value_row_cg1 * 128 + 32 ^
+                                             (16384 + value_row_cg1 * 128 + 32 >> 7 & 7) << 4))),
+                         "r"(state_words_cg1[0]), "r"(state_words_cg1[1]), "r"(state_words_cg1[2]),
+                         "r"(state_words_cg1[3])
+                         : "memory");
+            asm volatile("st.shared.v4.b32 [%0], {%1,%2,%3,%4};" ::"r"(
+                             (smem_checkpoint_addr + checkpoint_stage_cg1 * 32768 +
+                              (unsigned int)(16384 + value_row_cg1 * 128 + 48 ^
+                                             (16384 + value_row_cg1 * 128 + 48 >> 7 & 7) << 4))),
+                         "r"(state_words_cg1[4]), "r"(state_words_cg1[5]), "r"(state_words_cg1[6]),
+                         "r"(state_words_cg1[7])
+                         : "memory");
+          }
+#pragma unroll
+          for (int _lp = 0; _lp < 8; _lp++) {
+            __nv_bfloat162 _bf2 = __float22bfloat162_rn(
+                make_float2(_tmem_load_0[_lp * 2 + 96], _tmem_load_0[_lp * 2 + 1 + 96]));
+            state_words_cg1[_lp] = *(uint32_t*)&_bf2;
+          }
+          tmem_st_x8_u32(taddr + 128 + (unsigned int)tmem_row_base_cg1 + 48,
+                         (const uint32_t*)state_words_cg1);
+          {
+            asm volatile("st.shared.v4.b32 [%0], {%1,%2,%3,%4};" ::"r"(
+                             (smem_checkpoint_addr + checkpoint_stage_cg1 * 32768 +
+                              (unsigned int)(16384 + value_row_cg1 * 128 + 64 ^
+                                             (16384 + value_row_cg1 * 128 + 64 >> 7 & 7) << 4))),
+                         "r"(state_words_cg1[0]), "r"(state_words_cg1[1]), "r"(state_words_cg1[2]),
+                         "r"(state_words_cg1[3])
+                         : "memory");
+            asm volatile("st.shared.v4.b32 [%0], {%1,%2,%3,%4};" ::"r"(
+                             (smem_checkpoint_addr + checkpoint_stage_cg1 * 32768 +
+                              (unsigned int)(16384 + value_row_cg1 * 128 + 80 ^
+                                             (16384 + value_row_cg1 * 128 + 80 >> 7 & 7) << 4))),
+                         "r"(state_words_cg1[4]), "r"(state_words_cg1[5]), "r"(state_words_cg1[6]),
+                         "r"(state_words_cg1[7])
+                         : "memory");
+          }
+#pragma unroll
+          for (int _lp = 0; _lp < 8; _lp++) {
+            __nv_bfloat162 _bf2 = __float22bfloat162_rn(
+                make_float2(_tmem_load_0[_lp * 2 + 112], _tmem_load_0[_lp * 2 + 1 + 112]));
+            state_words_cg1[_lp] = *(uint32_t*)&_bf2;
+          }
+          tmem_st_x8_u32(taddr + 128 + (unsigned int)tmem_row_base_cg1 + 56,
+                         (const uint32_t*)state_words_cg1);
+          {
+            asm volatile("st.shared.v4.b32 [%0], {%1,%2,%3,%4};" ::"r"(
+                             (smem_checkpoint_addr + checkpoint_stage_cg1 * 32768 +
+                              (unsigned int)(16384 + value_row_cg1 * 128 + 96 ^
+                                             (16384 + value_row_cg1 * 128 + 96 >> 7 & 7) << 4))),
+                         "r"(state_words_cg1[0]), "r"(state_words_cg1[1]), "r"(state_words_cg1[2]),
+                         "r"(state_words_cg1[3])
+                         : "memory");
+            asm volatile("st.shared.v4.b32 [%0], {%1,%2,%3,%4};" ::"r"(
+                             (smem_checkpoint_addr + checkpoint_stage_cg1 * 32768 +
+                              (unsigned int)(16384 + value_row_cg1 * 128 + 112 ^
+                                             (16384 + value_row_cg1 * 128 + 112 >> 7 & 7) << 4))),
+                         "r"(state_words_cg1[4]), "r"(state_words_cg1[5]), "r"(state_words_cg1[6]),
+                         "r"(state_words_cg1[7])
+                         : "memory");
+          }
+          asm volatile("tcgen05.wait::st.sync.aligned;" ::: "memory");
+          mbarrier_arrive(state_inp_ready_addr);
+          {
+            asm volatile("fence.proxy.async.shared::cta;" ::: "memory");
+            mbarrier_arrive(state_read_done_addr);
+            mbarrier_arrive(checkpoint_ready_addr + (checkpoint_stage_cg1) * 8);
+          }
+          mbarrier_wait(v_ready_addr + (raw_bar_stage_cg1) * 8,
+                        (unsigned int)(cumulative_cg1 / 6 & 1));
+          mbarrier_wait(beta_ready_addr + (raw_bar_stage_cg1) * 8,
+                        (unsigned int)(cumulative_cg1 / 6 & 1));
+          mbarrier_wait(state_k_ready_addr, state_phase_cg1);
+          float _tmem_load_3[8];
+          asm volatile(
+              "tcgen05.ld.sync.aligned.16x256b.x2.b32"
+              " {%0, %1, %2, %3, %4, %5, %6, %7}, [%8];"
+              : "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[0])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[1])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[2])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[3])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[4])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[5])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[6])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[7]))
+              : "r"(taddr + 224 + (unsigned int)tmem_row_base_cg1));
+          float _tmem_load_4[8];
+          asm volatile(
+              "tcgen05.ld.sync.aligned.16x256b.x2.b32"
+              " {%0, %1, %2, %3, %4, %5, %6, %7}, [%8];"
+              : "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_4[0])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_4[1])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_4[2])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_4[3])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_4[4])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_4[5])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_4[6])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_4[7]))
+              : "r"(taddr + 224 + (unsigned int)tmem_row_base_cg1 + 1048576));
+          unsigned int raw_v_words_lo_cg1[4];
+          unsigned int raw_v_words_hi_cg1[4];
+          int segment_3 = (value_dim_base_cg1 + ov_col_cg1) / 64;
+          int segment_col_3 = value_dim_base_cg1 + ov_col_cg1 - segment_3 * 64;
+          int swizzled_col_3 = segment_col_3 ^ (ov_token_cg1 & 7) * 8;
+          asm volatile("ldmatrix.sync.aligned.m8n8.x4.trans.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                       : "=r"(raw_v_words_lo_cg1[0]), "=r"(raw_v_words_lo_cg1[1]),
+                         "=r"(raw_v_words_lo_cg1[2]), "=r"(raw_v_words_lo_cg1[3])
+                       : "r"(smem_v_all_addr +
+                             (raw_stage_cg1 * 16 * 128 + (unsigned int)(segment_3 * 16 * 64) +
+                              (unsigned int)(ov_token_cg1 * 64) + (unsigned int)swizzled_col_3) *
+                                 2)
+                       : "memory");
+          int segment_0_1 = (value_dim_base_cg1 + 16 + ov_col_cg1) / 64;
+          int segment_col_1_2 = value_dim_base_cg1 + 16 + ov_col_cg1 - segment_0_1 * 64;
+          int swizzled_col_2_2 = segment_col_1_2 ^ (ov_token_cg1 & 7) * 8;
+          asm volatile("ldmatrix.sync.aligned.m8n8.x4.trans.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                       : "=r"(raw_v_words_hi_cg1[0]), "=r"(raw_v_words_hi_cg1[1]),
+                         "=r"(raw_v_words_hi_cg1[2]), "=r"(raw_v_words_hi_cg1[3])
+                       : "r"(smem_v_all_addr +
+                             (raw_stage_cg1 * 16 * 128 + (unsigned int)(segment_0_1 * 16 * 64) +
+                              (unsigned int)(ov_token_cg1 * 64) + (unsigned int)swizzled_col_2_2) *
+                                 2)
+                       : "memory");
+          asm volatile("tcgen05.wait::ld.sync.aligned;" ::: "memory");
+          __nv_bfloat162 beta_pairs_cg1[4];
+#pragma unroll
+          for (int beta_reg_cg1 = 0; beta_reg_cg1 < 4; beta_reg_cg1++) {
+            int beta_packed_col_cg1 = beta_reg_cg1 / 2 * 4 + (lane & 3);
+            int beta_token0_cg1 = beta_packed_col_cg1 * 2;
+            int beta_token1_cg1 = beta_token0_cg1 + 1;
+            __nv_bfloat16 beta0_cg1 = smem_beta_all[(int)raw_bar_stage_cg1 * 16 + beta_token0_cg1];
+            __nv_bfloat16 beta1_cg1 = smem_beta_all[(int)raw_bar_stage_cg1 * 16 + beta_token1_cg1];
+            float _cvt_f32_3 = __bfloat162float(beta0_cg1);
+            float _cvt_f32_4 = __bfloat162float(beta1_cg1);
+            __nv_bfloat162 _bf16x2_6 = __float22bfloat162_rn(make_float2(_cvt_f32_3, _cvt_f32_4));
+            beta_pairs_cg1[beta_reg_cg1] = _bf16x2_6;
+          }
+          unsigned int y_words_lo_cg1[4];
+          unsigned int y_words_hi_cg1[4];
+#pragma unroll
+          for (int rhs_reg_cg1 = 0; rhs_reg_cg1 < 4; rhs_reg_cg1++) {
+            int rhs_raw_matrix_cg1 = rhs_reg_cg1;
+            int rhs_frag_pair_cg1 = rhs_reg_cg1 * 2;
+            __nv_bfloat162 _bf16x2_7 = __float22bfloat162_rn(
+                make_float2(_tmem_load_3[rhs_frag_pair_cg1], _tmem_load_3[rhs_frag_pair_cg1 + 1]));
+            __nv_bfloat162 _bf16x2_8 = __float22bfloat162_rn(
+                make_float2(_tmem_load_4[rhs_frag_pair_cg1], _tmem_load_4[rhs_frag_pair_cg1 + 1]));
+            uint32_t _bf16x2_sub_0;
+            asm volatile("sub.rn.bf16x2 %0, %1, %2;"
+                         : "=r"(_bf16x2_sub_0)
+                         : "r"(raw_v_words_lo_cg1[rhs_raw_matrix_cg1]), "r"(__as_u32(_bf16x2_7)));
+            uint32_t _bf16x2_sub_1;
+            asm volatile("sub.rn.bf16x2 %0, %1, %2;"
+                         : "=r"(_bf16x2_sub_1)
+                         : "r"(raw_v_words_hi_cg1[rhs_raw_matrix_cg1]), "r"(__as_u32(_bf16x2_8)));
+            __nv_bfloat162 rhs_diff_pair_lo_cg1 = __as_bf16x2(_bf16x2_sub_0);
+            __nv_bfloat162 rhs_diff_pair_hi_cg1 = __as_bf16x2(_bf16x2_sub_1);
+            __nv_bfloat162 y_pair_lo_cg1 = beta_pairs_cg1[rhs_reg_cg1] * rhs_diff_pair_lo_cg1;
+            __nv_bfloat162 y_pair_hi_cg1 = beta_pairs_cg1[rhs_reg_cg1] * rhs_diff_pair_hi_cg1;
+            y_words_lo_cg1[rhs_reg_cg1] = __as_u32(y_pair_lo_cg1);
+            y_words_hi_cg1[rhs_reg_cg1] = __as_u32(y_pair_hi_cg1);
+          }
+          asm volatile(
+              "tcgen05.st.sync.aligned.16x128b.x2.b32"
+              " [%0], {%1, %2, %3, %4};" ::"r"(taddr + 256 + (unsigned int)tmem_row_base_cg1),
+              "r"(*reinterpret_cast<const uint32_t*>(&y_words_lo_cg1[0])),
+              "r"(*reinterpret_cast<const uint32_t*>(&y_words_lo_cg1[1])),
+              "r"(*reinterpret_cast<const uint32_t*>(&y_words_lo_cg1[2])),
+              "r"(*reinterpret_cast<const uint32_t*>(&y_words_lo_cg1[3])));
+          asm volatile(
+              "tcgen05.st.sync.aligned.16x128b.x2.b32"
+              " [%0], {%1, %2, %3, %4};" ::"r"(taddr + 256 + (unsigned int)tmem_row_base_cg1 +
+                                               1048576),
+              "r"(*reinterpret_cast<const uint32_t*>(&y_words_hi_cg1[0])),
+              "r"(*reinterpret_cast<const uint32_t*>(&y_words_hi_cg1[1])),
+              "r"(*reinterpret_cast<const uint32_t*>(&y_words_hi_cg1[2])),
+              "r"(*reinterpret_cast<const uint32_t*>(&y_words_hi_cg1[3])));
+          asm volatile("tcgen05.wait::st.sync.aligned;" ::: "memory");
+          mbarrier_arrive(v_done_addr + (raw_stage_cg1) * 8);
+          mbarrier_arrive(beta_done_addr + (raw_bar_stage_cg1) * 8);
+          mbarrier_arrive(y_inp_ready_addr);
+          mbarrier_wait(u_acc_ready_addr, state_phase_cg1);
+          float _tmem_load_5[16];
+          tmem_ld_x16(&_tmem_load_5[0], taddr + 240 + (unsigned int)tmem_row_base_cg1);
+          asm volatile("tcgen05.wait::ld.sync.aligned;" ::: "memory");
+          unsigned int u_words_cg1[8];
+#pragma unroll
+          for (int _lp = 0; _lp < 8; _lp++) {
+            __nv_bfloat162 _bf2 = __float22bfloat162_rn(
+                make_float2(_tmem_load_5[_lp * 2 + 0], _tmem_load_5[_lp * 2 + 1 + 0]));
+            u_words_cg1[_lp] = *(uint32_t*)&_bf2;
+          }
+          tmem_st_x8_u32(taddr + 264 + (unsigned int)tmem_row_base_cg1,
+                         (const uint32_t*)u_words_cg1);
+          asm volatile("tcgen05.wait::st.sync.aligned;" ::: "memory");
+          mbarrier_arrive(u_inp_ready_addr);
+        }
+#pragma unroll 1
+        for (int chunk_cg1 = 1; chunk_cg1 < chunks_cg1; chunk_cg1++) {
+          int cumulative_cg1_1 = cumulative_chunk_cg1 + chunk_cg1;
+          unsigned int raw_stage_cg1_1 = (unsigned int)(cumulative_cg1_1 % 5);
+          unsigned int raw_bar_stage_cg1_1 = (unsigned int)(cumulative_cg1_1 % 6);
+          unsigned int o_stage_cg1_1 = (unsigned int)(cumulative_cg1_1 % 2);
+          unsigned int checkpoint_stage_cg1_1 = (unsigned int)(cumulative_cg1_1 % 2);
+          unsigned int state_phase_cg1_1 = (unsigned int)(cumulative_cg1_1 & 1);
+          {
+            mbarrier_wait(state_acc_done_addr, (unsigned int)(cumulative_cg1_1 - 1 & 1));
+          }
+          float _tmem_load_6[128];
+          tmem_ld_x16(&_tmem_load_6[0], taddr + (unsigned int)tmem_row_base_cg1);
+          tmem_ld_x16(&_tmem_load_6[16], taddr + (unsigned int)tmem_row_base_cg1 + 16);
+          tmem_ld_x16(&_tmem_load_6[32], taddr + (unsigned int)tmem_row_base_cg1 + 32);
+          tmem_ld_x16(&_tmem_load_6[48], taddr + (unsigned int)tmem_row_base_cg1 + 48);
+          tmem_ld_x16(&_tmem_load_6[64], taddr + (unsigned int)tmem_row_base_cg1 + 64);
+          tmem_ld_x16(&_tmem_load_6[80], taddr + (unsigned int)tmem_row_base_cg1 + 80);
+          tmem_ld_x16(&_tmem_load_6[96], taddr + (unsigned int)tmem_row_base_cg1 + 96);
+          tmem_ld_x16(&_tmem_load_6[112], taddr + (unsigned int)tmem_row_base_cg1 + 112);
+          asm volatile("tcgen05.wait::ld.sync.aligned;" ::: "memory");
+          {
+            mbarrier_wait(checkpoint_done_addr + (checkpoint_stage_cg1_1) * 8,
+                          (unsigned int)(cumulative_cg1_1 / 2 + 1 & 1));
+          }
+          unsigned int state_words_cg1_1[8];
+#pragma unroll
+          for (int _lp = 0; _lp < 8; _lp++) {
+            __nv_bfloat162 _bf2 = __float22bfloat162_rn(
+                make_float2(_tmem_load_6[_lp * 2 + 0], _tmem_load_6[_lp * 2 + 1 + 0]));
+            state_words_cg1_1[_lp] = *(uint32_t*)&_bf2;
+          }
+          tmem_st_x8_u32(taddr + 128 + (unsigned int)tmem_row_base_cg1,
+                         (const uint32_t*)state_words_cg1_1);
+          {
+            asm volatile(
+                "st.shared.v4.b32 [%0], {%1,%2,%3,%4};" ::"r"(
+                    (smem_checkpoint_addr + checkpoint_stage_cg1_1 * 32768 +
+                     (unsigned int)(value_row_cg1 * 128 ^ (value_row_cg1 * 128 >> 7 & 7) << 4))),
+                "r"(state_words_cg1_1[0]), "r"(state_words_cg1_1[1]), "r"(state_words_cg1_1[2]),
+                "r"(state_words_cg1_1[3])
+                : "memory");
+            asm volatile("st.shared.v4.b32 [%0], {%1,%2,%3,%4};" ::"r"(
+                             (smem_checkpoint_addr + checkpoint_stage_cg1_1 * 32768 +
+                              (unsigned int)(value_row_cg1 * 128 + 16 ^
+                                             (value_row_cg1 * 128 + 16 >> 7 & 7) << 4))),
+                         "r"(state_words_cg1_1[4]), "r"(state_words_cg1_1[5]),
+                         "r"(state_words_cg1_1[6]), "r"(state_words_cg1_1[7])
+                         : "memory");
+          }
+#pragma unroll
+          for (int _lp = 0; _lp < 8; _lp++) {
+            __nv_bfloat162 _bf2 = __float22bfloat162_rn(
+                make_float2(_tmem_load_6[_lp * 2 + 16], _tmem_load_6[_lp * 2 + 1 + 16]));
+            state_words_cg1_1[_lp] = *(uint32_t*)&_bf2;
+          }
+          tmem_st_x8_u32(taddr + 128 + (unsigned int)tmem_row_base_cg1 + 8,
+                         (const uint32_t*)state_words_cg1_1);
+          {
+            asm volatile("st.shared.v4.b32 [%0], {%1,%2,%3,%4};" ::"r"(
+                             (smem_checkpoint_addr + checkpoint_stage_cg1_1 * 32768 +
+                              (unsigned int)(value_row_cg1 * 128 + 32 ^
+                                             (value_row_cg1 * 128 + 32 >> 7 & 7) << 4))),
+                         "r"(state_words_cg1_1[0]), "r"(state_words_cg1_1[1]),
+                         "r"(state_words_cg1_1[2]), "r"(state_words_cg1_1[3])
+                         : "memory");
+            asm volatile("st.shared.v4.b32 [%0], {%1,%2,%3,%4};" ::"r"(
+                             (smem_checkpoint_addr + checkpoint_stage_cg1_1 * 32768 +
+                              (unsigned int)(value_row_cg1 * 128 + 48 ^
+                                             (value_row_cg1 * 128 + 48 >> 7 & 7) << 4))),
+                         "r"(state_words_cg1_1[4]), "r"(state_words_cg1_1[5]),
+                         "r"(state_words_cg1_1[6]), "r"(state_words_cg1_1[7])
+                         : "memory");
+          }
+#pragma unroll
+          for (int _lp = 0; _lp < 8; _lp++) {
+            __nv_bfloat162 _bf2 = __float22bfloat162_rn(
+                make_float2(_tmem_load_6[_lp * 2 + 32], _tmem_load_6[_lp * 2 + 1 + 32]));
+            state_words_cg1_1[_lp] = *(uint32_t*)&_bf2;
+          }
+          tmem_st_x8_u32(taddr + 128 + (unsigned int)tmem_row_base_cg1 + 16,
+                         (const uint32_t*)state_words_cg1_1);
+          {
+            asm volatile("st.shared.v4.b32 [%0], {%1,%2,%3,%4};" ::"r"(
+                             (smem_checkpoint_addr + checkpoint_stage_cg1_1 * 32768 +
+                              (unsigned int)(value_row_cg1 * 128 + 64 ^
+                                             (value_row_cg1 * 128 + 64 >> 7 & 7) << 4))),
+                         "r"(state_words_cg1_1[0]), "r"(state_words_cg1_1[1]),
+                         "r"(state_words_cg1_1[2]), "r"(state_words_cg1_1[3])
+                         : "memory");
+            asm volatile("st.shared.v4.b32 [%0], {%1,%2,%3,%4};" ::"r"(
+                             (smem_checkpoint_addr + checkpoint_stage_cg1_1 * 32768 +
+                              (unsigned int)(value_row_cg1 * 128 + 80 ^
+                                             (value_row_cg1 * 128 + 80 >> 7 & 7) << 4))),
+                         "r"(state_words_cg1_1[4]), "r"(state_words_cg1_1[5]),
+                         "r"(state_words_cg1_1[6]), "r"(state_words_cg1_1[7])
+                         : "memory");
+          }
+#pragma unroll
+          for (int _lp = 0; _lp < 8; _lp++) {
+            __nv_bfloat162 _bf2 = __float22bfloat162_rn(
+                make_float2(_tmem_load_6[_lp * 2 + 48], _tmem_load_6[_lp * 2 + 1 + 48]));
+            state_words_cg1_1[_lp] = *(uint32_t*)&_bf2;
+          }
+          tmem_st_x8_u32(taddr + 128 + (unsigned int)tmem_row_base_cg1 + 24,
+                         (const uint32_t*)state_words_cg1_1);
+          {
+            asm volatile("st.shared.v4.b32 [%0], {%1,%2,%3,%4};" ::"r"(
+                             (smem_checkpoint_addr + checkpoint_stage_cg1_1 * 32768 +
+                              (unsigned int)(value_row_cg1 * 128 + 96 ^
+                                             (value_row_cg1 * 128 + 96 >> 7 & 7) << 4))),
+                         "r"(state_words_cg1_1[0]), "r"(state_words_cg1_1[1]),
+                         "r"(state_words_cg1_1[2]), "r"(state_words_cg1_1[3])
+                         : "memory");
+            asm volatile("st.shared.v4.b32 [%0], {%1,%2,%3,%4};" ::"r"(
+                             (smem_checkpoint_addr + checkpoint_stage_cg1_1 * 32768 +
+                              (unsigned int)(value_row_cg1 * 128 + 112 ^
+                                             (value_row_cg1 * 128 + 112 >> 7 & 7) << 4))),
+                         "r"(state_words_cg1_1[4]), "r"(state_words_cg1_1[5]),
+                         "r"(state_words_cg1_1[6]), "r"(state_words_cg1_1[7])
+                         : "memory");
+          }
+#pragma unroll
+          for (int _lp = 0; _lp < 8; _lp++) {
+            __nv_bfloat162 _bf2 = __float22bfloat162_rn(
+                make_float2(_tmem_load_6[_lp * 2 + 64], _tmem_load_6[_lp * 2 + 1 + 64]));
+            state_words_cg1_1[_lp] = *(uint32_t*)&_bf2;
+          }
+          tmem_st_x8_u32(taddr + 128 + (unsigned int)tmem_row_base_cg1 + 32,
+                         (const uint32_t*)state_words_cg1_1);
+          {
+            asm volatile("st.shared.v4.b32 [%0], {%1,%2,%3,%4};" ::"r"(
+                             (smem_checkpoint_addr + checkpoint_stage_cg1_1 * 32768 +
+                              (unsigned int)(16384 + value_row_cg1 * 128 ^
+                                             (16384 + value_row_cg1 * 128 >> 7 & 7) << 4))),
+                         "r"(state_words_cg1_1[0]), "r"(state_words_cg1_1[1]),
+                         "r"(state_words_cg1_1[2]), "r"(state_words_cg1_1[3])
+                         : "memory");
+            asm volatile("st.shared.v4.b32 [%0], {%1,%2,%3,%4};" ::"r"(
+                             (smem_checkpoint_addr + checkpoint_stage_cg1_1 * 32768 +
+                              (unsigned int)(16384 + value_row_cg1 * 128 + 16 ^
+                                             (16384 + value_row_cg1 * 128 + 16 >> 7 & 7) << 4))),
+                         "r"(state_words_cg1_1[4]), "r"(state_words_cg1_1[5]),
+                         "r"(state_words_cg1_1[6]), "r"(state_words_cg1_1[7])
+                         : "memory");
+          }
+#pragma unroll
+          for (int _lp = 0; _lp < 8; _lp++) {
+            __nv_bfloat162 _bf2 = __float22bfloat162_rn(
+                make_float2(_tmem_load_6[_lp * 2 + 80], _tmem_load_6[_lp * 2 + 1 + 80]));
+            state_words_cg1_1[_lp] = *(uint32_t*)&_bf2;
+          }
+          tmem_st_x8_u32(taddr + 128 + (unsigned int)tmem_row_base_cg1 + 40,
+                         (const uint32_t*)state_words_cg1_1);
+          {
+            asm volatile("st.shared.v4.b32 [%0], {%1,%2,%3,%4};" ::"r"(
+                             (smem_checkpoint_addr + checkpoint_stage_cg1_1 * 32768 +
+                              (unsigned int)(16384 + value_row_cg1 * 128 + 32 ^
+                                             (16384 + value_row_cg1 * 128 + 32 >> 7 & 7) << 4))),
+                         "r"(state_words_cg1_1[0]), "r"(state_words_cg1_1[1]),
+                         "r"(state_words_cg1_1[2]), "r"(state_words_cg1_1[3])
+                         : "memory");
+            asm volatile("st.shared.v4.b32 [%0], {%1,%2,%3,%4};" ::"r"(
+                             (smem_checkpoint_addr + checkpoint_stage_cg1_1 * 32768 +
+                              (unsigned int)(16384 + value_row_cg1 * 128 + 48 ^
+                                             (16384 + value_row_cg1 * 128 + 48 >> 7 & 7) << 4))),
+                         "r"(state_words_cg1_1[4]), "r"(state_words_cg1_1[5]),
+                         "r"(state_words_cg1_1[6]), "r"(state_words_cg1_1[7])
+                         : "memory");
+          }
+#pragma unroll
+          for (int _lp = 0; _lp < 8; _lp++) {
+            __nv_bfloat162 _bf2 = __float22bfloat162_rn(
+                make_float2(_tmem_load_6[_lp * 2 + 96], _tmem_load_6[_lp * 2 + 1 + 96]));
+            state_words_cg1_1[_lp] = *(uint32_t*)&_bf2;
+          }
+          tmem_st_x8_u32(taddr + 128 + (unsigned int)tmem_row_base_cg1 + 48,
+                         (const uint32_t*)state_words_cg1_1);
+          {
+            asm volatile("st.shared.v4.b32 [%0], {%1,%2,%3,%4};" ::"r"(
+                             (smem_checkpoint_addr + checkpoint_stage_cg1_1 * 32768 +
+                              (unsigned int)(16384 + value_row_cg1 * 128 + 64 ^
+                                             (16384 + value_row_cg1 * 128 + 64 >> 7 & 7) << 4))),
+                         "r"(state_words_cg1_1[0]), "r"(state_words_cg1_1[1]),
+                         "r"(state_words_cg1_1[2]), "r"(state_words_cg1_1[3])
+                         : "memory");
+            asm volatile("st.shared.v4.b32 [%0], {%1,%2,%3,%4};" ::"r"(
+                             (smem_checkpoint_addr + checkpoint_stage_cg1_1 * 32768 +
+                              (unsigned int)(16384 + value_row_cg1 * 128 + 80 ^
+                                             (16384 + value_row_cg1 * 128 + 80 >> 7 & 7) << 4))),
+                         "r"(state_words_cg1_1[4]), "r"(state_words_cg1_1[5]),
+                         "r"(state_words_cg1_1[6]), "r"(state_words_cg1_1[7])
+                         : "memory");
+          }
+#pragma unroll
+          for (int _lp = 0; _lp < 8; _lp++) {
+            __nv_bfloat162 _bf2 = __float22bfloat162_rn(
+                make_float2(_tmem_load_6[_lp * 2 + 112], _tmem_load_6[_lp * 2 + 1 + 112]));
+            state_words_cg1_1[_lp] = *(uint32_t*)&_bf2;
+          }
+          tmem_st_x8_u32(taddr + 128 + (unsigned int)tmem_row_base_cg1 + 56,
+                         (const uint32_t*)state_words_cg1_1);
+          {
+            asm volatile("st.shared.v4.b32 [%0], {%1,%2,%3,%4};" ::"r"(
+                             (smem_checkpoint_addr + checkpoint_stage_cg1_1 * 32768 +
+                              (unsigned int)(16384 + value_row_cg1 * 128 + 96 ^
+                                             (16384 + value_row_cg1 * 128 + 96 >> 7 & 7) << 4))),
+                         "r"(state_words_cg1_1[0]), "r"(state_words_cg1_1[1]),
+                         "r"(state_words_cg1_1[2]), "r"(state_words_cg1_1[3])
+                         : "memory");
+            asm volatile("st.shared.v4.b32 [%0], {%1,%2,%3,%4};" ::"r"(
+                             (smem_checkpoint_addr + checkpoint_stage_cg1_1 * 32768 +
+                              (unsigned int)(16384 + value_row_cg1 * 128 + 112 ^
+                                             (16384 + value_row_cg1 * 128 + 112 >> 7 & 7) << 4))),
+                         "r"(state_words_cg1_1[4]), "r"(state_words_cg1_1[5]),
+                         "r"(state_words_cg1_1[6]), "r"(state_words_cg1_1[7])
+                         : "memory");
+          }
+          asm volatile("tcgen05.wait::st.sync.aligned;" ::: "memory");
+          mbarrier_arrive(state_inp_ready_addr);
+          {
+            asm volatile("fence.proxy.async.shared::cta;" ::: "memory");
+            mbarrier_arrive(state_read_done_addr);
+            mbarrier_arrive(checkpoint_ready_addr + (checkpoint_stage_cg1_1) * 8);
+          }
+          {
+            int previous_event_cg1 = cumulative_cg1_1 - 1;
+            unsigned int previous_o_stage_cg1 = (unsigned int)(previous_event_cg1 % 2);
+            mbarrier_wait(o_acc_ready_addr, (unsigned int)(previous_event_cg1 & 1));
+            mbarrier_wait(o_tma_done_addr + (previous_o_stage_cg1) * 8,
+                          (unsigned int)(previous_event_cg1 / 2 + 1 & 1));
+            int output_col_cg1 = 192 + (int)previous_o_stage_cg1 * 16;
+            float _tmem_load_7[8];
+            asm volatile(
+                "tcgen05.ld.sync.aligned.16x256b.x2.b32"
+                " {%0, %1, %2, %3, %4, %5, %6, %7}, [%8];"
+                : "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_7[0])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_7[1])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_7[2])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_7[3])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_7[4])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_7[5])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_7[6])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_7[7]))
+                : "r"(taddr + (unsigned int)output_col_cg1 + (unsigned int)tmem_row_base_cg1));
+            float _tmem_load_8[8];
+            asm volatile(
+                "tcgen05.ld.sync.aligned.16x256b.x2.b32"
+                " {%0, %1, %2, %3, %4, %5, %6, %7}, [%8];"
+                : "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_8[0])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_8[1])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_8[2])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_8[3])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_8[4])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_8[5])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_8[6])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_8[7]))
+                : "r"(taddr + (unsigned int)output_col_cg1 + (unsigned int)tmem_row_base_cg1 +
+                      1048576));
+            const float2 _scale2_1 = {scale, scale};
+#pragma unroll
+            for (int _ls = 0; _ls < 4; _ls++)
+              mul_f32x2_inplace(&reinterpret_cast<float2*>(_tmem_load_7)[_ls], _scale2_1);
+            const float2 _scale2_2 = {scale, scale};
+#pragma unroll
+            for (int _ls = 0; _ls < 4; _ls++)
+              mul_f32x2_inplace(&reinterpret_cast<float2*>(_tmem_load_8)[_ls], _scale2_2);
+            uint32_t _tmem_load_7_bf16[4];
+#pragma unroll
+            for (int _lp = 0; _lp < 4; _lp++) {
+              __nv_bfloat162 _bf2 = __float22bfloat162_rn(
+                  make_float2(_tmem_load_7[_lp * 2 + 0], _tmem_load_7[_lp * 2 + 1 + 0]));
+              _tmem_load_7_bf16[_lp] = *(uint32_t*)&_bf2;
+            }
+            uint32_t _tmem_load_8_bf16[4];
+#pragma unroll
+            for (int _lp = 0; _lp < 4; _lp++) {
+              __nv_bfloat162 _bf2 = __float22bfloat162_rn(
+                  make_float2(_tmem_load_8[_lp * 2 + 0], _tmem_load_8[_lp * 2 + 1 + 0]));
+              _tmem_load_8_bf16[_lp] = *(uint32_t*)&_bf2;
+            }
+            int segment_4 = (value_dim_base_cg1 + ov_col_cg1) / 64;
+            int segment_col_4 = value_dim_base_cg1 + ov_col_cg1 - segment_4 * 64;
+            int swizzled_col_4 = segment_col_4 ^ (ov_token_cg1 & 7) * 8;
+            int segment_0_2 = (value_dim_base_cg1 + 16 + ov_col_cg1) / 64;
+            int segment_col_1_3 = value_dim_base_cg1 + 16 + ov_col_cg1 - segment_0_2 * 64;
+            int swizzled_col_2_3 = segment_col_1_3 ^ (ov_token_cg1 & 7) * 8;
+            uint32_t _stmatrix_addr_3 = static_cast<uint32_t>(
+                (unsigned long long)(smem_o_all_addr +
+                                     (unsigned int)(((int)previous_o_stage_cg1 * 16 * 128 +
+                                                     segment_4 * 16 * 64 + ov_token_cg1 * 64 +
+                                                     swizzled_col_4) *
+                                                    2)));
+            asm volatile(
+                "stmatrix.sync.aligned.m8n8.x4.trans.shared.b16 [%0], {%1, %2, %3, %4};\n" ::"r"(
+                    _stmatrix_addr_3),
+                "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_7_bf16[0])),
+                "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_7_bf16[1])),
+                "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_7_bf16[2])),
+                "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_7_bf16[3]))
+                : "memory");
+            uint32_t _stmatrix_addr_4 = static_cast<uint32_t>(
+                (unsigned long long)(smem_o_all_addr +
+                                     (unsigned int)(((int)previous_o_stage_cg1 * 16 * 128 +
+                                                     segment_0_2 * 16 * 64 + ov_token_cg1 * 64 +
+                                                     swizzled_col_2_3) *
+                                                    2)));
+            asm volatile(
+                "stmatrix.sync.aligned.m8n8.x4.trans.shared.b16 [%0], {%1, %2, %3, %4};\n" ::"r"(
+                    _stmatrix_addr_4),
+                "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_8_bf16[0])),
+                "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_8_bf16[1])),
+                "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_8_bf16[2])),
+                "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_8_bf16[3]))
+                : "memory");
+            mbarrier_arrive(o_acc_done_addr + (previous_o_stage_cg1) * 8);
+            asm volatile("fence.proxy.async.shared::cta;" ::: "memory");
+            mbarrier_arrive(o_tma_ready_addr + (previous_o_stage_cg1) * 8);
+          }
+          mbarrier_wait(v_ready_addr + (raw_bar_stage_cg1_1) * 8,
+                        (unsigned int)(cumulative_cg1_1 / 6 & 1));
+          mbarrier_wait(beta_ready_addr + (raw_bar_stage_cg1_1) * 8,
+                        (unsigned int)(cumulative_cg1_1 / 6 & 1));
+          mbarrier_wait(state_k_ready_addr, state_phase_cg1_1);
+          float _tmem_load_9[8];
+          asm volatile(
+              "tcgen05.ld.sync.aligned.16x256b.x2.b32"
+              " {%0, %1, %2, %3, %4, %5, %6, %7}, [%8];"
+              : "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_9[0])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_9[1])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_9[2])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_9[3])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_9[4])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_9[5])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_9[6])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_9[7]))
+              : "r"(taddr + 224 + (unsigned int)tmem_row_base_cg1));
+          float _tmem_load_10[8];
+          asm volatile(
+              "tcgen05.ld.sync.aligned.16x256b.x2.b32"
+              " {%0, %1, %2, %3, %4, %5, %6, %7}, [%8];"
+              : "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_10[0])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_10[1])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_10[2])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_10[3])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_10[4])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_10[5])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_10[6])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_10[7]))
+              : "r"(taddr + 224 + (unsigned int)tmem_row_base_cg1 + 1048576));
+          unsigned int raw_v_words_lo_cg1_1[4];
+          unsigned int raw_v_words_hi_cg1_1[4];
+          int segment_5 = (value_dim_base_cg1 + ov_col_cg1) / 64;
+          int segment_col_5 = value_dim_base_cg1 + ov_col_cg1 - segment_5 * 64;
+          int swizzled_col_5 = segment_col_5 ^ (ov_token_cg1 & 7) * 8;
+          asm volatile("ldmatrix.sync.aligned.m8n8.x4.trans.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                       : "=r"(raw_v_words_lo_cg1_1[0]), "=r"(raw_v_words_lo_cg1_1[1]),
+                         "=r"(raw_v_words_lo_cg1_1[2]), "=r"(raw_v_words_lo_cg1_1[3])
+                       : "r"(smem_v_all_addr +
+                             (raw_stage_cg1_1 * 16 * 128 + (unsigned int)(segment_5 * 16 * 64) +
+                              (unsigned int)(ov_token_cg1 * 64) + (unsigned int)swizzled_col_5) *
+                                 2)
+                       : "memory");
+          int segment_0_3 = (value_dim_base_cg1 + 16 + ov_col_cg1) / 64;
+          int segment_col_1_4 = value_dim_base_cg1 + 16 + ov_col_cg1 - segment_0_3 * 64;
+          int swizzled_col_2_4 = segment_col_1_4 ^ (ov_token_cg1 & 7) * 8;
+          asm volatile("ldmatrix.sync.aligned.m8n8.x4.trans.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                       : "=r"(raw_v_words_hi_cg1_1[0]), "=r"(raw_v_words_hi_cg1_1[1]),
+                         "=r"(raw_v_words_hi_cg1_1[2]), "=r"(raw_v_words_hi_cg1_1[3])
+                       : "r"(smem_v_all_addr +
+                             (raw_stage_cg1_1 * 16 * 128 + (unsigned int)(segment_0_3 * 16 * 64) +
+                              (unsigned int)(ov_token_cg1 * 64) + (unsigned int)swizzled_col_2_4) *
+                                 2)
+                       : "memory");
+          asm volatile("tcgen05.wait::ld.sync.aligned;" ::: "memory");
+          __nv_bfloat162 beta_pairs_cg1_1[4];
+#pragma unroll
+          for (int beta_reg_cg1_1 = 0; beta_reg_cg1_1 < 4; beta_reg_cg1_1++) {
+            int beta_packed_col_cg1_1 = beta_reg_cg1_1 / 2 * 4 + (lane & 3);
+            int beta_token0_cg1_1 = beta_packed_col_cg1_1 * 2;
+            int beta_token1_cg1_1 = beta_token0_cg1_1 + 1;
+            __nv_bfloat16 beta0_cg1_1 =
+                smem_beta_all[(int)raw_bar_stage_cg1_1 * 16 + beta_token0_cg1_1];
+            __nv_bfloat16 beta1_cg1_1 =
+                smem_beta_all[(int)raw_bar_stage_cg1_1 * 16 + beta_token1_cg1_1];
+            float _cvt_f32_5 = __bfloat162float(beta0_cg1_1);
+            float _cvt_f32_6 = __bfloat162float(beta1_cg1_1);
+            __nv_bfloat162 _bf16x2_9 = __float22bfloat162_rn(make_float2(_cvt_f32_5, _cvt_f32_6));
+            beta_pairs_cg1_1[beta_reg_cg1_1] = _bf16x2_9;
+          }
+          unsigned int y_words_lo_cg1_1[4];
+          unsigned int y_words_hi_cg1_1[4];
+#pragma unroll
+          for (int rhs_reg_cg1_1 = 0; rhs_reg_cg1_1 < 4; rhs_reg_cg1_1++) {
+            int rhs_raw_matrix_cg1_1 = rhs_reg_cg1_1;
+            int rhs_frag_pair_cg1_1 = rhs_reg_cg1_1 * 2;
+            __nv_bfloat162 _bf16x2_10 = __float22bfloat162_rn(make_float2(
+                _tmem_load_9[rhs_frag_pair_cg1_1], _tmem_load_9[rhs_frag_pair_cg1_1 + 1]));
+            __nv_bfloat162 _bf16x2_11 = __float22bfloat162_rn(make_float2(
+                _tmem_load_10[rhs_frag_pair_cg1_1], _tmem_load_10[rhs_frag_pair_cg1_1 + 1]));
+            uint32_t _bf16x2_sub_2;
+            asm volatile("sub.rn.bf16x2 %0, %1, %2;"
+                         : "=r"(_bf16x2_sub_2)
+                         : "r"(raw_v_words_lo_cg1_1[rhs_raw_matrix_cg1_1]),
+                           "r"(__as_u32(_bf16x2_10)));
+            uint32_t _bf16x2_sub_3;
+            asm volatile("sub.rn.bf16x2 %0, %1, %2;"
+                         : "=r"(_bf16x2_sub_3)
+                         : "r"(raw_v_words_hi_cg1_1[rhs_raw_matrix_cg1_1]),
+                           "r"(__as_u32(_bf16x2_11)));
+            __nv_bfloat162 rhs_diff_pair_lo_cg1_1 = __as_bf16x2(_bf16x2_sub_2);
+            __nv_bfloat162 rhs_diff_pair_hi_cg1_1 = __as_bf16x2(_bf16x2_sub_3);
+            __nv_bfloat162 y_pair_lo_cg1_1 =
+                beta_pairs_cg1_1[rhs_reg_cg1_1] * rhs_diff_pair_lo_cg1_1;
+            __nv_bfloat162 y_pair_hi_cg1_1 =
+                beta_pairs_cg1_1[rhs_reg_cg1_1] * rhs_diff_pair_hi_cg1_1;
+            y_words_lo_cg1_1[rhs_reg_cg1_1] = __as_u32(y_pair_lo_cg1_1);
+            y_words_hi_cg1_1[rhs_reg_cg1_1] = __as_u32(y_pair_hi_cg1_1);
+          }
+          asm volatile(
+              "tcgen05.st.sync.aligned.16x128b.x2.b32"
+              " [%0], {%1, %2, %3, %4};" ::"r"(taddr + 256 + (unsigned int)tmem_row_base_cg1),
+              "r"(*reinterpret_cast<const uint32_t*>(&y_words_lo_cg1_1[0])),
+              "r"(*reinterpret_cast<const uint32_t*>(&y_words_lo_cg1_1[1])),
+              "r"(*reinterpret_cast<const uint32_t*>(&y_words_lo_cg1_1[2])),
+              "r"(*reinterpret_cast<const uint32_t*>(&y_words_lo_cg1_1[3])));
+          asm volatile(
+              "tcgen05.st.sync.aligned.16x128b.x2.b32"
+              " [%0], {%1, %2, %3, %4};" ::"r"(taddr + 256 + (unsigned int)tmem_row_base_cg1 +
+                                               1048576),
+              "r"(*reinterpret_cast<const uint32_t*>(&y_words_hi_cg1_1[0])),
+              "r"(*reinterpret_cast<const uint32_t*>(&y_words_hi_cg1_1[1])),
+              "r"(*reinterpret_cast<const uint32_t*>(&y_words_hi_cg1_1[2])),
+              "r"(*reinterpret_cast<const uint32_t*>(&y_words_hi_cg1_1[3])));
+          asm volatile("tcgen05.wait::st.sync.aligned;" ::: "memory");
+          mbarrier_arrive(v_done_addr + (raw_stage_cg1_1) * 8);
+          mbarrier_arrive(beta_done_addr + (raw_bar_stage_cg1_1) * 8);
+          mbarrier_arrive(y_inp_ready_addr);
+          mbarrier_wait(u_acc_ready_addr, state_phase_cg1_1);
+          float _tmem_load_11[16];
+          tmem_ld_x16(&_tmem_load_11[0], taddr + 240 + (unsigned int)tmem_row_base_cg1);
+          asm volatile("tcgen05.wait::ld.sync.aligned;" ::: "memory");
+          unsigned int u_words_cg1_1[8];
+#pragma unroll
+          for (int _lp = 0; _lp < 8; _lp++) {
+            __nv_bfloat162 _bf2 = __float22bfloat162_rn(
+                make_float2(_tmem_load_11[_lp * 2 + 0], _tmem_load_11[_lp * 2 + 1 + 0]));
+            u_words_cg1_1[_lp] = *(uint32_t*)&_bf2;
+          }
+          tmem_st_x8_u32(taddr + 264 + (unsigned int)tmem_row_base_cg1,
+                         (const uint32_t*)u_words_cg1_1);
+          asm volatile("tcgen05.wait::st.sync.aligned;" ::: "memory");
+          mbarrier_arrive(u_inp_ready_addr);
+        }
+        if (chunks_cg1 > 0) {
+          int final_event_cg1 = cumulative_chunk_cg1 + chunks_cg1 - 1;
+          unsigned int final_o_stage_cg1 = (unsigned int)(final_event_cg1 % 2);
+          mbarrier_wait(state_acc_done_addr, (unsigned int)(final_event_cg1 & 1));
+          mbarrier_wait(o_acc_ready_addr, (unsigned int)(final_event_cg1 & 1));
+          mbarrier_wait(o_tma_done_addr + (final_o_stage_cg1) * 8,
+                        (unsigned int)(final_event_cg1 / 2 + 1 & 1));
+          int output_col_cg1_1 = 192 + (int)final_o_stage_cg1 * 16;
+          float _tmem_load_12[8];
+          asm volatile(
+              "tcgen05.ld.sync.aligned.16x256b.x2.b32"
+              " {%0, %1, %2, %3, %4, %5, %6, %7}, [%8];"
+              : "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_12[0])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_12[1])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_12[2])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_12[3])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_12[4])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_12[5])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_12[6])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_12[7]))
+              : "r"(taddr + (unsigned int)output_col_cg1_1 + (unsigned int)tmem_row_base_cg1));
+          float _tmem_load_13[8];
+          asm volatile(
+              "tcgen05.ld.sync.aligned.16x256b.x2.b32"
+              " {%0, %1, %2, %3, %4, %5, %6, %7}, [%8];"
+              : "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_13[0])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_13[1])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_13[2])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_13[3])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_13[4])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_13[5])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_13[6])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_13[7]))
+              : "r"(taddr + (unsigned int)output_col_cg1_1 + (unsigned int)tmem_row_base_cg1 +
+                    1048576));
+          const float2 _scale2_5 = {scale, scale};
+#pragma unroll
+          for (int _ls = 0; _ls < 4; _ls++)
+            mul_f32x2_inplace(&reinterpret_cast<float2*>(_tmem_load_12)[_ls], _scale2_5);
+          const float2 _scale2_6 = {scale, scale};
+#pragma unroll
+          for (int _ls = 0; _ls < 4; _ls++)
+            mul_f32x2_inplace(&reinterpret_cast<float2*>(_tmem_load_13)[_ls], _scale2_6);
+          uint32_t _tmem_load_12_bf16[4];
+#pragma unroll
+          for (int _lp = 0; _lp < 4; _lp++) {
+            __nv_bfloat162 _bf2 = __float22bfloat162_rn(
+                make_float2(_tmem_load_12[_lp * 2 + 0], _tmem_load_12[_lp * 2 + 1 + 0]));
+            _tmem_load_12_bf16[_lp] = *(uint32_t*)&_bf2;
+          }
+          uint32_t _tmem_load_13_bf16[4];
+#pragma unroll
+          for (int _lp = 0; _lp < 4; _lp++) {
+            __nv_bfloat162 _bf2 = __float22bfloat162_rn(
+                make_float2(_tmem_load_13[_lp * 2 + 0], _tmem_load_13[_lp * 2 + 1 + 0]));
+            _tmem_load_13_bf16[_lp] = *(uint32_t*)&_bf2;
+          }
+          int segment_6 = (value_dim_base_cg1 + ov_col_cg1) / 64;
+          int segment_col_6 = value_dim_base_cg1 + ov_col_cg1 - segment_6 * 64;
+          int swizzled_col_6 = segment_col_6 ^ (ov_token_cg1 & 7) * 8;
+          int segment_0_4 = (value_dim_base_cg1 + 16 + ov_col_cg1) / 64;
+          int segment_col_1_5 = value_dim_base_cg1 + 16 + ov_col_cg1 - segment_0_4 * 64;
+          int swizzled_col_2_5 = segment_col_1_5 ^ (ov_token_cg1 & 7) * 8;
+          uint32_t _stmatrix_addr_7 = static_cast<uint32_t>(
+              (unsigned long long)(smem_o_all_addr +
+                                   (unsigned int)(((int)final_o_stage_cg1 * 16 * 128 +
+                                                   segment_6 * 16 * 64 + ov_token_cg1 * 64 +
+                                                   swizzled_col_6) *
+                                                  2)));
+          asm volatile(
+              "stmatrix.sync.aligned.m8n8.x4.trans.shared.b16 [%0], {%1, %2, %3, %4};\n" ::"r"(
+                  _stmatrix_addr_7),
+              "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_12_bf16[0])),
+              "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_12_bf16[1])),
+              "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_12_bf16[2])),
+              "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_12_bf16[3]))
+              : "memory");
+          uint32_t _stmatrix_addr_8 = static_cast<uint32_t>(
+              (unsigned long long)(smem_o_all_addr +
+                                   (unsigned int)(((int)final_o_stage_cg1 * 16 * 128 +
+                                                   segment_0_4 * 16 * 64 + ov_token_cg1 * 64 +
+                                                   swizzled_col_2_5) *
+                                                  2)));
+          asm volatile(
+              "stmatrix.sync.aligned.m8n8.x4.trans.shared.b16 [%0], {%1, %2, %3, %4};\n" ::"r"(
+                  _stmatrix_addr_8),
+              "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_13_bf16[0])),
+              "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_13_bf16[1])),
+              "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_13_bf16[2])),
+              "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_13_bf16[3]))
+              : "memory");
+          mbarrier_arrive(o_acc_done_addr + (final_o_stage_cg1) * 8);
+          asm volatile("fence.proxy.async.shared::cta;" ::: "memory");
+          mbarrier_arrive(o_tma_ready_addr + (final_o_stage_cg1) * 8);
+        }
+        cumulative_chunk_cg1 += chunks_cg1;
+      }
+      if (elect_sync()) {
+        mbarrier_arrive(consumers_done_addr);
+      }
+    }
+  }
+  // ---- Role: super_mma ----
+  if (warp == 12) {
+    {  // super_mma_main
+      unsigned int sched_stage_super = 0;
+      int cumulative_chunk_super = 0;
+      int lhs_row_super = lane % 8 + (lane / 8 & 1) * 8;
+      int lhs_col_super = lane / 16 * 8;
+      int rhs_row_super = lane % 8 + lane / 16 * 8;
+      int rhs_col_super = (lane / 8 & 1) * 8;
+      unsigned int _phase_sched_ready_2 = 0;
+#pragma unroll 1
+      for (int __2 = 0; __2 < total_work_items + 1; __2++) {
+        mbarrier_wait(sched_ready_addr + (sched_stage_super) * 8, _phase_sched_ready_2);
+        unsigned int slot_2[1];
+        asm volatile("ld.shared.b32 %0, [%1];"
+                     : "=r"(*reinterpret_cast<uint32_t*>(&slot_2[0]))
+                     : "r"(sched_slot_addr + sched_stage_super * 4));
+        unsigned int tile_super = slot_2[0];
+        if (elect_sync()) {
+          mbarrier_arrive(sched_done_addr + (sched_stage_super) * 8);
+        }
+        sched_stage_super += 1;
+        if (sched_stage_super == 8) {
+          sched_stage_super = 0;
+          _phase_sched_ready_2 ^= 1;
+        }
+        if (tile_super >= (unsigned int)total_work_items) {
+          break;
+        }
+        int item_base_super = (int)tile_super * 8;
+        int chunks_super = work_items[item_base_super + 3] - work_items[item_base_super + 4];
+#pragma unroll 1
+        for (int chunk_super = 0; chunk_super < chunks_super; chunk_super++) {
+          int cumulative_super = cumulative_chunk_super + chunk_super;
+          unsigned int decay_stage_super = (unsigned int)(cumulative_super % 2);
+          unsigned int raw_bar_stage_super = (unsigned int)(cumulative_super % 6);
+          unsigned int intermediate_stage_super = (unsigned int)(cumulative_super % 2);
+          mbarrier_wait(k_decay_inv_ready_addr + (decay_stage_super) * 8,
+                        (unsigned int)(cumulative_super / 2 & 1));
+          mbarrier_wait(beta_ready_addr + (raw_bar_stage_super) * 8,
+                        (unsigned int)(cumulative_super / 6 & 1));
+          mbarrier_wait(tinv_done_addr + (intermediate_stage_super) * 8,
+                        (unsigned int)(cumulative_super / 2 + 1 & 1));
+          float kk_acc_super[8];
+#pragma unroll
+          for (int k_block_super = 0; k_block_super < 8; k_block_super++) {
+            unsigned int a_frag_super[4];
+            unsigned int b_frag_super[4];
+            asm volatile(
+                "ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                : "=r"(a_frag_super[0]), "=r"(a_frag_super[1]), "=r"(a_frag_super[2]),
+                  "=r"(a_frag_super[3])
+                : "r"((smem_k_decay_addr + decay_stage_super * 4096 +
+                       (unsigned int)((k_block_super * 16 + lhs_col_super) / 64 * 2048 +
+                                          lhs_row_super * 128 +
+                                          (k_block_super * 16 + lhs_col_super) % 64 * 2 ^
+                                      ((k_block_super * 16 + lhs_col_super) / 64 * 2048 +
+                                               lhs_row_super * 128 +
+                                               (k_block_super * 16 + lhs_col_super) % 64 * 2 >>
+                                           7 &
+                                       7) << 4)))
+                : "memory");
+            asm volatile(
+                "ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                : "=r"(b_frag_super[0]), "=r"(b_frag_super[1]), "=r"(b_frag_super[2]),
+                  "=r"(b_frag_super[3])
+                : "r"((smem_k_inv_addr + decay_stage_super * 4096 +
+                       (unsigned int)((k_block_super * 16 + rhs_col_super) / 64 * 2048 +
+                                          rhs_row_super * 128 +
+                                          (k_block_super * 16 + rhs_col_super) % 64 * 2 ^
+                                      ((k_block_super * 16 + rhs_col_super) / 64 * 2048 +
+                                               rhs_row_super * 128 +
+                                               (k_block_super * 16 + rhs_col_super) % 64 * 2 >>
+                                           7 &
+                                       7) << 4)))
+                : "memory");
+            asm volatile(
+                "mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, "
+                "%6, %7}, {%8, %9}, {%10, %11, %12, %13};\n"
+                : "=f"(kk_acc_super[0]), "=f"(kk_acc_super[1]), "=f"(kk_acc_super[2]),
+                  "=f"(kk_acc_super[3])
+                : "r"(a_frag_super[0]), "r"(a_frag_super[1]), "r"(a_frag_super[2]),
+                  "r"(a_frag_super[3]), "r"(b_frag_super[0]), "r"(b_frag_super[1]),
+                  "f"(((k_block_super == 0) ? 0.0f : kk_acc_super[0])),
+                  "f"(((k_block_super == 0) ? 0.0f : kk_acc_super[1])),
+                  "f"(((k_block_super == 0) ? 0.0f : kk_acc_super[2])),
+                  "f"(((k_block_super == 0) ? 0.0f : kk_acc_super[3])));
+            asm volatile(
+                "mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, "
+                "%6, %7}, {%8, %9}, {%10, %11, %12, %13};\n"
+                : "=f"(kk_acc_super[4]), "=f"(kk_acc_super[(4) + 1]), "=f"(kk_acc_super[(4) + 2]),
+                  "=f"(kk_acc_super[(4) + 3])
+                : "r"(a_frag_super[0]), "r"(a_frag_super[1]), "r"(a_frag_super[2]),
+                  "r"(a_frag_super[3]), "r"(b_frag_super[2]), "r"(b_frag_super[(2) + 1]),
+                  "f"(((k_block_super == 0) ? 0.0f : kk_acc_super[4])),
+                  "f"(((k_block_super == 0) ? 0.0f : kk_acc_super[(4) + 1])),
+                  "f"(((k_block_super == 0) ? 0.0f : kk_acc_super[(4) + 2])),
+                  "f"(((k_block_super == 0) ? 0.0f : kk_acc_super[(4) + 3])));
+          }
+          int beta_stage_base_super = (int)raw_bar_stage_super * 16;
+          __nv_bfloat16 beta_lo_bf_super = smem_beta_all[beta_stage_base_super + lane / 4];
+          __nv_bfloat16 beta_hi_bf_super = smem_beta_all[beta_stage_base_super + lane / 4 + 8];
+          float _cvt_f32_0 = __bfloat162float(beta_lo_bf_super);
+          float beta_lo_super = _cvt_f32_0;
+          float _cvt_f32_1 = __bfloat162float(beta_hi_bf_super);
+          float beta_hi_super = _cvt_f32_1;
+          float l_values_super[8];
+          float tinv_acc_super[8];
+#pragma unroll
+          for (int accum_super = 0; accum_super < 8; accum_super++) {
+            int row_super = lane / 4 + accum_super % 4 / 2 * 8;
+            int col_super = accum_super / 4 * 8 + (lane & 3) * 2 + (accum_super & 1);
+            l_values_super[accum_super] = 0.0f;
+            if (row_super > col_super) {
+              float beta_scale_super = beta_lo_super;
+              if (accum_super % 4 >= 2) {
+                beta_scale_super = beta_hi_super;
+              }
+              l_values_super[accum_super] = kk_acc_super[accum_super] * beta_scale_super;
+            }
+            tinv_acc_super[accum_super] = -l_values_super[accum_super];
+            if (row_super == col_super) {
+              tinv_acc_super[accum_super] = 1.0f;
+            }
+          }
+          unsigned int lpow_words_super[4];
+          unsigned int lpow_trans_super[4];
+#pragma unroll
+          for (int _lp = 0; _lp < 4; _lp++) {
+            __nv_bfloat162 _bf2 = __float22bfloat162_rn(
+                make_float2(l_values_super[_lp * 2 + 0], l_values_super[_lp * 2 + 1 + 0]));
+            lpow_words_super[_lp] = *(uint32_t*)&_bf2;
+          }
+          int store_row_super = lane % 16;
+          int store_col_super = lane / 16 * 8;
+          int linear = store_row_super * 16 + store_col_super;
+          uint32_t _stmatrix_addr_0 = static_cast<uint32_t>(
+              (unsigned long long)(tinv_scratch_addr +
+                                   (unsigned int)((linear ^ (linear >> 6 & 1) * 8) * 2)));
+          asm volatile("stmatrix.sync.aligned.m8n8.x4.shared.b16 [%0], {%1, %2, %3, %4};\n" ::"r"(
+                           _stmatrix_addr_0),
+                       "r"(*reinterpret_cast<const uint32_t*>(&lpow_words_super[0])),
+                       "r"(*reinterpret_cast<const uint32_t*>(&lpow_words_super[1])),
+                       "r"(*reinterpret_cast<const uint32_t*>(&lpow_words_super[2])),
+                       "r"(*reinterpret_cast<const uint32_t*>(&lpow_words_super[3]))
+                       : "memory");
+          __syncwarp();
+          int load_row_super = lane % 16;
+#pragma unroll
+          for (int load_half_super = 0; load_half_super < 2; load_half_super++) {
+            int linear_0 = load_row_super * 16 + load_half_super * 8;
+            asm volatile(
+                "ldmatrix.sync.aligned.m8n8.x2.trans.shared.b16 {%0, %1}, [%2];\n"
+                : "=r"(lpow_trans_super[load_half_super * 2]),
+                  "=r"(lpow_trans_super[load_half_super * 2 + 1])
+                : "r"(tinv_scratch_addr + (unsigned int)((linear_0 ^ (linear_0 >> 6 & 1) * 8) * 2))
+                : "memory");
+          }
+#pragma unroll
+          for (int neumann_super = 0; neumann_super < 3; neumann_super++) {
+            float square_acc_super[8];
+            asm volatile(
+                "mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, "
+                "%6, %7}, {%8, %9}, {%10, %11, %12, %13};\n"
+                : "=f"(square_acc_super[0]), "=f"(square_acc_super[1]), "=f"(square_acc_super[2]),
+                  "=f"(square_acc_super[3])
+                : "r"(lpow_words_super[0]), "r"(lpow_words_super[1]), "r"(lpow_words_super[2]),
+                  "r"(lpow_words_super[3]), "r"(lpow_trans_super[0]), "r"(lpow_trans_super[1]),
+                  "f"(0.0f), "f"(0.0f), "f"(0.0f), "f"(0.0f));
+            asm volatile(
+                "mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, "
+                "%6, %7}, {%8, %9}, {%10, %11, %12, %13};\n"
+                : "=f"(square_acc_super[4]), "=f"(square_acc_super[(4) + 1]),
+                  "=f"(square_acc_super[(4) + 2]), "=f"(square_acc_super[(4) + 3])
+                : "r"(lpow_words_super[0]), "r"(lpow_words_super[1]), "r"(lpow_words_super[2]),
+                  "r"(lpow_words_super[3]), "r"(lpow_trans_super[2]),
+                  "r"(lpow_trans_super[(2) + 1]), "f"(0.0f), "f"(0.0f), "f"(0.0f), "f"(0.0f));
+#pragma unroll
+            for (int _lp = 0; _lp < 4; _lp++) {
+              __nv_bfloat162 _bf2 = __float22bfloat162_rn(
+                  make_float2(square_acc_super[_lp * 2 + 0], square_acc_super[_lp * 2 + 1 + 0]));
+              lpow_words_super[_lp] = *(uint32_t*)&_bf2;
+            }
+            int store_row_super_0 = lane % 16;
+            int store_col_super_1 = lane / 16 * 8;
+            int linear_2 = store_row_super_0 * 16 + store_col_super_1;
+            uint32_t _stmatrix_addr_1 = static_cast<uint32_t>(
+                (unsigned long long)(tinv_scratch_addr +
+                                     (unsigned int)((linear_2 ^ (linear_2 >> 6 & 1) * 8) * 2)));
+            asm volatile("stmatrix.sync.aligned.m8n8.x4.shared.b16 [%0], {%1, %2, %3, %4};\n" ::"r"(
+                             _stmatrix_addr_1),
+                         "r"(*reinterpret_cast<const uint32_t*>(&lpow_words_super[0])),
+                         "r"(*reinterpret_cast<const uint32_t*>(&lpow_words_super[1])),
+                         "r"(*reinterpret_cast<const uint32_t*>(&lpow_words_super[2])),
+                         "r"(*reinterpret_cast<const uint32_t*>(&lpow_words_super[3]))
+                         : "memory");
+            __syncwarp();
+            int load_row_super_3 = lane % 16;
+#pragma unroll
+            for (int load_half_super_1 = 0; load_half_super_1 < 2; load_half_super_1++) {
+              int linear_0_1 = load_row_super_3 * 16 + load_half_super_1 * 8;
+              asm volatile("ldmatrix.sync.aligned.m8n8.x2.trans.shared.b16 {%0, %1}, [%2];\n"
+                           : "=r"(lpow_trans_super[load_half_super_1 * 2]),
+                             "=r"(lpow_trans_super[load_half_super_1 * 2 + 1])
+                           : "r"(tinv_scratch_addr +
+                                 (unsigned int)((linear_0_1 ^ (linear_0_1 >> 6 & 1) * 8) * 2))
+                           : "memory");
+            }
+            unsigned int tinv_words_super[4];
+#pragma unroll
+            for (int _lp = 0; _lp < 4; _lp++) {
+              __nv_bfloat162 _bf2 = __float22bfloat162_rn(
+                  make_float2(tinv_acc_super[_lp * 2 + 0], tinv_acc_super[_lp * 2 + 1 + 0]));
+              tinv_words_super[_lp] = *(uint32_t*)&_bf2;
+            }
+            float update_acc_super[8];
+            asm volatile(
+                "mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, "
+                "%6, %7}, {%8, %9}, {%10, %11, %12, %13};\n"
+                : "=f"(update_acc_super[0]), "=f"(update_acc_super[1]), "=f"(update_acc_super[2]),
+                  "=f"(update_acc_super[3])
+                : "r"(tinv_words_super[0]), "r"(tinv_words_super[1]), "r"(tinv_words_super[2]),
+                  "r"(tinv_words_super[3]), "r"(lpow_trans_super[0]), "r"(lpow_trans_super[1]),
+                  "f"(0.0f), "f"(0.0f), "f"(0.0f), "f"(0.0f));
+            asm volatile(
+                "mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, "
+                "%6, %7}, {%8, %9}, {%10, %11, %12, %13};\n"
+                : "=f"(update_acc_super[4]), "=f"(update_acc_super[(4) + 1]),
+                  "=f"(update_acc_super[(4) + 2]), "=f"(update_acc_super[(4) + 3])
+                : "r"(tinv_words_super[0]), "r"(tinv_words_super[1]), "r"(tinv_words_super[2]),
+                  "r"(tinv_words_super[3]), "r"(lpow_trans_super[2]),
+                  "r"(lpow_trans_super[(2) + 1]), "f"(0.0f), "f"(0.0f), "f"(0.0f), "f"(0.0f));
+            float tinv_words_super_f32[8];
+#pragma unroll
+            for (int _pair = 0; _pair < 4; _pair++) {
+              asm volatile(
+                  "{\n\t"
+                  "shl.b32 %0, %2, 16;\n\t"
+                  "and.b32 %1, %2, 0xffff0000;\n\t"
+                  "}\n"
+                  : "=f"((&tinv_words_super_f32[_pair * 2])[0]),
+                    "=f"((&tinv_words_super_f32[_pair * 2])[1])
+                  : "r"(tinv_words_super[_pair]));
+            }
+#pragma unroll
+            for (int update_super = 0; update_super < 8; update_super++) {
+              tinv_acc_super[update_super] =
+                  tinv_words_super_f32[update_super] + update_acc_super[update_super];
+            }
+          }
+          unsigned int tinv_publish_super[4];
+#pragma unroll
+          for (int _lp = 0; _lp < 4; _lp++) {
+            __nv_bfloat162 _bf2 = __float22bfloat162_rn(
+                make_float2(tinv_acc_super[_lp * 2 + 0], tinv_acc_super[_lp * 2 + 1 + 0]));
+            tinv_publish_super[_lp] = *(uint32_t*)&_bf2;
+          }
+          uint32_t _stmatrix_addr_2 = static_cast<uint32_t>(
+              (unsigned long long)(smem_tinv_addr + intermediate_stage_super * 1024 +
+                                   (unsigned int)(lane / 16 * 8 / 16 * 512 + lane % 16 * 32 +
+                                                      lane / 16 * 8 % 16 * 2 ^
+                                                  (lane / 16 * 8 / 16 * 512 + lane % 16 * 32 +
+                                                           lane / 16 * 8 % 16 * 2 >>
+                                                       7 &
+                                                   1) << 4)));
+          asm volatile("stmatrix.sync.aligned.m8n8.x4.shared.b16 [%0], {%1, %2, %3, %4};\n" ::"r"(
+                           _stmatrix_addr_2),
+                       "r"(*reinterpret_cast<const uint32_t*>(&tinv_publish_super[0])),
+                       "r"(*reinterpret_cast<const uint32_t*>(&tinv_publish_super[1])),
+                       "r"(*reinterpret_cast<const uint32_t*>(&tinv_publish_super[2])),
+                       "r"(*reinterpret_cast<const uint32_t*>(&tinv_publish_super[3]))
+                       : "memory");
+          asm volatile("fence.proxy.async.shared::cta;" ::: "memory");
+          mbarrier_arrive(tinv_ready_addr + (intermediate_stage_super) * 8);
+          mbarrier_arrive(beta_done_addr + (raw_bar_stage_super) * 8);
+          mbarrier_arrive(decay_super_done_addr + (decay_stage_super) * 8);
+        }
+        cumulative_chunk_super += chunks_super;
+      }
+      if (elect_sync()) {
+        mbarrier_arrive(consumers_done_addr);
+      }
+    }
+  }
+  // ---- Role: tcgen ----
+  if (warp == 13) {
+    {  // tcgen_main
+      float tmem_seed_tcgen[1];
+      tmem_seed_tcgen[0] = 0.0f;
+      asm volatile(
+          "tcgen05.st.sync.aligned.32x32b.x1.b32"
+          " [%0], {%1};" ::"r"(taddr),
+          "r"(*reinterpret_cast<const uint32_t*>(&tmem_seed_tcgen[0])));
+      asm volatile("tcgen05.wait::st.sync.aligned;" ::: "memory");
+      unsigned int sched_stage_tcgen = 0;
+      int cumulative_chunk_tcgen = 0;
+      unsigned int _phase_sched_ready_3 = 0;
+#pragma unroll 1
+      for (int __3 = 0; __3 < total_work_items + 1; __3++) {
+        mbarrier_wait(sched_ready_addr + (sched_stage_tcgen) * 8, _phase_sched_ready_3);
+        unsigned int slot_3[1];
+        asm volatile("ld.shared.b32 %0, [%1];"
+                     : "=r"(*reinterpret_cast<uint32_t*>(&slot_3[0]))
+                     : "r"(sched_slot_addr + sched_stage_tcgen * 4));
+        unsigned int tile_tcgen = slot_3[0];
+        if (elect_sync()) {
+          mbarrier_arrive(sched_done_addr + (sched_stage_tcgen) * 8);
+        }
+        sched_stage_tcgen += 1;
+        if (sched_stage_tcgen == 8) {
+          sched_stage_tcgen = 0;
+          _phase_sched_ready_3 ^= 1;
+        }
+        if (tile_tcgen >= (unsigned int)total_work_items) {
+          break;
+        }
+        int item_base_tcgen = (int)tile_tcgen * 8;
+        int chunks_tcgen = work_items[item_base_tcgen + 3] - work_items[item_base_tcgen + 4];
+#pragma unroll 1
+        for (int chunk_tcgen = 0; chunk_tcgen < chunks_tcgen; chunk_tcgen++) {
+          int cumulative_tcgen = cumulative_chunk_tcgen + chunk_tcgen;
+          unsigned int state_phase_tcgen = (unsigned int)(cumulative_tcgen & 1);
+          unsigned int decay_stage_tcgen = (unsigned int)(cumulative_tcgen % 2);
+          unsigned int diag_stage_tcgen = (unsigned int)(cumulative_tcgen % 4);
+          unsigned int intermediate_stage_tcgen = (unsigned int)(cumulative_tcgen % 2);
+          unsigned int o_stage_tcgen = (unsigned int)(cumulative_tcgen % 2);
+          mbarrier_wait(k_decay_inv_ready_addr + (decay_stage_tcgen) * 8,
+                        (unsigned int)(cumulative_tcgen / 2 & 1));
+          mbarrier_wait(state_inp_ready_addr, state_phase_tcgen);
+          int _mma_b_lo_0 =
+              make_warp_uniform((((smem_k_decay_addr) >> 4) & 0x3FFF) + (decay_stage_tcgen) * 256);
+          asm volatile(
+              "{\n\t"
+              ".reg .pred leader, p0, p1;\n\t"
+              ".reg .b32 dhi, blo, ta, id;\n\t"
+              ".reg .b64 db;\n\t"
+              "elect.sync _|leader, 0xFFFFFFFF;\n\t"
+              "setp.ne.b32 p0, %3, 0;\n\t"
+              "setp.ne.b32 p1, 1, 0;\n\t"
+              ""
+              "mov.b32 dhi, 0x40004040;\n\t"
+              "mov.b32 id, 134481040;\n\t"
+              "mov.b32 ta, %2;\n\t"
+              "mov.b32 blo, %1;\n\t"
+              "mov.b64 db, {blo, dhi};\n\t"
+              "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p0;\n\t"
+              "add.u32 ta, ta, 8;\n\t"
+              "add.u32 blo, blo, 2;\n\t"
+              "mov.b64 db, {blo, dhi};\n\t"
+              "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+              "add.u32 ta, ta, 8;\n\t"
+              "add.u32 blo, blo, 2;\n\t"
+              "mov.b64 db, {blo, dhi};\n\t"
+              "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+              "add.u32 ta, ta, 8;\n\t"
+              "add.u32 blo, blo, 2;\n\t"
+              "mov.b64 db, {blo, dhi};\n\t"
+              "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+              "add.u32 ta, ta, 8;\n\t"
+              "add.u32 blo, blo, 122;\n\t"
+              "mov.b64 db, {blo, dhi};\n\t"
+              "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+              "add.u32 ta, ta, 8;\n\t"
+              "add.u32 blo, blo, 2;\n\t"
+              "mov.b64 db, {blo, dhi};\n\t"
+              "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+              "add.u32 ta, ta, 8;\n\t"
+              "add.u32 blo, blo, 2;\n\t"
+              "mov.b64 db, {blo, dhi};\n\t"
+              "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+              "add.u32 ta, ta, 8;\n\t"
+              "add.u32 blo, blo, 2;\n\t"
+              "mov.b64 db, {blo, dhi};\n\t"
+              "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+              "}\n" ::"r"(tmem_tmem_state_k),
+              "r"(_mma_b_lo_0), "r"(tmem_tmem_state_inp), "r"(0));
+          elect_commit(state_k_ready_addr);
+          mbarrier_wait(qk_scale_ready_addr + (diag_stage_tcgen) * 8,
+                        (unsigned int)(cumulative_tcgen / 4 & 1));
+          mbarrier_wait(o_acc_done_addr + (o_stage_tcgen) * 8,
+                        (unsigned int)(cumulative_tcgen / 2 + 1 & 1));
+          int _mma_b_lo_1 =
+              make_warp_uniform((((smem_q_decay_addr) >> 4) & 0x3FFF) + (decay_stage_tcgen) * 256);
+          asm volatile(
+              "{\n\t"
+              ".reg .pred leader, p0, p1;\n\t"
+              ".reg .b32 dhi, blo, ta, id;\n\t"
+              ".reg .b64 db;\n\t"
+              "elect.sync _|leader, 0xFFFFFFFF;\n\t"
+              "setp.ne.b32 p0, %3, 0;\n\t"
+              "setp.ne.b32 p1, 1, 0;\n\t"
+              ""
+              "mov.b32 dhi, 0x40004040;\n\t"
+              "mov.b32 id, 134481040;\n\t"
+              "mov.b32 ta, %2;\n\t"
+              "mov.b32 blo, %1;\n\t"
+              "mov.b64 db, {blo, dhi};\n\t"
+              "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p0;\n\t"
+              "add.u32 ta, ta, 8;\n\t"
+              "add.u32 blo, blo, 2;\n\t"
+              "mov.b64 db, {blo, dhi};\n\t"
+              "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+              "add.u32 ta, ta, 8;\n\t"
+              "add.u32 blo, blo, 2;\n\t"
+              "mov.b64 db, {blo, dhi};\n\t"
+              "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+              "add.u32 ta, ta, 8;\n\t"
+              "add.u32 blo, blo, 2;\n\t"
+              "mov.b64 db, {blo, dhi};\n\t"
+              "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+              "add.u32 ta, ta, 8;\n\t"
+              "add.u32 blo, blo, 122;\n\t"
+              "mov.b64 db, {blo, dhi};\n\t"
+              "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+              "add.u32 ta, ta, 8;\n\t"
+              "add.u32 blo, blo, 2;\n\t"
+              "mov.b64 db, {blo, dhi};\n\t"
+              "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+              "add.u32 ta, ta, 8;\n\t"
+              "add.u32 blo, blo, 2;\n\t"
+              "mov.b64 db, {blo, dhi};\n\t"
+              "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+              "add.u32 ta, ta, 8;\n\t"
+              "add.u32 blo, blo, 2;\n\t"
+              "mov.b64 db, {blo, dhi};\n\t"
+              "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+              "}\n" ::"r"((tmem_tmem_q_state + ((int)o_stage_tcgen * 16))),
+              "r"(_mma_b_lo_1), "r"(tmem_tmem_state_inp), "r"(0));
+          elect_commit(decay_tcgen_done_addr + (decay_stage_tcgen) * 8);
+          {
+            mbarrier_wait(state_read_done_addr, state_phase_tcgen);
+          }
+#pragma unroll
+          for (int diag_block_tcgen = 0; diag_block_tcgen < 8; diag_block_tcgen++) {
+            int _mma_b_lo_2 =
+                make_warp_uniform((((smem_state_diag_addr) >> 4) & 0x3FFF) +
+                                  ((int)diag_stage_tcgen * 8 + diag_block_tcgen) * 32);
+            mma_ts_step((tmem_tmem_state + (diag_block_tcgen * 16)),
+                        tmem_tmem_state_inp + diag_block_tcgen * 8, _mma_b_lo_2, 0xC0004010,
+                        134481040, 0);
+          }
+          elect_commit(state_diag_done_addr + (diag_stage_tcgen) * 8);
+          mbarrier_wait(tinv_ready_addr + (intermediate_stage_tcgen) * 8,
+                        (unsigned int)(cumulative_tcgen / 2 & 1));
+          mbarrier_wait(y_inp_ready_addr, state_phase_tcgen);
+          int _mma_b_lo_3 = make_warp_uniform(((((smem_tinv_mn_addr) >> 4) & 0x3FFF) | 0x200000) +
+                                              (intermediate_stage_tcgen) * 64);
+          mma_ts_step(tmem_tmem_u_acc, tmem_tmem_y_inp, _mma_b_lo_3, 0xC0004010, 134546576, 0);
+          elect_commit2(tinv_done_addr + (intermediate_stage_tcgen) * 8, u_acc_ready_addr);
+          mbarrier_wait(u_inp_ready_addr, state_phase_tcgen);
+          int _mma_b_lo_4 = make_warp_uniform(
+              ((((smem_k_restore_mn_addr) >> 4) & 0x3FFF) | 0x800000) + (decay_stage_tcgen) * 256);
+          mma_ts_step(tmem_tmem_state, tmem_tmem_u_inp, _mma_b_lo_4, 0x40004040, 136381584, 1);
+          elect_commit2(k_restore_done_addr + (decay_stage_tcgen) * 8, state_acc_done_addr);
+          mbarrier_wait(a_ready_addr + (intermediate_stage_tcgen) * 8,
+                        (unsigned int)(cumulative_tcgen / 2 & 1));
+          int _mma_b_lo_5 = make_warp_uniform(((((smem_a_mn_addr) >> 4) & 0x3FFF) | 0x200000) +
+                                              (intermediate_stage_tcgen) * 64);
+          mma_ts_step((tmem_tmem_q_state + ((int)o_stage_tcgen * 16)), tmem_tmem_u_inp, _mma_b_lo_5,
+                      0xC0004010, 134546576, 1);
+          elect_commit2(o_acc_ready_addr, a_done_addr + (intermediate_stage_tcgen) * 8);
+        }
+        cumulative_chunk_tcgen += chunks_tcgen;
+      }
+      if (elect_sync()) {
+        mbarrier_arrive(consumers_done_addr);
+      }
+      unsigned int _phase_cleanup_ready_0 = 0;
+      mbarrier_wait(cleanup_ready_addr, _phase_cleanup_ready_0);
+      _phase_cleanup_ready_0 ^= 1;
+      int _tmem_dealloc_addr = *((volatile int*)tmem_addr_storage);
+      asm volatile(
+          "tcgen05.dealloc.cta_group::1.sync.aligned.b32 %0, %1;" ::"r"(_tmem_dealloc_addr),
+          "r"(512));
+    }
+  }
+  // ---- Role: tma ----
+  if (warp == 14) {
+    {  // tma_main
+      unsigned int sched_stage_tma = 0;
+      int cumulative_chunk_tma = 0;
+      unsigned int _phase_sched_done = 1;
+      if (elect_sync()) {
+#pragma unroll 1
+        for (int sched_iter_tma = 0; sched_iter_tma < total_work_items + 1; sched_iter_tma++) {
+          mbarrier_wait(sched_done_addr + (sched_stage_tma) * 8, _phase_sched_done);
+          unsigned int tile_tma = blockIdx.x;
+          if (uniform_work_items != 0) {
+            tile_tma =
+                (unsigned int)blockIdx.x + (unsigned int)sched_iter_tma * (unsigned int)gridDim.x;
+          } else if (sched_iter_tma > 0) {
+            unsigned int _atomic_old_0 = atomicAdd(dynamic_counter, 1);
+            tile_tma = (unsigned int)gridDim.x + _atomic_old_0;
+          }
+          asm volatile("st.shared.b32 [%0], %1;" ::"r"(sched_slot_addr + sched_stage_tma * 4),
+                       "r"(tile_tma));
+          mbarrier_arrive(sched_ready_addr + (sched_stage_tma) * 8);
+          sched_stage_tma += 1;
+          if (sched_stage_tma == 8) {
+            sched_stage_tma = 0;
+            _phase_sched_done ^= 1;
+          }
+          if (tile_tma >= (unsigned int)total_work_items) {
+            break;
+          }
+          int item_base_tma = (int)tile_tma * 8;
+          int _vec_load_0[4];
+          {
+            int4 _iv4 = *reinterpret_cast<const int4*>(work_items + item_base_tma);
+            _vec_load_0[0 + 0] = _iv4.x;
+            _vec_load_0[0 + 1] = _iv4.y;
+            _vec_load_0[0 + 2] = _iv4.z;
+            _vec_load_0[0 + 3] = _iv4.w;
+          }
+          int _vec_load_1[4];
+          {
+            int4 _iv4 = *reinterpret_cast<const int4*>(work_items + item_base_tma + 4);
+            _vec_load_1[0 + 0] = _iv4.x;
+            _vec_load_1[0 + 1] = _iv4.y;
+            _vec_load_1[0 + 2] = _iv4.z;
+            _vec_load_1[0 + 3] = _iv4.w;
+          }
+          int head_tma = _vec_load_0[1];
+          int qk_head_tma = head_tma * num_qk_heads / num_heads;
+          int wend_tma = _vec_load_0[3];
+          int cstart_tma = _vec_load_1[0];
+          long long bos_tma = (long long)_vec_load_1[2];
+          int chunks_tma = wend_tma - cstart_tma;
+#pragma unroll 1
+          for (int chunk_tma = 0; chunk_tma < chunks_tma; chunk_tma++) {
+            int cumulative_tma = cumulative_chunk_tma + chunk_tma;
+            unsigned int raw_stage_tma = (unsigned int)(cumulative_tma % 5);
+            unsigned int raw_bar_stage_tma = (unsigned int)(cumulative_tma % 6);
+            unsigned int raw_done_phase_tma = (unsigned int)(cumulative_tma / 5 + 1 & 1);
+            mbarrier_wait(q_done_addr + (raw_stage_tma) * 8, raw_done_phase_tma);
+            mbarrier_wait(k_done_addr + (raw_stage_tma) * 8, raw_done_phase_tma);
+            mbarrier_wait(v_done_addr + (raw_stage_tma) * 8, raw_done_phase_tma);
+            mbarrier_wait(g_done_addr + (raw_stage_tma) * 8, raw_done_phase_tma);
+            mbarrier_arrive_expect_tx(q_ready_addr + (raw_bar_stage_tma) * 8, 4096);
+            mbarrier_arrive_expect_tx(k_ready_addr + (raw_bar_stage_tma) * 8, 4096);
+            mbarrier_arrive_expect_tx(v_ready_addr + (raw_bar_stage_tma) * 8, 4096);
+            {
+              mbarrier_arrive(g_ready_addr + (raw_bar_stage_tma) * 8);
+            }
+            int logical_chunk_tma = cstart_tma + chunk_tma;
+            int token_tma = (int)(bos_tma + (long long)logical_chunk_tma * 16);
+#pragma unroll
+            for (int segment_tma = 0; segment_tma < 2; segment_tma++) {
+              int segment_offset_tma = segment_tma * 16 * 64 * 2;
+              int segment_dim_tma = segment_tma * 64;
+              tma_3d_gmem2smem(
+                  smem_q_addr + raw_stage_tma * 4096 + (unsigned int)segment_offset_tma, (&q_tma),
+                  segment_dim_tma, qk_head_tma, token_tma, q_ready_addr + (raw_bar_stage_tma) * 8);
+              tma_3d_gmem2smem(
+                  smem_k_addr + raw_stage_tma * 4096 + (unsigned int)segment_offset_tma, (&k_tma),
+                  segment_dim_tma, qk_head_tma, token_tma, k_ready_addr + (raw_bar_stage_tma) * 8);
+              tma_3d_gmem2smem(
+                  smem_v_addr + raw_stage_tma * 4096 + (unsigned int)segment_offset_tma, (&v_tma),
+                  segment_dim_tma, head_tma, token_tma, v_ready_addr + (raw_bar_stage_tma) * 8);
+            }
+          }
+          cumulative_chunk_tma += chunks_tma;
+        }
+      }
+      unsigned int _phase_consumers_done_0 = 0;
+      mbarrier_wait(consumers_done_addr, _phase_consumers_done_0);
+      _phase_consumers_done_0 ^= 1;
+      if (elect_sync()) {
+        mbarrier_arrive(cleanup_ready_addr);
+      }
+    }
+  }
+  // ---- Role: epilogue ----
+  if (warp == 15) {
+    {  // epilogue_main
+      unsigned int sched_stage_epi = 0;
+      int cumulative_chunk_epi = 0;
+      int lhs_row_epi = lane % 8 + (lane / 8 & 1) * 8;
+      int lhs_col_epi = lane / 16 * 8;
+      int rhs_row_epi = lane % 8 + lane / 16 * 8;
+      int rhs_col_epi = (lane / 8 & 1) * 8;
+      unsigned int _phase_sched_ready_4 = 0;
+#pragma unroll 1
+      for (int __4 = 0; __4 < total_work_items + 1; __4++) {
+        mbarrier_wait(sched_ready_addr + (sched_stage_epi) * 8, _phase_sched_ready_4);
+        unsigned int slot_4[1];
+        asm volatile("ld.shared.b32 %0, [%1];"
+                     : "=r"(*reinterpret_cast<uint32_t*>(&slot_4[0]))
+                     : "r"(sched_slot_addr + sched_stage_epi * 4));
+        unsigned int tile_epi = slot_4[0];
+        if (elect_sync()) {
+          mbarrier_arrive(sched_done_addr + (sched_stage_epi) * 8);
+        }
+        sched_stage_epi += 1;
+        if (sched_stage_epi == 8) {
+          sched_stage_epi = 0;
+          _phase_sched_ready_4 ^= 1;
+        }
+        if (tile_epi >= (unsigned int)total_work_items) {
+          break;
+        }
+        int item_base_epi = (int)tile_epi * 8;
+        int _vec_load_3[4];
+        {
+          int4 _iv4 = *reinterpret_cast<const int4*>(work_items + item_base_epi);
+          _vec_load_3[0 + 0] = _iv4.x;
+          _vec_load_3[0 + 1] = _iv4.y;
+          _vec_load_3[0 + 2] = _iv4.z;
+          _vec_load_3[0 + 3] = _iv4.w;
+        }
+        int seq_epi = _vec_load_3[0];
+        int head_epi = _vec_load_3[1];
+        int wstart_epi = _vec_load_3[2];
+        int wend_epi = _vec_load_3[3];
+        int cstart_epi = work_items[item_base_epi + 4];
+        long long bos_epi = (long long)work_items[item_base_epi + 6];
+        int chunks_epi = wend_epi - cstart_epi;
+        long long checkpoint_base_epi = checkpoint_cu_starts[seq_epi];
+        if (ENABLE_CHECKPOINTS != 0 && chunks_epi > 0) {
+          int checkpoint_event_epi = cumulative_chunk_epi;
+          unsigned int checkpoint_stage_epi = (unsigned int)(checkpoint_event_epi % 2);
+          mbarrier_wait(checkpoint_ready_addr + (checkpoint_stage_epi) * 8,
+                        (unsigned int)(checkpoint_event_epi / 2 & 1));
+          if (wstart_epi == 0) {
+            if (elect_sync()) {
+#pragma unroll
+              for (int segment_checkpoint_epi = 0; segment_checkpoint_epi < 2;
+                   segment_checkpoint_epi++) {
+                tma_store_4d((&checkpoint_tma), segment_checkpoint_epi * 64, 0, head_epi,
+                             checkpoint_base_epi,
+                             smem_checkpoint_addr + checkpoint_stage_epi * 32768 +
+                                 (unsigned int)(segment_checkpoint_epi * 128 * 64 * 2));
+              }
+            }
+            asm volatile("cp.async.bulk.commit_group;");
+            asm volatile("cp.async.bulk.wait_group.read 0;");
+          }
+          mbarrier_arrive(checkpoint_done_addr + (checkpoint_stage_epi) * 8);
+        }
+#pragma unroll 1
+        for (int chunk_epi = 0; chunk_epi < chunks_epi; chunk_epi++) {
+          int cumulative_epi = cumulative_chunk_epi + chunk_epi;
+          int logical_chunk_epi = cstart_epi + chunk_epi;
+          unsigned int decay_stage_epi = (unsigned int)(cumulative_epi % 2);
+          unsigned int diag_stage_epi = (unsigned int)(cumulative_epi % 4);
+          unsigned int intermediate_stage_epi = (unsigned int)(cumulative_epi % 2);
+          mbarrier_wait(qk_scale_ready_addr + (diag_stage_epi) * 8,
+                        (unsigned int)(cumulative_epi / 4 & 1));
+          mbarrier_wait(a_done_addr + (intermediate_stage_epi) * 8,
+                        (unsigned int)(cumulative_epi / 2 + 1 & 1));
+          float a_acc_epi[8];
+#pragma unroll
+          for (int k_block_epi = 0; k_block_epi < 8; k_block_epi++) {
+            unsigned int a_frag_epi[4];
+            unsigned int b_frag_epi[4];
+            asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                         : "=r"(a_frag_epi[0]), "=r"(a_frag_epi[1]), "=r"(a_frag_epi[2]),
+                           "=r"(a_frag_epi[3])
+                         : "r"((smem_q_decay_addr + decay_stage_epi * 4096 +
+                                (unsigned int)((k_block_epi * 16 + lhs_col_epi) / 64 * 2048 +
+                                                   lhs_row_epi * 128 +
+                                                   (k_block_epi * 16 + lhs_col_epi) % 64 * 2 ^
+                                               ((k_block_epi * 16 + lhs_col_epi) / 64 * 2048 +
+                                                        lhs_row_epi * 128 +
+                                                        (k_block_epi * 16 + lhs_col_epi) % 64 * 2 >>
+                                                    7 &
+                                                7) << 4)))
+                         : "memory");
+            asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                         : "=r"(b_frag_epi[0]), "=r"(b_frag_epi[1]), "=r"(b_frag_epi[2]),
+                           "=r"(b_frag_epi[3])
+                         : "r"((smem_k_inv_addr + decay_stage_epi * 4096 +
+                                (unsigned int)((k_block_epi * 16 + rhs_col_epi) / 64 * 2048 +
+                                                   rhs_row_epi * 128 +
+                                                   (k_block_epi * 16 + rhs_col_epi) % 64 * 2 ^
+                                               ((k_block_epi * 16 + rhs_col_epi) / 64 * 2048 +
+                                                        rhs_row_epi * 128 +
+                                                        (k_block_epi * 16 + rhs_col_epi) % 64 * 2 >>
+                                                    7 &
+                                                7) << 4)))
+                         : "memory");
+            asm volatile(
+                "mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, "
+                "%6, %7}, {%8, %9}, {%10, %11, %12, %13};\n"
+                : "=f"(a_acc_epi[0]), "=f"(a_acc_epi[1]), "=f"(a_acc_epi[2]), "=f"(a_acc_epi[3])
+                : "r"(a_frag_epi[0]), "r"(a_frag_epi[1]), "r"(a_frag_epi[2]), "r"(a_frag_epi[3]),
+                  "r"(b_frag_epi[0]), "r"(b_frag_epi[1]),
+                  "f"(((k_block_epi == 0) ? 0.0f : a_acc_epi[0])),
+                  "f"(((k_block_epi == 0) ? 0.0f : a_acc_epi[1])),
+                  "f"(((k_block_epi == 0) ? 0.0f : a_acc_epi[2])),
+                  "f"(((k_block_epi == 0) ? 0.0f : a_acc_epi[3])));
+            asm volatile(
+                "mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, "
+                "%6, %7}, {%8, %9}, {%10, %11, %12, %13};\n"
+                : "=f"(a_acc_epi[4]), "=f"(a_acc_epi[(4) + 1]), "=f"(a_acc_epi[(4) + 2]),
+                  "=f"(a_acc_epi[(4) + 3])
+                : "r"(a_frag_epi[0]), "r"(a_frag_epi[1]), "r"(a_frag_epi[2]), "r"(a_frag_epi[3]),
+                  "r"(b_frag_epi[2]), "r"(b_frag_epi[(2) + 1]),
+                  "f"(((k_block_epi == 0) ? 0.0f : a_acc_epi[4])),
+                  "f"(((k_block_epi == 0) ? 0.0f : a_acc_epi[(4) + 1])),
+                  "f"(((k_block_epi == 0) ? 0.0f : a_acc_epi[(4) + 2])),
+                  "f"(((k_block_epi == 0) ? 0.0f : a_acc_epi[(4) + 3])));
+          }
+          float a_values_epi[8];
+#pragma unroll
+          for (int accum_epi = 0; accum_epi < 8; accum_epi++) {
+            int row_epi = lane / 4 + accum_epi % 4 / 2 * 8;
+            int col_epi = accum_epi / 4 * 8 + (lane & 3) * 2 + (accum_epi & 1);
+            a_values_epi[accum_epi] = 0.0f;
+            if (row_epi >= col_epi) {
+              a_values_epi[accum_epi] = a_acc_epi[accum_epi];
+            }
+          }
+          unsigned int a_words_epi[4];
+#pragma unroll
+          for (int _lp = 0; _lp < 4; _lp++) {
+            __nv_bfloat162 _bf2 = __float22bfloat162_rn(
+                make_float2(a_values_epi[_lp * 2 + 0], a_values_epi[_lp * 2 + 1 + 0]));
+            a_words_epi[_lp] = *(uint32_t*)&_bf2;
+          }
+          uint32_t _stmatrix_addr_0 = static_cast<uint32_t>(
+              (unsigned long long)(smem_a_addr + intermediate_stage_epi * 1024 +
+                                   (unsigned int)(lane / 16 * 8 / 16 * 512 + lane % 16 * 32 +
+                                                      lane / 16 * 8 % 16 * 2 ^
+                                                  (lane / 16 * 8 / 16 * 512 + lane % 16 * 32 +
+                                                           lane / 16 * 8 % 16 * 2 >>
+                                                       7 &
+                                                   1) << 4)));
+          asm volatile("stmatrix.sync.aligned.m8n8.x4.shared.b16 [%0], {%1, %2, %3, %4};\n" ::"r"(
+                           _stmatrix_addr_0),
+                       "r"(*reinterpret_cast<const uint32_t*>(&a_words_epi[0])),
+                       "r"(*reinterpret_cast<const uint32_t*>(&a_words_epi[1])),
+                       "r"(*reinterpret_cast<const uint32_t*>(&a_words_epi[2])),
+                       "r"(*reinterpret_cast<const uint32_t*>(&a_words_epi[3]))
+                       : "memory");
+          asm volatile("fence.proxy.async.shared::cta;" ::: "memory");
+          mbarrier_arrive(a_ready_addr + (intermediate_stage_epi) * 8);
+          mbarrier_arrive(decay_super_done_addr + (decay_stage_epi) * 8);
+          if (chunk_epi > 0) {
+            {
+              int checkpoint_event_loop_epi = cumulative_epi;
+              unsigned int checkpoint_stage_loop_epi =
+                  (unsigned int)(checkpoint_event_loop_epi % 2);
+              mbarrier_wait(checkpoint_ready_addr + (checkpoint_stage_loop_epi) * 8,
+                            (unsigned int)(checkpoint_event_loop_epi / 2 & 1));
+              if (logical_chunk_epi >= wstart_epi) {
+                if (elect_sync()) {
+#pragma unroll
+                  for (int checkpoint_segment_loop_epi = 0; checkpoint_segment_loop_epi < 2;
+                       checkpoint_segment_loop_epi++) {
+                    tma_store_4d((&checkpoint_tma), checkpoint_segment_loop_epi * 64, 0, head_epi,
+                                 checkpoint_base_epi + (long long)logical_chunk_epi,
+                                 smem_checkpoint_addr + checkpoint_stage_loop_epi * 32768 +
+                                     (unsigned int)(checkpoint_segment_loop_epi * 128 * 64 * 2));
+                  }
+                }
+                asm volatile("cp.async.bulk.commit_group;");
+                asm volatile("cp.async.bulk.wait_group.read 0;");
+              }
+              mbarrier_arrive(checkpoint_done_addr + (checkpoint_stage_loop_epi) * 8);
+            }
+            int output_event_epi = cumulative_epi - 1;
+            unsigned int output_stage_epi = (unsigned int)(output_event_epi % 2);
+            mbarrier_wait(o_tma_ready_addr + (output_stage_epi) * 8,
+                          (unsigned int)(output_event_epi / 2 & 1));
+            if (logical_chunk_epi > wstart_epi) {
+              if (elect_sync()) {
+#pragma unroll
+                for (int output_segment_epi = 0; output_segment_epi < 2; output_segment_epi++) {
+                  tma_store_3d((&out_tma), output_segment_epi * 64, head_epi,
+                               (int)(bos_epi + (long long)(logical_chunk_epi - 1) * 16),
+                               smem_o_addr + output_stage_epi * 4096 +
+                                   (unsigned int)(output_segment_epi * 16 * 64 * 2));
+                }
+              }
+              asm volatile("cp.async.bulk.commit_group;");
+              asm volatile("cp.async.bulk.wait_group.read 0;");
+            }
+            mbarrier_arrive(o_tma_done_addr + (output_stage_epi) * 8);
+          }
+        }
+        if (chunks_epi > 0) {
+          int last_event_epi = cumulative_chunk_epi + chunks_epi - 1;
+          unsigned int last_o_stage_epi = (unsigned int)(last_event_epi % 2);
+          mbarrier_wait(o_tma_ready_addr + (last_o_stage_epi) * 8,
+                        (unsigned int)(last_event_epi / 2 & 1));
+          if (elect_sync()) {
+#pragma unroll
+            for (int last_segment_epi = 0; last_segment_epi < 2; last_segment_epi++) {
+              tma_store_3d((&out_tma), last_segment_epi * 64, head_epi,
+                           (int)(bos_epi + (long long)(wend_epi - 1) * 16),
+                           smem_o_addr + last_o_stage_epi * 4096 +
+                               (unsigned int)(last_segment_epi * 16 * 64 * 2));
+            }
+          }
+          asm volatile("cp.async.bulk.commit_group;");
+          asm volatile("cp.async.bulk.wait_group.read 0;");
+          mbarrier_arrive(o_tma_done_addr + (last_o_stage_epi) * 8);
+        }
+        cumulative_chunk_epi += chunks_epi;
+      }
+      if (elect_sync()) {
+        mbarrier_arrive(consumers_done_addr);
+      }
+    }
+  }
+
+  // Cleanup
+}
+
+}  // extern "C"
+
+#undef ENABLE_CHECKPOINTS
+#undef G_INPUT_BF16
+#undef LOOM_INF
+#undef NUM_CHECKPOINT_PIPE_STAGES
+#undef NUM_DECAY_PIPE_STAGES
+#undef NUM_DIAG_PIPE_STAGES
+#undef NUM_INTERMEDIATE_PIPE_STAGES
+#undef NUM_O_PIPE_STAGES
+#undef NUM_RAW_BAR_PIPE_STAGES
+#undef NUM_RAW_PIPE_STAGES
+#undef NUM_SCHED_PIPE_STAGES
+#undef NUM_STATE_PIPE_STAGES
+#undef SMEM_SCHED_SLOT_OFF
+#undef SMEM_SCHED_SLOT_STAGE_BYTES
+#undef SMEM_SCHED_SLOT_STRIDE
+#undef SMEM_SMEM_A_MN_OFF
+#undef SMEM_SMEM_A_MN_STAGE_BYTES
+#undef SMEM_SMEM_A_MN_STRIDE
+#undef SMEM_SMEM_A_OFF
+#undef SMEM_SMEM_A_STAGE_BYTES
+#undef SMEM_SMEM_A_STRIDE
+#undef SMEM_SMEM_BETA_ALL_OFF
+#undef SMEM_SMEM_BETA_ALL_STAGE_BYTES
+#undef SMEM_SMEM_BETA_ALL_STRIDE
+#undef SMEM_SMEM_BETA_OFF
+#undef SMEM_SMEM_BETA_STAGE_BYTES
+#undef SMEM_SMEM_BETA_STRIDE
+#undef SMEM_SMEM_CHECKPOINT_OFF
+#undef SMEM_SMEM_CHECKPOINT_STAGE_BYTES
+#undef SMEM_SMEM_CHECKPOINT_STRIDE
+#undef SMEM_SMEM_G_ALL_OFF
+#undef SMEM_SMEM_G_ALL_STAGE_BYTES
+#undef SMEM_SMEM_G_ALL_STRIDE
+#undef SMEM_SMEM_G_OFF
+#undef SMEM_SMEM_G_STAGE_BYTES
+#undef SMEM_SMEM_G_STRIDE
+#undef SMEM_SMEM_K_ALL_OFF
+#undef SMEM_SMEM_K_ALL_STAGE_BYTES
+#undef SMEM_SMEM_K_ALL_STRIDE
+#undef SMEM_SMEM_K_DECAY_OFF
+#undef SMEM_SMEM_K_DECAY_STAGE_BYTES
+#undef SMEM_SMEM_K_DECAY_STRIDE
+#undef SMEM_SMEM_K_INV_OFF
+#undef SMEM_SMEM_K_INV_STAGE_BYTES
+#undef SMEM_SMEM_K_INV_STRIDE
+#undef SMEM_SMEM_K_OFF
+#undef SMEM_SMEM_K_RESTORE_MN_OFF
+#undef SMEM_SMEM_K_RESTORE_MN_STAGE_BYTES
+#undef SMEM_SMEM_K_RESTORE_MN_STRIDE
+#undef SMEM_SMEM_K_RESTORE_OFF
+#undef SMEM_SMEM_K_RESTORE_STAGE_BYTES
+#undef SMEM_SMEM_K_RESTORE_STRIDE
+#undef SMEM_SMEM_K_STAGE_BYTES
+#undef SMEM_SMEM_K_STRIDE
+#undef SMEM_SMEM_O_ALL_OFF
+#undef SMEM_SMEM_O_ALL_STAGE_BYTES
+#undef SMEM_SMEM_O_ALL_STRIDE
+#undef SMEM_SMEM_O_OFF
+#undef SMEM_SMEM_O_STAGE_BYTES
+#undef SMEM_SMEM_O_STRIDE
+#undef SMEM_SMEM_Q_ALL_OFF
+#undef SMEM_SMEM_Q_ALL_STAGE_BYTES
+#undef SMEM_SMEM_Q_ALL_STRIDE
+#undef SMEM_SMEM_Q_DECAY_OFF
+#undef SMEM_SMEM_Q_DECAY_STAGE_BYTES
+#undef SMEM_SMEM_Q_DECAY_STRIDE
+#undef SMEM_SMEM_Q_OFF
+#undef SMEM_SMEM_Q_STAGE_BYTES
+#undef SMEM_SMEM_Q_STRIDE
+#undef SMEM_SMEM_STATE_DIAG_OFF
+#undef SMEM_SMEM_STATE_DIAG_STAGE_BYTES
+#undef SMEM_SMEM_STATE_DIAG_STRIDE
+#undef SMEM_SMEM_TINV_MN_OFF
+#undef SMEM_SMEM_TINV_MN_STAGE_BYTES
+#undef SMEM_SMEM_TINV_MN_STRIDE
+#undef SMEM_SMEM_TINV_OFF
+#undef SMEM_SMEM_TINV_STAGE_BYTES
+#undef SMEM_SMEM_TINV_STRIDE
+#undef SMEM_SMEM_V_ALL_OFF
+#undef SMEM_SMEM_V_ALL_STAGE_BYTES
+#undef SMEM_SMEM_V_ALL_STRIDE
+#undef SMEM_SMEM_V_OFF
+#undef SMEM_SMEM_V_STAGE_BYTES
+#undef SMEM_SMEM_V_STRIDE
+#undef SMEM_TINV_SCRATCH_OFF
+#undef SMEM_TINV_SCRATCH_STAGE_BYTES
+#undef SMEM_TINV_SCRATCH_STRIDE
+#undef SMEM_TOTAL
+#undef STORE_BETA_ACTIVE
+#undef STORE_FINAL_STATE
+#undef THREADS
+#undef TMEM_NCOLS
+#undef TMEM_TMEM_Q_STATE_OFFSET
+#undef TMEM_TMEM_STATE_INP_OFFSET
+#undef TMEM_TMEM_STATE_K_OFFSET
+#undef TMEM_TMEM_STATE_OFFSET
+#undef TMEM_TMEM_U_ACC_OFFSET
+#undef TMEM_TMEM_U_INP_OFFSET
+#undef TMEM_TMEM_Y_INP_OFFSET
+#undef USE_INITIAL_STATE
+#undef a_done_addr
+#undef a_ready_addr
+#undef beta_done_addr
+#undef beta_ready_addr
+#undef checkpoint_done_addr
+#undef checkpoint_ready_addr
+#undef cleanup_ready_addr
+#undef consumers_done_addr
+#undef decay_super_done_addr
+#undef decay_tcgen_done_addr
+#undef g_done_addr
+#undef g_ready_addr
+#undef k_decay_inv_ready_addr
+#undef k_done_addr
+#undef k_ready_addr
+#undef k_restore_done_addr
+#undef o_acc_done_addr
+#undef o_acc_ready_addr
+#undef o_tma_done_addr
+#undef o_tma_ready_addr
+#undef q_done_addr
+#undef q_ready_addr
+#undef qk_scale_ready_addr
+#undef sched_done_addr
+#undef sched_ready_addr
+#undef sched_slot_addr
+#undef smem_a_addr
+#undef smem_a_mn_addr
+#undef smem_beta_addr
+#undef smem_beta_all_addr
+#undef smem_checkpoint_addr
+#undef smem_g_addr
+#undef smem_g_all_addr
+#undef smem_k_addr
+#undef smem_k_all_addr
+#undef smem_k_decay_addr
+#undef smem_k_inv_addr
+#undef smem_k_restore_addr
+#undef smem_k_restore_mn_addr
+#undef smem_o_addr
+#undef smem_o_all_addr
+#undef smem_q_addr
+#undef smem_q_all_addr
+#undef smem_q_decay_addr
+#undef smem_state_diag_addr
+#undef smem_tinv_addr
+#undef smem_tinv_mn_addr
+#undef smem_v_addr
+#undef smem_v_all_addr
+#undef state_acc_done_addr
+#undef state_diag_done_addr
+#undef state_inp_ready_addr
+#undef state_k_ready_addr
+#undef state_read_done_addr
+#undef tinv_done_addr
+#undef tinv_ready_addr
+#undef tinv_scratch_addr
+#undef u_acc_ready_addr
+#undef u_inp_ready_addr
+#undef v_done_addr
+#undef v_ready_addr
+#undef y_inp_ready_addr
+
+#define LOOM_INF CUDART_INF_F
+#define TMEM_NCOLS 512
+#define TMEM_FLASHKDA_BWD_PERSISTENT_C16_ENVELOPE_OFFSET 0
+#define TMEM_FLASHKDA_BWD_PERSISTENT_C16_Y_OFFSET 432
+#define TMEM_FLASHKDA_BWD_PERSISTENT_C16_U_OFFSET 336
+#define TMEM_FLASHKDA_BWD_PERSISTENT_C16_DU_OFFSET 352
+#define TMEM_FLASHKDA_BWD_PERSISTENT_C16_STATE_K_OFFSET 320
+#define TMEM_FLASHKDA_BWD_PERSISTENT_C16_DU_INP_OFFSET 440
+#define TMEM_FLASHKDA_BWD_PERSISTENT_C16_DY_OFFSET 320
+#define TMEM_FLASHKDA_BWD_PERSISTENT_C16_NEG_DY_OFFSET 432
+#define TMEM_FLASHKDA_BWD_PERSISTENT_C16_DO_INP_OFFSET 440
+#define TMEM_FLASHKDA_BWD_PERSISTENT_C16_DSTATE_OFFSET 0
+#define TMEM_FLASHKDA_BWD_PERSISTENT_C16_DSTATE_INP_OFFSET 128
+#define TMEM_FLASHKDA_BWD_PERSISTENT_C16_DK_RESTORE_OFFSET 416
+#define TMEM_FLASHKDA_BWD_PERSISTENT_C16_DQ_OFFSET 368
+#define TMEM_FLASHKDA_BWD_PERSISTENT_C16_DK_DECAY_OFFSET 384
+#define TMEM_FLASHKDA_BWD_PERSISTENT_C16_DK_INV_OFFSET 400
+#define NUM_SCHED_PIPE_STAGES 8
+#define NUM_RAW_PIPE_STAGES 2
+#define NUM_OPERAND_PIPE_STAGES 2
+#define NUM_INTERMEDIATE_PIPE_STAGES 2
+#define NUM_TCGEN_DATA_PIPE_STAGES 1
+#define NUM_DSTATE_RECURRENCE_PIPE_STAGES 1
+#define NUM_U_SMEM_PIPE_STAGES 1
+#define NUM_DSTATE_SMEM_PIPE_STAGES 1
+#define NUM_BOUNDARY_PIPE_STAGES 1
+#define NUM_BOUNDARY_LOCAL_GRAD_PIPE_STAGES 1
+#define NUM_DK_RESTORE_PIPE_STAGES 1
+#define NUM_DY_SMEM_PIPE_STAGES 1
+#define NUM_BETA_DY_SMEM_PIPE_STAGES 2
+#define NUM_DBETA_M_PIPE_STAGES 1
+#define NUM_LOCAL_GRAD_PIPE_STAGES 1
+#define NUM_QK_RAW_PIPE_STAGES 4
+#define NUM_G_PREFIX_PIPE_STAGES 2
+#define NUM_STATE_SMEM_PIPE_STAGES 2
+#define SMEM_STATE_OPERAND_OFF 1024
+#define SMEM_STATE_OPERAND_STAGE_BYTES 32768
+#define SMEM_STATE_OPERAND_STRIDE 32768
+#define SMEM_STATE_OPERAND_MN_OFF 1024
+#define SMEM_STATE_OPERAND_MN_STAGE_BYTES 32768
+#define SMEM_STATE_OPERAND_MN_STRIDE 32768
+#define SMEM_STATE_PANEL_OFF 1024
+#define SMEM_STATE_PANEL_STAGE_BYTES 16384
+#define SMEM_STATE_PANEL_STRIDE 16384
+#define SMEM_STATE_OPERAND_ALL_OFF 1024
+#define SMEM_STATE_OPERAND_ALL_STAGE_BYTES 65536
+#define SMEM_STATE_OPERAND_ALL_STRIDE 65536
+#define SMEM_WORK_ITEM_OFF 230368
+#define SMEM_WORK_ITEM_STAGE_BYTES 4
+#define SMEM_WORK_ITEM_STRIDE 4
+#define SMEM_RAW_Q_OFF 66560
+#define SMEM_RAW_Q_STAGE_BYTES 4096
+#define SMEM_RAW_Q_STRIDE 4096
+#define SMEM_RAW_K_OFF 74752
+#define SMEM_RAW_K_STAGE_BYTES 4096
+#define SMEM_RAW_K_STRIDE 4096
+#define SMEM_RAW_G_OFF 82944
+#define SMEM_RAW_G_STAGE_BYTES 4096
+#define SMEM_RAW_G_STRIDE 4096
+#define SMEM_RAW_DO_OFF 91136
+#define SMEM_RAW_DO_STAGE_BYTES 4096
+#define SMEM_RAW_DO_STRIDE 4096
+#define SMEM_RAW_DO_AMAJ_OFF 91136
+#define SMEM_RAW_DO_AMAJ_STAGE_BYTES 4096
+#define SMEM_RAW_DO_AMAJ_STRIDE 4096
+#define SMEM_RAW_V_OFF 99328
+#define SMEM_RAW_V_STAGE_BYTES 4096
+#define SMEM_RAW_V_STRIDE 4096
+#define SMEM_BETA_DY_SMEM_OFF 107520
+#define SMEM_BETA_DY_SMEM_STAGE_BYTES 4096
+#define SMEM_BETA_DY_SMEM_STRIDE 4096
+#define SMEM_RAW_V_ALL_OFF 99328
+#define SMEM_RAW_V_ALL_STAGE_BYTES 8192
+#define SMEM_RAW_V_ALL_STRIDE 8192
+#define SMEM_BETA_SMEM_OFF 220160
+#define SMEM_BETA_SMEM_STAGE_BYTES 256
+#define SMEM_BETA_SMEM_STRIDE 256
+#define SMEM_BETA_SMEM_ALL_OFF 220160
+#define SMEM_BETA_SMEM_ALL_STAGE_BYTES 512
+#define SMEM_BETA_SMEM_ALL_STRIDE 512
+#define SMEM_DBETA_M_SMEM_OFF 220672
+#define SMEM_DBETA_M_SMEM_STAGE_BYTES 64
+#define SMEM_DBETA_M_SMEM_STRIDE 64
+#define SMEM_DBETA_RED_SMEM_OFF 220736
+#define SMEM_DBETA_RED_SMEM_STAGE_BYTES 256
+#define SMEM_DBETA_RED_SMEM_STRIDE 256
+#define SMEM_QK_NORM_SMEM_OFF 220992
+#define SMEM_QK_NORM_SMEM_STAGE_BYTES 128
+#define SMEM_QK_NORM_SMEM_STRIDE 128
+#define SMEM_QK_NORM_SMEM_ALL_OFF 220992
+#define SMEM_QK_NORM_SMEM_ALL_STAGE_BYTES 512
+#define SMEM_QK_NORM_SMEM_ALL_STRIDE 512
+#define SMEM_QK_RED_SMEM_OFF 221504
+#define SMEM_QK_RED_SMEM_STAGE_BYTES 256
+#define SMEM_QK_RED_SMEM_STRIDE 256
+#define SMEM_RAW_DO_ALL_OFF 91136
+#define SMEM_RAW_DO_ALL_STAGE_BYTES 8192
+#define SMEM_RAW_DO_ALL_STRIDE 8192
+#define SMEM_RAW_Q_ALL_OFF 66560
+#define SMEM_RAW_Q_ALL_STAGE_BYTES 8192
+#define SMEM_RAW_Q_ALL_STRIDE 8192
+#define SMEM_RAW_K_ALL_OFF 74752
+#define SMEM_RAW_K_ALL_STAGE_BYTES 8192
+#define SMEM_RAW_K_ALL_STRIDE 8192
+#define SMEM_RAW_G_ALL_OFF 82944
+#define SMEM_RAW_G_ALL_STAGE_BYTES 8192
+#define SMEM_RAW_G_ALL_STRIDE 8192
+#define SMEM_G_PREFIX_OFF 115712
+#define SMEM_G_PREFIX_STAGE_BYTES 8192
+#define SMEM_G_PREFIX_STRIDE 8192
+#define SMEM_G_PREFIX_ALL_OFF 115712
+#define SMEM_G_PREFIX_ALL_STAGE_BYTES 16384
+#define SMEM_G_PREFIX_ALL_STRIDE 16384
+#define SMEM_K_INV_OPERAND_OFF 132096
+#define SMEM_K_INV_OPERAND_STAGE_BYTES 4096
+#define SMEM_K_INV_OPERAND_STRIDE 4096
+#define SMEM_K_INV_LEAD16_OFF 132096
+#define SMEM_K_INV_LEAD16_STAGE_BYTES 4096
+#define SMEM_K_INV_LEAD16_STRIDE 4096
+#define SMEM_K_INV_AMAJ_OFF 132096
+#define SMEM_K_INV_AMAJ_STAGE_BYTES 4096
+#define SMEM_K_INV_AMAJ_STRIDE 4096
+#define SMEM_K_DECAY_OPERAND_OFF 140288
+#define SMEM_K_DECAY_OPERAND_STAGE_BYTES 4096
+#define SMEM_K_DECAY_OPERAND_STRIDE 4096
+#define SMEM_K_DECAY_LEAD16_OFF 140288
+#define SMEM_K_DECAY_LEAD16_STAGE_BYTES 4096
+#define SMEM_K_DECAY_LEAD16_STRIDE 4096
+#define SMEM_K_DECAY_TRANS_OFF 140288
+#define SMEM_K_DECAY_TRANS_STAGE_BYTES 4096
+#define SMEM_K_DECAY_TRANS_STRIDE 4096
+#define SMEM_Q_DECAY_OPERAND_OFF 148480
+#define SMEM_Q_DECAY_OPERAND_STAGE_BYTES 4096
+#define SMEM_Q_DECAY_OPERAND_STRIDE 4096
+#define SMEM_Q_DECAY_TRANS_OFF 148480
+#define SMEM_Q_DECAY_TRANS_STAGE_BYTES 4096
+#define SMEM_Q_DECAY_TRANS_STRIDE 4096
+#define SMEM_K_RESTORE_OPERAND_OFF 156672
+#define SMEM_K_RESTORE_OPERAND_STAGE_BYTES 4096
+#define SMEM_K_RESTORE_OPERAND_STRIDE 4096
+#define SMEM_K_RESTORE_LEAD16_OFF 156672
+#define SMEM_K_RESTORE_LEAD16_STAGE_BYTES 4096
+#define SMEM_K_RESTORE_LEAD16_STRIDE 4096
+#define SMEM_K_INV_ALL_OFF 132096
+#define SMEM_K_INV_ALL_STAGE_BYTES 8192
+#define SMEM_K_INV_ALL_STRIDE 8192
+#define SMEM_K_DECAY_ALL_OFF 140288
+#define SMEM_K_DECAY_ALL_STAGE_BYTES 8192
+#define SMEM_K_DECAY_ALL_STRIDE 8192
+#define SMEM_Q_DECAY_ALL_OFF 148480
+#define SMEM_Q_DECAY_ALL_STAGE_BYTES 8192
+#define SMEM_Q_DECAY_ALL_STRIDE 8192
+#define SMEM_K_RESTORE_ALL_OFF 156672
+#define SMEM_K_RESTORE_ALL_STAGE_BYTES 8192
+#define SMEM_K_RESTORE_ALL_STRIDE 8192
+#define SMEM_TINV_SCRATCH_OFF 164864
+#define SMEM_TINV_SCRATCH_STAGE_BYTES 512
+#define SMEM_TINV_SCRATCH_STRIDE 512
+#define SMEM_INTERMEDIATE_A_OFF 165376
+#define SMEM_INTERMEDIATE_A_STAGE_BYTES 512
+#define SMEM_INTERMEDIATE_A_STRIDE 2560
+#define SMEM_INTERMEDIATE_TINV_OFF 165888
+#define SMEM_INTERMEDIATE_TINV_STAGE_BYTES 512
+#define SMEM_INTERMEDIATE_TINV_STRIDE 2560
+#define SMEM_INTERMEDIATE_DA_OFF 166400
+#define SMEM_INTERMEDIATE_DA_STAGE_BYTES 512
+#define SMEM_INTERMEDIATE_DA_STRIDE 2560
+#define SMEM_INTERMEDIATE_DM_OFF 166912
+#define SMEM_INTERMEDIATE_DM_STAGE_BYTES 512
+#define SMEM_INTERMEDIATE_DM_STRIDE 2560
+#define SMEM_INTERMEDIATE_NDM_OFF 167424
+#define SMEM_INTERMEDIATE_NDM_STAGE_BYTES 512
+#define SMEM_INTERMEDIATE_NDM_STRIDE 2560
+#define SMEM_INTERMEDIATE_A_MN_OFF 165376
+#define SMEM_INTERMEDIATE_A_MN_STAGE_BYTES 512
+#define SMEM_INTERMEDIATE_A_MN_STRIDE 2560
+#define SMEM_INTERMEDIATE_TINV_MN_OFF 165888
+#define SMEM_INTERMEDIATE_TINV_MN_STAGE_BYTES 512
+#define SMEM_INTERMEDIATE_TINV_MN_STRIDE 2560
+#define SMEM_INTERMEDIATE_DA_MN_OFF 166400
+#define SMEM_INTERMEDIATE_DA_MN_STAGE_BYTES 512
+#define SMEM_INTERMEDIATE_DA_MN_STRIDE 2560
+#define SMEM_INTERMEDIATE_NDM_MN_OFF 167424
+#define SMEM_INTERMEDIATE_NDM_MN_STAGE_BYTES 512
+#define SMEM_INTERMEDIATE_NDM_MN_STRIDE 2560
+#define SMEM_STATE_SCALE_DIAG_OFF 170496
+#define SMEM_STATE_SCALE_DIAG_STAGE_BYTES 512
+#define SMEM_STATE_SCALE_DIAG_STRIDE 512
+#define SMEM_U_SMEM_OFF 179200
+#define SMEM_U_SMEM_STAGE_BYTES 4096
+#define SMEM_U_SMEM_STRIDE 4096
+#define SMEM_U_SMEM_ALL_OFF 179200
+#define SMEM_U_SMEM_ALL_STAGE_BYTES 4096
+#define SMEM_U_SMEM_ALL_STRIDE 4096
+#define SMEM_U_LEAD16_OFF 179200
+#define SMEM_U_LEAD16_STAGE_BYTES 4096
+#define SMEM_U_LEAD16_STRIDE 4096
+#define SMEM_DSTATE_SMEM_OFF 183296
+#define SMEM_DSTATE_SMEM_STAGE_BYTES 32768
+#define SMEM_DSTATE_SMEM_STRIDE 32768
+#define SMEM_DSTATE_SMEM_MN_OFF 183296
+#define SMEM_DSTATE_SMEM_MN_STAGE_BYTES 32768
+#define SMEM_DSTATE_SMEM_MN_STRIDE 32768
+#define SMEM_DSTATE_SMEM_ALL_OFF 183296
+#define SMEM_DSTATE_SMEM_ALL_STAGE_BYTES 32768
+#define SMEM_DSTATE_SMEM_ALL_STRIDE 32768
+#define SMEM_DY_SMEM_OFF 216064
+#define SMEM_DY_SMEM_STAGE_BYTES 4096
+#define SMEM_DY_SMEM_STRIDE 4096
+#define SMEM_DY_SMEM_ALL_OFF 216064
+#define SMEM_DY_SMEM_ALL_STAGE_BYTES 4096
+#define SMEM_DY_SMEM_ALL_STRIDE 4096
+#define SMEM_DEBUG_DU_SMEM_OFF 221760
+#define SMEM_DEBUG_DU_SMEM_STAGE_BYTES 4096
+#define SMEM_DEBUG_DU_SMEM_STRIDE 4096
+#define SMEM_DEBUG_DU_SMEM_ALL_OFF 221760
+#define SMEM_DEBUG_DU_SMEM_ALL_STAGE_BYTES 4096
+#define SMEM_DEBUG_DU_SMEM_ALL_STRIDE 4096
+#define SMEM_BOUNDARY_STATE_SMEM_OFF 221760
+#define SMEM_BOUNDARY_STATE_SMEM_STAGE_BYTES 512
+#define SMEM_BOUNDARY_STATE_SMEM_STRIDE 512
+#define SMEM_TOTAL 230400
+#define THREADS 512
+#define validate_outputs 0
+#define USE_DSTATE_IN 1
+
+extern "C" {
+
+__global__ __launch_bounds__(512, 1) void kernel_flashkda_backward_persistent_c16(
+    unsigned int* __restrict__ dynamic_counter, const __grid_constant__ CUtensorMap q_tma,
+    const __grid_constant__ CUtensorMap k_tma, const __grid_constant__ CUtensorMap g_tma,
+    const __grid_constant__ CUtensorMap do_tma, const __grid_constant__ CUtensorMap v_tma,
+    const __grid_constant__ CUtensorMap state_tma, float* __restrict__ dfinal_state,
+    const __grid_constant__ CUtensorMap dv_tma, __nv_bfloat16* __restrict__ dq_out,
+    __nv_bfloat16* __restrict__ dk_out, float* __restrict__ dgate_out,
+    float* __restrict__ dgate_boundary_out, float* __restrict__ dinitial_state,
+    float* __restrict__ A_log, float* __restrict__ dt_bias,
+    const __grid_constant__ CUtensorMap beta_tma, float* __restrict__ dbeta,
+    long long* __restrict__ cu_seqlens, long long* __restrict__ checkpoint_cu_starts,
+    int* __restrict__ work_items, unsigned int* __restrict__ visits, float* __restrict__ observed,
+    float* __restrict__ raw_observed, float* __restrict__ gate_observed,
+    float* __restrict__ operand_observed, float* __restrict__ kk_observed,
+    float* __restrict__ tinv_observed, float* __restrict__ a_observed,
+    float* __restrict__ tcgen_observed, float* __restrict__ dstate_observed,
+    float* __restrict__ dk_restore_observed, float* __restrict__ da_observed,
+    float* __restrict__ dm_observed, float* __restrict__ local_grad_observed,
+    float* __restrict__ assembled_grad_observed, int total_work_items, int uniform_work_items,
+    int observed_chunks, int num_qk_heads, int num_heads, int enable_kk, int enable_tinv,
+    float scale, float lower_bound) {
+  const int tid = threadIdx.x;
+  const int warp = make_warp_uniform(tid / 32);
+  const int lane = tid % 32;
+
+  extern __shared__ __align__(1024) char smem_raw[];
+  int smem;
+  smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+
+  const int bid = blockIdx.x;
+  const int num_bids = gridDim.x;
+
+  // Kernel setup ops
+  __nv_bfloat16* state_operand = reinterpret_cast<__nv_bfloat16*>(smem_raw + 1024);
+  const int state_operand_addr = smem + 1024;
+  __nv_bfloat16* state_operand_mn = reinterpret_cast<__nv_bfloat16*>(smem_raw + 1024);
+  const int state_operand_mn_addr = smem + 1024;
+  __nv_bfloat16* state_panel = reinterpret_cast<__nv_bfloat16*>(smem_raw + 1024);
+  const int state_panel_addr = smem + 1024;
+  __nv_bfloat16* state_operand_all = reinterpret_cast<__nv_bfloat16*>(smem_raw + 1024);
+  const int state_operand_all_addr = smem + 1024;
+  unsigned int* work_item = reinterpret_cast<unsigned int*>(smem_raw + 230368);
+  const int work_item_addr = smem + 230368;
+  __nv_bfloat16* raw_q = reinterpret_cast<__nv_bfloat16*>(smem_raw + 66560);
+  const int raw_q_addr = smem + 66560;
+  __nv_bfloat16* raw_k = reinterpret_cast<__nv_bfloat16*>(smem_raw + 74752);
+  const int raw_k_addr = smem + 74752;
+  __nv_bfloat16* raw_g = reinterpret_cast<__nv_bfloat16*>(smem_raw + 82944);
+  const int raw_g_addr = smem + 82944;
+  __nv_bfloat16* raw_do = reinterpret_cast<__nv_bfloat16*>(smem_raw + 91136);
+  const int raw_do_addr = smem + 91136;
+  __nv_bfloat16* raw_do_amaj = reinterpret_cast<__nv_bfloat16*>(smem_raw + 91136);
+  const int raw_do_amaj_addr = smem + 91136;
+  __nv_bfloat16* raw_v = reinterpret_cast<__nv_bfloat16*>(smem_raw + 99328);
+  const int raw_v_addr = smem + 99328;
+  __nv_bfloat16* beta_dy_smem = reinterpret_cast<__nv_bfloat16*>(smem_raw + 107520);
+  const int beta_dy_smem_addr = smem + 107520;
+  __nv_bfloat16* raw_v_all = reinterpret_cast<__nv_bfloat16*>(smem_raw + 99328);
+  const int raw_v_all_addr = smem + 99328;
+  __nv_bfloat16* beta_smem = reinterpret_cast<__nv_bfloat16*>(smem_raw + 220160);
+  const int beta_smem_addr = smem + 220160;
+  __nv_bfloat16* beta_smem_all = reinterpret_cast<__nv_bfloat16*>(smem_raw + 220160);
+  const int beta_smem_all_addr = smem + 220160;
+  float* dbeta_m_smem = reinterpret_cast<float*>(smem_raw + 220672);
+  const int dbeta_m_smem_addr = smem + 220672;
+  float* dbeta_red_smem = reinterpret_cast<float*>(smem_raw + 220736);
+  const int dbeta_red_smem_addr = smem + 220736;
+  float* qk_norm_smem = reinterpret_cast<float*>(smem_raw + 220992);
+  const int qk_norm_smem_addr = smem + 220992;
+  float* qk_norm_smem_all = reinterpret_cast<float*>(smem_raw + 220992);
+  const int qk_norm_smem_all_addr = smem + 220992;
+  float* qk_red_smem = reinterpret_cast<float*>(smem_raw + 221504);
+  const int qk_red_smem_addr = smem + 221504;
+  __nv_bfloat16* raw_do_all = reinterpret_cast<__nv_bfloat16*>(smem_raw + 91136);
+  const int raw_do_all_addr = smem + 91136;
+  __nv_bfloat16* raw_q_all = reinterpret_cast<__nv_bfloat16*>(smem_raw + 66560);
+  const int raw_q_all_addr = smem + 66560;
+  __nv_bfloat16* raw_k_all = reinterpret_cast<__nv_bfloat16*>(smem_raw + 74752);
+  const int raw_k_all_addr = smem + 74752;
+  __nv_bfloat16* raw_g_all = reinterpret_cast<__nv_bfloat16*>(smem_raw + 82944);
+  const int raw_g_all_addr = smem + 82944;
+  float* g_prefix = reinterpret_cast<float*>(smem_raw + 115712);
+  const int g_prefix_addr = smem + 115712;
+  float* g_prefix_all = reinterpret_cast<float*>(smem_raw + 115712);
+  const int g_prefix_all_addr = smem + 115712;
+  __nv_bfloat16* k_inv_operand = reinterpret_cast<__nv_bfloat16*>(smem_raw + 132096);
+  const int k_inv_operand_addr = smem + 132096;
+  __nv_bfloat16* k_inv_lead16 = reinterpret_cast<__nv_bfloat16*>(smem_raw + 132096);
+  const int k_inv_lead16_addr = smem + 132096;
+  __nv_bfloat16* k_inv_amaj = reinterpret_cast<__nv_bfloat16*>(smem_raw + 132096);
+  const int k_inv_amaj_addr = smem + 132096;
+  __nv_bfloat16* k_decay_operand = reinterpret_cast<__nv_bfloat16*>(smem_raw + 140288);
+  const int k_decay_operand_addr = smem + 140288;
+  __nv_bfloat16* k_decay_lead16 = reinterpret_cast<__nv_bfloat16*>(smem_raw + 140288);
+  const int k_decay_lead16_addr = smem + 140288;
+  __nv_bfloat16* k_decay_trans = reinterpret_cast<__nv_bfloat16*>(smem_raw + 140288);
+  const int k_decay_trans_addr = smem + 140288;
+  __nv_bfloat16* q_decay_operand = reinterpret_cast<__nv_bfloat16*>(smem_raw + 148480);
+  const int q_decay_operand_addr = smem + 148480;
+  __nv_bfloat16* q_decay_trans = reinterpret_cast<__nv_bfloat16*>(smem_raw + 148480);
+  const int q_decay_trans_addr = smem + 148480;
+  __nv_bfloat16* k_restore_operand = reinterpret_cast<__nv_bfloat16*>(smem_raw + 156672);
+  const int k_restore_operand_addr = smem + 156672;
+  __nv_bfloat16* k_restore_lead16 = reinterpret_cast<__nv_bfloat16*>(smem_raw + 156672);
+  const int k_restore_lead16_addr = smem + 156672;
+  __nv_bfloat16* k_inv_all = reinterpret_cast<__nv_bfloat16*>(smem_raw + 132096);
+  const int k_inv_all_addr = smem + 132096;
+  __nv_bfloat16* k_decay_all = reinterpret_cast<__nv_bfloat16*>(smem_raw + 140288);
+  const int k_decay_all_addr = smem + 140288;
+  __nv_bfloat16* q_decay_all = reinterpret_cast<__nv_bfloat16*>(smem_raw + 148480);
+  const int q_decay_all_addr = smem + 148480;
+  __nv_bfloat16* k_restore_all = reinterpret_cast<__nv_bfloat16*>(smem_raw + 156672);
+  const int k_restore_all_addr = smem + 156672;
+  __nv_bfloat16* tinv_scratch = reinterpret_cast<__nv_bfloat16*>(smem_raw + 164864);
+  const int tinv_scratch_addr = smem + 164864;
+  __nv_bfloat16* intermediate_a = reinterpret_cast<__nv_bfloat16*>(smem_raw + 165376);
+  const int intermediate_a_addr = smem + 165376;
+  __nv_bfloat16* intermediate_tinv = reinterpret_cast<__nv_bfloat16*>(smem_raw + 165888);
+  const int intermediate_tinv_addr = smem + 165888;
+  __nv_bfloat16* intermediate_da = reinterpret_cast<__nv_bfloat16*>(smem_raw + 166400);
+  const int intermediate_da_addr = smem + 166400;
+  __nv_bfloat16* intermediate_dm = reinterpret_cast<__nv_bfloat16*>(smem_raw + 166912);
+  const int intermediate_dm_addr = smem + 166912;
+  __nv_bfloat16* intermediate_ndm = reinterpret_cast<__nv_bfloat16*>(smem_raw + 167424);
+  const int intermediate_ndm_addr = smem + 167424;
+  __nv_bfloat16* intermediate_a_mn = reinterpret_cast<__nv_bfloat16*>(smem_raw + 165376);
+  const int intermediate_a_mn_addr = smem + 165376;
+  __nv_bfloat16* intermediate_tinv_mn = reinterpret_cast<__nv_bfloat16*>(smem_raw + 165888);
+  const int intermediate_tinv_mn_addr = smem + 165888;
+  __nv_bfloat16* intermediate_da_mn = reinterpret_cast<__nv_bfloat16*>(smem_raw + 166400);
+  const int intermediate_da_mn_addr = smem + 166400;
+  __nv_bfloat16* intermediate_ndm_mn = reinterpret_cast<__nv_bfloat16*>(smem_raw + 167424);
+  const int intermediate_ndm_mn_addr = smem + 167424;
+  __nv_bfloat16* state_scale_diag = reinterpret_cast<__nv_bfloat16*>(smem_raw + 170496);
+  const int state_scale_diag_addr = smem + 170496;
+  __nv_bfloat16* u_smem = reinterpret_cast<__nv_bfloat16*>(smem_raw + 179200);
+  const int u_smem_addr = smem + 179200;
+  __nv_bfloat16* u_smem_all = reinterpret_cast<__nv_bfloat16*>(smem_raw + 179200);
+  const int u_smem_all_addr = smem + 179200;
+  __nv_bfloat16* u_lead16 = reinterpret_cast<__nv_bfloat16*>(smem_raw + 179200);
+  const int u_lead16_addr = smem + 179200;
+  __nv_bfloat16* dstate_smem = reinterpret_cast<__nv_bfloat16*>(smem_raw + 183296);
+  const int dstate_smem_addr = smem + 183296;
+  __nv_bfloat16* dstate_smem_mn = reinterpret_cast<__nv_bfloat16*>(smem_raw + 183296);
+  const int dstate_smem_mn_addr = smem + 183296;
+  __nv_bfloat16* dstate_smem_all = reinterpret_cast<__nv_bfloat16*>(smem_raw + 183296);
+  const int dstate_smem_all_addr = smem + 183296;
+  __nv_bfloat16* dy_smem = reinterpret_cast<__nv_bfloat16*>(smem_raw + 216064);
+  const int dy_smem_addr = smem + 216064;
+  __nv_bfloat16* dy_smem_all = reinterpret_cast<__nv_bfloat16*>(smem_raw + 216064);
+  const int dy_smem_all_addr = smem + 216064;
+  __nv_bfloat16* debug_du_smem = reinterpret_cast<__nv_bfloat16*>(smem_raw + 221760);
+  const int debug_du_smem_addr = smem + 221760;
+  __nv_bfloat16* debug_du_smem_all = reinterpret_cast<__nv_bfloat16*>(smem_raw + 221760);
+  const int debug_du_smem_all_addr = smem + 221760;
+  float* boundary_state_smem = reinterpret_cast<float*>(smem_raw + 221760);
+  const int boundary_state_smem_addr = smem + 221760;
+
+  // Mbarrier init (50 groups, 89 barriers)
+  // Mbarriers at smem_raw[0..712)
+
+  if (warp == 0) {
+    uint32_t leader = elect_sync();
+    if (leader) {
+      // --- pipeline 'sched_pipe' ---
+      // sched_ready: 8 barriers, init_count=1
+      mbarrier_init(smem + 0, 1);
+      mbarrier_init(smem + 8, 1);
+      mbarrier_init(smem + 16, 1);
+      mbarrier_init(smem + 24, 1);
+      mbarrier_init(smem + 32, 1);
+      mbarrier_init(smem + 40, 1);
+      mbarrier_init(smem + 48, 1);
+      mbarrier_init(smem + 56, 1);
+      // sched_done: 8 barriers, init_count=15
+      mbarrier_init(smem + 64, 15);
+      mbarrier_init(smem + 72, 15);
+      mbarrier_init(smem + 80, 15);
+      mbarrier_init(smem + 88, 15);
+      mbarrier_init(smem + 96, 15);
+      mbarrier_init(smem + 104, 15);
+      mbarrier_init(smem + 112, 15);
+      mbarrier_init(smem + 120, 15);
+      // --- pipeline 'raw_pipe' ---
+      // raw_ready: 2 barriers, init_count=1
+      mbarrier_init(smem + 128, 1);
+      mbarrier_init(smem + 136, 1);
+      // raw_done: 2 barriers, init_count=165
+      mbarrier_init(smem + 144, 165);
+      mbarrier_init(smem + 152, 165);
+      // --- pipeline 'g_prefix_pipe' ---
+      // g_prefix_ready: 2 barriers, init_count=128
+      mbarrier_init(smem + 160, 128);
+      mbarrier_init(smem + 168, 128);
+      // g_prefix_done: 2 barriers, init_count=128
+      mbarrier_init(smem + 176, 128);
+      mbarrier_init(smem + 184, 128);
+      // --- pipeline 'state_smem_pipe' ---
+      // state_ready: 2 barriers, init_count=1
+      mbarrier_init(smem + 192, 1);
+      mbarrier_init(smem + 200, 1);
+      // state_slot_done: 2 barriers, init_count=1
+      mbarrier_init(smem + 208, 1);
+      mbarrier_init(smem + 216, 1);
+      // state_cg2_done: 2 barriers, init_count=128
+      mbarrier_init(smem + 224, 128);
+      mbarrier_init(smem + 232, 128);
+      // state_k_ready: 2 barriers, init_count=1
+      mbarrier_init(smem + 240, 1);
+      mbarrier_init(smem + 248, 1);
+      // state_k_done: 2 barriers, init_count=4
+      mbarrier_init(smem + 256, 4);
+      mbarrier_init(smem + 264, 4);
+      // --- pipeline 'operand_pipe' ---
+      // k_decay_inv_ready: 2 barriers, init_count=128
+      mbarrier_init(smem + 272, 128);
+      mbarrier_init(smem + 280, 128);
+      // q_decay_k_restore_ready: 2 barriers, init_count=128
+      mbarrier_init(smem + 288, 128);
+      mbarrier_init(smem + 296, 128);
+      // decay_done: 2 barriers, init_count=1
+      mbarrier_init(smem + 304, 1);
+      mbarrier_init(smem + 312, 1);
+      // --- pipeline 'intermediate_pipe' ---
+      // tinv_ready: 2 barriers, init_count=32
+      mbarrier_init(smem + 320, 32);
+      mbarrier_init(smem + 328, 32);
+      // a_ready: 2 barriers, init_count=32
+      mbarrier_init(smem + 336, 32);
+      mbarrier_init(smem + 344, 32);
+      // da_ready: 2 barriers, init_count=32
+      mbarrier_init(smem + 352, 32);
+      mbarrier_init(smem + 360, 32);
+      // dm_ready: 2 barriers, init_count=32
+      mbarrier_init(smem + 368, 32);
+      mbarrier_init(smem + 376, 32);
+      // intermediate_done: 2 barriers, init_count=1
+      mbarrier_init(smem + 384, 1);
+      mbarrier_init(smem + 392, 1);
+      // --- pipeline 'tcgen_data_pipe' ---
+      // tcgen_inputs_ready: 1 barriers, init_count=4
+      mbarrier_init(smem + 400, 4);
+      // tcgen_inputs_done: 1 barriers, init_count=1
+      mbarrier_init(smem + 408, 1);
+      // tcgen_products_ready: 1 barriers, init_count=1
+      mbarrier_init(smem + 416, 1);
+      // tcgen_products_done: 1 barriers, init_count=4
+      mbarrier_init(smem + 424, 4);
+      // du_inp_ready: 1 barriers, init_count=4
+      mbarrier_init(smem + 432, 4);
+      // dy_ready: 1 barriers, init_count=1
+      mbarrier_init(smem + 440, 1);
+      // dy_done: 1 barriers, init_count=4
+      mbarrier_init(smem + 448, 4);
+      // neg_dy_ready: 1 barriers, init_count=4
+      mbarrier_init(smem + 456, 4);
+      // dstate_ready: 1 barriers, init_count=1
+      mbarrier_init(smem + 464, 1);
+      // --- pipeline 'dstate_recurrence_pipe' ---
+      // dstate_inp_ready: 1 barriers, init_count=4
+      mbarrier_init(smem + 472, 4);
+      // --- pipeline 'tcgen_data_pipe' ---
+      // dstate_done: 1 barriers, init_count=8
+      mbarrier_init(smem + 480, 8);
+      // --- pipeline 'u_smem_pipe' ---
+      // u_smem_ready: 1 barriers, init_count=4
+      mbarrier_init(smem + 488, 4);
+      // --- pipeline 'dy_smem_pipe' ---
+      // dy_smem_ready: 1 barriers, init_count=4
+      mbarrier_init(smem + 496, 4);
+      // --- pipeline 'beta_dy_smem_pipe' ---
+      // beta_dy_smem_ready: 2 barriers, init_count=4
+      mbarrier_init(smem + 504, 4);
+      mbarrier_init(smem + 512, 4);
+      // beta_dy_smem_done: 2 barriers, init_count=2
+      mbarrier_init(smem + 520, 2);
+      mbarrier_init(smem + 528, 2);
+      // --- pipeline 'dbeta_m_pipe' ---
+      // dbeta_m_ready: 1 barriers, init_count=1
+      mbarrier_init(smem + 536, 1);
+      // dbeta_m_done: 1 barriers, init_count=1
+      mbarrier_init(smem + 544, 1);
+      // --- pipeline 'dstate_smem_pipe' ---
+      // dstate_smem_ready: 1 barriers, init_count=4
+      mbarrier_init(smem + 552, 4);
+      // dstate_smem_done: 1 barriers, init_count=1
+      mbarrier_init(smem + 560, 1);
+      // --- pipeline 'boundary_pipe' ---
+      // boundary_smem_ready: 1 barriers, init_count=4
+      mbarrier_init(smem + 568, 4);
+      // boundary_state_ready: 1 barriers, init_count=4
+      mbarrier_init(smem + 576, 4);
+      // boundary_acc_ready: 1 barriers, init_count=1
+      mbarrier_init(smem + 584, 1);
+      // --- pipeline 'boundary_local_grad_pipe' ---
+      // boundary_local_grad_free: 1 barriers, init_count=4
+      mbarrier_init(smem + 592, 4);
+      // --- pipeline 'dk_restore_pipe' ---
+      // dk_restore_ready: 1 barriers, init_count=1
+      mbarrier_init(smem + 600, 1);
+      // dk_restore_done: 1 barriers, init_count=4
+      mbarrier_init(smem + 608, 4);
+      // --- pipeline 'local_grad_pipe' ---
+      // local_grad_ready: 1 barriers, init_count=1
+      mbarrier_init(smem + 616, 1);
+      // local_grad_done: 1 barriers, init_count=4
+      mbarrier_init(smem + 624, 4);
+      // --- pipeline 'qk_raw_pipe' ---
+      // qk_raw_ready: 4 barriers, init_count=128
+      mbarrier_init(smem + 632, 128);
+      mbarrier_init(smem + 640, 128);
+      mbarrier_init(smem + 648, 128);
+      mbarrier_init(smem + 656, 128);
+      // qk_raw_done: 4 barriers, init_count=128
+      mbarrier_init(smem + 664, 128);
+      mbarrier_init(smem + 672, 128);
+      mbarrier_init(smem + 680, 128);
+      mbarrier_init(smem + 688, 128);
+      // consumers_done: 1 barriers, init_count=15
+      mbarrier_init(smem + 696, 15);
+      // cleanup_ready: 1 barriers, init_count=1
+      mbarrier_init(smem + 704, 1);
+      asm volatile("fence.mbarrier_init.release.cluster;");
+    }
+  }
+
+  __syncwarp();
+
+  // TMEM alloc (512 columns, 512 used)
+  volatile int* tmem_addr_storage = (volatile int*)(smem_raw + 712);
+  if (warp == 13) {
+    int _tmem_hold = smem + 712;
+    asm volatile(
+        "tcgen05.alloc.cta_group::1.sync.aligned.shared::cta.b32 [%0], %1;" ::"r"(_tmem_hold),
+        "r"(512)
+        : "memory");
+    asm volatile("tcgen05.relinquish_alloc_permit.cta_group::1.sync.aligned;");
+  }
+
+  __syncthreads();
+  asm volatile("tcgen05.fence::after_thread_sync;");
+
+  const int mbar_base = smem;
+#define sched_ready_addr (mbar_base + 0)
+#define sched_done_addr (mbar_base + 64)
+#define raw_ready_addr (mbar_base + 128)
+#define raw_done_addr (mbar_base + 144)
+#define g_prefix_ready_addr (mbar_base + 160)
+#define g_prefix_done_addr (mbar_base + 176)
+#define state_ready_addr (mbar_base + 192)
+#define state_slot_done_addr (mbar_base + 208)
+#define state_cg2_done_addr (mbar_base + 224)
+#define state_k_ready_addr (mbar_base + 240)
+#define state_k_done_addr (mbar_base + 256)
+#define k_decay_inv_ready_addr (mbar_base + 272)
+#define q_decay_k_restore_ready_addr (mbar_base + 288)
+#define decay_done_addr (mbar_base + 304)
+#define tinv_ready_addr (mbar_base + 320)
+#define a_ready_addr (mbar_base + 336)
+#define da_ready_addr (mbar_base + 352)
+#define dm_ready_addr (mbar_base + 368)
+#define intermediate_done_addr (mbar_base + 384)
+#define tcgen_inputs_ready_addr (mbar_base + 400)
+#define tcgen_inputs_done_addr (mbar_base + 408)
+#define tcgen_products_ready_addr (mbar_base + 416)
+#define tcgen_products_done_addr (mbar_base + 424)
+#define du_inp_ready_addr (mbar_base + 432)
+#define dy_ready_addr (mbar_base + 440)
+#define dy_done_addr (mbar_base + 448)
+#define neg_dy_ready_addr (mbar_base + 456)
+#define dstate_ready_addr (mbar_base + 464)
+#define dstate_inp_ready_addr (mbar_base + 472)
+#define dstate_done_addr (mbar_base + 480)
+#define u_smem_ready_addr (mbar_base + 488)
+#define dy_smem_ready_addr (mbar_base + 496)
+#define beta_dy_smem_ready_addr (mbar_base + 504)
+#define beta_dy_smem_done_addr (mbar_base + 520)
+#define dbeta_m_ready_addr (mbar_base + 536)
+#define dbeta_m_done_addr (mbar_base + 544)
+#define dstate_smem_ready_addr (mbar_base + 552)
+#define dstate_smem_done_addr (mbar_base + 560)
+#define boundary_smem_ready_addr (mbar_base + 568)
+#define boundary_state_ready_addr (mbar_base + 576)
+#define boundary_acc_ready_addr (mbar_base + 584)
+#define boundary_local_grad_free_addr (mbar_base + 592)
+#define dk_restore_ready_addr (mbar_base + 600)
+#define dk_restore_done_addr (mbar_base + 608)
+#define local_grad_ready_addr (mbar_base + 616)
+#define local_grad_done_addr (mbar_base + 624)
+#define qk_raw_ready_addr (mbar_base + 632)
+#define qk_raw_done_addr (mbar_base + 664)
+#define consumers_done_addr (mbar_base + 696)
+#define cleanup_ready_addr (mbar_base + 704)
+  const int taddr = tmem_addr_storage[0];
+
+  // Kernel post-init ops
+  const int tmem_flashkda_bwd_persistent_c16_envelope = taddr;
+  const int tmem_flashkda_bwd_persistent_c16_y = taddr + 432;
+  const int tmem_flashkda_bwd_persistent_c16_u = taddr + 336;
+  const int tmem_flashkda_bwd_persistent_c16_du = taddr + 352;
+  const int tmem_flashkda_bwd_persistent_c16_state_k = taddr + 320;
+  const int tmem_flashkda_bwd_persistent_c16_du_inp = taddr + 440;
+  const int tmem_flashkda_bwd_persistent_c16_dy = taddr + 320;
+  const int tmem_flashkda_bwd_persistent_c16_neg_dy = taddr + 432;
+  const int tmem_flashkda_bwd_persistent_c16_do_inp = taddr + 440;
+  const int tmem_flashkda_bwd_persistent_c16_dstate = taddr;
+  const int tmem_flashkda_bwd_persistent_c16_dstate_inp = taddr + 128;
+  const int tmem_flashkda_bwd_persistent_c16_dk_restore = taddr + 416;
+  const int tmem_flashkda_bwd_persistent_c16_dq = taddr + 368;
+  const int tmem_flashkda_bwd_persistent_c16_dk_decay = taddr + 384;
+  const int tmem_flashkda_bwd_persistent_c16_dk_inv = taddr + 400;
+
+  // ---- Register redistribution for WGs split across roles ----
+  // Dec phase frees registers before any WG attempts inc.
+  if (warp >= 12 && warp <= 15) {
+    asm volatile("setmaxnreg.dec.sync.aligned.u32 56;");
+  }
+
+  // ---- Role: compute0 ----
+  if (warp <= 3) {
+    asm volatile("setmaxnreg.inc.sync.aligned.u32 144;");
+    {  // compute0_main
+      unsigned int sched_stage0 = 0;
+      unsigned int raw_stage0 = 0;
+      unsigned int operand_stage0 = 0;
+      unsigned int qk_raw_stage0 = 0;
+      unsigned int g_prefix_stage0 = 0;
+      int warp_id_in_role = (warp - 0);
+      const int tmem_row_base0 = warp_id_in_role * 32 << 16;
+      unsigned int _phase_sched_ready = 0;
+      unsigned int _phase_raw_ready = 0;
+      unsigned int _phase_g_prefix_done = 1;
+      unsigned int _phase_qk_raw_done = 1;
+      unsigned int _phase_decay_done = 1;
+#pragma unroll 1
+      for (int _ = 0; _ < total_work_items; _++) {
+        mbarrier_wait(sched_ready_addr + (sched_stage0) * 8, _phase_sched_ready);
+        unsigned int ticket_words[1];
+        asm volatile("ld.shared.b32 %0, [%1];"
+                     : "=r"(*reinterpret_cast<uint32_t*>(&ticket_words[0]))
+                     : "r"(work_item_addr + sched_stage0 * 4));
+        unsigned int tile0 = ticket_words[0];
+        if (elect_sync()) {
+          mbarrier_arrive(sched_done_addr + (sched_stage0) * 8);
+        }
+        sched_stage0 += 1;
+        if (sched_stage0 == 8) {
+          sched_stage0 = 0;
+          _phase_sched_ready ^= 1;
+        }
+        if (tile0 >= (unsigned int)total_work_items) {
+          break;
+        }
+        int item_base0 = (int)tile0 * 8;
+        int head0 = work_items[item_base0 + 1];
+        int write_start0 = work_items[item_base0 + 2];
+        int write_end0 = work_items[item_base0 + 3];
+        int compute_end0 = work_items[item_base0 + 5];
+        int role_tid0 = warp_id_in_role * 32 + lane;
+        float raw_sum0 = 0.0f;
+        float gate_sum0 = 0.0f;
+        float _expf_0 = __expf(A_log[head0]);
+        float gate_rate0 = _expf_0;
+        float gate_bias0 = dt_bias[head0 * 128 + role_tid0];
+#pragma unroll 1
+        for (int reverse0 = 0; reverse0 < compute_end0 - write_start0; reverse0++) {
+          mbarrier_wait(raw_ready_addr + (raw_stage0) * 8, _phase_raw_ready);
+          mbarrier_wait(g_prefix_done_addr + (g_prefix_stage0) * 8, _phase_g_prefix_done);
+          float gate_prefix0 = 0.0f;
+          float gate_last0 = 0.0f;
+          float q_raw_values0[16];
+          float k_raw_values0[16];
+#pragma unroll
+          for (int token0 = 0; token0 < 16; token0++) {
+            int segment = role_tid0 / 64;
+            int segment_col = role_tid0 - segment * 64;
+            int swizzled_col = segment_col ^ (token0 & 7) * 8;
+            int raw_index0 =
+                (int)raw_stage0 * 16 * 128 + segment * 16 * 64 + token0 * 64 + swizzled_col;
+            __nv_bfloat16 raw_q_value0 = raw_q_all[raw_index0];
+            __nv_bfloat16 raw_k_value0 = raw_k_all[raw_index0];
+            __nv_bfloat16 raw_g_value0 = raw_g_all[raw_index0];
+            float _cvt_f32_0 = __bfloat162float(raw_q_value0);
+            q_raw_values0[token0] = _cvt_f32_0;
+            float _cvt_f32_1 = __bfloat162float(raw_k_value0);
+            k_raw_values0[token0] = _cvt_f32_1;
+            float _cvt_f32_2 = __bfloat162float(raw_q_value0);
+            float _cvt_f32_3 = __bfloat162float(raw_k_value0);
+            float _cvt_f32_4 = __bfloat162float(raw_g_value0);
+            raw_sum0 += _cvt_f32_2 + _cvt_f32_3 + _cvt_f32_4;
+            float _cvt_f32_5 = __bfloat162float(raw_g_value0);
+            float gate_arg0 = gate_rate0 * (_cvt_f32_5 + gate_bias0);
+            float _tanh_approx_0;
+            asm volatile("tanh.approx.f32 %0, %1;" : "=f"(_tanh_approx_0) : "f"(gate_arg0 * 0.5f));
+            float gate_sigmoid0 = _tanh_approx_0 * 0.5f + 0.5f;
+            gate_prefix0 += lower_bound * 1.4426950408889634f * gate_sigmoid0;
+            float _exp2_0 = approx_exp2(gate_prefix0);
+            float gate_exp0 = _exp2_0;
+            gate_last0 = gate_exp0;
+            gate_sum0 += gate_exp0;
+            int segment_0 = role_tid0 / 32;
+            int segment_col_1 = role_tid0 - segment_0 * 32;
+            int swizzled_col_2 = segment_col_1 ^ (token0 & 7) * 4;
+            g_prefix_all[(int)raw_stage0 * 16 * 128 + segment_0 * 16 * 32 + token0 * 32 +
+                         swizzled_col_2] = gate_exp0;
+          }
+          asm volatile("fence.proxy.async.shared::cta;" ::: "memory");
+          mbarrier_arrive(g_prefix_ready_addr + (g_prefix_stage0) * 8);
+          unsigned int q_raw_words0[8];
+          unsigned int k_raw_words0[8];
+#pragma unroll
+          for (int _lp = 0; _lp < 8; _lp++) {
+            __nv_bfloat162 _bf2 = __float22bfloat162_rn(
+                make_float2(q_raw_values0[_lp * 2 + 0], q_raw_values0[_lp * 2 + 1 + 0]));
+            q_raw_words0[_lp] = *(uint32_t*)&_bf2;
+          }
+#pragma unroll
+          for (int _lp = 0; _lp < 8; _lp++) {
+            __nv_bfloat162 _bf2 = __float22bfloat162_rn(
+                make_float2(k_raw_values0[_lp * 2 + 0], k_raw_values0[_lp * 2 + 1 + 0]));
+            k_raw_words0[_lp] = *(uint32_t*)&_bf2;
+          }
+          mbarrier_wait(qk_raw_done_addr + (qk_raw_stage0) * 8, _phase_qk_raw_done);
+          tmem_st_x8_u32(taddr + 448 + qk_raw_stage0 % 4 * 8 + (unsigned int)tmem_row_base0,
+                         (const uint32_t*)q_raw_words0);
+          tmem_st_x8_u32(taddr + 480 + qk_raw_stage0 % 4 * 8 + (unsigned int)tmem_row_base0,
+                         (const uint32_t*)k_raw_words0);
+          asm volatile("tcgen05.wait::st.sync.aligned;" ::: "memory");
+          mbarrier_arrive(qk_raw_ready_addr + (qk_raw_stage0) * 8);
+          asm volatile("barrier.sync 8, 128;" ::: "memory");
+          mbarrier_wait(decay_done_addr + (operand_stage0) * 8, _phase_decay_done);
+          int state_scale_block0 = role_tid0 / 16;
+          int state_scale_row0 = role_tid0 - state_scale_block0 * 16;
+          float state_scale_values0[16];
+          state_scale_values0[0] = 0.0f;
+          state_scale_values0[1] = 0.0f;
+          state_scale_values0[2] = 0.0f;
+          state_scale_values0[3] = 0.0f;
+          state_scale_values0[4] = 0.0f;
+          state_scale_values0[5] = 0.0f;
+          state_scale_values0[6] = 0.0f;
+          state_scale_values0[7] = 0.0f;
+          state_scale_values0[8] = 0.0f;
+          state_scale_values0[9] = 0.0f;
+          state_scale_values0[10] = 0.0f;
+          state_scale_values0[11] = 0.0f;
+          state_scale_values0[12] = 0.0f;
+          state_scale_values0[13] = 0.0f;
+          state_scale_values0[14] = 0.0f;
+          state_scale_values0[15] = 0.0f;
+          state_scale_values0[state_scale_row0] = gate_last0;
+          unsigned int state_scale_words0[8];
+#pragma unroll
+          for (int _lp = 0; _lp < 8; _lp++) {
+            __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(
+                state_scale_values0[_lp * 2 + 0], state_scale_values0[_lp * 2 + 1 + 0]));
+            state_scale_words0[_lp] = *(uint32_t*)&_bf2;
+          }
+          int state_scale_stage0 = (int)operand_stage0 * 8 + state_scale_block0;
+          asm volatile(
+              "st.shared.v4.b32 [%0], {%1,%2,%3,%4};" ::"r"(
+                  (state_scale_diag_addr + (unsigned int)(state_scale_stage0 * 512) +
+                   (unsigned int)(state_scale_row0 * 32 ^ (state_scale_row0 * 32 >> 7 & 1) << 4))),
+              "r"(state_scale_words0[0]), "r"(state_scale_words0[1]), "r"(state_scale_words0[2]),
+              "r"(state_scale_words0[3])
+              : "memory");
+          asm volatile("st.shared.v4.b32 [%0], {%1,%2,%3,%4};" ::"r"(
+                           (state_scale_diag_addr + (unsigned int)(state_scale_stage0 * 512) +
+                            (unsigned int)(state_scale_row0 * 32 + 16 ^
+                                           (state_scale_row0 * 32 + 16 >> 7 & 1) << 4))),
+                       "r"(state_scale_words0[4]), "r"(state_scale_words0[5]),
+                       "r"(state_scale_words0[6]), "r"(state_scale_words0[7])
+                       : "memory");
+          int decay_row0 = warp_id_in_role * 4 + lane / 8;
+          int decay_lane0 = lane & 7;
+          float q_row0[16];
+          float k_row0[16];
+          float q_sq0 = 0.0f;
+          float k_sq0 = 0.0f;
+#pragma unroll
+          for (int dim_half0 = 0; dim_half0 < 2; dim_half0++) {
+            int dim_base0 = dim_half0 * 64 + decay_lane0 * 8;
+            unsigned int q_words0[4];
+            unsigned int k_words0[4];
+            int segment_1 = dim_base0 / 64;
+            int segment_col_2 = dim_base0 - segment_1 * 64;
+            int swizzled_col_1 = segment_col_2 ^ (decay_row0 & 7) * 8;
+            int qk_index0 =
+                (int)raw_stage0 * 16 * 128 + segment_1 * 16 * 64 + decay_row0 * 64 + swizzled_col_1;
+            asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                         : "=r"(*reinterpret_cast<uint32_t*>(&q_words0[0])),
+                           "=r"(*reinterpret_cast<uint32_t*>(&q_words0[(0) + 1])),
+                           "=r"(*reinterpret_cast<uint32_t*>(&q_words0[(0) + 2])),
+                           "=r"(*reinterpret_cast<uint32_t*>(&q_words0[(0) + 3]))
+                         : "r"(raw_q_all_addr + (unsigned int)(qk_index0 * 2)));
+            asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                         : "=r"(*reinterpret_cast<uint32_t*>(&k_words0[0])),
+                           "=r"(*reinterpret_cast<uint32_t*>(&k_words0[(0) + 1])),
+                           "=r"(*reinterpret_cast<uint32_t*>(&k_words0[(0) + 2])),
+                           "=r"(*reinterpret_cast<uint32_t*>(&k_words0[(0) + 3]))
+                         : "r"(raw_k_all_addr + (unsigned int)(qk_index0 * 2)));
+            float q_words0_f32[8];
+#pragma unroll
+            for (int _pair = 0; _pair < 4; _pair++) {
+              asm volatile(
+                  "{\n\t"
+                  "shl.b32 %0, %2, 16;\n\t"
+                  "and.b32 %1, %2, 0xffff0000;\n\t"
+                  "}\n"
+                  : "=f"((&q_words0_f32[_pair * 2])[0]), "=f"((&q_words0_f32[_pair * 2])[1])
+                  : "r"(q_words0[_pair]));
+            }
+            float k_words0_f32[8];
+#pragma unroll
+            for (int _pair = 0; _pair < 4; _pair++) {
+              asm volatile(
+                  "{\n\t"
+                  "shl.b32 %0, %2, 16;\n\t"
+                  "and.b32 %1, %2, 0xffff0000;\n\t"
+                  "}\n"
+                  : "=f"((&k_words0_f32[_pair * 2])[0]), "=f"((&k_words0_f32[_pair * 2])[1])
+                  : "r"(k_words0[_pair]));
+            }
+#pragma unroll
+            for (int dim_local0 = 0; dim_local0 < 8; dim_local0++) {
+              int row_reg0 = dim_half0 * 8 + dim_local0;
+              q_row0[row_reg0] = q_words0_f32[dim_local0];
+              k_row0[row_reg0] = k_words0_f32[dim_local0];
+              float _fma_0 = __fmaf_rn(q_row0[row_reg0], q_row0[row_reg0], q_sq0);
+              q_sq0 = _fma_0;
+              float _fma_1 = __fmaf_rn(k_row0[row_reg0], k_row0[row_reg0], k_sq0);
+              k_sq0 = _fma_1;
+            }
+          }
+          float _shfl_xor_0 = __shfl_xor_sync(0xFFFFFFFF, q_sq0, 4);
+          q_sq0 += _shfl_xor_0;
+          float _shfl_xor_1 = __shfl_xor_sync(0xFFFFFFFF, q_sq0, 2);
+          q_sq0 += _shfl_xor_1;
+          float _shfl_xor_2 = __shfl_xor_sync(0xFFFFFFFF, q_sq0, 1);
+          q_sq0 += _shfl_xor_2;
+          float _shfl_xor_3 = __shfl_xor_sync(0xFFFFFFFF, k_sq0, 4);
+          k_sq0 += _shfl_xor_3;
+          float _shfl_xor_4 = __shfl_xor_sync(0xFFFFFFFF, k_sq0, 2);
+          k_sq0 += _shfl_xor_4;
+          float _shfl_xor_5 = __shfl_xor_sync(0xFFFFFFFF, k_sq0, 1);
+          k_sq0 += _shfl_xor_5;
+          float _rsqrt_0 = rsqrtf(q_sq0 + 1e-06f);
+          float q_inv_norm0 = _rsqrt_0;
+          float _rsqrt_1 = rsqrtf(k_sq0 + 1e-06f);
+          float k_inv_norm0 = _rsqrt_1;
+          if (decay_lane0 == 0) {
+            int qk_norm_stage_base0 = (int)(qk_raw_stage0 % 4) * 2 * 16;
+            qk_norm_smem_all[qk_norm_stage_base0 + decay_row0] = q_inv_norm0;
+            qk_norm_smem_all[qk_norm_stage_base0 + 16 + decay_row0] = k_inv_norm0;
+          }
+#pragma unroll
+          for (int dim_half1 = 0; dim_half1 < 2; dim_half1++) {
+            int dim_base1 = dim_half1 * 64 + decay_lane0 * 8;
+            float k_inv_values0[8];
+            float k_decay_values0[8];
+            float q_decay_values0[8];
+            float k_restore_values0[8];
+#pragma unroll
+            for (int dim_local1 = 0; dim_local1 < 8; dim_local1++) {
+              int row_reg1 = dim_half1 * 8 + dim_local1;
+              int dim1 = dim_base1 + dim_local1;
+              int segment_2 = dim1 / 32;
+              int segment_col_3 = dim1 - segment_2 * 32;
+              int swizzled_col_3 = segment_col_3 ^ (decay_row0 & 7) * 4;
+              int prefix_index0 = (int)raw_stage0 * 16 * 128 + segment_2 * 16 * 32 +
+                                  decay_row0 * 32 + swizzled_col_3;
+              int segment_0_1 = dim1 / 32;
+              int segment_col_1_1 = dim1 - segment_0_1 * 32;
+              int swizzled_col_2_1 = segment_col_1_1 ^ 28;
+              int prefix_last_index0 =
+                  (int)raw_stage0 * 16 * 128 + segment_0_1 * 16 * 32 + 480 + swizzled_col_2_1;
+              float prefix0 = g_prefix_all[prefix_index0];
+              float prefix_last0 = g_prefix_all[prefix_last_index0];
+              __nv_bfloat16 _cvt_bf16_0 = __float2bfloat16(q_row0[row_reg1] * q_inv_norm0 * scale);
+              __nv_bfloat16 q_norm0 = _cvt_bf16_0;
+              __nv_bfloat16 _cvt_bf16_1 = __float2bfloat16(k_row0[row_reg1] * k_inv_norm0);
+              __nv_bfloat16 k_norm0 = _cvt_bf16_1;
+              float _cvt_f32_6 = __bfloat162float(k_norm0);
+              float _rcp_0 = approx_rcp(prefix0);
+              __nv_bfloat16 _cvt_bf16_2 = __float2bfloat16(_cvt_f32_6 * _rcp_0);
+              __nv_bfloat16 k_inv_value0 = _cvt_bf16_2;
+              float _cvt_f32_7 = __bfloat162float(k_inv_value0);
+              k_inv_values0[dim_local1] = _cvt_f32_7;
+              float _cvt_f32_9 = __bfloat162float(k_norm0);
+              __nv_bfloat16 _cvt_bf16_3 = __float2bfloat16(_cvt_f32_9 * prefix0);
+              __nv_bfloat16 k_decay_value0 = _cvt_bf16_3;
+              float _cvt_f32_10 = __bfloat162float(k_decay_value0);
+              k_decay_values0[dim_local1] = _cvt_f32_10;
+              float _cvt_f32_11 = __bfloat162float(q_norm0);
+              __nv_bfloat16 _cvt_bf16_4 = __float2bfloat16(_cvt_f32_11 * prefix0);
+              __nv_bfloat16 q_decay_value0 = _cvt_bf16_4;
+              float _cvt_f32_12 = __bfloat162float(q_decay_value0);
+              q_decay_values0[dim_local1] = _cvt_f32_12;
+              float _cvt_f32_13 = __bfloat162float(k_norm0);
+              float _rcp_1 = approx_rcp(prefix0);
+              __nv_bfloat16 _cvt_bf16_5 = __float2bfloat16(_cvt_f32_13 * prefix_last0 * _rcp_1);
+              __nv_bfloat16 k_restore_value0 = _cvt_bf16_5;
+              float _cvt_f32_14 = __bfloat162float(k_restore_value0);
+              k_restore_values0[dim_local1] = _cvt_f32_14;
+            }
+            unsigned int k_inv_words0[4];
+            unsigned int k_decay_words0[4];
+            unsigned int q_decay_words0[4];
+            unsigned int k_restore_words0[4];
+#pragma unroll
+            for (int _lp = 0; _lp < 4; _lp++) {
+              __nv_bfloat162 _bf2 = __float22bfloat162_rn(
+                  make_float2(k_inv_values0[_lp * 2 + 0], k_inv_values0[_lp * 2 + 1 + 0]));
+              k_inv_words0[_lp] = *(uint32_t*)&_bf2;
+            }
+#pragma unroll
+            for (int _lp = 0; _lp < 4; _lp++) {
+              __nv_bfloat162 _bf2 = __float22bfloat162_rn(
+                  make_float2(k_decay_values0[_lp * 2 + 0], k_decay_values0[_lp * 2 + 1 + 0]));
+              k_decay_words0[_lp] = *(uint32_t*)&_bf2;
+            }
+#pragma unroll
+            for (int _lp = 0; _lp < 4; _lp++) {
+              __nv_bfloat162 _bf2 = __float22bfloat162_rn(
+                  make_float2(q_decay_values0[_lp * 2 + 0], q_decay_values0[_lp * 2 + 1 + 0]));
+              q_decay_words0[_lp] = *(uint32_t*)&_bf2;
+            }
+#pragma unroll
+            for (int _lp = 0; _lp < 4; _lp++) {
+              __nv_bfloat162 _bf2 = __float22bfloat162_rn(
+                  make_float2(k_restore_values0[_lp * 2 + 0], k_restore_values0[_lp * 2 + 1 + 0]));
+              k_restore_words0[_lp] = *(uint32_t*)&_bf2;
+            }
+            int segment_3 = dim_base1 / 64;
+            int segment_col_4 = dim_base1 - segment_3 * 64;
+            int swizzled_col_4 = segment_col_4 ^ (decay_row0 & 7) * 8;
+            int operand_index0 = (int)operand_stage0 * 16 * 128 + segment_3 * 16 * 64 +
+                                 decay_row0 * 64 + swizzled_col_4;
+            int operand_addr0 = operand_index0 * 2;
+            asm volatile("st.shared.v4.b32 [%0], {%1,%2,%3,%4};" ::"r"(k_inv_all_addr +
+                                                                       (unsigned int)operand_addr0),
+                         "r"(k_inv_words0[0]), "r"(k_inv_words0[1]), "r"(k_inv_words0[2]),
+                         "r"(k_inv_words0[3])
+                         : "memory");
+            asm volatile("st.shared.v4.b32 [%0], {%1,%2,%3,%4};" ::"r"(k_decay_all_addr +
+                                                                       (unsigned int)operand_addr0),
+                         "r"(k_decay_words0[0]), "r"(k_decay_words0[1]), "r"(k_decay_words0[2]),
+                         "r"(k_decay_words0[3])
+                         : "memory");
+            asm volatile("st.shared.v4.b32 [%0], {%1,%2,%3,%4};" ::"r"(q_decay_all_addr +
+                                                                       (unsigned int)operand_addr0),
+                         "r"(q_decay_words0[0]), "r"(q_decay_words0[1]), "r"(q_decay_words0[2]),
+                         "r"(q_decay_words0[3])
+                         : "memory");
+            asm volatile("st.shared.v4.b32 [%0], {%1,%2,%3,%4};" ::"r"(k_restore_all_addr +
+                                                                       (unsigned int)operand_addr0),
+                         "r"(k_restore_words0[0]), "r"(k_restore_words0[1]),
+                         "r"(k_restore_words0[2]), "r"(k_restore_words0[3])
+                         : "memory");
+          }
+          asm volatile("fence.proxy.async.shared::cta;" ::: "memory");
+          mbarrier_arrive(k_decay_inv_ready_addr + (operand_stage0) * 8);
+          mbarrier_arrive(q_decay_k_restore_ready_addr + (operand_stage0) * 8);
+          mbarrier_arrive(raw_done_addr + (raw_stage0) * 8);
+          raw_stage0 += 1;
+          if (raw_stage0 == 2) {
+            raw_stage0 = 0;
+            _phase_raw_ready ^= 1;
+          }
+          operand_stage0 += 1;
+          if (operand_stage0 == 2) {
+            operand_stage0 = 0;
+            _phase_decay_done ^= 1;
+          }
+          qk_raw_stage0 += 1;
+          if (qk_raw_stage0 == 4) {
+            qk_raw_stage0 = 0;
+            _phase_qk_raw_done ^= 1;
+          }
+          g_prefix_stage0 += 1;
+          if (g_prefix_stage0 == 2) {
+            g_prefix_stage0 = 0;
+            _phase_g_prefix_done ^= 1;
+          }
+        }
+      }
+      if (elect_sync()) {
+        mbarrier_arrive(consumers_done_addr);
+      }
+    }
+  }
+  // ---- Role: compute1 ----
+  if (warp >= 4 && warp <= 7) {
+    asm volatile("setmaxnreg.inc.sync.aligned.u32 168;");
+    {  // compute1_main
+      unsigned int sched_stage1 = 0;
+      unsigned int raw_stage1 = 0;
+      unsigned int state_smem_stage1 = 0;
+      unsigned int tcgen_data_stage1 = 0;
+      unsigned int dstate_smem_stage1 = 0;
+      unsigned int beta_dy_smem_stage1 = 0;
+      unsigned int dbeta_m_stage1 = 0;
+      unsigned int boundary_stage1 = 0;
+      int dstate_smem_slot_acquired1 = 0;
+      int warp_id_in_role_1 = (warp - 4);
+      int value_dim_base1 = warp_id_in_role_1 * 32;
+      int role_tid1 = warp_id_in_role_1 * 32 + lane;
+      int ov_token1 = lane / 16 * 8 + (lane & 7);
+      int ov_col1 = (lane / 8 & 1) * 8;
+      const int tmem_row_base1 = warp_id_in_role_1 * 32 << 16;
+      unsigned int _phase_sched_ready_1 = 0;
+      unsigned int _phase_dstate_smem_done = 1;
+      unsigned int _phase_tcgen_inputs_done = 1;
+      unsigned int _phase_raw_ready_1 = 0;
+      unsigned int _phase_state_k_ready = 0;
+      unsigned int _phase_tcgen_products_ready = 0;
+      unsigned int _phase_dy_ready = 0;
+      unsigned int _phase_beta_dy_smem_done = 1;
+      unsigned int _phase_dbeta_m_ready = 0;
+      unsigned int _phase_dstate_ready = 0;
+      unsigned int _phase_boundary_acc_ready = 0;
+#pragma unroll 1
+      for (int __1 = 0; __1 < total_work_items; __1++) {
+        mbarrier_wait(sched_ready_addr + (sched_stage1) * 8, _phase_sched_ready_1);
+        unsigned int ticket_words_1[1];
+        asm volatile("ld.shared.b32 %0, [%1];"
+                     : "=r"(*reinterpret_cast<uint32_t*>(&ticket_words_1[0]))
+                     : "r"(work_item_addr + sched_stage1 * 4));
+        unsigned int tile1 = ticket_words_1[0];
+        if (elect_sync()) {
+          mbarrier_arrive(sched_done_addr + (sched_stage1) * 8);
+        }
+        sched_stage1 += 1;
+        if (sched_stage1 == 8) {
+          sched_stage1 = 0;
+          _phase_sched_ready_1 ^= 1;
+        }
+        if (tile1 >= (unsigned int)total_work_items) {
+          break;
+        }
+        int item_base1 = (int)tile1 * 8;
+        int sequence1 = work_items[item_base1];
+        int head1 = work_items[item_base1 + 1];
+        int write_start1 = work_items[item_base1 + 2];
+        int write_end1 = work_items[item_base1 + 3];
+        int compute_end1 = work_items[item_base1 + 5];
+        float checksum_sum1 = 0.0f;
+        long long bos1 = cu_seqlens[sequence1];
+        long long eos1 = cu_seqlens[sequence1 + 1];
+        int sequence_chunks1 = (int)((eos1 - bos1) / 16);
+        int seed_dfinal1 = (int)(compute_end1 == sequence_chunks1);
+        if (dstate_smem_slot_acquired1 == 0) {
+          mbarrier_wait(dstate_smem_done_addr + (dstate_smem_stage1) * 8, _phase_dstate_smem_done);
+        }
+#pragma unroll
+        for (int dstate_init_block1 = 0; dstate_init_block1 < 4; dstate_init_block1++) {
+          float dstate_init_values1[32];
+          dstate_init_values1[0] = 0.0f;
+          dstate_init_values1[1] = 0.0f;
+          dstate_init_values1[2] = 0.0f;
+          dstate_init_values1[3] = 0.0f;
+          dstate_init_values1[4] = 0.0f;
+          dstate_init_values1[5] = 0.0f;
+          dstate_init_values1[6] = 0.0f;
+          dstate_init_values1[7] = 0.0f;
+          dstate_init_values1[8] = 0.0f;
+          dstate_init_values1[9] = 0.0f;
+          dstate_init_values1[10] = 0.0f;
+          dstate_init_values1[11] = 0.0f;
+          dstate_init_values1[12] = 0.0f;
+          dstate_init_values1[13] = 0.0f;
+          dstate_init_values1[14] = 0.0f;
+          dstate_init_values1[15] = 0.0f;
+          dstate_init_values1[16] = 0.0f;
+          dstate_init_values1[17] = 0.0f;
+          dstate_init_values1[18] = 0.0f;
+          dstate_init_values1[19] = 0.0f;
+          dstate_init_values1[20] = 0.0f;
+          dstate_init_values1[21] = 0.0f;
+          dstate_init_values1[22] = 0.0f;
+          dstate_init_values1[23] = 0.0f;
+          dstate_init_values1[24] = 0.0f;
+          dstate_init_values1[25] = 0.0f;
+          dstate_init_values1[26] = 0.0f;
+          dstate_init_values1[27] = 0.0f;
+          dstate_init_values1[28] = 0.0f;
+          dstate_init_values1[29] = 0.0f;
+          dstate_init_values1[30] = 0.0f;
+          dstate_init_values1[31] = 0.0f;
+          if (USE_DSTATE_IN != 0 && seed_dfinal1 != 0) {
+            long long dstate_init_base1 =
+                (((long long)sequence1 * (long long)num_heads + (long long)head1) * 128 +
+                 (long long)role_tid1) *
+                    128 +
+                (long long)(dstate_init_block1 * 32);
+#pragma unroll
+            for (int dstate_init_vec1 = 0; dstate_init_vec1 < 4; dstate_init_vec1++) {
+              {
+                unsigned _ldv8_0_0;
+                unsigned _ldv8_0_1;
+                unsigned _ldv8_0_2;
+                unsigned _ldv8_0_3;
+                unsigned _ldv8_0_4;
+                unsigned _ldv8_0_5;
+                unsigned _ldv8_0_6;
+                unsigned _ldv8_0_7;
+                asm volatile(
+                    "ld.global.v8.b32 {%0, %1, %2, %3, %4, %5, %6, %7}, [%8];"
+                    : "=r"(_ldv8_0_0), "=r"(_ldv8_0_1), "=r"(_ldv8_0_2), "=r"(_ldv8_0_3),
+                      "=r"(_ldv8_0_4), "=r"(_ldv8_0_5), "=r"(_ldv8_0_6), "=r"(_ldv8_0_7)
+                    : "l"((const void*)(dfinal_state +
+                                        (dstate_init_base1 + (long long)(dstate_init_vec1 * 8))))
+                    : "memory");
+                dstate_init_values1[dstate_init_vec1 * 8 + 0] = __uint_as_float(_ldv8_0_0);
+                dstate_init_values1[dstate_init_vec1 * 8 + 1] = __uint_as_float(_ldv8_0_1);
+                dstate_init_values1[dstate_init_vec1 * 8 + 2] = __uint_as_float(_ldv8_0_2);
+                dstate_init_values1[dstate_init_vec1 * 8 + 3] = __uint_as_float(_ldv8_0_3);
+                dstate_init_values1[dstate_init_vec1 * 8 + 4] = __uint_as_float(_ldv8_0_4);
+                dstate_init_values1[dstate_init_vec1 * 8 + 5] = __uint_as_float(_ldv8_0_5);
+                dstate_init_values1[dstate_init_vec1 * 8 + 6] = __uint_as_float(_ldv8_0_6);
+                dstate_init_values1[dstate_init_vec1 * 8 + 7] = __uint_as_float(_ldv8_0_7);
+              }
+            }
+          }
+          tmem_st_x32_f32(
+              taddr + (unsigned int)(dstate_init_block1 * 32) + (unsigned int)tmem_row_base1,
+              dstate_init_values1);
+          uint32_t dstate_init_values1_bf16[16];
+#pragma unroll
+          for (int _lp = 0; _lp < 16; _lp++) {
+            __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(
+                dstate_init_values1[_lp * 2 + 0], dstate_init_values1[_lp * 2 + 1 + 0]));
+            dstate_init_values1_bf16[_lp] = *(uint32_t*)&_bf2;
+          }
+          asm volatile(
+              "tcgen05.st.sync.aligned.32x32b.x16.b32"
+              " [%0], {%1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15, %16};" ::
+                  "r"(taddr + 128 + (unsigned int)(dstate_init_block1 * 16) +
+                      (unsigned int)tmem_row_base1),
+              "r"(*reinterpret_cast<const uint32_t*>(&dstate_init_values1_bf16[0])),
+              "r"(*reinterpret_cast<const uint32_t*>(&dstate_init_values1_bf16[1])),
+              "r"(*reinterpret_cast<const uint32_t*>(&dstate_init_values1_bf16[2])),
+              "r"(*reinterpret_cast<const uint32_t*>(&dstate_init_values1_bf16[3])),
+              "r"(*reinterpret_cast<const uint32_t*>(&dstate_init_values1_bf16[4])),
+              "r"(*reinterpret_cast<const uint32_t*>(&dstate_init_values1_bf16[5])),
+              "r"(*reinterpret_cast<const uint32_t*>(&dstate_init_values1_bf16[6])),
+              "r"(*reinterpret_cast<const uint32_t*>(&dstate_init_values1_bf16[7])),
+              "r"(*reinterpret_cast<const uint32_t*>(&dstate_init_values1_bf16[8])),
+              "r"(*reinterpret_cast<const uint32_t*>(&dstate_init_values1_bf16[9])),
+              "r"(*reinterpret_cast<const uint32_t*>(&dstate_init_values1_bf16[10])),
+              "r"(*reinterpret_cast<const uint32_t*>(&dstate_init_values1_bf16[11])),
+              "r"(*reinterpret_cast<const uint32_t*>(&dstate_init_values1_bf16[12])),
+              "r"(*reinterpret_cast<const uint32_t*>(&dstate_init_values1_bf16[13])),
+              "r"(*reinterpret_cast<const uint32_t*>(&dstate_init_values1_bf16[14])),
+              "r"(*reinterpret_cast<const uint32_t*>(&dstate_init_values1_bf16[15])));
+#pragma unroll
+          for (int dstate_init_atom1 = 0; dstate_init_atom1 < 4; dstate_init_atom1++) {
+            int dstate_init_col1 = dstate_init_block1 * 32 + dstate_init_atom1 * 8;
+            int segment_4 = dstate_init_col1 / 64;
+            int segment_col_5 = dstate_init_col1 - segment_4 * 64;
+            int swizzled_col_5 = segment_col_5 ^ (role_tid1 & 7) * 8;
+            int dstate_init_smem_index1 = segment_4 * 128 * 64 + role_tid1 * 64 + swizzled_col_5;
+            asm volatile("st.shared.v4.b32 [%0], {%1,%2,%3,%4};" ::"r"(
+                             dstate_smem_all_addr + (unsigned int)(dstate_init_smem_index1 * 2)),
+                         "r"(dstate_init_values1_bf16[dstate_init_atom1 * 4]),
+                         "r"(dstate_init_values1_bf16[dstate_init_atom1 * 4 + 1]),
+                         "r"(dstate_init_values1_bf16[dstate_init_atom1 * 4 + 2]),
+                         "r"(dstate_init_values1_bf16[dstate_init_atom1 * 4 + 3])
+                         : "memory");
+          }
+        }
+        asm volatile("tcgen05.wait::st.sync.aligned;" ::: "memory");
+        asm volatile("fence.proxy.async.shared::cta;" ::: "memory");
+        if (elect_sync()) {
+          mbarrier_arrive(dstate_inp_ready_addr);
+          mbarrier_arrive(dstate_smem_ready_addr + (dstate_smem_stage1) * 8);
+        }
+        dstate_smem_stage1 += 1;
+        if (dstate_smem_stage1 == 1) {
+          dstate_smem_stage1 = 0;
+          _phase_dstate_smem_done ^= 1;
+        }
+        dstate_smem_slot_acquired1 = 0;
+#pragma unroll 1
+        for (int reverse1 = 0; reverse1 < compute_end1 - write_start1; reverse1++) {
+          mbarrier_wait(tcgen_inputs_done_addr + (tcgen_data_stage1) * 8, _phase_tcgen_inputs_done);
+          mbarrier_wait(raw_ready_addr + (raw_stage1) * 8, _phase_raw_ready_1);
+          int beta_lane_token1 = (lane & 3) * 2;
+          int beta_stage_base1 = (int)(raw_stage1 % 2) * 16 * 8;
+          int beta_head1 = head1 % 8;
+          __nv_bfloat16 beta_c0_bf1 =
+              beta_smem_all[beta_stage_base1 + beta_lane_token1 * 8 + beta_head1];
+          __nv_bfloat16 beta_c1_bf1 =
+              beta_smem_all[beta_stage_base1 + (beta_lane_token1 + 1) * 8 + beta_head1];
+          __nv_bfloat16 beta_c8_bf1 =
+              beta_smem_all[beta_stage_base1 + (beta_lane_token1 + 8) * 8 + beta_head1];
+          __nv_bfloat16 beta_c9_bf1 =
+              beta_smem_all[beta_stage_base1 + (beta_lane_token1 + 9) * 8 + beta_head1];
+          float _cvt_f32_15 = __bfloat162float(beta_c0_bf1);
+          float beta_c0_1 = _cvt_f32_15;
+          float _cvt_f32_16 = __bfloat162float(beta_c1_bf1);
+          float beta_c1_1 = _cvt_f32_16;
+          float _cvt_f32_17 = __bfloat162float(beta_c8_bf1);
+          float beta_c8_1 = _cvt_f32_17;
+          float _cvt_f32_18 = __bfloat162float(beta_c9_bf1);
+          float beta_c9_1 = _cvt_f32_18;
+          float beta_values1[4];
+          beta_values1[0] = beta_c8_1;
+          beta_values1[1] = beta_c9_1;
+          beta_values1[2] = beta_c0_1;
+          beta_values1[3] = beta_c1_1;
+          unsigned int beta_words1[2];
+#pragma unroll
+          for (int _lp = 0; _lp < 2; _lp++) {
+            __nv_bfloat162 _bf2 = __float22bfloat162_rn(
+                make_float2(beta_values1[_lp * 2 + 0], beta_values1[_lp * 2 + 1 + 0]));
+            beta_words1[_lp] = *(uint32_t*)&_bf2;
+          }
+          mbarrier_wait(state_k_ready_addr + (state_smem_stage1) * 8, _phase_state_k_ready);
+          float _tmem_load_0[8];
+          asm volatile(
+              "tcgen05.ld.sync.aligned.16x256b.x2.b32"
+              " {%0, %1, %2, %3, %4, %5, %6, %7}, [%8];"
+              : "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_0[0])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_0[1])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_0[2])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_0[3])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_0[4])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_0[5])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_0[6])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_0[7]))
+              : "r"(taddr + 320 + (unsigned int)tmem_row_base1));
+          float _tmem_load_1[8];
+          asm volatile(
+              "tcgen05.ld.sync.aligned.16x256b.x2.b32"
+              " {%0, %1, %2, %3, %4, %5, %6, %7}, [%8];"
+              : "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_1[0])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_1[1])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_1[2])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_1[3])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_1[4])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_1[5])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_1[6])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_1[7]))
+              : "r"(taddr + 320 + (unsigned int)tmem_row_base1 + 1048576));
+          asm volatile("tcgen05.wait::ld.sync.aligned;" ::: "memory");
+          if (elect_sync()) {
+            mbarrier_arrive(state_k_done_addr + (state_smem_stage1) * 8);
+          }
+          uint32_t _tmem_load_0_bf16[4];
+#pragma unroll
+          for (int _lp = 0; _lp < 4; _lp++) {
+            __nv_bfloat162 _bf2 = __float22bfloat162_rn(
+                make_float2(_tmem_load_0[_lp * 2 + 0], _tmem_load_0[_lp * 2 + 1 + 0]));
+            _tmem_load_0_bf16[_lp] = *(uint32_t*)&_bf2;
+          }
+          uint32_t _tmem_load_1_bf16[4];
+#pragma unroll
+          for (int _lp = 0; _lp < 4; _lp++) {
+            __nv_bfloat162 _bf2 = __float22bfloat162_rn(
+                make_float2(_tmem_load_1[_lp * 2 + 0], _tmem_load_1[_lp * 2 + 1 + 0]));
+            _tmem_load_1_bf16[_lp] = *(uint32_t*)&_bf2;
+          }
+          unsigned int v_fragment_lo1[4];
+          unsigned int v_fragment_hi1[4];
+          int segment_5 = (value_dim_base1 + ov_col1) / 64;
+          int segment_col_6 = value_dim_base1 + ov_col1 - segment_5 * 64;
+          int swizzled_col_6 = segment_col_6 ^ (ov_token1 & 7) * 8;
+          unsigned int v_addr_lo1 =
+              raw_v_all_addr + (unsigned int)(((int)raw_stage1 * 16 * 128 + segment_5 * 16 * 64 +
+                                               ov_token1 * 64 + swizzled_col_6) *
+                                              2);
+          int segment_0_2 = (value_dim_base1 + 16 + ov_col1) / 64;
+          int segment_col_1_2 = value_dim_base1 + 16 + ov_col1 - segment_0_2 * 64;
+          int swizzled_col_2_2 = segment_col_1_2 ^ (ov_token1 & 7) * 8;
+          unsigned int v_addr_hi1 =
+              raw_v_all_addr + (unsigned int)(((int)raw_stage1 * 16 * 128 + segment_0_2 * 16 * 64 +
+                                               ov_token1 * 64 + swizzled_col_2_2) *
+                                              2);
+          int segment_3_1 = (value_dim_base1 + ov_col1) / 64;
+          int segment_col_4_1 = value_dim_base1 + ov_col1 - segment_3_1 * 64;
+          int swizzled_col_5_1 = segment_col_4_1 ^ (ov_token1 & 7) * 8;
+          unsigned int do_addr_lo1 =
+              raw_do_all_addr + (unsigned int)(((int)raw_stage1 * 16 * 128 + segment_3_1 * 16 * 64 +
+                                                ov_token1 * 64 + swizzled_col_5_1) *
+                                               2);
+          int segment_6 = (value_dim_base1 + 16 + ov_col1) / 64;
+          int segment_col_7 = value_dim_base1 + 16 + ov_col1 - segment_6 * 64;
+          int swizzled_col_8 = segment_col_7 ^ (ov_token1 & 7) * 8;
+          unsigned int do_addr_hi1 =
+              raw_do_all_addr + (unsigned int)(((int)raw_stage1 * 16 * 128 + segment_6 * 16 * 64 +
+                                                ov_token1 * 64 + swizzled_col_8) *
+                                               2);
+          asm volatile("ldmatrix.sync.aligned.m8n8.x4.trans.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                       : "=r"(v_fragment_lo1[0]), "=r"(v_fragment_lo1[1]), "=r"(v_fragment_lo1[2]),
+                         "=r"(v_fragment_lo1[3])
+                       : "r"(v_addr_lo1)
+                       : "memory");
+          asm volatile("ldmatrix.sync.aligned.m8n8.x4.trans.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                       : "=r"(v_fragment_hi1[0]), "=r"(v_fragment_hi1[1]), "=r"(v_fragment_hi1[2]),
+                         "=r"(v_fragment_hi1[3])
+                       : "r"(v_addr_hi1)
+                       : "memory");
+          unsigned int do_fragment_lo1[4];
+          unsigned int do_fragment_hi1[4];
+          asm volatile("ldmatrix.sync.aligned.m8n8.x4.trans.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                       : "=r"(do_fragment_lo1[0]), "=r"(do_fragment_lo1[1]),
+                         "=r"(do_fragment_lo1[2]), "=r"(do_fragment_lo1[3])
+                       : "r"(do_addr_lo1)
+                       : "memory");
+          asm volatile("ldmatrix.sync.aligned.m8n8.x4.trans.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                       : "=r"(do_fragment_hi1[0]), "=r"(do_fragment_hi1[1]),
+                         "=r"(do_fragment_hi1[2]), "=r"(do_fragment_hi1[3])
+                       : "r"(do_addr_hi1)
+                       : "memory");
+          unsigned int diff_words_lo1[4];
+          unsigned int diff_words_hi1[4];
+          __nv_bfloat162 y_pairs_lo1[4];
+          __nv_bfloat162 y_pairs_hi1[4];
+          unsigned int y_words_lo1[4];
+          unsigned int y_words_hi1[4];
+          unsigned int do_words_lo1[4];
+          unsigned int do_words_hi1[4];
+#pragma unroll
+          for (int y_reg1 = 0; y_reg1 < 4; y_reg1++) {
+            const int raw_reg1 = (1 - y_reg1 / 2) * 2 + (y_reg1 & 1);
+            const int out_reg1 = y_reg1 ^ 2;
+            uint32_t _bf16x2_sub_0;
+            asm volatile("sub.rn.bf16x2 %0, %1, %2;"
+                         : "=r"(_bf16x2_sub_0)
+                         : "r"(v_fragment_lo1[raw_reg1]), "r"(_tmem_load_0_bf16[out_reg1]));
+            diff_words_lo1[out_reg1] = _bf16x2_sub_0;
+            uint32_t _bf16x2_sub_1;
+            asm volatile("sub.rn.bf16x2 %0, %1, %2;"
+                         : "=r"(_bf16x2_sub_1)
+                         : "r"(v_fragment_hi1[raw_reg1]), "r"(_tmem_load_1_bf16[out_reg1]));
+            diff_words_hi1[out_reg1] = _bf16x2_sub_1;
+            y_pairs_lo1[out_reg1] =
+                reinterpret_cast<__nv_bfloat162*>(diff_words_lo1 + out_reg1)[0] *
+                reinterpret_cast<__nv_bfloat162*>(beta_words1 + y_reg1 / 2)[0];
+            y_pairs_hi1[out_reg1] =
+                reinterpret_cast<__nv_bfloat162*>(diff_words_hi1 + out_reg1)[0] *
+                reinterpret_cast<__nv_bfloat162*>(beta_words1 + y_reg1 / 2)[0];
+            y_words_lo1[out_reg1] = reinterpret_cast<unsigned int*>(y_pairs_lo1 + out_reg1)[0];
+            y_words_hi1[out_reg1] = reinterpret_cast<unsigned int*>(y_pairs_hi1 + out_reg1)[0];
+            do_words_lo1[out_reg1] = do_fragment_lo1[raw_reg1];
+            do_words_hi1[out_reg1] = do_fragment_hi1[raw_reg1];
+          }
+          asm volatile(
+              "tcgen05.st.sync.aligned.16x128b.x2.b32"
+              " [%0], {%1, %2, %3, %4};" ::"r"(taddr + 432 + (unsigned int)tmem_row_base1),
+              "r"(*reinterpret_cast<const uint32_t*>(&y_words_lo1[0])),
+              "r"(*reinterpret_cast<const uint32_t*>(&y_words_lo1[1])),
+              "r"(*reinterpret_cast<const uint32_t*>(&y_words_lo1[2])),
+              "r"(*reinterpret_cast<const uint32_t*>(&y_words_lo1[3])));
+          asm volatile(
+              "tcgen05.st.sync.aligned.16x128b.x2.b32"
+              " [%0], {%1, %2, %3, %4};" ::"r"(taddr + 432 + (unsigned int)tmem_row_base1 +
+                                               1048576),
+              "r"(*reinterpret_cast<const uint32_t*>(&y_words_hi1[0])),
+              "r"(*reinterpret_cast<const uint32_t*>(&y_words_hi1[1])),
+              "r"(*reinterpret_cast<const uint32_t*>(&y_words_hi1[2])),
+              "r"(*reinterpret_cast<const uint32_t*>(&y_words_hi1[3])));
+          asm volatile(
+              "tcgen05.st.sync.aligned.16x128b.x2.b32"
+              " [%0], {%1, %2, %3, %4};" ::"r"(taddr + 440 + (unsigned int)tmem_row_base1),
+              "r"(*reinterpret_cast<const uint32_t*>(&do_words_lo1[0])),
+              "r"(*reinterpret_cast<const uint32_t*>(&do_words_lo1[1])),
+              "r"(*reinterpret_cast<const uint32_t*>(&do_words_lo1[2])),
+              "r"(*reinterpret_cast<const uint32_t*>(&do_words_lo1[3])));
+          asm volatile(
+              "tcgen05.st.sync.aligned.16x128b.x2.b32"
+              " [%0], {%1, %2, %3, %4};" ::"r"(taddr + 440 + (unsigned int)tmem_row_base1 +
+                                               1048576),
+              "r"(*reinterpret_cast<const uint32_t*>(&do_words_hi1[0])),
+              "r"(*reinterpret_cast<const uint32_t*>(&do_words_hi1[1])),
+              "r"(*reinterpret_cast<const uint32_t*>(&do_words_hi1[2])),
+              "r"(*reinterpret_cast<const uint32_t*>(&do_words_hi1[3])));
+          asm volatile("tcgen05.wait::st.sync.aligned;" ::: "memory");
+          if (elect_sync()) {
+            mbarrier_arrive(tcgen_inputs_ready_addr + (tcgen_data_stage1) * 8);
+            mbarrier_arrive(raw_done_addr + (raw_stage1) * 8);
+          }
+          mbarrier_wait(tcgen_products_ready_addr + (tcgen_data_stage1) * 8,
+                        _phase_tcgen_products_ready);
+          float _tmem_load_2[8];
+          asm volatile(
+              "tcgen05.ld.sync.aligned.16x256b.x2.b32"
+              " {%0, %1, %2, %3, %4, %5, %6, %7}, [%8];"
+              : "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_2[0])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_2[1])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_2[2])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_2[3])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_2[4])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_2[5])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_2[6])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_2[7]))
+              : "r"(taddr + 336 + (unsigned int)tmem_row_base1));
+          float _tmem_load_3[8];
+          asm volatile(
+              "tcgen05.ld.sync.aligned.16x256b.x2.b32"
+              " {%0, %1, %2, %3, %4, %5, %6, %7}, [%8];"
+              : "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[0])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[1])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[2])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[3])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[4])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[5])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[6])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[7]))
+              : "r"(taddr + 336 + (unsigned int)tmem_row_base1 + 1048576));
+          asm volatile("tcgen05.wait::ld.sync.aligned;" ::: "memory");
+          uint32_t _tmem_load_2_bf16[4];
+#pragma unroll
+          for (int _lp = 0; _lp < 4; _lp++) {
+            __nv_bfloat162 _bf2 = __float22bfloat162_rn(
+                make_float2(_tmem_load_2[_lp * 2 + 0], _tmem_load_2[_lp * 2 + 1 + 0]));
+            _tmem_load_2_bf16[_lp] = *(uint32_t*)&_bf2;
+          }
+          uint32_t _tmem_load_3_bf16[4];
+#pragma unroll
+          for (int _lp = 0; _lp < 4; _lp++) {
+            __nv_bfloat162 _bf2 = __float22bfloat162_rn(
+                make_float2(_tmem_load_3[_lp * 2 + 0], _tmem_load_3[_lp * 2 + 1 + 0]));
+            _tmem_load_3_bf16[_lp] = *(uint32_t*)&_bf2;
+          }
+          int segment_9 = (value_dim_base1 + ov_col1) / 64;
+          int segment_col_10 = value_dim_base1 + ov_col1 - segment_9 * 64;
+          int swizzled_col_11 = segment_col_10 ^ (ov_token1 & 7) * 8;
+          unsigned int u_addr_lo1 =
+              u_smem_addr +
+              (unsigned int)((segment_9 * 16 * 64 + ov_token1 * 64 + swizzled_col_11) * 2);
+          int segment_12 = (value_dim_base1 + 16 + ov_col1) / 64;
+          int segment_col_13 = value_dim_base1 + 16 + ov_col1 - segment_12 * 64;
+          int swizzled_col_14 = segment_col_13 ^ (ov_token1 & 7) * 8;
+          unsigned int u_addr_hi1 =
+              u_smem_addr +
+              (unsigned int)((segment_12 * 16 * 64 + ov_token1 * 64 + swizzled_col_14) * 2);
+          uint32_t _stmatrix_addr_1 = static_cast<uint32_t>((unsigned long long)u_addr_lo1);
+          asm volatile(
+              "stmatrix.sync.aligned.m8n8.x4.trans.shared.b16 [%0], {%1, %2, %3, %4};\n" ::"r"(
+                  _stmatrix_addr_1),
+              "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_2_bf16[0])),
+              "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_2_bf16[1])),
+              "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_2_bf16[2])),
+              "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_2_bf16[3]))
+              : "memory");
+          uint32_t _stmatrix_addr_2 = static_cast<uint32_t>((unsigned long long)u_addr_hi1);
+          asm volatile(
+              "stmatrix.sync.aligned.m8n8.x4.trans.shared.b16 [%0], {%1, %2, %3, %4};\n" ::"r"(
+                  _stmatrix_addr_2),
+              "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_3_bf16[0])),
+              "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_3_bf16[1])),
+              "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_3_bf16[2])),
+              "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_3_bf16[3]))
+              : "memory");
+          asm volatile("fence.proxy.async.shared::cta;" ::: "memory");
+          if (elect_sync()) {
+            mbarrier_arrive(u_smem_ready_addr);
+          }
+          float _tmem_load_4[8];
+          asm volatile(
+              "tcgen05.ld.sync.aligned.16x256b.x2.b32"
+              " {%0, %1, %2, %3, %4, %5, %6, %7}, [%8];"
+              : "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_4[0])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_4[1])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_4[2])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_4[3])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_4[4])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_4[5])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_4[6])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_4[7]))
+              : "r"(taddr + 352 + (unsigned int)tmem_row_base1));
+          float _tmem_load_5[8];
+          asm volatile(
+              "tcgen05.ld.sync.aligned.16x256b.x2.b32"
+              " {%0, %1, %2, %3, %4, %5, %6, %7}, [%8];"
+              : "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_5[0])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_5[1])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_5[2])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_5[3])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_5[4])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_5[5])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_5[6])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_5[7]))
+              : "r"(taddr + 352 + (unsigned int)tmem_row_base1 + 1048576));
+          asm volatile("tcgen05.wait::ld.sync.aligned;" ::: "memory");
+          checksum_sum1 += _tmem_load_2[0] + _tmem_load_4[0];
+          uint32_t _tmem_load_4_bf16[4];
+#pragma unroll
+          for (int _lp = 0; _lp < 4; _lp++) {
+            __nv_bfloat162 _bf2 = __float22bfloat162_rn(
+                make_float2(_tmem_load_4[_lp * 2 + 0], _tmem_load_4[_lp * 2 + 1 + 0]));
+            _tmem_load_4_bf16[_lp] = *(uint32_t*)&_bf2;
+          }
+          uint32_t _tmem_load_5_bf16[4];
+#pragma unroll
+          for (int _lp = 0; _lp < 4; _lp++) {
+            __nv_bfloat162 _bf2 = __float22bfloat162_rn(
+                make_float2(_tmem_load_5[_lp * 2 + 0], _tmem_load_5[_lp * 2 + 1 + 0]));
+            _tmem_load_5_bf16[_lp] = *(uint32_t*)&_bf2;
+          }
+          asm volatile(
+              "tcgen05.st.sync.aligned.16x128b.x2.b32"
+              " [%0], {%1, %2, %3, %4};" ::"r"(taddr + 440 + (unsigned int)tmem_row_base1),
+              "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_4_bf16[0])),
+              "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_4_bf16[1])),
+              "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_4_bf16[2])),
+              "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_4_bf16[3])));
+          asm volatile(
+              "tcgen05.st.sync.aligned.16x128b.x2.b32"
+              " [%0], {%1, %2, %3, %4};" ::"r"(taddr + 440 + (unsigned int)tmem_row_base1 +
+                                               1048576),
+              "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_5_bf16[0])),
+              "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_5_bf16[1])),
+              "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_5_bf16[2])),
+              "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_5_bf16[3])));
+          asm volatile("tcgen05.wait::st.sync.aligned;" ::: "memory");
+          if (elect_sync()) {
+            mbarrier_arrive(du_inp_ready_addr + (tcgen_data_stage1) * 8);
+            mbarrier_arrive(tcgen_products_done_addr + (tcgen_data_stage1) * 8);
+          }
+          mbarrier_wait(dy_ready_addr + (tcgen_data_stage1) * 8, _phase_dy_ready);
+          float _tmem_load_6[8];
+          asm volatile(
+              "tcgen05.ld.sync.aligned.16x256b.x2.b32"
+              " {%0, %1, %2, %3, %4, %5, %6, %7}, [%8];"
+              : "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_6[0])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_6[1])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_6[2])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_6[3])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_6[4])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_6[5])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_6[6])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_6[7]))
+              : "r"(taddr + 320 + (unsigned int)tmem_row_base1));
+          float _tmem_load_7[8];
+          asm volatile(
+              "tcgen05.ld.sync.aligned.16x256b.x2.b32"
+              " {%0, %1, %2, %3, %4, %5, %6, %7}, [%8];"
+              : "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_7[0])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_7[1])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_7[2])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_7[3])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_7[4])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_7[5])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_7[6])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_7[7]))
+              : "r"(taddr + 320 + (unsigned int)tmem_row_base1 + 1048576));
+          asm volatile("tcgen05.wait::ld.sync.aligned;" ::: "memory");
+          float diff_words_lo1_f32[8];
+#pragma unroll
+          for (int _pair = 0; _pair < 4; _pair++) {
+            asm volatile(
+                "{\n\t"
+                "shl.b32 %0, %2, 16;\n\t"
+                "and.b32 %1, %2, 0xffff0000;\n\t"
+                "}\n"
+                : "=f"((&diff_words_lo1_f32[_pair * 2])[0]),
+                  "=f"((&diff_words_lo1_f32[_pair * 2])[1])
+                : "r"(diff_words_lo1[_pair]));
+          }
+          float diff_words_hi1_f32[8];
+#pragma unroll
+          for (int _pair = 0; _pair < 4; _pair++) {
+            asm volatile(
+                "{\n\t"
+                "shl.b32 %0, %2, 16;\n\t"
+                "and.b32 %1, %2, 0xffff0000;\n\t"
+                "}\n"
+                : "=f"((&diff_words_hi1_f32[_pair * 2])[0]),
+                  "=f"((&diff_words_hi1_f32[_pair * 2])[1])
+                : "r"(diff_words_hi1[_pair]));
+          }
+          float dbeta_partial1[4];
+          dbeta_partial1[0] = 0.0f;
+          dbeta_partial1[1] = 0.0f;
+          dbeta_partial1[2] = 0.0f;
+          dbeta_partial1[3] = 0.0f;
+#pragma unroll
+          for (int dbeta_pair1 = 0; dbeta_pair1 < 4; dbeta_pair1++) {
+            const int dbeta_elem1 = dbeta_pair1 * 2;
+            const int dbeta_slot_lo1 = 2 * (dbeta_pair1 / 2);
+            const int dbeta_slot_hi1 = dbeta_slot_lo1 + 1;
+            dbeta_partial1[dbeta_slot_lo1] =
+                dbeta_partial1[dbeta_slot_lo1] +
+                _tmem_load_6[dbeta_elem1] * diff_words_lo1_f32[dbeta_elem1] +
+                _tmem_load_7[dbeta_elem1] * diff_words_hi1_f32[dbeta_elem1];
+            dbeta_partial1[dbeta_slot_hi1] =
+                dbeta_partial1[dbeta_slot_hi1] +
+                _tmem_load_6[dbeta_elem1 + 1] * diff_words_lo1_f32[dbeta_elem1 + 1] +
+                _tmem_load_7[dbeta_elem1 + 1] * diff_words_hi1_f32[dbeta_elem1 + 1];
+          }
+          uint32_t _tmem_load_6_bf16[4];
+#pragma unroll
+          for (int _lp = 0; _lp < 4; _lp++) {
+            __nv_bfloat162 _bf2 = __float22bfloat162_rn(
+                make_float2(_tmem_load_6[_lp * 2 + 0], _tmem_load_6[_lp * 2 + 1 + 0]));
+            _tmem_load_6_bf16[_lp] = *(uint32_t*)&_bf2;
+          }
+          uint32_t _tmem_load_7_bf16[4];
+#pragma unroll
+          for (int _lp = 0; _lp < 4; _lp++) {
+            __nv_bfloat162 _bf2 = __float22bfloat162_rn(
+                make_float2(_tmem_load_7[_lp * 2 + 0], _tmem_load_7[_lp * 2 + 1 + 0]));
+            _tmem_load_7_bf16[_lp] = *(uint32_t*)&_bf2;
+          }
+          int segment_15 = (value_dim_base1 + ov_col1) / 64;
+          int segment_col_16 = value_dim_base1 + ov_col1 - segment_15 * 64;
+          int swizzled_col_17 = segment_col_16 ^ (ov_token1 & 7) * 8;
+          unsigned int dy_addr_lo1 =
+              dy_smem_addr +
+              (unsigned int)((segment_15 * 16 * 64 + ov_token1 * 64 + swizzled_col_17) * 2);
+          int segment_18 = (value_dim_base1 + 16 + ov_col1) / 64;
+          int segment_col_19 = value_dim_base1 + 16 + ov_col1 - segment_18 * 64;
+          int swizzled_col_20 = segment_col_19 ^ (ov_token1 & 7) * 8;
+          unsigned int dy_addr_hi1 =
+              dy_smem_addr +
+              (unsigned int)((segment_18 * 16 * 64 + ov_token1 * 64 + swizzled_col_20) * 2);
+          uint32_t _stmatrix_addr_3 = static_cast<uint32_t>((unsigned long long)dy_addr_lo1);
+          asm volatile(
+              "stmatrix.sync.aligned.m8n8.x4.trans.shared.b16 [%0], {%1, %2, %3, %4};\n" ::"r"(
+                  _stmatrix_addr_3),
+              "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_6_bf16[0])),
+              "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_6_bf16[1])),
+              "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_6_bf16[2])),
+              "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_6_bf16[3]))
+              : "memory");
+          uint32_t _stmatrix_addr_4 = static_cast<uint32_t>((unsigned long long)dy_addr_hi1);
+          asm volatile(
+              "stmatrix.sync.aligned.m8n8.x4.trans.shared.b16 [%0], {%1, %2, %3, %4};\n" ::"r"(
+                  _stmatrix_addr_4),
+              "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_7_bf16[0])),
+              "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_7_bf16[1])),
+              "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_7_bf16[2])),
+              "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_7_bf16[3]))
+              : "memory");
+          asm volatile("fence.proxy.async.shared::cta;" ::: "memory");
+          if (elect_sync()) {
+            mbarrier_arrive(dy_smem_ready_addr);
+          }
+#pragma unroll
+          for (int beta_dy_pair1 = 0; beta_dy_pair1 < 4; beta_dy_pair1++) {
+            const int beta_dy_elem1 = beta_dy_pair1 * 2;
+            float beta_dy_lo1 = beta_c0_1;
+            float beta_dy_hi1 = beta_c1_1;
+            if (beta_dy_pair1 >= 2) {
+              beta_dy_lo1 = beta_c8_1;
+              beta_dy_hi1 = beta_c9_1;
+            }
+            _tmem_load_6[beta_dy_elem1] = _tmem_load_6[beta_dy_elem1] * beta_dy_lo1;
+            _tmem_load_6[beta_dy_elem1 + 1] = _tmem_load_6[beta_dy_elem1 + 1] * beta_dy_hi1;
+            _tmem_load_7[beta_dy_elem1] = _tmem_load_7[beta_dy_elem1] * beta_dy_lo1;
+            _tmem_load_7[beta_dy_elem1 + 1] = _tmem_load_7[beta_dy_elem1 + 1] * beta_dy_hi1;
+          }
+          uint32_t _tmem_load_6_bf16_21[4];
+#pragma unroll
+          for (int _lp = 0; _lp < 4; _lp++) {
+            __nv_bfloat162 _bf2 = __float22bfloat162_rn(
+                make_float2(_tmem_load_6[_lp * 2 + 0], _tmem_load_6[_lp * 2 + 1 + 0]));
+            _tmem_load_6_bf16_21[_lp] = *(uint32_t*)&_bf2;
+          }
+          uint32_t _tmem_load_7_bf16_22[4];
+#pragma unroll
+          for (int _lp = 0; _lp < 4; _lp++) {
+            __nv_bfloat162 _bf2 = __float22bfloat162_rn(
+                make_float2(_tmem_load_7[_lp * 2 + 0], _tmem_load_7[_lp * 2 + 1 + 0]));
+            _tmem_load_7_bf16_22[_lp] = *(uint32_t*)&_bf2;
+          }
+          int segment_23 = (value_dim_base1 + ov_col1) / 64;
+          int segment_col_24 = value_dim_base1 + ov_col1 - segment_23 * 64;
+          int swizzled_col_25 = segment_col_24 ^ (ov_token1 & 7) * 8;
+          unsigned int beta_dy_addr_lo1 =
+              beta_dy_smem_addr + beta_dy_smem_stage1 * 4096 +
+              (unsigned int)((segment_23 * 16 * 64 + ov_token1 * 64 + swizzled_col_25) * 2);
+          int segment_26 = (value_dim_base1 + 16 + ov_col1) / 64;
+          int segment_col_27 = value_dim_base1 + 16 + ov_col1 - segment_26 * 64;
+          int swizzled_col_28 = segment_col_27 ^ (ov_token1 & 7) * 8;
+          unsigned int beta_dy_addr_hi1 =
+              beta_dy_smem_addr + beta_dy_smem_stage1 * 4096 +
+              (unsigned int)((segment_26 * 16 * 64 + ov_token1 * 64 + swizzled_col_28) * 2);
+          mbarrier_wait(beta_dy_smem_done_addr + (beta_dy_smem_stage1) * 8,
+                        _phase_beta_dy_smem_done);
+          uint32_t _stmatrix_addr_5 = static_cast<uint32_t>((unsigned long long)beta_dy_addr_lo1);
+          asm volatile(
+              "stmatrix.sync.aligned.m8n8.x4.trans.shared.b16 [%0], {%1, %2, %3, %4};\n" ::"r"(
+                  _stmatrix_addr_5),
+              "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_6_bf16_21[0])),
+              "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_6_bf16_21[1])),
+              "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_6_bf16_21[2])),
+              "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_6_bf16_21[3]))
+              : "memory");
+          uint32_t _stmatrix_addr_6 = static_cast<uint32_t>((unsigned long long)beta_dy_addr_hi1);
+          asm volatile(
+              "stmatrix.sync.aligned.m8n8.x4.trans.shared.b16 [%0], {%1, %2, %3, %4};\n" ::"r"(
+                  _stmatrix_addr_6),
+              "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_7_bf16_22[0])),
+              "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_7_bf16_22[1])),
+              "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_7_bf16_22[2])),
+              "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_7_bf16_22[3]))
+              : "memory");
+          asm volatile("fence.proxy.async.shared::cta;" ::: "memory");
+          if (elect_sync()) {
+            mbarrier_arrive(beta_dy_smem_ready_addr + (beta_dy_smem_stage1) * 8);
+          }
+          beta_dy_smem_stage1 += 1;
+          if (beta_dy_smem_stage1 == 2) {
+            beta_dy_smem_stage1 = 0;
+            _phase_beta_dy_smem_done ^= 1;
+          }
+          const float2 _scale2_7 = {-1.0f, -1.0f};
+#pragma unroll
+          for (int _ls = 0; _ls < 4; _ls++)
+            mul_f32x2_inplace(&reinterpret_cast<float2*>(_tmem_load_6)[_ls], _scale2_7);
+          const float2 _scale2_8 = {-1.0f, -1.0f};
+#pragma unroll
+          for (int _ls = 0; _ls < 4; _ls++)
+            mul_f32x2_inplace(&reinterpret_cast<float2*>(_tmem_load_7)[_ls], _scale2_8);
+          uint32_t _tmem_load_6_bf16_29[4];
+#pragma unroll
+          for (int _lp = 0; _lp < 4; _lp++) {
+            __nv_bfloat162 _bf2 = __float22bfloat162_rn(
+                make_float2(_tmem_load_6[_lp * 2 + 0], _tmem_load_6[_lp * 2 + 1 + 0]));
+            _tmem_load_6_bf16_29[_lp] = *(uint32_t*)&_bf2;
+          }
+          uint32_t _tmem_load_7_bf16_30[4];
+#pragma unroll
+          for (int _lp = 0; _lp < 4; _lp++) {
+            __nv_bfloat162 _bf2 = __float22bfloat162_rn(
+                make_float2(_tmem_load_7[_lp * 2 + 0], _tmem_load_7[_lp * 2 + 1 + 0]));
+            _tmem_load_7_bf16_30[_lp] = *(uint32_t*)&_bf2;
+          }
+          asm volatile(
+              "tcgen05.st.sync.aligned.16x128b.x2.b32"
+              " [%0], {%1, %2, %3, %4};" ::"r"(taddr + 432 + (unsigned int)tmem_row_base1),
+              "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_6_bf16_29[0])),
+              "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_6_bf16_29[1])),
+              "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_6_bf16_29[2])),
+              "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_6_bf16_29[3])));
+          asm volatile(
+              "tcgen05.st.sync.aligned.16x128b.x2.b32"
+              " [%0], {%1, %2, %3, %4};" ::"r"(taddr + 432 + (unsigned int)tmem_row_base1 +
+                                               1048576),
+              "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_7_bf16_30[0])),
+              "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_7_bf16_30[1])),
+              "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_7_bf16_30[2])),
+              "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_7_bf16_30[3])));
+          asm volatile("tcgen05.wait::st.sync.aligned;" ::: "memory");
+          if (elect_sync()) {
+            mbarrier_arrive(neg_dy_ready_addr + (tcgen_data_stage1) * 8);
+            mbarrier_arrive(dy_done_addr + (tcgen_data_stage1) * 8);
+          }
+#pragma unroll
+          for (int dbeta_slot1 = 0; dbeta_slot1 < 4; dbeta_slot1++) {
+            float _shfl_xor_6 = __shfl_xor_sync(0xFFFFFFFF, dbeta_partial1[dbeta_slot1], 4);
+            dbeta_partial1[dbeta_slot1] = dbeta_partial1[dbeta_slot1] + _shfl_xor_6;
+            float _shfl_xor_7 = __shfl_xor_sync(0xFFFFFFFF, dbeta_partial1[dbeta_slot1], 8);
+            dbeta_partial1[dbeta_slot1] = dbeta_partial1[dbeta_slot1] + _shfl_xor_7;
+            float _shfl_xor_8 = __shfl_xor_sync(0xFFFFFFFF, dbeta_partial1[dbeta_slot1], 16);
+            dbeta_partial1[dbeta_slot1] = dbeta_partial1[dbeta_slot1] + _shfl_xor_8;
+          }
+          if (lane < 4) {
+#pragma unroll
+            for (int dbeta_slot1_1 = 0; dbeta_slot1_1 < 4; dbeta_slot1_1++) {
+              int dbeta_token_slot1 =
+                  (lane & 3) * 2 + (dbeta_slot1_1 & 1) + 8 * (dbeta_slot1_1 / 2);
+              dbeta_red_smem[warp_id_in_role_1 * 16 + dbeta_token_slot1] =
+                  dbeta_partial1[dbeta_slot1_1];
+            }
+          }
+          asm volatile("barrier.sync 9, 128;" ::: "memory");
+          mbarrier_wait(dbeta_m_ready_addr + (dbeta_m_stage1) * 8, _phase_dbeta_m_ready);
+          if (role_tid1 < 16) {
+            float dbeta_value1 = dbeta_m_smem[role_tid1];
+#pragma unroll
+            for (int dbeta_warp1 = 0; dbeta_warp1 < 4; dbeta_warp1++) {
+              float dbeta_part1 = dbeta_red_smem[dbeta_warp1 * 16 + role_tid1];
+              dbeta_value1 += dbeta_part1;
+            }
+            int dbeta_chunk1 = compute_end1 - 1 - reverse1;
+            long long dbeta_token1 = bos1 + (long long)dbeta_chunk1 * 16 + (long long)role_tid1;
+            if (dbeta_chunk1 < write_end1) {
+              dbeta[dbeta_token1 * (long long)num_heads + (long long)head1] = dbeta_value1;
+            }
+          }
+          asm volatile("barrier.sync 9, 128;" ::: "memory");
+          if (warp_id_in_role_1 == 0) {
+            if (elect_sync()) {
+              mbarrier_arrive(dbeta_m_done_addr + (dbeta_m_stage1) * 8);
+            }
+          }
+          dbeta_m_stage1 += 1;
+          if (dbeta_m_stage1 == 1) {
+            dbeta_m_stage1 = 0;
+            _phase_dbeta_m_ready ^= 1;
+          }
+          mbarrier_wait(dstate_ready_addr + (tcgen_data_stage1) * 8, _phase_dstate_ready);
+          mbarrier_wait(dstate_smem_done_addr + (dstate_smem_stage1) * 8, _phase_dstate_smem_done);
+          dstate_smem_slot_acquired1 = 1;
+          int boundary_chunk1 = compute_end1 - 1 - reverse1;
+          long long boundary_checkpoint1 = bos1 / 16 + (long long)boundary_chunk1;
+#pragma unroll
+          for (int dstate_block1 = 0; dstate_block1 < 4; dstate_block1++) {
+            float _tmem_load_8[32];
+            tmem_ld_x32(&_tmem_load_8[0],
+                        taddr + (unsigned int)(dstate_block1 * 32) + (unsigned int)tmem_row_base1);
+            asm volatile("tcgen05.wait::ld.sync.aligned;" ::: "memory");
+            uint32_t _tmem_load_8_bf16[16];
+#pragma unroll
+            for (int _lp = 0; _lp < 16; _lp++) {
+              __nv_bfloat162 _bf2 = __float22bfloat162_rn(
+                  make_float2(_tmem_load_8[_lp * 2 + 0], _tmem_load_8[_lp * 2 + 1 + 0]));
+              _tmem_load_8_bf16[_lp] = *(uint32_t*)&_bf2;
+            }
+            if (reverse1 + 1 < compute_end1 - write_start1) {
+              asm volatile(
+                  "tcgen05.st.sync.aligned.32x32b.x16.b32"
+                  " [%0], {%1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15, "
+                  "%16};" ::"r"(taddr + 128 + (unsigned int)(dstate_block1 * 16) +
+                                (unsigned int)tmem_row_base1),
+                  "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_8_bf16[0])),
+                  "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_8_bf16[1])),
+                  "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_8_bf16[2])),
+                  "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_8_bf16[3])),
+                  "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_8_bf16[4])),
+                  "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_8_bf16[5])),
+                  "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_8_bf16[6])),
+                  "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_8_bf16[7])),
+                  "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_8_bf16[8])),
+                  "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_8_bf16[9])),
+                  "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_8_bf16[10])),
+                  "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_8_bf16[11])),
+                  "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_8_bf16[12])),
+                  "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_8_bf16[13])),
+                  "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_8_bf16[14])),
+                  "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_8_bf16[15])));
+            }
+#pragma unroll
+            for (int dstate_atom1 = 0; dstate_atom1 < 4; dstate_atom1++) {
+              int dstate_col_base1 = dstate_block1 * 32 + dstate_atom1 * 8;
+              int segment_1_1 = dstate_col_base1 / 64;
+              int segment_col_2_1 = dstate_col_base1 - segment_1_1 * 64;
+              int swizzled_col_3_1 = segment_col_2_1 ^ (role_tid1 & 7) * 8;
+              int dstate_smem_index1 = segment_1_1 * 128 * 64 + role_tid1 * 64 + swizzled_col_3_1;
+              asm volatile("st.shared.v4.b32 [%0], {%1,%2,%3,%4};" ::"r"(
+                               dstate_smem_all_addr + (unsigned int)(dstate_smem_index1 * 2)),
+                           "r"(_tmem_load_8_bf16[dstate_atom1 * 4]),
+                           "r"(_tmem_load_8_bf16[dstate_atom1 * 4 + 1]),
+                           "r"(_tmem_load_8_bf16[dstate_atom1 * 4 + 2]),
+                           "r"(_tmem_load_8_bf16[dstate_atom1 * 4 + 3])
+                           : "memory");
+            }
+            if (write_start1 == 0 && reverse1 + 1 == compute_end1 - write_start1) {
+              long long dinitial_base1 =
+                  (((long long)sequence1 * (long long)num_heads + (long long)head1) * 128 +
+                   (long long)role_tid1) *
+                      128 +
+                  (long long)(dstate_block1 * 32);
+#pragma unroll
+              for (int dinitial_vec1 = 0; dinitial_vec1 < 4; dinitial_vec1++) {
+                {
+                  unsigned _stv8_9_0 = __float_as_uint(_tmem_load_8[dinitial_vec1 * 8 + 0]);
+                  unsigned _stv8_9_1 = __float_as_uint(_tmem_load_8[dinitial_vec1 * 8 + 1]);
+                  unsigned _stv8_9_2 = __float_as_uint(_tmem_load_8[dinitial_vec1 * 8 + 2]);
+                  unsigned _stv8_9_3 = __float_as_uint(_tmem_load_8[dinitial_vec1 * 8 + 3]);
+                  unsigned _stv8_9_4 = __float_as_uint(_tmem_load_8[dinitial_vec1 * 8 + 4]);
+                  unsigned _stv8_9_5 = __float_as_uint(_tmem_load_8[dinitial_vec1 * 8 + 5]);
+                  unsigned _stv8_9_6 = __float_as_uint(_tmem_load_8[dinitial_vec1 * 8 + 6]);
+                  unsigned _stv8_9_7 = __float_as_uint(_tmem_load_8[dinitial_vec1 * 8 + 7]);
+                  asm volatile("st.global.v8.b32 [%0], {%1, %2, %3, %4, %5, %6, %7, %8};" ::"l"(
+                                   (void*)(dinitial_state +
+                                           (dinitial_base1 + (long long)(dinitial_vec1 * 8)))),
+                               "r"(_stv8_9_0), "r"(_stv8_9_1), "r"(_stv8_9_2), "r"(_stv8_9_3),
+                               "r"(_stv8_9_4), "r"(_stv8_9_5), "r"(_stv8_9_6), "r"(_stv8_9_7)
+                               : "memory");
+                }
+              }
+            }
+          }
+          asm volatile("tcgen05.wait::st.sync.aligned;" ::: "memory");
+          asm volatile("barrier.sync 9, 128;" ::: "memory");
+          asm volatile("fence.proxy.async.shared::cta;" ::: "memory");
+          if (elect_sync()) {
+            mbarrier_arrive(boundary_smem_ready_addr + (boundary_stage1) * 8);
+          }
+          float boundary_diag_pair1[2];
+#pragma unroll
+          for (int boundary_diag_block1 = 0; boundary_diag_block1 < 2; boundary_diag_block1++) {
+            int boundary_channel_base1 = warp_id_in_role_1 * 32 + boundary_diag_block1 * 16;
+            float boundary_diag_acc1[8];
+#pragma unroll
+            for (int boundary_k1 = 0; boundary_k1 < 128; boundary_k1 += 16) {
+              unsigned int boundary_a_frag1[4];
+              unsigned int boundary_b_frag1[4];
+              int boundary_lane_matrix1 = lane / 8;
+              int boundary_lane_row1 = lane & 7;
+              int boundary_a_row1 =
+                  boundary_k1 + boundary_lane_row1 + boundary_lane_matrix1 / 2 * 8;
+              int boundary_a_col1 = boundary_channel_base1 + (boundary_lane_matrix1 & 1) * 8;
+              int segment_1_2 = boundary_a_col1 / 64;
+              int segment_col_2_2 = boundary_a_col1 - segment_1_2 * 64;
+              int swizzled_col_3_2 = segment_col_2_2 ^ (boundary_a_row1 & 7) * 8;
+              asm volatile(
+                  "ldmatrix.sync.aligned.m8n8.x4.trans.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                  : "=r"(boundary_a_frag1[0]), "=r"(boundary_a_frag1[1]), "=r"(boundary_a_frag1[2]),
+                    "=r"(boundary_a_frag1[3])
+                  : "r"(state_operand_all_addr +
+                        (unsigned int)(((int)state_smem_stage1 * 128 * 128 +
+                                        (segment_1_2 * 128 * 64 + boundary_a_row1 * 64 +
+                                         swizzled_col_3_2)) *
+                                       2))
+                  : "memory");
+#pragma unroll
+              for (int boundary_n_half1 = 0; boundary_n_half1 < 2; boundary_n_half1++) {
+                int boundary_b_row1 = boundary_k1 + lane % 16;
+                int boundary_b_col1 = boundary_channel_base1 + boundary_n_half1 * 8;
+                int segment_2_1 = boundary_b_col1 / 64;
+                int segment_col_3_1 = boundary_b_col1 - segment_2_1 * 64;
+                int swizzled_col_4_1 = segment_col_3_1 ^ (boundary_b_row1 & 7) * 8;
+                asm volatile("ldmatrix.sync.aligned.m8n8.x2.trans.shared.b16 {%0, %1}, [%2];\n"
+                             : "=r"(boundary_b_frag1[boundary_n_half1 * 2]),
+                               "=r"(boundary_b_frag1[boundary_n_half1 * 2 + 1])
+                             : "r"(dstate_smem_all_addr +
+                                   (unsigned int)((segment_2_1 * 128 * 64 + boundary_b_row1 * 64 +
+                                                   swizzled_col_4_1) *
+                                                  2))
+                             : "memory");
+              }
+              asm volatile(
+                  "mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, "
+                  "%6, %7}, {%8, %9}, {%10, %11, %12, %13};\n"
+                  : "=f"(boundary_diag_acc1[0]), "=f"(boundary_diag_acc1[1]),
+                    "=f"(boundary_diag_acc1[2]), "=f"(boundary_diag_acc1[3])
+                  : "r"(boundary_a_frag1[0]), "r"(boundary_a_frag1[1]), "r"(boundary_a_frag1[2]),
+                    "r"(boundary_a_frag1[3]), "r"(boundary_b_frag1[0]), "r"(boundary_b_frag1[1]),
+                    "f"(((boundary_k1 == 0) ? 0.0f : boundary_diag_acc1[0])),
+                    "f"(((boundary_k1 == 0) ? 0.0f : boundary_diag_acc1[1])),
+                    "f"(((boundary_k1 == 0) ? 0.0f : boundary_diag_acc1[2])),
+                    "f"(((boundary_k1 == 0) ? 0.0f : boundary_diag_acc1[3])));
+              asm volatile(
+                  "mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, "
+                  "%6, %7}, {%8, %9}, {%10, %11, %12, %13};\n"
+                  : "=f"(boundary_diag_acc1[4]), "=f"(boundary_diag_acc1[(4) + 1]),
+                    "=f"(boundary_diag_acc1[(4) + 2]), "=f"(boundary_diag_acc1[(4) + 3])
+                  : "r"(boundary_a_frag1[0]), "r"(boundary_a_frag1[1]), "r"(boundary_a_frag1[2]),
+                    "r"(boundary_a_frag1[3]), "r"(boundary_b_frag1[2]),
+                    "r"(boundary_b_frag1[(2) + 1]),
+                    "f"(((boundary_k1 == 0) ? 0.0f : boundary_diag_acc1[4])),
+                    "f"(((boundary_k1 == 0) ? 0.0f : boundary_diag_acc1[(4) + 1])),
+                    "f"(((boundary_k1 == 0) ? 0.0f : boundary_diag_acc1[(4) + 2])),
+                    "f"(((boundary_k1 == 0) ? 0.0f : boundary_diag_acc1[(4) + 3])));
+            }
+            float boundary_diag_lo1 = boundary_diag_acc1[0];
+            float boundary_diag_hi1 = boundary_diag_acc1[6];
+            if ((lane / 4 & 1) != 0) {
+              boundary_diag_lo1 = boundary_diag_acc1[1];
+              boundary_diag_hi1 = boundary_diag_acc1[7];
+            }
+            int boundary_target_row1 = lane & 15;
+            int boundary_source_lane1 =
+                (boundary_target_row1 & 7) * 4 + (boundary_target_row1 & 7) / 2;
+            float _shfl_0 = __shfl_sync(0xFFFFFFFF, boundary_diag_lo1, boundary_source_lane1);
+            float boundary_diag_lower1 = _shfl_0;
+            float _shfl_1 = __shfl_sync(0xFFFFFFFF, boundary_diag_hi1, boundary_source_lane1);
+            float boundary_diag_upper1 = _shfl_1;
+            boundary_diag_pair1[boundary_diag_block1] = boundary_diag_lower1;
+            if (boundary_target_row1 >= 8) {
+              boundary_diag_pair1[boundary_diag_block1] = boundary_diag_upper1;
+            }
+          }
+          float dgate_last_state1 = boundary_diag_pair1[0];
+          if (lane >= 16) {
+            dgate_last_state1 = boundary_diag_pair1[1];
+          }
+          boundary_state_smem[role_tid1] = dgate_last_state1;
+          asm volatile("fence.proxy.async.shared::cta;" ::: "memory");
+          if (elect_sync()) {
+            mbarrier_arrive(boundary_state_ready_addr + (boundary_stage1) * 8);
+          }
+          if (reverse1 + 1 < compute_end1 - write_start1) {
+            if (elect_sync()) {
+              mbarrier_arrive(dstate_inp_ready_addr);
+              mbarrier_arrive(dstate_smem_ready_addr + (dstate_smem_stage1) * 8);
+            }
+            dstate_smem_stage1 += 1;
+            if (dstate_smem_stage1 == 1) {
+              dstate_smem_stage1 = 0;
+              _phase_dstate_smem_done ^= 1;
+            }
+            dstate_smem_slot_acquired1 = 0;
+          }
+          if (boundary_chunk1 < write_end1) {
+            long long boundary_output_index1 =
+                (boundary_checkpoint1 * (long long)num_heads + (long long)head1) * 128 +
+                (long long)role_tid1;
+            dgate_boundary_out[boundary_output_index1] = dgate_last_state1;
+          }
+          mbarrier_wait(boundary_acc_ready_addr + (boundary_stage1) * 8, _phase_boundary_acc_ready);
+          if (elect_sync()) {
+            mbarrier_arrive(dstate_done_addr + (tcgen_data_stage1) * 8);
+          }
+          boundary_stage1 += 1;
+          if (boundary_stage1 == 1) {
+            boundary_stage1 = 0;
+            _phase_boundary_acc_ready ^= 1;
+          }
+          raw_stage1 += 1;
+          if (raw_stage1 == 2) {
+            raw_stage1 = 0;
+            _phase_raw_ready_1 ^= 1;
+          }
+          state_smem_stage1 += 1;
+          if (state_smem_stage1 == 2) {
+            state_smem_stage1 = 0;
+            _phase_state_k_ready ^= 1;
+          }
+          tcgen_data_stage1 += 1;
+          if (tcgen_data_stage1 == 1) {
+            tcgen_data_stage1 = 0;
+            _phase_tcgen_inputs_done ^= 1;
+            _phase_tcgen_products_ready ^= 1;
+            _phase_dy_ready ^= 1;
+            _phase_dstate_ready ^= 1;
+          }
+        }
+        if (validate_outputs != 0 && role_tid1 == 0) {
+          observed[tile1] = checksum_sum1;
+        }
+      }
+      if (elect_sync()) {
+        mbarrier_arrive(consumers_done_addr);
+      }
+    }
+  }
+  // ---- Role: compute2 ----
+  if (warp >= 8 && warp <= 11) {
+    asm volatile("setmaxnreg.inc.sync.aligned.u32 144;");
+    {  // compute2_main
+      unsigned int sched_stage2 = 0;
+      unsigned int dk_restore_stage2 = 0;
+      unsigned int local_grad_stage2 = 0;
+      unsigned int qk_raw_stage2 = 0;
+      unsigned int g_prefix_stage2 = 0;
+      unsigned int state_smem_stage2 = 0;
+      unsigned int boundary_stage2 = 0;
+      int warp_id_in_role_2 = (warp - 8);
+      int role_tid2 = warp_id_in_role_2 * 32 + lane;
+      const int tmem_row_base2 = warp_id_in_role_2 * 32 << 16;
+      unsigned int _phase_sched_ready_2 = 0;
+      unsigned int _phase_qk_raw_ready = 0;
+      unsigned int _phase_g_prefix_ready = 0;
+      unsigned int _phase_state_ready = 0;
+      unsigned int _phase_local_grad_ready = 0;
+      unsigned int _phase_boundary_acc_ready_1 = 0;
+      unsigned int _phase_boundary_state_ready = 0;
+      unsigned int _phase_dk_restore_ready = 0;
+#pragma unroll 1
+      for (int __2 = 0; __2 < total_work_items; __2++) {
+        mbarrier_wait(sched_ready_addr + (sched_stage2) * 8, _phase_sched_ready_2);
+        unsigned int ticket_words_2[1];
+        asm volatile("ld.shared.b32 %0, [%1];"
+                     : "=r"(*reinterpret_cast<uint32_t*>(&ticket_words_2[0]))
+                     : "r"(work_item_addr + sched_stage2 * 4));
+        unsigned int tile2 = ticket_words_2[0];
+        if (elect_sync()) {
+          mbarrier_arrive(sched_done_addr + (sched_stage2) * 8);
+        }
+        sched_stage2 += 1;
+        if (sched_stage2 == 8) {
+          sched_stage2 = 0;
+          _phase_sched_ready_2 ^= 1;
+        }
+        if (tile2 >= (unsigned int)total_work_items) {
+          break;
+        }
+        int item_base2 = (int)tile2 * 8;
+        int sequence2 = work_items[item_base2];
+        int head2 = work_items[item_base2 + 1];
+        int write_start2 = work_items[item_base2 + 2];
+        int write_end2 = work_items[item_base2 + 3];
+        int compute_end2 = work_items[item_base2 + 5];
+        long long bos2 = cu_seqlens[sequence2];
+#pragma unroll 1
+        for (int reverse2 = 0; reverse2 < compute_end2 - write_start2; reverse2++) {
+          mbarrier_wait(qk_raw_ready_addr + (qk_raw_stage2) * 8, _phase_qk_raw_ready);
+          mbarrier_wait(g_prefix_ready_addr + (g_prefix_stage2) * 8, _phase_g_prefix_ready);
+          mbarrier_wait(state_ready_addr + (state_smem_stage2) * 8, _phase_state_ready);
+          int norm_stage_base2 = (int)(qk_raw_stage2 % 4) * 2 * 16;
+          float eg_values2[16];
+#pragma unroll
+          for (int token_gate2 = 0; token_gate2 < 16; token_gate2++) {
+            int segment_7 = role_tid2 / 32;
+            int segment_col_8 = role_tid2 - segment_7 * 32;
+            int swizzled_col_7 = segment_col_8 ^ (token_gate2 & 7) * 4;
+            eg_values2[token_gate2] =
+                g_prefix_all[(int)g_prefix_stage2 * 16 * 128 + segment_7 * 16 * 32 +
+                             token_gate2 * 32 + swizzled_col_7];
+          }
+          mbarrier_arrive(g_prefix_done_addr + (g_prefix_stage2) * 8);
+          mbarrier_wait(local_grad_ready_addr + (local_grad_stage2) * 8, _phase_local_grad_ready);
+          asm volatile("tcgen05.fence::after_thread_sync;");
+          float _tmem_load_9[16];
+          tmem_ld_x16(&_tmem_load_9[0], taddr + 368 + (unsigned int)tmem_row_base2);
+          float _tmem_load_10[16];
+          tmem_ld_x16(&_tmem_load_10[0], taddr + 384 + (unsigned int)tmem_row_base2);
+          float _tmem_load_11[16];
+          tmem_ld_x16(&_tmem_load_11[0], taddr + 400 + (unsigned int)tmem_row_base2);
+          asm volatile("tcgen05.wait::ld.sync.aligned;" ::: "memory");
+          asm volatile("tcgen05.fence::before_thread_sync;");
+          if (elect_sync()) {
+            mbarrier_arrive(local_grad_done_addr + (local_grad_stage2) * 8);
+            mbarrier_arrive(boundary_local_grad_free_addr + (local_grad_stage2) * 8);
+            mbarrier_arrive(dstate_done_addr + (local_grad_stage2) * 8);
+          }
+          mbarrier_wait(boundary_acc_ready_addr + (boundary_stage2) * 8,
+                        _phase_boundary_acc_ready_1);
+          mbarrier_wait(boundary_state_ready_addr + (boundary_stage2) * 8,
+                        _phase_boundary_state_ready);
+          float dgate_last_state2 = boundary_state_smem[role_tid2];
+          boundary_stage2 += 1;
+          if (boundary_stage2 == 1) {
+            boundary_stage2 = 0;
+            _phase_boundary_acc_ready_1 ^= 1;
+            _phase_boundary_state_ready ^= 1;
+          }
+          mbarrier_arrive(state_cg2_done_addr + (state_smem_stage2) * 8);
+          float2 dgate_last_restore_acc2[2];
+#pragma unroll
+          for (int restore_acc_init2 = 0; restore_acc_init2 < 2; restore_acc_init2++) {
+            float2 _f2_0 = make_float2(0.0f, 0.0f);
+            dgate_last_restore_acc2[restore_acc_init2] = _f2_0;
+          }
+#pragma unroll
+          for (int token_pair2 = 0; token_pair2 < 8; token_pair2++) {
+            const int token_scale0_2 = token_pair2 * 2;
+            const int token_scale1_2 = token_scale0_2 + 1;
+            float eg0_2 = eg_values2[token_scale0_2];
+            float eg1_2 = eg_values2[token_scale1_2];
+            float2 _f2_1 = make_float2(_tmem_load_9[token_scale0_2], _tmem_load_9[token_scale1_2]);
+            float2 _f2_2 = make_float2(eg0_2 * scale, eg1_2 * scale);
+            float2 dq_pair2 = mul_f32x2(_f2_1, _f2_2);
+            float2 _f2_3 = make_float2(-eg0_2, -eg1_2);
+            float2 _f2_4 =
+                make_float2(_tmem_load_10[token_scale0_2], _tmem_load_10[token_scale1_2]);
+            float2 dk_decay_pair2 = mul_f32x2(_f2_3, _f2_4);
+            float2 _f2_5 =
+                make_float2(_tmem_load_11[token_scale0_2], _tmem_load_11[token_scale1_2]);
+            float _rcp_2 = approx_rcp(eg0_2);
+            float _rcp_3 = approx_rcp(eg1_2);
+            float2 _f2_6 = make_float2(_rcp_2, _rcp_3);
+            float2 dk_inv_pair2 = fma_f32x2(_f2_5, _f2_6, dk_decay_pair2);
+            _tmem_load_9[token_scale0_2] = dq_pair2.x;
+            _tmem_load_9[token_scale1_2] = dq_pair2.y;
+            _tmem_load_10[token_scale0_2] = dk_decay_pair2.x;
+            _tmem_load_10[token_scale1_2] = dk_decay_pair2.y;
+            _tmem_load_11[token_scale0_2] = dk_inv_pair2.x;
+            _tmem_load_11[token_scale1_2] = dk_inv_pair2.y;
+          }
+          unsigned int raw_words_bits2[8];
+          float q_raw_values2[16];
+          float k_raw_values2[16];
+          float _tmem_load_12[8];
+          tmem_ld_x8(&_tmem_load_12[0],
+                     taddr + 480 + qk_raw_stage2 % 4 * 8 + (unsigned int)tmem_row_base2);
+          asm volatile("tcgen05.wait::ld.sync.aligned;" ::: "memory");
+          raw_words_bits2[0] = __as_u32(_tmem_load_12[0]);
+          raw_words_bits2[1] = __as_u32(_tmem_load_12[1]);
+          raw_words_bits2[2] = __as_u32(_tmem_load_12[2]);
+          raw_words_bits2[3] = __as_u32(_tmem_load_12[3]);
+          raw_words_bits2[4] = __as_u32(_tmem_load_12[4]);
+          raw_words_bits2[5] = __as_u32(_tmem_load_12[5]);
+          raw_words_bits2[6] = __as_u32(_tmem_load_12[6]);
+          raw_words_bits2[7] = __as_u32(_tmem_load_12[7]);
+#pragma unroll
+          for (int _pair = 0; _pair < 8; _pair++) {
+            asm volatile(
+                "{\n\t"
+                "shl.b32 %0, %2, 16;\n\t"
+                "and.b32 %1, %2, 0xffff0000;\n\t"
+                "}\n"
+                : "=f"((&k_raw_values2[_pair * 2])[0]), "=f"((&k_raw_values2[_pair * 2])[1])
+                : "r"(raw_words_bits2[_pair]));
+          }
+          if (USE_DSTATE_IN != 0 || reverse2 > 0) {
+            mbarrier_wait(dk_restore_ready_addr + (dk_restore_stage2) * 8, _phase_dk_restore_ready);
+            asm volatile("tcgen05.fence::after_thread_sync;");
+            float _tmem_load_13[16];
+            tmem_ld_x16(&_tmem_load_13[0], taddr + 416 + (unsigned int)tmem_row_base2);
+            asm volatile("tcgen05.wait::ld.sync.aligned;" ::: "memory");
+#pragma unroll
+            for (int dk_pair2 = 0; dk_pair2 < 8; dk_pair2++) {
+              const int dk_col0_2 = dk_pair2 * 2;
+              const int dk_col1_2 = dk_col0_2 + 1;
+              float _rcp_4 = approx_rcp(eg_values2[dk_col0_2]);
+              float restore_scale0_2 = eg_values2[15] * _rcp_4;
+              float _rcp_5 = approx_rcp(eg_values2[dk_col1_2]);
+              float restore_scale1_2 = eg_values2[15] * _rcp_5;
+              float2 _f2_7 = make_float2(restore_scale0_2, restore_scale1_2);
+              float2 _f2_8 = make_float2(_tmem_load_13[dk_col0_2], _tmem_load_13[dk_col1_2]);
+              float2 restore_hat_pair2 = mul_f32x2(_f2_7, _f2_8);
+              float2 _f2_9 = make_float2(_tmem_load_11[dk_col0_2], _tmem_load_11[dk_col1_2]);
+              float2 dk_inv_restore_pair2 = add_f32x2(_f2_9, restore_hat_pair2);
+              _tmem_load_11[dk_col0_2] = dk_inv_restore_pair2.x;
+              _tmem_load_11[dk_col1_2] = dk_inv_restore_pair2.y;
+              float k_restore_norm0_2 = qk_norm_smem_all[norm_stage_base2 + 16 + dk_col0_2];
+              float k_restore_norm1_2 = qk_norm_smem_all[norm_stage_base2 + 16 + dk_col1_2];
+              float2 _f2_10 = make_float2(k_raw_values2[dk_col0_2], k_raw_values2[dk_col1_2]);
+              float2 _f2_11 = make_float2(k_restore_norm0_2, k_restore_norm1_2);
+              float2 k_normalized_pair2 = mul_f32x2(_f2_10, _f2_11);
+              float2 restore_gate_pair2 = mul_f32x2(k_normalized_pair2, restore_hat_pair2);
+              const int restore_acc_index2 = dk_pair2 % 2;
+              dgate_last_restore_acc2[restore_acc_index2] =
+                  add_f32x2(dgate_last_restore_acc2[restore_acc_index2], restore_gate_pair2);
+            }
+            if (elect_sync()) {
+              mbarrier_arrive(dk_restore_done_addr + (dk_restore_stage2) * 8);
+            }
+            dk_restore_stage2 += 1;
+            if (dk_restore_stage2 == 1) {
+              dk_restore_stage2 = 0;
+              _phase_dk_restore_ready ^= 1;
+            }
+          }
+          float _tmem_load_14[8];
+          tmem_ld_x8(&_tmem_load_14[0],
+                     taddr + 448 + qk_raw_stage2 % 4 * 8 + (unsigned int)tmem_row_base2);
+          asm volatile("tcgen05.wait::ld.sync.aligned;" ::: "memory");
+          raw_words_bits2[0] = __as_u32(_tmem_load_14[0]);
+          raw_words_bits2[1] = __as_u32(_tmem_load_14[1]);
+          raw_words_bits2[2] = __as_u32(_tmem_load_14[2]);
+          raw_words_bits2[3] = __as_u32(_tmem_load_14[3]);
+          raw_words_bits2[4] = __as_u32(_tmem_load_14[4]);
+          raw_words_bits2[5] = __as_u32(_tmem_load_14[5]);
+          raw_words_bits2[6] = __as_u32(_tmem_load_14[6]);
+          raw_words_bits2[7] = __as_u32(_tmem_load_14[7]);
+#pragma unroll
+          for (int _pair = 0; _pair < 8; _pair++) {
+            asm volatile(
+                "{\n\t"
+                "shl.b32 %0, %2, 16;\n\t"
+                "and.b32 %1, %2, 0xffff0000;\n\t"
+                "}\n"
+                : "=f"((&q_raw_values2[_pair * 2])[0]), "=f"((&q_raw_values2[_pair * 2])[1])
+                : "r"(raw_words_bits2[_pair]));
+          }
+          float dgate_last_restore2 = dgate_last_restore_acc2[0].x + dgate_last_restore_acc2[0].y +
+                                      (dgate_last_restore_acc2[1].x + dgate_last_restore_acc2[1].y);
+#pragma unroll
+          for (int gate_pair2 = 0; gate_pair2 < 8; gate_pair2++) {
+            const int gate_token0_2 = gate_pair2 * 2;
+            const int gate_token1_2 = gate_token0_2 + 1;
+            float q_gate_norm0_2 = qk_norm_smem_all[norm_stage_base2 + gate_token0_2];
+            float q_gate_norm1_2 = qk_norm_smem_all[norm_stage_base2 + gate_token1_2];
+            float k_gate_norm0_2 = qk_norm_smem_all[norm_stage_base2 + 16 + gate_token0_2];
+            float k_gate_norm1_2 = qk_norm_smem_all[norm_stage_base2 + 16 + gate_token1_2];
+            float2 _f2_12 = make_float2(q_raw_values2[gate_token0_2], q_raw_values2[gate_token1_2]);
+            float2 _f2_13 = make_float2(q_gate_norm0_2, q_gate_norm1_2);
+            float2 q_normalized_pair2 = mul_f32x2(_f2_12, _f2_13);
+            float2 _f2_14 = make_float2(k_raw_values2[gate_token0_2], k_raw_values2[gate_token1_2]);
+            float2 _f2_15 = make_float2(k_gate_norm0_2, k_gate_norm1_2);
+            float2 k_normalized_pair2_1 = mul_f32x2(_f2_14, _f2_15);
+            float2 _f2_16 = make_float2(2.0f, 2.0f);
+            float2 _f2_17 = make_float2(_tmem_load_10[gate_token0_2], _tmem_load_10[gate_token1_2]);
+            float2 _f2_18 = make_float2(_tmem_load_11[gate_token0_2], _tmem_load_11[gate_token1_2]);
+            float2 gate_residual_pair2 = fma_sub_f32x2(_f2_16, _f2_17, _f2_18);
+            float2 _f2_19 = make_float2(_tmem_load_9[gate_token0_2], _tmem_load_9[gate_token1_2]);
+            float2 dgate_pair2 = fma_f32x2(k_normalized_pair2_1, gate_residual_pair2,
+                                           mul_f32x2(q_normalized_pair2, _f2_19));
+            _tmem_load_10[gate_token0_2] = dgate_pair2.x;
+            _tmem_load_10[gate_token1_2] = dgate_pair2.y;
+          }
+          _tmem_load_10[15] = _tmem_load_10[15] + dgate_last_restore2;
+          if (USE_DSTATE_IN != 0 || reverse2 > 0) {
+            _tmem_load_10[15] = _tmem_load_10[15] + eg_values2[15] * dgate_last_state2;
+          }
+#pragma unroll
+          for (int gate_suffix2 = 15; gate_suffix2 >= 1; gate_suffix2--) {
+            _tmem_load_10[gate_suffix2 - 1] =
+                _tmem_load_10[gate_suffix2 - 1] + _tmem_load_10[gate_suffix2];
+          }
+          float anchored_dgate2 = dgate_last_state2;
+#pragma unroll
+          for (int gate_reconcile2 = 0; gate_reconcile2 < 8; gate_reconcile2++) {
+            float suffix_here2 = _tmem_load_10[gate_reconcile2];
+            float suffix_next2 = _tmem_load_10[gate_reconcile2 + 1];
+            _tmem_load_10[gate_reconcile2] = anchored_dgate2;
+            anchored_dgate2 -= suffix_here2 - suffix_next2;
+          }
+          float _tmem_load_15[8];
+          tmem_ld_x8(&_tmem_load_15[0],
+                     taddr + 448 + qk_raw_stage2 % 4 * 8 + (unsigned int)tmem_row_base2);
+          asm volatile("tcgen05.wait::ld.sync.aligned;" ::: "memory");
+          raw_words_bits2[0] = __as_u32(_tmem_load_15[0]);
+          raw_words_bits2[1] = __as_u32(_tmem_load_15[1]);
+          raw_words_bits2[2] = __as_u32(_tmem_load_15[2]);
+          raw_words_bits2[3] = __as_u32(_tmem_load_15[3]);
+          raw_words_bits2[4] = __as_u32(_tmem_load_15[4]);
+          raw_words_bits2[5] = __as_u32(_tmem_load_15[5]);
+          raw_words_bits2[6] = __as_u32(_tmem_load_15[6]);
+          raw_words_bits2[7] = __as_u32(_tmem_load_15[7]);
+#pragma unroll
+          for (int _pair = 0; _pair < 8; _pair++) {
+            asm volatile(
+                "{\n\t"
+                "shl.b32 %0, %2, 16;\n\t"
+                "and.b32 %1, %2, 0xffff0000;\n\t"
+                "}\n"
+                : "=f"((&q_raw_values2[_pair * 2])[0]), "=f"((&q_raw_values2[_pair * 2])[1])
+                : "r"(raw_words_bits2[_pair]));
+          }
+          float dot_values2[16];
+#pragma unroll
+          for (int qdot_pair2 = 0; qdot_pair2 < 8; qdot_pair2++) {
+            const int qdot_token0_2 = qdot_pair2 * 2;
+            const int qdot_token1_2 = qdot_token0_2 + 1;
+            float qdot_norm0_2 = qk_norm_smem_all[norm_stage_base2 + qdot_token0_2];
+            float qdot_norm1_2 = qk_norm_smem_all[norm_stage_base2 + qdot_token1_2];
+            float2 _f2_20 = make_float2(_tmem_load_9[qdot_token0_2], _tmem_load_9[qdot_token1_2]);
+            float2 _f2_21 = make_float2(q_raw_values2[qdot_token0_2], q_raw_values2[qdot_token1_2]);
+            float2 _f2_22 = make_float2(qdot_norm0_2, qdot_norm1_2);
+            float2 qdot_pair_value2 = mul_f32x2(_f2_20, mul_f32x2(_f2_21, _f2_22));
+            dot_values2[qdot_token0_2] = qdot_pair_value2.x;
+            dot_values2[qdot_token1_2] = qdot_pair_value2.y;
+#pragma unroll
+            for (int qdot_step2 = 0; qdot_step2 < 5; qdot_step2++) {
+              const int qdot_delta2 = 16 >> qdot_step2;
+              float _shfl_xor_9 =
+                  __shfl_xor_sync(0xFFFFFFFF, dot_values2[qdot_token0_2], qdot_delta2);
+              float qdot_shuffle0_2 = _shfl_xor_9;
+              float _shfl_xor_10 =
+                  __shfl_xor_sync(0xFFFFFFFF, dot_values2[qdot_token1_2], qdot_delta2);
+              float qdot_shuffle1_2 = _shfl_xor_10;
+              float2 _f2_23 = make_float2(dot_values2[qdot_token0_2], dot_values2[qdot_token1_2]);
+              float2 _f2_24 = make_float2(qdot_shuffle0_2, qdot_shuffle1_2);
+              qdot_pair_value2 = add_f32x2(_f2_23, _f2_24);
+              dot_values2[qdot_token0_2] = qdot_pair_value2.x;
+              dot_values2[qdot_token1_2] = qdot_pair_value2.y;
+            }
+          }
+          if (lane == 0) {
+#pragma unroll
+            for (int qdot_store2 = 0; qdot_store2 < 16; qdot_store2++) {
+              qk_red_smem[warp_id_in_role_2 * 16 + qdot_store2] = dot_values2[qdot_store2];
+            }
+          }
+          asm volatile("barrier.sync 10, 128;" ::: "memory");
+#pragma unroll
+          for (int qproj_pair2 = 0; qproj_pair2 < 8; qproj_pair2++) {
+            const int qproj_token0_2 = qproj_pair2 * 2;
+            const int qproj_token1_2 = qproj_token0_2 + 1;
+            float2 _f2_25 = make_float2(0.0f, 0.0f);
+            float2 qdot_total_pair2 = _f2_25;
+#pragma unroll
+            for (int qdot_warp2 = 0; qdot_warp2 < 4; qdot_warp2++) {
+              float qdot_total0_2 = qk_red_smem[qdot_warp2 * 16 + qproj_token0_2];
+              float qdot_total1_2 = qk_red_smem[qdot_warp2 * 16 + qproj_token1_2];
+              float2 _f2_26 = make_float2(qdot_total0_2, qdot_total1_2);
+              qdot_total_pair2 = add_f32x2(qdot_total_pair2, _f2_26);
+            }
+            float qproj_norm0_2 = qk_norm_smem_all[norm_stage_base2 + qproj_token0_2];
+            float qproj_norm1_2 = qk_norm_smem_all[norm_stage_base2 + qproj_token1_2];
+            float2 _f2_27 = make_float2(qproj_norm0_2, qproj_norm1_2);
+            float2 qproj_norm_pair2 = _f2_27;
+            float2 _f2_28 =
+                make_float2(q_raw_values2[qproj_token0_2], q_raw_values2[qproj_token1_2]);
+            float2 qproj_correction_pair2 =
+                mul_f32x2(mul_f32x2(_f2_28, qproj_norm_pair2), qdot_total_pair2);
+            float2 _f2_29 = make_float2(_tmem_load_9[qproj_token0_2], _tmem_load_9[qproj_token1_2]);
+            float2 qproj_result_pair2 =
+                mul_f32x2(sub_f32x2(_f2_29, qproj_correction_pair2), qproj_norm_pair2);
+            _tmem_load_9[qproj_token0_2] = qproj_result_pair2.x;
+            _tmem_load_9[qproj_token1_2] = qproj_result_pair2.y;
+          }
+          asm volatile("barrier.sync 10, 128;" ::: "memory");
+          float _tmem_load_16[8];
+          tmem_ld_x8(&_tmem_load_16[0],
+                     taddr + 480 + qk_raw_stage2 % 4 * 8 + (unsigned int)tmem_row_base2);
+          asm volatile("tcgen05.wait::ld.sync.aligned;" ::: "memory");
+          raw_words_bits2[0] = __as_u32(_tmem_load_16[0]);
+          raw_words_bits2[1] = __as_u32(_tmem_load_16[1]);
+          raw_words_bits2[2] = __as_u32(_tmem_load_16[2]);
+          raw_words_bits2[3] = __as_u32(_tmem_load_16[3]);
+          raw_words_bits2[4] = __as_u32(_tmem_load_16[4]);
+          raw_words_bits2[5] = __as_u32(_tmem_load_16[5]);
+          raw_words_bits2[6] = __as_u32(_tmem_load_16[6]);
+          raw_words_bits2[7] = __as_u32(_tmem_load_16[7]);
+#pragma unroll
+          for (int _pair = 0; _pair < 8; _pair++) {
+            asm volatile(
+                "{\n\t"
+                "shl.b32 %0, %2, 16;\n\t"
+                "and.b32 %1, %2, 0xffff0000;\n\t"
+                "}\n"
+                : "=f"((&k_raw_values2[_pair * 2])[0]), "=f"((&k_raw_values2[_pair * 2])[1])
+                : "r"(raw_words_bits2[_pair]));
+          }
+#pragma unroll
+          for (int kdot_pair2 = 0; kdot_pair2 < 8; kdot_pair2++) {
+            const int kdot_token0_2 = kdot_pair2 * 2;
+            const int kdot_token1_2 = kdot_token0_2 + 1;
+            float kdot_norm0_2 = qk_norm_smem_all[norm_stage_base2 + 16 + kdot_token0_2];
+            float kdot_norm1_2 = qk_norm_smem_all[norm_stage_base2 + 16 + kdot_token1_2];
+            float2 _f2_30 = make_float2(_tmem_load_11[kdot_token0_2], _tmem_load_11[kdot_token1_2]);
+            float2 _f2_31 = make_float2(k_raw_values2[kdot_token0_2], k_raw_values2[kdot_token1_2]);
+            float2 _f2_32 = make_float2(kdot_norm0_2, kdot_norm1_2);
+            float2 kdot_pair_value2 = mul_f32x2(_f2_30, mul_f32x2(_f2_31, _f2_32));
+            dot_values2[kdot_token0_2] = kdot_pair_value2.x;
+            dot_values2[kdot_token1_2] = kdot_pair_value2.y;
+#pragma unroll
+            for (int kdot_step2 = 0; kdot_step2 < 5; kdot_step2++) {
+              const int kdot_delta2 = 16 >> kdot_step2;
+              float _shfl_xor_11 =
+                  __shfl_xor_sync(0xFFFFFFFF, dot_values2[kdot_token0_2], kdot_delta2);
+              float kdot_shuffle0_2 = _shfl_xor_11;
+              float _shfl_xor_12 =
+                  __shfl_xor_sync(0xFFFFFFFF, dot_values2[kdot_token1_2], kdot_delta2);
+              float kdot_shuffle1_2 = _shfl_xor_12;
+              float2 _f2_33 = make_float2(dot_values2[kdot_token0_2], dot_values2[kdot_token1_2]);
+              float2 _f2_34 = make_float2(kdot_shuffle0_2, kdot_shuffle1_2);
+              kdot_pair_value2 = add_f32x2(_f2_33, _f2_34);
+              dot_values2[kdot_token0_2] = kdot_pair_value2.x;
+              dot_values2[kdot_token1_2] = kdot_pair_value2.y;
+            }
+          }
+          if (lane == 0) {
+#pragma unroll
+            for (int kdot_store2 = 0; kdot_store2 < 16; kdot_store2++) {
+              qk_red_smem[warp_id_in_role_2 * 16 + kdot_store2] = dot_values2[kdot_store2];
+            }
+          }
+          asm volatile("barrier.sync 10, 128;" ::: "memory");
+#pragma unroll
+          for (int kproj_pair2 = 0; kproj_pair2 < 8; kproj_pair2++) {
+            const int kproj_token0_2 = kproj_pair2 * 2;
+            const int kproj_token1_2 = kproj_token0_2 + 1;
+            float2 _f2_35 = make_float2(0.0f, 0.0f);
+            float2 kdot_total_pair2 = _f2_35;
+#pragma unroll
+            for (int kdot_warp2 = 0; kdot_warp2 < 4; kdot_warp2++) {
+              float kdot_total0_2 = qk_red_smem[kdot_warp2 * 16 + kproj_token0_2];
+              float kdot_total1_2 = qk_red_smem[kdot_warp2 * 16 + kproj_token1_2];
+              float2 _f2_36 = make_float2(kdot_total0_2, kdot_total1_2);
+              kdot_total_pair2 = add_f32x2(kdot_total_pair2, _f2_36);
+            }
+            float kproj_norm0_2 = qk_norm_smem_all[norm_stage_base2 + 16 + kproj_token0_2];
+            float kproj_norm1_2 = qk_norm_smem_all[norm_stage_base2 + 16 + kproj_token1_2];
+            float2 _f2_37 = make_float2(kproj_norm0_2, kproj_norm1_2);
+            float2 kproj_norm_pair2 = _f2_37;
+            float2 _f2_38 =
+                make_float2(k_raw_values2[kproj_token0_2], k_raw_values2[kproj_token1_2]);
+            float2 kproj_correction_pair2 =
+                mul_f32x2(mul_f32x2(_f2_38, kproj_norm_pair2), kdot_total_pair2);
+            float2 _f2_39 =
+                make_float2(_tmem_load_11[kproj_token0_2], _tmem_load_11[kproj_token1_2]);
+            float2 kproj_result_pair2 =
+                mul_f32x2(sub_f32x2(_f2_39, kproj_correction_pair2), kproj_norm_pair2);
+            _tmem_load_11[kproj_token0_2] = kproj_result_pair2.x;
+            _tmem_load_11[kproj_token1_2] = kproj_result_pair2.y;
+          }
+          asm volatile("barrier.sync 10, 128;" ::: "memory");
+          int output_chunk2 = compute_end2 - 1 - reverse2;
+          long long output_token_base2 = bos2 + (long long)output_chunk2 * 16;
+          if (output_chunk2 < write_end2) {
+#pragma unroll
+            for (int output_token2 = 0; output_token2 < 16; output_token2++) {
+              long long output_index2 =
+                  ((output_token_base2 + (long long)output_token2) * (long long)num_heads +
+                   (long long)head2) *
+                      128 +
+                  (long long)role_tid2;
+              __nv_bfloat16 _cvt_bf16_6 = __float2bfloat16(_tmem_load_9[output_token2]);
+              dq_out[output_index2] = _cvt_bf16_6;
+              __nv_bfloat16 _cvt_bf16_7 = __float2bfloat16(_tmem_load_11[output_token2]);
+              dk_out[output_index2] = _cvt_bf16_7;
+              dgate_out[output_index2] = _tmem_load_10[output_token2];
+            }
+          }
+          mbarrier_arrive(qk_raw_done_addr + (qk_raw_stage2) * 8);
+          local_grad_stage2 += 1;
+          if (local_grad_stage2 == 1) {
+            local_grad_stage2 = 0;
+            _phase_local_grad_ready ^= 1;
+          }
+          qk_raw_stage2 += 1;
+          if (qk_raw_stage2 == 4) {
+            qk_raw_stage2 = 0;
+            _phase_qk_raw_ready ^= 1;
+          }
+          g_prefix_stage2 += 1;
+          if (g_prefix_stage2 == 2) {
+            g_prefix_stage2 = 0;
+            _phase_g_prefix_ready ^= 1;
+          }
+          state_smem_stage2 += 1;
+          if (state_smem_stage2 == 2) {
+            state_smem_stage2 = 0;
+            _phase_state_ready ^= 1;
+          }
+        }
+      }
+      if (elect_sync()) {
+        mbarrier_arrive(consumers_done_addr);
+      }
+    }
+  }
+  // ---- Role: super_mma ----
+  if (warp == 12) {
+    {  // super_mma_main
+      unsigned int sched_stage3 = 0;
+      unsigned int raw_stage3 = 0;
+      unsigned int operand_stage3 = 0;
+      unsigned int intermediate_stage3 = 0;
+      unsigned int u_smem_stage3 = 0;
+      unsigned int dy_smem_stage3 = 0;
+      unsigned int dbeta_m_stage3 = 0;
+      int lhs_row3 = lane % 8 + (lane / 8 & 1) * 8;
+      int lhs_col_offset3 = lane / 16 * 8;
+      int rhs_row3 = lane % 8 + lane / 16 * 8;
+      int rhs_col_offset3 = (lane / 8 & 1) * 8;
+      unsigned int _phase_sched_ready_3 = 0;
+      unsigned int _phase_raw_ready_2 = 0;
+      unsigned int _phase_k_decay_inv_ready = 0;
+      unsigned int _phase_intermediate_done = 1;
+      unsigned int _phase_u_smem_ready = 0;
+      unsigned int _phase_dy_smem_ready = 0;
+      unsigned int _phase_dbeta_m_done = 1;
+#pragma unroll 1
+      for (int __3 = 0; __3 < total_work_items; __3++) {
+        mbarrier_wait(sched_ready_addr + (sched_stage3) * 8, _phase_sched_ready_3);
+        unsigned int ticket_words_3[1];
+        asm volatile("ld.shared.b32 %0, [%1];"
+                     : "=r"(*reinterpret_cast<uint32_t*>(&ticket_words_3[0]))
+                     : "r"(work_item_addr + sched_stage3 * 4));
+        unsigned int tile3 = ticket_words_3[0];
+        if (elect_sync()) {
+          mbarrier_arrive(sched_done_addr + (sched_stage3) * 8);
+        }
+        sched_stage3 += 1;
+        if (sched_stage3 == 8) {
+          sched_stage3 = 0;
+          _phase_sched_ready_3 ^= 1;
+        }
+        if (tile3 >= (unsigned int)total_work_items) {
+          break;
+        }
+        int item_base3 = (int)tile3 * 8;
+        int head3 = work_items[item_base3 + 1];
+        int write_start3 = work_items[item_base3 + 2];
+        int write_end3 = work_items[item_base3 + 3];
+        int compute_end3 = work_items[item_base3 + 5];
+        float kk_sum3[8];
+        kk_sum3[0] = 0.0f;
+        kk_sum3[1] = 0.0f;
+        kk_sum3[2] = 0.0f;
+        kk_sum3[3] = 0.0f;
+        kk_sum3[4] = 0.0f;
+        kk_sum3[5] = 0.0f;
+        kk_sum3[6] = 0.0f;
+        kk_sum3[7] = 0.0f;
+        float tinv_sum3[8];
+        tinv_sum3[0] = 0.0f;
+        tinv_sum3[1] = 0.0f;
+        tinv_sum3[2] = 0.0f;
+        tinv_sum3[3] = 0.0f;
+        tinv_sum3[4] = 0.0f;
+        tinv_sum3[5] = 0.0f;
+        tinv_sum3[6] = 0.0f;
+        tinv_sum3[7] = 0.0f;
+#pragma unroll 1
+        for (int reverse3 = 0; reverse3 < compute_end3 - write_start3; reverse3++) {
+          mbarrier_wait(raw_ready_addr + (raw_stage3) * 8, _phase_raw_ready_2);
+          int beta_stage_base3 = (int)(raw_stage3 % 2) * 16 * 8;
+          int beta_head3 = head3 % 8;
+          int beta_row_lo3 = lane / 4;
+          int beta_row_hi3 = beta_row_lo3 + 8;
+          __nv_bfloat16 beta_lo_bf3 =
+              beta_smem_all[beta_stage_base3 + beta_row_lo3 * 8 + beta_head3];
+          __nv_bfloat16 beta_hi_bf3 =
+              beta_smem_all[beta_stage_base3 + beta_row_hi3 * 8 + beta_head3];
+          float _cvt_f32_22 = __bfloat162float(beta_lo_bf3);
+          float beta_lo3 = _cvt_f32_22;
+          float _cvt_f32_23 = __bfloat162float(beta_hi_bf3);
+          float beta_hi3 = _cvt_f32_23;
+          mbarrier_wait(k_decay_inv_ready_addr + (operand_stage3) * 8, _phase_k_decay_inv_ready);
+          float kk_acc3[8];
+          kk_acc3[0] = 0.0f;
+          kk_acc3[1] = 0.0f;
+          kk_acc3[2] = 0.0f;
+          kk_acc3[3] = 0.0f;
+          kk_acc3[4] = 0.0f;
+          kk_acc3[5] = 0.0f;
+          kk_acc3[6] = 0.0f;
+          kk_acc3[7] = 0.0f;
+          mbarrier_wait(intermediate_done_addr + (intermediate_stage3) * 8,
+                        _phase_intermediate_done);
+          if (enable_kk != 0) {
+#pragma unroll
+            for (int k_block3 = 0; k_block3 < 8; k_block3++) {
+              int a_col3 = k_block3 * 16 + lhs_col_offset3;
+              int b_col3 = k_block3 * 16 + rhs_col_offset3;
+              unsigned int a_frag3[4];
+              unsigned int b_frag3[4];
+              int segment_8 = a_col3 / 64;
+              int segment_col_9 = a_col3 - segment_8 * 64;
+              int swizzled_col_9 = segment_col_9 ^ (lhs_row3 & 7) * 8;
+              asm volatile(
+                  "ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                  : "=r"(a_frag3[0]), "=r"(a_frag3[1]), "=r"(a_frag3[2]), "=r"(a_frag3[3])
+                  : "r"(k_decay_all_addr +
+                        (unsigned int)(((int)operand_stage3 * 16 * 128 + segment_8 * 16 * 64 +
+                                        lhs_row3 * 64 + swizzled_col_9) *
+                                       2))
+                  : "memory");
+              int segment_0_3 = b_col3 / 64;
+              int segment_col_1_3 = b_col3 - segment_0_3 * 64;
+              int swizzled_col_2_3 = segment_col_1_3 ^ (rhs_row3 & 7) * 8;
+              asm volatile(
+                  "ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                  : "=r"(b_frag3[0]), "=r"(b_frag3[1]), "=r"(b_frag3[2]), "=r"(b_frag3[3])
+                  : "r"(k_inv_all_addr +
+                        (unsigned int)(((int)operand_stage3 * 16 * 128 + segment_0_3 * 16 * 64 +
+                                        rhs_row3 * 64 + swizzled_col_2_3) *
+                                       2))
+                  : "memory");
+              asm volatile(
+                  "mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, "
+                  "%6, %7}, {%8, %9}, {%10, %11, %12, %13};\n"
+                  : "=f"(kk_acc3[0]), "=f"(kk_acc3[1]), "=f"(kk_acc3[2]), "=f"(kk_acc3[3])
+                  : "r"(a_frag3[0]), "r"(a_frag3[1]), "r"(a_frag3[2]), "r"(a_frag3[3]),
+                    "r"(b_frag3[0]), "r"(b_frag3[1]), "f"(((k_block3 == 0) ? 0.0f : kk_acc3[0])),
+                    "f"(((k_block3 == 0) ? 0.0f : kk_acc3[1])),
+                    "f"(((k_block3 == 0) ? 0.0f : kk_acc3[2])),
+                    "f"(((k_block3 == 0) ? 0.0f : kk_acc3[3])));
+              asm volatile(
+                  "mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, "
+                  "%6, %7}, {%8, %9}, {%10, %11, %12, %13};\n"
+                  : "=f"(kk_acc3[4]), "=f"(kk_acc3[(4) + 1]), "=f"(kk_acc3[(4) + 2]),
+                    "=f"(kk_acc3[(4) + 3])
+                  : "r"(a_frag3[0]), "r"(a_frag3[1]), "r"(a_frag3[2]), "r"(a_frag3[3]),
+                    "r"(b_frag3[2]), "r"(b_frag3[(2) + 1]),
+                    "f"(((k_block3 == 0) ? 0.0f : kk_acc3[4])),
+                    "f"(((k_block3 == 0) ? 0.0f : kk_acc3[(4) + 1])),
+                    "f"(((k_block3 == 0) ? 0.0f : kk_acc3[(4) + 2])),
+                    "f"(((k_block3 == 0) ? 0.0f : kk_acc3[(4) + 3])));
+            }
+#pragma unroll
+            for (int accum3 = 0; accum3 < 8; accum3++) {
+              kk_sum3[accum3] = kk_sum3[accum3] + kk_acc3[accum3];
+            }
+            if (enable_tinv != 0) {
+              float l_values3[8];
+              float tinv_acc3[8];
+#pragma unroll
+              for (int accum_t3 = 0; accum_t3 < 8; accum_t3++) {
+                int accum_row3 = lane / 4 + accum_t3 % 4 / 2 * 8;
+                int accum_col3 = accum_t3 / 4 * 8 + (lane & 3) * 2 + (accum_t3 & 1);
+                l_values3[accum_t3] = 0.0f;
+                if (accum_row3 > accum_col3) {
+                  float beta_scale3 = beta_lo3;
+                  if (accum_t3 % 4 >= 2) {
+                    beta_scale3 = beta_hi3;
+                  }
+                  l_values3[accum_t3] = kk_acc3[accum_t3] * beta_scale3;
+                }
+                tinv_acc3[accum_t3] = -l_values3[accum_t3];
+                if (accum_row3 == accum_col3) {
+                  tinv_acc3[accum_t3] = 1.0f;
+                }
+              }
+              unsigned int lpow_words3[4];
+              unsigned int lpow_trans3[4];
+#pragma unroll
+              for (int _lp = 0; _lp < 4; _lp++) {
+                __nv_bfloat162 _bf2 = __float22bfloat162_rn(
+                    make_float2(l_values3[_lp * 2 + 0], l_values3[_lp * 2 + 1 + 0]));
+                lpow_words3[_lp] = *(uint32_t*)&_bf2;
+              }
+              int store_row3 = lane % 16;
+              int store_col3 = lane / 16 * 8;
+              int linear = store_row3 * 16 + store_col3;
+              uint32_t _stmatrix_addr_0 = static_cast<uint32_t>(
+                  (unsigned long long)(tinv_scratch_addr +
+                                       (unsigned int)((linear ^ (linear >> 6 & 1) * 8) * 2)));
+              asm volatile(
+                  "stmatrix.sync.aligned.m8n8.x4.shared.b16 [%0], {%1, %2, %3, %4};\n" ::"r"(
+                      _stmatrix_addr_0),
+                  "r"(*reinterpret_cast<const uint32_t*>(&lpow_words3[0])),
+                  "r"(*reinterpret_cast<const uint32_t*>(&lpow_words3[1])),
+                  "r"(*reinterpret_cast<const uint32_t*>(&lpow_words3[2])),
+                  "r"(*reinterpret_cast<const uint32_t*>(&lpow_words3[3]))
+                  : "memory");
+              __syncwarp();
+              int load_row3 = lane % 16;
+#pragma unroll
+              for (int n_half3 = 0; n_half3 < 2; n_half3++) {
+                int load_col3 = n_half3 * 8;
+                int linear_0 = load_row3 * 16 + load_col3;
+                asm volatile("ldmatrix.sync.aligned.m8n8.x2.trans.shared.b16 {%0, %1}, [%2];\n"
+                             : "=r"(lpow_trans3[n_half3 * 2]), "=r"(lpow_trans3[n_half3 * 2 + 1])
+                             : "r"(tinv_scratch_addr +
+                                   (unsigned int)((linear_0 ^ (linear_0 >> 6 & 1) * 8) * 2))
+                             : "memory");
+              }
+#pragma unroll
+              for (int neumann_round3 = 0; neumann_round3 < 3; neumann_round3++) {
+                float square_acc3[8];
+                asm volatile(
+                    "mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, "
+                    "%5, %6, %7}, {%8, %9}, {%10, %11, %12, %13};\n"
+                    : "=f"(square_acc3[0]), "=f"(square_acc3[1]), "=f"(square_acc3[2]),
+                      "=f"(square_acc3[3])
+                    : "r"(lpow_words3[0]), "r"(lpow_words3[1]), "r"(lpow_words3[2]),
+                      "r"(lpow_words3[3]), "r"(lpow_trans3[0]), "r"(lpow_trans3[1]), "f"(0.0f),
+                      "f"(0.0f), "f"(0.0f), "f"(0.0f));
+                asm volatile(
+                    "mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, "
+                    "%5, %6, %7}, {%8, %9}, {%10, %11, %12, %13};\n"
+                    : "=f"(square_acc3[4]), "=f"(square_acc3[(4) + 1]), "=f"(square_acc3[(4) + 2]),
+                      "=f"(square_acc3[(4) + 3])
+                    : "r"(lpow_words3[0]), "r"(lpow_words3[1]), "r"(lpow_words3[2]),
+                      "r"(lpow_words3[3]), "r"(lpow_trans3[2]), "r"(lpow_trans3[(2) + 1]),
+                      "f"(0.0f), "f"(0.0f), "f"(0.0f), "f"(0.0f));
+#pragma unroll
+                for (int _lp = 0; _lp < 4; _lp++) {
+                  __nv_bfloat162 _bf2 = __float22bfloat162_rn(
+                      make_float2(square_acc3[_lp * 2 + 0], square_acc3[_lp * 2 + 1 + 0]));
+                  lpow_words3[_lp] = *(uint32_t*)&_bf2;
+                }
+                int store_row3_0 = lane % 16;
+                int store_col3_1 = lane / 16 * 8;
+                int linear_2 = store_row3_0 * 16 + store_col3_1;
+                uint32_t _stmatrix_addr_1 = static_cast<uint32_t>(
+                    (unsigned long long)(tinv_scratch_addr +
+                                         (unsigned int)((linear_2 ^ (linear_2 >> 6 & 1) * 8) * 2)));
+                asm volatile(
+                    "stmatrix.sync.aligned.m8n8.x4.shared.b16 [%0], {%1, %2, %3, %4};\n" ::"r"(
+                        _stmatrix_addr_1),
+                    "r"(*reinterpret_cast<const uint32_t*>(&lpow_words3[0])),
+                    "r"(*reinterpret_cast<const uint32_t*>(&lpow_words3[1])),
+                    "r"(*reinterpret_cast<const uint32_t*>(&lpow_words3[2])),
+                    "r"(*reinterpret_cast<const uint32_t*>(&lpow_words3[3]))
+                    : "memory");
+                __syncwarp();
+                int load_row3_3 = lane % 16;
+#pragma unroll
+                for (int n_half3_1 = 0; n_half3_1 < 2; n_half3_1++) {
+                  int load_col3_1 = n_half3_1 * 8;
+                  int linear_0_1 = load_row3_3 * 16 + load_col3_1;
+                  asm volatile("ldmatrix.sync.aligned.m8n8.x2.trans.shared.b16 {%0, %1}, [%2];\n"
+                               : "=r"(lpow_trans3[n_half3_1 * 2]),
+                                 "=r"(lpow_trans3[n_half3_1 * 2 + 1])
+                               : "r"(tinv_scratch_addr +
+                                     (unsigned int)((linear_0_1 ^ (linear_0_1 >> 6 & 1) * 8) * 2))
+                               : "memory");
+                }
+                unsigned int tinv_words3[4];
+#pragma unroll
+                for (int _lp = 0; _lp < 4; _lp++) {
+                  __nv_bfloat162 _bf2 = __float22bfloat162_rn(
+                      make_float2(tinv_acc3[_lp * 2 + 0], tinv_acc3[_lp * 2 + 1 + 0]));
+                  tinv_words3[_lp] = *(uint32_t*)&_bf2;
+                }
+                float update_acc3[8];
+                asm volatile(
+                    "mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, "
+                    "%5, %6, %7}, {%8, %9}, {%10, %11, %12, %13};\n"
+                    : "=f"(update_acc3[0]), "=f"(update_acc3[1]), "=f"(update_acc3[2]),
+                      "=f"(update_acc3[3])
+                    : "r"(tinv_words3[0]), "r"(tinv_words3[1]), "r"(tinv_words3[2]),
+                      "r"(tinv_words3[3]), "r"(lpow_trans3[0]), "r"(lpow_trans3[1]), "f"(0.0f),
+                      "f"(0.0f), "f"(0.0f), "f"(0.0f));
+                asm volatile(
+                    "mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, "
+                    "%5, %6, %7}, {%8, %9}, {%10, %11, %12, %13};\n"
+                    : "=f"(update_acc3[4]), "=f"(update_acc3[(4) + 1]), "=f"(update_acc3[(4) + 2]),
+                      "=f"(update_acc3[(4) + 3])
+                    : "r"(tinv_words3[0]), "r"(tinv_words3[1]), "r"(tinv_words3[2]),
+                      "r"(tinv_words3[3]), "r"(lpow_trans3[2]), "r"(lpow_trans3[(2) + 1]),
+                      "f"(0.0f), "f"(0.0f), "f"(0.0f), "f"(0.0f));
+                float tinv_words3_f32[8];
+#pragma unroll
+                for (int _pair = 0; _pair < 4; _pair++) {
+                  asm volatile(
+                      "{\n\t"
+                      "shl.b32 %0, %2, 16;\n\t"
+                      "and.b32 %1, %2, 0xffff0000;\n\t"
+                      "}\n"
+                      : "=f"((&tinv_words3_f32[_pair * 2])[0]),
+                        "=f"((&tinv_words3_f32[_pair * 2])[1])
+                      : "r"(tinv_words3[_pair]));
+                }
+#pragma unroll
+                for (int accum_u3 = 0; accum_u3 < 8; accum_u3++) {
+                  tinv_acc3[accum_u3] = tinv_words3_f32[accum_u3] + update_acc3[accum_u3];
+                }
+              }
+#pragma unroll
+              for (int accum_s3 = 0; accum_s3 < 8; accum_s3++) {
+                tinv_sum3[accum_s3] = tinv_sum3[accum_s3] + tinv_acc3[accum_s3];
+              }
+              unsigned int tinv_publish_words3[4];
+#pragma unroll
+              for (int _lp = 0; _lp < 4; _lp++) {
+                __nv_bfloat162 _bf2 = __float22bfloat162_rn(
+                    make_float2(tinv_acc3[_lp * 2 + 0], tinv_acc3[_lp * 2 + 1 + 0]));
+                tinv_publish_words3[_lp] = *(uint32_t*)&_bf2;
+              }
+              int publish_row3 = lane % 16;
+              int publish_col3 = lane / 16 * 8;
+              uint32_t _stmatrix_addr_2 = static_cast<uint32_t>(
+                  (unsigned long long)(intermediate_tinv_addr + intermediate_stage3 * 2560 +
+                                       (unsigned int)(publish_col3 / 16 * 512 + publish_row3 * 32 +
+                                                          publish_col3 % 16 * 2 ^
+                                                      (publish_col3 / 16 * 512 + publish_row3 * 32 +
+                                                               publish_col3 % 16 * 2 >>
+                                                           7 &
+                                                       1) << 4)));
+              asm volatile(
+                  "stmatrix.sync.aligned.m8n8.x4.shared.b16 [%0], {%1, %2, %3, %4};\n" ::"r"(
+                      _stmatrix_addr_2),
+                  "r"(*reinterpret_cast<const uint32_t*>(&tinv_publish_words3[0])),
+                  "r"(*reinterpret_cast<const uint32_t*>(&tinv_publish_words3[1])),
+                  "r"(*reinterpret_cast<const uint32_t*>(&tinv_publish_words3[2])),
+                  "r"(*reinterpret_cast<const uint32_t*>(&tinv_publish_words3[3]))
+                  : "memory");
+            }
+          }
+          asm volatile("fence.proxy.async.shared::cta;" ::: "memory");
+          mbarrier_arrive(tinv_ready_addr + (intermediate_stage3) * 8);
+          mbarrier_wait(u_smem_ready_addr + (u_smem_stage3) * 8, _phase_u_smem_ready);
+          mbarrier_wait(dy_smem_ready_addr + (dy_smem_stage3) * 8, _phase_dy_smem_ready);
+          float dm_acc3[8];
+#pragma unroll
+          for (int k_block_dm3 = 0; k_block_dm3 < 8; k_block_dm3++) {
+            int a_col_dm3 = k_block_dm3 * 16 + lhs_col_offset3;
+            int b_col_dm3 = k_block_dm3 * 16 + rhs_col_offset3;
+            unsigned int dy_frag3[4];
+            unsigned int u_frag3[4];
+            int segment_10 = a_col_dm3 / 64;
+            int segment_col_11 = a_col_dm3 - segment_10 * 64;
+            int swizzled_col_10 = segment_col_11 ^ (lhs_row3 & 7) * 8;
+            asm volatile(
+                "ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                : "=r"(dy_frag3[0]), "=r"(dy_frag3[1]), "=r"(dy_frag3[2]), "=r"(dy_frag3[3])
+                : "r"(dy_smem_all_addr +
+                      (unsigned int)((segment_10 * 16 * 64 + lhs_row3 * 64 + swizzled_col_10) * 2))
+                : "memory");
+            int segment_0_4 = b_col_dm3 / 64;
+            int segment_col_1_4 = b_col_dm3 - segment_0_4 * 64;
+            int swizzled_col_2_4 = segment_col_1_4 ^ (rhs_row3 & 7) * 8;
+            asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                         : "=r"(u_frag3[0]), "=r"(u_frag3[1]), "=r"(u_frag3[2]), "=r"(u_frag3[3])
+                         : "r"(u_smem_addr + (unsigned int)((segment_0_4 * 16 * 64 + rhs_row3 * 64 +
+                                                             swizzled_col_2_4) *
+                                                            2))
+                         : "memory");
+            asm volatile(
+                "mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, "
+                "%6, %7}, {%8, %9}, {%10, %11, %12, %13};\n"
+                : "=f"(dm_acc3[0]), "=f"(dm_acc3[1]), "=f"(dm_acc3[2]), "=f"(dm_acc3[3])
+                : "r"(dy_frag3[0]), "r"(dy_frag3[1]), "r"(dy_frag3[2]), "r"(dy_frag3[3]),
+                  "r"(u_frag3[0]), "r"(u_frag3[1]), "f"(((k_block_dm3 == 0) ? 0.0f : dm_acc3[0])),
+                  "f"(((k_block_dm3 == 0) ? 0.0f : dm_acc3[1])),
+                  "f"(((k_block_dm3 == 0) ? 0.0f : dm_acc3[2])),
+                  "f"(((k_block_dm3 == 0) ? 0.0f : dm_acc3[3])));
+            asm volatile(
+                "mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, "
+                "%6, %7}, {%8, %9}, {%10, %11, %12, %13};\n"
+                : "=f"(dm_acc3[4]), "=f"(dm_acc3[(4) + 1]), "=f"(dm_acc3[(4) + 2]),
+                  "=f"(dm_acc3[(4) + 3])
+                : "r"(dy_frag3[0]), "r"(dy_frag3[1]), "r"(dy_frag3[2]), "r"(dy_frag3[3]),
+                  "r"(u_frag3[2]), "r"(u_frag3[(2) + 1]),
+                  "f"(((k_block_dm3 == 0) ? 0.0f : dm_acc3[4])),
+                  "f"(((k_block_dm3 == 0) ? 0.0f : dm_acc3[(4) + 1])),
+                  "f"(((k_block_dm3 == 0) ? 0.0f : dm_acc3[(4) + 2])),
+                  "f"(((k_block_dm3 == 0) ? 0.0f : dm_acc3[(4) + 3])));
+          }
+          float dm_strict3[8];
+          float ndm_strict3[8];
+#pragma unroll
+          for (int accum_dm3 = 0; accum_dm3 < 8; accum_dm3++) {
+            int dm_row3 = lane / 4 + accum_dm3 % 4 / 2 * 8;
+            int dm_col3 = accum_dm3 / 4 * 8 + (lane & 3) * 2 + (accum_dm3 & 1);
+            dm_strict3[accum_dm3] = 0.0f;
+            if (dm_row3 > dm_col3) {
+              float beta_dm_scale3 = beta_lo3;
+              if (accum_dm3 % 4 >= 2) {
+                beta_dm_scale3 = beta_hi3;
+              }
+              dm_strict3[accum_dm3] = dm_acc3[accum_dm3] * beta_dm_scale3;
+            }
+            ndm_strict3[accum_dm3] = -dm_strict3[accum_dm3];
+          }
+          unsigned int dm_words3[4];
+          unsigned int ndm_words3[4];
+#pragma unroll
+          for (int _lp = 0; _lp < 4; _lp++) {
+            __nv_bfloat162 _bf2 = __float22bfloat162_rn(
+                make_float2(dm_strict3[_lp * 2 + 0], dm_strict3[_lp * 2 + 1 + 0]));
+            dm_words3[_lp] = *(uint32_t*)&_bf2;
+          }
+#pragma unroll
+          for (int _lp = 0; _lp < 4; _lp++) {
+            __nv_bfloat162 _bf2 = __float22bfloat162_rn(
+                make_float2(ndm_strict3[_lp * 2 + 0], ndm_strict3[_lp * 2 + 1 + 0]));
+            ndm_words3[_lp] = *(uint32_t*)&_bf2;
+          }
+          int dm_publish_row3 = lane % 16;
+          int dm_publish_col3 = lane / 16 * 8;
+          uint32_t _stmatrix_addr_3 = static_cast<uint32_t>((
+              unsigned long long)(intermediate_dm_addr + intermediate_stage3 * 2560 +
+                                  (unsigned int)(dm_publish_col3 / 16 * 512 + dm_publish_row3 * 32 +
+                                                     dm_publish_col3 % 16 * 2 ^
+                                                 (dm_publish_col3 / 16 * 512 +
+                                                          dm_publish_row3 * 32 +
+                                                          dm_publish_col3 % 16 * 2 >>
+                                                      7 &
+                                                  1) << 4)));
+          asm volatile("stmatrix.sync.aligned.m8n8.x4.shared.b16 [%0], {%1, %2, %3, %4};\n" ::"r"(
+                           _stmatrix_addr_3),
+                       "r"(*reinterpret_cast<const uint32_t*>(&dm_words3[0])),
+                       "r"(*reinterpret_cast<const uint32_t*>(&dm_words3[1])),
+                       "r"(*reinterpret_cast<const uint32_t*>(&dm_words3[2])),
+                       "r"(*reinterpret_cast<const uint32_t*>(&dm_words3[3]))
+                       : "memory");
+          uint32_t _stmatrix_addr_4 = static_cast<uint32_t>((
+              unsigned long long)(intermediate_ndm_addr + intermediate_stage3 * 2560 +
+                                  (unsigned int)(dm_publish_col3 / 16 * 512 + dm_publish_row3 * 32 +
+                                                     dm_publish_col3 % 16 * 2 ^
+                                                 (dm_publish_col3 / 16 * 512 +
+                                                          dm_publish_row3 * 32 +
+                                                          dm_publish_col3 % 16 * 2 >>
+                                                      7 &
+                                                  1) << 4)));
+          asm volatile("stmatrix.sync.aligned.m8n8.x4.shared.b16 [%0], {%1, %2, %3, %4};\n" ::"r"(
+                           _stmatrix_addr_4),
+                       "r"(*reinterpret_cast<const uint32_t*>(&ndm_words3[0])),
+                       "r"(*reinterpret_cast<const uint32_t*>(&ndm_words3[1])),
+                       "r"(*reinterpret_cast<const uint32_t*>(&ndm_words3[2])),
+                       "r"(*reinterpret_cast<const uint32_t*>(&ndm_words3[3]))
+                       : "memory");
+          asm volatile("fence.proxy.async.shared::cta;" ::: "memory");
+          mbarrier_arrive(dm_ready_addr + (intermediate_stage3) * 8);
+          float dbeta_m_lo3 = 0.0f;
+          float dbeta_m_hi3 = 0.0f;
+#pragma unroll
+          for (int dbeta_accum3 = 0; dbeta_accum3 < 8; dbeta_accum3++) {
+            int dbeta_row3 = lane / 4 + dbeta_accum3 % 4 / 2 * 8;
+            int dbeta_col3 = dbeta_accum3 / 4 * 8 + (lane & 3) * 2 + (dbeta_accum3 & 1);
+            float dbeta_m_part3 = 0.0f;
+            if (dbeta_row3 > dbeta_col3) {
+              dbeta_m_part3 = dm_acc3[dbeta_accum3] * kk_acc3[dbeta_accum3];
+            }
+            if (dbeta_accum3 % 4 < 2) {
+              dbeta_m_lo3 += dbeta_m_part3;
+            } else {
+              dbeta_m_hi3 += dbeta_m_part3;
+            }
+          }
+          float _shfl_xor_13 = __shfl_xor_sync(0xFFFFFFFF, dbeta_m_lo3, 1);
+          dbeta_m_lo3 += _shfl_xor_13;
+          float _shfl_xor_14 = __shfl_xor_sync(0xFFFFFFFF, dbeta_m_lo3, 2);
+          dbeta_m_lo3 += _shfl_xor_14;
+          float _shfl_xor_15 = __shfl_xor_sync(0xFFFFFFFF, dbeta_m_hi3, 1);
+          dbeta_m_hi3 += _shfl_xor_15;
+          float _shfl_xor_16 = __shfl_xor_sync(0xFFFFFFFF, dbeta_m_hi3, 2);
+          dbeta_m_hi3 += _shfl_xor_16;
+          mbarrier_wait(dbeta_m_done_addr + (dbeta_m_stage3) * 8, _phase_dbeta_m_done);
+          if (lane % 4 == 0) {
+            dbeta_m_smem[beta_row_lo3] = -dbeta_m_lo3;
+            dbeta_m_smem[beta_row_hi3] = -dbeta_m_hi3;
+          }
+          asm volatile("fence.proxy.async.shared::cta;" ::: "memory");
+          if (elect_sync()) {
+            mbarrier_arrive(dbeta_m_ready_addr + (dbeta_m_stage3) * 8);
+          }
+          dbeta_m_stage3 += 1;
+          if (dbeta_m_stage3 == 1) {
+            dbeta_m_stage3 = 0;
+            _phase_dbeta_m_done ^= 1;
+          }
+          raw_stage3 += 1;
+          if (raw_stage3 == 2) {
+            raw_stage3 = 0;
+            _phase_raw_ready_2 ^= 1;
+          }
+          operand_stage3 += 1;
+          if (operand_stage3 == 2) {
+            operand_stage3 = 0;
+            _phase_k_decay_inv_ready ^= 1;
+          }
+          intermediate_stage3 += 1;
+          if (intermediate_stage3 == 2) {
+            intermediate_stage3 = 0;
+            _phase_intermediate_done ^= 1;
+          }
+          u_smem_stage3 += 1;
+          if (u_smem_stage3 == 1) {
+            u_smem_stage3 = 0;
+            _phase_u_smem_ready ^= 1;
+          }
+          dy_smem_stage3 += 1;
+          if (dy_smem_stage3 == 1) {
+            dy_smem_stage3 = 0;
+            _phase_dy_smem_ready ^= 1;
+          }
+        }
+        if (validate_outputs != 0 && enable_kk != 0) {
+          int row_lo3 = lane / 4;
+          int col_pair3 = (lane & 3) * 2;
+#pragma unroll
+          for (int accum4 = 0; accum4 < 8; accum4++) {
+            int output_row3 = row_lo3 + accum4 % 4 / 2 * 8;
+            int output_col3 = accum4 / 4 * 8 + col_pair3 + (accum4 & 1);
+            kk_observed[(long long)tile3 * 16 * 16 + (long long)output_row3 * 16 +
+                        (long long)output_col3] = kk_sum3[accum4];
+            if (enable_tinv != 0) {
+              tinv_observed[(long long)tile3 * 16 * 16 + (long long)output_row3 * 16 +
+                            (long long)output_col3] = tinv_sum3[accum4];
+            }
+          }
+        }
+      }
+      if (elect_sync()) {
+        mbarrier_arrive(consumers_done_addr);
+      }
+    }
+  }
+  // ---- Role: tcgen ----
+  if (warp == 13) {
+    {  // tcgen_main
+      float tmem_seed[1];
+      tmem_seed[0] = 0.0f;
+      asm volatile(
+          "tcgen05.st.sync.aligned.32x32b.x1.b32"
+          " [%0], {%1};" ::"r"(taddr),
+          "r"(*reinterpret_cast<const uint32_t*>(&tmem_seed[0])));
+      asm volatile("tcgen05.wait::st.sync.aligned;" ::: "memory");
+      unsigned int sched_stage4 = 0;
+      unsigned int raw_stage4 = 0;
+      unsigned int state_smem_stage4 = 0;
+      unsigned int operand_stage4 = 0;
+      unsigned int intermediate_stage4 = 0;
+      unsigned int tcgen_data_stage4 = 0;
+      unsigned int dstate_recurrence_stage4 = 0;
+      unsigned int u_smem_stage4 = 0;
+      unsigned int dstate_smem_stage4 = 0;
+      unsigned int dk_restore_stage4 = 0;
+      unsigned int local_grad_stage4 = 0;
+      unsigned int beta_dy_smem_stage4 = 0;
+      unsigned int boundary_stage4 = 0;
+      unsigned int boundary_local_grad_stage4 = 0;
+      unsigned int _phase_sched_ready_4 = 0;
+      unsigned int _phase_dstate_done = 1;
+      unsigned int _phase_local_grad_done = 1;
+      unsigned int _phase_k_decay_inv_ready_1 = 0;
+      unsigned int _phase_state_k_done = 1;
+      unsigned int _phase_state_ready_1 = 0;
+      unsigned int _phase_raw_ready_3 = 0;
+      unsigned int _phase_q_decay_k_restore_ready = 0;
+      unsigned int _phase_tinv_ready = 0;
+      unsigned int _phase_a_ready = 0;
+      unsigned int _phase_tcgen_inputs_ready = 0;
+      unsigned int _phase_tcgen_products_done = 1;
+      unsigned int _phase_dy_done = 1;
+      unsigned int _phase_dstate_inp_ready = 0;
+      unsigned int _phase_tcgen_products_ready_1 = 0;
+      unsigned int _phase_du_inp_ready = 0;
+      unsigned int _phase_u_smem_ready_1 = 0;
+      unsigned int _phase_dstate_smem_ready = 0;
+      unsigned int _phase_dk_restore_done = 1;
+      unsigned int _phase_dy_ready_1 = 0;
+      unsigned int _phase_neg_dy_ready = 0;
+      unsigned int _phase_dstate_ready_1 = 0;
+      unsigned int _phase_beta_dy_smem_ready = 0;
+      unsigned int _phase_da_ready = 0;
+      unsigned int _phase_dm_ready = 0;
+      unsigned int _phase_boundary_smem_ready = 0;
+      unsigned int _phase_boundary_local_grad_free = 0;
+#pragma unroll 1
+      for (int __4 = 0; __4 < total_work_items; __4++) {
+        mbarrier_wait(sched_ready_addr + (sched_stage4) * 8, _phase_sched_ready_4);
+        unsigned int ticket_words_4[1];
+        asm volatile("ld.shared.b32 %0, [%1];"
+                     : "=r"(*reinterpret_cast<uint32_t*>(&ticket_words_4[0]))
+                     : "r"(work_item_addr + sched_stage4 * 4));
+        unsigned int tile4 = ticket_words_4[0];
+        if (elect_sync()) {
+          mbarrier_arrive(sched_done_addr + (sched_stage4) * 8);
+        }
+        sched_stage4 += 1;
+        if (sched_stage4 == 8) {
+          sched_stage4 = 0;
+          _phase_sched_ready_4 ^= 1;
+        }
+        if (tile4 >= (unsigned int)total_work_items) {
+          break;
+        }
+        int item_base4 = (int)tile4 * 8;
+        int write_start4 = work_items[item_base4 + 2];
+        int write_end4 = work_items[item_base4 + 3];
+        int compute_end4 = work_items[item_base4 + 5];
+        float operand_sums4[16];
+        operand_sums4[0] = 0.0f;
+        operand_sums4[1] = 0.0f;
+        operand_sums4[2] = 0.0f;
+        operand_sums4[3] = 0.0f;
+        operand_sums4[4] = 0.0f;
+        operand_sums4[5] = 0.0f;
+        operand_sums4[6] = 0.0f;
+        operand_sums4[7] = 0.0f;
+        operand_sums4[8] = 0.0f;
+        operand_sums4[9] = 0.0f;
+        operand_sums4[10] = 0.0f;
+        operand_sums4[11] = 0.0f;
+        operand_sums4[12] = 0.0f;
+        operand_sums4[13] = 0.0f;
+        operand_sums4[14] = 0.0f;
+        operand_sums4[15] = 0.0f;
+#pragma unroll 1
+        for (int reverse4 = 0; reverse4 < compute_end4 - write_start4; reverse4++) {
+          mbarrier_wait(dstate_done_addr + (tcgen_data_stage4) * 8, _phase_dstate_done);
+          mbarrier_wait(local_grad_done_addr + (local_grad_stage4) * 8, _phase_local_grad_done);
+          asm volatile("tcgen05.fence::after_thread_sync;");
+          mbarrier_wait(k_decay_inv_ready_addr + (operand_stage4) * 8, _phase_k_decay_inv_ready_1);
+          mbarrier_wait(state_k_done_addr + (state_smem_stage4) * 8, _phase_state_k_done);
+          mbarrier_wait(state_ready_addr + (state_smem_stage4) * 8, _phase_state_ready_1);
+          mbarrier_wait(raw_ready_addr + (raw_stage4) * 8, _phase_raw_ready_3);
+          int _mma_a_lo_0 = make_warp_uniform((((state_operand_addr) >> 4) & 0x3FFF) +
+                                              (state_smem_stage4) * 2048);
+          int _mma_b_lo_0 =
+              make_warp_uniform((((k_decay_lead16_addr) >> 4) & 0x3FFF) + (operand_stage4) * 256);
+          asm volatile(
+              "{\n\t"
+              ".reg .pred leader, p0, p1;\n\t"
+              ".reg .b32 adhi, bdhi, alo, blo, id;\n\t"
+              ".reg .b64 da, db;\n\t"
+              "elect.sync _|leader, 0xFFFFFFFF;\n\t"
+              "setp.ne.b32 p0, %3, 0;\n\t"
+              "setp.ne.b32 p1, 1, 0;\n\t"
+              ""
+              "mov.b32 adhi, 0x40004040;\n\t"
+              "mov.b32 bdhi, 0x40004040;\n\t"
+              "mov.b32 id, 134481040;\n\t"
+              "mov.b32 alo, %0;\n\t"
+              "mov.b32 blo, %1;\n\t"
+              "mov.b64 da, {alo, adhi};\n\t"
+              "mov.b64 db, {blo, bdhi};\n\t"
+              "@leader tcgen05.mma.cta_group::1.kind::f16 [%2], da, db, id, p0;\n\t"
+              "add.u32 alo, alo, 2;\n\t"
+              "add.u32 blo, blo, 2;\n\t"
+              "mov.b64 da, {alo, adhi};\n\t"
+              "mov.b64 db, {blo, bdhi};\n\t"
+              "@leader tcgen05.mma.cta_group::1.kind::f16 [%2], da, db, id, p1;\n\t"
+              "add.u32 alo, alo, 2;\n\t"
+              "add.u32 blo, blo, 2;\n\t"
+              "mov.b64 da, {alo, adhi};\n\t"
+              "mov.b64 db, {blo, bdhi};\n\t"
+              "@leader tcgen05.mma.cta_group::1.kind::f16 [%2], da, db, id, p1;\n\t"
+              "add.u32 alo, alo, 2;\n\t"
+              "add.u32 blo, blo, 2;\n\t"
+              "mov.b64 da, {alo, adhi};\n\t"
+              "mov.b64 db, {blo, bdhi};\n\t"
+              "@leader tcgen05.mma.cta_group::1.kind::f16 [%2], da, db, id, p1;\n\t"
+              "add.u32 alo, alo, 1018;\n\t"
+              "add.u32 blo, blo, 122;\n\t"
+              "mov.b64 da, {alo, adhi};\n\t"
+              "mov.b64 db, {blo, bdhi};\n\t"
+              "@leader tcgen05.mma.cta_group::1.kind::f16 [%2], da, db, id, p1;\n\t"
+              "add.u32 alo, alo, 2;\n\t"
+              "add.u32 blo, blo, 2;\n\t"
+              "mov.b64 da, {alo, adhi};\n\t"
+              "mov.b64 db, {blo, bdhi};\n\t"
+              "@leader tcgen05.mma.cta_group::1.kind::f16 [%2], da, db, id, p1;\n\t"
+              "add.u32 alo, alo, 2;\n\t"
+              "add.u32 blo, blo, 2;\n\t"
+              "mov.b64 da, {alo, adhi};\n\t"
+              "mov.b64 db, {blo, bdhi};\n\t"
+              "@leader tcgen05.mma.cta_group::1.kind::f16 [%2], da, db, id, p1;\n\t"
+              "add.u32 alo, alo, 2;\n\t"
+              "add.u32 blo, blo, 2;\n\t"
+              "mov.b64 da, {alo, adhi};\n\t"
+              "mov.b64 db, {blo, bdhi};\n\t"
+              "@leader tcgen05.mma.cta_group::1.kind::f16 [%2], da, db, id, p1;\n\t"
+              "}\n" ::"r"(_mma_a_lo_0),
+              "r"(_mma_b_lo_0), "r"(tmem_flashkda_bwd_persistent_c16_state_k), "r"(0));
+          int _mma_a_lo_1 = make_warp_uniform(
+              ((((state_operand_mn_addr) >> 4) & 0x3FFF) | 0x4000000) + (state_smem_stage4) * 2048);
+          int _mma_b_lo_1 =
+              make_warp_uniform(((((raw_do_addr) >> 4) & 0x3FFF) | 0x800000) + (raw_stage4) * 256);
+          asm volatile(
+              "{\n\t"
+              ".reg .pred leader, p0, p1;\n\t"
+              ".reg .b32 adhi, bdhi, alo, blo, id;\n\t"
+              ".reg .b64 da, db;\n\t"
+              "elect.sync _|leader, 0xFFFFFFFF;\n\t"
+              "setp.ne.b32 p0, %3, 0;\n\t"
+              "setp.ne.b32 p1, 1, 0;\n\t"
+              ""
+              "mov.b32 adhi, 0x40004040;\n\t"
+              "mov.b32 bdhi, 0x40004040;\n\t"
+              "mov.b32 id, 134513808;\n\t"
+              "mov.b32 alo, %0;\n\t"
+              "mov.b32 blo, %1;\n\t"
+              "mov.b64 da, {alo, adhi};\n\t"
+              "mov.b64 db, {blo, bdhi};\n\t"
+              "@leader tcgen05.mma.cta_group::1.kind::f16 [%2], da, db, id, p0;\n\t"
+              "add.u32 alo, alo, 128;\n\t"
+              "add.u32 blo, blo, 2;\n\t"
+              "mov.b64 da, {alo, adhi};\n\t"
+              "mov.b64 db, {blo, bdhi};\n\t"
+              "@leader tcgen05.mma.cta_group::1.kind::f16 [%2], da, db, id, p1;\n\t"
+              "add.u32 alo, alo, 128;\n\t"
+              "add.u32 blo, blo, 2;\n\t"
+              "mov.b64 da, {alo, adhi};\n\t"
+              "mov.b64 db, {blo, bdhi};\n\t"
+              "@leader tcgen05.mma.cta_group::1.kind::f16 [%2], da, db, id, p1;\n\t"
+              "add.u32 alo, alo, 128;\n\t"
+              "add.u32 blo, blo, 2;\n\t"
+              "mov.b64 da, {alo, adhi};\n\t"
+              "mov.b64 db, {blo, bdhi};\n\t"
+              "@leader tcgen05.mma.cta_group::1.kind::f16 [%2], da, db, id, p1;\n\t"
+              "add.u32 alo, alo, 128;\n\t"
+              "add.u32 blo, blo, 122;\n\t"
+              "mov.b64 da, {alo, adhi};\n\t"
+              "mov.b64 db, {blo, bdhi};\n\t"
+              "@leader tcgen05.mma.cta_group::1.kind::f16 [%2], da, db, id, p1;\n\t"
+              "add.u32 alo, alo, 128;\n\t"
+              "add.u32 blo, blo, 2;\n\t"
+              "mov.b64 da, {alo, adhi};\n\t"
+              "mov.b64 db, {blo, bdhi};\n\t"
+              "@leader tcgen05.mma.cta_group::1.kind::f16 [%2], da, db, id, p1;\n\t"
+              "add.u32 alo, alo, 128;\n\t"
+              "add.u32 blo, blo, 2;\n\t"
+              "mov.b64 da, {alo, adhi};\n\t"
+              "mov.b64 db, {blo, bdhi};\n\t"
+              "@leader tcgen05.mma.cta_group::1.kind::f16 [%2], da, db, id, p1;\n\t"
+              "add.u32 alo, alo, 128;\n\t"
+              "add.u32 blo, blo, 2;\n\t"
+              "mov.b64 da, {alo, adhi};\n\t"
+              "mov.b64 db, {blo, bdhi};\n\t"
+              "@leader tcgen05.mma.cta_group::1.kind::f16 [%2], da, db, id, p1;\n\t"
+              "}\n" ::"r"(_mma_a_lo_1),
+              "r"(_mma_b_lo_1), "r"(tmem_flashkda_bwd_persistent_c16_dq), "r"(0));
+          elect_commit(state_k_ready_addr + (state_smem_stage4) * 8);
+          mbarrier_wait(q_decay_k_restore_ready_addr + (operand_stage4) * 8,
+                        _phase_q_decay_k_restore_ready);
+          mbarrier_wait(tinv_ready_addr + (intermediate_stage4) * 8, _phase_tinv_ready);
+          mbarrier_wait(a_ready_addr + (intermediate_stage4) * 8, _phase_a_ready);
+          mbarrier_wait(tcgen_inputs_ready_addr + (tcgen_data_stage4) * 8,
+                        _phase_tcgen_inputs_ready);
+          mbarrier_wait(tcgen_products_done_addr + (tcgen_data_stage4) * 8,
+                        _phase_tcgen_products_done);
+          mbarrier_wait(dy_done_addr + (tcgen_data_stage4) * 8, _phase_dy_done);
+          mbarrier_wait(dstate_inp_ready_addr + (dstate_recurrence_stage4) * 8,
+                        _phase_dstate_inp_ready);
+          if (USE_DSTATE_IN != 0 || reverse4 > 0) {
+#pragma unroll
+            for (int dstate_block4 = 0; dstate_block4 < 8; dstate_block4++) {
+              int _mma_b_lo_2 = make_warp_uniform((((state_scale_diag_addr) >> 4) & 0x3FFF) +
+                                                  ((int)operand_stage4 * 8 + dstate_block4) * 32);
+              mma_ts_step((tmem_flashkda_bwd_persistent_c16_dstate + (dstate_block4 * 16)),
+                          tmem_flashkda_bwd_persistent_c16_dstate_inp + dstate_block4 * 8,
+                          _mma_b_lo_2, 0xC0004010, 134481040, 0);
+            }
+            int _mma_b_lo_3 = make_warp_uniform((((k_restore_lead16_addr) >> 4) & 0x3FFF) +
+                                                (operand_stage4) * 256);
+            asm volatile(
+                "{\n\t"
+                ".reg .pred leader, p0, p1;\n\t"
+                ".reg .b32 dhi, blo, ta, id;\n\t"
+                ".reg .b64 db;\n\t"
+                "elect.sync _|leader, 0xFFFFFFFF;\n\t"
+                "setp.ne.b32 p0, %3, 0;\n\t"
+                "setp.ne.b32 p1, 1, 0;\n\t"
+                ""
+                "mov.b32 dhi, 0x40004040;\n\t"
+                "mov.b32 id, 134481040;\n\t"
+                "mov.b32 ta, %2;\n\t"
+                "mov.b32 blo, %1;\n\t"
+                "mov.b64 db, {blo, dhi};\n\t"
+                "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p0;\n\t"
+                "add.u32 ta, ta, 8;\n\t"
+                "add.u32 blo, blo, 2;\n\t"
+                "mov.b64 db, {blo, dhi};\n\t"
+                "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                "add.u32 ta, ta, 8;\n\t"
+                "add.u32 blo, blo, 2;\n\t"
+                "mov.b64 db, {blo, dhi};\n\t"
+                "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                "add.u32 ta, ta, 8;\n\t"
+                "add.u32 blo, blo, 2;\n\t"
+                "mov.b64 db, {blo, dhi};\n\t"
+                "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                "add.u32 ta, ta, 8;\n\t"
+                "add.u32 blo, blo, 122;\n\t"
+                "mov.b64 db, {blo, dhi};\n\t"
+                "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                "add.u32 ta, ta, 8;\n\t"
+                "add.u32 blo, blo, 2;\n\t"
+                "mov.b64 db, {blo, dhi};\n\t"
+                "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                "add.u32 ta, ta, 8;\n\t"
+                "add.u32 blo, blo, 2;\n\t"
+                "mov.b64 db, {blo, dhi};\n\t"
+                "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                "add.u32 ta, ta, 8;\n\t"
+                "add.u32 blo, blo, 2;\n\t"
+                "mov.b64 db, {blo, dhi};\n\t"
+                "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                "}\n" ::"r"(tmem_flashkda_bwd_persistent_c16_du),
+                "r"(_mma_b_lo_3), "r"(tmem_flashkda_bwd_persistent_c16_dstate_inp), "r"(0));
+          }
+          dstate_recurrence_stage4 += 1;
+          if (dstate_recurrence_stage4 == 1) {
+            dstate_recurrence_stage4 = 0;
+            _phase_dstate_inp_ready ^= 1;
+          }
+          int _mma_b_lo_4 = make_warp_uniform(((((q_decay_trans_addr) >> 4) & 0x3FFF) | 0x800000) +
+                                              (operand_stage4) * 256);
+          mma_ts_step(tmem_flashkda_bwd_persistent_c16_dstate,
+                      tmem_flashkda_bwd_persistent_c16_do_inp, _mma_b_lo_4, 0x40004040, 136381584,
+                      ((reverse4 == 0 && USE_DSTATE_IN == 0) ? 0 : 1));
+          int _mma_b_lo_5 = make_warp_uniform((((intermediate_tinv_addr) >> 4) & 0x3FFF) +
+                                              (intermediate_stage4) * 160);
+          mma_ts_step(tmem_flashkda_bwd_persistent_c16_u, tmem_flashkda_bwd_persistent_c16_y,
+                      _mma_b_lo_5, 0xC0004010, 134481040, 0);
+          int _mma_a_lo_6 = make_warp_uniform(((((raw_do_amaj_addr) >> 4) & 0x3FFF) | 0x800000) +
+                                              (raw_stage4) * 256);
+          int _mma_b_lo_6 =
+              make_warp_uniform(((((intermediate_a_mn_addr) >> 4) & 0x3FFF) | 0x200000) +
+                                (intermediate_stage4) * 160);
+          asm volatile(
+              "{\n\t"
+              ".reg .pred leader, p0, p1;\n\t"
+              ".reg .b32 adhi, bdhi, alo, blo, id;\n\t"
+              ".reg .b64 da, db;\n\t"
+              "elect.sync _|leader, 0xFFFFFFFF;\n\t"
+              "setp.ne.b32 p0, %3, 0;\n\t"
+              "setp.ne.b32 p1, 1, 0;\n\t"
+              ""
+              "mov.b32 adhi, 0x40004040;\n\t"
+              "mov.b32 bdhi, 0xC0004010;\n\t"
+              "mov.b32 id, 134579344;\n\t"
+              "mov.b32 alo, %0;\n\t"
+              "mov.b32 blo, %1;\n\t"
+              "mov.b64 da, {alo, adhi};\n\t"
+              "mov.b64 db, {blo, bdhi};\n\t"
+              "@leader tcgen05.mma.cta_group::1.kind::f16 [%2], da, db, id, p0;\n\t"
+              "}\n" ::"r"(_mma_a_lo_6),
+              "r"(_mma_b_lo_6), "r"(tmem_flashkda_bwd_persistent_c16_du),
+              "r"(((reverse4 == 0 && USE_DSTATE_IN == 0) ? 0 : 1)));
+          elect_commit(tcgen_products_ready_addr + (tcgen_data_stage4) * 8);
+          mbarrier_wait(tcgen_products_ready_addr + (tcgen_data_stage4) * 8,
+                        _phase_tcgen_products_ready_1);
+          mbarrier_wait(du_inp_ready_addr + (tcgen_data_stage4) * 8, _phase_du_inp_ready);
+          int _mma_b_lo_7 =
+              make_warp_uniform(((((intermediate_tinv_mn_addr) >> 4) & 0x3FFF) | 0x200000) +
+                                (intermediate_stage4) * 160);
+          mma_ts_step(tmem_flashkda_bwd_persistent_c16_dy, tmem_flashkda_bwd_persistent_c16_du_inp,
+                      _mma_b_lo_7, 0xC0004010, 134546576, 0);
+          elect_commit(dy_ready_addr + (tcgen_data_stage4) * 8);
+          mbarrier_wait(u_smem_ready_addr + (u_smem_stage4) * 8, _phase_u_smem_ready_1);
+          if (USE_DSTATE_IN != 0 || reverse4 > 0) {
+            mbarrier_wait(dstate_smem_ready_addr + (dstate_smem_stage4) * 8,
+                          _phase_dstate_smem_ready);
+            mbarrier_wait(dk_restore_done_addr + (dk_restore_stage4) * 8, _phase_dk_restore_done);
+            int _mma_a_lo_8 =
+                make_warp_uniform((((dstate_smem_mn_addr) >> 4) & 0x3FFF) | 0x4000000);
+            int _mma_b_lo_8 = make_warp_uniform((((u_lead16_addr) >> 4) & 0x3FFF) | 0x800000);
+            asm volatile(
+                "{\n\t"
+                ".reg .pred leader, p0, p1;\n\t"
+                ".reg .b32 adhi, bdhi, alo, blo, id;\n\t"
+                ".reg .b64 da, db;\n\t"
+                "elect.sync _|leader, 0xFFFFFFFF;\n\t"
+                "setp.ne.b32 p0, %3, 0;\n\t"
+                "setp.ne.b32 p1, 1, 0;\n\t"
+                ""
+                "mov.b32 adhi, 0x40004040;\n\t"
+                "mov.b32 bdhi, 0x40004040;\n\t"
+                "mov.b32 id, 134513808;\n\t"
+                "mov.b32 alo, %0;\n\t"
+                "mov.b32 blo, %1;\n\t"
+                "mov.b64 da, {alo, adhi};\n\t"
+                "mov.b64 db, {blo, bdhi};\n\t"
+                "@leader tcgen05.mma.cta_group::1.kind::f16 [%2], da, db, id, p0;\n\t"
+                "add.u32 alo, alo, 128;\n\t"
+                "add.u32 blo, blo, 2;\n\t"
+                "mov.b64 da, {alo, adhi};\n\t"
+                "mov.b64 db, {blo, bdhi};\n\t"
+                "@leader tcgen05.mma.cta_group::1.kind::f16 [%2], da, db, id, p1;\n\t"
+                "add.u32 alo, alo, 128;\n\t"
+                "add.u32 blo, blo, 2;\n\t"
+                "mov.b64 da, {alo, adhi};\n\t"
+                "mov.b64 db, {blo, bdhi};\n\t"
+                "@leader tcgen05.mma.cta_group::1.kind::f16 [%2], da, db, id, p1;\n\t"
+                "add.u32 alo, alo, 128;\n\t"
+                "add.u32 blo, blo, 2;\n\t"
+                "mov.b64 da, {alo, adhi};\n\t"
+                "mov.b64 db, {blo, bdhi};\n\t"
+                "@leader tcgen05.mma.cta_group::1.kind::f16 [%2], da, db, id, p1;\n\t"
+                "add.u32 alo, alo, 128;\n\t"
+                "add.u32 blo, blo, 122;\n\t"
+                "mov.b64 da, {alo, adhi};\n\t"
+                "mov.b64 db, {blo, bdhi};\n\t"
+                "@leader tcgen05.mma.cta_group::1.kind::f16 [%2], da, db, id, p1;\n\t"
+                "add.u32 alo, alo, 128;\n\t"
+                "add.u32 blo, blo, 2;\n\t"
+                "mov.b64 da, {alo, adhi};\n\t"
+                "mov.b64 db, {blo, bdhi};\n\t"
+                "@leader tcgen05.mma.cta_group::1.kind::f16 [%2], da, db, id, p1;\n\t"
+                "add.u32 alo, alo, 128;\n\t"
+                "add.u32 blo, blo, 2;\n\t"
+                "mov.b64 da, {alo, adhi};\n\t"
+                "mov.b64 db, {blo, bdhi};\n\t"
+                "@leader tcgen05.mma.cta_group::1.kind::f16 [%2], da, db, id, p1;\n\t"
+                "add.u32 alo, alo, 128;\n\t"
+                "add.u32 blo, blo, 2;\n\t"
+                "mov.b64 da, {alo, adhi};\n\t"
+                "mov.b64 db, {blo, bdhi};\n\t"
+                "@leader tcgen05.mma.cta_group::1.kind::f16 [%2], da, db, id, p1;\n\t"
+                "}\n" ::"r"(_mma_a_lo_8),
+                "r"(_mma_b_lo_8), "r"(tmem_flashkda_bwd_persistent_c16_dk_restore), "r"(0));
+            elect_commit2(dk_restore_ready_addr + (dk_restore_stage4) * 8,
+                          dstate_smem_done_addr + (dstate_smem_stage4) * 8);
+            dstate_smem_stage4 += 1;
+            if (dstate_smem_stage4 == 1) {
+              dstate_smem_stage4 = 0;
+              _phase_dstate_smem_ready ^= 1;
+            }
+            dk_restore_stage4 += 1;
+            if (dk_restore_stage4 == 1) {
+              dk_restore_stage4 = 0;
+              _phase_dk_restore_done ^= 1;
+            }
+          }
+          u_smem_stage4 += 1;
+          if (u_smem_stage4 == 1) {
+            u_smem_stage4 = 0;
+            _phase_u_smem_ready_1 ^= 1;
+          }
+          mbarrier_wait(dy_ready_addr + (tcgen_data_stage4) * 8, _phase_dy_ready_1);
+          mbarrier_wait(neg_dy_ready_addr + (tcgen_data_stage4) * 8, _phase_neg_dy_ready);
+          int _mma_b_lo_9 = make_warp_uniform(((((k_decay_trans_addr) >> 4) & 0x3FFF) | 0x800000) +
+                                              (operand_stage4) * 256);
+          mma_ts_step(tmem_flashkda_bwd_persistent_c16_dstate,
+                      tmem_flashkda_bwd_persistent_c16_neg_dy, _mma_b_lo_9, 0x40004040, 136381584,
+                      1);
+          elect_commit(dstate_ready_addr + (tcgen_data_stage4) * 8);
+          mbarrier_wait(dstate_ready_addr + (tcgen_data_stage4) * 8, _phase_dstate_ready_1);
+          mbarrier_wait(beta_dy_smem_ready_addr + (beta_dy_smem_stage4) * 8,
+                        _phase_beta_dy_smem_ready);
+          int _mma_a_lo_10 = make_warp_uniform((((state_operand_addr) >> 4) & 0x3FFF) +
+                                               (state_smem_stage4) * 2048);
+          int _mma_b_lo_10 = make_warp_uniform((((beta_dy_smem_addr) >> 4) & 0x3FFF) +
+                                               (beta_dy_smem_stage4) * 256);
+          asm volatile(
+              "{\n\t"
+              ".reg .pred leader, p0, p1;\n\t"
+              ".reg .b32 adhi, bdhi, alo, blo, id;\n\t"
+              ".reg .b64 da, db;\n\t"
+              "elect.sync _|leader, 0xFFFFFFFF;\n\t"
+              "setp.ne.b32 p0, %3, 0;\n\t"
+              "setp.ne.b32 p1, 1, 0;\n\t"
+              ""
+              "mov.b32 adhi, 0x40004040;\n\t"
+              "mov.b32 bdhi, 0x40004040;\n\t"
+              "mov.b32 id, 134481040;\n\t"
+              "mov.b32 alo, %0;\n\t"
+              "mov.b32 blo, %1;\n\t"
+              "mov.b64 da, {alo, adhi};\n\t"
+              "mov.b64 db, {blo, bdhi};\n\t"
+              "@leader tcgen05.mma.cta_group::1.kind::f16 [%2], da, db, id, p0;\n\t"
+              "add.u32 alo, alo, 2;\n\t"
+              "add.u32 blo, blo, 2;\n\t"
+              "mov.b64 da, {alo, adhi};\n\t"
+              "mov.b64 db, {blo, bdhi};\n\t"
+              "@leader tcgen05.mma.cta_group::1.kind::f16 [%2], da, db, id, p1;\n\t"
+              "add.u32 alo, alo, 2;\n\t"
+              "add.u32 blo, blo, 2;\n\t"
+              "mov.b64 da, {alo, adhi};\n\t"
+              "mov.b64 db, {blo, bdhi};\n\t"
+              "@leader tcgen05.mma.cta_group::1.kind::f16 [%2], da, db, id, p1;\n\t"
+              "add.u32 alo, alo, 2;\n\t"
+              "add.u32 blo, blo, 2;\n\t"
+              "mov.b64 da, {alo, adhi};\n\t"
+              "mov.b64 db, {blo, bdhi};\n\t"
+              "@leader tcgen05.mma.cta_group::1.kind::f16 [%2], da, db, id, p1;\n\t"
+              "add.u32 alo, alo, 1018;\n\t"
+              "add.u32 blo, blo, 122;\n\t"
+              "mov.b64 da, {alo, adhi};\n\t"
+              "mov.b64 db, {blo, bdhi};\n\t"
+              "@leader tcgen05.mma.cta_group::1.kind::f16 [%2], da, db, id, p1;\n\t"
+              "add.u32 alo, alo, 2;\n\t"
+              "add.u32 blo, blo, 2;\n\t"
+              "mov.b64 da, {alo, adhi};\n\t"
+              "mov.b64 db, {blo, bdhi};\n\t"
+              "@leader tcgen05.mma.cta_group::1.kind::f16 [%2], da, db, id, p1;\n\t"
+              "add.u32 alo, alo, 2;\n\t"
+              "add.u32 blo, blo, 2;\n\t"
+              "mov.b64 da, {alo, adhi};\n\t"
+              "mov.b64 db, {blo, bdhi};\n\t"
+              "@leader tcgen05.mma.cta_group::1.kind::f16 [%2], da, db, id, p1;\n\t"
+              "add.u32 alo, alo, 2;\n\t"
+              "add.u32 blo, blo, 2;\n\t"
+              "mov.b64 da, {alo, adhi};\n\t"
+              "mov.b64 db, {blo, bdhi};\n\t"
+              "@leader tcgen05.mma.cta_group::1.kind::f16 [%2], da, db, id, p1;\n\t"
+              "}\n" ::"r"(_mma_a_lo_10),
+              "r"(_mma_b_lo_10), "r"(tmem_flashkda_bwd_persistent_c16_dk_decay), "r"(0));
+          mbarrier_wait(da_ready_addr + (intermediate_stage4) * 8, _phase_da_ready);
+          mbarrier_wait(dm_ready_addr + (intermediate_stage4) * 8, _phase_dm_ready);
+          int _mma_a_lo_11 = make_warp_uniform(((((q_decay_trans_addr) >> 4) & 0x3FFF) | 0x800000) +
+                                               (operand_stage4) * 256);
+          int _mma_b_lo_11 =
+              make_warp_uniform(((((intermediate_da_mn_addr) >> 4) & 0x3FFF) | 0x200000) +
+                                (intermediate_stage4) * 160);
+          asm volatile(
+              "{\n\t"
+              ".reg .pred leader, p0, p1;\n\t"
+              ".reg .b32 adhi, bdhi, alo, blo, id;\n\t"
+              ".reg .b64 da, db;\n\t"
+              "elect.sync _|leader, 0xFFFFFFFF;\n\t"
+              "setp.ne.b32 p0, %3, 0;\n\t"
+              "setp.ne.b32 p1, 1, 0;\n\t"
+              ""
+              "mov.b32 adhi, 0x40004040;\n\t"
+              "mov.b32 bdhi, 0xC0004010;\n\t"
+              "mov.b32 id, 134579344;\n\t"
+              "mov.b32 alo, %0;\n\t"
+              "mov.b32 blo, %1;\n\t"
+              "mov.b64 da, {alo, adhi};\n\t"
+              "mov.b64 db, {blo, bdhi};\n\t"
+              "@leader tcgen05.mma.cta_group::1.kind::f16 [%2], da, db, id, p0;\n\t"
+              "}\n" ::"r"(_mma_a_lo_11),
+              "r"(_mma_b_lo_11), "r"(tmem_flashkda_bwd_persistent_c16_dk_inv), "r"(0));
+          int _mma_a_lo_12 = make_warp_uniform(((((k_inv_amaj_addr) >> 4) & 0x3FFF) | 0x800000) +
+                                               (operand_stage4) * 256);
+          int _mma_b_lo_12 = make_warp_uniform(
+              ((((intermediate_da_addr) >> 4) & 0x3FFF) | 0x200000) + (intermediate_stage4) * 160);
+          asm volatile(
+              "{\n\t"
+              ".reg .pred leader, p0, p1;\n\t"
+              ".reg .b32 adhi, bdhi, alo, blo, id;\n\t"
+              ".reg .b64 da, db;\n\t"
+              "elect.sync _|leader, 0xFFFFFFFF;\n\t"
+              "setp.ne.b32 p0, %3, 0;\n\t"
+              "setp.ne.b32 p1, 1, 0;\n\t"
+              ""
+              "mov.b32 adhi, 0x40004040;\n\t"
+              "mov.b32 bdhi, 0xC0004010;\n\t"
+              "mov.b32 id, 134513808;\n\t"
+              "mov.b32 alo, %0;\n\t"
+              "mov.b32 blo, %1;\n\t"
+              "mov.b64 da, {alo, adhi};\n\t"
+              "mov.b64 db, {blo, bdhi};\n\t"
+              "@leader tcgen05.mma.cta_group::1.kind::f16 [%2], da, db, id, p0;\n\t"
+              "}\n" ::"r"(_mma_a_lo_12),
+              "r"(_mma_b_lo_12), "r"(tmem_flashkda_bwd_persistent_c16_dq), "r"(1));
+          int _mma_a_lo_13 = make_warp_uniform(((((k_decay_trans_addr) >> 4) & 0x3FFF) | 0x800000) +
+                                               (operand_stage4) * 256);
+          int _mma_b_lo_13 =
+              make_warp_uniform(((((intermediate_ndm_mn_addr) >> 4) & 0x3FFF) | 0x200000) +
+                                (intermediate_stage4) * 160);
+          asm volatile(
+              "{\n\t"
+              ".reg .pred leader, p0, p1;\n\t"
+              ".reg .b32 adhi, bdhi, alo, blo, id;\n\t"
+              ".reg .b64 da, db;\n\t"
+              "elect.sync _|leader, 0xFFFFFFFF;\n\t"
+              "setp.ne.b32 p0, %3, 0;\n\t"
+              "setp.ne.b32 p1, 1, 0;\n\t"
+              ""
+              "mov.b32 adhi, 0x40004040;\n\t"
+              "mov.b32 bdhi, 0xC0004010;\n\t"
+              "mov.b32 id, 134579344;\n\t"
+              "mov.b32 alo, %0;\n\t"
+              "mov.b32 blo, %1;\n\t"
+              "mov.b64 da, {alo, adhi};\n\t"
+              "mov.b64 db, {blo, bdhi};\n\t"
+              "@leader tcgen05.mma.cta_group::1.kind::f16 [%2], da, db, id, p0;\n\t"
+              "}\n" ::"r"(_mma_a_lo_13),
+              "r"(_mma_b_lo_13), "r"(tmem_flashkda_bwd_persistent_c16_dk_inv), "r"(1));
+          int _mma_a_lo_14 = make_warp_uniform(((((k_inv_amaj_addr) >> 4) & 0x3FFF) | 0x800000) +
+                                               (operand_stage4) * 256);
+          int _mma_b_lo_14 = make_warp_uniform(
+              ((((intermediate_dm_addr) >> 4) & 0x3FFF) | 0x200000) + (intermediate_stage4) * 160);
+          asm volatile(
+              "{\n\t"
+              ".reg .pred leader, p0, p1;\n\t"
+              ".reg .b32 adhi, bdhi, alo, blo, id;\n\t"
+              ".reg .b64 da, db;\n\t"
+              "elect.sync _|leader, 0xFFFFFFFF;\n\t"
+              "setp.ne.b32 p0, %3, 0;\n\t"
+              "setp.ne.b32 p1, 1, 0;\n\t"
+              ""
+              "mov.b32 adhi, 0x40004040;\n\t"
+              "mov.b32 bdhi, 0xC0004010;\n\t"
+              "mov.b32 id, 134513808;\n\t"
+              "mov.b32 alo, %0;\n\t"
+              "mov.b32 blo, %1;\n\t"
+              "mov.b64 da, {alo, adhi};\n\t"
+              "mov.b64 db, {blo, bdhi};\n\t"
+              "@leader tcgen05.mma.cta_group::1.kind::f16 [%2], da, db, id, p0;\n\t"
+              "}\n" ::"r"(_mma_a_lo_14),
+              "r"(_mma_b_lo_14), "r"(tmem_flashkda_bwd_persistent_c16_dk_decay), "r"(1));
+          elect_commit(local_grad_ready_addr + (local_grad_stage4) * 8);
+          elect_commit(beta_dy_smem_done_addr + (beta_dy_smem_stage4) * 8);
+          mbarrier_wait(boundary_smem_ready_addr + (boundary_stage4) * 8,
+                        _phase_boundary_smem_ready);
+          mbarrier_wait(boundary_local_grad_free_addr + (boundary_local_grad_stage4) * 8,
+                        _phase_boundary_local_grad_free);
+          int _mma_a_lo_15 = make_warp_uniform((((dstate_smem_mn_addr) >> 4) & 0x3FFF) | 0x4000000);
+          int _mma_b_lo_15 = make_warp_uniform((((u_lead16_addr) >> 4) & 0x3FFF) | 0x800000);
+          asm volatile(
+              "{\n\t"
+              ".reg .pred leader, p0, p1;\n\t"
+              ".reg .b32 adhi, bdhi, alo, blo, id;\n\t"
+              ".reg .b64 da, db;\n\t"
+              "elect.sync _|leader, 0xFFFFFFFF;\n\t"
+              "setp.ne.b32 p0, %3, 0;\n\t"
+              "setp.ne.b32 p1, 1, 0;\n\t"
+              ""
+              "mov.b32 adhi, 0x40004040;\n\t"
+              "mov.b32 bdhi, 0x40004040;\n\t"
+              "mov.b32 id, 134513808;\n\t"
+              "mov.b32 alo, %0;\n\t"
+              "mov.b32 blo, %1;\n\t"
+              "mov.b64 da, {alo, adhi};\n\t"
+              "mov.b64 db, {blo, bdhi};\n\t"
+              "@leader tcgen05.mma.cta_group::1.kind::f16 [%2], da, db, id, p0;\n\t"
+              "add.u32 alo, alo, 128;\n\t"
+              "add.u32 blo, blo, 2;\n\t"
+              "mov.b64 da, {alo, adhi};\n\t"
+              "mov.b64 db, {blo, bdhi};\n\t"
+              "@leader tcgen05.mma.cta_group::1.kind::f16 [%2], da, db, id, p1;\n\t"
+              "add.u32 alo, alo, 128;\n\t"
+              "add.u32 blo, blo, 2;\n\t"
+              "mov.b64 da, {alo, adhi};\n\t"
+              "mov.b64 db, {blo, bdhi};\n\t"
+              "@leader tcgen05.mma.cta_group::1.kind::f16 [%2], da, db, id, p1;\n\t"
+              "add.u32 alo, alo, 128;\n\t"
+              "add.u32 blo, blo, 2;\n\t"
+              "mov.b64 da, {alo, adhi};\n\t"
+              "mov.b64 db, {blo, bdhi};\n\t"
+              "@leader tcgen05.mma.cta_group::1.kind::f16 [%2], da, db, id, p1;\n\t"
+              "add.u32 alo, alo, 128;\n\t"
+              "add.u32 blo, blo, 122;\n\t"
+              "mov.b64 da, {alo, adhi};\n\t"
+              "mov.b64 db, {blo, bdhi};\n\t"
+              "@leader tcgen05.mma.cta_group::1.kind::f16 [%2], da, db, id, p1;\n\t"
+              "add.u32 alo, alo, 128;\n\t"
+              "add.u32 blo, blo, 2;\n\t"
+              "mov.b64 da, {alo, adhi};\n\t"
+              "mov.b64 db, {blo, bdhi};\n\t"
+              "@leader tcgen05.mma.cta_group::1.kind::f16 [%2], da, db, id, p1;\n\t"
+              "add.u32 alo, alo, 128;\n\t"
+              "add.u32 blo, blo, 2;\n\t"
+              "mov.b64 da, {alo, adhi};\n\t"
+              "mov.b64 db, {blo, bdhi};\n\t"
+              "@leader tcgen05.mma.cta_group::1.kind::f16 [%2], da, db, id, p1;\n\t"
+              "add.u32 alo, alo, 128;\n\t"
+              "add.u32 blo, blo, 2;\n\t"
+              "mov.b64 da, {alo, adhi};\n\t"
+              "mov.b64 db, {blo, bdhi};\n\t"
+              "@leader tcgen05.mma.cta_group::1.kind::f16 [%2], da, db, id, p1;\n\t"
+              "}\n" ::"r"(_mma_a_lo_15),
+              "r"(_mma_b_lo_15), "r"(tmem_flashkda_bwd_persistent_c16_dk_decay), "r"(0));
+          elect_commit2(boundary_acc_ready_addr + (boundary_stage4) * 8,
+                        state_slot_done_addr + (state_smem_stage4) * 8);
+          boundary_stage4 += 1;
+          if (boundary_stage4 == 1) {
+            boundary_stage4 = 0;
+            _phase_boundary_smem_ready ^= 1;
+          }
+          boundary_local_grad_stage4 += 1;
+          if (boundary_local_grad_stage4 == 1) {
+            boundary_local_grad_stage4 = 0;
+            _phase_boundary_local_grad_free ^= 1;
+          }
+          local_grad_stage4 += 1;
+          if (local_grad_stage4 == 1) {
+            local_grad_stage4 = 0;
+            _phase_local_grad_done ^= 1;
+          }
+          beta_dy_smem_stage4 += 1;
+          if (beta_dy_smem_stage4 == 2) {
+            beta_dy_smem_stage4 = 0;
+            _phase_beta_dy_smem_ready ^= 1;
+          }
+          if (elect_sync()) {
+            mbarrier_arrive(tcgen_inputs_done_addr + (tcgen_data_stage4) * 8);
+            mbarrier_arrive(raw_done_addr + (raw_stage4) * 8);
+            mbarrier_arrive(intermediate_done_addr + (intermediate_stage4) * 8);
+            mbarrier_arrive(decay_done_addr + (operand_stage4) * 8);
+          }
+          operand_stage4 += 1;
+          if (operand_stage4 == 2) {
+            operand_stage4 = 0;
+            _phase_k_decay_inv_ready_1 ^= 1;
+            _phase_q_decay_k_restore_ready ^= 1;
+          }
+          raw_stage4 += 1;
+          if (raw_stage4 == 2) {
+            raw_stage4 = 0;
+            _phase_raw_ready_3 ^= 1;
+          }
+          state_smem_stage4 += 1;
+          if (state_smem_stage4 == 2) {
+            state_smem_stage4 = 0;
+            _phase_state_k_done ^= 1;
+            _phase_state_ready_1 ^= 1;
+          }
+          intermediate_stage4 += 1;
+          if (intermediate_stage4 == 2) {
+            intermediate_stage4 = 0;
+            _phase_tinv_ready ^= 1;
+            _phase_a_ready ^= 1;
+            _phase_da_ready ^= 1;
+            _phase_dm_ready ^= 1;
+          }
+          tcgen_data_stage4 += 1;
+          if (tcgen_data_stage4 == 1) {
+            tcgen_data_stage4 = 0;
+            _phase_dstate_done ^= 1;
+            _phase_tcgen_inputs_ready ^= 1;
+            _phase_tcgen_products_done ^= 1;
+            _phase_dy_done ^= 1;
+            _phase_tcgen_products_ready_1 ^= 1;
+            _phase_du_inp_ready ^= 1;
+            _phase_dy_ready_1 ^= 1;
+            _phase_neg_dy_ready ^= 1;
+            _phase_dstate_ready_1 ^= 1;
+          }
+        }
+      }
+      if (elect_sync()) {
+        mbarrier_arrive(consumers_done_addr);
+      }
+      unsigned int _phase_cleanup_ready_0 = 0;
+      mbarrier_wait(cleanup_ready_addr, _phase_cleanup_ready_0);
+      _phase_cleanup_ready_0 ^= 1;
+      int _tmem_dealloc_addr = *((volatile int*)tmem_addr_storage);
+      asm volatile(
+          "tcgen05.dealloc.cta_group::1.sync.aligned.b32 %0, %1;" ::"r"(_tmem_dealloc_addr),
+          "r"(512));
+    }
+  }
+  // ---- Role: tma ----
+  if (warp == 14) {
+    {  // tma_main
+      unsigned int sched_stage6 = 0;
+      unsigned int raw_stage6 = 0;
+      unsigned int state_smem_stage6 = 0;
+      unsigned int _phase_sched_done = 1;
+      unsigned int _phase_state_slot_done = 1;
+      unsigned int _phase_state_cg2_done = 1;
+      unsigned int _phase_raw_done = 1;
+      if (elect_sync()) {
+#pragma unroll 1
+        for (int sched_iter6 = 0; sched_iter6 < total_work_items; sched_iter6++) {
+          mbarrier_wait(sched_done_addr + (sched_stage6) * 8, _phase_sched_done);
+          unsigned int tile6 = blockIdx.x;
+          if (uniform_work_items != 0) {
+            tile6 = (unsigned int)blockIdx.x + (unsigned int)sched_iter6 * (unsigned int)gridDim.x;
+          } else {
+            unsigned int _atomic_old_0 = atomicAdd(dynamic_counter, 1);
+            tile6 = _atomic_old_0;
+          }
+          asm volatile("st.shared.b32 [%0], %1;" ::"r"(work_item_addr + sched_stage6 * 4),
+                       "r"(tile6));
+          mbarrier_arrive(sched_ready_addr + (sched_stage6) * 8);
+          sched_stage6 += 1;
+          if (sched_stage6 == 8) {
+            sched_stage6 = 0;
+            _phase_sched_done ^= 1;
+          }
+          if (tile6 >= (unsigned int)total_work_items) {
+            break;
+          }
+          int item_base6 = (int)tile6 * 8;
+          int sequence6 = work_items[item_base6];
+          int head6 = work_items[item_base6 + 1];
+          int qk_head6 = head6 * num_qk_heads / num_heads;
+          int write_start6 = work_items[item_base6 + 2];
+          int write_end6 = work_items[item_base6 + 3];
+          int compute_end6 = work_items[item_base6 + 5];
+          long long bos6 = cu_seqlens[sequence6];
+#pragma unroll 1
+          for (int reverse6 = 0; reverse6 < compute_end6 - write_start6; reverse6++) {
+            int chunk6 = compute_end6 - 1 - reverse6;
+            int token6 = (int)(bos6 + (long long)chunk6 * 16);
+            int checkpoint6 = (int)(checkpoint_cu_starts[sequence6] + (long long)chunk6);
+            mbarrier_wait(state_slot_done_addr + (state_smem_stage6) * 8, _phase_state_slot_done);
+            mbarrier_wait(state_cg2_done_addr + (state_smem_stage6) * 8, _phase_state_cg2_done);
+            mbarrier_arrive_expect_tx(state_ready_addr + (state_smem_stage6) * 8, 32768);
+#pragma unroll
+            for (int state_segment6 = 0; state_segment6 < 2; state_segment6++) {
+              tma_4d_gmem2smem(
+                  state_panel_addr +
+                      (state_smem_stage6 % 2 * 2 + (unsigned int)state_segment6) * 16384,
+                  (&state_tma), state_segment6 * 64, 0, head6, checkpoint6,
+                  state_ready_addr + (state_smem_stage6) * 8);
+            }
+            state_smem_stage6 += 1;
+            if (state_smem_stage6 == 2) {
+              state_smem_stage6 = 0;
+              _phase_state_slot_done ^= 1;
+              _phase_state_cg2_done ^= 1;
+            }
+            mbarrier_wait(raw_done_addr + (raw_stage6) * 8, _phase_raw_done);
+            mbarrier_arrive_expect_tx(raw_ready_addr + (raw_stage6) * 8, 20736);
+            tma_2d_gmem2smem(beta_smem_addr + raw_stage6 * 256, (&beta_tma), head6 / 8 * 8, token6,
+                             raw_ready_addr + (raw_stage6) * 8);
+#pragma unroll
+            for (int raw_segment6 = 0; raw_segment6 < 2; raw_segment6++) {
+              int raw_segment_offset6 = raw_segment6 * 16 * 64 * 2;
+              int raw_channel6 = raw_segment6 * 64;
+              tma_3d_gmem2smem(raw_q_addr + raw_stage6 * 4096 + (unsigned int)raw_segment_offset6,
+                               (&q_tma), raw_channel6, qk_head6, token6,
+                               raw_ready_addr + (raw_stage6) * 8);
+              tma_3d_gmem2smem(raw_k_addr + raw_stage6 * 4096 + (unsigned int)raw_segment_offset6,
+                               (&k_tma), raw_channel6, qk_head6, token6,
+                               raw_ready_addr + (raw_stage6) * 8);
+              tma_3d_gmem2smem(raw_g_addr + raw_stage6 * 4096 + (unsigned int)raw_segment_offset6,
+                               (&g_tma), raw_channel6, head6, token6,
+                               raw_ready_addr + (raw_stage6) * 8);
+              tma_3d_gmem2smem(raw_do_addr + raw_stage6 * 4096 + (unsigned int)raw_segment_offset6,
+                               (&do_tma), raw_channel6, head6, token6,
+                               raw_ready_addr + (raw_stage6) * 8);
+              tma_3d_gmem2smem(raw_v_addr + raw_stage6 * 4096 + (unsigned int)raw_segment_offset6,
+                               (&v_tma), raw_channel6, head6, token6,
+                               raw_ready_addr + (raw_stage6) * 8);
+            }
+            raw_stage6 += 1;
+            if (raw_stage6 == 2) {
+              raw_stage6 = 0;
+              _phase_raw_done ^= 1;
+            }
+          }
+        }
+      }
+      unsigned int _phase_consumers_done_0 = 0;
+      mbarrier_wait(consumers_done_addr, _phase_consumers_done_0);
+      _phase_consumers_done_0 ^= 1;
+      if (elect_sync()) {
+        mbarrier_arrive(cleanup_ready_addr);
+      }
+    }
+  }
+  // ---- Role: epilogue ----
+  if (warp == 15) {
+    {  // epilogue_main
+      unsigned int sched_stage5 = 0;
+      unsigned int raw_stage5 = 0;
+      unsigned int operand_stage5 = 0;
+      unsigned int intermediate_stage5 = 0;
+      unsigned int u_smem_stage5 = 0;
+      unsigned int dv_stage5 = 0;
+      int lhs_row5 = lane % 8 + (lane / 8 & 1) * 8;
+      int lhs_col_offset5 = lane / 16 * 8;
+      int rhs_row5 = lane % 8 + lane / 16 * 8;
+      int rhs_col_offset5 = (lane / 8 & 1) * 8;
+      unsigned int _phase_sched_ready_5 = 0;
+      unsigned int _phase_q_decay_k_restore_ready_1 = 0;
+      unsigned int _phase_raw_ready_4 = 0;
+      unsigned int _phase_intermediate_done_1 = 1;
+      unsigned int _phase_beta_dy_smem_ready_1 = 0;
+      unsigned int _phase_u_smem_ready_2 = 0;
+#pragma unroll 1
+      for (int __5 = 0; __5 < total_work_items; __5++) {
+        mbarrier_wait(sched_ready_addr + (sched_stage5) * 8, _phase_sched_ready_5);
+        unsigned int ticket_words_5[1];
+        asm volatile("ld.shared.b32 %0, [%1];"
+                     : "=r"(*reinterpret_cast<uint32_t*>(&ticket_words_5[0]))
+                     : "r"(work_item_addr + sched_stage5 * 4));
+        unsigned int tile5 = ticket_words_5[0];
+        if (elect_sync()) {
+          mbarrier_arrive(sched_done_addr + (sched_stage5) * 8);
+        }
+        sched_stage5 += 1;
+        if (sched_stage5 == 8) {
+          sched_stage5 = 0;
+          _phase_sched_ready_5 ^= 1;
+        }
+        if (tile5 >= (unsigned int)total_work_items) {
+          break;
+        }
+        int item_base5 = (int)tile5 * 8;
+        int sequence5 = work_items[item_base5];
+        int head5 = work_items[item_base5 + 1];
+        int write_start5 = work_items[item_base5 + 2];
+        int write_end5 = work_items[item_base5 + 3];
+        int compute_end5 = work_items[item_base5 + 5];
+        long long bos5 = cu_seqlens[sequence5];
+        float a_sum5[8];
+        a_sum5[0] = 0.0f;
+        a_sum5[1] = 0.0f;
+        a_sum5[2] = 0.0f;
+        a_sum5[3] = 0.0f;
+        a_sum5[4] = 0.0f;
+        a_sum5[5] = 0.0f;
+        a_sum5[6] = 0.0f;
+        a_sum5[7] = 0.0f;
+#pragma unroll 1
+        for (int reverse5 = 0; reverse5 < compute_end5 - write_start5; reverse5++) {
+          mbarrier_wait(q_decay_k_restore_ready_addr + (operand_stage5) * 8,
+                        _phase_q_decay_k_restore_ready_1);
+          mbarrier_wait(raw_ready_addr + (raw_stage5) * 8, _phase_raw_ready_4);
+          int dv_chunk5 = compute_end5 - 1 - reverse5;
+          int dv_token5 = (int)(bos5 + (long long)dv_chunk5 * 16);
+          mbarrier_wait(intermediate_done_addr + (intermediate_stage5) * 8,
+                        _phase_intermediate_done_1);
+          float a_acc5[8];
+#pragma unroll
+          for (int k_block5 = 0; k_block5 < 8; k_block5++) {
+            int a_col5 = k_block5 * 16 + lhs_col_offset5;
+            int b_col5 = k_block5 * 16 + rhs_col_offset5;
+            unsigned int a_frag5[4];
+            unsigned int b_frag5[4];
+            int segment_11 = a_col5 / 64;
+            int segment_col_12 = a_col5 - segment_11 * 64;
+            int swizzled_col_12 = segment_col_12 ^ (lhs_row5 & 7) * 8;
+            asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                         : "=r"(a_frag5[0]), "=r"(a_frag5[1]), "=r"(a_frag5[2]), "=r"(a_frag5[3])
+                         : "r"(q_decay_all_addr + (unsigned int)(((int)operand_stage5 * 16 * 128 +
+                                                                  segment_11 * 16 * 64 +
+                                                                  lhs_row5 * 64 + swizzled_col_12) *
+                                                                 2))
+                         : "memory");
+            int segment_0_5 = b_col5 / 64;
+            int segment_col_1_5 = b_col5 - segment_0_5 * 64;
+            int swizzled_col_2_5 = segment_col_1_5 ^ (rhs_row5 & 7) * 8;
+            asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                         : "=r"(b_frag5[0]), "=r"(b_frag5[1]), "=r"(b_frag5[2]), "=r"(b_frag5[3])
+                         : "r"(k_inv_all_addr + (unsigned int)(((int)operand_stage5 * 16 * 128 +
+                                                                segment_0_5 * 16 * 64 +
+                                                                rhs_row5 * 64 + swizzled_col_2_5) *
+                                                               2))
+                         : "memory");
+            asm volatile(
+                "mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, "
+                "%6, %7}, {%8, %9}, {%10, %11, %12, %13};\n"
+                : "=f"(a_acc5[0]), "=f"(a_acc5[1]), "=f"(a_acc5[2]), "=f"(a_acc5[3])
+                : "r"(a_frag5[0]), "r"(a_frag5[1]), "r"(a_frag5[2]), "r"(a_frag5[3]),
+                  "r"(b_frag5[0]), "r"(b_frag5[1]), "f"(((k_block5 == 0) ? 0.0f : a_acc5[0])),
+                  "f"(((k_block5 == 0) ? 0.0f : a_acc5[1])),
+                  "f"(((k_block5 == 0) ? 0.0f : a_acc5[2])),
+                  "f"(((k_block5 == 0) ? 0.0f : a_acc5[3])));
+            asm volatile(
+                "mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, "
+                "%6, %7}, {%8, %9}, {%10, %11, %12, %13};\n"
+                : "=f"(a_acc5[4]), "=f"(a_acc5[(4) + 1]), "=f"(a_acc5[(4) + 2]),
+                  "=f"(a_acc5[(4) + 3])
+                : "r"(a_frag5[0]), "r"(a_frag5[1]), "r"(a_frag5[2]), "r"(a_frag5[3]),
+                  "r"(b_frag5[2]), "r"(b_frag5[(2) + 1]), "f"(((k_block5 == 0) ? 0.0f : a_acc5[4])),
+                  "f"(((k_block5 == 0) ? 0.0f : a_acc5[(4) + 1])),
+                  "f"(((k_block5 == 0) ? 0.0f : a_acc5[(4) + 2])),
+                  "f"(((k_block5 == 0) ? 0.0f : a_acc5[(4) + 3])));
+          }
+          float a_values5[8];
+#pragma unroll
+          for (int accum5 = 0; accum5 < 8; accum5++) {
+            int accum_row5 = lane / 4 + accum5 % 4 / 2 * 8;
+            int accum_col5 = accum5 / 4 * 8 + (lane & 3) * 2 + (accum5 & 1);
+            a_values5[accum5] = 0.0f;
+            if (accum_row5 >= accum_col5) {
+              a_values5[accum5] = a_acc5[accum5];
+            }
+            a_sum5[accum5] = a_sum5[accum5] + a_values5[accum5];
+          }
+          unsigned int a_words5[4];
+#pragma unroll
+          for (int _lp = 0; _lp < 4; _lp++) {
+            __nv_bfloat162 _bf2 = __float22bfloat162_rn(
+                make_float2(a_values5[_lp * 2 + 0], a_values5[_lp * 2 + 1 + 0]));
+            a_words5[_lp] = *(uint32_t*)&_bf2;
+          }
+          int publish_row5 = lane % 16;
+          int publish_col5 = lane / 16 * 8;
+          uint32_t _stmatrix_addr_0 = static_cast<uint32_t>(
+              (unsigned long long)(intermediate_a_addr + intermediate_stage5 * 2560 +
+                                   (unsigned int)(publish_col5 / 16 * 512 + publish_row5 * 32 +
+                                                      publish_col5 % 16 * 2 ^
+                                                  (publish_col5 / 16 * 512 + publish_row5 * 32 +
+                                                           publish_col5 % 16 * 2 >>
+                                                       7 &
+                                                   1) << 4)));
+          asm volatile("stmatrix.sync.aligned.m8n8.x4.shared.b16 [%0], {%1, %2, %3, %4};\n" ::"r"(
+                           _stmatrix_addr_0),
+                       "r"(*reinterpret_cast<const uint32_t*>(&a_words5[0])),
+                       "r"(*reinterpret_cast<const uint32_t*>(&a_words5[1])),
+                       "r"(*reinterpret_cast<const uint32_t*>(&a_words5[2])),
+                       "r"(*reinterpret_cast<const uint32_t*>(&a_words5[3]))
+                       : "memory");
+          asm volatile("fence.proxy.async.shared::cta;" ::: "memory");
+          mbarrier_arrive(a_ready_addr + (intermediate_stage5) * 8);
+          mbarrier_wait(beta_dy_smem_ready_addr + (dv_stage5) * 8, _phase_beta_dy_smem_ready_1);
+          if (dv_chunk5 < write_end5) {
+            if (elect_sync()) {
+#pragma unroll
+              for (int dv_segment5 = 0; dv_segment5 < 2; dv_segment5++) {
+                tma_store_3d((&dv_tma), dv_segment5 * 64, head5, dv_token5,
+                             beta_dy_smem_addr + dv_stage5 * 4096 +
+                                 (unsigned int)(dv_segment5 * 16 * 64 * 2));
+              }
+            }
+          }
+          asm volatile("cp.async.bulk.commit_group;");
+          mbarrier_wait(u_smem_ready_addr + (u_smem_stage5) * 8, _phase_u_smem_ready_2);
+          float da_acc5[8];
+#pragma unroll
+          for (int k_block_da5 = 0; k_block_da5 < 8; k_block_da5++) {
+            int a_col_da5 = k_block_da5 * 16 + lhs_col_offset5;
+            int b_col_da5 = k_block_da5 * 16 + rhs_col_offset5;
+            unsigned int do_frag5[4];
+            unsigned int u_frag5[4];
+            int segment_13 = a_col_da5 / 64;
+            int segment_col_14 = a_col_da5 - segment_13 * 64;
+            int swizzled_col_13 = segment_col_14 ^ (lhs_row5 & 7) * 8;
+            asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                         : "=r"(do_frag5[0]), "=r"(do_frag5[1]), "=r"(do_frag5[2]),
+                           "=r"(do_frag5[3])
+                         : "r"(raw_do_all_addr +
+                               (unsigned int)(((int)raw_stage5 * 16 * 128 + segment_13 * 16 * 64 +
+                                               lhs_row5 * 64 + swizzled_col_13) *
+                                              2))
+                         : "memory");
+            int segment_0_6 = b_col_da5 / 64;
+            int segment_col_1_6 = b_col_da5 - segment_0_6 * 64;
+            int swizzled_col_2_6 = segment_col_1_6 ^ (rhs_row5 & 7) * 8;
+            asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                         : "=r"(u_frag5[0]), "=r"(u_frag5[1]), "=r"(u_frag5[2]), "=r"(u_frag5[3])
+                         : "r"(u_smem_addr + (unsigned int)((segment_0_6 * 16 * 64 + rhs_row5 * 64 +
+                                                             swizzled_col_2_6) *
+                                                            2))
+                         : "memory");
+            asm volatile(
+                "mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, "
+                "%6, %7}, {%8, %9}, {%10, %11, %12, %13};\n"
+                : "=f"(da_acc5[0]), "=f"(da_acc5[1]), "=f"(da_acc5[2]), "=f"(da_acc5[3])
+                : "r"(do_frag5[0]), "r"(do_frag5[1]), "r"(do_frag5[2]), "r"(do_frag5[3]),
+                  "r"(u_frag5[0]), "r"(u_frag5[1]), "f"(((k_block_da5 == 0) ? 0.0f : da_acc5[0])),
+                  "f"(((k_block_da5 == 0) ? 0.0f : da_acc5[1])),
+                  "f"(((k_block_da5 == 0) ? 0.0f : da_acc5[2])),
+                  "f"(((k_block_da5 == 0) ? 0.0f : da_acc5[3])));
+            asm volatile(
+                "mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, "
+                "%6, %7}, {%8, %9}, {%10, %11, %12, %13};\n"
+                : "=f"(da_acc5[4]), "=f"(da_acc5[(4) + 1]), "=f"(da_acc5[(4) + 2]),
+                  "=f"(da_acc5[(4) + 3])
+                : "r"(do_frag5[0]), "r"(do_frag5[1]), "r"(do_frag5[2]), "r"(do_frag5[3]),
+                  "r"(u_frag5[2]), "r"(u_frag5[(2) + 1]),
+                  "f"(((k_block_da5 == 0) ? 0.0f : da_acc5[4])),
+                  "f"(((k_block_da5 == 0) ? 0.0f : da_acc5[(4) + 1])),
+                  "f"(((k_block_da5 == 0) ? 0.0f : da_acc5[(4) + 2])),
+                  "f"(((k_block_da5 == 0) ? 0.0f : da_acc5[(4) + 3])));
+          }
+          asm volatile("fence.proxy.async.shared::cta;" ::: "memory");
+          mbarrier_arrive(raw_done_addr + (raw_stage5) * 8);
+          float da_values5[8];
+#pragma unroll
+          for (int accum_da5 = 0; accum_da5 < 8; accum_da5++) {
+            int da_row5 = lane / 4 + accum_da5 % 4 / 2 * 8;
+            int da_col5 = accum_da5 / 4 * 8 + (lane & 3) * 2 + (accum_da5 & 1);
+            da_values5[accum_da5] = 0.0f;
+            if (da_row5 >= da_col5) {
+              da_values5[accum_da5] = da_acc5[accum_da5];
+            }
+          }
+          unsigned int da_words5[4];
+#pragma unroll
+          for (int _lp = 0; _lp < 4; _lp++) {
+            __nv_bfloat162 _bf2 = __float22bfloat162_rn(
+                make_float2(da_values5[_lp * 2 + 0], da_values5[_lp * 2 + 1 + 0]));
+            da_words5[_lp] = *(uint32_t*)&_bf2;
+          }
+          uint32_t _stmatrix_addr_1 = static_cast<uint32_t>(
+              (unsigned long long)(intermediate_da_addr + intermediate_stage5 * 2560 +
+                                   (unsigned int)(publish_col5 / 16 * 512 + publish_row5 * 32 +
+                                                      publish_col5 % 16 * 2 ^
+                                                  (publish_col5 / 16 * 512 + publish_row5 * 32 +
+                                                           publish_col5 % 16 * 2 >>
+                                                       7 &
+                                                   1) << 4)));
+          asm volatile("stmatrix.sync.aligned.m8n8.x4.shared.b16 [%0], {%1, %2, %3, %4};\n" ::"r"(
+                           _stmatrix_addr_1),
+                       "r"(*reinterpret_cast<const uint32_t*>(&da_words5[0])),
+                       "r"(*reinterpret_cast<const uint32_t*>(&da_words5[1])),
+                       "r"(*reinterpret_cast<const uint32_t*>(&da_words5[2])),
+                       "r"(*reinterpret_cast<const uint32_t*>(&da_words5[3]))
+                       : "memory");
+          asm volatile("fence.proxy.async.shared::cta;" ::: "memory");
+          mbarrier_arrive(da_ready_addr + (intermediate_stage5) * 8);
+          asm volatile("cp.async.bulk.wait_group 0;");
+          if (elect_sync()) {
+            mbarrier_arrive(beta_dy_smem_done_addr + (dv_stage5) * 8);
+          }
+          dv_stage5 += 1;
+          if (dv_stage5 == 2) {
+            dv_stage5 = 0;
+            _phase_beta_dy_smem_ready_1 ^= 1;
+          }
+          raw_stage5 += 1;
+          if (raw_stage5 == 2) {
+            raw_stage5 = 0;
+            _phase_raw_ready_4 ^= 1;
+          }
+          operand_stage5 += 1;
+          if (operand_stage5 == 2) {
+            operand_stage5 = 0;
+            _phase_q_decay_k_restore_ready_1 ^= 1;
+          }
+          intermediate_stage5 += 1;
+          if (intermediate_stage5 == 2) {
+            intermediate_stage5 = 0;
+            _phase_intermediate_done_1 ^= 1;
+          }
+          u_smem_stage5 += 1;
+          if (u_smem_stage5 == 1) {
+            u_smem_stage5 = 0;
+            _phase_u_smem_ready_2 ^= 1;
+          }
+        }
+      }
+      if (elect_sync()) {
+        mbarrier_arrive(consumers_done_addr);
+      }
+    }
+  }
+
+  // Cleanup
+}
+
+}  // extern "C"
+
+#undef LOOM_INF
+#undef NUM_BETA_DY_SMEM_PIPE_STAGES
+#undef NUM_BOUNDARY_LOCAL_GRAD_PIPE_STAGES
+#undef NUM_BOUNDARY_PIPE_STAGES
+#undef NUM_DBETA_M_PIPE_STAGES
+#undef NUM_DK_RESTORE_PIPE_STAGES
+#undef NUM_DSTATE_RECURRENCE_PIPE_STAGES
+#undef NUM_DSTATE_SMEM_PIPE_STAGES
+#undef NUM_DY_SMEM_PIPE_STAGES
+#undef NUM_G_PREFIX_PIPE_STAGES
+#undef NUM_INTERMEDIATE_PIPE_STAGES
+#undef NUM_LOCAL_GRAD_PIPE_STAGES
+#undef NUM_OPERAND_PIPE_STAGES
+#undef NUM_QK_RAW_PIPE_STAGES
+#undef NUM_RAW_PIPE_STAGES
+#undef NUM_SCHED_PIPE_STAGES
+#undef NUM_STATE_SMEM_PIPE_STAGES
+#undef NUM_TCGEN_DATA_PIPE_STAGES
+#undef NUM_U_SMEM_PIPE_STAGES
+#undef SMEM_BETA_DY_SMEM_OFF
+#undef SMEM_BETA_DY_SMEM_STAGE_BYTES
+#undef SMEM_BETA_DY_SMEM_STRIDE
+#undef SMEM_BETA_SMEM_ALL_OFF
+#undef SMEM_BETA_SMEM_ALL_STAGE_BYTES
+#undef SMEM_BETA_SMEM_ALL_STRIDE
+#undef SMEM_BETA_SMEM_OFF
+#undef SMEM_BETA_SMEM_STAGE_BYTES
+#undef SMEM_BETA_SMEM_STRIDE
+#undef SMEM_BOUNDARY_STATE_SMEM_OFF
+#undef SMEM_BOUNDARY_STATE_SMEM_STAGE_BYTES
+#undef SMEM_BOUNDARY_STATE_SMEM_STRIDE
+#undef SMEM_DBETA_M_SMEM_OFF
+#undef SMEM_DBETA_M_SMEM_STAGE_BYTES
+#undef SMEM_DBETA_M_SMEM_STRIDE
+#undef SMEM_DBETA_RED_SMEM_OFF
+#undef SMEM_DBETA_RED_SMEM_STAGE_BYTES
+#undef SMEM_DBETA_RED_SMEM_STRIDE
+#undef SMEM_DEBUG_DU_SMEM_ALL_OFF
+#undef SMEM_DEBUG_DU_SMEM_ALL_STAGE_BYTES
+#undef SMEM_DEBUG_DU_SMEM_ALL_STRIDE
+#undef SMEM_DEBUG_DU_SMEM_OFF
+#undef SMEM_DEBUG_DU_SMEM_STAGE_BYTES
+#undef SMEM_DEBUG_DU_SMEM_STRIDE
+#undef SMEM_DSTATE_SMEM_ALL_OFF
+#undef SMEM_DSTATE_SMEM_ALL_STAGE_BYTES
+#undef SMEM_DSTATE_SMEM_ALL_STRIDE
+#undef SMEM_DSTATE_SMEM_MN_OFF
+#undef SMEM_DSTATE_SMEM_MN_STAGE_BYTES
+#undef SMEM_DSTATE_SMEM_MN_STRIDE
+#undef SMEM_DSTATE_SMEM_OFF
+#undef SMEM_DSTATE_SMEM_STAGE_BYTES
+#undef SMEM_DSTATE_SMEM_STRIDE
+#undef SMEM_DY_SMEM_ALL_OFF
+#undef SMEM_DY_SMEM_ALL_STAGE_BYTES
+#undef SMEM_DY_SMEM_ALL_STRIDE
+#undef SMEM_DY_SMEM_OFF
+#undef SMEM_DY_SMEM_STAGE_BYTES
+#undef SMEM_DY_SMEM_STRIDE
+#undef SMEM_G_PREFIX_ALL_OFF
+#undef SMEM_G_PREFIX_ALL_STAGE_BYTES
+#undef SMEM_G_PREFIX_ALL_STRIDE
+#undef SMEM_G_PREFIX_OFF
+#undef SMEM_G_PREFIX_STAGE_BYTES
+#undef SMEM_G_PREFIX_STRIDE
+#undef SMEM_INTERMEDIATE_A_MN_OFF
+#undef SMEM_INTERMEDIATE_A_MN_STAGE_BYTES
+#undef SMEM_INTERMEDIATE_A_MN_STRIDE
+#undef SMEM_INTERMEDIATE_A_OFF
+#undef SMEM_INTERMEDIATE_A_STAGE_BYTES
+#undef SMEM_INTERMEDIATE_A_STRIDE
+#undef SMEM_INTERMEDIATE_DA_MN_OFF
+#undef SMEM_INTERMEDIATE_DA_MN_STAGE_BYTES
+#undef SMEM_INTERMEDIATE_DA_MN_STRIDE
+#undef SMEM_INTERMEDIATE_DA_OFF
+#undef SMEM_INTERMEDIATE_DA_STAGE_BYTES
+#undef SMEM_INTERMEDIATE_DA_STRIDE
+#undef SMEM_INTERMEDIATE_DM_OFF
+#undef SMEM_INTERMEDIATE_DM_STAGE_BYTES
+#undef SMEM_INTERMEDIATE_DM_STRIDE
+#undef SMEM_INTERMEDIATE_NDM_MN_OFF
+#undef SMEM_INTERMEDIATE_NDM_MN_STAGE_BYTES
+#undef SMEM_INTERMEDIATE_NDM_MN_STRIDE
+#undef SMEM_INTERMEDIATE_NDM_OFF
+#undef SMEM_INTERMEDIATE_NDM_STAGE_BYTES
+#undef SMEM_INTERMEDIATE_NDM_STRIDE
+#undef SMEM_INTERMEDIATE_TINV_MN_OFF
+#undef SMEM_INTERMEDIATE_TINV_MN_STAGE_BYTES
+#undef SMEM_INTERMEDIATE_TINV_MN_STRIDE
+#undef SMEM_INTERMEDIATE_TINV_OFF
+#undef SMEM_INTERMEDIATE_TINV_STAGE_BYTES
+#undef SMEM_INTERMEDIATE_TINV_STRIDE
+#undef SMEM_K_DECAY_ALL_OFF
+#undef SMEM_K_DECAY_ALL_STAGE_BYTES
+#undef SMEM_K_DECAY_ALL_STRIDE
+#undef SMEM_K_DECAY_LEAD16_OFF
+#undef SMEM_K_DECAY_LEAD16_STAGE_BYTES
+#undef SMEM_K_DECAY_LEAD16_STRIDE
+#undef SMEM_K_DECAY_OPERAND_OFF
+#undef SMEM_K_DECAY_OPERAND_STAGE_BYTES
+#undef SMEM_K_DECAY_OPERAND_STRIDE
+#undef SMEM_K_DECAY_TRANS_OFF
+#undef SMEM_K_DECAY_TRANS_STAGE_BYTES
+#undef SMEM_K_DECAY_TRANS_STRIDE
+#undef SMEM_K_INV_ALL_OFF
+#undef SMEM_K_INV_ALL_STAGE_BYTES
+#undef SMEM_K_INV_ALL_STRIDE
+#undef SMEM_K_INV_AMAJ_OFF
+#undef SMEM_K_INV_AMAJ_STAGE_BYTES
+#undef SMEM_K_INV_AMAJ_STRIDE
+#undef SMEM_K_INV_LEAD16_OFF
+#undef SMEM_K_INV_LEAD16_STAGE_BYTES
+#undef SMEM_K_INV_LEAD16_STRIDE
+#undef SMEM_K_INV_OPERAND_OFF
+#undef SMEM_K_INV_OPERAND_STAGE_BYTES
+#undef SMEM_K_INV_OPERAND_STRIDE
+#undef SMEM_K_RESTORE_ALL_OFF
+#undef SMEM_K_RESTORE_ALL_STAGE_BYTES
+#undef SMEM_K_RESTORE_ALL_STRIDE
+#undef SMEM_K_RESTORE_LEAD16_OFF
+#undef SMEM_K_RESTORE_LEAD16_STAGE_BYTES
+#undef SMEM_K_RESTORE_LEAD16_STRIDE
+#undef SMEM_K_RESTORE_OPERAND_OFF
+#undef SMEM_K_RESTORE_OPERAND_STAGE_BYTES
+#undef SMEM_K_RESTORE_OPERAND_STRIDE
+#undef SMEM_QK_NORM_SMEM_ALL_OFF
+#undef SMEM_QK_NORM_SMEM_ALL_STAGE_BYTES
+#undef SMEM_QK_NORM_SMEM_ALL_STRIDE
+#undef SMEM_QK_NORM_SMEM_OFF
+#undef SMEM_QK_NORM_SMEM_STAGE_BYTES
+#undef SMEM_QK_NORM_SMEM_STRIDE
+#undef SMEM_QK_RED_SMEM_OFF
+#undef SMEM_QK_RED_SMEM_STAGE_BYTES
+#undef SMEM_QK_RED_SMEM_STRIDE
+#undef SMEM_Q_DECAY_ALL_OFF
+#undef SMEM_Q_DECAY_ALL_STAGE_BYTES
+#undef SMEM_Q_DECAY_ALL_STRIDE
+#undef SMEM_Q_DECAY_OPERAND_OFF
+#undef SMEM_Q_DECAY_OPERAND_STAGE_BYTES
+#undef SMEM_Q_DECAY_OPERAND_STRIDE
+#undef SMEM_Q_DECAY_TRANS_OFF
+#undef SMEM_Q_DECAY_TRANS_STAGE_BYTES
+#undef SMEM_Q_DECAY_TRANS_STRIDE
+#undef SMEM_RAW_DO_ALL_OFF
+#undef SMEM_RAW_DO_ALL_STAGE_BYTES
+#undef SMEM_RAW_DO_ALL_STRIDE
+#undef SMEM_RAW_DO_AMAJ_OFF
+#undef SMEM_RAW_DO_AMAJ_STAGE_BYTES
+#undef SMEM_RAW_DO_AMAJ_STRIDE
+#undef SMEM_RAW_DO_OFF
+#undef SMEM_RAW_DO_STAGE_BYTES
+#undef SMEM_RAW_DO_STRIDE
+#undef SMEM_RAW_G_ALL_OFF
+#undef SMEM_RAW_G_ALL_STAGE_BYTES
+#undef SMEM_RAW_G_ALL_STRIDE
+#undef SMEM_RAW_G_OFF
+#undef SMEM_RAW_G_STAGE_BYTES
+#undef SMEM_RAW_G_STRIDE
+#undef SMEM_RAW_K_ALL_OFF
+#undef SMEM_RAW_K_ALL_STAGE_BYTES
+#undef SMEM_RAW_K_ALL_STRIDE
+#undef SMEM_RAW_K_OFF
+#undef SMEM_RAW_K_STAGE_BYTES
+#undef SMEM_RAW_K_STRIDE
+#undef SMEM_RAW_Q_ALL_OFF
+#undef SMEM_RAW_Q_ALL_STAGE_BYTES
+#undef SMEM_RAW_Q_ALL_STRIDE
+#undef SMEM_RAW_Q_OFF
+#undef SMEM_RAW_Q_STAGE_BYTES
+#undef SMEM_RAW_Q_STRIDE
+#undef SMEM_RAW_V_ALL_OFF
+#undef SMEM_RAW_V_ALL_STAGE_BYTES
+#undef SMEM_RAW_V_ALL_STRIDE
+#undef SMEM_RAW_V_OFF
+#undef SMEM_RAW_V_STAGE_BYTES
+#undef SMEM_RAW_V_STRIDE
+#undef SMEM_STATE_OPERAND_ALL_OFF
+#undef SMEM_STATE_OPERAND_ALL_STAGE_BYTES
+#undef SMEM_STATE_OPERAND_ALL_STRIDE
+#undef SMEM_STATE_OPERAND_MN_OFF
+#undef SMEM_STATE_OPERAND_MN_STAGE_BYTES
+#undef SMEM_STATE_OPERAND_MN_STRIDE
+#undef SMEM_STATE_OPERAND_OFF
+#undef SMEM_STATE_OPERAND_STAGE_BYTES
+#undef SMEM_STATE_OPERAND_STRIDE
+#undef SMEM_STATE_PANEL_OFF
+#undef SMEM_STATE_PANEL_STAGE_BYTES
+#undef SMEM_STATE_PANEL_STRIDE
+#undef SMEM_STATE_SCALE_DIAG_OFF
+#undef SMEM_STATE_SCALE_DIAG_STAGE_BYTES
+#undef SMEM_STATE_SCALE_DIAG_STRIDE
+#undef SMEM_TINV_SCRATCH_OFF
+#undef SMEM_TINV_SCRATCH_STAGE_BYTES
+#undef SMEM_TINV_SCRATCH_STRIDE
+#undef SMEM_TOTAL
+#undef SMEM_U_LEAD16_OFF
+#undef SMEM_U_LEAD16_STAGE_BYTES
+#undef SMEM_U_LEAD16_STRIDE
+#undef SMEM_U_SMEM_ALL_OFF
+#undef SMEM_U_SMEM_ALL_STAGE_BYTES
+#undef SMEM_U_SMEM_ALL_STRIDE
+#undef SMEM_U_SMEM_OFF
+#undef SMEM_U_SMEM_STAGE_BYTES
+#undef SMEM_U_SMEM_STRIDE
+#undef SMEM_WORK_ITEM_OFF
+#undef SMEM_WORK_ITEM_STAGE_BYTES
+#undef SMEM_WORK_ITEM_STRIDE
+#undef THREADS
+#undef TMEM_FLASHKDA_BWD_PERSISTENT_C16_DK_DECAY_OFFSET
+#undef TMEM_FLASHKDA_BWD_PERSISTENT_C16_DK_INV_OFFSET
+#undef TMEM_FLASHKDA_BWD_PERSISTENT_C16_DK_RESTORE_OFFSET
+#undef TMEM_FLASHKDA_BWD_PERSISTENT_C16_DO_INP_OFFSET
+#undef TMEM_FLASHKDA_BWD_PERSISTENT_C16_DQ_OFFSET
+#undef TMEM_FLASHKDA_BWD_PERSISTENT_C16_DSTATE_INP_OFFSET
+#undef TMEM_FLASHKDA_BWD_PERSISTENT_C16_DSTATE_OFFSET
+#undef TMEM_FLASHKDA_BWD_PERSISTENT_C16_DU_INP_OFFSET
+#undef TMEM_FLASHKDA_BWD_PERSISTENT_C16_DU_OFFSET
+#undef TMEM_FLASHKDA_BWD_PERSISTENT_C16_DY_OFFSET
+#undef TMEM_FLASHKDA_BWD_PERSISTENT_C16_ENVELOPE_OFFSET
+#undef TMEM_FLASHKDA_BWD_PERSISTENT_C16_NEG_DY_OFFSET
+#undef TMEM_FLASHKDA_BWD_PERSISTENT_C16_STATE_K_OFFSET
+#undef TMEM_FLASHKDA_BWD_PERSISTENT_C16_U_OFFSET
+#undef TMEM_FLASHKDA_BWD_PERSISTENT_C16_Y_OFFSET
+#undef TMEM_NCOLS
+#undef USE_DSTATE_IN
+#undef a_ready_addr
+#undef beta_dy_smem_addr
+#undef beta_dy_smem_done_addr
+#undef beta_dy_smem_ready_addr
+#undef beta_smem_addr
+#undef beta_smem_all_addr
+#undef boundary_acc_ready_addr
+#undef boundary_local_grad_free_addr
+#undef boundary_smem_ready_addr
+#undef boundary_state_ready_addr
+#undef boundary_state_smem_addr
+#undef cleanup_ready_addr
+#undef consumers_done_addr
+#undef da_ready_addr
+#undef dbeta_m_done_addr
+#undef dbeta_m_ready_addr
+#undef dbeta_m_smem_addr
+#undef dbeta_red_smem_addr
+#undef debug_du_smem_addr
+#undef debug_du_smem_all_addr
+#undef decay_done_addr
+#undef dk_restore_done_addr
+#undef dk_restore_ready_addr
+#undef dm_ready_addr
+#undef dstate_done_addr
+#undef dstate_inp_ready_addr
+#undef dstate_ready_addr
+#undef dstate_smem_addr
+#undef dstate_smem_all_addr
+#undef dstate_smem_done_addr
+#undef dstate_smem_mn_addr
+#undef dstate_smem_ready_addr
+#undef du_inp_ready_addr
+#undef dy_done_addr
+#undef dy_ready_addr
+#undef dy_smem_addr
+#undef dy_smem_all_addr
+#undef dy_smem_ready_addr
+#undef g_prefix_addr
+#undef g_prefix_all_addr
+#undef g_prefix_done_addr
+#undef g_prefix_ready_addr
+#undef intermediate_a_addr
+#undef intermediate_a_mn_addr
+#undef intermediate_da_addr
+#undef intermediate_da_mn_addr
+#undef intermediate_dm_addr
+#undef intermediate_done_addr
+#undef intermediate_ndm_addr
+#undef intermediate_ndm_mn_addr
+#undef intermediate_tinv_addr
+#undef intermediate_tinv_mn_addr
+#undef k_decay_all_addr
+#undef k_decay_inv_ready_addr
+#undef k_decay_lead16_addr
+#undef k_decay_operand_addr
+#undef k_decay_trans_addr
+#undef k_inv_all_addr
+#undef k_inv_amaj_addr
+#undef k_inv_lead16_addr
+#undef k_inv_operand_addr
+#undef k_restore_all_addr
+#undef k_restore_lead16_addr
+#undef k_restore_operand_addr
+#undef local_grad_done_addr
+#undef local_grad_ready_addr
+#undef neg_dy_ready_addr
+#undef q_decay_all_addr
+#undef q_decay_k_restore_ready_addr
+#undef q_decay_operand_addr
+#undef q_decay_trans_addr
+#undef qk_norm_smem_addr
+#undef qk_norm_smem_all_addr
+#undef qk_raw_done_addr
+#undef qk_raw_ready_addr
+#undef qk_red_smem_addr
+#undef raw_do_addr
+#undef raw_do_all_addr
+#undef raw_do_amaj_addr
+#undef raw_done_addr
+#undef raw_g_addr
+#undef raw_g_all_addr
+#undef raw_k_addr
+#undef raw_k_all_addr
+#undef raw_q_addr
+#undef raw_q_all_addr
+#undef raw_ready_addr
+#undef raw_v_addr
+#undef raw_v_all_addr
+#undef sched_done_addr
+#undef sched_ready_addr
+#undef state_cg2_done_addr
+#undef state_k_done_addr
+#undef state_k_ready_addr
+#undef state_operand_addr
+#undef state_operand_all_addr
+#undef state_operand_mn_addr
+#undef state_panel_addr
+#undef state_ready_addr
+#undef state_scale_diag_addr
+#undef state_slot_done_addr
+#undef tcgen_inputs_done_addr
+#undef tcgen_inputs_ready_addr
+#undef tcgen_products_done_addr
+#undef tcgen_products_ready_addr
+#undef tinv_ready_addr
+#undef tinv_scratch_addr
+#undef u_lead16_addr
+#undef u_smem_addr
+#undef u_smem_all_addr
+#undef u_smem_ready_addr
+#undef validate_outputs
+#undef work_item_addr

--- a/csrc/kda/flashkda_training_fallback_binding.cu
+++ b/csrc/kda/flashkda_training_fallback_binding.cu
@@ -1,0 +1,684 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ */
+
+#include "flashkda_binding_common.cuh"
+
+struct alignas(128) FlashKDATrainingFallbackTensorMap {
+  uint64_t opaque[16];
+};
+
+extern "C" {
+
+__global__ void kernel_flashkda_backward_preprocess(__nv_bfloat16*, __nv_bfloat16*, __nv_bfloat16*,
+                                                    __nv_bfloat16*, float*, float*, float*, float*,
+                                                    float*, float*, int, int, float);
+__global__ void kernel_flashkda_backward_checkpoint(float*, float*, float*, __nv_bfloat16*, float*,
+                                                    long long*, float*, int, int);
+__global__ void kernel_flashkda_backward_reverse_rows(float*, float*, float*, float*,
+                                                      __nv_bfloat16*, __nv_bfloat16*, float*,
+                                                      float*, long long*, float*, float*, float*,
+                                                      float*, float*, __nv_bfloat16*, float*, int,
+                                                      int, float);
+__global__ void kernel_flashkda_backward_finalize_tokens(__nv_bfloat16*, __nv_bfloat16*,
+                                                         __nv_bfloat16*, float*, float*, float*,
+                                                         float*, float*, float*, float*, float*,
+                                                         float*, __nv_bfloat16*, __nv_bfloat16*,
+                                                         __nv_bfloat16*, __nv_bfloat16*, int,
+                                                         float);
+__global__ void kernel_flashkda_backward_gate_reduce_split(float*, __nv_bfloat16*, float*, float*,
+                                                           float*, int, int, int);
+
+__global__ void kernel_flashkda_grouped_qk_expand(__nv_bfloat16*, __nv_bfloat16*, __nv_bfloat16*,
+                                                  __nv_bfloat16*, int, int, int);
+__global__ void kernel_flashkda_grouped_qk_reduce(__nv_bfloat16*, __nv_bfloat16*, __nv_bfloat16*,
+                                                  __nv_bfloat16*, int, int, int);
+
+__global__ void kernel_flashkda_bf16_fused_m128(
+    __nv_bfloat16*, const FlashKDATrainingFallbackTensorMap*, __nv_bfloat16*,
+    const FlashKDATrainingFallbackTensorMap*, __nv_bfloat16*,
+    const FlashKDATrainingFallbackTensorMap*, __nv_bfloat16*,
+    const FlashKDATrainingFallbackTensorMap*, __nv_bfloat16*,
+    const FlashKDATrainingFallbackTensorMap*, float*, float*, long long*, int*, __nv_bfloat16*,
+    __nv_bfloat16*, const FlashKDATrainingFallbackTensorMap*, __nv_bfloat16*, int, int, int, float,
+    float, unsigned long long, unsigned long long, unsigned long long, long long, long long, int,
+    int, long long*, __nv_bfloat16*, unsigned int*, __nv_bfloat16*, __nv_bfloat16*, __nv_bfloat16*,
+    __nv_bfloat16*, float*, __nv_bfloat16*, __nv_bfloat16*, __nv_bfloat16*, float*, __nv_bfloat16*,
+    float*, float*, unsigned int*, int, int, const FlashKDATrainingFallbackTensorMap*);
+__global__ void kernel_flashkda_bf16_fused_m128_unsplit(
+    __nv_bfloat16*, const FlashKDATrainingFallbackTensorMap*, __nv_bfloat16*,
+    const FlashKDATrainingFallbackTensorMap*, __nv_bfloat16*,
+    const FlashKDATrainingFallbackTensorMap*, __nv_bfloat16*,
+    const FlashKDATrainingFallbackTensorMap*, __nv_bfloat16*,
+    const FlashKDATrainingFallbackTensorMap*, float*, float*, long long*, int*, __nv_bfloat16*,
+    __nv_bfloat16*, const FlashKDATrainingFallbackTensorMap*, __nv_bfloat16*, int, int, int, float,
+    float, unsigned long long, unsigned long long, unsigned long long, long long, long long, int,
+    int, long long*, __nv_bfloat16*, unsigned int*, __nv_bfloat16*, __nv_bfloat16*, __nv_bfloat16*,
+    __nv_bfloat16*, float*, __nv_bfloat16*, __nv_bfloat16*, __nv_bfloat16*, float*, __nv_bfloat16*,
+    float*, float*, unsigned int*, int, int, const FlashKDATrainingFallbackTensorMap*);
+__global__ void kernel_flashkda_backward_state_checkpoint_fallback_c32(
+    long long*, long long*, unsigned int*, float*, __nv_bfloat16*, float*, __nv_bfloat16*,
+    __nv_bfloat16*, int, int, int, float, int);
+__global__ void kernel_flashkda_backward_boundary_c32_tcgen_m64(
+    __nv_bfloat16*, float*, float*, long long*, long long*, int*, __nv_bfloat16*, __nv_bfloat16*,
+    __nv_bfloat16*, __nv_bfloat16*, float*, __nv_bfloat16*, __nv_bfloat16*, __nv_bfloat16*, float*,
+    unsigned int*, int, int, float);
+__global__ void kernel_flashkda_backward_boundary_c32_tcgen(
+    __nv_bfloat16*, float*, float*, long long*, long long*, int*, __nv_bfloat16*, __nv_bfloat16*,
+    __nv_bfloat16*, __nv_bfloat16*, float*, __nv_bfloat16*, __nv_bfloat16*, __nv_bfloat16*,
+    unsigned int*, float*, int, int, float);
+__global__ void kernel_flashkda_backward_local_c32_tcgen(
+    __nv_bfloat16*, float*, long long*, int*, int*, int*, __nv_bfloat16*, unsigned int*, float*,
+    __nv_bfloat16*, __nv_bfloat16*, __nv_bfloat16*, __nv_bfloat16*, float*, __nv_bfloat16*,
+    __nv_bfloat16*, __nv_bfloat16*, __nv_bfloat16*, __nv_bfloat16*, __nv_bfloat16*, unsigned int*,
+    __nv_bfloat16*, __nv_bfloat16*, __nv_bfloat16*, float*, float*, __nv_bfloat16*, int, int,
+    float);
+__global__ void kernel_flashkda_backward_map_finalize_c32(
+    __nv_bfloat16*, __nv_bfloat16*, __nv_bfloat16*, float*, __nv_bfloat16*, float*, float*, float*,
+    long long*, int*, int*, int*, __nv_bfloat16*, __nv_bfloat16*, __nv_bfloat16*, float*, float*,
+    __nv_bfloat16*, __nv_bfloat16*, __nv_bfloat16*, __nv_bfloat16*, float*, float*, int, int, float,
+    float);
+
+__global__ void kernel_flashkda_blackwell_prefill_fp32_state_initial(
+    const FlashKDATrainingFallbackTensorMap*, const FlashKDATrainingFallbackTensorMap*,
+    const FlashKDATrainingFallbackTensorMap*, const FlashKDATrainingFallbackTensorMap*,
+    const FlashKDATrainingFallbackTensorMap*, __nv_bfloat16*, float*, float*, long long*, float*,
+    float*, float*, int*, uint8_t*, int, float, int, int, int, int, float);
+
+}  // extern "C"
+
+namespace flashinfer {
+namespace flash_kda_training_fallback {
+
+using flash_kda::CheckCuda;
+using flash_kda::CheckCudaTensor;
+using flash_kda::CheckDtype;
+using flash_kda::CheckDynamicSmemCapacity;
+using flash_kda::CheckFlashKDATarget;
+using flash_kda::EncodeTmaPointers;
+using flash_kda::PackBetaForTmaIfNeeded;
+using flash_kda::TmaPointers;
+
+constexpr int64_t kHeadDim = 128;
+constexpr int32_t kFinalSmemBytes = 226048;
+constexpr int64_t kFinalDescriptorCount = 5;
+constexpr int64_t kFinalDescriptorBytes = kFinalDescriptorCount * sizeof(CUtensorMap);
+constexpr int64_t kFinalWorkspaceBytesPerCta = 10 * 128;
+constexpr int64_t kLowGateTokensPerSplit = 128;
+constexpr int32_t kTapeThreads = 1024;
+constexpr int32_t kTapeSmemBytes = 227968;
+constexpr int32_t kFallbackThreads = 256;
+constexpr int32_t kFallbackSmemBytes = 128;
+constexpr int32_t kBoundaryM64Threads = 288;
+constexpr int32_t kBoundaryM64SmemBytes = 38016;
+constexpr int32_t kBoundaryM128Threads = 512;
+constexpr int32_t kBoundaryM128SmemBytes = 74880;
+constexpr int32_t kLocalThreads = 384;
+constexpr int32_t kLocalSmemBytes = 155136;
+constexpr int32_t kMapFinalizeThreads = 128;
+
+inline void CheckTensor(const TensorView& tensor, const char* name, int32_t device_id,
+                        DLDataType dtype) {
+  CheckCudaTensor(tensor, name, device_id);
+  CheckDtype(tensor, name, dtype);
+}
+
+inline void CheckElements(const TensorView& tensor, const char* name, int64_t elements) {
+  TVM_FFI_ICHECK(tensor.numel() == elements)
+      << name << " must contain " << elements << " elements, got " << tensor.numel();
+}
+
+inline uint32_t CheckedGridX(int64_t blocks, const char* name) {
+  TVM_FFI_ICHECK(blocks > 0 && blocks <= std::numeric_limits<uint32_t>::max())
+      << name << " grid.x is out of range: " << blocks;
+  return static_cast<uint32_t>(blocks);
+}
+
+template <typename Kernel>
+inline void ConfigureDynamicSmem(Kernel kernel, int32_t bytes, int32_t device_id,
+                                 const char* name) {
+  CheckDynamicSmemCapacity(device_id, bytes);
+  CheckCuda(cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, bytes), name);
+}
+
+inline CUtensorMap EncodeFinalTokenMap(const TensorView& tensor, const char* name,
+                                       int64_t total_tokens, int64_t num_heads) {
+  uint64_t global_dim[3] = {kHeadDim, static_cast<uint64_t>(total_tokens),
+                            static_cast<uint64_t>(num_heads)};
+  uint64_t global_strides[2] = {kHeadDim * static_cast<uint64_t>(num_heads) * sizeof(__nv_bfloat16),
+                                kHeadDim * sizeof(__nv_bfloat16)};
+  uint32_t box_dim[3] = {64, 64, 1};
+  uint32_t element_strides[3] = {1, 1, 1};
+  CUtensorMap map{};
+  const CUresult result = cuTensorMapEncodeTiled(
+      &map, CU_TENSOR_MAP_DATA_TYPE_BFLOAT16, 3, tensor.data_ptr(), global_dim, global_strides,
+      box_dim, element_strides, CU_TENSOR_MAP_INTERLEAVE_NONE, CU_TENSOR_MAP_SWIZZLE_128B,
+      CU_TENSOR_MAP_L2_PROMOTION_L2_256B, CU_TENSOR_MAP_FLOAT_OOB_FILL_NONE);
+  TVM_FFI_ICHECK(result == CUDA_SUCCESS)
+      << "cuTensorMapEncodeTiled failed for " << name << " with CUresult=" << int(result);
+  return map;
+}
+
+struct FinalTensorMapWords {
+  uint64_t words[kFinalDescriptorBytes / sizeof(uint64_t)];
+};
+
+static __global__ void PublishFinalTensorMaps(uint64_t* destination, FinalTensorMapWords source) {
+  const uint32_t index = threadIdx.x;
+  if (index < kFinalDescriptorBytes / sizeof(uint64_t)) {
+    destination[index] = source.words[index];
+  }
+}
+
+struct CheckpointTensorMapWords {
+  uint64_t words[sizeof(CUtensorMap) / sizeof(uint64_t)];
+};
+
+static __global__ void PublishCheckpointTensorMap(uint64_t* destination,
+                                                  CheckpointTensorMapWords source) {
+  if (threadIdx.x < sizeof(CUtensorMap) / sizeof(uint64_t)) {
+    destination[threadIdx.x] = source.words[threadIdx.x];
+  }
+}
+
+inline CUtensorMap EncodeCheckpointTensorMap(const TensorView& checkpoint, int64_t total_chunks,
+                                             int64_t num_heads) {
+  uint64_t global_dim[4] = {kHeadDim, kHeadDim, static_cast<uint64_t>(num_heads),
+                            static_cast<uint64_t>(total_chunks)};
+  uint64_t global_strides[3] = {
+      kHeadDim * sizeof(__nv_bfloat16), kHeadDim * kHeadDim * sizeof(__nv_bfloat16),
+      kHeadDim * kHeadDim * static_cast<uint64_t>(num_heads) * sizeof(__nv_bfloat16)};
+  uint32_t box_dim[4] = {64, 128, 1, 1};
+  uint32_t element_strides[4] = {1, 1, 1, 1};
+  CUtensorMap map{};
+  const CUresult result = cuTensorMapEncodeTiled(
+      &map, CU_TENSOR_MAP_DATA_TYPE_BFLOAT16, 4, checkpoint.data_ptr(), global_dim, global_strides,
+      box_dim, element_strides, CU_TENSOR_MAP_INTERLEAVE_NONE, CU_TENSOR_MAP_SWIZZLE_128B,
+      CU_TENSOR_MAP_L2_PROMOTION_NONE, CU_TENSOR_MAP_FLOAT_OOB_FILL_NONE);
+  TVM_FFI_ICHECK(result == CUDA_SUCCESS)
+      << "cuTensorMapEncodeTiled failed for C32 checkpoint with CUresult=" << int(result);
+  return map;
+}
+
+inline TmaPointers PrepareC32TensorMaps(const TensorView& q, const TensorView& k,
+                                        const TensorView& v, const TensorView& g,
+                                        const TensorView& beta_tma, const TensorView& out,
+                                        const TensorView& checkpoint,
+                                        const TensorView& descriptor_storage, int64_t total_chunks,
+                                        int64_t num_heads, int64_t prepare_descriptors,
+                                        cudaStream_t stream) {
+  const TmaPointers pointers = EncodeTmaPointers<128, 32>(
+      q, k, v, g, beta_tma, out, descriptor_storage, prepare_descriptors, stream);
+  if (prepare_descriptors != 0) {
+    const CUtensorMap map = EncodeCheckpointTensorMap(checkpoint, total_chunks, num_heads);
+    CheckpointTensorMapWords words{};
+    std::memcpy(words.words, &map, sizeof(map));
+    auto* bytes = static_cast<unsigned char*>(descriptor_storage.data_ptr());
+    PublishCheckpointTensorMap<<<1, 32, 0, stream>>>(
+        reinterpret_cast<uint64_t*>(bytes + 6 * sizeof(CUtensorMap)), words);
+    CheckCuda(cudaGetLastError(), "PublishCheckpointTensorMap launch");
+  }
+  return pointers;
+}
+
+inline void PrepareFinalTensorMaps(const TensorView& q, const TensorView& k, const TensorView& v,
+                                   const TensorView& g, const TensorView& out,
+                                   const TensorView& descriptor_storage, int64_t total_tokens,
+                                   int64_t num_qk_heads, int64_t num_v_heads,
+                                   int64_t prepare_descriptors, cudaStream_t stream) {
+  if (prepare_descriptors == 0) {
+    return;
+  }
+  std::array<CUtensorMap, kFinalDescriptorCount> host_maps = {
+      EncodeFinalTokenMap(q, "q", total_tokens, num_qk_heads),
+      EncodeFinalTokenMap(k, "k", total_tokens, num_qk_heads),
+      EncodeFinalTokenMap(v, "v", total_tokens, num_v_heads),
+      EncodeFinalTokenMap(g, "g", total_tokens, num_v_heads),
+      EncodeFinalTokenMap(out, "out", total_tokens, num_v_heads),
+  };
+  FinalTensorMapWords words{};
+  std::memcpy(words.words, host_maps.data(), sizeof(host_maps));
+  PublishFinalTensorMaps<<<1, 128, 0, stream>>>(
+      reinterpret_cast<uint64_t*>(descriptor_storage.data_ptr()), words);
+  CheckCuda(cudaGetLastError(), "PublishFinalTensorMaps launch");
+}
+
+inline void LaunchAccurateForward(
+    TensorView q, TensorView k, TensorView v, TensorView g, TensorView beta, TensorView A_log,
+    TensorView dt_bias, TensorView initial_state, TensorView cu_seqlens, TensorView out,
+    TensorView final_state, TensorView descriptor_storage, TensorView tensormap_workspace,
+    TensorView dummy_f32, TensorView dummy_i32, int64_t total_tokens, int64_t num_sequences,
+    int64_t num_qk_heads, int64_t num_v_heads, int64_t final_grid_ctas, int64_t prepare_descriptors,
+    double scale, double lower_bound, int32_t device_id, cudaStream_t stream) {
+  TVM_FFI_ICHECK(descriptor_storage.numel() >= kFinalDescriptorBytes);
+  TVM_FFI_ICHECK(tensormap_workspace.numel() >= final_grid_ctas * kFinalWorkspaceBytesPerCta);
+  PrepareFinalTensorMaps(q, k, v, g, out, descriptor_storage, total_tokens, num_qk_heads,
+                         num_v_heads, prepare_descriptors, stream);
+  ConfigureDynamicSmem(kernel_flashkda_blackwell_prefill_fp32_state_initial, kFinalSmemBytes,
+                       device_id, "cudaFuncSetAttribute(training accurate forward)");
+  auto* maps =
+      reinterpret_cast<const FlashKDATrainingFallbackTensorMap*>(descriptor_storage.data_ptr());
+  kernel_flashkda_blackwell_prefill_fp32_state_initial<<<dim3(final_grid_ctas, 1, 1), 384,
+                                                         kFinalSmemBytes, stream>>>(
+      maps + 0, maps + 1, maps + 2, maps + 3, maps + 4,
+      reinterpret_cast<__nv_bfloat16*>(beta.data_ptr()), reinterpret_cast<float*>(A_log.data_ptr()),
+      reinterpret_cast<float*>(dt_bias.data_ptr()),
+      reinterpret_cast<long long*>(cu_seqlens.data_ptr()),
+      reinterpret_cast<float*>(initial_state.data_ptr()),
+      reinterpret_cast<float*>(final_state.data_ptr()),
+      reinterpret_cast<float*>(dummy_f32.data_ptr()), reinterpret_cast<int*>(dummy_i32.data_ptr()),
+      reinterpret_cast<uint8_t*>(tensormap_workspace.data_ptr()), 0, static_cast<float>(scale),
+      static_cast<int>(num_sequences), static_cast<int>(num_qk_heads),
+      static_cast<int>(num_v_heads), static_cast<int>(num_sequences * num_v_heads),
+      static_cast<float>(lower_bound));
+  CheckCuda(cudaGetLastError(), "training accurate forward launch");
+}
+
+void RunTrainingRowForward(
+    TensorView q, TensorView k, TensorView v, TensorView g, TensorView beta, TensorView A_log,
+    TensorView dt_bias, TensorView initial_state, TensorView cu_seqlens, TensorView out,
+    TensorView final_state, TensorView q_norm, TensorView k_norm, TensorView decay,
+    TensorView beta_active, TensorView checkpoint, TensorView final_descriptor_storage,
+    TensorView final_tensormap_workspace, TensorView dummy_f32, TensorView dummy_i32,
+    int64_t total_tokens, int64_t num_sequences, int64_t num_heads, int64_t final_grid_ctas,
+    int64_t prepare_final_descriptors, double scale, double lower_bound, int64_t cuda_stream) {
+  const int32_t device_id = q.device().device_id;
+  ffi::CUDADeviceGuard device_guard(device_id);
+  CheckFlashKDATarget(device_id);
+  TVM_FFI_ICHECK(total_tokens > 0 && num_sequences > 0 && num_heads > 0);
+  const cudaStream_t stream = reinterpret_cast<cudaStream_t>(static_cast<uintptr_t>(cuda_stream));
+  const dim3 preprocess_grid(total_tokens, num_heads, 1);
+  kernel_flashkda_backward_preprocess<<<preprocess_grid, 32, 0, stream>>>(
+      reinterpret_cast<__nv_bfloat16*>(q.data_ptr()),
+      reinterpret_cast<__nv_bfloat16*>(k.data_ptr()),
+      reinterpret_cast<__nv_bfloat16*>(g.data_ptr()),
+      reinterpret_cast<__nv_bfloat16*>(beta.data_ptr()), reinterpret_cast<float*>(A_log.data_ptr()),
+      reinterpret_cast<float*>(dt_bias.data_ptr()), reinterpret_cast<float*>(q_norm.data_ptr()),
+      reinterpret_cast<float*>(k_norm.data_ptr()), reinterpret_cast<float*>(decay.data_ptr()),
+      reinterpret_cast<float*>(beta_active.data_ptr()), static_cast<int>(total_tokens),
+      static_cast<int>(num_heads), static_cast<float>(lower_bound));
+  CheckCuda(cudaGetLastError(), "row training preprocess launch");
+  const int64_t row_grid = num_sequences * num_heads * kHeadDim;
+  kernel_flashkda_backward_checkpoint<<<static_cast<uint32_t>(row_grid), 32, 0, stream>>>(
+      reinterpret_cast<float*>(k_norm.data_ptr()), reinterpret_cast<float*>(decay.data_ptr()),
+      reinterpret_cast<float*>(beta_active.data_ptr()),
+      reinterpret_cast<__nv_bfloat16*>(v.data_ptr()),
+      reinterpret_cast<float*>(initial_state.data_ptr()),
+      reinterpret_cast<long long*>(cu_seqlens.data_ptr()),
+      reinterpret_cast<float*>(checkpoint.data_ptr()), static_cast<int>(num_sequences),
+      static_cast<int>(num_heads));
+  CheckCuda(cudaGetLastError(), "row training checkpoint launch");
+  LaunchAccurateForward(q, k, v, g, beta, A_log, dt_bias, initial_state, cu_seqlens, out,
+                        final_state, final_descriptor_storage, final_tensormap_workspace, dummy_f32,
+                        dummy_i32, total_tokens, num_sequences, num_heads, num_heads,
+                        final_grid_ctas, prepare_final_descriptors, scale, lower_bound, device_id,
+                        stream);
+}
+
+void RunTrainingRowBackward(TensorView q, TensorView k, TensorView v, TensorView g,
+                            TensorView A_log, TensorView dt_bias, TensorView initial_state,
+                            TensorView do_tensor, TensorView dfinal_state, TensorView cu_seqlens,
+                            TensorView q_norm, TensorView k_norm, TensorView decay,
+                            TensorView beta_active, TensorView checkpoint, TensorView dq_normalized,
+                            TensorView dk_normalized, TensorView dlog_decay,
+                            TensorView dbeta_active, TensorView dq, TensorView dk, TensorView dv,
+                            TensorView dg, TensorView dbeta, TensorView dA_log, TensorView ddt_bias,
+                            TensorView dinitial_state, int64_t total_tokens, int64_t num_sequences,
+                            int64_t num_heads, double scale, double lower_bound,
+                            int64_t cuda_stream) {
+  const int32_t device_id = q.device().device_id;
+  ffi::CUDADeviceGuard device_guard(device_id);
+  CheckFlashKDATarget(device_id);
+  const cudaStream_t stream = reinterpret_cast<cudaStream_t>(static_cast<uintptr_t>(cuda_stream));
+  CheckCuda(cudaMemsetAsync(dA_log.data_ptr(), 0, dA_log.numel() * sizeof(float), stream),
+            "clear row dA_log");
+  CheckCuda(cudaMemsetAsync(ddt_bias.data_ptr(), 0, ddt_bias.numel() * sizeof(float), stream),
+            "clear row ddt_bias");
+  CheckCuda(
+      cudaMemsetAsync(dq_normalized.data_ptr(), 0, dq_normalized.numel() * sizeof(float), stream),
+      "clear row dq_normalized");
+  CheckCuda(
+      cudaMemsetAsync(dk_normalized.data_ptr(), 0, dk_normalized.numel() * sizeof(float), stream),
+      "clear row dk_normalized");
+  CheckCuda(cudaMemsetAsync(dlog_decay.data_ptr(), 0, dlog_decay.numel() * sizeof(float), stream),
+            "clear row dlog_decay");
+  CheckCuda(
+      cudaMemsetAsync(dbeta_active.data_ptr(), 0, dbeta_active.numel() * sizeof(float), stream),
+      "clear row dbeta_active");
+  const int64_t row_grid = num_sequences * num_heads * kHeadDim;
+  kernel_flashkda_backward_reverse_rows<<<static_cast<uint32_t>(row_grid), 32, 0, stream>>>(
+      reinterpret_cast<float*>(q_norm.data_ptr()), reinterpret_cast<float*>(k_norm.data_ptr()),
+      reinterpret_cast<float*>(decay.data_ptr()), reinterpret_cast<float*>(beta_active.data_ptr()),
+      reinterpret_cast<__nv_bfloat16*>(v.data_ptr()),
+      reinterpret_cast<__nv_bfloat16*>(do_tensor.data_ptr()),
+      reinterpret_cast<float*>(initial_state.data_ptr()),
+      reinterpret_cast<float*>(dfinal_state.data_ptr()),
+      reinterpret_cast<long long*>(cu_seqlens.data_ptr()),
+      reinterpret_cast<float*>(checkpoint.data_ptr()),
+      reinterpret_cast<float*>(dq_normalized.data_ptr()),
+      reinterpret_cast<float*>(dk_normalized.data_ptr()),
+      reinterpret_cast<float*>(dlog_decay.data_ptr()),
+      reinterpret_cast<float*>(dbeta_active.data_ptr()),
+      reinterpret_cast<__nv_bfloat16*>(dv.data_ptr()),
+      reinterpret_cast<float*>(dinitial_state.data_ptr()), static_cast<int>(num_sequences),
+      static_cast<int>(num_heads), static_cast<float>(scale));
+  CheckCuda(cudaGetLastError(), "row training reverse launch");
+  const dim3 token_grid(total_tokens, num_heads, 1);
+  kernel_flashkda_backward_finalize_tokens<<<token_grid, 32, 0, stream>>>(
+      reinterpret_cast<__nv_bfloat16*>(q.data_ptr()),
+      reinterpret_cast<__nv_bfloat16*>(k.data_ptr()),
+      reinterpret_cast<__nv_bfloat16*>(g.data_ptr()),
+      reinterpret_cast<float*>(beta_active.data_ptr()), reinterpret_cast<float*>(A_log.data_ptr()),
+      reinterpret_cast<float*>(dt_bias.data_ptr()), reinterpret_cast<float*>(q_norm.data_ptr()),
+      reinterpret_cast<float*>(k_norm.data_ptr()),
+      reinterpret_cast<float*>(dq_normalized.data_ptr()),
+      reinterpret_cast<float*>(dk_normalized.data_ptr()),
+      reinterpret_cast<float*>(dlog_decay.data_ptr()),
+      reinterpret_cast<float*>(dbeta_active.data_ptr()),
+      reinterpret_cast<__nv_bfloat16*>(dq.data_ptr()),
+      reinterpret_cast<__nv_bfloat16*>(dk.data_ptr()),
+      reinterpret_cast<__nv_bfloat16*>(dg.data_ptr()),
+      reinterpret_cast<__nv_bfloat16*>(dbeta.data_ptr()), static_cast<int>(num_heads),
+      static_cast<float>(lower_bound));
+  CheckCuda(cudaGetLastError(), "row training finalize launch");
+  ConfigureDynamicSmem(kernel_flashkda_backward_gate_reduce_split, 128, device_id,
+                       "cudaFuncSetAttribute(row gate reduce)");
+  const int64_t splits = (total_tokens + kLowGateTokensPerSplit - 1) / kLowGateTokensPerSplit;
+  kernel_flashkda_backward_gate_reduce_split<<<dim3(num_heads, splits, 1), 128, 128, stream>>>(
+      reinterpret_cast<float*>(dlog_decay.data_ptr()),
+      reinterpret_cast<__nv_bfloat16*>(g.data_ptr()), reinterpret_cast<float*>(dt_bias.data_ptr()),
+      reinterpret_cast<float*>(dA_log.data_ptr()), reinterpret_cast<float*>(ddt_bias.data_ptr()),
+      static_cast<int>(total_tokens), static_cast<int>(num_heads),
+      static_cast<int>(kLowGateTokensPerSplit));
+  CheckCuda(cudaGetLastError(), "row training gate reduce launch");
+}
+
+void RunTrainingC32Forward(
+    TensorView q_native, TensorView k_native, TensorView q, TensorView k, TensorView v,
+    TensorView g, TensorView beta, TensorView beta_tma, TensorView A_log, TensorView dt_bias,
+    TensorView initial_state, TensorView cu_seqlens, TensorView work_items, TensorView seq_order,
+    TensorView cu_chunk_offsets, TensorView descriptor_storage, TensorView out,
+    TensorView final_state, TensorView chunk_state, TensorView state_checkpoint_needed,
+    TensorView tape_qd, TensorView tape_kd, TensorView tape_kr, TensorView tape_j,
+    TensorView tape_restore_factor, TensorView tape_e, TensorView tape_x, TensorView tape_r,
+    TensorView norm_inv, TensorView decay, TensorView beta_active, TensorView zero_workspace,
+    TensorView final_output_scratch, TensorView final_descriptor_storage,
+    TensorView final_tensormap_workspace, TensorView dummy_f32, TensorView dummy_i32,
+    int64_t total_tokens, int64_t num_sequences, int64_t num_qk_heads, int64_t num_heads,
+    int64_t total_chunks, int64_t num_work_items, int64_t use_split_work_items, int64_t grouped,
+    int64_t prepare_descriptors, int64_t prepare_final_descriptors, int64_t final_grid_ctas,
+    double scale, double lower_bound, int64_t cuda_stream) {
+  const int32_t device_id = q_native.device().device_id;
+  ffi::CUDADeviceGuard device_guard(device_id);
+  CheckFlashKDATarget(device_id);
+  TVM_FFI_ICHECK(total_tokens > 0 && num_sequences > 0 && num_qk_heads > 0 && num_heads > 0);
+  TVM_FFI_ICHECK(total_chunks > 0 && num_work_items > 0);
+  TVM_FFI_ICHECK(use_split_work_items == 0 || use_split_work_items == 1);
+  TVM_FFI_ICHECK(grouped == 0 || grouped == 1);
+  const cudaStream_t stream = reinterpret_cast<cudaStream_t>(static_cast<uintptr_t>(cuda_stream));
+
+  if (grouped != 0) {
+    kernel_flashkda_grouped_qk_expand<<<
+        dim3(CheckedGridX((total_tokens + 31) / 32, "grouped expand"), num_heads, 1), 128, 0,
+        stream>>>(reinterpret_cast<__nv_bfloat16*>(q_native.data_ptr()),
+                  reinterpret_cast<__nv_bfloat16*>(k_native.data_ptr()),
+                  reinterpret_cast<__nv_bfloat16*>(q.data_ptr()),
+                  reinterpret_cast<__nv_bfloat16*>(k.data_ptr()), static_cast<int>(total_tokens),
+                  static_cast<int>(num_qk_heads), static_cast<int>(num_heads));
+    CheckCuda(cudaGetLastError(), "grouped C32 Q/K expand launch");
+  }
+
+  PackBetaForTmaIfNeeded(beta, beta_tma, num_heads, num_heads, stream);
+  const TmaPointers tma =
+      PrepareC32TensorMaps(q, k, v, g, beta_tma, out, chunk_state, descriptor_storage, total_chunks,
+                           num_heads, prepare_descriptors, stream);
+  auto* descriptor_bytes = static_cast<unsigned char*>(descriptor_storage.data_ptr());
+  auto* checkpoint_map = reinterpret_cast<const FlashKDATrainingFallbackTensorMap*>(
+      descriptor_bytes + 6 * sizeof(CUtensorMap));
+
+#define FLASHINFER_LAUNCH_C32_TAPE(KERNEL, GRID, SCHEDULE)                                       \
+  KERNEL<<<CheckedGridX(GRID, "training C32 tape"), kTapeThreads, kTapeSmemBytes, stream>>>(     \
+      reinterpret_cast<__nv_bfloat16*>(q.data_ptr()),                                            \
+      reinterpret_cast<const FlashKDATrainingFallbackTensorMap*>(tma.q),                         \
+      reinterpret_cast<__nv_bfloat16*>(k.data_ptr()),                                            \
+      reinterpret_cast<const FlashKDATrainingFallbackTensorMap*>(tma.k),                         \
+      reinterpret_cast<__nv_bfloat16*>(v.data_ptr()),                                            \
+      reinterpret_cast<const FlashKDATrainingFallbackTensorMap*>(tma.v),                         \
+      reinterpret_cast<__nv_bfloat16*>(g.data_ptr()),                                            \
+      reinterpret_cast<const FlashKDATrainingFallbackTensorMap*>(tma.g),                         \
+      reinterpret_cast<__nv_bfloat16*>(beta.data_ptr()),                                         \
+      reinterpret_cast<const FlashKDATrainingFallbackTensorMap*>(tma.beta),                      \
+      reinterpret_cast<float*>(A_log.data_ptr()), reinterpret_cast<float*>(dt_bias.data_ptr()),  \
+      reinterpret_cast<long long*>(cu_seqlens.data_ptr()), reinterpret_cast<int*>(SCHEDULE),     \
+      reinterpret_cast<__nv_bfloat16*>(q.data_ptr()),                                            \
+      reinterpret_cast<__nv_bfloat16*>(out.data_ptr()),                                          \
+      reinterpret_cast<const FlashKDATrainingFallbackTensorMap*>(tma.out),                       \
+      reinterpret_cast<__nv_bfloat16*>(out.data_ptr()), static_cast<int>(num_heads), 1, 0,       \
+      static_cast<float>(scale), static_cast<float>(lower_bound), 0ULL, 0ULL, 0ULL, 0LL, 0LL, 0, \
+      0, reinterpret_cast<long long*>(cu_chunk_offsets.data_ptr()),                              \
+      reinterpret_cast<__nv_bfloat16*>(chunk_state.data_ptr()),                                  \
+      reinterpret_cast<unsigned int*>(state_checkpoint_needed.data_ptr()),                       \
+      reinterpret_cast<__nv_bfloat16*>(tape_qd.data_ptr()),                                      \
+      reinterpret_cast<__nv_bfloat16*>(tape_kd.data_ptr()),                                      \
+      reinterpret_cast<__nv_bfloat16*>(tape_kr.data_ptr()),                                      \
+      reinterpret_cast<__nv_bfloat16*>(tape_j.data_ptr()),                                       \
+      reinterpret_cast<float*>(tape_restore_factor.data_ptr()),                                  \
+      reinterpret_cast<__nv_bfloat16*>(tape_e.data_ptr()),                                       \
+      reinterpret_cast<__nv_bfloat16*>(tape_x.data_ptr()),                                       \
+      reinterpret_cast<__nv_bfloat16*>(tape_r.data_ptr()),                                       \
+      reinterpret_cast<float*>(norm_inv.data_ptr()),                                             \
+      reinterpret_cast<__nv_bfloat16*>(decay.data_ptr()),                                        \
+      reinterpret_cast<float*>(beta_active.data_ptr()),                                          \
+      reinterpret_cast<float*>(initial_state.data_ptr()),                                        \
+      reinterpret_cast<unsigned int*>(zero_workspace.data_ptr()),                                \
+      static_cast<int>(zero_workspace.numel()), static_cast<int>(num_sequences), checkpoint_map)
+
+  if (use_split_work_items != 0) {
+    ConfigureDynamicSmem(kernel_flashkda_bf16_fused_m128, kTapeSmemBytes, device_id,
+                         "cudaFuncSetAttribute(training split C32 tape)");
+    FLASHINFER_LAUNCH_C32_TAPE(kernel_flashkda_bf16_fused_m128, num_work_items,
+                               work_items.data_ptr());
+  } else {
+    ConfigureDynamicSmem(kernel_flashkda_bf16_fused_m128_unsplit, kTapeSmemBytes, device_id,
+                         "cudaFuncSetAttribute(training unsplit C32 tape)");
+    FLASHINFER_LAUNCH_C32_TAPE(kernel_flashkda_bf16_fused_m128_unsplit, num_sequences * num_heads,
+                               seq_order.data_ptr());
+  }
+#undef FLASHINFER_LAUNCH_C32_TAPE
+  CheckCuda(cudaGetLastError(), "training C32 tape launch");
+
+  ConfigureDynamicSmem(kernel_flashkda_backward_state_checkpoint_fallback_c32, kFallbackSmemBytes,
+                       device_id, "cudaFuncSetAttribute(training C32 state fallback)");
+  kernel_flashkda_backward_state_checkpoint_fallback_c32<<<1, kFallbackThreads, kFallbackSmemBytes,
+                                                           stream>>>(
+      reinterpret_cast<long long*>(cu_seqlens.data_ptr()),
+      reinterpret_cast<long long*>(cu_chunk_offsets.data_ptr()),
+      reinterpret_cast<unsigned int*>(state_checkpoint_needed.data_ptr()),
+      reinterpret_cast<float*>(initial_state.data_ptr()),
+      reinterpret_cast<__nv_bfloat16*>(tape_kr.data_ptr()),
+      reinterpret_cast<float*>(tape_restore_factor.data_ptr()),
+      reinterpret_cast<__nv_bfloat16*>(tape_r.data_ptr()),
+      reinterpret_cast<__nv_bfloat16*>(chunk_state.data_ptr()), static_cast<int>(num_sequences),
+      static_cast<int>(num_heads), static_cast<int>(use_split_work_items != 0 ? num_work_items : 0),
+      static_cast<float>(lower_bound), static_cast<int>(use_split_work_items));
+  CheckCuda(cudaGetLastError(), "training C32 state fallback launch");
+
+  LaunchAccurateForward(q_native, k_native, v, g, beta, A_log, dt_bias, initial_state, cu_seqlens,
+                        final_output_scratch, final_state, final_descriptor_storage,
+                        final_tensormap_workspace, dummy_f32, dummy_i32, total_tokens,
+                        num_sequences, num_qk_heads, num_heads, final_grid_ctas,
+                        prepare_final_descriptors, scale, lower_bound, device_id, stream);
+}
+
+void RunTrainingC32Backward(
+    TensorView q, TensorView k, TensorView v, TensorView g, TensorView A_log, TensorView dt_bias,
+    TensorView initial_state, TensorView do_tensor, TensorView dfinal_state, TensorView cu_seqlens,
+    TensorView cu_chunk_offsets, TensorView boundary_work_items, TensorView consumer_chunk_order,
+    TensorView chunk_sequence, TensorView chunk_index, TensorView chunk_pair_start,
+    TensorView chunk_state, TensorView state_checkpoint_needed, TensorView tape_qd,
+    TensorView tape_kd, TensorView tape_kr, TensorView tape_j, TensorView tape_restore_factor,
+    TensorView tape_e, TensorView tape_x, TensorView tape_r, TensorView norm_inv, TensorView decay,
+    TensorView beta_active, TensorView chunk_dh, TensorView chunk_dr, TensorView chunk_dx,
+    TensorView boundary_ready, TensorView grad_qd, TensorView grad_kd, TensorView grad_ki,
+    TensorView dlog_decay, TensorView dbeta_active, TensorView dq_value, TensorView dk_value,
+    TensorView dv, TensorView dg, TensorView dbeta, TensorView dA_log, TensorView ddt_bias,
+    TensorView dinitial_state, TensorView dq_native, TensorView dk_native, int64_t total_tokens,
+    int64_t num_sequences, int64_t num_qk_heads, int64_t num_heads, int64_t total_chunks,
+    int64_t total_pairs, int64_t boundary_count, int64_t split_boundary, int64_t grouped,
+    double scale, double lower_bound, int64_t cuda_stream) {
+  const int32_t device_id = q.device().device_id;
+  ffi::CUDADeviceGuard device_guard(device_id);
+  CheckFlashKDATarget(device_id);
+  TVM_FFI_ICHECK(total_tokens > 0 && num_sequences > 0 && num_heads > 0 && total_chunks > 0);
+  TVM_FFI_ICHECK(total_pairs > 0 && boundary_count > 0);
+  TVM_FFI_ICHECK(split_boundary == 0 || split_boundary == 1);
+  TVM_FFI_ICHECK(grouped == 0 || grouped == 1);
+  const cudaStream_t stream = reinterpret_cast<cudaStream_t>(static_cast<uintptr_t>(cuda_stream));
+  CheckCuda(cudaMemsetAsync(dA_log.data_ptr(), 0, dA_log.numel() * sizeof(float), stream),
+            "clear training C32 dA_log");
+  CheckCuda(cudaMemsetAsync(ddt_bias.data_ptr(), 0, ddt_bias.numel() * sizeof(float), stream),
+            "clear training C32 ddt_bias");
+  CheckCuda(cudaMemsetAsync(boundary_ready.data_ptr(), 0,
+                            boundary_ready.numel() * sizeof(unsigned int), stream),
+            "clear training C32 boundary_ready");
+
+  if (split_boundary != 0) {
+    ConfigureDynamicSmem(kernel_flashkda_backward_boundary_c32_tcgen_m64, kBoundaryM64SmemBytes,
+                         device_id, "cudaFuncSetAttribute(training C32 boundary M64)");
+    kernel_flashkda_backward_boundary_c32_tcgen_m64<<<
+        CheckedGridX(boundary_count * 2, "training C32 boundary M64"), kBoundaryM64Threads,
+        kBoundaryM64SmemBytes, stream>>>(reinterpret_cast<__nv_bfloat16*>(do_tensor.data_ptr()),
+                                         reinterpret_cast<float*>(dfinal_state.data_ptr()),
+                                         reinterpret_cast<float*>(beta_active.data_ptr()),
+                                         reinterpret_cast<long long*>(cu_seqlens.data_ptr()),
+                                         reinterpret_cast<long long*>(cu_chunk_offsets.data_ptr()),
+                                         reinterpret_cast<int*>(boundary_work_items.data_ptr()),
+                                         reinterpret_cast<__nv_bfloat16*>(tape_qd.data_ptr()),
+                                         reinterpret_cast<__nv_bfloat16*>(tape_kd.data_ptr()),
+                                         reinterpret_cast<__nv_bfloat16*>(tape_kr.data_ptr()),
+                                         reinterpret_cast<__nv_bfloat16*>(tape_j.data_ptr()),
+                                         reinterpret_cast<float*>(tape_restore_factor.data_ptr()),
+                                         reinterpret_cast<__nv_bfloat16*>(chunk_dh.data_ptr()),
+                                         reinterpret_cast<__nv_bfloat16*>(chunk_dr.data_ptr()),
+                                         reinterpret_cast<__nv_bfloat16*>(chunk_dx.data_ptr()),
+                                         reinterpret_cast<float*>(dinitial_state.data_ptr()),
+                                         reinterpret_cast<unsigned int*>(boundary_ready.data_ptr()),
+                                         static_cast<int>(num_heads), 0,
+                                         static_cast<float>(lower_bound));
+    CheckCuda(cudaGetLastError(), "training C32 boundary M64 launch");
+  } else {
+    ConfigureDynamicSmem(kernel_flashkda_backward_boundary_c32_tcgen, kBoundaryM128SmemBytes,
+                         device_id, "cudaFuncSetAttribute(training C32 boundary M128)");
+    kernel_flashkda_backward_boundary_c32_tcgen<<<
+        CheckedGridX(boundary_count, "training C32 boundary M128"), kBoundaryM128Threads,
+        kBoundaryM128SmemBytes, stream>>>(
+        reinterpret_cast<__nv_bfloat16*>(do_tensor.data_ptr()),
+        reinterpret_cast<float*>(dfinal_state.data_ptr()),
+        reinterpret_cast<float*>(beta_active.data_ptr()),
+        reinterpret_cast<long long*>(cu_seqlens.data_ptr()),
+        reinterpret_cast<long long*>(cu_chunk_offsets.data_ptr()),
+        reinterpret_cast<int*>(boundary_work_items.data_ptr()),
+        reinterpret_cast<__nv_bfloat16*>(tape_qd.data_ptr()),
+        reinterpret_cast<__nv_bfloat16*>(tape_kd.data_ptr()),
+        reinterpret_cast<__nv_bfloat16*>(tape_kr.data_ptr()),
+        reinterpret_cast<__nv_bfloat16*>(tape_j.data_ptr()),
+        reinterpret_cast<float*>(tape_restore_factor.data_ptr()),
+        reinterpret_cast<__nv_bfloat16*>(chunk_dh.data_ptr()),
+        reinterpret_cast<__nv_bfloat16*>(chunk_dr.data_ptr()),
+        reinterpret_cast<__nv_bfloat16*>(chunk_dx.data_ptr()),
+        reinterpret_cast<unsigned int*>(boundary_ready.data_ptr()),
+        reinterpret_cast<float*>(dinitial_state.data_ptr()), static_cast<int>(num_heads), 0,
+        static_cast<float>(lower_bound));
+    CheckCuda(cudaGetLastError(), "training C32 boundary M128 launch");
+  }
+
+  ConfigureDynamicSmem(kernel_flashkda_backward_local_c32_tcgen, kLocalSmemBytes, device_id,
+                       "cudaFuncSetAttribute(training C32 local)");
+  kernel_flashkda_backward_local_c32_tcgen<<<CheckedGridX(total_chunks * num_heads,
+                                                          "training C32 local"),
+                                             kLocalThreads, kLocalSmemBytes, stream>>>(
+      reinterpret_cast<__nv_bfloat16*>(do_tensor.data_ptr()),
+      reinterpret_cast<float*>(beta_active.data_ptr()),
+      reinterpret_cast<long long*>(cu_seqlens.data_ptr()),
+      reinterpret_cast<int*>(consumer_chunk_order.data_ptr()),
+      reinterpret_cast<int*>(chunk_sequence.data_ptr()),
+      reinterpret_cast<int*>(chunk_index.data_ptr()),
+      reinterpret_cast<__nv_bfloat16*>(chunk_state.data_ptr()),
+      reinterpret_cast<unsigned int*>(state_checkpoint_needed.data_ptr()),
+      reinterpret_cast<float*>(initial_state.data_ptr()),
+      reinterpret_cast<__nv_bfloat16*>(tape_qd.data_ptr()),
+      reinterpret_cast<__nv_bfloat16*>(tape_kd.data_ptr()),
+      reinterpret_cast<__nv_bfloat16*>(tape_kr.data_ptr()),
+      reinterpret_cast<__nv_bfloat16*>(tape_j.data_ptr()),
+      reinterpret_cast<float*>(tape_restore_factor.data_ptr()),
+      reinterpret_cast<__nv_bfloat16*>(tape_e.data_ptr()),
+      reinterpret_cast<__nv_bfloat16*>(tape_x.data_ptr()),
+      reinterpret_cast<__nv_bfloat16*>(tape_r.data_ptr()),
+      reinterpret_cast<__nv_bfloat16*>(chunk_dh.data_ptr()),
+      reinterpret_cast<__nv_bfloat16*>(chunk_dr.data_ptr()),
+      reinterpret_cast<__nv_bfloat16*>(chunk_dx.data_ptr()),
+      reinterpret_cast<unsigned int*>(boundary_ready.data_ptr()),
+      reinterpret_cast<__nv_bfloat16*>(grad_qd.data_ptr()),
+      reinterpret_cast<__nv_bfloat16*>(grad_kd.data_ptr()),
+      reinterpret_cast<__nv_bfloat16*>(grad_ki.data_ptr()),
+      reinterpret_cast<float*>(dlog_decay.data_ptr()),
+      reinterpret_cast<float*>(dbeta_active.data_ptr()),
+      reinterpret_cast<__nv_bfloat16*>(dv.data_ptr()), static_cast<int>(num_heads), 0,
+      static_cast<float>(lower_bound));
+  CheckCuda(cudaGetLastError(), "training C32 local launch");
+
+  const int64_t num_pair_heads = total_pairs * num_heads;
+  kernel_flashkda_backward_map_finalize_c32<<<CheckedGridX(((num_pair_heads + 3) / 4) * 4,
+                                                           "training C32 map finalize"),
+                                              kMapFinalizeThreads, 0, stream>>>(
+      reinterpret_cast<__nv_bfloat16*>(decay.data_ptr()),
+      reinterpret_cast<__nv_bfloat16*>(q.data_ptr()),
+      reinterpret_cast<__nv_bfloat16*>(k.data_ptr()), reinterpret_cast<float*>(norm_inv.data_ptr()),
+      reinterpret_cast<__nv_bfloat16*>(g.data_ptr()),
+      reinterpret_cast<float*>(beta_active.data_ptr()), reinterpret_cast<float*>(A_log.data_ptr()),
+      reinterpret_cast<float*>(dt_bias.data_ptr()),
+      reinterpret_cast<long long*>(cu_seqlens.data_ptr()),
+      reinterpret_cast<int*>(chunk_sequence.data_ptr()),
+      reinterpret_cast<int*>(chunk_index.data_ptr()),
+      reinterpret_cast<int*>(chunk_pair_start.data_ptr()),
+      reinterpret_cast<__nv_bfloat16*>(grad_qd.data_ptr()),
+      reinterpret_cast<__nv_bfloat16*>(grad_kd.data_ptr()),
+      reinterpret_cast<__nv_bfloat16*>(grad_ki.data_ptr()),
+      reinterpret_cast<float*>(dlog_decay.data_ptr()),
+      reinterpret_cast<float*>(dbeta_active.data_ptr()),
+      reinterpret_cast<__nv_bfloat16*>(dq_value.data_ptr()),
+      reinterpret_cast<__nv_bfloat16*>(dk_value.data_ptr()),
+      reinterpret_cast<__nv_bfloat16*>(dg.data_ptr()),
+      reinterpret_cast<__nv_bfloat16*>(dbeta.data_ptr()),
+      reinterpret_cast<float*>(dA_log.data_ptr()), reinterpret_cast<float*>(ddt_bias.data_ptr()),
+      static_cast<int>(num_pair_heads), static_cast<int>(num_heads), static_cast<float>(scale),
+      static_cast<float>(lower_bound));
+  CheckCuda(cudaGetLastError(), "training C32 map finalize launch");
+
+  if (grouped != 0) {
+    kernel_flashkda_grouped_qk_reduce<<<
+        dim3(CheckedGridX((total_tokens + 15) / 16, "grouped reduce"), num_qk_heads, 1), 128, 0,
+        stream>>>(reinterpret_cast<__nv_bfloat16*>(dq_value.data_ptr()),
+                  reinterpret_cast<__nv_bfloat16*>(dk_value.data_ptr()),
+                  reinterpret_cast<__nv_bfloat16*>(dq_native.data_ptr()),
+                  reinterpret_cast<__nv_bfloat16*>(dk_native.data_ptr()),
+                  static_cast<int>(total_tokens), static_cast<int>(num_qk_heads),
+                  static_cast<int>(num_heads));
+    CheckCuda(cudaGetLastError(), "grouped C32 Q/K reduce launch");
+  }
+}
+
+}  // namespace flash_kda_training_fallback
+}  // namespace flashinfer
+
+TVM_FFI_DLL_EXPORT_TYPED_FUNC(run_training_row_forward,
+                              flashinfer::flash_kda_training_fallback::RunTrainingRowForward);
+TVM_FFI_DLL_EXPORT_TYPED_FUNC(run_training_row_backward,
+                              flashinfer::flash_kda_training_fallback::RunTrainingRowBackward);
+TVM_FFI_DLL_EXPORT_TYPED_FUNC(run_training_c32_forward,
+                              flashinfer::flash_kda_training_fallback::RunTrainingC32Forward);
+TVM_FFI_DLL_EXPORT_TYPED_FUNC(run_training_c32_backward,
+                              flashinfer::flash_kda_training_fallback::RunTrainingC32Backward);

--- a/csrc/kda/flashkda_training_final_state.cu
+++ b/csrc/kda/flashkda_training_final_state.cu
@@ -1,0 +1,4918 @@
+typedef signed char int8_t;
+typedef unsigned char uint8_t;
+typedef unsigned short uint16_t;
+typedef unsigned int uint32_t;
+typedef unsigned long long uint64_t;
+typedef signed int int32_t;
+typedef short int int16_t;
+struct __align__(128) LoomTensorMap {
+  uint64_t opaque[16];
+};
+template <int N>
+struct __align__(128) LoomTensorMapPack {
+  LoomTensorMap maps[N];
+};
+
+typedef struct __align__(64) {
+  uint64_t opaque[16];
+} CUtensorMap;
+
+#include <cuda_bf16.h>
+#include <math_constants.h>
+
+__device__ __forceinline__ uint32_t elect_sync() {
+  uint32_t pred = 0;
+  asm volatile(
+      "{\n\t"
+      ".reg .pred %%px;\n\t"
+      "elect.sync _|%%px, %1;\n\t"
+      "@%%px mov.s32 %0, 1;\n\t"
+      "}\n"
+      : "+r"(pred)
+      : "r"(0xFFFFFFFF));
+  return pred;
+}
+
+__device__ __forceinline__ void mbarrier_init(int mbar_addr, int count) {
+  asm volatile("mbarrier.init.shared::cta.b64 [%0], %1;" ::"r"(mbar_addr), "r"(count));
+}
+
+__device__ __forceinline__ uint32_t mbarrier_try_wait(int mbar_addr, int phase) {
+  uint32_t token;
+  asm volatile(
+      "{\n\t"
+      ".reg .pred P1;\n\t"
+      "mbarrier.try_wait.parity.acquire.cta.shared::cta.b64"
+      " P1, [%1], %2;\n\t"
+      "selp.u32 %0, 1, 0, P1;\n\t"
+      "}\n"
+      : "=r"(token)
+      : "r"(mbar_addr), "r"(phase)
+      : "memory");
+  return token;
+}
+
+__device__ __forceinline__ uint32_t mbarrier_try_wait_cluster(int mbar_addr, int phase) {
+  uint32_t token;
+  asm volatile(
+      "{\n\t"
+      ".reg .pred P1;\n\t"
+      "mbarrier.try_wait.parity.acquire.cluster.shared::cta.b64"
+      " P1, [%1], %2;\n\t"
+      "selp.u32 %0, 1, 0, P1;\n\t"
+      "}\n"
+      : "=r"(token)
+      : "r"(mbar_addr), "r"(phase)
+      : "memory");
+  return token;
+}
+
+__device__ __forceinline__ void mbarrier_wait(int mbar_addr, int phase) {
+  uint32_t ticks = 0x989680;
+  asm volatile(
+      "{\n\t"
+      ".reg .pred P1;\n\t"
+      "LAB_WAIT:\n\t"
+      "mbarrier.try_wait.parity.acquire.cta.shared::cta.b64"
+      " P1, [%0], %1, %2;\n\t"
+      "@P1 bra.uni DONE;\n\t"
+      "bra.uni LAB_WAIT;\n\t"
+      "DONE:\n\t"
+      "}\n" ::"r"(mbar_addr),
+      "r"(phase), "r"(ticks)
+      : "memory");
+}
+
+__device__ __forceinline__ void mbarrier_wait_cluster(int mbar_addr, int phase) {
+  uint32_t ticks = 0x989680;
+  asm volatile(
+      "{\n\t"
+      ".reg .pred P1;\n\t"
+      "LAB_WAIT_CLUSTER:\n\t"
+      "mbarrier.try_wait.parity.acquire.cluster.shared::cta.b64"
+      " P1, [%0], %1, %2;\n\t"
+      "@P1 bra.uni DONE_CLUSTER;\n\t"
+      "bra.uni LAB_WAIT_CLUSTER;\n\t"
+      "DONE_CLUSTER:\n\t"
+      "}\n" ::"r"(mbar_addr),
+      "r"(phase), "r"(ticks)
+      : "memory");
+}
+
+__device__ __forceinline__ void mbarrier_wait_token(int mbar_addr, int phase, uint32_t token) {
+  if (token == 0) {
+    mbarrier_wait(mbar_addr, phase);
+  }
+}
+
+__device__ __forceinline__ void mbarrier_wait_token_cluster(int mbar_addr, int phase,
+                                                            uint32_t token) {
+  if (token == 0) {
+    mbarrier_wait_cluster(mbar_addr, phase);
+  }
+}
+
+__device__ __forceinline__ void tcgen05_mma_f16(int taddr, uint64_t a_desc, uint64_t b_desc,
+                                                uint32_t i_desc, int enable_input_d) {
+  asm volatile(
+      "{\n\t"
+      ".reg .pred p;\n\t"
+      "setp.ne.b32 p, %4, 0;\n\t"
+      "tcgen05.mma.cta_group::1.kind::f16 [%0], %1, %2, %3, p;\n\t"
+      "}\n" ::"r"(taddr),
+      "l"(a_desc), "l"(b_desc), "r"(i_desc), "r"(enable_input_d));
+}
+
+__device__ __forceinline__ uint64_t desc_encode(uint64_t x) { return (x & 0x3FFFFULL) >> 4ULL; }
+
+__device__ __forceinline__ void mma_ss_step(int a_lo, int b_lo, int taddr, uint32_t i_desc,
+                                            int enable_d, uint32_t a_dhi, uint32_t b_dhi) {
+  asm volatile(
+      "{\n\t"
+      ".reg .pred leader, p;\n\t"
+      ".reg .b32 adhi, bdhi;\n\t"
+      ".reg .b64 da, db;\n\t"
+      "elect.sync _|leader, 0xFFFFFFFF;\n\t"
+      "setp.ne.b32 p, %4, 0;\n\t"
+      "mov.b32 adhi, %5;\n\t"
+      "mov.b32 bdhi, %6;\n\t"
+      "mov.b64 da, {%0, adhi};\n\t"
+      "mov.b64 db, {%1, bdhi};\n\t"
+      "@leader tcgen05.mma.cta_group::1.kind::f16 [%2], da, db, %3, p;\n\t"
+      "}\n" ::"r"(a_lo),
+      "r"(b_lo), "r"(taddr), "r"(i_desc), "r"(enable_d), "r"(a_dhi), "r"(b_dhi));
+}
+
+__device__ __forceinline__ void mma_ts_step(int taddr_out, int taddr_a, int b_lo, uint32_t b_dhi,
+                                            uint32_t i_desc, int enable_d) {
+  asm volatile(
+      "{\n\t"
+      ".reg .pred leader, p;\n\t"
+      ".reg .b32 dhi;\n\t"
+      ".reg .b64 db;\n\t"
+      "elect.sync _|leader, 0xFFFFFFFF;\n\t"
+      "setp.ne.b32 p, %5, 0;\n\t"
+      "mov.b32 dhi, %3;\n\t"
+      "mov.b64 db, {%2, dhi};\n\t"
+      "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [%1], db, %4, p;\n\t"
+      "}\n" ::"r"(taddr_out),
+      "r"(taddr_a), "r"(b_lo), "r"(b_dhi), "r"(i_desc), "r"(enable_d));
+}
+
+__device__ __forceinline__ void elect_commit(int mbar_addr) {
+  asm volatile(
+      "{\n\t"
+      ".reg .pred leader;\n\t"
+      "elect.sync _|leader, 0xFFFFFFFF;\n\t"
+      "@leader tcgen05.commit.cta_group::1.mbarrier::arrive::one"
+      ".shared::cluster.b64 [%0];\n\t"
+      "}\n" ::"r"(mbar_addr));
+}
+
+__device__ __forceinline__ void mbarrier_arrive(int mbar_addr) {
+  asm volatile("mbarrier.arrive.release.cta.shared::cta.b64 _, [%0];" ::"r"(mbar_addr) : "memory");
+}
+
+__device__ __forceinline__ void mbarrier_arrive_expect_tx(int mbar_addr, uint32_t bytes) {
+  asm volatile(
+      "mbarrier.arrive.expect_tx.release.cta.shared::cta.b64 _, [%0], %1;" ::"r"(mbar_addr),
+      "r"(bytes)
+      : "memory");
+}
+
+__device__ __forceinline__ void tmem_ld_x32(float* dst, int tmem_addr) {
+  asm volatile(
+      "tcgen05.ld.sync.aligned.32x32b.x32.b32"
+      " {%0, %1, %2, %3, %4, %5, %6, %7,"
+      "  %8, %9, %10, %11, %12, %13, %14, %15,"
+      "  %16, %17, %18, %19, %20, %21, %22, %23,"
+      "  %24, %25, %26, %27, %28, %29, %30, %31}, [%32];"
+      : "=f"(dst[0]), "=f"(dst[1]), "=f"(dst[2]), "=f"(dst[3]), "=f"(dst[4]), "=f"(dst[5]),
+        "=f"(dst[6]), "=f"(dst[7]), "=f"(dst[8]), "=f"(dst[9]), "=f"(dst[10]), "=f"(dst[11]),
+        "=f"(dst[12]), "=f"(dst[13]), "=f"(dst[14]), "=f"(dst[15]), "=f"(dst[16]), "=f"(dst[17]),
+        "=f"(dst[18]), "=f"(dst[19]), "=f"(dst[20]), "=f"(dst[21]), "=f"(dst[22]), "=f"(dst[23]),
+        "=f"(dst[24]), "=f"(dst[25]), "=f"(dst[26]), "=f"(dst[27]), "=f"(dst[28]), "=f"(dst[29]),
+        "=f"(dst[30]), "=f"(dst[31])
+      : "r"(tmem_addr));
+}
+
+__device__ __forceinline__ void tmem_st_x32_f32(int tmem_addr, const float* src) {
+  asm volatile(
+      "tcgen05.st.sync.aligned.32x32b.x32.b32"
+      " [%0], {%1, %2, %3, %4, %5, %6, %7, %8,"
+      "  %9, %10, %11, %12, %13, %14, %15, %16,"
+      "  %17, %18, %19, %20, %21, %22, %23, %24,"
+      "  %25, %26, %27, %28, %29, %30, %31, %32};" ::"r"(tmem_addr),
+      "f"(src[0]), "f"(src[1]), "f"(src[2]), "f"(src[3]), "f"(src[4]), "f"(src[5]), "f"(src[6]),
+      "f"(src[7]), "f"(src[8]), "f"(src[9]), "f"(src[10]), "f"(src[11]), "f"(src[12]), "f"(src[13]),
+      "f"(src[14]), "f"(src[15]), "f"(src[16]), "f"(src[17]), "f"(src[18]), "f"(src[19]),
+      "f"(src[20]), "f"(src[21]), "f"(src[22]), "f"(src[23]), "f"(src[24]), "f"(src[25]),
+      "f"(src[26]), "f"(src[27]), "f"(src[28]), "f"(src[29]), "f"(src[30]), "f"(src[31]));
+}
+
+__device__ __forceinline__ float approx_exp2(float x) {
+  float y;
+  asm("ex2.approx.ftz.f32 %0, %1;" : "=f"(y) : "f"(x));
+  return y;
+}
+
+__device__ __forceinline__ float approx_rcp(float x) {
+  float y;
+  asm("rcp.approx.ftz.f32 %0, %1;" : "=f"(y) : "f"(x));
+  return y;
+}
+
+__device__ __forceinline__ void fma_f32x2_inplace(float2* a, float2 b, float2 c) {
+  unsigned long long r;
+  asm("fma.rn.ftz.f32x2 %0, %1, %2, %3;"
+      : "=l"(r)
+      : "l"(*(unsigned long long*)a), "l"(*(unsigned long long*)&b), "l"(*(unsigned long long*)&c));
+  *(unsigned long long*)a = r;
+}
+
+__device__ __forceinline__ void mul_f32x2_inplace(float2* a, float2 b) {
+  asm("mul.rn.ftz.f32x2 %0, %0, %1;"
+      : "+l"(*(unsigned long long*)a)
+      : "l"(*(unsigned long long*)&b));
+}
+
+__device__ __forceinline__ void add_f32x2_inplace(float2* a, float2 b) {
+  asm("add.rn.ftz.f32x2 %0, %0, %1;"
+      : "+l"(*(unsigned long long*)a)
+      : "l"(*(unsigned long long*)&b));
+}
+
+__device__ __forceinline__ void sub_f32x2_inplace(float2* a, float2 b) {
+  asm("sub.rn.ftz.f32x2 %0, %0, %1;"
+      : "+l"(*(unsigned long long*)a)
+      : "l"(*(unsigned long long*)&b));
+}
+
+__device__ __forceinline__ float2 add_f32x2(float2 a, float2 b) {
+  float2 r;
+  asm("add.rn.ftz.f32x2 %0, %1, %2;"
+      : "=l"(*(unsigned long long*)&r)
+      : "l"(*(unsigned long long*)&a), "l"(*(unsigned long long*)&b));
+  return r;
+}
+
+__device__ __forceinline__ float2 sub_f32x2(float2 a, float2 b) {
+  float2 r;
+  asm("sub.rn.ftz.f32x2 %0, %1, %2;"
+      : "=l"(*(unsigned long long*)&r)
+      : "l"(*(unsigned long long*)&a), "l"(*(unsigned long long*)&b));
+  return r;
+}
+
+__device__ __forceinline__ void fma_scale_x32(float* sv, const float2* scale2,
+                                              const float2* neg_max2) {
+  float2* sv_2 = reinterpret_cast<float2*>(sv);
+
+#pragma unroll
+
+  for (int j = 0; j < 16; j++) fma_f32x2_inplace(&sv_2[j], *scale2, *neg_max2);
+}
+
+__device__ __forceinline__ float2 fma_f32x2(float2 a, float2 b, float2 c) {
+  float2 r;
+  asm("fma.rn.ftz.f32x2 %0, %1, %2, %3;"
+      : "=l"(*(unsigned long long*)&r)
+      : "l"(*(unsigned long long*)&a), "l"(*(unsigned long long*)&b),
+        "l"(*(unsigned long long*)&c));
+  return r;
+}
+
+__device__ __forceinline__ float2 fma_sub_f32x2(float2 a, float2 b, float2 c) {
+  float2 r;
+  asm volatile(
+      "{\n\t"
+      ".reg .f32 _c0, _c1;\n\t"
+      ".reg .b64 _neg_c;\n\t"
+      "mov.b64 {_c0, _c1}, %3;\n\t"
+      "neg.f32 _c0, _c0;\n\t"
+      "neg.f32 _c1, _c1;\n\t"
+      "mov.b64 _neg_c, {_c0, _c1};\n\t"
+      "fma.rn.ftz.f32x2 %0, %1, %2, _neg_c;\n\t"
+      "}\n"
+      : "=l"(*(unsigned long long*)&r)
+      : "l"(*(unsigned long long*)&a), "l"(*(unsigned long long*)&b),
+        "l"(*(unsigned long long*)&c));
+  return r;
+}
+
+__device__ __forceinline__ float2 mul_f32x2(float2 a, float2 b) {
+  float2 r;
+  asm("mul.rn.ftz.f32x2 %0, %1, %2;"
+      : "=l"(*(unsigned long long*)&r)
+      : "l"(*(unsigned long long*)&a), "l"(*(unsigned long long*)&b));
+  return r;
+}
+
+// ex2_emulation_f32x2 defined in softmax_frag_exp2_cast helper (or standalone)
+
+__device__ __forceinline__ void fence_async_shared() {
+  asm volatile("fence.proxy.async.shared::cta;" ::: "memory");
+}
+
+__device__ __forceinline__ uint64_t make_smem_desc(int addr) {
+  const int SBO = 1024;
+  return desc_encode(addr) | (desc_encode(SBO) << 32ULL) | (1ULL << 46ULL) | (2ULL << 61ULL);
+}
+
+__device__ __forceinline__ void tma_3d_gmem2smem(int dst, const void* tmap_ptr, int x, int y, int z,
+                                                 int mbar_addr) {
+  asm volatile(
+      "cp.async.bulk.tensor.3d.shared::cta.global"
+      ".mbarrier::complete_tx::bytes"
+      " [%0], [%1, {%2, %3, %4}], [%5];" ::"r"(dst),
+      "l"(tmap_ptr), "r"(x), "r"(y), "r"(z), "r"(mbar_addr)
+      : "memory");
+}
+
+__device__ __forceinline__ void tma_store_3d(const void* tmap, int x, int y, int z,
+                                             unsigned smem_addr) {
+  asm volatile(
+      "cp.async.bulk.tensor.3d.global.shared::cta.tile.bulk_group"
+      " [%0, {%1, %2, %3}], [%4];" ::"l"(tmap),
+      "r"(x), "r"(y), "r"(z), "r"(smem_addr)
+      : "memory");
+}
+
+__device__ __forceinline__ void tcgen05_commit(int mbar_addr) {
+  asm volatile(
+      "tcgen05.commit.cta_group::1.mbarrier::arrive::one"
+      ".shared::cluster.b64 [%0];" ::"r"(mbar_addr)
+      : "memory");
+}
+
+__device__ __forceinline__ uint32_t make_warp_uniform(uint32_t val) {
+  uint32_t result;
+  asm volatile("shfl.sync.idx.b32 %0, %1, 0, 0x1f, 0xffffffff;" : "=r"(result) : "r"(val));
+  return result;
+}
+
+#define LOOM_INF CUDART_INF_F
+#define TMEM_NCOLS 512
+#define TMEM_TMEM_STATE_OFFSET 0
+#define TMEM_TMEM_Q_STATE_OFFSET 128
+#define TMEM_TMEM_STATE_INP_OFFSET 192
+#define TMEM_TMEM_CG0_SHARED_ACC_OFFSET 256
+#define TMEM_TMEM_CG1_SHARED_ACC_OFFSET 384
+#define TMEM_TMEM_SHARED_INP_OFFSET 448
+#define NUM_K_PIPE_STAGES 3
+#define NUM_Q_PIPE_STAGES 2
+#define NUM_V_PIPE_STAGES 2
+#define NUM_G_PIPE_STAGES 2
+#define NUM_GATE_PIPE_STAGES 5
+#define NUM_BETA_PIPE_STAGES 5
+#define NUM_ONE_STAGE_STAGES 1
+#define NUM_CG0_ACC_PIPE_STAGES 2
+#define NUM_AINV_PIPE_STAGES 3
+#define NUM_QK_PIPE_STAGES 2
+#define NUM_O_PIPE_STAGES 2
+#define SMEM_SMEM_Q_OFF 1024
+#define SMEM_SMEM_Q_STAGE_BYTES 16384
+#define SMEM_SMEM_Q_STRIDE 16384
+#define SMEM_SMEM_K_OFF 33792
+#define SMEM_SMEM_K_STAGE_BYTES 16384
+#define SMEM_SMEM_K_STRIDE 16384
+#define SMEM_SMEM_K_TRANS_MMA_OFF 33792
+#define SMEM_SMEM_K_TRANS_MMA_STAGE_BYTES 16384
+#define SMEM_SMEM_K_TRANS_MMA_STRIDE 16384
+#define SMEM_SMEM_V_OFF 82944
+#define SMEM_SMEM_V_STAGE_BYTES 16384
+#define SMEM_SMEM_V_STRIDE 16384
+#define SMEM_SMEM_G_OFF 115712
+#define SMEM_SMEM_G_STAGE_BYTES 16384
+#define SMEM_SMEM_G_STRIDE 16384
+#define SMEM_SMEM_G_TRANS_MMA_OFF 115712
+#define SMEM_SMEM_G_TRANS_MMA_STAGE_BYTES 16384
+#define SMEM_SMEM_G_TRANS_MMA_STRIDE 16384
+#define SMEM_SMEM_V_MMA_OFF 82944
+#define SMEM_SMEM_V_MMA_STAGE_BYTES 16384
+#define SMEM_SMEM_V_MMA_STRIDE 16384
+#define SMEM_SMEM_AINV_OFF 148480
+#define SMEM_SMEM_AINV_STAGE_BYTES 8192
+#define SMEM_SMEM_AINV_STRIDE 8192
+#define SMEM_SMEM_AINV_RM_OFF 148480
+#define SMEM_SMEM_AINV_RM_STAGE_BYTES 8192
+#define SMEM_SMEM_AINV_RM_STRIDE 8192
+#define SMEM_SMEM_QK_OFF 173056
+#define SMEM_SMEM_QK_STAGE_BYTES 8192
+#define SMEM_SMEM_QK_STRIDE 8192
+#define SMEM_SMEM_O_OFF 189440
+#define SMEM_SMEM_O_STAGE_BYTES 16384
+#define SMEM_SMEM_O_STRIDE 16384
+#define SMEM_SMEM_G_TOTAL_OFF 222208
+#define SMEM_SMEM_G_TOTAL_STAGE_BYTES 512
+#define SMEM_SMEM_G_TOTAL_STRIDE 512
+#define SMEM_SMEM_BETA_OFF 224768
+#define SMEM_SMEM_BETA_STAGE_BYTES 256
+#define SMEM_SMEM_BETA_STRIDE 256
+#define SMEM_TOTAL 226048
+#define THREADS 384
+#define USE_INITIAL_STATE 1
+#define STORE_FINAL_STATE 1
+#define ENABLE_CHECKPOINTS 0
+#define IS_GQA 0
+
+extern "C" {
+
+__global__ __launch_bounds__(384, 1) void kernel_flashkda_blackwell_prefill_fp32_state_initial(
+    LoomTensorMap const* Q, LoomTensorMap const* K, LoomTensorMap const* V, LoomTensorMap const* G,
+    LoomTensorMap const* O, __nv_bfloat16* __restrict__ beta, float* __restrict__ A_log,
+    float* __restrict__ dt_bias, long long* __restrict__ cu_seqlens,
+    float* __restrict__ initial_state, float* __restrict__ output_state,
+    float* __restrict__ checkpoint_state, int* __restrict__ cu_checkpoints,
+    uint8_t* __restrict__ tensormap_workspace, int checkpoint_every_n_tokens, float scale,
+    int num_seqs, int num_q_heads, int num_v_heads, int total_tiles, float lower_bound) {
+  const int tid = threadIdx.x;
+  const int warp = make_warp_uniform(tid / 32);
+  const int lane = tid % 32;
+
+  extern __shared__ __align__(1024) char smem_raw[];
+  int smem;
+  smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+
+  const int bid = blockIdx.x;
+  const int num_bids = gridDim.x;
+  if (tid == 0) {
+    asm volatile("fence.proxy.tensormap::generic.acquire.sys [%0], 128;" ::"l"((uint64_t)(Q))
+                 : "memory");
+    asm volatile("fence.proxy.tensormap::generic.acquire.sys [%0], 128;" ::"l"((uint64_t)(K))
+                 : "memory");
+    asm volatile("fence.proxy.tensormap::generic.acquire.sys [%0], 128;" ::"l"((uint64_t)(V))
+                 : "memory");
+    asm volatile("fence.proxy.tensormap::generic.acquire.sys [%0], 128;" ::"l"((uint64_t)(G))
+                 : "memory");
+    asm volatile("fence.proxy.tensormap::generic.acquire.sys [%0], 128;" ::"l"((uint64_t)(O))
+                 : "memory");
+  }
+  __syncthreads();
+
+  // Kernel setup ops
+  __nv_bfloat16* smem_q = reinterpret_cast<__nv_bfloat16*>(smem_raw + 1024);
+  const int smem_q_addr = smem + 1024;
+  __nv_bfloat16* smem_k = reinterpret_cast<__nv_bfloat16*>(smem_raw + 33792);
+  const int smem_k_addr = smem + 33792;
+  __nv_bfloat16* smem_k_trans_mma = reinterpret_cast<__nv_bfloat16*>(smem_raw + 33792);
+  const int smem_k_trans_mma_addr = smem + 33792;
+  __nv_bfloat16* smem_v = reinterpret_cast<__nv_bfloat16*>(smem_raw + 82944);
+  const int smem_v_addr = smem + 82944;
+  __nv_bfloat16* smem_g = reinterpret_cast<__nv_bfloat16*>(smem_raw + 115712);
+  const int smem_g_addr = smem + 115712;
+  __nv_bfloat16* smem_g_trans_mma = reinterpret_cast<__nv_bfloat16*>(smem_raw + 115712);
+  const int smem_g_trans_mma_addr = smem + 115712;
+  __nv_bfloat16* smem_v_mma = reinterpret_cast<__nv_bfloat16*>(smem_raw + 82944);
+  const int smem_v_mma_addr = smem + 82944;
+  __nv_bfloat16* smem_ainv = reinterpret_cast<__nv_bfloat16*>(smem_raw + 148480);
+  const int smem_ainv_addr = smem + 148480;
+  __nv_bfloat16* smem_ainv_rm = reinterpret_cast<__nv_bfloat16*>(smem_raw + 148480);
+  const int smem_ainv_rm_addr = smem + 148480;
+  __nv_bfloat16* smem_qk = reinterpret_cast<__nv_bfloat16*>(smem_raw + 173056);
+  const int smem_qk_addr = smem + 173056;
+  __nv_bfloat16* smem_o = reinterpret_cast<__nv_bfloat16*>(smem_raw + 189440);
+  const int smem_o_addr = smem + 189440;
+  float* smem_g_total = reinterpret_cast<float*>(smem_raw + 222208);
+  const int smem_g_total_addr = smem + 222208;
+  float* smem_beta = reinterpret_cast<float*>(smem_raw + 224768);
+  const int smem_beta_addr = smem + 224768;
+
+  // Mbarrier init (34 groups, 73 barriers)
+  // Mbarriers at smem_raw[0..584)
+
+  if (warp == 0) {
+    uint32_t leader = elect_sync();
+    if (leader) {
+      // --- pipeline 'k_pipe' ---
+      // load_k_full: 3 barriers, init_count=1
+      mbarrier_init(smem + 0, 1);
+      mbarrier_init(smem + 8, 1);
+      mbarrier_init(smem + 16, 1);
+      // load_k_empty: 3 barriers, init_count=2
+      mbarrier_init(smem + 24, 2);
+      mbarrier_init(smem + 32, 2);
+      mbarrier_init(smem + 40, 2);
+      // --- pipeline 'q_pipe' ---
+      // load_q_full: 2 barriers, init_count=1
+      mbarrier_init(smem + 48, 1);
+      mbarrier_init(smem + 56, 1);
+      // --- pipeline 'v_pipe' ---
+      // load_v_full: 2 barriers, init_count=1
+      mbarrier_init(smem + 64, 1);
+      mbarrier_init(smem + 72, 1);
+      // --- pipeline 'g_pipe' ---
+      // load_g_full: 2 barriers, init_count=1
+      mbarrier_init(smem + 80, 1);
+      mbarrier_init(smem + 88, 1);
+      // load_g_empty: 2 barriers, init_count=1
+      mbarrier_init(smem + 96, 1);
+      mbarrier_init(smem + 104, 1);
+      // qkg_ready: 2 barriers, init_count=128
+      mbarrier_init(smem + 112, 128);
+      mbarrier_init(smem + 120, 128);
+      // ki_mma_consumed: 2 barriers, init_count=1
+      mbarrier_init(smem + 128, 1);
+      mbarrier_init(smem + 136, 1);
+      // kr_ready: 2 barriers, init_count=128
+      mbarrier_init(smem + 144, 128);
+      mbarrier_init(smem + 152, 128);
+      // --- pipeline 'gate_pipe' ---
+      // load_gate_full: 5 barriers, init_count=128
+      mbarrier_init(smem + 160, 128);
+      mbarrier_init(smem + 168, 128);
+      mbarrier_init(smem + 176, 128);
+      mbarrier_init(smem + 184, 128);
+      mbarrier_init(smem + 192, 128);
+      // --- pipeline 'beta_pipe' ---
+      // load_beta_full: 5 barriers, init_count=32
+      mbarrier_init(smem + 200, 32);
+      mbarrier_init(smem + 208, 32);
+      mbarrier_init(smem + 216, 32);
+      mbarrier_init(smem + 224, 32);
+      mbarrier_init(smem + 232, 32);
+      // q_state_acc_full: 1 barriers, init_count=1
+      mbarrier_init(smem + 240, 1);
+      // q_state_acc_empty: 1 barriers, init_count=128
+      mbarrier_init(smem + 248, 128);
+      // kv_acc_full: 1 barriers, init_count=1
+      mbarrier_init(smem + 256, 1);
+      // kv_acc_empty: 1 barriers, init_count=128
+      mbarrier_init(smem + 264, 128);
+      // initial_state_loaded: 1 barriers, init_count=4
+      mbarrier_init(smem + 272, 4);
+      // --- pipeline 'cg0_acc_pipe' ---
+      // cg0_shared_acc_full: 2 barriers, init_count=1
+      mbarrier_init(smem + 280, 1);
+      mbarrier_init(smem + 288, 1);
+      // cg0_shared_acc_empty: 2 barriers, init_count=128
+      mbarrier_init(smem + 296, 128);
+      mbarrier_init(smem + 304, 128);
+      // --- pipeline 'one_stage' ---
+      // cg1_shared_acc_full: 1 barriers, init_count=1
+      mbarrier_init(smem + 312, 1);
+      // cg1_shared_acc_empty: 1 barriers, init_count=128
+      mbarrier_init(smem + 320, 128);
+      // --- pipeline 'ainv_pipe' ---
+      // ainv_ready: 3 barriers, init_count=128
+      mbarrier_init(smem + 328, 128);
+      mbarrier_init(smem + 336, 128);
+      mbarrier_init(smem + 344, 128);
+      // --- pipeline 'qk_pipe' ---
+      // qk_ready: 2 barriers, init_count=128
+      mbarrier_init(smem + 352, 128);
+      mbarrier_init(smem + 360, 128);
+      // state_inp_ready: 1 barriers, init_count=128
+      mbarrier_init(smem + 368, 128);
+      // vks_ready: 1 barriers, init_count=128
+      mbarrier_init(smem + 376, 128);
+      // nv_ready: 1 barriers, init_count=128
+      mbarrier_init(smem + 384, 128);
+      // decay_v_ready: 1 barriers, init_count=128
+      mbarrier_init(smem + 392, 128);
+      // --- pipeline 'o_pipe' ---
+      // o_store_ready: 2 barriers, init_count=128
+      mbarrier_init(smem + 400, 128);
+      mbarrier_init(smem + 408, 128);
+      // --- pipeline 'gate_pipe' ---
+      // gate_cg1_empty: 5 barriers, init_count=128
+      mbarrier_init(smem + 416, 128);
+      mbarrier_init(smem + 424, 128);
+      mbarrier_init(smem + 432, 128);
+      mbarrier_init(smem + 440, 128);
+      mbarrier_init(smem + 448, 128);
+      // --- pipeline 'beta_pipe' ---
+      // beta_smem_empty: 5 barriers, init_count=128
+      mbarrier_init(smem + 456, 128);
+      mbarrier_init(smem + 464, 128);
+      mbarrier_init(smem + 472, 128);
+      mbarrier_init(smem + 480, 128);
+      mbarrier_init(smem + 488, 128);
+      // --- pipeline 'qk_pipe' ---
+      // qk_smem_empty: 2 barriers, init_count=1
+      mbarrier_init(smem + 496, 1);
+      mbarrier_init(smem + 504, 1);
+      // --- pipeline 'ainv_pipe' ---
+      // ainv_smem_empty: 3 barriers, init_count=1
+      mbarrier_init(smem + 512, 1);
+      mbarrier_init(smem + 520, 1);
+      mbarrier_init(smem + 528, 1);
+      // --- pipeline 'q_pipe' ---
+      // q_smem_empty: 2 barriers, init_count=2
+      mbarrier_init(smem + 536, 2);
+      mbarrier_init(smem + 544, 2);
+      // --- pipeline 'v_pipe' ---
+      // v_smem_empty: 2 barriers, init_count=4
+      mbarrier_init(smem + 552, 4);
+      mbarrier_init(smem + 560, 4);
+      // --- pipeline 'o_pipe' ---
+      // o_smem_empty: 2 barriers, init_count=32
+      mbarrier_init(smem + 568, 32);
+      mbarrier_init(smem + 576, 32);
+      asm volatile("fence.mbarrier_init.release.cluster;");
+    }
+  }
+
+  __syncwarp();
+
+  // TMEM alloc (512 columns, 512 used)
+  volatile int* tmem_addr_storage = (volatile int*)(smem_raw + 584);
+  if (warp == 4) {
+    int _tmem_hold = smem + 584;
+    asm volatile(
+        "tcgen05.alloc.cta_group::1.sync.aligned.shared::cta.b32 [%0], %1;" ::"r"(_tmem_hold),
+        "r"(512)
+        : "memory");
+    asm volatile("tcgen05.relinquish_alloc_permit.cta_group::1.sync.aligned;");
+  }
+
+  __syncthreads();
+  asm volatile("tcgen05.fence::after_thread_sync;");
+
+  const int mbar_base = smem;
+#define load_k_full_addr (mbar_base + 0)
+#define load_k_empty_addr (mbar_base + 24)
+#define load_q_full_addr (mbar_base + 48)
+#define load_v_full_addr (mbar_base + 64)
+#define load_g_full_addr (mbar_base + 80)
+#define load_g_empty_addr (mbar_base + 96)
+#define qkg_ready_addr (mbar_base + 112)
+#define ki_mma_consumed_addr (mbar_base + 128)
+#define kr_ready_addr (mbar_base + 144)
+#define load_gate_full_addr (mbar_base + 160)
+#define load_beta_full_addr (mbar_base + 200)
+#define q_state_acc_full_addr (mbar_base + 240)
+#define q_state_acc_empty_addr (mbar_base + 248)
+#define kv_acc_full_addr (mbar_base + 256)
+#define kv_acc_empty_addr (mbar_base + 264)
+#define initial_state_loaded_addr (mbar_base + 272)
+#define cg0_shared_acc_full_addr (mbar_base + 280)
+#define cg0_shared_acc_empty_addr (mbar_base + 296)
+#define cg1_shared_acc_full_addr (mbar_base + 312)
+#define cg1_shared_acc_empty_addr (mbar_base + 320)
+#define ainv_ready_addr (mbar_base + 328)
+#define qk_ready_addr (mbar_base + 352)
+#define state_inp_ready_addr (mbar_base + 368)
+#define vks_ready_addr (mbar_base + 376)
+#define nv_ready_addr (mbar_base + 384)
+#define decay_v_ready_addr (mbar_base + 392)
+#define o_store_ready_addr (mbar_base + 400)
+#define gate_cg1_empty_addr (mbar_base + 416)
+#define beta_smem_empty_addr (mbar_base + 456)
+#define qk_smem_empty_addr (mbar_base + 496)
+#define ainv_smem_empty_addr (mbar_base + 512)
+#define q_smem_empty_addr (mbar_base + 536)
+#define v_smem_empty_addr (mbar_base + 552)
+#define o_smem_empty_addr (mbar_base + 568)
+  const int taddr = tmem_addr_storage[0];
+
+  // Kernel post-init ops
+  const int tmem_tmem_state = taddr;
+  const int tmem_tmem_q_state = taddr + 128;
+  const int tmem_tmem_state_inp = taddr + 192;
+  const int tmem_tmem_cg0_shared_acc = taddr + 256;
+  const int tmem_tmem_cg1_shared_acc = taddr + 384;
+  const int tmem_tmem_shared_inp = taddr + 448;
+
+  // ---- Register redistribution for WGs split across roles ----
+  // Dec phase frees registers before any WG attempts inc.
+  if (warp >= 8 && warp <= 11) {
+    asm volatile("setmaxnreg.dec.sync.aligned.u32 24;");
+  }
+
+  // ---- Role: compute_group_0 ----
+  if (warp <= 3) {
+    asm volatile("setmaxnreg.inc.sync.aligned.u32 224;");
+    {  // compute_group_0_main
+      unsigned int k_pre_stage = 0;
+      unsigned int k_pre_phase = 0;
+      unsigned int q_pre_stage = 0;
+      unsigned int q_pre_phase = 0;
+      unsigned int g_pre_stage = 0;
+      unsigned int g_pre_phase = 0;
+      unsigned int g_kr_stage = 0;
+      unsigned int g_kr_phase = 0;
+      unsigned int gate_cg0_stage = 0;
+      unsigned int gate_cg0_phase = 1;
+      unsigned int beta_cg0_stage = 0;
+      unsigned int beta_cg0_phase = 0;
+      unsigned int ainv_cg0_stage = 0;
+      unsigned int ainv_cg0_phase = 1;
+      unsigned int qk_cg0_stage = 0;
+      unsigned int qk_cg0_phase = 1;
+#pragma unroll 1
+      for (unsigned int tile = bid; tile < total_tiles; tile += num_bids) {
+        int num_o_heads = ((num_q_heads >= num_v_heads) ? num_q_heads : num_v_heads);
+        int batch_idx = tile / (unsigned int)num_o_heads;
+        int head_idx = tile % (unsigned int)num_o_heads;
+        int qk_head_idx =
+            ((num_q_heads >= num_v_heads) ? head_idx : head_idx / (num_v_heads / num_q_heads));
+        int v_head_idx =
+            ((num_v_heads >= num_q_heads) ? head_idx : head_idx / (num_q_heads / num_v_heads));
+        int batch_start = (int)cu_seqlens[batch_idx];
+        int batch_end = (int)cu_seqlens[batch_idx + 1];
+        int seqlen_b = batch_end - batch_start;
+        int num_pairs_b = (seqlen_b + 32 - 1) / 32;
+        int num_chunks_b = num_pairs_b * 2;
+#pragma unroll 1
+        for (int chunk_idx = 0; chunk_idx < num_chunks_b; chunk_idx += 2) {
+          int chunk_offset = batch_start + chunk_idx * 16;
+          int _cg0_marker = batch_idx + head_idx + chunk_offset + batch_end;
+          int warp_id_in_role = (warp - 0);
+          int warp_id_in_role_cg0 = warp_id_in_role;
+          int row_cg0 = warp_id_in_role_cg0 * 32 + lane;
+          int lane_quad_cg0 = lane & 3;
+          int lane_row_cg0 = lane / 4;
+          int qk_warp_row_base_cg0 = warp_id_in_role_cg0 * 16;
+          int qk_tmem_row_base_cg0 = warp_id_in_role_cg0 * 32 << 16;
+          unsigned int k0_stage = k_pre_stage;
+          mbarrier_wait(load_k_full_addr + (k0_stage) * 8, k_pre_phase);
+          k_pre_stage += 1;
+          if (k_pre_stage == 3) {
+            k_pre_stage = 0;
+            k_pre_phase ^= 1;
+          }
+          unsigned int q0_stage = q_pre_stage;
+          mbarrier_wait(load_q_full_addr + (q0_stage) * 8, q_pre_phase);
+          q_pre_stage += 1;
+          if (q_pre_stage == 2) {
+            q_pre_stage = 0;
+            q_pre_phase ^= 1;
+          }
+          unsigned int g0_stage = g_pre_stage;
+          mbarrier_wait(load_g_full_addr + (g0_stage) * 8, g_pre_phase);
+          g_pre_stage += 1;
+          if (g_pre_stage == 2) {
+            g_pre_stage = 0;
+            g_pre_phase ^= 1;
+          }
+          unsigned int gate0_stage = gate_cg0_stage;
+          mbarrier_wait(gate_cg1_empty_addr + (gate0_stage) * 8, gate_cg0_phase);
+          gate_cg0_stage += 1;
+          if (gate_cg0_stage == 5) {
+            gate_cg0_stage = 0;
+            gate_cg0_phase ^= 1;
+          }
+          int norm_row = tid / 8;
+          int norm_lane = tid & 7;
+          int norm_col_base = norm_lane * 16;
+          float q_sum = 0.0f;
+          float k_sum = 0.0f;
+#pragma unroll
+          for (int norm_j = 0; norm_j < 16; norm_j++) {
+            int norm_col = norm_col_base + norm_j;
+            float q_raw = (float)reinterpret_cast<const __nv_bfloat16*>(
+                (reinterpret_cast<const uint8_t*>(reinterpret_cast<const uint8_t*>(smem_q) +
+                                                  (q0_stage * 16384)) +
+                 (norm_col / 64 * 8192 + norm_row * 128 + norm_col % 64 * 2 ^
+                  (norm_col / 64 * 8192 + norm_row * 128 + norm_col % 64 * 2 >> 7 & 7) << 4)))[0];
+            float k_raw = (float)reinterpret_cast<const __nv_bfloat16*>(
+                (reinterpret_cast<const uint8_t*>(reinterpret_cast<const uint8_t*>(smem_k) +
+                                                  (k0_stage * 16384)) +
+                 (norm_col / 64 * 8192 + norm_row * 128 + norm_col % 64 * 2 ^
+                  (norm_col / 64 * 8192 + norm_row * 128 + norm_col % 64 * 2 >> 7 & 7) << 4)))[0];
+            float _fma_0 = __fmaf_rn(q_raw, q_raw, q_sum);
+            q_sum = _fma_0;
+            float _fma_1 = __fmaf_rn(k_raw, k_raw, k_sum);
+            k_sum = _fma_1;
+          }
+          float _shfl_xor_0 = __shfl_xor_sync(0xFFFFFFFF, q_sum, 4);
+          q_sum += _shfl_xor_0;
+          float _shfl_xor_1 = __shfl_xor_sync(0xFFFFFFFF, k_sum, 4);
+          k_sum += _shfl_xor_1;
+          float _shfl_xor_2 = __shfl_xor_sync(0xFFFFFFFF, q_sum, 2);
+          q_sum += _shfl_xor_2;
+          float _shfl_xor_3 = __shfl_xor_sync(0xFFFFFFFF, k_sum, 2);
+          k_sum += _shfl_xor_3;
+          float _shfl_xor_4 = __shfl_xor_sync(0xFFFFFFFF, q_sum, 1);
+          q_sum += _shfl_xor_4;
+          float _shfl_xor_5 = __shfl_xor_sync(0xFFFFFFFF, k_sum, 1);
+          k_sum += _shfl_xor_5;
+          float _rsqrt_0 = rsqrtf(q_sum + 1e-06f);
+          float q_inv_norm = _rsqrt_0;
+          float _rsqrt_1 = rsqrtf(k_sum + 1e-06f);
+          float k_inv_norm = _rsqrt_1;
+          int row_is_valid = ((batch_end > chunk_offset + norm_row) ? 1 : 0);
+#pragma unroll
+          for (int norm_j_1 = 0; norm_j_1 < 16; norm_j_1++) {
+            int norm_col_1 = norm_col_base + norm_j_1;
+            float q_norm = 0.0f;
+            float k_norm = 0.0f;
+            if (row_is_valid != 0) {
+              q_norm = (float)reinterpret_cast<const __nv_bfloat16*>((
+                           reinterpret_cast<const uint8_t*>(
+                               reinterpret_cast<const uint8_t*>(smem_q) + (q0_stage * 16384)) +
+                           (norm_col_1 / 64 * 8192 + norm_row * 128 + norm_col_1 % 64 * 2 ^
+                            (norm_col_1 / 64 * 8192 + norm_row * 128 + norm_col_1 % 64 * 2 >> 7 & 7)
+                                << 4)))[0] *
+                       q_inv_norm;
+              k_norm = (float)reinterpret_cast<const __nv_bfloat16*>((
+                           reinterpret_cast<const uint8_t*>(
+                               reinterpret_cast<const uint8_t*>(smem_k) + (k0_stage * 16384)) +
+                           (norm_col_1 / 64 * 8192 + norm_row * 128 + norm_col_1 % 64 * 2 ^
+                            (norm_col_1 / 64 * 8192 + norm_row * 128 + norm_col_1 % 64 * 2 >> 7 & 7)
+                                << 4)))[0] *
+                       k_inv_norm;
+            }
+            {
+              __nv_bfloat16 _bval_0 = __float2bfloat16_rn(q_norm);
+              uint16_t _bits_0 = *(uint16_t*)&_bval_0;
+              uint32_t _addr_0 = static_cast<uint32_t>(
+                  (smem_q_addr + q0_stage * 16384 +
+                   (unsigned int)(norm_col_1 / 64 * 8192 + norm_row * 128 + norm_col_1 % 64 * 2 ^
+                                  (norm_col_1 / 64 * 8192 + norm_row * 128 + norm_col_1 % 64 * 2 >>
+                                       7 &
+                                   7) << 4)));
+              asm volatile("st.shared.b16 [%0], %1;" ::"r"(_addr_0), "h"(_bits_0) : "memory");
+            }
+            {
+              __nv_bfloat16 _bval_1 = __float2bfloat16_rn(k_norm);
+              uint16_t _bits_1 = *(uint16_t*)&_bval_1;
+              uint32_t _addr_1 = static_cast<uint32_t>(
+                  (smem_k_addr + k0_stage * 16384 +
+                   (unsigned int)(norm_col_1 / 64 * 8192 + norm_row * 128 + norm_col_1 % 64 * 2 ^
+                                  (norm_col_1 / 64 * 8192 + norm_row * 128 + norm_col_1 % 64 * 2 >>
+                                       7 &
+                                   7) << 4)));
+              asm volatile("st.shared.b16 [%0], %1;" ::"r"(_addr_1), "h"(_bits_1) : "memory");
+            }
+          }
+          asm volatile("barrier.sync 13, 128;" ::: "memory");
+          int gate_col = tid;
+          float gate_bias = dt_bias[head_idx * 128 + gate_col];
+          float _expf_0 = __expf(A_log[head_idx]);
+          float gate_rate = _expf_0;
+          float prefix_log2 = 0.0f;
+#pragma unroll
+          for (int gate_row = 0; gate_row < 16; gate_row++) {
+            float q_norm_1 = (float)reinterpret_cast<const __nv_bfloat16*>(
+                (reinterpret_cast<const uint8_t*>(reinterpret_cast<const uint8_t*>(smem_q) +
+                                                  (q0_stage * 16384)) +
+                 (gate_col / 64 * 8192 + gate_row * 128 + gate_col % 64 * 2 ^
+                  (gate_col / 64 * 8192 + gate_row * 128 + gate_col % 64 * 2 >> 7 & 7) << 4)))[0];
+            float k_norm_1 = (float)reinterpret_cast<const __nv_bfloat16*>(
+                (reinterpret_cast<const uint8_t*>(reinterpret_cast<const uint8_t*>(smem_k) +
+                                                  (k0_stage * 16384)) +
+                 (gate_col / 64 * 8192 + gate_row * 128 + gate_col % 64 * 2 ^
+                  (gate_col / 64 * 8192 + gate_row * 128 + gate_col % 64 * 2 >> 7 & 7) << 4)))[0];
+            float gate_log2 = 0.0f;
+            if (batch_end > chunk_offset + gate_row) {
+              float gate_raw = (float)reinterpret_cast<const __nv_bfloat16*>(
+                  (reinterpret_cast<const uint8_t*>(reinterpret_cast<const uint8_t*>(smem_g) +
+                                                    (g0_stage * 16384)) +
+                   (gate_col / 64 * 8192 + gate_row * 128 + gate_col % 64 * 2 ^
+                    (gate_col / 64 * 8192 + gate_row * 128 + gate_col % 64 * 2 >> 7 & 7) << 4)))[0];
+              float gate_arg = gate_rate * (gate_raw + gate_bias);
+              float _expf_1 = __expf(-gate_arg);
+              float _rcp_0 = approx_rcp(1.0f + _expf_1);
+              gate_log2 = lower_bound * 1.4426950408889634f * _rcp_0;
+            }
+            prefix_log2 += gate_log2;
+            float _exp2_0 = approx_exp2(prefix_log2);
+            float q_decay = _exp2_0;
+            {
+              __nv_bfloat16 _bval_2 = __float2bfloat16_rn(q_norm_1 * q_decay * scale);
+              uint16_t _bits_2 = *(uint16_t*)&_bval_2;
+              uint32_t _addr_2 = static_cast<uint32_t>(
+                  (smem_q_addr + q0_stage * 16384 +
+                   (unsigned int)(gate_col / 64 * 8192 + gate_row * 128 + gate_col % 64 * 2 ^
+                                  (gate_col / 64 * 8192 + gate_row * 128 + gate_col % 64 * 2 >> 7 &
+                                   7) << 4)));
+              asm volatile("st.shared.b16 [%0], %1;" ::"r"(_addr_2), "h"(_bits_2) : "memory");
+            }
+            {
+              __nv_bfloat16 _bval_3 = __float2bfloat16_rn(k_norm_1 * q_decay);
+              uint16_t _bits_3 = *(uint16_t*)&_bval_3;
+              uint32_t _addr_3 = static_cast<uint32_t>(
+                  (smem_k_addr + k0_stage * 16384 +
+                   (unsigned int)(gate_col / 64 * 8192 + gate_row * 128 + gate_col % 64 * 2 ^
+                                  (gate_col / 64 * 8192 + gate_row * 128 + gate_col % 64 * 2 >> 7 &
+                                   7) << 4)));
+              asm volatile("st.shared.b16 [%0], %1;" ::"r"(_addr_3), "h"(_bits_3) : "memory");
+            }
+            {
+              __nv_bfloat16 _bval_4 = __float2bfloat16_rn(k_norm_1 / q_decay);
+              uint16_t _bits_4 = *(uint16_t*)&_bval_4;
+              uint32_t _addr_4 = static_cast<uint32_t>(
+                  (smem_g_addr + g0_stage * 16384 +
+                   (unsigned int)(gate_col / 64 * 8192 + gate_row * 128 + gate_col % 64 * 2 ^
+                                  (gate_col / 64 * 8192 + gate_row * 128 + gate_col % 64 * 2 >> 7 &
+                                   7) << 4)));
+              asm volatile("st.shared.b16 [%0], %1;" ::"r"(_addr_4), "h"(_bits_4) : "memory");
+            }
+          }
+          float _exp2_1 = approx_exp2(prefix_log2);
+          smem_g_total[gate0_stage * 128 + (unsigned int)gate_col] = _exp2_1;
+          asm volatile("fence.proxy.async.shared::cta;" ::: "memory");
+          mbarrier_arrive(qkg_ready_addr + (g0_stage) * 8);
+          mbarrier_arrive(load_gate_full_addr + (gate0_stage) * 8);
+          unsigned int k1_stage = k_pre_stage;
+          mbarrier_wait(load_k_full_addr + (k1_stage) * 8, k_pre_phase);
+          k_pre_stage += 1;
+          if (k_pre_stage == 3) {
+            k_pre_stage = 0;
+            k_pre_phase ^= 1;
+          }
+          unsigned int q1_stage = q_pre_stage;
+          mbarrier_wait(load_q_full_addr + (q1_stage) * 8, q_pre_phase);
+          q_pre_stage += 1;
+          if (q_pre_stage == 2) {
+            q_pre_stage = 0;
+            q_pre_phase ^= 1;
+          }
+          unsigned int g1_stage = g_pre_stage;
+          mbarrier_wait(load_g_full_addr + (g1_stage) * 8, g_pre_phase);
+          g_pre_stage += 1;
+          if (g_pre_stage == 2) {
+            g_pre_stage = 0;
+            g_pre_phase ^= 1;
+          }
+          unsigned int gate1_stage = gate_cg0_stage;
+          mbarrier_wait(gate_cg1_empty_addr + (gate1_stage) * 8, gate_cg0_phase);
+          gate_cg0_stage += 1;
+          if (gate_cg0_stage == 5) {
+            gate_cg0_stage = 0;
+            gate_cg0_phase ^= 1;
+          }
+          int norm_row_0 = tid / 8;
+          int norm_lane_1 = tid & 7;
+          int norm_col_base_2 = norm_lane_1 * 16;
+          float q_sum_3 = 0.0f;
+          float k_sum_4 = 0.0f;
+#pragma unroll
+          for (int norm_j_2 = 0; norm_j_2 < 16; norm_j_2++) {
+            int norm_col_2 = norm_col_base_2 + norm_j_2;
+            float q_raw_1 = (float)reinterpret_cast<const __nv_bfloat16*>(
+                (reinterpret_cast<const uint8_t*>(reinterpret_cast<const uint8_t*>(smem_q) +
+                                                  (q1_stage * 16384)) +
+                 (norm_col_2 / 64 * 8192 + norm_row_0 * 128 + norm_col_2 % 64 * 2 ^
+                  (norm_col_2 / 64 * 8192 + norm_row_0 * 128 + norm_col_2 % 64 * 2 >> 7 & 7)
+                      << 4)))[0];
+            float k_raw_1 = (float)reinterpret_cast<const __nv_bfloat16*>(
+                (reinterpret_cast<const uint8_t*>(reinterpret_cast<const uint8_t*>(smem_k) +
+                                                  (k1_stage * 16384)) +
+                 (norm_col_2 / 64 * 8192 + norm_row_0 * 128 + norm_col_2 % 64 * 2 ^
+                  (norm_col_2 / 64 * 8192 + norm_row_0 * 128 + norm_col_2 % 64 * 2 >> 7 & 7)
+                      << 4)))[0];
+            float _fma_2 = __fmaf_rn(q_raw_1, q_raw_1, q_sum_3);
+            q_sum_3 = _fma_2;
+            float _fma_3 = __fmaf_rn(k_raw_1, k_raw_1, k_sum_4);
+            k_sum_4 = _fma_3;
+          }
+          float _shfl_xor_6 = __shfl_xor_sync(0xFFFFFFFF, q_sum_3, 4);
+          q_sum_3 += _shfl_xor_6;
+          float _shfl_xor_7 = __shfl_xor_sync(0xFFFFFFFF, k_sum_4, 4);
+          k_sum_4 += _shfl_xor_7;
+          float _shfl_xor_8 = __shfl_xor_sync(0xFFFFFFFF, q_sum_3, 2);
+          q_sum_3 += _shfl_xor_8;
+          float _shfl_xor_9 = __shfl_xor_sync(0xFFFFFFFF, k_sum_4, 2);
+          k_sum_4 += _shfl_xor_9;
+          float _shfl_xor_10 = __shfl_xor_sync(0xFFFFFFFF, q_sum_3, 1);
+          q_sum_3 += _shfl_xor_10;
+          float _shfl_xor_11 = __shfl_xor_sync(0xFFFFFFFF, k_sum_4, 1);
+          k_sum_4 += _shfl_xor_11;
+          float _rsqrt_2 = rsqrtf(q_sum_3 + 1e-06f);
+          float q_inv_norm_5 = _rsqrt_2;
+          float _rsqrt_3 = rsqrtf(k_sum_4 + 1e-06f);
+          float k_inv_norm_6 = _rsqrt_3;
+          int row_is_valid_7 = ((batch_end > chunk_offset + 16 + norm_row_0) ? 1 : 0);
+#pragma unroll
+          for (int norm_j_3 = 0; norm_j_3 < 16; norm_j_3++) {
+            int norm_col_3 = norm_col_base_2 + norm_j_3;
+            float q_norm_2 = 0.0f;
+            float k_norm_2 = 0.0f;
+            if (row_is_valid_7 != 0) {
+              q_norm_2 =
+                  (float)reinterpret_cast<const __nv_bfloat16*>(
+                      (reinterpret_cast<const uint8_t*>(reinterpret_cast<const uint8_t*>(smem_q) +
+                                                        (q1_stage * 16384)) +
+                       (norm_col_3 / 64 * 8192 + norm_row_0 * 128 + norm_col_3 % 64 * 2 ^
+                        (norm_col_3 / 64 * 8192 + norm_row_0 * 128 + norm_col_3 % 64 * 2 >> 7 & 7)
+                            << 4)))[0] *
+                  q_inv_norm_5;
+              k_norm_2 =
+                  (float)reinterpret_cast<const __nv_bfloat16*>(
+                      (reinterpret_cast<const uint8_t*>(reinterpret_cast<const uint8_t*>(smem_k) +
+                                                        (k1_stage * 16384)) +
+                       (norm_col_3 / 64 * 8192 + norm_row_0 * 128 + norm_col_3 % 64 * 2 ^
+                        (norm_col_3 / 64 * 8192 + norm_row_0 * 128 + norm_col_3 % 64 * 2 >> 7 & 7)
+                            << 4)))[0] *
+                  k_inv_norm_6;
+            }
+            {
+              __nv_bfloat16 _bval_5 = __float2bfloat16_rn(q_norm_2);
+              uint16_t _bits_5 = *(uint16_t*)&_bval_5;
+              uint32_t _addr_5 = static_cast<uint32_t>((
+                  smem_q_addr + q1_stage * 16384 +
+                  (unsigned int)(norm_col_3 / 64 * 8192 + norm_row_0 * 128 + norm_col_3 % 64 * 2 ^
+                                 (norm_col_3 / 64 * 8192 + norm_row_0 * 128 + norm_col_3 % 64 * 2 >>
+                                      7 &
+                                  7) << 4)));
+              asm volatile("st.shared.b16 [%0], %1;" ::"r"(_addr_5), "h"(_bits_5) : "memory");
+            }
+            {
+              __nv_bfloat16 _bval_6 = __float2bfloat16_rn(k_norm_2);
+              uint16_t _bits_6 = *(uint16_t*)&_bval_6;
+              uint32_t _addr_6 = static_cast<uint32_t>((
+                  smem_k_addr + k1_stage * 16384 +
+                  (unsigned int)(norm_col_3 / 64 * 8192 + norm_row_0 * 128 + norm_col_3 % 64 * 2 ^
+                                 (norm_col_3 / 64 * 8192 + norm_row_0 * 128 + norm_col_3 % 64 * 2 >>
+                                      7 &
+                                  7) << 4)));
+              asm volatile("st.shared.b16 [%0], %1;" ::"r"(_addr_6), "h"(_bits_6) : "memory");
+            }
+          }
+          asm volatile("barrier.sync 13, 128;" ::: "memory");
+          int gate_col_8 = tid;
+          float gate_bias_9 = dt_bias[head_idx * 128 + gate_col_8];
+          float _expf_2 = __expf(A_log[head_idx]);
+          float gate_rate_10 = _expf_2;
+          float prefix_log2_11 = 0.0f;
+#pragma unroll
+          for (int gate_row_1 = 0; gate_row_1 < 16; gate_row_1++) {
+            float q_norm_3 = (float)reinterpret_cast<const __nv_bfloat16*>(
+                (reinterpret_cast<const uint8_t*>(reinterpret_cast<const uint8_t*>(smem_q) +
+                                                  (q1_stage * 16384)) +
+                 (gate_col_8 / 64 * 8192 + gate_row_1 * 128 + gate_col_8 % 64 * 2 ^
+                  (gate_col_8 / 64 * 8192 + gate_row_1 * 128 + gate_col_8 % 64 * 2 >> 7 & 7)
+                      << 4)))[0];
+            float k_norm_3 = (float)reinterpret_cast<const __nv_bfloat16*>(
+                (reinterpret_cast<const uint8_t*>(reinterpret_cast<const uint8_t*>(smem_k) +
+                                                  (k1_stage * 16384)) +
+                 (gate_col_8 / 64 * 8192 + gate_row_1 * 128 + gate_col_8 % 64 * 2 ^
+                  (gate_col_8 / 64 * 8192 + gate_row_1 * 128 + gate_col_8 % 64 * 2 >> 7 & 7)
+                      << 4)))[0];
+            float gate_log2_1 = 0.0f;
+            if (batch_end > chunk_offset + 16 + gate_row_1) {
+              float gate_raw_1 = (float)reinterpret_cast<const __nv_bfloat16*>(
+                  (reinterpret_cast<const uint8_t*>(reinterpret_cast<const uint8_t*>(smem_g) +
+                                                    (g1_stage * 16384)) +
+                   (gate_col_8 / 64 * 8192 + gate_row_1 * 128 + gate_col_8 % 64 * 2 ^
+                    (gate_col_8 / 64 * 8192 + gate_row_1 * 128 + gate_col_8 % 64 * 2 >> 7 & 7)
+                        << 4)))[0];
+              float gate_arg_1 = gate_rate_10 * (gate_raw_1 + gate_bias_9);
+              float _expf_3 = __expf(-gate_arg_1);
+              float _rcp_1 = approx_rcp(1.0f + _expf_3);
+              gate_log2_1 = lower_bound * 1.4426950408889634f * _rcp_1;
+            }
+            prefix_log2_11 += gate_log2_1;
+            float _exp2_2 = approx_exp2(prefix_log2_11);
+            float q_decay_1 = _exp2_2;
+            {
+              __nv_bfloat16 _bval_7 = __float2bfloat16_rn(q_norm_3 * q_decay_1 * scale);
+              uint16_t _bits_7 = *(uint16_t*)&_bval_7;
+              uint32_t _addr_7 = static_cast<uint32_t>((
+                  smem_q_addr + q1_stage * 16384 +
+                  (unsigned int)(gate_col_8 / 64 * 8192 + gate_row_1 * 128 + gate_col_8 % 64 * 2 ^
+                                 (gate_col_8 / 64 * 8192 + gate_row_1 * 128 + gate_col_8 % 64 * 2 >>
+                                      7 &
+                                  7) << 4)));
+              asm volatile("st.shared.b16 [%0], %1;" ::"r"(_addr_7), "h"(_bits_7) : "memory");
+            }
+            {
+              __nv_bfloat16 _bval_8 = __float2bfloat16_rn(k_norm_3 * q_decay_1);
+              uint16_t _bits_8 = *(uint16_t*)&_bval_8;
+              uint32_t _addr_8 = static_cast<uint32_t>((
+                  smem_k_addr + k1_stage * 16384 +
+                  (unsigned int)(gate_col_8 / 64 * 8192 + gate_row_1 * 128 + gate_col_8 % 64 * 2 ^
+                                 (gate_col_8 / 64 * 8192 + gate_row_1 * 128 + gate_col_8 % 64 * 2 >>
+                                      7 &
+                                  7) << 4)));
+              asm volatile("st.shared.b16 [%0], %1;" ::"r"(_addr_8), "h"(_bits_8) : "memory");
+            }
+            {
+              __nv_bfloat16 _bval_9 = __float2bfloat16_rn(k_norm_3 / q_decay_1);
+              uint16_t _bits_9 = *(uint16_t*)&_bval_9;
+              uint32_t _addr_9 = static_cast<uint32_t>((
+                  smem_g_addr + g1_stage * 16384 +
+                  (unsigned int)(gate_col_8 / 64 * 8192 + gate_row_1 * 128 + gate_col_8 % 64 * 2 ^
+                                 (gate_col_8 / 64 * 8192 + gate_row_1 * 128 + gate_col_8 % 64 * 2 >>
+                                      7 &
+                                  7) << 4)));
+              asm volatile("st.shared.b16 [%0], %1;" ::"r"(_addr_9), "h"(_bits_9) : "memory");
+            }
+          }
+          float _exp2_3 = approx_exp2(prefix_log2_11);
+          smem_g_total[gate1_stage * 128 + (unsigned int)gate_col_8] = _exp2_3;
+          asm volatile("fence.proxy.async.shared::cta;" ::: "memory");
+          mbarrier_arrive(qkg_ready_addr + (g1_stage) * 8);
+          mbarrier_arrive(load_gate_full_addr + (gate1_stage) * 8);
+          float qk_transfer0_cg0[32];
+          float qk_transfer1_cg0[32];
+#pragma unroll
+          for (int qk_j_cg0 = 0; qk_j_cg0 < 32; qk_j_cg0++) {
+            int qk_repeat_cg0 = qk_j_cg0 / 4;
+            int qk_reg_cg0 = qk_j_cg0 & 3;
+            int qk_row_cg0 = qk_warp_row_base_cg0 + lane_row_cg0 + qk_reg_cg0 / 2 * 8;
+            int qk_col_cg0 = qk_repeat_cg0 * 8 + lane_quad_cg0 * 2 + (qk_reg_cg0 & 1);
+            qk_transfer0_cg0[qk_j_cg0] =
+                ((qk_row_cg0 < 16 && qk_col_cg0 < 16 && qk_row_cg0 >= qk_col_cg0) ? 1.0f : 0.0f);
+            qk_transfer1_cg0[qk_j_cg0] =
+                ((qk_row_cg0 < 16 && qk_col_cg0 < 16 && qk_row_cg0 >= qk_col_cg0) ? 1.0f : 0.0f);
+          }
+          unsigned int beta0_stage = beta_cg0_stage;
+          mbarrier_wait(load_beta_full_addr + (beta0_stage) * 8, beta_cg0_phase);
+          beta_cg0_stage += 1;
+          if (beta_cg0_stage == 5) {
+            beta_cg0_stage = 0;
+            beta_cg0_phase ^= 1;
+          }
+          unsigned int beta1_stage = beta_cg0_stage;
+          mbarrier_wait(load_beta_full_addr + (beta1_stage) * 8, beta_cg0_phase);
+          beta_cg0_stage += 1;
+          if (beta_cg0_stage == 5) {
+            beta_cg0_stage = 0;
+            beta_cg0_phase ^= 1;
+          }
+          int beta0_elem_base = beta0_stage * 64;
+          int beta1_elem_base = beta1_stage * 64;
+          unsigned int ainv0_stage = ainv_cg0_stage;
+          mbarrier_wait(ainv_smem_empty_addr + (ainv0_stage) * 8, ainv_cg0_phase);
+          ainv_cg0_stage += 1;
+          if (ainv_cg0_stage == 3) {
+            ainv_cg0_stage = 0;
+            ainv_cg0_phase ^= 1;
+          }
+          unsigned int ainv1_stage = ainv_cg0_stage;
+          mbarrier_wait(ainv_smem_empty_addr + (ainv1_stage) * 8, ainv_cg0_phase);
+          ainv_cg0_stage += 1;
+          if (ainv_cg0_stage == 3) {
+            ainv_cg0_stage = 0;
+            ainv_cg0_phase ^= 1;
+          }
+          mbarrier_wait(cg0_shared_acc_full_addr, 0);
+          int kk_addr = taddr + 256 + (unsigned int)qk_tmem_row_base_cg0;
+          float _tmem_load_0[32];
+          asm volatile(
+              "tcgen05.ld.sync.aligned.16x256b.x8.b32"
+              " {%0, %1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15, %16, %17, "
+              "%18, %19, %20, %21, %22, %23, %24, %25, %26, %27, %28, %29, %30, %31}, [%32];"
+              : "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_0[0])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_0[1])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_0[2])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_0[3])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_0[4])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_0[5])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_0[6])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_0[7])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_0[8])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_0[9])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_0[10])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_0[11])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_0[12])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_0[13])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_0[14])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_0[15])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_0[16])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_0[17])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_0[18])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_0[19])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_0[20])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_0[21])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_0[22])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_0[23])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_0[24])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_0[25])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_0[26])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_0[27])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_0[28])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_0[29])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_0[30])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_0[31]))
+              : "r"(kk_addr));
+          int kk_beta_row0_cg0 = qk_warp_row_base_cg0 + lane_row_cg0;
+          int kk_beta_row1_cg0 = kk_beta_row0_cg0 + 8;
+          float kk_beta0_cg0 = smem_beta[beta0_elem_base + kk_beta_row0_cg0];
+          float kk_beta1_cg0 = smem_beta[beta0_elem_base + kk_beta_row1_cg0];
+          int kk_stsm_row_cg0 = qk_warp_row_base_cg0 + (lane & 7) + (lane & 8);
+          int kk_stsm_col_lane_cg0 = (lane & 16) / 2;
+#pragma unroll
+          for (int qk_repeat_cg0_1 = 0; qk_repeat_cg0_1 < 4; qk_repeat_cg0_1++) {
+            const int qk_j0_cg0 = qk_repeat_cg0_1 * 8;
+            float _t0[8];
+#pragma unroll
+            for (int _ls = 0; _ls < 4; _ls++)
+              reinterpret_cast<float2*>(_t0)[_ls] =
+                  mul_f32x2(reinterpret_cast<float2*>((_tmem_load_0 + qk_j0_cg0))[_ls],
+                            reinterpret_cast<const float2*>((qk_transfer0_cg0 + qk_j0_cg0))[_ls]);
+            const float2 _scale2_10 = {kk_beta0_cg0, kk_beta0_cg0};
+#pragma unroll
+            for (int _ls = 0; _ls < 1; _ls++)
+              mul_f32x2_inplace(&reinterpret_cast<float2*>((_t0 + 0))[_ls], _scale2_10);
+            const float2 _scale2_11 = {kk_beta1_cg0, kk_beta1_cg0};
+#pragma unroll
+            for (int _ls = 0; _ls < 1; _ls++)
+              mul_f32x2_inplace(&reinterpret_cast<float2*>((_t0 + 2))[_ls], _scale2_11);
+            const float2 _scale2_12 = {kk_beta0_cg0, kk_beta0_cg0};
+#pragma unroll
+            for (int _ls = 0; _ls < 1; _ls++)
+              mul_f32x2_inplace(&reinterpret_cast<float2*>((_t0 + 4))[_ls], _scale2_12);
+            const float2 _scale2_13 = {kk_beta1_cg0, kk_beta1_cg0};
+#pragma unroll
+            for (int _ls = 0; _ls < 1; _ls++)
+              mul_f32x2_inplace(&reinterpret_cast<float2*>((_t0 + 6))[_ls], _scale2_13);
+            uint32_t _t0_bf16[4];
+#pragma unroll
+            for (int _lp = 0; _lp < 4; _lp++) {
+              __nv_bfloat162 _bf2 =
+                  __float22bfloat162_rn(make_float2(_t0[_lp * 2 + 0], _t0[_lp * 2 + 1 + 0]));
+              _t0_bf16[_lp] = *(uint32_t*)&_bf2;
+            }
+            int kk_stsm_addr_cg0 =
+                smem_ainv_rm_addr + ainv0_stage * 8192 +
+                (unsigned int)(kk_stsm_row_cg0 * 128 +
+                                   (qk_repeat_cg0_1 * 16 + kk_stsm_col_lane_cg0) * 2 ^
+                               (kk_stsm_row_cg0 * 128 +
+                                        (qk_repeat_cg0_1 * 16 + kk_stsm_col_lane_cg0) * 2 >>
+                                    7 &
+                                7) << 4);
+            uint32_t _stmatrix_addr_14 =
+                static_cast<uint32_t>((unsigned long long)kk_stsm_addr_cg0);
+            asm volatile("stmatrix.sync.aligned.m8n8.x4.shared.b16 [%0], {%1, %2, %3, %4};\n" ::"r"(
+                             _stmatrix_addr_14),
+                         "r"(*reinterpret_cast<const uint32_t*>(&_t0_bf16[0])),
+                         "r"(*reinterpret_cast<const uint32_t*>(&_t0_bf16[1])),
+                         "r"(*reinterpret_cast<const uint32_t*>(&_t0_bf16[2])),
+                         "r"(*reinterpret_cast<const uint32_t*>(&_t0_bf16[3]))
+                         : "memory");
+          }
+          mbarrier_arrive(cg0_shared_acc_empty_addr);
+          mbarrier_wait(cg0_shared_acc_full_addr + 8, 0);
+          int kk_addr_12 = taddr + 256 + 64 + (unsigned int)qk_tmem_row_base_cg0;
+          float _tmem_load_1[32];
+          asm volatile(
+              "tcgen05.ld.sync.aligned.16x256b.x8.b32"
+              " {%0, %1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15, %16, %17, "
+              "%18, %19, %20, %21, %22, %23, %24, %25, %26, %27, %28, %29, %30, %31}, [%32];"
+              : "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_1[0])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_1[1])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_1[2])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_1[3])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_1[4])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_1[5])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_1[6])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_1[7])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_1[8])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_1[9])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_1[10])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_1[11])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_1[12])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_1[13])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_1[14])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_1[15])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_1[16])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_1[17])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_1[18])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_1[19])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_1[20])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_1[21])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_1[22])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_1[23])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_1[24])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_1[25])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_1[26])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_1[27])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_1[28])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_1[29])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_1[30])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_1[31]))
+              : "r"(kk_addr_12));
+          int kk_beta_row0_cg0_13 = qk_warp_row_base_cg0 + lane_row_cg0;
+          int kk_beta_row1_cg0_14 = kk_beta_row0_cg0_13 + 8;
+          float kk_beta0_cg0_15 = smem_beta[beta1_elem_base + kk_beta_row0_cg0_13];
+          float kk_beta1_cg0_16 = smem_beta[beta1_elem_base + kk_beta_row1_cg0_14];
+          int kk_stsm_row_cg0_17 = qk_warp_row_base_cg0 + (lane & 7) + (lane & 8);
+          int kk_stsm_col_lane_cg0_18 = (lane & 16) / 2;
+#pragma unroll
+          for (int qk_repeat_cg0_2 = 0; qk_repeat_cg0_2 < 4; qk_repeat_cg0_2++) {
+            const int qk_j0_cg0_1 = qk_repeat_cg0_2 * 8;
+            float _t1[8];
+#pragma unroll
+            for (int _ls = 0; _ls < 4; _ls++)
+              reinterpret_cast<float2*>(_t1)[_ls] =
+                  mul_f32x2(reinterpret_cast<float2*>((_tmem_load_1 + qk_j0_cg0_1))[_ls],
+                            reinterpret_cast<const float2*>((qk_transfer1_cg0 + qk_j0_cg0_1))[_ls]);
+            const float2 _scale2_15 = {kk_beta0_cg0_15, kk_beta0_cg0_15};
+#pragma unroll
+            for (int _ls = 0; _ls < 1; _ls++)
+              mul_f32x2_inplace(&reinterpret_cast<float2*>((_t1 + 0))[_ls], _scale2_15);
+            const float2 _scale2_16 = {kk_beta1_cg0_16, kk_beta1_cg0_16};
+#pragma unroll
+            for (int _ls = 0; _ls < 1; _ls++)
+              mul_f32x2_inplace(&reinterpret_cast<float2*>((_t1 + 2))[_ls], _scale2_16);
+            const float2 _scale2_17 = {kk_beta0_cg0_15, kk_beta0_cg0_15};
+#pragma unroll
+            for (int _ls = 0; _ls < 1; _ls++)
+              mul_f32x2_inplace(&reinterpret_cast<float2*>((_t1 + 4))[_ls], _scale2_17);
+            const float2 _scale2_18 = {kk_beta1_cg0_16, kk_beta1_cg0_16};
+#pragma unroll
+            for (int _ls = 0; _ls < 1; _ls++)
+              mul_f32x2_inplace(&reinterpret_cast<float2*>((_t1 + 6))[_ls], _scale2_18);
+            uint32_t _t1_bf16[4];
+#pragma unroll
+            for (int _lp = 0; _lp < 4; _lp++) {
+              __nv_bfloat162 _bf2 =
+                  __float22bfloat162_rn(make_float2(_t1[_lp * 2 + 0], _t1[_lp * 2 + 1 + 0]));
+              _t1_bf16[_lp] = *(uint32_t*)&_bf2;
+            }
+            int kk_stsm_addr_cg0_1 =
+                smem_ainv_rm_addr + ainv1_stage * 8192 +
+                (unsigned int)(kk_stsm_row_cg0_17 * 128 +
+                                   (qk_repeat_cg0_2 * 16 + kk_stsm_col_lane_cg0_18) * 2 ^
+                               (kk_stsm_row_cg0_17 * 128 +
+                                        (qk_repeat_cg0_2 * 16 + kk_stsm_col_lane_cg0_18) * 2 >>
+                                    7 &
+                                7) << 4);
+            uint32_t _stmatrix_addr_19 =
+                static_cast<uint32_t>((unsigned long long)kk_stsm_addr_cg0_1);
+            asm volatile("stmatrix.sync.aligned.m8n8.x4.shared.b16 [%0], {%1, %2, %3, %4};\n" ::"r"(
+                             _stmatrix_addr_19),
+                         "r"(*reinterpret_cast<const uint32_t*>(&_t1_bf16[0])),
+                         "r"(*reinterpret_cast<const uint32_t*>(&_t1_bf16[1])),
+                         "r"(*reinterpret_cast<const uint32_t*>(&_t1_bf16[2])),
+                         "r"(*reinterpret_cast<const uint32_t*>(&_t1_bf16[3]))
+                         : "memory");
+          }
+          mbarrier_arrive(cg0_shared_acc_empty_addr + 8);
+          asm volatile("barrier.sync 12, 128;" ::: "memory");
+          int inverse_group_cg0 = warp_id_in_role_cg0 / 2;
+          int inverse_local_warp_cg0 = warp_id_in_role_cg0 & 1;
+          unsigned int inverse_stage_cg0 = ainv0_stage;
+          if (inverse_group_cg0 == 1) {
+            inverse_stage_cg0 = ainv1_stage;
+          }
+          int inverse_row_cg0 = inverse_local_warp_cg0 * 32 + lane;
+          int diag_block_cg0 = inverse_row_cg0 / 8;
+          int lane_in_diag_cg0 = lane & 7;
+          int diag_col_base_cg0 = diag_block_cg0 * 8;
+          float inv_row_cg0[8];
+          if (inverse_row_cg0 < 64) {
+#pragma unroll
+            for (int inv_j = 0; inv_j < 8; inv_j++) {
+              int inv_col_cg0 = diag_col_base_cg0 + inv_j;
+              inv_row_cg0[inv_j] = reinterpret_cast<const __nv_bfloat16*>(
+                  reinterpret_cast<const uint8_t*>(smem_ainv_rm) +
+                  (inverse_stage_cg0 * 8192 +
+                   (unsigned int)(inverse_row_cg0 * 128 + inv_col_cg0 * 2 ^
+                                  (inverse_row_cg0 * 128 + inv_col_cg0 * 2 >> 7 & 7) << 4)))[0];
+              if (lane_in_diag_cg0 == inv_j) {
+                inv_row_cg0[inv_j] = 1.0f;
+              }
+            }
+            int diag_group_base_cg0 = lane - lane_in_diag_cg0;
+#pragma unroll
+            for (int src_row_cg0 = 0; src_row_cg0 < 7; src_row_cg0++) {
+              float row_scale_cg0 = -1.0f * inv_row_cg0[src_row_cg0];
+#pragma unroll
+              for (int prev_col_cg0 = 0; prev_col_cg0 < src_row_cg0; prev_col_cg0++) {
+                int pivot_lane_cg0 = diag_group_base_cg0 + src_row_cg0;
+                float _shfl_0 = __shfl_sync(0xFFFFFFFF, inv_row_cg0[prev_col_cg0], pivot_lane_cg0);
+                float shfl_val_cg0 = _shfl_0;
+                if (lane_in_diag_cg0 > src_row_cg0) {
+                  inv_row_cg0[prev_col_cg0] =
+                      inv_row_cg0[prev_col_cg0] + row_scale_cg0 * shfl_val_cg0;
+                }
+              }
+              if (lane_in_diag_cg0 > src_row_cg0) {
+                inv_row_cg0[src_row_cg0] = row_scale_cg0;
+              }
+            }
+            uint32_t inv_row_cg0_bf16[4];
+#pragma unroll
+            for (int _lp = 0; _lp < 4; _lp++) {
+              __nv_bfloat162 _bf2 = __float22bfloat162_rn(
+                  make_float2(inv_row_cg0[_lp * 2 + 0], inv_row_cg0[_lp * 2 + 1 + 0]));
+              inv_row_cg0_bf16[_lp] = *(uint32_t*)&_bf2;
+            }
+            int inv_diag_addr_cg0 =
+                smem_ainv_rm_addr + inverse_stage_cg0 * 8192 +
+                (unsigned int)(inverse_row_cg0 * 128 + diag_col_base_cg0 * 2 ^
+                               (inverse_row_cg0 * 128 + diag_col_base_cg0 * 2 >> 7 & 7) << 4);
+#pragma unroll
+            for (int inv_store_j_cg0 = 0; inv_store_j_cg0 < 4; inv_store_j_cg0++) {
+              asm volatile("st.shared.b32 [%0], %1;" ::"r"(inv_diag_addr_cg0 + inv_store_j_cg0 * 4),
+                           "r"((inv_row_cg0_bf16[inv_store_j_cg0])));
+            }
+          }
+          asm volatile("barrier.sync 12, 128;" ::: "memory");
+          if (inverse_local_warp_cg0 == 0) {
+            int inv16_lane_row_cg0 = lane & 7;
+            int inv16_d_addr_cg0 =
+                smem_ainv_rm_addr + inverse_stage_cg0 * 8192 +
+                (unsigned int)((8 + inv16_lane_row_cg0) * 128 + 16 ^
+                               ((8 + inv16_lane_row_cg0) * 128 + 16 >> 7 & 7) << 4);
+            int inv16_c_addr_cg0 = smem_ainv_rm_addr + inverse_stage_cg0 * 8192 +
+                                   (unsigned int)((8 + inv16_lane_row_cg0) * 128 ^
+                                                  ((8 + inv16_lane_row_cg0) * 128 >> 7 & 7) << 4);
+            int inv16_a_addr_cg0 =
+                smem_ainv_rm_addr + inverse_stage_cg0 * 8192 +
+                (unsigned int)(inv16_lane_row_cg0 * 128 ^ (inv16_lane_row_cg0 * 128 >> 7 & 7) << 4);
+            int inv16_o_addr_cg0 = smem_ainv_rm_addr + inverse_stage_cg0 * 8192 +
+                                   (unsigned int)((8 + inv16_lane_row_cg0) * 128 ^
+                                                  ((8 + inv16_lane_row_cg0) * 128 >> 7 & 7) << 4);
+            unsigned int inv16_d_frag_cg0[2];
+            unsigned int inv16_c_frag_cg0[1];
+            float inv16_dc_acc_cg0[4];
+            unsigned int inv16_dc_bf16_cg0[2];
+            unsigned int inv16_a_frag_cg0[1];
+            float inv16_o_acc_cg0[4];
+            unsigned int inv16_o_bf16_cg0[2];
+            asm volatile("ldmatrix.sync.aligned.m8n8.x1.shared.b16 {%0}, [%1];\n"
+                         : "=r"(inv16_d_frag_cg0[0])
+                         : "r"(inv16_d_addr_cg0)
+                         : "memory");
+            asm volatile("ldmatrix.sync.aligned.m8n8.x1.shared.b16 {%0}, [%1];\n"
+                         : "=r"(inv16_d_frag_cg0[1])
+                         : "r"(inv16_d_addr_cg0)
+                         : "memory");
+            asm volatile("ldmatrix.sync.aligned.m8n8.x1.trans.shared.b16 {%0}, [%1];\n"
+                         : "=r"(inv16_c_frag_cg0[0])
+                         : "r"(inv16_c_addr_cg0)
+                         : "memory");
+            asm volatile(
+                "mma.sync.aligned.m16n8k8.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5}, "
+                "{%6}, {%7, %8, %9, %10};\n"
+                : "=f"(inv16_dc_acc_cg0[0]), "=f"(inv16_dc_acc_cg0[1]), "=f"(inv16_dc_acc_cg0[2]),
+                  "=f"(inv16_dc_acc_cg0[3])
+                : "r"(inv16_d_frag_cg0[0]), "r"(inv16_d_frag_cg0[1]), "r"(inv16_c_frag_cg0[0]),
+                  "f"(0.0f), "f"(0.0f), "f"(0.0f), "f"(0.0f));
+#pragma unroll
+            for (int inv16_i_cg0 = 0; inv16_i_cg0 < 4; inv16_i_cg0++) {
+              inv16_dc_acc_cg0[inv16_i_cg0] = inv16_dc_acc_cg0[inv16_i_cg0] * -1.0f;
+            }
+#pragma unroll
+            for (int _lp = 0; _lp < 2; _lp++) {
+              __nv_bfloat162 _bf2 = __float22bfloat162_rn(
+                  make_float2(inv16_dc_acc_cg0[_lp * 2 + 0], inv16_dc_acc_cg0[_lp * 2 + 1 + 0]));
+              inv16_dc_bf16_cg0[_lp] = *(uint32_t*)&_bf2;
+            }
+            asm volatile("ldmatrix.sync.aligned.m8n8.x1.trans.shared.b16 {%0}, [%1];\n"
+                         : "=r"(inv16_a_frag_cg0[0])
+                         : "r"(inv16_a_addr_cg0)
+                         : "memory");
+            asm volatile(
+                "mma.sync.aligned.m16n8k8.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5}, "
+                "{%6}, {%7, %8, %9, %10};\n"
+                : "=f"(inv16_o_acc_cg0[0]), "=f"(inv16_o_acc_cg0[1]), "=f"(inv16_o_acc_cg0[2]),
+                  "=f"(inv16_o_acc_cg0[3])
+                : "r"(inv16_dc_bf16_cg0[0]), "r"(inv16_dc_bf16_cg0[1]), "r"(inv16_a_frag_cg0[0]),
+                  "f"(0.0f), "f"(0.0f), "f"(0.0f), "f"(0.0f));
+#pragma unroll
+            for (int _lp = 0; _lp < 2; _lp++) {
+              __nv_bfloat162 _bf2 = __float22bfloat162_rn(
+                  make_float2(inv16_o_acc_cg0[_lp * 2 + 0], inv16_o_acc_cg0[_lp * 2 + 1 + 0]));
+              inv16_o_bf16_cg0[_lp] = *(uint32_t*)&_bf2;
+            }
+            uint32_t _stmatrix_addr_20 =
+                static_cast<uint32_t>((unsigned long long)inv16_o_addr_cg0);
+            asm volatile(
+                "stmatrix.sync.aligned.m8n8.x1.shared.b16 [%0], {%1};\n" ::"r"(_stmatrix_addr_20),
+                "r"(*reinterpret_cast<const uint32_t*>(&inv16_o_bf16_cg0[0]))
+                : "memory");
+          }
+          asm volatile("barrier.sync 12, 128;" ::: "memory");
+          asm volatile("barrier.sync 12, 128;" ::: "memory");
+          asm volatile("barrier.sync 12, 128;" ::: "memory");
+          if (warp_id_in_role_cg0 < 4) {
+            unsigned int ainv_beta_ld_bits_cg0[4];
+            int ainv_beta_tile_row_cg0 = warp_id_in_role_cg0 * 16 + (lane & 7) + (lane & 8);
+            int ainv_beta_tile_col_lane_cg0 = (lane & 16) / 2;
+            int ainv_beta_pair_col_cg0 = (lane & 3) * 2;
+#pragma unroll 1
+            for (int beta_col_tile_cg0 = 0; beta_col_tile_cg0 < 4; beta_col_tile_cg0++) {
+              int ainv_beta_tile_col_cg0 = beta_col_tile_cg0 * 16 + ainv_beta_tile_col_lane_cg0;
+              int ainv_beta_ld_addr_cg0 =
+                  smem_ainv_rm_addr + ainv0_stage * 8192 +
+                  (unsigned int)(ainv_beta_tile_row_cg0 * 128 + ainv_beta_tile_col_cg0 * 2 ^
+                                 (ainv_beta_tile_row_cg0 * 128 + ainv_beta_tile_col_cg0 * 2 >> 7 &
+                                  7) << 4);
+              asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                           : "=r"(ainv_beta_ld_bits_cg0[0]), "=r"(ainv_beta_ld_bits_cg0[1]),
+                             "=r"(ainv_beta_ld_bits_cg0[2]), "=r"(ainv_beta_ld_bits_cg0[3])
+                           : "r"(ainv_beta_ld_addr_cg0)
+                           : "memory");
+              int ainv_beta_col0_cg0 = beta_col_tile_cg0 * 16 + ainv_beta_pair_col_cg0;
+              int ainv_beta_col8_cg0 = ainv_beta_col0_cg0 + 8;
+              float ainv_beta_scale0_lo_cg0 = smem_beta[beta0_elem_base + ainv_beta_col0_cg0];
+              float ainv_beta_scale0_hi_cg0 = smem_beta[beta0_elem_base + ainv_beta_col0_cg0 + 1];
+              float ainv_beta_scale8_lo_cg0 = smem_beta[beta0_elem_base + ainv_beta_col8_cg0];
+              float ainv_beta_scale8_hi_cg0 = smem_beta[beta0_elem_base + ainv_beta_col8_cg0 + 1];
+              uint32_t _bf16x2_scale_0;
+              {
+                uint32_t _bf16x2_pair_21 = ainv_beta_ld_bits_cg0[0];
+                float _bf16x2_lo_21;
+                float _bf16x2_hi_21;
+                asm volatile("cvt.f32.bf16 %0, %1;"
+                             : "=f"(_bf16x2_lo_21)
+                             : "h"((uint16_t)(_bf16x2_pair_21 & 0xFFFFu)));
+                asm volatile("cvt.f32.bf16 %0, %1;"
+                             : "=f"(_bf16x2_hi_21)
+                             : "h"((uint16_t)(_bf16x2_pair_21 >> 16)));
+                _bf16x2_lo_21 *= ainv_beta_scale0_lo_cg0;
+                _bf16x2_hi_21 *= ainv_beta_scale0_hi_cg0;
+                uint32_t _bf16x2_out_21;
+                asm volatile("cvt.rn.bf16x2.f32 %0, %1, %2;"
+                             : "=r"(_bf16x2_out_21)
+                             : "f"(_bf16x2_hi_21), "f"(_bf16x2_lo_21));
+                _bf16x2_scale_0 = _bf16x2_out_21;
+              }
+              uint32_t _bf16x2_scale_1;
+              {
+                uint32_t _bf16x2_pair_22 = ainv_beta_ld_bits_cg0[1];
+                float _bf16x2_lo_22;
+                float _bf16x2_hi_22;
+                asm volatile("cvt.f32.bf16 %0, %1;"
+                             : "=f"(_bf16x2_lo_22)
+                             : "h"((uint16_t)(_bf16x2_pair_22 & 0xFFFFu)));
+                asm volatile("cvt.f32.bf16 %0, %1;"
+                             : "=f"(_bf16x2_hi_22)
+                             : "h"((uint16_t)(_bf16x2_pair_22 >> 16)));
+                _bf16x2_lo_22 *= ainv_beta_scale0_lo_cg0;
+                _bf16x2_hi_22 *= ainv_beta_scale0_hi_cg0;
+                uint32_t _bf16x2_out_22;
+                asm volatile("cvt.rn.bf16x2.f32 %0, %1, %2;"
+                             : "=r"(_bf16x2_out_22)
+                             : "f"(_bf16x2_hi_22), "f"(_bf16x2_lo_22));
+                _bf16x2_scale_1 = _bf16x2_out_22;
+              }
+              uint32_t _bf16x2_scale_2;
+              {
+                uint32_t _bf16x2_pair_23 = ainv_beta_ld_bits_cg0[2];
+                float _bf16x2_lo_23;
+                float _bf16x2_hi_23;
+                asm volatile("cvt.f32.bf16 %0, %1;"
+                             : "=f"(_bf16x2_lo_23)
+                             : "h"((uint16_t)(_bf16x2_pair_23 & 0xFFFFu)));
+                asm volatile("cvt.f32.bf16 %0, %1;"
+                             : "=f"(_bf16x2_hi_23)
+                             : "h"((uint16_t)(_bf16x2_pair_23 >> 16)));
+                _bf16x2_lo_23 *= ainv_beta_scale8_lo_cg0;
+                _bf16x2_hi_23 *= ainv_beta_scale8_hi_cg0;
+                uint32_t _bf16x2_out_23;
+                asm volatile("cvt.rn.bf16x2.f32 %0, %1, %2;"
+                             : "=r"(_bf16x2_out_23)
+                             : "f"(_bf16x2_hi_23), "f"(_bf16x2_lo_23));
+                _bf16x2_scale_2 = _bf16x2_out_23;
+              }
+              uint32_t _bf16x2_scale_3;
+              {
+                uint32_t _bf16x2_pair_24 = ainv_beta_ld_bits_cg0[3];
+                float _bf16x2_lo_24;
+                float _bf16x2_hi_24;
+                asm volatile("cvt.f32.bf16 %0, %1;"
+                             : "=f"(_bf16x2_lo_24)
+                             : "h"((uint16_t)(_bf16x2_pair_24 & 0xFFFFu)));
+                asm volatile("cvt.f32.bf16 %0, %1;"
+                             : "=f"(_bf16x2_hi_24)
+                             : "h"((uint16_t)(_bf16x2_pair_24 >> 16)));
+                _bf16x2_lo_24 *= ainv_beta_scale8_lo_cg0;
+                _bf16x2_hi_24 *= ainv_beta_scale8_hi_cg0;
+                uint32_t _bf16x2_out_24;
+                asm volatile("cvt.rn.bf16x2.f32 %0, %1, %2;"
+                             : "=r"(_bf16x2_out_24)
+                             : "f"(_bf16x2_hi_24), "f"(_bf16x2_lo_24));
+                _bf16x2_scale_3 = _bf16x2_out_24;
+              }
+              uint32_t _stmatrix_addr_25 = static_cast<uint32_t>(
+                  (unsigned long long)(smem_ainv_addr + ainv0_stage * 8192 +
+                                       (unsigned int)(ainv_beta_tile_row_cg0 * 128 +
+                                                          ainv_beta_tile_col_cg0 * 2 ^
+                                                      (ainv_beta_tile_row_cg0 * 128 +
+                                                               ainv_beta_tile_col_cg0 * 2 >>
+                                                           7 &
+                                                       7) << 4)));
+              asm volatile(
+                  "stmatrix.sync.aligned.m8n8.x4.shared.b16 [%0], {%1, %2, %3, %4};\n" ::"r"(
+                      _stmatrix_addr_25),
+                  "r"(*reinterpret_cast<const uint32_t*>(&_bf16x2_scale_0)),
+                  "r"(*reinterpret_cast<const uint32_t*>(&_bf16x2_scale_1)),
+                  "r"(*reinterpret_cast<const uint32_t*>(&_bf16x2_scale_2)),
+                  "r"(*reinterpret_cast<const uint32_t*>(&_bf16x2_scale_3))
+                  : "memory");
+            }
+          }
+          asm volatile("fence.proxy.async.shared::cta;" ::: "memory");
+          mbarrier_arrive(ainv_ready_addr + (ainv0_stage) * 8);
+          mbarrier_arrive(beta_smem_empty_addr + (beta0_stage) * 8);
+          if (warp_id_in_role_cg0 < 4) {
+            unsigned int ainv_beta_ld_bits_cg0_1[4];
+            int ainv_beta_tile_row_cg0_1 = warp_id_in_role_cg0 * 16 + (lane & 7) + (lane & 8);
+            int ainv_beta_tile_col_lane_cg0_1 = (lane & 16) / 2;
+            int ainv_beta_pair_col_cg0_1 = (lane & 3) * 2;
+#pragma unroll 1
+            for (int beta_col_tile_cg0_1 = 0; beta_col_tile_cg0_1 < 4; beta_col_tile_cg0_1++) {
+              int ainv_beta_tile_col_cg0_1 =
+                  beta_col_tile_cg0_1 * 16 + ainv_beta_tile_col_lane_cg0_1;
+              int ainv_beta_ld_addr_cg0_1 =
+                  smem_ainv_rm_addr + ainv1_stage * 8192 +
+                  (unsigned int)(ainv_beta_tile_row_cg0_1 * 128 + ainv_beta_tile_col_cg0_1 * 2 ^
+                                 (ainv_beta_tile_row_cg0_1 * 128 + ainv_beta_tile_col_cg0_1 * 2 >>
+                                      7 &
+                                  7) << 4);
+              asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                           : "=r"(ainv_beta_ld_bits_cg0_1[0]), "=r"(ainv_beta_ld_bits_cg0_1[1]),
+                             "=r"(ainv_beta_ld_bits_cg0_1[2]), "=r"(ainv_beta_ld_bits_cg0_1[3])
+                           : "r"(ainv_beta_ld_addr_cg0_1)
+                           : "memory");
+              int ainv_beta_col0_cg0_1 = beta_col_tile_cg0_1 * 16 + ainv_beta_pair_col_cg0_1;
+              int ainv_beta_col8_cg0_1 = ainv_beta_col0_cg0_1 + 8;
+              float ainv_beta_scale0_lo_cg0_1 = smem_beta[beta1_elem_base + ainv_beta_col0_cg0_1];
+              float ainv_beta_scale0_hi_cg0_1 =
+                  smem_beta[beta1_elem_base + ainv_beta_col0_cg0_1 + 1];
+              float ainv_beta_scale8_lo_cg0_1 = smem_beta[beta1_elem_base + ainv_beta_col8_cg0_1];
+              float ainv_beta_scale8_hi_cg0_1 =
+                  smem_beta[beta1_elem_base + ainv_beta_col8_cg0_1 + 1];
+              uint32_t _bf16x2_scale_4;
+              {
+                uint32_t _bf16x2_pair_26 = ainv_beta_ld_bits_cg0_1[0];
+                float _bf16x2_lo_26;
+                float _bf16x2_hi_26;
+                asm volatile("cvt.f32.bf16 %0, %1;"
+                             : "=f"(_bf16x2_lo_26)
+                             : "h"((uint16_t)(_bf16x2_pair_26 & 0xFFFFu)));
+                asm volatile("cvt.f32.bf16 %0, %1;"
+                             : "=f"(_bf16x2_hi_26)
+                             : "h"((uint16_t)(_bf16x2_pair_26 >> 16)));
+                _bf16x2_lo_26 *= ainv_beta_scale0_lo_cg0_1;
+                _bf16x2_hi_26 *= ainv_beta_scale0_hi_cg0_1;
+                uint32_t _bf16x2_out_26;
+                asm volatile("cvt.rn.bf16x2.f32 %0, %1, %2;"
+                             : "=r"(_bf16x2_out_26)
+                             : "f"(_bf16x2_hi_26), "f"(_bf16x2_lo_26));
+                _bf16x2_scale_4 = _bf16x2_out_26;
+              }
+              uint32_t _bf16x2_scale_5;
+              {
+                uint32_t _bf16x2_pair_27 = ainv_beta_ld_bits_cg0_1[1];
+                float _bf16x2_lo_27;
+                float _bf16x2_hi_27;
+                asm volatile("cvt.f32.bf16 %0, %1;"
+                             : "=f"(_bf16x2_lo_27)
+                             : "h"((uint16_t)(_bf16x2_pair_27 & 0xFFFFu)));
+                asm volatile("cvt.f32.bf16 %0, %1;"
+                             : "=f"(_bf16x2_hi_27)
+                             : "h"((uint16_t)(_bf16x2_pair_27 >> 16)));
+                _bf16x2_lo_27 *= ainv_beta_scale0_lo_cg0_1;
+                _bf16x2_hi_27 *= ainv_beta_scale0_hi_cg0_1;
+                uint32_t _bf16x2_out_27;
+                asm volatile("cvt.rn.bf16x2.f32 %0, %1, %2;"
+                             : "=r"(_bf16x2_out_27)
+                             : "f"(_bf16x2_hi_27), "f"(_bf16x2_lo_27));
+                _bf16x2_scale_5 = _bf16x2_out_27;
+              }
+              uint32_t _bf16x2_scale_6;
+              {
+                uint32_t _bf16x2_pair_28 = ainv_beta_ld_bits_cg0_1[2];
+                float _bf16x2_lo_28;
+                float _bf16x2_hi_28;
+                asm volatile("cvt.f32.bf16 %0, %1;"
+                             : "=f"(_bf16x2_lo_28)
+                             : "h"((uint16_t)(_bf16x2_pair_28 & 0xFFFFu)));
+                asm volatile("cvt.f32.bf16 %0, %1;"
+                             : "=f"(_bf16x2_hi_28)
+                             : "h"((uint16_t)(_bf16x2_pair_28 >> 16)));
+                _bf16x2_lo_28 *= ainv_beta_scale8_lo_cg0_1;
+                _bf16x2_hi_28 *= ainv_beta_scale8_hi_cg0_1;
+                uint32_t _bf16x2_out_28;
+                asm volatile("cvt.rn.bf16x2.f32 %0, %1, %2;"
+                             : "=r"(_bf16x2_out_28)
+                             : "f"(_bf16x2_hi_28), "f"(_bf16x2_lo_28));
+                _bf16x2_scale_6 = _bf16x2_out_28;
+              }
+              uint32_t _bf16x2_scale_7;
+              {
+                uint32_t _bf16x2_pair_29 = ainv_beta_ld_bits_cg0_1[3];
+                float _bf16x2_lo_29;
+                float _bf16x2_hi_29;
+                asm volatile("cvt.f32.bf16 %0, %1;"
+                             : "=f"(_bf16x2_lo_29)
+                             : "h"((uint16_t)(_bf16x2_pair_29 & 0xFFFFu)));
+                asm volatile("cvt.f32.bf16 %0, %1;"
+                             : "=f"(_bf16x2_hi_29)
+                             : "h"((uint16_t)(_bf16x2_pair_29 >> 16)));
+                _bf16x2_lo_29 *= ainv_beta_scale8_lo_cg0_1;
+                _bf16x2_hi_29 *= ainv_beta_scale8_hi_cg0_1;
+                uint32_t _bf16x2_out_29;
+                asm volatile("cvt.rn.bf16x2.f32 %0, %1, %2;"
+                             : "=r"(_bf16x2_out_29)
+                             : "f"(_bf16x2_hi_29), "f"(_bf16x2_lo_29));
+                _bf16x2_scale_7 = _bf16x2_out_29;
+              }
+              uint32_t _stmatrix_addr_30 = static_cast<uint32_t>(
+                  (unsigned long long)(smem_ainv_addr + ainv1_stage * 8192 +
+                                       (unsigned int)(ainv_beta_tile_row_cg0_1 * 128 +
+                                                          ainv_beta_tile_col_cg0_1 * 2 ^
+                                                      (ainv_beta_tile_row_cg0_1 * 128 +
+                                                               ainv_beta_tile_col_cg0_1 * 2 >>
+                                                           7 &
+                                                       7) << 4)));
+              asm volatile(
+                  "stmatrix.sync.aligned.m8n8.x4.shared.b16 [%0], {%1, %2, %3, %4};\n" ::"r"(
+                      _stmatrix_addr_30),
+                  "r"(*reinterpret_cast<const uint32_t*>(&_bf16x2_scale_4)),
+                  "r"(*reinterpret_cast<const uint32_t*>(&_bf16x2_scale_5)),
+                  "r"(*reinterpret_cast<const uint32_t*>(&_bf16x2_scale_6)),
+                  "r"(*reinterpret_cast<const uint32_t*>(&_bf16x2_scale_7))
+                  : "memory");
+            }
+          }
+          asm volatile("fence.proxy.async.shared::cta;" ::: "memory");
+          mbarrier_arrive(ainv_ready_addr + (ainv1_stage) * 8);
+          mbarrier_arrive(beta_smem_empty_addr + (beta1_stage) * 8);
+          unsigned int qk0_stage = qk_cg0_stage;
+          mbarrier_wait(qk_smem_empty_addr + (qk0_stage) * 8, qk_cg0_phase);
+          qk_cg0_stage += 1;
+          if (qk_cg0_stage == 2) {
+            qk_cg0_stage = 0;
+            qk_cg0_phase ^= 1;
+          }
+          unsigned int qk1_stage = qk_cg0_stage;
+          mbarrier_wait(qk_smem_empty_addr + (qk1_stage) * 8, qk_cg0_phase);
+          qk_cg0_stage += 1;
+          if (qk_cg0_stage == 2) {
+            qk_cg0_stage = 0;
+            qk_cg0_phase ^= 1;
+          }
+          mbarrier_wait(cg0_shared_acc_full_addr, 1);
+          int qk_addr = taddr + 256 + (unsigned int)qk_tmem_row_base_cg0;
+          float _tmem_load_2[32];
+          asm volatile(
+              "tcgen05.ld.sync.aligned.16x256b.x8.b32"
+              " {%0, %1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15, %16, %17, "
+              "%18, %19, %20, %21, %22, %23, %24, %25, %26, %27, %28, %29, %30, %31}, [%32];"
+              : "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_2[0])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_2[1])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_2[2])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_2[3])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_2[4])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_2[5])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_2[6])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_2[7])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_2[8])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_2[9])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_2[10])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_2[11])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_2[12])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_2[13])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_2[14])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_2[15])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_2[16])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_2[17])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_2[18])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_2[19])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_2[20])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_2[21])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_2[22])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_2[23])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_2[24])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_2[25])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_2[26])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_2[27])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_2[28])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_2[29])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_2[30])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_2[31]))
+              : "r"(qk_addr));
+          int qk_stsm_row_cg0 = qk_warp_row_base_cg0 + (lane & 7) + (lane & 8);
+          int qk_stsm_col_lane_cg0 = (lane & 16) / 2;
+#pragma unroll
+          for (int qk_repeat_cg0_3 = 0; qk_repeat_cg0_3 < 4; qk_repeat_cg0_3++) {
+            const int qk_j0_cg0_2 = qk_repeat_cg0_3 * 8;
+            float _t2[8];
+#pragma unroll
+            for (int _ls = 0; _ls < 4; _ls++)
+              reinterpret_cast<float2*>(_t2)[_ls] =
+                  mul_f32x2(reinterpret_cast<float2*>((_tmem_load_2 + qk_j0_cg0_2))[_ls],
+                            reinterpret_cast<const float2*>((qk_transfer0_cg0 + qk_j0_cg0_2))[_ls]);
+            uint32_t _t2_bf16[4];
+#pragma unroll
+            for (int _lp = 0; _lp < 4; _lp++) {
+              __nv_bfloat162 _bf2 =
+                  __float22bfloat162_rn(make_float2(_t2[_lp * 2 + 0], _t2[_lp * 2 + 1 + 0]));
+              _t2_bf16[_lp] = *(uint32_t*)&_bf2;
+            }
+            uint32_t _stmatrix_addr_31 = static_cast<uint32_t>((
+                unsigned long long)(smem_qk_addr + qk0_stage * 8192 +
+                                    (unsigned int)(qk_stsm_row_cg0 * 128 + (qk_repeat_cg0_3 * 16 +
+                                                                            qk_stsm_col_lane_cg0) *
+                                                                               2 ^
+                                                   (qk_stsm_row_cg0 * 128 + (qk_repeat_cg0_3 * 16 +
+                                                                             qk_stsm_col_lane_cg0) *
+                                                                                2 >>
+                                                        7 &
+                                                    7) << 4)));
+            asm volatile("stmatrix.sync.aligned.m8n8.x4.shared.b16 [%0], {%1, %2, %3, %4};\n" ::"r"(
+                             _stmatrix_addr_31),
+                         "r"(*reinterpret_cast<const uint32_t*>(&_t2_bf16[0])),
+                         "r"(*reinterpret_cast<const uint32_t*>(&_t2_bf16[1])),
+                         "r"(*reinterpret_cast<const uint32_t*>(&_t2_bf16[2])),
+                         "r"(*reinterpret_cast<const uint32_t*>(&_t2_bf16[3]))
+                         : "memory");
+          }
+          asm volatile("fence.proxy.async.shared::cta;" ::: "memory");
+          mbarrier_arrive(cg0_shared_acc_empty_addr);
+          mbarrier_arrive(qk_ready_addr + (qk0_stage) * 8);
+          mbarrier_wait(cg0_shared_acc_full_addr + 8, 1);
+          int qk_addr_19 = taddr + 256 + 64 + (unsigned int)qk_tmem_row_base_cg0;
+          float _tmem_load_3[32];
+          asm volatile(
+              "tcgen05.ld.sync.aligned.16x256b.x8.b32"
+              " {%0, %1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15, %16, %17, "
+              "%18, %19, %20, %21, %22, %23, %24, %25, %26, %27, %28, %29, %30, %31}, [%32];"
+              : "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[0])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[1])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[2])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[3])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[4])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[5])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[6])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[7])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[8])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[9])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[10])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[11])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[12])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[13])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[14])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[15])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[16])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[17])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[18])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[19])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[20])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[21])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[22])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[23])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[24])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[25])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[26])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[27])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[28])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[29])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[30])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[31]))
+              : "r"(qk_addr_19));
+          int qk_stsm_row_cg0_20 = qk_warp_row_base_cg0 + (lane & 7) + (lane & 8);
+          int qk_stsm_col_lane_cg0_21 = (lane & 16) / 2;
+#pragma unroll
+          for (int qk_repeat_cg0_4 = 0; qk_repeat_cg0_4 < 4; qk_repeat_cg0_4++) {
+            const int qk_j0_cg0_3 = qk_repeat_cg0_4 * 8;
+            float _t3[8];
+#pragma unroll
+            for (int _ls = 0; _ls < 4; _ls++)
+              reinterpret_cast<float2*>(_t3)[_ls] =
+                  mul_f32x2(reinterpret_cast<float2*>((_tmem_load_3 + qk_j0_cg0_3))[_ls],
+                            reinterpret_cast<const float2*>((qk_transfer1_cg0 + qk_j0_cg0_3))[_ls]);
+            uint32_t _t3_bf16[4];
+#pragma unroll
+            for (int _lp = 0; _lp < 4; _lp++) {
+              __nv_bfloat162 _bf2 =
+                  __float22bfloat162_rn(make_float2(_t3[_lp * 2 + 0], _t3[_lp * 2 + 1 + 0]));
+              _t3_bf16[_lp] = *(uint32_t*)&_bf2;
+            }
+            uint32_t _stmatrix_addr_32 = static_cast<uint32_t>(
+                (unsigned long long)(smem_qk_addr + qk1_stage * 8192 +
+                                     (unsigned int)(qk_stsm_row_cg0_20 * 128 +
+                                                        (qk_repeat_cg0_4 * 16 +
+                                                         qk_stsm_col_lane_cg0_21) *
+                                                            2 ^
+                                                    (qk_stsm_row_cg0_20 * 128 +
+                                                             (qk_repeat_cg0_4 * 16 +
+                                                              qk_stsm_col_lane_cg0_21) *
+                                                                 2 >>
+                                                         7 &
+                                                     7) << 4)));
+            asm volatile("stmatrix.sync.aligned.m8n8.x4.shared.b16 [%0], {%1, %2, %3, %4};\n" ::"r"(
+                             _stmatrix_addr_32),
+                         "r"(*reinterpret_cast<const uint32_t*>(&_t3_bf16[0])),
+                         "r"(*reinterpret_cast<const uint32_t*>(&_t3_bf16[1])),
+                         "r"(*reinterpret_cast<const uint32_t*>(&_t3_bf16[2])),
+                         "r"(*reinterpret_cast<const uint32_t*>(&_t3_bf16[3]))
+                         : "memory");
+          }
+          asm volatile("fence.proxy.async.shared::cta;" ::: "memory");
+          mbarrier_arrive(cg0_shared_acc_empty_addr + 8);
+          mbarrier_arrive(qk_ready_addr + (qk1_stage) * 8);
+          mbarrier_wait(ki_mma_consumed_addr + (g0_stage) * 8, g_kr_phase);
+          int kr_col = tid;
+          float g_total = smem_g_total[gate0_stage * 128 + (unsigned int)kr_col];
+#pragma unroll
+          for (int kr_row = 0; kr_row < 16; kr_row++) {
+            float ki = (float)reinterpret_cast<const __nv_bfloat16*>(
+                (reinterpret_cast<const uint8_t*>(reinterpret_cast<const uint8_t*>(smem_g) +
+                                                  (g0_stage * 16384)) +
+                 (kr_col / 64 * 8192 + kr_row * 128 + kr_col % 64 * 2 ^
+                  (kr_col / 64 * 8192 + kr_row * 128 + kr_col % 64 * 2 >> 7 & 7) << 4)))[0];
+            {
+              __nv_bfloat16 _bval_33 = __float2bfloat16_rn(ki * g_total);
+              uint16_t _bits_33 = *(uint16_t*)&_bval_33;
+              uint32_t _addr_33 = static_cast<uint32_t>(
+                  (smem_g_addr + g0_stage * 16384 +
+                   (unsigned int)(kr_col / 64 * 8192 + kr_row * 128 + kr_col % 64 * 2 ^
+                                  (kr_col / 64 * 8192 + kr_row * 128 + kr_col % 64 * 2 >> 7 & 7)
+                                      << 4)));
+              asm volatile("st.shared.b16 [%0], %1;" ::"r"(_addr_33), "h"(_bits_33) : "memory");
+            }
+          }
+          asm volatile("fence.proxy.async.shared::cta;" ::: "memory");
+          mbarrier_arrive(kr_ready_addr + (g0_stage) * 8);
+          g_kr_stage += 1;
+          if (g_kr_stage == 2) {
+            g_kr_stage = 0;
+            g_kr_phase ^= 1;
+          }
+          mbarrier_wait(ki_mma_consumed_addr + (g1_stage) * 8, g_kr_phase);
+          int kr_col_22 = tid;
+          float g_total_23 = smem_g_total[gate1_stage * 128 + (unsigned int)kr_col_22];
+#pragma unroll
+          for (int kr_row_1 = 0; kr_row_1 < 16; kr_row_1++) {
+            float ki_1 = (float)reinterpret_cast<const __nv_bfloat16*>(
+                (reinterpret_cast<const uint8_t*>(reinterpret_cast<const uint8_t*>(smem_g) +
+                                                  (g1_stage * 16384)) +
+                 (kr_col_22 / 64 * 8192 + kr_row_1 * 128 + kr_col_22 % 64 * 2 ^
+                  (kr_col_22 / 64 * 8192 + kr_row_1 * 128 + kr_col_22 % 64 * 2 >> 7 & 7) << 4)))[0];
+            {
+              __nv_bfloat16 _bval_34 = __float2bfloat16_rn(ki_1 * g_total_23);
+              uint16_t _bits_34 = *(uint16_t*)&_bval_34;
+              uint32_t _addr_34 = static_cast<uint32_t>((
+                  smem_g_addr + g1_stage * 16384 +
+                  (unsigned int)(kr_col_22 / 64 * 8192 + kr_row_1 * 128 + kr_col_22 % 64 * 2 ^
+                                 (kr_col_22 / 64 * 8192 + kr_row_1 * 128 + kr_col_22 % 64 * 2 >> 7 &
+                                  7) << 4)));
+              asm volatile("st.shared.b16 [%0], %1;" ::"r"(_addr_34), "h"(_bits_34) : "memory");
+            }
+          }
+          asm volatile("fence.proxy.async.shared::cta;" ::: "memory");
+          mbarrier_arrive(kr_ready_addr + (g1_stage) * 8);
+          g_kr_stage += 1;
+          if (g_kr_stage == 2) {
+            g_kr_stage = 0;
+            g_kr_phase ^= 1;
+          }
+        }
+      }
+    }
+  }
+  // ---- Role: compute_group_1 ----
+  if (warp >= 4 && warp <= 7) {
+    asm volatile("setmaxnreg.inc.sync.aligned.u32 256;");
+    {  // compute_group_1_main
+      unsigned int gate_cg1_stage = 0;
+      unsigned int gate_cg1_phase = 0;
+      unsigned int v_cg1_stage = 0;
+      unsigned int v_cg1_phase = 0;
+      unsigned int o_cg1_stage = 0;
+      unsigned int o_cg1_phase = 1;
+      unsigned int _phase_initial_state_loaded_0 = 0;
+      unsigned int _phase_kv_acc_full_0 = 0;
+      unsigned int _phase_cg1_shared_acc_full_0 = 0;
+      unsigned int _phase_q_state_acc_full_0 = 0;
+#pragma unroll 1
+      for (unsigned int tile_1 = bid; tile_1 < total_tiles; tile_1 += num_bids) {
+        int num_o_heads_1 = ((num_q_heads >= num_v_heads) ? num_q_heads : num_v_heads);
+        int batch_idx_1 = tile_1 / (unsigned int)num_o_heads_1;
+        int head_idx_1 = tile_1 % (unsigned int)num_o_heads_1;
+        int qk_head_idx_1 =
+            ((num_q_heads >= num_v_heads) ? head_idx_1 : head_idx_1 / (num_v_heads / num_q_heads));
+        int v_head_idx_1 =
+            ((num_v_heads >= num_q_heads) ? head_idx_1 : head_idx_1 / (num_q_heads / num_v_heads));
+        int batch_start_1 = (int)cu_seqlens[batch_idx_1];
+        int batch_end_1 = (int)cu_seqlens[batch_idx_1 + 1];
+        int seqlen_b_1 = batch_end_1 - batch_start_1;
+        int num_pairs_b_1 = (seqlen_b_1 + 32 - 1) / 32;
+        int num_chunks_b_1 = num_pairs_b_1 * 2;
+        if (USE_INITIAL_STATE != 0 && num_chunks_b_1 > 0) {
+          int warp_in_wg = warp % 4;
+          int state_tmem_row_base_init = warp_in_wg * 32 << 16;
+          int warp_id_in_role_1 = (warp - 4);
+          int state_warp_init = warp_id_in_role_1;
+          int state_row_init = state_warp_init * 32 + lane;
+          int state_base_init =
+              (batch_idx_1 * num_o_heads_1 + head_idx_1) * 128 * 128 + state_row_init * 128;
+#pragma unroll
+          for (int state_col_block_init = 0; state_col_block_init < 4; state_col_block_init++) {
+            float state_init_frag[32];
+#pragma unroll
+            for (int state_vec_init = 0; state_vec_init < 8; state_vec_init++) {
+              {
+                float4 _v4 = *reinterpret_cast<const float4*>(initial_state + state_base_init +
+                                                              state_col_block_init * 32 +
+                                                              state_vec_init * 4);
+                state_init_frag[state_vec_init * 4 + 0] = _v4.x;
+                state_init_frag[state_vec_init * 4 + 1] = _v4.y;
+                state_init_frag[state_vec_init * 4 + 2] = _v4.z;
+                state_init_frag[state_vec_init * 4 + 3] = _v4.w;
+              }
+            }
+            int state_init_addr = taddr + (unsigned int)state_tmem_row_base_init +
+                                  (unsigned int)(state_col_block_init * 32);
+            tmem_st_x32_f32(state_init_addr, state_init_frag);
+          }
+          asm volatile("tcgen05.wait::st.sync.aligned;" ::: "memory");
+          if (elect_sync()) {
+            mbarrier_arrive(initial_state_loaded_addr);
+          }
+          mbarrier_wait(initial_state_loaded_addr, _phase_initial_state_loaded_0);
+          _phase_initial_state_loaded_0 ^= 1;
+          if (state_warp_init == 0) {
+            if (elect_sync()) {
+              mbarrier_arrive(kv_acc_full_addr);
+            }
+          }
+        }
+        if (num_chunks_b_1 > 0) {
+          {
+            int chunk_offset_1 = batch_start_1;
+            int _cg1_marker = batch_idx_1 + head_idx_1 + chunk_offset_1 + batch_end_1 +
+                              checkpoint_every_n_tokens + USE_INITIAL_STATE + STORE_FINAL_STATE +
+                              ENABLE_CHECKPOINTS;
+            mbarrier_wait(load_gate_full_addr + (gate_cg1_stage) * 8, gate_cg1_phase);
+            int gate_cg1_elem_base = gate_cg1_stage * 128;
+            int warp_in_wg_1 = warp % 4;
+            int tmem_row_base_v = warp_in_wg_1 * 32 << 16;
+            {
+              mbarrier_wait(kv_acc_full_addr, _phase_kv_acc_full_0);
+              _phase_kv_acc_full_0 ^= 1;
+              int state_addr_0 = taddr + (unsigned int)tmem_row_base_v;
+              int state_addr_1 = state_addr_0 + 32;
+              int state_addr_2 = state_addr_0 + 64;
+              int state_addr_3 = state_addr_0 + 96;
+              float _tmem_load_4[32];
+              tmem_ld_x32(&_tmem_load_4[0], state_addr_0);
+              float _tmem_load_5[32];
+              tmem_ld_x32(&_tmem_load_5[0], state_addr_1);
+              float _tmem_load_6[32];
+              tmem_ld_x32(&_tmem_load_6[0], state_addr_2);
+              float _tmem_load_7[32];
+              tmem_ld_x32(&_tmem_load_7[0], state_addr_3);
+              int state_inp_addr_0 = taddr + 192 + (unsigned int)tmem_row_base_v;
+              int state_inp_addr_1 = state_inp_addr_0 + 16;
+              int state_inp_addr_2 = state_inp_addr_0 + 32;
+              int state_inp_addr_3 = state_inp_addr_0 + 48;
+              uint32_t _tmem_load_4_bf16[16];
+#pragma unroll
+              for (int _lp = 0; _lp < 16; _lp++) {
+                __nv_bfloat162 _bf2 = __float22bfloat162_rn(
+                    make_float2(_tmem_load_4[_lp * 2 + 0], _tmem_load_4[_lp * 2 + 1 + 0]));
+                _tmem_load_4_bf16[_lp] = *(uint32_t*)&_bf2;
+              }
+              asm volatile(
+                  "tcgen05.st.sync.aligned.32x32b.x16.b32"
+                  " [%0], {%1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15, "
+                  "%16};" ::"r"(state_inp_addr_0),
+                  "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_4_bf16[0])),
+                  "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_4_bf16[1])),
+                  "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_4_bf16[2])),
+                  "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_4_bf16[3])),
+                  "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_4_bf16[4])),
+                  "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_4_bf16[5])),
+                  "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_4_bf16[6])),
+                  "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_4_bf16[7])),
+                  "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_4_bf16[8])),
+                  "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_4_bf16[9])),
+                  "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_4_bf16[10])),
+                  "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_4_bf16[11])),
+                  "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_4_bf16[12])),
+                  "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_4_bf16[13])),
+                  "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_4_bf16[14])),
+                  "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_4_bf16[15])));
+              uint32_t _tmem_load_5_bf16[16];
+#pragma unroll
+              for (int _lp = 0; _lp < 16; _lp++) {
+                __nv_bfloat162 _bf2 = __float22bfloat162_rn(
+                    make_float2(_tmem_load_5[_lp * 2 + 0], _tmem_load_5[_lp * 2 + 1 + 0]));
+                _tmem_load_5_bf16[_lp] = *(uint32_t*)&_bf2;
+              }
+              asm volatile(
+                  "tcgen05.st.sync.aligned.32x32b.x16.b32"
+                  " [%0], {%1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15, "
+                  "%16};" ::"r"(state_inp_addr_1),
+                  "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_5_bf16[0])),
+                  "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_5_bf16[1])),
+                  "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_5_bf16[2])),
+                  "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_5_bf16[3])),
+                  "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_5_bf16[4])),
+                  "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_5_bf16[5])),
+                  "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_5_bf16[6])),
+                  "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_5_bf16[7])),
+                  "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_5_bf16[8])),
+                  "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_5_bf16[9])),
+                  "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_5_bf16[10])),
+                  "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_5_bf16[11])),
+                  "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_5_bf16[12])),
+                  "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_5_bf16[13])),
+                  "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_5_bf16[14])),
+                  "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_5_bf16[15])));
+              uint32_t _tmem_load_6_bf16[16];
+#pragma unroll
+              for (int _lp = 0; _lp < 16; _lp++) {
+                __nv_bfloat162 _bf2 = __float22bfloat162_rn(
+                    make_float2(_tmem_load_6[_lp * 2 + 0], _tmem_load_6[_lp * 2 + 1 + 0]));
+                _tmem_load_6_bf16[_lp] = *(uint32_t*)&_bf2;
+              }
+              asm volatile(
+                  "tcgen05.st.sync.aligned.32x32b.x16.b32"
+                  " [%0], {%1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15, "
+                  "%16};" ::"r"(state_inp_addr_2),
+                  "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_6_bf16[0])),
+                  "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_6_bf16[1])),
+                  "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_6_bf16[2])),
+                  "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_6_bf16[3])),
+                  "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_6_bf16[4])),
+                  "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_6_bf16[5])),
+                  "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_6_bf16[6])),
+                  "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_6_bf16[7])),
+                  "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_6_bf16[8])),
+                  "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_6_bf16[9])),
+                  "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_6_bf16[10])),
+                  "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_6_bf16[11])),
+                  "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_6_bf16[12])),
+                  "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_6_bf16[13])),
+                  "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_6_bf16[14])),
+                  "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_6_bf16[15])));
+              uint32_t _tmem_load_7_bf16[16];
+#pragma unroll
+              for (int _lp = 0; _lp < 16; _lp++) {
+                __nv_bfloat162 _bf2 = __float22bfloat162_rn(
+                    make_float2(_tmem_load_7[_lp * 2 + 0], _tmem_load_7[_lp * 2 + 1 + 0]));
+                _tmem_load_7_bf16[_lp] = *(uint32_t*)&_bf2;
+              }
+              asm volatile(
+                  "tcgen05.st.sync.aligned.32x32b.x16.b32"
+                  " [%0], {%1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15, "
+                  "%16};" ::"r"(state_inp_addr_3),
+                  "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_7_bf16[0])),
+                  "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_7_bf16[1])),
+                  "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_7_bf16[2])),
+                  "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_7_bf16[3])),
+                  "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_7_bf16[4])),
+                  "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_7_bf16[5])),
+                  "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_7_bf16[6])),
+                  "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_7_bf16[7])),
+                  "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_7_bf16[8])),
+                  "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_7_bf16[9])),
+                  "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_7_bf16[10])),
+                  "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_7_bf16[11])),
+                  "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_7_bf16[12])),
+                  "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_7_bf16[13])),
+                  "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_7_bf16[14])),
+                  "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_7_bf16[15])));
+#pragma unroll
+              for (int state_col_cg1 = 0; state_col_cg1 < 32; state_col_cg1++) {
+                _tmem_load_4[state_col_cg1] =
+                    _tmem_load_4[state_col_cg1] * smem_g_total[gate_cg1_elem_base + state_col_cg1];
+                _tmem_load_5[state_col_cg1] = _tmem_load_5[state_col_cg1] *
+                                              smem_g_total[gate_cg1_elem_base + 32 + state_col_cg1];
+                _tmem_load_6[state_col_cg1] = _tmem_load_6[state_col_cg1] *
+                                              smem_g_total[gate_cg1_elem_base + 64 + state_col_cg1];
+                _tmem_load_7[state_col_cg1] = _tmem_load_7[state_col_cg1] *
+                                              smem_g_total[gate_cg1_elem_base + 96 + state_col_cg1];
+              }
+              tmem_st_x32_f32(state_addr_0, _tmem_load_4);
+              tmem_st_x32_f32(state_addr_1, _tmem_load_5);
+              tmem_st_x32_f32(state_addr_2, _tmem_load_6);
+              tmem_st_x32_f32(state_addr_3, _tmem_load_7);
+              asm volatile("tcgen05.wait::st.sync.aligned;" ::: "memory");
+              mbarrier_arrive(state_inp_ready_addr);
+              mbarrier_arrive(kv_acc_empty_addr);
+            }
+            mbarrier_arrive(gate_cg1_empty_addr + (gate_cg1_stage) * 8);
+            gate_cg1_stage += 1;
+            if (gate_cg1_stage == 5) {
+              gate_cg1_stage = 0;
+              gate_cg1_phase ^= 1;
+            }
+            mbarrier_wait(load_v_full_addr + (v_cg1_stage) * 8, v_cg1_phase);
+            int v_stage_addr_cg1 = smem_v_addr + v_cg1_stage * 16384;
+            asm volatile("fence.proxy.async.shared::cta;" ::: "memory");
+            {
+              unsigned int v_frag_lo_cg1[16];
+              unsigned int v_frag_hi_cg1[16];
+              unsigned int v_ld_bits_cg1[4];
+#pragma unroll
+              for (int v_frag_repeat_cg1 = 0; v_frag_repeat_cg1 < 8; v_frag_repeat_cg1++) {
+                int v_ld_mtx_cg1 = lane / 8;
+                int v_ld_token_cg1 = v_frag_repeat_cg1 * 8 + (lane & 7);
+                int warp_id_in_role_2 = (warp - 4);
+                int v_ld_dv_cg1 = warp_id_in_role_2 * 32 + v_ld_mtx_cg1 * 8;
+                int v_d0_cg1 = v_ld_dv_cg1 & 63;
+                int v_d1_cg1 = v_ld_dv_cg1 / 64;
+                int v_t0_cg1 = v_ld_token_cg1 & 15;
+                int v_t1_cg1 = v_ld_token_cg1 / 16;
+                int v_ld_byte_off_cg1 =
+                    (v_d0_cg1 + v_d1_cg1 * 4096 + v_t0_cg1 * 64 + v_t1_cg1 * 1024) * 2;
+                v_ld_byte_off_cg1 = v_ld_byte_off_cg1 ^ (v_ld_byte_off_cg1 >> 7 & 7) << 4;
+                asm volatile(
+                    "ldmatrix.sync.aligned.m8n8.x4.trans.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                    : "=r"(v_ld_bits_cg1[0]), "=r"(v_ld_bits_cg1[1]), "=r"(v_ld_bits_cg1[2]),
+                      "=r"(v_ld_bits_cg1[3])
+                    : "r"(v_stage_addr_cg1 + v_ld_byte_off_cg1)
+                    : "memory");
+                const int v_frag_j0_cg1 = v_frag_repeat_cg1 * 2;
+                v_frag_lo_cg1[v_frag_j0_cg1] = v_ld_bits_cg1[0];
+                v_frag_lo_cg1[v_frag_j0_cg1 + 1] = v_ld_bits_cg1[1];
+                v_frag_hi_cg1[v_frag_j0_cg1] = v_ld_bits_cg1[2];
+                v_frag_hi_cg1[v_frag_j0_cg1 + 1] = v_ld_bits_cg1[3];
+              }
+              mbarrier_wait(cg1_shared_acc_full_addr, _phase_cg1_shared_acc_full_0);
+              _phase_cg1_shared_acc_full_0 ^= 1;
+              int ks_addr_lo_cg1 = taddr + 384 + (unsigned int)tmem_row_base_v;
+              int ks_addr_hi_cg1 = ks_addr_lo_cg1 + 1048576;
+              float _tmem_load_8[32];
+              asm volatile(
+                  "tcgen05.ld.sync.aligned.16x256b.x8.b32"
+                  " {%0, %1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15, %16, "
+                  "%17, %18, %19, %20, %21, %22, %23, %24, %25, %26, %27, %28, %29, %30, %31}, "
+                  "[%32];"
+                  : "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_8[0])),
+                    "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_8[1])),
+                    "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_8[2])),
+                    "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_8[3])),
+                    "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_8[4])),
+                    "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_8[5])),
+                    "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_8[6])),
+                    "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_8[7])),
+                    "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_8[8])),
+                    "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_8[9])),
+                    "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_8[10])),
+                    "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_8[11])),
+                    "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_8[12])),
+                    "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_8[13])),
+                    "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_8[14])),
+                    "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_8[15])),
+                    "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_8[16])),
+                    "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_8[17])),
+                    "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_8[18])),
+                    "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_8[19])),
+                    "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_8[20])),
+                    "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_8[21])),
+                    "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_8[22])),
+                    "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_8[23])),
+                    "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_8[24])),
+                    "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_8[25])),
+                    "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_8[26])),
+                    "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_8[27])),
+                    "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_8[28])),
+                    "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_8[29])),
+                    "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_8[30])),
+                    "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_8[31]))
+                  : "r"(ks_addr_lo_cg1));
+              float _tmem_load_9[32];
+              asm volatile(
+                  "tcgen05.ld.sync.aligned.16x256b.x8.b32"
+                  " {%0, %1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15, %16, "
+                  "%17, %18, %19, %20, %21, %22, %23, %24, %25, %26, %27, %28, %29, %30, %31}, "
+                  "[%32];"
+                  : "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_9[0])),
+                    "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_9[1])),
+                    "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_9[2])),
+                    "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_9[3])),
+                    "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_9[4])),
+                    "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_9[5])),
+                    "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_9[6])),
+                    "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_9[7])),
+                    "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_9[8])),
+                    "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_9[9])),
+                    "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_9[10])),
+                    "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_9[11])),
+                    "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_9[12])),
+                    "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_9[13])),
+                    "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_9[14])),
+                    "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_9[15])),
+                    "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_9[16])),
+                    "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_9[17])),
+                    "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_9[18])),
+                    "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_9[19])),
+                    "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_9[20])),
+                    "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_9[21])),
+                    "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_9[22])),
+                    "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_9[23])),
+                    "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_9[24])),
+                    "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_9[25])),
+                    "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_9[26])),
+                    "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_9[27])),
+                    "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_9[28])),
+                    "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_9[29])),
+                    "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_9[30])),
+                    "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_9[31]))
+                  : "r"(ks_addr_hi_cg1));
+              mbarrier_arrive(cg1_shared_acc_empty_addr);
+              uint32_t _tmem_load_8_bf16[16];
+#pragma unroll
+              for (int _lp = 0; _lp < 16; _lp++) {
+                __nv_bfloat162 _bf2 = __float22bfloat162_rn(
+                    make_float2(_tmem_load_8[_lp * 2 + 0], _tmem_load_8[_lp * 2 + 1 + 0]));
+                _tmem_load_8_bf16[_lp] = *(uint32_t*)&_bf2;
+              }
+              uint32_t _tmem_load_9_bf16[16];
+#pragma unroll
+              for (int _lp = 0; _lp < 16; _lp++) {
+                __nv_bfloat162 _bf2 = __float22bfloat162_rn(
+                    make_float2(_tmem_load_9[_lp * 2 + 0], _tmem_load_9[_lp * 2 + 1 + 0]));
+                _tmem_load_9_bf16[_lp] = *(uint32_t*)&_bf2;
+              }
+              unsigned int vks_packed_lo_cg1[16];
+              unsigned int vks_packed_hi_cg1[16];
+#pragma unroll
+              for (int frag_pair_j = 0; frag_pair_j < 16; frag_pair_j++) {
+                uint32_t _bf16x2_sub_0;
+                asm volatile("sub.rn.bf16x2 %0, %1, %2;"
+                             : "=r"(_bf16x2_sub_0)
+                             : "r"(v_frag_lo_cg1[frag_pair_j]),
+                               "r"(_tmem_load_8_bf16[frag_pair_j]));
+                vks_packed_lo_cg1[frag_pair_j] = _bf16x2_sub_0;
+                uint32_t _bf16x2_sub_1;
+                asm volatile("sub.rn.bf16x2 %0, %1, %2;"
+                             : "=r"(_bf16x2_sub_1)
+                             : "r"(v_frag_hi_cg1[frag_pair_j]),
+                               "r"(_tmem_load_9_bf16[frag_pair_j]));
+                vks_packed_hi_cg1[frag_pair_j] = _bf16x2_sub_1;
+              }
+              int vks_addr_lo_cg1 = taddr + 448 + (unsigned int)tmem_row_base_v;
+              int vks_addr_hi_cg1 = vks_addr_lo_cg1 + 1048576;
+              asm volatile(
+                  "tcgen05.st.sync.aligned.16x128b.x8.b32"
+                  " [%0], {%1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15, "
+                  "%16};" ::"r"(vks_addr_lo_cg1),
+                  "r"(*reinterpret_cast<const uint32_t*>(&vks_packed_lo_cg1[0])),
+                  "r"(*reinterpret_cast<const uint32_t*>(&vks_packed_lo_cg1[1])),
+                  "r"(*reinterpret_cast<const uint32_t*>(&vks_packed_lo_cg1[2])),
+                  "r"(*reinterpret_cast<const uint32_t*>(&vks_packed_lo_cg1[3])),
+                  "r"(*reinterpret_cast<const uint32_t*>(&vks_packed_lo_cg1[4])),
+                  "r"(*reinterpret_cast<const uint32_t*>(&vks_packed_lo_cg1[5])),
+                  "r"(*reinterpret_cast<const uint32_t*>(&vks_packed_lo_cg1[6])),
+                  "r"(*reinterpret_cast<const uint32_t*>(&vks_packed_lo_cg1[7])),
+                  "r"(*reinterpret_cast<const uint32_t*>(&vks_packed_lo_cg1[8])),
+                  "r"(*reinterpret_cast<const uint32_t*>(&vks_packed_lo_cg1[9])),
+                  "r"(*reinterpret_cast<const uint32_t*>(&vks_packed_lo_cg1[10])),
+                  "r"(*reinterpret_cast<const uint32_t*>(&vks_packed_lo_cg1[11])),
+                  "r"(*reinterpret_cast<const uint32_t*>(&vks_packed_lo_cg1[12])),
+                  "r"(*reinterpret_cast<const uint32_t*>(&vks_packed_lo_cg1[13])),
+                  "r"(*reinterpret_cast<const uint32_t*>(&vks_packed_lo_cg1[14])),
+                  "r"(*reinterpret_cast<const uint32_t*>(&vks_packed_lo_cg1[15])));
+              asm volatile(
+                  "tcgen05.st.sync.aligned.16x128b.x8.b32"
+                  " [%0], {%1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15, "
+                  "%16};" ::"r"(vks_addr_hi_cg1),
+                  "r"(*reinterpret_cast<const uint32_t*>(&vks_packed_hi_cg1[0])),
+                  "r"(*reinterpret_cast<const uint32_t*>(&vks_packed_hi_cg1[1])),
+                  "r"(*reinterpret_cast<const uint32_t*>(&vks_packed_hi_cg1[2])),
+                  "r"(*reinterpret_cast<const uint32_t*>(&vks_packed_hi_cg1[3])),
+                  "r"(*reinterpret_cast<const uint32_t*>(&vks_packed_hi_cg1[4])),
+                  "r"(*reinterpret_cast<const uint32_t*>(&vks_packed_hi_cg1[5])),
+                  "r"(*reinterpret_cast<const uint32_t*>(&vks_packed_hi_cg1[6])),
+                  "r"(*reinterpret_cast<const uint32_t*>(&vks_packed_hi_cg1[7])),
+                  "r"(*reinterpret_cast<const uint32_t*>(&vks_packed_hi_cg1[8])),
+                  "r"(*reinterpret_cast<const uint32_t*>(&vks_packed_hi_cg1[9])),
+                  "r"(*reinterpret_cast<const uint32_t*>(&vks_packed_hi_cg1[10])),
+                  "r"(*reinterpret_cast<const uint32_t*>(&vks_packed_hi_cg1[11])),
+                  "r"(*reinterpret_cast<const uint32_t*>(&vks_packed_hi_cg1[12])),
+                  "r"(*reinterpret_cast<const uint32_t*>(&vks_packed_hi_cg1[13])),
+                  "r"(*reinterpret_cast<const uint32_t*>(&vks_packed_hi_cg1[14])),
+                  "r"(*reinterpret_cast<const uint32_t*>(&vks_packed_hi_cg1[15])));
+              asm volatile("tcgen05.wait::st.sync.aligned;" ::: "memory");
+            }
+            mbarrier_arrive(vks_ready_addr);
+            {
+              mbarrier_wait(q_state_acc_full_addr, _phase_q_state_acc_full_0);
+              _phase_q_state_acc_full_0 ^= 1;
+#pragma unroll
+              for (int dim_half_qs = 0; dim_half_qs < 2; dim_half_qs++) {
+                int qs_addr = taddr + 128 + (unsigned int)tmem_row_base_v +
+                              (unsigned int)(dim_half_qs * 16 << 16);
+                float _tmem_load_10[32];
+                asm volatile(
+                    "tcgen05.ld.sync.aligned.16x256b.x8.b32"
+                    " {%0, %1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15, %16, "
+                    "%17, %18, %19, %20, %21, %22, %23, %24, %25, %26, %27, %28, %29, %30, %31}, "
+                    "[%32];"
+                    : "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_10[0])),
+                      "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_10[1])),
+                      "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_10[2])),
+                      "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_10[3])),
+                      "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_10[4])),
+                      "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_10[5])),
+                      "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_10[6])),
+                      "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_10[7])),
+                      "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_10[8])),
+                      "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_10[9])),
+                      "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_10[10])),
+                      "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_10[11])),
+                      "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_10[12])),
+                      "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_10[13])),
+                      "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_10[14])),
+                      "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_10[15])),
+                      "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_10[16])),
+                      "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_10[17])),
+                      "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_10[18])),
+                      "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_10[19])),
+                      "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_10[20])),
+                      "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_10[21])),
+                      "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_10[22])),
+                      "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_10[23])),
+                      "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_10[24])),
+                      "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_10[25])),
+                      "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_10[26])),
+                      "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_10[27])),
+                      "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_10[28])),
+                      "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_10[29])),
+                      "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_10[30])),
+                      "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_10[31]))
+                    : "r"(qs_addr));
+                asm volatile(
+                    "tcgen05.st.sync.aligned.16x256b.x8.b32"
+                    " [%0], {%1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15, "
+                    "%16, %17, %18, %19, %20, %21, %22, %23, %24, %25, %26, %27, %28, %29, %30, "
+                    "%31, %32};" ::"r"(qs_addr),
+                    "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_10[0])),
+                    "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_10[1])),
+                    "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_10[2])),
+                    "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_10[3])),
+                    "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_10[4])),
+                    "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_10[5])),
+                    "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_10[6])),
+                    "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_10[7])),
+                    "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_10[8])),
+                    "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_10[9])),
+                    "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_10[10])),
+                    "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_10[11])),
+                    "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_10[12])),
+                    "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_10[13])),
+                    "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_10[14])),
+                    "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_10[15])),
+                    "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_10[16])),
+                    "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_10[17])),
+                    "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_10[18])),
+                    "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_10[19])),
+                    "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_10[20])),
+                    "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_10[21])),
+                    "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_10[22])),
+                    "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_10[23])),
+                    "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_10[24])),
+                    "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_10[25])),
+                    "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_10[26])),
+                    "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_10[27])),
+                    "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_10[28])),
+                    "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_10[29])),
+                    "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_10[30])),
+                    "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_10[31])));
+              }
+              asm volatile("tcgen05.wait::st.sync.aligned;" ::: "memory");
+              mbarrier_arrive(q_state_acc_empty_addr);
+            }
+            mbarrier_wait(cg1_shared_acc_full_addr, _phase_cg1_shared_acc_full_0);
+            _phase_cg1_shared_acc_full_0 ^= 1;
+            if (elect_sync()) {
+              mbarrier_arrive(v_smem_empty_addr + (v_cg1_stage) * 8);
+            }
+            v_cg1_stage += 1;
+            if (v_cg1_stage == 2) {
+              v_cg1_stage = 0;
+              v_cg1_phase ^= 1;
+            }
+            int nv_src_addr_lo_cg1 = taddr + 384 + (unsigned int)tmem_row_base_v;
+            float _tmem_load_11[32];
+            asm volatile(
+                "tcgen05.ld.sync.aligned.16x256b.x8.b32"
+                " {%0, %1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15, %16, %17, "
+                "%18, %19, %20, %21, %22, %23, %24, %25, %26, %27, %28, %29, %30, %31}, [%32];"
+                : "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_11[0])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_11[1])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_11[2])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_11[3])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_11[4])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_11[5])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_11[6])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_11[7])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_11[8])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_11[9])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_11[10])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_11[11])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_11[12])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_11[13])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_11[14])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_11[15])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_11[16])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_11[17])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_11[18])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_11[19])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_11[20])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_11[21])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_11[22])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_11[23])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_11[24])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_11[25])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_11[26])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_11[27])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_11[28])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_11[29])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_11[30])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_11[31]))
+                : "r"(nv_src_addr_lo_cg1));
+            uint32_t _tmem_load_11_bf16[16];
+#pragma unroll
+            for (int _lp = 0; _lp < 16; _lp++) {
+              __nv_bfloat162 _bf2 = __float22bfloat162_rn(
+                  make_float2(_tmem_load_11[_lp * 2 + 0], _tmem_load_11[_lp * 2 + 1 + 0]));
+              _tmem_load_11_bf16[_lp] = *(uint32_t*)&_bf2;
+            }
+            int nv_dst_addr_lo_cg1 = taddr + 448 + (unsigned int)tmem_row_base_v;
+            asm volatile(
+                "tcgen05.st.sync.aligned.16x128b.x8.b32"
+                " [%0], {%1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15, %16};" ::
+                    "r"(nv_dst_addr_lo_cg1),
+                "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_11_bf16[0])),
+                "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_11_bf16[1])),
+                "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_11_bf16[2])),
+                "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_11_bf16[3])),
+                "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_11_bf16[4])),
+                "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_11_bf16[5])),
+                "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_11_bf16[6])),
+                "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_11_bf16[7])),
+                "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_11_bf16[8])),
+                "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_11_bf16[9])),
+                "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_11_bf16[10])),
+                "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_11_bf16[11])),
+                "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_11_bf16[12])),
+                "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_11_bf16[13])),
+                "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_11_bf16[14])),
+                "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_11_bf16[15])));
+            int nv_src_addr_hi_cg1 = taddr + 384 + (unsigned int)tmem_row_base_v + 1048576;
+            float _tmem_load_12[32];
+            asm volatile(
+                "tcgen05.ld.sync.aligned.16x256b.x8.b32"
+                " {%0, %1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15, %16, %17, "
+                "%18, %19, %20, %21, %22, %23, %24, %25, %26, %27, %28, %29, %30, %31}, [%32];"
+                : "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_12[0])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_12[1])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_12[2])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_12[3])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_12[4])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_12[5])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_12[6])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_12[7])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_12[8])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_12[9])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_12[10])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_12[11])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_12[12])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_12[13])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_12[14])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_12[15])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_12[16])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_12[17])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_12[18])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_12[19])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_12[20])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_12[21])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_12[22])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_12[23])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_12[24])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_12[25])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_12[26])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_12[27])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_12[28])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_12[29])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_12[30])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_12[31]))
+                : "r"(nv_src_addr_hi_cg1));
+            uint32_t _tmem_load_12_bf16[16];
+#pragma unroll
+            for (int _lp = 0; _lp < 16; _lp++) {
+              __nv_bfloat162 _bf2 = __float22bfloat162_rn(
+                  make_float2(_tmem_load_12[_lp * 2 + 0], _tmem_load_12[_lp * 2 + 1 + 0]));
+              _tmem_load_12_bf16[_lp] = *(uint32_t*)&_bf2;
+            }
+            mbarrier_arrive(cg1_shared_acc_empty_addr);
+            int nv_dst_addr_hi_cg1 = taddr + 448 + (unsigned int)tmem_row_base_v + 1048576;
+            asm volatile(
+                "tcgen05.st.sync.aligned.16x128b.x8.b32"
+                " [%0], {%1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15, %16};" ::
+                    "r"(nv_dst_addr_hi_cg1),
+                "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_12_bf16[0])),
+                "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_12_bf16[1])),
+                "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_12_bf16[2])),
+                "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_12_bf16[3])),
+                "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_12_bf16[4])),
+                "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_12_bf16[5])),
+                "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_12_bf16[6])),
+                "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_12_bf16[7])),
+                "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_12_bf16[8])),
+                "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_12_bf16[9])),
+                "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_12_bf16[10])),
+                "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_12_bf16[11])),
+                "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_12_bf16[12])),
+                "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_12_bf16[13])),
+                "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_12_bf16[14])),
+                "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_12_bf16[15])));
+            asm volatile("tcgen05.wait::st.sync.aligned;" ::: "memory");
+            mbarrier_arrive(nv_ready_addr);
+            int decay_dst_addr_lo_cg1 = taddr + 448 + 32 + (unsigned int)tmem_row_base_v;
+            asm volatile(
+                "tcgen05.st.sync.aligned.16x128b.x8.b32"
+                " [%0], {%1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15, %16};" ::
+                    "r"(decay_dst_addr_lo_cg1),
+                "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_11_bf16[0])),
+                "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_11_bf16[1])),
+                "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_11_bf16[2])),
+                "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_11_bf16[3])),
+                "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_11_bf16[4])),
+                "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_11_bf16[5])),
+                "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_11_bf16[6])),
+                "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_11_bf16[7])),
+                "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_11_bf16[8])),
+                "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_11_bf16[9])),
+                "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_11_bf16[10])),
+                "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_11_bf16[11])),
+                "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_11_bf16[12])),
+                "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_11_bf16[13])),
+                "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_11_bf16[14])),
+                "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_11_bf16[15])));
+            int decay_dst_addr_hi_cg1 = taddr + 448 + 32 + (unsigned int)tmem_row_base_v + 1048576;
+            asm volatile(
+                "tcgen05.st.sync.aligned.16x128b.x8.b32"
+                " [%0], {%1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15, %16};" ::
+                    "r"(decay_dst_addr_hi_cg1),
+                "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_12_bf16[0])),
+                "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_12_bf16[1])),
+                "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_12_bf16[2])),
+                "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_12_bf16[3])),
+                "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_12_bf16[4])),
+                "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_12_bf16[5])),
+                "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_12_bf16[6])),
+                "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_12_bf16[7])),
+                "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_12_bf16[8])),
+                "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_12_bf16[9])),
+                "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_12_bf16[10])),
+                "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_12_bf16[11])),
+                "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_12_bf16[12])),
+                "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_12_bf16[13])),
+                "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_12_bf16[14])),
+                "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_12_bf16[15])));
+            asm volatile("tcgen05.wait::st.sync.aligned;" ::: "memory");
+            mbarrier_arrive(decay_v_ready_addr);
+            mbarrier_wait(o_smem_empty_addr + (o_cg1_stage) * 8, o_cg1_phase);
+            int o_stage_addr_cg1 = smem_o_addr + o_cg1_stage * 16384;
+            mbarrier_wait(q_state_acc_full_addr, _phase_q_state_acc_full_0);
+            _phase_q_state_acc_full_0 ^= 1;
+#pragma unroll
+            for (int dim_half_cg1 = 0; dim_half_cg1 < 2; dim_half_cg1++) {
+              int dim_half_row_cg1 = dim_half_cg1 * 16;
+              int q_state_addr = taddr + 128 + (unsigned int)tmem_row_base_v +
+                                 (unsigned int)(dim_half_row_cg1 << 16);
+              float _tmem_load_13[32];
+              asm volatile(
+                  "tcgen05.ld.sync.aligned.16x256b.x8.b32"
+                  " {%0, %1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15, %16, "
+                  "%17, %18, %19, %20, %21, %22, %23, %24, %25, %26, %27, %28, %29, %30, %31}, "
+                  "[%32];"
+                  : "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_13[0])),
+                    "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_13[1])),
+                    "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_13[2])),
+                    "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_13[3])),
+                    "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_13[4])),
+                    "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_13[5])),
+                    "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_13[6])),
+                    "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_13[7])),
+                    "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_13[8])),
+                    "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_13[9])),
+                    "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_13[10])),
+                    "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_13[11])),
+                    "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_13[12])),
+                    "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_13[13])),
+                    "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_13[14])),
+                    "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_13[15])),
+                    "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_13[16])),
+                    "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_13[17])),
+                    "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_13[18])),
+                    "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_13[19])),
+                    "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_13[20])),
+                    "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_13[21])),
+                    "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_13[22])),
+                    "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_13[23])),
+                    "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_13[24])),
+                    "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_13[25])),
+                    "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_13[26])),
+                    "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_13[27])),
+                    "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_13[28])),
+                    "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_13[29])),
+                    "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_13[30])),
+                    "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_13[31]))
+                  : "r"(q_state_addr));
+              uint32_t _tmem_load_13_bf16[16];
+#pragma unroll
+              for (int _lp = 0; _lp < 16; _lp++) {
+                __nv_bfloat162 _bf2 = __float22bfloat162_rn(
+                    make_float2(_tmem_load_13[_lp * 2 + 0], _tmem_load_13[_lp * 2 + 1 + 0]));
+                _tmem_load_13_bf16[_lp] = *(uint32_t*)&_bf2;
+              }
+#pragma unroll
+              for (int token_group_cg1 = 0; token_group_cg1 < 4; token_group_cg1++) {
+                int o_mtx_idx_cg1 = lane / 8;
+                int o_row_addr_cg1 = lane & 7;
+                int warp_id_in_role_3 = (warp - 4);
+                int o_dim_base_cg1 =
+                    warp_id_in_role_3 * 32 + dim_half_row_cg1 + (o_mtx_idx_cg1 & 1) * 8;
+                int o_token_base_cg1 = token_group_cg1 * 16 + o_mtx_idx_cg1 / 2 * 8;
+                int o_token_addr_cg1 = o_token_base_cg1 + o_row_addr_cg1;
+                int o_token_pair_cg1 = o_token_addr_cg1 / 2;
+                int o_token_parity_cg1 = o_token_addr_cg1 & 1;
+                int o_raw_row_cg1 = o_token_pair_cg1 + o_dim_base_cg1 / 64 * 32;
+                int o_raw_col_cg1 =
+                    (o_dim_base_cg1 & 63 ^ (o_token_pair_cg1 & 3) << 4 ^ o_token_parity_cg1 << 3) +
+                    o_token_parity_cg1 * 64;
+                int o_stsm_offset_cg1 = (o_raw_row_cg1 * 128 + o_raw_col_cg1) * 2;
+                const int o_pack_base_cg1 = token_group_cg1 * 4;
+                uint32_t _stmatrix_addr_1 = static_cast<uint32_t>(
+                    (unsigned long long)(o_stage_addr_cg1 + o_stsm_offset_cg1));
+                asm volatile(
+                    "stmatrix.sync.aligned.m8n8.x4.trans.shared.b16 [%0], {%1, %2, %3, %4};\n" ::
+                        "r"(_stmatrix_addr_1),
+                    "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_13_bf16[o_pack_base_cg1])),
+                    "r"(*reinterpret_cast<const uint32_t*>(
+                        &_tmem_load_13_bf16[o_pack_base_cg1 + 1])),
+                    "r"(*reinterpret_cast<const uint32_t*>(
+                        &_tmem_load_13_bf16[o_pack_base_cg1 + 2])),
+                    "r"(*reinterpret_cast<const uint32_t*>(
+                        &_tmem_load_13_bf16[o_pack_base_cg1 + 3]))
+                    : "memory");
+              }
+            }
+            asm volatile("fence.proxy.async.shared::cta;" ::: "memory");
+            mbarrier_arrive(q_state_acc_empty_addr);
+            mbarrier_arrive(o_store_ready_addr + (o_cg1_stage) * 8);
+            o_cg1_stage += 1;
+            if (o_cg1_stage == 2) {
+              o_cg1_stage = 0;
+              o_cg1_phase ^= 1;
+            }
+          }
+        }
+#pragma unroll 1
+        for (int chunk_idx_1 = 1; chunk_idx_1 < num_chunks_b_1; chunk_idx_1++) {
+          int chunk_offset_2 = batch_start_1 + chunk_idx_1 * 16;
+          int _cg1_marker_1 = batch_idx_1 + head_idx_1 + chunk_offset_2 + batch_end_1 +
+                              checkpoint_every_n_tokens + USE_INITIAL_STATE + STORE_FINAL_STATE +
+                              ENABLE_CHECKPOINTS;
+          mbarrier_wait(load_gate_full_addr + (gate_cg1_stage) * 8, gate_cg1_phase);
+          int gate_cg1_elem_base_1 = gate_cg1_stage * 128;
+          int warp_in_wg_2 = warp % 4;
+          int tmem_row_base_v_1 = warp_in_wg_2 * 32 << 16;
+          {
+            mbarrier_wait(kv_acc_full_addr, _phase_kv_acc_full_0);
+            _phase_kv_acc_full_0 ^= 1;
+            int state_addr_0_1 = taddr + (unsigned int)tmem_row_base_v_1;
+            int state_addr_1_1 = state_addr_0_1 + 32;
+            int state_addr_2_1 = state_addr_0_1 + 64;
+            int state_addr_3_1 = state_addr_0_1 + 96;
+            float _tmem_load_24[32];
+            tmem_ld_x32(&_tmem_load_24[0], state_addr_0_1);
+            float _tmem_load_25[32];
+            tmem_ld_x32(&_tmem_load_25[0], state_addr_1_1);
+            float _tmem_load_26[32];
+            tmem_ld_x32(&_tmem_load_26[0], state_addr_2_1);
+            float _tmem_load_27[32];
+            tmem_ld_x32(&_tmem_load_27[0], state_addr_3_1);
+            int state_inp_addr_0_1 = taddr + 192 + (unsigned int)tmem_row_base_v_1;
+            int state_inp_addr_1_1 = state_inp_addr_0_1 + 16;
+            int state_inp_addr_2_1 = state_inp_addr_0_1 + 32;
+            int state_inp_addr_3_1 = state_inp_addr_0_1 + 48;
+            uint32_t _tmem_load_24_bf16[16];
+#pragma unroll
+            for (int _lp = 0; _lp < 16; _lp++) {
+              __nv_bfloat162 _bf2 = __float22bfloat162_rn(
+                  make_float2(_tmem_load_24[_lp * 2 + 0], _tmem_load_24[_lp * 2 + 1 + 0]));
+              _tmem_load_24_bf16[_lp] = *(uint32_t*)&_bf2;
+            }
+            asm volatile(
+                "tcgen05.st.sync.aligned.32x32b.x16.b32"
+                " [%0], {%1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15, %16};" ::
+                    "r"(state_inp_addr_0_1),
+                "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_24_bf16[0])),
+                "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_24_bf16[1])),
+                "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_24_bf16[2])),
+                "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_24_bf16[3])),
+                "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_24_bf16[4])),
+                "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_24_bf16[5])),
+                "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_24_bf16[6])),
+                "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_24_bf16[7])),
+                "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_24_bf16[8])),
+                "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_24_bf16[9])),
+                "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_24_bf16[10])),
+                "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_24_bf16[11])),
+                "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_24_bf16[12])),
+                "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_24_bf16[13])),
+                "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_24_bf16[14])),
+                "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_24_bf16[15])));
+            uint32_t _tmem_load_25_bf16[16];
+#pragma unroll
+            for (int _lp = 0; _lp < 16; _lp++) {
+              __nv_bfloat162 _bf2 = __float22bfloat162_rn(
+                  make_float2(_tmem_load_25[_lp * 2 + 0], _tmem_load_25[_lp * 2 + 1 + 0]));
+              _tmem_load_25_bf16[_lp] = *(uint32_t*)&_bf2;
+            }
+            asm volatile(
+                "tcgen05.st.sync.aligned.32x32b.x16.b32"
+                " [%0], {%1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15, %16};" ::
+                    "r"(state_inp_addr_1_1),
+                "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_25_bf16[0])),
+                "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_25_bf16[1])),
+                "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_25_bf16[2])),
+                "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_25_bf16[3])),
+                "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_25_bf16[4])),
+                "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_25_bf16[5])),
+                "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_25_bf16[6])),
+                "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_25_bf16[7])),
+                "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_25_bf16[8])),
+                "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_25_bf16[9])),
+                "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_25_bf16[10])),
+                "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_25_bf16[11])),
+                "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_25_bf16[12])),
+                "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_25_bf16[13])),
+                "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_25_bf16[14])),
+                "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_25_bf16[15])));
+            uint32_t _tmem_load_26_bf16[16];
+#pragma unroll
+            for (int _lp = 0; _lp < 16; _lp++) {
+              __nv_bfloat162 _bf2 = __float22bfloat162_rn(
+                  make_float2(_tmem_load_26[_lp * 2 + 0], _tmem_load_26[_lp * 2 + 1 + 0]));
+              _tmem_load_26_bf16[_lp] = *(uint32_t*)&_bf2;
+            }
+            asm volatile(
+                "tcgen05.st.sync.aligned.32x32b.x16.b32"
+                " [%0], {%1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15, %16};" ::
+                    "r"(state_inp_addr_2_1),
+                "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_26_bf16[0])),
+                "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_26_bf16[1])),
+                "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_26_bf16[2])),
+                "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_26_bf16[3])),
+                "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_26_bf16[4])),
+                "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_26_bf16[5])),
+                "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_26_bf16[6])),
+                "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_26_bf16[7])),
+                "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_26_bf16[8])),
+                "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_26_bf16[9])),
+                "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_26_bf16[10])),
+                "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_26_bf16[11])),
+                "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_26_bf16[12])),
+                "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_26_bf16[13])),
+                "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_26_bf16[14])),
+                "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_26_bf16[15])));
+            uint32_t _tmem_load_27_bf16[16];
+#pragma unroll
+            for (int _lp = 0; _lp < 16; _lp++) {
+              __nv_bfloat162 _bf2 = __float22bfloat162_rn(
+                  make_float2(_tmem_load_27[_lp * 2 + 0], _tmem_load_27[_lp * 2 + 1 + 0]));
+              _tmem_load_27_bf16[_lp] = *(uint32_t*)&_bf2;
+            }
+            asm volatile(
+                "tcgen05.st.sync.aligned.32x32b.x16.b32"
+                " [%0], {%1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15, %16};" ::
+                    "r"(state_inp_addr_3_1),
+                "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_27_bf16[0])),
+                "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_27_bf16[1])),
+                "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_27_bf16[2])),
+                "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_27_bf16[3])),
+                "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_27_bf16[4])),
+                "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_27_bf16[5])),
+                "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_27_bf16[6])),
+                "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_27_bf16[7])),
+                "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_27_bf16[8])),
+                "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_27_bf16[9])),
+                "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_27_bf16[10])),
+                "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_27_bf16[11])),
+                "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_27_bf16[12])),
+                "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_27_bf16[13])),
+                "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_27_bf16[14])),
+                "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_27_bf16[15])));
+#pragma unroll
+            for (int state_col_cg1_1 = 0; state_col_cg1_1 < 32; state_col_cg1_1++) {
+              _tmem_load_24[state_col_cg1_1] = _tmem_load_24[state_col_cg1_1] *
+                                               smem_g_total[gate_cg1_elem_base_1 + state_col_cg1_1];
+              _tmem_load_25[state_col_cg1_1] =
+                  _tmem_load_25[state_col_cg1_1] *
+                  smem_g_total[gate_cg1_elem_base_1 + 32 + state_col_cg1_1];
+              _tmem_load_26[state_col_cg1_1] =
+                  _tmem_load_26[state_col_cg1_1] *
+                  smem_g_total[gate_cg1_elem_base_1 + 64 + state_col_cg1_1];
+              _tmem_load_27[state_col_cg1_1] =
+                  _tmem_load_27[state_col_cg1_1] *
+                  smem_g_total[gate_cg1_elem_base_1 + 96 + state_col_cg1_1];
+            }
+            tmem_st_x32_f32(state_addr_0_1, _tmem_load_24);
+            tmem_st_x32_f32(state_addr_1_1, _tmem_load_25);
+            tmem_st_x32_f32(state_addr_2_1, _tmem_load_26);
+            tmem_st_x32_f32(state_addr_3_1, _tmem_load_27);
+            asm volatile("tcgen05.wait::st.sync.aligned;" ::: "memory");
+            mbarrier_arrive(state_inp_ready_addr);
+            mbarrier_arrive(kv_acc_empty_addr);
+          }
+          mbarrier_arrive(gate_cg1_empty_addr + (gate_cg1_stage) * 8);
+          gate_cg1_stage += 1;
+          if (gate_cg1_stage == 5) {
+            gate_cg1_stage = 0;
+            gate_cg1_phase ^= 1;
+          }
+          mbarrier_wait(load_v_full_addr + (v_cg1_stage) * 8, v_cg1_phase);
+          int v_stage_addr_cg1_1 = smem_v_addr + v_cg1_stage * 16384;
+          asm volatile("fence.proxy.async.shared::cta;" ::: "memory");
+          {
+            unsigned int v_frag_lo_cg1_1[16];
+            unsigned int v_frag_hi_cg1_1[16];
+            unsigned int v_ld_bits_cg1_1[4];
+#pragma unroll
+            for (int v_frag_repeat_cg1_1 = 0; v_frag_repeat_cg1_1 < 8; v_frag_repeat_cg1_1++) {
+              int v_ld_mtx_cg1_1 = lane / 8;
+              int v_ld_token_cg1_1 = v_frag_repeat_cg1_1 * 8 + (lane & 7);
+              int warp_id_in_role_4 = (warp - 4);
+              int v_ld_dv_cg1_1 = warp_id_in_role_4 * 32 + v_ld_mtx_cg1_1 * 8;
+              int v_d0_cg1_1 = v_ld_dv_cg1_1 & 63;
+              int v_d1_cg1_1 = v_ld_dv_cg1_1 / 64;
+              int v_t0_cg1_1 = v_ld_token_cg1_1 & 15;
+              int v_t1_cg1_1 = v_ld_token_cg1_1 / 16;
+              int v_ld_byte_off_cg1_1 =
+                  (v_d0_cg1_1 + v_d1_cg1_1 * 4096 + v_t0_cg1_1 * 64 + v_t1_cg1_1 * 1024) * 2;
+              v_ld_byte_off_cg1_1 = v_ld_byte_off_cg1_1 ^ (v_ld_byte_off_cg1_1 >> 7 & 7) << 4;
+              asm volatile(
+                  "ldmatrix.sync.aligned.m8n8.x4.trans.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                  : "=r"(v_ld_bits_cg1_1[0]), "=r"(v_ld_bits_cg1_1[1]), "=r"(v_ld_bits_cg1_1[2]),
+                    "=r"(v_ld_bits_cg1_1[3])
+                  : "r"(v_stage_addr_cg1_1 + v_ld_byte_off_cg1_1)
+                  : "memory");
+              const int v_frag_j0_cg1_1 = v_frag_repeat_cg1_1 * 2;
+              v_frag_lo_cg1_1[v_frag_j0_cg1_1] = v_ld_bits_cg1_1[0];
+              v_frag_lo_cg1_1[v_frag_j0_cg1_1 + 1] = v_ld_bits_cg1_1[1];
+              v_frag_hi_cg1_1[v_frag_j0_cg1_1] = v_ld_bits_cg1_1[2];
+              v_frag_hi_cg1_1[v_frag_j0_cg1_1 + 1] = v_ld_bits_cg1_1[3];
+            }
+            mbarrier_wait(cg1_shared_acc_full_addr, _phase_cg1_shared_acc_full_0);
+            _phase_cg1_shared_acc_full_0 ^= 1;
+            int ks_addr_lo_cg1_1 = taddr + 384 + (unsigned int)tmem_row_base_v_1;
+            int ks_addr_hi_cg1_1 = ks_addr_lo_cg1_1 + 1048576;
+            float _tmem_load_28[32];
+            asm volatile(
+                "tcgen05.ld.sync.aligned.16x256b.x8.b32"
+                " {%0, %1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15, %16, %17, "
+                "%18, %19, %20, %21, %22, %23, %24, %25, %26, %27, %28, %29, %30, %31}, [%32];"
+                : "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_28[0])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_28[1])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_28[2])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_28[3])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_28[4])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_28[5])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_28[6])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_28[7])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_28[8])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_28[9])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_28[10])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_28[11])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_28[12])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_28[13])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_28[14])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_28[15])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_28[16])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_28[17])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_28[18])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_28[19])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_28[20])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_28[21])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_28[22])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_28[23])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_28[24])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_28[25])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_28[26])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_28[27])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_28[28])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_28[29])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_28[30])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_28[31]))
+                : "r"(ks_addr_lo_cg1_1));
+            float _tmem_load_29[32];
+            asm volatile(
+                "tcgen05.ld.sync.aligned.16x256b.x8.b32"
+                " {%0, %1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15, %16, %17, "
+                "%18, %19, %20, %21, %22, %23, %24, %25, %26, %27, %28, %29, %30, %31}, [%32];"
+                : "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_29[0])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_29[1])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_29[2])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_29[3])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_29[4])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_29[5])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_29[6])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_29[7])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_29[8])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_29[9])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_29[10])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_29[11])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_29[12])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_29[13])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_29[14])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_29[15])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_29[16])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_29[17])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_29[18])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_29[19])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_29[20])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_29[21])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_29[22])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_29[23])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_29[24])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_29[25])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_29[26])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_29[27])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_29[28])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_29[29])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_29[30])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_29[31]))
+                : "r"(ks_addr_hi_cg1_1));
+            mbarrier_arrive(cg1_shared_acc_empty_addr);
+            uint32_t _tmem_load_28_bf16[16];
+#pragma unroll
+            for (int _lp = 0; _lp < 16; _lp++) {
+              __nv_bfloat162 _bf2 = __float22bfloat162_rn(
+                  make_float2(_tmem_load_28[_lp * 2 + 0], _tmem_load_28[_lp * 2 + 1 + 0]));
+              _tmem_load_28_bf16[_lp] = *(uint32_t*)&_bf2;
+            }
+            uint32_t _tmem_load_29_bf16[16];
+#pragma unroll
+            for (int _lp = 0; _lp < 16; _lp++) {
+              __nv_bfloat162 _bf2 = __float22bfloat162_rn(
+                  make_float2(_tmem_load_29[_lp * 2 + 0], _tmem_load_29[_lp * 2 + 1 + 0]));
+              _tmem_load_29_bf16[_lp] = *(uint32_t*)&_bf2;
+            }
+            unsigned int vks_packed_lo_cg1_1[16];
+            unsigned int vks_packed_hi_cg1_1[16];
+#pragma unroll
+            for (int frag_pair_j_1 = 0; frag_pair_j_1 < 16; frag_pair_j_1++) {
+              uint32_t _bf16x2_sub_4;
+              asm volatile("sub.rn.bf16x2 %0, %1, %2;"
+                           : "=r"(_bf16x2_sub_4)
+                           : "r"(v_frag_lo_cg1_1[frag_pair_j_1]),
+                             "r"(_tmem_load_28_bf16[frag_pair_j_1]));
+              vks_packed_lo_cg1_1[frag_pair_j_1] = _bf16x2_sub_4;
+              uint32_t _bf16x2_sub_5;
+              asm volatile("sub.rn.bf16x2 %0, %1, %2;"
+                           : "=r"(_bf16x2_sub_5)
+                           : "r"(v_frag_hi_cg1_1[frag_pair_j_1]),
+                             "r"(_tmem_load_29_bf16[frag_pair_j_1]));
+              vks_packed_hi_cg1_1[frag_pair_j_1] = _bf16x2_sub_5;
+            }
+            int vks_addr_lo_cg1_1 = taddr + 448 + (unsigned int)tmem_row_base_v_1;
+            int vks_addr_hi_cg1_1 = vks_addr_lo_cg1_1 + 1048576;
+            asm volatile(
+                "tcgen05.st.sync.aligned.16x128b.x8.b32"
+                " [%0], {%1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15, %16};" ::
+                    "r"(vks_addr_lo_cg1_1),
+                "r"(*reinterpret_cast<const uint32_t*>(&vks_packed_lo_cg1_1[0])),
+                "r"(*reinterpret_cast<const uint32_t*>(&vks_packed_lo_cg1_1[1])),
+                "r"(*reinterpret_cast<const uint32_t*>(&vks_packed_lo_cg1_1[2])),
+                "r"(*reinterpret_cast<const uint32_t*>(&vks_packed_lo_cg1_1[3])),
+                "r"(*reinterpret_cast<const uint32_t*>(&vks_packed_lo_cg1_1[4])),
+                "r"(*reinterpret_cast<const uint32_t*>(&vks_packed_lo_cg1_1[5])),
+                "r"(*reinterpret_cast<const uint32_t*>(&vks_packed_lo_cg1_1[6])),
+                "r"(*reinterpret_cast<const uint32_t*>(&vks_packed_lo_cg1_1[7])),
+                "r"(*reinterpret_cast<const uint32_t*>(&vks_packed_lo_cg1_1[8])),
+                "r"(*reinterpret_cast<const uint32_t*>(&vks_packed_lo_cg1_1[9])),
+                "r"(*reinterpret_cast<const uint32_t*>(&vks_packed_lo_cg1_1[10])),
+                "r"(*reinterpret_cast<const uint32_t*>(&vks_packed_lo_cg1_1[11])),
+                "r"(*reinterpret_cast<const uint32_t*>(&vks_packed_lo_cg1_1[12])),
+                "r"(*reinterpret_cast<const uint32_t*>(&vks_packed_lo_cg1_1[13])),
+                "r"(*reinterpret_cast<const uint32_t*>(&vks_packed_lo_cg1_1[14])),
+                "r"(*reinterpret_cast<const uint32_t*>(&vks_packed_lo_cg1_1[15])));
+            asm volatile(
+                "tcgen05.st.sync.aligned.16x128b.x8.b32"
+                " [%0], {%1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15, %16};" ::
+                    "r"(vks_addr_hi_cg1_1),
+                "r"(*reinterpret_cast<const uint32_t*>(&vks_packed_hi_cg1_1[0])),
+                "r"(*reinterpret_cast<const uint32_t*>(&vks_packed_hi_cg1_1[1])),
+                "r"(*reinterpret_cast<const uint32_t*>(&vks_packed_hi_cg1_1[2])),
+                "r"(*reinterpret_cast<const uint32_t*>(&vks_packed_hi_cg1_1[3])),
+                "r"(*reinterpret_cast<const uint32_t*>(&vks_packed_hi_cg1_1[4])),
+                "r"(*reinterpret_cast<const uint32_t*>(&vks_packed_hi_cg1_1[5])),
+                "r"(*reinterpret_cast<const uint32_t*>(&vks_packed_hi_cg1_1[6])),
+                "r"(*reinterpret_cast<const uint32_t*>(&vks_packed_hi_cg1_1[7])),
+                "r"(*reinterpret_cast<const uint32_t*>(&vks_packed_hi_cg1_1[8])),
+                "r"(*reinterpret_cast<const uint32_t*>(&vks_packed_hi_cg1_1[9])),
+                "r"(*reinterpret_cast<const uint32_t*>(&vks_packed_hi_cg1_1[10])),
+                "r"(*reinterpret_cast<const uint32_t*>(&vks_packed_hi_cg1_1[11])),
+                "r"(*reinterpret_cast<const uint32_t*>(&vks_packed_hi_cg1_1[12])),
+                "r"(*reinterpret_cast<const uint32_t*>(&vks_packed_hi_cg1_1[13])),
+                "r"(*reinterpret_cast<const uint32_t*>(&vks_packed_hi_cg1_1[14])),
+                "r"(*reinterpret_cast<const uint32_t*>(&vks_packed_hi_cg1_1[15])));
+            asm volatile("tcgen05.wait::st.sync.aligned;" ::: "memory");
+          }
+          mbarrier_arrive(vks_ready_addr);
+          {
+            mbarrier_wait(q_state_acc_full_addr, _phase_q_state_acc_full_0);
+            _phase_q_state_acc_full_0 ^= 1;
+#pragma unroll
+            for (int dim_half_qs_1 = 0; dim_half_qs_1 < 2; dim_half_qs_1++) {
+              int qs_addr_1 = taddr + 128 + (unsigned int)tmem_row_base_v_1 +
+                              (unsigned int)(dim_half_qs_1 * 16 << 16);
+              float _tmem_load_30[32];
+              asm volatile(
+                  "tcgen05.ld.sync.aligned.16x256b.x8.b32"
+                  " {%0, %1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15, %16, "
+                  "%17, %18, %19, %20, %21, %22, %23, %24, %25, %26, %27, %28, %29, %30, %31}, "
+                  "[%32];"
+                  : "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_30[0])),
+                    "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_30[1])),
+                    "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_30[2])),
+                    "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_30[3])),
+                    "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_30[4])),
+                    "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_30[5])),
+                    "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_30[6])),
+                    "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_30[7])),
+                    "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_30[8])),
+                    "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_30[9])),
+                    "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_30[10])),
+                    "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_30[11])),
+                    "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_30[12])),
+                    "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_30[13])),
+                    "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_30[14])),
+                    "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_30[15])),
+                    "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_30[16])),
+                    "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_30[17])),
+                    "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_30[18])),
+                    "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_30[19])),
+                    "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_30[20])),
+                    "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_30[21])),
+                    "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_30[22])),
+                    "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_30[23])),
+                    "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_30[24])),
+                    "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_30[25])),
+                    "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_30[26])),
+                    "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_30[27])),
+                    "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_30[28])),
+                    "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_30[29])),
+                    "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_30[30])),
+                    "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_30[31]))
+                  : "r"(qs_addr_1));
+              asm volatile(
+                  "tcgen05.st.sync.aligned.16x256b.x8.b32"
+                  " [%0], {%1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15, %16, "
+                  "%17, %18, %19, %20, %21, %22, %23, %24, %25, %26, %27, %28, %29, %30, %31, "
+                  "%32};" ::"r"(qs_addr_1),
+                  "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_30[0])),
+                  "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_30[1])),
+                  "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_30[2])),
+                  "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_30[3])),
+                  "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_30[4])),
+                  "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_30[5])),
+                  "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_30[6])),
+                  "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_30[7])),
+                  "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_30[8])),
+                  "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_30[9])),
+                  "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_30[10])),
+                  "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_30[11])),
+                  "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_30[12])),
+                  "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_30[13])),
+                  "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_30[14])),
+                  "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_30[15])),
+                  "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_30[16])),
+                  "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_30[17])),
+                  "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_30[18])),
+                  "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_30[19])),
+                  "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_30[20])),
+                  "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_30[21])),
+                  "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_30[22])),
+                  "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_30[23])),
+                  "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_30[24])),
+                  "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_30[25])),
+                  "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_30[26])),
+                  "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_30[27])),
+                  "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_30[28])),
+                  "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_30[29])),
+                  "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_30[30])),
+                  "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_30[31])));
+            }
+            asm volatile("tcgen05.wait::st.sync.aligned;" ::: "memory");
+            mbarrier_arrive(q_state_acc_empty_addr);
+          }
+          mbarrier_wait(cg1_shared_acc_full_addr, _phase_cg1_shared_acc_full_0);
+          _phase_cg1_shared_acc_full_0 ^= 1;
+          if (elect_sync()) {
+            mbarrier_arrive(v_smem_empty_addr + (v_cg1_stage) * 8);
+          }
+          v_cg1_stage += 1;
+          if (v_cg1_stage == 2) {
+            v_cg1_stage = 0;
+            v_cg1_phase ^= 1;
+          }
+          int nv_src_addr_lo_cg1_1 = taddr + 384 + (unsigned int)tmem_row_base_v_1;
+          float _tmem_load_31[32];
+          asm volatile(
+              "tcgen05.ld.sync.aligned.16x256b.x8.b32"
+              " {%0, %1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15, %16, %17, "
+              "%18, %19, %20, %21, %22, %23, %24, %25, %26, %27, %28, %29, %30, %31}, [%32];"
+              : "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_31[0])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_31[1])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_31[2])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_31[3])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_31[4])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_31[5])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_31[6])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_31[7])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_31[8])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_31[9])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_31[10])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_31[11])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_31[12])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_31[13])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_31[14])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_31[15])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_31[16])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_31[17])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_31[18])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_31[19])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_31[20])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_31[21])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_31[22])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_31[23])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_31[24])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_31[25])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_31[26])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_31[27])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_31[28])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_31[29])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_31[30])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_31[31]))
+              : "r"(nv_src_addr_lo_cg1_1));
+          uint32_t _tmem_load_31_bf16[16];
+#pragma unroll
+          for (int _lp = 0; _lp < 16; _lp++) {
+            __nv_bfloat162 _bf2 = __float22bfloat162_rn(
+                make_float2(_tmem_load_31[_lp * 2 + 0], _tmem_load_31[_lp * 2 + 1 + 0]));
+            _tmem_load_31_bf16[_lp] = *(uint32_t*)&_bf2;
+          }
+          int nv_dst_addr_lo_cg1_1 = taddr + 448 + (unsigned int)tmem_row_base_v_1;
+          asm volatile(
+              "tcgen05.st.sync.aligned.16x128b.x8.b32"
+              " [%0], {%1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15, %16};" ::
+                  "r"(nv_dst_addr_lo_cg1_1),
+              "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_31_bf16[0])),
+              "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_31_bf16[1])),
+              "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_31_bf16[2])),
+              "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_31_bf16[3])),
+              "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_31_bf16[4])),
+              "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_31_bf16[5])),
+              "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_31_bf16[6])),
+              "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_31_bf16[7])),
+              "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_31_bf16[8])),
+              "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_31_bf16[9])),
+              "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_31_bf16[10])),
+              "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_31_bf16[11])),
+              "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_31_bf16[12])),
+              "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_31_bf16[13])),
+              "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_31_bf16[14])),
+              "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_31_bf16[15])));
+          int nv_src_addr_hi_cg1_1 = taddr + 384 + (unsigned int)tmem_row_base_v_1 + 1048576;
+          float _tmem_load_32[32];
+          asm volatile(
+              "tcgen05.ld.sync.aligned.16x256b.x8.b32"
+              " {%0, %1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15, %16, %17, "
+              "%18, %19, %20, %21, %22, %23, %24, %25, %26, %27, %28, %29, %30, %31}, [%32];"
+              : "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_32[0])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_32[1])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_32[2])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_32[3])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_32[4])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_32[5])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_32[6])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_32[7])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_32[8])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_32[9])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_32[10])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_32[11])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_32[12])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_32[13])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_32[14])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_32[15])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_32[16])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_32[17])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_32[18])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_32[19])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_32[20])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_32[21])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_32[22])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_32[23])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_32[24])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_32[25])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_32[26])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_32[27])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_32[28])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_32[29])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_32[30])),
+                "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_32[31]))
+              : "r"(nv_src_addr_hi_cg1_1));
+          uint32_t _tmem_load_32_bf16[16];
+#pragma unroll
+          for (int _lp = 0; _lp < 16; _lp++) {
+            __nv_bfloat162 _bf2 = __float22bfloat162_rn(
+                make_float2(_tmem_load_32[_lp * 2 + 0], _tmem_load_32[_lp * 2 + 1 + 0]));
+            _tmem_load_32_bf16[_lp] = *(uint32_t*)&_bf2;
+          }
+          mbarrier_arrive(cg1_shared_acc_empty_addr);
+          int nv_dst_addr_hi_cg1_1 = taddr + 448 + (unsigned int)tmem_row_base_v_1 + 1048576;
+          asm volatile(
+              "tcgen05.st.sync.aligned.16x128b.x8.b32"
+              " [%0], {%1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15, %16};" ::
+                  "r"(nv_dst_addr_hi_cg1_1),
+              "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_32_bf16[0])),
+              "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_32_bf16[1])),
+              "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_32_bf16[2])),
+              "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_32_bf16[3])),
+              "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_32_bf16[4])),
+              "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_32_bf16[5])),
+              "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_32_bf16[6])),
+              "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_32_bf16[7])),
+              "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_32_bf16[8])),
+              "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_32_bf16[9])),
+              "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_32_bf16[10])),
+              "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_32_bf16[11])),
+              "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_32_bf16[12])),
+              "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_32_bf16[13])),
+              "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_32_bf16[14])),
+              "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_32_bf16[15])));
+          asm volatile("tcgen05.wait::st.sync.aligned;" ::: "memory");
+          mbarrier_arrive(nv_ready_addr);
+          int decay_dst_addr_lo_cg1_1 = taddr + 448 + 32 + (unsigned int)tmem_row_base_v_1;
+          asm volatile(
+              "tcgen05.st.sync.aligned.16x128b.x8.b32"
+              " [%0], {%1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15, %16};" ::
+                  "r"(decay_dst_addr_lo_cg1_1),
+              "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_31_bf16[0])),
+              "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_31_bf16[1])),
+              "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_31_bf16[2])),
+              "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_31_bf16[3])),
+              "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_31_bf16[4])),
+              "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_31_bf16[5])),
+              "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_31_bf16[6])),
+              "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_31_bf16[7])),
+              "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_31_bf16[8])),
+              "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_31_bf16[9])),
+              "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_31_bf16[10])),
+              "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_31_bf16[11])),
+              "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_31_bf16[12])),
+              "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_31_bf16[13])),
+              "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_31_bf16[14])),
+              "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_31_bf16[15])));
+          int decay_dst_addr_hi_cg1_1 =
+              taddr + 448 + 32 + (unsigned int)tmem_row_base_v_1 + 1048576;
+          asm volatile(
+              "tcgen05.st.sync.aligned.16x128b.x8.b32"
+              " [%0], {%1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15, %16};" ::
+                  "r"(decay_dst_addr_hi_cg1_1),
+              "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_32_bf16[0])),
+              "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_32_bf16[1])),
+              "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_32_bf16[2])),
+              "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_32_bf16[3])),
+              "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_32_bf16[4])),
+              "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_32_bf16[5])),
+              "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_32_bf16[6])),
+              "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_32_bf16[7])),
+              "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_32_bf16[8])),
+              "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_32_bf16[9])),
+              "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_32_bf16[10])),
+              "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_32_bf16[11])),
+              "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_32_bf16[12])),
+              "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_32_bf16[13])),
+              "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_32_bf16[14])),
+              "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_32_bf16[15])));
+          asm volatile("tcgen05.wait::st.sync.aligned;" ::: "memory");
+          mbarrier_arrive(decay_v_ready_addr);
+          mbarrier_wait(o_smem_empty_addr + (o_cg1_stage) * 8, o_cg1_phase);
+          int o_stage_addr_cg1_1 = smem_o_addr + o_cg1_stage * 16384;
+          mbarrier_wait(q_state_acc_full_addr, _phase_q_state_acc_full_0);
+          _phase_q_state_acc_full_0 ^= 1;
+#pragma unroll
+          for (int dim_half_cg1_1 = 0; dim_half_cg1_1 < 2; dim_half_cg1_1++) {
+            int dim_half_row_cg1_1 = dim_half_cg1_1 * 16;
+            int q_state_addr_1 = taddr + 128 + (unsigned int)tmem_row_base_v_1 +
+                                 (unsigned int)(dim_half_row_cg1_1 << 16);
+            float _tmem_load_33[32];
+            asm volatile(
+                "tcgen05.ld.sync.aligned.16x256b.x8.b32"
+                " {%0, %1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15, %16, %17, "
+                "%18, %19, %20, %21, %22, %23, %24, %25, %26, %27, %28, %29, %30, %31}, [%32];"
+                : "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_33[0])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_33[1])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_33[2])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_33[3])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_33[4])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_33[5])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_33[6])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_33[7])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_33[8])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_33[9])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_33[10])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_33[11])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_33[12])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_33[13])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_33[14])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_33[15])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_33[16])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_33[17])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_33[18])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_33[19])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_33[20])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_33[21])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_33[22])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_33[23])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_33[24])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_33[25])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_33[26])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_33[27])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_33[28])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_33[29])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_33[30])),
+                  "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_33[31]))
+                : "r"(q_state_addr_1));
+            uint32_t _tmem_load_33_bf16[16];
+#pragma unroll
+            for (int _lp = 0; _lp < 16; _lp++) {
+              __nv_bfloat162 _bf2 = __float22bfloat162_rn(
+                  make_float2(_tmem_load_33[_lp * 2 + 0], _tmem_load_33[_lp * 2 + 1 + 0]));
+              _tmem_load_33_bf16[_lp] = *(uint32_t*)&_bf2;
+            }
+#pragma unroll
+            for (int token_group_cg1_1 = 0; token_group_cg1_1 < 4; token_group_cg1_1++) {
+              int o_mtx_idx_cg1_1 = lane / 8;
+              int o_row_addr_cg1_1 = lane & 7;
+              int warp_id_in_role_5 = (warp - 4);
+              int o_dim_base_cg1_1 =
+                  warp_id_in_role_5 * 32 + dim_half_row_cg1_1 + (o_mtx_idx_cg1_1 & 1) * 8;
+              int o_token_base_cg1_1 = token_group_cg1_1 * 16 + o_mtx_idx_cg1_1 / 2 * 8;
+              int o_token_addr_cg1_1 = o_token_base_cg1_1 + o_row_addr_cg1_1;
+              int o_token_pair_cg1_1 = o_token_addr_cg1_1 / 2;
+              int o_token_parity_cg1_1 = o_token_addr_cg1_1 & 1;
+              int o_raw_row_cg1_1 = o_token_pair_cg1_1 + o_dim_base_cg1_1 / 64 * 32;
+              int o_raw_col_cg1_1 = (o_dim_base_cg1_1 & 63 ^ (o_token_pair_cg1_1 & 3) << 4 ^
+                                     o_token_parity_cg1_1 << 3) +
+                                    o_token_parity_cg1_1 * 64;
+              int o_stsm_offset_cg1_1 = (o_raw_row_cg1_1 * 128 + o_raw_col_cg1_1) * 2;
+              const int o_pack_base_cg1_1 = token_group_cg1_1 * 4;
+              uint32_t _stmatrix_addr_2 = static_cast<uint32_t>(
+                  (unsigned long long)(o_stage_addr_cg1_1 + o_stsm_offset_cg1_1));
+              asm volatile(
+                  "stmatrix.sync.aligned.m8n8.x4.trans.shared.b16 [%0], {%1, %2, %3, %4};\n" ::"r"(
+                      _stmatrix_addr_2),
+                  "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_33_bf16[o_pack_base_cg1_1])),
+                  "r"(*reinterpret_cast<const uint32_t*>(
+                      &_tmem_load_33_bf16[o_pack_base_cg1_1 + 1])),
+                  "r"(*reinterpret_cast<const uint32_t*>(
+                      &_tmem_load_33_bf16[o_pack_base_cg1_1 + 2])),
+                  "r"(*reinterpret_cast<const uint32_t*>(
+                      &_tmem_load_33_bf16[o_pack_base_cg1_1 + 3]))
+                  : "memory");
+            }
+          }
+          asm volatile("fence.proxy.async.shared::cta;" ::: "memory");
+          mbarrier_arrive(q_state_acc_empty_addr);
+          mbarrier_arrive(o_store_ready_addr + (o_cg1_stage) * 8);
+          o_cg1_stage += 1;
+          if (o_cg1_stage == 2) {
+            o_cg1_stage = 0;
+            o_cg1_phase ^= 1;
+          }
+        }
+        if (STORE_FINAL_STATE != 0 && num_chunks_b_1 > 0) {
+          mbarrier_wait(kv_acc_full_addr, _phase_kv_acc_full_0);
+          _phase_kv_acc_full_0 ^= 1;
+          int warp_in_wg_3 = warp % 4;
+          int state_tmem_row_base_cg1 = warp_in_wg_3 * 32 << 16;
+          int warp_id_in_role_6 = (warp - 4);
+          int state_row_cg1 = warp_id_in_role_6 * 32 + lane;
+          int state_base_idx_cg1 =
+              (batch_idx_1 * num_o_heads_1 + head_idx_1) * 128 * 128 + state_row_cg1 * 128;
+#pragma unroll
+          for (int state_col_block_cg1 = 0; state_col_block_cg1 < 4; state_col_block_cg1++) {
+            int final_state_addr_cg1 = taddr + (unsigned int)state_tmem_row_base_cg1 +
+                                       (unsigned int)(state_col_block_cg1 * 32);
+            float _tmem_load_34[32];
+            tmem_ld_x32(&_tmem_load_34[0], final_state_addr_cg1);
+#pragma unroll
+            for (int state_vec_idx_cg1 = 0; state_vec_idx_cg1 < 8; state_vec_idx_cg1++) {
+              asm volatile(
+                  "st.global.L1::no_allocate.v4.f32 [%0], {%1, %2, %3, %4};" ::"l"(
+                      output_state +
+                      (state_base_idx_cg1 + state_col_block_cg1 * 32 + state_vec_idx_cg1 * 4) + 0),
+                  "f"(_tmem_load_34[state_vec_idx_cg1 * 4 + 0]),
+                  "f"(_tmem_load_34[state_vec_idx_cg1 * 4 + 1]),
+                  "f"(_tmem_load_34[state_vec_idx_cg1 * 4 + 2]),
+                  "f"(_tmem_load_34[state_vec_idx_cg1 * 4 + 3])
+                  : "memory");
+            }
+          }
+          mbarrier_arrive(kv_acc_empty_addr);
+        }
+        if (STORE_FINAL_STATE != 0 && USE_INITIAL_STATE != 0 && num_chunks_b_1 == 0) {
+          int warp_id_in_role_7 = (warp - 4);
+          int empty_state_row = warp_id_in_role_7 * 32 + lane;
+          int empty_state_base =
+              ((batch_idx_1 * num_o_heads_1 + head_idx_1) * 128 + empty_state_row) * 128;
+#pragma unroll
+          for (int empty_state_vec = 0; empty_state_vec < 32; empty_state_vec++) {
+            int empty_state_col = empty_state_vec * 4;
+            float _vec_load_0[4];
+            {
+              float4 _v4 = *reinterpret_cast<const float4*>(initial_state + empty_state_base +
+                                                            empty_state_col);
+              _vec_load_0[0 + 0] = _v4.x;
+              _vec_load_0[0 + 1] = _v4.y;
+              _vec_load_0[0 + 2] = _v4.z;
+              _vec_load_0[0 + 3] = _v4.w;
+            }
+            {
+              float4 _v4 = make_float4(_vec_load_0[0 + 0], _vec_load_0[0 + 1], _vec_load_0[0 + 2],
+                                       _vec_load_0[0 + 3]);
+              *reinterpret_cast<float4*>(output_state + (empty_state_base + empty_state_col) + 0) =
+                  _v4;
+            }
+          }
+        }
+      }
+    }
+  }
+  // ---- Role: mma ----
+  if (warp == 8) {
+    {  // mma_main
+      asm volatile("prefetch.tensormap [%0];" ::"l"((uint64_t)(Q)) : "memory");
+      asm volatile("prefetch.tensormap [%0];" ::"l"((uint64_t)(K)) : "memory");
+      asm volatile("prefetch.tensormap [%0];" ::"l"((uint64_t)(V)) : "memory");
+      asm volatile("prefetch.tensormap [%0];" ::"l"((uint64_t)(G)) : "memory");
+      asm volatile("prefetch.tensormap [%0];" ::"l"((uint64_t)(O)) : "memory");
+      unsigned int k_cg0_stage = 0;
+      unsigned int k_cg0_phase = 0;
+      unsigned int q_cg0_stage = 0;
+      unsigned int q_cg0_phase = 0;
+      unsigned int g_cg0_stage = 0;
+      unsigned int g_cg0_phase = 0;
+#pragma unroll 1
+      for (unsigned int tile_2 = bid; tile_2 < total_tiles; tile_2 += num_bids) {
+        int num_o_heads_2 = ((num_q_heads >= num_v_heads) ? num_q_heads : num_v_heads);
+        int batch_idx_2 = tile_2 / (unsigned int)num_o_heads_2;
+        int head_idx_2 = tile_2 % (unsigned int)num_o_heads_2;
+        int qk_head_idx_2 =
+            ((num_q_heads >= num_v_heads) ? head_idx_2 : head_idx_2 / (num_v_heads / num_q_heads));
+        int v_head_idx_2 =
+            ((num_v_heads >= num_q_heads) ? head_idx_2 : head_idx_2 / (num_q_heads / num_v_heads));
+        int batch_start_2 = (int)cu_seqlens[batch_idx_2];
+        int batch_end_2 = (int)cu_seqlens[batch_idx_2 + 1];
+        int seqlen_b_2 = batch_end_2 - batch_start_2;
+        int num_pairs_b_2 = (seqlen_b_2 + 32 - 1) / 32;
+        int num_chunks_b_2 = num_pairs_b_2 * 2;
+        int num_pairs_b_0 = num_chunks_b_2 / 2;
+#pragma unroll 1
+        for (int _pair_idx = 0; _pair_idx < num_pairs_b_0; _pair_idx++) {
+          unsigned int k0_stage_1 = k_cg0_stage;
+          k_cg0_stage += 1;
+          if (k_cg0_stage == 3) {
+            k_cg0_stage = 0;
+            k_cg0_phase ^= 1;
+          }
+          unsigned int q0_stage_1 = q_cg0_stage;
+          q_cg0_stage += 1;
+          if (q_cg0_stage == 2) {
+            q_cg0_stage = 0;
+            q_cg0_phase ^= 1;
+          }
+          unsigned int g0_stage_1 = g_cg0_stage;
+          mbarrier_wait(qkg_ready_addr + (g0_stage_1) * 8, g_cg0_phase);
+          g_cg0_stage += 1;
+          if (g_cg0_stage == 2) {
+            g_cg0_stage = 0;
+            g_cg0_phase ^= 1;
+          }
+          mbarrier_wait(cg0_shared_acc_empty_addr, 1);
+          int _mma_a_lo_0 =
+              make_warp_uniform((((smem_k_addr) >> 4) & 0x3FFF) + (k0_stage_1) * 1024);
+          int _mma_b_lo_0 =
+              make_warp_uniform((((smem_g_addr) >> 4) & 0x3FFF) + (g0_stage_1) * 1024);
+          asm volatile(
+              "{\n\t"
+              ".reg .pred leader, p0, p1;\n\t"
+              ".reg .b32 adhi, bdhi, alo, blo, id;\n\t"
+              ".reg .b64 da, db;\n\t"
+              "elect.sync _|leader, 0xFFFFFFFF;\n\t"
+              "setp.ne.b32 p0, %3, 0;\n\t"
+              "setp.ne.b32 p1, 1, 0;\n\t"
+              ""
+              "mov.b32 adhi, 0x40004040;\n\t"
+              "mov.b32 bdhi, 0x40004040;\n\t"
+              "mov.b32 id, 68158608;\n\t"
+              "mov.b32 alo, %0;\n\t"
+              "mov.b32 blo, %1;\n\t"
+              "mov.b64 da, {alo, adhi};\n\t"
+              "mov.b64 db, {blo, bdhi};\n\t"
+              "@leader tcgen05.mma.cta_group::1.kind::f16 [%2], da, db, id, p0;\n\t"
+              "add.u32 alo, alo, 2;\n\t"
+              "add.u32 blo, blo, 2;\n\t"
+              "mov.b64 da, {alo, adhi};\n\t"
+              "mov.b64 db, {blo, bdhi};\n\t"
+              "@leader tcgen05.mma.cta_group::1.kind::f16 [%2], da, db, id, p1;\n\t"
+              "add.u32 alo, alo, 2;\n\t"
+              "add.u32 blo, blo, 2;\n\t"
+              "mov.b64 da, {alo, adhi};\n\t"
+              "mov.b64 db, {blo, bdhi};\n\t"
+              "@leader tcgen05.mma.cta_group::1.kind::f16 [%2], da, db, id, p1;\n\t"
+              "add.u32 alo, alo, 2;\n\t"
+              "add.u32 blo, blo, 2;\n\t"
+              "mov.b64 da, {alo, adhi};\n\t"
+              "mov.b64 db, {blo, bdhi};\n\t"
+              "@leader tcgen05.mma.cta_group::1.kind::f16 [%2], da, db, id, p1;\n\t"
+              "add.u32 alo, alo, 506;\n\t"
+              "add.u32 blo, blo, 506;\n\t"
+              "mov.b64 da, {alo, adhi};\n\t"
+              "mov.b64 db, {blo, bdhi};\n\t"
+              "@leader tcgen05.mma.cta_group::1.kind::f16 [%2], da, db, id, p1;\n\t"
+              "add.u32 alo, alo, 2;\n\t"
+              "add.u32 blo, blo, 2;\n\t"
+              "mov.b64 da, {alo, adhi};\n\t"
+              "mov.b64 db, {blo, bdhi};\n\t"
+              "@leader tcgen05.mma.cta_group::1.kind::f16 [%2], da, db, id, p1;\n\t"
+              "add.u32 alo, alo, 2;\n\t"
+              "add.u32 blo, blo, 2;\n\t"
+              "mov.b64 da, {alo, adhi};\n\t"
+              "mov.b64 db, {blo, bdhi};\n\t"
+              "@leader tcgen05.mma.cta_group::1.kind::f16 [%2], da, db, id, p1;\n\t"
+              "add.u32 alo, alo, 2;\n\t"
+              "add.u32 blo, blo, 2;\n\t"
+              "mov.b64 da, {alo, adhi};\n\t"
+              "mov.b64 db, {blo, bdhi};\n\t"
+              "@leader tcgen05.mma.cta_group::1.kind::f16 [%2], da, db, id, p1;\n\t"
+              "}\n" ::"r"(_mma_a_lo_0),
+              "r"(_mma_b_lo_0), "r"(tmem_tmem_cg0_shared_acc), "r"(0));
+          elect_commit(cg0_shared_acc_full_addr);
+          unsigned int k1_stage_1 = k_cg0_stage;
+          k_cg0_stage += 1;
+          if (k_cg0_stage == 3) {
+            k_cg0_stage = 0;
+            k_cg0_phase ^= 1;
+          }
+          unsigned int q1_stage_1 = q_cg0_stage;
+          q_cg0_stage += 1;
+          if (q_cg0_stage == 2) {
+            q_cg0_stage = 0;
+            q_cg0_phase ^= 1;
+          }
+          unsigned int g1_stage_1 = g_cg0_stage;
+          mbarrier_wait(qkg_ready_addr + (g1_stage_1) * 8, g_cg0_phase);
+          g_cg0_stage += 1;
+          if (g_cg0_stage == 2) {
+            g_cg0_stage = 0;
+            g_cg0_phase ^= 1;
+          }
+          mbarrier_wait(cg0_shared_acc_empty_addr + 8, 1);
+          int _mma_a_lo_1 =
+              make_warp_uniform((((smem_k_addr) >> 4) & 0x3FFF) + (k1_stage_1) * 1024);
+          int _mma_b_lo_1 =
+              make_warp_uniform((((smem_g_addr) >> 4) & 0x3FFF) + (g1_stage_1) * 1024);
+          asm volatile(
+              "{\n\t"
+              ".reg .pred leader, p0, p1;\n\t"
+              ".reg .b32 adhi, bdhi, alo, blo, id;\n\t"
+              ".reg .b64 da, db;\n\t"
+              "elect.sync _|leader, 0xFFFFFFFF;\n\t"
+              "setp.ne.b32 p0, %3, 0;\n\t"
+              "setp.ne.b32 p1, 1, 0;\n\t"
+              ""
+              "mov.b32 adhi, 0x40004040;\n\t"
+              "mov.b32 bdhi, 0x40004040;\n\t"
+              "mov.b32 id, 68158608;\n\t"
+              "mov.b32 alo, %0;\n\t"
+              "mov.b32 blo, %1;\n\t"
+              "mov.b64 da, {alo, adhi};\n\t"
+              "mov.b64 db, {blo, bdhi};\n\t"
+              "@leader tcgen05.mma.cta_group::1.kind::f16 [%2], da, db, id, p0;\n\t"
+              "add.u32 alo, alo, 2;\n\t"
+              "add.u32 blo, blo, 2;\n\t"
+              "mov.b64 da, {alo, adhi};\n\t"
+              "mov.b64 db, {blo, bdhi};\n\t"
+              "@leader tcgen05.mma.cta_group::1.kind::f16 [%2], da, db, id, p1;\n\t"
+              "add.u32 alo, alo, 2;\n\t"
+              "add.u32 blo, blo, 2;\n\t"
+              "mov.b64 da, {alo, adhi};\n\t"
+              "mov.b64 db, {blo, bdhi};\n\t"
+              "@leader tcgen05.mma.cta_group::1.kind::f16 [%2], da, db, id, p1;\n\t"
+              "add.u32 alo, alo, 2;\n\t"
+              "add.u32 blo, blo, 2;\n\t"
+              "mov.b64 da, {alo, adhi};\n\t"
+              "mov.b64 db, {blo, bdhi};\n\t"
+              "@leader tcgen05.mma.cta_group::1.kind::f16 [%2], da, db, id, p1;\n\t"
+              "add.u32 alo, alo, 506;\n\t"
+              "add.u32 blo, blo, 506;\n\t"
+              "mov.b64 da, {alo, adhi};\n\t"
+              "mov.b64 db, {blo, bdhi};\n\t"
+              "@leader tcgen05.mma.cta_group::1.kind::f16 [%2], da, db, id, p1;\n\t"
+              "add.u32 alo, alo, 2;\n\t"
+              "add.u32 blo, blo, 2;\n\t"
+              "mov.b64 da, {alo, adhi};\n\t"
+              "mov.b64 db, {blo, bdhi};\n\t"
+              "@leader tcgen05.mma.cta_group::1.kind::f16 [%2], da, db, id, p1;\n\t"
+              "add.u32 alo, alo, 2;\n\t"
+              "add.u32 blo, blo, 2;\n\t"
+              "mov.b64 da, {alo, adhi};\n\t"
+              "mov.b64 db, {blo, bdhi};\n\t"
+              "@leader tcgen05.mma.cta_group::1.kind::f16 [%2], da, db, id, p1;\n\t"
+              "add.u32 alo, alo, 2;\n\t"
+              "add.u32 blo, blo, 2;\n\t"
+              "mov.b64 da, {alo, adhi};\n\t"
+              "mov.b64 db, {blo, bdhi};\n\t"
+              "@leader tcgen05.mma.cta_group::1.kind::f16 [%2], da, db, id, p1;\n\t"
+              "}\n" ::"r"(_mma_a_lo_1),
+              "r"(_mma_b_lo_1), "r"((tmem_tmem_cg0_shared_acc + (64))), "r"(0));
+          elect_commit(cg0_shared_acc_full_addr + 8);
+          mbarrier_wait(cg0_shared_acc_empty_addr, 0);
+          int _mma_a_lo_2 =
+              make_warp_uniform((((smem_q_addr) >> 4) & 0x3FFF) + (q0_stage_1) * 1024);
+          int _mma_b_lo_2 =
+              make_warp_uniform((((smem_g_addr) >> 4) & 0x3FFF) + (g0_stage_1) * 1024);
+          asm volatile(
+              "{\n\t"
+              ".reg .pred leader, p0, p1;\n\t"
+              ".reg .b32 adhi, bdhi, alo, blo, id;\n\t"
+              ".reg .b64 da, db;\n\t"
+              "elect.sync _|leader, 0xFFFFFFFF;\n\t"
+              "setp.ne.b32 p0, %3, 0;\n\t"
+              "setp.ne.b32 p1, 1, 0;\n\t"
+              ""
+              "mov.b32 adhi, 0x40004040;\n\t"
+              "mov.b32 bdhi, 0x40004040;\n\t"
+              "mov.b32 id, 68158608;\n\t"
+              "mov.b32 alo, %0;\n\t"
+              "mov.b32 blo, %1;\n\t"
+              "mov.b64 da, {alo, adhi};\n\t"
+              "mov.b64 db, {blo, bdhi};\n\t"
+              "@leader tcgen05.mma.cta_group::1.kind::f16 [%2], da, db, id, p0;\n\t"
+              "add.u32 alo, alo, 2;\n\t"
+              "add.u32 blo, blo, 2;\n\t"
+              "mov.b64 da, {alo, adhi};\n\t"
+              "mov.b64 db, {blo, bdhi};\n\t"
+              "@leader tcgen05.mma.cta_group::1.kind::f16 [%2], da, db, id, p1;\n\t"
+              "add.u32 alo, alo, 2;\n\t"
+              "add.u32 blo, blo, 2;\n\t"
+              "mov.b64 da, {alo, adhi};\n\t"
+              "mov.b64 db, {blo, bdhi};\n\t"
+              "@leader tcgen05.mma.cta_group::1.kind::f16 [%2], da, db, id, p1;\n\t"
+              "add.u32 alo, alo, 2;\n\t"
+              "add.u32 blo, blo, 2;\n\t"
+              "mov.b64 da, {alo, adhi};\n\t"
+              "mov.b64 db, {blo, bdhi};\n\t"
+              "@leader tcgen05.mma.cta_group::1.kind::f16 [%2], da, db, id, p1;\n\t"
+              "add.u32 alo, alo, 506;\n\t"
+              "add.u32 blo, blo, 506;\n\t"
+              "mov.b64 da, {alo, adhi};\n\t"
+              "mov.b64 db, {blo, bdhi};\n\t"
+              "@leader tcgen05.mma.cta_group::1.kind::f16 [%2], da, db, id, p1;\n\t"
+              "add.u32 alo, alo, 2;\n\t"
+              "add.u32 blo, blo, 2;\n\t"
+              "mov.b64 da, {alo, adhi};\n\t"
+              "mov.b64 db, {blo, bdhi};\n\t"
+              "@leader tcgen05.mma.cta_group::1.kind::f16 [%2], da, db, id, p1;\n\t"
+              "add.u32 alo, alo, 2;\n\t"
+              "add.u32 blo, blo, 2;\n\t"
+              "mov.b64 da, {alo, adhi};\n\t"
+              "mov.b64 db, {blo, bdhi};\n\t"
+              "@leader tcgen05.mma.cta_group::1.kind::f16 [%2], da, db, id, p1;\n\t"
+              "add.u32 alo, alo, 2;\n\t"
+              "add.u32 blo, blo, 2;\n\t"
+              "mov.b64 da, {alo, adhi};\n\t"
+              "mov.b64 db, {blo, bdhi};\n\t"
+              "@leader tcgen05.mma.cta_group::1.kind::f16 [%2], da, db, id, p1;\n\t"
+              "}\n" ::"r"(_mma_a_lo_2),
+              "r"(_mma_b_lo_2), "r"(tmem_tmem_cg0_shared_acc), "r"(0));
+          elect_commit(cg0_shared_acc_full_addr);
+          elect_commit(ki_mma_consumed_addr + (g0_stage_1) * 8);
+          mbarrier_wait(cg0_shared_acc_empty_addr + 8, 0);
+          int _mma_a_lo_3 =
+              make_warp_uniform((((smem_q_addr) >> 4) & 0x3FFF) + (q1_stage_1) * 1024);
+          int _mma_b_lo_3 =
+              make_warp_uniform((((smem_g_addr) >> 4) & 0x3FFF) + (g1_stage_1) * 1024);
+          asm volatile(
+              "{\n\t"
+              ".reg .pred leader, p0, p1;\n\t"
+              ".reg .b32 adhi, bdhi, alo, blo, id;\n\t"
+              ".reg .b64 da, db;\n\t"
+              "elect.sync _|leader, 0xFFFFFFFF;\n\t"
+              "setp.ne.b32 p0, %3, 0;\n\t"
+              "setp.ne.b32 p1, 1, 0;\n\t"
+              ""
+              "mov.b32 adhi, 0x40004040;\n\t"
+              "mov.b32 bdhi, 0x40004040;\n\t"
+              "mov.b32 id, 68158608;\n\t"
+              "mov.b32 alo, %0;\n\t"
+              "mov.b32 blo, %1;\n\t"
+              "mov.b64 da, {alo, adhi};\n\t"
+              "mov.b64 db, {blo, bdhi};\n\t"
+              "@leader tcgen05.mma.cta_group::1.kind::f16 [%2], da, db, id, p0;\n\t"
+              "add.u32 alo, alo, 2;\n\t"
+              "add.u32 blo, blo, 2;\n\t"
+              "mov.b64 da, {alo, adhi};\n\t"
+              "mov.b64 db, {blo, bdhi};\n\t"
+              "@leader tcgen05.mma.cta_group::1.kind::f16 [%2], da, db, id, p1;\n\t"
+              "add.u32 alo, alo, 2;\n\t"
+              "add.u32 blo, blo, 2;\n\t"
+              "mov.b64 da, {alo, adhi};\n\t"
+              "mov.b64 db, {blo, bdhi};\n\t"
+              "@leader tcgen05.mma.cta_group::1.kind::f16 [%2], da, db, id, p1;\n\t"
+              "add.u32 alo, alo, 2;\n\t"
+              "add.u32 blo, blo, 2;\n\t"
+              "mov.b64 da, {alo, adhi};\n\t"
+              "mov.b64 db, {blo, bdhi};\n\t"
+              "@leader tcgen05.mma.cta_group::1.kind::f16 [%2], da, db, id, p1;\n\t"
+              "add.u32 alo, alo, 506;\n\t"
+              "add.u32 blo, blo, 506;\n\t"
+              "mov.b64 da, {alo, adhi};\n\t"
+              "mov.b64 db, {blo, bdhi};\n\t"
+              "@leader tcgen05.mma.cta_group::1.kind::f16 [%2], da, db, id, p1;\n\t"
+              "add.u32 alo, alo, 2;\n\t"
+              "add.u32 blo, blo, 2;\n\t"
+              "mov.b64 da, {alo, adhi};\n\t"
+              "mov.b64 db, {blo, bdhi};\n\t"
+              "@leader tcgen05.mma.cta_group::1.kind::f16 [%2], da, db, id, p1;\n\t"
+              "add.u32 alo, alo, 2;\n\t"
+              "add.u32 blo, blo, 2;\n\t"
+              "mov.b64 da, {alo, adhi};\n\t"
+              "mov.b64 db, {blo, bdhi};\n\t"
+              "@leader tcgen05.mma.cta_group::1.kind::f16 [%2], da, db, id, p1;\n\t"
+              "add.u32 alo, alo, 2;\n\t"
+              "add.u32 blo, blo, 2;\n\t"
+              "mov.b64 da, {alo, adhi};\n\t"
+              "mov.b64 db, {blo, bdhi};\n\t"
+              "@leader tcgen05.mma.cta_group::1.kind::f16 [%2], da, db, id, p1;\n\t"
+              "}\n" ::"r"(_mma_a_lo_3),
+              "r"(_mma_b_lo_3), "r"((tmem_tmem_cg0_shared_acc + (64))), "r"(0));
+          elect_commit(cg0_shared_acc_full_addr + 8);
+          elect_commit(ki_mma_consumed_addr + (g1_stage_1) * 8);
+          elect_commit(load_k_empty_addr + (k0_stage_1) * 8);
+          elect_commit(load_k_empty_addr + (k1_stage_1) * 8);
+          elect_commit(q_smem_empty_addr + (q0_stage_1) * 8);
+          elect_commit(q_smem_empty_addr + (q1_stage_1) * 8);
+        }
+      }
+    }
+  }
+  // ---- Role: tma_qkv ----
+  if (warp == 9) {
+    {  // tma_qkv_main
+      int cta_slot_base = bid * 1280;
+      if (elect_sync()) {
+#pragma unroll
+        for (int descriptor_stage = 0; descriptor_stage < 2; descriptor_stage++) {
+          {
+            const uint64_t* __tm_src = reinterpret_cast<const uint64_t*>(Q);
+            uint64_t* __tm_dst = reinterpret_cast<uint64_t*>(
+                (uint64_t)(tensormap_workspace + (cta_slot_base + descriptor_stage * 128)));
+#pragma unroll
+            for (int __tm_i = 0; __tm_i < 16; ++__tm_i) {
+              __tm_dst[__tm_i] = __tm_src[__tm_i];
+            }
+          }
+        }
+#pragma unroll
+        for (int descriptor_stage_1 = 0; descriptor_stage_1 < 3; descriptor_stage_1++) {
+          {
+            const uint64_t* __tm_src = reinterpret_cast<const uint64_t*>(K);
+            uint64_t* __tm_dst = reinterpret_cast<uint64_t*>(
+                (uint64_t)(tensormap_workspace + (cta_slot_base + 256 + descriptor_stage_1 * 128)));
+#pragma unroll
+            for (int __tm_i = 0; __tm_i < 16; ++__tm_i) {
+              __tm_dst[__tm_i] = __tm_src[__tm_i];
+            }
+          }
+        }
+#pragma unroll
+        for (int descriptor_stage_2 = 0; descriptor_stage_2 < 2; descriptor_stage_2++) {
+          {
+            const uint64_t* __tm_src = reinterpret_cast<const uint64_t*>(V);
+            uint64_t* __tm_dst = reinterpret_cast<uint64_t*>(
+                (uint64_t)(tensormap_workspace + (cta_slot_base + 640 + descriptor_stage_2 * 128)));
+#pragma unroll
+            for (int __tm_i = 0; __tm_i < 16; ++__tm_i) {
+              __tm_dst[__tm_i] = __tm_src[__tm_i];
+            }
+          }
+        }
+#pragma unroll
+        for (int descriptor_stage_3 = 0; descriptor_stage_3 < 2; descriptor_stage_3++) {
+          {
+            const uint64_t* __tm_src = reinterpret_cast<const uint64_t*>(G);
+            uint64_t* __tm_dst = reinterpret_cast<uint64_t*>(
+                (uint64_t)(tensormap_workspace + (cta_slot_base + 896 + descriptor_stage_3 * 128)));
+#pragma unroll
+            for (int __tm_i = 0; __tm_i < 16; ++__tm_i) {
+              __tm_dst[__tm_i] = __tm_src[__tm_i];
+            }
+          }
+        }
+        asm volatile("fence.proxy.tensormap::generic.release.gpu;" ::: "memory");
+      }
+      unsigned int k_stage = 0;
+      unsigned int k_empty_phase_tma = 1;
+      unsigned int q_stage = 0;
+      unsigned int q_empty_phase_tma = 1;
+      unsigned int v_stage = 0;
+      unsigned int v_empty_phase_tma = 1;
+      unsigned int g_stage = 0;
+      unsigned int g_empty_phase_tma = 1;
+#pragma unroll 1
+      for (unsigned int tile_3 = bid; tile_3 < total_tiles; tile_3 += num_bids) {
+        int num_o_heads_3 = ((num_q_heads >= num_v_heads) ? num_q_heads : num_v_heads);
+        int batch_idx_3 = tile_3 / (unsigned int)num_o_heads_3;
+        int head_idx_3 = tile_3 % (unsigned int)num_o_heads_3;
+        int qk_head_idx_3 =
+            ((num_q_heads >= num_v_heads) ? head_idx_3 : head_idx_3 / (num_v_heads / num_q_heads));
+        int v_head_idx_3 =
+            ((num_v_heads >= num_q_heads) ? head_idx_3 : head_idx_3 / (num_q_heads / num_v_heads));
+        int batch_start_3 = (int)cu_seqlens[batch_idx_3];
+        int batch_end_3 = (int)cu_seqlens[batch_idx_3 + 1];
+        int seqlen_b_3 = batch_end_3 - batch_start_3;
+        int num_pairs_b_3 = (seqlen_b_3 + 32 - 1) / 32;
+        int num_chunks_b_3 = num_pairs_b_3 * 2;
+#pragma unroll 1
+        for (int chunk_idx_2 = 0; chunk_idx_2 < num_chunks_b_3; chunk_idx_2++) {
+          int chunk_offset_3 = batch_start_3 + chunk_idx_2 * 16;
+          int chunk_end = chunk_offset_3 + 16;
+          if (chunk_end > batch_end_3) {
+            chunk_end = batch_end_3;
+          }
+          if (elect_sync()) {
+            mbarrier_wait(load_k_empty_addr + (k_stage) * 8, k_empty_phase_tma);
+            asm volatile(
+                "tensormap.replace.tile.global_dim.global.b1024.b32 [%0], 1, %1;" ::"l"(
+                    (uint64_t)(tensormap_workspace + (cta_slot_base + 256 + k_stage * 128))),
+                "r"((uint32_t)(chunk_end))
+                : "memory");
+            asm volatile("fence.proxy.tensormap::generic.release.gpu;" ::: "memory");
+            asm volatile("fence.proxy.tensormap::generic.acquire.gpu [%0], 128;" ::"l"((
+                uint64_t)(tensormap_workspace + (cta_slot_base + 256 + k_stage * 128)))
+                         : "memory");
+            mbarrier_arrive_expect_tx(load_k_full_addr + (k_stage) * 8, 16384);
+#pragma unroll
+            for (int dim_half = 0; dim_half < 2; dim_half++) {
+              tma_3d_gmem2smem(smem_k_addr + k_stage * 16384 + (unsigned int)(dim_half * 8192),
+                               tensormap_workspace + (cta_slot_base + 256 + k_stage * 128),
+                               dim_half * 64, chunk_offset_3, qk_head_idx_3,
+                               load_k_full_addr + (k_stage) * 8);
+            }
+            mbarrier_wait(q_smem_empty_addr + (q_stage) * 8, q_empty_phase_tma);
+            asm volatile(
+                "tensormap.replace.tile.global_dim.global.b1024.b32 [%0], 1, %1;" ::"l"((
+                    uint64_t)(tensormap_workspace + ((unsigned int)cta_slot_base + q_stage * 128))),
+                "r"((uint32_t)(chunk_end))
+                : "memory");
+            asm volatile("fence.proxy.tensormap::generic.release.gpu;" ::: "memory");
+            asm volatile("fence.proxy.tensormap::generic.acquire.gpu [%0], 128;" ::"l"((
+                uint64_t)(tensormap_workspace + ((unsigned int)cta_slot_base + q_stage * 128)))
+                         : "memory");
+            mbarrier_arrive_expect_tx(load_q_full_addr + (q_stage) * 8, 16384);
+#pragma unroll
+            for (int dim_half_1 = 0; dim_half_1 < 2; dim_half_1++) {
+              tma_3d_gmem2smem(smem_q_addr + q_stage * 16384 + (unsigned int)(dim_half_1 * 8192),
+                               tensormap_workspace + ((unsigned int)cta_slot_base + q_stage * 128),
+                               dim_half_1 * 64, chunk_offset_3, qk_head_idx_3,
+                               load_q_full_addr + (q_stage) * 8);
+            }
+            mbarrier_wait(v_smem_empty_addr + (v_stage) * 8, v_empty_phase_tma);
+            asm volatile(
+                "tensormap.replace.tile.global_dim.global.b1024.b32 [%0], 1, %1;" ::"l"(
+                    (uint64_t)(tensormap_workspace + (cta_slot_base + 640 + v_stage * 128))),
+                "r"((uint32_t)(chunk_end))
+                : "memory");
+            asm volatile("fence.proxy.tensormap::generic.release.gpu;" ::: "memory");
+            asm volatile("fence.proxy.tensormap::generic.acquire.gpu [%0], 128;" ::"l"((
+                uint64_t)(tensormap_workspace + (cta_slot_base + 640 + v_stage * 128)))
+                         : "memory");
+            mbarrier_arrive_expect_tx(load_v_full_addr + (v_stage) * 8, 16384);
+#pragma unroll
+            for (int dim_half_2 = 0; dim_half_2 < 2; dim_half_2++) {
+              tma_3d_gmem2smem(smem_v_addr + v_stage * 16384 + (unsigned int)(dim_half_2 * 8192),
+                               tensormap_workspace + (cta_slot_base + 640 + v_stage * 128),
+                               dim_half_2 * 64, chunk_offset_3, v_head_idx_3,
+                               load_v_full_addr + (v_stage) * 8);
+            }
+            mbarrier_wait(load_g_empty_addr + (g_stage) * 8, g_empty_phase_tma);
+            asm volatile(
+                "tensormap.replace.tile.global_dim.global.b1024.b32 [%0], 1, %1;" ::"l"(
+                    (uint64_t)(tensormap_workspace + (cta_slot_base + 896 + g_stage * 128))),
+                "r"((uint32_t)(chunk_end))
+                : "memory");
+            asm volatile("fence.proxy.tensormap::generic.release.gpu;" ::: "memory");
+            asm volatile("fence.proxy.tensormap::generic.acquire.gpu [%0], 128;" ::"l"((
+                uint64_t)(tensormap_workspace + (cta_slot_base + 896 + g_stage * 128)))
+                         : "memory");
+            mbarrier_arrive_expect_tx(load_g_full_addr + (g_stage) * 8, 16384);
+#pragma unroll
+            for (int dim_half_3 = 0; dim_half_3 < 2; dim_half_3++) {
+              tma_3d_gmem2smem(smem_g_addr + g_stage * 16384 + (unsigned int)(dim_half_3 * 8192),
+                               tensormap_workspace + (cta_slot_base + 896 + g_stage * 128),
+                               dim_half_3 * 64, chunk_offset_3, v_head_idx_3,
+                               load_g_full_addr + (g_stage) * 8);
+            }
+          }
+          k_stage += 1;
+          if (k_stage == 3) {
+            k_stage = 0;
+            k_empty_phase_tma ^= 1;
+          }
+          q_stage += 1;
+          if (q_stage == 2) {
+            q_stage = 0;
+            q_empty_phase_tma ^= 1;
+          }
+          v_stage += 1;
+          if (v_stage == 2) {
+            v_stage = 0;
+            v_empty_phase_tma ^= 1;
+          }
+          g_stage += 1;
+          if (g_stage == 2) {
+            g_stage = 0;
+            g_empty_phase_tma ^= 1;
+          }
+        }
+      }
+    }
+  }
+  // ---- Role: mma_cg1 ----
+  if (warp == 10) {
+    {  // mma_cg1_main
+      unsigned int k_stage_1 = 0;
+      unsigned int k_phase_mma = 0;
+      unsigned int q_stage_1 = 0;
+      unsigned int q_phase_mma = 0;
+      unsigned int g_stage_mma = 0;
+      unsigned int g_phase_mma = 0;
+      unsigned int v_stage_mma = 0;
+      unsigned int v_phase_mma = 0;
+      unsigned int ainv_stage_mma = 0;
+      unsigned int ainv_phase_mma = 0;
+      unsigned int qk_stage_mma = 0;
+      unsigned int qk_phase_mma = 0;
+      unsigned int q_state_acc_mma_stage = 0;
+      unsigned int q_state_acc_mma_phase = 1;
+      unsigned int kv_acc_mma_stage = 0;
+      unsigned int kv_acc_mma_phase = 1;
+      unsigned int _phase_state_inp_ready_0 = 0;
+      unsigned int _phase_cg1_shared_acc_empty_0 = 1;
+      unsigned int _phase_vks_ready_0 = 0;
+      unsigned int _phase_nv_ready_0 = 0;
+      unsigned int _phase_decay_v_ready_0 = 0;
+#pragma unroll 1
+      for (unsigned int tile_4 = bid; tile_4 < total_tiles; tile_4 += num_bids) {
+        int num_o_heads_4 = ((num_q_heads >= num_v_heads) ? num_q_heads : num_v_heads);
+        int batch_idx_4 = tile_4 / (unsigned int)num_o_heads_4;
+        int head_idx_4 = tile_4 % (unsigned int)num_o_heads_4;
+        int qk_head_idx_4 =
+            ((num_q_heads >= num_v_heads) ? head_idx_4 : head_idx_4 / (num_v_heads / num_q_heads));
+        int v_head_idx_4 =
+            ((num_v_heads >= num_q_heads) ? head_idx_4 : head_idx_4 / (num_q_heads / num_v_heads));
+        int batch_start_4 = (int)cu_seqlens[batch_idx_4];
+        int batch_end_4 = (int)cu_seqlens[batch_idx_4 + 1];
+        int seqlen_b_4 = batch_end_4 - batch_start_4;
+        int num_pairs_b_4 = (seqlen_b_4 + 32 - 1) / 32;
+        int num_chunks_b_4 = num_pairs_b_4 * 2;
+        if (num_chunks_b_4 > 0) {
+          {
+            kv_acc_mma_stage += 1;
+            if (kv_acc_mma_stage == 1) {
+              kv_acc_mma_stage = 0;
+              kv_acc_mma_phase ^= 1;
+            }
+            int chunk_offset_4 = batch_start_4;
+            int _mma_marker = batch_idx_4 + head_idx_4 + chunk_offset_4 + batch_end_4 + 512;
+            mbarrier_wait(qkg_ready_addr + (g_stage_mma) * 8, g_phase_mma);
+            {
+              mbarrier_wait(state_inp_ready_addr, _phase_state_inp_ready_0);
+              _phase_state_inp_ready_0 ^= 1;
+              mbarrier_wait(cg1_shared_acc_empty_addr, _phase_cg1_shared_acc_empty_0);
+              _phase_cg1_shared_acc_empty_0 ^= 1;
+              int _mma_b_lo_4 =
+                  make_warp_uniform((((smem_k_addr) >> 4) & 0x3FFF) + (k_stage_1) * 1024);
+              asm volatile(
+                  "{\n\t"
+                  ".reg .pred leader, p0, p1;\n\t"
+                  ".reg .b32 dhi, blo, ta, id;\n\t"
+                  ".reg .b64 db;\n\t"
+                  "elect.sync _|leader, 0xFFFFFFFF;\n\t"
+                  "setp.ne.b32 p0, %3, 0;\n\t"
+                  "setp.ne.b32 p1, 1, 0;\n\t"
+                  ""
+                  "mov.b32 dhi, 0x40004040;\n\t"
+                  "mov.b32 id, 135267472;\n\t"
+                  "mov.b32 ta, %2;\n\t"
+                  "mov.b32 blo, %1;\n\t"
+                  "mov.b64 db, {blo, dhi};\n\t"
+                  "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p0;\n\t"
+                  "add.u32 ta, ta, 8;\n\t"
+                  "add.u32 blo, blo, 2;\n\t"
+                  "mov.b64 db, {blo, dhi};\n\t"
+                  "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                  "add.u32 ta, ta, 8;\n\t"
+                  "add.u32 blo, blo, 2;\n\t"
+                  "mov.b64 db, {blo, dhi};\n\t"
+                  "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                  "add.u32 ta, ta, 8;\n\t"
+                  "add.u32 blo, blo, 2;\n\t"
+                  "mov.b64 db, {blo, dhi};\n\t"
+                  "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                  "add.u32 ta, ta, 8;\n\t"
+                  "add.u32 blo, blo, 506;\n\t"
+                  "mov.b64 db, {blo, dhi};\n\t"
+                  "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                  "add.u32 ta, ta, 8;\n\t"
+                  "add.u32 blo, blo, 2;\n\t"
+                  "mov.b64 db, {blo, dhi};\n\t"
+                  "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                  "add.u32 ta, ta, 8;\n\t"
+                  "add.u32 blo, blo, 2;\n\t"
+                  "mov.b64 db, {blo, dhi};\n\t"
+                  "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                  "add.u32 ta, ta, 8;\n\t"
+                  "add.u32 blo, blo, 2;\n\t"
+                  "mov.b64 db, {blo, dhi};\n\t"
+                  "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                  "}\n" ::"r"(tmem_tmem_cg1_shared_acc),
+                  "r"(_mma_b_lo_4), "r"(tmem_tmem_state_inp), "r"(0));
+              elect_commit(cg1_shared_acc_full_addr);
+              mbarrier_wait(q_state_acc_empty_addr + (q_state_acc_mma_stage) * 8,
+                            q_state_acc_mma_phase);
+              int _mma_b_lo_5 =
+                  make_warp_uniform((((smem_q_addr) >> 4) & 0x3FFF) + (q_stage_1) * 1024);
+              asm volatile(
+                  "{\n\t"
+                  ".reg .pred leader, p0, p1;\n\t"
+                  ".reg .b32 dhi, blo, ta, id;\n\t"
+                  ".reg .b64 db;\n\t"
+                  "elect.sync _|leader, 0xFFFFFFFF;\n\t"
+                  "setp.ne.b32 p0, %3, 0;\n\t"
+                  "setp.ne.b32 p1, 1, 0;\n\t"
+                  ""
+                  "mov.b32 dhi, 0x40004040;\n\t"
+                  "mov.b32 id, 135267472;\n\t"
+                  "mov.b32 ta, %2;\n\t"
+                  "mov.b32 blo, %1;\n\t"
+                  "mov.b64 db, {blo, dhi};\n\t"
+                  "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p0;\n\t"
+                  "add.u32 ta, ta, 8;\n\t"
+                  "add.u32 blo, blo, 2;\n\t"
+                  "mov.b64 db, {blo, dhi};\n\t"
+                  "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                  "add.u32 ta, ta, 8;\n\t"
+                  "add.u32 blo, blo, 2;\n\t"
+                  "mov.b64 db, {blo, dhi};\n\t"
+                  "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                  "add.u32 ta, ta, 8;\n\t"
+                  "add.u32 blo, blo, 2;\n\t"
+                  "mov.b64 db, {blo, dhi};\n\t"
+                  "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                  "add.u32 ta, ta, 8;\n\t"
+                  "add.u32 blo, blo, 506;\n\t"
+                  "mov.b64 db, {blo, dhi};\n\t"
+                  "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                  "add.u32 ta, ta, 8;\n\t"
+                  "add.u32 blo, blo, 2;\n\t"
+                  "mov.b64 db, {blo, dhi};\n\t"
+                  "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                  "add.u32 ta, ta, 8;\n\t"
+                  "add.u32 blo, blo, 2;\n\t"
+                  "mov.b64 db, {blo, dhi};\n\t"
+                  "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                  "add.u32 ta, ta, 8;\n\t"
+                  "add.u32 blo, blo, 2;\n\t"
+                  "mov.b64 db, {blo, dhi};\n\t"
+                  "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                  "}\n" ::"r"(tmem_tmem_q_state),
+                  "r"(_mma_b_lo_5), "r"(tmem_tmem_state_inp), "r"(0));
+              elect_commit(q_state_acc_full_addr);
+              q_state_acc_mma_stage += 1;
+              if (q_state_acc_mma_stage == 1) {
+                q_state_acc_mma_stage = 0;
+                q_state_acc_mma_phase ^= 1;
+              }
+            }
+            if (elect_sync()) {
+              mbarrier_arrive(q_smem_empty_addr + (q_stage_1) * 8);
+            }
+            mbarrier_wait(vks_ready_addr, _phase_vks_ready_0);
+            _phase_vks_ready_0 ^= 1;
+            mbarrier_wait(ainv_ready_addr + (ainv_stage_mma) * 8, ainv_phase_mma);
+            mbarrier_wait(cg1_shared_acc_empty_addr, _phase_cg1_shared_acc_empty_0);
+            _phase_cg1_shared_acc_empty_0 ^= 1;
+            {
+              int _mma_b_lo_6 =
+                  make_warp_uniform((((smem_ainv_addr) >> 4) & 0x3FFF) + (ainv_stage_mma) * 512);
+              asm volatile(
+                  "{\n\t"
+                  ".reg .pred leader, p0, p1;\n\t"
+                  ".reg .b32 dhi, blo, ta, id;\n\t"
+                  ".reg .b64 db;\n\t"
+                  "elect.sync _|leader, 0xFFFFFFFF;\n\t"
+                  "setp.ne.b32 p0, %3, 0;\n\t"
+                  "setp.ne.b32 p1, 1, 0;\n\t"
+                  ""
+                  "mov.b32 dhi, 0x40004040;\n\t"
+                  "mov.b32 id, 135267472;\n\t"
+                  "mov.b32 ta, %2;\n\t"
+                  "mov.b32 blo, %1;\n\t"
+                  "mov.b64 db, {blo, dhi};\n\t"
+                  "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p0;\n\t"
+                  "add.u32 ta, ta, 8;\n\t"
+                  "add.u32 blo, blo, 2;\n\t"
+                  "mov.b64 db, {blo, dhi};\n\t"
+                  "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                  "add.u32 ta, ta, 8;\n\t"
+                  "add.u32 blo, blo, 2;\n\t"
+                  "mov.b64 db, {blo, dhi};\n\t"
+                  "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                  "add.u32 ta, ta, 8;\n\t"
+                  "add.u32 blo, blo, 2;\n\t"
+                  "mov.b64 db, {blo, dhi};\n\t"
+                  "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                  "}\n" ::"r"(tmem_tmem_cg1_shared_acc),
+                  "r"(_mma_b_lo_6), "r"(tmem_tmem_shared_inp), "r"(0));
+            }
+            elect_commit(cg1_shared_acc_full_addr);
+            if (elect_sync()) {
+              mbarrier_arrive(ainv_smem_empty_addr + (ainv_stage_mma) * 8);
+            }
+            ainv_stage_mma += 1;
+            if (ainv_stage_mma == 3) {
+              ainv_stage_mma = 0;
+              ainv_phase_mma ^= 1;
+            }
+            mbarrier_wait(qk_ready_addr + (qk_stage_mma) * 8, qk_phase_mma);
+            mbarrier_wait(nv_ready_addr, _phase_nv_ready_0);
+            _phase_nv_ready_0 ^= 1;
+            mbarrier_wait(q_state_acc_empty_addr + (q_state_acc_mma_stage) * 8,
+                          q_state_acc_mma_phase);
+            int _mma_b_lo_8 =
+                make_warp_uniform((((smem_qk_addr) >> 4) & 0x3FFF) + (qk_stage_mma) * 512);
+            asm volatile(
+                "{\n\t"
+                ".reg .pred leader, p0, p1;\n\t"
+                ".reg .b32 dhi, blo, ta, id;\n\t"
+                ".reg .b64 db;\n\t"
+                "elect.sync _|leader, 0xFFFFFFFF;\n\t"
+                "setp.ne.b32 p0, %3, 0;\n\t"
+                "setp.ne.b32 p1, 1, 0;\n\t"
+                ""
+                "mov.b32 dhi, 0x40004040;\n\t"
+                "mov.b32 id, 135267472;\n\t"
+                "mov.b32 ta, %2;\n\t"
+                "mov.b32 blo, %1;\n\t"
+                "mov.b64 db, {blo, dhi};\n\t"
+                "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p0;\n\t"
+                "add.u32 ta, ta, 8;\n\t"
+                "add.u32 blo, blo, 2;\n\t"
+                "mov.b64 db, {blo, dhi};\n\t"
+                "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                "add.u32 ta, ta, 8;\n\t"
+                "add.u32 blo, blo, 2;\n\t"
+                "mov.b64 db, {blo, dhi};\n\t"
+                "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                "add.u32 ta, ta, 8;\n\t"
+                "add.u32 blo, blo, 2;\n\t"
+                "mov.b64 db, {blo, dhi};\n\t"
+                "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                "}\n" ::"r"(tmem_tmem_q_state),
+                "r"(_mma_b_lo_8), "r"(tmem_tmem_shared_inp), "r"(((!1) ? 0 : 1)));
+            elect_commit(q_state_acc_full_addr);
+            q_state_acc_mma_stage += 1;
+            if (q_state_acc_mma_stage == 1) {
+              q_state_acc_mma_stage = 0;
+              q_state_acc_mma_phase ^= 1;
+            }
+            if (elect_sync()) {
+              mbarrier_arrive(qk_smem_empty_addr + (qk_stage_mma) * 8);
+            }
+            qk_stage_mma += 1;
+            if (qk_stage_mma == 2) {
+              qk_stage_mma = 0;
+              qk_phase_mma ^= 1;
+            }
+            mbarrier_wait(kv_acc_empty_addr + (kv_acc_mma_stage) * 8, kv_acc_mma_phase);
+            mbarrier_wait(decay_v_ready_addr, _phase_decay_v_ready_0);
+            _phase_decay_v_ready_0 ^= 1;
+            mbarrier_wait(kr_ready_addr + (g_stage_mma) * 8, g_phase_mma);
+            int _mma_b_lo_9 = make_warp_uniform(
+                ((((smem_g_trans_mma_addr) >> 4) & 0x3FFF) | 0x2000000) + (g_stage_mma) * 1024);
+            asm volatile(
+                "{\n\t"
+                ".reg .pred leader, p0, p1;\n\t"
+                ".reg .b32 dhi, blo, ta, id;\n\t"
+                ".reg .b64 db;\n\t"
+                "elect.sync _|leader, 0xFFFFFFFF;\n\t"
+                "setp.ne.b32 p0, %3, 0;\n\t"
+                "setp.ne.b32 p1, 1, 0;\n\t"
+                ""
+                "mov.b32 dhi, 0x40004040;\n\t"
+                "mov.b32 id, 136381584;\n\t"
+                "mov.b32 ta, %2;\n\t"
+                "mov.b32 blo, %1;\n\t"
+                "mov.b64 db, {blo, dhi};\n\t"
+                "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p0;\n\t"
+                "add.u32 ta, ta, 8;\n\t"
+                "add.u32 blo, blo, 128;\n\t"
+                "mov.b64 db, {blo, dhi};\n\t"
+                "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                "add.u32 ta, ta, 8;\n\t"
+                "add.u32 blo, blo, 128;\n\t"
+                "mov.b64 db, {blo, dhi};\n\t"
+                "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                "add.u32 ta, ta, 8;\n\t"
+                "add.u32 blo, blo, 128;\n\t"
+                "mov.b64 db, {blo, dhi};\n\t"
+                "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                "}\n" ::"r"(tmem_tmem_state),
+                "r"(_mma_b_lo_9), "r"(tmem_tmem_shared_inp + 32), "r"(((!1) ? 0 : 1)));
+            elect_commit(kv_acc_full_addr);
+            elect_commit(load_k_empty_addr + (k_stage_1) * 8);
+            elect_commit(load_g_empty_addr + (g_stage_mma) * 8);
+            kv_acc_mma_stage += 1;
+            if (kv_acc_mma_stage == 1) {
+              kv_acc_mma_stage = 0;
+              kv_acc_mma_phase ^= 1;
+            }
+            k_stage_1 += 1;
+            if (k_stage_1 == 3) {
+              k_stage_1 = 0;
+              k_phase_mma ^= 1;
+            }
+            q_stage_1 += 1;
+            if (q_stage_1 == 2) {
+              q_stage_1 = 0;
+              q_phase_mma ^= 1;
+            }
+            g_stage_mma += 1;
+            if (g_stage_mma == 2) {
+              g_stage_mma = 0;
+              g_phase_mma ^= 1;
+            }
+            v_stage_mma += 1;
+            if (v_stage_mma == 2) {
+              v_stage_mma = 0;
+              v_phase_mma ^= 1;
+            }
+          }
+        }
+#pragma unroll 1
+        for (int chunk_idx_3 = 1; chunk_idx_3 < num_chunks_b_4; chunk_idx_3++) {
+          int chunk_offset_5 = batch_start_4 + chunk_idx_3 * 16;
+          int _mma_marker_1 = batch_idx_4 + head_idx_4 + chunk_offset_5 + batch_end_4 + 512;
+          mbarrier_wait(qkg_ready_addr + (g_stage_mma) * 8, g_phase_mma);
+          {
+            mbarrier_wait(state_inp_ready_addr, _phase_state_inp_ready_0);
+            _phase_state_inp_ready_0 ^= 1;
+            mbarrier_wait(cg1_shared_acc_empty_addr, _phase_cg1_shared_acc_empty_0);
+            _phase_cg1_shared_acc_empty_0 ^= 1;
+            int _mma_b_lo_16 =
+                make_warp_uniform((((smem_k_addr) >> 4) & 0x3FFF) + (k_stage_1) * 1024);
+            asm volatile(
+                "{\n\t"
+                ".reg .pred leader, p0, p1;\n\t"
+                ".reg .b32 dhi, blo, ta, id;\n\t"
+                ".reg .b64 db;\n\t"
+                "elect.sync _|leader, 0xFFFFFFFF;\n\t"
+                "setp.ne.b32 p0, %3, 0;\n\t"
+                "setp.ne.b32 p1, 1, 0;\n\t"
+                ""
+                "mov.b32 dhi, 0x40004040;\n\t"
+                "mov.b32 id, 135267472;\n\t"
+                "mov.b32 ta, %2;\n\t"
+                "mov.b32 blo, %1;\n\t"
+                "mov.b64 db, {blo, dhi};\n\t"
+                "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p0;\n\t"
+                "add.u32 ta, ta, 8;\n\t"
+                "add.u32 blo, blo, 2;\n\t"
+                "mov.b64 db, {blo, dhi};\n\t"
+                "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                "add.u32 ta, ta, 8;\n\t"
+                "add.u32 blo, blo, 2;\n\t"
+                "mov.b64 db, {blo, dhi};\n\t"
+                "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                "add.u32 ta, ta, 8;\n\t"
+                "add.u32 blo, blo, 2;\n\t"
+                "mov.b64 db, {blo, dhi};\n\t"
+                "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                "add.u32 ta, ta, 8;\n\t"
+                "add.u32 blo, blo, 506;\n\t"
+                "mov.b64 db, {blo, dhi};\n\t"
+                "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                "add.u32 ta, ta, 8;\n\t"
+                "add.u32 blo, blo, 2;\n\t"
+                "mov.b64 db, {blo, dhi};\n\t"
+                "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                "add.u32 ta, ta, 8;\n\t"
+                "add.u32 blo, blo, 2;\n\t"
+                "mov.b64 db, {blo, dhi};\n\t"
+                "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                "add.u32 ta, ta, 8;\n\t"
+                "add.u32 blo, blo, 2;\n\t"
+                "mov.b64 db, {blo, dhi};\n\t"
+                "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                "}\n" ::"r"(tmem_tmem_cg1_shared_acc),
+                "r"(_mma_b_lo_16), "r"(tmem_tmem_state_inp), "r"(0));
+            elect_commit(cg1_shared_acc_full_addr);
+            mbarrier_wait(q_state_acc_empty_addr + (q_state_acc_mma_stage) * 8,
+                          q_state_acc_mma_phase);
+            int _mma_b_lo_17 =
+                make_warp_uniform((((smem_q_addr) >> 4) & 0x3FFF) + (q_stage_1) * 1024);
+            asm volatile(
+                "{\n\t"
+                ".reg .pred leader, p0, p1;\n\t"
+                ".reg .b32 dhi, blo, ta, id;\n\t"
+                ".reg .b64 db;\n\t"
+                "elect.sync _|leader, 0xFFFFFFFF;\n\t"
+                "setp.ne.b32 p0, %3, 0;\n\t"
+                "setp.ne.b32 p1, 1, 0;\n\t"
+                ""
+                "mov.b32 dhi, 0x40004040;\n\t"
+                "mov.b32 id, 135267472;\n\t"
+                "mov.b32 ta, %2;\n\t"
+                "mov.b32 blo, %1;\n\t"
+                "mov.b64 db, {blo, dhi};\n\t"
+                "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p0;\n\t"
+                "add.u32 ta, ta, 8;\n\t"
+                "add.u32 blo, blo, 2;\n\t"
+                "mov.b64 db, {blo, dhi};\n\t"
+                "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                "add.u32 ta, ta, 8;\n\t"
+                "add.u32 blo, blo, 2;\n\t"
+                "mov.b64 db, {blo, dhi};\n\t"
+                "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                "add.u32 ta, ta, 8;\n\t"
+                "add.u32 blo, blo, 2;\n\t"
+                "mov.b64 db, {blo, dhi};\n\t"
+                "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                "add.u32 ta, ta, 8;\n\t"
+                "add.u32 blo, blo, 506;\n\t"
+                "mov.b64 db, {blo, dhi};\n\t"
+                "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                "add.u32 ta, ta, 8;\n\t"
+                "add.u32 blo, blo, 2;\n\t"
+                "mov.b64 db, {blo, dhi};\n\t"
+                "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                "add.u32 ta, ta, 8;\n\t"
+                "add.u32 blo, blo, 2;\n\t"
+                "mov.b64 db, {blo, dhi};\n\t"
+                "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                "add.u32 ta, ta, 8;\n\t"
+                "add.u32 blo, blo, 2;\n\t"
+                "mov.b64 db, {blo, dhi};\n\t"
+                "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                "}\n" ::"r"(tmem_tmem_q_state),
+                "r"(_mma_b_lo_17), "r"(tmem_tmem_state_inp), "r"(0));
+            elect_commit(q_state_acc_full_addr);
+            q_state_acc_mma_stage += 1;
+            if (q_state_acc_mma_stage == 1) {
+              q_state_acc_mma_stage = 0;
+              q_state_acc_mma_phase ^= 1;
+            }
+          }
+          if (elect_sync()) {
+            mbarrier_arrive(q_smem_empty_addr + (q_stage_1) * 8);
+          }
+          mbarrier_wait(vks_ready_addr, _phase_vks_ready_0);
+          _phase_vks_ready_0 ^= 1;
+          mbarrier_wait(ainv_ready_addr + (ainv_stage_mma) * 8, ainv_phase_mma);
+          mbarrier_wait(cg1_shared_acc_empty_addr, _phase_cg1_shared_acc_empty_0);
+          _phase_cg1_shared_acc_empty_0 ^= 1;
+          {
+            int _mma_b_lo_18 =
+                make_warp_uniform((((smem_ainv_addr) >> 4) & 0x3FFF) + (ainv_stage_mma) * 512);
+            asm volatile(
+                "{\n\t"
+                ".reg .pred leader, p0, p1;\n\t"
+                ".reg .b32 dhi, blo, ta, id;\n\t"
+                ".reg .b64 db;\n\t"
+                "elect.sync _|leader, 0xFFFFFFFF;\n\t"
+                "setp.ne.b32 p0, %3, 0;\n\t"
+                "setp.ne.b32 p1, 1, 0;\n\t"
+                ""
+                "mov.b32 dhi, 0x40004040;\n\t"
+                "mov.b32 id, 135267472;\n\t"
+                "mov.b32 ta, %2;\n\t"
+                "mov.b32 blo, %1;\n\t"
+                "mov.b64 db, {blo, dhi};\n\t"
+                "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p0;\n\t"
+                "add.u32 ta, ta, 8;\n\t"
+                "add.u32 blo, blo, 2;\n\t"
+                "mov.b64 db, {blo, dhi};\n\t"
+                "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                "add.u32 ta, ta, 8;\n\t"
+                "add.u32 blo, blo, 2;\n\t"
+                "mov.b64 db, {blo, dhi};\n\t"
+                "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                "add.u32 ta, ta, 8;\n\t"
+                "add.u32 blo, blo, 2;\n\t"
+                "mov.b64 db, {blo, dhi};\n\t"
+                "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                "}\n" ::"r"(tmem_tmem_cg1_shared_acc),
+                "r"(_mma_b_lo_18), "r"(tmem_tmem_shared_inp), "r"(0));
+          }
+          elect_commit(cg1_shared_acc_full_addr);
+          if (elect_sync()) {
+            mbarrier_arrive(ainv_smem_empty_addr + (ainv_stage_mma) * 8);
+          }
+          ainv_stage_mma += 1;
+          if (ainv_stage_mma == 3) {
+            ainv_stage_mma = 0;
+            ainv_phase_mma ^= 1;
+          }
+          mbarrier_wait(qk_ready_addr + (qk_stage_mma) * 8, qk_phase_mma);
+          mbarrier_wait(nv_ready_addr, _phase_nv_ready_0);
+          _phase_nv_ready_0 ^= 1;
+          mbarrier_wait(q_state_acc_empty_addr + (q_state_acc_mma_stage) * 8,
+                        q_state_acc_mma_phase);
+          int _mma_b_lo_20 =
+              make_warp_uniform((((smem_qk_addr) >> 4) & 0x3FFF) + (qk_stage_mma) * 512);
+          asm volatile(
+              "{\n\t"
+              ".reg .pred leader, p0, p1;\n\t"
+              ".reg .b32 dhi, blo, ta, id;\n\t"
+              ".reg .b64 db;\n\t"
+              "elect.sync _|leader, 0xFFFFFFFF;\n\t"
+              "setp.ne.b32 p0, %3, 0;\n\t"
+              "setp.ne.b32 p1, 1, 0;\n\t"
+              ""
+              "mov.b32 dhi, 0x40004040;\n\t"
+              "mov.b32 id, 135267472;\n\t"
+              "mov.b32 ta, %2;\n\t"
+              "mov.b32 blo, %1;\n\t"
+              "mov.b64 db, {blo, dhi};\n\t"
+              "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p0;\n\t"
+              "add.u32 ta, ta, 8;\n\t"
+              "add.u32 blo, blo, 2;\n\t"
+              "mov.b64 db, {blo, dhi};\n\t"
+              "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+              "add.u32 ta, ta, 8;\n\t"
+              "add.u32 blo, blo, 2;\n\t"
+              "mov.b64 db, {blo, dhi};\n\t"
+              "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+              "add.u32 ta, ta, 8;\n\t"
+              "add.u32 blo, blo, 2;\n\t"
+              "mov.b64 db, {blo, dhi};\n\t"
+              "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+              "}\n" ::"r"(tmem_tmem_q_state),
+              "r"(_mma_b_lo_20), "r"(tmem_tmem_shared_inp), "r"(((!1) ? 0 : 1)));
+          elect_commit(q_state_acc_full_addr);
+          q_state_acc_mma_stage += 1;
+          if (q_state_acc_mma_stage == 1) {
+            q_state_acc_mma_stage = 0;
+            q_state_acc_mma_phase ^= 1;
+          }
+          if (elect_sync()) {
+            mbarrier_arrive(qk_smem_empty_addr + (qk_stage_mma) * 8);
+          }
+          qk_stage_mma += 1;
+          if (qk_stage_mma == 2) {
+            qk_stage_mma = 0;
+            qk_phase_mma ^= 1;
+          }
+          mbarrier_wait(kv_acc_empty_addr + (kv_acc_mma_stage) * 8, kv_acc_mma_phase);
+          mbarrier_wait(decay_v_ready_addr, _phase_decay_v_ready_0);
+          _phase_decay_v_ready_0 ^= 1;
+          mbarrier_wait(kr_ready_addr + (g_stage_mma) * 8, g_phase_mma);
+          int _mma_b_lo_21 = make_warp_uniform(
+              ((((smem_g_trans_mma_addr) >> 4) & 0x3FFF) | 0x2000000) + (g_stage_mma) * 1024);
+          asm volatile(
+              "{\n\t"
+              ".reg .pred leader, p0, p1;\n\t"
+              ".reg .b32 dhi, blo, ta, id;\n\t"
+              ".reg .b64 db;\n\t"
+              "elect.sync _|leader, 0xFFFFFFFF;\n\t"
+              "setp.ne.b32 p0, %3, 0;\n\t"
+              "setp.ne.b32 p1, 1, 0;\n\t"
+              ""
+              "mov.b32 dhi, 0x40004040;\n\t"
+              "mov.b32 id, 136381584;\n\t"
+              "mov.b32 ta, %2;\n\t"
+              "mov.b32 blo, %1;\n\t"
+              "mov.b64 db, {blo, dhi};\n\t"
+              "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p0;\n\t"
+              "add.u32 ta, ta, 8;\n\t"
+              "add.u32 blo, blo, 128;\n\t"
+              "mov.b64 db, {blo, dhi};\n\t"
+              "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+              "add.u32 ta, ta, 8;\n\t"
+              "add.u32 blo, blo, 128;\n\t"
+              "mov.b64 db, {blo, dhi};\n\t"
+              "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+              "add.u32 ta, ta, 8;\n\t"
+              "add.u32 blo, blo, 128;\n\t"
+              "mov.b64 db, {blo, dhi};\n\t"
+              "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+              "}\n" ::"r"(tmem_tmem_state),
+              "r"(_mma_b_lo_21), "r"(tmem_tmem_shared_inp + 32), "r"(((!1) ? 0 : 1)));
+          elect_commit(kv_acc_full_addr);
+          elect_commit(load_k_empty_addr + (k_stage_1) * 8);
+          elect_commit(load_g_empty_addr + (g_stage_mma) * 8);
+          kv_acc_mma_stage += 1;
+          if (kv_acc_mma_stage == 1) {
+            kv_acc_mma_stage = 0;
+            kv_acc_mma_phase ^= 1;
+          }
+          k_stage_1 += 1;
+          if (k_stage_1 == 3) {
+            k_stage_1 = 0;
+            k_phase_mma ^= 1;
+          }
+          q_stage_1 += 1;
+          if (q_stage_1 == 2) {
+            q_stage_1 = 0;
+            q_phase_mma ^= 1;
+          }
+          g_stage_mma += 1;
+          if (g_stage_mma == 2) {
+            g_stage_mma = 0;
+            g_phase_mma ^= 1;
+          }
+          v_stage_mma += 1;
+          if (v_stage_mma == 2) {
+            v_stage_mma = 0;
+            v_phase_mma ^= 1;
+          }
+        }
+        if (STORE_FINAL_STATE != 0 && num_chunks_b_4 > 0) {
+          mbarrier_wait(kv_acc_empty_addr + (kv_acc_mma_stage) * 8, kv_acc_mma_phase);
+        }
+      }
+    }
+  }
+  // ---- Role: output_epilogue ----
+  if (warp == 11) {
+    {  // output_epilogue_main
+      int cta_slot_base_epi = bid * 1280;
+      unsigned int gate_prod_stage = 0;
+      unsigned int gate_prod_phase = 1;
+      unsigned int o_epi_stage = 0;
+      unsigned int o_epi_phase = 0;
+      if (elect_sync()) {
+        {
+          const uint64_t* __tm_src = reinterpret_cast<const uint64_t*>(O);
+          uint64_t* __tm_dst = reinterpret_cast<uint64_t*>(
+              (uint64_t)(tensormap_workspace + (cta_slot_base_epi + 1152)));
+#pragma unroll
+          for (int __tm_i = 0; __tm_i < 16; ++__tm_i) {
+            __tm_dst[__tm_i] = __tm_src[__tm_i];
+          }
+        }
+        asm volatile("fence.proxy.tensormap::generic.release.gpu;" ::: "memory");
+      }
+#pragma unroll 1
+      for (unsigned int tile_5 = bid; tile_5 < total_tiles; tile_5 += num_bids) {
+        int num_o_heads_5 = ((num_q_heads >= num_v_heads) ? num_q_heads : num_v_heads);
+        int batch_idx_5 = tile_5 / (unsigned int)num_o_heads_5;
+        int head_idx_5 = tile_5 % (unsigned int)num_o_heads_5;
+        int qk_head_idx_5 =
+            ((num_q_heads >= num_v_heads) ? head_idx_5 : head_idx_5 / (num_v_heads / num_q_heads));
+        int v_head_idx_5 =
+            ((num_v_heads >= num_q_heads) ? head_idx_5 : head_idx_5 / (num_q_heads / num_v_heads));
+        int batch_start_5 = (int)cu_seqlens[batch_idx_5];
+        int batch_end_5 = (int)cu_seqlens[batch_idx_5 + 1];
+        int seqlen_b_5 = batch_end_5 - batch_start_5;
+        int num_pairs_b_5 = (seqlen_b_5 + 32 - 1) / 32;
+        int num_chunks_b_5 = num_pairs_b_5 * 2;
+        if (elect_sync()) {
+          asm volatile("tensormap.replace.tile.global_dim.global.b1024.b32 [%0], 1, %1;" ::"l"(
+                           (uint64_t)(tensormap_workspace + (cta_slot_base_epi + 1152))),
+                       "r"((uint32_t)(batch_end_5))
+                       : "memory");
+          asm volatile("fence.proxy.tensormap::generic.release.gpu;" ::: "memory");
+        }
+        int num_valid_chunks_b = (batch_end_5 - batch_start_5 + 16 - 1) / 16;
+        if (num_chunks_b_5 > 0) {
+#pragma unroll
+          for (int prefetch_idx = 0; prefetch_idx < 2; prefetch_idx++) {
+            int prefetch_offset = batch_start_5 + prefetch_idx * 16;
+            mbarrier_wait(beta_smem_empty_addr + (gate_prod_stage) * 8, gate_prod_phase);
+            int gb_lane = lane;
+            int beta_elem_base = gate_prod_stage * 64;
+            int token_0 = prefetch_offset + gb_lane;
+            int beta_idx_0 = token_0 * num_o_heads_5 + head_idx_5;
+            float beta_val_0 = 0.0f;
+            if (gb_lane < 16 && token_0 < batch_end_5) {
+              __nv_bfloat16 beta_logit_0 = beta[beta_idx_0];
+              float _cvt_f32_0 = __bfloat162float(beta_logit_0);
+              float _expf_4 = __expf(-_cvt_f32_0);
+              float _rcp_2 = approx_rcp(1.0f + _expf_4);
+              beta_val_0 = _rcp_2;
+            }
+            smem_beta[beta_elem_base + gb_lane] = beta_val_0;
+            smem_beta[beta_elem_base + gb_lane + 32] = 0.0f;
+            mbarrier_arrive(load_beta_full_addr + (gate_prod_stage) * 8);
+            gate_prod_stage += 1;
+            if (gate_prod_stage == 5) {
+              gate_prod_stage = 0;
+              gate_prod_phase ^= 1;
+            }
+          }
+          if (num_chunks_b_5 > 2) {
+#pragma unroll
+            for (int prefetch_idx_1 = 2; prefetch_idx_1 < 4; prefetch_idx_1++) {
+              int prefetch_offset_1 = batch_start_5 + prefetch_idx_1 * 16;
+              mbarrier_wait(beta_smem_empty_addr + (gate_prod_stage) * 8, gate_prod_phase);
+              int gb_lane_1 = lane;
+              int beta_elem_base_1 = gate_prod_stage * 64;
+              int token_0_1 = prefetch_offset_1 + gb_lane_1;
+              int beta_idx_0_1 = token_0_1 * num_o_heads_5 + head_idx_5;
+              float beta_val_0_1 = 0.0f;
+              if (gb_lane_1 < 16 && token_0_1 < batch_end_5) {
+                __nv_bfloat16 beta_logit_0_1 = beta[beta_idx_0_1];
+                float _cvt_f32_1 = __bfloat162float(beta_logit_0_1);
+                float _expf_5 = __expf(-_cvt_f32_1);
+                float _rcp_3 = approx_rcp(1.0f + _expf_5);
+                beta_val_0_1 = _rcp_3;
+              }
+              smem_beta[beta_elem_base_1 + gb_lane_1] = beta_val_0_1;
+              smem_beta[beta_elem_base_1 + gb_lane_1 + 32] = 0.0f;
+              mbarrier_arrive(load_beta_full_addr + (gate_prod_stage) * 8);
+              gate_prod_stage += 1;
+              if (gate_prod_stage == 5) {
+                gate_prod_stage = 0;
+                gate_prod_phase ^= 1;
+              }
+            }
+          }
+        }
+#pragma unroll 1
+        for (int chunk_idx_4 = 0; chunk_idx_4 < num_chunks_b_5; chunk_idx_4++) {
+          int chunk_offset_6 = batch_start_5 + chunk_idx_4 * 16;
+          int prefetch_idx_2 = chunk_idx_4 + 4;
+          if (prefetch_idx_2 < num_chunks_b_5) {
+            int prefetch_offset_2 = batch_start_5 + prefetch_idx_2 * 16;
+            mbarrier_wait(beta_smem_empty_addr + (gate_prod_stage) * 8, gate_prod_phase);
+            int gb_lane_2 = lane;
+            int beta_elem_base_2 = gate_prod_stage * 64;
+            int token_0_2 = prefetch_offset_2 + gb_lane_2;
+            int beta_idx_0_2 = token_0_2 * num_o_heads_5 + head_idx_5;
+            float beta_val_0_2 = 0.0f;
+            if (gb_lane_2 < 16 && token_0_2 < batch_end_5) {
+              __nv_bfloat16 beta_logit_0_2 = beta[beta_idx_0_2];
+              float _cvt_f32_2 = __bfloat162float(beta_logit_0_2);
+              float _expf_6 = __expf(-_cvt_f32_2);
+              float _rcp_4 = approx_rcp(1.0f + _expf_6);
+              beta_val_0_2 = _rcp_4;
+            }
+            smem_beta[beta_elem_base_2 + gb_lane_2] = beta_val_0_2;
+            smem_beta[beta_elem_base_2 + gb_lane_2 + 32] = 0.0f;
+            mbarrier_arrive(load_beta_full_addr + (gate_prod_stage) * 8);
+            gate_prod_stage += 1;
+            if (gate_prod_stage == 5) {
+              gate_prod_stage = 0;
+              gate_prod_phase ^= 1;
+            }
+          }
+          mbarrier_wait(o_store_ready_addr + (o_epi_stage) * 8, o_epi_phase);
+          if (elect_sync()) {
+            if (chunk_idx_4 == 0) {
+              asm volatile("fence.proxy.tensormap::generic.acquire.gpu [%0], 128;" ::"l"(
+                               (uint64_t)(tensormap_workspace + (cta_slot_base_epi + 1152)))
+                           : "memory");
+            }
+            asm volatile("fence.proxy.async.shared::cta;" ::: "memory");
+#pragma unroll
+            for (int dim_half_4 = 0; dim_half_4 < 2; dim_half_4++) {
+              tma_store_3d(tensormap_workspace + (cta_slot_base_epi + 1152), dim_half_4 * 64,
+                           chunk_offset_6, head_idx_5,
+                           smem_o_addr + o_epi_stage * 16384 + (unsigned int)(dim_half_4 * 8192));
+            }
+          }
+          asm volatile("cp.async.bulk.commit_group;");
+          asm volatile("cp.async.bulk.wait_group 0;");
+          mbarrier_arrive(o_smem_empty_addr + (o_epi_stage) * 8);
+          o_epi_stage += 1;
+          if (o_epi_stage == 2) {
+            o_epi_stage = 0;
+            o_epi_phase ^= 1;
+          }
+        }
+      }
+    }
+  }
+
+  // Cleanup
+  __syncthreads();  // barrier before TMEM dealloc
+
+  if (warp == 4) {
+    asm volatile(
+        "tcgen05.dealloc.cta_group::1.sync.aligned.b32 %0, %1;" ::"r"(tmem_addr_storage[0]),
+        "r"(512));
+  }
+}
+
+}  // extern "C"
+
+#undef ENABLE_CHECKPOINTS
+#undef IS_GQA
+#undef LOOM_INF
+#undef NUM_AINV_PIPE_STAGES
+#undef NUM_BETA_PIPE_STAGES
+#undef NUM_CG0_ACC_PIPE_STAGES
+#undef NUM_GATE_PIPE_STAGES
+#undef NUM_G_PIPE_STAGES
+#undef NUM_K_PIPE_STAGES
+#undef NUM_ONE_STAGE_STAGES
+#undef NUM_O_PIPE_STAGES
+#undef NUM_QK_PIPE_STAGES
+#undef NUM_Q_PIPE_STAGES
+#undef NUM_V_PIPE_STAGES
+#undef SMEM_SMEM_AINV_OFF
+#undef SMEM_SMEM_AINV_RM_OFF
+#undef SMEM_SMEM_AINV_RM_STAGE_BYTES
+#undef SMEM_SMEM_AINV_RM_STRIDE
+#undef SMEM_SMEM_AINV_STAGE_BYTES
+#undef SMEM_SMEM_AINV_STRIDE
+#undef SMEM_SMEM_BETA_OFF
+#undef SMEM_SMEM_BETA_STAGE_BYTES
+#undef SMEM_SMEM_BETA_STRIDE
+#undef SMEM_SMEM_G_OFF
+#undef SMEM_SMEM_G_STAGE_BYTES
+#undef SMEM_SMEM_G_STRIDE
+#undef SMEM_SMEM_G_TOTAL_OFF
+#undef SMEM_SMEM_G_TOTAL_STAGE_BYTES
+#undef SMEM_SMEM_G_TOTAL_STRIDE
+#undef SMEM_SMEM_G_TRANS_MMA_OFF
+#undef SMEM_SMEM_G_TRANS_MMA_STAGE_BYTES
+#undef SMEM_SMEM_G_TRANS_MMA_STRIDE
+#undef SMEM_SMEM_K_OFF
+#undef SMEM_SMEM_K_STAGE_BYTES
+#undef SMEM_SMEM_K_STRIDE
+#undef SMEM_SMEM_K_TRANS_MMA_OFF
+#undef SMEM_SMEM_K_TRANS_MMA_STAGE_BYTES
+#undef SMEM_SMEM_K_TRANS_MMA_STRIDE
+#undef SMEM_SMEM_O_OFF
+#undef SMEM_SMEM_O_STAGE_BYTES
+#undef SMEM_SMEM_O_STRIDE
+#undef SMEM_SMEM_QK_OFF
+#undef SMEM_SMEM_QK_STAGE_BYTES
+#undef SMEM_SMEM_QK_STRIDE
+#undef SMEM_SMEM_Q_OFF
+#undef SMEM_SMEM_Q_STAGE_BYTES
+#undef SMEM_SMEM_Q_STRIDE
+#undef SMEM_SMEM_V_MMA_OFF
+#undef SMEM_SMEM_V_MMA_STAGE_BYTES
+#undef SMEM_SMEM_V_MMA_STRIDE
+#undef SMEM_SMEM_V_OFF
+#undef SMEM_SMEM_V_STAGE_BYTES
+#undef SMEM_SMEM_V_STRIDE
+#undef SMEM_TOTAL
+#undef STORE_FINAL_STATE
+#undef THREADS
+#undef TMEM_NCOLS
+#undef TMEM_TMEM_CG0_SHARED_ACC_OFFSET
+#undef TMEM_TMEM_CG1_SHARED_ACC_OFFSET
+#undef TMEM_TMEM_Q_STATE_OFFSET
+#undef TMEM_TMEM_SHARED_INP_OFFSET
+#undef TMEM_TMEM_STATE_INP_OFFSET
+#undef TMEM_TMEM_STATE_OFFSET
+#undef USE_INITIAL_STATE
+#undef ainv_ready_addr
+#undef ainv_smem_empty_addr
+#undef beta_smem_empty_addr
+#undef cg0_shared_acc_empty_addr
+#undef cg0_shared_acc_full_addr
+#undef cg1_shared_acc_empty_addr
+#undef cg1_shared_acc_full_addr
+#undef decay_v_ready_addr
+#undef gate_cg1_empty_addr
+#undef initial_state_loaded_addr
+#undef ki_mma_consumed_addr
+#undef kr_ready_addr
+#undef kv_acc_empty_addr
+#undef kv_acc_full_addr
+#undef load_beta_full_addr
+#undef load_g_empty_addr
+#undef load_g_full_addr
+#undef load_gate_full_addr
+#undef load_k_empty_addr
+#undef load_k_full_addr
+#undef load_q_full_addr
+#undef load_v_full_addr
+#undef nv_ready_addr
+#undef o_smem_empty_addr
+#undef o_store_ready_addr
+#undef q_smem_empty_addr
+#undef q_state_acc_empty_addr
+#undef q_state_acc_full_addr
+#undef qk_ready_addr
+#undef qk_smem_empty_addr
+#undef qkg_ready_addr
+#undef smem_ainv_addr
+#undef smem_ainv_rm_addr
+#undef smem_beta_addr
+#undef smem_g_addr
+#undef smem_g_total_addr
+#undef smem_g_trans_mma_addr
+#undef smem_k_addr
+#undef smem_k_trans_mma_addr
+#undef smem_o_addr
+#undef smem_q_addr
+#undef smem_qk_addr
+#undef smem_v_addr
+#undef smem_v_mma_addr
+#undef state_inp_ready_addr
+#undef v_smem_empty_addr
+#undef vks_ready_addr

--- a/csrc/kda/flashkda_training_forward_v483.cu
+++ b/csrc/kda/flashkda_training_forward_v483.cu
@@ -1,0 +1,2552 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+// Frozen generated training-forward kernel; do not edit the generated body.
+// clang-format off
+typedef signed char        int8_t;
+typedef unsigned char      uint8_t;
+typedef unsigned short     uint16_t;
+typedef unsigned int       uint32_t;
+typedef unsigned long long uint64_t;
+typedef signed int         int32_t;
+typedef short int          int16_t;
+struct __align__(128) FlashKDATensorMap { uint64_t opaque[16]; };
+template <int N>
+struct __align__(128) FlashKDATensorMapPack { FlashKDATensorMap maps[N]; };
+
+typedef struct __align__(64) { uint64_t opaque[16]; } CUtensorMap;
+
+#include <cuda_bf16.h>
+
+#define FLASH_KDA_INF CUDART_INF_F
+#define TMEM_NCOLS 272
+#define TMEM_TMEM_STATE_OFFSET 0
+#define TMEM_TMEM_STATE_INP_OFFSET 128
+#define TMEM_TMEM_Q_STATE_OFFSET 192
+#define TMEM_TMEM_STATE_K_OFFSET 224
+#define TMEM_TMEM_U_ACC_OFFSET 240
+#define TMEM_TMEM_Y_INP_OFFSET 256
+#define TMEM_TMEM_U_INP_OFFSET 264
+#define NUM_SCHED_PIPE_STAGES 8
+#define NUM_RAW_PIPE_STAGES 5
+#define NUM_RAW_BAR_PIPE_STAGES 6
+#define NUM_DECAY_PIPE_STAGES 2
+#define NUM_INTERMEDIATE_PIPE_STAGES 2
+#define NUM_DIAG_PIPE_STAGES 4
+#define NUM_STATE_PIPE_STAGES 1
+#define NUM_O_PIPE_STAGES 2
+#define NUM_CHECKPOINT_PIPE_STAGES 2
+#define SMEM_SMEM_Q_OFF 1024
+#define SMEM_SMEM_Q_STAGE_BYTES 4096
+#define SMEM_SMEM_Q_STRIDE 4096
+#define SMEM_SMEM_K_OFF 21504
+#define SMEM_SMEM_K_STAGE_BYTES 4096
+#define SMEM_SMEM_K_STRIDE 4096
+#define SMEM_SMEM_V_OFF 41984
+#define SMEM_SMEM_V_STAGE_BYTES 4096
+#define SMEM_SMEM_V_STRIDE 4096
+#define SMEM_SMEM_G_OFF 62464
+#define SMEM_SMEM_G_STAGE_BYTES 8192
+#define SMEM_SMEM_G_STRIDE 8192
+#define SMEM_SMEM_BETA_OFF 103424
+#define SMEM_SMEM_BETA_STAGE_BYTES 32
+#define SMEM_SMEM_BETA_STRIDE 32
+#define SMEM_SMEM_BETA_ALL_OFF 103424
+#define SMEM_SMEM_BETA_ALL_STAGE_BYTES 192
+#define SMEM_SMEM_BETA_ALL_STRIDE 192
+#define SMEM_SMEM_K_INV_OFF 104448
+#define SMEM_SMEM_K_INV_STAGE_BYTES 4096
+#define SMEM_SMEM_K_INV_STRIDE 4096
+#define SMEM_SMEM_K_DECAY_OFF 112640
+#define SMEM_SMEM_K_DECAY_STAGE_BYTES 4096
+#define SMEM_SMEM_K_DECAY_STRIDE 4096
+#define SMEM_SMEM_Q_DECAY_OFF 120832
+#define SMEM_SMEM_Q_DECAY_STAGE_BYTES 4096
+#define SMEM_SMEM_Q_DECAY_STRIDE 4096
+#define SMEM_SMEM_K_RESTORE_OFF 129024
+#define SMEM_SMEM_K_RESTORE_STAGE_BYTES 4096
+#define SMEM_SMEM_K_RESTORE_STRIDE 4096
+#define SMEM_SMEM_K_RESTORE_MN_OFF 129024
+#define SMEM_SMEM_K_RESTORE_MN_STAGE_BYTES 4096
+#define SMEM_SMEM_K_RESTORE_MN_STRIDE 4096
+#define SMEM_SMEM_TINV_OFF 137216
+#define SMEM_SMEM_TINV_STAGE_BYTES 512
+#define SMEM_SMEM_TINV_STRIDE 1024
+#define SMEM_SMEM_A_OFF 137728
+#define SMEM_SMEM_A_STAGE_BYTES 512
+#define SMEM_SMEM_A_STRIDE 1024
+#define SMEM_SMEM_TINV_MN_OFF 137216
+#define SMEM_SMEM_TINV_MN_STAGE_BYTES 512
+#define SMEM_SMEM_TINV_MN_STRIDE 1024
+#define SMEM_SMEM_A_MN_OFF 137728
+#define SMEM_SMEM_A_MN_STAGE_BYTES 512
+#define SMEM_SMEM_A_MN_STRIDE 1024
+#define SMEM_SMEM_STATE_DIAG_OFF 139264
+#define SMEM_SMEM_STATE_DIAG_STAGE_BYTES 512
+#define SMEM_SMEM_STATE_DIAG_STRIDE 512
+#define SMEM_SMEM_O_OFF 155648
+#define SMEM_SMEM_O_STAGE_BYTES 4096
+#define SMEM_SMEM_O_STRIDE 4096
+#define SMEM_SMEM_CHECKPOINT_OFF 163840
+#define SMEM_SMEM_CHECKPOINT_STAGE_BYTES 32768
+#define SMEM_SMEM_CHECKPOINT_STRIDE 32768
+#define SMEM_TINV_SCRATCH_OFF 229376
+#define SMEM_TINV_SCRATCH_STAGE_BYTES 512
+#define SMEM_TINV_SCRATCH_STRIDE 512
+#define SMEM_SCHED_SLOT_OFF 229888
+#define SMEM_SCHED_SLOT_STAGE_BYTES 4
+#define SMEM_SCHED_SLOT_STRIDE 4
+#define SMEM_SMEM_Q_ALL_OFF 1024
+#define SMEM_SMEM_Q_ALL_STAGE_BYTES 20480
+#define SMEM_SMEM_Q_ALL_STRIDE 20480
+#define SMEM_SMEM_K_ALL_OFF 21504
+#define SMEM_SMEM_K_ALL_STAGE_BYTES 20480
+#define SMEM_SMEM_K_ALL_STRIDE 20480
+#define SMEM_SMEM_G_ALL_OFF 62464
+#define SMEM_SMEM_G_ALL_STAGE_BYTES 40960
+#define SMEM_SMEM_G_ALL_STRIDE 40960
+#define SMEM_SMEM_V_ALL_OFF 41984
+#define SMEM_SMEM_V_ALL_STAGE_BYTES 20480
+#define SMEM_SMEM_V_ALL_STRIDE 20480
+#define SMEM_SMEM_O_ALL_OFF 155648
+#define SMEM_SMEM_O_ALL_STAGE_BYTES 8192
+#define SMEM_SMEM_O_ALL_STRIDE 8192
+#define SMEM_TOTAL 230016
+#define THREADS 512
+#define USE_INITIAL_STATE 1
+#define STORE_FINAL_STATE 1
+#define ENABLE_CHECKPOINTS 1
+#define STORE_BETA_ACTIVE 1
+#define G_INPUT_BF16 1
+
+#include <math_constants.h>
+
+__device__ __forceinline__ uint32_t elect_sync() {
+    uint32_t pred = 0;
+    asm volatile(
+        "{\n\t"
+        ".reg .pred %%px;\n\t"
+        "elect.sync _|%%px, %1;\n\t"
+        "@%%px mov.s32 %0, 1;\n\t"
+        "}\n"
+        : "+r"(pred)
+        : "r"(0xFFFFFFFF));
+    return pred;
+}
+
+
+__device__ __forceinline__ void mbarrier_init(int mbar_addr, int count) {
+    asm volatile("mbarrier.init.shared::cta.b64 [%0], %1;"
+        :: "r"(mbar_addr), "r"(count));
+}
+
+
+__device__ __forceinline__ uint32_t mbarrier_try_wait(int mbar_addr, int phase) {
+    uint32_t token;
+    asm volatile(
+        "{\n\t"
+        ".reg .pred P1;\n\t"
+        "mbarrier.try_wait.parity.acquire.cta.shared::cta.b64"
+        " P1, [%1], %2;\n\t"
+        "selp.u32 %0, 1, 0, P1;\n\t"
+        "}\n"
+        : "=r"(token)
+        : "r"(mbar_addr), "r"(phase) : "memory");
+    return token;
+}
+
+__device__ __forceinline__ uint32_t mbarrier_try_wait_cluster(int mbar_addr, int phase) {
+    uint32_t token;
+    asm volatile(
+        "{\n\t"
+        ".reg .pred P1;\n\t"
+        "mbarrier.try_wait.parity.acquire.cluster.shared::cta.b64"
+        " P1, [%1], %2;\n\t"
+        "selp.u32 %0, 1, 0, P1;\n\t"
+        "}\n"
+        : "=r"(token)
+        : "r"(mbar_addr), "r"(phase) : "memory");
+    return token;
+}
+
+__device__ __forceinline__ void mbarrier_wait(int mbar_addr, int phase) {
+    uint32_t ticks = 0x989680;
+    asm volatile(
+        "{\n\t"
+        ".reg .pred P1;\n\t"
+        "LAB_WAIT:\n\t"
+        "mbarrier.try_wait.parity.acquire.cta.shared::cta.b64"
+        " P1, [%0], %1, %2;\n\t"
+        "@P1 bra.uni DONE;\n\t"
+        "bra.uni LAB_WAIT;\n\t"
+        "DONE:\n\t"
+        "}\n"
+        :: "r"(mbar_addr), "r"(phase), "r"(ticks) : "memory");
+}
+
+__device__ __forceinline__ void mbarrier_wait_cluster(int mbar_addr, int phase) {
+    uint32_t ticks = 0x989680;
+    asm volatile(
+        "{\n\t"
+        ".reg .pred P1;\n\t"
+        "LAB_WAIT_CLUSTER:\n\t"
+        "mbarrier.try_wait.parity.acquire.cluster.shared::cta.b64"
+        " P1, [%0], %1, %2;\n\t"
+        "@P1 bra.uni DONE_CLUSTER;\n\t"
+        "bra.uni LAB_WAIT_CLUSTER;\n\t"
+        "DONE_CLUSTER:\n\t"
+        "}\n"
+        :: "r"(mbar_addr), "r"(phase), "r"(ticks) : "memory");
+}
+
+__device__ __forceinline__ void mbarrier_wait_token(int mbar_addr, int phase, uint32_t token) {
+    if (token == 0) {
+        mbarrier_wait(mbar_addr, phase);
+    }
+}
+
+__device__ __forceinline__ void mbarrier_wait_token_cluster(int mbar_addr, int phase, uint32_t token) {
+    if (token == 0) {
+        mbarrier_wait_cluster(mbar_addr, phase);
+    }
+}
+
+
+__device__ __forceinline__ void tcgen05_mma_f16(
+    int taddr, uint64_t a_desc, uint64_t b_desc,
+    uint32_t i_desc, int enable_input_d) {
+    asm volatile(
+        "{\n\t"
+        ".reg .pred p;\n\t"
+        "setp.ne.b32 p, %4, 0;\n\t"
+        "tcgen05.mma.cta_group::1.kind::f16 [%0], %1, %2, %3, p;\n\t"
+        "}\n"
+        :: "r"(taddr), "l"(a_desc), "l"(b_desc),
+           "r"(i_desc), "r"(enable_input_d));
+}
+
+
+__device__ __forceinline__ uint64_t desc_encode(uint64_t x) {
+    return (x & 0x3FFFFULL) >> 4ULL;
+}
+
+
+__device__ __forceinline__ void mma_ts_step(
+    int taddr_out, int taddr_a, int b_lo, uint32_t b_dhi,
+    uint32_t i_desc, int enable_d) {
+    asm volatile(
+        "{\n\t"
+        ".reg .pred leader, p;\n\t"
+        ".reg .b32 dhi;\n\t"
+        ".reg .b64 db;\n\t"
+        "elect.sync _|leader, 0xFFFFFFFF;\n\t"
+        "setp.ne.b32 p, %5, 0;\n\t"
+        "mov.b32 dhi, %3;\n\t"
+        "mov.b64 db, {%2, dhi};\n\t"
+        "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [%1], db, %4, p;\n\t"
+        "}\n"
+        :: "r"(taddr_out), "r"(taddr_a), "r"(b_lo), "r"(b_dhi),
+           "r"(i_desc), "r"(enable_d));
+}
+
+
+__device__ __forceinline__ void elect_commit(int mbar_addr) {
+    asm volatile(
+        "{\n\t"
+        ".reg .pred leader;\n\t"
+        "elect.sync _|leader, 0xFFFFFFFF;\n\t"
+        "@leader tcgen05.commit.cta_group::1.mbarrier::arrive::one"
+        ".shared::cluster.b64 [%0];\n\t"
+        "}\n"
+        :: "r"(mbar_addr));
+}
+
+
+__device__ __forceinline__ void mbarrier_arrive(int mbar_addr) {
+    asm volatile(
+        "mbarrier.arrive.release.cta.shared::cta.b64 _, [%0];"
+        :: "r"(mbar_addr) : "memory");
+}
+
+
+__device__ __forceinline__ void mbarrier_arrive_expect_tx(int mbar_addr, uint32_t bytes) {
+    asm volatile(
+        "mbarrier.arrive.expect_tx.release.cta.shared::cta.b64 _, [%0], %1;"
+        :: "r"(mbar_addr), "r"(bytes) : "memory");
+}
+
+
+__device__ __forceinline__ void tmem_ld_x32(float* dst, int tmem_addr) {
+    asm volatile(
+        "tcgen05.ld.sync.aligned.32x32b.x32.b32"
+        " {%0, %1, %2, %3, %4, %5, %6, %7,"
+        "  %8, %9, %10, %11, %12, %13, %14, %15,"
+        "  %16, %17, %18, %19, %20, %21, %22, %23,"
+        "  %24, %25, %26, %27, %28, %29, %30, %31}, [%32];"
+        : "=f"(dst[0]),  "=f"(dst[1]),  "=f"(dst[2]),  "=f"(dst[3]),
+          "=f"(dst[4]),  "=f"(dst[5]),  "=f"(dst[6]),  "=f"(dst[7]),
+          "=f"(dst[8]),  "=f"(dst[9]),  "=f"(dst[10]), "=f"(dst[11]),
+          "=f"(dst[12]), "=f"(dst[13]), "=f"(dst[14]), "=f"(dst[15]),
+          "=f"(dst[16]), "=f"(dst[17]), "=f"(dst[18]), "=f"(dst[19]),
+          "=f"(dst[20]), "=f"(dst[21]), "=f"(dst[22]), "=f"(dst[23]),
+          "=f"(dst[24]), "=f"(dst[25]), "=f"(dst[26]), "=f"(dst[27]),
+          "=f"(dst[28]), "=f"(dst[29]), "=f"(dst[30]), "=f"(dst[31])
+        : "r"(tmem_addr));
+}
+
+
+__device__ __forceinline__ void tmem_ld_x16(float* dst, int tmem_addr) {
+    asm volatile(
+        "tcgen05.ld.sync.aligned.32x32b.x16.b32"
+        " {%0, %1, %2, %3, %4, %5, %6, %7,"
+        "  %8, %9, %10, %11, %12, %13, %14, %15}, [%16];"
+        : "=f"(dst[0]),  "=f"(dst[1]),  "=f"(dst[2]),  "=f"(dst[3]),
+          "=f"(dst[4]),  "=f"(dst[5]),  "=f"(dst[6]),  "=f"(dst[7]),
+          "=f"(dst[8]),  "=f"(dst[9]),  "=f"(dst[10]), "=f"(dst[11]),
+          "=f"(dst[12]), "=f"(dst[13]), "=f"(dst[14]), "=f"(dst[15])
+        : "r"(tmem_addr));
+}
+
+
+__device__ __forceinline__ void tmem_st_x32_f32(int tmem_addr, const float* src) {
+    asm volatile(
+        "tcgen05.st.sync.aligned.32x32b.x32.b32"
+        " [%0], {%1, %2, %3, %4, %5, %6, %7, %8,"
+        "  %9, %10, %11, %12, %13, %14, %15, %16,"
+        "  %17, %18, %19, %20, %21, %22, %23, %24,"
+        "  %25, %26, %27, %28, %29, %30, %31, %32};"
+        :: "r"(tmem_addr),
+           "f"(src[0]),  "f"(src[1]),  "f"(src[2]),  "f"(src[3]),
+           "f"(src[4]),  "f"(src[5]),  "f"(src[6]),  "f"(src[7]),
+           "f"(src[8]),  "f"(src[9]),  "f"(src[10]), "f"(src[11]),
+           "f"(src[12]), "f"(src[13]), "f"(src[14]), "f"(src[15]),
+           "f"(src[16]), "f"(src[17]), "f"(src[18]), "f"(src[19]),
+           "f"(src[20]), "f"(src[21]), "f"(src[22]), "f"(src[23]),
+           "f"(src[24]), "f"(src[25]), "f"(src[26]), "f"(src[27]),
+           "f"(src[28]), "f"(src[29]), "f"(src[30]), "f"(src[31]));
+}
+
+
+__device__ __forceinline__ float approx_exp2(float x) {
+    float y;
+    asm("ex2.approx.ftz.f32 %0, %1;" : "=f"(y) : "f"(x));
+    return y;
+}
+
+
+__device__ __forceinline__ float approx_rcp(float x) {
+    float y;
+    asm("rcp.approx.ftz.f32 %0, %1;" : "=f"(y) : "f"(x));
+    return y;
+}
+
+
+__device__ __forceinline__ float max_noftz(float a, float b) {
+    float c;
+    asm("max.f32 %0, %1, %2;" : "=f"(c) : "f"(a), "f"(b));
+    return c;
+}
+
+
+__device__ __forceinline__ void fma_f32x2_inplace(float2* a, float2 b, float2 c) {
+    unsigned long long r;
+    asm("fma.rn.ftz.f32x2 %0, %1, %2, %3;"
+        : "=l"(r)
+        : "l"(*(unsigned long long*)a), "l"(*(unsigned long long*)&b),
+          "l"(*(unsigned long long*)&c));
+    *(unsigned long long*)a = r;
+}
+
+__device__ __forceinline__ void mul_f32x2_inplace(float2* a, float2 b) {
+    asm("mul.rn.ftz.f32x2 %0, %0, %1;"
+        : "+l"(*(unsigned long long*)a) : "l"(*(unsigned long long*)&b));
+}
+
+__device__ __forceinline__ void add_f32x2_inplace(float2* a, float2 b) {
+    asm("add.rn.ftz.f32x2 %0, %0, %1;"
+        : "+l"(*(unsigned long long*)a) : "l"(*(unsigned long long*)&b));
+}
+
+__device__ __forceinline__ void sub_f32x2_inplace(float2* a, float2 b) {
+    asm("sub.rn.ftz.f32x2 %0, %0, %1;"
+        : "+l"(*(unsigned long long*)a) : "l"(*(unsigned long long*)&b));
+}
+
+__device__ __forceinline__ float2 add_f32x2(float2 a, float2 b) {
+    float2 r;
+    asm("add.rn.ftz.f32x2 %0, %1, %2;"
+        : "=l"(*(unsigned long long*)&r)
+        : "l"(*(unsigned long long*)&a), "l"(*(unsigned long long*)&b));
+    return r;
+}
+
+__device__ __forceinline__ float2 sub_f32x2(float2 a, float2 b) {
+    float2 r;
+    asm("sub.rn.ftz.f32x2 %0, %1, %2;"
+        : "=l"(*(unsigned long long*)&r)
+        : "l"(*(unsigned long long*)&a), "l"(*(unsigned long long*)&b));
+    return r;
+}
+
+__device__ __forceinline__ void fma_scale_x32(
+    float* sv, const float2* scale2, const float2* neg_max2)
+{
+    float2* sv_2 = reinterpret_cast<float2*>(sv);
+    #pragma unroll
+    for (int j = 0; j < 16; j++)
+        fma_f32x2_inplace(&sv_2[j], *scale2, *neg_max2);
+}
+
+__device__ __forceinline__ float2 fma_f32x2(float2 a, float2 b, float2 c) {
+    float2 r;
+    asm("fma.rn.ftz.f32x2 %0, %1, %2, %3;"
+        : "=l"(*(unsigned long long*)&r)
+        : "l"(*(unsigned long long*)&a), "l"(*(unsigned long long*)&b),
+          "l"(*(unsigned long long*)&c));
+    return r;
+}
+
+__device__ __forceinline__ float2 fma_sub_f32x2(float2 a, float2 b, float2 c) {
+    float2 r;
+    asm volatile("{\n\t"
+        ".reg .f32 _c0, _c1;\n\t"
+        ".reg .b64 _neg_c;\n\t"
+        "mov.b64 {_c0, _c1}, %3;\n\t"
+        "neg.f32 _c0, _c0;\n\t"
+        "neg.f32 _c1, _c1;\n\t"
+        "mov.b64 _neg_c, {_c0, _c1};\n\t"
+        "fma.rn.ftz.f32x2 %0, %1, %2, _neg_c;\n\t"
+        "}\n"
+        : "=l"(*(unsigned long long*)&r)
+        : "l"(*(unsigned long long*)&a), "l"(*(unsigned long long*)&b),
+          "l"(*(unsigned long long*)&c));
+    return r;
+}
+
+__device__ __forceinline__ float2 mul_f32x2(float2 a, float2 b) {
+    float2 r;
+    asm("mul.rn.ftz.f32x2 %0, %1, %2;"
+        : "=l"(*(unsigned long long*)&r)
+        : "l"(*(unsigned long long*)&a), "l"(*(unsigned long long*)&b));
+    return r;
+}
+
+// ex2_emulation_f32x2 defined in softmax_frag_exp2_cast helper (or standalone)
+
+
+__device__ __forceinline__ void elect_commit2(int mbar_addr0, int mbar_addr1) {
+    asm volatile(
+        "{\n\t"
+        ".reg .pred leader;\n\t"
+        "elect.sync _|leader, 0xFFFFFFFF;\n\t"
+        "@leader tcgen05.commit.cta_group::1.mbarrier::arrive::one"
+        ".shared::cluster.b64 [%0];\n\t"
+        "@leader tcgen05.commit.cta_group::1.mbarrier::arrive::one"
+        ".shared::cluster.b64 [%1];\n\t"
+        "}\n"
+        :: "r"(mbar_addr0), "r"(mbar_addr1) : "memory");
+}
+
+
+__device__ __forceinline__ void fence_async_shared() {
+    asm volatile("fence.proxy.async.shared::cta;" ::: "memory");
+}
+
+
+__device__ __forceinline__ uint64_t make_smem_desc(int addr) {
+    const int SBO = 1024;
+    return desc_encode(addr)
+         | (desc_encode(SBO) << 32ULL)
+         | (1ULL << 46ULL)
+         | (2ULL << 61ULL);
+}
+
+
+__device__ __forceinline__ void tma_3d_gmem2smem(
+    int dst, const void *tmap_ptr, int x, int y, int z, int mbar_addr) {
+    asm volatile(
+        "cp.async.bulk.tensor.3d.shared::cta.global"
+        ".mbarrier::complete_tx::bytes"
+        " [%0], [%1, {%2, %3, %4}], [%5];"
+        :: "r"(dst), "l"(tmap_ptr), "r"(x), "r"(y), "r"(z),
+           "r"(mbar_addr) : "memory");
+}
+
+
+__device__ __forceinline__ void tma_4d_gmem2smem(
+    int dst, const void *tmap_ptr, int x, int y, int z, int w, int mbar_addr) {
+    asm volatile(
+        "cp.async.bulk.tensor.4d.shared::cta.global"
+        ".mbarrier::complete_tx::bytes"
+        " [%0], [%1, {%2, %3, %4, %5}], [%6];"
+        :: "r"(dst), "l"(tmap_ptr), "r"(x), "r"(y), "r"(z), "r"(w),
+           "r"(mbar_addr) : "memory");
+}
+
+
+__device__ __forceinline__ void tma_store_3d(
+    const void *tmap, int x, int y, int z, unsigned smem_addr) {
+    asm volatile(
+        "cp.async.bulk.tensor.3d.global.shared::cta.tile.bulk_group"
+        " [%0, {%1, %2, %3}], [%4];"
+        :: "l"(tmap), "r"(x), "r"(y), "r"(z), "r"(smem_addr) : "memory");
+}
+
+
+__device__ __forceinline__ void tma_store_4d(
+    const void *tmap, int x, int y, int z, int w, unsigned smem_addr) {
+    asm volatile(
+        "cp.async.bulk.tensor.4d.global.shared::cta.tile.bulk_group"
+        " [%0, {%1, %2, %3, %4}], [%5];"
+        :: "l"(tmap), "r"(x), "r"(y), "r"(z), "r"(w), "r"(smem_addr) : "memory");
+}
+
+
+__device__ __forceinline__ void tcgen05_commit(int mbar_addr) {
+    asm volatile(
+        "tcgen05.commit.cta_group::1.mbarrier::arrive::one"
+        ".shared::cluster.b64 [%0];"
+        :: "r"(mbar_addr) : "memory");
+}
+
+
+__device__ __forceinline__ void tmem_ld_x8(float* dst, int tmem_addr) {
+    asm volatile(
+        "tcgen05.ld.sync.aligned.32x32b.x8.b32"
+        " {%0, %1, %2, %3, %4, %5, %6, %7}, [%8];"
+        : "=f"(dst[0]), "=f"(dst[1]), "=f"(dst[2]), "=f"(dst[3]),
+          "=f"(dst[4]), "=f"(dst[5]), "=f"(dst[6]), "=f"(dst[7])
+        : "r"(tmem_addr));
+}
+
+
+__device__ __forceinline__ void tmem_st_x8_u32(int addr, const uint32_t* src) {
+    asm volatile(
+        "tcgen05.st.sync.aligned.32x32b.x8.b32"
+        " [%0], {%1,%2,%3,%4,%5,%6,%7,%8};"
+        :: "r"(addr),
+           "r"(src[0]), "r"(src[1]), "r"(src[2]), "r"(src[3]),
+           "r"(src[4]), "r"(src[5]), "r"(src[6]), "r"(src[7]));
+}
+
+
+__device__ __forceinline__ uint32_t make_warp_uniform(uint32_t val) {
+    uint32_t result;
+    asm volatile("shfl.sync.idx.b32 %0, %1, 0, 0x1f, 0xffffffff;"
+        : "=r"(result) : "r"(val));
+    return result;
+}
+
+
+__device__ __forceinline__ unsigned int __as_u32(float v) {
+    unsigned int u;
+    asm("mov.b32 %0, %1;" : "=r"(u) : "f"(v));
+    return u;
+}
+__device__ __forceinline__ unsigned int __as_u32(__nv_bfloat162 v) {
+    return *reinterpret_cast<const unsigned int*>(&v);
+}
+__device__ __forceinline__ unsigned int __as_u32(unsigned int v) { return v; }
+__device__ __forceinline__ unsigned int __as_u32(int v) {
+    unsigned int u;
+    asm("mov.b32 %0, %1;" : "=r"(u) : "r"(v));
+    return u;
+}
+
+__device__ __forceinline__ __nv_bfloat162 __as_bf16x2(unsigned int v) {
+    __nv_bfloat162_raw raw;
+    raw.x = static_cast<unsigned short>(v);
+    raw.y = static_cast<unsigned short>(v >> 16);
+    return __nv_bfloat162(raw);
+}
+
+extern "C" {
+
+__global__ __launch_bounds__(512, 1) void
+kernel_flashkda_forward_checkpoint_c16(unsigned int* __restrict__ dynamic_counter, FlashKDATensorMap const* q_tma, FlashKDATensorMap const* k_tma, FlashKDATensorMap const* v_tma, FlashKDATensorMap const* g_tma, __nv_bfloat16* __restrict__ g, FlashKDATensorMap const* out_tma, FlashKDATensorMap const* checkpoint_tma, __nv_bfloat16* __restrict__ beta, __nv_bfloat16* __restrict__ beta_active_out, float* __restrict__ A_log, float* __restrict__ dt_bias, long long* __restrict__ cu_seqlens, long long* __restrict__ checkpoint_cu_starts, int* __restrict__ work_items, float* __restrict__ initial_state, __nv_bfloat16* __restrict__ final_state, int total_work_items, int uniform_work_items, int num_heads, int checkpoint_every_n_tokens, float scale, float lower_bound)
+{
+    const int tid = threadIdx.x;
+    const int warp = make_warp_uniform(tid / 32);
+    const int lane = tid % 32;
+
+    extern __shared__ __align__(1024) char smem_raw[];
+    int smem;
+    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+
+    const int bid = blockIdx.x;
+    const int num_bids = gridDim.x;
+    if (tid == 0) {
+        asm volatile("fence.proxy.tensormap::generic.acquire.sys [%0], 128;" :: "l"((uint64_t)(q_tma)) : "memory");
+        asm volatile("fence.proxy.tensormap::generic.acquire.sys [%0], 128;" :: "l"((uint64_t)(k_tma)) : "memory");
+        asm volatile("fence.proxy.tensormap::generic.acquire.sys [%0], 128;" :: "l"((uint64_t)(v_tma)) : "memory");
+        asm volatile("fence.proxy.tensormap::generic.acquire.sys [%0], 128;" :: "l"((uint64_t)(g_tma)) : "memory");
+        asm volatile("fence.proxy.tensormap::generic.acquire.sys [%0], 128;" :: "l"((uint64_t)(out_tma)) : "memory");
+        asm volatile("fence.proxy.tensormap::generic.acquire.sys [%0], 128;" :: "l"((uint64_t)(checkpoint_tma)) : "memory");
+    }
+    __syncthreads();
+
+
+    // Kernel setup ops
+    __nv_bfloat16* smem_q = reinterpret_cast<__nv_bfloat16*>(smem_raw + 1024);
+    const int smem_q_addr = smem + 1024;
+    __nv_bfloat16* smem_k = reinterpret_cast<__nv_bfloat16*>(smem_raw + 21504);
+    const int smem_k_addr = smem + 21504;
+    __nv_bfloat16* smem_v = reinterpret_cast<__nv_bfloat16*>(smem_raw + 41984);
+    const int smem_v_addr = smem + 41984;
+    float* smem_g = reinterpret_cast<float*>(smem_raw + 62464);
+    const int smem_g_addr = smem + 62464;
+    __nv_bfloat16* smem_beta = reinterpret_cast<__nv_bfloat16*>(smem_raw + 103424);
+    const int smem_beta_addr = smem + 103424;
+    __nv_bfloat16* smem_beta_all = reinterpret_cast<__nv_bfloat16*>(smem_raw + 103424);
+    const int smem_beta_all_addr = smem + 103424;
+    __nv_bfloat16* smem_k_inv = reinterpret_cast<__nv_bfloat16*>(smem_raw + 104448);
+    const int smem_k_inv_addr = smem + 104448;
+    __nv_bfloat16* smem_k_decay = reinterpret_cast<__nv_bfloat16*>(smem_raw + 112640);
+    const int smem_k_decay_addr = smem + 112640;
+    __nv_bfloat16* smem_q_decay = reinterpret_cast<__nv_bfloat16*>(smem_raw + 120832);
+    const int smem_q_decay_addr = smem + 120832;
+    __nv_bfloat16* smem_k_restore = reinterpret_cast<__nv_bfloat16*>(smem_raw + 129024);
+    const int smem_k_restore_addr = smem + 129024;
+    __nv_bfloat16* smem_k_restore_mn = reinterpret_cast<__nv_bfloat16*>(smem_raw + 129024);
+    const int smem_k_restore_mn_addr = smem + 129024;
+    __nv_bfloat16* smem_tinv = reinterpret_cast<__nv_bfloat16*>(smem_raw + 137216);
+    const int smem_tinv_addr = smem + 137216;
+    __nv_bfloat16* smem_a = reinterpret_cast<__nv_bfloat16*>(smem_raw + 137728);
+    const int smem_a_addr = smem + 137728;
+    __nv_bfloat16* smem_tinv_mn = reinterpret_cast<__nv_bfloat16*>(smem_raw + 137216);
+    const int smem_tinv_mn_addr = smem + 137216;
+    __nv_bfloat16* smem_a_mn = reinterpret_cast<__nv_bfloat16*>(smem_raw + 137728);
+    const int smem_a_mn_addr = smem + 137728;
+    __nv_bfloat16* smem_state_diag = reinterpret_cast<__nv_bfloat16*>(smem_raw + 139264);
+    const int smem_state_diag_addr = smem + 139264;
+    __nv_bfloat16* smem_o = reinterpret_cast<__nv_bfloat16*>(smem_raw + 155648);
+    const int smem_o_addr = smem + 155648;
+    __nv_bfloat16* smem_checkpoint = reinterpret_cast<__nv_bfloat16*>(smem_raw + 163840);
+    const int smem_checkpoint_addr = smem + 163840;
+    __nv_bfloat16* tinv_scratch = reinterpret_cast<__nv_bfloat16*>(smem_raw + 229376);
+    const int tinv_scratch_addr = smem + 229376;
+    unsigned int* sched_slot = reinterpret_cast<unsigned int*>(smem_raw + 229888);
+    const int sched_slot_addr = smem + 229888;
+    __nv_bfloat16* smem_q_all = reinterpret_cast<__nv_bfloat16*>(smem_raw + 1024);
+    const int smem_q_all_addr = smem + 1024;
+    __nv_bfloat16* smem_k_all = reinterpret_cast<__nv_bfloat16*>(smem_raw + 21504);
+    const int smem_k_all_addr = smem + 21504;
+    float* smem_g_all = reinterpret_cast<float*>(smem_raw + 62464);
+    const int smem_g_all_addr = smem + 62464;
+    __nv_bfloat16* smem_v_all = reinterpret_cast<__nv_bfloat16*>(smem_raw + 41984);
+    const int smem_v_all_addr = smem + 41984;
+    __nv_bfloat16* smem_o_all = reinterpret_cast<__nv_bfloat16*>(smem_raw + 155648);
+    const int smem_o_all_addr = smem + 155648;
+
+    // Mbarrier init (37 groups, 116 barriers)
+    // Mbarriers at smem_raw[0..928)
+
+    if (warp == 0) {
+        uint32_t leader = elect_sync();
+        if (leader) {
+            // --- pipeline 'sched_pipe' ---
+            // sched_ready: 8 barriers, init_count=1
+            mbarrier_init(smem + 0, 1);
+            mbarrier_init(smem + 8, 1);
+            mbarrier_init(smem + 16, 1);
+            mbarrier_init(smem + 24, 1);
+            mbarrier_init(smem + 32, 1);
+            mbarrier_init(smem + 40, 1);
+            mbarrier_init(smem + 48, 1);
+            mbarrier_init(smem + 56, 1);
+            // sched_done: 8 barriers, init_count=15
+            mbarrier_init(smem + 64, 15);
+            mbarrier_init(smem + 72, 15);
+            mbarrier_init(smem + 80, 15);
+            mbarrier_init(smem + 88, 15);
+            mbarrier_init(smem + 96, 15);
+            mbarrier_init(smem + 104, 15);
+            mbarrier_init(smem + 112, 15);
+            mbarrier_init(smem + 120, 15);
+            // --- pipeline 'raw_bar_pipe' ---
+            // q_ready: 6 barriers, init_count=1
+            mbarrier_init(smem + 128, 1);
+            mbarrier_init(smem + 136, 1);
+            mbarrier_init(smem + 144, 1);
+            mbarrier_init(smem + 152, 1);
+            mbarrier_init(smem + 160, 1);
+            mbarrier_init(smem + 168, 1);
+            // k_ready: 6 barriers, init_count=1
+            mbarrier_init(smem + 176, 1);
+            mbarrier_init(smem + 184, 1);
+            mbarrier_init(smem + 192, 1);
+            mbarrier_init(smem + 200, 1);
+            mbarrier_init(smem + 208, 1);
+            mbarrier_init(smem + 216, 1);
+            // v_ready: 6 barriers, init_count=1
+            mbarrier_init(smem + 224, 1);
+            mbarrier_init(smem + 232, 1);
+            mbarrier_init(smem + 240, 1);
+            mbarrier_init(smem + 248, 1);
+            mbarrier_init(smem + 256, 1);
+            mbarrier_init(smem + 264, 1);
+            // g_ready: 6 barriers, init_count=1
+            mbarrier_init(smem + 272, 1);
+            mbarrier_init(smem + 280, 1);
+            mbarrier_init(smem + 288, 1);
+            mbarrier_init(smem + 296, 1);
+            mbarrier_init(smem + 304, 1);
+            mbarrier_init(smem + 312, 1);
+            // --- pipeline 'raw_pipe' ---
+            // q_done: 5 barriers, init_count=128
+            mbarrier_init(smem + 320, 128);
+            mbarrier_init(smem + 328, 128);
+            mbarrier_init(smem + 336, 128);
+            mbarrier_init(smem + 344, 128);
+            mbarrier_init(smem + 352, 128);
+            // k_done: 5 barriers, init_count=128
+            mbarrier_init(smem + 360, 128);
+            mbarrier_init(smem + 368, 128);
+            mbarrier_init(smem + 376, 128);
+            mbarrier_init(smem + 384, 128);
+            mbarrier_init(smem + 392, 128);
+            // g_done: 5 barriers, init_count=128
+            mbarrier_init(smem + 400, 128);
+            mbarrier_init(smem + 408, 128);
+            mbarrier_init(smem + 416, 128);
+            mbarrier_init(smem + 424, 128);
+            mbarrier_init(smem + 432, 128);
+            // v_done: 5 barriers, init_count=128
+            mbarrier_init(smem + 440, 128);
+            mbarrier_init(smem + 448, 128);
+            mbarrier_init(smem + 456, 128);
+            mbarrier_init(smem + 464, 128);
+            mbarrier_init(smem + 472, 128);
+            // --- pipeline 'raw_bar_pipe' ---
+            // beta_ready: 6 barriers, init_count=32
+            mbarrier_init(smem + 480, 32);
+            mbarrier_init(smem + 488, 32);
+            mbarrier_init(smem + 496, 32);
+            mbarrier_init(smem + 504, 32);
+            mbarrier_init(smem + 512, 32);
+            mbarrier_init(smem + 520, 32);
+            // beta_done: 6 barriers, init_count=160
+            mbarrier_init(smem + 528, 160);
+            mbarrier_init(smem + 536, 160);
+            mbarrier_init(smem + 544, 160);
+            mbarrier_init(smem + 552, 160);
+            mbarrier_init(smem + 560, 160);
+            mbarrier_init(smem + 568, 160);
+            // --- pipeline 'decay_pipe' ---
+            // k_decay_inv_ready: 2 barriers, init_count=128
+            mbarrier_init(smem + 576, 128);
+            mbarrier_init(smem + 584, 128);
+            // --- pipeline 'diag_pipe' ---
+            // qk_scale_ready: 4 barriers, init_count=128
+            mbarrier_init(smem + 592, 128);
+            mbarrier_init(smem + 600, 128);
+            mbarrier_init(smem + 608, 128);
+            mbarrier_init(smem + 616, 128);
+            // --- pipeline 'decay_pipe' ---
+            // decay_tcgen_done: 2 barriers, init_count=1
+            mbarrier_init(smem + 624, 1);
+            mbarrier_init(smem + 632, 1);
+            // decay_super_done: 2 barriers, init_count=64
+            mbarrier_init(smem + 640, 64);
+            mbarrier_init(smem + 648, 64);
+            // k_restore_done: 2 barriers, init_count=1
+            mbarrier_init(smem + 656, 1);
+            mbarrier_init(smem + 664, 1);
+            // --- pipeline 'diag_pipe' ---
+            // state_diag_done: 4 barriers, init_count=1
+            mbarrier_init(smem + 672, 1);
+            mbarrier_init(smem + 680, 1);
+            mbarrier_init(smem + 688, 1);
+            mbarrier_init(smem + 696, 1);
+            // --- pipeline 'intermediate_pipe' ---
+            // tinv_ready: 2 barriers, init_count=32
+            mbarrier_init(smem + 704, 32);
+            mbarrier_init(smem + 712, 32);
+            // tinv_done: 2 barriers, init_count=1
+            mbarrier_init(smem + 720, 1);
+            mbarrier_init(smem + 728, 1);
+            // a_ready: 2 barriers, init_count=32
+            mbarrier_init(smem + 736, 32);
+            mbarrier_init(smem + 744, 32);
+            // a_done: 2 barriers, init_count=1
+            mbarrier_init(smem + 752, 1);
+            mbarrier_init(smem + 760, 1);
+            // --- pipeline 'state_pipe' ---
+            // state_inp_ready: 1 barriers, init_count=128
+            mbarrier_init(smem + 768, 128);
+            // state_read_done: 1 barriers, init_count=128
+            mbarrier_init(smem + 776, 128);
+            // state_acc_done: 1 barriers, init_count=1
+            mbarrier_init(smem + 784, 1);
+            // state_k_ready: 1 barriers, init_count=1
+            mbarrier_init(smem + 792, 1);
+            // y_inp_ready: 1 barriers, init_count=128
+            mbarrier_init(smem + 800, 128);
+            // u_acc_ready: 1 barriers, init_count=1
+            mbarrier_init(smem + 808, 1);
+            // u_inp_ready: 1 barriers, init_count=128
+            mbarrier_init(smem + 816, 128);
+            // o_acc_ready: 1 barriers, init_count=1
+            mbarrier_init(smem + 824, 1);
+            // --- pipeline 'o_pipe' ---
+            // o_acc_done: 2 barriers, init_count=128
+            mbarrier_init(smem + 832, 128);
+            mbarrier_init(smem + 840, 128);
+            // o_tma_ready: 2 barriers, init_count=128
+            mbarrier_init(smem + 848, 128);
+            mbarrier_init(smem + 856, 128);
+            // o_tma_done: 2 barriers, init_count=32
+            mbarrier_init(smem + 864, 32);
+            mbarrier_init(smem + 872, 32);
+            // --- pipeline 'checkpoint_pipe' ---
+            // checkpoint_ready: 2 barriers, init_count=128
+            mbarrier_init(smem + 880, 128);
+            mbarrier_init(smem + 888, 128);
+            // checkpoint_done: 2 barriers, init_count=32
+            mbarrier_init(smem + 896, 32);
+            mbarrier_init(smem + 904, 32);
+            // consumers_done: 1 barriers, init_count=15
+            mbarrier_init(smem + 912, 15);
+            // cleanup_ready: 1 barriers, init_count=1
+            mbarrier_init(smem + 920, 1);
+            asm volatile("fence.mbarrier_init.release.cluster;");
+        }
+    }
+
+    __syncwarp();
+
+    // TMEM alloc (512 columns, 272 used)
+    volatile int* tmem_addr_storage = (volatile int*)(smem_raw + 928);
+    if (warp == 13) {
+        int _tmem_hold = smem + 928;
+        asm volatile("tcgen05.alloc.cta_group::1.sync.aligned.shared::cta.b32 [%0], %1;" :: "r"(_tmem_hold), "r"(512) : "memory");
+        asm volatile("tcgen05.relinquish_alloc_permit.cta_group::1.sync.aligned;");
+    }
+
+    __syncthreads();
+    asm volatile("tcgen05.fence::after_thread_sync;");
+
+    const int mbar_base = smem;
+    #define sched_ready_addr (mbar_base + 0)
+    #define sched_done_addr (mbar_base + 64)
+    #define q_ready_addr (mbar_base + 128)
+    #define k_ready_addr (mbar_base + 176)
+    #define v_ready_addr (mbar_base + 224)
+    #define g_ready_addr (mbar_base + 272)
+    #define q_done_addr (mbar_base + 320)
+    #define k_done_addr (mbar_base + 360)
+    #define g_done_addr (mbar_base + 400)
+    #define v_done_addr (mbar_base + 440)
+    #define beta_ready_addr (mbar_base + 480)
+    #define beta_done_addr (mbar_base + 528)
+    #define k_decay_inv_ready_addr (mbar_base + 576)
+    #define qk_scale_ready_addr (mbar_base + 592)
+    #define decay_tcgen_done_addr (mbar_base + 624)
+    #define decay_super_done_addr (mbar_base + 640)
+    #define k_restore_done_addr (mbar_base + 656)
+    #define state_diag_done_addr (mbar_base + 672)
+    #define tinv_ready_addr (mbar_base + 704)
+    #define tinv_done_addr (mbar_base + 720)
+    #define a_ready_addr (mbar_base + 736)
+    #define a_done_addr (mbar_base + 752)
+    #define state_inp_ready_addr (mbar_base + 768)
+    #define state_read_done_addr (mbar_base + 776)
+    #define state_acc_done_addr (mbar_base + 784)
+    #define state_k_ready_addr (mbar_base + 792)
+    #define y_inp_ready_addr (mbar_base + 800)
+    #define u_acc_ready_addr (mbar_base + 808)
+    #define u_inp_ready_addr (mbar_base + 816)
+    #define o_acc_ready_addr (mbar_base + 824)
+    #define o_acc_done_addr (mbar_base + 832)
+    #define o_tma_ready_addr (mbar_base + 848)
+    #define o_tma_done_addr (mbar_base + 864)
+    #define checkpoint_ready_addr (mbar_base + 880)
+    #define checkpoint_done_addr (mbar_base + 896)
+    #define consumers_done_addr (mbar_base + 912)
+    #define cleanup_ready_addr (mbar_base + 920)
+    const int taddr = tmem_addr_storage[0];
+
+    // Kernel post-init ops
+    const int tmem_tmem_state = taddr;
+    const int tmem_tmem_state_inp = taddr + 128;
+    const int tmem_tmem_q_state = taddr + 192;
+    const int tmem_tmem_state_k = taddr + 224;
+    const int tmem_tmem_u_acc = taddr + 240;
+    const int tmem_tmem_y_inp = taddr + 256;
+    const int tmem_tmem_u_inp = taddr + 264;
+
+    // ---- Register redistribution for WGs split across roles ----
+    // Dec phase frees registers before any WG attempts inc.
+    if (warp >= 12 && warp <= 15) {
+        asm volatile("setmaxnreg.dec.sync.aligned.u32 56;");
+    }
+
+    // ---- Role: cg0 ----
+    if (warp <= 7) {
+        asm volatile("setmaxnreg.inc.sync.aligned.u32 160;");
+        { // cg0_main
+            unsigned int sched_stage_cg0 = 0;
+            int cumulative_chunk_cg0 = 0;
+            int instance_id = (warp - 0) / 4;
+            int cg0_instance = instance_id;
+            int warp_id_in_role = (warp - 0);
+            int cg0_local_warp = warp_id_in_role - cg0_instance * 4;
+            int cg0_tid = cg0_local_warp * 32 + lane;
+            unsigned int _phase_sched_ready = 0;
+            #pragma unroll 1
+            for (int _ = 0; _ < total_work_items + 1; _++) {
+                mbarrier_wait(sched_ready_addr + (sched_stage_cg0) * 8, _phase_sched_ready);
+                unsigned int slot[1];
+                asm volatile("ld.shared.b32 %0, [%1];" : "=r"(*reinterpret_cast<uint32_t*>(&slot[0])) : "r"(sched_slot_addr + sched_stage_cg0 * 4));
+                unsigned int tile_cg0 = slot[0];
+                if (elect_sync()) {
+                    mbarrier_arrive(sched_done_addr + (sched_stage_cg0) * 8);
+                }
+                sched_stage_cg0 += 1;
+                if (sched_stage_cg0 == 8) { sched_stage_cg0 = 0; _phase_sched_ready ^= 1; }
+                if (tile_cg0 >= (unsigned int)total_work_items) {
+                    break;
+                }
+                int item_base_cg0 = (int)tile_cg0 * 8;
+                int _vec_load_2[4];
+                {
+                    int4 _iv4 = *reinterpret_cast<const int4*>(work_items + item_base_cg0 + 4);
+                    _vec_load_2[0 + 0] = _iv4.x;
+                    _vec_load_2[0 + 1] = _iv4.y;
+                    _vec_load_2[0 + 2] = _iv4.z;
+                    _vec_load_2[0 + 3] = _iv4.w;
+                }
+                int head_cg0 = work_items[item_base_cg0 + 1];
+                int wend_cg0 = work_items[item_base_cg0 + 3];
+                int cstart_cg0 = _vec_load_2[0];
+                long long bos_cg0 = (long long)_vec_load_2[2];
+                long long eos_cg0 = (long long)_vec_load_2[3];
+                int chunks_cg0 = wend_cg0 - cstart_cg0;
+                float _expf_0 = __expf(A_log[head_cg0]);
+                float gate_rate_cg0 = _expf_0;
+                float gate_bias_cg0 = dt_bias[head_cg0 * 128 + cg0_tid];
+                asm volatile("barrier.sync 10, 256;" ::: "memory");
+                int first_cumulative_cg0 = cumulative_chunk_cg0 + cg0_instance;
+                int raw_stage_cg0 = first_cumulative_cg0 % 5;
+                int raw_bar_stage_cg0 = first_cumulative_cg0 % 6;
+                int decay_stage_cg0 = first_cumulative_cg0 % 2;
+                int diag_stage_cg0 = first_cumulative_cg0 % 4;
+                int raw_bar_phase_cg0 = first_cumulative_cg0 / 6 & 1;
+                int decay_free_phase_cg0 = first_cumulative_cg0 / 2 + 1 & 1;
+                int diag_free_phase_cg0 = first_cumulative_cg0 / 4 + 1 & 1;
+                #pragma unroll 1
+                for (int chunk_cg0 = cg0_instance; chunk_cg0 < chunks_cg0; chunk_cg0 += 2) {
+                    int cumulative_cg0 = cumulative_chunk_cg0 + chunk_cg0;
+                    int logical_chunk_cg0 = cstart_cg0 + chunk_cg0;
+                    if (cg0_local_warp == 0) {
+                        mbarrier_wait(beta_done_addr + (raw_bar_stage_cg0) * 8, (unsigned int)(cumulative_cg0 / 6 + 1 & 1));
+                        if (lane < 16) {
+                            long long beta_token_cg0 = bos_cg0 + (long long)logical_chunk_cg0 * 16 + (long long)lane;
+                            float beta_value_cg0 = 0.0f;
+                            if (beta_token_cg0 < eos_cg0) {
+                                float beta_logit_cg0 = (float)beta[beta_token_cg0 * (long long)num_heads + (long long)head_cg0];
+                                float _tanh_approx_0;
+                                asm volatile("tanh.approx.f32 %0, %1;" : "=f"(_tanh_approx_0) : "f"(beta_logit_cg0 * 0.5f));
+                                beta_value_cg0 = _tanh_approx_0 * 0.5f + 0.5f;
+                            }
+                            __nv_bfloat16 _cvt_bf16_0 = __float2bfloat16(beta_value_cg0);
+                            __nv_bfloat16 beta_active_cg0 = _cvt_bf16_0;
+                            smem_beta_all[(int)raw_bar_stage_cg0 * 16 + lane] = beta_active_cg0;
+                            if (STORE_BETA_ACTIVE != 0 && beta_token_cg0 < eos_cg0) {
+                                beta_active_out[beta_token_cg0 * (long long)num_heads + (long long)head_cg0] = beta_active_cg0;
+                            }
+                        }
+                        mbarrier_arrive(beta_ready_addr + (raw_bar_stage_cg0) * 8);
+                    }
+                    mbarrier_wait(g_ready_addr + (raw_bar_stage_cg0) * 8, raw_bar_phase_cg0);
+                    float gate_raw_cg0[16];
+                    float gate_log_cg0[16];
+                    float gate_prefix_regs_cg0[16];
+                    #pragma unroll
+                    for (int token_gate_cg0 = 0; token_gate_cg0 < 16; token_gate_cg0++) {
+                        {
+                            long long gate_token_cg0 = bos_cg0 + (long long)logical_chunk_cg0 * 16 + (long long)token_gate_cg0;
+                            gate_raw_cg0[token_gate_cg0] = (float)g[(gate_token_cg0 * (long long)num_heads + (long long)head_cg0) * 128 + (long long)cg0_tid];
+                        }
+                    }
+                    #pragma unroll
+                    for (int gate_row_cg0 = 0; gate_row_cg0 < 16; gate_row_cg0++) {
+                        float gate_arg_cg0 = gate_rate_cg0 * (gate_raw_cg0[gate_row_cg0] + gate_bias_cg0);
+                        float _tanh_approx_1;
+                        asm volatile("tanh.approx.f32 %0, %1;" : "=f"(_tanh_approx_1) : "f"(gate_arg_cg0 * 0.5f));
+                        float gate_value_cg0 = _tanh_approx_1 * 0.5f + 0.5f;
+                        long long valid_gate_cg0 = bos_cg0 + (long long)logical_chunk_cg0 * 16 + (long long)gate_row_cg0;
+                        gate_log_cg0[gate_row_cg0] = 0.0f;
+                        if (valid_gate_cg0 < eos_cg0) {
+                            gate_log_cg0[gate_row_cg0] = lower_bound * 1.4426950408889634f * gate_value_cg0;
+                        }
+                    }
+                    float gate_prefix_cg0 = 0.0f;
+                    #pragma unroll
+                    for (int gate_pair_idx_cg0 = 0; gate_pair_idx_cg0 < 8; gate_pair_idx_cg0++) {
+                        int gate_row0_cg0 = gate_pair_idx_cg0 * 2;
+                        int gate_row1_cg0 = gate_row0_cg0 + 1;
+                        float2 _f2_0 = make_float2(gate_prefix_cg0, gate_log_cg0[gate_row0_cg0]);
+                        float2 _f2_1 = make_float2(gate_log_cg0[gate_row0_cg0], gate_log_cg0[gate_row1_cg0]);
+                        float2 gate_pair_sum_cg0 = add_f32x2(_f2_0, _f2_1);
+                        gate_prefix_regs_cg0[gate_row0_cg0] = gate_pair_sum_cg0.x;
+                        gate_prefix_cg0 += gate_pair_sum_cg0.y;
+                        gate_prefix_regs_cg0[gate_row1_cg0] = gate_prefix_cg0;
+                    }
+                    float gate_last_cg0 = 1.0f;
+                    #pragma unroll
+                    for (int token_gate_cg0_1 = 0; token_gate_cg0_1 < 16; token_gate_cg0_1++) {
+                        float _exp2_0 = approx_exp2(gate_prefix_regs_cg0[token_gate_cg0_1]);
+                        gate_last_cg0 = _exp2_0;
+                        int segment = cg0_tid / 32;
+                        int segment_col = cg0_tid - segment * 32;
+                        int swizzled_col = segment_col ^ (token_gate_cg0_1 & 7) * 4;
+                        smem_g_all[raw_stage_cg0 * 16 * 128 + segment * 16 * 32 + token_gate_cg0_1 * 32 + swizzled_col] = gate_last_cg0;
+                    }
+                    mbarrier_wait(state_diag_done_addr + (diag_stage_cg0) * 8, diag_free_phase_cg0);
+                    int diag_block_cg0 = cg0_tid / 16;
+                    int diag_coord_cg0 = cg0_tid - diag_block_cg0 * 16;
+                    int diag_storage_stage_cg0 = (int)diag_stage_cg0 * 8 + diag_block_cg0;
+                    if (cumulative_cg0 < 4) {
+                        #pragma unroll
+                        for (int diag_half_cg0 = 0; diag_half_cg0 < 2; diag_half_cg0++) {
+                            asm volatile("st.shared.v4.b32 [%0], {%1,%2,%3,%4};" :: "r"((smem_state_diag_addr + (unsigned int)(diag_storage_stage_cg0 * 512) + (unsigned int)(diag_half_cg0 * 8 / 16 * 512 + diag_coord_cg0 * 32 + diag_half_cg0 * 8 % 16 * 2 ^ (diag_half_cg0 * 8 / 16 * 512 + diag_coord_cg0 * 32 + diag_half_cg0 * 8 % 16 * 2 >> 7 & 1) << 4))), "r"(0), "r"(0), "r"(0), "r"(0) : "memory");
+                        }
+                    }
+                    {
+                        __nv_bfloat16 _bval_0 = __float2bfloat16_rn(gate_last_cg0);
+                        uint16_t _bits_0 = *(uint16_t*)&_bval_0;
+                        uint32_t _addr_0 = static_cast<uint32_t>((smem_state_diag_addr + (unsigned int)(diag_storage_stage_cg0 * 512) + (unsigned int)(diag_coord_cg0 / 16 * 512 + diag_coord_cg0 * 32 + diag_coord_cg0 % 16 * 2 ^ (diag_coord_cg0 / 16 * 512 + diag_coord_cg0 * 32 + diag_coord_cg0 % 16 * 2 >> 7 & 1) << 4)));
+                        asm volatile("st.shared.b16 [%0], %1;" :: "r"(_addr_0), "h"(_bits_0) : "memory");
+                    }
+                    if (cg0_instance == 0) {
+                        asm volatile("barrier.sync 8, 128;" ::: "memory");
+                    } else {
+                        asm volatile("barrier.sync 9, 128;" ::: "memory");
+                    }
+                    mbarrier_wait(q_ready_addr + (raw_bar_stage_cg0) * 8, raw_bar_phase_cg0);
+                    mbarrier_wait(k_ready_addr + (raw_bar_stage_cg0) * 8, raw_bar_phase_cg0);
+                    int decay_row_cg0 = cg0_local_warp * 4 + lane / 8;
+                    int decay_lane_cg0 = lane & 7;
+                    float q_values_cg0[16];
+                    float k_values_cg0[16];
+                    float2 _f2_2 = make_float2(0.0f, 0.0f);
+                    float2 qk_sq_even_cg0 = _f2_2;
+                    float2 _f2_3 = make_float2(0.0f, 0.0f);
+                    float2 qk_sq_odd_cg0 = _f2_3;
+                    #pragma unroll
+                    for (int dim_half_cg0 = 0; dim_half_cg0 < 2; dim_half_cg0++) {
+                        int dim_base_cg0 = dim_half_cg0 * 64 + decay_lane_cg0 * 8;
+                        unsigned int q_words_cg0[4];
+                        unsigned int k_words_cg0[4];
+                        int segment_1 = dim_base_cg0 / 64;
+                        int segment_col_1 = dim_base_cg0 - segment_1 * 64;
+                        int swizzled_col_1 = segment_col_1 ^ (decay_row_cg0 & 7) * 8;
+                        int raw_index_cg0 = raw_stage_cg0 * 16 * 128 + segment_1 * 16 * 64 + decay_row_cg0 * 64 + swizzled_col_1;
+                        asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                            : "=r"(*reinterpret_cast<uint32_t*>(&q_words_cg0[0])), "=r"(*reinterpret_cast<uint32_t*>(&q_words_cg0[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&q_words_cg0[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&q_words_cg0[(0) + 3]))
+                            : "r"(smem_q_all_addr + (unsigned int)(raw_index_cg0 * 2)));
+                        asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                            : "=r"(*reinterpret_cast<uint32_t*>(&k_words_cg0[0])), "=r"(*reinterpret_cast<uint32_t*>(&k_words_cg0[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&k_words_cg0[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&k_words_cg0[(0) + 3]))
+                            : "r"(smem_k_all_addr + (unsigned int)(raw_index_cg0 * 2)));
+                        float q_words_cg0_f32[8];
+                        #pragma unroll
+                        for (int _pair = 0; _pair < 4; _pair++) {
+                            asm volatile(
+                                "{\n\t"
+                                "shl.b32 %0, %2, 16;\n\t"
+                                "and.b32 %1, %2, 0xffff0000;\n\t"
+                                "}\n"
+                                : "=f"((&q_words_cg0_f32[_pair * 2])[0]), "=f"((&q_words_cg0_f32[_pair * 2])[1])
+                                : "r"(q_words_cg0[_pair]));
+                        }
+                        float k_words_cg0_f32[8];
+                        #pragma unroll
+                        for (int _pair = 0; _pair < 4; _pair++) {
+                            asm volatile(
+                                "{\n\t"
+                                "shl.b32 %0, %2, 16;\n\t"
+                                "and.b32 %1, %2, 0xffff0000;\n\t"
+                                "}\n"
+                                : "=f"((&k_words_cg0_f32[_pair * 2])[0]), "=f"((&k_words_cg0_f32[_pair * 2])[1])
+                                : "r"(k_words_cg0[_pair]));
+                        }
+                        #pragma unroll
+                        for (int dim_local_cg0 = 0; dim_local_cg0 < 8; dim_local_cg0++) {
+                            int reg_cg0 = dim_half_cg0 * 8 + dim_local_cg0;
+                            q_values_cg0[reg_cg0] = q_words_cg0_f32[dim_local_cg0];
+                            k_values_cg0[reg_cg0] = k_words_cg0_f32[dim_local_cg0];
+                        }
+                        #pragma unroll
+                        for (int dim_pair_sq_cg0 = 0; dim_pair_sq_cg0 < 4; dim_pair_sq_cg0++) {
+                            int even_reg_cg0 = dim_half_cg0 * 8 + dim_pair_sq_cg0 * 2;
+                            int odd_reg_cg0 = even_reg_cg0 + 1;
+                            float2 _f2_4 = make_float2(q_values_cg0[even_reg_cg0], k_values_cg0[even_reg_cg0]);
+                            float2 qk_even_cg0 = _f2_4;
+                            float2 _f2_5 = make_float2(q_values_cg0[odd_reg_cg0], k_values_cg0[odd_reg_cg0]);
+                            float2 qk_odd_cg0 = _f2_5;
+                            qk_sq_even_cg0 = fma_f32x2(qk_even_cg0, qk_even_cg0, qk_sq_even_cg0);
+                            qk_sq_odd_cg0 = fma_f32x2(qk_odd_cg0, qk_odd_cg0, qk_sq_odd_cg0);
+                        }
+                    }
+                    float q_sq_cg0 = qk_sq_even_cg0.x + qk_sq_odd_cg0.x;
+                    float k_sq_cg0 = qk_sq_even_cg0.y + qk_sq_odd_cg0.y;
+                    float _shfl_xor_0 = __shfl_xor_sync(0xFFFFFFFF, q_sq_cg0, 4);
+                    q_sq_cg0 += _shfl_xor_0;
+                    float _shfl_xor_1 = __shfl_xor_sync(0xFFFFFFFF, k_sq_cg0, 4);
+                    k_sq_cg0 += _shfl_xor_1;
+                    float _shfl_xor_2 = __shfl_xor_sync(0xFFFFFFFF, q_sq_cg0, 2);
+                    q_sq_cg0 += _shfl_xor_2;
+                    float _shfl_xor_3 = __shfl_xor_sync(0xFFFFFFFF, k_sq_cg0, 2);
+                    k_sq_cg0 += _shfl_xor_3;
+                    float _shfl_xor_4 = __shfl_xor_sync(0xFFFFFFFF, q_sq_cg0, 1);
+                    q_sq_cg0 += _shfl_xor_4;
+                    float _shfl_xor_5 = __shfl_xor_sync(0xFFFFFFFF, k_sq_cg0, 1);
+                    k_sq_cg0 += _shfl_xor_5;
+                    float _max_0 = max_noftz(q_sq_cg0, 1e-12f);
+                    float _rsqrt_0 = rsqrtf(_max_0);
+                    float q_inv_norm_cg0 = _rsqrt_0;
+                    float _max_1 = max_noftz(k_sq_cg0, 1e-12f);
+                    float _rsqrt_1 = rsqrtf(_max_1);
+                    float k_inv_norm_cg0 = _rsqrt_1;
+                    float exp_g_regs_cg0[16];
+                    float exp_g_last_regs_cg0[16];
+                    #pragma unroll
+                    for (int dim_half_prefix_cg0 = 0; dim_half_prefix_cg0 < 2; dim_half_prefix_cg0++) {
+                        int dim_base_prefix_cg0 = dim_half_prefix_cg0 * 64 + decay_lane_cg0 * 8;
+                        #pragma unroll
+                        for (int f32_group_cg0 = 0; f32_group_cg0 < 2; f32_group_cg0++) {
+                            int f32_dim_base_cg0 = dim_base_prefix_cg0 + f32_group_cg0 * 4;
+                            unsigned int exp_g_words_cg0[4];
+                            unsigned int exp_g_last_words_cg0[4];
+                            int segment_2 = f32_dim_base_cg0 / 32;
+                            int segment_col_2 = f32_dim_base_cg0 - segment_2 * 32;
+                            int swizzled_col_2 = segment_col_2 ^ (decay_row_cg0 & 7) * 4;
+                            int exp_g_index_cg0 = raw_stage_cg0 * 16 * 128 + segment_2 * 16 * 32 + decay_row_cg0 * 32 + swizzled_col_2;
+                            int segment_0 = f32_dim_base_cg0 / 32;
+                            int segment_col_1_1 = f32_dim_base_cg0 - segment_0 * 32;
+                            int swizzled_col_2_1 = segment_col_1_1 ^ 28;
+                            int exp_g_last_index_cg0 = raw_stage_cg0 * 16 * 128 + segment_0 * 16 * 32 + 480 + swizzled_col_2_1;
+                            asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                                : "=r"(*reinterpret_cast<uint32_t*>(&exp_g_words_cg0[0])), "=r"(*reinterpret_cast<uint32_t*>(&exp_g_words_cg0[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&exp_g_words_cg0[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&exp_g_words_cg0[(0) + 3]))
+                                : "r"(smem_g_all_addr + (unsigned int)(exp_g_index_cg0 * 4)));
+                            asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                                : "=r"(*reinterpret_cast<uint32_t*>(&exp_g_last_words_cg0[0])), "=r"(*reinterpret_cast<uint32_t*>(&exp_g_last_words_cg0[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&exp_g_last_words_cg0[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&exp_g_last_words_cg0[(0) + 3]))
+                                : "r"(smem_g_all_addr + (unsigned int)(exp_g_last_index_cg0 * 4)));
+                            #pragma unroll
+                            for (int prefix_word_cg0 = 0; prefix_word_cg0 < 4; prefix_word_cg0++) {
+                                int prefix_reg_cg0 = dim_half_prefix_cg0 * 8 + f32_group_cg0 * 4 + prefix_word_cg0;
+                                exp_g_regs_cg0[prefix_reg_cg0] = __uint_as_float(exp_g_words_cg0[prefix_word_cg0]);
+                                exp_g_last_regs_cg0[prefix_reg_cg0] = __uint_as_float(exp_g_last_words_cg0[prefix_word_cg0]);
+                            }
+                        }
+                    }
+                    __nv_bfloat162 k_inv_pairs_all_cg0[8];
+                    float2 _f2_6 = make_float2(k_inv_norm_cg0, k_inv_norm_cg0);
+                    float2 k_inv_norm_pair_cg0 = _f2_6;
+                    #pragma unroll
+                    for (int dim_half_k_cg0 = 0; dim_half_k_cg0 < 2; dim_half_k_cg0++) {
+                        int dim_base_k_cg0 = dim_half_k_cg0 * 64 + decay_lane_cg0 * 8;
+                        unsigned int k_decay_words_cg0[4];
+                        #pragma unroll
+                        for (int dim_pair_k_cg0 = 0; dim_pair_k_cg0 < 4; dim_pair_k_cg0++) {
+                            int dim_local0_k_cg0 = dim_pair_k_cg0 * 2;
+                            int dim_local1_k_cg0 = dim_local0_k_cg0 + 1;
+                            int reg_k0_cg0 = dim_half_k_cg0 * 8 + dim_local0_k_cg0;
+                            int reg_k1_cg0 = reg_k0_cg0 + 1;
+                            float prefix_k0_cg0 = exp_g_regs_cg0[reg_k0_cg0];
+                            float prefix_k1_cg0 = exp_g_regs_cg0[reg_k1_cg0];
+                            float2 _f2_7 = make_float2(k_values_cg0[reg_k0_cg0], k_values_cg0[reg_k1_cg0]);
+                            float2 k_norm_pair_cg0 = mul_f32x2(_f2_7, k_inv_norm_pair_cg0);
+                            __nv_bfloat162 _bf16x2_0 = __float22bfloat162_rn(make_float2(k_norm_pair_cg0.x, k_norm_pair_cg0.y));
+                            __nv_bfloat162 k_norm_bf16x2_cg0 = _bf16x2_0;
+                            __nv_bfloat162 _bf16x2_1 = __float22bfloat162_rn(make_float2(prefix_k0_cg0, prefix_k1_cg0));
+                            __nv_bfloat162 prefix_bf16x2_cg0 = _bf16x2_1;
+                            float _rcp_0 = approx_rcp(prefix_k0_cg0);
+                            float _rcp_1 = approx_rcp(prefix_k1_cg0);
+                            __nv_bfloat162 _bf16x2_2 = __float22bfloat162_rn(make_float2(_rcp_0, _rcp_1));
+                            __nv_bfloat162 reciprocal_bf16x2_cg0 = _bf16x2_2;
+                            __nv_bfloat162 k_inv_bf16x2_cg0 = k_norm_bf16x2_cg0 * reciprocal_bf16x2_cg0;
+                            __nv_bfloat162 k_decay_bf16x2_cg0 = k_norm_bf16x2_cg0 * prefix_bf16x2_cg0;
+                            int k_word_cg0 = dim_half_k_cg0 * 4 + dim_pair_k_cg0;
+                            k_inv_pairs_all_cg0[k_word_cg0] = k_inv_bf16x2_cg0;
+                            k_decay_words_cg0[dim_pair_k_cg0] = __as_u32(k_decay_bf16x2_cg0);
+                        }
+                        if (dim_half_k_cg0 == 0) {
+                            mbarrier_wait(decay_super_done_addr + (decay_stage_cg0) * 8, decay_free_phase_cg0);
+                            mbarrier_wait(decay_tcgen_done_addr + (decay_stage_cg0) * 8, decay_free_phase_cg0);
+                        }
+                        asm volatile("st.shared.v4.b32 [%0], {%1,%2,%3,%4};" :: "r"((smem_k_inv_addr + (unsigned int)(decay_stage_cg0 * 4096) + (unsigned int)(dim_base_k_cg0 / 64 * 2048 + decay_row_cg0 * 128 + dim_base_k_cg0 % 64 * 2 ^ (dim_base_k_cg0 / 64 * 2048 + decay_row_cg0 * 128 + dim_base_k_cg0 % 64 * 2 >> 7 & 7) << 4))), "r"(__as_u32(k_inv_pairs_all_cg0[dim_half_k_cg0 * 4])), "r"(__as_u32(k_inv_pairs_all_cg0[dim_half_k_cg0 * 4 + 1])), "r"(__as_u32(k_inv_pairs_all_cg0[dim_half_k_cg0 * 4 + 2])), "r"(__as_u32(k_inv_pairs_all_cg0[dim_half_k_cg0 * 4 + 3])) : "memory");
+                        asm volatile("st.shared.v4.b32 [%0], {%1,%2,%3,%4};" :: "r"((smem_k_decay_addr + (unsigned int)(decay_stage_cg0 * 4096) + (unsigned int)(dim_base_k_cg0 / 64 * 2048 + decay_row_cg0 * 128 + dim_base_k_cg0 % 64 * 2 ^ (dim_base_k_cg0 / 64 * 2048 + decay_row_cg0 * 128 + dim_base_k_cg0 % 64 * 2 >> 7 & 7) << 4))), "r"(k_decay_words_cg0[0]), "r"(k_decay_words_cg0[1]), "r"(k_decay_words_cg0[2]), "r"(k_decay_words_cg0[3]) : "memory");
+                    }
+                    asm volatile("fence.proxy.async.shared::cta;" ::: "memory");
+                    mbarrier_arrive(k_decay_inv_ready_addr + (decay_stage_cg0) * 8);
+                    mbarrier_arrive(q_done_addr + (raw_stage_cg0) * 8);
+                    mbarrier_arrive(k_done_addr + (raw_stage_cg0) * 8);
+                    mbarrier_arrive(g_done_addr + (raw_stage_cg0) * 8);
+                    float2 _f2_8 = make_float2(q_inv_norm_cg0, q_inv_norm_cg0);
+                    float2 q_inv_pair_cg0 = _f2_8;
+                    #pragma unroll
+                    for (int dim_half_q_cg0 = 0; dim_half_q_cg0 < 2; dim_half_q_cg0++) {
+                        int dim_base_q_cg0 = dim_half_q_cg0 * 64 + decay_lane_cg0 * 8;
+                        unsigned int q_decay_words_cg0[4];
+                        #pragma unroll
+                        for (int dim_pair_q_cg0 = 0; dim_pair_q_cg0 < 4; dim_pair_q_cg0++) {
+                            int dim_local0_q_cg0 = dim_pair_q_cg0 * 2;
+                            int dim_local1_q_cg0 = dim_local0_q_cg0 + 1;
+                            int reg_q0_cg0 = dim_half_q_cg0 * 8 + dim_local0_q_cg0;
+                            int reg_q1_cg0 = reg_q0_cg0 + 1;
+                            float2 _f2_9 = make_float2(q_values_cg0[reg_q0_cg0], q_values_cg0[reg_q1_cg0]);
+                            float2 q_norm_pair_cg0 = mul_f32x2(_f2_9, q_inv_pair_cg0);
+                            __nv_bfloat162 _bf16x2_3 = __float22bfloat162_rn(make_float2(q_norm_pair_cg0.x, q_norm_pair_cg0.y));
+                            __nv_bfloat162 q_norm_bf16x2_cg0 = _bf16x2_3;
+                            __nv_bfloat162 _bf16x2_4 = __float22bfloat162_rn(make_float2(exp_g_regs_cg0[reg_q0_cg0], exp_g_regs_cg0[reg_q1_cg0]));
+                            __nv_bfloat162 q_prefix_bf16x2_cg0 = _bf16x2_4;
+                            __nv_bfloat162 q_decay_bf16x2_cg0 = q_norm_bf16x2_cg0 * q_prefix_bf16x2_cg0;
+                            q_decay_words_cg0[dim_pair_q_cg0] = __as_u32(q_decay_bf16x2_cg0);
+                        }
+                        asm volatile("st.shared.v4.b32 [%0], {%1,%2,%3,%4};" :: "r"((smem_q_decay_addr + (unsigned int)(decay_stage_cg0 * 4096) + (unsigned int)(dim_base_q_cg0 / 64 * 2048 + decay_row_cg0 * 128 + dim_base_q_cg0 % 64 * 2 ^ (dim_base_q_cg0 / 64 * 2048 + decay_row_cg0 * 128 + dim_base_q_cg0 % 64 * 2 >> 7 & 7) << 4))), "r"(q_decay_words_cg0[0]), "r"(q_decay_words_cg0[1]), "r"(q_decay_words_cg0[2]), "r"(q_decay_words_cg0[3]) : "memory");
+                    }
+                    mbarrier_wait(k_restore_done_addr + (decay_stage_cg0) * 8, decay_free_phase_cg0);
+                    #pragma unroll
+                    for (int dim_half_restore_cg0 = 0; dim_half_restore_cg0 < 2; dim_half_restore_cg0++) {
+                        int dim_base_restore_cg0 = dim_half_restore_cg0 * 64 + decay_lane_cg0 * 8;
+                        unsigned int k_restore_words_cg0[4];
+                        #pragma unroll
+                        for (int dim_pair_restore_cg0 = 0; dim_pair_restore_cg0 < 4; dim_pair_restore_cg0++) {
+                            int dim_local0_restore_cg0 = dim_pair_restore_cg0 * 2;
+                            int dim_local1_restore_cg0 = dim_local0_restore_cg0 + 1;
+                            int reg_restore0_cg0 = dim_half_restore_cg0 * 8 + dim_local0_restore_cg0;
+                            int reg_restore1_cg0 = reg_restore0_cg0 + 1;
+                            int restore_word_cg0 = dim_half_restore_cg0 * 4 + dim_pair_restore_cg0;
+                            __nv_bfloat162 _bf16x2_5 = __float22bfloat162_rn(make_float2(exp_g_last_regs_cg0[reg_restore0_cg0], exp_g_last_regs_cg0[reg_restore1_cg0]));
+                            __nv_bfloat162 k_restore_bf16x2_cg0 = k_inv_pairs_all_cg0[restore_word_cg0] * _bf16x2_5;
+                            k_restore_words_cg0[dim_pair_restore_cg0] = __as_u32(k_restore_bf16x2_cg0);
+                        }
+                        asm volatile("st.shared.v4.b32 [%0], {%1,%2,%3,%4};" :: "r"((smem_k_restore_addr + (unsigned int)(decay_stage_cg0 * 4096) + (unsigned int)(dim_base_restore_cg0 / 64 * 2048 + decay_row_cg0 * 128 + dim_base_restore_cg0 % 64 * 2 ^ (dim_base_restore_cg0 / 64 * 2048 + decay_row_cg0 * 128 + dim_base_restore_cg0 % 64 * 2 >> 7 & 7) << 4))), "r"(k_restore_words_cg0[0]), "r"(k_restore_words_cg0[1]), "r"(k_restore_words_cg0[2]), "r"(k_restore_words_cg0[3]) : "memory");
+                    }
+                    asm volatile("fence.proxy.async.shared::cta;" ::: "memory");
+                    mbarrier_arrive(qk_scale_ready_addr + (diag_stage_cg0) * 8);
+                    raw_stage_cg0 += 2;
+                    if (raw_stage_cg0 >= 5) {
+                        raw_stage_cg0 -= 5;
+                    }
+                    raw_bar_stage_cg0 += 2;
+                    if (raw_bar_stage_cg0 >= 6) {
+                        raw_bar_stage_cg0 -= 6;
+                        raw_bar_phase_cg0 ^= 1;
+                    }
+                    decay_free_phase_cg0 ^= 1;
+                    diag_stage_cg0 += 2;
+                    if (diag_stage_cg0 >= 4) {
+                        diag_stage_cg0 -= 4;
+                        diag_free_phase_cg0 ^= 1;
+                    }
+                }
+                cumulative_chunk_cg0 += chunks_cg0;
+            }
+            if (elect_sync()) {
+                mbarrier_arrive(consumers_done_addr);
+            }
+        }
+    }
+    // ---- Role: cg1 ----
+    if (warp >= 8 && warp <= 11) {
+        asm volatile("setmaxnreg.inc.sync.aligned.u32 136;");
+        { // cg1_main
+            unsigned int sched_stage_cg1 = 0;
+            int cumulative_chunk_cg1 = 0;
+            int warp_in_wg = warp % 4;
+            int value_row_cg1 = warp_in_wg * 32 + lane;
+            int value_dim_base_cg1 = warp_in_wg * 32;
+            const int tmem_row_base_cg1 = warp_in_wg * 32 << 16;
+            int ov_token_cg1 = lane / 16 * 8 + (lane & 7);
+            int ov_col_cg1 = (lane / 8 & 1) * 8;
+            unsigned int _phase_sched_ready_1 = 0;
+            #pragma unroll 1
+            for (int __1 = 0; __1 < total_work_items + 1; __1++) {
+                mbarrier_wait(sched_ready_addr + (sched_stage_cg1) * 8, _phase_sched_ready_1);
+                unsigned int slot_1[1];
+                asm volatile("ld.shared.b32 %0, [%1];" : "=r"(*reinterpret_cast<uint32_t*>(&slot_1[0])) : "r"(sched_slot_addr + sched_stage_cg1 * 4));
+                unsigned int tile_cg1 = slot_1[0];
+                if (elect_sync()) {
+                    mbarrier_arrive(sched_done_addr + (sched_stage_cg1) * 8);
+                }
+                sched_stage_cg1 += 1;
+                if (sched_stage_cg1 == 8) { sched_stage_cg1 = 0; _phase_sched_ready_1 ^= 1; }
+                if (tile_cg1 >= (unsigned int)total_work_items) {
+                    break;
+                }
+                int item_base_cg1 = (int)tile_cg1 * 8;
+                int _vec_load_4[4];
+                {
+                    int4 _iv4 = *reinterpret_cast<const int4*>(work_items + item_base_cg1);
+                    _vec_load_4[0 + 0] = _iv4.x;
+                    _vec_load_4[0 + 1] = _iv4.y;
+                    _vec_load_4[0 + 2] = _iv4.z;
+                    _vec_load_4[0 + 3] = _iv4.w;
+                }
+                int _vec_load_5[4];
+                {
+                    int4 _iv4 = *reinterpret_cast<const int4*>(work_items + item_base_cg1 + 4);
+                    _vec_load_5[0 + 0] = _iv4.x;
+                    _vec_load_5[0 + 1] = _iv4.y;
+                    _vec_load_5[0 + 2] = _iv4.z;
+                    _vec_load_5[0 + 3] = _iv4.w;
+                }
+                int seq_cg1 = _vec_load_4[0];
+                int head_cg1 = _vec_load_4[1];
+                int wstart_cg1 = _vec_load_4[2];
+                int wend_cg1 = _vec_load_4[3];
+                int cstart_cg1 = _vec_load_5[0];
+                int chunks_cg1 = wend_cg1 - cstart_cg1;
+                long long state_base_cg1 = (((long long)seq_cg1 * (long long)num_heads + (long long)head_cg1) * 128 + (long long)value_row_cg1) * 128;
+                #pragma unroll
+                for (int state_block_cg1 = 0; state_block_cg1 < 4; state_block_cg1++) {
+                    float state_init_cg1[32];
+                    state_init_cg1[0] = 0.0f;
+                    state_init_cg1[1] = 0.0f;
+                    state_init_cg1[2] = 0.0f;
+                    state_init_cg1[3] = 0.0f;
+                    state_init_cg1[4] = 0.0f;
+                    state_init_cg1[5] = 0.0f;
+                    state_init_cg1[6] = 0.0f;
+                    state_init_cg1[7] = 0.0f;
+                    state_init_cg1[8] = 0.0f;
+                    state_init_cg1[9] = 0.0f;
+                    state_init_cg1[10] = 0.0f;
+                    state_init_cg1[11] = 0.0f;
+                    state_init_cg1[12] = 0.0f;
+                    state_init_cg1[13] = 0.0f;
+                    state_init_cg1[14] = 0.0f;
+                    state_init_cg1[15] = 0.0f;
+                    state_init_cg1[16] = 0.0f;
+                    state_init_cg1[17] = 0.0f;
+                    state_init_cg1[18] = 0.0f;
+                    state_init_cg1[19] = 0.0f;
+                    state_init_cg1[20] = 0.0f;
+                    state_init_cg1[21] = 0.0f;
+                    state_init_cg1[22] = 0.0f;
+                    state_init_cg1[23] = 0.0f;
+                    state_init_cg1[24] = 0.0f;
+                    state_init_cg1[25] = 0.0f;
+                    state_init_cg1[26] = 0.0f;
+                    state_init_cg1[27] = 0.0f;
+                    state_init_cg1[28] = 0.0f;
+                    state_init_cg1[29] = 0.0f;
+                    state_init_cg1[30] = 0.0f;
+                    state_init_cg1[31] = 0.0f;
+                    if (USE_INITIAL_STATE != 0 && cstart_cg1 == 0) {
+                        #pragma unroll
+                        for (int state_vec_cg1 = 0; state_vec_cg1 < 4; state_vec_cg1++) {
+                            {
+                                unsigned _ldv8_0_0;
+                                unsigned _ldv8_0_1;
+                                unsigned _ldv8_0_2;
+                                unsigned _ldv8_0_3;
+                                unsigned _ldv8_0_4;
+                                unsigned _ldv8_0_5;
+                                unsigned _ldv8_0_6;
+                                unsigned _ldv8_0_7;
+                                asm volatile(
+                                    "ld.global.v8.b32 {%0, %1, %2, %3, %4, %5, %6, %7}, [%8];"
+                                    : "=r"(_ldv8_0_0), "=r"(_ldv8_0_1), "=r"(_ldv8_0_2), "=r"(_ldv8_0_3), "=r"(_ldv8_0_4), "=r"(_ldv8_0_5), "=r"(_ldv8_0_6), "=r"(_ldv8_0_7) : "l"((const void*)(initial_state + (state_base_cg1 + (long long)(state_block_cg1 * 32) + (long long)(state_vec_cg1 * 8)))) : "memory");
+                                state_init_cg1[state_vec_cg1 * 8 + 0] = __uint_as_float(_ldv8_0_0);
+                                state_init_cg1[state_vec_cg1 * 8 + 1] = __uint_as_float(_ldv8_0_1);
+                                state_init_cg1[state_vec_cg1 * 8 + 2] = __uint_as_float(_ldv8_0_2);
+                                state_init_cg1[state_vec_cg1 * 8 + 3] = __uint_as_float(_ldv8_0_3);
+                                state_init_cg1[state_vec_cg1 * 8 + 4] = __uint_as_float(_ldv8_0_4);
+                                state_init_cg1[state_vec_cg1 * 8 + 5] = __uint_as_float(_ldv8_0_5);
+                                state_init_cg1[state_vec_cg1 * 8 + 6] = __uint_as_float(_ldv8_0_6);
+                                state_init_cg1[state_vec_cg1 * 8 + 7] = __uint_as_float(_ldv8_0_7);
+                            }
+                        }
+                        #pragma unroll
+                        for (int state_elem_cg1 = 0; state_elem_cg1 < 32; state_elem_cg1++) {
+                            __nv_bfloat16 _cvt_bf16_1 = __float2bfloat16(state_init_cg1[state_elem_cg1]);
+                            float _cvt_f32_2 = __bfloat162float(_cvt_bf16_1);
+                            state_init_cg1[state_elem_cg1] = _cvt_f32_2;
+                        }
+                    }
+                    tmem_st_x32_f32(taddr + (unsigned int)tmem_row_base_cg1 + (unsigned int)(state_block_cg1 * 32), state_init_cg1);
+                }
+                asm volatile("tcgen05.wait::st.sync.aligned;" ::: "memory");
+                if (chunks_cg1 > 0) {
+                    int cumulative_cg1 = cumulative_chunk_cg1;
+                    unsigned int raw_stage_cg1 = (unsigned int)(cumulative_cg1 % 5);
+                    unsigned int raw_bar_stage_cg1 = (unsigned int)(cumulative_cg1 % 6);
+                    unsigned int o_stage_cg1 = (unsigned int)(cumulative_cg1 % 2);
+                    unsigned int checkpoint_stage_cg1 = (unsigned int)(cumulative_cg1 % 2);
+                    unsigned int state_phase_cg1 = (unsigned int)(cumulative_cg1 & 1);
+                    float _tmem_load_0[128];
+                    tmem_ld_x16(&_tmem_load_0[0], taddr + (unsigned int)tmem_row_base_cg1);
+                    tmem_ld_x16(&_tmem_load_0[16], taddr + (unsigned int)tmem_row_base_cg1 + 16);
+                    tmem_ld_x16(&_tmem_load_0[32], taddr + (unsigned int)tmem_row_base_cg1 + 32);
+                    tmem_ld_x16(&_tmem_load_0[48], taddr + (unsigned int)tmem_row_base_cg1 + 48);
+                    tmem_ld_x16(&_tmem_load_0[64], taddr + (unsigned int)tmem_row_base_cg1 + 64);
+                    tmem_ld_x16(&_tmem_load_0[80], taddr + (unsigned int)tmem_row_base_cg1 + 80);
+                    tmem_ld_x16(&_tmem_load_0[96], taddr + (unsigned int)tmem_row_base_cg1 + 96);
+                    tmem_ld_x16(&_tmem_load_0[112], taddr + (unsigned int)tmem_row_base_cg1 + 112);
+                    asm volatile("tcgen05.wait::ld.sync.aligned;" ::: "memory");
+                    {
+                        mbarrier_wait(checkpoint_done_addr + (checkpoint_stage_cg1) * 8, (unsigned int)(cumulative_cg1 / 2 + 1 & 1));
+                    }
+                    unsigned int state_words_cg1[8];
+                    #pragma unroll
+                    for (int _lp = 0; _lp < 8; _lp++) {
+                        __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(_tmem_load_0[_lp*2 + 0], _tmem_load_0[_lp*2+1 + 0]));
+                        state_words_cg1[_lp] = *(uint32_t*)&_bf2;
+                    }
+                    tmem_st_x8_u32(taddr + 128 + (unsigned int)tmem_row_base_cg1, (const uint32_t*)state_words_cg1);
+                    {
+                        asm volatile("st.shared.v4.b32 [%0], {%1,%2,%3,%4};" :: "r"((smem_checkpoint_addr + checkpoint_stage_cg1 * 32768 + (unsigned int)(value_row_cg1 * 128 ^ (value_row_cg1 * 128 >> 7 & 7) << 4))), "r"(state_words_cg1[0]), "r"(state_words_cg1[1]), "r"(state_words_cg1[2]), "r"(state_words_cg1[3]) : "memory");
+                        asm volatile("st.shared.v4.b32 [%0], {%1,%2,%3,%4};" :: "r"((smem_checkpoint_addr + checkpoint_stage_cg1 * 32768 + (unsigned int)(value_row_cg1 * 128 + 16 ^ (value_row_cg1 * 128 + 16 >> 7 & 7) << 4))), "r"(state_words_cg1[4]), "r"(state_words_cg1[5]), "r"(state_words_cg1[6]), "r"(state_words_cg1[7]) : "memory");
+                    }
+                    #pragma unroll
+                    for (int _lp = 0; _lp < 8; _lp++) {
+                        __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(_tmem_load_0[_lp*2 + 16], _tmem_load_0[_lp*2+1 + 16]));
+                        state_words_cg1[_lp] = *(uint32_t*)&_bf2;
+                    }
+                    tmem_st_x8_u32(taddr + 128 + (unsigned int)tmem_row_base_cg1 + 8, (const uint32_t*)state_words_cg1);
+                    {
+                        asm volatile("st.shared.v4.b32 [%0], {%1,%2,%3,%4};" :: "r"((smem_checkpoint_addr + checkpoint_stage_cg1 * 32768 + (unsigned int)(value_row_cg1 * 128 + 32 ^ (value_row_cg1 * 128 + 32 >> 7 & 7) << 4))), "r"(state_words_cg1[0]), "r"(state_words_cg1[1]), "r"(state_words_cg1[2]), "r"(state_words_cg1[3]) : "memory");
+                        asm volatile("st.shared.v4.b32 [%0], {%1,%2,%3,%4};" :: "r"((smem_checkpoint_addr + checkpoint_stage_cg1 * 32768 + (unsigned int)(value_row_cg1 * 128 + 48 ^ (value_row_cg1 * 128 + 48 >> 7 & 7) << 4))), "r"(state_words_cg1[4]), "r"(state_words_cg1[5]), "r"(state_words_cg1[6]), "r"(state_words_cg1[7]) : "memory");
+                    }
+                    #pragma unroll
+                    for (int _lp = 0; _lp < 8; _lp++) {
+                        __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(_tmem_load_0[_lp*2 + 32], _tmem_load_0[_lp*2+1 + 32]));
+                        state_words_cg1[_lp] = *(uint32_t*)&_bf2;
+                    }
+                    tmem_st_x8_u32(taddr + 128 + (unsigned int)tmem_row_base_cg1 + 16, (const uint32_t*)state_words_cg1);
+                    {
+                        asm volatile("st.shared.v4.b32 [%0], {%1,%2,%3,%4};" :: "r"((smem_checkpoint_addr + checkpoint_stage_cg1 * 32768 + (unsigned int)(value_row_cg1 * 128 + 64 ^ (value_row_cg1 * 128 + 64 >> 7 & 7) << 4))), "r"(state_words_cg1[0]), "r"(state_words_cg1[1]), "r"(state_words_cg1[2]), "r"(state_words_cg1[3]) : "memory");
+                        asm volatile("st.shared.v4.b32 [%0], {%1,%2,%3,%4};" :: "r"((smem_checkpoint_addr + checkpoint_stage_cg1 * 32768 + (unsigned int)(value_row_cg1 * 128 + 80 ^ (value_row_cg1 * 128 + 80 >> 7 & 7) << 4))), "r"(state_words_cg1[4]), "r"(state_words_cg1[5]), "r"(state_words_cg1[6]), "r"(state_words_cg1[7]) : "memory");
+                    }
+                    #pragma unroll
+                    for (int _lp = 0; _lp < 8; _lp++) {
+                        __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(_tmem_load_0[_lp*2 + 48], _tmem_load_0[_lp*2+1 + 48]));
+                        state_words_cg1[_lp] = *(uint32_t*)&_bf2;
+                    }
+                    tmem_st_x8_u32(taddr + 128 + (unsigned int)tmem_row_base_cg1 + 24, (const uint32_t*)state_words_cg1);
+                    {
+                        asm volatile("st.shared.v4.b32 [%0], {%1,%2,%3,%4};" :: "r"((smem_checkpoint_addr + checkpoint_stage_cg1 * 32768 + (unsigned int)(value_row_cg1 * 128 + 96 ^ (value_row_cg1 * 128 + 96 >> 7 & 7) << 4))), "r"(state_words_cg1[0]), "r"(state_words_cg1[1]), "r"(state_words_cg1[2]), "r"(state_words_cg1[3]) : "memory");
+                        asm volatile("st.shared.v4.b32 [%0], {%1,%2,%3,%4};" :: "r"((smem_checkpoint_addr + checkpoint_stage_cg1 * 32768 + (unsigned int)(value_row_cg1 * 128 + 112 ^ (value_row_cg1 * 128 + 112 >> 7 & 7) << 4))), "r"(state_words_cg1[4]), "r"(state_words_cg1[5]), "r"(state_words_cg1[6]), "r"(state_words_cg1[7]) : "memory");
+                    }
+                    #pragma unroll
+                    for (int _lp = 0; _lp < 8; _lp++) {
+                        __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(_tmem_load_0[_lp*2 + 64], _tmem_load_0[_lp*2+1 + 64]));
+                        state_words_cg1[_lp] = *(uint32_t*)&_bf2;
+                    }
+                    tmem_st_x8_u32(taddr + 128 + (unsigned int)tmem_row_base_cg1 + 32, (const uint32_t*)state_words_cg1);
+                    {
+                        asm volatile("st.shared.v4.b32 [%0], {%1,%2,%3,%4};" :: "r"((smem_checkpoint_addr + checkpoint_stage_cg1 * 32768 + (unsigned int)(16384 + value_row_cg1 * 128 ^ (16384 + value_row_cg1 * 128 >> 7 & 7) << 4))), "r"(state_words_cg1[0]), "r"(state_words_cg1[1]), "r"(state_words_cg1[2]), "r"(state_words_cg1[3]) : "memory");
+                        asm volatile("st.shared.v4.b32 [%0], {%1,%2,%3,%4};" :: "r"((smem_checkpoint_addr + checkpoint_stage_cg1 * 32768 + (unsigned int)(16384 + value_row_cg1 * 128 + 16 ^ (16384 + value_row_cg1 * 128 + 16 >> 7 & 7) << 4))), "r"(state_words_cg1[4]), "r"(state_words_cg1[5]), "r"(state_words_cg1[6]), "r"(state_words_cg1[7]) : "memory");
+                    }
+                    #pragma unroll
+                    for (int _lp = 0; _lp < 8; _lp++) {
+                        __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(_tmem_load_0[_lp*2 + 80], _tmem_load_0[_lp*2+1 + 80]));
+                        state_words_cg1[_lp] = *(uint32_t*)&_bf2;
+                    }
+                    tmem_st_x8_u32(taddr + 128 + (unsigned int)tmem_row_base_cg1 + 40, (const uint32_t*)state_words_cg1);
+                    {
+                        asm volatile("st.shared.v4.b32 [%0], {%1,%2,%3,%4};" :: "r"((smem_checkpoint_addr + checkpoint_stage_cg1 * 32768 + (unsigned int)(16384 + value_row_cg1 * 128 + 32 ^ (16384 + value_row_cg1 * 128 + 32 >> 7 & 7) << 4))), "r"(state_words_cg1[0]), "r"(state_words_cg1[1]), "r"(state_words_cg1[2]), "r"(state_words_cg1[3]) : "memory");
+                        asm volatile("st.shared.v4.b32 [%0], {%1,%2,%3,%4};" :: "r"((smem_checkpoint_addr + checkpoint_stage_cg1 * 32768 + (unsigned int)(16384 + value_row_cg1 * 128 + 48 ^ (16384 + value_row_cg1 * 128 + 48 >> 7 & 7) << 4))), "r"(state_words_cg1[4]), "r"(state_words_cg1[5]), "r"(state_words_cg1[6]), "r"(state_words_cg1[7]) : "memory");
+                    }
+                    #pragma unroll
+                    for (int _lp = 0; _lp < 8; _lp++) {
+                        __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(_tmem_load_0[_lp*2 + 96], _tmem_load_0[_lp*2+1 + 96]));
+                        state_words_cg1[_lp] = *(uint32_t*)&_bf2;
+                    }
+                    tmem_st_x8_u32(taddr + 128 + (unsigned int)tmem_row_base_cg1 + 48, (const uint32_t*)state_words_cg1);
+                    {
+                        asm volatile("st.shared.v4.b32 [%0], {%1,%2,%3,%4};" :: "r"((smem_checkpoint_addr + checkpoint_stage_cg1 * 32768 + (unsigned int)(16384 + value_row_cg1 * 128 + 64 ^ (16384 + value_row_cg1 * 128 + 64 >> 7 & 7) << 4))), "r"(state_words_cg1[0]), "r"(state_words_cg1[1]), "r"(state_words_cg1[2]), "r"(state_words_cg1[3]) : "memory");
+                        asm volatile("st.shared.v4.b32 [%0], {%1,%2,%3,%4};" :: "r"((smem_checkpoint_addr + checkpoint_stage_cg1 * 32768 + (unsigned int)(16384 + value_row_cg1 * 128 + 80 ^ (16384 + value_row_cg1 * 128 + 80 >> 7 & 7) << 4))), "r"(state_words_cg1[4]), "r"(state_words_cg1[5]), "r"(state_words_cg1[6]), "r"(state_words_cg1[7]) : "memory");
+                    }
+                    #pragma unroll
+                    for (int _lp = 0; _lp < 8; _lp++) {
+                        __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(_tmem_load_0[_lp*2 + 112], _tmem_load_0[_lp*2+1 + 112]));
+                        state_words_cg1[_lp] = *(uint32_t*)&_bf2;
+                    }
+                    tmem_st_x8_u32(taddr + 128 + (unsigned int)tmem_row_base_cg1 + 56, (const uint32_t*)state_words_cg1);
+                    {
+                        asm volatile("st.shared.v4.b32 [%0], {%1,%2,%3,%4};" :: "r"((smem_checkpoint_addr + checkpoint_stage_cg1 * 32768 + (unsigned int)(16384 + value_row_cg1 * 128 + 96 ^ (16384 + value_row_cg1 * 128 + 96 >> 7 & 7) << 4))), "r"(state_words_cg1[0]), "r"(state_words_cg1[1]), "r"(state_words_cg1[2]), "r"(state_words_cg1[3]) : "memory");
+                        asm volatile("st.shared.v4.b32 [%0], {%1,%2,%3,%4};" :: "r"((smem_checkpoint_addr + checkpoint_stage_cg1 * 32768 + (unsigned int)(16384 + value_row_cg1 * 128 + 112 ^ (16384 + value_row_cg1 * 128 + 112 >> 7 & 7) << 4))), "r"(state_words_cg1[4]), "r"(state_words_cg1[5]), "r"(state_words_cg1[6]), "r"(state_words_cg1[7]) : "memory");
+                    }
+                    asm volatile("tcgen05.wait::st.sync.aligned;" ::: "memory");
+                    mbarrier_arrive(state_inp_ready_addr);
+                    {
+                        asm volatile("fence.proxy.async.shared::cta;" ::: "memory");
+                        mbarrier_arrive(state_read_done_addr);
+                        mbarrier_arrive(checkpoint_ready_addr + (checkpoint_stage_cg1) * 8);
+                    }
+                    mbarrier_wait(v_ready_addr + (raw_bar_stage_cg1) * 8, (unsigned int)(cumulative_cg1 / 6 & 1));
+                    mbarrier_wait(beta_ready_addr + (raw_bar_stage_cg1) * 8, (unsigned int)(cumulative_cg1 / 6 & 1));
+                    mbarrier_wait(state_k_ready_addr, state_phase_cg1);
+                    float _tmem_load_3[8];
+                    asm volatile(
+                        "tcgen05.ld.sync.aligned.16x256b.x2.b32"
+                        " {%0, %1, %2, %3, %4, %5, %6, %7}, [%8];"
+                        : "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[0])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[1])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[2])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[3])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[4])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[5])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[6])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[7]))
+                        : "r"(taddr + 224 + (unsigned int)tmem_row_base_cg1)
+                        : "memory");
+                    float _tmem_load_4[8];
+                    asm volatile(
+                        "tcgen05.ld.sync.aligned.16x256b.x2.b32"
+                        " {%0, %1, %2, %3, %4, %5, %6, %7}, [%8];"
+                        : "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_4[0])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_4[1])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_4[2])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_4[3])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_4[4])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_4[5])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_4[6])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_4[7]))
+                        : "r"(taddr + 224 + (unsigned int)tmem_row_base_cg1 + 1048576)
+                        : "memory");
+                    unsigned int raw_v_words_lo_cg1[4];
+                    unsigned int raw_v_words_hi_cg1[4];
+                    int segment_3 = (value_dim_base_cg1 + ov_col_cg1) / 64;
+                    int segment_col_3 = value_dim_base_cg1 + ov_col_cg1 - segment_3 * 64;
+                    int swizzled_col_3 = segment_col_3 ^ (ov_token_cg1 & 7) * 8;
+                    asm volatile("ldmatrix.sync.aligned.m8n8.x4.trans.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                        : "=r"(raw_v_words_lo_cg1[0]), "=r"(raw_v_words_lo_cg1[1]), "=r"(raw_v_words_lo_cg1[2]), "=r"(raw_v_words_lo_cg1[3])
+                        : "r"(smem_v_all_addr + (raw_stage_cg1 * 16 * 128 + (unsigned int)(segment_3 * 16 * 64) + (unsigned int)(ov_token_cg1 * 64) + (unsigned int)swizzled_col_3) * 2)
+                        : "memory");
+                    int segment_0_1 = (value_dim_base_cg1 + 16 + ov_col_cg1) / 64;
+                    int segment_col_1_2 = value_dim_base_cg1 + 16 + ov_col_cg1 - segment_0_1 * 64;
+                    int swizzled_col_2_2 = segment_col_1_2 ^ (ov_token_cg1 & 7) * 8;
+                    asm volatile("ldmatrix.sync.aligned.m8n8.x4.trans.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                        : "=r"(raw_v_words_hi_cg1[0]), "=r"(raw_v_words_hi_cg1[1]), "=r"(raw_v_words_hi_cg1[2]), "=r"(raw_v_words_hi_cg1[3])
+                        : "r"(smem_v_all_addr + (raw_stage_cg1 * 16 * 128 + (unsigned int)(segment_0_1 * 16 * 64) + (unsigned int)(ov_token_cg1 * 64) + (unsigned int)swizzled_col_2_2) * 2)
+                        : "memory");
+                    asm volatile("tcgen05.wait::ld.sync.aligned;" ::: "memory");
+                    __nv_bfloat162 beta_pairs_cg1[4];
+                    #pragma unroll
+                    for (int beta_reg_cg1 = 0; beta_reg_cg1 < 4; beta_reg_cg1++) {
+                        int beta_packed_col_cg1 = beta_reg_cg1 / 2 * 4 + (lane & 3);
+                        int beta_token0_cg1 = beta_packed_col_cg1 * 2;
+                        int beta_token1_cg1 = beta_token0_cg1 + 1;
+                        __nv_bfloat16 beta0_cg1 = smem_beta_all[(int)raw_bar_stage_cg1 * 16 + beta_token0_cg1];
+                        __nv_bfloat16 beta1_cg1 = smem_beta_all[(int)raw_bar_stage_cg1 * 16 + beta_token1_cg1];
+                        float _cvt_f32_3 = __bfloat162float(beta0_cg1);
+                        float _cvt_f32_4 = __bfloat162float(beta1_cg1);
+                        __nv_bfloat162 _bf16x2_6 = __float22bfloat162_rn(make_float2(_cvt_f32_3, _cvt_f32_4));
+                        beta_pairs_cg1[beta_reg_cg1] = _bf16x2_6;
+                    }
+                    unsigned int y_words_lo_cg1[4];
+                    unsigned int y_words_hi_cg1[4];
+                    #pragma unroll
+                    for (int rhs_reg_cg1 = 0; rhs_reg_cg1 < 4; rhs_reg_cg1++) {
+                        int rhs_raw_matrix_cg1 = rhs_reg_cg1;
+                        int rhs_frag_pair_cg1 = rhs_reg_cg1 * 2;
+                        __nv_bfloat162 _bf16x2_7 = __float22bfloat162_rn(make_float2(_tmem_load_3[rhs_frag_pair_cg1], _tmem_load_3[rhs_frag_pair_cg1 + 1]));
+                        __nv_bfloat162 _bf16x2_8 = __float22bfloat162_rn(make_float2(_tmem_load_4[rhs_frag_pair_cg1], _tmem_load_4[rhs_frag_pair_cg1 + 1]));
+                        uint32_t _bf16x2_sub_0;
+                        asm volatile("sub.rn.bf16x2 %0, %1, %2;" : "=r"(_bf16x2_sub_0) : "r"(raw_v_words_lo_cg1[rhs_raw_matrix_cg1]), "r"(__as_u32(_bf16x2_7)));
+                        uint32_t _bf16x2_sub_1;
+                        asm volatile("sub.rn.bf16x2 %0, %1, %2;" : "=r"(_bf16x2_sub_1) : "r"(raw_v_words_hi_cg1[rhs_raw_matrix_cg1]), "r"(__as_u32(_bf16x2_8)));
+                        __nv_bfloat162 rhs_diff_pair_lo_cg1 = __as_bf16x2(_bf16x2_sub_0);
+                        __nv_bfloat162 rhs_diff_pair_hi_cg1 = __as_bf16x2(_bf16x2_sub_1);
+                        __nv_bfloat162 y_pair_lo_cg1 = beta_pairs_cg1[rhs_reg_cg1] * rhs_diff_pair_lo_cg1;
+                        __nv_bfloat162 y_pair_hi_cg1 = beta_pairs_cg1[rhs_reg_cg1] * rhs_diff_pair_hi_cg1;
+                        y_words_lo_cg1[rhs_reg_cg1] = __as_u32(y_pair_lo_cg1);
+                        y_words_hi_cg1[rhs_reg_cg1] = __as_u32(y_pair_hi_cg1);
+                    }
+                    asm volatile(
+                        "tcgen05.st.sync.aligned.16x128b.x2.b32"
+                        " [%0], {%1, %2, %3, %4};"
+                        :: "r"(taddr + 256 + (unsigned int)tmem_row_base_cg1), "r"(*reinterpret_cast<const uint32_t*>(&y_words_lo_cg1[0])), "r"(*reinterpret_cast<const uint32_t*>(&y_words_lo_cg1[1])), "r"(*reinterpret_cast<const uint32_t*>(&y_words_lo_cg1[2])), "r"(*reinterpret_cast<const uint32_t*>(&y_words_lo_cg1[3]))
+                        : "memory");
+                    asm volatile(
+                        "tcgen05.st.sync.aligned.16x128b.x2.b32"
+                        " [%0], {%1, %2, %3, %4};"
+                        :: "r"(taddr + 256 + (unsigned int)tmem_row_base_cg1 + 1048576), "r"(*reinterpret_cast<const uint32_t*>(&y_words_hi_cg1[0])), "r"(*reinterpret_cast<const uint32_t*>(&y_words_hi_cg1[1])), "r"(*reinterpret_cast<const uint32_t*>(&y_words_hi_cg1[2])), "r"(*reinterpret_cast<const uint32_t*>(&y_words_hi_cg1[3]))
+                        : "memory");
+                    asm volatile("tcgen05.wait::st.sync.aligned;" ::: "memory");
+                    mbarrier_arrive(v_done_addr + (raw_stage_cg1) * 8);
+                    mbarrier_arrive(beta_done_addr + (raw_bar_stage_cg1) * 8);
+                    mbarrier_arrive(y_inp_ready_addr);
+                    mbarrier_wait(u_acc_ready_addr, state_phase_cg1);
+                    float _tmem_load_5[16];
+                    tmem_ld_x16(&_tmem_load_5[0], taddr + 240 + (unsigned int)tmem_row_base_cg1);
+                    asm volatile("tcgen05.wait::ld.sync.aligned;" ::: "memory");
+                    unsigned int u_words_cg1[8];
+                    #pragma unroll
+                    for (int _lp = 0; _lp < 8; _lp++) {
+                        __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(_tmem_load_5[_lp*2 + 0], _tmem_load_5[_lp*2+1 + 0]));
+                        u_words_cg1[_lp] = *(uint32_t*)&_bf2;
+                    }
+                    tmem_st_x8_u32(taddr + 264 + (unsigned int)tmem_row_base_cg1, (const uint32_t*)u_words_cg1);
+                    asm volatile("tcgen05.wait::st.sync.aligned;" ::: "memory");
+                    mbarrier_arrive(u_inp_ready_addr);
+                }
+                #pragma unroll 1
+                for (int chunk_cg1 = 1; chunk_cg1 < chunks_cg1; chunk_cg1++) {
+                    int cumulative_cg1_1 = cumulative_chunk_cg1 + chunk_cg1;
+                    unsigned int raw_stage_cg1_1 = (unsigned int)(cumulative_cg1_1 % 5);
+                    unsigned int raw_bar_stage_cg1_1 = (unsigned int)(cumulative_cg1_1 % 6);
+                    unsigned int o_stage_cg1_1 = (unsigned int)(cumulative_cg1_1 % 2);
+                    unsigned int checkpoint_stage_cg1_1 = (unsigned int)(cumulative_cg1_1 % 2);
+                    unsigned int state_phase_cg1_1 = (unsigned int)(cumulative_cg1_1 & 1);
+                    {
+                        mbarrier_wait(state_acc_done_addr, (unsigned int)(cumulative_cg1_1 - 1 & 1));
+                    }
+                    float _tmem_load_6[128];
+                    tmem_ld_x16(&_tmem_load_6[0], taddr + (unsigned int)tmem_row_base_cg1);
+                    tmem_ld_x16(&_tmem_load_6[16], taddr + (unsigned int)tmem_row_base_cg1 + 16);
+                    tmem_ld_x16(&_tmem_load_6[32], taddr + (unsigned int)tmem_row_base_cg1 + 32);
+                    tmem_ld_x16(&_tmem_load_6[48], taddr + (unsigned int)tmem_row_base_cg1 + 48);
+                    tmem_ld_x16(&_tmem_load_6[64], taddr + (unsigned int)tmem_row_base_cg1 + 64);
+                    tmem_ld_x16(&_tmem_load_6[80], taddr + (unsigned int)tmem_row_base_cg1 + 80);
+                    tmem_ld_x16(&_tmem_load_6[96], taddr + (unsigned int)tmem_row_base_cg1 + 96);
+                    tmem_ld_x16(&_tmem_load_6[112], taddr + (unsigned int)tmem_row_base_cg1 + 112);
+                    asm volatile("tcgen05.wait::ld.sync.aligned;" ::: "memory");
+                    {
+                        mbarrier_wait(checkpoint_done_addr + (checkpoint_stage_cg1_1) * 8, (unsigned int)(cumulative_cg1_1 / 2 + 1 & 1));
+                    }
+                    unsigned int state_words_cg1_1[8];
+                    #pragma unroll
+                    for (int _lp = 0; _lp < 8; _lp++) {
+                        __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(_tmem_load_6[_lp*2 + 0], _tmem_load_6[_lp*2+1 + 0]));
+                        state_words_cg1_1[_lp] = *(uint32_t*)&_bf2;
+                    }
+                    tmem_st_x8_u32(taddr + 128 + (unsigned int)tmem_row_base_cg1, (const uint32_t*)state_words_cg1_1);
+                    {
+                        asm volatile("st.shared.v4.b32 [%0], {%1,%2,%3,%4};" :: "r"((smem_checkpoint_addr + checkpoint_stage_cg1_1 * 32768 + (unsigned int)(value_row_cg1 * 128 ^ (value_row_cg1 * 128 >> 7 & 7) << 4))), "r"(state_words_cg1_1[0]), "r"(state_words_cg1_1[1]), "r"(state_words_cg1_1[2]), "r"(state_words_cg1_1[3]) : "memory");
+                        asm volatile("st.shared.v4.b32 [%0], {%1,%2,%3,%4};" :: "r"((smem_checkpoint_addr + checkpoint_stage_cg1_1 * 32768 + (unsigned int)(value_row_cg1 * 128 + 16 ^ (value_row_cg1 * 128 + 16 >> 7 & 7) << 4))), "r"(state_words_cg1_1[4]), "r"(state_words_cg1_1[5]), "r"(state_words_cg1_1[6]), "r"(state_words_cg1_1[7]) : "memory");
+                    }
+                    #pragma unroll
+                    for (int _lp = 0; _lp < 8; _lp++) {
+                        __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(_tmem_load_6[_lp*2 + 16], _tmem_load_6[_lp*2+1 + 16]));
+                        state_words_cg1_1[_lp] = *(uint32_t*)&_bf2;
+                    }
+                    tmem_st_x8_u32(taddr + 128 + (unsigned int)tmem_row_base_cg1 + 8, (const uint32_t*)state_words_cg1_1);
+                    {
+                        asm volatile("st.shared.v4.b32 [%0], {%1,%2,%3,%4};" :: "r"((smem_checkpoint_addr + checkpoint_stage_cg1_1 * 32768 + (unsigned int)(value_row_cg1 * 128 + 32 ^ (value_row_cg1 * 128 + 32 >> 7 & 7) << 4))), "r"(state_words_cg1_1[0]), "r"(state_words_cg1_1[1]), "r"(state_words_cg1_1[2]), "r"(state_words_cg1_1[3]) : "memory");
+                        asm volatile("st.shared.v4.b32 [%0], {%1,%2,%3,%4};" :: "r"((smem_checkpoint_addr + checkpoint_stage_cg1_1 * 32768 + (unsigned int)(value_row_cg1 * 128 + 48 ^ (value_row_cg1 * 128 + 48 >> 7 & 7) << 4))), "r"(state_words_cg1_1[4]), "r"(state_words_cg1_1[5]), "r"(state_words_cg1_1[6]), "r"(state_words_cg1_1[7]) : "memory");
+                    }
+                    #pragma unroll
+                    for (int _lp = 0; _lp < 8; _lp++) {
+                        __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(_tmem_load_6[_lp*2 + 32], _tmem_load_6[_lp*2+1 + 32]));
+                        state_words_cg1_1[_lp] = *(uint32_t*)&_bf2;
+                    }
+                    tmem_st_x8_u32(taddr + 128 + (unsigned int)tmem_row_base_cg1 + 16, (const uint32_t*)state_words_cg1_1);
+                    {
+                        asm volatile("st.shared.v4.b32 [%0], {%1,%2,%3,%4};" :: "r"((smem_checkpoint_addr + checkpoint_stage_cg1_1 * 32768 + (unsigned int)(value_row_cg1 * 128 + 64 ^ (value_row_cg1 * 128 + 64 >> 7 & 7) << 4))), "r"(state_words_cg1_1[0]), "r"(state_words_cg1_1[1]), "r"(state_words_cg1_1[2]), "r"(state_words_cg1_1[3]) : "memory");
+                        asm volatile("st.shared.v4.b32 [%0], {%1,%2,%3,%4};" :: "r"((smem_checkpoint_addr + checkpoint_stage_cg1_1 * 32768 + (unsigned int)(value_row_cg1 * 128 + 80 ^ (value_row_cg1 * 128 + 80 >> 7 & 7) << 4))), "r"(state_words_cg1_1[4]), "r"(state_words_cg1_1[5]), "r"(state_words_cg1_1[6]), "r"(state_words_cg1_1[7]) : "memory");
+                    }
+                    #pragma unroll
+                    for (int _lp = 0; _lp < 8; _lp++) {
+                        __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(_tmem_load_6[_lp*2 + 48], _tmem_load_6[_lp*2+1 + 48]));
+                        state_words_cg1_1[_lp] = *(uint32_t*)&_bf2;
+                    }
+                    tmem_st_x8_u32(taddr + 128 + (unsigned int)tmem_row_base_cg1 + 24, (const uint32_t*)state_words_cg1_1);
+                    {
+                        asm volatile("st.shared.v4.b32 [%0], {%1,%2,%3,%4};" :: "r"((smem_checkpoint_addr + checkpoint_stage_cg1_1 * 32768 + (unsigned int)(value_row_cg1 * 128 + 96 ^ (value_row_cg1 * 128 + 96 >> 7 & 7) << 4))), "r"(state_words_cg1_1[0]), "r"(state_words_cg1_1[1]), "r"(state_words_cg1_1[2]), "r"(state_words_cg1_1[3]) : "memory");
+                        asm volatile("st.shared.v4.b32 [%0], {%1,%2,%3,%4};" :: "r"((smem_checkpoint_addr + checkpoint_stage_cg1_1 * 32768 + (unsigned int)(value_row_cg1 * 128 + 112 ^ (value_row_cg1 * 128 + 112 >> 7 & 7) << 4))), "r"(state_words_cg1_1[4]), "r"(state_words_cg1_1[5]), "r"(state_words_cg1_1[6]), "r"(state_words_cg1_1[7]) : "memory");
+                    }
+                    #pragma unroll
+                    for (int _lp = 0; _lp < 8; _lp++) {
+                        __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(_tmem_load_6[_lp*2 + 64], _tmem_load_6[_lp*2+1 + 64]));
+                        state_words_cg1_1[_lp] = *(uint32_t*)&_bf2;
+                    }
+                    tmem_st_x8_u32(taddr + 128 + (unsigned int)tmem_row_base_cg1 + 32, (const uint32_t*)state_words_cg1_1);
+                    {
+                        asm volatile("st.shared.v4.b32 [%0], {%1,%2,%3,%4};" :: "r"((smem_checkpoint_addr + checkpoint_stage_cg1_1 * 32768 + (unsigned int)(16384 + value_row_cg1 * 128 ^ (16384 + value_row_cg1 * 128 >> 7 & 7) << 4))), "r"(state_words_cg1_1[0]), "r"(state_words_cg1_1[1]), "r"(state_words_cg1_1[2]), "r"(state_words_cg1_1[3]) : "memory");
+                        asm volatile("st.shared.v4.b32 [%0], {%1,%2,%3,%4};" :: "r"((smem_checkpoint_addr + checkpoint_stage_cg1_1 * 32768 + (unsigned int)(16384 + value_row_cg1 * 128 + 16 ^ (16384 + value_row_cg1 * 128 + 16 >> 7 & 7) << 4))), "r"(state_words_cg1_1[4]), "r"(state_words_cg1_1[5]), "r"(state_words_cg1_1[6]), "r"(state_words_cg1_1[7]) : "memory");
+                    }
+                    #pragma unroll
+                    for (int _lp = 0; _lp < 8; _lp++) {
+                        __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(_tmem_load_6[_lp*2 + 80], _tmem_load_6[_lp*2+1 + 80]));
+                        state_words_cg1_1[_lp] = *(uint32_t*)&_bf2;
+                    }
+                    tmem_st_x8_u32(taddr + 128 + (unsigned int)tmem_row_base_cg1 + 40, (const uint32_t*)state_words_cg1_1);
+                    {
+                        asm volatile("st.shared.v4.b32 [%0], {%1,%2,%3,%4};" :: "r"((smem_checkpoint_addr + checkpoint_stage_cg1_1 * 32768 + (unsigned int)(16384 + value_row_cg1 * 128 + 32 ^ (16384 + value_row_cg1 * 128 + 32 >> 7 & 7) << 4))), "r"(state_words_cg1_1[0]), "r"(state_words_cg1_1[1]), "r"(state_words_cg1_1[2]), "r"(state_words_cg1_1[3]) : "memory");
+                        asm volatile("st.shared.v4.b32 [%0], {%1,%2,%3,%4};" :: "r"((smem_checkpoint_addr + checkpoint_stage_cg1_1 * 32768 + (unsigned int)(16384 + value_row_cg1 * 128 + 48 ^ (16384 + value_row_cg1 * 128 + 48 >> 7 & 7) << 4))), "r"(state_words_cg1_1[4]), "r"(state_words_cg1_1[5]), "r"(state_words_cg1_1[6]), "r"(state_words_cg1_1[7]) : "memory");
+                    }
+                    #pragma unroll
+                    for (int _lp = 0; _lp < 8; _lp++) {
+                        __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(_tmem_load_6[_lp*2 + 96], _tmem_load_6[_lp*2+1 + 96]));
+                        state_words_cg1_1[_lp] = *(uint32_t*)&_bf2;
+                    }
+                    tmem_st_x8_u32(taddr + 128 + (unsigned int)tmem_row_base_cg1 + 48, (const uint32_t*)state_words_cg1_1);
+                    {
+                        asm volatile("st.shared.v4.b32 [%0], {%1,%2,%3,%4};" :: "r"((smem_checkpoint_addr + checkpoint_stage_cg1_1 * 32768 + (unsigned int)(16384 + value_row_cg1 * 128 + 64 ^ (16384 + value_row_cg1 * 128 + 64 >> 7 & 7) << 4))), "r"(state_words_cg1_1[0]), "r"(state_words_cg1_1[1]), "r"(state_words_cg1_1[2]), "r"(state_words_cg1_1[3]) : "memory");
+                        asm volatile("st.shared.v4.b32 [%0], {%1,%2,%3,%4};" :: "r"((smem_checkpoint_addr + checkpoint_stage_cg1_1 * 32768 + (unsigned int)(16384 + value_row_cg1 * 128 + 80 ^ (16384 + value_row_cg1 * 128 + 80 >> 7 & 7) << 4))), "r"(state_words_cg1_1[4]), "r"(state_words_cg1_1[5]), "r"(state_words_cg1_1[6]), "r"(state_words_cg1_1[7]) : "memory");
+                    }
+                    #pragma unroll
+                    for (int _lp = 0; _lp < 8; _lp++) {
+                        __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(_tmem_load_6[_lp*2 + 112], _tmem_load_6[_lp*2+1 + 112]));
+                        state_words_cg1_1[_lp] = *(uint32_t*)&_bf2;
+                    }
+                    tmem_st_x8_u32(taddr + 128 + (unsigned int)tmem_row_base_cg1 + 56, (const uint32_t*)state_words_cg1_1);
+                    {
+                        asm volatile("st.shared.v4.b32 [%0], {%1,%2,%3,%4};" :: "r"((smem_checkpoint_addr + checkpoint_stage_cg1_1 * 32768 + (unsigned int)(16384 + value_row_cg1 * 128 + 96 ^ (16384 + value_row_cg1 * 128 + 96 >> 7 & 7) << 4))), "r"(state_words_cg1_1[0]), "r"(state_words_cg1_1[1]), "r"(state_words_cg1_1[2]), "r"(state_words_cg1_1[3]) : "memory");
+                        asm volatile("st.shared.v4.b32 [%0], {%1,%2,%3,%4};" :: "r"((smem_checkpoint_addr + checkpoint_stage_cg1_1 * 32768 + (unsigned int)(16384 + value_row_cg1 * 128 + 112 ^ (16384 + value_row_cg1 * 128 + 112 >> 7 & 7) << 4))), "r"(state_words_cg1_1[4]), "r"(state_words_cg1_1[5]), "r"(state_words_cg1_1[6]), "r"(state_words_cg1_1[7]) : "memory");
+                    }
+                    asm volatile("tcgen05.wait::st.sync.aligned;" ::: "memory");
+                    mbarrier_arrive(state_inp_ready_addr);
+                    {
+                        asm volatile("fence.proxy.async.shared::cta;" ::: "memory");
+                        mbarrier_arrive(state_read_done_addr);
+                        mbarrier_arrive(checkpoint_ready_addr + (checkpoint_stage_cg1_1) * 8);
+                    }
+                    {
+                        int previous_event_cg1 = cumulative_cg1_1 - 1;
+                        unsigned int previous_o_stage_cg1 = (unsigned int)(previous_event_cg1 % 2);
+                        mbarrier_wait(o_acc_ready_addr, (unsigned int)(previous_event_cg1 & 1));
+                        mbarrier_wait(o_tma_done_addr + (previous_o_stage_cg1) * 8, (unsigned int)(previous_event_cg1 / 2 + 1 & 1));
+                        int output_col_cg1 = 192 + (int)previous_o_stage_cg1 * 16;
+                        float _tmem_load_7[8];
+                        asm volatile(
+                            "tcgen05.ld.sync.aligned.16x256b.x2.b32"
+                            " {%0, %1, %2, %3, %4, %5, %6, %7}, [%8];"
+                            : "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_7[0])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_7[1])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_7[2])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_7[3])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_7[4])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_7[5])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_7[6])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_7[7]))
+                            : "r"(taddr + (unsigned int)output_col_cg1 + (unsigned int)tmem_row_base_cg1)
+                            : "memory");
+                        float _tmem_load_8[8];
+                        asm volatile(
+                            "tcgen05.ld.sync.aligned.16x256b.x2.b32"
+                            " {%0, %1, %2, %3, %4, %5, %6, %7}, [%8];"
+                            : "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_8[0])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_8[1])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_8[2])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_8[3])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_8[4])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_8[5])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_8[6])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_8[7]))
+                            : "r"(taddr + (unsigned int)output_col_cg1 + (unsigned int)tmem_row_base_cg1 + 1048576)
+                            : "memory");
+                        const float2 _scale2_1 = {scale, scale};
+                        #pragma unroll
+                        for (int _ls = 0; _ls < 4; _ls++)
+                            mul_f32x2_inplace(&reinterpret_cast<float2*>(_tmem_load_7)[_ls], _scale2_1);
+                        const float2 _scale2_2 = {scale, scale};
+                        #pragma unroll
+                        for (int _ls = 0; _ls < 4; _ls++)
+                            mul_f32x2_inplace(&reinterpret_cast<float2*>(_tmem_load_8)[_ls], _scale2_2);
+                        uint32_t _tmem_load_7_bf16[4];
+                        #pragma unroll
+                        for (int _lp = 0; _lp < 4; _lp++) {
+                            __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(_tmem_load_7[_lp*2 + 0], _tmem_load_7[_lp*2+1 + 0]));
+                            _tmem_load_7_bf16[_lp] = *(uint32_t*)&_bf2;
+                        }
+                        uint32_t _tmem_load_8_bf16[4];
+                        #pragma unroll
+                        for (int _lp = 0; _lp < 4; _lp++) {
+                            __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(_tmem_load_8[_lp*2 + 0], _tmem_load_8[_lp*2+1 + 0]));
+                            _tmem_load_8_bf16[_lp] = *(uint32_t*)&_bf2;
+                        }
+                        int segment_4 = (value_dim_base_cg1 + ov_col_cg1) / 64;
+                        int segment_col_4 = value_dim_base_cg1 + ov_col_cg1 - segment_4 * 64;
+                        int swizzled_col_4 = segment_col_4 ^ (ov_token_cg1 & 7) * 8;
+                        int segment_0_2 = (value_dim_base_cg1 + 16 + ov_col_cg1) / 64;
+                        int segment_col_1_3 = value_dim_base_cg1 + 16 + ov_col_cg1 - segment_0_2 * 64;
+                        int swizzled_col_2_3 = segment_col_1_3 ^ (ov_token_cg1 & 7) * 8;
+                        uint32_t _stmatrix_addr_3 = static_cast<uint32_t>((unsigned long long)(smem_o_all_addr + (unsigned int)(((int)previous_o_stage_cg1 * 16 * 128 + segment_4 * 16 * 64 + ov_token_cg1 * 64 + swizzled_col_4) * 2)));
+                        asm volatile("stmatrix.sync.aligned.m8n8.x4.trans.shared.b16 [%0], {%1, %2, %3, %4};\n"
+                            :: "r"(_stmatrix_addr_3), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_7_bf16[0])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_7_bf16[1])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_7_bf16[2])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_7_bf16[3]))
+                            : "memory");
+                        uint32_t _stmatrix_addr_4 = static_cast<uint32_t>((unsigned long long)(smem_o_all_addr + (unsigned int)(((int)previous_o_stage_cg1 * 16 * 128 + segment_0_2 * 16 * 64 + ov_token_cg1 * 64 + swizzled_col_2_3) * 2)));
+                        asm volatile("stmatrix.sync.aligned.m8n8.x4.trans.shared.b16 [%0], {%1, %2, %3, %4};\n"
+                            :: "r"(_stmatrix_addr_4), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_8_bf16[0])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_8_bf16[1])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_8_bf16[2])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_8_bf16[3]))
+                            : "memory");
+                        mbarrier_arrive(o_acc_done_addr + (previous_o_stage_cg1) * 8);
+                        asm volatile("fence.proxy.async.shared::cta;" ::: "memory");
+                        mbarrier_arrive(o_tma_ready_addr + (previous_o_stage_cg1) * 8);
+                    }
+                    mbarrier_wait(v_ready_addr + (raw_bar_stage_cg1_1) * 8, (unsigned int)(cumulative_cg1_1 / 6 & 1));
+                    mbarrier_wait(beta_ready_addr + (raw_bar_stage_cg1_1) * 8, (unsigned int)(cumulative_cg1_1 / 6 & 1));
+                    mbarrier_wait(state_k_ready_addr, state_phase_cg1_1);
+                    float _tmem_load_9[8];
+                    asm volatile(
+                        "tcgen05.ld.sync.aligned.16x256b.x2.b32"
+                        " {%0, %1, %2, %3, %4, %5, %6, %7}, [%8];"
+                        : "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_9[0])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_9[1])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_9[2])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_9[3])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_9[4])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_9[5])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_9[6])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_9[7]))
+                        : "r"(taddr + 224 + (unsigned int)tmem_row_base_cg1)
+                        : "memory");
+                    float _tmem_load_10[8];
+                    asm volatile(
+                        "tcgen05.ld.sync.aligned.16x256b.x2.b32"
+                        " {%0, %1, %2, %3, %4, %5, %6, %7}, [%8];"
+                        : "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_10[0])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_10[1])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_10[2])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_10[3])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_10[4])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_10[5])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_10[6])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_10[7]))
+                        : "r"(taddr + 224 + (unsigned int)tmem_row_base_cg1 + 1048576)
+                        : "memory");
+                    unsigned int raw_v_words_lo_cg1_1[4];
+                    unsigned int raw_v_words_hi_cg1_1[4];
+                    int segment_5 = (value_dim_base_cg1 + ov_col_cg1) / 64;
+                    int segment_col_5 = value_dim_base_cg1 + ov_col_cg1 - segment_5 * 64;
+                    int swizzled_col_5 = segment_col_5 ^ (ov_token_cg1 & 7) * 8;
+                    asm volatile("ldmatrix.sync.aligned.m8n8.x4.trans.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                        : "=r"(raw_v_words_lo_cg1_1[0]), "=r"(raw_v_words_lo_cg1_1[1]), "=r"(raw_v_words_lo_cg1_1[2]), "=r"(raw_v_words_lo_cg1_1[3])
+                        : "r"(smem_v_all_addr + (raw_stage_cg1_1 * 16 * 128 + (unsigned int)(segment_5 * 16 * 64) + (unsigned int)(ov_token_cg1 * 64) + (unsigned int)swizzled_col_5) * 2)
+                        : "memory");
+                    int segment_0_3 = (value_dim_base_cg1 + 16 + ov_col_cg1) / 64;
+                    int segment_col_1_4 = value_dim_base_cg1 + 16 + ov_col_cg1 - segment_0_3 * 64;
+                    int swizzled_col_2_4 = segment_col_1_4 ^ (ov_token_cg1 & 7) * 8;
+                    asm volatile("ldmatrix.sync.aligned.m8n8.x4.trans.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                        : "=r"(raw_v_words_hi_cg1_1[0]), "=r"(raw_v_words_hi_cg1_1[1]), "=r"(raw_v_words_hi_cg1_1[2]), "=r"(raw_v_words_hi_cg1_1[3])
+                        : "r"(smem_v_all_addr + (raw_stage_cg1_1 * 16 * 128 + (unsigned int)(segment_0_3 * 16 * 64) + (unsigned int)(ov_token_cg1 * 64) + (unsigned int)swizzled_col_2_4) * 2)
+                        : "memory");
+                    asm volatile("tcgen05.wait::ld.sync.aligned;" ::: "memory");
+                    __nv_bfloat162 beta_pairs_cg1_1[4];
+                    #pragma unroll
+                    for (int beta_reg_cg1_1 = 0; beta_reg_cg1_1 < 4; beta_reg_cg1_1++) {
+                        int beta_packed_col_cg1_1 = beta_reg_cg1_1 / 2 * 4 + (lane & 3);
+                        int beta_token0_cg1_1 = beta_packed_col_cg1_1 * 2;
+                        int beta_token1_cg1_1 = beta_token0_cg1_1 + 1;
+                        __nv_bfloat16 beta0_cg1_1 = smem_beta_all[(int)raw_bar_stage_cg1_1 * 16 + beta_token0_cg1_1];
+                        __nv_bfloat16 beta1_cg1_1 = smem_beta_all[(int)raw_bar_stage_cg1_1 * 16 + beta_token1_cg1_1];
+                        float _cvt_f32_5 = __bfloat162float(beta0_cg1_1);
+                        float _cvt_f32_6 = __bfloat162float(beta1_cg1_1);
+                        __nv_bfloat162 _bf16x2_9 = __float22bfloat162_rn(make_float2(_cvt_f32_5, _cvt_f32_6));
+                        beta_pairs_cg1_1[beta_reg_cg1_1] = _bf16x2_9;
+                    }
+                    unsigned int y_words_lo_cg1_1[4];
+                    unsigned int y_words_hi_cg1_1[4];
+                    #pragma unroll
+                    for (int rhs_reg_cg1_1 = 0; rhs_reg_cg1_1 < 4; rhs_reg_cg1_1++) {
+                        int rhs_raw_matrix_cg1_1 = rhs_reg_cg1_1;
+                        int rhs_frag_pair_cg1_1 = rhs_reg_cg1_1 * 2;
+                        __nv_bfloat162 _bf16x2_10 = __float22bfloat162_rn(make_float2(_tmem_load_9[rhs_frag_pair_cg1_1], _tmem_load_9[rhs_frag_pair_cg1_1 + 1]));
+                        __nv_bfloat162 _bf16x2_11 = __float22bfloat162_rn(make_float2(_tmem_load_10[rhs_frag_pair_cg1_1], _tmem_load_10[rhs_frag_pair_cg1_1 + 1]));
+                        uint32_t _bf16x2_sub_2;
+                        asm volatile("sub.rn.bf16x2 %0, %1, %2;" : "=r"(_bf16x2_sub_2) : "r"(raw_v_words_lo_cg1_1[rhs_raw_matrix_cg1_1]), "r"(__as_u32(_bf16x2_10)));
+                        uint32_t _bf16x2_sub_3;
+                        asm volatile("sub.rn.bf16x2 %0, %1, %2;" : "=r"(_bf16x2_sub_3) : "r"(raw_v_words_hi_cg1_1[rhs_raw_matrix_cg1_1]), "r"(__as_u32(_bf16x2_11)));
+                        __nv_bfloat162 rhs_diff_pair_lo_cg1_1 = __as_bf16x2(_bf16x2_sub_2);
+                        __nv_bfloat162 rhs_diff_pair_hi_cg1_1 = __as_bf16x2(_bf16x2_sub_3);
+                        __nv_bfloat162 y_pair_lo_cg1_1 = beta_pairs_cg1_1[rhs_reg_cg1_1] * rhs_diff_pair_lo_cg1_1;
+                        __nv_bfloat162 y_pair_hi_cg1_1 = beta_pairs_cg1_1[rhs_reg_cg1_1] * rhs_diff_pair_hi_cg1_1;
+                        y_words_lo_cg1_1[rhs_reg_cg1_1] = __as_u32(y_pair_lo_cg1_1);
+                        y_words_hi_cg1_1[rhs_reg_cg1_1] = __as_u32(y_pair_hi_cg1_1);
+                    }
+                    asm volatile(
+                        "tcgen05.st.sync.aligned.16x128b.x2.b32"
+                        " [%0], {%1, %2, %3, %4};"
+                        :: "r"(taddr + 256 + (unsigned int)tmem_row_base_cg1), "r"(*reinterpret_cast<const uint32_t*>(&y_words_lo_cg1_1[0])), "r"(*reinterpret_cast<const uint32_t*>(&y_words_lo_cg1_1[1])), "r"(*reinterpret_cast<const uint32_t*>(&y_words_lo_cg1_1[2])), "r"(*reinterpret_cast<const uint32_t*>(&y_words_lo_cg1_1[3]))
+                        : "memory");
+                    asm volatile(
+                        "tcgen05.st.sync.aligned.16x128b.x2.b32"
+                        " [%0], {%1, %2, %3, %4};"
+                        :: "r"(taddr + 256 + (unsigned int)tmem_row_base_cg1 + 1048576), "r"(*reinterpret_cast<const uint32_t*>(&y_words_hi_cg1_1[0])), "r"(*reinterpret_cast<const uint32_t*>(&y_words_hi_cg1_1[1])), "r"(*reinterpret_cast<const uint32_t*>(&y_words_hi_cg1_1[2])), "r"(*reinterpret_cast<const uint32_t*>(&y_words_hi_cg1_1[3]))
+                        : "memory");
+                    asm volatile("tcgen05.wait::st.sync.aligned;" ::: "memory");
+                    mbarrier_arrive(v_done_addr + (raw_stage_cg1_1) * 8);
+                    mbarrier_arrive(beta_done_addr + (raw_bar_stage_cg1_1) * 8);
+                    mbarrier_arrive(y_inp_ready_addr);
+                    mbarrier_wait(u_acc_ready_addr, state_phase_cg1_1);
+                    float _tmem_load_11[16];
+                    tmem_ld_x16(&_tmem_load_11[0], taddr + 240 + (unsigned int)tmem_row_base_cg1);
+                    asm volatile("tcgen05.wait::ld.sync.aligned;" ::: "memory");
+                    unsigned int u_words_cg1_1[8];
+                    #pragma unroll
+                    for (int _lp = 0; _lp < 8; _lp++) {
+                        __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(_tmem_load_11[_lp*2 + 0], _tmem_load_11[_lp*2+1 + 0]));
+                        u_words_cg1_1[_lp] = *(uint32_t*)&_bf2;
+                    }
+                    tmem_st_x8_u32(taddr + 264 + (unsigned int)tmem_row_base_cg1, (const uint32_t*)u_words_cg1_1);
+                    asm volatile("tcgen05.wait::st.sync.aligned;" ::: "memory");
+                    mbarrier_arrive(u_inp_ready_addr);
+                }
+                if (chunks_cg1 > 0) {
+                    int final_event_cg1 = cumulative_chunk_cg1 + chunks_cg1 - 1;
+                    unsigned int final_o_stage_cg1 = (unsigned int)(final_event_cg1 % 2);
+                    mbarrier_wait(state_acc_done_addr, (unsigned int)(final_event_cg1 & 1));
+                    mbarrier_wait(o_acc_ready_addr, (unsigned int)(final_event_cg1 & 1));
+                    mbarrier_wait(o_tma_done_addr + (final_o_stage_cg1) * 8, (unsigned int)(final_event_cg1 / 2 + 1 & 1));
+                    int output_col_cg1_1 = 192 + (int)final_o_stage_cg1 * 16;
+                    float _tmem_load_12[8];
+                    asm volatile(
+                        "tcgen05.ld.sync.aligned.16x256b.x2.b32"
+                        " {%0, %1, %2, %3, %4, %5, %6, %7}, [%8];"
+                        : "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_12[0])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_12[1])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_12[2])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_12[3])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_12[4])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_12[5])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_12[6])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_12[7]))
+                        : "r"(taddr + (unsigned int)output_col_cg1_1 + (unsigned int)tmem_row_base_cg1)
+                        : "memory");
+                    float _tmem_load_13[8];
+                    asm volatile(
+                        "tcgen05.ld.sync.aligned.16x256b.x2.b32"
+                        " {%0, %1, %2, %3, %4, %5, %6, %7}, [%8];"
+                        : "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_13[0])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_13[1])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_13[2])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_13[3])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_13[4])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_13[5])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_13[6])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_13[7]))
+                        : "r"(taddr + (unsigned int)output_col_cg1_1 + (unsigned int)tmem_row_base_cg1 + 1048576)
+                        : "memory");
+                    const float2 _scale2_5 = {scale, scale};
+                    #pragma unroll
+                    for (int _ls = 0; _ls < 4; _ls++)
+                        mul_f32x2_inplace(&reinterpret_cast<float2*>(_tmem_load_12)[_ls], _scale2_5);
+                    const float2 _scale2_6 = {scale, scale};
+                    #pragma unroll
+                    for (int _ls = 0; _ls < 4; _ls++)
+                        mul_f32x2_inplace(&reinterpret_cast<float2*>(_tmem_load_13)[_ls], _scale2_6);
+                    uint32_t _tmem_load_12_bf16[4];
+                    #pragma unroll
+                    for (int _lp = 0; _lp < 4; _lp++) {
+                        __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(_tmem_load_12[_lp*2 + 0], _tmem_load_12[_lp*2+1 + 0]));
+                        _tmem_load_12_bf16[_lp] = *(uint32_t*)&_bf2;
+                    }
+                    uint32_t _tmem_load_13_bf16[4];
+                    #pragma unroll
+                    for (int _lp = 0; _lp < 4; _lp++) {
+                        __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(_tmem_load_13[_lp*2 + 0], _tmem_load_13[_lp*2+1 + 0]));
+                        _tmem_load_13_bf16[_lp] = *(uint32_t*)&_bf2;
+                    }
+                    int segment_6 = (value_dim_base_cg1 + ov_col_cg1) / 64;
+                    int segment_col_6 = value_dim_base_cg1 + ov_col_cg1 - segment_6 * 64;
+                    int swizzled_col_6 = segment_col_6 ^ (ov_token_cg1 & 7) * 8;
+                    int segment_0_4 = (value_dim_base_cg1 + 16 + ov_col_cg1) / 64;
+                    int segment_col_1_5 = value_dim_base_cg1 + 16 + ov_col_cg1 - segment_0_4 * 64;
+                    int swizzled_col_2_5 = segment_col_1_5 ^ (ov_token_cg1 & 7) * 8;
+                    uint32_t _stmatrix_addr_7 = static_cast<uint32_t>((unsigned long long)(smem_o_all_addr + (unsigned int)(((int)final_o_stage_cg1 * 16 * 128 + segment_6 * 16 * 64 + ov_token_cg1 * 64 + swizzled_col_6) * 2)));
+                    asm volatile("stmatrix.sync.aligned.m8n8.x4.trans.shared.b16 [%0], {%1, %2, %3, %4};\n"
+                        :: "r"(_stmatrix_addr_7), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_12_bf16[0])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_12_bf16[1])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_12_bf16[2])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_12_bf16[3]))
+                        : "memory");
+                    uint32_t _stmatrix_addr_8 = static_cast<uint32_t>((unsigned long long)(smem_o_all_addr + (unsigned int)(((int)final_o_stage_cg1 * 16 * 128 + segment_0_4 * 16 * 64 + ov_token_cg1 * 64 + swizzled_col_2_5) * 2)));
+                    asm volatile("stmatrix.sync.aligned.m8n8.x4.trans.shared.b16 [%0], {%1, %2, %3, %4};\n"
+                        :: "r"(_stmatrix_addr_8), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_13_bf16[0])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_13_bf16[1])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_13_bf16[2])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_13_bf16[3]))
+                        : "memory");
+                    mbarrier_arrive(o_acc_done_addr + (final_o_stage_cg1) * 8);
+                    asm volatile("fence.proxy.async.shared::cta;" ::: "memory");
+                    mbarrier_arrive(o_tma_ready_addr + (final_o_stage_cg1) * 8);
+                    {
+                        #pragma unroll
+                        for (int final_block_cg1 = 0; final_block_cg1 < 4; final_block_cg1++) {
+                            float _tmem_load_14[32];
+                            tmem_ld_x32(&_tmem_load_14[0], taddr + (unsigned int)tmem_row_base_cg1 + (unsigned int)(final_block_cg1 * 32));
+                            asm volatile("tcgen05.wait::ld.sync.aligned;" ::: "memory");
+                            {
+                                __nv_bfloat162 _pk[8];
+                                _pk[0] = __floats2bfloat162_rn(_tmem_load_14[0 + 0], _tmem_load_14[0 + 1]);
+                                _pk[1] = __floats2bfloat162_rn(_tmem_load_14[0 + 2], _tmem_load_14[0 + 3]);
+                                _pk[2] = __floats2bfloat162_rn(_tmem_load_14[0 + 4], _tmem_load_14[0 + 5]);
+                                _pk[3] = __floats2bfloat162_rn(_tmem_load_14[0 + 6], _tmem_load_14[0 + 7]);
+                                _pk[4] = __floats2bfloat162_rn(_tmem_load_14[0 + 8], _tmem_load_14[0 + 9]);
+                                _pk[5] = __floats2bfloat162_rn(_tmem_load_14[0 + 10], _tmem_load_14[0 + 11]);
+                                _pk[6] = __floats2bfloat162_rn(_tmem_load_14[0 + 12], _tmem_load_14[0 + 13]);
+                                _pk[7] = __floats2bfloat162_rn(_tmem_load_14[0 + 14], _tmem_load_14[0 + 15]);
+                                *reinterpret_cast<uint4*>(&((__nv_bfloat16*)(final_state + (state_base_cg1 + (long long)(final_block_cg1 * 32))))[0]) = *reinterpret_cast<uint4*>(&_pk[0]);
+                                *reinterpret_cast<uint4*>(&((__nv_bfloat16*)(final_state + (state_base_cg1 + (long long)(final_block_cg1 * 32))))[8]) = *reinterpret_cast<uint4*>(&_pk[4]);
+                            }
+                            {
+                                __nv_bfloat162 _pk[8];
+                                _pk[0] = __floats2bfloat162_rn(_tmem_load_14[16 + 0], _tmem_load_14[16 + 1]);
+                                _pk[1] = __floats2bfloat162_rn(_tmem_load_14[16 + 2], _tmem_load_14[16 + 3]);
+                                _pk[2] = __floats2bfloat162_rn(_tmem_load_14[16 + 4], _tmem_load_14[16 + 5]);
+                                _pk[3] = __floats2bfloat162_rn(_tmem_load_14[16 + 6], _tmem_load_14[16 + 7]);
+                                _pk[4] = __floats2bfloat162_rn(_tmem_load_14[16 + 8], _tmem_load_14[16 + 9]);
+                                _pk[5] = __floats2bfloat162_rn(_tmem_load_14[16 + 10], _tmem_load_14[16 + 11]);
+                                _pk[6] = __floats2bfloat162_rn(_tmem_load_14[16 + 12], _tmem_load_14[16 + 13]);
+                                _pk[7] = __floats2bfloat162_rn(_tmem_load_14[16 + 14], _tmem_load_14[16 + 15]);
+                                *reinterpret_cast<uint4*>(&((__nv_bfloat16*)(final_state + (state_base_cg1 + (long long)(final_block_cg1 * 32) + 16)))[0]) = *reinterpret_cast<uint4*>(&_pk[0]);
+                                *reinterpret_cast<uint4*>(&((__nv_bfloat16*)(final_state + (state_base_cg1 + (long long)(final_block_cg1 * 32) + 16)))[8]) = *reinterpret_cast<uint4*>(&_pk[4]);
+                            }
+                        }
+                    }
+                }
+                cumulative_chunk_cg1 += chunks_cg1;
+            }
+            if (elect_sync()) {
+                mbarrier_arrive(consumers_done_addr);
+            }
+        }
+    }
+    // ---- Role: super_mma ----
+    if (warp == 12) {
+        { // super_mma_main
+            unsigned int sched_stage_super = 0;
+            int cumulative_chunk_super = 0;
+            int lhs_row_super = lane % 8 + (lane / 8 & 1) * 8;
+            int lhs_col_super = lane / 16 * 8;
+            int rhs_row_super = lane % 8 + lane / 16 * 8;
+            int rhs_col_super = (lane / 8 & 1) * 8;
+            unsigned int _phase_sched_ready_2 = 0;
+            #pragma unroll 1
+            for (int __2 = 0; __2 < total_work_items + 1; __2++) {
+                mbarrier_wait(sched_ready_addr + (sched_stage_super) * 8, _phase_sched_ready_2);
+                unsigned int slot_2[1];
+                asm volatile("ld.shared.b32 %0, [%1];" : "=r"(*reinterpret_cast<uint32_t*>(&slot_2[0])) : "r"(sched_slot_addr + sched_stage_super * 4));
+                unsigned int tile_super = slot_2[0];
+                if (elect_sync()) {
+                    mbarrier_arrive(sched_done_addr + (sched_stage_super) * 8);
+                }
+                sched_stage_super += 1;
+                if (sched_stage_super == 8) { sched_stage_super = 0; _phase_sched_ready_2 ^= 1; }
+                if (tile_super >= (unsigned int)total_work_items) {
+                    break;
+                }
+                int item_base_super = (int)tile_super * 8;
+                int chunks_super = work_items[item_base_super + 3] - work_items[item_base_super + 4];
+                #pragma unroll 1
+                for (int chunk_super = 0; chunk_super < chunks_super; chunk_super++) {
+                    int cumulative_super = cumulative_chunk_super + chunk_super;
+                    unsigned int decay_stage_super = (unsigned int)(cumulative_super % 2);
+                    unsigned int raw_bar_stage_super = (unsigned int)(cumulative_super % 6);
+                    unsigned int intermediate_stage_super = (unsigned int)(cumulative_super % 2);
+                    mbarrier_wait(k_decay_inv_ready_addr + (decay_stage_super) * 8, (unsigned int)(cumulative_super / 2 & 1));
+                    mbarrier_wait(beta_ready_addr + (raw_bar_stage_super) * 8, (unsigned int)(cumulative_super / 6 & 1));
+                    mbarrier_wait(tinv_done_addr + (intermediate_stage_super) * 8, (unsigned int)(cumulative_super / 2 + 1 & 1));
+                    float kk_acc_super[8];
+                    #pragma unroll
+                    for (int k_block_super = 0; k_block_super < 8; k_block_super++) {
+                        unsigned int a_frag_super[4];
+                        unsigned int b_frag_super[4];
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(a_frag_super[0]), "=r"(a_frag_super[1]), "=r"(a_frag_super[2]), "=r"(a_frag_super[3])
+                            : "r"((smem_k_decay_addr + decay_stage_super * 4096 + (unsigned int)((k_block_super * 16 + lhs_col_super) / 64 * 2048 + lhs_row_super * 128 + (k_block_super * 16 + lhs_col_super) % 64 * 2 ^ ((k_block_super * 16 + lhs_col_super) / 64 * 2048 + lhs_row_super * 128 + (k_block_super * 16 + lhs_col_super) % 64 * 2 >> 7 & 7) << 4)))
+                            : "memory");
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(b_frag_super[0]), "=r"(b_frag_super[1]), "=r"(b_frag_super[2]), "=r"(b_frag_super[3])
+                            : "r"((smem_k_inv_addr + decay_stage_super * 4096 + (unsigned int)((k_block_super * 16 + rhs_col_super) / 64 * 2048 + rhs_row_super * 128 + (k_block_super * 16 + rhs_col_super) % 64 * 2 ^ ((k_block_super * 16 + rhs_col_super) / 64 * 2048 + rhs_row_super * 128 + (k_block_super * 16 + rhs_col_super) % 64 * 2 >> 7 & 7) << 4)))
+                            : "memory");
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%10, %11, %12, %13};\n"
+                            : "=f"(kk_acc_super[0]), "=f"(kk_acc_super[1]), "=f"(kk_acc_super[2]), "=f"(kk_acc_super[3])
+                            : "r"(a_frag_super[0]), "r"(a_frag_super[1]), "r"(a_frag_super[2]), "r"(a_frag_super[3]), "r"(b_frag_super[0]), "r"(b_frag_super[1]), "f"(((k_block_super == 0) ? 0.0f : kk_acc_super[0])), "f"(((k_block_super == 0) ? 0.0f : kk_acc_super[1])), "f"(((k_block_super == 0) ? 0.0f : kk_acc_super[2])), "f"(((k_block_super == 0) ? 0.0f : kk_acc_super[3])));
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%10, %11, %12, %13};\n"
+                            : "=f"(kk_acc_super[4]), "=f"(kk_acc_super[(4) + 1]), "=f"(kk_acc_super[(4) + 2]), "=f"(kk_acc_super[(4) + 3])
+                            : "r"(a_frag_super[0]), "r"(a_frag_super[1]), "r"(a_frag_super[2]), "r"(a_frag_super[3]), "r"(b_frag_super[2]), "r"(b_frag_super[(2) + 1]), "f"(((k_block_super == 0) ? 0.0f : kk_acc_super[4])), "f"(((k_block_super == 0) ? 0.0f : kk_acc_super[(4) + 1])), "f"(((k_block_super == 0) ? 0.0f : kk_acc_super[(4) + 2])), "f"(((k_block_super == 0) ? 0.0f : kk_acc_super[(4) + 3])));
+                    }
+                    int beta_stage_base_super = (int)raw_bar_stage_super * 16;
+                    __nv_bfloat16 beta_lo_bf_super = smem_beta_all[beta_stage_base_super + lane / 4];
+                    __nv_bfloat16 beta_hi_bf_super = smem_beta_all[beta_stage_base_super + lane / 4 + 8];
+                    float _cvt_f32_0 = __bfloat162float(beta_lo_bf_super);
+                    float beta_lo_super = _cvt_f32_0;
+                    float _cvt_f32_1 = __bfloat162float(beta_hi_bf_super);
+                    float beta_hi_super = _cvt_f32_1;
+                    float l_values_super[8];
+                    float tinv_acc_super[8];
+                    #pragma unroll
+                    for (int accum_super = 0; accum_super < 8; accum_super++) {
+                        int row_super = lane / 4 + accum_super % 4 / 2 * 8;
+                        int col_super = accum_super / 4 * 8 + (lane & 3) * 2 + (accum_super & 1);
+                        l_values_super[accum_super] = 0.0f;
+                        if (row_super > col_super) {
+                            float beta_scale_super = beta_lo_super;
+                            if (accum_super % 4 >= 2) {
+                                beta_scale_super = beta_hi_super;
+                            }
+                            l_values_super[accum_super] = kk_acc_super[accum_super] * beta_scale_super;
+                        }
+                        tinv_acc_super[accum_super] = -l_values_super[accum_super];
+                        if (row_super == col_super) {
+                            tinv_acc_super[accum_super] = 1.0f;
+                        }
+                    }
+                    unsigned int lpow_words_super[4];
+                    unsigned int lpow_trans_super[4];
+                    #pragma unroll
+                    for (int _lp = 0; _lp < 4; _lp++) {
+                        __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(l_values_super[_lp*2 + 0], l_values_super[_lp*2+1 + 0]));
+                        lpow_words_super[_lp] = *(uint32_t*)&_bf2;
+                    }
+                    int store_row_super = lane % 16;
+                    int store_col_super = lane / 16 * 8;
+                    int linear = store_row_super * 16 + store_col_super;
+                    uint32_t _stmatrix_addr_0 = static_cast<uint32_t>((unsigned long long)(tinv_scratch_addr + (unsigned int)((linear ^ (linear >> 6 & 1) * 8) * 2)));
+                    asm volatile("stmatrix.sync.aligned.m8n8.x4.shared.b16 [%0], {%1, %2, %3, %4};\n"
+                        :: "r"(_stmatrix_addr_0), "r"(*reinterpret_cast<const uint32_t*>(&lpow_words_super[0])), "r"(*reinterpret_cast<const uint32_t*>(&lpow_words_super[1])), "r"(*reinterpret_cast<const uint32_t*>(&lpow_words_super[2])), "r"(*reinterpret_cast<const uint32_t*>(&lpow_words_super[3]))
+                        : "memory");
+                    __syncwarp();
+                    int load_row_super = lane % 16;
+                    #pragma unroll
+                    for (int load_half_super = 0; load_half_super < 2; load_half_super++) {
+                        int linear_0 = load_row_super * 16 + load_half_super * 8;
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x2.trans.shared.b16 {%0, %1}, [%2];\n"
+                            : "=r"(lpow_trans_super[load_half_super * 2]), "=r"(lpow_trans_super[load_half_super * 2 + 1])
+                            : "r"(tinv_scratch_addr + (unsigned int)((linear_0 ^ (linear_0 >> 6 & 1) * 8) * 2))
+                            : "memory");
+                    }
+                    #pragma unroll
+                    for (int neumann_super = 0; neumann_super < 3; neumann_super++) {
+                        float square_acc_super[8];
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%10, %11, %12, %13};\n"
+                            : "=f"(square_acc_super[0]), "=f"(square_acc_super[1]), "=f"(square_acc_super[2]), "=f"(square_acc_super[3])
+                            : "r"(lpow_words_super[0]), "r"(lpow_words_super[1]), "r"(lpow_words_super[2]), "r"(lpow_words_super[3]), "r"(lpow_trans_super[0]), "r"(lpow_trans_super[1]), "f"(0.0f), "f"(0.0f), "f"(0.0f), "f"(0.0f));
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%10, %11, %12, %13};\n"
+                            : "=f"(square_acc_super[4]), "=f"(square_acc_super[(4) + 1]), "=f"(square_acc_super[(4) + 2]), "=f"(square_acc_super[(4) + 3])
+                            : "r"(lpow_words_super[0]), "r"(lpow_words_super[1]), "r"(lpow_words_super[2]), "r"(lpow_words_super[3]), "r"(lpow_trans_super[2]), "r"(lpow_trans_super[(2) + 1]), "f"(0.0f), "f"(0.0f), "f"(0.0f), "f"(0.0f));
+                        #pragma unroll
+                        for (int _lp = 0; _lp < 4; _lp++) {
+                            __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(square_acc_super[_lp*2 + 0], square_acc_super[_lp*2+1 + 0]));
+                            lpow_words_super[_lp] = *(uint32_t*)&_bf2;
+                        }
+                        int store_row_super_0 = lane % 16;
+                        int store_col_super_1 = lane / 16 * 8;
+                        int linear_2 = store_row_super_0 * 16 + store_col_super_1;
+                        uint32_t _stmatrix_addr_1 = static_cast<uint32_t>((unsigned long long)(tinv_scratch_addr + (unsigned int)((linear_2 ^ (linear_2 >> 6 & 1) * 8) * 2)));
+                        asm volatile("stmatrix.sync.aligned.m8n8.x4.shared.b16 [%0], {%1, %2, %3, %4};\n"
+                            :: "r"(_stmatrix_addr_1), "r"(*reinterpret_cast<const uint32_t*>(&lpow_words_super[0])), "r"(*reinterpret_cast<const uint32_t*>(&lpow_words_super[1])), "r"(*reinterpret_cast<const uint32_t*>(&lpow_words_super[2])), "r"(*reinterpret_cast<const uint32_t*>(&lpow_words_super[3]))
+                            : "memory");
+                        __syncwarp();
+                        int load_row_super_3 = lane % 16;
+                        #pragma unroll
+                        for (int load_half_super_1 = 0; load_half_super_1 < 2; load_half_super_1++) {
+                            int linear_0_1 = load_row_super_3 * 16 + load_half_super_1 * 8;
+                            asm volatile("ldmatrix.sync.aligned.m8n8.x2.trans.shared.b16 {%0, %1}, [%2];\n"
+                                : "=r"(lpow_trans_super[load_half_super_1 * 2]), "=r"(lpow_trans_super[load_half_super_1 * 2 + 1])
+                                : "r"(tinv_scratch_addr + (unsigned int)((linear_0_1 ^ (linear_0_1 >> 6 & 1) * 8) * 2))
+                                : "memory");
+                        }
+                        unsigned int tinv_words_super[4];
+                        #pragma unroll
+                        for (int _lp = 0; _lp < 4; _lp++) {
+                            __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(tinv_acc_super[_lp*2 + 0], tinv_acc_super[_lp*2+1 + 0]));
+                            tinv_words_super[_lp] = *(uint32_t*)&_bf2;
+                        }
+                        float update_acc_super[8];
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%10, %11, %12, %13};\n"
+                            : "=f"(update_acc_super[0]), "=f"(update_acc_super[1]), "=f"(update_acc_super[2]), "=f"(update_acc_super[3])
+                            : "r"(tinv_words_super[0]), "r"(tinv_words_super[1]), "r"(tinv_words_super[2]), "r"(tinv_words_super[3]), "r"(lpow_trans_super[0]), "r"(lpow_trans_super[1]), "f"(0.0f), "f"(0.0f), "f"(0.0f), "f"(0.0f));
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%10, %11, %12, %13};\n"
+                            : "=f"(update_acc_super[4]), "=f"(update_acc_super[(4) + 1]), "=f"(update_acc_super[(4) + 2]), "=f"(update_acc_super[(4) + 3])
+                            : "r"(tinv_words_super[0]), "r"(tinv_words_super[1]), "r"(tinv_words_super[2]), "r"(tinv_words_super[3]), "r"(lpow_trans_super[2]), "r"(lpow_trans_super[(2) + 1]), "f"(0.0f), "f"(0.0f), "f"(0.0f), "f"(0.0f));
+                        float tinv_words_super_f32[8];
+                        #pragma unroll
+                        for (int _pair = 0; _pair < 4; _pair++) {
+                            asm volatile(
+                                "{\n\t"
+                                "shl.b32 %0, %2, 16;\n\t"
+                                "and.b32 %1, %2, 0xffff0000;\n\t"
+                                "}\n"
+                                : "=f"((&tinv_words_super_f32[_pair * 2])[0]), "=f"((&tinv_words_super_f32[_pair * 2])[1])
+                                : "r"(tinv_words_super[_pair]));
+                        }
+                        #pragma unroll
+                        for (int update_super = 0; update_super < 8; update_super++) {
+                            tinv_acc_super[update_super] = tinv_words_super_f32[update_super] + update_acc_super[update_super];
+                        }
+                    }
+                    unsigned int tinv_publish_super[4];
+                    #pragma unroll
+                    for (int _lp = 0; _lp < 4; _lp++) {
+                        __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(tinv_acc_super[_lp*2 + 0], tinv_acc_super[_lp*2+1 + 0]));
+                        tinv_publish_super[_lp] = *(uint32_t*)&_bf2;
+                    }
+                    uint32_t _stmatrix_addr_2 = static_cast<uint32_t>((unsigned long long)(smem_tinv_addr + intermediate_stage_super * 1024 + (unsigned int)(lane / 16 * 8 / 16 * 512 + lane % 16 * 32 + lane / 16 * 8 % 16 * 2 ^ (lane / 16 * 8 / 16 * 512 + lane % 16 * 32 + lane / 16 * 8 % 16 * 2 >> 7 & 1) << 4)));
+                    asm volatile("stmatrix.sync.aligned.m8n8.x4.shared.b16 [%0], {%1, %2, %3, %4};\n"
+                        :: "r"(_stmatrix_addr_2), "r"(*reinterpret_cast<const uint32_t*>(&tinv_publish_super[0])), "r"(*reinterpret_cast<const uint32_t*>(&tinv_publish_super[1])), "r"(*reinterpret_cast<const uint32_t*>(&tinv_publish_super[2])), "r"(*reinterpret_cast<const uint32_t*>(&tinv_publish_super[3]))
+                        : "memory");
+                    asm volatile("fence.proxy.async.shared::cta;" ::: "memory");
+                    mbarrier_arrive(tinv_ready_addr + (intermediate_stage_super) * 8);
+                    mbarrier_arrive(beta_done_addr + (raw_bar_stage_super) * 8);
+                    mbarrier_arrive(decay_super_done_addr + (decay_stage_super) * 8);
+                }
+                cumulative_chunk_super += chunks_super;
+            }
+            if (elect_sync()) {
+                mbarrier_arrive(consumers_done_addr);
+            }
+        }
+    }
+    // ---- Role: tcgen ----
+    if (warp == 13) {
+        { // tcgen_main
+            float tmem_seed_tcgen[1];
+            tmem_seed_tcgen[0] = 0.0f;
+            asm volatile(
+                "tcgen05.st.sync.aligned.32x32b.x1.b32"
+                " [%0], {%1};"
+                :: "r"(taddr), "r"(*reinterpret_cast<const uint32_t*>(&tmem_seed_tcgen[0]))
+                : "memory");
+            asm volatile("tcgen05.wait::st.sync.aligned;" ::: "memory");
+            unsigned int sched_stage_tcgen = 0;
+            int cumulative_chunk_tcgen = 0;
+            unsigned int _phase_sched_ready_3 = 0;
+            #pragma unroll 1
+            for (int __3 = 0; __3 < total_work_items + 1; __3++) {
+                mbarrier_wait(sched_ready_addr + (sched_stage_tcgen) * 8, _phase_sched_ready_3);
+                unsigned int slot_3[1];
+                asm volatile("ld.shared.b32 %0, [%1];" : "=r"(*reinterpret_cast<uint32_t*>(&slot_3[0])) : "r"(sched_slot_addr + sched_stage_tcgen * 4));
+                unsigned int tile_tcgen = slot_3[0];
+                if (elect_sync()) {
+                    mbarrier_arrive(sched_done_addr + (sched_stage_tcgen) * 8);
+                }
+                sched_stage_tcgen += 1;
+                if (sched_stage_tcgen == 8) { sched_stage_tcgen = 0; _phase_sched_ready_3 ^= 1; }
+                if (tile_tcgen >= (unsigned int)total_work_items) {
+                    break;
+                }
+                int item_base_tcgen = (int)tile_tcgen * 8;
+                int chunks_tcgen = work_items[item_base_tcgen + 3] - work_items[item_base_tcgen + 4];
+                #pragma unroll 1
+                for (int chunk_tcgen = 0; chunk_tcgen < chunks_tcgen; chunk_tcgen++) {
+                    int cumulative_tcgen = cumulative_chunk_tcgen + chunk_tcgen;
+                    unsigned int state_phase_tcgen = (unsigned int)(cumulative_tcgen & 1);
+                    unsigned int decay_stage_tcgen = (unsigned int)(cumulative_tcgen % 2);
+                    unsigned int diag_stage_tcgen = (unsigned int)(cumulative_tcgen % 4);
+                    unsigned int intermediate_stage_tcgen = (unsigned int)(cumulative_tcgen % 2);
+                    unsigned int o_stage_tcgen = (unsigned int)(cumulative_tcgen % 2);
+                    mbarrier_wait(k_decay_inv_ready_addr + (decay_stage_tcgen) * 8, (unsigned int)(cumulative_tcgen / 2 & 1));
+                    mbarrier_wait(state_inp_ready_addr, state_phase_tcgen);
+                    int _mma_b_lo_0 = make_warp_uniform((((smem_k_decay_addr) >> 4) & 0x3FFF) + (decay_stage_tcgen) * 256);
+                    asm volatile(
+                    "{\n\t"
+                    ".reg .pred leader, p0, p1;\n\t"
+                    ".reg .b32 dhi, blo, ta, id;\n\t"
+                    ".reg .b64 db;\n\t"
+                    "elect.sync _|leader, 0xFFFFFFFF;\n\t"
+                    "setp.ne.b32 p0, %3, 0;\n\t"
+                    "setp.ne.b32 p1, 1, 0;\n\t"
+                    ""
+                    "mov.b32 dhi, 0x40004040;\n\t"
+                    "mov.b32 id, 134481040;\n\t"
+                    "mov.b32 ta, %2;\n\t"
+                    "mov.b32 blo, %1;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p0;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 122;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "}\n"
+                    :: "r"(tmem_tmem_state_k), "r"(_mma_b_lo_0), "r"(tmem_tmem_state_inp), "r"(0));
+                    elect_commit(state_k_ready_addr);
+                    mbarrier_wait(qk_scale_ready_addr + (diag_stage_tcgen) * 8, (unsigned int)(cumulative_tcgen / 4 & 1));
+                    mbarrier_wait(o_acc_done_addr + (o_stage_tcgen) * 8, (unsigned int)(cumulative_tcgen / 2 + 1 & 1));
+                    int _mma_b_lo_1 = make_warp_uniform((((smem_q_decay_addr) >> 4) & 0x3FFF) + (decay_stage_tcgen) * 256);
+                    asm volatile(
+                    "{\n\t"
+                    ".reg .pred leader, p0, p1;\n\t"
+                    ".reg .b32 dhi, blo, ta, id;\n\t"
+                    ".reg .b64 db;\n\t"
+                    "elect.sync _|leader, 0xFFFFFFFF;\n\t"
+                    "setp.ne.b32 p0, %3, 0;\n\t"
+                    "setp.ne.b32 p1, 1, 0;\n\t"
+                    ""
+                    "mov.b32 dhi, 0x40004040;\n\t"
+                    "mov.b32 id, 134481040;\n\t"
+                    "mov.b32 ta, %2;\n\t"
+                    "mov.b32 blo, %1;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p0;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 122;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "}\n"
+                    :: "r"((tmem_tmem_q_state + ((int)o_stage_tcgen * 16))), "r"(_mma_b_lo_1), "r"(tmem_tmem_state_inp), "r"(0));
+                    elect_commit(decay_tcgen_done_addr + (decay_stage_tcgen) * 8);
+                    {
+                        mbarrier_wait(state_read_done_addr, state_phase_tcgen);
+                    }
+                    #pragma unroll
+                    for (int diag_block_tcgen = 0; diag_block_tcgen < 8; diag_block_tcgen++) {
+                        int _mma_b_lo_2 = make_warp_uniform((((smem_state_diag_addr) >> 4) & 0x3FFF) + ((int)diag_stage_tcgen * 8 + diag_block_tcgen) * 32);
+                        mma_ts_step((tmem_tmem_state + (diag_block_tcgen * 16)), tmem_tmem_state_inp + diag_block_tcgen * 8, _mma_b_lo_2, 0xC0004010, 134481040, 0);
+                    }
+                    elect_commit(state_diag_done_addr + (diag_stage_tcgen) * 8);
+                    mbarrier_wait(tinv_ready_addr + (intermediate_stage_tcgen) * 8, (unsigned int)(cumulative_tcgen / 2 & 1));
+                    mbarrier_wait(y_inp_ready_addr, state_phase_tcgen);
+                    int _mma_b_lo_3 = make_warp_uniform(((((smem_tinv_mn_addr) >> 4) & 0x3FFF) | 0x200000) + (intermediate_stage_tcgen) * 64);
+                    mma_ts_step(tmem_tmem_u_acc, tmem_tmem_y_inp, _mma_b_lo_3, 0xC0004010, 134546576, 0);
+                    elect_commit2(tinv_done_addr + (intermediate_stage_tcgen) * 8, u_acc_ready_addr);
+                    mbarrier_wait(u_inp_ready_addr, state_phase_tcgen);
+                    int _mma_b_lo_4 = make_warp_uniform(((((smem_k_restore_mn_addr) >> 4) & 0x3FFF) | 0x800000) + (decay_stage_tcgen) * 256);
+                    mma_ts_step(tmem_tmem_state, tmem_tmem_u_inp, _mma_b_lo_4, 0x40004040, 136381584, 1);
+                    elect_commit2(k_restore_done_addr + (decay_stage_tcgen) * 8, state_acc_done_addr);
+                    mbarrier_wait(a_ready_addr + (intermediate_stage_tcgen) * 8, (unsigned int)(cumulative_tcgen / 2 & 1));
+                    int _mma_b_lo_5 = make_warp_uniform(((((smem_a_mn_addr) >> 4) & 0x3FFF) | 0x200000) + (intermediate_stage_tcgen) * 64);
+                    mma_ts_step((tmem_tmem_q_state + ((int)o_stage_tcgen * 16)), tmem_tmem_u_inp, _mma_b_lo_5, 0xC0004010, 134546576, 1);
+                    elect_commit2(o_acc_ready_addr, a_done_addr + (intermediate_stage_tcgen) * 8);
+                }
+                cumulative_chunk_tcgen += chunks_tcgen;
+            }
+            if (elect_sync()) {
+                mbarrier_arrive(consumers_done_addr);
+            }
+            unsigned int _phase_cleanup_ready_0 = 0;
+            mbarrier_wait(cleanup_ready_addr, _phase_cleanup_ready_0);
+            _phase_cleanup_ready_0 ^= 1;
+            int _tmem_dealloc_addr = *((volatile int*)tmem_addr_storage);
+            asm volatile("tcgen05.dealloc.cta_group::1.sync.aligned.b32 %0, %1;" :: "r"(_tmem_dealloc_addr), "r"(512));
+        }
+    }
+    // ---- Role: tma ----
+    if (warp == 14) {
+        { // tma_main
+            unsigned int sched_stage_tma = 0;
+            int cumulative_chunk_tma = 0;
+            unsigned int _phase_sched_done = 1;
+            if (elect_sync()) {
+                #pragma unroll 1
+                for (int sched_iter_tma = 0; sched_iter_tma < total_work_items + 1; sched_iter_tma++) {
+                    mbarrier_wait(sched_done_addr + (sched_stage_tma) * 8, _phase_sched_done);
+                    unsigned int tile_tma = blockIdx.x;
+                    if (uniform_work_items != 0) {
+                        tile_tma = (unsigned int)blockIdx.x + (unsigned int)sched_iter_tma * (unsigned int)gridDim.x;
+                    } else if (sched_iter_tma > 0) {
+                        unsigned int _atomic_old_0 = atomicAdd(dynamic_counter, 1);
+                        tile_tma = (unsigned int)gridDim.x + _atomic_old_0;
+                    }
+                    asm volatile("st.shared.b32 [%0], %1;" :: "r"(sched_slot_addr + sched_stage_tma * 4), "r"(tile_tma));
+                    mbarrier_arrive(sched_ready_addr + (sched_stage_tma) * 8);
+                    sched_stage_tma += 1;
+                    if (sched_stage_tma == 8) { sched_stage_tma = 0; _phase_sched_done ^= 1; }
+                    if (tile_tma >= (unsigned int)total_work_items) {
+                        break;
+                    }
+                    int item_base_tma = (int)tile_tma * 8;
+                    int _vec_load_0[4];
+                    {
+                        int4 _iv4 = *reinterpret_cast<const int4*>(work_items + item_base_tma);
+                        _vec_load_0[0 + 0] = _iv4.x;
+                        _vec_load_0[0 + 1] = _iv4.y;
+                        _vec_load_0[0 + 2] = _iv4.z;
+                        _vec_load_0[0 + 3] = _iv4.w;
+                    }
+                    int _vec_load_1[4];
+                    {
+                        int4 _iv4 = *reinterpret_cast<const int4*>(work_items + item_base_tma + 4);
+                        _vec_load_1[0 + 0] = _iv4.x;
+                        _vec_load_1[0 + 1] = _iv4.y;
+                        _vec_load_1[0 + 2] = _iv4.z;
+                        _vec_load_1[0 + 3] = _iv4.w;
+                    }
+                    int head_tma = _vec_load_0[1];
+                    int wend_tma = _vec_load_0[3];
+                    int cstart_tma = _vec_load_1[0];
+                    long long bos_tma = (long long)_vec_load_1[2];
+                    int chunks_tma = wend_tma - cstart_tma;
+                    #pragma unroll 1
+                    for (int chunk_tma = 0; chunk_tma < chunks_tma; chunk_tma++) {
+                        int cumulative_tma = cumulative_chunk_tma + chunk_tma;
+                        unsigned int raw_stage_tma = (unsigned int)(cumulative_tma % 5);
+                        unsigned int raw_bar_stage_tma = (unsigned int)(cumulative_tma % 6);
+                        unsigned int raw_done_phase_tma = (unsigned int)(cumulative_tma / 5 + 1 & 1);
+                        mbarrier_wait(q_done_addr + (raw_stage_tma) * 8, raw_done_phase_tma);
+                        mbarrier_wait(k_done_addr + (raw_stage_tma) * 8, raw_done_phase_tma);
+                        mbarrier_wait(v_done_addr + (raw_stage_tma) * 8, raw_done_phase_tma);
+                        mbarrier_wait(g_done_addr + (raw_stage_tma) * 8, raw_done_phase_tma);
+                        mbarrier_arrive_expect_tx(q_ready_addr + (raw_bar_stage_tma) * 8, 4096);
+                        mbarrier_arrive_expect_tx(k_ready_addr + (raw_bar_stage_tma) * 8, 4096);
+                        mbarrier_arrive_expect_tx(v_ready_addr + (raw_bar_stage_tma) * 8, 4096);
+                        {
+                            mbarrier_arrive(g_ready_addr + (raw_bar_stage_tma) * 8);
+                        }
+                        int logical_chunk_tma = cstart_tma + chunk_tma;
+                        int token_tma = (int)(bos_tma + (long long)logical_chunk_tma * 16);
+                        #pragma unroll
+                        for (int segment_tma = 0; segment_tma < 2; segment_tma++) {
+                            int segment_offset_tma = segment_tma * 16 * 64 * 2;
+                            int segment_dim_tma = segment_tma * 64;
+                            tma_3d_gmem2smem(smem_q_addr + raw_stage_tma * 4096 + (unsigned int)segment_offset_tma, q_tma, segment_dim_tma, head_tma, token_tma, q_ready_addr + (raw_bar_stage_tma) * 8);
+                            tma_3d_gmem2smem(smem_k_addr + raw_stage_tma * 4096 + (unsigned int)segment_offset_tma, k_tma, segment_dim_tma, head_tma, token_tma, k_ready_addr + (raw_bar_stage_tma) * 8);
+                            tma_3d_gmem2smem(smem_v_addr + raw_stage_tma * 4096 + (unsigned int)segment_offset_tma, v_tma, segment_dim_tma, head_tma, token_tma, v_ready_addr + (raw_bar_stage_tma) * 8);
+                        }
+                    }
+                    cumulative_chunk_tma += chunks_tma;
+                }
+            }
+            unsigned int _phase_consumers_done_0 = 0;
+            mbarrier_wait(consumers_done_addr, _phase_consumers_done_0);
+            _phase_consumers_done_0 ^= 1;
+            if (elect_sync()) {
+                mbarrier_arrive(cleanup_ready_addr);
+            }
+        }
+    }
+    // ---- Role: epilogue ----
+    if (warp == 15) {
+        { // epilogue_main
+            unsigned int sched_stage_epi = 0;
+            int cumulative_chunk_epi = 0;
+            int lhs_row_epi = lane % 8 + (lane / 8 & 1) * 8;
+            int lhs_col_epi = lane / 16 * 8;
+            int rhs_row_epi = lane % 8 + lane / 16 * 8;
+            int rhs_col_epi = (lane / 8 & 1) * 8;
+            unsigned int _phase_sched_ready_4 = 0;
+            #pragma unroll 1
+            for (int __4 = 0; __4 < total_work_items + 1; __4++) {
+                mbarrier_wait(sched_ready_addr + (sched_stage_epi) * 8, _phase_sched_ready_4);
+                unsigned int slot_4[1];
+                asm volatile("ld.shared.b32 %0, [%1];" : "=r"(*reinterpret_cast<uint32_t*>(&slot_4[0])) : "r"(sched_slot_addr + sched_stage_epi * 4));
+                unsigned int tile_epi = slot_4[0];
+                if (elect_sync()) {
+                    mbarrier_arrive(sched_done_addr + (sched_stage_epi) * 8);
+                }
+                sched_stage_epi += 1;
+                if (sched_stage_epi == 8) { sched_stage_epi = 0; _phase_sched_ready_4 ^= 1; }
+                if (tile_epi >= (unsigned int)total_work_items) {
+                    break;
+                }
+                int item_base_epi = (int)tile_epi * 8;
+                int _vec_load_3[4];
+                {
+                    int4 _iv4 = *reinterpret_cast<const int4*>(work_items + item_base_epi);
+                    _vec_load_3[0 + 0] = _iv4.x;
+                    _vec_load_3[0 + 1] = _iv4.y;
+                    _vec_load_3[0 + 2] = _iv4.z;
+                    _vec_load_3[0 + 3] = _iv4.w;
+                }
+                int seq_epi = _vec_load_3[0];
+                int head_epi = _vec_load_3[1];
+                int wstart_epi = _vec_load_3[2];
+                int wend_epi = _vec_load_3[3];
+                int cstart_epi = work_items[item_base_epi + 4];
+                long long bos_epi = (long long)work_items[item_base_epi + 6];
+                int chunks_epi = wend_epi - cstart_epi;
+                long long checkpoint_base_epi = checkpoint_cu_starts[seq_epi];
+                if (ENABLE_CHECKPOINTS != 0 && chunks_epi > 0 && wstart_epi == 0) {
+                    int checkpoint_event_epi = cumulative_chunk_epi;
+                    unsigned int checkpoint_stage_epi = (unsigned int)(checkpoint_event_epi % 2);
+                    mbarrier_wait(checkpoint_ready_addr + (checkpoint_stage_epi) * 8, (unsigned int)(checkpoint_event_epi / 2 & 1));
+                    if (elect_sync()) {
+                        #pragma unroll
+                        for (int segment_checkpoint_epi = 0; segment_checkpoint_epi < 2; segment_checkpoint_epi++) {
+                            tma_store_4d(checkpoint_tma, segment_checkpoint_epi * 64, 0, head_epi, checkpoint_base_epi, smem_checkpoint_addr + checkpoint_stage_epi * 32768 + (unsigned int)(segment_checkpoint_epi * 128 * 64 * 2));
+                        }
+                    }
+                    asm volatile("cp.async.bulk.commit_group;");
+                    asm volatile("cp.async.bulk.wait_group.read 0;");
+                    mbarrier_arrive(checkpoint_done_addr + (checkpoint_stage_epi) * 8);
+                }
+                #pragma unroll 1
+                for (int chunk_epi = 0; chunk_epi < chunks_epi; chunk_epi++) {
+                    int cumulative_epi = cumulative_chunk_epi + chunk_epi;
+                    int logical_chunk_epi = cstart_epi + chunk_epi;
+                    unsigned int decay_stage_epi = (unsigned int)(cumulative_epi % 2);
+                    unsigned int diag_stage_epi = (unsigned int)(cumulative_epi % 4);
+                    unsigned int intermediate_stage_epi = (unsigned int)(cumulative_epi % 2);
+                    mbarrier_wait(qk_scale_ready_addr + (diag_stage_epi) * 8, (unsigned int)(cumulative_epi / 4 & 1));
+                    mbarrier_wait(a_done_addr + (intermediate_stage_epi) * 8, (unsigned int)(cumulative_epi / 2 + 1 & 1));
+                    float a_acc_epi[8];
+                    #pragma unroll
+                    for (int k_block_epi = 0; k_block_epi < 8; k_block_epi++) {
+                        unsigned int a_frag_epi[4];
+                        unsigned int b_frag_epi[4];
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(a_frag_epi[0]), "=r"(a_frag_epi[1]), "=r"(a_frag_epi[2]), "=r"(a_frag_epi[3])
+                            : "r"((smem_q_decay_addr + decay_stage_epi * 4096 + (unsigned int)((k_block_epi * 16 + lhs_col_epi) / 64 * 2048 + lhs_row_epi * 128 + (k_block_epi * 16 + lhs_col_epi) % 64 * 2 ^ ((k_block_epi * 16 + lhs_col_epi) / 64 * 2048 + lhs_row_epi * 128 + (k_block_epi * 16 + lhs_col_epi) % 64 * 2 >> 7 & 7) << 4)))
+                            : "memory");
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(b_frag_epi[0]), "=r"(b_frag_epi[1]), "=r"(b_frag_epi[2]), "=r"(b_frag_epi[3])
+                            : "r"((smem_k_inv_addr + decay_stage_epi * 4096 + (unsigned int)((k_block_epi * 16 + rhs_col_epi) / 64 * 2048 + rhs_row_epi * 128 + (k_block_epi * 16 + rhs_col_epi) % 64 * 2 ^ ((k_block_epi * 16 + rhs_col_epi) / 64 * 2048 + rhs_row_epi * 128 + (k_block_epi * 16 + rhs_col_epi) % 64 * 2 >> 7 & 7) << 4)))
+                            : "memory");
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%10, %11, %12, %13};\n"
+                            : "=f"(a_acc_epi[0]), "=f"(a_acc_epi[1]), "=f"(a_acc_epi[2]), "=f"(a_acc_epi[3])
+                            : "r"(a_frag_epi[0]), "r"(a_frag_epi[1]), "r"(a_frag_epi[2]), "r"(a_frag_epi[3]), "r"(b_frag_epi[0]), "r"(b_frag_epi[1]), "f"(((k_block_epi == 0) ? 0.0f : a_acc_epi[0])), "f"(((k_block_epi == 0) ? 0.0f : a_acc_epi[1])), "f"(((k_block_epi == 0) ? 0.0f : a_acc_epi[2])), "f"(((k_block_epi == 0) ? 0.0f : a_acc_epi[3])));
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%10, %11, %12, %13};\n"
+                            : "=f"(a_acc_epi[4]), "=f"(a_acc_epi[(4) + 1]), "=f"(a_acc_epi[(4) + 2]), "=f"(a_acc_epi[(4) + 3])
+                            : "r"(a_frag_epi[0]), "r"(a_frag_epi[1]), "r"(a_frag_epi[2]), "r"(a_frag_epi[3]), "r"(b_frag_epi[2]), "r"(b_frag_epi[(2) + 1]), "f"(((k_block_epi == 0) ? 0.0f : a_acc_epi[4])), "f"(((k_block_epi == 0) ? 0.0f : a_acc_epi[(4) + 1])), "f"(((k_block_epi == 0) ? 0.0f : a_acc_epi[(4) + 2])), "f"(((k_block_epi == 0) ? 0.0f : a_acc_epi[(4) + 3])));
+                    }
+                    float a_values_epi[8];
+                    #pragma unroll
+                    for (int accum_epi = 0; accum_epi < 8; accum_epi++) {
+                        int row_epi = lane / 4 + accum_epi % 4 / 2 * 8;
+                        int col_epi = accum_epi / 4 * 8 + (lane & 3) * 2 + (accum_epi & 1);
+                        a_values_epi[accum_epi] = 0.0f;
+                        if (row_epi >= col_epi) {
+                            a_values_epi[accum_epi] = a_acc_epi[accum_epi];
+                        }
+                    }
+                    unsigned int a_words_epi[4];
+                    #pragma unroll
+                    for (int _lp = 0; _lp < 4; _lp++) {
+                        __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(a_values_epi[_lp*2 + 0], a_values_epi[_lp*2+1 + 0]));
+                        a_words_epi[_lp] = *(uint32_t*)&_bf2;
+                    }
+                    uint32_t _stmatrix_addr_0 = static_cast<uint32_t>((unsigned long long)(smem_a_addr + intermediate_stage_epi * 1024 + (unsigned int)(lane / 16 * 8 / 16 * 512 + lane % 16 * 32 + lane / 16 * 8 % 16 * 2 ^ (lane / 16 * 8 / 16 * 512 + lane % 16 * 32 + lane / 16 * 8 % 16 * 2 >> 7 & 1) << 4)));
+                    asm volatile("stmatrix.sync.aligned.m8n8.x4.shared.b16 [%0], {%1, %2, %3, %4};\n"
+                        :: "r"(_stmatrix_addr_0), "r"(*reinterpret_cast<const uint32_t*>(&a_words_epi[0])), "r"(*reinterpret_cast<const uint32_t*>(&a_words_epi[1])), "r"(*reinterpret_cast<const uint32_t*>(&a_words_epi[2])), "r"(*reinterpret_cast<const uint32_t*>(&a_words_epi[3]))
+                        : "memory");
+                    asm volatile("fence.proxy.async.shared::cta;" ::: "memory");
+                    mbarrier_arrive(a_ready_addr + (intermediate_stage_epi) * 8);
+                    mbarrier_arrive(decay_super_done_addr + (decay_stage_epi) * 8);
+                    if (chunk_epi > 0) {
+                        {
+                            int checkpoint_event_loop_epi = cumulative_epi;
+                            unsigned int checkpoint_stage_loop_epi = (unsigned int)(checkpoint_event_loop_epi % 2);
+                            mbarrier_wait(checkpoint_ready_addr + (checkpoint_stage_loop_epi) * 8, (unsigned int)(checkpoint_event_loop_epi / 2 & 1));
+                            if (elect_sync()) {
+                                #pragma unroll
+                                for (int checkpoint_segment_loop_epi = 0; checkpoint_segment_loop_epi < 2; checkpoint_segment_loop_epi++) {
+                                    tma_store_4d(checkpoint_tma, checkpoint_segment_loop_epi * 64, 0, head_epi, checkpoint_base_epi + (long long)logical_chunk_epi, smem_checkpoint_addr + checkpoint_stage_loop_epi * 32768 + (unsigned int)(checkpoint_segment_loop_epi * 128 * 64 * 2));
+                                }
+                            }
+                            asm volatile("cp.async.bulk.commit_group;");
+                            asm volatile("cp.async.bulk.wait_group.read 0;");
+                            mbarrier_arrive(checkpoint_done_addr + (checkpoint_stage_loop_epi) * 8);
+                        }
+                        int output_event_epi = cumulative_epi - 1;
+                        unsigned int output_stage_epi = (unsigned int)(output_event_epi % 2);
+                        mbarrier_wait(o_tma_ready_addr + (output_stage_epi) * 8, (unsigned int)(output_event_epi / 2 & 1));
+                        if (elect_sync()) {
+                            #pragma unroll
+                            for (int output_segment_epi = 0; output_segment_epi < 2; output_segment_epi++) {
+                                tma_store_3d(out_tma, output_segment_epi * 64, head_epi, (int)(bos_epi + (long long)(logical_chunk_epi - 1) * 16), smem_o_addr + output_stage_epi * 4096 + (unsigned int)(output_segment_epi * 16 * 64 * 2));
+                            }
+                        }
+                        asm volatile("cp.async.bulk.commit_group;");
+                        asm volatile("cp.async.bulk.wait_group.read 0;");
+                        mbarrier_arrive(o_tma_done_addr + (output_stage_epi) * 8);
+                    }
+                }
+                if (chunks_epi > 0) {
+                    int last_event_epi = cumulative_chunk_epi + chunks_epi - 1;
+                    unsigned int last_o_stage_epi = (unsigned int)(last_event_epi % 2);
+                    mbarrier_wait(o_tma_ready_addr + (last_o_stage_epi) * 8, (unsigned int)(last_event_epi / 2 & 1));
+                    if (elect_sync()) {
+                        #pragma unroll
+                        for (int last_segment_epi = 0; last_segment_epi < 2; last_segment_epi++) {
+                            tma_store_3d(out_tma, last_segment_epi * 64, head_epi, (int)(bos_epi + (long long)(wend_epi - 1) * 16), smem_o_addr + last_o_stage_epi * 4096 + (unsigned int)(last_segment_epi * 16 * 64 * 2));
+                        }
+                    }
+                    asm volatile("cp.async.bulk.commit_group;");
+                    asm volatile("cp.async.bulk.wait_group.read 0;");
+                    mbarrier_arrive(o_tma_done_addr + (last_o_stage_epi) * 8);
+                }
+                cumulative_chunk_epi += chunks_epi;
+            }
+            if (elect_sync()) {
+                mbarrier_arrive(consumers_done_addr);
+            }
+        }
+    }
+
+    // Cleanup
+}
+
+} // extern "C"
+
+// clang-format on

--- a/csrc/kda/flashkda_training_forward_v483_binding.cu
+++ b/csrc/kda/flashkda_training_forward_v483_binding.cu
@@ -1,0 +1,214 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+#include "flashkda_binding_common.cuh"
+
+extern "C" __global__ void kernel_flashkda_forward_checkpoint_c16(
+    unsigned int*, const __grid_constant__ CUtensorMap, const __grid_constant__ CUtensorMap,
+    const __grid_constant__ CUtensorMap, const __grid_constant__ CUtensorMap, __nv_bfloat16*,
+    const __grid_constant__ CUtensorMap, const __grid_constant__ CUtensorMap, __nv_bfloat16*,
+    __nv_bfloat16*, float*, float*, long long*, long long*, int*, float*, __nv_bfloat16*, int, int,
+    int, int, int, int, float, float);
+
+namespace flashinfer {
+namespace flash_kda_training {
+
+using flash_kda::CheckCuda;
+using flash_kda::CheckCudaTensor;
+using flash_kda::CheckDtype;
+using flash_kda::CheckDynamicSmemCapacity;
+using flash_kda::CheckFlashKDATarget;
+
+constexpr int64_t kTokens = 8192;
+constexpr int64_t kSequences = 8;
+constexpr int64_t kHeads = 96;
+constexpr int64_t kHeadDim = 128;
+constexpr int64_t kChunks = 512;
+constexpr int64_t kWorkItems = kSequences * kHeads;
+constexpr size_t kTensorMapCount = 6;
+constexpr size_t kDescriptorBytes = kTensorMapCount * sizeof(CUtensorMap);
+constexpr int32_t kSmemBytes = 230016;
+
+inline void CheckTensor(const TensorView& tensor, const char* name, int32_t device_id,
+                        DLDataType dtype) {
+  CheckCudaTensor(tensor, name, device_id);
+  CheckDtype(tensor, name, dtype);
+}
+
+inline void CheckNumel(const TensorView& tensor, const char* name, int64_t numel) {
+  TVM_FFI_ICHECK(tensor.numel() == numel) << name << " must contain " << numel << " elements";
+}
+
+inline CUtensorMap EncodeTokenTensor(const TensorView& tensor, const char* name) {
+  uint64_t global_dim[3] = {kHeadDim, kHeads, kTokens};
+  uint64_t global_strides[2] = {kHeadDim * sizeof(__nv_bfloat16),
+                                kHeadDim * kHeads * sizeof(__nv_bfloat16)};
+  uint32_t box_dim[3] = {64, 1, 16};
+  uint32_t elem_strides[3] = {1, 1, 1};
+  CUtensorMap map{};
+  const CUresult result = cuTensorMapEncodeTiled(
+      &map, CU_TENSOR_MAP_DATA_TYPE_BFLOAT16, 3, tensor.data_ptr(), global_dim, global_strides,
+      box_dim, elem_strides, CU_TENSOR_MAP_INTERLEAVE_NONE, CU_TENSOR_MAP_SWIZZLE_128B,
+      CU_TENSOR_MAP_L2_PROMOTION_NONE, CU_TENSOR_MAP_FLOAT_OOB_FILL_NONE);
+  TVM_FFI_ICHECK(result == CUDA_SUCCESS)
+      << "cuTensorMapEncodeTiled failed for " << name << " with CUresult=" << int(result);
+  return map;
+}
+
+inline CUtensorMap EncodeCheckpointTensor(const TensorView& tensor) {
+  uint64_t global_dim[4] = {kHeadDim, kHeadDim, kHeads, kChunks};
+  uint64_t global_strides[3] = {kHeadDim * sizeof(__nv_bfloat16),
+                                kHeadDim * kHeadDim * sizeof(__nv_bfloat16),
+                                kHeadDim * kHeadDim * kHeads * sizeof(__nv_bfloat16)};
+  uint32_t box_dim[4] = {64, 128, 1, 1};
+  uint32_t elem_strides[4] = {1, 1, 1, 1};
+  CUtensorMap map{};
+  const CUresult result = cuTensorMapEncodeTiled(
+      &map, CU_TENSOR_MAP_DATA_TYPE_BFLOAT16, 4, tensor.data_ptr(), global_dim, global_strides,
+      box_dim, elem_strides, CU_TENSOR_MAP_INTERLEAVE_NONE, CU_TENSOR_MAP_SWIZZLE_128B,
+      CU_TENSOR_MAP_L2_PROMOTION_NONE, CU_TENSOR_MAP_FLOAT_OOB_FILL_NONE);
+  TVM_FFI_ICHECK(result == CUDA_SUCCESS)
+      << "cuTensorMapEncodeTiled failed for checkpoints with CUresult=" << int(result);
+  return map;
+}
+
+struct TensorMapWords {
+  uint64_t words[kDescriptorBytes / sizeof(uint64_t)];
+};
+
+static __global__ void PublishTensorMaps(uint64_t* destination, TensorMapWords source) {
+  if (threadIdx.x < kDescriptorBytes / sizeof(uint64_t)) {
+    destination[threadIdx.x] = source.words[threadIdx.x];
+  }
+}
+
+static __global__ void CastFinalState(const __nv_bfloat16* source, float* destination,
+                                      int64_t count) {
+  const int64_t index = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  if (index < count) {
+    destination[index] = static_cast<float>(source[index]);
+  }
+}
+
+void RunForward(TensorView q, TensorView k, TensorView v, TensorView g, TensorView beta,
+                TensorView A_log, TensorView dt_bias, TensorView initial_state,
+                TensorView cu_seqlens, TensorView checkpoint_cu_starts, TensorView work_items,
+                TensorView descriptor_storage, TensorView out, TensorView final_state_bf16,
+                TensorView final_state, TensorView state_checkpoints, TensorView beta_active,
+                TensorView counter, int64_t prepare_descriptors, int64_t num_sequences,
+                int64_t num_heads, double scale, double lower_bound, int64_t cuda_stream) {
+  TVM_FFI_ICHECK(q.device().device_type == kDLCUDA) << "q must be a CUDA tensor";
+  const int32_t device_id = q.device().device_id;
+  ffi::CUDADeviceGuard device_guard(device_id);
+  CheckFlashKDATarget(device_id);
+  TVM_FFI_ICHECK(num_sequences == kSequences && num_heads == kHeads)
+      << "the training forward requires eight sequences and 96 heads";
+  TVM_FFI_ICHECK(prepare_descriptors == 0 || prepare_descriptors == 1);
+  TVM_FFI_ICHECK(std::abs(scale - 1.0 / std::sqrt(128.0)) <= 1e-15)
+      << "the training forward fixes scale=1/sqrt(128)";
+  TVM_FFI_ICHECK(lower_bound == -5.0) << "the training forward fixes lower_bound=-5.0";
+
+  for (const auto& named : std::initializer_list<std::pair<TensorView*, const char*>>{
+           {&q, "q"},
+           {&k, "k"},
+           {&v, "v"},
+           {&g, "g"},
+           {&beta, "beta"},
+           {&out, "out"},
+           {&final_state_bf16, "final_state_bf16"},
+           {&state_checkpoints, "state_checkpoints"},
+           {&beta_active, "beta_active"}}) {
+    CheckTensor(*named.first, named.second, device_id, dl_bfloat16);
+  }
+  for (const auto& named :
+       std::initializer_list<std::pair<TensorView*, const char*>>{{&A_log, "A_log"},
+                                                                  {&dt_bias, "dt_bias"},
+                                                                  {&initial_state, "initial_state"},
+                                                                  {&final_state, "final_state"}}) {
+    CheckTensor(*named.first, named.second, device_id, dl_float32);
+  }
+  CheckTensor(cu_seqlens, "cu_seqlens", device_id, dl_int64);
+  CheckTensor(checkpoint_cu_starts, "checkpoint_cu_starts", device_id, dl_int64);
+  CheckTensor(work_items, "work_items", device_id, dl_int32);
+  CheckTensor(descriptor_storage, "descriptor_storage", device_id, dl_uint8);
+  CheckTensor(counter, "counter", device_id, dl_uint32);
+  CheckNumel(q, "q", kTokens * kHeads * kHeadDim);
+  CheckNumel(beta, "beta", kTokens * kHeads);
+  CheckNumel(initial_state, "initial_state", kSequences * kHeads * kHeadDim * kHeadDim);
+  CheckNumel(final_state_bf16, "final_state_bf16", kSequences * kHeads * kHeadDim * kHeadDim);
+  CheckNumel(final_state, "final_state", kSequences * kHeads * kHeadDim * kHeadDim);
+  CheckNumel(state_checkpoints, "state_checkpoints", kChunks * kHeads * kHeadDim * kHeadDim);
+  CheckNumel(beta_active, "beta_active", kTokens * kHeads);
+  CheckNumel(work_items, "work_items", kWorkItems * 8);
+  TVM_FFI_ICHECK(descriptor_storage.numel() >= static_cast<int64_t>(kDescriptorBytes));
+  TVM_FFI_ICHECK(reinterpret_cast<uintptr_t>(descriptor_storage.data_ptr()) % 64 == 0);
+
+  const cudaStream_t stream = reinterpret_cast<cudaStream_t>(static_cast<uintptr_t>(cuda_stream));
+  if (prepare_descriptors != 0) {
+    cudaStreamCaptureStatus capture_status = cudaStreamCaptureStatusNone;
+    CheckCuda(cudaStreamIsCapturing(stream, &capture_status), "cudaStreamIsCapturing");
+    TVM_FFI_ICHECK(capture_status == cudaStreamCaptureStatusNone)
+        << "training-forward descriptors must be warmed before CUDA graph "
+           "capture";
+    const std::array<CUtensorMap, kTensorMapCount> maps = {
+        EncodeTokenTensor(q, "q"),     EncodeTokenTensor(k, "k"),
+        EncodeTokenTensor(v, "v"),     EncodeTokenTensor(g, "g"),
+        EncodeTokenTensor(out, "out"), EncodeCheckpointTensor(state_checkpoints),
+    };
+    TensorMapWords words{};
+    std::memcpy(words.words, maps.data(), sizeof(maps));
+    PublishTensorMaps<<<1, kDescriptorBytes / sizeof(uint64_t), 0, stream>>>(
+        reinterpret_cast<uint64_t*>(descriptor_storage.data_ptr()), words);
+    CheckCuda(cudaGetLastError(), "PublishTensorMaps launch");
+  }
+  auto* descriptor_bytes = static_cast<unsigned char*>(descriptor_storage.data_ptr());
+  constexpr size_t stride = sizeof(CUtensorMap);
+  int resident_ctas = 0;
+  CheckCuda(cudaDeviceGetAttribute(&resident_ctas, cudaDevAttrMultiProcessorCount, device_id),
+            "cudaDeviceGetAttribute(multiProcessorCount)");
+  const dim3 grid(std::min<int64_t>(kWorkItems, resident_ctas), 1, 1);
+  CheckDynamicSmemCapacity(device_id, kSmemBytes);
+  CheckCuda(cudaFuncSetAttribute(kernel_flashkda_forward_checkpoint_c16,
+                                 cudaFuncAttributeMaxDynamicSharedMemorySize, kSmemBytes),
+            "cudaFuncSetAttribute(training forward)");
+  kernel_flashkda_forward_checkpoint_c16<<<grid, 512, kSmemBytes, stream>>>(
+      reinterpret_cast<unsigned int*>(counter.data_ptr()),
+      *reinterpret_cast<CUtensorMap const*>(descriptor_bytes + 0 * stride),
+      *reinterpret_cast<CUtensorMap const*>(descriptor_bytes + 1 * stride),
+      *reinterpret_cast<CUtensorMap const*>(descriptor_bytes + 2 * stride),
+      *reinterpret_cast<CUtensorMap const*>(descriptor_bytes + 3 * stride),
+      reinterpret_cast<__nv_bfloat16*>(g.data_ptr()),
+      *reinterpret_cast<CUtensorMap const*>(descriptor_bytes + 4 * stride),
+      *reinterpret_cast<CUtensorMap const*>(descriptor_bytes + 5 * stride),
+      reinterpret_cast<__nv_bfloat16*>(beta.data_ptr()),
+      reinterpret_cast<__nv_bfloat16*>(beta_active.data_ptr()),
+      reinterpret_cast<float*>(A_log.data_ptr()), reinterpret_cast<float*>(dt_bias.data_ptr()),
+      reinterpret_cast<long long*>(cu_seqlens.data_ptr()),
+      reinterpret_cast<long long*>(checkpoint_cu_starts.data_ptr()),
+      reinterpret_cast<int*>(work_items.data_ptr()),
+      reinterpret_cast<float*>(initial_state.data_ptr()),
+      reinterpret_cast<__nv_bfloat16*>(final_state_bf16.data_ptr()), kWorkItems, 1, kHeads, kHeads,
+      kHeads, 16, static_cast<float>(scale), static_cast<float>(lower_bound));
+  CheckCuda(cudaGetLastError(), "training forward launch");
+
+  constexpr int32_t kCastThreads = 256;
+  const int64_t final_count = final_state.numel();
+  const uint32_t cast_blocks =
+      static_cast<uint32_t>((final_count + kCastThreads - 1) / kCastThreads);
+  CastFinalState<<<cast_blocks, kCastThreads, 0, stream>>>(
+      reinterpret_cast<__nv_bfloat16*>(final_state_bf16.data_ptr()),
+      reinterpret_cast<float*>(final_state.data_ptr()), final_count);
+  CheckCuda(cudaGetLastError(), "training final-state cast launch");
+}
+
+}  // namespace flash_kda_training
+}  // namespace flashinfer
+
+TVM_FFI_DLL_EXPORT_TYPED_FUNC(run_forward, flashinfer::flash_kda_training::RunForward);

--- a/csrc/kda/flashkda_training_paired_binding.cu
+++ b/csrc/kda/flashkda_training_paired_binding.cu
@@ -1,0 +1,572 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+#include "flashkda_binding_common.cuh"
+
+struct alignas(128) FlashKDATrainingTensorMap {
+  uint64_t opaque[16];
+};
+
+extern "C" {
+
+__global__ void kernel_flashkda_forward_checkpoint_c16(
+    unsigned int*, const __grid_constant__ CUtensorMap, const __grid_constant__ CUtensorMap,
+    const __grid_constant__ CUtensorMap, const __grid_constant__ CUtensorMap, __nv_bfloat16*,
+    const __grid_constant__ CUtensorMap, const __grid_constant__ CUtensorMap, __nv_bfloat16*,
+    __nv_bfloat16*, float*, float*, long long*, long long*, int*, float*, __nv_bfloat16*, int, int,
+    int, int, int, int, float, float);
+
+__global__ void kernel_flashkda_backward_persistent_c16(
+    unsigned int*, const __grid_constant__ CUtensorMap, const __grid_constant__ CUtensorMap,
+    const __grid_constant__ CUtensorMap, const __grid_constant__ CUtensorMap,
+    const __grid_constant__ CUtensorMap, const __grid_constant__ CUtensorMap, float*,
+    const __grid_constant__ CUtensorMap, __nv_bfloat16*, __nv_bfloat16*, float*, float*, float*,
+    float*, float*, const __grid_constant__ CUtensorMap, float*, long long*, long long*, int*,
+    unsigned int*, float*, float*, float*, float*, float*, float*, float*, float*, float*, float*,
+    float*, float*, float*, float*, int, int, int, int, int, int, int, float, float);
+
+__global__ void kernel_flashkda_refine_forgetting_horizons(__nv_bfloat16*, float*, float*, int*,
+                                                           int*, unsigned int*, int, float, float);
+
+__global__ void kernel_flashkda_backward_param_reduce_c16_partial(
+    __nv_bfloat16*, __nv_bfloat16*, float*, float*, float*, float*, float*, __nv_bfloat16*,
+    __nv_bfloat16*, float*, float*, unsigned int*, float*, float*, int, int, int, int, float);
+
+__global__ void kernel_flashkda_grouped_qk_reduce(__nv_bfloat16*, __nv_bfloat16*, __nv_bfloat16*,
+                                                  __nv_bfloat16*, int, int, int);
+
+__global__ void kernel_flashkda_blackwell_prefill_fp32_state_initial(
+    const FlashKDATrainingTensorMap*, const FlashKDATrainingTensorMap*,
+    const FlashKDATrainingTensorMap*, const FlashKDATrainingTensorMap*,
+    const FlashKDATrainingTensorMap*, __nv_bfloat16*, float*, float*, long long*, float*, float*,
+    float*, int*, uint8_t*, int, float, int, int, int, int, float);
+
+}  // extern "C"
+
+namespace flashinfer {
+namespace flash_kda_training_paired {
+
+using flash_kda::CheckCuda;
+using flash_kda::CheckCudaTensor;
+using flash_kda::CheckDtype;
+using flash_kda::CheckDynamicSmemCapacity;
+using flash_kda::CheckFlashKDATarget;
+
+constexpr int64_t kHeadDim = 128;
+constexpr int64_t kChunk = 16;
+constexpr int32_t kForwardSmemBytes = 230016;
+constexpr int32_t kBackwardSmemBytes = 230400;
+constexpr int32_t kRefineSmemBytes = 128;
+constexpr int32_t kReduceSmemBytes = 4224;
+constexpr int32_t kFinalSmemBytes = 226048;
+constexpr float kDefaultLog2Threshold = -14.426950408889635f;
+constexpr int64_t kFinalDescriptorCount = 5;
+constexpr int64_t kFinalDescriptorBytes = kFinalDescriptorCount * sizeof(CUtensorMap);
+constexpr int64_t kFinalWorkspaceBytesPerCta = 10 * 128;
+
+inline void CheckTensor(const TensorView& tensor, const char* name, int32_t device_id,
+                        DLDataType dtype) {
+  CheckCudaTensor(tensor, name, device_id);
+  CheckDtype(tensor, name, dtype);
+}
+
+inline void CheckElements(const TensorView& tensor, const char* name, int64_t elements) {
+  TVM_FFI_ICHECK(tensor.numel() == elements)
+      << name << " must contain " << elements << " elements, got " << tensor.numel();
+}
+
+inline CUtensorMap EncodeTokenMap(const TensorView& tensor, const char* name, int64_t total_tokens,
+                                  int64_t num_heads) {
+  uint64_t global_dim[3] = {kHeadDim, static_cast<uint64_t>(num_heads),
+                            static_cast<uint64_t>(total_tokens)};
+  uint64_t global_strides[2] = {
+      kHeadDim * sizeof(__nv_bfloat16),
+      kHeadDim * static_cast<uint64_t>(num_heads) * sizeof(__nv_bfloat16)};
+  uint32_t box_dim[3] = {64, 1, kChunk};
+  uint32_t element_strides[3] = {1, 1, 1};
+  CUtensorMap map{};
+  const CUresult result = cuTensorMapEncodeTiled(
+      &map, CU_TENSOR_MAP_DATA_TYPE_BFLOAT16, 3, tensor.data_ptr(), global_dim, global_strides,
+      box_dim, element_strides, CU_TENSOR_MAP_INTERLEAVE_NONE, CU_TENSOR_MAP_SWIZZLE_128B,
+      CU_TENSOR_MAP_L2_PROMOTION_NONE, CU_TENSOR_MAP_FLOAT_OOB_FILL_NONE);
+  TVM_FFI_ICHECK(result == CUDA_SUCCESS)
+      << "cuTensorMapEncodeTiled failed for " << name << " with CUresult=" << int(result);
+  return map;
+}
+
+inline CUtensorMap EncodeCheckpointMap(const TensorView& tensor, int64_t total_chunks,
+                                       int64_t num_heads) {
+  uint64_t global_dim[4] = {kHeadDim, kHeadDim, static_cast<uint64_t>(num_heads),
+                            static_cast<uint64_t>(total_chunks)};
+  uint64_t global_strides[3] = {
+      kHeadDim * sizeof(__nv_bfloat16), kHeadDim * kHeadDim * sizeof(__nv_bfloat16),
+      kHeadDim * kHeadDim * static_cast<uint64_t>(num_heads) * sizeof(__nv_bfloat16)};
+  uint32_t box_dim[4] = {64, kHeadDim, 1, 1};
+  uint32_t element_strides[4] = {1, 1, 1, 1};
+  CUtensorMap map{};
+  const CUresult result = cuTensorMapEncodeTiled(
+      &map, CU_TENSOR_MAP_DATA_TYPE_BFLOAT16, 4, tensor.data_ptr(), global_dim, global_strides,
+      box_dim, element_strides, CU_TENSOR_MAP_INTERLEAVE_NONE, CU_TENSOR_MAP_SWIZZLE_128B,
+      CU_TENSOR_MAP_L2_PROMOTION_NONE, CU_TENSOR_MAP_FLOAT_OOB_FILL_NONE);
+  TVM_FFI_ICHECK(result == CUDA_SUCCESS)
+      << "cuTensorMapEncodeTiled failed for state checkpoints with CUresult=" << int(result);
+  return map;
+}
+
+inline CUtensorMap EncodeBetaMap(const TensorView& tensor, int64_t total_tokens,
+                                 int64_t beta_stride) {
+  uint64_t global_dim[2] = {static_cast<uint64_t>(beta_stride),
+                            static_cast<uint64_t>(total_tokens)};
+  uint64_t global_strides[1] = {static_cast<uint64_t>(beta_stride) * sizeof(__nv_bfloat16)};
+  uint32_t box_dim[2] = {8, kChunk};
+  uint32_t element_strides[2] = {1, 1};
+  CUtensorMap map{};
+  const CUresult result = cuTensorMapEncodeTiled(
+      &map, CU_TENSOR_MAP_DATA_TYPE_BFLOAT16, 2, tensor.data_ptr(), global_dim, global_strides,
+      box_dim, element_strides, CU_TENSOR_MAP_INTERLEAVE_NONE, CU_TENSOR_MAP_SWIZZLE_NONE,
+      CU_TENSOR_MAP_L2_PROMOTION_NONE, CU_TENSOR_MAP_FLOAT_OOB_FILL_NONE);
+  TVM_FFI_ICHECK(result == CUDA_SUCCESS)
+      << "cuTensorMapEncodeTiled failed for beta_active with CUresult=" << int(result);
+  return map;
+}
+
+inline CUtensorMap EncodeFinalMap(const TensorView& tensor, const char* name, int64_t total_tokens,
+                                  int64_t num_heads) {
+  uint64_t global_dim[3] = {kHeadDim, static_cast<uint64_t>(total_tokens),
+                            static_cast<uint64_t>(num_heads)};
+  uint64_t global_strides[2] = {kHeadDim * static_cast<uint64_t>(num_heads) * sizeof(__nv_bfloat16),
+                                kHeadDim * sizeof(__nv_bfloat16)};
+  uint32_t box_dim[3] = {64, 64, 1};
+  uint32_t element_strides[3] = {1, 1, 1};
+  CUtensorMap map{};
+  const CUresult result = cuTensorMapEncodeTiled(
+      &map, CU_TENSOR_MAP_DATA_TYPE_BFLOAT16, 3, tensor.data_ptr(), global_dim, global_strides,
+      box_dim, element_strides, CU_TENSOR_MAP_INTERLEAVE_NONE, CU_TENSOR_MAP_SWIZZLE_128B,
+      CU_TENSOR_MAP_L2_PROMOTION_L2_256B, CU_TENSOR_MAP_FLOAT_OOB_FILL_NONE);
+  TVM_FFI_ICHECK(result == CUDA_SUCCESS)
+      << "cuTensorMapEncodeTiled failed for " << name << " with CUresult=" << int(result);
+  return map;
+}
+
+struct FinalTensorMapWords {
+  uint64_t words[kFinalDescriptorBytes / sizeof(uint64_t)];
+};
+
+static __global__ void PublishFinalTensorMaps(uint64_t* destination, FinalTensorMapWords source) {
+  if (threadIdx.x < kFinalDescriptorBytes / sizeof(uint64_t)) {
+    destination[threadIdx.x] = source.words[threadIdx.x];
+  }
+}
+
+inline void PrepareFinalTensorMaps(const TensorView& q, const TensorView& k, const TensorView& v,
+                                   const TensorView& g, const TensorView& out,
+                                   const TensorView& descriptor_storage, int64_t total_tokens,
+                                   int64_t num_qk_heads, int64_t num_v_heads,
+                                   int64_t prepare_descriptors, cudaStream_t stream) {
+  if (prepare_descriptors == 0) {
+    return;
+  }
+  cudaStreamCaptureStatus capture_status = cudaStreamCaptureStatusNone;
+  CheckCuda(cudaStreamIsCapturing(stream, &capture_status), "cudaStreamIsCapturing");
+  TVM_FFI_ICHECK(capture_status == cudaStreamCaptureStatusNone)
+      << "final-state descriptors must be prepared outside CUDA graph capture";
+  const std::array<CUtensorMap, kFinalDescriptorCount> maps = {
+      EncodeFinalMap(q, "q", total_tokens, num_qk_heads),
+      EncodeFinalMap(k, "k", total_tokens, num_qk_heads),
+      EncodeFinalMap(v, "v", total_tokens, num_v_heads),
+      EncodeFinalMap(g, "g", total_tokens, num_v_heads),
+      EncodeFinalMap(out, "final output scratch", total_tokens, num_v_heads),
+  };
+  FinalTensorMapWords words{};
+  std::memcpy(words.words, maps.data(), sizeof(maps));
+  PublishFinalTensorMaps<<<1, kFinalDescriptorBytes / sizeof(uint64_t), 0, stream>>>(
+      reinterpret_cast<uint64_t*>(descriptor_storage.data_ptr()), words);
+  CheckCuda(cudaGetLastError(), "PublishFinalTensorMaps launch");
+}
+
+template <typename Kernel>
+inline void ConfigureDynamicSmem(Kernel kernel, int32_t bytes, int32_t device_id,
+                                 const char* name) {
+  CheckDynamicSmemCapacity(device_id, bytes);
+  CheckCuda(cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, bytes), name);
+}
+
+inline int32_t ResidentCtas(int32_t device_id) {
+  int32_t resident_ctas = 0;
+  CheckCuda(cudaDeviceGetAttribute(&resident_ctas, cudaDevAttrMultiProcessorCount, device_id),
+            "cudaDeviceGetAttribute(multiProcessorCount)");
+  return resident_ctas;
+}
+
+void RunTrainingForward(
+    TensorView q, TensorView k, TensorView v, TensorView g, TensorView beta, TensorView A_log,
+    TensorView dt_bias, TensorView initial_state, TensorView cu_seqlens,
+    TensorView checkpoint_cu_starts, TensorView base_work_items, TensorView work_items,
+    TensorView boundaries, TensorView counters, TensorView out, TensorView final_state,
+    TensorView state_checkpoints, TensorView beta_active, TensorView final_output_scratch,
+    TensorView final_descriptor_storage, TensorView final_tensormap_workspace, TensorView dummy_f32,
+    TensorView dummy_i32, int64_t boundary_count, int64_t total_work_items, int64_t total_tokens,
+    int64_t num_sequences, int64_t num_qk_heads, int64_t num_v_heads, int64_t total_chunks,
+    int64_t beta_active_stride, int64_t uniform_work_items, int64_t final_grid_ctas,
+    int64_t prepare_final_descriptors, double scale, double lower_bound, int64_t cuda_stream) {
+  TVM_FFI_ICHECK(q.device().device_type == kDLCUDA) << "q must be a CUDA tensor";
+  const int32_t device_id = q.device().device_id;
+  ffi::CUDADeviceGuard device_guard(device_id);
+  CheckFlashKDATarget(device_id);
+  TVM_FFI_ICHECK(total_tokens > 0 && num_sequences > 0 && num_qk_heads > 0 &&
+                 num_v_heads >= num_qk_heads && num_v_heads % num_qk_heads == 0);
+  TVM_FFI_ICHECK(total_chunks > 0 && total_work_items > 0 && final_grid_ctas > 0);
+  TVM_FFI_ICHECK(boundary_count >= 0 && beta_active_stride >= num_v_heads);
+  TVM_FFI_ICHECK(uniform_work_items == 0 || uniform_work_items == 1);
+  TVM_FFI_ICHECK(prepare_final_descriptors == 0 || prepare_final_descriptors == 1);
+
+  for (const auto& named : std::initializer_list<std::pair<TensorView*, const char*>>{
+           {&q, "q"},
+           {&k, "k"},
+           {&v, "v"},
+           {&g, "g"},
+           {&beta, "beta"},
+           {&out, "out"},
+           {&state_checkpoints, "state_checkpoints"},
+           {&beta_active, "beta_active"},
+           {&final_output_scratch, "final_output_scratch"}}) {
+    CheckTensor(*named.first, named.second, device_id, dl_bfloat16);
+  }
+  for (const auto& named :
+       std::initializer_list<std::pair<TensorView*, const char*>>{{&A_log, "A_log"},
+                                                                  {&dt_bias, "dt_bias"},
+                                                                  {&initial_state, "initial_state"},
+                                                                  {&final_state, "final_state"},
+                                                                  {&dummy_f32, "dummy_f32"}}) {
+    CheckTensor(*named.first, named.second, device_id, dl_float32);
+  }
+  CheckTensor(cu_seqlens, "cu_seqlens", device_id, dl_int64);
+  CheckTensor(checkpoint_cu_starts, "checkpoint_cu_starts", device_id, dl_int64);
+  CheckTensor(base_work_items, "base_work_items", device_id, dl_int32);
+  CheckTensor(work_items, "work_items", device_id, dl_int32);
+  CheckTensor(boundaries, "boundaries", device_id, dl_int32);
+  CheckTensor(counters, "counters", device_id, dl_uint32);
+  CheckTensor(final_descriptor_storage, "final_descriptor_storage", device_id, dl_uint8);
+  CheckTensor(final_tensormap_workspace, "final_tensormap_workspace", device_id, dl_uint8);
+  CheckTensor(dummy_i32, "dummy_i32", device_id, dl_int32);
+
+  CheckElements(q, "q", total_tokens * num_qk_heads * kHeadDim);
+  CheckElements(k, "k", q.numel());
+  for (const auto& named : std::initializer_list<std::pair<TensorView*, const char*>>{
+           {&v, "v"}, {&g, "g"}, {&out, "out"}, {&final_output_scratch, "final_output_scratch"}}) {
+    CheckElements(*named.first, named.second, total_tokens * num_v_heads * kHeadDim);
+  }
+  CheckElements(beta, "beta", total_tokens * num_v_heads);
+  CheckElements(A_log, "A_log", num_v_heads);
+  CheckElements(dt_bias, "dt_bias", num_v_heads * kHeadDim);
+  CheckElements(initial_state, "initial_state", num_sequences * num_v_heads * kHeadDim * kHeadDim);
+  CheckElements(final_state, "final_state", initial_state.numel());
+  CheckElements(cu_seqlens, "cu_seqlens", num_sequences + 1);
+  CheckElements(checkpoint_cu_starts, "checkpoint_cu_starts", num_sequences + 1);
+  CheckElements(base_work_items, "base_work_items", total_work_items * 8);
+  CheckElements(work_items, "work_items", total_work_items * 8);
+  TVM_FFI_ICHECK(boundaries.numel() >= std::max<int64_t>(2, boundary_count * 2));
+  CheckElements(counters, "counters", num_v_heads + 2);
+  CheckElements(state_checkpoints, "state_checkpoints",
+                total_chunks * num_v_heads * kHeadDim * kHeadDim);
+  CheckElements(beta_active, "beta_active", total_tokens * beta_active_stride);
+  TVM_FFI_ICHECK(final_descriptor_storage.numel() >= kFinalDescriptorBytes);
+  TVM_FFI_ICHECK(reinterpret_cast<uintptr_t>(final_descriptor_storage.data_ptr()) % 64 == 0);
+  TVM_FFI_ICHECK(final_tensormap_workspace.numel() >= final_grid_ctas * kFinalWorkspaceBytesPerCta);
+
+  const cudaStream_t stream = reinterpret_cast<cudaStream_t>(static_cast<uintptr_t>(cuda_stream));
+  CheckCuda(
+      cudaMemcpyAsync(work_items.data_ptr(), base_work_items.data_ptr(),
+                      total_work_items * 8 * sizeof(int32_t), cudaMemcpyDeviceToDevice, stream),
+      "copy training work items");
+  CheckCuda(cudaMemsetAsync(counters.data_ptr(), 0, counters.numel() * sizeof(uint32_t), stream),
+            "reset training counters");
+  if (boundary_count != 0) {
+    ConfigureDynamicSmem(kernel_flashkda_refine_forgetting_horizons, kRefineSmemBytes, device_id,
+                         "cudaFuncSetAttribute(forgetting-horizon refinement)");
+    kernel_flashkda_refine_forgetting_horizons<<<dim3(boundary_count, 1, 1), 128, kRefineSmemBytes,
+                                                 stream>>>(
+        reinterpret_cast<__nv_bfloat16*>(g.data_ptr()), reinterpret_cast<float*>(A_log.data_ptr()),
+        reinterpret_cast<float*>(dt_bias.data_ptr()), reinterpret_cast<int*>(work_items.data_ptr()),
+        reinterpret_cast<int*>(boundaries.data_ptr()),
+        reinterpret_cast<unsigned int*>(counters.data_ptr()), static_cast<int>(num_v_heads),
+        static_cast<float>(lower_bound), kDefaultLog2Threshold);
+    CheckCuda(cudaGetLastError(), "forgetting-horizon refinement launch");
+  }
+
+  const CUtensorMap q_map = EncodeTokenMap(q, "q", total_tokens, num_qk_heads);
+  const CUtensorMap k_map = EncodeTokenMap(k, "k", total_tokens, num_qk_heads);
+  const CUtensorMap v_map = EncodeTokenMap(v, "v", total_tokens, num_v_heads);
+  const CUtensorMap g_map = EncodeTokenMap(g, "g", total_tokens, num_v_heads);
+  const CUtensorMap out_map = EncodeTokenMap(out, "out", total_tokens, num_v_heads);
+  const CUtensorMap checkpoint_map =
+      EncodeCheckpointMap(state_checkpoints, total_chunks, num_v_heads);
+  const dim3 grid(std::min<int64_t>(total_work_items, ResidentCtas(device_id)), 1, 1);
+  ConfigureDynamicSmem(kernel_flashkda_forward_checkpoint_c16, kForwardSmemBytes, device_id,
+                       "cudaFuncSetAttribute(training forward)");
+  kernel_flashkda_forward_checkpoint_c16<<<grid, 512, kForwardSmemBytes, stream>>>(
+      reinterpret_cast<unsigned int*>(counters.data_ptr()), q_map, k_map, v_map, g_map,
+      reinterpret_cast<__nv_bfloat16*>(g.data_ptr()), out_map, checkpoint_map,
+      reinterpret_cast<__nv_bfloat16*>(beta.data_ptr()),
+      reinterpret_cast<__nv_bfloat16*>(beta_active.data_ptr()),
+      reinterpret_cast<float*>(A_log.data_ptr()), reinterpret_cast<float*>(dt_bias.data_ptr()),
+      reinterpret_cast<long long*>(cu_seqlens.data_ptr()),
+      reinterpret_cast<long long*>(checkpoint_cu_starts.data_ptr()),
+      reinterpret_cast<int*>(work_items.data_ptr()),
+      reinterpret_cast<float*>(initial_state.data_ptr()),
+      reinterpret_cast<__nv_bfloat16*>(beta_active.data_ptr()), static_cast<int>(total_work_items),
+      static_cast<int>(uniform_work_items), static_cast<int>(num_qk_heads),
+      static_cast<int>(num_v_heads), static_cast<int>(beta_active_stride), kChunk,
+      static_cast<float>(scale), static_cast<float>(lower_bound));
+  CheckCuda(cudaGetLastError(), "training forward launch");
+
+  PrepareFinalTensorMaps(q, k, v, g, final_output_scratch, final_descriptor_storage, total_tokens,
+                         num_qk_heads, num_v_heads, prepare_final_descriptors, stream);
+  ConfigureDynamicSmem(kernel_flashkda_blackwell_prefill_fp32_state_initial, kFinalSmemBytes,
+                       device_id, "cudaFuncSetAttribute(training final state)");
+  auto* final_maps =
+      reinterpret_cast<const FlashKDATrainingTensorMap*>(final_descriptor_storage.data_ptr());
+  kernel_flashkda_blackwell_prefill_fp32_state_initial<<<dim3(final_grid_ctas, 1, 1), 384,
+                                                         kFinalSmemBytes, stream>>>(
+      final_maps + 0, final_maps + 1, final_maps + 2, final_maps + 3, final_maps + 4,
+      reinterpret_cast<__nv_bfloat16*>(beta.data_ptr()), reinterpret_cast<float*>(A_log.data_ptr()),
+      reinterpret_cast<float*>(dt_bias.data_ptr()),
+      reinterpret_cast<long long*>(cu_seqlens.data_ptr()),
+      reinterpret_cast<float*>(initial_state.data_ptr()),
+      reinterpret_cast<float*>(final_state.data_ptr()),
+      reinterpret_cast<float*>(dummy_f32.data_ptr()), reinterpret_cast<int*>(dummy_i32.data_ptr()),
+      reinterpret_cast<uint8_t*>(final_tensormap_workspace.data_ptr()), 0,
+      static_cast<float>(scale), static_cast<int>(num_sequences), static_cast<int>(num_qk_heads),
+      static_cast<int>(num_v_heads), static_cast<int>(num_sequences * num_v_heads),
+      static_cast<float>(lower_bound));
+  CheckCuda(cudaGetLastError(), "training final-state launch");
+}
+
+void RunTrainingBackward(TensorView q, TensorView k, TensorView v, TensorView g, TensorView A_log,
+                         TensorView dt_bias, TensorView do_tensor, TensorView dfinal_state,
+                         TensorView cu_seqlens, TensorView checkpoint_cu_starts,
+                         TensorView work_items, TensorView counters, TensorView state_checkpoints,
+                         TensorView beta_active, TensorView dlog_decay, TensorView dlog_boundary,
+                         TensorView dbeta_active, TensorView gate_part_a, TensorView gate_part_dt,
+                         TensorView dummy_u32, TensorView dummy_f32, TensorView dq_value_heads,
+                         TensorView dk_value_heads, TensorView dv, TensorView dg, TensorView dbeta,
+                         TensorView dA_log, TensorView ddt_bias, TensorView dinitial_state,
+                         TensorView dq, TensorView dk, int64_t total_work_items,
+                         int64_t total_tokens, int64_t num_sequences, int64_t num_qk_heads,
+                         int64_t num_v_heads, int64_t total_chunks, int64_t beta_active_stride,
+                         int64_t uniform_work_items, int64_t grouped, double scale,
+                         double lower_bound, int64_t cuda_stream) {
+  TVM_FFI_ICHECK(q.device().device_type == kDLCUDA) << "q must be a CUDA tensor";
+  const int32_t device_id = q.device().device_id;
+  ffi::CUDADeviceGuard device_guard(device_id);
+  CheckFlashKDATarget(device_id);
+  TVM_FFI_ICHECK(grouped == 0 || grouped == 1);
+  TVM_FFI_ICHECK(grouped == int64_t(num_qk_heads != num_v_heads));
+  TVM_FFI_ICHECK(total_work_items > 0 && total_tokens > 0 && num_sequences > 0 &&
+                 num_qk_heads > 0 && num_v_heads >= num_qk_heads &&
+                 num_v_heads % num_qk_heads == 0 && total_chunks > 0);
+
+  for (const auto& named : std::initializer_list<std::pair<TensorView*, const char*>>{
+           {&q, "q"},
+           {&k, "k"},
+           {&v, "v"},
+           {&g, "g"},
+           {&do_tensor, "do"},
+           {&state_checkpoints, "state_checkpoints"},
+           {&beta_active, "beta_active"},
+           {&dq_value_heads, "dq_value_heads"},
+           {&dk_value_heads, "dk_value_heads"},
+           {&dv, "dv"},
+           {&dg, "dg"},
+           {&dbeta, "dbeta"},
+           {&dq, "dq"},
+           {&dk, "dk"}}) {
+    CheckTensor(*named.first, named.second, device_id, dl_bfloat16);
+  }
+  for (const auto& named : std::initializer_list<std::pair<TensorView*, const char*>>{
+           {&A_log, "A_log"},
+           {&dt_bias, "dt_bias"},
+           {&dfinal_state, "dfinal_state"},
+           {&dlog_decay, "dlog_decay"},
+           {&dlog_boundary, "dlog_boundary"},
+           {&dbeta_active, "dbeta_active"},
+           {&gate_part_a, "gate_part_a"},
+           {&gate_part_dt, "gate_part_dt"},
+           {&dummy_f32, "dummy_f32"},
+           {&dA_log, "dA_log"},
+           {&ddt_bias, "ddt_bias"},
+           {&dinitial_state, "dinitial_state"}}) {
+    CheckTensor(*named.first, named.second, device_id, dl_float32);
+  }
+  CheckTensor(cu_seqlens, "cu_seqlens", device_id, dl_int64);
+  CheckTensor(checkpoint_cu_starts, "checkpoint_cu_starts", device_id, dl_int64);
+  CheckTensor(work_items, "work_items", device_id, dl_int32);
+  CheckTensor(counters, "counters", device_id, dl_uint32);
+  CheckTensor(dummy_u32, "dummy_u32", device_id, dl_uint32);
+
+  CheckElements(q, "q", total_tokens * num_qk_heads * kHeadDim);
+  CheckElements(k, "k", q.numel());
+  for (const auto& named : std::initializer_list<std::pair<TensorView*, const char*>>{
+           {&v, "v"},
+           {&g, "g"},
+           {&do_tensor, "do"},
+           {&dq_value_heads, "dq_value_heads"},
+           {&dk_value_heads, "dk_value_heads"},
+           {&dv, "dv"},
+           {&dg, "dg"}}) {
+    CheckElements(*named.first, named.second, total_tokens * num_v_heads * kHeadDim);
+  }
+  CheckElements(dbeta, "dbeta", total_tokens * num_v_heads);
+  CheckElements(dq, "dq", q.numel());
+  CheckElements(dk, "dk", k.numel());
+  CheckElements(dfinal_state, "dfinal_state", num_sequences * num_v_heads * kHeadDim * kHeadDim);
+  CheckElements(state_checkpoints, "state_checkpoints",
+                total_chunks * num_v_heads * kHeadDim * kHeadDim);
+  CheckElements(beta_active, "beta_active", total_tokens * beta_active_stride);
+  CheckElements(dlog_decay, "dlog_decay", total_tokens * num_v_heads * kHeadDim);
+  CheckElements(dlog_boundary, "dlog_boundary", total_chunks * num_v_heads * kHeadDim);
+  CheckElements(dbeta_active, "dbeta_active", total_tokens * num_v_heads);
+  CheckElements(gate_part_a, "gate_part_a", 128 * num_v_heads * kHeadDim);
+  CheckElements(gate_part_dt, "gate_part_dt", gate_part_a.numel());
+  CheckElements(dA_log, "dA_log", num_v_heads);
+  CheckElements(ddt_bias, "ddt_bias", num_v_heads * kHeadDim);
+  CheckElements(dinitial_state, "dinitial_state", dfinal_state.numel());
+  CheckElements(counters, "counters", num_v_heads + 2);
+
+  const cudaStream_t stream = reinterpret_cast<cudaStream_t>(static_cast<uintptr_t>(cuda_stream));
+  CheckCuda(cudaMemsetAsync(static_cast<unsigned int*>(counters.data_ptr()) + 1, 0,
+                            (num_v_heads + 1) * sizeof(uint32_t), stream),
+            "reset backward counters");
+  CUtensorMap q_map = EncodeTokenMap(q, "q", total_tokens, num_qk_heads);
+  CUtensorMap k_map = EncodeTokenMap(k, "k", total_tokens, num_qk_heads);
+  CUtensorMap g_map = EncodeTokenMap(g, "g", total_tokens, num_v_heads);
+  CUtensorMap do_map = EncodeTokenMap(do_tensor, "do", total_tokens, num_v_heads);
+  CUtensorMap v_map = EncodeTokenMap(v, "v", total_tokens, num_v_heads);
+  CUtensorMap state_map = EncodeCheckpointMap(state_checkpoints, total_chunks, num_v_heads);
+  CUtensorMap dv_map = EncodeTokenMap(dv, "dv", total_tokens, num_v_heads);
+  CUtensorMap beta_map = EncodeBetaMap(beta_active, total_tokens, beta_active_stride);
+  const dim3 grid(std::min<int64_t>(total_work_items, ResidentCtas(device_id)), 1, 1);
+  ConfigureDynamicSmem(kernel_flashkda_backward_persistent_c16, kBackwardSmemBytes, device_id,
+                       "cudaFuncSetAttribute(training backward)");
+  auto* dynamic_counter = reinterpret_cast<unsigned int*>(counters.data_ptr()) + 1;
+  auto* dfinal_state_ptr = reinterpret_cast<float*>(dfinal_state.data_ptr());
+  auto* dq_value_heads_ptr = reinterpret_cast<__nv_bfloat16*>(dq_value_heads.data_ptr());
+  auto* dk_value_heads_ptr = reinterpret_cast<__nv_bfloat16*>(dk_value_heads.data_ptr());
+  auto* dlog_decay_ptr = reinterpret_cast<float*>(dlog_decay.data_ptr());
+  auto* dlog_boundary_ptr = reinterpret_cast<float*>(dlog_boundary.data_ptr());
+  auto* dinitial_state_ptr = reinterpret_cast<float*>(dinitial_state.data_ptr());
+  auto* A_log_ptr = reinterpret_cast<float*>(A_log.data_ptr());
+  auto* dt_bias_ptr = reinterpret_cast<float*>(dt_bias.data_ptr());
+  auto* dbeta_active_ptr = reinterpret_cast<float*>(dbeta_active.data_ptr());
+  auto* cu_seqlens_ptr = reinterpret_cast<long long*>(cu_seqlens.data_ptr());
+  auto* checkpoint_cu_starts_ptr = reinterpret_cast<long long*>(checkpoint_cu_starts.data_ptr());
+  auto* work_items_ptr = reinterpret_cast<int*>(work_items.data_ptr());
+  auto* visits_ptr = reinterpret_cast<unsigned int*>(dummy_u32.data_ptr());
+  auto* diagnostic = reinterpret_cast<float*>(dummy_f32.data_ptr());
+  int total_work_items_arg = static_cast<int>(total_work_items);
+  int uniform_work_items_arg = static_cast<int>(uniform_work_items);
+  int total_chunks_arg = static_cast<int>(total_chunks);
+  int num_qk_heads_arg = static_cast<int>(num_qk_heads);
+  int num_v_heads_arg = static_cast<int>(num_v_heads);
+  int enable_kk = 1;
+  int enable_tinv = 1;
+  float scale_arg = static_cast<float>(scale);
+  float lower_bound_arg = static_cast<float>(lower_bound);
+  void* kernel_args[] = {
+      &dynamic_counter,
+      &q_map,
+      &k_map,
+      &g_map,
+      &do_map,
+      &v_map,
+      &state_map,
+      &dfinal_state_ptr,
+      &dv_map,
+      &dq_value_heads_ptr,
+      &dk_value_heads_ptr,
+      &dlog_decay_ptr,
+      &dlog_boundary_ptr,
+      &dinitial_state_ptr,
+      &A_log_ptr,
+      &dt_bias_ptr,
+      &beta_map,
+      &dbeta_active_ptr,
+      &cu_seqlens_ptr,
+      &checkpoint_cu_starts_ptr,
+      &work_items_ptr,
+      &visits_ptr,
+      &diagnostic,
+      &diagnostic,
+      &diagnostic,
+      &diagnostic,
+      &diagnostic,
+      &diagnostic,
+      &diagnostic,
+      &diagnostic,
+      &diagnostic,
+      &diagnostic,
+      &diagnostic,
+      &diagnostic,
+      &diagnostic,
+      &diagnostic,
+      &total_work_items_arg,
+      &uniform_work_items_arg,
+      &total_chunks_arg,
+      &num_qk_heads_arg,
+      &num_v_heads_arg,
+      &enable_kk,
+      &enable_tinv,
+      &scale_arg,
+      &lower_bound_arg,
+  };
+  CheckCuda(cudaLaunchKernel(reinterpret_cast<const void*>(kernel_flashkda_backward_persistent_c16),
+                             grid, dim3(512, 1, 1), kernel_args, kBackwardSmemBytes, stream),
+            "training backward launch");
+
+  ConfigureDynamicSmem(kernel_flashkda_backward_param_reduce_c16_partial, kReduceSmemBytes,
+                       device_id, "cudaFuncSetAttribute(training parameter reduction)");
+  kernel_flashkda_backward_param_reduce_c16_partial<<<dim3(128, num_v_heads, 1), 128,
+                                                      kReduceSmemBytes, stream>>>(
+      reinterpret_cast<__nv_bfloat16*>(g.data_ptr()),
+      reinterpret_cast<__nv_bfloat16*>(beta_active.data_ptr()),
+      reinterpret_cast<float*>(A_log.data_ptr()), reinterpret_cast<float*>(dt_bias.data_ptr()),
+      reinterpret_cast<float*>(dlog_decay.data_ptr()),
+      reinterpret_cast<float*>(dlog_boundary.data_ptr()),
+      reinterpret_cast<float*>(dbeta_active.data_ptr()),
+      reinterpret_cast<__nv_bfloat16*>(dg.data_ptr()),
+      reinterpret_cast<__nv_bfloat16*>(dbeta.data_ptr()),
+      reinterpret_cast<float*>(gate_part_a.data_ptr()),
+      reinterpret_cast<float*>(gate_part_dt.data_ptr()),
+      reinterpret_cast<unsigned int*>(counters.data_ptr()) + 2,
+      reinterpret_cast<float*>(dA_log.data_ptr()), reinterpret_cast<float*>(ddt_bias.data_ptr()),
+      static_cast<int>(total_tokens), static_cast<int>(num_v_heads),
+      static_cast<int>(beta_active_stride), static_cast<int>((total_tokens + 127) / 128),
+      static_cast<float>(lower_bound));
+  CheckCuda(cudaGetLastError(), "training parameter-reduction launch");
+
+  if (grouped != 0) {
+    kernel_flashkda_grouped_qk_reduce<<<dim3((total_tokens + 15) / 16, num_qk_heads, 1), 128, 0,
+                                        stream>>>(
+        reinterpret_cast<__nv_bfloat16*>(dq_value_heads.data_ptr()),
+        reinterpret_cast<__nv_bfloat16*>(dk_value_heads.data_ptr()),
+        reinterpret_cast<__nv_bfloat16*>(dq.data_ptr()),
+        reinterpret_cast<__nv_bfloat16*>(dk.data_ptr()), static_cast<int>(total_tokens),
+        static_cast<int>(num_qk_heads), static_cast<int>(num_v_heads));
+    CheckCuda(cudaGetLastError(), "grouped Q/K gradient reduction launch");
+  }
+}
+
+}  // namespace flash_kda_training_paired
+}  // namespace flashinfer
+
+TVM_FFI_DLL_EXPORT_TYPED_FUNC(run_training_forward,
+                              flashinfer::flash_kda_training_paired::RunTrainingForward);
+TVM_FFI_DLL_EXPORT_TYPED_FUNC(run_training_backward,
+                              flashinfer::flash_kda_training_paired::RunTrainingBackward);

--- a/csrc/kda/training_fallback_pointer_sm_100a.cu
+++ b/csrc/kda/training_fallback_pointer_sm_100a.cu
@@ -1,0 +1,11588 @@
+typedef signed char        int8_t;
+typedef unsigned char      uint8_t;
+typedef unsigned short     uint16_t;
+typedef unsigned int       uint32_t;
+typedef unsigned long long uint64_t;
+typedef signed int         int32_t;
+typedef short int          int16_t;
+struct __align__(128) LoomTensorMap { uint64_t opaque[16]; };
+template <int N>
+struct __align__(128) LoomTensorMapPack { LoomTensorMap maps[N]; };
+
+typedef struct __align__(64) { uint64_t opaque[16]; } CUtensorMap;
+
+#include <cuda_bf16.h>
+
+#include <math_constants.h>
+
+__device__ __forceinline__ float approx_rcp(float x) {
+    float y;
+    asm("rcp.approx.ftz.f32 %0, %1;" : "=f"(y) : "f"(x));
+    return y;
+}
+
+__device__ __forceinline__ uint32_t elect_sync() {
+    uint32_t pred = 0;
+    asm volatile(
+        "{\n\t"
+        ".reg .pred %%px;\n\t"
+        "elect.sync _|%%px, %1;\n\t"
+        "@%%px mov.s32 %0, 1;\n\t"
+        "}\n"
+        : "+r"(pred)
+        : "r"(0xFFFFFFFF));
+    return pred;
+}
+
+__device__ __forceinline__ void mbarrier_init(int mbar_addr, int count) {
+    asm volatile("mbarrier.init.shared::cta.b64 [%0], %1;"
+        :: "r"(mbar_addr), "r"(count));
+}
+
+__device__ __forceinline__ uint32_t mbarrier_try_wait(int mbar_addr, int phase) {
+    uint32_t token;
+    asm volatile(
+        "{\n\t"
+        ".reg .pred P1;\n\t"
+        "mbarrier.try_wait.parity.acquire.cta.shared::cta.b64"
+        " P1, [%1], %2;\n\t"
+        "selp.u32 %0, 1, 0, P1;\n\t"
+        "}\n"
+        : "=r"(token)
+        : "r"(mbar_addr), "r"(phase) : "memory");
+    return token;
+}
+
+__device__ __forceinline__ uint32_t mbarrier_try_wait_cluster(int mbar_addr, int phase) {
+    uint32_t token;
+    asm volatile(
+        "{\n\t"
+        ".reg .pred P1;\n\t"
+        "mbarrier.try_wait.parity.acquire.cluster.shared::cta.b64"
+        " P1, [%1], %2;\n\t"
+        "selp.u32 %0, 1, 0, P1;\n\t"
+        "}\n"
+        : "=r"(token)
+        : "r"(mbar_addr), "r"(phase) : "memory");
+    return token;
+}
+
+__device__ __forceinline__ void mbarrier_wait(int mbar_addr, int phase) {
+    uint32_t ticks = 0x989680;
+    asm volatile(
+        "{\n\t"
+        ".reg .pred P1;\n\t"
+        "LAB_WAIT:\n\t"
+        "mbarrier.try_wait.parity.acquire.cta.shared::cta.b64"
+        " P1, [%0], %1, %2;\n\t"
+        "@P1 bra.uni DONE;\n\t"
+        "bra.uni LAB_WAIT;\n\t"
+        "DONE:\n\t"
+        "}\n"
+        :: "r"(mbar_addr), "r"(phase), "r"(ticks) : "memory");
+}
+
+__device__ __forceinline__ void mbarrier_wait_cluster(int mbar_addr, int phase) {
+    uint32_t ticks = 0x989680;
+    asm volatile(
+        "{\n\t"
+        ".reg .pred P1;\n\t"
+        "LAB_WAIT_CLUSTER:\n\t"
+        "mbarrier.try_wait.parity.acquire.cluster.shared::cta.b64"
+        " P1, [%0], %1, %2;\n\t"
+        "@P1 bra.uni DONE_CLUSTER;\n\t"
+        "bra.uni LAB_WAIT_CLUSTER;\n\t"
+        "DONE_CLUSTER:\n\t"
+        "}\n"
+        :: "r"(mbar_addr), "r"(phase), "r"(ticks) : "memory");
+}
+
+__device__ __forceinline__ void mbarrier_wait_token(int mbar_addr, int phase, uint32_t token) {
+    if (token == 0) {
+        mbarrier_wait(mbar_addr, phase);
+    }
+}
+
+__device__ __forceinline__ void mbarrier_wait_token_cluster(int mbar_addr, int phase, uint32_t token) {
+    if (token == 0) {
+        mbarrier_wait_cluster(mbar_addr, phase);
+    }
+}
+
+__device__ __forceinline__ void tcgen05_mma_f16(
+    int taddr, uint64_t a_desc, uint64_t b_desc,
+    uint32_t i_desc, int enable_input_d) {
+    asm volatile(
+        "{\n\t"
+        ".reg .pred p;\n\t"
+        "setp.ne.b32 p, %4, 0;\n\t"
+        "tcgen05.mma.cta_group::1.kind::f16 [%0], %1, %2, %3, p;\n\t"
+        "}\n"
+        :: "r"(taddr), "l"(a_desc), "l"(b_desc),
+           "r"(i_desc), "r"(enable_input_d));
+}
+
+__device__ __forceinline__ uint64_t desc_encode(uint64_t x) {
+    return (x & 0x3FFFFULL) >> 4ULL;
+}
+
+__device__ __forceinline__ void mma_ts_step(
+    int taddr_out, int taddr_a, int b_lo, uint32_t b_dhi,
+    uint32_t i_desc, int enable_d) {
+    asm volatile(
+        "{\n\t"
+        ".reg .pred leader, p;\n\t"
+        ".reg .b32 dhi;\n\t"
+        ".reg .b64 db;\n\t"
+        "elect.sync _|leader, 0xFFFFFFFF;\n\t"
+        "setp.ne.b32 p, %5, 0;\n\t"
+        "mov.b32 dhi, %3;\n\t"
+        "mov.b64 db, {%2, dhi};\n\t"
+        "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [%1], db, %4, p;\n\t"
+        "}\n"
+        :: "r"(taddr_out), "r"(taddr_a), "r"(b_lo), "r"(b_dhi),
+           "r"(i_desc), "r"(enable_d));
+}
+
+__device__ __forceinline__ void elect_commit(int mbar_addr) {
+    asm volatile(
+        "{\n\t"
+        ".reg .pred leader;\n\t"
+        "elect.sync _|leader, 0xFFFFFFFF;\n\t"
+        "@leader tcgen05.commit.cta_group::1.mbarrier::arrive::one"
+        ".shared::cluster.b64 [%0];\n\t"
+        "}\n"
+        :: "r"(mbar_addr));
+}
+
+__device__ __forceinline__ void mbarrier_arrive(int mbar_addr) {
+    asm volatile(
+        "mbarrier.arrive.release.cta.shared::cta.b64 _, [%0];"
+        :: "r"(mbar_addr) : "memory");
+}
+
+__device__ __forceinline__ void mbarrier_arrive_expect_tx(int mbar_addr, uint32_t bytes) {
+    asm volatile(
+        "mbarrier.arrive.expect_tx.release.cta.shared::cta.b64 _, [%0], %1;"
+        :: "r"(mbar_addr), "r"(bytes) : "memory");
+}
+
+__device__ __forceinline__ void tmem_ld_x32(float* dst, int tmem_addr) {
+    asm volatile(
+        "tcgen05.ld.sync.aligned.32x32b.x32.b32"
+        " {%0, %1, %2, %3, %4, %5, %6, %7,"
+        "  %8, %9, %10, %11, %12, %13, %14, %15,"
+        "  %16, %17, %18, %19, %20, %21, %22, %23,"
+        "  %24, %25, %26, %27, %28, %29, %30, %31}, [%32];"
+        : "=f"(dst[0]),  "=f"(dst[1]),  "=f"(dst[2]),  "=f"(dst[3]),
+          "=f"(dst[4]),  "=f"(dst[5]),  "=f"(dst[6]),  "=f"(dst[7]),
+          "=f"(dst[8]),  "=f"(dst[9]),  "=f"(dst[10]), "=f"(dst[11]),
+          "=f"(dst[12]), "=f"(dst[13]), "=f"(dst[14]), "=f"(dst[15]),
+          "=f"(dst[16]), "=f"(dst[17]), "=f"(dst[18]), "=f"(dst[19]),
+          "=f"(dst[20]), "=f"(dst[21]), "=f"(dst[22]), "=f"(dst[23]),
+          "=f"(dst[24]), "=f"(dst[25]), "=f"(dst[26]), "=f"(dst[27]),
+          "=f"(dst[28]), "=f"(dst[29]), "=f"(dst[30]), "=f"(dst[31])
+        : "r"(tmem_addr));
+}
+
+__device__ __forceinline__ void tmem_ld_x16(float* dst, int tmem_addr) {
+    asm volatile(
+        "tcgen05.ld.sync.aligned.32x32b.x16.b32"
+        " {%0, %1, %2, %3, %4, %5, %6, %7,"
+        "  %8, %9, %10, %11, %12, %13, %14, %15}, [%16];"
+        : "=f"(dst[0]),  "=f"(dst[1]),  "=f"(dst[2]),  "=f"(dst[3]),
+          "=f"(dst[4]),  "=f"(dst[5]),  "=f"(dst[6]),  "=f"(dst[7]),
+          "=f"(dst[8]),  "=f"(dst[9]),  "=f"(dst[10]), "=f"(dst[11]),
+          "=f"(dst[12]), "=f"(dst[13]), "=f"(dst[14]), "=f"(dst[15])
+        : "r"(tmem_addr));
+}
+
+__device__ __forceinline__ void tmem_st_x32_f32(int tmem_addr, const float* src) {
+    asm volatile(
+        "tcgen05.st.sync.aligned.32x32b.x32.b32"
+        " [%0], {%1, %2, %3, %4, %5, %6, %7, %8,"
+        "  %9, %10, %11, %12, %13, %14, %15, %16,"
+        "  %17, %18, %19, %20, %21, %22, %23, %24,"
+        "  %25, %26, %27, %28, %29, %30, %31, %32};"
+        :: "r"(tmem_addr),
+           "f"(src[0]),  "f"(src[1]),  "f"(src[2]),  "f"(src[3]),
+           "f"(src[4]),  "f"(src[5]),  "f"(src[6]),  "f"(src[7]),
+           "f"(src[8]),  "f"(src[9]),  "f"(src[10]), "f"(src[11]),
+           "f"(src[12]), "f"(src[13]), "f"(src[14]), "f"(src[15]),
+           "f"(src[16]), "f"(src[17]), "f"(src[18]), "f"(src[19]),
+           "f"(src[20]), "f"(src[21]), "f"(src[22]), "f"(src[23]),
+           "f"(src[24]), "f"(src[25]), "f"(src[26]), "f"(src[27]),
+           "f"(src[28]), "f"(src[29]), "f"(src[30]), "f"(src[31]));
+}
+
+__device__ __forceinline__ float approx_exp2(float x) {
+    float y;
+    asm("ex2.approx.ftz.f32 %0, %1;" : "=f"(y) : "f"(x));
+    return y;
+}
+
+__device__ __forceinline__ float max_noftz(float a, float b) {
+    float c;
+    asm("max.f32 %0, %1, %2;" : "=f"(c) : "f"(a), "f"(b));
+    return c;
+}
+
+__device__ __forceinline__ void fma_f32x2_inplace(float2* a, float2 b, float2 c) {
+    unsigned long long r;
+    asm("fma.rn.ftz.f32x2 %0, %1, %2, %3;"
+        : "=l"(r)
+        : "l"(*(unsigned long long*)a), "l"(*(unsigned long long*)&b),
+          "l"(*(unsigned long long*)&c));
+    *(unsigned long long*)a = r;
+}
+
+__device__ __forceinline__ void mul_f32x2_inplace(float2* a, float2 b) {
+    asm("mul.rn.ftz.f32x2 %0, %0, %1;"
+        : "+l"(*(unsigned long long*)a) : "l"(*(unsigned long long*)&b));
+}
+
+__device__ __forceinline__ void add_f32x2_inplace(float2* a, float2 b) {
+    asm("add.rn.ftz.f32x2 %0, %0, %1;"
+        : "+l"(*(unsigned long long*)a) : "l"(*(unsigned long long*)&b));
+}
+
+__device__ __forceinline__ void sub_f32x2_inplace(float2* a, float2 b) {
+    asm("sub.rn.ftz.f32x2 %0, %0, %1;"
+        : "+l"(*(unsigned long long*)a) : "l"(*(unsigned long long*)&b));
+}
+
+__device__ __forceinline__ float2 add_f32x2(float2 a, float2 b) {
+    float2 r;
+    asm("add.rn.ftz.f32x2 %0, %1, %2;"
+        : "=l"(*(unsigned long long*)&r)
+        : "l"(*(unsigned long long*)&a), "l"(*(unsigned long long*)&b));
+    return r;
+}
+
+__device__ __forceinline__ float2 sub_f32x2(float2 a, float2 b) {
+    float2 r;
+    asm("sub.rn.ftz.f32x2 %0, %1, %2;"
+        : "=l"(*(unsigned long long*)&r)
+        : "l"(*(unsigned long long*)&a), "l"(*(unsigned long long*)&b));
+    return r;
+}
+
+__device__ __forceinline__ void fma_scale_x32(
+    float* sv, const float2* scale2, const float2* neg_max2)
+{
+    float2* sv_2 = reinterpret_cast<float2*>(sv);
+
+#pragma unroll
+
+for (int j = 0; j < 16; j++)
+        fma_f32x2_inplace(&sv_2[j], *scale2, *neg_max2);
+}
+
+__device__ __forceinline__ float2 fma_f32x2(float2 a, float2 b, float2 c) {
+    float2 r;
+    asm("fma.rn.ftz.f32x2 %0, %1, %2, %3;"
+        : "=l"(*(unsigned long long*)&r)
+        : "l"(*(unsigned long long*)&a), "l"(*(unsigned long long*)&b),
+          "l"(*(unsigned long long*)&c));
+    return r;
+}
+
+__device__ __forceinline__ float2 fma_sub_f32x2(float2 a, float2 b, float2 c) {
+    float2 r;
+    asm volatile("{\n\t"
+        ".reg .f32 _c0, _c1;\n\t"
+        ".reg .b64 _neg_c;\n\t"
+        "mov.b64 {_c0, _c1}, %3;\n\t"
+        "neg.f32 _c0, _c0;\n\t"
+        "neg.f32 _c1, _c1;\n\t"
+        "mov.b64 _neg_c, {_c0, _c1};\n\t"
+        "fma.rn.ftz.f32x2 %0, %1, %2, _neg_c;\n\t"
+        "}\n"
+        : "=l"(*(unsigned long long*)&r)
+        : "l"(*(unsigned long long*)&a), "l"(*(unsigned long long*)&b),
+          "l"(*(unsigned long long*)&c));
+    return r;
+}
+
+__device__ __forceinline__ float2 mul_f32x2(float2 a, float2 b) {
+    float2 r;
+    asm("mul.rn.ftz.f32x2 %0, %1, %2;"
+        : "=l"(*(unsigned long long*)&r)
+        : "l"(*(unsigned long long*)&a), "l"(*(unsigned long long*)&b));
+    return r;
+}
+
+// ex2_emulation_f32x2 defined in softmax_frag_exp2_cast helper (or standalone)
+
+__device__ __forceinline__ void elect_commit2(int mbar_addr0, int mbar_addr1) {
+    asm volatile(
+        "{\n\t"
+        ".reg .pred leader;\n\t"
+        "elect.sync _|leader, 0xFFFFFFFF;\n\t"
+        "@leader tcgen05.commit.cta_group::1.mbarrier::arrive::one"
+        ".shared::cluster.b64 [%0];\n\t"
+        "@leader tcgen05.commit.cta_group::1.mbarrier::arrive::one"
+        ".shared::cluster.b64 [%1];\n\t"
+        "}\n"
+        :: "r"(mbar_addr0), "r"(mbar_addr1) : "memory");
+}
+
+__device__ __forceinline__ void fence_async_shared() {
+    asm volatile("fence.proxy.async.shared::cta;" ::: "memory");
+}
+
+__device__ __forceinline__ uint64_t make_smem_desc(int addr) {
+    const int SBO = 1024;
+    return desc_encode(addr)
+         | (desc_encode(SBO) << 32ULL)
+         | (1ULL << 46ULL)
+         | (2ULL << 61ULL);
+}
+
+__device__ __forceinline__ void tma_3d_gmem2smem(
+    int dst, const void *tmap_ptr, int x, int y, int z, int mbar_addr) {
+    asm volatile(
+        "cp.async.bulk.tensor.3d.shared::cta.global"
+        ".mbarrier::complete_tx::bytes"
+        " [%0], [%1, {%2, %3, %4}], [%5];"
+        :: "r"(dst), "l"(tmap_ptr), "r"(x), "r"(y), "r"(z),
+           "r"(mbar_addr) : "memory");
+}
+
+__device__ __forceinline__ void tma_2d_gmem2smem(
+    int dst, const void *tmap_ptr, int x, int y, int mbar_addr) {
+    asm volatile(
+        "cp.async.bulk.tensor.2d.shared::cta.global"
+        ".mbarrier::complete_tx::bytes"
+        " [%0], [%1, {%2, %3}], [%4];"
+        :: "r"(dst), "l"(tmap_ptr), "r"(x), "r"(y),
+           "r"(mbar_addr) : "memory");
+}
+
+__device__ __forceinline__ void tma_4d_gmem2smem(
+    int dst, const void *tmap_ptr, int x, int y, int z, int w, int mbar_addr) {
+    asm volatile(
+        "cp.async.bulk.tensor.4d.shared::cta.global"
+        ".mbarrier::complete_tx::bytes"
+        " [%0], [%1, {%2, %3, %4, %5}], [%6];"
+        :: "r"(dst), "l"(tmap_ptr), "r"(x), "r"(y), "r"(z), "r"(w),
+           "r"(mbar_addr) : "memory");
+}
+
+__device__ __forceinline__ void tma_store_4d(
+    const void *tmap, int x, int y, int z, int w, unsigned smem_addr) {
+    asm volatile(
+        "cp.async.bulk.tensor.4d.global.shared::cta.tile.bulk_group"
+        " [%0, {%1, %2, %3, %4}], [%5];"
+        :: "l"(tmap), "r"(x), "r"(y), "r"(z), "r"(w), "r"(smem_addr) : "memory");
+}
+
+__device__ __forceinline__ void tcgen05_commit(int mbar_addr) {
+    asm volatile(
+        "tcgen05.commit.cta_group::1.mbarrier::arrive::one"
+        ".shared::cluster.b64 [%0];"
+        :: "r"(mbar_addr) : "memory");
+}
+
+__device__ __forceinline__ void tmem_st_x8_u32(int addr, const uint32_t* src) {
+    asm volatile(
+        "tcgen05.st.sync.aligned.32x32b.x8.b32"
+        " [%0], {%1,%2,%3,%4,%5,%6,%7,%8};"
+        :: "r"(addr),
+           "r"(src[0]), "r"(src[1]), "r"(src[2]), "r"(src[3]),
+           "r"(src[4]), "r"(src[5]), "r"(src[6]), "r"(src[7]));
+}
+
+__device__ __forceinline__ uint32_t make_warp_uniform(uint32_t val) {
+    uint32_t result;
+    asm volatile("shfl.sync.idx.b32 %0, %1, 0, 0x1f, 0xffffffff;"
+        : "=r"(result) : "r"(val));
+    return result;
+}
+
+__device__ __forceinline__ void tmem_ld_x16_wait(float* dst, int addr) {
+    tmem_ld_x16(dst, addr);
+    asm volatile("tcgen05.wait::ld.sync.aligned;");
+}
+
+__device__ __forceinline__ void tmem_ld_x8(float* dst, int tmem_addr) {
+    asm volatile(
+        "tcgen05.ld.sync.aligned.32x32b.x8.b32"
+        " {%0, %1, %2, %3, %4, %5, %6, %7}, [%8];"
+        : "=f"(dst[0]), "=f"(dst[1]), "=f"(dst[2]), "=f"(dst[3]),
+          "=f"(dst[4]), "=f"(dst[5]), "=f"(dst[6]), "=f"(dst[7])
+        : "r"(tmem_addr));
+}
+
+__device__ __forceinline__ void tmem_ld_x8_wait(float* dst, int addr) {
+    tmem_ld_x8(dst, addr);
+    asm volatile("tcgen05.wait::ld.sync.aligned;");
+}
+
+#define LOOM_INF CUDART_INF_F
+#define NUM_MAIN_STAGES 1
+#define THREADS 32
+#define D 128
+
+extern "C" {
+
+__global__ __launch_bounds__(32) void
+kernel_flashkda_backward_preprocess(__nv_bfloat16* __restrict__ q, __nv_bfloat16* __restrict__ k, __nv_bfloat16* __restrict__ g, __nv_bfloat16* __restrict__ beta, float* __restrict__ A_log, float* __restrict__ dt_bias, float* __restrict__ q_norm, float* __restrict__ k_norm, float* __restrict__ decay, float* __restrict__ beta_active, int total_tokens, int num_heads, float lower_bound)
+{
+    const int tid = threadIdx.x;
+    const int warp = make_warp_uniform(tid / 32);
+    const int lane = tid % 32;
+
+
+    const int bid = blockIdx.x;
+    const int num_bids = gridDim.x;
+
+    // === Task calls (dependency order) ===
+    int token = blockIdx.x;
+    int head = blockIdx.y;
+    int elem = lane * 4;
+    long long base = ((long long)token * (long long)num_heads + (long long)head) * (long long)D;
+    float q_frag[4];
+    float k_frag[4];
+    float g_frag[4];
+    {
+        uint2 _vld_0;
+        _vld_0 = *reinterpret_cast<const uint2*>(q + base + (long long)elem);
+        uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0);
+        #pragma unroll
+        for (int _pair = 0; _pair < 2; _pair++) {
+            asm volatile(
+                "{\n\t"
+                "shl.b32 %0, %2, 16;\n\t"
+                "and.b32 %1, %2, 0xffff0000;\n\t"
+                "}\n"
+                : "=f"((&q_frag[0 + _pair * 2])[0]), "=f"((&q_frag[0 + _pair * 2])[1])
+                : "r"(_vpairs_0[_pair]));
+        }
+    }
+    {
+        uint2 _vld_1;
+        _vld_1 = *reinterpret_cast<const uint2*>(k + base + (long long)elem);
+        uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1);
+        #pragma unroll
+        for (int _pair = 0; _pair < 2; _pair++) {
+            asm volatile(
+                "{\n\t"
+                "shl.b32 %0, %2, 16;\n\t"
+                "and.b32 %1, %2, 0xffff0000;\n\t"
+                "}\n"
+                : "=f"((&k_frag[0 + _pair * 2])[0]), "=f"((&k_frag[0 + _pair * 2])[1])
+                : "r"(_vpairs_1[_pair]));
+        }
+    }
+    {
+        uint2 _vld_2;
+        _vld_2 = *reinterpret_cast<const uint2*>(g + base + (long long)elem);
+        uint32_t* _vpairs_2 = reinterpret_cast<uint32_t*>(&_vld_2);
+        #pragma unroll
+        for (int _pair = 0; _pair < 2; _pair++) {
+            asm volatile(
+                "{\n\t"
+                "shl.b32 %0, %2, 16;\n\t"
+                "and.b32 %1, %2, 0xffff0000;\n\t"
+                "}\n"
+                : "=f"((&g_frag[0 + _pair * 2])[0]), "=f"((&g_frag[0 + _pair * 2])[1])
+                : "r"(_vpairs_2[_pair]));
+        }
+    }
+    float q_sq = 0.0f;
+    float k_sq = 0.0f;
+    #pragma unroll
+    for (int i = 0; i < 4; i++) {
+        float _fma_0 = __fmaf_rn(q_frag[i], q_frag[i], q_sq);
+        q_sq = _fma_0;
+        float _fma_1 = __fmaf_rn(k_frag[i], k_frag[i], k_sq);
+        k_sq = _fma_1;
+    }
+    float _warp_reduce_0 = q_sq;
+    #pragma unroll
+    for (int offset = 16; offset > 0; offset >>= 1)
+        _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
+    q_sq = _warp_reduce_0;
+    float _warp_reduce_1 = k_sq;
+    #pragma unroll
+    for (int offset = 16; offset > 0; offset >>= 1)
+        _warp_reduce_1 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_1, offset);
+    k_sq = _warp_reduce_1;
+    float _rsqrt_0 = rsqrtf(q_sq + 1e-06f);
+    float q_inv = _rsqrt_0;
+    float _rsqrt_1 = rsqrtf(k_sq + 1e-06f);
+    float k_inv = _rsqrt_1;
+    float _expf_0 = __expf(A_log[head]);
+    float gate_a = _expf_0;
+    #pragma unroll
+    for (int i2 = 0; i2 < 4; i2++) {
+        int dim = elem + i2;
+        float biased = g_frag[i2] + dt_bias[head * D + dim];
+        float _expf_1 = __expf((-gate_a) * biased);
+        float _rcp_0 = approx_rcp(1.0f + _expf_1);
+        float gate_sigmoid = _rcp_0;
+        q_norm[base + (long long)dim] = q_frag[i2] * q_inv;
+        k_norm[base + (long long)dim] = k_frag[i2] * k_inv;
+        float _expf_2 = __expf(lower_bound * gate_sigmoid);
+        decay[base + (long long)dim] = _expf_2;
+    }
+    if (lane == 0) {
+        long long beta_index = (long long)token * (long long)num_heads + (long long)head;
+        float beta_raw = (float)beta[beta_index];
+        float _expf_3 = __expf(-beta_raw);
+        float _rcp_1 = approx_rcp(1.0f + _expf_3);
+        beta_active[beta_index] = _rcp_1;
+    }
+}
+
+} // extern "C"
+
+#undef D
+#undef LOOM_INF
+#undef NUM_MAIN_STAGES
+#undef THREADS
+
+#define LOOM_INF CUDART_INF_F
+#define NUM_MAIN_STAGES 1
+#define THREADS 32
+#define D 128
+#define V 128
+
+extern "C" {
+
+__global__ __launch_bounds__(32) void
+kernel_flashkda_backward_checkpoint(float* __restrict__ k_norm, float* __restrict__ decay, float* __restrict__ beta_active, __nv_bfloat16* __restrict__ v, float* __restrict__ initial_state, long long* __restrict__ cu_seqlens, float* __restrict__ checkpoint, int num_sequences, int num_heads)
+{
+    const int tid = threadIdx.x;
+    const int warp = make_warp_uniform(tid / 32);
+    const int lane = tid % 32;
+
+
+    const int bid = blockIdx.x;
+    const int num_bids = gridDim.x;
+
+    // === Task calls (dependency order) ===
+    int work = blockIdx.x;
+    int rows_per_sequence = num_heads * V;
+    int sequence = work / rows_per_sequence;
+    int remainder = work - sequence * rows_per_sequence;
+    int head = remainder / V;
+    int value_row = remainder - head * V;
+    int elem = lane * 4;
+    long long bos = cu_seqlens[sequence];
+    long long eos = cu_seqlens[sequence + 1];
+    long long state_base = (((long long)sequence * (long long)num_heads + (long long)head) * (long long)V + (long long)value_row) * (long long)D;
+    float state[4];
+    {
+        float4 _v4 = *reinterpret_cast<const float4*>(initial_state + state_base + (long long)elem);
+        state[0 + 0] = _v4.x;
+        state[0 + 1] = _v4.y;
+        state[0 + 2] = _v4.z;
+        state[0 + 3] = _v4.w;
+    }
+    #pragma unroll 1
+    for (long long token = bos; token < eos; token++) {
+        long long token_base = (token * (long long)num_heads + (long long)head) * (long long)D;
+        float k_frag[4];
+        float d_frag[4];
+        {
+            float4 _v4 = *reinterpret_cast<const float4*>(k_norm + token_base + (long long)elem);
+            k_frag[0 + 0] = _v4.x;
+            k_frag[0 + 1] = _v4.y;
+            k_frag[0 + 2] = _v4.z;
+            k_frag[0 + 3] = _v4.w;
+        }
+        {
+            float4 _v4 = *reinterpret_cast<const float4*>(decay + token_base + (long long)elem);
+            d_frag[0 + 0] = _v4.x;
+            d_frag[0 + 1] = _v4.y;
+            d_frag[0 + 2] = _v4.z;
+            d_frag[0 + 3] = _v4.w;
+        }
+        float pred = 0.0f;
+        float decayed[4];
+        #pragma unroll
+        for (int i = 0; i < 4; i++) {
+            decayed[i] = state[i] * d_frag[i];
+            float _fma_0 = __fmaf_rn(k_frag[i], decayed[i], pred);
+            pred = _fma_0;
+        }
+        float _warp_reduce_0 = pred;
+        #pragma unroll
+        for (int offset = 16; offset > 0; offset >>= 1)
+            _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
+        pred = _warp_reduce_0;
+        long long beta_index = token * (long long)num_heads + (long long)head;
+        long long value_index = token_base + (long long)value_row;
+        float residual = beta_active[beta_index] * ((float)v[value_index] - pred);
+        long long checkpoint_base = ((token * (long long)num_heads + (long long)head) * (long long)V + (long long)value_row) * (long long)D;
+        #pragma unroll
+        for (int i2 = 0; i2 < 4; i2++) {
+            float _fma_1 = __fmaf_rn(residual, k_frag[i2], decayed[i2]);
+            state[i2] = _fma_1;
+            checkpoint[checkpoint_base + (long long)elem + (long long)i2] = state[i2];
+        }
+    }
+}
+
+} // extern "C"
+
+#undef D
+#undef LOOM_INF
+#undef NUM_MAIN_STAGES
+#undef THREADS
+#undef V
+
+#define LOOM_INF CUDART_INF_F
+#define NUM_MAIN_STAGES 1
+#define THREADS 32
+#define D 128
+#define V 128
+
+extern "C" {
+
+__global__ __launch_bounds__(32) void
+kernel_flashkda_backward_reverse_rows(float* __restrict__ q_norm, float* __restrict__ k_norm, float* __restrict__ decay, float* __restrict__ beta_active, __nv_bfloat16* __restrict__ v, __nv_bfloat16* __restrict__ do_, float* __restrict__ initial_state, float* __restrict__ dfinal_state, long long* __restrict__ cu_seqlens, float* __restrict__ checkpoint, float* __restrict__ dq_normalized, float* __restrict__ dk_normalized, float* __restrict__ dlog_decay, float* __restrict__ dbeta_active, __nv_bfloat16* __restrict__ dv, float* __restrict__ dinitial_state, int num_sequences, int num_heads, float scale)
+{
+    const int tid = threadIdx.x;
+    const int warp = make_warp_uniform(tid / 32);
+    const int lane = tid % 32;
+
+
+    const int bid = blockIdx.x;
+    const int num_bids = gridDim.x;
+
+    // === Task calls (dependency order) ===
+    int work = blockIdx.x;
+    int rows_per_sequence = num_heads * V;
+    int sequence = work / rows_per_sequence;
+    int remainder = work - sequence * rows_per_sequence;
+    int head = remainder / V;
+    int value_row = remainder - head * V;
+    int elem = lane * 4;
+    long long bos = cu_seqlens[sequence];
+    long long eos = cu_seqlens[sequence + 1];
+    long long sequence_length = eos - bos;
+    long long state_base = (((long long)sequence * (long long)num_heads + (long long)head) * (long long)V + (long long)value_row) * (long long)D;
+    float dstate[4];
+    {
+        float4 _v4 = *reinterpret_cast<const float4*>(dfinal_state + state_base + (long long)elem);
+        dstate[0 + 0] = _v4.x;
+        dstate[0 + 1] = _v4.y;
+        dstate[0 + 2] = _v4.z;
+        dstate[0 + 3] = _v4.w;
+    }
+    #pragma unroll 1
+    for (long long reverse_step = 0; reverse_step < sequence_length; reverse_step++) {
+        long long token = eos - 1 - reverse_step;
+        long long token_base = (token * (long long)num_heads + (long long)head) * (long long)D;
+        long long checkpoint_base = ((token * (long long)num_heads + (long long)head) * (long long)V + (long long)value_row) * (long long)D;
+        long long previous_base = checkpoint_base - (long long)num_heads * (long long)V * (long long)D;
+        if (token == bos) {
+            previous_base = state_base;
+        }
+        float q_frag[4];
+        float k_frag[4];
+        float d_frag[4];
+        float state_now[4];
+        float state_prev[4];
+        {
+            float4 _v4 = *reinterpret_cast<const float4*>(q_norm + token_base + (long long)elem);
+            q_frag[0 + 0] = _v4.x;
+            q_frag[0 + 1] = _v4.y;
+            q_frag[0 + 2] = _v4.z;
+            q_frag[0 + 3] = _v4.w;
+        }
+        {
+            float4 _v4 = *reinterpret_cast<const float4*>(k_norm + token_base + (long long)elem);
+            k_frag[0 + 0] = _v4.x;
+            k_frag[0 + 1] = _v4.y;
+            k_frag[0 + 2] = _v4.z;
+            k_frag[0 + 3] = _v4.w;
+        }
+        {
+            float4 _v4 = *reinterpret_cast<const float4*>(decay + token_base + (long long)elem);
+            d_frag[0 + 0] = _v4.x;
+            d_frag[0 + 1] = _v4.y;
+            d_frag[0 + 2] = _v4.z;
+            d_frag[0 + 3] = _v4.w;
+        }
+        {
+            float4 _v4 = *reinterpret_cast<const float4*>(checkpoint + checkpoint_base + (long long)elem);
+            state_now[0 + 0] = _v4.x;
+            state_now[0 + 1] = _v4.y;
+            state_now[0 + 2] = _v4.z;
+            state_now[0 + 3] = _v4.w;
+        }
+        if (token == bos) {
+            {
+                float4 _v4 = *reinterpret_cast<const float4*>(initial_state + previous_base + (long long)elem);
+                state_prev[0 + 0] = _v4.x;
+                state_prev[0 + 1] = _v4.y;
+                state_prev[0 + 2] = _v4.z;
+                state_prev[0 + 3] = _v4.w;
+            }
+        } else {
+            {
+                float4 _v4 = *reinterpret_cast<const float4*>(checkpoint + previous_base + (long long)elem);
+                state_prev[0 + 0] = _v4.x;
+                state_prev[0 + 1] = _v4.y;
+                state_prev[0 + 2] = _v4.z;
+                state_prev[0 + 3] = _v4.w;
+            }
+        }
+        long long value_index = token_base + (long long)value_row;
+        float output_adjoint = (float)do_[value_index];
+        float pred = 0.0f;
+        #pragma unroll
+        for (int i = 0; i < 4; i++) {
+            float _fma_0 = __fmaf_rn(scale * output_adjoint, q_frag[i], dstate[i]);
+            dstate[i] = _fma_0;
+            float _fma_1 = __fmaf_rn(k_frag[i], state_prev[i] * d_frag[i], pred);
+            pred = _fma_1;
+        }
+        float _warp_reduce_0 = pred;
+        #pragma unroll
+        for (int offset = 16; offset > 0; offset >>= 1)
+            _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
+        pred = _warp_reduce_0;
+        float dr = 0.0f;
+        #pragma unroll
+        for (int i2 = 0; i2 < 4; i2++) {
+            float _fma_2 = __fmaf_rn(dstate[i2], k_frag[i2], dr);
+            dr = _fma_2;
+        }
+        float _warp_reduce_1 = dr;
+        #pragma unroll
+        for (int offset = 16; offset > 0; offset >>= 1)
+            _warp_reduce_1 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_1, offset);
+        dr = _warp_reduce_1;
+        long long beta_index = token * (long long)num_heads + (long long)head;
+        float beta_value = beta_active[beta_index];
+        float value_raw = (float)v[value_index];
+        float residual = beta_value * (value_raw - pred);
+        float dpred = (-dr) * beta_value;
+        #pragma unroll
+        for (int i3 = 0; i3 < 4; i3++) {
+            long long dim_index = token_base + (long long)elem + (long long)i3;
+            float decayed_state = state_prev[i3] * d_frag[i3];
+            float _fma_3 = __fmaf_rn(dpred, k_frag[i3], dstate[i3]);
+            float d_p = _fma_3;
+            float _fma_4 = __fmaf_rn(dpred, decayed_state, residual * dstate[i3]);
+            float d_k = _fma_4;
+            atomicAdd(&dq_normalized[dim_index], scale * output_adjoint * state_now[i3]);
+            atomicAdd(&dk_normalized[dim_index], d_k);
+            atomicAdd(&dlog_decay[dim_index], d_p * state_prev[i3] * d_frag[i3]);
+            dstate[i3] = d_p * d_frag[i3];
+        }
+        if (lane == 0) {
+            atomicAdd(&dbeta_active[beta_index], dr * (value_raw - pred));
+            __nv_bfloat16 _cvt_bf16_0 = __float2bfloat16(dr * beta_value);
+            dv[value_index] = _cvt_bf16_0;
+        }
+    }
+    #pragma unroll
+    for (int i4 = 0; i4 < 4; i4++) {
+        dinitial_state[state_base + (long long)elem + (long long)i4] = dstate[i4];
+    }
+}
+
+} // extern "C"
+
+#undef D
+#undef LOOM_INF
+#undef NUM_MAIN_STAGES
+#undef THREADS
+#undef V
+
+#define LOOM_INF CUDART_INF_F
+#define NUM_MAIN_STAGES 1
+#define THREADS 32
+#define D 128
+
+extern "C" {
+
+__global__ __launch_bounds__(32) void
+kernel_flashkda_backward_finalize_tokens(__nv_bfloat16* __restrict__ q, __nv_bfloat16* __restrict__ k, __nv_bfloat16* __restrict__ g, float* __restrict__ beta_active, float* __restrict__ A_log, float* __restrict__ dt_bias, float* __restrict__ q_norm, float* __restrict__ k_norm, float* __restrict__ dq_normalized, float* __restrict__ dk_normalized, float* __restrict__ gate_common, float* __restrict__ dbeta_active, __nv_bfloat16* __restrict__ dq, __nv_bfloat16* __restrict__ dk, __nv_bfloat16* __restrict__ dg, __nv_bfloat16* __restrict__ dbeta, int num_heads, float lower_bound)
+{
+    const int tid = threadIdx.x;
+    const int warp = make_warp_uniform(tid / 32);
+    const int lane = tid % 32;
+
+
+    const int bid = blockIdx.x;
+    const int num_bids = gridDim.x;
+
+    // === Task calls (dependency order) ===
+    int token = blockIdx.x;
+    int head = blockIdx.y;
+    int elem = lane * 4;
+    long long base = ((long long)token * (long long)num_heads + (long long)head) * (long long)D;
+    float q_raw[4];
+    float k_raw[4];
+    float g_raw[4];
+    float qn[4];
+    float kn[4];
+    float dqn[4];
+    float dkn[4];
+    float dlog[4];
+    {
+        uint2 _vld_0;
+        _vld_0 = *reinterpret_cast<const uint2*>(q + base + (long long)elem);
+        uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0);
+        #pragma unroll
+        for (int _pair = 0; _pair < 2; _pair++) {
+            asm volatile(
+                "{\n\t"
+                "shl.b32 %0, %2, 16;\n\t"
+                "and.b32 %1, %2, 0xffff0000;\n\t"
+                "}\n"
+                : "=f"((&q_raw[0 + _pair * 2])[0]), "=f"((&q_raw[0 + _pair * 2])[1])
+                : "r"(_vpairs_0[_pair]));
+        }
+    }
+    {
+        uint2 _vld_1;
+        _vld_1 = *reinterpret_cast<const uint2*>(k + base + (long long)elem);
+        uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1);
+        #pragma unroll
+        for (int _pair = 0; _pair < 2; _pair++) {
+            asm volatile(
+                "{\n\t"
+                "shl.b32 %0, %2, 16;\n\t"
+                "and.b32 %1, %2, 0xffff0000;\n\t"
+                "}\n"
+                : "=f"((&k_raw[0 + _pair * 2])[0]), "=f"((&k_raw[0 + _pair * 2])[1])
+                : "r"(_vpairs_1[_pair]));
+        }
+    }
+    {
+        uint2 _vld_2;
+        _vld_2 = *reinterpret_cast<const uint2*>(g + base + (long long)elem);
+        uint32_t* _vpairs_2 = reinterpret_cast<uint32_t*>(&_vld_2);
+        #pragma unroll
+        for (int _pair = 0; _pair < 2; _pair++) {
+            asm volatile(
+                "{\n\t"
+                "shl.b32 %0, %2, 16;\n\t"
+                "and.b32 %1, %2, 0xffff0000;\n\t"
+                "}\n"
+                : "=f"((&g_raw[0 + _pair * 2])[0]), "=f"((&g_raw[0 + _pair * 2])[1])
+                : "r"(_vpairs_2[_pair]));
+        }
+    }
+    {
+        float4 _v4 = *reinterpret_cast<const float4*>(q_norm + base + (long long)elem);
+        qn[0 + 0] = _v4.x;
+        qn[0 + 1] = _v4.y;
+        qn[0 + 2] = _v4.z;
+        qn[0 + 3] = _v4.w;
+    }
+    {
+        float4 _v4 = *reinterpret_cast<const float4*>(k_norm + base + (long long)elem);
+        kn[0 + 0] = _v4.x;
+        kn[0 + 1] = _v4.y;
+        kn[0 + 2] = _v4.z;
+        kn[0 + 3] = _v4.w;
+    }
+    {
+        float4 _v4 = *reinterpret_cast<const float4*>(dq_normalized + base + (long long)elem);
+        dqn[0 + 0] = _v4.x;
+        dqn[0 + 1] = _v4.y;
+        dqn[0 + 2] = _v4.z;
+        dqn[0 + 3] = _v4.w;
+    }
+    {
+        float4 _v4 = *reinterpret_cast<const float4*>(dk_normalized + base + (long long)elem);
+        dkn[0 + 0] = _v4.x;
+        dkn[0 + 1] = _v4.y;
+        dkn[0 + 2] = _v4.z;
+        dkn[0 + 3] = _v4.w;
+    }
+    {
+        float4 _v4 = *reinterpret_cast<const float4*>(gate_common + base + (long long)elem);
+        dlog[0 + 0] = _v4.x;
+        dlog[0 + 1] = _v4.y;
+        dlog[0 + 2] = _v4.z;
+        dlog[0 + 3] = _v4.w;
+    }
+    float q_sq = 0.0f;
+    float k_sq = 0.0f;
+    float q_dot = 0.0f;
+    float k_dot = 0.0f;
+    #pragma unroll
+    for (int i = 0; i < 4; i++) {
+        float _fma_0 = __fmaf_rn(q_raw[i], q_raw[i], q_sq);
+        q_sq = _fma_0;
+        float _fma_1 = __fmaf_rn(k_raw[i], k_raw[i], k_sq);
+        k_sq = _fma_1;
+        float _fma_2 = __fmaf_rn(dqn[i], qn[i], q_dot);
+        q_dot = _fma_2;
+        float _fma_3 = __fmaf_rn(dkn[i], kn[i], k_dot);
+        k_dot = _fma_3;
+    }
+    float _warp_reduce_0 = q_sq;
+    #pragma unroll
+    for (int offset = 16; offset > 0; offset >>= 1)
+        _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
+    q_sq = _warp_reduce_0;
+    float _warp_reduce_1 = k_sq;
+    #pragma unroll
+    for (int offset = 16; offset > 0; offset >>= 1)
+        _warp_reduce_1 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_1, offset);
+    k_sq = _warp_reduce_1;
+    float _warp_reduce_2 = q_dot;
+    #pragma unroll
+    for (int offset = 16; offset > 0; offset >>= 1)
+        _warp_reduce_2 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_2, offset);
+    q_dot = _warp_reduce_2;
+    float _warp_reduce_3 = k_dot;
+    #pragma unroll
+    for (int offset = 16; offset > 0; offset >>= 1)
+        _warp_reduce_3 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_3, offset);
+    k_dot = _warp_reduce_3;
+    float _rsqrt_0 = rsqrtf(q_sq + 1e-06f);
+    float q_inv = _rsqrt_0;
+    float _rsqrt_1 = rsqrtf(k_sq + 1e-06f);
+    float k_inv = _rsqrt_1;
+    float _expf_0 = __expf(A_log[head]);
+    float gate_a = _expf_0;
+    #pragma unroll
+    for (int i2 = 0; i2 < 4; i2++) {
+        int dim = elem + i2;
+        long long index = base + (long long)dim;
+        float biased = g_raw[i2] + dt_bias[head * D + dim];
+        float _expf_1 = __expf((-gate_a) * biased);
+        float _rcp_0 = approx_rcp(1.0f + _expf_1);
+        float gate_sigmoid = _rcp_0;
+        float common = dlog[i2] * lower_bound * gate_sigmoid * (1.0f - gate_sigmoid) * gate_a;
+        __nv_bfloat16 _cvt_bf16_0 = __float2bfloat16(q_inv * (dqn[i2] - qn[i2] * q_dot));
+        dq[index] = _cvt_bf16_0;
+        __nv_bfloat16 _cvt_bf16_1 = __float2bfloat16(k_inv * (dkn[i2] - kn[i2] * k_dot));
+        dk[index] = _cvt_bf16_1;
+        __nv_bfloat16 _cvt_bf16_2 = __float2bfloat16(common);
+        dg[index] = _cvt_bf16_2;
+        gate_common[index] = common;
+    }
+    if (lane == 0) {
+        long long beta_index = (long long)token * (long long)num_heads + (long long)head;
+        float beta_sigmoid = beta_active[beta_index];
+        __nv_bfloat16 _cvt_bf16_3 = __float2bfloat16(dbeta_active[beta_index] * beta_sigmoid * (1.0f - beta_sigmoid));
+        dbeta[beta_index] = _cvt_bf16_3;
+    }
+}
+
+} // extern "C"
+
+#undef D
+#undef LOOM_INF
+#undef NUM_MAIN_STAGES
+#undef THREADS
+
+#define LOOM_INF CUDART_INF_F
+#define NUM_MAIN_STAGES 1
+#define SMEM_SMEM_DA_OFF 0
+#define SMEM_SMEM_DA_STAGE_BYTES 16
+#define SMEM_SMEM_DA_STRIDE 16
+#define SMEM_TOTAL 128
+#define THREADS 128
+#define D 128
+
+extern "C" {
+
+__global__ __launch_bounds__(128) void
+kernel_flashkda_backward_gate_reduce_split(float* __restrict__ gate_common, __nv_bfloat16* __restrict__ g, float* __restrict__ dt_bias, float* __restrict__ dA_log, float* __restrict__ ddt_bias, int total_tokens, int num_heads, int tokens_per_split)
+{
+    const int tid = threadIdx.x;
+    const int warp = make_warp_uniform(tid / 32);
+    const int lane = tid % 32;
+
+    extern __shared__ __align__(1024) char smem_raw[];
+    int smem;
+    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+
+    const int bid = blockIdx.x;
+    const int num_bids = gridDim.x;
+
+    // Kernel setup ops
+    float* smem_dA = reinterpret_cast<float*>(smem_raw + 0);
+    const int smem_dA_addr = smem + 0;
+
+    // === Task calls (dependency order) ===
+    int head = blockIdx.x;
+    int split = blockIdx.y;
+    int dim = tid;
+    int token_start = split * tokens_per_split;
+    int token_end = token_start + tokens_per_split;
+    if (token_end > total_tokens) {
+        token_end = total_tokens;
+    }
+    float bias = dt_bias[head * D + dim];
+    float ddt_sum = 0.0f;
+    float dA_sum = 0.0f;
+    #pragma unroll 4
+    for (int token = token_start; token < token_end; token++) {
+        long long index = ((long long)token * (long long)num_heads + (long long)head) * (long long)D + (long long)dim;
+        float common = gate_common[index];
+        ddt_sum += common;
+        float _fma_0 = __fmaf_rn(common, (float)g[index] + bias, dA_sum);
+        dA_sum = _fma_0;
+    }
+    atomicAdd(&ddt_bias[head * D + dim], ddt_sum);
+    float _warp_reduce_0 = dA_sum;
+    #pragma unroll
+    for (int offset = 16; offset > 0; offset >>= 1)
+        _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
+    dA_sum = _warp_reduce_0;
+    if (lane == 0) {
+        smem_dA[warp] = dA_sum;
+    }
+    __syncthreads();
+    if (warp == 0) {
+        if (elect_sync()) {
+            atomicAdd(&dA_log[head], smem_dA[0] + smem_dA[1] + smem_dA[2] + smem_dA[3]);
+        }
+    }
+}
+
+} // extern "C"
+
+#undef D
+#undef LOOM_INF
+#undef NUM_MAIN_STAGES
+#undef SMEM_SMEM_DA_OFF
+#undef SMEM_SMEM_DA_STAGE_BYTES
+#undef SMEM_SMEM_DA_STRIDE
+#undef SMEM_TOTAL
+#undef THREADS
+#undef smem_dA_addr
+
+#define LOOM_INF CUDART_INF_F
+#define TMEM_NCOLS 256
+#define TMEM_TMEM_STATE_OFFSET 64
+#define TMEM_TMEM_STATE_INP_OFFSET 0
+#define TMEM_TMEM_U_ACC_OFFSET 224
+#define TMEM_TMEM_U2_INP_OFFSET 224
+#define TMEM_TMEM_U2_ACC_OFFSET 0
+#define TMEM_TMEM_OUT_OFFSET 192
+#define TMEM_TMEM_STATE_OUT_OFFSET 64
+#define NUM_CHUNK_PIPE_STAGES 5
+#define NUM_CHECKPOINT_PIPE_STAGES 2
+#define SMEM_SMEM_QD_OFF 1024
+#define SMEM_SMEM_QD_STAGE_BYTES 8192
+#define SMEM_SMEM_QD_STRIDE 41984
+#define SMEM_SMEM_G_RAW_OFF 1024
+#define SMEM_SMEM_G_RAW_STAGE_BYTES 8192
+#define SMEM_SMEM_G_RAW_STRIDE 41984
+#define SMEM_SMEM_G_RAW_ALL_OFF 1024
+#define SMEM_SMEM_G_RAW_ALL_STAGE_BYTES 176128
+#define SMEM_SMEM_G_RAW_ALL_STRIDE 176128
+#define SMEM_SMEM_KD_OFF 9216
+#define SMEM_SMEM_KD_STAGE_BYTES 8192
+#define SMEM_SMEM_KD_STRIDE 41984
+#define SMEM_SMEM_Q_RAW_PREFETCH_OFF 17408
+#define SMEM_SMEM_Q_RAW_PREFETCH_STAGE_BYTES 8192
+#define SMEM_SMEM_Q_RAW_PREFETCH_STRIDE 41984
+#define SMEM_SMEM_FINAL_TRANS_OFF 17408
+#define SMEM_SMEM_FINAL_TRANS_STAGE_BYTES 12288
+#define SMEM_SMEM_FINAL_TRANS_STRIDE 41984
+#define SMEM_SMEM_KR_TRANS_OFF 17408
+#define SMEM_SMEM_KR_TRANS_STAGE_BYTES 8192
+#define SMEM_SMEM_KR_TRANS_STRIDE 41984
+#define SMEM_SMEM_MQK_TRANS_OFF 25600
+#define SMEM_SMEM_MQK_TRANS_STAGE_BYTES 2048
+#define SMEM_SMEM_MQK_TRANS_STRIDE 41984
+#define SMEM_SMEM_INV_OFF 29696
+#define SMEM_SMEM_INV_STAGE_BYTES 2048
+#define SMEM_SMEM_INV_STRIDE 41984
+#define SMEM_SMEM_V_OFF 32384
+#define SMEM_SMEM_V_STAGE_BYTES 8192
+#define SMEM_SMEM_V_STRIDE 41984
+#define SMEM_SMEM_SHORT_N32_V_OFF 168960
+#define SMEM_SMEM_SHORT_N32_V_STAGE_BYTES 32768
+#define SMEM_SMEM_SHORT_N32_V_STRIDE 32768
+#define SMEM_SMEM_KI_OFF 17408
+#define SMEM_SMEM_KI_STAGE_BYTES 8192
+#define SMEM_SMEM_KI_STRIDE 41984
+#define SMEM_SMEM_GATE_OFF 25600
+#define SMEM_SMEM_GATE_STAGE_BYTES 16384
+#define SMEM_SMEM_GATE_STRIDE 41984
+#define SMEM_SMEM_BETA_RAW_OFF 41984
+#define SMEM_SMEM_BETA_RAW_STAGE_BYTES 512
+#define SMEM_SMEM_BETA_RAW_STRIDE 41984
+#define SMEM_SMEM_BETA_RAW_ALL_OFF 41984
+#define SMEM_SMEM_BETA_RAW_ALL_STAGE_BYTES 168448
+#define SMEM_SMEM_BETA_RAW_ALL_STRIDE 168448
+#define SMEM_SMEM_INV_WORK_OFF 32384
+#define SMEM_SMEM_INV_WORK_STAGE_BYTES 4096
+#define SMEM_SMEM_INV_WORK_STRIDE 41984
+#define SMEM_SMEM_OUT_OFF 210944
+#define SMEM_SMEM_OUT_STAGE_BYTES 8192
+#define SMEM_SMEM_OUT_STRIDE 8192
+#define SMEM_SMEM_CHECKPOINT_OFF 228352
+#define SMEM_SMEM_CHECKPOINT_STAGE_BYTES 32768
+#define SMEM_SMEM_CHECKPOINT_STRIDE 32768
+#define SMEM_SMEM_RESTORE_FACTOR_ALL_OFF 41984
+#define SMEM_SMEM_RESTORE_FACTOR_ALL_STAGE_BYTES 168452
+#define SMEM_SMEM_RESTORE_FACTOR_ALL_STRIDE 168452
+#define SMEM_SMEM_GT_PREFIX_ALL_OFF 41472
+#define SMEM_SMEM_GT_PREFIX_ALL_STAGE_BYTES 168448
+#define SMEM_SMEM_GT_PREFIX_ALL_STRIDE 168448
+#define SMEM_SMEM_GT_ALL_OFF 31744
+#define SMEM_SMEM_GT_ALL_STAGE_BYTES 168448
+#define SMEM_SMEM_GT_ALL_STRIDE 168448
+#define SMEM_SMEM_PREP_BETA_ALL_OFF 42500
+#define SMEM_SMEM_PREP_BETA_ALL_STAGE_BYTES 168064
+#define SMEM_SMEM_PREP_BETA_ALL_STRIDE 168064
+#define SMEM_SMEM_PREP_BETA_BF16_ALL_OFF 42500
+#define SMEM_SMEM_PREP_BETA_BF16_ALL_STAGE_BYTES 168000
+#define SMEM_SMEM_PREP_BETA_BF16_ALL_STRIDE 168000
+#define SMEM_SMEM_PREP_BETA_U32_ALL_OFF 42500
+#define SMEM_SMEM_PREP_BETA_U32_ALL_STAGE_BYTES 168000
+#define SMEM_SMEM_PREP_BETA_U32_ALL_STRIDE 168000
+#define SMEM_SMEM_GATE_RATE_ALL_OFF 42628
+#define SMEM_SMEM_GATE_RATE_ALL_STAGE_BYTES 167940
+#define SMEM_SMEM_GATE_RATE_ALL_STRIDE 167940
+#define SMEM_SMEM_GATE_BIAS_ALL_OFF 227408
+#define SMEM_SMEM_GATE_BIAS_ALL_STAGE_BYTES 512
+#define SMEM_SMEM_GATE_BIAS_ALL_STRIDE 512
+#define SMEM_SMEM_V_ALL_OFF 32384
+#define SMEM_SMEM_V_ALL_STAGE_BYTES 176128
+#define SMEM_SMEM_V_ALL_STRIDE 176128
+#define SMEM_SMEM_GATE_ALL_OFF 25600
+#define SMEM_SMEM_GATE_ALL_STAGE_BYTES 184320
+#define SMEM_SMEM_GATE_ALL_STRIDE 184320
+#define SMEM_SMEM_STATE_CHECKPOINT_NEEDED_OFF 227328
+#define SMEM_SMEM_STATE_CHECKPOINT_NEEDED_STAGE_BYTES 80
+#define SMEM_SMEM_STATE_CHECKPOINT_NEEDED_STRIDE 80
+#define SMEM_SMEM_WORK_ITEM_WARP_MAX_OFF 227328
+#define SMEM_SMEM_WORK_ITEM_WARP_MAX_STAGE_BYTES 16
+#define SMEM_SMEM_WORK_ITEM_WARP_MAX_STRIDE 16
+#define SMEM_SMEM_WORK_ITEM_COMPUTE_START_OFF 227344
+#define SMEM_SMEM_WORK_ITEM_COMPUTE_START_STAGE_BYTES 4
+#define SMEM_SMEM_WORK_ITEM_COMPUTE_START_STRIDE 4
+#define SMEM_SMEM_WORK_ITEM_RESOLVED_OFF 227348
+#define SMEM_SMEM_WORK_ITEM_RESOLVED_STAGE_BYTES 4
+#define SMEM_SMEM_WORK_ITEM_RESOLVED_STRIDE 4
+#define SMEM_TOTAL 227968
+#define STORE_BACKWARD_TAPE 1
+#define STORE_E_TAPE 0
+#define SPLIT_WORK_ITEMS 0
+
+extern "C" {
+
+__global__ __launch_bounds__(1024) void
+kernel_flashkda_bf16_fused_m128_unsplit(__nv_bfloat16* __restrict__ q, LoomTensorMap const* q_tma, __nv_bfloat16* __restrict__ k, LoomTensorMap const* k_tma, __nv_bfloat16* __restrict__ v, LoomTensorMap const* v_tma, __nv_bfloat16* __restrict__ g, LoomTensorMap const* g_tma, __nv_bfloat16* __restrict__ beta, LoomTensorMap const* beta_tma, float* __restrict__ A_log, float* __restrict__ dt_bias, long long* __restrict__ cu_seqlens, int* __restrict__ seq_order, __nv_bfloat16* __restrict__ initial_state, __nv_bfloat16* __restrict__ out, LoomTensorMap const* out_tma, __nv_bfloat16* __restrict__ final_state, int num_heads, int use_initial_state, int store_final_state, float scale, float lower_bound, unsigned long long state_indices_addr, unsigned long long state_checkpoints_addr, unsigned long long checkpoint_cu_starts_addr, long long beta_token_stride, long long state_slot_stride, int use_state_indices, int checkpoint_every_n_tokens, long long* __restrict__ cu_chunk_offsets, __nv_bfloat16* __restrict__ chunk_state, unsigned int* __restrict__ state_checkpoint_needed, __nv_bfloat16* __restrict__ tape_qd, __nv_bfloat16* __restrict__ tape_kd, __nv_bfloat16* __restrict__ tape_kr, __nv_bfloat16* __restrict__ tape_j, float* __restrict__ tape_restore_factor, __nv_bfloat16* __restrict__ tape_e, __nv_bfloat16* __restrict__ tape_x, __nv_bfloat16* __restrict__ tape_r, float* __restrict__ norm_inv_out, __nv_bfloat16* __restrict__ decay_out, float* __restrict__ beta_active_out, float* __restrict__ initial_state_f32, unsigned int* __restrict__ zero_workspace, int zero_words, int num_sequences, LoomTensorMap const* state_checkpoints_tma)
+{
+    const int tid = threadIdx.x;
+    const int warp = make_warp_uniform(tid / 32);
+    const int lane = tid % 32;
+
+    extern __shared__ __align__(1024) char smem_raw[];
+    int smem;
+    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+
+    const int bid = blockIdx.x;
+    const int num_bids = gridDim.x;
+    if (warp == 8 && lane == 0) {
+        asm volatile("fence.proxy.tensormap::generic.acquire.sys [%0], 128;" :: "l"((uint64_t)(q_tma)) : "memory");
+        asm volatile("fence.proxy.tensormap::generic.acquire.sys [%0], 128;" :: "l"((uint64_t)(k_tma)) : "memory");
+        asm volatile("fence.proxy.tensormap::generic.acquire.sys [%0], 128;" :: "l"((uint64_t)(v_tma)) : "memory");
+        asm volatile("fence.proxy.tensormap::generic.acquire.sys [%0], 128;" :: "l"((uint64_t)(g_tma)) : "memory");
+        asm volatile("fence.proxy.tensormap::generic.acquire.sys [%0], 128;" :: "l"((uint64_t)(beta_tma)) : "memory");
+        asm volatile("fence.proxy.tensormap::generic.acquire.sys [%0], 128;" :: "l"((uint64_t)(out_tma)) : "memory");
+        asm volatile("fence.proxy.tensormap::generic.acquire.sys [%0], 128;" :: "l"((uint64_t)(state_checkpoints_tma)) : "memory");
+    }
+
+
+    // Kernel setup ops
+    __nv_bfloat16* smem_qd = reinterpret_cast<__nv_bfloat16*>(smem_raw + 1024);
+    const int smem_qd_addr = smem + 1024;
+    __nv_bfloat16* smem_g_raw = reinterpret_cast<__nv_bfloat16*>(smem_raw + 1024);
+    const int smem_g_raw_addr = smem + 1024;
+    __nv_bfloat16* smem_g_raw_all = reinterpret_cast<__nv_bfloat16*>(smem_raw + 1024);
+    const int smem_g_raw_all_addr = smem + 1024;
+    __nv_bfloat16* smem_kd = reinterpret_cast<__nv_bfloat16*>(smem_raw + 9216);
+    const int smem_kd_addr = smem + 9216;
+    __nv_bfloat16* smem_q_raw_prefetch = reinterpret_cast<__nv_bfloat16*>(smem_raw + 17408);
+    const int smem_q_raw_prefetch_addr = smem + 17408;
+    __nv_bfloat16* smem_final_trans = reinterpret_cast<__nv_bfloat16*>(smem_raw + 17408);
+    const int smem_final_trans_addr = smem + 17408;
+    __nv_bfloat16* smem_kr_trans = reinterpret_cast<__nv_bfloat16*>(smem_raw + 17408);
+    const int smem_kr_trans_addr = smem + 17408;
+    __nv_bfloat16* smem_mqk_trans = reinterpret_cast<__nv_bfloat16*>(smem_raw + 25600);
+    const int smem_mqk_trans_addr = smem + 25600;
+    __nv_bfloat16* smem_inv = reinterpret_cast<__nv_bfloat16*>(smem_raw + 29696);
+    const int smem_inv_addr = smem + 29696;
+    __nv_bfloat16* smem_v = reinterpret_cast<__nv_bfloat16*>(smem_raw + 32384);
+    const int smem_v_addr = smem + 32384;
+    __nv_bfloat16* smem_short_n32_v = reinterpret_cast<__nv_bfloat16*>(smem_raw + 168960);
+    const int smem_short_n32_v_addr = smem + 168960;
+    __nv_bfloat16* smem_ki = reinterpret_cast<__nv_bfloat16*>(smem_raw + 17408);
+    const int smem_ki_addr = smem + 17408;
+    float* smem_gate = reinterpret_cast<float*>(smem_raw + 25600);
+    const int smem_gate_addr = smem + 25600;
+    __nv_bfloat16* smem_beta_raw = reinterpret_cast<__nv_bfloat16*>(smem_raw + 41984);
+    const int smem_beta_raw_addr = smem + 41984;
+    __nv_bfloat16* smem_beta_raw_all = reinterpret_cast<__nv_bfloat16*>(smem_raw + 41984);
+    const int smem_beta_raw_all_addr = smem + 41984;
+    __nv_bfloat16* smem_inv_work = reinterpret_cast<__nv_bfloat16*>(smem_raw + 32384);
+    const int smem_inv_work_addr = smem + 32384;
+    __nv_bfloat16* smem_out = reinterpret_cast<__nv_bfloat16*>(smem_raw + 210944);
+    const int smem_out_addr = smem + 210944;
+    __nv_bfloat16* smem_checkpoint = reinterpret_cast<__nv_bfloat16*>(smem_raw + 228352);
+    const int smem_checkpoint_addr = smem + 228352;
+    float* smem_restore_factor_all = reinterpret_cast<float*>(smem_raw + 41984);
+    const int smem_restore_factor_all_addr = smem + 41984;
+    float* smem_gt_prefix_all = reinterpret_cast<float*>(smem_raw + 41472);
+    const int smem_gt_prefix_all_addr = smem + 41472;
+    float* smem_gt_all = reinterpret_cast<float*>(smem_raw + 31744);
+    const int smem_gt_all_addr = smem + 31744;
+    float* smem_prep_beta_all = reinterpret_cast<float*>(smem_raw + 42500);
+    const int smem_prep_beta_all_addr = smem + 42500;
+    __nv_bfloat16* smem_prep_beta_bf16_all = reinterpret_cast<__nv_bfloat16*>(smem_raw + 42500);
+    const int smem_prep_beta_bf16_all_addr = smem + 42500;
+    unsigned int* smem_prep_beta_u32_all = reinterpret_cast<unsigned int*>(smem_raw + 42500);
+    const int smem_prep_beta_u32_all_addr = smem + 42500;
+    float* smem_gate_rate_all = reinterpret_cast<float*>(smem_raw + 42628);
+    const int smem_gate_rate_all_addr = smem + 42628;
+    float* smem_gate_bias_all = reinterpret_cast<float*>(smem_raw + 227408);
+    const int smem_gate_bias_all_addr = smem + 227408;
+    __nv_bfloat16* smem_v_all = reinterpret_cast<__nv_bfloat16*>(smem_raw + 32384);
+    const int smem_v_all_addr = smem + 32384;
+    float* smem_gate_all = reinterpret_cast<float*>(smem_raw + 25600);
+    const int smem_gate_all_addr = smem + 25600;
+    unsigned int* smem_state_checkpoint_needed = reinterpret_cast<unsigned int*>(smem_raw + 227328);
+    const int smem_state_checkpoint_needed_addr = smem + 227328;
+    float* smem_work_item_warp_max = reinterpret_cast<float*>(smem_raw + 227328);
+    const int smem_work_item_warp_max_addr = smem + 227328;
+    int* smem_work_item_compute_start = reinterpret_cast<int*>(smem_raw + 227344);
+    const int smem_work_item_compute_start_addr = smem + 227344;
+    unsigned int* smem_work_item_resolved = reinterpret_cast<unsigned int*>(smem_raw + 227348);
+    const int smem_work_item_resolved_addr = smem + 227348;
+
+    // Mbarrier init (23 groups, 97 barriers)
+    // Mbarriers at smem_raw[0..776)
+
+    if (warp == 10) {
+        // --- pipeline 'chunk_pipe' ---
+        // qk_full: 5 barriers, init_count=1
+        // tape_ready: 5 barriers, init_count=1
+        // tape_free: 5 barriers, init_count=2
+        // gate_raw_full: 5 barriers, init_count=1
+        // qk_raw_full: 5 barriers, init_count=1
+        // v_full: 5 barriers, init_count=1
+        // v_free: 5 barriers, init_count=4
+        // smem_free: 5 barriers, init_count=1
+        // raw_inputs_free: 5 barriers, init_count=1
+        // state_inp_ready: 5 barriers, init_count=4
+        // old_out_ready: 5 barriers, init_count=1
+        // u_inp_ready: 5 barriers, init_count=4
+        // u2_acc_ready: 5 barriers, init_count=1
+        // u2_inp_ready: 5 barriers, init_count=4
+        // final_ready: 5 barriers, init_count=1
+        // out_empty: 1 barriers, init_count=1
+        // tmem_dealloc_ready: 1 barriers, init_count=2
+        // --- pipeline 'checkpoint_pipe' ---
+        // checkpoint_ready: 2 barriers, init_count=4
+        // checkpoint_free: 2 barriers, init_count=1
+        // --- pipeline 'chunk_pipe' ---
+        // prep_diag_ready: 5 barriers, init_count=2
+        // prep_inv16_ready: 5 barriers, init_count=2
+        // work_item_ready: 1 barriers, init_count=1
+        // short_beta_ready: 5 barriers, init_count=1
+        // Warp-cooperative initialization, grouped by equal arrival count.
+        for (int _bar = lane; _bar < 10; _bar += 32) {
+            mbarrier_init(smem + 0 + _bar * 8, 1);
+        }
+        for (int _bar = lane; _bar < 5; _bar += 32) {
+            mbarrier_init(smem + 80 + _bar * 8, 2);
+        }
+        for (int _bar = lane; _bar < 15; _bar += 32) {
+            mbarrier_init(smem + 120 + _bar * 8, 1);
+        }
+        for (int _bar = lane; _bar < 5; _bar += 32) {
+            mbarrier_init(smem + 240 + _bar * 8, 4);
+        }
+        for (int _bar = lane; _bar < 10; _bar += 32) {
+            mbarrier_init(smem + 280 + _bar * 8, 1);
+        }
+        for (int _bar = lane; _bar < 5; _bar += 32) {
+            mbarrier_init(smem + 360 + _bar * 8, 4);
+        }
+        for (int _bar = lane; _bar < 5; _bar += 32) {
+            mbarrier_init(smem + 400 + _bar * 8, 1);
+        }
+        for (int _bar = lane; _bar < 5; _bar += 32) {
+            mbarrier_init(smem + 440 + _bar * 8, 4);
+        }
+        for (int _bar = lane; _bar < 5; _bar += 32) {
+            mbarrier_init(smem + 480 + _bar * 8, 1);
+        }
+        for (int _bar = lane; _bar < 5; _bar += 32) {
+            mbarrier_init(smem + 520 + _bar * 8, 4);
+        }
+        for (int _bar = lane; _bar < 6; _bar += 32) {
+            mbarrier_init(smem + 560 + _bar * 8, 1);
+        }
+        for (int _bar = lane; _bar < 1; _bar += 32) {
+            mbarrier_init(smem + 608 + _bar * 8, 2);
+        }
+        for (int _bar = lane; _bar < 2; _bar += 32) {
+            mbarrier_init(smem + 616 + _bar * 8, 4);
+        }
+        for (int _bar = lane; _bar < 2; _bar += 32) {
+            mbarrier_init(smem + 632 + _bar * 8, 1);
+        }
+        for (int _bar = lane; _bar < 10; _bar += 32) {
+            mbarrier_init(smem + 648 + _bar * 8, 2);
+        }
+        for (int _bar = lane; _bar < 6; _bar += 32) {
+            mbarrier_init(smem + 728 + _bar * 8, 1);
+        }
+        asm volatile("fence.mbarrier_init.release.cluster;");
+    }
+
+    __syncwarp();
+
+    // TMEM alloc (256 columns, 256 used)
+    volatile int* tmem_addr_storage = (volatile int*)(smem_raw + 776);
+    if (warp == 0) {
+        int _tmem_hold = smem + 776;
+        asm volatile("tcgen05.alloc.cta_group::1.sync.aligned.shared::cta.b32 [%0], %1;" :: "r"(_tmem_hold), "r"(256) : "memory");
+        asm volatile("tcgen05.relinquish_alloc_permit.cta_group::1.sync.aligned;");
+    }
+
+    __syncthreads();
+    asm volatile("tcgen05.fence::after_thread_sync;");
+
+    const int mbar_base = smem;
+    #define qk_full_addr (mbar_base + 0)
+    #define tape_ready_addr (mbar_base + 40)
+    #define tape_free_addr (mbar_base + 80)
+    #define gate_raw_full_addr (mbar_base + 120)
+    #define qk_raw_full_addr (mbar_base + 160)
+    #define v_full_addr (mbar_base + 200)
+    #define v_free_addr (mbar_base + 240)
+    #define smem_free_addr (mbar_base + 280)
+    #define raw_inputs_free_addr (mbar_base + 320)
+    #define state_inp_ready_addr (mbar_base + 360)
+    #define old_out_ready_addr (mbar_base + 400)
+    #define u_inp_ready_addr (mbar_base + 440)
+    #define u2_acc_ready_addr (mbar_base + 480)
+    #define u2_inp_ready_addr (mbar_base + 520)
+    #define final_ready_addr (mbar_base + 560)
+    #define out_empty_addr (mbar_base + 600)
+    #define tmem_dealloc_ready_addr (mbar_base + 608)
+    #define checkpoint_ready_addr (mbar_base + 616)
+    #define checkpoint_free_addr (mbar_base + 632)
+    #define prep_diag_ready_addr (mbar_base + 648)
+    #define prep_inv16_ready_addr (mbar_base + 688)
+    #define work_item_ready_addr (mbar_base + 728)
+    #define short_beta_ready_addr (mbar_base + 736)
+    const int taddr = tmem_addr_storage[0];
+
+    // Kernel post-init ops
+    const int tmem_tmem_state = taddr + 64;
+    const int tmem_tmem_state_inp = taddr;
+    const int tmem_tmem_u_acc = taddr + 224;
+    const int tmem_tmem_u2_inp = taddr + 224;
+    const int tmem_tmem_u2_acc = taddr;
+    const int tmem_tmem_out = taddr + 192;
+    const int tmem_tmem_state_out = taddr + 64;
+
+    // ---- Register redistribution for WGs split across roles ----
+    // Dec phase frees registers before any WG attempts inc.
+    if (warp >= 8 && warp <= 11) {
+        asm volatile("setmaxnreg.dec.sync.aligned.u32 48;");
+    }
+
+    // ---- Role: compute ----
+    if (warp <= 3) {
+        asm volatile("setmaxnreg.inc.sync.aligned.u32 168;");
+        { // compute_main
+            int task_idx = blockIdx.x;
+            int warp_id_in_role = (warp - 0);
+            int compute_local_warp = warp_id_in_role;
+            int warp_in_wg = warp % 4;
+            int state_row = warp_in_wg * 32 + lane;
+            int split_compute_start = 0;
+            int seq_idx = seq_order[task_idx / num_heads];
+            int head_idx = task_idx % num_heads;
+            long long bos = cu_seqlens[seq_idx];
+            long long eos = cu_seqlens[seq_idx + 1];
+            int num_chunks = ((int)(eos - bos) + 32 - 1) / 32;
+            int seq_len = (int)(eos - bos);
+            int num_chunks_0 = (seq_len + 32 - 1) / 32;
+            long long total_chunks = cu_chunk_offsets[num_sequences];
+            long long fallback_head = total_chunks * (long long)num_heads + (long long)seq_idx * (long long)num_heads + (long long)head_idx;
+            const int tmem_row_base = warp_in_wg * 32 << 16;
+            long long state_base = (((long long)seq_idx * (long long)num_heads + (long long)head_idx) * 128 + (long long)state_row) * 128;
+            #pragma unroll
+            for (int state_col_block = 0; state_col_block < 4; state_col_block++) {
+                float state_frag[32];
+                state_frag[0] = 0.0f;
+                state_frag[1] = 0.0f;
+                state_frag[2] = 0.0f;
+                state_frag[3] = 0.0f;
+                state_frag[4] = 0.0f;
+                state_frag[5] = 0.0f;
+                state_frag[6] = 0.0f;
+                state_frag[7] = 0.0f;
+                state_frag[8] = 0.0f;
+                state_frag[9] = 0.0f;
+                state_frag[10] = 0.0f;
+                state_frag[11] = 0.0f;
+                state_frag[12] = 0.0f;
+                state_frag[13] = 0.0f;
+                state_frag[14] = 0.0f;
+                state_frag[15] = 0.0f;
+                state_frag[16] = 0.0f;
+                state_frag[17] = 0.0f;
+                state_frag[18] = 0.0f;
+                state_frag[19] = 0.0f;
+                state_frag[20] = 0.0f;
+                state_frag[21] = 0.0f;
+                state_frag[22] = 0.0f;
+                state_frag[23] = 0.0f;
+                state_frag[24] = 0.0f;
+                state_frag[25] = 0.0f;
+                state_frag[26] = 0.0f;
+                state_frag[27] = 0.0f;
+                state_frag[28] = 0.0f;
+                state_frag[29] = 0.0f;
+                state_frag[30] = 0.0f;
+                state_frag[31] = 0.0f;
+                if (use_initial_state != 0) {
+                    {
+                        float initial_values[8];
+                        #pragma unroll
+                        for (int initial_quarter = 0; initial_quarter < 4; initial_quarter++) {
+                            {
+                                unsigned _ldv8_0_0;
+                                unsigned _ldv8_0_1;
+                                unsigned _ldv8_0_2;
+                                unsigned _ldv8_0_3;
+                                unsigned _ldv8_0_4;
+                                unsigned _ldv8_0_5;
+                                unsigned _ldv8_0_6;
+                                unsigned _ldv8_0_7;
+                                asm volatile(
+                                    "ld.global.v8.b32 {%0, %1, %2, %3, %4, %5, %6, %7}, [%8];"
+                                    : "=r"(_ldv8_0_0), "=r"(_ldv8_0_1), "=r"(_ldv8_0_2), "=r"(_ldv8_0_3), "=r"(_ldv8_0_4), "=r"(_ldv8_0_5), "=r"(_ldv8_0_6), "=r"(_ldv8_0_7) : "l"((const void*)(initial_state_f32 + (state_base + (long long)(state_col_block * 32) + (long long)(initial_quarter * 8)))) : "memory");
+                                initial_values[0 + 0] = __uint_as_float(_ldv8_0_0);
+                                initial_values[0 + 1] = __uint_as_float(_ldv8_0_1);
+                                initial_values[0 + 2] = __uint_as_float(_ldv8_0_2);
+                                initial_values[0 + 3] = __uint_as_float(_ldv8_0_3);
+                                initial_values[0 + 4] = __uint_as_float(_ldv8_0_4);
+                                initial_values[0 + 5] = __uint_as_float(_ldv8_0_5);
+                                initial_values[0 + 6] = __uint_as_float(_ldv8_0_6);
+                                initial_values[0 + 7] = __uint_as_float(_ldv8_0_7);
+                            }
+                            #pragma unroll
+                            for (int initial_item = 0; initial_item < 8; initial_item++) {
+                                __nv_bfloat16 _cvt_bf16_9 = __float2bfloat16(initial_values[initial_item]);
+                                float _cvt_f32_19 = __bfloat162float(_cvt_bf16_9);
+                                state_frag[initial_quarter * 8 + initial_item] = _cvt_f32_19;
+                            }
+                        }
+                    }
+                }
+                tmem_st_x32_f32(taddr + 64 + (unsigned int)tmem_row_base + (unsigned int)(state_col_block * 32), state_frag);
+            }
+            asm volatile("tcgen05.wait::st.sync.aligned;" ::: "memory");
+            {
+                if (compute_local_warp == 0) {
+                    if (elect_sync()) {
+                        long long first_chunk_head = cu_chunk_offsets[seq_idx] * (long long)num_heads + (long long)head_idx;
+                        state_checkpoint_needed[first_chunk_head] = 0;
+                        {
+                            state_checkpoint_needed[fallback_head] = 0;
+                        }
+                    }
+                }
+            }
+            unsigned int compute_stage = 0;
+            unsigned int checkpoint_stage_compute = 0;
+            float _exp2_10 = approx_exp2(lower_bound * 1.4426950408889634f * 16.0f);
+            unsigned int _phase_checkpoint_free = 1;
+            unsigned int _phase_qk_full = 0;
+            unsigned int _phase_v_full = 0;
+            unsigned int _phase_old_out_ready = 0;
+            unsigned int _phase_u2_acc_ready = 0;
+            unsigned int _phase_final_ready = 0;
+            #pragma unroll 1
+            for (int chunk_idx = 0; chunk_idx < num_chunks_0; chunk_idx++) {
+                int chunk_global_local = chunk_idx;
+                int owned_chunk = chunk_global_local >= 0 && chunk_global_local < num_chunks;
+                int checkpoint_token_entering = chunk_idx * 32;
+                int checkpoint_entering = checkpoint_every_n_tokens != 0 && checkpoint_token_entering % checkpoint_every_n_tokens == 0;
+                float state_panel0[32];
+                float state_panel1[32];
+                float state_panel2[32];
+                float state_panel3[32];
+                unsigned int state_packed0[16];
+                unsigned int state_packed1[16];
+                unsigned int state_packed2[16];
+                unsigned int state_packed3[16];
+                mbarrier_wait(qk_full_addr + (compute_stage) * 8, _phase_qk_full);
+                #pragma unroll 1
+                for (int state_col_block_1 = 0; state_col_block_1 < ((0) ? 4 : 3); state_col_block_1++) {
+                    int state_addr = taddr + 64 + (unsigned int)tmem_row_base + (unsigned int)(state_col_block_1 * 32);
+                    float _tmem_load_1[32];
+                    tmem_ld_x32(&_tmem_load_1[0], state_addr);
+                    asm volatile("tcgen05.wait::ld.sync.aligned;");
+                    uint32_t _tmem_load_1_bf16[16];
+                    #pragma unroll
+                    for (int _lp = 0; _lp < 16; _lp++) {
+                        __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(_tmem_load_1[_lp*2 + 0], _tmem_load_1[_lp*2+1 + 0]));
+                        _tmem_load_1_bf16[_lp] = *(uint32_t*)&_bf2;
+                    }
+                    asm volatile(
+                        "tcgen05.st.sync.aligned.32x32b.x16.b32"
+                        " [%0], {%1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15, %16};"
+                        :: "r"(taddr + (unsigned int)tmem_row_base + (unsigned int)(state_col_block_1 * 16)), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_1_bf16[0])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_1_bf16[1])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_1_bf16[2])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_1_bf16[3])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_1_bf16[4])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_1_bf16[5])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_1_bf16[6])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_1_bf16[7])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_1_bf16[8])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_1_bf16[9])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_1_bf16[10])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_1_bf16[11])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_1_bf16[12])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_1_bf16[13])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_1_bf16[14])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_1_bf16[15])));
+                    float state_scale[16];
+                    #pragma unroll
+                    for (int state_half = 0; state_half < 2; state_half++) {
+                        #pragma unroll
+                        for (int state_col = 0; state_col < 16; state_col++) {
+                            state_scale[state_col] = smem_gt_all[compute_stage * 10496 + (unsigned int)(state_col_block_1 * 32) + (unsigned int)(state_half * 16) + (unsigned int)state_col];
+                        }
+                        #pragma unroll
+                        for (int _ls = 0; _ls < 8; _ls++)
+                            mul_f32x2_inplace(&reinterpret_cast<float2*>((_tmem_load_1 + state_half * 16))[_ls], reinterpret_cast<const float2*>(state_scale)[_ls]);
+                    }
+                    tmem_st_x32_f32(state_addr, _tmem_load_1);
+                }
+                int state_tail_addr = taddr + 64 + (unsigned int)tmem_row_base + 96;
+                float state_tail_frag[32];
+                unsigned int state_tail_packed[16];
+                {
+                    tmem_ld_x32(&state_tail_frag[0], state_tail_addr);
+                    #pragma unroll
+                    for (int _lp = 0; _lp < 16; _lp++) {
+                        __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(state_tail_frag[_lp*2 + 0], state_tail_frag[_lp*2+1 + 0]));
+                        state_tail_packed[_lp] = *(uint32_t*)&_bf2;
+                    }
+                    asm volatile(
+                        "tcgen05.st.sync.aligned.32x32b.x16.b32"
+                        " [%0], {%1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15, %16};"
+                        :: "r"(taddr + (unsigned int)tmem_row_base + 48), "r"(*reinterpret_cast<const uint32_t*>(&state_tail_packed[0])), "r"(*reinterpret_cast<const uint32_t*>(&state_tail_packed[1])), "r"(*reinterpret_cast<const uint32_t*>(&state_tail_packed[2])), "r"(*reinterpret_cast<const uint32_t*>(&state_tail_packed[3])), "r"(*reinterpret_cast<const uint32_t*>(&state_tail_packed[4])), "r"(*reinterpret_cast<const uint32_t*>(&state_tail_packed[5])), "r"(*reinterpret_cast<const uint32_t*>(&state_tail_packed[6])), "r"(*reinterpret_cast<const uint32_t*>(&state_tail_packed[7])), "r"(*reinterpret_cast<const uint32_t*>(&state_tail_packed[8])), "r"(*reinterpret_cast<const uint32_t*>(&state_tail_packed[9])), "r"(*reinterpret_cast<const uint32_t*>(&state_tail_packed[10])), "r"(*reinterpret_cast<const uint32_t*>(&state_tail_packed[11])), "r"(*reinterpret_cast<const uint32_t*>(&state_tail_packed[12])), "r"(*reinterpret_cast<const uint32_t*>(&state_tail_packed[13])), "r"(*reinterpret_cast<const uint32_t*>(&state_tail_packed[14])), "r"(*reinterpret_cast<const uint32_t*>(&state_tail_packed[15])));
+                }
+                asm volatile("tcgen05.wait::st.sync.aligned;" ::: "memory");
+                if (elect_sync()) {
+                    mbarrier_arrive(state_inp_ready_addr + (compute_stage) * 8);
+                }
+                {
+                    float state_tail_scale[16];
+                    #pragma unroll
+                    for (int state_half_1 = 0; state_half_1 < 2; state_half_1++) {
+                        #pragma unroll
+                        for (int state_col_1 = 0; state_col_1 < 16; state_col_1++) {
+                            state_tail_scale[state_col_1] = smem_gt_all[compute_stage * 10496 + 96 + (unsigned int)(state_half_1 * 16) + (unsigned int)state_col_1];
+                        }
+                        #pragma unroll
+                        for (int _ls = 0; _ls < 8; _ls++)
+                            mul_f32x2_inplace(&reinterpret_cast<float2*>((state_tail_frag + state_half_1 * 16))[_ls], reinterpret_cast<const float2*>(state_tail_scale)[_ls]);
+                    }
+                    tmem_st_x32_f32(state_tail_addr, state_tail_frag);
+                }
+                mbarrier_wait(v_full_addr + (compute_stage) * 8, _phase_v_full);
+                unsigned int v_prefetch_bits[8];
+                mbarrier_wait(old_out_ready_addr + (compute_stage) * 8, _phase_old_out_ready);
+                float _tmem_load_2[32];
+                tmem_ld_x32(&_tmem_load_2[0], taddr + 224 + (unsigned int)tmem_row_base);
+                asm volatile("tcgen05.wait::ld.sync.aligned;");
+                {
+                    const float2 _scale2_1 = {_exp2_10, _exp2_10};
+                    #pragma unroll
+                    for (int _ls = 0; _ls < 16; _ls++)
+                        mul_f32x2_inplace(&reinterpret_cast<float2*>(_tmem_load_2)[_ls], _scale2_1);
+                }
+                long long chunk_global_e = cu_chunk_offsets[seq_idx] + (long long)chunk_global_local;
+                long long tape_ex_base = ((chunk_global_e * (long long)num_heads + (long long)head_idx) * 128 + (long long)state_row) * 32;
+                #pragma unroll
+                for (int residual_half = 0; residual_half < 2; residual_half++) {
+                    float residual_v[16];
+                    float residual_beta[16];
+                    #pragma unroll
+                    for (int residual_col = 0; residual_col < 16; residual_col++) {
+                        int token_col = residual_half * 16 + residual_col;
+                        {
+                            __nv_bfloat16 v_value = smem_v_all[compute_stage * 20992 + (unsigned int)(token_col * 128) + (unsigned int)state_row];
+                            float _cvt_f32_20 = __bfloat162float(v_value);
+                            residual_v[residual_col] = _cvt_f32_20;
+                            residual_beta[residual_col] = smem_prep_beta_all[compute_stage * 10496 + (unsigned int)token_col];
+                        }
+                    }
+                    {
+                        #pragma unroll
+                        for (int _ls = 0; _ls < 8; _ls++)
+                            sub_f32x2_inplace(&reinterpret_cast<float2*>(residual_v)[_ls], reinterpret_cast<const float2*>((_tmem_load_2 + residual_half * 16))[_ls]);
+                    }
+                    if (STORE_BACKWARD_TAPE != 0 && STORE_E_TAPE != 0 && owned_chunk != 0) {
+                        {
+                            __nv_bfloat162 _pk[4];
+                            _pk[0] = __floats2bfloat162_rn(residual_v[0 + 0], residual_v[0 + 1]);
+                            _pk[1] = __floats2bfloat162_rn(residual_v[0 + 2], residual_v[0 + 3]);
+                            _pk[2] = __floats2bfloat162_rn(residual_v[0 + 4], residual_v[0 + 5]);
+                            _pk[3] = __floats2bfloat162_rn(residual_v[0 + 6], residual_v[0 + 7]);
+                            *reinterpret_cast<uint4*>(&((__nv_bfloat16*)(tape_e + (tape_ex_base + (long long)(residual_half * 16))))[0]) = *reinterpret_cast<uint4*>(&_pk[0]);
+                        }
+                        {
+                            __nv_bfloat162 _pk[4];
+                            _pk[0] = __floats2bfloat162_rn(residual_v[8 + 0], residual_v[8 + 1]);
+                            _pk[1] = __floats2bfloat162_rn(residual_v[8 + 2], residual_v[8 + 3]);
+                            _pk[2] = __floats2bfloat162_rn(residual_v[8 + 4], residual_v[8 + 5]);
+                            _pk[3] = __floats2bfloat162_rn(residual_v[8 + 6], residual_v[8 + 7]);
+                            *reinterpret_cast<uint4*>(&((__nv_bfloat16*)(tape_e + (tape_ex_base + (long long)(residual_half * 16) + 8)))[0]) = *reinterpret_cast<uint4*>(&_pk[0]);
+                        }
+                    }
+                    {
+                        #pragma unroll
+                        for (int _ls = 0; _ls < 8; _ls++)
+                            mul_f32x2_inplace(&reinterpret_cast<float2*>(residual_v)[_ls], reinterpret_cast<const float2*>(residual_beta)[_ls]);
+                        if (STORE_BACKWARD_TAPE != 0 && owned_chunk != 0) {
+                            {
+                                __nv_bfloat162 _pk[4];
+                                _pk[0] = __floats2bfloat162_rn(residual_v[0 + 0], residual_v[0 + 1]);
+                                _pk[1] = __floats2bfloat162_rn(residual_v[0 + 2], residual_v[0 + 3]);
+                                _pk[2] = __floats2bfloat162_rn(residual_v[0 + 4], residual_v[0 + 5]);
+                                _pk[3] = __floats2bfloat162_rn(residual_v[0 + 6], residual_v[0 + 7]);
+                                *reinterpret_cast<uint4*>(&((__nv_bfloat16*)(tape_x + (tape_ex_base + (long long)(residual_half * 16))))[0]) = *reinterpret_cast<uint4*>(&_pk[0]);
+                            }
+                            {
+                                __nv_bfloat162 _pk[4];
+                                _pk[0] = __floats2bfloat162_rn(residual_v[8 + 0], residual_v[8 + 1]);
+                                _pk[1] = __floats2bfloat162_rn(residual_v[8 + 2], residual_v[8 + 3]);
+                                _pk[2] = __floats2bfloat162_rn(residual_v[8 + 4], residual_v[8 + 5]);
+                                _pk[3] = __floats2bfloat162_rn(residual_v[8 + 6], residual_v[8 + 7]);
+                                *reinterpret_cast<uint4*>(&((__nv_bfloat16*)(tape_x + (tape_ex_base + (long long)(residual_half * 16) + 8)))[0]) = *reinterpret_cast<uint4*>(&_pk[0]);
+                            }
+                        }
+                        uint32_t residual_v_bf16[8];
+                        #pragma unroll
+                        for (int _lp = 0; _lp < 8; _lp++) {
+                            __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(residual_v[_lp*2 + 0], residual_v[_lp*2+1 + 0]));
+                            residual_v_bf16[_lp] = *(uint32_t*)&_bf2;
+                        }
+                        tmem_st_x8_u32(taddr + 224 + (unsigned int)tmem_row_base + (unsigned int)(residual_half * 8), (const uint32_t*)residual_v_bf16);
+                    }
+                }
+                asm volatile("tcgen05.wait::st.sync.aligned;" ::: "memory");
+                if (elect_sync()) {
+                    mbarrier_arrive(v_free_addr + (compute_stage) * 8);
+                    mbarrier_arrive(u_inp_ready_addr + (compute_stage) * 8);
+                }
+                mbarrier_wait(u2_acc_ready_addr + (compute_stage) * 8, _phase_u2_acc_ready);
+                float _tmem_load_4[32];
+                tmem_ld_x32(&_tmem_load_4[0], taddr + (unsigned int)tmem_row_base);
+                asm volatile("tcgen05.wait::ld.sync.aligned;");
+                if (STORE_BACKWARD_TAPE != 0 && owned_chunk != 0) {
+                    long long chunk_global_r = cu_chunk_offsets[seq_idx] + (long long)chunk_global_local;
+                    long long tape_r_base = ((chunk_global_r * (long long)num_heads + (long long)head_idx) * 128 + (long long)state_row) * 32;
+                    #pragma unroll
+                    for (int tape_r_vec = 0; tape_r_vec < 4; tape_r_vec++) {
+                        {
+                            __nv_bfloat162 _pk[4];
+                            _pk[0] = __floats2bfloat162_rn(_tmem_load_4[tape_r_vec * 8 + 0], _tmem_load_4[tape_r_vec * 8 + 1]);
+                            _pk[1] = __floats2bfloat162_rn(_tmem_load_4[tape_r_vec * 8 + 2], _tmem_load_4[tape_r_vec * 8 + 3]);
+                            _pk[2] = __floats2bfloat162_rn(_tmem_load_4[tape_r_vec * 8 + 4], _tmem_load_4[tape_r_vec * 8 + 5]);
+                            _pk[3] = __floats2bfloat162_rn(_tmem_load_4[tape_r_vec * 8 + 6], _tmem_load_4[tape_r_vec * 8 + 7]);
+                            *reinterpret_cast<uint4*>(&((__nv_bfloat16*)(tape_r + (tape_r_base + (long long)(tape_r_vec * 8))))[0]) = *reinterpret_cast<uint4*>(&_pk[0]);
+                        }
+                    }
+                }
+                uint32_t _tmem_load_4_bf16[16];
+                #pragma unroll
+                for (int _lp = 0; _lp < 16; _lp++) {
+                    __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(_tmem_load_4[_lp*2 + 0], _tmem_load_4[_lp*2+1 + 0]));
+                    _tmem_load_4_bf16[_lp] = *(uint32_t*)&_bf2;
+                }
+                asm volatile(
+                    "tcgen05.st.sync.aligned.32x32b.x16.b32"
+                    " [%0], {%1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15, %16};"
+                    :: "r"(taddr + 224 + (unsigned int)tmem_row_base), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_4_bf16[0])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_4_bf16[1])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_4_bf16[2])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_4_bf16[3])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_4_bf16[4])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_4_bf16[5])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_4_bf16[6])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_4_bf16[7])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_4_bf16[8])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_4_bf16[9])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_4_bf16[10])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_4_bf16[11])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_4_bf16[12])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_4_bf16[13])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_4_bf16[14])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_4_bf16[15])));
+                asm volatile("tcgen05.wait::st.sync.aligned;" ::: "memory");
+                if (elect_sync()) {
+                    mbarrier_arrive(u2_inp_ready_addr + (compute_stage) * 8);
+                }
+                mbarrier_wait(final_ready_addr + (compute_stage) * 8, _phase_final_ready);
+                {
+                    int next_chunk_global_local = chunk_global_local + 1;
+                    if (next_chunk_global_local >= 0 && next_chunk_global_local < num_chunks) {
+                        int checkpoint_needed = smem_state_checkpoint_needed[compute_stage * 4] != 0 || smem_state_checkpoint_needed[compute_stage * 4 + 1] != 0 || smem_state_checkpoint_needed[compute_stage * 4 + 2] != 0 || smem_state_checkpoint_needed[compute_stage * 4 + 3] != 0;
+                        if (compute_local_warp == 0) {
+                            if (elect_sync()) {
+                                long long chunk_global_next = cu_chunk_offsets[seq_idx] + (long long)next_chunk_global_local;
+                                state_checkpoint_needed[chunk_global_next * (long long)num_heads + (long long)head_idx] = (unsigned int)checkpoint_needed;
+                                if (SPLIT_WORK_ITEMS == 0 && checkpoint_needed != 0) {
+                                    state_checkpoint_needed[fallback_head] = 1;
+                                }
+                                if (SPLIT_WORK_ITEMS != 0 && checkpoint_needed != 0) {
+                                    state_checkpoint_needed[total_chunks * (long long)num_heads + (long long)task_idx] = 1;
+                                }
+                            }
+                        }
+                    }
+                    if (compute_local_warp == 0) {
+                        if (elect_sync()) {
+                            mbarrier_arrive(smem_free_addr + (compute_stage) * 8);
+                        }
+                    }
+                }
+                compute_stage += 1;
+                if (compute_stage == 5) { compute_stage = 0; _phase_qk_full ^= 1; _phase_v_full ^= 1; _phase_old_out_ready ^= 1; _phase_u2_acc_ready ^= 1; _phase_final_ready ^= 1; }
+            }
+            if (store_final_state != 0) {
+                #pragma unroll
+                for (int state_col_block_2 = 0; state_col_block_2 < 4; state_col_block_2++) {
+                    float _tmem_load_6[32];
+                    tmem_ld_x32(&_tmem_load_6[0], taddr + 64 + (unsigned int)tmem_row_base + (unsigned int)(state_col_block_2 * 32));
+                    asm volatile("tcgen05.wait::ld.sync.aligned;");
+                    {
+                        __nv_bfloat162 _pk[8];
+                        _pk[0] = __floats2bfloat162_rn(_tmem_load_6[0 + 0], _tmem_load_6[0 + 1]);
+                        _pk[1] = __floats2bfloat162_rn(_tmem_load_6[0 + 2], _tmem_load_6[0 + 3]);
+                        _pk[2] = __floats2bfloat162_rn(_tmem_load_6[0 + 4], _tmem_load_6[0 + 5]);
+                        _pk[3] = __floats2bfloat162_rn(_tmem_load_6[0 + 6], _tmem_load_6[0 + 7]);
+                        _pk[4] = __floats2bfloat162_rn(_tmem_load_6[0 + 8], _tmem_load_6[0 + 9]);
+                        _pk[5] = __floats2bfloat162_rn(_tmem_load_6[0 + 10], _tmem_load_6[0 + 11]);
+                        _pk[6] = __floats2bfloat162_rn(_tmem_load_6[0 + 12], _tmem_load_6[0 + 13]);
+                        _pk[7] = __floats2bfloat162_rn(_tmem_load_6[0 + 14], _tmem_load_6[0 + 15]);
+                        *reinterpret_cast<uint4*>(&((__nv_bfloat16*)(final_state + (state_base + (long long)(state_col_block_2 * 32))))[0]) = *reinterpret_cast<uint4*>(&_pk[0]);
+                        *reinterpret_cast<uint4*>(&((__nv_bfloat16*)(final_state + (state_base + (long long)(state_col_block_2 * 32))))[8]) = *reinterpret_cast<uint4*>(&_pk[4]);
+                    }
+                    {
+                        __nv_bfloat162 _pk[8];
+                        _pk[0] = __floats2bfloat162_rn(_tmem_load_6[16 + 0], _tmem_load_6[16 + 1]);
+                        _pk[1] = __floats2bfloat162_rn(_tmem_load_6[16 + 2], _tmem_load_6[16 + 3]);
+                        _pk[2] = __floats2bfloat162_rn(_tmem_load_6[16 + 4], _tmem_load_6[16 + 5]);
+                        _pk[3] = __floats2bfloat162_rn(_tmem_load_6[16 + 6], _tmem_load_6[16 + 7]);
+                        _pk[4] = __floats2bfloat162_rn(_tmem_load_6[16 + 8], _tmem_load_6[16 + 9]);
+                        _pk[5] = __floats2bfloat162_rn(_tmem_load_6[16 + 10], _tmem_load_6[16 + 11]);
+                        _pk[6] = __floats2bfloat162_rn(_tmem_load_6[16 + 12], _tmem_load_6[16 + 13]);
+                        _pk[7] = __floats2bfloat162_rn(_tmem_load_6[16 + 14], _tmem_load_6[16 + 15]);
+                        *reinterpret_cast<uint4*>(&((__nv_bfloat16*)(final_state + (state_base + (long long)(state_col_block_2 * 32) + 16)))[0]) = *reinterpret_cast<uint4*>(&_pk[0]);
+                        *reinterpret_cast<uint4*>(&((__nv_bfloat16*)(final_state + (state_base + (long long)(state_col_block_2 * 32) + 16)))[8]) = *reinterpret_cast<uint4*>(&_pk[4]);
+                    }
+                }
+            }
+            asm volatile("barrier.sync 9, 128;" ::: "memory");
+            if (compute_local_warp == 0) {
+                if (elect_sync()) {
+                    mbarrier_arrive(tmem_dealloc_ready_addr);
+                }
+            }
+        }
+    }
+    // ---- Role: epilogue ----
+    if (warp >= 4 && warp <= 7) {
+        asm volatile("setmaxnreg.dec.sync.aligned.u32 48;");
+        { // epilogue_main
+            int task_idx_1 = blockIdx.x;
+            int split_compute_start_1 = 0;
+            unsigned int _phase_work_item_ready_0 = 0;
+            int seq_idx_1 = seq_order[task_idx_1 / num_heads];
+            int head_idx_1 = task_idx_1 % num_heads;
+            long long bos_1 = cu_seqlens[seq_idx_1];
+            long long eos_1 = cu_seqlens[seq_idx_1 + 1];
+            int num_chunks_1 = ((int)(eos_1 - bos_1) + 32 - 1) / 32;
+            int seq_len_1 = (int)(eos_1 - bos_1);
+            int num_chunks_0_1 = (seq_len_1 + 32 - 1) / 32;
+            int warp_id_in_role_1 = (warp - 4);
+            int epilogue_local_warp = warp_id_in_role_1;
+            int warp_in_wg_1 = warp % 4;
+            const int tmem_row_base_1 = warp_in_wg_1 * 32 << 16;
+            int state_row_1 = warp_in_wg_1 * 32 + lane;
+            unsigned int epilogue_stage = 0;
+            unsigned int output_stage = 0;
+            unsigned int checkpoint_stage_epilogue = 0;
+            int epilogue_chunks = num_chunks_0_1;
+            {
+                epilogue_chunks = 0;
+            }
+            unsigned int _phase_checkpoint_ready = 0;
+            unsigned int _phase_final_ready_1 = 0;
+            #pragma unroll 1
+            for (int chunk_idx_1 = 0; chunk_idx_1 < epilogue_chunks; chunk_idx_1++) {
+                int checkpoint_token_epilogue = chunk_idx_1 * 32;
+                int checkpoint_entering_epilogue = checkpoint_every_n_tokens != 0 && checkpoint_token_epilogue % checkpoint_every_n_tokens == 0;
+                int chunk_is_full = ((seq_len_1 >= (chunk_idx_1 + 1) * 32) ? 1 : 0);
+                if (chunk_is_full != 0) {
+                    mbarrier_wait(final_ready_addr + (epilogue_stage) * 8, _phase_final_ready_1);
+                    float _tmem_load_7[16];
+                    asm volatile(
+                        "tcgen05.ld.sync.aligned.16x256b.x4.b32"
+                        " {%0, %1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15}, [%16];"
+                        : "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_7[0])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_7[1])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_7[2])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_7[3])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_7[4])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_7[5])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_7[6])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_7[7])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_7[8])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_7[9])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_7[10])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_7[11])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_7[12])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_7[13])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_7[14])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_7[15]))
+                        : "r"(taddr + 192 + (unsigned int)tmem_row_base_1));
+                    float _tmem_load_8[16];
+                    asm volatile(
+                        "tcgen05.ld.sync.aligned.16x256b.x4.b32"
+                        " {%0, %1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15}, [%16];"
+                        : "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_8[0])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_8[1])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_8[2])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_8[3])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_8[4])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_8[5])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_8[6])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_8[7])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_8[8])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_8[9])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_8[10])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_8[11])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_8[12])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_8[13])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_8[14])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_8[15]))
+                        : "r"(taddr + 192 + (unsigned int)tmem_row_base_1 + 1048576));
+                    asm volatile("tcgen05.wait::ld.sync.aligned;" ::: "memory");
+                    asm volatile("barrier.sync 8, 128;" ::: "memory");
+                    if (epilogue_local_warp == 0) {
+                        if (elect_sync()) {
+                            mbarrier_arrive(out_empty_addr);
+                        }
+                    }
+                    if (epilogue_local_warp == 0) {
+                        if (chunk_idx_1 >= 2) {
+                            asm volatile("cp.async.bulk.wait_group.read 1;");
+                        }
+                    }
+                    asm volatile("barrier.sync 8, 128;" ::: "memory");
+                    int out_stage_addr = smem_out_addr + output_stage * 8192;
+                    #pragma unroll
+                    for (int dim_half = 0; dim_half < 2; dim_half++) {
+                        unsigned int out_packed[8];
+                        if (dim_half == 0) {
+                            #pragma unroll
+                            for (int _lp = 0; _lp < 8; _lp++) {
+                                __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(_tmem_load_7[_lp*2 + 0], _tmem_load_7[_lp*2+1 + 0]));
+                                out_packed[_lp] = *(uint32_t*)&_bf2;
+                            }
+                        } else {
+                            #pragma unroll
+                            for (int _lp = 0; _lp < 8; _lp++) {
+                                __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(_tmem_load_8[_lp*2 + 0], _tmem_load_8[_lp*2+1 + 0]));
+                                out_packed[_lp] = *(uint32_t*)&_bf2;
+                            }
+                        }
+                        #pragma unroll
+                        for (int token_group = 0; token_group < 2; token_group++) {
+                            int mtx_idx = lane / 8;
+                            int row_addr = lane & 7;
+                            int dim_base = epilogue_local_warp * 32 + dim_half * 16 + (mtx_idx & 1) * 8;
+                            int token_base = token_group * 16 + mtx_idx / 2 * 8;
+                            int token_addr = token_base + row_addr;
+                            int token_pair = token_addr / 2;
+                            int token_parity = token_addr & 1;
+                            int raw_row = token_pair + dim_base / 64 * 16;
+                            int raw_col = (dim_base & 63 ^ (token_pair & 3) << 4 ^ token_parity << 3) + token_parity * 64;
+                            int stsm_offset = (raw_row * 128 + raw_col) * 2;
+                            const int pack_base = token_group * 4;
+                            uint32_t _stmatrix_addr_0 = static_cast<uint32_t>((unsigned long long)(out_stage_addr + stsm_offset));
+                            asm volatile("stmatrix.sync.aligned.m8n8.x4.trans.shared.b16 [%0], {%1, %2, %3, %4};\n"
+                                :: "r"(_stmatrix_addr_0), "r"(*reinterpret_cast<const uint32_t*>(&out_packed[pack_base])), "r"(*reinterpret_cast<const uint32_t*>(&out_packed[pack_base + 1])), "r"(*reinterpret_cast<const uint32_t*>(&out_packed[pack_base + 2])), "r"(*reinterpret_cast<const uint32_t*>(&out_packed[pack_base + 3]))
+                                : "memory");
+                        }
+                    }
+                    asm volatile("fence.proxy.async.shared::cta;" ::: "memory");
+                    asm volatile("barrier.sync 8, 128;" ::: "memory");
+                    if (epilogue_local_warp == 0) {
+                        if (elect_sync()) {
+                            tma_store_4d(out_tma, 0, (int)(bos_1 + (long long)(chunk_idx_1 * 32)), head_idx_1, 0, smem_out_addr + output_stage * 8192);
+                        }
+                        asm volatile("cp.async.bulk.commit_group;");
+                    }
+                    output_stage = output_stage ^ 1;
+                } else {
+                    mbarrier_wait(final_ready_addr + (epilogue_stage) * 8, _phase_final_ready_1);
+                    float _tmem_load_9[32];
+                    tmem_ld_x32(&_tmem_load_9[0], taddr + 192 + (unsigned int)tmem_row_base_1);
+                    asm volatile("tcgen05.wait::ld.sync.aligned;" ::: "memory");
+                    asm volatile("barrier.sync 8, 128;" ::: "memory");
+                    if (epilogue_local_warp == 0) {
+                        if (elect_sync()) {
+                            mbarrier_arrive(out_empty_addr);
+                        }
+                    }
+                    #pragma unroll
+                    for (int token_col_1 = 0; token_col_1 < 32; token_col_1++) {
+                        long long out_token = bos_1 + (long long)(chunk_idx_1 * 32 + token_col_1);
+                        if (out_token < eos_1) {
+                            long long out_idx = (out_token * (long long)num_heads + (long long)head_idx_1) * 128 + (long long)state_row_1;
+                            out[out_idx] = _tmem_load_9[token_col_1];
+                        }
+                    }
+                }
+                epilogue_stage += 1;
+                if (epilogue_stage == 5) { epilogue_stage = 0; _phase_final_ready_1 ^= 1; }
+            }
+            if (epilogue_local_warp == 0) {
+                if (elect_sync()) {
+                    mbarrier_arrive(tmem_dealloc_ready_addr);
+                }
+            }
+        }
+    }
+    // ---- Role: beta_prefetch ----
+    if (warp == 8) {
+        { // beta_prefetch_main
+
+        }
+    }
+    // ---- Role: aux_mma ----
+    if (warp >= 10 && warp <= 11) {
+        { // aux_mma_main
+            unsigned int _phase_work_item_ready_0_1 = 0;
+            unsigned int _phase_tape_ready = 0;
+            {
+                int task_idx_2 = blockIdx.x;
+                int split_compute_start_2 = 0;
+                int seq_idx_2 = seq_order[task_idx_2 / num_heads];
+                int head_idx_2 = task_idx_2 % num_heads;
+                long long bos_2 = cu_seqlens[seq_idx_2];
+                long long eos_2 = cu_seqlens[seq_idx_2 + 1];
+                int num_chunks_2 = ((int)(eos_2 - bos_2) + 32 - 1) / 32;
+                int seq_len_2 = (int)(eos_2 - bos_2);
+                int num_chunks_0_2 = (seq_len_2 + 32 - 1) / 32;
+                int warp_id_in_role_2 = (warp - 10);
+                int tape_tid = warp_id_in_role_2 * 32 + lane;
+                int zero_stride = num_bids * 64;
+                #pragma unroll 1
+                for (int zero_item = task_idx_2 * 64 + tape_tid; zero_item < zero_words; zero_item += zero_stride) {
+                    zero_workspace[zero_item] = 0;
+                }
+                unsigned int tape_stage = 0;
+                #pragma unroll 1
+                for (int chunk_idx_2 = 0; chunk_idx_2 < num_chunks_0_2; chunk_idx_2++) {
+                    mbarrier_wait(tape_ready_addr + (tape_stage) * 8, _phase_tape_ready);
+                    int chunk_global_local_1 = chunk_idx_2;
+                    int owned_chunk_1 = chunk_global_local_1 >= 0 && chunk_global_local_1 < num_chunks_2;
+                    long long chunk_global = cu_chunk_offsets[seq_idx_2] + (long long)chunk_global_local_1;
+                    long long tape_vec_base = (chunk_global * (long long)num_heads + (long long)head_idx_2) * 32 * 128;
+                    #pragma unroll
+                    for (int tape_pass = 0; tape_pass < 8; tape_pass++) {
+                        int tape_item = tape_pass * 64 + tape_tid;
+                        int tape_row = tape_item / 16;
+                        int tape_segment = tape_item % 16;
+                        float tape_kr_values[8];
+                        unsigned int packed[4];
+                        asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                            : "=r"(*reinterpret_cast<uint32_t*>(&packed[0])), "=r"(*reinterpret_cast<uint32_t*>(&packed[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&packed[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&packed[(0) + 3]))
+                            : "r"((smem_kr_trans_addr + tape_stage * 41984 + (unsigned int)(tape_segment * 8 / 64 * 4096 + tape_row * 128 + tape_segment * 8 % 64 * 2 ^ (tape_segment * 8 / 64 * 4096 + tape_row * 128 + tape_segment * 8 % 64 * 2 >> 7 & 7) << 4))));
+                        float packed_f32[8];
+                        #pragma unroll
+                        for (int _pair = 0; _pair < 4; _pair++) {
+                            asm volatile(
+                                "{\n\t"
+                                "shl.b32 %0, %2, 16;\n\t"
+                                "and.b32 %1, %2, 0xffff0000;\n\t"
+                                "}\n"
+                                : "=f"((&packed_f32[_pair * 2])[0]), "=f"((&packed_f32[_pair * 2])[1])
+                                : "r"(packed[_pair]));
+                        }
+                        #pragma unroll
+                        for (int value_idx = 0; value_idx < 8; value_idx++) {
+                            tape_kr_values[value_idx] = packed_f32[value_idx];
+                        }
+                        long long tape_index = tape_vec_base + (long long)tape_row * 128 + (long long)(tape_segment * 8);
+                        if (owned_chunk_1 != 0) {
+                            {
+                                __nv_bfloat162 _pk[4];
+                                _pk[0] = __floats2bfloat162_rn(tape_kr_values[0 + 0], tape_kr_values[0 + 1]);
+                                _pk[1] = __floats2bfloat162_rn(tape_kr_values[0 + 2], tape_kr_values[0 + 3]);
+                                _pk[2] = __floats2bfloat162_rn(tape_kr_values[0 + 4], tape_kr_values[0 + 5]);
+                                _pk[3] = __floats2bfloat162_rn(tape_kr_values[0 + 6], tape_kr_values[0 + 7]);
+                                *reinterpret_cast<uint4*>(&((__nv_bfloat16*)(tape_kr + tape_index))[0]) = *reinterpret_cast<uint4*>(&_pk[0]);
+                            }
+                        }
+                    }
+                    long long tape_j_base = (chunk_global * (long long)num_heads + (long long)head_idx_2) * 32 * 32;
+                    #pragma unroll
+                    for (int tape_j_pass = 0; tape_j_pass < 2; tape_j_pass++) {
+                        int tape_j_item = tape_j_pass * 64 + tape_tid;
+                        int tape_j_row = tape_j_item / 4;
+                        int tape_j_segment = tape_j_item % 4;
+                        float tape_j_values[8];
+                        unsigned int packed_1[4];
+                        asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                            : "=r"(*reinterpret_cast<uint32_t*>(&packed_1[0])), "=r"(*reinterpret_cast<uint32_t*>(&packed_1[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&packed_1[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&packed_1[(0) + 3]))
+                            : "r"((smem_inv_addr + tape_stage * 41984 + (unsigned int)(tape_j_segment * 8 / 16 * 1024 + tape_j_row * 32 + tape_j_segment * 8 % 16 * 2 ^ (tape_j_segment * 8 / 16 * 1024 + tape_j_row * 32 + tape_j_segment * 8 % 16 * 2 >> 7 & 1) << 4))));
+                        float packed_f32_1[8];
+                        #pragma unroll
+                        for (int _pair = 0; _pair < 4; _pair++) {
+                            asm volatile(
+                                "{\n\t"
+                                "shl.b32 %0, %2, 16;\n\t"
+                                "and.b32 %1, %2, 0xffff0000;\n\t"
+                                "}\n"
+                                : "=f"((&packed_f32_1[_pair * 2])[0]), "=f"((&packed_f32_1[_pair * 2])[1])
+                                : "r"(packed_1[_pair]));
+                        }
+                        #pragma unroll
+                        for (int value_idx_1 = 0; value_idx_1 < 8; value_idx_1++) {
+                            tape_j_values[value_idx_1] = packed_f32_1[value_idx_1];
+                        }
+                        if (owned_chunk_1 != 0) {
+                            {
+                                __nv_bfloat162 _pk[4];
+                                _pk[0] = __floats2bfloat162_rn(tape_j_values[0 + 0], tape_j_values[0 + 1]);
+                                _pk[1] = __floats2bfloat162_rn(tape_j_values[0 + 2], tape_j_values[0 + 3]);
+                                _pk[2] = __floats2bfloat162_rn(tape_j_values[0 + 4], tape_j_values[0 + 5]);
+                                _pk[3] = __floats2bfloat162_rn(tape_j_values[0 + 6], tape_j_values[0 + 7]);
+                                *reinterpret_cast<uint4*>(&((__nv_bfloat16*)(tape_j + (tape_j_base + (long long)tape_j_row * 32 + (long long)(tape_j_segment * 8))))[0]) = *reinterpret_cast<uint4*>(&_pk[0]);
+                            }
+                        }
+                    }
+                    if (elect_sync()) {
+                        mbarrier_arrive(tape_free_addr + (tape_stage) * 8);
+                    }
+                    tape_stage += 1;
+                    if (tape_stage == 5) { tape_stage = 0; _phase_tape_ready ^= 1; }
+                }
+            }
+        }
+    }
+    // ---- Role: mma ----
+    if (warp == 9) {
+        { // mma_main
+            int task_idx_3 = blockIdx.x;
+            int split_compute_start_3 = 0;
+            unsigned int _phase_work_item_ready_0_2 = 0;
+            int seq_idx_3 = seq_order[task_idx_3 / num_heads];
+            int head_idx_3 = task_idx_3 % num_heads;
+            long long bos_3 = cu_seqlens[seq_idx_3];
+            long long eos_3 = cu_seqlens[seq_idx_3 + 1];
+            int num_chunks_3 = ((int)(eos_3 - bos_3) + 32 - 1) / 32;
+            int seq_len_3 = (int)(eos_3 - bos_3);
+            int num_chunks_0_3 = (seq_len_3 + 32 - 1) / 32;
+            unsigned int mma_stage = 0;
+            unsigned int _phase_qk_full_1 = 0;
+            unsigned int _phase_out_empty_0 = 1;
+            unsigned int _phase_state_inp_ready = 0;
+            unsigned int _phase_u_inp_ready = 0;
+            unsigned int _phase_u2_inp_ready = 0;
+            unsigned int _phase_final_ready_2 = 0;
+            #pragma unroll 1
+            for (int _chunk_idx = 0; _chunk_idx < num_chunks_0_3; _chunk_idx++) {
+                mbarrier_wait(qk_full_addr + (mma_stage) * 8, _phase_qk_full_1);
+                {
+                    mbarrier_wait(state_inp_ready_addr + (mma_stage) * 8, _phase_state_inp_ready);
+                    {
+                        int _mma_b_lo_6 = make_warp_uniform((((smem_kd_addr) >> 4) & 0x3FFF) + (mma_stage) * 2624);
+                        asm volatile(
+                    "{\n\t"
+                    ".reg .pred leader, p0, p1;\n\t"
+                    ".reg .b32 dhi, blo, ta, id;\n\t"
+                    ".reg .b64 db;\n\t"
+                    "elect.sync _|leader, 0xFFFFFFFF;\n\t"
+                    "setp.ne.b32 p0, %3, 0;\n\t"
+                    "setp.ne.b32 p1, 1, 0;\n\t"
+                    ""
+                    "mov.b32 dhi, 0x40004040;\n\t"
+                    "mov.b32 id, 134743184;\n\t"
+                    "mov.b32 ta, %2;\n\t"
+                    "mov.b32 blo, %1;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p0;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 250;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "}\n"
+                    :: "r"(tmem_tmem_u_acc), "r"(_mma_b_lo_6), "r"(tmem_tmem_state_inp), "r"(0));
+                    }
+                }
+                {
+                    elect_commit2(old_out_ready_addr + (mma_stage) * 8, raw_inputs_free_addr + (mma_stage) * 8);
+                }
+                mbarrier_wait(u_inp_ready_addr + (mma_stage) * 8, _phase_u_inp_ready);
+                int _mma_b_lo_7 = make_warp_uniform((((smem_inv_addr) >> 4) & 0x3FFF) + (mma_stage) * 2624);
+                asm volatile(
+                    "{\n\t"
+                    ".reg .pred leader, p0, p1;\n\t"
+                    ".reg .b32 dhi, blo, ta, id;\n\t"
+                    ".reg .b64 db;\n\t"
+                    "elect.sync _|leader, 0xFFFFFFFF;\n\t"
+                    "setp.ne.b32 p0, %3, 0;\n\t"
+                    "setp.ne.b32 p1, 1, 0;\n\t"
+                    ""
+                    "mov.b32 dhi, 0xC0004010;\n\t"
+                    "mov.b32 id, 134743184;\n\t"
+                    "mov.b32 ta, %2;\n\t"
+                    "mov.b32 blo, %1;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p0;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 64;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "}\n"
+                    :: "r"(tmem_tmem_u2_acc), "r"(_mma_b_lo_7), "r"(tmem_tmem_u2_inp), "r"(0));
+                elect_commit(u2_acc_ready_addr + (mma_stage) * 8);
+                mbarrier_wait(u2_inp_ready_addr + (mma_stage) * 8, _phase_u2_inp_ready);
+                int _mma_b_lo_8 = make_warp_uniform(((((smem_final_trans_addr) >> 4) & 0x3FFF) | 0x1000000) + (mma_stage) * 2624);
+                asm volatile(
+                    "{\n\t"
+                    ".reg .pred leader, p0, p1;\n\t"
+                    ".reg .b32 dhi, blo, ta, id;\n\t"
+                    ".reg .b64 db;\n\t"
+                    "elect.sync _|leader, 0xFFFFFFFF;\n\t"
+                    "setp.ne.b32 p0, %3, 0;\n\t"
+                    "setp.ne.b32 p1, 1, 0;\n\t"
+                    ""
+                    "mov.b32 dhi, 0x40004040;\n\t"
+                    "mov.b32 id, 136905872;\n\t"
+                    "mov.b32 ta, %2;\n\t"
+                    "mov.b32 blo, %1;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p0;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 128;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "}\n"
+                    :: "r"(tmem_tmem_state_out), "r"(_mma_b_lo_8), "r"(tmem_tmem_u2_inp), "r"(1));
+                elect_commit(final_ready_addr + (mma_stage) * 8);
+                {
+                    mbarrier_wait(final_ready_addr + (mma_stage) * 8, _phase_final_ready_2);
+                }
+                mma_stage += 1;
+                if (mma_stage == 5) { mma_stage = 0; _phase_qk_full_1 ^= 1; _phase_state_inp_ready ^= 1; _phase_u_inp_ready ^= 1; _phase_u2_inp_ready ^= 1; _phase_final_ready_2 ^= 1; }
+            }
+            unsigned int _phase_tmem_dealloc_ready_0 = 0;
+            mbarrier_wait(tmem_dealloc_ready_addr, _phase_tmem_dealloc_ready_0);
+            _phase_tmem_dealloc_ready_0 ^= 1;
+            int _tmem_dealloc_addr = *((volatile int*)tmem_addr_storage);
+            asm volatile("tcgen05.dealloc.cta_group::1.sync.aligned.b32 %0, %1;" :: "r"(_tmem_dealloc_addr), "r"(256));
+        }
+    }
+    // ---- Role: prep ----
+    if (warp >= 12 && warp <= 31) {
+        asm volatile("setmaxnreg.dec.sync.aligned.u32 48;");
+        { // prep_main
+            int task_idx_4 = blockIdx.x;
+            int split_compute_start_4 = 0;
+            unsigned int _phase_work_item_ready_0_3 = 0;
+            int seq_idx_4 = seq_order[task_idx_4 / num_heads];
+            int head_idx_4 = task_idx_4 % num_heads;
+            long long bos_4 = cu_seqlens[seq_idx_4];
+            long long eos_4 = cu_seqlens[seq_idx_4 + 1];
+            int num_chunks_4 = ((int)(eos_4 - bos_4) + 32 - 1) / 32;
+            int seq_len_4 = (int)(eos_4 - bos_4);
+            int num_chunks_0_4 = (seq_len_4 + 32 - 1) / 32;
+            int instance_id = (warp - 12) / 4;
+            int prep_instance = instance_id;
+            int warp_id_in_role_3 = (warp - 12);
+            int prep_local_warp = warp_id_in_role_3 - prep_instance * 4;
+            int prep_tid = prep_local_warp * 32 + lane;
+            int num_prep_iters = (num_chunks_0_4 + 5 - 1 - prep_instance) / 5;
+            unsigned int prep_stage = (unsigned int)prep_instance;
+            int gate_rate_stage_f32 = prep_instance * 10496;
+            int prep_global_tid = warp_id_in_role_3 * 32 + lane;
+            if (prep_tid == 0) {
+                float _expf_0 = __expf(A_log[head_idx_4]);
+                smem_gate_rate_all[gate_rate_stage_f32] = _expf_0;
+            }
+            if (prep_global_tid < 128) {
+                smem_gate_bias_all[prep_global_tid] = dt_bias[head_idx_4 * 128 + prep_global_tid];
+            }
+            asm volatile("barrier.sync 15, 640;" ::: "memory");
+            {
+                if (prep_global_tid < 128) {
+                    smem_gate_bias_all[prep_global_tid] = smem_gate_bias_all[prep_global_tid] * smem_gate_rate_all[0];
+                }
+                asm volatile("barrier.sync 15, 640;" ::: "memory");
+            }
+            unsigned int _phase_raw_inputs_free = 1;
+            unsigned int _phase_gate_raw_full = 0;
+            unsigned int _phase_smem_free = 1;
+            unsigned int _phase_v_free = 1;
+            unsigned int _phase_qk_raw_full = 0;
+            unsigned int _phase_short_beta_ready = 0;
+            unsigned int _phase_prep_diag_ready = 0;
+            unsigned int _phase_prep_inv16_ready = 0;
+            unsigned int _phase_tape_free = 1;
+            #pragma unroll 1
+            for (int prep_iter = 0; prep_iter < num_prep_iters; prep_iter++) {
+                int chunk_idx_3 = prep_iter * 5 + prep_instance;
+                int chunk_global_local_2 = chunk_idx_3;
+                int owned_chunk_2 = chunk_global_local_2 >= 0 && chunk_global_local_2 < num_chunks_4;
+                int stage_f32 = prep_stage * 10496;
+                int stage_bf16 = prep_stage * 20992;
+                int chunk_is_full_1 = ((seq_len_4 >= (chunk_idx_3 + 1) * 32) ? 1 : 0);
+                float early_beta_value = 0.0f;
+                float early_gate0 = 0.0f;
+                if (chunk_is_full_1 != 0 || prep_iter != 0) {
+                    mbarrier_wait(raw_inputs_free_addr + (prep_stage) * 8, _phase_raw_inputs_free);
+                }
+                if (chunk_is_full_1 != 0) {
+                    if (prep_local_warp == 0) {
+                        if (elect_sync()) {
+                            mbarrier_arrive_expect_tx(gate_raw_full_addr + (prep_stage) * 8, 8704);
+                            tma_3d_gmem2smem(smem_g_raw_addr + prep_stage * 41984, g_tma, 0, head_idx_4, (int)(bos_4 + (long long)(chunk_idx_3 * 32)), gate_raw_full_addr + (prep_stage) * 8);
+                            {
+                                tma_2d_gmem2smem(smem_beta_raw_addr + prep_stage * 41984, beta_tma, ((0) ? 0 : head_idx_4 / 8 * 8), (int)(((0) ? (bos_4 + (long long)(chunk_idx_3 * 32)) / 2 : bos_4 + (long long)(chunk_idx_3 * 32))), gate_raw_full_addr + (prep_stage) * 8);
+                            }
+                            mbarrier_arrive_expect_tx(qk_raw_full_addr + (prep_stage) * 8, 16384);
+                            tma_4d_gmem2smem(smem_kd_addr + prep_stage * 41984, k_tma, 0, (int)(bos_4 + (long long)(chunk_idx_3 * 32)), head_idx_4, 0, qk_raw_full_addr + (prep_stage) * 8);
+                        }
+                    }
+                    mbarrier_wait(gate_raw_full_addr + (prep_stage) * 8, _phase_gate_raw_full);
+                    if (prep_local_warp == 2 && lane < 32) {
+                        float beta_logit = 0.0f;
+                        {
+                            {
+                                unsigned int beta_raw_pair[1];
+                                asm volatile("ld.shared.b32 %0, [%1];" : "=r"(*reinterpret_cast<uint32_t*>(&beta_raw_pair[0])) : "r"(smem_beta_raw_addr + prep_stage * 41984 + (unsigned int)(lane * 16) + (unsigned int)(head_idx_4 % 8 / 2 * 4)));
+                                float beta_raw_pair_f32[2];
+                                #pragma unroll
+                                for (int _pair = 0; _pair < 1; _pair++) {
+                                    asm volatile(
+                                        "{\n\t"
+                                        "shl.b32 %0, %2, 16;\n\t"
+                                        "and.b32 %1, %2, 0xffff0000;\n\t"
+                                        "}\n"
+                                        : "=f"((&beta_raw_pair_f32[_pair * 2])[0]), "=f"((&beta_raw_pair_f32[_pair * 2])[1])
+                                        : "r"(beta_raw_pair[_pair]));
+                                }
+                                beta_logit = beta_raw_pair_f32[0];
+                                if (head_idx_4 % 2 != 0) {
+                                    beta_logit = beta_raw_pair_f32[1];
+                                }
+                            }
+                        }
+                        float _tanh_approx_1;
+                        asm volatile("tanh.approx.f32 %0, %1;" : "=f"(_tanh_approx_1) : "f"(beta_logit * 0.5f));
+                        early_beta_value = _tanh_approx_1 * 0.5f + 0.5f;
+                    }
+                }
+                mbarrier_wait(smem_free_addr + (prep_stage) * 8, _phase_smem_free);
+                mbarrier_wait(v_free_addr + (prep_stage) * 8, _phase_v_free);
+                if (chunk_is_full_1 != 0) {
+                    if (prep_local_warp == 0) {
+                        if (elect_sync()) {
+                            tma_4d_gmem2smem(smem_q_raw_prefetch_addr + prep_stage * 41984, q_tma, 0, (int)(bos_4 + (long long)(chunk_idx_3 * 32)), head_idx_4, 0, qk_raw_full_addr + (prep_stage) * 8);
+                        }
+                    }
+                }
+                if (chunk_is_full_1 == 0) {
+                    #pragma unroll
+                    for (int gate_load_pass = 0; gate_load_pass < 4; gate_load_pass++) {
+                        int gate_load_item = gate_load_pass * 128 + prep_tid;
+                        int gate_load_row = gate_load_item / 16;
+                        int gate_load_segment = gate_load_item % 16;
+                        long long gate_load_token = bos_4 + (long long)(chunk_idx_3 * 32 + gate_load_row);
+                        long long gate_load_base = (gate_load_token * (long long)num_heads + (long long)head_idx_4) * 128 + (long long)(gate_load_segment * 8);
+                        asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16, %2;"
+                            :: "r"(smem_g_raw_addr + prep_stage * 41984 + (unsigned int)(gate_load_item * 16)), "l"(g + gate_load_base), "r"((gate_load_token < eos_4) ? 16 : 0));
+                        int q_tail_addr = (smem_q_raw_prefetch_addr + prep_stage * 41984 + (unsigned int)(gate_load_segment * 8 / 64 * 4096 + gate_load_row * 128 + gate_load_segment * 8 % 64 * 2 ^ (gate_load_segment * 8 / 64 * 4096 + gate_load_row * 128 + gate_load_segment * 8 % 64 * 2 >> 7 & 7) << 4));
+                        asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16, %2;"
+                            :: "r"(q_tail_addr), "l"(q + gate_load_base), "r"((gate_load_token < eos_4) ? 16 : 0));
+                        int k_tail_addr = (smem_kd_addr + prep_stage * 41984 + (unsigned int)(gate_load_segment * 8 / 64 * 4096 + gate_load_row * 128 + gate_load_segment * 8 % 64 * 2 ^ (gate_load_segment * 8 / 64 * 4096 + gate_load_row * 128 + gate_load_segment * 8 % 64 * 2 >> 7 & 7) << 4));
+                        asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16, %2;"
+                            :: "r"(k_tail_addr), "l"(k + gate_load_base), "r"((gate_load_token < eos_4) ? 16 : 0));
+                    }
+                }
+                if (chunk_is_full_1 == 0) {
+                    asm volatile("cp.async.commit_group;");
+                    asm volatile("cp.async.wait_group 0;");
+                    asm volatile("barrier.sync %0, 128;" :: "r"(10 + prep_instance) : "memory");
+                }
+                if (prep_local_warp == 2 && lane < 32) {
+                    long long beta_token = bos_4 + (long long)(chunk_idx_3 * 32 + lane);
+                    float beta_value = early_beta_value;
+                    if (chunk_is_full_1 == 0) {
+                        if (beta_token < eos_4) {
+                            float beta_logit_1 = (float)beta[beta_token * (long long)num_heads + (long long)head_idx_4];
+                            float _tanh_approx_3;
+                            asm volatile("tanh.approx.f32 %0, %1;" : "=f"(_tanh_approx_3) : "f"(beta_logit_1 * 0.5f));
+                            beta_value = _tanh_approx_3 * 0.5f + 0.5f;
+                        }
+                    }
+                    {
+                        smem_prep_beta_all[stage_f32 + lane] = beta_value;
+                    }
+                    {
+                        if (beta_token < eos_4 && owned_chunk_2 != 0) {
+                            beta_active_out[beta_token * (long long)num_heads + (long long)head_idx_4] = beta_value;
+                        }
+                    }
+                }
+                if (prep_tid < 128) {
+                    int gate_col = prep_tid;
+                    float gate_rate = smem_gate_rate_all[stage_f32];
+                    float gate_bias = smem_gate_bias_all[gate_col];
+                    float prefix_log2 = 0.0f;
+                    {
+                        float2 _f2_0 = make_float2(gate_rate, gate_rate);
+                        float2 gate_rate_pair = _f2_0;
+                        float2 _f2_1 = make_float2(gate_bias, gate_bias);
+                        float2 gate_bias_pair = _f2_1;
+                        float half_gate_scale = lower_bound * 0.7213475204444817f;
+                        float2 _f2_2 = make_float2(half_gate_scale, half_gate_scale);
+                        float2 half_gate_scale_pair = _f2_2;
+                        if (chunk_is_full_1 != 0) {
+                            for (int gate_row_pair = 0; gate_row_pair < 16; gate_row_pair++) {
+                                const int gate_row0 = gate_row_pair * 2;
+                                const int gate_row1 = gate_row0 + 1;
+                                const int gate_row0_0 = gate_row_pair * 2;
+                                const int gate_row1_1 = gate_row0_0 + 1;
+                                __nv_bfloat16 gate_raw0 = smem_g_raw_all[stage_bf16 + gate_row0_0 * 128 + gate_col];
+                                __nv_bfloat16 gate_raw1 = smem_g_raw_all[stage_bf16 + gate_row1_1 * 128 + gate_col];
+                                float _cvt_f32_2 = __bfloat162float(gate_raw0);
+                                float _cvt_f32_3 = __bfloat162float(gate_raw1);
+                                float2 _f2_3 = make_float2(_cvt_f32_2, _cvt_f32_3);
+                                float2 gate_raw_pair = _f2_3;
+                                float2 gate_arg_pair = fma_f32x2(gate_raw_pair, gate_rate_pair, gate_bias_pair);
+                                float _tanh_approx_4;
+                                asm volatile("tanh.approx.f32 %0, %1;" : "=f"(_tanh_approx_4) : "f"(gate_arg_pair.x * 0.5f));
+                                float _tanh_approx_5;
+                                asm volatile("tanh.approx.f32 %0, %1;" : "=f"(_tanh_approx_5) : "f"(gate_arg_pair.y * 0.5f));
+                                float2 _f2_4 = make_float2(_tanh_approx_4, _tanh_approx_5);
+                                float2 gate_tanh_pair = _f2_4;
+                                float2 gate_log_pair = fma_f32x2(gate_tanh_pair, half_gate_scale_pair, half_gate_scale_pair);
+                                float gate_log0 = gate_log_pair.x;
+                                float gate_log1 = gate_log_pair.y;
+                                prefix_log2 += gate_log0;
+                                smem_gate_all[stage_f32 + gate_row0 * 128 + gate_col] = prefix_log2;
+                                prefix_log2 += gate_log1;
+                                smem_gate_all[stage_f32 + gate_row1 * 128 + gate_col] = prefix_log2;
+                            }
+                        } else {
+                            for (int gate_row_pair_1 = 0; gate_row_pair_1 < 16; gate_row_pair_1++) {
+                                const int gate_row0_1 = gate_row_pair_1 * 2;
+                                const int gate_row1_2 = gate_row0_1 + 1;
+                                const int gate_row0_0_1 = gate_row_pair_1 * 2;
+                                const int gate_row1_1_1 = gate_row0_0_1 + 1;
+                                __nv_bfloat16 gate_raw0_1 = smem_g_raw_all[stage_bf16 + gate_row0_0_1 * 128 + gate_col];
+                                __nv_bfloat16 gate_raw1_1 = smem_g_raw_all[stage_bf16 + gate_row1_1_1 * 128 + gate_col];
+                                float _cvt_f32_4 = __bfloat162float(gate_raw0_1);
+                                float _cvt_f32_5 = __bfloat162float(gate_raw1_1);
+                                float2 _f2_5 = make_float2(_cvt_f32_4, _cvt_f32_5);
+                                float2 gate_raw_pair_1 = _f2_5;
+                                float2 gate_arg_pair_1 = fma_f32x2(gate_raw_pair_1, gate_rate_pair, gate_bias_pair);
+                                float _tanh_approx_6;
+                                asm volatile("tanh.approx.f32 %0, %1;" : "=f"(_tanh_approx_6) : "f"(gate_arg_pair_1.x * 0.5f));
+                                float _tanh_approx_7;
+                                asm volatile("tanh.approx.f32 %0, %1;" : "=f"(_tanh_approx_7) : "f"(gate_arg_pair_1.y * 0.5f));
+                                float2 _f2_6 = make_float2(_tanh_approx_6, _tanh_approx_7);
+                                float2 gate_tanh_pair_1 = _f2_6;
+                                float2 gate_log_pair_1 = fma_f32x2(gate_tanh_pair_1, half_gate_scale_pair, half_gate_scale_pair);
+                                float gate_log0_1 = gate_log_pair_1.x;
+                                float gate_log1_1 = gate_log_pair_1.y;
+                                {
+                                    long long gate_token0 = bos_4 + (long long)(chunk_idx_3 * 32 + gate_row0_0_1);
+                                    long long gate_token1 = gate_token0 + 1;
+                                    if (gate_token0 >= eos_4) {
+                                        gate_log0_1 = 0.0f;
+                                    }
+                                    if (gate_token1 >= eos_4) {
+                                        gate_log1_1 = 0.0f;
+                                    }
+                                }
+                                prefix_log2 += gate_log0_1;
+                                smem_gate_all[stage_f32 + gate_row0_1 * 128 + gate_col] = prefix_log2;
+                                prefix_log2 += gate_log1_1;
+                                smem_gate_all[stage_f32 + gate_row1_2 * 128 + gate_col] = prefix_log2;
+                            }
+                        }
+                    }
+                }
+                asm volatile("barrier.sync %0, 128;" :: "r"(10 + prep_instance) : "memory");
+                if (chunk_is_full_1 != 0) {
+                    mbarrier_wait(qk_raw_full_addr + (prep_stage) * 8, _phase_qk_raw_full);
+                }
+                if (prep_tid < 128) {
+                    float total_log2 = smem_gt_prefix_all[stage_f32 + prep_tid];
+                    float _exp2_0 = approx_exp2(total_log2 - lower_bound * 1.4426950408889634f * 16.0f);
+                    float restore_factor_value = _exp2_0;
+                    smem_restore_factor_all[stage_f32 + prep_tid] = restore_factor_value;
+                    {
+                        long long chunk_global_restore = cu_chunk_offsets[seq_idx_4] + (long long)chunk_global_local_2;
+                        if (owned_chunk_2 != 0) {
+                            tape_restore_factor[(chunk_global_restore * (long long)num_heads + (long long)head_idx_4) * 128 + (long long)prep_tid] = restore_factor_value;
+                        }
+                        int _vote_0 = __any_sync(0xFFFFFFFF, num_chunks_0_4 > chunk_idx_3 + 1 && total_log2 > -30.0f);
+                        int warp_slow = _vote_0;
+                        if (lane == 0) {
+                            smem_state_checkpoint_needed[prep_stage * 4 + (unsigned int)prep_local_warp] = (unsigned int)warp_slow;
+                        }
+                    }
+                }
+                if (prep_tid == 0) {
+                    float _exp2_1 = approx_exp2(lower_bound * 1.4426950408889634f * 16.0f);
+                    smem_restore_factor_all[stage_f32 + 128] = _exp2_1;
+                }
+                #pragma unroll 1
+                for (int work_pass = 0; work_pass < 4; work_pass++) {
+                    int work_item = work_pass * 128 + prep_tid;
+                    int row = work_item / 16;
+                    int segment = work_item % 16;
+                    long long token = bos_4 + (long long)(chunk_idx_3 * 32 + row);
+                    int token_valid = ((token < eos_4) ? 1 : 0);
+                    long long gmem_base = (token * (long long)num_heads + (long long)head_idx_4) * 128 + (long long)(segment * 8);
+                    float q_raw_vec[8];
+                    float k_raw_vec[8];
+                    unsigned int packed_2[4];
+                    asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                        : "=r"(*reinterpret_cast<uint32_t*>(&packed_2[0])), "=r"(*reinterpret_cast<uint32_t*>(&packed_2[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&packed_2[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&packed_2[(0) + 3]))
+                        : "r"((smem_q_raw_prefetch_addr + prep_stage * 41984 + (unsigned int)(segment * 8 / 64 * 4096 + row * 128 + segment * 8 % 64 * 2 ^ (segment * 8 / 64 * 4096 + row * 128 + segment * 8 % 64 * 2 >> 7 & 7) << 4))));
+                    float packed_f32_2[8];
+                    #pragma unroll
+                    for (int _pair = 0; _pair < 4; _pair++) {
+                        asm volatile(
+                            "{\n\t"
+                            "shl.b32 %0, %2, 16;\n\t"
+                            "and.b32 %1, %2, 0xffff0000;\n\t"
+                            "}\n"
+                            : "=f"((&packed_f32_2[_pair * 2])[0]), "=f"((&packed_f32_2[_pair * 2])[1])
+                            : "r"(packed_2[_pair]));
+                    }
+                    #pragma unroll
+                    for (int value_idx_2 = 0; value_idx_2 < 8; value_idx_2++) {
+                        q_raw_vec[value_idx_2] = packed_f32_2[value_idx_2];
+                    }
+                    unsigned int packed_0[4];
+                    asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                        : "=r"(*reinterpret_cast<uint32_t*>(&packed_0[0])), "=r"(*reinterpret_cast<uint32_t*>(&packed_0[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&packed_0[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&packed_0[(0) + 3]))
+                        : "r"((smem_kd_addr + prep_stage * 41984 + (unsigned int)(segment * 8 / 64 * 4096 + row * 128 + segment * 8 % 64 * 2 ^ (segment * 8 / 64 * 4096 + row * 128 + segment * 8 % 64 * 2 >> 7 & 7) << 4))));
+                    float packed_0_f32[8];
+                    #pragma unroll
+                    for (int _pair = 0; _pair < 4; _pair++) {
+                        asm volatile(
+                            "{\n\t"
+                            "shl.b32 %0, %2, 16;\n\t"
+                            "and.b32 %1, %2, 0xffff0000;\n\t"
+                            "}\n"
+                            : "=f"((&packed_0_f32[_pair * 2])[0]), "=f"((&packed_0_f32[_pair * 2])[1])
+                            : "r"(packed_0[_pair]));
+                    }
+                    #pragma unroll
+                    for (int value_idx_3 = 0; value_idx_3 < 8; value_idx_3++) {
+                        k_raw_vec[value_idx_3] = packed_0_f32[value_idx_3];
+                    }
+                    float q_sum = 0.0f;
+                    float k_sum = 0.0f;
+                    for (int elem_in_segment = 0; elem_in_segment < 8; elem_in_segment++) {
+                        float q_raw = q_raw_vec[elem_in_segment];
+                        float k_raw = k_raw_vec[elem_in_segment];
+                        float _fma_4 = __fmaf_rn(q_raw, q_raw, q_sum);
+                        q_sum = _fma_4;
+                        float _fma_5 = __fmaf_rn(k_raw, k_raw, k_sum);
+                        k_sum = _fma_5;
+                    }
+                    float _shfl_xor_0 = __shfl_xor_sync(0xFFFFFFFF, q_sum, 8);
+                    q_sum += _shfl_xor_0;
+                    float _shfl_xor_1 = __shfl_xor_sync(0xFFFFFFFF, k_sum, 8);
+                    k_sum += _shfl_xor_1;
+                    float _shfl_xor_2 = __shfl_xor_sync(0xFFFFFFFF, q_sum, 4);
+                    q_sum += _shfl_xor_2;
+                    float _shfl_xor_3 = __shfl_xor_sync(0xFFFFFFFF, k_sum, 4);
+                    k_sum += _shfl_xor_3;
+                    float _shfl_xor_4 = __shfl_xor_sync(0xFFFFFFFF, q_sum, 2);
+                    q_sum += _shfl_xor_4;
+                    float _shfl_xor_5 = __shfl_xor_sync(0xFFFFFFFF, k_sum, 2);
+                    k_sum += _shfl_xor_5;
+                    float _shfl_xor_6 = __shfl_xor_sync(0xFFFFFFFF, q_sum, 1);
+                    q_sum += _shfl_xor_6;
+                    float _shfl_xor_7 = __shfl_xor_sync(0xFFFFFFFF, k_sum, 1);
+                    k_sum += _shfl_xor_7;
+                    float _rsqrt_0 = rsqrtf(q_sum + 1e-06f);
+                    float q_inv = _rsqrt_0;
+                    float _rsqrt_1 = rsqrtf(k_sum + 1e-06f);
+                    float k_inv = _rsqrt_1;
+                    {
+                        q_inv *= scale;
+                    }
+                    const float2 _scale2_0 = {q_inv, q_inv};
+                    #pragma unroll
+                    for (int _ls = 0; _ls < 4; _ls++)
+                        mul_f32x2_inplace(&reinterpret_cast<float2*>(q_raw_vec)[_ls], _scale2_0);
+                    const float2 _scale2_1 = {k_inv, k_inv};
+                    #pragma unroll
+                    for (int _ls = 0; _ls < 4; _ls++)
+                        mul_f32x2_inplace(&reinterpret_cast<float2*>(k_raw_vec)[_ls], _scale2_1);
+                    {
+                        if (token_valid != 0 && owned_chunk_2 != 0) {
+                            if (segment == 0) {
+                                float norm_pair[2];
+                                norm_pair[0] = q_inv;
+                                norm_pair[1] = k_inv;
+                                {
+                                    float2 _v2 = make_float2(norm_pair[0 + 0], norm_pair[0 + 1]);
+                                    *reinterpret_cast<float2*>(norm_inv_out + (token * (long long)num_heads + (long long)head_idx_4) * 2) = _v2;
+                                }
+                            }
+                        }
+                    }
+                    float qd_vec[8];
+                    float kd_vec[8];
+                    float ki_vec[8];
+                    for (int elem_in_segment_1 = 0; elem_in_segment_1 < 8; elem_in_segment_1++) {
+                        int col = segment * 8 + elem_in_segment_1;
+                        float prefix = smem_gate_all[stage_f32 + row * 128 + col];
+                        float common_log2 = lower_bound * 1.4426950408889634f * 16.0f;
+                        float _exp2_2 = approx_exp2(prefix - common_log2);
+                        float decay = _exp2_2;
+                        qd_vec[elem_in_segment_1] = decay;
+                        kd_vec[elem_in_segment_1] = decay;
+                        ki_vec[elem_in_segment_1] = k_raw_vec[elem_in_segment_1] / decay;
+                    }
+                    {
+                        if (token_valid != 0 && owned_chunk_2 != 0) {
+                            {
+                                __nv_bfloat162 _pk[4];
+                                _pk[0] = __floats2bfloat162_rn(qd_vec[0 + 0], qd_vec[0 + 1]);
+                                _pk[1] = __floats2bfloat162_rn(qd_vec[0 + 2], qd_vec[0 + 3]);
+                                _pk[2] = __floats2bfloat162_rn(qd_vec[0 + 4], qd_vec[0 + 5]);
+                                _pk[3] = __floats2bfloat162_rn(qd_vec[0 + 6], qd_vec[0 + 7]);
+                                *reinterpret_cast<uint4*>(&((__nv_bfloat16*)(decay_out))[gmem_base + 0]) = *reinterpret_cast<uint4*>(&_pk[0]);
+                            }
+                        }
+                    }
+                    #pragma unroll
+                    for (int _ls = 0; _ls < 4; _ls++)
+                        mul_f32x2_inplace(&reinterpret_cast<float2*>(qd_vec)[_ls], reinterpret_cast<const float2*>(q_raw_vec)[_ls]);
+                    #pragma unroll
+                    for (int _ls = 0; _ls < 4; _ls++)
+                        mul_f32x2_inplace(&reinterpret_cast<float2*>(kd_vec)[_ls], reinterpret_cast<const float2*>(k_raw_vec)[_ls]);
+                    unsigned int packed_1_1[4];
+                    #pragma unroll
+                    for (int _lp = 0; _lp < 4; _lp++) {
+                        __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(qd_vec[_lp*2 + 0], qd_vec[_lp*2+1 + 0]));
+                        packed_1_1[_lp] = *(uint32_t*)&_bf2;
+                    }
+                    #pragma unroll
+                    for (int word = 0; word < 4; word++) {
+                        asm volatile("st.shared.b32 [%0], %1;" :: "r"((smem_qd_addr + prep_stage * 41984 + (unsigned int)(segment * 8 / 64 * 4096 + row * 128 + segment * 8 % 64 * 2 ^ (segment * 8 / 64 * 4096 + row * 128 + segment * 8 % 64 * 2 >> 7 & 7) << 4)) + (unsigned int)(word * 4)), "r"((packed_1_1[word])));
+                    }
+                    unsigned int packed_2_1[4];
+                    #pragma unroll
+                    for (int _lp = 0; _lp < 4; _lp++) {
+                        __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(kd_vec[_lp*2 + 0], kd_vec[_lp*2+1 + 0]));
+                        packed_2_1[_lp] = *(uint32_t*)&_bf2;
+                    }
+                    #pragma unroll
+                    for (int word_1 = 0; word_1 < 4; word_1++) {
+                        asm volatile("st.shared.b32 [%0], %1;" :: "r"((smem_kd_addr + prep_stage * 41984 + (unsigned int)(segment * 8 / 64 * 4096 + row * 128 + segment * 8 % 64 * 2 ^ (segment * 8 / 64 * 4096 + row * 128 + segment * 8 % 64 * 2 >> 7 & 7) << 4)) + (unsigned int)(word_1 * 4)), "r"((packed_2_1[word_1])));
+                    }
+                    unsigned int packed_3[4];
+                    #pragma unroll
+                    for (int _lp = 0; _lp < 4; _lp++) {
+                        __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(ki_vec[_lp*2 + 0], ki_vec[_lp*2+1 + 0]));
+                        packed_3[_lp] = *(uint32_t*)&_bf2;
+                    }
+                    #pragma unroll
+                    for (int word_2 = 0; word_2 < 4; word_2++) {
+                        asm volatile("st.shared.b32 [%0], %1;" :: "r"((smem_ki_addr + prep_stage * 41984 + (unsigned int)(segment * 8 / 64 * 4096 + row * 128 + segment * 8 % 64 * 2 ^ (segment * 8 / 64 * 4096 + row * 128 + segment * 8 % 64 * 2 >> 7 & 7) << 4)) + (unsigned int)(word_2 * 4)), "r"((packed_3[word_2])));
+                    }
+                }
+                asm volatile("barrier.sync %0, 128;" :: "r"(10 + prep_instance) : "memory");
+                unsigned int a_frag[4];
+                unsigned int b_frag[4];
+                float acc[8];
+                {
+                    int pair_row_base = prep_local_warp / 2 * 16;
+                    int pair_col_base = prep_local_warp % 2 * 16;
+                    if (pair_row_base >= pair_col_base) {
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(a_frag[0]), "=r"(a_frag[1]), "=r"(a_frag[2]), "=r"(a_frag[3])
+                            : "r"(smem_kd_addr + prep_stage * 41984 + (unsigned int)((lane / 16 / 8 * 256 + (pair_row_base + lane % 16) * 8 + (lane / 16 % 8 * 16 ^ (pair_row_base + lane % 16 & 7) << 4) / 16) * 16))
+                            : "memory");
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(b_frag[0]), "=r"(b_frag[1]), "=r"(b_frag[2]), "=r"(b_frag[3])
+                            : "r"(smem_ki_addr + prep_stage * 41984 + (unsigned int)((lane % 16 / 8 / 8 * 256 + (pair_col_base + 8 * (lane / 16) + lane % 8) * 8 + (lane % 16 / 8 % 8 * 16 ^ (pair_col_base + 8 * (lane / 16) + lane % 8 & 7) << 4) / 16) * 16))
+                            : "memory");
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%10, %11, %12, %13};\n"
+                            : "=f"(acc[0]), "=f"(acc[1]), "=f"(acc[2]), "=f"(acc[3])
+                            : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[0]), "r"(b_frag[1]), "f"(0.0f), "f"(0.0f), "f"(0.0f), "f"(0.0f));
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%10, %11, %12, %13};\n"
+                            : "=f"(acc[4]), "=f"(acc[(4) + 1]), "=f"(acc[(4) + 2]), "=f"(acc[(4) + 3])
+                            : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[2]), "r"(b_frag[(2) + 1]), "f"(0.0f), "f"(0.0f), "f"(0.0f), "f"(0.0f));
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(a_frag[0]), "=r"(a_frag[1]), "=r"(a_frag[2]), "=r"(a_frag[3])
+                            : "r"(smem_kd_addr + prep_stage * 41984 + (unsigned int)((lane / 16 / 8 * 256 + (pair_row_base + lane % 16) * 8 + (lane / 16 % 8 * 16 ^ (pair_row_base + lane % 16 & 7) << 4) / 16 ^ 2) * 16))
+                            : "memory");
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(b_frag[0]), "=r"(b_frag[1]), "=r"(b_frag[2]), "=r"(b_frag[3])
+                            : "r"(smem_ki_addr + prep_stage * 41984 + (unsigned int)(((lane % 16 / 8 / 8 * 256 + (pair_col_base + 8 * (lane / 16) + lane % 8) * 8 + (lane % 16 / 8 % 8 * 16 ^ (pair_col_base + 8 * (lane / 16) + lane % 8 & 7) << 4) / 16 + 256 ^ 2) - 256) * 16))
+                            : "memory");
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                            : "+f"(acc[0]), "+f"(acc[1]), "+f"(acc[2]), "+f"(acc[3])
+                            : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[0]), "r"(b_frag[1]));
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                            : "+f"(acc[4]), "+f"(acc[(4) + 1]), "+f"(acc[(4) + 2]), "+f"(acc[(4) + 3])
+                            : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[2]), "r"(b_frag[(2) + 1]));
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(a_frag[0]), "=r"(a_frag[1]), "=r"(a_frag[2]), "=r"(a_frag[3])
+                            : "r"(smem_kd_addr + prep_stage * 41984 + (unsigned int)((lane / 16 / 8 * 256 + (pair_row_base + lane % 16) * 8 + (lane / 16 % 8 * 16 ^ (pair_row_base + lane % 16 & 7) << 4) / 16 ^ 2 ^ 6) * 16))
+                            : "memory");
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(b_frag[0]), "=r"(b_frag[1]), "=r"(b_frag[2]), "=r"(b_frag[3])
+                            : "r"(smem_ki_addr + prep_stage * 41984 + (unsigned int)((((lane % 16 / 8 / 8 * 256 + (pair_col_base + 8 * (lane / 16) + lane % 8) * 8 + (lane % 16 / 8 % 8 * 16 ^ (pair_col_base + 8 * (lane / 16) + lane % 8 & 7) << 4) / 16 + 256 ^ 2) - 256 + 256 ^ 6) - 256) * 16))
+                            : "memory");
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                            : "+f"(acc[0]), "+f"(acc[1]), "+f"(acc[2]), "+f"(acc[3])
+                            : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[0]), "r"(b_frag[1]));
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                            : "+f"(acc[4]), "+f"(acc[(4) + 1]), "+f"(acc[(4) + 2]), "+f"(acc[(4) + 3])
+                            : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[2]), "r"(b_frag[(2) + 1]));
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(a_frag[0]), "=r"(a_frag[1]), "=r"(a_frag[2]), "=r"(a_frag[3])
+                            : "r"(smem_kd_addr + prep_stage * 41984 + (unsigned int)((lane / 16 / 8 * 256 + (pair_row_base + lane % 16) * 8 + (lane / 16 % 8 * 16 ^ (pair_row_base + lane % 16 & 7) << 4) / 16 ^ 2 ^ 6 ^ 2) * 16))
+                            : "memory");
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(b_frag[0]), "=r"(b_frag[1]), "=r"(b_frag[2]), "=r"(b_frag[3])
+                            : "r"(smem_ki_addr + prep_stage * 41984 + (unsigned int)(((((lane % 16 / 8 / 8 * 256 + (pair_col_base + 8 * (lane / 16) + lane % 8) * 8 + (lane % 16 / 8 % 8 * 16 ^ (pair_col_base + 8 * (lane / 16) + lane % 8 & 7) << 4) / 16 + 256 ^ 2) - 256 + 256 ^ 6) - 256 + 256 ^ 2) - 256) * 16))
+                            : "memory");
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                            : "+f"(acc[0]), "+f"(acc[1]), "+f"(acc[2]), "+f"(acc[3])
+                            : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[0]), "r"(b_frag[1]));
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                            : "+f"(acc[4]), "+f"(acc[(4) + 1]), "+f"(acc[(4) + 2]), "+f"(acc[(4) + 3])
+                            : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[2]), "r"(b_frag[(2) + 1]));
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(a_frag[0]), "=r"(a_frag[1]), "=r"(a_frag[2]), "=r"(a_frag[3])
+                            : "r"(smem_kd_addr + prep_stage * 41984 + (unsigned int)(((lane / 16 / 8 * 256 + (pair_row_base + lane % 16) * 8 + (lane / 16 % 8 * 16 ^ (pair_row_base + lane % 16 & 7) << 4) / 16 ^ 2 ^ 6 ^ 2 ^ 6) + 256) * 16))
+                            : "memory");
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(b_frag[0]), "=r"(b_frag[1]), "=r"(b_frag[2]), "=r"(b_frag[3])
+                            : "r"(smem_ki_addr + prep_stage * 41984 + (unsigned int)((((((lane % 16 / 8 / 8 * 256 + (pair_col_base + 8 * (lane / 16) + lane % 8) * 8 + (lane % 16 / 8 % 8 * 16 ^ (pair_col_base + 8 * (lane / 16) + lane % 8 & 7) << 4) / 16 + 256 ^ 2) - 256 + 256 ^ 6) - 256 + 256 ^ 2) - 256 + 256 ^ 6) + 256 - 256) * 16))
+                            : "memory");
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                            : "+f"(acc[0]), "+f"(acc[1]), "+f"(acc[2]), "+f"(acc[3])
+                            : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[0]), "r"(b_frag[1]));
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                            : "+f"(acc[4]), "+f"(acc[(4) + 1]), "+f"(acc[(4) + 2]), "+f"(acc[(4) + 3])
+                            : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[2]), "r"(b_frag[(2) + 1]));
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(a_frag[0]), "=r"(a_frag[1]), "=r"(a_frag[2]), "=r"(a_frag[3])
+                            : "r"(smem_kd_addr + prep_stage * 41984 + (unsigned int)(((lane / 16 / 8 * 256 + (pair_row_base + lane % 16) * 8 + (lane / 16 % 8 * 16 ^ (pair_row_base + lane % 16 & 7) << 4) / 16 ^ 2 ^ 6 ^ 2 ^ 6) + 256 ^ 2) * 16))
+                            : "memory");
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(b_frag[0]), "=r"(b_frag[1]), "=r"(b_frag[2]), "=r"(b_frag[3])
+                            : "r"(smem_ki_addr + prep_stage * 41984 + (unsigned int)(((((((lane % 16 / 8 / 8 * 256 + (pair_col_base + 8 * (lane / 16) + lane % 8) * 8 + (lane % 16 / 8 % 8 * 16 ^ (pair_col_base + 8 * (lane / 16) + lane % 8 & 7) << 4) / 16 + 256 ^ 2) - 256 + 256 ^ 6) - 256 + 256 ^ 2) - 256 + 256 ^ 6) + 256 - 256 + 256 ^ 2) - 256) * 16))
+                            : "memory");
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                            : "+f"(acc[0]), "+f"(acc[1]), "+f"(acc[2]), "+f"(acc[3])
+                            : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[0]), "r"(b_frag[1]));
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                            : "+f"(acc[4]), "+f"(acc[(4) + 1]), "+f"(acc[(4) + 2]), "+f"(acc[(4) + 3])
+                            : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[2]), "r"(b_frag[(2) + 1]));
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(a_frag[0]), "=r"(a_frag[1]), "=r"(a_frag[2]), "=r"(a_frag[3])
+                            : "r"(smem_kd_addr + prep_stage * 41984 + (unsigned int)(((lane / 16 / 8 * 256 + (pair_row_base + lane % 16) * 8 + (lane / 16 % 8 * 16 ^ (pair_row_base + lane % 16 & 7) << 4) / 16 ^ 2 ^ 6 ^ 2 ^ 6) + 256 ^ 2 ^ 6) * 16))
+                            : "memory");
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(b_frag[0]), "=r"(b_frag[1]), "=r"(b_frag[2]), "=r"(b_frag[3])
+                            : "r"(smem_ki_addr + prep_stage * 41984 + (unsigned int)((((((((lane % 16 / 8 / 8 * 256 + (pair_col_base + 8 * (lane / 16) + lane % 8) * 8 + (lane % 16 / 8 % 8 * 16 ^ (pair_col_base + 8 * (lane / 16) + lane % 8 & 7) << 4) / 16 + 256 ^ 2) - 256 + 256 ^ 6) - 256 + 256 ^ 2) - 256 + 256 ^ 6) + 256 - 256 + 256 ^ 2) - 256 + 256 ^ 6) - 256) * 16))
+                            : "memory");
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                            : "+f"(acc[0]), "+f"(acc[1]), "+f"(acc[2]), "+f"(acc[3])
+                            : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[0]), "r"(b_frag[1]));
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                            : "+f"(acc[4]), "+f"(acc[(4) + 1]), "+f"(acc[(4) + 2]), "+f"(acc[(4) + 3])
+                            : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[2]), "r"(b_frag[(2) + 1]));
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(a_frag[0]), "=r"(a_frag[1]), "=r"(a_frag[2]), "=r"(a_frag[3])
+                            : "r"(smem_kd_addr + prep_stage * 41984 + (unsigned int)(((lane / 16 / 8 * 256 + (pair_row_base + lane % 16) * 8 + (lane / 16 % 8 * 16 ^ (pair_row_base + lane % 16 & 7) << 4) / 16 ^ 2 ^ 6 ^ 2 ^ 6) + 256 ^ 2 ^ 6 ^ 2) * 16))
+                            : "memory");
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(b_frag[0]), "=r"(b_frag[1]), "=r"(b_frag[2]), "=r"(b_frag[3])
+                            : "r"(smem_ki_addr + prep_stage * 41984 + (unsigned int)(((((((((lane % 16 / 8 / 8 * 256 + (pair_col_base + 8 * (lane / 16) + lane % 8) * 8 + (lane % 16 / 8 % 8 * 16 ^ (pair_col_base + 8 * (lane / 16) + lane % 8 & 7) << 4) / 16 + 256 ^ 2) - 256 + 256 ^ 6) - 256 + 256 ^ 2) - 256 + 256 ^ 6) + 256 - 256 + 256 ^ 2) - 256 + 256 ^ 6) - 256 + 256 ^ 2) - 256) * 16))
+                            : "memory");
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                            : "+f"(acc[0]), "+f"(acc[1]), "+f"(acc[2]), "+f"(acc[3])
+                            : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[0]), "r"(b_frag[1]));
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                            : "+f"(acc[4]), "+f"(acc[(4) + 1]), "+f"(acc[(4) + 2]), "+f"(acc[(4) + 3])
+                            : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[2]), "r"(b_frag[(2) + 1]));
+                        int row0 = pair_row_base + lane / 4;
+                        int row1 = row0 + 8;
+                        int col0 = pair_col_base + lane % 4 * 2;
+                        float beta0 = 0.0f;
+                        float beta1 = 0.0f;
+                        {
+                            beta0 = smem_prep_beta_all[stage_f32 + row0];
+                            beta1 = smem_prep_beta_all[stage_f32 + row1];
+                        }
+                        float seed[8];
+                        seed[0] = 0.0f;
+                        seed[1] = 0.0f;
+                        seed[2] = 0.0f;
+                        seed[3] = 0.0f;
+                        seed[4] = 0.0f;
+                        seed[5] = 0.0f;
+                        seed[6] = 0.0f;
+                        seed[7] = 0.0f;
+                        if (row0 > col0) {
+                            seed[0] = acc[0] * beta0;
+                        }
+                        if (row0 > col0 + 1) {
+                            seed[1] = acc[1] * beta0;
+                        }
+                        if (row1 > col0) {
+                            seed[2] = acc[2] * beta1;
+                        }
+                        if (row1 > col0 + 1) {
+                            seed[3] = acc[3] * beta1;
+                        }
+                        if (row0 > col0 + 8) {
+                            seed[4] = acc[4] * beta0;
+                        }
+                        if (row0 > col0 + 9) {
+                            seed[5] = acc[5] * beta0;
+                        }
+                        if (row1 > col0 + 8) {
+                            seed[6] = acc[6] * beta1;
+                        }
+                        if (row1 > col0 + 9) {
+                            seed[7] = acc[7] * beta1;
+                        }
+                        unsigned int seed_packed[4];
+                        #pragma unroll
+                        for (int _lp = 0; _lp < 4; _lp++) {
+                            __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(seed[_lp*2 + 0], seed[_lp*2+1 + 0]));
+                            seed_packed[_lp] = *(uint32_t*)&_bf2;
+                        }
+                        int seed_lane_row = lane % 16;
+                        int seed_lane_col = lane / 16 * 8;
+                        int byte_off = (int)prep_stage * 41984 + (pair_row_base + seed_lane_row) * 128 + (pair_col_base + seed_lane_col) * 2;
+                        int swizzled_off = byte_off ^ (byte_off >> 7 & 7) << 4;
+                        int seed_addr = smem_inv_work_addr + (unsigned int)swizzled_off;
+                        uint32_t _stmatrix_addr_2 = static_cast<uint32_t>((unsigned long long)seed_addr);
+                        asm volatile("stmatrix.sync.aligned.m8n8.x4.shared.b16 [%0], {%1, %2, %3, %4};\n"
+                            :: "r"(_stmatrix_addr_2), "r"(*reinterpret_cast<const uint32_t*>(&seed_packed[0])), "r"(*reinterpret_cast<const uint32_t*>(&seed_packed[1])), "r"(*reinterpret_cast<const uint32_t*>(&seed_packed[2])), "r"(*reinterpret_cast<const uint32_t*>(&seed_packed[3]))
+                            : "memory");
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(a_frag[0]), "=r"(a_frag[1]), "=r"(a_frag[2]), "=r"(a_frag[3])
+                            : "r"(smem_qd_addr + prep_stage * 41984 + (unsigned int)((lane / 16 / 8 * 256 + (pair_row_base + lane % 16) * 8 + (lane / 16 % 8 * 16 ^ (pair_row_base + lane % 16 & 7) << 4) / 16) * 16))
+                            : "memory");
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(b_frag[0]), "=r"(b_frag[1]), "=r"(b_frag[2]), "=r"(b_frag[3])
+                            : "r"(smem_ki_addr + prep_stage * 41984 + (unsigned int)((lane % 16 / 8 / 8 * 256 + (pair_col_base + 8 * (lane / 16) + lane % 8) * 8 + (lane % 16 / 8 % 8 * 16 ^ (pair_col_base + 8 * (lane / 16) + lane % 8 & 7) << 4) / 16) * 16))
+                            : "memory");
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%10, %11, %12, %13};\n"
+                            : "=f"(acc[0]), "=f"(acc[1]), "=f"(acc[2]), "=f"(acc[3])
+                            : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[0]), "r"(b_frag[1]), "f"(0.0f), "f"(0.0f), "f"(0.0f), "f"(0.0f));
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%10, %11, %12, %13};\n"
+                            : "=f"(acc[4]), "=f"(acc[(4) + 1]), "=f"(acc[(4) + 2]), "=f"(acc[(4) + 3])
+                            : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[2]), "r"(b_frag[(2) + 1]), "f"(0.0f), "f"(0.0f), "f"(0.0f), "f"(0.0f));
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(a_frag[0]), "=r"(a_frag[1]), "=r"(a_frag[2]), "=r"(a_frag[3])
+                            : "r"(smem_qd_addr + prep_stage * 41984 + (unsigned int)((lane / 16 / 8 * 256 + (pair_row_base + lane % 16) * 8 + (lane / 16 % 8 * 16 ^ (pair_row_base + lane % 16 & 7) << 4) / 16 ^ 2) * 16))
+                            : "memory");
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(b_frag[0]), "=r"(b_frag[1]), "=r"(b_frag[2]), "=r"(b_frag[3])
+                            : "r"(smem_ki_addr + prep_stage * 41984 + (unsigned int)(((lane % 16 / 8 / 8 * 256 + (pair_col_base + 8 * (lane / 16) + lane % 8) * 8 + (lane % 16 / 8 % 8 * 16 ^ (pair_col_base + 8 * (lane / 16) + lane % 8 & 7) << 4) / 16 + 256 ^ 2) - 256) * 16))
+                            : "memory");
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                            : "+f"(acc[0]), "+f"(acc[1]), "+f"(acc[2]), "+f"(acc[3])
+                            : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[0]), "r"(b_frag[1]));
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                            : "+f"(acc[4]), "+f"(acc[(4) + 1]), "+f"(acc[(4) + 2]), "+f"(acc[(4) + 3])
+                            : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[2]), "r"(b_frag[(2) + 1]));
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(a_frag[0]), "=r"(a_frag[1]), "=r"(a_frag[2]), "=r"(a_frag[3])
+                            : "r"(smem_qd_addr + prep_stage * 41984 + (unsigned int)((lane / 16 / 8 * 256 + (pair_row_base + lane % 16) * 8 + (lane / 16 % 8 * 16 ^ (pair_row_base + lane % 16 & 7) << 4) / 16 ^ 2 ^ 6) * 16))
+                            : "memory");
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(b_frag[0]), "=r"(b_frag[1]), "=r"(b_frag[2]), "=r"(b_frag[3])
+                            : "r"(smem_ki_addr + prep_stage * 41984 + (unsigned int)((((lane % 16 / 8 / 8 * 256 + (pair_col_base + 8 * (lane / 16) + lane % 8) * 8 + (lane % 16 / 8 % 8 * 16 ^ (pair_col_base + 8 * (lane / 16) + lane % 8 & 7) << 4) / 16 + 256 ^ 2) - 256 + 256 ^ 6) - 256) * 16))
+                            : "memory");
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                            : "+f"(acc[0]), "+f"(acc[1]), "+f"(acc[2]), "+f"(acc[3])
+                            : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[0]), "r"(b_frag[1]));
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                            : "+f"(acc[4]), "+f"(acc[(4) + 1]), "+f"(acc[(4) + 2]), "+f"(acc[(4) + 3])
+                            : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[2]), "r"(b_frag[(2) + 1]));
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(a_frag[0]), "=r"(a_frag[1]), "=r"(a_frag[2]), "=r"(a_frag[3])
+                            : "r"(smem_qd_addr + prep_stage * 41984 + (unsigned int)((lane / 16 / 8 * 256 + (pair_row_base + lane % 16) * 8 + (lane / 16 % 8 * 16 ^ (pair_row_base + lane % 16 & 7) << 4) / 16 ^ 2 ^ 6 ^ 2) * 16))
+                            : "memory");
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(b_frag[0]), "=r"(b_frag[1]), "=r"(b_frag[2]), "=r"(b_frag[3])
+                            : "r"(smem_ki_addr + prep_stage * 41984 + (unsigned int)(((((lane % 16 / 8 / 8 * 256 + (pair_col_base + 8 * (lane / 16) + lane % 8) * 8 + (lane % 16 / 8 % 8 * 16 ^ (pair_col_base + 8 * (lane / 16) + lane % 8 & 7) << 4) / 16 + 256 ^ 2) - 256 + 256 ^ 6) - 256 + 256 ^ 2) - 256) * 16))
+                            : "memory");
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                            : "+f"(acc[0]), "+f"(acc[1]), "+f"(acc[2]), "+f"(acc[3])
+                            : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[0]), "r"(b_frag[1]));
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                            : "+f"(acc[4]), "+f"(acc[(4) + 1]), "+f"(acc[(4) + 2]), "+f"(acc[(4) + 3])
+                            : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[2]), "r"(b_frag[(2) + 1]));
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(a_frag[0]), "=r"(a_frag[1]), "=r"(a_frag[2]), "=r"(a_frag[3])
+                            : "r"(smem_qd_addr + prep_stage * 41984 + (unsigned int)(((lane / 16 / 8 * 256 + (pair_row_base + lane % 16) * 8 + (lane / 16 % 8 * 16 ^ (pair_row_base + lane % 16 & 7) << 4) / 16 ^ 2 ^ 6 ^ 2 ^ 6) + 256) * 16))
+                            : "memory");
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(b_frag[0]), "=r"(b_frag[1]), "=r"(b_frag[2]), "=r"(b_frag[3])
+                            : "r"(smem_ki_addr + prep_stage * 41984 + (unsigned int)((((((lane % 16 / 8 / 8 * 256 + (pair_col_base + 8 * (lane / 16) + lane % 8) * 8 + (lane % 16 / 8 % 8 * 16 ^ (pair_col_base + 8 * (lane / 16) + lane % 8 & 7) << 4) / 16 + 256 ^ 2) - 256 + 256 ^ 6) - 256 + 256 ^ 2) - 256 + 256 ^ 6) + 256 - 256) * 16))
+                            : "memory");
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                            : "+f"(acc[0]), "+f"(acc[1]), "+f"(acc[2]), "+f"(acc[3])
+                            : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[0]), "r"(b_frag[1]));
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                            : "+f"(acc[4]), "+f"(acc[(4) + 1]), "+f"(acc[(4) + 2]), "+f"(acc[(4) + 3])
+                            : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[2]), "r"(b_frag[(2) + 1]));
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(a_frag[0]), "=r"(a_frag[1]), "=r"(a_frag[2]), "=r"(a_frag[3])
+                            : "r"(smem_qd_addr + prep_stage * 41984 + (unsigned int)(((lane / 16 / 8 * 256 + (pair_row_base + lane % 16) * 8 + (lane / 16 % 8 * 16 ^ (pair_row_base + lane % 16 & 7) << 4) / 16 ^ 2 ^ 6 ^ 2 ^ 6) + 256 ^ 2) * 16))
+                            : "memory");
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(b_frag[0]), "=r"(b_frag[1]), "=r"(b_frag[2]), "=r"(b_frag[3])
+                            : "r"(smem_ki_addr + prep_stage * 41984 + (unsigned int)(((((((lane % 16 / 8 / 8 * 256 + (pair_col_base + 8 * (lane / 16) + lane % 8) * 8 + (lane % 16 / 8 % 8 * 16 ^ (pair_col_base + 8 * (lane / 16) + lane % 8 & 7) << 4) / 16 + 256 ^ 2) - 256 + 256 ^ 6) - 256 + 256 ^ 2) - 256 + 256 ^ 6) + 256 - 256 + 256 ^ 2) - 256) * 16))
+                            : "memory");
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                            : "+f"(acc[0]), "+f"(acc[1]), "+f"(acc[2]), "+f"(acc[3])
+                            : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[0]), "r"(b_frag[1]));
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                            : "+f"(acc[4]), "+f"(acc[(4) + 1]), "+f"(acc[(4) + 2]), "+f"(acc[(4) + 3])
+                            : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[2]), "r"(b_frag[(2) + 1]));
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(a_frag[0]), "=r"(a_frag[1]), "=r"(a_frag[2]), "=r"(a_frag[3])
+                            : "r"(smem_qd_addr + prep_stage * 41984 + (unsigned int)(((lane / 16 / 8 * 256 + (pair_row_base + lane % 16) * 8 + (lane / 16 % 8 * 16 ^ (pair_row_base + lane % 16 & 7) << 4) / 16 ^ 2 ^ 6 ^ 2 ^ 6) + 256 ^ 2 ^ 6) * 16))
+                            : "memory");
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(b_frag[0]), "=r"(b_frag[1]), "=r"(b_frag[2]), "=r"(b_frag[3])
+                            : "r"(smem_ki_addr + prep_stage * 41984 + (unsigned int)((((((((lane % 16 / 8 / 8 * 256 + (pair_col_base + 8 * (lane / 16) + lane % 8) * 8 + (lane % 16 / 8 % 8 * 16 ^ (pair_col_base + 8 * (lane / 16) + lane % 8 & 7) << 4) / 16 + 256 ^ 2) - 256 + 256 ^ 6) - 256 + 256 ^ 2) - 256 + 256 ^ 6) + 256 - 256 + 256 ^ 2) - 256 + 256 ^ 6) - 256) * 16))
+                            : "memory");
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                            : "+f"(acc[0]), "+f"(acc[1]), "+f"(acc[2]), "+f"(acc[3])
+                            : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[0]), "r"(b_frag[1]));
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                            : "+f"(acc[4]), "+f"(acc[(4) + 1]), "+f"(acc[(4) + 2]), "+f"(acc[(4) + 3])
+                            : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[2]), "r"(b_frag[(2) + 1]));
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(a_frag[0]), "=r"(a_frag[1]), "=r"(a_frag[2]), "=r"(a_frag[3])
+                            : "r"(smem_qd_addr + prep_stage * 41984 + (unsigned int)(((lane / 16 / 8 * 256 + (pair_row_base + lane % 16) * 8 + (lane / 16 % 8 * 16 ^ (pair_row_base + lane % 16 & 7) << 4) / 16 ^ 2 ^ 6 ^ 2 ^ 6) + 256 ^ 2 ^ 6 ^ 2) * 16))
+                            : "memory");
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(b_frag[0]), "=r"(b_frag[1]), "=r"(b_frag[2]), "=r"(b_frag[3])
+                            : "r"(smem_ki_addr + prep_stage * 41984 + (unsigned int)(((((((((lane % 16 / 8 / 8 * 256 + (pair_col_base + 8 * (lane / 16) + lane % 8) * 8 + (lane % 16 / 8 % 8 * 16 ^ (pair_col_base + 8 * (lane / 16) + lane % 8 & 7) << 4) / 16 + 256 ^ 2) - 256 + 256 ^ 6) - 256 + 256 ^ 2) - 256 + 256 ^ 6) + 256 - 256 + 256 ^ 2) - 256 + 256 ^ 6) - 256 + 256 ^ 2) - 256) * 16))
+                            : "memory");
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                            : "+f"(acc[0]), "+f"(acc[1]), "+f"(acc[2]), "+f"(acc[3])
+                            : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[0]), "r"(b_frag[1]));
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                            : "+f"(acc[4]), "+f"(acc[(4) + 1]), "+f"(acc[(4) + 2]), "+f"(acc[(4) + 3])
+                            : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[2]), "r"(b_frag[(2) + 1]));
+                    } else {
+                        acc[0] = 0.0f;
+                        acc[1] = 0.0f;
+                        acc[2] = 0.0f;
+                        acc[3] = 0.0f;
+                        acc[4] = 0.0f;
+                        acc[5] = 0.0f;
+                        acc[6] = 0.0f;
+                        acc[7] = 0.0f;
+                    }
+                    int row0_1 = pair_row_base + lane / 4;
+                    int row1_1 = row0_1 + 8;
+                    int col0_1 = pair_col_base + lane % 4 * 2;
+                    float mqk[8];
+                    mqk[0] = 0.0f;
+                    mqk[1] = 0.0f;
+                    mqk[2] = 0.0f;
+                    mqk[3] = 0.0f;
+                    mqk[4] = 0.0f;
+                    mqk[5] = 0.0f;
+                    mqk[6] = 0.0f;
+                    mqk[7] = 0.0f;
+                    if (row0_1 >= col0_1) {
+                        mqk[0] = acc[0];
+                    }
+                    if (row0_1 >= col0_1 + 1) {
+                        mqk[1] = acc[1];
+                    }
+                    if (row1_1 >= col0_1) {
+                        mqk[2] = acc[2];
+                    }
+                    if (row1_1 >= col0_1 + 1) {
+                        mqk[3] = acc[3];
+                    }
+                    if (row0_1 >= col0_1 + 8) {
+                        mqk[4] = acc[4];
+                    }
+                    if (row0_1 >= col0_1 + 9) {
+                        mqk[5] = acc[5];
+                    }
+                    if (row1_1 >= col0_1 + 8) {
+                        mqk[6] = acc[6];
+                    }
+                    if (row1_1 >= col0_1 + 9) {
+                        mqk[7] = acc[7];
+                    }
+                    unsigned int mqk_packed[4];
+                    #pragma unroll
+                    for (int _lp = 0; _lp < 4; _lp++) {
+                        __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(mqk[_lp*2 + 0], mqk[_lp*2+1 + 0]));
+                        mqk_packed[_lp] = *(uint32_t*)&_bf2;
+                    }
+                    #pragma unroll
+                    for (int publish_pair = 0; publish_pair < 2; publish_pair++) {
+                        int publish_row = pair_col_base + publish_pair * 8 + (lane & 7);
+                        int publish_col = 128 + pair_row_base + lane / 8 * 8;
+                        uint32_t _stmatrix_addr_3 = static_cast<uint32_t>((unsigned long long)(smem_final_trans_addr + prep_stage * 41984 + (unsigned int)(publish_col / 64 * 4096 + publish_row * 128 + publish_col % 64 * 2 ^ (publish_col / 64 * 4096 + publish_row * 128 + publish_col % 64 * 2 >> 7 & 7) << 4)));
+                        asm volatile("stmatrix.sync.aligned.m8n8.x2.trans.shared.b16 [%0], {%1, %2};\n"
+                            :: "r"(_stmatrix_addr_3), "r"(*reinterpret_cast<const uint32_t*>(&mqk_packed[publish_pair * 2])), "r"(*reinterpret_cast<const uint32_t*>(&mqk_packed[publish_pair * 2 + 1]))
+                            : "memory");
+                    }
+                    asm volatile("barrier.sync %0, 128;" :: "r"(10 + prep_instance) : "memory");
+                }
+                long long tape_scaled_base = 0;
+                {
+                    long long chunk_global_scaled = cu_chunk_offsets[seq_idx_4] + (long long)chunk_global_local_2;
+                    tape_scaled_base = (chunk_global_scaled * (long long)num_heads + (long long)head_idx_4) * 32 * 128;
+                }
+                if (prep_tid < 128) {
+                    float total_log2_1 = smem_gt_prefix_all[stage_f32 + prep_tid];
+                    float _exp2_3 = approx_exp2(total_log2_1);
+                    smem_gt_all[stage_f32 + prep_tid] = _exp2_3;
+                }
+                {
+                    if (prep_local_warp >= 2) {
+                        int stage_f32_0 = prep_stage * 10496;
+                        float restore_scale = smem_restore_factor_all[stage_f32_0 + 128];
+                        float restore_factor[8];
+                        int restore_segment = lane & 15;
+                        #pragma unroll
+                        for (int restore_elem = 0; restore_elem < 8; restore_elem++) {
+                            int restore_col = restore_segment * 8 + restore_elem;
+                            restore_factor[restore_elem] = smem_restore_factor_all[stage_f32_0 + restore_col];
+                        }
+                        #pragma unroll 1
+                        for (int restore_pass = 0; restore_pass < 6; restore_pass++) {
+                            int restore_row = 8 + (prep_local_warp - 2) * 12 + restore_pass * 2 + (lane >> 4);
+                            float restore_kr_values[8];
+                            {
+                                float restore_qd_values[8];
+                                float restore_kd_values[8];
+                                float restore_ki_values[8];
+                                unsigned int packed_4[4];
+                                asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                                    : "=r"(*reinterpret_cast<uint32_t*>(&packed_4[0])), "=r"(*reinterpret_cast<uint32_t*>(&packed_4[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&packed_4[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&packed_4[(0) + 3]))
+                                    : "r"((smem_qd_addr + prep_stage * 41984 + (unsigned int)(restore_segment * 8 / 64 * 4096 + restore_row * 128 + restore_segment * 8 % 64 * 2 ^ (restore_segment * 8 / 64 * 4096 + restore_row * 128 + restore_segment * 8 % 64 * 2 >> 7 & 7) << 4))));
+                                float packed_f32_3[8];
+                                #pragma unroll
+                                for (int _pair = 0; _pair < 4; _pair++) {
+                                    asm volatile(
+                                        "{\n\t"
+                                        "shl.b32 %0, %2, 16;\n\t"
+                                        "and.b32 %1, %2, 0xffff0000;\n\t"
+                                        "}\n"
+                                        : "=f"((&packed_f32_3[_pair * 2])[0]), "=f"((&packed_f32_3[_pair * 2])[1])
+                                        : "r"(packed_4[_pair]));
+                                }
+                                #pragma unroll
+                                for (int value_idx_4 = 0; value_idx_4 < 8; value_idx_4++) {
+                                    restore_qd_values[value_idx_4] = packed_f32_3[value_idx_4];
+                                }
+                                unsigned int packed_0_1[4];
+                                asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                                    : "=r"(*reinterpret_cast<uint32_t*>(&packed_0_1[0])), "=r"(*reinterpret_cast<uint32_t*>(&packed_0_1[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&packed_0_1[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&packed_0_1[(0) + 3]))
+                                    : "r"((smem_ki_addr + prep_stage * 41984 + (unsigned int)(restore_segment * 8 / 64 * 4096 + restore_row * 128 + restore_segment * 8 % 64 * 2 ^ (restore_segment * 8 / 64 * 4096 + restore_row * 128 + restore_segment * 8 % 64 * 2 >> 7 & 7) << 4))));
+                                float packed_0_f32_1[8];
+                                #pragma unroll
+                                for (int _pair = 0; _pair < 4; _pair++) {
+                                    asm volatile(
+                                        "{\n\t"
+                                        "shl.b32 %0, %2, 16;\n\t"
+                                        "and.b32 %1, %2, 0xffff0000;\n\t"
+                                        "}\n"
+                                        : "=f"((&packed_0_f32_1[_pair * 2])[0]), "=f"((&packed_0_f32_1[_pair * 2])[1])
+                                        : "r"(packed_0_1[_pair]));
+                                }
+                                #pragma unroll
+                                for (int value_idx_5 = 0; value_idx_5 < 8; value_idx_5++) {
+                                    restore_ki_values[value_idx_5] = packed_0_f32_1[value_idx_5];
+                                }
+                                if (STORE_BACKWARD_TAPE != 0 && owned_chunk_2 != 0) {
+                                    unsigned int packed_1_2[4];
+                                    asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                                        : "=r"(*reinterpret_cast<uint32_t*>(&packed_1_2[0])), "=r"(*reinterpret_cast<uint32_t*>(&packed_1_2[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&packed_1_2[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&packed_1_2[(0) + 3]))
+                                        : "r"((smem_kd_addr + prep_stage * 41984 + (unsigned int)(restore_segment * 8 / 64 * 4096 + restore_row * 128 + restore_segment * 8 % 64 * 2 ^ (restore_segment * 8 / 64 * 4096 + restore_row * 128 + restore_segment * 8 % 64 * 2 >> 7 & 7) << 4))));
+                                    float packed_1_f32[8];
+                                    #pragma unroll
+                                    for (int _pair = 0; _pair < 4; _pair++) {
+                                        asm volatile(
+                                            "{\n\t"
+                                            "shl.b32 %0, %2, 16;\n\t"
+                                            "and.b32 %1, %2, 0xffff0000;\n\t"
+                                            "}\n"
+                                            : "=f"((&packed_1_f32[_pair * 2])[0]), "=f"((&packed_1_f32[_pair * 2])[1])
+                                            : "r"(packed_1_2[_pair]));
+                                    }
+                                    #pragma unroll
+                                    for (int value_idx_6 = 0; value_idx_6 < 8; value_idx_6++) {
+                                        restore_kd_values[value_idx_6] = packed_1_f32[value_idx_6];
+                                    }
+                                    long long tape_scaled_index = tape_scaled_base + (long long)restore_row * 128 + (long long)(restore_segment * 8);
+                                    {
+                                        __nv_bfloat162 _pk[4];
+                                        _pk[0] = __floats2bfloat162_rn(restore_qd_values[0 + 0], restore_qd_values[0 + 1]);
+                                        _pk[1] = __floats2bfloat162_rn(restore_qd_values[0 + 2], restore_qd_values[0 + 3]);
+                                        _pk[2] = __floats2bfloat162_rn(restore_qd_values[0 + 4], restore_qd_values[0 + 5]);
+                                        _pk[3] = __floats2bfloat162_rn(restore_qd_values[0 + 6], restore_qd_values[0 + 7]);
+                                        *reinterpret_cast<uint4*>(&((__nv_bfloat16*)(tape_qd + tape_scaled_index))[0]) = *reinterpret_cast<uint4*>(&_pk[0]);
+                                    }
+                                    {
+                                        __nv_bfloat162 _pk[4];
+                                        _pk[0] = __floats2bfloat162_rn(restore_kd_values[0 + 0], restore_kd_values[0 + 1]);
+                                        _pk[1] = __floats2bfloat162_rn(restore_kd_values[0 + 2], restore_kd_values[0 + 3]);
+                                        _pk[2] = __floats2bfloat162_rn(restore_kd_values[0 + 4], restore_kd_values[0 + 5]);
+                                        _pk[3] = __floats2bfloat162_rn(restore_kd_values[0 + 6], restore_kd_values[0 + 7]);
+                                        *reinterpret_cast<uint4*>(&((__nv_bfloat16*)(tape_kd + tape_scaled_index))[0]) = *reinterpret_cast<uint4*>(&_pk[0]);
+                                    }
+                                }
+                                const float2 _scale2_4 = {restore_scale, restore_scale};
+                                #pragma unroll
+                                for (int _ls = 0; _ls < 4; _ls++)
+                                    mul_f32x2_inplace(&reinterpret_cast<float2*>(restore_qd_values)[_ls], _scale2_4);
+                                #pragma unroll
+                                for (int restore_elem_1 = 0; restore_elem_1 < 8; restore_elem_1++) {
+                                    restore_kr_values[restore_elem_1] = restore_ki_values[restore_elem_1] * restore_factor[restore_elem_1];
+                                }
+                            }
+                            unsigned int packed_5[4];
+                            #pragma unroll
+                            for (int _lp = 0; _lp < 4; _lp++) {
+                                __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(restore_kr_values[_lp*2 + 0], restore_kr_values[_lp*2+1 + 0]));
+                                packed_5[_lp] = *(uint32_t*)&_bf2;
+                            }
+                            #pragma unroll
+                            for (int word_3 = 0; word_3 < 4; word_3++) {
+                                asm volatile("st.shared.b32 [%0], %1;" :: "r"((smem_kr_trans_addr + prep_stage * 41984 + (unsigned int)(restore_segment * 8 / 64 * 4096 + restore_row * 128 + restore_segment * 8 % 64 * 2 ^ (restore_segment * 8 / 64 * 4096 + restore_row * 128 + restore_segment * 8 % 64 * 2 >> 7 & 7) << 4)) + (unsigned int)(word_3 * 4)), "r"((packed_5[word_3])));
+                            }
+                        }
+                    } else if (prep_local_warp == 1) {
+                        int stage_f32_0_1 = prep_stage * 10496;
+                        float restore_scale_1 = smem_restore_factor_all[stage_f32_0_1 + 128];
+                        float restore_factor_1[8];
+                        int restore_segment_1 = lane & 15;
+                        #pragma unroll
+                        for (int restore_elem_2 = 0; restore_elem_2 < 8; restore_elem_2++) {
+                            int restore_col_1 = restore_segment_1 * 8 + restore_elem_2;
+                            restore_factor_1[restore_elem_2] = smem_restore_factor_all[stage_f32_0_1 + restore_col_1];
+                        }
+                        #pragma unroll 1
+                        for (int restore_pass_1 = 0; restore_pass_1 < 4; restore_pass_1++) {
+                            int restore_row_1 = restore_pass_1 * 2 + (lane >> 4);
+                            float restore_kr_values_1[8];
+                            {
+                                float restore_qd_values_1[8];
+                                float restore_kd_values_1[8];
+                                float restore_ki_values_1[8];
+                                unsigned int packed_6[4];
+                                asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                                    : "=r"(*reinterpret_cast<uint32_t*>(&packed_6[0])), "=r"(*reinterpret_cast<uint32_t*>(&packed_6[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&packed_6[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&packed_6[(0) + 3]))
+                                    : "r"((smem_qd_addr + prep_stage * 41984 + (unsigned int)(restore_segment_1 * 8 / 64 * 4096 + restore_row_1 * 128 + restore_segment_1 * 8 % 64 * 2 ^ (restore_segment_1 * 8 / 64 * 4096 + restore_row_1 * 128 + restore_segment_1 * 8 % 64 * 2 >> 7 & 7) << 4))));
+                                float packed_f32_4[8];
+                                #pragma unroll
+                                for (int _pair = 0; _pair < 4; _pair++) {
+                                    asm volatile(
+                                        "{\n\t"
+                                        "shl.b32 %0, %2, 16;\n\t"
+                                        "and.b32 %1, %2, 0xffff0000;\n\t"
+                                        "}\n"
+                                        : "=f"((&packed_f32_4[_pair * 2])[0]), "=f"((&packed_f32_4[_pair * 2])[1])
+                                        : "r"(packed_6[_pair]));
+                                }
+                                #pragma unroll
+                                for (int value_idx_7 = 0; value_idx_7 < 8; value_idx_7++) {
+                                    restore_qd_values_1[value_idx_7] = packed_f32_4[value_idx_7];
+                                }
+                                unsigned int packed_0_2[4];
+                                asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                                    : "=r"(*reinterpret_cast<uint32_t*>(&packed_0_2[0])), "=r"(*reinterpret_cast<uint32_t*>(&packed_0_2[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&packed_0_2[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&packed_0_2[(0) + 3]))
+                                    : "r"((smem_ki_addr + prep_stage * 41984 + (unsigned int)(restore_segment_1 * 8 / 64 * 4096 + restore_row_1 * 128 + restore_segment_1 * 8 % 64 * 2 ^ (restore_segment_1 * 8 / 64 * 4096 + restore_row_1 * 128 + restore_segment_1 * 8 % 64 * 2 >> 7 & 7) << 4))));
+                                float packed_0_f32_2[8];
+                                #pragma unroll
+                                for (int _pair = 0; _pair < 4; _pair++) {
+                                    asm volatile(
+                                        "{\n\t"
+                                        "shl.b32 %0, %2, 16;\n\t"
+                                        "and.b32 %1, %2, 0xffff0000;\n\t"
+                                        "}\n"
+                                        : "=f"((&packed_0_f32_2[_pair * 2])[0]), "=f"((&packed_0_f32_2[_pair * 2])[1])
+                                        : "r"(packed_0_2[_pair]));
+                                }
+                                #pragma unroll
+                                for (int value_idx_8 = 0; value_idx_8 < 8; value_idx_8++) {
+                                    restore_ki_values_1[value_idx_8] = packed_0_f32_2[value_idx_8];
+                                }
+                                if (STORE_BACKWARD_TAPE != 0 && owned_chunk_2 != 0) {
+                                    unsigned int packed_1_3[4];
+                                    asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                                        : "=r"(*reinterpret_cast<uint32_t*>(&packed_1_3[0])), "=r"(*reinterpret_cast<uint32_t*>(&packed_1_3[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&packed_1_3[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&packed_1_3[(0) + 3]))
+                                        : "r"((smem_kd_addr + prep_stage * 41984 + (unsigned int)(restore_segment_1 * 8 / 64 * 4096 + restore_row_1 * 128 + restore_segment_1 * 8 % 64 * 2 ^ (restore_segment_1 * 8 / 64 * 4096 + restore_row_1 * 128 + restore_segment_1 * 8 % 64 * 2 >> 7 & 7) << 4))));
+                                    float packed_1_f32_1[8];
+                                    #pragma unroll
+                                    for (int _pair = 0; _pair < 4; _pair++) {
+                                        asm volatile(
+                                            "{\n\t"
+                                            "shl.b32 %0, %2, 16;\n\t"
+                                            "and.b32 %1, %2, 0xffff0000;\n\t"
+                                            "}\n"
+                                            : "=f"((&packed_1_f32_1[_pair * 2])[0]), "=f"((&packed_1_f32_1[_pair * 2])[1])
+                                            : "r"(packed_1_3[_pair]));
+                                    }
+                                    #pragma unroll
+                                    for (int value_idx_9 = 0; value_idx_9 < 8; value_idx_9++) {
+                                        restore_kd_values_1[value_idx_9] = packed_1_f32_1[value_idx_9];
+                                    }
+                                    long long tape_scaled_index_1 = tape_scaled_base + (long long)restore_row_1 * 128 + (long long)(restore_segment_1 * 8);
+                                    {
+                                        __nv_bfloat162 _pk[4];
+                                        _pk[0] = __floats2bfloat162_rn(restore_qd_values_1[0 + 0], restore_qd_values_1[0 + 1]);
+                                        _pk[1] = __floats2bfloat162_rn(restore_qd_values_1[0 + 2], restore_qd_values_1[0 + 3]);
+                                        _pk[2] = __floats2bfloat162_rn(restore_qd_values_1[0 + 4], restore_qd_values_1[0 + 5]);
+                                        _pk[3] = __floats2bfloat162_rn(restore_qd_values_1[0 + 6], restore_qd_values_1[0 + 7]);
+                                        *reinterpret_cast<uint4*>(&((__nv_bfloat16*)(tape_qd + tape_scaled_index_1))[0]) = *reinterpret_cast<uint4*>(&_pk[0]);
+                                    }
+                                    {
+                                        __nv_bfloat162 _pk[4];
+                                        _pk[0] = __floats2bfloat162_rn(restore_kd_values_1[0 + 0], restore_kd_values_1[0 + 1]);
+                                        _pk[1] = __floats2bfloat162_rn(restore_kd_values_1[0 + 2], restore_kd_values_1[0 + 3]);
+                                        _pk[2] = __floats2bfloat162_rn(restore_kd_values_1[0 + 4], restore_kd_values_1[0 + 5]);
+                                        _pk[3] = __floats2bfloat162_rn(restore_kd_values_1[0 + 6], restore_kd_values_1[0 + 7]);
+                                        *reinterpret_cast<uint4*>(&((__nv_bfloat16*)(tape_kd + tape_scaled_index_1))[0]) = *reinterpret_cast<uint4*>(&_pk[0]);
+                                    }
+                                }
+                                const float2 _scale2_5 = {restore_scale_1, restore_scale_1};
+                                #pragma unroll
+                                for (int _ls = 0; _ls < 4; _ls++)
+                                    mul_f32x2_inplace(&reinterpret_cast<float2*>(restore_qd_values_1)[_ls], _scale2_5);
+                                #pragma unroll
+                                for (int restore_elem_3 = 0; restore_elem_3 < 8; restore_elem_3++) {
+                                    restore_kr_values_1[restore_elem_3] = restore_ki_values_1[restore_elem_3] * restore_factor_1[restore_elem_3];
+                                }
+                            }
+                            unsigned int packed_7[4];
+                            #pragma unroll
+                            for (int _lp = 0; _lp < 4; _lp++) {
+                                __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(restore_kr_values_1[_lp*2 + 0], restore_kr_values_1[_lp*2+1 + 0]));
+                                packed_7[_lp] = *(uint32_t*)&_bf2;
+                            }
+                            #pragma unroll
+                            for (int word_4 = 0; word_4 < 4; word_4++) {
+                                asm volatile("st.shared.b32 [%0], %1;" :: "r"((smem_kr_trans_addr + prep_stage * 41984 + (unsigned int)(restore_segment_1 * 8 / 64 * 4096 + restore_row_1 * 128 + restore_segment_1 * 8 % 64 * 2 ^ (restore_segment_1 * 8 / 64 * 4096 + restore_row_1 * 128 + restore_segment_1 * 8 % 64 * 2 >> 7 & 7) << 4)) + (unsigned int)(word_4 * 4)), "r"((packed_7[word_4])));
+                            }
+                        }
+                    }
+                }
+                if (prep_local_warp == 0) {
+                    int inverse_row = lane;
+                    int diag_block = inverse_row / 8;
+                    int lane_in_diag = lane & 7;
+                    float inv_row[8];
+                    unsigned int packed_8[4];
+                    int byte_off_1 = (int)prep_stage * 41984 + inverse_row * 128 + diag_block * 8 * 2;
+                    int swizzled_off_1 = byte_off_1 ^ (byte_off_1 >> 7 & 7) << 4;
+                    asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                        : "=r"(*reinterpret_cast<uint32_t*>(&packed_8[0])), "=r"(*reinterpret_cast<uint32_t*>(&packed_8[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&packed_8[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&packed_8[(0) + 3]))
+                        : "r"(smem_inv_work_addr + (unsigned int)swizzled_off_1));
+                    float packed_f32_5[8];
+                    #pragma unroll
+                    for (int _pair = 0; _pair < 4; _pair++) {
+                        asm volatile(
+                            "{\n\t"
+                            "shl.b32 %0, %2, 16;\n\t"
+                            "and.b32 %1, %2, 0xffff0000;\n\t"
+                            "}\n"
+                            : "=f"((&packed_f32_5[_pair * 2])[0]), "=f"((&packed_f32_5[_pair * 2])[1])
+                            : "r"(packed_8[_pair]));
+                    }
+                    #pragma unroll
+                    for (int value_idx_10 = 0; value_idx_10 < 8; value_idx_10++) {
+                        inv_row[value_idx_10] = packed_f32_5[value_idx_10];
+                    }
+                    #pragma unroll
+                    for (int diag_elem = 0; diag_elem < 8; diag_elem++) {
+                        if (lane_in_diag == diag_elem) {
+                            inv_row[diag_elem] = 1.0f;
+                        }
+                    }
+                    int diag_group_base = lane - lane_in_diag;
+                    #pragma unroll
+                    for (int src_row = 0; src_row < 7; src_row++) {
+                        float row_scale = -inv_row[src_row];
+                        #pragma unroll
+                        for (int prev_col = 0; prev_col < src_row; prev_col++) {
+                            int pivot_lane = diag_group_base + src_row;
+                            float _shfl_0 = __shfl_sync(0xFFFFFFFF, inv_row[prev_col], pivot_lane);
+                            float pivot = _shfl_0;
+                            if (lane_in_diag > src_row) {
+                                float _fma_6 = __fmaf_rn(row_scale, pivot, inv_row[prev_col]);
+                                inv_row[prev_col] = _fma_6;
+                            }
+                        }
+                        if (lane_in_diag > src_row) {
+                            inv_row[src_row] = row_scale;
+                        }
+                    }
+                    unsigned int packed_0_3[4];
+                    #pragma unroll
+                    for (int _lp = 0; _lp < 4; _lp++) {
+                        __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(inv_row[_lp*2 + 0], inv_row[_lp*2+1 + 0]));
+                        packed_0_3[_lp] = *(uint32_t*)&_bf2;
+                    }
+                    int byte_off_1_1 = (int)prep_stage * 41984 + inverse_row * 128 + diag_block * 8 * 2;
+                    int swizzled_off_2 = byte_off_1_1 ^ (byte_off_1_1 >> 7 & 7) << 4;
+                    #pragma unroll
+                    for (int word_5 = 0; word_5 < 4; word_5++) {
+                        asm volatile("st.shared.b32 [%0], %1;" :: "r"(smem_inv_work_addr + (unsigned int)swizzled_off_2 + (unsigned int)(word_5 * 4)), "r"((packed_0_3[word_5])));
+                    }
+                }
+                if (prep_local_warp < 2) {
+                    __syncwarp();
+                    if (elect_sync()) {
+                        mbarrier_arrive(prep_diag_ready_addr + (prep_stage) * 8);
+                    }
+                    mbarrier_wait(prep_diag_ready_addr + (prep_stage) * 8, _phase_prep_diag_ready);
+                }
+                {
+                    if (prep_local_warp < 2) {
+                        int lane_row = lane & 7;
+                        int byte_off_2 = (int)prep_stage * 41984 + (prep_local_warp * 16 + 8 + lane_row) * 128 + (prep_local_warp * 16 + 8) * 2;
+                        int swizzled_off_3 = byte_off_2 ^ (byte_off_2 >> 7 & 7) << 4;
+                        int d_addr = smem_inv_work_addr + (unsigned int)swizzled_off_3;
+                        int byte_off_0 = (int)prep_stage * 41984 + (prep_local_warp * 16 + 8 + lane_row) * 128 + prep_local_warp * 16 * 2;
+                        int swizzled_off_1_1 = byte_off_0 ^ (byte_off_0 >> 7 & 7) << 4;
+                        int c_addr = smem_inv_work_addr + (unsigned int)swizzled_off_1_1;
+                        int byte_off_2_1 = (int)prep_stage * 41984 + (prep_local_warp * 16 + lane_row) * 128 + prep_local_warp * 16 * 2;
+                        int swizzled_off_3_1 = byte_off_2_1 ^ (byte_off_2_1 >> 7 & 7) << 4;
+                        int a_addr = smem_inv_work_addr + (unsigned int)swizzled_off_3_1;
+                        unsigned int d_frag[2];
+                        unsigned int c_frag[1];
+                        float dc_acc[4];
+                        unsigned int dc_bf16[2];
+                        unsigned int inv_a_frag[1];
+                        float o_acc[4];
+                        unsigned int o_bf16[2];
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x1.shared.b16 {%0}, [%1];\n"
+                            : "=r"(d_frag[0])
+                            : "r"(d_addr)
+                            : "memory");
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x1.shared.b16 {%0}, [%1];\n"
+                            : "=r"(d_frag[1])
+                            : "r"(d_addr)
+                            : "memory");
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x1.trans.shared.b16 {%0}, [%1];\n"
+                            : "=r"(c_frag[0])
+                            : "r"(c_addr)
+                            : "memory");
+                        asm volatile("mma.sync.aligned.m16n8k8.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5}, {%6}, {%7, %8, %9, %10};\n"
+                            : "=f"(dc_acc[0]), "=f"(dc_acc[1]), "=f"(dc_acc[2]), "=f"(dc_acc[3])
+                            : "r"(d_frag[0]), "r"(d_frag[1]), "r"(c_frag[0]), "f"(0.0f), "f"(0.0f), "f"(0.0f), "f"(0.0f));
+                        const float2 _scale2_6 = {-1.0f, -1.0f};
+                        #pragma unroll
+                        for (int _ls = 0; _ls < 2; _ls++)
+                            mul_f32x2_inplace(&reinterpret_cast<float2*>(dc_acc)[_ls], _scale2_6);
+                        #pragma unroll
+                        for (int _lp = 0; _lp < 2; _lp++) {
+                            __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(dc_acc[_lp*2 + 0], dc_acc[_lp*2+1 + 0]));
+                            dc_bf16[_lp] = *(uint32_t*)&_bf2;
+                        }
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x1.trans.shared.b16 {%0}, [%1];\n"
+                            : "=r"(inv_a_frag[0])
+                            : "r"(a_addr)
+                            : "memory");
+                        asm volatile("mma.sync.aligned.m16n8k8.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5}, {%6}, {%7, %8, %9, %10};\n"
+                            : "=f"(o_acc[0]), "=f"(o_acc[1]), "=f"(o_acc[2]), "=f"(o_acc[3])
+                            : "r"(dc_bf16[0]), "r"(dc_bf16[1]), "r"(inv_a_frag[0]), "f"(0.0f), "f"(0.0f), "f"(0.0f), "f"(0.0f));
+                        #pragma unroll
+                        for (int _lp = 0; _lp < 2; _lp++) {
+                            __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(o_acc[_lp*2 + 0], o_acc[_lp*2+1 + 0]));
+                            o_bf16[_lp] = *(uint32_t*)&_bf2;
+                        }
+                        int byte_off_4 = (int)prep_stage * 41984 + (prep_local_warp * 16 + 8 + lane_row) * 128 + prep_local_warp * 16 * 2;
+                        int swizzled_off_5 = byte_off_4 ^ (byte_off_4 >> 7 & 7) << 4;
+                        int o_addr = smem_inv_work_addr + (unsigned int)swizzled_off_5;
+                        uint32_t _stmatrix_addr_7 = static_cast<uint32_t>((unsigned long long)o_addr);
+                        asm volatile("stmatrix.sync.aligned.m8n8.x1.shared.b16 [%0], {%1};\n"
+                            :: "r"(_stmatrix_addr_7), "r"(*reinterpret_cast<const uint32_t*>(&o_bf16[0]))
+                            : "memory");
+                        __syncwarp();
+                        if (elect_sync()) {
+                            mbarrier_arrive(prep_inv16_ready_addr + (prep_stage) * 8);
+                        }
+                        mbarrier_wait(prep_inv16_ready_addr + (prep_stage) * 8, _phase_prep_inv16_ready);
+                    }
+                }
+                {
+                    if (prep_local_warp == 0) {
+                        int lane_row_1 = lane % 16;
+                        int lane_col = lane / 16 * 8;
+                        int byte_off_3 = (int)prep_stage * 41984 + (16 + lane_row_1) * 128 + (16 + lane_col) * 2;
+                        int swizzled_off_4 = byte_off_3 ^ (byte_off_3 >> 7 & 7) << 4;
+                        int d_addr_1 = smem_inv_work_addr + (unsigned int)swizzled_off_4;
+                        int byte_off_0_1 = (int)prep_stage * 41984 + (16 + lane_row_1) * 128 + lane_col * 2;
+                        int swizzled_off_1_2 = byte_off_0_1 ^ (byte_off_0_1 >> 7 & 7) << 4;
+                        int c_addr_1 = smem_inv_work_addr + (unsigned int)swizzled_off_1_2;
+                        int byte_off_2_2 = (int)prep_stage * 41984 + lane_row_1 * 128 + lane_col * 2;
+                        int swizzled_off_3_2 = byte_off_2_2 ^ (byte_off_2_2 >> 7 & 7) << 4;
+                        int a_addr_1 = smem_inv_work_addr + (unsigned int)swizzled_off_3_2;
+                        unsigned int d32_frag[4];
+                        unsigned int c32_frag[4];
+                        float dc32_acc[8];
+                        unsigned int dc32_bf16[4];
+                        unsigned int a32_frag[4];
+                        float o32_acc[8];
+                        unsigned int o32_bf16[4];
+                        unsigned int zero32_bf16[4];
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(d32_frag[0]), "=r"(d32_frag[1]), "=r"(d32_frag[2]), "=r"(d32_frag[3])
+                            : "r"(d_addr_1)
+                            : "memory");
+                        int d_publish_addr = (smem_inv_addr + prep_stage * 41984 + (unsigned int)((16 + lane_col) / 16 * 1024 + (16 + lane_row_1) * 32 + (16 + lane_col) % 16 * 2 ^ ((16 + lane_col) / 16 * 1024 + (16 + lane_row_1) * 32 + (16 + lane_col) % 16 * 2 >> 7 & 1) << 4));
+                        uint32_t _stmatrix_addr_8 = static_cast<uint32_t>((unsigned long long)d_publish_addr);
+                        asm volatile("stmatrix.sync.aligned.m8n8.x4.shared.b16 [%0], {%1, %2, %3, %4};\n"
+                            :: "r"(_stmatrix_addr_8), "r"(*reinterpret_cast<const uint32_t*>(&d32_frag[0])), "r"(*reinterpret_cast<const uint32_t*>(&d32_frag[1])), "r"(*reinterpret_cast<const uint32_t*>(&d32_frag[2])), "r"(*reinterpret_cast<const uint32_t*>(&d32_frag[3]))
+                            : "memory");
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.trans.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(c32_frag[0]), "=r"(c32_frag[1]), "=r"(c32_frag[2]), "=r"(c32_frag[3])
+                            : "r"(c_addr_1)
+                            : "memory");
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%10, %11, %12, %13};\n"
+                            : "=f"(dc32_acc[0]), "=f"(dc32_acc[1]), "=f"(dc32_acc[2]), "=f"(dc32_acc[3])
+                            : "r"(d32_frag[0]), "r"(d32_frag[1]), "r"(d32_frag[2]), "r"(d32_frag[3]), "r"(c32_frag[0]), "r"(c32_frag[1]), "f"(0.0f), "f"(0.0f), "f"(0.0f), "f"(0.0f));
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%10, %11, %12, %13};\n"
+                            : "=f"(dc32_acc[4]), "=f"(dc32_acc[(4) + 1]), "=f"(dc32_acc[(4) + 2]), "=f"(dc32_acc[(4) + 3])
+                            : "r"(d32_frag[0]), "r"(d32_frag[1]), "r"(d32_frag[2]), "r"(d32_frag[3]), "r"(c32_frag[2]), "r"(c32_frag[(2) + 1]), "f"(0.0f), "f"(0.0f), "f"(0.0f), "f"(0.0f));
+                        const float2 _scale2_9 = {-1.0f, -1.0f};
+                        #pragma unroll
+                        for (int _ls = 0; _ls < 4; _ls++)
+                            mul_f32x2_inplace(&reinterpret_cast<float2*>(dc32_acc)[_ls], _scale2_9);
+                        #pragma unroll
+                        for (int _lp = 0; _lp < 4; _lp++) {
+                            __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(dc32_acc[_lp*2 + 0], dc32_acc[_lp*2+1 + 0]));
+                            dc32_bf16[_lp] = *(uint32_t*)&_bf2;
+                        }
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.trans.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(a32_frag[0]), "=r"(a32_frag[1]), "=r"(a32_frag[2]), "=r"(a32_frag[3])
+                            : "r"(a_addr_1)
+                            : "memory");
+                        int a_publish_addr = (smem_inv_addr + prep_stage * 41984 + (unsigned int)(lane_col / 16 * 1024 + lane_row_1 * 32 + lane_col % 16 * 2 ^ (lane_col / 16 * 1024 + lane_row_1 * 32 + lane_col % 16 * 2 >> 7 & 1) << 4));
+                        uint32_t _stmatrix_addr_10 = static_cast<uint32_t>((unsigned long long)a_publish_addr);
+                        asm volatile("stmatrix.sync.aligned.m8n8.x4.trans.shared.b16 [%0], {%1, %2, %3, %4};\n"
+                            :: "r"(_stmatrix_addr_10), "r"(*reinterpret_cast<const uint32_t*>(&a32_frag[0])), "r"(*reinterpret_cast<const uint32_t*>(&a32_frag[1])), "r"(*reinterpret_cast<const uint32_t*>(&a32_frag[2])), "r"(*reinterpret_cast<const uint32_t*>(&a32_frag[3]))
+                            : "memory");
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%10, %11, %12, %13};\n"
+                            : "=f"(o32_acc[0]), "=f"(o32_acc[1]), "=f"(o32_acc[2]), "=f"(o32_acc[3])
+                            : "r"(dc32_bf16[0]), "r"(dc32_bf16[1]), "r"(dc32_bf16[2]), "r"(dc32_bf16[3]), "r"(a32_frag[0]), "r"(a32_frag[1]), "f"(0.0f), "f"(0.0f), "f"(0.0f), "f"(0.0f));
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%10, %11, %12, %13};\n"
+                            : "=f"(o32_acc[4]), "=f"(o32_acc[(4) + 1]), "=f"(o32_acc[(4) + 2]), "=f"(o32_acc[(4) + 3])
+                            : "r"(dc32_bf16[0]), "r"(dc32_bf16[1]), "r"(dc32_bf16[2]), "r"(dc32_bf16[3]), "r"(a32_frag[2]), "r"(a32_frag[(2) + 1]), "f"(0.0f), "f"(0.0f), "f"(0.0f), "f"(0.0f));
+                        #pragma unroll
+                        for (int _lp = 0; _lp < 4; _lp++) {
+                            __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(o32_acc[_lp*2 + 0], o32_acc[_lp*2+1 + 0]));
+                            o32_bf16[_lp] = *(uint32_t*)&_bf2;
+                        }
+                        int o_publish_addr = (smem_inv_addr + prep_stage * 41984 + (unsigned int)(lane_col / 16 * 1024 + (16 + lane_row_1) * 32 + lane_col % 16 * 2 ^ (lane_col / 16 * 1024 + (16 + lane_row_1) * 32 + lane_col % 16 * 2 >> 7 & 1) << 4));
+                        uint32_t _stmatrix_addr_11 = static_cast<uint32_t>((unsigned long long)o_publish_addr);
+                        asm volatile("stmatrix.sync.aligned.m8n8.x4.shared.b16 [%0], {%1, %2, %3, %4};\n"
+                            :: "r"(_stmatrix_addr_11), "r"(*reinterpret_cast<const uint32_t*>(&o32_bf16[0])), "r"(*reinterpret_cast<const uint32_t*>(&o32_bf16[1])), "r"(*reinterpret_cast<const uint32_t*>(&o32_bf16[2])), "r"(*reinterpret_cast<const uint32_t*>(&o32_bf16[3]))
+                            : "memory");
+                        #pragma unroll
+                        for (int zero_word = 0; zero_word < 4; zero_word++) {
+                            zero32_bf16[zero_word] = 0;
+                        }
+                        int zero_publish_addr = (smem_inv_addr + prep_stage * 41984 + (unsigned int)((16 + lane_col) / 16 * 1024 + lane_row_1 * 32 + (16 + lane_col) % 16 * 2 ^ ((16 + lane_col) / 16 * 1024 + lane_row_1 * 32 + (16 + lane_col) % 16 * 2 >> 7 & 1) << 4));
+                        uint32_t _stmatrix_addr_12 = static_cast<uint32_t>((unsigned long long)zero_publish_addr);
+                        asm volatile("stmatrix.sync.aligned.m8n8.x4.shared.b16 [%0], {%1, %2, %3, %4};\n"
+                            :: "r"(_stmatrix_addr_12), "r"(*reinterpret_cast<const uint32_t*>(&zero32_bf16[0])), "r"(*reinterpret_cast<const uint32_t*>(&zero32_bf16[1])), "r"(*reinterpret_cast<const uint32_t*>(&zero32_bf16[2])), "r"(*reinterpret_cast<const uint32_t*>(&zero32_bf16[3]))
+                            : "memory");
+                    }
+                }
+                asm volatile("fence.proxy.async.shared::cta;" ::: "memory");
+                asm volatile("barrier.sync %0, 128;" :: "r"(10 + prep_instance) : "memory");
+                if (prep_local_warp == 0) {
+                    if (elect_sync()) {
+                        {
+                            mbarrier_arrive(qk_full_addr + (prep_stage) * 8);
+                        }
+                        {
+                            mbarrier_arrive(tape_ready_addr + (prep_stage) * 8);
+                        }
+                    }
+                }
+                {
+                    mbarrier_wait(tape_free_addr + (prep_stage) * 8, _phase_tape_free);
+                }
+                if (chunk_is_full_1 != 0) {
+                    if (prep_local_warp == 0) {
+                        if (elect_sync()) {
+                            mbarrier_arrive_expect_tx(v_full_addr + (prep_stage) * 8, 8192);
+                            {
+                                tma_3d_gmem2smem(smem_v_addr + prep_stage * 41984, v_tma, 0, head_idx_4, (int)(bos_4 + (long long)(chunk_idx_3 * 32)), v_full_addr + (prep_stage) * 8);
+                            }
+                        }
+                    }
+                } else {
+                    #pragma unroll
+                    for (int v_load_iter = 0; v_load_iter < 4; v_load_iter++) {
+                        int v_item = v_load_iter * 128 + prep_tid;
+                        int row_1 = v_item / 16;
+                        int segment_1 = v_item % 16;
+                        long long token_1 = bos_4 + (long long)(chunk_idx_3 * 32 + row_1);
+                        int token_valid_1 = ((token_1 < eos_4) ? 1 : 0);
+                        long long v_src = (token_1 * (long long)num_heads + (long long)head_idx_4) * 128 + (long long)(segment_1 * 8);
+                        int v_dst = smem_v_addr + prep_stage * 41984 + (unsigned int)((row_1 * 128 + segment_1 * 8) * 2);
+                        asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16, %2;"
+                            :: "r"(v_dst), "l"(v + v_src), "r"((token_valid_1 != 0) ? 16 : 0));
+                    }
+                    asm volatile("cp.async.commit_group;");
+                    asm volatile("cp.async.wait_group 0;");
+                    asm volatile("barrier.sync %0, 128;" :: "r"(10 + prep_instance) : "memory");
+                    if (prep_local_warp == 0) {
+                        if (elect_sync()) {
+                            asm volatile("fence.proxy.async.shared::cta;" ::: "memory");
+                            mbarrier_arrive(v_full_addr + (prep_stage) * 8);
+                        }
+                    }
+                }
+                for (int _advance = 0; _advance < 5; _advance++) {
+                    prep_stage += 1;
+                    if (prep_stage == 5) { prep_stage = 0; _phase_raw_inputs_free ^= 1; _phase_gate_raw_full ^= 1; _phase_smem_free ^= 1; _phase_v_free ^= 1; _phase_qk_raw_full ^= 1; _phase_short_beta_ready ^= 1; _phase_prep_diag_ready ^= 1; _phase_prep_inv16_ready ^= 1; _phase_tape_free ^= 1; }
+                }
+            }
+        }
+    }
+
+    // Cleanup
+}
+
+} // extern "C"
+
+#undef LOOM_INF
+#undef NUM_CHECKPOINT_PIPE_STAGES
+#undef NUM_CHUNK_PIPE_STAGES
+#undef SMEM_SMEM_BETA_RAW_ALL_OFF
+#undef SMEM_SMEM_BETA_RAW_ALL_STAGE_BYTES
+#undef SMEM_SMEM_BETA_RAW_ALL_STRIDE
+#undef SMEM_SMEM_BETA_RAW_OFF
+#undef SMEM_SMEM_BETA_RAW_STAGE_BYTES
+#undef SMEM_SMEM_BETA_RAW_STRIDE
+#undef SMEM_SMEM_CHECKPOINT_OFF
+#undef SMEM_SMEM_CHECKPOINT_STAGE_BYTES
+#undef SMEM_SMEM_CHECKPOINT_STRIDE
+#undef SMEM_SMEM_FINAL_TRANS_OFF
+#undef SMEM_SMEM_FINAL_TRANS_STAGE_BYTES
+#undef SMEM_SMEM_FINAL_TRANS_STRIDE
+#undef SMEM_SMEM_GATE_ALL_OFF
+#undef SMEM_SMEM_GATE_ALL_STAGE_BYTES
+#undef SMEM_SMEM_GATE_ALL_STRIDE
+#undef SMEM_SMEM_GATE_BIAS_ALL_OFF
+#undef SMEM_SMEM_GATE_BIAS_ALL_STAGE_BYTES
+#undef SMEM_SMEM_GATE_BIAS_ALL_STRIDE
+#undef SMEM_SMEM_GATE_OFF
+#undef SMEM_SMEM_GATE_RATE_ALL_OFF
+#undef SMEM_SMEM_GATE_RATE_ALL_STAGE_BYTES
+#undef SMEM_SMEM_GATE_RATE_ALL_STRIDE
+#undef SMEM_SMEM_GATE_STAGE_BYTES
+#undef SMEM_SMEM_GATE_STRIDE
+#undef SMEM_SMEM_GT_ALL_OFF
+#undef SMEM_SMEM_GT_ALL_STAGE_BYTES
+#undef SMEM_SMEM_GT_ALL_STRIDE
+#undef SMEM_SMEM_GT_PREFIX_ALL_OFF
+#undef SMEM_SMEM_GT_PREFIX_ALL_STAGE_BYTES
+#undef SMEM_SMEM_GT_PREFIX_ALL_STRIDE
+#undef SMEM_SMEM_G_RAW_ALL_OFF
+#undef SMEM_SMEM_G_RAW_ALL_STAGE_BYTES
+#undef SMEM_SMEM_G_RAW_ALL_STRIDE
+#undef SMEM_SMEM_G_RAW_OFF
+#undef SMEM_SMEM_G_RAW_STAGE_BYTES
+#undef SMEM_SMEM_G_RAW_STRIDE
+#undef SMEM_SMEM_INV_OFF
+#undef SMEM_SMEM_INV_STAGE_BYTES
+#undef SMEM_SMEM_INV_STRIDE
+#undef SMEM_SMEM_INV_WORK_OFF
+#undef SMEM_SMEM_INV_WORK_STAGE_BYTES
+#undef SMEM_SMEM_INV_WORK_STRIDE
+#undef SMEM_SMEM_KD_OFF
+#undef SMEM_SMEM_KD_STAGE_BYTES
+#undef SMEM_SMEM_KD_STRIDE
+#undef SMEM_SMEM_KI_OFF
+#undef SMEM_SMEM_KI_STAGE_BYTES
+#undef SMEM_SMEM_KI_STRIDE
+#undef SMEM_SMEM_KR_TRANS_OFF
+#undef SMEM_SMEM_KR_TRANS_STAGE_BYTES
+#undef SMEM_SMEM_KR_TRANS_STRIDE
+#undef SMEM_SMEM_MQK_TRANS_OFF
+#undef SMEM_SMEM_MQK_TRANS_STAGE_BYTES
+#undef SMEM_SMEM_MQK_TRANS_STRIDE
+#undef SMEM_SMEM_OUT_OFF
+#undef SMEM_SMEM_OUT_STAGE_BYTES
+#undef SMEM_SMEM_OUT_STRIDE
+#undef SMEM_SMEM_PREP_BETA_ALL_OFF
+#undef SMEM_SMEM_PREP_BETA_ALL_STAGE_BYTES
+#undef SMEM_SMEM_PREP_BETA_ALL_STRIDE
+#undef SMEM_SMEM_PREP_BETA_BF16_ALL_OFF
+#undef SMEM_SMEM_PREP_BETA_BF16_ALL_STAGE_BYTES
+#undef SMEM_SMEM_PREP_BETA_BF16_ALL_STRIDE
+#undef SMEM_SMEM_PREP_BETA_U32_ALL_OFF
+#undef SMEM_SMEM_PREP_BETA_U32_ALL_STAGE_BYTES
+#undef SMEM_SMEM_PREP_BETA_U32_ALL_STRIDE
+#undef SMEM_SMEM_QD_OFF
+#undef SMEM_SMEM_QD_STAGE_BYTES
+#undef SMEM_SMEM_QD_STRIDE
+#undef SMEM_SMEM_Q_RAW_PREFETCH_OFF
+#undef SMEM_SMEM_Q_RAW_PREFETCH_STAGE_BYTES
+#undef SMEM_SMEM_Q_RAW_PREFETCH_STRIDE
+#undef SMEM_SMEM_RESTORE_FACTOR_ALL_OFF
+#undef SMEM_SMEM_RESTORE_FACTOR_ALL_STAGE_BYTES
+#undef SMEM_SMEM_RESTORE_FACTOR_ALL_STRIDE
+#undef SMEM_SMEM_SHORT_N32_V_OFF
+#undef SMEM_SMEM_SHORT_N32_V_STAGE_BYTES
+#undef SMEM_SMEM_SHORT_N32_V_STRIDE
+#undef SMEM_SMEM_STATE_CHECKPOINT_NEEDED_OFF
+#undef SMEM_SMEM_STATE_CHECKPOINT_NEEDED_STAGE_BYTES
+#undef SMEM_SMEM_STATE_CHECKPOINT_NEEDED_STRIDE
+#undef SMEM_SMEM_V_ALL_OFF
+#undef SMEM_SMEM_V_ALL_STAGE_BYTES
+#undef SMEM_SMEM_V_ALL_STRIDE
+#undef SMEM_SMEM_V_OFF
+#undef SMEM_SMEM_V_STAGE_BYTES
+#undef SMEM_SMEM_V_STRIDE
+#undef SMEM_SMEM_WORK_ITEM_COMPUTE_START_OFF
+#undef SMEM_SMEM_WORK_ITEM_COMPUTE_START_STAGE_BYTES
+#undef SMEM_SMEM_WORK_ITEM_COMPUTE_START_STRIDE
+#undef SMEM_SMEM_WORK_ITEM_RESOLVED_OFF
+#undef SMEM_SMEM_WORK_ITEM_RESOLVED_STAGE_BYTES
+#undef SMEM_SMEM_WORK_ITEM_RESOLVED_STRIDE
+#undef SMEM_SMEM_WORK_ITEM_WARP_MAX_OFF
+#undef SMEM_SMEM_WORK_ITEM_WARP_MAX_STAGE_BYTES
+#undef SMEM_SMEM_WORK_ITEM_WARP_MAX_STRIDE
+#undef SMEM_TOTAL
+#undef SPLIT_WORK_ITEMS
+#undef STORE_BACKWARD_TAPE
+#undef STORE_E_TAPE
+#undef TMEM_NCOLS
+#undef TMEM_TMEM_OUT_OFFSET
+#undef TMEM_TMEM_STATE_INP_OFFSET
+#undef TMEM_TMEM_STATE_OFFSET
+#undef TMEM_TMEM_STATE_OUT_OFFSET
+#undef TMEM_TMEM_U2_ACC_OFFSET
+#undef TMEM_TMEM_U2_INP_OFFSET
+#undef TMEM_TMEM_U_ACC_OFFSET
+#undef checkpoint_free_addr
+#undef checkpoint_ready_addr
+#undef final_ready_addr
+#undef gate_raw_full_addr
+#undef old_out_ready_addr
+#undef out_empty_addr
+#undef prep_diag_ready_addr
+#undef prep_inv16_ready_addr
+#undef qk_full_addr
+#undef qk_raw_full_addr
+#undef raw_inputs_free_addr
+#undef short_beta_ready_addr
+#undef smem_beta_raw_addr
+#undef smem_beta_raw_all_addr
+#undef smem_checkpoint_addr
+#undef smem_final_trans_addr
+#undef smem_free_addr
+#undef smem_g_raw_addr
+#undef smem_g_raw_all_addr
+#undef smem_gate_addr
+#undef smem_gate_all_addr
+#undef smem_gate_bias_all_addr
+#undef smem_gate_rate_all_addr
+#undef smem_gt_all_addr
+#undef smem_gt_prefix_all_addr
+#undef smem_inv_addr
+#undef smem_inv_work_addr
+#undef smem_kd_addr
+#undef smem_ki_addr
+#undef smem_kr_trans_addr
+#undef smem_mqk_trans_addr
+#undef smem_out_addr
+#undef smem_prep_beta_all_addr
+#undef smem_prep_beta_bf16_all_addr
+#undef smem_prep_beta_u32_all_addr
+#undef smem_q_raw_prefetch_addr
+#undef smem_qd_addr
+#undef smem_restore_factor_all_addr
+#undef smem_short_n32_v_addr
+#undef smem_state_checkpoint_needed_addr
+#undef smem_v_addr
+#undef smem_v_all_addr
+#undef smem_work_item_compute_start_addr
+#undef smem_work_item_resolved_addr
+#undef smem_work_item_warp_max_addr
+#undef state_inp_ready_addr
+#undef tape_free_addr
+#undef tape_ready_addr
+#undef tmem_dealloc_ready_addr
+#undef u2_acc_ready_addr
+#undef u2_inp_ready_addr
+#undef u_inp_ready_addr
+#undef v_free_addr
+#undef v_full_addr
+#undef work_item_ready_addr
+
+#define LOOM_INF CUDART_INF_F
+#define TMEM_NCOLS 256
+#define TMEM_TMEM_STATE_OFFSET 64
+#define TMEM_TMEM_STATE_INP_OFFSET 0
+#define TMEM_TMEM_U_ACC_OFFSET 224
+#define TMEM_TMEM_U2_INP_OFFSET 224
+#define TMEM_TMEM_U2_ACC_OFFSET 0
+#define TMEM_TMEM_OUT_OFFSET 192
+#define TMEM_TMEM_STATE_OUT_OFFSET 64
+#define NUM_CHUNK_PIPE_STAGES 5
+#define NUM_CHECKPOINT_PIPE_STAGES 2
+#define SMEM_SMEM_QD_OFF 1024
+#define SMEM_SMEM_QD_STAGE_BYTES 8192
+#define SMEM_SMEM_QD_STRIDE 41984
+#define SMEM_SMEM_G_RAW_OFF 1024
+#define SMEM_SMEM_G_RAW_STAGE_BYTES 8192
+#define SMEM_SMEM_G_RAW_STRIDE 41984
+#define SMEM_SMEM_G_RAW_ALL_OFF 1024
+#define SMEM_SMEM_G_RAW_ALL_STAGE_BYTES 176128
+#define SMEM_SMEM_G_RAW_ALL_STRIDE 176128
+#define SMEM_SMEM_KD_OFF 9216
+#define SMEM_SMEM_KD_STAGE_BYTES 8192
+#define SMEM_SMEM_KD_STRIDE 41984
+#define SMEM_SMEM_Q_RAW_PREFETCH_OFF 17408
+#define SMEM_SMEM_Q_RAW_PREFETCH_STAGE_BYTES 8192
+#define SMEM_SMEM_Q_RAW_PREFETCH_STRIDE 41984
+#define SMEM_SMEM_FINAL_TRANS_OFF 17408
+#define SMEM_SMEM_FINAL_TRANS_STAGE_BYTES 12288
+#define SMEM_SMEM_FINAL_TRANS_STRIDE 41984
+#define SMEM_SMEM_KR_TRANS_OFF 17408
+#define SMEM_SMEM_KR_TRANS_STAGE_BYTES 8192
+#define SMEM_SMEM_KR_TRANS_STRIDE 41984
+#define SMEM_SMEM_MQK_TRANS_OFF 25600
+#define SMEM_SMEM_MQK_TRANS_STAGE_BYTES 2048
+#define SMEM_SMEM_MQK_TRANS_STRIDE 41984
+#define SMEM_SMEM_INV_OFF 29696
+#define SMEM_SMEM_INV_STAGE_BYTES 2048
+#define SMEM_SMEM_INV_STRIDE 41984
+#define SMEM_SMEM_V_OFF 32384
+#define SMEM_SMEM_V_STAGE_BYTES 8192
+#define SMEM_SMEM_V_STRIDE 41984
+#define SMEM_SMEM_SHORT_N32_V_OFF 168960
+#define SMEM_SMEM_SHORT_N32_V_STAGE_BYTES 32768
+#define SMEM_SMEM_SHORT_N32_V_STRIDE 32768
+#define SMEM_SMEM_KI_OFF 17408
+#define SMEM_SMEM_KI_STAGE_BYTES 8192
+#define SMEM_SMEM_KI_STRIDE 41984
+#define SMEM_SMEM_GATE_OFF 25600
+#define SMEM_SMEM_GATE_STAGE_BYTES 16384
+#define SMEM_SMEM_GATE_STRIDE 41984
+#define SMEM_SMEM_BETA_RAW_OFF 41984
+#define SMEM_SMEM_BETA_RAW_STAGE_BYTES 512
+#define SMEM_SMEM_BETA_RAW_STRIDE 41984
+#define SMEM_SMEM_BETA_RAW_ALL_OFF 41984
+#define SMEM_SMEM_BETA_RAW_ALL_STAGE_BYTES 168448
+#define SMEM_SMEM_BETA_RAW_ALL_STRIDE 168448
+#define SMEM_SMEM_INV_WORK_OFF 32384
+#define SMEM_SMEM_INV_WORK_STAGE_BYTES 4096
+#define SMEM_SMEM_INV_WORK_STRIDE 41984
+#define SMEM_SMEM_OUT_OFF 210944
+#define SMEM_SMEM_OUT_STAGE_BYTES 8192
+#define SMEM_SMEM_OUT_STRIDE 8192
+#define SMEM_SMEM_CHECKPOINT_OFF 228352
+#define SMEM_SMEM_CHECKPOINT_STAGE_BYTES 32768
+#define SMEM_SMEM_CHECKPOINT_STRIDE 32768
+#define SMEM_SMEM_RESTORE_FACTOR_ALL_OFF 41984
+#define SMEM_SMEM_RESTORE_FACTOR_ALL_STAGE_BYTES 168452
+#define SMEM_SMEM_RESTORE_FACTOR_ALL_STRIDE 168452
+#define SMEM_SMEM_GT_PREFIX_ALL_OFF 41472
+#define SMEM_SMEM_GT_PREFIX_ALL_STAGE_BYTES 168448
+#define SMEM_SMEM_GT_PREFIX_ALL_STRIDE 168448
+#define SMEM_SMEM_GT_ALL_OFF 31744
+#define SMEM_SMEM_GT_ALL_STAGE_BYTES 168448
+#define SMEM_SMEM_GT_ALL_STRIDE 168448
+#define SMEM_SMEM_PREP_BETA_ALL_OFF 42500
+#define SMEM_SMEM_PREP_BETA_ALL_STAGE_BYTES 168064
+#define SMEM_SMEM_PREP_BETA_ALL_STRIDE 168064
+#define SMEM_SMEM_PREP_BETA_BF16_ALL_OFF 42500
+#define SMEM_SMEM_PREP_BETA_BF16_ALL_STAGE_BYTES 168000
+#define SMEM_SMEM_PREP_BETA_BF16_ALL_STRIDE 168000
+#define SMEM_SMEM_PREP_BETA_U32_ALL_OFF 42500
+#define SMEM_SMEM_PREP_BETA_U32_ALL_STAGE_BYTES 168000
+#define SMEM_SMEM_PREP_BETA_U32_ALL_STRIDE 168000
+#define SMEM_SMEM_GATE_RATE_ALL_OFF 42628
+#define SMEM_SMEM_GATE_RATE_ALL_STAGE_BYTES 167940
+#define SMEM_SMEM_GATE_RATE_ALL_STRIDE 167940
+#define SMEM_SMEM_GATE_BIAS_ALL_OFF 227408
+#define SMEM_SMEM_GATE_BIAS_ALL_STAGE_BYTES 512
+#define SMEM_SMEM_GATE_BIAS_ALL_STRIDE 512
+#define SMEM_SMEM_V_ALL_OFF 32384
+#define SMEM_SMEM_V_ALL_STAGE_BYTES 176128
+#define SMEM_SMEM_V_ALL_STRIDE 176128
+#define SMEM_SMEM_GATE_ALL_OFF 25600
+#define SMEM_SMEM_GATE_ALL_STAGE_BYTES 184320
+#define SMEM_SMEM_GATE_ALL_STRIDE 184320
+#define SMEM_SMEM_STATE_CHECKPOINT_NEEDED_OFF 227328
+#define SMEM_SMEM_STATE_CHECKPOINT_NEEDED_STAGE_BYTES 80
+#define SMEM_SMEM_STATE_CHECKPOINT_NEEDED_STRIDE 80
+#define SMEM_SMEM_WORK_ITEM_WARP_MAX_OFF 227328
+#define SMEM_SMEM_WORK_ITEM_WARP_MAX_STAGE_BYTES 16
+#define SMEM_SMEM_WORK_ITEM_WARP_MAX_STRIDE 16
+#define SMEM_SMEM_WORK_ITEM_COMPUTE_START_OFF 227344
+#define SMEM_SMEM_WORK_ITEM_COMPUTE_START_STAGE_BYTES 4
+#define SMEM_SMEM_WORK_ITEM_COMPUTE_START_STRIDE 4
+#define SMEM_SMEM_WORK_ITEM_RESOLVED_OFF 227348
+#define SMEM_SMEM_WORK_ITEM_RESOLVED_STAGE_BYTES 4
+#define SMEM_SMEM_WORK_ITEM_RESOLVED_STRIDE 4
+#define SMEM_TOTAL 227968
+#define STORE_BACKWARD_TAPE 1
+#define STORE_E_TAPE 0
+#define SPLIT_WORK_ITEMS 1
+
+extern "C" {
+
+__global__ __launch_bounds__(1024) void
+kernel_flashkda_bf16_fused_m128(__nv_bfloat16* __restrict__ q, LoomTensorMap const* q_tma, __nv_bfloat16* __restrict__ k, LoomTensorMap const* k_tma, __nv_bfloat16* __restrict__ v, LoomTensorMap const* v_tma, __nv_bfloat16* __restrict__ g, LoomTensorMap const* g_tma, __nv_bfloat16* __restrict__ beta, LoomTensorMap const* beta_tma, float* __restrict__ A_log, float* __restrict__ dt_bias, long long* __restrict__ cu_seqlens, int* __restrict__ seq_order, __nv_bfloat16* __restrict__ initial_state, __nv_bfloat16* __restrict__ out, LoomTensorMap const* out_tma, __nv_bfloat16* __restrict__ final_state, int num_heads, int use_initial_state, int store_final_state, float scale, float lower_bound, unsigned long long state_indices_addr, unsigned long long state_checkpoints_addr, unsigned long long checkpoint_cu_starts_addr, long long beta_token_stride, long long state_slot_stride, int use_state_indices, int checkpoint_every_n_tokens, long long* __restrict__ cu_chunk_offsets, __nv_bfloat16* __restrict__ chunk_state, unsigned int* __restrict__ state_checkpoint_needed, __nv_bfloat16* __restrict__ tape_qd, __nv_bfloat16* __restrict__ tape_kd, __nv_bfloat16* __restrict__ tape_kr, __nv_bfloat16* __restrict__ tape_j, float* __restrict__ tape_restore_factor, __nv_bfloat16* __restrict__ tape_e, __nv_bfloat16* __restrict__ tape_x, __nv_bfloat16* __restrict__ tape_r, float* __restrict__ norm_inv_out, __nv_bfloat16* __restrict__ decay_out, float* __restrict__ beta_active_out, float* __restrict__ initial_state_f32, unsigned int* __restrict__ zero_workspace, int zero_words, int num_sequences, LoomTensorMap const* state_checkpoints_tma)
+{
+    const int tid = threadIdx.x;
+    const int warp = make_warp_uniform(tid / 32);
+    const int lane = tid % 32;
+
+    extern __shared__ __align__(1024) char smem_raw[];
+    int smem;
+    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+
+    const int bid = blockIdx.x;
+    const int num_bids = gridDim.x;
+    if (warp == 8 && lane == 0) {
+        asm volatile("fence.proxy.tensormap::generic.acquire.sys [%0], 128;" :: "l"((uint64_t)(q_tma)) : "memory");
+        asm volatile("fence.proxy.tensormap::generic.acquire.sys [%0], 128;" :: "l"((uint64_t)(k_tma)) : "memory");
+        asm volatile("fence.proxy.tensormap::generic.acquire.sys [%0], 128;" :: "l"((uint64_t)(v_tma)) : "memory");
+        asm volatile("fence.proxy.tensormap::generic.acquire.sys [%0], 128;" :: "l"((uint64_t)(g_tma)) : "memory");
+        asm volatile("fence.proxy.tensormap::generic.acquire.sys [%0], 128;" :: "l"((uint64_t)(beta_tma)) : "memory");
+        asm volatile("fence.proxy.tensormap::generic.acquire.sys [%0], 128;" :: "l"((uint64_t)(out_tma)) : "memory");
+        asm volatile("fence.proxy.tensormap::generic.acquire.sys [%0], 128;" :: "l"((uint64_t)(state_checkpoints_tma)) : "memory");
+    }
+
+
+    // Kernel setup ops
+    __nv_bfloat16* smem_qd = reinterpret_cast<__nv_bfloat16*>(smem_raw + 1024);
+    const int smem_qd_addr = smem + 1024;
+    __nv_bfloat16* smem_g_raw = reinterpret_cast<__nv_bfloat16*>(smem_raw + 1024);
+    const int smem_g_raw_addr = smem + 1024;
+    __nv_bfloat16* smem_g_raw_all = reinterpret_cast<__nv_bfloat16*>(smem_raw + 1024);
+    const int smem_g_raw_all_addr = smem + 1024;
+    __nv_bfloat16* smem_kd = reinterpret_cast<__nv_bfloat16*>(smem_raw + 9216);
+    const int smem_kd_addr = smem + 9216;
+    __nv_bfloat16* smem_q_raw_prefetch = reinterpret_cast<__nv_bfloat16*>(smem_raw + 17408);
+    const int smem_q_raw_prefetch_addr = smem + 17408;
+    __nv_bfloat16* smem_final_trans = reinterpret_cast<__nv_bfloat16*>(smem_raw + 17408);
+    const int smem_final_trans_addr = smem + 17408;
+    __nv_bfloat16* smem_kr_trans = reinterpret_cast<__nv_bfloat16*>(smem_raw + 17408);
+    const int smem_kr_trans_addr = smem + 17408;
+    __nv_bfloat16* smem_mqk_trans = reinterpret_cast<__nv_bfloat16*>(smem_raw + 25600);
+    const int smem_mqk_trans_addr = smem + 25600;
+    __nv_bfloat16* smem_inv = reinterpret_cast<__nv_bfloat16*>(smem_raw + 29696);
+    const int smem_inv_addr = smem + 29696;
+    __nv_bfloat16* smem_v = reinterpret_cast<__nv_bfloat16*>(smem_raw + 32384);
+    const int smem_v_addr = smem + 32384;
+    __nv_bfloat16* smem_short_n32_v = reinterpret_cast<__nv_bfloat16*>(smem_raw + 168960);
+    const int smem_short_n32_v_addr = smem + 168960;
+    __nv_bfloat16* smem_ki = reinterpret_cast<__nv_bfloat16*>(smem_raw + 17408);
+    const int smem_ki_addr = smem + 17408;
+    float* smem_gate = reinterpret_cast<float*>(smem_raw + 25600);
+    const int smem_gate_addr = smem + 25600;
+    __nv_bfloat16* smem_beta_raw = reinterpret_cast<__nv_bfloat16*>(smem_raw + 41984);
+    const int smem_beta_raw_addr = smem + 41984;
+    __nv_bfloat16* smem_beta_raw_all = reinterpret_cast<__nv_bfloat16*>(smem_raw + 41984);
+    const int smem_beta_raw_all_addr = smem + 41984;
+    __nv_bfloat16* smem_inv_work = reinterpret_cast<__nv_bfloat16*>(smem_raw + 32384);
+    const int smem_inv_work_addr = smem + 32384;
+    __nv_bfloat16* smem_out = reinterpret_cast<__nv_bfloat16*>(smem_raw + 210944);
+    const int smem_out_addr = smem + 210944;
+    __nv_bfloat16* smem_checkpoint = reinterpret_cast<__nv_bfloat16*>(smem_raw + 228352);
+    const int smem_checkpoint_addr = smem + 228352;
+    float* smem_restore_factor_all = reinterpret_cast<float*>(smem_raw + 41984);
+    const int smem_restore_factor_all_addr = smem + 41984;
+    float* smem_gt_prefix_all = reinterpret_cast<float*>(smem_raw + 41472);
+    const int smem_gt_prefix_all_addr = smem + 41472;
+    float* smem_gt_all = reinterpret_cast<float*>(smem_raw + 31744);
+    const int smem_gt_all_addr = smem + 31744;
+    float* smem_prep_beta_all = reinterpret_cast<float*>(smem_raw + 42500);
+    const int smem_prep_beta_all_addr = smem + 42500;
+    __nv_bfloat16* smem_prep_beta_bf16_all = reinterpret_cast<__nv_bfloat16*>(smem_raw + 42500);
+    const int smem_prep_beta_bf16_all_addr = smem + 42500;
+    unsigned int* smem_prep_beta_u32_all = reinterpret_cast<unsigned int*>(smem_raw + 42500);
+    const int smem_prep_beta_u32_all_addr = smem + 42500;
+    float* smem_gate_rate_all = reinterpret_cast<float*>(smem_raw + 42628);
+    const int smem_gate_rate_all_addr = smem + 42628;
+    float* smem_gate_bias_all = reinterpret_cast<float*>(smem_raw + 227408);
+    const int smem_gate_bias_all_addr = smem + 227408;
+    __nv_bfloat16* smem_v_all = reinterpret_cast<__nv_bfloat16*>(smem_raw + 32384);
+    const int smem_v_all_addr = smem + 32384;
+    float* smem_gate_all = reinterpret_cast<float*>(smem_raw + 25600);
+    const int smem_gate_all_addr = smem + 25600;
+    unsigned int* smem_state_checkpoint_needed = reinterpret_cast<unsigned int*>(smem_raw + 227328);
+    const int smem_state_checkpoint_needed_addr = smem + 227328;
+    float* smem_work_item_warp_max = reinterpret_cast<float*>(smem_raw + 227328);
+    const int smem_work_item_warp_max_addr = smem + 227328;
+    int* smem_work_item_compute_start = reinterpret_cast<int*>(smem_raw + 227344);
+    const int smem_work_item_compute_start_addr = smem + 227344;
+    unsigned int* smem_work_item_resolved = reinterpret_cast<unsigned int*>(smem_raw + 227348);
+    const int smem_work_item_resolved_addr = smem + 227348;
+
+    // Mbarrier init (23 groups, 97 barriers)
+    // Mbarriers at smem_raw[0..776)
+
+    if (warp == 10) {
+        // --- pipeline 'chunk_pipe' ---
+        // qk_full: 5 barriers, init_count=1
+        // tape_ready: 5 barriers, init_count=1
+        // tape_free: 5 barriers, init_count=2
+        // gate_raw_full: 5 barriers, init_count=1
+        // qk_raw_full: 5 barriers, init_count=1
+        // v_full: 5 barriers, init_count=1
+        // v_free: 5 barriers, init_count=4
+        // smem_free: 5 barriers, init_count=1
+        // raw_inputs_free: 5 barriers, init_count=1
+        // state_inp_ready: 5 barriers, init_count=4
+        // old_out_ready: 5 barriers, init_count=1
+        // u_inp_ready: 5 barriers, init_count=4
+        // u2_acc_ready: 5 barriers, init_count=1
+        // u2_inp_ready: 5 barriers, init_count=4
+        // final_ready: 5 barriers, init_count=1
+        // out_empty: 1 barriers, init_count=1
+        // tmem_dealloc_ready: 1 barriers, init_count=2
+        // --- pipeline 'checkpoint_pipe' ---
+        // checkpoint_ready: 2 barriers, init_count=4
+        // checkpoint_free: 2 barriers, init_count=1
+        // --- pipeline 'chunk_pipe' ---
+        // prep_diag_ready: 5 barriers, init_count=2
+        // prep_inv16_ready: 5 barriers, init_count=2
+        // work_item_ready: 1 barriers, init_count=1
+        // short_beta_ready: 5 barriers, init_count=1
+        // Warp-cooperative initialization, grouped by equal arrival count.
+        for (int _bar = lane; _bar < 10; _bar += 32) {
+            mbarrier_init(smem + 0 + _bar * 8, 1);
+        }
+        for (int _bar = lane; _bar < 5; _bar += 32) {
+            mbarrier_init(smem + 80 + _bar * 8, 2);
+        }
+        for (int _bar = lane; _bar < 15; _bar += 32) {
+            mbarrier_init(smem + 120 + _bar * 8, 1);
+        }
+        for (int _bar = lane; _bar < 5; _bar += 32) {
+            mbarrier_init(smem + 240 + _bar * 8, 4);
+        }
+        for (int _bar = lane; _bar < 10; _bar += 32) {
+            mbarrier_init(smem + 280 + _bar * 8, 1);
+        }
+        for (int _bar = lane; _bar < 5; _bar += 32) {
+            mbarrier_init(smem + 360 + _bar * 8, 4);
+        }
+        for (int _bar = lane; _bar < 5; _bar += 32) {
+            mbarrier_init(smem + 400 + _bar * 8, 1);
+        }
+        for (int _bar = lane; _bar < 5; _bar += 32) {
+            mbarrier_init(smem + 440 + _bar * 8, 4);
+        }
+        for (int _bar = lane; _bar < 5; _bar += 32) {
+            mbarrier_init(smem + 480 + _bar * 8, 1);
+        }
+        for (int _bar = lane; _bar < 5; _bar += 32) {
+            mbarrier_init(smem + 520 + _bar * 8, 4);
+        }
+        for (int _bar = lane; _bar < 6; _bar += 32) {
+            mbarrier_init(smem + 560 + _bar * 8, 1);
+        }
+        for (int _bar = lane; _bar < 1; _bar += 32) {
+            mbarrier_init(smem + 608 + _bar * 8, 2);
+        }
+        for (int _bar = lane; _bar < 2; _bar += 32) {
+            mbarrier_init(smem + 616 + _bar * 8, 4);
+        }
+        for (int _bar = lane; _bar < 2; _bar += 32) {
+            mbarrier_init(smem + 632 + _bar * 8, 1);
+        }
+        for (int _bar = lane; _bar < 10; _bar += 32) {
+            mbarrier_init(smem + 648 + _bar * 8, 2);
+        }
+        for (int _bar = lane; _bar < 6; _bar += 32) {
+            mbarrier_init(smem + 728 + _bar * 8, 1);
+        }
+        asm volatile("fence.mbarrier_init.release.cluster;");
+    }
+
+    __syncwarp();
+
+    // TMEM alloc (256 columns, 256 used)
+    volatile int* tmem_addr_storage = (volatile int*)(smem_raw + 776);
+    if (warp == 0) {
+        int _tmem_hold = smem + 776;
+        asm volatile("tcgen05.alloc.cta_group::1.sync.aligned.shared::cta.b32 [%0], %1;" :: "r"(_tmem_hold), "r"(256) : "memory");
+        asm volatile("tcgen05.relinquish_alloc_permit.cta_group::1.sync.aligned;");
+    }
+
+    __syncthreads();
+    asm volatile("tcgen05.fence::after_thread_sync;");
+
+    const int mbar_base = smem;
+    #define qk_full_addr (mbar_base + 0)
+    #define tape_ready_addr (mbar_base + 40)
+    #define tape_free_addr (mbar_base + 80)
+    #define gate_raw_full_addr (mbar_base + 120)
+    #define qk_raw_full_addr (mbar_base + 160)
+    #define v_full_addr (mbar_base + 200)
+    #define v_free_addr (mbar_base + 240)
+    #define smem_free_addr (mbar_base + 280)
+    #define raw_inputs_free_addr (mbar_base + 320)
+    #define state_inp_ready_addr (mbar_base + 360)
+    #define old_out_ready_addr (mbar_base + 400)
+    #define u_inp_ready_addr (mbar_base + 440)
+    #define u2_acc_ready_addr (mbar_base + 480)
+    #define u2_inp_ready_addr (mbar_base + 520)
+    #define final_ready_addr (mbar_base + 560)
+    #define out_empty_addr (mbar_base + 600)
+    #define tmem_dealloc_ready_addr (mbar_base + 608)
+    #define checkpoint_ready_addr (mbar_base + 616)
+    #define checkpoint_free_addr (mbar_base + 632)
+    #define prep_diag_ready_addr (mbar_base + 648)
+    #define prep_inv16_ready_addr (mbar_base + 688)
+    #define work_item_ready_addr (mbar_base + 728)
+    #define short_beta_ready_addr (mbar_base + 736)
+    const int taddr = tmem_addr_storage[0];
+
+    // Kernel post-init ops
+    const int tmem_tmem_state = taddr + 64;
+    const int tmem_tmem_state_inp = taddr;
+    const int tmem_tmem_u_acc = taddr + 224;
+    const int tmem_tmem_u2_inp = taddr + 224;
+    const int tmem_tmem_u2_acc = taddr;
+    const int tmem_tmem_out = taddr + 192;
+    const int tmem_tmem_state_out = taddr + 64;
+
+    // ---- Register redistribution for WGs split across roles ----
+    // Dec phase frees registers before any WG attempts inc.
+    if (warp >= 8 && warp <= 11) {
+        asm volatile("setmaxnreg.dec.sync.aligned.u32 48;");
+    }
+
+    // ---- Role: compute ----
+    if (warp <= 3) {
+        asm volatile("setmaxnreg.inc.sync.aligned.u32 168;");
+        { // compute_main
+            int task_idx = blockIdx.x;
+            int warp_id_in_role = (warp - 0);
+            int compute_local_warp = warp_id_in_role;
+            int warp_in_wg = warp % 4;
+            int state_row = warp_in_wg * 32 + lane;
+            int split_compute_start = 0;
+            {
+                int item_base = task_idx * 5;
+                int warmup_sequence = seq_order[item_base];
+                int warmup_head = seq_order[item_base + 1];
+                int warmup_write_start = seq_order[item_base + 2];
+                if (state_row == 0) {
+                    smem_work_item_compute_start[0] = 0;
+                    smem_work_item_resolved[0] = 0;
+                }
+                asm volatile("barrier.sync 9, 128;" ::: "memory");
+                float cumulative_log2 = 0.0f;
+                float _expf_1 = __expf(A_log[warmup_head]);
+                float warmup_gate_rate = _expf_1;
+                float warmup_gate_bias = dt_bias[warmup_head * 128 + state_row];
+                int _min_5 = ((warmup_write_start) < (32) ? (warmup_write_start) : (32));
+                int warmup_limit = _min_5;
+                long long warmup_sequence_bos = cu_seqlens[warmup_sequence];
+                #pragma unroll 1
+                for (int warmup_chunks = 1; warmup_chunks < warmup_limit + 1; warmup_chunks++) {
+                    if (smem_work_item_resolved[0] == 0) {
+                        int warmup_chunk = warmup_write_start - warmup_chunks;
+                        long long warmup_token_base = warmup_sequence_bos + (long long)warmup_chunk * 32;
+                        #pragma unroll 1
+                        for (int warmup_token_offset = 0; warmup_token_offset < 32; warmup_token_offset++) {
+                            long long warmup_token = warmup_token_base + (long long)warmup_token_offset;
+                            long long warmup_gate_index = (warmup_token * (long long)num_heads + (long long)warmup_head) * 128 + (long long)state_row;
+                            float _fma_7 = __fmaf_rn((float)g[warmup_gate_index], warmup_gate_rate, warmup_gate_bias);
+                            float gate_arg = _fma_7;
+                            float _tanh_approx_9;
+                            asm volatile("tanh.approx.f32 %0, %1;" : "=f"(_tanh_approx_9) : "f"(gate_arg * 0.5f));
+                            float _fma_8 = __fmaf_rn(_tanh_approx_9, lower_bound * 0.7213475204444817f, lower_bound * 0.7213475204444817f);
+                            cumulative_log2 += _fma_8;
+                        }
+                        float _warp_reduce_0 = cumulative_log2;
+                        #pragma unroll
+                        for (int offset = 16; offset > 0; offset >>= 1)
+                            _warp_reduce_0 = max_noftz(_warp_reduce_0, __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset));
+                        float warmup_warp_max = _warp_reduce_0;
+                        if (lane == 0) {
+                            smem_work_item_warp_max[compute_local_warp] = warmup_warp_max;
+                        }
+                        asm volatile("barrier.sync 9, 128;" ::: "memory");
+                        float warmup_block_max = ((lane < 4) ? smem_work_item_warp_max[lane] : -LOOM_INF);
+                        float _warp_reduce_1 = warmup_block_max;
+                        #pragma unroll
+                        for (int offset = 16; offset > 0; offset >>= 1)
+                            _warp_reduce_1 = max_noftz(_warp_reduce_1, __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_1, offset));
+                        warmup_block_max = _warp_reduce_1;
+                        if (state_row == 0 && warmup_block_max <= -30.0f) {
+                            smem_work_item_compute_start[0] = warmup_chunk;
+                            smem_work_item_resolved[0] = 1;
+                        }
+                        asm volatile("barrier.sync 9, 128;" ::: "memory");
+                    }
+                }
+                split_compute_start = smem_work_item_compute_start[0];
+                int warmup_num_chunks = ((int)(cu_seqlens[warmup_sequence + 1] - warmup_sequence_bos) + 32 - 1) / 32;
+                if (state_row == 0) {
+                    seq_order[item_base + 4] = warmup_num_chunks;
+                }
+                if (compute_local_warp == 0) {
+                    if (elect_sync()) {
+                        mbarrier_arrive(work_item_ready_addr);
+                    }
+                }
+            }
+            int item_base_1 = task_idx * 5;
+            int seq_idx = seq_order[item_base_1];
+            int head_idx = seq_order[item_base_1 + 1];
+            int compute_start = split_compute_start;
+            int write_start = seq_order[item_base_1 + 2];
+            int write_end = seq_order[item_base_1 + 3];
+            long long sequence_bos = cu_seqlens[seq_idx];
+            long long sequence_eos = cu_seqlens[seq_idx + 1];
+            long long bos = sequence_bos + (long long)compute_start * 32;
+            long long _min_6 = ((sequence_eos) < (sequence_bos + (long long)write_end * 32) ? (sequence_eos) : (sequence_bos + (long long)write_end * 32));
+            long long eos = _min_6;
+            int seq_len = (int)(eos - bos);
+            int num_chunks = (seq_len + 32 - 1) / 32;
+            long long total_chunks = cu_chunk_offsets[num_sequences];
+            long long fallback_head = total_chunks * (long long)num_heads + (long long)seq_idx * (long long)num_heads + (long long)head_idx;
+            {
+                if (compute_local_warp == 0) {
+                    if (elect_sync()) {
+                        state_checkpoint_needed[total_chunks * (long long)num_heads + (long long)task_idx] = 0;
+                    }
+                }
+            }
+            const int tmem_row_base = warp_in_wg * 32 << 16;
+            long long state_base = (((long long)seq_idx * (long long)num_heads + (long long)head_idx) * 128 + (long long)state_row) * 128;
+            #pragma unroll
+            for (int state_col_block = 0; state_col_block < 4; state_col_block++) {
+                float state_frag[32];
+                state_frag[0] = 0.0f;
+                state_frag[1] = 0.0f;
+                state_frag[2] = 0.0f;
+                state_frag[3] = 0.0f;
+                state_frag[4] = 0.0f;
+                state_frag[5] = 0.0f;
+                state_frag[6] = 0.0f;
+                state_frag[7] = 0.0f;
+                state_frag[8] = 0.0f;
+                state_frag[9] = 0.0f;
+                state_frag[10] = 0.0f;
+                state_frag[11] = 0.0f;
+                state_frag[12] = 0.0f;
+                state_frag[13] = 0.0f;
+                state_frag[14] = 0.0f;
+                state_frag[15] = 0.0f;
+                state_frag[16] = 0.0f;
+                state_frag[17] = 0.0f;
+                state_frag[18] = 0.0f;
+                state_frag[19] = 0.0f;
+                state_frag[20] = 0.0f;
+                state_frag[21] = 0.0f;
+                state_frag[22] = 0.0f;
+                state_frag[23] = 0.0f;
+                state_frag[24] = 0.0f;
+                state_frag[25] = 0.0f;
+                state_frag[26] = 0.0f;
+                state_frag[27] = 0.0f;
+                state_frag[28] = 0.0f;
+                state_frag[29] = 0.0f;
+                state_frag[30] = 0.0f;
+                state_frag[31] = 0.0f;
+                if (use_initial_state != 0 && compute_start == 0) {
+                    {
+                        float initial_values[8];
+                        #pragma unroll
+                        for (int initial_quarter = 0; initial_quarter < 4; initial_quarter++) {
+                            {
+                                unsigned _ldv8_0_0;
+                                unsigned _ldv8_0_1;
+                                unsigned _ldv8_0_2;
+                                unsigned _ldv8_0_3;
+                                unsigned _ldv8_0_4;
+                                unsigned _ldv8_0_5;
+                                unsigned _ldv8_0_6;
+                                unsigned _ldv8_0_7;
+                                asm volatile(
+                                    "ld.global.v8.b32 {%0, %1, %2, %3, %4, %5, %6, %7}, [%8];"
+                                    : "=r"(_ldv8_0_0), "=r"(_ldv8_0_1), "=r"(_ldv8_0_2), "=r"(_ldv8_0_3), "=r"(_ldv8_0_4), "=r"(_ldv8_0_5), "=r"(_ldv8_0_6), "=r"(_ldv8_0_7) : "l"((const void*)(initial_state_f32 + (state_base + (long long)(state_col_block * 32) + (long long)(initial_quarter * 8)))) : "memory");
+                                initial_values[0 + 0] = __uint_as_float(_ldv8_0_0);
+                                initial_values[0 + 1] = __uint_as_float(_ldv8_0_1);
+                                initial_values[0 + 2] = __uint_as_float(_ldv8_0_2);
+                                initial_values[0 + 3] = __uint_as_float(_ldv8_0_3);
+                                initial_values[0 + 4] = __uint_as_float(_ldv8_0_4);
+                                initial_values[0 + 5] = __uint_as_float(_ldv8_0_5);
+                                initial_values[0 + 6] = __uint_as_float(_ldv8_0_6);
+                                initial_values[0 + 7] = __uint_as_float(_ldv8_0_7);
+                            }
+                            #pragma unroll
+                            for (int initial_item = 0; initial_item < 8; initial_item++) {
+                                __nv_bfloat16 _cvt_bf16_9 = __float2bfloat16(initial_values[initial_item]);
+                                float _cvt_f32_19 = __bfloat162float(_cvt_bf16_9);
+                                state_frag[initial_quarter * 8 + initial_item] = _cvt_f32_19;
+                            }
+                        }
+                    }
+                }
+                tmem_st_x32_f32(taddr + 64 + (unsigned int)tmem_row_base + (unsigned int)(state_col_block * 32), state_frag);
+            }
+            asm volatile("tcgen05.wait::st.sync.aligned;" ::: "memory");
+            {
+                if (compute_local_warp == 0 && compute_start == 0) {
+                    if (elect_sync()) {
+                        long long first_chunk_head = cu_chunk_offsets[seq_idx] * (long long)num_heads + (long long)head_idx;
+                        state_checkpoint_needed[first_chunk_head] = 0;
+                    }
+                }
+            }
+            unsigned int compute_stage = 0;
+            unsigned int checkpoint_stage_compute = 0;
+            float _exp2_10 = approx_exp2(lower_bound * 1.4426950408889634f * 16.0f);
+            unsigned int _phase_checkpoint_free = 1;
+            unsigned int _phase_qk_full = 0;
+            unsigned int _phase_v_full = 0;
+            unsigned int _phase_old_out_ready = 0;
+            unsigned int _phase_u2_acc_ready = 0;
+            unsigned int _phase_final_ready = 0;
+            #pragma unroll 1
+            for (int chunk_idx = 0; chunk_idx < num_chunks; chunk_idx++) {
+                int chunk_global_local = compute_start + chunk_idx;
+                int owned_chunk = chunk_global_local >= write_start && chunk_global_local < write_end;
+                int checkpoint_token_entering = chunk_idx * 32;
+                int checkpoint_entering = checkpoint_every_n_tokens != 0 && checkpoint_token_entering % checkpoint_every_n_tokens == 0;
+                float state_panel0[32];
+                float state_panel1[32];
+                float state_panel2[32];
+                float state_panel3[32];
+                unsigned int state_packed0[16];
+                unsigned int state_packed1[16];
+                unsigned int state_packed2[16];
+                unsigned int state_packed3[16];
+                mbarrier_wait(qk_full_addr + (compute_stage) * 8, _phase_qk_full);
+                #pragma unroll 1
+                for (int state_col_block_1 = 0; state_col_block_1 < ((0) ? 4 : 3); state_col_block_1++) {
+                    int state_addr = taddr + 64 + (unsigned int)tmem_row_base + (unsigned int)(state_col_block_1 * 32);
+                    float _tmem_load_1[32];
+                    tmem_ld_x32(&_tmem_load_1[0], state_addr);
+                    asm volatile("tcgen05.wait::ld.sync.aligned;");
+                    uint32_t _tmem_load_1_bf16[16];
+                    #pragma unroll
+                    for (int _lp = 0; _lp < 16; _lp++) {
+                        __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(_tmem_load_1[_lp*2 + 0], _tmem_load_1[_lp*2+1 + 0]));
+                        _tmem_load_1_bf16[_lp] = *(uint32_t*)&_bf2;
+                    }
+                    asm volatile(
+                        "tcgen05.st.sync.aligned.32x32b.x16.b32"
+                        " [%0], {%1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15, %16};"
+                        :: "r"(taddr + (unsigned int)tmem_row_base + (unsigned int)(state_col_block_1 * 16)), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_1_bf16[0])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_1_bf16[1])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_1_bf16[2])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_1_bf16[3])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_1_bf16[4])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_1_bf16[5])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_1_bf16[6])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_1_bf16[7])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_1_bf16[8])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_1_bf16[9])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_1_bf16[10])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_1_bf16[11])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_1_bf16[12])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_1_bf16[13])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_1_bf16[14])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_1_bf16[15])));
+                    float state_scale[16];
+                    #pragma unroll
+                    for (int state_half = 0; state_half < 2; state_half++) {
+                        #pragma unroll
+                        for (int state_col = 0; state_col < 16; state_col++) {
+                            state_scale[state_col] = smem_gt_all[compute_stage * 10496 + (unsigned int)(state_col_block_1 * 32) + (unsigned int)(state_half * 16) + (unsigned int)state_col];
+                        }
+                        #pragma unroll
+                        for (int _ls = 0; _ls < 8; _ls++)
+                            mul_f32x2_inplace(&reinterpret_cast<float2*>((_tmem_load_1 + state_half * 16))[_ls], reinterpret_cast<const float2*>(state_scale)[_ls]);
+                    }
+                    tmem_st_x32_f32(state_addr, _tmem_load_1);
+                }
+                int state_tail_addr = taddr + 64 + (unsigned int)tmem_row_base + 96;
+                float state_tail_frag[32];
+                unsigned int state_tail_packed[16];
+                {
+                    tmem_ld_x32(&state_tail_frag[0], state_tail_addr);
+                    #pragma unroll
+                    for (int _lp = 0; _lp < 16; _lp++) {
+                        __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(state_tail_frag[_lp*2 + 0], state_tail_frag[_lp*2+1 + 0]));
+                        state_tail_packed[_lp] = *(uint32_t*)&_bf2;
+                    }
+                    asm volatile(
+                        "tcgen05.st.sync.aligned.32x32b.x16.b32"
+                        " [%0], {%1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15, %16};"
+                        :: "r"(taddr + (unsigned int)tmem_row_base + 48), "r"(*reinterpret_cast<const uint32_t*>(&state_tail_packed[0])), "r"(*reinterpret_cast<const uint32_t*>(&state_tail_packed[1])), "r"(*reinterpret_cast<const uint32_t*>(&state_tail_packed[2])), "r"(*reinterpret_cast<const uint32_t*>(&state_tail_packed[3])), "r"(*reinterpret_cast<const uint32_t*>(&state_tail_packed[4])), "r"(*reinterpret_cast<const uint32_t*>(&state_tail_packed[5])), "r"(*reinterpret_cast<const uint32_t*>(&state_tail_packed[6])), "r"(*reinterpret_cast<const uint32_t*>(&state_tail_packed[7])), "r"(*reinterpret_cast<const uint32_t*>(&state_tail_packed[8])), "r"(*reinterpret_cast<const uint32_t*>(&state_tail_packed[9])), "r"(*reinterpret_cast<const uint32_t*>(&state_tail_packed[10])), "r"(*reinterpret_cast<const uint32_t*>(&state_tail_packed[11])), "r"(*reinterpret_cast<const uint32_t*>(&state_tail_packed[12])), "r"(*reinterpret_cast<const uint32_t*>(&state_tail_packed[13])), "r"(*reinterpret_cast<const uint32_t*>(&state_tail_packed[14])), "r"(*reinterpret_cast<const uint32_t*>(&state_tail_packed[15])));
+                }
+                asm volatile("tcgen05.wait::st.sync.aligned;" ::: "memory");
+                if (elect_sync()) {
+                    mbarrier_arrive(state_inp_ready_addr + (compute_stage) * 8);
+                }
+                {
+                    float state_tail_scale[16];
+                    #pragma unroll
+                    for (int state_half_1 = 0; state_half_1 < 2; state_half_1++) {
+                        #pragma unroll
+                        for (int state_col_1 = 0; state_col_1 < 16; state_col_1++) {
+                            state_tail_scale[state_col_1] = smem_gt_all[compute_stage * 10496 + 96 + (unsigned int)(state_half_1 * 16) + (unsigned int)state_col_1];
+                        }
+                        #pragma unroll
+                        for (int _ls = 0; _ls < 8; _ls++)
+                            mul_f32x2_inplace(&reinterpret_cast<float2*>((state_tail_frag + state_half_1 * 16))[_ls], reinterpret_cast<const float2*>(state_tail_scale)[_ls]);
+                    }
+                    tmem_st_x32_f32(state_tail_addr, state_tail_frag);
+                }
+                mbarrier_wait(v_full_addr + (compute_stage) * 8, _phase_v_full);
+                unsigned int v_prefetch_bits[8];
+                mbarrier_wait(old_out_ready_addr + (compute_stage) * 8, _phase_old_out_ready);
+                float _tmem_load_2[32];
+                tmem_ld_x32(&_tmem_load_2[0], taddr + 224 + (unsigned int)tmem_row_base);
+                asm volatile("tcgen05.wait::ld.sync.aligned;");
+                {
+                    const float2 _scale2_1 = {_exp2_10, _exp2_10};
+                    #pragma unroll
+                    for (int _ls = 0; _ls < 16; _ls++)
+                        mul_f32x2_inplace(&reinterpret_cast<float2*>(_tmem_load_2)[_ls], _scale2_1);
+                }
+                long long chunk_global_e = cu_chunk_offsets[seq_idx] + (long long)chunk_global_local;
+                long long tape_ex_base = ((chunk_global_e * (long long)num_heads + (long long)head_idx) * 128 + (long long)state_row) * 32;
+                #pragma unroll
+                for (int residual_half = 0; residual_half < 2; residual_half++) {
+                    float residual_v[16];
+                    float residual_beta[16];
+                    #pragma unroll
+                    for (int residual_col = 0; residual_col < 16; residual_col++) {
+                        int token_col = residual_half * 16 + residual_col;
+                        {
+                            __nv_bfloat16 v_value = smem_v_all[compute_stage * 20992 + (unsigned int)(token_col * 128) + (unsigned int)state_row];
+                            float _cvt_f32_20 = __bfloat162float(v_value);
+                            residual_v[residual_col] = _cvt_f32_20;
+                            residual_beta[residual_col] = smem_prep_beta_all[compute_stage * 10496 + (unsigned int)token_col];
+                        }
+                    }
+                    {
+                        #pragma unroll
+                        for (int _ls = 0; _ls < 8; _ls++)
+                            sub_f32x2_inplace(&reinterpret_cast<float2*>(residual_v)[_ls], reinterpret_cast<const float2*>((_tmem_load_2 + residual_half * 16))[_ls]);
+                    }
+                    if (STORE_BACKWARD_TAPE != 0 && STORE_E_TAPE != 0 && owned_chunk != 0) {
+                        {
+                            __nv_bfloat162 _pk[4];
+                            _pk[0] = __floats2bfloat162_rn(residual_v[0 + 0], residual_v[0 + 1]);
+                            _pk[1] = __floats2bfloat162_rn(residual_v[0 + 2], residual_v[0 + 3]);
+                            _pk[2] = __floats2bfloat162_rn(residual_v[0 + 4], residual_v[0 + 5]);
+                            _pk[3] = __floats2bfloat162_rn(residual_v[0 + 6], residual_v[0 + 7]);
+                            *reinterpret_cast<uint4*>(&((__nv_bfloat16*)(tape_e + (tape_ex_base + (long long)(residual_half * 16))))[0]) = *reinterpret_cast<uint4*>(&_pk[0]);
+                        }
+                        {
+                            __nv_bfloat162 _pk[4];
+                            _pk[0] = __floats2bfloat162_rn(residual_v[8 + 0], residual_v[8 + 1]);
+                            _pk[1] = __floats2bfloat162_rn(residual_v[8 + 2], residual_v[8 + 3]);
+                            _pk[2] = __floats2bfloat162_rn(residual_v[8 + 4], residual_v[8 + 5]);
+                            _pk[3] = __floats2bfloat162_rn(residual_v[8 + 6], residual_v[8 + 7]);
+                            *reinterpret_cast<uint4*>(&((__nv_bfloat16*)(tape_e + (tape_ex_base + (long long)(residual_half * 16) + 8)))[0]) = *reinterpret_cast<uint4*>(&_pk[0]);
+                        }
+                    }
+                    {
+                        #pragma unroll
+                        for (int _ls = 0; _ls < 8; _ls++)
+                            mul_f32x2_inplace(&reinterpret_cast<float2*>(residual_v)[_ls], reinterpret_cast<const float2*>(residual_beta)[_ls]);
+                        if (STORE_BACKWARD_TAPE != 0 && owned_chunk != 0) {
+                            {
+                                __nv_bfloat162 _pk[4];
+                                _pk[0] = __floats2bfloat162_rn(residual_v[0 + 0], residual_v[0 + 1]);
+                                _pk[1] = __floats2bfloat162_rn(residual_v[0 + 2], residual_v[0 + 3]);
+                                _pk[2] = __floats2bfloat162_rn(residual_v[0 + 4], residual_v[0 + 5]);
+                                _pk[3] = __floats2bfloat162_rn(residual_v[0 + 6], residual_v[0 + 7]);
+                                *reinterpret_cast<uint4*>(&((__nv_bfloat16*)(tape_x + (tape_ex_base + (long long)(residual_half * 16))))[0]) = *reinterpret_cast<uint4*>(&_pk[0]);
+                            }
+                            {
+                                __nv_bfloat162 _pk[4];
+                                _pk[0] = __floats2bfloat162_rn(residual_v[8 + 0], residual_v[8 + 1]);
+                                _pk[1] = __floats2bfloat162_rn(residual_v[8 + 2], residual_v[8 + 3]);
+                                _pk[2] = __floats2bfloat162_rn(residual_v[8 + 4], residual_v[8 + 5]);
+                                _pk[3] = __floats2bfloat162_rn(residual_v[8 + 6], residual_v[8 + 7]);
+                                *reinterpret_cast<uint4*>(&((__nv_bfloat16*)(tape_x + (tape_ex_base + (long long)(residual_half * 16) + 8)))[0]) = *reinterpret_cast<uint4*>(&_pk[0]);
+                            }
+                        }
+                        uint32_t residual_v_bf16[8];
+                        #pragma unroll
+                        for (int _lp = 0; _lp < 8; _lp++) {
+                            __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(residual_v[_lp*2 + 0], residual_v[_lp*2+1 + 0]));
+                            residual_v_bf16[_lp] = *(uint32_t*)&_bf2;
+                        }
+                        tmem_st_x8_u32(taddr + 224 + (unsigned int)tmem_row_base + (unsigned int)(residual_half * 8), (const uint32_t*)residual_v_bf16);
+                    }
+                }
+                asm volatile("tcgen05.wait::st.sync.aligned;" ::: "memory");
+                if (elect_sync()) {
+                    mbarrier_arrive(v_free_addr + (compute_stage) * 8);
+                    mbarrier_arrive(u_inp_ready_addr + (compute_stage) * 8);
+                }
+                mbarrier_wait(u2_acc_ready_addr + (compute_stage) * 8, _phase_u2_acc_ready);
+                float _tmem_load_4[32];
+                tmem_ld_x32(&_tmem_load_4[0], taddr + (unsigned int)tmem_row_base);
+                asm volatile("tcgen05.wait::ld.sync.aligned;");
+                if (STORE_BACKWARD_TAPE != 0 && owned_chunk != 0) {
+                    long long chunk_global_r = cu_chunk_offsets[seq_idx] + (long long)chunk_global_local;
+                    long long tape_r_base = ((chunk_global_r * (long long)num_heads + (long long)head_idx) * 128 + (long long)state_row) * 32;
+                    #pragma unroll
+                    for (int tape_r_vec = 0; tape_r_vec < 4; tape_r_vec++) {
+                        {
+                            __nv_bfloat162 _pk[4];
+                            _pk[0] = __floats2bfloat162_rn(_tmem_load_4[tape_r_vec * 8 + 0], _tmem_load_4[tape_r_vec * 8 + 1]);
+                            _pk[1] = __floats2bfloat162_rn(_tmem_load_4[tape_r_vec * 8 + 2], _tmem_load_4[tape_r_vec * 8 + 3]);
+                            _pk[2] = __floats2bfloat162_rn(_tmem_load_4[tape_r_vec * 8 + 4], _tmem_load_4[tape_r_vec * 8 + 5]);
+                            _pk[3] = __floats2bfloat162_rn(_tmem_load_4[tape_r_vec * 8 + 6], _tmem_load_4[tape_r_vec * 8 + 7]);
+                            *reinterpret_cast<uint4*>(&((__nv_bfloat16*)(tape_r + (tape_r_base + (long long)(tape_r_vec * 8))))[0]) = *reinterpret_cast<uint4*>(&_pk[0]);
+                        }
+                    }
+                }
+                uint32_t _tmem_load_4_bf16[16];
+                #pragma unroll
+                for (int _lp = 0; _lp < 16; _lp++) {
+                    __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(_tmem_load_4[_lp*2 + 0], _tmem_load_4[_lp*2+1 + 0]));
+                    _tmem_load_4_bf16[_lp] = *(uint32_t*)&_bf2;
+                }
+                asm volatile(
+                    "tcgen05.st.sync.aligned.32x32b.x16.b32"
+                    " [%0], {%1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15, %16};"
+                    :: "r"(taddr + 224 + (unsigned int)tmem_row_base), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_4_bf16[0])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_4_bf16[1])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_4_bf16[2])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_4_bf16[3])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_4_bf16[4])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_4_bf16[5])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_4_bf16[6])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_4_bf16[7])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_4_bf16[8])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_4_bf16[9])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_4_bf16[10])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_4_bf16[11])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_4_bf16[12])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_4_bf16[13])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_4_bf16[14])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_4_bf16[15])));
+                asm volatile("tcgen05.wait::st.sync.aligned;" ::: "memory");
+                if (elect_sync()) {
+                    mbarrier_arrive(u2_inp_ready_addr + (compute_stage) * 8);
+                }
+                mbarrier_wait(final_ready_addr + (compute_stage) * 8, _phase_final_ready);
+                {
+                    int next_chunk_global_local = chunk_global_local + 1;
+                    if (next_chunk_global_local >= write_start && next_chunk_global_local < write_end) {
+                        int checkpoint_needed = smem_state_checkpoint_needed[compute_stage * 4] != 0 || smem_state_checkpoint_needed[compute_stage * 4 + 1] != 0 || smem_state_checkpoint_needed[compute_stage * 4 + 2] != 0 || smem_state_checkpoint_needed[compute_stage * 4 + 3] != 0;
+                        if (compute_local_warp == 0) {
+                            if (elect_sync()) {
+                                long long chunk_global_next = cu_chunk_offsets[seq_idx] + (long long)next_chunk_global_local;
+                                state_checkpoint_needed[chunk_global_next * (long long)num_heads + (long long)head_idx] = (unsigned int)checkpoint_needed;
+                                if (SPLIT_WORK_ITEMS == 0 && checkpoint_needed != 0) {
+                                    state_checkpoint_needed[fallback_head] = 1;
+                                }
+                                if (SPLIT_WORK_ITEMS != 0 && checkpoint_needed != 0) {
+                                    state_checkpoint_needed[total_chunks * (long long)num_heads + (long long)task_idx] = 1;
+                                }
+                            }
+                        }
+                    }
+                    if (compute_local_warp == 0) {
+                        if (elect_sync()) {
+                            mbarrier_arrive(smem_free_addr + (compute_stage) * 8);
+                        }
+                    }
+                }
+                compute_stage += 1;
+                if (compute_stage == 5) { compute_stage = 0; _phase_qk_full ^= 1; _phase_v_full ^= 1; _phase_old_out_ready ^= 1; _phase_u2_acc_ready ^= 1; _phase_final_ready ^= 1; }
+            }
+            if (store_final_state != 0) {
+                #pragma unroll
+                for (int state_col_block_2 = 0; state_col_block_2 < 4; state_col_block_2++) {
+                    float _tmem_load_6[32];
+                    tmem_ld_x32(&_tmem_load_6[0], taddr + 64 + (unsigned int)tmem_row_base + (unsigned int)(state_col_block_2 * 32));
+                    asm volatile("tcgen05.wait::ld.sync.aligned;");
+                    {
+                        __nv_bfloat162 _pk[8];
+                        _pk[0] = __floats2bfloat162_rn(_tmem_load_6[0 + 0], _tmem_load_6[0 + 1]);
+                        _pk[1] = __floats2bfloat162_rn(_tmem_load_6[0 + 2], _tmem_load_6[0 + 3]);
+                        _pk[2] = __floats2bfloat162_rn(_tmem_load_6[0 + 4], _tmem_load_6[0 + 5]);
+                        _pk[3] = __floats2bfloat162_rn(_tmem_load_6[0 + 6], _tmem_load_6[0 + 7]);
+                        _pk[4] = __floats2bfloat162_rn(_tmem_load_6[0 + 8], _tmem_load_6[0 + 9]);
+                        _pk[5] = __floats2bfloat162_rn(_tmem_load_6[0 + 10], _tmem_load_6[0 + 11]);
+                        _pk[6] = __floats2bfloat162_rn(_tmem_load_6[0 + 12], _tmem_load_6[0 + 13]);
+                        _pk[7] = __floats2bfloat162_rn(_tmem_load_6[0 + 14], _tmem_load_6[0 + 15]);
+                        *reinterpret_cast<uint4*>(&((__nv_bfloat16*)(final_state + (state_base + (long long)(state_col_block_2 * 32))))[0]) = *reinterpret_cast<uint4*>(&_pk[0]);
+                        *reinterpret_cast<uint4*>(&((__nv_bfloat16*)(final_state + (state_base + (long long)(state_col_block_2 * 32))))[8]) = *reinterpret_cast<uint4*>(&_pk[4]);
+                    }
+                    {
+                        __nv_bfloat162 _pk[8];
+                        _pk[0] = __floats2bfloat162_rn(_tmem_load_6[16 + 0], _tmem_load_6[16 + 1]);
+                        _pk[1] = __floats2bfloat162_rn(_tmem_load_6[16 + 2], _tmem_load_6[16 + 3]);
+                        _pk[2] = __floats2bfloat162_rn(_tmem_load_6[16 + 4], _tmem_load_6[16 + 5]);
+                        _pk[3] = __floats2bfloat162_rn(_tmem_load_6[16 + 6], _tmem_load_6[16 + 7]);
+                        _pk[4] = __floats2bfloat162_rn(_tmem_load_6[16 + 8], _tmem_load_6[16 + 9]);
+                        _pk[5] = __floats2bfloat162_rn(_tmem_load_6[16 + 10], _tmem_load_6[16 + 11]);
+                        _pk[6] = __floats2bfloat162_rn(_tmem_load_6[16 + 12], _tmem_load_6[16 + 13]);
+                        _pk[7] = __floats2bfloat162_rn(_tmem_load_6[16 + 14], _tmem_load_6[16 + 15]);
+                        *reinterpret_cast<uint4*>(&((__nv_bfloat16*)(final_state + (state_base + (long long)(state_col_block_2 * 32) + 16)))[0]) = *reinterpret_cast<uint4*>(&_pk[0]);
+                        *reinterpret_cast<uint4*>(&((__nv_bfloat16*)(final_state + (state_base + (long long)(state_col_block_2 * 32) + 16)))[8]) = *reinterpret_cast<uint4*>(&_pk[4]);
+                    }
+                }
+            }
+            asm volatile("barrier.sync 9, 128;" ::: "memory");
+            if (compute_local_warp == 0) {
+                if (elect_sync()) {
+                    mbarrier_arrive(tmem_dealloc_ready_addr);
+                }
+            }
+        }
+    }
+    // ---- Role: epilogue ----
+    if (warp >= 4 && warp <= 7) {
+        asm volatile("setmaxnreg.dec.sync.aligned.u32 48;");
+        { // epilogue_main
+            int task_idx_1 = blockIdx.x;
+            int split_compute_start_1 = 0;
+            unsigned int _phase_work_item_ready_0 = 0;
+            {
+                mbarrier_wait(work_item_ready_addr, _phase_work_item_ready_0);
+                _phase_work_item_ready_0 ^= 1;
+                split_compute_start_1 = smem_work_item_compute_start[0];
+            }
+            int item_base_2 = task_idx_1 * 5;
+            int seq_idx_1 = seq_order[item_base_2];
+            int head_idx_1 = seq_order[item_base_2 + 1];
+            int compute_start_1 = split_compute_start_1;
+            int write_start_1 = seq_order[item_base_2 + 2];
+            int write_end_1 = seq_order[item_base_2 + 3];
+            long long sequence_bos_1 = cu_seqlens[seq_idx_1];
+            long long sequence_eos_1 = cu_seqlens[seq_idx_1 + 1];
+            long long bos_1 = sequence_bos_1 + (long long)compute_start_1 * 32;
+            long long _min_7 = ((sequence_eos_1) < (sequence_bos_1 + (long long)write_end_1 * 32) ? (sequence_eos_1) : (sequence_bos_1 + (long long)write_end_1 * 32));
+            long long eos_1 = _min_7;
+            int seq_len_1 = (int)(eos_1 - bos_1);
+            int num_chunks_1 = (seq_len_1 + 32 - 1) / 32;
+            int warp_id_in_role_1 = (warp - 4);
+            int epilogue_local_warp = warp_id_in_role_1;
+            int warp_in_wg_1 = warp % 4;
+            const int tmem_row_base_1 = warp_in_wg_1 * 32 << 16;
+            int state_row_1 = warp_in_wg_1 * 32 + lane;
+            unsigned int epilogue_stage = 0;
+            unsigned int output_stage = 0;
+            unsigned int checkpoint_stage_epilogue = 0;
+            int epilogue_chunks = num_chunks_1;
+            {
+                epilogue_chunks = 0;
+            }
+            unsigned int _phase_checkpoint_ready = 0;
+            unsigned int _phase_final_ready_1 = 0;
+            #pragma unroll 1
+            for (int chunk_idx_1 = 0; chunk_idx_1 < epilogue_chunks; chunk_idx_1++) {
+                int checkpoint_token_epilogue = chunk_idx_1 * 32;
+                int checkpoint_entering_epilogue = checkpoint_every_n_tokens != 0 && checkpoint_token_epilogue % checkpoint_every_n_tokens == 0;
+                int chunk_is_full = ((seq_len_1 >= (chunk_idx_1 + 1) * 32) ? 1 : 0);
+                if (chunk_is_full != 0) {
+                    mbarrier_wait(final_ready_addr + (epilogue_stage) * 8, _phase_final_ready_1);
+                    float _tmem_load_7[16];
+                    asm volatile(
+                        "tcgen05.ld.sync.aligned.16x256b.x4.b32"
+                        " {%0, %1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15}, [%16];"
+                        : "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_7[0])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_7[1])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_7[2])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_7[3])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_7[4])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_7[5])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_7[6])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_7[7])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_7[8])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_7[9])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_7[10])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_7[11])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_7[12])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_7[13])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_7[14])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_7[15]))
+                        : "r"(taddr + 192 + (unsigned int)tmem_row_base_1));
+                    float _tmem_load_8[16];
+                    asm volatile(
+                        "tcgen05.ld.sync.aligned.16x256b.x4.b32"
+                        " {%0, %1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15}, [%16];"
+                        : "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_8[0])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_8[1])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_8[2])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_8[3])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_8[4])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_8[5])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_8[6])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_8[7])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_8[8])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_8[9])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_8[10])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_8[11])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_8[12])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_8[13])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_8[14])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_8[15]))
+                        : "r"(taddr + 192 + (unsigned int)tmem_row_base_1 + 1048576));
+                    asm volatile("tcgen05.wait::ld.sync.aligned;" ::: "memory");
+                    asm volatile("barrier.sync 8, 128;" ::: "memory");
+                    if (epilogue_local_warp == 0) {
+                        if (elect_sync()) {
+                            mbarrier_arrive(out_empty_addr);
+                        }
+                    }
+                    if (epilogue_local_warp == 0) {
+                        if (chunk_idx_1 >= 2) {
+                            asm volatile("cp.async.bulk.wait_group.read 1;");
+                        }
+                    }
+                    asm volatile("barrier.sync 8, 128;" ::: "memory");
+                    int out_stage_addr = smem_out_addr + output_stage * 8192;
+                    #pragma unroll
+                    for (int dim_half = 0; dim_half < 2; dim_half++) {
+                        unsigned int out_packed[8];
+                        if (dim_half == 0) {
+                            #pragma unroll
+                            for (int _lp = 0; _lp < 8; _lp++) {
+                                __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(_tmem_load_7[_lp*2 + 0], _tmem_load_7[_lp*2+1 + 0]));
+                                out_packed[_lp] = *(uint32_t*)&_bf2;
+                            }
+                        } else {
+                            #pragma unroll
+                            for (int _lp = 0; _lp < 8; _lp++) {
+                                __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(_tmem_load_8[_lp*2 + 0], _tmem_load_8[_lp*2+1 + 0]));
+                                out_packed[_lp] = *(uint32_t*)&_bf2;
+                            }
+                        }
+                        #pragma unroll
+                        for (int token_group = 0; token_group < 2; token_group++) {
+                            int mtx_idx = lane / 8;
+                            int row_addr = lane & 7;
+                            int dim_base = epilogue_local_warp * 32 + dim_half * 16 + (mtx_idx & 1) * 8;
+                            int token_base = token_group * 16 + mtx_idx / 2 * 8;
+                            int token_addr = token_base + row_addr;
+                            int token_pair = token_addr / 2;
+                            int token_parity = token_addr & 1;
+                            int raw_row = token_pair + dim_base / 64 * 16;
+                            int raw_col = (dim_base & 63 ^ (token_pair & 3) << 4 ^ token_parity << 3) + token_parity * 64;
+                            int stsm_offset = (raw_row * 128 + raw_col) * 2;
+                            const int pack_base = token_group * 4;
+                            uint32_t _stmatrix_addr_0 = static_cast<uint32_t>((unsigned long long)(out_stage_addr + stsm_offset));
+                            asm volatile("stmatrix.sync.aligned.m8n8.x4.trans.shared.b16 [%0], {%1, %2, %3, %4};\n"
+                                :: "r"(_stmatrix_addr_0), "r"(*reinterpret_cast<const uint32_t*>(&out_packed[pack_base])), "r"(*reinterpret_cast<const uint32_t*>(&out_packed[pack_base + 1])), "r"(*reinterpret_cast<const uint32_t*>(&out_packed[pack_base + 2])), "r"(*reinterpret_cast<const uint32_t*>(&out_packed[pack_base + 3]))
+                                : "memory");
+                        }
+                    }
+                    asm volatile("fence.proxy.async.shared::cta;" ::: "memory");
+                    asm volatile("barrier.sync 8, 128;" ::: "memory");
+                    if (epilogue_local_warp == 0) {
+                        if (elect_sync()) {
+                            tma_store_4d(out_tma, 0, (int)(bos_1 + (long long)(chunk_idx_1 * 32)), head_idx_1, 0, smem_out_addr + output_stage * 8192);
+                        }
+                        asm volatile("cp.async.bulk.commit_group;");
+                    }
+                    output_stage = output_stage ^ 1;
+                } else {
+                    mbarrier_wait(final_ready_addr + (epilogue_stage) * 8, _phase_final_ready_1);
+                    float _tmem_load_9[32];
+                    tmem_ld_x32(&_tmem_load_9[0], taddr + 192 + (unsigned int)tmem_row_base_1);
+                    asm volatile("tcgen05.wait::ld.sync.aligned;" ::: "memory");
+                    asm volatile("barrier.sync 8, 128;" ::: "memory");
+                    if (epilogue_local_warp == 0) {
+                        if (elect_sync()) {
+                            mbarrier_arrive(out_empty_addr);
+                        }
+                    }
+                    #pragma unroll
+                    for (int token_col_1 = 0; token_col_1 < 32; token_col_1++) {
+                        long long out_token = bos_1 + (long long)(chunk_idx_1 * 32 + token_col_1);
+                        if (out_token < eos_1) {
+                            long long out_idx = (out_token * (long long)num_heads + (long long)head_idx_1) * 128 + (long long)state_row_1;
+                            out[out_idx] = _tmem_load_9[token_col_1];
+                        }
+                    }
+                }
+                epilogue_stage += 1;
+                if (epilogue_stage == 5) { epilogue_stage = 0; _phase_final_ready_1 ^= 1; }
+            }
+            if (epilogue_local_warp == 0) {
+                if (elect_sync()) {
+                    mbarrier_arrive(tmem_dealloc_ready_addr);
+                }
+            }
+        }
+    }
+    // ---- Role: beta_prefetch ----
+    if (warp == 8) {
+        { // beta_prefetch_main
+
+        }
+    }
+    // ---- Role: aux_mma ----
+    if (warp >= 10 && warp <= 11) {
+        { // aux_mma_main
+            unsigned int _phase_work_item_ready_0_1 = 0;
+            unsigned int _phase_tape_ready = 0;
+            {
+                int task_idx_2 = blockIdx.x;
+                int split_compute_start_2 = 0;
+                {
+                    mbarrier_wait(work_item_ready_addr, _phase_work_item_ready_0_1);
+                    _phase_work_item_ready_0_1 ^= 1;
+                    split_compute_start_2 = smem_work_item_compute_start[0];
+                }
+                int item_base_3 = task_idx_2 * 5;
+                int seq_idx_2 = seq_order[item_base_3];
+                int head_idx_2 = seq_order[item_base_3 + 1];
+                int compute_start_2 = split_compute_start_2;
+                int write_start_2 = seq_order[item_base_3 + 2];
+                int write_end_2 = seq_order[item_base_3 + 3];
+                long long sequence_bos_2 = cu_seqlens[seq_idx_2];
+                long long sequence_eos_2 = cu_seqlens[seq_idx_2 + 1];
+                long long bos_2 = sequence_bos_2 + (long long)compute_start_2 * 32;
+                long long _min_4 = ((sequence_eos_2) < (sequence_bos_2 + (long long)write_end_2 * 32) ? (sequence_eos_2) : (sequence_bos_2 + (long long)write_end_2 * 32));
+                long long eos_2 = _min_4;
+                int seq_len_2 = (int)(eos_2 - bos_2);
+                int num_chunks_2 = (seq_len_2 + 32 - 1) / 32;
+                int warp_id_in_role_2 = (warp - 10);
+                int tape_tid = warp_id_in_role_2 * 32 + lane;
+                int zero_stride = num_bids * 64;
+                #pragma unroll 1
+                for (int zero_item = task_idx_2 * 64 + tape_tid; zero_item < zero_words; zero_item += zero_stride) {
+                    zero_workspace[zero_item] = 0;
+                }
+                unsigned int tape_stage = 0;
+                #pragma unroll 1
+                for (int chunk_idx_2 = 0; chunk_idx_2 < num_chunks_2; chunk_idx_2++) {
+                    mbarrier_wait(tape_ready_addr + (tape_stage) * 8, _phase_tape_ready);
+                    int chunk_global_local_1 = compute_start_2 + chunk_idx_2;
+                    int owned_chunk_1 = chunk_global_local_1 >= write_start_2 && chunk_global_local_1 < write_end_2;
+                    long long chunk_global = cu_chunk_offsets[seq_idx_2] + (long long)chunk_global_local_1;
+                    long long tape_vec_base = (chunk_global * (long long)num_heads + (long long)head_idx_2) * 32 * 128;
+                    #pragma unroll
+                    for (int tape_pass = 0; tape_pass < 8; tape_pass++) {
+                        int tape_item = tape_pass * 64 + tape_tid;
+                        int tape_row = tape_item / 16;
+                        int tape_segment = tape_item % 16;
+                        float tape_kr_values[8];
+                        unsigned int packed[4];
+                        asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                            : "=r"(*reinterpret_cast<uint32_t*>(&packed[0])), "=r"(*reinterpret_cast<uint32_t*>(&packed[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&packed[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&packed[(0) + 3]))
+                            : "r"((smem_kr_trans_addr + tape_stage * 41984 + (unsigned int)(tape_segment * 8 / 64 * 4096 + tape_row * 128 + tape_segment * 8 % 64 * 2 ^ (tape_segment * 8 / 64 * 4096 + tape_row * 128 + tape_segment * 8 % 64 * 2 >> 7 & 7) << 4))));
+                        float packed_f32[8];
+                        #pragma unroll
+                        for (int _pair = 0; _pair < 4; _pair++) {
+                            asm volatile(
+                                "{\n\t"
+                                "shl.b32 %0, %2, 16;\n\t"
+                                "and.b32 %1, %2, 0xffff0000;\n\t"
+                                "}\n"
+                                : "=f"((&packed_f32[_pair * 2])[0]), "=f"((&packed_f32[_pair * 2])[1])
+                                : "r"(packed[_pair]));
+                        }
+                        #pragma unroll
+                        for (int value_idx = 0; value_idx < 8; value_idx++) {
+                            tape_kr_values[value_idx] = packed_f32[value_idx];
+                        }
+                        long long tape_index = tape_vec_base + (long long)tape_row * 128 + (long long)(tape_segment * 8);
+                        if (owned_chunk_1 != 0) {
+                            {
+                                __nv_bfloat162 _pk[4];
+                                _pk[0] = __floats2bfloat162_rn(tape_kr_values[0 + 0], tape_kr_values[0 + 1]);
+                                _pk[1] = __floats2bfloat162_rn(tape_kr_values[0 + 2], tape_kr_values[0 + 3]);
+                                _pk[2] = __floats2bfloat162_rn(tape_kr_values[0 + 4], tape_kr_values[0 + 5]);
+                                _pk[3] = __floats2bfloat162_rn(tape_kr_values[0 + 6], tape_kr_values[0 + 7]);
+                                *reinterpret_cast<uint4*>(&((__nv_bfloat16*)(tape_kr + tape_index))[0]) = *reinterpret_cast<uint4*>(&_pk[0]);
+                            }
+                        }
+                    }
+                    long long tape_j_base = (chunk_global * (long long)num_heads + (long long)head_idx_2) * 32 * 32;
+                    #pragma unroll
+                    for (int tape_j_pass = 0; tape_j_pass < 2; tape_j_pass++) {
+                        int tape_j_item = tape_j_pass * 64 + tape_tid;
+                        int tape_j_row = tape_j_item / 4;
+                        int tape_j_segment = tape_j_item % 4;
+                        float tape_j_values[8];
+                        unsigned int packed_1[4];
+                        asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                            : "=r"(*reinterpret_cast<uint32_t*>(&packed_1[0])), "=r"(*reinterpret_cast<uint32_t*>(&packed_1[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&packed_1[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&packed_1[(0) + 3]))
+                            : "r"((smem_inv_addr + tape_stage * 41984 + (unsigned int)(tape_j_segment * 8 / 16 * 1024 + tape_j_row * 32 + tape_j_segment * 8 % 16 * 2 ^ (tape_j_segment * 8 / 16 * 1024 + tape_j_row * 32 + tape_j_segment * 8 % 16 * 2 >> 7 & 1) << 4))));
+                        float packed_f32_1[8];
+                        #pragma unroll
+                        for (int _pair = 0; _pair < 4; _pair++) {
+                            asm volatile(
+                                "{\n\t"
+                                "shl.b32 %0, %2, 16;\n\t"
+                                "and.b32 %1, %2, 0xffff0000;\n\t"
+                                "}\n"
+                                : "=f"((&packed_f32_1[_pair * 2])[0]), "=f"((&packed_f32_1[_pair * 2])[1])
+                                : "r"(packed_1[_pair]));
+                        }
+                        #pragma unroll
+                        for (int value_idx_1 = 0; value_idx_1 < 8; value_idx_1++) {
+                            tape_j_values[value_idx_1] = packed_f32_1[value_idx_1];
+                        }
+                        if (owned_chunk_1 != 0) {
+                            {
+                                __nv_bfloat162 _pk[4];
+                                _pk[0] = __floats2bfloat162_rn(tape_j_values[0 + 0], tape_j_values[0 + 1]);
+                                _pk[1] = __floats2bfloat162_rn(tape_j_values[0 + 2], tape_j_values[0 + 3]);
+                                _pk[2] = __floats2bfloat162_rn(tape_j_values[0 + 4], tape_j_values[0 + 5]);
+                                _pk[3] = __floats2bfloat162_rn(tape_j_values[0 + 6], tape_j_values[0 + 7]);
+                                *reinterpret_cast<uint4*>(&((__nv_bfloat16*)(tape_j + (tape_j_base + (long long)tape_j_row * 32 + (long long)(tape_j_segment * 8))))[0]) = *reinterpret_cast<uint4*>(&_pk[0]);
+                            }
+                        }
+                    }
+                    if (elect_sync()) {
+                        mbarrier_arrive(tape_free_addr + (tape_stage) * 8);
+                    }
+                    tape_stage += 1;
+                    if (tape_stage == 5) { tape_stage = 0; _phase_tape_ready ^= 1; }
+                }
+            }
+        }
+    }
+    // ---- Role: mma ----
+    if (warp == 9) {
+        { // mma_main
+            int task_idx_3 = blockIdx.x;
+            int split_compute_start_3 = 0;
+            unsigned int _phase_work_item_ready_0_2 = 0;
+            {
+                mbarrier_wait(work_item_ready_addr, _phase_work_item_ready_0_2);
+                _phase_work_item_ready_0_2 ^= 1;
+                split_compute_start_3 = smem_work_item_compute_start[0];
+            }
+            int item_base_4 = task_idx_3 * 5;
+            int seq_idx_3 = seq_order[item_base_4];
+            int head_idx_3 = seq_order[item_base_4 + 1];
+            int compute_start_3 = split_compute_start_3;
+            int write_start_3 = seq_order[item_base_4 + 2];
+            int write_end_3 = seq_order[item_base_4 + 3];
+            long long sequence_bos_3 = cu_seqlens[seq_idx_3];
+            long long sequence_eos_3 = cu_seqlens[seq_idx_3 + 1];
+            long long bos_3 = sequence_bos_3 + (long long)compute_start_3 * 32;
+            long long _min_8 = ((sequence_eos_3) < (sequence_bos_3 + (long long)write_end_3 * 32) ? (sequence_eos_3) : (sequence_bos_3 + (long long)write_end_3 * 32));
+            long long eos_3 = _min_8;
+            int seq_len_3 = (int)(eos_3 - bos_3);
+            int num_chunks_3 = (seq_len_3 + 32 - 1) / 32;
+            unsigned int mma_stage = 0;
+            unsigned int _phase_qk_full_1 = 0;
+            unsigned int _phase_out_empty_0 = 1;
+            unsigned int _phase_state_inp_ready = 0;
+            unsigned int _phase_u_inp_ready = 0;
+            unsigned int _phase_u2_inp_ready = 0;
+            unsigned int _phase_final_ready_2 = 0;
+            #pragma unroll 1
+            for (int _chunk_idx = 0; _chunk_idx < num_chunks_3; _chunk_idx++) {
+                mbarrier_wait(qk_full_addr + (mma_stage) * 8, _phase_qk_full_1);
+                {
+                    mbarrier_wait(state_inp_ready_addr + (mma_stage) * 8, _phase_state_inp_ready);
+                    {
+                        int _mma_b_lo_6 = make_warp_uniform((((smem_kd_addr) >> 4) & 0x3FFF) + (mma_stage) * 2624);
+                        asm volatile(
+                    "{\n\t"
+                    ".reg .pred leader, p0, p1;\n\t"
+                    ".reg .b32 dhi, blo, ta, id;\n\t"
+                    ".reg .b64 db;\n\t"
+                    "elect.sync _|leader, 0xFFFFFFFF;\n\t"
+                    "setp.ne.b32 p0, %3, 0;\n\t"
+                    "setp.ne.b32 p1, 1, 0;\n\t"
+                    ""
+                    "mov.b32 dhi, 0x40004040;\n\t"
+                    "mov.b32 id, 134743184;\n\t"
+                    "mov.b32 ta, %2;\n\t"
+                    "mov.b32 blo, %1;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p0;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 250;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "}\n"
+                    :: "r"(tmem_tmem_u_acc), "r"(_mma_b_lo_6), "r"(tmem_tmem_state_inp), "r"(0));
+                    }
+                }
+                {
+                    elect_commit2(old_out_ready_addr + (mma_stage) * 8, raw_inputs_free_addr + (mma_stage) * 8);
+                }
+                mbarrier_wait(u_inp_ready_addr + (mma_stage) * 8, _phase_u_inp_ready);
+                int _mma_b_lo_7 = make_warp_uniform((((smem_inv_addr) >> 4) & 0x3FFF) + (mma_stage) * 2624);
+                asm volatile(
+                    "{\n\t"
+                    ".reg .pred leader, p0, p1;\n\t"
+                    ".reg .b32 dhi, blo, ta, id;\n\t"
+                    ".reg .b64 db;\n\t"
+                    "elect.sync _|leader, 0xFFFFFFFF;\n\t"
+                    "setp.ne.b32 p0, %3, 0;\n\t"
+                    "setp.ne.b32 p1, 1, 0;\n\t"
+                    ""
+                    "mov.b32 dhi, 0xC0004010;\n\t"
+                    "mov.b32 id, 134743184;\n\t"
+                    "mov.b32 ta, %2;\n\t"
+                    "mov.b32 blo, %1;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p0;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 64;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "}\n"
+                    :: "r"(tmem_tmem_u2_acc), "r"(_mma_b_lo_7), "r"(tmem_tmem_u2_inp), "r"(0));
+                elect_commit(u2_acc_ready_addr + (mma_stage) * 8);
+                mbarrier_wait(u2_inp_ready_addr + (mma_stage) * 8, _phase_u2_inp_ready);
+                int _mma_b_lo_8 = make_warp_uniform(((((smem_final_trans_addr) >> 4) & 0x3FFF) | 0x1000000) + (mma_stage) * 2624);
+                asm volatile(
+                    "{\n\t"
+                    ".reg .pred leader, p0, p1;\n\t"
+                    ".reg .b32 dhi, blo, ta, id;\n\t"
+                    ".reg .b64 db;\n\t"
+                    "elect.sync _|leader, 0xFFFFFFFF;\n\t"
+                    "setp.ne.b32 p0, %3, 0;\n\t"
+                    "setp.ne.b32 p1, 1, 0;\n\t"
+                    ""
+                    "mov.b32 dhi, 0x40004040;\n\t"
+                    "mov.b32 id, 136905872;\n\t"
+                    "mov.b32 ta, %2;\n\t"
+                    "mov.b32 blo, %1;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p0;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 128;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "}\n"
+                    :: "r"(tmem_tmem_state_out), "r"(_mma_b_lo_8), "r"(tmem_tmem_u2_inp), "r"(1));
+                elect_commit(final_ready_addr + (mma_stage) * 8);
+                {
+                    mbarrier_wait(final_ready_addr + (mma_stage) * 8, _phase_final_ready_2);
+                }
+                mma_stage += 1;
+                if (mma_stage == 5) { mma_stage = 0; _phase_qk_full_1 ^= 1; _phase_state_inp_ready ^= 1; _phase_u_inp_ready ^= 1; _phase_u2_inp_ready ^= 1; _phase_final_ready_2 ^= 1; }
+            }
+            unsigned int _phase_tmem_dealloc_ready_0 = 0;
+            mbarrier_wait(tmem_dealloc_ready_addr, _phase_tmem_dealloc_ready_0);
+            _phase_tmem_dealloc_ready_0 ^= 1;
+            int _tmem_dealloc_addr = *((volatile int*)tmem_addr_storage);
+            asm volatile("tcgen05.dealloc.cta_group::1.sync.aligned.b32 %0, %1;" :: "r"(_tmem_dealloc_addr), "r"(256));
+        }
+    }
+    // ---- Role: prep ----
+    if (warp >= 12 && warp <= 31) {
+        asm volatile("setmaxnreg.dec.sync.aligned.u32 48;");
+        { // prep_main
+            int task_idx_4 = blockIdx.x;
+            int split_compute_start_4 = 0;
+            unsigned int _phase_work_item_ready_0_3 = 0;
+            {
+                mbarrier_wait(work_item_ready_addr, _phase_work_item_ready_0_3);
+                _phase_work_item_ready_0_3 ^= 1;
+                split_compute_start_4 = smem_work_item_compute_start[0];
+            }
+            int item_base_5 = task_idx_4 * 5;
+            int seq_idx_4 = seq_order[item_base_5];
+            int head_idx_4 = seq_order[item_base_5 + 1];
+            int compute_start_4 = split_compute_start_4;
+            int write_start_4 = seq_order[item_base_5 + 2];
+            int write_end_4 = seq_order[item_base_5 + 3];
+            long long sequence_bos_4 = cu_seqlens[seq_idx_4];
+            long long sequence_eos_4 = cu_seqlens[seq_idx_4 + 1];
+            long long bos_4 = sequence_bos_4 + (long long)compute_start_4 * 32;
+            long long _min_0 = ((sequence_eos_4) < (sequence_bos_4 + (long long)write_end_4 * 32) ? (sequence_eos_4) : (sequence_bos_4 + (long long)write_end_4 * 32));
+            long long eos_4 = _min_0;
+            int seq_len_4 = (int)(eos_4 - bos_4);
+            int num_chunks_4 = (seq_len_4 + 32 - 1) / 32;
+            int instance_id = (warp - 12) / 4;
+            int prep_instance = instance_id;
+            int warp_id_in_role_3 = (warp - 12);
+            int prep_local_warp = warp_id_in_role_3 - prep_instance * 4;
+            int prep_tid = prep_local_warp * 32 + lane;
+            int num_prep_iters = (num_chunks_4 + 5 - 1 - prep_instance) / 5;
+            unsigned int prep_stage = (unsigned int)prep_instance;
+            int gate_rate_stage_f32 = prep_instance * 10496;
+            int prep_global_tid = warp_id_in_role_3 * 32 + lane;
+            if (prep_tid == 0) {
+                float _expf_0 = __expf(A_log[head_idx_4]);
+                smem_gate_rate_all[gate_rate_stage_f32] = _expf_0;
+            }
+            if (prep_global_tid < 128) {
+                smem_gate_bias_all[prep_global_tid] = dt_bias[head_idx_4 * 128 + prep_global_tid];
+            }
+            asm volatile("barrier.sync 15, 640;" ::: "memory");
+            {
+                if (prep_global_tid < 128) {
+                    smem_gate_bias_all[prep_global_tid] = smem_gate_bias_all[prep_global_tid] * smem_gate_rate_all[0];
+                }
+                asm volatile("barrier.sync 15, 640;" ::: "memory");
+            }
+            unsigned int _phase_raw_inputs_free = 1;
+            unsigned int _phase_gate_raw_full = 0;
+            unsigned int _phase_smem_free = 1;
+            unsigned int _phase_v_free = 1;
+            unsigned int _phase_qk_raw_full = 0;
+            unsigned int _phase_short_beta_ready = 0;
+            unsigned int _phase_prep_diag_ready = 0;
+            unsigned int _phase_prep_inv16_ready = 0;
+            unsigned int _phase_tape_free = 1;
+            #pragma unroll 1
+            for (int prep_iter = 0; prep_iter < num_prep_iters; prep_iter++) {
+                int chunk_idx_3 = prep_iter * 5 + prep_instance;
+                int chunk_global_local_2 = compute_start_4 + chunk_idx_3;
+                int owned_chunk_2 = chunk_global_local_2 >= write_start_4 && chunk_global_local_2 < write_end_4;
+                int stage_f32 = prep_stage * 10496;
+                int stage_bf16 = prep_stage * 20992;
+                int chunk_is_full_1 = ((seq_len_4 >= (chunk_idx_3 + 1) * 32) ? 1 : 0);
+                float early_beta_value = 0.0f;
+                float early_gate0 = 0.0f;
+                if (chunk_is_full_1 != 0 || prep_iter != 0) {
+                    mbarrier_wait(raw_inputs_free_addr + (prep_stage) * 8, _phase_raw_inputs_free);
+                }
+                if (chunk_is_full_1 != 0) {
+                    if (prep_local_warp == 0) {
+                        if (elect_sync()) {
+                            mbarrier_arrive_expect_tx(gate_raw_full_addr + (prep_stage) * 8, 8704);
+                            tma_3d_gmem2smem(smem_g_raw_addr + prep_stage * 41984, g_tma, 0, head_idx_4, (int)(bos_4 + (long long)(chunk_idx_3 * 32)), gate_raw_full_addr + (prep_stage) * 8);
+                            {
+                                tma_2d_gmem2smem(smem_beta_raw_addr + prep_stage * 41984, beta_tma, ((0) ? 0 : head_idx_4 / 8 * 8), (int)(((0) ? (bos_4 + (long long)(chunk_idx_3 * 32)) / 2 : bos_4 + (long long)(chunk_idx_3 * 32))), gate_raw_full_addr + (prep_stage) * 8);
+                            }
+                            mbarrier_arrive_expect_tx(qk_raw_full_addr + (prep_stage) * 8, 16384);
+                            tma_4d_gmem2smem(smem_kd_addr + prep_stage * 41984, k_tma, 0, (int)(bos_4 + (long long)(chunk_idx_3 * 32)), head_idx_4, 0, qk_raw_full_addr + (prep_stage) * 8);
+                        }
+                    }
+                    mbarrier_wait(gate_raw_full_addr + (prep_stage) * 8, _phase_gate_raw_full);
+                    if (prep_local_warp == 2 && lane < 32) {
+                        float beta_logit = 0.0f;
+                        {
+                            {
+                                unsigned int beta_raw_pair[1];
+                                asm volatile("ld.shared.b32 %0, [%1];" : "=r"(*reinterpret_cast<uint32_t*>(&beta_raw_pair[0])) : "r"(smem_beta_raw_addr + prep_stage * 41984 + (unsigned int)(lane * 16) + (unsigned int)(head_idx_4 % 8 / 2 * 4)));
+                                float beta_raw_pair_f32[2];
+                                #pragma unroll
+                                for (int _pair = 0; _pair < 1; _pair++) {
+                                    asm volatile(
+                                        "{\n\t"
+                                        "shl.b32 %0, %2, 16;\n\t"
+                                        "and.b32 %1, %2, 0xffff0000;\n\t"
+                                        "}\n"
+                                        : "=f"((&beta_raw_pair_f32[_pair * 2])[0]), "=f"((&beta_raw_pair_f32[_pair * 2])[1])
+                                        : "r"(beta_raw_pair[_pair]));
+                                }
+                                beta_logit = beta_raw_pair_f32[0];
+                                if (head_idx_4 % 2 != 0) {
+                                    beta_logit = beta_raw_pair_f32[1];
+                                }
+                            }
+                        }
+                        float _tanh_approx_1;
+                        asm volatile("tanh.approx.f32 %0, %1;" : "=f"(_tanh_approx_1) : "f"(beta_logit * 0.5f));
+                        early_beta_value = _tanh_approx_1 * 0.5f + 0.5f;
+                    }
+                }
+                mbarrier_wait(smem_free_addr + (prep_stage) * 8, _phase_smem_free);
+                mbarrier_wait(v_free_addr + (prep_stage) * 8, _phase_v_free);
+                if (chunk_is_full_1 != 0) {
+                    if (prep_local_warp == 0) {
+                        if (elect_sync()) {
+                            tma_4d_gmem2smem(smem_q_raw_prefetch_addr + prep_stage * 41984, q_tma, 0, (int)(bos_4 + (long long)(chunk_idx_3 * 32)), head_idx_4, 0, qk_raw_full_addr + (prep_stage) * 8);
+                        }
+                    }
+                }
+                if (chunk_is_full_1 == 0) {
+                    #pragma unroll
+                    for (int gate_load_pass = 0; gate_load_pass < 4; gate_load_pass++) {
+                        int gate_load_item = gate_load_pass * 128 + prep_tid;
+                        int gate_load_row = gate_load_item / 16;
+                        int gate_load_segment = gate_load_item % 16;
+                        long long gate_load_token = bos_4 + (long long)(chunk_idx_3 * 32 + gate_load_row);
+                        long long gate_load_base = (gate_load_token * (long long)num_heads + (long long)head_idx_4) * 128 + (long long)(gate_load_segment * 8);
+                        asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16, %2;"
+                            :: "r"(smem_g_raw_addr + prep_stage * 41984 + (unsigned int)(gate_load_item * 16)), "l"(g + gate_load_base), "r"((gate_load_token < eos_4) ? 16 : 0));
+                        int q_tail_addr = (smem_q_raw_prefetch_addr + prep_stage * 41984 + (unsigned int)(gate_load_segment * 8 / 64 * 4096 + gate_load_row * 128 + gate_load_segment * 8 % 64 * 2 ^ (gate_load_segment * 8 / 64 * 4096 + gate_load_row * 128 + gate_load_segment * 8 % 64 * 2 >> 7 & 7) << 4));
+                        asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16, %2;"
+                            :: "r"(q_tail_addr), "l"(q + gate_load_base), "r"((gate_load_token < eos_4) ? 16 : 0));
+                        int k_tail_addr = (smem_kd_addr + prep_stage * 41984 + (unsigned int)(gate_load_segment * 8 / 64 * 4096 + gate_load_row * 128 + gate_load_segment * 8 % 64 * 2 ^ (gate_load_segment * 8 / 64 * 4096 + gate_load_row * 128 + gate_load_segment * 8 % 64 * 2 >> 7 & 7) << 4));
+                        asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16, %2;"
+                            :: "r"(k_tail_addr), "l"(k + gate_load_base), "r"((gate_load_token < eos_4) ? 16 : 0));
+                    }
+                }
+                if (chunk_is_full_1 == 0) {
+                    asm volatile("cp.async.commit_group;");
+                    asm volatile("cp.async.wait_group 0;");
+                    asm volatile("barrier.sync %0, 128;" :: "r"(10 + prep_instance) : "memory");
+                }
+                if (prep_local_warp == 2 && lane < 32) {
+                    long long beta_token = bos_4 + (long long)(chunk_idx_3 * 32 + lane);
+                    float beta_value = early_beta_value;
+                    if (chunk_is_full_1 == 0) {
+                        if (beta_token < eos_4) {
+                            float beta_logit_1 = (float)beta[beta_token * (long long)num_heads + (long long)head_idx_4];
+                            float _tanh_approx_3;
+                            asm volatile("tanh.approx.f32 %0, %1;" : "=f"(_tanh_approx_3) : "f"(beta_logit_1 * 0.5f));
+                            beta_value = _tanh_approx_3 * 0.5f + 0.5f;
+                        }
+                    }
+                    {
+                        smem_prep_beta_all[stage_f32 + lane] = beta_value;
+                    }
+                    {
+                        if (beta_token < eos_4 && owned_chunk_2 != 0) {
+                            beta_active_out[beta_token * (long long)num_heads + (long long)head_idx_4] = beta_value;
+                        }
+                    }
+                }
+                if (prep_tid < 128) {
+                    int gate_col = prep_tid;
+                    float gate_rate = smem_gate_rate_all[stage_f32];
+                    float gate_bias = smem_gate_bias_all[gate_col];
+                    float prefix_log2 = 0.0f;
+                    {
+                        float2 _f2_0 = make_float2(gate_rate, gate_rate);
+                        float2 gate_rate_pair = _f2_0;
+                        float2 _f2_1 = make_float2(gate_bias, gate_bias);
+                        float2 gate_bias_pair = _f2_1;
+                        float half_gate_scale = lower_bound * 0.7213475204444817f;
+                        float2 _f2_2 = make_float2(half_gate_scale, half_gate_scale);
+                        float2 half_gate_scale_pair = _f2_2;
+                        if (chunk_is_full_1 != 0) {
+                            for (int gate_row_pair = 0; gate_row_pair < 16; gate_row_pair++) {
+                                const int gate_row0 = gate_row_pair * 2;
+                                const int gate_row1 = gate_row0 + 1;
+                                const int gate_row0_0 = gate_row_pair * 2;
+                                const int gate_row1_1 = gate_row0_0 + 1;
+                                __nv_bfloat16 gate_raw0 = smem_g_raw_all[stage_bf16 + gate_row0_0 * 128 + gate_col];
+                                __nv_bfloat16 gate_raw1 = smem_g_raw_all[stage_bf16 + gate_row1_1 * 128 + gate_col];
+                                float _cvt_f32_2 = __bfloat162float(gate_raw0);
+                                float _cvt_f32_3 = __bfloat162float(gate_raw1);
+                                float2 _f2_3 = make_float2(_cvt_f32_2, _cvt_f32_3);
+                                float2 gate_raw_pair = _f2_3;
+                                float2 gate_arg_pair = fma_f32x2(gate_raw_pair, gate_rate_pair, gate_bias_pair);
+                                float _tanh_approx_4;
+                                asm volatile("tanh.approx.f32 %0, %1;" : "=f"(_tanh_approx_4) : "f"(gate_arg_pair.x * 0.5f));
+                                float _tanh_approx_5;
+                                asm volatile("tanh.approx.f32 %0, %1;" : "=f"(_tanh_approx_5) : "f"(gate_arg_pair.y * 0.5f));
+                                float2 _f2_4 = make_float2(_tanh_approx_4, _tanh_approx_5);
+                                float2 gate_tanh_pair = _f2_4;
+                                float2 gate_log_pair = fma_f32x2(gate_tanh_pair, half_gate_scale_pair, half_gate_scale_pair);
+                                float gate_log0 = gate_log_pair.x;
+                                float gate_log1 = gate_log_pair.y;
+                                prefix_log2 += gate_log0;
+                                smem_gate_all[stage_f32 + gate_row0 * 128 + gate_col] = prefix_log2;
+                                prefix_log2 += gate_log1;
+                                smem_gate_all[stage_f32 + gate_row1 * 128 + gate_col] = prefix_log2;
+                            }
+                        } else {
+                            for (int gate_row_pair_1 = 0; gate_row_pair_1 < 16; gate_row_pair_1++) {
+                                const int gate_row0_1 = gate_row_pair_1 * 2;
+                                const int gate_row1_2 = gate_row0_1 + 1;
+                                const int gate_row0_0_1 = gate_row_pair_1 * 2;
+                                const int gate_row1_1_1 = gate_row0_0_1 + 1;
+                                __nv_bfloat16 gate_raw0_1 = smem_g_raw_all[stage_bf16 + gate_row0_0_1 * 128 + gate_col];
+                                __nv_bfloat16 gate_raw1_1 = smem_g_raw_all[stage_bf16 + gate_row1_1_1 * 128 + gate_col];
+                                float _cvt_f32_4 = __bfloat162float(gate_raw0_1);
+                                float _cvt_f32_5 = __bfloat162float(gate_raw1_1);
+                                float2 _f2_5 = make_float2(_cvt_f32_4, _cvt_f32_5);
+                                float2 gate_raw_pair_1 = _f2_5;
+                                float2 gate_arg_pair_1 = fma_f32x2(gate_raw_pair_1, gate_rate_pair, gate_bias_pair);
+                                float _tanh_approx_6;
+                                asm volatile("tanh.approx.f32 %0, %1;" : "=f"(_tanh_approx_6) : "f"(gate_arg_pair_1.x * 0.5f));
+                                float _tanh_approx_7;
+                                asm volatile("tanh.approx.f32 %0, %1;" : "=f"(_tanh_approx_7) : "f"(gate_arg_pair_1.y * 0.5f));
+                                float2 _f2_6 = make_float2(_tanh_approx_6, _tanh_approx_7);
+                                float2 gate_tanh_pair_1 = _f2_6;
+                                float2 gate_log_pair_1 = fma_f32x2(gate_tanh_pair_1, half_gate_scale_pair, half_gate_scale_pair);
+                                float gate_log0_1 = gate_log_pair_1.x;
+                                float gate_log1_1 = gate_log_pair_1.y;
+                                {
+                                    long long gate_token0 = bos_4 + (long long)(chunk_idx_3 * 32 + gate_row0_0_1);
+                                    long long gate_token1 = gate_token0 + 1;
+                                    if (gate_token0 >= eos_4) {
+                                        gate_log0_1 = 0.0f;
+                                    }
+                                    if (gate_token1 >= eos_4) {
+                                        gate_log1_1 = 0.0f;
+                                    }
+                                }
+                                prefix_log2 += gate_log0_1;
+                                smem_gate_all[stage_f32 + gate_row0_1 * 128 + gate_col] = prefix_log2;
+                                prefix_log2 += gate_log1_1;
+                                smem_gate_all[stage_f32 + gate_row1_2 * 128 + gate_col] = prefix_log2;
+                            }
+                        }
+                    }
+                }
+                asm volatile("barrier.sync %0, 128;" :: "r"(10 + prep_instance) : "memory");
+                if (chunk_is_full_1 != 0) {
+                    mbarrier_wait(qk_raw_full_addr + (prep_stage) * 8, _phase_qk_raw_full);
+                }
+                if (prep_tid < 128) {
+                    float total_log2 = smem_gt_prefix_all[stage_f32 + prep_tid];
+                    float _exp2_0 = approx_exp2(total_log2 - lower_bound * 1.4426950408889634f * 16.0f);
+                    float restore_factor_value = _exp2_0;
+                    smem_restore_factor_all[stage_f32 + prep_tid] = restore_factor_value;
+                    {
+                        long long chunk_global_restore = cu_chunk_offsets[seq_idx_4] + (long long)chunk_global_local_2;
+                        if (owned_chunk_2 != 0) {
+                            tape_restore_factor[(chunk_global_restore * (long long)num_heads + (long long)head_idx_4) * 128 + (long long)prep_tid] = restore_factor_value;
+                        }
+                        int _vote_0 = __any_sync(0xFFFFFFFF, num_chunks_4 > chunk_idx_3 + 1 && total_log2 > -30.0f);
+                        int warp_slow = _vote_0;
+                        if (lane == 0) {
+                            smem_state_checkpoint_needed[prep_stage * 4 + (unsigned int)prep_local_warp] = (unsigned int)warp_slow;
+                        }
+                    }
+                }
+                if (prep_tid == 0) {
+                    float _exp2_1 = approx_exp2(lower_bound * 1.4426950408889634f * 16.0f);
+                    smem_restore_factor_all[stage_f32 + 128] = _exp2_1;
+                }
+                #pragma unroll 1
+                for (int work_pass = 0; work_pass < 4; work_pass++) {
+                    int work_item = work_pass * 128 + prep_tid;
+                    int row = work_item / 16;
+                    int segment = work_item % 16;
+                    long long token = bos_4 + (long long)(chunk_idx_3 * 32 + row);
+                    int token_valid = ((token < eos_4) ? 1 : 0);
+                    long long gmem_base = (token * (long long)num_heads + (long long)head_idx_4) * 128 + (long long)(segment * 8);
+                    float q_raw_vec[8];
+                    float k_raw_vec[8];
+                    unsigned int packed_2[4];
+                    asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                        : "=r"(*reinterpret_cast<uint32_t*>(&packed_2[0])), "=r"(*reinterpret_cast<uint32_t*>(&packed_2[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&packed_2[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&packed_2[(0) + 3]))
+                        : "r"((smem_q_raw_prefetch_addr + prep_stage * 41984 + (unsigned int)(segment * 8 / 64 * 4096 + row * 128 + segment * 8 % 64 * 2 ^ (segment * 8 / 64 * 4096 + row * 128 + segment * 8 % 64 * 2 >> 7 & 7) << 4))));
+                    float packed_f32_2[8];
+                    #pragma unroll
+                    for (int _pair = 0; _pair < 4; _pair++) {
+                        asm volatile(
+                            "{\n\t"
+                            "shl.b32 %0, %2, 16;\n\t"
+                            "and.b32 %1, %2, 0xffff0000;\n\t"
+                            "}\n"
+                            : "=f"((&packed_f32_2[_pair * 2])[0]), "=f"((&packed_f32_2[_pair * 2])[1])
+                            : "r"(packed_2[_pair]));
+                    }
+                    #pragma unroll
+                    for (int value_idx_2 = 0; value_idx_2 < 8; value_idx_2++) {
+                        q_raw_vec[value_idx_2] = packed_f32_2[value_idx_2];
+                    }
+                    unsigned int packed_0[4];
+                    asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                        : "=r"(*reinterpret_cast<uint32_t*>(&packed_0[0])), "=r"(*reinterpret_cast<uint32_t*>(&packed_0[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&packed_0[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&packed_0[(0) + 3]))
+                        : "r"((smem_kd_addr + prep_stage * 41984 + (unsigned int)(segment * 8 / 64 * 4096 + row * 128 + segment * 8 % 64 * 2 ^ (segment * 8 / 64 * 4096 + row * 128 + segment * 8 % 64 * 2 >> 7 & 7) << 4))));
+                    float packed_0_f32[8];
+                    #pragma unroll
+                    for (int _pair = 0; _pair < 4; _pair++) {
+                        asm volatile(
+                            "{\n\t"
+                            "shl.b32 %0, %2, 16;\n\t"
+                            "and.b32 %1, %2, 0xffff0000;\n\t"
+                            "}\n"
+                            : "=f"((&packed_0_f32[_pair * 2])[0]), "=f"((&packed_0_f32[_pair * 2])[1])
+                            : "r"(packed_0[_pair]));
+                    }
+                    #pragma unroll
+                    for (int value_idx_3 = 0; value_idx_3 < 8; value_idx_3++) {
+                        k_raw_vec[value_idx_3] = packed_0_f32[value_idx_3];
+                    }
+                    float q_sum = 0.0f;
+                    float k_sum = 0.0f;
+                    for (int elem_in_segment = 0; elem_in_segment < 8; elem_in_segment++) {
+                        float q_raw = q_raw_vec[elem_in_segment];
+                        float k_raw = k_raw_vec[elem_in_segment];
+                        float _fma_4 = __fmaf_rn(q_raw, q_raw, q_sum);
+                        q_sum = _fma_4;
+                        float _fma_5 = __fmaf_rn(k_raw, k_raw, k_sum);
+                        k_sum = _fma_5;
+                    }
+                    float _shfl_xor_0 = __shfl_xor_sync(0xFFFFFFFF, q_sum, 8);
+                    q_sum += _shfl_xor_0;
+                    float _shfl_xor_1 = __shfl_xor_sync(0xFFFFFFFF, k_sum, 8);
+                    k_sum += _shfl_xor_1;
+                    float _shfl_xor_2 = __shfl_xor_sync(0xFFFFFFFF, q_sum, 4);
+                    q_sum += _shfl_xor_2;
+                    float _shfl_xor_3 = __shfl_xor_sync(0xFFFFFFFF, k_sum, 4);
+                    k_sum += _shfl_xor_3;
+                    float _shfl_xor_4 = __shfl_xor_sync(0xFFFFFFFF, q_sum, 2);
+                    q_sum += _shfl_xor_4;
+                    float _shfl_xor_5 = __shfl_xor_sync(0xFFFFFFFF, k_sum, 2);
+                    k_sum += _shfl_xor_5;
+                    float _shfl_xor_6 = __shfl_xor_sync(0xFFFFFFFF, q_sum, 1);
+                    q_sum += _shfl_xor_6;
+                    float _shfl_xor_7 = __shfl_xor_sync(0xFFFFFFFF, k_sum, 1);
+                    k_sum += _shfl_xor_7;
+                    float _rsqrt_0 = rsqrtf(q_sum + 1e-06f);
+                    float q_inv = _rsqrt_0;
+                    float _rsqrt_1 = rsqrtf(k_sum + 1e-06f);
+                    float k_inv = _rsqrt_1;
+                    {
+                        q_inv *= scale;
+                    }
+                    const float2 _scale2_0 = {q_inv, q_inv};
+                    #pragma unroll
+                    for (int _ls = 0; _ls < 4; _ls++)
+                        mul_f32x2_inplace(&reinterpret_cast<float2*>(q_raw_vec)[_ls], _scale2_0);
+                    const float2 _scale2_1 = {k_inv, k_inv};
+                    #pragma unroll
+                    for (int _ls = 0; _ls < 4; _ls++)
+                        mul_f32x2_inplace(&reinterpret_cast<float2*>(k_raw_vec)[_ls], _scale2_1);
+                    {
+                        if (token_valid != 0 && owned_chunk_2 != 0) {
+                            if (segment == 0) {
+                                float norm_pair[2];
+                                norm_pair[0] = q_inv;
+                                norm_pair[1] = k_inv;
+                                {
+                                    float2 _v2 = make_float2(norm_pair[0 + 0], norm_pair[0 + 1]);
+                                    *reinterpret_cast<float2*>(norm_inv_out + (token * (long long)num_heads + (long long)head_idx_4) * 2) = _v2;
+                                }
+                            }
+                        }
+                    }
+                    float qd_vec[8];
+                    float kd_vec[8];
+                    float ki_vec[8];
+                    for (int elem_in_segment_1 = 0; elem_in_segment_1 < 8; elem_in_segment_1++) {
+                        int col = segment * 8 + elem_in_segment_1;
+                        float prefix = smem_gate_all[stage_f32 + row * 128 + col];
+                        float common_log2 = lower_bound * 1.4426950408889634f * 16.0f;
+                        float _exp2_2 = approx_exp2(prefix - common_log2);
+                        float decay = _exp2_2;
+                        qd_vec[elem_in_segment_1] = decay;
+                        kd_vec[elem_in_segment_1] = decay;
+                        ki_vec[elem_in_segment_1] = k_raw_vec[elem_in_segment_1] / decay;
+                    }
+                    {
+                        if (token_valid != 0 && owned_chunk_2 != 0) {
+                            {
+                                __nv_bfloat162 _pk[4];
+                                _pk[0] = __floats2bfloat162_rn(qd_vec[0 + 0], qd_vec[0 + 1]);
+                                _pk[1] = __floats2bfloat162_rn(qd_vec[0 + 2], qd_vec[0 + 3]);
+                                _pk[2] = __floats2bfloat162_rn(qd_vec[0 + 4], qd_vec[0 + 5]);
+                                _pk[3] = __floats2bfloat162_rn(qd_vec[0 + 6], qd_vec[0 + 7]);
+                                *reinterpret_cast<uint4*>(&((__nv_bfloat16*)(decay_out))[gmem_base + 0]) = *reinterpret_cast<uint4*>(&_pk[0]);
+                            }
+                        }
+                    }
+                    #pragma unroll
+                    for (int _ls = 0; _ls < 4; _ls++)
+                        mul_f32x2_inplace(&reinterpret_cast<float2*>(qd_vec)[_ls], reinterpret_cast<const float2*>(q_raw_vec)[_ls]);
+                    #pragma unroll
+                    for (int _ls = 0; _ls < 4; _ls++)
+                        mul_f32x2_inplace(&reinterpret_cast<float2*>(kd_vec)[_ls], reinterpret_cast<const float2*>(k_raw_vec)[_ls]);
+                    unsigned int packed_1_1[4];
+                    #pragma unroll
+                    for (int _lp = 0; _lp < 4; _lp++) {
+                        __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(qd_vec[_lp*2 + 0], qd_vec[_lp*2+1 + 0]));
+                        packed_1_1[_lp] = *(uint32_t*)&_bf2;
+                    }
+                    #pragma unroll
+                    for (int word = 0; word < 4; word++) {
+                        asm volatile("st.shared.b32 [%0], %1;" :: "r"((smem_qd_addr + prep_stage * 41984 + (unsigned int)(segment * 8 / 64 * 4096 + row * 128 + segment * 8 % 64 * 2 ^ (segment * 8 / 64 * 4096 + row * 128 + segment * 8 % 64 * 2 >> 7 & 7) << 4)) + (unsigned int)(word * 4)), "r"((packed_1_1[word])));
+                    }
+                    unsigned int packed_2_1[4];
+                    #pragma unroll
+                    for (int _lp = 0; _lp < 4; _lp++) {
+                        __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(kd_vec[_lp*2 + 0], kd_vec[_lp*2+1 + 0]));
+                        packed_2_1[_lp] = *(uint32_t*)&_bf2;
+                    }
+                    #pragma unroll
+                    for (int word_1 = 0; word_1 < 4; word_1++) {
+                        asm volatile("st.shared.b32 [%0], %1;" :: "r"((smem_kd_addr + prep_stage * 41984 + (unsigned int)(segment * 8 / 64 * 4096 + row * 128 + segment * 8 % 64 * 2 ^ (segment * 8 / 64 * 4096 + row * 128 + segment * 8 % 64 * 2 >> 7 & 7) << 4)) + (unsigned int)(word_1 * 4)), "r"((packed_2_1[word_1])));
+                    }
+                    unsigned int packed_3[4];
+                    #pragma unroll
+                    for (int _lp = 0; _lp < 4; _lp++) {
+                        __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(ki_vec[_lp*2 + 0], ki_vec[_lp*2+1 + 0]));
+                        packed_3[_lp] = *(uint32_t*)&_bf2;
+                    }
+                    #pragma unroll
+                    for (int word_2 = 0; word_2 < 4; word_2++) {
+                        asm volatile("st.shared.b32 [%0], %1;" :: "r"((smem_ki_addr + prep_stage * 41984 + (unsigned int)(segment * 8 / 64 * 4096 + row * 128 + segment * 8 % 64 * 2 ^ (segment * 8 / 64 * 4096 + row * 128 + segment * 8 % 64 * 2 >> 7 & 7) << 4)) + (unsigned int)(word_2 * 4)), "r"((packed_3[word_2])));
+                    }
+                }
+                asm volatile("barrier.sync %0, 128;" :: "r"(10 + prep_instance) : "memory");
+                unsigned int a_frag[4];
+                unsigned int b_frag[4];
+                float acc[8];
+                {
+                    int pair_row_base = prep_local_warp / 2 * 16;
+                    int pair_col_base = prep_local_warp % 2 * 16;
+                    if (pair_row_base >= pair_col_base) {
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(a_frag[0]), "=r"(a_frag[1]), "=r"(a_frag[2]), "=r"(a_frag[3])
+                            : "r"(smem_kd_addr + prep_stage * 41984 + (unsigned int)((lane / 16 / 8 * 256 + (pair_row_base + lane % 16) * 8 + (lane / 16 % 8 * 16 ^ (pair_row_base + lane % 16 & 7) << 4) / 16) * 16))
+                            : "memory");
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(b_frag[0]), "=r"(b_frag[1]), "=r"(b_frag[2]), "=r"(b_frag[3])
+                            : "r"(smem_ki_addr + prep_stage * 41984 + (unsigned int)((lane % 16 / 8 / 8 * 256 + (pair_col_base + 8 * (lane / 16) + lane % 8) * 8 + (lane % 16 / 8 % 8 * 16 ^ (pair_col_base + 8 * (lane / 16) + lane % 8 & 7) << 4) / 16) * 16))
+                            : "memory");
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%10, %11, %12, %13};\n"
+                            : "=f"(acc[0]), "=f"(acc[1]), "=f"(acc[2]), "=f"(acc[3])
+                            : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[0]), "r"(b_frag[1]), "f"(0.0f), "f"(0.0f), "f"(0.0f), "f"(0.0f));
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%10, %11, %12, %13};\n"
+                            : "=f"(acc[4]), "=f"(acc[(4) + 1]), "=f"(acc[(4) + 2]), "=f"(acc[(4) + 3])
+                            : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[2]), "r"(b_frag[(2) + 1]), "f"(0.0f), "f"(0.0f), "f"(0.0f), "f"(0.0f));
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(a_frag[0]), "=r"(a_frag[1]), "=r"(a_frag[2]), "=r"(a_frag[3])
+                            : "r"(smem_kd_addr + prep_stage * 41984 + (unsigned int)((lane / 16 / 8 * 256 + (pair_row_base + lane % 16) * 8 + (lane / 16 % 8 * 16 ^ (pair_row_base + lane % 16 & 7) << 4) / 16 ^ 2) * 16))
+                            : "memory");
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(b_frag[0]), "=r"(b_frag[1]), "=r"(b_frag[2]), "=r"(b_frag[3])
+                            : "r"(smem_ki_addr + prep_stage * 41984 + (unsigned int)(((lane % 16 / 8 / 8 * 256 + (pair_col_base + 8 * (lane / 16) + lane % 8) * 8 + (lane % 16 / 8 % 8 * 16 ^ (pair_col_base + 8 * (lane / 16) + lane % 8 & 7) << 4) / 16 + 256 ^ 2) - 256) * 16))
+                            : "memory");
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                            : "+f"(acc[0]), "+f"(acc[1]), "+f"(acc[2]), "+f"(acc[3])
+                            : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[0]), "r"(b_frag[1]));
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                            : "+f"(acc[4]), "+f"(acc[(4) + 1]), "+f"(acc[(4) + 2]), "+f"(acc[(4) + 3])
+                            : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[2]), "r"(b_frag[(2) + 1]));
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(a_frag[0]), "=r"(a_frag[1]), "=r"(a_frag[2]), "=r"(a_frag[3])
+                            : "r"(smem_kd_addr + prep_stage * 41984 + (unsigned int)((lane / 16 / 8 * 256 + (pair_row_base + lane % 16) * 8 + (lane / 16 % 8 * 16 ^ (pair_row_base + lane % 16 & 7) << 4) / 16 ^ 2 ^ 6) * 16))
+                            : "memory");
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(b_frag[0]), "=r"(b_frag[1]), "=r"(b_frag[2]), "=r"(b_frag[3])
+                            : "r"(smem_ki_addr + prep_stage * 41984 + (unsigned int)((((lane % 16 / 8 / 8 * 256 + (pair_col_base + 8 * (lane / 16) + lane % 8) * 8 + (lane % 16 / 8 % 8 * 16 ^ (pair_col_base + 8 * (lane / 16) + lane % 8 & 7) << 4) / 16 + 256 ^ 2) - 256 + 256 ^ 6) - 256) * 16))
+                            : "memory");
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                            : "+f"(acc[0]), "+f"(acc[1]), "+f"(acc[2]), "+f"(acc[3])
+                            : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[0]), "r"(b_frag[1]));
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                            : "+f"(acc[4]), "+f"(acc[(4) + 1]), "+f"(acc[(4) + 2]), "+f"(acc[(4) + 3])
+                            : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[2]), "r"(b_frag[(2) + 1]));
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(a_frag[0]), "=r"(a_frag[1]), "=r"(a_frag[2]), "=r"(a_frag[3])
+                            : "r"(smem_kd_addr + prep_stage * 41984 + (unsigned int)((lane / 16 / 8 * 256 + (pair_row_base + lane % 16) * 8 + (lane / 16 % 8 * 16 ^ (pair_row_base + lane % 16 & 7) << 4) / 16 ^ 2 ^ 6 ^ 2) * 16))
+                            : "memory");
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(b_frag[0]), "=r"(b_frag[1]), "=r"(b_frag[2]), "=r"(b_frag[3])
+                            : "r"(smem_ki_addr + prep_stage * 41984 + (unsigned int)(((((lane % 16 / 8 / 8 * 256 + (pair_col_base + 8 * (lane / 16) + lane % 8) * 8 + (lane % 16 / 8 % 8 * 16 ^ (pair_col_base + 8 * (lane / 16) + lane % 8 & 7) << 4) / 16 + 256 ^ 2) - 256 + 256 ^ 6) - 256 + 256 ^ 2) - 256) * 16))
+                            : "memory");
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                            : "+f"(acc[0]), "+f"(acc[1]), "+f"(acc[2]), "+f"(acc[3])
+                            : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[0]), "r"(b_frag[1]));
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                            : "+f"(acc[4]), "+f"(acc[(4) + 1]), "+f"(acc[(4) + 2]), "+f"(acc[(4) + 3])
+                            : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[2]), "r"(b_frag[(2) + 1]));
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(a_frag[0]), "=r"(a_frag[1]), "=r"(a_frag[2]), "=r"(a_frag[3])
+                            : "r"(smem_kd_addr + prep_stage * 41984 + (unsigned int)(((lane / 16 / 8 * 256 + (pair_row_base + lane % 16) * 8 + (lane / 16 % 8 * 16 ^ (pair_row_base + lane % 16 & 7) << 4) / 16 ^ 2 ^ 6 ^ 2 ^ 6) + 256) * 16))
+                            : "memory");
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(b_frag[0]), "=r"(b_frag[1]), "=r"(b_frag[2]), "=r"(b_frag[3])
+                            : "r"(smem_ki_addr + prep_stage * 41984 + (unsigned int)((((((lane % 16 / 8 / 8 * 256 + (pair_col_base + 8 * (lane / 16) + lane % 8) * 8 + (lane % 16 / 8 % 8 * 16 ^ (pair_col_base + 8 * (lane / 16) + lane % 8 & 7) << 4) / 16 + 256 ^ 2) - 256 + 256 ^ 6) - 256 + 256 ^ 2) - 256 + 256 ^ 6) + 256 - 256) * 16))
+                            : "memory");
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                            : "+f"(acc[0]), "+f"(acc[1]), "+f"(acc[2]), "+f"(acc[3])
+                            : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[0]), "r"(b_frag[1]));
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                            : "+f"(acc[4]), "+f"(acc[(4) + 1]), "+f"(acc[(4) + 2]), "+f"(acc[(4) + 3])
+                            : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[2]), "r"(b_frag[(2) + 1]));
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(a_frag[0]), "=r"(a_frag[1]), "=r"(a_frag[2]), "=r"(a_frag[3])
+                            : "r"(smem_kd_addr + prep_stage * 41984 + (unsigned int)(((lane / 16 / 8 * 256 + (pair_row_base + lane % 16) * 8 + (lane / 16 % 8 * 16 ^ (pair_row_base + lane % 16 & 7) << 4) / 16 ^ 2 ^ 6 ^ 2 ^ 6) + 256 ^ 2) * 16))
+                            : "memory");
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(b_frag[0]), "=r"(b_frag[1]), "=r"(b_frag[2]), "=r"(b_frag[3])
+                            : "r"(smem_ki_addr + prep_stage * 41984 + (unsigned int)(((((((lane % 16 / 8 / 8 * 256 + (pair_col_base + 8 * (lane / 16) + lane % 8) * 8 + (lane % 16 / 8 % 8 * 16 ^ (pair_col_base + 8 * (lane / 16) + lane % 8 & 7) << 4) / 16 + 256 ^ 2) - 256 + 256 ^ 6) - 256 + 256 ^ 2) - 256 + 256 ^ 6) + 256 - 256 + 256 ^ 2) - 256) * 16))
+                            : "memory");
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                            : "+f"(acc[0]), "+f"(acc[1]), "+f"(acc[2]), "+f"(acc[3])
+                            : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[0]), "r"(b_frag[1]));
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                            : "+f"(acc[4]), "+f"(acc[(4) + 1]), "+f"(acc[(4) + 2]), "+f"(acc[(4) + 3])
+                            : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[2]), "r"(b_frag[(2) + 1]));
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(a_frag[0]), "=r"(a_frag[1]), "=r"(a_frag[2]), "=r"(a_frag[3])
+                            : "r"(smem_kd_addr + prep_stage * 41984 + (unsigned int)(((lane / 16 / 8 * 256 + (pair_row_base + lane % 16) * 8 + (lane / 16 % 8 * 16 ^ (pair_row_base + lane % 16 & 7) << 4) / 16 ^ 2 ^ 6 ^ 2 ^ 6) + 256 ^ 2 ^ 6) * 16))
+                            : "memory");
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(b_frag[0]), "=r"(b_frag[1]), "=r"(b_frag[2]), "=r"(b_frag[3])
+                            : "r"(smem_ki_addr + prep_stage * 41984 + (unsigned int)((((((((lane % 16 / 8 / 8 * 256 + (pair_col_base + 8 * (lane / 16) + lane % 8) * 8 + (lane % 16 / 8 % 8 * 16 ^ (pair_col_base + 8 * (lane / 16) + lane % 8 & 7) << 4) / 16 + 256 ^ 2) - 256 + 256 ^ 6) - 256 + 256 ^ 2) - 256 + 256 ^ 6) + 256 - 256 + 256 ^ 2) - 256 + 256 ^ 6) - 256) * 16))
+                            : "memory");
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                            : "+f"(acc[0]), "+f"(acc[1]), "+f"(acc[2]), "+f"(acc[3])
+                            : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[0]), "r"(b_frag[1]));
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                            : "+f"(acc[4]), "+f"(acc[(4) + 1]), "+f"(acc[(4) + 2]), "+f"(acc[(4) + 3])
+                            : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[2]), "r"(b_frag[(2) + 1]));
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(a_frag[0]), "=r"(a_frag[1]), "=r"(a_frag[2]), "=r"(a_frag[3])
+                            : "r"(smem_kd_addr + prep_stage * 41984 + (unsigned int)(((lane / 16 / 8 * 256 + (pair_row_base + lane % 16) * 8 + (lane / 16 % 8 * 16 ^ (pair_row_base + lane % 16 & 7) << 4) / 16 ^ 2 ^ 6 ^ 2 ^ 6) + 256 ^ 2 ^ 6 ^ 2) * 16))
+                            : "memory");
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(b_frag[0]), "=r"(b_frag[1]), "=r"(b_frag[2]), "=r"(b_frag[3])
+                            : "r"(smem_ki_addr + prep_stage * 41984 + (unsigned int)(((((((((lane % 16 / 8 / 8 * 256 + (pair_col_base + 8 * (lane / 16) + lane % 8) * 8 + (lane % 16 / 8 % 8 * 16 ^ (pair_col_base + 8 * (lane / 16) + lane % 8 & 7) << 4) / 16 + 256 ^ 2) - 256 + 256 ^ 6) - 256 + 256 ^ 2) - 256 + 256 ^ 6) + 256 - 256 + 256 ^ 2) - 256 + 256 ^ 6) - 256 + 256 ^ 2) - 256) * 16))
+                            : "memory");
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                            : "+f"(acc[0]), "+f"(acc[1]), "+f"(acc[2]), "+f"(acc[3])
+                            : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[0]), "r"(b_frag[1]));
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                            : "+f"(acc[4]), "+f"(acc[(4) + 1]), "+f"(acc[(4) + 2]), "+f"(acc[(4) + 3])
+                            : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[2]), "r"(b_frag[(2) + 1]));
+                        int row0 = pair_row_base + lane / 4;
+                        int row1 = row0 + 8;
+                        int col0 = pair_col_base + lane % 4 * 2;
+                        float beta0 = 0.0f;
+                        float beta1 = 0.0f;
+                        {
+                            beta0 = smem_prep_beta_all[stage_f32 + row0];
+                            beta1 = smem_prep_beta_all[stage_f32 + row1];
+                        }
+                        float seed[8];
+                        seed[0] = 0.0f;
+                        seed[1] = 0.0f;
+                        seed[2] = 0.0f;
+                        seed[3] = 0.0f;
+                        seed[4] = 0.0f;
+                        seed[5] = 0.0f;
+                        seed[6] = 0.0f;
+                        seed[7] = 0.0f;
+                        if (row0 > col0) {
+                            seed[0] = acc[0] * beta0;
+                        }
+                        if (row0 > col0 + 1) {
+                            seed[1] = acc[1] * beta0;
+                        }
+                        if (row1 > col0) {
+                            seed[2] = acc[2] * beta1;
+                        }
+                        if (row1 > col0 + 1) {
+                            seed[3] = acc[3] * beta1;
+                        }
+                        if (row0 > col0 + 8) {
+                            seed[4] = acc[4] * beta0;
+                        }
+                        if (row0 > col0 + 9) {
+                            seed[5] = acc[5] * beta0;
+                        }
+                        if (row1 > col0 + 8) {
+                            seed[6] = acc[6] * beta1;
+                        }
+                        if (row1 > col0 + 9) {
+                            seed[7] = acc[7] * beta1;
+                        }
+                        unsigned int seed_packed[4];
+                        #pragma unroll
+                        for (int _lp = 0; _lp < 4; _lp++) {
+                            __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(seed[_lp*2 + 0], seed[_lp*2+1 + 0]));
+                            seed_packed[_lp] = *(uint32_t*)&_bf2;
+                        }
+                        int seed_lane_row = lane % 16;
+                        int seed_lane_col = lane / 16 * 8;
+                        int byte_off = (int)prep_stage * 41984 + (pair_row_base + seed_lane_row) * 128 + (pair_col_base + seed_lane_col) * 2;
+                        int swizzled_off = byte_off ^ (byte_off >> 7 & 7) << 4;
+                        int seed_addr = smem_inv_work_addr + (unsigned int)swizzled_off;
+                        uint32_t _stmatrix_addr_2 = static_cast<uint32_t>((unsigned long long)seed_addr);
+                        asm volatile("stmatrix.sync.aligned.m8n8.x4.shared.b16 [%0], {%1, %2, %3, %4};\n"
+                            :: "r"(_stmatrix_addr_2), "r"(*reinterpret_cast<const uint32_t*>(&seed_packed[0])), "r"(*reinterpret_cast<const uint32_t*>(&seed_packed[1])), "r"(*reinterpret_cast<const uint32_t*>(&seed_packed[2])), "r"(*reinterpret_cast<const uint32_t*>(&seed_packed[3]))
+                            : "memory");
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(a_frag[0]), "=r"(a_frag[1]), "=r"(a_frag[2]), "=r"(a_frag[3])
+                            : "r"(smem_qd_addr + prep_stage * 41984 + (unsigned int)((lane / 16 / 8 * 256 + (pair_row_base + lane % 16) * 8 + (lane / 16 % 8 * 16 ^ (pair_row_base + lane % 16 & 7) << 4) / 16) * 16))
+                            : "memory");
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(b_frag[0]), "=r"(b_frag[1]), "=r"(b_frag[2]), "=r"(b_frag[3])
+                            : "r"(smem_ki_addr + prep_stage * 41984 + (unsigned int)((lane % 16 / 8 / 8 * 256 + (pair_col_base + 8 * (lane / 16) + lane % 8) * 8 + (lane % 16 / 8 % 8 * 16 ^ (pair_col_base + 8 * (lane / 16) + lane % 8 & 7) << 4) / 16) * 16))
+                            : "memory");
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%10, %11, %12, %13};\n"
+                            : "=f"(acc[0]), "=f"(acc[1]), "=f"(acc[2]), "=f"(acc[3])
+                            : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[0]), "r"(b_frag[1]), "f"(0.0f), "f"(0.0f), "f"(0.0f), "f"(0.0f));
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%10, %11, %12, %13};\n"
+                            : "=f"(acc[4]), "=f"(acc[(4) + 1]), "=f"(acc[(4) + 2]), "=f"(acc[(4) + 3])
+                            : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[2]), "r"(b_frag[(2) + 1]), "f"(0.0f), "f"(0.0f), "f"(0.0f), "f"(0.0f));
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(a_frag[0]), "=r"(a_frag[1]), "=r"(a_frag[2]), "=r"(a_frag[3])
+                            : "r"(smem_qd_addr + prep_stage * 41984 + (unsigned int)((lane / 16 / 8 * 256 + (pair_row_base + lane % 16) * 8 + (lane / 16 % 8 * 16 ^ (pair_row_base + lane % 16 & 7) << 4) / 16 ^ 2) * 16))
+                            : "memory");
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(b_frag[0]), "=r"(b_frag[1]), "=r"(b_frag[2]), "=r"(b_frag[3])
+                            : "r"(smem_ki_addr + prep_stage * 41984 + (unsigned int)(((lane % 16 / 8 / 8 * 256 + (pair_col_base + 8 * (lane / 16) + lane % 8) * 8 + (lane % 16 / 8 % 8 * 16 ^ (pair_col_base + 8 * (lane / 16) + lane % 8 & 7) << 4) / 16 + 256 ^ 2) - 256) * 16))
+                            : "memory");
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                            : "+f"(acc[0]), "+f"(acc[1]), "+f"(acc[2]), "+f"(acc[3])
+                            : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[0]), "r"(b_frag[1]));
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                            : "+f"(acc[4]), "+f"(acc[(4) + 1]), "+f"(acc[(4) + 2]), "+f"(acc[(4) + 3])
+                            : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[2]), "r"(b_frag[(2) + 1]));
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(a_frag[0]), "=r"(a_frag[1]), "=r"(a_frag[2]), "=r"(a_frag[3])
+                            : "r"(smem_qd_addr + prep_stage * 41984 + (unsigned int)((lane / 16 / 8 * 256 + (pair_row_base + lane % 16) * 8 + (lane / 16 % 8 * 16 ^ (pair_row_base + lane % 16 & 7) << 4) / 16 ^ 2 ^ 6) * 16))
+                            : "memory");
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(b_frag[0]), "=r"(b_frag[1]), "=r"(b_frag[2]), "=r"(b_frag[3])
+                            : "r"(smem_ki_addr + prep_stage * 41984 + (unsigned int)((((lane % 16 / 8 / 8 * 256 + (pair_col_base + 8 * (lane / 16) + lane % 8) * 8 + (lane % 16 / 8 % 8 * 16 ^ (pair_col_base + 8 * (lane / 16) + lane % 8 & 7) << 4) / 16 + 256 ^ 2) - 256 + 256 ^ 6) - 256) * 16))
+                            : "memory");
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                            : "+f"(acc[0]), "+f"(acc[1]), "+f"(acc[2]), "+f"(acc[3])
+                            : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[0]), "r"(b_frag[1]));
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                            : "+f"(acc[4]), "+f"(acc[(4) + 1]), "+f"(acc[(4) + 2]), "+f"(acc[(4) + 3])
+                            : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[2]), "r"(b_frag[(2) + 1]));
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(a_frag[0]), "=r"(a_frag[1]), "=r"(a_frag[2]), "=r"(a_frag[3])
+                            : "r"(smem_qd_addr + prep_stage * 41984 + (unsigned int)((lane / 16 / 8 * 256 + (pair_row_base + lane % 16) * 8 + (lane / 16 % 8 * 16 ^ (pair_row_base + lane % 16 & 7) << 4) / 16 ^ 2 ^ 6 ^ 2) * 16))
+                            : "memory");
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(b_frag[0]), "=r"(b_frag[1]), "=r"(b_frag[2]), "=r"(b_frag[3])
+                            : "r"(smem_ki_addr + prep_stage * 41984 + (unsigned int)(((((lane % 16 / 8 / 8 * 256 + (pair_col_base + 8 * (lane / 16) + lane % 8) * 8 + (lane % 16 / 8 % 8 * 16 ^ (pair_col_base + 8 * (lane / 16) + lane % 8 & 7) << 4) / 16 + 256 ^ 2) - 256 + 256 ^ 6) - 256 + 256 ^ 2) - 256) * 16))
+                            : "memory");
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                            : "+f"(acc[0]), "+f"(acc[1]), "+f"(acc[2]), "+f"(acc[3])
+                            : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[0]), "r"(b_frag[1]));
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                            : "+f"(acc[4]), "+f"(acc[(4) + 1]), "+f"(acc[(4) + 2]), "+f"(acc[(4) + 3])
+                            : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[2]), "r"(b_frag[(2) + 1]));
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(a_frag[0]), "=r"(a_frag[1]), "=r"(a_frag[2]), "=r"(a_frag[3])
+                            : "r"(smem_qd_addr + prep_stage * 41984 + (unsigned int)(((lane / 16 / 8 * 256 + (pair_row_base + lane % 16) * 8 + (lane / 16 % 8 * 16 ^ (pair_row_base + lane % 16 & 7) << 4) / 16 ^ 2 ^ 6 ^ 2 ^ 6) + 256) * 16))
+                            : "memory");
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(b_frag[0]), "=r"(b_frag[1]), "=r"(b_frag[2]), "=r"(b_frag[3])
+                            : "r"(smem_ki_addr + prep_stage * 41984 + (unsigned int)((((((lane % 16 / 8 / 8 * 256 + (pair_col_base + 8 * (lane / 16) + lane % 8) * 8 + (lane % 16 / 8 % 8 * 16 ^ (pair_col_base + 8 * (lane / 16) + lane % 8 & 7) << 4) / 16 + 256 ^ 2) - 256 + 256 ^ 6) - 256 + 256 ^ 2) - 256 + 256 ^ 6) + 256 - 256) * 16))
+                            : "memory");
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                            : "+f"(acc[0]), "+f"(acc[1]), "+f"(acc[2]), "+f"(acc[3])
+                            : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[0]), "r"(b_frag[1]));
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                            : "+f"(acc[4]), "+f"(acc[(4) + 1]), "+f"(acc[(4) + 2]), "+f"(acc[(4) + 3])
+                            : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[2]), "r"(b_frag[(2) + 1]));
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(a_frag[0]), "=r"(a_frag[1]), "=r"(a_frag[2]), "=r"(a_frag[3])
+                            : "r"(smem_qd_addr + prep_stage * 41984 + (unsigned int)(((lane / 16 / 8 * 256 + (pair_row_base + lane % 16) * 8 + (lane / 16 % 8 * 16 ^ (pair_row_base + lane % 16 & 7) << 4) / 16 ^ 2 ^ 6 ^ 2 ^ 6) + 256 ^ 2) * 16))
+                            : "memory");
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(b_frag[0]), "=r"(b_frag[1]), "=r"(b_frag[2]), "=r"(b_frag[3])
+                            : "r"(smem_ki_addr + prep_stage * 41984 + (unsigned int)(((((((lane % 16 / 8 / 8 * 256 + (pair_col_base + 8 * (lane / 16) + lane % 8) * 8 + (lane % 16 / 8 % 8 * 16 ^ (pair_col_base + 8 * (lane / 16) + lane % 8 & 7) << 4) / 16 + 256 ^ 2) - 256 + 256 ^ 6) - 256 + 256 ^ 2) - 256 + 256 ^ 6) + 256 - 256 + 256 ^ 2) - 256) * 16))
+                            : "memory");
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                            : "+f"(acc[0]), "+f"(acc[1]), "+f"(acc[2]), "+f"(acc[3])
+                            : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[0]), "r"(b_frag[1]));
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                            : "+f"(acc[4]), "+f"(acc[(4) + 1]), "+f"(acc[(4) + 2]), "+f"(acc[(4) + 3])
+                            : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[2]), "r"(b_frag[(2) + 1]));
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(a_frag[0]), "=r"(a_frag[1]), "=r"(a_frag[2]), "=r"(a_frag[3])
+                            : "r"(smem_qd_addr + prep_stage * 41984 + (unsigned int)(((lane / 16 / 8 * 256 + (pair_row_base + lane % 16) * 8 + (lane / 16 % 8 * 16 ^ (pair_row_base + lane % 16 & 7) << 4) / 16 ^ 2 ^ 6 ^ 2 ^ 6) + 256 ^ 2 ^ 6) * 16))
+                            : "memory");
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(b_frag[0]), "=r"(b_frag[1]), "=r"(b_frag[2]), "=r"(b_frag[3])
+                            : "r"(smem_ki_addr + prep_stage * 41984 + (unsigned int)((((((((lane % 16 / 8 / 8 * 256 + (pair_col_base + 8 * (lane / 16) + lane % 8) * 8 + (lane % 16 / 8 % 8 * 16 ^ (pair_col_base + 8 * (lane / 16) + lane % 8 & 7) << 4) / 16 + 256 ^ 2) - 256 + 256 ^ 6) - 256 + 256 ^ 2) - 256 + 256 ^ 6) + 256 - 256 + 256 ^ 2) - 256 + 256 ^ 6) - 256) * 16))
+                            : "memory");
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                            : "+f"(acc[0]), "+f"(acc[1]), "+f"(acc[2]), "+f"(acc[3])
+                            : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[0]), "r"(b_frag[1]));
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                            : "+f"(acc[4]), "+f"(acc[(4) + 1]), "+f"(acc[(4) + 2]), "+f"(acc[(4) + 3])
+                            : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[2]), "r"(b_frag[(2) + 1]));
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(a_frag[0]), "=r"(a_frag[1]), "=r"(a_frag[2]), "=r"(a_frag[3])
+                            : "r"(smem_qd_addr + prep_stage * 41984 + (unsigned int)(((lane / 16 / 8 * 256 + (pair_row_base + lane % 16) * 8 + (lane / 16 % 8 * 16 ^ (pair_row_base + lane % 16 & 7) << 4) / 16 ^ 2 ^ 6 ^ 2 ^ 6) + 256 ^ 2 ^ 6 ^ 2) * 16))
+                            : "memory");
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(b_frag[0]), "=r"(b_frag[1]), "=r"(b_frag[2]), "=r"(b_frag[3])
+                            : "r"(smem_ki_addr + prep_stage * 41984 + (unsigned int)(((((((((lane % 16 / 8 / 8 * 256 + (pair_col_base + 8 * (lane / 16) + lane % 8) * 8 + (lane % 16 / 8 % 8 * 16 ^ (pair_col_base + 8 * (lane / 16) + lane % 8 & 7) << 4) / 16 + 256 ^ 2) - 256 + 256 ^ 6) - 256 + 256 ^ 2) - 256 + 256 ^ 6) + 256 - 256 + 256 ^ 2) - 256 + 256 ^ 6) - 256 + 256 ^ 2) - 256) * 16))
+                            : "memory");
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                            : "+f"(acc[0]), "+f"(acc[1]), "+f"(acc[2]), "+f"(acc[3])
+                            : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[0]), "r"(b_frag[1]));
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                            : "+f"(acc[4]), "+f"(acc[(4) + 1]), "+f"(acc[(4) + 2]), "+f"(acc[(4) + 3])
+                            : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[2]), "r"(b_frag[(2) + 1]));
+                    } else {
+                        acc[0] = 0.0f;
+                        acc[1] = 0.0f;
+                        acc[2] = 0.0f;
+                        acc[3] = 0.0f;
+                        acc[4] = 0.0f;
+                        acc[5] = 0.0f;
+                        acc[6] = 0.0f;
+                        acc[7] = 0.0f;
+                    }
+                    int row0_1 = pair_row_base + lane / 4;
+                    int row1_1 = row0_1 + 8;
+                    int col0_1 = pair_col_base + lane % 4 * 2;
+                    float mqk[8];
+                    mqk[0] = 0.0f;
+                    mqk[1] = 0.0f;
+                    mqk[2] = 0.0f;
+                    mqk[3] = 0.0f;
+                    mqk[4] = 0.0f;
+                    mqk[5] = 0.0f;
+                    mqk[6] = 0.0f;
+                    mqk[7] = 0.0f;
+                    if (row0_1 >= col0_1) {
+                        mqk[0] = acc[0];
+                    }
+                    if (row0_1 >= col0_1 + 1) {
+                        mqk[1] = acc[1];
+                    }
+                    if (row1_1 >= col0_1) {
+                        mqk[2] = acc[2];
+                    }
+                    if (row1_1 >= col0_1 + 1) {
+                        mqk[3] = acc[3];
+                    }
+                    if (row0_1 >= col0_1 + 8) {
+                        mqk[4] = acc[4];
+                    }
+                    if (row0_1 >= col0_1 + 9) {
+                        mqk[5] = acc[5];
+                    }
+                    if (row1_1 >= col0_1 + 8) {
+                        mqk[6] = acc[6];
+                    }
+                    if (row1_1 >= col0_1 + 9) {
+                        mqk[7] = acc[7];
+                    }
+                    unsigned int mqk_packed[4];
+                    #pragma unroll
+                    for (int _lp = 0; _lp < 4; _lp++) {
+                        __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(mqk[_lp*2 + 0], mqk[_lp*2+1 + 0]));
+                        mqk_packed[_lp] = *(uint32_t*)&_bf2;
+                    }
+                    #pragma unroll
+                    for (int publish_pair = 0; publish_pair < 2; publish_pair++) {
+                        int publish_row = pair_col_base + publish_pair * 8 + (lane & 7);
+                        int publish_col = 128 + pair_row_base + lane / 8 * 8;
+                        uint32_t _stmatrix_addr_3 = static_cast<uint32_t>((unsigned long long)(smem_final_trans_addr + prep_stage * 41984 + (unsigned int)(publish_col / 64 * 4096 + publish_row * 128 + publish_col % 64 * 2 ^ (publish_col / 64 * 4096 + publish_row * 128 + publish_col % 64 * 2 >> 7 & 7) << 4)));
+                        asm volatile("stmatrix.sync.aligned.m8n8.x2.trans.shared.b16 [%0], {%1, %2};\n"
+                            :: "r"(_stmatrix_addr_3), "r"(*reinterpret_cast<const uint32_t*>(&mqk_packed[publish_pair * 2])), "r"(*reinterpret_cast<const uint32_t*>(&mqk_packed[publish_pair * 2 + 1]))
+                            : "memory");
+                    }
+                    asm volatile("barrier.sync %0, 128;" :: "r"(10 + prep_instance) : "memory");
+                }
+                long long tape_scaled_base = 0;
+                {
+                    long long chunk_global_scaled = cu_chunk_offsets[seq_idx_4] + (long long)chunk_global_local_2;
+                    tape_scaled_base = (chunk_global_scaled * (long long)num_heads + (long long)head_idx_4) * 32 * 128;
+                }
+                if (prep_tid < 128) {
+                    float total_log2_1 = smem_gt_prefix_all[stage_f32 + prep_tid];
+                    float _exp2_3 = approx_exp2(total_log2_1);
+                    smem_gt_all[stage_f32 + prep_tid] = _exp2_3;
+                }
+                {
+                    if (prep_local_warp >= 2) {
+                        int stage_f32_0 = prep_stage * 10496;
+                        float restore_scale = smem_restore_factor_all[stage_f32_0 + 128];
+                        float restore_factor[8];
+                        int restore_segment = lane & 15;
+                        #pragma unroll
+                        for (int restore_elem = 0; restore_elem < 8; restore_elem++) {
+                            int restore_col = restore_segment * 8 + restore_elem;
+                            restore_factor[restore_elem] = smem_restore_factor_all[stage_f32_0 + restore_col];
+                        }
+                        #pragma unroll 1
+                        for (int restore_pass = 0; restore_pass < 6; restore_pass++) {
+                            int restore_row = 8 + (prep_local_warp - 2) * 12 + restore_pass * 2 + (lane >> 4);
+                            float restore_kr_values[8];
+                            {
+                                float restore_qd_values[8];
+                                float restore_kd_values[8];
+                                float restore_ki_values[8];
+                                unsigned int packed_4[4];
+                                asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                                    : "=r"(*reinterpret_cast<uint32_t*>(&packed_4[0])), "=r"(*reinterpret_cast<uint32_t*>(&packed_4[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&packed_4[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&packed_4[(0) + 3]))
+                                    : "r"((smem_qd_addr + prep_stage * 41984 + (unsigned int)(restore_segment * 8 / 64 * 4096 + restore_row * 128 + restore_segment * 8 % 64 * 2 ^ (restore_segment * 8 / 64 * 4096 + restore_row * 128 + restore_segment * 8 % 64 * 2 >> 7 & 7) << 4))));
+                                float packed_f32_3[8];
+                                #pragma unroll
+                                for (int _pair = 0; _pair < 4; _pair++) {
+                                    asm volatile(
+                                        "{\n\t"
+                                        "shl.b32 %0, %2, 16;\n\t"
+                                        "and.b32 %1, %2, 0xffff0000;\n\t"
+                                        "}\n"
+                                        : "=f"((&packed_f32_3[_pair * 2])[0]), "=f"((&packed_f32_3[_pair * 2])[1])
+                                        : "r"(packed_4[_pair]));
+                                }
+                                #pragma unroll
+                                for (int value_idx_4 = 0; value_idx_4 < 8; value_idx_4++) {
+                                    restore_qd_values[value_idx_4] = packed_f32_3[value_idx_4];
+                                }
+                                unsigned int packed_0_1[4];
+                                asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                                    : "=r"(*reinterpret_cast<uint32_t*>(&packed_0_1[0])), "=r"(*reinterpret_cast<uint32_t*>(&packed_0_1[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&packed_0_1[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&packed_0_1[(0) + 3]))
+                                    : "r"((smem_ki_addr + prep_stage * 41984 + (unsigned int)(restore_segment * 8 / 64 * 4096 + restore_row * 128 + restore_segment * 8 % 64 * 2 ^ (restore_segment * 8 / 64 * 4096 + restore_row * 128 + restore_segment * 8 % 64 * 2 >> 7 & 7) << 4))));
+                                float packed_0_f32_1[8];
+                                #pragma unroll
+                                for (int _pair = 0; _pair < 4; _pair++) {
+                                    asm volatile(
+                                        "{\n\t"
+                                        "shl.b32 %0, %2, 16;\n\t"
+                                        "and.b32 %1, %2, 0xffff0000;\n\t"
+                                        "}\n"
+                                        : "=f"((&packed_0_f32_1[_pair * 2])[0]), "=f"((&packed_0_f32_1[_pair * 2])[1])
+                                        : "r"(packed_0_1[_pair]));
+                                }
+                                #pragma unroll
+                                for (int value_idx_5 = 0; value_idx_5 < 8; value_idx_5++) {
+                                    restore_ki_values[value_idx_5] = packed_0_f32_1[value_idx_5];
+                                }
+                                if (STORE_BACKWARD_TAPE != 0 && owned_chunk_2 != 0) {
+                                    unsigned int packed_1_2[4];
+                                    asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                                        : "=r"(*reinterpret_cast<uint32_t*>(&packed_1_2[0])), "=r"(*reinterpret_cast<uint32_t*>(&packed_1_2[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&packed_1_2[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&packed_1_2[(0) + 3]))
+                                        : "r"((smem_kd_addr + prep_stage * 41984 + (unsigned int)(restore_segment * 8 / 64 * 4096 + restore_row * 128 + restore_segment * 8 % 64 * 2 ^ (restore_segment * 8 / 64 * 4096 + restore_row * 128 + restore_segment * 8 % 64 * 2 >> 7 & 7) << 4))));
+                                    float packed_1_f32[8];
+                                    #pragma unroll
+                                    for (int _pair = 0; _pair < 4; _pair++) {
+                                        asm volatile(
+                                            "{\n\t"
+                                            "shl.b32 %0, %2, 16;\n\t"
+                                            "and.b32 %1, %2, 0xffff0000;\n\t"
+                                            "}\n"
+                                            : "=f"((&packed_1_f32[_pair * 2])[0]), "=f"((&packed_1_f32[_pair * 2])[1])
+                                            : "r"(packed_1_2[_pair]));
+                                    }
+                                    #pragma unroll
+                                    for (int value_idx_6 = 0; value_idx_6 < 8; value_idx_6++) {
+                                        restore_kd_values[value_idx_6] = packed_1_f32[value_idx_6];
+                                    }
+                                    long long tape_scaled_index = tape_scaled_base + (long long)restore_row * 128 + (long long)(restore_segment * 8);
+                                    {
+                                        __nv_bfloat162 _pk[4];
+                                        _pk[0] = __floats2bfloat162_rn(restore_qd_values[0 + 0], restore_qd_values[0 + 1]);
+                                        _pk[1] = __floats2bfloat162_rn(restore_qd_values[0 + 2], restore_qd_values[0 + 3]);
+                                        _pk[2] = __floats2bfloat162_rn(restore_qd_values[0 + 4], restore_qd_values[0 + 5]);
+                                        _pk[3] = __floats2bfloat162_rn(restore_qd_values[0 + 6], restore_qd_values[0 + 7]);
+                                        *reinterpret_cast<uint4*>(&((__nv_bfloat16*)(tape_qd + tape_scaled_index))[0]) = *reinterpret_cast<uint4*>(&_pk[0]);
+                                    }
+                                    {
+                                        __nv_bfloat162 _pk[4];
+                                        _pk[0] = __floats2bfloat162_rn(restore_kd_values[0 + 0], restore_kd_values[0 + 1]);
+                                        _pk[1] = __floats2bfloat162_rn(restore_kd_values[0 + 2], restore_kd_values[0 + 3]);
+                                        _pk[2] = __floats2bfloat162_rn(restore_kd_values[0 + 4], restore_kd_values[0 + 5]);
+                                        _pk[3] = __floats2bfloat162_rn(restore_kd_values[0 + 6], restore_kd_values[0 + 7]);
+                                        *reinterpret_cast<uint4*>(&((__nv_bfloat16*)(tape_kd + tape_scaled_index))[0]) = *reinterpret_cast<uint4*>(&_pk[0]);
+                                    }
+                                }
+                                const float2 _scale2_4 = {restore_scale, restore_scale};
+                                #pragma unroll
+                                for (int _ls = 0; _ls < 4; _ls++)
+                                    mul_f32x2_inplace(&reinterpret_cast<float2*>(restore_qd_values)[_ls], _scale2_4);
+                                #pragma unroll
+                                for (int restore_elem_1 = 0; restore_elem_1 < 8; restore_elem_1++) {
+                                    restore_kr_values[restore_elem_1] = restore_ki_values[restore_elem_1] * restore_factor[restore_elem_1];
+                                }
+                            }
+                            unsigned int packed_5[4];
+                            #pragma unroll
+                            for (int _lp = 0; _lp < 4; _lp++) {
+                                __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(restore_kr_values[_lp*2 + 0], restore_kr_values[_lp*2+1 + 0]));
+                                packed_5[_lp] = *(uint32_t*)&_bf2;
+                            }
+                            #pragma unroll
+                            for (int word_3 = 0; word_3 < 4; word_3++) {
+                                asm volatile("st.shared.b32 [%0], %1;" :: "r"((smem_kr_trans_addr + prep_stage * 41984 + (unsigned int)(restore_segment * 8 / 64 * 4096 + restore_row * 128 + restore_segment * 8 % 64 * 2 ^ (restore_segment * 8 / 64 * 4096 + restore_row * 128 + restore_segment * 8 % 64 * 2 >> 7 & 7) << 4)) + (unsigned int)(word_3 * 4)), "r"((packed_5[word_3])));
+                            }
+                        }
+                    } else if (prep_local_warp == 1) {
+                        int stage_f32_0_1 = prep_stage * 10496;
+                        float restore_scale_1 = smem_restore_factor_all[stage_f32_0_1 + 128];
+                        float restore_factor_1[8];
+                        int restore_segment_1 = lane & 15;
+                        #pragma unroll
+                        for (int restore_elem_2 = 0; restore_elem_2 < 8; restore_elem_2++) {
+                            int restore_col_1 = restore_segment_1 * 8 + restore_elem_2;
+                            restore_factor_1[restore_elem_2] = smem_restore_factor_all[stage_f32_0_1 + restore_col_1];
+                        }
+                        #pragma unroll 1
+                        for (int restore_pass_1 = 0; restore_pass_1 < 4; restore_pass_1++) {
+                            int restore_row_1 = restore_pass_1 * 2 + (lane >> 4);
+                            float restore_kr_values_1[8];
+                            {
+                                float restore_qd_values_1[8];
+                                float restore_kd_values_1[8];
+                                float restore_ki_values_1[8];
+                                unsigned int packed_6[4];
+                                asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                                    : "=r"(*reinterpret_cast<uint32_t*>(&packed_6[0])), "=r"(*reinterpret_cast<uint32_t*>(&packed_6[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&packed_6[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&packed_6[(0) + 3]))
+                                    : "r"((smem_qd_addr + prep_stage * 41984 + (unsigned int)(restore_segment_1 * 8 / 64 * 4096 + restore_row_1 * 128 + restore_segment_1 * 8 % 64 * 2 ^ (restore_segment_1 * 8 / 64 * 4096 + restore_row_1 * 128 + restore_segment_1 * 8 % 64 * 2 >> 7 & 7) << 4))));
+                                float packed_f32_4[8];
+                                #pragma unroll
+                                for (int _pair = 0; _pair < 4; _pair++) {
+                                    asm volatile(
+                                        "{\n\t"
+                                        "shl.b32 %0, %2, 16;\n\t"
+                                        "and.b32 %1, %2, 0xffff0000;\n\t"
+                                        "}\n"
+                                        : "=f"((&packed_f32_4[_pair * 2])[0]), "=f"((&packed_f32_4[_pair * 2])[1])
+                                        : "r"(packed_6[_pair]));
+                                }
+                                #pragma unroll
+                                for (int value_idx_7 = 0; value_idx_7 < 8; value_idx_7++) {
+                                    restore_qd_values_1[value_idx_7] = packed_f32_4[value_idx_7];
+                                }
+                                unsigned int packed_0_2[4];
+                                asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                                    : "=r"(*reinterpret_cast<uint32_t*>(&packed_0_2[0])), "=r"(*reinterpret_cast<uint32_t*>(&packed_0_2[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&packed_0_2[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&packed_0_2[(0) + 3]))
+                                    : "r"((smem_ki_addr + prep_stage * 41984 + (unsigned int)(restore_segment_1 * 8 / 64 * 4096 + restore_row_1 * 128 + restore_segment_1 * 8 % 64 * 2 ^ (restore_segment_1 * 8 / 64 * 4096 + restore_row_1 * 128 + restore_segment_1 * 8 % 64 * 2 >> 7 & 7) << 4))));
+                                float packed_0_f32_2[8];
+                                #pragma unroll
+                                for (int _pair = 0; _pair < 4; _pair++) {
+                                    asm volatile(
+                                        "{\n\t"
+                                        "shl.b32 %0, %2, 16;\n\t"
+                                        "and.b32 %1, %2, 0xffff0000;\n\t"
+                                        "}\n"
+                                        : "=f"((&packed_0_f32_2[_pair * 2])[0]), "=f"((&packed_0_f32_2[_pair * 2])[1])
+                                        : "r"(packed_0_2[_pair]));
+                                }
+                                #pragma unroll
+                                for (int value_idx_8 = 0; value_idx_8 < 8; value_idx_8++) {
+                                    restore_ki_values_1[value_idx_8] = packed_0_f32_2[value_idx_8];
+                                }
+                                if (STORE_BACKWARD_TAPE != 0 && owned_chunk_2 != 0) {
+                                    unsigned int packed_1_3[4];
+                                    asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                                        : "=r"(*reinterpret_cast<uint32_t*>(&packed_1_3[0])), "=r"(*reinterpret_cast<uint32_t*>(&packed_1_3[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&packed_1_3[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&packed_1_3[(0) + 3]))
+                                        : "r"((smem_kd_addr + prep_stage * 41984 + (unsigned int)(restore_segment_1 * 8 / 64 * 4096 + restore_row_1 * 128 + restore_segment_1 * 8 % 64 * 2 ^ (restore_segment_1 * 8 / 64 * 4096 + restore_row_1 * 128 + restore_segment_1 * 8 % 64 * 2 >> 7 & 7) << 4))));
+                                    float packed_1_f32_1[8];
+                                    #pragma unroll
+                                    for (int _pair = 0; _pair < 4; _pair++) {
+                                        asm volatile(
+                                            "{\n\t"
+                                            "shl.b32 %0, %2, 16;\n\t"
+                                            "and.b32 %1, %2, 0xffff0000;\n\t"
+                                            "}\n"
+                                            : "=f"((&packed_1_f32_1[_pair * 2])[0]), "=f"((&packed_1_f32_1[_pair * 2])[1])
+                                            : "r"(packed_1_3[_pair]));
+                                    }
+                                    #pragma unroll
+                                    for (int value_idx_9 = 0; value_idx_9 < 8; value_idx_9++) {
+                                        restore_kd_values_1[value_idx_9] = packed_1_f32_1[value_idx_9];
+                                    }
+                                    long long tape_scaled_index_1 = tape_scaled_base + (long long)restore_row_1 * 128 + (long long)(restore_segment_1 * 8);
+                                    {
+                                        __nv_bfloat162 _pk[4];
+                                        _pk[0] = __floats2bfloat162_rn(restore_qd_values_1[0 + 0], restore_qd_values_1[0 + 1]);
+                                        _pk[1] = __floats2bfloat162_rn(restore_qd_values_1[0 + 2], restore_qd_values_1[0 + 3]);
+                                        _pk[2] = __floats2bfloat162_rn(restore_qd_values_1[0 + 4], restore_qd_values_1[0 + 5]);
+                                        _pk[3] = __floats2bfloat162_rn(restore_qd_values_1[0 + 6], restore_qd_values_1[0 + 7]);
+                                        *reinterpret_cast<uint4*>(&((__nv_bfloat16*)(tape_qd + tape_scaled_index_1))[0]) = *reinterpret_cast<uint4*>(&_pk[0]);
+                                    }
+                                    {
+                                        __nv_bfloat162 _pk[4];
+                                        _pk[0] = __floats2bfloat162_rn(restore_kd_values_1[0 + 0], restore_kd_values_1[0 + 1]);
+                                        _pk[1] = __floats2bfloat162_rn(restore_kd_values_1[0 + 2], restore_kd_values_1[0 + 3]);
+                                        _pk[2] = __floats2bfloat162_rn(restore_kd_values_1[0 + 4], restore_kd_values_1[0 + 5]);
+                                        _pk[3] = __floats2bfloat162_rn(restore_kd_values_1[0 + 6], restore_kd_values_1[0 + 7]);
+                                        *reinterpret_cast<uint4*>(&((__nv_bfloat16*)(tape_kd + tape_scaled_index_1))[0]) = *reinterpret_cast<uint4*>(&_pk[0]);
+                                    }
+                                }
+                                const float2 _scale2_5 = {restore_scale_1, restore_scale_1};
+                                #pragma unroll
+                                for (int _ls = 0; _ls < 4; _ls++)
+                                    mul_f32x2_inplace(&reinterpret_cast<float2*>(restore_qd_values_1)[_ls], _scale2_5);
+                                #pragma unroll
+                                for (int restore_elem_3 = 0; restore_elem_3 < 8; restore_elem_3++) {
+                                    restore_kr_values_1[restore_elem_3] = restore_ki_values_1[restore_elem_3] * restore_factor_1[restore_elem_3];
+                                }
+                            }
+                            unsigned int packed_7[4];
+                            #pragma unroll
+                            for (int _lp = 0; _lp < 4; _lp++) {
+                                __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(restore_kr_values_1[_lp*2 + 0], restore_kr_values_1[_lp*2+1 + 0]));
+                                packed_7[_lp] = *(uint32_t*)&_bf2;
+                            }
+                            #pragma unroll
+                            for (int word_4 = 0; word_4 < 4; word_4++) {
+                                asm volatile("st.shared.b32 [%0], %1;" :: "r"((smem_kr_trans_addr + prep_stage * 41984 + (unsigned int)(restore_segment_1 * 8 / 64 * 4096 + restore_row_1 * 128 + restore_segment_1 * 8 % 64 * 2 ^ (restore_segment_1 * 8 / 64 * 4096 + restore_row_1 * 128 + restore_segment_1 * 8 % 64 * 2 >> 7 & 7) << 4)) + (unsigned int)(word_4 * 4)), "r"((packed_7[word_4])));
+                            }
+                        }
+                    }
+                }
+                if (prep_local_warp == 0) {
+                    int inverse_row = lane;
+                    int diag_block = inverse_row / 8;
+                    int lane_in_diag = lane & 7;
+                    float inv_row[8];
+                    unsigned int packed_8[4];
+                    int byte_off_1 = (int)prep_stage * 41984 + inverse_row * 128 + diag_block * 8 * 2;
+                    int swizzled_off_1 = byte_off_1 ^ (byte_off_1 >> 7 & 7) << 4;
+                    asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                        : "=r"(*reinterpret_cast<uint32_t*>(&packed_8[0])), "=r"(*reinterpret_cast<uint32_t*>(&packed_8[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&packed_8[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&packed_8[(0) + 3]))
+                        : "r"(smem_inv_work_addr + (unsigned int)swizzled_off_1));
+                    float packed_f32_5[8];
+                    #pragma unroll
+                    for (int _pair = 0; _pair < 4; _pair++) {
+                        asm volatile(
+                            "{\n\t"
+                            "shl.b32 %0, %2, 16;\n\t"
+                            "and.b32 %1, %2, 0xffff0000;\n\t"
+                            "}\n"
+                            : "=f"((&packed_f32_5[_pair * 2])[0]), "=f"((&packed_f32_5[_pair * 2])[1])
+                            : "r"(packed_8[_pair]));
+                    }
+                    #pragma unroll
+                    for (int value_idx_10 = 0; value_idx_10 < 8; value_idx_10++) {
+                        inv_row[value_idx_10] = packed_f32_5[value_idx_10];
+                    }
+                    #pragma unroll
+                    for (int diag_elem = 0; diag_elem < 8; diag_elem++) {
+                        if (lane_in_diag == diag_elem) {
+                            inv_row[diag_elem] = 1.0f;
+                        }
+                    }
+                    int diag_group_base = lane - lane_in_diag;
+                    #pragma unroll
+                    for (int src_row = 0; src_row < 7; src_row++) {
+                        float row_scale = -inv_row[src_row];
+                        #pragma unroll
+                        for (int prev_col = 0; prev_col < src_row; prev_col++) {
+                            int pivot_lane = diag_group_base + src_row;
+                            float _shfl_0 = __shfl_sync(0xFFFFFFFF, inv_row[prev_col], pivot_lane);
+                            float pivot = _shfl_0;
+                            if (lane_in_diag > src_row) {
+                                float _fma_6 = __fmaf_rn(row_scale, pivot, inv_row[prev_col]);
+                                inv_row[prev_col] = _fma_6;
+                            }
+                        }
+                        if (lane_in_diag > src_row) {
+                            inv_row[src_row] = row_scale;
+                        }
+                    }
+                    unsigned int packed_0_3[4];
+                    #pragma unroll
+                    for (int _lp = 0; _lp < 4; _lp++) {
+                        __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(inv_row[_lp*2 + 0], inv_row[_lp*2+1 + 0]));
+                        packed_0_3[_lp] = *(uint32_t*)&_bf2;
+                    }
+                    int byte_off_1_1 = (int)prep_stage * 41984 + inverse_row * 128 + diag_block * 8 * 2;
+                    int swizzled_off_2 = byte_off_1_1 ^ (byte_off_1_1 >> 7 & 7) << 4;
+                    #pragma unroll
+                    for (int word_5 = 0; word_5 < 4; word_5++) {
+                        asm volatile("st.shared.b32 [%0], %1;" :: "r"(smem_inv_work_addr + (unsigned int)swizzled_off_2 + (unsigned int)(word_5 * 4)), "r"((packed_0_3[word_5])));
+                    }
+                }
+                if (prep_local_warp < 2) {
+                    __syncwarp();
+                    if (elect_sync()) {
+                        mbarrier_arrive(prep_diag_ready_addr + (prep_stage) * 8);
+                    }
+                    mbarrier_wait(prep_diag_ready_addr + (prep_stage) * 8, _phase_prep_diag_ready);
+                }
+                {
+                    if (prep_local_warp < 2) {
+                        int lane_row = lane & 7;
+                        int byte_off_2 = (int)prep_stage * 41984 + (prep_local_warp * 16 + 8 + lane_row) * 128 + (prep_local_warp * 16 + 8) * 2;
+                        int swizzled_off_3 = byte_off_2 ^ (byte_off_2 >> 7 & 7) << 4;
+                        int d_addr = smem_inv_work_addr + (unsigned int)swizzled_off_3;
+                        int byte_off_0 = (int)prep_stage * 41984 + (prep_local_warp * 16 + 8 + lane_row) * 128 + prep_local_warp * 16 * 2;
+                        int swizzled_off_1_1 = byte_off_0 ^ (byte_off_0 >> 7 & 7) << 4;
+                        int c_addr = smem_inv_work_addr + (unsigned int)swizzled_off_1_1;
+                        int byte_off_2_1 = (int)prep_stage * 41984 + (prep_local_warp * 16 + lane_row) * 128 + prep_local_warp * 16 * 2;
+                        int swizzled_off_3_1 = byte_off_2_1 ^ (byte_off_2_1 >> 7 & 7) << 4;
+                        int a_addr = smem_inv_work_addr + (unsigned int)swizzled_off_3_1;
+                        unsigned int d_frag[2];
+                        unsigned int c_frag[1];
+                        float dc_acc[4];
+                        unsigned int dc_bf16[2];
+                        unsigned int inv_a_frag[1];
+                        float o_acc[4];
+                        unsigned int o_bf16[2];
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x1.shared.b16 {%0}, [%1];\n"
+                            : "=r"(d_frag[0])
+                            : "r"(d_addr)
+                            : "memory");
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x1.shared.b16 {%0}, [%1];\n"
+                            : "=r"(d_frag[1])
+                            : "r"(d_addr)
+                            : "memory");
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x1.trans.shared.b16 {%0}, [%1];\n"
+                            : "=r"(c_frag[0])
+                            : "r"(c_addr)
+                            : "memory");
+                        asm volatile("mma.sync.aligned.m16n8k8.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5}, {%6}, {%7, %8, %9, %10};\n"
+                            : "=f"(dc_acc[0]), "=f"(dc_acc[1]), "=f"(dc_acc[2]), "=f"(dc_acc[3])
+                            : "r"(d_frag[0]), "r"(d_frag[1]), "r"(c_frag[0]), "f"(0.0f), "f"(0.0f), "f"(0.0f), "f"(0.0f));
+                        const float2 _scale2_6 = {-1.0f, -1.0f};
+                        #pragma unroll
+                        for (int _ls = 0; _ls < 2; _ls++)
+                            mul_f32x2_inplace(&reinterpret_cast<float2*>(dc_acc)[_ls], _scale2_6);
+                        #pragma unroll
+                        for (int _lp = 0; _lp < 2; _lp++) {
+                            __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(dc_acc[_lp*2 + 0], dc_acc[_lp*2+1 + 0]));
+                            dc_bf16[_lp] = *(uint32_t*)&_bf2;
+                        }
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x1.trans.shared.b16 {%0}, [%1];\n"
+                            : "=r"(inv_a_frag[0])
+                            : "r"(a_addr)
+                            : "memory");
+                        asm volatile("mma.sync.aligned.m16n8k8.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5}, {%6}, {%7, %8, %9, %10};\n"
+                            : "=f"(o_acc[0]), "=f"(o_acc[1]), "=f"(o_acc[2]), "=f"(o_acc[3])
+                            : "r"(dc_bf16[0]), "r"(dc_bf16[1]), "r"(inv_a_frag[0]), "f"(0.0f), "f"(0.0f), "f"(0.0f), "f"(0.0f));
+                        #pragma unroll
+                        for (int _lp = 0; _lp < 2; _lp++) {
+                            __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(o_acc[_lp*2 + 0], o_acc[_lp*2+1 + 0]));
+                            o_bf16[_lp] = *(uint32_t*)&_bf2;
+                        }
+                        int byte_off_4 = (int)prep_stage * 41984 + (prep_local_warp * 16 + 8 + lane_row) * 128 + prep_local_warp * 16 * 2;
+                        int swizzled_off_5 = byte_off_4 ^ (byte_off_4 >> 7 & 7) << 4;
+                        int o_addr = smem_inv_work_addr + (unsigned int)swizzled_off_5;
+                        uint32_t _stmatrix_addr_7 = static_cast<uint32_t>((unsigned long long)o_addr);
+                        asm volatile("stmatrix.sync.aligned.m8n8.x1.shared.b16 [%0], {%1};\n"
+                            :: "r"(_stmatrix_addr_7), "r"(*reinterpret_cast<const uint32_t*>(&o_bf16[0]))
+                            : "memory");
+                        __syncwarp();
+                        if (elect_sync()) {
+                            mbarrier_arrive(prep_inv16_ready_addr + (prep_stage) * 8);
+                        }
+                        mbarrier_wait(prep_inv16_ready_addr + (prep_stage) * 8, _phase_prep_inv16_ready);
+                    }
+                }
+                {
+                    if (prep_local_warp == 0) {
+                        int lane_row_1 = lane % 16;
+                        int lane_col = lane / 16 * 8;
+                        int byte_off_3 = (int)prep_stage * 41984 + (16 + lane_row_1) * 128 + (16 + lane_col) * 2;
+                        int swizzled_off_4 = byte_off_3 ^ (byte_off_3 >> 7 & 7) << 4;
+                        int d_addr_1 = smem_inv_work_addr + (unsigned int)swizzled_off_4;
+                        int byte_off_0_1 = (int)prep_stage * 41984 + (16 + lane_row_1) * 128 + lane_col * 2;
+                        int swizzled_off_1_2 = byte_off_0_1 ^ (byte_off_0_1 >> 7 & 7) << 4;
+                        int c_addr_1 = smem_inv_work_addr + (unsigned int)swizzled_off_1_2;
+                        int byte_off_2_2 = (int)prep_stage * 41984 + lane_row_1 * 128 + lane_col * 2;
+                        int swizzled_off_3_2 = byte_off_2_2 ^ (byte_off_2_2 >> 7 & 7) << 4;
+                        int a_addr_1 = smem_inv_work_addr + (unsigned int)swizzled_off_3_2;
+                        unsigned int d32_frag[4];
+                        unsigned int c32_frag[4];
+                        float dc32_acc[8];
+                        unsigned int dc32_bf16[4];
+                        unsigned int a32_frag[4];
+                        float o32_acc[8];
+                        unsigned int o32_bf16[4];
+                        unsigned int zero32_bf16[4];
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(d32_frag[0]), "=r"(d32_frag[1]), "=r"(d32_frag[2]), "=r"(d32_frag[3])
+                            : "r"(d_addr_1)
+                            : "memory");
+                        int d_publish_addr = (smem_inv_addr + prep_stage * 41984 + (unsigned int)((16 + lane_col) / 16 * 1024 + (16 + lane_row_1) * 32 + (16 + lane_col) % 16 * 2 ^ ((16 + lane_col) / 16 * 1024 + (16 + lane_row_1) * 32 + (16 + lane_col) % 16 * 2 >> 7 & 1) << 4));
+                        uint32_t _stmatrix_addr_8 = static_cast<uint32_t>((unsigned long long)d_publish_addr);
+                        asm volatile("stmatrix.sync.aligned.m8n8.x4.shared.b16 [%0], {%1, %2, %3, %4};\n"
+                            :: "r"(_stmatrix_addr_8), "r"(*reinterpret_cast<const uint32_t*>(&d32_frag[0])), "r"(*reinterpret_cast<const uint32_t*>(&d32_frag[1])), "r"(*reinterpret_cast<const uint32_t*>(&d32_frag[2])), "r"(*reinterpret_cast<const uint32_t*>(&d32_frag[3]))
+                            : "memory");
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.trans.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(c32_frag[0]), "=r"(c32_frag[1]), "=r"(c32_frag[2]), "=r"(c32_frag[3])
+                            : "r"(c_addr_1)
+                            : "memory");
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%10, %11, %12, %13};\n"
+                            : "=f"(dc32_acc[0]), "=f"(dc32_acc[1]), "=f"(dc32_acc[2]), "=f"(dc32_acc[3])
+                            : "r"(d32_frag[0]), "r"(d32_frag[1]), "r"(d32_frag[2]), "r"(d32_frag[3]), "r"(c32_frag[0]), "r"(c32_frag[1]), "f"(0.0f), "f"(0.0f), "f"(0.0f), "f"(0.0f));
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%10, %11, %12, %13};\n"
+                            : "=f"(dc32_acc[4]), "=f"(dc32_acc[(4) + 1]), "=f"(dc32_acc[(4) + 2]), "=f"(dc32_acc[(4) + 3])
+                            : "r"(d32_frag[0]), "r"(d32_frag[1]), "r"(d32_frag[2]), "r"(d32_frag[3]), "r"(c32_frag[2]), "r"(c32_frag[(2) + 1]), "f"(0.0f), "f"(0.0f), "f"(0.0f), "f"(0.0f));
+                        const float2 _scale2_9 = {-1.0f, -1.0f};
+                        #pragma unroll
+                        for (int _ls = 0; _ls < 4; _ls++)
+                            mul_f32x2_inplace(&reinterpret_cast<float2*>(dc32_acc)[_ls], _scale2_9);
+                        #pragma unroll
+                        for (int _lp = 0; _lp < 4; _lp++) {
+                            __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(dc32_acc[_lp*2 + 0], dc32_acc[_lp*2+1 + 0]));
+                            dc32_bf16[_lp] = *(uint32_t*)&_bf2;
+                        }
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.trans.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(a32_frag[0]), "=r"(a32_frag[1]), "=r"(a32_frag[2]), "=r"(a32_frag[3])
+                            : "r"(a_addr_1)
+                            : "memory");
+                        int a_publish_addr = (smem_inv_addr + prep_stage * 41984 + (unsigned int)(lane_col / 16 * 1024 + lane_row_1 * 32 + lane_col % 16 * 2 ^ (lane_col / 16 * 1024 + lane_row_1 * 32 + lane_col % 16 * 2 >> 7 & 1) << 4));
+                        uint32_t _stmatrix_addr_10 = static_cast<uint32_t>((unsigned long long)a_publish_addr);
+                        asm volatile("stmatrix.sync.aligned.m8n8.x4.trans.shared.b16 [%0], {%1, %2, %3, %4};\n"
+                            :: "r"(_stmatrix_addr_10), "r"(*reinterpret_cast<const uint32_t*>(&a32_frag[0])), "r"(*reinterpret_cast<const uint32_t*>(&a32_frag[1])), "r"(*reinterpret_cast<const uint32_t*>(&a32_frag[2])), "r"(*reinterpret_cast<const uint32_t*>(&a32_frag[3]))
+                            : "memory");
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%10, %11, %12, %13};\n"
+                            : "=f"(o32_acc[0]), "=f"(o32_acc[1]), "=f"(o32_acc[2]), "=f"(o32_acc[3])
+                            : "r"(dc32_bf16[0]), "r"(dc32_bf16[1]), "r"(dc32_bf16[2]), "r"(dc32_bf16[3]), "r"(a32_frag[0]), "r"(a32_frag[1]), "f"(0.0f), "f"(0.0f), "f"(0.0f), "f"(0.0f));
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%10, %11, %12, %13};\n"
+                            : "=f"(o32_acc[4]), "=f"(o32_acc[(4) + 1]), "=f"(o32_acc[(4) + 2]), "=f"(o32_acc[(4) + 3])
+                            : "r"(dc32_bf16[0]), "r"(dc32_bf16[1]), "r"(dc32_bf16[2]), "r"(dc32_bf16[3]), "r"(a32_frag[2]), "r"(a32_frag[(2) + 1]), "f"(0.0f), "f"(0.0f), "f"(0.0f), "f"(0.0f));
+                        #pragma unroll
+                        for (int _lp = 0; _lp < 4; _lp++) {
+                            __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(o32_acc[_lp*2 + 0], o32_acc[_lp*2+1 + 0]));
+                            o32_bf16[_lp] = *(uint32_t*)&_bf2;
+                        }
+                        int o_publish_addr = (smem_inv_addr + prep_stage * 41984 + (unsigned int)(lane_col / 16 * 1024 + (16 + lane_row_1) * 32 + lane_col % 16 * 2 ^ (lane_col / 16 * 1024 + (16 + lane_row_1) * 32 + lane_col % 16 * 2 >> 7 & 1) << 4));
+                        uint32_t _stmatrix_addr_11 = static_cast<uint32_t>((unsigned long long)o_publish_addr);
+                        asm volatile("stmatrix.sync.aligned.m8n8.x4.shared.b16 [%0], {%1, %2, %3, %4};\n"
+                            :: "r"(_stmatrix_addr_11), "r"(*reinterpret_cast<const uint32_t*>(&o32_bf16[0])), "r"(*reinterpret_cast<const uint32_t*>(&o32_bf16[1])), "r"(*reinterpret_cast<const uint32_t*>(&o32_bf16[2])), "r"(*reinterpret_cast<const uint32_t*>(&o32_bf16[3]))
+                            : "memory");
+                        #pragma unroll
+                        for (int zero_word = 0; zero_word < 4; zero_word++) {
+                            zero32_bf16[zero_word] = 0;
+                        }
+                        int zero_publish_addr = (smem_inv_addr + prep_stage * 41984 + (unsigned int)((16 + lane_col) / 16 * 1024 + lane_row_1 * 32 + (16 + lane_col) % 16 * 2 ^ ((16 + lane_col) / 16 * 1024 + lane_row_1 * 32 + (16 + lane_col) % 16 * 2 >> 7 & 1) << 4));
+                        uint32_t _stmatrix_addr_12 = static_cast<uint32_t>((unsigned long long)zero_publish_addr);
+                        asm volatile("stmatrix.sync.aligned.m8n8.x4.shared.b16 [%0], {%1, %2, %3, %4};\n"
+                            :: "r"(_stmatrix_addr_12), "r"(*reinterpret_cast<const uint32_t*>(&zero32_bf16[0])), "r"(*reinterpret_cast<const uint32_t*>(&zero32_bf16[1])), "r"(*reinterpret_cast<const uint32_t*>(&zero32_bf16[2])), "r"(*reinterpret_cast<const uint32_t*>(&zero32_bf16[3]))
+                            : "memory");
+                    }
+                }
+                asm volatile("fence.proxy.async.shared::cta;" ::: "memory");
+                asm volatile("barrier.sync %0, 128;" :: "r"(10 + prep_instance) : "memory");
+                if (prep_local_warp == 0) {
+                    if (elect_sync()) {
+                        {
+                            mbarrier_arrive(qk_full_addr + (prep_stage) * 8);
+                        }
+                        {
+                            mbarrier_arrive(tape_ready_addr + (prep_stage) * 8);
+                        }
+                    }
+                }
+                {
+                    mbarrier_wait(tape_free_addr + (prep_stage) * 8, _phase_tape_free);
+                }
+                if (chunk_is_full_1 != 0) {
+                    if (prep_local_warp == 0) {
+                        if (elect_sync()) {
+                            mbarrier_arrive_expect_tx(v_full_addr + (prep_stage) * 8, 8192);
+                            {
+                                tma_3d_gmem2smem(smem_v_addr + prep_stage * 41984, v_tma, 0, head_idx_4, (int)(bos_4 + (long long)(chunk_idx_3 * 32)), v_full_addr + (prep_stage) * 8);
+                            }
+                        }
+                    }
+                } else {
+                    #pragma unroll
+                    for (int v_load_iter = 0; v_load_iter < 4; v_load_iter++) {
+                        int v_item = v_load_iter * 128 + prep_tid;
+                        int row_1 = v_item / 16;
+                        int segment_1 = v_item % 16;
+                        long long token_1 = bos_4 + (long long)(chunk_idx_3 * 32 + row_1);
+                        int token_valid_1 = ((token_1 < eos_4) ? 1 : 0);
+                        long long v_src = (token_1 * (long long)num_heads + (long long)head_idx_4) * 128 + (long long)(segment_1 * 8);
+                        int v_dst = smem_v_addr + prep_stage * 41984 + (unsigned int)((row_1 * 128 + segment_1 * 8) * 2);
+                        asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16, %2;"
+                            :: "r"(v_dst), "l"(v + v_src), "r"((token_valid_1 != 0) ? 16 : 0));
+                    }
+                    asm volatile("cp.async.commit_group;");
+                    asm volatile("cp.async.wait_group 0;");
+                    asm volatile("barrier.sync %0, 128;" :: "r"(10 + prep_instance) : "memory");
+                    if (prep_local_warp == 0) {
+                        if (elect_sync()) {
+                            asm volatile("fence.proxy.async.shared::cta;" ::: "memory");
+                            mbarrier_arrive(v_full_addr + (prep_stage) * 8);
+                        }
+                    }
+                }
+                for (int _advance = 0; _advance < 5; _advance++) {
+                    prep_stage += 1;
+                    if (prep_stage == 5) { prep_stage = 0; _phase_raw_inputs_free ^= 1; _phase_gate_raw_full ^= 1; _phase_smem_free ^= 1; _phase_v_free ^= 1; _phase_qk_raw_full ^= 1; _phase_short_beta_ready ^= 1; _phase_prep_diag_ready ^= 1; _phase_prep_inv16_ready ^= 1; _phase_tape_free ^= 1; }
+                }
+            }
+        }
+    }
+
+    // Cleanup
+}
+
+} // extern "C"
+
+#undef LOOM_INF
+#undef NUM_CHECKPOINT_PIPE_STAGES
+#undef NUM_CHUNK_PIPE_STAGES
+#undef SMEM_SMEM_BETA_RAW_ALL_OFF
+#undef SMEM_SMEM_BETA_RAW_ALL_STAGE_BYTES
+#undef SMEM_SMEM_BETA_RAW_ALL_STRIDE
+#undef SMEM_SMEM_BETA_RAW_OFF
+#undef SMEM_SMEM_BETA_RAW_STAGE_BYTES
+#undef SMEM_SMEM_BETA_RAW_STRIDE
+#undef SMEM_SMEM_CHECKPOINT_OFF
+#undef SMEM_SMEM_CHECKPOINT_STAGE_BYTES
+#undef SMEM_SMEM_CHECKPOINT_STRIDE
+#undef SMEM_SMEM_FINAL_TRANS_OFF
+#undef SMEM_SMEM_FINAL_TRANS_STAGE_BYTES
+#undef SMEM_SMEM_FINAL_TRANS_STRIDE
+#undef SMEM_SMEM_GATE_ALL_OFF
+#undef SMEM_SMEM_GATE_ALL_STAGE_BYTES
+#undef SMEM_SMEM_GATE_ALL_STRIDE
+#undef SMEM_SMEM_GATE_BIAS_ALL_OFF
+#undef SMEM_SMEM_GATE_BIAS_ALL_STAGE_BYTES
+#undef SMEM_SMEM_GATE_BIAS_ALL_STRIDE
+#undef SMEM_SMEM_GATE_OFF
+#undef SMEM_SMEM_GATE_RATE_ALL_OFF
+#undef SMEM_SMEM_GATE_RATE_ALL_STAGE_BYTES
+#undef SMEM_SMEM_GATE_RATE_ALL_STRIDE
+#undef SMEM_SMEM_GATE_STAGE_BYTES
+#undef SMEM_SMEM_GATE_STRIDE
+#undef SMEM_SMEM_GT_ALL_OFF
+#undef SMEM_SMEM_GT_ALL_STAGE_BYTES
+#undef SMEM_SMEM_GT_ALL_STRIDE
+#undef SMEM_SMEM_GT_PREFIX_ALL_OFF
+#undef SMEM_SMEM_GT_PREFIX_ALL_STAGE_BYTES
+#undef SMEM_SMEM_GT_PREFIX_ALL_STRIDE
+#undef SMEM_SMEM_G_RAW_ALL_OFF
+#undef SMEM_SMEM_G_RAW_ALL_STAGE_BYTES
+#undef SMEM_SMEM_G_RAW_ALL_STRIDE
+#undef SMEM_SMEM_G_RAW_OFF
+#undef SMEM_SMEM_G_RAW_STAGE_BYTES
+#undef SMEM_SMEM_G_RAW_STRIDE
+#undef SMEM_SMEM_INV_OFF
+#undef SMEM_SMEM_INV_STAGE_BYTES
+#undef SMEM_SMEM_INV_STRIDE
+#undef SMEM_SMEM_INV_WORK_OFF
+#undef SMEM_SMEM_INV_WORK_STAGE_BYTES
+#undef SMEM_SMEM_INV_WORK_STRIDE
+#undef SMEM_SMEM_KD_OFF
+#undef SMEM_SMEM_KD_STAGE_BYTES
+#undef SMEM_SMEM_KD_STRIDE
+#undef SMEM_SMEM_KI_OFF
+#undef SMEM_SMEM_KI_STAGE_BYTES
+#undef SMEM_SMEM_KI_STRIDE
+#undef SMEM_SMEM_KR_TRANS_OFF
+#undef SMEM_SMEM_KR_TRANS_STAGE_BYTES
+#undef SMEM_SMEM_KR_TRANS_STRIDE
+#undef SMEM_SMEM_MQK_TRANS_OFF
+#undef SMEM_SMEM_MQK_TRANS_STAGE_BYTES
+#undef SMEM_SMEM_MQK_TRANS_STRIDE
+#undef SMEM_SMEM_OUT_OFF
+#undef SMEM_SMEM_OUT_STAGE_BYTES
+#undef SMEM_SMEM_OUT_STRIDE
+#undef SMEM_SMEM_PREP_BETA_ALL_OFF
+#undef SMEM_SMEM_PREP_BETA_ALL_STAGE_BYTES
+#undef SMEM_SMEM_PREP_BETA_ALL_STRIDE
+#undef SMEM_SMEM_PREP_BETA_BF16_ALL_OFF
+#undef SMEM_SMEM_PREP_BETA_BF16_ALL_STAGE_BYTES
+#undef SMEM_SMEM_PREP_BETA_BF16_ALL_STRIDE
+#undef SMEM_SMEM_PREP_BETA_U32_ALL_OFF
+#undef SMEM_SMEM_PREP_BETA_U32_ALL_STAGE_BYTES
+#undef SMEM_SMEM_PREP_BETA_U32_ALL_STRIDE
+#undef SMEM_SMEM_QD_OFF
+#undef SMEM_SMEM_QD_STAGE_BYTES
+#undef SMEM_SMEM_QD_STRIDE
+#undef SMEM_SMEM_Q_RAW_PREFETCH_OFF
+#undef SMEM_SMEM_Q_RAW_PREFETCH_STAGE_BYTES
+#undef SMEM_SMEM_Q_RAW_PREFETCH_STRIDE
+#undef SMEM_SMEM_RESTORE_FACTOR_ALL_OFF
+#undef SMEM_SMEM_RESTORE_FACTOR_ALL_STAGE_BYTES
+#undef SMEM_SMEM_RESTORE_FACTOR_ALL_STRIDE
+#undef SMEM_SMEM_SHORT_N32_V_OFF
+#undef SMEM_SMEM_SHORT_N32_V_STAGE_BYTES
+#undef SMEM_SMEM_SHORT_N32_V_STRIDE
+#undef SMEM_SMEM_STATE_CHECKPOINT_NEEDED_OFF
+#undef SMEM_SMEM_STATE_CHECKPOINT_NEEDED_STAGE_BYTES
+#undef SMEM_SMEM_STATE_CHECKPOINT_NEEDED_STRIDE
+#undef SMEM_SMEM_V_ALL_OFF
+#undef SMEM_SMEM_V_ALL_STAGE_BYTES
+#undef SMEM_SMEM_V_ALL_STRIDE
+#undef SMEM_SMEM_V_OFF
+#undef SMEM_SMEM_V_STAGE_BYTES
+#undef SMEM_SMEM_V_STRIDE
+#undef SMEM_SMEM_WORK_ITEM_COMPUTE_START_OFF
+#undef SMEM_SMEM_WORK_ITEM_COMPUTE_START_STAGE_BYTES
+#undef SMEM_SMEM_WORK_ITEM_COMPUTE_START_STRIDE
+#undef SMEM_SMEM_WORK_ITEM_RESOLVED_OFF
+#undef SMEM_SMEM_WORK_ITEM_RESOLVED_STAGE_BYTES
+#undef SMEM_SMEM_WORK_ITEM_RESOLVED_STRIDE
+#undef SMEM_SMEM_WORK_ITEM_WARP_MAX_OFF
+#undef SMEM_SMEM_WORK_ITEM_WARP_MAX_STAGE_BYTES
+#undef SMEM_SMEM_WORK_ITEM_WARP_MAX_STRIDE
+#undef SMEM_TOTAL
+#undef SPLIT_WORK_ITEMS
+#undef STORE_BACKWARD_TAPE
+#undef STORE_E_TAPE
+#undef TMEM_NCOLS
+#undef TMEM_TMEM_OUT_OFFSET
+#undef TMEM_TMEM_STATE_INP_OFFSET
+#undef TMEM_TMEM_STATE_OFFSET
+#undef TMEM_TMEM_STATE_OUT_OFFSET
+#undef TMEM_TMEM_U2_ACC_OFFSET
+#undef TMEM_TMEM_U2_INP_OFFSET
+#undef TMEM_TMEM_U_ACC_OFFSET
+#undef checkpoint_free_addr
+#undef checkpoint_ready_addr
+#undef final_ready_addr
+#undef gate_raw_full_addr
+#undef old_out_ready_addr
+#undef out_empty_addr
+#undef prep_diag_ready_addr
+#undef prep_inv16_ready_addr
+#undef qk_full_addr
+#undef qk_raw_full_addr
+#undef raw_inputs_free_addr
+#undef short_beta_ready_addr
+#undef smem_beta_raw_addr
+#undef smem_beta_raw_all_addr
+#undef smem_checkpoint_addr
+#undef smem_final_trans_addr
+#undef smem_free_addr
+#undef smem_g_raw_addr
+#undef smem_g_raw_all_addr
+#undef smem_gate_addr
+#undef smem_gate_all_addr
+#undef smem_gate_bias_all_addr
+#undef smem_gate_rate_all_addr
+#undef smem_gt_all_addr
+#undef smem_gt_prefix_all_addr
+#undef smem_inv_addr
+#undef smem_inv_work_addr
+#undef smem_kd_addr
+#undef smem_ki_addr
+#undef smem_kr_trans_addr
+#undef smem_mqk_trans_addr
+#undef smem_out_addr
+#undef smem_prep_beta_all_addr
+#undef smem_prep_beta_bf16_all_addr
+#undef smem_prep_beta_u32_all_addr
+#undef smem_q_raw_prefetch_addr
+#undef smem_qd_addr
+#undef smem_restore_factor_all_addr
+#undef smem_short_n32_v_addr
+#undef smem_state_checkpoint_needed_addr
+#undef smem_v_addr
+#undef smem_v_all_addr
+#undef smem_work_item_compute_start_addr
+#undef smem_work_item_resolved_addr
+#undef smem_work_item_warp_max_addr
+#undef state_inp_ready_addr
+#undef tape_free_addr
+#undef tape_ready_addr
+#undef tmem_dealloc_ready_addr
+#undef u2_acc_ready_addr
+#undef u2_inp_ready_addr
+#undef u_inp_ready_addr
+#undef v_free_addr
+#undef v_full_addr
+#undef work_item_ready_addr
+
+#define LOOM_INF CUDART_INF_F
+#define NUM_MAIN_STAGES 1
+#define SMEM_ANY_FALLBACK_OFF 0
+#define SMEM_ANY_FALLBACK_STAGE_BYTES 4
+#define SMEM_ANY_FALLBACK_STRIDE 4
+#define SMEM_TOTAL 128
+#define THREADS 256
+#define C 32
+#define K 128
+#define V 128
+
+extern "C" {
+
+__global__ __launch_bounds__(256) void
+kernel_flashkda_backward_state_checkpoint_fallback_c32(long long* __restrict__ cu_seqlens, long long* __restrict__ cu_chunk_offsets, unsigned int* __restrict__ state_checkpoint_needed, float* __restrict__ initial_state, __nv_bfloat16* __restrict__ tape_kr, float* __restrict__ tape_restore_factor, __nv_bfloat16* __restrict__ tape_r, __nv_bfloat16* __restrict__ chunk_state, int num_sequences, int num_heads, int num_work_items, float lower_bound, int scan_chunk_flags)
+{
+    const int tid = threadIdx.x;
+    const int warp = make_warp_uniform(tid / 32);
+    const int lane = tid % 32;
+
+    extern __shared__ __align__(1024) char smem_raw[];
+    int smem;
+    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+
+    const int bid = blockIdx.x;
+    const int num_bids = gridDim.x;
+
+    // Kernel setup ops
+    unsigned int* any_fallback = reinterpret_cast<unsigned int*>(smem_raw + 0);
+    const int any_fallback_addr = smem + 0;
+
+    // === Task calls (dependency order) ===
+    long long total_chunks = cu_chunk_offsets[num_sequences];
+    int num_tasks = num_sequences * num_heads;
+    long long num_chunk_heads = total_chunks * (long long)num_heads;
+    if (tid == 0) {
+        any_fallback[0] = 0;
+    }
+    asm volatile("barrier.sync 1, 256;" ::: "memory");
+    if (scan_chunk_flags != 0) {
+        #pragma unroll 1
+        for (int scan_work_item = tid; scan_work_item < num_work_items; scan_work_item += 256) {
+            if (state_checkpoint_needed[num_chunk_heads + (long long)scan_work_item] != 0) {
+                atomicAdd(&any_fallback[0], 1);
+            }
+        }
+    } else {
+        #pragma unroll 1
+        for (int scan_task = tid; scan_task < num_tasks; scan_task += 256) {
+            if (state_checkpoint_needed[num_chunk_heads + (long long)scan_task] != 0) {
+                atomicAdd(&any_fallback[0], 1);
+            }
+        }
+    }
+    asm volatile("barrier.sync 2, 256;" ::: "memory");
+    if (any_fallback[0] != 0) {
+        #pragma unroll 1
+        for (int task = 0; task < num_tasks; task++) {
+            int sequence = task / num_heads;
+            int head = task - sequence * num_heads;
+            long long bos = cu_seqlens[sequence];
+            long long eos = cu_seqlens[sequence + 1];
+            int num_chunks = ((int)(eos - bos) + C - 1) / C;
+            unsigned int head_fallback_needed = 0;
+            if (scan_chunk_flags != 0) {
+                #pragma unroll 1
+                for (int scan_chunk = 0; scan_chunk < num_chunks; scan_chunk++) {
+                    long long scan_chunk_global = cu_chunk_offsets[sequence] + (long long)scan_chunk;
+                    if (state_checkpoint_needed[scan_chunk_global * (long long)num_heads + (long long)head] != 0) {
+                        head_fallback_needed = 1;
+                    }
+                }
+            } else {
+                head_fallback_needed = state_checkpoint_needed[num_chunk_heads + (long long)task];
+            }
+            if (head_fallback_needed != 0) {
+                int key_base = lane * 4;
+                long long initial_base = ((long long)sequence * (long long)num_heads + (long long)head) * (long long)V * (long long)K;
+                float _expf_0 = __expf(lower_bound * (float)(C / 2));
+                float common_decay = _expf_0;
+                int warp_id_in_role = (warp - 0);
+                #pragma unroll 1
+                for (int value_row = warp_id_in_role; value_row < V; value_row += 8) {
+                    float state[4];
+                    long long initial_row_base = initial_base + (long long)value_row * (long long)K + (long long)key_base;
+                    {
+                        float4 _v4 = *reinterpret_cast<const float4*>(initial_state + initial_row_base);
+                        state[0 + 0] = _v4.x;
+                        state[0 + 1] = _v4.y;
+                        state[0 + 2] = _v4.z;
+                        state[0 + 3] = _v4.w;
+                    }
+                    #pragma unroll
+                    for (int key_elem = 0; key_elem < 4; key_elem++) {
+                        __nv_bfloat16 _cvt_bf16_0 = __float2bfloat16(state[key_elem]);
+                        float _cvt_f32_0 = __bfloat162float(_cvt_bf16_0);
+                        state[key_elem] = _cvt_f32_0;
+                    }
+                    #pragma unroll 1
+                    for (int local_chunk = 0; local_chunk < num_chunks; local_chunk++) {
+                        long long chunk_global = cu_chunk_offsets[sequence] + (long long)local_chunk;
+                        long long chunk_head = chunk_global * (long long)num_heads + (long long)head;
+                        long long restore_base = chunk_head * (long long)K + (long long)key_base;
+                        float restore_values[4];
+                        {
+                            float4 _v4 = *reinterpret_cast<const float4*>(tape_restore_factor + restore_base);
+                            restore_values[0 + 0] = _v4.x;
+                            restore_values[0 + 1] = _v4.y;
+                            restore_values[0 + 2] = _v4.z;
+                            restore_values[0 + 3] = _v4.w;
+                        }
+                        #pragma unroll
+                        for (int key_elem2 = 0; key_elem2 < 4; key_elem2++) {
+                            state[key_elem2] = state[key_elem2] * (restore_values[key_elem2] * common_decay);
+                        }
+                        long long kr_base = chunk_head * (long long)C * (long long)K + (long long)key_base;
+                        long long r_base = (chunk_head * (long long)V + (long long)value_row) * (long long)C;
+                        #pragma unroll
+                        for (int token_local = 0; token_local < C; token_local++) {
+                            float kr_values[4];
+                            {
+                                uint2 _vld_2;
+                                _vld_2 = *reinterpret_cast<const uint2*>(tape_kr + kr_base + (long long)(token_local * K));
+                                uint32_t* _vpairs_2 = reinterpret_cast<uint32_t*>(&_vld_2);
+                                #pragma unroll
+                                for (int _pair = 0; _pair < 2; _pair++) {
+                                    asm volatile(
+                                        "{\n\t"
+                                        "shl.b32 %0, %2, 16;\n\t"
+                                        "and.b32 %1, %2, 0xffff0000;\n\t"
+                                        "}\n"
+                                        : "=f"((&kr_values[0 + _pair * 2])[0]), "=f"((&kr_values[0 + _pair * 2])[1])
+                                        : "r"(_vpairs_2[_pair]));
+                                }
+                            }
+                            float r_value = (float)tape_r[r_base + (long long)token_local];
+                            #pragma unroll
+                            for (int key_elem3 = 0; key_elem3 < 4; key_elem3++) {
+                                float _fma_0 = __fmaf_rn(r_value, kr_values[key_elem3], state[key_elem3]);
+                                state[key_elem3] = _fma_0;
+                            }
+                        }
+                        if (num_chunks > local_chunk + 1) {
+                            long long next_chunk_global = chunk_global + 1;
+                            long long next_chunk_head = next_chunk_global * (long long)num_heads + (long long)head;
+                            if (state_checkpoint_needed[next_chunk_head] != 0) {
+                                long long checkpoint_base = (next_chunk_head * (long long)V + (long long)value_row) * (long long)K + (long long)key_base;
+                                {
+                                    uint2 _pk2;
+                                    __nv_bfloat162* _pk = reinterpret_cast<__nv_bfloat162*>(&_pk2);
+                                    _pk[0] = __floats2bfloat162_rn(state[0 + 0], state[0 + 1]);
+                                    _pk[1] = __floats2bfloat162_rn(state[0 + 2], state[0 + 3]);
+                                    *reinterpret_cast<uint2*>(&((__nv_bfloat16*)(chunk_state + checkpoint_base))[0]) = _pk2;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+} // extern "C"
+
+#undef C
+#undef K
+#undef LOOM_INF
+#undef NUM_MAIN_STAGES
+#undef SMEM_ANY_FALLBACK_OFF
+#undef SMEM_ANY_FALLBACK_STAGE_BYTES
+#undef SMEM_ANY_FALLBACK_STRIDE
+#undef SMEM_TOTAL
+#undef THREADS
+#undef V
+#undef any_fallback_addr
+
+#define LOOM_INF CUDART_INF_F
+#define TMEM_NCOLS 256
+#define TMEM_TMEM_DH_OFFSET 64
+#define TMEM_TMEM_DH_INP_OFFSET 0
+#define TMEM_TMEM_DO_INITIAL_OFFSET 224
+#define TMEM_TMEM_DO_FINAL_OFFSET 0
+#define TMEM_TMEM_DR_OFFSET 192
+#define TMEM_TMEM_DR_INP_OFFSET 192
+#define TMEM_TMEM_DX_OFFSET 224
+#define TMEM_TMEM_DE_INP_OFFSET 224
+#define NUM_REVERSE_PIPE_STAGES 1
+#define SMEM_SMEM_QD_OFF 1024
+#define SMEM_SMEM_QD_STAGE_BYTES 8192
+#define SMEM_SMEM_QD_STRIDE 8192
+#define SMEM_SMEM_QD_TRANS_OFF 1024
+#define SMEM_SMEM_QD_TRANS_STAGE_BYTES 8192
+#define SMEM_SMEM_QD_TRANS_STRIDE 8192
+#define SMEM_SMEM_KD_OFF 9216
+#define SMEM_SMEM_KD_STAGE_BYTES 8192
+#define SMEM_SMEM_KD_STRIDE 8192
+#define SMEM_SMEM_KD_TRANS_OFF 9216
+#define SMEM_SMEM_KD_TRANS_STAGE_BYTES 8192
+#define SMEM_SMEM_KD_TRANS_STRIDE 8192
+#define SMEM_SMEM_KR_OFF 17408
+#define SMEM_SMEM_KR_STAGE_BYTES 8192
+#define SMEM_SMEM_KR_STRIDE 8192
+#define SMEM_SMEM_KI_OFF 25600
+#define SMEM_SMEM_KI_STAGE_BYTES 8192
+#define SMEM_SMEM_KI_STRIDE 8192
+#define SMEM_SMEM_J_OFF 33792
+#define SMEM_SMEM_J_STAGE_BYTES 2048
+#define SMEM_SMEM_J_STRIDE 2048
+#define SMEM_SMEM_J_TRANS_OFF 33792
+#define SMEM_SMEM_J_TRANS_STAGE_BYTES 2048
+#define SMEM_SMEM_J_TRANS_STRIDE 2048
+#define SMEM_SMEM_N_OFF 35840
+#define SMEM_SMEM_N_STAGE_BYTES 2048
+#define SMEM_SMEM_N_STRIDE 2048
+#define SMEM_SMEM_WORK_ITEM_WARP_MAX_OFF 37888
+#define SMEM_SMEM_WORK_ITEM_WARP_MAX_STAGE_BYTES 16
+#define SMEM_SMEM_WORK_ITEM_WARP_MAX_STRIDE 16
+#define SMEM_SMEM_WORK_ITEM_COMPUTE_END_OFF 37904
+#define SMEM_SMEM_WORK_ITEM_COMPUTE_END_STAGE_BYTES 4
+#define SMEM_SMEM_WORK_ITEM_COMPUTE_END_STRIDE 4
+#define SMEM_SMEM_WORK_ITEM_RESOLVED_OFF 37908
+#define SMEM_SMEM_WORK_ITEM_RESOLVED_STAGE_BYTES 4
+#define SMEM_SMEM_WORK_ITEM_RESOLVED_STRIDE 4
+#define SMEM_TOTAL 38016
+#define THREADS 288
+
+extern "C" {
+
+__global__ __launch_bounds__(288) void
+kernel_flashkda_backward_boundary_c32_tcgen_m64(__nv_bfloat16* __restrict__ do_, float* __restrict__ dfinal_state, float* __restrict__ beta_active, long long* __restrict__ cu_seqlens, long long* __restrict__ cu_chunk_offsets, int* __restrict__ work_items, __nv_bfloat16* __restrict__ tape_qd, __nv_bfloat16* __restrict__ tape_kd, __nv_bfloat16* __restrict__ tape_kr, __nv_bfloat16* __restrict__ tape_j, float* __restrict__ tape_restore_factor, __nv_bfloat16* __restrict__ chunk_dh, __nv_bfloat16* __restrict__ chunk_dr, __nv_bfloat16* __restrict__ chunk_dx, float* __restrict__ dinitial_state, unsigned int* __restrict__ boundary_ready, int num_heads, int publish_ready, float lower_bound)
+{
+    const int tid = threadIdx.x;
+    const int warp = make_warp_uniform(tid / 32);
+    const int lane = tid % 32;
+
+    extern __shared__ __align__(1024) char smem_raw[];
+    int smem;
+    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+
+    const int bid = blockIdx.x;
+    const int num_bids = gridDim.x;
+
+    // Kernel setup ops
+    __nv_bfloat16* smem_qd = reinterpret_cast<__nv_bfloat16*>(smem_raw + 1024);
+    const int smem_qd_addr = smem + 1024;
+    __nv_bfloat16* smem_qd_trans = reinterpret_cast<__nv_bfloat16*>(smem_raw + 1024);
+    const int smem_qd_trans_addr = smem + 1024;
+    __nv_bfloat16* smem_kd = reinterpret_cast<__nv_bfloat16*>(smem_raw + 9216);
+    const int smem_kd_addr = smem + 9216;
+    __nv_bfloat16* smem_kd_trans = reinterpret_cast<__nv_bfloat16*>(smem_raw + 9216);
+    const int smem_kd_trans_addr = smem + 9216;
+    __nv_bfloat16* smem_kr = reinterpret_cast<__nv_bfloat16*>(smem_raw + 17408);
+    const int smem_kr_addr = smem + 17408;
+    __nv_bfloat16* smem_ki = reinterpret_cast<__nv_bfloat16*>(smem_raw + 25600);
+    const int smem_ki_addr = smem + 25600;
+    __nv_bfloat16* smem_j = reinterpret_cast<__nv_bfloat16*>(smem_raw + 33792);
+    const int smem_j_addr = smem + 33792;
+    __nv_bfloat16* smem_j_trans = reinterpret_cast<__nv_bfloat16*>(smem_raw + 33792);
+    const int smem_j_trans_addr = smem + 33792;
+    __nv_bfloat16* smem_n = reinterpret_cast<__nv_bfloat16*>(smem_raw + 35840);
+    const int smem_n_addr = smem + 35840;
+    float* smem_work_item_warp_max = reinterpret_cast<float*>(smem_raw + 37888);
+    const int smem_work_item_warp_max_addr = smem + 37888;
+    int* smem_work_item_compute_end = reinterpret_cast<int*>(smem_raw + 37904);
+    const int smem_work_item_compute_end_addr = smem + 37904;
+    unsigned int* smem_work_item_resolved = reinterpret_cast<unsigned int*>(smem_raw + 37908);
+    const int smem_work_item_resolved_addr = smem + 37908;
+
+    // Mbarrier init (10 groups, 10 barriers)
+    // Mbarriers at smem_raw[0..80)
+
+    if (warp == 0) {
+        uint32_t leader = elect_sync();
+        if (leader) {
+            // --- pipeline 'reverse_pipe' ---
+            // prep_ready: 1 barriers, init_count=1
+            mbarrier_init(smem + 0, 1);
+            // smem_free: 1 barriers, init_count=1
+            mbarrier_init(smem + 8, 1);
+            // inputs_ready: 1 barriers, init_count=4
+            mbarrier_init(smem + 16, 4);
+            // dr_ready: 1 barriers, init_count=1
+            mbarrier_init(smem + 24, 1);
+            // dr_inp_ready: 1 barriers, init_count=4
+            mbarrier_init(smem + 32, 4);
+            // dx_ready: 1 barriers, init_count=1
+            mbarrier_init(smem + 40, 1);
+            // de_inp_ready: 1 barriers, init_count=4
+            mbarrier_init(smem + 48, 4);
+            // dh_ready: 1 barriers, init_count=1
+            mbarrier_init(smem + 56, 1);
+            // compute_done: 1 barriers, init_count=4
+            mbarrier_init(smem + 64, 4);
+            // work_item_ready: 1 barriers, init_count=1
+            mbarrier_init(smem + 72, 1);
+            asm volatile("fence.mbarrier_init.release.cluster;");
+        }
+    }
+
+    __syncwarp();
+
+    // TMEM alloc (256 columns, 256 used)
+    volatile int* tmem_addr_storage = (volatile int*)(smem_raw + 80);
+    if (warp == 0) {
+        int _tmem_hold = smem + 80;
+        asm volatile("tcgen05.alloc.cta_group::1.sync.aligned.shared::cta.b32 [%0], %1;" :: "r"(_tmem_hold), "r"(256) : "memory");
+        asm volatile("tcgen05.relinquish_alloc_permit.cta_group::1.sync.aligned;");
+    }
+
+    __syncthreads();
+    asm volatile("tcgen05.fence::after_thread_sync;");
+
+    const int mbar_base = smem;
+    #define prep_ready_addr (mbar_base + 0)
+    #define smem_free_addr (mbar_base + 8)
+    #define inputs_ready_addr (mbar_base + 16)
+    #define dr_ready_addr (mbar_base + 24)
+    #define dr_inp_ready_addr (mbar_base + 32)
+    #define dx_ready_addr (mbar_base + 40)
+    #define de_inp_ready_addr (mbar_base + 48)
+    #define dh_ready_addr (mbar_base + 56)
+    #define compute_done_addr (mbar_base + 64)
+    #define work_item_ready_addr (mbar_base + 72)
+    const int taddr = tmem_addr_storage[0];
+
+    // Kernel post-init ops
+    const int tmem_tmem_dh = taddr + 64;
+    const int tmem_tmem_dh_inp = taddr;
+    const int tmem_tmem_do_initial = taddr + 224;
+    const int tmem_tmem_do_final = taddr;
+    const int tmem_tmem_dr = taddr + 192;
+    const int tmem_tmem_dr_inp = taddr + 192;
+    const int tmem_tmem_dx = taddr + 224;
+    const int tmem_tmem_de_inp = taddr + 224;
+
+    // ---- Register redistribution for WGs split across roles ----
+    // Dec phase frees registers before any WG attempts inc.
+    if (warp >= 8 && warp <= 11) {
+        asm volatile("setmaxnreg.dec.sync.aligned.u32 112;");
+    }
+
+    // ---- Role: compute ----
+    if (warp <= 3) {
+        asm volatile("setmaxnreg.inc.sync.aligned.u32 224;");
+        { // compute_main
+            int split_task_idx = blockIdx.x;
+            int task_idx = split_task_idx / 2;
+            int value_split_idx = split_task_idx % 2;
+            int value_row_offset = value_split_idx * 64;
+            int item_base = task_idx * 5;
+            int seq_idx = work_items[item_base];
+            int head_idx = work_items[item_base + 1];
+            int write_start = work_items[item_base + 2];
+            int write_end = work_items[item_base + 3];
+            long long bos = cu_seqlens[seq_idx];
+            long long eos = cu_seqlens[seq_idx + 1];
+            int seq_len = (int)(eos - bos);
+            int num_chunks = (seq_len + 32 - 1) / 32;
+            int compute_end = num_chunks;
+            int warp_in_wg = warp % 4;
+            int scan_dim = warp_in_wg * 32 + lane;
+            if (scan_dim == 0) {
+                smem_work_item_compute_end[0] = num_chunks;
+                smem_work_item_resolved[0] = 0;
+            }
+            asm volatile("barrier.sync 10, 128;" ::: "memory");
+            float suffix_log2 = 0.0f;
+            int _min_0 = ((num_chunks - write_end) < (32) ? (num_chunks - write_end) : (32));
+            int suffix_limit = _min_0;
+            float common_log2 = lower_bound * 1.4426950408889634f * 16.0f;
+            #pragma unroll 1
+            for (int suffix_chunks = 1; suffix_chunks < suffix_limit + 1; suffix_chunks++) {
+                if (smem_work_item_resolved[0] == 0) {
+                    int suffix_chunk = write_end + suffix_chunks - 1;
+                    long long suffix_global = cu_chunk_offsets[seq_idx] + (long long)suffix_chunk;
+                    float suffix_restore = tape_restore_factor[(suffix_global * (long long)num_heads + (long long)head_idx) * 128 + (long long)scan_dim];
+                    float _log2_0;
+                    asm volatile("lg2.approx.ftz.f32 %0, %1;" : "=f"(_log2_0) : "f"(suffix_restore));
+                    suffix_log2 += _log2_0 + common_log2;
+                    float _warp_reduce_0 = suffix_log2;
+                    #pragma unroll
+                    for (int offset = 16; offset > 0; offset >>= 1)
+                        _warp_reduce_0 = max_noftz(_warp_reduce_0, __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset));
+                    float suffix_warp_max = _warp_reduce_0;
+                    if (lane == 0) {
+                        smem_work_item_warp_max[warp_in_wg] = suffix_warp_max;
+                    }
+                    asm volatile("barrier.sync 10, 128;" ::: "memory");
+                    float suffix_block_max = ((lane < 4) ? smem_work_item_warp_max[lane] : -LOOM_INF);
+                    float _warp_reduce_1 = suffix_block_max;
+                    #pragma unroll
+                    for (int offset = 16; offset > 0; offset >>= 1)
+                        _warp_reduce_1 = max_noftz(_warp_reduce_1, __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_1, offset));
+                    suffix_block_max = _warp_reduce_1;
+                    if (scan_dim == 0 && suffix_block_max <= -30.0f) {
+                        smem_work_item_compute_end[0] = suffix_chunk + 1;
+                        smem_work_item_resolved[0] = 1;
+                    }
+                    asm volatile("barrier.sync 10, 128;" ::: "memory");
+                }
+            }
+            compute_end = smem_work_item_compute_end[0];
+            if (warp_in_wg == 0) {
+                if (elect_sync()) {
+                    mbarrier_arrive(work_item_ready_addr);
+                }
+            }
+            int scan_chunks = compute_end - write_start;
+            int lane_quad = lane & 3;
+            int local_row_top = warp_in_wg * 16 + lane / 4;
+            int local_row_bot = local_row_top + 8;
+            int state_row_top = value_row_offset + local_row_top;
+            int state_row_bot = value_row_offset + local_row_bot;
+            const int tmem_row_base = warp_in_wg * 32 << 16;
+            long long state_head_base = ((long long)seq_idx * (long long)num_heads + (long long)head_idx) * 128 * 128;
+            long long state_base_top = state_head_base + (long long)state_row_top * 128;
+            long long state_base_bot = state_head_base + (long long)state_row_bot * 128;
+            #pragma unroll
+            for (int state_col_half = 0; state_col_half < 2; state_col_half++) {
+                float state_values[32];
+                #pragma unroll
+                for (int state_col_group = 0; state_col_group < 8; state_col_group++) {
+                    int state_col_pair = state_col_half * 64 + state_col_group * 8 + lane_quad * 2;
+                    const int state_reg_base = state_col_group * 4;
+                    if (compute_end == num_chunks) {
+                        state_values[state_reg_base] = dfinal_state[state_base_top + (long long)state_col_pair];
+                        state_values[state_reg_base + 1] = dfinal_state[state_base_top + (long long)state_col_pair + 1];
+                        state_values[state_reg_base + 2] = dfinal_state[state_base_bot + (long long)state_col_pair];
+                        state_values[state_reg_base + 3] = dfinal_state[state_base_bot + (long long)state_col_pair + 1];
+                    } else {
+                        state_values[state_reg_base] = 0.0f;
+                        state_values[state_reg_base + 1] = 0.0f;
+                        state_values[state_reg_base + 2] = 0.0f;
+                        state_values[state_reg_base + 3] = 0.0f;
+                    }
+                }
+                asm volatile(
+                    "tcgen05.st.sync.aligned.16x256b.x8.b32"
+                    " [%0], {%1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15, %16, %17, %18, %19, %20, %21, %22, %23, %24, %25, %26, %27, %28, %29, %30, %31, %32};"
+                    :: "r"(taddr + 64 + (unsigned int)tmem_row_base + (unsigned int)(state_col_half * 64)), "r"(*reinterpret_cast<const uint32_t*>(&state_values[0])), "r"(*reinterpret_cast<const uint32_t*>(&state_values[1])), "r"(*reinterpret_cast<const uint32_t*>(&state_values[2])), "r"(*reinterpret_cast<const uint32_t*>(&state_values[3])), "r"(*reinterpret_cast<const uint32_t*>(&state_values[4])), "r"(*reinterpret_cast<const uint32_t*>(&state_values[5])), "r"(*reinterpret_cast<const uint32_t*>(&state_values[6])), "r"(*reinterpret_cast<const uint32_t*>(&state_values[7])), "r"(*reinterpret_cast<const uint32_t*>(&state_values[8])), "r"(*reinterpret_cast<const uint32_t*>(&state_values[9])), "r"(*reinterpret_cast<const uint32_t*>(&state_values[10])), "r"(*reinterpret_cast<const uint32_t*>(&state_values[11])), "r"(*reinterpret_cast<const uint32_t*>(&state_values[12])), "r"(*reinterpret_cast<const uint32_t*>(&state_values[13])), "r"(*reinterpret_cast<const uint32_t*>(&state_values[14])), "r"(*reinterpret_cast<const uint32_t*>(&state_values[15])), "r"(*reinterpret_cast<const uint32_t*>(&state_values[16])), "r"(*reinterpret_cast<const uint32_t*>(&state_values[17])), "r"(*reinterpret_cast<const uint32_t*>(&state_values[18])), "r"(*reinterpret_cast<const uint32_t*>(&state_values[19])), "r"(*reinterpret_cast<const uint32_t*>(&state_values[20])), "r"(*reinterpret_cast<const uint32_t*>(&state_values[21])), "r"(*reinterpret_cast<const uint32_t*>(&state_values[22])), "r"(*reinterpret_cast<const uint32_t*>(&state_values[23])), "r"(*reinterpret_cast<const uint32_t*>(&state_values[24])), "r"(*reinterpret_cast<const uint32_t*>(&state_values[25])), "r"(*reinterpret_cast<const uint32_t*>(&state_values[26])), "r"(*reinterpret_cast<const uint32_t*>(&state_values[27])), "r"(*reinterpret_cast<const uint32_t*>(&state_values[28])), "r"(*reinterpret_cast<const uint32_t*>(&state_values[29])), "r"(*reinterpret_cast<const uint32_t*>(&state_values[30])), "r"(*reinterpret_cast<const uint32_t*>(&state_values[31])));
+            }
+            asm volatile("tcgen05.wait::st.sync.aligned;" ::: "memory");
+            unsigned int compute_stage = 0;
+            float _exp2_0 = approx_exp2(lower_bound * 1.4426950408889634f * 16.0f);
+            float common_factor = _exp2_0;
+            unsigned int _phase_prep_ready = 0;
+            unsigned int _phase_dr_ready = 0;
+            unsigned int _phase_dx_ready = 0;
+            unsigned int _phase_dh_ready = 0;
+            #pragma unroll 1
+            for (int reverse_chunk = 0; reverse_chunk < scan_chunks; reverse_chunk++) {
+                mbarrier_wait(prep_ready_addr + (compute_stage) * 8, _phase_prep_ready);
+                int chunk_idx = compute_end - 1 - reverse_chunk;
+                int owned_chunk = (int)(chunk_idx < write_end);
+                long long chunk_global = cu_chunk_offsets[seq_idx] + (long long)chunk_idx;
+                long long chunk_start = bos + (long long)chunk_idx * 32;
+                float do_values[16];
+                do_values[0] = 0.0f;
+                do_values[1] = 0.0f;
+                do_values[2] = 0.0f;
+                do_values[3] = 0.0f;
+                do_values[4] = 0.0f;
+                do_values[5] = 0.0f;
+                do_values[6] = 0.0f;
+                do_values[7] = 0.0f;
+                do_values[8] = 0.0f;
+                do_values[9] = 0.0f;
+                do_values[10] = 0.0f;
+                do_values[11] = 0.0f;
+                do_values[12] = 0.0f;
+                do_values[13] = 0.0f;
+                do_values[14] = 0.0f;
+                do_values[15] = 0.0f;
+                #pragma unroll
+                for (int token_group = 0; token_group < 4; token_group++) {
+                    int token_pair = token_group * 8 + lane_quad * 2;
+                    const int token_reg_base = token_group * 4;
+                    long long token0 = chunk_start + (long long)token_pair;
+                    long long token1 = token0 + 1;
+                    if (token0 < eos) {
+                        long long token_head0 = (token0 * (long long)num_heads + (long long)head_idx) * 128;
+                        do_values[token_reg_base] = (float)do_[token_head0 + (long long)state_row_top];
+                        do_values[token_reg_base + 2] = (float)do_[token_head0 + (long long)state_row_bot];
+                    }
+                    if (token1 < eos) {
+                        long long token_head1 = (token1 * (long long)num_heads + (long long)head_idx) * 128;
+                        do_values[token_reg_base + 1] = (float)do_[token_head1 + (long long)state_row_top];
+                        do_values[token_reg_base + 3] = (float)do_[token_head1 + (long long)state_row_bot];
+                    }
+                }
+                uint32_t do_values_bf16[8];
+                #pragma unroll
+                for (int _lp = 0; _lp < 8; _lp++) {
+                    __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(do_values[_lp*2 + 0], do_values[_lp*2+1 + 0]));
+                    do_values_bf16[_lp] = *(uint32_t*)&_bf2;
+                }
+                asm volatile(
+                    "tcgen05.st.sync.aligned.16x128b.x4.b32"
+                    " [%0], {%1, %2, %3, %4, %5, %6, %7, %8};"
+                    :: "r"(taddr + 224 + (unsigned int)tmem_row_base), "r"(*reinterpret_cast<const uint32_t*>(&do_values_bf16[0])), "r"(*reinterpret_cast<const uint32_t*>(&do_values_bf16[1])), "r"(*reinterpret_cast<const uint32_t*>(&do_values_bf16[2])), "r"(*reinterpret_cast<const uint32_t*>(&do_values_bf16[3])), "r"(*reinterpret_cast<const uint32_t*>(&do_values_bf16[4])), "r"(*reinterpret_cast<const uint32_t*>(&do_values_bf16[5])), "r"(*reinterpret_cast<const uint32_t*>(&do_values_bf16[6])), "r"(*reinterpret_cast<const uint32_t*>(&do_values_bf16[7])));
+                long long chunk_state_head_base = (chunk_global * (long long)num_heads + (long long)head_idx) * 128 * 128;
+                long long chunk_dh_base_top = chunk_state_head_base + (long long)state_row_top * 128;
+                long long chunk_dh_base_bot = chunk_state_head_base + (long long)state_row_bot * 128;
+                long long restore_base = (chunk_global * (long long)num_heads + (long long)head_idx) * 128;
+                #pragma unroll
+                for (int state_col_half2 = 0; state_col_half2 < 2; state_col_half2++) {
+                    float _tmem_load_0[32];
+                    asm volatile(
+                        "tcgen05.ld.sync.aligned.16x256b.x8.b32"
+                        " {%0, %1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15, %16, %17, %18, %19, %20, %21, %22, %23, %24, %25, %26, %27, %28, %29, %30, %31}, [%32];"
+                        : "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_0[0])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_0[1])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_0[2])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_0[3])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_0[4])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_0[5])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_0[6])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_0[7])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_0[8])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_0[9])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_0[10])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_0[11])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_0[12])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_0[13])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_0[14])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_0[15])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_0[16])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_0[17])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_0[18])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_0[19])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_0[20])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_0[21])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_0[22])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_0[23])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_0[24])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_0[25])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_0[26])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_0[27])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_0[28])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_0[29])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_0[30])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_0[31]))
+                        : "r"(taddr + 64 + (unsigned int)tmem_row_base + (unsigned int)(state_col_half2 * 64)));
+                    asm volatile("tcgen05.wait::ld.sync.aligned;");
+                    #pragma unroll
+                    for (int state_col_group2 = 0; state_col_group2 < 8; state_col_group2++) {
+                        int state_col_pair2 = state_col_half2 * 64 + state_col_group2 * 8 + lane_quad * 2;
+                        const int state_reg_base2 = state_col_group2 * 4;
+                        if (owned_chunk != 0) {
+                            chunk_dh[chunk_dh_base_top + (long long)state_col_pair2] = _tmem_load_0[state_reg_base2];
+                            chunk_dh[chunk_dh_base_top + (long long)state_col_pair2 + 1] = _tmem_load_0[state_reg_base2 + 1];
+                            chunk_dh[chunk_dh_base_bot + (long long)state_col_pair2] = _tmem_load_0[state_reg_base2 + 2];
+                            chunk_dh[chunk_dh_base_bot + (long long)state_col_pair2 + 1] = _tmem_load_0[state_reg_base2 + 3];
+                        }
+                    }
+                    uint32_t _tmem_load_0_bf16[16];
+                    #pragma unroll
+                    for (int _lp = 0; _lp < 16; _lp++) {
+                        __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(_tmem_load_0[_lp*2 + 0], _tmem_load_0[_lp*2+1 + 0]));
+                        _tmem_load_0_bf16[_lp] = *(uint32_t*)&_bf2;
+                    }
+                    asm volatile(
+                        "tcgen05.st.sync.aligned.16x128b.x8.b32"
+                        " [%0], {%1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15, %16};"
+                        :: "r"(taddr + (unsigned int)tmem_row_base + (unsigned int)(state_col_half2 * 32)), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0_bf16[0])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0_bf16[1])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0_bf16[2])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0_bf16[3])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0_bf16[4])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0_bf16[5])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0_bf16[6])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0_bf16[7])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0_bf16[8])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0_bf16[9])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0_bf16[10])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0_bf16[11])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0_bf16[12])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0_bf16[13])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0_bf16[14])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0_bf16[15])));
+                    #pragma unroll
+                    for (int restore_group = 0; restore_group < 8; restore_group++) {
+                        int restore_col_pair = state_col_half2 * 64 + restore_group * 8 + lane_quad * 2;
+                        const int restore_reg_base = restore_group * 4;
+                        float restore0 = tape_restore_factor[restore_base + (long long)restore_col_pair];
+                        float restore1 = tape_restore_factor[restore_base + (long long)restore_col_pair + 1];
+                        _tmem_load_0[restore_reg_base] = _tmem_load_0[restore_reg_base] * restore0;
+                        _tmem_load_0[restore_reg_base + 1] = _tmem_load_0[restore_reg_base + 1] * restore1;
+                        _tmem_load_0[restore_reg_base + 2] = _tmem_load_0[restore_reg_base + 2] * restore0;
+                        _tmem_load_0[restore_reg_base + 3] = _tmem_load_0[restore_reg_base + 3] * restore1;
+                    }
+                    asm volatile(
+                        "tcgen05.st.sync.aligned.16x256b.x8.b32"
+                        " [%0], {%1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15, %16, %17, %18, %19, %20, %21, %22, %23, %24, %25, %26, %27, %28, %29, %30, %31, %32};"
+                        :: "r"(taddr + 64 + (unsigned int)tmem_row_base + (unsigned int)(state_col_half2 * 64)), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0[0])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0[1])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0[2])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0[3])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0[4])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0[5])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0[6])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0[7])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0[8])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0[9])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0[10])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0[11])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0[12])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0[13])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0[14])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0[15])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0[16])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0[17])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0[18])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0[19])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0[20])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0[21])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0[22])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0[23])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0[24])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0[25])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0[26])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0[27])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0[28])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0[29])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0[30])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0[31])));
+                }
+                asm volatile("tcgen05.wait::st.sync.aligned;" ::: "memory");
+                if (elect_sync()) {
+                    mbarrier_arrive(inputs_ready_addr + (compute_stage) * 8);
+                }
+                mbarrier_wait(dr_ready_addr + (compute_stage) * 8, _phase_dr_ready);
+                float _tmem_load_1[16];
+                asm volatile(
+                    "tcgen05.ld.sync.aligned.16x256b.x4.b32"
+                    " {%0, %1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15}, [%16];"
+                    : "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_1[0])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_1[1])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_1[2])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_1[3])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_1[4])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_1[5])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_1[6])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_1[7])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_1[8])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_1[9])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_1[10])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_1[11])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_1[12])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_1[13])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_1[14])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_1[15]))
+                    : "r"(taddr + 192 + (unsigned int)tmem_row_base));
+                asm volatile("tcgen05.wait::ld.sync.aligned;");
+                long long chunk_value_head_base = (chunk_global * (long long)num_heads + (long long)head_idx) * 128 * 32;
+                long long dr_tape_base_top = chunk_value_head_base + (long long)state_row_top * 32;
+                long long dr_tape_base_bot = chunk_value_head_base + (long long)state_row_bot * 32;
+                #pragma unroll
+                for (int dr_group = 0; dr_group < 4; dr_group++) {
+                    int dr_col_pair = dr_group * 8 + lane_quad * 2;
+                    const int dr_reg_base = dr_group * 4;
+                    if (owned_chunk != 0) {
+                        chunk_dr[dr_tape_base_top + (long long)dr_col_pair] = _tmem_load_1[dr_reg_base];
+                        chunk_dr[dr_tape_base_top + (long long)dr_col_pair + 1] = _tmem_load_1[dr_reg_base + 1];
+                        chunk_dr[dr_tape_base_bot + (long long)dr_col_pair] = _tmem_load_1[dr_reg_base + 2];
+                        chunk_dr[dr_tape_base_bot + (long long)dr_col_pair + 1] = _tmem_load_1[dr_reg_base + 3];
+                    }
+                }
+                uint32_t _tmem_load_1_bf16[8];
+                #pragma unroll
+                for (int _lp = 0; _lp < 8; _lp++) {
+                    __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(_tmem_load_1[_lp*2 + 0], _tmem_load_1[_lp*2+1 + 0]));
+                    _tmem_load_1_bf16[_lp] = *(uint32_t*)&_bf2;
+                }
+                asm volatile(
+                    "tcgen05.st.sync.aligned.16x128b.x4.b32"
+                    " [%0], {%1, %2, %3, %4, %5, %6, %7, %8};"
+                    :: "r"(taddr + 192 + (unsigned int)tmem_row_base), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_1_bf16[0])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_1_bf16[1])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_1_bf16[2])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_1_bf16[3])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_1_bf16[4])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_1_bf16[5])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_1_bf16[6])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_1_bf16[7])));
+                asm volatile(
+                    "tcgen05.st.sync.aligned.16x128b.x4.b32"
+                    " [%0], {%1, %2, %3, %4, %5, %6, %7, %8};"
+                    :: "r"(taddr + (unsigned int)tmem_row_base), "r"(*reinterpret_cast<const uint32_t*>(&do_values_bf16[0])), "r"(*reinterpret_cast<const uint32_t*>(&do_values_bf16[1])), "r"(*reinterpret_cast<const uint32_t*>(&do_values_bf16[2])), "r"(*reinterpret_cast<const uint32_t*>(&do_values_bf16[3])), "r"(*reinterpret_cast<const uint32_t*>(&do_values_bf16[4])), "r"(*reinterpret_cast<const uint32_t*>(&do_values_bf16[5])), "r"(*reinterpret_cast<const uint32_t*>(&do_values_bf16[6])), "r"(*reinterpret_cast<const uint32_t*>(&do_values_bf16[7])));
+                asm volatile("tcgen05.wait::st.sync.aligned;" ::: "memory");
+                if (elect_sync()) {
+                    mbarrier_arrive(dr_inp_ready_addr + (compute_stage) * 8);
+                }
+                mbarrier_wait(dx_ready_addr + (compute_stage) * 8, _phase_dx_ready);
+                float _tmem_load_2[16];
+                asm volatile(
+                    "tcgen05.ld.sync.aligned.16x256b.x4.b32"
+                    " {%0, %1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15}, [%16];"
+                    : "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_2[0])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_2[1])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_2[2])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_2[3])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_2[4])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_2[5])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_2[6])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_2[7])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_2[8])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_2[9])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_2[10])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_2[11])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_2[12])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_2[13])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_2[14])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_2[15]))
+                    : "r"(taddr + 224 + (unsigned int)tmem_row_base));
+                asm volatile("tcgen05.wait::ld.sync.aligned;");
+                #pragma unroll
+                for (int dx_group = 0; dx_group < 4; dx_group++) {
+                    int dx_col_pair = dx_group * 8 + lane_quad * 2;
+                    const int dx_reg_base = dx_group * 4;
+                    if (owned_chunk != 0) {
+                        chunk_dx[dr_tape_base_top + (long long)dx_col_pair] = _tmem_load_2[dx_reg_base];
+                        chunk_dx[dr_tape_base_top + (long long)dx_col_pair + 1] = _tmem_load_2[dx_reg_base + 1];
+                        chunk_dx[dr_tape_base_bot + (long long)dx_col_pair] = _tmem_load_2[dx_reg_base + 2];
+                        chunk_dx[dr_tape_base_bot + (long long)dx_col_pair + 1] = _tmem_load_2[dx_reg_base + 3];
+                    }
+                    float beta0 = 0.0f;
+                    float beta1 = 0.0f;
+                    long long beta_token0 = chunk_start + (long long)dx_col_pair;
+                    long long beta_token1 = beta_token0 + 1;
+                    if (beta_token0 < eos) {
+                        beta0 = beta_active[beta_token0 * (long long)num_heads + (long long)head_idx];
+                    }
+                    if (beta_token1 < eos) {
+                        beta1 = beta_active[beta_token1 * (long long)num_heads + (long long)head_idx];
+                    }
+                    _tmem_load_2[dx_reg_base] = _tmem_load_2[dx_reg_base] * (-beta0);
+                    _tmem_load_2[dx_reg_base + 1] = _tmem_load_2[dx_reg_base + 1] * (-beta1);
+                    _tmem_load_2[dx_reg_base + 2] = _tmem_load_2[dx_reg_base + 2] * (-beta0);
+                    _tmem_load_2[dx_reg_base + 3] = _tmem_load_2[dx_reg_base + 3] * (-beta1);
+                }
+                uint32_t _tmem_load_2_bf16[8];
+                #pragma unroll
+                for (int _lp = 0; _lp < 8; _lp++) {
+                    __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(_tmem_load_2[_lp*2 + 0], _tmem_load_2[_lp*2+1 + 0]));
+                    _tmem_load_2_bf16[_lp] = *(uint32_t*)&_bf2;
+                }
+                asm volatile(
+                    "tcgen05.st.sync.aligned.16x128b.x4.b32"
+                    " [%0], {%1, %2, %3, %4, %5, %6, %7, %8};"
+                    :: "r"(taddr + 224 + (unsigned int)tmem_row_base), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_2_bf16[0])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_2_bf16[1])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_2_bf16[2])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_2_bf16[3])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_2_bf16[4])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_2_bf16[5])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_2_bf16[6])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_2_bf16[7])));
+                asm volatile("tcgen05.wait::st.sync.aligned;" ::: "memory");
+                if (elect_sync()) {
+                    mbarrier_arrive(de_inp_ready_addr + (compute_stage) * 8);
+                }
+                if (publish_ready != 0 && owned_chunk != 0) {
+                    __threadfence();
+                    asm volatile("barrier.sync 9, 128;" ::: "memory");
+                    if (warp == 0) {
+                        if (elect_sync()) {
+                            {
+                                unsigned int* _gc_p = reinterpret_cast<unsigned int*>(boundary_ready) + (chunk_global * (long long)num_heads + (long long)head_idx);
+                                unsigned int _gc_old;
+                                asm volatile("atom.release.gpu.global.add.u32 %0, [%1], 1;" : "=r"(_gc_old) : "l"(_gc_p) : "memory");
+                            }
+                        }
+                    }
+                }
+                mbarrier_wait(dh_ready_addr + (compute_stage) * 8, _phase_dh_ready);
+                #pragma unroll
+                for (int state_col_half3 = 0; state_col_half3 < 2; state_col_half3++) {
+                    float _tmem_load_3[32];
+                    asm volatile(
+                        "tcgen05.ld.sync.aligned.16x256b.x8.b32"
+                        " {%0, %1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15, %16, %17, %18, %19, %20, %21, %22, %23, %24, %25, %26, %27, %28, %29, %30, %31}, [%32];"
+                        : "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[0])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[1])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[2])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[3])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[4])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[5])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[6])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[7])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[8])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[9])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[10])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[11])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[12])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[13])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[14])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[15])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[16])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[17])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[18])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[19])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[20])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[21])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[22])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[23])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[24])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[25])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[26])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[27])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[28])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[29])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[30])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[31]))
+                        : "r"(taddr + 64 + (unsigned int)tmem_row_base + (unsigned int)(state_col_half3 * 64)));
+                    asm volatile("tcgen05.wait::ld.sync.aligned;");
+                    const float2 _scale2_0 = {common_factor, common_factor};
+                    #pragma unroll
+                    for (int _ls = 0; _ls < 16; _ls++)
+                        mul_f32x2_inplace(&reinterpret_cast<float2*>(_tmem_load_3)[_ls], _scale2_0);
+                    asm volatile(
+                        "tcgen05.st.sync.aligned.16x256b.x8.b32"
+                        " [%0], {%1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15, %16, %17, %18, %19, %20, %21, %22, %23, %24, %25, %26, %27, %28, %29, %30, %31, %32};"
+                        :: "r"(taddr + 64 + (unsigned int)tmem_row_base + (unsigned int)(state_col_half3 * 64)), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_3[0])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_3[1])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_3[2])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_3[3])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_3[4])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_3[5])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_3[6])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_3[7])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_3[8])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_3[9])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_3[10])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_3[11])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_3[12])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_3[13])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_3[14])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_3[15])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_3[16])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_3[17])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_3[18])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_3[19])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_3[20])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_3[21])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_3[22])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_3[23])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_3[24])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_3[25])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_3[26])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_3[27])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_3[28])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_3[29])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_3[30])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_3[31])));
+                }
+                asm volatile("tcgen05.wait::st.sync.aligned;" ::: "memory");
+                compute_stage += 1;
+                if (compute_stage == 1) { compute_stage = 0; _phase_prep_ready ^= 1; _phase_dr_ready ^= 1; _phase_dx_ready ^= 1; _phase_dh_ready ^= 1; }
+            }
+            if (write_start == 0) {
+                #pragma unroll
+                for (int final_half = 0; final_half < 2; final_half++) {
+                    float _tmem_load_4[32];
+                    asm volatile(
+                        "tcgen05.ld.sync.aligned.16x256b.x8.b32"
+                        " {%0, %1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15, %16, %17, %18, %19, %20, %21, %22, %23, %24, %25, %26, %27, %28, %29, %30, %31}, [%32];"
+                        : "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_4[0])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_4[1])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_4[2])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_4[3])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_4[4])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_4[5])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_4[6])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_4[7])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_4[8])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_4[9])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_4[10])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_4[11])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_4[12])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_4[13])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_4[14])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_4[15])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_4[16])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_4[17])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_4[18])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_4[19])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_4[20])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_4[21])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_4[22])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_4[23])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_4[24])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_4[25])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_4[26])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_4[27])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_4[28])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_4[29])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_4[30])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_4[31]))
+                        : "r"(taddr + 64 + (unsigned int)tmem_row_base + (unsigned int)(final_half * 64)));
+                    asm volatile("tcgen05.wait::ld.sync.aligned;");
+                    #pragma unroll
+                    for (int final_group = 0; final_group < 8; final_group++) {
+                        int final_col_pair = final_half * 64 + final_group * 8 + lane_quad * 2;
+                        const int final_reg_base = final_group * 4;
+                        dinitial_state[state_base_top + (long long)final_col_pair] = _tmem_load_4[final_reg_base];
+                        dinitial_state[state_base_top + (long long)final_col_pair + 1] = _tmem_load_4[final_reg_base + 1];
+                        dinitial_state[state_base_bot + (long long)final_col_pair] = _tmem_load_4[final_reg_base + 2];
+                        dinitial_state[state_base_bot + (long long)final_col_pair + 1] = _tmem_load_4[final_reg_base + 3];
+                    }
+                }
+            }
+            if (elect_sync()) {
+                mbarrier_arrive(compute_done_addr);
+            }
+        }
+    }
+    // ---- Role: prep ----
+    if (warp >= 4 && warp <= 7) {
+        asm volatile("setmaxnreg.dec.sync.aligned.u32 112;");
+        { // prep_main
+            int split_task_idx_1 = blockIdx.x;
+            int task_idx_1 = split_task_idx_1 / 2;
+            int item_base_1 = task_idx_1 * 5;
+            int seq_idx_1 = work_items[item_base_1];
+            int head_idx_1 = work_items[item_base_1 + 1];
+            int write_start_1 = work_items[item_base_1 + 2];
+            unsigned int _phase_work_item_ready_0 = 0;
+            mbarrier_wait(work_item_ready_addr, _phase_work_item_ready_0);
+            _phase_work_item_ready_0 ^= 1;
+            int compute_end_1 = smem_work_item_compute_end[0];
+            long long bos_1 = cu_seqlens[seq_idx_1];
+            long long eos_1 = cu_seqlens[seq_idx_1 + 1];
+            int seq_len_1 = (int)(eos_1 - bos_1);
+            int scan_chunks_1 = compute_end_1 - write_start_1;
+            int warp_id_in_role = (warp - 4);
+            int prep_tid = warp_id_in_role * 32 + lane;
+            int prep_local_warp = warp_id_in_role;
+            unsigned int prep_stage = 0;
+            unsigned int _phase_smem_free = 1;
+            #pragma unroll 1
+            for (int reverse_chunk_1 = 0; reverse_chunk_1 < scan_chunks_1; reverse_chunk_1++) {
+                mbarrier_wait(smem_free_addr + (prep_stage) * 8, _phase_smem_free);
+                int chunk_idx_1 = compute_end_1 - 1 - reverse_chunk_1;
+                long long chunk_global_1 = cu_chunk_offsets[seq_idx_1] + (long long)chunk_idx_1;
+                long long tape_vec_base = (chunk_global_1 * (long long)num_heads + (long long)head_idx_1) * 32 * 128;
+                long long restore_base_1 = (chunk_global_1 * (long long)num_heads + (long long)head_idx_1) * 128;
+                #pragma unroll
+                for (int load_pass = 0; load_pass < 4; load_pass++) {
+                    int item = load_pass * 128 + prep_tid;
+                    int row = item / 16;
+                    int segment = item % 16;
+                    long long index = tape_vec_base + (long long)row * 128 + (long long)(segment * 8);
+                    float qd_values[8];
+                    float kd_values[8];
+                    float kr_values[8];
+                    float ki_values[8];
+                    {
+                        const uint4* _vptr_0 = reinterpret_cast<const uint4*>(tape_qd + index);
+                        uint4 _vld_0[1];
+                        #pragma unroll
+                        for (int _blk = 0; _blk < 1; _blk++) {
+                            _vld_0[_blk] = _vptr_0[_blk];
+                            uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
+                            #pragma unroll
+                            for (int _pair = 0; _pair < 4; _pair++) {
+                                asm volatile(
+                                    "{\n\t"
+                                    "shl.b32 %0, %2, 16;\n\t"
+                                    "and.b32 %1, %2, 0xffff0000;\n\t"
+                                    "}\n"
+                                    : "=f"((&qd_values[0 + _blk * 8 + _pair * 2])[0]), "=f"((&qd_values[0 + _blk * 8 + _pair * 2])[1])
+                                    : "r"(_vpairs_0[_pair]));
+                            }
+                        }
+                    }
+                    {
+                        const uint4* _vptr_1 = reinterpret_cast<const uint4*>(tape_kd + index);
+                        uint4 _vld_1[1];
+                        #pragma unroll
+                        for (int _blk = 0; _blk < 1; _blk++) {
+                            _vld_1[_blk] = _vptr_1[_blk];
+                            uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
+                            #pragma unroll
+                            for (int _pair = 0; _pair < 4; _pair++) {
+                                asm volatile(
+                                    "{\n\t"
+                                    "shl.b32 %0, %2, 16;\n\t"
+                                    "and.b32 %1, %2, 0xffff0000;\n\t"
+                                    "}\n"
+                                    : "=f"((&kd_values[0 + _blk * 8 + _pair * 2])[0]), "=f"((&kd_values[0 + _blk * 8 + _pair * 2])[1])
+                                    : "r"(_vpairs_1[_pair]));
+                            }
+                        }
+                    }
+                    {
+                        const uint4* _vptr_2 = reinterpret_cast<const uint4*>(tape_kr + index);
+                        uint4 _vld_2[1];
+                        #pragma unroll
+                        for (int _blk = 0; _blk < 1; _blk++) {
+                            _vld_2[_blk] = _vptr_2[_blk];
+                            uint32_t* _vpairs_2 = reinterpret_cast<uint32_t*>(&_vld_2[_blk]);
+                            #pragma unroll
+                            for (int _pair = 0; _pair < 4; _pair++) {
+                                asm volatile(
+                                    "{\n\t"
+                                    "shl.b32 %0, %2, 16;\n\t"
+                                    "and.b32 %1, %2, 0xffff0000;\n\t"
+                                    "}\n"
+                                    : "=f"((&kr_values[0 + _blk * 8 + _pair * 2])[0]), "=f"((&kr_values[0 + _blk * 8 + _pair * 2])[1])
+                                    : "r"(_vpairs_2[_pair]));
+                            }
+                        }
+                    }
+                    #pragma unroll
+                    for (int elem = 0; elem < 8; elem++) {
+                        float factor = tape_restore_factor[restore_base_1 + (long long)(segment * 8) + (long long)elem];
+                        ki_values[elem] = kr_values[elem] / factor;
+                    }
+                    unsigned int packed[4];
+                    #pragma unroll
+                    for (int _lp = 0; _lp < 4; _lp++) {
+                        __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(qd_values[_lp*2 + 0], qd_values[_lp*2+1 + 0]));
+                        packed[_lp] = *(uint32_t*)&_bf2;
+                    }
+                    #pragma unroll
+                    for (int word = 0; word < 4; word++) {
+                        asm volatile("st.shared.b32 [%0], %1;" :: "r"((smem_qd_addr + (unsigned int)(segment * 8 / 64 * 4096 + row * 128 + segment * 8 % 64 * 2 ^ (segment * 8 / 64 * 4096 + row * 128 + segment * 8 % 64 * 2 >> 7 & 7) << 4)) + (unsigned int)(word * 4)), "r"((packed[word])));
+                    }
+                    unsigned int packed_0[4];
+                    #pragma unroll
+                    for (int _lp = 0; _lp < 4; _lp++) {
+                        __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(kd_values[_lp*2 + 0], kd_values[_lp*2+1 + 0]));
+                        packed_0[_lp] = *(uint32_t*)&_bf2;
+                    }
+                    #pragma unroll
+                    for (int word_1 = 0; word_1 < 4; word_1++) {
+                        asm volatile("st.shared.b32 [%0], %1;" :: "r"((smem_kd_addr + (unsigned int)(segment * 8 / 64 * 4096 + row * 128 + segment * 8 % 64 * 2 ^ (segment * 8 / 64 * 4096 + row * 128 + segment * 8 % 64 * 2 >> 7 & 7) << 4)) + (unsigned int)(word_1 * 4)), "r"((packed_0[word_1])));
+                    }
+                    unsigned int packed_1[4];
+                    #pragma unroll
+                    for (int _lp = 0; _lp < 4; _lp++) {
+                        __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(kr_values[_lp*2 + 0], kr_values[_lp*2+1 + 0]));
+                        packed_1[_lp] = *(uint32_t*)&_bf2;
+                    }
+                    #pragma unroll
+                    for (int word_2 = 0; word_2 < 4; word_2++) {
+                        asm volatile("st.shared.b32 [%0], %1;" :: "r"((smem_kr_addr + (unsigned int)(segment * 8 / 64 * 4096 + row * 128 + segment * 8 % 64 * 2 ^ (segment * 8 / 64 * 4096 + row * 128 + segment * 8 % 64 * 2 >> 7 & 7) << 4)) + (unsigned int)(word_2 * 4)), "r"((packed_1[word_2])));
+                    }
+                    unsigned int packed_2[4];
+                    #pragma unroll
+                    for (int _lp = 0; _lp < 4; _lp++) {
+                        __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(ki_values[_lp*2 + 0], ki_values[_lp*2+1 + 0]));
+                        packed_2[_lp] = *(uint32_t*)&_bf2;
+                    }
+                    #pragma unroll
+                    for (int word_3 = 0; word_3 < 4; word_3++) {
+                        asm volatile("st.shared.b32 [%0], %1;" :: "r"((smem_ki_addr + (unsigned int)(segment * 8 / 64 * 4096 + row * 128 + segment * 8 % 64 * 2 ^ (segment * 8 / 64 * 4096 + row * 128 + segment * 8 % 64 * 2 >> 7 & 7) << 4)) + (unsigned int)(word_3 * 4)), "r"((packed_2[word_3])));
+                    }
+                }
+                int j_row = prep_tid / 4;
+                int j_segment = prep_tid % 4;
+                float j_values[8];
+                long long j_base = (chunk_global_1 * (long long)num_heads + (long long)head_idx_1) * 32 * 32;
+                {
+                    const uint4* _vptr_3 = reinterpret_cast<const uint4*>(tape_j + j_base + (long long)j_row * 32 + (long long)(j_segment * 8));
+                    uint4 _vld_3[1];
+                    #pragma unroll
+                    for (int _blk = 0; _blk < 1; _blk++) {
+                        _vld_3[_blk] = _vptr_3[_blk];
+                        uint32_t* _vpairs_3 = reinterpret_cast<uint32_t*>(&_vld_3[_blk]);
+                        #pragma unroll
+                        for (int _pair = 0; _pair < 4; _pair++) {
+                            asm volatile(
+                                "{\n\t"
+                                "shl.b32 %0, %2, 16;\n\t"
+                                "and.b32 %1, %2, 0xffff0000;\n\t"
+                                "}\n"
+                                : "=f"((&j_values[0 + _blk * 8 + _pair * 2])[0]), "=f"((&j_values[0 + _blk * 8 + _pair * 2])[1])
+                                : "r"(_vpairs_3[_pair]));
+                        }
+                    }
+                }
+                unsigned int packed_3[4];
+                #pragma unroll
+                for (int _lp = 0; _lp < 4; _lp++) {
+                    __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(j_values[_lp*2 + 0], j_values[_lp*2+1 + 0]));
+                    packed_3[_lp] = *(uint32_t*)&_bf2;
+                }
+                #pragma unroll
+                for (int word_4 = 0; word_4 < 4; word_4++) {
+                    asm volatile("st.shared.b32 [%0], %1;" :: "r"((smem_j_addr + (unsigned int)(j_segment * 8 / 16 * 1024 + j_row * 32 + j_segment * 8 % 16 * 2 ^ (j_segment * 8 / 16 * 1024 + j_row * 32 + j_segment * 8 % 16 * 2 >> 7 & 1) << 4)) + (unsigned int)(word_4 * 4)), "r"((packed_3[word_4])));
+                }
+                asm volatile("fence.proxy.async.shared::cta;" ::: "memory");
+                asm volatile("barrier.sync 8, 128;" ::: "memory");
+                int row_base = prep_local_warp / 2 * 16;
+                int col_base = prep_local_warp % 2 * 16;
+                unsigned int a_frag[4];
+                unsigned int b_frag[4];
+                float acc[8];
+                if (row_base <= col_base) {
+                    asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                        : "=r"(a_frag[0]), "=r"(a_frag[1]), "=r"(a_frag[2]), "=r"(a_frag[3])
+                        : "r"(smem_ki_addr + (unsigned int)((lane / 16 / 8 * 256 + (row_base + lane % 16) * 8 + (lane / 16 % 8 * 16 ^ (row_base + lane % 16 & 7) << 4) / 16) * 16))
+                        : "memory");
+                    asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                        : "=r"(b_frag[0]), "=r"(b_frag[1]), "=r"(b_frag[2]), "=r"(b_frag[3])
+                        : "r"(smem_qd_addr + (unsigned int)((lane % 16 / 8 / 8 * 256 + (col_base + 8 * (lane / 16) + lane % 8) * 8 + (lane % 16 / 8 % 8 * 16 ^ (col_base + 8 * (lane / 16) + lane % 8 & 7) << 4) / 16) * 16))
+                        : "memory");
+                    asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%10, %11, %12, %13};\n"
+                        : "=f"(acc[0]), "=f"(acc[1]), "=f"(acc[2]), "=f"(acc[3])
+                        : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[0]), "r"(b_frag[1]), "f"(0.0f), "f"(0.0f), "f"(0.0f), "f"(0.0f));
+                    asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%10, %11, %12, %13};\n"
+                        : "=f"(acc[4]), "=f"(acc[(4) + 1]), "=f"(acc[(4) + 2]), "=f"(acc[(4) + 3])
+                        : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[2]), "r"(b_frag[(2) + 1]), "f"(0.0f), "f"(0.0f), "f"(0.0f), "f"(0.0f));
+                    asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                        : "=r"(a_frag[0]), "=r"(a_frag[1]), "=r"(a_frag[2]), "=r"(a_frag[3])
+                        : "r"(smem_ki_addr + (unsigned int)((lane / 16 / 8 * 256 + (row_base + lane % 16) * 8 + (lane / 16 % 8 * 16 ^ (row_base + lane % 16 & 7) << 4) / 16 ^ 2) * 16))
+                        : "memory");
+                    asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                        : "=r"(b_frag[0]), "=r"(b_frag[1]), "=r"(b_frag[2]), "=r"(b_frag[3])
+                        : "r"(smem_qd_addr + (unsigned int)(((lane % 16 / 8 / 8 * 256 + (col_base + 8 * (lane / 16) + lane % 8) * 8 + (lane % 16 / 8 % 8 * 16 ^ (col_base + 8 * (lane / 16) + lane % 8 & 7) << 4) / 16 + 256 ^ 2) - 256) * 16))
+                        : "memory");
+                    asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                        : "+f"(acc[0]), "+f"(acc[1]), "+f"(acc[2]), "+f"(acc[3])
+                        : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[0]), "r"(b_frag[1]));
+                    asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                        : "+f"(acc[4]), "+f"(acc[(4) + 1]), "+f"(acc[(4) + 2]), "+f"(acc[(4) + 3])
+                        : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[2]), "r"(b_frag[(2) + 1]));
+                    asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                        : "=r"(a_frag[0]), "=r"(a_frag[1]), "=r"(a_frag[2]), "=r"(a_frag[3])
+                        : "r"(smem_ki_addr + (unsigned int)((lane / 16 / 8 * 256 + (row_base + lane % 16) * 8 + (lane / 16 % 8 * 16 ^ (row_base + lane % 16 & 7) << 4) / 16 ^ 2 ^ 6) * 16))
+                        : "memory");
+                    asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                        : "=r"(b_frag[0]), "=r"(b_frag[1]), "=r"(b_frag[2]), "=r"(b_frag[3])
+                        : "r"(smem_qd_addr + (unsigned int)((((lane % 16 / 8 / 8 * 256 + (col_base + 8 * (lane / 16) + lane % 8) * 8 + (lane % 16 / 8 % 8 * 16 ^ (col_base + 8 * (lane / 16) + lane % 8 & 7) << 4) / 16 + 256 ^ 2) - 256 + 256 ^ 6) - 256) * 16))
+                        : "memory");
+                    asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                        : "+f"(acc[0]), "+f"(acc[1]), "+f"(acc[2]), "+f"(acc[3])
+                        : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[0]), "r"(b_frag[1]));
+                    asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                        : "+f"(acc[4]), "+f"(acc[(4) + 1]), "+f"(acc[(4) + 2]), "+f"(acc[(4) + 3])
+                        : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[2]), "r"(b_frag[(2) + 1]));
+                    asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                        : "=r"(a_frag[0]), "=r"(a_frag[1]), "=r"(a_frag[2]), "=r"(a_frag[3])
+                        : "r"(smem_ki_addr + (unsigned int)((lane / 16 / 8 * 256 + (row_base + lane % 16) * 8 + (lane / 16 % 8 * 16 ^ (row_base + lane % 16 & 7) << 4) / 16 ^ 2 ^ 6 ^ 2) * 16))
+                        : "memory");
+                    asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                        : "=r"(b_frag[0]), "=r"(b_frag[1]), "=r"(b_frag[2]), "=r"(b_frag[3])
+                        : "r"(smem_qd_addr + (unsigned int)(((((lane % 16 / 8 / 8 * 256 + (col_base + 8 * (lane / 16) + lane % 8) * 8 + (lane % 16 / 8 % 8 * 16 ^ (col_base + 8 * (lane / 16) + lane % 8 & 7) << 4) / 16 + 256 ^ 2) - 256 + 256 ^ 6) - 256 + 256 ^ 2) - 256) * 16))
+                        : "memory");
+                    asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                        : "+f"(acc[0]), "+f"(acc[1]), "+f"(acc[2]), "+f"(acc[3])
+                        : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[0]), "r"(b_frag[1]));
+                    asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                        : "+f"(acc[4]), "+f"(acc[(4) + 1]), "+f"(acc[(4) + 2]), "+f"(acc[(4) + 3])
+                        : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[2]), "r"(b_frag[(2) + 1]));
+                    asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                        : "=r"(a_frag[0]), "=r"(a_frag[1]), "=r"(a_frag[2]), "=r"(a_frag[3])
+                        : "r"(smem_ki_addr + (unsigned int)(((lane / 16 / 8 * 256 + (row_base + lane % 16) * 8 + (lane / 16 % 8 * 16 ^ (row_base + lane % 16 & 7) << 4) / 16 ^ 2 ^ 6 ^ 2 ^ 6) + 256) * 16))
+                        : "memory");
+                    asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                        : "=r"(b_frag[0]), "=r"(b_frag[1]), "=r"(b_frag[2]), "=r"(b_frag[3])
+                        : "r"(smem_qd_addr + (unsigned int)((((((lane % 16 / 8 / 8 * 256 + (col_base + 8 * (lane / 16) + lane % 8) * 8 + (lane % 16 / 8 % 8 * 16 ^ (col_base + 8 * (lane / 16) + lane % 8 & 7) << 4) / 16 + 256 ^ 2) - 256 + 256 ^ 6) - 256 + 256 ^ 2) - 256 + 256 ^ 6) + 256 - 256) * 16))
+                        : "memory");
+                    asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                        : "+f"(acc[0]), "+f"(acc[1]), "+f"(acc[2]), "+f"(acc[3])
+                        : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[0]), "r"(b_frag[1]));
+                    asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                        : "+f"(acc[4]), "+f"(acc[(4) + 1]), "+f"(acc[(4) + 2]), "+f"(acc[(4) + 3])
+                        : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[2]), "r"(b_frag[(2) + 1]));
+                    asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                        : "=r"(a_frag[0]), "=r"(a_frag[1]), "=r"(a_frag[2]), "=r"(a_frag[3])
+                        : "r"(smem_ki_addr + (unsigned int)(((lane / 16 / 8 * 256 + (row_base + lane % 16) * 8 + (lane / 16 % 8 * 16 ^ (row_base + lane % 16 & 7) << 4) / 16 ^ 2 ^ 6 ^ 2 ^ 6) + 256 ^ 2) * 16))
+                        : "memory");
+                    asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                        : "=r"(b_frag[0]), "=r"(b_frag[1]), "=r"(b_frag[2]), "=r"(b_frag[3])
+                        : "r"(smem_qd_addr + (unsigned int)(((((((lane % 16 / 8 / 8 * 256 + (col_base + 8 * (lane / 16) + lane % 8) * 8 + (lane % 16 / 8 % 8 * 16 ^ (col_base + 8 * (lane / 16) + lane % 8 & 7) << 4) / 16 + 256 ^ 2) - 256 + 256 ^ 6) - 256 + 256 ^ 2) - 256 + 256 ^ 6) + 256 - 256 + 256 ^ 2) - 256) * 16))
+                        : "memory");
+                    asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                        : "+f"(acc[0]), "+f"(acc[1]), "+f"(acc[2]), "+f"(acc[3])
+                        : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[0]), "r"(b_frag[1]));
+                    asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                        : "+f"(acc[4]), "+f"(acc[(4) + 1]), "+f"(acc[(4) + 2]), "+f"(acc[(4) + 3])
+                        : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[2]), "r"(b_frag[(2) + 1]));
+                    asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                        : "=r"(a_frag[0]), "=r"(a_frag[1]), "=r"(a_frag[2]), "=r"(a_frag[3])
+                        : "r"(smem_ki_addr + (unsigned int)(((lane / 16 / 8 * 256 + (row_base + lane % 16) * 8 + (lane / 16 % 8 * 16 ^ (row_base + lane % 16 & 7) << 4) / 16 ^ 2 ^ 6 ^ 2 ^ 6) + 256 ^ 2 ^ 6) * 16))
+                        : "memory");
+                    asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                        : "=r"(b_frag[0]), "=r"(b_frag[1]), "=r"(b_frag[2]), "=r"(b_frag[3])
+                        : "r"(smem_qd_addr + (unsigned int)((((((((lane % 16 / 8 / 8 * 256 + (col_base + 8 * (lane / 16) + lane % 8) * 8 + (lane % 16 / 8 % 8 * 16 ^ (col_base + 8 * (lane / 16) + lane % 8 & 7) << 4) / 16 + 256 ^ 2) - 256 + 256 ^ 6) - 256 + 256 ^ 2) - 256 + 256 ^ 6) + 256 - 256 + 256 ^ 2) - 256 + 256 ^ 6) - 256) * 16))
+                        : "memory");
+                    asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                        : "+f"(acc[0]), "+f"(acc[1]), "+f"(acc[2]), "+f"(acc[3])
+                        : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[0]), "r"(b_frag[1]));
+                    asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                        : "+f"(acc[4]), "+f"(acc[(4) + 1]), "+f"(acc[(4) + 2]), "+f"(acc[(4) + 3])
+                        : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[2]), "r"(b_frag[(2) + 1]));
+                    asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                        : "=r"(a_frag[0]), "=r"(a_frag[1]), "=r"(a_frag[2]), "=r"(a_frag[3])
+                        : "r"(smem_ki_addr + (unsigned int)(((lane / 16 / 8 * 256 + (row_base + lane % 16) * 8 + (lane / 16 % 8 * 16 ^ (row_base + lane % 16 & 7) << 4) / 16 ^ 2 ^ 6 ^ 2 ^ 6) + 256 ^ 2 ^ 6 ^ 2) * 16))
+                        : "memory");
+                    asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                        : "=r"(b_frag[0]), "=r"(b_frag[1]), "=r"(b_frag[2]), "=r"(b_frag[3])
+                        : "r"(smem_qd_addr + (unsigned int)(((((((((lane % 16 / 8 / 8 * 256 + (col_base + 8 * (lane / 16) + lane % 8) * 8 + (lane % 16 / 8 % 8 * 16 ^ (col_base + 8 * (lane / 16) + lane % 8 & 7) << 4) / 16 + 256 ^ 2) - 256 + 256 ^ 6) - 256 + 256 ^ 2) - 256 + 256 ^ 6) + 256 - 256 + 256 ^ 2) - 256 + 256 ^ 6) - 256 + 256 ^ 2) - 256) * 16))
+                        : "memory");
+                    asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                        : "+f"(acc[0]), "+f"(acc[1]), "+f"(acc[2]), "+f"(acc[3])
+                        : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[0]), "r"(b_frag[1]));
+                    asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                        : "+f"(acc[4]), "+f"(acc[(4) + 1]), "+f"(acc[(4) + 2]), "+f"(acc[(4) + 3])
+                        : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[2]), "r"(b_frag[(2) + 1]));
+                } else {
+                    acc[0] = 0.0f;
+                    acc[1] = 0.0f;
+                    acc[2] = 0.0f;
+                    acc[3] = 0.0f;
+                    acc[4] = 0.0f;
+                    acc[5] = 0.0f;
+                    acc[6] = 0.0f;
+                    acc[7] = 0.0f;
+                }
+                int row0 = row_base + lane / 4;
+                int row1 = row0 + 8;
+                int col0 = col_base + lane % 4 * 2;
+                float values[8];
+                values[0] = 0.0f;
+                values[1] = 0.0f;
+                values[2] = 0.0f;
+                values[3] = 0.0f;
+                values[4] = 0.0f;
+                values[5] = 0.0f;
+                values[6] = 0.0f;
+                values[7] = 0.0f;
+                if (row0 <= col0) {
+                    values[0] = acc[0];
+                }
+                if (row0 <= col0 + 1) {
+                    values[1] = acc[1];
+                }
+                if (row1 <= col0) {
+                    values[2] = acc[2];
+                }
+                if (row1 <= col0 + 1) {
+                    values[3] = acc[3];
+                }
+                if (row0 <= col0 + 8) {
+                    values[4] = acc[4];
+                }
+                if (row0 <= col0 + 9) {
+                    values[5] = acc[5];
+                }
+                if (row1 <= col0 + 8) {
+                    values[6] = acc[6];
+                }
+                if (row1 <= col0 + 9) {
+                    values[7] = acc[7];
+                }
+                unsigned int packed_0_1[4];
+                #pragma unroll
+                for (int _lp = 0; _lp < 4; _lp++) {
+                    __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(values[_lp*2 + 0], values[_lp*2+1 + 0]));
+                    packed_0_1[_lp] = *(uint32_t*)&_bf2;
+                }
+                int lane_row = lane % 16;
+                int lane_col = lane / 16 * 8;
+                uint32_t _stmatrix_addr_4 = static_cast<uint32_t>((unsigned long long)(smem_n_addr + (unsigned int)((col_base + lane_col) / 16 * 1024 + (row_base + lane_row) * 32 + (col_base + lane_col) % 16 * 2 ^ ((col_base + lane_col) / 16 * 1024 + (row_base + lane_row) * 32 + (col_base + lane_col) % 16 * 2 >> 7 & 1) << 4)));
+                asm volatile("stmatrix.sync.aligned.m8n8.x4.shared.b16 [%0], {%1, %2, %3, %4};\n"
+                    :: "r"(_stmatrix_addr_4), "r"(*reinterpret_cast<const uint32_t*>(&packed_0_1[0])), "r"(*reinterpret_cast<const uint32_t*>(&packed_0_1[1])), "r"(*reinterpret_cast<const uint32_t*>(&packed_0_1[2])), "r"(*reinterpret_cast<const uint32_t*>(&packed_0_1[3]))
+                    : "memory");
+                asm volatile("fence.proxy.async.shared::cta;" ::: "memory");
+                asm volatile("barrier.sync 8, 128;" ::: "memory");
+                if (prep_local_warp == 0) {
+                    if (elect_sync()) {
+                        mbarrier_arrive(prep_ready_addr + (prep_stage) * 8);
+                    }
+                }
+                prep_stage += 1;
+                if (prep_stage == 1) { prep_stage = 0; _phase_smem_free ^= 1; }
+            }
+        }
+    }
+    // ---- Role: mma ----
+    if (warp == 8) {
+        { // mma_main
+            int split_task_idx_2 = blockIdx.x;
+            int task_idx_2 = split_task_idx_2 / 2;
+            int item_base_2 = task_idx_2 * 5;
+            int write_start_2 = work_items[item_base_2 + 2];
+            unsigned int _phase_work_item_ready_0_1 = 0;
+            mbarrier_wait(work_item_ready_addr, _phase_work_item_ready_0_1);
+            _phase_work_item_ready_0_1 ^= 1;
+            int compute_end_2 = smem_work_item_compute_end[0];
+            int scan_chunks_2 = compute_end_2 - write_start_2;
+            unsigned int mma_stage = 0;
+            unsigned int _phase_prep_ready_1 = 0;
+            unsigned int _phase_inputs_ready = 0;
+            unsigned int _phase_dr_inp_ready = 0;
+            unsigned int _phase_de_inp_ready = 0;
+            #pragma unroll 1
+            for (int _reverse_chunk = 0; _reverse_chunk < scan_chunks_2; _reverse_chunk++) {
+                mbarrier_wait(prep_ready_addr + (mma_stage) * 8, _phase_prep_ready_1);
+                mbarrier_wait(inputs_ready_addr + (mma_stage) * 8, _phase_inputs_ready);
+                int _mma_b_lo_0 = make_warp_uniform(((smem_n_addr) >> 4) & 0x3FFF);
+                asm volatile(
+                    "{\n\t"
+                    ".reg .pred leader, p0, p1;\n\t"
+                    ".reg .b32 dhi, blo, ta, id;\n\t"
+                    ".reg .b64 db;\n\t"
+                    "elect.sync _|leader, 0xFFFFFFFF;\n\t"
+                    "setp.ne.b32 p0, %3, 0;\n\t"
+                    "setp.ne.b32 p1, 1, 0;\n\t"
+                    ""
+                    "mov.b32 dhi, 0xC0004010;\n\t"
+                    "mov.b32 id, 67634320;\n\t"
+                    "mov.b32 ta, %2;\n\t"
+                    "mov.b32 blo, %1;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p0;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 64;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "}\n"
+                    :: "r"(tmem_tmem_dr), "r"(_mma_b_lo_0), "r"(tmem_tmem_do_initial), "r"(0));
+                int _mma_b_lo_1 = make_warp_uniform(((smem_kr_addr) >> 4) & 0x3FFF);
+                asm volatile(
+                    "{\n\t"
+                    ".reg .pred leader, p0, p1;\n\t"
+                    ".reg .b32 dhi, blo, ta, id;\n\t"
+                    ".reg .b64 db;\n\t"
+                    "elect.sync _|leader, 0xFFFFFFFF;\n\t"
+                    "setp.ne.b32 p0, %3, 0;\n\t"
+                    "setp.ne.b32 p1, 1, 0;\n\t"
+                    ""
+                    "mov.b32 dhi, 0x40004040;\n\t"
+                    "mov.b32 id, 67634320;\n\t"
+                    "mov.b32 ta, %2;\n\t"
+                    "mov.b32 blo, %1;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p0;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 250;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "}\n"
+                    :: "r"(tmem_tmem_dr), "r"(_mma_b_lo_1), "r"(tmem_tmem_dh_inp), "r"(1));
+                elect_commit(dr_ready_addr + (mma_stage) * 8);
+                mbarrier_wait(dr_inp_ready_addr + (mma_stage) * 8, _phase_dr_inp_ready);
+                int _mma_b_lo_2 = make_warp_uniform((((smem_j_trans_addr) >> 4) & 0x3FFF) | 0x400000);
+                asm volatile(
+                    "{\n\t"
+                    ".reg .pred leader, p0, p1;\n\t"
+                    ".reg .b32 dhi, blo, ta, id;\n\t"
+                    ".reg .b64 db;\n\t"
+                    "elect.sync _|leader, 0xFFFFFFFF;\n\t"
+                    "setp.ne.b32 p0, %3, 0;\n\t"
+                    "setp.ne.b32 p1, 1, 0;\n\t"
+                    ""
+                    "mov.b32 dhi, 0xC0004010;\n\t"
+                    "mov.b32 id, 67699856;\n\t"
+                    "mov.b32 ta, %2;\n\t"
+                    "mov.b32 blo, %1;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p0;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 32;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "}\n"
+                    :: "r"(tmem_tmem_dx), "r"(_mma_b_lo_2), "r"(tmem_tmem_dr_inp), "r"(0));
+                elect_commit(dx_ready_addr + (mma_stage) * 8);
+                mbarrier_wait(de_inp_ready_addr + (mma_stage) * 8, _phase_de_inp_ready);
+                int _mma_b_lo_3 = make_warp_uniform((((smem_qd_trans_addr) >> 4) & 0x3FFF) | 0x1000000);
+                asm volatile(
+                    "{\n\t"
+                    ".reg .pred leader, p0, p1;\n\t"
+                    ".reg .b32 dhi, blo, ta, id;\n\t"
+                    ".reg .b64 db;\n\t"
+                    "elect.sync _|leader, 0xFFFFFFFF;\n\t"
+                    "setp.ne.b32 p0, %3, 0;\n\t"
+                    "setp.ne.b32 p1, 1, 0;\n\t"
+                    ""
+                    "mov.b32 dhi, 0x40004040;\n\t"
+                    "mov.b32 id, 69272720;\n\t"
+                    "mov.b32 ta, %2;\n\t"
+                    "mov.b32 blo, %1;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p0;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 128;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "}\n"
+                    :: "r"(tmem_tmem_dh), "r"(_mma_b_lo_3), "r"(tmem_tmem_do_final), "r"(1));
+                int _mma_b_lo_4 = make_warp_uniform((((smem_kd_trans_addr) >> 4) & 0x3FFF) | 0x1000000);
+                asm volatile(
+                    "{\n\t"
+                    ".reg .pred leader, p0, p1;\n\t"
+                    ".reg .b32 dhi, blo, ta, id;\n\t"
+                    ".reg .b64 db;\n\t"
+                    "elect.sync _|leader, 0xFFFFFFFF;\n\t"
+                    "setp.ne.b32 p0, %3, 0;\n\t"
+                    "setp.ne.b32 p1, 1, 0;\n\t"
+                    ""
+                    "mov.b32 dhi, 0x40004040;\n\t"
+                    "mov.b32 id, 69272720;\n\t"
+                    "mov.b32 ta, %2;\n\t"
+                    "mov.b32 blo, %1;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p0;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 128;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "}\n"
+                    :: "r"(tmem_tmem_dh), "r"(_mma_b_lo_4), "r"(tmem_tmem_de_inp), "r"(1));
+                elect_commit2(dh_ready_addr + (mma_stage) * 8, smem_free_addr + (mma_stage) * 8);
+                mma_stage += 1;
+                if (mma_stage == 1) { mma_stage = 0; _phase_prep_ready_1 ^= 1; _phase_inputs_ready ^= 1; _phase_dr_inp_ready ^= 1; _phase_de_inp_ready ^= 1; }
+            }
+            unsigned int _phase_compute_done_0 = 0;
+            mbarrier_wait(compute_done_addr, _phase_compute_done_0);
+            _phase_compute_done_0 ^= 1;
+            int _tmem_dealloc_addr = *((volatile int*)tmem_addr_storage);
+            asm volatile("tcgen05.dealloc.cta_group::1.sync.aligned.b32 %0, %1;" :: "r"(_tmem_dealloc_addr), "r"(256));
+        }
+    }
+
+    // Cleanup
+}
+
+} // extern "C"
+
+#undef LOOM_INF
+#undef NUM_REVERSE_PIPE_STAGES
+#undef SMEM_SMEM_J_OFF
+#undef SMEM_SMEM_J_STAGE_BYTES
+#undef SMEM_SMEM_J_STRIDE
+#undef SMEM_SMEM_J_TRANS_OFF
+#undef SMEM_SMEM_J_TRANS_STAGE_BYTES
+#undef SMEM_SMEM_J_TRANS_STRIDE
+#undef SMEM_SMEM_KD_OFF
+#undef SMEM_SMEM_KD_STAGE_BYTES
+#undef SMEM_SMEM_KD_STRIDE
+#undef SMEM_SMEM_KD_TRANS_OFF
+#undef SMEM_SMEM_KD_TRANS_STAGE_BYTES
+#undef SMEM_SMEM_KD_TRANS_STRIDE
+#undef SMEM_SMEM_KI_OFF
+#undef SMEM_SMEM_KI_STAGE_BYTES
+#undef SMEM_SMEM_KI_STRIDE
+#undef SMEM_SMEM_KR_OFF
+#undef SMEM_SMEM_KR_STAGE_BYTES
+#undef SMEM_SMEM_KR_STRIDE
+#undef SMEM_SMEM_N_OFF
+#undef SMEM_SMEM_N_STAGE_BYTES
+#undef SMEM_SMEM_N_STRIDE
+#undef SMEM_SMEM_QD_OFF
+#undef SMEM_SMEM_QD_STAGE_BYTES
+#undef SMEM_SMEM_QD_STRIDE
+#undef SMEM_SMEM_QD_TRANS_OFF
+#undef SMEM_SMEM_QD_TRANS_STAGE_BYTES
+#undef SMEM_SMEM_QD_TRANS_STRIDE
+#undef SMEM_SMEM_WORK_ITEM_COMPUTE_END_OFF
+#undef SMEM_SMEM_WORK_ITEM_COMPUTE_END_STAGE_BYTES
+#undef SMEM_SMEM_WORK_ITEM_COMPUTE_END_STRIDE
+#undef SMEM_SMEM_WORK_ITEM_RESOLVED_OFF
+#undef SMEM_SMEM_WORK_ITEM_RESOLVED_STAGE_BYTES
+#undef SMEM_SMEM_WORK_ITEM_RESOLVED_STRIDE
+#undef SMEM_SMEM_WORK_ITEM_WARP_MAX_OFF
+#undef SMEM_SMEM_WORK_ITEM_WARP_MAX_STAGE_BYTES
+#undef SMEM_SMEM_WORK_ITEM_WARP_MAX_STRIDE
+#undef SMEM_TOTAL
+#undef THREADS
+#undef TMEM_NCOLS
+#undef TMEM_TMEM_DE_INP_OFFSET
+#undef TMEM_TMEM_DH_INP_OFFSET
+#undef TMEM_TMEM_DH_OFFSET
+#undef TMEM_TMEM_DO_FINAL_OFFSET
+#undef TMEM_TMEM_DO_INITIAL_OFFSET
+#undef TMEM_TMEM_DR_INP_OFFSET
+#undef TMEM_TMEM_DR_OFFSET
+#undef TMEM_TMEM_DX_OFFSET
+#undef compute_done_addr
+#undef de_inp_ready_addr
+#undef dh_ready_addr
+#undef dr_inp_ready_addr
+#undef dr_ready_addr
+#undef dx_ready_addr
+#undef inputs_ready_addr
+#undef prep_ready_addr
+#undef smem_free_addr
+#undef smem_j_addr
+#undef smem_j_trans_addr
+#undef smem_kd_addr
+#undef smem_kd_trans_addr
+#undef smem_ki_addr
+#undef smem_kr_addr
+#undef smem_n_addr
+#undef smem_qd_addr
+#undef smem_qd_trans_addr
+#undef smem_work_item_compute_end_addr
+#undef smem_work_item_resolved_addr
+#undef smem_work_item_warp_max_addr
+#undef work_item_ready_addr
+
+#define LOOM_INF CUDART_INF_F
+#define TMEM_NCOLS 256
+#define TMEM_TMEM_DH_OFFSET 64
+#define TMEM_TMEM_DH_INP_OFFSET 0
+#define TMEM_TMEM_DO_INITIAL_OFFSET 224
+#define TMEM_TMEM_DO_FINAL_OFFSET 0
+#define TMEM_TMEM_DR_OFFSET 192
+#define TMEM_TMEM_DR_INP_OFFSET 192
+#define TMEM_TMEM_DX_OFFSET 224
+#define TMEM_TMEM_DE_INP_OFFSET 224
+#define NUM_PREP_PIPE_STAGES 2
+#define NUM_REVERSE_PIPE_STAGES 1
+#define SMEM_SMEM_QD_OFF 1024
+#define SMEM_SMEM_QD_STAGE_BYTES 8192
+#define SMEM_SMEM_QD_STRIDE 36864
+#define SMEM_SMEM_QD_TRANS_OFF 1024
+#define SMEM_SMEM_QD_TRANS_STAGE_BYTES 8192
+#define SMEM_SMEM_QD_TRANS_STRIDE 36864
+#define SMEM_SMEM_KD_OFF 9216
+#define SMEM_SMEM_KD_STAGE_BYTES 8192
+#define SMEM_SMEM_KD_STRIDE 36864
+#define SMEM_SMEM_KD_TRANS_OFF 9216
+#define SMEM_SMEM_KD_TRANS_STAGE_BYTES 8192
+#define SMEM_SMEM_KD_TRANS_STRIDE 36864
+#define SMEM_SMEM_KR_OFF 17408
+#define SMEM_SMEM_KR_STAGE_BYTES 8192
+#define SMEM_SMEM_KR_STRIDE 36864
+#define SMEM_SMEM_KI_OFF 25600
+#define SMEM_SMEM_KI_STAGE_BYTES 8192
+#define SMEM_SMEM_KI_STRIDE 36864
+#define SMEM_SMEM_J_OFF 33792
+#define SMEM_SMEM_J_STAGE_BYTES 2048
+#define SMEM_SMEM_J_STRIDE 36864
+#define SMEM_SMEM_J_TRANS_OFF 33792
+#define SMEM_SMEM_J_TRANS_STAGE_BYTES 2048
+#define SMEM_SMEM_J_TRANS_STRIDE 36864
+#define SMEM_SMEM_N_OFF 35840
+#define SMEM_SMEM_N_STAGE_BYTES 2048
+#define SMEM_SMEM_N_STRIDE 36864
+#define SMEM_SMEM_WORK_ITEM_WARP_MAX_OFF 74752
+#define SMEM_SMEM_WORK_ITEM_WARP_MAX_STAGE_BYTES 16
+#define SMEM_SMEM_WORK_ITEM_WARP_MAX_STRIDE 16
+#define SMEM_SMEM_WORK_ITEM_COMPUTE_END_OFF 74768
+#define SMEM_SMEM_WORK_ITEM_COMPUTE_END_STAGE_BYTES 4
+#define SMEM_SMEM_WORK_ITEM_COMPUTE_END_STRIDE 4
+#define SMEM_SMEM_WORK_ITEM_RESOLVED_OFF 74772
+#define SMEM_SMEM_WORK_ITEM_RESOLVED_STAGE_BYTES 4
+#define SMEM_SMEM_WORK_ITEM_RESOLVED_STRIDE 4
+#define SMEM_TOTAL 74880
+#define THREADS 512
+
+extern "C" {
+
+__global__ __launch_bounds__(512) void
+kernel_flashkda_backward_boundary_c32_tcgen(__nv_bfloat16* __restrict__ do_, float* __restrict__ dfinal_state, float* __restrict__ beta_active, long long* __restrict__ cu_seqlens, long long* __restrict__ cu_chunk_offsets, int* __restrict__ work_items, __nv_bfloat16* __restrict__ tape_qd, __nv_bfloat16* __restrict__ tape_kd, __nv_bfloat16* __restrict__ tape_kr, __nv_bfloat16* __restrict__ tape_j, float* __restrict__ tape_restore_factor, __nv_bfloat16* __restrict__ chunk_dh, __nv_bfloat16* __restrict__ chunk_dr, __nv_bfloat16* __restrict__ chunk_dx, unsigned int* __restrict__ boundary_ready, float* __restrict__ dinitial_state, int num_heads, int publish_ready, float lower_bound)
+{
+    const int tid = threadIdx.x;
+    const int warp = make_warp_uniform(tid / 32);
+    const int lane = tid % 32;
+
+    extern __shared__ __align__(1024) char smem_raw[];
+    int smem;
+    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+
+    const int bid = blockIdx.x;
+    const int num_bids = gridDim.x;
+
+    // Kernel setup ops
+    __nv_bfloat16* smem_qd = reinterpret_cast<__nv_bfloat16*>(smem_raw + 1024);
+    const int smem_qd_addr = smem + 1024;
+    __nv_bfloat16* smem_qd_trans = reinterpret_cast<__nv_bfloat16*>(smem_raw + 1024);
+    const int smem_qd_trans_addr = smem + 1024;
+    __nv_bfloat16* smem_kd = reinterpret_cast<__nv_bfloat16*>(smem_raw + 9216);
+    const int smem_kd_addr = smem + 9216;
+    __nv_bfloat16* smem_kd_trans = reinterpret_cast<__nv_bfloat16*>(smem_raw + 9216);
+    const int smem_kd_trans_addr = smem + 9216;
+    __nv_bfloat16* smem_kr = reinterpret_cast<__nv_bfloat16*>(smem_raw + 17408);
+    const int smem_kr_addr = smem + 17408;
+    __nv_bfloat16* smem_ki = reinterpret_cast<__nv_bfloat16*>(smem_raw + 25600);
+    const int smem_ki_addr = smem + 25600;
+    __nv_bfloat16* smem_j = reinterpret_cast<__nv_bfloat16*>(smem_raw + 33792);
+    const int smem_j_addr = smem + 33792;
+    __nv_bfloat16* smem_j_trans = reinterpret_cast<__nv_bfloat16*>(smem_raw + 33792);
+    const int smem_j_trans_addr = smem + 33792;
+    __nv_bfloat16* smem_n = reinterpret_cast<__nv_bfloat16*>(smem_raw + 35840);
+    const int smem_n_addr = smem + 35840;
+    float* smem_work_item_warp_max = reinterpret_cast<float*>(smem_raw + 74752);
+    const int smem_work_item_warp_max_addr = smem + 74752;
+    int* smem_work_item_compute_end = reinterpret_cast<int*>(smem_raw + 74768);
+    const int smem_work_item_compute_end_addr = smem + 74768;
+    unsigned int* smem_work_item_resolved = reinterpret_cast<unsigned int*>(smem_raw + 74772);
+    const int smem_work_item_resolved_addr = smem + 74772;
+
+    // Mbarrier init (9 groups, 11 barriers)
+    // Mbarriers at smem_raw[0..88)
+
+    if (warp == 0) {
+        uint32_t leader = elect_sync();
+        if (leader) {
+            // --- pipeline 'prep_pipe' ---
+            // smem_free: 2 barriers, init_count=1
+            mbarrier_init(smem + 0, 1);
+            mbarrier_init(smem + 8, 1);
+            // prep_ready: 2 barriers, init_count=1
+            mbarrier_init(smem + 16, 1);
+            mbarrier_init(smem + 24, 1);
+            // --- pipeline 'reverse_pipe' ---
+            // dr_ready: 1 barriers, init_count=1
+            mbarrier_init(smem + 32, 1);
+            // dr_inp_ready: 1 barriers, init_count=1
+            mbarrier_init(smem + 40, 1);
+            // dx_ready: 1 barriers, init_count=1
+            mbarrier_init(smem + 48, 1);
+            // de_inp_ready: 1 barriers, init_count=1
+            mbarrier_init(smem + 56, 1);
+            // dh_ready: 1 barriers, init_count=1
+            mbarrier_init(smem + 64, 1);
+            // owners_done: 1 barriers, init_count=12
+            mbarrier_init(smem + 72, 12);
+            // work_item_ready: 1 barriers, init_count=1
+            mbarrier_init(smem + 80, 1);
+            asm volatile("fence.mbarrier_init.release.cluster;");
+        }
+    }
+
+    __syncwarp();
+
+    // TMEM alloc (256 columns, 256 used)
+    volatile int* tmem_addr_storage = (volatile int*)(smem_raw + 88);
+    if (warp == 0) {
+        int _tmem_hold = smem + 88;
+        asm volatile("tcgen05.alloc.cta_group::1.sync.aligned.shared::cta.b32 [%0], %1;" :: "r"(_tmem_hold), "r"(256) : "memory");
+        asm volatile("tcgen05.relinquish_alloc_permit.cta_group::1.sync.aligned;");
+    }
+
+    __syncthreads();
+    asm volatile("tcgen05.fence::after_thread_sync;");
+
+    const int mbar_base = smem;
+    #define smem_free_addr (mbar_base + 0)
+    #define prep_ready_addr (mbar_base + 16)
+    #define dr_ready_addr (mbar_base + 32)
+    #define dr_inp_ready_addr (mbar_base + 40)
+    #define dx_ready_addr (mbar_base + 48)
+    #define de_inp_ready_addr (mbar_base + 56)
+    #define dh_ready_addr (mbar_base + 64)
+    #define owners_done_addr (mbar_base + 72)
+    #define work_item_ready_addr (mbar_base + 80)
+    const int taddr = tmem_addr_storage[0];
+
+    // Kernel post-init ops
+    const int tmem_tmem_dh = taddr + 64;
+    const int tmem_tmem_dh_inp = taddr;
+    const int tmem_tmem_do_initial = taddr + 224;
+    const int tmem_tmem_do_final = taddr;
+    const int tmem_tmem_dr = taddr + 192;
+    const int tmem_tmem_dr_inp = taddr + 192;
+    const int tmem_tmem_dx = taddr + 224;
+    const int tmem_tmem_de_inp = taddr + 224;
+
+    // ---- Role: state ----
+    if (warp <= 3) {
+        asm volatile("setmaxnreg.dec.sync.aligned.u32 80;");
+        { // state_main
+            int task_idx = blockIdx.x;
+            int seq_idx = 0;
+            int head_idx = 0;
+            int write_start = 0;
+            int write_end = 0;
+            {
+                int item_base = task_idx * 5;
+                seq_idx = work_items[item_base];
+                head_idx = work_items[item_base + 1];
+                write_start = work_items[item_base + 2];
+                write_end = work_items[item_base + 3];
+            }
+            long long bos = cu_seqlens[seq_idx];
+            long long eos = cu_seqlens[seq_idx + 1];
+            int seq_len = (int)(eos - bos);
+            int num_chunks = (seq_len + 32 - 1) / 32;
+            int warp_id_in_role = (warp - 0);
+            int state_row = warp_id_in_role * 32 + lane;
+            int compute_end = num_chunks;
+            int scan_chunks = num_chunks;
+            {
+                if (state_row == 0) {
+                    smem_work_item_compute_end[0] = num_chunks;
+                    smem_work_item_resolved[0] = 0;
+                }
+                asm volatile("barrier.sync 15, 128;" ::: "memory");
+                float suffix_log2 = 0.0f;
+                int _min_0 = ((num_chunks - write_end) < (32) ? (num_chunks - write_end) : (32));
+                int suffix_limit = _min_0;
+                float common_log2 = lower_bound * 1.4426950408889634f * 16.0f;
+                #pragma unroll 1
+                for (int suffix_chunks = 1; suffix_chunks < suffix_limit + 1; suffix_chunks++) {
+                    if (smem_work_item_resolved[0] == 0) {
+                        int suffix_chunk = write_end + suffix_chunks - 1;
+                        long long suffix_global = cu_chunk_offsets[seq_idx] + (long long)suffix_chunk;
+                        float suffix_restore = tape_restore_factor[(suffix_global * (long long)num_heads + (long long)head_idx) * 128 + (long long)state_row];
+                        float _log2_0;
+                        asm volatile("lg2.approx.ftz.f32 %0, %1;" : "=f"(_log2_0) : "f"(suffix_restore));
+                        suffix_log2 += _log2_0 + common_log2;
+                        float _warp_reduce_0 = suffix_log2;
+                        #pragma unroll
+                        for (int offset = 16; offset > 0; offset >>= 1)
+                            _warp_reduce_0 = max_noftz(_warp_reduce_0, __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset));
+                        float suffix_warp_max = _warp_reduce_0;
+                        if (lane == 0) {
+                            smem_work_item_warp_max[warp_id_in_role] = suffix_warp_max;
+                        }
+                        asm volatile("barrier.sync 15, 128;" ::: "memory");
+                        float suffix_block_max = ((lane < 4) ? smem_work_item_warp_max[lane] : -LOOM_INF);
+                        float _warp_reduce_1 = suffix_block_max;
+                        #pragma unroll
+                        for (int offset = 16; offset > 0; offset >>= 1)
+                            _warp_reduce_1 = max_noftz(_warp_reduce_1, __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_1, offset));
+                        suffix_block_max = _warp_reduce_1;
+                        if (state_row == 0 && suffix_block_max <= -30.0f) {
+                            smem_work_item_compute_end[0] = suffix_chunk + 1;
+                            smem_work_item_resolved[0] = 1;
+                        }
+                        asm volatile("barrier.sync 15, 128;" ::: "memory");
+                    }
+                }
+                compute_end = smem_work_item_compute_end[0];
+                if (warp_id_in_role == 0) {
+                    if (elect_sync()) {
+                        mbarrier_arrive(work_item_ready_addr);
+                    }
+                }
+                scan_chunks = compute_end - write_start;
+            }
+            int tmem_row_base = warp_id_in_role * 32 << 16;
+            long long state_base = (((long long)seq_idx * (long long)num_heads + (long long)head_idx) * 128 + (long long)state_row) * 128;
+            #pragma unroll
+            for (int state_block = 0; state_block < 4; state_block++) {
+                float state_values[32];
+                {
+                    state_values[0] = 0.0f;
+                    state_values[1] = 0.0f;
+                    state_values[2] = 0.0f;
+                    state_values[3] = 0.0f;
+                    state_values[4] = 0.0f;
+                    state_values[5] = 0.0f;
+                    state_values[6] = 0.0f;
+                    state_values[7] = 0.0f;
+                    state_values[8] = 0.0f;
+                    state_values[9] = 0.0f;
+                    state_values[10] = 0.0f;
+                    state_values[11] = 0.0f;
+                    state_values[12] = 0.0f;
+                    state_values[13] = 0.0f;
+                    state_values[14] = 0.0f;
+                    state_values[15] = 0.0f;
+                    state_values[16] = 0.0f;
+                    state_values[17] = 0.0f;
+                    state_values[18] = 0.0f;
+                    state_values[19] = 0.0f;
+                    state_values[20] = 0.0f;
+                    state_values[21] = 0.0f;
+                    state_values[22] = 0.0f;
+                    state_values[23] = 0.0f;
+                    state_values[24] = 0.0f;
+                    state_values[25] = 0.0f;
+                    state_values[26] = 0.0f;
+                    state_values[27] = 0.0f;
+                    state_values[28] = 0.0f;
+                    state_values[29] = 0.0f;
+                    state_values[30] = 0.0f;
+                    state_values[31] = 0.0f;
+                    if (compute_end == num_chunks) {
+                        #pragma unroll
+                        for (int state_vec = 0; state_vec < 4; state_vec++) {
+                            {
+                                unsigned _ldv8_0_0;
+                                unsigned _ldv8_0_1;
+                                unsigned _ldv8_0_2;
+                                unsigned _ldv8_0_3;
+                                unsigned _ldv8_0_4;
+                                unsigned _ldv8_0_5;
+                                unsigned _ldv8_0_6;
+                                unsigned _ldv8_0_7;
+                                asm volatile(
+                                    "ld.global.v8.b32 {%0, %1, %2, %3, %4, %5, %6, %7}, [%8];"
+                                    : "=r"(_ldv8_0_0), "=r"(_ldv8_0_1), "=r"(_ldv8_0_2), "=r"(_ldv8_0_3), "=r"(_ldv8_0_4), "=r"(_ldv8_0_5), "=r"(_ldv8_0_6), "=r"(_ldv8_0_7) : "l"((const void*)(dfinal_state + (state_base + (long long)(state_block * 32) + (long long)(state_vec * 8)))) : "memory");
+                                state_values[state_vec * 8 + 0] = __uint_as_float(_ldv8_0_0);
+                                state_values[state_vec * 8 + 1] = __uint_as_float(_ldv8_0_1);
+                                state_values[state_vec * 8 + 2] = __uint_as_float(_ldv8_0_2);
+                                state_values[state_vec * 8 + 3] = __uint_as_float(_ldv8_0_3);
+                                state_values[state_vec * 8 + 4] = __uint_as_float(_ldv8_0_4);
+                                state_values[state_vec * 8 + 5] = __uint_as_float(_ldv8_0_5);
+                                state_values[state_vec * 8 + 6] = __uint_as_float(_ldv8_0_6);
+                                state_values[state_vec * 8 + 7] = __uint_as_float(_ldv8_0_7);
+                            }
+                        }
+                    }
+                }
+                tmem_st_x32_f32(taddr + 64 + (unsigned int)tmem_row_base + (unsigned int)(state_block * 32), state_values);
+            }
+            asm volatile("tcgen05.wait::st.sync.aligned;" ::: "memory");
+            asm volatile("griddepcontrol.launch_dependents;" ::: "memory");
+            unsigned int state_stage = 0;
+            unsigned int issue_smem_stage = 0;
+            float _exp2_0 = approx_exp2(lower_bound * 1.4426950408889634f * 16.0f);
+            float common_factor = _exp2_0;
+            unsigned int _phase_prep_ready = 0;
+            unsigned int _phase_dr_inp_ready = 0;
+            unsigned int _phase_de_inp_ready = 0;
+            unsigned int _phase_dh_ready = 0;
+            #pragma unroll 1
+            for (int reverse_chunk = 0; reverse_chunk < scan_chunks; reverse_chunk++) {
+                int chunk_idx = compute_end - 1 - reverse_chunk;
+                int owned_chunk = 1;
+                {
+                    owned_chunk = (int)(chunk_idx < write_end);
+                }
+                long long chunk_global = cu_chunk_offsets[seq_idx] + (long long)chunk_idx;
+                long long chunk_dh_base = ((chunk_global * (long long)num_heads + (long long)head_idx) * 128 + (long long)state_row) * 128;
+                long long restore_base = (chunk_global * (long long)num_heads + (long long)head_idx) * 128;
+                #pragma unroll
+                for (int state_block2 = 0; state_block2 < 4; state_block2++) {
+                    float _tmem_load_0[32];
+                    tmem_ld_x32(&_tmem_load_0[0], taddr + 64 + (unsigned int)tmem_row_base + (unsigned int)(state_block2 * 32));
+                    asm volatile("tcgen05.wait::ld.sync.aligned;");
+                    if (reverse_chunk != 0) {
+                        const float2 _scale2_1 = {common_factor, common_factor};
+                        #pragma unroll
+                        for (int _ls = 0; _ls < 16; _ls++)
+                            mul_f32x2_inplace(&reinterpret_cast<float2*>(_tmem_load_0)[_ls], _scale2_1);
+                    }
+                    if (owned_chunk != 0) {
+                        #pragma unroll
+                        for (int dh_store_vec = 0; dh_store_vec < 4; dh_store_vec++) {
+                            {
+                                __nv_bfloat162 _pk[4];
+                                _pk[0] = __floats2bfloat162_rn(_tmem_load_0[dh_store_vec * 8 + 0], _tmem_load_0[dh_store_vec * 8 + 1]);
+                                _pk[1] = __floats2bfloat162_rn(_tmem_load_0[dh_store_vec * 8 + 2], _tmem_load_0[dh_store_vec * 8 + 3]);
+                                _pk[2] = __floats2bfloat162_rn(_tmem_load_0[dh_store_vec * 8 + 4], _tmem_load_0[dh_store_vec * 8 + 5]);
+                                _pk[3] = __floats2bfloat162_rn(_tmem_load_0[dh_store_vec * 8 + 6], _tmem_load_0[dh_store_vec * 8 + 7]);
+                                *reinterpret_cast<uint4*>(&((__nv_bfloat16*)(chunk_dh + (chunk_dh_base + (long long)(state_block2 * 32) + (long long)(dh_store_vec * 8))))[0]) = *reinterpret_cast<uint4*>(&_pk[0]);
+                            }
+                        }
+                    }
+                    uint32_t _tmem_load_0_bf16[16];
+                    #pragma unroll
+                    for (int _lp = 0; _lp < 16; _lp++) {
+                        __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(_tmem_load_0[_lp*2 + 0], _tmem_load_0[_lp*2+1 + 0]));
+                        _tmem_load_0_bf16[_lp] = *(uint32_t*)&_bf2;
+                    }
+                    asm volatile(
+                        "tcgen05.st.sync.aligned.32x32b.x16.b32"
+                        " [%0], {%1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15, %16};"
+                        :: "r"(taddr + (unsigned int)tmem_row_base + (unsigned int)(state_block2 * 16)), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0_bf16[0])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0_bf16[1])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0_bf16[2])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0_bf16[3])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0_bf16[4])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0_bf16[5])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0_bf16[6])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0_bf16[7])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0_bf16[8])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0_bf16[9])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0_bf16[10])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0_bf16[11])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0_bf16[12])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0_bf16[13])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0_bf16[14])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0_bf16[15])));
+                    float restore_lane = tape_restore_factor[restore_base + (long long)(state_block2 * 32) + (long long)lane];
+                    #pragma unroll
+                    for (int restore_elem = 0; restore_elem < 32; restore_elem++) {
+                        float _shfl_0 = __shfl_sync(0xFFFFFFFF, restore_lane, restore_elem);
+                        _tmem_load_0[restore_elem] = _tmem_load_0[restore_elem] * _shfl_0;
+                    }
+                    tmem_st_x32_f32(taddr + 64 + (unsigned int)tmem_row_base + (unsigned int)(state_block2 * 32), _tmem_load_0);
+                }
+                asm volatile("tcgen05.wait::st.sync.aligned;" ::: "memory");
+                asm volatile("barrier.sync 9, 384;" ::: "memory");
+                if (warp_id_in_role == 0) {
+                    mbarrier_wait(prep_ready_addr + (issue_smem_stage) * 8, _phase_prep_ready);
+                    int _mma_b_lo_0 = make_warp_uniform((((smem_n_addr) >> 4) & 0x3FFF) + (issue_smem_stage) * 2304);
+                    asm volatile(
+                    "{\n\t"
+                    ".reg .pred leader, p0, p1;\n\t"
+                    ".reg .b32 dhi, blo, ta, id;\n\t"
+                    ".reg .b64 db;\n\t"
+                    "elect.sync _|leader, 0xFFFFFFFF;\n\t"
+                    "setp.ne.b32 p0, %3, 0;\n\t"
+                    "setp.ne.b32 p1, 1, 0;\n\t"
+                    ""
+                    "mov.b32 dhi, 0xC0004010;\n\t"
+                    "mov.b32 id, 134743184;\n\t"
+                    "mov.b32 ta, %2;\n\t"
+                    "mov.b32 blo, %1;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p0;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 64;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "}\n"
+                    :: "r"(tmem_tmem_dr), "r"(_mma_b_lo_0), "r"(tmem_tmem_do_initial), "r"(0));
+                    int _mma_b_lo_1 = make_warp_uniform((((smem_kr_addr) >> 4) & 0x3FFF) + (issue_smem_stage) * 2304);
+                    asm volatile(
+                    "{\n\t"
+                    ".reg .pred leader, p0, p1;\n\t"
+                    ".reg .b32 dhi, blo, ta, id;\n\t"
+                    ".reg .b64 db;\n\t"
+                    "elect.sync _|leader, 0xFFFFFFFF;\n\t"
+                    "setp.ne.b32 p0, %3, 0;\n\t"
+                    "setp.ne.b32 p1, 1, 0;\n\t"
+                    ""
+                    "mov.b32 dhi, 0x40004040;\n\t"
+                    "mov.b32 id, 134743184;\n\t"
+                    "mov.b32 ta, %2;\n\t"
+                    "mov.b32 blo, %1;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p0;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 250;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "}\n"
+                    :: "r"(tmem_tmem_dr), "r"(_mma_b_lo_1), "r"(tmem_tmem_dh_inp), "r"(1));
+                    elect_commit(dr_ready_addr + (state_stage) * 8);
+                    mbarrier_wait(dr_inp_ready_addr + (state_stage) * 8, _phase_dr_inp_ready);
+                    int _mma_b_lo_2 = make_warp_uniform(((((smem_j_trans_addr) >> 4) & 0x3FFF) | 0x400000) + (issue_smem_stage) * 2304);
+                    asm volatile(
+                    "{\n\t"
+                    ".reg .pred leader, p0, p1;\n\t"
+                    ".reg .b32 dhi, blo, ta, id;\n\t"
+                    ".reg .b64 db;\n\t"
+                    "elect.sync _|leader, 0xFFFFFFFF;\n\t"
+                    "setp.ne.b32 p0, %3, 0;\n\t"
+                    "setp.ne.b32 p1, 1, 0;\n\t"
+                    ""
+                    "mov.b32 dhi, 0xC0004010;\n\t"
+                    "mov.b32 id, 134808720;\n\t"
+                    "mov.b32 ta, %2;\n\t"
+                    "mov.b32 blo, %1;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p0;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 32;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "}\n"
+                    :: "r"(tmem_tmem_dx), "r"(_mma_b_lo_2), "r"(tmem_tmem_dr_inp), "r"(0));
+                    elect_commit(dx_ready_addr + (state_stage) * 8);
+                    mbarrier_wait(de_inp_ready_addr + (state_stage) * 8, _phase_de_inp_ready);
+                    int _mma_b_lo_3 = make_warp_uniform(((((smem_qd_trans_addr) >> 4) & 0x3FFF) | 0x1000000) + (issue_smem_stage) * 2304);
+                    asm volatile(
+                    "{\n\t"
+                    ".reg .pred leader, p0, p1;\n\t"
+                    ".reg .b32 dhi, blo, ta, id;\n\t"
+                    ".reg .b64 db;\n\t"
+                    "elect.sync _|leader, 0xFFFFFFFF;\n\t"
+                    "setp.ne.b32 p0, %3, 0;\n\t"
+                    "setp.ne.b32 p1, 1, 0;\n\t"
+                    ""
+                    "mov.b32 dhi, 0x40004040;\n\t"
+                    "mov.b32 id, 136381584;\n\t"
+                    "mov.b32 ta, %2;\n\t"
+                    "mov.b32 blo, %1;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p0;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 128;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "}\n"
+                    :: "r"(tmem_tmem_dh), "r"(_mma_b_lo_3), "r"(tmem_tmem_do_final), "r"(1));
+                    int _mma_b_lo_4 = make_warp_uniform(((((smem_kd_trans_addr) >> 4) & 0x3FFF) | 0x1000000) + (issue_smem_stage) * 2304);
+                    asm volatile(
+                    "{\n\t"
+                    ".reg .pred leader, p0, p1;\n\t"
+                    ".reg .b32 dhi, blo, ta, id;\n\t"
+                    ".reg .b64 db;\n\t"
+                    "elect.sync _|leader, 0xFFFFFFFF;\n\t"
+                    "setp.ne.b32 p0, %3, 0;\n\t"
+                    "setp.ne.b32 p1, 1, 0;\n\t"
+                    ""
+                    "mov.b32 dhi, 0x40004040;\n\t"
+                    "mov.b32 id, 136381584;\n\t"
+                    "mov.b32 ta, %2;\n\t"
+                    "mov.b32 blo, %1;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p0;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 128;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "}\n"
+                    :: "r"(tmem_tmem_dh), "r"(_mma_b_lo_4), "r"(tmem_tmem_de_inp), "r"(1));
+                    elect_commit2(dh_ready_addr + (state_stage) * 8, smem_free_addr + (issue_smem_stage) * 8);
+                    issue_smem_stage += 1;
+                    if (issue_smem_stage == 2) { issue_smem_stage = 0; _phase_prep_ready ^= 1; }
+                }
+                if (publish_ready != 0 && owned_chunk != 0) {
+                    asm volatile("barrier.sync 12, 128;" ::: "memory");
+                    if (warp_id_in_role == 0) {
+                        if (elect_sync()) {
+                            {
+                                unsigned int* _gc_p = reinterpret_cast<unsigned int*>(boundary_ready) + (chunk_global * (long long)num_heads + (long long)head_idx);
+                                unsigned int _gc_old;
+                                asm volatile("atom.release.gpu.global.add.u32 %0, [%1], 1;" : "=r"(_gc_old) : "l"(_gc_p) : "memory");
+                            }
+                        }
+                    }
+                }
+                mbarrier_wait(dh_ready_addr + (state_stage) * 8, _phase_dh_ready);
+                state_stage += 1;
+                if (state_stage == 1) { state_stage = 0; _phase_dr_inp_ready ^= 1; _phase_de_inp_ready ^= 1; _phase_dh_ready ^= 1; }
+            }
+            if (write_start == 0) {
+                #pragma unroll
+                for (int final_block = 0; final_block < 4; final_block++) {
+                    float _tmem_load_1[32];
+                    tmem_ld_x32(&_tmem_load_1[0], taddr + 64 + (unsigned int)tmem_row_base + (unsigned int)(final_block * 32));
+                    asm volatile("tcgen05.wait::ld.sync.aligned;");
+                    const float2 _scale2_2 = {common_factor, common_factor};
+                    #pragma unroll
+                    for (int _ls = 0; _ls < 16; _ls++)
+                        mul_f32x2_inplace(&reinterpret_cast<float2*>(_tmem_load_1)[_ls], _scale2_2);
+                    #pragma unroll
+                    for (int final_vec = 0; final_vec < 4; final_vec++) {
+                        {
+                            unsigned _stv8_3_0 = __float_as_uint(_tmem_load_1[final_vec * 8 + 0]);
+                            unsigned _stv8_3_1 = __float_as_uint(_tmem_load_1[final_vec * 8 + 1]);
+                            unsigned _stv8_3_2 = __float_as_uint(_tmem_load_1[final_vec * 8 + 2]);
+                            unsigned _stv8_3_3 = __float_as_uint(_tmem_load_1[final_vec * 8 + 3]);
+                            unsigned _stv8_3_4 = __float_as_uint(_tmem_load_1[final_vec * 8 + 4]);
+                            unsigned _stv8_3_5 = __float_as_uint(_tmem_load_1[final_vec * 8 + 5]);
+                            unsigned _stv8_3_6 = __float_as_uint(_tmem_load_1[final_vec * 8 + 6]);
+                            unsigned _stv8_3_7 = __float_as_uint(_tmem_load_1[final_vec * 8 + 7]);
+                            asm volatile(
+                                "st.global.v8.b32 [%0], {%1, %2, %3, %4, %5, %6, %7, %8};"
+                                :: "l"((void*)(dinitial_state + (state_base + (long long)(final_block * 32) + (long long)(final_vec * 8)) + (0))), "r"(_stv8_3_0), "r"(_stv8_3_1), "r"(_stv8_3_2), "r"(_stv8_3_3), "r"(_stv8_3_4), "r"(_stv8_3_5), "r"(_stv8_3_6), "r"(_stv8_3_7) : "memory");
+                        }
+                    }
+                }
+            }
+            if (elect_sync()) {
+                mbarrier_arrive(owners_done_addr);
+            }
+        }
+    }
+    // ---- Role: prep ----
+    if (warp >= 4 && warp <= 7) {
+        asm volatile("setmaxnreg.dec.sync.aligned.u32 80;");
+        { // prep_main
+            int task_idx_1 = blockIdx.x;
+            int seq_idx_1 = 0;
+            int head_idx_1 = 0;
+            int write_start_1 = 0;
+            {
+                int item_base_1 = task_idx_1 * 5;
+                seq_idx_1 = work_items[item_base_1];
+                head_idx_1 = work_items[item_base_1 + 1];
+                write_start_1 = work_items[item_base_1 + 2];
+            }
+            long long bos_1 = cu_seqlens[seq_idx_1];
+            long long eos_1 = cu_seqlens[seq_idx_1 + 1];
+            int seq_len_1 = (int)(eos_1 - bos_1);
+            int compute_end_1 = 0;
+            int scan_chunks_1 = 0;
+            unsigned int _phase_work_item_ready_0 = 0;
+            {
+                mbarrier_wait(work_item_ready_addr, _phase_work_item_ready_0);
+                _phase_work_item_ready_0 ^= 1;
+                compute_end_1 = smem_work_item_compute_end[0];
+                scan_chunks_1 = compute_end_1 - write_start_1;
+            }
+            int warp_id_in_role_1 = (warp - 4);
+            int prep_tid = warp_id_in_role_1 * 32 + lane;
+            int prep_local_warp = warp_id_in_role_1;
+            unsigned int prep_stage = 0;
+            unsigned int _phase_smem_free = 1;
+            #pragma unroll 1
+            for (int reverse_chunk_1 = 0; reverse_chunk_1 < scan_chunks_1; reverse_chunk_1++) {
+                mbarrier_wait(smem_free_addr + (prep_stage) * 8, _phase_smem_free);
+                int chunk_idx_1 = compute_end_1 - 1 - reverse_chunk_1;
+                long long chunk_global_1 = cu_chunk_offsets[seq_idx_1] + (long long)chunk_idx_1;
+                long long tape_vec_base = (chunk_global_1 * (long long)num_heads + (long long)head_idx_1) * 32 * 128;
+                long long restore_base_1 = (chunk_global_1 * (long long)num_heads + (long long)head_idx_1) * 128;
+                #pragma unroll
+                for (int load_pass = 0; load_pass < 4; load_pass++) {
+                    int item = load_pass * 128 + prep_tid;
+                    int row = item / 16;
+                    int segment = item % 16;
+                    long long index = tape_vec_base + (long long)row * 128 + (long long)(segment * 8);
+                    float qd_values[8];
+                    float kd_values[8];
+                    float kr_values[8];
+                    float ki_values[8];
+                    {
+                        const uint4* _vptr_0 = reinterpret_cast<const uint4*>(tape_qd + index);
+                        uint4 _vld_0[1];
+                        #pragma unroll
+                        for (int _blk = 0; _blk < 1; _blk++) {
+                            _vld_0[_blk] = _vptr_0[_blk];
+                            uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
+                            #pragma unroll
+                            for (int _pair = 0; _pair < 4; _pair++) {
+                                asm volatile(
+                                    "{\n\t"
+                                    "shl.b32 %0, %2, 16;\n\t"
+                                    "and.b32 %1, %2, 0xffff0000;\n\t"
+                                    "}\n"
+                                    : "=f"((&qd_values[0 + _blk * 8 + _pair * 2])[0]), "=f"((&qd_values[0 + _blk * 8 + _pair * 2])[1])
+                                    : "r"(_vpairs_0[_pair]));
+                            }
+                        }
+                    }
+                    {
+                        const uint4* _vptr_1 = reinterpret_cast<const uint4*>(tape_kd + index);
+                        uint4 _vld_1[1];
+                        #pragma unroll
+                        for (int _blk = 0; _blk < 1; _blk++) {
+                            _vld_1[_blk] = _vptr_1[_blk];
+                            uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
+                            #pragma unroll
+                            for (int _pair = 0; _pair < 4; _pair++) {
+                                asm volatile(
+                                    "{\n\t"
+                                    "shl.b32 %0, %2, 16;\n\t"
+                                    "and.b32 %1, %2, 0xffff0000;\n\t"
+                                    "}\n"
+                                    : "=f"((&kd_values[0 + _blk * 8 + _pair * 2])[0]), "=f"((&kd_values[0 + _blk * 8 + _pair * 2])[1])
+                                    : "r"(_vpairs_1[_pair]));
+                            }
+                        }
+                    }
+                    {
+                        const uint4* _vptr_2 = reinterpret_cast<const uint4*>(tape_kr + index);
+                        uint4 _vld_2[1];
+                        #pragma unroll
+                        for (int _blk = 0; _blk < 1; _blk++) {
+                            _vld_2[_blk] = _vptr_2[_blk];
+                            uint32_t* _vpairs_2 = reinterpret_cast<uint32_t*>(&_vld_2[_blk]);
+                            #pragma unroll
+                            for (int _pair = 0; _pair < 4; _pair++) {
+                                asm volatile(
+                                    "{\n\t"
+                                    "shl.b32 %0, %2, 16;\n\t"
+                                    "and.b32 %1, %2, 0xffff0000;\n\t"
+                                    "}\n"
+                                    : "=f"((&kr_values[0 + _blk * 8 + _pair * 2])[0]), "=f"((&kr_values[0 + _blk * 8 + _pair * 2])[1])
+                                    : "r"(_vpairs_2[_pair]));
+                            }
+                        }
+                    }
+                    #pragma unroll
+                    for (int elem = 0; elem < 8; elem++) {
+                        float factor = tape_restore_factor[restore_base_1 + (long long)(segment * 8) + (long long)elem];
+                        ki_values[elem] = kr_values[elem] / factor;
+                    }
+                    unsigned int packed[4];
+                    #pragma unroll
+                    for (int _lp = 0; _lp < 4; _lp++) {
+                        __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(qd_values[_lp*2 + 0], qd_values[_lp*2+1 + 0]));
+                        packed[_lp] = *(uint32_t*)&_bf2;
+                    }
+                    #pragma unroll
+                    for (int word = 0; word < 4; word++) {
+                        asm volatile("st.shared.b32 [%0], %1;" :: "r"((smem_qd_addr + prep_stage * 36864 + (unsigned int)(segment * 8 / 64 * 4096 + row * 128 + segment * 8 % 64 * 2 ^ (segment * 8 / 64 * 4096 + row * 128 + segment * 8 % 64 * 2 >> 7 & 7) << 4)) + (unsigned int)(word * 4)), "r"((packed[word])));
+                    }
+                    unsigned int packed_0[4];
+                    #pragma unroll
+                    for (int _lp = 0; _lp < 4; _lp++) {
+                        __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(kd_values[_lp*2 + 0], kd_values[_lp*2+1 + 0]));
+                        packed_0[_lp] = *(uint32_t*)&_bf2;
+                    }
+                    #pragma unroll
+                    for (int word_1 = 0; word_1 < 4; word_1++) {
+                        asm volatile("st.shared.b32 [%0], %1;" :: "r"((smem_kd_addr + prep_stage * 36864 + (unsigned int)(segment * 8 / 64 * 4096 + row * 128 + segment * 8 % 64 * 2 ^ (segment * 8 / 64 * 4096 + row * 128 + segment * 8 % 64 * 2 >> 7 & 7) << 4)) + (unsigned int)(word_1 * 4)), "r"((packed_0[word_1])));
+                    }
+                    unsigned int packed_1[4];
+                    #pragma unroll
+                    for (int _lp = 0; _lp < 4; _lp++) {
+                        __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(kr_values[_lp*2 + 0], kr_values[_lp*2+1 + 0]));
+                        packed_1[_lp] = *(uint32_t*)&_bf2;
+                    }
+                    #pragma unroll
+                    for (int word_2 = 0; word_2 < 4; word_2++) {
+                        asm volatile("st.shared.b32 [%0], %1;" :: "r"((smem_kr_addr + prep_stage * 36864 + (unsigned int)(segment * 8 / 64 * 4096 + row * 128 + segment * 8 % 64 * 2 ^ (segment * 8 / 64 * 4096 + row * 128 + segment * 8 % 64 * 2 >> 7 & 7) << 4)) + (unsigned int)(word_2 * 4)), "r"((packed_1[word_2])));
+                    }
+                    unsigned int packed_2[4];
+                    #pragma unroll
+                    for (int _lp = 0; _lp < 4; _lp++) {
+                        __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(ki_values[_lp*2 + 0], ki_values[_lp*2+1 + 0]));
+                        packed_2[_lp] = *(uint32_t*)&_bf2;
+                    }
+                    #pragma unroll
+                    for (int word_3 = 0; word_3 < 4; word_3++) {
+                        asm volatile("st.shared.b32 [%0], %1;" :: "r"((smem_ki_addr + prep_stage * 36864 + (unsigned int)(segment * 8 / 64 * 4096 + row * 128 + segment * 8 % 64 * 2 ^ (segment * 8 / 64 * 4096 + row * 128 + segment * 8 % 64 * 2 >> 7 & 7) << 4)) + (unsigned int)(word_3 * 4)), "r"((packed_2[word_3])));
+                    }
+                }
+                int j_row = prep_tid / 4;
+                int j_segment = prep_tid % 4;
+                float j_values[8];
+                long long j_base = (chunk_global_1 * (long long)num_heads + (long long)head_idx_1) * 32 * 32;
+                {
+                    const uint4* _vptr_3 = reinterpret_cast<const uint4*>(tape_j + j_base + (long long)j_row * 32 + (long long)(j_segment * 8));
+                    uint4 _vld_3[1];
+                    #pragma unroll
+                    for (int _blk = 0; _blk < 1; _blk++) {
+                        _vld_3[_blk] = _vptr_3[_blk];
+                        uint32_t* _vpairs_3 = reinterpret_cast<uint32_t*>(&_vld_3[_blk]);
+                        #pragma unroll
+                        for (int _pair = 0; _pair < 4; _pair++) {
+                            asm volatile(
+                                "{\n\t"
+                                "shl.b32 %0, %2, 16;\n\t"
+                                "and.b32 %1, %2, 0xffff0000;\n\t"
+                                "}\n"
+                                : "=f"((&j_values[0 + _blk * 8 + _pair * 2])[0]), "=f"((&j_values[0 + _blk * 8 + _pair * 2])[1])
+                                : "r"(_vpairs_3[_pair]));
+                        }
+                    }
+                }
+                unsigned int packed_3[4];
+                #pragma unroll
+                for (int _lp = 0; _lp < 4; _lp++) {
+                    __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(j_values[_lp*2 + 0], j_values[_lp*2+1 + 0]));
+                    packed_3[_lp] = *(uint32_t*)&_bf2;
+                }
+                #pragma unroll
+                for (int word_4 = 0; word_4 < 4; word_4++) {
+                    asm volatile("st.shared.b32 [%0], %1;" :: "r"((smem_j_addr + prep_stage * 36864 + (unsigned int)(j_segment * 8 / 16 * 1024 + j_row * 32 + j_segment * 8 % 16 * 2 ^ (j_segment * 8 / 16 * 1024 + j_row * 32 + j_segment * 8 % 16 * 2 >> 7 & 1) << 4)) + (unsigned int)(word_4 * 4)), "r"((packed_3[word_4])));
+                }
+                asm volatile("fence.proxy.async.shared::cta;" ::: "memory");
+                asm volatile("barrier.sync 8, 128;" ::: "memory");
+                int row_base = prep_local_warp / 2 * 16;
+                int col_base = prep_local_warp % 2 * 16;
+                unsigned int a_frag[4];
+                unsigned int b_frag[4];
+                float acc[8];
+                if (row_base <= col_base) {
+                    asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                        : "=r"(a_frag[0]), "=r"(a_frag[1]), "=r"(a_frag[2]), "=r"(a_frag[3])
+                        : "r"(smem_ki_addr + prep_stage * 36864 + (unsigned int)((lane / 16 / 8 * 256 + (row_base + lane % 16) * 8 + (lane / 16 % 8 * 16 ^ (row_base + lane % 16 & 7) << 4) / 16) * 16))
+                        : "memory");
+                    asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                        : "=r"(b_frag[0]), "=r"(b_frag[1]), "=r"(b_frag[2]), "=r"(b_frag[3])
+                        : "r"(smem_qd_addr + prep_stage * 36864 + (unsigned int)((lane % 16 / 8 / 8 * 256 + (col_base + 8 * (lane / 16) + lane % 8) * 8 + (lane % 16 / 8 % 8 * 16 ^ (col_base + 8 * (lane / 16) + lane % 8 & 7) << 4) / 16) * 16))
+                        : "memory");
+                    asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%10, %11, %12, %13};\n"
+                        : "=f"(acc[0]), "=f"(acc[1]), "=f"(acc[2]), "=f"(acc[3])
+                        : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[0]), "r"(b_frag[1]), "f"(0.0f), "f"(0.0f), "f"(0.0f), "f"(0.0f));
+                    asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%10, %11, %12, %13};\n"
+                        : "=f"(acc[4]), "=f"(acc[(4) + 1]), "=f"(acc[(4) + 2]), "=f"(acc[(4) + 3])
+                        : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[2]), "r"(b_frag[(2) + 1]), "f"(0.0f), "f"(0.0f), "f"(0.0f), "f"(0.0f));
+                    asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                        : "=r"(a_frag[0]), "=r"(a_frag[1]), "=r"(a_frag[2]), "=r"(a_frag[3])
+                        : "r"(smem_ki_addr + prep_stage * 36864 + (unsigned int)((lane / 16 / 8 * 256 + (row_base + lane % 16) * 8 + (lane / 16 % 8 * 16 ^ (row_base + lane % 16 & 7) << 4) / 16 ^ 2) * 16))
+                        : "memory");
+                    asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                        : "=r"(b_frag[0]), "=r"(b_frag[1]), "=r"(b_frag[2]), "=r"(b_frag[3])
+                        : "r"(smem_qd_addr + prep_stage * 36864 + (unsigned int)(((lane % 16 / 8 / 8 * 256 + (col_base + 8 * (lane / 16) + lane % 8) * 8 + (lane % 16 / 8 % 8 * 16 ^ (col_base + 8 * (lane / 16) + lane % 8 & 7) << 4) / 16 + 256 ^ 2) - 256) * 16))
+                        : "memory");
+                    asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                        : "+f"(acc[0]), "+f"(acc[1]), "+f"(acc[2]), "+f"(acc[3])
+                        : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[0]), "r"(b_frag[1]));
+                    asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                        : "+f"(acc[4]), "+f"(acc[(4) + 1]), "+f"(acc[(4) + 2]), "+f"(acc[(4) + 3])
+                        : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[2]), "r"(b_frag[(2) + 1]));
+                    asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                        : "=r"(a_frag[0]), "=r"(a_frag[1]), "=r"(a_frag[2]), "=r"(a_frag[3])
+                        : "r"(smem_ki_addr + prep_stage * 36864 + (unsigned int)((lane / 16 / 8 * 256 + (row_base + lane % 16) * 8 + (lane / 16 % 8 * 16 ^ (row_base + lane % 16 & 7) << 4) / 16 ^ 2 ^ 6) * 16))
+                        : "memory");
+                    asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                        : "=r"(b_frag[0]), "=r"(b_frag[1]), "=r"(b_frag[2]), "=r"(b_frag[3])
+                        : "r"(smem_qd_addr + prep_stage * 36864 + (unsigned int)((((lane % 16 / 8 / 8 * 256 + (col_base + 8 * (lane / 16) + lane % 8) * 8 + (lane % 16 / 8 % 8 * 16 ^ (col_base + 8 * (lane / 16) + lane % 8 & 7) << 4) / 16 + 256 ^ 2) - 256 + 256 ^ 6) - 256) * 16))
+                        : "memory");
+                    asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                        : "+f"(acc[0]), "+f"(acc[1]), "+f"(acc[2]), "+f"(acc[3])
+                        : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[0]), "r"(b_frag[1]));
+                    asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                        : "+f"(acc[4]), "+f"(acc[(4) + 1]), "+f"(acc[(4) + 2]), "+f"(acc[(4) + 3])
+                        : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[2]), "r"(b_frag[(2) + 1]));
+                    asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                        : "=r"(a_frag[0]), "=r"(a_frag[1]), "=r"(a_frag[2]), "=r"(a_frag[3])
+                        : "r"(smem_ki_addr + prep_stage * 36864 + (unsigned int)((lane / 16 / 8 * 256 + (row_base + lane % 16) * 8 + (lane / 16 % 8 * 16 ^ (row_base + lane % 16 & 7) << 4) / 16 ^ 2 ^ 6 ^ 2) * 16))
+                        : "memory");
+                    asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                        : "=r"(b_frag[0]), "=r"(b_frag[1]), "=r"(b_frag[2]), "=r"(b_frag[3])
+                        : "r"(smem_qd_addr + prep_stage * 36864 + (unsigned int)(((((lane % 16 / 8 / 8 * 256 + (col_base + 8 * (lane / 16) + lane % 8) * 8 + (lane % 16 / 8 % 8 * 16 ^ (col_base + 8 * (lane / 16) + lane % 8 & 7) << 4) / 16 + 256 ^ 2) - 256 + 256 ^ 6) - 256 + 256 ^ 2) - 256) * 16))
+                        : "memory");
+                    asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                        : "+f"(acc[0]), "+f"(acc[1]), "+f"(acc[2]), "+f"(acc[3])
+                        : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[0]), "r"(b_frag[1]));
+                    asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                        : "+f"(acc[4]), "+f"(acc[(4) + 1]), "+f"(acc[(4) + 2]), "+f"(acc[(4) + 3])
+                        : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[2]), "r"(b_frag[(2) + 1]));
+                    asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                        : "=r"(a_frag[0]), "=r"(a_frag[1]), "=r"(a_frag[2]), "=r"(a_frag[3])
+                        : "r"(smem_ki_addr + prep_stage * 36864 + (unsigned int)(((lane / 16 / 8 * 256 + (row_base + lane % 16) * 8 + (lane / 16 % 8 * 16 ^ (row_base + lane % 16 & 7) << 4) / 16 ^ 2 ^ 6 ^ 2 ^ 6) + 256) * 16))
+                        : "memory");
+                    asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                        : "=r"(b_frag[0]), "=r"(b_frag[1]), "=r"(b_frag[2]), "=r"(b_frag[3])
+                        : "r"(smem_qd_addr + prep_stage * 36864 + (unsigned int)((((((lane % 16 / 8 / 8 * 256 + (col_base + 8 * (lane / 16) + lane % 8) * 8 + (lane % 16 / 8 % 8 * 16 ^ (col_base + 8 * (lane / 16) + lane % 8 & 7) << 4) / 16 + 256 ^ 2) - 256 + 256 ^ 6) - 256 + 256 ^ 2) - 256 + 256 ^ 6) + 256 - 256) * 16))
+                        : "memory");
+                    asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                        : "+f"(acc[0]), "+f"(acc[1]), "+f"(acc[2]), "+f"(acc[3])
+                        : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[0]), "r"(b_frag[1]));
+                    asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                        : "+f"(acc[4]), "+f"(acc[(4) + 1]), "+f"(acc[(4) + 2]), "+f"(acc[(4) + 3])
+                        : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[2]), "r"(b_frag[(2) + 1]));
+                    asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                        : "=r"(a_frag[0]), "=r"(a_frag[1]), "=r"(a_frag[2]), "=r"(a_frag[3])
+                        : "r"(smem_ki_addr + prep_stage * 36864 + (unsigned int)(((lane / 16 / 8 * 256 + (row_base + lane % 16) * 8 + (lane / 16 % 8 * 16 ^ (row_base + lane % 16 & 7) << 4) / 16 ^ 2 ^ 6 ^ 2 ^ 6) + 256 ^ 2) * 16))
+                        : "memory");
+                    asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                        : "=r"(b_frag[0]), "=r"(b_frag[1]), "=r"(b_frag[2]), "=r"(b_frag[3])
+                        : "r"(smem_qd_addr + prep_stage * 36864 + (unsigned int)(((((((lane % 16 / 8 / 8 * 256 + (col_base + 8 * (lane / 16) + lane % 8) * 8 + (lane % 16 / 8 % 8 * 16 ^ (col_base + 8 * (lane / 16) + lane % 8 & 7) << 4) / 16 + 256 ^ 2) - 256 + 256 ^ 6) - 256 + 256 ^ 2) - 256 + 256 ^ 6) + 256 - 256 + 256 ^ 2) - 256) * 16))
+                        : "memory");
+                    asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                        : "+f"(acc[0]), "+f"(acc[1]), "+f"(acc[2]), "+f"(acc[3])
+                        : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[0]), "r"(b_frag[1]));
+                    asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                        : "+f"(acc[4]), "+f"(acc[(4) + 1]), "+f"(acc[(4) + 2]), "+f"(acc[(4) + 3])
+                        : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[2]), "r"(b_frag[(2) + 1]));
+                    asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                        : "=r"(a_frag[0]), "=r"(a_frag[1]), "=r"(a_frag[2]), "=r"(a_frag[3])
+                        : "r"(smem_ki_addr + prep_stage * 36864 + (unsigned int)(((lane / 16 / 8 * 256 + (row_base + lane % 16) * 8 + (lane / 16 % 8 * 16 ^ (row_base + lane % 16 & 7) << 4) / 16 ^ 2 ^ 6 ^ 2 ^ 6) + 256 ^ 2 ^ 6) * 16))
+                        : "memory");
+                    asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                        : "=r"(b_frag[0]), "=r"(b_frag[1]), "=r"(b_frag[2]), "=r"(b_frag[3])
+                        : "r"(smem_qd_addr + prep_stage * 36864 + (unsigned int)((((((((lane % 16 / 8 / 8 * 256 + (col_base + 8 * (lane / 16) + lane % 8) * 8 + (lane % 16 / 8 % 8 * 16 ^ (col_base + 8 * (lane / 16) + lane % 8 & 7) << 4) / 16 + 256 ^ 2) - 256 + 256 ^ 6) - 256 + 256 ^ 2) - 256 + 256 ^ 6) + 256 - 256 + 256 ^ 2) - 256 + 256 ^ 6) - 256) * 16))
+                        : "memory");
+                    asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                        : "+f"(acc[0]), "+f"(acc[1]), "+f"(acc[2]), "+f"(acc[3])
+                        : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[0]), "r"(b_frag[1]));
+                    asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                        : "+f"(acc[4]), "+f"(acc[(4) + 1]), "+f"(acc[(4) + 2]), "+f"(acc[(4) + 3])
+                        : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[2]), "r"(b_frag[(2) + 1]));
+                    asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                        : "=r"(a_frag[0]), "=r"(a_frag[1]), "=r"(a_frag[2]), "=r"(a_frag[3])
+                        : "r"(smem_ki_addr + prep_stage * 36864 + (unsigned int)(((lane / 16 / 8 * 256 + (row_base + lane % 16) * 8 + (lane / 16 % 8 * 16 ^ (row_base + lane % 16 & 7) << 4) / 16 ^ 2 ^ 6 ^ 2 ^ 6) + 256 ^ 2 ^ 6 ^ 2) * 16))
+                        : "memory");
+                    asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                        : "=r"(b_frag[0]), "=r"(b_frag[1]), "=r"(b_frag[2]), "=r"(b_frag[3])
+                        : "r"(smem_qd_addr + prep_stage * 36864 + (unsigned int)(((((((((lane % 16 / 8 / 8 * 256 + (col_base + 8 * (lane / 16) + lane % 8) * 8 + (lane % 16 / 8 % 8 * 16 ^ (col_base + 8 * (lane / 16) + lane % 8 & 7) << 4) / 16 + 256 ^ 2) - 256 + 256 ^ 6) - 256 + 256 ^ 2) - 256 + 256 ^ 6) + 256 - 256 + 256 ^ 2) - 256 + 256 ^ 6) - 256 + 256 ^ 2) - 256) * 16))
+                        : "memory");
+                    asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                        : "+f"(acc[0]), "+f"(acc[1]), "+f"(acc[2]), "+f"(acc[3])
+                        : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[0]), "r"(b_frag[1]));
+                    asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                        : "+f"(acc[4]), "+f"(acc[(4) + 1]), "+f"(acc[(4) + 2]), "+f"(acc[(4) + 3])
+                        : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[2]), "r"(b_frag[(2) + 1]));
+                } else {
+                    acc[0] = 0.0f;
+                    acc[1] = 0.0f;
+                    acc[2] = 0.0f;
+                    acc[3] = 0.0f;
+                    acc[4] = 0.0f;
+                    acc[5] = 0.0f;
+                    acc[6] = 0.0f;
+                    acc[7] = 0.0f;
+                }
+                int row0 = row_base + lane / 4;
+                int row1 = row0 + 8;
+                int col0 = col_base + lane % 4 * 2;
+                float values[8];
+                values[0] = 0.0f;
+                values[1] = 0.0f;
+                values[2] = 0.0f;
+                values[3] = 0.0f;
+                values[4] = 0.0f;
+                values[5] = 0.0f;
+                values[6] = 0.0f;
+                values[7] = 0.0f;
+                if (row0 <= col0) {
+                    values[0] = acc[0];
+                }
+                if (row0 <= col0 + 1) {
+                    values[1] = acc[1];
+                }
+                if (row1 <= col0) {
+                    values[2] = acc[2];
+                }
+                if (row1 <= col0 + 1) {
+                    values[3] = acc[3];
+                }
+                if (row0 <= col0 + 8) {
+                    values[4] = acc[4];
+                }
+                if (row0 <= col0 + 9) {
+                    values[5] = acc[5];
+                }
+                if (row1 <= col0 + 8) {
+                    values[6] = acc[6];
+                }
+                if (row1 <= col0 + 9) {
+                    values[7] = acc[7];
+                }
+                unsigned int packed_0_1[4];
+                #pragma unroll
+                for (int _lp = 0; _lp < 4; _lp++) {
+                    __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(values[_lp*2 + 0], values[_lp*2+1 + 0]));
+                    packed_0_1[_lp] = *(uint32_t*)&_bf2;
+                }
+                int lane_row = lane % 16;
+                int lane_col = lane / 16 * 8;
+                uint32_t _stmatrix_addr_4 = static_cast<uint32_t>((unsigned long long)(smem_n_addr + prep_stage * 36864 + (unsigned int)((col_base + lane_col) / 16 * 1024 + (row_base + lane_row) * 32 + (col_base + lane_col) % 16 * 2 ^ ((col_base + lane_col) / 16 * 1024 + (row_base + lane_row) * 32 + (col_base + lane_col) % 16 * 2 >> 7 & 1) << 4)));
+                asm volatile("stmatrix.sync.aligned.m8n8.x4.shared.b16 [%0], {%1, %2, %3, %4};\n"
+                    :: "r"(_stmatrix_addr_4), "r"(*reinterpret_cast<const uint32_t*>(&packed_0_1[0])), "r"(*reinterpret_cast<const uint32_t*>(&packed_0_1[1])), "r"(*reinterpret_cast<const uint32_t*>(&packed_0_1[2])), "r"(*reinterpret_cast<const uint32_t*>(&packed_0_1[3]))
+                    : "memory");
+                asm volatile("fence.proxy.async.shared::cta;" ::: "memory");
+                asm volatile("barrier.sync 8, 128;" ::: "memory");
+                if (prep_local_warp == 2) {
+                    if (elect_sync()) {
+                        mbarrier_arrive(prep_ready_addr + (prep_stage) * 8);
+                    }
+                }
+                prep_stage += 1;
+                if (prep_stage == 2) { prep_stage = 0; _phase_smem_free ^= 1; }
+            }
+            unsigned int _phase_owners_done_0 = 0;
+            if (prep_local_warp == 2) {
+                mbarrier_wait(owners_done_addr, _phase_owners_done_0);
+                _phase_owners_done_0 ^= 1;
+                int _tmem_dealloc_addr = *((volatile int*)tmem_addr_storage);
+                asm volatile("tcgen05.dealloc.cta_group::1.sync.aligned.b32 %0, %1;" :: "r"(_tmem_dealloc_addr), "r"(256));
+            }
+        }
+    }
+    // ---- Role: high_token ----
+    if (warp >= 8 && warp <= 11) {
+        asm volatile("setmaxnreg.dec.sync.aligned.u32 80;");
+        { // high_token_main
+            int task_idx_2 = blockIdx.x;
+            int seq_idx_2 = 0;
+            int head_idx_2 = 0;
+            int write_start_2 = 0;
+            int write_end_1 = 0;
+            {
+                int item_base_2 = task_idx_2 * 5;
+                seq_idx_2 = work_items[item_base_2];
+                head_idx_2 = work_items[item_base_2 + 1];
+                write_start_2 = work_items[item_base_2 + 2];
+                write_end_1 = work_items[item_base_2 + 3];
+            }
+            long long bos_2 = cu_seqlens[seq_idx_2];
+            long long eos_2 = cu_seqlens[seq_idx_2 + 1];
+            int seq_len_2 = (int)(eos_2 - bos_2);
+            int compute_end_2 = 0;
+            int scan_chunks_2 = 0;
+            unsigned int _phase_work_item_ready_0_1 = 0;
+            {
+                mbarrier_wait(work_item_ready_addr, _phase_work_item_ready_0_1);
+                _phase_work_item_ready_0_1 ^= 1;
+                compute_end_2 = smem_work_item_compute_end[0];
+                scan_chunks_2 = compute_end_2 - write_start_2;
+            }
+            const int token_offset = 16;
+            unsigned int token_stage = 0;
+            unsigned int _phase_dr_ready = 0;
+            unsigned int _phase_dx_ready = 0;
+            unsigned int _phase_dh_ready_1 = 0;
+            #pragma unroll 1
+            for (int reverse_chunk_2 = 0; reverse_chunk_2 < scan_chunks_2; reverse_chunk_2++) {
+                int chunk_idx_2 = compute_end_2 - 1 - reverse_chunk_2;
+                int owned_chunk_1 = 1;
+                {
+                    owned_chunk_1 = (int)(chunk_idx_2 < write_end_1);
+                }
+                long long chunk_global_2 = cu_chunk_offsets[seq_idx_2] + (long long)chunk_idx_2;
+                long long chunk_start = bos_2 + (long long)chunk_idx_2 * 32;
+                float do_values[16];
+                do_values[0] = 0.0f;
+                do_values[1] = 0.0f;
+                do_values[2] = 0.0f;
+                do_values[3] = 0.0f;
+                do_values[4] = 0.0f;
+                do_values[5] = 0.0f;
+                do_values[6] = 0.0f;
+                do_values[7] = 0.0f;
+                do_values[8] = 0.0f;
+                do_values[9] = 0.0f;
+                do_values[10] = 0.0f;
+                do_values[11] = 0.0f;
+                do_values[12] = 0.0f;
+                do_values[13] = 0.0f;
+                do_values[14] = 0.0f;
+                do_values[15] = 0.0f;
+                #pragma unroll
+                for (int row_pass = 0; row_pass < 1; row_pass++) {
+                    int warp_id_in_role_2 = (warp - 8);
+                    int state_row_1 = (warp_id_in_role_2 + row_pass) * 32 + lane;
+                    #pragma unroll
+                    for (int token_local = 0; token_local < 16; token_local++) {
+                        int token_col = token_offset + token_local;
+                        long long token_idx = chunk_start + (long long)token_col;
+                        if (token_idx < eos_2) {
+                            do_values[row_pass * 16 + token_local] = (float)do_[(token_idx * (long long)num_heads + (long long)head_idx_2) * 128 + (long long)state_row_1];
+                        }
+                    }
+                }
+                uint32_t do_values_bf16[8];
+                #pragma unroll
+                for (int _lp = 0; _lp < 8; _lp++) {
+                    __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(do_values[_lp*2 + 0], do_values[_lp*2+1 + 0]));
+                    do_values_bf16[_lp] = *(uint32_t*)&_bf2;
+                }
+                #pragma unroll
+                for (int row_pass2 = 0; row_pass2 < 1; row_pass2++) {
+                    int warp_id_in_role_3 = (warp - 8);
+                    int row_group = warp_id_in_role_3 + row_pass2;
+                    int tmem_row_base_1 = row_group * 32 << 16;
+                    tmem_st_x8_u32(taddr + 224 + (unsigned int)tmem_row_base_1 + (unsigned int)(token_offset / 2), (const uint32_t*)(do_values_bf16 + row_pass2 * 8));
+                }
+                asm volatile("tcgen05.wait::st.sync.aligned;" ::: "memory");
+                asm volatile("barrier.sync 9, 384;" ::: "memory");
+                mbarrier_wait(dr_ready_addr + (token_stage) * 8, _phase_dr_ready);
+                #pragma unroll
+                for (int dr_row_pass = 0; dr_row_pass < 1; dr_row_pass++) {
+                    int warp_id_in_role_4 = (warp - 8);
+                    int row_group2 = warp_id_in_role_4 + dr_row_pass;
+                    int state_row2 = row_group2 * 32 + lane;
+                    int tmem_row_base2 = row_group2 * 32 << 16;
+                    float _tmem_load_4[16];
+                    tmem_ld_x16(&_tmem_load_4[0], taddr + 192 + (unsigned int)tmem_row_base2 + (unsigned int)token_offset);
+                    asm volatile("tcgen05.wait::ld.sync.aligned;");
+                    long long dr_tape_base = ((chunk_global_2 * (long long)num_heads + (long long)head_idx_2) * 128 + (long long)state_row2) * 32;
+                    if (owned_chunk_1 != 0) {
+                        #pragma unroll
+                        for (int dr_store_vec = 0; dr_store_vec < 2; dr_store_vec++) {
+                            {
+                                __nv_bfloat162 _pk[4];
+                                _pk[0] = __floats2bfloat162_rn(_tmem_load_4[dr_store_vec * 8 + 0], _tmem_load_4[dr_store_vec * 8 + 1]);
+                                _pk[1] = __floats2bfloat162_rn(_tmem_load_4[dr_store_vec * 8 + 2], _tmem_load_4[dr_store_vec * 8 + 3]);
+                                _pk[2] = __floats2bfloat162_rn(_tmem_load_4[dr_store_vec * 8 + 4], _tmem_load_4[dr_store_vec * 8 + 5]);
+                                _pk[3] = __floats2bfloat162_rn(_tmem_load_4[dr_store_vec * 8 + 6], _tmem_load_4[dr_store_vec * 8 + 7]);
+                                *reinterpret_cast<uint4*>(&((__nv_bfloat16*)(chunk_dr + (dr_tape_base + (long long)token_offset + (long long)(dr_store_vec * 8))))[0]) = *reinterpret_cast<uint4*>(&_pk[0]);
+                            }
+                        }
+                    }
+                    uint32_t _tmem_load_4_bf16[8];
+                    #pragma unroll
+                    for (int _lp = 0; _lp < 8; _lp++) {
+                        __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(_tmem_load_4[_lp*2 + 0], _tmem_load_4[_lp*2+1 + 0]));
+                        _tmem_load_4_bf16[_lp] = *(uint32_t*)&_bf2;
+                    }
+                    tmem_st_x8_u32(taddr + 192 + (unsigned int)tmem_row_base2 + (unsigned int)(token_offset / 2), (const uint32_t*)_tmem_load_4_bf16);
+                    tmem_st_x8_u32(taddr + (unsigned int)tmem_row_base2 + (unsigned int)(token_offset / 2), (const uint32_t*)(do_values_bf16 + dr_row_pass * 8));
+                }
+                asm volatile("tcgen05.wait::st.sync.aligned;" ::: "memory");
+                asm volatile("barrier.sync 10, 256;" ::: "memory");
+                mbarrier_wait(dx_ready_addr + (token_stage) * 8, _phase_dx_ready);
+                long long beta_token = chunk_start + (long long)lane;
+                float beta_lane = 0.0f;
+                if (beta_token < eos_2) {
+                    beta_lane = beta_active[beta_token * (long long)num_heads + (long long)head_idx_2];
+                }
+                #pragma unroll
+                for (int dx_row_pass = 0; dx_row_pass < 1; dx_row_pass++) {
+                    int warp_id_in_role_5 = (warp - 8);
+                    int row_group3 = warp_id_in_role_5 + dx_row_pass;
+                    int state_row3 = row_group3 * 32 + lane;
+                    int tmem_row_base3 = row_group3 * 32 << 16;
+                    float _tmem_load_5[16];
+                    tmem_ld_x16(&_tmem_load_5[0], taddr + 224 + (unsigned int)tmem_row_base3 + (unsigned int)token_offset);
+                    asm volatile("tcgen05.wait::ld.sync.aligned;");
+                    long long dx_tape_base = ((chunk_global_2 * (long long)num_heads + (long long)head_idx_2) * 128 + (long long)state_row3) * 32;
+                    if (owned_chunk_1 != 0) {
+                        #pragma unroll
+                        for (int dx_store_vec = 0; dx_store_vec < 2; dx_store_vec++) {
+                            {
+                                __nv_bfloat162 _pk[4];
+                                _pk[0] = __floats2bfloat162_rn(_tmem_load_5[dx_store_vec * 8 + 0], _tmem_load_5[dx_store_vec * 8 + 1]);
+                                _pk[1] = __floats2bfloat162_rn(_tmem_load_5[dx_store_vec * 8 + 2], _tmem_load_5[dx_store_vec * 8 + 3]);
+                                _pk[2] = __floats2bfloat162_rn(_tmem_load_5[dx_store_vec * 8 + 4], _tmem_load_5[dx_store_vec * 8 + 5]);
+                                _pk[3] = __floats2bfloat162_rn(_tmem_load_5[dx_store_vec * 8 + 6], _tmem_load_5[dx_store_vec * 8 + 7]);
+                                *reinterpret_cast<uint4*>(&((__nv_bfloat16*)(chunk_dx + (dx_tape_base + (long long)token_offset + (long long)(dx_store_vec * 8))))[0]) = *reinterpret_cast<uint4*>(&_pk[0]);
+                            }
+                        }
+                    }
+                    #pragma unroll
+                    for (int token_local2 = 0; token_local2 < 16; token_local2++) {
+                        int token_col2 = token_offset + token_local2;
+                        float _shfl_2 = __shfl_sync(0xFFFFFFFF, beta_lane, token_col2);
+                        float beta_value = _shfl_2;
+                        _tmem_load_5[token_local2] = _tmem_load_5[token_local2] * (-beta_value);
+                    }
+                    uint32_t _tmem_load_5_bf16[8];
+                    #pragma unroll
+                    for (int _lp = 0; _lp < 8; _lp++) {
+                        __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(_tmem_load_5[_lp*2 + 0], _tmem_load_5[_lp*2+1 + 0]));
+                        _tmem_load_5_bf16[_lp] = *(uint32_t*)&_bf2;
+                    }
+                    tmem_st_x8_u32(taddr + 224 + (unsigned int)tmem_row_base3 + (unsigned int)(token_offset / 2), (const uint32_t*)_tmem_load_5_bf16);
+                }
+                asm volatile("tcgen05.wait::st.sync.aligned;" ::: "memory");
+                asm volatile("barrier.sync 11, 256;" ::: "memory");
+                if (publish_ready != 0 && owned_chunk_1 != 0) {
+                    asm volatile("barrier.sync 14, 128;" ::: "memory");
+                    int warp_id_in_role_6 = (warp - 8);
+                    if (warp_id_in_role_6 == 0) {
+                        if (elect_sync()) {
+                            {
+                                unsigned int* _gc_p = reinterpret_cast<unsigned int*>(boundary_ready) + (chunk_global_2 * (long long)num_heads + (long long)head_idx_2);
+                                unsigned int _gc_old;
+                                asm volatile("atom.release.gpu.global.add.u32 %0, [%1], 1;" : "=r"(_gc_old) : "l"(_gc_p) : "memory");
+                            }
+                        }
+                    }
+                }
+                mbarrier_wait(dh_ready_addr + (token_stage) * 8, _phase_dh_ready_1);
+                token_stage += 1;
+                if (token_stage == 1) { token_stage = 0; _phase_dr_ready ^= 1; _phase_dx_ready ^= 1; _phase_dh_ready_1 ^= 1; }
+            }
+            if (elect_sync()) {
+                mbarrier_arrive(owners_done_addr);
+            }
+        }
+    }
+    // ---- Role: low_token ----
+    if (warp >= 12 && warp <= 15) {
+        asm volatile("setmaxnreg.dec.sync.aligned.u32 80;");
+        { // low_token_main
+            int task_idx_3 = blockIdx.x;
+            int seq_idx_3 = 0;
+            int head_idx_3 = 0;
+            int write_start_3 = 0;
+            int write_end_2 = 0;
+            {
+                int item_base_3 = task_idx_3 * 5;
+                seq_idx_3 = work_items[item_base_3];
+                head_idx_3 = work_items[item_base_3 + 1];
+                write_start_3 = work_items[item_base_3 + 2];
+                write_end_2 = work_items[item_base_3 + 3];
+            }
+            long long bos_3 = cu_seqlens[seq_idx_3];
+            long long eos_3 = cu_seqlens[seq_idx_3 + 1];
+            int seq_len_3 = (int)(eos_3 - bos_3);
+            int compute_end_3 = 0;
+            int scan_chunks_3 = 0;
+            unsigned int _phase_work_item_ready_0_2 = 0;
+            {
+                mbarrier_wait(work_item_ready_addr, _phase_work_item_ready_0_2);
+                _phase_work_item_ready_0_2 ^= 1;
+                compute_end_3 = smem_work_item_compute_end[0];
+                scan_chunks_3 = compute_end_3 - write_start_3;
+            }
+            int warp_id_in_role_7 = (warp - 12);
+            int state_row_2 = warp_id_in_role_7 * 32 + lane;
+            int tmem_row_base_2 = warp_id_in_role_7 * 32 << 16;
+            unsigned int low_token_stage = 0;
+            unsigned int _phase_dr_ready_1 = 0;
+            unsigned int _phase_dx_ready_1 = 0;
+            unsigned int _phase_dh_ready_2 = 0;
+            #pragma unroll 1
+            for (int reverse_chunk_3 = 0; reverse_chunk_3 < scan_chunks_3; reverse_chunk_3++) {
+                int chunk_idx_3 = compute_end_3 - 1 - reverse_chunk_3;
+                int owned_chunk_2 = 1;
+                {
+                    owned_chunk_2 = (int)(chunk_idx_3 < write_end_2);
+                }
+                long long chunk_global_3 = cu_chunk_offsets[seq_idx_3] + (long long)chunk_idx_3;
+                long long chunk_start_1 = bos_3 + (long long)chunk_idx_3 * 32;
+                float do_values_1[16];
+                do_values_1[0] = 0.0f;
+                do_values_1[1] = 0.0f;
+                do_values_1[2] = 0.0f;
+                do_values_1[3] = 0.0f;
+                do_values_1[4] = 0.0f;
+                do_values_1[5] = 0.0f;
+                do_values_1[6] = 0.0f;
+                do_values_1[7] = 0.0f;
+                do_values_1[8] = 0.0f;
+                do_values_1[9] = 0.0f;
+                do_values_1[10] = 0.0f;
+                do_values_1[11] = 0.0f;
+                do_values_1[12] = 0.0f;
+                do_values_1[13] = 0.0f;
+                do_values_1[14] = 0.0f;
+                do_values_1[15] = 0.0f;
+                #pragma unroll
+                for (int token_col_1 = 0; token_col_1 < 16; token_col_1++) {
+                    long long token_idx_1 = chunk_start_1 + (long long)token_col_1;
+                    if (token_idx_1 < eos_3) {
+                        do_values_1[token_col_1] = (float)do_[(token_idx_1 * (long long)num_heads + (long long)head_idx_3) * 128 + (long long)state_row_2];
+                    }
+                }
+                uint32_t do_values_bf16_1[8];
+                #pragma unroll
+                for (int _lp = 0; _lp < 8; _lp++) {
+                    __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(do_values_1[_lp*2 + 0], do_values_1[_lp*2+1 + 0]));
+                    do_values_bf16_1[_lp] = *(uint32_t*)&_bf2;
+                }
+                tmem_st_x8_u32(taddr + 224 + (unsigned int)tmem_row_base_2, (const uint32_t*)do_values_bf16_1);
+                asm volatile("tcgen05.wait::st.sync.aligned;" ::: "memory");
+                asm volatile("barrier.sync 9, 384;" ::: "memory");
+                mbarrier_wait(dr_ready_addr + (low_token_stage) * 8, _phase_dr_ready_1);
+                float _tmem_load_2[16];
+                tmem_ld_x16(&_tmem_load_2[0], taddr + 192 + (unsigned int)tmem_row_base_2);
+                asm volatile("tcgen05.wait::ld.sync.aligned;");
+                long long dr_tape_base_1 = ((chunk_global_3 * (long long)num_heads + (long long)head_idx_3) * 128 + (long long)state_row_2) * 32;
+                if (owned_chunk_2 != 0) {
+                    #pragma unroll
+                    for (int dr_store_vec_1 = 0; dr_store_vec_1 < 2; dr_store_vec_1++) {
+                        {
+                            __nv_bfloat162 _pk[4];
+                            _pk[0] = __floats2bfloat162_rn(_tmem_load_2[dr_store_vec_1 * 8 + 0], _tmem_load_2[dr_store_vec_1 * 8 + 1]);
+                            _pk[1] = __floats2bfloat162_rn(_tmem_load_2[dr_store_vec_1 * 8 + 2], _tmem_load_2[dr_store_vec_1 * 8 + 3]);
+                            _pk[2] = __floats2bfloat162_rn(_tmem_load_2[dr_store_vec_1 * 8 + 4], _tmem_load_2[dr_store_vec_1 * 8 + 5]);
+                            _pk[3] = __floats2bfloat162_rn(_tmem_load_2[dr_store_vec_1 * 8 + 6], _tmem_load_2[dr_store_vec_1 * 8 + 7]);
+                            *reinterpret_cast<uint4*>(&((__nv_bfloat16*)(chunk_dr + (dr_tape_base_1 + (long long)(dr_store_vec_1 * 8))))[0]) = *reinterpret_cast<uint4*>(&_pk[0]);
+                        }
+                    }
+                }
+                uint32_t _tmem_load_2_bf16[8];
+                #pragma unroll
+                for (int _lp = 0; _lp < 8; _lp++) {
+                    __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(_tmem_load_2[_lp*2 + 0], _tmem_load_2[_lp*2+1 + 0]));
+                    _tmem_load_2_bf16[_lp] = *(uint32_t*)&_bf2;
+                }
+                tmem_st_x8_u32(taddr + 192 + (unsigned int)tmem_row_base_2, (const uint32_t*)_tmem_load_2_bf16);
+                tmem_st_x8_u32(taddr + (unsigned int)tmem_row_base_2, (const uint32_t*)do_values_bf16_1);
+                asm volatile("tcgen05.wait::st.sync.aligned;" ::: "memory");
+                asm volatile("barrier.sync 10, 256;" ::: "memory");
+                if (warp_id_in_role_7 == 0) {
+                    if (elect_sync()) {
+                        mbarrier_arrive(dr_inp_ready_addr + (low_token_stage) * 8);
+                    }
+                }
+                mbarrier_wait(dx_ready_addr + (low_token_stage) * 8, _phase_dx_ready_1);
+                float _tmem_load_3[16];
+                tmem_ld_x16(&_tmem_load_3[0], taddr + 224 + (unsigned int)tmem_row_base_2);
+                asm volatile("tcgen05.wait::ld.sync.aligned;");
+                if (owned_chunk_2 != 0) {
+                    #pragma unroll
+                    for (int dx_store_vec_1 = 0; dx_store_vec_1 < 2; dx_store_vec_1++) {
+                        {
+                            __nv_bfloat162 _pk[4];
+                            _pk[0] = __floats2bfloat162_rn(_tmem_load_3[dx_store_vec_1 * 8 + 0], _tmem_load_3[dx_store_vec_1 * 8 + 1]);
+                            _pk[1] = __floats2bfloat162_rn(_tmem_load_3[dx_store_vec_1 * 8 + 2], _tmem_load_3[dx_store_vec_1 * 8 + 3]);
+                            _pk[2] = __floats2bfloat162_rn(_tmem_load_3[dx_store_vec_1 * 8 + 4], _tmem_load_3[dx_store_vec_1 * 8 + 5]);
+                            _pk[3] = __floats2bfloat162_rn(_tmem_load_3[dx_store_vec_1 * 8 + 6], _tmem_load_3[dx_store_vec_1 * 8 + 7]);
+                            *reinterpret_cast<uint4*>(&((__nv_bfloat16*)(chunk_dx + (dr_tape_base_1 + (long long)(dx_store_vec_1 * 8))))[0]) = *reinterpret_cast<uint4*>(&_pk[0]);
+                        }
+                    }
+                }
+                long long beta_token_1 = chunk_start_1 + (long long)lane;
+                float beta_lane_1 = 0.0f;
+                if (beta_token_1 < eos_3) {
+                    beta_lane_1 = beta_active[beta_token_1 * (long long)num_heads + (long long)head_idx_3];
+                }
+                #pragma unroll
+                for (int token_col2_1 = 0; token_col2_1 < 16; token_col2_1++) {
+                    float _shfl_1 = __shfl_sync(0xFFFFFFFF, beta_lane_1, token_col2_1);
+                    float beta_value_1 = _shfl_1;
+                    _tmem_load_3[token_col2_1] = _tmem_load_3[token_col2_1] * (-beta_value_1);
+                }
+                uint32_t _tmem_load_3_bf16[8];
+                #pragma unroll
+                for (int _lp = 0; _lp < 8; _lp++) {
+                    __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(_tmem_load_3[_lp*2 + 0], _tmem_load_3[_lp*2+1 + 0]));
+                    _tmem_load_3_bf16[_lp] = *(uint32_t*)&_bf2;
+                }
+                tmem_st_x8_u32(taddr + 224 + (unsigned int)tmem_row_base_2, (const uint32_t*)_tmem_load_3_bf16);
+                asm volatile("tcgen05.wait::st.sync.aligned;" ::: "memory");
+                asm volatile("barrier.sync 11, 256;" ::: "memory");
+                if (warp_id_in_role_7 == 0) {
+                    if (elect_sync()) {
+                        mbarrier_arrive(de_inp_ready_addr + (low_token_stage) * 8);
+                    }
+                }
+                if (publish_ready != 0 && owned_chunk_2 != 0) {
+                    asm volatile("barrier.sync 13, 128;" ::: "memory");
+                    if (warp_id_in_role_7 == 0) {
+                        if (elect_sync()) {
+                            {
+                                unsigned int* _gc_p = reinterpret_cast<unsigned int*>(boundary_ready) + (chunk_global_3 * (long long)num_heads + (long long)head_idx_3);
+                                unsigned int _gc_old;
+                                asm volatile("atom.release.gpu.global.add.u32 %0, [%1], 1;" : "=r"(_gc_old) : "l"(_gc_p) : "memory");
+                            }
+                        }
+                    }
+                }
+                mbarrier_wait(dh_ready_addr + (low_token_stage) * 8, _phase_dh_ready_2);
+                low_token_stage += 1;
+                if (low_token_stage == 1) { low_token_stage = 0; _phase_dr_ready_1 ^= 1; _phase_dx_ready_1 ^= 1; _phase_dh_ready_2 ^= 1; }
+            }
+            if (elect_sync()) {
+                mbarrier_arrive(owners_done_addr);
+            }
+        }
+    }
+
+    // Cleanup
+}
+
+} // extern "C"
+
+#undef LOOM_INF
+#undef NUM_PREP_PIPE_STAGES
+#undef NUM_REVERSE_PIPE_STAGES
+#undef SMEM_SMEM_J_OFF
+#undef SMEM_SMEM_J_STAGE_BYTES
+#undef SMEM_SMEM_J_STRIDE
+#undef SMEM_SMEM_J_TRANS_OFF
+#undef SMEM_SMEM_J_TRANS_STAGE_BYTES
+#undef SMEM_SMEM_J_TRANS_STRIDE
+#undef SMEM_SMEM_KD_OFF
+#undef SMEM_SMEM_KD_STAGE_BYTES
+#undef SMEM_SMEM_KD_STRIDE
+#undef SMEM_SMEM_KD_TRANS_OFF
+#undef SMEM_SMEM_KD_TRANS_STAGE_BYTES
+#undef SMEM_SMEM_KD_TRANS_STRIDE
+#undef SMEM_SMEM_KI_OFF
+#undef SMEM_SMEM_KI_STAGE_BYTES
+#undef SMEM_SMEM_KI_STRIDE
+#undef SMEM_SMEM_KR_OFF
+#undef SMEM_SMEM_KR_STAGE_BYTES
+#undef SMEM_SMEM_KR_STRIDE
+#undef SMEM_SMEM_N_OFF
+#undef SMEM_SMEM_N_STAGE_BYTES
+#undef SMEM_SMEM_N_STRIDE
+#undef SMEM_SMEM_QD_OFF
+#undef SMEM_SMEM_QD_STAGE_BYTES
+#undef SMEM_SMEM_QD_STRIDE
+#undef SMEM_SMEM_QD_TRANS_OFF
+#undef SMEM_SMEM_QD_TRANS_STAGE_BYTES
+#undef SMEM_SMEM_QD_TRANS_STRIDE
+#undef SMEM_SMEM_WORK_ITEM_COMPUTE_END_OFF
+#undef SMEM_SMEM_WORK_ITEM_COMPUTE_END_STAGE_BYTES
+#undef SMEM_SMEM_WORK_ITEM_COMPUTE_END_STRIDE
+#undef SMEM_SMEM_WORK_ITEM_RESOLVED_OFF
+#undef SMEM_SMEM_WORK_ITEM_RESOLVED_STAGE_BYTES
+#undef SMEM_SMEM_WORK_ITEM_RESOLVED_STRIDE
+#undef SMEM_SMEM_WORK_ITEM_WARP_MAX_OFF
+#undef SMEM_SMEM_WORK_ITEM_WARP_MAX_STAGE_BYTES
+#undef SMEM_SMEM_WORK_ITEM_WARP_MAX_STRIDE
+#undef SMEM_TOTAL
+#undef THREADS
+#undef TMEM_NCOLS
+#undef TMEM_TMEM_DE_INP_OFFSET
+#undef TMEM_TMEM_DH_INP_OFFSET
+#undef TMEM_TMEM_DH_OFFSET
+#undef TMEM_TMEM_DO_FINAL_OFFSET
+#undef TMEM_TMEM_DO_INITIAL_OFFSET
+#undef TMEM_TMEM_DR_INP_OFFSET
+#undef TMEM_TMEM_DR_OFFSET
+#undef TMEM_TMEM_DX_OFFSET
+#undef de_inp_ready_addr
+#undef dh_ready_addr
+#undef dr_inp_ready_addr
+#undef dr_ready_addr
+#undef dx_ready_addr
+#undef owners_done_addr
+#undef prep_ready_addr
+#undef smem_free_addr
+#undef smem_j_addr
+#undef smem_j_trans_addr
+#undef smem_kd_addr
+#undef smem_kd_trans_addr
+#undef smem_ki_addr
+#undef smem_kr_addr
+#undef smem_n_addr
+#undef smem_qd_addr
+#undef smem_qd_trans_addr
+#undef smem_work_item_compute_end_addr
+#undef smem_work_item_resolved_addr
+#undef smem_work_item_warp_max_addr
+#undef work_item_ready_addr
+
+#define LOOM_INF CUDART_INF_F
+#define TMEM_NCOLS 496
+#define TMEM_TMEM_A_DH_OFFSET 0
+#define TMEM_TMEM_A_STATE_OFFSET 64
+#define TMEM_TMEM_A_K_OFFSET 128
+#define TMEM_TMEM_A_Q_OFFSET 144
+#define TMEM_TMEM_A_I_OFFSET 160
+#define TMEM_TMEM_DKR_OFFSET 176
+#define TMEM_TMEM_DI_OFFSET 208
+#define TMEM_TMEM_DQ_LOCAL_OFFSET 240
+#define TMEM_TMEM_DQ_BOUNDARY_OFFSET 272
+#define TMEM_TMEM_DK_LOCAL_OFFSET 304
+#define TMEM_TMEM_DK_BOUNDARY_OFFSET 336
+#define TMEM_TMEM_RECON_KR_OFFSET 64
+#define TMEM_TMEM_RECON_STATE_OFFSET 368
+#define NUM_MAIN_STAGES 1
+#define SMEM_S_K_OFF 1024
+#define SMEM_S_K_STAGE_BYTES 8192
+#define SMEM_S_K_STRIDE 8192
+#define SMEM_S_I_OFF 9216
+#define SMEM_S_I_STAGE_BYTES 8192
+#define SMEM_S_I_STRIDE 8192
+#define SMEM_S_DOT_OFF 17408
+#define SMEM_S_DOT_STAGE_BYTES 8192
+#define SMEM_S_DOT_STRIDE 8192
+#define SMEM_S_RT_OFF 25600
+#define SMEM_S_RT_STAGE_BYTES 8192
+#define SMEM_S_RT_STRIDE 8192
+#define SMEM_S_DRT_OFF 33792
+#define SMEM_S_DRT_STAGE_BYTES 8192
+#define SMEM_S_DRT_STRIDE 8192
+#define SMEM_S_X_OFF 41984
+#define SMEM_S_X_STAGE_BYTES 8192
+#define SMEM_S_X_STRIDE 8192
+#define SMEM_S_DET_OFF 50176
+#define SMEM_S_DET_STAGE_BYTES 8192
+#define SMEM_S_DET_STRIDE 8192
+#define SMEM_S_DOT_TC_OFF 58368
+#define SMEM_S_DOT_TC_STAGE_BYTES 8192
+#define SMEM_S_DOT_TC_STRIDE 8192
+#define SMEM_S_RT_TC_OFF 66560
+#define SMEM_S_RT_TC_STAGE_BYTES 8192
+#define SMEM_S_RT_TC_STRIDE 8192
+#define SMEM_S_DET_TC_OFF 74752
+#define SMEM_S_DET_TC_STAGE_BYTES 8192
+#define SMEM_S_DET_TC_STRIDE 8192
+#define SMEM_S_J_OFF 82944
+#define SMEM_S_J_STAGE_BYTES 2048
+#define SMEM_S_J_STRIDE 2048
+#define SMEM_S_M_OFF 84992
+#define SMEM_S_M_STAGE_BYTES 2048
+#define SMEM_S_M_STRIDE 2048
+#define SMEM_S_DJ_OFF 89088
+#define SMEM_S_DJ_STAGE_BYTES 2048
+#define SMEM_S_DJ_STRIDE 2048
+#define SMEM_S_TMP_OFF 91136
+#define SMEM_S_TMP_STAGE_BYTES 2048
+#define SMEM_S_TMP_STRIDE 2048
+#define SMEM_S_DF_OFF 93184
+#define SMEM_S_DF_STAGE_BYTES 2048
+#define SMEM_S_DF_STRIDE 2048
+#define SMEM_S_DO_STAGE_OFF 89088
+#define SMEM_S_DO_STAGE_STAGE_BYTES 8192
+#define SMEM_S_DO_STAGE_STRIDE 8192
+#define SMEM_S_DN_TC_OFF 97280
+#define SMEM_S_DN_TC_STAGE_BYTES 2048
+#define SMEM_S_DN_TC_STRIDE 2048
+#define SMEM_S_DNT_TC_OFF 99328
+#define SMEM_S_DNT_TC_STAGE_BYTES 2048
+#define SMEM_S_DNT_TC_STRIDE 2048
+#define SMEM_S_DM_TC_OFF 101376
+#define SMEM_S_DM_TC_STAGE_BYTES 2048
+#define SMEM_S_DM_TC_STRIDE 2048
+#define SMEM_S_DMT_TC_OFF 103424
+#define SMEM_S_DMT_TC_STAGE_BYTES 2048
+#define SMEM_S_DMT_TC_STRIDE 2048
+#define SMEM_S_DBETA_PARTIAL_OFF 105472
+#define SMEM_S_DBETA_PARTIAL_STAGE_BYTES 512
+#define SMEM_S_DBETA_PARTIAL_STRIDE 512
+#define SMEM_S_Q_OFF 105984
+#define SMEM_S_Q_STAGE_BYTES 8192
+#define SMEM_S_Q_STRIDE 8192
+#define SMEM_S_PREV_R_TC_OFF 114176
+#define SMEM_S_PREV_R_TC_STAGE_BYTES 8192
+#define SMEM_S_PREV_R_TC_STRIDE 8192
+#define SMEM_S_DH_STAGE_OFF 122368
+#define SMEM_S_DH_STAGE_STAGE_BYTES 32768
+#define SMEM_S_DH_STAGE_STRIDE 32768
+#define SMEM_S_STABLE_DKR_OFF 17408
+#define SMEM_S_STABLE_DKR_STAGE_BYTES 16384
+#define SMEM_S_STABLE_DKR_STRIDE 16384
+#define SMEM_S_STABLE_DELTA_OFF 33792
+#define SMEM_S_STABLE_DELTA_STAGE_BYTES 16384
+#define SMEM_S_STABLE_DELTA_STRIDE 16384
+#define SMEM_S_STABLE_BASE_OFF 50176
+#define SMEM_S_STABLE_BASE_STAGE_BYTES 16384
+#define SMEM_S_STABLE_BASE_STRIDE 16384
+#define SMEM_S_MIDDLE_BASE_SUFFIX_OFF 122368
+#define SMEM_S_MIDDLE_BASE_SUFFIX_STAGE_BYTES 512
+#define SMEM_S_MIDDLE_BASE_SUFFIX_STRIDE 512
+#define SMEM_S_HIGH_BASE_SUFFIX_OFF 122880
+#define SMEM_S_HIGH_BASE_SUFFIX_STAGE_BYTES 512
+#define SMEM_S_HIGH_BASE_SUFFIX_STRIDE 512
+#define SMEM_TOTAL 155136
+#define THREADS 384
+
+extern "C" {
+
+__global__ __launch_bounds__(384) void
+kernel_flashkda_backward_local_c32_tcgen(__nv_bfloat16* __restrict__ do_, float* __restrict__ beta_active, long long* __restrict__ cu_seqlens, int* __restrict__ consumer_chunk_order, int* __restrict__ chunk_sequence, int* __restrict__ chunk_index, __nv_bfloat16* __restrict__ chunk_state, unsigned int* __restrict__ state_checkpoint_needed, float* __restrict__ initial_state, __nv_bfloat16* __restrict__ tape_qd, __nv_bfloat16* __restrict__ tape_kd, __nv_bfloat16* __restrict__ tape_kr, __nv_bfloat16* __restrict__ tape_j, float* __restrict__ tape_restore_factor, __nv_bfloat16* __restrict__ tape_e, __nv_bfloat16* __restrict__ tape_x, __nv_bfloat16* __restrict__ tape_r, __nv_bfloat16* __restrict__ chunk_dh, __nv_bfloat16* __restrict__ chunk_dr, __nv_bfloat16* __restrict__ chunk_dx, unsigned int* __restrict__ boundary_ready, __nv_bfloat16* __restrict__ grad_qd, __nv_bfloat16* __restrict__ grad_kd, __nv_bfloat16* __restrict__ grad_ki, float* __restrict__ dlog_decay, float* __restrict__ dbeta_active, __nv_bfloat16* __restrict__ dv, int num_heads, int boundary_ready_target, float lower_bound)
+{
+    const int tid = threadIdx.x;
+    const int warp = make_warp_uniform(tid / 32);
+    const int lane = tid % 32;
+
+    extern __shared__ __align__(1024) char smem_raw[];
+    int smem;
+    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+
+    const int bid = blockIdx.x;
+    const int num_bids = gridDim.x;
+
+    // Kernel setup ops
+    __nv_bfloat16* s_k = reinterpret_cast<__nv_bfloat16*>(smem_raw + 1024);
+    const int s_k_addr = smem + 1024;
+    __nv_bfloat16* s_i = reinterpret_cast<__nv_bfloat16*>(smem_raw + 9216);
+    const int s_i_addr = smem + 9216;
+    __nv_bfloat16* s_dot = reinterpret_cast<__nv_bfloat16*>(smem_raw + 17408);
+    const int s_dot_addr = smem + 17408;
+    __nv_bfloat16* s_rt = reinterpret_cast<__nv_bfloat16*>(smem_raw + 25600);
+    const int s_rt_addr = smem + 25600;
+    __nv_bfloat16* s_drt = reinterpret_cast<__nv_bfloat16*>(smem_raw + 33792);
+    const int s_drt_addr = smem + 33792;
+    __nv_bfloat16* s_x = reinterpret_cast<__nv_bfloat16*>(smem_raw + 41984);
+    const int s_x_addr = smem + 41984;
+    __nv_bfloat16* s_det = reinterpret_cast<__nv_bfloat16*>(smem_raw + 50176);
+    const int s_det_addr = smem + 50176;
+    __nv_bfloat16* s_dot_tc = reinterpret_cast<__nv_bfloat16*>(smem_raw + 58368);
+    const int s_dot_tc_addr = smem + 58368;
+    __nv_bfloat16* s_rt_tc = reinterpret_cast<__nv_bfloat16*>(smem_raw + 66560);
+    const int s_rt_tc_addr = smem + 66560;
+    __nv_bfloat16* s_det_tc = reinterpret_cast<__nv_bfloat16*>(smem_raw + 74752);
+    const int s_det_tc_addr = smem + 74752;
+    __nv_bfloat16* s_j = reinterpret_cast<__nv_bfloat16*>(smem_raw + 82944);
+    const int s_j_addr = smem + 82944;
+    __nv_bfloat16* s_m = reinterpret_cast<__nv_bfloat16*>(smem_raw + 84992);
+    const int s_m_addr = smem + 84992;
+    __nv_bfloat16* s_dj = reinterpret_cast<__nv_bfloat16*>(smem_raw + 89088);
+    const int s_dj_addr = smem + 89088;
+    __nv_bfloat16* s_tmp = reinterpret_cast<__nv_bfloat16*>(smem_raw + 91136);
+    const int s_tmp_addr = smem + 91136;
+    __nv_bfloat16* s_df = reinterpret_cast<__nv_bfloat16*>(smem_raw + 93184);
+    const int s_df_addr = smem + 93184;
+    __nv_bfloat16* s_do_stage = reinterpret_cast<__nv_bfloat16*>(smem_raw + 89088);
+    const int s_do_stage_addr = smem + 89088;
+    __nv_bfloat16* s_dn_tc = reinterpret_cast<__nv_bfloat16*>(smem_raw + 97280);
+    const int s_dn_tc_addr = smem + 97280;
+    __nv_bfloat16* s_dnt_tc = reinterpret_cast<__nv_bfloat16*>(smem_raw + 99328);
+    const int s_dnt_tc_addr = smem + 99328;
+    __nv_bfloat16* s_dm_tc = reinterpret_cast<__nv_bfloat16*>(smem_raw + 101376);
+    const int s_dm_tc_addr = smem + 101376;
+    __nv_bfloat16* s_dmt_tc = reinterpret_cast<__nv_bfloat16*>(smem_raw + 103424);
+    const int s_dmt_tc_addr = smem + 103424;
+    float* s_dbeta_partial = reinterpret_cast<float*>(smem_raw + 105472);
+    const int s_dbeta_partial_addr = smem + 105472;
+    __nv_bfloat16* s_q = reinterpret_cast<__nv_bfloat16*>(smem_raw + 105984);
+    const int s_q_addr = smem + 105984;
+    __nv_bfloat16* s_prev_r_tc = reinterpret_cast<__nv_bfloat16*>(smem_raw + 114176);
+    const int s_prev_r_tc_addr = smem + 114176;
+    __nv_bfloat16* s_dh_stage = reinterpret_cast<__nv_bfloat16*>(smem_raw + 122368);
+    const int s_dh_stage_addr = smem + 122368;
+    float* s_stable_dkr = reinterpret_cast<float*>(smem_raw + 17408);
+    const int s_stable_dkr_addr = smem + 17408;
+    float* s_stable_delta = reinterpret_cast<float*>(smem_raw + 33792);
+    const int s_stable_delta_addr = smem + 33792;
+    float* s_stable_base = reinterpret_cast<float*>(smem_raw + 50176);
+    const int s_stable_base_addr = smem + 50176;
+    float* s_middle_base_suffix = reinterpret_cast<float*>(smem_raw + 122368);
+    const int s_middle_base_suffix_addr = smem + 122368;
+    float* s_high_base_suffix = reinterpret_cast<float*>(smem_raw + 122880);
+    const int s_high_base_suffix_addr = smem + 122880;
+
+    // Mbarrier init (15 groups, 15 barriers)
+    // Mbarriers at smem_raw[0..120)
+
+    if (warp == 0) {
+        uint32_t leader = elect_sync();
+        if (leader) {
+            // prep_ready: 1 barriers, init_count=1
+            mbarrier_init(smem + 0, 1);
+            // boundary_local_ready: 1 barriers, init_count=1
+            mbarrier_init(smem + 8, 1);
+            // dbeta_done: 1 barriers, init_count=4
+            mbarrier_init(smem + 16, 4);
+            // qki_ready: 1 barriers, init_count=1
+            mbarrier_init(smem + 24, 1);
+            // qki_tc_ready: 1 barriers, init_count=4
+            mbarrier_init(smem + 32, 4);
+            // dv_ready: 1 barriers, init_count=1
+            mbarrier_init(smem + 40, 1);
+            // value_tc_ready: 1 barriers, init_count=3
+            mbarrier_init(smem + 48, 3);
+            // dh_ready: 1 barriers, init_count=1
+            mbarrier_init(smem + 56, 1);
+            // state_tc_ready: 1 barriers, init_count=4
+            mbarrier_init(smem + 64, 4);
+            // recon_inputs_ready: 1 barriers, init_count=4
+            mbarrier_init(smem + 72, 4);
+            // recon_output_ready: 1 barriers, init_count=1
+            mbarrier_init(smem + 80, 1);
+            // a_ready: 1 barriers, init_count=4
+            mbarrier_init(smem + 88, 4);
+            // first_outputs_ready: 1 barriers, init_count=1
+            mbarrier_init(smem + 96, 1);
+            // outputs_ready: 1 barriers, init_count=1
+            mbarrier_init(smem + 104, 1);
+            // epilogue_done: 1 barriers, init_count=4
+            mbarrier_init(smem + 112, 4);
+            asm volatile("fence.mbarrier_init.release.cluster;");
+        }
+    }
+
+    __syncwarp();
+
+    // TMEM alloc (512 columns, 496 used)
+    volatile int* tmem_addr_storage = (volatile int*)(smem_raw + 120);
+    if (warp == 0) {
+        int _tmem_hold = smem + 120;
+        asm volatile("tcgen05.alloc.cta_group::1.sync.aligned.shared::cta.b32 [%0], %1;" :: "r"(_tmem_hold), "r"(512) : "memory");
+        asm volatile("tcgen05.relinquish_alloc_permit.cta_group::1.sync.aligned;");
+    }
+
+    __syncthreads();
+    asm volatile("tcgen05.fence::after_thread_sync;");
+
+    const int mbar_base = smem;
+    #define prep_ready_addr (mbar_base + 0)
+    #define boundary_local_ready_addr (mbar_base + 8)
+    #define dbeta_done_addr (mbar_base + 16)
+    #define qki_ready_addr (mbar_base + 24)
+    #define qki_tc_ready_addr (mbar_base + 32)
+    #define dv_ready_addr (mbar_base + 40)
+    #define value_tc_ready_addr (mbar_base + 48)
+    #define dh_ready_addr (mbar_base + 56)
+    #define state_tc_ready_addr (mbar_base + 64)
+    #define recon_inputs_ready_addr (mbar_base + 72)
+    #define recon_output_ready_addr (mbar_base + 80)
+    #define a_ready_addr (mbar_base + 88)
+    #define first_outputs_ready_addr (mbar_base + 96)
+    #define outputs_ready_addr (mbar_base + 104)
+    #define epilogue_done_addr (mbar_base + 112)
+    const int taddr = tmem_addr_storage[0];
+
+    // Kernel post-init ops
+    const int tmem_tmem_a_dh = taddr;
+    const int tmem_tmem_a_state = taddr + 64;
+    const int tmem_tmem_a_k = taddr + 128;
+    const int tmem_tmem_a_q = taddr + 144;
+    const int tmem_tmem_a_i = taddr + 160;
+    const int tmem_tmem_dkr = taddr + 176;
+    const int tmem_tmem_di = taddr + 208;
+    const int tmem_tmem_dq_local = taddr + 240;
+    const int tmem_tmem_dq_boundary = taddr + 272;
+    const int tmem_tmem_dk_local = taddr + 304;
+    const int tmem_tmem_dk_boundary = taddr + 336;
+    const int tmem_tmem_recon_kr = taddr + 64;
+    const int tmem_tmem_recon_state = taddr + 368;
+
+    // ---- Role: prep ----
+    if (warp <= 3) {
+        asm volatile("setmaxnreg.inc.sync.aligned.u32 208;");
+        { // prep_main
+            int ordered_chunk = blockIdx.x / num_heads;
+            int chunk_global = consumer_chunk_order[ordered_chunk];
+            int head = blockIdx.x - ordered_chunk * num_heads;
+            int sequence = chunk_sequence[chunk_global];
+            int local_chunk = chunk_index[chunk_global];
+            long long bos = cu_seqlens[sequence];
+            long long eos = cu_seqlens[sequence + 1];
+            long long chunk_start = bos + (long long)local_chunk * 32;
+            long long chunk_head = (long long)chunk_global * (long long)num_heads + (long long)head;
+            int warp_id_in_role = (warp - 0);
+            int prep_tid = warp_id_in_role * 32 + lane;
+            long long token_key_base = chunk_head * 32 * 128;
+            long long state_base = chunk_head * 128 * 128;
+            long long restore_base = chunk_head * 128;
+            int restore_key_col = prep_tid * 2 % 128;
+            float _vec_load_0[2];
+            {
+                float2 _v2_0 = *reinterpret_cast<const float2*>(tape_restore_factor + restore_base + (long long)restore_key_col);
+                _vec_load_0[0] = _v2_0.x;
+                _vec_load_0[0 + 1] = _v2_0.y;
+            }
+            float _rcp_0 = approx_rcp(_vec_load_0[0]);
+            float inv_restore0 = _rcp_0;
+            float _rcp_1 = approx_rcp(_vec_load_0[1]);
+            float inv_restore1 = _rcp_1;
+            #pragma unroll
+            for (int key_copy_pass = 0; key_copy_pass < 4; key_copy_pass++) {
+                int key_copy_item = key_copy_pass * 128 * 8 + prep_tid * 8;
+                asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
+                    :: "r"(s_k_addr + (unsigned int)((key_copy_item * 2 ^ (key_copy_item * 2 >> 8 & 7) << 4) / 2 * 2)), "l"(tape_kd + (token_key_base + (long long)key_copy_item)));
+                asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
+                    :: "r"(s_q_addr + (unsigned int)((key_copy_item * 2 ^ (key_copy_item * 2 >> 8 & 7) << 4) / 2 * 2)), "l"(tape_qd + (token_key_base + (long long)key_copy_item)));
+            }
+            asm volatile("cp.async.commit_group;");
+            #pragma unroll
+            for (int key_pass = 0; key_pass < 16; key_pass++) {
+                int item = key_pass * 256 + prep_tid * 2;
+                float _vec_load_1[2];
+                {
+                    uint32_t _bf16x2_bits_1;
+                    _bf16x2_bits_1 = *reinterpret_cast<const uint32_t*>(tape_kr + token_key_base + (long long)item);
+                    asm volatile(
+                        "{\n\t"
+                        "shl.b32 %0, %2, 16;\n\t"
+                        "and.b32 %1, %2, 0xffff0000;\n\t"
+                        "}\n"
+                        : "=f"((&_vec_load_1[0])[0]), "=f"((&_vec_load_1[0])[1])
+                        : "r"(_bf16x2_bits_1));
+                }
+                float i_values[2];
+                unsigned int i_packed[1];
+                i_values[0] = _vec_load_1[0] * inv_restore0;
+                i_values[1] = _vec_load_1[1] * inv_restore1;
+                #pragma unroll
+                for (int _lp = 0; _lp < 1; _lp++) {
+                    __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(i_values[_lp*2 + 0], i_values[_lp*2+1 + 0]));
+                    i_packed[_lp] = *(uint32_t*)&_bf2;
+                }
+                asm volatile("st.shared.b32 [%0], %1;" :: "r"(s_i_addr + (unsigned int)((item * 2 ^ (item * 2 >> 8 & 7) << 4) / 2 * 2)), "r"((i_packed[0])));
+            }
+            asm volatile("cp.async.wait_group 0;");
+            asm volatile("barrier.sync 8, 128;" ::: "memory");
+            if (warp_id_in_role == 0) {
+                if (elect_sync()) {
+                    mbarrier_arrive(qki_ready_addr);
+                }
+            }
+            long long j_base = chunk_head * 32 * 32;
+            #pragma unroll
+            for (int j_pass = 0; j_pass < 8; j_pass++) {
+                int item_1 = j_pass * 128 + prep_tid;
+                s_j[(item_1 * 2 ^ (item_1 * 2 >> 7 & 7) << 4) / 2] = tape_j[j_base + (long long)item_1];
+            }
+            long long token_value_base = chunk_head * 128 * 32;
+            #pragma unroll
+            for (int value_copy_pass = 0; value_copy_pass < 4; value_copy_pass++) {
+                int value_copy_item = value_copy_pass * 128 * 8 + prep_tid * 8;
+                int value_copy_dst = (value_copy_item * 2 ^ (value_copy_item * 2 >> 7 & 7) << 4) / 2 * 2;
+                asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
+                    :: "r"(s_x_addr + (unsigned int)value_copy_dst), "l"(tape_x + (token_value_base + (long long)value_copy_item)));
+                asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
+                    :: "r"(s_rt_addr + (unsigned int)value_copy_dst), "l"(tape_r + (token_value_base + (long long)value_copy_item)));
+            }
+            asm volatile("cp.async.commit_group;");
+            int tile = warp_id_in_role;
+            int row_base = tile / 2 * 16;
+            int col_base = tile % 2 * 16;
+            float acc[8];
+            int lane_matrix = lane / 8;
+            int lane_row8 = lane & 7;
+            #pragma unroll
+            for (int kk = 0; kk < 128; kk += 16) {
+                unsigned int a_plain[4];
+                unsigned int a_trans[4];
+                unsigned int b_plain[4];
+                unsigned int b_trans[4];
+                {
+                    int a_row = row_base + lane_row8 + (lane_matrix & 1) * 8;
+                    int a_col = kk + lane_matrix / 2 * 8;
+                    asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                        : "=r"(a_plain[0]), "=r"(a_plain[1]), "=r"(a_plain[2]), "=r"(a_plain[3])
+                        : "r"(s_k_addr + (unsigned int)(((1) ? ((a_row * 128 + a_col) * 2 ^ ((a_row * 128 + a_col) * 2 >> 8 & 7) << 4) / 2 : ((a_row * 128 + a_col) * 2 ^ ((a_row * 128 + a_col) * 2 >> 7 & 7) << 4) / 2) * 2))
+                        : "memory");
+                }
+                {
+                    #pragma unroll
+                    for (int n_half = 0; n_half < 2; n_half++) {
+                        int b_row = col_base + n_half * 8 + lane_row8;
+                        int b_col = kk + lane / 8 * 8;
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x2.shared.b16 {%0, %1}, [%2];\n"
+                            : "=r"(b_plain[n_half * 2]), "=r"(b_plain[n_half * 2 + 1])
+                            : "r"(s_i_addr + (unsigned int)(((1) ? ((b_row * 128 + b_col) * 2 ^ ((b_row * 128 + b_col) * 2 >> 8 & 7) << 4) / 2 : ((b_row * 128 + b_col) * 2 ^ ((b_row * 128 + b_col) * 2 >> 7 & 7) << 4) / 2) * 2))
+                            : "memory");
+                    }
+                }
+                {
+                    {
+                        {
+                            asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%10, %11, %12, %13};\n"
+                                : "=f"(acc[0]), "=f"(acc[1]), "=f"(acc[2]), "=f"(acc[3])
+                                : "r"(a_plain[0]), "r"(a_plain[1]), "r"(a_plain[2]), "r"(a_plain[3]), "r"(b_plain[0]), "r"(b_plain[1]), "f"(((kk == 0) ? 0.0f : acc[0])), "f"(((kk == 0) ? 0.0f : acc[1])), "f"(((kk == 0) ? 0.0f : acc[2])), "f"(((kk == 0) ? 0.0f : acc[3])));
+                            asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%10, %11, %12, %13};\n"
+                                : "=f"(acc[4]), "=f"(acc[(4) + 1]), "=f"(acc[(4) + 2]), "=f"(acc[(4) + 3])
+                                : "r"(a_plain[0]), "r"(a_plain[1]), "r"(a_plain[2]), "r"(a_plain[3]), "r"(b_plain[2]), "r"(b_plain[(2) + 1]), "f"(((kk == 0) ? 0.0f : acc[4])), "f"(((kk == 0) ? 0.0f : acc[(4) + 1])), "f"(((kk == 0) ? 0.0f : acc[(4) + 2])), "f"(((kk == 0) ? 0.0f : acc[(4) + 3])));
+                        }
+                    }
+                }
+            }
+            int frag_row = lane / 4;
+            int frag_col = (lane & 3) * 2;
+            #pragma unroll
+            for (int n_half_1 = 0; n_half_1 < 2; n_half_1++) {
+                int frag = n_half_1 * 4;
+                int row0 = row_base + frag_row;
+                int row1 = row0 + 8;
+                int col0 = col_base + n_half_1 * 8 + frag_col;
+                float pair[2];
+                unsigned int packed[1];
+                pair[0] = acc[frag];
+                pair[1] = acc[frag + 1];
+                #pragma unroll
+                for (int _lp = 0; _lp < 1; _lp++) {
+                    __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(pair[_lp*2 + 0], pair[_lp*2+1 + 0]));
+                    packed[_lp] = *(uint32_t*)&_bf2;
+                }
+                asm volatile("st.shared.b32 [%0], %1;" :: "r"(s_m_addr + (unsigned int)(((row0 * 32 + col0) * 2 ^ ((row0 * 32 + col0) * 2 >> 7 & 7) << 4) / 2 * 2)), "r"((packed[0])));
+                pair[0] = acc[frag + 2];
+                pair[1] = acc[frag + 3];
+                #pragma unroll
+                for (int _lp = 0; _lp < 1; _lp++) {
+                    __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(pair[_lp*2 + 0], pair[_lp*2+1 + 0]));
+                    packed[_lp] = *(uint32_t*)&_bf2;
+                }
+                asm volatile("st.shared.b32 [%0], %1;" :: "r"(s_m_addr + (unsigned int)(((row1 * 32 + col0) * 2 ^ ((row1 * 32 + col0) * 2 >> 7 & 7) << 4) / 2 * 2)), "r"((packed[0])));
+            }
+            asm volatile("barrier.sync 8, 128;" ::: "memory");
+            if (boundary_ready_target != 0) {
+                if (warp_id_in_role == 0) {
+                    {
+                        unsigned int* _gca_p = reinterpret_cast<unsigned int*>(boundary_ready) + (chunk_head);
+                        while (true) {
+                            unsigned int _gca_v;
+                            asm volatile("ld.acquire.gpu.global.u32 %0, [%1];" : "=r"(_gca_v) : "l"(_gca_p));
+                            if (_gca_v >= (unsigned int)(boundary_ready_target)) break;
+                        }
+                    }
+                }
+                asm volatile("barrier.sync 8, 128;" ::: "memory");
+            }
+            if (warp_id_in_role == 0) {
+                if (elect_sync()) {
+                    mbarrier_arrive(boundary_local_ready_addr);
+                }
+            }
+            #pragma unroll
+            for (int dh_copy_pass = 0; dh_copy_pass < 16; dh_copy_pass++) {
+                int dh_copy_item = dh_copy_pass * 128 * 8 + prep_tid * 8;
+                asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
+                    :: "r"(s_dh_stage_addr + (unsigned int)((dh_copy_item * 2 ^ (dh_copy_item * 2 >> 7 & 7) << 4) / 2 * 2)), "l"(chunk_dh + (state_base + (long long)dh_copy_item)));
+            }
+            asm volatile("cp.async.commit_group;");
+            #pragma unroll
+            for (int boundary_copy_pass = 0; boundary_copy_pass < 4; boundary_copy_pass++) {
+                int boundary_copy_item = boundary_copy_pass * 128 * 8 + prep_tid * 8;
+                int boundary_copy_dst = (boundary_copy_item * 2 ^ (boundary_copy_item * 2 >> 7 & 7) << 4) / 2 * 2;
+                asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
+                    :: "r"(s_dot_addr + (unsigned int)boundary_copy_dst), "l"(chunk_dx + (token_value_base + (long long)boundary_copy_item)));
+            }
+            asm volatile("cp.async.commit_group;");
+            asm volatile("cp.async.wait_group 2;");
+            asm volatile("barrier.sync 8, 128;" ::: "memory");
+            int value_token = lane;
+            long long value_token_global = chunk_start + (long long)value_token;
+            float value_beta = 0.0f;
+            if (value_token_global < eos) {
+                value_beta = beta_active[value_token_global * (long long)num_heads + (long long)head];
+            }
+            #pragma unroll
+            for (int value_segment = 0; value_segment < 4; value_segment++) {
+                int tc_segment = warp_id_in_role * 4 + value_segment;
+                float r_values[8];
+                #pragma unroll
+                for (int value_elem = 0; value_elem < 8; value_elem++) {
+                    int value_row = tc_segment * 8 + value_elem;
+                    int value_major_item = value_row * 32 + value_token;
+                    __nv_bfloat16 r_value = s_rt[(value_major_item * 2 ^ (value_major_item * 2 >> 7 & 7) << 4) / 2];
+                    float _cvt_f32_0 = __bfloat162float(r_value);
+                    r_values[value_elem] = _cvt_f32_0;
+                }
+                unsigned int packed_1[4];
+                #pragma unroll
+                for (int _lp = 0; _lp < 4; _lp++) {
+                    __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(r_values[_lp*2 + 0], r_values[_lp*2+1 + 0]));
+                    packed_1[_lp] = *(uint32_t*)&_bf2;
+                }
+                asm volatile("st.shared.v4.b32 [%0], {%1,%2,%3,%4};" :: "r"(s_rt_tc_addr + ((s_rt_tc_addr + (unsigned int)(tc_segment * 8 / 64 * 4096 + value_token * 128 + tc_segment * 8 % 64 * 2 ^ (tc_segment * 8 / 64 * 4096 + value_token * 128 + tc_segment * 8 % 64 * 2 >> 7 & 7) << 4)) - s_rt_tc_addr)), "r"(packed_1[0]), "r"(packed_1[1]), "r"(packed_1[2]), "r"(packed_1[3]) : "memory");
+            }
+            asm volatile("cp.async.wait_group 1;");
+            asm volatile("barrier.sync 8, 128;" ::: "memory");
+            if (warp_id_in_role == 0) {
+                if (elect_sync()) {
+                    mbarrier_arrive(dh_ready_addr);
+                }
+            }
+            asm volatile("cp.async.wait_group 0;");
+            asm volatile("barrier.sync 8, 128;" ::: "memory");
+            #pragma unroll
+            for (int value_segment_1 = 0; value_segment_1 < 4; value_segment_1++) {
+                int tc_segment_1 = warp_id_in_role * 4 + value_segment_1;
+                float det_values[8];
+                #pragma unroll
+                for (int value_elem_1 = 0; value_elem_1 < 8; value_elem_1++) {
+                    int value_row_1 = tc_segment_1 * 8 + value_elem_1;
+                    int value_major_item_1 = value_row_1 * 32 + value_token;
+                    __nv_bfloat16 dx_value = s_dot[(value_major_item_1 * 2 ^ (value_major_item_1 * 2 >> 7 & 7) << 4) / 2];
+                    int det_group = tc_segment_1 * 2 + value_elem_1 / 4;
+                    s_det[value_row_1 * 32 + (value_token ^ det_group)] = dx_value;
+                    float _cvt_f32_1 = __bfloat162float(dx_value);
+                    det_values[value_elem_1] = _cvt_f32_1 * value_beta;
+                }
+                unsigned int packed_2[4];
+                #pragma unroll
+                for (int _lp = 0; _lp < 4; _lp++) {
+                    __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(det_values[_lp*2 + 0], det_values[_lp*2+1 + 0]));
+                    packed_2[_lp] = *(uint32_t*)&_bf2;
+                }
+                asm volatile("st.shared.v4.b32 [%0], {%1,%2,%3,%4};" :: "r"(s_det_tc_addr + ((s_det_tc_addr + (unsigned int)(tc_segment_1 * 8 / 64 * 4096 + value_token * 128 + tc_segment_1 * 8 % 64 * 2 ^ (tc_segment_1 * 8 / 64 * 4096 + value_token * 128 + tc_segment_1 * 8 % 64 * 2 >> 7 & 7) << 4)) - s_det_tc_addr)), "r"(packed_2[0]), "r"(packed_2[1]), "r"(packed_2[2]), "r"(packed_2[3]) : "memory");
+            }
+            asm volatile("barrier.sync 8, 128;" ::: "memory");
+            asm volatile("fence.proxy.async.shared::cta;" ::: "memory");
+            if (warp_id_in_role == 0) {
+                if (elect_sync()) {
+                    mbarrier_arrive(dv_ready_addr);
+                }
+            }
+            unsigned int _phase_value_tc_ready_0 = 0;
+            mbarrier_wait(value_tc_ready_addr, _phase_value_tc_ready_0);
+            _phase_value_tc_ready_0 ^= 1;
+            asm volatile("barrier.sync 8, 128;" ::: "memory");
+            int lane_matrix_0 = lane / 8;
+            int lane_row8_1 = lane & 7;
+            #pragma unroll
+            for (int kk_1 = 0; kk_1 < 128; kk_1 += 16) {
+                unsigned int a_plain_1[4];
+                unsigned int a_trans_1[4];
+                unsigned int b_plain_1[4];
+                unsigned int b_trans_1[4];
+                {
+                    int a_row_1 = kk_1 + lane_row8_1 + lane_matrix_0 / 2 * 8;
+                    int a_col_1 = row_base + (lane_matrix_0 & 1) * 8;
+                    asm volatile("ldmatrix.sync.aligned.m8n8.x4.trans.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                        : "=r"(a_trans_1[0]), "=r"(a_trans_1[1]), "=r"(a_trans_1[2]), "=r"(a_trans_1[3])
+                        : "r"(s_rt_addr + (unsigned int)(((0) ? ((a_row_1 * 32 + a_col_1) * 2 ^ ((a_row_1 * 32 + a_col_1) * 2 >> 8 & 7) << 4) / 2 : ((a_row_1 * 32 + a_col_1) * 2 ^ ((a_row_1 * 32 + a_col_1) * 2 >> 7 & 7) << 4) / 2) * 2))
+                        : "memory");
+                }
+                {
+                    #pragma unroll
+                    for (int n_half_2 = 0; n_half_2 < 2; n_half_2++) {
+                        int b_row_1 = col_base + n_half_2 * 8 + lane_row8_1;
+                        int b_col_1 = kk_1 + lane / 8 * 8;
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x2.shared.b16 {%0, %1}, [%2];\n"
+                            : "=r"(b_plain_1[n_half_2 * 2]), "=r"(b_plain_1[n_half_2 * 2 + 1])
+                            : "r"(s_do_stage_addr + (unsigned int)(((1) ? ((b_row_1 * 128 + b_col_1) * 2 ^ ((b_row_1 * 128 + b_col_1) * 2 >> 8 & 7) << 4) / 2 : ((b_row_1 * 128 + b_col_1) * 2 ^ ((b_row_1 * 128 + b_col_1) * 2 >> 7 & 7) << 4) / 2) * 2))
+                            : "memory");
+                    }
+                }
+                {
+                    {
+                        {
+                            asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%10, %11, %12, %13};\n"
+                                : "=f"(acc[0]), "=f"(acc[1]), "=f"(acc[2]), "=f"(acc[3])
+                                : "r"(a_trans_1[0]), "r"(a_trans_1[1]), "r"(a_trans_1[2]), "r"(a_trans_1[3]), "r"(b_plain_1[0]), "r"(b_plain_1[1]), "f"(((kk_1 == 0) ? 0.0f : acc[0])), "f"(((kk_1 == 0) ? 0.0f : acc[1])), "f"(((kk_1 == 0) ? 0.0f : acc[2])), "f"(((kk_1 == 0) ? 0.0f : acc[3])));
+                            asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%10, %11, %12, %13};\n"
+                                : "=f"(acc[4]), "=f"(acc[(4) + 1]), "=f"(acc[(4) + 2]), "=f"(acc[(4) + 3])
+                                : "r"(a_trans_1[0]), "r"(a_trans_1[1]), "r"(a_trans_1[2]), "r"(a_trans_1[3]), "r"(b_plain_1[2]), "r"(b_plain_1[(2) + 1]), "f"(((kk_1 == 0) ? 0.0f : acc[4])), "f"(((kk_1 == 0) ? 0.0f : acc[(4) + 1])), "f"(((kk_1 == 0) ? 0.0f : acc[(4) + 2])), "f"(((kk_1 == 0) ? 0.0f : acc[(4) + 3])));
+                        }
+                    }
+                }
+            }
+            float dn_values[8];
+            dn_values[0] = 0.0f;
+            dn_values[1] = 0.0f;
+            dn_values[2] = 0.0f;
+            dn_values[3] = 0.0f;
+            dn_values[4] = 0.0f;
+            dn_values[5] = 0.0f;
+            dn_values[6] = 0.0f;
+            dn_values[7] = 0.0f;
+            int dn_row0 = row_base + lane / 4;
+            int dn_row1 = dn_row0 + 8;
+            int dn_col0 = col_base + (lane & 3) * 2;
+            if (dn_row0 <= dn_col0) {
+                dn_values[0] = acc[0];
+            }
+            if (dn_row0 <= dn_col0 + 1) {
+                dn_values[1] = acc[1];
+            }
+            if (dn_row1 <= dn_col0) {
+                dn_values[2] = acc[2];
+            }
+            if (dn_row1 <= dn_col0 + 1) {
+                dn_values[3] = acc[3];
+            }
+            if (dn_row0 <= dn_col0 + 8) {
+                dn_values[4] = acc[4];
+            }
+            if (dn_row0 <= dn_col0 + 9) {
+                dn_values[5] = acc[5];
+            }
+            if (dn_row1 <= dn_col0 + 8) {
+                dn_values[6] = acc[6];
+            }
+            if (dn_row1 <= dn_col0 + 9) {
+                dn_values[7] = acc[7];
+            }
+            unsigned int packed_3[4];
+            #pragma unroll
+            for (int _lp = 0; _lp < 4; _lp++) {
+                __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(dn_values[_lp*2 + 0], dn_values[_lp*2+1 + 0]));
+                packed_3[_lp] = *(uint32_t*)&_bf2;
+            }
+            int direct_row = row_base + lane % 16;
+            int direct_col = col_base + lane / 16 * 8;
+            uint32_t _stmatrix_addr_2 = static_cast<uint32_t>((unsigned long long)(s_dnt_tc_addr + (unsigned int)(direct_col / 16 * 1024 + direct_row * 32 + direct_col % 16 * 2 ^ (direct_col / 16 * 1024 + direct_row * 32 + direct_col % 16 * 2 >> 7 & 1) << 4)));
+            asm volatile("stmatrix.sync.aligned.m8n8.x4.shared.b16 [%0], {%1, %2, %3, %4};\n"
+                :: "r"(_stmatrix_addr_2), "r"(*reinterpret_cast<const uint32_t*>(&packed_3[0])), "r"(*reinterpret_cast<const uint32_t*>(&packed_3[1])), "r"(*reinterpret_cast<const uint32_t*>(&packed_3[2])), "r"(*reinterpret_cast<const uint32_t*>(&packed_3[3]))
+                : "memory");
+            #pragma unroll
+            for (int publish_pair = 0; publish_pair < 2; publish_pair++) {
+                int transpose_row = col_base + publish_pair * 8 + (lane & 7);
+                int transpose_col = row_base + lane / 8 * 8;
+                uint32_t _stmatrix_addr_3 = static_cast<uint32_t>((unsigned long long)(s_dn_tc_addr + (unsigned int)(transpose_col / 16 * 1024 + transpose_row * 32 + transpose_col % 16 * 2 ^ (transpose_col / 16 * 1024 + transpose_row * 32 + transpose_col % 16 * 2 >> 7 & 1) << 4)));
+                asm volatile("stmatrix.sync.aligned.m8n8.x2.trans.shared.b16 [%0], {%1, %2};\n"
+                    :: "r"(_stmatrix_addr_3), "r"(*reinterpret_cast<const uint32_t*>(&packed_3[publish_pair * 2])), "r"(*reinterpret_cast<const uint32_t*>(&packed_3[publish_pair * 2 + 1]))
+                    : "memory");
+            }
+            int lane_matrix_2 = lane / 8;
+            int lane_row8_3 = lane & 7;
+            #pragma unroll
+            for (int kk_2 = 0; kk_2 < 128; kk_2 += 16) {
+                unsigned int a_plain_2[4];
+                unsigned int a_trans_2[4];
+                unsigned int b_plain_2[4];
+                unsigned int b_trans_2[4];
+                {
+                    int a_row_2 = kk_2 + lane_row8_3 + lane_matrix_2 / 2 * 8;
+                    int a_col_2 = row_base + (lane_matrix_2 & 1) * 8;
+                    asm volatile("ldmatrix.sync.aligned.m8n8.x4.trans.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                        : "=r"(a_trans_2[0]), "=r"(a_trans_2[1]), "=r"(a_trans_2[2]), "=r"(a_trans_2[3])
+                        : "r"(s_drt_addr + (unsigned int)(((0) ? ((a_row_2 * 32 + a_col_2) * 2 ^ ((a_row_2 * 32 + a_col_2) * 2 >> 8 & 7) << 4) / 2 : ((a_row_2 * 32 + a_col_2) * 2 ^ ((a_row_2 * 32 + a_col_2) * 2 >> 7 & 7) << 4) / 2) * 2))
+                        : "memory");
+                }
+                {
+                    #pragma unroll
+                    for (int n_half_3 = 0; n_half_3 < 2; n_half_3++) {
+                        int b_row_2 = kk_2 + lane % 16;
+                        int b_col_2 = col_base + n_half_3 * 8;
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x2.trans.shared.b16 {%0, %1}, [%2];\n"
+                            : "=r"(b_trans_2[n_half_3 * 2]), "=r"(b_trans_2[n_half_3 * 2 + 1])
+                            : "r"(s_x_addr + (unsigned int)(((0) ? ((b_row_2 * 32 + b_col_2) * 2 ^ ((b_row_2 * 32 + b_col_2) * 2 >> 8 & 7) << 4) / 2 : ((b_row_2 * 32 + b_col_2) * 2 ^ ((b_row_2 * 32 + b_col_2) * 2 >> 7 & 7) << 4) / 2) * 2))
+                            : "memory");
+                    }
+                }
+                {
+                    {
+                        {
+                            asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%10, %11, %12, %13};\n"
+                                : "=f"(acc[0]), "=f"(acc[1]), "=f"(acc[2]), "=f"(acc[3])
+                                : "r"(a_trans_2[0]), "r"(a_trans_2[1]), "r"(a_trans_2[2]), "r"(a_trans_2[3]), "r"(b_trans_2[0]), "r"(b_trans_2[1]), "f"(((kk_2 == 0) ? 0.0f : acc[0])), "f"(((kk_2 == 0) ? 0.0f : acc[1])), "f"(((kk_2 == 0) ? 0.0f : acc[2])), "f"(((kk_2 == 0) ? 0.0f : acc[3])));
+                            asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%10, %11, %12, %13};\n"
+                                : "=f"(acc[4]), "=f"(acc[(4) + 1]), "=f"(acc[(4) + 2]), "=f"(acc[(4) + 3])
+                                : "r"(a_trans_2[0]), "r"(a_trans_2[1]), "r"(a_trans_2[2]), "r"(a_trans_2[3]), "r"(b_trans_2[2]), "r"(b_trans_2[(2) + 1]), "f"(((kk_2 == 0) ? 0.0f : acc[4])), "f"(((kk_2 == 0) ? 0.0f : acc[(4) + 1])), "f"(((kk_2 == 0) ? 0.0f : acc[(4) + 2])), "f"(((kk_2 == 0) ? 0.0f : acc[(4) + 3])));
+                        }
+                    }
+                }
+            }
+            int frag_row_4 = lane / 4;
+            int frag_col_5 = (lane & 3) * 2;
+            #pragma unroll
+            for (int n_half_4 = 0; n_half_4 < 2; n_half_4++) {
+                int frag_1 = n_half_4 * 4;
+                int row0_1 = row_base + frag_row_4;
+                int row1_1 = row0_1 + 8;
+                int col0_1 = col_base + n_half_4 * 8 + frag_col_5;
+                float pair_1[2];
+                unsigned int packed_0[1];
+                pair_1[0] = acc[frag_1];
+                pair_1[1] = acc[frag_1 + 1];
+                #pragma unroll
+                for (int _lp = 0; _lp < 1; _lp++) {
+                    __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(pair_1[_lp*2 + 0], pair_1[_lp*2+1 + 0]));
+                    packed_0[_lp] = *(uint32_t*)&_bf2;
+                }
+                asm volatile("st.shared.b32 [%0], %1;" :: "r"(s_dj_addr + (unsigned int)(((row0_1 * 32 + col0_1) * 2 ^ ((row0_1 * 32 + col0_1) * 2 >> 7 & 7) << 4) / 2 * 2)), "r"((packed_0[0])));
+                pair_1[0] = acc[frag_1 + 2];
+                pair_1[1] = acc[frag_1 + 3];
+                #pragma unroll
+                for (int _lp = 0; _lp < 1; _lp++) {
+                    __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(pair_1[_lp*2 + 0], pair_1[_lp*2+1 + 0]));
+                    packed_0[_lp] = *(uint32_t*)&_bf2;
+                }
+                asm volatile("st.shared.b32 [%0], %1;" :: "r"(s_dj_addr + (unsigned int)(((row1_1 * 32 + col0_1) * 2 ^ ((row1_1 * 32 + col0_1) * 2 >> 7 & 7) << 4) / 2 * 2)), "r"((packed_0[0])));
+            }
+            asm volatile("barrier.sync 8, 128;" ::: "memory");
+            #pragma unroll
+            for (int mask_pass = 0; mask_pass < 8; mask_pass++) {
+                int item_2 = mask_pass * 128 + prep_tid;
+                int row = item_2 / 32;
+                int col = item_2 % 32;
+                if (row <= col) {
+                    s_m[(item_2 * 2 ^ (item_2 * 2 >> 7 & 7) << 4) / 2] = 0.0f;
+                }
+            }
+            asm volatile("barrier.sync 8, 128;" ::: "memory");
+            int lane_matrix_6 = lane / 8;
+            int lane_row8_7 = lane & 7;
+            #pragma unroll
+            for (int kk_3 = 0; kk_3 < 32; kk_3 += 16) {
+                unsigned int a_plain_3[4];
+                unsigned int a_trans_3[4];
+                unsigned int b_plain_3[4];
+                unsigned int b_trans_3[4];
+                {
+                    int a_row_3 = kk_3 + lane_row8_7 + lane_matrix_6 / 2 * 8;
+                    int a_col_3 = row_base + (lane_matrix_6 & 1) * 8;
+                    asm volatile("ldmatrix.sync.aligned.m8n8.x4.trans.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                        : "=r"(a_trans_3[0]), "=r"(a_trans_3[1]), "=r"(a_trans_3[2]), "=r"(a_trans_3[3])
+                        : "r"(s_j_addr + (unsigned int)(((0) ? ((a_row_3 * 32 + a_col_3) * 2 ^ ((a_row_3 * 32 + a_col_3) * 2 >> 8 & 7) << 4) / 2 : ((a_row_3 * 32 + a_col_3) * 2 ^ ((a_row_3 * 32 + a_col_3) * 2 >> 7 & 7) << 4) / 2) * 2))
+                        : "memory");
+                }
+                {
+                    #pragma unroll
+                    for (int n_half_5 = 0; n_half_5 < 2; n_half_5++) {
+                        int b_row_3 = kk_3 + lane % 16;
+                        int b_col_3 = col_base + n_half_5 * 8;
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x2.trans.shared.b16 {%0, %1}, [%2];\n"
+                            : "=r"(b_trans_3[n_half_5 * 2]), "=r"(b_trans_3[n_half_5 * 2 + 1])
+                            : "r"(s_dj_addr + (unsigned int)(((0) ? ((b_row_3 * 32 + b_col_3) * 2 ^ ((b_row_3 * 32 + b_col_3) * 2 >> 8 & 7) << 4) / 2 : ((b_row_3 * 32 + b_col_3) * 2 ^ ((b_row_3 * 32 + b_col_3) * 2 >> 7 & 7) << 4) / 2) * 2))
+                            : "memory");
+                    }
+                }
+                {
+                    {
+                        {
+                            asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%10, %11, %12, %13};\n"
+                                : "=f"(acc[0]), "=f"(acc[1]), "=f"(acc[2]), "=f"(acc[3])
+                                : "r"(a_trans_3[0]), "r"(a_trans_3[1]), "r"(a_trans_3[2]), "r"(a_trans_3[3]), "r"(b_trans_3[0]), "r"(b_trans_3[1]), "f"(((kk_3 == 0) ? 0.0f : acc[0])), "f"(((kk_3 == 0) ? 0.0f : acc[1])), "f"(((kk_3 == 0) ? 0.0f : acc[2])), "f"(((kk_3 == 0) ? 0.0f : acc[3])));
+                            asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%10, %11, %12, %13};\n"
+                                : "=f"(acc[4]), "=f"(acc[(4) + 1]), "=f"(acc[(4) + 2]), "=f"(acc[(4) + 3])
+                                : "r"(a_trans_3[0]), "r"(a_trans_3[1]), "r"(a_trans_3[2]), "r"(a_trans_3[3]), "r"(b_trans_3[2]), "r"(b_trans_3[(2) + 1]), "f"(((kk_3 == 0) ? 0.0f : acc[4])), "f"(((kk_3 == 0) ? 0.0f : acc[(4) + 1])), "f"(((kk_3 == 0) ? 0.0f : acc[(4) + 2])), "f"(((kk_3 == 0) ? 0.0f : acc[(4) + 3])));
+                        }
+                    }
+                }
+            }
+            int frag_row_8 = lane / 4;
+            int frag_col_9 = (lane & 3) * 2;
+            #pragma unroll
+            for (int n_half_6 = 0; n_half_6 < 2; n_half_6++) {
+                int frag_2 = n_half_6 * 4;
+                int row0_2 = row_base + frag_row_8;
+                int row1_2 = row0_2 + 8;
+                int col0_2 = col_base + n_half_6 * 8 + frag_col_9;
+                float pair_2[2];
+                unsigned int packed_0_1[1];
+                pair_2[0] = acc[frag_2];
+                pair_2[1] = acc[frag_2 + 1];
+                #pragma unroll
+                for (int _lp = 0; _lp < 1; _lp++) {
+                    __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(pair_2[_lp*2 + 0], pair_2[_lp*2+1 + 0]));
+                    packed_0_1[_lp] = *(uint32_t*)&_bf2;
+                }
+                asm volatile("st.shared.b32 [%0], %1;" :: "r"(s_tmp_addr + (unsigned int)(((row0_2 * 32 + col0_2) * 2 ^ ((row0_2 * 32 + col0_2) * 2 >> 7 & 7) << 4) / 2 * 2)), "r"((packed_0_1[0])));
+                pair_2[0] = acc[frag_2 + 2];
+                pair_2[1] = acc[frag_2 + 3];
+                #pragma unroll
+                for (int _lp = 0; _lp < 1; _lp++) {
+                    __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(pair_2[_lp*2 + 0], pair_2[_lp*2+1 + 0]));
+                    packed_0_1[_lp] = *(uint32_t*)&_bf2;
+                }
+                asm volatile("st.shared.b32 [%0], %1;" :: "r"(s_tmp_addr + (unsigned int)(((row1_2 * 32 + col0_2) * 2 ^ ((row1_2 * 32 + col0_2) * 2 >> 7 & 7) << 4) / 2 * 2)), "r"((packed_0_1[0])));
+            }
+            asm volatile("barrier.sync 8, 128;" ::: "memory");
+            int lane_matrix_10 = lane / 8;
+            int lane_row8_11 = lane & 7;
+            #pragma unroll
+            for (int kk_4 = 0; kk_4 < 32; kk_4 += 16) {
+                unsigned int a_plain_4[4];
+                unsigned int a_trans_4[4];
+                unsigned int b_plain_4[4];
+                unsigned int b_trans_4[4];
+                {
+                    int a_row_4 = row_base + lane_row8_11 + (lane_matrix_10 & 1) * 8;
+                    int a_col_4 = kk_4 + lane_matrix_10 / 2 * 8;
+                    asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                        : "=r"(a_plain_4[0]), "=r"(a_plain_4[1]), "=r"(a_plain_4[2]), "=r"(a_plain_4[3])
+                        : "r"(s_tmp_addr + (unsigned int)(((0) ? ((a_row_4 * 32 + a_col_4) * 2 ^ ((a_row_4 * 32 + a_col_4) * 2 >> 8 & 7) << 4) / 2 : ((a_row_4 * 32 + a_col_4) * 2 ^ ((a_row_4 * 32 + a_col_4) * 2 >> 7 & 7) << 4) / 2) * 2))
+                        : "memory");
+                }
+                {
+                    #pragma unroll
+                    for (int n_half_7 = 0; n_half_7 < 2; n_half_7++) {
+                        int b_row_4 = col_base + n_half_7 * 8 + lane_row8_11;
+                        int b_col_4 = kk_4 + lane / 8 * 8;
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x2.shared.b16 {%0, %1}, [%2];\n"
+                            : "=r"(b_plain_4[n_half_7 * 2]), "=r"(b_plain_4[n_half_7 * 2 + 1])
+                            : "r"(s_j_addr + (unsigned int)(((0) ? ((b_row_4 * 32 + b_col_4) * 2 ^ ((b_row_4 * 32 + b_col_4) * 2 >> 8 & 7) << 4) / 2 : ((b_row_4 * 32 + b_col_4) * 2 ^ ((b_row_4 * 32 + b_col_4) * 2 >> 7 & 7) << 4) / 2) * 2))
+                            : "memory");
+                    }
+                }
+                {
+                    {
+                        {
+                            asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%10, %11, %12, %13};\n"
+                                : "=f"(acc[0]), "=f"(acc[1]), "=f"(acc[2]), "=f"(acc[3])
+                                : "r"(a_plain_4[0]), "r"(a_plain_4[1]), "r"(a_plain_4[2]), "r"(a_plain_4[3]), "r"(b_plain_4[0]), "r"(b_plain_4[1]), "f"(((kk_4 == 0) ? 0.0f : acc[0])), "f"(((kk_4 == 0) ? 0.0f : acc[1])), "f"(((kk_4 == 0) ? 0.0f : acc[2])), "f"(((kk_4 == 0) ? 0.0f : acc[3])));
+                            asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%10, %11, %12, %13};\n"
+                                : "=f"(acc[4]), "=f"(acc[(4) + 1]), "=f"(acc[(4) + 2]), "=f"(acc[(4) + 3])
+                                : "r"(a_plain_4[0]), "r"(a_plain_4[1]), "r"(a_plain_4[2]), "r"(a_plain_4[3]), "r"(b_plain_4[2]), "r"(b_plain_4[(2) + 1]), "f"(((kk_4 == 0) ? 0.0f : acc[4])), "f"(((kk_4 == 0) ? 0.0f : acc[(4) + 1])), "f"(((kk_4 == 0) ? 0.0f : acc[(4) + 2])), "f"(((kk_4 == 0) ? 0.0f : acc[(4) + 3])));
+                        }
+                    }
+                }
+            }
+            const float2 _scale2_4 = {-1.0f, -1.0f};
+            #pragma unroll
+            for (int _ls = 0; _ls < 4; _ls++)
+                mul_f32x2_inplace(&reinterpret_cast<float2*>(acc)[_ls], _scale2_4);
+            int frag_row_12 = lane / 4;
+            int frag_col_13 = (lane & 3) * 2;
+            #pragma unroll
+            for (int n_half_8 = 0; n_half_8 < 2; n_half_8++) {
+                int frag_3 = n_half_8 * 4;
+                int row0_3 = row_base + frag_row_12;
+                int row1_3 = row0_3 + 8;
+                int col0_3 = col_base + n_half_8 * 8 + frag_col_13;
+                float pair_3[2];
+                unsigned int packed_0_2[1];
+                pair_3[0] = acc[frag_3];
+                pair_3[1] = acc[frag_3 + 1];
+                #pragma unroll
+                for (int _lp = 0; _lp < 1; _lp++) {
+                    __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(pair_3[_lp*2 + 0], pair_3[_lp*2+1 + 0]));
+                    packed_0_2[_lp] = *(uint32_t*)&_bf2;
+                }
+                asm volatile("st.shared.b32 [%0], %1;" :: "r"(s_df_addr + (unsigned int)(((row0_3 * 32 + col0_3) * 2 ^ ((row0_3 * 32 + col0_3) * 2 >> 7 & 7) << 4) / 2 * 2)), "r"((packed_0_2[0])));
+                pair_3[0] = acc[frag_3 + 2];
+                pair_3[1] = acc[frag_3 + 3];
+                #pragma unroll
+                for (int _lp = 0; _lp < 1; _lp++) {
+                    __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(pair_3[_lp*2 + 0], pair_3[_lp*2+1 + 0]));
+                    packed_0_2[_lp] = *(uint32_t*)&_bf2;
+                }
+                asm volatile("st.shared.b32 [%0], %1;" :: "r"(s_df_addr + (unsigned int)(((row1_3 * 32 + col0_3) * 2 ^ ((row1_3 * 32 + col0_3) * 2 >> 7 & 7) << 4) / 2 * 2)), "r"((packed_0_2[0])));
+            }
+            float _shfl_0 = __shfl_sync(0xFFFFFFFF, value_beta, dn_row0);
+            float dm_beta0 = _shfl_0;
+            float _shfl_1 = __shfl_sync(0xFFFFFFFF, value_beta, dn_row1);
+            float dm_beta1 = _shfl_1;
+            float dm_values[8];
+            dm_values[0] = 0.0f;
+            dm_values[1] = 0.0f;
+            dm_values[2] = 0.0f;
+            dm_values[3] = 0.0f;
+            dm_values[4] = 0.0f;
+            dm_values[5] = 0.0f;
+            dm_values[6] = 0.0f;
+            dm_values[7] = 0.0f;
+            if (dn_row0 > dn_col0) {
+                __nv_bfloat16 _cvt_bf16_0 = __float2bfloat16(acc[0]);
+                float _cvt_f32_2 = __bfloat162float(_cvt_bf16_0);
+                dm_values[0] = _cvt_f32_2 * dm_beta0;
+            }
+            if (dn_row0 > dn_col0 + 1) {
+                __nv_bfloat16 _cvt_bf16_1 = __float2bfloat16(acc[1]);
+                float _cvt_f32_3 = __bfloat162float(_cvt_bf16_1);
+                dm_values[1] = _cvt_f32_3 * dm_beta0;
+            }
+            if (dn_row1 > dn_col0) {
+                __nv_bfloat16 _cvt_bf16_2 = __float2bfloat16(acc[2]);
+                float _cvt_f32_4 = __bfloat162float(_cvt_bf16_2);
+                dm_values[2] = _cvt_f32_4 * dm_beta1;
+            }
+            if (dn_row1 > dn_col0 + 1) {
+                __nv_bfloat16 _cvt_bf16_3 = __float2bfloat16(acc[3]);
+                float _cvt_f32_5 = __bfloat162float(_cvt_bf16_3);
+                dm_values[3] = _cvt_f32_5 * dm_beta1;
+            }
+            if (dn_row0 > dn_col0 + 8) {
+                __nv_bfloat16 _cvt_bf16_4 = __float2bfloat16(acc[4]);
+                float _cvt_f32_6 = __bfloat162float(_cvt_bf16_4);
+                dm_values[4] = _cvt_f32_6 * dm_beta0;
+            }
+            if (dn_row0 > dn_col0 + 9) {
+                __nv_bfloat16 _cvt_bf16_5 = __float2bfloat16(acc[5]);
+                float _cvt_f32_7 = __bfloat162float(_cvt_bf16_5);
+                dm_values[5] = _cvt_f32_7 * dm_beta0;
+            }
+            if (dn_row1 > dn_col0 + 8) {
+                __nv_bfloat16 _cvt_bf16_6 = __float2bfloat16(acc[6]);
+                float _cvt_f32_8 = __bfloat162float(_cvt_bf16_6);
+                dm_values[6] = _cvt_f32_8 * dm_beta1;
+            }
+            if (dn_row1 > dn_col0 + 9) {
+                __nv_bfloat16 _cvt_bf16_7 = __float2bfloat16(acc[7]);
+                float _cvt_f32_9 = __bfloat162float(_cvt_bf16_7);
+                dm_values[7] = _cvt_f32_9 * dm_beta1;
+            }
+            unsigned int packed_14[4];
+            #pragma unroll
+            for (int _lp = 0; _lp < 4; _lp++) {
+                __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(dm_values[_lp*2 + 0], dm_values[_lp*2+1 + 0]));
+                packed_14[_lp] = *(uint32_t*)&_bf2;
+            }
+            int direct_row_15 = row_base + lane % 16;
+            int direct_col_16 = col_base + lane / 16 * 8;
+            uint32_t _stmatrix_addr_5 = static_cast<uint32_t>((unsigned long long)(s_dmt_tc_addr + (unsigned int)(direct_col_16 / 16 * 1024 + direct_row_15 * 32 + direct_col_16 % 16 * 2 ^ (direct_col_16 / 16 * 1024 + direct_row_15 * 32 + direct_col_16 % 16 * 2 >> 7 & 1) << 4)));
+            asm volatile("stmatrix.sync.aligned.m8n8.x4.shared.b16 [%0], {%1, %2, %3, %4};\n"
+                :: "r"(_stmatrix_addr_5), "r"(*reinterpret_cast<const uint32_t*>(&packed_14[0])), "r"(*reinterpret_cast<const uint32_t*>(&packed_14[1])), "r"(*reinterpret_cast<const uint32_t*>(&packed_14[2])), "r"(*reinterpret_cast<const uint32_t*>(&packed_14[3]))
+                : "memory");
+            #pragma unroll
+            for (int publish_pair_1 = 0; publish_pair_1 < 2; publish_pair_1++) {
+                int transpose_row_1 = col_base + publish_pair_1 * 8 + (lane & 7);
+                int transpose_col_1 = row_base + lane / 8 * 8;
+                uint32_t _stmatrix_addr_6 = static_cast<uint32_t>((unsigned long long)(s_dm_tc_addr + (unsigned int)(transpose_col_1 / 16 * 1024 + transpose_row_1 * 32 + transpose_col_1 % 16 * 2 ^ (transpose_col_1 / 16 * 1024 + transpose_row_1 * 32 + transpose_col_1 % 16 * 2 >> 7 & 1) << 4)));
+                asm volatile("stmatrix.sync.aligned.m8n8.x2.trans.shared.b16 [%0], {%1, %2};\n"
+                    :: "r"(_stmatrix_addr_6), "r"(*reinterpret_cast<const uint32_t*>(&packed_14[publish_pair_1 * 2])), "r"(*reinterpret_cast<const uint32_t*>(&packed_14[publish_pair_1 * 2 + 1]))
+                    : "memory");
+            }
+            asm volatile("fence.proxy.async.shared::cta;" ::: "memory");
+            asm volatile("barrier.sync 8, 128;" ::: "memory");
+            if (warp_id_in_role == 0) {
+                if (elect_sync()) {
+                    mbarrier_arrive(prep_ready_addr);
+                }
+            }
+            int token_col = lane;
+            float db_partial = 0.0f;
+            float inv_value_beta = 0.0f;
+            if (value_beta != 0.0f) {
+                float _rcp_2 = approx_rcp(value_beta);
+                inv_value_beta = _rcp_2;
+            }
+            #pragma unroll
+            for (int value_local = 0; value_local < 32; value_local++) {
+                int value_row_2 = warp_id_in_role * 32 + value_local;
+                long long tape_item = token_value_base + (long long)(value_row_2 * 32) + (long long)token_col;
+                int value_major_item_2 = value_row_2 * 32 + token_col;
+                __nv_bfloat16 x_value = s_x[(value_major_item_2 * 2 ^ (value_major_item_2 * 2 >> 7 & 7) << 4) / 2];
+                float _cvt_f32_10 = __bfloat162float(x_value);
+                float recovered_e = _cvt_f32_10 * inv_value_beta;
+                float _fma_0 = __fmaf_rn((float)chunk_dx[tape_item], recovered_e, db_partial);
+                db_partial = _fma_0;
+            }
+            int db_matrix_item = token_col * 32 + warp_id_in_role * 8;
+            unsigned int db_df_packed[4];
+            unsigned int db_m_packed[4];
+            asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                : "=r"(*reinterpret_cast<uint32_t*>(&db_df_packed[0])), "=r"(*reinterpret_cast<uint32_t*>(&db_df_packed[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&db_df_packed[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&db_df_packed[(0) + 3]))
+                : "r"(s_df_addr + (unsigned int)((db_matrix_item * 2 ^ (db_matrix_item * 2 >> 7 & 7) << 4) / 2 * 2)));
+            asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                : "=r"(*reinterpret_cast<uint32_t*>(&db_m_packed[0])), "=r"(*reinterpret_cast<uint32_t*>(&db_m_packed[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&db_m_packed[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&db_m_packed[(0) + 3]))
+                : "r"(s_m_addr + (unsigned int)((db_matrix_item * 2 ^ (db_matrix_item * 2 >> 7 & 7) << 4) / 2 * 2)));
+            float db_df_packed_f32[8];
+            #pragma unroll
+            for (int _pair = 0; _pair < 4; _pair++) {
+                asm volatile(
+                    "{\n\t"
+                    "shl.b32 %0, %2, 16;\n\t"
+                    "and.b32 %1, %2, 0xffff0000;\n\t"
+                    "}\n"
+                    : "=f"((&db_df_packed_f32[_pair * 2])[0]), "=f"((&db_df_packed_f32[_pair * 2])[1])
+                    : "r"(db_df_packed[_pair]));
+            }
+            float db_m_packed_f32[8];
+            #pragma unroll
+            for (int _pair = 0; _pair < 4; _pair++) {
+                asm volatile(
+                    "{\n\t"
+                    "shl.b32 %0, %2, 16;\n\t"
+                    "and.b32 %1, %2, 0xffff0000;\n\t"
+                    "}\n"
+                    : "=f"((&db_m_packed_f32[_pair * 2])[0]), "=f"((&db_m_packed_f32[_pair * 2])[1])
+                    : "r"(db_m_packed[_pair]));
+            }
+            #pragma unroll
+            for (int col_local = 0; col_local < 8; col_local++) {
+                float _fma_1 = __fmaf_rn(db_df_packed_f32[col_local], db_m_packed_f32[col_local], db_partial);
+                db_partial = _fma_1;
+            }
+            s_dbeta_partial[warp_id_in_role * 32 + token_col] = db_partial;
+            asm volatile("barrier.sync 8, 128;" ::: "memory");
+            if (warp_id_in_role == 0) {
+                float db_value = s_dbeta_partial[token_col] + s_dbeta_partial[32 + token_col] + s_dbeta_partial[64 + token_col] + s_dbeta_partial[96 + token_col];
+                long long token = chunk_start + (long long)token_col;
+                if (token < eos) {
+                    dbeta_active[token * (long long)num_heads + (long long)head] = db_value;
+                }
+                if (elect_sync()) {
+                    mbarrier_arrive(dbeta_done_addr);
+                }
+            }
+            int prep_key_row = prep_tid;
+            const int prep_tmem_row_base = warp_id_in_role * 32 << 16;
+            float prep_restore = tape_restore_factor[restore_base + (long long)prep_key_row];
+            float prep_kr_prefetch = (float)tape_kr[token_key_base + 2048 + (long long)prep_key_row];
+            unsigned int _phase_first_outputs_ready_0 = 0;
+            mbarrier_wait(first_outputs_ready_addr, _phase_first_outputs_ready_0);
+            _phase_first_outputs_ready_0 ^= 1;
+            long long prep_out_base = chunk_head * 32 * 128;
+            long long prep_chunk_end = chunk_start + 32;
+            if (prep_chunk_end > eos) {
+                prep_chunk_end = eos;
+            }
+            int prep_chunk_length = (int)(prep_chunk_end - chunk_start);
+            float _exp2_0 = approx_exp2(lower_bound * 1.4426950408889634f * 16.0f);
+            float prep_common_factor = _exp2_0;
+            const int prep_token_offset = 16;
+            float _tmem_load_0[8];
+            tmem_ld_x8(&_tmem_load_0[0], taddr + 176 + (unsigned int)prep_tmem_row_base + (unsigned int)prep_token_offset);
+            #pragma unroll
+            for (int prep_token_local_early = 0; prep_token_local_early < 8; prep_token_local_early++) {
+                int prep_token_out_early = prep_token_offset + prep_token_local_early;
+                float prep_kr_value_early = prep_kr_prefetch;
+                if (prep_token_local_early != 0) {
+                    prep_kr_value_early = (float)tape_kr[token_key_base + (long long)(prep_token_out_early * 128) + (long long)prep_key_row];
+                }
+                int prep_stable_index_early = prep_token_out_early * 128 + prep_key_row;
+                s_stable_dkr[prep_stable_index_early] = _tmem_load_0[prep_token_local_early] * prep_kr_value_early;
+                _tmem_load_0[prep_token_local_early] = _tmem_load_0[prep_token_local_early] * prep_restore;
+            }
+            unsigned int _phase_outputs_ready_0 = 0;
+            mbarrier_wait(outputs_ready_addr, _phase_outputs_ready_0);
+            _phase_outputs_ready_0 ^= 1;
+            float _tmem_load_1[8];
+            tmem_ld_x8(&_tmem_load_1[0], taddr + 208 + (unsigned int)prep_tmem_row_base + (unsigned int)prep_token_offset);
+            asm volatile("tcgen05.wait::ld.sync.aligned;");
+            #pragma unroll
+            for (int prep_token_local = 0; prep_token_local < 8; prep_token_local++) {
+                int prep_token_out = prep_token_offset + prep_token_local;
+                long long prep_out_index = prep_out_base + (long long)(prep_token_out * 128) + (long long)prep_key_row;
+                int prep_shared_index = prep_token_out * 128 + prep_key_row;
+                __nv_bfloat16 prep_i_value_bf16 = s_i[(prep_shared_index * 2 ^ (prep_shared_index * 2 >> 8 & 7) << 4) / 2];
+                float _cvt_f32_11 = __bfloat162float(prep_i_value_bf16);
+                float prep_i_value = _cvt_f32_11;
+                grad_ki[prep_out_index] = _tmem_load_1[prep_token_local] + _tmem_load_0[prep_token_local];
+                _tmem_load_1[prep_token_local] = _tmem_load_1[prep_token_local] * prep_i_value;
+            }
+            float _tmem_load_2[8];
+            tmem_ld_x8(&_tmem_load_2[0], taddr + 240 + (unsigned int)prep_tmem_row_base + (unsigned int)prep_token_offset);
+            float _tmem_load_3[8];
+            tmem_ld_x8(&_tmem_load_3[0], taddr + 272 + (unsigned int)prep_tmem_row_base + (unsigned int)prep_token_offset);
+            asm volatile("tcgen05.wait::ld.sync.aligned;");
+            #pragma unroll
+            for (int prep_token_local2 = 0; prep_token_local2 < 8; prep_token_local2++) {
+                int prep_token_out2 = prep_token_offset + prep_token_local2;
+                long long prep_out_index2 = prep_out_base + (long long)(prep_token_out2 * 128) + (long long)prep_key_row;
+                int prep_shared_index2 = prep_token_out2 * 128 + prep_key_row;
+                __nv_bfloat16 prep_q_value_bf16 = s_q[(prep_shared_index2 * 2 ^ (prep_shared_index2 * 2 >> 8 & 7) << 4) / 2];
+                float _cvt_f32_12 = __bfloat162float(prep_q_value_bf16);
+                float prep_q_value = _cvt_f32_12;
+                _tmem_load_3[prep_token_local2] = _tmem_load_3[prep_token_local2] * prep_common_factor;
+                float _fma_2 = __fmaf_rn(-_tmem_load_2[prep_token_local2], prep_q_value, _tmem_load_1[prep_token_local2]);
+                _tmem_load_1[prep_token_local2] = _fma_2;
+                _tmem_load_0[prep_token_local2] = _tmem_load_3[prep_token_local2] * prep_q_value;
+                grad_qd[prep_out_index2] = _tmem_load_2[prep_token_local2] + _tmem_load_3[prep_token_local2];
+            }
+            unsigned int _phase_dbeta_done_0 = 0;
+            mbarrier_wait(dbeta_done_addr, _phase_dbeta_done_0);
+            _phase_dbeta_done_0 ^= 1;
+            float _tmem_load_4[8];
+            tmem_ld_x8(&_tmem_load_4[0], taddr + 304 + (unsigned int)prep_tmem_row_base + (unsigned int)prep_token_offset);
+            float _tmem_load_5[8];
+            tmem_ld_x8(&_tmem_load_5[0], taddr + 336 + (unsigned int)prep_tmem_row_base + (unsigned int)prep_token_offset);
+            asm volatile("tcgen05.wait::ld.sync.aligned;");
+            float prep_middle_base_suffix = 0.0f;
+            #pragma unroll
+            for (int prep_token_local3 = 0; prep_token_local3 < 8; prep_token_local3++) {
+                int prep_token_out3 = prep_token_offset + prep_token_local3;
+                long long prep_out_index3 = prep_out_base + (long long)(prep_token_out3 * 128) + (long long)prep_key_row;
+                int prep_shared_index3 = prep_token_out3 * 128 + prep_key_row;
+                __nv_bfloat16 prep_k_value_bf16 = s_k[(prep_shared_index3 * 2 ^ (prep_shared_index3 * 2 >> 8 & 7) << 4) / 2];
+                float _cvt_f32_13 = __bfloat162float(prep_k_value_bf16);
+                float prep_k_value = _cvt_f32_13;
+                _tmem_load_5[prep_token_local3] = _tmem_load_5[prep_token_local3] * (-prep_common_factor);
+                float _fma_3 = __fmaf_rn(-_tmem_load_4[prep_token_local3], prep_k_value, _tmem_load_1[prep_token_local3]);
+                _tmem_load_1[prep_token_local3] = _fma_3;
+                float prep_base_value = _tmem_load_0[prep_token_local3] + _tmem_load_5[prep_token_local3] * prep_k_value;
+                int prep_stable_index3 = prep_token_out3 * 128 + prep_key_row;
+                s_stable_delta[prep_stable_index3] = _tmem_load_1[prep_token_local3];
+                s_stable_base[prep_stable_index3] = prep_base_value;
+                if (prep_token_out3 < prep_chunk_length) {
+                    prep_middle_base_suffix += prep_base_value;
+                }
+                grad_kd[prep_out_index3] = _tmem_load_4[prep_token_local3] + _tmem_load_5[prep_token_local3];
+            }
+            s_middle_base_suffix[prep_key_row] = prep_middle_base_suffix;
+            asm volatile("barrier.sync 10, 384;" ::: "memory");
+        }
+    }
+    // ---- Role: epilogue ----
+    if (warp >= 4 && warp <= 7) {
+        asm volatile("setmaxnreg.inc.sync.aligned.u32 208;");
+        { // epilogue_main
+            int ordered_chunk_1 = blockIdx.x / num_heads;
+            int chunk_global_1 = consumer_chunk_order[ordered_chunk_1];
+            int head_1 = blockIdx.x - ordered_chunk_1 * num_heads;
+            int sequence_1 = chunk_sequence[chunk_global_1];
+            int local_chunk_1 = chunk_index[chunk_global_1];
+            long long bos_1 = cu_seqlens[sequence_1];
+            long long eos_1 = cu_seqlens[sequence_1 + 1];
+            long long chunk_start_1 = bos_1 + (long long)local_chunk_1 * 32;
+            long long chunk_head_1 = (long long)chunk_global_1 * (long long)num_heads + (long long)head_1;
+            int warp_id_in_role_1 = (warp - 4);
+            int key_row = warp_id_in_role_1 * 32 + lane;
+            const int tmem_row_base = warp_id_in_role_1 * 32 << 16;
+            long long token_key_base_1 = chunk_head_1 * 32 * 128;
+            long long state_base_1 = chunk_head_1 * 128 * 128;
+            long long restore_base_1 = chunk_head_1 * 128;
+            long long initial_state_base = ((long long)sequence_1 * (long long)num_heads + (long long)head_1) * 128 * 128;
+            int checkpoint_needed = 0;
+            if (local_chunk_1 != 0) {
+                checkpoint_needed = state_checkpoint_needed[chunk_head_1] != 0;
+            }
+            float restore = tape_restore_factor[restore_base_1 + (long long)key_row];
+            float gate_constant = 0.0f;
+            unsigned int _phase_recon_output_ready_0 = 0;
+            if (local_chunk_1 == 0) {
+                #pragma unroll
+                for (int value_block = 0; value_block < 128; value_block += 16) {
+                    float state_values[16];
+                    #pragma unroll
+                    for (int value_elem_2 = 0; value_elem_2 < 16; value_elem_2++) {
+                        __nv_bfloat16 _cvt_bf16_8 = __float2bfloat16(initial_state[initial_state_base + (long long)((value_block + value_elem_2) * 128) + (long long)key_row]);
+                        float _cvt_f32_14 = __bfloat162float(_cvt_bf16_8);
+                        state_values[value_elem_2] = _cvt_f32_14;
+                    }
+                    uint32_t state_values_bf16[8];
+                    #pragma unroll
+                    for (int _lp = 0; _lp < 8; _lp++) {
+                        __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(state_values[_lp*2 + 0], state_values[_lp*2+1 + 0]));
+                        state_values_bf16[_lp] = *(uint32_t*)&_bf2;
+                    }
+                    tmem_st_x8_u32(taddr + 64 + (unsigned int)tmem_row_base + (unsigned int)(value_block / 2), (const uint32_t*)state_values_bf16);
+                }
+            } else if (checkpoint_needed != 0) {
+                #pragma unroll
+                for (int value_block_1 = 0; value_block_1 < 128; value_block_1 += 16) {
+                    float state_values_1[16];
+                    #pragma unroll
+                    for (int value_elem_3 = 0; value_elem_3 < 16; value_elem_3++) {
+                        state_values_1[value_elem_3] = (float)chunk_state[state_base_1 + (long long)((value_block_1 + value_elem_3) * 128) + (long long)key_row];
+                    }
+                    uint32_t state_values_bf16_1[8];
+                    #pragma unroll
+                    for (int _lp = 0; _lp < 8; _lp++) {
+                        __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(state_values_1[_lp*2 + 0], state_values_1[_lp*2+1 + 0]));
+                        state_values_bf16_1[_lp] = *(uint32_t*)&_bf2;
+                    }
+                    tmem_st_x8_u32(taddr + 64 + (unsigned int)tmem_row_base + (unsigned int)(value_block_1 / 2), (const uint32_t*)state_values_bf16_1);
+                }
+            } else {
+                long long prev_chunk_head = (long long)(chunk_global_1 - 1) * (long long)num_heads + (long long)head_1;
+                long long prev_token_key_base = prev_chunk_head * 32 * 128;
+                long long prev_value_token_base = prev_chunk_head * 128 * 32;
+                #pragma unroll
+                for (int token_half_state = 0; token_half_state < 2; token_half_state++) {
+                    int token_offset_state = token_half_state * 16;
+                    float kr_values[16];
+                    #pragma unroll
+                    for (int token_local_state = 0; token_local_state < 16; token_local_state++) {
+                        int token_col_state = token_offset_state + token_local_state;
+                        kr_values[token_local_state] = (float)tape_kr[prev_token_key_base + (long long)token_col_state * 128 + (long long)key_row];
+                    }
+                    uint32_t kr_values_bf16[8];
+                    #pragma unroll
+                    for (int _lp = 0; _lp < 8; _lp++) {
+                        __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(kr_values[_lp*2 + 0], kr_values[_lp*2+1 + 0]));
+                        kr_values_bf16[_lp] = *(uint32_t*)&_bf2;
+                    }
+                    tmem_st_x8_u32(taddr + 64 + (unsigned int)tmem_row_base + (unsigned int)(token_half_state * 8), (const uint32_t*)kr_values_bf16);
+                }
+                #pragma unroll
+                for (int prev_r_segment = 0; prev_r_segment < 4; prev_r_segment++) {
+                    float prev_r_values[8];
+                    {
+                        const uint4* _vptr_0 = reinterpret_cast<const uint4*>(tape_r + prev_value_token_base + (long long)key_row * 32 + (long long)(prev_r_segment * 8));
+                        uint4 _vld_0[1];
+                        #pragma unroll
+                        for (int _blk = 0; _blk < 1; _blk++) {
+                            _vld_0[_blk] = _vptr_0[_blk];
+                            uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
+                            #pragma unroll
+                            for (int _pair = 0; _pair < 4; _pair++) {
+                                asm volatile(
+                                    "{\n\t"
+                                    "shl.b32 %0, %2, 16;\n\t"
+                                    "and.b32 %1, %2, 0xffff0000;\n\t"
+                                    "}\n"
+                                    : "=f"((&prev_r_values[0 + _blk * 8 + _pair * 2])[0]), "=f"((&prev_r_values[0 + _blk * 8 + _pair * 2])[1])
+                                    : "r"(_vpairs_0[_pair]));
+                            }
+                        }
+                    }
+                    unsigned int packed_4[4];
+                    #pragma unroll
+                    for (int _lp = 0; _lp < 4; _lp++) {
+                        __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(prev_r_values[_lp*2 + 0], prev_r_values[_lp*2+1 + 0]));
+                        packed_4[_lp] = *(uint32_t*)&_bf2;
+                    }
+                    #pragma unroll
+                    for (int word = 0; word < 4; word++) {
+                        asm volatile("st.shared.b32 [%0], %1;" :: "r"((s_prev_r_tc_addr + (unsigned int)(prev_r_segment * 8 / 16 * 4096 + key_row * 32 + prev_r_segment * 8 % 16 * 2 ^ (prev_r_segment * 8 / 16 * 4096 + key_row * 32 + prev_r_segment * 8 % 16 * 2 >> 7 & 1) << 4)) + (unsigned int)(word * 4)), "r"((packed_4[word])));
+                    }
+                }
+                asm volatile("fence.proxy.async.shared::cta;" ::: "memory");
+                asm volatile("tcgen05.wait::st.sync.aligned;" ::: "memory");
+                if (elect_sync()) {
+                    mbarrier_arrive(recon_inputs_ready_addr);
+                }
+                mbarrier_wait(recon_output_ready_addr, _phase_recon_output_ready_0);
+                _phase_recon_output_ready_0 ^= 1;
+                #pragma unroll
+                for (int value_block_2 = 0; value_block_2 < 128; value_block_2 += 16) {
+                    float _tmem_load_6[16];
+                    tmem_ld_x16(&_tmem_load_6[0], taddr + 368 + (unsigned int)tmem_row_base + (unsigned int)value_block_2);
+                    asm volatile("tcgen05.wait::ld.sync.aligned;" ::: "memory");
+                    uint32_t _tmem_load_6_bf16[8];
+                    #pragma unroll
+                    for (int _lp = 0; _lp < 8; _lp++) {
+                        __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(_tmem_load_6[_lp*2 + 0], _tmem_load_6[_lp*2+1 + 0]));
+                        _tmem_load_6_bf16[_lp] = *(uint32_t*)&_bf2;
+                    }
+                    tmem_st_x8_u32(taddr + 64 + (unsigned int)tmem_row_base + (unsigned int)(value_block_2 / 2), (const uint32_t*)_tmem_load_6_bf16);
+                }
+            }
+            asm volatile("tcgen05.wait::st.sync.aligned;" ::: "memory");
+            if (elect_sync()) {
+                mbarrier_arrive(state_tc_ready_addr);
+            }
+            unsigned int _phase_qki_ready_0 = 0;
+            mbarrier_wait(qki_ready_addr, _phase_qki_ready_0);
+            _phase_qki_ready_0 ^= 1;
+            #pragma unroll
+            for (int token_half_ki = 0; token_half_ki < 2; token_half_ki++) {
+                int token_offset_ki = token_half_ki * 16;
+                float ki_values[16];
+                #pragma unroll
+                for (int token_local_k = 0; token_local_k < 16; token_local_k++) {
+                    int token_col_k = token_offset_ki + token_local_k;
+                    int shared_index_k = token_col_k * 128 + key_row;
+                    ki_values[token_local_k] = s_k[(shared_index_k * 2 ^ (shared_index_k * 2 >> 8 & 7) << 4) / 2];
+                }
+                uint32_t ki_values_bf16[8];
+                #pragma unroll
+                for (int _lp = 0; _lp < 8; _lp++) {
+                    __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(ki_values[_lp*2 + 0], ki_values[_lp*2+1 + 0]));
+                    ki_values_bf16[_lp] = *(uint32_t*)&_bf2;
+                }
+                tmem_st_x8_u32(taddr + 128 + (unsigned int)tmem_row_base + (unsigned int)(token_half_ki * 8), (const uint32_t*)ki_values_bf16);
+                #pragma unroll
+                for (int token_local_q = 0; token_local_q < 16; token_local_q++) {
+                    int token_col_q = token_offset_ki + token_local_q;
+                    int shared_index_q = token_col_q * 128 + key_row;
+                    ki_values[token_local_q] = s_q[(shared_index_q * 2 ^ (shared_index_q * 2 >> 8 & 7) << 4) / 2];
+                }
+                uint32_t ki_values_bf16_0[8];
+                #pragma unroll
+                for (int _lp = 0; _lp < 8; _lp++) {
+                    __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(ki_values[_lp*2 + 0], ki_values[_lp*2+1 + 0]));
+                    ki_values_bf16_0[_lp] = *(uint32_t*)&_bf2;
+                }
+                tmem_st_x8_u32(taddr + 144 + (unsigned int)tmem_row_base + (unsigned int)(token_half_ki * 8), (const uint32_t*)ki_values_bf16_0);
+                #pragma unroll
+                for (int token_local_i = 0; token_local_i < 16; token_local_i++) {
+                    int token_col_i = token_offset_ki + token_local_i;
+                    int shared_index_i = token_col_i * 128 + key_row;
+                    ki_values[token_local_i] = s_i[(shared_index_i * 2 ^ (shared_index_i * 2 >> 8 & 7) << 4) / 2];
+                }
+                uint32_t ki_values_bf16_1[8];
+                #pragma unroll
+                for (int _lp = 0; _lp < 8; _lp++) {
+                    __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(ki_values[_lp*2 + 0], ki_values[_lp*2+1 + 0]));
+                    ki_values_bf16_1[_lp] = *(uint32_t*)&_bf2;
+                }
+                tmem_st_x8_u32(taddr + 160 + (unsigned int)tmem_row_base + (unsigned int)(token_half_ki * 8), (const uint32_t*)ki_values_bf16_1);
+            }
+            asm volatile("tcgen05.wait::st.sync.aligned;" ::: "memory");
+            if (elect_sync()) {
+                mbarrier_arrive(qki_tc_ready_addr);
+            }
+            if (boundary_ready_target != 0) {
+                if (warp_id_in_role_1 == 0) {
+                    {
+                        unsigned int* _gca_p = reinterpret_cast<unsigned int*>(boundary_ready) + (chunk_head_1);
+                        while (true) {
+                            unsigned int _gca_v;
+                            asm volatile("ld.acquire.gpu.global.u32 %0, [%1];" : "=r"(_gca_v) : "l"(_gca_p));
+                            if (_gca_v >= (unsigned int)(boundary_ready_target)) break;
+                        }
+                    }
+                }
+                asm volatile("barrier.sync 9, 128;" ::: "memory");
+            }
+            unsigned int _phase_dh_ready_0 = 0;
+            mbarrier_wait(dh_ready_addr, _phase_dh_ready_0);
+            _phase_dh_ready_0 ^= 1;
+            if (local_chunk_1 == 0) {
+                #pragma unroll
+                for (int value_block2 = 0; value_block2 < 128; value_block2 += 16) {
+                    float dh_values[16];
+                    #pragma unroll
+                    for (int value_elem2 = 0; value_elem2 < 16; value_elem2++) {
+                        int value_row_3 = value_block2 + value_elem2;
+                        __nv_bfloat16 _cvt_bf16_9 = __float2bfloat16(initial_state[initial_state_base + (long long)(value_row_3 * 128) + (long long)key_row]);
+                        float _cvt_f32_15 = __bfloat162float(_cvt_bf16_9);
+                        float state_value = _cvt_f32_15;
+                        __nv_bfloat16 dh_value = s_dh_stage[((value_row_3 * 128 + key_row) * 2 ^ ((value_row_3 * 128 + key_row) * 2 >> 7 & 7) << 4) / 2];
+                        float _cvt_f32_16 = __bfloat162float(dh_value);
+                        dh_values[value_elem2] = _cvt_f32_16;
+                        float _fma_4 = __fmaf_rn(dh_values[value_elem2], state_value, gate_constant);
+                        gate_constant = _fma_4;
+                    }
+                    uint32_t dh_values_bf16[8];
+                    #pragma unroll
+                    for (int _lp = 0; _lp < 8; _lp++) {
+                        __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(dh_values[_lp*2 + 0], dh_values[_lp*2+1 + 0]));
+                        dh_values_bf16[_lp] = *(uint32_t*)&_bf2;
+                    }
+                    tmem_st_x8_u32(taddr + (unsigned int)tmem_row_base + (unsigned int)(value_block2 / 2), (const uint32_t*)dh_values_bf16);
+                }
+            } else if (checkpoint_needed != 0) {
+                #pragma unroll
+                for (int value_block2_1 = 0; value_block2_1 < 128; value_block2_1 += 16) {
+                    float dh_values_1[16];
+                    #pragma unroll
+                    for (int value_elem2_1 = 0; value_elem2_1 < 16; value_elem2_1++) {
+                        int value_row_4 = value_block2_1 + value_elem2_1;
+                        float state_value_1 = (float)chunk_state[state_base_1 + (long long)(value_row_4 * 128) + (long long)key_row];
+                        __nv_bfloat16 dh_value_1 = s_dh_stage[((value_row_4 * 128 + key_row) * 2 ^ ((value_row_4 * 128 + key_row) * 2 >> 7 & 7) << 4) / 2];
+                        float _cvt_f32_17 = __bfloat162float(dh_value_1);
+                        dh_values_1[value_elem2_1] = _cvt_f32_17;
+                        float _fma_5 = __fmaf_rn(dh_values_1[value_elem2_1], state_value_1, gate_constant);
+                        gate_constant = _fma_5;
+                    }
+                    uint32_t dh_values_bf16_1[8];
+                    #pragma unroll
+                    for (int _lp = 0; _lp < 8; _lp++) {
+                        __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(dh_values_1[_lp*2 + 0], dh_values_1[_lp*2+1 + 0]));
+                        dh_values_bf16_1[_lp] = *(uint32_t*)&_bf2;
+                    }
+                    tmem_st_x8_u32(taddr + (unsigned int)tmem_row_base + (unsigned int)(value_block2_1 / 2), (const uint32_t*)dh_values_bf16_1);
+                }
+            } else {
+                #pragma unroll
+                for (int value_block2_2 = 0; value_block2_2 < 128; value_block2_2 += 16) {
+                    float _tmem_load_7[16];
+                    tmem_ld_x16(&_tmem_load_7[0], taddr + 368 + (unsigned int)tmem_row_base + (unsigned int)value_block2_2);
+                    asm volatile("tcgen05.wait::ld.sync.aligned;" ::: "memory");
+                    float dh_values_2[16];
+                    #pragma unroll
+                    for (int value_elem2_2 = 0; value_elem2_2 < 16; value_elem2_2++) {
+                        int value_row_5 = value_block2_2 + value_elem2_2;
+                        __nv_bfloat16 dh_value_2 = s_dh_stage[((value_row_5 * 128 + key_row) * 2 ^ ((value_row_5 * 128 + key_row) * 2 >> 7 & 7) << 4) / 2];
+                        float _cvt_f32_18 = __bfloat162float(dh_value_2);
+                        dh_values_2[value_elem2_2] = _cvt_f32_18;
+                        float _fma_6 = __fmaf_rn(dh_values_2[value_elem2_2], _tmem_load_7[value_elem2_2], gate_constant);
+                        gate_constant = _fma_6;
+                    }
+                    uint32_t dh_values_bf16_2[8];
+                    #pragma unroll
+                    for (int _lp = 0; _lp < 8; _lp++) {
+                        __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(dh_values_2[_lp*2 + 0], dh_values_2[_lp*2+1 + 0]));
+                        dh_values_bf16_2[_lp] = *(uint32_t*)&_bf2;
+                    }
+                    tmem_st_x8_u32(taddr + (unsigned int)tmem_row_base + (unsigned int)(value_block2_2 / 2), (const uint32_t*)dh_values_bf16_2);
+                }
+            }
+            asm volatile("tcgen05.wait::st.sync.aligned;" ::: "memory");
+            float _exp2_1 = approx_exp2(lower_bound * 1.4426950408889634f * 16.0f);
+            float common_factor = _exp2_1;
+            gate_constant *= common_factor * restore;
+            if (elect_sync()) {
+                mbarrier_arrive(a_ready_addr);
+            }
+            float kr_prefetch = (float)tape_kr[token_key_base_1 + (long long)key_row];
+            unsigned int _phase_first_outputs_ready_0_1 = 0;
+            mbarrier_wait(first_outputs_ready_addr, _phase_first_outputs_ready_0_1);
+            _phase_first_outputs_ready_0_1 ^= 1;
+            long long out_base = chunk_head_1 * 32 * 128;
+            float base_suffix = 0.0f;
+            long long chunk_end = chunk_start_1 + 32;
+            if (chunk_end > eos_1) {
+                chunk_end = eos_1;
+            }
+            int chunk_length = (int)(chunk_end - chunk_start_1);
+            unsigned int _phase_outputs_ready_0_1 = 0;
+            unsigned int _phase_dbeta_done_0_1 = 0;
+            #pragma unroll
+            for (int token_half = 0; token_half < 1; token_half++) {
+                int token_offset = token_half * 16;
+                float _tmem_load_8[16];
+                tmem_ld_x16(&_tmem_load_8[0], taddr + 176 + (unsigned int)tmem_row_base + (unsigned int)token_offset);
+                #pragma unroll
+                for (int token_local_early = 0; token_local_early < 16; token_local_early++) {
+                    int token_out_early = token_offset + token_local_early;
+                    float kr_value_early = kr_prefetch;
+                    if (token_local_early != 0) {
+                        kr_value_early = (float)tape_kr[token_key_base_1 + (long long)(token_out_early * 128) + (long long)key_row];
+                    }
+                    int stable_index_early = token_out_early * 128 + key_row;
+                    s_stable_dkr[stable_index_early] = _tmem_load_8[token_local_early] * kr_value_early;
+                    _tmem_load_8[token_local_early] = _tmem_load_8[token_local_early] * restore;
+                }
+                mbarrier_wait(outputs_ready_addr, _phase_outputs_ready_0_1);
+                _phase_outputs_ready_0_1 ^= 1;
+                float _tmem_load_9[16];
+                tmem_ld_x16(&_tmem_load_9[0], taddr + 208 + (unsigned int)tmem_row_base + (unsigned int)token_offset);
+                asm volatile("tcgen05.wait::ld.sync.aligned;");
+                #pragma unroll
+                for (int token_local = 0; token_local < 16; token_local++) {
+                    int token_out = token_offset + token_local;
+                    long long out_index = out_base + (long long)(token_out * 128) + (long long)key_row;
+                    int shared_index = token_out * 128 + key_row;
+                    __nv_bfloat16 i_value_bf16 = s_i[(shared_index * 2 ^ (shared_index * 2 >> 8 & 7) << 4) / 2];
+                    float _cvt_f32_19 = __bfloat162float(i_value_bf16);
+                    float i_value = _cvt_f32_19;
+                    grad_ki[out_index] = _tmem_load_9[token_local] + _tmem_load_8[token_local];
+                    _tmem_load_9[token_local] = _tmem_load_9[token_local] * i_value;
+                }
+                float _tmem_load_10[16];
+                tmem_ld_x16(&_tmem_load_10[0], taddr + 240 + (unsigned int)tmem_row_base + (unsigned int)token_offset);
+                float _tmem_load_11[16];
+                tmem_ld_x16(&_tmem_load_11[0], taddr + 272 + (unsigned int)tmem_row_base + (unsigned int)token_offset);
+                asm volatile("tcgen05.wait::ld.sync.aligned;");
+                #pragma unroll
+                for (int token_local2 = 0; token_local2 < 16; token_local2++) {
+                    int token_out2 = token_offset + token_local2;
+                    long long out_index_1 = out_base + (long long)(token_out2 * 128) + (long long)key_row;
+                    int shared_index2 = token_out2 * 128 + key_row;
+                    __nv_bfloat16 q_value_bf16 = s_q[(shared_index2 * 2 ^ (shared_index2 * 2 >> 8 & 7) << 4) / 2];
+                    float _cvt_f32_20 = __bfloat162float(q_value_bf16);
+                    float q_value = _cvt_f32_20;
+                    _tmem_load_11[token_local2] = _tmem_load_11[token_local2] * common_factor;
+                    float _fma_7 = __fmaf_rn(-_tmem_load_10[token_local2], q_value, _tmem_load_9[token_local2]);
+                    _tmem_load_9[token_local2] = _fma_7;
+                    _tmem_load_8[token_local2] = _tmem_load_11[token_local2] * q_value;
+                    grad_qd[out_index_1] = _tmem_load_10[token_local2] + _tmem_load_11[token_local2];
+                }
+                mbarrier_wait(dbeta_done_addr, _phase_dbeta_done_0_1);
+                _phase_dbeta_done_0_1 ^= 1;
+                float _tmem_load_12[16];
+                tmem_ld_x16(&_tmem_load_12[0], taddr + 304 + (unsigned int)tmem_row_base + (unsigned int)token_offset);
+                float _tmem_load_13[16];
+                tmem_ld_x16(&_tmem_load_13[0], taddr + 336 + (unsigned int)tmem_row_base + (unsigned int)token_offset);
+                asm volatile("tcgen05.wait::ld.sync.aligned;");
+                #pragma unroll
+                for (int token_local3 = 0; token_local3 < 16; token_local3++) {
+                    int token_out3 = token_offset + token_local3;
+                    long long out_index_2 = out_base + (long long)(token_out3 * 128) + (long long)key_row;
+                    int shared_index3 = token_out3 * 128 + key_row;
+                    __nv_bfloat16 k_value_bf16 = s_k[(shared_index3 * 2 ^ (shared_index3 * 2 >> 8 & 7) << 4) / 2];
+                    float _cvt_f32_21 = __bfloat162float(k_value_bf16);
+                    float k_value = _cvt_f32_21;
+                    _tmem_load_13[token_local3] = _tmem_load_13[token_local3] * (-common_factor);
+                    float _fma_8 = __fmaf_rn(-_tmem_load_12[token_local3], k_value, _tmem_load_9[token_local3]);
+                    _tmem_load_9[token_local3] = _fma_8;
+                    float base_value = _tmem_load_8[token_local3] + _tmem_load_13[token_local3] * k_value;
+                    int stable_index3 = token_out3 * 128 + key_row;
+                    s_stable_delta[stable_index3] = _tmem_load_9[token_local3];
+                    s_stable_base[stable_index3] = base_value;
+                    if (token_out3 < chunk_length) {
+                        base_suffix += base_value;
+                    }
+                    grad_kd[out_index_2] = _tmem_load_12[token_local3] + _tmem_load_13[token_local3];
+                }
+            }
+            asm volatile("barrier.sync 10, 384;" ::: "memory");
+            base_suffix += s_middle_base_suffix[key_row] + s_high_base_suffix[key_row];
+            float prefix_dkr = 0.0f;
+            float crossing = 0.0f;
+            #pragma unroll 4
+            for (int gate_token = 0; gate_token < chunk_length; gate_token++) {
+                int stable_index = gate_token * 128 + key_row;
+                long long token_1 = chunk_start_1 + (long long)gate_token;
+                long long dlog_index = (token_1 * (long long)num_heads + (long long)head_1) * 128 + (long long)key_row;
+                dlog_decay[dlog_index] = base_suffix + gate_constant + (prefix_dkr + crossing);
+                crossing += s_stable_delta[stable_index];
+                prefix_dkr += s_stable_dkr[stable_index];
+                base_suffix -= s_stable_base[stable_index];
+            }
+            if (elect_sync()) {
+                mbarrier_arrive(epilogue_done_addr);
+            }
+        }
+    }
+    // ---- Role: mma ----
+    if (warp >= 8 && warp <= 11) {
+        asm volatile("setmaxnreg.dec.sync.aligned.u32 96;");
+        { // mma_main
+            int ordered_chunk_2 = blockIdx.x / num_heads;
+            int chunk_global_2 = consumer_chunk_order[ordered_chunk_2];
+            int local_chunk_2 = chunk_index[chunk_global_2];
+            int head_2 = blockIdx.x - ordered_chunk_2 * num_heads;
+            long long chunk_head_2 = (long long)chunk_global_2 * (long long)num_heads + (long long)head_2;
+            int warp_id_in_role_2 = (warp - 8);
+            unsigned int _phase_boundary_local_ready_0 = 0;
+            unsigned int _phase_dv_ready_0 = 0;
+            if (warp_id_in_role_2 != 0) {
+                mbarrier_wait(boundary_local_ready_addr, _phase_boundary_local_ready_0);
+                _phase_boundary_local_ready_0 ^= 1;
+                int sequence_do = chunk_sequence[chunk_global_2];
+                long long eos_do = cu_seqlens[sequence_do + 1];
+                long long chunk_start_do = cu_seqlens[sequence_do] + (long long)local_chunk_2 * 32;
+                int do_tid = (warp_id_in_role_2 - 1) * 32 + lane;
+                #pragma unroll 1
+                for (int do_group = do_tid; do_group < 512; do_group += 96) {
+                    int do_token_col = do_group / 16;
+                    int do_segment = do_group % 16;
+                    long long token_do = chunk_start_do + (long long)do_token_col;
+                    int do_rowmajor_item = do_token_col * 128 + do_segment * 8;
+                    asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16, %2;"
+                        :: "r"(s_do_stage_addr + (unsigned int)((do_rowmajor_item * 2 ^ (do_rowmajor_item * 2 >> 8 & 7) << 4) / 2 * 2)), "l"(do_ + ((token_do * (long long)num_heads + (long long)head_2) * 128 + (long long)(do_segment * 8))), "r"((token_do < eos_do) ? 16 : 0));
+                }
+                long long token_value_base_do = chunk_head_2 * 128 * 32;
+                #pragma unroll 1
+                for (int dr_group = do_tid; dr_group < 512; dr_group += 96) {
+                    int dr_copy_item = dr_group * 8;
+                    asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
+                        :: "r"(s_drt_addr + (unsigned int)((dr_copy_item * 2 ^ (dr_copy_item * 2 >> 7 & 7) << 4) / 2 * 2)), "l"(chunk_dr + (token_value_base_do + (long long)dr_copy_item)));
+                }
+                asm volatile("cp.async.commit_group;");
+                asm volatile("cp.async.wait_group 0;");
+                #pragma unroll 1
+                for (int do_relay_group = do_tid; do_relay_group < 512; do_relay_group += 96) {
+                    int do_relay_token_col = do_relay_group / 16;
+                    int do_relay_segment = do_relay_group % 16;
+                    int do_relay_rowmajor_item = do_relay_token_col * 128 + do_relay_segment * 8;
+                    unsigned int do_packed[4];
+                    asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                        : "=r"(*reinterpret_cast<uint32_t*>(&do_packed[0])), "=r"(*reinterpret_cast<uint32_t*>(&do_packed[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&do_packed[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&do_packed[(0) + 3]))
+                        : "r"(s_do_stage_addr + (unsigned int)((do_relay_rowmajor_item * 2 ^ (do_relay_rowmajor_item * 2 >> 8 & 7) << 4) / 2 * 2)));
+                    asm volatile("st.shared.v4.b32 [%0], {%1,%2,%3,%4};" :: "r"(s_dot_tc_addr + ((s_dot_tc_addr + (unsigned int)(do_relay_segment * 8 / 64 * 4096 + do_relay_token_col * 128 + do_relay_segment * 8 % 64 * 2 ^ (do_relay_segment * 8 / 64 * 4096 + do_relay_token_col * 128 + do_relay_segment * 8 % 64 * 2 >> 7 & 7) << 4)) - s_dot_tc_addr)), "r"(do_packed[0]), "r"(do_packed[1]), "r"(do_packed[2]), "r"(do_packed[3]) : "memory");
+                }
+                asm volatile("fence.proxy.async.shared::cta;" ::: "memory");
+                if (elect_sync()) {
+                    mbarrier_arrive(value_tc_ready_addr);
+                }
+                mbarrier_wait(dv_ready_addr, _phase_dv_ready_0);
+                _phase_dv_ready_0 ^= 1;
+                int sequence_dv = chunk_sequence[chunk_global_2];
+                long long eos_dv = cu_seqlens[sequence_dv + 1];
+                long long chunk_start_dv = cu_seqlens[sequence_dv] + (long long)local_chunk_2 * 32;
+                int dv_tid = (warp_id_in_role_2 - 1) * 32 + lane;
+                #pragma unroll 1
+                for (int dv_group = dv_tid; dv_group < 512; dv_group += 96) {
+                    int dv_token_col = dv_group / 16;
+                    int dv_segment = dv_group % 16;
+                    long long token_dv = chunk_start_dv + (long long)dv_token_col;
+                    float beta_value_dv = 0.0f;
+                    if (token_dv < eos_dv) {
+                        beta_value_dv = beta_active[token_dv * (long long)num_heads + (long long)head_2];
+                    }
+                    float dv_values[8];
+                    #pragma unroll
+                    for (int value_elem_dv = 0; value_elem_dv < 8; value_elem_dv++) {
+                        int value_row_dv = dv_segment * 8 + value_elem_dv;
+                        int det_group_dv = dv_segment * 2 + value_elem_dv / 4;
+                        float dx_value_dv = s_det[value_row_dv * 32 + (dv_token_col ^ det_group_dv)];
+                        dv_values[value_elem_dv] = dx_value_dv * beta_value_dv;
+                    }
+                    if (token_dv < eos_dv) {
+                        {
+                            __nv_bfloat162 _pk[4];
+                            _pk[0] = __floats2bfloat162_rn(dv_values[0 + 0], dv_values[0 + 1]);
+                            _pk[1] = __floats2bfloat162_rn(dv_values[0 + 2], dv_values[0 + 3]);
+                            _pk[2] = __floats2bfloat162_rn(dv_values[0 + 4], dv_values[0 + 5]);
+                            _pk[3] = __floats2bfloat162_rn(dv_values[0 + 6], dv_values[0 + 7]);
+                            *reinterpret_cast<uint4*>(&((__nv_bfloat16*)(dv + ((token_dv * (long long)num_heads + (long long)head_2) * 128 + (long long)(dv_segment * 8))))[0]) = *reinterpret_cast<uint4*>(&_pk[0]);
+                        }
+                    }
+                }
+                if (elect_sync()) {
+                    mbarrier_arrive(dbeta_done_addr);
+                }
+            }
+            unsigned int _phase_recon_inputs_ready_0 = 0;
+            unsigned int _phase_state_tc_ready_0 = 0;
+            unsigned int _phase_value_tc_ready_0_1 = 0;
+            unsigned int _phase_a_ready_0 = 0;
+            unsigned int _phase_prep_ready_0 = 0;
+            unsigned int _phase_qki_tc_ready_0 = 0;
+            if (warp_id_in_role_2 == 0) {
+                if (local_chunk_2 != 0) {
+                    if (state_checkpoint_needed[chunk_head_2] == 0) {
+                        mbarrier_wait(recon_inputs_ready_addr, _phase_recon_inputs_ready_0);
+                        _phase_recon_inputs_ready_0 ^= 1;
+                        int _mma_b_lo_0 = make_warp_uniform(((s_prev_r_tc_addr) >> 4) & 0x3FFF);
+                        asm volatile(
+                    "{\n\t"
+                    ".reg .pred leader, p0, p1;\n\t"
+                    ".reg .b32 dhi, blo, ta, id;\n\t"
+                    ".reg .b64 db;\n\t"
+                    "elect.sync _|leader, 0xFFFFFFFF;\n\t"
+                    "setp.ne.b32 p0, %3, 0;\n\t"
+                    "setp.ne.b32 p1, 1, 0;\n\t"
+                    ""
+                    "mov.b32 dhi, 0xC0004010;\n\t"
+                    "mov.b32 id, 136316048;\n\t"
+                    "mov.b32 ta, %2;\n\t"
+                    "mov.b32 blo, %1;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p0;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 256;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "}\n"
+                    :: "r"(tmem_tmem_recon_state), "r"(_mma_b_lo_0), "r"(tmem_tmem_recon_kr), "r"(0));
+                        elect_commit(recon_output_ready_addr);
+                    }
+                }
+                mbarrier_wait(dv_ready_addr, _phase_dv_ready_0);
+                _phase_dv_ready_0 ^= 1;
+                mbarrier_wait(state_tc_ready_addr, _phase_state_tc_ready_0);
+                _phase_state_tc_ready_0 ^= 1;
+                int _mma_b_lo_1 = make_warp_uniform(((s_det_tc_addr) >> 4) & 0x3FFF);
+                asm volatile(
+                    "{\n\t"
+                    ".reg .pred leader, p0, p1;\n\t"
+                    ".reg .b32 dhi, blo, ta, id;\n\t"
+                    ".reg .b64 db;\n\t"
+                    "elect.sync _|leader, 0xFFFFFFFF;\n\t"
+                    "setp.ne.b32 p0, %3, 0;\n\t"
+                    "setp.ne.b32 p1, 1, 0;\n\t"
+                    ""
+                    "mov.b32 dhi, 0x40004040;\n\t"
+                    "mov.b32 id, 134743184;\n\t"
+                    "mov.b32 ta, %2;\n\t"
+                    "mov.b32 blo, %1;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p0;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 250;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "}\n"
+                    :: "r"(tmem_tmem_dk_boundary), "r"(_mma_b_lo_1), "r"(tmem_tmem_a_state), "r"(0));
+                mbarrier_wait(value_tc_ready_addr, _phase_value_tc_ready_0_1);
+                _phase_value_tc_ready_0_1 ^= 1;
+                int _mma_b_lo_2 = make_warp_uniform(((s_dot_tc_addr) >> 4) & 0x3FFF);
+                asm volatile(
+                    "{\n\t"
+                    ".reg .pred leader, p0, p1;\n\t"
+                    ".reg .b32 dhi, blo, ta, id;\n\t"
+                    ".reg .b64 db;\n\t"
+                    "elect.sync _|leader, 0xFFFFFFFF;\n\t"
+                    "setp.ne.b32 p0, %3, 0;\n\t"
+                    "setp.ne.b32 p1, 1, 0;\n\t"
+                    ""
+                    "mov.b32 dhi, 0x40004040;\n\t"
+                    "mov.b32 id, 134743184;\n\t"
+                    "mov.b32 ta, %2;\n\t"
+                    "mov.b32 blo, %1;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p0;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 250;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "}\n"
+                    :: "r"(tmem_tmem_dq_boundary), "r"(_mma_b_lo_2), "r"(tmem_tmem_a_state), "r"(0));
+                mbarrier_wait(a_ready_addr, _phase_a_ready_0);
+                _phase_a_ready_0 ^= 1;
+                int _mma_b_lo_3 = make_warp_uniform(((s_rt_tc_addr) >> 4) & 0x3FFF);
+                asm volatile(
+                    "{\n\t"
+                    ".reg .pred leader, p0, p1;\n\t"
+                    ".reg .b32 dhi, blo, ta, id;\n\t"
+                    ".reg .b64 db;\n\t"
+                    "elect.sync _|leader, 0xFFFFFFFF;\n\t"
+                    "setp.ne.b32 p0, %3, 0;\n\t"
+                    "setp.ne.b32 p1, 1, 0;\n\t"
+                    ""
+                    "mov.b32 dhi, 0x40004040;\n\t"
+                    "mov.b32 id, 134743184;\n\t"
+                    "mov.b32 ta, %2;\n\t"
+                    "mov.b32 blo, %1;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p0;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 250;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "}\n"
+                    :: "r"(tmem_tmem_dkr), "r"(_mma_b_lo_3), "r"(tmem_tmem_a_dh), "r"(0));
+                elect_commit(first_outputs_ready_addr);
+                mbarrier_wait(prep_ready_addr, _phase_prep_ready_0);
+                _phase_prep_ready_0 ^= 1;
+                mbarrier_wait(qki_tc_ready_addr, _phase_qki_tc_ready_0);
+                _phase_qki_tc_ready_0 ^= 1;
+                int _mma_b_lo_4 = make_warp_uniform(((s_dm_tc_addr) >> 4) & 0x3FFF);
+                asm volatile(
+                    "{\n\t"
+                    ".reg .pred leader, p0, p1;\n\t"
+                    ".reg .b32 dhi, blo, ta, id;\n\t"
+                    ".reg .b64 db;\n\t"
+                    "elect.sync _|leader, 0xFFFFFFFF;\n\t"
+                    "setp.ne.b32 p0, %3, 0;\n\t"
+                    "setp.ne.b32 p1, 1, 0;\n\t"
+                    ""
+                    "mov.b32 dhi, 0xC0004010;\n\t"
+                    "mov.b32 id, 134743184;\n\t"
+                    "mov.b32 ta, %2;\n\t"
+                    "mov.b32 blo, %1;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p0;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 64;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "}\n"
+                    :: "r"(tmem_tmem_di), "r"(_mma_b_lo_4), "r"(tmem_tmem_a_k), "r"(0));
+                int _mma_b_lo_5 = make_warp_uniform(((s_dnt_tc_addr) >> 4) & 0x3FFF);
+                asm volatile(
+                    "{\n\t"
+                    ".reg .pred leader, p0, p1;\n\t"
+                    ".reg .b32 dhi, blo, ta, id;\n\t"
+                    ".reg .b64 db;\n\t"
+                    "elect.sync _|leader, 0xFFFFFFFF;\n\t"
+                    "setp.ne.b32 p0, %3, 0;\n\t"
+                    "setp.ne.b32 p1, 1, 0;\n\t"
+                    ""
+                    "mov.b32 dhi, 0xC0004010;\n\t"
+                    "mov.b32 id, 134743184;\n\t"
+                    "mov.b32 ta, %2;\n\t"
+                    "mov.b32 blo, %1;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p0;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 64;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "}\n"
+                    :: "r"(tmem_tmem_di), "r"(_mma_b_lo_5), "r"(tmem_tmem_a_q), "r"(1));
+                int _mma_b_lo_6 = make_warp_uniform(((s_dn_tc_addr) >> 4) & 0x3FFF);
+                asm volatile(
+                    "{\n\t"
+                    ".reg .pred leader, p0, p1;\n\t"
+                    ".reg .b32 dhi, blo, ta, id;\n\t"
+                    ".reg .b64 db;\n\t"
+                    "elect.sync _|leader, 0xFFFFFFFF;\n\t"
+                    "setp.ne.b32 p0, %3, 0;\n\t"
+                    "setp.ne.b32 p1, 1, 0;\n\t"
+                    ""
+                    "mov.b32 dhi, 0xC0004010;\n\t"
+                    "mov.b32 id, 134743184;\n\t"
+                    "mov.b32 ta, %2;\n\t"
+                    "mov.b32 blo, %1;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p0;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 64;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "}\n"
+                    :: "r"(tmem_tmem_dq_local), "r"(_mma_b_lo_6), "r"(tmem_tmem_a_i), "r"(0));
+                int _mma_b_lo_7 = make_warp_uniform(((s_dmt_tc_addr) >> 4) & 0x3FFF);
+                asm volatile(
+                    "{\n\t"
+                    ".reg .pred leader, p0, p1;\n\t"
+                    ".reg .b32 dhi, blo, ta, id;\n\t"
+                    ".reg .b64 db;\n\t"
+                    "elect.sync _|leader, 0xFFFFFFFF;\n\t"
+                    "setp.ne.b32 p0, %3, 0;\n\t"
+                    "setp.ne.b32 p1, 1, 0;\n\t"
+                    ""
+                    "mov.b32 dhi, 0xC0004010;\n\t"
+                    "mov.b32 id, 134743184;\n\t"
+                    "mov.b32 ta, %2;\n\t"
+                    "mov.b32 blo, %1;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p0;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 64;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "}\n"
+                    :: "r"(tmem_tmem_dk_local), "r"(_mma_b_lo_7), "r"(tmem_tmem_a_i), "r"(0));
+                elect_commit(outputs_ready_addr);
+            }
+            int key_row_1 = warp_id_in_role_2 * 32 + lane;
+            long long restore_base_2 = chunk_head_2 * 128;
+            float restore_1 = tape_restore_factor[restore_base_2 + (long long)key_row_1];
+            long long token_key_base_2 = chunk_head_2 * 32 * 128;
+            float kr_prefetch_1 = (float)tape_kr[token_key_base_2 + 3072 + (long long)key_row_1];
+            unsigned int _phase_first_outputs_ready_0_2 = 0;
+            mbarrier_wait(first_outputs_ready_addr, _phase_first_outputs_ready_0_2);
+            _phase_first_outputs_ready_0_2 ^= 1;
+            int sequence_2 = chunk_sequence[chunk_global_2];
+            long long bos_2 = cu_seqlens[sequence_2];
+            long long eos_2 = cu_seqlens[sequence_2 + 1];
+            long long chunk_start_2 = bos_2 + (long long)local_chunk_2 * 32;
+            long long chunk_end_1 = chunk_start_2 + 32;
+            if (chunk_end_1 > eos_2) {
+                chunk_end_1 = eos_2;
+            }
+            int chunk_length_1 = (int)(chunk_end_1 - chunk_start_2);
+            const int tmem_row_base_1 = warp_id_in_role_2 * 32 << 16;
+            long long out_base_1 = chunk_head_2 * 32 * 128;
+            float _exp2_2 = approx_exp2(lower_bound * 1.4426950408889634f * 16.0f);
+            float common_factor_1 = _exp2_2;
+            const int token_offset_1 = 24;
+            float _tmem_load_14[8];
+            tmem_ld_x8(&_tmem_load_14[0], taddr + 176 + (unsigned int)tmem_row_base_1 + (unsigned int)token_offset_1);
+            #pragma unroll
+            for (int token_local_early_1 = 0; token_local_early_1 < 8; token_local_early_1++) {
+                int token_out_early_1 = token_offset_1 + token_local_early_1;
+                float kr_value_early_1 = kr_prefetch_1;
+                if (token_local_early_1 != 0) {
+                    kr_value_early_1 = (float)tape_kr[token_key_base_2 + (long long)(token_out_early_1 * 128) + (long long)key_row_1];
+                }
+                int stable_index_early_1 = token_out_early_1 * 128 + key_row_1;
+                s_stable_dkr[stable_index_early_1] = _tmem_load_14[token_local_early_1] * kr_value_early_1;
+                _tmem_load_14[token_local_early_1] = _tmem_load_14[token_local_early_1] * restore_1;
+            }
+            unsigned int _phase_outputs_ready_0_2 = 0;
+            mbarrier_wait(outputs_ready_addr, _phase_outputs_ready_0_2);
+            _phase_outputs_ready_0_2 ^= 1;
+            float _tmem_load_15[8];
+            tmem_ld_x8(&_tmem_load_15[0], taddr + 208 + (unsigned int)tmem_row_base_1 + (unsigned int)token_offset_1);
+            asm volatile("tcgen05.wait::ld.sync.aligned;");
+            #pragma unroll
+            for (int token_local_1 = 0; token_local_1 < 8; token_local_1++) {
+                int token_out_1 = token_offset_1 + token_local_1;
+                long long out_index_3 = out_base_1 + (long long)(token_out_1 * 128) + (long long)key_row_1;
+                int shared_index_1 = token_out_1 * 128 + key_row_1;
+                __nv_bfloat16 i_value_bf16_1 = s_i[(shared_index_1 * 2 ^ (shared_index_1 * 2 >> 8 & 7) << 4) / 2];
+                float _cvt_f32_22 = __bfloat162float(i_value_bf16_1);
+                float i_value_1 = _cvt_f32_22;
+                grad_ki[out_index_3] = _tmem_load_15[token_local_1] + _tmem_load_14[token_local_1];
+                _tmem_load_15[token_local_1] = _tmem_load_15[token_local_1] * i_value_1;
+            }
+            float _tmem_load_16[8];
+            tmem_ld_x8(&_tmem_load_16[0], taddr + 240 + (unsigned int)tmem_row_base_1 + (unsigned int)token_offset_1);
+            float _tmem_load_17[8];
+            tmem_ld_x8(&_tmem_load_17[0], taddr + 272 + (unsigned int)tmem_row_base_1 + (unsigned int)token_offset_1);
+            asm volatile("tcgen05.wait::ld.sync.aligned;");
+            #pragma unroll
+            for (int token_local2_1 = 0; token_local2_1 < 8; token_local2_1++) {
+                int token_out2_1 = token_offset_1 + token_local2_1;
+                long long out_index_4 = out_base_1 + (long long)(token_out2_1 * 128) + (long long)key_row_1;
+                int shared_index2_1 = token_out2_1 * 128 + key_row_1;
+                __nv_bfloat16 q_value_bf16_1 = s_q[(shared_index2_1 * 2 ^ (shared_index2_1 * 2 >> 8 & 7) << 4) / 2];
+                float _cvt_f32_23 = __bfloat162float(q_value_bf16_1);
+                float q_value_1 = _cvt_f32_23;
+                _tmem_load_17[token_local2_1] = _tmem_load_17[token_local2_1] * common_factor_1;
+                float _fma_9 = __fmaf_rn(-_tmem_load_16[token_local2_1], q_value_1, _tmem_load_15[token_local2_1]);
+                _tmem_load_15[token_local2_1] = _fma_9;
+                _tmem_load_14[token_local2_1] = _tmem_load_17[token_local2_1] * q_value_1;
+                grad_qd[out_index_4] = _tmem_load_16[token_local2_1] + _tmem_load_17[token_local2_1];
+            }
+            unsigned int _phase_dbeta_done_0_2 = 0;
+            mbarrier_wait(dbeta_done_addr, _phase_dbeta_done_0_2);
+            _phase_dbeta_done_0_2 ^= 1;
+            float _tmem_load_18[8];
+            tmem_ld_x8(&_tmem_load_18[0], taddr + 304 + (unsigned int)tmem_row_base_1 + (unsigned int)token_offset_1);
+            float _tmem_load_19[8];
+            tmem_ld_x8(&_tmem_load_19[0], taddr + 336 + (unsigned int)tmem_row_base_1 + (unsigned int)token_offset_1);
+            asm volatile("tcgen05.wait::ld.sync.aligned;");
+            float high_base_suffix = 0.0f;
+            #pragma unroll
+            for (int token_local3_1 = 0; token_local3_1 < 8; token_local3_1++) {
+                int token_out3_1 = token_offset_1 + token_local3_1;
+                long long out_index_5 = out_base_1 + (long long)(token_out3_1 * 128) + (long long)key_row_1;
+                int shared_index3_1 = token_out3_1 * 128 + key_row_1;
+                __nv_bfloat16 k_value_bf16_1 = s_k[(shared_index3_1 * 2 ^ (shared_index3_1 * 2 >> 8 & 7) << 4) / 2];
+                float _cvt_f32_24 = __bfloat162float(k_value_bf16_1);
+                float k_value_1 = _cvt_f32_24;
+                _tmem_load_19[token_local3_1] = _tmem_load_19[token_local3_1] * (-common_factor_1);
+                float _fma_10 = __fmaf_rn(-_tmem_load_18[token_local3_1], k_value_1, _tmem_load_15[token_local3_1]);
+                _tmem_load_15[token_local3_1] = _fma_10;
+                float base_value_1 = _tmem_load_14[token_local3_1] + _tmem_load_19[token_local3_1] * k_value_1;
+                int stable_index3_1 = token_out3_1 * 128 + key_row_1;
+                s_stable_delta[stable_index3_1] = _tmem_load_15[token_local3_1];
+                s_stable_base[stable_index3_1] = base_value_1;
+                if (token_out3_1 < chunk_length_1) {
+                    high_base_suffix += base_value_1;
+                }
+                grad_kd[out_index_5] = _tmem_load_18[token_local3_1] + _tmem_load_19[token_local3_1];
+            }
+            s_high_base_suffix[key_row_1] = high_base_suffix;
+            asm volatile("barrier.sync 10, 384;" ::: "memory");
+            unsigned int _phase_epilogue_done_0 = 0;
+            mbarrier_wait(epilogue_done_addr, _phase_epilogue_done_0);
+            _phase_epilogue_done_0 ^= 1;
+            if (warp_id_in_role_2 == 0) {
+                int _tmem_dealloc_addr = *((volatile int*)tmem_addr_storage);
+                asm volatile("tcgen05.dealloc.cta_group::1.sync.aligned.b32 %0, %1;" :: "r"(_tmem_dealloc_addr), "r"(512));
+            }
+        }
+    }
+
+    // Cleanup
+}
+
+} // extern "C"
+
+#undef LOOM_INF
+#undef NUM_MAIN_STAGES
+#undef SMEM_S_DBETA_PARTIAL_OFF
+#undef SMEM_S_DBETA_PARTIAL_STAGE_BYTES
+#undef SMEM_S_DBETA_PARTIAL_STRIDE
+#undef SMEM_S_DET_OFF
+#undef SMEM_S_DET_STAGE_BYTES
+#undef SMEM_S_DET_STRIDE
+#undef SMEM_S_DET_TC_OFF
+#undef SMEM_S_DET_TC_STAGE_BYTES
+#undef SMEM_S_DET_TC_STRIDE
+#undef SMEM_S_DF_OFF
+#undef SMEM_S_DF_STAGE_BYTES
+#undef SMEM_S_DF_STRIDE
+#undef SMEM_S_DH_STAGE_OFF
+#undef SMEM_S_DH_STAGE_STAGE_BYTES
+#undef SMEM_S_DH_STAGE_STRIDE
+#undef SMEM_S_DJ_OFF
+#undef SMEM_S_DJ_STAGE_BYTES
+#undef SMEM_S_DJ_STRIDE
+#undef SMEM_S_DMT_TC_OFF
+#undef SMEM_S_DMT_TC_STAGE_BYTES
+#undef SMEM_S_DMT_TC_STRIDE
+#undef SMEM_S_DM_TC_OFF
+#undef SMEM_S_DM_TC_STAGE_BYTES
+#undef SMEM_S_DM_TC_STRIDE
+#undef SMEM_S_DNT_TC_OFF
+#undef SMEM_S_DNT_TC_STAGE_BYTES
+#undef SMEM_S_DNT_TC_STRIDE
+#undef SMEM_S_DN_TC_OFF
+#undef SMEM_S_DN_TC_STAGE_BYTES
+#undef SMEM_S_DN_TC_STRIDE
+#undef SMEM_S_DOT_OFF
+#undef SMEM_S_DOT_STAGE_BYTES
+#undef SMEM_S_DOT_STRIDE
+#undef SMEM_S_DOT_TC_OFF
+#undef SMEM_S_DOT_TC_STAGE_BYTES
+#undef SMEM_S_DOT_TC_STRIDE
+#undef SMEM_S_DO_STAGE_OFF
+#undef SMEM_S_DO_STAGE_STAGE_BYTES
+#undef SMEM_S_DO_STAGE_STRIDE
+#undef SMEM_S_DRT_OFF
+#undef SMEM_S_DRT_STAGE_BYTES
+#undef SMEM_S_DRT_STRIDE
+#undef SMEM_S_HIGH_BASE_SUFFIX_OFF
+#undef SMEM_S_HIGH_BASE_SUFFIX_STAGE_BYTES
+#undef SMEM_S_HIGH_BASE_SUFFIX_STRIDE
+#undef SMEM_S_I_OFF
+#undef SMEM_S_I_STAGE_BYTES
+#undef SMEM_S_I_STRIDE
+#undef SMEM_S_J_OFF
+#undef SMEM_S_J_STAGE_BYTES
+#undef SMEM_S_J_STRIDE
+#undef SMEM_S_K_OFF
+#undef SMEM_S_K_STAGE_BYTES
+#undef SMEM_S_K_STRIDE
+#undef SMEM_S_MIDDLE_BASE_SUFFIX_OFF
+#undef SMEM_S_MIDDLE_BASE_SUFFIX_STAGE_BYTES
+#undef SMEM_S_MIDDLE_BASE_SUFFIX_STRIDE
+#undef SMEM_S_M_OFF
+#undef SMEM_S_M_STAGE_BYTES
+#undef SMEM_S_M_STRIDE
+#undef SMEM_S_PREV_R_TC_OFF
+#undef SMEM_S_PREV_R_TC_STAGE_BYTES
+#undef SMEM_S_PREV_R_TC_STRIDE
+#undef SMEM_S_Q_OFF
+#undef SMEM_S_Q_STAGE_BYTES
+#undef SMEM_S_Q_STRIDE
+#undef SMEM_S_RT_OFF
+#undef SMEM_S_RT_STAGE_BYTES
+#undef SMEM_S_RT_STRIDE
+#undef SMEM_S_RT_TC_OFF
+#undef SMEM_S_RT_TC_STAGE_BYTES
+#undef SMEM_S_RT_TC_STRIDE
+#undef SMEM_S_STABLE_BASE_OFF
+#undef SMEM_S_STABLE_BASE_STAGE_BYTES
+#undef SMEM_S_STABLE_BASE_STRIDE
+#undef SMEM_S_STABLE_DELTA_OFF
+#undef SMEM_S_STABLE_DELTA_STAGE_BYTES
+#undef SMEM_S_STABLE_DELTA_STRIDE
+#undef SMEM_S_STABLE_DKR_OFF
+#undef SMEM_S_STABLE_DKR_STAGE_BYTES
+#undef SMEM_S_STABLE_DKR_STRIDE
+#undef SMEM_S_TMP_OFF
+#undef SMEM_S_TMP_STAGE_BYTES
+#undef SMEM_S_TMP_STRIDE
+#undef SMEM_S_X_OFF
+#undef SMEM_S_X_STAGE_BYTES
+#undef SMEM_S_X_STRIDE
+#undef SMEM_TOTAL
+#undef THREADS
+#undef TMEM_NCOLS
+#undef TMEM_TMEM_A_DH_OFFSET
+#undef TMEM_TMEM_A_I_OFFSET
+#undef TMEM_TMEM_A_K_OFFSET
+#undef TMEM_TMEM_A_Q_OFFSET
+#undef TMEM_TMEM_A_STATE_OFFSET
+#undef TMEM_TMEM_DI_OFFSET
+#undef TMEM_TMEM_DKR_OFFSET
+#undef TMEM_TMEM_DK_BOUNDARY_OFFSET
+#undef TMEM_TMEM_DK_LOCAL_OFFSET
+#undef TMEM_TMEM_DQ_BOUNDARY_OFFSET
+#undef TMEM_TMEM_DQ_LOCAL_OFFSET
+#undef TMEM_TMEM_RECON_KR_OFFSET
+#undef TMEM_TMEM_RECON_STATE_OFFSET
+#undef a_ready_addr
+#undef boundary_local_ready_addr
+#undef dbeta_done_addr
+#undef dh_ready_addr
+#undef dv_ready_addr
+#undef epilogue_done_addr
+#undef first_outputs_ready_addr
+#undef outputs_ready_addr
+#undef prep_ready_addr
+#undef qki_ready_addr
+#undef qki_tc_ready_addr
+#undef recon_inputs_ready_addr
+#undef recon_output_ready_addr
+#undef s_dbeta_partial_addr
+#undef s_det_addr
+#undef s_det_tc_addr
+#undef s_df_addr
+#undef s_dh_stage_addr
+#undef s_dj_addr
+#undef s_dm_tc_addr
+#undef s_dmt_tc_addr
+#undef s_dn_tc_addr
+#undef s_dnt_tc_addr
+#undef s_do_stage_addr
+#undef s_dot_addr
+#undef s_dot_tc_addr
+#undef s_drt_addr
+#undef s_high_base_suffix_addr
+#undef s_i_addr
+#undef s_j_addr
+#undef s_k_addr
+#undef s_m_addr
+#undef s_middle_base_suffix_addr
+#undef s_prev_r_tc_addr
+#undef s_q_addr
+#undef s_rt_addr
+#undef s_rt_tc_addr
+#undef s_stable_base_addr
+#undef s_stable_delta_addr
+#undef s_stable_dkr_addr
+#undef s_tmp_addr
+#undef s_x_addr
+#undef state_tc_ready_addr
+#undef value_tc_ready_addr
+
+#define LOOM_INF CUDART_INF_F
+#define NUM_MAIN_STAGES 1
+#define THREADS 128
+
+extern "C" {
+
+__global__ __launch_bounds__(128) void
+kernel_flashkda_backward_map_finalize_c32(__nv_bfloat16* __restrict__ decay, __nv_bfloat16* __restrict__ q, __nv_bfloat16* __restrict__ k, float* __restrict__ norm_inv, __nv_bfloat16* __restrict__ g, float* __restrict__ beta_active, float* __restrict__ A_log, float* __restrict__ dt_bias, long long* __restrict__ cu_seqlens, int* __restrict__ chunk_sequence, int* __restrict__ chunk_index, int* __restrict__ chunk_pair_start, __nv_bfloat16* __restrict__ grad_qd, __nv_bfloat16* __restrict__ grad_kd, __nv_bfloat16* __restrict__ grad_ki, float* __restrict__ dlog_decay, float* __restrict__ dbeta_active, __nv_bfloat16* __restrict__ dq, __nv_bfloat16* __restrict__ dk, __nv_bfloat16* __restrict__ dg, __nv_bfloat16* __restrict__ dbeta, float* __restrict__ dA_log, float* __restrict__ ddt_bias, int num_pair_heads, int num_heads, float scale, float lower_bound)
+{
+    const int tid = threadIdx.x;
+    const int warp = make_warp_uniform(tid / 32);
+    const int lane = tid % 32;
+
+
+    const int bid = blockIdx.x;
+    const int num_bids = gridDim.x;
+
+    // === Task calls (dependency order) ===
+    int block_type = blockIdx.x & 3;
+    int task_group = blockIdx.x / 4;
+    int warp_id_in_role = (warp - 0);
+    int pair_task = task_group * 4 + warp_id_in_role;
+    int gate_task = task_group * 8 + (block_type - 2) * 4 + warp_id_in_role;
+    int gate_pair_task = gate_task / 2;
+    int gate_pair_chunk = gate_task - gate_pair_task * 2;
+    if (block_type == 0 && pair_task < num_pair_heads) {
+        int pair = pair_task / num_heads;
+        int head = pair_task - pair * num_heads;
+        int first_chunk = chunk_pair_start[pair];
+        int sequence = chunk_sequence[first_chunk];
+        int first_local_chunk = chunk_index[first_chunk];
+        long long bos = cu_seqlens[sequence];
+        long long eos = cu_seqlens[sequence + 1];
+        int subwarp = lane / 16;
+        int sub_lane = lane - subwarp * 16;
+        int elem = sub_lane * 8;
+        #pragma unroll
+        for (int pair_chunk = 0; pair_chunk < 2; pair_chunk++) {
+            int chunk_global = first_chunk + pair_chunk;
+            int local_chunk = first_local_chunk + pair_chunk;
+            long long chunk_start = bos + (long long)local_chunk * 32;
+            if (chunk_start < eos) {
+                long long chunk_end = chunk_start + 32;
+                if (chunk_end > eos) {
+                    chunk_end = eos;
+                }
+                int chunk_length = (int)(chunk_end - chunk_start);
+                long long chunk_head = (long long)chunk_global * (long long)num_heads + (long long)head;
+                long long tape_base = chunk_head * 32 * 128;
+                #pragma unroll 2
+                for (int token_pair = 0; token_pair < chunk_length; token_pair += 2) {
+                    int token_col = token_pair + subwarp;
+                    long long token = chunk_start + (long long)token_col;
+                    long long token_base = (token * (long long)num_heads + (long long)head) * 128;
+                    long long index = token_base + (long long)elem;
+                    long long tape_index = tape_base + (long long)(token_col * 128) + (long long)elem;
+                    float decay_values[8];
+                    float grad_values[8];
+                    float q_values[8];
+                    float q_inv_lane = 0.0f;
+                    if (token_col < chunk_length) {
+                        {
+                            const uint4* _vptr_0 = reinterpret_cast<const uint4*>(decay + index);
+                            uint4 _vld_0[1];
+                            #pragma unroll
+                            for (int _blk = 0; _blk < 1; _blk++) {
+                                _vld_0[_blk] = _vptr_0[_blk];
+                                uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
+                                #pragma unroll
+                                for (int _pair = 0; _pair < 4; _pair++) {
+                                    asm volatile(
+                                        "{\n\t"
+                                        "shl.b32 %0, %2, 16;\n\t"
+                                        "and.b32 %1, %2, 0xffff0000;\n\t"
+                                        "}\n"
+                                        : "=f"((&decay_values[0 + _blk * 8 + _pair * 2])[0]), "=f"((&decay_values[0 + _blk * 8 + _pair * 2])[1])
+                                        : "r"(_vpairs_0[_pair]));
+                                }
+                            }
+                        }
+                        {
+                            const uint4* _vptr_1 = reinterpret_cast<const uint4*>(grad_qd + tape_index);
+                            uint4 _vld_1[1];
+                            #pragma unroll
+                            for (int _blk = 0; _blk < 1; _blk++) {
+                                _vld_1[_blk] = _vptr_1[_blk];
+                                uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
+                                #pragma unroll
+                                for (int _pair = 0; _pair < 4; _pair++) {
+                                    asm volatile(
+                                        "{\n\t"
+                                        "shl.b32 %0, %2, 16;\n\t"
+                                        "and.b32 %1, %2, 0xffff0000;\n\t"
+                                        "}\n"
+                                        : "=f"((&grad_values[0 + _blk * 8 + _pair * 2])[0]), "=f"((&grad_values[0 + _blk * 8 + _pair * 2])[1])
+                                        : "r"(_vpairs_1[_pair]));
+                                }
+                            }
+                        }
+                        {
+                            const uint4* _vptr_2 = reinterpret_cast<const uint4*>(q + index);
+                            uint4 _vld_2[1];
+                            #pragma unroll
+                            for (int _blk = 0; _blk < 1; _blk++) {
+                                _vld_2[_blk] = _vptr_2[_blk];
+                                uint32_t* _vpairs_2 = reinterpret_cast<uint32_t*>(&_vld_2[_blk]);
+                                #pragma unroll
+                                for (int _pair = 0; _pair < 4; _pair++) {
+                                    asm volatile(
+                                        "{\n\t"
+                                        "shl.b32 %0, %2, 16;\n\t"
+                                        "and.b32 %1, %2, 0xffff0000;\n\t"
+                                        "}\n"
+                                        : "=f"((&q_values[0 + _blk * 8 + _pair * 2])[0]), "=f"((&q_values[0 + _blk * 8 + _pair * 2])[1])
+                                        : "r"(_vpairs_2[_pair]));
+                                }
+                            }
+                        }
+                        if (sub_lane == 0) {
+                            long long norm_base = (token * (long long)num_heads + (long long)head) * 2;
+                            q_inv_lane = norm_inv[norm_base];
+                        }
+                    }
+                    float _shfl_0 = __shfl_sync(0xFFFFFFFF, q_inv_lane, subwarp * 16);
+                    float q_inv = _shfl_0;
+                    float q_dot = 0.0f;
+                    if (token_col < chunk_length) {
+                        #pragma unroll
+                        for (int map_i = 0; map_i < 8; map_i++) {
+                            grad_values[map_i] = grad_values[map_i] * decay_values[map_i] * scale;
+                            __nv_bfloat16 _cvt_bf16_0 = __float2bfloat16(q_values[map_i] * q_inv);
+                            q_values[map_i] = _cvt_bf16_0;
+                            float _fma_0 = __fmaf_rn(grad_values[map_i], q_values[map_i], q_dot);
+                            q_dot = _fma_0;
+                        }
+                    }
+                    float _shfl_xor_0 = __shfl_xor_sync(0xFFFFFFFF, q_dot, 8);
+                    q_dot += _shfl_xor_0;
+                    float _shfl_xor_1 = __shfl_xor_sync(0xFFFFFFFF, q_dot, 4);
+                    q_dot += _shfl_xor_1;
+                    float _shfl_xor_2 = __shfl_xor_sync(0xFFFFFFFF, q_dot, 2);
+                    q_dot += _shfl_xor_2;
+                    float _shfl_xor_3 = __shfl_xor_sync(0xFFFFFFFF, q_dot, 1);
+                    q_dot += _shfl_xor_3;
+                    if (token_col < chunk_length) {
+                        #pragma unroll
+                        for (int pullback_i = 0; pullback_i < 8; pullback_i++) {
+                            grad_values[pullback_i] = q_inv * (grad_values[pullback_i] - q_values[pullback_i] * q_dot);
+                        }
+                        {
+                            __nv_bfloat162 _pk[4];
+                            _pk[0] = __floats2bfloat162_rn(grad_values[0 + 0], grad_values[0 + 1]);
+                            _pk[1] = __floats2bfloat162_rn(grad_values[0 + 2], grad_values[0 + 3]);
+                            _pk[2] = __floats2bfloat162_rn(grad_values[0 + 4], grad_values[0 + 5]);
+                            _pk[3] = __floats2bfloat162_rn(grad_values[0 + 6], grad_values[0 + 7]);
+                            *reinterpret_cast<uint4*>(&((__nv_bfloat16*)(dq))[index + 0]) = *reinterpret_cast<uint4*>(&_pk[0]);
+                        }
+                    }
+                }
+            }
+        }
+    }
+    if (block_type == 1 && pair_task < num_pair_heads) {
+        int pair_1 = pair_task / num_heads;
+        int head_1 = pair_task - pair_1 * num_heads;
+        int first_chunk_1 = chunk_pair_start[pair_1];
+        int sequence_1 = chunk_sequence[first_chunk_1];
+        int first_local_chunk_1 = chunk_index[first_chunk_1];
+        long long bos_1 = cu_seqlens[sequence_1];
+        long long eos_1 = cu_seqlens[sequence_1 + 1];
+        int subwarp_1 = lane / 16;
+        int sub_lane_1 = lane - subwarp_1 * 16;
+        int elem_1 = sub_lane_1 * 8;
+        #pragma unroll
+        for (int pair_chunk_1 = 0; pair_chunk_1 < 2; pair_chunk_1++) {
+            int chunk_global_1 = first_chunk_1 + pair_chunk_1;
+            int local_chunk_1 = first_local_chunk_1 + pair_chunk_1;
+            long long chunk_start_1 = bos_1 + (long long)local_chunk_1 * 32;
+            if (chunk_start_1 < eos_1) {
+                long long chunk_end_1 = chunk_start_1 + 32;
+                if (chunk_end_1 > eos_1) {
+                    chunk_end_1 = eos_1;
+                }
+                int chunk_length_1 = (int)(chunk_end_1 - chunk_start_1);
+                long long chunk_head_1 = (long long)chunk_global_1 * (long long)num_heads + (long long)head_1;
+                long long tape_base_1 = chunk_head_1 * 32 * 128;
+                #pragma unroll 2
+                for (int token_pair_1 = 0; token_pair_1 < chunk_length_1; token_pair_1 += 2) {
+                    int token_col_1 = token_pair_1 + subwarp_1;
+                    long long token_1 = chunk_start_1 + (long long)token_col_1;
+                    long long token_base_1 = (token_1 * (long long)num_heads + (long long)head_1) * 128;
+                    long long index_1 = token_base_1 + (long long)elem_1;
+                    long long tape_index_1 = tape_base_1 + (long long)(token_col_1 * 128) + (long long)elem_1;
+                    float decay_values_1[8];
+                    float grad_k_values[8];
+                    float grad_i_values[8];
+                    float k_values[8];
+                    float k_inv_lane = 0.0f;
+                    if (token_col_1 < chunk_length_1) {
+                        {
+                            const uint4* _vptr_3 = reinterpret_cast<const uint4*>(decay + index_1);
+                            uint4 _vld_3[1];
+                            #pragma unroll
+                            for (int _blk = 0; _blk < 1; _blk++) {
+                                _vld_3[_blk] = _vptr_3[_blk];
+                                uint32_t* _vpairs_3 = reinterpret_cast<uint32_t*>(&_vld_3[_blk]);
+                                #pragma unroll
+                                for (int _pair = 0; _pair < 4; _pair++) {
+                                    asm volatile(
+                                        "{\n\t"
+                                        "shl.b32 %0, %2, 16;\n\t"
+                                        "and.b32 %1, %2, 0xffff0000;\n\t"
+                                        "}\n"
+                                        : "=f"((&decay_values_1[0 + _blk * 8 + _pair * 2])[0]), "=f"((&decay_values_1[0 + _blk * 8 + _pair * 2])[1])
+                                        : "r"(_vpairs_3[_pair]));
+                                }
+                            }
+                        }
+                        {
+                            const uint4* _vptr_4 = reinterpret_cast<const uint4*>(grad_kd + tape_index_1);
+                            uint4 _vld_4[1];
+                            #pragma unroll
+                            for (int _blk = 0; _blk < 1; _blk++) {
+                                _vld_4[_blk] = _vptr_4[_blk];
+                                uint32_t* _vpairs_4 = reinterpret_cast<uint32_t*>(&_vld_4[_blk]);
+                                #pragma unroll
+                                for (int _pair = 0; _pair < 4; _pair++) {
+                                    asm volatile(
+                                        "{\n\t"
+                                        "shl.b32 %0, %2, 16;\n\t"
+                                        "and.b32 %1, %2, 0xffff0000;\n\t"
+                                        "}\n"
+                                        : "=f"((&grad_k_values[0 + _blk * 8 + _pair * 2])[0]), "=f"((&grad_k_values[0 + _blk * 8 + _pair * 2])[1])
+                                        : "r"(_vpairs_4[_pair]));
+                                }
+                            }
+                        }
+                        {
+                            const uint4* _vptr_5 = reinterpret_cast<const uint4*>(grad_ki + tape_index_1);
+                            uint4 _vld_5[1];
+                            #pragma unroll
+                            for (int _blk = 0; _blk < 1; _blk++) {
+                                _vld_5[_blk] = _vptr_5[_blk];
+                                uint32_t* _vpairs_5 = reinterpret_cast<uint32_t*>(&_vld_5[_blk]);
+                                #pragma unroll
+                                for (int _pair = 0; _pair < 4; _pair++) {
+                                    asm volatile(
+                                        "{\n\t"
+                                        "shl.b32 %0, %2, 16;\n\t"
+                                        "and.b32 %1, %2, 0xffff0000;\n\t"
+                                        "}\n"
+                                        : "=f"((&grad_i_values[0 + _blk * 8 + _pair * 2])[0]), "=f"((&grad_i_values[0 + _blk * 8 + _pair * 2])[1])
+                                        : "r"(_vpairs_5[_pair]));
+                                }
+                            }
+                        }
+                        {
+                            const uint4* _vptr_6 = reinterpret_cast<const uint4*>(k + index_1);
+                            uint4 _vld_6[1];
+                            #pragma unroll
+                            for (int _blk = 0; _blk < 1; _blk++) {
+                                _vld_6[_blk] = _vptr_6[_blk];
+                                uint32_t* _vpairs_6 = reinterpret_cast<uint32_t*>(&_vld_6[_blk]);
+                                #pragma unroll
+                                for (int _pair = 0; _pair < 4; _pair++) {
+                                    asm volatile(
+                                        "{\n\t"
+                                        "shl.b32 %0, %2, 16;\n\t"
+                                        "and.b32 %1, %2, 0xffff0000;\n\t"
+                                        "}\n"
+                                        : "=f"((&k_values[0 + _blk * 8 + _pair * 2])[0]), "=f"((&k_values[0 + _blk * 8 + _pair * 2])[1])
+                                        : "r"(_vpairs_6[_pair]));
+                                }
+                            }
+                        }
+                        if (sub_lane_1 == 0) {
+                            long long norm_base_1 = (token_1 * (long long)num_heads + (long long)head_1) * 2;
+                            k_inv_lane = norm_inv[norm_base_1 + 1];
+                        }
+                    }
+                    float _shfl_1 = __shfl_sync(0xFFFFFFFF, k_inv_lane, subwarp_1 * 16);
+                    float k_inv = _shfl_1;
+                    float k_dot = 0.0f;
+                    if (token_col_1 < chunk_length_1) {
+                        #pragma unroll
+                        for (int map_i_1 = 0; map_i_1 < 8; map_i_1++) {
+                            float _rcp_0 = approx_rcp(decay_values_1[map_i_1]);
+                            grad_k_values[map_i_1] = grad_i_values[map_i_1] * _rcp_0 + grad_k_values[map_i_1] * decay_values_1[map_i_1];
+                            __nv_bfloat16 _cvt_bf16_1 = __float2bfloat16(k_values[map_i_1] * k_inv);
+                            k_values[map_i_1] = _cvt_bf16_1;
+                            float _fma_1 = __fmaf_rn(grad_k_values[map_i_1], k_values[map_i_1], k_dot);
+                            k_dot = _fma_1;
+                        }
+                    }
+                    float _shfl_xor_4 = __shfl_xor_sync(0xFFFFFFFF, k_dot, 8);
+                    k_dot += _shfl_xor_4;
+                    float _shfl_xor_5 = __shfl_xor_sync(0xFFFFFFFF, k_dot, 4);
+                    k_dot += _shfl_xor_5;
+                    float _shfl_xor_6 = __shfl_xor_sync(0xFFFFFFFF, k_dot, 2);
+                    k_dot += _shfl_xor_6;
+                    float _shfl_xor_7 = __shfl_xor_sync(0xFFFFFFFF, k_dot, 1);
+                    k_dot += _shfl_xor_7;
+                    if (token_col_1 < chunk_length_1) {
+                        #pragma unroll
+                        for (int pullback_i_1 = 0; pullback_i_1 < 8; pullback_i_1++) {
+                            grad_k_values[pullback_i_1] = k_inv * (grad_k_values[pullback_i_1] - k_values[pullback_i_1] * k_dot);
+                        }
+                        {
+                            __nv_bfloat162 _pk[4];
+                            _pk[0] = __floats2bfloat162_rn(grad_k_values[0 + 0], grad_k_values[0 + 1]);
+                            _pk[1] = __floats2bfloat162_rn(grad_k_values[0 + 2], grad_k_values[0 + 3]);
+                            _pk[2] = __floats2bfloat162_rn(grad_k_values[0 + 4], grad_k_values[0 + 5]);
+                            _pk[3] = __floats2bfloat162_rn(grad_k_values[0 + 6], grad_k_values[0 + 7]);
+                            *reinterpret_cast<uint4*>(&((__nv_bfloat16*)(dk))[index_1 + 0]) = *reinterpret_cast<uint4*>(&_pk[0]);
+                        }
+                    }
+                }
+            }
+        }
+    }
+    if (block_type >= 2 && gate_pair_task < num_pair_heads) {
+        int pair_2 = gate_pair_task / num_heads;
+        int head_2 = gate_pair_task - pair_2 * num_heads;
+        int first_chunk_2 = chunk_pair_start[pair_2];
+        int sequence_2 = chunk_sequence[first_chunk_2];
+        int first_local_chunk_2 = chunk_index[first_chunk_2];
+        long long bos_2 = cu_seqlens[sequence_2];
+        long long eos_2 = cu_seqlens[sequence_2 + 1];
+        int elem_2 = lane * 4;
+        int pair_chunk_2 = gate_pair_chunk;
+        int local_chunk_2 = first_local_chunk_2 + pair_chunk_2;
+        long long chunk_start_2 = bos_2 + (long long)local_chunk_2 * 32;
+        long long chunk_end_2 = chunk_start_2 + 32;
+        if (chunk_end_2 > eos_2) {
+            chunk_end_2 = eos_2;
+        }
+        float gate_a_lane = 0.0f;
+        if (lane == 0) {
+            float _expf_0 = __expf(A_log[head_2]);
+            gate_a_lane = _expf_0;
+        }
+        float _shfl_2 = __shfl_sync(0xFFFFFFFF, gate_a_lane, 0);
+        float gate_a = _shfl_2;
+        float gate_scale = lower_bound * gate_a;
+        float bias[4];
+        float ddt_sum[4];
+        float dA_sum[4];
+        #pragma unroll
+        for (int init_i = 0; init_i < 4; init_i++) {
+            bias[init_i] = dt_bias[head_2 * 128 + elem_2 + init_i];
+            ddt_sum[init_i] = 0.0f;
+            dA_sum[init_i] = 0.0f;
+        }
+        if (chunk_start_2 < eos_2) {
+            int chunk_length_2 = (int)(chunk_end_2 - chunk_start_2);
+            #pragma unroll 2
+            for (int token_col_2 = 0; token_col_2 < chunk_length_2; token_col_2++) {
+                long long token_2 = chunk_start_2 + (long long)token_col_2;
+                long long token_base_2 = (token_2 * (long long)num_heads + (long long)head_2) * 128;
+                long long index_2 = token_base_2 + (long long)elem_2;
+                float g_values[4];
+                float dlog_values[4];
+                float output_values[4];
+                {
+                    uint2 _vld_7;
+                    _vld_7 = *reinterpret_cast<const uint2*>(g + index_2);
+                    uint32_t* _vpairs_7 = reinterpret_cast<uint32_t*>(&_vld_7);
+                    #pragma unroll
+                    for (int _pair = 0; _pair < 2; _pair++) {
+                        asm volatile(
+                            "{\n\t"
+                            "shl.b32 %0, %2, 16;\n\t"
+                            "and.b32 %1, %2, 0xffff0000;\n\t"
+                            "}\n"
+                            : "=f"((&g_values[0 + _pair * 2])[0]), "=f"((&g_values[0 + _pair * 2])[1])
+                            : "r"(_vpairs_7[_pair]));
+                    }
+                }
+                {
+                    float4 _v4 = *reinterpret_cast<const float4*>(dlog_decay + index_2);
+                    dlog_values[0 + 0] = _v4.x;
+                    dlog_values[0 + 1] = _v4.y;
+                    dlog_values[0 + 2] = _v4.z;
+                    dlog_values[0 + 3] = _v4.w;
+                }
+                #pragma unroll
+                for (int gate_i = 0; gate_i < 4; gate_i++) {
+                    float biased = g_values[gate_i] + bias[gate_i];
+                    float _expf_1 = __expf((-gate_a) * biased);
+                    float _rcp_1 = approx_rcp(1.0f + _expf_1);
+                    float sigmoid = _rcp_1;
+                    float common = dlog_values[gate_i] * gate_scale * sigmoid * (1.0f - sigmoid);
+                    output_values[gate_i] = common;
+                    ddt_sum[gate_i] = ddt_sum[gate_i] + common;
+                    float _fma_2 = __fmaf_rn(common, biased, dA_sum[gate_i]);
+                    dA_sum[gate_i] = _fma_2;
+                }
+                {
+                    uint2 _pk2;
+                    __nv_bfloat162* _pk = reinterpret_cast<__nv_bfloat162*>(&_pk2);
+                    _pk[0] = __floats2bfloat162_rn(output_values[0 + 0], output_values[0 + 1]);
+                    _pk[1] = __floats2bfloat162_rn(output_values[0 + 2], output_values[0 + 3]);
+                    *reinterpret_cast<uint2*>(&((__nv_bfloat16*)(dg))[index_2]) = _pk2;
+                }
+                if (lane == 0) {
+                    long long beta_index = token_2 * (long long)num_heads + (long long)head_2;
+                    float beta_sigmoid = beta_active[beta_index];
+                    __nv_bfloat16 _cvt_bf16_2 = __float2bfloat16(dbeta_active[beta_index] * beta_sigmoid * (1.0f - beta_sigmoid));
+                    dbeta[beta_index] = _cvt_bf16_2;
+                }
+            }
+            #pragma unroll
+            for (int publish_i = 0; publish_i < 4; publish_i++) {
+                atomicAdd(&ddt_bias[head_2 * 128 + elem_2 + publish_i], ddt_sum[publish_i]);
+            }
+            float head_dA = 0.0f;
+            #pragma unroll
+            for (int reduce_i = 0; reduce_i < 4; reduce_i++) {
+                head_dA += dA_sum[reduce_i];
+            }
+            float _warp_reduce_0 = head_dA;
+            #pragma unroll
+            for (int offset = 16; offset > 0; offset >>= 1)
+                _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
+            head_dA = _warp_reduce_0;
+            if (lane == 0) {
+                atomicAdd(&dA_log[head_2], head_dA);
+            }
+        }
+    }
+}
+
+} // extern "C"
+
+#undef LOOM_INF
+#undef NUM_MAIN_STAGES
+#undef THREADS

--- a/csrc/kda/training_fallback_pointer_sm_103a.cu
+++ b/csrc/kda/training_fallback_pointer_sm_103a.cu
@@ -1,0 +1,11588 @@
+typedef signed char        int8_t;
+typedef unsigned char      uint8_t;
+typedef unsigned short     uint16_t;
+typedef unsigned int       uint32_t;
+typedef unsigned long long uint64_t;
+typedef signed int         int32_t;
+typedef short int          int16_t;
+struct __align__(128) LoomTensorMap { uint64_t opaque[16]; };
+template <int N>
+struct __align__(128) LoomTensorMapPack { LoomTensorMap maps[N]; };
+
+typedef struct __align__(64) { uint64_t opaque[16]; } CUtensorMap;
+
+#include <cuda_bf16.h>
+
+#include <math_constants.h>
+
+__device__ __forceinline__ float approx_rcp(float x) {
+    float y;
+    asm("rcp.approx.ftz.f32 %0, %1;" : "=f"(y) : "f"(x));
+    return y;
+}
+
+__device__ __forceinline__ uint32_t elect_sync() {
+    uint32_t pred = 0;
+    asm volatile(
+        "{\n\t"
+        ".reg .pred %%px;\n\t"
+        "elect.sync _|%%px, %1;\n\t"
+        "@%%px mov.s32 %0, 1;\n\t"
+        "}\n"
+        : "+r"(pred)
+        : "r"(0xFFFFFFFF));
+    return pred;
+}
+
+__device__ __forceinline__ void mbarrier_init(int mbar_addr, int count) {
+    asm volatile("mbarrier.init.shared::cta.b64 [%0], %1;"
+        :: "r"(mbar_addr), "r"(count));
+}
+
+__device__ __forceinline__ uint32_t mbarrier_try_wait(int mbar_addr, int phase) {
+    uint32_t token;
+    asm volatile(
+        "{\n\t"
+        ".reg .pred P1;\n\t"
+        "mbarrier.try_wait.parity.acquire.cta.shared::cta.b64"
+        " P1, [%1], %2;\n\t"
+        "selp.u32 %0, 1, 0, P1;\n\t"
+        "}\n"
+        : "=r"(token)
+        : "r"(mbar_addr), "r"(phase) : "memory");
+    return token;
+}
+
+__device__ __forceinline__ uint32_t mbarrier_try_wait_cluster(int mbar_addr, int phase) {
+    uint32_t token;
+    asm volatile(
+        "{\n\t"
+        ".reg .pred P1;\n\t"
+        "mbarrier.try_wait.parity.acquire.cluster.shared::cta.b64"
+        " P1, [%1], %2;\n\t"
+        "selp.u32 %0, 1, 0, P1;\n\t"
+        "}\n"
+        : "=r"(token)
+        : "r"(mbar_addr), "r"(phase) : "memory");
+    return token;
+}
+
+__device__ __forceinline__ void mbarrier_wait(int mbar_addr, int phase) {
+    uint32_t ticks = 0x989680;
+    asm volatile(
+        "{\n\t"
+        ".reg .pred P1;\n\t"
+        "LAB_WAIT:\n\t"
+        "mbarrier.try_wait.parity.acquire.cta.shared::cta.b64"
+        " P1, [%0], %1, %2;\n\t"
+        "@P1 bra.uni DONE;\n\t"
+        "bra.uni LAB_WAIT;\n\t"
+        "DONE:\n\t"
+        "}\n"
+        :: "r"(mbar_addr), "r"(phase), "r"(ticks) : "memory");
+}
+
+__device__ __forceinline__ void mbarrier_wait_cluster(int mbar_addr, int phase) {
+    uint32_t ticks = 0x989680;
+    asm volatile(
+        "{\n\t"
+        ".reg .pred P1;\n\t"
+        "LAB_WAIT_CLUSTER:\n\t"
+        "mbarrier.try_wait.parity.acquire.cluster.shared::cta.b64"
+        " P1, [%0], %1, %2;\n\t"
+        "@P1 bra.uni DONE_CLUSTER;\n\t"
+        "bra.uni LAB_WAIT_CLUSTER;\n\t"
+        "DONE_CLUSTER:\n\t"
+        "}\n"
+        :: "r"(mbar_addr), "r"(phase), "r"(ticks) : "memory");
+}
+
+__device__ __forceinline__ void mbarrier_wait_token(int mbar_addr, int phase, uint32_t token) {
+    if (token == 0) {
+        mbarrier_wait(mbar_addr, phase);
+    }
+}
+
+__device__ __forceinline__ void mbarrier_wait_token_cluster(int mbar_addr, int phase, uint32_t token) {
+    if (token == 0) {
+        mbarrier_wait_cluster(mbar_addr, phase);
+    }
+}
+
+__device__ __forceinline__ void tcgen05_mma_f16(
+    int taddr, uint64_t a_desc, uint64_t b_desc,
+    uint32_t i_desc, int enable_input_d) {
+    asm volatile(
+        "{\n\t"
+        ".reg .pred p;\n\t"
+        "setp.ne.b32 p, %4, 0;\n\t"
+        "tcgen05.mma.cta_group::1.kind::f16 [%0], %1, %2, %3, p;\n\t"
+        "}\n"
+        :: "r"(taddr), "l"(a_desc), "l"(b_desc),
+           "r"(i_desc), "r"(enable_input_d));
+}
+
+__device__ __forceinline__ uint64_t desc_encode(uint64_t x) {
+    return (x & 0x3FFFFULL) >> 4ULL;
+}
+
+__device__ __forceinline__ void mma_ts_step(
+    int taddr_out, int taddr_a, int b_lo, uint32_t b_dhi,
+    uint32_t i_desc, int enable_d) {
+    asm volatile(
+        "{\n\t"
+        ".reg .pred leader, p;\n\t"
+        ".reg .b32 dhi;\n\t"
+        ".reg .b64 db;\n\t"
+        "elect.sync _|leader, 0xFFFFFFFF;\n\t"
+        "setp.ne.b32 p, %5, 0;\n\t"
+        "mov.b32 dhi, %3;\n\t"
+        "mov.b64 db, {%2, dhi};\n\t"
+        "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [%1], db, %4, p;\n\t"
+        "}\n"
+        :: "r"(taddr_out), "r"(taddr_a), "r"(b_lo), "r"(b_dhi),
+           "r"(i_desc), "r"(enable_d));
+}
+
+__device__ __forceinline__ void elect_commit(int mbar_addr) {
+    asm volatile(
+        "{\n\t"
+        ".reg .pred leader;\n\t"
+        "elect.sync _|leader, 0xFFFFFFFF;\n\t"
+        "@leader tcgen05.commit.cta_group::1.mbarrier::arrive::one"
+        ".shared::cluster.b64 [%0];\n\t"
+        "}\n"
+        :: "r"(mbar_addr));
+}
+
+__device__ __forceinline__ void mbarrier_arrive(int mbar_addr) {
+    asm volatile(
+        "mbarrier.arrive.release.cta.shared::cta.b64 _, [%0];"
+        :: "r"(mbar_addr) : "memory");
+}
+
+__device__ __forceinline__ void mbarrier_arrive_expect_tx(int mbar_addr, uint32_t bytes) {
+    asm volatile(
+        "mbarrier.arrive.expect_tx.release.cta.shared::cta.b64 _, [%0], %1;"
+        :: "r"(mbar_addr), "r"(bytes) : "memory");
+}
+
+__device__ __forceinline__ void tmem_ld_x32(float* dst, int tmem_addr) {
+    asm volatile(
+        "tcgen05.ld.sync.aligned.32x32b.x32.b32"
+        " {%0, %1, %2, %3, %4, %5, %6, %7,"
+        "  %8, %9, %10, %11, %12, %13, %14, %15,"
+        "  %16, %17, %18, %19, %20, %21, %22, %23,"
+        "  %24, %25, %26, %27, %28, %29, %30, %31}, [%32];"
+        : "=f"(dst[0]),  "=f"(dst[1]),  "=f"(dst[2]),  "=f"(dst[3]),
+          "=f"(dst[4]),  "=f"(dst[5]),  "=f"(dst[6]),  "=f"(dst[7]),
+          "=f"(dst[8]),  "=f"(dst[9]),  "=f"(dst[10]), "=f"(dst[11]),
+          "=f"(dst[12]), "=f"(dst[13]), "=f"(dst[14]), "=f"(dst[15]),
+          "=f"(dst[16]), "=f"(dst[17]), "=f"(dst[18]), "=f"(dst[19]),
+          "=f"(dst[20]), "=f"(dst[21]), "=f"(dst[22]), "=f"(dst[23]),
+          "=f"(dst[24]), "=f"(dst[25]), "=f"(dst[26]), "=f"(dst[27]),
+          "=f"(dst[28]), "=f"(dst[29]), "=f"(dst[30]), "=f"(dst[31])
+        : "r"(tmem_addr));
+}
+
+__device__ __forceinline__ void tmem_ld_x16(float* dst, int tmem_addr) {
+    asm volatile(
+        "tcgen05.ld.sync.aligned.32x32b.x16.b32"
+        " {%0, %1, %2, %3, %4, %5, %6, %7,"
+        "  %8, %9, %10, %11, %12, %13, %14, %15}, [%16];"
+        : "=f"(dst[0]),  "=f"(dst[1]),  "=f"(dst[2]),  "=f"(dst[3]),
+          "=f"(dst[4]),  "=f"(dst[5]),  "=f"(dst[6]),  "=f"(dst[7]),
+          "=f"(dst[8]),  "=f"(dst[9]),  "=f"(dst[10]), "=f"(dst[11]),
+          "=f"(dst[12]), "=f"(dst[13]), "=f"(dst[14]), "=f"(dst[15])
+        : "r"(tmem_addr));
+}
+
+__device__ __forceinline__ void tmem_st_x32_f32(int tmem_addr, const float* src) {
+    asm volatile(
+        "tcgen05.st.sync.aligned.32x32b.x32.b32"
+        " [%0], {%1, %2, %3, %4, %5, %6, %7, %8,"
+        "  %9, %10, %11, %12, %13, %14, %15, %16,"
+        "  %17, %18, %19, %20, %21, %22, %23, %24,"
+        "  %25, %26, %27, %28, %29, %30, %31, %32};"
+        :: "r"(tmem_addr),
+           "f"(src[0]),  "f"(src[1]),  "f"(src[2]),  "f"(src[3]),
+           "f"(src[4]),  "f"(src[5]),  "f"(src[6]),  "f"(src[7]),
+           "f"(src[8]),  "f"(src[9]),  "f"(src[10]), "f"(src[11]),
+           "f"(src[12]), "f"(src[13]), "f"(src[14]), "f"(src[15]),
+           "f"(src[16]), "f"(src[17]), "f"(src[18]), "f"(src[19]),
+           "f"(src[20]), "f"(src[21]), "f"(src[22]), "f"(src[23]),
+           "f"(src[24]), "f"(src[25]), "f"(src[26]), "f"(src[27]),
+           "f"(src[28]), "f"(src[29]), "f"(src[30]), "f"(src[31]));
+}
+
+__device__ __forceinline__ float approx_exp2(float x) {
+    float y;
+    asm("ex2.approx.ftz.f32 %0, %1;" : "=f"(y) : "f"(x));
+    return y;
+}
+
+__device__ __forceinline__ float max_noftz(float a, float b) {
+    float c;
+    asm("max.f32 %0, %1, %2;" : "=f"(c) : "f"(a), "f"(b));
+    return c;
+}
+
+__device__ __forceinline__ void fma_f32x2_inplace(float2* a, float2 b, float2 c) {
+    unsigned long long r;
+    asm("fma.rn.ftz.f32x2 %0, %1, %2, %3;"
+        : "=l"(r)
+        : "l"(*(unsigned long long*)a), "l"(*(unsigned long long*)&b),
+          "l"(*(unsigned long long*)&c));
+    *(unsigned long long*)a = r;
+}
+
+__device__ __forceinline__ void mul_f32x2_inplace(float2* a, float2 b) {
+    asm("mul.rn.ftz.f32x2 %0, %0, %1;"
+        : "+l"(*(unsigned long long*)a) : "l"(*(unsigned long long*)&b));
+}
+
+__device__ __forceinline__ void add_f32x2_inplace(float2* a, float2 b) {
+    asm("add.rn.ftz.f32x2 %0, %0, %1;"
+        : "+l"(*(unsigned long long*)a) : "l"(*(unsigned long long*)&b));
+}
+
+__device__ __forceinline__ void sub_f32x2_inplace(float2* a, float2 b) {
+    asm("sub.rn.ftz.f32x2 %0, %0, %1;"
+        : "+l"(*(unsigned long long*)a) : "l"(*(unsigned long long*)&b));
+}
+
+__device__ __forceinline__ float2 add_f32x2(float2 a, float2 b) {
+    float2 r;
+    asm("add.rn.ftz.f32x2 %0, %1, %2;"
+        : "=l"(*(unsigned long long*)&r)
+        : "l"(*(unsigned long long*)&a), "l"(*(unsigned long long*)&b));
+    return r;
+}
+
+__device__ __forceinline__ float2 sub_f32x2(float2 a, float2 b) {
+    float2 r;
+    asm("sub.rn.ftz.f32x2 %0, %1, %2;"
+        : "=l"(*(unsigned long long*)&r)
+        : "l"(*(unsigned long long*)&a), "l"(*(unsigned long long*)&b));
+    return r;
+}
+
+__device__ __forceinline__ void fma_scale_x32(
+    float* sv, const float2* scale2, const float2* neg_max2)
+{
+    float2* sv_2 = reinterpret_cast<float2*>(sv);
+
+#pragma unroll
+
+for (int j = 0; j < 16; j++)
+        fma_f32x2_inplace(&sv_2[j], *scale2, *neg_max2);
+}
+
+__device__ __forceinline__ float2 fma_f32x2(float2 a, float2 b, float2 c) {
+    float2 r;
+    asm("fma.rn.ftz.f32x2 %0, %1, %2, %3;"
+        : "=l"(*(unsigned long long*)&r)
+        : "l"(*(unsigned long long*)&a), "l"(*(unsigned long long*)&b),
+          "l"(*(unsigned long long*)&c));
+    return r;
+}
+
+__device__ __forceinline__ float2 fma_sub_f32x2(float2 a, float2 b, float2 c) {
+    float2 r;
+    asm volatile("{\n\t"
+        ".reg .f32 _c0, _c1;\n\t"
+        ".reg .b64 _neg_c;\n\t"
+        "mov.b64 {_c0, _c1}, %3;\n\t"
+        "neg.f32 _c0, _c0;\n\t"
+        "neg.f32 _c1, _c1;\n\t"
+        "mov.b64 _neg_c, {_c0, _c1};\n\t"
+        "fma.rn.ftz.f32x2 %0, %1, %2, _neg_c;\n\t"
+        "}\n"
+        : "=l"(*(unsigned long long*)&r)
+        : "l"(*(unsigned long long*)&a), "l"(*(unsigned long long*)&b),
+          "l"(*(unsigned long long*)&c));
+    return r;
+}
+
+__device__ __forceinline__ float2 mul_f32x2(float2 a, float2 b) {
+    float2 r;
+    asm("mul.rn.ftz.f32x2 %0, %1, %2;"
+        : "=l"(*(unsigned long long*)&r)
+        : "l"(*(unsigned long long*)&a), "l"(*(unsigned long long*)&b));
+    return r;
+}
+
+// ex2_emulation_f32x2 defined in softmax_frag_exp2_cast helper (or standalone)
+
+__device__ __forceinline__ void elect_commit2(int mbar_addr0, int mbar_addr1) {
+    asm volatile(
+        "{\n\t"
+        ".reg .pred leader;\n\t"
+        "elect.sync _|leader, 0xFFFFFFFF;\n\t"
+        "@leader tcgen05.commit.cta_group::1.mbarrier::arrive::one"
+        ".shared::cluster.b64 [%0];\n\t"
+        "@leader tcgen05.commit.cta_group::1.mbarrier::arrive::one"
+        ".shared::cluster.b64 [%1];\n\t"
+        "}\n"
+        :: "r"(mbar_addr0), "r"(mbar_addr1) : "memory");
+}
+
+__device__ __forceinline__ void fence_async_shared() {
+    asm volatile("fence.proxy.async.shared::cta;" ::: "memory");
+}
+
+__device__ __forceinline__ uint64_t make_smem_desc(int addr) {
+    const int SBO = 1024;
+    return desc_encode(addr)
+         | (desc_encode(SBO) << 32ULL)
+         | (1ULL << 46ULL)
+         | (2ULL << 61ULL);
+}
+
+__device__ __forceinline__ void tma_3d_gmem2smem(
+    int dst, const void *tmap_ptr, int x, int y, int z, int mbar_addr) {
+    asm volatile(
+        "cp.async.bulk.tensor.3d.shared::cta.global"
+        ".mbarrier::complete_tx::bytes"
+        " [%0], [%1, {%2, %3, %4}], [%5];"
+        :: "r"(dst), "l"(tmap_ptr), "r"(x), "r"(y), "r"(z),
+           "r"(mbar_addr) : "memory");
+}
+
+__device__ __forceinline__ void tma_2d_gmem2smem(
+    int dst, const void *tmap_ptr, int x, int y, int mbar_addr) {
+    asm volatile(
+        "cp.async.bulk.tensor.2d.shared::cta.global"
+        ".mbarrier::complete_tx::bytes"
+        " [%0], [%1, {%2, %3}], [%4];"
+        :: "r"(dst), "l"(tmap_ptr), "r"(x), "r"(y),
+           "r"(mbar_addr) : "memory");
+}
+
+__device__ __forceinline__ void tma_4d_gmem2smem(
+    int dst, const void *tmap_ptr, int x, int y, int z, int w, int mbar_addr) {
+    asm volatile(
+        "cp.async.bulk.tensor.4d.shared::cta.global"
+        ".mbarrier::complete_tx::bytes"
+        " [%0], [%1, {%2, %3, %4, %5}], [%6];"
+        :: "r"(dst), "l"(tmap_ptr), "r"(x), "r"(y), "r"(z), "r"(w),
+           "r"(mbar_addr) : "memory");
+}
+
+__device__ __forceinline__ void tma_store_4d(
+    const void *tmap, int x, int y, int z, int w, unsigned smem_addr) {
+    asm volatile(
+        "cp.async.bulk.tensor.4d.global.shared::cta.tile.bulk_group"
+        " [%0, {%1, %2, %3, %4}], [%5];"
+        :: "l"(tmap), "r"(x), "r"(y), "r"(z), "r"(w), "r"(smem_addr) : "memory");
+}
+
+__device__ __forceinline__ void tcgen05_commit(int mbar_addr) {
+    asm volatile(
+        "tcgen05.commit.cta_group::1.mbarrier::arrive::one"
+        ".shared::cluster.b64 [%0];"
+        :: "r"(mbar_addr) : "memory");
+}
+
+__device__ __forceinline__ void tmem_st_x8_u32(int addr, const uint32_t* src) {
+    asm volatile(
+        "tcgen05.st.sync.aligned.32x32b.x8.b32"
+        " [%0], {%1,%2,%3,%4,%5,%6,%7,%8};"
+        :: "r"(addr),
+           "r"(src[0]), "r"(src[1]), "r"(src[2]), "r"(src[3]),
+           "r"(src[4]), "r"(src[5]), "r"(src[6]), "r"(src[7]));
+}
+
+__device__ __forceinline__ uint32_t make_warp_uniform(uint32_t val) {
+    uint32_t result;
+    asm volatile("shfl.sync.idx.b32 %0, %1, 0, 0x1f, 0xffffffff;"
+        : "=r"(result) : "r"(val));
+    return result;
+}
+
+__device__ __forceinline__ void tmem_ld_x16_wait(float* dst, int addr) {
+    tmem_ld_x16(dst, addr);
+    asm volatile("tcgen05.wait::ld.sync.aligned;");
+}
+
+__device__ __forceinline__ void tmem_ld_x8(float* dst, int tmem_addr) {
+    asm volatile(
+        "tcgen05.ld.sync.aligned.32x32b.x8.b32"
+        " {%0, %1, %2, %3, %4, %5, %6, %7}, [%8];"
+        : "=f"(dst[0]), "=f"(dst[1]), "=f"(dst[2]), "=f"(dst[3]),
+          "=f"(dst[4]), "=f"(dst[5]), "=f"(dst[6]), "=f"(dst[7])
+        : "r"(tmem_addr));
+}
+
+__device__ __forceinline__ void tmem_ld_x8_wait(float* dst, int addr) {
+    tmem_ld_x8(dst, addr);
+    asm volatile("tcgen05.wait::ld.sync.aligned;");
+}
+
+#define LOOM_INF CUDART_INF_F
+#define NUM_MAIN_STAGES 1
+#define THREADS 32
+#define D 128
+
+extern "C" {
+
+__global__ __launch_bounds__(32) void
+kernel_flashkda_backward_preprocess(__nv_bfloat16* __restrict__ q, __nv_bfloat16* __restrict__ k, __nv_bfloat16* __restrict__ g, __nv_bfloat16* __restrict__ beta, float* __restrict__ A_log, float* __restrict__ dt_bias, float* __restrict__ q_norm, float* __restrict__ k_norm, float* __restrict__ decay, float* __restrict__ beta_active, int total_tokens, int num_heads, float lower_bound)
+{
+    const int tid = threadIdx.x;
+    const int warp = make_warp_uniform(tid / 32);
+    const int lane = tid % 32;
+
+
+    const int bid = blockIdx.x;
+    const int num_bids = gridDim.x;
+
+    // === Task calls (dependency order) ===
+    int token = blockIdx.x;
+    int head = blockIdx.y;
+    int elem = lane * 4;
+    long long base = ((long long)token * (long long)num_heads + (long long)head) * (long long)D;
+    float q_frag[4];
+    float k_frag[4];
+    float g_frag[4];
+    {
+        uint2 _vld_0;
+        _vld_0 = *reinterpret_cast<const uint2*>(q + base + (long long)elem);
+        uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0);
+        #pragma unroll
+        for (int _pair = 0; _pair < 2; _pair++) {
+            asm volatile(
+                "{\n\t"
+                "shl.b32 %0, %2, 16;\n\t"
+                "and.b32 %1, %2, 0xffff0000;\n\t"
+                "}\n"
+                : "=f"((&q_frag[0 + _pair * 2])[0]), "=f"((&q_frag[0 + _pair * 2])[1])
+                : "r"(_vpairs_0[_pair]));
+        }
+    }
+    {
+        uint2 _vld_1;
+        _vld_1 = *reinterpret_cast<const uint2*>(k + base + (long long)elem);
+        uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1);
+        #pragma unroll
+        for (int _pair = 0; _pair < 2; _pair++) {
+            asm volatile(
+                "{\n\t"
+                "shl.b32 %0, %2, 16;\n\t"
+                "and.b32 %1, %2, 0xffff0000;\n\t"
+                "}\n"
+                : "=f"((&k_frag[0 + _pair * 2])[0]), "=f"((&k_frag[0 + _pair * 2])[1])
+                : "r"(_vpairs_1[_pair]));
+        }
+    }
+    {
+        uint2 _vld_2;
+        _vld_2 = *reinterpret_cast<const uint2*>(g + base + (long long)elem);
+        uint32_t* _vpairs_2 = reinterpret_cast<uint32_t*>(&_vld_2);
+        #pragma unroll
+        for (int _pair = 0; _pair < 2; _pair++) {
+            asm volatile(
+                "{\n\t"
+                "shl.b32 %0, %2, 16;\n\t"
+                "and.b32 %1, %2, 0xffff0000;\n\t"
+                "}\n"
+                : "=f"((&g_frag[0 + _pair * 2])[0]), "=f"((&g_frag[0 + _pair * 2])[1])
+                : "r"(_vpairs_2[_pair]));
+        }
+    }
+    float q_sq = 0.0f;
+    float k_sq = 0.0f;
+    #pragma unroll
+    for (int i = 0; i < 4; i++) {
+        float _fma_0 = __fmaf_rn(q_frag[i], q_frag[i], q_sq);
+        q_sq = _fma_0;
+        float _fma_1 = __fmaf_rn(k_frag[i], k_frag[i], k_sq);
+        k_sq = _fma_1;
+    }
+    float _warp_reduce_0 = q_sq;
+    #pragma unroll
+    for (int offset = 16; offset > 0; offset >>= 1)
+        _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
+    q_sq = _warp_reduce_0;
+    float _warp_reduce_1 = k_sq;
+    #pragma unroll
+    for (int offset = 16; offset > 0; offset >>= 1)
+        _warp_reduce_1 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_1, offset);
+    k_sq = _warp_reduce_1;
+    float _rsqrt_0 = rsqrtf(q_sq + 1e-06f);
+    float q_inv = _rsqrt_0;
+    float _rsqrt_1 = rsqrtf(k_sq + 1e-06f);
+    float k_inv = _rsqrt_1;
+    float _expf_0 = __expf(A_log[head]);
+    float gate_a = _expf_0;
+    #pragma unroll
+    for (int i2 = 0; i2 < 4; i2++) {
+        int dim = elem + i2;
+        float biased = g_frag[i2] + dt_bias[head * D + dim];
+        float _expf_1 = __expf((-gate_a) * biased);
+        float _rcp_0 = approx_rcp(1.0f + _expf_1);
+        float gate_sigmoid = _rcp_0;
+        q_norm[base + (long long)dim] = q_frag[i2] * q_inv;
+        k_norm[base + (long long)dim] = k_frag[i2] * k_inv;
+        float _expf_2 = __expf(lower_bound * gate_sigmoid);
+        decay[base + (long long)dim] = _expf_2;
+    }
+    if (lane == 0) {
+        long long beta_index = (long long)token * (long long)num_heads + (long long)head;
+        float beta_raw = (float)beta[beta_index];
+        float _expf_3 = __expf(-beta_raw);
+        float _rcp_1 = approx_rcp(1.0f + _expf_3);
+        beta_active[beta_index] = _rcp_1;
+    }
+}
+
+} // extern "C"
+
+#undef D
+#undef LOOM_INF
+#undef NUM_MAIN_STAGES
+#undef THREADS
+
+#define LOOM_INF CUDART_INF_F
+#define NUM_MAIN_STAGES 1
+#define THREADS 32
+#define D 128
+#define V 128
+
+extern "C" {
+
+__global__ __launch_bounds__(32) void
+kernel_flashkda_backward_checkpoint(float* __restrict__ k_norm, float* __restrict__ decay, float* __restrict__ beta_active, __nv_bfloat16* __restrict__ v, float* __restrict__ initial_state, long long* __restrict__ cu_seqlens, float* __restrict__ checkpoint, int num_sequences, int num_heads)
+{
+    const int tid = threadIdx.x;
+    const int warp = make_warp_uniform(tid / 32);
+    const int lane = tid % 32;
+
+
+    const int bid = blockIdx.x;
+    const int num_bids = gridDim.x;
+
+    // === Task calls (dependency order) ===
+    int work = blockIdx.x;
+    int rows_per_sequence = num_heads * V;
+    int sequence = work / rows_per_sequence;
+    int remainder = work - sequence * rows_per_sequence;
+    int head = remainder / V;
+    int value_row = remainder - head * V;
+    int elem = lane * 4;
+    long long bos = cu_seqlens[sequence];
+    long long eos = cu_seqlens[sequence + 1];
+    long long state_base = (((long long)sequence * (long long)num_heads + (long long)head) * (long long)V + (long long)value_row) * (long long)D;
+    float state[4];
+    {
+        float4 _v4 = *reinterpret_cast<const float4*>(initial_state + state_base + (long long)elem);
+        state[0 + 0] = _v4.x;
+        state[0 + 1] = _v4.y;
+        state[0 + 2] = _v4.z;
+        state[0 + 3] = _v4.w;
+    }
+    #pragma unroll 1
+    for (long long token = bos; token < eos; token++) {
+        long long token_base = (token * (long long)num_heads + (long long)head) * (long long)D;
+        float k_frag[4];
+        float d_frag[4];
+        {
+            float4 _v4 = *reinterpret_cast<const float4*>(k_norm + token_base + (long long)elem);
+            k_frag[0 + 0] = _v4.x;
+            k_frag[0 + 1] = _v4.y;
+            k_frag[0 + 2] = _v4.z;
+            k_frag[0 + 3] = _v4.w;
+        }
+        {
+            float4 _v4 = *reinterpret_cast<const float4*>(decay + token_base + (long long)elem);
+            d_frag[0 + 0] = _v4.x;
+            d_frag[0 + 1] = _v4.y;
+            d_frag[0 + 2] = _v4.z;
+            d_frag[0 + 3] = _v4.w;
+        }
+        float pred = 0.0f;
+        float decayed[4];
+        #pragma unroll
+        for (int i = 0; i < 4; i++) {
+            decayed[i] = state[i] * d_frag[i];
+            float _fma_0 = __fmaf_rn(k_frag[i], decayed[i], pred);
+            pred = _fma_0;
+        }
+        float _warp_reduce_0 = pred;
+        #pragma unroll
+        for (int offset = 16; offset > 0; offset >>= 1)
+            _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
+        pred = _warp_reduce_0;
+        long long beta_index = token * (long long)num_heads + (long long)head;
+        long long value_index = token_base + (long long)value_row;
+        float residual = beta_active[beta_index] * ((float)v[value_index] - pred);
+        long long checkpoint_base = ((token * (long long)num_heads + (long long)head) * (long long)V + (long long)value_row) * (long long)D;
+        #pragma unroll
+        for (int i2 = 0; i2 < 4; i2++) {
+            float _fma_1 = __fmaf_rn(residual, k_frag[i2], decayed[i2]);
+            state[i2] = _fma_1;
+            checkpoint[checkpoint_base + (long long)elem + (long long)i2] = state[i2];
+        }
+    }
+}
+
+} // extern "C"
+
+#undef D
+#undef LOOM_INF
+#undef NUM_MAIN_STAGES
+#undef THREADS
+#undef V
+
+#define LOOM_INF CUDART_INF_F
+#define NUM_MAIN_STAGES 1
+#define THREADS 32
+#define D 128
+#define V 128
+
+extern "C" {
+
+__global__ __launch_bounds__(32) void
+kernel_flashkda_backward_reverse_rows(float* __restrict__ q_norm, float* __restrict__ k_norm, float* __restrict__ decay, float* __restrict__ beta_active, __nv_bfloat16* __restrict__ v, __nv_bfloat16* __restrict__ do_, float* __restrict__ initial_state, float* __restrict__ dfinal_state, long long* __restrict__ cu_seqlens, float* __restrict__ checkpoint, float* __restrict__ dq_normalized, float* __restrict__ dk_normalized, float* __restrict__ dlog_decay, float* __restrict__ dbeta_active, __nv_bfloat16* __restrict__ dv, float* __restrict__ dinitial_state, int num_sequences, int num_heads, float scale)
+{
+    const int tid = threadIdx.x;
+    const int warp = make_warp_uniform(tid / 32);
+    const int lane = tid % 32;
+
+
+    const int bid = blockIdx.x;
+    const int num_bids = gridDim.x;
+
+    // === Task calls (dependency order) ===
+    int work = blockIdx.x;
+    int rows_per_sequence = num_heads * V;
+    int sequence = work / rows_per_sequence;
+    int remainder = work - sequence * rows_per_sequence;
+    int head = remainder / V;
+    int value_row = remainder - head * V;
+    int elem = lane * 4;
+    long long bos = cu_seqlens[sequence];
+    long long eos = cu_seqlens[sequence + 1];
+    long long sequence_length = eos - bos;
+    long long state_base = (((long long)sequence * (long long)num_heads + (long long)head) * (long long)V + (long long)value_row) * (long long)D;
+    float dstate[4];
+    {
+        float4 _v4 = *reinterpret_cast<const float4*>(dfinal_state + state_base + (long long)elem);
+        dstate[0 + 0] = _v4.x;
+        dstate[0 + 1] = _v4.y;
+        dstate[0 + 2] = _v4.z;
+        dstate[0 + 3] = _v4.w;
+    }
+    #pragma unroll 1
+    for (long long reverse_step = 0; reverse_step < sequence_length; reverse_step++) {
+        long long token = eos - 1 - reverse_step;
+        long long token_base = (token * (long long)num_heads + (long long)head) * (long long)D;
+        long long checkpoint_base = ((token * (long long)num_heads + (long long)head) * (long long)V + (long long)value_row) * (long long)D;
+        long long previous_base = checkpoint_base - (long long)num_heads * (long long)V * (long long)D;
+        if (token == bos) {
+            previous_base = state_base;
+        }
+        float q_frag[4];
+        float k_frag[4];
+        float d_frag[4];
+        float state_now[4];
+        float state_prev[4];
+        {
+            float4 _v4 = *reinterpret_cast<const float4*>(q_norm + token_base + (long long)elem);
+            q_frag[0 + 0] = _v4.x;
+            q_frag[0 + 1] = _v4.y;
+            q_frag[0 + 2] = _v4.z;
+            q_frag[0 + 3] = _v4.w;
+        }
+        {
+            float4 _v4 = *reinterpret_cast<const float4*>(k_norm + token_base + (long long)elem);
+            k_frag[0 + 0] = _v4.x;
+            k_frag[0 + 1] = _v4.y;
+            k_frag[0 + 2] = _v4.z;
+            k_frag[0 + 3] = _v4.w;
+        }
+        {
+            float4 _v4 = *reinterpret_cast<const float4*>(decay + token_base + (long long)elem);
+            d_frag[0 + 0] = _v4.x;
+            d_frag[0 + 1] = _v4.y;
+            d_frag[0 + 2] = _v4.z;
+            d_frag[0 + 3] = _v4.w;
+        }
+        {
+            float4 _v4 = *reinterpret_cast<const float4*>(checkpoint + checkpoint_base + (long long)elem);
+            state_now[0 + 0] = _v4.x;
+            state_now[0 + 1] = _v4.y;
+            state_now[0 + 2] = _v4.z;
+            state_now[0 + 3] = _v4.w;
+        }
+        if (token == bos) {
+            {
+                float4 _v4 = *reinterpret_cast<const float4*>(initial_state + previous_base + (long long)elem);
+                state_prev[0 + 0] = _v4.x;
+                state_prev[0 + 1] = _v4.y;
+                state_prev[0 + 2] = _v4.z;
+                state_prev[0 + 3] = _v4.w;
+            }
+        } else {
+            {
+                float4 _v4 = *reinterpret_cast<const float4*>(checkpoint + previous_base + (long long)elem);
+                state_prev[0 + 0] = _v4.x;
+                state_prev[0 + 1] = _v4.y;
+                state_prev[0 + 2] = _v4.z;
+                state_prev[0 + 3] = _v4.w;
+            }
+        }
+        long long value_index = token_base + (long long)value_row;
+        float output_adjoint = (float)do_[value_index];
+        float pred = 0.0f;
+        #pragma unroll
+        for (int i = 0; i < 4; i++) {
+            float _fma_0 = __fmaf_rn(scale * output_adjoint, q_frag[i], dstate[i]);
+            dstate[i] = _fma_0;
+            float _fma_1 = __fmaf_rn(k_frag[i], state_prev[i] * d_frag[i], pred);
+            pred = _fma_1;
+        }
+        float _warp_reduce_0 = pred;
+        #pragma unroll
+        for (int offset = 16; offset > 0; offset >>= 1)
+            _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
+        pred = _warp_reduce_0;
+        float dr = 0.0f;
+        #pragma unroll
+        for (int i2 = 0; i2 < 4; i2++) {
+            float _fma_2 = __fmaf_rn(dstate[i2], k_frag[i2], dr);
+            dr = _fma_2;
+        }
+        float _warp_reduce_1 = dr;
+        #pragma unroll
+        for (int offset = 16; offset > 0; offset >>= 1)
+            _warp_reduce_1 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_1, offset);
+        dr = _warp_reduce_1;
+        long long beta_index = token * (long long)num_heads + (long long)head;
+        float beta_value = beta_active[beta_index];
+        float value_raw = (float)v[value_index];
+        float residual = beta_value * (value_raw - pred);
+        float dpred = (-dr) * beta_value;
+        #pragma unroll
+        for (int i3 = 0; i3 < 4; i3++) {
+            long long dim_index = token_base + (long long)elem + (long long)i3;
+            float decayed_state = state_prev[i3] * d_frag[i3];
+            float _fma_3 = __fmaf_rn(dpred, k_frag[i3], dstate[i3]);
+            float d_p = _fma_3;
+            float _fma_4 = __fmaf_rn(dpred, decayed_state, residual * dstate[i3]);
+            float d_k = _fma_4;
+            atomicAdd(&dq_normalized[dim_index], scale * output_adjoint * state_now[i3]);
+            atomicAdd(&dk_normalized[dim_index], d_k);
+            atomicAdd(&dlog_decay[dim_index], d_p * state_prev[i3] * d_frag[i3]);
+            dstate[i3] = d_p * d_frag[i3];
+        }
+        if (lane == 0) {
+            atomicAdd(&dbeta_active[beta_index], dr * (value_raw - pred));
+            __nv_bfloat16 _cvt_bf16_0 = __float2bfloat16(dr * beta_value);
+            dv[value_index] = _cvt_bf16_0;
+        }
+    }
+    #pragma unroll
+    for (int i4 = 0; i4 < 4; i4++) {
+        dinitial_state[state_base + (long long)elem + (long long)i4] = dstate[i4];
+    }
+}
+
+} // extern "C"
+
+#undef D
+#undef LOOM_INF
+#undef NUM_MAIN_STAGES
+#undef THREADS
+#undef V
+
+#define LOOM_INF CUDART_INF_F
+#define NUM_MAIN_STAGES 1
+#define THREADS 32
+#define D 128
+
+extern "C" {
+
+__global__ __launch_bounds__(32) void
+kernel_flashkda_backward_finalize_tokens(__nv_bfloat16* __restrict__ q, __nv_bfloat16* __restrict__ k, __nv_bfloat16* __restrict__ g, float* __restrict__ beta_active, float* __restrict__ A_log, float* __restrict__ dt_bias, float* __restrict__ q_norm, float* __restrict__ k_norm, float* __restrict__ dq_normalized, float* __restrict__ dk_normalized, float* __restrict__ gate_common, float* __restrict__ dbeta_active, __nv_bfloat16* __restrict__ dq, __nv_bfloat16* __restrict__ dk, __nv_bfloat16* __restrict__ dg, __nv_bfloat16* __restrict__ dbeta, int num_heads, float lower_bound)
+{
+    const int tid = threadIdx.x;
+    const int warp = make_warp_uniform(tid / 32);
+    const int lane = tid % 32;
+
+
+    const int bid = blockIdx.x;
+    const int num_bids = gridDim.x;
+
+    // === Task calls (dependency order) ===
+    int token = blockIdx.x;
+    int head = blockIdx.y;
+    int elem = lane * 4;
+    long long base = ((long long)token * (long long)num_heads + (long long)head) * (long long)D;
+    float q_raw[4];
+    float k_raw[4];
+    float g_raw[4];
+    float qn[4];
+    float kn[4];
+    float dqn[4];
+    float dkn[4];
+    float dlog[4];
+    {
+        uint2 _vld_0;
+        _vld_0 = *reinterpret_cast<const uint2*>(q + base + (long long)elem);
+        uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0);
+        #pragma unroll
+        for (int _pair = 0; _pair < 2; _pair++) {
+            asm volatile(
+                "{\n\t"
+                "shl.b32 %0, %2, 16;\n\t"
+                "and.b32 %1, %2, 0xffff0000;\n\t"
+                "}\n"
+                : "=f"((&q_raw[0 + _pair * 2])[0]), "=f"((&q_raw[0 + _pair * 2])[1])
+                : "r"(_vpairs_0[_pair]));
+        }
+    }
+    {
+        uint2 _vld_1;
+        _vld_1 = *reinterpret_cast<const uint2*>(k + base + (long long)elem);
+        uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1);
+        #pragma unroll
+        for (int _pair = 0; _pair < 2; _pair++) {
+            asm volatile(
+                "{\n\t"
+                "shl.b32 %0, %2, 16;\n\t"
+                "and.b32 %1, %2, 0xffff0000;\n\t"
+                "}\n"
+                : "=f"((&k_raw[0 + _pair * 2])[0]), "=f"((&k_raw[0 + _pair * 2])[1])
+                : "r"(_vpairs_1[_pair]));
+        }
+    }
+    {
+        uint2 _vld_2;
+        _vld_2 = *reinterpret_cast<const uint2*>(g + base + (long long)elem);
+        uint32_t* _vpairs_2 = reinterpret_cast<uint32_t*>(&_vld_2);
+        #pragma unroll
+        for (int _pair = 0; _pair < 2; _pair++) {
+            asm volatile(
+                "{\n\t"
+                "shl.b32 %0, %2, 16;\n\t"
+                "and.b32 %1, %2, 0xffff0000;\n\t"
+                "}\n"
+                : "=f"((&g_raw[0 + _pair * 2])[0]), "=f"((&g_raw[0 + _pair * 2])[1])
+                : "r"(_vpairs_2[_pair]));
+        }
+    }
+    {
+        float4 _v4 = *reinterpret_cast<const float4*>(q_norm + base + (long long)elem);
+        qn[0 + 0] = _v4.x;
+        qn[0 + 1] = _v4.y;
+        qn[0 + 2] = _v4.z;
+        qn[0 + 3] = _v4.w;
+    }
+    {
+        float4 _v4 = *reinterpret_cast<const float4*>(k_norm + base + (long long)elem);
+        kn[0 + 0] = _v4.x;
+        kn[0 + 1] = _v4.y;
+        kn[0 + 2] = _v4.z;
+        kn[0 + 3] = _v4.w;
+    }
+    {
+        float4 _v4 = *reinterpret_cast<const float4*>(dq_normalized + base + (long long)elem);
+        dqn[0 + 0] = _v4.x;
+        dqn[0 + 1] = _v4.y;
+        dqn[0 + 2] = _v4.z;
+        dqn[0 + 3] = _v4.w;
+    }
+    {
+        float4 _v4 = *reinterpret_cast<const float4*>(dk_normalized + base + (long long)elem);
+        dkn[0 + 0] = _v4.x;
+        dkn[0 + 1] = _v4.y;
+        dkn[0 + 2] = _v4.z;
+        dkn[0 + 3] = _v4.w;
+    }
+    {
+        float4 _v4 = *reinterpret_cast<const float4*>(gate_common + base + (long long)elem);
+        dlog[0 + 0] = _v4.x;
+        dlog[0 + 1] = _v4.y;
+        dlog[0 + 2] = _v4.z;
+        dlog[0 + 3] = _v4.w;
+    }
+    float q_sq = 0.0f;
+    float k_sq = 0.0f;
+    float q_dot = 0.0f;
+    float k_dot = 0.0f;
+    #pragma unroll
+    for (int i = 0; i < 4; i++) {
+        float _fma_0 = __fmaf_rn(q_raw[i], q_raw[i], q_sq);
+        q_sq = _fma_0;
+        float _fma_1 = __fmaf_rn(k_raw[i], k_raw[i], k_sq);
+        k_sq = _fma_1;
+        float _fma_2 = __fmaf_rn(dqn[i], qn[i], q_dot);
+        q_dot = _fma_2;
+        float _fma_3 = __fmaf_rn(dkn[i], kn[i], k_dot);
+        k_dot = _fma_3;
+    }
+    float _warp_reduce_0 = q_sq;
+    #pragma unroll
+    for (int offset = 16; offset > 0; offset >>= 1)
+        _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
+    q_sq = _warp_reduce_0;
+    float _warp_reduce_1 = k_sq;
+    #pragma unroll
+    for (int offset = 16; offset > 0; offset >>= 1)
+        _warp_reduce_1 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_1, offset);
+    k_sq = _warp_reduce_1;
+    float _warp_reduce_2 = q_dot;
+    #pragma unroll
+    for (int offset = 16; offset > 0; offset >>= 1)
+        _warp_reduce_2 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_2, offset);
+    q_dot = _warp_reduce_2;
+    float _warp_reduce_3 = k_dot;
+    #pragma unroll
+    for (int offset = 16; offset > 0; offset >>= 1)
+        _warp_reduce_3 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_3, offset);
+    k_dot = _warp_reduce_3;
+    float _rsqrt_0 = rsqrtf(q_sq + 1e-06f);
+    float q_inv = _rsqrt_0;
+    float _rsqrt_1 = rsqrtf(k_sq + 1e-06f);
+    float k_inv = _rsqrt_1;
+    float _expf_0 = __expf(A_log[head]);
+    float gate_a = _expf_0;
+    #pragma unroll
+    for (int i2 = 0; i2 < 4; i2++) {
+        int dim = elem + i2;
+        long long index = base + (long long)dim;
+        float biased = g_raw[i2] + dt_bias[head * D + dim];
+        float _expf_1 = __expf((-gate_a) * biased);
+        float _rcp_0 = approx_rcp(1.0f + _expf_1);
+        float gate_sigmoid = _rcp_0;
+        float common = dlog[i2] * lower_bound * gate_sigmoid * (1.0f - gate_sigmoid) * gate_a;
+        __nv_bfloat16 _cvt_bf16_0 = __float2bfloat16(q_inv * (dqn[i2] - qn[i2] * q_dot));
+        dq[index] = _cvt_bf16_0;
+        __nv_bfloat16 _cvt_bf16_1 = __float2bfloat16(k_inv * (dkn[i2] - kn[i2] * k_dot));
+        dk[index] = _cvt_bf16_1;
+        __nv_bfloat16 _cvt_bf16_2 = __float2bfloat16(common);
+        dg[index] = _cvt_bf16_2;
+        gate_common[index] = common;
+    }
+    if (lane == 0) {
+        long long beta_index = (long long)token * (long long)num_heads + (long long)head;
+        float beta_sigmoid = beta_active[beta_index];
+        __nv_bfloat16 _cvt_bf16_3 = __float2bfloat16(dbeta_active[beta_index] * beta_sigmoid * (1.0f - beta_sigmoid));
+        dbeta[beta_index] = _cvt_bf16_3;
+    }
+}
+
+} // extern "C"
+
+#undef D
+#undef LOOM_INF
+#undef NUM_MAIN_STAGES
+#undef THREADS
+
+#define LOOM_INF CUDART_INF_F
+#define NUM_MAIN_STAGES 1
+#define SMEM_SMEM_DA_OFF 0
+#define SMEM_SMEM_DA_STAGE_BYTES 16
+#define SMEM_SMEM_DA_STRIDE 16
+#define SMEM_TOTAL 128
+#define THREADS 128
+#define D 128
+
+extern "C" {
+
+__global__ __launch_bounds__(128) void
+kernel_flashkda_backward_gate_reduce_split(float* __restrict__ gate_common, __nv_bfloat16* __restrict__ g, float* __restrict__ dt_bias, float* __restrict__ dA_log, float* __restrict__ ddt_bias, int total_tokens, int num_heads, int tokens_per_split)
+{
+    const int tid = threadIdx.x;
+    const int warp = make_warp_uniform(tid / 32);
+    const int lane = tid % 32;
+
+    extern __shared__ __align__(1024) char smem_raw[];
+    int smem;
+    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+
+    const int bid = blockIdx.x;
+    const int num_bids = gridDim.x;
+
+    // Kernel setup ops
+    float* smem_dA = reinterpret_cast<float*>(smem_raw + 0);
+    const int smem_dA_addr = smem + 0;
+
+    // === Task calls (dependency order) ===
+    int head = blockIdx.x;
+    int split = blockIdx.y;
+    int dim = tid;
+    int token_start = split * tokens_per_split;
+    int token_end = token_start + tokens_per_split;
+    if (token_end > total_tokens) {
+        token_end = total_tokens;
+    }
+    float bias = dt_bias[head * D + dim];
+    float ddt_sum = 0.0f;
+    float dA_sum = 0.0f;
+    #pragma unroll 4
+    for (int token = token_start; token < token_end; token++) {
+        long long index = ((long long)token * (long long)num_heads + (long long)head) * (long long)D + (long long)dim;
+        float common = gate_common[index];
+        ddt_sum += common;
+        float _fma_0 = __fmaf_rn(common, (float)g[index] + bias, dA_sum);
+        dA_sum = _fma_0;
+    }
+    atomicAdd(&ddt_bias[head * D + dim], ddt_sum);
+    float _warp_reduce_0 = dA_sum;
+    #pragma unroll
+    for (int offset = 16; offset > 0; offset >>= 1)
+        _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
+    dA_sum = _warp_reduce_0;
+    if (lane == 0) {
+        smem_dA[warp] = dA_sum;
+    }
+    __syncthreads();
+    if (warp == 0) {
+        if (elect_sync()) {
+            atomicAdd(&dA_log[head], smem_dA[0] + smem_dA[1] + smem_dA[2] + smem_dA[3]);
+        }
+    }
+}
+
+} // extern "C"
+
+#undef D
+#undef LOOM_INF
+#undef NUM_MAIN_STAGES
+#undef SMEM_SMEM_DA_OFF
+#undef SMEM_SMEM_DA_STAGE_BYTES
+#undef SMEM_SMEM_DA_STRIDE
+#undef SMEM_TOTAL
+#undef THREADS
+#undef smem_dA_addr
+
+#define LOOM_INF CUDART_INF_F
+#define TMEM_NCOLS 256
+#define TMEM_TMEM_STATE_OFFSET 64
+#define TMEM_TMEM_STATE_INP_OFFSET 0
+#define TMEM_TMEM_U_ACC_OFFSET 224
+#define TMEM_TMEM_U2_INP_OFFSET 224
+#define TMEM_TMEM_U2_ACC_OFFSET 0
+#define TMEM_TMEM_OUT_OFFSET 192
+#define TMEM_TMEM_STATE_OUT_OFFSET 64
+#define NUM_CHUNK_PIPE_STAGES 5
+#define NUM_CHECKPOINT_PIPE_STAGES 2
+#define SMEM_SMEM_QD_OFF 1024
+#define SMEM_SMEM_QD_STAGE_BYTES 8192
+#define SMEM_SMEM_QD_STRIDE 41984
+#define SMEM_SMEM_G_RAW_OFF 1024
+#define SMEM_SMEM_G_RAW_STAGE_BYTES 8192
+#define SMEM_SMEM_G_RAW_STRIDE 41984
+#define SMEM_SMEM_G_RAW_ALL_OFF 1024
+#define SMEM_SMEM_G_RAW_ALL_STAGE_BYTES 176128
+#define SMEM_SMEM_G_RAW_ALL_STRIDE 176128
+#define SMEM_SMEM_KD_OFF 9216
+#define SMEM_SMEM_KD_STAGE_BYTES 8192
+#define SMEM_SMEM_KD_STRIDE 41984
+#define SMEM_SMEM_Q_RAW_PREFETCH_OFF 17408
+#define SMEM_SMEM_Q_RAW_PREFETCH_STAGE_BYTES 8192
+#define SMEM_SMEM_Q_RAW_PREFETCH_STRIDE 41984
+#define SMEM_SMEM_FINAL_TRANS_OFF 17408
+#define SMEM_SMEM_FINAL_TRANS_STAGE_BYTES 12288
+#define SMEM_SMEM_FINAL_TRANS_STRIDE 41984
+#define SMEM_SMEM_KR_TRANS_OFF 17408
+#define SMEM_SMEM_KR_TRANS_STAGE_BYTES 8192
+#define SMEM_SMEM_KR_TRANS_STRIDE 41984
+#define SMEM_SMEM_MQK_TRANS_OFF 25600
+#define SMEM_SMEM_MQK_TRANS_STAGE_BYTES 2048
+#define SMEM_SMEM_MQK_TRANS_STRIDE 41984
+#define SMEM_SMEM_INV_OFF 29696
+#define SMEM_SMEM_INV_STAGE_BYTES 2048
+#define SMEM_SMEM_INV_STRIDE 41984
+#define SMEM_SMEM_V_OFF 32384
+#define SMEM_SMEM_V_STAGE_BYTES 8192
+#define SMEM_SMEM_V_STRIDE 41984
+#define SMEM_SMEM_SHORT_N32_V_OFF 168960
+#define SMEM_SMEM_SHORT_N32_V_STAGE_BYTES 32768
+#define SMEM_SMEM_SHORT_N32_V_STRIDE 32768
+#define SMEM_SMEM_KI_OFF 17408
+#define SMEM_SMEM_KI_STAGE_BYTES 8192
+#define SMEM_SMEM_KI_STRIDE 41984
+#define SMEM_SMEM_GATE_OFF 25600
+#define SMEM_SMEM_GATE_STAGE_BYTES 16384
+#define SMEM_SMEM_GATE_STRIDE 41984
+#define SMEM_SMEM_BETA_RAW_OFF 41984
+#define SMEM_SMEM_BETA_RAW_STAGE_BYTES 512
+#define SMEM_SMEM_BETA_RAW_STRIDE 41984
+#define SMEM_SMEM_BETA_RAW_ALL_OFF 41984
+#define SMEM_SMEM_BETA_RAW_ALL_STAGE_BYTES 168448
+#define SMEM_SMEM_BETA_RAW_ALL_STRIDE 168448
+#define SMEM_SMEM_INV_WORK_OFF 32384
+#define SMEM_SMEM_INV_WORK_STAGE_BYTES 4096
+#define SMEM_SMEM_INV_WORK_STRIDE 41984
+#define SMEM_SMEM_OUT_OFF 210944
+#define SMEM_SMEM_OUT_STAGE_BYTES 8192
+#define SMEM_SMEM_OUT_STRIDE 8192
+#define SMEM_SMEM_CHECKPOINT_OFF 228352
+#define SMEM_SMEM_CHECKPOINT_STAGE_BYTES 32768
+#define SMEM_SMEM_CHECKPOINT_STRIDE 32768
+#define SMEM_SMEM_RESTORE_FACTOR_ALL_OFF 41984
+#define SMEM_SMEM_RESTORE_FACTOR_ALL_STAGE_BYTES 168452
+#define SMEM_SMEM_RESTORE_FACTOR_ALL_STRIDE 168452
+#define SMEM_SMEM_GT_PREFIX_ALL_OFF 41472
+#define SMEM_SMEM_GT_PREFIX_ALL_STAGE_BYTES 168448
+#define SMEM_SMEM_GT_PREFIX_ALL_STRIDE 168448
+#define SMEM_SMEM_GT_ALL_OFF 31744
+#define SMEM_SMEM_GT_ALL_STAGE_BYTES 168448
+#define SMEM_SMEM_GT_ALL_STRIDE 168448
+#define SMEM_SMEM_PREP_BETA_ALL_OFF 42500
+#define SMEM_SMEM_PREP_BETA_ALL_STAGE_BYTES 168064
+#define SMEM_SMEM_PREP_BETA_ALL_STRIDE 168064
+#define SMEM_SMEM_PREP_BETA_BF16_ALL_OFF 42500
+#define SMEM_SMEM_PREP_BETA_BF16_ALL_STAGE_BYTES 168000
+#define SMEM_SMEM_PREP_BETA_BF16_ALL_STRIDE 168000
+#define SMEM_SMEM_PREP_BETA_U32_ALL_OFF 42500
+#define SMEM_SMEM_PREP_BETA_U32_ALL_STAGE_BYTES 168000
+#define SMEM_SMEM_PREP_BETA_U32_ALL_STRIDE 168000
+#define SMEM_SMEM_GATE_RATE_ALL_OFF 42628
+#define SMEM_SMEM_GATE_RATE_ALL_STAGE_BYTES 167940
+#define SMEM_SMEM_GATE_RATE_ALL_STRIDE 167940
+#define SMEM_SMEM_GATE_BIAS_ALL_OFF 227408
+#define SMEM_SMEM_GATE_BIAS_ALL_STAGE_BYTES 512
+#define SMEM_SMEM_GATE_BIAS_ALL_STRIDE 512
+#define SMEM_SMEM_V_ALL_OFF 32384
+#define SMEM_SMEM_V_ALL_STAGE_BYTES 176128
+#define SMEM_SMEM_V_ALL_STRIDE 176128
+#define SMEM_SMEM_GATE_ALL_OFF 25600
+#define SMEM_SMEM_GATE_ALL_STAGE_BYTES 184320
+#define SMEM_SMEM_GATE_ALL_STRIDE 184320
+#define SMEM_SMEM_STATE_CHECKPOINT_NEEDED_OFF 227328
+#define SMEM_SMEM_STATE_CHECKPOINT_NEEDED_STAGE_BYTES 80
+#define SMEM_SMEM_STATE_CHECKPOINT_NEEDED_STRIDE 80
+#define SMEM_SMEM_WORK_ITEM_WARP_MAX_OFF 227328
+#define SMEM_SMEM_WORK_ITEM_WARP_MAX_STAGE_BYTES 16
+#define SMEM_SMEM_WORK_ITEM_WARP_MAX_STRIDE 16
+#define SMEM_SMEM_WORK_ITEM_COMPUTE_START_OFF 227344
+#define SMEM_SMEM_WORK_ITEM_COMPUTE_START_STAGE_BYTES 4
+#define SMEM_SMEM_WORK_ITEM_COMPUTE_START_STRIDE 4
+#define SMEM_SMEM_WORK_ITEM_RESOLVED_OFF 227348
+#define SMEM_SMEM_WORK_ITEM_RESOLVED_STAGE_BYTES 4
+#define SMEM_SMEM_WORK_ITEM_RESOLVED_STRIDE 4
+#define SMEM_TOTAL 227968
+#define STORE_BACKWARD_TAPE 1
+#define STORE_E_TAPE 0
+#define SPLIT_WORK_ITEMS 0
+
+extern "C" {
+
+__global__ __launch_bounds__(1024) void
+kernel_flashkda_bf16_fused_m128_unsplit(__nv_bfloat16* __restrict__ q, LoomTensorMap const* q_tma, __nv_bfloat16* __restrict__ k, LoomTensorMap const* k_tma, __nv_bfloat16* __restrict__ v, LoomTensorMap const* v_tma, __nv_bfloat16* __restrict__ g, LoomTensorMap const* g_tma, __nv_bfloat16* __restrict__ beta, LoomTensorMap const* beta_tma, float* __restrict__ A_log, float* __restrict__ dt_bias, long long* __restrict__ cu_seqlens, int* __restrict__ seq_order, __nv_bfloat16* __restrict__ initial_state, __nv_bfloat16* __restrict__ out, LoomTensorMap const* out_tma, __nv_bfloat16* __restrict__ final_state, int num_heads, int use_initial_state, int store_final_state, float scale, float lower_bound, unsigned long long state_indices_addr, unsigned long long state_checkpoints_addr, unsigned long long checkpoint_cu_starts_addr, long long beta_token_stride, long long state_slot_stride, int use_state_indices, int checkpoint_every_n_tokens, long long* __restrict__ cu_chunk_offsets, __nv_bfloat16* __restrict__ chunk_state, unsigned int* __restrict__ state_checkpoint_needed, __nv_bfloat16* __restrict__ tape_qd, __nv_bfloat16* __restrict__ tape_kd, __nv_bfloat16* __restrict__ tape_kr, __nv_bfloat16* __restrict__ tape_j, float* __restrict__ tape_restore_factor, __nv_bfloat16* __restrict__ tape_e, __nv_bfloat16* __restrict__ tape_x, __nv_bfloat16* __restrict__ tape_r, float* __restrict__ norm_inv_out, __nv_bfloat16* __restrict__ decay_out, float* __restrict__ beta_active_out, float* __restrict__ initial_state_f32, unsigned int* __restrict__ zero_workspace, int zero_words, int num_sequences, LoomTensorMap const* state_checkpoints_tma)
+{
+    const int tid = threadIdx.x;
+    const int warp = make_warp_uniform(tid / 32);
+    const int lane = tid % 32;
+
+    extern __shared__ __align__(1024) char smem_raw[];
+    int smem;
+    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+
+    const int bid = blockIdx.x;
+    const int num_bids = gridDim.x;
+    if (warp == 8 && lane == 0) {
+        asm volatile("fence.proxy.tensormap::generic.acquire.sys [%0], 128;" :: "l"((uint64_t)(q_tma)) : "memory");
+        asm volatile("fence.proxy.tensormap::generic.acquire.sys [%0], 128;" :: "l"((uint64_t)(k_tma)) : "memory");
+        asm volatile("fence.proxy.tensormap::generic.acquire.sys [%0], 128;" :: "l"((uint64_t)(v_tma)) : "memory");
+        asm volatile("fence.proxy.tensormap::generic.acquire.sys [%0], 128;" :: "l"((uint64_t)(g_tma)) : "memory");
+        asm volatile("fence.proxy.tensormap::generic.acquire.sys [%0], 128;" :: "l"((uint64_t)(beta_tma)) : "memory");
+        asm volatile("fence.proxy.tensormap::generic.acquire.sys [%0], 128;" :: "l"((uint64_t)(out_tma)) : "memory");
+        asm volatile("fence.proxy.tensormap::generic.acquire.sys [%0], 128;" :: "l"((uint64_t)(state_checkpoints_tma)) : "memory");
+    }
+
+
+    // Kernel setup ops
+    __nv_bfloat16* smem_qd = reinterpret_cast<__nv_bfloat16*>(smem_raw + 1024);
+    const int smem_qd_addr = smem + 1024;
+    __nv_bfloat16* smem_g_raw = reinterpret_cast<__nv_bfloat16*>(smem_raw + 1024);
+    const int smem_g_raw_addr = smem + 1024;
+    __nv_bfloat16* smem_g_raw_all = reinterpret_cast<__nv_bfloat16*>(smem_raw + 1024);
+    const int smem_g_raw_all_addr = smem + 1024;
+    __nv_bfloat16* smem_kd = reinterpret_cast<__nv_bfloat16*>(smem_raw + 9216);
+    const int smem_kd_addr = smem + 9216;
+    __nv_bfloat16* smem_q_raw_prefetch = reinterpret_cast<__nv_bfloat16*>(smem_raw + 17408);
+    const int smem_q_raw_prefetch_addr = smem + 17408;
+    __nv_bfloat16* smem_final_trans = reinterpret_cast<__nv_bfloat16*>(smem_raw + 17408);
+    const int smem_final_trans_addr = smem + 17408;
+    __nv_bfloat16* smem_kr_trans = reinterpret_cast<__nv_bfloat16*>(smem_raw + 17408);
+    const int smem_kr_trans_addr = smem + 17408;
+    __nv_bfloat16* smem_mqk_trans = reinterpret_cast<__nv_bfloat16*>(smem_raw + 25600);
+    const int smem_mqk_trans_addr = smem + 25600;
+    __nv_bfloat16* smem_inv = reinterpret_cast<__nv_bfloat16*>(smem_raw + 29696);
+    const int smem_inv_addr = smem + 29696;
+    __nv_bfloat16* smem_v = reinterpret_cast<__nv_bfloat16*>(smem_raw + 32384);
+    const int smem_v_addr = smem + 32384;
+    __nv_bfloat16* smem_short_n32_v = reinterpret_cast<__nv_bfloat16*>(smem_raw + 168960);
+    const int smem_short_n32_v_addr = smem + 168960;
+    __nv_bfloat16* smem_ki = reinterpret_cast<__nv_bfloat16*>(smem_raw + 17408);
+    const int smem_ki_addr = smem + 17408;
+    float* smem_gate = reinterpret_cast<float*>(smem_raw + 25600);
+    const int smem_gate_addr = smem + 25600;
+    __nv_bfloat16* smem_beta_raw = reinterpret_cast<__nv_bfloat16*>(smem_raw + 41984);
+    const int smem_beta_raw_addr = smem + 41984;
+    __nv_bfloat16* smem_beta_raw_all = reinterpret_cast<__nv_bfloat16*>(smem_raw + 41984);
+    const int smem_beta_raw_all_addr = smem + 41984;
+    __nv_bfloat16* smem_inv_work = reinterpret_cast<__nv_bfloat16*>(smem_raw + 32384);
+    const int smem_inv_work_addr = smem + 32384;
+    __nv_bfloat16* smem_out = reinterpret_cast<__nv_bfloat16*>(smem_raw + 210944);
+    const int smem_out_addr = smem + 210944;
+    __nv_bfloat16* smem_checkpoint = reinterpret_cast<__nv_bfloat16*>(smem_raw + 228352);
+    const int smem_checkpoint_addr = smem + 228352;
+    float* smem_restore_factor_all = reinterpret_cast<float*>(smem_raw + 41984);
+    const int smem_restore_factor_all_addr = smem + 41984;
+    float* smem_gt_prefix_all = reinterpret_cast<float*>(smem_raw + 41472);
+    const int smem_gt_prefix_all_addr = smem + 41472;
+    float* smem_gt_all = reinterpret_cast<float*>(smem_raw + 31744);
+    const int smem_gt_all_addr = smem + 31744;
+    float* smem_prep_beta_all = reinterpret_cast<float*>(smem_raw + 42500);
+    const int smem_prep_beta_all_addr = smem + 42500;
+    __nv_bfloat16* smem_prep_beta_bf16_all = reinterpret_cast<__nv_bfloat16*>(smem_raw + 42500);
+    const int smem_prep_beta_bf16_all_addr = smem + 42500;
+    unsigned int* smem_prep_beta_u32_all = reinterpret_cast<unsigned int*>(smem_raw + 42500);
+    const int smem_prep_beta_u32_all_addr = smem + 42500;
+    float* smem_gate_rate_all = reinterpret_cast<float*>(smem_raw + 42628);
+    const int smem_gate_rate_all_addr = smem + 42628;
+    float* smem_gate_bias_all = reinterpret_cast<float*>(smem_raw + 227408);
+    const int smem_gate_bias_all_addr = smem + 227408;
+    __nv_bfloat16* smem_v_all = reinterpret_cast<__nv_bfloat16*>(smem_raw + 32384);
+    const int smem_v_all_addr = smem + 32384;
+    float* smem_gate_all = reinterpret_cast<float*>(smem_raw + 25600);
+    const int smem_gate_all_addr = smem + 25600;
+    unsigned int* smem_state_checkpoint_needed = reinterpret_cast<unsigned int*>(smem_raw + 227328);
+    const int smem_state_checkpoint_needed_addr = smem + 227328;
+    float* smem_work_item_warp_max = reinterpret_cast<float*>(smem_raw + 227328);
+    const int smem_work_item_warp_max_addr = smem + 227328;
+    int* smem_work_item_compute_start = reinterpret_cast<int*>(smem_raw + 227344);
+    const int smem_work_item_compute_start_addr = smem + 227344;
+    unsigned int* smem_work_item_resolved = reinterpret_cast<unsigned int*>(smem_raw + 227348);
+    const int smem_work_item_resolved_addr = smem + 227348;
+
+    // Mbarrier init (23 groups, 97 barriers)
+    // Mbarriers at smem_raw[0..776)
+
+    if (warp == 10) {
+        // --- pipeline 'chunk_pipe' ---
+        // qk_full: 5 barriers, init_count=1
+        // tape_ready: 5 barriers, init_count=1
+        // tape_free: 5 barriers, init_count=2
+        // gate_raw_full: 5 barriers, init_count=1
+        // qk_raw_full: 5 barriers, init_count=1
+        // v_full: 5 barriers, init_count=1
+        // v_free: 5 barriers, init_count=4
+        // smem_free: 5 barriers, init_count=1
+        // raw_inputs_free: 5 barriers, init_count=1
+        // state_inp_ready: 5 barriers, init_count=4
+        // old_out_ready: 5 barriers, init_count=1
+        // u_inp_ready: 5 barriers, init_count=4
+        // u2_acc_ready: 5 barriers, init_count=1
+        // u2_inp_ready: 5 barriers, init_count=4
+        // final_ready: 5 barriers, init_count=1
+        // out_empty: 1 barriers, init_count=1
+        // tmem_dealloc_ready: 1 barriers, init_count=2
+        // --- pipeline 'checkpoint_pipe' ---
+        // checkpoint_ready: 2 barriers, init_count=4
+        // checkpoint_free: 2 barriers, init_count=1
+        // --- pipeline 'chunk_pipe' ---
+        // prep_diag_ready: 5 barriers, init_count=2
+        // prep_inv16_ready: 5 barriers, init_count=2
+        // work_item_ready: 1 barriers, init_count=1
+        // short_beta_ready: 5 barriers, init_count=1
+        // Warp-cooperative initialization, grouped by equal arrival count.
+        for (int _bar = lane; _bar < 10; _bar += 32) {
+            mbarrier_init(smem + 0 + _bar * 8, 1);
+        }
+        for (int _bar = lane; _bar < 5; _bar += 32) {
+            mbarrier_init(smem + 80 + _bar * 8, 2);
+        }
+        for (int _bar = lane; _bar < 15; _bar += 32) {
+            mbarrier_init(smem + 120 + _bar * 8, 1);
+        }
+        for (int _bar = lane; _bar < 5; _bar += 32) {
+            mbarrier_init(smem + 240 + _bar * 8, 4);
+        }
+        for (int _bar = lane; _bar < 10; _bar += 32) {
+            mbarrier_init(smem + 280 + _bar * 8, 1);
+        }
+        for (int _bar = lane; _bar < 5; _bar += 32) {
+            mbarrier_init(smem + 360 + _bar * 8, 4);
+        }
+        for (int _bar = lane; _bar < 5; _bar += 32) {
+            mbarrier_init(smem + 400 + _bar * 8, 1);
+        }
+        for (int _bar = lane; _bar < 5; _bar += 32) {
+            mbarrier_init(smem + 440 + _bar * 8, 4);
+        }
+        for (int _bar = lane; _bar < 5; _bar += 32) {
+            mbarrier_init(smem + 480 + _bar * 8, 1);
+        }
+        for (int _bar = lane; _bar < 5; _bar += 32) {
+            mbarrier_init(smem + 520 + _bar * 8, 4);
+        }
+        for (int _bar = lane; _bar < 6; _bar += 32) {
+            mbarrier_init(smem + 560 + _bar * 8, 1);
+        }
+        for (int _bar = lane; _bar < 1; _bar += 32) {
+            mbarrier_init(smem + 608 + _bar * 8, 2);
+        }
+        for (int _bar = lane; _bar < 2; _bar += 32) {
+            mbarrier_init(smem + 616 + _bar * 8, 4);
+        }
+        for (int _bar = lane; _bar < 2; _bar += 32) {
+            mbarrier_init(smem + 632 + _bar * 8, 1);
+        }
+        for (int _bar = lane; _bar < 10; _bar += 32) {
+            mbarrier_init(smem + 648 + _bar * 8, 2);
+        }
+        for (int _bar = lane; _bar < 6; _bar += 32) {
+            mbarrier_init(smem + 728 + _bar * 8, 1);
+        }
+        asm volatile("fence.mbarrier_init.release.cluster;");
+    }
+
+    __syncwarp();
+
+    // TMEM alloc (256 columns, 256 used)
+    volatile int* tmem_addr_storage = (volatile int*)(smem_raw + 776);
+    if (warp == 0) {
+        int _tmem_hold = smem + 776;
+        asm volatile("tcgen05.alloc.cta_group::1.sync.aligned.shared::cta.b32 [%0], %1;" :: "r"(_tmem_hold), "r"(256) : "memory");
+        asm volatile("tcgen05.relinquish_alloc_permit.cta_group::1.sync.aligned;");
+    }
+
+    __syncthreads();
+    asm volatile("tcgen05.fence::after_thread_sync;");
+
+    const int mbar_base = smem;
+    #define qk_full_addr (mbar_base + 0)
+    #define tape_ready_addr (mbar_base + 40)
+    #define tape_free_addr (mbar_base + 80)
+    #define gate_raw_full_addr (mbar_base + 120)
+    #define qk_raw_full_addr (mbar_base + 160)
+    #define v_full_addr (mbar_base + 200)
+    #define v_free_addr (mbar_base + 240)
+    #define smem_free_addr (mbar_base + 280)
+    #define raw_inputs_free_addr (mbar_base + 320)
+    #define state_inp_ready_addr (mbar_base + 360)
+    #define old_out_ready_addr (mbar_base + 400)
+    #define u_inp_ready_addr (mbar_base + 440)
+    #define u2_acc_ready_addr (mbar_base + 480)
+    #define u2_inp_ready_addr (mbar_base + 520)
+    #define final_ready_addr (mbar_base + 560)
+    #define out_empty_addr (mbar_base + 600)
+    #define tmem_dealloc_ready_addr (mbar_base + 608)
+    #define checkpoint_ready_addr (mbar_base + 616)
+    #define checkpoint_free_addr (mbar_base + 632)
+    #define prep_diag_ready_addr (mbar_base + 648)
+    #define prep_inv16_ready_addr (mbar_base + 688)
+    #define work_item_ready_addr (mbar_base + 728)
+    #define short_beta_ready_addr (mbar_base + 736)
+    const int taddr = tmem_addr_storage[0];
+
+    // Kernel post-init ops
+    const int tmem_tmem_state = taddr + 64;
+    const int tmem_tmem_state_inp = taddr;
+    const int tmem_tmem_u_acc = taddr + 224;
+    const int tmem_tmem_u2_inp = taddr + 224;
+    const int tmem_tmem_u2_acc = taddr;
+    const int tmem_tmem_out = taddr + 192;
+    const int tmem_tmem_state_out = taddr + 64;
+
+    // ---- Register redistribution for WGs split across roles ----
+    // Dec phase frees registers before any WG attempts inc.
+    if (warp >= 8 && warp <= 11) {
+        asm volatile("setmaxnreg.dec.sync.aligned.u32 48;");
+    }
+
+    // ---- Role: compute ----
+    if (warp <= 3) {
+        asm volatile("setmaxnreg.inc.sync.aligned.u32 168;");
+        { // compute_main
+            int task_idx = blockIdx.x;
+            int warp_id_in_role = (warp - 0);
+            int compute_local_warp = warp_id_in_role;
+            int warp_in_wg = warp % 4;
+            int state_row = warp_in_wg * 32 + lane;
+            int split_compute_start = 0;
+            int seq_idx = seq_order[task_idx / num_heads];
+            int head_idx = task_idx % num_heads;
+            long long bos = cu_seqlens[seq_idx];
+            long long eos = cu_seqlens[seq_idx + 1];
+            int num_chunks = ((int)(eos - bos) + 32 - 1) / 32;
+            int seq_len = (int)(eos - bos);
+            int num_chunks_0 = (seq_len + 32 - 1) / 32;
+            long long total_chunks = cu_chunk_offsets[num_sequences];
+            long long fallback_head = total_chunks * (long long)num_heads + (long long)seq_idx * (long long)num_heads + (long long)head_idx;
+            const int tmem_row_base = warp_in_wg * 32 << 16;
+            long long state_base = (((long long)seq_idx * (long long)num_heads + (long long)head_idx) * 128 + (long long)state_row) * 128;
+            #pragma unroll
+            for (int state_col_block = 0; state_col_block < 4; state_col_block++) {
+                float state_frag[32];
+                state_frag[0] = 0.0f;
+                state_frag[1] = 0.0f;
+                state_frag[2] = 0.0f;
+                state_frag[3] = 0.0f;
+                state_frag[4] = 0.0f;
+                state_frag[5] = 0.0f;
+                state_frag[6] = 0.0f;
+                state_frag[7] = 0.0f;
+                state_frag[8] = 0.0f;
+                state_frag[9] = 0.0f;
+                state_frag[10] = 0.0f;
+                state_frag[11] = 0.0f;
+                state_frag[12] = 0.0f;
+                state_frag[13] = 0.0f;
+                state_frag[14] = 0.0f;
+                state_frag[15] = 0.0f;
+                state_frag[16] = 0.0f;
+                state_frag[17] = 0.0f;
+                state_frag[18] = 0.0f;
+                state_frag[19] = 0.0f;
+                state_frag[20] = 0.0f;
+                state_frag[21] = 0.0f;
+                state_frag[22] = 0.0f;
+                state_frag[23] = 0.0f;
+                state_frag[24] = 0.0f;
+                state_frag[25] = 0.0f;
+                state_frag[26] = 0.0f;
+                state_frag[27] = 0.0f;
+                state_frag[28] = 0.0f;
+                state_frag[29] = 0.0f;
+                state_frag[30] = 0.0f;
+                state_frag[31] = 0.0f;
+                if (use_initial_state != 0) {
+                    {
+                        float initial_values[8];
+                        #pragma unroll
+                        for (int initial_quarter = 0; initial_quarter < 4; initial_quarter++) {
+                            {
+                                unsigned _ldv8_0_0;
+                                unsigned _ldv8_0_1;
+                                unsigned _ldv8_0_2;
+                                unsigned _ldv8_0_3;
+                                unsigned _ldv8_0_4;
+                                unsigned _ldv8_0_5;
+                                unsigned _ldv8_0_6;
+                                unsigned _ldv8_0_7;
+                                asm volatile(
+                                    "ld.global.v8.b32 {%0, %1, %2, %3, %4, %5, %6, %7}, [%8];"
+                                    : "=r"(_ldv8_0_0), "=r"(_ldv8_0_1), "=r"(_ldv8_0_2), "=r"(_ldv8_0_3), "=r"(_ldv8_0_4), "=r"(_ldv8_0_5), "=r"(_ldv8_0_6), "=r"(_ldv8_0_7) : "l"((const void*)(initial_state_f32 + (state_base + (long long)(state_col_block * 32) + (long long)(initial_quarter * 8)))) : "memory");
+                                initial_values[0 + 0] = __uint_as_float(_ldv8_0_0);
+                                initial_values[0 + 1] = __uint_as_float(_ldv8_0_1);
+                                initial_values[0 + 2] = __uint_as_float(_ldv8_0_2);
+                                initial_values[0 + 3] = __uint_as_float(_ldv8_0_3);
+                                initial_values[0 + 4] = __uint_as_float(_ldv8_0_4);
+                                initial_values[0 + 5] = __uint_as_float(_ldv8_0_5);
+                                initial_values[0 + 6] = __uint_as_float(_ldv8_0_6);
+                                initial_values[0 + 7] = __uint_as_float(_ldv8_0_7);
+                            }
+                            #pragma unroll
+                            for (int initial_item = 0; initial_item < 8; initial_item++) {
+                                __nv_bfloat16 _cvt_bf16_9 = __float2bfloat16(initial_values[initial_item]);
+                                float _cvt_f32_19 = __bfloat162float(_cvt_bf16_9);
+                                state_frag[initial_quarter * 8 + initial_item] = _cvt_f32_19;
+                            }
+                        }
+                    }
+                }
+                tmem_st_x32_f32(taddr + 64 + (unsigned int)tmem_row_base + (unsigned int)(state_col_block * 32), state_frag);
+            }
+            asm volatile("tcgen05.wait::st.sync.aligned;" ::: "memory");
+            {
+                if (compute_local_warp == 0) {
+                    if (elect_sync()) {
+                        long long first_chunk_head = cu_chunk_offsets[seq_idx] * (long long)num_heads + (long long)head_idx;
+                        state_checkpoint_needed[first_chunk_head] = 0;
+                        {
+                            state_checkpoint_needed[fallback_head] = 0;
+                        }
+                    }
+                }
+            }
+            unsigned int compute_stage = 0;
+            unsigned int checkpoint_stage_compute = 0;
+            float _exp2_10 = approx_exp2(lower_bound * 1.4426950408889634f * 16.0f);
+            unsigned int _phase_checkpoint_free = 1;
+            unsigned int _phase_qk_full = 0;
+            unsigned int _phase_v_full = 0;
+            unsigned int _phase_old_out_ready = 0;
+            unsigned int _phase_u2_acc_ready = 0;
+            unsigned int _phase_final_ready = 0;
+            #pragma unroll 1
+            for (int chunk_idx = 0; chunk_idx < num_chunks_0; chunk_idx++) {
+                int chunk_global_local = chunk_idx;
+                int owned_chunk = chunk_global_local >= 0 && chunk_global_local < num_chunks;
+                int checkpoint_token_entering = chunk_idx * 32;
+                int checkpoint_entering = checkpoint_every_n_tokens != 0 && checkpoint_token_entering % checkpoint_every_n_tokens == 0;
+                float state_panel0[32];
+                float state_panel1[32];
+                float state_panel2[32];
+                float state_panel3[32];
+                unsigned int state_packed0[16];
+                unsigned int state_packed1[16];
+                unsigned int state_packed2[16];
+                unsigned int state_packed3[16];
+                mbarrier_wait(qk_full_addr + (compute_stage) * 8, _phase_qk_full);
+                #pragma unroll 1
+                for (int state_col_block_1 = 0; state_col_block_1 < ((0) ? 4 : 3); state_col_block_1++) {
+                    int state_addr = taddr + 64 + (unsigned int)tmem_row_base + (unsigned int)(state_col_block_1 * 32);
+                    float _tmem_load_1[32];
+                    tmem_ld_x32(&_tmem_load_1[0], state_addr);
+                    asm volatile("tcgen05.wait::ld.sync.aligned;");
+                    uint32_t _tmem_load_1_bf16[16];
+                    #pragma unroll
+                    for (int _lp = 0; _lp < 16; _lp++) {
+                        __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(_tmem_load_1[_lp*2 + 0], _tmem_load_1[_lp*2+1 + 0]));
+                        _tmem_load_1_bf16[_lp] = *(uint32_t*)&_bf2;
+                    }
+                    asm volatile(
+                        "tcgen05.st.sync.aligned.32x32b.x16.b32"
+                        " [%0], {%1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15, %16};"
+                        :: "r"(taddr + (unsigned int)tmem_row_base + (unsigned int)(state_col_block_1 * 16)), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_1_bf16[0])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_1_bf16[1])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_1_bf16[2])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_1_bf16[3])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_1_bf16[4])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_1_bf16[5])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_1_bf16[6])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_1_bf16[7])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_1_bf16[8])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_1_bf16[9])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_1_bf16[10])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_1_bf16[11])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_1_bf16[12])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_1_bf16[13])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_1_bf16[14])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_1_bf16[15])));
+                    float state_scale[16];
+                    #pragma unroll
+                    for (int state_half = 0; state_half < 2; state_half++) {
+                        #pragma unroll
+                        for (int state_col = 0; state_col < 16; state_col++) {
+                            state_scale[state_col] = smem_gt_all[compute_stage * 10496 + (unsigned int)(state_col_block_1 * 32) + (unsigned int)(state_half * 16) + (unsigned int)state_col];
+                        }
+                        #pragma unroll
+                        for (int _ls = 0; _ls < 8; _ls++)
+                            mul_f32x2_inplace(&reinterpret_cast<float2*>((_tmem_load_1 + state_half * 16))[_ls], reinterpret_cast<const float2*>(state_scale)[_ls]);
+                    }
+                    tmem_st_x32_f32(state_addr, _tmem_load_1);
+                }
+                int state_tail_addr = taddr + 64 + (unsigned int)tmem_row_base + 96;
+                float state_tail_frag[32];
+                unsigned int state_tail_packed[16];
+                {
+                    tmem_ld_x32(&state_tail_frag[0], state_tail_addr);
+                    #pragma unroll
+                    for (int _lp = 0; _lp < 16; _lp++) {
+                        __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(state_tail_frag[_lp*2 + 0], state_tail_frag[_lp*2+1 + 0]));
+                        state_tail_packed[_lp] = *(uint32_t*)&_bf2;
+                    }
+                    asm volatile(
+                        "tcgen05.st.sync.aligned.32x32b.x16.b32"
+                        " [%0], {%1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15, %16};"
+                        :: "r"(taddr + (unsigned int)tmem_row_base + 48), "r"(*reinterpret_cast<const uint32_t*>(&state_tail_packed[0])), "r"(*reinterpret_cast<const uint32_t*>(&state_tail_packed[1])), "r"(*reinterpret_cast<const uint32_t*>(&state_tail_packed[2])), "r"(*reinterpret_cast<const uint32_t*>(&state_tail_packed[3])), "r"(*reinterpret_cast<const uint32_t*>(&state_tail_packed[4])), "r"(*reinterpret_cast<const uint32_t*>(&state_tail_packed[5])), "r"(*reinterpret_cast<const uint32_t*>(&state_tail_packed[6])), "r"(*reinterpret_cast<const uint32_t*>(&state_tail_packed[7])), "r"(*reinterpret_cast<const uint32_t*>(&state_tail_packed[8])), "r"(*reinterpret_cast<const uint32_t*>(&state_tail_packed[9])), "r"(*reinterpret_cast<const uint32_t*>(&state_tail_packed[10])), "r"(*reinterpret_cast<const uint32_t*>(&state_tail_packed[11])), "r"(*reinterpret_cast<const uint32_t*>(&state_tail_packed[12])), "r"(*reinterpret_cast<const uint32_t*>(&state_tail_packed[13])), "r"(*reinterpret_cast<const uint32_t*>(&state_tail_packed[14])), "r"(*reinterpret_cast<const uint32_t*>(&state_tail_packed[15])));
+                }
+                asm volatile("tcgen05.wait::st.sync.aligned;" ::: "memory");
+                if (elect_sync()) {
+                    mbarrier_arrive(state_inp_ready_addr + (compute_stage) * 8);
+                }
+                {
+                    float state_tail_scale[16];
+                    #pragma unroll
+                    for (int state_half_1 = 0; state_half_1 < 2; state_half_1++) {
+                        #pragma unroll
+                        for (int state_col_1 = 0; state_col_1 < 16; state_col_1++) {
+                            state_tail_scale[state_col_1] = smem_gt_all[compute_stage * 10496 + 96 + (unsigned int)(state_half_1 * 16) + (unsigned int)state_col_1];
+                        }
+                        #pragma unroll
+                        for (int _ls = 0; _ls < 8; _ls++)
+                            mul_f32x2_inplace(&reinterpret_cast<float2*>((state_tail_frag + state_half_1 * 16))[_ls], reinterpret_cast<const float2*>(state_tail_scale)[_ls]);
+                    }
+                    tmem_st_x32_f32(state_tail_addr, state_tail_frag);
+                }
+                mbarrier_wait(v_full_addr + (compute_stage) * 8, _phase_v_full);
+                unsigned int v_prefetch_bits[8];
+                mbarrier_wait(old_out_ready_addr + (compute_stage) * 8, _phase_old_out_ready);
+                float _tmem_load_2[32];
+                tmem_ld_x32(&_tmem_load_2[0], taddr + 224 + (unsigned int)tmem_row_base);
+                asm volatile("tcgen05.wait::ld.sync.aligned;");
+                {
+                    const float2 _scale2_1 = {_exp2_10, _exp2_10};
+                    #pragma unroll
+                    for (int _ls = 0; _ls < 16; _ls++)
+                        mul_f32x2_inplace(&reinterpret_cast<float2*>(_tmem_load_2)[_ls], _scale2_1);
+                }
+                long long chunk_global_e = cu_chunk_offsets[seq_idx] + (long long)chunk_global_local;
+                long long tape_ex_base = ((chunk_global_e * (long long)num_heads + (long long)head_idx) * 128 + (long long)state_row) * 32;
+                #pragma unroll
+                for (int residual_half = 0; residual_half < 2; residual_half++) {
+                    float residual_v[16];
+                    float residual_beta[16];
+                    #pragma unroll
+                    for (int residual_col = 0; residual_col < 16; residual_col++) {
+                        int token_col = residual_half * 16 + residual_col;
+                        {
+                            __nv_bfloat16 v_value = smem_v_all[compute_stage * 20992 + (unsigned int)(token_col * 128) + (unsigned int)state_row];
+                            float _cvt_f32_20 = __bfloat162float(v_value);
+                            residual_v[residual_col] = _cvt_f32_20;
+                            residual_beta[residual_col] = smem_prep_beta_all[compute_stage * 10496 + (unsigned int)token_col];
+                        }
+                    }
+                    {
+                        #pragma unroll
+                        for (int _ls = 0; _ls < 8; _ls++)
+                            sub_f32x2_inplace(&reinterpret_cast<float2*>(residual_v)[_ls], reinterpret_cast<const float2*>((_tmem_load_2 + residual_half * 16))[_ls]);
+                    }
+                    if (STORE_BACKWARD_TAPE != 0 && STORE_E_TAPE != 0 && owned_chunk != 0) {
+                        {
+                            __nv_bfloat162 _pk[4];
+                            _pk[0] = __floats2bfloat162_rn(residual_v[0 + 0], residual_v[0 + 1]);
+                            _pk[1] = __floats2bfloat162_rn(residual_v[0 + 2], residual_v[0 + 3]);
+                            _pk[2] = __floats2bfloat162_rn(residual_v[0 + 4], residual_v[0 + 5]);
+                            _pk[3] = __floats2bfloat162_rn(residual_v[0 + 6], residual_v[0 + 7]);
+                            *reinterpret_cast<uint4*>(&((__nv_bfloat16*)(tape_e + (tape_ex_base + (long long)(residual_half * 16))))[0]) = *reinterpret_cast<uint4*>(&_pk[0]);
+                        }
+                        {
+                            __nv_bfloat162 _pk[4];
+                            _pk[0] = __floats2bfloat162_rn(residual_v[8 + 0], residual_v[8 + 1]);
+                            _pk[1] = __floats2bfloat162_rn(residual_v[8 + 2], residual_v[8 + 3]);
+                            _pk[2] = __floats2bfloat162_rn(residual_v[8 + 4], residual_v[8 + 5]);
+                            _pk[3] = __floats2bfloat162_rn(residual_v[8 + 6], residual_v[8 + 7]);
+                            *reinterpret_cast<uint4*>(&((__nv_bfloat16*)(tape_e + (tape_ex_base + (long long)(residual_half * 16) + 8)))[0]) = *reinterpret_cast<uint4*>(&_pk[0]);
+                        }
+                    }
+                    {
+                        #pragma unroll
+                        for (int _ls = 0; _ls < 8; _ls++)
+                            mul_f32x2_inplace(&reinterpret_cast<float2*>(residual_v)[_ls], reinterpret_cast<const float2*>(residual_beta)[_ls]);
+                        if (STORE_BACKWARD_TAPE != 0 && owned_chunk != 0) {
+                            {
+                                __nv_bfloat162 _pk[4];
+                                _pk[0] = __floats2bfloat162_rn(residual_v[0 + 0], residual_v[0 + 1]);
+                                _pk[1] = __floats2bfloat162_rn(residual_v[0 + 2], residual_v[0 + 3]);
+                                _pk[2] = __floats2bfloat162_rn(residual_v[0 + 4], residual_v[0 + 5]);
+                                _pk[3] = __floats2bfloat162_rn(residual_v[0 + 6], residual_v[0 + 7]);
+                                *reinterpret_cast<uint4*>(&((__nv_bfloat16*)(tape_x + (tape_ex_base + (long long)(residual_half * 16))))[0]) = *reinterpret_cast<uint4*>(&_pk[0]);
+                            }
+                            {
+                                __nv_bfloat162 _pk[4];
+                                _pk[0] = __floats2bfloat162_rn(residual_v[8 + 0], residual_v[8 + 1]);
+                                _pk[1] = __floats2bfloat162_rn(residual_v[8 + 2], residual_v[8 + 3]);
+                                _pk[2] = __floats2bfloat162_rn(residual_v[8 + 4], residual_v[8 + 5]);
+                                _pk[3] = __floats2bfloat162_rn(residual_v[8 + 6], residual_v[8 + 7]);
+                                *reinterpret_cast<uint4*>(&((__nv_bfloat16*)(tape_x + (tape_ex_base + (long long)(residual_half * 16) + 8)))[0]) = *reinterpret_cast<uint4*>(&_pk[0]);
+                            }
+                        }
+                        uint32_t residual_v_bf16[8];
+                        #pragma unroll
+                        for (int _lp = 0; _lp < 8; _lp++) {
+                            __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(residual_v[_lp*2 + 0], residual_v[_lp*2+1 + 0]));
+                            residual_v_bf16[_lp] = *(uint32_t*)&_bf2;
+                        }
+                        tmem_st_x8_u32(taddr + 224 + (unsigned int)tmem_row_base + (unsigned int)(residual_half * 8), (const uint32_t*)residual_v_bf16);
+                    }
+                }
+                asm volatile("tcgen05.wait::st.sync.aligned;" ::: "memory");
+                if (elect_sync()) {
+                    mbarrier_arrive(v_free_addr + (compute_stage) * 8);
+                    mbarrier_arrive(u_inp_ready_addr + (compute_stage) * 8);
+                }
+                mbarrier_wait(u2_acc_ready_addr + (compute_stage) * 8, _phase_u2_acc_ready);
+                float _tmem_load_4[32];
+                tmem_ld_x32(&_tmem_load_4[0], taddr + (unsigned int)tmem_row_base);
+                asm volatile("tcgen05.wait::ld.sync.aligned;");
+                if (STORE_BACKWARD_TAPE != 0 && owned_chunk != 0) {
+                    long long chunk_global_r = cu_chunk_offsets[seq_idx] + (long long)chunk_global_local;
+                    long long tape_r_base = ((chunk_global_r * (long long)num_heads + (long long)head_idx) * 128 + (long long)state_row) * 32;
+                    #pragma unroll
+                    for (int tape_r_vec = 0; tape_r_vec < 4; tape_r_vec++) {
+                        {
+                            __nv_bfloat162 _pk[4];
+                            _pk[0] = __floats2bfloat162_rn(_tmem_load_4[tape_r_vec * 8 + 0], _tmem_load_4[tape_r_vec * 8 + 1]);
+                            _pk[1] = __floats2bfloat162_rn(_tmem_load_4[tape_r_vec * 8 + 2], _tmem_load_4[tape_r_vec * 8 + 3]);
+                            _pk[2] = __floats2bfloat162_rn(_tmem_load_4[tape_r_vec * 8 + 4], _tmem_load_4[tape_r_vec * 8 + 5]);
+                            _pk[3] = __floats2bfloat162_rn(_tmem_load_4[tape_r_vec * 8 + 6], _tmem_load_4[tape_r_vec * 8 + 7]);
+                            *reinterpret_cast<uint4*>(&((__nv_bfloat16*)(tape_r + (tape_r_base + (long long)(tape_r_vec * 8))))[0]) = *reinterpret_cast<uint4*>(&_pk[0]);
+                        }
+                    }
+                }
+                uint32_t _tmem_load_4_bf16[16];
+                #pragma unroll
+                for (int _lp = 0; _lp < 16; _lp++) {
+                    __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(_tmem_load_4[_lp*2 + 0], _tmem_load_4[_lp*2+1 + 0]));
+                    _tmem_load_4_bf16[_lp] = *(uint32_t*)&_bf2;
+                }
+                asm volatile(
+                    "tcgen05.st.sync.aligned.32x32b.x16.b32"
+                    " [%0], {%1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15, %16};"
+                    :: "r"(taddr + 224 + (unsigned int)tmem_row_base), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_4_bf16[0])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_4_bf16[1])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_4_bf16[2])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_4_bf16[3])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_4_bf16[4])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_4_bf16[5])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_4_bf16[6])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_4_bf16[7])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_4_bf16[8])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_4_bf16[9])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_4_bf16[10])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_4_bf16[11])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_4_bf16[12])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_4_bf16[13])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_4_bf16[14])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_4_bf16[15])));
+                asm volatile("tcgen05.wait::st.sync.aligned;" ::: "memory");
+                if (elect_sync()) {
+                    mbarrier_arrive(u2_inp_ready_addr + (compute_stage) * 8);
+                }
+                mbarrier_wait(final_ready_addr + (compute_stage) * 8, _phase_final_ready);
+                {
+                    int next_chunk_global_local = chunk_global_local + 1;
+                    if (next_chunk_global_local >= 0 && next_chunk_global_local < num_chunks) {
+                        int checkpoint_needed = smem_state_checkpoint_needed[compute_stage * 4] != 0 || smem_state_checkpoint_needed[compute_stage * 4 + 1] != 0 || smem_state_checkpoint_needed[compute_stage * 4 + 2] != 0 || smem_state_checkpoint_needed[compute_stage * 4 + 3] != 0;
+                        if (compute_local_warp == 0) {
+                            if (elect_sync()) {
+                                long long chunk_global_next = cu_chunk_offsets[seq_idx] + (long long)next_chunk_global_local;
+                                state_checkpoint_needed[chunk_global_next * (long long)num_heads + (long long)head_idx] = (unsigned int)checkpoint_needed;
+                                if (SPLIT_WORK_ITEMS == 0 && checkpoint_needed != 0) {
+                                    state_checkpoint_needed[fallback_head] = 1;
+                                }
+                                if (SPLIT_WORK_ITEMS != 0 && checkpoint_needed != 0) {
+                                    state_checkpoint_needed[total_chunks * (long long)num_heads + (long long)task_idx] = 1;
+                                }
+                            }
+                        }
+                    }
+                    if (compute_local_warp == 0) {
+                        if (elect_sync()) {
+                            mbarrier_arrive(smem_free_addr + (compute_stage) * 8);
+                        }
+                    }
+                }
+                compute_stage += 1;
+                if (compute_stage == 5) { compute_stage = 0; _phase_qk_full ^= 1; _phase_v_full ^= 1; _phase_old_out_ready ^= 1; _phase_u2_acc_ready ^= 1; _phase_final_ready ^= 1; }
+            }
+            if (store_final_state != 0) {
+                #pragma unroll
+                for (int state_col_block_2 = 0; state_col_block_2 < 4; state_col_block_2++) {
+                    float _tmem_load_6[32];
+                    tmem_ld_x32(&_tmem_load_6[0], taddr + 64 + (unsigned int)tmem_row_base + (unsigned int)(state_col_block_2 * 32));
+                    asm volatile("tcgen05.wait::ld.sync.aligned;");
+                    {
+                        __nv_bfloat162 _pk[8];
+                        _pk[0] = __floats2bfloat162_rn(_tmem_load_6[0 + 0], _tmem_load_6[0 + 1]);
+                        _pk[1] = __floats2bfloat162_rn(_tmem_load_6[0 + 2], _tmem_load_6[0 + 3]);
+                        _pk[2] = __floats2bfloat162_rn(_tmem_load_6[0 + 4], _tmem_load_6[0 + 5]);
+                        _pk[3] = __floats2bfloat162_rn(_tmem_load_6[0 + 6], _tmem_load_6[0 + 7]);
+                        _pk[4] = __floats2bfloat162_rn(_tmem_load_6[0 + 8], _tmem_load_6[0 + 9]);
+                        _pk[5] = __floats2bfloat162_rn(_tmem_load_6[0 + 10], _tmem_load_6[0 + 11]);
+                        _pk[6] = __floats2bfloat162_rn(_tmem_load_6[0 + 12], _tmem_load_6[0 + 13]);
+                        _pk[7] = __floats2bfloat162_rn(_tmem_load_6[0 + 14], _tmem_load_6[0 + 15]);
+                        *reinterpret_cast<uint4*>(&((__nv_bfloat16*)(final_state + (state_base + (long long)(state_col_block_2 * 32))))[0]) = *reinterpret_cast<uint4*>(&_pk[0]);
+                        *reinterpret_cast<uint4*>(&((__nv_bfloat16*)(final_state + (state_base + (long long)(state_col_block_2 * 32))))[8]) = *reinterpret_cast<uint4*>(&_pk[4]);
+                    }
+                    {
+                        __nv_bfloat162 _pk[8];
+                        _pk[0] = __floats2bfloat162_rn(_tmem_load_6[16 + 0], _tmem_load_6[16 + 1]);
+                        _pk[1] = __floats2bfloat162_rn(_tmem_load_6[16 + 2], _tmem_load_6[16 + 3]);
+                        _pk[2] = __floats2bfloat162_rn(_tmem_load_6[16 + 4], _tmem_load_6[16 + 5]);
+                        _pk[3] = __floats2bfloat162_rn(_tmem_load_6[16 + 6], _tmem_load_6[16 + 7]);
+                        _pk[4] = __floats2bfloat162_rn(_tmem_load_6[16 + 8], _tmem_load_6[16 + 9]);
+                        _pk[5] = __floats2bfloat162_rn(_tmem_load_6[16 + 10], _tmem_load_6[16 + 11]);
+                        _pk[6] = __floats2bfloat162_rn(_tmem_load_6[16 + 12], _tmem_load_6[16 + 13]);
+                        _pk[7] = __floats2bfloat162_rn(_tmem_load_6[16 + 14], _tmem_load_6[16 + 15]);
+                        *reinterpret_cast<uint4*>(&((__nv_bfloat16*)(final_state + (state_base + (long long)(state_col_block_2 * 32) + 16)))[0]) = *reinterpret_cast<uint4*>(&_pk[0]);
+                        *reinterpret_cast<uint4*>(&((__nv_bfloat16*)(final_state + (state_base + (long long)(state_col_block_2 * 32) + 16)))[8]) = *reinterpret_cast<uint4*>(&_pk[4]);
+                    }
+                }
+            }
+            asm volatile("barrier.sync 9, 128;" ::: "memory");
+            if (compute_local_warp == 0) {
+                if (elect_sync()) {
+                    mbarrier_arrive(tmem_dealloc_ready_addr);
+                }
+            }
+        }
+    }
+    // ---- Role: epilogue ----
+    if (warp >= 4 && warp <= 7) {
+        asm volatile("setmaxnreg.dec.sync.aligned.u32 48;");
+        { // epilogue_main
+            int task_idx_1 = blockIdx.x;
+            int split_compute_start_1 = 0;
+            unsigned int _phase_work_item_ready_0 = 0;
+            int seq_idx_1 = seq_order[task_idx_1 / num_heads];
+            int head_idx_1 = task_idx_1 % num_heads;
+            long long bos_1 = cu_seqlens[seq_idx_1];
+            long long eos_1 = cu_seqlens[seq_idx_1 + 1];
+            int num_chunks_1 = ((int)(eos_1 - bos_1) + 32 - 1) / 32;
+            int seq_len_1 = (int)(eos_1 - bos_1);
+            int num_chunks_0_1 = (seq_len_1 + 32 - 1) / 32;
+            int warp_id_in_role_1 = (warp - 4);
+            int epilogue_local_warp = warp_id_in_role_1;
+            int warp_in_wg_1 = warp % 4;
+            const int tmem_row_base_1 = warp_in_wg_1 * 32 << 16;
+            int state_row_1 = warp_in_wg_1 * 32 + lane;
+            unsigned int epilogue_stage = 0;
+            unsigned int output_stage = 0;
+            unsigned int checkpoint_stage_epilogue = 0;
+            int epilogue_chunks = num_chunks_0_1;
+            {
+                epilogue_chunks = 0;
+            }
+            unsigned int _phase_checkpoint_ready = 0;
+            unsigned int _phase_final_ready_1 = 0;
+            #pragma unroll 1
+            for (int chunk_idx_1 = 0; chunk_idx_1 < epilogue_chunks; chunk_idx_1++) {
+                int checkpoint_token_epilogue = chunk_idx_1 * 32;
+                int checkpoint_entering_epilogue = checkpoint_every_n_tokens != 0 && checkpoint_token_epilogue % checkpoint_every_n_tokens == 0;
+                int chunk_is_full = ((seq_len_1 >= (chunk_idx_1 + 1) * 32) ? 1 : 0);
+                if (chunk_is_full != 0) {
+                    mbarrier_wait(final_ready_addr + (epilogue_stage) * 8, _phase_final_ready_1);
+                    float _tmem_load_7[16];
+                    asm volatile(
+                        "tcgen05.ld.sync.aligned.16x256b.x4.b32"
+                        " {%0, %1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15}, [%16];"
+                        : "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_7[0])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_7[1])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_7[2])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_7[3])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_7[4])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_7[5])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_7[6])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_7[7])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_7[8])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_7[9])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_7[10])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_7[11])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_7[12])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_7[13])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_7[14])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_7[15]))
+                        : "r"(taddr + 192 + (unsigned int)tmem_row_base_1));
+                    float _tmem_load_8[16];
+                    asm volatile(
+                        "tcgen05.ld.sync.aligned.16x256b.x4.b32"
+                        " {%0, %1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15}, [%16];"
+                        : "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_8[0])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_8[1])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_8[2])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_8[3])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_8[4])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_8[5])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_8[6])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_8[7])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_8[8])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_8[9])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_8[10])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_8[11])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_8[12])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_8[13])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_8[14])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_8[15]))
+                        : "r"(taddr + 192 + (unsigned int)tmem_row_base_1 + 1048576));
+                    asm volatile("tcgen05.wait::ld.sync.aligned;" ::: "memory");
+                    asm volatile("barrier.sync 8, 128;" ::: "memory");
+                    if (epilogue_local_warp == 0) {
+                        if (elect_sync()) {
+                            mbarrier_arrive(out_empty_addr);
+                        }
+                    }
+                    if (epilogue_local_warp == 0) {
+                        if (chunk_idx_1 >= 2) {
+                            asm volatile("cp.async.bulk.wait_group.read 1;");
+                        }
+                    }
+                    asm volatile("barrier.sync 8, 128;" ::: "memory");
+                    int out_stage_addr = smem_out_addr + output_stage * 8192;
+                    #pragma unroll
+                    for (int dim_half = 0; dim_half < 2; dim_half++) {
+                        unsigned int out_packed[8];
+                        if (dim_half == 0) {
+                            #pragma unroll
+                            for (int _lp = 0; _lp < 8; _lp++) {
+                                __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(_tmem_load_7[_lp*2 + 0], _tmem_load_7[_lp*2+1 + 0]));
+                                out_packed[_lp] = *(uint32_t*)&_bf2;
+                            }
+                        } else {
+                            #pragma unroll
+                            for (int _lp = 0; _lp < 8; _lp++) {
+                                __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(_tmem_load_8[_lp*2 + 0], _tmem_load_8[_lp*2+1 + 0]));
+                                out_packed[_lp] = *(uint32_t*)&_bf2;
+                            }
+                        }
+                        #pragma unroll
+                        for (int token_group = 0; token_group < 2; token_group++) {
+                            int mtx_idx = lane / 8;
+                            int row_addr = lane & 7;
+                            int dim_base = epilogue_local_warp * 32 + dim_half * 16 + (mtx_idx & 1) * 8;
+                            int token_base = token_group * 16 + mtx_idx / 2 * 8;
+                            int token_addr = token_base + row_addr;
+                            int token_pair = token_addr / 2;
+                            int token_parity = token_addr & 1;
+                            int raw_row = token_pair + dim_base / 64 * 16;
+                            int raw_col = (dim_base & 63 ^ (token_pair & 3) << 4 ^ token_parity << 3) + token_parity * 64;
+                            int stsm_offset = (raw_row * 128 + raw_col) * 2;
+                            const int pack_base = token_group * 4;
+                            uint32_t _stmatrix_addr_0 = static_cast<uint32_t>((unsigned long long)(out_stage_addr + stsm_offset));
+                            asm volatile("stmatrix.sync.aligned.m8n8.x4.trans.shared.b16 [%0], {%1, %2, %3, %4};\n"
+                                :: "r"(_stmatrix_addr_0), "r"(*reinterpret_cast<const uint32_t*>(&out_packed[pack_base])), "r"(*reinterpret_cast<const uint32_t*>(&out_packed[pack_base + 1])), "r"(*reinterpret_cast<const uint32_t*>(&out_packed[pack_base + 2])), "r"(*reinterpret_cast<const uint32_t*>(&out_packed[pack_base + 3]))
+                                : "memory");
+                        }
+                    }
+                    asm volatile("fence.proxy.async.shared::cta;" ::: "memory");
+                    asm volatile("barrier.sync 8, 128;" ::: "memory");
+                    if (epilogue_local_warp == 0) {
+                        if (elect_sync()) {
+                            tma_store_4d(out_tma, 0, (int)(bos_1 + (long long)(chunk_idx_1 * 32)), head_idx_1, 0, smem_out_addr + output_stage * 8192);
+                        }
+                        asm volatile("cp.async.bulk.commit_group;");
+                    }
+                    output_stage = output_stage ^ 1;
+                } else {
+                    mbarrier_wait(final_ready_addr + (epilogue_stage) * 8, _phase_final_ready_1);
+                    float _tmem_load_9[32];
+                    tmem_ld_x32(&_tmem_load_9[0], taddr + 192 + (unsigned int)tmem_row_base_1);
+                    asm volatile("tcgen05.wait::ld.sync.aligned;" ::: "memory");
+                    asm volatile("barrier.sync 8, 128;" ::: "memory");
+                    if (epilogue_local_warp == 0) {
+                        if (elect_sync()) {
+                            mbarrier_arrive(out_empty_addr);
+                        }
+                    }
+                    #pragma unroll
+                    for (int token_col_1 = 0; token_col_1 < 32; token_col_1++) {
+                        long long out_token = bos_1 + (long long)(chunk_idx_1 * 32 + token_col_1);
+                        if (out_token < eos_1) {
+                            long long out_idx = (out_token * (long long)num_heads + (long long)head_idx_1) * 128 + (long long)state_row_1;
+                            out[out_idx] = _tmem_load_9[token_col_1];
+                        }
+                    }
+                }
+                epilogue_stage += 1;
+                if (epilogue_stage == 5) { epilogue_stage = 0; _phase_final_ready_1 ^= 1; }
+            }
+            if (epilogue_local_warp == 0) {
+                if (elect_sync()) {
+                    mbarrier_arrive(tmem_dealloc_ready_addr);
+                }
+            }
+        }
+    }
+    // ---- Role: beta_prefetch ----
+    if (warp == 8) {
+        { // beta_prefetch_main
+
+        }
+    }
+    // ---- Role: aux_mma ----
+    if (warp >= 10 && warp <= 11) {
+        { // aux_mma_main
+            unsigned int _phase_work_item_ready_0_1 = 0;
+            unsigned int _phase_tape_ready = 0;
+            {
+                int task_idx_2 = blockIdx.x;
+                int split_compute_start_2 = 0;
+                int seq_idx_2 = seq_order[task_idx_2 / num_heads];
+                int head_idx_2 = task_idx_2 % num_heads;
+                long long bos_2 = cu_seqlens[seq_idx_2];
+                long long eos_2 = cu_seqlens[seq_idx_2 + 1];
+                int num_chunks_2 = ((int)(eos_2 - bos_2) + 32 - 1) / 32;
+                int seq_len_2 = (int)(eos_2 - bos_2);
+                int num_chunks_0_2 = (seq_len_2 + 32 - 1) / 32;
+                int warp_id_in_role_2 = (warp - 10);
+                int tape_tid = warp_id_in_role_2 * 32 + lane;
+                int zero_stride = num_bids * 64;
+                #pragma unroll 1
+                for (int zero_item = task_idx_2 * 64 + tape_tid; zero_item < zero_words; zero_item += zero_stride) {
+                    zero_workspace[zero_item] = 0;
+                }
+                unsigned int tape_stage = 0;
+                #pragma unroll 1
+                for (int chunk_idx_2 = 0; chunk_idx_2 < num_chunks_0_2; chunk_idx_2++) {
+                    mbarrier_wait(tape_ready_addr + (tape_stage) * 8, _phase_tape_ready);
+                    int chunk_global_local_1 = chunk_idx_2;
+                    int owned_chunk_1 = chunk_global_local_1 >= 0 && chunk_global_local_1 < num_chunks_2;
+                    long long chunk_global = cu_chunk_offsets[seq_idx_2] + (long long)chunk_global_local_1;
+                    long long tape_vec_base = (chunk_global * (long long)num_heads + (long long)head_idx_2) * 32 * 128;
+                    #pragma unroll
+                    for (int tape_pass = 0; tape_pass < 8; tape_pass++) {
+                        int tape_item = tape_pass * 64 + tape_tid;
+                        int tape_row = tape_item / 16;
+                        int tape_segment = tape_item % 16;
+                        float tape_kr_values[8];
+                        unsigned int packed[4];
+                        asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                            : "=r"(*reinterpret_cast<uint32_t*>(&packed[0])), "=r"(*reinterpret_cast<uint32_t*>(&packed[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&packed[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&packed[(0) + 3]))
+                            : "r"((smem_kr_trans_addr + tape_stage * 41984 + (unsigned int)(tape_segment * 8 / 64 * 4096 + tape_row * 128 + tape_segment * 8 % 64 * 2 ^ (tape_segment * 8 / 64 * 4096 + tape_row * 128 + tape_segment * 8 % 64 * 2 >> 7 & 7) << 4))));
+                        float packed_f32[8];
+                        #pragma unroll
+                        for (int _pair = 0; _pair < 4; _pair++) {
+                            asm volatile(
+                                "{\n\t"
+                                "shl.b32 %0, %2, 16;\n\t"
+                                "and.b32 %1, %2, 0xffff0000;\n\t"
+                                "}\n"
+                                : "=f"((&packed_f32[_pair * 2])[0]), "=f"((&packed_f32[_pair * 2])[1])
+                                : "r"(packed[_pair]));
+                        }
+                        #pragma unroll
+                        for (int value_idx = 0; value_idx < 8; value_idx++) {
+                            tape_kr_values[value_idx] = packed_f32[value_idx];
+                        }
+                        long long tape_index = tape_vec_base + (long long)tape_row * 128 + (long long)(tape_segment * 8);
+                        if (owned_chunk_1 != 0) {
+                            {
+                                __nv_bfloat162 _pk[4];
+                                _pk[0] = __floats2bfloat162_rn(tape_kr_values[0 + 0], tape_kr_values[0 + 1]);
+                                _pk[1] = __floats2bfloat162_rn(tape_kr_values[0 + 2], tape_kr_values[0 + 3]);
+                                _pk[2] = __floats2bfloat162_rn(tape_kr_values[0 + 4], tape_kr_values[0 + 5]);
+                                _pk[3] = __floats2bfloat162_rn(tape_kr_values[0 + 6], tape_kr_values[0 + 7]);
+                                *reinterpret_cast<uint4*>(&((__nv_bfloat16*)(tape_kr + tape_index))[0]) = *reinterpret_cast<uint4*>(&_pk[0]);
+                            }
+                        }
+                    }
+                    long long tape_j_base = (chunk_global * (long long)num_heads + (long long)head_idx_2) * 32 * 32;
+                    #pragma unroll
+                    for (int tape_j_pass = 0; tape_j_pass < 2; tape_j_pass++) {
+                        int tape_j_item = tape_j_pass * 64 + tape_tid;
+                        int tape_j_row = tape_j_item / 4;
+                        int tape_j_segment = tape_j_item % 4;
+                        float tape_j_values[8];
+                        unsigned int packed_1[4];
+                        asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                            : "=r"(*reinterpret_cast<uint32_t*>(&packed_1[0])), "=r"(*reinterpret_cast<uint32_t*>(&packed_1[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&packed_1[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&packed_1[(0) + 3]))
+                            : "r"((smem_inv_addr + tape_stage * 41984 + (unsigned int)(tape_j_segment * 8 / 16 * 1024 + tape_j_row * 32 + tape_j_segment * 8 % 16 * 2 ^ (tape_j_segment * 8 / 16 * 1024 + tape_j_row * 32 + tape_j_segment * 8 % 16 * 2 >> 7 & 1) << 4))));
+                        float packed_f32_1[8];
+                        #pragma unroll
+                        for (int _pair = 0; _pair < 4; _pair++) {
+                            asm volatile(
+                                "{\n\t"
+                                "shl.b32 %0, %2, 16;\n\t"
+                                "and.b32 %1, %2, 0xffff0000;\n\t"
+                                "}\n"
+                                : "=f"((&packed_f32_1[_pair * 2])[0]), "=f"((&packed_f32_1[_pair * 2])[1])
+                                : "r"(packed_1[_pair]));
+                        }
+                        #pragma unroll
+                        for (int value_idx_1 = 0; value_idx_1 < 8; value_idx_1++) {
+                            tape_j_values[value_idx_1] = packed_f32_1[value_idx_1];
+                        }
+                        if (owned_chunk_1 != 0) {
+                            {
+                                __nv_bfloat162 _pk[4];
+                                _pk[0] = __floats2bfloat162_rn(tape_j_values[0 + 0], tape_j_values[0 + 1]);
+                                _pk[1] = __floats2bfloat162_rn(tape_j_values[0 + 2], tape_j_values[0 + 3]);
+                                _pk[2] = __floats2bfloat162_rn(tape_j_values[0 + 4], tape_j_values[0 + 5]);
+                                _pk[3] = __floats2bfloat162_rn(tape_j_values[0 + 6], tape_j_values[0 + 7]);
+                                *reinterpret_cast<uint4*>(&((__nv_bfloat16*)(tape_j + (tape_j_base + (long long)tape_j_row * 32 + (long long)(tape_j_segment * 8))))[0]) = *reinterpret_cast<uint4*>(&_pk[0]);
+                            }
+                        }
+                    }
+                    if (elect_sync()) {
+                        mbarrier_arrive(tape_free_addr + (tape_stage) * 8);
+                    }
+                    tape_stage += 1;
+                    if (tape_stage == 5) { tape_stage = 0; _phase_tape_ready ^= 1; }
+                }
+            }
+        }
+    }
+    // ---- Role: mma ----
+    if (warp == 9) {
+        { // mma_main
+            int task_idx_3 = blockIdx.x;
+            int split_compute_start_3 = 0;
+            unsigned int _phase_work_item_ready_0_2 = 0;
+            int seq_idx_3 = seq_order[task_idx_3 / num_heads];
+            int head_idx_3 = task_idx_3 % num_heads;
+            long long bos_3 = cu_seqlens[seq_idx_3];
+            long long eos_3 = cu_seqlens[seq_idx_3 + 1];
+            int num_chunks_3 = ((int)(eos_3 - bos_3) + 32 - 1) / 32;
+            int seq_len_3 = (int)(eos_3 - bos_3);
+            int num_chunks_0_3 = (seq_len_3 + 32 - 1) / 32;
+            unsigned int mma_stage = 0;
+            unsigned int _phase_qk_full_1 = 0;
+            unsigned int _phase_out_empty_0 = 1;
+            unsigned int _phase_state_inp_ready = 0;
+            unsigned int _phase_u_inp_ready = 0;
+            unsigned int _phase_u2_inp_ready = 0;
+            unsigned int _phase_final_ready_2 = 0;
+            #pragma unroll 1
+            for (int _chunk_idx = 0; _chunk_idx < num_chunks_0_3; _chunk_idx++) {
+                mbarrier_wait(qk_full_addr + (mma_stage) * 8, _phase_qk_full_1);
+                {
+                    mbarrier_wait(state_inp_ready_addr + (mma_stage) * 8, _phase_state_inp_ready);
+                    {
+                        int _mma_b_lo_6 = make_warp_uniform((((smem_kd_addr) >> 4) & 0x3FFF) + (mma_stage) * 2624);
+                        asm volatile(
+                    "{\n\t"
+                    ".reg .pred leader, p0, p1;\n\t"
+                    ".reg .b32 dhi, blo, ta, id;\n\t"
+                    ".reg .b64 db;\n\t"
+                    "elect.sync _|leader, 0xFFFFFFFF;\n\t"
+                    "setp.ne.b32 p0, %3, 0;\n\t"
+                    "setp.ne.b32 p1, 1, 0;\n\t"
+                    ""
+                    "mov.b32 dhi, 0x40004040;\n\t"
+                    "mov.b32 id, 134743184;\n\t"
+                    "mov.b32 ta, %2;\n\t"
+                    "mov.b32 blo, %1;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p0;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 250;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "}\n"
+                    :: "r"(tmem_tmem_u_acc), "r"(_mma_b_lo_6), "r"(tmem_tmem_state_inp), "r"(0));
+                    }
+                }
+                {
+                    elect_commit2(old_out_ready_addr + (mma_stage) * 8, raw_inputs_free_addr + (mma_stage) * 8);
+                }
+                mbarrier_wait(u_inp_ready_addr + (mma_stage) * 8, _phase_u_inp_ready);
+                int _mma_b_lo_7 = make_warp_uniform((((smem_inv_addr) >> 4) & 0x3FFF) + (mma_stage) * 2624);
+                asm volatile(
+                    "{\n\t"
+                    ".reg .pred leader, p0, p1;\n\t"
+                    ".reg .b32 dhi, blo, ta, id;\n\t"
+                    ".reg .b64 db;\n\t"
+                    "elect.sync _|leader, 0xFFFFFFFF;\n\t"
+                    "setp.ne.b32 p0, %3, 0;\n\t"
+                    "setp.ne.b32 p1, 1, 0;\n\t"
+                    ""
+                    "mov.b32 dhi, 0xC0004010;\n\t"
+                    "mov.b32 id, 134743184;\n\t"
+                    "mov.b32 ta, %2;\n\t"
+                    "mov.b32 blo, %1;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p0;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 64;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "}\n"
+                    :: "r"(tmem_tmem_u2_acc), "r"(_mma_b_lo_7), "r"(tmem_tmem_u2_inp), "r"(0));
+                elect_commit(u2_acc_ready_addr + (mma_stage) * 8);
+                mbarrier_wait(u2_inp_ready_addr + (mma_stage) * 8, _phase_u2_inp_ready);
+                int _mma_b_lo_8 = make_warp_uniform(((((smem_final_trans_addr) >> 4) & 0x3FFF) | 0x1000000) + (mma_stage) * 2624);
+                asm volatile(
+                    "{\n\t"
+                    ".reg .pred leader, p0, p1;\n\t"
+                    ".reg .b32 dhi, blo, ta, id;\n\t"
+                    ".reg .b64 db;\n\t"
+                    "elect.sync _|leader, 0xFFFFFFFF;\n\t"
+                    "setp.ne.b32 p0, %3, 0;\n\t"
+                    "setp.ne.b32 p1, 1, 0;\n\t"
+                    ""
+                    "mov.b32 dhi, 0x40004040;\n\t"
+                    "mov.b32 id, 136905872;\n\t"
+                    "mov.b32 ta, %2;\n\t"
+                    "mov.b32 blo, %1;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p0;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 128;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "}\n"
+                    :: "r"(tmem_tmem_state_out), "r"(_mma_b_lo_8), "r"(tmem_tmem_u2_inp), "r"(1));
+                elect_commit(final_ready_addr + (mma_stage) * 8);
+                {
+                    mbarrier_wait(final_ready_addr + (mma_stage) * 8, _phase_final_ready_2);
+                }
+                mma_stage += 1;
+                if (mma_stage == 5) { mma_stage = 0; _phase_qk_full_1 ^= 1; _phase_state_inp_ready ^= 1; _phase_u_inp_ready ^= 1; _phase_u2_inp_ready ^= 1; _phase_final_ready_2 ^= 1; }
+            }
+            unsigned int _phase_tmem_dealloc_ready_0 = 0;
+            mbarrier_wait(tmem_dealloc_ready_addr, _phase_tmem_dealloc_ready_0);
+            _phase_tmem_dealloc_ready_0 ^= 1;
+            int _tmem_dealloc_addr = *((volatile int*)tmem_addr_storage);
+            asm volatile("tcgen05.dealloc.cta_group::1.sync.aligned.b32 %0, %1;" :: "r"(_tmem_dealloc_addr), "r"(256));
+        }
+    }
+    // ---- Role: prep ----
+    if (warp >= 12 && warp <= 31) {
+        asm volatile("setmaxnreg.dec.sync.aligned.u32 48;");
+        { // prep_main
+            int task_idx_4 = blockIdx.x;
+            int split_compute_start_4 = 0;
+            unsigned int _phase_work_item_ready_0_3 = 0;
+            int seq_idx_4 = seq_order[task_idx_4 / num_heads];
+            int head_idx_4 = task_idx_4 % num_heads;
+            long long bos_4 = cu_seqlens[seq_idx_4];
+            long long eos_4 = cu_seqlens[seq_idx_4 + 1];
+            int num_chunks_4 = ((int)(eos_4 - bos_4) + 32 - 1) / 32;
+            int seq_len_4 = (int)(eos_4 - bos_4);
+            int num_chunks_0_4 = (seq_len_4 + 32 - 1) / 32;
+            int instance_id = (warp - 12) / 4;
+            int prep_instance = instance_id;
+            int warp_id_in_role_3 = (warp - 12);
+            int prep_local_warp = warp_id_in_role_3 - prep_instance * 4;
+            int prep_tid = prep_local_warp * 32 + lane;
+            int num_prep_iters = (num_chunks_0_4 + 5 - 1 - prep_instance) / 5;
+            unsigned int prep_stage = (unsigned int)prep_instance;
+            int gate_rate_stage_f32 = prep_instance * 10496;
+            int prep_global_tid = warp_id_in_role_3 * 32 + lane;
+            if (prep_tid == 0) {
+                float _expf_0 = __expf(A_log[head_idx_4]);
+                smem_gate_rate_all[gate_rate_stage_f32] = _expf_0;
+            }
+            if (prep_global_tid < 128) {
+                smem_gate_bias_all[prep_global_tid] = dt_bias[head_idx_4 * 128 + prep_global_tid];
+            }
+            asm volatile("barrier.sync 15, 640;" ::: "memory");
+            {
+                if (prep_global_tid < 128) {
+                    smem_gate_bias_all[prep_global_tid] = smem_gate_bias_all[prep_global_tid] * smem_gate_rate_all[0];
+                }
+                asm volatile("barrier.sync 15, 640;" ::: "memory");
+            }
+            unsigned int _phase_raw_inputs_free = 1;
+            unsigned int _phase_gate_raw_full = 0;
+            unsigned int _phase_smem_free = 1;
+            unsigned int _phase_v_free = 1;
+            unsigned int _phase_qk_raw_full = 0;
+            unsigned int _phase_short_beta_ready = 0;
+            unsigned int _phase_prep_diag_ready = 0;
+            unsigned int _phase_prep_inv16_ready = 0;
+            unsigned int _phase_tape_free = 1;
+            #pragma unroll 1
+            for (int prep_iter = 0; prep_iter < num_prep_iters; prep_iter++) {
+                int chunk_idx_3 = prep_iter * 5 + prep_instance;
+                int chunk_global_local_2 = chunk_idx_3;
+                int owned_chunk_2 = chunk_global_local_2 >= 0 && chunk_global_local_2 < num_chunks_4;
+                int stage_f32 = prep_stage * 10496;
+                int stage_bf16 = prep_stage * 20992;
+                int chunk_is_full_1 = ((seq_len_4 >= (chunk_idx_3 + 1) * 32) ? 1 : 0);
+                float early_beta_value = 0.0f;
+                float early_gate0 = 0.0f;
+                if (chunk_is_full_1 != 0 || prep_iter != 0) {
+                    mbarrier_wait(raw_inputs_free_addr + (prep_stage) * 8, _phase_raw_inputs_free);
+                }
+                if (chunk_is_full_1 != 0) {
+                    if (prep_local_warp == 0) {
+                        if (elect_sync()) {
+                            mbarrier_arrive_expect_tx(gate_raw_full_addr + (prep_stage) * 8, 8704);
+                            tma_3d_gmem2smem(smem_g_raw_addr + prep_stage * 41984, g_tma, 0, head_idx_4, (int)(bos_4 + (long long)(chunk_idx_3 * 32)), gate_raw_full_addr + (prep_stage) * 8);
+                            {
+                                tma_2d_gmem2smem(smem_beta_raw_addr + prep_stage * 41984, beta_tma, ((0) ? 0 : head_idx_4 / 8 * 8), (int)(((0) ? (bos_4 + (long long)(chunk_idx_3 * 32)) / 2 : bos_4 + (long long)(chunk_idx_3 * 32))), gate_raw_full_addr + (prep_stage) * 8);
+                            }
+                            mbarrier_arrive_expect_tx(qk_raw_full_addr + (prep_stage) * 8, 16384);
+                            tma_4d_gmem2smem(smem_kd_addr + prep_stage * 41984, k_tma, 0, (int)(bos_4 + (long long)(chunk_idx_3 * 32)), head_idx_4, 0, qk_raw_full_addr + (prep_stage) * 8);
+                        }
+                    }
+                    mbarrier_wait(gate_raw_full_addr + (prep_stage) * 8, _phase_gate_raw_full);
+                    if (prep_local_warp == 2 && lane < 32) {
+                        float beta_logit = 0.0f;
+                        {
+                            {
+                                unsigned int beta_raw_pair[1];
+                                asm volatile("ld.shared.b32 %0, [%1];" : "=r"(*reinterpret_cast<uint32_t*>(&beta_raw_pair[0])) : "r"(smem_beta_raw_addr + prep_stage * 41984 + (unsigned int)(lane * 16) + (unsigned int)(head_idx_4 % 8 / 2 * 4)));
+                                float beta_raw_pair_f32[2];
+                                #pragma unroll
+                                for (int _pair = 0; _pair < 1; _pair++) {
+                                    asm volatile(
+                                        "{\n\t"
+                                        "shl.b32 %0, %2, 16;\n\t"
+                                        "and.b32 %1, %2, 0xffff0000;\n\t"
+                                        "}\n"
+                                        : "=f"((&beta_raw_pair_f32[_pair * 2])[0]), "=f"((&beta_raw_pair_f32[_pair * 2])[1])
+                                        : "r"(beta_raw_pair[_pair]));
+                                }
+                                beta_logit = beta_raw_pair_f32[0];
+                                if (head_idx_4 % 2 != 0) {
+                                    beta_logit = beta_raw_pair_f32[1];
+                                }
+                            }
+                        }
+                        float _tanh_approx_1;
+                        asm volatile("tanh.approx.f32 %0, %1;" : "=f"(_tanh_approx_1) : "f"(beta_logit * 0.5f));
+                        early_beta_value = _tanh_approx_1 * 0.5f + 0.5f;
+                    }
+                }
+                mbarrier_wait(smem_free_addr + (prep_stage) * 8, _phase_smem_free);
+                mbarrier_wait(v_free_addr + (prep_stage) * 8, _phase_v_free);
+                if (chunk_is_full_1 != 0) {
+                    if (prep_local_warp == 0) {
+                        if (elect_sync()) {
+                            tma_4d_gmem2smem(smem_q_raw_prefetch_addr + prep_stage * 41984, q_tma, 0, (int)(bos_4 + (long long)(chunk_idx_3 * 32)), head_idx_4, 0, qk_raw_full_addr + (prep_stage) * 8);
+                        }
+                    }
+                }
+                if (chunk_is_full_1 == 0) {
+                    #pragma unroll
+                    for (int gate_load_pass = 0; gate_load_pass < 4; gate_load_pass++) {
+                        int gate_load_item = gate_load_pass * 128 + prep_tid;
+                        int gate_load_row = gate_load_item / 16;
+                        int gate_load_segment = gate_load_item % 16;
+                        long long gate_load_token = bos_4 + (long long)(chunk_idx_3 * 32 + gate_load_row);
+                        long long gate_load_base = (gate_load_token * (long long)num_heads + (long long)head_idx_4) * 128 + (long long)(gate_load_segment * 8);
+                        asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16, %2;"
+                            :: "r"(smem_g_raw_addr + prep_stage * 41984 + (unsigned int)(gate_load_item * 16)), "l"(g + gate_load_base), "r"((gate_load_token < eos_4) ? 16 : 0));
+                        int q_tail_addr = (smem_q_raw_prefetch_addr + prep_stage * 41984 + (unsigned int)(gate_load_segment * 8 / 64 * 4096 + gate_load_row * 128 + gate_load_segment * 8 % 64 * 2 ^ (gate_load_segment * 8 / 64 * 4096 + gate_load_row * 128 + gate_load_segment * 8 % 64 * 2 >> 7 & 7) << 4));
+                        asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16, %2;"
+                            :: "r"(q_tail_addr), "l"(q + gate_load_base), "r"((gate_load_token < eos_4) ? 16 : 0));
+                        int k_tail_addr = (smem_kd_addr + prep_stage * 41984 + (unsigned int)(gate_load_segment * 8 / 64 * 4096 + gate_load_row * 128 + gate_load_segment * 8 % 64 * 2 ^ (gate_load_segment * 8 / 64 * 4096 + gate_load_row * 128 + gate_load_segment * 8 % 64 * 2 >> 7 & 7) << 4));
+                        asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16, %2;"
+                            :: "r"(k_tail_addr), "l"(k + gate_load_base), "r"((gate_load_token < eos_4) ? 16 : 0));
+                    }
+                }
+                if (chunk_is_full_1 == 0) {
+                    asm volatile("cp.async.commit_group;");
+                    asm volatile("cp.async.wait_group 0;");
+                    asm volatile("barrier.sync %0, 128;" :: "r"(10 + prep_instance) : "memory");
+                }
+                if (prep_local_warp == 2 && lane < 32) {
+                    long long beta_token = bos_4 + (long long)(chunk_idx_3 * 32 + lane);
+                    float beta_value = early_beta_value;
+                    if (chunk_is_full_1 == 0) {
+                        if (beta_token < eos_4) {
+                            float beta_logit_1 = (float)beta[beta_token * (long long)num_heads + (long long)head_idx_4];
+                            float _tanh_approx_3;
+                            asm volatile("tanh.approx.f32 %0, %1;" : "=f"(_tanh_approx_3) : "f"(beta_logit_1 * 0.5f));
+                            beta_value = _tanh_approx_3 * 0.5f + 0.5f;
+                        }
+                    }
+                    {
+                        smem_prep_beta_all[stage_f32 + lane] = beta_value;
+                    }
+                    {
+                        if (beta_token < eos_4 && owned_chunk_2 != 0) {
+                            beta_active_out[beta_token * (long long)num_heads + (long long)head_idx_4] = beta_value;
+                        }
+                    }
+                }
+                if (prep_tid < 128) {
+                    int gate_col = prep_tid;
+                    float gate_rate = smem_gate_rate_all[stage_f32];
+                    float gate_bias = smem_gate_bias_all[gate_col];
+                    float prefix_log2 = 0.0f;
+                    {
+                        float2 _f2_0 = make_float2(gate_rate, gate_rate);
+                        float2 gate_rate_pair = _f2_0;
+                        float2 _f2_1 = make_float2(gate_bias, gate_bias);
+                        float2 gate_bias_pair = _f2_1;
+                        float half_gate_scale = lower_bound * 0.7213475204444817f;
+                        float2 _f2_2 = make_float2(half_gate_scale, half_gate_scale);
+                        float2 half_gate_scale_pair = _f2_2;
+                        if (chunk_is_full_1 != 0) {
+                            for (int gate_row_pair = 0; gate_row_pair < 16; gate_row_pair++) {
+                                const int gate_row0 = gate_row_pair * 2;
+                                const int gate_row1 = gate_row0 + 1;
+                                const int gate_row0_0 = gate_row_pair * 2;
+                                const int gate_row1_1 = gate_row0_0 + 1;
+                                __nv_bfloat16 gate_raw0 = smem_g_raw_all[stage_bf16 + gate_row0_0 * 128 + gate_col];
+                                __nv_bfloat16 gate_raw1 = smem_g_raw_all[stage_bf16 + gate_row1_1 * 128 + gate_col];
+                                float _cvt_f32_2 = __bfloat162float(gate_raw0);
+                                float _cvt_f32_3 = __bfloat162float(gate_raw1);
+                                float2 _f2_3 = make_float2(_cvt_f32_2, _cvt_f32_3);
+                                float2 gate_raw_pair = _f2_3;
+                                float2 gate_arg_pair = fma_f32x2(gate_raw_pair, gate_rate_pair, gate_bias_pair);
+                                float _tanh_approx_4;
+                                asm volatile("tanh.approx.f32 %0, %1;" : "=f"(_tanh_approx_4) : "f"(gate_arg_pair.x * 0.5f));
+                                float _tanh_approx_5;
+                                asm volatile("tanh.approx.f32 %0, %1;" : "=f"(_tanh_approx_5) : "f"(gate_arg_pair.y * 0.5f));
+                                float2 _f2_4 = make_float2(_tanh_approx_4, _tanh_approx_5);
+                                float2 gate_tanh_pair = _f2_4;
+                                float2 gate_log_pair = fma_f32x2(gate_tanh_pair, half_gate_scale_pair, half_gate_scale_pair);
+                                float gate_log0 = gate_log_pair.x;
+                                float gate_log1 = gate_log_pair.y;
+                                prefix_log2 += gate_log0;
+                                smem_gate_all[stage_f32 + gate_row0 * 128 + gate_col] = prefix_log2;
+                                prefix_log2 += gate_log1;
+                                smem_gate_all[stage_f32 + gate_row1 * 128 + gate_col] = prefix_log2;
+                            }
+                        } else {
+                            for (int gate_row_pair_1 = 0; gate_row_pair_1 < 16; gate_row_pair_1++) {
+                                const int gate_row0_1 = gate_row_pair_1 * 2;
+                                const int gate_row1_2 = gate_row0_1 + 1;
+                                const int gate_row0_0_1 = gate_row_pair_1 * 2;
+                                const int gate_row1_1_1 = gate_row0_0_1 + 1;
+                                __nv_bfloat16 gate_raw0_1 = smem_g_raw_all[stage_bf16 + gate_row0_0_1 * 128 + gate_col];
+                                __nv_bfloat16 gate_raw1_1 = smem_g_raw_all[stage_bf16 + gate_row1_1_1 * 128 + gate_col];
+                                float _cvt_f32_4 = __bfloat162float(gate_raw0_1);
+                                float _cvt_f32_5 = __bfloat162float(gate_raw1_1);
+                                float2 _f2_5 = make_float2(_cvt_f32_4, _cvt_f32_5);
+                                float2 gate_raw_pair_1 = _f2_5;
+                                float2 gate_arg_pair_1 = fma_f32x2(gate_raw_pair_1, gate_rate_pair, gate_bias_pair);
+                                float _tanh_approx_6;
+                                asm volatile("tanh.approx.f32 %0, %1;" : "=f"(_tanh_approx_6) : "f"(gate_arg_pair_1.x * 0.5f));
+                                float _tanh_approx_7;
+                                asm volatile("tanh.approx.f32 %0, %1;" : "=f"(_tanh_approx_7) : "f"(gate_arg_pair_1.y * 0.5f));
+                                float2 _f2_6 = make_float2(_tanh_approx_6, _tanh_approx_7);
+                                float2 gate_tanh_pair_1 = _f2_6;
+                                float2 gate_log_pair_1 = fma_f32x2(gate_tanh_pair_1, half_gate_scale_pair, half_gate_scale_pair);
+                                float gate_log0_1 = gate_log_pair_1.x;
+                                float gate_log1_1 = gate_log_pair_1.y;
+                                {
+                                    long long gate_token0 = bos_4 + (long long)(chunk_idx_3 * 32 + gate_row0_0_1);
+                                    long long gate_token1 = gate_token0 + 1;
+                                    if (gate_token0 >= eos_4) {
+                                        gate_log0_1 = 0.0f;
+                                    }
+                                    if (gate_token1 >= eos_4) {
+                                        gate_log1_1 = 0.0f;
+                                    }
+                                }
+                                prefix_log2 += gate_log0_1;
+                                smem_gate_all[stage_f32 + gate_row0_1 * 128 + gate_col] = prefix_log2;
+                                prefix_log2 += gate_log1_1;
+                                smem_gate_all[stage_f32 + gate_row1_2 * 128 + gate_col] = prefix_log2;
+                            }
+                        }
+                    }
+                }
+                asm volatile("barrier.sync %0, 128;" :: "r"(10 + prep_instance) : "memory");
+                if (chunk_is_full_1 != 0) {
+                    mbarrier_wait(qk_raw_full_addr + (prep_stage) * 8, _phase_qk_raw_full);
+                }
+                if (prep_tid < 128) {
+                    float total_log2 = smem_gt_prefix_all[stage_f32 + prep_tid];
+                    float _exp2_0 = approx_exp2(total_log2 - lower_bound * 1.4426950408889634f * 16.0f);
+                    float restore_factor_value = _exp2_0;
+                    smem_restore_factor_all[stage_f32 + prep_tid] = restore_factor_value;
+                    {
+                        long long chunk_global_restore = cu_chunk_offsets[seq_idx_4] + (long long)chunk_global_local_2;
+                        if (owned_chunk_2 != 0) {
+                            tape_restore_factor[(chunk_global_restore * (long long)num_heads + (long long)head_idx_4) * 128 + (long long)prep_tid] = restore_factor_value;
+                        }
+                        int _vote_0 = __any_sync(0xFFFFFFFF, num_chunks_0_4 > chunk_idx_3 + 1 && total_log2 > -30.0f);
+                        int warp_slow = _vote_0;
+                        if (lane == 0) {
+                            smem_state_checkpoint_needed[prep_stage * 4 + (unsigned int)prep_local_warp] = (unsigned int)warp_slow;
+                        }
+                    }
+                }
+                if (prep_tid == 0) {
+                    float _exp2_1 = approx_exp2(lower_bound * 1.4426950408889634f * 16.0f);
+                    smem_restore_factor_all[stage_f32 + 128] = _exp2_1;
+                }
+                #pragma unroll 1
+                for (int work_pass = 0; work_pass < 4; work_pass++) {
+                    int work_item = work_pass * 128 + prep_tid;
+                    int row = work_item / 16;
+                    int segment = work_item % 16;
+                    long long token = bos_4 + (long long)(chunk_idx_3 * 32 + row);
+                    int token_valid = ((token < eos_4) ? 1 : 0);
+                    long long gmem_base = (token * (long long)num_heads + (long long)head_idx_4) * 128 + (long long)(segment * 8);
+                    float q_raw_vec[8];
+                    float k_raw_vec[8];
+                    unsigned int packed_2[4];
+                    asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                        : "=r"(*reinterpret_cast<uint32_t*>(&packed_2[0])), "=r"(*reinterpret_cast<uint32_t*>(&packed_2[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&packed_2[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&packed_2[(0) + 3]))
+                        : "r"((smem_q_raw_prefetch_addr + prep_stage * 41984 + (unsigned int)(segment * 8 / 64 * 4096 + row * 128 + segment * 8 % 64 * 2 ^ (segment * 8 / 64 * 4096 + row * 128 + segment * 8 % 64 * 2 >> 7 & 7) << 4))));
+                    float packed_f32_2[8];
+                    #pragma unroll
+                    for (int _pair = 0; _pair < 4; _pair++) {
+                        asm volatile(
+                            "{\n\t"
+                            "shl.b32 %0, %2, 16;\n\t"
+                            "and.b32 %1, %2, 0xffff0000;\n\t"
+                            "}\n"
+                            : "=f"((&packed_f32_2[_pair * 2])[0]), "=f"((&packed_f32_2[_pair * 2])[1])
+                            : "r"(packed_2[_pair]));
+                    }
+                    #pragma unroll
+                    for (int value_idx_2 = 0; value_idx_2 < 8; value_idx_2++) {
+                        q_raw_vec[value_idx_2] = packed_f32_2[value_idx_2];
+                    }
+                    unsigned int packed_0[4];
+                    asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                        : "=r"(*reinterpret_cast<uint32_t*>(&packed_0[0])), "=r"(*reinterpret_cast<uint32_t*>(&packed_0[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&packed_0[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&packed_0[(0) + 3]))
+                        : "r"((smem_kd_addr + prep_stage * 41984 + (unsigned int)(segment * 8 / 64 * 4096 + row * 128 + segment * 8 % 64 * 2 ^ (segment * 8 / 64 * 4096 + row * 128 + segment * 8 % 64 * 2 >> 7 & 7) << 4))));
+                    float packed_0_f32[8];
+                    #pragma unroll
+                    for (int _pair = 0; _pair < 4; _pair++) {
+                        asm volatile(
+                            "{\n\t"
+                            "shl.b32 %0, %2, 16;\n\t"
+                            "and.b32 %1, %2, 0xffff0000;\n\t"
+                            "}\n"
+                            : "=f"((&packed_0_f32[_pair * 2])[0]), "=f"((&packed_0_f32[_pair * 2])[1])
+                            : "r"(packed_0[_pair]));
+                    }
+                    #pragma unroll
+                    for (int value_idx_3 = 0; value_idx_3 < 8; value_idx_3++) {
+                        k_raw_vec[value_idx_3] = packed_0_f32[value_idx_3];
+                    }
+                    float q_sum = 0.0f;
+                    float k_sum = 0.0f;
+                    for (int elem_in_segment = 0; elem_in_segment < 8; elem_in_segment++) {
+                        float q_raw = q_raw_vec[elem_in_segment];
+                        float k_raw = k_raw_vec[elem_in_segment];
+                        float _fma_4 = __fmaf_rn(q_raw, q_raw, q_sum);
+                        q_sum = _fma_4;
+                        float _fma_5 = __fmaf_rn(k_raw, k_raw, k_sum);
+                        k_sum = _fma_5;
+                    }
+                    float _shfl_xor_0 = __shfl_xor_sync(0xFFFFFFFF, q_sum, 8);
+                    q_sum += _shfl_xor_0;
+                    float _shfl_xor_1 = __shfl_xor_sync(0xFFFFFFFF, k_sum, 8);
+                    k_sum += _shfl_xor_1;
+                    float _shfl_xor_2 = __shfl_xor_sync(0xFFFFFFFF, q_sum, 4);
+                    q_sum += _shfl_xor_2;
+                    float _shfl_xor_3 = __shfl_xor_sync(0xFFFFFFFF, k_sum, 4);
+                    k_sum += _shfl_xor_3;
+                    float _shfl_xor_4 = __shfl_xor_sync(0xFFFFFFFF, q_sum, 2);
+                    q_sum += _shfl_xor_4;
+                    float _shfl_xor_5 = __shfl_xor_sync(0xFFFFFFFF, k_sum, 2);
+                    k_sum += _shfl_xor_5;
+                    float _shfl_xor_6 = __shfl_xor_sync(0xFFFFFFFF, q_sum, 1);
+                    q_sum += _shfl_xor_6;
+                    float _shfl_xor_7 = __shfl_xor_sync(0xFFFFFFFF, k_sum, 1);
+                    k_sum += _shfl_xor_7;
+                    float _rsqrt_0 = rsqrtf(q_sum + 1e-06f);
+                    float q_inv = _rsqrt_0;
+                    float _rsqrt_1 = rsqrtf(k_sum + 1e-06f);
+                    float k_inv = _rsqrt_1;
+                    {
+                        q_inv *= scale;
+                    }
+                    const float2 _scale2_0 = {q_inv, q_inv};
+                    #pragma unroll
+                    for (int _ls = 0; _ls < 4; _ls++)
+                        mul_f32x2_inplace(&reinterpret_cast<float2*>(q_raw_vec)[_ls], _scale2_0);
+                    const float2 _scale2_1 = {k_inv, k_inv};
+                    #pragma unroll
+                    for (int _ls = 0; _ls < 4; _ls++)
+                        mul_f32x2_inplace(&reinterpret_cast<float2*>(k_raw_vec)[_ls], _scale2_1);
+                    {
+                        if (token_valid != 0 && owned_chunk_2 != 0) {
+                            if (segment == 0) {
+                                float norm_pair[2];
+                                norm_pair[0] = q_inv;
+                                norm_pair[1] = k_inv;
+                                {
+                                    float2 _v2 = make_float2(norm_pair[0 + 0], norm_pair[0 + 1]);
+                                    *reinterpret_cast<float2*>(norm_inv_out + (token * (long long)num_heads + (long long)head_idx_4) * 2) = _v2;
+                                }
+                            }
+                        }
+                    }
+                    float qd_vec[8];
+                    float kd_vec[8];
+                    float ki_vec[8];
+                    for (int elem_in_segment_1 = 0; elem_in_segment_1 < 8; elem_in_segment_1++) {
+                        int col = segment * 8 + elem_in_segment_1;
+                        float prefix = smem_gate_all[stage_f32 + row * 128 + col];
+                        float common_log2 = lower_bound * 1.4426950408889634f * 16.0f;
+                        float _exp2_2 = approx_exp2(prefix - common_log2);
+                        float decay = _exp2_2;
+                        qd_vec[elem_in_segment_1] = decay;
+                        kd_vec[elem_in_segment_1] = decay;
+                        ki_vec[elem_in_segment_1] = k_raw_vec[elem_in_segment_1] / decay;
+                    }
+                    {
+                        if (token_valid != 0 && owned_chunk_2 != 0) {
+                            {
+                                __nv_bfloat162 _pk[4];
+                                _pk[0] = __floats2bfloat162_rn(qd_vec[0 + 0], qd_vec[0 + 1]);
+                                _pk[1] = __floats2bfloat162_rn(qd_vec[0 + 2], qd_vec[0 + 3]);
+                                _pk[2] = __floats2bfloat162_rn(qd_vec[0 + 4], qd_vec[0 + 5]);
+                                _pk[3] = __floats2bfloat162_rn(qd_vec[0 + 6], qd_vec[0 + 7]);
+                                *reinterpret_cast<uint4*>(&((__nv_bfloat16*)(decay_out))[gmem_base + 0]) = *reinterpret_cast<uint4*>(&_pk[0]);
+                            }
+                        }
+                    }
+                    #pragma unroll
+                    for (int _ls = 0; _ls < 4; _ls++)
+                        mul_f32x2_inplace(&reinterpret_cast<float2*>(qd_vec)[_ls], reinterpret_cast<const float2*>(q_raw_vec)[_ls]);
+                    #pragma unroll
+                    for (int _ls = 0; _ls < 4; _ls++)
+                        mul_f32x2_inplace(&reinterpret_cast<float2*>(kd_vec)[_ls], reinterpret_cast<const float2*>(k_raw_vec)[_ls]);
+                    unsigned int packed_1_1[4];
+                    #pragma unroll
+                    for (int _lp = 0; _lp < 4; _lp++) {
+                        __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(qd_vec[_lp*2 + 0], qd_vec[_lp*2+1 + 0]));
+                        packed_1_1[_lp] = *(uint32_t*)&_bf2;
+                    }
+                    #pragma unroll
+                    for (int word = 0; word < 4; word++) {
+                        asm volatile("st.shared.b32 [%0], %1;" :: "r"((smem_qd_addr + prep_stage * 41984 + (unsigned int)(segment * 8 / 64 * 4096 + row * 128 + segment * 8 % 64 * 2 ^ (segment * 8 / 64 * 4096 + row * 128 + segment * 8 % 64 * 2 >> 7 & 7) << 4)) + (unsigned int)(word * 4)), "r"((packed_1_1[word])));
+                    }
+                    unsigned int packed_2_1[4];
+                    #pragma unroll
+                    for (int _lp = 0; _lp < 4; _lp++) {
+                        __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(kd_vec[_lp*2 + 0], kd_vec[_lp*2+1 + 0]));
+                        packed_2_1[_lp] = *(uint32_t*)&_bf2;
+                    }
+                    #pragma unroll
+                    for (int word_1 = 0; word_1 < 4; word_1++) {
+                        asm volatile("st.shared.b32 [%0], %1;" :: "r"((smem_kd_addr + prep_stage * 41984 + (unsigned int)(segment * 8 / 64 * 4096 + row * 128 + segment * 8 % 64 * 2 ^ (segment * 8 / 64 * 4096 + row * 128 + segment * 8 % 64 * 2 >> 7 & 7) << 4)) + (unsigned int)(word_1 * 4)), "r"((packed_2_1[word_1])));
+                    }
+                    unsigned int packed_3[4];
+                    #pragma unroll
+                    for (int _lp = 0; _lp < 4; _lp++) {
+                        __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(ki_vec[_lp*2 + 0], ki_vec[_lp*2+1 + 0]));
+                        packed_3[_lp] = *(uint32_t*)&_bf2;
+                    }
+                    #pragma unroll
+                    for (int word_2 = 0; word_2 < 4; word_2++) {
+                        asm volatile("st.shared.b32 [%0], %1;" :: "r"((smem_ki_addr + prep_stage * 41984 + (unsigned int)(segment * 8 / 64 * 4096 + row * 128 + segment * 8 % 64 * 2 ^ (segment * 8 / 64 * 4096 + row * 128 + segment * 8 % 64 * 2 >> 7 & 7) << 4)) + (unsigned int)(word_2 * 4)), "r"((packed_3[word_2])));
+                    }
+                }
+                asm volatile("barrier.sync %0, 128;" :: "r"(10 + prep_instance) : "memory");
+                unsigned int a_frag[4];
+                unsigned int b_frag[4];
+                float acc[8];
+                {
+                    int pair_row_base = prep_local_warp / 2 * 16;
+                    int pair_col_base = prep_local_warp % 2 * 16;
+                    if (pair_row_base >= pair_col_base) {
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(a_frag[0]), "=r"(a_frag[1]), "=r"(a_frag[2]), "=r"(a_frag[3])
+                            : "r"(smem_kd_addr + prep_stage * 41984 + (unsigned int)((lane / 16 / 8 * 256 + (pair_row_base + lane % 16) * 8 + (lane / 16 % 8 * 16 ^ (pair_row_base + lane % 16 & 7) << 4) / 16) * 16))
+                            : "memory");
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(b_frag[0]), "=r"(b_frag[1]), "=r"(b_frag[2]), "=r"(b_frag[3])
+                            : "r"(smem_ki_addr + prep_stage * 41984 + (unsigned int)((lane % 16 / 8 / 8 * 256 + (pair_col_base + 8 * (lane / 16) + lane % 8) * 8 + (lane % 16 / 8 % 8 * 16 ^ (pair_col_base + 8 * (lane / 16) + lane % 8 & 7) << 4) / 16) * 16))
+                            : "memory");
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%10, %11, %12, %13};\n"
+                            : "=f"(acc[0]), "=f"(acc[1]), "=f"(acc[2]), "=f"(acc[3])
+                            : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[0]), "r"(b_frag[1]), "f"(0.0f), "f"(0.0f), "f"(0.0f), "f"(0.0f));
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%10, %11, %12, %13};\n"
+                            : "=f"(acc[4]), "=f"(acc[(4) + 1]), "=f"(acc[(4) + 2]), "=f"(acc[(4) + 3])
+                            : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[2]), "r"(b_frag[(2) + 1]), "f"(0.0f), "f"(0.0f), "f"(0.0f), "f"(0.0f));
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(a_frag[0]), "=r"(a_frag[1]), "=r"(a_frag[2]), "=r"(a_frag[3])
+                            : "r"(smem_kd_addr + prep_stage * 41984 + (unsigned int)((lane / 16 / 8 * 256 + (pair_row_base + lane % 16) * 8 + (lane / 16 % 8 * 16 ^ (pair_row_base + lane % 16 & 7) << 4) / 16 ^ 2) * 16))
+                            : "memory");
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(b_frag[0]), "=r"(b_frag[1]), "=r"(b_frag[2]), "=r"(b_frag[3])
+                            : "r"(smem_ki_addr + prep_stage * 41984 + (unsigned int)(((lane % 16 / 8 / 8 * 256 + (pair_col_base + 8 * (lane / 16) + lane % 8) * 8 + (lane % 16 / 8 % 8 * 16 ^ (pair_col_base + 8 * (lane / 16) + lane % 8 & 7) << 4) / 16 + 256 ^ 2) - 256) * 16))
+                            : "memory");
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                            : "+f"(acc[0]), "+f"(acc[1]), "+f"(acc[2]), "+f"(acc[3])
+                            : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[0]), "r"(b_frag[1]));
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                            : "+f"(acc[4]), "+f"(acc[(4) + 1]), "+f"(acc[(4) + 2]), "+f"(acc[(4) + 3])
+                            : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[2]), "r"(b_frag[(2) + 1]));
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(a_frag[0]), "=r"(a_frag[1]), "=r"(a_frag[2]), "=r"(a_frag[3])
+                            : "r"(smem_kd_addr + prep_stage * 41984 + (unsigned int)((lane / 16 / 8 * 256 + (pair_row_base + lane % 16) * 8 + (lane / 16 % 8 * 16 ^ (pair_row_base + lane % 16 & 7) << 4) / 16 ^ 2 ^ 6) * 16))
+                            : "memory");
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(b_frag[0]), "=r"(b_frag[1]), "=r"(b_frag[2]), "=r"(b_frag[3])
+                            : "r"(smem_ki_addr + prep_stage * 41984 + (unsigned int)((((lane % 16 / 8 / 8 * 256 + (pair_col_base + 8 * (lane / 16) + lane % 8) * 8 + (lane % 16 / 8 % 8 * 16 ^ (pair_col_base + 8 * (lane / 16) + lane % 8 & 7) << 4) / 16 + 256 ^ 2) - 256 + 256 ^ 6) - 256) * 16))
+                            : "memory");
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                            : "+f"(acc[0]), "+f"(acc[1]), "+f"(acc[2]), "+f"(acc[3])
+                            : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[0]), "r"(b_frag[1]));
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                            : "+f"(acc[4]), "+f"(acc[(4) + 1]), "+f"(acc[(4) + 2]), "+f"(acc[(4) + 3])
+                            : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[2]), "r"(b_frag[(2) + 1]));
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(a_frag[0]), "=r"(a_frag[1]), "=r"(a_frag[2]), "=r"(a_frag[3])
+                            : "r"(smem_kd_addr + prep_stage * 41984 + (unsigned int)((lane / 16 / 8 * 256 + (pair_row_base + lane % 16) * 8 + (lane / 16 % 8 * 16 ^ (pair_row_base + lane % 16 & 7) << 4) / 16 ^ 2 ^ 6 ^ 2) * 16))
+                            : "memory");
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(b_frag[0]), "=r"(b_frag[1]), "=r"(b_frag[2]), "=r"(b_frag[3])
+                            : "r"(smem_ki_addr + prep_stage * 41984 + (unsigned int)(((((lane % 16 / 8 / 8 * 256 + (pair_col_base + 8 * (lane / 16) + lane % 8) * 8 + (lane % 16 / 8 % 8 * 16 ^ (pair_col_base + 8 * (lane / 16) + lane % 8 & 7) << 4) / 16 + 256 ^ 2) - 256 + 256 ^ 6) - 256 + 256 ^ 2) - 256) * 16))
+                            : "memory");
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                            : "+f"(acc[0]), "+f"(acc[1]), "+f"(acc[2]), "+f"(acc[3])
+                            : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[0]), "r"(b_frag[1]));
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                            : "+f"(acc[4]), "+f"(acc[(4) + 1]), "+f"(acc[(4) + 2]), "+f"(acc[(4) + 3])
+                            : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[2]), "r"(b_frag[(2) + 1]));
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(a_frag[0]), "=r"(a_frag[1]), "=r"(a_frag[2]), "=r"(a_frag[3])
+                            : "r"(smem_kd_addr + prep_stage * 41984 + (unsigned int)(((lane / 16 / 8 * 256 + (pair_row_base + lane % 16) * 8 + (lane / 16 % 8 * 16 ^ (pair_row_base + lane % 16 & 7) << 4) / 16 ^ 2 ^ 6 ^ 2 ^ 6) + 256) * 16))
+                            : "memory");
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(b_frag[0]), "=r"(b_frag[1]), "=r"(b_frag[2]), "=r"(b_frag[3])
+                            : "r"(smem_ki_addr + prep_stage * 41984 + (unsigned int)((((((lane % 16 / 8 / 8 * 256 + (pair_col_base + 8 * (lane / 16) + lane % 8) * 8 + (lane % 16 / 8 % 8 * 16 ^ (pair_col_base + 8 * (lane / 16) + lane % 8 & 7) << 4) / 16 + 256 ^ 2) - 256 + 256 ^ 6) - 256 + 256 ^ 2) - 256 + 256 ^ 6) + 256 - 256) * 16))
+                            : "memory");
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                            : "+f"(acc[0]), "+f"(acc[1]), "+f"(acc[2]), "+f"(acc[3])
+                            : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[0]), "r"(b_frag[1]));
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                            : "+f"(acc[4]), "+f"(acc[(4) + 1]), "+f"(acc[(4) + 2]), "+f"(acc[(4) + 3])
+                            : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[2]), "r"(b_frag[(2) + 1]));
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(a_frag[0]), "=r"(a_frag[1]), "=r"(a_frag[2]), "=r"(a_frag[3])
+                            : "r"(smem_kd_addr + prep_stage * 41984 + (unsigned int)(((lane / 16 / 8 * 256 + (pair_row_base + lane % 16) * 8 + (lane / 16 % 8 * 16 ^ (pair_row_base + lane % 16 & 7) << 4) / 16 ^ 2 ^ 6 ^ 2 ^ 6) + 256 ^ 2) * 16))
+                            : "memory");
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(b_frag[0]), "=r"(b_frag[1]), "=r"(b_frag[2]), "=r"(b_frag[3])
+                            : "r"(smem_ki_addr + prep_stage * 41984 + (unsigned int)(((((((lane % 16 / 8 / 8 * 256 + (pair_col_base + 8 * (lane / 16) + lane % 8) * 8 + (lane % 16 / 8 % 8 * 16 ^ (pair_col_base + 8 * (lane / 16) + lane % 8 & 7) << 4) / 16 + 256 ^ 2) - 256 + 256 ^ 6) - 256 + 256 ^ 2) - 256 + 256 ^ 6) + 256 - 256 + 256 ^ 2) - 256) * 16))
+                            : "memory");
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                            : "+f"(acc[0]), "+f"(acc[1]), "+f"(acc[2]), "+f"(acc[3])
+                            : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[0]), "r"(b_frag[1]));
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                            : "+f"(acc[4]), "+f"(acc[(4) + 1]), "+f"(acc[(4) + 2]), "+f"(acc[(4) + 3])
+                            : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[2]), "r"(b_frag[(2) + 1]));
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(a_frag[0]), "=r"(a_frag[1]), "=r"(a_frag[2]), "=r"(a_frag[3])
+                            : "r"(smem_kd_addr + prep_stage * 41984 + (unsigned int)(((lane / 16 / 8 * 256 + (pair_row_base + lane % 16) * 8 + (lane / 16 % 8 * 16 ^ (pair_row_base + lane % 16 & 7) << 4) / 16 ^ 2 ^ 6 ^ 2 ^ 6) + 256 ^ 2 ^ 6) * 16))
+                            : "memory");
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(b_frag[0]), "=r"(b_frag[1]), "=r"(b_frag[2]), "=r"(b_frag[3])
+                            : "r"(smem_ki_addr + prep_stage * 41984 + (unsigned int)((((((((lane % 16 / 8 / 8 * 256 + (pair_col_base + 8 * (lane / 16) + lane % 8) * 8 + (lane % 16 / 8 % 8 * 16 ^ (pair_col_base + 8 * (lane / 16) + lane % 8 & 7) << 4) / 16 + 256 ^ 2) - 256 + 256 ^ 6) - 256 + 256 ^ 2) - 256 + 256 ^ 6) + 256 - 256 + 256 ^ 2) - 256 + 256 ^ 6) - 256) * 16))
+                            : "memory");
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                            : "+f"(acc[0]), "+f"(acc[1]), "+f"(acc[2]), "+f"(acc[3])
+                            : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[0]), "r"(b_frag[1]));
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                            : "+f"(acc[4]), "+f"(acc[(4) + 1]), "+f"(acc[(4) + 2]), "+f"(acc[(4) + 3])
+                            : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[2]), "r"(b_frag[(2) + 1]));
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(a_frag[0]), "=r"(a_frag[1]), "=r"(a_frag[2]), "=r"(a_frag[3])
+                            : "r"(smem_kd_addr + prep_stage * 41984 + (unsigned int)(((lane / 16 / 8 * 256 + (pair_row_base + lane % 16) * 8 + (lane / 16 % 8 * 16 ^ (pair_row_base + lane % 16 & 7) << 4) / 16 ^ 2 ^ 6 ^ 2 ^ 6) + 256 ^ 2 ^ 6 ^ 2) * 16))
+                            : "memory");
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(b_frag[0]), "=r"(b_frag[1]), "=r"(b_frag[2]), "=r"(b_frag[3])
+                            : "r"(smem_ki_addr + prep_stage * 41984 + (unsigned int)(((((((((lane % 16 / 8 / 8 * 256 + (pair_col_base + 8 * (lane / 16) + lane % 8) * 8 + (lane % 16 / 8 % 8 * 16 ^ (pair_col_base + 8 * (lane / 16) + lane % 8 & 7) << 4) / 16 + 256 ^ 2) - 256 + 256 ^ 6) - 256 + 256 ^ 2) - 256 + 256 ^ 6) + 256 - 256 + 256 ^ 2) - 256 + 256 ^ 6) - 256 + 256 ^ 2) - 256) * 16))
+                            : "memory");
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                            : "+f"(acc[0]), "+f"(acc[1]), "+f"(acc[2]), "+f"(acc[3])
+                            : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[0]), "r"(b_frag[1]));
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                            : "+f"(acc[4]), "+f"(acc[(4) + 1]), "+f"(acc[(4) + 2]), "+f"(acc[(4) + 3])
+                            : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[2]), "r"(b_frag[(2) + 1]));
+                        int row0 = pair_row_base + lane / 4;
+                        int row1 = row0 + 8;
+                        int col0 = pair_col_base + lane % 4 * 2;
+                        float beta0 = 0.0f;
+                        float beta1 = 0.0f;
+                        {
+                            beta0 = smem_prep_beta_all[stage_f32 + row0];
+                            beta1 = smem_prep_beta_all[stage_f32 + row1];
+                        }
+                        float seed[8];
+                        seed[0] = 0.0f;
+                        seed[1] = 0.0f;
+                        seed[2] = 0.0f;
+                        seed[3] = 0.0f;
+                        seed[4] = 0.0f;
+                        seed[5] = 0.0f;
+                        seed[6] = 0.0f;
+                        seed[7] = 0.0f;
+                        if (row0 > col0) {
+                            seed[0] = acc[0] * beta0;
+                        }
+                        if (row0 > col0 + 1) {
+                            seed[1] = acc[1] * beta0;
+                        }
+                        if (row1 > col0) {
+                            seed[2] = acc[2] * beta1;
+                        }
+                        if (row1 > col0 + 1) {
+                            seed[3] = acc[3] * beta1;
+                        }
+                        if (row0 > col0 + 8) {
+                            seed[4] = acc[4] * beta0;
+                        }
+                        if (row0 > col0 + 9) {
+                            seed[5] = acc[5] * beta0;
+                        }
+                        if (row1 > col0 + 8) {
+                            seed[6] = acc[6] * beta1;
+                        }
+                        if (row1 > col0 + 9) {
+                            seed[7] = acc[7] * beta1;
+                        }
+                        unsigned int seed_packed[4];
+                        #pragma unroll
+                        for (int _lp = 0; _lp < 4; _lp++) {
+                            __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(seed[_lp*2 + 0], seed[_lp*2+1 + 0]));
+                            seed_packed[_lp] = *(uint32_t*)&_bf2;
+                        }
+                        int seed_lane_row = lane % 16;
+                        int seed_lane_col = lane / 16 * 8;
+                        int byte_off = (int)prep_stage * 41984 + (pair_row_base + seed_lane_row) * 128 + (pair_col_base + seed_lane_col) * 2;
+                        int swizzled_off = byte_off ^ (byte_off >> 7 & 7) << 4;
+                        int seed_addr = smem_inv_work_addr + (unsigned int)swizzled_off;
+                        uint32_t _stmatrix_addr_2 = static_cast<uint32_t>((unsigned long long)seed_addr);
+                        asm volatile("stmatrix.sync.aligned.m8n8.x4.shared.b16 [%0], {%1, %2, %3, %4};\n"
+                            :: "r"(_stmatrix_addr_2), "r"(*reinterpret_cast<const uint32_t*>(&seed_packed[0])), "r"(*reinterpret_cast<const uint32_t*>(&seed_packed[1])), "r"(*reinterpret_cast<const uint32_t*>(&seed_packed[2])), "r"(*reinterpret_cast<const uint32_t*>(&seed_packed[3]))
+                            : "memory");
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(a_frag[0]), "=r"(a_frag[1]), "=r"(a_frag[2]), "=r"(a_frag[3])
+                            : "r"(smem_qd_addr + prep_stage * 41984 + (unsigned int)((lane / 16 / 8 * 256 + (pair_row_base + lane % 16) * 8 + (lane / 16 % 8 * 16 ^ (pair_row_base + lane % 16 & 7) << 4) / 16) * 16))
+                            : "memory");
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(b_frag[0]), "=r"(b_frag[1]), "=r"(b_frag[2]), "=r"(b_frag[3])
+                            : "r"(smem_ki_addr + prep_stage * 41984 + (unsigned int)((lane % 16 / 8 / 8 * 256 + (pair_col_base + 8 * (lane / 16) + lane % 8) * 8 + (lane % 16 / 8 % 8 * 16 ^ (pair_col_base + 8 * (lane / 16) + lane % 8 & 7) << 4) / 16) * 16))
+                            : "memory");
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%10, %11, %12, %13};\n"
+                            : "=f"(acc[0]), "=f"(acc[1]), "=f"(acc[2]), "=f"(acc[3])
+                            : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[0]), "r"(b_frag[1]), "f"(0.0f), "f"(0.0f), "f"(0.0f), "f"(0.0f));
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%10, %11, %12, %13};\n"
+                            : "=f"(acc[4]), "=f"(acc[(4) + 1]), "=f"(acc[(4) + 2]), "=f"(acc[(4) + 3])
+                            : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[2]), "r"(b_frag[(2) + 1]), "f"(0.0f), "f"(0.0f), "f"(0.0f), "f"(0.0f));
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(a_frag[0]), "=r"(a_frag[1]), "=r"(a_frag[2]), "=r"(a_frag[3])
+                            : "r"(smem_qd_addr + prep_stage * 41984 + (unsigned int)((lane / 16 / 8 * 256 + (pair_row_base + lane % 16) * 8 + (lane / 16 % 8 * 16 ^ (pair_row_base + lane % 16 & 7) << 4) / 16 ^ 2) * 16))
+                            : "memory");
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(b_frag[0]), "=r"(b_frag[1]), "=r"(b_frag[2]), "=r"(b_frag[3])
+                            : "r"(smem_ki_addr + prep_stage * 41984 + (unsigned int)(((lane % 16 / 8 / 8 * 256 + (pair_col_base + 8 * (lane / 16) + lane % 8) * 8 + (lane % 16 / 8 % 8 * 16 ^ (pair_col_base + 8 * (lane / 16) + lane % 8 & 7) << 4) / 16 + 256 ^ 2) - 256) * 16))
+                            : "memory");
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                            : "+f"(acc[0]), "+f"(acc[1]), "+f"(acc[2]), "+f"(acc[3])
+                            : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[0]), "r"(b_frag[1]));
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                            : "+f"(acc[4]), "+f"(acc[(4) + 1]), "+f"(acc[(4) + 2]), "+f"(acc[(4) + 3])
+                            : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[2]), "r"(b_frag[(2) + 1]));
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(a_frag[0]), "=r"(a_frag[1]), "=r"(a_frag[2]), "=r"(a_frag[3])
+                            : "r"(smem_qd_addr + prep_stage * 41984 + (unsigned int)((lane / 16 / 8 * 256 + (pair_row_base + lane % 16) * 8 + (lane / 16 % 8 * 16 ^ (pair_row_base + lane % 16 & 7) << 4) / 16 ^ 2 ^ 6) * 16))
+                            : "memory");
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(b_frag[0]), "=r"(b_frag[1]), "=r"(b_frag[2]), "=r"(b_frag[3])
+                            : "r"(smem_ki_addr + prep_stage * 41984 + (unsigned int)((((lane % 16 / 8 / 8 * 256 + (pair_col_base + 8 * (lane / 16) + lane % 8) * 8 + (lane % 16 / 8 % 8 * 16 ^ (pair_col_base + 8 * (lane / 16) + lane % 8 & 7) << 4) / 16 + 256 ^ 2) - 256 + 256 ^ 6) - 256) * 16))
+                            : "memory");
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                            : "+f"(acc[0]), "+f"(acc[1]), "+f"(acc[2]), "+f"(acc[3])
+                            : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[0]), "r"(b_frag[1]));
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                            : "+f"(acc[4]), "+f"(acc[(4) + 1]), "+f"(acc[(4) + 2]), "+f"(acc[(4) + 3])
+                            : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[2]), "r"(b_frag[(2) + 1]));
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(a_frag[0]), "=r"(a_frag[1]), "=r"(a_frag[2]), "=r"(a_frag[3])
+                            : "r"(smem_qd_addr + prep_stage * 41984 + (unsigned int)((lane / 16 / 8 * 256 + (pair_row_base + lane % 16) * 8 + (lane / 16 % 8 * 16 ^ (pair_row_base + lane % 16 & 7) << 4) / 16 ^ 2 ^ 6 ^ 2) * 16))
+                            : "memory");
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(b_frag[0]), "=r"(b_frag[1]), "=r"(b_frag[2]), "=r"(b_frag[3])
+                            : "r"(smem_ki_addr + prep_stage * 41984 + (unsigned int)(((((lane % 16 / 8 / 8 * 256 + (pair_col_base + 8 * (lane / 16) + lane % 8) * 8 + (lane % 16 / 8 % 8 * 16 ^ (pair_col_base + 8 * (lane / 16) + lane % 8 & 7) << 4) / 16 + 256 ^ 2) - 256 + 256 ^ 6) - 256 + 256 ^ 2) - 256) * 16))
+                            : "memory");
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                            : "+f"(acc[0]), "+f"(acc[1]), "+f"(acc[2]), "+f"(acc[3])
+                            : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[0]), "r"(b_frag[1]));
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                            : "+f"(acc[4]), "+f"(acc[(4) + 1]), "+f"(acc[(4) + 2]), "+f"(acc[(4) + 3])
+                            : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[2]), "r"(b_frag[(2) + 1]));
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(a_frag[0]), "=r"(a_frag[1]), "=r"(a_frag[2]), "=r"(a_frag[3])
+                            : "r"(smem_qd_addr + prep_stage * 41984 + (unsigned int)(((lane / 16 / 8 * 256 + (pair_row_base + lane % 16) * 8 + (lane / 16 % 8 * 16 ^ (pair_row_base + lane % 16 & 7) << 4) / 16 ^ 2 ^ 6 ^ 2 ^ 6) + 256) * 16))
+                            : "memory");
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(b_frag[0]), "=r"(b_frag[1]), "=r"(b_frag[2]), "=r"(b_frag[3])
+                            : "r"(smem_ki_addr + prep_stage * 41984 + (unsigned int)((((((lane % 16 / 8 / 8 * 256 + (pair_col_base + 8 * (lane / 16) + lane % 8) * 8 + (lane % 16 / 8 % 8 * 16 ^ (pair_col_base + 8 * (lane / 16) + lane % 8 & 7) << 4) / 16 + 256 ^ 2) - 256 + 256 ^ 6) - 256 + 256 ^ 2) - 256 + 256 ^ 6) + 256 - 256) * 16))
+                            : "memory");
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                            : "+f"(acc[0]), "+f"(acc[1]), "+f"(acc[2]), "+f"(acc[3])
+                            : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[0]), "r"(b_frag[1]));
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                            : "+f"(acc[4]), "+f"(acc[(4) + 1]), "+f"(acc[(4) + 2]), "+f"(acc[(4) + 3])
+                            : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[2]), "r"(b_frag[(2) + 1]));
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(a_frag[0]), "=r"(a_frag[1]), "=r"(a_frag[2]), "=r"(a_frag[3])
+                            : "r"(smem_qd_addr + prep_stage * 41984 + (unsigned int)(((lane / 16 / 8 * 256 + (pair_row_base + lane % 16) * 8 + (lane / 16 % 8 * 16 ^ (pair_row_base + lane % 16 & 7) << 4) / 16 ^ 2 ^ 6 ^ 2 ^ 6) + 256 ^ 2) * 16))
+                            : "memory");
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(b_frag[0]), "=r"(b_frag[1]), "=r"(b_frag[2]), "=r"(b_frag[3])
+                            : "r"(smem_ki_addr + prep_stage * 41984 + (unsigned int)(((((((lane % 16 / 8 / 8 * 256 + (pair_col_base + 8 * (lane / 16) + lane % 8) * 8 + (lane % 16 / 8 % 8 * 16 ^ (pair_col_base + 8 * (lane / 16) + lane % 8 & 7) << 4) / 16 + 256 ^ 2) - 256 + 256 ^ 6) - 256 + 256 ^ 2) - 256 + 256 ^ 6) + 256 - 256 + 256 ^ 2) - 256) * 16))
+                            : "memory");
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                            : "+f"(acc[0]), "+f"(acc[1]), "+f"(acc[2]), "+f"(acc[3])
+                            : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[0]), "r"(b_frag[1]));
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                            : "+f"(acc[4]), "+f"(acc[(4) + 1]), "+f"(acc[(4) + 2]), "+f"(acc[(4) + 3])
+                            : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[2]), "r"(b_frag[(2) + 1]));
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(a_frag[0]), "=r"(a_frag[1]), "=r"(a_frag[2]), "=r"(a_frag[3])
+                            : "r"(smem_qd_addr + prep_stage * 41984 + (unsigned int)(((lane / 16 / 8 * 256 + (pair_row_base + lane % 16) * 8 + (lane / 16 % 8 * 16 ^ (pair_row_base + lane % 16 & 7) << 4) / 16 ^ 2 ^ 6 ^ 2 ^ 6) + 256 ^ 2 ^ 6) * 16))
+                            : "memory");
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(b_frag[0]), "=r"(b_frag[1]), "=r"(b_frag[2]), "=r"(b_frag[3])
+                            : "r"(smem_ki_addr + prep_stage * 41984 + (unsigned int)((((((((lane % 16 / 8 / 8 * 256 + (pair_col_base + 8 * (lane / 16) + lane % 8) * 8 + (lane % 16 / 8 % 8 * 16 ^ (pair_col_base + 8 * (lane / 16) + lane % 8 & 7) << 4) / 16 + 256 ^ 2) - 256 + 256 ^ 6) - 256 + 256 ^ 2) - 256 + 256 ^ 6) + 256 - 256 + 256 ^ 2) - 256 + 256 ^ 6) - 256) * 16))
+                            : "memory");
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                            : "+f"(acc[0]), "+f"(acc[1]), "+f"(acc[2]), "+f"(acc[3])
+                            : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[0]), "r"(b_frag[1]));
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                            : "+f"(acc[4]), "+f"(acc[(4) + 1]), "+f"(acc[(4) + 2]), "+f"(acc[(4) + 3])
+                            : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[2]), "r"(b_frag[(2) + 1]));
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(a_frag[0]), "=r"(a_frag[1]), "=r"(a_frag[2]), "=r"(a_frag[3])
+                            : "r"(smem_qd_addr + prep_stage * 41984 + (unsigned int)(((lane / 16 / 8 * 256 + (pair_row_base + lane % 16) * 8 + (lane / 16 % 8 * 16 ^ (pair_row_base + lane % 16 & 7) << 4) / 16 ^ 2 ^ 6 ^ 2 ^ 6) + 256 ^ 2 ^ 6 ^ 2) * 16))
+                            : "memory");
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(b_frag[0]), "=r"(b_frag[1]), "=r"(b_frag[2]), "=r"(b_frag[3])
+                            : "r"(smem_ki_addr + prep_stage * 41984 + (unsigned int)(((((((((lane % 16 / 8 / 8 * 256 + (pair_col_base + 8 * (lane / 16) + lane % 8) * 8 + (lane % 16 / 8 % 8 * 16 ^ (pair_col_base + 8 * (lane / 16) + lane % 8 & 7) << 4) / 16 + 256 ^ 2) - 256 + 256 ^ 6) - 256 + 256 ^ 2) - 256 + 256 ^ 6) + 256 - 256 + 256 ^ 2) - 256 + 256 ^ 6) - 256 + 256 ^ 2) - 256) * 16))
+                            : "memory");
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                            : "+f"(acc[0]), "+f"(acc[1]), "+f"(acc[2]), "+f"(acc[3])
+                            : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[0]), "r"(b_frag[1]));
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                            : "+f"(acc[4]), "+f"(acc[(4) + 1]), "+f"(acc[(4) + 2]), "+f"(acc[(4) + 3])
+                            : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[2]), "r"(b_frag[(2) + 1]));
+                    } else {
+                        acc[0] = 0.0f;
+                        acc[1] = 0.0f;
+                        acc[2] = 0.0f;
+                        acc[3] = 0.0f;
+                        acc[4] = 0.0f;
+                        acc[5] = 0.0f;
+                        acc[6] = 0.0f;
+                        acc[7] = 0.0f;
+                    }
+                    int row0_1 = pair_row_base + lane / 4;
+                    int row1_1 = row0_1 + 8;
+                    int col0_1 = pair_col_base + lane % 4 * 2;
+                    float mqk[8];
+                    mqk[0] = 0.0f;
+                    mqk[1] = 0.0f;
+                    mqk[2] = 0.0f;
+                    mqk[3] = 0.0f;
+                    mqk[4] = 0.0f;
+                    mqk[5] = 0.0f;
+                    mqk[6] = 0.0f;
+                    mqk[7] = 0.0f;
+                    if (row0_1 >= col0_1) {
+                        mqk[0] = acc[0];
+                    }
+                    if (row0_1 >= col0_1 + 1) {
+                        mqk[1] = acc[1];
+                    }
+                    if (row1_1 >= col0_1) {
+                        mqk[2] = acc[2];
+                    }
+                    if (row1_1 >= col0_1 + 1) {
+                        mqk[3] = acc[3];
+                    }
+                    if (row0_1 >= col0_1 + 8) {
+                        mqk[4] = acc[4];
+                    }
+                    if (row0_1 >= col0_1 + 9) {
+                        mqk[5] = acc[5];
+                    }
+                    if (row1_1 >= col0_1 + 8) {
+                        mqk[6] = acc[6];
+                    }
+                    if (row1_1 >= col0_1 + 9) {
+                        mqk[7] = acc[7];
+                    }
+                    unsigned int mqk_packed[4];
+                    #pragma unroll
+                    for (int _lp = 0; _lp < 4; _lp++) {
+                        __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(mqk[_lp*2 + 0], mqk[_lp*2+1 + 0]));
+                        mqk_packed[_lp] = *(uint32_t*)&_bf2;
+                    }
+                    #pragma unroll
+                    for (int publish_pair = 0; publish_pair < 2; publish_pair++) {
+                        int publish_row = pair_col_base + publish_pair * 8 + (lane & 7);
+                        int publish_col = 128 + pair_row_base + lane / 8 * 8;
+                        uint32_t _stmatrix_addr_3 = static_cast<uint32_t>((unsigned long long)(smem_final_trans_addr + prep_stage * 41984 + (unsigned int)(publish_col / 64 * 4096 + publish_row * 128 + publish_col % 64 * 2 ^ (publish_col / 64 * 4096 + publish_row * 128 + publish_col % 64 * 2 >> 7 & 7) << 4)));
+                        asm volatile("stmatrix.sync.aligned.m8n8.x2.trans.shared.b16 [%0], {%1, %2};\n"
+                            :: "r"(_stmatrix_addr_3), "r"(*reinterpret_cast<const uint32_t*>(&mqk_packed[publish_pair * 2])), "r"(*reinterpret_cast<const uint32_t*>(&mqk_packed[publish_pair * 2 + 1]))
+                            : "memory");
+                    }
+                    asm volatile("barrier.sync %0, 128;" :: "r"(10 + prep_instance) : "memory");
+                }
+                long long tape_scaled_base = 0;
+                {
+                    long long chunk_global_scaled = cu_chunk_offsets[seq_idx_4] + (long long)chunk_global_local_2;
+                    tape_scaled_base = (chunk_global_scaled * (long long)num_heads + (long long)head_idx_4) * 32 * 128;
+                }
+                if (prep_tid < 128) {
+                    float total_log2_1 = smem_gt_prefix_all[stage_f32 + prep_tid];
+                    float _exp2_3 = approx_exp2(total_log2_1);
+                    smem_gt_all[stage_f32 + prep_tid] = _exp2_3;
+                }
+                {
+                    if (prep_local_warp >= 2) {
+                        int stage_f32_0 = prep_stage * 10496;
+                        float restore_scale = smem_restore_factor_all[stage_f32_0 + 128];
+                        float restore_factor[8];
+                        int restore_segment = lane & 15;
+                        #pragma unroll
+                        for (int restore_elem = 0; restore_elem < 8; restore_elem++) {
+                            int restore_col = restore_segment * 8 + restore_elem;
+                            restore_factor[restore_elem] = smem_restore_factor_all[stage_f32_0 + restore_col];
+                        }
+                        #pragma unroll 1
+                        for (int restore_pass = 0; restore_pass < 6; restore_pass++) {
+                            int restore_row = 8 + (prep_local_warp - 2) * 12 + restore_pass * 2 + (lane >> 4);
+                            float restore_kr_values[8];
+                            {
+                                float restore_qd_values[8];
+                                float restore_kd_values[8];
+                                float restore_ki_values[8];
+                                unsigned int packed_4[4];
+                                asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                                    : "=r"(*reinterpret_cast<uint32_t*>(&packed_4[0])), "=r"(*reinterpret_cast<uint32_t*>(&packed_4[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&packed_4[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&packed_4[(0) + 3]))
+                                    : "r"((smem_qd_addr + prep_stage * 41984 + (unsigned int)(restore_segment * 8 / 64 * 4096 + restore_row * 128 + restore_segment * 8 % 64 * 2 ^ (restore_segment * 8 / 64 * 4096 + restore_row * 128 + restore_segment * 8 % 64 * 2 >> 7 & 7) << 4))));
+                                float packed_f32_3[8];
+                                #pragma unroll
+                                for (int _pair = 0; _pair < 4; _pair++) {
+                                    asm volatile(
+                                        "{\n\t"
+                                        "shl.b32 %0, %2, 16;\n\t"
+                                        "and.b32 %1, %2, 0xffff0000;\n\t"
+                                        "}\n"
+                                        : "=f"((&packed_f32_3[_pair * 2])[0]), "=f"((&packed_f32_3[_pair * 2])[1])
+                                        : "r"(packed_4[_pair]));
+                                }
+                                #pragma unroll
+                                for (int value_idx_4 = 0; value_idx_4 < 8; value_idx_4++) {
+                                    restore_qd_values[value_idx_4] = packed_f32_3[value_idx_4];
+                                }
+                                unsigned int packed_0_1[4];
+                                asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                                    : "=r"(*reinterpret_cast<uint32_t*>(&packed_0_1[0])), "=r"(*reinterpret_cast<uint32_t*>(&packed_0_1[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&packed_0_1[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&packed_0_1[(0) + 3]))
+                                    : "r"((smem_ki_addr + prep_stage * 41984 + (unsigned int)(restore_segment * 8 / 64 * 4096 + restore_row * 128 + restore_segment * 8 % 64 * 2 ^ (restore_segment * 8 / 64 * 4096 + restore_row * 128 + restore_segment * 8 % 64 * 2 >> 7 & 7) << 4))));
+                                float packed_0_f32_1[8];
+                                #pragma unroll
+                                for (int _pair = 0; _pair < 4; _pair++) {
+                                    asm volatile(
+                                        "{\n\t"
+                                        "shl.b32 %0, %2, 16;\n\t"
+                                        "and.b32 %1, %2, 0xffff0000;\n\t"
+                                        "}\n"
+                                        : "=f"((&packed_0_f32_1[_pair * 2])[0]), "=f"((&packed_0_f32_1[_pair * 2])[1])
+                                        : "r"(packed_0_1[_pair]));
+                                }
+                                #pragma unroll
+                                for (int value_idx_5 = 0; value_idx_5 < 8; value_idx_5++) {
+                                    restore_ki_values[value_idx_5] = packed_0_f32_1[value_idx_5];
+                                }
+                                if (STORE_BACKWARD_TAPE != 0 && owned_chunk_2 != 0) {
+                                    unsigned int packed_1_2[4];
+                                    asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                                        : "=r"(*reinterpret_cast<uint32_t*>(&packed_1_2[0])), "=r"(*reinterpret_cast<uint32_t*>(&packed_1_2[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&packed_1_2[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&packed_1_2[(0) + 3]))
+                                        : "r"((smem_kd_addr + prep_stage * 41984 + (unsigned int)(restore_segment * 8 / 64 * 4096 + restore_row * 128 + restore_segment * 8 % 64 * 2 ^ (restore_segment * 8 / 64 * 4096 + restore_row * 128 + restore_segment * 8 % 64 * 2 >> 7 & 7) << 4))));
+                                    float packed_1_f32[8];
+                                    #pragma unroll
+                                    for (int _pair = 0; _pair < 4; _pair++) {
+                                        asm volatile(
+                                            "{\n\t"
+                                            "shl.b32 %0, %2, 16;\n\t"
+                                            "and.b32 %1, %2, 0xffff0000;\n\t"
+                                            "}\n"
+                                            : "=f"((&packed_1_f32[_pair * 2])[0]), "=f"((&packed_1_f32[_pair * 2])[1])
+                                            : "r"(packed_1_2[_pair]));
+                                    }
+                                    #pragma unroll
+                                    for (int value_idx_6 = 0; value_idx_6 < 8; value_idx_6++) {
+                                        restore_kd_values[value_idx_6] = packed_1_f32[value_idx_6];
+                                    }
+                                    long long tape_scaled_index = tape_scaled_base + (long long)restore_row * 128 + (long long)(restore_segment * 8);
+                                    {
+                                        __nv_bfloat162 _pk[4];
+                                        _pk[0] = __floats2bfloat162_rn(restore_qd_values[0 + 0], restore_qd_values[0 + 1]);
+                                        _pk[1] = __floats2bfloat162_rn(restore_qd_values[0 + 2], restore_qd_values[0 + 3]);
+                                        _pk[2] = __floats2bfloat162_rn(restore_qd_values[0 + 4], restore_qd_values[0 + 5]);
+                                        _pk[3] = __floats2bfloat162_rn(restore_qd_values[0 + 6], restore_qd_values[0 + 7]);
+                                        *reinterpret_cast<uint4*>(&((__nv_bfloat16*)(tape_qd + tape_scaled_index))[0]) = *reinterpret_cast<uint4*>(&_pk[0]);
+                                    }
+                                    {
+                                        __nv_bfloat162 _pk[4];
+                                        _pk[0] = __floats2bfloat162_rn(restore_kd_values[0 + 0], restore_kd_values[0 + 1]);
+                                        _pk[1] = __floats2bfloat162_rn(restore_kd_values[0 + 2], restore_kd_values[0 + 3]);
+                                        _pk[2] = __floats2bfloat162_rn(restore_kd_values[0 + 4], restore_kd_values[0 + 5]);
+                                        _pk[3] = __floats2bfloat162_rn(restore_kd_values[0 + 6], restore_kd_values[0 + 7]);
+                                        *reinterpret_cast<uint4*>(&((__nv_bfloat16*)(tape_kd + tape_scaled_index))[0]) = *reinterpret_cast<uint4*>(&_pk[0]);
+                                    }
+                                }
+                                const float2 _scale2_4 = {restore_scale, restore_scale};
+                                #pragma unroll
+                                for (int _ls = 0; _ls < 4; _ls++)
+                                    mul_f32x2_inplace(&reinterpret_cast<float2*>(restore_qd_values)[_ls], _scale2_4);
+                                #pragma unroll
+                                for (int restore_elem_1 = 0; restore_elem_1 < 8; restore_elem_1++) {
+                                    restore_kr_values[restore_elem_1] = restore_ki_values[restore_elem_1] * restore_factor[restore_elem_1];
+                                }
+                            }
+                            unsigned int packed_5[4];
+                            #pragma unroll
+                            for (int _lp = 0; _lp < 4; _lp++) {
+                                __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(restore_kr_values[_lp*2 + 0], restore_kr_values[_lp*2+1 + 0]));
+                                packed_5[_lp] = *(uint32_t*)&_bf2;
+                            }
+                            #pragma unroll
+                            for (int word_3 = 0; word_3 < 4; word_3++) {
+                                asm volatile("st.shared.b32 [%0], %1;" :: "r"((smem_kr_trans_addr + prep_stage * 41984 + (unsigned int)(restore_segment * 8 / 64 * 4096 + restore_row * 128 + restore_segment * 8 % 64 * 2 ^ (restore_segment * 8 / 64 * 4096 + restore_row * 128 + restore_segment * 8 % 64 * 2 >> 7 & 7) << 4)) + (unsigned int)(word_3 * 4)), "r"((packed_5[word_3])));
+                            }
+                        }
+                    } else if (prep_local_warp == 1) {
+                        int stage_f32_0_1 = prep_stage * 10496;
+                        float restore_scale_1 = smem_restore_factor_all[stage_f32_0_1 + 128];
+                        float restore_factor_1[8];
+                        int restore_segment_1 = lane & 15;
+                        #pragma unroll
+                        for (int restore_elem_2 = 0; restore_elem_2 < 8; restore_elem_2++) {
+                            int restore_col_1 = restore_segment_1 * 8 + restore_elem_2;
+                            restore_factor_1[restore_elem_2] = smem_restore_factor_all[stage_f32_0_1 + restore_col_1];
+                        }
+                        #pragma unroll 1
+                        for (int restore_pass_1 = 0; restore_pass_1 < 4; restore_pass_1++) {
+                            int restore_row_1 = restore_pass_1 * 2 + (lane >> 4);
+                            float restore_kr_values_1[8];
+                            {
+                                float restore_qd_values_1[8];
+                                float restore_kd_values_1[8];
+                                float restore_ki_values_1[8];
+                                unsigned int packed_6[4];
+                                asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                                    : "=r"(*reinterpret_cast<uint32_t*>(&packed_6[0])), "=r"(*reinterpret_cast<uint32_t*>(&packed_6[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&packed_6[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&packed_6[(0) + 3]))
+                                    : "r"((smem_qd_addr + prep_stage * 41984 + (unsigned int)(restore_segment_1 * 8 / 64 * 4096 + restore_row_1 * 128 + restore_segment_1 * 8 % 64 * 2 ^ (restore_segment_1 * 8 / 64 * 4096 + restore_row_1 * 128 + restore_segment_1 * 8 % 64 * 2 >> 7 & 7) << 4))));
+                                float packed_f32_4[8];
+                                #pragma unroll
+                                for (int _pair = 0; _pair < 4; _pair++) {
+                                    asm volatile(
+                                        "{\n\t"
+                                        "shl.b32 %0, %2, 16;\n\t"
+                                        "and.b32 %1, %2, 0xffff0000;\n\t"
+                                        "}\n"
+                                        : "=f"((&packed_f32_4[_pair * 2])[0]), "=f"((&packed_f32_4[_pair * 2])[1])
+                                        : "r"(packed_6[_pair]));
+                                }
+                                #pragma unroll
+                                for (int value_idx_7 = 0; value_idx_7 < 8; value_idx_7++) {
+                                    restore_qd_values_1[value_idx_7] = packed_f32_4[value_idx_7];
+                                }
+                                unsigned int packed_0_2[4];
+                                asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                                    : "=r"(*reinterpret_cast<uint32_t*>(&packed_0_2[0])), "=r"(*reinterpret_cast<uint32_t*>(&packed_0_2[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&packed_0_2[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&packed_0_2[(0) + 3]))
+                                    : "r"((smem_ki_addr + prep_stage * 41984 + (unsigned int)(restore_segment_1 * 8 / 64 * 4096 + restore_row_1 * 128 + restore_segment_1 * 8 % 64 * 2 ^ (restore_segment_1 * 8 / 64 * 4096 + restore_row_1 * 128 + restore_segment_1 * 8 % 64 * 2 >> 7 & 7) << 4))));
+                                float packed_0_f32_2[8];
+                                #pragma unroll
+                                for (int _pair = 0; _pair < 4; _pair++) {
+                                    asm volatile(
+                                        "{\n\t"
+                                        "shl.b32 %0, %2, 16;\n\t"
+                                        "and.b32 %1, %2, 0xffff0000;\n\t"
+                                        "}\n"
+                                        : "=f"((&packed_0_f32_2[_pair * 2])[0]), "=f"((&packed_0_f32_2[_pair * 2])[1])
+                                        : "r"(packed_0_2[_pair]));
+                                }
+                                #pragma unroll
+                                for (int value_idx_8 = 0; value_idx_8 < 8; value_idx_8++) {
+                                    restore_ki_values_1[value_idx_8] = packed_0_f32_2[value_idx_8];
+                                }
+                                if (STORE_BACKWARD_TAPE != 0 && owned_chunk_2 != 0) {
+                                    unsigned int packed_1_3[4];
+                                    asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                                        : "=r"(*reinterpret_cast<uint32_t*>(&packed_1_3[0])), "=r"(*reinterpret_cast<uint32_t*>(&packed_1_3[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&packed_1_3[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&packed_1_3[(0) + 3]))
+                                        : "r"((smem_kd_addr + prep_stage * 41984 + (unsigned int)(restore_segment_1 * 8 / 64 * 4096 + restore_row_1 * 128 + restore_segment_1 * 8 % 64 * 2 ^ (restore_segment_1 * 8 / 64 * 4096 + restore_row_1 * 128 + restore_segment_1 * 8 % 64 * 2 >> 7 & 7) << 4))));
+                                    float packed_1_f32_1[8];
+                                    #pragma unroll
+                                    for (int _pair = 0; _pair < 4; _pair++) {
+                                        asm volatile(
+                                            "{\n\t"
+                                            "shl.b32 %0, %2, 16;\n\t"
+                                            "and.b32 %1, %2, 0xffff0000;\n\t"
+                                            "}\n"
+                                            : "=f"((&packed_1_f32_1[_pair * 2])[0]), "=f"((&packed_1_f32_1[_pair * 2])[1])
+                                            : "r"(packed_1_3[_pair]));
+                                    }
+                                    #pragma unroll
+                                    for (int value_idx_9 = 0; value_idx_9 < 8; value_idx_9++) {
+                                        restore_kd_values_1[value_idx_9] = packed_1_f32_1[value_idx_9];
+                                    }
+                                    long long tape_scaled_index_1 = tape_scaled_base + (long long)restore_row_1 * 128 + (long long)(restore_segment_1 * 8);
+                                    {
+                                        __nv_bfloat162 _pk[4];
+                                        _pk[0] = __floats2bfloat162_rn(restore_qd_values_1[0 + 0], restore_qd_values_1[0 + 1]);
+                                        _pk[1] = __floats2bfloat162_rn(restore_qd_values_1[0 + 2], restore_qd_values_1[0 + 3]);
+                                        _pk[2] = __floats2bfloat162_rn(restore_qd_values_1[0 + 4], restore_qd_values_1[0 + 5]);
+                                        _pk[3] = __floats2bfloat162_rn(restore_qd_values_1[0 + 6], restore_qd_values_1[0 + 7]);
+                                        *reinterpret_cast<uint4*>(&((__nv_bfloat16*)(tape_qd + tape_scaled_index_1))[0]) = *reinterpret_cast<uint4*>(&_pk[0]);
+                                    }
+                                    {
+                                        __nv_bfloat162 _pk[4];
+                                        _pk[0] = __floats2bfloat162_rn(restore_kd_values_1[0 + 0], restore_kd_values_1[0 + 1]);
+                                        _pk[1] = __floats2bfloat162_rn(restore_kd_values_1[0 + 2], restore_kd_values_1[0 + 3]);
+                                        _pk[2] = __floats2bfloat162_rn(restore_kd_values_1[0 + 4], restore_kd_values_1[0 + 5]);
+                                        _pk[3] = __floats2bfloat162_rn(restore_kd_values_1[0 + 6], restore_kd_values_1[0 + 7]);
+                                        *reinterpret_cast<uint4*>(&((__nv_bfloat16*)(tape_kd + tape_scaled_index_1))[0]) = *reinterpret_cast<uint4*>(&_pk[0]);
+                                    }
+                                }
+                                const float2 _scale2_5 = {restore_scale_1, restore_scale_1};
+                                #pragma unroll
+                                for (int _ls = 0; _ls < 4; _ls++)
+                                    mul_f32x2_inplace(&reinterpret_cast<float2*>(restore_qd_values_1)[_ls], _scale2_5);
+                                #pragma unroll
+                                for (int restore_elem_3 = 0; restore_elem_3 < 8; restore_elem_3++) {
+                                    restore_kr_values_1[restore_elem_3] = restore_ki_values_1[restore_elem_3] * restore_factor_1[restore_elem_3];
+                                }
+                            }
+                            unsigned int packed_7[4];
+                            #pragma unroll
+                            for (int _lp = 0; _lp < 4; _lp++) {
+                                __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(restore_kr_values_1[_lp*2 + 0], restore_kr_values_1[_lp*2+1 + 0]));
+                                packed_7[_lp] = *(uint32_t*)&_bf2;
+                            }
+                            #pragma unroll
+                            for (int word_4 = 0; word_4 < 4; word_4++) {
+                                asm volatile("st.shared.b32 [%0], %1;" :: "r"((smem_kr_trans_addr + prep_stage * 41984 + (unsigned int)(restore_segment_1 * 8 / 64 * 4096 + restore_row_1 * 128 + restore_segment_1 * 8 % 64 * 2 ^ (restore_segment_1 * 8 / 64 * 4096 + restore_row_1 * 128 + restore_segment_1 * 8 % 64 * 2 >> 7 & 7) << 4)) + (unsigned int)(word_4 * 4)), "r"((packed_7[word_4])));
+                            }
+                        }
+                    }
+                }
+                if (prep_local_warp == 0) {
+                    int inverse_row = lane;
+                    int diag_block = inverse_row / 8;
+                    int lane_in_diag = lane & 7;
+                    float inv_row[8];
+                    unsigned int packed_8[4];
+                    int byte_off_1 = (int)prep_stage * 41984 + inverse_row * 128 + diag_block * 8 * 2;
+                    int swizzled_off_1 = byte_off_1 ^ (byte_off_1 >> 7 & 7) << 4;
+                    asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                        : "=r"(*reinterpret_cast<uint32_t*>(&packed_8[0])), "=r"(*reinterpret_cast<uint32_t*>(&packed_8[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&packed_8[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&packed_8[(0) + 3]))
+                        : "r"(smem_inv_work_addr + (unsigned int)swizzled_off_1));
+                    float packed_f32_5[8];
+                    #pragma unroll
+                    for (int _pair = 0; _pair < 4; _pair++) {
+                        asm volatile(
+                            "{\n\t"
+                            "shl.b32 %0, %2, 16;\n\t"
+                            "and.b32 %1, %2, 0xffff0000;\n\t"
+                            "}\n"
+                            : "=f"((&packed_f32_5[_pair * 2])[0]), "=f"((&packed_f32_5[_pair * 2])[1])
+                            : "r"(packed_8[_pair]));
+                    }
+                    #pragma unroll
+                    for (int value_idx_10 = 0; value_idx_10 < 8; value_idx_10++) {
+                        inv_row[value_idx_10] = packed_f32_5[value_idx_10];
+                    }
+                    #pragma unroll
+                    for (int diag_elem = 0; diag_elem < 8; diag_elem++) {
+                        if (lane_in_diag == diag_elem) {
+                            inv_row[diag_elem] = 1.0f;
+                        }
+                    }
+                    int diag_group_base = lane - lane_in_diag;
+                    #pragma unroll
+                    for (int src_row = 0; src_row < 7; src_row++) {
+                        float row_scale = -inv_row[src_row];
+                        #pragma unroll
+                        for (int prev_col = 0; prev_col < src_row; prev_col++) {
+                            int pivot_lane = diag_group_base + src_row;
+                            float _shfl_0 = __shfl_sync(0xFFFFFFFF, inv_row[prev_col], pivot_lane);
+                            float pivot = _shfl_0;
+                            if (lane_in_diag > src_row) {
+                                float _fma_6 = __fmaf_rn(row_scale, pivot, inv_row[prev_col]);
+                                inv_row[prev_col] = _fma_6;
+                            }
+                        }
+                        if (lane_in_diag > src_row) {
+                            inv_row[src_row] = row_scale;
+                        }
+                    }
+                    unsigned int packed_0_3[4];
+                    #pragma unroll
+                    for (int _lp = 0; _lp < 4; _lp++) {
+                        __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(inv_row[_lp*2 + 0], inv_row[_lp*2+1 + 0]));
+                        packed_0_3[_lp] = *(uint32_t*)&_bf2;
+                    }
+                    int byte_off_1_1 = (int)prep_stage * 41984 + inverse_row * 128 + diag_block * 8 * 2;
+                    int swizzled_off_2 = byte_off_1_1 ^ (byte_off_1_1 >> 7 & 7) << 4;
+                    #pragma unroll
+                    for (int word_5 = 0; word_5 < 4; word_5++) {
+                        asm volatile("st.shared.b32 [%0], %1;" :: "r"(smem_inv_work_addr + (unsigned int)swizzled_off_2 + (unsigned int)(word_5 * 4)), "r"((packed_0_3[word_5])));
+                    }
+                }
+                if (prep_local_warp < 2) {
+                    __syncwarp();
+                    if (elect_sync()) {
+                        mbarrier_arrive(prep_diag_ready_addr + (prep_stage) * 8);
+                    }
+                    mbarrier_wait(prep_diag_ready_addr + (prep_stage) * 8, _phase_prep_diag_ready);
+                }
+                {
+                    if (prep_local_warp < 2) {
+                        int lane_row = lane & 7;
+                        int byte_off_2 = (int)prep_stage * 41984 + (prep_local_warp * 16 + 8 + lane_row) * 128 + (prep_local_warp * 16 + 8) * 2;
+                        int swizzled_off_3 = byte_off_2 ^ (byte_off_2 >> 7 & 7) << 4;
+                        int d_addr = smem_inv_work_addr + (unsigned int)swizzled_off_3;
+                        int byte_off_0 = (int)prep_stage * 41984 + (prep_local_warp * 16 + 8 + lane_row) * 128 + prep_local_warp * 16 * 2;
+                        int swizzled_off_1_1 = byte_off_0 ^ (byte_off_0 >> 7 & 7) << 4;
+                        int c_addr = smem_inv_work_addr + (unsigned int)swizzled_off_1_1;
+                        int byte_off_2_1 = (int)prep_stage * 41984 + (prep_local_warp * 16 + lane_row) * 128 + prep_local_warp * 16 * 2;
+                        int swizzled_off_3_1 = byte_off_2_1 ^ (byte_off_2_1 >> 7 & 7) << 4;
+                        int a_addr = smem_inv_work_addr + (unsigned int)swizzled_off_3_1;
+                        unsigned int d_frag[2];
+                        unsigned int c_frag[1];
+                        float dc_acc[4];
+                        unsigned int dc_bf16[2];
+                        unsigned int inv_a_frag[1];
+                        float o_acc[4];
+                        unsigned int o_bf16[2];
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x1.shared.b16 {%0}, [%1];\n"
+                            : "=r"(d_frag[0])
+                            : "r"(d_addr)
+                            : "memory");
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x1.shared.b16 {%0}, [%1];\n"
+                            : "=r"(d_frag[1])
+                            : "r"(d_addr)
+                            : "memory");
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x1.trans.shared.b16 {%0}, [%1];\n"
+                            : "=r"(c_frag[0])
+                            : "r"(c_addr)
+                            : "memory");
+                        asm volatile("mma.sync.aligned.m16n8k8.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5}, {%6}, {%7, %8, %9, %10};\n"
+                            : "=f"(dc_acc[0]), "=f"(dc_acc[1]), "=f"(dc_acc[2]), "=f"(dc_acc[3])
+                            : "r"(d_frag[0]), "r"(d_frag[1]), "r"(c_frag[0]), "f"(0.0f), "f"(0.0f), "f"(0.0f), "f"(0.0f));
+                        const float2 _scale2_6 = {-1.0f, -1.0f};
+                        #pragma unroll
+                        for (int _ls = 0; _ls < 2; _ls++)
+                            mul_f32x2_inplace(&reinterpret_cast<float2*>(dc_acc)[_ls], _scale2_6);
+                        #pragma unroll
+                        for (int _lp = 0; _lp < 2; _lp++) {
+                            __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(dc_acc[_lp*2 + 0], dc_acc[_lp*2+1 + 0]));
+                            dc_bf16[_lp] = *(uint32_t*)&_bf2;
+                        }
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x1.trans.shared.b16 {%0}, [%1];\n"
+                            : "=r"(inv_a_frag[0])
+                            : "r"(a_addr)
+                            : "memory");
+                        asm volatile("mma.sync.aligned.m16n8k8.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5}, {%6}, {%7, %8, %9, %10};\n"
+                            : "=f"(o_acc[0]), "=f"(o_acc[1]), "=f"(o_acc[2]), "=f"(o_acc[3])
+                            : "r"(dc_bf16[0]), "r"(dc_bf16[1]), "r"(inv_a_frag[0]), "f"(0.0f), "f"(0.0f), "f"(0.0f), "f"(0.0f));
+                        #pragma unroll
+                        for (int _lp = 0; _lp < 2; _lp++) {
+                            __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(o_acc[_lp*2 + 0], o_acc[_lp*2+1 + 0]));
+                            o_bf16[_lp] = *(uint32_t*)&_bf2;
+                        }
+                        int byte_off_4 = (int)prep_stage * 41984 + (prep_local_warp * 16 + 8 + lane_row) * 128 + prep_local_warp * 16 * 2;
+                        int swizzled_off_5 = byte_off_4 ^ (byte_off_4 >> 7 & 7) << 4;
+                        int o_addr = smem_inv_work_addr + (unsigned int)swizzled_off_5;
+                        uint32_t _stmatrix_addr_7 = static_cast<uint32_t>((unsigned long long)o_addr);
+                        asm volatile("stmatrix.sync.aligned.m8n8.x1.shared.b16 [%0], {%1};\n"
+                            :: "r"(_stmatrix_addr_7), "r"(*reinterpret_cast<const uint32_t*>(&o_bf16[0]))
+                            : "memory");
+                        __syncwarp();
+                        if (elect_sync()) {
+                            mbarrier_arrive(prep_inv16_ready_addr + (prep_stage) * 8);
+                        }
+                        mbarrier_wait(prep_inv16_ready_addr + (prep_stage) * 8, _phase_prep_inv16_ready);
+                    }
+                }
+                {
+                    if (prep_local_warp == 0) {
+                        int lane_row_1 = lane % 16;
+                        int lane_col = lane / 16 * 8;
+                        int byte_off_3 = (int)prep_stage * 41984 + (16 + lane_row_1) * 128 + (16 + lane_col) * 2;
+                        int swizzled_off_4 = byte_off_3 ^ (byte_off_3 >> 7 & 7) << 4;
+                        int d_addr_1 = smem_inv_work_addr + (unsigned int)swizzled_off_4;
+                        int byte_off_0_1 = (int)prep_stage * 41984 + (16 + lane_row_1) * 128 + lane_col * 2;
+                        int swizzled_off_1_2 = byte_off_0_1 ^ (byte_off_0_1 >> 7 & 7) << 4;
+                        int c_addr_1 = smem_inv_work_addr + (unsigned int)swizzled_off_1_2;
+                        int byte_off_2_2 = (int)prep_stage * 41984 + lane_row_1 * 128 + lane_col * 2;
+                        int swizzled_off_3_2 = byte_off_2_2 ^ (byte_off_2_2 >> 7 & 7) << 4;
+                        int a_addr_1 = smem_inv_work_addr + (unsigned int)swizzled_off_3_2;
+                        unsigned int d32_frag[4];
+                        unsigned int c32_frag[4];
+                        float dc32_acc[8];
+                        unsigned int dc32_bf16[4];
+                        unsigned int a32_frag[4];
+                        float o32_acc[8];
+                        unsigned int o32_bf16[4];
+                        unsigned int zero32_bf16[4];
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(d32_frag[0]), "=r"(d32_frag[1]), "=r"(d32_frag[2]), "=r"(d32_frag[3])
+                            : "r"(d_addr_1)
+                            : "memory");
+                        int d_publish_addr = (smem_inv_addr + prep_stage * 41984 + (unsigned int)((16 + lane_col) / 16 * 1024 + (16 + lane_row_1) * 32 + (16 + lane_col) % 16 * 2 ^ ((16 + lane_col) / 16 * 1024 + (16 + lane_row_1) * 32 + (16 + lane_col) % 16 * 2 >> 7 & 1) << 4));
+                        uint32_t _stmatrix_addr_8 = static_cast<uint32_t>((unsigned long long)d_publish_addr);
+                        asm volatile("stmatrix.sync.aligned.m8n8.x4.shared.b16 [%0], {%1, %2, %3, %4};\n"
+                            :: "r"(_stmatrix_addr_8), "r"(*reinterpret_cast<const uint32_t*>(&d32_frag[0])), "r"(*reinterpret_cast<const uint32_t*>(&d32_frag[1])), "r"(*reinterpret_cast<const uint32_t*>(&d32_frag[2])), "r"(*reinterpret_cast<const uint32_t*>(&d32_frag[3]))
+                            : "memory");
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.trans.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(c32_frag[0]), "=r"(c32_frag[1]), "=r"(c32_frag[2]), "=r"(c32_frag[3])
+                            : "r"(c_addr_1)
+                            : "memory");
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%10, %11, %12, %13};\n"
+                            : "=f"(dc32_acc[0]), "=f"(dc32_acc[1]), "=f"(dc32_acc[2]), "=f"(dc32_acc[3])
+                            : "r"(d32_frag[0]), "r"(d32_frag[1]), "r"(d32_frag[2]), "r"(d32_frag[3]), "r"(c32_frag[0]), "r"(c32_frag[1]), "f"(0.0f), "f"(0.0f), "f"(0.0f), "f"(0.0f));
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%10, %11, %12, %13};\n"
+                            : "=f"(dc32_acc[4]), "=f"(dc32_acc[(4) + 1]), "=f"(dc32_acc[(4) + 2]), "=f"(dc32_acc[(4) + 3])
+                            : "r"(d32_frag[0]), "r"(d32_frag[1]), "r"(d32_frag[2]), "r"(d32_frag[3]), "r"(c32_frag[2]), "r"(c32_frag[(2) + 1]), "f"(0.0f), "f"(0.0f), "f"(0.0f), "f"(0.0f));
+                        const float2 _scale2_9 = {-1.0f, -1.0f};
+                        #pragma unroll
+                        for (int _ls = 0; _ls < 4; _ls++)
+                            mul_f32x2_inplace(&reinterpret_cast<float2*>(dc32_acc)[_ls], _scale2_9);
+                        #pragma unroll
+                        for (int _lp = 0; _lp < 4; _lp++) {
+                            __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(dc32_acc[_lp*2 + 0], dc32_acc[_lp*2+1 + 0]));
+                            dc32_bf16[_lp] = *(uint32_t*)&_bf2;
+                        }
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.trans.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(a32_frag[0]), "=r"(a32_frag[1]), "=r"(a32_frag[2]), "=r"(a32_frag[3])
+                            : "r"(a_addr_1)
+                            : "memory");
+                        int a_publish_addr = (smem_inv_addr + prep_stage * 41984 + (unsigned int)(lane_col / 16 * 1024 + lane_row_1 * 32 + lane_col % 16 * 2 ^ (lane_col / 16 * 1024 + lane_row_1 * 32 + lane_col % 16 * 2 >> 7 & 1) << 4));
+                        uint32_t _stmatrix_addr_10 = static_cast<uint32_t>((unsigned long long)a_publish_addr);
+                        asm volatile("stmatrix.sync.aligned.m8n8.x4.trans.shared.b16 [%0], {%1, %2, %3, %4};\n"
+                            :: "r"(_stmatrix_addr_10), "r"(*reinterpret_cast<const uint32_t*>(&a32_frag[0])), "r"(*reinterpret_cast<const uint32_t*>(&a32_frag[1])), "r"(*reinterpret_cast<const uint32_t*>(&a32_frag[2])), "r"(*reinterpret_cast<const uint32_t*>(&a32_frag[3]))
+                            : "memory");
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%10, %11, %12, %13};\n"
+                            : "=f"(o32_acc[0]), "=f"(o32_acc[1]), "=f"(o32_acc[2]), "=f"(o32_acc[3])
+                            : "r"(dc32_bf16[0]), "r"(dc32_bf16[1]), "r"(dc32_bf16[2]), "r"(dc32_bf16[3]), "r"(a32_frag[0]), "r"(a32_frag[1]), "f"(0.0f), "f"(0.0f), "f"(0.0f), "f"(0.0f));
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%10, %11, %12, %13};\n"
+                            : "=f"(o32_acc[4]), "=f"(o32_acc[(4) + 1]), "=f"(o32_acc[(4) + 2]), "=f"(o32_acc[(4) + 3])
+                            : "r"(dc32_bf16[0]), "r"(dc32_bf16[1]), "r"(dc32_bf16[2]), "r"(dc32_bf16[3]), "r"(a32_frag[2]), "r"(a32_frag[(2) + 1]), "f"(0.0f), "f"(0.0f), "f"(0.0f), "f"(0.0f));
+                        #pragma unroll
+                        for (int _lp = 0; _lp < 4; _lp++) {
+                            __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(o32_acc[_lp*2 + 0], o32_acc[_lp*2+1 + 0]));
+                            o32_bf16[_lp] = *(uint32_t*)&_bf2;
+                        }
+                        int o_publish_addr = (smem_inv_addr + prep_stage * 41984 + (unsigned int)(lane_col / 16 * 1024 + (16 + lane_row_1) * 32 + lane_col % 16 * 2 ^ (lane_col / 16 * 1024 + (16 + lane_row_1) * 32 + lane_col % 16 * 2 >> 7 & 1) << 4));
+                        uint32_t _stmatrix_addr_11 = static_cast<uint32_t>((unsigned long long)o_publish_addr);
+                        asm volatile("stmatrix.sync.aligned.m8n8.x4.shared.b16 [%0], {%1, %2, %3, %4};\n"
+                            :: "r"(_stmatrix_addr_11), "r"(*reinterpret_cast<const uint32_t*>(&o32_bf16[0])), "r"(*reinterpret_cast<const uint32_t*>(&o32_bf16[1])), "r"(*reinterpret_cast<const uint32_t*>(&o32_bf16[2])), "r"(*reinterpret_cast<const uint32_t*>(&o32_bf16[3]))
+                            : "memory");
+                        #pragma unroll
+                        for (int zero_word = 0; zero_word < 4; zero_word++) {
+                            zero32_bf16[zero_word] = 0;
+                        }
+                        int zero_publish_addr = (smem_inv_addr + prep_stage * 41984 + (unsigned int)((16 + lane_col) / 16 * 1024 + lane_row_1 * 32 + (16 + lane_col) % 16 * 2 ^ ((16 + lane_col) / 16 * 1024 + lane_row_1 * 32 + (16 + lane_col) % 16 * 2 >> 7 & 1) << 4));
+                        uint32_t _stmatrix_addr_12 = static_cast<uint32_t>((unsigned long long)zero_publish_addr);
+                        asm volatile("stmatrix.sync.aligned.m8n8.x4.shared.b16 [%0], {%1, %2, %3, %4};\n"
+                            :: "r"(_stmatrix_addr_12), "r"(*reinterpret_cast<const uint32_t*>(&zero32_bf16[0])), "r"(*reinterpret_cast<const uint32_t*>(&zero32_bf16[1])), "r"(*reinterpret_cast<const uint32_t*>(&zero32_bf16[2])), "r"(*reinterpret_cast<const uint32_t*>(&zero32_bf16[3]))
+                            : "memory");
+                    }
+                }
+                asm volatile("fence.proxy.async.shared::cta;" ::: "memory");
+                asm volatile("barrier.sync %0, 128;" :: "r"(10 + prep_instance) : "memory");
+                if (prep_local_warp == 0) {
+                    if (elect_sync()) {
+                        {
+                            mbarrier_arrive(qk_full_addr + (prep_stage) * 8);
+                        }
+                        {
+                            mbarrier_arrive(tape_ready_addr + (prep_stage) * 8);
+                        }
+                    }
+                }
+                {
+                    mbarrier_wait(tape_free_addr + (prep_stage) * 8, _phase_tape_free);
+                }
+                if (chunk_is_full_1 != 0) {
+                    if (prep_local_warp == 0) {
+                        if (elect_sync()) {
+                            mbarrier_arrive_expect_tx(v_full_addr + (prep_stage) * 8, 8192);
+                            {
+                                tma_3d_gmem2smem(smem_v_addr + prep_stage * 41984, v_tma, 0, head_idx_4, (int)(bos_4 + (long long)(chunk_idx_3 * 32)), v_full_addr + (prep_stage) * 8);
+                            }
+                        }
+                    }
+                } else {
+                    #pragma unroll
+                    for (int v_load_iter = 0; v_load_iter < 4; v_load_iter++) {
+                        int v_item = v_load_iter * 128 + prep_tid;
+                        int row_1 = v_item / 16;
+                        int segment_1 = v_item % 16;
+                        long long token_1 = bos_4 + (long long)(chunk_idx_3 * 32 + row_1);
+                        int token_valid_1 = ((token_1 < eos_4) ? 1 : 0);
+                        long long v_src = (token_1 * (long long)num_heads + (long long)head_idx_4) * 128 + (long long)(segment_1 * 8);
+                        int v_dst = smem_v_addr + prep_stage * 41984 + (unsigned int)((row_1 * 128 + segment_1 * 8) * 2);
+                        asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16, %2;"
+                            :: "r"(v_dst), "l"(v + v_src), "r"((token_valid_1 != 0) ? 16 : 0));
+                    }
+                    asm volatile("cp.async.commit_group;");
+                    asm volatile("cp.async.wait_group 0;");
+                    asm volatile("barrier.sync %0, 128;" :: "r"(10 + prep_instance) : "memory");
+                    if (prep_local_warp == 0) {
+                        if (elect_sync()) {
+                            asm volatile("fence.proxy.async.shared::cta;" ::: "memory");
+                            mbarrier_arrive(v_full_addr + (prep_stage) * 8);
+                        }
+                    }
+                }
+                for (int _advance = 0; _advance < 5; _advance++) {
+                    prep_stage += 1;
+                    if (prep_stage == 5) { prep_stage = 0; _phase_raw_inputs_free ^= 1; _phase_gate_raw_full ^= 1; _phase_smem_free ^= 1; _phase_v_free ^= 1; _phase_qk_raw_full ^= 1; _phase_short_beta_ready ^= 1; _phase_prep_diag_ready ^= 1; _phase_prep_inv16_ready ^= 1; _phase_tape_free ^= 1; }
+                }
+            }
+        }
+    }
+
+    // Cleanup
+}
+
+} // extern "C"
+
+#undef LOOM_INF
+#undef NUM_CHECKPOINT_PIPE_STAGES
+#undef NUM_CHUNK_PIPE_STAGES
+#undef SMEM_SMEM_BETA_RAW_ALL_OFF
+#undef SMEM_SMEM_BETA_RAW_ALL_STAGE_BYTES
+#undef SMEM_SMEM_BETA_RAW_ALL_STRIDE
+#undef SMEM_SMEM_BETA_RAW_OFF
+#undef SMEM_SMEM_BETA_RAW_STAGE_BYTES
+#undef SMEM_SMEM_BETA_RAW_STRIDE
+#undef SMEM_SMEM_CHECKPOINT_OFF
+#undef SMEM_SMEM_CHECKPOINT_STAGE_BYTES
+#undef SMEM_SMEM_CHECKPOINT_STRIDE
+#undef SMEM_SMEM_FINAL_TRANS_OFF
+#undef SMEM_SMEM_FINAL_TRANS_STAGE_BYTES
+#undef SMEM_SMEM_FINAL_TRANS_STRIDE
+#undef SMEM_SMEM_GATE_ALL_OFF
+#undef SMEM_SMEM_GATE_ALL_STAGE_BYTES
+#undef SMEM_SMEM_GATE_ALL_STRIDE
+#undef SMEM_SMEM_GATE_BIAS_ALL_OFF
+#undef SMEM_SMEM_GATE_BIAS_ALL_STAGE_BYTES
+#undef SMEM_SMEM_GATE_BIAS_ALL_STRIDE
+#undef SMEM_SMEM_GATE_OFF
+#undef SMEM_SMEM_GATE_RATE_ALL_OFF
+#undef SMEM_SMEM_GATE_RATE_ALL_STAGE_BYTES
+#undef SMEM_SMEM_GATE_RATE_ALL_STRIDE
+#undef SMEM_SMEM_GATE_STAGE_BYTES
+#undef SMEM_SMEM_GATE_STRIDE
+#undef SMEM_SMEM_GT_ALL_OFF
+#undef SMEM_SMEM_GT_ALL_STAGE_BYTES
+#undef SMEM_SMEM_GT_ALL_STRIDE
+#undef SMEM_SMEM_GT_PREFIX_ALL_OFF
+#undef SMEM_SMEM_GT_PREFIX_ALL_STAGE_BYTES
+#undef SMEM_SMEM_GT_PREFIX_ALL_STRIDE
+#undef SMEM_SMEM_G_RAW_ALL_OFF
+#undef SMEM_SMEM_G_RAW_ALL_STAGE_BYTES
+#undef SMEM_SMEM_G_RAW_ALL_STRIDE
+#undef SMEM_SMEM_G_RAW_OFF
+#undef SMEM_SMEM_G_RAW_STAGE_BYTES
+#undef SMEM_SMEM_G_RAW_STRIDE
+#undef SMEM_SMEM_INV_OFF
+#undef SMEM_SMEM_INV_STAGE_BYTES
+#undef SMEM_SMEM_INV_STRIDE
+#undef SMEM_SMEM_INV_WORK_OFF
+#undef SMEM_SMEM_INV_WORK_STAGE_BYTES
+#undef SMEM_SMEM_INV_WORK_STRIDE
+#undef SMEM_SMEM_KD_OFF
+#undef SMEM_SMEM_KD_STAGE_BYTES
+#undef SMEM_SMEM_KD_STRIDE
+#undef SMEM_SMEM_KI_OFF
+#undef SMEM_SMEM_KI_STAGE_BYTES
+#undef SMEM_SMEM_KI_STRIDE
+#undef SMEM_SMEM_KR_TRANS_OFF
+#undef SMEM_SMEM_KR_TRANS_STAGE_BYTES
+#undef SMEM_SMEM_KR_TRANS_STRIDE
+#undef SMEM_SMEM_MQK_TRANS_OFF
+#undef SMEM_SMEM_MQK_TRANS_STAGE_BYTES
+#undef SMEM_SMEM_MQK_TRANS_STRIDE
+#undef SMEM_SMEM_OUT_OFF
+#undef SMEM_SMEM_OUT_STAGE_BYTES
+#undef SMEM_SMEM_OUT_STRIDE
+#undef SMEM_SMEM_PREP_BETA_ALL_OFF
+#undef SMEM_SMEM_PREP_BETA_ALL_STAGE_BYTES
+#undef SMEM_SMEM_PREP_BETA_ALL_STRIDE
+#undef SMEM_SMEM_PREP_BETA_BF16_ALL_OFF
+#undef SMEM_SMEM_PREP_BETA_BF16_ALL_STAGE_BYTES
+#undef SMEM_SMEM_PREP_BETA_BF16_ALL_STRIDE
+#undef SMEM_SMEM_PREP_BETA_U32_ALL_OFF
+#undef SMEM_SMEM_PREP_BETA_U32_ALL_STAGE_BYTES
+#undef SMEM_SMEM_PREP_BETA_U32_ALL_STRIDE
+#undef SMEM_SMEM_QD_OFF
+#undef SMEM_SMEM_QD_STAGE_BYTES
+#undef SMEM_SMEM_QD_STRIDE
+#undef SMEM_SMEM_Q_RAW_PREFETCH_OFF
+#undef SMEM_SMEM_Q_RAW_PREFETCH_STAGE_BYTES
+#undef SMEM_SMEM_Q_RAW_PREFETCH_STRIDE
+#undef SMEM_SMEM_RESTORE_FACTOR_ALL_OFF
+#undef SMEM_SMEM_RESTORE_FACTOR_ALL_STAGE_BYTES
+#undef SMEM_SMEM_RESTORE_FACTOR_ALL_STRIDE
+#undef SMEM_SMEM_SHORT_N32_V_OFF
+#undef SMEM_SMEM_SHORT_N32_V_STAGE_BYTES
+#undef SMEM_SMEM_SHORT_N32_V_STRIDE
+#undef SMEM_SMEM_STATE_CHECKPOINT_NEEDED_OFF
+#undef SMEM_SMEM_STATE_CHECKPOINT_NEEDED_STAGE_BYTES
+#undef SMEM_SMEM_STATE_CHECKPOINT_NEEDED_STRIDE
+#undef SMEM_SMEM_V_ALL_OFF
+#undef SMEM_SMEM_V_ALL_STAGE_BYTES
+#undef SMEM_SMEM_V_ALL_STRIDE
+#undef SMEM_SMEM_V_OFF
+#undef SMEM_SMEM_V_STAGE_BYTES
+#undef SMEM_SMEM_V_STRIDE
+#undef SMEM_SMEM_WORK_ITEM_COMPUTE_START_OFF
+#undef SMEM_SMEM_WORK_ITEM_COMPUTE_START_STAGE_BYTES
+#undef SMEM_SMEM_WORK_ITEM_COMPUTE_START_STRIDE
+#undef SMEM_SMEM_WORK_ITEM_RESOLVED_OFF
+#undef SMEM_SMEM_WORK_ITEM_RESOLVED_STAGE_BYTES
+#undef SMEM_SMEM_WORK_ITEM_RESOLVED_STRIDE
+#undef SMEM_SMEM_WORK_ITEM_WARP_MAX_OFF
+#undef SMEM_SMEM_WORK_ITEM_WARP_MAX_STAGE_BYTES
+#undef SMEM_SMEM_WORK_ITEM_WARP_MAX_STRIDE
+#undef SMEM_TOTAL
+#undef SPLIT_WORK_ITEMS
+#undef STORE_BACKWARD_TAPE
+#undef STORE_E_TAPE
+#undef TMEM_NCOLS
+#undef TMEM_TMEM_OUT_OFFSET
+#undef TMEM_TMEM_STATE_INP_OFFSET
+#undef TMEM_TMEM_STATE_OFFSET
+#undef TMEM_TMEM_STATE_OUT_OFFSET
+#undef TMEM_TMEM_U2_ACC_OFFSET
+#undef TMEM_TMEM_U2_INP_OFFSET
+#undef TMEM_TMEM_U_ACC_OFFSET
+#undef checkpoint_free_addr
+#undef checkpoint_ready_addr
+#undef final_ready_addr
+#undef gate_raw_full_addr
+#undef old_out_ready_addr
+#undef out_empty_addr
+#undef prep_diag_ready_addr
+#undef prep_inv16_ready_addr
+#undef qk_full_addr
+#undef qk_raw_full_addr
+#undef raw_inputs_free_addr
+#undef short_beta_ready_addr
+#undef smem_beta_raw_addr
+#undef smem_beta_raw_all_addr
+#undef smem_checkpoint_addr
+#undef smem_final_trans_addr
+#undef smem_free_addr
+#undef smem_g_raw_addr
+#undef smem_g_raw_all_addr
+#undef smem_gate_addr
+#undef smem_gate_all_addr
+#undef smem_gate_bias_all_addr
+#undef smem_gate_rate_all_addr
+#undef smem_gt_all_addr
+#undef smem_gt_prefix_all_addr
+#undef smem_inv_addr
+#undef smem_inv_work_addr
+#undef smem_kd_addr
+#undef smem_ki_addr
+#undef smem_kr_trans_addr
+#undef smem_mqk_trans_addr
+#undef smem_out_addr
+#undef smem_prep_beta_all_addr
+#undef smem_prep_beta_bf16_all_addr
+#undef smem_prep_beta_u32_all_addr
+#undef smem_q_raw_prefetch_addr
+#undef smem_qd_addr
+#undef smem_restore_factor_all_addr
+#undef smem_short_n32_v_addr
+#undef smem_state_checkpoint_needed_addr
+#undef smem_v_addr
+#undef smem_v_all_addr
+#undef smem_work_item_compute_start_addr
+#undef smem_work_item_resolved_addr
+#undef smem_work_item_warp_max_addr
+#undef state_inp_ready_addr
+#undef tape_free_addr
+#undef tape_ready_addr
+#undef tmem_dealloc_ready_addr
+#undef u2_acc_ready_addr
+#undef u2_inp_ready_addr
+#undef u_inp_ready_addr
+#undef v_free_addr
+#undef v_full_addr
+#undef work_item_ready_addr
+
+#define LOOM_INF CUDART_INF_F
+#define TMEM_NCOLS 256
+#define TMEM_TMEM_STATE_OFFSET 64
+#define TMEM_TMEM_STATE_INP_OFFSET 0
+#define TMEM_TMEM_U_ACC_OFFSET 224
+#define TMEM_TMEM_U2_INP_OFFSET 224
+#define TMEM_TMEM_U2_ACC_OFFSET 0
+#define TMEM_TMEM_OUT_OFFSET 192
+#define TMEM_TMEM_STATE_OUT_OFFSET 64
+#define NUM_CHUNK_PIPE_STAGES 5
+#define NUM_CHECKPOINT_PIPE_STAGES 2
+#define SMEM_SMEM_QD_OFF 1024
+#define SMEM_SMEM_QD_STAGE_BYTES 8192
+#define SMEM_SMEM_QD_STRIDE 41984
+#define SMEM_SMEM_G_RAW_OFF 1024
+#define SMEM_SMEM_G_RAW_STAGE_BYTES 8192
+#define SMEM_SMEM_G_RAW_STRIDE 41984
+#define SMEM_SMEM_G_RAW_ALL_OFF 1024
+#define SMEM_SMEM_G_RAW_ALL_STAGE_BYTES 176128
+#define SMEM_SMEM_G_RAW_ALL_STRIDE 176128
+#define SMEM_SMEM_KD_OFF 9216
+#define SMEM_SMEM_KD_STAGE_BYTES 8192
+#define SMEM_SMEM_KD_STRIDE 41984
+#define SMEM_SMEM_Q_RAW_PREFETCH_OFF 17408
+#define SMEM_SMEM_Q_RAW_PREFETCH_STAGE_BYTES 8192
+#define SMEM_SMEM_Q_RAW_PREFETCH_STRIDE 41984
+#define SMEM_SMEM_FINAL_TRANS_OFF 17408
+#define SMEM_SMEM_FINAL_TRANS_STAGE_BYTES 12288
+#define SMEM_SMEM_FINAL_TRANS_STRIDE 41984
+#define SMEM_SMEM_KR_TRANS_OFF 17408
+#define SMEM_SMEM_KR_TRANS_STAGE_BYTES 8192
+#define SMEM_SMEM_KR_TRANS_STRIDE 41984
+#define SMEM_SMEM_MQK_TRANS_OFF 25600
+#define SMEM_SMEM_MQK_TRANS_STAGE_BYTES 2048
+#define SMEM_SMEM_MQK_TRANS_STRIDE 41984
+#define SMEM_SMEM_INV_OFF 29696
+#define SMEM_SMEM_INV_STAGE_BYTES 2048
+#define SMEM_SMEM_INV_STRIDE 41984
+#define SMEM_SMEM_V_OFF 32384
+#define SMEM_SMEM_V_STAGE_BYTES 8192
+#define SMEM_SMEM_V_STRIDE 41984
+#define SMEM_SMEM_SHORT_N32_V_OFF 168960
+#define SMEM_SMEM_SHORT_N32_V_STAGE_BYTES 32768
+#define SMEM_SMEM_SHORT_N32_V_STRIDE 32768
+#define SMEM_SMEM_KI_OFF 17408
+#define SMEM_SMEM_KI_STAGE_BYTES 8192
+#define SMEM_SMEM_KI_STRIDE 41984
+#define SMEM_SMEM_GATE_OFF 25600
+#define SMEM_SMEM_GATE_STAGE_BYTES 16384
+#define SMEM_SMEM_GATE_STRIDE 41984
+#define SMEM_SMEM_BETA_RAW_OFF 41984
+#define SMEM_SMEM_BETA_RAW_STAGE_BYTES 512
+#define SMEM_SMEM_BETA_RAW_STRIDE 41984
+#define SMEM_SMEM_BETA_RAW_ALL_OFF 41984
+#define SMEM_SMEM_BETA_RAW_ALL_STAGE_BYTES 168448
+#define SMEM_SMEM_BETA_RAW_ALL_STRIDE 168448
+#define SMEM_SMEM_INV_WORK_OFF 32384
+#define SMEM_SMEM_INV_WORK_STAGE_BYTES 4096
+#define SMEM_SMEM_INV_WORK_STRIDE 41984
+#define SMEM_SMEM_OUT_OFF 210944
+#define SMEM_SMEM_OUT_STAGE_BYTES 8192
+#define SMEM_SMEM_OUT_STRIDE 8192
+#define SMEM_SMEM_CHECKPOINT_OFF 228352
+#define SMEM_SMEM_CHECKPOINT_STAGE_BYTES 32768
+#define SMEM_SMEM_CHECKPOINT_STRIDE 32768
+#define SMEM_SMEM_RESTORE_FACTOR_ALL_OFF 41984
+#define SMEM_SMEM_RESTORE_FACTOR_ALL_STAGE_BYTES 168452
+#define SMEM_SMEM_RESTORE_FACTOR_ALL_STRIDE 168452
+#define SMEM_SMEM_GT_PREFIX_ALL_OFF 41472
+#define SMEM_SMEM_GT_PREFIX_ALL_STAGE_BYTES 168448
+#define SMEM_SMEM_GT_PREFIX_ALL_STRIDE 168448
+#define SMEM_SMEM_GT_ALL_OFF 31744
+#define SMEM_SMEM_GT_ALL_STAGE_BYTES 168448
+#define SMEM_SMEM_GT_ALL_STRIDE 168448
+#define SMEM_SMEM_PREP_BETA_ALL_OFF 42500
+#define SMEM_SMEM_PREP_BETA_ALL_STAGE_BYTES 168064
+#define SMEM_SMEM_PREP_BETA_ALL_STRIDE 168064
+#define SMEM_SMEM_PREP_BETA_BF16_ALL_OFF 42500
+#define SMEM_SMEM_PREP_BETA_BF16_ALL_STAGE_BYTES 168000
+#define SMEM_SMEM_PREP_BETA_BF16_ALL_STRIDE 168000
+#define SMEM_SMEM_PREP_BETA_U32_ALL_OFF 42500
+#define SMEM_SMEM_PREP_BETA_U32_ALL_STAGE_BYTES 168000
+#define SMEM_SMEM_PREP_BETA_U32_ALL_STRIDE 168000
+#define SMEM_SMEM_GATE_RATE_ALL_OFF 42628
+#define SMEM_SMEM_GATE_RATE_ALL_STAGE_BYTES 167940
+#define SMEM_SMEM_GATE_RATE_ALL_STRIDE 167940
+#define SMEM_SMEM_GATE_BIAS_ALL_OFF 227408
+#define SMEM_SMEM_GATE_BIAS_ALL_STAGE_BYTES 512
+#define SMEM_SMEM_GATE_BIAS_ALL_STRIDE 512
+#define SMEM_SMEM_V_ALL_OFF 32384
+#define SMEM_SMEM_V_ALL_STAGE_BYTES 176128
+#define SMEM_SMEM_V_ALL_STRIDE 176128
+#define SMEM_SMEM_GATE_ALL_OFF 25600
+#define SMEM_SMEM_GATE_ALL_STAGE_BYTES 184320
+#define SMEM_SMEM_GATE_ALL_STRIDE 184320
+#define SMEM_SMEM_STATE_CHECKPOINT_NEEDED_OFF 227328
+#define SMEM_SMEM_STATE_CHECKPOINT_NEEDED_STAGE_BYTES 80
+#define SMEM_SMEM_STATE_CHECKPOINT_NEEDED_STRIDE 80
+#define SMEM_SMEM_WORK_ITEM_WARP_MAX_OFF 227328
+#define SMEM_SMEM_WORK_ITEM_WARP_MAX_STAGE_BYTES 16
+#define SMEM_SMEM_WORK_ITEM_WARP_MAX_STRIDE 16
+#define SMEM_SMEM_WORK_ITEM_COMPUTE_START_OFF 227344
+#define SMEM_SMEM_WORK_ITEM_COMPUTE_START_STAGE_BYTES 4
+#define SMEM_SMEM_WORK_ITEM_COMPUTE_START_STRIDE 4
+#define SMEM_SMEM_WORK_ITEM_RESOLVED_OFF 227348
+#define SMEM_SMEM_WORK_ITEM_RESOLVED_STAGE_BYTES 4
+#define SMEM_SMEM_WORK_ITEM_RESOLVED_STRIDE 4
+#define SMEM_TOTAL 227968
+#define STORE_BACKWARD_TAPE 1
+#define STORE_E_TAPE 0
+#define SPLIT_WORK_ITEMS 1
+
+extern "C" {
+
+__global__ __launch_bounds__(1024) void
+kernel_flashkda_bf16_fused_m128(__nv_bfloat16* __restrict__ q, LoomTensorMap const* q_tma, __nv_bfloat16* __restrict__ k, LoomTensorMap const* k_tma, __nv_bfloat16* __restrict__ v, LoomTensorMap const* v_tma, __nv_bfloat16* __restrict__ g, LoomTensorMap const* g_tma, __nv_bfloat16* __restrict__ beta, LoomTensorMap const* beta_tma, float* __restrict__ A_log, float* __restrict__ dt_bias, long long* __restrict__ cu_seqlens, int* __restrict__ seq_order, __nv_bfloat16* __restrict__ initial_state, __nv_bfloat16* __restrict__ out, LoomTensorMap const* out_tma, __nv_bfloat16* __restrict__ final_state, int num_heads, int use_initial_state, int store_final_state, float scale, float lower_bound, unsigned long long state_indices_addr, unsigned long long state_checkpoints_addr, unsigned long long checkpoint_cu_starts_addr, long long beta_token_stride, long long state_slot_stride, int use_state_indices, int checkpoint_every_n_tokens, long long* __restrict__ cu_chunk_offsets, __nv_bfloat16* __restrict__ chunk_state, unsigned int* __restrict__ state_checkpoint_needed, __nv_bfloat16* __restrict__ tape_qd, __nv_bfloat16* __restrict__ tape_kd, __nv_bfloat16* __restrict__ tape_kr, __nv_bfloat16* __restrict__ tape_j, float* __restrict__ tape_restore_factor, __nv_bfloat16* __restrict__ tape_e, __nv_bfloat16* __restrict__ tape_x, __nv_bfloat16* __restrict__ tape_r, float* __restrict__ norm_inv_out, __nv_bfloat16* __restrict__ decay_out, float* __restrict__ beta_active_out, float* __restrict__ initial_state_f32, unsigned int* __restrict__ zero_workspace, int zero_words, int num_sequences, LoomTensorMap const* state_checkpoints_tma)
+{
+    const int tid = threadIdx.x;
+    const int warp = make_warp_uniform(tid / 32);
+    const int lane = tid % 32;
+
+    extern __shared__ __align__(1024) char smem_raw[];
+    int smem;
+    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+
+    const int bid = blockIdx.x;
+    const int num_bids = gridDim.x;
+    if (warp == 8 && lane == 0) {
+        asm volatile("fence.proxy.tensormap::generic.acquire.sys [%0], 128;" :: "l"((uint64_t)(q_tma)) : "memory");
+        asm volatile("fence.proxy.tensormap::generic.acquire.sys [%0], 128;" :: "l"((uint64_t)(k_tma)) : "memory");
+        asm volatile("fence.proxy.tensormap::generic.acquire.sys [%0], 128;" :: "l"((uint64_t)(v_tma)) : "memory");
+        asm volatile("fence.proxy.tensormap::generic.acquire.sys [%0], 128;" :: "l"((uint64_t)(g_tma)) : "memory");
+        asm volatile("fence.proxy.tensormap::generic.acquire.sys [%0], 128;" :: "l"((uint64_t)(beta_tma)) : "memory");
+        asm volatile("fence.proxy.tensormap::generic.acquire.sys [%0], 128;" :: "l"((uint64_t)(out_tma)) : "memory");
+        asm volatile("fence.proxy.tensormap::generic.acquire.sys [%0], 128;" :: "l"((uint64_t)(state_checkpoints_tma)) : "memory");
+    }
+
+
+    // Kernel setup ops
+    __nv_bfloat16* smem_qd = reinterpret_cast<__nv_bfloat16*>(smem_raw + 1024);
+    const int smem_qd_addr = smem + 1024;
+    __nv_bfloat16* smem_g_raw = reinterpret_cast<__nv_bfloat16*>(smem_raw + 1024);
+    const int smem_g_raw_addr = smem + 1024;
+    __nv_bfloat16* smem_g_raw_all = reinterpret_cast<__nv_bfloat16*>(smem_raw + 1024);
+    const int smem_g_raw_all_addr = smem + 1024;
+    __nv_bfloat16* smem_kd = reinterpret_cast<__nv_bfloat16*>(smem_raw + 9216);
+    const int smem_kd_addr = smem + 9216;
+    __nv_bfloat16* smem_q_raw_prefetch = reinterpret_cast<__nv_bfloat16*>(smem_raw + 17408);
+    const int smem_q_raw_prefetch_addr = smem + 17408;
+    __nv_bfloat16* smem_final_trans = reinterpret_cast<__nv_bfloat16*>(smem_raw + 17408);
+    const int smem_final_trans_addr = smem + 17408;
+    __nv_bfloat16* smem_kr_trans = reinterpret_cast<__nv_bfloat16*>(smem_raw + 17408);
+    const int smem_kr_trans_addr = smem + 17408;
+    __nv_bfloat16* smem_mqk_trans = reinterpret_cast<__nv_bfloat16*>(smem_raw + 25600);
+    const int smem_mqk_trans_addr = smem + 25600;
+    __nv_bfloat16* smem_inv = reinterpret_cast<__nv_bfloat16*>(smem_raw + 29696);
+    const int smem_inv_addr = smem + 29696;
+    __nv_bfloat16* smem_v = reinterpret_cast<__nv_bfloat16*>(smem_raw + 32384);
+    const int smem_v_addr = smem + 32384;
+    __nv_bfloat16* smem_short_n32_v = reinterpret_cast<__nv_bfloat16*>(smem_raw + 168960);
+    const int smem_short_n32_v_addr = smem + 168960;
+    __nv_bfloat16* smem_ki = reinterpret_cast<__nv_bfloat16*>(smem_raw + 17408);
+    const int smem_ki_addr = smem + 17408;
+    float* smem_gate = reinterpret_cast<float*>(smem_raw + 25600);
+    const int smem_gate_addr = smem + 25600;
+    __nv_bfloat16* smem_beta_raw = reinterpret_cast<__nv_bfloat16*>(smem_raw + 41984);
+    const int smem_beta_raw_addr = smem + 41984;
+    __nv_bfloat16* smem_beta_raw_all = reinterpret_cast<__nv_bfloat16*>(smem_raw + 41984);
+    const int smem_beta_raw_all_addr = smem + 41984;
+    __nv_bfloat16* smem_inv_work = reinterpret_cast<__nv_bfloat16*>(smem_raw + 32384);
+    const int smem_inv_work_addr = smem + 32384;
+    __nv_bfloat16* smem_out = reinterpret_cast<__nv_bfloat16*>(smem_raw + 210944);
+    const int smem_out_addr = smem + 210944;
+    __nv_bfloat16* smem_checkpoint = reinterpret_cast<__nv_bfloat16*>(smem_raw + 228352);
+    const int smem_checkpoint_addr = smem + 228352;
+    float* smem_restore_factor_all = reinterpret_cast<float*>(smem_raw + 41984);
+    const int smem_restore_factor_all_addr = smem + 41984;
+    float* smem_gt_prefix_all = reinterpret_cast<float*>(smem_raw + 41472);
+    const int smem_gt_prefix_all_addr = smem + 41472;
+    float* smem_gt_all = reinterpret_cast<float*>(smem_raw + 31744);
+    const int smem_gt_all_addr = smem + 31744;
+    float* smem_prep_beta_all = reinterpret_cast<float*>(smem_raw + 42500);
+    const int smem_prep_beta_all_addr = smem + 42500;
+    __nv_bfloat16* smem_prep_beta_bf16_all = reinterpret_cast<__nv_bfloat16*>(smem_raw + 42500);
+    const int smem_prep_beta_bf16_all_addr = smem + 42500;
+    unsigned int* smem_prep_beta_u32_all = reinterpret_cast<unsigned int*>(smem_raw + 42500);
+    const int smem_prep_beta_u32_all_addr = smem + 42500;
+    float* smem_gate_rate_all = reinterpret_cast<float*>(smem_raw + 42628);
+    const int smem_gate_rate_all_addr = smem + 42628;
+    float* smem_gate_bias_all = reinterpret_cast<float*>(smem_raw + 227408);
+    const int smem_gate_bias_all_addr = smem + 227408;
+    __nv_bfloat16* smem_v_all = reinterpret_cast<__nv_bfloat16*>(smem_raw + 32384);
+    const int smem_v_all_addr = smem + 32384;
+    float* smem_gate_all = reinterpret_cast<float*>(smem_raw + 25600);
+    const int smem_gate_all_addr = smem + 25600;
+    unsigned int* smem_state_checkpoint_needed = reinterpret_cast<unsigned int*>(smem_raw + 227328);
+    const int smem_state_checkpoint_needed_addr = smem + 227328;
+    float* smem_work_item_warp_max = reinterpret_cast<float*>(smem_raw + 227328);
+    const int smem_work_item_warp_max_addr = smem + 227328;
+    int* smem_work_item_compute_start = reinterpret_cast<int*>(smem_raw + 227344);
+    const int smem_work_item_compute_start_addr = smem + 227344;
+    unsigned int* smem_work_item_resolved = reinterpret_cast<unsigned int*>(smem_raw + 227348);
+    const int smem_work_item_resolved_addr = smem + 227348;
+
+    // Mbarrier init (23 groups, 97 barriers)
+    // Mbarriers at smem_raw[0..776)
+
+    if (warp == 10) {
+        // --- pipeline 'chunk_pipe' ---
+        // qk_full: 5 barriers, init_count=1
+        // tape_ready: 5 barriers, init_count=1
+        // tape_free: 5 barriers, init_count=2
+        // gate_raw_full: 5 barriers, init_count=1
+        // qk_raw_full: 5 barriers, init_count=1
+        // v_full: 5 barriers, init_count=1
+        // v_free: 5 barriers, init_count=4
+        // smem_free: 5 barriers, init_count=1
+        // raw_inputs_free: 5 barriers, init_count=1
+        // state_inp_ready: 5 barriers, init_count=4
+        // old_out_ready: 5 barriers, init_count=1
+        // u_inp_ready: 5 barriers, init_count=4
+        // u2_acc_ready: 5 barriers, init_count=1
+        // u2_inp_ready: 5 barriers, init_count=4
+        // final_ready: 5 barriers, init_count=1
+        // out_empty: 1 barriers, init_count=1
+        // tmem_dealloc_ready: 1 barriers, init_count=2
+        // --- pipeline 'checkpoint_pipe' ---
+        // checkpoint_ready: 2 barriers, init_count=4
+        // checkpoint_free: 2 barriers, init_count=1
+        // --- pipeline 'chunk_pipe' ---
+        // prep_diag_ready: 5 barriers, init_count=2
+        // prep_inv16_ready: 5 barriers, init_count=2
+        // work_item_ready: 1 barriers, init_count=1
+        // short_beta_ready: 5 barriers, init_count=1
+        // Warp-cooperative initialization, grouped by equal arrival count.
+        for (int _bar = lane; _bar < 10; _bar += 32) {
+            mbarrier_init(smem + 0 + _bar * 8, 1);
+        }
+        for (int _bar = lane; _bar < 5; _bar += 32) {
+            mbarrier_init(smem + 80 + _bar * 8, 2);
+        }
+        for (int _bar = lane; _bar < 15; _bar += 32) {
+            mbarrier_init(smem + 120 + _bar * 8, 1);
+        }
+        for (int _bar = lane; _bar < 5; _bar += 32) {
+            mbarrier_init(smem + 240 + _bar * 8, 4);
+        }
+        for (int _bar = lane; _bar < 10; _bar += 32) {
+            mbarrier_init(smem + 280 + _bar * 8, 1);
+        }
+        for (int _bar = lane; _bar < 5; _bar += 32) {
+            mbarrier_init(smem + 360 + _bar * 8, 4);
+        }
+        for (int _bar = lane; _bar < 5; _bar += 32) {
+            mbarrier_init(smem + 400 + _bar * 8, 1);
+        }
+        for (int _bar = lane; _bar < 5; _bar += 32) {
+            mbarrier_init(smem + 440 + _bar * 8, 4);
+        }
+        for (int _bar = lane; _bar < 5; _bar += 32) {
+            mbarrier_init(smem + 480 + _bar * 8, 1);
+        }
+        for (int _bar = lane; _bar < 5; _bar += 32) {
+            mbarrier_init(smem + 520 + _bar * 8, 4);
+        }
+        for (int _bar = lane; _bar < 6; _bar += 32) {
+            mbarrier_init(smem + 560 + _bar * 8, 1);
+        }
+        for (int _bar = lane; _bar < 1; _bar += 32) {
+            mbarrier_init(smem + 608 + _bar * 8, 2);
+        }
+        for (int _bar = lane; _bar < 2; _bar += 32) {
+            mbarrier_init(smem + 616 + _bar * 8, 4);
+        }
+        for (int _bar = lane; _bar < 2; _bar += 32) {
+            mbarrier_init(smem + 632 + _bar * 8, 1);
+        }
+        for (int _bar = lane; _bar < 10; _bar += 32) {
+            mbarrier_init(smem + 648 + _bar * 8, 2);
+        }
+        for (int _bar = lane; _bar < 6; _bar += 32) {
+            mbarrier_init(smem + 728 + _bar * 8, 1);
+        }
+        asm volatile("fence.mbarrier_init.release.cluster;");
+    }
+
+    __syncwarp();
+
+    // TMEM alloc (256 columns, 256 used)
+    volatile int* tmem_addr_storage = (volatile int*)(smem_raw + 776);
+    if (warp == 0) {
+        int _tmem_hold = smem + 776;
+        asm volatile("tcgen05.alloc.cta_group::1.sync.aligned.shared::cta.b32 [%0], %1;" :: "r"(_tmem_hold), "r"(256) : "memory");
+        asm volatile("tcgen05.relinquish_alloc_permit.cta_group::1.sync.aligned;");
+    }
+
+    __syncthreads();
+    asm volatile("tcgen05.fence::after_thread_sync;");
+
+    const int mbar_base = smem;
+    #define qk_full_addr (mbar_base + 0)
+    #define tape_ready_addr (mbar_base + 40)
+    #define tape_free_addr (mbar_base + 80)
+    #define gate_raw_full_addr (mbar_base + 120)
+    #define qk_raw_full_addr (mbar_base + 160)
+    #define v_full_addr (mbar_base + 200)
+    #define v_free_addr (mbar_base + 240)
+    #define smem_free_addr (mbar_base + 280)
+    #define raw_inputs_free_addr (mbar_base + 320)
+    #define state_inp_ready_addr (mbar_base + 360)
+    #define old_out_ready_addr (mbar_base + 400)
+    #define u_inp_ready_addr (mbar_base + 440)
+    #define u2_acc_ready_addr (mbar_base + 480)
+    #define u2_inp_ready_addr (mbar_base + 520)
+    #define final_ready_addr (mbar_base + 560)
+    #define out_empty_addr (mbar_base + 600)
+    #define tmem_dealloc_ready_addr (mbar_base + 608)
+    #define checkpoint_ready_addr (mbar_base + 616)
+    #define checkpoint_free_addr (mbar_base + 632)
+    #define prep_diag_ready_addr (mbar_base + 648)
+    #define prep_inv16_ready_addr (mbar_base + 688)
+    #define work_item_ready_addr (mbar_base + 728)
+    #define short_beta_ready_addr (mbar_base + 736)
+    const int taddr = tmem_addr_storage[0];
+
+    // Kernel post-init ops
+    const int tmem_tmem_state = taddr + 64;
+    const int tmem_tmem_state_inp = taddr;
+    const int tmem_tmem_u_acc = taddr + 224;
+    const int tmem_tmem_u2_inp = taddr + 224;
+    const int tmem_tmem_u2_acc = taddr;
+    const int tmem_tmem_out = taddr + 192;
+    const int tmem_tmem_state_out = taddr + 64;
+
+    // ---- Register redistribution for WGs split across roles ----
+    // Dec phase frees registers before any WG attempts inc.
+    if (warp >= 8 && warp <= 11) {
+        asm volatile("setmaxnreg.dec.sync.aligned.u32 48;");
+    }
+
+    // ---- Role: compute ----
+    if (warp <= 3) {
+        asm volatile("setmaxnreg.inc.sync.aligned.u32 168;");
+        { // compute_main
+            int task_idx = blockIdx.x;
+            int warp_id_in_role = (warp - 0);
+            int compute_local_warp = warp_id_in_role;
+            int warp_in_wg = warp % 4;
+            int state_row = warp_in_wg * 32 + lane;
+            int split_compute_start = 0;
+            {
+                int item_base = task_idx * 5;
+                int warmup_sequence = seq_order[item_base];
+                int warmup_head = seq_order[item_base + 1];
+                int warmup_write_start = seq_order[item_base + 2];
+                if (state_row == 0) {
+                    smem_work_item_compute_start[0] = 0;
+                    smem_work_item_resolved[0] = 0;
+                }
+                asm volatile("barrier.sync 9, 128;" ::: "memory");
+                float cumulative_log2 = 0.0f;
+                float _expf_1 = __expf(A_log[warmup_head]);
+                float warmup_gate_rate = _expf_1;
+                float warmup_gate_bias = dt_bias[warmup_head * 128 + state_row];
+                int _min_5 = ((warmup_write_start) < (32) ? (warmup_write_start) : (32));
+                int warmup_limit = _min_5;
+                long long warmup_sequence_bos = cu_seqlens[warmup_sequence];
+                #pragma unroll 1
+                for (int warmup_chunks = 1; warmup_chunks < warmup_limit + 1; warmup_chunks++) {
+                    if (smem_work_item_resolved[0] == 0) {
+                        int warmup_chunk = warmup_write_start - warmup_chunks;
+                        long long warmup_token_base = warmup_sequence_bos + (long long)warmup_chunk * 32;
+                        #pragma unroll 1
+                        for (int warmup_token_offset = 0; warmup_token_offset < 32; warmup_token_offset++) {
+                            long long warmup_token = warmup_token_base + (long long)warmup_token_offset;
+                            long long warmup_gate_index = (warmup_token * (long long)num_heads + (long long)warmup_head) * 128 + (long long)state_row;
+                            float _fma_7 = __fmaf_rn((float)g[warmup_gate_index], warmup_gate_rate, warmup_gate_bias);
+                            float gate_arg = _fma_7;
+                            float _tanh_approx_9;
+                            asm volatile("tanh.approx.f32 %0, %1;" : "=f"(_tanh_approx_9) : "f"(gate_arg * 0.5f));
+                            float _fma_8 = __fmaf_rn(_tanh_approx_9, lower_bound * 0.7213475204444817f, lower_bound * 0.7213475204444817f);
+                            cumulative_log2 += _fma_8;
+                        }
+                        float _warp_reduce_0 = cumulative_log2;
+                        #pragma unroll
+                        for (int offset = 16; offset > 0; offset >>= 1)
+                            _warp_reduce_0 = max_noftz(_warp_reduce_0, __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset));
+                        float warmup_warp_max = _warp_reduce_0;
+                        if (lane == 0) {
+                            smem_work_item_warp_max[compute_local_warp] = warmup_warp_max;
+                        }
+                        asm volatile("barrier.sync 9, 128;" ::: "memory");
+                        float warmup_block_max = ((lane < 4) ? smem_work_item_warp_max[lane] : -LOOM_INF);
+                        float _warp_reduce_1 = warmup_block_max;
+                        #pragma unroll
+                        for (int offset = 16; offset > 0; offset >>= 1)
+                            _warp_reduce_1 = max_noftz(_warp_reduce_1, __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_1, offset));
+                        warmup_block_max = _warp_reduce_1;
+                        if (state_row == 0 && warmup_block_max <= -30.0f) {
+                            smem_work_item_compute_start[0] = warmup_chunk;
+                            smem_work_item_resolved[0] = 1;
+                        }
+                        asm volatile("barrier.sync 9, 128;" ::: "memory");
+                    }
+                }
+                split_compute_start = smem_work_item_compute_start[0];
+                int warmup_num_chunks = ((int)(cu_seqlens[warmup_sequence + 1] - warmup_sequence_bos) + 32 - 1) / 32;
+                if (state_row == 0) {
+                    seq_order[item_base + 4] = warmup_num_chunks;
+                }
+                if (compute_local_warp == 0) {
+                    if (elect_sync()) {
+                        mbarrier_arrive(work_item_ready_addr);
+                    }
+                }
+            }
+            int item_base_1 = task_idx * 5;
+            int seq_idx = seq_order[item_base_1];
+            int head_idx = seq_order[item_base_1 + 1];
+            int compute_start = split_compute_start;
+            int write_start = seq_order[item_base_1 + 2];
+            int write_end = seq_order[item_base_1 + 3];
+            long long sequence_bos = cu_seqlens[seq_idx];
+            long long sequence_eos = cu_seqlens[seq_idx + 1];
+            long long bos = sequence_bos + (long long)compute_start * 32;
+            long long _min_6 = ((sequence_eos) < (sequence_bos + (long long)write_end * 32) ? (sequence_eos) : (sequence_bos + (long long)write_end * 32));
+            long long eos = _min_6;
+            int seq_len = (int)(eos - bos);
+            int num_chunks = (seq_len + 32 - 1) / 32;
+            long long total_chunks = cu_chunk_offsets[num_sequences];
+            long long fallback_head = total_chunks * (long long)num_heads + (long long)seq_idx * (long long)num_heads + (long long)head_idx;
+            {
+                if (compute_local_warp == 0) {
+                    if (elect_sync()) {
+                        state_checkpoint_needed[total_chunks * (long long)num_heads + (long long)task_idx] = 0;
+                    }
+                }
+            }
+            const int tmem_row_base = warp_in_wg * 32 << 16;
+            long long state_base = (((long long)seq_idx * (long long)num_heads + (long long)head_idx) * 128 + (long long)state_row) * 128;
+            #pragma unroll
+            for (int state_col_block = 0; state_col_block < 4; state_col_block++) {
+                float state_frag[32];
+                state_frag[0] = 0.0f;
+                state_frag[1] = 0.0f;
+                state_frag[2] = 0.0f;
+                state_frag[3] = 0.0f;
+                state_frag[4] = 0.0f;
+                state_frag[5] = 0.0f;
+                state_frag[6] = 0.0f;
+                state_frag[7] = 0.0f;
+                state_frag[8] = 0.0f;
+                state_frag[9] = 0.0f;
+                state_frag[10] = 0.0f;
+                state_frag[11] = 0.0f;
+                state_frag[12] = 0.0f;
+                state_frag[13] = 0.0f;
+                state_frag[14] = 0.0f;
+                state_frag[15] = 0.0f;
+                state_frag[16] = 0.0f;
+                state_frag[17] = 0.0f;
+                state_frag[18] = 0.0f;
+                state_frag[19] = 0.0f;
+                state_frag[20] = 0.0f;
+                state_frag[21] = 0.0f;
+                state_frag[22] = 0.0f;
+                state_frag[23] = 0.0f;
+                state_frag[24] = 0.0f;
+                state_frag[25] = 0.0f;
+                state_frag[26] = 0.0f;
+                state_frag[27] = 0.0f;
+                state_frag[28] = 0.0f;
+                state_frag[29] = 0.0f;
+                state_frag[30] = 0.0f;
+                state_frag[31] = 0.0f;
+                if (use_initial_state != 0 && compute_start == 0) {
+                    {
+                        float initial_values[8];
+                        #pragma unroll
+                        for (int initial_quarter = 0; initial_quarter < 4; initial_quarter++) {
+                            {
+                                unsigned _ldv8_0_0;
+                                unsigned _ldv8_0_1;
+                                unsigned _ldv8_0_2;
+                                unsigned _ldv8_0_3;
+                                unsigned _ldv8_0_4;
+                                unsigned _ldv8_0_5;
+                                unsigned _ldv8_0_6;
+                                unsigned _ldv8_0_7;
+                                asm volatile(
+                                    "ld.global.v8.b32 {%0, %1, %2, %3, %4, %5, %6, %7}, [%8];"
+                                    : "=r"(_ldv8_0_0), "=r"(_ldv8_0_1), "=r"(_ldv8_0_2), "=r"(_ldv8_0_3), "=r"(_ldv8_0_4), "=r"(_ldv8_0_5), "=r"(_ldv8_0_6), "=r"(_ldv8_0_7) : "l"((const void*)(initial_state_f32 + (state_base + (long long)(state_col_block * 32) + (long long)(initial_quarter * 8)))) : "memory");
+                                initial_values[0 + 0] = __uint_as_float(_ldv8_0_0);
+                                initial_values[0 + 1] = __uint_as_float(_ldv8_0_1);
+                                initial_values[0 + 2] = __uint_as_float(_ldv8_0_2);
+                                initial_values[0 + 3] = __uint_as_float(_ldv8_0_3);
+                                initial_values[0 + 4] = __uint_as_float(_ldv8_0_4);
+                                initial_values[0 + 5] = __uint_as_float(_ldv8_0_5);
+                                initial_values[0 + 6] = __uint_as_float(_ldv8_0_6);
+                                initial_values[0 + 7] = __uint_as_float(_ldv8_0_7);
+                            }
+                            #pragma unroll
+                            for (int initial_item = 0; initial_item < 8; initial_item++) {
+                                __nv_bfloat16 _cvt_bf16_9 = __float2bfloat16(initial_values[initial_item]);
+                                float _cvt_f32_19 = __bfloat162float(_cvt_bf16_9);
+                                state_frag[initial_quarter * 8 + initial_item] = _cvt_f32_19;
+                            }
+                        }
+                    }
+                }
+                tmem_st_x32_f32(taddr + 64 + (unsigned int)tmem_row_base + (unsigned int)(state_col_block * 32), state_frag);
+            }
+            asm volatile("tcgen05.wait::st.sync.aligned;" ::: "memory");
+            {
+                if (compute_local_warp == 0 && compute_start == 0) {
+                    if (elect_sync()) {
+                        long long first_chunk_head = cu_chunk_offsets[seq_idx] * (long long)num_heads + (long long)head_idx;
+                        state_checkpoint_needed[first_chunk_head] = 0;
+                    }
+                }
+            }
+            unsigned int compute_stage = 0;
+            unsigned int checkpoint_stage_compute = 0;
+            float _exp2_10 = approx_exp2(lower_bound * 1.4426950408889634f * 16.0f);
+            unsigned int _phase_checkpoint_free = 1;
+            unsigned int _phase_qk_full = 0;
+            unsigned int _phase_v_full = 0;
+            unsigned int _phase_old_out_ready = 0;
+            unsigned int _phase_u2_acc_ready = 0;
+            unsigned int _phase_final_ready = 0;
+            #pragma unroll 1
+            for (int chunk_idx = 0; chunk_idx < num_chunks; chunk_idx++) {
+                int chunk_global_local = compute_start + chunk_idx;
+                int owned_chunk = chunk_global_local >= write_start && chunk_global_local < write_end;
+                int checkpoint_token_entering = chunk_idx * 32;
+                int checkpoint_entering = checkpoint_every_n_tokens != 0 && checkpoint_token_entering % checkpoint_every_n_tokens == 0;
+                float state_panel0[32];
+                float state_panel1[32];
+                float state_panel2[32];
+                float state_panel3[32];
+                unsigned int state_packed0[16];
+                unsigned int state_packed1[16];
+                unsigned int state_packed2[16];
+                unsigned int state_packed3[16];
+                mbarrier_wait(qk_full_addr + (compute_stage) * 8, _phase_qk_full);
+                #pragma unroll 1
+                for (int state_col_block_1 = 0; state_col_block_1 < ((0) ? 4 : 3); state_col_block_1++) {
+                    int state_addr = taddr + 64 + (unsigned int)tmem_row_base + (unsigned int)(state_col_block_1 * 32);
+                    float _tmem_load_1[32];
+                    tmem_ld_x32(&_tmem_load_1[0], state_addr);
+                    asm volatile("tcgen05.wait::ld.sync.aligned;");
+                    uint32_t _tmem_load_1_bf16[16];
+                    #pragma unroll
+                    for (int _lp = 0; _lp < 16; _lp++) {
+                        __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(_tmem_load_1[_lp*2 + 0], _tmem_load_1[_lp*2+1 + 0]));
+                        _tmem_load_1_bf16[_lp] = *(uint32_t*)&_bf2;
+                    }
+                    asm volatile(
+                        "tcgen05.st.sync.aligned.32x32b.x16.b32"
+                        " [%0], {%1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15, %16};"
+                        :: "r"(taddr + (unsigned int)tmem_row_base + (unsigned int)(state_col_block_1 * 16)), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_1_bf16[0])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_1_bf16[1])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_1_bf16[2])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_1_bf16[3])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_1_bf16[4])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_1_bf16[5])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_1_bf16[6])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_1_bf16[7])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_1_bf16[8])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_1_bf16[9])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_1_bf16[10])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_1_bf16[11])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_1_bf16[12])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_1_bf16[13])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_1_bf16[14])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_1_bf16[15])));
+                    float state_scale[16];
+                    #pragma unroll
+                    for (int state_half = 0; state_half < 2; state_half++) {
+                        #pragma unroll
+                        for (int state_col = 0; state_col < 16; state_col++) {
+                            state_scale[state_col] = smem_gt_all[compute_stage * 10496 + (unsigned int)(state_col_block_1 * 32) + (unsigned int)(state_half * 16) + (unsigned int)state_col];
+                        }
+                        #pragma unroll
+                        for (int _ls = 0; _ls < 8; _ls++)
+                            mul_f32x2_inplace(&reinterpret_cast<float2*>((_tmem_load_1 + state_half * 16))[_ls], reinterpret_cast<const float2*>(state_scale)[_ls]);
+                    }
+                    tmem_st_x32_f32(state_addr, _tmem_load_1);
+                }
+                int state_tail_addr = taddr + 64 + (unsigned int)tmem_row_base + 96;
+                float state_tail_frag[32];
+                unsigned int state_tail_packed[16];
+                {
+                    tmem_ld_x32(&state_tail_frag[0], state_tail_addr);
+                    #pragma unroll
+                    for (int _lp = 0; _lp < 16; _lp++) {
+                        __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(state_tail_frag[_lp*2 + 0], state_tail_frag[_lp*2+1 + 0]));
+                        state_tail_packed[_lp] = *(uint32_t*)&_bf2;
+                    }
+                    asm volatile(
+                        "tcgen05.st.sync.aligned.32x32b.x16.b32"
+                        " [%0], {%1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15, %16};"
+                        :: "r"(taddr + (unsigned int)tmem_row_base + 48), "r"(*reinterpret_cast<const uint32_t*>(&state_tail_packed[0])), "r"(*reinterpret_cast<const uint32_t*>(&state_tail_packed[1])), "r"(*reinterpret_cast<const uint32_t*>(&state_tail_packed[2])), "r"(*reinterpret_cast<const uint32_t*>(&state_tail_packed[3])), "r"(*reinterpret_cast<const uint32_t*>(&state_tail_packed[4])), "r"(*reinterpret_cast<const uint32_t*>(&state_tail_packed[5])), "r"(*reinterpret_cast<const uint32_t*>(&state_tail_packed[6])), "r"(*reinterpret_cast<const uint32_t*>(&state_tail_packed[7])), "r"(*reinterpret_cast<const uint32_t*>(&state_tail_packed[8])), "r"(*reinterpret_cast<const uint32_t*>(&state_tail_packed[9])), "r"(*reinterpret_cast<const uint32_t*>(&state_tail_packed[10])), "r"(*reinterpret_cast<const uint32_t*>(&state_tail_packed[11])), "r"(*reinterpret_cast<const uint32_t*>(&state_tail_packed[12])), "r"(*reinterpret_cast<const uint32_t*>(&state_tail_packed[13])), "r"(*reinterpret_cast<const uint32_t*>(&state_tail_packed[14])), "r"(*reinterpret_cast<const uint32_t*>(&state_tail_packed[15])));
+                }
+                asm volatile("tcgen05.wait::st.sync.aligned;" ::: "memory");
+                if (elect_sync()) {
+                    mbarrier_arrive(state_inp_ready_addr + (compute_stage) * 8);
+                }
+                {
+                    float state_tail_scale[16];
+                    #pragma unroll
+                    for (int state_half_1 = 0; state_half_1 < 2; state_half_1++) {
+                        #pragma unroll
+                        for (int state_col_1 = 0; state_col_1 < 16; state_col_1++) {
+                            state_tail_scale[state_col_1] = smem_gt_all[compute_stage * 10496 + 96 + (unsigned int)(state_half_1 * 16) + (unsigned int)state_col_1];
+                        }
+                        #pragma unroll
+                        for (int _ls = 0; _ls < 8; _ls++)
+                            mul_f32x2_inplace(&reinterpret_cast<float2*>((state_tail_frag + state_half_1 * 16))[_ls], reinterpret_cast<const float2*>(state_tail_scale)[_ls]);
+                    }
+                    tmem_st_x32_f32(state_tail_addr, state_tail_frag);
+                }
+                mbarrier_wait(v_full_addr + (compute_stage) * 8, _phase_v_full);
+                unsigned int v_prefetch_bits[8];
+                mbarrier_wait(old_out_ready_addr + (compute_stage) * 8, _phase_old_out_ready);
+                float _tmem_load_2[32];
+                tmem_ld_x32(&_tmem_load_2[0], taddr + 224 + (unsigned int)tmem_row_base);
+                asm volatile("tcgen05.wait::ld.sync.aligned;");
+                {
+                    const float2 _scale2_1 = {_exp2_10, _exp2_10};
+                    #pragma unroll
+                    for (int _ls = 0; _ls < 16; _ls++)
+                        mul_f32x2_inplace(&reinterpret_cast<float2*>(_tmem_load_2)[_ls], _scale2_1);
+                }
+                long long chunk_global_e = cu_chunk_offsets[seq_idx] + (long long)chunk_global_local;
+                long long tape_ex_base = ((chunk_global_e * (long long)num_heads + (long long)head_idx) * 128 + (long long)state_row) * 32;
+                #pragma unroll
+                for (int residual_half = 0; residual_half < 2; residual_half++) {
+                    float residual_v[16];
+                    float residual_beta[16];
+                    #pragma unroll
+                    for (int residual_col = 0; residual_col < 16; residual_col++) {
+                        int token_col = residual_half * 16 + residual_col;
+                        {
+                            __nv_bfloat16 v_value = smem_v_all[compute_stage * 20992 + (unsigned int)(token_col * 128) + (unsigned int)state_row];
+                            float _cvt_f32_20 = __bfloat162float(v_value);
+                            residual_v[residual_col] = _cvt_f32_20;
+                            residual_beta[residual_col] = smem_prep_beta_all[compute_stage * 10496 + (unsigned int)token_col];
+                        }
+                    }
+                    {
+                        #pragma unroll
+                        for (int _ls = 0; _ls < 8; _ls++)
+                            sub_f32x2_inplace(&reinterpret_cast<float2*>(residual_v)[_ls], reinterpret_cast<const float2*>((_tmem_load_2 + residual_half * 16))[_ls]);
+                    }
+                    if (STORE_BACKWARD_TAPE != 0 && STORE_E_TAPE != 0 && owned_chunk != 0) {
+                        {
+                            __nv_bfloat162 _pk[4];
+                            _pk[0] = __floats2bfloat162_rn(residual_v[0 + 0], residual_v[0 + 1]);
+                            _pk[1] = __floats2bfloat162_rn(residual_v[0 + 2], residual_v[0 + 3]);
+                            _pk[2] = __floats2bfloat162_rn(residual_v[0 + 4], residual_v[0 + 5]);
+                            _pk[3] = __floats2bfloat162_rn(residual_v[0 + 6], residual_v[0 + 7]);
+                            *reinterpret_cast<uint4*>(&((__nv_bfloat16*)(tape_e + (tape_ex_base + (long long)(residual_half * 16))))[0]) = *reinterpret_cast<uint4*>(&_pk[0]);
+                        }
+                        {
+                            __nv_bfloat162 _pk[4];
+                            _pk[0] = __floats2bfloat162_rn(residual_v[8 + 0], residual_v[8 + 1]);
+                            _pk[1] = __floats2bfloat162_rn(residual_v[8 + 2], residual_v[8 + 3]);
+                            _pk[2] = __floats2bfloat162_rn(residual_v[8 + 4], residual_v[8 + 5]);
+                            _pk[3] = __floats2bfloat162_rn(residual_v[8 + 6], residual_v[8 + 7]);
+                            *reinterpret_cast<uint4*>(&((__nv_bfloat16*)(tape_e + (tape_ex_base + (long long)(residual_half * 16) + 8)))[0]) = *reinterpret_cast<uint4*>(&_pk[0]);
+                        }
+                    }
+                    {
+                        #pragma unroll
+                        for (int _ls = 0; _ls < 8; _ls++)
+                            mul_f32x2_inplace(&reinterpret_cast<float2*>(residual_v)[_ls], reinterpret_cast<const float2*>(residual_beta)[_ls]);
+                        if (STORE_BACKWARD_TAPE != 0 && owned_chunk != 0) {
+                            {
+                                __nv_bfloat162 _pk[4];
+                                _pk[0] = __floats2bfloat162_rn(residual_v[0 + 0], residual_v[0 + 1]);
+                                _pk[1] = __floats2bfloat162_rn(residual_v[0 + 2], residual_v[0 + 3]);
+                                _pk[2] = __floats2bfloat162_rn(residual_v[0 + 4], residual_v[0 + 5]);
+                                _pk[3] = __floats2bfloat162_rn(residual_v[0 + 6], residual_v[0 + 7]);
+                                *reinterpret_cast<uint4*>(&((__nv_bfloat16*)(tape_x + (tape_ex_base + (long long)(residual_half * 16))))[0]) = *reinterpret_cast<uint4*>(&_pk[0]);
+                            }
+                            {
+                                __nv_bfloat162 _pk[4];
+                                _pk[0] = __floats2bfloat162_rn(residual_v[8 + 0], residual_v[8 + 1]);
+                                _pk[1] = __floats2bfloat162_rn(residual_v[8 + 2], residual_v[8 + 3]);
+                                _pk[2] = __floats2bfloat162_rn(residual_v[8 + 4], residual_v[8 + 5]);
+                                _pk[3] = __floats2bfloat162_rn(residual_v[8 + 6], residual_v[8 + 7]);
+                                *reinterpret_cast<uint4*>(&((__nv_bfloat16*)(tape_x + (tape_ex_base + (long long)(residual_half * 16) + 8)))[0]) = *reinterpret_cast<uint4*>(&_pk[0]);
+                            }
+                        }
+                        uint32_t residual_v_bf16[8];
+                        #pragma unroll
+                        for (int _lp = 0; _lp < 8; _lp++) {
+                            __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(residual_v[_lp*2 + 0], residual_v[_lp*2+1 + 0]));
+                            residual_v_bf16[_lp] = *(uint32_t*)&_bf2;
+                        }
+                        tmem_st_x8_u32(taddr + 224 + (unsigned int)tmem_row_base + (unsigned int)(residual_half * 8), (const uint32_t*)residual_v_bf16);
+                    }
+                }
+                asm volatile("tcgen05.wait::st.sync.aligned;" ::: "memory");
+                if (elect_sync()) {
+                    mbarrier_arrive(v_free_addr + (compute_stage) * 8);
+                    mbarrier_arrive(u_inp_ready_addr + (compute_stage) * 8);
+                }
+                mbarrier_wait(u2_acc_ready_addr + (compute_stage) * 8, _phase_u2_acc_ready);
+                float _tmem_load_4[32];
+                tmem_ld_x32(&_tmem_load_4[0], taddr + (unsigned int)tmem_row_base);
+                asm volatile("tcgen05.wait::ld.sync.aligned;");
+                if (STORE_BACKWARD_TAPE != 0 && owned_chunk != 0) {
+                    long long chunk_global_r = cu_chunk_offsets[seq_idx] + (long long)chunk_global_local;
+                    long long tape_r_base = ((chunk_global_r * (long long)num_heads + (long long)head_idx) * 128 + (long long)state_row) * 32;
+                    #pragma unroll
+                    for (int tape_r_vec = 0; tape_r_vec < 4; tape_r_vec++) {
+                        {
+                            __nv_bfloat162 _pk[4];
+                            _pk[0] = __floats2bfloat162_rn(_tmem_load_4[tape_r_vec * 8 + 0], _tmem_load_4[tape_r_vec * 8 + 1]);
+                            _pk[1] = __floats2bfloat162_rn(_tmem_load_4[tape_r_vec * 8 + 2], _tmem_load_4[tape_r_vec * 8 + 3]);
+                            _pk[2] = __floats2bfloat162_rn(_tmem_load_4[tape_r_vec * 8 + 4], _tmem_load_4[tape_r_vec * 8 + 5]);
+                            _pk[3] = __floats2bfloat162_rn(_tmem_load_4[tape_r_vec * 8 + 6], _tmem_load_4[tape_r_vec * 8 + 7]);
+                            *reinterpret_cast<uint4*>(&((__nv_bfloat16*)(tape_r + (tape_r_base + (long long)(tape_r_vec * 8))))[0]) = *reinterpret_cast<uint4*>(&_pk[0]);
+                        }
+                    }
+                }
+                uint32_t _tmem_load_4_bf16[16];
+                #pragma unroll
+                for (int _lp = 0; _lp < 16; _lp++) {
+                    __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(_tmem_load_4[_lp*2 + 0], _tmem_load_4[_lp*2+1 + 0]));
+                    _tmem_load_4_bf16[_lp] = *(uint32_t*)&_bf2;
+                }
+                asm volatile(
+                    "tcgen05.st.sync.aligned.32x32b.x16.b32"
+                    " [%0], {%1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15, %16};"
+                    :: "r"(taddr + 224 + (unsigned int)tmem_row_base), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_4_bf16[0])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_4_bf16[1])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_4_bf16[2])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_4_bf16[3])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_4_bf16[4])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_4_bf16[5])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_4_bf16[6])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_4_bf16[7])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_4_bf16[8])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_4_bf16[9])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_4_bf16[10])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_4_bf16[11])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_4_bf16[12])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_4_bf16[13])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_4_bf16[14])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_4_bf16[15])));
+                asm volatile("tcgen05.wait::st.sync.aligned;" ::: "memory");
+                if (elect_sync()) {
+                    mbarrier_arrive(u2_inp_ready_addr + (compute_stage) * 8);
+                }
+                mbarrier_wait(final_ready_addr + (compute_stage) * 8, _phase_final_ready);
+                {
+                    int next_chunk_global_local = chunk_global_local + 1;
+                    if (next_chunk_global_local >= write_start && next_chunk_global_local < write_end) {
+                        int checkpoint_needed = smem_state_checkpoint_needed[compute_stage * 4] != 0 || smem_state_checkpoint_needed[compute_stage * 4 + 1] != 0 || smem_state_checkpoint_needed[compute_stage * 4 + 2] != 0 || smem_state_checkpoint_needed[compute_stage * 4 + 3] != 0;
+                        if (compute_local_warp == 0) {
+                            if (elect_sync()) {
+                                long long chunk_global_next = cu_chunk_offsets[seq_idx] + (long long)next_chunk_global_local;
+                                state_checkpoint_needed[chunk_global_next * (long long)num_heads + (long long)head_idx] = (unsigned int)checkpoint_needed;
+                                if (SPLIT_WORK_ITEMS == 0 && checkpoint_needed != 0) {
+                                    state_checkpoint_needed[fallback_head] = 1;
+                                }
+                                if (SPLIT_WORK_ITEMS != 0 && checkpoint_needed != 0) {
+                                    state_checkpoint_needed[total_chunks * (long long)num_heads + (long long)task_idx] = 1;
+                                }
+                            }
+                        }
+                    }
+                    if (compute_local_warp == 0) {
+                        if (elect_sync()) {
+                            mbarrier_arrive(smem_free_addr + (compute_stage) * 8);
+                        }
+                    }
+                }
+                compute_stage += 1;
+                if (compute_stage == 5) { compute_stage = 0; _phase_qk_full ^= 1; _phase_v_full ^= 1; _phase_old_out_ready ^= 1; _phase_u2_acc_ready ^= 1; _phase_final_ready ^= 1; }
+            }
+            if (store_final_state != 0) {
+                #pragma unroll
+                for (int state_col_block_2 = 0; state_col_block_2 < 4; state_col_block_2++) {
+                    float _tmem_load_6[32];
+                    tmem_ld_x32(&_tmem_load_6[0], taddr + 64 + (unsigned int)tmem_row_base + (unsigned int)(state_col_block_2 * 32));
+                    asm volatile("tcgen05.wait::ld.sync.aligned;");
+                    {
+                        __nv_bfloat162 _pk[8];
+                        _pk[0] = __floats2bfloat162_rn(_tmem_load_6[0 + 0], _tmem_load_6[0 + 1]);
+                        _pk[1] = __floats2bfloat162_rn(_tmem_load_6[0 + 2], _tmem_load_6[0 + 3]);
+                        _pk[2] = __floats2bfloat162_rn(_tmem_load_6[0 + 4], _tmem_load_6[0 + 5]);
+                        _pk[3] = __floats2bfloat162_rn(_tmem_load_6[0 + 6], _tmem_load_6[0 + 7]);
+                        _pk[4] = __floats2bfloat162_rn(_tmem_load_6[0 + 8], _tmem_load_6[0 + 9]);
+                        _pk[5] = __floats2bfloat162_rn(_tmem_load_6[0 + 10], _tmem_load_6[0 + 11]);
+                        _pk[6] = __floats2bfloat162_rn(_tmem_load_6[0 + 12], _tmem_load_6[0 + 13]);
+                        _pk[7] = __floats2bfloat162_rn(_tmem_load_6[0 + 14], _tmem_load_6[0 + 15]);
+                        *reinterpret_cast<uint4*>(&((__nv_bfloat16*)(final_state + (state_base + (long long)(state_col_block_2 * 32))))[0]) = *reinterpret_cast<uint4*>(&_pk[0]);
+                        *reinterpret_cast<uint4*>(&((__nv_bfloat16*)(final_state + (state_base + (long long)(state_col_block_2 * 32))))[8]) = *reinterpret_cast<uint4*>(&_pk[4]);
+                    }
+                    {
+                        __nv_bfloat162 _pk[8];
+                        _pk[0] = __floats2bfloat162_rn(_tmem_load_6[16 + 0], _tmem_load_6[16 + 1]);
+                        _pk[1] = __floats2bfloat162_rn(_tmem_load_6[16 + 2], _tmem_load_6[16 + 3]);
+                        _pk[2] = __floats2bfloat162_rn(_tmem_load_6[16 + 4], _tmem_load_6[16 + 5]);
+                        _pk[3] = __floats2bfloat162_rn(_tmem_load_6[16 + 6], _tmem_load_6[16 + 7]);
+                        _pk[4] = __floats2bfloat162_rn(_tmem_load_6[16 + 8], _tmem_load_6[16 + 9]);
+                        _pk[5] = __floats2bfloat162_rn(_tmem_load_6[16 + 10], _tmem_load_6[16 + 11]);
+                        _pk[6] = __floats2bfloat162_rn(_tmem_load_6[16 + 12], _tmem_load_6[16 + 13]);
+                        _pk[7] = __floats2bfloat162_rn(_tmem_load_6[16 + 14], _tmem_load_6[16 + 15]);
+                        *reinterpret_cast<uint4*>(&((__nv_bfloat16*)(final_state + (state_base + (long long)(state_col_block_2 * 32) + 16)))[0]) = *reinterpret_cast<uint4*>(&_pk[0]);
+                        *reinterpret_cast<uint4*>(&((__nv_bfloat16*)(final_state + (state_base + (long long)(state_col_block_2 * 32) + 16)))[8]) = *reinterpret_cast<uint4*>(&_pk[4]);
+                    }
+                }
+            }
+            asm volatile("barrier.sync 9, 128;" ::: "memory");
+            if (compute_local_warp == 0) {
+                if (elect_sync()) {
+                    mbarrier_arrive(tmem_dealloc_ready_addr);
+                }
+            }
+        }
+    }
+    // ---- Role: epilogue ----
+    if (warp >= 4 && warp <= 7) {
+        asm volatile("setmaxnreg.dec.sync.aligned.u32 48;");
+        { // epilogue_main
+            int task_idx_1 = blockIdx.x;
+            int split_compute_start_1 = 0;
+            unsigned int _phase_work_item_ready_0 = 0;
+            {
+                mbarrier_wait(work_item_ready_addr, _phase_work_item_ready_0);
+                _phase_work_item_ready_0 ^= 1;
+                split_compute_start_1 = smem_work_item_compute_start[0];
+            }
+            int item_base_2 = task_idx_1 * 5;
+            int seq_idx_1 = seq_order[item_base_2];
+            int head_idx_1 = seq_order[item_base_2 + 1];
+            int compute_start_1 = split_compute_start_1;
+            int write_start_1 = seq_order[item_base_2 + 2];
+            int write_end_1 = seq_order[item_base_2 + 3];
+            long long sequence_bos_1 = cu_seqlens[seq_idx_1];
+            long long sequence_eos_1 = cu_seqlens[seq_idx_1 + 1];
+            long long bos_1 = sequence_bos_1 + (long long)compute_start_1 * 32;
+            long long _min_7 = ((sequence_eos_1) < (sequence_bos_1 + (long long)write_end_1 * 32) ? (sequence_eos_1) : (sequence_bos_1 + (long long)write_end_1 * 32));
+            long long eos_1 = _min_7;
+            int seq_len_1 = (int)(eos_1 - bos_1);
+            int num_chunks_1 = (seq_len_1 + 32 - 1) / 32;
+            int warp_id_in_role_1 = (warp - 4);
+            int epilogue_local_warp = warp_id_in_role_1;
+            int warp_in_wg_1 = warp % 4;
+            const int tmem_row_base_1 = warp_in_wg_1 * 32 << 16;
+            int state_row_1 = warp_in_wg_1 * 32 + lane;
+            unsigned int epilogue_stage = 0;
+            unsigned int output_stage = 0;
+            unsigned int checkpoint_stage_epilogue = 0;
+            int epilogue_chunks = num_chunks_1;
+            {
+                epilogue_chunks = 0;
+            }
+            unsigned int _phase_checkpoint_ready = 0;
+            unsigned int _phase_final_ready_1 = 0;
+            #pragma unroll 1
+            for (int chunk_idx_1 = 0; chunk_idx_1 < epilogue_chunks; chunk_idx_1++) {
+                int checkpoint_token_epilogue = chunk_idx_1 * 32;
+                int checkpoint_entering_epilogue = checkpoint_every_n_tokens != 0 && checkpoint_token_epilogue % checkpoint_every_n_tokens == 0;
+                int chunk_is_full = ((seq_len_1 >= (chunk_idx_1 + 1) * 32) ? 1 : 0);
+                if (chunk_is_full != 0) {
+                    mbarrier_wait(final_ready_addr + (epilogue_stage) * 8, _phase_final_ready_1);
+                    float _tmem_load_7[16];
+                    asm volatile(
+                        "tcgen05.ld.sync.aligned.16x256b.x4.b32"
+                        " {%0, %1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15}, [%16];"
+                        : "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_7[0])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_7[1])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_7[2])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_7[3])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_7[4])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_7[5])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_7[6])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_7[7])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_7[8])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_7[9])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_7[10])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_7[11])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_7[12])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_7[13])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_7[14])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_7[15]))
+                        : "r"(taddr + 192 + (unsigned int)tmem_row_base_1));
+                    float _tmem_load_8[16];
+                    asm volatile(
+                        "tcgen05.ld.sync.aligned.16x256b.x4.b32"
+                        " {%0, %1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15}, [%16];"
+                        : "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_8[0])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_8[1])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_8[2])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_8[3])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_8[4])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_8[5])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_8[6])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_8[7])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_8[8])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_8[9])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_8[10])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_8[11])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_8[12])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_8[13])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_8[14])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_8[15]))
+                        : "r"(taddr + 192 + (unsigned int)tmem_row_base_1 + 1048576));
+                    asm volatile("tcgen05.wait::ld.sync.aligned;" ::: "memory");
+                    asm volatile("barrier.sync 8, 128;" ::: "memory");
+                    if (epilogue_local_warp == 0) {
+                        if (elect_sync()) {
+                            mbarrier_arrive(out_empty_addr);
+                        }
+                    }
+                    if (epilogue_local_warp == 0) {
+                        if (chunk_idx_1 >= 2) {
+                            asm volatile("cp.async.bulk.wait_group.read 1;");
+                        }
+                    }
+                    asm volatile("barrier.sync 8, 128;" ::: "memory");
+                    int out_stage_addr = smem_out_addr + output_stage * 8192;
+                    #pragma unroll
+                    for (int dim_half = 0; dim_half < 2; dim_half++) {
+                        unsigned int out_packed[8];
+                        if (dim_half == 0) {
+                            #pragma unroll
+                            for (int _lp = 0; _lp < 8; _lp++) {
+                                __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(_tmem_load_7[_lp*2 + 0], _tmem_load_7[_lp*2+1 + 0]));
+                                out_packed[_lp] = *(uint32_t*)&_bf2;
+                            }
+                        } else {
+                            #pragma unroll
+                            for (int _lp = 0; _lp < 8; _lp++) {
+                                __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(_tmem_load_8[_lp*2 + 0], _tmem_load_8[_lp*2+1 + 0]));
+                                out_packed[_lp] = *(uint32_t*)&_bf2;
+                            }
+                        }
+                        #pragma unroll
+                        for (int token_group = 0; token_group < 2; token_group++) {
+                            int mtx_idx = lane / 8;
+                            int row_addr = lane & 7;
+                            int dim_base = epilogue_local_warp * 32 + dim_half * 16 + (mtx_idx & 1) * 8;
+                            int token_base = token_group * 16 + mtx_idx / 2 * 8;
+                            int token_addr = token_base + row_addr;
+                            int token_pair = token_addr / 2;
+                            int token_parity = token_addr & 1;
+                            int raw_row = token_pair + dim_base / 64 * 16;
+                            int raw_col = (dim_base & 63 ^ (token_pair & 3) << 4 ^ token_parity << 3) + token_parity * 64;
+                            int stsm_offset = (raw_row * 128 + raw_col) * 2;
+                            const int pack_base = token_group * 4;
+                            uint32_t _stmatrix_addr_0 = static_cast<uint32_t>((unsigned long long)(out_stage_addr + stsm_offset));
+                            asm volatile("stmatrix.sync.aligned.m8n8.x4.trans.shared.b16 [%0], {%1, %2, %3, %4};\n"
+                                :: "r"(_stmatrix_addr_0), "r"(*reinterpret_cast<const uint32_t*>(&out_packed[pack_base])), "r"(*reinterpret_cast<const uint32_t*>(&out_packed[pack_base + 1])), "r"(*reinterpret_cast<const uint32_t*>(&out_packed[pack_base + 2])), "r"(*reinterpret_cast<const uint32_t*>(&out_packed[pack_base + 3]))
+                                : "memory");
+                        }
+                    }
+                    asm volatile("fence.proxy.async.shared::cta;" ::: "memory");
+                    asm volatile("barrier.sync 8, 128;" ::: "memory");
+                    if (epilogue_local_warp == 0) {
+                        if (elect_sync()) {
+                            tma_store_4d(out_tma, 0, (int)(bos_1 + (long long)(chunk_idx_1 * 32)), head_idx_1, 0, smem_out_addr + output_stage * 8192);
+                        }
+                        asm volatile("cp.async.bulk.commit_group;");
+                    }
+                    output_stage = output_stage ^ 1;
+                } else {
+                    mbarrier_wait(final_ready_addr + (epilogue_stage) * 8, _phase_final_ready_1);
+                    float _tmem_load_9[32];
+                    tmem_ld_x32(&_tmem_load_9[0], taddr + 192 + (unsigned int)tmem_row_base_1);
+                    asm volatile("tcgen05.wait::ld.sync.aligned;" ::: "memory");
+                    asm volatile("barrier.sync 8, 128;" ::: "memory");
+                    if (epilogue_local_warp == 0) {
+                        if (elect_sync()) {
+                            mbarrier_arrive(out_empty_addr);
+                        }
+                    }
+                    #pragma unroll
+                    for (int token_col_1 = 0; token_col_1 < 32; token_col_1++) {
+                        long long out_token = bos_1 + (long long)(chunk_idx_1 * 32 + token_col_1);
+                        if (out_token < eos_1) {
+                            long long out_idx = (out_token * (long long)num_heads + (long long)head_idx_1) * 128 + (long long)state_row_1;
+                            out[out_idx] = _tmem_load_9[token_col_1];
+                        }
+                    }
+                }
+                epilogue_stage += 1;
+                if (epilogue_stage == 5) { epilogue_stage = 0; _phase_final_ready_1 ^= 1; }
+            }
+            if (epilogue_local_warp == 0) {
+                if (elect_sync()) {
+                    mbarrier_arrive(tmem_dealloc_ready_addr);
+                }
+            }
+        }
+    }
+    // ---- Role: beta_prefetch ----
+    if (warp == 8) {
+        { // beta_prefetch_main
+
+        }
+    }
+    // ---- Role: aux_mma ----
+    if (warp >= 10 && warp <= 11) {
+        { // aux_mma_main
+            unsigned int _phase_work_item_ready_0_1 = 0;
+            unsigned int _phase_tape_ready = 0;
+            {
+                int task_idx_2 = blockIdx.x;
+                int split_compute_start_2 = 0;
+                {
+                    mbarrier_wait(work_item_ready_addr, _phase_work_item_ready_0_1);
+                    _phase_work_item_ready_0_1 ^= 1;
+                    split_compute_start_2 = smem_work_item_compute_start[0];
+                }
+                int item_base_3 = task_idx_2 * 5;
+                int seq_idx_2 = seq_order[item_base_3];
+                int head_idx_2 = seq_order[item_base_3 + 1];
+                int compute_start_2 = split_compute_start_2;
+                int write_start_2 = seq_order[item_base_3 + 2];
+                int write_end_2 = seq_order[item_base_3 + 3];
+                long long sequence_bos_2 = cu_seqlens[seq_idx_2];
+                long long sequence_eos_2 = cu_seqlens[seq_idx_2 + 1];
+                long long bos_2 = sequence_bos_2 + (long long)compute_start_2 * 32;
+                long long _min_4 = ((sequence_eos_2) < (sequence_bos_2 + (long long)write_end_2 * 32) ? (sequence_eos_2) : (sequence_bos_2 + (long long)write_end_2 * 32));
+                long long eos_2 = _min_4;
+                int seq_len_2 = (int)(eos_2 - bos_2);
+                int num_chunks_2 = (seq_len_2 + 32 - 1) / 32;
+                int warp_id_in_role_2 = (warp - 10);
+                int tape_tid = warp_id_in_role_2 * 32 + lane;
+                int zero_stride = num_bids * 64;
+                #pragma unroll 1
+                for (int zero_item = task_idx_2 * 64 + tape_tid; zero_item < zero_words; zero_item += zero_stride) {
+                    zero_workspace[zero_item] = 0;
+                }
+                unsigned int tape_stage = 0;
+                #pragma unroll 1
+                for (int chunk_idx_2 = 0; chunk_idx_2 < num_chunks_2; chunk_idx_2++) {
+                    mbarrier_wait(tape_ready_addr + (tape_stage) * 8, _phase_tape_ready);
+                    int chunk_global_local_1 = compute_start_2 + chunk_idx_2;
+                    int owned_chunk_1 = chunk_global_local_1 >= write_start_2 && chunk_global_local_1 < write_end_2;
+                    long long chunk_global = cu_chunk_offsets[seq_idx_2] + (long long)chunk_global_local_1;
+                    long long tape_vec_base = (chunk_global * (long long)num_heads + (long long)head_idx_2) * 32 * 128;
+                    #pragma unroll
+                    for (int tape_pass = 0; tape_pass < 8; tape_pass++) {
+                        int tape_item = tape_pass * 64 + tape_tid;
+                        int tape_row = tape_item / 16;
+                        int tape_segment = tape_item % 16;
+                        float tape_kr_values[8];
+                        unsigned int packed[4];
+                        asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                            : "=r"(*reinterpret_cast<uint32_t*>(&packed[0])), "=r"(*reinterpret_cast<uint32_t*>(&packed[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&packed[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&packed[(0) + 3]))
+                            : "r"((smem_kr_trans_addr + tape_stage * 41984 + (unsigned int)(tape_segment * 8 / 64 * 4096 + tape_row * 128 + tape_segment * 8 % 64 * 2 ^ (tape_segment * 8 / 64 * 4096 + tape_row * 128 + tape_segment * 8 % 64 * 2 >> 7 & 7) << 4))));
+                        float packed_f32[8];
+                        #pragma unroll
+                        for (int _pair = 0; _pair < 4; _pair++) {
+                            asm volatile(
+                                "{\n\t"
+                                "shl.b32 %0, %2, 16;\n\t"
+                                "and.b32 %1, %2, 0xffff0000;\n\t"
+                                "}\n"
+                                : "=f"((&packed_f32[_pair * 2])[0]), "=f"((&packed_f32[_pair * 2])[1])
+                                : "r"(packed[_pair]));
+                        }
+                        #pragma unroll
+                        for (int value_idx = 0; value_idx < 8; value_idx++) {
+                            tape_kr_values[value_idx] = packed_f32[value_idx];
+                        }
+                        long long tape_index = tape_vec_base + (long long)tape_row * 128 + (long long)(tape_segment * 8);
+                        if (owned_chunk_1 != 0) {
+                            {
+                                __nv_bfloat162 _pk[4];
+                                _pk[0] = __floats2bfloat162_rn(tape_kr_values[0 + 0], tape_kr_values[0 + 1]);
+                                _pk[1] = __floats2bfloat162_rn(tape_kr_values[0 + 2], tape_kr_values[0 + 3]);
+                                _pk[2] = __floats2bfloat162_rn(tape_kr_values[0 + 4], tape_kr_values[0 + 5]);
+                                _pk[3] = __floats2bfloat162_rn(tape_kr_values[0 + 6], tape_kr_values[0 + 7]);
+                                *reinterpret_cast<uint4*>(&((__nv_bfloat16*)(tape_kr + tape_index))[0]) = *reinterpret_cast<uint4*>(&_pk[0]);
+                            }
+                        }
+                    }
+                    long long tape_j_base = (chunk_global * (long long)num_heads + (long long)head_idx_2) * 32 * 32;
+                    #pragma unroll
+                    for (int tape_j_pass = 0; tape_j_pass < 2; tape_j_pass++) {
+                        int tape_j_item = tape_j_pass * 64 + tape_tid;
+                        int tape_j_row = tape_j_item / 4;
+                        int tape_j_segment = tape_j_item % 4;
+                        float tape_j_values[8];
+                        unsigned int packed_1[4];
+                        asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                            : "=r"(*reinterpret_cast<uint32_t*>(&packed_1[0])), "=r"(*reinterpret_cast<uint32_t*>(&packed_1[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&packed_1[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&packed_1[(0) + 3]))
+                            : "r"((smem_inv_addr + tape_stage * 41984 + (unsigned int)(tape_j_segment * 8 / 16 * 1024 + tape_j_row * 32 + tape_j_segment * 8 % 16 * 2 ^ (tape_j_segment * 8 / 16 * 1024 + tape_j_row * 32 + tape_j_segment * 8 % 16 * 2 >> 7 & 1) << 4))));
+                        float packed_f32_1[8];
+                        #pragma unroll
+                        for (int _pair = 0; _pair < 4; _pair++) {
+                            asm volatile(
+                                "{\n\t"
+                                "shl.b32 %0, %2, 16;\n\t"
+                                "and.b32 %1, %2, 0xffff0000;\n\t"
+                                "}\n"
+                                : "=f"((&packed_f32_1[_pair * 2])[0]), "=f"((&packed_f32_1[_pair * 2])[1])
+                                : "r"(packed_1[_pair]));
+                        }
+                        #pragma unroll
+                        for (int value_idx_1 = 0; value_idx_1 < 8; value_idx_1++) {
+                            tape_j_values[value_idx_1] = packed_f32_1[value_idx_1];
+                        }
+                        if (owned_chunk_1 != 0) {
+                            {
+                                __nv_bfloat162 _pk[4];
+                                _pk[0] = __floats2bfloat162_rn(tape_j_values[0 + 0], tape_j_values[0 + 1]);
+                                _pk[1] = __floats2bfloat162_rn(tape_j_values[0 + 2], tape_j_values[0 + 3]);
+                                _pk[2] = __floats2bfloat162_rn(tape_j_values[0 + 4], tape_j_values[0 + 5]);
+                                _pk[3] = __floats2bfloat162_rn(tape_j_values[0 + 6], tape_j_values[0 + 7]);
+                                *reinterpret_cast<uint4*>(&((__nv_bfloat16*)(tape_j + (tape_j_base + (long long)tape_j_row * 32 + (long long)(tape_j_segment * 8))))[0]) = *reinterpret_cast<uint4*>(&_pk[0]);
+                            }
+                        }
+                    }
+                    if (elect_sync()) {
+                        mbarrier_arrive(tape_free_addr + (tape_stage) * 8);
+                    }
+                    tape_stage += 1;
+                    if (tape_stage == 5) { tape_stage = 0; _phase_tape_ready ^= 1; }
+                }
+            }
+        }
+    }
+    // ---- Role: mma ----
+    if (warp == 9) {
+        { // mma_main
+            int task_idx_3 = blockIdx.x;
+            int split_compute_start_3 = 0;
+            unsigned int _phase_work_item_ready_0_2 = 0;
+            {
+                mbarrier_wait(work_item_ready_addr, _phase_work_item_ready_0_2);
+                _phase_work_item_ready_0_2 ^= 1;
+                split_compute_start_3 = smem_work_item_compute_start[0];
+            }
+            int item_base_4 = task_idx_3 * 5;
+            int seq_idx_3 = seq_order[item_base_4];
+            int head_idx_3 = seq_order[item_base_4 + 1];
+            int compute_start_3 = split_compute_start_3;
+            int write_start_3 = seq_order[item_base_4 + 2];
+            int write_end_3 = seq_order[item_base_4 + 3];
+            long long sequence_bos_3 = cu_seqlens[seq_idx_3];
+            long long sequence_eos_3 = cu_seqlens[seq_idx_3 + 1];
+            long long bos_3 = sequence_bos_3 + (long long)compute_start_3 * 32;
+            long long _min_8 = ((sequence_eos_3) < (sequence_bos_3 + (long long)write_end_3 * 32) ? (sequence_eos_3) : (sequence_bos_3 + (long long)write_end_3 * 32));
+            long long eos_3 = _min_8;
+            int seq_len_3 = (int)(eos_3 - bos_3);
+            int num_chunks_3 = (seq_len_3 + 32 - 1) / 32;
+            unsigned int mma_stage = 0;
+            unsigned int _phase_qk_full_1 = 0;
+            unsigned int _phase_out_empty_0 = 1;
+            unsigned int _phase_state_inp_ready = 0;
+            unsigned int _phase_u_inp_ready = 0;
+            unsigned int _phase_u2_inp_ready = 0;
+            unsigned int _phase_final_ready_2 = 0;
+            #pragma unroll 1
+            for (int _chunk_idx = 0; _chunk_idx < num_chunks_3; _chunk_idx++) {
+                mbarrier_wait(qk_full_addr + (mma_stage) * 8, _phase_qk_full_1);
+                {
+                    mbarrier_wait(state_inp_ready_addr + (mma_stage) * 8, _phase_state_inp_ready);
+                    {
+                        int _mma_b_lo_6 = make_warp_uniform((((smem_kd_addr) >> 4) & 0x3FFF) + (mma_stage) * 2624);
+                        asm volatile(
+                    "{\n\t"
+                    ".reg .pred leader, p0, p1;\n\t"
+                    ".reg .b32 dhi, blo, ta, id;\n\t"
+                    ".reg .b64 db;\n\t"
+                    "elect.sync _|leader, 0xFFFFFFFF;\n\t"
+                    "setp.ne.b32 p0, %3, 0;\n\t"
+                    "setp.ne.b32 p1, 1, 0;\n\t"
+                    ""
+                    "mov.b32 dhi, 0x40004040;\n\t"
+                    "mov.b32 id, 134743184;\n\t"
+                    "mov.b32 ta, %2;\n\t"
+                    "mov.b32 blo, %1;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p0;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 250;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "}\n"
+                    :: "r"(tmem_tmem_u_acc), "r"(_mma_b_lo_6), "r"(tmem_tmem_state_inp), "r"(0));
+                    }
+                }
+                {
+                    elect_commit2(old_out_ready_addr + (mma_stage) * 8, raw_inputs_free_addr + (mma_stage) * 8);
+                }
+                mbarrier_wait(u_inp_ready_addr + (mma_stage) * 8, _phase_u_inp_ready);
+                int _mma_b_lo_7 = make_warp_uniform((((smem_inv_addr) >> 4) & 0x3FFF) + (mma_stage) * 2624);
+                asm volatile(
+                    "{\n\t"
+                    ".reg .pred leader, p0, p1;\n\t"
+                    ".reg .b32 dhi, blo, ta, id;\n\t"
+                    ".reg .b64 db;\n\t"
+                    "elect.sync _|leader, 0xFFFFFFFF;\n\t"
+                    "setp.ne.b32 p0, %3, 0;\n\t"
+                    "setp.ne.b32 p1, 1, 0;\n\t"
+                    ""
+                    "mov.b32 dhi, 0xC0004010;\n\t"
+                    "mov.b32 id, 134743184;\n\t"
+                    "mov.b32 ta, %2;\n\t"
+                    "mov.b32 blo, %1;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p0;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 64;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "}\n"
+                    :: "r"(tmem_tmem_u2_acc), "r"(_mma_b_lo_7), "r"(tmem_tmem_u2_inp), "r"(0));
+                elect_commit(u2_acc_ready_addr + (mma_stage) * 8);
+                mbarrier_wait(u2_inp_ready_addr + (mma_stage) * 8, _phase_u2_inp_ready);
+                int _mma_b_lo_8 = make_warp_uniform(((((smem_final_trans_addr) >> 4) & 0x3FFF) | 0x1000000) + (mma_stage) * 2624);
+                asm volatile(
+                    "{\n\t"
+                    ".reg .pred leader, p0, p1;\n\t"
+                    ".reg .b32 dhi, blo, ta, id;\n\t"
+                    ".reg .b64 db;\n\t"
+                    "elect.sync _|leader, 0xFFFFFFFF;\n\t"
+                    "setp.ne.b32 p0, %3, 0;\n\t"
+                    "setp.ne.b32 p1, 1, 0;\n\t"
+                    ""
+                    "mov.b32 dhi, 0x40004040;\n\t"
+                    "mov.b32 id, 136905872;\n\t"
+                    "mov.b32 ta, %2;\n\t"
+                    "mov.b32 blo, %1;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p0;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 128;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "}\n"
+                    :: "r"(tmem_tmem_state_out), "r"(_mma_b_lo_8), "r"(tmem_tmem_u2_inp), "r"(1));
+                elect_commit(final_ready_addr + (mma_stage) * 8);
+                {
+                    mbarrier_wait(final_ready_addr + (mma_stage) * 8, _phase_final_ready_2);
+                }
+                mma_stage += 1;
+                if (mma_stage == 5) { mma_stage = 0; _phase_qk_full_1 ^= 1; _phase_state_inp_ready ^= 1; _phase_u_inp_ready ^= 1; _phase_u2_inp_ready ^= 1; _phase_final_ready_2 ^= 1; }
+            }
+            unsigned int _phase_tmem_dealloc_ready_0 = 0;
+            mbarrier_wait(tmem_dealloc_ready_addr, _phase_tmem_dealloc_ready_0);
+            _phase_tmem_dealloc_ready_0 ^= 1;
+            int _tmem_dealloc_addr = *((volatile int*)tmem_addr_storage);
+            asm volatile("tcgen05.dealloc.cta_group::1.sync.aligned.b32 %0, %1;" :: "r"(_tmem_dealloc_addr), "r"(256));
+        }
+    }
+    // ---- Role: prep ----
+    if (warp >= 12 && warp <= 31) {
+        asm volatile("setmaxnreg.dec.sync.aligned.u32 48;");
+        { // prep_main
+            int task_idx_4 = blockIdx.x;
+            int split_compute_start_4 = 0;
+            unsigned int _phase_work_item_ready_0_3 = 0;
+            {
+                mbarrier_wait(work_item_ready_addr, _phase_work_item_ready_0_3);
+                _phase_work_item_ready_0_3 ^= 1;
+                split_compute_start_4 = smem_work_item_compute_start[0];
+            }
+            int item_base_5 = task_idx_4 * 5;
+            int seq_idx_4 = seq_order[item_base_5];
+            int head_idx_4 = seq_order[item_base_5 + 1];
+            int compute_start_4 = split_compute_start_4;
+            int write_start_4 = seq_order[item_base_5 + 2];
+            int write_end_4 = seq_order[item_base_5 + 3];
+            long long sequence_bos_4 = cu_seqlens[seq_idx_4];
+            long long sequence_eos_4 = cu_seqlens[seq_idx_4 + 1];
+            long long bos_4 = sequence_bos_4 + (long long)compute_start_4 * 32;
+            long long _min_0 = ((sequence_eos_4) < (sequence_bos_4 + (long long)write_end_4 * 32) ? (sequence_eos_4) : (sequence_bos_4 + (long long)write_end_4 * 32));
+            long long eos_4 = _min_0;
+            int seq_len_4 = (int)(eos_4 - bos_4);
+            int num_chunks_4 = (seq_len_4 + 32 - 1) / 32;
+            int instance_id = (warp - 12) / 4;
+            int prep_instance = instance_id;
+            int warp_id_in_role_3 = (warp - 12);
+            int prep_local_warp = warp_id_in_role_3 - prep_instance * 4;
+            int prep_tid = prep_local_warp * 32 + lane;
+            int num_prep_iters = (num_chunks_4 + 5 - 1 - prep_instance) / 5;
+            unsigned int prep_stage = (unsigned int)prep_instance;
+            int gate_rate_stage_f32 = prep_instance * 10496;
+            int prep_global_tid = warp_id_in_role_3 * 32 + lane;
+            if (prep_tid == 0) {
+                float _expf_0 = __expf(A_log[head_idx_4]);
+                smem_gate_rate_all[gate_rate_stage_f32] = _expf_0;
+            }
+            if (prep_global_tid < 128) {
+                smem_gate_bias_all[prep_global_tid] = dt_bias[head_idx_4 * 128 + prep_global_tid];
+            }
+            asm volatile("barrier.sync 15, 640;" ::: "memory");
+            {
+                if (prep_global_tid < 128) {
+                    smem_gate_bias_all[prep_global_tid] = smem_gate_bias_all[prep_global_tid] * smem_gate_rate_all[0];
+                }
+                asm volatile("barrier.sync 15, 640;" ::: "memory");
+            }
+            unsigned int _phase_raw_inputs_free = 1;
+            unsigned int _phase_gate_raw_full = 0;
+            unsigned int _phase_smem_free = 1;
+            unsigned int _phase_v_free = 1;
+            unsigned int _phase_qk_raw_full = 0;
+            unsigned int _phase_short_beta_ready = 0;
+            unsigned int _phase_prep_diag_ready = 0;
+            unsigned int _phase_prep_inv16_ready = 0;
+            unsigned int _phase_tape_free = 1;
+            #pragma unroll 1
+            for (int prep_iter = 0; prep_iter < num_prep_iters; prep_iter++) {
+                int chunk_idx_3 = prep_iter * 5 + prep_instance;
+                int chunk_global_local_2 = compute_start_4 + chunk_idx_3;
+                int owned_chunk_2 = chunk_global_local_2 >= write_start_4 && chunk_global_local_2 < write_end_4;
+                int stage_f32 = prep_stage * 10496;
+                int stage_bf16 = prep_stage * 20992;
+                int chunk_is_full_1 = ((seq_len_4 >= (chunk_idx_3 + 1) * 32) ? 1 : 0);
+                float early_beta_value = 0.0f;
+                float early_gate0 = 0.0f;
+                if (chunk_is_full_1 != 0 || prep_iter != 0) {
+                    mbarrier_wait(raw_inputs_free_addr + (prep_stage) * 8, _phase_raw_inputs_free);
+                }
+                if (chunk_is_full_1 != 0) {
+                    if (prep_local_warp == 0) {
+                        if (elect_sync()) {
+                            mbarrier_arrive_expect_tx(gate_raw_full_addr + (prep_stage) * 8, 8704);
+                            tma_3d_gmem2smem(smem_g_raw_addr + prep_stage * 41984, g_tma, 0, head_idx_4, (int)(bos_4 + (long long)(chunk_idx_3 * 32)), gate_raw_full_addr + (prep_stage) * 8);
+                            {
+                                tma_2d_gmem2smem(smem_beta_raw_addr + prep_stage * 41984, beta_tma, ((0) ? 0 : head_idx_4 / 8 * 8), (int)(((0) ? (bos_4 + (long long)(chunk_idx_3 * 32)) / 2 : bos_4 + (long long)(chunk_idx_3 * 32))), gate_raw_full_addr + (prep_stage) * 8);
+                            }
+                            mbarrier_arrive_expect_tx(qk_raw_full_addr + (prep_stage) * 8, 16384);
+                            tma_4d_gmem2smem(smem_kd_addr + prep_stage * 41984, k_tma, 0, (int)(bos_4 + (long long)(chunk_idx_3 * 32)), head_idx_4, 0, qk_raw_full_addr + (prep_stage) * 8);
+                        }
+                    }
+                    mbarrier_wait(gate_raw_full_addr + (prep_stage) * 8, _phase_gate_raw_full);
+                    if (prep_local_warp == 2 && lane < 32) {
+                        float beta_logit = 0.0f;
+                        {
+                            {
+                                unsigned int beta_raw_pair[1];
+                                asm volatile("ld.shared.b32 %0, [%1];" : "=r"(*reinterpret_cast<uint32_t*>(&beta_raw_pair[0])) : "r"(smem_beta_raw_addr + prep_stage * 41984 + (unsigned int)(lane * 16) + (unsigned int)(head_idx_4 % 8 / 2 * 4)));
+                                float beta_raw_pair_f32[2];
+                                #pragma unroll
+                                for (int _pair = 0; _pair < 1; _pair++) {
+                                    asm volatile(
+                                        "{\n\t"
+                                        "shl.b32 %0, %2, 16;\n\t"
+                                        "and.b32 %1, %2, 0xffff0000;\n\t"
+                                        "}\n"
+                                        : "=f"((&beta_raw_pair_f32[_pair * 2])[0]), "=f"((&beta_raw_pair_f32[_pair * 2])[1])
+                                        : "r"(beta_raw_pair[_pair]));
+                                }
+                                beta_logit = beta_raw_pair_f32[0];
+                                if (head_idx_4 % 2 != 0) {
+                                    beta_logit = beta_raw_pair_f32[1];
+                                }
+                            }
+                        }
+                        float _tanh_approx_1;
+                        asm volatile("tanh.approx.f32 %0, %1;" : "=f"(_tanh_approx_1) : "f"(beta_logit * 0.5f));
+                        early_beta_value = _tanh_approx_1 * 0.5f + 0.5f;
+                    }
+                }
+                mbarrier_wait(smem_free_addr + (prep_stage) * 8, _phase_smem_free);
+                mbarrier_wait(v_free_addr + (prep_stage) * 8, _phase_v_free);
+                if (chunk_is_full_1 != 0) {
+                    if (prep_local_warp == 0) {
+                        if (elect_sync()) {
+                            tma_4d_gmem2smem(smem_q_raw_prefetch_addr + prep_stage * 41984, q_tma, 0, (int)(bos_4 + (long long)(chunk_idx_3 * 32)), head_idx_4, 0, qk_raw_full_addr + (prep_stage) * 8);
+                        }
+                    }
+                }
+                if (chunk_is_full_1 == 0) {
+                    #pragma unroll
+                    for (int gate_load_pass = 0; gate_load_pass < 4; gate_load_pass++) {
+                        int gate_load_item = gate_load_pass * 128 + prep_tid;
+                        int gate_load_row = gate_load_item / 16;
+                        int gate_load_segment = gate_load_item % 16;
+                        long long gate_load_token = bos_4 + (long long)(chunk_idx_3 * 32 + gate_load_row);
+                        long long gate_load_base = (gate_load_token * (long long)num_heads + (long long)head_idx_4) * 128 + (long long)(gate_load_segment * 8);
+                        asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16, %2;"
+                            :: "r"(smem_g_raw_addr + prep_stage * 41984 + (unsigned int)(gate_load_item * 16)), "l"(g + gate_load_base), "r"((gate_load_token < eos_4) ? 16 : 0));
+                        int q_tail_addr = (smem_q_raw_prefetch_addr + prep_stage * 41984 + (unsigned int)(gate_load_segment * 8 / 64 * 4096 + gate_load_row * 128 + gate_load_segment * 8 % 64 * 2 ^ (gate_load_segment * 8 / 64 * 4096 + gate_load_row * 128 + gate_load_segment * 8 % 64 * 2 >> 7 & 7) << 4));
+                        asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16, %2;"
+                            :: "r"(q_tail_addr), "l"(q + gate_load_base), "r"((gate_load_token < eos_4) ? 16 : 0));
+                        int k_tail_addr = (smem_kd_addr + prep_stage * 41984 + (unsigned int)(gate_load_segment * 8 / 64 * 4096 + gate_load_row * 128 + gate_load_segment * 8 % 64 * 2 ^ (gate_load_segment * 8 / 64 * 4096 + gate_load_row * 128 + gate_load_segment * 8 % 64 * 2 >> 7 & 7) << 4));
+                        asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16, %2;"
+                            :: "r"(k_tail_addr), "l"(k + gate_load_base), "r"((gate_load_token < eos_4) ? 16 : 0));
+                    }
+                }
+                if (chunk_is_full_1 == 0) {
+                    asm volatile("cp.async.commit_group;");
+                    asm volatile("cp.async.wait_group 0;");
+                    asm volatile("barrier.sync %0, 128;" :: "r"(10 + prep_instance) : "memory");
+                }
+                if (prep_local_warp == 2 && lane < 32) {
+                    long long beta_token = bos_4 + (long long)(chunk_idx_3 * 32 + lane);
+                    float beta_value = early_beta_value;
+                    if (chunk_is_full_1 == 0) {
+                        if (beta_token < eos_4) {
+                            float beta_logit_1 = (float)beta[beta_token * (long long)num_heads + (long long)head_idx_4];
+                            float _tanh_approx_3;
+                            asm volatile("tanh.approx.f32 %0, %1;" : "=f"(_tanh_approx_3) : "f"(beta_logit_1 * 0.5f));
+                            beta_value = _tanh_approx_3 * 0.5f + 0.5f;
+                        }
+                    }
+                    {
+                        smem_prep_beta_all[stage_f32 + lane] = beta_value;
+                    }
+                    {
+                        if (beta_token < eos_4 && owned_chunk_2 != 0) {
+                            beta_active_out[beta_token * (long long)num_heads + (long long)head_idx_4] = beta_value;
+                        }
+                    }
+                }
+                if (prep_tid < 128) {
+                    int gate_col = prep_tid;
+                    float gate_rate = smem_gate_rate_all[stage_f32];
+                    float gate_bias = smem_gate_bias_all[gate_col];
+                    float prefix_log2 = 0.0f;
+                    {
+                        float2 _f2_0 = make_float2(gate_rate, gate_rate);
+                        float2 gate_rate_pair = _f2_0;
+                        float2 _f2_1 = make_float2(gate_bias, gate_bias);
+                        float2 gate_bias_pair = _f2_1;
+                        float half_gate_scale = lower_bound * 0.7213475204444817f;
+                        float2 _f2_2 = make_float2(half_gate_scale, half_gate_scale);
+                        float2 half_gate_scale_pair = _f2_2;
+                        if (chunk_is_full_1 != 0) {
+                            for (int gate_row_pair = 0; gate_row_pair < 16; gate_row_pair++) {
+                                const int gate_row0 = gate_row_pair * 2;
+                                const int gate_row1 = gate_row0 + 1;
+                                const int gate_row0_0 = gate_row_pair * 2;
+                                const int gate_row1_1 = gate_row0_0 + 1;
+                                __nv_bfloat16 gate_raw0 = smem_g_raw_all[stage_bf16 + gate_row0_0 * 128 + gate_col];
+                                __nv_bfloat16 gate_raw1 = smem_g_raw_all[stage_bf16 + gate_row1_1 * 128 + gate_col];
+                                float _cvt_f32_2 = __bfloat162float(gate_raw0);
+                                float _cvt_f32_3 = __bfloat162float(gate_raw1);
+                                float2 _f2_3 = make_float2(_cvt_f32_2, _cvt_f32_3);
+                                float2 gate_raw_pair = _f2_3;
+                                float2 gate_arg_pair = fma_f32x2(gate_raw_pair, gate_rate_pair, gate_bias_pair);
+                                float _tanh_approx_4;
+                                asm volatile("tanh.approx.f32 %0, %1;" : "=f"(_tanh_approx_4) : "f"(gate_arg_pair.x * 0.5f));
+                                float _tanh_approx_5;
+                                asm volatile("tanh.approx.f32 %0, %1;" : "=f"(_tanh_approx_5) : "f"(gate_arg_pair.y * 0.5f));
+                                float2 _f2_4 = make_float2(_tanh_approx_4, _tanh_approx_5);
+                                float2 gate_tanh_pair = _f2_4;
+                                float2 gate_log_pair = fma_f32x2(gate_tanh_pair, half_gate_scale_pair, half_gate_scale_pair);
+                                float gate_log0 = gate_log_pair.x;
+                                float gate_log1 = gate_log_pair.y;
+                                prefix_log2 += gate_log0;
+                                smem_gate_all[stage_f32 + gate_row0 * 128 + gate_col] = prefix_log2;
+                                prefix_log2 += gate_log1;
+                                smem_gate_all[stage_f32 + gate_row1 * 128 + gate_col] = prefix_log2;
+                            }
+                        } else {
+                            for (int gate_row_pair_1 = 0; gate_row_pair_1 < 16; gate_row_pair_1++) {
+                                const int gate_row0_1 = gate_row_pair_1 * 2;
+                                const int gate_row1_2 = gate_row0_1 + 1;
+                                const int gate_row0_0_1 = gate_row_pair_1 * 2;
+                                const int gate_row1_1_1 = gate_row0_0_1 + 1;
+                                __nv_bfloat16 gate_raw0_1 = smem_g_raw_all[stage_bf16 + gate_row0_0_1 * 128 + gate_col];
+                                __nv_bfloat16 gate_raw1_1 = smem_g_raw_all[stage_bf16 + gate_row1_1_1 * 128 + gate_col];
+                                float _cvt_f32_4 = __bfloat162float(gate_raw0_1);
+                                float _cvt_f32_5 = __bfloat162float(gate_raw1_1);
+                                float2 _f2_5 = make_float2(_cvt_f32_4, _cvt_f32_5);
+                                float2 gate_raw_pair_1 = _f2_5;
+                                float2 gate_arg_pair_1 = fma_f32x2(gate_raw_pair_1, gate_rate_pair, gate_bias_pair);
+                                float _tanh_approx_6;
+                                asm volatile("tanh.approx.f32 %0, %1;" : "=f"(_tanh_approx_6) : "f"(gate_arg_pair_1.x * 0.5f));
+                                float _tanh_approx_7;
+                                asm volatile("tanh.approx.f32 %0, %1;" : "=f"(_tanh_approx_7) : "f"(gate_arg_pair_1.y * 0.5f));
+                                float2 _f2_6 = make_float2(_tanh_approx_6, _tanh_approx_7);
+                                float2 gate_tanh_pair_1 = _f2_6;
+                                float2 gate_log_pair_1 = fma_f32x2(gate_tanh_pair_1, half_gate_scale_pair, half_gate_scale_pair);
+                                float gate_log0_1 = gate_log_pair_1.x;
+                                float gate_log1_1 = gate_log_pair_1.y;
+                                {
+                                    long long gate_token0 = bos_4 + (long long)(chunk_idx_3 * 32 + gate_row0_0_1);
+                                    long long gate_token1 = gate_token0 + 1;
+                                    if (gate_token0 >= eos_4) {
+                                        gate_log0_1 = 0.0f;
+                                    }
+                                    if (gate_token1 >= eos_4) {
+                                        gate_log1_1 = 0.0f;
+                                    }
+                                }
+                                prefix_log2 += gate_log0_1;
+                                smem_gate_all[stage_f32 + gate_row0_1 * 128 + gate_col] = prefix_log2;
+                                prefix_log2 += gate_log1_1;
+                                smem_gate_all[stage_f32 + gate_row1_2 * 128 + gate_col] = prefix_log2;
+                            }
+                        }
+                    }
+                }
+                asm volatile("barrier.sync %0, 128;" :: "r"(10 + prep_instance) : "memory");
+                if (chunk_is_full_1 != 0) {
+                    mbarrier_wait(qk_raw_full_addr + (prep_stage) * 8, _phase_qk_raw_full);
+                }
+                if (prep_tid < 128) {
+                    float total_log2 = smem_gt_prefix_all[stage_f32 + prep_tid];
+                    float _exp2_0 = approx_exp2(total_log2 - lower_bound * 1.4426950408889634f * 16.0f);
+                    float restore_factor_value = _exp2_0;
+                    smem_restore_factor_all[stage_f32 + prep_tid] = restore_factor_value;
+                    {
+                        long long chunk_global_restore = cu_chunk_offsets[seq_idx_4] + (long long)chunk_global_local_2;
+                        if (owned_chunk_2 != 0) {
+                            tape_restore_factor[(chunk_global_restore * (long long)num_heads + (long long)head_idx_4) * 128 + (long long)prep_tid] = restore_factor_value;
+                        }
+                        int _vote_0 = __any_sync(0xFFFFFFFF, num_chunks_4 > chunk_idx_3 + 1 && total_log2 > -30.0f);
+                        int warp_slow = _vote_0;
+                        if (lane == 0) {
+                            smem_state_checkpoint_needed[prep_stage * 4 + (unsigned int)prep_local_warp] = (unsigned int)warp_slow;
+                        }
+                    }
+                }
+                if (prep_tid == 0) {
+                    float _exp2_1 = approx_exp2(lower_bound * 1.4426950408889634f * 16.0f);
+                    smem_restore_factor_all[stage_f32 + 128] = _exp2_1;
+                }
+                #pragma unroll 1
+                for (int work_pass = 0; work_pass < 4; work_pass++) {
+                    int work_item = work_pass * 128 + prep_tid;
+                    int row = work_item / 16;
+                    int segment = work_item % 16;
+                    long long token = bos_4 + (long long)(chunk_idx_3 * 32 + row);
+                    int token_valid = ((token < eos_4) ? 1 : 0);
+                    long long gmem_base = (token * (long long)num_heads + (long long)head_idx_4) * 128 + (long long)(segment * 8);
+                    float q_raw_vec[8];
+                    float k_raw_vec[8];
+                    unsigned int packed_2[4];
+                    asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                        : "=r"(*reinterpret_cast<uint32_t*>(&packed_2[0])), "=r"(*reinterpret_cast<uint32_t*>(&packed_2[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&packed_2[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&packed_2[(0) + 3]))
+                        : "r"((smem_q_raw_prefetch_addr + prep_stage * 41984 + (unsigned int)(segment * 8 / 64 * 4096 + row * 128 + segment * 8 % 64 * 2 ^ (segment * 8 / 64 * 4096 + row * 128 + segment * 8 % 64 * 2 >> 7 & 7) << 4))));
+                    float packed_f32_2[8];
+                    #pragma unroll
+                    for (int _pair = 0; _pair < 4; _pair++) {
+                        asm volatile(
+                            "{\n\t"
+                            "shl.b32 %0, %2, 16;\n\t"
+                            "and.b32 %1, %2, 0xffff0000;\n\t"
+                            "}\n"
+                            : "=f"((&packed_f32_2[_pair * 2])[0]), "=f"((&packed_f32_2[_pair * 2])[1])
+                            : "r"(packed_2[_pair]));
+                    }
+                    #pragma unroll
+                    for (int value_idx_2 = 0; value_idx_2 < 8; value_idx_2++) {
+                        q_raw_vec[value_idx_2] = packed_f32_2[value_idx_2];
+                    }
+                    unsigned int packed_0[4];
+                    asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                        : "=r"(*reinterpret_cast<uint32_t*>(&packed_0[0])), "=r"(*reinterpret_cast<uint32_t*>(&packed_0[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&packed_0[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&packed_0[(0) + 3]))
+                        : "r"((smem_kd_addr + prep_stage * 41984 + (unsigned int)(segment * 8 / 64 * 4096 + row * 128 + segment * 8 % 64 * 2 ^ (segment * 8 / 64 * 4096 + row * 128 + segment * 8 % 64 * 2 >> 7 & 7) << 4))));
+                    float packed_0_f32[8];
+                    #pragma unroll
+                    for (int _pair = 0; _pair < 4; _pair++) {
+                        asm volatile(
+                            "{\n\t"
+                            "shl.b32 %0, %2, 16;\n\t"
+                            "and.b32 %1, %2, 0xffff0000;\n\t"
+                            "}\n"
+                            : "=f"((&packed_0_f32[_pair * 2])[0]), "=f"((&packed_0_f32[_pair * 2])[1])
+                            : "r"(packed_0[_pair]));
+                    }
+                    #pragma unroll
+                    for (int value_idx_3 = 0; value_idx_3 < 8; value_idx_3++) {
+                        k_raw_vec[value_idx_3] = packed_0_f32[value_idx_3];
+                    }
+                    float q_sum = 0.0f;
+                    float k_sum = 0.0f;
+                    for (int elem_in_segment = 0; elem_in_segment < 8; elem_in_segment++) {
+                        float q_raw = q_raw_vec[elem_in_segment];
+                        float k_raw = k_raw_vec[elem_in_segment];
+                        float _fma_4 = __fmaf_rn(q_raw, q_raw, q_sum);
+                        q_sum = _fma_4;
+                        float _fma_5 = __fmaf_rn(k_raw, k_raw, k_sum);
+                        k_sum = _fma_5;
+                    }
+                    float _shfl_xor_0 = __shfl_xor_sync(0xFFFFFFFF, q_sum, 8);
+                    q_sum += _shfl_xor_0;
+                    float _shfl_xor_1 = __shfl_xor_sync(0xFFFFFFFF, k_sum, 8);
+                    k_sum += _shfl_xor_1;
+                    float _shfl_xor_2 = __shfl_xor_sync(0xFFFFFFFF, q_sum, 4);
+                    q_sum += _shfl_xor_2;
+                    float _shfl_xor_3 = __shfl_xor_sync(0xFFFFFFFF, k_sum, 4);
+                    k_sum += _shfl_xor_3;
+                    float _shfl_xor_4 = __shfl_xor_sync(0xFFFFFFFF, q_sum, 2);
+                    q_sum += _shfl_xor_4;
+                    float _shfl_xor_5 = __shfl_xor_sync(0xFFFFFFFF, k_sum, 2);
+                    k_sum += _shfl_xor_5;
+                    float _shfl_xor_6 = __shfl_xor_sync(0xFFFFFFFF, q_sum, 1);
+                    q_sum += _shfl_xor_6;
+                    float _shfl_xor_7 = __shfl_xor_sync(0xFFFFFFFF, k_sum, 1);
+                    k_sum += _shfl_xor_7;
+                    float _rsqrt_0 = rsqrtf(q_sum + 1e-06f);
+                    float q_inv = _rsqrt_0;
+                    float _rsqrt_1 = rsqrtf(k_sum + 1e-06f);
+                    float k_inv = _rsqrt_1;
+                    {
+                        q_inv *= scale;
+                    }
+                    const float2 _scale2_0 = {q_inv, q_inv};
+                    #pragma unroll
+                    for (int _ls = 0; _ls < 4; _ls++)
+                        mul_f32x2_inplace(&reinterpret_cast<float2*>(q_raw_vec)[_ls], _scale2_0);
+                    const float2 _scale2_1 = {k_inv, k_inv};
+                    #pragma unroll
+                    for (int _ls = 0; _ls < 4; _ls++)
+                        mul_f32x2_inplace(&reinterpret_cast<float2*>(k_raw_vec)[_ls], _scale2_1);
+                    {
+                        if (token_valid != 0 && owned_chunk_2 != 0) {
+                            if (segment == 0) {
+                                float norm_pair[2];
+                                norm_pair[0] = q_inv;
+                                norm_pair[1] = k_inv;
+                                {
+                                    float2 _v2 = make_float2(norm_pair[0 + 0], norm_pair[0 + 1]);
+                                    *reinterpret_cast<float2*>(norm_inv_out + (token * (long long)num_heads + (long long)head_idx_4) * 2) = _v2;
+                                }
+                            }
+                        }
+                    }
+                    float qd_vec[8];
+                    float kd_vec[8];
+                    float ki_vec[8];
+                    for (int elem_in_segment_1 = 0; elem_in_segment_1 < 8; elem_in_segment_1++) {
+                        int col = segment * 8 + elem_in_segment_1;
+                        float prefix = smem_gate_all[stage_f32 + row * 128 + col];
+                        float common_log2 = lower_bound * 1.4426950408889634f * 16.0f;
+                        float _exp2_2 = approx_exp2(prefix - common_log2);
+                        float decay = _exp2_2;
+                        qd_vec[elem_in_segment_1] = decay;
+                        kd_vec[elem_in_segment_1] = decay;
+                        ki_vec[elem_in_segment_1] = k_raw_vec[elem_in_segment_1] / decay;
+                    }
+                    {
+                        if (token_valid != 0 && owned_chunk_2 != 0) {
+                            {
+                                __nv_bfloat162 _pk[4];
+                                _pk[0] = __floats2bfloat162_rn(qd_vec[0 + 0], qd_vec[0 + 1]);
+                                _pk[1] = __floats2bfloat162_rn(qd_vec[0 + 2], qd_vec[0 + 3]);
+                                _pk[2] = __floats2bfloat162_rn(qd_vec[0 + 4], qd_vec[0 + 5]);
+                                _pk[3] = __floats2bfloat162_rn(qd_vec[0 + 6], qd_vec[0 + 7]);
+                                *reinterpret_cast<uint4*>(&((__nv_bfloat16*)(decay_out))[gmem_base + 0]) = *reinterpret_cast<uint4*>(&_pk[0]);
+                            }
+                        }
+                    }
+                    #pragma unroll
+                    for (int _ls = 0; _ls < 4; _ls++)
+                        mul_f32x2_inplace(&reinterpret_cast<float2*>(qd_vec)[_ls], reinterpret_cast<const float2*>(q_raw_vec)[_ls]);
+                    #pragma unroll
+                    for (int _ls = 0; _ls < 4; _ls++)
+                        mul_f32x2_inplace(&reinterpret_cast<float2*>(kd_vec)[_ls], reinterpret_cast<const float2*>(k_raw_vec)[_ls]);
+                    unsigned int packed_1_1[4];
+                    #pragma unroll
+                    for (int _lp = 0; _lp < 4; _lp++) {
+                        __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(qd_vec[_lp*2 + 0], qd_vec[_lp*2+1 + 0]));
+                        packed_1_1[_lp] = *(uint32_t*)&_bf2;
+                    }
+                    #pragma unroll
+                    for (int word = 0; word < 4; word++) {
+                        asm volatile("st.shared.b32 [%0], %1;" :: "r"((smem_qd_addr + prep_stage * 41984 + (unsigned int)(segment * 8 / 64 * 4096 + row * 128 + segment * 8 % 64 * 2 ^ (segment * 8 / 64 * 4096 + row * 128 + segment * 8 % 64 * 2 >> 7 & 7) << 4)) + (unsigned int)(word * 4)), "r"((packed_1_1[word])));
+                    }
+                    unsigned int packed_2_1[4];
+                    #pragma unroll
+                    for (int _lp = 0; _lp < 4; _lp++) {
+                        __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(kd_vec[_lp*2 + 0], kd_vec[_lp*2+1 + 0]));
+                        packed_2_1[_lp] = *(uint32_t*)&_bf2;
+                    }
+                    #pragma unroll
+                    for (int word_1 = 0; word_1 < 4; word_1++) {
+                        asm volatile("st.shared.b32 [%0], %1;" :: "r"((smem_kd_addr + prep_stage * 41984 + (unsigned int)(segment * 8 / 64 * 4096 + row * 128 + segment * 8 % 64 * 2 ^ (segment * 8 / 64 * 4096 + row * 128 + segment * 8 % 64 * 2 >> 7 & 7) << 4)) + (unsigned int)(word_1 * 4)), "r"((packed_2_1[word_1])));
+                    }
+                    unsigned int packed_3[4];
+                    #pragma unroll
+                    for (int _lp = 0; _lp < 4; _lp++) {
+                        __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(ki_vec[_lp*2 + 0], ki_vec[_lp*2+1 + 0]));
+                        packed_3[_lp] = *(uint32_t*)&_bf2;
+                    }
+                    #pragma unroll
+                    for (int word_2 = 0; word_2 < 4; word_2++) {
+                        asm volatile("st.shared.b32 [%0], %1;" :: "r"((smem_ki_addr + prep_stage * 41984 + (unsigned int)(segment * 8 / 64 * 4096 + row * 128 + segment * 8 % 64 * 2 ^ (segment * 8 / 64 * 4096 + row * 128 + segment * 8 % 64 * 2 >> 7 & 7) << 4)) + (unsigned int)(word_2 * 4)), "r"((packed_3[word_2])));
+                    }
+                }
+                asm volatile("barrier.sync %0, 128;" :: "r"(10 + prep_instance) : "memory");
+                unsigned int a_frag[4];
+                unsigned int b_frag[4];
+                float acc[8];
+                {
+                    int pair_row_base = prep_local_warp / 2 * 16;
+                    int pair_col_base = prep_local_warp % 2 * 16;
+                    if (pair_row_base >= pair_col_base) {
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(a_frag[0]), "=r"(a_frag[1]), "=r"(a_frag[2]), "=r"(a_frag[3])
+                            : "r"(smem_kd_addr + prep_stage * 41984 + (unsigned int)((lane / 16 / 8 * 256 + (pair_row_base + lane % 16) * 8 + (lane / 16 % 8 * 16 ^ (pair_row_base + lane % 16 & 7) << 4) / 16) * 16))
+                            : "memory");
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(b_frag[0]), "=r"(b_frag[1]), "=r"(b_frag[2]), "=r"(b_frag[3])
+                            : "r"(smem_ki_addr + prep_stage * 41984 + (unsigned int)((lane % 16 / 8 / 8 * 256 + (pair_col_base + 8 * (lane / 16) + lane % 8) * 8 + (lane % 16 / 8 % 8 * 16 ^ (pair_col_base + 8 * (lane / 16) + lane % 8 & 7) << 4) / 16) * 16))
+                            : "memory");
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%10, %11, %12, %13};\n"
+                            : "=f"(acc[0]), "=f"(acc[1]), "=f"(acc[2]), "=f"(acc[3])
+                            : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[0]), "r"(b_frag[1]), "f"(0.0f), "f"(0.0f), "f"(0.0f), "f"(0.0f));
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%10, %11, %12, %13};\n"
+                            : "=f"(acc[4]), "=f"(acc[(4) + 1]), "=f"(acc[(4) + 2]), "=f"(acc[(4) + 3])
+                            : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[2]), "r"(b_frag[(2) + 1]), "f"(0.0f), "f"(0.0f), "f"(0.0f), "f"(0.0f));
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(a_frag[0]), "=r"(a_frag[1]), "=r"(a_frag[2]), "=r"(a_frag[3])
+                            : "r"(smem_kd_addr + prep_stage * 41984 + (unsigned int)((lane / 16 / 8 * 256 + (pair_row_base + lane % 16) * 8 + (lane / 16 % 8 * 16 ^ (pair_row_base + lane % 16 & 7) << 4) / 16 ^ 2) * 16))
+                            : "memory");
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(b_frag[0]), "=r"(b_frag[1]), "=r"(b_frag[2]), "=r"(b_frag[3])
+                            : "r"(smem_ki_addr + prep_stage * 41984 + (unsigned int)(((lane % 16 / 8 / 8 * 256 + (pair_col_base + 8 * (lane / 16) + lane % 8) * 8 + (lane % 16 / 8 % 8 * 16 ^ (pair_col_base + 8 * (lane / 16) + lane % 8 & 7) << 4) / 16 + 256 ^ 2) - 256) * 16))
+                            : "memory");
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                            : "+f"(acc[0]), "+f"(acc[1]), "+f"(acc[2]), "+f"(acc[3])
+                            : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[0]), "r"(b_frag[1]));
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                            : "+f"(acc[4]), "+f"(acc[(4) + 1]), "+f"(acc[(4) + 2]), "+f"(acc[(4) + 3])
+                            : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[2]), "r"(b_frag[(2) + 1]));
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(a_frag[0]), "=r"(a_frag[1]), "=r"(a_frag[2]), "=r"(a_frag[3])
+                            : "r"(smem_kd_addr + prep_stage * 41984 + (unsigned int)((lane / 16 / 8 * 256 + (pair_row_base + lane % 16) * 8 + (lane / 16 % 8 * 16 ^ (pair_row_base + lane % 16 & 7) << 4) / 16 ^ 2 ^ 6) * 16))
+                            : "memory");
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(b_frag[0]), "=r"(b_frag[1]), "=r"(b_frag[2]), "=r"(b_frag[3])
+                            : "r"(smem_ki_addr + prep_stage * 41984 + (unsigned int)((((lane % 16 / 8 / 8 * 256 + (pair_col_base + 8 * (lane / 16) + lane % 8) * 8 + (lane % 16 / 8 % 8 * 16 ^ (pair_col_base + 8 * (lane / 16) + lane % 8 & 7) << 4) / 16 + 256 ^ 2) - 256 + 256 ^ 6) - 256) * 16))
+                            : "memory");
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                            : "+f"(acc[0]), "+f"(acc[1]), "+f"(acc[2]), "+f"(acc[3])
+                            : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[0]), "r"(b_frag[1]));
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                            : "+f"(acc[4]), "+f"(acc[(4) + 1]), "+f"(acc[(4) + 2]), "+f"(acc[(4) + 3])
+                            : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[2]), "r"(b_frag[(2) + 1]));
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(a_frag[0]), "=r"(a_frag[1]), "=r"(a_frag[2]), "=r"(a_frag[3])
+                            : "r"(smem_kd_addr + prep_stage * 41984 + (unsigned int)((lane / 16 / 8 * 256 + (pair_row_base + lane % 16) * 8 + (lane / 16 % 8 * 16 ^ (pair_row_base + lane % 16 & 7) << 4) / 16 ^ 2 ^ 6 ^ 2) * 16))
+                            : "memory");
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(b_frag[0]), "=r"(b_frag[1]), "=r"(b_frag[2]), "=r"(b_frag[3])
+                            : "r"(smem_ki_addr + prep_stage * 41984 + (unsigned int)(((((lane % 16 / 8 / 8 * 256 + (pair_col_base + 8 * (lane / 16) + lane % 8) * 8 + (lane % 16 / 8 % 8 * 16 ^ (pair_col_base + 8 * (lane / 16) + lane % 8 & 7) << 4) / 16 + 256 ^ 2) - 256 + 256 ^ 6) - 256 + 256 ^ 2) - 256) * 16))
+                            : "memory");
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                            : "+f"(acc[0]), "+f"(acc[1]), "+f"(acc[2]), "+f"(acc[3])
+                            : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[0]), "r"(b_frag[1]));
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                            : "+f"(acc[4]), "+f"(acc[(4) + 1]), "+f"(acc[(4) + 2]), "+f"(acc[(4) + 3])
+                            : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[2]), "r"(b_frag[(2) + 1]));
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(a_frag[0]), "=r"(a_frag[1]), "=r"(a_frag[2]), "=r"(a_frag[3])
+                            : "r"(smem_kd_addr + prep_stage * 41984 + (unsigned int)(((lane / 16 / 8 * 256 + (pair_row_base + lane % 16) * 8 + (lane / 16 % 8 * 16 ^ (pair_row_base + lane % 16 & 7) << 4) / 16 ^ 2 ^ 6 ^ 2 ^ 6) + 256) * 16))
+                            : "memory");
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(b_frag[0]), "=r"(b_frag[1]), "=r"(b_frag[2]), "=r"(b_frag[3])
+                            : "r"(smem_ki_addr + prep_stage * 41984 + (unsigned int)((((((lane % 16 / 8 / 8 * 256 + (pair_col_base + 8 * (lane / 16) + lane % 8) * 8 + (lane % 16 / 8 % 8 * 16 ^ (pair_col_base + 8 * (lane / 16) + lane % 8 & 7) << 4) / 16 + 256 ^ 2) - 256 + 256 ^ 6) - 256 + 256 ^ 2) - 256 + 256 ^ 6) + 256 - 256) * 16))
+                            : "memory");
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                            : "+f"(acc[0]), "+f"(acc[1]), "+f"(acc[2]), "+f"(acc[3])
+                            : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[0]), "r"(b_frag[1]));
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                            : "+f"(acc[4]), "+f"(acc[(4) + 1]), "+f"(acc[(4) + 2]), "+f"(acc[(4) + 3])
+                            : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[2]), "r"(b_frag[(2) + 1]));
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(a_frag[0]), "=r"(a_frag[1]), "=r"(a_frag[2]), "=r"(a_frag[3])
+                            : "r"(smem_kd_addr + prep_stage * 41984 + (unsigned int)(((lane / 16 / 8 * 256 + (pair_row_base + lane % 16) * 8 + (lane / 16 % 8 * 16 ^ (pair_row_base + lane % 16 & 7) << 4) / 16 ^ 2 ^ 6 ^ 2 ^ 6) + 256 ^ 2) * 16))
+                            : "memory");
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(b_frag[0]), "=r"(b_frag[1]), "=r"(b_frag[2]), "=r"(b_frag[3])
+                            : "r"(smem_ki_addr + prep_stage * 41984 + (unsigned int)(((((((lane % 16 / 8 / 8 * 256 + (pair_col_base + 8 * (lane / 16) + lane % 8) * 8 + (lane % 16 / 8 % 8 * 16 ^ (pair_col_base + 8 * (lane / 16) + lane % 8 & 7) << 4) / 16 + 256 ^ 2) - 256 + 256 ^ 6) - 256 + 256 ^ 2) - 256 + 256 ^ 6) + 256 - 256 + 256 ^ 2) - 256) * 16))
+                            : "memory");
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                            : "+f"(acc[0]), "+f"(acc[1]), "+f"(acc[2]), "+f"(acc[3])
+                            : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[0]), "r"(b_frag[1]));
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                            : "+f"(acc[4]), "+f"(acc[(4) + 1]), "+f"(acc[(4) + 2]), "+f"(acc[(4) + 3])
+                            : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[2]), "r"(b_frag[(2) + 1]));
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(a_frag[0]), "=r"(a_frag[1]), "=r"(a_frag[2]), "=r"(a_frag[3])
+                            : "r"(smem_kd_addr + prep_stage * 41984 + (unsigned int)(((lane / 16 / 8 * 256 + (pair_row_base + lane % 16) * 8 + (lane / 16 % 8 * 16 ^ (pair_row_base + lane % 16 & 7) << 4) / 16 ^ 2 ^ 6 ^ 2 ^ 6) + 256 ^ 2 ^ 6) * 16))
+                            : "memory");
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(b_frag[0]), "=r"(b_frag[1]), "=r"(b_frag[2]), "=r"(b_frag[3])
+                            : "r"(smem_ki_addr + prep_stage * 41984 + (unsigned int)((((((((lane % 16 / 8 / 8 * 256 + (pair_col_base + 8 * (lane / 16) + lane % 8) * 8 + (lane % 16 / 8 % 8 * 16 ^ (pair_col_base + 8 * (lane / 16) + lane % 8 & 7) << 4) / 16 + 256 ^ 2) - 256 + 256 ^ 6) - 256 + 256 ^ 2) - 256 + 256 ^ 6) + 256 - 256 + 256 ^ 2) - 256 + 256 ^ 6) - 256) * 16))
+                            : "memory");
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                            : "+f"(acc[0]), "+f"(acc[1]), "+f"(acc[2]), "+f"(acc[3])
+                            : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[0]), "r"(b_frag[1]));
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                            : "+f"(acc[4]), "+f"(acc[(4) + 1]), "+f"(acc[(4) + 2]), "+f"(acc[(4) + 3])
+                            : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[2]), "r"(b_frag[(2) + 1]));
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(a_frag[0]), "=r"(a_frag[1]), "=r"(a_frag[2]), "=r"(a_frag[3])
+                            : "r"(smem_kd_addr + prep_stage * 41984 + (unsigned int)(((lane / 16 / 8 * 256 + (pair_row_base + lane % 16) * 8 + (lane / 16 % 8 * 16 ^ (pair_row_base + lane % 16 & 7) << 4) / 16 ^ 2 ^ 6 ^ 2 ^ 6) + 256 ^ 2 ^ 6 ^ 2) * 16))
+                            : "memory");
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(b_frag[0]), "=r"(b_frag[1]), "=r"(b_frag[2]), "=r"(b_frag[3])
+                            : "r"(smem_ki_addr + prep_stage * 41984 + (unsigned int)(((((((((lane % 16 / 8 / 8 * 256 + (pair_col_base + 8 * (lane / 16) + lane % 8) * 8 + (lane % 16 / 8 % 8 * 16 ^ (pair_col_base + 8 * (lane / 16) + lane % 8 & 7) << 4) / 16 + 256 ^ 2) - 256 + 256 ^ 6) - 256 + 256 ^ 2) - 256 + 256 ^ 6) + 256 - 256 + 256 ^ 2) - 256 + 256 ^ 6) - 256 + 256 ^ 2) - 256) * 16))
+                            : "memory");
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                            : "+f"(acc[0]), "+f"(acc[1]), "+f"(acc[2]), "+f"(acc[3])
+                            : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[0]), "r"(b_frag[1]));
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                            : "+f"(acc[4]), "+f"(acc[(4) + 1]), "+f"(acc[(4) + 2]), "+f"(acc[(4) + 3])
+                            : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[2]), "r"(b_frag[(2) + 1]));
+                        int row0 = pair_row_base + lane / 4;
+                        int row1 = row0 + 8;
+                        int col0 = pair_col_base + lane % 4 * 2;
+                        float beta0 = 0.0f;
+                        float beta1 = 0.0f;
+                        {
+                            beta0 = smem_prep_beta_all[stage_f32 + row0];
+                            beta1 = smem_prep_beta_all[stage_f32 + row1];
+                        }
+                        float seed[8];
+                        seed[0] = 0.0f;
+                        seed[1] = 0.0f;
+                        seed[2] = 0.0f;
+                        seed[3] = 0.0f;
+                        seed[4] = 0.0f;
+                        seed[5] = 0.0f;
+                        seed[6] = 0.0f;
+                        seed[7] = 0.0f;
+                        if (row0 > col0) {
+                            seed[0] = acc[0] * beta0;
+                        }
+                        if (row0 > col0 + 1) {
+                            seed[1] = acc[1] * beta0;
+                        }
+                        if (row1 > col0) {
+                            seed[2] = acc[2] * beta1;
+                        }
+                        if (row1 > col0 + 1) {
+                            seed[3] = acc[3] * beta1;
+                        }
+                        if (row0 > col0 + 8) {
+                            seed[4] = acc[4] * beta0;
+                        }
+                        if (row0 > col0 + 9) {
+                            seed[5] = acc[5] * beta0;
+                        }
+                        if (row1 > col0 + 8) {
+                            seed[6] = acc[6] * beta1;
+                        }
+                        if (row1 > col0 + 9) {
+                            seed[7] = acc[7] * beta1;
+                        }
+                        unsigned int seed_packed[4];
+                        #pragma unroll
+                        for (int _lp = 0; _lp < 4; _lp++) {
+                            __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(seed[_lp*2 + 0], seed[_lp*2+1 + 0]));
+                            seed_packed[_lp] = *(uint32_t*)&_bf2;
+                        }
+                        int seed_lane_row = lane % 16;
+                        int seed_lane_col = lane / 16 * 8;
+                        int byte_off = (int)prep_stage * 41984 + (pair_row_base + seed_lane_row) * 128 + (pair_col_base + seed_lane_col) * 2;
+                        int swizzled_off = byte_off ^ (byte_off >> 7 & 7) << 4;
+                        int seed_addr = smem_inv_work_addr + (unsigned int)swizzled_off;
+                        uint32_t _stmatrix_addr_2 = static_cast<uint32_t>((unsigned long long)seed_addr);
+                        asm volatile("stmatrix.sync.aligned.m8n8.x4.shared.b16 [%0], {%1, %2, %3, %4};\n"
+                            :: "r"(_stmatrix_addr_2), "r"(*reinterpret_cast<const uint32_t*>(&seed_packed[0])), "r"(*reinterpret_cast<const uint32_t*>(&seed_packed[1])), "r"(*reinterpret_cast<const uint32_t*>(&seed_packed[2])), "r"(*reinterpret_cast<const uint32_t*>(&seed_packed[3]))
+                            : "memory");
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(a_frag[0]), "=r"(a_frag[1]), "=r"(a_frag[2]), "=r"(a_frag[3])
+                            : "r"(smem_qd_addr + prep_stage * 41984 + (unsigned int)((lane / 16 / 8 * 256 + (pair_row_base + lane % 16) * 8 + (lane / 16 % 8 * 16 ^ (pair_row_base + lane % 16 & 7) << 4) / 16) * 16))
+                            : "memory");
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(b_frag[0]), "=r"(b_frag[1]), "=r"(b_frag[2]), "=r"(b_frag[3])
+                            : "r"(smem_ki_addr + prep_stage * 41984 + (unsigned int)((lane % 16 / 8 / 8 * 256 + (pair_col_base + 8 * (lane / 16) + lane % 8) * 8 + (lane % 16 / 8 % 8 * 16 ^ (pair_col_base + 8 * (lane / 16) + lane % 8 & 7) << 4) / 16) * 16))
+                            : "memory");
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%10, %11, %12, %13};\n"
+                            : "=f"(acc[0]), "=f"(acc[1]), "=f"(acc[2]), "=f"(acc[3])
+                            : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[0]), "r"(b_frag[1]), "f"(0.0f), "f"(0.0f), "f"(0.0f), "f"(0.0f));
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%10, %11, %12, %13};\n"
+                            : "=f"(acc[4]), "=f"(acc[(4) + 1]), "=f"(acc[(4) + 2]), "=f"(acc[(4) + 3])
+                            : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[2]), "r"(b_frag[(2) + 1]), "f"(0.0f), "f"(0.0f), "f"(0.0f), "f"(0.0f));
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(a_frag[0]), "=r"(a_frag[1]), "=r"(a_frag[2]), "=r"(a_frag[3])
+                            : "r"(smem_qd_addr + prep_stage * 41984 + (unsigned int)((lane / 16 / 8 * 256 + (pair_row_base + lane % 16) * 8 + (lane / 16 % 8 * 16 ^ (pair_row_base + lane % 16 & 7) << 4) / 16 ^ 2) * 16))
+                            : "memory");
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(b_frag[0]), "=r"(b_frag[1]), "=r"(b_frag[2]), "=r"(b_frag[3])
+                            : "r"(smem_ki_addr + prep_stage * 41984 + (unsigned int)(((lane % 16 / 8 / 8 * 256 + (pair_col_base + 8 * (lane / 16) + lane % 8) * 8 + (lane % 16 / 8 % 8 * 16 ^ (pair_col_base + 8 * (lane / 16) + lane % 8 & 7) << 4) / 16 + 256 ^ 2) - 256) * 16))
+                            : "memory");
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                            : "+f"(acc[0]), "+f"(acc[1]), "+f"(acc[2]), "+f"(acc[3])
+                            : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[0]), "r"(b_frag[1]));
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                            : "+f"(acc[4]), "+f"(acc[(4) + 1]), "+f"(acc[(4) + 2]), "+f"(acc[(4) + 3])
+                            : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[2]), "r"(b_frag[(2) + 1]));
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(a_frag[0]), "=r"(a_frag[1]), "=r"(a_frag[2]), "=r"(a_frag[3])
+                            : "r"(smem_qd_addr + prep_stage * 41984 + (unsigned int)((lane / 16 / 8 * 256 + (pair_row_base + lane % 16) * 8 + (lane / 16 % 8 * 16 ^ (pair_row_base + lane % 16 & 7) << 4) / 16 ^ 2 ^ 6) * 16))
+                            : "memory");
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(b_frag[0]), "=r"(b_frag[1]), "=r"(b_frag[2]), "=r"(b_frag[3])
+                            : "r"(smem_ki_addr + prep_stage * 41984 + (unsigned int)((((lane % 16 / 8 / 8 * 256 + (pair_col_base + 8 * (lane / 16) + lane % 8) * 8 + (lane % 16 / 8 % 8 * 16 ^ (pair_col_base + 8 * (lane / 16) + lane % 8 & 7) << 4) / 16 + 256 ^ 2) - 256 + 256 ^ 6) - 256) * 16))
+                            : "memory");
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                            : "+f"(acc[0]), "+f"(acc[1]), "+f"(acc[2]), "+f"(acc[3])
+                            : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[0]), "r"(b_frag[1]));
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                            : "+f"(acc[4]), "+f"(acc[(4) + 1]), "+f"(acc[(4) + 2]), "+f"(acc[(4) + 3])
+                            : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[2]), "r"(b_frag[(2) + 1]));
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(a_frag[0]), "=r"(a_frag[1]), "=r"(a_frag[2]), "=r"(a_frag[3])
+                            : "r"(smem_qd_addr + prep_stage * 41984 + (unsigned int)((lane / 16 / 8 * 256 + (pair_row_base + lane % 16) * 8 + (lane / 16 % 8 * 16 ^ (pair_row_base + lane % 16 & 7) << 4) / 16 ^ 2 ^ 6 ^ 2) * 16))
+                            : "memory");
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(b_frag[0]), "=r"(b_frag[1]), "=r"(b_frag[2]), "=r"(b_frag[3])
+                            : "r"(smem_ki_addr + prep_stage * 41984 + (unsigned int)(((((lane % 16 / 8 / 8 * 256 + (pair_col_base + 8 * (lane / 16) + lane % 8) * 8 + (lane % 16 / 8 % 8 * 16 ^ (pair_col_base + 8 * (lane / 16) + lane % 8 & 7) << 4) / 16 + 256 ^ 2) - 256 + 256 ^ 6) - 256 + 256 ^ 2) - 256) * 16))
+                            : "memory");
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                            : "+f"(acc[0]), "+f"(acc[1]), "+f"(acc[2]), "+f"(acc[3])
+                            : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[0]), "r"(b_frag[1]));
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                            : "+f"(acc[4]), "+f"(acc[(4) + 1]), "+f"(acc[(4) + 2]), "+f"(acc[(4) + 3])
+                            : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[2]), "r"(b_frag[(2) + 1]));
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(a_frag[0]), "=r"(a_frag[1]), "=r"(a_frag[2]), "=r"(a_frag[3])
+                            : "r"(smem_qd_addr + prep_stage * 41984 + (unsigned int)(((lane / 16 / 8 * 256 + (pair_row_base + lane % 16) * 8 + (lane / 16 % 8 * 16 ^ (pair_row_base + lane % 16 & 7) << 4) / 16 ^ 2 ^ 6 ^ 2 ^ 6) + 256) * 16))
+                            : "memory");
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(b_frag[0]), "=r"(b_frag[1]), "=r"(b_frag[2]), "=r"(b_frag[3])
+                            : "r"(smem_ki_addr + prep_stage * 41984 + (unsigned int)((((((lane % 16 / 8 / 8 * 256 + (pair_col_base + 8 * (lane / 16) + lane % 8) * 8 + (lane % 16 / 8 % 8 * 16 ^ (pair_col_base + 8 * (lane / 16) + lane % 8 & 7) << 4) / 16 + 256 ^ 2) - 256 + 256 ^ 6) - 256 + 256 ^ 2) - 256 + 256 ^ 6) + 256 - 256) * 16))
+                            : "memory");
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                            : "+f"(acc[0]), "+f"(acc[1]), "+f"(acc[2]), "+f"(acc[3])
+                            : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[0]), "r"(b_frag[1]));
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                            : "+f"(acc[4]), "+f"(acc[(4) + 1]), "+f"(acc[(4) + 2]), "+f"(acc[(4) + 3])
+                            : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[2]), "r"(b_frag[(2) + 1]));
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(a_frag[0]), "=r"(a_frag[1]), "=r"(a_frag[2]), "=r"(a_frag[3])
+                            : "r"(smem_qd_addr + prep_stage * 41984 + (unsigned int)(((lane / 16 / 8 * 256 + (pair_row_base + lane % 16) * 8 + (lane / 16 % 8 * 16 ^ (pair_row_base + lane % 16 & 7) << 4) / 16 ^ 2 ^ 6 ^ 2 ^ 6) + 256 ^ 2) * 16))
+                            : "memory");
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(b_frag[0]), "=r"(b_frag[1]), "=r"(b_frag[2]), "=r"(b_frag[3])
+                            : "r"(smem_ki_addr + prep_stage * 41984 + (unsigned int)(((((((lane % 16 / 8 / 8 * 256 + (pair_col_base + 8 * (lane / 16) + lane % 8) * 8 + (lane % 16 / 8 % 8 * 16 ^ (pair_col_base + 8 * (lane / 16) + lane % 8 & 7) << 4) / 16 + 256 ^ 2) - 256 + 256 ^ 6) - 256 + 256 ^ 2) - 256 + 256 ^ 6) + 256 - 256 + 256 ^ 2) - 256) * 16))
+                            : "memory");
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                            : "+f"(acc[0]), "+f"(acc[1]), "+f"(acc[2]), "+f"(acc[3])
+                            : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[0]), "r"(b_frag[1]));
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                            : "+f"(acc[4]), "+f"(acc[(4) + 1]), "+f"(acc[(4) + 2]), "+f"(acc[(4) + 3])
+                            : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[2]), "r"(b_frag[(2) + 1]));
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(a_frag[0]), "=r"(a_frag[1]), "=r"(a_frag[2]), "=r"(a_frag[3])
+                            : "r"(smem_qd_addr + prep_stage * 41984 + (unsigned int)(((lane / 16 / 8 * 256 + (pair_row_base + lane % 16) * 8 + (lane / 16 % 8 * 16 ^ (pair_row_base + lane % 16 & 7) << 4) / 16 ^ 2 ^ 6 ^ 2 ^ 6) + 256 ^ 2 ^ 6) * 16))
+                            : "memory");
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(b_frag[0]), "=r"(b_frag[1]), "=r"(b_frag[2]), "=r"(b_frag[3])
+                            : "r"(smem_ki_addr + prep_stage * 41984 + (unsigned int)((((((((lane % 16 / 8 / 8 * 256 + (pair_col_base + 8 * (lane / 16) + lane % 8) * 8 + (lane % 16 / 8 % 8 * 16 ^ (pair_col_base + 8 * (lane / 16) + lane % 8 & 7) << 4) / 16 + 256 ^ 2) - 256 + 256 ^ 6) - 256 + 256 ^ 2) - 256 + 256 ^ 6) + 256 - 256 + 256 ^ 2) - 256 + 256 ^ 6) - 256) * 16))
+                            : "memory");
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                            : "+f"(acc[0]), "+f"(acc[1]), "+f"(acc[2]), "+f"(acc[3])
+                            : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[0]), "r"(b_frag[1]));
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                            : "+f"(acc[4]), "+f"(acc[(4) + 1]), "+f"(acc[(4) + 2]), "+f"(acc[(4) + 3])
+                            : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[2]), "r"(b_frag[(2) + 1]));
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(a_frag[0]), "=r"(a_frag[1]), "=r"(a_frag[2]), "=r"(a_frag[3])
+                            : "r"(smem_qd_addr + prep_stage * 41984 + (unsigned int)(((lane / 16 / 8 * 256 + (pair_row_base + lane % 16) * 8 + (lane / 16 % 8 * 16 ^ (pair_row_base + lane % 16 & 7) << 4) / 16 ^ 2 ^ 6 ^ 2 ^ 6) + 256 ^ 2 ^ 6 ^ 2) * 16))
+                            : "memory");
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(b_frag[0]), "=r"(b_frag[1]), "=r"(b_frag[2]), "=r"(b_frag[3])
+                            : "r"(smem_ki_addr + prep_stage * 41984 + (unsigned int)(((((((((lane % 16 / 8 / 8 * 256 + (pair_col_base + 8 * (lane / 16) + lane % 8) * 8 + (lane % 16 / 8 % 8 * 16 ^ (pair_col_base + 8 * (lane / 16) + lane % 8 & 7) << 4) / 16 + 256 ^ 2) - 256 + 256 ^ 6) - 256 + 256 ^ 2) - 256 + 256 ^ 6) + 256 - 256 + 256 ^ 2) - 256 + 256 ^ 6) - 256 + 256 ^ 2) - 256) * 16))
+                            : "memory");
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                            : "+f"(acc[0]), "+f"(acc[1]), "+f"(acc[2]), "+f"(acc[3])
+                            : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[0]), "r"(b_frag[1]));
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                            : "+f"(acc[4]), "+f"(acc[(4) + 1]), "+f"(acc[(4) + 2]), "+f"(acc[(4) + 3])
+                            : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[2]), "r"(b_frag[(2) + 1]));
+                    } else {
+                        acc[0] = 0.0f;
+                        acc[1] = 0.0f;
+                        acc[2] = 0.0f;
+                        acc[3] = 0.0f;
+                        acc[4] = 0.0f;
+                        acc[5] = 0.0f;
+                        acc[6] = 0.0f;
+                        acc[7] = 0.0f;
+                    }
+                    int row0_1 = pair_row_base + lane / 4;
+                    int row1_1 = row0_1 + 8;
+                    int col0_1 = pair_col_base + lane % 4 * 2;
+                    float mqk[8];
+                    mqk[0] = 0.0f;
+                    mqk[1] = 0.0f;
+                    mqk[2] = 0.0f;
+                    mqk[3] = 0.0f;
+                    mqk[4] = 0.0f;
+                    mqk[5] = 0.0f;
+                    mqk[6] = 0.0f;
+                    mqk[7] = 0.0f;
+                    if (row0_1 >= col0_1) {
+                        mqk[0] = acc[0];
+                    }
+                    if (row0_1 >= col0_1 + 1) {
+                        mqk[1] = acc[1];
+                    }
+                    if (row1_1 >= col0_1) {
+                        mqk[2] = acc[2];
+                    }
+                    if (row1_1 >= col0_1 + 1) {
+                        mqk[3] = acc[3];
+                    }
+                    if (row0_1 >= col0_1 + 8) {
+                        mqk[4] = acc[4];
+                    }
+                    if (row0_1 >= col0_1 + 9) {
+                        mqk[5] = acc[5];
+                    }
+                    if (row1_1 >= col0_1 + 8) {
+                        mqk[6] = acc[6];
+                    }
+                    if (row1_1 >= col0_1 + 9) {
+                        mqk[7] = acc[7];
+                    }
+                    unsigned int mqk_packed[4];
+                    #pragma unroll
+                    for (int _lp = 0; _lp < 4; _lp++) {
+                        __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(mqk[_lp*2 + 0], mqk[_lp*2+1 + 0]));
+                        mqk_packed[_lp] = *(uint32_t*)&_bf2;
+                    }
+                    #pragma unroll
+                    for (int publish_pair = 0; publish_pair < 2; publish_pair++) {
+                        int publish_row = pair_col_base + publish_pair * 8 + (lane & 7);
+                        int publish_col = 128 + pair_row_base + lane / 8 * 8;
+                        uint32_t _stmatrix_addr_3 = static_cast<uint32_t>((unsigned long long)(smem_final_trans_addr + prep_stage * 41984 + (unsigned int)(publish_col / 64 * 4096 + publish_row * 128 + publish_col % 64 * 2 ^ (publish_col / 64 * 4096 + publish_row * 128 + publish_col % 64 * 2 >> 7 & 7) << 4)));
+                        asm volatile("stmatrix.sync.aligned.m8n8.x2.trans.shared.b16 [%0], {%1, %2};\n"
+                            :: "r"(_stmatrix_addr_3), "r"(*reinterpret_cast<const uint32_t*>(&mqk_packed[publish_pair * 2])), "r"(*reinterpret_cast<const uint32_t*>(&mqk_packed[publish_pair * 2 + 1]))
+                            : "memory");
+                    }
+                    asm volatile("barrier.sync %0, 128;" :: "r"(10 + prep_instance) : "memory");
+                }
+                long long tape_scaled_base = 0;
+                {
+                    long long chunk_global_scaled = cu_chunk_offsets[seq_idx_4] + (long long)chunk_global_local_2;
+                    tape_scaled_base = (chunk_global_scaled * (long long)num_heads + (long long)head_idx_4) * 32 * 128;
+                }
+                if (prep_tid < 128) {
+                    float total_log2_1 = smem_gt_prefix_all[stage_f32 + prep_tid];
+                    float _exp2_3 = approx_exp2(total_log2_1);
+                    smem_gt_all[stage_f32 + prep_tid] = _exp2_3;
+                }
+                {
+                    if (prep_local_warp >= 2) {
+                        int stage_f32_0 = prep_stage * 10496;
+                        float restore_scale = smem_restore_factor_all[stage_f32_0 + 128];
+                        float restore_factor[8];
+                        int restore_segment = lane & 15;
+                        #pragma unroll
+                        for (int restore_elem = 0; restore_elem < 8; restore_elem++) {
+                            int restore_col = restore_segment * 8 + restore_elem;
+                            restore_factor[restore_elem] = smem_restore_factor_all[stage_f32_0 + restore_col];
+                        }
+                        #pragma unroll 1
+                        for (int restore_pass = 0; restore_pass < 6; restore_pass++) {
+                            int restore_row = 8 + (prep_local_warp - 2) * 12 + restore_pass * 2 + (lane >> 4);
+                            float restore_kr_values[8];
+                            {
+                                float restore_qd_values[8];
+                                float restore_kd_values[8];
+                                float restore_ki_values[8];
+                                unsigned int packed_4[4];
+                                asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                                    : "=r"(*reinterpret_cast<uint32_t*>(&packed_4[0])), "=r"(*reinterpret_cast<uint32_t*>(&packed_4[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&packed_4[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&packed_4[(0) + 3]))
+                                    : "r"((smem_qd_addr + prep_stage * 41984 + (unsigned int)(restore_segment * 8 / 64 * 4096 + restore_row * 128 + restore_segment * 8 % 64 * 2 ^ (restore_segment * 8 / 64 * 4096 + restore_row * 128 + restore_segment * 8 % 64 * 2 >> 7 & 7) << 4))));
+                                float packed_f32_3[8];
+                                #pragma unroll
+                                for (int _pair = 0; _pair < 4; _pair++) {
+                                    asm volatile(
+                                        "{\n\t"
+                                        "shl.b32 %0, %2, 16;\n\t"
+                                        "and.b32 %1, %2, 0xffff0000;\n\t"
+                                        "}\n"
+                                        : "=f"((&packed_f32_3[_pair * 2])[0]), "=f"((&packed_f32_3[_pair * 2])[1])
+                                        : "r"(packed_4[_pair]));
+                                }
+                                #pragma unroll
+                                for (int value_idx_4 = 0; value_idx_4 < 8; value_idx_4++) {
+                                    restore_qd_values[value_idx_4] = packed_f32_3[value_idx_4];
+                                }
+                                unsigned int packed_0_1[4];
+                                asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                                    : "=r"(*reinterpret_cast<uint32_t*>(&packed_0_1[0])), "=r"(*reinterpret_cast<uint32_t*>(&packed_0_1[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&packed_0_1[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&packed_0_1[(0) + 3]))
+                                    : "r"((smem_ki_addr + prep_stage * 41984 + (unsigned int)(restore_segment * 8 / 64 * 4096 + restore_row * 128 + restore_segment * 8 % 64 * 2 ^ (restore_segment * 8 / 64 * 4096 + restore_row * 128 + restore_segment * 8 % 64 * 2 >> 7 & 7) << 4))));
+                                float packed_0_f32_1[8];
+                                #pragma unroll
+                                for (int _pair = 0; _pair < 4; _pair++) {
+                                    asm volatile(
+                                        "{\n\t"
+                                        "shl.b32 %0, %2, 16;\n\t"
+                                        "and.b32 %1, %2, 0xffff0000;\n\t"
+                                        "}\n"
+                                        : "=f"((&packed_0_f32_1[_pair * 2])[0]), "=f"((&packed_0_f32_1[_pair * 2])[1])
+                                        : "r"(packed_0_1[_pair]));
+                                }
+                                #pragma unroll
+                                for (int value_idx_5 = 0; value_idx_5 < 8; value_idx_5++) {
+                                    restore_ki_values[value_idx_5] = packed_0_f32_1[value_idx_5];
+                                }
+                                if (STORE_BACKWARD_TAPE != 0 && owned_chunk_2 != 0) {
+                                    unsigned int packed_1_2[4];
+                                    asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                                        : "=r"(*reinterpret_cast<uint32_t*>(&packed_1_2[0])), "=r"(*reinterpret_cast<uint32_t*>(&packed_1_2[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&packed_1_2[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&packed_1_2[(0) + 3]))
+                                        : "r"((smem_kd_addr + prep_stage * 41984 + (unsigned int)(restore_segment * 8 / 64 * 4096 + restore_row * 128 + restore_segment * 8 % 64 * 2 ^ (restore_segment * 8 / 64 * 4096 + restore_row * 128 + restore_segment * 8 % 64 * 2 >> 7 & 7) << 4))));
+                                    float packed_1_f32[8];
+                                    #pragma unroll
+                                    for (int _pair = 0; _pair < 4; _pair++) {
+                                        asm volatile(
+                                            "{\n\t"
+                                            "shl.b32 %0, %2, 16;\n\t"
+                                            "and.b32 %1, %2, 0xffff0000;\n\t"
+                                            "}\n"
+                                            : "=f"((&packed_1_f32[_pair * 2])[0]), "=f"((&packed_1_f32[_pair * 2])[1])
+                                            : "r"(packed_1_2[_pair]));
+                                    }
+                                    #pragma unroll
+                                    for (int value_idx_6 = 0; value_idx_6 < 8; value_idx_6++) {
+                                        restore_kd_values[value_idx_6] = packed_1_f32[value_idx_6];
+                                    }
+                                    long long tape_scaled_index = tape_scaled_base + (long long)restore_row * 128 + (long long)(restore_segment * 8);
+                                    {
+                                        __nv_bfloat162 _pk[4];
+                                        _pk[0] = __floats2bfloat162_rn(restore_qd_values[0 + 0], restore_qd_values[0 + 1]);
+                                        _pk[1] = __floats2bfloat162_rn(restore_qd_values[0 + 2], restore_qd_values[0 + 3]);
+                                        _pk[2] = __floats2bfloat162_rn(restore_qd_values[0 + 4], restore_qd_values[0 + 5]);
+                                        _pk[3] = __floats2bfloat162_rn(restore_qd_values[0 + 6], restore_qd_values[0 + 7]);
+                                        *reinterpret_cast<uint4*>(&((__nv_bfloat16*)(tape_qd + tape_scaled_index))[0]) = *reinterpret_cast<uint4*>(&_pk[0]);
+                                    }
+                                    {
+                                        __nv_bfloat162 _pk[4];
+                                        _pk[0] = __floats2bfloat162_rn(restore_kd_values[0 + 0], restore_kd_values[0 + 1]);
+                                        _pk[1] = __floats2bfloat162_rn(restore_kd_values[0 + 2], restore_kd_values[0 + 3]);
+                                        _pk[2] = __floats2bfloat162_rn(restore_kd_values[0 + 4], restore_kd_values[0 + 5]);
+                                        _pk[3] = __floats2bfloat162_rn(restore_kd_values[0 + 6], restore_kd_values[0 + 7]);
+                                        *reinterpret_cast<uint4*>(&((__nv_bfloat16*)(tape_kd + tape_scaled_index))[0]) = *reinterpret_cast<uint4*>(&_pk[0]);
+                                    }
+                                }
+                                const float2 _scale2_4 = {restore_scale, restore_scale};
+                                #pragma unroll
+                                for (int _ls = 0; _ls < 4; _ls++)
+                                    mul_f32x2_inplace(&reinterpret_cast<float2*>(restore_qd_values)[_ls], _scale2_4);
+                                #pragma unroll
+                                for (int restore_elem_1 = 0; restore_elem_1 < 8; restore_elem_1++) {
+                                    restore_kr_values[restore_elem_1] = restore_ki_values[restore_elem_1] * restore_factor[restore_elem_1];
+                                }
+                            }
+                            unsigned int packed_5[4];
+                            #pragma unroll
+                            for (int _lp = 0; _lp < 4; _lp++) {
+                                __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(restore_kr_values[_lp*2 + 0], restore_kr_values[_lp*2+1 + 0]));
+                                packed_5[_lp] = *(uint32_t*)&_bf2;
+                            }
+                            #pragma unroll
+                            for (int word_3 = 0; word_3 < 4; word_3++) {
+                                asm volatile("st.shared.b32 [%0], %1;" :: "r"((smem_kr_trans_addr + prep_stage * 41984 + (unsigned int)(restore_segment * 8 / 64 * 4096 + restore_row * 128 + restore_segment * 8 % 64 * 2 ^ (restore_segment * 8 / 64 * 4096 + restore_row * 128 + restore_segment * 8 % 64 * 2 >> 7 & 7) << 4)) + (unsigned int)(word_3 * 4)), "r"((packed_5[word_3])));
+                            }
+                        }
+                    } else if (prep_local_warp == 1) {
+                        int stage_f32_0_1 = prep_stage * 10496;
+                        float restore_scale_1 = smem_restore_factor_all[stage_f32_0_1 + 128];
+                        float restore_factor_1[8];
+                        int restore_segment_1 = lane & 15;
+                        #pragma unroll
+                        for (int restore_elem_2 = 0; restore_elem_2 < 8; restore_elem_2++) {
+                            int restore_col_1 = restore_segment_1 * 8 + restore_elem_2;
+                            restore_factor_1[restore_elem_2] = smem_restore_factor_all[stage_f32_0_1 + restore_col_1];
+                        }
+                        #pragma unroll 1
+                        for (int restore_pass_1 = 0; restore_pass_1 < 4; restore_pass_1++) {
+                            int restore_row_1 = restore_pass_1 * 2 + (lane >> 4);
+                            float restore_kr_values_1[8];
+                            {
+                                float restore_qd_values_1[8];
+                                float restore_kd_values_1[8];
+                                float restore_ki_values_1[8];
+                                unsigned int packed_6[4];
+                                asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                                    : "=r"(*reinterpret_cast<uint32_t*>(&packed_6[0])), "=r"(*reinterpret_cast<uint32_t*>(&packed_6[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&packed_6[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&packed_6[(0) + 3]))
+                                    : "r"((smem_qd_addr + prep_stage * 41984 + (unsigned int)(restore_segment_1 * 8 / 64 * 4096 + restore_row_1 * 128 + restore_segment_1 * 8 % 64 * 2 ^ (restore_segment_1 * 8 / 64 * 4096 + restore_row_1 * 128 + restore_segment_1 * 8 % 64 * 2 >> 7 & 7) << 4))));
+                                float packed_f32_4[8];
+                                #pragma unroll
+                                for (int _pair = 0; _pair < 4; _pair++) {
+                                    asm volatile(
+                                        "{\n\t"
+                                        "shl.b32 %0, %2, 16;\n\t"
+                                        "and.b32 %1, %2, 0xffff0000;\n\t"
+                                        "}\n"
+                                        : "=f"((&packed_f32_4[_pair * 2])[0]), "=f"((&packed_f32_4[_pair * 2])[1])
+                                        : "r"(packed_6[_pair]));
+                                }
+                                #pragma unroll
+                                for (int value_idx_7 = 0; value_idx_7 < 8; value_idx_7++) {
+                                    restore_qd_values_1[value_idx_7] = packed_f32_4[value_idx_7];
+                                }
+                                unsigned int packed_0_2[4];
+                                asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                                    : "=r"(*reinterpret_cast<uint32_t*>(&packed_0_2[0])), "=r"(*reinterpret_cast<uint32_t*>(&packed_0_2[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&packed_0_2[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&packed_0_2[(0) + 3]))
+                                    : "r"((smem_ki_addr + prep_stage * 41984 + (unsigned int)(restore_segment_1 * 8 / 64 * 4096 + restore_row_1 * 128 + restore_segment_1 * 8 % 64 * 2 ^ (restore_segment_1 * 8 / 64 * 4096 + restore_row_1 * 128 + restore_segment_1 * 8 % 64 * 2 >> 7 & 7) << 4))));
+                                float packed_0_f32_2[8];
+                                #pragma unroll
+                                for (int _pair = 0; _pair < 4; _pair++) {
+                                    asm volatile(
+                                        "{\n\t"
+                                        "shl.b32 %0, %2, 16;\n\t"
+                                        "and.b32 %1, %2, 0xffff0000;\n\t"
+                                        "}\n"
+                                        : "=f"((&packed_0_f32_2[_pair * 2])[0]), "=f"((&packed_0_f32_2[_pair * 2])[1])
+                                        : "r"(packed_0_2[_pair]));
+                                }
+                                #pragma unroll
+                                for (int value_idx_8 = 0; value_idx_8 < 8; value_idx_8++) {
+                                    restore_ki_values_1[value_idx_8] = packed_0_f32_2[value_idx_8];
+                                }
+                                if (STORE_BACKWARD_TAPE != 0 && owned_chunk_2 != 0) {
+                                    unsigned int packed_1_3[4];
+                                    asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                                        : "=r"(*reinterpret_cast<uint32_t*>(&packed_1_3[0])), "=r"(*reinterpret_cast<uint32_t*>(&packed_1_3[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&packed_1_3[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&packed_1_3[(0) + 3]))
+                                        : "r"((smem_kd_addr + prep_stage * 41984 + (unsigned int)(restore_segment_1 * 8 / 64 * 4096 + restore_row_1 * 128 + restore_segment_1 * 8 % 64 * 2 ^ (restore_segment_1 * 8 / 64 * 4096 + restore_row_1 * 128 + restore_segment_1 * 8 % 64 * 2 >> 7 & 7) << 4))));
+                                    float packed_1_f32_1[8];
+                                    #pragma unroll
+                                    for (int _pair = 0; _pair < 4; _pair++) {
+                                        asm volatile(
+                                            "{\n\t"
+                                            "shl.b32 %0, %2, 16;\n\t"
+                                            "and.b32 %1, %2, 0xffff0000;\n\t"
+                                            "}\n"
+                                            : "=f"((&packed_1_f32_1[_pair * 2])[0]), "=f"((&packed_1_f32_1[_pair * 2])[1])
+                                            : "r"(packed_1_3[_pair]));
+                                    }
+                                    #pragma unroll
+                                    for (int value_idx_9 = 0; value_idx_9 < 8; value_idx_9++) {
+                                        restore_kd_values_1[value_idx_9] = packed_1_f32_1[value_idx_9];
+                                    }
+                                    long long tape_scaled_index_1 = tape_scaled_base + (long long)restore_row_1 * 128 + (long long)(restore_segment_1 * 8);
+                                    {
+                                        __nv_bfloat162 _pk[4];
+                                        _pk[0] = __floats2bfloat162_rn(restore_qd_values_1[0 + 0], restore_qd_values_1[0 + 1]);
+                                        _pk[1] = __floats2bfloat162_rn(restore_qd_values_1[0 + 2], restore_qd_values_1[0 + 3]);
+                                        _pk[2] = __floats2bfloat162_rn(restore_qd_values_1[0 + 4], restore_qd_values_1[0 + 5]);
+                                        _pk[3] = __floats2bfloat162_rn(restore_qd_values_1[0 + 6], restore_qd_values_1[0 + 7]);
+                                        *reinterpret_cast<uint4*>(&((__nv_bfloat16*)(tape_qd + tape_scaled_index_1))[0]) = *reinterpret_cast<uint4*>(&_pk[0]);
+                                    }
+                                    {
+                                        __nv_bfloat162 _pk[4];
+                                        _pk[0] = __floats2bfloat162_rn(restore_kd_values_1[0 + 0], restore_kd_values_1[0 + 1]);
+                                        _pk[1] = __floats2bfloat162_rn(restore_kd_values_1[0 + 2], restore_kd_values_1[0 + 3]);
+                                        _pk[2] = __floats2bfloat162_rn(restore_kd_values_1[0 + 4], restore_kd_values_1[0 + 5]);
+                                        _pk[3] = __floats2bfloat162_rn(restore_kd_values_1[0 + 6], restore_kd_values_1[0 + 7]);
+                                        *reinterpret_cast<uint4*>(&((__nv_bfloat16*)(tape_kd + tape_scaled_index_1))[0]) = *reinterpret_cast<uint4*>(&_pk[0]);
+                                    }
+                                }
+                                const float2 _scale2_5 = {restore_scale_1, restore_scale_1};
+                                #pragma unroll
+                                for (int _ls = 0; _ls < 4; _ls++)
+                                    mul_f32x2_inplace(&reinterpret_cast<float2*>(restore_qd_values_1)[_ls], _scale2_5);
+                                #pragma unroll
+                                for (int restore_elem_3 = 0; restore_elem_3 < 8; restore_elem_3++) {
+                                    restore_kr_values_1[restore_elem_3] = restore_ki_values_1[restore_elem_3] * restore_factor_1[restore_elem_3];
+                                }
+                            }
+                            unsigned int packed_7[4];
+                            #pragma unroll
+                            for (int _lp = 0; _lp < 4; _lp++) {
+                                __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(restore_kr_values_1[_lp*2 + 0], restore_kr_values_1[_lp*2+1 + 0]));
+                                packed_7[_lp] = *(uint32_t*)&_bf2;
+                            }
+                            #pragma unroll
+                            for (int word_4 = 0; word_4 < 4; word_4++) {
+                                asm volatile("st.shared.b32 [%0], %1;" :: "r"((smem_kr_trans_addr + prep_stage * 41984 + (unsigned int)(restore_segment_1 * 8 / 64 * 4096 + restore_row_1 * 128 + restore_segment_1 * 8 % 64 * 2 ^ (restore_segment_1 * 8 / 64 * 4096 + restore_row_1 * 128 + restore_segment_1 * 8 % 64 * 2 >> 7 & 7) << 4)) + (unsigned int)(word_4 * 4)), "r"((packed_7[word_4])));
+                            }
+                        }
+                    }
+                }
+                if (prep_local_warp == 0) {
+                    int inverse_row = lane;
+                    int diag_block = inverse_row / 8;
+                    int lane_in_diag = lane & 7;
+                    float inv_row[8];
+                    unsigned int packed_8[4];
+                    int byte_off_1 = (int)prep_stage * 41984 + inverse_row * 128 + diag_block * 8 * 2;
+                    int swizzled_off_1 = byte_off_1 ^ (byte_off_1 >> 7 & 7) << 4;
+                    asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                        : "=r"(*reinterpret_cast<uint32_t*>(&packed_8[0])), "=r"(*reinterpret_cast<uint32_t*>(&packed_8[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&packed_8[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&packed_8[(0) + 3]))
+                        : "r"(smem_inv_work_addr + (unsigned int)swizzled_off_1));
+                    float packed_f32_5[8];
+                    #pragma unroll
+                    for (int _pair = 0; _pair < 4; _pair++) {
+                        asm volatile(
+                            "{\n\t"
+                            "shl.b32 %0, %2, 16;\n\t"
+                            "and.b32 %1, %2, 0xffff0000;\n\t"
+                            "}\n"
+                            : "=f"((&packed_f32_5[_pair * 2])[0]), "=f"((&packed_f32_5[_pair * 2])[1])
+                            : "r"(packed_8[_pair]));
+                    }
+                    #pragma unroll
+                    for (int value_idx_10 = 0; value_idx_10 < 8; value_idx_10++) {
+                        inv_row[value_idx_10] = packed_f32_5[value_idx_10];
+                    }
+                    #pragma unroll
+                    for (int diag_elem = 0; diag_elem < 8; diag_elem++) {
+                        if (lane_in_diag == diag_elem) {
+                            inv_row[diag_elem] = 1.0f;
+                        }
+                    }
+                    int diag_group_base = lane - lane_in_diag;
+                    #pragma unroll
+                    for (int src_row = 0; src_row < 7; src_row++) {
+                        float row_scale = -inv_row[src_row];
+                        #pragma unroll
+                        for (int prev_col = 0; prev_col < src_row; prev_col++) {
+                            int pivot_lane = diag_group_base + src_row;
+                            float _shfl_0 = __shfl_sync(0xFFFFFFFF, inv_row[prev_col], pivot_lane);
+                            float pivot = _shfl_0;
+                            if (lane_in_diag > src_row) {
+                                float _fma_6 = __fmaf_rn(row_scale, pivot, inv_row[prev_col]);
+                                inv_row[prev_col] = _fma_6;
+                            }
+                        }
+                        if (lane_in_diag > src_row) {
+                            inv_row[src_row] = row_scale;
+                        }
+                    }
+                    unsigned int packed_0_3[4];
+                    #pragma unroll
+                    for (int _lp = 0; _lp < 4; _lp++) {
+                        __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(inv_row[_lp*2 + 0], inv_row[_lp*2+1 + 0]));
+                        packed_0_3[_lp] = *(uint32_t*)&_bf2;
+                    }
+                    int byte_off_1_1 = (int)prep_stage * 41984 + inverse_row * 128 + diag_block * 8 * 2;
+                    int swizzled_off_2 = byte_off_1_1 ^ (byte_off_1_1 >> 7 & 7) << 4;
+                    #pragma unroll
+                    for (int word_5 = 0; word_5 < 4; word_5++) {
+                        asm volatile("st.shared.b32 [%0], %1;" :: "r"(smem_inv_work_addr + (unsigned int)swizzled_off_2 + (unsigned int)(word_5 * 4)), "r"((packed_0_3[word_5])));
+                    }
+                }
+                if (prep_local_warp < 2) {
+                    __syncwarp();
+                    if (elect_sync()) {
+                        mbarrier_arrive(prep_diag_ready_addr + (prep_stage) * 8);
+                    }
+                    mbarrier_wait(prep_diag_ready_addr + (prep_stage) * 8, _phase_prep_diag_ready);
+                }
+                {
+                    if (prep_local_warp < 2) {
+                        int lane_row = lane & 7;
+                        int byte_off_2 = (int)prep_stage * 41984 + (prep_local_warp * 16 + 8 + lane_row) * 128 + (prep_local_warp * 16 + 8) * 2;
+                        int swizzled_off_3 = byte_off_2 ^ (byte_off_2 >> 7 & 7) << 4;
+                        int d_addr = smem_inv_work_addr + (unsigned int)swizzled_off_3;
+                        int byte_off_0 = (int)prep_stage * 41984 + (prep_local_warp * 16 + 8 + lane_row) * 128 + prep_local_warp * 16 * 2;
+                        int swizzled_off_1_1 = byte_off_0 ^ (byte_off_0 >> 7 & 7) << 4;
+                        int c_addr = smem_inv_work_addr + (unsigned int)swizzled_off_1_1;
+                        int byte_off_2_1 = (int)prep_stage * 41984 + (prep_local_warp * 16 + lane_row) * 128 + prep_local_warp * 16 * 2;
+                        int swizzled_off_3_1 = byte_off_2_1 ^ (byte_off_2_1 >> 7 & 7) << 4;
+                        int a_addr = smem_inv_work_addr + (unsigned int)swizzled_off_3_1;
+                        unsigned int d_frag[2];
+                        unsigned int c_frag[1];
+                        float dc_acc[4];
+                        unsigned int dc_bf16[2];
+                        unsigned int inv_a_frag[1];
+                        float o_acc[4];
+                        unsigned int o_bf16[2];
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x1.shared.b16 {%0}, [%1];\n"
+                            : "=r"(d_frag[0])
+                            : "r"(d_addr)
+                            : "memory");
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x1.shared.b16 {%0}, [%1];\n"
+                            : "=r"(d_frag[1])
+                            : "r"(d_addr)
+                            : "memory");
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x1.trans.shared.b16 {%0}, [%1];\n"
+                            : "=r"(c_frag[0])
+                            : "r"(c_addr)
+                            : "memory");
+                        asm volatile("mma.sync.aligned.m16n8k8.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5}, {%6}, {%7, %8, %9, %10};\n"
+                            : "=f"(dc_acc[0]), "=f"(dc_acc[1]), "=f"(dc_acc[2]), "=f"(dc_acc[3])
+                            : "r"(d_frag[0]), "r"(d_frag[1]), "r"(c_frag[0]), "f"(0.0f), "f"(0.0f), "f"(0.0f), "f"(0.0f));
+                        const float2 _scale2_6 = {-1.0f, -1.0f};
+                        #pragma unroll
+                        for (int _ls = 0; _ls < 2; _ls++)
+                            mul_f32x2_inplace(&reinterpret_cast<float2*>(dc_acc)[_ls], _scale2_6);
+                        #pragma unroll
+                        for (int _lp = 0; _lp < 2; _lp++) {
+                            __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(dc_acc[_lp*2 + 0], dc_acc[_lp*2+1 + 0]));
+                            dc_bf16[_lp] = *(uint32_t*)&_bf2;
+                        }
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x1.trans.shared.b16 {%0}, [%1];\n"
+                            : "=r"(inv_a_frag[0])
+                            : "r"(a_addr)
+                            : "memory");
+                        asm volatile("mma.sync.aligned.m16n8k8.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5}, {%6}, {%7, %8, %9, %10};\n"
+                            : "=f"(o_acc[0]), "=f"(o_acc[1]), "=f"(o_acc[2]), "=f"(o_acc[3])
+                            : "r"(dc_bf16[0]), "r"(dc_bf16[1]), "r"(inv_a_frag[0]), "f"(0.0f), "f"(0.0f), "f"(0.0f), "f"(0.0f));
+                        #pragma unroll
+                        for (int _lp = 0; _lp < 2; _lp++) {
+                            __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(o_acc[_lp*2 + 0], o_acc[_lp*2+1 + 0]));
+                            o_bf16[_lp] = *(uint32_t*)&_bf2;
+                        }
+                        int byte_off_4 = (int)prep_stage * 41984 + (prep_local_warp * 16 + 8 + lane_row) * 128 + prep_local_warp * 16 * 2;
+                        int swizzled_off_5 = byte_off_4 ^ (byte_off_4 >> 7 & 7) << 4;
+                        int o_addr = smem_inv_work_addr + (unsigned int)swizzled_off_5;
+                        uint32_t _stmatrix_addr_7 = static_cast<uint32_t>((unsigned long long)o_addr);
+                        asm volatile("stmatrix.sync.aligned.m8n8.x1.shared.b16 [%0], {%1};\n"
+                            :: "r"(_stmatrix_addr_7), "r"(*reinterpret_cast<const uint32_t*>(&o_bf16[0]))
+                            : "memory");
+                        __syncwarp();
+                        if (elect_sync()) {
+                            mbarrier_arrive(prep_inv16_ready_addr + (prep_stage) * 8);
+                        }
+                        mbarrier_wait(prep_inv16_ready_addr + (prep_stage) * 8, _phase_prep_inv16_ready);
+                    }
+                }
+                {
+                    if (prep_local_warp == 0) {
+                        int lane_row_1 = lane % 16;
+                        int lane_col = lane / 16 * 8;
+                        int byte_off_3 = (int)prep_stage * 41984 + (16 + lane_row_1) * 128 + (16 + lane_col) * 2;
+                        int swizzled_off_4 = byte_off_3 ^ (byte_off_3 >> 7 & 7) << 4;
+                        int d_addr_1 = smem_inv_work_addr + (unsigned int)swizzled_off_4;
+                        int byte_off_0_1 = (int)prep_stage * 41984 + (16 + lane_row_1) * 128 + lane_col * 2;
+                        int swizzled_off_1_2 = byte_off_0_1 ^ (byte_off_0_1 >> 7 & 7) << 4;
+                        int c_addr_1 = smem_inv_work_addr + (unsigned int)swizzled_off_1_2;
+                        int byte_off_2_2 = (int)prep_stage * 41984 + lane_row_1 * 128 + lane_col * 2;
+                        int swizzled_off_3_2 = byte_off_2_2 ^ (byte_off_2_2 >> 7 & 7) << 4;
+                        int a_addr_1 = smem_inv_work_addr + (unsigned int)swizzled_off_3_2;
+                        unsigned int d32_frag[4];
+                        unsigned int c32_frag[4];
+                        float dc32_acc[8];
+                        unsigned int dc32_bf16[4];
+                        unsigned int a32_frag[4];
+                        float o32_acc[8];
+                        unsigned int o32_bf16[4];
+                        unsigned int zero32_bf16[4];
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(d32_frag[0]), "=r"(d32_frag[1]), "=r"(d32_frag[2]), "=r"(d32_frag[3])
+                            : "r"(d_addr_1)
+                            : "memory");
+                        int d_publish_addr = (smem_inv_addr + prep_stage * 41984 + (unsigned int)((16 + lane_col) / 16 * 1024 + (16 + lane_row_1) * 32 + (16 + lane_col) % 16 * 2 ^ ((16 + lane_col) / 16 * 1024 + (16 + lane_row_1) * 32 + (16 + lane_col) % 16 * 2 >> 7 & 1) << 4));
+                        uint32_t _stmatrix_addr_8 = static_cast<uint32_t>((unsigned long long)d_publish_addr);
+                        asm volatile("stmatrix.sync.aligned.m8n8.x4.shared.b16 [%0], {%1, %2, %3, %4};\n"
+                            :: "r"(_stmatrix_addr_8), "r"(*reinterpret_cast<const uint32_t*>(&d32_frag[0])), "r"(*reinterpret_cast<const uint32_t*>(&d32_frag[1])), "r"(*reinterpret_cast<const uint32_t*>(&d32_frag[2])), "r"(*reinterpret_cast<const uint32_t*>(&d32_frag[3]))
+                            : "memory");
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.trans.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(c32_frag[0]), "=r"(c32_frag[1]), "=r"(c32_frag[2]), "=r"(c32_frag[3])
+                            : "r"(c_addr_1)
+                            : "memory");
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%10, %11, %12, %13};\n"
+                            : "=f"(dc32_acc[0]), "=f"(dc32_acc[1]), "=f"(dc32_acc[2]), "=f"(dc32_acc[3])
+                            : "r"(d32_frag[0]), "r"(d32_frag[1]), "r"(d32_frag[2]), "r"(d32_frag[3]), "r"(c32_frag[0]), "r"(c32_frag[1]), "f"(0.0f), "f"(0.0f), "f"(0.0f), "f"(0.0f));
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%10, %11, %12, %13};\n"
+                            : "=f"(dc32_acc[4]), "=f"(dc32_acc[(4) + 1]), "=f"(dc32_acc[(4) + 2]), "=f"(dc32_acc[(4) + 3])
+                            : "r"(d32_frag[0]), "r"(d32_frag[1]), "r"(d32_frag[2]), "r"(d32_frag[3]), "r"(c32_frag[2]), "r"(c32_frag[(2) + 1]), "f"(0.0f), "f"(0.0f), "f"(0.0f), "f"(0.0f));
+                        const float2 _scale2_9 = {-1.0f, -1.0f};
+                        #pragma unroll
+                        for (int _ls = 0; _ls < 4; _ls++)
+                            mul_f32x2_inplace(&reinterpret_cast<float2*>(dc32_acc)[_ls], _scale2_9);
+                        #pragma unroll
+                        for (int _lp = 0; _lp < 4; _lp++) {
+                            __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(dc32_acc[_lp*2 + 0], dc32_acc[_lp*2+1 + 0]));
+                            dc32_bf16[_lp] = *(uint32_t*)&_bf2;
+                        }
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x4.trans.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                            : "=r"(a32_frag[0]), "=r"(a32_frag[1]), "=r"(a32_frag[2]), "=r"(a32_frag[3])
+                            : "r"(a_addr_1)
+                            : "memory");
+                        int a_publish_addr = (smem_inv_addr + prep_stage * 41984 + (unsigned int)(lane_col / 16 * 1024 + lane_row_1 * 32 + lane_col % 16 * 2 ^ (lane_col / 16 * 1024 + lane_row_1 * 32 + lane_col % 16 * 2 >> 7 & 1) << 4));
+                        uint32_t _stmatrix_addr_10 = static_cast<uint32_t>((unsigned long long)a_publish_addr);
+                        asm volatile("stmatrix.sync.aligned.m8n8.x4.trans.shared.b16 [%0], {%1, %2, %3, %4};\n"
+                            :: "r"(_stmatrix_addr_10), "r"(*reinterpret_cast<const uint32_t*>(&a32_frag[0])), "r"(*reinterpret_cast<const uint32_t*>(&a32_frag[1])), "r"(*reinterpret_cast<const uint32_t*>(&a32_frag[2])), "r"(*reinterpret_cast<const uint32_t*>(&a32_frag[3]))
+                            : "memory");
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%10, %11, %12, %13};\n"
+                            : "=f"(o32_acc[0]), "=f"(o32_acc[1]), "=f"(o32_acc[2]), "=f"(o32_acc[3])
+                            : "r"(dc32_bf16[0]), "r"(dc32_bf16[1]), "r"(dc32_bf16[2]), "r"(dc32_bf16[3]), "r"(a32_frag[0]), "r"(a32_frag[1]), "f"(0.0f), "f"(0.0f), "f"(0.0f), "f"(0.0f));
+                        asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%10, %11, %12, %13};\n"
+                            : "=f"(o32_acc[4]), "=f"(o32_acc[(4) + 1]), "=f"(o32_acc[(4) + 2]), "=f"(o32_acc[(4) + 3])
+                            : "r"(dc32_bf16[0]), "r"(dc32_bf16[1]), "r"(dc32_bf16[2]), "r"(dc32_bf16[3]), "r"(a32_frag[2]), "r"(a32_frag[(2) + 1]), "f"(0.0f), "f"(0.0f), "f"(0.0f), "f"(0.0f));
+                        #pragma unroll
+                        for (int _lp = 0; _lp < 4; _lp++) {
+                            __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(o32_acc[_lp*2 + 0], o32_acc[_lp*2+1 + 0]));
+                            o32_bf16[_lp] = *(uint32_t*)&_bf2;
+                        }
+                        int o_publish_addr = (smem_inv_addr + prep_stage * 41984 + (unsigned int)(lane_col / 16 * 1024 + (16 + lane_row_1) * 32 + lane_col % 16 * 2 ^ (lane_col / 16 * 1024 + (16 + lane_row_1) * 32 + lane_col % 16 * 2 >> 7 & 1) << 4));
+                        uint32_t _stmatrix_addr_11 = static_cast<uint32_t>((unsigned long long)o_publish_addr);
+                        asm volatile("stmatrix.sync.aligned.m8n8.x4.shared.b16 [%0], {%1, %2, %3, %4};\n"
+                            :: "r"(_stmatrix_addr_11), "r"(*reinterpret_cast<const uint32_t*>(&o32_bf16[0])), "r"(*reinterpret_cast<const uint32_t*>(&o32_bf16[1])), "r"(*reinterpret_cast<const uint32_t*>(&o32_bf16[2])), "r"(*reinterpret_cast<const uint32_t*>(&o32_bf16[3]))
+                            : "memory");
+                        #pragma unroll
+                        for (int zero_word = 0; zero_word < 4; zero_word++) {
+                            zero32_bf16[zero_word] = 0;
+                        }
+                        int zero_publish_addr = (smem_inv_addr + prep_stage * 41984 + (unsigned int)((16 + lane_col) / 16 * 1024 + lane_row_1 * 32 + (16 + lane_col) % 16 * 2 ^ ((16 + lane_col) / 16 * 1024 + lane_row_1 * 32 + (16 + lane_col) % 16 * 2 >> 7 & 1) << 4));
+                        uint32_t _stmatrix_addr_12 = static_cast<uint32_t>((unsigned long long)zero_publish_addr);
+                        asm volatile("stmatrix.sync.aligned.m8n8.x4.shared.b16 [%0], {%1, %2, %3, %4};\n"
+                            :: "r"(_stmatrix_addr_12), "r"(*reinterpret_cast<const uint32_t*>(&zero32_bf16[0])), "r"(*reinterpret_cast<const uint32_t*>(&zero32_bf16[1])), "r"(*reinterpret_cast<const uint32_t*>(&zero32_bf16[2])), "r"(*reinterpret_cast<const uint32_t*>(&zero32_bf16[3]))
+                            : "memory");
+                    }
+                }
+                asm volatile("fence.proxy.async.shared::cta;" ::: "memory");
+                asm volatile("barrier.sync %0, 128;" :: "r"(10 + prep_instance) : "memory");
+                if (prep_local_warp == 0) {
+                    if (elect_sync()) {
+                        {
+                            mbarrier_arrive(qk_full_addr + (prep_stage) * 8);
+                        }
+                        {
+                            mbarrier_arrive(tape_ready_addr + (prep_stage) * 8);
+                        }
+                    }
+                }
+                {
+                    mbarrier_wait(tape_free_addr + (prep_stage) * 8, _phase_tape_free);
+                }
+                if (chunk_is_full_1 != 0) {
+                    if (prep_local_warp == 0) {
+                        if (elect_sync()) {
+                            mbarrier_arrive_expect_tx(v_full_addr + (prep_stage) * 8, 8192);
+                            {
+                                tma_3d_gmem2smem(smem_v_addr + prep_stage * 41984, v_tma, 0, head_idx_4, (int)(bos_4 + (long long)(chunk_idx_3 * 32)), v_full_addr + (prep_stage) * 8);
+                            }
+                        }
+                    }
+                } else {
+                    #pragma unroll
+                    for (int v_load_iter = 0; v_load_iter < 4; v_load_iter++) {
+                        int v_item = v_load_iter * 128 + prep_tid;
+                        int row_1 = v_item / 16;
+                        int segment_1 = v_item % 16;
+                        long long token_1 = bos_4 + (long long)(chunk_idx_3 * 32 + row_1);
+                        int token_valid_1 = ((token_1 < eos_4) ? 1 : 0);
+                        long long v_src = (token_1 * (long long)num_heads + (long long)head_idx_4) * 128 + (long long)(segment_1 * 8);
+                        int v_dst = smem_v_addr + prep_stage * 41984 + (unsigned int)((row_1 * 128 + segment_1 * 8) * 2);
+                        asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16, %2;"
+                            :: "r"(v_dst), "l"(v + v_src), "r"((token_valid_1 != 0) ? 16 : 0));
+                    }
+                    asm volatile("cp.async.commit_group;");
+                    asm volatile("cp.async.wait_group 0;");
+                    asm volatile("barrier.sync %0, 128;" :: "r"(10 + prep_instance) : "memory");
+                    if (prep_local_warp == 0) {
+                        if (elect_sync()) {
+                            asm volatile("fence.proxy.async.shared::cta;" ::: "memory");
+                            mbarrier_arrive(v_full_addr + (prep_stage) * 8);
+                        }
+                    }
+                }
+                for (int _advance = 0; _advance < 5; _advance++) {
+                    prep_stage += 1;
+                    if (prep_stage == 5) { prep_stage = 0; _phase_raw_inputs_free ^= 1; _phase_gate_raw_full ^= 1; _phase_smem_free ^= 1; _phase_v_free ^= 1; _phase_qk_raw_full ^= 1; _phase_short_beta_ready ^= 1; _phase_prep_diag_ready ^= 1; _phase_prep_inv16_ready ^= 1; _phase_tape_free ^= 1; }
+                }
+            }
+        }
+    }
+
+    // Cleanup
+}
+
+} // extern "C"
+
+#undef LOOM_INF
+#undef NUM_CHECKPOINT_PIPE_STAGES
+#undef NUM_CHUNK_PIPE_STAGES
+#undef SMEM_SMEM_BETA_RAW_ALL_OFF
+#undef SMEM_SMEM_BETA_RAW_ALL_STAGE_BYTES
+#undef SMEM_SMEM_BETA_RAW_ALL_STRIDE
+#undef SMEM_SMEM_BETA_RAW_OFF
+#undef SMEM_SMEM_BETA_RAW_STAGE_BYTES
+#undef SMEM_SMEM_BETA_RAW_STRIDE
+#undef SMEM_SMEM_CHECKPOINT_OFF
+#undef SMEM_SMEM_CHECKPOINT_STAGE_BYTES
+#undef SMEM_SMEM_CHECKPOINT_STRIDE
+#undef SMEM_SMEM_FINAL_TRANS_OFF
+#undef SMEM_SMEM_FINAL_TRANS_STAGE_BYTES
+#undef SMEM_SMEM_FINAL_TRANS_STRIDE
+#undef SMEM_SMEM_GATE_ALL_OFF
+#undef SMEM_SMEM_GATE_ALL_STAGE_BYTES
+#undef SMEM_SMEM_GATE_ALL_STRIDE
+#undef SMEM_SMEM_GATE_BIAS_ALL_OFF
+#undef SMEM_SMEM_GATE_BIAS_ALL_STAGE_BYTES
+#undef SMEM_SMEM_GATE_BIAS_ALL_STRIDE
+#undef SMEM_SMEM_GATE_OFF
+#undef SMEM_SMEM_GATE_RATE_ALL_OFF
+#undef SMEM_SMEM_GATE_RATE_ALL_STAGE_BYTES
+#undef SMEM_SMEM_GATE_RATE_ALL_STRIDE
+#undef SMEM_SMEM_GATE_STAGE_BYTES
+#undef SMEM_SMEM_GATE_STRIDE
+#undef SMEM_SMEM_GT_ALL_OFF
+#undef SMEM_SMEM_GT_ALL_STAGE_BYTES
+#undef SMEM_SMEM_GT_ALL_STRIDE
+#undef SMEM_SMEM_GT_PREFIX_ALL_OFF
+#undef SMEM_SMEM_GT_PREFIX_ALL_STAGE_BYTES
+#undef SMEM_SMEM_GT_PREFIX_ALL_STRIDE
+#undef SMEM_SMEM_G_RAW_ALL_OFF
+#undef SMEM_SMEM_G_RAW_ALL_STAGE_BYTES
+#undef SMEM_SMEM_G_RAW_ALL_STRIDE
+#undef SMEM_SMEM_G_RAW_OFF
+#undef SMEM_SMEM_G_RAW_STAGE_BYTES
+#undef SMEM_SMEM_G_RAW_STRIDE
+#undef SMEM_SMEM_INV_OFF
+#undef SMEM_SMEM_INV_STAGE_BYTES
+#undef SMEM_SMEM_INV_STRIDE
+#undef SMEM_SMEM_INV_WORK_OFF
+#undef SMEM_SMEM_INV_WORK_STAGE_BYTES
+#undef SMEM_SMEM_INV_WORK_STRIDE
+#undef SMEM_SMEM_KD_OFF
+#undef SMEM_SMEM_KD_STAGE_BYTES
+#undef SMEM_SMEM_KD_STRIDE
+#undef SMEM_SMEM_KI_OFF
+#undef SMEM_SMEM_KI_STAGE_BYTES
+#undef SMEM_SMEM_KI_STRIDE
+#undef SMEM_SMEM_KR_TRANS_OFF
+#undef SMEM_SMEM_KR_TRANS_STAGE_BYTES
+#undef SMEM_SMEM_KR_TRANS_STRIDE
+#undef SMEM_SMEM_MQK_TRANS_OFF
+#undef SMEM_SMEM_MQK_TRANS_STAGE_BYTES
+#undef SMEM_SMEM_MQK_TRANS_STRIDE
+#undef SMEM_SMEM_OUT_OFF
+#undef SMEM_SMEM_OUT_STAGE_BYTES
+#undef SMEM_SMEM_OUT_STRIDE
+#undef SMEM_SMEM_PREP_BETA_ALL_OFF
+#undef SMEM_SMEM_PREP_BETA_ALL_STAGE_BYTES
+#undef SMEM_SMEM_PREP_BETA_ALL_STRIDE
+#undef SMEM_SMEM_PREP_BETA_BF16_ALL_OFF
+#undef SMEM_SMEM_PREP_BETA_BF16_ALL_STAGE_BYTES
+#undef SMEM_SMEM_PREP_BETA_BF16_ALL_STRIDE
+#undef SMEM_SMEM_PREP_BETA_U32_ALL_OFF
+#undef SMEM_SMEM_PREP_BETA_U32_ALL_STAGE_BYTES
+#undef SMEM_SMEM_PREP_BETA_U32_ALL_STRIDE
+#undef SMEM_SMEM_QD_OFF
+#undef SMEM_SMEM_QD_STAGE_BYTES
+#undef SMEM_SMEM_QD_STRIDE
+#undef SMEM_SMEM_Q_RAW_PREFETCH_OFF
+#undef SMEM_SMEM_Q_RAW_PREFETCH_STAGE_BYTES
+#undef SMEM_SMEM_Q_RAW_PREFETCH_STRIDE
+#undef SMEM_SMEM_RESTORE_FACTOR_ALL_OFF
+#undef SMEM_SMEM_RESTORE_FACTOR_ALL_STAGE_BYTES
+#undef SMEM_SMEM_RESTORE_FACTOR_ALL_STRIDE
+#undef SMEM_SMEM_SHORT_N32_V_OFF
+#undef SMEM_SMEM_SHORT_N32_V_STAGE_BYTES
+#undef SMEM_SMEM_SHORT_N32_V_STRIDE
+#undef SMEM_SMEM_STATE_CHECKPOINT_NEEDED_OFF
+#undef SMEM_SMEM_STATE_CHECKPOINT_NEEDED_STAGE_BYTES
+#undef SMEM_SMEM_STATE_CHECKPOINT_NEEDED_STRIDE
+#undef SMEM_SMEM_V_ALL_OFF
+#undef SMEM_SMEM_V_ALL_STAGE_BYTES
+#undef SMEM_SMEM_V_ALL_STRIDE
+#undef SMEM_SMEM_V_OFF
+#undef SMEM_SMEM_V_STAGE_BYTES
+#undef SMEM_SMEM_V_STRIDE
+#undef SMEM_SMEM_WORK_ITEM_COMPUTE_START_OFF
+#undef SMEM_SMEM_WORK_ITEM_COMPUTE_START_STAGE_BYTES
+#undef SMEM_SMEM_WORK_ITEM_COMPUTE_START_STRIDE
+#undef SMEM_SMEM_WORK_ITEM_RESOLVED_OFF
+#undef SMEM_SMEM_WORK_ITEM_RESOLVED_STAGE_BYTES
+#undef SMEM_SMEM_WORK_ITEM_RESOLVED_STRIDE
+#undef SMEM_SMEM_WORK_ITEM_WARP_MAX_OFF
+#undef SMEM_SMEM_WORK_ITEM_WARP_MAX_STAGE_BYTES
+#undef SMEM_SMEM_WORK_ITEM_WARP_MAX_STRIDE
+#undef SMEM_TOTAL
+#undef SPLIT_WORK_ITEMS
+#undef STORE_BACKWARD_TAPE
+#undef STORE_E_TAPE
+#undef TMEM_NCOLS
+#undef TMEM_TMEM_OUT_OFFSET
+#undef TMEM_TMEM_STATE_INP_OFFSET
+#undef TMEM_TMEM_STATE_OFFSET
+#undef TMEM_TMEM_STATE_OUT_OFFSET
+#undef TMEM_TMEM_U2_ACC_OFFSET
+#undef TMEM_TMEM_U2_INP_OFFSET
+#undef TMEM_TMEM_U_ACC_OFFSET
+#undef checkpoint_free_addr
+#undef checkpoint_ready_addr
+#undef final_ready_addr
+#undef gate_raw_full_addr
+#undef old_out_ready_addr
+#undef out_empty_addr
+#undef prep_diag_ready_addr
+#undef prep_inv16_ready_addr
+#undef qk_full_addr
+#undef qk_raw_full_addr
+#undef raw_inputs_free_addr
+#undef short_beta_ready_addr
+#undef smem_beta_raw_addr
+#undef smem_beta_raw_all_addr
+#undef smem_checkpoint_addr
+#undef smem_final_trans_addr
+#undef smem_free_addr
+#undef smem_g_raw_addr
+#undef smem_g_raw_all_addr
+#undef smem_gate_addr
+#undef smem_gate_all_addr
+#undef smem_gate_bias_all_addr
+#undef smem_gate_rate_all_addr
+#undef smem_gt_all_addr
+#undef smem_gt_prefix_all_addr
+#undef smem_inv_addr
+#undef smem_inv_work_addr
+#undef smem_kd_addr
+#undef smem_ki_addr
+#undef smem_kr_trans_addr
+#undef smem_mqk_trans_addr
+#undef smem_out_addr
+#undef smem_prep_beta_all_addr
+#undef smem_prep_beta_bf16_all_addr
+#undef smem_prep_beta_u32_all_addr
+#undef smem_q_raw_prefetch_addr
+#undef smem_qd_addr
+#undef smem_restore_factor_all_addr
+#undef smem_short_n32_v_addr
+#undef smem_state_checkpoint_needed_addr
+#undef smem_v_addr
+#undef smem_v_all_addr
+#undef smem_work_item_compute_start_addr
+#undef smem_work_item_resolved_addr
+#undef smem_work_item_warp_max_addr
+#undef state_inp_ready_addr
+#undef tape_free_addr
+#undef tape_ready_addr
+#undef tmem_dealloc_ready_addr
+#undef u2_acc_ready_addr
+#undef u2_inp_ready_addr
+#undef u_inp_ready_addr
+#undef v_free_addr
+#undef v_full_addr
+#undef work_item_ready_addr
+
+#define LOOM_INF CUDART_INF_F
+#define NUM_MAIN_STAGES 1
+#define SMEM_ANY_FALLBACK_OFF 0
+#define SMEM_ANY_FALLBACK_STAGE_BYTES 4
+#define SMEM_ANY_FALLBACK_STRIDE 4
+#define SMEM_TOTAL 128
+#define THREADS 256
+#define C 32
+#define K 128
+#define V 128
+
+extern "C" {
+
+__global__ __launch_bounds__(256) void
+kernel_flashkda_backward_state_checkpoint_fallback_c32(long long* __restrict__ cu_seqlens, long long* __restrict__ cu_chunk_offsets, unsigned int* __restrict__ state_checkpoint_needed, float* __restrict__ initial_state, __nv_bfloat16* __restrict__ tape_kr, float* __restrict__ tape_restore_factor, __nv_bfloat16* __restrict__ tape_r, __nv_bfloat16* __restrict__ chunk_state, int num_sequences, int num_heads, int num_work_items, float lower_bound, int scan_chunk_flags)
+{
+    const int tid = threadIdx.x;
+    const int warp = make_warp_uniform(tid / 32);
+    const int lane = tid % 32;
+
+    extern __shared__ __align__(1024) char smem_raw[];
+    int smem;
+    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+
+    const int bid = blockIdx.x;
+    const int num_bids = gridDim.x;
+
+    // Kernel setup ops
+    unsigned int* any_fallback = reinterpret_cast<unsigned int*>(smem_raw + 0);
+    const int any_fallback_addr = smem + 0;
+
+    // === Task calls (dependency order) ===
+    long long total_chunks = cu_chunk_offsets[num_sequences];
+    int num_tasks = num_sequences * num_heads;
+    long long num_chunk_heads = total_chunks * (long long)num_heads;
+    if (tid == 0) {
+        any_fallback[0] = 0;
+    }
+    asm volatile("barrier.sync 1, 256;" ::: "memory");
+    if (scan_chunk_flags != 0) {
+        #pragma unroll 1
+        for (int scan_work_item = tid; scan_work_item < num_work_items; scan_work_item += 256) {
+            if (state_checkpoint_needed[num_chunk_heads + (long long)scan_work_item] != 0) {
+                atomicAdd(&any_fallback[0], 1);
+            }
+        }
+    } else {
+        #pragma unroll 1
+        for (int scan_task = tid; scan_task < num_tasks; scan_task += 256) {
+            if (state_checkpoint_needed[num_chunk_heads + (long long)scan_task] != 0) {
+                atomicAdd(&any_fallback[0], 1);
+            }
+        }
+    }
+    asm volatile("barrier.sync 2, 256;" ::: "memory");
+    if (any_fallback[0] != 0) {
+        #pragma unroll 1
+        for (int task = 0; task < num_tasks; task++) {
+            int sequence = task / num_heads;
+            int head = task - sequence * num_heads;
+            long long bos = cu_seqlens[sequence];
+            long long eos = cu_seqlens[sequence + 1];
+            int num_chunks = ((int)(eos - bos) + C - 1) / C;
+            unsigned int head_fallback_needed = 0;
+            if (scan_chunk_flags != 0) {
+                #pragma unroll 1
+                for (int scan_chunk = 0; scan_chunk < num_chunks; scan_chunk++) {
+                    long long scan_chunk_global = cu_chunk_offsets[sequence] + (long long)scan_chunk;
+                    if (state_checkpoint_needed[scan_chunk_global * (long long)num_heads + (long long)head] != 0) {
+                        head_fallback_needed = 1;
+                    }
+                }
+            } else {
+                head_fallback_needed = state_checkpoint_needed[num_chunk_heads + (long long)task];
+            }
+            if (head_fallback_needed != 0) {
+                int key_base = lane * 4;
+                long long initial_base = ((long long)sequence * (long long)num_heads + (long long)head) * (long long)V * (long long)K;
+                float _expf_0 = __expf(lower_bound * (float)(C / 2));
+                float common_decay = _expf_0;
+                int warp_id_in_role = (warp - 0);
+                #pragma unroll 1
+                for (int value_row = warp_id_in_role; value_row < V; value_row += 8) {
+                    float state[4];
+                    long long initial_row_base = initial_base + (long long)value_row * (long long)K + (long long)key_base;
+                    {
+                        float4 _v4 = *reinterpret_cast<const float4*>(initial_state + initial_row_base);
+                        state[0 + 0] = _v4.x;
+                        state[0 + 1] = _v4.y;
+                        state[0 + 2] = _v4.z;
+                        state[0 + 3] = _v4.w;
+                    }
+                    #pragma unroll
+                    for (int key_elem = 0; key_elem < 4; key_elem++) {
+                        __nv_bfloat16 _cvt_bf16_0 = __float2bfloat16(state[key_elem]);
+                        float _cvt_f32_0 = __bfloat162float(_cvt_bf16_0);
+                        state[key_elem] = _cvt_f32_0;
+                    }
+                    #pragma unroll 1
+                    for (int local_chunk = 0; local_chunk < num_chunks; local_chunk++) {
+                        long long chunk_global = cu_chunk_offsets[sequence] + (long long)local_chunk;
+                        long long chunk_head = chunk_global * (long long)num_heads + (long long)head;
+                        long long restore_base = chunk_head * (long long)K + (long long)key_base;
+                        float restore_values[4];
+                        {
+                            float4 _v4 = *reinterpret_cast<const float4*>(tape_restore_factor + restore_base);
+                            restore_values[0 + 0] = _v4.x;
+                            restore_values[0 + 1] = _v4.y;
+                            restore_values[0 + 2] = _v4.z;
+                            restore_values[0 + 3] = _v4.w;
+                        }
+                        #pragma unroll
+                        for (int key_elem2 = 0; key_elem2 < 4; key_elem2++) {
+                            state[key_elem2] = state[key_elem2] * (restore_values[key_elem2] * common_decay);
+                        }
+                        long long kr_base = chunk_head * (long long)C * (long long)K + (long long)key_base;
+                        long long r_base = (chunk_head * (long long)V + (long long)value_row) * (long long)C;
+                        #pragma unroll
+                        for (int token_local = 0; token_local < C; token_local++) {
+                            float kr_values[4];
+                            {
+                                uint2 _vld_2;
+                                _vld_2 = *reinterpret_cast<const uint2*>(tape_kr + kr_base + (long long)(token_local * K));
+                                uint32_t* _vpairs_2 = reinterpret_cast<uint32_t*>(&_vld_2);
+                                #pragma unroll
+                                for (int _pair = 0; _pair < 2; _pair++) {
+                                    asm volatile(
+                                        "{\n\t"
+                                        "shl.b32 %0, %2, 16;\n\t"
+                                        "and.b32 %1, %2, 0xffff0000;\n\t"
+                                        "}\n"
+                                        : "=f"((&kr_values[0 + _pair * 2])[0]), "=f"((&kr_values[0 + _pair * 2])[1])
+                                        : "r"(_vpairs_2[_pair]));
+                                }
+                            }
+                            float r_value = (float)tape_r[r_base + (long long)token_local];
+                            #pragma unroll
+                            for (int key_elem3 = 0; key_elem3 < 4; key_elem3++) {
+                                float _fma_0 = __fmaf_rn(r_value, kr_values[key_elem3], state[key_elem3]);
+                                state[key_elem3] = _fma_0;
+                            }
+                        }
+                        if (num_chunks > local_chunk + 1) {
+                            long long next_chunk_global = chunk_global + 1;
+                            long long next_chunk_head = next_chunk_global * (long long)num_heads + (long long)head;
+                            if (state_checkpoint_needed[next_chunk_head] != 0) {
+                                long long checkpoint_base = (next_chunk_head * (long long)V + (long long)value_row) * (long long)K + (long long)key_base;
+                                {
+                                    uint2 _pk2;
+                                    __nv_bfloat162* _pk = reinterpret_cast<__nv_bfloat162*>(&_pk2);
+                                    _pk[0] = __floats2bfloat162_rn(state[0 + 0], state[0 + 1]);
+                                    _pk[1] = __floats2bfloat162_rn(state[0 + 2], state[0 + 3]);
+                                    *reinterpret_cast<uint2*>(&((__nv_bfloat16*)(chunk_state + checkpoint_base))[0]) = _pk2;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+} // extern "C"
+
+#undef C
+#undef K
+#undef LOOM_INF
+#undef NUM_MAIN_STAGES
+#undef SMEM_ANY_FALLBACK_OFF
+#undef SMEM_ANY_FALLBACK_STAGE_BYTES
+#undef SMEM_ANY_FALLBACK_STRIDE
+#undef SMEM_TOTAL
+#undef THREADS
+#undef V
+#undef any_fallback_addr
+
+#define LOOM_INF CUDART_INF_F
+#define TMEM_NCOLS 256
+#define TMEM_TMEM_DH_OFFSET 64
+#define TMEM_TMEM_DH_INP_OFFSET 0
+#define TMEM_TMEM_DO_INITIAL_OFFSET 224
+#define TMEM_TMEM_DO_FINAL_OFFSET 0
+#define TMEM_TMEM_DR_OFFSET 192
+#define TMEM_TMEM_DR_INP_OFFSET 192
+#define TMEM_TMEM_DX_OFFSET 224
+#define TMEM_TMEM_DE_INP_OFFSET 224
+#define NUM_REVERSE_PIPE_STAGES 1
+#define SMEM_SMEM_QD_OFF 1024
+#define SMEM_SMEM_QD_STAGE_BYTES 8192
+#define SMEM_SMEM_QD_STRIDE 8192
+#define SMEM_SMEM_QD_TRANS_OFF 1024
+#define SMEM_SMEM_QD_TRANS_STAGE_BYTES 8192
+#define SMEM_SMEM_QD_TRANS_STRIDE 8192
+#define SMEM_SMEM_KD_OFF 9216
+#define SMEM_SMEM_KD_STAGE_BYTES 8192
+#define SMEM_SMEM_KD_STRIDE 8192
+#define SMEM_SMEM_KD_TRANS_OFF 9216
+#define SMEM_SMEM_KD_TRANS_STAGE_BYTES 8192
+#define SMEM_SMEM_KD_TRANS_STRIDE 8192
+#define SMEM_SMEM_KR_OFF 17408
+#define SMEM_SMEM_KR_STAGE_BYTES 8192
+#define SMEM_SMEM_KR_STRIDE 8192
+#define SMEM_SMEM_KI_OFF 25600
+#define SMEM_SMEM_KI_STAGE_BYTES 8192
+#define SMEM_SMEM_KI_STRIDE 8192
+#define SMEM_SMEM_J_OFF 33792
+#define SMEM_SMEM_J_STAGE_BYTES 2048
+#define SMEM_SMEM_J_STRIDE 2048
+#define SMEM_SMEM_J_TRANS_OFF 33792
+#define SMEM_SMEM_J_TRANS_STAGE_BYTES 2048
+#define SMEM_SMEM_J_TRANS_STRIDE 2048
+#define SMEM_SMEM_N_OFF 35840
+#define SMEM_SMEM_N_STAGE_BYTES 2048
+#define SMEM_SMEM_N_STRIDE 2048
+#define SMEM_SMEM_WORK_ITEM_WARP_MAX_OFF 37888
+#define SMEM_SMEM_WORK_ITEM_WARP_MAX_STAGE_BYTES 16
+#define SMEM_SMEM_WORK_ITEM_WARP_MAX_STRIDE 16
+#define SMEM_SMEM_WORK_ITEM_COMPUTE_END_OFF 37904
+#define SMEM_SMEM_WORK_ITEM_COMPUTE_END_STAGE_BYTES 4
+#define SMEM_SMEM_WORK_ITEM_COMPUTE_END_STRIDE 4
+#define SMEM_SMEM_WORK_ITEM_RESOLVED_OFF 37908
+#define SMEM_SMEM_WORK_ITEM_RESOLVED_STAGE_BYTES 4
+#define SMEM_SMEM_WORK_ITEM_RESOLVED_STRIDE 4
+#define SMEM_TOTAL 38016
+#define THREADS 288
+
+extern "C" {
+
+__global__ __launch_bounds__(288) void
+kernel_flashkda_backward_boundary_c32_tcgen_m64(__nv_bfloat16* __restrict__ do_, float* __restrict__ dfinal_state, float* __restrict__ beta_active, long long* __restrict__ cu_seqlens, long long* __restrict__ cu_chunk_offsets, int* __restrict__ work_items, __nv_bfloat16* __restrict__ tape_qd, __nv_bfloat16* __restrict__ tape_kd, __nv_bfloat16* __restrict__ tape_kr, __nv_bfloat16* __restrict__ tape_j, float* __restrict__ tape_restore_factor, __nv_bfloat16* __restrict__ chunk_dh, __nv_bfloat16* __restrict__ chunk_dr, __nv_bfloat16* __restrict__ chunk_dx, float* __restrict__ dinitial_state, unsigned int* __restrict__ boundary_ready, int num_heads, int publish_ready, float lower_bound)
+{
+    const int tid = threadIdx.x;
+    const int warp = make_warp_uniform(tid / 32);
+    const int lane = tid % 32;
+
+    extern __shared__ __align__(1024) char smem_raw[];
+    int smem;
+    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+
+    const int bid = blockIdx.x;
+    const int num_bids = gridDim.x;
+
+    // Kernel setup ops
+    __nv_bfloat16* smem_qd = reinterpret_cast<__nv_bfloat16*>(smem_raw + 1024);
+    const int smem_qd_addr = smem + 1024;
+    __nv_bfloat16* smem_qd_trans = reinterpret_cast<__nv_bfloat16*>(smem_raw + 1024);
+    const int smem_qd_trans_addr = smem + 1024;
+    __nv_bfloat16* smem_kd = reinterpret_cast<__nv_bfloat16*>(smem_raw + 9216);
+    const int smem_kd_addr = smem + 9216;
+    __nv_bfloat16* smem_kd_trans = reinterpret_cast<__nv_bfloat16*>(smem_raw + 9216);
+    const int smem_kd_trans_addr = smem + 9216;
+    __nv_bfloat16* smem_kr = reinterpret_cast<__nv_bfloat16*>(smem_raw + 17408);
+    const int smem_kr_addr = smem + 17408;
+    __nv_bfloat16* smem_ki = reinterpret_cast<__nv_bfloat16*>(smem_raw + 25600);
+    const int smem_ki_addr = smem + 25600;
+    __nv_bfloat16* smem_j = reinterpret_cast<__nv_bfloat16*>(smem_raw + 33792);
+    const int smem_j_addr = smem + 33792;
+    __nv_bfloat16* smem_j_trans = reinterpret_cast<__nv_bfloat16*>(smem_raw + 33792);
+    const int smem_j_trans_addr = smem + 33792;
+    __nv_bfloat16* smem_n = reinterpret_cast<__nv_bfloat16*>(smem_raw + 35840);
+    const int smem_n_addr = smem + 35840;
+    float* smem_work_item_warp_max = reinterpret_cast<float*>(smem_raw + 37888);
+    const int smem_work_item_warp_max_addr = smem + 37888;
+    int* smem_work_item_compute_end = reinterpret_cast<int*>(smem_raw + 37904);
+    const int smem_work_item_compute_end_addr = smem + 37904;
+    unsigned int* smem_work_item_resolved = reinterpret_cast<unsigned int*>(smem_raw + 37908);
+    const int smem_work_item_resolved_addr = smem + 37908;
+
+    // Mbarrier init (10 groups, 10 barriers)
+    // Mbarriers at smem_raw[0..80)
+
+    if (warp == 0) {
+        uint32_t leader = elect_sync();
+        if (leader) {
+            // --- pipeline 'reverse_pipe' ---
+            // prep_ready: 1 barriers, init_count=1
+            mbarrier_init(smem + 0, 1);
+            // smem_free: 1 barriers, init_count=1
+            mbarrier_init(smem + 8, 1);
+            // inputs_ready: 1 barriers, init_count=4
+            mbarrier_init(smem + 16, 4);
+            // dr_ready: 1 barriers, init_count=1
+            mbarrier_init(smem + 24, 1);
+            // dr_inp_ready: 1 barriers, init_count=4
+            mbarrier_init(smem + 32, 4);
+            // dx_ready: 1 barriers, init_count=1
+            mbarrier_init(smem + 40, 1);
+            // de_inp_ready: 1 barriers, init_count=4
+            mbarrier_init(smem + 48, 4);
+            // dh_ready: 1 barriers, init_count=1
+            mbarrier_init(smem + 56, 1);
+            // compute_done: 1 barriers, init_count=4
+            mbarrier_init(smem + 64, 4);
+            // work_item_ready: 1 barriers, init_count=1
+            mbarrier_init(smem + 72, 1);
+            asm volatile("fence.mbarrier_init.release.cluster;");
+        }
+    }
+
+    __syncwarp();
+
+    // TMEM alloc (256 columns, 256 used)
+    volatile int* tmem_addr_storage = (volatile int*)(smem_raw + 80);
+    if (warp == 0) {
+        int _tmem_hold = smem + 80;
+        asm volatile("tcgen05.alloc.cta_group::1.sync.aligned.shared::cta.b32 [%0], %1;" :: "r"(_tmem_hold), "r"(256) : "memory");
+        asm volatile("tcgen05.relinquish_alloc_permit.cta_group::1.sync.aligned;");
+    }
+
+    __syncthreads();
+    asm volatile("tcgen05.fence::after_thread_sync;");
+
+    const int mbar_base = smem;
+    #define prep_ready_addr (mbar_base + 0)
+    #define smem_free_addr (mbar_base + 8)
+    #define inputs_ready_addr (mbar_base + 16)
+    #define dr_ready_addr (mbar_base + 24)
+    #define dr_inp_ready_addr (mbar_base + 32)
+    #define dx_ready_addr (mbar_base + 40)
+    #define de_inp_ready_addr (mbar_base + 48)
+    #define dh_ready_addr (mbar_base + 56)
+    #define compute_done_addr (mbar_base + 64)
+    #define work_item_ready_addr (mbar_base + 72)
+    const int taddr = tmem_addr_storage[0];
+
+    // Kernel post-init ops
+    const int tmem_tmem_dh = taddr + 64;
+    const int tmem_tmem_dh_inp = taddr;
+    const int tmem_tmem_do_initial = taddr + 224;
+    const int tmem_tmem_do_final = taddr;
+    const int tmem_tmem_dr = taddr + 192;
+    const int tmem_tmem_dr_inp = taddr + 192;
+    const int tmem_tmem_dx = taddr + 224;
+    const int tmem_tmem_de_inp = taddr + 224;
+
+    // ---- Register redistribution for WGs split across roles ----
+    // Dec phase frees registers before any WG attempts inc.
+    if (warp >= 8 && warp <= 11) {
+        asm volatile("setmaxnreg.dec.sync.aligned.u32 112;");
+    }
+
+    // ---- Role: compute ----
+    if (warp <= 3) {
+        asm volatile("setmaxnreg.inc.sync.aligned.u32 224;");
+        { // compute_main
+            int split_task_idx = blockIdx.x;
+            int task_idx = split_task_idx / 2;
+            int value_split_idx = split_task_idx % 2;
+            int value_row_offset = value_split_idx * 64;
+            int item_base = task_idx * 5;
+            int seq_idx = work_items[item_base];
+            int head_idx = work_items[item_base + 1];
+            int write_start = work_items[item_base + 2];
+            int write_end = work_items[item_base + 3];
+            long long bos = cu_seqlens[seq_idx];
+            long long eos = cu_seqlens[seq_idx + 1];
+            int seq_len = (int)(eos - bos);
+            int num_chunks = (seq_len + 32 - 1) / 32;
+            int compute_end = num_chunks;
+            int warp_in_wg = warp % 4;
+            int scan_dim = warp_in_wg * 32 + lane;
+            if (scan_dim == 0) {
+                smem_work_item_compute_end[0] = num_chunks;
+                smem_work_item_resolved[0] = 0;
+            }
+            asm volatile("barrier.sync 10, 128;" ::: "memory");
+            float suffix_log2 = 0.0f;
+            int _min_0 = ((num_chunks - write_end) < (32) ? (num_chunks - write_end) : (32));
+            int suffix_limit = _min_0;
+            float common_log2 = lower_bound * 1.4426950408889634f * 16.0f;
+            #pragma unroll 1
+            for (int suffix_chunks = 1; suffix_chunks < suffix_limit + 1; suffix_chunks++) {
+                if (smem_work_item_resolved[0] == 0) {
+                    int suffix_chunk = write_end + suffix_chunks - 1;
+                    long long suffix_global = cu_chunk_offsets[seq_idx] + (long long)suffix_chunk;
+                    float suffix_restore = tape_restore_factor[(suffix_global * (long long)num_heads + (long long)head_idx) * 128 + (long long)scan_dim];
+                    float _log2_0;
+                    asm volatile("lg2.approx.ftz.f32 %0, %1;" : "=f"(_log2_0) : "f"(suffix_restore));
+                    suffix_log2 += _log2_0 + common_log2;
+                    float _warp_reduce_0 = suffix_log2;
+                    #pragma unroll
+                    for (int offset = 16; offset > 0; offset >>= 1)
+                        _warp_reduce_0 = max_noftz(_warp_reduce_0, __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset));
+                    float suffix_warp_max = _warp_reduce_0;
+                    if (lane == 0) {
+                        smem_work_item_warp_max[warp_in_wg] = suffix_warp_max;
+                    }
+                    asm volatile("barrier.sync 10, 128;" ::: "memory");
+                    float suffix_block_max = ((lane < 4) ? smem_work_item_warp_max[lane] : -LOOM_INF);
+                    float _warp_reduce_1 = suffix_block_max;
+                    #pragma unroll
+                    for (int offset = 16; offset > 0; offset >>= 1)
+                        _warp_reduce_1 = max_noftz(_warp_reduce_1, __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_1, offset));
+                    suffix_block_max = _warp_reduce_1;
+                    if (scan_dim == 0 && suffix_block_max <= -30.0f) {
+                        smem_work_item_compute_end[0] = suffix_chunk + 1;
+                        smem_work_item_resolved[0] = 1;
+                    }
+                    asm volatile("barrier.sync 10, 128;" ::: "memory");
+                }
+            }
+            compute_end = smem_work_item_compute_end[0];
+            if (warp_in_wg == 0) {
+                if (elect_sync()) {
+                    mbarrier_arrive(work_item_ready_addr);
+                }
+            }
+            int scan_chunks = compute_end - write_start;
+            int lane_quad = lane & 3;
+            int local_row_top = warp_in_wg * 16 + lane / 4;
+            int local_row_bot = local_row_top + 8;
+            int state_row_top = value_row_offset + local_row_top;
+            int state_row_bot = value_row_offset + local_row_bot;
+            const int tmem_row_base = warp_in_wg * 32 << 16;
+            long long state_head_base = ((long long)seq_idx * (long long)num_heads + (long long)head_idx) * 128 * 128;
+            long long state_base_top = state_head_base + (long long)state_row_top * 128;
+            long long state_base_bot = state_head_base + (long long)state_row_bot * 128;
+            #pragma unroll
+            for (int state_col_half = 0; state_col_half < 2; state_col_half++) {
+                float state_values[32];
+                #pragma unroll
+                for (int state_col_group = 0; state_col_group < 8; state_col_group++) {
+                    int state_col_pair = state_col_half * 64 + state_col_group * 8 + lane_quad * 2;
+                    const int state_reg_base = state_col_group * 4;
+                    if (compute_end == num_chunks) {
+                        state_values[state_reg_base] = dfinal_state[state_base_top + (long long)state_col_pair];
+                        state_values[state_reg_base + 1] = dfinal_state[state_base_top + (long long)state_col_pair + 1];
+                        state_values[state_reg_base + 2] = dfinal_state[state_base_bot + (long long)state_col_pair];
+                        state_values[state_reg_base + 3] = dfinal_state[state_base_bot + (long long)state_col_pair + 1];
+                    } else {
+                        state_values[state_reg_base] = 0.0f;
+                        state_values[state_reg_base + 1] = 0.0f;
+                        state_values[state_reg_base + 2] = 0.0f;
+                        state_values[state_reg_base + 3] = 0.0f;
+                    }
+                }
+                asm volatile(
+                    "tcgen05.st.sync.aligned.16x256b.x8.b32"
+                    " [%0], {%1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15, %16, %17, %18, %19, %20, %21, %22, %23, %24, %25, %26, %27, %28, %29, %30, %31, %32};"
+                    :: "r"(taddr + 64 + (unsigned int)tmem_row_base + (unsigned int)(state_col_half * 64)), "r"(*reinterpret_cast<const uint32_t*>(&state_values[0])), "r"(*reinterpret_cast<const uint32_t*>(&state_values[1])), "r"(*reinterpret_cast<const uint32_t*>(&state_values[2])), "r"(*reinterpret_cast<const uint32_t*>(&state_values[3])), "r"(*reinterpret_cast<const uint32_t*>(&state_values[4])), "r"(*reinterpret_cast<const uint32_t*>(&state_values[5])), "r"(*reinterpret_cast<const uint32_t*>(&state_values[6])), "r"(*reinterpret_cast<const uint32_t*>(&state_values[7])), "r"(*reinterpret_cast<const uint32_t*>(&state_values[8])), "r"(*reinterpret_cast<const uint32_t*>(&state_values[9])), "r"(*reinterpret_cast<const uint32_t*>(&state_values[10])), "r"(*reinterpret_cast<const uint32_t*>(&state_values[11])), "r"(*reinterpret_cast<const uint32_t*>(&state_values[12])), "r"(*reinterpret_cast<const uint32_t*>(&state_values[13])), "r"(*reinterpret_cast<const uint32_t*>(&state_values[14])), "r"(*reinterpret_cast<const uint32_t*>(&state_values[15])), "r"(*reinterpret_cast<const uint32_t*>(&state_values[16])), "r"(*reinterpret_cast<const uint32_t*>(&state_values[17])), "r"(*reinterpret_cast<const uint32_t*>(&state_values[18])), "r"(*reinterpret_cast<const uint32_t*>(&state_values[19])), "r"(*reinterpret_cast<const uint32_t*>(&state_values[20])), "r"(*reinterpret_cast<const uint32_t*>(&state_values[21])), "r"(*reinterpret_cast<const uint32_t*>(&state_values[22])), "r"(*reinterpret_cast<const uint32_t*>(&state_values[23])), "r"(*reinterpret_cast<const uint32_t*>(&state_values[24])), "r"(*reinterpret_cast<const uint32_t*>(&state_values[25])), "r"(*reinterpret_cast<const uint32_t*>(&state_values[26])), "r"(*reinterpret_cast<const uint32_t*>(&state_values[27])), "r"(*reinterpret_cast<const uint32_t*>(&state_values[28])), "r"(*reinterpret_cast<const uint32_t*>(&state_values[29])), "r"(*reinterpret_cast<const uint32_t*>(&state_values[30])), "r"(*reinterpret_cast<const uint32_t*>(&state_values[31])));
+            }
+            asm volatile("tcgen05.wait::st.sync.aligned;" ::: "memory");
+            unsigned int compute_stage = 0;
+            float _exp2_0 = approx_exp2(lower_bound * 1.4426950408889634f * 16.0f);
+            float common_factor = _exp2_0;
+            unsigned int _phase_prep_ready = 0;
+            unsigned int _phase_dr_ready = 0;
+            unsigned int _phase_dx_ready = 0;
+            unsigned int _phase_dh_ready = 0;
+            #pragma unroll 1
+            for (int reverse_chunk = 0; reverse_chunk < scan_chunks; reverse_chunk++) {
+                mbarrier_wait(prep_ready_addr + (compute_stage) * 8, _phase_prep_ready);
+                int chunk_idx = compute_end - 1 - reverse_chunk;
+                int owned_chunk = (int)(chunk_idx < write_end);
+                long long chunk_global = cu_chunk_offsets[seq_idx] + (long long)chunk_idx;
+                long long chunk_start = bos + (long long)chunk_idx * 32;
+                float do_values[16];
+                do_values[0] = 0.0f;
+                do_values[1] = 0.0f;
+                do_values[2] = 0.0f;
+                do_values[3] = 0.0f;
+                do_values[4] = 0.0f;
+                do_values[5] = 0.0f;
+                do_values[6] = 0.0f;
+                do_values[7] = 0.0f;
+                do_values[8] = 0.0f;
+                do_values[9] = 0.0f;
+                do_values[10] = 0.0f;
+                do_values[11] = 0.0f;
+                do_values[12] = 0.0f;
+                do_values[13] = 0.0f;
+                do_values[14] = 0.0f;
+                do_values[15] = 0.0f;
+                #pragma unroll
+                for (int token_group = 0; token_group < 4; token_group++) {
+                    int token_pair = token_group * 8 + lane_quad * 2;
+                    const int token_reg_base = token_group * 4;
+                    long long token0 = chunk_start + (long long)token_pair;
+                    long long token1 = token0 + 1;
+                    if (token0 < eos) {
+                        long long token_head0 = (token0 * (long long)num_heads + (long long)head_idx) * 128;
+                        do_values[token_reg_base] = (float)do_[token_head0 + (long long)state_row_top];
+                        do_values[token_reg_base + 2] = (float)do_[token_head0 + (long long)state_row_bot];
+                    }
+                    if (token1 < eos) {
+                        long long token_head1 = (token1 * (long long)num_heads + (long long)head_idx) * 128;
+                        do_values[token_reg_base + 1] = (float)do_[token_head1 + (long long)state_row_top];
+                        do_values[token_reg_base + 3] = (float)do_[token_head1 + (long long)state_row_bot];
+                    }
+                }
+                uint32_t do_values_bf16[8];
+                #pragma unroll
+                for (int _lp = 0; _lp < 8; _lp++) {
+                    __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(do_values[_lp*2 + 0], do_values[_lp*2+1 + 0]));
+                    do_values_bf16[_lp] = *(uint32_t*)&_bf2;
+                }
+                asm volatile(
+                    "tcgen05.st.sync.aligned.16x128b.x4.b32"
+                    " [%0], {%1, %2, %3, %4, %5, %6, %7, %8};"
+                    :: "r"(taddr + 224 + (unsigned int)tmem_row_base), "r"(*reinterpret_cast<const uint32_t*>(&do_values_bf16[0])), "r"(*reinterpret_cast<const uint32_t*>(&do_values_bf16[1])), "r"(*reinterpret_cast<const uint32_t*>(&do_values_bf16[2])), "r"(*reinterpret_cast<const uint32_t*>(&do_values_bf16[3])), "r"(*reinterpret_cast<const uint32_t*>(&do_values_bf16[4])), "r"(*reinterpret_cast<const uint32_t*>(&do_values_bf16[5])), "r"(*reinterpret_cast<const uint32_t*>(&do_values_bf16[6])), "r"(*reinterpret_cast<const uint32_t*>(&do_values_bf16[7])));
+                long long chunk_state_head_base = (chunk_global * (long long)num_heads + (long long)head_idx) * 128 * 128;
+                long long chunk_dh_base_top = chunk_state_head_base + (long long)state_row_top * 128;
+                long long chunk_dh_base_bot = chunk_state_head_base + (long long)state_row_bot * 128;
+                long long restore_base = (chunk_global * (long long)num_heads + (long long)head_idx) * 128;
+                #pragma unroll
+                for (int state_col_half2 = 0; state_col_half2 < 2; state_col_half2++) {
+                    float _tmem_load_0[32];
+                    asm volatile(
+                        "tcgen05.ld.sync.aligned.16x256b.x8.b32"
+                        " {%0, %1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15, %16, %17, %18, %19, %20, %21, %22, %23, %24, %25, %26, %27, %28, %29, %30, %31}, [%32];"
+                        : "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_0[0])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_0[1])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_0[2])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_0[3])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_0[4])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_0[5])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_0[6])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_0[7])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_0[8])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_0[9])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_0[10])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_0[11])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_0[12])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_0[13])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_0[14])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_0[15])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_0[16])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_0[17])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_0[18])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_0[19])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_0[20])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_0[21])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_0[22])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_0[23])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_0[24])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_0[25])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_0[26])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_0[27])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_0[28])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_0[29])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_0[30])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_0[31]))
+                        : "r"(taddr + 64 + (unsigned int)tmem_row_base + (unsigned int)(state_col_half2 * 64)));
+                    asm volatile("tcgen05.wait::ld.sync.aligned;");
+                    #pragma unroll
+                    for (int state_col_group2 = 0; state_col_group2 < 8; state_col_group2++) {
+                        int state_col_pair2 = state_col_half2 * 64 + state_col_group2 * 8 + lane_quad * 2;
+                        const int state_reg_base2 = state_col_group2 * 4;
+                        if (owned_chunk != 0) {
+                            chunk_dh[chunk_dh_base_top + (long long)state_col_pair2] = _tmem_load_0[state_reg_base2];
+                            chunk_dh[chunk_dh_base_top + (long long)state_col_pair2 + 1] = _tmem_load_0[state_reg_base2 + 1];
+                            chunk_dh[chunk_dh_base_bot + (long long)state_col_pair2] = _tmem_load_0[state_reg_base2 + 2];
+                            chunk_dh[chunk_dh_base_bot + (long long)state_col_pair2 + 1] = _tmem_load_0[state_reg_base2 + 3];
+                        }
+                    }
+                    uint32_t _tmem_load_0_bf16[16];
+                    #pragma unroll
+                    for (int _lp = 0; _lp < 16; _lp++) {
+                        __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(_tmem_load_0[_lp*2 + 0], _tmem_load_0[_lp*2+1 + 0]));
+                        _tmem_load_0_bf16[_lp] = *(uint32_t*)&_bf2;
+                    }
+                    asm volatile(
+                        "tcgen05.st.sync.aligned.16x128b.x8.b32"
+                        " [%0], {%1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15, %16};"
+                        :: "r"(taddr + (unsigned int)tmem_row_base + (unsigned int)(state_col_half2 * 32)), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0_bf16[0])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0_bf16[1])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0_bf16[2])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0_bf16[3])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0_bf16[4])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0_bf16[5])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0_bf16[6])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0_bf16[7])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0_bf16[8])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0_bf16[9])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0_bf16[10])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0_bf16[11])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0_bf16[12])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0_bf16[13])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0_bf16[14])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0_bf16[15])));
+                    #pragma unroll
+                    for (int restore_group = 0; restore_group < 8; restore_group++) {
+                        int restore_col_pair = state_col_half2 * 64 + restore_group * 8 + lane_quad * 2;
+                        const int restore_reg_base = restore_group * 4;
+                        float restore0 = tape_restore_factor[restore_base + (long long)restore_col_pair];
+                        float restore1 = tape_restore_factor[restore_base + (long long)restore_col_pair + 1];
+                        _tmem_load_0[restore_reg_base] = _tmem_load_0[restore_reg_base] * restore0;
+                        _tmem_load_0[restore_reg_base + 1] = _tmem_load_0[restore_reg_base + 1] * restore1;
+                        _tmem_load_0[restore_reg_base + 2] = _tmem_load_0[restore_reg_base + 2] * restore0;
+                        _tmem_load_0[restore_reg_base + 3] = _tmem_load_0[restore_reg_base + 3] * restore1;
+                    }
+                    asm volatile(
+                        "tcgen05.st.sync.aligned.16x256b.x8.b32"
+                        " [%0], {%1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15, %16, %17, %18, %19, %20, %21, %22, %23, %24, %25, %26, %27, %28, %29, %30, %31, %32};"
+                        :: "r"(taddr + 64 + (unsigned int)tmem_row_base + (unsigned int)(state_col_half2 * 64)), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0[0])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0[1])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0[2])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0[3])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0[4])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0[5])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0[6])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0[7])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0[8])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0[9])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0[10])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0[11])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0[12])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0[13])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0[14])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0[15])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0[16])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0[17])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0[18])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0[19])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0[20])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0[21])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0[22])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0[23])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0[24])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0[25])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0[26])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0[27])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0[28])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0[29])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0[30])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0[31])));
+                }
+                asm volatile("tcgen05.wait::st.sync.aligned;" ::: "memory");
+                if (elect_sync()) {
+                    mbarrier_arrive(inputs_ready_addr + (compute_stage) * 8);
+                }
+                mbarrier_wait(dr_ready_addr + (compute_stage) * 8, _phase_dr_ready);
+                float _tmem_load_1[16];
+                asm volatile(
+                    "tcgen05.ld.sync.aligned.16x256b.x4.b32"
+                    " {%0, %1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15}, [%16];"
+                    : "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_1[0])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_1[1])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_1[2])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_1[3])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_1[4])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_1[5])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_1[6])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_1[7])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_1[8])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_1[9])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_1[10])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_1[11])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_1[12])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_1[13])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_1[14])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_1[15]))
+                    : "r"(taddr + 192 + (unsigned int)tmem_row_base));
+                asm volatile("tcgen05.wait::ld.sync.aligned;");
+                long long chunk_value_head_base = (chunk_global * (long long)num_heads + (long long)head_idx) * 128 * 32;
+                long long dr_tape_base_top = chunk_value_head_base + (long long)state_row_top * 32;
+                long long dr_tape_base_bot = chunk_value_head_base + (long long)state_row_bot * 32;
+                #pragma unroll
+                for (int dr_group = 0; dr_group < 4; dr_group++) {
+                    int dr_col_pair = dr_group * 8 + lane_quad * 2;
+                    const int dr_reg_base = dr_group * 4;
+                    if (owned_chunk != 0) {
+                        chunk_dr[dr_tape_base_top + (long long)dr_col_pair] = _tmem_load_1[dr_reg_base];
+                        chunk_dr[dr_tape_base_top + (long long)dr_col_pair + 1] = _tmem_load_1[dr_reg_base + 1];
+                        chunk_dr[dr_tape_base_bot + (long long)dr_col_pair] = _tmem_load_1[dr_reg_base + 2];
+                        chunk_dr[dr_tape_base_bot + (long long)dr_col_pair + 1] = _tmem_load_1[dr_reg_base + 3];
+                    }
+                }
+                uint32_t _tmem_load_1_bf16[8];
+                #pragma unroll
+                for (int _lp = 0; _lp < 8; _lp++) {
+                    __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(_tmem_load_1[_lp*2 + 0], _tmem_load_1[_lp*2+1 + 0]));
+                    _tmem_load_1_bf16[_lp] = *(uint32_t*)&_bf2;
+                }
+                asm volatile(
+                    "tcgen05.st.sync.aligned.16x128b.x4.b32"
+                    " [%0], {%1, %2, %3, %4, %5, %6, %7, %8};"
+                    :: "r"(taddr + 192 + (unsigned int)tmem_row_base), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_1_bf16[0])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_1_bf16[1])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_1_bf16[2])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_1_bf16[3])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_1_bf16[4])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_1_bf16[5])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_1_bf16[6])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_1_bf16[7])));
+                asm volatile(
+                    "tcgen05.st.sync.aligned.16x128b.x4.b32"
+                    " [%0], {%1, %2, %3, %4, %5, %6, %7, %8};"
+                    :: "r"(taddr + (unsigned int)tmem_row_base), "r"(*reinterpret_cast<const uint32_t*>(&do_values_bf16[0])), "r"(*reinterpret_cast<const uint32_t*>(&do_values_bf16[1])), "r"(*reinterpret_cast<const uint32_t*>(&do_values_bf16[2])), "r"(*reinterpret_cast<const uint32_t*>(&do_values_bf16[3])), "r"(*reinterpret_cast<const uint32_t*>(&do_values_bf16[4])), "r"(*reinterpret_cast<const uint32_t*>(&do_values_bf16[5])), "r"(*reinterpret_cast<const uint32_t*>(&do_values_bf16[6])), "r"(*reinterpret_cast<const uint32_t*>(&do_values_bf16[7])));
+                asm volatile("tcgen05.wait::st.sync.aligned;" ::: "memory");
+                if (elect_sync()) {
+                    mbarrier_arrive(dr_inp_ready_addr + (compute_stage) * 8);
+                }
+                mbarrier_wait(dx_ready_addr + (compute_stage) * 8, _phase_dx_ready);
+                float _tmem_load_2[16];
+                asm volatile(
+                    "tcgen05.ld.sync.aligned.16x256b.x4.b32"
+                    " {%0, %1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15}, [%16];"
+                    : "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_2[0])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_2[1])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_2[2])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_2[3])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_2[4])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_2[5])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_2[6])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_2[7])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_2[8])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_2[9])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_2[10])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_2[11])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_2[12])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_2[13])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_2[14])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_2[15]))
+                    : "r"(taddr + 224 + (unsigned int)tmem_row_base));
+                asm volatile("tcgen05.wait::ld.sync.aligned;");
+                #pragma unroll
+                for (int dx_group = 0; dx_group < 4; dx_group++) {
+                    int dx_col_pair = dx_group * 8 + lane_quad * 2;
+                    const int dx_reg_base = dx_group * 4;
+                    if (owned_chunk != 0) {
+                        chunk_dx[dr_tape_base_top + (long long)dx_col_pair] = _tmem_load_2[dx_reg_base];
+                        chunk_dx[dr_tape_base_top + (long long)dx_col_pair + 1] = _tmem_load_2[dx_reg_base + 1];
+                        chunk_dx[dr_tape_base_bot + (long long)dx_col_pair] = _tmem_load_2[dx_reg_base + 2];
+                        chunk_dx[dr_tape_base_bot + (long long)dx_col_pair + 1] = _tmem_load_2[dx_reg_base + 3];
+                    }
+                    float beta0 = 0.0f;
+                    float beta1 = 0.0f;
+                    long long beta_token0 = chunk_start + (long long)dx_col_pair;
+                    long long beta_token1 = beta_token0 + 1;
+                    if (beta_token0 < eos) {
+                        beta0 = beta_active[beta_token0 * (long long)num_heads + (long long)head_idx];
+                    }
+                    if (beta_token1 < eos) {
+                        beta1 = beta_active[beta_token1 * (long long)num_heads + (long long)head_idx];
+                    }
+                    _tmem_load_2[dx_reg_base] = _tmem_load_2[dx_reg_base] * (-beta0);
+                    _tmem_load_2[dx_reg_base + 1] = _tmem_load_2[dx_reg_base + 1] * (-beta1);
+                    _tmem_load_2[dx_reg_base + 2] = _tmem_load_2[dx_reg_base + 2] * (-beta0);
+                    _tmem_load_2[dx_reg_base + 3] = _tmem_load_2[dx_reg_base + 3] * (-beta1);
+                }
+                uint32_t _tmem_load_2_bf16[8];
+                #pragma unroll
+                for (int _lp = 0; _lp < 8; _lp++) {
+                    __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(_tmem_load_2[_lp*2 + 0], _tmem_load_2[_lp*2+1 + 0]));
+                    _tmem_load_2_bf16[_lp] = *(uint32_t*)&_bf2;
+                }
+                asm volatile(
+                    "tcgen05.st.sync.aligned.16x128b.x4.b32"
+                    " [%0], {%1, %2, %3, %4, %5, %6, %7, %8};"
+                    :: "r"(taddr + 224 + (unsigned int)tmem_row_base), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_2_bf16[0])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_2_bf16[1])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_2_bf16[2])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_2_bf16[3])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_2_bf16[4])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_2_bf16[5])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_2_bf16[6])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_2_bf16[7])));
+                asm volatile("tcgen05.wait::st.sync.aligned;" ::: "memory");
+                if (elect_sync()) {
+                    mbarrier_arrive(de_inp_ready_addr + (compute_stage) * 8);
+                }
+                if (publish_ready != 0 && owned_chunk != 0) {
+                    __threadfence();
+                    asm volatile("barrier.sync 9, 128;" ::: "memory");
+                    if (warp == 0) {
+                        if (elect_sync()) {
+                            {
+                                unsigned int* _gc_p = reinterpret_cast<unsigned int*>(boundary_ready) + (chunk_global * (long long)num_heads + (long long)head_idx);
+                                unsigned int _gc_old;
+                                asm volatile("atom.release.gpu.global.add.u32 %0, [%1], 1;" : "=r"(_gc_old) : "l"(_gc_p) : "memory");
+                            }
+                        }
+                    }
+                }
+                mbarrier_wait(dh_ready_addr + (compute_stage) * 8, _phase_dh_ready);
+                #pragma unroll
+                for (int state_col_half3 = 0; state_col_half3 < 2; state_col_half3++) {
+                    float _tmem_load_3[32];
+                    asm volatile(
+                        "tcgen05.ld.sync.aligned.16x256b.x8.b32"
+                        " {%0, %1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15, %16, %17, %18, %19, %20, %21, %22, %23, %24, %25, %26, %27, %28, %29, %30, %31}, [%32];"
+                        : "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[0])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[1])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[2])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[3])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[4])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[5])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[6])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[7])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[8])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[9])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[10])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[11])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[12])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[13])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[14])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[15])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[16])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[17])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[18])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[19])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[20])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[21])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[22])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[23])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[24])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[25])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[26])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[27])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[28])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[29])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[30])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_3[31]))
+                        : "r"(taddr + 64 + (unsigned int)tmem_row_base + (unsigned int)(state_col_half3 * 64)));
+                    asm volatile("tcgen05.wait::ld.sync.aligned;");
+                    const float2 _scale2_0 = {common_factor, common_factor};
+                    #pragma unroll
+                    for (int _ls = 0; _ls < 16; _ls++)
+                        mul_f32x2_inplace(&reinterpret_cast<float2*>(_tmem_load_3)[_ls], _scale2_0);
+                    asm volatile(
+                        "tcgen05.st.sync.aligned.16x256b.x8.b32"
+                        " [%0], {%1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15, %16, %17, %18, %19, %20, %21, %22, %23, %24, %25, %26, %27, %28, %29, %30, %31, %32};"
+                        :: "r"(taddr + 64 + (unsigned int)tmem_row_base + (unsigned int)(state_col_half3 * 64)), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_3[0])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_3[1])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_3[2])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_3[3])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_3[4])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_3[5])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_3[6])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_3[7])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_3[8])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_3[9])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_3[10])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_3[11])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_3[12])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_3[13])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_3[14])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_3[15])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_3[16])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_3[17])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_3[18])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_3[19])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_3[20])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_3[21])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_3[22])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_3[23])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_3[24])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_3[25])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_3[26])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_3[27])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_3[28])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_3[29])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_3[30])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_3[31])));
+                }
+                asm volatile("tcgen05.wait::st.sync.aligned;" ::: "memory");
+                compute_stage += 1;
+                if (compute_stage == 1) { compute_stage = 0; _phase_prep_ready ^= 1; _phase_dr_ready ^= 1; _phase_dx_ready ^= 1; _phase_dh_ready ^= 1; }
+            }
+            if (write_start == 0) {
+                #pragma unroll
+                for (int final_half = 0; final_half < 2; final_half++) {
+                    float _tmem_load_4[32];
+                    asm volatile(
+                        "tcgen05.ld.sync.aligned.16x256b.x8.b32"
+                        " {%0, %1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15, %16, %17, %18, %19, %20, %21, %22, %23, %24, %25, %26, %27, %28, %29, %30, %31}, [%32];"
+                        : "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_4[0])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_4[1])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_4[2])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_4[3])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_4[4])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_4[5])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_4[6])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_4[7])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_4[8])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_4[9])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_4[10])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_4[11])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_4[12])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_4[13])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_4[14])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_4[15])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_4[16])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_4[17])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_4[18])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_4[19])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_4[20])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_4[21])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_4[22])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_4[23])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_4[24])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_4[25])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_4[26])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_4[27])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_4[28])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_4[29])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_4[30])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_4[31]))
+                        : "r"(taddr + 64 + (unsigned int)tmem_row_base + (unsigned int)(final_half * 64)));
+                    asm volatile("tcgen05.wait::ld.sync.aligned;");
+                    #pragma unroll
+                    for (int final_group = 0; final_group < 8; final_group++) {
+                        int final_col_pair = final_half * 64 + final_group * 8 + lane_quad * 2;
+                        const int final_reg_base = final_group * 4;
+                        dinitial_state[state_base_top + (long long)final_col_pair] = _tmem_load_4[final_reg_base];
+                        dinitial_state[state_base_top + (long long)final_col_pair + 1] = _tmem_load_4[final_reg_base + 1];
+                        dinitial_state[state_base_bot + (long long)final_col_pair] = _tmem_load_4[final_reg_base + 2];
+                        dinitial_state[state_base_bot + (long long)final_col_pair + 1] = _tmem_load_4[final_reg_base + 3];
+                    }
+                }
+            }
+            if (elect_sync()) {
+                mbarrier_arrive(compute_done_addr);
+            }
+        }
+    }
+    // ---- Role: prep ----
+    if (warp >= 4 && warp <= 7) {
+        asm volatile("setmaxnreg.dec.sync.aligned.u32 112;");
+        { // prep_main
+            int split_task_idx_1 = blockIdx.x;
+            int task_idx_1 = split_task_idx_1 / 2;
+            int item_base_1 = task_idx_1 * 5;
+            int seq_idx_1 = work_items[item_base_1];
+            int head_idx_1 = work_items[item_base_1 + 1];
+            int write_start_1 = work_items[item_base_1 + 2];
+            unsigned int _phase_work_item_ready_0 = 0;
+            mbarrier_wait(work_item_ready_addr, _phase_work_item_ready_0);
+            _phase_work_item_ready_0 ^= 1;
+            int compute_end_1 = smem_work_item_compute_end[0];
+            long long bos_1 = cu_seqlens[seq_idx_1];
+            long long eos_1 = cu_seqlens[seq_idx_1 + 1];
+            int seq_len_1 = (int)(eos_1 - bos_1);
+            int scan_chunks_1 = compute_end_1 - write_start_1;
+            int warp_id_in_role = (warp - 4);
+            int prep_tid = warp_id_in_role * 32 + lane;
+            int prep_local_warp = warp_id_in_role;
+            unsigned int prep_stage = 0;
+            unsigned int _phase_smem_free = 1;
+            #pragma unroll 1
+            for (int reverse_chunk_1 = 0; reverse_chunk_1 < scan_chunks_1; reverse_chunk_1++) {
+                mbarrier_wait(smem_free_addr + (prep_stage) * 8, _phase_smem_free);
+                int chunk_idx_1 = compute_end_1 - 1 - reverse_chunk_1;
+                long long chunk_global_1 = cu_chunk_offsets[seq_idx_1] + (long long)chunk_idx_1;
+                long long tape_vec_base = (chunk_global_1 * (long long)num_heads + (long long)head_idx_1) * 32 * 128;
+                long long restore_base_1 = (chunk_global_1 * (long long)num_heads + (long long)head_idx_1) * 128;
+                #pragma unroll
+                for (int load_pass = 0; load_pass < 4; load_pass++) {
+                    int item = load_pass * 128 + prep_tid;
+                    int row = item / 16;
+                    int segment = item % 16;
+                    long long index = tape_vec_base + (long long)row * 128 + (long long)(segment * 8);
+                    float qd_values[8];
+                    float kd_values[8];
+                    float kr_values[8];
+                    float ki_values[8];
+                    {
+                        const uint4* _vptr_0 = reinterpret_cast<const uint4*>(tape_qd + index);
+                        uint4 _vld_0[1];
+                        #pragma unroll
+                        for (int _blk = 0; _blk < 1; _blk++) {
+                            _vld_0[_blk] = _vptr_0[_blk];
+                            uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
+                            #pragma unroll
+                            for (int _pair = 0; _pair < 4; _pair++) {
+                                asm volatile(
+                                    "{\n\t"
+                                    "shl.b32 %0, %2, 16;\n\t"
+                                    "and.b32 %1, %2, 0xffff0000;\n\t"
+                                    "}\n"
+                                    : "=f"((&qd_values[0 + _blk * 8 + _pair * 2])[0]), "=f"((&qd_values[0 + _blk * 8 + _pair * 2])[1])
+                                    : "r"(_vpairs_0[_pair]));
+                            }
+                        }
+                    }
+                    {
+                        const uint4* _vptr_1 = reinterpret_cast<const uint4*>(tape_kd + index);
+                        uint4 _vld_1[1];
+                        #pragma unroll
+                        for (int _blk = 0; _blk < 1; _blk++) {
+                            _vld_1[_blk] = _vptr_1[_blk];
+                            uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
+                            #pragma unroll
+                            for (int _pair = 0; _pair < 4; _pair++) {
+                                asm volatile(
+                                    "{\n\t"
+                                    "shl.b32 %0, %2, 16;\n\t"
+                                    "and.b32 %1, %2, 0xffff0000;\n\t"
+                                    "}\n"
+                                    : "=f"((&kd_values[0 + _blk * 8 + _pair * 2])[0]), "=f"((&kd_values[0 + _blk * 8 + _pair * 2])[1])
+                                    : "r"(_vpairs_1[_pair]));
+                            }
+                        }
+                    }
+                    {
+                        const uint4* _vptr_2 = reinterpret_cast<const uint4*>(tape_kr + index);
+                        uint4 _vld_2[1];
+                        #pragma unroll
+                        for (int _blk = 0; _blk < 1; _blk++) {
+                            _vld_2[_blk] = _vptr_2[_blk];
+                            uint32_t* _vpairs_2 = reinterpret_cast<uint32_t*>(&_vld_2[_blk]);
+                            #pragma unroll
+                            for (int _pair = 0; _pair < 4; _pair++) {
+                                asm volatile(
+                                    "{\n\t"
+                                    "shl.b32 %0, %2, 16;\n\t"
+                                    "and.b32 %1, %2, 0xffff0000;\n\t"
+                                    "}\n"
+                                    : "=f"((&kr_values[0 + _blk * 8 + _pair * 2])[0]), "=f"((&kr_values[0 + _blk * 8 + _pair * 2])[1])
+                                    : "r"(_vpairs_2[_pair]));
+                            }
+                        }
+                    }
+                    #pragma unroll
+                    for (int elem = 0; elem < 8; elem++) {
+                        float factor = tape_restore_factor[restore_base_1 + (long long)(segment * 8) + (long long)elem];
+                        ki_values[elem] = kr_values[elem] / factor;
+                    }
+                    unsigned int packed[4];
+                    #pragma unroll
+                    for (int _lp = 0; _lp < 4; _lp++) {
+                        __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(qd_values[_lp*2 + 0], qd_values[_lp*2+1 + 0]));
+                        packed[_lp] = *(uint32_t*)&_bf2;
+                    }
+                    #pragma unroll
+                    for (int word = 0; word < 4; word++) {
+                        asm volatile("st.shared.b32 [%0], %1;" :: "r"((smem_qd_addr + (unsigned int)(segment * 8 / 64 * 4096 + row * 128 + segment * 8 % 64 * 2 ^ (segment * 8 / 64 * 4096 + row * 128 + segment * 8 % 64 * 2 >> 7 & 7) << 4)) + (unsigned int)(word * 4)), "r"((packed[word])));
+                    }
+                    unsigned int packed_0[4];
+                    #pragma unroll
+                    for (int _lp = 0; _lp < 4; _lp++) {
+                        __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(kd_values[_lp*2 + 0], kd_values[_lp*2+1 + 0]));
+                        packed_0[_lp] = *(uint32_t*)&_bf2;
+                    }
+                    #pragma unroll
+                    for (int word_1 = 0; word_1 < 4; word_1++) {
+                        asm volatile("st.shared.b32 [%0], %1;" :: "r"((smem_kd_addr + (unsigned int)(segment * 8 / 64 * 4096 + row * 128 + segment * 8 % 64 * 2 ^ (segment * 8 / 64 * 4096 + row * 128 + segment * 8 % 64 * 2 >> 7 & 7) << 4)) + (unsigned int)(word_1 * 4)), "r"((packed_0[word_1])));
+                    }
+                    unsigned int packed_1[4];
+                    #pragma unroll
+                    for (int _lp = 0; _lp < 4; _lp++) {
+                        __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(kr_values[_lp*2 + 0], kr_values[_lp*2+1 + 0]));
+                        packed_1[_lp] = *(uint32_t*)&_bf2;
+                    }
+                    #pragma unroll
+                    for (int word_2 = 0; word_2 < 4; word_2++) {
+                        asm volatile("st.shared.b32 [%0], %1;" :: "r"((smem_kr_addr + (unsigned int)(segment * 8 / 64 * 4096 + row * 128 + segment * 8 % 64 * 2 ^ (segment * 8 / 64 * 4096 + row * 128 + segment * 8 % 64 * 2 >> 7 & 7) << 4)) + (unsigned int)(word_2 * 4)), "r"((packed_1[word_2])));
+                    }
+                    unsigned int packed_2[4];
+                    #pragma unroll
+                    for (int _lp = 0; _lp < 4; _lp++) {
+                        __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(ki_values[_lp*2 + 0], ki_values[_lp*2+1 + 0]));
+                        packed_2[_lp] = *(uint32_t*)&_bf2;
+                    }
+                    #pragma unroll
+                    for (int word_3 = 0; word_3 < 4; word_3++) {
+                        asm volatile("st.shared.b32 [%0], %1;" :: "r"((smem_ki_addr + (unsigned int)(segment * 8 / 64 * 4096 + row * 128 + segment * 8 % 64 * 2 ^ (segment * 8 / 64 * 4096 + row * 128 + segment * 8 % 64 * 2 >> 7 & 7) << 4)) + (unsigned int)(word_3 * 4)), "r"((packed_2[word_3])));
+                    }
+                }
+                int j_row = prep_tid / 4;
+                int j_segment = prep_tid % 4;
+                float j_values[8];
+                long long j_base = (chunk_global_1 * (long long)num_heads + (long long)head_idx_1) * 32 * 32;
+                {
+                    const uint4* _vptr_3 = reinterpret_cast<const uint4*>(tape_j + j_base + (long long)j_row * 32 + (long long)(j_segment * 8));
+                    uint4 _vld_3[1];
+                    #pragma unroll
+                    for (int _blk = 0; _blk < 1; _blk++) {
+                        _vld_3[_blk] = _vptr_3[_blk];
+                        uint32_t* _vpairs_3 = reinterpret_cast<uint32_t*>(&_vld_3[_blk]);
+                        #pragma unroll
+                        for (int _pair = 0; _pair < 4; _pair++) {
+                            asm volatile(
+                                "{\n\t"
+                                "shl.b32 %0, %2, 16;\n\t"
+                                "and.b32 %1, %2, 0xffff0000;\n\t"
+                                "}\n"
+                                : "=f"((&j_values[0 + _blk * 8 + _pair * 2])[0]), "=f"((&j_values[0 + _blk * 8 + _pair * 2])[1])
+                                : "r"(_vpairs_3[_pair]));
+                        }
+                    }
+                }
+                unsigned int packed_3[4];
+                #pragma unroll
+                for (int _lp = 0; _lp < 4; _lp++) {
+                    __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(j_values[_lp*2 + 0], j_values[_lp*2+1 + 0]));
+                    packed_3[_lp] = *(uint32_t*)&_bf2;
+                }
+                #pragma unroll
+                for (int word_4 = 0; word_4 < 4; word_4++) {
+                    asm volatile("st.shared.b32 [%0], %1;" :: "r"((smem_j_addr + (unsigned int)(j_segment * 8 / 16 * 1024 + j_row * 32 + j_segment * 8 % 16 * 2 ^ (j_segment * 8 / 16 * 1024 + j_row * 32 + j_segment * 8 % 16 * 2 >> 7 & 1) << 4)) + (unsigned int)(word_4 * 4)), "r"((packed_3[word_4])));
+                }
+                asm volatile("fence.proxy.async.shared::cta;" ::: "memory");
+                asm volatile("barrier.sync 8, 128;" ::: "memory");
+                int row_base = prep_local_warp / 2 * 16;
+                int col_base = prep_local_warp % 2 * 16;
+                unsigned int a_frag[4];
+                unsigned int b_frag[4];
+                float acc[8];
+                if (row_base <= col_base) {
+                    asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                        : "=r"(a_frag[0]), "=r"(a_frag[1]), "=r"(a_frag[2]), "=r"(a_frag[3])
+                        : "r"(smem_ki_addr + (unsigned int)((lane / 16 / 8 * 256 + (row_base + lane % 16) * 8 + (lane / 16 % 8 * 16 ^ (row_base + lane % 16 & 7) << 4) / 16) * 16))
+                        : "memory");
+                    asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                        : "=r"(b_frag[0]), "=r"(b_frag[1]), "=r"(b_frag[2]), "=r"(b_frag[3])
+                        : "r"(smem_qd_addr + (unsigned int)((lane % 16 / 8 / 8 * 256 + (col_base + 8 * (lane / 16) + lane % 8) * 8 + (lane % 16 / 8 % 8 * 16 ^ (col_base + 8 * (lane / 16) + lane % 8 & 7) << 4) / 16) * 16))
+                        : "memory");
+                    asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%10, %11, %12, %13};\n"
+                        : "=f"(acc[0]), "=f"(acc[1]), "=f"(acc[2]), "=f"(acc[3])
+                        : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[0]), "r"(b_frag[1]), "f"(0.0f), "f"(0.0f), "f"(0.0f), "f"(0.0f));
+                    asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%10, %11, %12, %13};\n"
+                        : "=f"(acc[4]), "=f"(acc[(4) + 1]), "=f"(acc[(4) + 2]), "=f"(acc[(4) + 3])
+                        : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[2]), "r"(b_frag[(2) + 1]), "f"(0.0f), "f"(0.0f), "f"(0.0f), "f"(0.0f));
+                    asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                        : "=r"(a_frag[0]), "=r"(a_frag[1]), "=r"(a_frag[2]), "=r"(a_frag[3])
+                        : "r"(smem_ki_addr + (unsigned int)((lane / 16 / 8 * 256 + (row_base + lane % 16) * 8 + (lane / 16 % 8 * 16 ^ (row_base + lane % 16 & 7) << 4) / 16 ^ 2) * 16))
+                        : "memory");
+                    asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                        : "=r"(b_frag[0]), "=r"(b_frag[1]), "=r"(b_frag[2]), "=r"(b_frag[3])
+                        : "r"(smem_qd_addr + (unsigned int)(((lane % 16 / 8 / 8 * 256 + (col_base + 8 * (lane / 16) + lane % 8) * 8 + (lane % 16 / 8 % 8 * 16 ^ (col_base + 8 * (lane / 16) + lane % 8 & 7) << 4) / 16 + 256 ^ 2) - 256) * 16))
+                        : "memory");
+                    asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                        : "+f"(acc[0]), "+f"(acc[1]), "+f"(acc[2]), "+f"(acc[3])
+                        : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[0]), "r"(b_frag[1]));
+                    asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                        : "+f"(acc[4]), "+f"(acc[(4) + 1]), "+f"(acc[(4) + 2]), "+f"(acc[(4) + 3])
+                        : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[2]), "r"(b_frag[(2) + 1]));
+                    asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                        : "=r"(a_frag[0]), "=r"(a_frag[1]), "=r"(a_frag[2]), "=r"(a_frag[3])
+                        : "r"(smem_ki_addr + (unsigned int)((lane / 16 / 8 * 256 + (row_base + lane % 16) * 8 + (lane / 16 % 8 * 16 ^ (row_base + lane % 16 & 7) << 4) / 16 ^ 2 ^ 6) * 16))
+                        : "memory");
+                    asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                        : "=r"(b_frag[0]), "=r"(b_frag[1]), "=r"(b_frag[2]), "=r"(b_frag[3])
+                        : "r"(smem_qd_addr + (unsigned int)((((lane % 16 / 8 / 8 * 256 + (col_base + 8 * (lane / 16) + lane % 8) * 8 + (lane % 16 / 8 % 8 * 16 ^ (col_base + 8 * (lane / 16) + lane % 8 & 7) << 4) / 16 + 256 ^ 2) - 256 + 256 ^ 6) - 256) * 16))
+                        : "memory");
+                    asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                        : "+f"(acc[0]), "+f"(acc[1]), "+f"(acc[2]), "+f"(acc[3])
+                        : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[0]), "r"(b_frag[1]));
+                    asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                        : "+f"(acc[4]), "+f"(acc[(4) + 1]), "+f"(acc[(4) + 2]), "+f"(acc[(4) + 3])
+                        : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[2]), "r"(b_frag[(2) + 1]));
+                    asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                        : "=r"(a_frag[0]), "=r"(a_frag[1]), "=r"(a_frag[2]), "=r"(a_frag[3])
+                        : "r"(smem_ki_addr + (unsigned int)((lane / 16 / 8 * 256 + (row_base + lane % 16) * 8 + (lane / 16 % 8 * 16 ^ (row_base + lane % 16 & 7) << 4) / 16 ^ 2 ^ 6 ^ 2) * 16))
+                        : "memory");
+                    asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                        : "=r"(b_frag[0]), "=r"(b_frag[1]), "=r"(b_frag[2]), "=r"(b_frag[3])
+                        : "r"(smem_qd_addr + (unsigned int)(((((lane % 16 / 8 / 8 * 256 + (col_base + 8 * (lane / 16) + lane % 8) * 8 + (lane % 16 / 8 % 8 * 16 ^ (col_base + 8 * (lane / 16) + lane % 8 & 7) << 4) / 16 + 256 ^ 2) - 256 + 256 ^ 6) - 256 + 256 ^ 2) - 256) * 16))
+                        : "memory");
+                    asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                        : "+f"(acc[0]), "+f"(acc[1]), "+f"(acc[2]), "+f"(acc[3])
+                        : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[0]), "r"(b_frag[1]));
+                    asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                        : "+f"(acc[4]), "+f"(acc[(4) + 1]), "+f"(acc[(4) + 2]), "+f"(acc[(4) + 3])
+                        : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[2]), "r"(b_frag[(2) + 1]));
+                    asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                        : "=r"(a_frag[0]), "=r"(a_frag[1]), "=r"(a_frag[2]), "=r"(a_frag[3])
+                        : "r"(smem_ki_addr + (unsigned int)(((lane / 16 / 8 * 256 + (row_base + lane % 16) * 8 + (lane / 16 % 8 * 16 ^ (row_base + lane % 16 & 7) << 4) / 16 ^ 2 ^ 6 ^ 2 ^ 6) + 256) * 16))
+                        : "memory");
+                    asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                        : "=r"(b_frag[0]), "=r"(b_frag[1]), "=r"(b_frag[2]), "=r"(b_frag[3])
+                        : "r"(smem_qd_addr + (unsigned int)((((((lane % 16 / 8 / 8 * 256 + (col_base + 8 * (lane / 16) + lane % 8) * 8 + (lane % 16 / 8 % 8 * 16 ^ (col_base + 8 * (lane / 16) + lane % 8 & 7) << 4) / 16 + 256 ^ 2) - 256 + 256 ^ 6) - 256 + 256 ^ 2) - 256 + 256 ^ 6) + 256 - 256) * 16))
+                        : "memory");
+                    asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                        : "+f"(acc[0]), "+f"(acc[1]), "+f"(acc[2]), "+f"(acc[3])
+                        : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[0]), "r"(b_frag[1]));
+                    asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                        : "+f"(acc[4]), "+f"(acc[(4) + 1]), "+f"(acc[(4) + 2]), "+f"(acc[(4) + 3])
+                        : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[2]), "r"(b_frag[(2) + 1]));
+                    asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                        : "=r"(a_frag[0]), "=r"(a_frag[1]), "=r"(a_frag[2]), "=r"(a_frag[3])
+                        : "r"(smem_ki_addr + (unsigned int)(((lane / 16 / 8 * 256 + (row_base + lane % 16) * 8 + (lane / 16 % 8 * 16 ^ (row_base + lane % 16 & 7) << 4) / 16 ^ 2 ^ 6 ^ 2 ^ 6) + 256 ^ 2) * 16))
+                        : "memory");
+                    asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                        : "=r"(b_frag[0]), "=r"(b_frag[1]), "=r"(b_frag[2]), "=r"(b_frag[3])
+                        : "r"(smem_qd_addr + (unsigned int)(((((((lane % 16 / 8 / 8 * 256 + (col_base + 8 * (lane / 16) + lane % 8) * 8 + (lane % 16 / 8 % 8 * 16 ^ (col_base + 8 * (lane / 16) + lane % 8 & 7) << 4) / 16 + 256 ^ 2) - 256 + 256 ^ 6) - 256 + 256 ^ 2) - 256 + 256 ^ 6) + 256 - 256 + 256 ^ 2) - 256) * 16))
+                        : "memory");
+                    asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                        : "+f"(acc[0]), "+f"(acc[1]), "+f"(acc[2]), "+f"(acc[3])
+                        : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[0]), "r"(b_frag[1]));
+                    asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                        : "+f"(acc[4]), "+f"(acc[(4) + 1]), "+f"(acc[(4) + 2]), "+f"(acc[(4) + 3])
+                        : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[2]), "r"(b_frag[(2) + 1]));
+                    asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                        : "=r"(a_frag[0]), "=r"(a_frag[1]), "=r"(a_frag[2]), "=r"(a_frag[3])
+                        : "r"(smem_ki_addr + (unsigned int)(((lane / 16 / 8 * 256 + (row_base + lane % 16) * 8 + (lane / 16 % 8 * 16 ^ (row_base + lane % 16 & 7) << 4) / 16 ^ 2 ^ 6 ^ 2 ^ 6) + 256 ^ 2 ^ 6) * 16))
+                        : "memory");
+                    asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                        : "=r"(b_frag[0]), "=r"(b_frag[1]), "=r"(b_frag[2]), "=r"(b_frag[3])
+                        : "r"(smem_qd_addr + (unsigned int)((((((((lane % 16 / 8 / 8 * 256 + (col_base + 8 * (lane / 16) + lane % 8) * 8 + (lane % 16 / 8 % 8 * 16 ^ (col_base + 8 * (lane / 16) + lane % 8 & 7) << 4) / 16 + 256 ^ 2) - 256 + 256 ^ 6) - 256 + 256 ^ 2) - 256 + 256 ^ 6) + 256 - 256 + 256 ^ 2) - 256 + 256 ^ 6) - 256) * 16))
+                        : "memory");
+                    asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                        : "+f"(acc[0]), "+f"(acc[1]), "+f"(acc[2]), "+f"(acc[3])
+                        : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[0]), "r"(b_frag[1]));
+                    asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                        : "+f"(acc[4]), "+f"(acc[(4) + 1]), "+f"(acc[(4) + 2]), "+f"(acc[(4) + 3])
+                        : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[2]), "r"(b_frag[(2) + 1]));
+                    asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                        : "=r"(a_frag[0]), "=r"(a_frag[1]), "=r"(a_frag[2]), "=r"(a_frag[3])
+                        : "r"(smem_ki_addr + (unsigned int)(((lane / 16 / 8 * 256 + (row_base + lane % 16) * 8 + (lane / 16 % 8 * 16 ^ (row_base + lane % 16 & 7) << 4) / 16 ^ 2 ^ 6 ^ 2 ^ 6) + 256 ^ 2 ^ 6 ^ 2) * 16))
+                        : "memory");
+                    asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                        : "=r"(b_frag[0]), "=r"(b_frag[1]), "=r"(b_frag[2]), "=r"(b_frag[3])
+                        : "r"(smem_qd_addr + (unsigned int)(((((((((lane % 16 / 8 / 8 * 256 + (col_base + 8 * (lane / 16) + lane % 8) * 8 + (lane % 16 / 8 % 8 * 16 ^ (col_base + 8 * (lane / 16) + lane % 8 & 7) << 4) / 16 + 256 ^ 2) - 256 + 256 ^ 6) - 256 + 256 ^ 2) - 256 + 256 ^ 6) + 256 - 256 + 256 ^ 2) - 256 + 256 ^ 6) - 256 + 256 ^ 2) - 256) * 16))
+                        : "memory");
+                    asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                        : "+f"(acc[0]), "+f"(acc[1]), "+f"(acc[2]), "+f"(acc[3])
+                        : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[0]), "r"(b_frag[1]));
+                    asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                        : "+f"(acc[4]), "+f"(acc[(4) + 1]), "+f"(acc[(4) + 2]), "+f"(acc[(4) + 3])
+                        : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[2]), "r"(b_frag[(2) + 1]));
+                } else {
+                    acc[0] = 0.0f;
+                    acc[1] = 0.0f;
+                    acc[2] = 0.0f;
+                    acc[3] = 0.0f;
+                    acc[4] = 0.0f;
+                    acc[5] = 0.0f;
+                    acc[6] = 0.0f;
+                    acc[7] = 0.0f;
+                }
+                int row0 = row_base + lane / 4;
+                int row1 = row0 + 8;
+                int col0 = col_base + lane % 4 * 2;
+                float values[8];
+                values[0] = 0.0f;
+                values[1] = 0.0f;
+                values[2] = 0.0f;
+                values[3] = 0.0f;
+                values[4] = 0.0f;
+                values[5] = 0.0f;
+                values[6] = 0.0f;
+                values[7] = 0.0f;
+                if (row0 <= col0) {
+                    values[0] = acc[0];
+                }
+                if (row0 <= col0 + 1) {
+                    values[1] = acc[1];
+                }
+                if (row1 <= col0) {
+                    values[2] = acc[2];
+                }
+                if (row1 <= col0 + 1) {
+                    values[3] = acc[3];
+                }
+                if (row0 <= col0 + 8) {
+                    values[4] = acc[4];
+                }
+                if (row0 <= col0 + 9) {
+                    values[5] = acc[5];
+                }
+                if (row1 <= col0 + 8) {
+                    values[6] = acc[6];
+                }
+                if (row1 <= col0 + 9) {
+                    values[7] = acc[7];
+                }
+                unsigned int packed_0_1[4];
+                #pragma unroll
+                for (int _lp = 0; _lp < 4; _lp++) {
+                    __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(values[_lp*2 + 0], values[_lp*2+1 + 0]));
+                    packed_0_1[_lp] = *(uint32_t*)&_bf2;
+                }
+                int lane_row = lane % 16;
+                int lane_col = lane / 16 * 8;
+                uint32_t _stmatrix_addr_4 = static_cast<uint32_t>((unsigned long long)(smem_n_addr + (unsigned int)((col_base + lane_col) / 16 * 1024 + (row_base + lane_row) * 32 + (col_base + lane_col) % 16 * 2 ^ ((col_base + lane_col) / 16 * 1024 + (row_base + lane_row) * 32 + (col_base + lane_col) % 16 * 2 >> 7 & 1) << 4)));
+                asm volatile("stmatrix.sync.aligned.m8n8.x4.shared.b16 [%0], {%1, %2, %3, %4};\n"
+                    :: "r"(_stmatrix_addr_4), "r"(*reinterpret_cast<const uint32_t*>(&packed_0_1[0])), "r"(*reinterpret_cast<const uint32_t*>(&packed_0_1[1])), "r"(*reinterpret_cast<const uint32_t*>(&packed_0_1[2])), "r"(*reinterpret_cast<const uint32_t*>(&packed_0_1[3]))
+                    : "memory");
+                asm volatile("fence.proxy.async.shared::cta;" ::: "memory");
+                asm volatile("barrier.sync 8, 128;" ::: "memory");
+                if (prep_local_warp == 0) {
+                    if (elect_sync()) {
+                        mbarrier_arrive(prep_ready_addr + (prep_stage) * 8);
+                    }
+                }
+                prep_stage += 1;
+                if (prep_stage == 1) { prep_stage = 0; _phase_smem_free ^= 1; }
+            }
+        }
+    }
+    // ---- Role: mma ----
+    if (warp == 8) {
+        { // mma_main
+            int split_task_idx_2 = blockIdx.x;
+            int task_idx_2 = split_task_idx_2 / 2;
+            int item_base_2 = task_idx_2 * 5;
+            int write_start_2 = work_items[item_base_2 + 2];
+            unsigned int _phase_work_item_ready_0_1 = 0;
+            mbarrier_wait(work_item_ready_addr, _phase_work_item_ready_0_1);
+            _phase_work_item_ready_0_1 ^= 1;
+            int compute_end_2 = smem_work_item_compute_end[0];
+            int scan_chunks_2 = compute_end_2 - write_start_2;
+            unsigned int mma_stage = 0;
+            unsigned int _phase_prep_ready_1 = 0;
+            unsigned int _phase_inputs_ready = 0;
+            unsigned int _phase_dr_inp_ready = 0;
+            unsigned int _phase_de_inp_ready = 0;
+            #pragma unroll 1
+            for (int _reverse_chunk = 0; _reverse_chunk < scan_chunks_2; _reverse_chunk++) {
+                mbarrier_wait(prep_ready_addr + (mma_stage) * 8, _phase_prep_ready_1);
+                mbarrier_wait(inputs_ready_addr + (mma_stage) * 8, _phase_inputs_ready);
+                int _mma_b_lo_0 = make_warp_uniform(((smem_n_addr) >> 4) & 0x3FFF);
+                asm volatile(
+                    "{\n\t"
+                    ".reg .pred leader, p0, p1;\n\t"
+                    ".reg .b32 dhi, blo, ta, id;\n\t"
+                    ".reg .b64 db;\n\t"
+                    "elect.sync _|leader, 0xFFFFFFFF;\n\t"
+                    "setp.ne.b32 p0, %3, 0;\n\t"
+                    "setp.ne.b32 p1, 1, 0;\n\t"
+                    ""
+                    "mov.b32 dhi, 0xC0004010;\n\t"
+                    "mov.b32 id, 67634320;\n\t"
+                    "mov.b32 ta, %2;\n\t"
+                    "mov.b32 blo, %1;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p0;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 64;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "}\n"
+                    :: "r"(tmem_tmem_dr), "r"(_mma_b_lo_0), "r"(tmem_tmem_do_initial), "r"(0));
+                int _mma_b_lo_1 = make_warp_uniform(((smem_kr_addr) >> 4) & 0x3FFF);
+                asm volatile(
+                    "{\n\t"
+                    ".reg .pred leader, p0, p1;\n\t"
+                    ".reg .b32 dhi, blo, ta, id;\n\t"
+                    ".reg .b64 db;\n\t"
+                    "elect.sync _|leader, 0xFFFFFFFF;\n\t"
+                    "setp.ne.b32 p0, %3, 0;\n\t"
+                    "setp.ne.b32 p1, 1, 0;\n\t"
+                    ""
+                    "mov.b32 dhi, 0x40004040;\n\t"
+                    "mov.b32 id, 67634320;\n\t"
+                    "mov.b32 ta, %2;\n\t"
+                    "mov.b32 blo, %1;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p0;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 250;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "}\n"
+                    :: "r"(tmem_tmem_dr), "r"(_mma_b_lo_1), "r"(tmem_tmem_dh_inp), "r"(1));
+                elect_commit(dr_ready_addr + (mma_stage) * 8);
+                mbarrier_wait(dr_inp_ready_addr + (mma_stage) * 8, _phase_dr_inp_ready);
+                int _mma_b_lo_2 = make_warp_uniform((((smem_j_trans_addr) >> 4) & 0x3FFF) | 0x400000);
+                asm volatile(
+                    "{\n\t"
+                    ".reg .pred leader, p0, p1;\n\t"
+                    ".reg .b32 dhi, blo, ta, id;\n\t"
+                    ".reg .b64 db;\n\t"
+                    "elect.sync _|leader, 0xFFFFFFFF;\n\t"
+                    "setp.ne.b32 p0, %3, 0;\n\t"
+                    "setp.ne.b32 p1, 1, 0;\n\t"
+                    ""
+                    "mov.b32 dhi, 0xC0004010;\n\t"
+                    "mov.b32 id, 67699856;\n\t"
+                    "mov.b32 ta, %2;\n\t"
+                    "mov.b32 blo, %1;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p0;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 32;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "}\n"
+                    :: "r"(tmem_tmem_dx), "r"(_mma_b_lo_2), "r"(tmem_tmem_dr_inp), "r"(0));
+                elect_commit(dx_ready_addr + (mma_stage) * 8);
+                mbarrier_wait(de_inp_ready_addr + (mma_stage) * 8, _phase_de_inp_ready);
+                int _mma_b_lo_3 = make_warp_uniform((((smem_qd_trans_addr) >> 4) & 0x3FFF) | 0x1000000);
+                asm volatile(
+                    "{\n\t"
+                    ".reg .pred leader, p0, p1;\n\t"
+                    ".reg .b32 dhi, blo, ta, id;\n\t"
+                    ".reg .b64 db;\n\t"
+                    "elect.sync _|leader, 0xFFFFFFFF;\n\t"
+                    "setp.ne.b32 p0, %3, 0;\n\t"
+                    "setp.ne.b32 p1, 1, 0;\n\t"
+                    ""
+                    "mov.b32 dhi, 0x40004040;\n\t"
+                    "mov.b32 id, 69272720;\n\t"
+                    "mov.b32 ta, %2;\n\t"
+                    "mov.b32 blo, %1;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p0;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 128;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "}\n"
+                    :: "r"(tmem_tmem_dh), "r"(_mma_b_lo_3), "r"(tmem_tmem_do_final), "r"(1));
+                int _mma_b_lo_4 = make_warp_uniform((((smem_kd_trans_addr) >> 4) & 0x3FFF) | 0x1000000);
+                asm volatile(
+                    "{\n\t"
+                    ".reg .pred leader, p0, p1;\n\t"
+                    ".reg .b32 dhi, blo, ta, id;\n\t"
+                    ".reg .b64 db;\n\t"
+                    "elect.sync _|leader, 0xFFFFFFFF;\n\t"
+                    "setp.ne.b32 p0, %3, 0;\n\t"
+                    "setp.ne.b32 p1, 1, 0;\n\t"
+                    ""
+                    "mov.b32 dhi, 0x40004040;\n\t"
+                    "mov.b32 id, 69272720;\n\t"
+                    "mov.b32 ta, %2;\n\t"
+                    "mov.b32 blo, %1;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p0;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 128;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "}\n"
+                    :: "r"(tmem_tmem_dh), "r"(_mma_b_lo_4), "r"(tmem_tmem_de_inp), "r"(1));
+                elect_commit2(dh_ready_addr + (mma_stage) * 8, smem_free_addr + (mma_stage) * 8);
+                mma_stage += 1;
+                if (mma_stage == 1) { mma_stage = 0; _phase_prep_ready_1 ^= 1; _phase_inputs_ready ^= 1; _phase_dr_inp_ready ^= 1; _phase_de_inp_ready ^= 1; }
+            }
+            unsigned int _phase_compute_done_0 = 0;
+            mbarrier_wait(compute_done_addr, _phase_compute_done_0);
+            _phase_compute_done_0 ^= 1;
+            int _tmem_dealloc_addr = *((volatile int*)tmem_addr_storage);
+            asm volatile("tcgen05.dealloc.cta_group::1.sync.aligned.b32 %0, %1;" :: "r"(_tmem_dealloc_addr), "r"(256));
+        }
+    }
+
+    // Cleanup
+}
+
+} // extern "C"
+
+#undef LOOM_INF
+#undef NUM_REVERSE_PIPE_STAGES
+#undef SMEM_SMEM_J_OFF
+#undef SMEM_SMEM_J_STAGE_BYTES
+#undef SMEM_SMEM_J_STRIDE
+#undef SMEM_SMEM_J_TRANS_OFF
+#undef SMEM_SMEM_J_TRANS_STAGE_BYTES
+#undef SMEM_SMEM_J_TRANS_STRIDE
+#undef SMEM_SMEM_KD_OFF
+#undef SMEM_SMEM_KD_STAGE_BYTES
+#undef SMEM_SMEM_KD_STRIDE
+#undef SMEM_SMEM_KD_TRANS_OFF
+#undef SMEM_SMEM_KD_TRANS_STAGE_BYTES
+#undef SMEM_SMEM_KD_TRANS_STRIDE
+#undef SMEM_SMEM_KI_OFF
+#undef SMEM_SMEM_KI_STAGE_BYTES
+#undef SMEM_SMEM_KI_STRIDE
+#undef SMEM_SMEM_KR_OFF
+#undef SMEM_SMEM_KR_STAGE_BYTES
+#undef SMEM_SMEM_KR_STRIDE
+#undef SMEM_SMEM_N_OFF
+#undef SMEM_SMEM_N_STAGE_BYTES
+#undef SMEM_SMEM_N_STRIDE
+#undef SMEM_SMEM_QD_OFF
+#undef SMEM_SMEM_QD_STAGE_BYTES
+#undef SMEM_SMEM_QD_STRIDE
+#undef SMEM_SMEM_QD_TRANS_OFF
+#undef SMEM_SMEM_QD_TRANS_STAGE_BYTES
+#undef SMEM_SMEM_QD_TRANS_STRIDE
+#undef SMEM_SMEM_WORK_ITEM_COMPUTE_END_OFF
+#undef SMEM_SMEM_WORK_ITEM_COMPUTE_END_STAGE_BYTES
+#undef SMEM_SMEM_WORK_ITEM_COMPUTE_END_STRIDE
+#undef SMEM_SMEM_WORK_ITEM_RESOLVED_OFF
+#undef SMEM_SMEM_WORK_ITEM_RESOLVED_STAGE_BYTES
+#undef SMEM_SMEM_WORK_ITEM_RESOLVED_STRIDE
+#undef SMEM_SMEM_WORK_ITEM_WARP_MAX_OFF
+#undef SMEM_SMEM_WORK_ITEM_WARP_MAX_STAGE_BYTES
+#undef SMEM_SMEM_WORK_ITEM_WARP_MAX_STRIDE
+#undef SMEM_TOTAL
+#undef THREADS
+#undef TMEM_NCOLS
+#undef TMEM_TMEM_DE_INP_OFFSET
+#undef TMEM_TMEM_DH_INP_OFFSET
+#undef TMEM_TMEM_DH_OFFSET
+#undef TMEM_TMEM_DO_FINAL_OFFSET
+#undef TMEM_TMEM_DO_INITIAL_OFFSET
+#undef TMEM_TMEM_DR_INP_OFFSET
+#undef TMEM_TMEM_DR_OFFSET
+#undef TMEM_TMEM_DX_OFFSET
+#undef compute_done_addr
+#undef de_inp_ready_addr
+#undef dh_ready_addr
+#undef dr_inp_ready_addr
+#undef dr_ready_addr
+#undef dx_ready_addr
+#undef inputs_ready_addr
+#undef prep_ready_addr
+#undef smem_free_addr
+#undef smem_j_addr
+#undef smem_j_trans_addr
+#undef smem_kd_addr
+#undef smem_kd_trans_addr
+#undef smem_ki_addr
+#undef smem_kr_addr
+#undef smem_n_addr
+#undef smem_qd_addr
+#undef smem_qd_trans_addr
+#undef smem_work_item_compute_end_addr
+#undef smem_work_item_resolved_addr
+#undef smem_work_item_warp_max_addr
+#undef work_item_ready_addr
+
+#define LOOM_INF CUDART_INF_F
+#define TMEM_NCOLS 256
+#define TMEM_TMEM_DH_OFFSET 64
+#define TMEM_TMEM_DH_INP_OFFSET 0
+#define TMEM_TMEM_DO_INITIAL_OFFSET 224
+#define TMEM_TMEM_DO_FINAL_OFFSET 0
+#define TMEM_TMEM_DR_OFFSET 192
+#define TMEM_TMEM_DR_INP_OFFSET 192
+#define TMEM_TMEM_DX_OFFSET 224
+#define TMEM_TMEM_DE_INP_OFFSET 224
+#define NUM_PREP_PIPE_STAGES 2
+#define NUM_REVERSE_PIPE_STAGES 1
+#define SMEM_SMEM_QD_OFF 1024
+#define SMEM_SMEM_QD_STAGE_BYTES 8192
+#define SMEM_SMEM_QD_STRIDE 36864
+#define SMEM_SMEM_QD_TRANS_OFF 1024
+#define SMEM_SMEM_QD_TRANS_STAGE_BYTES 8192
+#define SMEM_SMEM_QD_TRANS_STRIDE 36864
+#define SMEM_SMEM_KD_OFF 9216
+#define SMEM_SMEM_KD_STAGE_BYTES 8192
+#define SMEM_SMEM_KD_STRIDE 36864
+#define SMEM_SMEM_KD_TRANS_OFF 9216
+#define SMEM_SMEM_KD_TRANS_STAGE_BYTES 8192
+#define SMEM_SMEM_KD_TRANS_STRIDE 36864
+#define SMEM_SMEM_KR_OFF 17408
+#define SMEM_SMEM_KR_STAGE_BYTES 8192
+#define SMEM_SMEM_KR_STRIDE 36864
+#define SMEM_SMEM_KI_OFF 25600
+#define SMEM_SMEM_KI_STAGE_BYTES 8192
+#define SMEM_SMEM_KI_STRIDE 36864
+#define SMEM_SMEM_J_OFF 33792
+#define SMEM_SMEM_J_STAGE_BYTES 2048
+#define SMEM_SMEM_J_STRIDE 36864
+#define SMEM_SMEM_J_TRANS_OFF 33792
+#define SMEM_SMEM_J_TRANS_STAGE_BYTES 2048
+#define SMEM_SMEM_J_TRANS_STRIDE 36864
+#define SMEM_SMEM_N_OFF 35840
+#define SMEM_SMEM_N_STAGE_BYTES 2048
+#define SMEM_SMEM_N_STRIDE 36864
+#define SMEM_SMEM_WORK_ITEM_WARP_MAX_OFF 74752
+#define SMEM_SMEM_WORK_ITEM_WARP_MAX_STAGE_BYTES 16
+#define SMEM_SMEM_WORK_ITEM_WARP_MAX_STRIDE 16
+#define SMEM_SMEM_WORK_ITEM_COMPUTE_END_OFF 74768
+#define SMEM_SMEM_WORK_ITEM_COMPUTE_END_STAGE_BYTES 4
+#define SMEM_SMEM_WORK_ITEM_COMPUTE_END_STRIDE 4
+#define SMEM_SMEM_WORK_ITEM_RESOLVED_OFF 74772
+#define SMEM_SMEM_WORK_ITEM_RESOLVED_STAGE_BYTES 4
+#define SMEM_SMEM_WORK_ITEM_RESOLVED_STRIDE 4
+#define SMEM_TOTAL 74880
+#define THREADS 512
+
+extern "C" {
+
+__global__ __launch_bounds__(512) void
+kernel_flashkda_backward_boundary_c32_tcgen(__nv_bfloat16* __restrict__ do_, float* __restrict__ dfinal_state, float* __restrict__ beta_active, long long* __restrict__ cu_seqlens, long long* __restrict__ cu_chunk_offsets, int* __restrict__ work_items, __nv_bfloat16* __restrict__ tape_qd, __nv_bfloat16* __restrict__ tape_kd, __nv_bfloat16* __restrict__ tape_kr, __nv_bfloat16* __restrict__ tape_j, float* __restrict__ tape_restore_factor, __nv_bfloat16* __restrict__ chunk_dh, __nv_bfloat16* __restrict__ chunk_dr, __nv_bfloat16* __restrict__ chunk_dx, unsigned int* __restrict__ boundary_ready, float* __restrict__ dinitial_state, int num_heads, int publish_ready, float lower_bound)
+{
+    const int tid = threadIdx.x;
+    const int warp = make_warp_uniform(tid / 32);
+    const int lane = tid % 32;
+
+    extern __shared__ __align__(1024) char smem_raw[];
+    int smem;
+    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+
+    const int bid = blockIdx.x;
+    const int num_bids = gridDim.x;
+
+    // Kernel setup ops
+    __nv_bfloat16* smem_qd = reinterpret_cast<__nv_bfloat16*>(smem_raw + 1024);
+    const int smem_qd_addr = smem + 1024;
+    __nv_bfloat16* smem_qd_trans = reinterpret_cast<__nv_bfloat16*>(smem_raw + 1024);
+    const int smem_qd_trans_addr = smem + 1024;
+    __nv_bfloat16* smem_kd = reinterpret_cast<__nv_bfloat16*>(smem_raw + 9216);
+    const int smem_kd_addr = smem + 9216;
+    __nv_bfloat16* smem_kd_trans = reinterpret_cast<__nv_bfloat16*>(smem_raw + 9216);
+    const int smem_kd_trans_addr = smem + 9216;
+    __nv_bfloat16* smem_kr = reinterpret_cast<__nv_bfloat16*>(smem_raw + 17408);
+    const int smem_kr_addr = smem + 17408;
+    __nv_bfloat16* smem_ki = reinterpret_cast<__nv_bfloat16*>(smem_raw + 25600);
+    const int smem_ki_addr = smem + 25600;
+    __nv_bfloat16* smem_j = reinterpret_cast<__nv_bfloat16*>(smem_raw + 33792);
+    const int smem_j_addr = smem + 33792;
+    __nv_bfloat16* smem_j_trans = reinterpret_cast<__nv_bfloat16*>(smem_raw + 33792);
+    const int smem_j_trans_addr = smem + 33792;
+    __nv_bfloat16* smem_n = reinterpret_cast<__nv_bfloat16*>(smem_raw + 35840);
+    const int smem_n_addr = smem + 35840;
+    float* smem_work_item_warp_max = reinterpret_cast<float*>(smem_raw + 74752);
+    const int smem_work_item_warp_max_addr = smem + 74752;
+    int* smem_work_item_compute_end = reinterpret_cast<int*>(smem_raw + 74768);
+    const int smem_work_item_compute_end_addr = smem + 74768;
+    unsigned int* smem_work_item_resolved = reinterpret_cast<unsigned int*>(smem_raw + 74772);
+    const int smem_work_item_resolved_addr = smem + 74772;
+
+    // Mbarrier init (9 groups, 11 barriers)
+    // Mbarriers at smem_raw[0..88)
+
+    if (warp == 0) {
+        uint32_t leader = elect_sync();
+        if (leader) {
+            // --- pipeline 'prep_pipe' ---
+            // smem_free: 2 barriers, init_count=1
+            mbarrier_init(smem + 0, 1);
+            mbarrier_init(smem + 8, 1);
+            // prep_ready: 2 barriers, init_count=1
+            mbarrier_init(smem + 16, 1);
+            mbarrier_init(smem + 24, 1);
+            // --- pipeline 'reverse_pipe' ---
+            // dr_ready: 1 barriers, init_count=1
+            mbarrier_init(smem + 32, 1);
+            // dr_inp_ready: 1 barriers, init_count=1
+            mbarrier_init(smem + 40, 1);
+            // dx_ready: 1 barriers, init_count=1
+            mbarrier_init(smem + 48, 1);
+            // de_inp_ready: 1 barriers, init_count=1
+            mbarrier_init(smem + 56, 1);
+            // dh_ready: 1 barriers, init_count=1
+            mbarrier_init(smem + 64, 1);
+            // owners_done: 1 barriers, init_count=12
+            mbarrier_init(smem + 72, 12);
+            // work_item_ready: 1 barriers, init_count=1
+            mbarrier_init(smem + 80, 1);
+            asm volatile("fence.mbarrier_init.release.cluster;");
+        }
+    }
+
+    __syncwarp();
+
+    // TMEM alloc (256 columns, 256 used)
+    volatile int* tmem_addr_storage = (volatile int*)(smem_raw + 88);
+    if (warp == 0) {
+        int _tmem_hold = smem + 88;
+        asm volatile("tcgen05.alloc.cta_group::1.sync.aligned.shared::cta.b32 [%0], %1;" :: "r"(_tmem_hold), "r"(256) : "memory");
+        asm volatile("tcgen05.relinquish_alloc_permit.cta_group::1.sync.aligned;");
+    }
+
+    __syncthreads();
+    asm volatile("tcgen05.fence::after_thread_sync;");
+
+    const int mbar_base = smem;
+    #define smem_free_addr (mbar_base + 0)
+    #define prep_ready_addr (mbar_base + 16)
+    #define dr_ready_addr (mbar_base + 32)
+    #define dr_inp_ready_addr (mbar_base + 40)
+    #define dx_ready_addr (mbar_base + 48)
+    #define de_inp_ready_addr (mbar_base + 56)
+    #define dh_ready_addr (mbar_base + 64)
+    #define owners_done_addr (mbar_base + 72)
+    #define work_item_ready_addr (mbar_base + 80)
+    const int taddr = tmem_addr_storage[0];
+
+    // Kernel post-init ops
+    const int tmem_tmem_dh = taddr + 64;
+    const int tmem_tmem_dh_inp = taddr;
+    const int tmem_tmem_do_initial = taddr + 224;
+    const int tmem_tmem_do_final = taddr;
+    const int tmem_tmem_dr = taddr + 192;
+    const int tmem_tmem_dr_inp = taddr + 192;
+    const int tmem_tmem_dx = taddr + 224;
+    const int tmem_tmem_de_inp = taddr + 224;
+
+    // ---- Role: state ----
+    if (warp <= 3) {
+        asm volatile("setmaxnreg.dec.sync.aligned.u32 80;");
+        { // state_main
+            int task_idx = blockIdx.x;
+            int seq_idx = 0;
+            int head_idx = 0;
+            int write_start = 0;
+            int write_end = 0;
+            {
+                int item_base = task_idx * 5;
+                seq_idx = work_items[item_base];
+                head_idx = work_items[item_base + 1];
+                write_start = work_items[item_base + 2];
+                write_end = work_items[item_base + 3];
+            }
+            long long bos = cu_seqlens[seq_idx];
+            long long eos = cu_seqlens[seq_idx + 1];
+            int seq_len = (int)(eos - bos);
+            int num_chunks = (seq_len + 32 - 1) / 32;
+            int warp_id_in_role = (warp - 0);
+            int state_row = warp_id_in_role * 32 + lane;
+            int compute_end = num_chunks;
+            int scan_chunks = num_chunks;
+            {
+                if (state_row == 0) {
+                    smem_work_item_compute_end[0] = num_chunks;
+                    smem_work_item_resolved[0] = 0;
+                }
+                asm volatile("barrier.sync 15, 128;" ::: "memory");
+                float suffix_log2 = 0.0f;
+                int _min_0 = ((num_chunks - write_end) < (32) ? (num_chunks - write_end) : (32));
+                int suffix_limit = _min_0;
+                float common_log2 = lower_bound * 1.4426950408889634f * 16.0f;
+                #pragma unroll 1
+                for (int suffix_chunks = 1; suffix_chunks < suffix_limit + 1; suffix_chunks++) {
+                    if (smem_work_item_resolved[0] == 0) {
+                        int suffix_chunk = write_end + suffix_chunks - 1;
+                        long long suffix_global = cu_chunk_offsets[seq_idx] + (long long)suffix_chunk;
+                        float suffix_restore = tape_restore_factor[(suffix_global * (long long)num_heads + (long long)head_idx) * 128 + (long long)state_row];
+                        float _log2_0;
+                        asm volatile("lg2.approx.ftz.f32 %0, %1;" : "=f"(_log2_0) : "f"(suffix_restore));
+                        suffix_log2 += _log2_0 + common_log2;
+                        float _warp_reduce_0 = suffix_log2;
+                        #pragma unroll
+                        for (int offset = 16; offset > 0; offset >>= 1)
+                            _warp_reduce_0 = max_noftz(_warp_reduce_0, __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset));
+                        float suffix_warp_max = _warp_reduce_0;
+                        if (lane == 0) {
+                            smem_work_item_warp_max[warp_id_in_role] = suffix_warp_max;
+                        }
+                        asm volatile("barrier.sync 15, 128;" ::: "memory");
+                        float suffix_block_max = ((lane < 4) ? smem_work_item_warp_max[lane] : -LOOM_INF);
+                        float _warp_reduce_1 = suffix_block_max;
+                        #pragma unroll
+                        for (int offset = 16; offset > 0; offset >>= 1)
+                            _warp_reduce_1 = max_noftz(_warp_reduce_1, __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_1, offset));
+                        suffix_block_max = _warp_reduce_1;
+                        if (state_row == 0 && suffix_block_max <= -30.0f) {
+                            smem_work_item_compute_end[0] = suffix_chunk + 1;
+                            smem_work_item_resolved[0] = 1;
+                        }
+                        asm volatile("barrier.sync 15, 128;" ::: "memory");
+                    }
+                }
+                compute_end = smem_work_item_compute_end[0];
+                if (warp_id_in_role == 0) {
+                    if (elect_sync()) {
+                        mbarrier_arrive(work_item_ready_addr);
+                    }
+                }
+                scan_chunks = compute_end - write_start;
+            }
+            int tmem_row_base = warp_id_in_role * 32 << 16;
+            long long state_base = (((long long)seq_idx * (long long)num_heads + (long long)head_idx) * 128 + (long long)state_row) * 128;
+            #pragma unroll
+            for (int state_block = 0; state_block < 4; state_block++) {
+                float state_values[32];
+                {
+                    state_values[0] = 0.0f;
+                    state_values[1] = 0.0f;
+                    state_values[2] = 0.0f;
+                    state_values[3] = 0.0f;
+                    state_values[4] = 0.0f;
+                    state_values[5] = 0.0f;
+                    state_values[6] = 0.0f;
+                    state_values[7] = 0.0f;
+                    state_values[8] = 0.0f;
+                    state_values[9] = 0.0f;
+                    state_values[10] = 0.0f;
+                    state_values[11] = 0.0f;
+                    state_values[12] = 0.0f;
+                    state_values[13] = 0.0f;
+                    state_values[14] = 0.0f;
+                    state_values[15] = 0.0f;
+                    state_values[16] = 0.0f;
+                    state_values[17] = 0.0f;
+                    state_values[18] = 0.0f;
+                    state_values[19] = 0.0f;
+                    state_values[20] = 0.0f;
+                    state_values[21] = 0.0f;
+                    state_values[22] = 0.0f;
+                    state_values[23] = 0.0f;
+                    state_values[24] = 0.0f;
+                    state_values[25] = 0.0f;
+                    state_values[26] = 0.0f;
+                    state_values[27] = 0.0f;
+                    state_values[28] = 0.0f;
+                    state_values[29] = 0.0f;
+                    state_values[30] = 0.0f;
+                    state_values[31] = 0.0f;
+                    if (compute_end == num_chunks) {
+                        #pragma unroll
+                        for (int state_vec = 0; state_vec < 4; state_vec++) {
+                            {
+                                unsigned _ldv8_0_0;
+                                unsigned _ldv8_0_1;
+                                unsigned _ldv8_0_2;
+                                unsigned _ldv8_0_3;
+                                unsigned _ldv8_0_4;
+                                unsigned _ldv8_0_5;
+                                unsigned _ldv8_0_6;
+                                unsigned _ldv8_0_7;
+                                asm volatile(
+                                    "ld.global.v8.b32 {%0, %1, %2, %3, %4, %5, %6, %7}, [%8];"
+                                    : "=r"(_ldv8_0_0), "=r"(_ldv8_0_1), "=r"(_ldv8_0_2), "=r"(_ldv8_0_3), "=r"(_ldv8_0_4), "=r"(_ldv8_0_5), "=r"(_ldv8_0_6), "=r"(_ldv8_0_7) : "l"((const void*)(dfinal_state + (state_base + (long long)(state_block * 32) + (long long)(state_vec * 8)))) : "memory");
+                                state_values[state_vec * 8 + 0] = __uint_as_float(_ldv8_0_0);
+                                state_values[state_vec * 8 + 1] = __uint_as_float(_ldv8_0_1);
+                                state_values[state_vec * 8 + 2] = __uint_as_float(_ldv8_0_2);
+                                state_values[state_vec * 8 + 3] = __uint_as_float(_ldv8_0_3);
+                                state_values[state_vec * 8 + 4] = __uint_as_float(_ldv8_0_4);
+                                state_values[state_vec * 8 + 5] = __uint_as_float(_ldv8_0_5);
+                                state_values[state_vec * 8 + 6] = __uint_as_float(_ldv8_0_6);
+                                state_values[state_vec * 8 + 7] = __uint_as_float(_ldv8_0_7);
+                            }
+                        }
+                    }
+                }
+                tmem_st_x32_f32(taddr + 64 + (unsigned int)tmem_row_base + (unsigned int)(state_block * 32), state_values);
+            }
+            asm volatile("tcgen05.wait::st.sync.aligned;" ::: "memory");
+            asm volatile("griddepcontrol.launch_dependents;" ::: "memory");
+            unsigned int state_stage = 0;
+            unsigned int issue_smem_stage = 0;
+            float _exp2_0 = approx_exp2(lower_bound * 1.4426950408889634f * 16.0f);
+            float common_factor = _exp2_0;
+            unsigned int _phase_prep_ready = 0;
+            unsigned int _phase_dr_inp_ready = 0;
+            unsigned int _phase_de_inp_ready = 0;
+            unsigned int _phase_dh_ready = 0;
+            #pragma unroll 1
+            for (int reverse_chunk = 0; reverse_chunk < scan_chunks; reverse_chunk++) {
+                int chunk_idx = compute_end - 1 - reverse_chunk;
+                int owned_chunk = 1;
+                {
+                    owned_chunk = (int)(chunk_idx < write_end);
+                }
+                long long chunk_global = cu_chunk_offsets[seq_idx] + (long long)chunk_idx;
+                long long chunk_dh_base = ((chunk_global * (long long)num_heads + (long long)head_idx) * 128 + (long long)state_row) * 128;
+                long long restore_base = (chunk_global * (long long)num_heads + (long long)head_idx) * 128;
+                #pragma unroll
+                for (int state_block2 = 0; state_block2 < 4; state_block2++) {
+                    float _tmem_load_0[32];
+                    tmem_ld_x32(&_tmem_load_0[0], taddr + 64 + (unsigned int)tmem_row_base + (unsigned int)(state_block2 * 32));
+                    asm volatile("tcgen05.wait::ld.sync.aligned;");
+                    if (reverse_chunk != 0) {
+                        const float2 _scale2_1 = {common_factor, common_factor};
+                        #pragma unroll
+                        for (int _ls = 0; _ls < 16; _ls++)
+                            mul_f32x2_inplace(&reinterpret_cast<float2*>(_tmem_load_0)[_ls], _scale2_1);
+                    }
+                    if (owned_chunk != 0) {
+                        #pragma unroll
+                        for (int dh_store_vec = 0; dh_store_vec < 4; dh_store_vec++) {
+                            {
+                                __nv_bfloat162 _pk[4];
+                                _pk[0] = __floats2bfloat162_rn(_tmem_load_0[dh_store_vec * 8 + 0], _tmem_load_0[dh_store_vec * 8 + 1]);
+                                _pk[1] = __floats2bfloat162_rn(_tmem_load_0[dh_store_vec * 8 + 2], _tmem_load_0[dh_store_vec * 8 + 3]);
+                                _pk[2] = __floats2bfloat162_rn(_tmem_load_0[dh_store_vec * 8 + 4], _tmem_load_0[dh_store_vec * 8 + 5]);
+                                _pk[3] = __floats2bfloat162_rn(_tmem_load_0[dh_store_vec * 8 + 6], _tmem_load_0[dh_store_vec * 8 + 7]);
+                                *reinterpret_cast<uint4*>(&((__nv_bfloat16*)(chunk_dh + (chunk_dh_base + (long long)(state_block2 * 32) + (long long)(dh_store_vec * 8))))[0]) = *reinterpret_cast<uint4*>(&_pk[0]);
+                            }
+                        }
+                    }
+                    uint32_t _tmem_load_0_bf16[16];
+                    #pragma unroll
+                    for (int _lp = 0; _lp < 16; _lp++) {
+                        __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(_tmem_load_0[_lp*2 + 0], _tmem_load_0[_lp*2+1 + 0]));
+                        _tmem_load_0_bf16[_lp] = *(uint32_t*)&_bf2;
+                    }
+                    asm volatile(
+                        "tcgen05.st.sync.aligned.32x32b.x16.b32"
+                        " [%0], {%1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15, %16};"
+                        :: "r"(taddr + (unsigned int)tmem_row_base + (unsigned int)(state_block2 * 16)), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0_bf16[0])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0_bf16[1])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0_bf16[2])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0_bf16[3])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0_bf16[4])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0_bf16[5])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0_bf16[6])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0_bf16[7])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0_bf16[8])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0_bf16[9])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0_bf16[10])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0_bf16[11])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0_bf16[12])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0_bf16[13])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0_bf16[14])), "r"(*reinterpret_cast<const uint32_t*>(&_tmem_load_0_bf16[15])));
+                    float restore_lane = tape_restore_factor[restore_base + (long long)(state_block2 * 32) + (long long)lane];
+                    #pragma unroll
+                    for (int restore_elem = 0; restore_elem < 32; restore_elem++) {
+                        float _shfl_0 = __shfl_sync(0xFFFFFFFF, restore_lane, restore_elem);
+                        _tmem_load_0[restore_elem] = _tmem_load_0[restore_elem] * _shfl_0;
+                    }
+                    tmem_st_x32_f32(taddr + 64 + (unsigned int)tmem_row_base + (unsigned int)(state_block2 * 32), _tmem_load_0);
+                }
+                asm volatile("tcgen05.wait::st.sync.aligned;" ::: "memory");
+                asm volatile("barrier.sync 9, 384;" ::: "memory");
+                if (warp_id_in_role == 0) {
+                    mbarrier_wait(prep_ready_addr + (issue_smem_stage) * 8, _phase_prep_ready);
+                    int _mma_b_lo_0 = make_warp_uniform((((smem_n_addr) >> 4) & 0x3FFF) + (issue_smem_stage) * 2304);
+                    asm volatile(
+                    "{\n\t"
+                    ".reg .pred leader, p0, p1;\n\t"
+                    ".reg .b32 dhi, blo, ta, id;\n\t"
+                    ".reg .b64 db;\n\t"
+                    "elect.sync _|leader, 0xFFFFFFFF;\n\t"
+                    "setp.ne.b32 p0, %3, 0;\n\t"
+                    "setp.ne.b32 p1, 1, 0;\n\t"
+                    ""
+                    "mov.b32 dhi, 0xC0004010;\n\t"
+                    "mov.b32 id, 134743184;\n\t"
+                    "mov.b32 ta, %2;\n\t"
+                    "mov.b32 blo, %1;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p0;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 64;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "}\n"
+                    :: "r"(tmem_tmem_dr), "r"(_mma_b_lo_0), "r"(tmem_tmem_do_initial), "r"(0));
+                    int _mma_b_lo_1 = make_warp_uniform((((smem_kr_addr) >> 4) & 0x3FFF) + (issue_smem_stage) * 2304);
+                    asm volatile(
+                    "{\n\t"
+                    ".reg .pred leader, p0, p1;\n\t"
+                    ".reg .b32 dhi, blo, ta, id;\n\t"
+                    ".reg .b64 db;\n\t"
+                    "elect.sync _|leader, 0xFFFFFFFF;\n\t"
+                    "setp.ne.b32 p0, %3, 0;\n\t"
+                    "setp.ne.b32 p1, 1, 0;\n\t"
+                    ""
+                    "mov.b32 dhi, 0x40004040;\n\t"
+                    "mov.b32 id, 134743184;\n\t"
+                    "mov.b32 ta, %2;\n\t"
+                    "mov.b32 blo, %1;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p0;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 250;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "}\n"
+                    :: "r"(tmem_tmem_dr), "r"(_mma_b_lo_1), "r"(tmem_tmem_dh_inp), "r"(1));
+                    elect_commit(dr_ready_addr + (state_stage) * 8);
+                    mbarrier_wait(dr_inp_ready_addr + (state_stage) * 8, _phase_dr_inp_ready);
+                    int _mma_b_lo_2 = make_warp_uniform(((((smem_j_trans_addr) >> 4) & 0x3FFF) | 0x400000) + (issue_smem_stage) * 2304);
+                    asm volatile(
+                    "{\n\t"
+                    ".reg .pred leader, p0, p1;\n\t"
+                    ".reg .b32 dhi, blo, ta, id;\n\t"
+                    ".reg .b64 db;\n\t"
+                    "elect.sync _|leader, 0xFFFFFFFF;\n\t"
+                    "setp.ne.b32 p0, %3, 0;\n\t"
+                    "setp.ne.b32 p1, 1, 0;\n\t"
+                    ""
+                    "mov.b32 dhi, 0xC0004010;\n\t"
+                    "mov.b32 id, 134808720;\n\t"
+                    "mov.b32 ta, %2;\n\t"
+                    "mov.b32 blo, %1;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p0;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 32;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "}\n"
+                    :: "r"(tmem_tmem_dx), "r"(_mma_b_lo_2), "r"(tmem_tmem_dr_inp), "r"(0));
+                    elect_commit(dx_ready_addr + (state_stage) * 8);
+                    mbarrier_wait(de_inp_ready_addr + (state_stage) * 8, _phase_de_inp_ready);
+                    int _mma_b_lo_3 = make_warp_uniform(((((smem_qd_trans_addr) >> 4) & 0x3FFF) | 0x1000000) + (issue_smem_stage) * 2304);
+                    asm volatile(
+                    "{\n\t"
+                    ".reg .pred leader, p0, p1;\n\t"
+                    ".reg .b32 dhi, blo, ta, id;\n\t"
+                    ".reg .b64 db;\n\t"
+                    "elect.sync _|leader, 0xFFFFFFFF;\n\t"
+                    "setp.ne.b32 p0, %3, 0;\n\t"
+                    "setp.ne.b32 p1, 1, 0;\n\t"
+                    ""
+                    "mov.b32 dhi, 0x40004040;\n\t"
+                    "mov.b32 id, 136381584;\n\t"
+                    "mov.b32 ta, %2;\n\t"
+                    "mov.b32 blo, %1;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p0;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 128;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "}\n"
+                    :: "r"(tmem_tmem_dh), "r"(_mma_b_lo_3), "r"(tmem_tmem_do_final), "r"(1));
+                    int _mma_b_lo_4 = make_warp_uniform(((((smem_kd_trans_addr) >> 4) & 0x3FFF) | 0x1000000) + (issue_smem_stage) * 2304);
+                    asm volatile(
+                    "{\n\t"
+                    ".reg .pred leader, p0, p1;\n\t"
+                    ".reg .b32 dhi, blo, ta, id;\n\t"
+                    ".reg .b64 db;\n\t"
+                    "elect.sync _|leader, 0xFFFFFFFF;\n\t"
+                    "setp.ne.b32 p0, %3, 0;\n\t"
+                    "setp.ne.b32 p1, 1, 0;\n\t"
+                    ""
+                    "mov.b32 dhi, 0x40004040;\n\t"
+                    "mov.b32 id, 136381584;\n\t"
+                    "mov.b32 ta, %2;\n\t"
+                    "mov.b32 blo, %1;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p0;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 128;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "}\n"
+                    :: "r"(tmem_tmem_dh), "r"(_mma_b_lo_4), "r"(tmem_tmem_de_inp), "r"(1));
+                    elect_commit2(dh_ready_addr + (state_stage) * 8, smem_free_addr + (issue_smem_stage) * 8);
+                    issue_smem_stage += 1;
+                    if (issue_smem_stage == 2) { issue_smem_stage = 0; _phase_prep_ready ^= 1; }
+                }
+                if (publish_ready != 0 && owned_chunk != 0) {
+                    asm volatile("barrier.sync 12, 128;" ::: "memory");
+                    if (warp_id_in_role == 0) {
+                        if (elect_sync()) {
+                            {
+                                unsigned int* _gc_p = reinterpret_cast<unsigned int*>(boundary_ready) + (chunk_global * (long long)num_heads + (long long)head_idx);
+                                unsigned int _gc_old;
+                                asm volatile("atom.release.gpu.global.add.u32 %0, [%1], 1;" : "=r"(_gc_old) : "l"(_gc_p) : "memory");
+                            }
+                        }
+                    }
+                }
+                mbarrier_wait(dh_ready_addr + (state_stage) * 8, _phase_dh_ready);
+                state_stage += 1;
+                if (state_stage == 1) { state_stage = 0; _phase_dr_inp_ready ^= 1; _phase_de_inp_ready ^= 1; _phase_dh_ready ^= 1; }
+            }
+            if (write_start == 0) {
+                #pragma unroll
+                for (int final_block = 0; final_block < 4; final_block++) {
+                    float _tmem_load_1[32];
+                    tmem_ld_x32(&_tmem_load_1[0], taddr + 64 + (unsigned int)tmem_row_base + (unsigned int)(final_block * 32));
+                    asm volatile("tcgen05.wait::ld.sync.aligned;");
+                    const float2 _scale2_2 = {common_factor, common_factor};
+                    #pragma unroll
+                    for (int _ls = 0; _ls < 16; _ls++)
+                        mul_f32x2_inplace(&reinterpret_cast<float2*>(_tmem_load_1)[_ls], _scale2_2);
+                    #pragma unroll
+                    for (int final_vec = 0; final_vec < 4; final_vec++) {
+                        {
+                            unsigned _stv8_3_0 = __float_as_uint(_tmem_load_1[final_vec * 8 + 0]);
+                            unsigned _stv8_3_1 = __float_as_uint(_tmem_load_1[final_vec * 8 + 1]);
+                            unsigned _stv8_3_2 = __float_as_uint(_tmem_load_1[final_vec * 8 + 2]);
+                            unsigned _stv8_3_3 = __float_as_uint(_tmem_load_1[final_vec * 8 + 3]);
+                            unsigned _stv8_3_4 = __float_as_uint(_tmem_load_1[final_vec * 8 + 4]);
+                            unsigned _stv8_3_5 = __float_as_uint(_tmem_load_1[final_vec * 8 + 5]);
+                            unsigned _stv8_3_6 = __float_as_uint(_tmem_load_1[final_vec * 8 + 6]);
+                            unsigned _stv8_3_7 = __float_as_uint(_tmem_load_1[final_vec * 8 + 7]);
+                            asm volatile(
+                                "st.global.v8.b32 [%0], {%1, %2, %3, %4, %5, %6, %7, %8};"
+                                :: "l"((void*)(dinitial_state + (state_base + (long long)(final_block * 32) + (long long)(final_vec * 8)) + (0))), "r"(_stv8_3_0), "r"(_stv8_3_1), "r"(_stv8_3_2), "r"(_stv8_3_3), "r"(_stv8_3_4), "r"(_stv8_3_5), "r"(_stv8_3_6), "r"(_stv8_3_7) : "memory");
+                        }
+                    }
+                }
+            }
+            if (elect_sync()) {
+                mbarrier_arrive(owners_done_addr);
+            }
+        }
+    }
+    // ---- Role: prep ----
+    if (warp >= 4 && warp <= 7) {
+        asm volatile("setmaxnreg.dec.sync.aligned.u32 80;");
+        { // prep_main
+            int task_idx_1 = blockIdx.x;
+            int seq_idx_1 = 0;
+            int head_idx_1 = 0;
+            int write_start_1 = 0;
+            {
+                int item_base_1 = task_idx_1 * 5;
+                seq_idx_1 = work_items[item_base_1];
+                head_idx_1 = work_items[item_base_1 + 1];
+                write_start_1 = work_items[item_base_1 + 2];
+            }
+            long long bos_1 = cu_seqlens[seq_idx_1];
+            long long eos_1 = cu_seqlens[seq_idx_1 + 1];
+            int seq_len_1 = (int)(eos_1 - bos_1);
+            int compute_end_1 = 0;
+            int scan_chunks_1 = 0;
+            unsigned int _phase_work_item_ready_0 = 0;
+            {
+                mbarrier_wait(work_item_ready_addr, _phase_work_item_ready_0);
+                _phase_work_item_ready_0 ^= 1;
+                compute_end_1 = smem_work_item_compute_end[0];
+                scan_chunks_1 = compute_end_1 - write_start_1;
+            }
+            int warp_id_in_role_1 = (warp - 4);
+            int prep_tid = warp_id_in_role_1 * 32 + lane;
+            int prep_local_warp = warp_id_in_role_1;
+            unsigned int prep_stage = 0;
+            unsigned int _phase_smem_free = 1;
+            #pragma unroll 1
+            for (int reverse_chunk_1 = 0; reverse_chunk_1 < scan_chunks_1; reverse_chunk_1++) {
+                mbarrier_wait(smem_free_addr + (prep_stage) * 8, _phase_smem_free);
+                int chunk_idx_1 = compute_end_1 - 1 - reverse_chunk_1;
+                long long chunk_global_1 = cu_chunk_offsets[seq_idx_1] + (long long)chunk_idx_1;
+                long long tape_vec_base = (chunk_global_1 * (long long)num_heads + (long long)head_idx_1) * 32 * 128;
+                long long restore_base_1 = (chunk_global_1 * (long long)num_heads + (long long)head_idx_1) * 128;
+                #pragma unroll
+                for (int load_pass = 0; load_pass < 4; load_pass++) {
+                    int item = load_pass * 128 + prep_tid;
+                    int row = item / 16;
+                    int segment = item % 16;
+                    long long index = tape_vec_base + (long long)row * 128 + (long long)(segment * 8);
+                    float qd_values[8];
+                    float kd_values[8];
+                    float kr_values[8];
+                    float ki_values[8];
+                    {
+                        const uint4* _vptr_0 = reinterpret_cast<const uint4*>(tape_qd + index);
+                        uint4 _vld_0[1];
+                        #pragma unroll
+                        for (int _blk = 0; _blk < 1; _blk++) {
+                            _vld_0[_blk] = _vptr_0[_blk];
+                            uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
+                            #pragma unroll
+                            for (int _pair = 0; _pair < 4; _pair++) {
+                                asm volatile(
+                                    "{\n\t"
+                                    "shl.b32 %0, %2, 16;\n\t"
+                                    "and.b32 %1, %2, 0xffff0000;\n\t"
+                                    "}\n"
+                                    : "=f"((&qd_values[0 + _blk * 8 + _pair * 2])[0]), "=f"((&qd_values[0 + _blk * 8 + _pair * 2])[1])
+                                    : "r"(_vpairs_0[_pair]));
+                            }
+                        }
+                    }
+                    {
+                        const uint4* _vptr_1 = reinterpret_cast<const uint4*>(tape_kd + index);
+                        uint4 _vld_1[1];
+                        #pragma unroll
+                        for (int _blk = 0; _blk < 1; _blk++) {
+                            _vld_1[_blk] = _vptr_1[_blk];
+                            uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
+                            #pragma unroll
+                            for (int _pair = 0; _pair < 4; _pair++) {
+                                asm volatile(
+                                    "{\n\t"
+                                    "shl.b32 %0, %2, 16;\n\t"
+                                    "and.b32 %1, %2, 0xffff0000;\n\t"
+                                    "}\n"
+                                    : "=f"((&kd_values[0 + _blk * 8 + _pair * 2])[0]), "=f"((&kd_values[0 + _blk * 8 + _pair * 2])[1])
+                                    : "r"(_vpairs_1[_pair]));
+                            }
+                        }
+                    }
+                    {
+                        const uint4* _vptr_2 = reinterpret_cast<const uint4*>(tape_kr + index);
+                        uint4 _vld_2[1];
+                        #pragma unroll
+                        for (int _blk = 0; _blk < 1; _blk++) {
+                            _vld_2[_blk] = _vptr_2[_blk];
+                            uint32_t* _vpairs_2 = reinterpret_cast<uint32_t*>(&_vld_2[_blk]);
+                            #pragma unroll
+                            for (int _pair = 0; _pair < 4; _pair++) {
+                                asm volatile(
+                                    "{\n\t"
+                                    "shl.b32 %0, %2, 16;\n\t"
+                                    "and.b32 %1, %2, 0xffff0000;\n\t"
+                                    "}\n"
+                                    : "=f"((&kr_values[0 + _blk * 8 + _pair * 2])[0]), "=f"((&kr_values[0 + _blk * 8 + _pair * 2])[1])
+                                    : "r"(_vpairs_2[_pair]));
+                            }
+                        }
+                    }
+                    #pragma unroll
+                    for (int elem = 0; elem < 8; elem++) {
+                        float factor = tape_restore_factor[restore_base_1 + (long long)(segment * 8) + (long long)elem];
+                        ki_values[elem] = kr_values[elem] / factor;
+                    }
+                    unsigned int packed[4];
+                    #pragma unroll
+                    for (int _lp = 0; _lp < 4; _lp++) {
+                        __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(qd_values[_lp*2 + 0], qd_values[_lp*2+1 + 0]));
+                        packed[_lp] = *(uint32_t*)&_bf2;
+                    }
+                    #pragma unroll
+                    for (int word = 0; word < 4; word++) {
+                        asm volatile("st.shared.b32 [%0], %1;" :: "r"((smem_qd_addr + prep_stage * 36864 + (unsigned int)(segment * 8 / 64 * 4096 + row * 128 + segment * 8 % 64 * 2 ^ (segment * 8 / 64 * 4096 + row * 128 + segment * 8 % 64 * 2 >> 7 & 7) << 4)) + (unsigned int)(word * 4)), "r"((packed[word])));
+                    }
+                    unsigned int packed_0[4];
+                    #pragma unroll
+                    for (int _lp = 0; _lp < 4; _lp++) {
+                        __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(kd_values[_lp*2 + 0], kd_values[_lp*2+1 + 0]));
+                        packed_0[_lp] = *(uint32_t*)&_bf2;
+                    }
+                    #pragma unroll
+                    for (int word_1 = 0; word_1 < 4; word_1++) {
+                        asm volatile("st.shared.b32 [%0], %1;" :: "r"((smem_kd_addr + prep_stage * 36864 + (unsigned int)(segment * 8 / 64 * 4096 + row * 128 + segment * 8 % 64 * 2 ^ (segment * 8 / 64 * 4096 + row * 128 + segment * 8 % 64 * 2 >> 7 & 7) << 4)) + (unsigned int)(word_1 * 4)), "r"((packed_0[word_1])));
+                    }
+                    unsigned int packed_1[4];
+                    #pragma unroll
+                    for (int _lp = 0; _lp < 4; _lp++) {
+                        __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(kr_values[_lp*2 + 0], kr_values[_lp*2+1 + 0]));
+                        packed_1[_lp] = *(uint32_t*)&_bf2;
+                    }
+                    #pragma unroll
+                    for (int word_2 = 0; word_2 < 4; word_2++) {
+                        asm volatile("st.shared.b32 [%0], %1;" :: "r"((smem_kr_addr + prep_stage * 36864 + (unsigned int)(segment * 8 / 64 * 4096 + row * 128 + segment * 8 % 64 * 2 ^ (segment * 8 / 64 * 4096 + row * 128 + segment * 8 % 64 * 2 >> 7 & 7) << 4)) + (unsigned int)(word_2 * 4)), "r"((packed_1[word_2])));
+                    }
+                    unsigned int packed_2[4];
+                    #pragma unroll
+                    for (int _lp = 0; _lp < 4; _lp++) {
+                        __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(ki_values[_lp*2 + 0], ki_values[_lp*2+1 + 0]));
+                        packed_2[_lp] = *(uint32_t*)&_bf2;
+                    }
+                    #pragma unroll
+                    for (int word_3 = 0; word_3 < 4; word_3++) {
+                        asm volatile("st.shared.b32 [%0], %1;" :: "r"((smem_ki_addr + prep_stage * 36864 + (unsigned int)(segment * 8 / 64 * 4096 + row * 128 + segment * 8 % 64 * 2 ^ (segment * 8 / 64 * 4096 + row * 128 + segment * 8 % 64 * 2 >> 7 & 7) << 4)) + (unsigned int)(word_3 * 4)), "r"((packed_2[word_3])));
+                    }
+                }
+                int j_row = prep_tid / 4;
+                int j_segment = prep_tid % 4;
+                float j_values[8];
+                long long j_base = (chunk_global_1 * (long long)num_heads + (long long)head_idx_1) * 32 * 32;
+                {
+                    const uint4* _vptr_3 = reinterpret_cast<const uint4*>(tape_j + j_base + (long long)j_row * 32 + (long long)(j_segment * 8));
+                    uint4 _vld_3[1];
+                    #pragma unroll
+                    for (int _blk = 0; _blk < 1; _blk++) {
+                        _vld_3[_blk] = _vptr_3[_blk];
+                        uint32_t* _vpairs_3 = reinterpret_cast<uint32_t*>(&_vld_3[_blk]);
+                        #pragma unroll
+                        for (int _pair = 0; _pair < 4; _pair++) {
+                            asm volatile(
+                                "{\n\t"
+                                "shl.b32 %0, %2, 16;\n\t"
+                                "and.b32 %1, %2, 0xffff0000;\n\t"
+                                "}\n"
+                                : "=f"((&j_values[0 + _blk * 8 + _pair * 2])[0]), "=f"((&j_values[0 + _blk * 8 + _pair * 2])[1])
+                                : "r"(_vpairs_3[_pair]));
+                        }
+                    }
+                }
+                unsigned int packed_3[4];
+                #pragma unroll
+                for (int _lp = 0; _lp < 4; _lp++) {
+                    __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(j_values[_lp*2 + 0], j_values[_lp*2+1 + 0]));
+                    packed_3[_lp] = *(uint32_t*)&_bf2;
+                }
+                #pragma unroll
+                for (int word_4 = 0; word_4 < 4; word_4++) {
+                    asm volatile("st.shared.b32 [%0], %1;" :: "r"((smem_j_addr + prep_stage * 36864 + (unsigned int)(j_segment * 8 / 16 * 1024 + j_row * 32 + j_segment * 8 % 16 * 2 ^ (j_segment * 8 / 16 * 1024 + j_row * 32 + j_segment * 8 % 16 * 2 >> 7 & 1) << 4)) + (unsigned int)(word_4 * 4)), "r"((packed_3[word_4])));
+                }
+                asm volatile("fence.proxy.async.shared::cta;" ::: "memory");
+                asm volatile("barrier.sync 8, 128;" ::: "memory");
+                int row_base = prep_local_warp / 2 * 16;
+                int col_base = prep_local_warp % 2 * 16;
+                unsigned int a_frag[4];
+                unsigned int b_frag[4];
+                float acc[8];
+                if (row_base <= col_base) {
+                    asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                        : "=r"(a_frag[0]), "=r"(a_frag[1]), "=r"(a_frag[2]), "=r"(a_frag[3])
+                        : "r"(smem_ki_addr + prep_stage * 36864 + (unsigned int)((lane / 16 / 8 * 256 + (row_base + lane % 16) * 8 + (lane / 16 % 8 * 16 ^ (row_base + lane % 16 & 7) << 4) / 16) * 16))
+                        : "memory");
+                    asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                        : "=r"(b_frag[0]), "=r"(b_frag[1]), "=r"(b_frag[2]), "=r"(b_frag[3])
+                        : "r"(smem_qd_addr + prep_stage * 36864 + (unsigned int)((lane % 16 / 8 / 8 * 256 + (col_base + 8 * (lane / 16) + lane % 8) * 8 + (lane % 16 / 8 % 8 * 16 ^ (col_base + 8 * (lane / 16) + lane % 8 & 7) << 4) / 16) * 16))
+                        : "memory");
+                    asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%10, %11, %12, %13};\n"
+                        : "=f"(acc[0]), "=f"(acc[1]), "=f"(acc[2]), "=f"(acc[3])
+                        : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[0]), "r"(b_frag[1]), "f"(0.0f), "f"(0.0f), "f"(0.0f), "f"(0.0f));
+                    asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%10, %11, %12, %13};\n"
+                        : "=f"(acc[4]), "=f"(acc[(4) + 1]), "=f"(acc[(4) + 2]), "=f"(acc[(4) + 3])
+                        : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[2]), "r"(b_frag[(2) + 1]), "f"(0.0f), "f"(0.0f), "f"(0.0f), "f"(0.0f));
+                    asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                        : "=r"(a_frag[0]), "=r"(a_frag[1]), "=r"(a_frag[2]), "=r"(a_frag[3])
+                        : "r"(smem_ki_addr + prep_stage * 36864 + (unsigned int)((lane / 16 / 8 * 256 + (row_base + lane % 16) * 8 + (lane / 16 % 8 * 16 ^ (row_base + lane % 16 & 7) << 4) / 16 ^ 2) * 16))
+                        : "memory");
+                    asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                        : "=r"(b_frag[0]), "=r"(b_frag[1]), "=r"(b_frag[2]), "=r"(b_frag[3])
+                        : "r"(smem_qd_addr + prep_stage * 36864 + (unsigned int)(((lane % 16 / 8 / 8 * 256 + (col_base + 8 * (lane / 16) + lane % 8) * 8 + (lane % 16 / 8 % 8 * 16 ^ (col_base + 8 * (lane / 16) + lane % 8 & 7) << 4) / 16 + 256 ^ 2) - 256) * 16))
+                        : "memory");
+                    asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                        : "+f"(acc[0]), "+f"(acc[1]), "+f"(acc[2]), "+f"(acc[3])
+                        : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[0]), "r"(b_frag[1]));
+                    asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                        : "+f"(acc[4]), "+f"(acc[(4) + 1]), "+f"(acc[(4) + 2]), "+f"(acc[(4) + 3])
+                        : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[2]), "r"(b_frag[(2) + 1]));
+                    asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                        : "=r"(a_frag[0]), "=r"(a_frag[1]), "=r"(a_frag[2]), "=r"(a_frag[3])
+                        : "r"(smem_ki_addr + prep_stage * 36864 + (unsigned int)((lane / 16 / 8 * 256 + (row_base + lane % 16) * 8 + (lane / 16 % 8 * 16 ^ (row_base + lane % 16 & 7) << 4) / 16 ^ 2 ^ 6) * 16))
+                        : "memory");
+                    asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                        : "=r"(b_frag[0]), "=r"(b_frag[1]), "=r"(b_frag[2]), "=r"(b_frag[3])
+                        : "r"(smem_qd_addr + prep_stage * 36864 + (unsigned int)((((lane % 16 / 8 / 8 * 256 + (col_base + 8 * (lane / 16) + lane % 8) * 8 + (lane % 16 / 8 % 8 * 16 ^ (col_base + 8 * (lane / 16) + lane % 8 & 7) << 4) / 16 + 256 ^ 2) - 256 + 256 ^ 6) - 256) * 16))
+                        : "memory");
+                    asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                        : "+f"(acc[0]), "+f"(acc[1]), "+f"(acc[2]), "+f"(acc[3])
+                        : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[0]), "r"(b_frag[1]));
+                    asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                        : "+f"(acc[4]), "+f"(acc[(4) + 1]), "+f"(acc[(4) + 2]), "+f"(acc[(4) + 3])
+                        : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[2]), "r"(b_frag[(2) + 1]));
+                    asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                        : "=r"(a_frag[0]), "=r"(a_frag[1]), "=r"(a_frag[2]), "=r"(a_frag[3])
+                        : "r"(smem_ki_addr + prep_stage * 36864 + (unsigned int)((lane / 16 / 8 * 256 + (row_base + lane % 16) * 8 + (lane / 16 % 8 * 16 ^ (row_base + lane % 16 & 7) << 4) / 16 ^ 2 ^ 6 ^ 2) * 16))
+                        : "memory");
+                    asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                        : "=r"(b_frag[0]), "=r"(b_frag[1]), "=r"(b_frag[2]), "=r"(b_frag[3])
+                        : "r"(smem_qd_addr + prep_stage * 36864 + (unsigned int)(((((lane % 16 / 8 / 8 * 256 + (col_base + 8 * (lane / 16) + lane % 8) * 8 + (lane % 16 / 8 % 8 * 16 ^ (col_base + 8 * (lane / 16) + lane % 8 & 7) << 4) / 16 + 256 ^ 2) - 256 + 256 ^ 6) - 256 + 256 ^ 2) - 256) * 16))
+                        : "memory");
+                    asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                        : "+f"(acc[0]), "+f"(acc[1]), "+f"(acc[2]), "+f"(acc[3])
+                        : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[0]), "r"(b_frag[1]));
+                    asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                        : "+f"(acc[4]), "+f"(acc[(4) + 1]), "+f"(acc[(4) + 2]), "+f"(acc[(4) + 3])
+                        : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[2]), "r"(b_frag[(2) + 1]));
+                    asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                        : "=r"(a_frag[0]), "=r"(a_frag[1]), "=r"(a_frag[2]), "=r"(a_frag[3])
+                        : "r"(smem_ki_addr + prep_stage * 36864 + (unsigned int)(((lane / 16 / 8 * 256 + (row_base + lane % 16) * 8 + (lane / 16 % 8 * 16 ^ (row_base + lane % 16 & 7) << 4) / 16 ^ 2 ^ 6 ^ 2 ^ 6) + 256) * 16))
+                        : "memory");
+                    asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                        : "=r"(b_frag[0]), "=r"(b_frag[1]), "=r"(b_frag[2]), "=r"(b_frag[3])
+                        : "r"(smem_qd_addr + prep_stage * 36864 + (unsigned int)((((((lane % 16 / 8 / 8 * 256 + (col_base + 8 * (lane / 16) + lane % 8) * 8 + (lane % 16 / 8 % 8 * 16 ^ (col_base + 8 * (lane / 16) + lane % 8 & 7) << 4) / 16 + 256 ^ 2) - 256 + 256 ^ 6) - 256 + 256 ^ 2) - 256 + 256 ^ 6) + 256 - 256) * 16))
+                        : "memory");
+                    asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                        : "+f"(acc[0]), "+f"(acc[1]), "+f"(acc[2]), "+f"(acc[3])
+                        : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[0]), "r"(b_frag[1]));
+                    asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                        : "+f"(acc[4]), "+f"(acc[(4) + 1]), "+f"(acc[(4) + 2]), "+f"(acc[(4) + 3])
+                        : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[2]), "r"(b_frag[(2) + 1]));
+                    asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                        : "=r"(a_frag[0]), "=r"(a_frag[1]), "=r"(a_frag[2]), "=r"(a_frag[3])
+                        : "r"(smem_ki_addr + prep_stage * 36864 + (unsigned int)(((lane / 16 / 8 * 256 + (row_base + lane % 16) * 8 + (lane / 16 % 8 * 16 ^ (row_base + lane % 16 & 7) << 4) / 16 ^ 2 ^ 6 ^ 2 ^ 6) + 256 ^ 2) * 16))
+                        : "memory");
+                    asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                        : "=r"(b_frag[0]), "=r"(b_frag[1]), "=r"(b_frag[2]), "=r"(b_frag[3])
+                        : "r"(smem_qd_addr + prep_stage * 36864 + (unsigned int)(((((((lane % 16 / 8 / 8 * 256 + (col_base + 8 * (lane / 16) + lane % 8) * 8 + (lane % 16 / 8 % 8 * 16 ^ (col_base + 8 * (lane / 16) + lane % 8 & 7) << 4) / 16 + 256 ^ 2) - 256 + 256 ^ 6) - 256 + 256 ^ 2) - 256 + 256 ^ 6) + 256 - 256 + 256 ^ 2) - 256) * 16))
+                        : "memory");
+                    asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                        : "+f"(acc[0]), "+f"(acc[1]), "+f"(acc[2]), "+f"(acc[3])
+                        : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[0]), "r"(b_frag[1]));
+                    asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                        : "+f"(acc[4]), "+f"(acc[(4) + 1]), "+f"(acc[(4) + 2]), "+f"(acc[(4) + 3])
+                        : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[2]), "r"(b_frag[(2) + 1]));
+                    asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                        : "=r"(a_frag[0]), "=r"(a_frag[1]), "=r"(a_frag[2]), "=r"(a_frag[3])
+                        : "r"(smem_ki_addr + prep_stage * 36864 + (unsigned int)(((lane / 16 / 8 * 256 + (row_base + lane % 16) * 8 + (lane / 16 % 8 * 16 ^ (row_base + lane % 16 & 7) << 4) / 16 ^ 2 ^ 6 ^ 2 ^ 6) + 256 ^ 2 ^ 6) * 16))
+                        : "memory");
+                    asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                        : "=r"(b_frag[0]), "=r"(b_frag[1]), "=r"(b_frag[2]), "=r"(b_frag[3])
+                        : "r"(smem_qd_addr + prep_stage * 36864 + (unsigned int)((((((((lane % 16 / 8 / 8 * 256 + (col_base + 8 * (lane / 16) + lane % 8) * 8 + (lane % 16 / 8 % 8 * 16 ^ (col_base + 8 * (lane / 16) + lane % 8 & 7) << 4) / 16 + 256 ^ 2) - 256 + 256 ^ 6) - 256 + 256 ^ 2) - 256 + 256 ^ 6) + 256 - 256 + 256 ^ 2) - 256 + 256 ^ 6) - 256) * 16))
+                        : "memory");
+                    asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                        : "+f"(acc[0]), "+f"(acc[1]), "+f"(acc[2]), "+f"(acc[3])
+                        : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[0]), "r"(b_frag[1]));
+                    asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                        : "+f"(acc[4]), "+f"(acc[(4) + 1]), "+f"(acc[(4) + 2]), "+f"(acc[(4) + 3])
+                        : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[2]), "r"(b_frag[(2) + 1]));
+                    asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                        : "=r"(a_frag[0]), "=r"(a_frag[1]), "=r"(a_frag[2]), "=r"(a_frag[3])
+                        : "r"(smem_ki_addr + prep_stage * 36864 + (unsigned int)(((lane / 16 / 8 * 256 + (row_base + lane % 16) * 8 + (lane / 16 % 8 * 16 ^ (row_base + lane % 16 & 7) << 4) / 16 ^ 2 ^ 6 ^ 2 ^ 6) + 256 ^ 2 ^ 6 ^ 2) * 16))
+                        : "memory");
+                    asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                        : "=r"(b_frag[0]), "=r"(b_frag[1]), "=r"(b_frag[2]), "=r"(b_frag[3])
+                        : "r"(smem_qd_addr + prep_stage * 36864 + (unsigned int)(((((((((lane % 16 / 8 / 8 * 256 + (col_base + 8 * (lane / 16) + lane % 8) * 8 + (lane % 16 / 8 % 8 * 16 ^ (col_base + 8 * (lane / 16) + lane % 8 & 7) << 4) / 16 + 256 ^ 2) - 256 + 256 ^ 6) - 256 + 256 ^ 2) - 256 + 256 ^ 6) + 256 - 256 + 256 ^ 2) - 256 + 256 ^ 6) - 256 + 256 ^ 2) - 256) * 16))
+                        : "memory");
+                    asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                        : "+f"(acc[0]), "+f"(acc[1]), "+f"(acc[2]), "+f"(acc[3])
+                        : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[0]), "r"(b_frag[1]));
+                    asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                        : "+f"(acc[4]), "+f"(acc[(4) + 1]), "+f"(acc[(4) + 2]), "+f"(acc[(4) + 3])
+                        : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[2]), "r"(b_frag[(2) + 1]));
+                } else {
+                    acc[0] = 0.0f;
+                    acc[1] = 0.0f;
+                    acc[2] = 0.0f;
+                    acc[3] = 0.0f;
+                    acc[4] = 0.0f;
+                    acc[5] = 0.0f;
+                    acc[6] = 0.0f;
+                    acc[7] = 0.0f;
+                }
+                int row0 = row_base + lane / 4;
+                int row1 = row0 + 8;
+                int col0 = col_base + lane % 4 * 2;
+                float values[8];
+                values[0] = 0.0f;
+                values[1] = 0.0f;
+                values[2] = 0.0f;
+                values[3] = 0.0f;
+                values[4] = 0.0f;
+                values[5] = 0.0f;
+                values[6] = 0.0f;
+                values[7] = 0.0f;
+                if (row0 <= col0) {
+                    values[0] = acc[0];
+                }
+                if (row0 <= col0 + 1) {
+                    values[1] = acc[1];
+                }
+                if (row1 <= col0) {
+                    values[2] = acc[2];
+                }
+                if (row1 <= col0 + 1) {
+                    values[3] = acc[3];
+                }
+                if (row0 <= col0 + 8) {
+                    values[4] = acc[4];
+                }
+                if (row0 <= col0 + 9) {
+                    values[5] = acc[5];
+                }
+                if (row1 <= col0 + 8) {
+                    values[6] = acc[6];
+                }
+                if (row1 <= col0 + 9) {
+                    values[7] = acc[7];
+                }
+                unsigned int packed_0_1[4];
+                #pragma unroll
+                for (int _lp = 0; _lp < 4; _lp++) {
+                    __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(values[_lp*2 + 0], values[_lp*2+1 + 0]));
+                    packed_0_1[_lp] = *(uint32_t*)&_bf2;
+                }
+                int lane_row = lane % 16;
+                int lane_col = lane / 16 * 8;
+                uint32_t _stmatrix_addr_4 = static_cast<uint32_t>((unsigned long long)(smem_n_addr + prep_stage * 36864 + (unsigned int)((col_base + lane_col) / 16 * 1024 + (row_base + lane_row) * 32 + (col_base + lane_col) % 16 * 2 ^ ((col_base + lane_col) / 16 * 1024 + (row_base + lane_row) * 32 + (col_base + lane_col) % 16 * 2 >> 7 & 1) << 4)));
+                asm volatile("stmatrix.sync.aligned.m8n8.x4.shared.b16 [%0], {%1, %2, %3, %4};\n"
+                    :: "r"(_stmatrix_addr_4), "r"(*reinterpret_cast<const uint32_t*>(&packed_0_1[0])), "r"(*reinterpret_cast<const uint32_t*>(&packed_0_1[1])), "r"(*reinterpret_cast<const uint32_t*>(&packed_0_1[2])), "r"(*reinterpret_cast<const uint32_t*>(&packed_0_1[3]))
+                    : "memory");
+                asm volatile("fence.proxy.async.shared::cta;" ::: "memory");
+                asm volatile("barrier.sync 8, 128;" ::: "memory");
+                if (prep_local_warp == 2) {
+                    if (elect_sync()) {
+                        mbarrier_arrive(prep_ready_addr + (prep_stage) * 8);
+                    }
+                }
+                prep_stage += 1;
+                if (prep_stage == 2) { prep_stage = 0; _phase_smem_free ^= 1; }
+            }
+            unsigned int _phase_owners_done_0 = 0;
+            if (prep_local_warp == 2) {
+                mbarrier_wait(owners_done_addr, _phase_owners_done_0);
+                _phase_owners_done_0 ^= 1;
+                int _tmem_dealloc_addr = *((volatile int*)tmem_addr_storage);
+                asm volatile("tcgen05.dealloc.cta_group::1.sync.aligned.b32 %0, %1;" :: "r"(_tmem_dealloc_addr), "r"(256));
+            }
+        }
+    }
+    // ---- Role: high_token ----
+    if (warp >= 8 && warp <= 11) {
+        asm volatile("setmaxnreg.dec.sync.aligned.u32 80;");
+        { // high_token_main
+            int task_idx_2 = blockIdx.x;
+            int seq_idx_2 = 0;
+            int head_idx_2 = 0;
+            int write_start_2 = 0;
+            int write_end_1 = 0;
+            {
+                int item_base_2 = task_idx_2 * 5;
+                seq_idx_2 = work_items[item_base_2];
+                head_idx_2 = work_items[item_base_2 + 1];
+                write_start_2 = work_items[item_base_2 + 2];
+                write_end_1 = work_items[item_base_2 + 3];
+            }
+            long long bos_2 = cu_seqlens[seq_idx_2];
+            long long eos_2 = cu_seqlens[seq_idx_2 + 1];
+            int seq_len_2 = (int)(eos_2 - bos_2);
+            int compute_end_2 = 0;
+            int scan_chunks_2 = 0;
+            unsigned int _phase_work_item_ready_0_1 = 0;
+            {
+                mbarrier_wait(work_item_ready_addr, _phase_work_item_ready_0_1);
+                _phase_work_item_ready_0_1 ^= 1;
+                compute_end_2 = smem_work_item_compute_end[0];
+                scan_chunks_2 = compute_end_2 - write_start_2;
+            }
+            const int token_offset = 16;
+            unsigned int token_stage = 0;
+            unsigned int _phase_dr_ready = 0;
+            unsigned int _phase_dx_ready = 0;
+            unsigned int _phase_dh_ready_1 = 0;
+            #pragma unroll 1
+            for (int reverse_chunk_2 = 0; reverse_chunk_2 < scan_chunks_2; reverse_chunk_2++) {
+                int chunk_idx_2 = compute_end_2 - 1 - reverse_chunk_2;
+                int owned_chunk_1 = 1;
+                {
+                    owned_chunk_1 = (int)(chunk_idx_2 < write_end_1);
+                }
+                long long chunk_global_2 = cu_chunk_offsets[seq_idx_2] + (long long)chunk_idx_2;
+                long long chunk_start = bos_2 + (long long)chunk_idx_2 * 32;
+                float do_values[16];
+                do_values[0] = 0.0f;
+                do_values[1] = 0.0f;
+                do_values[2] = 0.0f;
+                do_values[3] = 0.0f;
+                do_values[4] = 0.0f;
+                do_values[5] = 0.0f;
+                do_values[6] = 0.0f;
+                do_values[7] = 0.0f;
+                do_values[8] = 0.0f;
+                do_values[9] = 0.0f;
+                do_values[10] = 0.0f;
+                do_values[11] = 0.0f;
+                do_values[12] = 0.0f;
+                do_values[13] = 0.0f;
+                do_values[14] = 0.0f;
+                do_values[15] = 0.0f;
+                #pragma unroll
+                for (int row_pass = 0; row_pass < 1; row_pass++) {
+                    int warp_id_in_role_2 = (warp - 8);
+                    int state_row_1 = (warp_id_in_role_2 + row_pass) * 32 + lane;
+                    #pragma unroll
+                    for (int token_local = 0; token_local < 16; token_local++) {
+                        int token_col = token_offset + token_local;
+                        long long token_idx = chunk_start + (long long)token_col;
+                        if (token_idx < eos_2) {
+                            do_values[row_pass * 16 + token_local] = (float)do_[(token_idx * (long long)num_heads + (long long)head_idx_2) * 128 + (long long)state_row_1];
+                        }
+                    }
+                }
+                uint32_t do_values_bf16[8];
+                #pragma unroll
+                for (int _lp = 0; _lp < 8; _lp++) {
+                    __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(do_values[_lp*2 + 0], do_values[_lp*2+1 + 0]));
+                    do_values_bf16[_lp] = *(uint32_t*)&_bf2;
+                }
+                #pragma unroll
+                for (int row_pass2 = 0; row_pass2 < 1; row_pass2++) {
+                    int warp_id_in_role_3 = (warp - 8);
+                    int row_group = warp_id_in_role_3 + row_pass2;
+                    int tmem_row_base_1 = row_group * 32 << 16;
+                    tmem_st_x8_u32(taddr + 224 + (unsigned int)tmem_row_base_1 + (unsigned int)(token_offset / 2), (const uint32_t*)(do_values_bf16 + row_pass2 * 8));
+                }
+                asm volatile("tcgen05.wait::st.sync.aligned;" ::: "memory");
+                asm volatile("barrier.sync 9, 384;" ::: "memory");
+                mbarrier_wait(dr_ready_addr + (token_stage) * 8, _phase_dr_ready);
+                #pragma unroll
+                for (int dr_row_pass = 0; dr_row_pass < 1; dr_row_pass++) {
+                    int warp_id_in_role_4 = (warp - 8);
+                    int row_group2 = warp_id_in_role_4 + dr_row_pass;
+                    int state_row2 = row_group2 * 32 + lane;
+                    int tmem_row_base2 = row_group2 * 32 << 16;
+                    float _tmem_load_4[16];
+                    tmem_ld_x16(&_tmem_load_4[0], taddr + 192 + (unsigned int)tmem_row_base2 + (unsigned int)token_offset);
+                    asm volatile("tcgen05.wait::ld.sync.aligned;");
+                    long long dr_tape_base = ((chunk_global_2 * (long long)num_heads + (long long)head_idx_2) * 128 + (long long)state_row2) * 32;
+                    if (owned_chunk_1 != 0) {
+                        #pragma unroll
+                        for (int dr_store_vec = 0; dr_store_vec < 2; dr_store_vec++) {
+                            {
+                                __nv_bfloat162 _pk[4];
+                                _pk[0] = __floats2bfloat162_rn(_tmem_load_4[dr_store_vec * 8 + 0], _tmem_load_4[dr_store_vec * 8 + 1]);
+                                _pk[1] = __floats2bfloat162_rn(_tmem_load_4[dr_store_vec * 8 + 2], _tmem_load_4[dr_store_vec * 8 + 3]);
+                                _pk[2] = __floats2bfloat162_rn(_tmem_load_4[dr_store_vec * 8 + 4], _tmem_load_4[dr_store_vec * 8 + 5]);
+                                _pk[3] = __floats2bfloat162_rn(_tmem_load_4[dr_store_vec * 8 + 6], _tmem_load_4[dr_store_vec * 8 + 7]);
+                                *reinterpret_cast<uint4*>(&((__nv_bfloat16*)(chunk_dr + (dr_tape_base + (long long)token_offset + (long long)(dr_store_vec * 8))))[0]) = *reinterpret_cast<uint4*>(&_pk[0]);
+                            }
+                        }
+                    }
+                    uint32_t _tmem_load_4_bf16[8];
+                    #pragma unroll
+                    for (int _lp = 0; _lp < 8; _lp++) {
+                        __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(_tmem_load_4[_lp*2 + 0], _tmem_load_4[_lp*2+1 + 0]));
+                        _tmem_load_4_bf16[_lp] = *(uint32_t*)&_bf2;
+                    }
+                    tmem_st_x8_u32(taddr + 192 + (unsigned int)tmem_row_base2 + (unsigned int)(token_offset / 2), (const uint32_t*)_tmem_load_4_bf16);
+                    tmem_st_x8_u32(taddr + (unsigned int)tmem_row_base2 + (unsigned int)(token_offset / 2), (const uint32_t*)(do_values_bf16 + dr_row_pass * 8));
+                }
+                asm volatile("tcgen05.wait::st.sync.aligned;" ::: "memory");
+                asm volatile("barrier.sync 10, 256;" ::: "memory");
+                mbarrier_wait(dx_ready_addr + (token_stage) * 8, _phase_dx_ready);
+                long long beta_token = chunk_start + (long long)lane;
+                float beta_lane = 0.0f;
+                if (beta_token < eos_2) {
+                    beta_lane = beta_active[beta_token * (long long)num_heads + (long long)head_idx_2];
+                }
+                #pragma unroll
+                for (int dx_row_pass = 0; dx_row_pass < 1; dx_row_pass++) {
+                    int warp_id_in_role_5 = (warp - 8);
+                    int row_group3 = warp_id_in_role_5 + dx_row_pass;
+                    int state_row3 = row_group3 * 32 + lane;
+                    int tmem_row_base3 = row_group3 * 32 << 16;
+                    float _tmem_load_5[16];
+                    tmem_ld_x16(&_tmem_load_5[0], taddr + 224 + (unsigned int)tmem_row_base3 + (unsigned int)token_offset);
+                    asm volatile("tcgen05.wait::ld.sync.aligned;");
+                    long long dx_tape_base = ((chunk_global_2 * (long long)num_heads + (long long)head_idx_2) * 128 + (long long)state_row3) * 32;
+                    if (owned_chunk_1 != 0) {
+                        #pragma unroll
+                        for (int dx_store_vec = 0; dx_store_vec < 2; dx_store_vec++) {
+                            {
+                                __nv_bfloat162 _pk[4];
+                                _pk[0] = __floats2bfloat162_rn(_tmem_load_5[dx_store_vec * 8 + 0], _tmem_load_5[dx_store_vec * 8 + 1]);
+                                _pk[1] = __floats2bfloat162_rn(_tmem_load_5[dx_store_vec * 8 + 2], _tmem_load_5[dx_store_vec * 8 + 3]);
+                                _pk[2] = __floats2bfloat162_rn(_tmem_load_5[dx_store_vec * 8 + 4], _tmem_load_5[dx_store_vec * 8 + 5]);
+                                _pk[3] = __floats2bfloat162_rn(_tmem_load_5[dx_store_vec * 8 + 6], _tmem_load_5[dx_store_vec * 8 + 7]);
+                                *reinterpret_cast<uint4*>(&((__nv_bfloat16*)(chunk_dx + (dx_tape_base + (long long)token_offset + (long long)(dx_store_vec * 8))))[0]) = *reinterpret_cast<uint4*>(&_pk[0]);
+                            }
+                        }
+                    }
+                    #pragma unroll
+                    for (int token_local2 = 0; token_local2 < 16; token_local2++) {
+                        int token_col2 = token_offset + token_local2;
+                        float _shfl_2 = __shfl_sync(0xFFFFFFFF, beta_lane, token_col2);
+                        float beta_value = _shfl_2;
+                        _tmem_load_5[token_local2] = _tmem_load_5[token_local2] * (-beta_value);
+                    }
+                    uint32_t _tmem_load_5_bf16[8];
+                    #pragma unroll
+                    for (int _lp = 0; _lp < 8; _lp++) {
+                        __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(_tmem_load_5[_lp*2 + 0], _tmem_load_5[_lp*2+1 + 0]));
+                        _tmem_load_5_bf16[_lp] = *(uint32_t*)&_bf2;
+                    }
+                    tmem_st_x8_u32(taddr + 224 + (unsigned int)tmem_row_base3 + (unsigned int)(token_offset / 2), (const uint32_t*)_tmem_load_5_bf16);
+                }
+                asm volatile("tcgen05.wait::st.sync.aligned;" ::: "memory");
+                asm volatile("barrier.sync 11, 256;" ::: "memory");
+                if (publish_ready != 0 && owned_chunk_1 != 0) {
+                    asm volatile("barrier.sync 14, 128;" ::: "memory");
+                    int warp_id_in_role_6 = (warp - 8);
+                    if (warp_id_in_role_6 == 0) {
+                        if (elect_sync()) {
+                            {
+                                unsigned int* _gc_p = reinterpret_cast<unsigned int*>(boundary_ready) + (chunk_global_2 * (long long)num_heads + (long long)head_idx_2);
+                                unsigned int _gc_old;
+                                asm volatile("atom.release.gpu.global.add.u32 %0, [%1], 1;" : "=r"(_gc_old) : "l"(_gc_p) : "memory");
+                            }
+                        }
+                    }
+                }
+                mbarrier_wait(dh_ready_addr + (token_stage) * 8, _phase_dh_ready_1);
+                token_stage += 1;
+                if (token_stage == 1) { token_stage = 0; _phase_dr_ready ^= 1; _phase_dx_ready ^= 1; _phase_dh_ready_1 ^= 1; }
+            }
+            if (elect_sync()) {
+                mbarrier_arrive(owners_done_addr);
+            }
+        }
+    }
+    // ---- Role: low_token ----
+    if (warp >= 12 && warp <= 15) {
+        asm volatile("setmaxnreg.dec.sync.aligned.u32 80;");
+        { // low_token_main
+            int task_idx_3 = blockIdx.x;
+            int seq_idx_3 = 0;
+            int head_idx_3 = 0;
+            int write_start_3 = 0;
+            int write_end_2 = 0;
+            {
+                int item_base_3 = task_idx_3 * 5;
+                seq_idx_3 = work_items[item_base_3];
+                head_idx_3 = work_items[item_base_3 + 1];
+                write_start_3 = work_items[item_base_3 + 2];
+                write_end_2 = work_items[item_base_3 + 3];
+            }
+            long long bos_3 = cu_seqlens[seq_idx_3];
+            long long eos_3 = cu_seqlens[seq_idx_3 + 1];
+            int seq_len_3 = (int)(eos_3 - bos_3);
+            int compute_end_3 = 0;
+            int scan_chunks_3 = 0;
+            unsigned int _phase_work_item_ready_0_2 = 0;
+            {
+                mbarrier_wait(work_item_ready_addr, _phase_work_item_ready_0_2);
+                _phase_work_item_ready_0_2 ^= 1;
+                compute_end_3 = smem_work_item_compute_end[0];
+                scan_chunks_3 = compute_end_3 - write_start_3;
+            }
+            int warp_id_in_role_7 = (warp - 12);
+            int state_row_2 = warp_id_in_role_7 * 32 + lane;
+            int tmem_row_base_2 = warp_id_in_role_7 * 32 << 16;
+            unsigned int low_token_stage = 0;
+            unsigned int _phase_dr_ready_1 = 0;
+            unsigned int _phase_dx_ready_1 = 0;
+            unsigned int _phase_dh_ready_2 = 0;
+            #pragma unroll 1
+            for (int reverse_chunk_3 = 0; reverse_chunk_3 < scan_chunks_3; reverse_chunk_3++) {
+                int chunk_idx_3 = compute_end_3 - 1 - reverse_chunk_3;
+                int owned_chunk_2 = 1;
+                {
+                    owned_chunk_2 = (int)(chunk_idx_3 < write_end_2);
+                }
+                long long chunk_global_3 = cu_chunk_offsets[seq_idx_3] + (long long)chunk_idx_3;
+                long long chunk_start_1 = bos_3 + (long long)chunk_idx_3 * 32;
+                float do_values_1[16];
+                do_values_1[0] = 0.0f;
+                do_values_1[1] = 0.0f;
+                do_values_1[2] = 0.0f;
+                do_values_1[3] = 0.0f;
+                do_values_1[4] = 0.0f;
+                do_values_1[5] = 0.0f;
+                do_values_1[6] = 0.0f;
+                do_values_1[7] = 0.0f;
+                do_values_1[8] = 0.0f;
+                do_values_1[9] = 0.0f;
+                do_values_1[10] = 0.0f;
+                do_values_1[11] = 0.0f;
+                do_values_1[12] = 0.0f;
+                do_values_1[13] = 0.0f;
+                do_values_1[14] = 0.0f;
+                do_values_1[15] = 0.0f;
+                #pragma unroll
+                for (int token_col_1 = 0; token_col_1 < 16; token_col_1++) {
+                    long long token_idx_1 = chunk_start_1 + (long long)token_col_1;
+                    if (token_idx_1 < eos_3) {
+                        do_values_1[token_col_1] = (float)do_[(token_idx_1 * (long long)num_heads + (long long)head_idx_3) * 128 + (long long)state_row_2];
+                    }
+                }
+                uint32_t do_values_bf16_1[8];
+                #pragma unroll
+                for (int _lp = 0; _lp < 8; _lp++) {
+                    __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(do_values_1[_lp*2 + 0], do_values_1[_lp*2+1 + 0]));
+                    do_values_bf16_1[_lp] = *(uint32_t*)&_bf2;
+                }
+                tmem_st_x8_u32(taddr + 224 + (unsigned int)tmem_row_base_2, (const uint32_t*)do_values_bf16_1);
+                asm volatile("tcgen05.wait::st.sync.aligned;" ::: "memory");
+                asm volatile("barrier.sync 9, 384;" ::: "memory");
+                mbarrier_wait(dr_ready_addr + (low_token_stage) * 8, _phase_dr_ready_1);
+                float _tmem_load_2[16];
+                tmem_ld_x16(&_tmem_load_2[0], taddr + 192 + (unsigned int)tmem_row_base_2);
+                asm volatile("tcgen05.wait::ld.sync.aligned;");
+                long long dr_tape_base_1 = ((chunk_global_3 * (long long)num_heads + (long long)head_idx_3) * 128 + (long long)state_row_2) * 32;
+                if (owned_chunk_2 != 0) {
+                    #pragma unroll
+                    for (int dr_store_vec_1 = 0; dr_store_vec_1 < 2; dr_store_vec_1++) {
+                        {
+                            __nv_bfloat162 _pk[4];
+                            _pk[0] = __floats2bfloat162_rn(_tmem_load_2[dr_store_vec_1 * 8 + 0], _tmem_load_2[dr_store_vec_1 * 8 + 1]);
+                            _pk[1] = __floats2bfloat162_rn(_tmem_load_2[dr_store_vec_1 * 8 + 2], _tmem_load_2[dr_store_vec_1 * 8 + 3]);
+                            _pk[2] = __floats2bfloat162_rn(_tmem_load_2[dr_store_vec_1 * 8 + 4], _tmem_load_2[dr_store_vec_1 * 8 + 5]);
+                            _pk[3] = __floats2bfloat162_rn(_tmem_load_2[dr_store_vec_1 * 8 + 6], _tmem_load_2[dr_store_vec_1 * 8 + 7]);
+                            *reinterpret_cast<uint4*>(&((__nv_bfloat16*)(chunk_dr + (dr_tape_base_1 + (long long)(dr_store_vec_1 * 8))))[0]) = *reinterpret_cast<uint4*>(&_pk[0]);
+                        }
+                    }
+                }
+                uint32_t _tmem_load_2_bf16[8];
+                #pragma unroll
+                for (int _lp = 0; _lp < 8; _lp++) {
+                    __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(_tmem_load_2[_lp*2 + 0], _tmem_load_2[_lp*2+1 + 0]));
+                    _tmem_load_2_bf16[_lp] = *(uint32_t*)&_bf2;
+                }
+                tmem_st_x8_u32(taddr + 192 + (unsigned int)tmem_row_base_2, (const uint32_t*)_tmem_load_2_bf16);
+                tmem_st_x8_u32(taddr + (unsigned int)tmem_row_base_2, (const uint32_t*)do_values_bf16_1);
+                asm volatile("tcgen05.wait::st.sync.aligned;" ::: "memory");
+                asm volatile("barrier.sync 10, 256;" ::: "memory");
+                if (warp_id_in_role_7 == 0) {
+                    if (elect_sync()) {
+                        mbarrier_arrive(dr_inp_ready_addr + (low_token_stage) * 8);
+                    }
+                }
+                mbarrier_wait(dx_ready_addr + (low_token_stage) * 8, _phase_dx_ready_1);
+                float _tmem_load_3[16];
+                tmem_ld_x16(&_tmem_load_3[0], taddr + 224 + (unsigned int)tmem_row_base_2);
+                asm volatile("tcgen05.wait::ld.sync.aligned;");
+                if (owned_chunk_2 != 0) {
+                    #pragma unroll
+                    for (int dx_store_vec_1 = 0; dx_store_vec_1 < 2; dx_store_vec_1++) {
+                        {
+                            __nv_bfloat162 _pk[4];
+                            _pk[0] = __floats2bfloat162_rn(_tmem_load_3[dx_store_vec_1 * 8 + 0], _tmem_load_3[dx_store_vec_1 * 8 + 1]);
+                            _pk[1] = __floats2bfloat162_rn(_tmem_load_3[dx_store_vec_1 * 8 + 2], _tmem_load_3[dx_store_vec_1 * 8 + 3]);
+                            _pk[2] = __floats2bfloat162_rn(_tmem_load_3[dx_store_vec_1 * 8 + 4], _tmem_load_3[dx_store_vec_1 * 8 + 5]);
+                            _pk[3] = __floats2bfloat162_rn(_tmem_load_3[dx_store_vec_1 * 8 + 6], _tmem_load_3[dx_store_vec_1 * 8 + 7]);
+                            *reinterpret_cast<uint4*>(&((__nv_bfloat16*)(chunk_dx + (dr_tape_base_1 + (long long)(dx_store_vec_1 * 8))))[0]) = *reinterpret_cast<uint4*>(&_pk[0]);
+                        }
+                    }
+                }
+                long long beta_token_1 = chunk_start_1 + (long long)lane;
+                float beta_lane_1 = 0.0f;
+                if (beta_token_1 < eos_3) {
+                    beta_lane_1 = beta_active[beta_token_1 * (long long)num_heads + (long long)head_idx_3];
+                }
+                #pragma unroll
+                for (int token_col2_1 = 0; token_col2_1 < 16; token_col2_1++) {
+                    float _shfl_1 = __shfl_sync(0xFFFFFFFF, beta_lane_1, token_col2_1);
+                    float beta_value_1 = _shfl_1;
+                    _tmem_load_3[token_col2_1] = _tmem_load_3[token_col2_1] * (-beta_value_1);
+                }
+                uint32_t _tmem_load_3_bf16[8];
+                #pragma unroll
+                for (int _lp = 0; _lp < 8; _lp++) {
+                    __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(_tmem_load_3[_lp*2 + 0], _tmem_load_3[_lp*2+1 + 0]));
+                    _tmem_load_3_bf16[_lp] = *(uint32_t*)&_bf2;
+                }
+                tmem_st_x8_u32(taddr + 224 + (unsigned int)tmem_row_base_2, (const uint32_t*)_tmem_load_3_bf16);
+                asm volatile("tcgen05.wait::st.sync.aligned;" ::: "memory");
+                asm volatile("barrier.sync 11, 256;" ::: "memory");
+                if (warp_id_in_role_7 == 0) {
+                    if (elect_sync()) {
+                        mbarrier_arrive(de_inp_ready_addr + (low_token_stage) * 8);
+                    }
+                }
+                if (publish_ready != 0 && owned_chunk_2 != 0) {
+                    asm volatile("barrier.sync 13, 128;" ::: "memory");
+                    if (warp_id_in_role_7 == 0) {
+                        if (elect_sync()) {
+                            {
+                                unsigned int* _gc_p = reinterpret_cast<unsigned int*>(boundary_ready) + (chunk_global_3 * (long long)num_heads + (long long)head_idx_3);
+                                unsigned int _gc_old;
+                                asm volatile("atom.release.gpu.global.add.u32 %0, [%1], 1;" : "=r"(_gc_old) : "l"(_gc_p) : "memory");
+                            }
+                        }
+                    }
+                }
+                mbarrier_wait(dh_ready_addr + (low_token_stage) * 8, _phase_dh_ready_2);
+                low_token_stage += 1;
+                if (low_token_stage == 1) { low_token_stage = 0; _phase_dr_ready_1 ^= 1; _phase_dx_ready_1 ^= 1; _phase_dh_ready_2 ^= 1; }
+            }
+            if (elect_sync()) {
+                mbarrier_arrive(owners_done_addr);
+            }
+        }
+    }
+
+    // Cleanup
+}
+
+} // extern "C"
+
+#undef LOOM_INF
+#undef NUM_PREP_PIPE_STAGES
+#undef NUM_REVERSE_PIPE_STAGES
+#undef SMEM_SMEM_J_OFF
+#undef SMEM_SMEM_J_STAGE_BYTES
+#undef SMEM_SMEM_J_STRIDE
+#undef SMEM_SMEM_J_TRANS_OFF
+#undef SMEM_SMEM_J_TRANS_STAGE_BYTES
+#undef SMEM_SMEM_J_TRANS_STRIDE
+#undef SMEM_SMEM_KD_OFF
+#undef SMEM_SMEM_KD_STAGE_BYTES
+#undef SMEM_SMEM_KD_STRIDE
+#undef SMEM_SMEM_KD_TRANS_OFF
+#undef SMEM_SMEM_KD_TRANS_STAGE_BYTES
+#undef SMEM_SMEM_KD_TRANS_STRIDE
+#undef SMEM_SMEM_KI_OFF
+#undef SMEM_SMEM_KI_STAGE_BYTES
+#undef SMEM_SMEM_KI_STRIDE
+#undef SMEM_SMEM_KR_OFF
+#undef SMEM_SMEM_KR_STAGE_BYTES
+#undef SMEM_SMEM_KR_STRIDE
+#undef SMEM_SMEM_N_OFF
+#undef SMEM_SMEM_N_STAGE_BYTES
+#undef SMEM_SMEM_N_STRIDE
+#undef SMEM_SMEM_QD_OFF
+#undef SMEM_SMEM_QD_STAGE_BYTES
+#undef SMEM_SMEM_QD_STRIDE
+#undef SMEM_SMEM_QD_TRANS_OFF
+#undef SMEM_SMEM_QD_TRANS_STAGE_BYTES
+#undef SMEM_SMEM_QD_TRANS_STRIDE
+#undef SMEM_SMEM_WORK_ITEM_COMPUTE_END_OFF
+#undef SMEM_SMEM_WORK_ITEM_COMPUTE_END_STAGE_BYTES
+#undef SMEM_SMEM_WORK_ITEM_COMPUTE_END_STRIDE
+#undef SMEM_SMEM_WORK_ITEM_RESOLVED_OFF
+#undef SMEM_SMEM_WORK_ITEM_RESOLVED_STAGE_BYTES
+#undef SMEM_SMEM_WORK_ITEM_RESOLVED_STRIDE
+#undef SMEM_SMEM_WORK_ITEM_WARP_MAX_OFF
+#undef SMEM_SMEM_WORK_ITEM_WARP_MAX_STAGE_BYTES
+#undef SMEM_SMEM_WORK_ITEM_WARP_MAX_STRIDE
+#undef SMEM_TOTAL
+#undef THREADS
+#undef TMEM_NCOLS
+#undef TMEM_TMEM_DE_INP_OFFSET
+#undef TMEM_TMEM_DH_INP_OFFSET
+#undef TMEM_TMEM_DH_OFFSET
+#undef TMEM_TMEM_DO_FINAL_OFFSET
+#undef TMEM_TMEM_DO_INITIAL_OFFSET
+#undef TMEM_TMEM_DR_INP_OFFSET
+#undef TMEM_TMEM_DR_OFFSET
+#undef TMEM_TMEM_DX_OFFSET
+#undef de_inp_ready_addr
+#undef dh_ready_addr
+#undef dr_inp_ready_addr
+#undef dr_ready_addr
+#undef dx_ready_addr
+#undef owners_done_addr
+#undef prep_ready_addr
+#undef smem_free_addr
+#undef smem_j_addr
+#undef smem_j_trans_addr
+#undef smem_kd_addr
+#undef smem_kd_trans_addr
+#undef smem_ki_addr
+#undef smem_kr_addr
+#undef smem_n_addr
+#undef smem_qd_addr
+#undef smem_qd_trans_addr
+#undef smem_work_item_compute_end_addr
+#undef smem_work_item_resolved_addr
+#undef smem_work_item_warp_max_addr
+#undef work_item_ready_addr
+
+#define LOOM_INF CUDART_INF_F
+#define TMEM_NCOLS 496
+#define TMEM_TMEM_A_DH_OFFSET 0
+#define TMEM_TMEM_A_STATE_OFFSET 64
+#define TMEM_TMEM_A_K_OFFSET 128
+#define TMEM_TMEM_A_Q_OFFSET 144
+#define TMEM_TMEM_A_I_OFFSET 160
+#define TMEM_TMEM_DKR_OFFSET 176
+#define TMEM_TMEM_DI_OFFSET 208
+#define TMEM_TMEM_DQ_LOCAL_OFFSET 240
+#define TMEM_TMEM_DQ_BOUNDARY_OFFSET 272
+#define TMEM_TMEM_DK_LOCAL_OFFSET 304
+#define TMEM_TMEM_DK_BOUNDARY_OFFSET 336
+#define TMEM_TMEM_RECON_KR_OFFSET 64
+#define TMEM_TMEM_RECON_STATE_OFFSET 368
+#define NUM_MAIN_STAGES 1
+#define SMEM_S_K_OFF 1024
+#define SMEM_S_K_STAGE_BYTES 8192
+#define SMEM_S_K_STRIDE 8192
+#define SMEM_S_I_OFF 9216
+#define SMEM_S_I_STAGE_BYTES 8192
+#define SMEM_S_I_STRIDE 8192
+#define SMEM_S_DOT_OFF 17408
+#define SMEM_S_DOT_STAGE_BYTES 8192
+#define SMEM_S_DOT_STRIDE 8192
+#define SMEM_S_RT_OFF 25600
+#define SMEM_S_RT_STAGE_BYTES 8192
+#define SMEM_S_RT_STRIDE 8192
+#define SMEM_S_DRT_OFF 33792
+#define SMEM_S_DRT_STAGE_BYTES 8192
+#define SMEM_S_DRT_STRIDE 8192
+#define SMEM_S_X_OFF 41984
+#define SMEM_S_X_STAGE_BYTES 8192
+#define SMEM_S_X_STRIDE 8192
+#define SMEM_S_DET_OFF 50176
+#define SMEM_S_DET_STAGE_BYTES 8192
+#define SMEM_S_DET_STRIDE 8192
+#define SMEM_S_DOT_TC_OFF 58368
+#define SMEM_S_DOT_TC_STAGE_BYTES 8192
+#define SMEM_S_DOT_TC_STRIDE 8192
+#define SMEM_S_RT_TC_OFF 66560
+#define SMEM_S_RT_TC_STAGE_BYTES 8192
+#define SMEM_S_RT_TC_STRIDE 8192
+#define SMEM_S_DET_TC_OFF 74752
+#define SMEM_S_DET_TC_STAGE_BYTES 8192
+#define SMEM_S_DET_TC_STRIDE 8192
+#define SMEM_S_J_OFF 82944
+#define SMEM_S_J_STAGE_BYTES 2048
+#define SMEM_S_J_STRIDE 2048
+#define SMEM_S_M_OFF 84992
+#define SMEM_S_M_STAGE_BYTES 2048
+#define SMEM_S_M_STRIDE 2048
+#define SMEM_S_DJ_OFF 89088
+#define SMEM_S_DJ_STAGE_BYTES 2048
+#define SMEM_S_DJ_STRIDE 2048
+#define SMEM_S_TMP_OFF 91136
+#define SMEM_S_TMP_STAGE_BYTES 2048
+#define SMEM_S_TMP_STRIDE 2048
+#define SMEM_S_DF_OFF 93184
+#define SMEM_S_DF_STAGE_BYTES 2048
+#define SMEM_S_DF_STRIDE 2048
+#define SMEM_S_DO_STAGE_OFF 89088
+#define SMEM_S_DO_STAGE_STAGE_BYTES 8192
+#define SMEM_S_DO_STAGE_STRIDE 8192
+#define SMEM_S_DN_TC_OFF 97280
+#define SMEM_S_DN_TC_STAGE_BYTES 2048
+#define SMEM_S_DN_TC_STRIDE 2048
+#define SMEM_S_DNT_TC_OFF 99328
+#define SMEM_S_DNT_TC_STAGE_BYTES 2048
+#define SMEM_S_DNT_TC_STRIDE 2048
+#define SMEM_S_DM_TC_OFF 101376
+#define SMEM_S_DM_TC_STAGE_BYTES 2048
+#define SMEM_S_DM_TC_STRIDE 2048
+#define SMEM_S_DMT_TC_OFF 103424
+#define SMEM_S_DMT_TC_STAGE_BYTES 2048
+#define SMEM_S_DMT_TC_STRIDE 2048
+#define SMEM_S_DBETA_PARTIAL_OFF 105472
+#define SMEM_S_DBETA_PARTIAL_STAGE_BYTES 512
+#define SMEM_S_DBETA_PARTIAL_STRIDE 512
+#define SMEM_S_Q_OFF 105984
+#define SMEM_S_Q_STAGE_BYTES 8192
+#define SMEM_S_Q_STRIDE 8192
+#define SMEM_S_PREV_R_TC_OFF 114176
+#define SMEM_S_PREV_R_TC_STAGE_BYTES 8192
+#define SMEM_S_PREV_R_TC_STRIDE 8192
+#define SMEM_S_DH_STAGE_OFF 122368
+#define SMEM_S_DH_STAGE_STAGE_BYTES 32768
+#define SMEM_S_DH_STAGE_STRIDE 32768
+#define SMEM_S_STABLE_DKR_OFF 17408
+#define SMEM_S_STABLE_DKR_STAGE_BYTES 16384
+#define SMEM_S_STABLE_DKR_STRIDE 16384
+#define SMEM_S_STABLE_DELTA_OFF 33792
+#define SMEM_S_STABLE_DELTA_STAGE_BYTES 16384
+#define SMEM_S_STABLE_DELTA_STRIDE 16384
+#define SMEM_S_STABLE_BASE_OFF 50176
+#define SMEM_S_STABLE_BASE_STAGE_BYTES 16384
+#define SMEM_S_STABLE_BASE_STRIDE 16384
+#define SMEM_S_MIDDLE_BASE_SUFFIX_OFF 122368
+#define SMEM_S_MIDDLE_BASE_SUFFIX_STAGE_BYTES 512
+#define SMEM_S_MIDDLE_BASE_SUFFIX_STRIDE 512
+#define SMEM_S_HIGH_BASE_SUFFIX_OFF 122880
+#define SMEM_S_HIGH_BASE_SUFFIX_STAGE_BYTES 512
+#define SMEM_S_HIGH_BASE_SUFFIX_STRIDE 512
+#define SMEM_TOTAL 155136
+#define THREADS 384
+
+extern "C" {
+
+__global__ __launch_bounds__(384) void
+kernel_flashkda_backward_local_c32_tcgen(__nv_bfloat16* __restrict__ do_, float* __restrict__ beta_active, long long* __restrict__ cu_seqlens, int* __restrict__ consumer_chunk_order, int* __restrict__ chunk_sequence, int* __restrict__ chunk_index, __nv_bfloat16* __restrict__ chunk_state, unsigned int* __restrict__ state_checkpoint_needed, float* __restrict__ initial_state, __nv_bfloat16* __restrict__ tape_qd, __nv_bfloat16* __restrict__ tape_kd, __nv_bfloat16* __restrict__ tape_kr, __nv_bfloat16* __restrict__ tape_j, float* __restrict__ tape_restore_factor, __nv_bfloat16* __restrict__ tape_e, __nv_bfloat16* __restrict__ tape_x, __nv_bfloat16* __restrict__ tape_r, __nv_bfloat16* __restrict__ chunk_dh, __nv_bfloat16* __restrict__ chunk_dr, __nv_bfloat16* __restrict__ chunk_dx, unsigned int* __restrict__ boundary_ready, __nv_bfloat16* __restrict__ grad_qd, __nv_bfloat16* __restrict__ grad_kd, __nv_bfloat16* __restrict__ grad_ki, float* __restrict__ dlog_decay, float* __restrict__ dbeta_active, __nv_bfloat16* __restrict__ dv, int num_heads, int boundary_ready_target, float lower_bound)
+{
+    const int tid = threadIdx.x;
+    const int warp = make_warp_uniform(tid / 32);
+    const int lane = tid % 32;
+
+    extern __shared__ __align__(1024) char smem_raw[];
+    int smem;
+    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+
+    const int bid = blockIdx.x;
+    const int num_bids = gridDim.x;
+
+    // Kernel setup ops
+    __nv_bfloat16* s_k = reinterpret_cast<__nv_bfloat16*>(smem_raw + 1024);
+    const int s_k_addr = smem + 1024;
+    __nv_bfloat16* s_i = reinterpret_cast<__nv_bfloat16*>(smem_raw + 9216);
+    const int s_i_addr = smem + 9216;
+    __nv_bfloat16* s_dot = reinterpret_cast<__nv_bfloat16*>(smem_raw + 17408);
+    const int s_dot_addr = smem + 17408;
+    __nv_bfloat16* s_rt = reinterpret_cast<__nv_bfloat16*>(smem_raw + 25600);
+    const int s_rt_addr = smem + 25600;
+    __nv_bfloat16* s_drt = reinterpret_cast<__nv_bfloat16*>(smem_raw + 33792);
+    const int s_drt_addr = smem + 33792;
+    __nv_bfloat16* s_x = reinterpret_cast<__nv_bfloat16*>(smem_raw + 41984);
+    const int s_x_addr = smem + 41984;
+    __nv_bfloat16* s_det = reinterpret_cast<__nv_bfloat16*>(smem_raw + 50176);
+    const int s_det_addr = smem + 50176;
+    __nv_bfloat16* s_dot_tc = reinterpret_cast<__nv_bfloat16*>(smem_raw + 58368);
+    const int s_dot_tc_addr = smem + 58368;
+    __nv_bfloat16* s_rt_tc = reinterpret_cast<__nv_bfloat16*>(smem_raw + 66560);
+    const int s_rt_tc_addr = smem + 66560;
+    __nv_bfloat16* s_det_tc = reinterpret_cast<__nv_bfloat16*>(smem_raw + 74752);
+    const int s_det_tc_addr = smem + 74752;
+    __nv_bfloat16* s_j = reinterpret_cast<__nv_bfloat16*>(smem_raw + 82944);
+    const int s_j_addr = smem + 82944;
+    __nv_bfloat16* s_m = reinterpret_cast<__nv_bfloat16*>(smem_raw + 84992);
+    const int s_m_addr = smem + 84992;
+    __nv_bfloat16* s_dj = reinterpret_cast<__nv_bfloat16*>(smem_raw + 89088);
+    const int s_dj_addr = smem + 89088;
+    __nv_bfloat16* s_tmp = reinterpret_cast<__nv_bfloat16*>(smem_raw + 91136);
+    const int s_tmp_addr = smem + 91136;
+    __nv_bfloat16* s_df = reinterpret_cast<__nv_bfloat16*>(smem_raw + 93184);
+    const int s_df_addr = smem + 93184;
+    __nv_bfloat16* s_do_stage = reinterpret_cast<__nv_bfloat16*>(smem_raw + 89088);
+    const int s_do_stage_addr = smem + 89088;
+    __nv_bfloat16* s_dn_tc = reinterpret_cast<__nv_bfloat16*>(smem_raw + 97280);
+    const int s_dn_tc_addr = smem + 97280;
+    __nv_bfloat16* s_dnt_tc = reinterpret_cast<__nv_bfloat16*>(smem_raw + 99328);
+    const int s_dnt_tc_addr = smem + 99328;
+    __nv_bfloat16* s_dm_tc = reinterpret_cast<__nv_bfloat16*>(smem_raw + 101376);
+    const int s_dm_tc_addr = smem + 101376;
+    __nv_bfloat16* s_dmt_tc = reinterpret_cast<__nv_bfloat16*>(smem_raw + 103424);
+    const int s_dmt_tc_addr = smem + 103424;
+    float* s_dbeta_partial = reinterpret_cast<float*>(smem_raw + 105472);
+    const int s_dbeta_partial_addr = smem + 105472;
+    __nv_bfloat16* s_q = reinterpret_cast<__nv_bfloat16*>(smem_raw + 105984);
+    const int s_q_addr = smem + 105984;
+    __nv_bfloat16* s_prev_r_tc = reinterpret_cast<__nv_bfloat16*>(smem_raw + 114176);
+    const int s_prev_r_tc_addr = smem + 114176;
+    __nv_bfloat16* s_dh_stage = reinterpret_cast<__nv_bfloat16*>(smem_raw + 122368);
+    const int s_dh_stage_addr = smem + 122368;
+    float* s_stable_dkr = reinterpret_cast<float*>(smem_raw + 17408);
+    const int s_stable_dkr_addr = smem + 17408;
+    float* s_stable_delta = reinterpret_cast<float*>(smem_raw + 33792);
+    const int s_stable_delta_addr = smem + 33792;
+    float* s_stable_base = reinterpret_cast<float*>(smem_raw + 50176);
+    const int s_stable_base_addr = smem + 50176;
+    float* s_middle_base_suffix = reinterpret_cast<float*>(smem_raw + 122368);
+    const int s_middle_base_suffix_addr = smem + 122368;
+    float* s_high_base_suffix = reinterpret_cast<float*>(smem_raw + 122880);
+    const int s_high_base_suffix_addr = smem + 122880;
+
+    // Mbarrier init (15 groups, 15 barriers)
+    // Mbarriers at smem_raw[0..120)
+
+    if (warp == 0) {
+        uint32_t leader = elect_sync();
+        if (leader) {
+            // prep_ready: 1 barriers, init_count=1
+            mbarrier_init(smem + 0, 1);
+            // boundary_local_ready: 1 barriers, init_count=1
+            mbarrier_init(smem + 8, 1);
+            // dbeta_done: 1 barriers, init_count=4
+            mbarrier_init(smem + 16, 4);
+            // qki_ready: 1 barriers, init_count=1
+            mbarrier_init(smem + 24, 1);
+            // qki_tc_ready: 1 barriers, init_count=4
+            mbarrier_init(smem + 32, 4);
+            // dv_ready: 1 barriers, init_count=1
+            mbarrier_init(smem + 40, 1);
+            // value_tc_ready: 1 barriers, init_count=3
+            mbarrier_init(smem + 48, 3);
+            // dh_ready: 1 barriers, init_count=1
+            mbarrier_init(smem + 56, 1);
+            // state_tc_ready: 1 barriers, init_count=4
+            mbarrier_init(smem + 64, 4);
+            // recon_inputs_ready: 1 barriers, init_count=4
+            mbarrier_init(smem + 72, 4);
+            // recon_output_ready: 1 barriers, init_count=1
+            mbarrier_init(smem + 80, 1);
+            // a_ready: 1 barriers, init_count=4
+            mbarrier_init(smem + 88, 4);
+            // first_outputs_ready: 1 barriers, init_count=1
+            mbarrier_init(smem + 96, 1);
+            // outputs_ready: 1 barriers, init_count=1
+            mbarrier_init(smem + 104, 1);
+            // epilogue_done: 1 barriers, init_count=4
+            mbarrier_init(smem + 112, 4);
+            asm volatile("fence.mbarrier_init.release.cluster;");
+        }
+    }
+
+    __syncwarp();
+
+    // TMEM alloc (512 columns, 496 used)
+    volatile int* tmem_addr_storage = (volatile int*)(smem_raw + 120);
+    if (warp == 0) {
+        int _tmem_hold = smem + 120;
+        asm volatile("tcgen05.alloc.cta_group::1.sync.aligned.shared::cta.b32 [%0], %1;" :: "r"(_tmem_hold), "r"(512) : "memory");
+        asm volatile("tcgen05.relinquish_alloc_permit.cta_group::1.sync.aligned;");
+    }
+
+    __syncthreads();
+    asm volatile("tcgen05.fence::after_thread_sync;");
+
+    const int mbar_base = smem;
+    #define prep_ready_addr (mbar_base + 0)
+    #define boundary_local_ready_addr (mbar_base + 8)
+    #define dbeta_done_addr (mbar_base + 16)
+    #define qki_ready_addr (mbar_base + 24)
+    #define qki_tc_ready_addr (mbar_base + 32)
+    #define dv_ready_addr (mbar_base + 40)
+    #define value_tc_ready_addr (mbar_base + 48)
+    #define dh_ready_addr (mbar_base + 56)
+    #define state_tc_ready_addr (mbar_base + 64)
+    #define recon_inputs_ready_addr (mbar_base + 72)
+    #define recon_output_ready_addr (mbar_base + 80)
+    #define a_ready_addr (mbar_base + 88)
+    #define first_outputs_ready_addr (mbar_base + 96)
+    #define outputs_ready_addr (mbar_base + 104)
+    #define epilogue_done_addr (mbar_base + 112)
+    const int taddr = tmem_addr_storage[0];
+
+    // Kernel post-init ops
+    const int tmem_tmem_a_dh = taddr;
+    const int tmem_tmem_a_state = taddr + 64;
+    const int tmem_tmem_a_k = taddr + 128;
+    const int tmem_tmem_a_q = taddr + 144;
+    const int tmem_tmem_a_i = taddr + 160;
+    const int tmem_tmem_dkr = taddr + 176;
+    const int tmem_tmem_di = taddr + 208;
+    const int tmem_tmem_dq_local = taddr + 240;
+    const int tmem_tmem_dq_boundary = taddr + 272;
+    const int tmem_tmem_dk_local = taddr + 304;
+    const int tmem_tmem_dk_boundary = taddr + 336;
+    const int tmem_tmem_recon_kr = taddr + 64;
+    const int tmem_tmem_recon_state = taddr + 368;
+
+    // ---- Role: prep ----
+    if (warp <= 3) {
+        asm volatile("setmaxnreg.inc.sync.aligned.u32 208;");
+        { // prep_main
+            int ordered_chunk = blockIdx.x / num_heads;
+            int chunk_global = consumer_chunk_order[ordered_chunk];
+            int head = blockIdx.x - ordered_chunk * num_heads;
+            int sequence = chunk_sequence[chunk_global];
+            int local_chunk = chunk_index[chunk_global];
+            long long bos = cu_seqlens[sequence];
+            long long eos = cu_seqlens[sequence + 1];
+            long long chunk_start = bos + (long long)local_chunk * 32;
+            long long chunk_head = (long long)chunk_global * (long long)num_heads + (long long)head;
+            int warp_id_in_role = (warp - 0);
+            int prep_tid = warp_id_in_role * 32 + lane;
+            long long token_key_base = chunk_head * 32 * 128;
+            long long state_base = chunk_head * 128 * 128;
+            long long restore_base = chunk_head * 128;
+            int restore_key_col = prep_tid * 2 % 128;
+            float _vec_load_0[2];
+            {
+                float2 _v2_0 = *reinterpret_cast<const float2*>(tape_restore_factor + restore_base + (long long)restore_key_col);
+                _vec_load_0[0] = _v2_0.x;
+                _vec_load_0[0 + 1] = _v2_0.y;
+            }
+            float _rcp_0 = approx_rcp(_vec_load_0[0]);
+            float inv_restore0 = _rcp_0;
+            float _rcp_1 = approx_rcp(_vec_load_0[1]);
+            float inv_restore1 = _rcp_1;
+            #pragma unroll
+            for (int key_copy_pass = 0; key_copy_pass < 4; key_copy_pass++) {
+                int key_copy_item = key_copy_pass * 128 * 8 + prep_tid * 8;
+                asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
+                    :: "r"(s_k_addr + (unsigned int)((key_copy_item * 2 ^ (key_copy_item * 2 >> 8 & 7) << 4) / 2 * 2)), "l"(tape_kd + (token_key_base + (long long)key_copy_item)));
+                asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
+                    :: "r"(s_q_addr + (unsigned int)((key_copy_item * 2 ^ (key_copy_item * 2 >> 8 & 7) << 4) / 2 * 2)), "l"(tape_qd + (token_key_base + (long long)key_copy_item)));
+            }
+            asm volatile("cp.async.commit_group;");
+            #pragma unroll
+            for (int key_pass = 0; key_pass < 16; key_pass++) {
+                int item = key_pass * 256 + prep_tid * 2;
+                float _vec_load_1[2];
+                {
+                    uint32_t _bf16x2_bits_1;
+                    _bf16x2_bits_1 = *reinterpret_cast<const uint32_t*>(tape_kr + token_key_base + (long long)item);
+                    asm volatile(
+                        "{\n\t"
+                        "shl.b32 %0, %2, 16;\n\t"
+                        "and.b32 %1, %2, 0xffff0000;\n\t"
+                        "}\n"
+                        : "=f"((&_vec_load_1[0])[0]), "=f"((&_vec_load_1[0])[1])
+                        : "r"(_bf16x2_bits_1));
+                }
+                float i_values[2];
+                unsigned int i_packed[1];
+                i_values[0] = _vec_load_1[0] * inv_restore0;
+                i_values[1] = _vec_load_1[1] * inv_restore1;
+                #pragma unroll
+                for (int _lp = 0; _lp < 1; _lp++) {
+                    __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(i_values[_lp*2 + 0], i_values[_lp*2+1 + 0]));
+                    i_packed[_lp] = *(uint32_t*)&_bf2;
+                }
+                asm volatile("st.shared.b32 [%0], %1;" :: "r"(s_i_addr + (unsigned int)((item * 2 ^ (item * 2 >> 8 & 7) << 4) / 2 * 2)), "r"((i_packed[0])));
+            }
+            asm volatile("cp.async.wait_group 0;");
+            asm volatile("barrier.sync 8, 128;" ::: "memory");
+            if (warp_id_in_role == 0) {
+                if (elect_sync()) {
+                    mbarrier_arrive(qki_ready_addr);
+                }
+            }
+            long long j_base = chunk_head * 32 * 32;
+            #pragma unroll
+            for (int j_pass = 0; j_pass < 8; j_pass++) {
+                int item_1 = j_pass * 128 + prep_tid;
+                s_j[(item_1 * 2 ^ (item_1 * 2 >> 7 & 7) << 4) / 2] = tape_j[j_base + (long long)item_1];
+            }
+            long long token_value_base = chunk_head * 128 * 32;
+            #pragma unroll
+            for (int value_copy_pass = 0; value_copy_pass < 4; value_copy_pass++) {
+                int value_copy_item = value_copy_pass * 128 * 8 + prep_tid * 8;
+                int value_copy_dst = (value_copy_item * 2 ^ (value_copy_item * 2 >> 7 & 7) << 4) / 2 * 2;
+                asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
+                    :: "r"(s_x_addr + (unsigned int)value_copy_dst), "l"(tape_x + (token_value_base + (long long)value_copy_item)));
+                asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
+                    :: "r"(s_rt_addr + (unsigned int)value_copy_dst), "l"(tape_r + (token_value_base + (long long)value_copy_item)));
+            }
+            asm volatile("cp.async.commit_group;");
+            int tile = warp_id_in_role;
+            int row_base = tile / 2 * 16;
+            int col_base = tile % 2 * 16;
+            float acc[8];
+            int lane_matrix = lane / 8;
+            int lane_row8 = lane & 7;
+            #pragma unroll
+            for (int kk = 0; kk < 128; kk += 16) {
+                unsigned int a_plain[4];
+                unsigned int a_trans[4];
+                unsigned int b_plain[4];
+                unsigned int b_trans[4];
+                {
+                    int a_row = row_base + lane_row8 + (lane_matrix & 1) * 8;
+                    int a_col = kk + lane_matrix / 2 * 8;
+                    asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                        : "=r"(a_plain[0]), "=r"(a_plain[1]), "=r"(a_plain[2]), "=r"(a_plain[3])
+                        : "r"(s_k_addr + (unsigned int)(((1) ? ((a_row * 128 + a_col) * 2 ^ ((a_row * 128 + a_col) * 2 >> 8 & 7) << 4) / 2 : ((a_row * 128 + a_col) * 2 ^ ((a_row * 128 + a_col) * 2 >> 7 & 7) << 4) / 2) * 2))
+                        : "memory");
+                }
+                {
+                    #pragma unroll
+                    for (int n_half = 0; n_half < 2; n_half++) {
+                        int b_row = col_base + n_half * 8 + lane_row8;
+                        int b_col = kk + lane / 8 * 8;
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x2.shared.b16 {%0, %1}, [%2];\n"
+                            : "=r"(b_plain[n_half * 2]), "=r"(b_plain[n_half * 2 + 1])
+                            : "r"(s_i_addr + (unsigned int)(((1) ? ((b_row * 128 + b_col) * 2 ^ ((b_row * 128 + b_col) * 2 >> 8 & 7) << 4) / 2 : ((b_row * 128 + b_col) * 2 ^ ((b_row * 128 + b_col) * 2 >> 7 & 7) << 4) / 2) * 2))
+                            : "memory");
+                    }
+                }
+                {
+                    {
+                        {
+                            asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%10, %11, %12, %13};\n"
+                                : "=f"(acc[0]), "=f"(acc[1]), "=f"(acc[2]), "=f"(acc[3])
+                                : "r"(a_plain[0]), "r"(a_plain[1]), "r"(a_plain[2]), "r"(a_plain[3]), "r"(b_plain[0]), "r"(b_plain[1]), "f"(((kk == 0) ? 0.0f : acc[0])), "f"(((kk == 0) ? 0.0f : acc[1])), "f"(((kk == 0) ? 0.0f : acc[2])), "f"(((kk == 0) ? 0.0f : acc[3])));
+                            asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%10, %11, %12, %13};\n"
+                                : "=f"(acc[4]), "=f"(acc[(4) + 1]), "=f"(acc[(4) + 2]), "=f"(acc[(4) + 3])
+                                : "r"(a_plain[0]), "r"(a_plain[1]), "r"(a_plain[2]), "r"(a_plain[3]), "r"(b_plain[2]), "r"(b_plain[(2) + 1]), "f"(((kk == 0) ? 0.0f : acc[4])), "f"(((kk == 0) ? 0.0f : acc[(4) + 1])), "f"(((kk == 0) ? 0.0f : acc[(4) + 2])), "f"(((kk == 0) ? 0.0f : acc[(4) + 3])));
+                        }
+                    }
+                }
+            }
+            int frag_row = lane / 4;
+            int frag_col = (lane & 3) * 2;
+            #pragma unroll
+            for (int n_half_1 = 0; n_half_1 < 2; n_half_1++) {
+                int frag = n_half_1 * 4;
+                int row0 = row_base + frag_row;
+                int row1 = row0 + 8;
+                int col0 = col_base + n_half_1 * 8 + frag_col;
+                float pair[2];
+                unsigned int packed[1];
+                pair[0] = acc[frag];
+                pair[1] = acc[frag + 1];
+                #pragma unroll
+                for (int _lp = 0; _lp < 1; _lp++) {
+                    __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(pair[_lp*2 + 0], pair[_lp*2+1 + 0]));
+                    packed[_lp] = *(uint32_t*)&_bf2;
+                }
+                asm volatile("st.shared.b32 [%0], %1;" :: "r"(s_m_addr + (unsigned int)(((row0 * 32 + col0) * 2 ^ ((row0 * 32 + col0) * 2 >> 7 & 7) << 4) / 2 * 2)), "r"((packed[0])));
+                pair[0] = acc[frag + 2];
+                pair[1] = acc[frag + 3];
+                #pragma unroll
+                for (int _lp = 0; _lp < 1; _lp++) {
+                    __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(pair[_lp*2 + 0], pair[_lp*2+1 + 0]));
+                    packed[_lp] = *(uint32_t*)&_bf2;
+                }
+                asm volatile("st.shared.b32 [%0], %1;" :: "r"(s_m_addr + (unsigned int)(((row1 * 32 + col0) * 2 ^ ((row1 * 32 + col0) * 2 >> 7 & 7) << 4) / 2 * 2)), "r"((packed[0])));
+            }
+            asm volatile("barrier.sync 8, 128;" ::: "memory");
+            if (boundary_ready_target != 0) {
+                if (warp_id_in_role == 0) {
+                    {
+                        unsigned int* _gca_p = reinterpret_cast<unsigned int*>(boundary_ready) + (chunk_head);
+                        while (true) {
+                            unsigned int _gca_v;
+                            asm volatile("ld.acquire.gpu.global.u32 %0, [%1];" : "=r"(_gca_v) : "l"(_gca_p));
+                            if (_gca_v >= (unsigned int)(boundary_ready_target)) break;
+                        }
+                    }
+                }
+                asm volatile("barrier.sync 8, 128;" ::: "memory");
+            }
+            if (warp_id_in_role == 0) {
+                if (elect_sync()) {
+                    mbarrier_arrive(boundary_local_ready_addr);
+                }
+            }
+            #pragma unroll
+            for (int dh_copy_pass = 0; dh_copy_pass < 16; dh_copy_pass++) {
+                int dh_copy_item = dh_copy_pass * 128 * 8 + prep_tid * 8;
+                asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
+                    :: "r"(s_dh_stage_addr + (unsigned int)((dh_copy_item * 2 ^ (dh_copy_item * 2 >> 7 & 7) << 4) / 2 * 2)), "l"(chunk_dh + (state_base + (long long)dh_copy_item)));
+            }
+            asm volatile("cp.async.commit_group;");
+            #pragma unroll
+            for (int boundary_copy_pass = 0; boundary_copy_pass < 4; boundary_copy_pass++) {
+                int boundary_copy_item = boundary_copy_pass * 128 * 8 + prep_tid * 8;
+                int boundary_copy_dst = (boundary_copy_item * 2 ^ (boundary_copy_item * 2 >> 7 & 7) << 4) / 2 * 2;
+                asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
+                    :: "r"(s_dot_addr + (unsigned int)boundary_copy_dst), "l"(chunk_dx + (token_value_base + (long long)boundary_copy_item)));
+            }
+            asm volatile("cp.async.commit_group;");
+            asm volatile("cp.async.wait_group 2;");
+            asm volatile("barrier.sync 8, 128;" ::: "memory");
+            int value_token = lane;
+            long long value_token_global = chunk_start + (long long)value_token;
+            float value_beta = 0.0f;
+            if (value_token_global < eos) {
+                value_beta = beta_active[value_token_global * (long long)num_heads + (long long)head];
+            }
+            #pragma unroll
+            for (int value_segment = 0; value_segment < 4; value_segment++) {
+                int tc_segment = warp_id_in_role * 4 + value_segment;
+                float r_values[8];
+                #pragma unroll
+                for (int value_elem = 0; value_elem < 8; value_elem++) {
+                    int value_row = tc_segment * 8 + value_elem;
+                    int value_major_item = value_row * 32 + value_token;
+                    __nv_bfloat16 r_value = s_rt[(value_major_item * 2 ^ (value_major_item * 2 >> 7 & 7) << 4) / 2];
+                    float _cvt_f32_0 = __bfloat162float(r_value);
+                    r_values[value_elem] = _cvt_f32_0;
+                }
+                unsigned int packed_1[4];
+                #pragma unroll
+                for (int _lp = 0; _lp < 4; _lp++) {
+                    __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(r_values[_lp*2 + 0], r_values[_lp*2+1 + 0]));
+                    packed_1[_lp] = *(uint32_t*)&_bf2;
+                }
+                asm volatile("st.shared.v4.b32 [%0], {%1,%2,%3,%4};" :: "r"(s_rt_tc_addr + ((s_rt_tc_addr + (unsigned int)(tc_segment * 8 / 64 * 4096 + value_token * 128 + tc_segment * 8 % 64 * 2 ^ (tc_segment * 8 / 64 * 4096 + value_token * 128 + tc_segment * 8 % 64 * 2 >> 7 & 7) << 4)) - s_rt_tc_addr)), "r"(packed_1[0]), "r"(packed_1[1]), "r"(packed_1[2]), "r"(packed_1[3]) : "memory");
+            }
+            asm volatile("cp.async.wait_group 1;");
+            asm volatile("barrier.sync 8, 128;" ::: "memory");
+            if (warp_id_in_role == 0) {
+                if (elect_sync()) {
+                    mbarrier_arrive(dh_ready_addr);
+                }
+            }
+            asm volatile("cp.async.wait_group 0;");
+            asm volatile("barrier.sync 8, 128;" ::: "memory");
+            #pragma unroll
+            for (int value_segment_1 = 0; value_segment_1 < 4; value_segment_1++) {
+                int tc_segment_1 = warp_id_in_role * 4 + value_segment_1;
+                float det_values[8];
+                #pragma unroll
+                for (int value_elem_1 = 0; value_elem_1 < 8; value_elem_1++) {
+                    int value_row_1 = tc_segment_1 * 8 + value_elem_1;
+                    int value_major_item_1 = value_row_1 * 32 + value_token;
+                    __nv_bfloat16 dx_value = s_dot[(value_major_item_1 * 2 ^ (value_major_item_1 * 2 >> 7 & 7) << 4) / 2];
+                    int det_group = tc_segment_1 * 2 + value_elem_1 / 4;
+                    s_det[value_row_1 * 32 + (value_token ^ det_group)] = dx_value;
+                    float _cvt_f32_1 = __bfloat162float(dx_value);
+                    det_values[value_elem_1] = _cvt_f32_1 * value_beta;
+                }
+                unsigned int packed_2[4];
+                #pragma unroll
+                for (int _lp = 0; _lp < 4; _lp++) {
+                    __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(det_values[_lp*2 + 0], det_values[_lp*2+1 + 0]));
+                    packed_2[_lp] = *(uint32_t*)&_bf2;
+                }
+                asm volatile("st.shared.v4.b32 [%0], {%1,%2,%3,%4};" :: "r"(s_det_tc_addr + ((s_det_tc_addr + (unsigned int)(tc_segment_1 * 8 / 64 * 4096 + value_token * 128 + tc_segment_1 * 8 % 64 * 2 ^ (tc_segment_1 * 8 / 64 * 4096 + value_token * 128 + tc_segment_1 * 8 % 64 * 2 >> 7 & 7) << 4)) - s_det_tc_addr)), "r"(packed_2[0]), "r"(packed_2[1]), "r"(packed_2[2]), "r"(packed_2[3]) : "memory");
+            }
+            asm volatile("barrier.sync 8, 128;" ::: "memory");
+            asm volatile("fence.proxy.async.shared::cta;" ::: "memory");
+            if (warp_id_in_role == 0) {
+                if (elect_sync()) {
+                    mbarrier_arrive(dv_ready_addr);
+                }
+            }
+            unsigned int _phase_value_tc_ready_0 = 0;
+            mbarrier_wait(value_tc_ready_addr, _phase_value_tc_ready_0);
+            _phase_value_tc_ready_0 ^= 1;
+            asm volatile("barrier.sync 8, 128;" ::: "memory");
+            int lane_matrix_0 = lane / 8;
+            int lane_row8_1 = lane & 7;
+            #pragma unroll
+            for (int kk_1 = 0; kk_1 < 128; kk_1 += 16) {
+                unsigned int a_plain_1[4];
+                unsigned int a_trans_1[4];
+                unsigned int b_plain_1[4];
+                unsigned int b_trans_1[4];
+                {
+                    int a_row_1 = kk_1 + lane_row8_1 + lane_matrix_0 / 2 * 8;
+                    int a_col_1 = row_base + (lane_matrix_0 & 1) * 8;
+                    asm volatile("ldmatrix.sync.aligned.m8n8.x4.trans.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                        : "=r"(a_trans_1[0]), "=r"(a_trans_1[1]), "=r"(a_trans_1[2]), "=r"(a_trans_1[3])
+                        : "r"(s_rt_addr + (unsigned int)(((0) ? ((a_row_1 * 32 + a_col_1) * 2 ^ ((a_row_1 * 32 + a_col_1) * 2 >> 8 & 7) << 4) / 2 : ((a_row_1 * 32 + a_col_1) * 2 ^ ((a_row_1 * 32 + a_col_1) * 2 >> 7 & 7) << 4) / 2) * 2))
+                        : "memory");
+                }
+                {
+                    #pragma unroll
+                    for (int n_half_2 = 0; n_half_2 < 2; n_half_2++) {
+                        int b_row_1 = col_base + n_half_2 * 8 + lane_row8_1;
+                        int b_col_1 = kk_1 + lane / 8 * 8;
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x2.shared.b16 {%0, %1}, [%2];\n"
+                            : "=r"(b_plain_1[n_half_2 * 2]), "=r"(b_plain_1[n_half_2 * 2 + 1])
+                            : "r"(s_do_stage_addr + (unsigned int)(((1) ? ((b_row_1 * 128 + b_col_1) * 2 ^ ((b_row_1 * 128 + b_col_1) * 2 >> 8 & 7) << 4) / 2 : ((b_row_1 * 128 + b_col_1) * 2 ^ ((b_row_1 * 128 + b_col_1) * 2 >> 7 & 7) << 4) / 2) * 2))
+                            : "memory");
+                    }
+                }
+                {
+                    {
+                        {
+                            asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%10, %11, %12, %13};\n"
+                                : "=f"(acc[0]), "=f"(acc[1]), "=f"(acc[2]), "=f"(acc[3])
+                                : "r"(a_trans_1[0]), "r"(a_trans_1[1]), "r"(a_trans_1[2]), "r"(a_trans_1[3]), "r"(b_plain_1[0]), "r"(b_plain_1[1]), "f"(((kk_1 == 0) ? 0.0f : acc[0])), "f"(((kk_1 == 0) ? 0.0f : acc[1])), "f"(((kk_1 == 0) ? 0.0f : acc[2])), "f"(((kk_1 == 0) ? 0.0f : acc[3])));
+                            asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%10, %11, %12, %13};\n"
+                                : "=f"(acc[4]), "=f"(acc[(4) + 1]), "=f"(acc[(4) + 2]), "=f"(acc[(4) + 3])
+                                : "r"(a_trans_1[0]), "r"(a_trans_1[1]), "r"(a_trans_1[2]), "r"(a_trans_1[3]), "r"(b_plain_1[2]), "r"(b_plain_1[(2) + 1]), "f"(((kk_1 == 0) ? 0.0f : acc[4])), "f"(((kk_1 == 0) ? 0.0f : acc[(4) + 1])), "f"(((kk_1 == 0) ? 0.0f : acc[(4) + 2])), "f"(((kk_1 == 0) ? 0.0f : acc[(4) + 3])));
+                        }
+                    }
+                }
+            }
+            float dn_values[8];
+            dn_values[0] = 0.0f;
+            dn_values[1] = 0.0f;
+            dn_values[2] = 0.0f;
+            dn_values[3] = 0.0f;
+            dn_values[4] = 0.0f;
+            dn_values[5] = 0.0f;
+            dn_values[6] = 0.0f;
+            dn_values[7] = 0.0f;
+            int dn_row0 = row_base + lane / 4;
+            int dn_row1 = dn_row0 + 8;
+            int dn_col0 = col_base + (lane & 3) * 2;
+            if (dn_row0 <= dn_col0) {
+                dn_values[0] = acc[0];
+            }
+            if (dn_row0 <= dn_col0 + 1) {
+                dn_values[1] = acc[1];
+            }
+            if (dn_row1 <= dn_col0) {
+                dn_values[2] = acc[2];
+            }
+            if (dn_row1 <= dn_col0 + 1) {
+                dn_values[3] = acc[3];
+            }
+            if (dn_row0 <= dn_col0 + 8) {
+                dn_values[4] = acc[4];
+            }
+            if (dn_row0 <= dn_col0 + 9) {
+                dn_values[5] = acc[5];
+            }
+            if (dn_row1 <= dn_col0 + 8) {
+                dn_values[6] = acc[6];
+            }
+            if (dn_row1 <= dn_col0 + 9) {
+                dn_values[7] = acc[7];
+            }
+            unsigned int packed_3[4];
+            #pragma unroll
+            for (int _lp = 0; _lp < 4; _lp++) {
+                __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(dn_values[_lp*2 + 0], dn_values[_lp*2+1 + 0]));
+                packed_3[_lp] = *(uint32_t*)&_bf2;
+            }
+            int direct_row = row_base + lane % 16;
+            int direct_col = col_base + lane / 16 * 8;
+            uint32_t _stmatrix_addr_2 = static_cast<uint32_t>((unsigned long long)(s_dnt_tc_addr + (unsigned int)(direct_col / 16 * 1024 + direct_row * 32 + direct_col % 16 * 2 ^ (direct_col / 16 * 1024 + direct_row * 32 + direct_col % 16 * 2 >> 7 & 1) << 4)));
+            asm volatile("stmatrix.sync.aligned.m8n8.x4.shared.b16 [%0], {%1, %2, %3, %4};\n"
+                :: "r"(_stmatrix_addr_2), "r"(*reinterpret_cast<const uint32_t*>(&packed_3[0])), "r"(*reinterpret_cast<const uint32_t*>(&packed_3[1])), "r"(*reinterpret_cast<const uint32_t*>(&packed_3[2])), "r"(*reinterpret_cast<const uint32_t*>(&packed_3[3]))
+                : "memory");
+            #pragma unroll
+            for (int publish_pair = 0; publish_pair < 2; publish_pair++) {
+                int transpose_row = col_base + publish_pair * 8 + (lane & 7);
+                int transpose_col = row_base + lane / 8 * 8;
+                uint32_t _stmatrix_addr_3 = static_cast<uint32_t>((unsigned long long)(s_dn_tc_addr + (unsigned int)(transpose_col / 16 * 1024 + transpose_row * 32 + transpose_col % 16 * 2 ^ (transpose_col / 16 * 1024 + transpose_row * 32 + transpose_col % 16 * 2 >> 7 & 1) << 4)));
+                asm volatile("stmatrix.sync.aligned.m8n8.x2.trans.shared.b16 [%0], {%1, %2};\n"
+                    :: "r"(_stmatrix_addr_3), "r"(*reinterpret_cast<const uint32_t*>(&packed_3[publish_pair * 2])), "r"(*reinterpret_cast<const uint32_t*>(&packed_3[publish_pair * 2 + 1]))
+                    : "memory");
+            }
+            int lane_matrix_2 = lane / 8;
+            int lane_row8_3 = lane & 7;
+            #pragma unroll
+            for (int kk_2 = 0; kk_2 < 128; kk_2 += 16) {
+                unsigned int a_plain_2[4];
+                unsigned int a_trans_2[4];
+                unsigned int b_plain_2[4];
+                unsigned int b_trans_2[4];
+                {
+                    int a_row_2 = kk_2 + lane_row8_3 + lane_matrix_2 / 2 * 8;
+                    int a_col_2 = row_base + (lane_matrix_2 & 1) * 8;
+                    asm volatile("ldmatrix.sync.aligned.m8n8.x4.trans.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                        : "=r"(a_trans_2[0]), "=r"(a_trans_2[1]), "=r"(a_trans_2[2]), "=r"(a_trans_2[3])
+                        : "r"(s_drt_addr + (unsigned int)(((0) ? ((a_row_2 * 32 + a_col_2) * 2 ^ ((a_row_2 * 32 + a_col_2) * 2 >> 8 & 7) << 4) / 2 : ((a_row_2 * 32 + a_col_2) * 2 ^ ((a_row_2 * 32 + a_col_2) * 2 >> 7 & 7) << 4) / 2) * 2))
+                        : "memory");
+                }
+                {
+                    #pragma unroll
+                    for (int n_half_3 = 0; n_half_3 < 2; n_half_3++) {
+                        int b_row_2 = kk_2 + lane % 16;
+                        int b_col_2 = col_base + n_half_3 * 8;
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x2.trans.shared.b16 {%0, %1}, [%2];\n"
+                            : "=r"(b_trans_2[n_half_3 * 2]), "=r"(b_trans_2[n_half_3 * 2 + 1])
+                            : "r"(s_x_addr + (unsigned int)(((0) ? ((b_row_2 * 32 + b_col_2) * 2 ^ ((b_row_2 * 32 + b_col_2) * 2 >> 8 & 7) << 4) / 2 : ((b_row_2 * 32 + b_col_2) * 2 ^ ((b_row_2 * 32 + b_col_2) * 2 >> 7 & 7) << 4) / 2) * 2))
+                            : "memory");
+                    }
+                }
+                {
+                    {
+                        {
+                            asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%10, %11, %12, %13};\n"
+                                : "=f"(acc[0]), "=f"(acc[1]), "=f"(acc[2]), "=f"(acc[3])
+                                : "r"(a_trans_2[0]), "r"(a_trans_2[1]), "r"(a_trans_2[2]), "r"(a_trans_2[3]), "r"(b_trans_2[0]), "r"(b_trans_2[1]), "f"(((kk_2 == 0) ? 0.0f : acc[0])), "f"(((kk_2 == 0) ? 0.0f : acc[1])), "f"(((kk_2 == 0) ? 0.0f : acc[2])), "f"(((kk_2 == 0) ? 0.0f : acc[3])));
+                            asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%10, %11, %12, %13};\n"
+                                : "=f"(acc[4]), "=f"(acc[(4) + 1]), "=f"(acc[(4) + 2]), "=f"(acc[(4) + 3])
+                                : "r"(a_trans_2[0]), "r"(a_trans_2[1]), "r"(a_trans_2[2]), "r"(a_trans_2[3]), "r"(b_trans_2[2]), "r"(b_trans_2[(2) + 1]), "f"(((kk_2 == 0) ? 0.0f : acc[4])), "f"(((kk_2 == 0) ? 0.0f : acc[(4) + 1])), "f"(((kk_2 == 0) ? 0.0f : acc[(4) + 2])), "f"(((kk_2 == 0) ? 0.0f : acc[(4) + 3])));
+                        }
+                    }
+                }
+            }
+            int frag_row_4 = lane / 4;
+            int frag_col_5 = (lane & 3) * 2;
+            #pragma unroll
+            for (int n_half_4 = 0; n_half_4 < 2; n_half_4++) {
+                int frag_1 = n_half_4 * 4;
+                int row0_1 = row_base + frag_row_4;
+                int row1_1 = row0_1 + 8;
+                int col0_1 = col_base + n_half_4 * 8 + frag_col_5;
+                float pair_1[2];
+                unsigned int packed_0[1];
+                pair_1[0] = acc[frag_1];
+                pair_1[1] = acc[frag_1 + 1];
+                #pragma unroll
+                for (int _lp = 0; _lp < 1; _lp++) {
+                    __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(pair_1[_lp*2 + 0], pair_1[_lp*2+1 + 0]));
+                    packed_0[_lp] = *(uint32_t*)&_bf2;
+                }
+                asm volatile("st.shared.b32 [%0], %1;" :: "r"(s_dj_addr + (unsigned int)(((row0_1 * 32 + col0_1) * 2 ^ ((row0_1 * 32 + col0_1) * 2 >> 7 & 7) << 4) / 2 * 2)), "r"((packed_0[0])));
+                pair_1[0] = acc[frag_1 + 2];
+                pair_1[1] = acc[frag_1 + 3];
+                #pragma unroll
+                for (int _lp = 0; _lp < 1; _lp++) {
+                    __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(pair_1[_lp*2 + 0], pair_1[_lp*2+1 + 0]));
+                    packed_0[_lp] = *(uint32_t*)&_bf2;
+                }
+                asm volatile("st.shared.b32 [%0], %1;" :: "r"(s_dj_addr + (unsigned int)(((row1_1 * 32 + col0_1) * 2 ^ ((row1_1 * 32 + col0_1) * 2 >> 7 & 7) << 4) / 2 * 2)), "r"((packed_0[0])));
+            }
+            asm volatile("barrier.sync 8, 128;" ::: "memory");
+            #pragma unroll
+            for (int mask_pass = 0; mask_pass < 8; mask_pass++) {
+                int item_2 = mask_pass * 128 + prep_tid;
+                int row = item_2 / 32;
+                int col = item_2 % 32;
+                if (row <= col) {
+                    s_m[(item_2 * 2 ^ (item_2 * 2 >> 7 & 7) << 4) / 2] = 0.0f;
+                }
+            }
+            asm volatile("barrier.sync 8, 128;" ::: "memory");
+            int lane_matrix_6 = lane / 8;
+            int lane_row8_7 = lane & 7;
+            #pragma unroll
+            for (int kk_3 = 0; kk_3 < 32; kk_3 += 16) {
+                unsigned int a_plain_3[4];
+                unsigned int a_trans_3[4];
+                unsigned int b_plain_3[4];
+                unsigned int b_trans_3[4];
+                {
+                    int a_row_3 = kk_3 + lane_row8_7 + lane_matrix_6 / 2 * 8;
+                    int a_col_3 = row_base + (lane_matrix_6 & 1) * 8;
+                    asm volatile("ldmatrix.sync.aligned.m8n8.x4.trans.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                        : "=r"(a_trans_3[0]), "=r"(a_trans_3[1]), "=r"(a_trans_3[2]), "=r"(a_trans_3[3])
+                        : "r"(s_j_addr + (unsigned int)(((0) ? ((a_row_3 * 32 + a_col_3) * 2 ^ ((a_row_3 * 32 + a_col_3) * 2 >> 8 & 7) << 4) / 2 : ((a_row_3 * 32 + a_col_3) * 2 ^ ((a_row_3 * 32 + a_col_3) * 2 >> 7 & 7) << 4) / 2) * 2))
+                        : "memory");
+                }
+                {
+                    #pragma unroll
+                    for (int n_half_5 = 0; n_half_5 < 2; n_half_5++) {
+                        int b_row_3 = kk_3 + lane % 16;
+                        int b_col_3 = col_base + n_half_5 * 8;
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x2.trans.shared.b16 {%0, %1}, [%2];\n"
+                            : "=r"(b_trans_3[n_half_5 * 2]), "=r"(b_trans_3[n_half_5 * 2 + 1])
+                            : "r"(s_dj_addr + (unsigned int)(((0) ? ((b_row_3 * 32 + b_col_3) * 2 ^ ((b_row_3 * 32 + b_col_3) * 2 >> 8 & 7) << 4) / 2 : ((b_row_3 * 32 + b_col_3) * 2 ^ ((b_row_3 * 32 + b_col_3) * 2 >> 7 & 7) << 4) / 2) * 2))
+                            : "memory");
+                    }
+                }
+                {
+                    {
+                        {
+                            asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%10, %11, %12, %13};\n"
+                                : "=f"(acc[0]), "=f"(acc[1]), "=f"(acc[2]), "=f"(acc[3])
+                                : "r"(a_trans_3[0]), "r"(a_trans_3[1]), "r"(a_trans_3[2]), "r"(a_trans_3[3]), "r"(b_trans_3[0]), "r"(b_trans_3[1]), "f"(((kk_3 == 0) ? 0.0f : acc[0])), "f"(((kk_3 == 0) ? 0.0f : acc[1])), "f"(((kk_3 == 0) ? 0.0f : acc[2])), "f"(((kk_3 == 0) ? 0.0f : acc[3])));
+                            asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%10, %11, %12, %13};\n"
+                                : "=f"(acc[4]), "=f"(acc[(4) + 1]), "=f"(acc[(4) + 2]), "=f"(acc[(4) + 3])
+                                : "r"(a_trans_3[0]), "r"(a_trans_3[1]), "r"(a_trans_3[2]), "r"(a_trans_3[3]), "r"(b_trans_3[2]), "r"(b_trans_3[(2) + 1]), "f"(((kk_3 == 0) ? 0.0f : acc[4])), "f"(((kk_3 == 0) ? 0.0f : acc[(4) + 1])), "f"(((kk_3 == 0) ? 0.0f : acc[(4) + 2])), "f"(((kk_3 == 0) ? 0.0f : acc[(4) + 3])));
+                        }
+                    }
+                }
+            }
+            int frag_row_8 = lane / 4;
+            int frag_col_9 = (lane & 3) * 2;
+            #pragma unroll
+            for (int n_half_6 = 0; n_half_6 < 2; n_half_6++) {
+                int frag_2 = n_half_6 * 4;
+                int row0_2 = row_base + frag_row_8;
+                int row1_2 = row0_2 + 8;
+                int col0_2 = col_base + n_half_6 * 8 + frag_col_9;
+                float pair_2[2];
+                unsigned int packed_0_1[1];
+                pair_2[0] = acc[frag_2];
+                pair_2[1] = acc[frag_2 + 1];
+                #pragma unroll
+                for (int _lp = 0; _lp < 1; _lp++) {
+                    __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(pair_2[_lp*2 + 0], pair_2[_lp*2+1 + 0]));
+                    packed_0_1[_lp] = *(uint32_t*)&_bf2;
+                }
+                asm volatile("st.shared.b32 [%0], %1;" :: "r"(s_tmp_addr + (unsigned int)(((row0_2 * 32 + col0_2) * 2 ^ ((row0_2 * 32 + col0_2) * 2 >> 7 & 7) << 4) / 2 * 2)), "r"((packed_0_1[0])));
+                pair_2[0] = acc[frag_2 + 2];
+                pair_2[1] = acc[frag_2 + 3];
+                #pragma unroll
+                for (int _lp = 0; _lp < 1; _lp++) {
+                    __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(pair_2[_lp*2 + 0], pair_2[_lp*2+1 + 0]));
+                    packed_0_1[_lp] = *(uint32_t*)&_bf2;
+                }
+                asm volatile("st.shared.b32 [%0], %1;" :: "r"(s_tmp_addr + (unsigned int)(((row1_2 * 32 + col0_2) * 2 ^ ((row1_2 * 32 + col0_2) * 2 >> 7 & 7) << 4) / 2 * 2)), "r"((packed_0_1[0])));
+            }
+            asm volatile("barrier.sync 8, 128;" ::: "memory");
+            int lane_matrix_10 = lane / 8;
+            int lane_row8_11 = lane & 7;
+            #pragma unroll
+            for (int kk_4 = 0; kk_4 < 32; kk_4 += 16) {
+                unsigned int a_plain_4[4];
+                unsigned int a_trans_4[4];
+                unsigned int b_plain_4[4];
+                unsigned int b_trans_4[4];
+                {
+                    int a_row_4 = row_base + lane_row8_11 + (lane_matrix_10 & 1) * 8;
+                    int a_col_4 = kk_4 + lane_matrix_10 / 2 * 8;
+                    asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                        : "=r"(a_plain_4[0]), "=r"(a_plain_4[1]), "=r"(a_plain_4[2]), "=r"(a_plain_4[3])
+                        : "r"(s_tmp_addr + (unsigned int)(((0) ? ((a_row_4 * 32 + a_col_4) * 2 ^ ((a_row_4 * 32 + a_col_4) * 2 >> 8 & 7) << 4) / 2 : ((a_row_4 * 32 + a_col_4) * 2 ^ ((a_row_4 * 32 + a_col_4) * 2 >> 7 & 7) << 4) / 2) * 2))
+                        : "memory");
+                }
+                {
+                    #pragma unroll
+                    for (int n_half_7 = 0; n_half_7 < 2; n_half_7++) {
+                        int b_row_4 = col_base + n_half_7 * 8 + lane_row8_11;
+                        int b_col_4 = kk_4 + lane / 8 * 8;
+                        asm volatile("ldmatrix.sync.aligned.m8n8.x2.shared.b16 {%0, %1}, [%2];\n"
+                            : "=r"(b_plain_4[n_half_7 * 2]), "=r"(b_plain_4[n_half_7 * 2 + 1])
+                            : "r"(s_j_addr + (unsigned int)(((0) ? ((b_row_4 * 32 + b_col_4) * 2 ^ ((b_row_4 * 32 + b_col_4) * 2 >> 8 & 7) << 4) / 2 : ((b_row_4 * 32 + b_col_4) * 2 ^ ((b_row_4 * 32 + b_col_4) * 2 >> 7 & 7) << 4) / 2) * 2))
+                            : "memory");
+                    }
+                }
+                {
+                    {
+                        {
+                            asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%10, %11, %12, %13};\n"
+                                : "=f"(acc[0]), "=f"(acc[1]), "=f"(acc[2]), "=f"(acc[3])
+                                : "r"(a_plain_4[0]), "r"(a_plain_4[1]), "r"(a_plain_4[2]), "r"(a_plain_4[3]), "r"(b_plain_4[0]), "r"(b_plain_4[1]), "f"(((kk_4 == 0) ? 0.0f : acc[0])), "f"(((kk_4 == 0) ? 0.0f : acc[1])), "f"(((kk_4 == 0) ? 0.0f : acc[2])), "f"(((kk_4 == 0) ? 0.0f : acc[3])));
+                            asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%10, %11, %12, %13};\n"
+                                : "=f"(acc[4]), "=f"(acc[(4) + 1]), "=f"(acc[(4) + 2]), "=f"(acc[(4) + 3])
+                                : "r"(a_plain_4[0]), "r"(a_plain_4[1]), "r"(a_plain_4[2]), "r"(a_plain_4[3]), "r"(b_plain_4[2]), "r"(b_plain_4[(2) + 1]), "f"(((kk_4 == 0) ? 0.0f : acc[4])), "f"(((kk_4 == 0) ? 0.0f : acc[(4) + 1])), "f"(((kk_4 == 0) ? 0.0f : acc[(4) + 2])), "f"(((kk_4 == 0) ? 0.0f : acc[(4) + 3])));
+                        }
+                    }
+                }
+            }
+            const float2 _scale2_4 = {-1.0f, -1.0f};
+            #pragma unroll
+            for (int _ls = 0; _ls < 4; _ls++)
+                mul_f32x2_inplace(&reinterpret_cast<float2*>(acc)[_ls], _scale2_4);
+            int frag_row_12 = lane / 4;
+            int frag_col_13 = (lane & 3) * 2;
+            #pragma unroll
+            for (int n_half_8 = 0; n_half_8 < 2; n_half_8++) {
+                int frag_3 = n_half_8 * 4;
+                int row0_3 = row_base + frag_row_12;
+                int row1_3 = row0_3 + 8;
+                int col0_3 = col_base + n_half_8 * 8 + frag_col_13;
+                float pair_3[2];
+                unsigned int packed_0_2[1];
+                pair_3[0] = acc[frag_3];
+                pair_3[1] = acc[frag_3 + 1];
+                #pragma unroll
+                for (int _lp = 0; _lp < 1; _lp++) {
+                    __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(pair_3[_lp*2 + 0], pair_3[_lp*2+1 + 0]));
+                    packed_0_2[_lp] = *(uint32_t*)&_bf2;
+                }
+                asm volatile("st.shared.b32 [%0], %1;" :: "r"(s_df_addr + (unsigned int)(((row0_3 * 32 + col0_3) * 2 ^ ((row0_3 * 32 + col0_3) * 2 >> 7 & 7) << 4) / 2 * 2)), "r"((packed_0_2[0])));
+                pair_3[0] = acc[frag_3 + 2];
+                pair_3[1] = acc[frag_3 + 3];
+                #pragma unroll
+                for (int _lp = 0; _lp < 1; _lp++) {
+                    __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(pair_3[_lp*2 + 0], pair_3[_lp*2+1 + 0]));
+                    packed_0_2[_lp] = *(uint32_t*)&_bf2;
+                }
+                asm volatile("st.shared.b32 [%0], %1;" :: "r"(s_df_addr + (unsigned int)(((row1_3 * 32 + col0_3) * 2 ^ ((row1_3 * 32 + col0_3) * 2 >> 7 & 7) << 4) / 2 * 2)), "r"((packed_0_2[0])));
+            }
+            float _shfl_0 = __shfl_sync(0xFFFFFFFF, value_beta, dn_row0);
+            float dm_beta0 = _shfl_0;
+            float _shfl_1 = __shfl_sync(0xFFFFFFFF, value_beta, dn_row1);
+            float dm_beta1 = _shfl_1;
+            float dm_values[8];
+            dm_values[0] = 0.0f;
+            dm_values[1] = 0.0f;
+            dm_values[2] = 0.0f;
+            dm_values[3] = 0.0f;
+            dm_values[4] = 0.0f;
+            dm_values[5] = 0.0f;
+            dm_values[6] = 0.0f;
+            dm_values[7] = 0.0f;
+            if (dn_row0 > dn_col0) {
+                __nv_bfloat16 _cvt_bf16_0 = __float2bfloat16(acc[0]);
+                float _cvt_f32_2 = __bfloat162float(_cvt_bf16_0);
+                dm_values[0] = _cvt_f32_2 * dm_beta0;
+            }
+            if (dn_row0 > dn_col0 + 1) {
+                __nv_bfloat16 _cvt_bf16_1 = __float2bfloat16(acc[1]);
+                float _cvt_f32_3 = __bfloat162float(_cvt_bf16_1);
+                dm_values[1] = _cvt_f32_3 * dm_beta0;
+            }
+            if (dn_row1 > dn_col0) {
+                __nv_bfloat16 _cvt_bf16_2 = __float2bfloat16(acc[2]);
+                float _cvt_f32_4 = __bfloat162float(_cvt_bf16_2);
+                dm_values[2] = _cvt_f32_4 * dm_beta1;
+            }
+            if (dn_row1 > dn_col0 + 1) {
+                __nv_bfloat16 _cvt_bf16_3 = __float2bfloat16(acc[3]);
+                float _cvt_f32_5 = __bfloat162float(_cvt_bf16_3);
+                dm_values[3] = _cvt_f32_5 * dm_beta1;
+            }
+            if (dn_row0 > dn_col0 + 8) {
+                __nv_bfloat16 _cvt_bf16_4 = __float2bfloat16(acc[4]);
+                float _cvt_f32_6 = __bfloat162float(_cvt_bf16_4);
+                dm_values[4] = _cvt_f32_6 * dm_beta0;
+            }
+            if (dn_row0 > dn_col0 + 9) {
+                __nv_bfloat16 _cvt_bf16_5 = __float2bfloat16(acc[5]);
+                float _cvt_f32_7 = __bfloat162float(_cvt_bf16_5);
+                dm_values[5] = _cvt_f32_7 * dm_beta0;
+            }
+            if (dn_row1 > dn_col0 + 8) {
+                __nv_bfloat16 _cvt_bf16_6 = __float2bfloat16(acc[6]);
+                float _cvt_f32_8 = __bfloat162float(_cvt_bf16_6);
+                dm_values[6] = _cvt_f32_8 * dm_beta1;
+            }
+            if (dn_row1 > dn_col0 + 9) {
+                __nv_bfloat16 _cvt_bf16_7 = __float2bfloat16(acc[7]);
+                float _cvt_f32_9 = __bfloat162float(_cvt_bf16_7);
+                dm_values[7] = _cvt_f32_9 * dm_beta1;
+            }
+            unsigned int packed_14[4];
+            #pragma unroll
+            for (int _lp = 0; _lp < 4; _lp++) {
+                __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(dm_values[_lp*2 + 0], dm_values[_lp*2+1 + 0]));
+                packed_14[_lp] = *(uint32_t*)&_bf2;
+            }
+            int direct_row_15 = row_base + lane % 16;
+            int direct_col_16 = col_base + lane / 16 * 8;
+            uint32_t _stmatrix_addr_5 = static_cast<uint32_t>((unsigned long long)(s_dmt_tc_addr + (unsigned int)(direct_col_16 / 16 * 1024 + direct_row_15 * 32 + direct_col_16 % 16 * 2 ^ (direct_col_16 / 16 * 1024 + direct_row_15 * 32 + direct_col_16 % 16 * 2 >> 7 & 1) << 4)));
+            asm volatile("stmatrix.sync.aligned.m8n8.x4.shared.b16 [%0], {%1, %2, %3, %4};\n"
+                :: "r"(_stmatrix_addr_5), "r"(*reinterpret_cast<const uint32_t*>(&packed_14[0])), "r"(*reinterpret_cast<const uint32_t*>(&packed_14[1])), "r"(*reinterpret_cast<const uint32_t*>(&packed_14[2])), "r"(*reinterpret_cast<const uint32_t*>(&packed_14[3]))
+                : "memory");
+            #pragma unroll
+            for (int publish_pair_1 = 0; publish_pair_1 < 2; publish_pair_1++) {
+                int transpose_row_1 = col_base + publish_pair_1 * 8 + (lane & 7);
+                int transpose_col_1 = row_base + lane / 8 * 8;
+                uint32_t _stmatrix_addr_6 = static_cast<uint32_t>((unsigned long long)(s_dm_tc_addr + (unsigned int)(transpose_col_1 / 16 * 1024 + transpose_row_1 * 32 + transpose_col_1 % 16 * 2 ^ (transpose_col_1 / 16 * 1024 + transpose_row_1 * 32 + transpose_col_1 % 16 * 2 >> 7 & 1) << 4)));
+                asm volatile("stmatrix.sync.aligned.m8n8.x2.trans.shared.b16 [%0], {%1, %2};\n"
+                    :: "r"(_stmatrix_addr_6), "r"(*reinterpret_cast<const uint32_t*>(&packed_14[publish_pair_1 * 2])), "r"(*reinterpret_cast<const uint32_t*>(&packed_14[publish_pair_1 * 2 + 1]))
+                    : "memory");
+            }
+            asm volatile("fence.proxy.async.shared::cta;" ::: "memory");
+            asm volatile("barrier.sync 8, 128;" ::: "memory");
+            if (warp_id_in_role == 0) {
+                if (elect_sync()) {
+                    mbarrier_arrive(prep_ready_addr);
+                }
+            }
+            int token_col = lane;
+            float db_partial = 0.0f;
+            float inv_value_beta = 0.0f;
+            if (value_beta != 0.0f) {
+                float _rcp_2 = approx_rcp(value_beta);
+                inv_value_beta = _rcp_2;
+            }
+            #pragma unroll
+            for (int value_local = 0; value_local < 32; value_local++) {
+                int value_row_2 = warp_id_in_role * 32 + value_local;
+                long long tape_item = token_value_base + (long long)(value_row_2 * 32) + (long long)token_col;
+                int value_major_item_2 = value_row_2 * 32 + token_col;
+                __nv_bfloat16 x_value = s_x[(value_major_item_2 * 2 ^ (value_major_item_2 * 2 >> 7 & 7) << 4) / 2];
+                float _cvt_f32_10 = __bfloat162float(x_value);
+                float recovered_e = _cvt_f32_10 * inv_value_beta;
+                float _fma_0 = __fmaf_rn((float)chunk_dx[tape_item], recovered_e, db_partial);
+                db_partial = _fma_0;
+            }
+            int db_matrix_item = token_col * 32 + warp_id_in_role * 8;
+            unsigned int db_df_packed[4];
+            unsigned int db_m_packed[4];
+            asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                : "=r"(*reinterpret_cast<uint32_t*>(&db_df_packed[0])), "=r"(*reinterpret_cast<uint32_t*>(&db_df_packed[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&db_df_packed[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&db_df_packed[(0) + 3]))
+                : "r"(s_df_addr + (unsigned int)((db_matrix_item * 2 ^ (db_matrix_item * 2 >> 7 & 7) << 4) / 2 * 2)));
+            asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                : "=r"(*reinterpret_cast<uint32_t*>(&db_m_packed[0])), "=r"(*reinterpret_cast<uint32_t*>(&db_m_packed[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&db_m_packed[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&db_m_packed[(0) + 3]))
+                : "r"(s_m_addr + (unsigned int)((db_matrix_item * 2 ^ (db_matrix_item * 2 >> 7 & 7) << 4) / 2 * 2)));
+            float db_df_packed_f32[8];
+            #pragma unroll
+            for (int _pair = 0; _pair < 4; _pair++) {
+                asm volatile(
+                    "{\n\t"
+                    "shl.b32 %0, %2, 16;\n\t"
+                    "and.b32 %1, %2, 0xffff0000;\n\t"
+                    "}\n"
+                    : "=f"((&db_df_packed_f32[_pair * 2])[0]), "=f"((&db_df_packed_f32[_pair * 2])[1])
+                    : "r"(db_df_packed[_pair]));
+            }
+            float db_m_packed_f32[8];
+            #pragma unroll
+            for (int _pair = 0; _pair < 4; _pair++) {
+                asm volatile(
+                    "{\n\t"
+                    "shl.b32 %0, %2, 16;\n\t"
+                    "and.b32 %1, %2, 0xffff0000;\n\t"
+                    "}\n"
+                    : "=f"((&db_m_packed_f32[_pair * 2])[0]), "=f"((&db_m_packed_f32[_pair * 2])[1])
+                    : "r"(db_m_packed[_pair]));
+            }
+            #pragma unroll
+            for (int col_local = 0; col_local < 8; col_local++) {
+                float _fma_1 = __fmaf_rn(db_df_packed_f32[col_local], db_m_packed_f32[col_local], db_partial);
+                db_partial = _fma_1;
+            }
+            s_dbeta_partial[warp_id_in_role * 32 + token_col] = db_partial;
+            asm volatile("barrier.sync 8, 128;" ::: "memory");
+            if (warp_id_in_role == 0) {
+                float db_value = s_dbeta_partial[token_col] + s_dbeta_partial[32 + token_col] + s_dbeta_partial[64 + token_col] + s_dbeta_partial[96 + token_col];
+                long long token = chunk_start + (long long)token_col;
+                if (token < eos) {
+                    dbeta_active[token * (long long)num_heads + (long long)head] = db_value;
+                }
+                if (elect_sync()) {
+                    mbarrier_arrive(dbeta_done_addr);
+                }
+            }
+            int prep_key_row = prep_tid;
+            const int prep_tmem_row_base = warp_id_in_role * 32 << 16;
+            float prep_restore = tape_restore_factor[restore_base + (long long)prep_key_row];
+            float prep_kr_prefetch = (float)tape_kr[token_key_base + 2048 + (long long)prep_key_row];
+            unsigned int _phase_first_outputs_ready_0 = 0;
+            mbarrier_wait(first_outputs_ready_addr, _phase_first_outputs_ready_0);
+            _phase_first_outputs_ready_0 ^= 1;
+            long long prep_out_base = chunk_head * 32 * 128;
+            long long prep_chunk_end = chunk_start + 32;
+            if (prep_chunk_end > eos) {
+                prep_chunk_end = eos;
+            }
+            int prep_chunk_length = (int)(prep_chunk_end - chunk_start);
+            float _exp2_0 = approx_exp2(lower_bound * 1.4426950408889634f * 16.0f);
+            float prep_common_factor = _exp2_0;
+            const int prep_token_offset = 16;
+            float _tmem_load_0[8];
+            tmem_ld_x8(&_tmem_load_0[0], taddr + 176 + (unsigned int)prep_tmem_row_base + (unsigned int)prep_token_offset);
+            #pragma unroll
+            for (int prep_token_local_early = 0; prep_token_local_early < 8; prep_token_local_early++) {
+                int prep_token_out_early = prep_token_offset + prep_token_local_early;
+                float prep_kr_value_early = prep_kr_prefetch;
+                if (prep_token_local_early != 0) {
+                    prep_kr_value_early = (float)tape_kr[token_key_base + (long long)(prep_token_out_early * 128) + (long long)prep_key_row];
+                }
+                int prep_stable_index_early = prep_token_out_early * 128 + prep_key_row;
+                s_stable_dkr[prep_stable_index_early] = _tmem_load_0[prep_token_local_early] * prep_kr_value_early;
+                _tmem_load_0[prep_token_local_early] = _tmem_load_0[prep_token_local_early] * prep_restore;
+            }
+            unsigned int _phase_outputs_ready_0 = 0;
+            mbarrier_wait(outputs_ready_addr, _phase_outputs_ready_0);
+            _phase_outputs_ready_0 ^= 1;
+            float _tmem_load_1[8];
+            tmem_ld_x8(&_tmem_load_1[0], taddr + 208 + (unsigned int)prep_tmem_row_base + (unsigned int)prep_token_offset);
+            asm volatile("tcgen05.wait::ld.sync.aligned;");
+            #pragma unroll
+            for (int prep_token_local = 0; prep_token_local < 8; prep_token_local++) {
+                int prep_token_out = prep_token_offset + prep_token_local;
+                long long prep_out_index = prep_out_base + (long long)(prep_token_out * 128) + (long long)prep_key_row;
+                int prep_shared_index = prep_token_out * 128 + prep_key_row;
+                __nv_bfloat16 prep_i_value_bf16 = s_i[(prep_shared_index * 2 ^ (prep_shared_index * 2 >> 8 & 7) << 4) / 2];
+                float _cvt_f32_11 = __bfloat162float(prep_i_value_bf16);
+                float prep_i_value = _cvt_f32_11;
+                grad_ki[prep_out_index] = _tmem_load_1[prep_token_local] + _tmem_load_0[prep_token_local];
+                _tmem_load_1[prep_token_local] = _tmem_load_1[prep_token_local] * prep_i_value;
+            }
+            float _tmem_load_2[8];
+            tmem_ld_x8(&_tmem_load_2[0], taddr + 240 + (unsigned int)prep_tmem_row_base + (unsigned int)prep_token_offset);
+            float _tmem_load_3[8];
+            tmem_ld_x8(&_tmem_load_3[0], taddr + 272 + (unsigned int)prep_tmem_row_base + (unsigned int)prep_token_offset);
+            asm volatile("tcgen05.wait::ld.sync.aligned;");
+            #pragma unroll
+            for (int prep_token_local2 = 0; prep_token_local2 < 8; prep_token_local2++) {
+                int prep_token_out2 = prep_token_offset + prep_token_local2;
+                long long prep_out_index2 = prep_out_base + (long long)(prep_token_out2 * 128) + (long long)prep_key_row;
+                int prep_shared_index2 = prep_token_out2 * 128 + prep_key_row;
+                __nv_bfloat16 prep_q_value_bf16 = s_q[(prep_shared_index2 * 2 ^ (prep_shared_index2 * 2 >> 8 & 7) << 4) / 2];
+                float _cvt_f32_12 = __bfloat162float(prep_q_value_bf16);
+                float prep_q_value = _cvt_f32_12;
+                _tmem_load_3[prep_token_local2] = _tmem_load_3[prep_token_local2] * prep_common_factor;
+                float _fma_2 = __fmaf_rn(-_tmem_load_2[prep_token_local2], prep_q_value, _tmem_load_1[prep_token_local2]);
+                _tmem_load_1[prep_token_local2] = _fma_2;
+                _tmem_load_0[prep_token_local2] = _tmem_load_3[prep_token_local2] * prep_q_value;
+                grad_qd[prep_out_index2] = _tmem_load_2[prep_token_local2] + _tmem_load_3[prep_token_local2];
+            }
+            unsigned int _phase_dbeta_done_0 = 0;
+            mbarrier_wait(dbeta_done_addr, _phase_dbeta_done_0);
+            _phase_dbeta_done_0 ^= 1;
+            float _tmem_load_4[8];
+            tmem_ld_x8(&_tmem_load_4[0], taddr + 304 + (unsigned int)prep_tmem_row_base + (unsigned int)prep_token_offset);
+            float _tmem_load_5[8];
+            tmem_ld_x8(&_tmem_load_5[0], taddr + 336 + (unsigned int)prep_tmem_row_base + (unsigned int)prep_token_offset);
+            asm volatile("tcgen05.wait::ld.sync.aligned;");
+            float prep_middle_base_suffix = 0.0f;
+            #pragma unroll
+            for (int prep_token_local3 = 0; prep_token_local3 < 8; prep_token_local3++) {
+                int prep_token_out3 = prep_token_offset + prep_token_local3;
+                long long prep_out_index3 = prep_out_base + (long long)(prep_token_out3 * 128) + (long long)prep_key_row;
+                int prep_shared_index3 = prep_token_out3 * 128 + prep_key_row;
+                __nv_bfloat16 prep_k_value_bf16 = s_k[(prep_shared_index3 * 2 ^ (prep_shared_index3 * 2 >> 8 & 7) << 4) / 2];
+                float _cvt_f32_13 = __bfloat162float(prep_k_value_bf16);
+                float prep_k_value = _cvt_f32_13;
+                _tmem_load_5[prep_token_local3] = _tmem_load_5[prep_token_local3] * (-prep_common_factor);
+                float _fma_3 = __fmaf_rn(-_tmem_load_4[prep_token_local3], prep_k_value, _tmem_load_1[prep_token_local3]);
+                _tmem_load_1[prep_token_local3] = _fma_3;
+                float prep_base_value = _tmem_load_0[prep_token_local3] + _tmem_load_5[prep_token_local3] * prep_k_value;
+                int prep_stable_index3 = prep_token_out3 * 128 + prep_key_row;
+                s_stable_delta[prep_stable_index3] = _tmem_load_1[prep_token_local3];
+                s_stable_base[prep_stable_index3] = prep_base_value;
+                if (prep_token_out3 < prep_chunk_length) {
+                    prep_middle_base_suffix += prep_base_value;
+                }
+                grad_kd[prep_out_index3] = _tmem_load_4[prep_token_local3] + _tmem_load_5[prep_token_local3];
+            }
+            s_middle_base_suffix[prep_key_row] = prep_middle_base_suffix;
+            asm volatile("barrier.sync 10, 384;" ::: "memory");
+        }
+    }
+    // ---- Role: epilogue ----
+    if (warp >= 4 && warp <= 7) {
+        asm volatile("setmaxnreg.inc.sync.aligned.u32 208;");
+        { // epilogue_main
+            int ordered_chunk_1 = blockIdx.x / num_heads;
+            int chunk_global_1 = consumer_chunk_order[ordered_chunk_1];
+            int head_1 = blockIdx.x - ordered_chunk_1 * num_heads;
+            int sequence_1 = chunk_sequence[chunk_global_1];
+            int local_chunk_1 = chunk_index[chunk_global_1];
+            long long bos_1 = cu_seqlens[sequence_1];
+            long long eos_1 = cu_seqlens[sequence_1 + 1];
+            long long chunk_start_1 = bos_1 + (long long)local_chunk_1 * 32;
+            long long chunk_head_1 = (long long)chunk_global_1 * (long long)num_heads + (long long)head_1;
+            int warp_id_in_role_1 = (warp - 4);
+            int key_row = warp_id_in_role_1 * 32 + lane;
+            const int tmem_row_base = warp_id_in_role_1 * 32 << 16;
+            long long token_key_base_1 = chunk_head_1 * 32 * 128;
+            long long state_base_1 = chunk_head_1 * 128 * 128;
+            long long restore_base_1 = chunk_head_1 * 128;
+            long long initial_state_base = ((long long)sequence_1 * (long long)num_heads + (long long)head_1) * 128 * 128;
+            int checkpoint_needed = 0;
+            if (local_chunk_1 != 0) {
+                checkpoint_needed = state_checkpoint_needed[chunk_head_1] != 0;
+            }
+            float restore = tape_restore_factor[restore_base_1 + (long long)key_row];
+            float gate_constant = 0.0f;
+            unsigned int _phase_recon_output_ready_0 = 0;
+            if (local_chunk_1 == 0) {
+                #pragma unroll
+                for (int value_block = 0; value_block < 128; value_block += 16) {
+                    float state_values[16];
+                    #pragma unroll
+                    for (int value_elem_2 = 0; value_elem_2 < 16; value_elem_2++) {
+                        __nv_bfloat16 _cvt_bf16_8 = __float2bfloat16(initial_state[initial_state_base + (long long)((value_block + value_elem_2) * 128) + (long long)key_row]);
+                        float _cvt_f32_14 = __bfloat162float(_cvt_bf16_8);
+                        state_values[value_elem_2] = _cvt_f32_14;
+                    }
+                    uint32_t state_values_bf16[8];
+                    #pragma unroll
+                    for (int _lp = 0; _lp < 8; _lp++) {
+                        __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(state_values[_lp*2 + 0], state_values[_lp*2+1 + 0]));
+                        state_values_bf16[_lp] = *(uint32_t*)&_bf2;
+                    }
+                    tmem_st_x8_u32(taddr + 64 + (unsigned int)tmem_row_base + (unsigned int)(value_block / 2), (const uint32_t*)state_values_bf16);
+                }
+            } else if (checkpoint_needed != 0) {
+                #pragma unroll
+                for (int value_block_1 = 0; value_block_1 < 128; value_block_1 += 16) {
+                    float state_values_1[16];
+                    #pragma unroll
+                    for (int value_elem_3 = 0; value_elem_3 < 16; value_elem_3++) {
+                        state_values_1[value_elem_3] = (float)chunk_state[state_base_1 + (long long)((value_block_1 + value_elem_3) * 128) + (long long)key_row];
+                    }
+                    uint32_t state_values_bf16_1[8];
+                    #pragma unroll
+                    for (int _lp = 0; _lp < 8; _lp++) {
+                        __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(state_values_1[_lp*2 + 0], state_values_1[_lp*2+1 + 0]));
+                        state_values_bf16_1[_lp] = *(uint32_t*)&_bf2;
+                    }
+                    tmem_st_x8_u32(taddr + 64 + (unsigned int)tmem_row_base + (unsigned int)(value_block_1 / 2), (const uint32_t*)state_values_bf16_1);
+                }
+            } else {
+                long long prev_chunk_head = (long long)(chunk_global_1 - 1) * (long long)num_heads + (long long)head_1;
+                long long prev_token_key_base = prev_chunk_head * 32 * 128;
+                long long prev_value_token_base = prev_chunk_head * 128 * 32;
+                #pragma unroll
+                for (int token_half_state = 0; token_half_state < 2; token_half_state++) {
+                    int token_offset_state = token_half_state * 16;
+                    float kr_values[16];
+                    #pragma unroll
+                    for (int token_local_state = 0; token_local_state < 16; token_local_state++) {
+                        int token_col_state = token_offset_state + token_local_state;
+                        kr_values[token_local_state] = (float)tape_kr[prev_token_key_base + (long long)token_col_state * 128 + (long long)key_row];
+                    }
+                    uint32_t kr_values_bf16[8];
+                    #pragma unroll
+                    for (int _lp = 0; _lp < 8; _lp++) {
+                        __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(kr_values[_lp*2 + 0], kr_values[_lp*2+1 + 0]));
+                        kr_values_bf16[_lp] = *(uint32_t*)&_bf2;
+                    }
+                    tmem_st_x8_u32(taddr + 64 + (unsigned int)tmem_row_base + (unsigned int)(token_half_state * 8), (const uint32_t*)kr_values_bf16);
+                }
+                #pragma unroll
+                for (int prev_r_segment = 0; prev_r_segment < 4; prev_r_segment++) {
+                    float prev_r_values[8];
+                    {
+                        const uint4* _vptr_0 = reinterpret_cast<const uint4*>(tape_r + prev_value_token_base + (long long)key_row * 32 + (long long)(prev_r_segment * 8));
+                        uint4 _vld_0[1];
+                        #pragma unroll
+                        for (int _blk = 0; _blk < 1; _blk++) {
+                            _vld_0[_blk] = _vptr_0[_blk];
+                            uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
+                            #pragma unroll
+                            for (int _pair = 0; _pair < 4; _pair++) {
+                                asm volatile(
+                                    "{\n\t"
+                                    "shl.b32 %0, %2, 16;\n\t"
+                                    "and.b32 %1, %2, 0xffff0000;\n\t"
+                                    "}\n"
+                                    : "=f"((&prev_r_values[0 + _blk * 8 + _pair * 2])[0]), "=f"((&prev_r_values[0 + _blk * 8 + _pair * 2])[1])
+                                    : "r"(_vpairs_0[_pair]));
+                            }
+                        }
+                    }
+                    unsigned int packed_4[4];
+                    #pragma unroll
+                    for (int _lp = 0; _lp < 4; _lp++) {
+                        __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(prev_r_values[_lp*2 + 0], prev_r_values[_lp*2+1 + 0]));
+                        packed_4[_lp] = *(uint32_t*)&_bf2;
+                    }
+                    #pragma unroll
+                    for (int word = 0; word < 4; word++) {
+                        asm volatile("st.shared.b32 [%0], %1;" :: "r"((s_prev_r_tc_addr + (unsigned int)(prev_r_segment * 8 / 16 * 4096 + key_row * 32 + prev_r_segment * 8 % 16 * 2 ^ (prev_r_segment * 8 / 16 * 4096 + key_row * 32 + prev_r_segment * 8 % 16 * 2 >> 7 & 1) << 4)) + (unsigned int)(word * 4)), "r"((packed_4[word])));
+                    }
+                }
+                asm volatile("fence.proxy.async.shared::cta;" ::: "memory");
+                asm volatile("tcgen05.wait::st.sync.aligned;" ::: "memory");
+                if (elect_sync()) {
+                    mbarrier_arrive(recon_inputs_ready_addr);
+                }
+                mbarrier_wait(recon_output_ready_addr, _phase_recon_output_ready_0);
+                _phase_recon_output_ready_0 ^= 1;
+                #pragma unroll
+                for (int value_block_2 = 0; value_block_2 < 128; value_block_2 += 16) {
+                    float _tmem_load_6[16];
+                    tmem_ld_x16(&_tmem_load_6[0], taddr + 368 + (unsigned int)tmem_row_base + (unsigned int)value_block_2);
+                    asm volatile("tcgen05.wait::ld.sync.aligned;" ::: "memory");
+                    uint32_t _tmem_load_6_bf16[8];
+                    #pragma unroll
+                    for (int _lp = 0; _lp < 8; _lp++) {
+                        __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(_tmem_load_6[_lp*2 + 0], _tmem_load_6[_lp*2+1 + 0]));
+                        _tmem_load_6_bf16[_lp] = *(uint32_t*)&_bf2;
+                    }
+                    tmem_st_x8_u32(taddr + 64 + (unsigned int)tmem_row_base + (unsigned int)(value_block_2 / 2), (const uint32_t*)_tmem_load_6_bf16);
+                }
+            }
+            asm volatile("tcgen05.wait::st.sync.aligned;" ::: "memory");
+            if (elect_sync()) {
+                mbarrier_arrive(state_tc_ready_addr);
+            }
+            unsigned int _phase_qki_ready_0 = 0;
+            mbarrier_wait(qki_ready_addr, _phase_qki_ready_0);
+            _phase_qki_ready_0 ^= 1;
+            #pragma unroll
+            for (int token_half_ki = 0; token_half_ki < 2; token_half_ki++) {
+                int token_offset_ki = token_half_ki * 16;
+                float ki_values[16];
+                #pragma unroll
+                for (int token_local_k = 0; token_local_k < 16; token_local_k++) {
+                    int token_col_k = token_offset_ki + token_local_k;
+                    int shared_index_k = token_col_k * 128 + key_row;
+                    ki_values[token_local_k] = s_k[(shared_index_k * 2 ^ (shared_index_k * 2 >> 8 & 7) << 4) / 2];
+                }
+                uint32_t ki_values_bf16[8];
+                #pragma unroll
+                for (int _lp = 0; _lp < 8; _lp++) {
+                    __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(ki_values[_lp*2 + 0], ki_values[_lp*2+1 + 0]));
+                    ki_values_bf16[_lp] = *(uint32_t*)&_bf2;
+                }
+                tmem_st_x8_u32(taddr + 128 + (unsigned int)tmem_row_base + (unsigned int)(token_half_ki * 8), (const uint32_t*)ki_values_bf16);
+                #pragma unroll
+                for (int token_local_q = 0; token_local_q < 16; token_local_q++) {
+                    int token_col_q = token_offset_ki + token_local_q;
+                    int shared_index_q = token_col_q * 128 + key_row;
+                    ki_values[token_local_q] = s_q[(shared_index_q * 2 ^ (shared_index_q * 2 >> 8 & 7) << 4) / 2];
+                }
+                uint32_t ki_values_bf16_0[8];
+                #pragma unroll
+                for (int _lp = 0; _lp < 8; _lp++) {
+                    __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(ki_values[_lp*2 + 0], ki_values[_lp*2+1 + 0]));
+                    ki_values_bf16_0[_lp] = *(uint32_t*)&_bf2;
+                }
+                tmem_st_x8_u32(taddr + 144 + (unsigned int)tmem_row_base + (unsigned int)(token_half_ki * 8), (const uint32_t*)ki_values_bf16_0);
+                #pragma unroll
+                for (int token_local_i = 0; token_local_i < 16; token_local_i++) {
+                    int token_col_i = token_offset_ki + token_local_i;
+                    int shared_index_i = token_col_i * 128 + key_row;
+                    ki_values[token_local_i] = s_i[(shared_index_i * 2 ^ (shared_index_i * 2 >> 8 & 7) << 4) / 2];
+                }
+                uint32_t ki_values_bf16_1[8];
+                #pragma unroll
+                for (int _lp = 0; _lp < 8; _lp++) {
+                    __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(ki_values[_lp*2 + 0], ki_values[_lp*2+1 + 0]));
+                    ki_values_bf16_1[_lp] = *(uint32_t*)&_bf2;
+                }
+                tmem_st_x8_u32(taddr + 160 + (unsigned int)tmem_row_base + (unsigned int)(token_half_ki * 8), (const uint32_t*)ki_values_bf16_1);
+            }
+            asm volatile("tcgen05.wait::st.sync.aligned;" ::: "memory");
+            if (elect_sync()) {
+                mbarrier_arrive(qki_tc_ready_addr);
+            }
+            if (boundary_ready_target != 0) {
+                if (warp_id_in_role_1 == 0) {
+                    {
+                        unsigned int* _gca_p = reinterpret_cast<unsigned int*>(boundary_ready) + (chunk_head_1);
+                        while (true) {
+                            unsigned int _gca_v;
+                            asm volatile("ld.acquire.gpu.global.u32 %0, [%1];" : "=r"(_gca_v) : "l"(_gca_p));
+                            if (_gca_v >= (unsigned int)(boundary_ready_target)) break;
+                        }
+                    }
+                }
+                asm volatile("barrier.sync 9, 128;" ::: "memory");
+            }
+            unsigned int _phase_dh_ready_0 = 0;
+            mbarrier_wait(dh_ready_addr, _phase_dh_ready_0);
+            _phase_dh_ready_0 ^= 1;
+            if (local_chunk_1 == 0) {
+                #pragma unroll
+                for (int value_block2 = 0; value_block2 < 128; value_block2 += 16) {
+                    float dh_values[16];
+                    #pragma unroll
+                    for (int value_elem2 = 0; value_elem2 < 16; value_elem2++) {
+                        int value_row_3 = value_block2 + value_elem2;
+                        __nv_bfloat16 _cvt_bf16_9 = __float2bfloat16(initial_state[initial_state_base + (long long)(value_row_3 * 128) + (long long)key_row]);
+                        float _cvt_f32_15 = __bfloat162float(_cvt_bf16_9);
+                        float state_value = _cvt_f32_15;
+                        __nv_bfloat16 dh_value = s_dh_stage[((value_row_3 * 128 + key_row) * 2 ^ ((value_row_3 * 128 + key_row) * 2 >> 7 & 7) << 4) / 2];
+                        float _cvt_f32_16 = __bfloat162float(dh_value);
+                        dh_values[value_elem2] = _cvt_f32_16;
+                        float _fma_4 = __fmaf_rn(dh_values[value_elem2], state_value, gate_constant);
+                        gate_constant = _fma_4;
+                    }
+                    uint32_t dh_values_bf16[8];
+                    #pragma unroll
+                    for (int _lp = 0; _lp < 8; _lp++) {
+                        __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(dh_values[_lp*2 + 0], dh_values[_lp*2+1 + 0]));
+                        dh_values_bf16[_lp] = *(uint32_t*)&_bf2;
+                    }
+                    tmem_st_x8_u32(taddr + (unsigned int)tmem_row_base + (unsigned int)(value_block2 / 2), (const uint32_t*)dh_values_bf16);
+                }
+            } else if (checkpoint_needed != 0) {
+                #pragma unroll
+                for (int value_block2_1 = 0; value_block2_1 < 128; value_block2_1 += 16) {
+                    float dh_values_1[16];
+                    #pragma unroll
+                    for (int value_elem2_1 = 0; value_elem2_1 < 16; value_elem2_1++) {
+                        int value_row_4 = value_block2_1 + value_elem2_1;
+                        float state_value_1 = (float)chunk_state[state_base_1 + (long long)(value_row_4 * 128) + (long long)key_row];
+                        __nv_bfloat16 dh_value_1 = s_dh_stage[((value_row_4 * 128 + key_row) * 2 ^ ((value_row_4 * 128 + key_row) * 2 >> 7 & 7) << 4) / 2];
+                        float _cvt_f32_17 = __bfloat162float(dh_value_1);
+                        dh_values_1[value_elem2_1] = _cvt_f32_17;
+                        float _fma_5 = __fmaf_rn(dh_values_1[value_elem2_1], state_value_1, gate_constant);
+                        gate_constant = _fma_5;
+                    }
+                    uint32_t dh_values_bf16_1[8];
+                    #pragma unroll
+                    for (int _lp = 0; _lp < 8; _lp++) {
+                        __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(dh_values_1[_lp*2 + 0], dh_values_1[_lp*2+1 + 0]));
+                        dh_values_bf16_1[_lp] = *(uint32_t*)&_bf2;
+                    }
+                    tmem_st_x8_u32(taddr + (unsigned int)tmem_row_base + (unsigned int)(value_block2_1 / 2), (const uint32_t*)dh_values_bf16_1);
+                }
+            } else {
+                #pragma unroll
+                for (int value_block2_2 = 0; value_block2_2 < 128; value_block2_2 += 16) {
+                    float _tmem_load_7[16];
+                    tmem_ld_x16(&_tmem_load_7[0], taddr + 368 + (unsigned int)tmem_row_base + (unsigned int)value_block2_2);
+                    asm volatile("tcgen05.wait::ld.sync.aligned;" ::: "memory");
+                    float dh_values_2[16];
+                    #pragma unroll
+                    for (int value_elem2_2 = 0; value_elem2_2 < 16; value_elem2_2++) {
+                        int value_row_5 = value_block2_2 + value_elem2_2;
+                        __nv_bfloat16 dh_value_2 = s_dh_stage[((value_row_5 * 128 + key_row) * 2 ^ ((value_row_5 * 128 + key_row) * 2 >> 7 & 7) << 4) / 2];
+                        float _cvt_f32_18 = __bfloat162float(dh_value_2);
+                        dh_values_2[value_elem2_2] = _cvt_f32_18;
+                        float _fma_6 = __fmaf_rn(dh_values_2[value_elem2_2], _tmem_load_7[value_elem2_2], gate_constant);
+                        gate_constant = _fma_6;
+                    }
+                    uint32_t dh_values_bf16_2[8];
+                    #pragma unroll
+                    for (int _lp = 0; _lp < 8; _lp++) {
+                        __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(dh_values_2[_lp*2 + 0], dh_values_2[_lp*2+1 + 0]));
+                        dh_values_bf16_2[_lp] = *(uint32_t*)&_bf2;
+                    }
+                    tmem_st_x8_u32(taddr + (unsigned int)tmem_row_base + (unsigned int)(value_block2_2 / 2), (const uint32_t*)dh_values_bf16_2);
+                }
+            }
+            asm volatile("tcgen05.wait::st.sync.aligned;" ::: "memory");
+            float _exp2_1 = approx_exp2(lower_bound * 1.4426950408889634f * 16.0f);
+            float common_factor = _exp2_1;
+            gate_constant *= common_factor * restore;
+            if (elect_sync()) {
+                mbarrier_arrive(a_ready_addr);
+            }
+            float kr_prefetch = (float)tape_kr[token_key_base_1 + (long long)key_row];
+            unsigned int _phase_first_outputs_ready_0_1 = 0;
+            mbarrier_wait(first_outputs_ready_addr, _phase_first_outputs_ready_0_1);
+            _phase_first_outputs_ready_0_1 ^= 1;
+            long long out_base = chunk_head_1 * 32 * 128;
+            float base_suffix = 0.0f;
+            long long chunk_end = chunk_start_1 + 32;
+            if (chunk_end > eos_1) {
+                chunk_end = eos_1;
+            }
+            int chunk_length = (int)(chunk_end - chunk_start_1);
+            unsigned int _phase_outputs_ready_0_1 = 0;
+            unsigned int _phase_dbeta_done_0_1 = 0;
+            #pragma unroll
+            for (int token_half = 0; token_half < 1; token_half++) {
+                int token_offset = token_half * 16;
+                float _tmem_load_8[16];
+                tmem_ld_x16(&_tmem_load_8[0], taddr + 176 + (unsigned int)tmem_row_base + (unsigned int)token_offset);
+                #pragma unroll
+                for (int token_local_early = 0; token_local_early < 16; token_local_early++) {
+                    int token_out_early = token_offset + token_local_early;
+                    float kr_value_early = kr_prefetch;
+                    if (token_local_early != 0) {
+                        kr_value_early = (float)tape_kr[token_key_base_1 + (long long)(token_out_early * 128) + (long long)key_row];
+                    }
+                    int stable_index_early = token_out_early * 128 + key_row;
+                    s_stable_dkr[stable_index_early] = _tmem_load_8[token_local_early] * kr_value_early;
+                    _tmem_load_8[token_local_early] = _tmem_load_8[token_local_early] * restore;
+                }
+                mbarrier_wait(outputs_ready_addr, _phase_outputs_ready_0_1);
+                _phase_outputs_ready_0_1 ^= 1;
+                float _tmem_load_9[16];
+                tmem_ld_x16(&_tmem_load_9[0], taddr + 208 + (unsigned int)tmem_row_base + (unsigned int)token_offset);
+                asm volatile("tcgen05.wait::ld.sync.aligned;");
+                #pragma unroll
+                for (int token_local = 0; token_local < 16; token_local++) {
+                    int token_out = token_offset + token_local;
+                    long long out_index = out_base + (long long)(token_out * 128) + (long long)key_row;
+                    int shared_index = token_out * 128 + key_row;
+                    __nv_bfloat16 i_value_bf16 = s_i[(shared_index * 2 ^ (shared_index * 2 >> 8 & 7) << 4) / 2];
+                    float _cvt_f32_19 = __bfloat162float(i_value_bf16);
+                    float i_value = _cvt_f32_19;
+                    grad_ki[out_index] = _tmem_load_9[token_local] + _tmem_load_8[token_local];
+                    _tmem_load_9[token_local] = _tmem_load_9[token_local] * i_value;
+                }
+                float _tmem_load_10[16];
+                tmem_ld_x16(&_tmem_load_10[0], taddr + 240 + (unsigned int)tmem_row_base + (unsigned int)token_offset);
+                float _tmem_load_11[16];
+                tmem_ld_x16(&_tmem_load_11[0], taddr + 272 + (unsigned int)tmem_row_base + (unsigned int)token_offset);
+                asm volatile("tcgen05.wait::ld.sync.aligned;");
+                #pragma unroll
+                for (int token_local2 = 0; token_local2 < 16; token_local2++) {
+                    int token_out2 = token_offset + token_local2;
+                    long long out_index_1 = out_base + (long long)(token_out2 * 128) + (long long)key_row;
+                    int shared_index2 = token_out2 * 128 + key_row;
+                    __nv_bfloat16 q_value_bf16 = s_q[(shared_index2 * 2 ^ (shared_index2 * 2 >> 8 & 7) << 4) / 2];
+                    float _cvt_f32_20 = __bfloat162float(q_value_bf16);
+                    float q_value = _cvt_f32_20;
+                    _tmem_load_11[token_local2] = _tmem_load_11[token_local2] * common_factor;
+                    float _fma_7 = __fmaf_rn(-_tmem_load_10[token_local2], q_value, _tmem_load_9[token_local2]);
+                    _tmem_load_9[token_local2] = _fma_7;
+                    _tmem_load_8[token_local2] = _tmem_load_11[token_local2] * q_value;
+                    grad_qd[out_index_1] = _tmem_load_10[token_local2] + _tmem_load_11[token_local2];
+                }
+                mbarrier_wait(dbeta_done_addr, _phase_dbeta_done_0_1);
+                _phase_dbeta_done_0_1 ^= 1;
+                float _tmem_load_12[16];
+                tmem_ld_x16(&_tmem_load_12[0], taddr + 304 + (unsigned int)tmem_row_base + (unsigned int)token_offset);
+                float _tmem_load_13[16];
+                tmem_ld_x16(&_tmem_load_13[0], taddr + 336 + (unsigned int)tmem_row_base + (unsigned int)token_offset);
+                asm volatile("tcgen05.wait::ld.sync.aligned;");
+                #pragma unroll
+                for (int token_local3 = 0; token_local3 < 16; token_local3++) {
+                    int token_out3 = token_offset + token_local3;
+                    long long out_index_2 = out_base + (long long)(token_out3 * 128) + (long long)key_row;
+                    int shared_index3 = token_out3 * 128 + key_row;
+                    __nv_bfloat16 k_value_bf16 = s_k[(shared_index3 * 2 ^ (shared_index3 * 2 >> 8 & 7) << 4) / 2];
+                    float _cvt_f32_21 = __bfloat162float(k_value_bf16);
+                    float k_value = _cvt_f32_21;
+                    _tmem_load_13[token_local3] = _tmem_load_13[token_local3] * (-common_factor);
+                    float _fma_8 = __fmaf_rn(-_tmem_load_12[token_local3], k_value, _tmem_load_9[token_local3]);
+                    _tmem_load_9[token_local3] = _fma_8;
+                    float base_value = _tmem_load_8[token_local3] + _tmem_load_13[token_local3] * k_value;
+                    int stable_index3 = token_out3 * 128 + key_row;
+                    s_stable_delta[stable_index3] = _tmem_load_9[token_local3];
+                    s_stable_base[stable_index3] = base_value;
+                    if (token_out3 < chunk_length) {
+                        base_suffix += base_value;
+                    }
+                    grad_kd[out_index_2] = _tmem_load_12[token_local3] + _tmem_load_13[token_local3];
+                }
+            }
+            asm volatile("barrier.sync 10, 384;" ::: "memory");
+            base_suffix += s_middle_base_suffix[key_row] + s_high_base_suffix[key_row];
+            float prefix_dkr = 0.0f;
+            float crossing = 0.0f;
+            #pragma unroll 4
+            for (int gate_token = 0; gate_token < chunk_length; gate_token++) {
+                int stable_index = gate_token * 128 + key_row;
+                long long token_1 = chunk_start_1 + (long long)gate_token;
+                long long dlog_index = (token_1 * (long long)num_heads + (long long)head_1) * 128 + (long long)key_row;
+                dlog_decay[dlog_index] = base_suffix + gate_constant + (prefix_dkr + crossing);
+                crossing += s_stable_delta[stable_index];
+                prefix_dkr += s_stable_dkr[stable_index];
+                base_suffix -= s_stable_base[stable_index];
+            }
+            if (elect_sync()) {
+                mbarrier_arrive(epilogue_done_addr);
+            }
+        }
+    }
+    // ---- Role: mma ----
+    if (warp >= 8 && warp <= 11) {
+        asm volatile("setmaxnreg.dec.sync.aligned.u32 96;");
+        { // mma_main
+            int ordered_chunk_2 = blockIdx.x / num_heads;
+            int chunk_global_2 = consumer_chunk_order[ordered_chunk_2];
+            int local_chunk_2 = chunk_index[chunk_global_2];
+            int head_2 = blockIdx.x - ordered_chunk_2 * num_heads;
+            long long chunk_head_2 = (long long)chunk_global_2 * (long long)num_heads + (long long)head_2;
+            int warp_id_in_role_2 = (warp - 8);
+            unsigned int _phase_boundary_local_ready_0 = 0;
+            unsigned int _phase_dv_ready_0 = 0;
+            if (warp_id_in_role_2 != 0) {
+                mbarrier_wait(boundary_local_ready_addr, _phase_boundary_local_ready_0);
+                _phase_boundary_local_ready_0 ^= 1;
+                int sequence_do = chunk_sequence[chunk_global_2];
+                long long eos_do = cu_seqlens[sequence_do + 1];
+                long long chunk_start_do = cu_seqlens[sequence_do] + (long long)local_chunk_2 * 32;
+                int do_tid = (warp_id_in_role_2 - 1) * 32 + lane;
+                #pragma unroll 1
+                for (int do_group = do_tid; do_group < 512; do_group += 96) {
+                    int do_token_col = do_group / 16;
+                    int do_segment = do_group % 16;
+                    long long token_do = chunk_start_do + (long long)do_token_col;
+                    int do_rowmajor_item = do_token_col * 128 + do_segment * 8;
+                    asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16, %2;"
+                        :: "r"(s_do_stage_addr + (unsigned int)((do_rowmajor_item * 2 ^ (do_rowmajor_item * 2 >> 8 & 7) << 4) / 2 * 2)), "l"(do_ + ((token_do * (long long)num_heads + (long long)head_2) * 128 + (long long)(do_segment * 8))), "r"((token_do < eos_do) ? 16 : 0));
+                }
+                long long token_value_base_do = chunk_head_2 * 128 * 32;
+                #pragma unroll 1
+                for (int dr_group = do_tid; dr_group < 512; dr_group += 96) {
+                    int dr_copy_item = dr_group * 8;
+                    asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
+                        :: "r"(s_drt_addr + (unsigned int)((dr_copy_item * 2 ^ (dr_copy_item * 2 >> 7 & 7) << 4) / 2 * 2)), "l"(chunk_dr + (token_value_base_do + (long long)dr_copy_item)));
+                }
+                asm volatile("cp.async.commit_group;");
+                asm volatile("cp.async.wait_group 0;");
+                #pragma unroll 1
+                for (int do_relay_group = do_tid; do_relay_group < 512; do_relay_group += 96) {
+                    int do_relay_token_col = do_relay_group / 16;
+                    int do_relay_segment = do_relay_group % 16;
+                    int do_relay_rowmajor_item = do_relay_token_col * 128 + do_relay_segment * 8;
+                    unsigned int do_packed[4];
+                    asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                        : "=r"(*reinterpret_cast<uint32_t*>(&do_packed[0])), "=r"(*reinterpret_cast<uint32_t*>(&do_packed[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&do_packed[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&do_packed[(0) + 3]))
+                        : "r"(s_do_stage_addr + (unsigned int)((do_relay_rowmajor_item * 2 ^ (do_relay_rowmajor_item * 2 >> 8 & 7) << 4) / 2 * 2)));
+                    asm volatile("st.shared.v4.b32 [%0], {%1,%2,%3,%4};" :: "r"(s_dot_tc_addr + ((s_dot_tc_addr + (unsigned int)(do_relay_segment * 8 / 64 * 4096 + do_relay_token_col * 128 + do_relay_segment * 8 % 64 * 2 ^ (do_relay_segment * 8 / 64 * 4096 + do_relay_token_col * 128 + do_relay_segment * 8 % 64 * 2 >> 7 & 7) << 4)) - s_dot_tc_addr)), "r"(do_packed[0]), "r"(do_packed[1]), "r"(do_packed[2]), "r"(do_packed[3]) : "memory");
+                }
+                asm volatile("fence.proxy.async.shared::cta;" ::: "memory");
+                if (elect_sync()) {
+                    mbarrier_arrive(value_tc_ready_addr);
+                }
+                mbarrier_wait(dv_ready_addr, _phase_dv_ready_0);
+                _phase_dv_ready_0 ^= 1;
+                int sequence_dv = chunk_sequence[chunk_global_2];
+                long long eos_dv = cu_seqlens[sequence_dv + 1];
+                long long chunk_start_dv = cu_seqlens[sequence_dv] + (long long)local_chunk_2 * 32;
+                int dv_tid = (warp_id_in_role_2 - 1) * 32 + lane;
+                #pragma unroll 1
+                for (int dv_group = dv_tid; dv_group < 512; dv_group += 96) {
+                    int dv_token_col = dv_group / 16;
+                    int dv_segment = dv_group % 16;
+                    long long token_dv = chunk_start_dv + (long long)dv_token_col;
+                    float beta_value_dv = 0.0f;
+                    if (token_dv < eos_dv) {
+                        beta_value_dv = beta_active[token_dv * (long long)num_heads + (long long)head_2];
+                    }
+                    float dv_values[8];
+                    #pragma unroll
+                    for (int value_elem_dv = 0; value_elem_dv < 8; value_elem_dv++) {
+                        int value_row_dv = dv_segment * 8 + value_elem_dv;
+                        int det_group_dv = dv_segment * 2 + value_elem_dv / 4;
+                        float dx_value_dv = s_det[value_row_dv * 32 + (dv_token_col ^ det_group_dv)];
+                        dv_values[value_elem_dv] = dx_value_dv * beta_value_dv;
+                    }
+                    if (token_dv < eos_dv) {
+                        {
+                            __nv_bfloat162 _pk[4];
+                            _pk[0] = __floats2bfloat162_rn(dv_values[0 + 0], dv_values[0 + 1]);
+                            _pk[1] = __floats2bfloat162_rn(dv_values[0 + 2], dv_values[0 + 3]);
+                            _pk[2] = __floats2bfloat162_rn(dv_values[0 + 4], dv_values[0 + 5]);
+                            _pk[3] = __floats2bfloat162_rn(dv_values[0 + 6], dv_values[0 + 7]);
+                            *reinterpret_cast<uint4*>(&((__nv_bfloat16*)(dv + ((token_dv * (long long)num_heads + (long long)head_2) * 128 + (long long)(dv_segment * 8))))[0]) = *reinterpret_cast<uint4*>(&_pk[0]);
+                        }
+                    }
+                }
+                if (elect_sync()) {
+                    mbarrier_arrive(dbeta_done_addr);
+                }
+            }
+            unsigned int _phase_recon_inputs_ready_0 = 0;
+            unsigned int _phase_state_tc_ready_0 = 0;
+            unsigned int _phase_value_tc_ready_0_1 = 0;
+            unsigned int _phase_a_ready_0 = 0;
+            unsigned int _phase_prep_ready_0 = 0;
+            unsigned int _phase_qki_tc_ready_0 = 0;
+            if (warp_id_in_role_2 == 0) {
+                if (local_chunk_2 != 0) {
+                    if (state_checkpoint_needed[chunk_head_2] == 0) {
+                        mbarrier_wait(recon_inputs_ready_addr, _phase_recon_inputs_ready_0);
+                        _phase_recon_inputs_ready_0 ^= 1;
+                        int _mma_b_lo_0 = make_warp_uniform(((s_prev_r_tc_addr) >> 4) & 0x3FFF);
+                        asm volatile(
+                    "{\n\t"
+                    ".reg .pred leader, p0, p1;\n\t"
+                    ".reg .b32 dhi, blo, ta, id;\n\t"
+                    ".reg .b64 db;\n\t"
+                    "elect.sync _|leader, 0xFFFFFFFF;\n\t"
+                    "setp.ne.b32 p0, %3, 0;\n\t"
+                    "setp.ne.b32 p1, 1, 0;\n\t"
+                    ""
+                    "mov.b32 dhi, 0xC0004010;\n\t"
+                    "mov.b32 id, 136316048;\n\t"
+                    "mov.b32 ta, %2;\n\t"
+                    "mov.b32 blo, %1;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p0;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 256;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "}\n"
+                    :: "r"(tmem_tmem_recon_state), "r"(_mma_b_lo_0), "r"(tmem_tmem_recon_kr), "r"(0));
+                        elect_commit(recon_output_ready_addr);
+                    }
+                }
+                mbarrier_wait(dv_ready_addr, _phase_dv_ready_0);
+                _phase_dv_ready_0 ^= 1;
+                mbarrier_wait(state_tc_ready_addr, _phase_state_tc_ready_0);
+                _phase_state_tc_ready_0 ^= 1;
+                int _mma_b_lo_1 = make_warp_uniform(((s_det_tc_addr) >> 4) & 0x3FFF);
+                asm volatile(
+                    "{\n\t"
+                    ".reg .pred leader, p0, p1;\n\t"
+                    ".reg .b32 dhi, blo, ta, id;\n\t"
+                    ".reg .b64 db;\n\t"
+                    "elect.sync _|leader, 0xFFFFFFFF;\n\t"
+                    "setp.ne.b32 p0, %3, 0;\n\t"
+                    "setp.ne.b32 p1, 1, 0;\n\t"
+                    ""
+                    "mov.b32 dhi, 0x40004040;\n\t"
+                    "mov.b32 id, 134743184;\n\t"
+                    "mov.b32 ta, %2;\n\t"
+                    "mov.b32 blo, %1;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p0;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 250;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "}\n"
+                    :: "r"(tmem_tmem_dk_boundary), "r"(_mma_b_lo_1), "r"(tmem_tmem_a_state), "r"(0));
+                mbarrier_wait(value_tc_ready_addr, _phase_value_tc_ready_0_1);
+                _phase_value_tc_ready_0_1 ^= 1;
+                int _mma_b_lo_2 = make_warp_uniform(((s_dot_tc_addr) >> 4) & 0x3FFF);
+                asm volatile(
+                    "{\n\t"
+                    ".reg .pred leader, p0, p1;\n\t"
+                    ".reg .b32 dhi, blo, ta, id;\n\t"
+                    ".reg .b64 db;\n\t"
+                    "elect.sync _|leader, 0xFFFFFFFF;\n\t"
+                    "setp.ne.b32 p0, %3, 0;\n\t"
+                    "setp.ne.b32 p1, 1, 0;\n\t"
+                    ""
+                    "mov.b32 dhi, 0x40004040;\n\t"
+                    "mov.b32 id, 134743184;\n\t"
+                    "mov.b32 ta, %2;\n\t"
+                    "mov.b32 blo, %1;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p0;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 250;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "}\n"
+                    :: "r"(tmem_tmem_dq_boundary), "r"(_mma_b_lo_2), "r"(tmem_tmem_a_state), "r"(0));
+                mbarrier_wait(a_ready_addr, _phase_a_ready_0);
+                _phase_a_ready_0 ^= 1;
+                int _mma_b_lo_3 = make_warp_uniform(((s_rt_tc_addr) >> 4) & 0x3FFF);
+                asm volatile(
+                    "{\n\t"
+                    ".reg .pred leader, p0, p1;\n\t"
+                    ".reg .b32 dhi, blo, ta, id;\n\t"
+                    ".reg .b64 db;\n\t"
+                    "elect.sync _|leader, 0xFFFFFFFF;\n\t"
+                    "setp.ne.b32 p0, %3, 0;\n\t"
+                    "setp.ne.b32 p1, 1, 0;\n\t"
+                    ""
+                    "mov.b32 dhi, 0x40004040;\n\t"
+                    "mov.b32 id, 134743184;\n\t"
+                    "mov.b32 ta, %2;\n\t"
+                    "mov.b32 blo, %1;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p0;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 250;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "}\n"
+                    :: "r"(tmem_tmem_dkr), "r"(_mma_b_lo_3), "r"(tmem_tmem_a_dh), "r"(0));
+                elect_commit(first_outputs_ready_addr);
+                mbarrier_wait(prep_ready_addr, _phase_prep_ready_0);
+                _phase_prep_ready_0 ^= 1;
+                mbarrier_wait(qki_tc_ready_addr, _phase_qki_tc_ready_0);
+                _phase_qki_tc_ready_0 ^= 1;
+                int _mma_b_lo_4 = make_warp_uniform(((s_dm_tc_addr) >> 4) & 0x3FFF);
+                asm volatile(
+                    "{\n\t"
+                    ".reg .pred leader, p0, p1;\n\t"
+                    ".reg .b32 dhi, blo, ta, id;\n\t"
+                    ".reg .b64 db;\n\t"
+                    "elect.sync _|leader, 0xFFFFFFFF;\n\t"
+                    "setp.ne.b32 p0, %3, 0;\n\t"
+                    "setp.ne.b32 p1, 1, 0;\n\t"
+                    ""
+                    "mov.b32 dhi, 0xC0004010;\n\t"
+                    "mov.b32 id, 134743184;\n\t"
+                    "mov.b32 ta, %2;\n\t"
+                    "mov.b32 blo, %1;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p0;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 64;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "}\n"
+                    :: "r"(tmem_tmem_di), "r"(_mma_b_lo_4), "r"(tmem_tmem_a_k), "r"(0));
+                int _mma_b_lo_5 = make_warp_uniform(((s_dnt_tc_addr) >> 4) & 0x3FFF);
+                asm volatile(
+                    "{\n\t"
+                    ".reg .pred leader, p0, p1;\n\t"
+                    ".reg .b32 dhi, blo, ta, id;\n\t"
+                    ".reg .b64 db;\n\t"
+                    "elect.sync _|leader, 0xFFFFFFFF;\n\t"
+                    "setp.ne.b32 p0, %3, 0;\n\t"
+                    "setp.ne.b32 p1, 1, 0;\n\t"
+                    ""
+                    "mov.b32 dhi, 0xC0004010;\n\t"
+                    "mov.b32 id, 134743184;\n\t"
+                    "mov.b32 ta, %2;\n\t"
+                    "mov.b32 blo, %1;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p0;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 64;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "}\n"
+                    :: "r"(tmem_tmem_di), "r"(_mma_b_lo_5), "r"(tmem_tmem_a_q), "r"(1));
+                int _mma_b_lo_6 = make_warp_uniform(((s_dn_tc_addr) >> 4) & 0x3FFF);
+                asm volatile(
+                    "{\n\t"
+                    ".reg .pred leader, p0, p1;\n\t"
+                    ".reg .b32 dhi, blo, ta, id;\n\t"
+                    ".reg .b64 db;\n\t"
+                    "elect.sync _|leader, 0xFFFFFFFF;\n\t"
+                    "setp.ne.b32 p0, %3, 0;\n\t"
+                    "setp.ne.b32 p1, 1, 0;\n\t"
+                    ""
+                    "mov.b32 dhi, 0xC0004010;\n\t"
+                    "mov.b32 id, 134743184;\n\t"
+                    "mov.b32 ta, %2;\n\t"
+                    "mov.b32 blo, %1;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p0;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 64;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "}\n"
+                    :: "r"(tmem_tmem_dq_local), "r"(_mma_b_lo_6), "r"(tmem_tmem_a_i), "r"(0));
+                int _mma_b_lo_7 = make_warp_uniform(((s_dmt_tc_addr) >> 4) & 0x3FFF);
+                asm volatile(
+                    "{\n\t"
+                    ".reg .pred leader, p0, p1;\n\t"
+                    ".reg .b32 dhi, blo, ta, id;\n\t"
+                    ".reg .b64 db;\n\t"
+                    "elect.sync _|leader, 0xFFFFFFFF;\n\t"
+                    "setp.ne.b32 p0, %3, 0;\n\t"
+                    "setp.ne.b32 p1, 1, 0;\n\t"
+                    ""
+                    "mov.b32 dhi, 0xC0004010;\n\t"
+                    "mov.b32 id, 134743184;\n\t"
+                    "mov.b32 ta, %2;\n\t"
+                    "mov.b32 blo, %1;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p0;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 64;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "}\n"
+                    :: "r"(tmem_tmem_dk_local), "r"(_mma_b_lo_7), "r"(tmem_tmem_a_i), "r"(0));
+                elect_commit(outputs_ready_addr);
+            }
+            int key_row_1 = warp_id_in_role_2 * 32 + lane;
+            long long restore_base_2 = chunk_head_2 * 128;
+            float restore_1 = tape_restore_factor[restore_base_2 + (long long)key_row_1];
+            long long token_key_base_2 = chunk_head_2 * 32 * 128;
+            float kr_prefetch_1 = (float)tape_kr[token_key_base_2 + 3072 + (long long)key_row_1];
+            unsigned int _phase_first_outputs_ready_0_2 = 0;
+            mbarrier_wait(first_outputs_ready_addr, _phase_first_outputs_ready_0_2);
+            _phase_first_outputs_ready_0_2 ^= 1;
+            int sequence_2 = chunk_sequence[chunk_global_2];
+            long long bos_2 = cu_seqlens[sequence_2];
+            long long eos_2 = cu_seqlens[sequence_2 + 1];
+            long long chunk_start_2 = bos_2 + (long long)local_chunk_2 * 32;
+            long long chunk_end_1 = chunk_start_2 + 32;
+            if (chunk_end_1 > eos_2) {
+                chunk_end_1 = eos_2;
+            }
+            int chunk_length_1 = (int)(chunk_end_1 - chunk_start_2);
+            const int tmem_row_base_1 = warp_id_in_role_2 * 32 << 16;
+            long long out_base_1 = chunk_head_2 * 32 * 128;
+            float _exp2_2 = approx_exp2(lower_bound * 1.4426950408889634f * 16.0f);
+            float common_factor_1 = _exp2_2;
+            const int token_offset_1 = 24;
+            float _tmem_load_14[8];
+            tmem_ld_x8(&_tmem_load_14[0], taddr + 176 + (unsigned int)tmem_row_base_1 + (unsigned int)token_offset_1);
+            #pragma unroll
+            for (int token_local_early_1 = 0; token_local_early_1 < 8; token_local_early_1++) {
+                int token_out_early_1 = token_offset_1 + token_local_early_1;
+                float kr_value_early_1 = kr_prefetch_1;
+                if (token_local_early_1 != 0) {
+                    kr_value_early_1 = (float)tape_kr[token_key_base_2 + (long long)(token_out_early_1 * 128) + (long long)key_row_1];
+                }
+                int stable_index_early_1 = token_out_early_1 * 128 + key_row_1;
+                s_stable_dkr[stable_index_early_1] = _tmem_load_14[token_local_early_1] * kr_value_early_1;
+                _tmem_load_14[token_local_early_1] = _tmem_load_14[token_local_early_1] * restore_1;
+            }
+            unsigned int _phase_outputs_ready_0_2 = 0;
+            mbarrier_wait(outputs_ready_addr, _phase_outputs_ready_0_2);
+            _phase_outputs_ready_0_2 ^= 1;
+            float _tmem_load_15[8];
+            tmem_ld_x8(&_tmem_load_15[0], taddr + 208 + (unsigned int)tmem_row_base_1 + (unsigned int)token_offset_1);
+            asm volatile("tcgen05.wait::ld.sync.aligned;");
+            #pragma unroll
+            for (int token_local_1 = 0; token_local_1 < 8; token_local_1++) {
+                int token_out_1 = token_offset_1 + token_local_1;
+                long long out_index_3 = out_base_1 + (long long)(token_out_1 * 128) + (long long)key_row_1;
+                int shared_index_1 = token_out_1 * 128 + key_row_1;
+                __nv_bfloat16 i_value_bf16_1 = s_i[(shared_index_1 * 2 ^ (shared_index_1 * 2 >> 8 & 7) << 4) / 2];
+                float _cvt_f32_22 = __bfloat162float(i_value_bf16_1);
+                float i_value_1 = _cvt_f32_22;
+                grad_ki[out_index_3] = _tmem_load_15[token_local_1] + _tmem_load_14[token_local_1];
+                _tmem_load_15[token_local_1] = _tmem_load_15[token_local_1] * i_value_1;
+            }
+            float _tmem_load_16[8];
+            tmem_ld_x8(&_tmem_load_16[0], taddr + 240 + (unsigned int)tmem_row_base_1 + (unsigned int)token_offset_1);
+            float _tmem_load_17[8];
+            tmem_ld_x8(&_tmem_load_17[0], taddr + 272 + (unsigned int)tmem_row_base_1 + (unsigned int)token_offset_1);
+            asm volatile("tcgen05.wait::ld.sync.aligned;");
+            #pragma unroll
+            for (int token_local2_1 = 0; token_local2_1 < 8; token_local2_1++) {
+                int token_out2_1 = token_offset_1 + token_local2_1;
+                long long out_index_4 = out_base_1 + (long long)(token_out2_1 * 128) + (long long)key_row_1;
+                int shared_index2_1 = token_out2_1 * 128 + key_row_1;
+                __nv_bfloat16 q_value_bf16_1 = s_q[(shared_index2_1 * 2 ^ (shared_index2_1 * 2 >> 8 & 7) << 4) / 2];
+                float _cvt_f32_23 = __bfloat162float(q_value_bf16_1);
+                float q_value_1 = _cvt_f32_23;
+                _tmem_load_17[token_local2_1] = _tmem_load_17[token_local2_1] * common_factor_1;
+                float _fma_9 = __fmaf_rn(-_tmem_load_16[token_local2_1], q_value_1, _tmem_load_15[token_local2_1]);
+                _tmem_load_15[token_local2_1] = _fma_9;
+                _tmem_load_14[token_local2_1] = _tmem_load_17[token_local2_1] * q_value_1;
+                grad_qd[out_index_4] = _tmem_load_16[token_local2_1] + _tmem_load_17[token_local2_1];
+            }
+            unsigned int _phase_dbeta_done_0_2 = 0;
+            mbarrier_wait(dbeta_done_addr, _phase_dbeta_done_0_2);
+            _phase_dbeta_done_0_2 ^= 1;
+            float _tmem_load_18[8];
+            tmem_ld_x8(&_tmem_load_18[0], taddr + 304 + (unsigned int)tmem_row_base_1 + (unsigned int)token_offset_1);
+            float _tmem_load_19[8];
+            tmem_ld_x8(&_tmem_load_19[0], taddr + 336 + (unsigned int)tmem_row_base_1 + (unsigned int)token_offset_1);
+            asm volatile("tcgen05.wait::ld.sync.aligned;");
+            float high_base_suffix = 0.0f;
+            #pragma unroll
+            for (int token_local3_1 = 0; token_local3_1 < 8; token_local3_1++) {
+                int token_out3_1 = token_offset_1 + token_local3_1;
+                long long out_index_5 = out_base_1 + (long long)(token_out3_1 * 128) + (long long)key_row_1;
+                int shared_index3_1 = token_out3_1 * 128 + key_row_1;
+                __nv_bfloat16 k_value_bf16_1 = s_k[(shared_index3_1 * 2 ^ (shared_index3_1 * 2 >> 8 & 7) << 4) / 2];
+                float _cvt_f32_24 = __bfloat162float(k_value_bf16_1);
+                float k_value_1 = _cvt_f32_24;
+                _tmem_load_19[token_local3_1] = _tmem_load_19[token_local3_1] * (-common_factor_1);
+                float _fma_10 = __fmaf_rn(-_tmem_load_18[token_local3_1], k_value_1, _tmem_load_15[token_local3_1]);
+                _tmem_load_15[token_local3_1] = _fma_10;
+                float base_value_1 = _tmem_load_14[token_local3_1] + _tmem_load_19[token_local3_1] * k_value_1;
+                int stable_index3_1 = token_out3_1 * 128 + key_row_1;
+                s_stable_delta[stable_index3_1] = _tmem_load_15[token_local3_1];
+                s_stable_base[stable_index3_1] = base_value_1;
+                if (token_out3_1 < chunk_length_1) {
+                    high_base_suffix += base_value_1;
+                }
+                grad_kd[out_index_5] = _tmem_load_18[token_local3_1] + _tmem_load_19[token_local3_1];
+            }
+            s_high_base_suffix[key_row_1] = high_base_suffix;
+            asm volatile("barrier.sync 10, 384;" ::: "memory");
+            unsigned int _phase_epilogue_done_0 = 0;
+            mbarrier_wait(epilogue_done_addr, _phase_epilogue_done_0);
+            _phase_epilogue_done_0 ^= 1;
+            if (warp_id_in_role_2 == 0) {
+                int _tmem_dealloc_addr = *((volatile int*)tmem_addr_storage);
+                asm volatile("tcgen05.dealloc.cta_group::1.sync.aligned.b32 %0, %1;" :: "r"(_tmem_dealloc_addr), "r"(512));
+            }
+        }
+    }
+
+    // Cleanup
+}
+
+} // extern "C"
+
+#undef LOOM_INF
+#undef NUM_MAIN_STAGES
+#undef SMEM_S_DBETA_PARTIAL_OFF
+#undef SMEM_S_DBETA_PARTIAL_STAGE_BYTES
+#undef SMEM_S_DBETA_PARTIAL_STRIDE
+#undef SMEM_S_DET_OFF
+#undef SMEM_S_DET_STAGE_BYTES
+#undef SMEM_S_DET_STRIDE
+#undef SMEM_S_DET_TC_OFF
+#undef SMEM_S_DET_TC_STAGE_BYTES
+#undef SMEM_S_DET_TC_STRIDE
+#undef SMEM_S_DF_OFF
+#undef SMEM_S_DF_STAGE_BYTES
+#undef SMEM_S_DF_STRIDE
+#undef SMEM_S_DH_STAGE_OFF
+#undef SMEM_S_DH_STAGE_STAGE_BYTES
+#undef SMEM_S_DH_STAGE_STRIDE
+#undef SMEM_S_DJ_OFF
+#undef SMEM_S_DJ_STAGE_BYTES
+#undef SMEM_S_DJ_STRIDE
+#undef SMEM_S_DMT_TC_OFF
+#undef SMEM_S_DMT_TC_STAGE_BYTES
+#undef SMEM_S_DMT_TC_STRIDE
+#undef SMEM_S_DM_TC_OFF
+#undef SMEM_S_DM_TC_STAGE_BYTES
+#undef SMEM_S_DM_TC_STRIDE
+#undef SMEM_S_DNT_TC_OFF
+#undef SMEM_S_DNT_TC_STAGE_BYTES
+#undef SMEM_S_DNT_TC_STRIDE
+#undef SMEM_S_DN_TC_OFF
+#undef SMEM_S_DN_TC_STAGE_BYTES
+#undef SMEM_S_DN_TC_STRIDE
+#undef SMEM_S_DOT_OFF
+#undef SMEM_S_DOT_STAGE_BYTES
+#undef SMEM_S_DOT_STRIDE
+#undef SMEM_S_DOT_TC_OFF
+#undef SMEM_S_DOT_TC_STAGE_BYTES
+#undef SMEM_S_DOT_TC_STRIDE
+#undef SMEM_S_DO_STAGE_OFF
+#undef SMEM_S_DO_STAGE_STAGE_BYTES
+#undef SMEM_S_DO_STAGE_STRIDE
+#undef SMEM_S_DRT_OFF
+#undef SMEM_S_DRT_STAGE_BYTES
+#undef SMEM_S_DRT_STRIDE
+#undef SMEM_S_HIGH_BASE_SUFFIX_OFF
+#undef SMEM_S_HIGH_BASE_SUFFIX_STAGE_BYTES
+#undef SMEM_S_HIGH_BASE_SUFFIX_STRIDE
+#undef SMEM_S_I_OFF
+#undef SMEM_S_I_STAGE_BYTES
+#undef SMEM_S_I_STRIDE
+#undef SMEM_S_J_OFF
+#undef SMEM_S_J_STAGE_BYTES
+#undef SMEM_S_J_STRIDE
+#undef SMEM_S_K_OFF
+#undef SMEM_S_K_STAGE_BYTES
+#undef SMEM_S_K_STRIDE
+#undef SMEM_S_MIDDLE_BASE_SUFFIX_OFF
+#undef SMEM_S_MIDDLE_BASE_SUFFIX_STAGE_BYTES
+#undef SMEM_S_MIDDLE_BASE_SUFFIX_STRIDE
+#undef SMEM_S_M_OFF
+#undef SMEM_S_M_STAGE_BYTES
+#undef SMEM_S_M_STRIDE
+#undef SMEM_S_PREV_R_TC_OFF
+#undef SMEM_S_PREV_R_TC_STAGE_BYTES
+#undef SMEM_S_PREV_R_TC_STRIDE
+#undef SMEM_S_Q_OFF
+#undef SMEM_S_Q_STAGE_BYTES
+#undef SMEM_S_Q_STRIDE
+#undef SMEM_S_RT_OFF
+#undef SMEM_S_RT_STAGE_BYTES
+#undef SMEM_S_RT_STRIDE
+#undef SMEM_S_RT_TC_OFF
+#undef SMEM_S_RT_TC_STAGE_BYTES
+#undef SMEM_S_RT_TC_STRIDE
+#undef SMEM_S_STABLE_BASE_OFF
+#undef SMEM_S_STABLE_BASE_STAGE_BYTES
+#undef SMEM_S_STABLE_BASE_STRIDE
+#undef SMEM_S_STABLE_DELTA_OFF
+#undef SMEM_S_STABLE_DELTA_STAGE_BYTES
+#undef SMEM_S_STABLE_DELTA_STRIDE
+#undef SMEM_S_STABLE_DKR_OFF
+#undef SMEM_S_STABLE_DKR_STAGE_BYTES
+#undef SMEM_S_STABLE_DKR_STRIDE
+#undef SMEM_S_TMP_OFF
+#undef SMEM_S_TMP_STAGE_BYTES
+#undef SMEM_S_TMP_STRIDE
+#undef SMEM_S_X_OFF
+#undef SMEM_S_X_STAGE_BYTES
+#undef SMEM_S_X_STRIDE
+#undef SMEM_TOTAL
+#undef THREADS
+#undef TMEM_NCOLS
+#undef TMEM_TMEM_A_DH_OFFSET
+#undef TMEM_TMEM_A_I_OFFSET
+#undef TMEM_TMEM_A_K_OFFSET
+#undef TMEM_TMEM_A_Q_OFFSET
+#undef TMEM_TMEM_A_STATE_OFFSET
+#undef TMEM_TMEM_DI_OFFSET
+#undef TMEM_TMEM_DKR_OFFSET
+#undef TMEM_TMEM_DK_BOUNDARY_OFFSET
+#undef TMEM_TMEM_DK_LOCAL_OFFSET
+#undef TMEM_TMEM_DQ_BOUNDARY_OFFSET
+#undef TMEM_TMEM_DQ_LOCAL_OFFSET
+#undef TMEM_TMEM_RECON_KR_OFFSET
+#undef TMEM_TMEM_RECON_STATE_OFFSET
+#undef a_ready_addr
+#undef boundary_local_ready_addr
+#undef dbeta_done_addr
+#undef dh_ready_addr
+#undef dv_ready_addr
+#undef epilogue_done_addr
+#undef first_outputs_ready_addr
+#undef outputs_ready_addr
+#undef prep_ready_addr
+#undef qki_ready_addr
+#undef qki_tc_ready_addr
+#undef recon_inputs_ready_addr
+#undef recon_output_ready_addr
+#undef s_dbeta_partial_addr
+#undef s_det_addr
+#undef s_det_tc_addr
+#undef s_df_addr
+#undef s_dh_stage_addr
+#undef s_dj_addr
+#undef s_dm_tc_addr
+#undef s_dmt_tc_addr
+#undef s_dn_tc_addr
+#undef s_dnt_tc_addr
+#undef s_do_stage_addr
+#undef s_dot_addr
+#undef s_dot_tc_addr
+#undef s_drt_addr
+#undef s_high_base_suffix_addr
+#undef s_i_addr
+#undef s_j_addr
+#undef s_k_addr
+#undef s_m_addr
+#undef s_middle_base_suffix_addr
+#undef s_prev_r_tc_addr
+#undef s_q_addr
+#undef s_rt_addr
+#undef s_rt_tc_addr
+#undef s_stable_base_addr
+#undef s_stable_delta_addr
+#undef s_stable_dkr_addr
+#undef s_tmp_addr
+#undef s_x_addr
+#undef state_tc_ready_addr
+#undef value_tc_ready_addr
+
+#define LOOM_INF CUDART_INF_F
+#define NUM_MAIN_STAGES 1
+#define THREADS 128
+
+extern "C" {
+
+__global__ __launch_bounds__(128) void
+kernel_flashkda_backward_map_finalize_c32(__nv_bfloat16* __restrict__ decay, __nv_bfloat16* __restrict__ q, __nv_bfloat16* __restrict__ k, float* __restrict__ norm_inv, __nv_bfloat16* __restrict__ g, float* __restrict__ beta_active, float* __restrict__ A_log, float* __restrict__ dt_bias, long long* __restrict__ cu_seqlens, int* __restrict__ chunk_sequence, int* __restrict__ chunk_index, int* __restrict__ chunk_pair_start, __nv_bfloat16* __restrict__ grad_qd, __nv_bfloat16* __restrict__ grad_kd, __nv_bfloat16* __restrict__ grad_ki, float* __restrict__ dlog_decay, float* __restrict__ dbeta_active, __nv_bfloat16* __restrict__ dq, __nv_bfloat16* __restrict__ dk, __nv_bfloat16* __restrict__ dg, __nv_bfloat16* __restrict__ dbeta, float* __restrict__ dA_log, float* __restrict__ ddt_bias, int num_pair_heads, int num_heads, float scale, float lower_bound)
+{
+    const int tid = threadIdx.x;
+    const int warp = make_warp_uniform(tid / 32);
+    const int lane = tid % 32;
+
+
+    const int bid = blockIdx.x;
+    const int num_bids = gridDim.x;
+
+    // === Task calls (dependency order) ===
+    int block_type = blockIdx.x & 3;
+    int task_group = blockIdx.x / 4;
+    int warp_id_in_role = (warp - 0);
+    int pair_task = task_group * 4 + warp_id_in_role;
+    int gate_task = task_group * 8 + (block_type - 2) * 4 + warp_id_in_role;
+    int gate_pair_task = gate_task / 2;
+    int gate_pair_chunk = gate_task - gate_pair_task * 2;
+    if (block_type == 0 && pair_task < num_pair_heads) {
+        int pair = pair_task / num_heads;
+        int head = pair_task - pair * num_heads;
+        int first_chunk = chunk_pair_start[pair];
+        int sequence = chunk_sequence[first_chunk];
+        int first_local_chunk = chunk_index[first_chunk];
+        long long bos = cu_seqlens[sequence];
+        long long eos = cu_seqlens[sequence + 1];
+        int subwarp = lane / 16;
+        int sub_lane = lane - subwarp * 16;
+        int elem = sub_lane * 8;
+        #pragma unroll
+        for (int pair_chunk = 0; pair_chunk < 2; pair_chunk++) {
+            int chunk_global = first_chunk + pair_chunk;
+            int local_chunk = first_local_chunk + pair_chunk;
+            long long chunk_start = bos + (long long)local_chunk * 32;
+            if (chunk_start < eos) {
+                long long chunk_end = chunk_start + 32;
+                if (chunk_end > eos) {
+                    chunk_end = eos;
+                }
+                int chunk_length = (int)(chunk_end - chunk_start);
+                long long chunk_head = (long long)chunk_global * (long long)num_heads + (long long)head;
+                long long tape_base = chunk_head * 32 * 128;
+                #pragma unroll 2
+                for (int token_pair = 0; token_pair < chunk_length; token_pair += 2) {
+                    int token_col = token_pair + subwarp;
+                    long long token = chunk_start + (long long)token_col;
+                    long long token_base = (token * (long long)num_heads + (long long)head) * 128;
+                    long long index = token_base + (long long)elem;
+                    long long tape_index = tape_base + (long long)(token_col * 128) + (long long)elem;
+                    float decay_values[8];
+                    float grad_values[8];
+                    float q_values[8];
+                    float q_inv_lane = 0.0f;
+                    if (token_col < chunk_length) {
+                        {
+                            const uint4* _vptr_0 = reinterpret_cast<const uint4*>(decay + index);
+                            uint4 _vld_0[1];
+                            #pragma unroll
+                            for (int _blk = 0; _blk < 1; _blk++) {
+                                _vld_0[_blk] = _vptr_0[_blk];
+                                uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
+                                #pragma unroll
+                                for (int _pair = 0; _pair < 4; _pair++) {
+                                    asm volatile(
+                                        "{\n\t"
+                                        "shl.b32 %0, %2, 16;\n\t"
+                                        "and.b32 %1, %2, 0xffff0000;\n\t"
+                                        "}\n"
+                                        : "=f"((&decay_values[0 + _blk * 8 + _pair * 2])[0]), "=f"((&decay_values[0 + _blk * 8 + _pair * 2])[1])
+                                        : "r"(_vpairs_0[_pair]));
+                                }
+                            }
+                        }
+                        {
+                            const uint4* _vptr_1 = reinterpret_cast<const uint4*>(grad_qd + tape_index);
+                            uint4 _vld_1[1];
+                            #pragma unroll
+                            for (int _blk = 0; _blk < 1; _blk++) {
+                                _vld_1[_blk] = _vptr_1[_blk];
+                                uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
+                                #pragma unroll
+                                for (int _pair = 0; _pair < 4; _pair++) {
+                                    asm volatile(
+                                        "{\n\t"
+                                        "shl.b32 %0, %2, 16;\n\t"
+                                        "and.b32 %1, %2, 0xffff0000;\n\t"
+                                        "}\n"
+                                        : "=f"((&grad_values[0 + _blk * 8 + _pair * 2])[0]), "=f"((&grad_values[0 + _blk * 8 + _pair * 2])[1])
+                                        : "r"(_vpairs_1[_pair]));
+                                }
+                            }
+                        }
+                        {
+                            const uint4* _vptr_2 = reinterpret_cast<const uint4*>(q + index);
+                            uint4 _vld_2[1];
+                            #pragma unroll
+                            for (int _blk = 0; _blk < 1; _blk++) {
+                                _vld_2[_blk] = _vptr_2[_blk];
+                                uint32_t* _vpairs_2 = reinterpret_cast<uint32_t*>(&_vld_2[_blk]);
+                                #pragma unroll
+                                for (int _pair = 0; _pair < 4; _pair++) {
+                                    asm volatile(
+                                        "{\n\t"
+                                        "shl.b32 %0, %2, 16;\n\t"
+                                        "and.b32 %1, %2, 0xffff0000;\n\t"
+                                        "}\n"
+                                        : "=f"((&q_values[0 + _blk * 8 + _pair * 2])[0]), "=f"((&q_values[0 + _blk * 8 + _pair * 2])[1])
+                                        : "r"(_vpairs_2[_pair]));
+                                }
+                            }
+                        }
+                        if (sub_lane == 0) {
+                            long long norm_base = (token * (long long)num_heads + (long long)head) * 2;
+                            q_inv_lane = norm_inv[norm_base];
+                        }
+                    }
+                    float _shfl_0 = __shfl_sync(0xFFFFFFFF, q_inv_lane, subwarp * 16);
+                    float q_inv = _shfl_0;
+                    float q_dot = 0.0f;
+                    if (token_col < chunk_length) {
+                        #pragma unroll
+                        for (int map_i = 0; map_i < 8; map_i++) {
+                            grad_values[map_i] = grad_values[map_i] * decay_values[map_i] * scale;
+                            __nv_bfloat16 _cvt_bf16_0 = __float2bfloat16(q_values[map_i] * q_inv);
+                            q_values[map_i] = _cvt_bf16_0;
+                            float _fma_0 = __fmaf_rn(grad_values[map_i], q_values[map_i], q_dot);
+                            q_dot = _fma_0;
+                        }
+                    }
+                    float _shfl_xor_0 = __shfl_xor_sync(0xFFFFFFFF, q_dot, 8);
+                    q_dot += _shfl_xor_0;
+                    float _shfl_xor_1 = __shfl_xor_sync(0xFFFFFFFF, q_dot, 4);
+                    q_dot += _shfl_xor_1;
+                    float _shfl_xor_2 = __shfl_xor_sync(0xFFFFFFFF, q_dot, 2);
+                    q_dot += _shfl_xor_2;
+                    float _shfl_xor_3 = __shfl_xor_sync(0xFFFFFFFF, q_dot, 1);
+                    q_dot += _shfl_xor_3;
+                    if (token_col < chunk_length) {
+                        #pragma unroll
+                        for (int pullback_i = 0; pullback_i < 8; pullback_i++) {
+                            grad_values[pullback_i] = q_inv * (grad_values[pullback_i] - q_values[pullback_i] * q_dot);
+                        }
+                        {
+                            __nv_bfloat162 _pk[4];
+                            _pk[0] = __floats2bfloat162_rn(grad_values[0 + 0], grad_values[0 + 1]);
+                            _pk[1] = __floats2bfloat162_rn(grad_values[0 + 2], grad_values[0 + 3]);
+                            _pk[2] = __floats2bfloat162_rn(grad_values[0 + 4], grad_values[0 + 5]);
+                            _pk[3] = __floats2bfloat162_rn(grad_values[0 + 6], grad_values[0 + 7]);
+                            *reinterpret_cast<uint4*>(&((__nv_bfloat16*)(dq))[index + 0]) = *reinterpret_cast<uint4*>(&_pk[0]);
+                        }
+                    }
+                }
+            }
+        }
+    }
+    if (block_type == 1 && pair_task < num_pair_heads) {
+        int pair_1 = pair_task / num_heads;
+        int head_1 = pair_task - pair_1 * num_heads;
+        int first_chunk_1 = chunk_pair_start[pair_1];
+        int sequence_1 = chunk_sequence[first_chunk_1];
+        int first_local_chunk_1 = chunk_index[first_chunk_1];
+        long long bos_1 = cu_seqlens[sequence_1];
+        long long eos_1 = cu_seqlens[sequence_1 + 1];
+        int subwarp_1 = lane / 16;
+        int sub_lane_1 = lane - subwarp_1 * 16;
+        int elem_1 = sub_lane_1 * 8;
+        #pragma unroll
+        for (int pair_chunk_1 = 0; pair_chunk_1 < 2; pair_chunk_1++) {
+            int chunk_global_1 = first_chunk_1 + pair_chunk_1;
+            int local_chunk_1 = first_local_chunk_1 + pair_chunk_1;
+            long long chunk_start_1 = bos_1 + (long long)local_chunk_1 * 32;
+            if (chunk_start_1 < eos_1) {
+                long long chunk_end_1 = chunk_start_1 + 32;
+                if (chunk_end_1 > eos_1) {
+                    chunk_end_1 = eos_1;
+                }
+                int chunk_length_1 = (int)(chunk_end_1 - chunk_start_1);
+                long long chunk_head_1 = (long long)chunk_global_1 * (long long)num_heads + (long long)head_1;
+                long long tape_base_1 = chunk_head_1 * 32 * 128;
+                #pragma unroll 2
+                for (int token_pair_1 = 0; token_pair_1 < chunk_length_1; token_pair_1 += 2) {
+                    int token_col_1 = token_pair_1 + subwarp_1;
+                    long long token_1 = chunk_start_1 + (long long)token_col_1;
+                    long long token_base_1 = (token_1 * (long long)num_heads + (long long)head_1) * 128;
+                    long long index_1 = token_base_1 + (long long)elem_1;
+                    long long tape_index_1 = tape_base_1 + (long long)(token_col_1 * 128) + (long long)elem_1;
+                    float decay_values_1[8];
+                    float grad_k_values[8];
+                    float grad_i_values[8];
+                    float k_values[8];
+                    float k_inv_lane = 0.0f;
+                    if (token_col_1 < chunk_length_1) {
+                        {
+                            const uint4* _vptr_3 = reinterpret_cast<const uint4*>(decay + index_1);
+                            uint4 _vld_3[1];
+                            #pragma unroll
+                            for (int _blk = 0; _blk < 1; _blk++) {
+                                _vld_3[_blk] = _vptr_3[_blk];
+                                uint32_t* _vpairs_3 = reinterpret_cast<uint32_t*>(&_vld_3[_blk]);
+                                #pragma unroll
+                                for (int _pair = 0; _pair < 4; _pair++) {
+                                    asm volatile(
+                                        "{\n\t"
+                                        "shl.b32 %0, %2, 16;\n\t"
+                                        "and.b32 %1, %2, 0xffff0000;\n\t"
+                                        "}\n"
+                                        : "=f"((&decay_values_1[0 + _blk * 8 + _pair * 2])[0]), "=f"((&decay_values_1[0 + _blk * 8 + _pair * 2])[1])
+                                        : "r"(_vpairs_3[_pair]));
+                                }
+                            }
+                        }
+                        {
+                            const uint4* _vptr_4 = reinterpret_cast<const uint4*>(grad_kd + tape_index_1);
+                            uint4 _vld_4[1];
+                            #pragma unroll
+                            for (int _blk = 0; _blk < 1; _blk++) {
+                                _vld_4[_blk] = _vptr_4[_blk];
+                                uint32_t* _vpairs_4 = reinterpret_cast<uint32_t*>(&_vld_4[_blk]);
+                                #pragma unroll
+                                for (int _pair = 0; _pair < 4; _pair++) {
+                                    asm volatile(
+                                        "{\n\t"
+                                        "shl.b32 %0, %2, 16;\n\t"
+                                        "and.b32 %1, %2, 0xffff0000;\n\t"
+                                        "}\n"
+                                        : "=f"((&grad_k_values[0 + _blk * 8 + _pair * 2])[0]), "=f"((&grad_k_values[0 + _blk * 8 + _pair * 2])[1])
+                                        : "r"(_vpairs_4[_pair]));
+                                }
+                            }
+                        }
+                        {
+                            const uint4* _vptr_5 = reinterpret_cast<const uint4*>(grad_ki + tape_index_1);
+                            uint4 _vld_5[1];
+                            #pragma unroll
+                            for (int _blk = 0; _blk < 1; _blk++) {
+                                _vld_5[_blk] = _vptr_5[_blk];
+                                uint32_t* _vpairs_5 = reinterpret_cast<uint32_t*>(&_vld_5[_blk]);
+                                #pragma unroll
+                                for (int _pair = 0; _pair < 4; _pair++) {
+                                    asm volatile(
+                                        "{\n\t"
+                                        "shl.b32 %0, %2, 16;\n\t"
+                                        "and.b32 %1, %2, 0xffff0000;\n\t"
+                                        "}\n"
+                                        : "=f"((&grad_i_values[0 + _blk * 8 + _pair * 2])[0]), "=f"((&grad_i_values[0 + _blk * 8 + _pair * 2])[1])
+                                        : "r"(_vpairs_5[_pair]));
+                                }
+                            }
+                        }
+                        {
+                            const uint4* _vptr_6 = reinterpret_cast<const uint4*>(k + index_1);
+                            uint4 _vld_6[1];
+                            #pragma unroll
+                            for (int _blk = 0; _blk < 1; _blk++) {
+                                _vld_6[_blk] = _vptr_6[_blk];
+                                uint32_t* _vpairs_6 = reinterpret_cast<uint32_t*>(&_vld_6[_blk]);
+                                #pragma unroll
+                                for (int _pair = 0; _pair < 4; _pair++) {
+                                    asm volatile(
+                                        "{\n\t"
+                                        "shl.b32 %0, %2, 16;\n\t"
+                                        "and.b32 %1, %2, 0xffff0000;\n\t"
+                                        "}\n"
+                                        : "=f"((&k_values[0 + _blk * 8 + _pair * 2])[0]), "=f"((&k_values[0 + _blk * 8 + _pair * 2])[1])
+                                        : "r"(_vpairs_6[_pair]));
+                                }
+                            }
+                        }
+                        if (sub_lane_1 == 0) {
+                            long long norm_base_1 = (token_1 * (long long)num_heads + (long long)head_1) * 2;
+                            k_inv_lane = norm_inv[norm_base_1 + 1];
+                        }
+                    }
+                    float _shfl_1 = __shfl_sync(0xFFFFFFFF, k_inv_lane, subwarp_1 * 16);
+                    float k_inv = _shfl_1;
+                    float k_dot = 0.0f;
+                    if (token_col_1 < chunk_length_1) {
+                        #pragma unroll
+                        for (int map_i_1 = 0; map_i_1 < 8; map_i_1++) {
+                            float _rcp_0 = approx_rcp(decay_values_1[map_i_1]);
+                            grad_k_values[map_i_1] = grad_i_values[map_i_1] * _rcp_0 + grad_k_values[map_i_1] * decay_values_1[map_i_1];
+                            __nv_bfloat16 _cvt_bf16_1 = __float2bfloat16(k_values[map_i_1] * k_inv);
+                            k_values[map_i_1] = _cvt_bf16_1;
+                            float _fma_1 = __fmaf_rn(grad_k_values[map_i_1], k_values[map_i_1], k_dot);
+                            k_dot = _fma_1;
+                        }
+                    }
+                    float _shfl_xor_4 = __shfl_xor_sync(0xFFFFFFFF, k_dot, 8);
+                    k_dot += _shfl_xor_4;
+                    float _shfl_xor_5 = __shfl_xor_sync(0xFFFFFFFF, k_dot, 4);
+                    k_dot += _shfl_xor_5;
+                    float _shfl_xor_6 = __shfl_xor_sync(0xFFFFFFFF, k_dot, 2);
+                    k_dot += _shfl_xor_6;
+                    float _shfl_xor_7 = __shfl_xor_sync(0xFFFFFFFF, k_dot, 1);
+                    k_dot += _shfl_xor_7;
+                    if (token_col_1 < chunk_length_1) {
+                        #pragma unroll
+                        for (int pullback_i_1 = 0; pullback_i_1 < 8; pullback_i_1++) {
+                            grad_k_values[pullback_i_1] = k_inv * (grad_k_values[pullback_i_1] - k_values[pullback_i_1] * k_dot);
+                        }
+                        {
+                            __nv_bfloat162 _pk[4];
+                            _pk[0] = __floats2bfloat162_rn(grad_k_values[0 + 0], grad_k_values[0 + 1]);
+                            _pk[1] = __floats2bfloat162_rn(grad_k_values[0 + 2], grad_k_values[0 + 3]);
+                            _pk[2] = __floats2bfloat162_rn(grad_k_values[0 + 4], grad_k_values[0 + 5]);
+                            _pk[3] = __floats2bfloat162_rn(grad_k_values[0 + 6], grad_k_values[0 + 7]);
+                            *reinterpret_cast<uint4*>(&((__nv_bfloat16*)(dk))[index_1 + 0]) = *reinterpret_cast<uint4*>(&_pk[0]);
+                        }
+                    }
+                }
+            }
+        }
+    }
+    if (block_type >= 2 && gate_pair_task < num_pair_heads) {
+        int pair_2 = gate_pair_task / num_heads;
+        int head_2 = gate_pair_task - pair_2 * num_heads;
+        int first_chunk_2 = chunk_pair_start[pair_2];
+        int sequence_2 = chunk_sequence[first_chunk_2];
+        int first_local_chunk_2 = chunk_index[first_chunk_2];
+        long long bos_2 = cu_seqlens[sequence_2];
+        long long eos_2 = cu_seqlens[sequence_2 + 1];
+        int elem_2 = lane * 4;
+        int pair_chunk_2 = gate_pair_chunk;
+        int local_chunk_2 = first_local_chunk_2 + pair_chunk_2;
+        long long chunk_start_2 = bos_2 + (long long)local_chunk_2 * 32;
+        long long chunk_end_2 = chunk_start_2 + 32;
+        if (chunk_end_2 > eos_2) {
+            chunk_end_2 = eos_2;
+        }
+        float gate_a_lane = 0.0f;
+        if (lane == 0) {
+            float _expf_0 = __expf(A_log[head_2]);
+            gate_a_lane = _expf_0;
+        }
+        float _shfl_2 = __shfl_sync(0xFFFFFFFF, gate_a_lane, 0);
+        float gate_a = _shfl_2;
+        float gate_scale = lower_bound * gate_a;
+        float bias[4];
+        float ddt_sum[4];
+        float dA_sum[4];
+        #pragma unroll
+        for (int init_i = 0; init_i < 4; init_i++) {
+            bias[init_i] = dt_bias[head_2 * 128 + elem_2 + init_i];
+            ddt_sum[init_i] = 0.0f;
+            dA_sum[init_i] = 0.0f;
+        }
+        if (chunk_start_2 < eos_2) {
+            int chunk_length_2 = (int)(chunk_end_2 - chunk_start_2);
+            #pragma unroll 2
+            for (int token_col_2 = 0; token_col_2 < chunk_length_2; token_col_2++) {
+                long long token_2 = chunk_start_2 + (long long)token_col_2;
+                long long token_base_2 = (token_2 * (long long)num_heads + (long long)head_2) * 128;
+                long long index_2 = token_base_2 + (long long)elem_2;
+                float g_values[4];
+                float dlog_values[4];
+                float output_values[4];
+                {
+                    uint2 _vld_7;
+                    _vld_7 = *reinterpret_cast<const uint2*>(g + index_2);
+                    uint32_t* _vpairs_7 = reinterpret_cast<uint32_t*>(&_vld_7);
+                    #pragma unroll
+                    for (int _pair = 0; _pair < 2; _pair++) {
+                        asm volatile(
+                            "{\n\t"
+                            "shl.b32 %0, %2, 16;\n\t"
+                            "and.b32 %1, %2, 0xffff0000;\n\t"
+                            "}\n"
+                            : "=f"((&g_values[0 + _pair * 2])[0]), "=f"((&g_values[0 + _pair * 2])[1])
+                            : "r"(_vpairs_7[_pair]));
+                    }
+                }
+                {
+                    float4 _v4 = *reinterpret_cast<const float4*>(dlog_decay + index_2);
+                    dlog_values[0 + 0] = _v4.x;
+                    dlog_values[0 + 1] = _v4.y;
+                    dlog_values[0 + 2] = _v4.z;
+                    dlog_values[0 + 3] = _v4.w;
+                }
+                #pragma unroll
+                for (int gate_i = 0; gate_i < 4; gate_i++) {
+                    float biased = g_values[gate_i] + bias[gate_i];
+                    float _expf_1 = __expf((-gate_a) * biased);
+                    float _rcp_1 = approx_rcp(1.0f + _expf_1);
+                    float sigmoid = _rcp_1;
+                    float common = dlog_values[gate_i] * gate_scale * sigmoid * (1.0f - sigmoid);
+                    output_values[gate_i] = common;
+                    ddt_sum[gate_i] = ddt_sum[gate_i] + common;
+                    float _fma_2 = __fmaf_rn(common, biased, dA_sum[gate_i]);
+                    dA_sum[gate_i] = _fma_2;
+                }
+                {
+                    uint2 _pk2;
+                    __nv_bfloat162* _pk = reinterpret_cast<__nv_bfloat162*>(&_pk2);
+                    _pk[0] = __floats2bfloat162_rn(output_values[0 + 0], output_values[0 + 1]);
+                    _pk[1] = __floats2bfloat162_rn(output_values[0 + 2], output_values[0 + 3]);
+                    *reinterpret_cast<uint2*>(&((__nv_bfloat16*)(dg))[index_2]) = _pk2;
+                }
+                if (lane == 0) {
+                    long long beta_index = token_2 * (long long)num_heads + (long long)head_2;
+                    float beta_sigmoid = beta_active[beta_index];
+                    __nv_bfloat16 _cvt_bf16_2 = __float2bfloat16(dbeta_active[beta_index] * beta_sigmoid * (1.0f - beta_sigmoid));
+                    dbeta[beta_index] = _cvt_bf16_2;
+                }
+            }
+            #pragma unroll
+            for (int publish_i = 0; publish_i < 4; publish_i++) {
+                atomicAdd(&ddt_bias[head_2 * 128 + elem_2 + publish_i], ddt_sum[publish_i]);
+            }
+            float head_dA = 0.0f;
+            #pragma unroll
+            for (int reduce_i = 0; reduce_i < 4; reduce_i++) {
+                head_dA += dA_sum[reduce_i];
+            }
+            float _warp_reduce_0 = head_dA;
+            #pragma unroll
+            for (int offset = 16; offset > 0; offset >>= 1)
+                _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
+            head_dA = _warp_reduce_0;
+            if (lane == 0) {
+                atomicAdd(&dA_log[head_2], head_dA);
+            }
+        }
+    }
+}
+
+} // extern "C"
+
+#undef LOOM_INF
+#undef NUM_MAIN_STAGES
+#undef THREADS

--- a/docs/api/kda_backward.rst
+++ b/docs/api/kda_backward.rst
@@ -1,0 +1,73 @@
+.. _apikda_backward:
+
+flashinfer.kda_backward
+=======================
+
+Frozen recurrent Kimi Delta Attention (KDA) training backward for SM100a and
+SM103a.
+The operation reconstructs the forward recurrence and returns gradients for
+Q, K, V, raw gate, raw beta, ``A_log``, ``dt_bias``, and initial state.
+
+.. currentmodule:: flashinfer.kda_backward
+
+.. autosummary::
+    :toctree: ../generated
+
+    recurrent_kda_backward
+    RecurrentKDABackwardWorkspace
+
+Supported contract
+------------------
+
+The implementation requires an NVIDIA compute-capability 10.0 or 10.3 GPU.
+SM100a requires CUDA 12.8 or newer and SM103a requires CUDA 12.9 or newer.
+Token tensors and output adjoint are contiguous BF16,
+parameters and state tensors are contiguous FP32, and both key and value
+dimensions are 128. State tensors use value-first ``[N,H,V,K]`` layout. Q and
+K use L2 normalization with epsilon ``1e-6``. The decay and beta
+transformations are ``exp(-5 * sigmoid(exp(A_log) * (g + dt_bias)))`` and
+``sigmoid(beta)`` respectively. The output scale is fixed at
+``1 / sqrt(128)``.
+
+Only these shapes are admitted:
+
+* fixed ``B=1,T=17,H=1``;
+* packed sequence lengths ``[17,33,65]``, ``H=4``;
+* fixed ``B=1,T=17,H=16``;
+* fixed ``B=1,T=1024,H=4``;
+* fixed ``B=1,T=4096,H=32``;
+* fixed ``B=1,T=8192,H=96``;
+* packed sequence lengths ``[1300,547,2048,963,271,3063]``, ``H=96``; and
+* eight packed sequences of length 1024, ``H=96``.
+
+Packed offsets must be a contiguous CUDA int64 tensor with the exact values
+for the selected shape. The eager warm call synchronizes once to validate
+those values; the launch path then consumes the CUDA tensor directly.
+
+Workspace and CUDA Graphs
+-------------------------
+
+Eager calls without an explicit workspace use stream-local reusable scratch.
+For CUDA Graph capture, construct one
+``RecurrentKDABackwardWorkspace(device)`` per captured invocation and provide
+eight preallocated tensors through ``out=``. Eagerly invoke the same call on
+the intended capture stream with the exact input and output tensors, then
+synchronize that stream before capture. This allocates every intermediate and
+prepares the route's TMA descriptors. Capture accepts only that exact
+pointer, shape, stride, dtype, scale, and lower-bound signature and performs
+no allocation or descriptor preparation.
+
+The aligned, uniform eight-by-1024 shape uses a persistent C16 forward
+checkpoint kernel, a persistent C16 reverse kernel, and two parameter-gradient
+reduction kernels. The other documented shapes retain the C32 or low-head
+routes.
+
+The low-head route stores an FP32 checkpoint tensor with shape
+``[T,H,128,128]``. Its largest supported configuration, fixed
+``T=1024,H=4``, occupies 256 MiB (about 268 MB) per workspace. An explicit
+workspace used by a captured graph retains that storage for the workspace and
+graph lifetime.
+
+The workspace binds to its first stream and must outlive the graph and all
+replays. Once a workspace participates in capture it cannot be passed through
+Python again. Graph replay does not re-enter Python.

--- a/docs/api/kda_prefill.rst
+++ b/docs/api/kda_prefill.rst
@@ -141,7 +141,7 @@ contract so the launch path does not synchronize to inspect them.
 
 Native checkpoints use a preallocated BF16
 ``state_checkpoints[C,H,V,K]``, int64 ``checkpoint_cu_starts[N+1]``, and a
-positive ``checkpoint_every_n_tokens`` divisible by 32. KDA checkpoints are
+positive ``checkpoint_every_n_tokens`` divisible by 16. KDA checkpoints are
 states *before* each interval: every non-empty sequence contributes its
 initial state as row zero, followed by states after one, two, ... intervals
 that strictly precede its end. Consequently each sequence contributes

--- a/docs/api/kda_training.rst
+++ b/docs/api/kda_training.rst
@@ -1,0 +1,60 @@
+.. _apikda_training:
+
+flashinfer.kda_training
+=======================
+
+``recurrent_kda_training_forward`` and
+``recurrent_kda_training_backward`` form one paired training API. The forward
+returns BF16 token output, an FP32 recurrent final state, and a persistent
+context containing the route-specific checkpoints, tapes, and active-beta
+values consumed by the backward. An accurate full-precision-state recurrence
+produces the public FP32 final state for the C16 and C32 routes. On C16, its
+token output is private scratch so the selected training output remains public.
+On C32, the accurate recurrence also produces the public token output, while
+the chunked C32 tape and checkpoints remain saved only as backward context.
+The row-split route directly produces its public token output and final state.
+The paired backward consumes the saved training context directly; it does not
+recompute either forward recurrence.
+CUDA graph capture is not supported. Caller-provided forward outputs and
+backward gradient outputs must not overlap each other or any input or saved
+context storage read by the same call. Inputs and saved checkpoint or metadata
+tensors must not be modified between forward and backward; tensor-version
+changes are rejected before the backward launch and also prevent context reuse.
+
+A caller-owned context may be reused only with matching shape metadata and CUDA
+device, on the CUDA stream that originally created it. Reuse overwrites its
+saved checkpoints and metadata. Calls sharing one context are serialized.
+
+The frozen production dispatcher requires Blackwell compute capability 10.0
+or 10.3, key/value dimensions 128, BF16 Q/K/V/raw-gate/raw-beta, and FP32
+parameters and recurrent states. Q and K use ``Hqk`` heads; V, raw gate, raw
+beta, and recurrent state use ``Hv`` heads, where ``Hv % Hqk == 0``. Every
+semantic sequence must be non-empty. The safe gate lower bound is fixed to
+``-5.0`` and the scale to ``1 / sqrt(128)``.
+
+Fixed layout accepts contiguous ``[B, T, H, 128]`` tensors with ``B >= 1`` and
+omitted ``cu_seqlens``; each physical batch row is one semantic sequence.
+Packed layout accepts a physical batch dimension of one plus CUDA int64
+``cu_seqlens``. Packed sequence lengths may be mixed, and neither layout
+requires a 16-token-aligned length.
+
+The dispatcher selects grouped or equal-head C16 for shapes that satisfy its
+fast-route predicates. Other grouped or high-head shapes use the C32 fallback;
+other low-head equal-head shapes use the row-split fallback. These predicates
+select an implementation and are not public shape guards. The paired backward
+consumes the exact context saved by the selected route, including C32 tails and
+mixed sequence lengths, without rerunning a forward kernel.
+
+The exact packed training shape with eight 1024-token sequences and 96 equal
+heads is validated against FLA for output, final state, and all eight gradients
+at ``atol=rtol=1e-2``. Regression coverage also exercises grouped C32 mixed
+tails and fixed B2/B4/B8 layouts through the same public paired API.
+
+.. currentmodule:: flashinfer.kda_training
+
+.. autosummary::
+    :toctree: generated
+
+    RecurrentKDATrainingContext
+    recurrent_kda_training_forward
+    recurrent_kda_training_backward

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -55,6 +55,8 @@ FlashInfer is a library and kernel generator for Large Language Models that prov
    api/gdn_fused_decode
    api/gdn_prefill
    api/kda
+   api/kda_backward
+   api/kda_training
    api/kda_decode
    api/kda_prefill
    api/mamba

--- a/flashinfer/__init__.py
+++ b/flashinfer/__init__.py
@@ -140,6 +140,19 @@ from .grouped_mm import grouped_mm_bf16 as grouped_mm_bf16
 from .grouped_mm import grouped_mm_fp8 as grouped_mm_fp8
 from .grouped_mm import grouped_mm_mxfp8 as grouped_mm_mxfp8
 from .grouped_mm import grouped_mm_fp4 as grouped_mm_fp4
+from .kda_backward import (
+    RecurrentKDABackwardWorkspace as RecurrentKDABackwardWorkspace,
+)
+from .kda_backward import recurrent_kda_backward as recurrent_kda_backward
+from .kda_training import (
+    RecurrentKDATrainingContext as RecurrentKDATrainingContext,
+)
+from .kda_training import (
+    recurrent_kda_training_backward as recurrent_kda_training_backward,
+)
+from .kda_training import (
+    recurrent_kda_training_forward as recurrent_kda_training_forward,
+)
 from .kda_prefill import (
     RecurrentKDAPrefillWorkspace as RecurrentKDAPrefillWorkspace,
 )

--- a/flashinfer/_kda_training_impl.py
+++ b/flashinfer/_kda_training_impl.py
@@ -1,0 +1,1565 @@
+"""Full-dispatch paired Blackwell recurrent KDA training implementation."""
+
+from __future__ import annotations
+
+import math
+import threading
+from dataclasses import dataclass, field
+from typing import Literal, Optional, Sequence, cast
+
+import torch
+
+from .api_logging import flashinfer_api
+from .kda_backward import KDA_BACKWARD_GRADIENT_NAMES
+from .utils import get_compute_capability
+
+_HEAD_DIM = 128
+_C16_CHUNK = 16
+_C32_CHUNK = 32
+_LOWER_BOUND = -5.0
+_SCALE = 1.0 / math.sqrt(_HEAD_DIM)
+_SUPPORTED_COMPUTE_CAPABILITIES = ((10, 0), (10, 3))
+_FINAL_TMAP_SLOTS_PER_CTA = 10
+_FINAL_TMAP_BYTES_PER_SLOT = 128
+_FINAL_SHORT_GRID_CTAS = 128
+_FINAL_LONG_GRID_CTAS = 148
+_TrainingTarget = Literal["sm100a", "sm103a"]
+_RouteTag = Literal["grouped_c16", "grouped_c32", "c16", "c32", "row_split"]
+_RouteFamily = Literal["c16", "c32", "row_split"]
+
+
+def _tensor_signature(tensor: torch.Tensor) -> tuple:
+    return (
+        tensor.data_ptr(),
+        tuple(tensor.shape),
+        tuple(tensor.stride()),
+        tensor.dtype,
+        int(tensor._version),
+    )
+
+
+def _storage_ranges_overlap(left: torch.Tensor, right: torch.Tensor) -> bool:
+    if left.device != right.device or left.numel() == 0 or right.numel() == 0:
+        return False
+
+    def storage_end(tensor: torch.Tensor) -> int:
+        offset = sum(
+            (size - 1) * stride
+            for size, stride in zip(tensor.shape, tensor.stride(), strict=True)
+            if size > 0
+        )
+        return tensor.data_ptr() + (offset + 1) * tensor.element_size()
+
+    return left.data_ptr() < storage_end(right) and right.data_ptr() < storage_end(left)
+
+
+def _check_writes_do_not_overlap(
+    writes: Sequence[tuple[str, torch.Tensor]],
+    reads: Sequence[tuple[str, torch.Tensor]],
+) -> None:
+    for index, (write_name, write_tensor) in enumerate(writes):
+        for read_name, read_tensor in reads:
+            if _storage_ranges_overlap(write_tensor, read_tensor):
+                raise ValueError(f"{write_name} must not overlap {read_name}")
+        for other_name, other_tensor in writes[index + 1 :]:
+            if _storage_ranges_overlap(write_tensor, other_tensor):
+                raise ValueError(f"{write_name} must not overlap {other_name}")
+
+
+def _validate_tensor(
+    tensor: torch.Tensor,
+    name: str,
+    *,
+    shape: tuple[int, ...],
+    dtype: torch.dtype,
+    device: torch.device,
+) -> None:
+    if not isinstance(tensor, torch.Tensor):
+        raise TypeError(f"{name} must be a torch.Tensor")
+    if not tensor.is_cuda or tensor.device != device:
+        raise ValueError(f"{name} must be on CUDA device {device}")
+    if tensor.dtype != dtype:
+        raise ValueError(f"{name} must have dtype {dtype}, got {tensor.dtype}")
+    if tuple(tensor.shape) != shape:
+        raise ValueError(f"{name} must have shape {shape}, got {tuple(tensor.shape)}")
+    if not tensor.is_contiguous():
+        raise ValueError(f"{name} must be contiguous")
+
+
+def _validate_scale_and_bound(
+    scale: Optional[float], lower_bound: float
+) -> tuple[float, float]:
+    scale_value = _SCALE if scale is None else float(scale)
+    lower_bound_value = float(lower_bound)
+    if not math.isfinite(scale_value) or abs(scale_value - _SCALE) > 1e-15:
+        raise ValueError(
+            f"recurrent KDA training fixes scale=1/sqrt(128), got {scale_value}"
+        )
+    if not math.isfinite(lower_bound_value) or lower_bound_value != _LOWER_BOUND:
+        raise ValueError(
+            f"recurrent KDA training fixes lower_bound=-5.0, got {lower_bound_value}"
+        )
+    return scale_value, lower_bound_value
+
+
+@dataclass(frozen=True)
+class _TrainingRouteSpec:
+    tag: _RouteTag
+
+    @property
+    def family(self) -> _RouteFamily:
+        if self.tag.endswith("c16"):
+            return "c16"
+        if self.tag.endswith("c32"):
+            return "c32"
+        return "row_split"
+
+    @property
+    def grouped(self) -> bool:
+        return self.tag.startswith("grouped_")
+
+
+def _select_training_route(
+    seq_lens: tuple[int, ...], num_qk_heads: int, num_v_heads: int
+) -> _TrainingRouteSpec:
+    """Mirror the source dispatcher without promoting fast-route predicates to guards."""
+
+    long_underfilled_c16 = (
+        num_v_heads <= 8
+        and max(seq_lens) >= 1024
+        and all(length > 0 and length % _C16_CHUNK == 0 for length in seq_lens)
+    )
+    grouped = num_qk_heads != num_v_heads
+    if grouped:
+        return _TrainingRouteSpec(
+            "grouped_c16" if long_underfilled_c16 else "grouped_c32"
+        )
+    if long_underfilled_c16:
+        return _TrainingRouteSpec("c16")
+    uniform_c16 = (
+        num_v_heads >= 16
+        and len(set(seq_lens)) == 1
+        and seq_lens[0] > 0
+        and seq_lens[0] % _C16_CHUNK == 0
+    )
+    if uniform_c16:
+        chunks_per_item = seq_lens[0] // _C16_CHUNK
+        work_items = len(seq_lens) * num_v_heads
+        use_c16 = (
+            num_v_heads <= 64
+            and (
+                (chunks_per_item <= 32 and work_items >= 128)
+                or (chunks_per_item <= 64 and work_items >= 192)
+            )
+        ) or (
+            num_v_heads > 64
+            and (
+                (chunks_per_item <= 64 and work_items >= 384)
+                or (chunks_per_item <= 96 and work_items >= 768)
+            )
+        )
+        if use_c16:
+            return _TrainingRouteSpec("c16")
+    return _TrainingRouteSpec("c32" if num_v_heads >= 16 else "row_split")
+
+
+@dataclass(frozen=True)
+class _TrainingShape:
+    layout: Literal["fixed", "packed"]
+    public_batch: int
+    public_tokens: int
+    total_tokens: int
+    num_sequences: int
+    num_qk_heads: int
+    num_v_heads: int
+    seq_lens: tuple[int, ...]
+    offsets: tuple[int, ...]
+    route: _TrainingRouteSpec
+
+
+def _validate_forward_inputs(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor,
+    beta: torch.Tensor,
+    A_log: torch.Tensor,
+    dt_bias: torch.Tensor,
+    initial_state: torch.Tensor,
+    cu_seqlens: Optional[torch.Tensor],
+) -> _TrainingShape:
+    if not isinstance(q, torch.Tensor) or not q.is_cuda:
+        raise ValueError("recurrent_kda_training_forward requires CUDA tensors")
+    device = q.device
+    if get_compute_capability(device) not in _SUPPORTED_COMPUTE_CAPABILITIES:
+        raise ValueError(
+            "recurrent_kda_training_forward requires compute capability 10.0 or 10.3"
+        )
+    if q.ndim != 4 or q.shape[-1] != _HEAD_DIM:
+        raise ValueError("q must have shape [B, T, num_qk_heads, 128]")
+    batch, tokens, num_qk_heads = map(int, q.shape[:3])
+    if batch <= 0 or tokens <= 0 or num_qk_heads <= 0:
+        raise ValueError("batch, sequence length, and head count must be positive")
+    if cu_seqlens is None:
+        layout: Literal["fixed", "packed"] = "fixed"
+        seq_lens = (tokens,) * batch
+        offsets = tuple(index * tokens for index in range(batch + 1))
+    else:
+        layout = "packed"
+        if batch != 1:
+            raise ValueError("packed tensors must have physical batch dimension 1")
+        if not isinstance(cu_seqlens, torch.Tensor) or cu_seqlens.ndim != 1:
+            raise ValueError("cu_seqlens must be a one-dimensional CUDA tensor")
+        _validate_tensor(
+            cu_seqlens,
+            "cu_seqlens",
+            shape=(int(cu_seqlens.numel()),),
+            dtype=torch.int64,
+            device=device,
+        )
+        if cu_seqlens.numel() < 2:
+            raise ValueError("cu_seqlens must contain at least one sequence")
+        offsets = tuple(int(value) for value in cu_seqlens.detach().cpu().tolist())
+        if offsets[0] != 0 or offsets[-1] != tokens:
+            raise ValueError("cu_seqlens must start at zero and end at total_tokens")
+        seq_lens = tuple(
+            right - left for left, right in zip(offsets, offsets[1:], strict=False)
+        )
+    if any(length <= 0 for length in seq_lens):
+        raise ValueError("all sequence lengths must be positive")
+    if v.ndim != 4 or v.shape[:2] != q.shape[:2] or v.shape[-1] != _HEAD_DIM:
+        raise ValueError("v must have shape [B, T, num_v_heads, 128]")
+    num_v_heads = int(v.shape[2])
+    if num_v_heads <= 0 or num_v_heads % num_qk_heads != 0:
+        raise ValueError("num_v_heads must be an integer multiple of num_qk_heads")
+    qk_shape = (batch, tokens, num_qk_heads, _HEAD_DIM)
+    value_shape = (batch, tokens, num_v_heads, _HEAD_DIM)
+    for name, tensor, expected in (
+        ("q", q, qk_shape),
+        ("k", k, qk_shape),
+        ("v", v, value_shape),
+        ("g", g, value_shape),
+    ):
+        _validate_tensor(
+            tensor, name, shape=expected, dtype=torch.bfloat16, device=device
+        )
+    _validate_tensor(
+        beta,
+        "beta",
+        shape=(batch, tokens, num_v_heads),
+        dtype=torch.bfloat16,
+        device=device,
+    )
+    _validate_tensor(
+        A_log, "A_log", shape=(num_v_heads,), dtype=torch.float32, device=device
+    )
+    _validate_tensor(
+        dt_bias,
+        "dt_bias",
+        shape=(num_v_heads, _HEAD_DIM),
+        dtype=torch.float32,
+        device=device,
+    )
+    num_sequences = len(seq_lens)
+    _validate_tensor(
+        initial_state,
+        "initial_state",
+        shape=(num_sequences, num_v_heads, _HEAD_DIM, _HEAD_DIM),
+        dtype=torch.float32,
+        device=device,
+    )
+    return _TrainingShape(
+        layout=layout,
+        public_batch=batch,
+        public_tokens=tokens,
+        total_tokens=batch * tokens,
+        num_sequences=num_sequences,
+        num_qk_heads=num_qk_heads,
+        num_v_heads=num_v_heads,
+        seq_lens=seq_lens,
+        offsets=offsets,
+        route=_select_training_route(seq_lens, num_qk_heads, num_v_heads),
+    )
+
+
+def _training_target(device: torch.device) -> _TrainingTarget:
+    return "sm100a" if get_compute_capability(device) == (10, 0) else "sm103a"
+
+
+def _load_training_module(device: torch.device):
+    from .jit.flash_kda_training import load_flash_kda_training_module
+
+    return load_flash_kda_training_module(_training_target(device))
+
+
+def _get_training_module(device: torch.device):
+    # Keep the historical monkeypatch seam on flashinfer.kda_training.
+    from . import kda_training
+
+    return kda_training._get_training_module(device)
+
+
+def _aligned_u8(device: torch.device, size: int) -> torch.Tensor:
+    raw = torch.empty(size + 63, dtype=torch.uint8, device=device)
+    offset = (-raw.data_ptr()) % 64
+    return raw[offset : offset + size]
+
+
+def _canonical_views(
+    shape: _TrainingShape,
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor,
+    beta: torch.Tensor,
+) -> tuple[torch.Tensor, ...]:
+    return (
+        q.view(1, shape.total_tokens, shape.num_qk_heads, _HEAD_DIM),
+        k.view(1, shape.total_tokens, shape.num_qk_heads, _HEAD_DIM),
+        v.view(1, shape.total_tokens, shape.num_v_heads, _HEAD_DIM),
+        g.view(1, shape.total_tokens, shape.num_v_heads, _HEAD_DIM),
+        beta.view(1, shape.total_tokens, shape.num_v_heads),
+    )
+
+
+def _final_grid_ctas(shape: _TrainingShape) -> int:
+    total_tiles = shape.num_sequences * shape.num_v_heads
+    if total_tiles <= _FINAL_SHORT_GRID_CTAS:
+        return total_tiles
+    max_chunks = max((length + 63) // 64 for length in shape.seq_lens)
+    if max_chunks <= 8:
+        return min(_FINAL_SHORT_GRID_CTAS, total_tiles)
+    return min(_FINAL_LONG_GRID_CTAS, total_tiles)
+
+
+def _build_c16_metadata(
+    shape: _TrainingShape, device: torch.device
+) -> dict[str, object]:
+    chunk_counts = tuple(length // _C16_CHUNK for length in shape.seq_lens)
+    resident_ctas = int(torch.cuda.get_device_properties(device).multi_processor_count)
+    token_starts = [0]
+    checkpoint_starts = [0]
+    for length, count in zip(shape.seq_lens, chunk_counts, strict=True):
+        token_starts.append(token_starts[-1] + length)
+        checkpoint_starts.append(checkpoint_starts[-1] + count)
+    split = shape.num_v_heads <= 8 and max(shape.seq_lens) >= 1024
+    rows: list[tuple[int, int, int, int, int, int, int, int, int]] = []
+    n_tiles = shape.num_sequences * shape.num_v_heads
+    ideal_tokens = (
+        shape.total_tokens * shape.num_v_heads + resident_ctas - 1
+    ) // resident_ctas
+    ideal_chunks = max(1, (ideal_tokens + _C16_CHUNK - 1) // _C16_CHUNK)
+    for sequence, count in enumerate(chunk_counts):
+        piece_count = 1
+        if split:
+            piece_cap = max(1, min(count, 2048))
+            piece_count = max(
+                1, min((count + ideal_chunks - 1) // ideal_chunks, piece_cap)
+            )
+            if n_tiles < 2 * resident_ctas:
+                piece_start = max(1, piece_count - 8)
+                best_cost = 2**31 - 1
+                for delta in range(16):
+                    candidate = min(piece_start + delta, piece_cap)
+                    span = (count + candidate - 1) // candidate
+                    waves = (n_tiles * candidate + resident_ctas - 1) // resident_ctas
+                    cost = waves * (span + 16)
+                    if cost < best_cost:
+                        best_cost, piece_count = cost, candidate
+                unsplit_cost = ((n_tiles + resident_ctas - 1) // resident_ctas) * (
+                    count + 16
+                )
+                if 4 * best_cost > 3 * unsplit_cost:
+                    piece_count = 1
+        span = (count + piece_count - 1) // piece_count
+        num_pieces = (count + span - 1) // span
+        for head in range(shape.num_v_heads):
+            for piece in range(num_pieces):
+                write_start = piece * span
+                write_end = min(count, write_start + span)
+                rows.append(
+                    (
+                        sequence,
+                        head,
+                        piece,
+                        write_start,
+                        write_end,
+                        0 if piece == 0 else write_start,
+                        count if piece + 1 == num_pieces else write_end,
+                        token_starts[sequence],
+                        token_starts[sequence + 1],
+                    )
+                )
+    rows.sort(key=lambda row: row[4] - row[3], reverse=True)
+    row_index = {(row[0], row[1], row[2]): index for index, row in enumerate(rows)}
+    boundaries: list[tuple[int, int]] = []
+    for sequence in range(shape.num_sequences):
+        pieces = max(row[2] for row in rows if row[0] == sequence) + 1
+        for head in range(shape.num_v_heads):
+            for piece in range(1, pieces):
+                boundaries.append(
+                    (
+                        row_index[(sequence, head, piece - 1)],
+                        row_index[(sequence, head, piece)],
+                    )
+                )
+    work_rows = [
+        (sequence, head, write_start, write_end, compute_start, compute_end, bos, eos)
+        for sequence, head, _piece, write_start, write_end, compute_start, compute_end, bos, eos in rows
+    ]
+    base_work_items = torch.tensor(work_rows, dtype=torch.int32, device=device)
+    return {
+        "chunk_counts": chunk_counts,
+        "total_chunks": sum(chunk_counts),
+        "base_work_items": base_work_items,
+        "work_items": base_work_items.clone(),
+        "boundaries": torch.tensor(
+            boundaries if boundaries else [(0, 0)], dtype=torch.int32, device=device
+        ),
+        "checkpoint_cu_starts": torch.tensor(
+            checkpoint_starts, dtype=torch.int64, device=device
+        ),
+        "total_work_items": len(rows),
+        "uniform_work_items": int(not boundaries and len(set(chunk_counts)) == 1),
+        "boundary_count": len(boundaries),
+    }
+
+
+def _build_c32_metadata(
+    shape: _TrainingShape, device: torch.device
+) -> dict[str, object]:
+    sm_count = int(torch.cuda.get_device_properties(device).multi_processor_count)
+    total_sequence_heads = shape.num_sequences * shape.num_v_heads
+    chunk_offsets = [0]
+    chunk_counts: list[int] = []
+    chunk_sequences: list[int] = []
+    chunk_indices: list[int] = []
+    for sequence, length in enumerate(shape.seq_lens):
+        count = (length + _C32_CHUNK - 1) // _C32_CHUNK
+        chunk_counts.append(count)
+        chunk_offsets.append(chunk_offsets[-1] + count)
+        chunk_sequences.extend([sequence] * count)
+        chunk_indices.extend(range(count))
+    sequence_order = sorted(
+        range(shape.num_sequences),
+        key=lambda index: shape.seq_lens[index],
+        reverse=True,
+    )
+    split_multiplier = sm_count // total_sequence_heads
+    forward_two_wave_fill = (
+        sm_count // 2 < total_sequence_heads < sm_count and max(chunk_counts) >= 96
+    )
+    use_split = (
+        split_multiplier >= 2 and max(chunk_counts) >= 64
+    ) or forward_two_wave_fill
+    rows: list[tuple[int, int, int, int, int]] = []
+    for sequence in sequence_order:
+        count = chunk_counts[sequence]
+        splits = 1
+        if use_split:
+            split_cap = (
+                (2 * sm_count) // total_sequence_heads
+                if forward_two_wave_fill
+                else split_multiplier
+            )
+            splits = min(split_cap, max(1, count // 32))
+        for head in range(shape.num_v_heads):
+            for split in range(splits):
+                rows.append(
+                    (
+                        sequence,
+                        head,
+                        (count * split) // splits,
+                        (count * (split + 1)) // splits,
+                        count,
+                    )
+                )
+    rows.sort(key=lambda row: row[3] - row[2], reverse=True)
+    boundary_split_items = use_split and not forward_two_wave_fill
+    split_boundary = shape.num_v_heads <= 64 and not boundary_split_items
+    boundary_value_splits = 2 if split_boundary else 1
+    boundary_multiplier = max(
+        1, sm_count // (total_sequence_heads * boundary_value_splits)
+    )
+    boundary_rows: list[tuple[int, int, int, int, int]] = []
+    for sequence in sequence_order:
+        count = chunk_counts[sequence]
+        splits = (
+            min(boundary_multiplier, max(1, count // 32)) if boundary_split_items else 1
+        )
+        for head in range(shape.num_v_heads):
+            for split in range(splits):
+                boundary_rows.append(
+                    (
+                        sequence,
+                        head,
+                        (count * split) // splits,
+                        (count * (split + 1)) // splits,
+                        count,
+                    )
+                )
+    boundary_rows.sort(key=lambda row: row[3] - row[2], reverse=True)
+    consumer_chunks = [
+        chunk_offsets[sequence] + chunk_counts[sequence] - 1 - reverse_depth
+        for reverse_depth in range(max(chunk_counts))
+        for sequence in sequence_order
+        if reverse_depth < chunk_counts[sequence]
+    ]
+    pair_starts = [
+        chunk_offsets[sequence] + local
+        for sequence, count in enumerate(chunk_counts)
+        for local in range(0, count, 2)
+    ]
+    return {
+        "chunk_counts": tuple(chunk_counts),
+        "total_chunks": chunk_offsets[-1],
+        "cu_chunk_offsets": torch.tensor(
+            chunk_offsets, dtype=torch.int64, device=device
+        ),
+        "chunk_sequence": torch.tensor(
+            chunk_sequences, dtype=torch.int32, device=device
+        ),
+        "chunk_index": torch.tensor(chunk_indices, dtype=torch.int32, device=device),
+        "seq_order": torch.tensor(sequence_order, dtype=torch.int32, device=device),
+        "work_items": torch.tensor(rows, dtype=torch.int32, device=device),
+        "boundary_work_items": torch.tensor(
+            boundary_rows, dtype=torch.int32, device=device
+        ),
+        "consumer_chunk_order": torch.tensor(
+            consumer_chunks, dtype=torch.int32, device=device
+        ),
+        "chunk_pair_start": torch.tensor(pair_starts, dtype=torch.int32, device=device),
+        "num_work_items": len(rows),
+        "boundary_count": len(boundary_rows),
+        "split_boundary": split_boundary,
+        "boundary_value_splits": boundary_value_splits,
+        "total_pairs": len(pair_starts),
+        "use_split_work_items": use_split,
+        "forward_two_wave_fill": forward_two_wave_fill,
+        "boundary_split_work_items": boundary_split_items,
+    }
+
+
+@dataclass
+class RecurrentKDATrainingContext:
+    """Route-tagged forward tapes consumed by the paired backward."""
+
+    state_checkpoints: torch.Tensor
+    beta_active: torch.Tensor
+    _route: _TrainingRouteSpec = field(repr=False)
+    _shape: _TrainingShape = field(repr=False)
+    _q: torch.Tensor = field(repr=False)
+    _k: torch.Tensor = field(repr=False)
+    _v: torch.Tensor = field(repr=False)
+    _g: torch.Tensor = field(repr=False)
+    _beta: torch.Tensor = field(repr=False)
+    _A_log: torch.Tensor = field(repr=False)
+    _dt_bias: torch.Tensor = field(repr=False)
+    _initial_state: torch.Tensor = field(repr=False)
+    _cu_seqlens: torch.Tensor = field(repr=False)
+    _route_tensors: dict[str, torch.Tensor] = field(repr=False)
+    _metadata: dict[str, object] = field(repr=False)
+    _final_output_scratch: torch.Tensor = field(repr=False)
+    _final_descriptor_storage: torch.Tensor = field(repr=False)
+    _final_tensormap_workspace: torch.Tensor = field(repr=False)
+    _dummy_f32: torch.Tensor = field(repr=False)
+    _dummy_i32: torch.Tensor = field(repr=False)
+    _final_grid_ctas: int = field(repr=False)
+    _stream_ptr: int = field(repr=False)
+    _input_tensors: tuple[torch.Tensor, ...] = field(default=(), repr=False)
+    _input_signatures: tuple[tuple, ...] = field(default=(), repr=False)
+    _saved_context_signatures: tuple[tuple, ...] = field(default=(), repr=False)
+    _final_descriptor_signature: Optional[tuple] = field(default=None, repr=False)
+    _route_descriptor_signature: Optional[tuple] = field(default=None, repr=False)
+    _backward_buffers: dict[str, torch.Tensor] = field(default_factory=dict, repr=False)
+    _lock: threading.Lock = field(default_factory=threading.Lock, repr=False)
+
+
+def _saved_context_tensors(
+    context: RecurrentKDATrainingContext,
+) -> tuple[torch.Tensor, ...]:
+    metadata_tensors = tuple(
+        value for value in context._metadata.values() if isinstance(value, torch.Tensor)
+    )
+    return (
+        context.state_checkpoints,
+        context.beta_active,
+        context._cu_seqlens,
+        *context._route_tensors.values(),
+        *metadata_tensors,
+    )
+
+
+def _new_context(
+    shape: _TrainingShape,
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor,
+    beta: torch.Tensor,
+    A_log: torch.Tensor,
+    dt_bias: torch.Tensor,
+    initial_state: torch.Tensor,
+    cu_seqlens: Optional[torch.Tensor],
+    stream_ptr: int,
+) -> RecurrentKDATrainingContext:
+    device = q.device
+    qf, kf, vf, _gf, betaf = _canonical_views(shape, q, k, v, g, beta)
+    canonical_cu = (
+        torch.tensor(shape.offsets, dtype=torch.int64, device=device)
+        if cu_seqlens is None
+        else cu_seqlens
+    )
+    route_tensors: dict[str, torch.Tensor] = {}
+    if shape.route.family == "c16":
+        metadata = _build_c16_metadata(shape, device)
+        total_chunks = cast(int, metadata["total_chunks"])
+        state_checkpoints = torch.empty(
+            (total_chunks, shape.num_v_heads, _HEAD_DIM, _HEAD_DIM),
+            dtype=torch.bfloat16,
+            device=device,
+        )
+        beta_active = torch.empty(
+            (shape.total_tokens, max(shape.num_v_heads, 8)),
+            dtype=torch.bfloat16,
+            device=device,
+        )
+        route_tensors["counters"] = torch.empty(
+            shape.num_v_heads + 2, dtype=torch.uint32, device=device
+        )
+    elif shape.route.family == "row_split":
+        metadata = {"total_chunks": shape.total_tokens}
+        state_checkpoints = torch.empty(
+            (shape.total_tokens, shape.num_v_heads, _HEAD_DIM, _HEAD_DIM),
+            dtype=torch.float32,
+            device=device,
+        )
+        beta_active = torch.empty(
+            (shape.total_tokens, shape.num_v_heads), dtype=torch.float32, device=device
+        )
+        vector_shape = (shape.total_tokens, shape.num_v_heads, _HEAD_DIM)
+        route_tensors.update(
+            q_norm=torch.empty(vector_shape, dtype=torch.float32, device=device),
+            k_norm=torch.empty(vector_shape, dtype=torch.float32, device=device),
+            decay=torch.empty(vector_shape, dtype=torch.float32, device=device),
+        )
+    else:
+        metadata = _build_c32_metadata(shape, device)
+        total_chunks = cast(int, metadata["total_chunks"])
+        token_vector = (shape.total_tokens, shape.num_v_heads, _HEAD_DIM)
+        tape_vector = (total_chunks, shape.num_v_heads, _C32_CHUNK, _HEAD_DIM)
+        tape_value = (total_chunks, shape.num_v_heads, _HEAD_DIM, _C32_CHUNK)
+        grouped = shape.route.grouped
+        route_tensors["q_value_heads"] = (
+            torch.empty(
+                (1, shape.total_tokens, shape.num_v_heads, _HEAD_DIM),
+                dtype=torch.bfloat16,
+                device=device,
+            )
+            if grouped
+            else qf
+        )
+        route_tensors["k_value_heads"] = (
+            torch.empty_like(route_tensors["q_value_heads"]) if grouped else kf
+        )
+        padded_beta_heads = ((shape.num_v_heads + 7) // 8) * 8
+        route_tensors["beta_tma"] = (
+            betaf.view(shape.total_tokens, shape.num_v_heads)
+            if shape.total_tokens >= _C32_CHUNK
+            and padded_beta_heads == shape.num_v_heads
+            else torch.empty(
+                (max(shape.total_tokens, _C32_CHUNK), padded_beta_heads),
+                dtype=torch.bfloat16,
+                device=device,
+            )
+        )
+        state_checkpoints = torch.empty(
+            (total_chunks, shape.num_v_heads, _HEAD_DIM, _HEAD_DIM),
+            dtype=torch.bfloat16,
+            device=device,
+        )
+        beta_active = torch.empty(
+            (shape.total_tokens, shape.num_v_heads), dtype=torch.float32, device=device
+        )
+        state_votes = total_chunks * shape.num_v_heads + max(
+            shape.num_sequences * shape.num_v_heads,
+            cast(int, metadata["num_work_items"]),
+        )
+        route_tensors.update(
+            state_checkpoint_needed=torch.empty(
+                state_votes, dtype=torch.uint32, device=device
+            ),
+            tape_qd=torch.empty(tape_vector, dtype=torch.bfloat16, device=device),
+            tape_kd=torch.empty(tape_vector, dtype=torch.bfloat16, device=device),
+            tape_kr=torch.empty(tape_vector, dtype=torch.bfloat16, device=device),
+            tape_j=torch.empty(
+                (total_chunks, shape.num_v_heads, _C32_CHUNK, _C32_CHUNK),
+                dtype=torch.bfloat16,
+                device=device,
+            ),
+            tape_restore_factor=torch.empty(
+                (total_chunks, shape.num_v_heads, _HEAD_DIM),
+                dtype=torch.float32,
+                device=device,
+            ),
+            tape_x=torch.empty(tape_value, dtype=torch.bfloat16, device=device),
+            tape_r=torch.empty(tape_value, dtype=torch.bfloat16, device=device),
+            norm_inv=torch.empty(
+                (shape.total_tokens, shape.num_v_heads, 2),
+                dtype=torch.float32,
+                device=device,
+            ),
+            decay=torch.empty(token_vector, dtype=torch.bfloat16, device=device),
+            zero_workspace=torch.empty(
+                total_chunks * shape.num_v_heads, dtype=torch.uint32, device=device
+            ),
+            descriptor_storage=_aligned_u8(device, 7 * 128),
+        )
+        route_tensors["tape_e"] = route_tensors["tape_x"]
+    final_grid = _final_grid_ctas(shape)
+    return RecurrentKDATrainingContext(
+        state_checkpoints=state_checkpoints,
+        beta_active=beta_active,
+        _route=shape.route,
+        _shape=shape,
+        _q=q,
+        _k=k,
+        _v=v,
+        _g=g,
+        _beta=beta,
+        _A_log=A_log,
+        _dt_bias=dt_bias,
+        _initial_state=initial_state,
+        _cu_seqlens=canonical_cu,
+        _route_tensors=route_tensors,
+        _metadata=metadata,
+        _final_output_scratch=torch.empty_like(vf),
+        _final_descriptor_storage=_aligned_u8(device, 5 * 128),
+        _final_tensormap_workspace=torch.empty(
+            final_grid * _FINAL_TMAP_SLOTS_PER_CTA * _FINAL_TMAP_BYTES_PER_SLOT,
+            dtype=torch.uint8,
+            device=device,
+        ),
+        _dummy_f32=torch.empty(1, dtype=torch.float32, device=device),
+        _dummy_i32=torch.empty(1, dtype=torch.int32, device=device),
+        _final_grid_ctas=final_grid,
+        _stream_ptr=stream_ptr,
+    )
+
+
+def _validate_context_storage(
+    context: RecurrentKDATrainingContext, device: torch.device
+) -> None:
+    if context._shape.route != context._route:
+        raise ValueError("context route tag does not match its normalized shape")
+    named = [
+        ("state_checkpoints", context.state_checkpoints),
+        ("beta_active", context.beta_active),
+        *context._route_tensors.items(),
+        *(
+            (name, value)
+            for name, value in context._metadata.items()
+            if isinstance(value, torch.Tensor)
+        ),
+    ]
+    for name, tensor in named:
+        if not tensor.is_cuda or tensor.device != device or not tensor.is_contiguous():
+            raise ValueError(f"context tensor {name} must be contiguous on {device}")
+    if context._route.family == "c32":
+        if (
+            context._route_tensors["tape_e"].data_ptr()
+            != context._route_tensors["tape_x"].data_ptr()
+        ):
+            raise ValueError("C32 tape_e must exactly alias tape_x")
+        if context._route_tensors["descriptor_storage"].data_ptr() % 64:
+            raise ValueError("C32 descriptor storage must be 64-byte aligned")
+    if context._final_descriptor_storage.data_ptr() % 64:
+        raise ValueError("final descriptor storage must be 64-byte aligned")
+
+
+def _descriptor_signature(*tensors: torch.Tensor) -> tuple:
+    return tuple(_tensor_signature(tensor) for tensor in tensors)
+
+
+def _run_forward_route(
+    context: RecurrentKDATrainingContext,
+    output_flat: torch.Tensor,
+    final_state: torch.Tensor,
+    scale: float,
+    lower_bound: float,
+) -> None:
+    shape = context._shape
+    qf, kf, vf, gf, betaf = _canonical_views(
+        shape, context._q, context._k, context._v, context._g, context._beta
+    )
+    module = _get_training_module(context._q.device)
+    route = context._route.family
+    final_target = context._final_output_scratch if route == "c16" else output_flat
+    final_signature = _descriptor_signature(
+        qf, kf, vf, gf, final_target, context._final_descriptor_storage
+    )
+    prepare_final = int(final_signature != context._final_descriptor_signature)
+    if route == "c16":
+        m = context._metadata
+        t = context._route_tensors
+        module.run_training_forward(
+            qf,
+            kf,
+            vf,
+            gf,
+            betaf,
+            context._A_log,
+            context._dt_bias,
+            context._initial_state,
+            context._cu_seqlens,
+            m["checkpoint_cu_starts"],
+            m["base_work_items"],
+            m["work_items"],
+            m["boundaries"],
+            t["counters"],
+            output_flat,
+            final_state,
+            context.state_checkpoints,
+            context.beta_active,
+            context._final_output_scratch,
+            context._final_descriptor_storage,
+            context._final_tensormap_workspace,
+            context._dummy_f32,
+            context._dummy_i32,
+            m["boundary_count"],
+            m["total_work_items"],
+            shape.total_tokens,
+            shape.num_sequences,
+            shape.num_qk_heads,
+            shape.num_v_heads,
+            m["total_chunks"],
+            max(shape.num_v_heads, 8),
+            m["uniform_work_items"],
+            context._final_grid_ctas,
+            prepare_final,
+            scale,
+            lower_bound,
+            context._stream_ptr,
+        )
+    elif route == "row_split":
+        t = context._route_tensors
+        module.run_training_row_forward(
+            qf,
+            kf,
+            vf,
+            gf,
+            betaf,
+            context._A_log,
+            context._dt_bias,
+            context._initial_state,
+            context._cu_seqlens,
+            output_flat,
+            final_state,
+            t["q_norm"],
+            t["k_norm"],
+            t["decay"],
+            context.beta_active,
+            context.state_checkpoints,
+            context._final_descriptor_storage,
+            context._final_tensormap_workspace,
+            context._dummy_f32,
+            context._dummy_i32,
+            shape.total_tokens,
+            shape.num_sequences,
+            shape.num_v_heads,
+            context._final_grid_ctas,
+            prepare_final,
+            scale,
+            lower_bound,
+            context._stream_ptr,
+        )
+    else:
+        t = context._route_tensors
+        m = context._metadata
+        route_signature = _descriptor_signature(
+            t["q_value_heads"],
+            t["k_value_heads"],
+            vf,
+            gf,
+            t["beta_tma"],
+            output_flat,
+            context.state_checkpoints,
+            t["descriptor_storage"],
+        )
+        prepare_route = int(route_signature != context._route_descriptor_signature)
+        module.run_training_c32_forward(
+            qf,
+            kf,
+            t["q_value_heads"],
+            t["k_value_heads"],
+            vf,
+            gf,
+            betaf,
+            t["beta_tma"],
+            context._A_log,
+            context._dt_bias,
+            context._initial_state,
+            context._cu_seqlens,
+            m["work_items"],
+            m["seq_order"],
+            m["cu_chunk_offsets"],
+            t["descriptor_storage"],
+            output_flat,
+            final_state,
+            context.state_checkpoints,
+            t["state_checkpoint_needed"],
+            t["tape_qd"],
+            t["tape_kd"],
+            t["tape_kr"],
+            t["tape_j"],
+            t["tape_restore_factor"],
+            t["tape_e"],
+            t["tape_x"],
+            t["tape_r"],
+            t["norm_inv"],
+            t["decay"],
+            context.beta_active,
+            t["zero_workspace"],
+            final_target,
+            context._final_descriptor_storage,
+            context._final_tensormap_workspace,
+            context._dummy_f32,
+            context._dummy_i32,
+            shape.total_tokens,
+            shape.num_sequences,
+            shape.num_qk_heads,
+            shape.num_v_heads,
+            m["total_chunks"],
+            m["num_work_items"],
+            int(cast(bool, m["use_split_work_items"])),
+            int(context._route.grouped),
+            prepare_route,
+            prepare_final,
+            context._final_grid_ctas,
+            scale,
+            lower_bound,
+            context._stream_ptr,
+        )
+        context._route_descriptor_signature = route_signature
+    context._final_descriptor_signature = final_signature
+
+
+def _recurrent_kda_training_forward_impl(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor,
+    beta: torch.Tensor,
+    A_log: torch.Tensor,
+    dt_bias: torch.Tensor,
+    initial_state: torch.Tensor,
+    cu_seqlens: Optional[torch.Tensor] = None,
+    scale: Optional[float] = None,
+    lower_bound: float = _LOWER_BOUND,
+    out: Optional[torch.Tensor] = None,
+    final_state_out: Optional[torch.Tensor] = None,
+    context_out: Optional[RecurrentKDATrainingContext] = None,
+) -> tuple[torch.Tensor, torch.Tensor, RecurrentKDATrainingContext]:
+    shape = _validate_forward_inputs(
+        q, k, v, g, beta, A_log, dt_bias, initial_state, cu_seqlens
+    )
+    scale_value, lower_bound_value = _validate_scale_and_bound(scale, lower_bound)
+    device = q.device
+    with torch.cuda.device(device):
+        if torch.cuda.is_current_stream_capturing():
+            raise RuntimeError(
+                "recurrent KDA training does not support CUDA graph capture"
+            )
+    stream_ptr = int(torch.cuda.current_stream(device).cuda_stream)
+    output = torch.empty_like(v) if out is None else out
+    final_state = (
+        torch.empty_like(initial_state) if final_state_out is None else final_state_out
+    )
+    _validate_tensor(
+        output, "out", shape=tuple(v.shape), dtype=torch.bfloat16, device=device
+    )
+    _validate_tensor(
+        final_state,
+        "final_state_out",
+        shape=tuple(initial_state.shape),
+        dtype=torch.float32,
+        device=device,
+    )
+    public_inputs: tuple[torch.Tensor, ...] = (
+        q,
+        k,
+        v,
+        g,
+        beta,
+        A_log,
+        dt_bias,
+        initial_state,
+    )
+    input_names: tuple[str, ...] = (
+        "q",
+        "k",
+        "v",
+        "g",
+        "beta",
+        "A_log",
+        "dt_bias",
+        "initial_state",
+    )
+    if cu_seqlens is not None:
+        public_inputs += (cu_seqlens,)
+        input_names += ("cu_seqlens",)
+    _check_writes_do_not_overlap(
+        (("out", output), ("final_state_out", final_state)),
+        tuple(zip(input_names, public_inputs, strict=True)),
+    )
+    if context_out is None:
+        context = _new_context(
+            shape,
+            q,
+            k,
+            v,
+            g,
+            beta,
+            A_log,
+            dt_bias,
+            initial_state,
+            cu_seqlens,
+            stream_ptr,
+        )
+    else:
+        context = context_out
+        if context._stream_ptr != stream_ptr:
+            raise RuntimeError(
+                "a recurrent KDA training context must be reused on its forward stream"
+            )
+        if context._shape != shape or context._route != shape.route:
+            raise ValueError(
+                "context_out layout, shape, or route does not match the new inputs"
+            )
+        _validate_context_storage(context, device)
+        if (
+            context._saved_context_signatures
+            and tuple(
+                _tensor_signature(tensor) for tensor in _saved_context_tensors(context)
+            )
+            != context._saved_context_signatures
+        ):
+            raise RuntimeError(
+                "the recurrent KDA training context was modified after forward"
+            )
+        if cu_seqlens is not None:
+            context._cu_seqlens = cu_seqlens
+    _qf, _kf, vf, _gf, _betaf = _canonical_views(shape, q, k, v, g, beta)
+    context._q, context._k, context._v, context._g = q, k, v, g
+    context._beta, context._A_log, context._dt_bias = beta, A_log, dt_bias
+    context._initial_state = initial_state
+    internal_writes: list[tuple[str, torch.Tensor]] = [
+        ("context.state_checkpoints", context.state_checkpoints),
+        ("context.beta_active", context.beta_active),
+        ("context._final_output_scratch", context._final_output_scratch),
+        ("context._final_descriptor_storage", context._final_descriptor_storage),
+        ("context._final_tensormap_workspace", context._final_tensormap_workspace),
+    ]
+    if context._route.family == "c16":
+        internal_writes.extend(
+            (
+                ("context._work_items", context._metadata["work_items"]),
+                ("context._counters", context._route_tensors["counters"]),
+            )
+        )
+    elif context._route.family == "row_split":
+        internal_writes.extend(
+            (f"context.{name}", context._route_tensors[name])
+            for name in ("q_norm", "k_norm", "decay")
+        )
+    else:
+        c32_write_names = [
+            "state_checkpoint_needed",
+            "tape_qd",
+            "tape_kd",
+            "tape_kr",
+            "tape_j",
+            "tape_restore_factor",
+            "tape_x",
+            "tape_r",
+            "norm_inv",
+            "decay",
+            "zero_workspace",
+            "descriptor_storage",
+        ]
+        if context._route.grouped:
+            c32_write_names.extend(("q_value_heads", "k_value_heads"))
+        beta_tma = context._route_tensors["beta_tma"]
+        if not _storage_ranges_overlap(beta_tma, beta):
+            c32_write_names.append("beta_tma")
+        internal_writes.extend(
+            (f"context.{name}", context._route_tensors[name])
+            for name in c32_write_names
+        )
+    _check_writes_do_not_overlap(
+        (("out", output), ("final_state_out", final_state), *internal_writes),
+        tuple(zip(input_names, public_inputs, strict=True)),
+    )
+    _run_forward_route(
+        context, output.view_as(vf), final_state, scale_value, lower_bound_value
+    )
+    context._input_tensors = public_inputs
+    context._input_signatures = tuple(
+        _tensor_signature(tensor) for tensor in public_inputs
+    )
+    context._saved_context_signatures = tuple(
+        _tensor_signature(tensor) for tensor in _saved_context_tensors(context)
+    )
+    return output, final_state, context
+
+
+@flashinfer_api
+def recurrent_kda_training_forward(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor,
+    beta: torch.Tensor,
+    A_log: torch.Tensor,
+    dt_bias: torch.Tensor,
+    initial_state: torch.Tensor,
+    cu_seqlens: Optional[torch.Tensor] = None,
+    scale: Optional[float] = None,
+    lower_bound: float = _LOWER_BOUND,
+    out: Optional[torch.Tensor] = None,
+    final_state_out: Optional[torch.Tensor] = None,
+    context_out: Optional[RecurrentKDATrainingContext] = None,
+) -> tuple[torch.Tensor, torch.Tensor, RecurrentKDATrainingContext]:
+    r"""Run fixed or packed KDA forward and save the selected route's tapes."""
+
+    args = (
+        q,
+        k,
+        v,
+        g,
+        beta,
+        A_log,
+        dt_bias,
+        initial_state,
+        cu_seqlens,
+        scale,
+        lower_bound,
+        out,
+        final_state_out,
+    )
+    if context_out is None:
+        return _recurrent_kda_training_forward_impl(*args, None)
+    if not isinstance(context_out, RecurrentKDATrainingContext):
+        raise TypeError("context_out must be a RecurrentKDATrainingContext")
+    with context_out._lock:
+        return _recurrent_kda_training_forward_impl(*args, context_out)
+
+
+def _gradient_outputs(
+    out: Optional[Sequence[torch.Tensor]], context: RecurrentKDATrainingContext
+) -> tuple[torch.Tensor, ...]:
+    expected = (
+        (context._q.shape, torch.bfloat16),
+        (context._k.shape, torch.bfloat16),
+        (context._v.shape, torch.bfloat16),
+        (context._g.shape, torch.bfloat16),
+        (context._beta.shape, torch.bfloat16),
+        (context._A_log.shape, torch.float32),
+        (context._dt_bias.shape, torch.float32),
+        (context._initial_state.shape, torch.float32),
+    )
+    if out is None:
+        return tuple(
+            torch.empty(shape, dtype=dtype, device=context._q.device)
+            for shape, dtype in expected
+        )
+    if len(out) != len(expected):
+        raise ValueError("out must contain eight gradient tensors")
+    for name, tensor, (shape, dtype) in zip(
+        KDA_BACKWARD_GRADIENT_NAMES, out, expected, strict=True
+    ):
+        _validate_tensor(
+            tensor,
+            name,
+            shape=tuple(shape),
+            dtype=dtype,
+            device=context._q.device,
+        )
+    return tuple(out)
+
+
+def _backward_buffer(
+    context: RecurrentKDATrainingContext,
+    name: str,
+    shape: tuple[int, ...],
+    dtype: torch.dtype,
+) -> torch.Tensor:
+    tensor = context._backward_buffers.get(name)
+    if tensor is None:
+        tensor = torch.empty(shape, dtype=dtype, device=context._q.device)
+        context._backward_buffers[name] = tensor
+    else:
+        _validate_tensor(
+            tensor,
+            f"context._backward_buffers[{name!r}]",
+            shape=shape,
+            dtype=dtype,
+            device=context._q.device,
+        )
+    return tensor
+
+
+def _run_c16_backward(
+    context: RecurrentKDATrainingContext,
+    do_flat: torch.Tensor,
+    dfinal_state: torch.Tensor,
+    outputs: tuple[torch.Tensor, ...],
+) -> None:
+    shape, m, t = context._shape, context._metadata, context._route_tensors
+    qf, kf, vf, gf, _ = _canonical_views(
+        shape, context._q, context._k, context._v, context._g, context._beta
+    )
+    dq, dk, dv, dg, dbeta, dA, ddt, dinit = outputs
+    dqf, dkf = dq.view_as(qf), dk.view_as(kf)
+    dvf, dgf = dv.view_as(vf), dg.view_as(gf)
+    dbetaf = dbeta.view(1, shape.total_tokens, shape.num_v_heads)
+    vector = (shape.total_tokens, shape.num_v_heads, _HEAD_DIM)
+    dlog = _backward_buffer(context, "c16_dlog_decay", vector, torch.float32)
+    dboundary = _backward_buffer(
+        context,
+        "c16_dlog_boundary",
+        (cast(int, m["total_chunks"]), shape.num_v_heads, _HEAD_DIM),
+        torch.float32,
+    )
+    dbeta_active = _backward_buffer(
+        context,
+        "c16_dbeta_active",
+        (shape.total_tokens, shape.num_v_heads),
+        torch.float32,
+    )
+    gate_a = _backward_buffer(
+        context, "c16_gate_a", (128, shape.num_v_heads, _HEAD_DIM), torch.float32
+    )
+    gate_dt = _backward_buffer(
+        context, "c16_gate_dt", (128, shape.num_v_heads, _HEAD_DIM), torch.float32
+    )
+    dummy_u32 = _backward_buffer(context, "c16_dummy_u32", (1,), torch.uint32)
+    dummy_f32 = _backward_buffer(context, "c16_dummy_f32", (1,), torch.float32)
+    grouped = context._route.grouped
+    dq_value = (
+        _backward_buffer(context, "c16_dq_value", tuple(vf.shape), torch.bfloat16)
+        if grouped
+        else dqf
+    )
+    dk_value = (
+        _backward_buffer(context, "c16_dk_value", tuple(vf.shape), torch.bfloat16)
+        if grouped
+        else dkf
+    )
+    _get_training_module(context._q.device).run_training_backward(
+        qf,
+        kf,
+        vf,
+        gf,
+        context._A_log,
+        context._dt_bias,
+        do_flat,
+        dfinal_state,
+        context._cu_seqlens,
+        m["checkpoint_cu_starts"],
+        m["work_items"],
+        t["counters"],
+        context.state_checkpoints,
+        context.beta_active,
+        dlog,
+        dboundary,
+        dbeta_active,
+        gate_a,
+        gate_dt,
+        dummy_u32,
+        dummy_f32,
+        dq_value,
+        dk_value,
+        dvf,
+        dgf,
+        dbetaf,
+        dA,
+        ddt,
+        dinit,
+        dqf,
+        dkf,
+        m["total_work_items"],
+        shape.total_tokens,
+        shape.num_sequences,
+        shape.num_qk_heads,
+        shape.num_v_heads,
+        m["total_chunks"],
+        max(shape.num_v_heads, 8),
+        m["uniform_work_items"],
+        int(grouped),
+        _SCALE,
+        _LOWER_BOUND,
+        context._stream_ptr,
+    )
+
+
+def _run_row_backward(
+    context: RecurrentKDATrainingContext,
+    do_flat: torch.Tensor,
+    dfinal_state: torch.Tensor,
+    outputs: tuple[torch.Tensor, ...],
+) -> None:
+    shape, t = context._shape, context._route_tensors
+    qf, kf, vf, gf, _ = _canonical_views(
+        shape, context._q, context._k, context._v, context._g, context._beta
+    )
+    dq, dk, dv, dg, dbeta, dA, ddt, dinit = outputs
+    vector = (shape.total_tokens, shape.num_v_heads, _HEAD_DIM)
+    dq_norm = _backward_buffer(context, "row_dq_norm", vector, torch.float32)
+    dk_norm = _backward_buffer(context, "row_dk_norm", vector, torch.float32)
+    dlog = _backward_buffer(context, "row_dlog", vector, torch.float32)
+    dbeta_active = _backward_buffer(
+        context,
+        "row_dbeta_active",
+        (shape.total_tokens, shape.num_v_heads),
+        torch.float32,
+    )
+    _get_training_module(context._q.device).run_training_row_backward(
+        qf,
+        kf,
+        vf,
+        gf,
+        context._A_log,
+        context._dt_bias,
+        context._initial_state,
+        do_flat,
+        dfinal_state,
+        context._cu_seqlens,
+        t["q_norm"],
+        t["k_norm"],
+        t["decay"],
+        context.beta_active,
+        context.state_checkpoints,
+        dq_norm,
+        dk_norm,
+        dlog,
+        dbeta_active,
+        dq.view_as(qf),
+        dk.view_as(kf),
+        dv.view_as(vf),
+        dg.view_as(gf),
+        dbeta.view(1, shape.total_tokens, shape.num_v_heads),
+        dA,
+        ddt,
+        dinit,
+        shape.total_tokens,
+        shape.num_sequences,
+        shape.num_v_heads,
+        _SCALE,
+        _LOWER_BOUND,
+        context._stream_ptr,
+    )
+
+
+def _run_c32_backward(
+    context: RecurrentKDATrainingContext,
+    do_flat: torch.Tensor,
+    dfinal_state: torch.Tensor,
+    outputs: tuple[torch.Tensor, ...],
+) -> None:
+    shape, t, m = context._shape, context._route_tensors, context._metadata
+    qf, kf, vf, gf, _ = _canonical_views(
+        shape, context._q, context._k, context._v, context._g, context._beta
+    )
+    dq, dk, dv, dg, dbeta, dA, ddt, dinit = outputs
+    total_chunks = cast(int, m["total_chunks"])
+    tape_value = (total_chunks, shape.num_v_heads, _HEAD_DIM, _C32_CHUNK)
+    tape_vector = (total_chunks, shape.num_v_heads, _C32_CHUNK, _HEAD_DIM)
+    chunk_state_shape = (total_chunks, shape.num_v_heads, _HEAD_DIM, _HEAD_DIM)
+    chunk_dh = _backward_buffer(
+        context, "c32_chunk_dh", chunk_state_shape, torch.bfloat16
+    )
+    chunk_dr = _backward_buffer(context, "c32_chunk_dr", tape_value, torch.bfloat16)
+    chunk_dx = _backward_buffer(context, "c32_chunk_dx", tape_value, torch.bfloat16)
+    boundary_ready = _backward_buffer(
+        context, "c32_boundary_ready", (total_chunks * shape.num_v_heads,), torch.uint32
+    )
+    grad_qd = _backward_buffer(context, "c32_grad_qd", tape_vector, torch.bfloat16)
+    grad_kd = _backward_buffer(context, "c32_grad_kd", tape_vector, torch.bfloat16)
+    grad_ki = _backward_buffer(context, "c32_grad_ki", tape_vector, torch.bfloat16)
+    dlog = _backward_buffer(
+        context,
+        "c32_dlog",
+        (shape.total_tokens, shape.num_v_heads, _HEAD_DIM),
+        torch.float32,
+    )
+    dbeta_active = _backward_buffer(
+        context,
+        "c32_dbeta_active",
+        (shape.total_tokens, shape.num_v_heads),
+        torch.float32,
+    )
+    grouped = context._route.grouped
+    dq_value = (
+        _backward_buffer(context, "c32_dq_value", tuple(vf.shape), torch.bfloat16)
+        if grouped
+        else dq.view_as(qf)
+    )
+    dk_value = (
+        _backward_buffer(context, "c32_dk_value", tuple(vf.shape), torch.bfloat16)
+        if grouped
+        else dk.view_as(kf)
+    )
+    _get_training_module(context._q.device).run_training_c32_backward(
+        t["q_value_heads"],
+        t["k_value_heads"],
+        vf,
+        gf,
+        context._A_log,
+        context._dt_bias,
+        context._initial_state,
+        do_flat,
+        dfinal_state,
+        context._cu_seqlens,
+        m["cu_chunk_offsets"],
+        m["boundary_work_items"],
+        m["consumer_chunk_order"],
+        m["chunk_sequence"],
+        m["chunk_index"],
+        m["chunk_pair_start"],
+        context.state_checkpoints,
+        t["state_checkpoint_needed"],
+        t["tape_qd"],
+        t["tape_kd"],
+        t["tape_kr"],
+        t["tape_j"],
+        t["tape_restore_factor"],
+        t["tape_e"],
+        t["tape_x"],
+        t["tape_r"],
+        t["norm_inv"],
+        t["decay"],
+        context.beta_active,
+        chunk_dh,
+        chunk_dr,
+        chunk_dx,
+        boundary_ready,
+        grad_qd,
+        grad_kd,
+        grad_ki,
+        dlog,
+        dbeta_active,
+        dq_value,
+        dk_value,
+        dv.view_as(vf),
+        dg.view_as(gf),
+        dbeta.view(1, shape.total_tokens, shape.num_v_heads),
+        dA,
+        ddt,
+        dinit,
+        dq.view_as(qf),
+        dk.view_as(kf),
+        shape.total_tokens,
+        shape.num_sequences,
+        shape.num_qk_heads,
+        shape.num_v_heads,
+        total_chunks,
+        m["total_pairs"],
+        m["boundary_count"],
+        int(cast(bool, m["split_boundary"])),
+        int(grouped),
+        _SCALE,
+        _LOWER_BOUND,
+        context._stream_ptr,
+    )
+
+
+@flashinfer_api
+def recurrent_kda_training_backward(
+    context: RecurrentKDATrainingContext,
+    do: torch.Tensor,
+    dfinal_state: torch.Tensor,
+    out: Optional[Sequence[torch.Tensor]] = None,
+) -> tuple[torch.Tensor, ...]:
+    r"""Differentiate a saved route context without rerunning forward recurrence."""
+
+    # Route helpers invoke run_training_backward or the route-specific FFI symbol.
+
+    if not isinstance(context, RecurrentKDATrainingContext):
+        raise TypeError("context must be a RecurrentKDATrainingContext")
+    with context._lock:
+        device = context._q.device
+        with torch.cuda.device(device):
+            if torch.cuda.is_current_stream_capturing():
+                raise RuntimeError(
+                    "recurrent KDA training does not support CUDA graph capture"
+                )
+        if int(torch.cuda.current_stream(device).cuda_stream) != context._stream_ptr:
+            raise RuntimeError(
+                "recurrent KDA training backward must run on the forward stream"
+            )
+        _validate_context_storage(context, device)
+        if (
+            tuple(_tensor_signature(tensor) for tensor in context._input_tensors)
+            != context._input_signatures
+        ):
+            raise RuntimeError(
+                "a recurrent KDA training input was modified after forward"
+            )
+        if (
+            tuple(
+                _tensor_signature(tensor) for tensor in _saved_context_tensors(context)
+            )
+            != context._saved_context_signatures
+        ):
+            raise RuntimeError(
+                "the recurrent KDA training context was modified after forward"
+            )
+        _validate_tensor(
+            do, "do", shape=tuple(context._v.shape), dtype=torch.bfloat16, device=device
+        )
+        _validate_tensor(
+            dfinal_state,
+            "dfinal_state",
+            shape=tuple(context._initial_state.shape),
+            dtype=torch.float32,
+            device=device,
+        )
+        outputs = _gradient_outputs(out, context)
+        _check_writes_do_not_overlap(
+            tuple(
+                (name, tensor)
+                for name, tensor in zip(
+                    KDA_BACKWARD_GRADIENT_NAMES, outputs, strict=True
+                )
+            ),
+            (
+                *(
+                    (f"input[{index}]", tensor)
+                    for index, tensor in enumerate(context._input_tensors)
+                ),
+                ("do", do),
+                ("dfinal_state", dfinal_state),
+                *(
+                    (f"saved[{index}]", tensor)
+                    for index, tensor in enumerate(_saved_context_tensors(context))
+                ),
+            ),
+        )
+        do_flat = do.view(
+            1, context._shape.total_tokens, context._shape.num_v_heads, _HEAD_DIM
+        )
+        if context._route.family == "c16":
+            _run_c16_backward(context, do_flat, dfinal_state, outputs)
+        elif context._route.family == "row_split":
+            _run_row_backward(context, do_flat, dfinal_state, outputs)
+        else:
+            _run_c32_backward(context, do_flat, dfinal_state, outputs)
+        return outputs
+
+
+__all__ = [
+    "RecurrentKDATrainingContext",
+    "recurrent_kda_training_backward",
+    "recurrent_kda_training_forward",
+]

--- a/flashinfer/aot.py
+++ b/flashinfer/aot.py
@@ -65,10 +65,13 @@ from .jit.flash_kda import (
     FlashKDATarget,
     gen_flash_kda_m64_module,
     gen_flash_kda_m128_module,
+    gen_flash_kda_m128_n16_checkpoint_module,
     gen_flash_kda_m128_n16_module,
     gen_flash_kda_persistent_m128_module,
     gen_flash_kda_small_bh_m128_module,
 )
+from .jit.flash_kda_backward import gen_flash_kda_backward_module
+from .jit.flash_kda_training import gen_flash_kda_training_module
 from .jit.flash_kda_decode import (
     FLASH_KDA_DECODE_DIRECT_VARIANTS,
     FLASH_KDA_DECODE_VARIANTS,
@@ -534,6 +537,12 @@ def gen_all_modules(
     has_flash_kda_decode_sm103a_direct = sm_capabilities.get(
         "flash_kda_decode_sm103a_direct", False
     )
+    has_flash_kda_backward_sm100a = sm_capabilities.get(
+        "flash_kda_backward_sm100a", False
+    )
+    has_flash_kda_backward_sm103a = sm_capabilities.get(
+        "flash_kda_backward_sm103a", False
+    )
     has_flash_kda_packed_t1_sm100a = sm_capabilities.get(
         "flash_kda_packed_t1_sm100a", False
     )
@@ -577,6 +586,7 @@ def gen_all_modules(
                     gen_flash_kda_m64_module(flash_kda_target),
                     gen_flash_kda_m128_module(flash_kda_target),
                     gen_flash_kda_m128_n16_module(flash_kda_target),
+                    gen_flash_kda_m128_n16_checkpoint_module(flash_kda_target),
                     gen_flash_kda_small_bh_m128_module(flash_kda_target),
                 ]
             )
@@ -602,6 +612,12 @@ def gen_all_modules(
             gen_flash_kda_decode_module(variant, "sm103a")
             for variant in FLASH_KDA_DECODE_DIRECT_VARIANTS
         )
+    if has_flash_kda_backward_sm100a:
+        jit_specs.append(gen_flash_kda_backward_module("sm100a"))
+        jit_specs.append(gen_flash_kda_training_module("sm100a"))
+    if has_flash_kda_backward_sm103a:
+        jit_specs.append(gen_flash_kda_backward_module("sm103a"))
+        jit_specs.append(gen_flash_kda_training_module("sm103a"))
 
     # Packed Kimi K3 decode follows the same legacy-exact/family split.
     if has_flash_kda_packed_t1_sm100a:
@@ -1116,6 +1132,14 @@ def detect_sm_capabilities():
             flash_kda_decode_sm103_arches & compilation_context.TARGET_CUDA_ARCHS
         )
         and cuda_version >= Version("12.9"),
+        "flash_kda_backward_sm103a": bool(
+            flash_kda_decode_sm103_arches & compilation_context.TARGET_CUDA_ARCHS
+        )
+        and cuda_version >= Version("12.9"),
+        "flash_kda_backward_sm100a": (
+            (10, "0a") in compilation_context.TARGET_CUDA_ARCHS
+            and cuda_version >= Version("12.8")
+        ),
         "flash_kda_packed_t1_sm100a": (
             (10, "0a") in compilation_context.TARGET_CUDA_ARCHS
             and Version("12.8") <= cuda_version < Version("12.9")

--- a/flashinfer/jit/flash_kda.py
+++ b/flashinfer/jit/flash_kda.py
@@ -31,6 +31,7 @@ FlashKDAVariant = Literal[
     "m64",
     "m128",
     "m128_n16",
+    "m128_n16_checkpoint",
     "persistent_m128",
     "small_bh_m128",
 ]
@@ -40,6 +41,7 @@ FLASH_KDA_VARIANTS: tuple[FlashKDAVariant, ...] = (
     "m64",
     "m128",
     "m128_n16",
+    "m128_n16_checkpoint",
     "persistent_m128",
     "small_bh_m128",
 )
@@ -58,16 +60,21 @@ _FLASH_KDA_TARGET_DEFINE = {
 # refreshed export or binding specialization after an in-place package upgrade.
 _FLASH_KDA_MODULE_IDENTS = {
     "m64": "9a5566f3be",
-    "m128": "ea022a2f1f",
-    "m128_n16": "ef8b47d690",
-    "persistent_m128": "64bc19d01c",
-    "small_bh_m128": "73369168de",
+    "m128": "564a06c652",
+    "m128_n16": "65709d917f",
+    # Generated body, binding, and shared binding header, separated by NUL
+    # bytes without a trailing separator. Keep this route's cache key tied to
+    # all compiled content.
+    "m128_n16_checkpoint": "3fce0271a4",
+    "persistent_m128": "aae6c933e8",
+    "small_bh_m128": "84472afa2f",
 }
 
 _FLASH_KDA_BINDING_STEMS = {
     "m64": "flashkda_bf16_fused_m64",
     "m128": "flashkda_bf16_fused_m128",
     "m128_n16": "cake_flashkda_bf16_fused_m128_n16",
+    "m128_n16_checkpoint": "flashkda_bf16_fused_m128_n16_checkpoint",
     "persistent_m128": "cake_flashkda_bf16_persistent_m128",
     "small_bh_m128": "cake_flashkda_bf16_small_bh_m128",
 }
@@ -170,6 +177,12 @@ def gen_flash_kda_m128_n16_module(target: FlashKDATarget) -> JitSpec:
     return gen_flash_kda_module("m128_n16", target)
 
 
+def gen_flash_kda_m128_n16_checkpoint_module(target: FlashKDATarget) -> JitSpec:
+    """Generate the N16 M128 module with checkpoint TMA stores."""
+
+    return gen_flash_kda_module("m128_n16_checkpoint", target)
+
+
 def gen_flash_kda_persistent_m128_module(target: FlashKDATarget) -> JitSpec:
     """Generate the SM100-only static-binned persistent M128 module."""
 
@@ -234,6 +247,7 @@ __all__ = [
     "gen_flash_kda_m64_module",
     "gen_flash_kda_m128_module",
     "gen_flash_kda_m128_n16_module",
+    "gen_flash_kda_m128_n16_checkpoint_module",
     "gen_flash_kda_persistent_m128_module",
     "gen_flash_kda_small_bh_m128_module",
     "gen_flash_kda_module",

--- a/flashinfer/jit/flash_kda_backward.py
+++ b/flashinfer/jit/flash_kda_backward.py
@@ -1,0 +1,139 @@
+"""
+Copyright (c) 2026 by FlashInfer team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import functools
+from pathlib import Path
+from typing import Literal
+
+from . import env as jit_env
+from .core import (
+    JitSpec,
+    gen_jit_spec,
+    logger,
+    sm100a_nvcc_flags,
+    sm103a_nvcc_flags,
+)
+
+# First ten hex digits of SHA256 over the normalized C32 body, C16 body, C32
+# binding, and C16 binding, separated by NUL bytes. This keeps the JIT cache
+# tied to executable content without making the identifier self-referential.
+_FLASH_KDA_BACKWARD_MODULE_IDENT = "6af2ba3a09"
+
+FlashKDABackwardTarget = Literal["sm100a", "sm103a"]
+
+_TARGET_FLAGS: dict[FlashKDABackwardTarget, list[str]] = {
+    "sm100a": sm100a_nvcc_flags,
+    "sm103a": sm103a_nvcc_flags,
+}
+
+
+def _get_flash_kda_backward_csrc_dir() -> Path:
+    """Locate the frozen backward sources in installed and source checkouts."""
+
+    installed = jit_env.FLASHINFER_CSRC_DIR / "kda"
+    if installed.exists():
+        return installed
+
+    checkout = Path(__file__).resolve().parents[2] / "csrc" / "kda"
+    if checkout.exists():
+        return checkout
+
+    raise FileNotFoundError(
+        "frozen FlashKDA backward sources were not found. Checked:\n"
+        f"  - {installed}\n"
+        f"  - {checkout}"
+    )
+
+
+def _get_include_dir() -> Path:
+    """Locate FlashInfer headers in installed and source checkouts."""
+
+    if jit_env.FLASHINFER_INCLUDE_DIR.exists():
+        return jit_env.FLASHINFER_INCLUDE_DIR
+
+    checkout = Path(__file__).resolve().parents[2] / "include"
+    if checkout.exists():
+        return checkout
+
+    raise FileNotFoundError(
+        "FlashInfer headers were not found. Checked:\n"
+        f"  - {jit_env.FLASHINFER_INCLUDE_DIR}\n"
+        f"  - {checkout}"
+    )
+
+
+def get_flash_kda_backward_uri(target: FlashKDABackwardTarget) -> str:
+    """Return the exact-architecture JIT/AOT module key."""
+
+    return f"flash_kda_backward_{_FLASH_KDA_BACKWARD_MODULE_IDENT}_{target}"
+
+
+@functools.cache
+def gen_flash_kda_backward_module(target: FlashKDABackwardTarget) -> JitSpec:
+    """Generate the exact-architecture recurrent backward module."""
+
+    if target not in _TARGET_FLAGS:
+        raise ValueError(f"unsupported FlashKDA backward target: {target}")
+
+    csrc_dir = _get_flash_kda_backward_csrc_dir()
+    binding = csrc_dir / "flashkda_backward_binding.cu"
+    v483_binding = csrc_dir / "flashkda_backward_v483_binding.cu"
+    body = csrc_dir / "flashkda_backward.cu"
+    v483_body = csrc_dir / "flashkda_backward_v483.cu"
+    common = csrc_dir / "flashkda_binding_common.cuh"
+    for source in (binding, v483_binding, body, v483_body, common):
+        if not source.exists():
+            raise FileNotFoundError(f"FlashKDA backward source not found: {source}")
+
+    spec = gen_jit_spec(
+        name=get_flash_kda_backward_uri(target),
+        sources=[binding, v483_binding],
+        extra_cuda_cflags=[
+            *_TARGET_FLAGS[target],
+            f"-DFLASHINFER_FLASH_KDA_TARGET_MINOR={0 if target == 'sm100a' else 3}",
+        ],
+        extra_include_paths=[
+            csrc_dir,
+            csrc_dir.parent,
+            _get_include_dir(),
+        ],
+    )
+    logger.info(f"Generated FlashKDA backward JIT spec: {spec.name}")
+    return spec
+
+
+@functools.cache
+def load_flash_kda_backward_module(target: FlashKDABackwardTarget):
+    """Build or load the exact-architecture backward module."""
+
+    module = gen_flash_kda_backward_module(target).build_and_load()
+    logger.info(f"Loaded FlashKDA backward {target} module")
+    return module
+
+
+def get_flash_kda_backward_module(target: FlashKDABackwardTarget):
+    """Return the loaded module used by the recurrent-KDA backward API."""
+
+    return load_flash_kda_backward_module(target)
+
+
+__all__ = [
+    "FlashKDABackwardTarget",
+    "gen_flash_kda_backward_module",
+    "get_flash_kda_backward_module",
+    "get_flash_kda_backward_uri",
+    "load_flash_kda_backward_module",
+]

--- a/flashinfer/jit/flash_kda_training.py
+++ b/flashinfer/jit/flash_kda_training.py
@@ -1,0 +1,116 @@
+"""
+Copyright (c) 2026 by FlashInfer team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import functools
+from pathlib import Path
+from typing import Literal
+
+from . import env as jit_env
+from .core import (
+    JitSpec,
+    gen_jit_spec,
+    logger,
+    sm100a_nvcc_flags,
+    sm103a_nvcc_flags,
+)
+
+FlashKDATrainingTarget = Literal["sm100a", "sm103a"]
+
+# First ten hex digits of SHA256 over the target's complete source list and the
+# shared binding header, separated by NUL bytes without a trailing separator.
+_FLASH_KDA_TRAINING_MODULE_IDENT = "44c7c508ad"
+_TARGET_FLAGS: dict[FlashKDATrainingTarget, list[str]] = {
+    "sm100a": sm100a_nvcc_flags,
+    "sm103a": sm103a_nvcc_flags,
+}
+
+
+def _get_csrc_dir() -> Path:
+    installed = jit_env.FLASHINFER_CSRC_DIR / "kda"
+    if installed.exists():
+        return installed
+    checkout = Path(__file__).resolve().parents[2] / "csrc" / "kda"
+    if checkout.exists():
+        return checkout
+    raise FileNotFoundError("frozen FlashKDA training sources were not found")
+
+
+def _get_include_dir() -> Path:
+    if jit_env.FLASHINFER_INCLUDE_DIR.exists():
+        return jit_env.FLASHINFER_INCLUDE_DIR
+    checkout = Path(__file__).resolve().parents[2] / "include"
+    if checkout.exists():
+        return checkout
+    raise FileNotFoundError("FlashInfer headers were not found")
+
+
+def get_flash_kda_training_uri(target: FlashKDATrainingTarget) -> str:
+    if target not in _TARGET_FLAGS:
+        raise ValueError(f"unsupported FlashKDA training target: {target}")
+    return f"flash_kda_training_{_FLASH_KDA_TRAINING_MODULE_IDENT}_{target}"
+
+
+@functools.cache
+def gen_flash_kda_training_module(target: FlashKDATrainingTarget) -> JitSpec:
+    csrc_dir = _get_csrc_dir()
+    legacy_binding = csrc_dir / "flashkda_training_forward_v483_binding.cu"
+    paired_binding = csrc_dir / "flashkda_training_paired_binding.cu"
+    fallback_binding = csrc_dir / "flashkda_training_fallback_binding.cu"
+    c16 = csrc_dir / "flashkda_training_c16.cu"
+    auxiliary = csrc_dir / "flashkda_training_aux.cu"
+    final_state = csrc_dir / "flashkda_training_final_state.cu"
+    fallback = (
+        csrc_dir / f"training_fallback_pointer_{target.replace('sm', 'sm_', 1)}.cu"
+    )
+    common = csrc_dir / "flashkda_binding_common.cuh"
+    sources = [
+        legacy_binding,
+        paired_binding,
+        fallback_binding,
+        c16,
+        auxiliary,
+        final_state,
+        fallback,
+    ]
+    for source in (*sources, common):
+        if not source.exists():
+            raise FileNotFoundError(f"FlashKDA training source not found: {source}")
+    spec = gen_jit_spec(
+        name=get_flash_kda_training_uri(target),
+        sources=sources,
+        extra_cuda_cflags=[
+            *_TARGET_FLAGS[target],
+            f"-DFLASHINFER_FLASH_KDA_TARGET_MINOR={0 if target == 'sm100a' else 3}",
+        ],
+        extra_include_paths=[csrc_dir, csrc_dir.parent, _get_include_dir()],
+    )
+    logger.info(f"Generated FlashKDA training {target} JIT spec: {spec.name}")
+    return spec
+
+
+@functools.cache
+def load_flash_kda_training_module(target: FlashKDATrainingTarget):
+    module = gen_flash_kda_training_module(target).build_and_load()
+    logger.info(f"Loaded FlashKDA training {target} module")
+    return module
+
+
+__all__ = [
+    "FlashKDATrainingTarget",
+    "gen_flash_kda_training_module",
+    "get_flash_kda_training_uri",
+    "load_flash_kda_training_module",
+]

--- a/flashinfer/kda.py
+++ b/flashinfer/kda.py
@@ -33,6 +33,19 @@ from . import kda_decode as _kda_decode
 from . import kda_prefill as _kda_prefill
 from . import kda_prefill_cute as _kda_prefill_cute
 from .api_logging import flashinfer_api
+from .kda_backward import (
+    RecurrentKDABackwardWorkspace as RecurrentKDABackwardWorkspace,
+)
+from .kda_backward import recurrent_kda_backward as recurrent_kda_backward
+from .kda_training import (
+    RecurrentKDATrainingContext as RecurrentKDATrainingContext,
+)
+from .kda_training import (
+    recurrent_kda_training_backward as recurrent_kda_training_backward,
+)
+from .kda_training import (
+    recurrent_kda_training_forward as recurrent_kda_training_forward,
+)
 from .trace.templates.kda import recurrent_kda_trace
 from .utils import get_compute_capability
 
@@ -206,8 +219,9 @@ def recurrent_kda(
             Each count must equal ``ceil(seq_len / checkpoint_every_n_tokens)``.
         checkpoint_every_n_tokens (int):
             Checkpoint interval. Zero disables checkpoints; a positive value
-            must be divisible by 32. SGLang normally uses 64 or a larger
-            cache-page-aligned multiple.
+            must be divisible by 32, except that the SM100-family exact-N16
+            frozen route also accepts multiples of 16. SGLang normally uses
+            64 or a larger cache-page-aligned multiple.
         backend (Literal["auto", "cute-dsl", "cake"]):
             Implementation backend. ``"auto"`` selects the architecture-
             appropriate CuTe DSL kernel for supported ordinary multi-token

--- a/flashinfer/kda_backward.py
+++ b/flashinfer/kda_backward.py
@@ -1,0 +1,1239 @@
+"""
+Copyright (c) 2026 by FlashInfer team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+# Frozen Blackwell recurrent Kimi Delta Attention backward support.
+
+import math
+import threading
+from dataclasses import dataclass
+from typing import Optional, Sequence
+
+import torch
+
+from .api_logging import flashinfer_api
+from .utils import get_compute_capability
+
+
+_HEAD_DIM = 128
+_CHUNK_SIZE = 32
+_C16_CHUNK_SIZE = 16
+_DESCRIPTOR_BYTES = 1152
+_DESCRIPTOR_ALIGNMENT = 64
+_SUPPORTED_COMPUTE_CAPABILITIES = ((10, 0), (10, 3))
+_DEFAULT_LOWER_BOUND = -5.0
+
+KDA_BACKWARD_GRADIENT_NAMES = (
+    "dq",
+    "dk",
+    "dv",
+    "dg",
+    "dbeta",
+    "dA_log",
+    "ddt_bias",
+    "dinitial_state",
+)
+
+
+@dataclass(frozen=True)
+class _ShapeSpec:
+    name: str
+    seq_lens: tuple[int, ...]
+    num_heads: int
+    packed: bool
+
+    @property
+    def total_tokens(self) -> int:
+        return sum(self.seq_lens)
+
+    @property
+    def num_sequences(self) -> int:
+        return len(self.seq_lens)
+
+    @property
+    def high_head_route(self) -> bool:
+        return self.num_heads >= 16
+
+    @property
+    def c16_route(self) -> bool:
+        # The exported V483 binding intentionally freezes the one measured
+        # production crossover shape. Other admitted shapes retain their
+        # established low-head or C32 route.
+        return self.packed and self.seq_lens == (1024,) * 8 and self.num_heads == 96
+
+    @property
+    def cu_seqlens(self) -> tuple[int, ...]:
+        offsets = [0]
+        for length in self.seq_lens:
+            offsets.append(offsets[-1] + length)
+        return tuple(offsets)
+
+
+_SUPPORTED_SHAPES = (
+    _ShapeSpec("fixed_t17_h1", (17,), 1, False),
+    _ShapeSpec("packed_17_33_65_h4", (17, 33, 65), 4, True),
+    _ShapeSpec("fixed_t17_h16", (17,), 16, False),
+    _ShapeSpec("fixed_t1024_h4", (1024,), 4, False),
+    _ShapeSpec("fixed_t4096_h32", (4096,), 32, False),
+    _ShapeSpec("fixed_t8192_h96", (8192,), 96, False),
+    _ShapeSpec(
+        "packed_1300_547_2048_963_271_3063_h96",
+        (1300, 547, 2048, 963, 271, 3063),
+        96,
+        True,
+    ),
+    _ShapeSpec("packed_1024x8_h96", (1024,) * 8, 96, True),
+)
+
+
+def _select_shape(
+    q_shape: Sequence[int], cu_seqlens_numel: Optional[int]
+) -> _ShapeSpec:
+    if len(q_shape) != 4:
+        raise ValueError(f"q must have rank 4, got shape {tuple(q_shape)}")
+    batch_size, total_tokens, num_heads, head_dim = map(int, q_shape)
+    packed = cu_seqlens_numel is not None
+    num_sequences = None if cu_seqlens_numel is None else cu_seqlens_numel - 1
+    for spec in _SUPPORTED_SHAPES:
+        if (
+            batch_size == 1
+            and total_tokens == spec.total_tokens
+            and num_heads == spec.num_heads
+            and head_dim == _HEAD_DIM
+            and packed == spec.packed
+            and (not packed or num_sequences == spec.num_sequences)
+        ):
+            return spec
+    layout = (
+        "fixed"
+        if cu_seqlens_numel is None
+        else f"packed with {num_sequences} sequences"
+    )
+    raise ValueError(
+        "recurrent_kda_backward supports only its eight documented Blackwell "
+        f"shapes; got {layout} q shape {tuple(q_shape)}"
+    )
+
+
+def _tensor_signature(tensor: torch.Tensor) -> tuple:
+    return (
+        tensor.data_ptr(),
+        tuple(tensor.shape),
+        tuple(tensor.stride()),
+        tensor.dtype,
+    )
+
+
+def _metadata_values(spec: _ShapeSpec) -> dict[str, tuple[int, ...]]:
+    chunk_counts = tuple(
+        (length + _CHUNK_SIZE - 1) // _CHUNK_SIZE for length in spec.seq_lens
+    )
+    chunk_offsets = [0]
+    chunk_sequence: list[int] = []
+    chunk_index: list[int] = []
+    for sequence, count in enumerate(chunk_counts):
+        chunk_offsets.append(chunk_offsets[-1] + count)
+        chunk_sequence.extend((sequence,) * count)
+        chunk_index.extend(range(count))
+
+    seq_order = tuple(
+        sorted(
+            range(spec.num_sequences),
+            key=lambda sequence: spec.seq_lens[sequence],
+            reverse=True,
+        )
+    )
+    consumer_chunk_order = tuple(
+        chunk_offsets[sequence] + chunk_counts[sequence] - 1 - reverse_depth
+        for reverse_depth in range(max(chunk_counts))
+        for sequence in seq_order
+        if reverse_depth < chunk_counts[sequence]
+    )
+    chunk_pair_start = tuple(
+        chunk_offsets[sequence] + local_chunk
+        for sequence, count in enumerate(chunk_counts)
+        for local_chunk in range(0, count, 2)
+    )
+    result = {
+        "fixed_cu_seqlens": spec.cu_seqlens,
+        "seq_order": seq_order,
+        "cu_chunk_offsets": tuple(chunk_offsets),
+        "consumer_chunk_order": consumer_chunk_order,
+        "chunk_sequence": tuple(chunk_sequence),
+        "chunk_index": tuple(chunk_index),
+        "chunk_pair_start": chunk_pair_start,
+    }
+    if spec.c16_route:
+        counts = tuple(length // _C16_CHUNK_SIZE for length in spec.seq_lens)
+        checkpoint_starts = [0]
+        for count in counts:
+            checkpoint_starts.append(checkpoint_starts[-1] + count)
+        forward_rows = tuple(
+            item
+            for sequence, count in enumerate(counts)
+            for head in range(spec.num_heads)
+            for item in (
+                sequence,
+                head,
+                0,
+                count,
+                0,
+                count,
+                spec.cu_seqlens[sequence],
+                spec.cu_seqlens[sequence + 1],
+            )
+        )
+        backward_rows = tuple(
+            item
+            for sequence, count in enumerate(counts)
+            for head in range(spec.num_heads)
+            for item in (sequence, head, 0, count, count)
+        )
+        result.update(
+            {
+                "c16_checkpoint_cu_starts": tuple(checkpoint_starts),
+                "c16_forward_work_items": forward_rows,
+                "c16_backward_work_items": backward_rows,
+            }
+        )
+    return result
+
+
+class _RecurrentKDABackwardWorkspaceBase:
+    def __init__(self, device: torch.device | str) -> None:
+        normalized_device = torch.device(device)
+        if normalized_device.type != "cuda":
+            raise ValueError("RecurrentKDABackwardWorkspace requires a CUDA device")
+        if normalized_device.index is None:
+            normalized_device = torch.device("cuda", torch.cuda.current_device())
+        self.device = normalized_device
+        self._lock = threading.Lock()
+        self._buffers: dict[str, torch.Tensor] = {}
+        self._metadata: dict[str, torch.Tensor] = {}
+        self._metadata_shape_name: Optional[str] = None
+        self._descriptor_raw = torch.empty(
+            _DESCRIPTOR_BYTES + _DESCRIPTOR_ALIGNMENT - 1,
+            dtype=torch.uint8,
+            device=self.device,
+        )
+        descriptor_offset = (-self._descriptor_raw.data_ptr()) % _DESCRIPTOR_ALIGNMENT
+        self._descriptor_storage = self._descriptor_raw[
+            descriptor_offset : descriptor_offset + _DESCRIPTOR_BYTES
+        ]
+        self._descriptor_signature: Optional[tuple] = None
+        self._forward_descriptor_raw = torch.empty(
+            6 * 128 + _DESCRIPTOR_ALIGNMENT - 1,
+            dtype=torch.uint8,
+            device=self.device,
+        )
+        forward_descriptor_offset = (
+            -self._forward_descriptor_raw.data_ptr()
+        ) % _DESCRIPTOR_ALIGNMENT
+        self._forward_descriptor_storage = self._forward_descriptor_raw[
+            forward_descriptor_offset : forward_descriptor_offset + 6 * 128
+        ]
+        self._forward_descriptor_signature: Optional[tuple] = None
+        self._warmed_signature: Optional[tuple] = None
+        self._packed_offsets_signature: Optional[tuple] = None
+        self._bound_stream_ptr: Optional[int] = None
+        self._captured = False
+
+
+class RecurrentKDABackwardWorkspace(_RecurrentKDABackwardWorkspaceBase):
+    """Caller-owned scratch for :func:`recurrent_kda_backward`.
+
+    Construct one workspace per invocation that will be captured by a CUDA
+    Graph. Warm it by calling :func:`recurrent_kda_backward` eagerly with the
+    exact input and ``out`` tensors on the intended capture stream, then
+    synchronize that stream before capture. The warm call allocates every
+    route-specific intermediate, validates packed offsets, and prepares the
+    high-head TMA descriptors. Capture performs no allocation or descriptor
+    preparation.
+
+    A workspace binds to its first stream. Once it participates in capture it
+    cannot be passed through Python again; graph replay remains valid while
+    the workspace and all warmed tensors stay alive.
+    """
+
+
+class _StreamWorkspace(_RecurrentKDABackwardWorkspaceBase):
+    """Internal eager-only workspace for one device stream."""
+
+
+_stream_workspaces: dict[tuple[int, int], _StreamWorkspace] = {}
+_stream_workspaces_lock = threading.Lock()
+
+
+def _get_stream_workspace(device: torch.device, stream_ptr: int) -> _StreamWorkspace:
+    device_index = device.index
+    assert device_index is not None
+    key = (device_index, stream_ptr)
+    with _stream_workspaces_lock:
+        workspace = _stream_workspaces.get(key)
+        if workspace is None:
+            workspace = _StreamWorkspace(device)
+            _stream_workspaces[key] = workspace
+        return workspace
+
+
+def _bind_workspace(
+    workspace: _RecurrentKDABackwardWorkspaceBase,
+    *,
+    device: torch.device,
+    stream_ptr: int,
+    capturing: bool,
+    explicit: bool,
+) -> None:
+    if workspace.device != device:
+        raise ValueError(
+            "RecurrentKDABackwardWorkspace is bound to "
+            f"{workspace.device}, but inputs are on {device}"
+        )
+    if workspace._bound_stream_ptr is None:
+        workspace._bound_stream_ptr = stream_ptr
+    elif workspace._bound_stream_ptr != stream_ptr:
+        raise RuntimeError(
+            "RecurrentKDABackwardWorkspace is bound to a different CUDA "
+            "stream; warm and capture it on one stream"
+        )
+    if explicit and workspace._captured:
+        reuse_kind = "captured again" if capturing else "reused eagerly"
+        raise RuntimeError(
+            "RecurrentKDABackwardWorkspace has participated in CUDA graph "
+            f"capture and cannot be {reuse_kind} or mutated"
+        )
+
+
+def _buffer(
+    workspace: _RecurrentKDABackwardWorkspaceBase,
+    name: str,
+    shape: tuple[int, ...],
+    dtype: torch.dtype,
+    *,
+    capturing: bool,
+) -> torch.Tensor:
+    numel = math.prod(shape)
+    allocation = workspace._buffers.get(name)
+    if allocation is None or allocation.numel() < numel:
+        if capturing:
+            raise RuntimeError(
+                "RecurrentKDABackwardWorkspace is not large enough for CUDA "
+                "graph capture; eagerly warm this exact shape first"
+            )
+        allocation = torch.empty(numel, dtype=dtype, device=workspace.device)
+        workspace._buffers[name] = allocation
+    elif allocation.dtype != dtype:
+        raise RuntimeError(
+            f"workspace buffer {name} has dtype {allocation.dtype}, expected {dtype}"
+        )
+    return allocation[:numel].view(shape)
+
+
+def _prepare_metadata(
+    workspace: _RecurrentKDABackwardWorkspaceBase,
+    spec: _ShapeSpec,
+    *,
+    capturing: bool,
+) -> dict[str, torch.Tensor]:
+    if workspace._metadata_shape_name == spec.name:
+        return workspace._metadata
+    if capturing:
+        raise RuntimeError(
+            "RecurrentKDABackwardWorkspace metadata was not warmed for "
+            f"shape {spec.name}"
+        )
+
+    values = _metadata_values(spec)
+    result: dict[str, torch.Tensor] = {}
+    int64_metadata = {
+        "fixed_cu_seqlens",
+        "cu_chunk_offsets",
+        "c16_checkpoint_cu_starts",
+    }
+    for name, items in values.items():
+        dtype = torch.int64 if name in int64_metadata else torch.int32
+        result[name] = torch.tensor(items, dtype=dtype, device=workspace.device)
+    workspace._metadata = result
+    workspace._metadata_shape_name = spec.name
+    return result
+
+
+def _validate_tensor(
+    name: str,
+    tensor: torch.Tensor,
+    *,
+    shape: tuple[int, ...],
+    dtype: torch.dtype,
+    device: torch.device,
+) -> None:
+    if not isinstance(tensor, torch.Tensor):
+        raise TypeError(f"{name} must be a torch.Tensor")
+    if tensor.device != device or not tensor.is_cuda:
+        raise ValueError(f"{name} must be on CUDA device {device}")
+    if tensor.dtype != dtype:
+        raise ValueError(f"{name} must have dtype {dtype}, got {tensor.dtype}")
+    if tuple(tensor.shape) != shape:
+        raise ValueError(f"{name} must have shape {shape}, got {tuple(tensor.shape)}")
+    if not tensor.is_contiguous():
+        raise ValueError(f"{name} must be contiguous")
+
+
+def _validate_and_select_shape(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor,
+    beta: torch.Tensor,
+    A_log: torch.Tensor,
+    dt_bias: torch.Tensor,
+    initial_state: torch.Tensor,
+    do: torch.Tensor,
+    dfinal_state: torch.Tensor,
+    cu_seqlens: Optional[torch.Tensor],
+) -> _ShapeSpec:
+    if not isinstance(q, torch.Tensor):
+        raise TypeError("q must be a torch.Tensor")
+    if not q.is_cuda:
+        raise ValueError("recurrent_kda_backward requires CUDA tensors")
+    device = q.device
+    compute_capability = get_compute_capability(device)
+    if compute_capability not in _SUPPORTED_COMPUTE_CAPABILITIES:
+        raise ValueError(
+            "recurrent_kda_backward requires compute capability 10.0 or 10.3"
+        )
+    if cu_seqlens is not None and not isinstance(cu_seqlens, torch.Tensor):
+        raise TypeError("cu_seqlens must be a torch.Tensor or None")
+    spec = _select_shape(q.shape, None if cu_seqlens is None else cu_seqlens.numel())
+    token_shape = (1, spec.total_tokens, spec.num_heads, _HEAD_DIM)
+    beta_shape = token_shape[:-1]
+    state_shape = (
+        spec.num_sequences,
+        spec.num_heads,
+        _HEAD_DIM,
+        _HEAD_DIM,
+    )
+    for name, tensor in (
+        ("q", q),
+        ("k", k),
+        ("v", v),
+        ("g", g),
+        ("do", do),
+    ):
+        _validate_tensor(
+            name, tensor, shape=token_shape, dtype=torch.bfloat16, device=device
+        )
+    _validate_tensor(
+        "beta", beta, shape=beta_shape, dtype=torch.bfloat16, device=device
+    )
+    _validate_tensor(
+        "A_log",
+        A_log,
+        shape=(spec.num_heads,),
+        dtype=torch.float32,
+        device=device,
+    )
+    _validate_tensor(
+        "dt_bias",
+        dt_bias,
+        shape=(spec.num_heads, _HEAD_DIM),
+        dtype=torch.float32,
+        device=device,
+    )
+    _validate_tensor(
+        "initial_state",
+        initial_state,
+        shape=state_shape,
+        dtype=torch.float32,
+        device=device,
+    )
+    _validate_tensor(
+        "dfinal_state",
+        dfinal_state,
+        shape=state_shape,
+        dtype=torch.float32,
+        device=device,
+    )
+    if spec.packed:
+        assert cu_seqlens is not None
+        _validate_tensor(
+            "cu_seqlens",
+            cu_seqlens,
+            shape=(spec.num_sequences + 1,),
+            dtype=torch.int64,
+            device=device,
+        )
+    elif cu_seqlens is not None:
+        raise ValueError(f"shape {spec.name} requires cu_seqlens=None")
+    return spec
+
+
+def _validate_packed_offsets(
+    workspace: _RecurrentKDABackwardWorkspaceBase,
+    spec: _ShapeSpec,
+    cu_seqlens: Optional[torch.Tensor],
+    *,
+    capturing: bool,
+) -> None:
+    if not spec.packed:
+        return
+    assert cu_seqlens is not None
+    signature = (*_tensor_signature(cu_seqlens), int(cu_seqlens._version))
+    if workspace._packed_offsets_signature == signature:
+        return
+    if capturing:
+        raise RuntimeError(
+            "packed cu_seqlens was not warmed for this CUDA graph capture"
+        )
+    offsets = tuple(int(value) for value in cu_seqlens.detach().cpu().tolist())
+    if offsets != spec.cu_seqlens:
+        raise ValueError(
+            f"shape {spec.name} requires cu_seqlens={spec.cu_seqlens}, got {offsets}"
+        )
+    workspace._packed_offsets_signature = signature
+
+
+def _validate_outputs(
+    out: Optional[Sequence[torch.Tensor]],
+    *,
+    q: torch.Tensor,
+    beta: torch.Tensor,
+    A_log: torch.Tensor,
+    dt_bias: torch.Tensor,
+    initial_state: torch.Tensor,
+    capturing: bool,
+) -> tuple[torch.Tensor, ...]:
+    expected = (
+        ("dq", q.shape, torch.bfloat16),
+        ("dk", q.shape, torch.bfloat16),
+        ("dv", q.shape, torch.bfloat16),
+        ("dg", q.shape, torch.bfloat16),
+        ("dbeta", beta.shape, torch.bfloat16),
+        ("dA_log", A_log.shape, torch.float32),
+        ("ddt_bias", dt_bias.shape, torch.float32),
+        ("dinitial_state", initial_state.shape, torch.float32),
+    )
+    if out is None:
+        if capturing:
+            raise RuntimeError(
+                "CUDA graph capture requires eight preallocated gradient tensors "
+                "passed through out="
+            )
+        return tuple(
+            torch.empty(shape, dtype=dtype, device=q.device)
+            for _, shape, dtype in expected
+        )
+    if len(out) != len(expected):
+        raise ValueError(f"out must contain eight tensors, got {len(out)}")
+    result = tuple(out)
+    for tensor, (name, shape, dtype) in zip(result, expected, strict=True):
+        _validate_tensor(
+            f"out[{name}]",
+            tensor,
+            shape=tuple(shape),
+            dtype=dtype,
+            device=q.device,
+        )
+    return result
+
+
+def _allocate_low_workspace(
+    workspace: _RecurrentKDABackwardWorkspaceBase,
+    spec: _ShapeSpec,
+    *,
+    capturing: bool,
+) -> tuple[torch.Tensor, ...]:
+    token_vector_shape = (spec.total_tokens, spec.num_heads, _HEAD_DIM)
+    token_scalar_shape = (spec.total_tokens, spec.num_heads)
+    checkpoint_shape = (
+        spec.total_tokens,
+        spec.num_heads,
+        _HEAD_DIM,
+        _HEAD_DIM,
+    )
+    return (
+        _buffer(
+            workspace,
+            "low_q_norm",
+            token_vector_shape,
+            torch.float32,
+            capturing=capturing,
+        ),
+        _buffer(
+            workspace,
+            "low_k_norm",
+            token_vector_shape,
+            torch.float32,
+            capturing=capturing,
+        ),
+        _buffer(
+            workspace,
+            "low_decay",
+            token_vector_shape,
+            torch.float32,
+            capturing=capturing,
+        ),
+        _buffer(
+            workspace,
+            "low_beta_active",
+            token_scalar_shape,
+            torch.float32,
+            capturing=capturing,
+        ),
+        _buffer(
+            workspace,
+            "low_checkpoint",
+            checkpoint_shape,
+            torch.float32,
+            capturing=capturing,
+        ),
+        _buffer(
+            workspace,
+            "low_dq_normalized",
+            token_vector_shape,
+            torch.float32,
+            capturing=capturing,
+        ),
+        _buffer(
+            workspace,
+            "low_dk_normalized",
+            token_vector_shape,
+            torch.float32,
+            capturing=capturing,
+        ),
+        _buffer(
+            workspace,
+            "low_dlog_decay",
+            token_vector_shape,
+            torch.float32,
+            capturing=capturing,
+        ),
+        _buffer(
+            workspace,
+            "low_dbeta_active",
+            token_scalar_shape,
+            torch.float32,
+            capturing=capturing,
+        ),
+    )
+
+
+def _allocate_high_workspace(
+    workspace: _RecurrentKDABackwardWorkspaceBase,
+    spec: _ShapeSpec,
+    beta: torch.Tensor,
+    *,
+    capturing: bool,
+) -> dict[str, torch.Tensor]:
+    total_chunks = sum(
+        (length + _CHUNK_SIZE - 1) // _CHUNK_SIZE for length in spec.seq_lens
+    )
+    h = spec.num_heads
+    token_vector_shape = (spec.total_tokens, h, _HEAD_DIM)
+    token_scalar_shape = (spec.total_tokens, h)
+    tape_vector_shape = (total_chunks, h, _CHUNK_SIZE, _HEAD_DIM)
+    tape_value_shape = (total_chunks, h, _HEAD_DIM, _CHUNK_SIZE)
+    chunk_state_shape = (total_chunks, h, _HEAD_DIM, _HEAD_DIM)
+    beta_tma = beta.reshape(spec.total_tokens, h)
+    if spec.total_tokens < 32 or h < 8:
+        beta_tma = _buffer(
+            workspace,
+            "high_beta_tma",
+            (max(spec.total_tokens, 32), max(h, 8)),
+            torch.bfloat16,
+            capturing=capturing,
+        )
+
+    def high_buffer(
+        name: str, shape: tuple[int, ...], dtype: torch.dtype
+    ) -> torch.Tensor:
+        return _buffer(
+            workspace,
+            f"high_{name}",
+            shape,
+            dtype,
+            capturing=capturing,
+        )
+
+    tensors = {
+        "beta_tma": beta_tma,
+        "q_tma_out": high_buffer("q_tma_out", token_vector_shape, torch.bfloat16),
+        "forward_final": high_buffer(
+            "forward_final",
+            (spec.num_sequences, h, _HEAD_DIM, _HEAD_DIM),
+            torch.bfloat16,
+        ),
+        "chunk_state": high_buffer("chunk_state", chunk_state_shape, torch.bfloat16),
+        "state_checkpoint_needed": high_buffer(
+            "state_checkpoint_needed",
+            ((total_chunks + spec.num_sequences) * h,),
+            torch.uint32,
+        ),
+        "tape_qd": high_buffer("tape_qd", tape_vector_shape, torch.bfloat16),
+        "tape_kd": high_buffer("tape_kd", tape_vector_shape, torch.bfloat16),
+        "tape_kr": high_buffer("tape_kr", tape_vector_shape, torch.bfloat16),
+        "tape_j": high_buffer(
+            "tape_j",
+            (total_chunks, h, _CHUNK_SIZE, _CHUNK_SIZE),
+            torch.bfloat16,
+        ),
+        "tape_restore_factor": high_buffer(
+            "tape_restore_factor",
+            (total_chunks, h, _HEAD_DIM),
+            torch.float32,
+        ),
+        "tape_x": high_buffer("tape_x", tape_value_shape, torch.bfloat16),
+        "tape_r": high_buffer("tape_r", tape_value_shape, torch.bfloat16),
+        "norm_inv": high_buffer("norm_inv", (spec.total_tokens, h, 2), torch.float32),
+        "decay": high_buffer("decay", token_vector_shape, torch.bfloat16),
+        "beta_active": high_buffer("beta_active", token_scalar_shape, torch.float32),
+        "zero_workspace": high_buffer(
+            "zero_workspace",
+            (total_chunks * h,),
+            torch.uint32,
+        ),
+        "chunk_dh": high_buffer("chunk_dh", chunk_state_shape, torch.bfloat16),
+        "chunk_dr": high_buffer("chunk_dr", tape_value_shape, torch.bfloat16),
+        "chunk_dx": high_buffer("chunk_dx", tape_value_shape, torch.bfloat16),
+        "grad_qd": high_buffer("grad_qd", tape_vector_shape, torch.bfloat16),
+        "grad_kd": high_buffer("grad_kd", tape_vector_shape, torch.bfloat16),
+        "grad_ki": high_buffer("grad_ki", tape_vector_shape, torch.bfloat16),
+        "dlog_decay": high_buffer("dlog_decay", token_vector_shape, torch.float32),
+        "dbeta_active": high_buffer("dbeta_active", token_scalar_shape, torch.float32),
+    }
+    tensors["tape_e"] = tensors["tape_x"]
+    return tensors
+
+
+def _allocate_c16_workspace(
+    workspace: _RecurrentKDABackwardWorkspaceBase,
+    spec: _ShapeSpec,
+    *,
+    capturing: bool,
+) -> dict[str, torch.Tensor]:
+    total_chunks = sum(length // _C16_CHUNK_SIZE for length in spec.seq_lens)
+    h = spec.num_heads
+    token_vector_shape = (spec.total_tokens, h, _HEAD_DIM)
+    token_scalar_shape = (spec.total_tokens, h)
+
+    def c16_buffer(
+        name: str, shape: tuple[int, ...], dtype: torch.dtype
+    ) -> torch.Tensor:
+        return _buffer(
+            workspace,
+            f"c16_{name}",
+            shape,
+            dtype,
+            capturing=capturing,
+        )
+
+    return {
+        "forward_out": c16_buffer("forward_out", token_vector_shape, torch.bfloat16),
+        "forward_final_bf16": c16_buffer(
+            "forward_final_bf16",
+            (spec.num_sequences, h, _HEAD_DIM, _HEAD_DIM),
+            torch.bfloat16,
+        ),
+        "forward_final": c16_buffer(
+            "forward_final",
+            (spec.num_sequences, h, _HEAD_DIM, _HEAD_DIM),
+            torch.float32,
+        ),
+        "state_checkpoints": c16_buffer(
+            "state_checkpoints",
+            (total_chunks, h, _HEAD_DIM, _HEAD_DIM),
+            torch.bfloat16,
+        ),
+        "beta_active": c16_buffer("beta_active", token_scalar_shape, torch.bfloat16),
+        "dlog_decay": c16_buffer("dlog_decay", token_vector_shape, torch.float32),
+        "dlog_boundary": c16_buffer(
+            "dlog_boundary", (total_chunks, h, _HEAD_DIM), torch.float32
+        ),
+        "dbeta_active": c16_buffer("dbeta_active", token_scalar_shape, torch.float32),
+        "gate_part_a": c16_buffer("gate_part_a", (128, h, _HEAD_DIM), torch.float32),
+        "gate_part_dt": c16_buffer("gate_part_dt", (128, h, _HEAD_DIM), torch.float32),
+        "counter": c16_buffer("counter", (1,), torch.uint32),
+        "dummy_u32": c16_buffer("dummy_u32", (1,), torch.uint32),
+        "dummy_f32": c16_buffer("dummy_f32", (1,), torch.float32),
+    }
+
+
+def _get_flash_kda_backward_module(device: torch.device):
+    from .jit.flash_kda_backward import (
+        FlashKDABackwardTarget,
+        get_flash_kda_backward_module,
+    )
+
+    capability = get_compute_capability(device)
+    target: FlashKDABackwardTarget = "sm100a" if capability == (10, 0) else "sm103a"
+    return get_flash_kda_backward_module(target)
+
+
+def _get_flash_kda_training_module(device: torch.device):
+    from .jit.flash_kda_training import (
+        FlashKDATrainingTarget,
+        load_flash_kda_training_module,
+    )
+
+    capability = get_compute_capability(device)
+    target: FlashKDATrainingTarget = "sm100a" if capability == (10, 0) else "sm103a"
+    return load_flash_kda_training_module(target)
+
+
+@flashinfer_api
+def recurrent_kda_backward(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor,
+    beta: torch.Tensor,
+    A_log: torch.Tensor,
+    dt_bias: torch.Tensor,
+    initial_state: torch.Tensor,
+    do: torch.Tensor,
+    dfinal_state: torch.Tensor,
+    cu_seqlens: Optional[torch.Tensor] = None,
+    scale: Optional[float] = None,
+    lower_bound: float = _DEFAULT_LOWER_BOUND,
+    workspace: Optional[RecurrentKDABackwardWorkspace] = None,
+    out: Optional[Sequence[torch.Tensor]] = None,
+) -> tuple[torch.Tensor, ...]:
+    r"""Compute all gradients of the recurrent KDA training recurrence.
+
+    The kernel differentiates BF16 Q/K/V/raw-gate/raw-beta token inputs and
+    FP32 parameters and recurrent state. Q and K are L2-normalized with
+    epsilon ``1e-6``; decay is
+    ``exp(lower_bound * sigmoid(exp(A_log) * (g + dt_bias)))`` and beta is
+    passed through a sigmoid. The loss adjoints are ``do`` for token output
+    and ``dfinal_state`` for final recurrent state.
+
+    This frozen implementation is specialized for SM100a/SM103a, head/key/value
+    dimension 128, FP32 state, and the eight shapes listed in
+    :doc:`../api/kda_backward`. It returns ``(dq, dk, dv, dg, dbeta,
+    dA_log, ddt_bias, dinitial_state)`` in that order.
+
+    Args:
+        q: Contiguous BF16 ``[1,T,H,128]`` query tensor.
+        k: Contiguous BF16 ``[1,T,H,128]`` key tensor.
+        v: Contiguous BF16 ``[1,T,H,128]`` value tensor.
+        g: Contiguous BF16 ``[1,T,H,128]`` raw gate tensor.
+        beta: Contiguous BF16 ``[1,T,H]`` raw beta logits.
+        A_log: Contiguous FP32 ``[H]`` decay parameter.
+        dt_bias: Contiguous FP32 ``[H,128]`` decay bias.
+        initial_state: Contiguous FP32 value-first ``[N,H,V,K]`` state, with
+            ``V=K=128``.
+        do: Contiguous BF16 token-output adjoint matching ``q``.
+        dfinal_state: Contiguous FP32 value-first final-state adjoint matching
+            ``initial_state``.
+        cu_seqlens: Exact contiguous CUDA int64 packed
+            offsets for one of the documented packed shapes, otherwise ``None``.
+        scale: Fixed output scale ``1 / sqrt(128)``.
+        lower_bound: Fixed safe-gate lower bound ``-5.0``.
+        workspace: Reusable scratch.
+            Required, eagerly warmed, for CUDA Graph capture.
+        out: Eight preallocated gradient
+            tensors in return order. Required for CUDA Graph capture.
+    """
+
+    spec = _validate_and_select_shape(
+        q,
+        k,
+        v,
+        g,
+        beta,
+        A_log,
+        dt_bias,
+        initial_state,
+        do,
+        dfinal_state,
+        cu_seqlens,
+    )
+    scale_value = 1.0 / math.sqrt(_HEAD_DIM) if scale is None else float(scale)
+    lower_bound_value = float(lower_bound)
+    required_scale = 1.0 / math.sqrt(_HEAD_DIM)
+    if not math.isfinite(scale_value) or abs(scale_value - required_scale) > 1e-15:
+        raise ValueError(
+            f"recurrent_kda_backward fixes scale=1/sqrt(128), got {scale_value}"
+        )
+    if not math.isfinite(lower_bound_value) or lower_bound_value != -5.0:
+        raise ValueError(
+            f"recurrent_kda_backward fixes lower_bound=-5.0, got {lower_bound_value}"
+        )
+
+    capturing = torch.cuda.is_current_stream_capturing()
+    if capturing and workspace is None:
+        raise RuntimeError(
+            "CUDA graph capture requires an explicit "
+            "RecurrentKDABackwardWorkspace warmed with the exact tensors"
+        )
+    outputs = _validate_outputs(
+        out,
+        q=q,
+        beta=beta,
+        A_log=A_log,
+        dt_bias=dt_bias,
+        initial_state=initial_state,
+        capturing=capturing,
+    )
+    stream_ptr = int(torch.cuda.current_stream(q.device).cuda_stream)
+    explicit_workspace = workspace is not None
+    active_workspace: _RecurrentKDABackwardWorkspaceBase
+    if workspace is None:
+        active_workspace = _get_stream_workspace(q.device, stream_ptr)
+    else:
+        active_workspace = workspace
+
+    with active_workspace._lock:
+        _bind_workspace(
+            active_workspace,
+            device=q.device,
+            stream_ptr=stream_ptr,
+            capturing=capturing,
+            explicit=explicit_workspace,
+        )
+        _validate_packed_offsets(
+            active_workspace,
+            spec,
+            cu_seqlens,
+            capturing=capturing,
+        )
+        metadata = _prepare_metadata(active_workspace, spec, capturing=capturing)
+        cu_seqlens_arg = cu_seqlens if spec.packed else metadata["fixed_cu_seqlens"]
+        assert cu_seqlens_arg is not None
+        launch_signature = (
+            spec.name,
+            scale_value,
+            lower_bound_value,
+            *(
+                _tensor_signature(tensor)
+                for tensor in (
+                    q,
+                    k,
+                    v,
+                    g,
+                    beta,
+                    A_log,
+                    dt_bias,
+                    initial_state,
+                    do,
+                    dfinal_state,
+                    cu_seqlens_arg,
+                    *outputs,
+                )
+            ),
+        )
+        if capturing and active_workspace._warmed_signature != launch_signature:
+            raise RuntimeError(
+                "RecurrentKDABackwardWorkspace is not warmed for the exact "
+                "input, output, metadata, scale, and lower-bound signature"
+            )
+
+        module = _get_flash_kda_backward_module(q.device)
+        dq, dk, dv, dg, dbeta, dA_log, ddt_bias, dinitial_state = outputs
+        if spec.c16_route:
+            c16 = _allocate_c16_workspace(
+                active_workspace,
+                spec,
+                capturing=capturing,
+            )
+            forward_work_items = metadata["c16_forward_work_items"].view(-1, 8)
+            backward_work_items = metadata["c16_backward_work_items"].view(-1, 5)
+            forward_descriptor_signature = tuple(
+                _tensor_signature(tensor)
+                for tensor in (
+                    q,
+                    k,
+                    v,
+                    g,
+                    c16["forward_out"],
+                    c16["state_checkpoints"],
+                )
+            )
+            descriptor_signature = tuple(
+                _tensor_signature(tensor)
+                for tensor in (
+                    q,
+                    k,
+                    v,
+                    g,
+                    do,
+                    c16["state_checkpoints"],
+                    dv,
+                    c16["beta_active"],
+                )
+            )
+            if capturing:
+                if (
+                    active_workspace._forward_descriptor_signature
+                    != forward_descriptor_signature
+                    or active_workspace._descriptor_signature != descriptor_signature
+                ):
+                    raise RuntimeError(
+                        "C16 TMA descriptors were not warmed for the exact tensor signature"
+                    )
+                prepare_forward_descriptors = 0
+                prepare_backward_descriptors = 0
+            else:
+                prepare_forward_descriptors = int(
+                    active_workspace._forward_descriptor_signature
+                    != forward_descriptor_signature
+                )
+                prepare_backward_descriptors = int(
+                    active_workspace._descriptor_signature != descriptor_signature
+                )
+            if (
+                active_workspace._descriptor_storage.numel() < _DESCRIPTOR_BYTES
+                or active_workspace._descriptor_storage.data_ptr()
+                % _DESCRIPTOR_ALIGNMENT
+                != 0
+            ):
+                raise RuntimeError("invalid C16 descriptor storage")
+            try:
+                _get_flash_kda_training_module(q.device).run_forward(
+                    q,
+                    k,
+                    v,
+                    g,
+                    beta,
+                    A_log,
+                    dt_bias,
+                    initial_state,
+                    cu_seqlens_arg,
+                    metadata["c16_checkpoint_cu_starts"],
+                    forward_work_items,
+                    active_workspace._forward_descriptor_storage,
+                    c16["forward_out"],
+                    c16["forward_final_bf16"],
+                    c16["forward_final"],
+                    c16["state_checkpoints"],
+                    c16["beta_active"],
+                    c16["counter"],
+                    prepare_forward_descriptors,
+                    spec.num_sequences,
+                    spec.num_heads,
+                    scale_value,
+                    lower_bound_value,
+                    stream_ptr,
+                )
+                module.run_c16_backward(
+                    q,
+                    k,
+                    v,
+                    g,
+                    A_log,
+                    dt_bias,
+                    do,
+                    dfinal_state,
+                    cu_seqlens_arg,
+                    backward_work_items,
+                    active_workspace._descriptor_storage,
+                    c16["state_checkpoints"],
+                    c16["beta_active"],
+                    c16["dlog_decay"],
+                    c16["dlog_boundary"],
+                    c16["dbeta_active"],
+                    c16["gate_part_a"],
+                    c16["gate_part_dt"],
+                    c16["counter"],
+                    c16["dummy_u32"],
+                    c16["dummy_f32"],
+                    dq,
+                    dk,
+                    dv,
+                    dg,
+                    dbeta,
+                    dA_log,
+                    ddt_bias,
+                    dinitial_state,
+                    prepare_backward_descriptors,
+                    spec.num_sequences,
+                    spec.num_heads,
+                    scale_value,
+                    lower_bound_value,
+                    stream_ptr,
+                )
+            except Exception:
+                if prepare_forward_descriptors:
+                    active_workspace._forward_descriptor_signature = None
+                if prepare_backward_descriptors:
+                    active_workspace._descriptor_signature = None
+                raise
+            if prepare_forward_descriptors:
+                active_workspace._forward_descriptor_signature = (
+                    forward_descriptor_signature
+                )
+            if prepare_backward_descriptors:
+                active_workspace._descriptor_signature = descriptor_signature
+        elif not spec.high_head_route:
+            (
+                q_norm,
+                k_norm,
+                decay,
+                beta_active,
+                checkpoint,
+                dq_normalized,
+                dk_normalized,
+                dlog_decay,
+                dbeta_active,
+            ) = _allocate_low_workspace(active_workspace, spec, capturing=capturing)
+            module.run_low(
+                q,
+                k,
+                v,
+                g,
+                beta,
+                A_log,
+                dt_bias,
+                initial_state,
+                do,
+                dfinal_state,
+                cu_seqlens_arg,
+                q_norm,
+                k_norm,
+                decay,
+                beta_active,
+                checkpoint,
+                dq_normalized,
+                dk_normalized,
+                dlog_decay,
+                dbeta_active,
+                dq,
+                dk,
+                dv,
+                dg,
+                dbeta,
+                dA_log,
+                ddt_bias,
+                dinitial_state,
+                spec.num_sequences,
+                spec.num_heads,
+                scale_value,
+                lower_bound_value,
+                stream_ptr,
+            )
+        else:
+            high = _allocate_high_workspace(
+                active_workspace,
+                spec,
+                beta,
+                capturing=capturing,
+            )
+            descriptor_signature = tuple(
+                _tensor_signature(tensor)
+                for tensor in (
+                    q,
+                    k,
+                    v,
+                    g,
+                    high["beta_tma"],
+                    high["q_tma_out"],
+                )
+            )
+            if capturing:
+                if active_workspace._descriptor_signature != descriptor_signature:
+                    raise RuntimeError(
+                        "high-head TMA descriptors were not warmed for the exact "
+                        "tensor signature"
+                    )
+                prepare_descriptors = 0
+            else:
+                prepare_descriptors = int(
+                    active_workspace._descriptor_signature != descriptor_signature
+                )
+            if (
+                active_workspace._descriptor_storage.numel() < _DESCRIPTOR_BYTES
+                or active_workspace._descriptor_storage.data_ptr()
+                % _DESCRIPTOR_ALIGNMENT
+                != 0
+            ):
+                raise RuntimeError("invalid high-head descriptor storage")
+            try:
+                module.run_high(
+                    q,
+                    k,
+                    v,
+                    g,
+                    beta,
+                    high["beta_tma"],
+                    A_log,
+                    dt_bias,
+                    initial_state,
+                    do,
+                    dfinal_state,
+                    cu_seqlens_arg,
+                    metadata["seq_order"],
+                    metadata["cu_chunk_offsets"],
+                    metadata["consumer_chunk_order"],
+                    metadata["chunk_sequence"],
+                    metadata["chunk_index"],
+                    metadata["chunk_pair_start"],
+                    active_workspace._descriptor_storage,
+                    high["q_tma_out"],
+                    high["forward_final"],
+                    high["chunk_state"],
+                    high["state_checkpoint_needed"],
+                    high["tape_qd"],
+                    high["tape_kd"],
+                    high["tape_kr"],
+                    high["tape_j"],
+                    high["tape_restore_factor"],
+                    high["tape_e"],
+                    high["tape_x"],
+                    high["tape_r"],
+                    high["norm_inv"],
+                    high["decay"],
+                    high["beta_active"],
+                    high["zero_workspace"],
+                    high["chunk_dh"],
+                    high["chunk_dr"],
+                    high["chunk_dx"],
+                    high["grad_qd"],
+                    high["grad_kd"],
+                    high["grad_ki"],
+                    high["dlog_decay"],
+                    high["dbeta_active"],
+                    dq,
+                    dk,
+                    dv,
+                    dg,
+                    dbeta,
+                    dA_log,
+                    ddt_bias,
+                    dinitial_state,
+                    prepare_descriptors,
+                    spec.num_sequences,
+                    spec.num_heads,
+                    scale_value,
+                    lower_bound_value,
+                    stream_ptr,
+                )
+            except Exception:
+                if prepare_descriptors:
+                    active_workspace._descriptor_signature = None
+                raise
+            if prepare_descriptors:
+                active_workspace._descriptor_signature = descriptor_signature
+
+        if not capturing:
+            active_workspace._warmed_signature = launch_signature
+        elif explicit_workspace:
+            active_workspace._captured = True
+    return outputs
+
+
+__all__ = [
+    "KDA_BACKWARD_GRADIENT_NAMES",
+    "RecurrentKDABackwardWorkspace",
+    "recurrent_kda_backward",
+]

--- a/flashinfer/kda_prefill.py
+++ b/flashinfer/kda_prefill.py
@@ -39,7 +39,7 @@ _FLASH_KDA_HEAD_DIM = 128
 _FLASH_KDA_BETA_TMA_HEADS_PER_BOX = 8
 _FLASH_KDA_SUPPORTED_COMPUTE_CAPABILITIES = {(10, 0), (10, 3)}
 _FLASH_KDA_DESCRIPTOR_STORAGE_BYTES = 6 * 128
-_FLASH_KDA_SMALL_BH_DESCRIPTOR_STORAGE_BYTES = 7 * 128
+_FLASH_KDA_SEVEN_DESCRIPTOR_STORAGE_BYTES = 7 * 128
 _FLASH_KDA_PERSISTENT_MIN_BALANCED_CTAS = 128
 _FLASH_KDA_LPT_MAX_IMBALANCE_NUMERATOR = 21
 _FLASH_KDA_LPT_MAX_IMBALANCE_DENOMINATOR = 20
@@ -78,8 +78,8 @@ class _RecurrentKDAPrefillWorkspaceBase:
         self._descriptor_storages = {
             variant: torch.empty(
                 (
-                    _FLASH_KDA_SMALL_BH_DESCRIPTOR_STORAGE_BYTES
-                    if variant == "small_bh_m128"
+                    _FLASH_KDA_SEVEN_DESCRIPTOR_STORAGE_BYTES
+                    if variant in ("m128_n16_checkpoint", "small_bh_m128")
                     else _FLASH_KDA_DESCRIPTOR_STORAGE_BYTES
                 ),
                 dtype=torch.uint8,
@@ -89,6 +89,7 @@ class _RecurrentKDAPrefillWorkspaceBase:
                 "m64",
                 "m128",
                 "m128_n16",
+                "m128_n16_checkpoint",
                 "persistent_m128",
                 "small_bh_m128",
             )
@@ -349,7 +350,7 @@ def _flash_kda_prefill_is_eligible(
     if (
         checkpoint_every_n_tokens < 0
         or checkpoint_every_n_tokens > torch.iinfo(torch.int32).max
-        or checkpoint_every_n_tokens % 32 != 0
+        or checkpoint_every_n_tokens % 16 != 0
     ):
         return False
     if checkpoint_every_n_tokens:
@@ -943,12 +944,15 @@ def _descriptor_signature(
     beta_tma: torch.Tensor,
     out: torch.Tensor,
     packet_workspace: Optional[torch.Tensor] = None,
+    state_checkpoints: Optional[torch.Tensor] = None,
 ) -> tuple:
     signature = tuple(
         _tensor_descriptor_signature(tensor) for tensor in (q, k, v, g, beta_tma, out)
     )
     if packet_workspace is not None:
         signature += (_tensor_descriptor_signature(packet_workspace),)
+    if state_checkpoints is not None:
+        signature += (_tensor_descriptor_signature(state_checkpoints),)
     return signature
 
 
@@ -1196,7 +1200,9 @@ def _run_flash_kda_prefill(
             num_heads=num_heads,
             sm_count=sm_count,
         )
-    use_exact_n16 = _requires_exact_n16_recurrence(
+    use_exact_n16 = (
+        checkpoint_every_n_tokens != 0 and checkpoint_every_n_tokens % 32 != 0
+    ) or _requires_exact_n16_recurrence(
         sm_count=sm_count,
         fixed_layout=fixed_layout,
         num_sequences=num_sequences,
@@ -1214,6 +1220,8 @@ def _run_flash_kda_prefill(
         use_small_bh_m128=small_bh_candidate,
         use_exact_n16=use_exact_n16,
     )
+    if checkpoint_every_n_tokens and variant == "m128_n16":
+        variant = "m128_n16_checkpoint"
     if fixed_layout:
         cu_seqlens_i64 = _fixed_cu_seqlens(
             device=q.device, batch_size=batch_size, seq_len=seq_len
@@ -1379,6 +1387,9 @@ def _run_flash_kda_prefill(
             beta_tma=beta_tma,
             out=out_buf,
             packet_workspace=packet_workspace,
+            state_checkpoints=(
+                state_checkpoints if variant == "m128_n16_checkpoint" else None
+            ),
         )
         warmed_signature = workspace._descriptor_signatures.get(variant)
         if capturing:

--- a/flashinfer/kda_training.py
+++ b/flashinfer/kda_training.py
@@ -1,0 +1,23 @@
+"""Paired Blackwell forward/backward training API for recurrent KDA."""
+
+from ._kda_training_impl import (
+    RecurrentKDATrainingContext,
+    _load_training_module,
+    _select_training_route as _select_training_route,
+    _validate_forward_inputs as _validate_forward_inputs,
+    recurrent_kda_training_backward,
+    recurrent_kda_training_forward,
+)
+
+
+def _get_training_module(device):
+    """Internal indirection seam used by the training API tests."""
+
+    return _load_training_module(device)
+
+
+__all__ = [
+    "RecurrentKDATrainingContext",
+    "recurrent_kda_training_backward",
+    "recurrent_kda_training_forward",
+]

--- a/tests/jit/test_flash_kda_backward_jit.py
+++ b/tests/jit/test_flash_kda_backward_jit.py
@@ -1,0 +1,213 @@
+# Copyright (c) 2026 by FlashInfer team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import re
+from types import SimpleNamespace
+
+import pytest
+from packaging.version import Version
+
+from flashinfer.jit import core as jit_core
+from flashinfer.jit import flash_kda_backward
+
+
+@pytest.mark.parametrize(
+    ("target", "arch_flag"),
+    [
+        ("sm100a", "-gencode=arch=compute_100a,code=sm_100a"),
+        ("sm103a", "-gencode=arch=compute_103a,code=sm_103a"),
+    ],
+)
+def test_flash_kda_backward_jit_spec_is_exact_blackwell(monkeypatch, target, arch_flag):
+    monkeypatch.setattr(
+        jit_core.current_compilation_context,
+        "TARGET_CUDA_ARCHS",
+        {(10, "3a")},
+    )
+    flash_kda_backward.gen_flash_kda_backward_module.cache_clear()
+
+    uri = flash_kda_backward.get_flash_kda_backward_uri(target)
+    spec = flash_kda_backward.gen_flash_kda_backward_module(target)
+
+    assert re.fullmatch(rf"flash_kda_backward_[0-9a-f]{{10}}_{target}", uri)
+    assert spec.name == uri
+    assert spec.sources == [
+        flash_kda_backward._get_flash_kda_backward_csrc_dir()
+        / "flashkda_backward_binding.cu",
+        flash_kda_backward._get_flash_kda_backward_csrc_dir()
+        / "flashkda_backward_v483_binding.cu",
+    ]
+    assert all(source.is_file() for source in spec.sources)
+    assert arch_flag in spec.extra_cuda_cflags
+    assert "-use_fast_math" in spec.extra_cuda_cflags
+    assert sum("-gencode=arch=compute_" in flag for flag in spec.extra_cuda_cflags) == 1
+
+    generated_binding = spec.sources[0].read_text()
+    assert '#include "flashkda_backward.cu"' in generated_binding
+    assert "TVM_FFI_DLL_EXPORT_TYPED_FUNC(run_low" in generated_binding
+    assert "TVM_FFI_DLL_EXPORT_TYPED_FUNC(run_high" in generated_binding
+    assert (
+        "TVM_FFI_DLL_EXPORT_TYPED_FUNC(run_c16_backward" in spec.sources[1].read_text()
+    )
+    flash_kda_backward.gen_flash_kda_backward_module.cache_clear()
+
+
+def test_flash_kda_backward_getter_uses_one_module(monkeypatch):
+    sentinel = object()
+    monkeypatch.setattr(
+        flash_kda_backward,
+        "load_flash_kda_backward_module",
+        lambda target: (target, sentinel),
+    )
+    assert flash_kda_backward.get_flash_kda_backward_module("sm100a") == (
+        "sm100a",
+        sentinel,
+    )
+
+
+def test_flash_kda_backward_binding_contract():
+    binding = (
+        flash_kda_backward._get_flash_kda_backward_csrc_dir()
+        / "flashkda_backward_binding.cu"
+    ).read_text()
+
+    assert "CheckExactBlackwellTarget" in binding
+    assert "FLASHINFER_FLASH_KDA_TARGET_MINOR" in binding
+    assert "scale=1/sqrt(128)" in binding
+    assert "lower_bound=-5.0" in binding
+    assert "descriptor_storage must provide at least 768 bytes" in binding
+    assert "descriptor_storage must be 64-byte aligned" in binding
+    assert "reinterpret_cast<cudaStream_t>" in binding
+    assert "TVM_FFI_DLL_EXPORT_TYPED_FUNC(run_low" in binding
+    assert "TVM_FFI_DLL_EXPORT_TYPED_FUNC(run_high" in binding
+
+
+@pytest.mark.parametrize(
+    ("target_archs", "cuda_version", "expected"),
+    [
+        ({(10, "3a")}, "12.9", True),
+        ({(10, "3a")}, "12.8", False),
+        ({(10, "0a")}, "12.9", False),
+    ],
+)
+def test_flash_kda_backward_aot_capability_gate(
+    monkeypatch, target_archs, cuda_version, expected
+):
+    from flashinfer import aot
+
+    class FakeCompilationContext:
+        TARGET_CUDA_ARCHS = target_archs
+
+        def get_nvcc_flags_list(self, supported_major_versions=None):
+            del supported_major_versions
+            return [
+                f"-gencode=arch=compute_{major}{minor},code=sm_{major}{minor}"
+                for major, minor in sorted(self.TARGET_CUDA_ARCHS)
+            ]
+
+    monkeypatch.setattr(aot, "CompilationContext", FakeCompilationContext)
+    monkeypatch.setattr(aot, "get_cuda_version", lambda: Version(cuda_version))
+    capabilities = aot.detect_sm_capabilities()
+    assert capabilities["flash_kda_backward_sm103a"] is expected
+
+
+@pytest.mark.parametrize(
+    ("target_archs", "cuda_version", "expected"),
+    [
+        ({(10, "0a")}, "12.8", True),
+        ({(10, "0a")}, "12.7", False),
+        ({(10, "3a")}, "12.9", False),
+    ],
+)
+def test_flash_kda_backward_sm100a_aot_capability_gate(
+    monkeypatch, target_archs, cuda_version, expected
+):
+    from flashinfer import aot
+
+    class FakeCompilationContext:
+        TARGET_CUDA_ARCHS = target_archs
+
+        def get_nvcc_flags_list(self, supported_major_versions=None):
+            del supported_major_versions
+            return []
+
+    monkeypatch.setattr(aot, "CompilationContext", FakeCompilationContext)
+    monkeypatch.setattr(aot, "get_cuda_version", lambda: Version(cuda_version))
+    capabilities = aot.detect_sm_capabilities()
+    assert capabilities["flash_kda_backward_sm100a"] is expected
+
+
+def test_aot_registers_flash_kda_backward(monkeypatch):
+    from flashinfer import aot
+
+    calls = []
+
+    def fake_flash_kda_backward(target):
+        calls.append(target)
+        return SimpleNamespace(name=f"flash_kda_backward_{target}")
+
+    training_calls = []
+
+    def fake_flash_kda_training(target):
+        training_calls.append(target)
+        return SimpleNamespace(name=f"flash_kda_training_{target}")
+
+    monkeypatch.setattr(
+        aot,
+        "gen_flash_kda_backward_module",
+        fake_flash_kda_backward,
+    )
+    monkeypatch.setattr(
+        aot,
+        "gen_flash_kda_training_module",
+        fake_flash_kda_training,
+    )
+    monkeypatch.setattr(
+        aot, "gen_spdlog_module", lambda: SimpleNamespace(name="spdlog")
+    )
+    monkeypatch.setattr(aot, "gen_attention", lambda *args: ())
+    monkeypatch.setattr(
+        aot, "gen_cudnn_fmha_module", lambda: SimpleNamespace(name="cudnn")
+    )
+
+    specs = aot.gen_all_modules(
+        [],
+        [],
+        [],
+        [],
+        [],
+        [],
+        {
+            "flash_kda_backward_sm100a": True,
+            "flash_kda_backward_sm103a": True,
+        },
+        False,
+        False,
+        False,
+        False,
+        False,
+        False,
+        False,
+    )
+
+    assert calls == ["sm100a", "sm103a"]
+    assert training_calls == ["sm100a", "sm103a"]
+    assert [spec.name for spec in specs] == [
+        "spdlog",
+        "flash_kda_backward_sm100a",
+        "flash_kda_training_sm100a",
+        "flash_kda_backward_sm103a",
+        "flash_kda_training_sm103a",
+        "cudnn",
+    ]

--- a/tests/jit/test_flash_kda_training_jit.py
+++ b/tests/jit/test_flash_kda_training_jit.py
@@ -1,0 +1,166 @@
+# Copyright (c) 2026 by FlashInfer team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+import hashlib
+import re
+
+import pytest
+
+from flashinfer.jit import flash_kda, flash_kda_training
+
+
+@pytest.mark.parametrize(
+    ("target", "arch_flag"),
+    [
+        ("sm100a", "-gencode=arch=compute_100a,code=sm_100a"),
+        ("sm103a", "-gencode=arch=compute_103a,code=sm_103a"),
+    ],
+)
+def test_flash_kda_training_jit_spec(target, arch_flag):
+    flash_kda_training.gen_flash_kda_training_module.cache_clear()
+    uri = flash_kda_training.get_flash_kda_training_uri(target)
+    spec = flash_kda_training.gen_flash_kda_training_module(target)
+    assert re.fullmatch(rf"flash_kda_training_[0-9a-f]{{10}}_{target}", uri)
+    assert spec.name == uri
+    assert [source.name for source in spec.sources] == [
+        "flashkda_training_forward_v483_binding.cu",
+        "flashkda_training_paired_binding.cu",
+        "flashkda_training_fallback_binding.cu",
+        "flashkda_training_c16.cu",
+        "flashkda_training_aux.cu",
+        "flashkda_training_final_state.cu",
+        f"training_fallback_pointer_{target.replace('sm', 'sm_', 1)}.cu",
+    ]
+    assert all(source.is_file() for source in spec.sources)
+    common = flash_kda_training._get_csrc_dir() / "flashkda_binding_common.cuh"
+    source_digest = hashlib.sha256(
+        b"\0".join(source.read_bytes() for source in (*spec.sources, common))
+    ).hexdigest()[:10]
+    assert uri == f"flash_kda_training_{source_digest}_{target}"
+    assert arch_flag in spec.extra_cuda_cflags
+    assert "-use_fast_math" in spec.extra_cuda_cflags
+    (
+        legacy_binding,
+        paired_binding,
+        fallback_binding,
+        c16,
+        auxiliary,
+        final_state,
+        fallback,
+    ) = (source.read_text() for source in spec.sources)
+    assert '#include "flashkda_training_forward_v483.cu"' not in legacy_binding
+    assert "TVM_FFI_DLL_EXPORT_TYPED_FUNC(run_forward" in legacy_binding
+    assert "TVM_FFI_DLL_EXPORT_TYPED_FUNC(run_training_forward" in paired_binding
+    assert "TVM_FFI_DLL_EXPORT_TYPED_FUNC(run_training_backward" in paired_binding
+    assert "TVM_FFI_DLL_EXPORT_TYPED_FUNC(run_training_c32_forward" in fallback_binding
+    assert "TVM_FFI_DLL_EXPORT_TYPED_FUNC(run_training_c32_backward" in fallback_binding
+    assert "kernel_flashkda_forward_checkpoint_c16" in c16
+    assert "kernel_flashkda_backward_persistent_c16" in c16
+    assert "kernel_flashkda_refine_forgetting_horizons" in auxiliary
+    assert "kernel_flashkda_backward_param_reduce_c16_partial" in auxiliary
+    assert "kernel_flashkda_grouped_qk_reduce" in auxiliary
+    assert "kernel_flashkda_blackwell_prefill_fp32_state_initial" in final_state
+    assert "kernel_flashkda_backward_state_checkpoint_fallback_c32" in fallback
+    assert "kernel_flashkda_bf16_fused_m128_unsplit" in fallback
+    assert "kernel_flashkda_bf16_fused_m128_unsplit" in fallback_binding
+    assert "use_split_work_items" in fallback_binding
+    assert "seq_order" in fallback_binding
+    assert "#define SPLIT_WORK_ITEMS 0" in fallback
+    assert "#define SPLIT_WORK_ITEMS 1" in fallback
+    for workspace in (
+        "dq_normalized",
+        "dk_normalized",
+        "dlog_decay",
+        "dbeta_active",
+    ):
+        assert f"clear row {workspace}" in fallback_binding
+    flash_kda_training.gen_flash_kda_training_module.cache_clear()
+
+
+def test_training_forward_frozen_specialization_contract():
+    csrc_dir = flash_kda_training._get_csrc_dir()
+    c16 = (csrc_dir / "flashkda_training_c16.cu").read_text()
+    final_state = (csrc_dir / "flashkda_training_final_state.cu").read_text()
+    paired_binding = (csrc_dir / "flashkda_training_paired_binding.cu").read_text()
+    assert "STORE_BETA_ACTIVE 1" in c16
+    assert "G_INPUT_BF16 1" in c16
+    assert "STORE_FINAL_STATE 0" in c16
+    assert "#define validate_outputs 0" in c16
+    assert "USE_INITIAL_STATE 1" in final_state
+    assert "STORE_FINAL_STATE 1" in final_state
+    assert "ENABLE_CHECKPOINTS 0" in final_state
+    assert "CastFinalState" not in paired_binding
+    assert "final_output_scratch" in paired_binding
+    assert "dl_float32" in paired_binding
+
+
+def test_paired_backward_binding_has_no_forward_recompute_symbols():
+    """Every route consumes context produced by the paired forward."""
+
+    paired_binding = (
+        flash_kda_training._get_csrc_dir() / "flashkda_training_paired_binding.cu"
+    ).read_text()
+    backward = paired_binding.split("void RunTrainingBackward(", 1)[1]
+    backward = backward.split("}  // namespace flash_kda_training_paired", 1)[0]
+    assert "run_training_forward" not in backward
+    assert not re.search(r"kernel_flashkda_[A-Za-z0-9_]*forward", backward)
+    assert "RunLow(" not in backward
+    assert "RunHigh(" not in backward
+
+    fallback_binding = (
+        flash_kda_training._get_csrc_dir() / "flashkda_training_fallback_binding.cu"
+    ).read_text()
+    row_backward = fallback_binding.split("void RunTrainingRowBackward(", 1)[1]
+    row_backward = row_backward.split("void RunTrainingC32Forward(", 1)[0]
+    c32_backward = fallback_binding.split("void RunTrainingC32Backward(", 1)[1]
+    c32_backward = c32_backward.split("}  // namespace flash_kda_training_fallback", 1)[
+        0
+    ]
+    for fallback_backward in (row_backward, c32_backward):
+        assert "LaunchAccurateForward" not in fallback_backward
+        assert "run_training_forward" not in fallback_backward
+
+
+@pytest.mark.parametrize("target", ["sm100a", "sm100f"])
+def test_checkpoint_n16_prefill_jit_spec(target):
+    flash_kda.gen_flash_kda_module.cache_clear()
+    uri = flash_kda.get_flash_kda_uri("m128_n16_checkpoint", target)
+    spec = flash_kda.gen_flash_kda_m128_n16_checkpoint_module(target)
+    assert re.fullmatch(
+        rf"flash_kda_bf16_m128_n16_checkpoint_[0-9a-f]{{10}}_{target}", uri
+    )
+    assert spec.name == uri
+    assert len(spec.sources) == 1
+    binding = spec.sources[0].read_text()
+    body = (
+        flash_kda._get_flash_kda_csrc_dir()
+        / "flashkda_bf16_fused_m128_n16_checkpoint.cu"
+    ).read_text()
+    assert spec.sources[0].name == (
+        "flashkda_bf16_fused_m128_n16_checkpoint_binding.cu"
+    )
+    assert (
+        "checkpoint N16 descriptor_storage must provide at least 896 bytes" in binding
+    )
+    assert "PublishCheckpointMap" in binding
+    assert "state_checkpoints_tma" in body
+    assert "flashkda_checkpoint_generated_LoomTensorMap" in binding
+    common = flash_kda._get_flash_kda_csrc_dir() / "flashkda_binding_common.cuh"
+    source_digest = hashlib.sha256(
+        b"\0".join(
+            source.read_bytes()
+            for source in (
+                flash_kda._get_flash_kda_csrc_dir()
+                / "flashkda_bf16_fused_m128_n16_checkpoint.cu",
+                spec.sources[0],
+                common,
+            )
+        )
+    ).hexdigest()[:10]
+    assert uri == f"flash_kda_bf16_m128_n16_checkpoint_{source_digest}_{target}"
+    flash_kda.gen_flash_kda_module.cache_clear()

--- a/tests/kda/test_recurrent_kda_backward.py
+++ b/tests/kda/test_recurrent_kda_backward.py
@@ -1,0 +1,484 @@
+# Copyright (c) 2026 by FlashInfer team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import math
+import os
+
+import pytest
+import torch
+
+from flashinfer import kda_backward as kda_backward_api
+from flashinfer.kda_backward import (
+    KDA_BACKWARD_GRADIENT_NAMES,
+    RecurrentKDABackwardWorkspace,
+    recurrent_kda_backward,
+)
+
+
+SUPPORTED_CASES = (
+    ("fixed_t17_h1", (17,), 1, False),
+    ("packed_17_33_65_h4", (17, 33, 65), 4, True),
+    ("fixed_t17_h16", (17,), 16, False),
+    ("fixed_t1024_h4", (1024,), 4, False),
+    ("fixed_t4096_h32", (4096,), 32, False),
+    ("fixed_t8192_h96", (8192,), 96, False),
+    (
+        "packed_1300_547_2048_963_271_3063_h96",
+        (1300, 547, 2048, 963, 271, 3063),
+        96,
+        True,
+    ),
+    ("packed_1024x8_h96", (1024,) * 8, 96, True),
+)
+
+
+def _offsets(seq_lens):
+    result = [0]
+    for length in seq_lens:
+        result.append(result[-1] + length)
+    return tuple(result)
+
+
+def _make_inputs(seq_lens, num_heads, packed, *, seed=0):
+    total_tokens = sum(seq_lens)
+    device = torch.device("cuda")
+    generator = torch.Generator(device=device).manual_seed(seed)
+    token_shape = (1, total_tokens, num_heads, 128)
+    state_shape = (len(seq_lens), num_heads, 128, 128)
+
+    def bf16(shape, multiplier=1.0):
+        return (
+            torch.randn(shape, generator=generator, device=device, dtype=torch.float32)
+            * multiplier
+        ).to(torch.bfloat16)
+
+    inputs = {
+        "q": bf16(token_shape),
+        "k": bf16(token_shape),
+        "v": bf16(token_shape),
+        "g": bf16(token_shape, 0.1),
+        "beta": bf16(token_shape[:-1]),
+        "A_log": torch.log(
+            torch.rand(
+                (num_heads,), generator=generator, device=device, dtype=torch.float32
+            )
+            + 1.0
+        ),
+        "dt_bias": torch.randn(
+            (num_heads, 128),
+            generator=generator,
+            device=device,
+            dtype=torch.float32,
+        )
+        * 0.1,
+        "initial_state": torch.randn(
+            state_shape,
+            generator=generator,
+            device=device,
+            dtype=torch.float32,
+        )
+        * 0.02,
+        "do": bf16(token_shape, 0.1),
+        "dfinal_state": torch.randn(
+            state_shape,
+            generator=generator,
+            device=device,
+            dtype=torch.float32,
+        )
+        * 0.1,
+        "cu_seqlens": (
+            torch.tensor(_offsets(seq_lens), dtype=torch.int64, device=device)
+            if packed
+            else None
+        ),
+    }
+    return inputs
+
+
+def _make_outputs(inputs):
+    return (
+        torch.empty_like(inputs["q"]),
+        torch.empty_like(inputs["q"]),
+        torch.empty_like(inputs["q"]),
+        torch.empty_like(inputs["q"]),
+        torch.empty_like(inputs["beta"]),
+        torch.empty_like(inputs["A_log"]),
+        torch.empty_like(inputs["dt_bias"]),
+        torch.empty_like(inputs["initial_state"]),
+    )
+
+
+def _reference(inputs, seq_lens):
+    names = (
+        "q",
+        "k",
+        "v",
+        "g",
+        "beta",
+        "A_log",
+        "dt_bias",
+        "initial_state",
+    )
+    leaves = {
+        name: inputs[name].detach().clone().requires_grad_(True) for name in names
+    }
+    q_raw = leaves["q"].float()
+    k_raw = leaves["k"].float()
+    q = q_raw * torch.rsqrt((q_raw * q_raw).sum(-1, keepdim=True) + 1e-6)
+    k = k_raw * torch.rsqrt((k_raw * k_raw).sum(-1, keepdim=True) + 1e-6)
+    heads = inputs["q"].shape[2]
+    q = q.reshape(-1, heads, 128)
+    k = k.reshape_as(q)
+    v = leaves["v"].float().reshape_as(q)
+    g = leaves["g"].float().reshape_as(q)
+    beta = torch.sigmoid(leaves["beta"].float().reshape(-1, heads))
+    decay = torch.exp(
+        -5.0
+        * torch.sigmoid(
+            leaves["A_log"].exp().view(1, heads, 1)
+            * (g + leaves["dt_bias"].view(1, heads, 128))
+        )
+    )
+    states = list(leaves["initial_state"].unbind(0))
+    token = 0
+    outputs = []
+    for sequence, length in enumerate(seq_lens):
+        state = states[sequence]
+        for _ in range(length):
+            decayed = state * decay[token].unsqueeze(1)
+            prediction = torch.einsum("hk,hvk->hv", k[token], decayed)
+            residual = beta[token].unsqueeze(-1) * (v[token] - prediction)
+            state = decayed + residual.unsqueeze(-1) * k[token].unsqueeze(1)
+            outputs.append(
+                (1.0 / math.sqrt(128)) * torch.einsum("hk,hvk->hv", q[token], state)
+            )
+            token += 1
+        states[sequence] = state
+    output = torch.stack(outputs).reshape_as(inputs["q"]).to(torch.bfloat16)
+    final_state = torch.stack(states)
+    loss = output.float().mul(inputs["do"].float()).sum()
+    loss = loss + final_state.mul(inputs["dfinal_state"]).sum()
+    return torch.autograd.grad(loss, tuple(leaves[name] for name in names))
+
+
+def _fla_reference(inputs):
+    os.environ.setdefault("FLA_FLASH_KDA", "0")
+    kda_ops = pytest.importorskip("fla.ops.kda")
+    names = (
+        "q",
+        "k",
+        "v",
+        "g",
+        "beta",
+        "A_log",
+        "dt_bias",
+        "initial_state",
+    )
+    leaves = {
+        name: inputs[name].detach().clone().requires_grad_(True) for name in names
+    }
+    leaves["dt_bias"] = (
+        inputs["dt_bias"].detach().reshape(-1).clone().requires_grad_(True)
+    )
+    cu_seqlens = inputs["cu_seqlens"]
+    output, final_state = kda_ops.chunk_kda(
+        leaves["q"],
+        leaves["k"],
+        leaves["v"],
+        leaves["g"],
+        leaves["beta"],
+        scale=1.0 / math.sqrt(128),
+        initial_state=leaves["initial_state"],
+        output_final_state=True,
+        use_qk_l2norm_in_kernel=True,
+        use_gate_in_kernel=True,
+        use_beta_sigmoid_in_kernel=True,
+        safe_gate=True,
+        lower_bound=-5.0,
+        state_v_first=True,
+        cu_seqlens=cu_seqlens,
+        cu_seqlens_cpu=(None if cu_seqlens is None else cu_seqlens.detach().cpu()),
+        A_log=leaves["A_log"],
+        dt_bias=leaves["dt_bias"],
+        chunk_size=32,
+    )
+    gradients = torch.autograd.grad(
+        (output, final_state),
+        tuple(leaves[name] for name in names),
+        grad_outputs=(inputs["do"], inputs["dfinal_state"]),
+        allow_unused=False,
+    )
+    return (
+        *gradients[:-2],
+        gradients[-2].reshape_as(inputs["dt_bias"]),
+        gradients[-1],
+    )
+
+
+class _RecorderModule:
+    def __init__(self):
+        self.low_calls = []
+        self.high_calls = []
+        self.c16_calls = []
+
+    def run_low(self, *args):
+        self.low_calls.append(args)
+
+    def run_high(self, *args):
+        self.high_calls.append(args)
+
+    def run_c16_backward(self, *args):
+        self.c16_calls.append(args)
+
+
+def _require_cuda():
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is required")
+
+
+def _require_blackwell():
+    _require_cuda()
+    if torch.cuda.get_device_capability() not in {(10, 0), (10, 3)}:
+        pytest.skip("the frozen KDA backward requires compute capability 10.0 or 10.3")
+
+
+@pytest.mark.parametrize(("name", "seq_lens", "num_heads", "packed"), SUPPORTED_CASES)
+def test_exact_supported_shape_table(name, seq_lens, num_heads, packed):
+    spec = kda_backward_api._select_shape(
+        (1, sum(seq_lens), num_heads, 128),
+        len(seq_lens) + 1 if packed else None,
+    )
+    assert spec.name == name
+    assert spec.seq_lens == seq_lens
+
+
+@pytest.mark.parametrize(
+    ("shape", "cu_numel"),
+    [
+        ((1, 18, 1, 128), None),
+        ((2, 17, 1, 128), None),
+        ((1, 115, 4, 128), None),
+        ((1, 8192, 96, 128), 5),
+        ((1, 8192, 64, 128), None),
+        ((1, 17, 16, 64), None),
+    ],
+)
+def test_unsupported_shapes_are_rejected(shape, cu_numel):
+    with pytest.raises(ValueError, match="eight documented"):
+        kda_backward_api._select_shape(shape, cu_numel)
+
+
+def test_high_metadata_matches_chunk_schedule():
+    spec = kda_backward_api._select_shape((1, 115, 4, 128), 4)
+    metadata = kda_backward_api._metadata_values(spec)
+    assert metadata["fixed_cu_seqlens"] == (0, 17, 50, 115)
+    assert metadata["cu_chunk_offsets"] == (0, 1, 3, 6)
+    assert metadata["seq_order"] == (2, 1, 0)
+    assert metadata["chunk_sequence"] == (0, 1, 1, 2, 2, 2)
+    assert metadata["chunk_index"] == (0, 0, 1, 0, 1, 2)
+    assert metadata["consumer_chunk_order"] == (5, 2, 0, 4, 1, 3)
+    assert metadata["chunk_pair_start"] == (0, 1, 3, 5)
+
+
+def test_c16_metadata_matches_uniform_packed_schedule():
+    spec = kda_backward_api._select_shape((1, 8192, 96, 128), 9)
+    assert spec.c16_route
+    metadata = kda_backward_api._metadata_values(spec)
+    assert metadata["c16_checkpoint_cu_starts"] == tuple(range(0, 513, 64))
+    assert len(metadata["c16_forward_work_items"]) == 8 * 96 * 8
+    assert len(metadata["c16_backward_work_items"]) == 8 * 96 * 5
+    assert metadata["c16_forward_work_items"][:8] == (0, 0, 0, 64, 0, 64, 0, 1024)
+    assert metadata["c16_backward_work_items"][-5:] == (7, 95, 0, 64, 64)
+
+
+@pytest.mark.parametrize(
+    ("q_shape", "cu_numel"),
+    [
+        ((1, 4096, 32, 128), None),
+        ((1, 8192, 96, 128), None),
+        ((1, 8192, 96, 128), 7),
+    ],
+)
+def test_c16_route_rejects_other_supported_shapes(q_shape, cu_numel):
+    spec = kda_backward_api._select_shape(q_shape, cu_numel)
+    assert not spec.c16_route
+
+
+def test_packed_offsets_with_same_total_and_count_are_rejected(monkeypatch):
+    _require_cuda()
+    monkeypatch.setattr(kda_backward_api, "get_compute_capability", lambda _: (10, 3))
+    recorder = _RecorderModule()
+    monkeypatch.setattr(
+        kda_backward_api, "_get_flash_kda_backward_module", lambda _: recorder
+    )
+    inputs = _make_inputs((17, 33, 65), 4, True)
+    inputs["cu_seqlens"] = torch.tensor(
+        (0, 18, 50, 115), dtype=torch.int64, device="cuda"
+    )
+    with pytest.raises(ValueError, match="requires cu_seqlens"):
+        recurrent_kda_backward(**inputs)
+    assert not recorder.low_calls
+    assert not recorder.high_calls
+
+
+@pytest.mark.parametrize(
+    ("scale", "lower_bound", "match"),
+    [
+        (0.1, -5.0, "scale=1/sqrt"),
+        (1.0 / math.sqrt(128), -4.0, "lower_bound=-5.0"),
+    ],
+)
+def test_scale_and_lower_bound_are_fixed(monkeypatch, scale, lower_bound, match):
+    _require_cuda()
+    monkeypatch.setattr(kda_backward_api, "get_compute_capability", lambda _: (10, 3))
+    inputs = _make_inputs((17,), 1, False)
+    with pytest.raises(ValueError, match=match):
+        recurrent_kda_backward(
+            **inputs,
+            scale=scale,
+            lower_bound=lower_bound,
+        )
+
+
+def test_low_ffi_abi(monkeypatch):
+    _require_cuda()
+    monkeypatch.setattr(kda_backward_api, "get_compute_capability", lambda _: (10, 3))
+    recorder = _RecorderModule()
+    monkeypatch.setattr(
+        kda_backward_api, "_get_flash_kda_backward_module", lambda _: recorder
+    )
+    inputs = _make_inputs((17,), 1, False)
+    outputs = _make_outputs(inputs)
+    actual = recurrent_kda_backward(**inputs, out=outputs)
+    assert tuple(tensor.data_ptr() for tensor in actual) == tuple(
+        tensor.data_ptr() for tensor in outputs
+    )
+    assert len(recorder.low_calls) == 1
+    assert not recorder.high_calls
+    args = recorder.low_calls[0]
+    assert len(args) == 33
+    assert args[0].data_ptr() == inputs["q"].data_ptr()
+    assert args[10].dtype == torch.int64
+    assert tuple(args[10].cpu().tolist()) == (0, 17)
+    assert args[20].data_ptr() == outputs[0].data_ptr()
+    assert args[27].data_ptr() == outputs[7].data_ptr()
+    assert args[28:30] == (1, 1)
+
+
+def test_high_ffi_abi_and_capture_prepare_flag(monkeypatch):
+    _require_cuda()
+    monkeypatch.setattr(kda_backward_api, "get_compute_capability", lambda _: (10, 3))
+    recorder = _RecorderModule()
+    monkeypatch.setattr(
+        kda_backward_api, "_get_flash_kda_backward_module", lambda _: recorder
+    )
+    capturing = iter((False, True))
+    monkeypatch.setattr(
+        torch.cuda, "is_current_stream_capturing", lambda: next(capturing)
+    )
+    inputs = _make_inputs((17,), 16, False)
+    outputs = _make_outputs(inputs)
+    workspace = RecurrentKDABackwardWorkspace("cuda")
+    recurrent_kda_backward(**inputs, workspace=workspace, out=outputs)
+    recurrent_kda_backward(**inputs, workspace=workspace, out=outputs)
+
+    assert len(recorder.high_calls) == 2
+    assert not recorder.low_calls
+    warm_args, capture_args = recorder.high_calls
+    assert len(warm_args) == 57
+    assert warm_args[-6] == 1
+    assert capture_args[-6] == 0
+    descriptor = warm_args[18]
+    assert descriptor.dtype == torch.uint8
+    assert descriptor.numel() >= 768
+    assert descriptor.data_ptr() % 64 == 0
+    assert warm_args[5].shape == (32, 16)
+    assert warm_args[34].shape == (16,)
+    assert tuple(warm_args[12].cpu().tolist()) == (0,)
+    assert tuple(warm_args[13].cpu().tolist()) == (0, 1)
+
+
+@pytest.mark.parametrize(
+    ("seq_lens", "num_heads", "packed"),
+    [
+        ((17,), 1, False),
+        ((17, 33, 65), 4, True),
+        ((17,), 16, False),
+    ],
+)
+def test_backward_matches_pytorch_reference(seq_lens, num_heads, packed):
+    _require_blackwell()
+    inputs = _make_inputs(seq_lens, num_heads, packed, seed=1234)
+    expected = _reference(inputs, seq_lens)
+    actual = recurrent_kda_backward(**inputs)
+    assert tuple(KDA_BACKWARD_GRADIENT_NAMES) == (
+        "dq",
+        "dk",
+        "dv",
+        "dg",
+        "dbeta",
+        "dA_log",
+        "ddt_bias",
+        "dinitial_state",
+    )
+    for name, actual_tensor, expected_tensor in zip(
+        KDA_BACKWARD_GRADIENT_NAMES, actual, expected, strict=True
+    ):
+        torch.testing.assert_close(
+            actual_tensor,
+            expected_tensor,
+            atol=1e-2,
+            rtol=1e-2,
+            msg=lambda message: f"{name}: {message}",
+        )
+
+
+@pytest.mark.parametrize(("name", "seq_lens", "num_heads", "packed"), SUPPORTED_CASES)
+def test_backward_matches_fla_reference_all_supported_shapes(
+    name, seq_lens, num_heads, packed
+):
+    _require_blackwell()
+    inputs = _make_inputs(seq_lens, num_heads, packed, seed=1234)
+    expected = _fla_reference(inputs)
+    actual = recurrent_kda_backward(**inputs)
+    for gradient_name, actual_tensor, expected_tensor in zip(
+        KDA_BACKWARD_GRADIENT_NAMES, actual, expected, strict=True
+    ):
+        torch.testing.assert_close(
+            actual_tensor,
+            expected_tensor,
+            atol=1e-2,
+            rtol=1e-2,
+            msg=lambda message: f"{name}/{gradient_name}: {message}",
+        )
+
+
+def test_cuda_graph_capture_after_exact_warmup():
+    _require_blackwell()
+    inputs = _make_inputs((17,), 16, False, seed=4321)
+    outputs = _make_outputs(inputs)
+    workspace = RecurrentKDABackwardWorkspace("cuda")
+    stream = torch.cuda.Stream()
+    stream.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(stream):
+        recurrent_kda_backward(**inputs, workspace=workspace, out=outputs)
+    stream.synchronize()
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph, stream=stream):
+        recurrent_kda_backward(**inputs, workspace=workspace, out=outputs)
+    graph.replay()
+    torch.cuda.synchronize()
+    for tensor in outputs:
+        assert torch.isfinite(tensor).all()

--- a/tests/kda/test_recurrent_kda_prefill.py
+++ b/tests/kda/test_recurrent_kda_prefill.py
@@ -1506,10 +1506,10 @@ def test_strided_beta_indexed_state_and_checkpoints_reach_native_ffi(
     inputs["initial_state"] = state_pool
 
     checkpoint_cu_starts = torch.tensor(
-        [0, 2, 5], dtype=torch.int64, device=cuda_device
+        [0, 5, 14], dtype=torch.int64, device=cuda_device
     )
     state_checkpoints = torch.empty(
-        (5, 12, 128, 128), dtype=torch.bfloat16, device=cuda_device
+        (14, 12, 128, 128), dtype=torch.bfloat16, device=cuda_device
     )
     output, returned_state, returned_checkpoints = recurrent_kda(
         **_strict_prefill_kwargs(inputs),
@@ -1518,12 +1518,12 @@ def test_strided_beta_indexed_state_and_checkpoints_reach_native_ffi(
         ssm_state_indices=state_indices,
         state_checkpoints=state_checkpoints,
         checkpoint_cu_starts=checkpoint_cu_starts,
-        checkpoint_every_n_tokens=64,
+        checkpoint_every_n_tokens=16,
     )
     assert output.shape == inputs["q"].shape
     assert returned_state is state_pool
     assert returned_checkpoints is state_checkpoints
-    assert routes == [("m128_n16", "sm100f")]
+    assert routes == [("m128_n16_checkpoint", "sm100f")]
     (args,) = module.calls
     assert len(args) == 28
     assert args[4].data_ptr() == inputs["beta"].data_ptr()
@@ -1535,7 +1535,7 @@ def test_strided_beta_indexed_state_and_checkpoints_reach_native_ffi(
     assert args[15].data_ptr() == checkpoint_cu_starts.data_ptr()
     assert args[19] == inputs["beta"].stride(-2)
     assert args[20] == state_pool.stride(0)
-    assert args[21:25] == (1, 1, 1, 64)
+    assert args[21:25] == (1, 1, 1, 16)
 
 
 def test_unaligned_strided_beta_uses_internal_tma_workspace(cuda_device, monkeypatch):
@@ -2258,6 +2258,7 @@ def test_frozen_prefill_h12_packed_matches_reference(flash_kda_device):
 def test_frozen_prefill_h12_strided_beta_indexed_state_and_checkpoints_match_reference(
     flash_kda_device,
 ):
+    checkpoint_interval = 16
     inputs = _make_inputs(
         seq_lens=[65, 131],
         num_heads=12,
@@ -2275,7 +2276,7 @@ def test_frozen_prefill_h12_strided_beta_indexed_state_and_checkpoints_match_ref
     inputs["beta"] = beta_carrier[None, :, 8:20]
     expected_output, expected_state, expected_checkpoints = _chunk16_debug_reference(
         {**inputs, "initial_state": compact_initial_state},
-        checkpoint_every_n_tokens=64,
+        checkpoint_every_n_tokens=checkpoint_interval,
     )
 
     state_slot_numel = 12 * 128 * 128
@@ -2294,10 +2295,10 @@ def test_frozen_prefill_h12_strided_beta_indexed_state_and_checkpoints_match_ref
     untouched_before = state_pool[[0, 2, 4]].clone()
     inputs["initial_state"] = state_pool
     checkpoint_cu_starts = torch.tensor(
-        [0, 2, 5], dtype=torch.int64, device=flash_kda_device
+        [0, 5, 14], dtype=torch.int64, device=flash_kda_device
     )
     state_checkpoints = torch.empty(
-        (5, 12, 128, 128), dtype=torch.bfloat16, device=flash_kda_device
+        (14, 12, 128, 128), dtype=torch.bfloat16, device=flash_kda_device
     )
 
     actual_output, actual_state, actual_checkpoints = recurrent_kda(
@@ -2307,7 +2308,7 @@ def test_frozen_prefill_h12_strided_beta_indexed_state_and_checkpoints_match_ref
         ssm_state_indices=state_indices,
         state_checkpoints=state_checkpoints,
         checkpoint_cu_starts=checkpoint_cu_starts,
-        checkpoint_every_n_tokens=64,
+        checkpoint_every_n_tokens=checkpoint_interval,
     )
 
     assert actual_state is state_pool

--- a/tests/kda/test_recurrent_kda_training.py
+++ b/tests/kda/test_recurrent_kda_training.py
@@ -1,0 +1,682 @@
+# Copyright (c) 2026 by FlashInfer team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+import inspect
+import math
+import os
+
+import pytest
+import torch
+
+from flashinfer import kda_training as kda_training_api
+from flashinfer.kda_training import (
+    RecurrentKDATrainingContext,
+    recurrent_kda_training_backward,
+    recurrent_kda_training_forward,
+)
+
+
+class _TrainingRecorder:
+    def __init__(self):
+        self.forward_calls = []
+        self.backward_calls = []
+        self.row_forward_calls = []
+        self.row_backward_calls = []
+        self.c32_forward_calls = []
+        self.c32_backward_calls = []
+
+    def run_training_forward(self, *args):
+        assert len(args) == 37
+        self.forward_calls.append(args)
+
+    def run_training_backward(self, *args):
+        assert len(args) == 43
+        self.backward_calls.append(args)
+
+    def run_training_row_forward(self, *args):
+        assert len(args) == 28
+        self.row_forward_calls.append(args)
+
+    def run_training_row_backward(self, *args):
+        assert len(args) == 33
+        self.row_backward_calls.append(args)
+
+    def run_training_c32_forward(self, *args):
+        assert len(args) == 51
+        self.c32_forward_calls.append(args)
+
+    def run_training_c32_backward(self, *args):
+        assert len(args) == 60
+        self.c32_backward_calls.append(args)
+
+
+def test_training_api_signatures_and_no_forward_recompute():
+    forward_parameters = tuple(
+        inspect.signature(recurrent_kda_training_forward).parameters
+    )
+    backward_parameters = tuple(
+        inspect.signature(recurrent_kda_training_backward).parameters
+    )
+    assert forward_parameters[:9] == (
+        "q",
+        "k",
+        "v",
+        "g",
+        "beta",
+        "A_log",
+        "dt_bias",
+        "initial_state",
+        "cu_seqlens",
+    )
+    assert (
+        inspect.signature(recurrent_kda_training_forward)
+        .parameters["cu_seqlens"]
+        .default
+        is None
+    )
+    assert backward_parameters == ("context", "do", "dfinal_state", "out")
+    source = inspect.getsource(recurrent_kda_training_backward)
+    assert "run_training_backward" in source
+    assert "run_training_forward" not in source
+    assert ".run_low(" not in source
+    assert ".run_high(" not in source
+
+
+@pytest.mark.parametrize(
+    ("seq_lens", "num_qk_heads", "num_v_heads", "tag", "family"),
+    [
+        ((1024,) * 8, 4, 8, "grouped_c16", "c16"),
+        ((17, 33, 65), 4, 8, "grouped_c32", "c32"),
+        ((17,), 1, 1, "row_split", "row_split"),
+        ((1024,) * 8, 96, 96, "c16", "c16"),
+        ((1300, 547, 2048, 963, 271, 3063), 96, 96, "c32", "c32"),
+    ],
+)
+def test_full_training_dispatcher_route_selector(
+    seq_lens, num_qk_heads, num_v_heads, tag, family
+):
+    """Fast-path predicates select a route; they do not restrict the API."""
+
+    spec = kda_training_api._select_training_route(seq_lens, num_qk_heads, num_v_heads)
+    assert spec.tag == tag
+    assert spec.family == family
+
+
+@pytest.mark.parametrize(
+    ("batch_size", "seq_len", "num_heads", "tag"),
+    [
+        (2, 17, 1, "row_split"),
+        (4, 33, 16, "c32"),
+        (8, 64, 32, "c16"),
+    ],
+)
+def test_fixed_batch_route_selection_uses_semantic_sequences(
+    batch_size, seq_len, num_heads, tag
+):
+    spec = kda_training_api._select_training_route(
+        (seq_len,) * batch_size, num_heads, num_heads
+    )
+    assert spec.tag == tag
+
+
+def test_public_contract_does_not_promote_fast_path_predicates_to_guards():
+    source = inspect.getsource(kda_training_api._validate_forward_inputs)
+    assert "divisible by 16" not in source
+    assert "validated C16 production routes only" not in source
+    assert "grouped Q/K heads only" not in source
+    assert "torch.bfloat16" in source
+    assert "torch.float32" in source
+
+
+def test_context_has_an_explicit_route_tag():
+    assert "_route" in RecurrentKDATrainingContext.__dataclass_fields__
+
+
+def _require_blackwell():
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is required")
+    if torch.cuda.get_device_capability() not in {(10, 0), (10, 3)}:
+        pytest.skip("the recurrent KDA training route requires SM100a or SM103a")
+
+
+def _make_inputs(
+    seed=819208,
+    *,
+    seq_lens=(1024,) * 8,
+    num_qk_heads=96,
+    num_v_heads=None,
+):
+    num_v_heads = num_qk_heads if num_v_heads is None else num_v_heads
+    generator = torch.Generator(device="cuda").manual_seed(seed)
+    total_tokens = sum(seq_lens)
+    qk_shape = (1, total_tokens, num_qk_heads, 128)
+    value_shape = (1, total_tokens, num_v_heads, 128)
+    state_shape = (len(seq_lens), num_v_heads, 128, 128)
+
+    def bf16(shape, multiplier=1.0):
+        return (torch.randn(shape, generator=generator, device="cuda") * multiplier).to(
+            torch.bfloat16
+        )
+
+    return {
+        "q": bf16(qk_shape),
+        "k": bf16(qk_shape),
+        "v": bf16(value_shape),
+        "g": bf16(value_shape, 0.1),
+        "beta": bf16(value_shape[:-1]),
+        "A_log": torch.log(
+            torch.rand((num_v_heads,), generator=generator, device="cuda") + 1.0
+        ),
+        "dt_bias": torch.randn((num_v_heads, 128), generator=generator, device="cuda")
+        * 0.1,
+        "initial_state": torch.randn(state_shape, generator=generator, device="cuda")
+        * 0.02,
+        "cu_seqlens": torch.tensor(
+            [0, *torch.tensor(seq_lens).cumsum(0).tolist()],
+            dtype=torch.int64,
+            device="cuda",
+        ),
+        "do": bf16(value_shape, 0.1),
+        "dfinal_state": torch.randn(state_shape, generator=generator, device="cuda")
+        * 0.1,
+    }
+
+
+def _make_fixed_inputs(
+    batch_size,
+    seq_len,
+    num_heads,
+    *,
+    seed,
+):
+    generator = torch.Generator(device="cuda").manual_seed(seed)
+    token_shape = (batch_size, seq_len, num_heads, 128)
+    state_shape = (batch_size, num_heads, 128, 128)
+
+    def bf16(shape, multiplier=1.0):
+        return (torch.randn(shape, generator=generator, device="cuda") * multiplier).to(
+            torch.bfloat16
+        )
+
+    return {
+        "q": bf16(token_shape),
+        "k": bf16(token_shape),
+        "v": bf16(token_shape),
+        "g": bf16(token_shape, 0.1),
+        "beta": bf16(token_shape[:-1]),
+        "A_log": torch.log(
+            torch.rand((num_heads,), generator=generator, device="cuda") + 1.0
+        ),
+        "dt_bias": torch.randn((num_heads, 128), generator=generator, device="cuda")
+        * 0.1,
+        "initial_state": torch.randn(state_shape, generator=generator, device="cuda")
+        * 0.02,
+        "cu_seqlens": None,
+        "do": bf16(token_shape, 0.1),
+        "dfinal_state": torch.randn(state_shape, generator=generator, device="cuda")
+        * 0.1,
+    }
+
+
+def _fla_reference(inputs):
+    os.environ["FLA_FLASH_KDA"] = "0"
+    kda_ops = pytest.importorskip("fla.ops.kda")
+    names = ("q", "k", "v", "g", "beta", "A_log", "dt_bias", "initial_state")
+    leaves = {
+        name: inputs[name].detach().clone().requires_grad_(True) for name in names
+    }
+    leaves["dt_bias"] = (
+        inputs["dt_bias"].detach().reshape(-1).clone().requires_grad_(True)
+    )
+    cu_seqlens = inputs["cu_seqlens"]
+    output, final_state = kda_ops.chunk_kda(
+        leaves["q"],
+        leaves["k"],
+        leaves["v"],
+        leaves["g"],
+        leaves["beta"],
+        scale=1.0 / math.sqrt(128),
+        initial_state=leaves["initial_state"],
+        output_final_state=True,
+        use_qk_l2norm_in_kernel=True,
+        use_gate_in_kernel=True,
+        use_beta_sigmoid_in_kernel=True,
+        safe_gate=True,
+        lower_bound=-5.0,
+        state_v_first=True,
+        cu_seqlens=cu_seqlens,
+        cu_seqlens_cpu=(None if cu_seqlens is None else cu_seqlens.detach().cpu()),
+        A_log=leaves["A_log"],
+        dt_bias=leaves["dt_bias"],
+        chunk_size=32,
+    )
+    gradients = torch.autograd.grad(
+        (output, final_state),
+        tuple(leaves[name] for name in names),
+        grad_outputs=(inputs["do"], inputs["dfinal_state"]),
+    )
+    gradients = (
+        *gradients[:-2],
+        gradients[-2].reshape_as(inputs["dt_bias"]),
+        gradients[-1],
+    )
+    return output, final_state, gradients
+
+
+def _assert_training_matches_fla(inputs, expected_route):
+    expected_output, expected_final, expected_gradients = _fla_reference(inputs)
+    initial_state_before = inputs["initial_state"].clone()
+    output, final_state, context = recurrent_kda_training_forward(
+        inputs["q"],
+        inputs["k"],
+        inputs["v"],
+        inputs["g"],
+        inputs["beta"],
+        inputs["A_log"],
+        inputs["dt_bias"],
+        inputs["initial_state"],
+        inputs["cu_seqlens"],
+    )
+    assert isinstance(context, RecurrentKDATrainingContext)
+    assert context._route.tag == expected_route
+    assert output.dtype == torch.bfloat16
+    assert final_state.dtype == torch.float32
+    assert output.shape == inputs["v"].shape
+    assert final_state.shape == inputs["initial_state"].shape
+    gradients = recurrent_kda_training_backward(
+        context, inputs["do"], inputs["dfinal_state"]
+    )
+    assert torch.equal(inputs["initial_state"], initial_state_before)
+    torch.testing.assert_close(output, expected_output, atol=1e-2, rtol=1e-2)
+    torch.testing.assert_close(final_state, expected_final, atol=1e-2, rtol=1e-2)
+    for actual, expected in zip(gradients, expected_gradients, strict=True):
+        torch.testing.assert_close(actual, expected, atol=1e-2, rtol=1e-2)
+
+
+@pytest.mark.arch_blackwell
+def test_training_forward_context_backward_matches_fla():
+    _require_blackwell()
+    _assert_training_matches_fla(_make_inputs(), "c16")
+
+
+@pytest.mark.arch_blackwell
+def test_grouped_c32_forward_context_backward_matches_fla():
+    """The grouped C32 fallback is part of the API, not a rejected shape."""
+
+    _require_blackwell()
+    inputs = _make_inputs(
+        seed=24005,
+        seq_lens=(17, 33, 65),
+        num_qk_heads=4,
+        num_v_heads=8,
+    )
+    _assert_training_matches_fla(inputs, "grouped_c32")
+
+
+@pytest.mark.arch_blackwell
+def test_grouped_c16_forward_context_backward_matches_fla():
+    """The fast grouped route preserves paired forward/backward semantics."""
+
+    _require_blackwell()
+    inputs = _make_inputs(
+        seed=24001,
+        seq_lens=(1024,),
+        num_qk_heads=4,
+        num_v_heads=8,
+    )
+    _assert_training_matches_fla(inputs, "grouped_c16")
+
+
+@pytest.mark.arch_blackwell
+def test_high_head_mixed_c32_forward_context_backward_matches_fla():
+    """Mixed packed lengths use the equal-head C32 fallback without rejection."""
+
+    _require_blackwell()
+    inputs = _make_inputs(
+        seed=24017,
+        seq_lens=(17, 33),
+        num_qk_heads=16,
+        num_v_heads=16,
+    )
+    _assert_training_matches_fla(inputs, "c32")
+
+
+@pytest.mark.arch_blackwell
+def test_short_high_head_c32_forward_context_backward_matches_fla():
+    """A token-padded beta TMA scratch is materialized before C32 tape use."""
+
+    _require_blackwell()
+    inputs = _make_inputs(
+        seed=24020,
+        seq_lens=(17,),
+        num_qk_heads=16,
+        num_v_heads=16,
+    )
+    _assert_training_matches_fla(inputs, "c32")
+
+
+@pytest.mark.arch_blackwell
+def test_split_c32_forward_context_backward_matches_fla():
+    """A multi-work-item C32 route preserves the saved training tape."""
+
+    _require_blackwell()
+    inputs = _make_inputs(
+        seed=24019,
+        seq_lens=(2049,),
+        num_qk_heads=16,
+        num_v_heads=16,
+    )
+    _assert_training_matches_fla(inputs, "c32")
+
+
+@pytest.mark.arch_blackwell
+def test_packed_row_split_forward_context_backward_matches_fla():
+    """The packed row-split benchmark shape is covered by exact correctness."""
+
+    _require_blackwell()
+    inputs = _make_inputs(
+        seed=24018,
+        seq_lens=(17, 33),
+        num_qk_heads=1,
+        num_v_heads=1,
+    )
+    _assert_training_matches_fla(inputs, "row_split")
+
+
+@pytest.mark.arch_blackwell
+@pytest.mark.parametrize(
+    ("batch_size", "seq_len", "num_heads", "route"),
+    [
+        (2, 17, 1, "row_split"),
+        (4, 33, 16, "c32"),
+        (8, 64, 32, "c16"),
+    ],
+)
+def test_fixed_batch_normalization_output_shape_and_correctness(
+    batch_size, seq_len, num_heads, route
+):
+    _require_blackwell()
+    inputs = _make_fixed_inputs(batch_size, seq_len, num_heads, seed=9100 + batch_size)
+    _assert_training_matches_fla(inputs, route)
+
+
+def test_paired_backward_ffi_does_not_rerun_forward(monkeypatch):
+    _require_blackwell()
+    training_module = _TrainingRecorder()
+    monkeypatch.setattr(
+        kda_training_api, "_get_training_module", lambda _: training_module
+    )
+    inputs = _make_inputs(seed=1024)
+    output, final_state, context = recurrent_kda_training_forward(
+        inputs["q"],
+        inputs["k"],
+        inputs["v"],
+        inputs["g"],
+        inputs["beta"],
+        inputs["A_log"],
+        inputs["dt_bias"],
+        inputs["initial_state"],
+        inputs["cu_seqlens"],
+    )
+    final_state_output_ptr = context._final_output_scratch.data_ptr()
+    assert final_state_output_ptr != output.data_ptr()
+    rejected_q = torch.empty_like(inputs["q"])
+    with pytest.raises(ValueError, match="out must not overlap q"):
+        recurrent_kda_training_forward(
+            rejected_q,
+            inputs["k"],
+            inputs["v"],
+            inputs["g"],
+            inputs["beta"],
+            inputs["A_log"],
+            inputs["dt_bias"],
+            inputs["initial_state"],
+            inputs["cu_seqlens"],
+            out=rejected_q,
+            final_state_out=final_state,
+            context_out=context,
+        )
+    assert context._q is inputs["q"]
+    with pytest.raises(
+        ValueError, match="out must not overlap context._final_output_scratch"
+    ):
+        recurrent_kda_training_forward(
+            inputs["q"],
+            inputs["k"],
+            inputs["v"],
+            inputs["g"],
+            inputs["beta"],
+            inputs["A_log"],
+            inputs["dt_bias"],
+            inputs["initial_state"],
+            inputs["cu_seqlens"],
+            out=context._final_output_scratch,
+            final_state_out=final_state,
+            context_out=context,
+        )
+    _, _, reused_context = recurrent_kda_training_forward(
+        inputs["q"],
+        inputs["k"],
+        inputs["v"],
+        inputs["g"],
+        inputs["beta"],
+        inputs["A_log"],
+        inputs["dt_bias"],
+        inputs["initial_state"],
+        inputs["cu_seqlens"],
+        out=output,
+        final_state_out=final_state,
+        context_out=context,
+    )
+    assert reused_context is context
+    assert context._final_output_scratch.data_ptr() == final_state_output_ptr
+    assert training_module.forward_calls[-1][33] == 0
+    context._final_descriptor_storage[0] = context._final_descriptor_storage[0]
+    recurrent_kda_training_forward(
+        inputs["q"],
+        inputs["k"],
+        inputs["v"],
+        inputs["g"],
+        inputs["beta"],
+        inputs["A_log"],
+        inputs["dt_bias"],
+        inputs["initial_state"],
+        inputs["cu_seqlens"],
+        out=output,
+        final_state_out=final_state,
+        context_out=context,
+    )
+    assert training_module.forward_calls[-1][33] == 1
+    recurrent_kda_training_backward(context, inputs["do"], inputs["dfinal_state"])
+    assert len(training_module.forward_calls) == 3
+    assert len(training_module.backward_calls) == 1
+
+    other_stream = torch.cuda.Stream(device=inputs["q"].device)
+    with torch.cuda.stream(other_stream):
+        with pytest.raises(RuntimeError, match="must run on the forward stream"):
+            recurrent_kda_training_backward(
+                context, inputs["do"], inputs["dfinal_state"]
+            )
+        with pytest.raises(RuntimeError, match="reused on its forward stream"):
+            recurrent_kda_training_forward(
+                inputs["q"],
+                inputs["k"],
+                inputs["v"],
+                inputs["g"],
+                inputs["beta"],
+                inputs["A_log"],
+                inputs["dt_bias"],
+                inputs["initial_state"],
+                inputs["cu_seqlens"],
+                out=output,
+                final_state_out=final_state,
+                context_out=context,
+            )
+    assert len(training_module.forward_calls) == 3
+    assert len(training_module.backward_calls) == 1
+
+    inputs["q"][0, 0, 0, 0] = inputs["q"][0, 0, 0, 0]
+    with pytest.raises(RuntimeError, match="input was modified after forward"):
+        recurrent_kda_training_backward(context, inputs["do"], inputs["dfinal_state"])
+    assert len(training_module.forward_calls) == 3
+    assert len(training_module.backward_calls) == 1
+
+
+@pytest.mark.parametrize(
+    ("route", "inputs"),
+    [
+        (
+            "row_split",
+            lambda: _make_inputs(
+                seed=24018,
+                seq_lens=(17, 33),
+                num_qk_heads=1,
+                num_v_heads=1,
+            ),
+        ),
+        (
+            "grouped_c32",
+            lambda: _make_inputs(
+                seed=24005,
+                seq_lens=(17, 33, 65),
+                num_qk_heads=4,
+                num_v_heads=8,
+            ),
+        ),
+    ],
+)
+def test_fallback_ffi_consumes_route_context_without_recompute(
+    monkeypatch, route, inputs
+):
+    _require_blackwell()
+    training_module = _TrainingRecorder()
+    monkeypatch.setattr(
+        kda_training_api, "_get_training_module", lambda _: training_module
+    )
+    values = inputs()
+    _, _, context = recurrent_kda_training_forward(
+        values["q"],
+        values["k"],
+        values["v"],
+        values["g"],
+        values["beta"],
+        values["A_log"],
+        values["dt_bias"],
+        values["initial_state"],
+        values["cu_seqlens"],
+    )
+    assert context._route.tag == route
+    recurrent_kda_training_backward(context, values["do"], values["dfinal_state"])
+    if route == "row_split":
+        assert len(training_module.row_forward_calls) == 1
+        assert len(training_module.row_backward_calls) == 1
+    else:
+        assert len(training_module.c32_forward_calls) == 1
+        assert len(training_module.c32_backward_calls) == 1
+        forward_args = training_module.c32_forward_calls[0]
+        assert forward_args[12] is context._metadata["work_items"]
+        assert forward_args[13] is context._metadata["seq_order"]
+        assert forward_args[32].data_ptr() == forward_args[16].data_ptr()
+        assert forward_args[32].data_ptr() != context._final_output_scratch.data_ptr()
+        assert forward_args[43] == 0
+        assert forward_args[44] == 1
+    assert not training_module.forward_calls
+    assert not training_module.backward_calls
+
+
+def test_training_rejects_cuda_graph_capture_before_ffi(monkeypatch):
+    _require_blackwell()
+    training_module = _TrainingRecorder()
+    monkeypatch.setattr(
+        kda_training_api, "_get_training_module", lambda _: training_module
+    )
+    inputs = _make_inputs(
+        seed=1025,
+        seq_lens=(1024,),
+        num_qk_heads=4,
+        num_v_heads=4,
+    )
+    _, _, context = recurrent_kda_training_forward(
+        inputs["q"],
+        inputs["k"],
+        inputs["v"],
+        inputs["g"],
+        inputs["beta"],
+        inputs["A_log"],
+        inputs["dt_bias"],
+        inputs["initial_state"],
+        inputs["cu_seqlens"],
+    )
+    assert len(training_module.forward_calls) == 1
+    assert len(training_module.backward_calls) == 0
+
+    monkeypatch.setattr(torch.cuda, "is_current_stream_capturing", lambda: True)
+    with pytest.raises(RuntimeError, match="does not support CUDA graph capture"):
+        recurrent_kda_training_forward(
+            inputs["q"],
+            inputs["k"],
+            inputs["v"],
+            inputs["g"],
+            inputs["beta"],
+            inputs["A_log"],
+            inputs["dt_bias"],
+            inputs["initial_state"],
+            inputs["cu_seqlens"],
+        )
+    with pytest.raises(RuntimeError, match="does not support CUDA graph capture"):
+        recurrent_kda_training_backward(context, inputs["do"], inputs["dfinal_state"])
+
+    assert len(training_module.forward_calls) == 1
+    assert len(training_module.backward_calls) == 0
+
+
+def test_saved_context_mutation_rejected_before_ffi(monkeypatch):
+    _require_blackwell()
+    training_module = _TrainingRecorder()
+    monkeypatch.setattr(
+        kda_training_api, "_get_training_module", lambda _: training_module
+    )
+    inputs = _make_inputs(
+        seed=1026,
+        seq_lens=(1024,),
+        num_qk_heads=4,
+        num_v_heads=4,
+    )
+    output, final_state, context = recurrent_kda_training_forward(
+        inputs["q"],
+        inputs["k"],
+        inputs["v"],
+        inputs["g"],
+        inputs["beta"],
+        inputs["A_log"],
+        inputs["dt_bias"],
+        inputs["initial_state"],
+        inputs["cu_seqlens"],
+    )
+    context.state_checkpoints.zero_()
+
+    with pytest.raises(RuntimeError, match="context was modified after forward"):
+        recurrent_kda_training_backward(context, inputs["do"], inputs["dfinal_state"])
+    with pytest.raises(RuntimeError, match="context was modified after forward"):
+        recurrent_kda_training_forward(
+            inputs["q"],
+            inputs["k"],
+            inputs["v"],
+            inputs["g"],
+            inputs["beta"],
+            inputs["A_log"],
+            inputs["dt_bias"],
+            inputs["initial_state"],
+            inputs["cu_seqlens"],
+            out=output,
+            final_state_out=final_state,
+            context_out=context,
+        )
+
+    assert len(training_module.forward_calls) == 1
+    assert len(training_module.backward_calls) == 0


### PR DESCRIPTION
## Summary

- add paired `recurrent_kda_training_forward` and `recurrent_kda_training_backward` APIs for exact SM100a and SM103a Blackwell targets
- return the public BF16 token output, an accurate FP32 final state, and a persistent route-specific context consumed directly by backward
- export the complete C16, grouped/equal-head C32, and row-split dispatcher instead of treating fast-route predicates as public shape guards
- keep backward free of forward recomputation and support caller-owned output, gradient, and context reuse with stream, ownership, and alias validation
- add exact-architecture JIT/AOT registration, the native N16 checkpoint route, documentation, correctness tests, and mandatory-CUPTI benchmarks

Related to #4254.

## Supported training routes

| Shape condition | Dispatcher route |
|---|---|
| grouped heads, low head count, long sequences, all lengths 16-aligned | grouped C16 fast path |
| grouped heads, other valid shapes | grouped C32 fallback |
| equal heads, low head count, long 16-aligned sequences | C16 fast path |
| equal heads, other low-head shapes | row-split fallback |
| equal heads, high head count, uniform shape meeting the occupancy crossover | C16 fast path |
| equal heads, other high-head shapes | C32 fallback |

The route predicates select an implementation; they are not API guards. The public contract is:

- key and value dimensions are 128
- Q/K/V, raw gate, and raw beta are BF16; parameters and recurrent state are FP32
- the value-head count is an integer multiple of the Q/K-head count
- fixed layout accepts contiguous `[B, T, H, 128]` tensors with `B >= 1`
- packed layout uses physical batch one and derives semantic sequences from CUDA int64 `cu_seqlens`
- semantic sequence lengths are positive and may be mixed or not 16-aligned
- compute capability is exactly 10.0 or 10.3, scale is `1 / sqrt(128)`, and the safe-gate lower bound is `-5.0`

For C16, the accurate full-state recurrence writes token output to private scratch so the training route's output remains public. For C32, that recurrence supplies the public token output while the chunked tape and checkpoints remain saved as backward context. Row-split directly produces its public output and final state.

## Correctness and validation

- on physical B200, B300, and GB300 GPUs, the forward output, FP32 final state, and all eight gradients match pinned FLA 0.5.1 at `atol=rtol=1e-2`, including fixed seed `819208`
- the exact anchor is `[1, 8192, 96, 128]`, eight packed 1024-token sequences, H96, K/V128
- the full paired suite covers fixed B2/B4/B8, packed mixed and nonaligned sequence lengths, grouped C32, high-head C32, row-split, and C16; backward consumes saved context without rerunning forward
- the real native N16 checkpoint route passes on all three GPUs
- JIT/AOT and dual-architecture native builds pass for SM100a and SM103a
- full `pre-commit run --all-files` passes without rewrites
- complete paired forward/backward passes Compute Sanitizer synccheck and memcheck on B200 and B300 with `ERROR SUMMARY: 0 errors`

## Performance

Every number below is from the final public snapshot on one physical GPU. Timing uses CUPTI activity tracing with `cupti-python 13.3.1` and `pyelftools 0.32`, cold L2, and no CUDA Graph; there is no CUDA-event fallback. `Public DAG` includes public forward, accurate final-state recurrence, context production, backward, reductions, and all eight gradients. `Delta` is relative to the matching pinned FLA DAG.

| GPU | Arch | Exact H96 forward | Exact H96 backward | Exact H96 public DAG | Exact H96 FLA DAG | Exact H96 delta vs FLA | Exact H96 speedup `(FLA DAG / public DAG)` | 17-primary-shape speedup geomean |
|---|---|---:|---:|---:|---:|---:|---:|---:|
| B200 | SM100a | 3.321074 ms | 2.370027 ms | 5.696506 ms | 9.333127 ms | -3.636621 ms (-38.96%) | 1.638x | 2.646x |
| B300 | SM103a | 3.034555 ms | 2.115836 ms | 5.170232 ms | 9.029394 ms | -3.859162 ms (-42.74%) | 1.746x | 3.050x |
| GB300 | SM103a | 3.096315 ms | 2.243613 ms | 5.333206 ms | 7.663061 ms | -2.329855 ms (-30.40%) | 1.437x | 1.793x |

“Exact H96” is the single `[1, 8192, 96, 128]`, packed `8 × 1024` anchor. “17-primary-shape speedup geomean” is the geometric mean of the per-shape `FLA DAG / public DAG` ratios over that anchor plus the 16 primary portfolio shapes on the same GPU. It is not a ratio of averaged latencies and excludes the three fallback-validation shapes.

The three-GPU exact-H96 geometric-mean speedup is **1.602x**. The geometric mean across all 51 primary measurements is **2.437x**.

### Fallback validation shapes

| GPU | Shape | Route | Forward | Backward | Public DAG | FLA DAG | Delta vs FLA | Speedup |
|---|---|---|---:|---:|---:|---:|---:|---:|
| B200 | packed 17/33/65, Hq4/Hv8 | grouped C32 | 1.108709 ms | 0.082785 ms | 2.038841 ms | 5.362554 ms | -3.323713 ms (-61.98%) | 2.630x |
| B200 | packed 17/33, Hq1/Hv1 | row-split | 0.461282 ms | 0.069169 ms | 0.869220 ms | 4.945126 ms | -4.075906 ms (-82.42%) | 5.689x |
| B200 | packed 17/33, Hq16/Hv16 | equal-head C32 | 0.993924 ms | 0.071201 ms | 1.898055 ms | 5.227257 ms | -3.329202 ms (-63.69%) | 2.754x |
| B300 | packed 17/33/65, Hq4/Hv8 | grouped C32 | 0.903966 ms | 0.077504 ms | 1.678813 ms | 5.371415 ms | -3.692602 ms (-68.75%) | 3.200x |
| B300 | packed 17/33, Hq1/Hv1 | row-split | 0.385663 ms | 0.065472 ms | 0.734015 ms | 5.762295 ms | -5.028280 ms (-87.26%) | 7.850x |
| B300 | packed 17/33, Hq16/Hv16 | equal-head C32 | 0.823055 ms | 0.065055 ms | 1.585182 ms | 5.561064 ms | -3.975882 ms (-71.49%) | 3.508x |
| GB300 | packed 17/33/65, Hq4/Hv8 | grouped C32 | 0.997951 ms | 0.084224 ms | 1.855262 ms | 3.176634 ms | -1.321372 ms (-41.60%) | 1.712x |
| GB300 | packed 17/33, Hq1/Hv1 | row-split | 0.430111 ms | 0.075776 ms | 0.824879 ms | 3.004844 ms | -2.179965 ms (-72.55%) | 3.643x |
| GB300 | packed 17/33, Hq16/Hv16 | equal-head C32 | 0.908383 ms | 0.075248 ms | 1.755710 ms | 2.985757 ms | -1.230047 ms (-41.20%) | 1.701x |

### Physical validation jobs and turnaround

| Gate | GPU | Slurm job(s) | Submit-to-End physical turnaround | Allocated/workload turnaround |
|---|---|---|---:|---:|
| Full correctness, N16, 17 primary + 3 fallback CUPTI benchmarks | B200 | `3862370` | 00:22:32 | 00:22:32 allocated / 00:22:30 workload |
| Full correctness, N16, 17 primary + 3 fallback CUPTI benchmarks | B300 | `3862371` | 02:16:25 | 00:22:39 allocated / 00:22:37 workload |
| Full correctness, N16, 17 primary + 3 fallback CUPTI benchmarks | GB300 | `545363` | 00:23:54 | 00:23:53 allocated / 00:23:33 workload |
| Static, dual-architecture JIT/AOT/native build, N16, source and publication-boundary gate | B200 | `3862372` | 00:05:42 | 00:05:42 allocated / 00:05:38 workload |
| Compute Sanitizer synccheck + memcheck | B200 | `3862375` / `3862373` | 00:02:53 campaign span | 00:02:50 / 00:02:52 allocated |
| Compute Sanitizer synccheck + memcheck | B300 | `3863286` / `3862374` | 01:57:40 campaign span | 00:03:27 allocated / 00:03:25 workload; 00:03:55 allocated / 00:03:53 workload |
| Cross-result fleet manifest and metric validation | CPU-only | `3863498` | 00:00:02 | 00:00:01 allocated |

The full final-validation campaign took **02:20:48** from the earliest Slurm submission to the final fleet-validator completion. Benchmark medians above are GPU activity durations, not host or allocation elapsed time.

## Runtime behavior

- exact compute-capability routing: 10.0 uses SM100a and 10.3 uses SM103a
- caller-owned output, final-state, context, and gradient reuse is supported after warmup
- context reuse remains stream-local and serialized
- dtype, shape, device, layout, offsets, aliasing, scale, and lower-bound contracts are validated before launch
- CUDA Graph capture is not supported by the paired training API

## Final snapshot and manifests

- final public head: `71ba319e8374bf373389e1678e68c407545a414c`
- final public tree: `4c7a880beace317aaa7f6920da5fb97bbadc874e`
- based on upstream `main` at `fb28d7242b3506a2348265962041acc1fb56cca4`
- pinned FLA baseline: `97bcb883dafd3fa5b859917184e4abfb1c4e8a71`
- generated training JIT modules: `flash_kda_training_44c7c508ad_sm100a`, `flash_kda_training_44c7c508ad_sm103a`
- N16 checkpoint JIT modules: `flash_kda_bf16_m128_n16_checkpoint_3fce0271a4_sm100a`, `flash_kda_bf16_m128_n16_checkpoint_3fce0271a4_sm100f`
- frozen generated-source SHA256: `6e296646445a6b1acb7a6cc1d280de6a5434f47739b6ce0939b1124085fc1603`
- final source bundle SHA256: `f72b41eb5e97a8447402ef491434f9bfddee3b4853e460f087fec540a9cb3408`
- pinned FLA bundle SHA256: `fd4bd5a230f64fc67e7ce085782158d7dad21ef669395a1ba87a7aa8c137b086`
- 38-file public source manifest SHA256: `915dbd8ba7ac28900ef09aff85a053bdff214fd121fa6e251698f9743b08e71d`
- all GPU, gate, sanitizer, source, input, and result manifests were re-read and verified
