### PR TITLE
fix(moe): correct unified fuzzer references

### DIFF
--- a/tests/model_optimizations/test_dsv3_fused_routing.py
+++ b/tests/model_optimizations/test_dsv3_fused_routing.py
@@ -202,12 +202,14 @@ class DSv3RoutingGroundTruth:
 
         for token_idx in range(self.num_tokens):
             # Create mask for selected groups
-            group_mask = torch.zeros(n_group, dtype=torch.float32, device=self.device)
-            group_mask[self.ref_group_indices[token_idx]] = 1.0
+            group_mask = torch.zeros(n_group, dtype=torch.bool, device=self.device)
+            group_mask[self.ref_group_indices[token_idx]] = True
             expert_mask = group_mask.repeat_interleave(self.experts_per_group)
 
             # Mask and select top-k experts
-            masked_biased_scores = self.biased_scores[token_idx] * expert_mask
+            masked_biased_scores = self.biased_scores[token_idx].masked_fill(
+                ~expert_mask, float("-inf")
+            )
             _, topk_idx = torch.topk(
                 masked_biased_scores, k=topk, dim=-1, largest=True, sorted=True
             )
@@ -318,18 +320,42 @@ class DSv3RoutingGroundTruth:
         This computes what experts SHOULD be selected if these groups were chosen.
         """
         # Create mask for specified groups
-        group_mask = torch.zeros(self.n_group, dtype=torch.float32, device=self.device)
+        group_mask = torch.zeros(self.n_group, dtype=torch.bool, device=self.device)
         for g in groups:
-            group_mask[g] = 1.0
+            group_mask[g] = True
         expert_mask = group_mask.repeat_interleave(self.experts_per_group)
 
         # Mask and select top-k experts
-        masked_biased_scores = self.biased_scores[token_idx] * expert_mask
+        masked_biased_scores = self.biased_scores[token_idx].masked_fill(
+            ~expert_mask, float("-inf")
+        )
         _, topk_idx = torch.topk(
             masked_biased_scores, k=self.topk, dim=-1, largest=True, sorted=True
         )
 
         return set(topk_idx.tolist())
+
+
+def test_ground_truth_excludes_unselected_groups_with_negative_scores():
+    scores = torch.zeros((1, 8), dtype=torch.float32)
+    bias = torch.tensor(
+        [[2.5, 1.5, 0.5, -1.5, 0.0, -0.1, -0.2, -0.3]],
+        dtype=torch.float32,
+    )
+
+    ground_truth = DSv3RoutingGroundTruth(
+        scores,
+        bias,
+        n_group=2,
+        topk_group=1,
+        topk=4,
+        routed_scaling_factor=1.0,
+        data_type=torch.float32,
+    )
+
+    expected = {0, 1, 2, 3}
+    assert set(ground_truth.ref_expert_indices[0].tolist()) == expected
+    assert ground_truth._get_topk_experts_from_groups(0, [0]) == expected
 
 
 def validate_expert_selection(ground_truth, topk_indices_kernel, topk_values_kernel):

--- a/tests/moe/test_unified_moe.py
+++ b/tests/moe/test_unified_moe.py
@@ -89,6 +89,30 @@ from tests.moe.test_cute_dsl_fused_moe import (  # noqa: E402
     compute_reference_moe_fp4,
     create_moe_tensors,
 )
+
+
+def test_noaux_tc_ref_excludes_unselected_groups_with_negative_scores():
+    from tests.moe.trtllm_gen_fused_moe_utils import noaux_tc_ref
+
+    logits = torch.zeros((1, 8), dtype=torch.float32)
+    bias = torch.tensor(
+        [[2.5, 1.5, 0.5, -1.5, 0.0, -0.1, -0.2, -0.3]],
+        dtype=torch.float32,
+    )
+
+    scores = noaux_tc_ref(
+        logits,
+        bias,
+        n_group=2,
+        topk_group=1,
+        top_k=4,
+        routed_scaling_factor=1.0,
+    )
+
+    selected = torch.where(scores[0] != 0)[0]
+    assert set(selected.tolist()) == {0, 1, 2, 3}
+
+
 # ---------------------------------------------------------------------------
 # Enum repr round-trip
 # ---------------------------------------------------------------------------

--- a/tests/moe/test_unified_moe_fuzz.py
+++ b/tests/moe/test_unified_moe_fuzz.py
@@ -878,9 +878,9 @@ _DTYPE = {
         reference=_mxint4_reference,
         poison=_poison_bf16_out,
         out_dtype=torch.bfloat16,
-        # The full 160-seed SM100 sweep observes max|diff| / ||ref||inf
-        # ~= 0.0535 for a 4096-token FromLogits case.
-        atol_frac=0.06,
+        # The full 160-seed GB200 sweep requires atol_frac ~= 0.062 for seed 18
+        # after the relative-tolerance contribution; retain a small margin.
+        atol_frac=0.065,
         rtol=0.3,
     ),
 }
@@ -1602,15 +1602,17 @@ def _route(
                 dim=-1
             )  # top-2 sum per group
             _, gidx = torch.topk(group_scores, k=topk_group, dim=-1)
-            gmask = torch.zeros_like(group_scores).scatter_(-1, gidx, 1.0)
+            gmask = torch.zeros_like(group_scores, dtype=torch.bool).scatter_(
+                -1, gidx, True
+            )
             smask = (
                 gmask.unsqueeze(-1)
                 .expand(*sel_scores.shape[:-1], n_group, E // n_group)
                 .reshape(sel_scores.shape)
             )
-            sel_scores = (
-                sel_scores * smask
-            )  # zero out experts outside the selected groups
+            # A routing bias can make scores negative. Zero-masking would let an
+            # unselected expert outrank a valid negative score in the selected group.
+            sel_scores = sel_scores.masked_fill(~smask, float("-inf"))
         _, sel = torch.topk(sel_scores, top_k, dim=-1)
         w = torch.gather(scores, -1, sel)  # UNBIASED sigmoid weights
         w = w / (w.sum(dim=-1, keepdim=True) + 1e-20)
@@ -1621,6 +1623,29 @@ def _route(
             f"routing method {method!r} not supported by the fuzzer oracle"
         )
     return sel.to(torch.int64), w.float()
+
+
+def test_deepseek_v3_route_excludes_unselected_groups_with_negative_scores():
+    logits = torch.zeros((1, 8), dtype=torch.float32)
+    # Group 0 wins by its top-2 sum, but its fourth selection score is negative.
+    # Experts in group 1 must remain ineligible rather than becoming zero-score
+    # candidates that can displace that valid negative-score expert.
+    bias = torch.tensor(
+        [[2.5, 1.5, 0.5, -1.5, 0.0, -0.1, -0.2, -0.3]],
+        dtype=torch.float32,
+    )
+
+    selected, _ = _route(
+        logits,
+        RoutingMethodType.DeepSeekV3,
+        top_k=4,
+        bias=bias,
+        n_group=2,
+        topk_group=1,
+        routed_scaling=1.0,
+    )
+
+    assert set(selected[0].tolist()) == {0, 1, 2, 3}
 
 
 def _master(cfg, handler):

--- a/tests/moe/test_unified_moe_fuzz.py
+++ b/tests/moe/test_unified_moe_fuzz.py
@@ -878,8 +878,9 @@ _DTYPE = {
         reference=_mxint4_reference,
         poison=_poison_bf16_out,
         out_dtype=torch.bfloat16,
-        # The full 160-seed GB200 sweep requires atol_frac ~= 0.062 for seed 18
-        # after the relative-tolerance contribution; retain a small margin.
+        # A 160-seed GB200 (SM100) sweep exercised 17 MxInt4 cases; seed 18
+        # requires atol_frac ~= 0.062 after the relative-tolerance contribution.
+        # Keep a small SM100-calibrated margin; SM103/SM107 remain uncalibrated.
         atol_frac=0.065,
         rtol=0.3,
     ),

--- a/tests/moe/trtllm_gen_fused_moe_utils.py
+++ b/tests/moe/trtllm_gen_fused_moe_utils.py
@@ -2312,14 +2312,16 @@ def noaux_tc_ref(logits, bias, n_group, topk_group, top_k, routed_scaling_factor
         _, group_idx = torch.topk(
             group_scores, k=topk_group, dim=-1, largest=True, sorted=True
         )
-        group_mask = torch.zeros_like(group_scores)
-        group_mask.scatter_(-1, group_idx, 1)
+        group_mask = torch.zeros_like(group_scores, dtype=torch.bool)
+        group_mask.scatter_(-1, group_idx, True)
         score_mask = (
             group_mask.unsqueeze(-1)
             .expand(scores_shape[:-1] + [n_group, scores_shape[-1] // n_group])
             .reshape(scores_shape)
         )
-        scores_with_bias = scores_with_bias * score_mask
+        # A routing bias can make scores negative. Zero-masking would let an
+        # unselected expert outrank a valid negative score in the selected group.
+        scores_with_bias = scores_with_bias.masked_fill(~score_mask, float("-inf"))
 
     _, topk_idx = torch.topk(
         scores_with_bias, k=top_k, dim=-1, largest=True, sorted=True


### PR DESCRIPTION
## 📌 Description

Fix two false failures exposed by the unified MoE fuzzer on GB200:

- Increase the MxInt4 absolute tolerance fraction from `0.06` to `0.065`, calibrated using the full 160-seed GB200 sweep.
- Correct DeepSeekV3 reference routing to mask experts outside selected groups with `-inf` instead of zero. Zero masking could incorrectly select an out-of-group expert when a valid in-group biased score was negative.
- Apply the routing correction to both unified and legacy references.
- Add focused regression coverage for negative biased scores.

No production kernel behavior is changed.

## 🔍 Related Issues

- Follow-up to #4475

## 🚀 Pull Request Checklist

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All relevant tests are passing.

Validation performed:

- Focused DeepSeekV3 negative-score regression: passed.
- Seed 18 with full checks and `atol_frac=0.065`: passed.
- GB200 MxInt4 160-seed sweep: `17 passed, 176 skipped`.
- Seed 153 with corrected reference masking: passed.

## Reviewer Notes

Please focus on:

- Whether `0.065` provides an appropriate margin for MxInt4 accuracy.
- The use of `-inf` masking to enforce DeepSeekV3 selected-group membership.
- Keeping the unified and legacy routing references semantically consistent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected mixture-of-experts routing so unselected groups are reliably excluded, including when routing scores are negative.
  * Improved routing behavior for DeepSeek-V3 and related fused implementations.
  * Adjusted MxInt4 validation tolerance based on expanded calibration coverage.

* **Tests**
  * Added regression coverage for negative-score routing and expert-group selection.
  * Added CPU validation confirming selection of only the highest-scoring expert group.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->