### PR TITLE
feat: collect a union of TEST_PATH targets in unit CI

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,7 +88,8 @@ Internal CI runs an extended test matrix across NVIDIA GPU architectures. It is 
 
 | Command | Who can use | Description |
 |---------|-------------|-------------|
-| `/bot run` | Allowed users | Mirror PR to GitLab and run CI pipeline |
+| `/bot run` | Allowed users | Mirror PR to GitLab and run the full unit-test pipeline |
+| `/bot run tests/<dir-or-file> [tests/...]` | Allowed users | Same pipeline, scoped to one or more paths under `tests/` (whitespace-separated). Invalid tokens are rejected and do not start a pipeline. Multi-GPU and multi-node jobs still run their dedicated scripts. |
 | `/bot status` | Allowed users | Check current pipeline status |
 | `/bot stop` | Allowed users | Cancel a running pipeline |
 

--- a/scripts/rebuild_test_duration_estimates.py
+++ b/scripts/rebuild_test_duration_estimates.py
@@ -109,8 +109,18 @@ def _prune_scope(manifest_path: Path) -> set[str]:
     manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
     if manifest.get("selection", {}).get("sanity_test"):
         raise ValueError("a sampled manifest cannot authorize pruning")
-    test_path = (REPO_ROOT / Path(manifest["test_path"])).resolve()
-    if test_path != (REPO_ROOT / "tests").resolve():
+
+    def _resolve_scope(raw: str) -> Path:
+        path = Path(raw)
+        return path.resolve() if path.is_absolute() else (REPO_ROOT / path).resolve()
+
+    if manifest.get("test_paths"):
+        resolved = tuple(_resolve_scope(path) for path in manifest["test_paths"])
+    else:
+        resolved = tuple(
+            _resolve_scope(part) for part in str(manifest["test_path"]).split()
+        )
+    if resolved != ((REPO_ROOT / "tests").resolve(),):
         raise ValueError("pruning requires a complete collection rooted at tests/")
     plan = Plan.from_dict(manifest["plan"])
     return {node.nodeid for node in plan.nodes}

--- a/scripts/test_sharding/runner.py
+++ b/scripts/test_sharding/runner.py
@@ -13,7 +13,7 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any
+from typing import Any, Sequence
 
 from .estimates import EstimateBook
 from .io import atomic_write_json
@@ -64,6 +64,7 @@ from .workers import BatchExecutionRequest, execute_batch, write_console
 
 
 _COLLECTION_HEARTBEAT_SECONDS = 30.0
+MAX_TEST_PATHS = 16
 _LEASE_HEARTBEAT_SECONDS = 10.0
 _LEASE_CLOSE_SECONDS = 2.0
 _CONTROLLER_PROGRESS_SECONDS = 60.0
@@ -131,10 +132,17 @@ class CollectionTimeoutError(RunnerStateError):
 
 @dataclass(frozen=True)
 class SelectionSettings:
-    test_path: Path
+    test_paths: tuple[Path, ...]
     sanity_test: bool
     sample_rate: int
     sample_offset: int
+
+    @property
+    def test_path(self) -> Path:
+        return self.test_paths[0]
+
+    def display_test_path(self) -> str:
+        return " ".join(str(path) for path in self.test_paths)
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -223,10 +231,47 @@ def _estimate_checksums(
     }
 
 
+def _as_test_paths(test_path: Path | Sequence[Path]) -> tuple[Path, ...]:
+    if isinstance(test_path, Path):
+        return (test_path,)
+    return tuple(test_path)
+
+
+def _path_is_under(child: Path, parent: Path) -> bool:
+    if not parent.is_dir():
+        return False
+    try:
+        child.resolve().relative_to(parent.resolve())
+    except ValueError:
+        return False
+    return child.resolve() != parent.resolve()
+
+
+def collapse_test_paths(paths: Sequence[Path]) -> tuple[Path, ...]:
+    unique: list[Path] = []
+    seen: set[Path] = set()
+    for path in paths:
+        resolved = path.resolve()
+        if resolved in seen:
+            continue
+        seen.add(resolved)
+        unique.append(resolved)
+    if len(unique) > MAX_TEST_PATHS:
+        raise RunnerStateError(
+            f"too many test paths ({len(unique)}); maximum is {MAX_TEST_PATHS}"
+        )
+    kept = [
+        path
+        for path in unique
+        if not any(_path_is_under(path, other) for other in unique)
+    ]
+    return tuple(kept)
+
+
 def _wait_for_collection(
     process: subprocess.Popen[Any],
     *,
-    test_path: Path,
+    test_path: Path | str,
     timeout_seconds: float | None,
     grace_seconds: float,
 ) -> None:
