### PR TITLE
fix: SageAttention support block size doesn't divide sequence; support K-smoothing 

### DIFF
--- a/csrc/nv_internal/tensorrt_llm/common/sageQuant.cu
+++ b/csrc/nv_internal/tensorrt_llm/common/sageQuant.cu
@@ -32,12 +32,17 @@ namespace flashinfer::trtllm {
 // Each launch quantizes Q or K. It can simultaneously collect V scales
 // (VStage=1) or quantize V using scales collected by an earlier launch
 // (VStage=2).
+//
+// Q/K scale layout matches the FMHA kernel: the head stride is
+// ceil(sumSeqLensQk / TokenPerScale) + batchSize - 1. Local token t of sequence b uses
+// cumSeqLens[b] / TokenPerScale + b + t / TokenPerScale. The b padding prevents a trailing
+// partial block from being shared with the next sequence.
 template <typename Element, typename ElementQuantized, int TokenPerScale, int HeadDim, bool KSmooth,
           int VStage>
-__global__ void sageQuantQkvKernel(int sumSeqLensQk, void const* ptrQk, void* ptrQkQuant,
-                                   float* ptrQkScale, float* ptrKMean, int sumSeqLensV,
-                                   int numHeadsV, void const* ptrV, void* ptrVQuant,
-                                   float* ptrVScale) {
+__global__ void sageQuantQkvKernel(int sumSeqLensQk, int batchSize, int const* ptrCuSeqLensQk,
+                                   void const* ptrQk, void* ptrQkQuant, float* ptrQkScale,
+                                   float* ptrKMean, int sumSeqLensV, int numHeadsV,
+                                   void const* ptrV, void* ptrVQuant, float* ptrVScale) {
   using namespace cute;
   using namespace cutlass;
   static_assert(!KSmooth, "K-smoothing not implemented yet");
@@ -51,80 +56,71 @@ __global__ void sageQuantQkvKernel(int sumSeqLensQk, void const* ptrQk, void* pt
 
   (void)ptrKMean;
 
-  int const numHeads = gridDim.y;
-  int const headIdx = blockIdx.y;
   int const numWarpsPerCta = blockDim.x / 32;
   int const numWarps = gridDim.x * numWarpsPerCta;
   int const warpId = blockIdx.x * numWarpsPerCta + threadIdx.x / 32;
   int const thrId = threadIdx.x % 32;
 
   if (blockIdx.z == 0) {
-    Tensor gQk = make_tensor(reinterpret_cast<Element const*>(ptrQk),
-                             make_shape(Int<HeadDim>{}, numHeads, sumSeqLensQk));
-    Tensor gQkQuant = make_tensor(reinterpret_cast<ElementQuantized*>(ptrQkQuant),
-                                  make_shape(Int<HeadDim>{}, numHeads, sumSeqLensQk));
-    Tensor gQkScale =
-        make_tensor(ptrQkScale, make_shape(ceil_div(sumSeqLensQk, TokenPerScale), numHeads));
+    // blockIdx.y maps to (headIdx * batchSize + seqIdx).
+    int const numHeads = gridDim.y / batchSize;
+    int const headIdx = blockIdx.y / batchSize;
+    int const seqIdx = blockIdx.y % batchSize;
 
-    Tensor gQkSeq = gQk(_, headIdx, _);
-    Tensor gQkSeqQuant = gQkQuant(_, headIdx, _);
-    Tensor gQkSeqScale = gQkScale(_, headIdx);
-    Tensor gQkVecs = tiled_divide(gQkSeq, Shape<VL, Int<TokenPerScale>>{});
-    Tensor gQkVecsQuant = tiled_divide(gQkSeqQuant, Shape<VL, Int<TokenPerScale>>{});
-
-    Tensor rQk = make_tensor<Element>(Shape<VL, Int<TokenPerScale>>{});
-    Tensor rQkQuant = make_tensor<ElementQuantized>(Shape<VL, Int<TokenPerScale>>{});
-    Tensor rQkCompute = make_tensor<float>(Shape<VL, Int<TokenPerScale>>{});
-    Tensor rQk_x2 = recast<Array<Element, 2>>(rQk);
-    Tensor rQkCompute_x2 = recast<Array<float, 2>>(rQkCompute);
-    Tensor rQk_x4 = recast<Array<Element, 4>>(rQk);
-    Tensor rQkQuant_x4 = recast<Array<ElementQuantized, 4>>(rQkQuant);
-
-    constexpr int threadsPerScale = size<1>(gQkVecs);
+    constexpr int threadsPerScale = HeadDim / BestVL;
+    static_assert(HeadDim % BestVL == 0, "VL must divide HeadDim");
     static_assert(threadsPerScale <= 32, "One token block should never exceed warp scope");
     int const numScalesPerWarp = 32 / threadsPerScale;
     int const numScalesPerWave = numWarps * numScalesPerWarp;
-    int const numWholeScales = sumSeqLensQk / TokenPerScale;
-    int tokBlkIdx = warpId * numScalesPerWarp + thrId / threadsPerScale;
+    int const tokBlkIdxInWave = warpId * numScalesPerWarp + thrId / threadsPerScale;
     int const threadInScaleIdx = thrId % threadsPerScale;
+    constexpr uint32_t scaleMask = threadsPerScale == 32 ? ~0u : ((1u << threadsPerScale) - 1u);
+    uint32_t const laneMask = scaleMask << (thrId / threadsPerScale * threadsPerScale);
 
-    for (; tokBlkIdx < numWholeScales; tokBlkIdx += numScalesPerWave) {
-      cute::copy(AutoVectorizingCopy{}, gQkVecs(_, threadInScaleIdx, tokBlkIdx), rQk);
-      cute::transform(rQk_x2, rQkCompute_x2, NumericArrayConverter<float, Element, 2>::convert);
-
-      float maxScale = 1e-3f;
-      CUTLASS_PRAGMA_UNROLL
-      for (int i = 0; i < size(rQk); ++i) {
-        maxScale = ::fmaxf(maxScale, ::fabsf(rQkCompute(i)));
-      }
-      CUTLASS_PRAGMA_UNROLL
-      for (int delta = 1; delta < threadsPerScale; delta <<= 1) {
-        maxScale = ::fmaxf(maxScale, __shfl_xor_sync(0xffffffffu, maxScale, delta));
-      }
-
-      maxScale /= TypeMax;
-      gQkSeqScale(tokBlkIdx) = maxScale;
-      Array<Element, 2> scaleQuant =
-          NumericArrayConverter<Element, float, 2>::convert(Array<float, 2>{maxScale, maxScale});
-      scaleQuant = cutlass::reciprocal_approximate<Array<Element, 2>>{}(scaleQuant);
-      cutlass::multiplies<Array<Element, 2>> scaleQuantOp;
-      cute::transform(rQk_x2, rQk_x2, [&](auto& x) { return scaleQuantOp(x, scaleQuant); });
-      cute::transform(rQk_x4, rQkQuant_x4,
-                      NumericArrayConverter<ElementQuantized, Element, 4>::convert);
-      cute::copy(AutoVectorizingCopy{}, rQkQuant, gQkVecsQuant(_, threadInScaleIdx, tokBlkIdx));
+    int const seqBegin = ptrCuSeqLensQk[seqIdx];
+    int const seqLen = ptrCuSeqLensQk[seqIdx + 1] - seqBegin;
+    if (seqLen <= 0) {
+      return;
     }
 
-    int const lastIterTokenIdx = tokBlkIdx * TokenPerScale;
-    if (lastIterTokenIdx < sumSeqLensQk) {
-      CUTLASS_PRAGMA_UNROLL
-      for (int i = 0; i < size<1>(rQk); ++i) {
-        if (lastIterTokenIdx + i < sumSeqLensQk) {
-          cute::copy(AutoVectorizingCopy{}, gQkVecs(make_tuple(_, i), threadInScaleIdx, tokBlkIdx),
-                     rQk(_, i));
-        } else {
-          CUTLASS_PRAGMA_UNROLL
-          for (int j = 0; j < BestVL; ++j) {
-            rQk(j, i) = static_cast<Element>(0);
+    float* ptrQkScaleHead =
+        ptrQkScale +
+        static_cast<int64_t>(headIdx) * (ceil_div(sumSeqLensQk, TokenPerScale) + batchSize - 1);
+    int const tokenStride = numHeads * HeadDim;
+    int64_t const seqHeadOffset = static_cast<int64_t>(seqBegin) * tokenStride + headIdx * HeadDim;
+    Tensor gQkSeq = make_tensor(reinterpret_cast<Element const*>(ptrQk) + seqHeadOffset,
+                                make_shape(Int<HeadDim>{}, seqLen), make_stride(_1{}, tokenStride));
+    Tensor gQkSeqQuant =
+        make_tensor(reinterpret_cast<ElementQuantized*>(ptrQkQuant) + seqHeadOffset,
+                    make_shape(Int<HeadDim>{}, seqLen), make_stride(_1{}, tokenStride));
+    Tensor gQkSeqScale = make_tensor(ptrQkScaleHead + seqBegin / TokenPerScale + seqIdx,
+                                     make_shape(ceil_div(seqLen, TokenPerScale)));
+    Tensor gQkVecs = tiled_divide(gQkSeq, Shape<VL, Int<TokenPerScale>>{});
+    Tensor gQkVecsQuant = tiled_divide(gQkSeqQuant, Shape<VL, Int<TokenPerScale>>{});
+
+    auto quantizeTokBlk = [&](auto isFullBlk, int tokBlkIdx, int numValidTokens) {
+      constexpr bool IsFullBlk = decltype(isFullBlk)::value;
+      Tensor rQk = make_tensor<Element>(Shape<VL, Int<TokenPerScale>>{});
+      Tensor rQkQuant = make_tensor<ElementQuantized>(Shape<VL, Int<TokenPerScale>>{});
+      Tensor rQkCompute = make_tensor<float>(Shape<VL, Int<TokenPerScale>>{});
+      Tensor rQk_x2 = recast<Array<Element, 2>>(rQk);
+      Tensor rQkCompute_x2 = recast<Array<float, 2>>(rQkCompute);
+      Tensor rQk_x4 = recast<Array<Element, 4>>(rQk);
+      Tensor rQkQuant_x4 = recast<Array<ElementQuantized, 4>>(rQkQuant);
+
+      if constexpr (IsFullBlk) {
+        cute::copy(AutoVectorizingCopy{}, gQkVecs(_, threadInScaleIdx, tokBlkIdx), rQk);
+      } else {
+        CUTLASS_PRAGMA_UNROLL
+        for (int i = 0; i < size<1>(rQk); ++i) {
+          if (i < numValidTokens) {
+            cute::copy(AutoVectorizingCopy{},
+                       gQkVecs(make_tuple(_, i), threadInScaleIdx, tokBlkIdx), rQk(_, i));
+          } else {
+            CUTLASS_PRAGMA_UNROLL
+            for (int j = 0; j < BestVL; ++j) {
+              rQk(j, i) = static_cast<Element>(0);
+            }
           }
         }
       }
@@ -137,7 +133,7 @@ __global__ void sageQuantQkvKernel(int sumSeqLensQk, void const* ptrQk, void* pt
       }
       CUTLASS_PRAGMA_UNROLL
       for (int delta = 1; delta < threadsPerScale; delta <<= 1) {
-        maxScale = ::fmaxf(maxScale, __shfl_xor_sync(0xffffffffu, maxScale, delta));
+        maxScale = ::fmaxf(maxScale, __shfl_xor_sync(laneMask, maxScale, delta));
       }
 
       maxScale /= TypeMax;
@@ -150,15 +146,31 @@ __global__ void sageQuantQkvKernel(int sumSeqLensQk, void const* ptrQk, void* pt
       cute::transform(rQk_x4, rQkQuant_x4,
                       NumericArrayConverter<ElementQuantized, Element, 4>::convert);
 
-      CUTLASS_PRAGMA_UNROLL
-      for (int i = 0; i < size<1>(rQk); ++i) {
-        if (lastIterTokenIdx + i < sumSeqLensQk) {
-          cute::copy(AutoVectorizingCopy{}, rQkQuant(_, i),
-                     gQkVecsQuant(make_tuple(_, i), threadInScaleIdx, tokBlkIdx));
+      if constexpr (IsFullBlk) {
+        cute::copy(AutoVectorizingCopy{}, rQkQuant, gQkVecsQuant(_, threadInScaleIdx, tokBlkIdx));
+      } else {
+        CUTLASS_PRAGMA_UNROLL
+        for (int i = 0; i < size<1>(rQk); ++i) {
+          if (i < numValidTokens) {
+            cute::copy(AutoVectorizingCopy{}, rQkQuant(_, i),
+                       gQkVecsQuant(make_tuple(_, i), threadInScaleIdx, tokBlkIdx));
+          }
         }
       }
+    };
+
+    int const numWholeScales = seqLen / TokenPerScale;
+    for (int tokBlkIdx = tokBlkIdxInWave; tokBlkIdx < numWholeScales;
+         tokBlkIdx += numScalesPerWave) {
+      quantizeTokBlk(cute::true_type{}, tokBlkIdx, TokenPerScale);
+    }
+
+    int const numTailTokens = seqLen - numWholeScales * TokenPerScale;
+    if (numTailTokens > 0 && tokBlkIdxInWave == numWholeScales % numScalesPerWave) {
+      quantizeTokBlk(cute::false_type{}, numWholeScales, numTailTokens);
     }
   } else if (blockIdx.z == 1) {
+    int const headIdx = blockIdx.y;
     using ElementQuantizedV = cutlass::float_e4m3_t;
     constexpr int threadsPerHead = HeadDim / BestVL;
     static_assert(HeadDim % BestVL == 0, "VL must divide HeadDim");
@@ -243,8 +255,9 @@ __global__ void sageQuantQkvKernel(int sumSeqLensQk, void const* ptrQk, void* pt
 template <typename Element>
 void invokeSageQuantQkvImpl(SageQuantParams const& params) {
   using namespace cute;
-  FLASHINFER_CHECK(params.sumSeqLensQk > 0 && params.numHeads > 0 && params.headDim > 0 &&
-                       params.tokenBlockSize > 0 && params.ptrQk != nullptr &&
+  FLASHINFER_CHECK(params.sumSeqLensQk > 0 && params.batchSize > 0 &&
+                       params.ptrCuSeqLensQk != nullptr && params.numHeads > 0 &&
+                       params.headDim > 0 && params.tokenBlockSize > 0 && params.ptrQk != nullptr &&
                        params.ptrQkQuant != nullptr && params.ptrQkScale != nullptr &&
                        params.smCount > 0,
                    "Invalid SageQuantQk parameters");
@@ -258,11 +271,11 @@ void invokeSageQuantQkvImpl(SageQuantParams const& params) {
     constexpr int HeadDim_ = headDimStatic;
     constexpr int TokenBlockSize_ = tokenBlockSizeStatic;
     SageQuantParams kernelParams = params;
-    void* kernelArgs[] = {&kernelParams.sumSeqLensQk, &kernelParams.ptrQk,
-                          &kernelParams.ptrQkQuant,   &kernelParams.ptrQkScale,
-                          &kernelParams.ptrKMean,     &kernelParams.sumSeqLensV,
-                          &kernelParams.numHeadsV,    &kernelParams.ptrV,
-                          &kernelParams.ptrVQuant,    &kernelParams.ptrVScale};
+    void* kernelArgs[] = {
+        &kernelParams.sumSeqLensQk, &kernelParams.batchSize,   &kernelParams.ptrCuSeqLensQk,
+        &kernelParams.ptrQk,        &kernelParams.ptrQkQuant,  &kernelParams.ptrQkScale,
+        &kernelParams.ptrKMean,     &kernelParams.sumSeqLensV, &kernelParams.numHeadsV,
+        &kernelParams.ptrV,         &kernelParams.ptrVQuant,   &kernelParams.ptrVScale};
 
     auto launchWithVStage = [&](auto vStageStatic) {
       constexpr int VStage_ = vStageStatic;
@@ -277,9 +290,10 @@ void invokeSageQuantQkvImpl(SageQuantParams const& params) {
       } else {
         FLASHINFER_ERROR("SageQuant Q/K output must be INT8 or FP8 E4M3");
       }
+      int const numHeadSeqs = params.numHeads * params.batchSize;
       uint32_t const gridX =
-          static_cast<uint32_t>(std::max(1, (params.smCount * 32) / params.numHeads));
-      dim3 const launchGrid{gridX, static_cast<uint32_t>(params.numHeads), VStage_ > 0 ? 2U : 1U};
+          static_cast<uint32_t>(std::max(1, (params.smCount * 32) / numHeadSeqs));
+      dim3 const launchGrid{gridX, static_cast<uint32_t>(numHeadSeqs), VStage_ > 0 ? 2U : 1U};
       auto status =
           cudaLaunchKernel(kernelFunc, launchGrid, dim3{64U, 1U, 1U}, kernelArgs, 0, params.stream);
       FLASHINFER_CHECK(status == cudaSuccess, cudaGetErrorString(status));

--- a/csrc/nv_internal/tensorrt_llm/common/sageQuant.cu
+++ b/csrc/nv_internal/tensorrt_llm/common/sageQuant.cu
@@ -31,21 +31,24 @@ namespace flashinfer::trtllm {
 // [D, H, S], which is the same physical layout as contiguous PyTorch [S, H, D].
 // Each launch quantizes Q or K. It can simultaneously collect V scales
 // (VStage=1) or quantize V using scales collected by an earlier launch
-// (VStage=2).
+// (VStage=2). When SmoothK is enabled, the VStage=1 launch also collects a
+// per-head-per-channel K mean and the VStage=2 launch uses it to perform
+// K-smoothing before quantization.
 //
 // Q/K scale layout matches the FMHA kernel: the head stride is
 // ceil(sumSeqLensQk / TokenPerScale) + batchSize - 1. Local token t of sequence b uses
 // cumSeqLens[b] / TokenPerScale + b + t / TokenPerScale. The b padding prevents a trailing
 // partial block from being shared with the next sequence.
-template <typename Element, typename ElementQuantized, int TokenPerScale, int HeadDim, bool KSmooth,
+template <typename Element, typename ElementQuantized, int TokenPerScale, int HeadDim, bool SmoothK,
           int VStage>
 __global__ void sageQuantQkvKernel(int sumSeqLensQk, int batchSize, int const* ptrCuSeqLensQk,
                                    void const* ptrQk, void* ptrQkQuant, float* ptrQkScale,
-                                   float* ptrKMean, int sumSeqLensV, int numHeadsV,
-                                   void const* ptrV, void* ptrVQuant, float* ptrVScale) {
+                                   void const* ptrKForMean, float* ptrKMean, int sumSeqLensV,
+                                   int numHeadsV, void const* ptrV, void* ptrVQuant,
+                                   float* ptrVScale) {
   using namespace cute;
   using namespace cutlass;
-  static_assert(!KSmooth, "K-smoothing not implemented yet");
+  static_assert(!SmoothK || VStage != 0, "K smoothing requires V staging");
   static_assert(std::is_same_v<ElementQuantized, float_e4m3_t> ||
                     std::is_same_v<ElementQuantized, std::int8_t>,
                 "Unrecognized target dtype for quantization");
@@ -53,8 +56,6 @@ __global__ void sageQuantQkvKernel(int sumSeqLensQk, int batchSize, int const* p
       cute::is_same_v<ElementQuantized, float_e4m3_t> ? 448.0f : static_cast<float>(126.9f);
   constexpr int BestVL = 128 / sizeof_bits_v<Element>;
   using VL = Int<BestVL>;
-
-  (void)ptrKMean;
 
   int const numWarpsPerCta = blockDim.x / 32;
   int const numWarps = gridDim.x * numWarpsPerCta;
@@ -126,6 +127,20 @@ __global__ void sageQuantQkvKernel(int sumSeqLensQk, int batchSize, int const* p
       }
       cute::transform(rQk_x2, rQkCompute_x2, NumericArrayConverter<float, Element, 2>::convert);
 
+      if constexpr (SmoothK && VStage == 2) {
+        float const* ptrKMeanHead = ptrKMean + headIdx * HeadDim;
+        int const numValidTokensLoc = IsFullBlk ? TokenPerScale : numValidTokens;
+        CUTLASS_PRAGMA_UNROLL
+        for (int tokenIdx = 0; tokenIdx < TokenPerScale; ++tokenIdx) {
+          if (tokenIdx < numValidTokensLoc) {
+            CUTLASS_PRAGMA_UNROLL
+            for (int vecIdx = 0; vecIdx < BestVL; ++vecIdx) {
+              rQkCompute(vecIdx, tokenIdx) -= ptrKMeanHead[threadInScaleIdx * BestVL + vecIdx];
+            }
+          }
+        }
+      }
+
       float maxScale = 1e-3f;
       CUTLASS_PRAGMA_UNROLL
       for (int i = 0; i < size(rQk); ++i) {
@@ -138,13 +153,23 @@ __global__ void sageQuantQkvKernel(int sumSeqLensQk, int batchSize, int const* p
 
       maxScale /= TypeMax;
       gQkSeqScale(tokBlkIdx) = maxScale;
-      Array<Element, 2> scaleQuant =
-          NumericArrayConverter<Element, float, 2>::convert(Array<float, 2>{maxScale, maxScale});
-      scaleQuant = cutlass::reciprocal_approximate<Array<Element, 2>>{}(scaleQuant);
-      cutlass::multiplies<Array<Element, 2>> scaleQuantOp;
-      cute::transform(rQk_x2, rQk_x2, [&](auto& x) { return scaleQuantOp(x, scaleQuant); });
-      cute::transform(rQk_x4, rQkQuant_x4,
-                      NumericArrayConverter<ElementQuantized, Element, 4>::convert);
+      if constexpr (SmoothK && VStage == 2) {
+        // rQkCompute holds the result value
+        Tensor rQkCompute_x4 = recast<Array<float, 4>>(rQkCompute);
+        float const invScale = 1.0f / maxScale;
+        cute::transform(rQkCompute, rQkCompute, [&](float const& x) { return x * invScale; });
+        cute::transform(rQkCompute_x4, rQkQuant_x4,
+                        NumericArrayConverter<ElementQuantized, float, 4>::convert);
+      } else {
+        // rQk holds to result value
+        Array<Element, 2> scaleQuant =
+            NumericArrayConverter<Element, float, 2>::convert(Array<float, 2>{maxScale, maxScale});
+        scaleQuant = cutlass::reciprocal_approximate<Array<Element, 2>>{}(scaleQuant);
+        cutlass::multiplies<Array<Element, 2>> scaleQuantOp;
+        cute::transform(rQk_x2, rQk_x2, [&](auto& x) { return scaleQuantOp(x, scaleQuant); });
+        cute::transform(rQk_x4, rQkQuant_x4,
+                        NumericArrayConverter<ElementQuantized, Element, 4>::convert);
+      }
 
       if constexpr (IsFullBlk) {
         cute::copy(AutoVectorizingCopy{}, rQkQuant, gQkVecsQuant(_, threadInScaleIdx, tokBlkIdx));
@@ -249,6 +274,58 @@ __global__ void sageQuantQkvKernel(int sumSeqLensQk, int batchSize, int const* p
         }
       }
     }
+  } else if (blockIdx.z == 2) {
+    if constexpr (SmoothK && VStage == 1) {
+      int const headIdx = blockIdx.y;
+      constexpr int threadsPerHead = HeadDim / BestVL;
+      static_assert(HeadDim % BestVL == 0, "VL must divide HeadDim");
+      static_assert(threadsPerHead <= 32, "One token block should never exceed warp scope");
+
+      if (headIdx < numHeadsV) {
+        Tensor gK = make_tensor(reinterpret_cast<Element const*>(ptrKForMean),
+                                make_shape(VL{}, Int<threadsPerHead>{}, numHeadsV, sumSeqLensV));
+        Tensor gKMean = make_tensor(ptrKMean, make_shape(VL{}, Int<threadsPerHead>{}, numHeadsV));
+        Tensor rK = make_tensor<Element>(Shape<VL>{});
+        Tensor rKCompute = make_tensor<float>(Shape<VL>{});
+        Tensor rKSum = make_tensor<float>(Shape<VL>{});
+        Tensor rK_x2 = recast<Array<Element, 2>>(rK);
+        Tensor rKCompute_x2 = recast<Array<float, 2>>(rKCompute);
+
+        int const numToksPerWarp = 32 / threadsPerHead;
+        int const numWarpsToUse = cutlass::fast_min(numWarps, 256);
+        int const numToksPerWave = numWarpsToUse * numToksPerWarp;
+        if (warpId >= numWarpsToUse) {
+          return;
+        }
+        int tokIdx = warpId * numToksPerWarp + thrId / threadsPerHead;
+        int const threadInTokIdx = thrId % threadsPerHead;
+        Tensor gKSeq = gK(_, threadInTokIdx, headIdx, _);
+        Tensor gKMeanHead = gKMean(_, threadInTokIdx, headIdx);
+
+        clear(rKSum);
+        for (; tokIdx < sumSeqLensV; tokIdx += numToksPerWave) {
+          cute::copy(AutoVectorizingCopy{}, gKSeq(_, tokIdx), rK);
+          cute::transform(rK_x2, rKCompute_x2, NumericArrayConverter<float, Element, 2>::convert);
+          CUTLASS_PRAGMA_UNROLL
+          for (int i = 0; i < BestVL; ++i) {
+            rKSum(i) += rKCompute(i);
+          }
+        }
+        for (int delta = threadsPerHead; delta < 32; delta <<= 1) {
+          CUTLASS_PRAGMA_UNROLL
+          for (int i = 0; i < BestVL; ++i) {
+            rKSum(i) += __shfl_xor_sync(0xffffffffu, rKSum(i), delta);
+          }
+        }
+        if (threadInTokIdx == thrId) {
+          float const invNumTokens = 1.0f / sumSeqLensV;
+          CUTLASS_PRAGMA_UNROLL
+          for (int i = 0; i < BestVL; ++i) {
+            atomicAdd(&gKMeanHead(i), rKSum(i) * invNumTokens);
+          }
+        }
+      }
+    }
   }
 }
 
@@ -265,35 +342,42 @@ void invokeSageQuantQkvImpl(SageQuantParams const& params) {
                        (params.sumSeqLensV > 0 && params.numHeadsV > 0 && params.ptrV != nullptr &&
                         params.ptrVQuant != nullptr && params.ptrVScale != nullptr),
                    "Invalid SageQuantV parameters");
-  FLASHINFER_CHECK(!params.kSmooth, "SageQuantQk K-smoothing is not supported yet");
+  FLASHINFER_CHECK(!params.kSmooth || params.vStage != 0,
+                   "SageQuant K smoothing requires V staging");
+  FLASHINFER_CHECK(!params.kSmooth || (params.ptrKMean != nullptr &&
+                                       (params.vStage != 1 || params.ptrKForMean != nullptr)),
+                   "Invalid SageQuant K-smoothing parameters");
 
   auto invokeKernel = [&](auto headDimStatic, auto tokenBlockSizeStatic) {
     constexpr int HeadDim_ = headDimStatic;
     constexpr int TokenBlockSize_ = tokenBlockSizeStatic;
     SageQuantParams kernelParams = params;
     void* kernelArgs[] = {
-        &kernelParams.sumSeqLensQk, &kernelParams.batchSize,   &kernelParams.ptrCuSeqLensQk,
-        &kernelParams.ptrQk,        &kernelParams.ptrQkQuant,  &kernelParams.ptrQkScale,
-        &kernelParams.ptrKMean,     &kernelParams.sumSeqLensV, &kernelParams.numHeadsV,
-        &kernelParams.ptrV,         &kernelParams.ptrVQuant,   &kernelParams.ptrVScale};
+        &kernelParams.sumSeqLensQk, &kernelParams.batchSize,  &kernelParams.ptrCuSeqLensQk,
+        &kernelParams.ptrQk,        &kernelParams.ptrQkQuant, &kernelParams.ptrQkScale,
+        &kernelParams.ptrKForMean,  &kernelParams.ptrKMean,   &kernelParams.sumSeqLensV,
+        &kernelParams.numHeadsV,    &kernelParams.ptrV,       &kernelParams.ptrVQuant,
+        &kernelParams.ptrVScale};
 
-    auto launchWithVStage = [&](auto vStageStatic) {
+    auto launchKernel = [&](auto smoothKStatic, auto vStageStatic) {
+      constexpr bool SmoothK_ = decltype(smoothKStatic)::value;
       constexpr int VStage_ = vStageStatic;
       void const* kernelFunc = nullptr;
       if (params.quantType == DATA_TYPE_E4M3) {
         kernelFunc = reinterpret_cast<void const*>(
-            sageQuantQkvKernel<Element, cutlass::float_e4m3_t, TokenBlockSize_, HeadDim_, false,
+            sageQuantQkvKernel<Element, cutlass::float_e4m3_t, TokenBlockSize_, HeadDim_, SmoothK_,
                                VStage_>);
       } else if (params.quantType == DATA_TYPE_INT8) {
         kernelFunc = reinterpret_cast<void const*>(
-            sageQuantQkvKernel<Element, std::int8_t, TokenBlockSize_, HeadDim_, false, VStage_>);
+            sageQuantQkvKernel<Element, std::int8_t, TokenBlockSize_, HeadDim_, SmoothK_, VStage_>);
       } else {
         FLASHINFER_ERROR("SageQuant Q/K output must be INT8 or FP8 E4M3");
       }
       int const numHeadSeqs = params.numHeads * params.batchSize;
       uint32_t const gridX =
           static_cast<uint32_t>(std::max(1, (params.smCount * 32) / numHeadSeqs));
-      dim3 const launchGrid{gridX, static_cast<uint32_t>(numHeadSeqs), VStage_ > 0 ? 2U : 1U};
+      constexpr uint32_t GridZ = VStage_ == 0 ? 1U : (SmoothK_ && VStage_ == 1 ? 3U : 2U);
+      dim3 const launchGrid{gridX, static_cast<uint32_t>(numHeadSeqs), GridZ};
       auto status =
           cudaLaunchKernel(kernelFunc, launchGrid, dim3{64U, 1U, 1U}, kernelArgs, 0, params.stream);
       FLASHINFER_CHECK(status == cudaSuccess, cudaGetErrorString(status));
@@ -303,13 +387,21 @@ void invokeSageQuantQkvImpl(SageQuantParams const& params) {
 
     switch (params.vStage) {
       case 0:
-        launchWithVStage(Int<0>{});
+        launchKernel(cute::false_type{}, Int<0>{});
         return;
       case 1:
-        launchWithVStage(Int<1>{});
+        if (params.kSmooth) {
+          launchKernel(cute::true_type{}, Int<1>{});
+        } else {
+          launchKernel(cute::false_type{}, Int<1>{});
+        }
         return;
       case 2:
-        launchWithVStage(Int<2>{});
+        if (params.kSmooth) {
+          launchKernel(cute::true_type{}, Int<2>{});
+        } else {
+          launchKernel(cute::false_type{}, Int<2>{});
+        }
         return;
       default:
         FLASHINFER_ERROR("Unsupported SageQuantV stage");

--- a/csrc/trtllm_sage_quant.cu
+++ b/csrc/trtllm_sage_quant.cu
@@ -27,6 +27,7 @@ using trtllm::SageQuantParams;
 void trtllm_sage_attention_quantize(TensorView q_quant, TensorView k_quant, TensorView v_quant,
                                     TensorView q_scale, TensorView k_scale, TensorView v_scale,
                                     TensorView query, TensorView key, TensorView value,
+                                    TensorView cum_seq_lens_q, TensorView cum_seq_lens_kv,
                                     int64_t q_block_size, int64_t k_block_size, int64_t sm_count) {
   TVM_FFI_ICHECK_EQ(query.ndim(), 3) << "query must have shape [tokens, heads, head_dim]";
   TVM_FFI_ICHECK_EQ(key.ndim(), 3) << "key must have shape [tokens, heads, head_dim]";
@@ -48,6 +49,18 @@ void trtllm_sage_attention_quantize(TensorView q_quant, TensorView k_quant, Tens
   TVM_FFI_ICHECK(is_contiguous_3d(query)) << "query must be contiguous";
   TVM_FFI_ICHECK(is_contiguous_3d(key)) << "key must be contiguous";
   TVM_FFI_ICHECK(is_contiguous_3d(value)) << "value must be contiguous";
+
+  TVM_FFI_ICHECK_EQ(cum_seq_lens_q.ndim(), 1) << "cum_seq_lens_q must be 1D";
+  TVM_FFI_ICHECK_EQ(cum_seq_lens_kv.ndim(), 1) << "cum_seq_lens_kv must be 1D";
+  TVM_FFI_ICHECK_EQ(cum_seq_lens_q.dtype(), dl_int32) << "cum_seq_lens_q must be int32";
+  TVM_FFI_ICHECK_EQ(cum_seq_lens_kv.dtype(), dl_int32) << "cum_seq_lens_kv must be int32";
+  TVM_FFI_ICHECK_EQ(cum_seq_lens_q.stride(0), 1) << "cum_seq_lens_q must be contiguous";
+  TVM_FFI_ICHECK_EQ(cum_seq_lens_kv.stride(0), 1) << "cum_seq_lens_kv must be contiguous";
+  TVM_FFI_ICHECK_EQ(cum_seq_lens_q.size(0), cum_seq_lens_kv.size(0))
+      << "Q and KV cumulative sequence lengths must have the same size";
+  TVM_FFI_ICHECK_GT(cum_seq_lens_q.size(0), 1)
+      << "cumulative sequence lengths must contain at least one sequence";
+  int64_t const batch_size = cum_seq_lens_q.size(0) - 1;
 
   TVM_FFI_ICHECK_EQ(q_quant.ndim(), 3);
   TVM_FFI_ICHECK_EQ(k_quant.ndim(), 3);
@@ -71,10 +84,12 @@ void trtllm_sage_attention_quantize(TensorView q_quant, TensorView k_quant, Tens
   TVM_FFI_ICHECK_EQ(q_scale.dtype(), dl_float32);
   TVM_FFI_ICHECK_EQ(k_scale.dtype(), dl_float32);
   TVM_FFI_ICHECK_EQ(v_scale.dtype(), dl_float32);
-  TVM_FFI_ICHECK_EQ(q_scale.numel(),
-                    query.size(1) * ((query.size(0) + q_block_size - 1) / q_block_size));
-  TVM_FFI_ICHECK_EQ(k_scale.numel(),
-                    key.size(1) * ((key.size(0) + k_block_size - 1) / k_block_size));
+  TVM_FFI_ICHECK_EQ(
+      q_scale.numel(),
+      query.size(1) * ((query.size(0) + q_block_size - 1) / q_block_size + batch_size - 1));
+  TVM_FFI_ICHECK_EQ(
+      k_scale.numel(),
+      key.size(1) * ((key.size(0) + k_block_size - 1) / k_block_size + batch_size - 1));
   TVM_FFI_ICHECK_EQ(v_scale.numel(), value.size(1) * value.size(2));
   TVM_FFI_ICHECK_GT(sm_count, 0);
 
@@ -97,6 +112,8 @@ void trtllm_sage_attention_quantize(TensorView q_quant, TensorView k_quant, Tens
   params.stream = stream;
 
   params.sumSeqLensQk = query.size(0);
+  params.batchSize = batch_size;
+  params.ptrCuSeqLensQk = static_cast<int const*>(cum_seq_lens_q.data_ptr());
   params.numHeads = query.size(1);
   params.tokenBlockSize = q_block_size;
   params.ptrQk = query.data_ptr();
@@ -106,6 +123,7 @@ void trtllm_sage_attention_quantize(TensorView q_quant, TensorView k_quant, Tens
   invokeSageQuant(params);
 
   params.sumSeqLensQk = key.size(0);
+  params.ptrCuSeqLensQk = static_cast<int const*>(cum_seq_lens_kv.data_ptr());
   params.numHeads = key.size(1);
   params.tokenBlockSize = k_block_size;
   params.ptrQk = key.data_ptr();

--- a/csrc/trtllm_sage_quant.cu
+++ b/csrc/trtllm_sage_quant.cu
@@ -23,12 +23,14 @@ namespace flashinfer {
 
 using trtllm::invokeSageQuant;
 using trtllm::SageQuantParams;
+using tvm::ffi::Optional;
 
 void trtllm_sage_attention_quantize(TensorView q_quant, TensorView k_quant, TensorView v_quant,
                                     TensorView q_scale, TensorView k_scale, TensorView v_scale,
                                     TensorView query, TensorView key, TensorView value,
                                     TensorView cum_seq_lens_q, TensorView cum_seq_lens_kv,
-                                    int64_t q_block_size, int64_t k_block_size, int64_t sm_count) {
+                                    int64_t q_block_size, int64_t k_block_size, int64_t sm_count,
+                                    Optional<TensorView> maybe_k_mean, bool smooth_k) {
   TVM_FFI_ICHECK_EQ(query.ndim(), 3) << "query must have shape [tokens, heads, head_dim]";
   TVM_FFI_ICHECK_EQ(key.ndim(), 3) << "key must have shape [tokens, heads, head_dim]";
   TVM_FFI_ICHECK_EQ(value.ndim(), 3) << "value must have shape [tokens, heads, head_dim]";
@@ -91,6 +93,16 @@ void trtllm_sage_attention_quantize(TensorView q_quant, TensorView k_quant, Tens
       k_scale.numel(),
       key.size(1) * ((key.size(0) + k_block_size - 1) / k_block_size + batch_size - 1));
   TVM_FFI_ICHECK_EQ(v_scale.numel(), value.size(1) * value.size(2));
+  if (smooth_k) {
+    TVM_FFI_ICHECK(maybe_k_mean.has_value()) << "k_mean is required when smooth_k is enabled";
+    auto const& k_mean = *maybe_k_mean;
+    TVM_FFI_ICHECK_EQ(k_mean.ndim(), 2) << "k_mean must have shape [heads, head_dim]";
+    TVM_FFI_ICHECK_EQ(k_mean.size(0), key.size(1));
+    TVM_FFI_ICHECK_EQ(k_mean.size(1), key.size(2));
+    TVM_FFI_ICHECK_EQ(k_mean.dtype(), dl_float32);
+    TVM_FFI_ICHECK_EQ(k_mean.stride(1), 1) << "k_mean must be contiguous";
+    TVM_FFI_ICHECK_EQ(k_mean.stride(0), k_mean.size(1)) << "k_mean must be contiguous";
+  }
   TVM_FFI_ICHECK_GT(sm_count, 0);
 
   ffi::CUDADeviceGuard device_guard(query.device().device_id);
@@ -98,6 +110,12 @@ void trtllm_sage_attention_quantize(TensorView q_quant, TensorView k_quant, Tens
   auto const memset_status =
       cudaMemsetAsync(v_scale.data_ptr(), 0, v_scale.numel() * sizeof(float), stream);
   TVM_FFI_ICHECK_EQ(memset_status, cudaSuccess) << cudaGetErrorString(memset_status);
+  if (smooth_k) {
+    auto const& k_mean = *maybe_k_mean;
+    auto const memset_status_2 =
+        cudaMemsetAsync(k_mean.data_ptr(), 0, k_mean.numel() * sizeof(float), stream);
+    TVM_FFI_ICHECK_EQ(memset_status_2, cudaSuccess) << cudaGetErrorString(memset_status_2);
+  }
 
   SageQuantParams params{};
   params.headDim = query.size(2);
@@ -108,6 +126,9 @@ void trtllm_sage_attention_quantize(TensorView q_quant, TensorView k_quant, Tens
   params.ptrV = value.data_ptr();
   params.ptrVQuant = v_quant.data_ptr();
   params.ptrVScale = static_cast<float*>(v_scale.data_ptr());
+  params.kSmooth = smooth_k;
+  params.ptrKForMean = smooth_k ? key.data_ptr() : nullptr;
+  params.ptrKMean = smooth_k ? static_cast<float*>((*maybe_k_mean).data_ptr()) : nullptr;
   params.smCount = sm_count;
   params.stream = stream;
 

--- a/flashinfer/artifacts.py
+++ b/flashinfer/artifacts.py
@@ -135,7 +135,7 @@ class ArtifactPath:
     When compiling new cubins for backend directories, update the corresponding path.
     """
 
-    TRTLLM_GEN_FMHA: str = "ce0795149bb2a183db22de04a3fec3aca65fff04/fmha/trtllm-gen/"
+    TRTLLM_GEN_FMHA: str = "2d6a5a029eefcc388ec0ceb87efb55d8bcce5c3c/fmha/trtllm-gen/"
     TRTLLM_GEN_BMM: str = (
         "14e0be19166763fb6a00cc6cb0e9bcf9b0231159/batched_gemm-fe08bc1-9f05022/"
     )
@@ -170,7 +170,7 @@ class CheckSumHash:
     """
 
     TRTLLM_GEN_FMHA: str = (
-        "a8d5d3e86f5ee7dfecd36a8d6cf9a933ca0cb8225a2f954f0212c5db2d250f40"
+        "d79b5c51fc8597fac57dae0da4afa114fb2014575e4ec3df099ad856d97cabc3"
     )
     TRTLLM_GEN_BMM: str = (
         "4bbb1fe8373c0f8f340b539a90e9ff69c223bdacdc9d5410f59c2706d40c415f"

--- a/flashinfer/prefill.py
+++ b/flashinfer/prefill.py
@@ -4625,13 +4625,25 @@ def trtllm_sage_attention_quantize(
     qk_quant_dtype: torch.dtype = torch.int8,
     cum_seq_lens_q: Optional[torch.Tensor] = None,
     cum_seq_lens_kv: Optional[torch.Tensor] = None,
-) -> Tuple[
-    torch.Tensor,
-    torch.Tensor,
-    torch.Tensor,
-    torch.Tensor,
-    torch.Tensor,
-    torch.Tensor,
+    smooth_k: bool = False,
+) -> Union[
+    Tuple[
+        torch.Tensor,
+        torch.Tensor,
+        torch.Tensor,
+        torch.Tensor,
+        torch.Tensor,
+        torch.Tensor,
+    ],
+    Tuple[
+        torch.Tensor,
+        torch.Tensor,
+        torch.Tensor,
+        torch.Tensor,
+        torch.Tensor,
+        torch.Tensor,
+        torch.Tensor,
+    ],
 ]:
     """Quantize Q/K/V into the layout consumed by TRTLLM SageAttention.
 
@@ -4654,12 +4666,19 @@ def trtllm_sage_attention_quantize(
         Contiguous INT32 CUDA tensors of shape ``[batch_size + 1]`` containing
         cumulative Q and KV sequence lengths. Assumes single-batch input if
         `cum_seq_lens_q` is missing.
+    smooth_k : bool
+        Whether to perform K-smoothing before quantization for better accuracy.
+        NOTE: K-smoothing shifts LSE by ``-sm_scale * (query * k_mean).sum(-1)``
+        FlashInfer does not consume `k_mean`, thus it's up to users to shift
+        back the LSE if performing ring attention with this option enabled.
 
     Returns
     -------
-    (q_quant, k_quant, v_quant, q_scale, k_scale, v_scale)
+    (q_quant, k_quant, v_quant, q_scale, k_scale, v_scale) or
+    (q_quant, k_quant, v_quant, q_scale, k_scale, v_scale, k_mean)
         Quantized Q/K/V followed by their FP32 dequantization scales.
-        These outputs can be passed directly to `trtllm_ragged_attention_deepseek`.
+        When ``smooth_k=True``, the FP32 K mean is appended. The first six
+        outputs can be passed directly to `trtllm_ragged_attention_deepseek`.
     """
     if query.dtype not in (torch.float16, torch.bfloat16):
         raise ValueError(f"query must be float16 or bfloat16, got {query.dtype}")
@@ -4714,6 +4733,15 @@ def trtllm_sage_attention_quantize(
         dtype=torch.float32,
         device=query.device,
     )
+    k_mean = (
+        torch.empty(
+            (key.shape[1], key.shape[2]),
+            dtype=torch.float32,
+            device=query.device,
+        )
+        if smooth_k
+        else None
+    )
 
     get_trtllm_gen_fmha_module().trtllm_sage_attention_quantize(
         q_quant,
@@ -4730,7 +4758,11 @@ def trtllm_sage_attention_quantize(
         q_block_size,
         k_block_size,
         get_device_sm_count(query.device),
+        k_mean,
+        smooth_k,
     )
+    if smooth_k:
+        return q_quant, k_quant, v_quant, q_scale, k_scale, v_scale, k_mean
     return q_quant, k_quant, v_quant, q_scale, k_scale, v_scale
 
 

--- a/flashinfer/prefill.py
+++ b/flashinfer/prefill.py
@@ -4623,6 +4623,8 @@ def trtllm_sage_attention_quantize(
     q_block_size: int = 1,
     k_block_size: int = 16,
     qk_quant_dtype: torch.dtype = torch.int8,
+    cum_seq_lens_q: Optional[torch.Tensor] = None,
+    cum_seq_lens_kv: Optional[torch.Tensor] = None,
 ) -> Tuple[
     torch.Tensor,
     torch.Tensor,
@@ -4648,15 +4650,16 @@ def trtllm_sage_attention_quantize(
     qk_quant_dtype : torch.dtype
         ``torch.int8`` (the SageAttention INT8 path) or
         ``torch.float8_e4m3fn``.
+    cum_seq_lens_q, cum_seq_lens_kv : Optional[torch.Tensor]
+        Contiguous INT32 CUDA tensors of shape ``[batch_size + 1]`` containing
+        cumulative Q and KV sequence lengths. Assumes single-batch input if
+        `cum_seq_lens_q` is missing.
 
     Returns
     -------
     (q_quant, k_quant, v_quant, q_scale, k_scale, v_scale)
-        Quantized Q/K/V followed by their FP32 dequantization scales. Q and K
-        scales have shapes ``[q_heads, ceil(q_tokens / q_block_size)]`` and
-        ``[kv_heads, ceil(kv_tokens / k_block_size)]``. V scales have shape
-        ``[kv_heads, head_dim]``. These outputs can be passed directly to
-        :func:`trtllm_ragged_attention_deepseek`.
+        Quantized Q/K/V followed by their FP32 dequantization scales.
+        These outputs can be passed directly to `trtllm_ragged_attention_deepseek`.
     """
     if query.dtype not in (torch.float16, torch.bfloat16):
         raise ValueError(f"query must be float16 or bfloat16, got {query.dtype}")
@@ -4678,6 +4681,17 @@ def trtllm_sage_attention_quantize(
         raise ValueError("q_block_size and k_block_size must be 1, 4, or 16")
     if qk_quant_dtype not in (torch.int8, torch.float8_e4m3fn):
         raise ValueError("qk_quant_dtype must be torch.int8 or torch.float8_e4m3fn")
+    if cum_seq_lens_q is None:
+        cum_seq_lens_q = torch.tensor(
+            [0, query.shape[0]], dtype=torch.int32, device=query.device
+        )
+        cum_seq_lens_kv = torch.tensor(
+            [0, key.shape[0]], dtype=torch.int32, device=query.device
+        )
+    elif cum_seq_lens_kv is None:
+        cum_seq_lens_kv = cum_seq_lens_q
+
+    batch_size = cum_seq_lens_q.numel() - 1
 
     query = query.contiguous()
     key = key.contiguous()
@@ -4686,12 +4700,12 @@ def trtllm_sage_attention_quantize(
     k_quant = torch.empty_like(key, dtype=qk_quant_dtype)
     v_quant = torch.empty_like(value, dtype=torch.float8_e4m3fn)
     q_scale = torch.empty(
-        (query.shape[1], ceil_div(query.shape[0], q_block_size)),
+        (query.shape[1], ceil_div(query.shape[0], q_block_size) + batch_size - 1),
         dtype=torch.float32,
         device=query.device,
     )
     k_scale = torch.empty(
-        (key.shape[1], ceil_div(key.shape[0], k_block_size)),
+        (key.shape[1], ceil_div(key.shape[0], k_block_size) + batch_size - 1),
         dtype=torch.float32,
         device=query.device,
     )
@@ -4711,6 +4725,8 @@ def trtllm_sage_attention_quantize(
         query,
         key,
         value,
+        cum_seq_lens_q,
+        cum_seq_lens_kv,
         q_block_size,
         k_block_size,
         get_device_sm_count(query.device),

--- a/include/flashinfer/trtllm/common/sageQuant.h
+++ b/include/flashinfer/trtllm/common/sageQuant.h
@@ -37,6 +37,8 @@ struct SageQuantParams {
   Data_type inputType{DATA_TYPE_FP16};
   Data_type quantType{DATA_TYPE_E4M3};
   float* ptrQkScale{nullptr};
+  // Optional source and scratch mean used to perform K-smoothing.
+  void const* ptrKForMean{nullptr};
   float* ptrKMean{nullptr};
   // Optional arguments for SageQuantV.
   // vStage: 0: disabled, 1: collect scales, 2: quantize.

--- a/include/flashinfer/trtllm/common/sageQuant.h
+++ b/include/flashinfer/trtllm/common/sageQuant.h
@@ -26,10 +26,12 @@ namespace flashinfer::trtllm {
 struct SageQuantParams {
   // Required arguments for SageQuantQk (Q or K).
   int sumSeqLensQk{};
+  int batchSize{};
   int numHeads{};
   int headDim{};
   int tokenBlockSize{};
   bool kSmooth{false};
+  int const* ptrCuSeqLensQk{nullptr};
   void const* ptrQk{nullptr};
   void* ptrQkQuant{nullptr};
   Data_type inputType{DATA_TYPE_FP16};

--- a/tests/attention/test_trtllm_ragged_dit.py
+++ b/tests/attention/test_trtllm_ragged_dit.py
@@ -279,7 +279,7 @@ def test_trtllm_ragged_dit_qk_bf16_v_fp8(
 )
 @pytest.mark.parametrize("causal", [False])
 @pytest.mark.parametrize("batch_size", [1, 2])
-@pytest.mark.parametrize("s_qo,s_kv", [(256, 256), (512, 2048)])
+@pytest.mark.parametrize("s_qo,s_kv", [(256, 256), (1560, 1560), (512, 2048)])
 @pytest.mark.parametrize("num_heads", [1, 8])
 @pytest.mark.parametrize("head_dim", [128])
 @pytest.mark.parametrize("sage_blk_q", [1])
@@ -306,6 +306,13 @@ def test_trtllm_ragged_dit_sage_qdq(
     k = torch.randn(total_kv, num_heads, head_dim, device=device, dtype=torch.bfloat16)
     v = torch.randn(total_kv, num_heads, head_dim, device=device, dtype=torch.bfloat16)
 
+    qo_indptr = torch.cat(
+        [torch.zeros(1, dtype=torch.int32, device=device), q_lens.cumsum(0).int()]
+    )
+    kv_indptr = torch.cat(
+        [torch.zeros(1, dtype=torch.int32, device=device), kv_lens.cumsum(0).int()]
+    )
+
     q_int8, k_int8, v_fp8, q_sfs, k_sfs, v_sfs = (
         flashinfer.trtllm_sage_attention_quantize(
             q,
@@ -314,20 +321,20 @@ def test_trtllm_ragged_dit_sage_qdq(
             q_block_size=sage_blk_q,
             k_block_size=sage_blk_k,
             qk_quant_dtype=torch.int8,
+            cum_seq_lens_q=qo_indptr,
+            cum_seq_lens_kv=kv_indptr,
         )
     )
 
     assert q_sfs.shape == (
         num_heads,
-        (total_q + sage_blk_q - 1) // sage_blk_q,
+        (total_q + sage_blk_q - 1) // sage_blk_q + batch_size - 1,
     )
     assert k_sfs.shape == (
         num_heads,
-        (total_kv + sage_blk_k - 1) // sage_blk_k,
+        (total_kv + sage_blk_k - 1) // sage_blk_k + batch_size - 1,
     )
     assert v_sfs.shape == (num_heads, head_dim)
-    assert torch.isfinite(q_sfs).all()
-    assert torch.isfinite(k_sfs).all()
     assert torch.isfinite(v_sfs).all()
 
     sage_blk_v = 1
@@ -340,13 +347,6 @@ def test_trtllm_ragged_dit_sage_qdq(
     bmm1_scale = 1.0 / math.sqrt(head_dim)
     # All dequantization scales are supplied through SageAttention scale tensors.
     bmm2_scale = 1.0
-
-    qo_indptr = torch.cat(
-        [torch.zeros(1, dtype=torch.int32, device=device), q_lens.cumsum(0).int()]
-    )
-    kv_indptr = torch.cat(
-        [torch.zeros(1, dtype=torch.int32, device=device), kv_lens.cumsum(0).int()]
-    )
 
     workspace = _get_workspace()
 

--- a/tests/attention/test_trtllm_ragged_dit.py
+++ b/tests/attention/test_trtllm_ragged_dit.py
@@ -284,6 +284,7 @@ def test_trtllm_ragged_dit_qk_bf16_v_fp8(
 @pytest.mark.parametrize("head_dim", [128])
 @pytest.mark.parametrize("sage_blk_q", [1])
 @pytest.mark.parametrize("sage_blk_k", [4, 16])
+@pytest.mark.parametrize("smooth_k", [False, True])
 def test_trtllm_ragged_dit_sage_qdq(
     causal: bool,
     batch_size: int,
@@ -293,6 +294,7 @@ def test_trtllm_ragged_dit_sage_qdq(
     head_dim: int,
     sage_blk_q: int,
     sage_blk_k: int,
+    smooth_k: bool,
 ):
     torch.manual_seed(42)
     device = GPU_DEVICE
@@ -313,18 +315,23 @@ def test_trtllm_ragged_dit_sage_qdq(
         [torch.zeros(1, dtype=torch.int32, device=device), kv_lens.cumsum(0).int()]
     )
 
-    q_int8, k_int8, v_fp8, q_sfs, k_sfs, v_sfs = (
-        flashinfer.trtllm_sage_attention_quantize(
-            q,
-            k,
-            v,
-            q_block_size=sage_blk_q,
-            k_block_size=sage_blk_k,
-            qk_quant_dtype=torch.int8,
-            cum_seq_lens_q=qo_indptr,
-            cum_seq_lens_kv=kv_indptr,
-        )
+    quantized = flashinfer.trtllm_sage_attention_quantize(
+        q,
+        k,
+        v,
+        q_block_size=sage_blk_q,
+        k_block_size=sage_blk_k,
+        qk_quant_dtype=torch.int8,
+        cum_seq_lens_q=qo_indptr,
+        cum_seq_lens_kv=kv_indptr,
+        smooth_k=smooth_k,
     )
+    q_int8, k_int8, v_fp8, q_sfs, k_sfs, v_sfs = quantized[:6]
+    if smooth_k:
+        k_mean = quantized[6]
+        assert k_mean.shape == (num_heads, head_dim)
+        assert k_mean.dtype == torch.float32
+        assert torch.isfinite(k_mean).all()
 
     assert q_sfs.shape == (
         num_heads,
@@ -390,3 +397,56 @@ def test_trtllm_ragged_dit_sage_qdq(
         atol=0.1,
         rtol=0.1,
     )
+
+
+@pytest.mark.skipif(
+    (CC_MAJOR, CC_MINOR) != (10, 0),
+    reason="SageAttention quantization tests require SM100.",
+)
+@pytest.mark.parametrize("head_dim", [64, 128, 256])
+def test_trtllm_sage_quant_qkv_error(head_dim: int):
+    torch.manual_seed(42)
+    num_tokens, num_heads = 260, 2
+    q_block_size = 1
+    k_block_size = 16
+
+    q = torch.randn(
+        num_tokens,
+        num_heads,
+        head_dim,
+        device=GPU_DEVICE,
+        dtype=torch.bfloat16,
+    )
+    k = torch.randn_like(q)
+    v = torch.randn_like(q)
+
+    q_block_indices = torch.arange(num_tokens, device=GPU_DEVICE) // q_block_size
+    block_indices = torch.arange(num_tokens, device=GPU_DEVICE) // k_block_size
+    max_error_tolerance = {"q": 0.04, "k": 0.04, "v": 0.17}
+    for smooth_k in (False, True):
+        quantized = flashinfer.trtllm_sage_attention_quantize(
+            q,
+            k,
+            v,
+            q_block_size=q_block_size,
+            k_block_size=k_block_size,
+            qk_quant_dtype=torch.int8,
+            smooth_k=smooth_k,
+        )
+        q_quant, k_quant, v_quant, q_sfs, k_sfs, v_sfs = quantized[:6]
+        k_mean = quantized[6] if smooth_k else None
+
+        q_dequant = q_quant.float() * q_sfs[:, q_block_indices].T.unsqueeze(-1)
+        k_dequant = k_quant.float() * k_sfs[:, block_indices].T.unsqueeze(-1)
+        if k_mean is not None:
+            k_dequant += k_mean.unsqueeze(0)
+        v_dequant = v_quant.float() * v_sfs.unsqueeze(0)
+
+        for name, dequant, reference in (
+            ("q", q_dequant, q),
+            ("k", k_dequant, k),
+            ("v", v_dequant, v),
+        ):
+            abs_error = (dequant - reference.float()).abs()
+            assert torch.isfinite(abs_error).all()
+            assert abs_error.max().item() < max_error_tolerance[name]


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

The latest TRTLLM_GEN_FMHA artifact contains not only updated LLM support, but also a fix for SageAttention to address quality corruption when seqLen%SfsK!=0. This fix demands a fix for `sageQuant` provided by this PR.

## 🔍 Related Issues

N/A
(corruption not spotted by issues yet)

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added optional K smoothing for SageAttention quantization with V staging.
  - K-mean outputs are now available when smoothing is enabled.
  - Added support for batched, variable-length query and key/value sequences, including ragged inputs and partial token blocks.

- **Bug Fixes**
  - Improved validation and handling of sequence offsets, batch dimensions, and per-batch scale buffers.
  - Improved quantization accuracy across supported head dimensions and smoothing modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->