### PR TITLE
Enable CuTe DSL MLA benchmarks for low head counts

### DIFF
--- a/benchmarks/routines/attention.py
+++ b/benchmarks/routines/attention.py
@@ -3157,13 +3157,6 @@ def testBatchMLAPagedAttentionWrapper(args):
             remove_trtllm_native = True
         if remove_trtllm_native:
             backends.remove("trtllm-native")
-    if "cute-dsl" in backends:
-        remove_cute_dsl = False
-        if num_qo_heads < 128:
-            print("[INFO] cute-dsl MLA backend requires num_heads >= 128. Skipping.")
-            remove_cute_dsl = True
-        if remove_cute_dsl:
-            backends.remove("cute-dsl")
     if s_qo > 1:
         for backend in ("fa2", "fa3", "cutlass"):
             _drop_backend(


### PR DESCRIPTION
## 📌 Description

Remove the benchmark-side restriction that excludes the `cute-dsl` backend when `num_qo_heads` is less than 128.

This enables `BatchMLAPagedAttentionWrapper` to benchmark `cute-dsl` for tensor-parallel MLA decode configurations with low per-rank query-head counts, including long-context `s_qo=8` workloads.

Objective: Enable CuTe DSL benchmark coverage for low query-head counts.

This PR is limited to the benchmark harness. It does not modify production backend implementations or add `fold_sq` to the `trtllm-gen` kernel.

## 🔍 Related Issues

N/A

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used my preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

Pre-commit result: **PASS** (`pre-commit run --all-files`).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All applicable tests are passing.

Test results:
- `pre-commit run --all-files`: PASS
- `BatchMLAPagedAttentionWrapper` with `cute-dsl`, low per-rank query-head count, and `s_qo=8`: PASS

## Reviewer Notes