@@ -258,18 +303,21 @@ def _wait_for_collection(
             )
 
 
-def _isolated_collection_groups(test_path: Path) -> list[tuple[str, list[Path]]]:
+def _isolated_collection_groups(
+    test_paths: Sequence[Path],
+) -> list[tuple[str, list[Path]]]:
     groups = []
     for name, patterns in _COLLECTION_ISOLATION_GROUPS:
         matches: set[Path] = set()
-        for pattern in patterns:
-            if test_path.is_file():
-                if test_path.match(pattern):
-                    matches.add(test_path)
-            else:
-                matches.update(
-                    path for path in test_path.rglob(pattern) if path.is_file()
-                )
+        for test_path in test_paths:
+            for pattern in patterns:
+                if test_path.is_file():
+                    if test_path.match(pattern):
+                        matches.add(test_path)
+                else:
+                    matches.update(
+                        path for path in test_path.rglob(pattern) if path.is_file()
+                    )
         if matches:
             groups.append(
                 (name, sorted(matches, key=lambda path: str(path).encode("utf-8")))
@@ -277,20 +325,21 @@ def _isolated_collection_groups(test_path: Path) -> list[tuple[str, list[Path]]]
     return groups
 
 
-def _pytest_root(repo_root: Path, test_path: Path) -> Path:
+def _pytest_root(repo_root: Path, test_path: Path | Sequence[Path]) -> Path:
     """Return the stable pytest root used for collection and execution."""
     resolved_repo = repo_root.resolve()
-    resolved_test = test_path.resolve()
-    try:
-        resolved_test.relative_to(resolved_repo)
-    except ValueError:
-        return resolved_test if resolved_test.is_dir() else resolved_test.parent
+    for path in _as_test_paths(test_path):
+        resolved_test = path.resolve()
+        try:
+            resolved_test.relative_to(resolved_repo)
+        except ValueError:
+            return resolved_test if resolved_test.is_dir() else resolved_test.parent
     return resolved_repo
 
 
 def _collect_partition(
     repo_root: Path,
-    test_path: Path,
+    test_paths: Sequence[Path],
     targets: list[Path],
     ignored_paths: list[Path],
     timeout_seconds: float | None,
@@ -303,7 +352,7 @@ def _collect_partition(
 ) -> list[dict[str, Any]]:
     output = directory / f"collection-{partition_index:02d}.json"
     log_path = directory / f"collection-{partition_index:02d}.log"
-    pytest_root = _pytest_root(repo_root, test_path)
+    pytest_root = _pytest_root(repo_root, test_paths)
     env = os.environ.copy()
     pythonpath = env.get("PYTHONPATH")
     env["PYTHONPATH"] = (
@@ -335,7 +384,7 @@ def _collect_partition(
         )
         _wait_for_collection(
             process,
-            test_path=test_path,
+            test_path=" ".join(str(path) for path in test_paths),
             timeout_seconds=timeout_seconds,
             grace_seconds=grace_seconds,
         )
@@ -361,13 +410,16 @@ def _collect_partition(
 
 def _collect_nodes(
     repo_root: Path,
-    test_path: Path,
+    test_path: Path | Sequence[Path],
     timeout_seconds: float | None,
     grace_seconds: float,
 ) -> list[dict[str, Any]]:
     started_at = time.monotonic()
-    isolated_groups = _isolated_collection_groups(test_path)
+    test_paths = _as_test_paths(test_path)
+    display_test_path = " ".join(str(path) for path in test_paths)
+    isolated_groups = _isolated_collection_groups(test_paths)
     isolated_paths = [path for _, paths in isolated_groups for path in paths]
+    primary_targets = [path for path in test_paths if path not in isolated_paths]
 
     def remaining_timeout() -> float | None:
         if timeout_seconds is None:
@@ -380,12 +432,12 @@ def _collect_nodes(
         ) as temporary_directory:
             directory = Path(temporary_directory)
             partitions = []
-            if test_path not in isolated_paths:
+            if primary_targets:
                 partitions.append(
                     _collect_partition(
                         repo_root,
-                        test_path,
-                        [test_path],
+                        test_paths,
+                        primary_targets,
                         isolated_paths,
                         remaining_timeout(),
                         grace_seconds,
@@ -399,7 +451,7 @@ def _collect_nodes(
                 partitions.append(
                     _collect_partition(
                         repo_root,
-                        test_path,
+                        test_paths,
                         paths,
                         [],
                         remaining_timeout(),
@@ -428,13 +480,16 @@ def _collect_nodes(
             merged["order"] = len(nodes)
             nodes.append(merged)
     if not nodes:
-        raise RunnerStateError(f"pytest collected no tests below {test_path}")
+        raise RunnerStateError(f"pytest collected no tests below {display_test_path}")
     return nodes
 
 
 def _validate_selection(selection: SelectionSettings) -> None:
-    if not selection.test_path.exists():
-        raise RunnerStateError(f"test path does not exist: {selection.test_path}")
+    missing = [path for path in selection.test_paths if not path.exists()]
+    if missing:
+        raise RunnerStateError(
+            "test path does not exist: " + ", ".join(str(path) for path in missing)
+        )
     if selection.sample_rate <= 0:
         raise RunnerStateError("SAMPLE_RATE must be positive")
     if not 0 <= selection.sample_offset < selection.sample_rate:
@@ -492,6 +547,7 @@ def _write_new_manifest(
                 concurrent,
                 source_git_sha=source_git_sha,
                 test_path=request.selection.test_path,
+                test_paths=request.selection.test_paths,
                 selection=request.selection.to_dict(),
                 planning_options=request.planning.to_dict(),
                 pytest_command_prefix=request.pytest_command_prefix,
@@ -519,7 +575,7 @@ def prepare_manifest(
     collection_timeout_seconds = request.collection_timeout_seconds
     attempt_settings = request.attempt_settings
     operation_started_at = request.operation_started_at
-    test_path = selection.test_path
+    test_paths = selection.test_paths
     _validate_selection(selection)
     junit_dir.mkdir(parents=True, exist_ok=True)
     source_git_sha = source_git_sha_from_env()
@@ -533,7 +589,8 @@ def prepare_manifest(
         verify_manifest(
             existing,
             source_git_sha=source_git_sha,
-            test_path=test_path,
+            test_path=test_paths[0],
+            test_paths=test_paths,
             selection=selection_value,
             planning_options=planning.to_dict(),
             pytest_command_prefix=request.pytest_command_prefix,
@@ -584,7 +641,7 @@ def prepare_manifest(
     try:
         raw_nodes = _collect_nodes(
             repo_root,
-            test_path,
+            test_paths,
             collection_timeout_seconds,
             request.collection_grace_seconds,
         )
@@ -603,7 +660,8 @@ def prepare_manifest(
     manifest = build_manifest(
         ManifestBuild(
             repo_root=repo_root,
-            test_path=test_path,
+            test_path=test_paths[0],
+            test_paths=test_paths,
             source_git_sha=source_git_sha,
             plan=plan,
             selection=selection_value,
@@ -1531,7 +1589,7 @@ def execute_shard(
     plan: Plan,
     execution: ExecutionSettings,
     operation_started_at: float,
-    test_path: Path,
+    test_path: Path | Sequence[Path],
 ) -> int:
     if not 0 <= execution.shard_index < plan.options.shard_count:
         raise RunnerStateError(

--- a/scripts/test_sharding/state.py
+++ b/scripts/test_sharding/state.py
@@ -204,11 +204,20 @@ class ManifestBuild:
     selection: dict[str, Any]
     estimate_files: dict[str, str | None]
     pytest_command_prefix: tuple[str, ...] = ()
+    test_paths: tuple[Path, ...] | None = None
+
+
+def _resolved_test_paths(
+    test_path: Path, test_paths: Sequence[Path] | None = None
+) -> tuple[Path, ...]:
+    if test_paths:
+        return tuple(path.resolve() for path in test_paths)
+    return (test_path.resolve(),)
 
 
 def build_manifest(request: ManifestBuild) -> dict[str, Any]:
     repo_root = request.repo_root
-    test_path = request.test_path
+    test_paths = _resolved_test_paths(request.test_path, request.test_paths)
     plan = request.plan
     return {
         "schema_version": SCHEMA_VERSION,
@@ -217,7 +226,8 @@ def build_manifest(request: ManifestBuild) -> dict[str, Any]:
         "repository_root": str(repo_root.resolve()),
         "source_git_sha": request.source_git_sha,
         "collection_fingerprint": collection_fingerprint(plan),
-        "test_path": str(test_path.resolve()),
+        "test_path": " ".join(str(path) for path in test_paths),
+        "test_paths": [str(path) for path in test_paths],
         "selection": request.selection,
         "pytest_command_prefix": list(request.pytest_command_prefix),
         "estimate_files": request.estimate_files,
@@ -234,15 +244,18 @@ def verify_manifest(
     planning_options: dict[str, Any],
     pytest_command_prefix: tuple[str, ...] = (),
     estimate_files: dict[str, str | None] | None = None,
+    test_paths: Sequence[Path] | None = None,
 ) -> None:
     mismatches: list[str] = []
+    resolved_paths = _resolved_test_paths(test_path, test_paths)
+    expected_test_path = " ".join(str(path) for path in resolved_paths)
     checks = {
         "schema_version": (manifest.get("schema_version"), SCHEMA_VERSION),
         "algorithm_version": (
             manifest.get("algorithm_version"),
             ALGORITHM_VERSION,
         ),
-        "test_path": (manifest.get("test_path"), str(test_path.resolve())),
+        "test_path": (manifest.get("test_path"), expected_test_path),
         "selection": (manifest.get("selection"), selection),
         "pytest_command_prefix": (
             tuple(manifest.get("pytest_command_prefix", ())),
@@ -253,6 +266,11 @@ def verify_manifest(
             planning_options,
         ),
     }
+    if "test_paths" in manifest:
+        checks["test_paths"] = (
+            manifest.get("test_paths"),
+            [str(path) for path in resolved_paths],
+        )
     if estimate_files is not None:
         checks["estimate_files"] = (manifest.get("estimate_files"), estimate_files)
     for name, (saved, current) in checks.items():

--- a/scripts/unit_test_runner.py
+++ b/scripts/unit_test_runner.py
@@ -29,6 +29,7 @@ from scripts.test_sharding.runner import (
     ExecutionSettings,
     ManifestPreparation,
     SelectionSettings,
+    collapse_test_paths,
     execute_shard,
     finalize_latest,
     plan_description,
@@ -75,6 +76,11 @@ def _pytest_command_prefix() -> tuple[str, ...]:
         return tuple(shlex.split(os.environ.get("PYTEST_COMMAND_PREFIX", "")))
     except ValueError as error:
         raise RunnerStateError(f"invalid PYTEST_COMMAND_PREFIX: {error}") from error
+
+
+def _default_test_paths() -> list[Path]:
+    parts = (os.environ.get("TEST_PATH") or "").split()
+    return [Path(part) for part in parts] if parts else [Path("tests/")]
 
 
 def _configure_output() -> None:
@@ -222,9 +228,10 @@ def _add_common(parser: argparse.ArgumentParser) -> None:
     )
     parser.add_argument(
         "--test-path",
+        nargs="+",
         type=Path,
-        default=Path(os.environ.get("TEST_PATH") or "tests/"),
-        help="pytest collection scope (TEST_PATH)",
+        default=_default_test_paths(),
+        help="pytest collection scope (TEST_PATH; space-separated)",
     )
     parser.add_argument(
         "--sanity-test",
@@ -322,7 +329,7 @@ def _shell_settings(argv: list[str]) -> int:
     except (RunnerStateError, ValueError) as error:
         parser.error(str(error))
     print(operation)
-    print(args.test_path)
+    print(" ".join(str(path) for path in args.test_path))
     return 0
 
 
@@ -363,7 +370,7 @@ def _execute_command(args: argparse.Namespace, operation_started_at: float) -> i
     sample_rate = _env_int("SAMPLE_RATE", 5)
     sample_offset = _env_int("SAMPLE_OFFSET", 0)
     selection = SelectionSettings(
-        test_path=args.test_path.resolve(),
+        test_paths=collapse_test_paths(args.test_path),
         sanity_test=args.sanity_test,
         sample_rate=sample_rate,
         sample_offset=sample_offset,
@@ -381,7 +388,7 @@ def _execute_command(args: argparse.Namespace, operation_started_at: float) -> i
     )
     print(
         f"RUNNER STATUS: state=collecting command={args.command} "
-        f"test_path={selection.test_path}",
+        f"test_path={selection.display_test_path()}",
         flush=True,
     )
     _, plan, created = prepare_manifest(
@@ -464,7 +471,7 @@ def _execute_command(args: argparse.Namespace, operation_started_at: float) -> i
         plan=plan,
         execution=execution,
         operation_started_at=operation_started_at,
-        test_path=selection.test_path,
+        test_path=selection.test_paths,
     )
 
 

--- a/tests/test_sharding/test_runner_cli.py
+++ b/tests/test_sharding/test_runner_cli.py
@@ -147,7 +147,7 @@ def test_empty_test_path_environment_uses_default_suite(
 
     args = unit_test_runner._parser().parse_args(["run"])
 
-    assert args.test_path == Path("tests/")
+    assert args.test_path == [Path("tests/")]
 
 
 @pytest.mark.parametrize(
@@ -1719,3 +1719,75 @@ def test_finalize_fan_in_closes_an_attempt_after_all_leases_are_gone(
     )
     assert summary["complete"] is True
     assert summary["synthetic"] == 1
+
+
+def test_test_path_environment_splits_multiple_scopes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("TEST_PATH", "tests/moe tests/gdn")
+
+    args = unit_test_runner._parser().parse_args(["run"])
+
+    assert args.test_path == [Path("tests/moe"), Path("tests/gdn")]
+
+
+def test_shell_settings_prints_space_separated_paths(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setenv("TEST_PATH", "tests/moe tests/gdn")
+
+    assert unit_test_runner._shell_settings([]) == 0
+    lines = capsys.readouterr().out.splitlines()
+    assert lines[:2] == ["run", "tests/moe tests/gdn"]
+
+
+def test_cli_test_path_accepts_multiple_values(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("TEST_PATH", raising=False)
+
+    args = unit_test_runner._parser().parse_args(
+        ["run", "--test-path", "tests/moe", "tests/gdn"]
+    )
+
+    assert args.test_path == [Path("tests/moe"), Path("tests/gdn")]
+
+
+def test_collapse_drops_nested_file(tmp_path: Path) -> None:
+    parent = tmp_path / "suite"
+    parent.mkdir()
+    child = parent / "test_sample.py"
+    child.write_text("def test_case(): pass\n", encoding="utf-8")
+
+    assert runner.collapse_test_paths([parent, child]) == (parent.resolve(),)
+    assert runner.collapse_test_paths([child, parent]) == (parent.resolve(),)
+
+
+def test_missing_test_path_fails_closed(tmp_path: Path) -> None:
+    present = tmp_path / "suite"
+    present.mkdir()
+    missing = tmp_path / "missing"
+    selection = runner.SelectionSettings(
+        test_paths=(present, missing),
+        sanity_test=False,
+        sample_rate=5,
+        sample_offset=0,
+    )
+
+    with pytest.raises(runner.RunnerStateError, match="missing"):
+        runner._validate_selection(selection)
+
+
+def test_collect_nodes_unions_multiple_directories(tmp_path: Path) -> None:
+    first = tmp_path / "a"
+    second = tmp_path / "b"
+    first.mkdir()
+    second.mkdir()
+    (first / "test_a.py").write_text("def test_a(): pass\n", encoding="utf-8")
+    (second / "test_b.py").write_text("def test_b(): pass\n", encoding="utf-8")
+
+    nodes = runner._collect_nodes(REPO_ROOT, (first, second), 15, 0)
+    nodeids = {node["nodeid"] for node in nodes}
+
+    assert "test_a.py::test_a" in nodeids
+    assert "test_b.py::test_b" in nodeids


### PR DESCRIPTION
## Summary
- Honor a whitespace-separated `TEST_PATH` / `--test-path` list so `/bot run tests/moe tests/gdn` collects the union of those trees in one pipeline.
- Fail closed if any listed path is missing; drop nested targets that are already covered by a parent directory.
- Document the multi-path `/bot run` syntax in CONTRIBUTING.md.

Depends on internal GitLab changes:
- flashinfer-ci MR: pass `TEST_PATH` into Slurm containers
- ci-bot MR: parse multiple `/bot run` paths

Deploy this runner change **before** enabling the ci-bot parser, or a space-separated `TEST_PATH` will fail as a missing directory on old runners.

## Test plan
- [ ] `pytest tests/test_sharding/` (already passing locally)
- [ ] `/bot run` with no path still runs the full suite
- [ ] `/bot run tests/moe tests/gdn` collects both directories
- [ ] `/bot run tests/moe tests/not-a-path` fails the job without falling back to `tests/`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Run the test pipeline against multiple selected files or directories.
  - Support space-separated test paths through command-line options and environment settings.
  - Automatically combine overlapping paths and display all selected paths in status information.
  - Preserve specialized handling for multi-GPU and multi-node test jobs.

- **Bug Fixes**
  - Reject invalid test paths and enforce a maximum of 16 selections.
  - Maintain compatibility with existing test manifests and default to the full test suite when no path is specified.

- **Documentation**
  - Updated CI guidance for targeted test runs and clarified full-pipeline behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->