### PR TITLE
feat(sm120): add CuteDSL grouped MoE backends for FP8 and MXFP8

### DIFF
--- a/csrc/cute_sm120_mxfp8_groupwise/cute_sm120_fp8_runner.cu
+++ b/csrc/cute_sm120_mxfp8_groupwise/cute_sm120_fp8_runner.cu
@@ -431,11 +431,14 @@ void CuteSm120Fp8GemmRunner<ElementType, OutElementType, AccumElementType, Block
                                    int shape_n, int shape_k, cudaStream_t stream, float const* SFA,
                                    float const* SFB) {
   constexpr auto kGT = sm120_common::GemmType::MGroupedContiguousWithZeroPadding;
-  using KT_M32 = sm120_blockscaling::SM120BlockScalingBuilder<32, 128, 128, 2, 1, 128, 128, kGT>;
-  using KT_M64 = sm120_blockscaling::SM120BlockScalingBuilder<64, 128, 128, 2, 1, 128, 128, kGT>;
-  using KT_M128 = sm120_blockscaling::SM120BlockScalingBuilder<128, 128, 128, 2, 1, 128, 128, kGT>;
+  using KT_M32 =
+      sm120_blockscaling::SM120BlockScalingBuilder<32, 128, 128, 4, 1, 128, 128, kGT, false>;
+  using KT_M64 =
+      sm120_blockscaling::SM120BlockScalingBuilder<64, 128, 128, 4, 1, 128, 128, kGT, false>;
+  using KT_M128 =
+      sm120_blockscaling::SM120BlockScalingBuilder<128, 128, 128, 3, 1, 128, 128, kGT, false>;
   using KT_SWAPAB_N8 =
-      sm120_blockscaling::SM120BlockScalingBuilder<128, 8, 128, 2, 128, 1, 128, kGT, true>;
+      sm120_blockscaling::SM120BlockScalingBuilder<128, 8, 128, 4, 128, 1, 128, kGT, true>;
 
   auto ptr_A = reinterpret_cast<typename KT_M128::ElementA const*>(A);
   auto ptr_B = reinterpret_cast<typename KT_M128::ElementB const*>(B);

--- a/csrc/cute_sm120_mxfp8_groupwise/cute_sm120_mxfp8_runner.cu
+++ b/csrc/cute_sm120_mxfp8_groupwise/cute_sm120_mxfp8_runner.cu
@@ -325,8 +325,8 @@ void CuteSm120Mxfp8GemmRunner<ElementType, OutElementType, AccumElementType,
                       (tactic_tile_m == 128 && tactic_tile_n == 128);
   TVM_FFI_ICHECK(valid_tactic) << "unsupported MXFP8 MoE tactic (TileM, TileN)=(" << tactic_tile_m
                                << ", " << tactic_tile_n << ")";
-  TVM_FFI_ICHECK(tactic_tile_m != 128 || tactic_tile_n != 128 || granK == 128)
-      << "unsupported MXFP8 GranK=32 MoE tactic (TileM, TileN)=(128, 128)";
+  TVM_FFI_ICHECK(tactic_tile_m != 128 || tactic_tile_n != 128 || !is_gated || granK == 128)
+      << "unsupported gated MXFP8 GranK=32 MoE tactic (TileM, TileN)=(128, 128)";
   DISPATCH_GRAN_K(granK, GRAN_K, {
     if (is_gated) {
       fused_moe_mxfp8_nt_groupwise_tuned_impl<GRAN_K>(D, A, B, token_offset, num_experts,
@@ -415,6 +415,7 @@ void CuteSm120Mxfp8GemmRunner<ElementType, OutElementType, AccumElementType,
   using KT_M64_N128 =
       sm120_blockscaled::SM120BlockScaledBuilder<64, 128, kTileK_M64, 4, GranK, kGT>;
   using KT_M128_N64 = sm120_blockscaled::SM120BlockScaledBuilder<128, 64, 64, 4, GranK, kGT>;
+  using KT_M128_N128 = sm120_blockscaled::SM120BlockScaledBuilder<128, 128, 64, 4, GranK, kGT>;
   using KT_M32_N128 = sm120_blockscaled::SM120BlockScaledBuilder<32, 128, 128, 4, GranK, kGT>;
   using KT_SWAPAB_N8 = sm120_blockscaled::SM120BlockScaledBuilder<128, 8, 128, 4, GranK, kGT, true>;
 
@@ -447,8 +448,7 @@ void CuteSm120Mxfp8GemmRunner<ElementType, OutElementType, AccumElementType,
     sm120_blockscaled::launch_moe_gemm<KT_M128_N64>(ptr_A, ptr_B, ptr_SFA, ptr_SFB, ptr_D,
                                                     total_rows, shape_n, shape_k, num_experts,
                                                     token_offset, num_sms, stream);
-  } else if constexpr (GranK == 128) {
-    using KT_M128_N128 = sm120_blockscaled::SM120BlockScaledBuilder<128, 128, 64, 4, GranK, kGT>;
+  } else {
     sm120_blockscaled::launch_moe_gemm<KT_M128_N128>(ptr_A, ptr_B, ptr_SFA, ptr_SFB, ptr_D,
                                                      total_rows, shape_n, shape_k, num_experts,
                                                      token_offset, num_sms, stream);

--- a/csrc/cute_sm120_mxfp8_groupwise/sm120_blockscaling/builder.cuh
+++ b/csrc/cute_sm120_mxfp8_groupwise/sm120_blockscaling/builder.cuh
@@ -75,7 +75,8 @@ struct SM120BlockScalingMMAConfig {
 
 template <int TileM_ = 128, int TileN_ = 128, int TileK_ = 128, int Stages_ = 4,
           int ScaleGranularityM_ = 1, int ScaleGranularityN_ = 128, int ScaleGranularityK_ = 128,
-          sm120_common::GemmType GemmType_ = sm120_common::GemmType::Normal, bool SwapAB_ = false>
+          sm120_common::GemmType GemmType_ = sm120_common::GemmType::Normal,
+          bool SwapAB_ = false>
 struct SM120BlockScalingBuilder {
   using ElementA = cute::float_e4m3_t;
   using ElementB = cute::float_e4m3_t;
@@ -90,9 +91,7 @@ struct SM120BlockScalingBuilder {
                                        GemmType_ == sm120_common::GemmType::MGroupedMasked);
   static constexpr bool kUseTmaStore =
       sm120_common::utils::EnableTmaStore<kFlat, kSwapAB, TileN_, kPerBatchAB>();
-  static constexpr bool kUseStagedR2G =
-      GemmType_ == sm120_common::GemmType::MGroupedContiguousWithZeroPadding && !SwapAB_ &&
-      TileM_ >= 64;
+  static constexpr bool kUseStagedR2G = false;
   static constexpr bool kUnionSmem = !kUseTmaStore && !kUseStagedR2G;
   static constexpr int AB_Stages = Stages_;
   static constexpr uint32_t LoadRegisterRequirement = kUseStagedR2G ? 88 : 40;

--- a/flashinfer/grouped_mm/__init__.py
+++ b/flashinfer/grouped_mm/__init__.py
@@ -16,6 +16,9 @@ from .core import grouped_mm_mxfp8 as grouped_mm_mxfp8
 from .cute_sm120_fp8_groupwise import (
     moe_gemm_fp8_nt_groupwise as moe_gemm_fp8_nt_groupwise,
 )
+from .cutedsl_sm120_mxfp8_mxfp4 import (
+    moe_gemm_mxfp8_mxfp4_nt_groupwise as moe_gemm_mxfp8_mxfp4_nt_groupwise,
+)
 from .cute_sm120_mxfp8_groupwise import (
     moe_gemm_mxfp8_nt_groupwise as moe_gemm_mxfp8_nt_groupwise,
 )
@@ -26,5 +29,6 @@ __all__ = [
     "grouped_mm_fp8",
     "grouped_mm_mxfp8",
     "moe_gemm_fp8_nt_groupwise",
+    "moe_gemm_mxfp8_mxfp4_nt_groupwise",
     "moe_gemm_mxfp8_nt_groupwise",
 ]

--- a/flashinfer/grouped_mm/cute_sm120_fp8_groupwise/core.py
+++ b/flashinfer/grouped_mm/cute_sm120_fp8_groupwise/core.py
@@ -201,7 +201,7 @@ def moe_gemm_fp8_nt_groupwise(
     m_indptr: torch.Tensor,
     scale_granularity_mnk: Tuple[int, int, int] = (1, 128, 128),
     scale_major_mode: Literal["MN"] = "MN",
-    backend: Literal["cute"] = "cute",
+    backend: Literal["cute", "cutedsl"] = "cute",
     out: Optional[torch.Tensor] = None,
     out_dtype: Optional[torch.dtype] = None,
     is_gated: bool = False,
@@ -251,8 +251,9 @@ def moe_gemm_fp8_nt_groupwise(
         The layout mode of scale tensors. Currently only ``"MN"`` is supported.
         Defaults to ``"MN"``.
 
-    backend: Literal["cute"]
-        Backend selector. Currently only ``"cute"`` is implemented.
+    backend: Literal["cute", "cutedsl"]
+        Backend selector. ``"cute"`` is the CuTe C++ kernel; ``"cutedsl"`` is the CuteDSL
+        kernel, which shares this ABI but does not implement ``is_gated=True``.
 
     out: Optional[torch.Tensor]
         The output tensor, shape ``(cum_m, n)``. If not specified, an output tensor will be
@@ -285,9 +286,10 @@ def moe_gemm_fp8_nt_groupwise(
     _check_scale_granularity_mnk_fp8(scale_granularity_mnk)
     _check_scale_major_mode_fp8(scale_major_mode)
     _check_m_indptr(m_indptr, num_experts=b.shape[0])
-    if backend != "cute":
+    if backend not in ("cute", "cutedsl"):
         raise NotImplementedError(
-            f'Only backend="cute" is currently implemented; got backend="{backend}"'
+            f'backend must be "cute" (CuTe C++) or "cutedsl" (self-written CuteDSL); '
+            f'got backend="{backend}"'
         )
 
     if out_dtype is None:
@@ -305,6 +307,14 @@ def moe_gemm_fp8_nt_groupwise(
         out = torch.empty((a.shape[0], out_n), dtype=out_dtype, device=a.device)
 
     inputs = [a, b, a_scale, b_scale, m_indptr]
+    if backend == "cutedsl":
+        from ..cutedsl_sm120_fp8 import launch_cutedsl_fp8_moe
+
+        launch_cutedsl_fp8_moe(
+            inputs, out, scale_granularity_mnk, scale_major_mode, is_gated
+        )
+        return out
+
     if not _should_autotune_fp8_moe(a, b):
         _launch_fp8_moe_fallback(
             inputs, out, scale_granularity_mnk, scale_major_mode, is_gated

--- a/flashinfer/grouped_mm/cute_sm120_mxfp8_groupwise/core.py
+++ b/flashinfer/grouped_mm/cute_sm120_mxfp8_groupwise/core.py
@@ -37,6 +37,9 @@ _MXFP8_MOE_TACTICS = (
     (_MXFP8_MOE_TACTIC_SCHEMA_VERSION, 128, 64),
     (_MXFP8_MOE_TACTIC_SCHEMA_VERSION, 128, 8),
 )
+_MXFP8_MOE_PLAIN_TACTICS_GRANK32 = _MXFP8_MOE_TACTICS + (
+    (_MXFP8_MOE_TACTIC_SCHEMA_VERSION, 128, 128),
+)
 _MXFP8_MOE_TACTICS_GRANK128 = _MXFP8_MOE_TACTICS + (
     (_MXFP8_MOE_TACTIC_SCHEMA_VERSION, 128, 128),
 )
@@ -114,11 +117,18 @@ class _CuteSm120Mxfp8MoeRunner(Sm120MoeTunableRunner):
         scale_granularity_mnk: Tuple[int, int, int],
         scale_major_mode: str,
     ) -> None:
-        tactics = (
-            _MXFP8_MOE_TACTICS_GRANK128
-            if scale_granularity_mnk[2] == 128
-            else _MXFP8_MOE_TACTICS
-        )
+        if is_gated:
+            tactics = (
+                _MXFP8_MOE_TACTICS_GRANK128
+                if scale_granularity_mnk[2] == 128
+                else _MXFP8_MOE_TACTICS
+            )
+        else:
+            tactics = (
+                _MXFP8_MOE_TACTICS_GRANK128
+                if scale_granularity_mnk[2] == 128
+                else _MXFP8_MOE_PLAIN_TACTICS_GRANK32
+            )
         super().__init__(
             out,
             is_gated,

--- a/flashinfer/grouped_mm/cutedsl_sm120_fp8/__init__.py
+++ b/flashinfer/grouped_mm/cutedsl_sm120_fp8/__init__.py
@@ -1,0 +1,19 @@
+# Copyright (c) 2026 by FlashInfer team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""CuteDSL backend for the SM120 FP8 groupwise MoE GEMM, selected via backend="cutedsl"."""
+
+from .runner import launch_cutedsl_fp8_moe as launch_cutedsl_fp8_moe
+
+__all__ = ["launch_cutedsl_fp8_moe"]

--- a/flashinfer/grouped_mm/cutedsl_sm120_fp8/_arm.py
+++ b/flashinfer/grouped_mm/cutedsl_sm120_fp8/_arm.py
@@ -1,0 +1,154 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+"""fp8 x fp8 arm of grouped_mm: compile-time configuration carrier and static feasibility."""
+
+import functools
+
+import cutlass.cute as cute
+import torch
+
+from ..kernels.cutedsl.sm120_moe.moe_gemm_fp8 import (
+    GRAN_K, GRAN_N, CutedslSm120MoeFp8Grouped, make_args, make_cfg, is_swapab)
+from ..kernels.cutedsl.sm120_moe.core.sm120_gemm_builder import (
+    Sm120GemmBuilder,
+    StoreMethod,
+)
+from ..kernels.cutedsl.sm120_moe.core._common import ceil_div
+from ..cutedsl_sm120_mxfp8_mxfp4._arm import select_plain_bm_64_or_128
+
+FALLBACK_TILE = (128, 128, 128)
+
+# Tie-break when no tactic is named; wg leads on smem-free depth, measured on one card/shape (exp_12).
+STORE_ORDER = (StoreMethod.R2G_WG, StoreMethod.STAGED_R2G)
+
+
+def store_tactics(tile):
+    """The store methods a tile admits. A swapped tile stages nothing: its epilogue is the"""
+    return (StoreMethod.DIRECT_STG,) if is_swapab(tile) else STORE_ORDER
+
+
+def resolve_stage(tile, store):
+    """Deepest A/B ring this tile affords under one store method."""
+    return Sm120GemmBuilder.max_ab_stage(functools.partial(make_cfg, store=store), tuple(tile))
+
+
+def resolve_stage_store(tile):
+    """The default when no tactic is named: the deepest ring any store method affords."""
+    best = None
+    for store in store_tactics(tile):
+        try:
+            stage = resolve_stage(tile, store)
+        except (AssertionError, ValueError):
+            continue
+        if best is None or stage > best[0]:
+            best = (stage, store)
+    if best is None:
+        raise ValueError(f"no ab_stage fits smem for tile {tuple(tile)} under any store method")
+    return best
+
+
+class CutedslSm120GroupedFp8Op:
+    """Holds the configuration one compiled kernel is specialized on, and answers whether it exists."""
+
+    OUT_DTYPES = (torch.bfloat16,)
+    # Measured, not assumed: the tests sweep TACTICS, so every value here has a case behind it.
+    BM_SUPPORTED = (128, 64, 32, 8)
+
+    def __init__(self, *, n: int, k: int, tile, out_dtype: torch.dtype, store=None):
+        if not self.can_implement(n=n, k=k, tile=tile, out_dtype=out_dtype, store=store):
+            raise TypeError(f"{type(self).__name__}: unsupported n={n} k={k} tile={tuple(tile)} "
+                            f"store={store} out_dtype={out_dtype}")
+        self.n, self.k, self.tile, self.out_dtype = n, k, tuple(tile), out_dtype
+        if store is None:
+            self.ab_stage, self.store = resolve_stage_store(self.tile)
+        else:
+            self.ab_stage, self.store = resolve_stage(self.tile, store), store
+        self.cfg = make_cfg(self.tile, self.ab_stage, store=self.store)
+
+    @staticmethod
+    def is_valid_dtypes(out_dtype) -> bool:
+        """StagedR2GStoreConfig is built with bf16; the MMA operand pair is fixed e4m3 x e4m3."""
+        return out_dtype in CutedslSm120GroupedFp8Op.OUT_DTYPES
+
+    @staticmethod
+    def is_valid_tile(tile) -> bool:
+        """bn and bk are the scale granularity itself -- the kernel asserts both as identities."""
+        bm, bn, bk = tile
+        return bm in CutedslSm120GroupedFp8Op.BM_SUPPORTED and bn == GRAN_N and bk == GRAN_K
+
+    @staticmethod
+    def is_valid_alignment(n: int, k: int, tile) -> bool:
+        """K rides whole k-tiles; N only needs the TMA box, since the epilogue predicates its residue."""
+        return n > 0 and k > 0 and k % tile[2] == 0
+
+    @classmethod
+    def is_constructible(cls, tile, store=None) -> bool:
+        """Build the configuration and the kernel object, which is where the rest of the invariants live."""
+        try:
+            if store is None:
+                stage, store = resolve_stage_store(tuple(tile))
+            else:
+                stage = resolve_stage(tuple(tile), store)
+            CutedslSm120MoeFp8Grouped(make_cfg(tuple(tile), stage, store=store), 1)
+        except (AssertionError, ValueError):
+            return False
+        return True
+
+    @classmethod
+    def can_implement(cls, *, n: int, k: int, tile, out_dtype, store=None) -> bool:
+        return (cls.is_valid_dtypes(out_dtype) and cls.is_valid_tile(tile)
+                and cls.is_valid_alignment(n, k, tile) and cls.is_constructible(tile, store))
+
+    def build(self, grid_x: int) -> CutedslSm120MoeFp8Grouped:
+        return CutedslSm120MoeFp8Grouped(self.cfg, grid_x)
+
+
+# The verified domain, expressed once: the tests sweep exactly what can_implement accepts.
+TACTICS = tuple((bm, GRAN_N, store.name)
+                for bm in CutedslSm120GroupedFp8Op.BM_SUPPORTED
+                for store in store_tactics((bm, GRAN_N, GRAN_K)))
+
+
+def split_tactic(tactic):
+    """A tactic back into the pair the entry point takes."""
+    bm, bn, store = tactic
+    return (bm, bn, GRAN_K), StoreMethod[store]
+
+# Building the configuration walks the whole smem cost model, so it is cached per compiled kernel.
+@functools.lru_cache(maxsize=None)
+def _op(n: int, k: int, tile, out_dtype, store=None) -> CutedslSm120GroupedFp8Op:
+    return CutedslSm120GroupedFp8Op(n=n, k=k, tile=tile, out_dtype=out_dtype, store=store)
+
+
+_COMPILED: dict = {}
+
+
+def compiled_kernel(sample_args, *, op: CutedslSm120GroupedFp8Op, grid_x: int, sm_version: str):
+    """One compiled kernel per (problem-invariant, tile, device) key; ``sample_args`` only shape the trace."""
+    key = (op.n, op.k, op.tile, op.ab_stage, op.store, op.out_dtype, grid_x, sm_version)
+    hit = _COMPILED.get(key)
+    if hit is None:
+        hit = cute.compile(op.build(grid_x), *sample_args)
+        _COMPILED[key] = hit
+    return hit
+
+
+def select_tile(*, total_rows: int, n: int, k: int, num_experts: int, num_sms: int):
+    """Pick bm from the problem shape. Ported from flashinfer's C++ runner (da1ac9fe), which chose it"""
+    m_per_expert = total_rows // num_experts if num_experts > 0 else 0
+    smallest = min(CutedslSm120GroupedFp8Op.BM_SUPPORTED)
+
+    def tile_count(bm: int, bn: int) -> int:
+        return num_experts * ceil_div(m_per_expert, bm) * ceil_div(n, bn)
+
+    if n % 128 == 0 and (m_per_expert <= 8
+                         or (tile_count(32, 128) < num_sms // 2
+                             and tile_count(8, 128) <= num_sms)):
+        bm = smallest                      # upstream: 8 (swap-AB)
+    elif m_per_expert <= 32:
+        bm = 32
+    elif k <= 2048:
+        bm = 64 if m_per_expert < 192 else 128
+    else:
+        bm = select_plain_bm_64_or_128(m_per_expert, n, num_experts, num_sms)
+    return (max(bm, smallest), GRAN_N, GRAN_K)

--- a/flashinfer/grouped_mm/cutedsl_sm120_fp8/runner.py
+++ b/flashinfer/grouped_mm/cutedsl_sm120_fp8/runner.py
@@ -1,0 +1,137 @@
+# Copyright (c) 2026 by FlashInfer team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""The cutedsl backend behind moe_gemm_fp8_nt_groupwise: an autotuner runner plus its launcher."""
+
+from typing import Any, Tuple
+
+import torch
+
+from ...autotuner import AutoTuner
+from ..kernels.cutedsl.sm120_moe.core.sm120_gemm_builder import StoreMethod
+from ..kernels.cutedsl.sm120_moe.moe_gemm_fp8 import make_args
+from .._sm120_moe_autotune import SM120_MOE_TUNING_CONFIG, Sm120MoeTunableRunner
+from ._arm import (
+    TACTICS,
+    CutedslSm120GroupedFp8Op,
+    _op,
+    compiled_kernel,
+    select_tile,
+    split_tactic,
+)
+
+_FP8_TACTIC_SCHEMA_VERSION = 1
+_SCALE_CONTRACT = "fp8_1x128x128_mn_major_f32"
+
+
+def _encoded_tactics() -> tuple:
+    """`(schema, bm, bn, store)` as ints; the store method is an axis, so three slots do not fit."""
+    return tuple(
+        (_FP8_TACTIC_SCHEMA_VERSION, bm, bn, StoreMethod[store].value)
+        for bm, bn, store in TACTICS
+    )
+
+
+def _decode_tactic(tactic: tuple):
+    _, bm, bn, store_value = tactic
+    return split_tactic((bm, bn, StoreMethod(store_value).name))
+
+
+class _CutedslSm120Fp8MoeRunner(Sm120MoeTunableRunner):
+    """Tunable view of the self-written fp8 arm."""
+
+    def __init__(
+        self,
+        out: torch.Tensor,
+        is_gated: bool,
+        scale_granularity_mnk: Tuple[int, int, int],
+        scale_major_mode: str,
+    ) -> None:
+        super().__init__(
+            out,
+            is_gated,
+            scale_granularity_mnk,
+            scale_major_mode,
+            _encoded_tactics(),
+            _FP8_TACTIC_SCHEMA_VERSION,
+            _SCALE_CONTRACT,
+        )
+
+    def get_valid_tactics(self, inputs, profile) -> list:
+        b = inputs[1]
+        n, k = int(b.shape[1]), int(b.shape[2])
+        out_dtype = self._out.dtype if self._out is not None else torch.bfloat16
+        return [
+            tactic
+            for tactic in self._tactics
+            if CutedslSm120GroupedFp8Op.can_implement(
+                n=n,
+                k=k,
+                tile=_decode_tactic(tactic)[0],
+                out_dtype=out_dtype,
+                store=_decode_tactic(tactic)[1],
+            )
+        ]
+
+    def is_valid_tactic(self, tactic: Any, inputs=None) -> bool:
+        if type(tactic) is not tuple or len(tactic) != 4:
+            return False
+        if any(type(value) is not int for value in tactic):
+            return False
+        return tactic in self._tactics
+
+    def _launch(self, inputs, out, is_gated, tactic) -> None:
+        a, b, a_scale, b_scale, m_indptr = inputs
+        n, k = int(b.shape[1]), int(b.shape[2])
+        props = torch.cuda.get_device_properties(a.device)
+        grid_x = props.multi_processor_count
+        if self.is_valid_tactic(tactic):
+            tile, store = _decode_tactic(tactic)
+        else:
+            tile, store = (
+                select_tile(
+                    total_rows=int(a.shape[0]),
+                    n=n,
+                    k=k,
+                    num_experts=int(b.shape[0]),
+                    num_sms=grid_x,
+                ),
+                None,
+            )
+        op = _op(n, k, tuple(tile), out.dtype, store)
+        args = make_args(a, a_scale, b, b_scale, out, m_indptr)
+        compiled_kernel(
+            args, op=op, grid_x=grid_x, sm_version=f"sm_{props.major}{props.minor}"
+        )(*args)
+
+
+def launch_cutedsl_fp8_moe(
+    inputs, out: torch.Tensor, scale_granularity_mnk, scale_major_mode, is_gated: bool
+) -> None:
+    """Entry point moe_gemm_fp8_nt_groupwise calls when backend="cutedsl"."""
+    if is_gated:
+        raise NotImplementedError(
+            'backend="cutedsl" does not implement the fused gated (SwiGLU) path; '
+            'use backend="cute" for is_gated=True'
+        )
+    runner = _CutedslSm120Fp8MoeRunner(
+        out, is_gated, scale_granularity_mnk, scale_major_mode
+    )
+    runner, tactic = AutoTuner.get().choose_one(
+        "cutedsl_sm120_fp8_groupwise_moe",
+        [runner],
+        SM120_MOE_TUNING_CONFIG,
+        inputs,
+    )
+    runner(inputs, tactic=tactic)

--- a/flashinfer/grouped_mm/cutedsl_sm120_mxfp8_mxfp4/__init__.py
+++ b/flashinfer/grouped_mm/cutedsl_sm120_mxfp8_mxfp4/__init__.py
@@ -1,0 +1,19 @@
+# Copyright (c) 2026 by FlashInfer team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .core import (
+    moe_gemm_mxfp8_mxfp4_nt_groupwise as moe_gemm_mxfp8_mxfp4_nt_groupwise,
+)
+
+__all__ = ["moe_gemm_mxfp8_mxfp4_nt_groupwise"]

--- a/flashinfer/grouped_mm/cutedsl_sm120_mxfp8_mxfp4/_arm.py
+++ b/flashinfer/grouped_mm/cutedsl_sm120_mxfp8_mxfp4/_arm.py
@@ -1,0 +1,184 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+"""act-MXFP8 x weight-MXFP4 arm: compile-time configuration carrier, tactic table and static feasibility."""
+
+import functools
+
+import cutlass.cute as cute
+import torch
+
+from ..kernels.cutedsl.sm120_moe.core._common import ceil_div
+from ..kernels.cutedsl.sm120_moe.moe_gemm_mxfp8_mxfp4 import (
+    GRANK_A, GRANK_B, CutedslSm120MoeMxfp8Mxfp4Grouped, is_swapab, make_args, make_cfg)
+from ..kernels.cutedsl.sm120_moe.core.sm120_blockscaled_layout import Sm120SfConfigMxfp8Mxfp4
+from ..kernels.cutedsl.sm120_moe.core.sm120_gemm_builder import Sm120GemmBuilder, StoreMethod
+
+PLAIN_TILE_OVERHEAD = 48
+
+
+def select_plain_bm_64_or_128(m_per_expert: int, n: int, num_experts: int, num_sms: int) -> int:
+    """Cost is waves x (bm + overhead), not tile count."""
+    def cost(bm: int) -> int:
+        num_tiles = num_experts * ceil_div(m_per_expert, bm) * ceil_div(n, 128)
+        return ceil_div(num_tiles, num_sms) * (bm + PLAIN_TILE_OVERHEAD)
+
+    return 64 if cost(64) < cost(128) else 128
+
+FALLBACK_TILE = (128, 128, 128)
+
+# Tie-break when no tactic is named; staged leads here across two cases, widening with M (exp_15).
+STORE_ORDER = (StoreMethod.STAGED_R2G, StoreMethod.R2G_WG)
+
+
+def store_tactics(tile):
+    """The store methods a tile admits. A swapped tile stages nothing: its epilogue is the"""
+    return (StoreMethod.DIRECT_STG,) if is_swapab(tile) else STORE_ORDER
+
+
+def resolve_stage(tile, store, grank_a=GRANK_A):
+    """Deepest A/B ring this tile affords under one store method."""
+    return Sm120GemmBuilder.max_ab_stage(
+        functools.partial(make_cfg, store=store, grank_a=grank_a), tuple(tile))
+
+
+def resolve_stage_store(tile, grank_a=GRANK_A):
+    """The default when no tactic is named: the deepest ring any store method affords."""
+    best = None
+    for store in store_tactics(tile):
+        try:
+            stage = resolve_stage(tile, store, grank_a)
+        except (AssertionError, ValueError):
+            continue
+        if best is None or stage > best[0]:
+            best = (stage, store)
+    if best is None:
+        raise ValueError(f'no store method yields a viable ab_stage for tile {tuple(tile)}')
+    return best
+
+
+class CutedslSm120GroupedMxfp8Mxfp4Op:
+    """Holds the configuration one compiled kernel is specialized on, and answers whether it exists."""
+
+    OUT_DTYPES = (torch.bfloat16,)
+    # Measured, not assumed: exp_09 swept these bit-exact; an unmeasured tile is a silent wrong answer.
+    BM_SUPPORTED = (128, 64, 32, 8)
+    BN_SUPPORTED = (128,)
+
+    def __init__(self, *, n: int, k: int, tile, out_dtype: torch.dtype, store=None,
+                 grank_a: int = GRANK_A):
+        if not self.can_implement(n=n, k=k, tile=tile, out_dtype=out_dtype, store=store,
+                                  grank_a=grank_a):
+            raise TypeError(f"{type(self).__name__}: unsupported n={n} k={k} tile={tuple(tile)} "
+                            f"out_dtype={out_dtype} store={store} grank_a={grank_a}")
+        self.n, self.k, self.tile, self.out_dtype = n, k, tuple(tile), out_dtype
+        self.grank_a = grank_a
+        if store is None:
+            self.ab_stage, self.store = resolve_stage_store(self.tile, grank_a)
+        else:
+            self.ab_stage, self.store = resolve_stage(self.tile, store, grank_a), store
+        self.cfg = make_cfg(self.tile, self.ab_stage, store=self.store, grank_a=grank_a)
+
+    @staticmethod
+    def is_valid_dtypes(out_dtype) -> bool:
+        """R2GWgStoreConfig is built with bf16; the MMA operand pair is fixed act-e4m3 x weight-e2m1."""
+        return out_dtype in CutedslSm120GroupedMxfp8Mxfp4Op.OUT_DTYPES
+
+    @staticmethod
+    def is_valid_tile(tile) -> bool:
+        """bk is the SFB pack width, not a free axis: one int32 pack must cover exactly one k-tile."""
+        bm, bn, bk = tile
+        return (bm in CutedslSm120GroupedMxfp8Mxfp4Op.BM_SUPPORTED
+                and bn in CutedslSm120GroupedMxfp8Mxfp4Op.BN_SUPPORTED
+                and bk == GRANK_B * Sm120SfConfigMxfp8Mxfp4.PACK_NSF)
+
+    @staticmethod
+    def is_valid_alignment(n: int, k: int, tile) -> bool:
+        """K rides whole k-tiles; N only needs the TMA box, since the epilogue predicates its residue."""
+        return n > 0 and k > 0 and k % tile[2] == 0
+
+    @classmethod
+    def is_constructible(cls, tile, store=None, grank_a: int = GRANK_A) -> bool:
+        """Build the configuration and the kernel object, which is where the rest of the invariants live."""
+        try:
+            if store is None:
+                stage, store = resolve_stage_store(tuple(tile), grank_a)
+            else:
+                stage = resolve_stage(tuple(tile), store, grank_a)
+            CutedslSm120MoeMxfp8Mxfp4Grouped(
+                make_cfg(tuple(tile), stage, store=store, grank_a=grank_a), 1)
+        except (AssertionError, ValueError):
+            return False
+        return True
+
+    @staticmethod
+    def is_valid_granularity(grank_a: int) -> bool:
+        """A-side SF granularity: the two the same-family entry admits, nesting with the fixed B side."""
+        return grank_a in (128, 32)
+
+    @classmethod
+    def can_implement(cls, *, n: int, k: int, tile, out_dtype, store=None,
+                      grank_a: int = GRANK_A) -> bool:
+        return (cls.is_valid_dtypes(out_dtype) and cls.is_valid_tile(tile)
+                and cls.is_valid_granularity(grank_a)
+                and cls.is_valid_alignment(n, k, tile)
+                and cls.is_constructible(tile, store, grank_a))
+
+    def build(self, grid_x: int) -> CutedslSm120MoeMxfp8Mxfp4Grouped:
+        return CutedslSm120MoeMxfp8Mxfp4Grouped(self.cfg, grid_x)
+
+
+# The verified domain, expressed once: the tests sweep exactly what can_implement accepts.
+TACTICS = tuple((bm, bn, store.name)
+                for bm in CutedslSm120GroupedMxfp8Mxfp4Op.BM_SUPPORTED
+                for bn in CutedslSm120GroupedMxfp8Mxfp4Op.BN_SUPPORTED
+                for store in store_tactics((bm, bn, GRANK_B * Sm120SfConfigMxfp8Mxfp4.PACK_NSF)))
+
+
+def split_tactic(tactic):
+    """A tactic back into the pair the entry point takes."""
+    bm, bn, store = tactic
+    return (bm, bn, GRANK_B * Sm120SfConfigMxfp8Mxfp4.PACK_NSF), StoreMethod[store]
+
+# Building the configuration walks the whole smem cost model, so it is cached per compiled kernel.
+@functools.lru_cache(maxsize=None)
+def _op(n: int, k: int, tile, out_dtype, store=None,
+        grank_a: int = GRANK_A) -> CutedslSm120GroupedMxfp8Mxfp4Op:
+    return CutedslSm120GroupedMxfp8Mxfp4Op(n=n, k=k, tile=tile, out_dtype=out_dtype, store=store,
+                                           grank_a=grank_a)
+
+
+_COMPILED: dict = {}
+
+
+def compiled_kernel(sample_args, *, op: CutedslSm120GroupedMxfp8Mxfp4Op, grid_x: int, sm_version: str):
+    """One compiled kernel per (problem-invariant, tile, device) key; ``sample_args`` only shape the trace."""
+    key = (op.n, op.k, op.tile, op.ab_stage, op.store, op.out_dtype, op.grank_a, grid_x, sm_version)
+    hit = _COMPILED.get(key)
+    if hit is None:
+        hit = cute.compile(op.build(grid_x), *sample_args)
+        _COMPILED[key] = hit
+    return hit
+
+
+def select_tile(*, total_rows: int, n: int, k: int, num_experts: int, num_sms: int):
+    """Pick bm from the problem shape. Ported from flashinfer's C++ runner (da1ac9fe)."""
+    m_per_expert = total_rows // num_experts if num_experts > 0 else 0
+    smallest = min(CutedslSm120GroupedMxfp8Mxfp4Op.BM_SUPPORTED)
+    bn = CutedslSm120GroupedMxfp8Mxfp4Op.BN_SUPPORTED[0]
+
+    if m_per_expert <= 12:
+        bm = smallest                      # 8: the swap-AB tile
+    elif m_per_expert <= 32:
+        bm = 32
+    else:
+        # no k<=2048 shortcut here: measured 41% slower than the plain choice on this kernel
+        bm = select_plain_bm_64_or_128(m_per_expert, n, num_experts, num_sms)
+    return (max(bm, smallest), bn, GRANK_B * Sm120SfConfigMxfp8Mxfp4.PACK_NSF)
+
+
+def _check_a_scale_granularity(a_scale, k: int, grank_a: int) -> None:
+    """The kernel rebuilds a_scale's K extent from config and never reads it, so mismatch is silent."""
+    want = ceil_div(k, grank_a * Sm120SfConfigMxfp8Mxfp4.PACK_NSF)
+    got = int(a_scale.shape[0])
+    if got != want:
+        raise ValueError(f"a_scale K extent {got} != {want} implied by k={k}, grank_a={grank_a}")

--- a/flashinfer/grouped_mm/cutedsl_sm120_mxfp8_mxfp4/core.py
+++ b/flashinfer/grouped_mm/cutedsl_sm120_mxfp8_mxfp4/core.py
@@ -1,0 +1,283 @@
+# Copyright (c) 2026 by FlashInfer team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""SM120 CuteDSL backend for the MXFP8-activation x MXFP4-weight grouped MoE GEMM.
+
+Zero-padding mode with token-packed ``a`` and a CSR ``m_indptr``, matching the
+``moe_gemm_*_nt_groupwise`` family. The kernels live in
+``flashinfer.grouped_mm.kernels.cutedsl.sm120_moe``; this module is the public entry.
+"""
+
+from typing import Any, Literal, Optional, Tuple
+
+import torch
+
+from ...api_logging import flashinfer_api
+from ...autotuner import AutoTuner
+from ...utils import supported_compute_capability
+from .._sm120_moe_autotune import SM120_MOE_TUNING_CONFIG, Sm120MoeTunableRunner
+from ..kernels.cutedsl.sm120_moe.core._common import ceil_div
+from ..kernels.cutedsl.sm120_moe.core.sm120_blockscaled_layout import (
+    Sm120SfConfigMxfp8Mxfp4,
+)
+from ..kernels.cutedsl.sm120_moe.core.sm120_gemm_builder import StoreMethod
+from ..kernels.cutedsl.sm120_moe.moe_gemm_mxfp8_mxfp4 import GRANK_A, make_args
+from ._arm import (
+    TACTICS,
+    CutedslSm120GroupedMxfp8Mxfp4Op,
+    _check_a_scale_granularity,
+    _op,
+    compiled_kernel,
+    select_tile,
+    split_tactic,
+)
+
+_MXFP8_MXFP4_TACTIC_SCHEMA_VERSION = 1
+_SCALE_CONTRACT = "mxfp8_mxfp4_mn_major_int32_ue8m0"
+# The A side admits both the DeepGEMM-style 128 and the OCP MXFP8 32; the B side is fixed at 32 by
+# the MXFP4 spec, so it is not a parameter.
+_SUPPORTED_A_GRANULARITY = (128, 32)
+
+
+def _encoded_tactics() -> tuple:
+    """`(schema, bm, bn, store)` as ints, so the autotuner's cache can round-trip a tactic."""
+    return tuple(
+        (_MXFP8_MXFP4_TACTIC_SCHEMA_VERSION, bm, bn, StoreMethod[store].value)
+        for bm, bn, store in TACTICS
+    )
+
+
+def _decode_tactic(tactic: tuple):
+    _, bm, bn, store_value = tactic
+    store = StoreMethod(store_value)
+    return split_tactic((bm, bn, store.name))
+
+
+def _check_scale_granularity_mnk(scale_granularity_mnk: Tuple[int, int, int]) -> int:
+    """Validate the A-side granularity and return its K component."""
+    if len(scale_granularity_mnk) != 3:
+        raise ValueError(
+            f"scale_granularity_mnk must be a 3-tuple (m_gran, n_gran, k_gran); "
+            f"got length {len(scale_granularity_mnk)}"
+        )
+    if scale_granularity_mnk[0] != 1 or scale_granularity_mnk[1] != 1:
+        raise ValueError(
+            f"scale_granularity_mnk[0:2] must both be 1 (per-token scaling along M and N); "
+            f"got {scale_granularity_mnk[:2]}"
+        )
+    if scale_granularity_mnk[2] not in _SUPPORTED_A_GRANULARITY:
+        raise ValueError(
+            f"scale_granularity_mnk[2] (k_gran) describes the activation side and must be one of "
+            f"{_SUPPORTED_A_GRANULARITY}; got {scale_granularity_mnk[2]}"
+        )
+    return scale_granularity_mnk[2]
+
+
+def _check_m_indptr(m_indptr: torch.Tensor, num_experts: int) -> None:
+    """Metadata shape only; value invariants would force a GPU->CPU sync on a low-latency path."""
+    if m_indptr.dtype != torch.int32:
+        raise ValueError(f"m_indptr must be torch.int32; got {m_indptr.dtype}")
+    if tuple(m_indptr.shape) != (num_experts + 1,):
+        raise ValueError(
+            f"m_indptr must have shape ({num_experts + 1},); got {tuple(m_indptr.shape)}"
+        )
+
+
+class _CutedslSm120Mxfp8Mxfp4MoeRunner(Sm120MoeTunableRunner):
+    """Tunable view of the arm. The base keys the cache on granularity already."""
+
+    def __init__(
+        self,
+        out: torch.Tensor,
+        scale_granularity_mnk: Tuple[int, int, int],
+        scale_major_mode: str,
+        grank_a: int,
+    ) -> None:
+        super().__init__(
+            out,
+            False,
+            scale_granularity_mnk,
+            scale_major_mode,
+            _encoded_tactics(),
+            _MXFP8_MXFP4_TACTIC_SCHEMA_VERSION,
+            _SCALE_CONTRACT,
+        )
+        self._grank_a = grank_a
+
+    def get_valid_tactics(self, inputs, profile) -> list:
+        """The base returns everything; feasibility here depends on the shape, so filter."""
+        a, b = inputs[0], inputs[1]
+        n, k = int(b.shape[1]), int(b.shape[2]) * 2
+        out_dtype = self._out.dtype if self._out is not None else torch.bfloat16
+        valid = []
+        for tactic in self._tactics:
+            tile, store = _decode_tactic(tactic)
+            if CutedslSm120GroupedMxfp8Mxfp4Op.can_implement(
+                n=n, k=k, tile=tile, out_dtype=out_dtype, store=store, grank_a=self._grank_a
+            ):
+                valid.append(tactic)
+        return valid
+
+    def is_valid_tactic(self, tactic: Any, inputs=None) -> bool:
+        """Four ints, not three: slot 0 is the schema version and the store method is an axis."""
+        if type(tactic) is not tuple or len(tactic) != 4:
+            return False
+        if any(type(value) is not int for value in tactic):
+            return False
+        return tactic in self._tactics
+
+    def get_cache_key_extras(self, inputs) -> tuple:
+        return super().get_cache_key_extras(inputs) + (self._grank_a,)
+
+    def _launch(self, inputs, out, is_gated, tactic) -> None:
+        a, b, a_scale, b_scale, m_indptr = inputs
+        n, k = int(b.shape[1]), int(b.shape[2]) * 2
+        props = torch.cuda.get_device_properties(a.device)
+        grid_x = props.multi_processor_count
+        if self.is_valid_tactic(tactic):
+            tile, store = _decode_tactic(tactic)
+        else:
+            tile, store = (
+                select_tile(
+                    total_rows=int(a.shape[0]),
+                    n=n,
+                    k=k,
+                    num_experts=int(b.shape[0]),
+                    num_sms=grid_x,
+                ),
+                None,
+            )
+        op = _op(n, k, tuple(tile), out.dtype, store, self._grank_a)
+        args = make_args(a, b, a_scale, b_scale, out, m_indptr)
+        compiled_kernel(
+            args, op=op, grid_x=grid_x, sm_version=f"sm_{props.major}{props.minor}"
+        )(*args)
+
+
+@supported_compute_capability([120, 121])
+@flashinfer_api
+def moe_gemm_mxfp8_mxfp4_nt_groupwise(
+    a: torch.Tensor,
+    b: torch.Tensor,
+    a_scale: torch.Tensor,
+    b_scale: torch.Tensor,
+    m_indptr: torch.Tensor,
+    scale_granularity_mnk: Tuple[int, int, int] = (1, 1, 128),
+    scale_major_mode: Literal["MN"] = "MN",
+    backend: Literal["cutedsl"] = "cutedsl",
+    out: Optional[torch.Tensor] = None,
+    out_dtype: Optional[torch.dtype] = None,
+) -> torch.Tensor:
+    r"""Grouped GEMM with MXFP8 activations and packed MXFP4 weights in zero-padding mode.
+
+    Currently only supported on NVIDIA RTX PRO 6000 Blackwell (SM120) architecture.
+
+    Zero-padding mode accepts token-packed input ``a`` (no per-expert pre-padding along M)
+    with a CSR cumsum group descriptor ``m_indptr``. It targets decoding, where the
+    per-expert M can be as small as 1 and DeepGEMM-style contiguous padding would waste
+    memory and compute.
+
+    Parameters
+    ----------
+    a: torch.Tensor
+        Row-major activation tensor, shape ``(cum_m, k)``, data type ``torch.float8_e4m3fn``.
+        Token-packed across experts; ``cum_m`` is the cumulative sum of the segment lengths.
+
+    b: torch.Tensor
+        Column-major weight tensor, shape ``(num_experts, n, k // 2)``, data type
+        ``torch.uint8``: two E2M1 values per byte.
+
+    a_scale: torch.Tensor
+        UE8M0 activation scales, ``torch.uint8`` viewing INT32 storage (4 scales per INT32
+        along K). MN-major with M contiguous: shape ``(k_align_a, m_padded * 4)`` where
+        ``k_align_a = ceil(k / (k_gran * 4))`` and ``m_padded = (cum_m + num_experts * 3) // 4 * 4``.
+        Expert ``i``'s scales start at column ``(m_indptr[i] + 3 * i) // 4 * 4``. The 4-column
+        padding is what keeps the TMA global stride 16-byte aligned; it is not optional.
+
+    b_scale: torch.Tensor
+        UE8M0 weight scales, ``torch.uint8`` viewing INT32 storage, MN-major with N
+        contiguous: shape ``(num_experts, k_packs_b, n_padded * 4)`` where
+        ``k_packs_b = ceil(k / 128)`` and ``n_padded = ceil(n / 4) * 4``. The weight side is
+        fixed at block-32 by the MXFP4 spec.
+
+    m_indptr: torch.Tensor
+        Segment-length indptr, shape ``(num_experts + 1,)``, ``torch.int32``.
+        ``m_indptr[0] = 0``, ``m_indptr[num_experts] = cum_m``.
+
+    scale_granularity_mnk: Tuple[int, int, int]
+        ``(m_granularity, n_granularity, k_granularity)`` of the **activation** scales.
+        ``m`` and ``n`` must both be ``1`` (per-token). ``k`` is ``128`` (DeepGEMM-style
+        production, default) or ``32`` (OCP MXFP8). The weight side takes no parameter: MXFP4
+        fixes it at 32.
+
+    scale_major_mode: Literal["MN"]
+        Layout mode of the scale tensors. Only ``"MN"`` is supported.
+
+    backend: Literal["cutedsl"]
+        Backend selector. Only the CuteDSL backend is implemented for this dtype pair.
+
+    out: Optional[torch.Tensor]
+        Output tensor, shape ``(cum_m, n)``. Allocated when not given.
+
+    out_dtype: Optional[torch.dtype]
+        Output data type. Only ``torch.bfloat16`` is supported.
+
+    Returns
+    -------
+    out: torch.Tensor
+        The output tensor, shape ``(cum_m, n)``.
+
+    Notes
+    -----
+    - Both scale tensors are UE8M0 bytes viewed over INT32 storage, so their trailing extent
+      counts bytes: an ``(x, y)`` INT32 tensor is passed as ``(x, y * 4)`` ``uint8``.
+    - The kernel derives the scales' K extent from ``scale_granularity_mnk`` rather than
+      reading it off the tensor, so a mismatch between how ``a_scale`` was packed and what is
+      declared here cannot be detected downstream; it is validated on entry instead.
+    """
+    if backend != "cutedsl":
+        raise NotImplementedError(
+            f'Only backend="cutedsl" is implemented for MXFP8 x MXFP4; got backend="{backend}"'
+        )
+    if scale_major_mode != "MN":
+        raise NotImplementedError(
+            f'Only scale_major_mode="MN" is supported; got "{scale_major_mode}"'
+        )
+    grank_a = _check_scale_granularity_mnk(scale_granularity_mnk)
+    _check_m_indptr(m_indptr, num_experts=int(b.shape[0]))
+
+    if out_dtype is None:
+        out_dtype = out.dtype if out is not None else torch.bfloat16
+    if out_dtype != torch.bfloat16:
+        raise NotImplementedError(
+            f"Only out_dtype=torch.bfloat16 is supported; got {out_dtype}"
+        )
+
+    n, k = int(b.shape[1]), int(b.shape[2]) * 2
+    _check_a_scale_granularity(a_scale, k, grank_a)
+    if out is None:
+        out = torch.zeros((a.shape[0], n), dtype=out_dtype, device=a.device)
+
+    inputs = [a, b, a_scale, b_scale, m_indptr]
+    runner = _CutedslSm120Mxfp8Mxfp4MoeRunner(
+        out, scale_granularity_mnk, scale_major_mode, grank_a
+    )
+    runner, tactic = AutoTuner.get().choose_one(
+        "cutedsl_sm120_mxfp8_mxfp4_groupwise_moe",
+        [runner],
+        SM120_MOE_TUNING_CONFIG,
+        inputs,
+    )
+    runner(inputs, tactic=tactic)
+    return out

--- a/flashinfer/grouped_mm/kernels/__init__.py
+++ b/flashinfer/grouped_mm/kernels/__init__.py
@@ -1,0 +1,16 @@
+# Copyright (c) 2026 by FlashInfer team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""CuteDSL and other kernel implementations backing the grouped_mm entry points."""
+

--- a/flashinfer/grouped_mm/kernels/cutedsl/__init__.py
+++ b/flashinfer/grouped_mm/kernels/cutedsl/__init__.py
@@ -1,0 +1,16 @@
+# Copyright (c) 2026 by FlashInfer team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""CuteDSL kernel implementations for grouped MoE GEMMs."""
+

--- a/flashinfer/grouped_mm/kernels/cutedsl/sm120_moe/__init__.py
+++ b/flashinfer/grouped_mm/kernels/cutedsl/sm120_moe/__init__.py
@@ -1,0 +1,8 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+"""Self-written CuteDSL grouped MoE GEMM kernels for SM120a: mxfp8 x mxfp4 and fp8."""
+
+from .moe_gemm_fp8 import CutedslSm120MoeFp8Grouped
+from .moe_gemm_mxfp8_mxfp4 import CutedslSm120MoeMxfp8Mxfp4Grouped
+
+__all__ = ["CutedslSm120MoeFp8Grouped", "CutedslSm120MoeMxfp8Mxfp4Grouped"]

--- a/flashinfer/grouped_mm/kernels/cutedsl/sm120_moe/core/__init__.py
+++ b/flashinfer/grouped_mm/kernels/cutedsl/sm120_moe/core/__init__.py
@@ -1,0 +1,3 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+"""Pieces both MoE GEMM arms share: tile/smem builder, SF layouts, scheduler and epilogue stores."""

--- a/flashinfer/grouped_mm/kernels/cutedsl/sm120_moe/core/_common.py
+++ b/flashinfer/grouped_mm/kernels/cutedsl/sm120_moe/core/_common.py
@@ -1,0 +1,22 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+"""Constants and integer helpers these SM120 MoE kernels share."""
+
+TMA_ALIGN_BYTES = 16
+UE8M0_PACK_NUM = 4
+SF_ELEM_BYTES = 4
+SF_M_ALIGN = TMA_ALIGN_BYTES // SF_ELEM_BYTES
+
+
+def ceil_div(a, b):
+    """Tiles/packs needed to cover ``a``; a floor here silently drops the partial tail."""
+    return (a + b - 1) // b
+
+
+def align(a, b):
+    return ceil_div(a, b) * b
+
+
+def compute_padded_offset(offset, expert_idx, alignment):
+    """Where expert ``expert_idx``'s rows start in the per-expert-aligned scale-factor buffer."""
+    return (offset + expert_idx * (alignment - 1)) // alignment * alignment

--- a/flashinfer/grouped_mm/kernels/cutedsl/sm120_moe/core/scheduler.py
+++ b/flashinfer/grouped_mm/kernels/cutedsl/sm120_moe/core/scheduler.py
@@ -1,0 +1,316 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+"""SM120 persistent tile scheduler for the static-tiling family."""
+import enum
+
+import cutlass
+from cutlass.cutlass_dsl import Int32, Boolean, extract_mlir_values, new_from_mlir_values, dsl_user_op
+from cutlass._mlir import ir
+import cutlass.cute as cute
+
+from ._common import ceil_div
+
+
+class GemmType(enum.IntEnum):
+    NORMAL = 0
+    BATCHED = 1
+    MGROUPED_CONTIGUOUS = 2
+    MGROUPED_MASKED = 3
+    MGROUPED_CONTIGUOUS_WITH_PSUM_LAYOUT = 4
+    MGROUPED_CONTIGUOUS_WITH_ZERO_PADDING = 5
+
+
+kDefaultNumSMs = 188
+
+
+def get_num_1d_blocks_per_group(bm, bn, num_sms=None):
+    if num_sms is None:
+        num_sms = kDefaultNumSMs
+    usage8 = 8 * bm + ((num_sms + 7) // 8) * bn
+    usage16 = 16 * bm + ((num_sms + 15) // 16) * bn
+    return 8 if usage8 <= usage16 else 16
+
+
+def swizzle_block(block_idx, num_n_blocks, num_m_blocks, k_1d, min_fn, max_fn):
+    num_blocks_per_group = num_n_blocks * k_1d
+    group_idx = block_idx // num_blocks_per_group
+    first_block_idx = group_idx * k_1d
+    in_group_idx = block_idx % num_blocks_per_group
+    # max(1,...): guard divisor on the terminating index (result ignored when has_next false).
+    num_blocks_in_group = max_fn(1, min_fn(k_1d, num_m_blocks - first_block_idx))
+    m_block = first_block_idx + in_group_idx % num_blocks_in_group
+    n_block = in_group_idx // num_blocks_in_group
+    return m_block, n_block
+
+
+def decode_block(block_idx, gemm_type, num_m_blocks, num_n_blocks, k_1d, min_fn, max_fn):
+    if gemm_type == GemmType.BATCHED:
+        blocks_per_batch = num_m_blocks * num_n_blocks
+        batch = block_idx // blocks_per_batch
+        m_block, n_block = swizzle_block(block_idx % blocks_per_batch, num_n_blocks, num_m_blocks, k_1d, min_fn, max_fn)
+        return batch, m_block, n_block
+    m_block, n_block = swizzle_block(block_idx, num_n_blocks, num_m_blocks, k_1d, min_fn, max_fn)
+    return 0, m_block, n_block
+
+
+# ------------------------------ StaticTileScheduler: Dense / Batched ------------------------------
+
+
+class StaticTileScheduler:
+    def __init__(self, gemm_type, bm, bn, grid_dim_x, num_groups, num_m_blocks, num_n_blocks,
+                 total_blocks, block_idx_x, current_iter, current_group_idx):
+        self.gemm_type = gemm_type
+        self.bm = bm
+        self.bn = bn
+        self.grid_dim_x = grid_dim_x
+        self.num_groups = num_groups
+        self.k_1d = get_num_1d_blocks_per_group(bm, bn)
+        self.num_m_blocks = num_m_blocks
+        self.num_n_blocks = num_n_blocks
+        self.total_blocks = total_blocks
+        self.block_idx_x = block_idx_x
+        self.current_iter = current_iter
+        self.current_group_idx = current_group_idx
+
+    @staticmethod
+    @dsl_user_op
+    def create(gemm_type, bm, bn, shape_m, shape_n, num_groups, grid_dim_x, block_idx_x, *, loc=None, ip=None):
+        num_m_blocks = Int32(ceil_div(shape_m, bm))
+        num_n_blocks = Int32(ceil_div(shape_n, bn))
+        total_blocks = num_m_blocks * num_n_blocks
+        if gemm_type == GemmType.BATCHED:
+            total_blocks = total_blocks * num_groups
+        return StaticTileScheduler(gemm_type, bm, bn, grid_dim_x, num_groups,
+                                   num_m_blocks, num_n_blocks, total_blocks, Int32(block_idx_x), Int32(-1), Int32(0))
+
+    def __extract_mlir_values__(self):
+        values = extract_mlir_values(self.num_m_blocks)
+        values.extend(extract_mlir_values(self.num_n_blocks))
+        values.extend(extract_mlir_values(self.total_blocks))
+        values.extend(extract_mlir_values(self.block_idx_x))
+        values.extend(extract_mlir_values(self.current_iter))
+        values.extend(extract_mlir_values(self.current_group_idx))
+        return values
+
+    def __new_from_mlir_values__(self, values):
+        fields = [self.num_m_blocks, self.num_n_blocks, self.total_blocks,
+                  self.block_idx_x, self.current_iter, self.current_group_idx]
+        new_fields = []
+        i = 0
+        for f in fields:
+            w = len(extract_mlir_values(f))
+            new_fields.append(new_from_mlir_values(f, values[i:i + w]))
+            i += w
+        return StaticTileScheduler(self.gemm_type, self.bm, self.bn, self.grid_dim_x, self.num_groups, *new_fields)
+
+    @dsl_user_op
+    @cute.jit
+    def get_next_block(self, *, loc=None, ip=None):
+        self.current_iter = self.current_iter + Int32(1)
+        next_block_idx = self.current_iter * self.grid_dim_x + self.block_idx_x
+        batch, m, n = decode_block(next_block_idx, self.gemm_type, self.num_m_blocks, self.num_n_blocks,
+                                   self.k_1d, cute.min, cute.max)
+        self.current_group_idx = batch
+        return next_block_idx < self.total_blocks, m, n
+
+    @dsl_user_op
+    @cute.jit
+    def get_group_idx(self, *, loc=None, ip=None):
+        return self.current_group_idx
+
+
+# ------------------------------- MoeTileScheduler: MoE token-packed -------------------------------
+
+
+MoeSchedStages = 2
+
+
+class MoeWorkTile:
+    def __init__(self, m_block, n_block, group, m_offset, m_boundary, valid):
+        self.m_block, self.n_block, self.group = m_block, n_block, group
+        self.m_offset, self.m_boundary, self.valid = m_offset, m_boundary, valid
+
+    FIELDS = 6
+
+    def store(self, work: cute.Tensor, sched_stage):
+        for i, v in enumerate((self.m_block, self.n_block, self.group,
+                               self.m_offset, self.m_boundary, self.valid)):
+            work[sched_stage, i] = v
+
+    @staticmethod
+    def load(work: cute.Tensor, sched_stage) -> "MoeWorkTile":
+        return MoeWorkTile(*(work[sched_stage, i] for i in range(MoeWorkTile.FIELDS)))
+
+    def __extract_mlir_values__(self):
+        vals = []
+        for f in (self.m_block, self.n_block, self.group, self.m_offset, self.m_boundary, self.valid):
+            vals.extend(extract_mlir_values(f))
+        return vals
+
+    def __new_from_mlir_values__(self, values):
+        fields = [self.m_block, self.n_block, self.group, self.m_offset, self.m_boundary, self.valid]
+        new_fields, i = [], 0
+        for f in fields:
+            w = len(extract_mlir_values(f))
+            new_fields.append(new_from_mlir_values(f, values[i:i + w]))
+            i += w
+        return MoeWorkTile(*new_fields)
+
+
+class MoeSchedProducer:
+    def __init__(self, stages, sched_iter):
+        self.stages = stages
+        self.sched_iter = sched_iter
+
+    @staticmethod
+    def create(stages) -> "MoeSchedProducer":
+        return MoeSchedProducer(stages, Int32(0))
+
+    def __extract_mlir_values__(self):
+        return extract_mlir_values(self.sched_iter)
+
+    def __new_from_mlir_values__(self, values):
+        return MoeSchedProducer(self.stages, new_from_mlir_values(self.sched_iter, values))
+
+    @dsl_user_op
+    @cute.jit
+    def publish(self, work: cute.Tensor, full, empty, tile: MoeWorkTile, *, loc=None, ip=None):
+        sched_stage = self.sched_iter % self.stages
+        cute.arch.mbarrier_wait(empty + sched_stage, ((self.sched_iter // self.stages) & 1) ^ 1)
+        with cute.arch.elect_one():
+            tile.store(work, sched_stage)
+            cute.arch.mbarrier_arrive(full + sched_stage)
+        self.sched_iter = self.sched_iter + Int32(1)
+
+    @dsl_user_op
+    @cute.jit
+    def publish_sentinel(self, work: cute.Tensor, full, empty, *, loc=None, ip=None):
+        sched_stage = self.sched_iter % self.stages
+        cute.arch.mbarrier_wait(empty + sched_stage, ((self.sched_iter // self.stages) & 1) ^ 1)
+        with cute.arch.elect_one():
+            work[sched_stage, MoeWorkTile.FIELDS - 1] = Int32(0)
+            cute.arch.mbarrier_arrive(full + sched_stage)
+
+
+class MoeSchedConsumer:
+    def __init__(self, stages, sched_iter):
+        self.stages = stages
+        self.sched_iter = sched_iter
+
+    @staticmethod
+    def create(stages) -> "MoeSchedConsumer":
+        return MoeSchedConsumer(stages, Int32(0))
+
+    def __extract_mlir_values__(self):
+        return extract_mlir_values(self.sched_iter)
+
+    def __new_from_mlir_values__(self, values):
+        return MoeSchedConsumer(self.stages, new_from_mlir_values(self.sched_iter, values))
+
+    @dsl_user_op
+    @cute.jit
+    def get_next_tile(self, work: cute.Tensor, full, empty, *, loc=None, ip=None) -> MoeWorkTile:
+        sched_stage = self.sched_iter % self.stages
+        cute.arch.mbarrier_wait(full + sched_stage, (self.sched_iter // self.stages) & 1)
+        tile = MoeWorkTile.load(work, sched_stage)
+        cute.arch.sync_warp()  # release only after every lane owns its copy
+        if tile.valid != Int32(0):  # the sentinel is never released
+            with cute.arch.elect_one():
+                cute.arch.mbarrier_arrive(empty + sched_stage)
+            self.sched_iter = self.sched_iter + Int32(1)
+        return tile
+
+
+class MoeTileScheduler:
+    def __init__(self, bm, grid_dim_x, num_groups, num_n_blocks, block_idx_x, current_iter,
+                 current_group_idx, prev_psum_m, current_psum_m, window_base, window_start_block, lane_off, lane_next):
+        self.bm = bm
+        self.grid_dim_x = grid_dim_x
+        self.num_groups = num_groups
+        self.num_n_blocks = num_n_blocks
+        self.block_idx_x = block_idx_x
+        self.current_iter = current_iter
+        self.current_group_idx = current_group_idx
+        self.prev_psum_m = prev_psum_m
+        self.current_psum_m = current_psum_m
+        self.window_base = window_base
+        self.window_start_block = window_start_block
+        self.lane_off = lane_off
+        self.lane_next = lane_next
+
+    @staticmethod
+    @dsl_user_op
+    def create(bm, num_groups, num_n_blocks, grid_dim_x, block_idx_x, offsets, *, loc=None, ip=None):
+        ng = Int32(num_groups)
+        lane = cute.arch.lane_idx()
+        lane_off = offsets[cute.min(lane, ng)]
+        lane_next = offsets[cute.min(lane + Int32(1), ng)]
+        return MoeTileScheduler(bm, grid_dim_x, ng, Int32(num_n_blocks), Int32(block_idx_x), Int32(-1),
+                                Int32(0), Int32(0), Int32(0), Int32(0), Int32(0), lane_off, lane_next)
+
+    def __extract_mlir_values__(self):
+        vals = []
+        for f in (self.num_groups, self.num_n_blocks, self.block_idx_x, self.current_iter, self.current_group_idx,
+                  self.prev_psum_m, self.current_psum_m, self.window_base, self.window_start_block,
+                  self.lane_off, self.lane_next):
+            vals.extend(extract_mlir_values(f))
+        return vals
+
+    def __new_from_mlir_values__(self, values):
+        fields = [self.num_groups, self.num_n_blocks, self.block_idx_x, self.current_iter, self.current_group_idx,
+                  self.prev_psum_m, self.current_psum_m, self.window_base, self.window_start_block,
+                  self.lane_off, self.lane_next]
+        new_fields, i = [], 0
+        for f in fields:
+            w = len(extract_mlir_values(f))
+            new_fields.append(new_from_mlir_values(f, values[i:i + w]))
+            i += w
+        return MoeTileScheduler(self.bm, self.grid_dim_x, *new_fields)
+
+    @dsl_user_op
+    @cute.jit
+    def get_next_block(self, offsets: cute.Tensor, *, loc=None, ip=None):
+        self.current_iter = self.current_iter + Int32(1)
+        nbi = self.current_iter * self.grid_dim_x + self.block_idx_x
+        target_m_block = nbi // self.num_n_blocks
+        n_block = nbi % self.num_n_blocks
+        lane = cute.arch.lane_idx()
+        wbase, wstart = self.window_base, self.window_start_block
+        loff, lnext = self.lane_off, self.lane_next
+        cg, po, cp = self.current_group_idx, self.prev_psum_m, self.current_psum_m
+        m_block, has, done = Int32(0), Boolean(False), Int32(0)
+        while done == Int32(0):
+            my_blocks = ceil_div(lnext - loff, self.bm)
+            incl = my_blocks
+            for i in cutlass.range_constexpr(5):
+                d = 1 << i
+                up = cute.arch.shuffle_sync_up(incl, Int32(d), mask_and_clamp=0)
+                incl = incl + up * (Int32(1) + ((lane - Int32(d)) >> Int32(31)))
+            window_total = cute.arch.shuffle_sync(incl, Int32(31))
+            local = target_m_block - wstart
+            owners = cute.arch.vote_ballot_sync(incl > local)
+            src = cute.arch.popc((owners & (Int32(0) - owners)) - Int32(1))
+            group_start = cute.arch.shuffle_sync(incl - my_blocks, src)
+            landed = target_m_block < wstart + window_total
+            exhausted = (wbase + Int32(32)) >= self.num_groups
+            if landed:
+                cg = wbase + src
+                po = cute.arch.shuffle_sync(loff, src)
+                cp = cute.arch.shuffle_sync(lnext, src)
+                m_block = local - group_start
+                has = Boolean(True)
+                done = Int32(1)
+            else:
+                if exhausted:
+                    has = Boolean(False)
+                    done = Int32(1)
+                else:
+                    wstart = wstart + window_total
+                    wbase = wbase + Int32(32)
+                    g2 = wbase + lane
+                    loff = offsets[cute.min(g2, self.num_groups)]
+                    lnext = offsets[cute.min(g2 + Int32(1), self.num_groups)]
+        self.window_base, self.window_start_block = wbase, wstart
+        self.lane_off, self.lane_next = loff, lnext
+        self.current_group_idx, self.prev_psum_m, self.current_psum_m = cg, po, cp
+        return has, cg, m_block, n_block, po, cp

--- a/flashinfer/grouped_mm/kernels/cutedsl/sm120_moe/core/sm120_blockscaled_layout.py
+++ b/flashinfer/grouped_mm/kernels/cutedsl/sm120_moe/core/sm120_blockscaled_layout.py
@@ -1,0 +1,274 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+"""SM120 per-variant scale-factor configs (fp8 float-scale, mxfp8 x mxfp4 UE8M0), each self-contained."""
+import cutlass
+import cutlass.cute as cute
+
+from ._common import SF_M_ALIGN, TMA_ALIGN_BYTES
+from ._common import align, ceil_div
+
+
+class Sm120SfConfigMxfp8Mxfp4:
+    """mxfp8 (pure + mix) self-contained ue8m0 SF config for the SM120 block-scaled MMA. K-independent (sized by stages, never total K)."""
+    KTILE_SF = 1
+    PACK_NSF = 4
+    SF_VEC = 32
+
+    def __init__(self, grank_a, grank_b):
+        assert grank_a % grank_b == 0 or grank_b % grank_a == 0, (
+            f"SF granularities must nest: neither {grank_a} nor {grank_b} divides the other, so the "
+            f"coarser side's pack does not hold a whole number of the finer side's")
+        self.sf_dtype = cutlass.Int32
+        self.use_ue8m0 = True
+        self.grank_a = grank_a
+        self.grank_b = grank_b
+        self.sf_load_warp = 1
+
+    def _k_tiles_per_pack(self, grank, tile_k):
+        """tile-Ks covered by one int32 SF pack (pack_nk = grank*PACK_NSF)."""
+        pack_nk = grank * self.PACK_NSF
+        assert pack_nk % tile_k == 0, "grank*PACK_NSF must be a multiple of tile_k (int32 SF pack aligns to tile-K)"
+        return pack_nk // tile_k
+
+    def k_tiles_per_pack_a(self, tile_k):
+        return self._k_tiles_per_pack(self.grank_a, tile_k)
+
+    def k_tiles_per_pack_b(self, tile_k):
+        return self._k_tiles_per_pack(self.grank_b, tile_k)
+
+    def _sf_stages(self, ab_stage, k_tiles_per_pack):
+        """SF stages backing ab_stage k-tiles; never below 1, or a lone outliving pack gets no buffer."""
+        return max(1, ceil_div(ab_stage, k_tiles_per_pack))
+
+    def ab_stages_contract(self, ab_stage):
+        """Powers of two only: the stage index is a bit mask (sf_mxfp8_tma_load.cuh:80)."""
+        return ab_stage & (ab_stage - 1) == 0
+
+    def sfa_stages(self, ab_stage, tile_k):
+        return self._sf_stages(ab_stage, self.k_tiles_per_pack_a(tile_k))
+
+    def sfb_stages(self, ab_stage, tile_k):
+        return self._sf_stages(ab_stage, self.k_tiles_per_pack_b(tile_k))
+
+    def _stage_stride(self, mn):
+        """Elements between SF stages: the mn extent floored at 128 B (sf_mxfp8_tma_load.cuh:256-263)."""
+        return max(mn, 128 * 8 // self.sf_dtype.width)
+
+    def _smem_layout(self, mn, sf_stages):
+        return cute.make_layout((mn, self.KTILE_SF, sf_stages), stride=(1, mn, self._stage_stride(mn)))
+
+    def _cosize(self, mn, sf_stages):
+        return (sf_stages - 1) * self._stage_stride(mn) + mn
+
+    def smem_bytes(self, tile, ab_stage):
+        """SFA+SFB smem cost; mirrors _smem_layout's cosize so the stage search budgets what is allocated."""
+        bm, bn, bk = tile
+        packs = (self._cosize(bm, self.sfa_stages(ab_stage, bk))
+                 + self._cosize(bn, self.sfb_stages(ab_stage, bk)))
+        return packs * (self.sf_dtype.width // 8)
+
+    def make_smem_layout_sfa(self, tile_m, sf_stages):
+        return self._smem_layout(tile_m, sf_stages)
+
+    def make_smem_layout_sfb(self, tile_n, sf_stages):
+        return self._smem_layout(tile_n, sf_stages)
+
+    def make_s2r_sf(self, tv_layout, tiler):
+        """int32 SF S2R tiled copy; tv_layout from get_layoutSF{A,B}_TV, tiler = (perm_mn, KTILE_SF=1)."""
+        atom = cute.make_copy_atom(cute.nvgpu.CopyUniversalOp(), self.sf_dtype)
+        return cute.make_tiled_copy(atom, tv_layout, tiler)
+
+    def _deduce_layout(self, mn, K, L, grank):
+        """MN-major SF gmem layout; mn rides m_align so the TMA globalStride stays 16B-aligned."""
+        pack_nk = grank * self.PACK_NSF
+        scale_k = ceil_div(K, pack_nk)
+        mn = align(mn, SF_M_ALIGN)
+        return cute.make_layout((mn, scale_k, L), stride=(1, mn, mn * scale_k))
+
+    def deduce_sfa_layout(self, mn, K, L):
+        return self._deduce_layout(mn, K, L, self.grank_a)
+
+    def deduce_sfb_layout(self, mn, K, L):
+        return self._deduce_layout(mn, K, L, self.grank_b)
+
+    def thrfrg_SFA(self, sf_layout, tiled_mma):
+        """SFA thread fragment; AtomLayoutSFA_TV = ((2,2,8),1):((8,0,1),16)."""
+        atom_shape_mnk = tiled_mma.shape_mnk
+        perm = tiled_mma.permutation_mnk
+        thr_vmnk = tiled_mma.thr_layout_vmnk
+        atom_sf_layout = cute.make_layout(((2, 2, 8), self.KTILE_SF), stride=((8, 0, 1), 16))
+        t_tile = (perm[0], cute.make_layout(self.KTILE_SF))
+        t_tensor = cute.logical_divide(sf_layout, t_tile)
+        a_tile = (cute.make_layout(atom_shape_mnk[0]), cute.make_layout(self.KTILE_SF))
+        a_tensor = cute.zipped_divide(t_tensor, a_tile)
+        tv_tensor = cute.composition(a_tensor, (atom_sf_layout, None))
+        thr_tile = (None, (cute.make_layout(cute.size(thr_vmnk[1])),
+                           cute.make_layout(cute.size(thr_vmnk[3]))))
+        return cute.zipped_divide(tv_tensor, thr_tile)
+
+    @staticmethod
+    def _thr_partition(thr_tensor, thr_coord):
+        """One slice per value mode, counted off the layout so the rank follows the warp layout."""
+        rest = (None, tuple([None] * cute.rank(thr_tensor.layout, mode=[1, 1])))
+        return thr_tensor[thr_coord, rest]
+
+    def partition_fragment_SFA(self, sf_tensor, thr_mma, tidx):
+        thr_tensor = cute.make_tensor(sf_tensor.iterator, self.thrfrg_SFA(sf_tensor.layout, thr_mma))
+        thr_vmnk = thr_mma.thr_layout_vmnk.get_flat_coord(tidx)
+        thr_vmk = (thr_vmnk[0], (thr_vmnk[1], thr_vmnk[3]))
+        return cute.make_fragment_like(self._thr_partition(thr_tensor, thr_vmk))
+
+    def get_layoutSFA_TV(self, tiled_mma):
+        """int32 (thr,val) layout for the SFA S2R copy."""
+        perm = tiled_mma.permutation_mnk
+        thr_vmnk = tiled_mma.thr_layout_vmnk
+        ref = cute.make_layout((cute.size(perm[0]), self.KTILE_SF))
+        atile = (None, (cute.make_layout(shape=(cute.size(thr_vmnk[1]), cute.size(thr_vmnk[2])),
+                                         stride=(1, 0)), None))
+        thrfrg = self.thrfrg_SFA(ref, tiled_mma)
+        tv = cute.composition(thrfrg, (atile, None))
+        return cute.composition(tv, (cute.right_inverse(thr_vmnk), None))
+
+    def make_sf_ue8m0_view(self, frg_int32, grank, tile_k):
+        """Restore the packed int32 fragment into the per-mma-atom ue8m0 view fed into the MMA (shared by SFA/SFB)."""
+        ue8m0_ptr = cute.recast_ptr(frg_int32.iterator, dtype=cutlass.Float8E8M0FNU)
+        num_mn = cute.size(frg_int32.layout, mode=[1])
+        pack_nk = grank * self.PACK_NSF
+        atoms_per_sf = min(grank, tile_k) // self.SF_VEC
+        num_sf_per_tk = tile_k // grank if tile_k >= grank else 1
+        num_tk_per_sf = grank // tile_k if grank > tile_k else 1
+        num_tk_groups = (pack_nk // tile_k) // num_tk_per_sf
+        view = cute.make_layout(
+            (self.SF_VEC, num_mn, (atoms_per_sf, num_sf_per_tk), (num_tk_per_sf, num_tk_groups)),
+            stride=(0, self.PACK_NSF, (0, 1), (0, num_sf_per_tk)))
+        return cute.make_tensor(ue8m0_ptr, view)
+
+    def make_sfa_ue8m0_view(self, frg_int32, tile_k):
+        """SFA (act) ue8m0 view with kGranK = grank_a. See make_sf_ue8m0_view."""
+        return self.make_sf_ue8m0_view(frg_int32, self.grank_a, tile_k)
+
+    def thrfrg_SFB(self, sf_layout, tiled_mma):
+        """SFB thread fragment; AtomLayoutSFB_TV = ((4,8),1):((0,1),8)."""
+        atom_shape_mnk = tiled_mma.shape_mnk
+        perm = tiled_mma.permutation_mnk
+        thr_vmnk = tiled_mma.thr_layout_vmnk
+        atom_sf_layout = cute.make_layout(((4, 8), self.KTILE_SF), stride=((0, 1), 8))
+        t_tile = (perm[1], cute.make_layout(self.KTILE_SF))
+        t_tensor = cute.logical_divide(sf_layout, t_tile)
+        a_tile = (cute.make_layout(atom_shape_mnk[1]), cute.make_layout(self.KTILE_SF))
+        a_tensor = cute.zipped_divide(t_tensor, a_tile)
+        tv_tensor = cute.composition(a_tensor, (atom_sf_layout, None))
+        thr_tile = (None, (cute.make_layout(cute.size(thr_vmnk[2])),
+                           cute.make_layout(cute.size(thr_vmnk[3]))))
+        return cute.zipped_divide(tv_tensor, thr_tile)
+
+    def partition_fragment_SFB(self, sf_tensor, thr_mma, tidx):
+        thr_tensor = cute.make_tensor(sf_tensor.iterator, self.thrfrg_SFB(sf_tensor.layout, thr_mma))
+        thr_vmnk = thr_mma.thr_layout_vmnk.get_flat_coord(tidx)
+        thr_vnk = (thr_vmnk[0], (thr_vmnk[2], thr_vmnk[3]))
+        return cute.make_fragment_like(self._thr_partition(thr_tensor, thr_vnk))
+
+    def get_layoutSFB_TV(self, tiled_mma):
+        """int32 (thr,val) layout for the SFB S2R copy."""
+        perm = tiled_mma.permutation_mnk
+        thr_vmnk = tiled_mma.thr_layout_vmnk
+        ref = cute.make_layout((cute.size(perm[1]), self.KTILE_SF))
+        btile = (None, (cute.make_layout(shape=(cute.size(thr_vmnk[1]), cute.size(thr_vmnk[2])),
+                                         stride=(0, 1)), None))
+        thrfrg = self.thrfrg_SFB(ref, tiled_mma)
+        tv = cute.composition(thrfrg, (btile, None))
+        return cute.composition(tv, (cute.right_inverse(thr_vmnk), None))
+
+    def make_sfb_ue8m0_view(self, frg_int32, tile_k):
+        """SFB (weight) ue8m0 view with kGranK = grank_b. See make_sf_ue8m0_view."""
+        return self.make_sf_ue8m0_view(frg_int32, self.grank_b, tile_k)
+
+
+class Sm120SfConfigFp8:
+    """fp8 block_scaling (DSv3) self-contained SF config for the SM120 plain-fp8 MMA (fp32 scale applied outside the MMA)."""
+    NUM_SCALE_COPY_THREADS = 32
+
+    def __init__(self, gran_m, gran_n, gran_k):
+        self.sf_dtype = cutlass.Float32
+        self.use_ue8m0 = False
+        self.gran_m = gran_m
+        self.gran_n = gran_n
+        self.gran_k = gran_k
+        self.sf_load_warp = 1
+        # rows each expert's scales are padded to, the same quantity the host pads by
+        SF_M_ALIGN = TMA_ALIGN_BYTES // (self.sf_dtype.width // 8)
+
+    def k_tiles_per_pack(self, tile_k):
+        """k-tiles one SF entry covers, i.e. the SF load cadence against the A/B loop."""
+        assert self.gran_k % tile_k == 0, (
+            f"gran_k ({self.gran_k}) must be a multiple of tile_k ({tile_k}): an SF entry has to "
+            f"cover a whole number of k-tiles")
+        return self.gran_k // tile_k
+
+    def sf_stages(self, ab_stage, tile_k):
+        """SF ring depth backing ab_stage k-tiles; equals ab_stage while the cadence is 1."""
+        return max(1, ceil_div(ab_stage, self.k_tiles_per_pack(tile_k)))
+
+    def ab_stages_contract(self, ab_stage):
+        """Any depth: the SF ring shares the A/B stage counter, and both wrap on a runtime compare."""
+        return True
+
+    def assert_k_invariant(self, tile_k):
+        """Require tile_k == gran_k (the 2D staged SF smem layout has no in-tile K dim)."""
+        assert tile_k == self.gran_k, (
+            f"tile_k ({tile_k}) must equal gran_k ({self.gran_k}): the 2D staged SF layout has no in-tile "
+            f"K dim (kTileScaleK must be 1); use tile_k == gran_k or extend to a 3D K-scale layout.")
+
+    def assert_mn_invariant(self, tile_m, tile_n):
+        """Require whole granules on both axes; which one is coarse is what swap-AB exchanges."""
+        assert tile_m % self.gran_m == 0 and tile_n % self.gran_n == 0, (
+            f"tile ({tile_m}, {tile_n}) must cover whole scale granules "
+            f"({self.gran_m}, {self.gran_n}); a partial granule indexes past the SF tensor.")
+
+    def deduce_sfa_layout(self, M, K, L):
+        """MN-major SFA gmem layout [ceil(M/gran_m), ceil(K/gran_k), L]."""
+        scale_m = ceil_div(M, self.gran_m)
+        scale_k = ceil_div(K, self.gran_k)
+        return cute.make_layout((scale_m, scale_k, L), stride=(1, scale_m, scale_m * scale_k))
+
+    def deduce_sfb_layout(self, N, K, L):
+        """MN-major SFB gmem layout [ceil(N/gran_n), ceil(K/gran_k), L]."""
+        scale_n = ceil_div(N, self.gran_n)
+        scale_k = ceil_div(K, self.gran_k)
+        return cute.make_layout((scale_n, scale_k, L), stride=(1, scale_n, scale_n * scale_k))
+
+    def make_smem_layout_sfa(self, tile_m, stages):
+        """Staged SFA consume view [kTileScaleM, SF_Stages]."""
+        tscale_m = ceil_div(tile_m, self.gran_m)
+        return cute.make_layout((tscale_m, stages), stride=(1, tscale_m))
+
+    def make_smem_layout_sfb(self, tile_n, stages):
+        """Staged SFB consume view [kTileScaleN, SF_Stages]."""
+        tscale_n = ceil_div(tile_n, self.gran_n)
+        return cute.make_layout((tscale_n, stages), stride=(1, tscale_n))
+
+    def smem_bytes(self, tile, ab_stage):
+        """SFA+SFB smem cost. SFA is allocated over its TMA view, which adds no elements."""
+        bm, bn, _ = tile
+        entries = (ceil_div(bm, self.gran_m) + ceil_div(bn, self.gran_n)) * ab_stage
+        return entries * (self.sf_dtype.width // 8)
+
+    def make_tma_smem_layout_sfa(self, tile_m, stages):
+        """SFA TMA-target smem [kTileScaleM, 1, SF_Stages], overlaying the SmemLayoutSFA buffer."""
+        tscale_m = ceil_div(tile_m, self.gran_m)
+        return cute.make_layout((tscale_m, 1, stages), stride=(1, tscale_m, tscale_m))
+
+    def partition_scale_as_c(self, sSFA, sSFB, thr_mma):
+        """ViewAsC: re-view the staged SF smem as the C tile. Returns (tCsSFA, tCsSFB, tCrSFA, tCrSFB)."""
+        tscale_m, stages = cute.size(sSFA, mode=[0]), cute.size(sSFA, mode=[1])
+        tscale_n = cute.size(sSFB, mode=[0])
+        tile_m, tile_n = self.gran_m * tscale_m, self.gran_n * tscale_n
+        sSFA_vc = cute.make_tensor(sSFA.iterator, cute.make_layout(
+            ((self.gran_m, tscale_m), tile_n, stages), stride=((0, 1), 0, tscale_m)))
+        sSFB_vc = cute.make_tensor(sSFB.iterator, cute.make_layout(
+            (tile_m, (self.gran_n, tscale_n), stages), stride=(0, (0, 1), tscale_n)))
+        tCsSFA = thr_mma.partition_C(sSFA_vc)
+        tCsSFB = thr_mma.partition_C(sSFB_vc)
+        tCrSFA = cute.make_fragment_like(tCsSFA[None, None, None, 0])
+        tCrSFB = cute.make_fragment_like(tCsSFB[None, None, None, 0])
+        return tCsSFA, tCsSFB, tCrSFA, tCrSFB

--- a/flashinfer/grouped_mm/kernels/cutedsl/sm120_moe/core/sm120_gemm_builder.py
+++ b/flashinfer/grouped_mm/kernels/cutedsl/sm120_moe/core/sm120_gemm_builder.py
@@ -1,0 +1,354 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+"""SM120 block-scaled GEMM builder for the warp-specialized kernel family: composable per-phase configs + top builder."""
+import abc
+import enum
+
+import cutlass
+import cutlass.utils
+import cutlass.cute as cute
+import cutlass.cute.nvgpu.warp.mma as warp_mma
+import cutlass.utils.blackwell_helpers as sm120_utils
+import cutlass.utils.hopper_helpers as sm90_utils
+from cutlass.cute.nvgpu import cpasync
+
+from .scheduler import MoeSchedStages, MoeWorkTile
+
+
+
+class MmaConfig:
+    """MMA phase: warp-MMA op + the warp layout its tile implies + permutation flag."""
+    def __init__(self, op, mma_tile_mn, num_math_warps, swap_ab=False):
+        self.op = op
+        self.mma_tile_mn = tuple(mma_tile_mn)
+        self.num_math_warps = num_math_warps
+        self.swap_ab = swap_ab
+        self.use_mxf8f6f4 = not isinstance(op, warp_mma.MmaMXF4NVF4Op)
+        self.plain_fp8 = isinstance(op, warp_mma.MmaFP8Op)
+        assert self.mma_tile_mn[1] // self.num_warp_n >= op.shape_mnk[1], (
+            f"tile_n {self.mma_tile_mn[1]} over {self.num_warp_n} N-warps leaves each warp less "
+            f"than the atom's N extent {op.shape_mnk[1]}")
+
+    @property
+    def num_warp_m(self):
+        """M-major by owner decision, not upstream's bn-derived rule; swap-AB uses upstream's (builder.cuh:52-55)."""
+        if self.swap_ab:
+            bn, atom_n = self.mma_tile_mn[1], self.op.shape_mnk[1]
+            return self.num_math_warps // (4 if bn >= 32 else bn // atom_n)
+        return 4 if self.mma_tile_mn[0] >= 64 else 2
+
+    @property
+    def num_warp_n(self):
+        return self.num_math_warps // self.num_warp_m
+
+    def mma_warp_layout(self):
+        """The MNK warp layout (call inside @cute.jit)."""
+        warp_m = self.num_warp_m
+        return cute.make_ordered_layout((warp_m, self.num_math_warps // warp_m, 1), order=(0, 1, 2))
+
+    @property
+    def sf_vec(self):
+        """Block-scale vector length the op itself declares; fp8 has none, so K rides the atom."""
+        return self.op.shape_mnk[2] if self.plain_fp8 else self.op.sf_vec_size
+
+    def make_tiled_mma(self, tile):
+        """Build the TiledMMA (call inside @cute.jit)."""
+        # get_permutation_mnk pins perm_n at 32 regardless of bn, which a swapped bn cannot hold
+        if self.plain_fp8 or self.swap_ab:
+            perm = (tile[0], tile[1], self.sf_vec)
+        else:
+            perm = sm120_utils.get_permutation_mnk(tile, self.sf_vec, self.use_mxf8f6f4)
+        return cute.make_tiled_mma(self.op, self.mma_warp_layout(), permutation_mnk=perm)
+
+    def make_s2r_a(self, tiledmma, smem_dtype, transpose, unpack_bits=None):
+        if unpack_bits is None:
+            ld = cute.make_copy_atom(
+                cute.nvgpu.warp.LdMatrix8x8x16bOp(transpose=transpose, num_matrices=4), smem_dtype)
+        else:
+            ld = cute.make_copy_atom(
+                cute.nvgpu.warp.LdMatrix8x16x8bOp(transpose=False, num_matrices=4,
+                                                  unpack_bits=unpack_bits), smem_dtype)
+        return cute.make_tiled_copy_A(ld, tiledmma)
+
+    @property
+    def ldsm_matrices_b(self):
+        """How many matrices one B ldmatrix moves, from kPerWarpN (flashinfer ab_tma_load.cuh:42-48)."""
+        per_warp_n = self.mma_tile_mn[1] // self.num_warp_n
+        return 4 if per_warp_n >= 16 else (2 if per_warp_n >= 8 else 1)
+
+    def make_s2r_b(self, tiledmma, smem_dtype, transpose, unpack_bits=None):
+        num_matrices = self.ldsm_matrices_b
+        if unpack_bits is None:
+            ld = cute.make_copy_atom(
+                cute.nvgpu.warp.LdMatrix8x8x16bOp(transpose=transpose, num_matrices=num_matrices), smem_dtype)
+        else:
+            ld = cute.make_copy_atom(
+                cute.nvgpu.warp.LdMatrix8x16x8bOp(transpose=False, num_matrices=num_matrices,
+                                                  unpack_bits=unpack_bits), smem_dtype)
+        return cute.make_tiled_copy_B(ld, tiledmma)
+
+    def make_s2r_sf(self, sf_dtype, tv_layout, tiler):
+        """SF S2R tiled copy (consumer side)."""
+        atom = cute.make_copy_atom(cute.nvgpu.CopyUniversalOp(), sf_dtype)
+        return cute.make_tiled_copy(atom, tv_layout, tiler)
+
+
+class LoadABConfig:
+    """A/B G2S phase: per-operand dtypes and extents in, k-major smem layouts + TMA atoms out."""
+    def __init__(self, tile, ab_stage, a_dtype, b_dtype,
+                 a_smem_dtype=None, b_smem_dtype=None,
+                 a_tma_internal=None, b_tma_internal=None,
+                 a_unpack_bits=None, b_unpack_bits=None):
+        self.tile, self.ab_stage = tuple(tile), ab_stage
+        self.a_dtype, self.b_dtype = a_dtype, b_dtype
+        self.a_smem_dtype = a_smem_dtype or a_dtype
+        self.b_smem_dtype = b_smem_dtype or b_dtype
+        self.a_tma_internal, self.b_tma_internal = a_tma_internal, b_tma_internal
+        self.a_unpack_bits, self.b_unpack_bits = a_unpack_bits, b_unpack_bits
+
+        bm, bn, bk = self.tile
+        # smem always holds one value per element, natively or because the TMA unpacked it on the way in
+        self.tma_box_a, self.tma_box_b = (bm, bk), (bn, bk)
+        # the transaction counts gmem bytes, which the source dtype over the K tile gives directly
+        self.tma_bytes_a = bm * bk * a_dtype.width // 8
+        self.tma_bytes_b = bn * bk * b_dtype.width // 8
+        self.tma_bytes_ab = self.tma_bytes_a + self.tma_bytes_b
+
+    def _smem_layout(self, box, smem_dtype):
+        atom = cute.nvgpu.warpgroup.make_smem_layout_atom(
+            sm90_utils.get_smem_layout_atom(cutlass.utils.LayoutEnum.ROW_MAJOR, smem_dtype, box[1]), smem_dtype)
+        return cute.tile_to_shape(atom, (*box, self.ab_stage), order=(0, 1, 2))
+
+    def smem_bytes_a(self):
+        """A staging cost. tile_to_shape over a dense box, so cosize is box * ab_stage."""
+        bm, _, bk = self.tile
+        return bm * bk * self.a_smem_dtype.width * self.ab_stage // 8
+
+    def smem_bytes_b(self):
+        _, bn, bk = self.tile
+        return bn * bk * self.b_smem_dtype.width * self.ab_stage // 8
+
+    def smem_bytes(self):
+        return self.smem_bytes_a() + self.smem_bytes_b()
+
+    def make_smem_layout_a(self):
+        return self._smem_layout(self.tma_box_a, self.a_smem_dtype)
+
+    def make_smem_layout_b(self):
+        return self._smem_layout(self.tma_box_b, self.b_smem_dtype)
+
+    def _tma_atom(self, g, smem_layout, box, internal):
+        return cpasync.make_tiled_tma_atom(
+            cpasync.CopyBulkTensorTileG2SOp(), g, cute.slice_(smem_layout, (None, None, 0)), box,
+            num_multicast=1, internal_type=internal)
+
+    def make_tma_atom_a(self, gA, smem_layout_a):
+        return self._tma_atom(gA, smem_layout_a, self.tma_box_a, self.a_tma_internal)
+
+    def make_tma_atom_b(self, gB, smem_layout_b):
+        return self._tma_atom(gB, smem_layout_b, self.tma_box_b, self.b_tma_internal)
+
+
+class StoreMethod(enum.Enum):
+    """Identity of an epilogue store path. Each value has exactly one StoreConfig subclass."""
+    R2G_WG = enum.auto()
+    STAGED_R2G = enum.auto()
+    DIRECT_STG = enum.auto()
+
+
+class StoreConfig(abc.ABC):
+    """Epilogue store phase. One subclass per store path; the base holds what they share."""
+    STG_BYTES = 16    # the widest vectorized global store, i.e. the copy atom's width
+    METHOD = None           # StoreMethod this subclass implements
+    HAS_STORE_WARP = None   # declared per path, not derived: it is a property of the store method
+    # Bytes one swizzle period covers, per atom kind (get_smem_layout_atom's own thresholds).
+    _PERIOD_BYTES = {
+        cute.nvgpu.warpgroup.SmemLayoutAtomKind.K_SW128: 128,
+        cute.nvgpu.warpgroup.SmemLayoutAtomKind.K_SW64: 64,
+        cute.nvgpu.warpgroup.SmemLayoutAtomKind.K_SW32: 32,
+        cute.nvgpu.warpgroup.SmemLayoutAtomKind.K_INTER: STG_BYTES,
+    }
+
+    def __init__(self, out_dtype, mma_threads, epi_stage=1):
+        self.out_dtype = out_dtype
+        self.mma_threads = mma_threads
+        # Buffered epilogue tiles; the store_full/store_empty barriers count the same quantity.
+        self.epi_stage = epi_stage
+
+    @property
+    def s2g_vec(self):
+        """Elements per thread per pass: the store atom's 16 B, counted in the output dtype."""
+        vec = self.STG_BYTES * 8 // self.out_dtype.width
+        assert vec >= 1 and vec & (vec - 1) == 0, (
+            f"{self.out_dtype} gives {vec} elements per {self.STG_BYTES} B store; the swizzle's M "
+            f"mode counts elements and needs a power of two")
+        return vec
+
+    def smem_layout_atom_kind(self, tile):
+        """The atom whose swizzle suits sC's contiguous extent, by the same rule the A/B path uses."""
+        return sm90_utils.get_smem_layout_atom(
+            cutlass.utils.LayoutEnum.ROW_MAJOR, self.out_dtype, self.epi_tile(tile)[1])
+
+    def epi_tile(self, tile):
+        """Epilogue subtile. Upstream stages a smaller one on the TMA (32 x bn) and staged (64 x 32)"""
+        return tile[0], tile[1]
+
+    def num_epi(self, tile):
+        epi_m, epi_n = self.epi_tile(tile)
+        return tile[0] // epi_m, tile[1] // epi_n
+
+    @property
+    @abc.abstractmethod
+    def num_store_threads(self):
+        """Threads that consume sC, i.e. that arrive on store_empty."""
+
+    def smem_bytes(self, tile):
+        epi_m, epi_n = self.epi_tile(tile)
+        return epi_m * epi_n * self.epi_stage * self.out_dtype.width // 8
+
+    def make_smem_layout(self, tile):
+        """sC's layout (call inside @cute.jit)."""
+        epi_m, epi_n = self.epi_tile(tile)
+        atom = cute.nvgpu.warpgroup.make_smem_layout_atom(
+            self.smem_layout_atom_kind(tile), self.out_dtype)
+        return cute.tile_to_shape(atom, (epi_m, epi_n, self.epi_stage), order=(0, 1, 2))
+
+    def s2g_thr_layout(self, tile):
+        """Thread layout covering exactly the threads that drain sC (call inside @cute.jit)."""
+        threads_n = self._PERIOD_BYTES[self.smem_layout_atom_kind(tile)] // self.STG_BYTES
+        threads_m, rem = divmod(self.num_store_threads, threads_n)
+        assert rem == 0, (
+            f"{type(self).__name__}: {self.num_store_threads} draining threads do not split into "
+            f"rows of {threads_n}; the S2G thread layout must cover the participating threads "
+            f"exactly, or the threads left out write past their slice of gD")
+        return cute.make_layout((threads_m, threads_n), stride=(threads_n, 1))
+
+    def make_tiled_s2g(self, atom, tile):
+        """Build the S2G TiledCopy (call inside @cute.jit)."""
+        return cute.make_tiled_copy_tv(atom, self.s2g_thr_layout(tile),
+                                       cute.make_layout((1, self.s2g_vec)))
+
+
+class R2GWgStoreConfig(StoreConfig):
+    """The whole math warpgroup drains sC to gmem itself, so there is no store warp."""
+    METHOD = StoreMethod.R2G_WG
+    HAS_STORE_WARP = False
+
+    @property
+    def num_store_threads(self):
+        return self.mma_threads
+
+
+class StagedR2GStoreConfig(StoreConfig):
+    """One dedicated store warp drains sC while the math warpgroup moves on."""
+    METHOD = StoreMethod.STAGED_R2G
+    HAS_STORE_WARP = True
+    STORE_THREADS = 32
+
+    @property
+    def num_store_threads(self):
+        return self.STORE_THREADS
+
+
+class DirectStgStoreConfig(StoreConfig):
+    """Each math thread stores its own accumulator fragment, so there is no sC and no handoff."""
+    METHOD = StoreMethod.DIRECT_STG
+    HAS_STORE_WARP = False
+
+    @property
+    def num_store_threads(self):
+        return self.mma_threads
+
+    def smem_bytes(self, tile):
+        return 0
+
+
+STORE_CONFIGS = {StoreMethod.STAGED_R2G: StagedR2GStoreConfig, StoreMethod.R2G_WG: R2GWgStoreConfig,
+                 StoreMethod.DIRECT_STG: DirectStgStoreConfig}
+
+
+class Sm120GemmBuilder:
+    """Top WS builder: composes the phase configs + derives the warp-role layout (3 warpgroups, 384 threads)."""
+    ACC = cutlass.Float32
+    I64, I32, I16, I8 = cutlass.Int64, cutlass.Int32, cutlass.Int16, cutlass.Int8
+
+    def __init__(self, mma, load_ab, load_sf, store, ab_stage, tile, epi_bar_id=2, union_smem=False):
+        self.mma, self.load_ab, self.load_sf, self.store = mma, load_ab, load_sf, store
+        # union_smem: sC views the A/B buffers, so store_empty gates the producer's refill.
+        self.union_smem = union_smem
+        assert not union_smem or store.METHOD is StoreMethod.R2G_WG, (
+            f"union_smem overlays sC on A/B, which only {StoreMethod.R2G_WG} drains itself; "
+            f"{store.METHOD} would leave store_empty without a counterpart")
+        assert not union_smem or store.smem_bytes(tile) <= load_ab.smem_bytes(), (
+            f"sC is {store.smem_bytes(tile)} B over {load_ab.smem_bytes()} B of A/B staging; past "
+            f"that it overlays whatever follows, which no size model reports")
+        self.TILE = tuple(tile)
+        self.ab_stage = ab_stage
+        self.epi_bar_id = epi_bar_id
+        num_math_warps = mma.num_math_warps
+        self.num_math_warps = num_math_warps
+        self.mma_threads = num_math_warps * 32
+        assert store.mma_threads == self.mma_threads, (
+            f"StoreConfig was built for {store.mma_threads} math threads but MmaConfig gives "
+            f"{self.mma_threads}; the S2G thread layout is derived from that count")
+        self.store_threads = store.num_store_threads
+        # producer warps right after the math warps: sched, ab, sf, then store (never two in the last slot).
+        self.sched_warp = num_math_warps
+        self.ab_warp = num_math_warps + 1
+        self.sf_warp = num_math_warps + 2
+        self.store_warp = num_math_warps + 3
+        num_producer_warps = 2 + self.load_sf.sf_load_warp + (1 if store.HAS_STORE_WARP else 0)
+        assert num_producer_warps <= 4, (
+            f"sched, ab, {self.load_sf.sf_load_warp} SF and "
+            f"{'a store' if store.HAS_STORE_WARP else 'no store'} warp need "
+            f"{num_producer_warps} producer slots, but the layout has four")
+        self.threads = (num_math_warps + num_producer_warps) * 32
+        self.epi_threads = self.mma_threads + (32 if store.HAS_STORE_WARP else 0)
+        self.reg_prod = self.REG_PROD
+        self.reg_math = self._reg_math(num_math_warps, num_producer_warps)
+        self.sched_stages = MoeSchedStages
+        self.store_stages = store.epi_stage
+        self.fields = MoeWorkTile.FIELDS
+        self.num_sched_consumers = num_math_warps + num_producer_warps - 1
+
+    # barriers and the work tile are dozens of bytes against tens of KB, so the search reserves a flat slab.
+    MBAR_RESERVE = 1024
+    MAX_AB_STAGE = 4
+
+    # setmaxregister budget: the grid is persistent, so the whole per-SM register file is this CTA's.
+    REGS_PER_SM = 65536
+    REG_GRANULARITY = 8     # setmaxregister operates in steps of 8
+    REG_MAX = 256
+    REG_PROD = 40
+
+    @classmethod
+    def _reg_math(cls, num_math_warps, num_producer_warps):
+        """Registers per math thread: whatever the producers leave, rounded down to the granularity."""
+        left = cls.REGS_PER_SM - num_producer_warps * 32 * cls.REG_PROD
+        per_thread = left // (num_math_warps * 32)
+        reg_math = min(cls.REG_MAX, per_thread - per_thread % cls.REG_GRANULARITY)
+        assert reg_math >= cls.REG_PROD, (
+            f"{num_math_warps} math and {num_producer_warps} producer warps leave {reg_math} registers "
+            f"per math thread, below the {cls.REG_PROD} the producers get")
+        return reg_math
+
+    @property
+    def smem_bytes(self):
+        """Tensor-buffer smem for this configuration. Excludes barriers (see MBAR_RESERVE)."""
+        total = self.load_ab.smem_bytes() + self.load_sf.smem_bytes(self.TILE, self.ab_stage)
+        if not self.union_smem:
+            total += self.store.smem_bytes(self.TILE)
+        return total
+
+    @classmethod
+    def max_ab_stage(cls, make_cfg, tile):
+        """Deepest A/B ring the tile affords in smem and the arm's SF ring can index."""
+        capacity = cutlass.utils.SmemAllocator.capacity_in_bytes() - cls.MBAR_RESERVE
+        for stage in range(cls.MAX_AB_STAGE, 0, -1):
+            cfg = make_cfg(tile, stage)
+            if cfg.load_sf.ab_stages_contract(stage) and cfg.smem_bytes <= capacity:
+                return stage
+        raise ValueError(f"no ab_stage fits {capacity} B of smem for tile {tile}")
+
+    def is_prod_wg(self, warp_idx):
+        return warp_idx >= self.num_math_warps

--- a/flashinfer/grouped_mm/kernels/cutedsl/sm120_moe/core/store_output.py
+++ b/flashinfer/grouped_mm/kernels/cutedsl/sm120_moe/core/store_output.py
@@ -1,0 +1,52 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+"""Epilogue store steps shared by the SM120 warp-specialized arms: convert, R2S, S2R, predicated R2G."""
+import cutlass
+import cutlass.cute as cute
+
+
+def convert_acc(acc, out_dtype):
+    """Accumulator -> output dtype, in registers."""
+    tD = cute.make_fragment_like(acc, out_dtype)
+    tD.store(acc.load().to(out_dtype))
+    return tD
+
+
+def acc_to_smem(tD, thr_mma, sC):
+    """R2S: the converted accumulator into the epilogue buffer, along the MMA's own C partition."""
+    cute.autovec_copy(tD, thr_mma.partition_C(sC))
+
+
+def smem_to_reg(thr_st, sC):
+    """S2R: the epilogue buffer back into registers, so sC is free before the gmem store drains."""
+    tDsC = thr_st.partition_S(sC)
+    tDrD = cute.make_fragment_like(tDsC)
+    cute.autovec_copy(tDsC, tDrD)
+    return tDrD
+
+
+@cute.jit
+def store_direct(thr_mma, tDrD, gD_tile, tile_mn, m_base, n_base, m_boundary, n_boundary):
+    """R2G from the MMA's C partition without smem; scalar since cute.copy wants one predicate per access."""
+    bm, bn = tile_mn
+    cD = cute.make_identity_tensor((bm, bn))
+    tDgD = thr_mma.partition_C(gD_tile)
+    tDcD = thr_mma.partition_C(cD)
+    for i in cutlass.range_constexpr(cute.size(tDrD)):
+        mi, ni = tDcD[i]
+        if m_base + mi < m_boundary and n_base + ni < n_boundary:
+            tDgD[i] = tDrD[i]
+
+
+@cute.jit
+def store_predicated(atom, thr_st, tDrD, gD_tile, tile_mn, m_base, n_base, m_boundary, n_boundary):
+    """R2G for one tile, dropping the rows and columns past the problem's edge."""
+    bm, bn = tile_mn
+    cD = cute.make_identity_tensor((bm, bn))
+    tDgD = thr_st.partition_D(gD_tile)
+    tDcD = thr_st.partition_S(cD)
+    tDpD = cute.make_fragment_like(tDcD, cutlass.Boolean)
+    for i in cutlass.range_constexpr(cute.size(tDpD)):
+        mi, ni = tDcD[i]
+        tDpD[i] = (m_base + mi) < m_boundary and (n_base + ni) < n_boundary
+    cute.copy(atom, tDrD, tDgD, pred=tDpD)

--- a/flashinfer/grouped_mm/kernels/cutedsl/sm120_moe/moe_gemm_fp8.py
+++ b/flashinfer/grouped_mm/kernels/cutedsl/sm120_moe/moe_gemm_fp8.py
@@ -1,0 +1,614 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+"""Self-written CuteDSL fp8 block-scaled (1x128x128) token-packed grouped MoE GEMM for SM120a."""
+import torch
+
+import cuda.bindings.driver as cuda
+import cutlass
+import cutlass.cute as cute
+import cutlass.cute.nvgpu.warp.mma as warp_mma
+import cutlass.utils as utils
+from cutlass.cute.nvgpu import cpasync
+from cutlass.cute.runtime import from_dlpack
+
+from .core.sm120_gemm_builder import (
+    Sm120GemmBuilder, MmaConfig, LoadABConfig, StoreMethod, STORE_CONFIGS)
+from .core.sm120_blockscaled_layout import Sm120SfConfigFp8
+from .core._common import TMA_ALIGN_BYTES
+from .core._common import ceil_div, compute_padded_offset
+from .core import scheduler, store_output
+
+
+# The arm's scale-granularity contract (DSv3 1x128x128); the op layer reads it here, not a copy.
+GRAN_M, GRAN_N, GRAN_K = 1, 128, 128
+
+ATOM_MNK = (16, 8, 32)
+
+def is_swapab(tile):
+    return ATOM_MNK[0] > tile[0] # bm == 8
+
+
+def make_cfg(tile, ab_stage, store=StoreMethod.STAGED_R2G):
+    """``tile`` in is problem space; everything the builder sees below is kernel space, never mixed."""
+    e4m3, f32, bf16 = cutlass.Float8E4M3FN, cutlass.Float32, cutlass.BFloat16
+    num_math_warps = 8
+    bm, bn, bk = tile
+    swap = is_swapab(tile)
+    if swap:
+        bm, bn = bn, bm
+        gran_m, gran_n = GRAN_N, GRAN_M
+        store = StoreMethod.DIRECT_STG
+    else:
+        # DIRECT_STG is the swapped epilogue: store_swap writes D^T and indexes with n_block
+        assert store is not StoreMethod.DIRECT_STG, (
+            f"{store} needs the swapped geometry; this tile is not swap-AB")
+        gran_m, gran_n = GRAN_M, GRAN_N
+    tile = (bm, bn, bk)
+    # the whole warpgroup drains sC itself, which is what lets sC alias sA instead of costing smem
+    union = store is StoreMethod.R2G_WG
+    return Sm120GemmBuilder(
+        MmaConfig(warp_mma.MmaFP8Op(e4m3, f32, ATOM_MNK), tile[:2], num_math_warps, swap_ab=swap),
+        LoadABConfig(tile, ab_stage, e4m3, e4m3),
+        Sm120SfConfigFp8(gran_m, gran_n, GRAN_K),
+        STORE_CONFIGS[store](bf16, num_math_warps * 32),
+        ab_stage, tile, epi_bar_id=3, union_smem=union)
+
+
+@cute.jit
+def load_ab(tma_atom_a, tma_atom_b, tma_tensor_a, tma_tensor_b, sA, sB, tile_mnk, tile,
+            ab_full, ab_empty, ab_bytes, k_tile_count, ab_stages, ab_stage, ab_phase):
+    """One tile's A/B G2S: partition A at the expert's row offset, then run the k-loop."""
+    i32 = cutlass.Int32
+    cluster = cute.make_layout((1, 1, 1))
+    multicast = cute.make_layout(cute.slice_(cluster, (0, None, 0)).shape)
+    mA = cute.domain_offset((tile.m_offset, 0), tma_tensor_a)
+    gA_mkl = cute.local_tile(mA, cute.slice_(tile_mnk, (None, 0, None)), (None, None))
+    tAsA, tAgA = cpasync.tma_partition(tma_atom_a, i32(0), multicast, cute.group_modes(sA, 0, 2),
+                                       cute.group_modes(gA_mkl, 0, 2))
+    gB_nkl = cute.local_tile(tma_tensor_b, cute.slice_(tile_mnk, (0, None, None)), (None, None, None))
+    tBsB, tBgB = cpasync.tma_partition(tma_atom_b, i32(0), multicast, cute.group_modes(sB, 0, 2),
+                                       cute.group_modes(gB_nkl, 0, 2))
+    for k_tile_idx in cutlass.range(0, k_tile_count):
+        cute.arch.mbarrier_wait(ab_empty + ab_stage, ab_phase)
+        with cute.arch.elect_one():
+            cute.arch.mbarrier_arrive_and_expect_tx(ab_full + ab_stage, ab_bytes)
+        cute.copy(tma_atom_a, tAgA[(None, tile.m_block, k_tile_idx)], tAsA[(None, ab_stage)], tma_bar_ptr=ab_full + ab_stage)
+        cute.copy(tma_atom_b, tBgB[(None, tile.n_block, k_tile_idx, tile.group)], tBsB[(None, ab_stage)], tma_bar_ptr=ab_full + ab_stage)
+        ab_stage += 1
+        if ab_stage == ab_stages:
+            ab_stage = i32(0)
+            ab_phase ^= 1
+    return ab_stage, ab_phase
+
+
+@cute.jit
+def load_ab_swap(tma_atom_a, tma_atom_b, tma_tensor_a, tma_tensor_b, sA, sB, tile_mnk, tile,
+                 ab_full, ab_empty, ab_bytes, k_tile_count, ab_stages, ab_stage, ab_phase):
+    """One tile's A/B G2S with the operands exchanged: A is the expert's weights, B the tokens."""
+    i32 = cutlass.Int32
+    cluster = cute.make_layout((1, 1, 1))
+    multicast = cute.make_layout(cute.slice_(cluster, (0, None, 0)).shape)
+    gA_mkl = cute.local_tile(tma_tensor_a, cute.slice_(tile_mnk, (None, 0, None)), (None, None, None))
+    tAsA, tAgA = cpasync.tma_partition(tma_atom_a, i32(0), multicast, cute.group_modes(sA, 0, 2),
+                                       cute.group_modes(gA_mkl, 0, 2))
+    mB = cute.domain_offset((tile.m_offset, 0), tma_tensor_b)
+    gB_nkl = cute.local_tile(mB, cute.slice_(tile_mnk, (0, None, None)), (None, None))
+    tBsB, tBgB = cpasync.tma_partition(tma_atom_b, i32(0), multicast, cute.group_modes(sB, 0, 2),
+                                       cute.group_modes(gB_nkl, 0, 2))
+    for k_tile_idx in cutlass.range(0, k_tile_count):
+        cute.arch.mbarrier_wait(ab_empty + ab_stage, ab_phase)
+        with cute.arch.elect_one():
+            cute.arch.mbarrier_arrive_and_expect_tx(ab_full + ab_stage, ab_bytes)
+        cute.copy(tma_atom_a, tAgA[(None, tile.m_block, k_tile_idx, tile.group)], tAsA[(None, ab_stage)], tma_bar_ptr=ab_full + ab_stage)
+        cute.copy(tma_atom_b, tBgB[(None, tile.n_block, k_tile_idx)], tBsB[(None, ab_stage)], tma_bar_ptr=ab_full + ab_stage)
+        ab_stage += 1
+        if ab_stage == ab_stages:
+            ab_stage = i32(0)
+            ab_phase ^= 1
+    return ab_stage, ab_phase
+
+
+@cute.jit
+def load_sf_tma(tma_atom_sfa, tma_tensor_sfa, sSFA_tma, sf_atom, gSFB, sSFB, tile,
+                sf_full, sf_empty, sfa_bytes, num_copy_threads,
+                k_tile_count, sf_stages, sf_stage, sf_phase):
+    """One tile's SF G2S with SFA on TMA and SFB on cp.async, the non-swap pairing."""
+    i32 = cutlass.Int32
+    cluster = cute.make_layout((1, 1, 1))
+    multicast = cute.make_layout(cute.slice_(cluster, (0, None, 0)).shape)
+    tscale_m, tscale_n = cute.size(sSFA_tma, mode=[0]), cute.size(sSFB, mode=[0])
+    scale_n = cute.size(gSFB, mode=[0])
+    m_align = TMA_ALIGN_BYTES // (sSFB.element_type.width // 8)
+    lane_idx = cute.arch.lane_idx()
+
+    sf_m_off = compute_padded_offset(tile.m_offset, tile.group, i32(m_align))
+    mSFA = cute.domain_offset((sf_m_off, 0, 0), tma_tensor_sfa)
+    gSFA_ml_t = cute.local_tile(mSFA, (tscale_m, 1), (None, None, None))
+    tSAs, tSAg = cpasync.tma_partition(tma_atom_sfa, i32(0), multicast, cute.group_modes(sSFA_tma, 0, 2),
+                                       cute.group_modes(gSFA_ml_t, 0, 2))
+
+    cSFB = cute.make_identity_tensor(gSFB.shape)
+    gSFB_nk = cute.local_tile(gSFB, (tscale_n,), (tile.n_block, None, tile.group))
+    coordSFB = cute.local_tile(cSFB, (tscale_n,), (tile.n_block, None, tile.group))
+    scale_copy_b = cute.make_tiled_copy_tv(sf_atom, cute.make_layout(num_copy_threads),
+                                           cute.make_layout(1))
+    thr_scale_copy_b = scale_copy_b.get_slice(lane_idx)
+    tBgSFB = thr_scale_copy_b.partition_S(gSFB_nk)
+    tBcSFB = thr_scale_copy_b.partition_S(coordSFB)
+    tBsSFB = thr_scale_copy_b.partition_D(sSFB)
+    tBpSFB = cute.make_fragment_like(tBcSFB[None, None, 0], cutlass.Boolean)
+    for i in cutlass.range_constexpr(cute.size(tBpSFB)):
+        tBpSFB[i] = lane_idx < tscale_n and tBcSFB[i][0] < scale_n
+
+    for k_tile_idx in cutlass.range(0, k_tile_count):
+        cute.arch.mbarrier_wait(sf_empty + sf_stage, sf_phase)
+        with cute.arch.elect_one():
+            cute.arch.mbarrier_arrive_and_expect_tx(sf_full + sf_stage, sfa_bytes)
+        cute.copy(tma_atom_sfa, tSAg[(None, tile.m_block, k_tile_idx, 0)], tSAs[(None, sf_stage)], tma_bar_ptr=sf_full + sf_stage)
+        cute.arch.sync_warp()
+        # a predicated-off cp.async zero-fills rather than skipping, so out-of-tile lanes must not issue
+        if lane_idx < tscale_n:
+            cute.copy(scale_copy_b, tBgSFB[None, None, k_tile_idx], tBsSFB[None, None, sf_stage], pred=tBpSFB)
+        cute.arch.cp_async_mbarrier_arrive_noinc(sf_full + sf_stage)
+        sf_stage += 1
+        if sf_stage == sf_stages:
+            sf_stage = i32(0)
+            sf_phase ^= 1
+    return sf_stage, sf_phase
+
+
+@cute.jit
+def load_sf(gSFA, sSFA, gSFB, sSFB, sf_atom, tile, sf_full, sf_empty, num_copy_threads,
+            k_tile_count, sf_stages, sf_stage, sf_phase):
+    """One tile's SF G2S with both sides on cp.async, the swap-AB pairing; tile blocks are kernel-space."""
+    i32 = cutlass.Int32
+    tscale_m, tscale_n = cute.size(sSFA, mode=[0]), cute.size(sSFB, mode=[0])
+    scale_m, scale_n = cute.size(gSFA, mode=[0]), cute.size(gSFB, mode=[0])
+    m_align = TMA_ALIGN_BYTES // (sSFB.element_type.width // 8)
+    lane_idx = cute.arch.lane_idx()
+
+    sf_m_off = compute_padded_offset(tile.m_offset, tile.group, i32(m_align))
+    mSFB = cute.domain_offset((sf_m_off, 0, 0), gSFB)
+    cSFA = cute.make_identity_tensor(gSFA.shape)
+    cSFB = cute.domain_offset((sf_m_off, 0, 0), cute.make_identity_tensor(gSFB.shape))
+
+    gSFA_mk = cute.local_tile(gSFA, (tscale_m,), (tile.m_block, None, tile.group))
+    coordSFA = cute.local_tile(cSFA, (tscale_m,), (tile.m_block, None, tile.group))
+    gSFB_nk = cute.local_tile(mSFB, (tscale_n,), (tile.n_block, None, 0))
+    coordSFB = cute.local_tile(cSFB, (tscale_n,), (tile.n_block, None, 0))
+
+    scale_copy_a = cute.make_tiled_copy_tv(sf_atom, cute.make_layout(num_copy_threads),
+                                           cute.make_layout(1))
+    scale_copy_b = cute.make_tiled_copy_tv(sf_atom, cute.make_layout(num_copy_threads),
+                                           cute.make_layout(1))
+    thr_scale_copy_a = scale_copy_a.get_slice(lane_idx)
+    thr_scale_copy_b = scale_copy_b.get_slice(lane_idx)
+    tAgSFA = thr_scale_copy_a.partition_S(gSFA_mk)
+    tAcSFA = thr_scale_copy_a.partition_S(coordSFA)
+    tAsSFA = thr_scale_copy_a.partition_D(sSFA)
+    tBgSFB = thr_scale_copy_b.partition_S(gSFB_nk)
+    tBcSFB = thr_scale_copy_b.partition_S(coordSFB)
+    tBsSFB = thr_scale_copy_b.partition_D(sSFB)
+    tApSFA = cute.make_fragment_like(tAcSFA[None, None, 0], cutlass.Boolean)
+    for i in cutlass.range_constexpr(cute.size(tApSFA)):
+        tApSFA[i] = lane_idx < tscale_m and tAcSFA[i][0] < scale_m
+    tBpSFB = cute.make_fragment_like(tBcSFB[None, None, 0], cutlass.Boolean)
+    for i in cutlass.range_constexpr(cute.size(tBpSFB)):
+        tBpSFB[i] = lane_idx < tscale_n and tBcSFB[i][0] < scale_n
+
+    for k_tile_idx in cutlass.range(0, k_tile_count):
+        cute.arch.mbarrier_wait(sf_empty + sf_stage, sf_phase)
+        # a predicated-off cp.async zero-fills rather than skipping, so out-of-tile lanes must not issue
+        if lane_idx < tscale_m:
+            cute.copy(scale_copy_a, tAgSFA[None, None, k_tile_idx], tAsSFA[None, None, sf_stage], pred=tApSFA)
+        if lane_idx < tscale_n:
+            cute.copy(scale_copy_b, tBgSFB[None, None, k_tile_idx], tBsSFB[None, None, sf_stage], pred=tBpSFB)
+        cute.arch.cp_async_mbarrier_arrive_noinc(sf_full + sf_stage)
+        sf_stage += 1
+        if sf_stage == sf_stages:
+            sf_stage = i32(0)
+            sf_phase ^= 1
+    return sf_stage, sf_phase
+
+
+@cute.jit
+def copy_scale_s2r(stage, tCsSFA, tCsSFB, tCrSFA, tCrSFB, tscale_mn):
+    """Both scales into registers, folding the broadcast side into the varying one."""
+    tscale_m, tscale_n = tscale_mn
+    cute.autovec_copy(tCsSFA[None, None, None, stage], tCrSFA)
+    cute.autovec_copy(tCsSFB[None, None, None, stage], tCrSFB)
+    if tscale_m == 1 and tscale_n == 1:
+        tCrSFA[0] = tCrSFA[0] * tCrSFB[0]
+    elif tscale_m > 1 and tscale_n == 1:
+        tCrSFA.store(tCrSFA.load() * tCrSFB.load()[0])
+    elif tscale_m == 1 and tscale_n > 1:
+        tCrSFB.store(tCrSFB.load() * tCrSFA.load()[0])
+
+
+@cute.jit
+def rescale(acc, tmp, tCrSFA, tCrSFB, tscale_mn):
+    """Fold one k-tile's plain accumulator into the scaled one and clear it."""
+    tscale_m, tscale_n = tscale_mn
+    if tscale_m == 1 and tscale_n == 1:
+        acc.store(acc.load() + tmp.load() * tCrSFA.load()[0])
+    elif tscale_m > 1 and tscale_n == 1:
+        acc.store(acc.load() + tmp.load() * tCrSFA.load())
+    elif tscale_m == 1 and tscale_n > 1:
+        acc.store(acc.load() + tmp.load() * tCrSFB.load())
+    else:
+        acc.store(acc.load() + tmp.load() * tCrSFA.load() * tCrSFB.load())
+    tmp.fill(0.0)
+
+
+@cute.jit
+def store_staged(acc, thr, sC, out_dtype, store_full, store_empty, store_phase):
+    """Hand the tile to the store warp through its own sC and go back to the math."""
+    cute.arch.mbarrier_wait(store_empty, store_phase)
+    store_output.acc_to_smem(store_output.convert_acc(acc, out_dtype), thr, sC)
+    cute.arch.mbarrier_arrive(store_full)
+    return store_phase ^ 1
+
+
+@cute.jit
+def store_wg(acc, thr, thr_st, sC, st_atom, gD, tile, tile_mn, n_boundary, out_dtype,
+             store_empty, epi_bar_id, mma_threads):
+    """The math warpgroup drains sC itself; sC aliases sA, so it is released before the gmem store."""
+    bm, bn = tile_mn
+    tD = store_output.convert_acc(acc, out_dtype)
+    cute.arch.barrier(barrier_id=epi_bar_id, number_of_threads=mma_threads)
+    store_output.acc_to_smem(tD, thr, sC)
+    cute.arch.barrier(barrier_id=epi_bar_id, number_of_threads=mma_threads)
+    tDrD = store_output.smem_to_reg(thr_st, sC)
+    cute.arch.barrier(barrier_id=epi_bar_id, number_of_threads=mma_threads)
+    cute.arch.mbarrier_arrive(store_empty)
+    gD_tile = cute.local_tile(cute.domain_offset((tile.m_offset, 0), gD), (bm, bn),
+                              (tile.m_block, tile.n_block))
+    store_output.store_predicated(st_atom, thr_st, tDrD, gD_tile, (bm, bn),
+                                  tile.m_offset + tile.m_block * bm, tile.n_block * bn,
+                                  tile.m_boundary, n_boundary)
+
+
+@cute.jit
+def store_swap(acc, thr, gD_t, tile, tile_mn, n_total, out_dtype):
+    """Straight from the MMA's C partition to gmem through D^T: axis 0 is the output channel."""
+    bm, bn = tile_mn
+    gD_tile = cute.local_tile(cute.domain_offset((0, tile.m_offset), gD_t), (bm, bn),
+                              (tile.m_block, tile.n_block))
+    store_output.store_direct(thr, store_output.convert_acc(acc, out_dtype), gD_tile, (bm, bn),
+                              tile.m_block * bm, tile.m_offset + tile.n_block * bn,
+                              n_total, tile.m_boundary)
+
+
+@cute.jit
+def mma(tiledmma, mma_cfg, sf_cfg, sA, sB, sSFA, sSFB, tile_mn, acc_dtype,
+        a_dtype, b_smem_dtype, a_is_m_major, b_is_n_major, tidx,
+        ab_full, ab_empty, sf_full, sf_empty,
+        k_tile_count, ab_stages, read_stage, ab_phase):
+    """One tile's math: a k_block-deep s2r prefetch over the scaled k-loop, accumulator out."""
+    i32 = cutlass.Int32
+    bm, bn = tile_mn
+    thr = tiledmma.get_slice(tidx)
+    tCrA = tiledmma.make_fragment_A(thr.partition_A(sA)[None, None, None, 0])
+    tCrB = tiledmma.make_fragment_B(thr.partition_B(sB)[None, None, None, 0])
+    acc = cute.make_rmem_tensor(tiledmma.partition_shape_C((bm, bn)), acc_dtype)
+    tmp = cute.make_rmem_tensor(tiledmma.partition_shape_C((bm, bn)), acc_dtype)
+    s2r_a = mma_cfg.make_s2r_a(tiledmma, a_dtype, a_is_m_major)
+    s2r_b = mma_cfg.make_s2r_b(tiledmma, b_smem_dtype, b_is_n_major)
+    thr_a, thr_b = s2r_a.get_slice(tidx), s2r_b.get_slice(tidx)
+    tCrA_v, tCrB_v = thr_a.retile(tCrA), thr_b.retile(tCrB)
+    tCsSFA, tCsSFB, tCrSFA, tCrSFB = sf_cfg.partition_scale_as_c(sSFA, sSFB, thr)
+    tscale_mn = (cute.size(sSFA, mode=[0]), cute.size(sSFB, mode=[0]))
+    tXsA, tXsB = thr_a.partition_S(sA), thr_b.partition_S(sB)
+    k_blocks = cute.size(tCrA_v, mode=[2])
+
+    acc.fill(0.0)
+    tmp.fill(0.0)
+
+    cute.arch.mbarrier_wait(sf_full + read_stage, ab_phase)
+    copy_scale_s2r(read_stage, tCsSFA, tCsSFB, tCrSFA, tCrSFB, tscale_mn)
+    cute.arch.mbarrier_arrive(sf_empty + read_stage)
+
+    cute.arch.mbarrier_wait(ab_full + read_stage, ab_phase)
+    tAsA_s = tXsA[None, None, None, read_stage]
+    tBsB_s = tXsB[None, None, None, read_stage]
+    cute.copy(s2r_a, tAsA_s[None, None, 0], tCrA_v[None, None, 0])
+    cute.copy(s2r_b, tBsB_s[None, None, 0], tCrB_v[None, None, 0])
+
+    for k_tile_idx in cutlass.range(0, k_tile_count - 1):
+        for k_block in cutlass.range_constexpr(0, k_blocks):
+            k_next = 0 if k_block + 1 == k_blocks else k_block + 1
+            if k_block != k_blocks - 1:
+                cute.copy(s2r_a, tAsA_s[None, None, k_next], tCrA_v[None, None, k_next])
+                cute.copy(s2r_b, tBsB_s[None, None, k_next], tCrB_v[None, None, k_next])
+            cute.gemm(tiledmma, tmp, tCrA[None, None, k_block], tCrB[None, None, k_block], tmp)
+            if k_block == k_blocks - 1:
+                cute.arch.mbarrier_arrive(ab_empty + read_stage)
+                read_stage += 1
+                if read_stage == ab_stages:
+                    read_stage = i32(0)
+                    ab_phase ^= 1
+                tAsA_s = tXsA[None, None, None, read_stage]
+                tBsB_s = tXsB[None, None, None, read_stage]
+                cute.arch.mbarrier_wait(ab_full + read_stage, ab_phase)
+                cute.copy(s2r_a, tAsA_s[None, None, 0], tCrA_v[None, None, 0])
+                cute.copy(s2r_b, tBsB_s[None, None, 0], tCrB_v[None, None, 0])
+                rescale(acc, tmp, tCrSFA, tCrSFB, tscale_mn)
+                cute.arch.mbarrier_wait(sf_full + read_stage, ab_phase)
+                copy_scale_s2r(read_stage, tCsSFA, tCsSFB, tCrSFA, tCrSFB, tscale_mn)
+                cute.arch.mbarrier_arrive(sf_empty + read_stage)
+
+    for k_block in cutlass.range_constexpr(0, k_blocks):
+        k_next = 0 if k_block + 1 == k_blocks else k_block + 1
+        if k_next > 0:
+            cute.copy(s2r_a, tAsA_s[None, None, k_next], tCrA_v[None, None, k_next])
+            cute.copy(s2r_b, tBsB_s[None, None, k_next], tCrB_v[None, None, k_next])
+        if k_block == k_blocks - 1:
+            cute.arch.mbarrier_arrive(ab_empty + read_stage)
+            read_stage += 1
+            if read_stage == ab_stages:
+                read_stage = i32(0)
+                ab_phase ^= 1
+        cute.gemm(tiledmma, tmp, tCrA[None, None, k_block], tCrB[None, None, k_block], tmp)
+    rescale(acc, tmp, tCrSFA, tCrSFB, tscale_mn)
+    return acc, read_stage, ab_phase
+
+
+class CutedslSm120MoeFp8Grouped:
+    def __init__(self, cfg, grid_x):
+        self.cfg = cfg
+        self.mma = cfg.mma
+        self.scale = cfg.load_sf
+        self.scale.assert_k_invariant(cfg.TILE[2])
+        self.scale.assert_mn_invariant(cfg.TILE[0], cfg.TILE[1])
+        self.sf_stages = self.scale.sf_stages(cfg.ab_stage, cfg.TILE[2])
+        assert self.sf_stages == cfg.ab_stage, (
+            f"SF ring is {self.sf_stages} deep against {cfg.ab_stage} for A/B, but the math warp "
+            f"indexes both with one stage counter")
+        self.grid_x = grid_x
+
+    @cute.jit
+    def __call__(self, gA: cute.Tensor, gB_e: cute.Tensor, gSFA_f32: cute.Tensor, gSFB_f32: cute.Tensor,
+                 gD: cute.Tensor, offsets: cute.Tensor, stream):
+        cfg = self.cfg
+        tiledmma = cfg.mma.make_tiled_mma(cfg.TILE)
+        E, N, K = cute.size(gB_e, mode=[0]), cute.size(gB_e, mode=[1]), cute.size(gB_e, mode=[2])
+        gB = cute.make_tensor(gB_e.iterator, cute.make_layout((N, K, E), stride=(K, 1, N * K)))
+        m_padded_sf = cute.size(gSFA_f32, mode=[1])
+        # every operand and every scale changes places here and nowhere else
+        if cutlass.const_expr(cfg.mma.swap_ab):
+            t_a, t_b = gB, gA
+            gSFA = cute.make_tensor(gSFB_f32.iterator, cfg.load_sf.deduce_sfa_layout(N, K, E))
+            gSFB = cute.make_tensor(gSFA_f32.iterator, cfg.load_sf.deduce_sfb_layout(m_padded_sf, K, 1))
+        else:
+            t_a, t_b = gA, gB
+            gSFA = cute.make_tensor(gSFA_f32.iterator, cfg.load_sf.deduce_sfa_layout(m_padded_sf, K, 1))
+            gSFB = cute.make_tensor(gSFB_f32.iterator, cfg.load_sf.deduce_sfb_layout(N, K, E))
+        a_layout = utils.LayoutEnum.from_tensor(t_a)
+        b_layout = utils.LayoutEnum.from_tensor(t_b)
+        assert a_layout.is_k_major_a() and b_layout.is_k_major_b(), "LoadABConfig is k-major only"
+        a_smem = cfg.load_ab.make_smem_layout_a()
+        b_smem = cfg.load_ab.make_smem_layout_b()
+        sfa_smem = cfg.load_sf.make_smem_layout_sfa(cfg.TILE[0], cfg.ab_stage)
+        sfa_tma_smem = cfg.load_sf.make_tma_smem_layout_sfa(cfg.TILE[0], cfg.ab_stage)
+        sfb_smem = cfg.load_sf.make_smem_layout_sfb(cfg.TILE[1], cfg.ab_stage)
+        epi_smem = cfg.store.make_smem_layout(cfg.TILE)
+        self.a_is_m_major = a_layout.is_m_major_a()
+        self.b_is_n_major = b_layout.is_n_major_b()
+
+        tma_atom_a, tma_tensor_a = cfg.load_ab.make_tma_atom_a(t_a, a_smem)
+        tma_atom_b, tma_tensor_b = cfg.load_ab.make_tma_atom_b(t_b, b_smem)
+        tscale_m = cfg.TILE[0] // cfg.load_sf.gran_m
+        # swapped, one M granule is one scale and a 4-byte TMA box is unrepresentable, so SFA drops to cp.async
+        if cutlass.const_expr(cfg.mma.swap_ab):
+            tma_atom_sfa, tma_tensor_sfa = None, None
+        else:
+            tma_atom_sfa, tma_tensor_sfa = cpasync.make_tiled_tma_atom(
+                cpasync.CopyBulkTensorTileG2SOp(), gSFA, cute.slice_(sfa_tma_smem, (None, None, 0)), (tscale_m, 1), num_multicast=1)
+        self.ab_bytes = cfg.load_ab.tma_bytes_ab
+        self.sfa_bytes = cute.size_in_bytes(cfg.load_sf.sf_dtype, cute.slice_(sfa_tma_smem, (None, None, 0)))
+
+        # what the store method does not use is not allocated
+        store_full_bars = cfg.store_stages if cfg.store.HAS_STORE_WARP else 0
+        store_empty_bars = 0 if cfg.store.METHOD is StoreMethod.DIRECT_STG else cfg.store_stages
+        epi_elems = cute.cosize(epi_smem) if cfg.store.METHOD is StoreMethod.STAGED_R2G else 0
+
+        @cute.struct
+        class SharedStorage:
+            ab_full: cute.struct.MemRange[cfg.I64, cfg.ab_stage]
+            ab_empty: cute.struct.MemRange[cfg.I64, cfg.ab_stage]
+            sf_full: cute.struct.MemRange[cfg.I64, cfg.ab_stage]
+            sf_empty: cute.struct.MemRange[cfg.I64, cfg.ab_stage]
+            store_full: cute.struct.MemRange[cfg.I64, store_full_bars]
+            store_empty: cute.struct.MemRange[cfg.I64, store_empty_bars]
+            sfull: cute.struct.MemRange[cfg.I64, cfg.sched_stages]
+            sempty: cute.struct.MemRange[cfg.I64, cfg.sched_stages]
+            work: cute.struct.MemRange[cfg.I32, cfg.sched_stages * cfg.fields]
+            sA: cute.struct.Align[cute.struct.MemRange[cfg.load_ab.a_dtype, cute.cosize(a_smem)], 128]
+            sB: cute.struct.Align[cute.struct.MemRange[cfg.load_ab.b_smem_dtype, cute.cosize(b_smem)], 128]
+            sSFA: cute.struct.Align[cute.struct.MemRange[cfg.load_sf.sf_dtype, cute.cosize(sfa_tma_smem)], 128]
+            sSFB: cute.struct.Align[cute.struct.MemRange[cfg.load_sf.sf_dtype, cute.cosize(sfb_smem)], 128]
+            sC: cute.struct.Align[cute.struct.MemRange[cfg.store.out_dtype, epi_elems], 128]
+
+        # keep the analytic cost model honest against the struct the kernel really allocates
+        assert cfg.smem_bytes <= SharedStorage.__sizeof__() <= cfg.smem_bytes + cfg.MBAR_RESERVE, (
+            f"smem model {cfg.smem_bytes} B vs allocated {SharedStorage.__sizeof__()} B")
+
+        self.storage = SharedStorage
+        self.kernel(tiledmma, tma_atom_a, tma_atom_b, tma_atom_sfa, tma_tensor_a, tma_tensor_b, tma_tensor_sfa,
+                    gSFA, gSFB, gD, offsets, a_smem, b_smem, sfa_smem, sfa_tma_smem, sfb_smem, epi_smem).launch(
+            grid=[self.grid_x, 1, 1], block=[cfg.threads, 1, 1], stream=stream)
+
+    @cute.kernel
+    def kernel(self, tiledmma, tma_atom_a, tma_atom_b, tma_atom_sfa, tma_tensor_a: cute.Tensor,
+               tma_tensor_b: cute.Tensor, tma_tensor_sfa, gSFA: cute.Tensor,
+               gSFB: cute.Tensor, gD: cute.Tensor,
+               offsets: cute.Tensor, a_smem, b_smem, sfa_smem, sfa_tma_smem, sfb_smem, epi_smem):
+        cfg = self.cfg
+        i32 = cutlass.Int32
+        tidx, _, _ = cute.arch.thread_idx()
+        warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx())
+        bidx, _, _ = cute.arch.block_idx()
+        swap = cfg.mma.swap_ab
+        bm, bn, bk = cfg.TILE[0], cfg.TILE[1], cfg.TILE[2]
+        # the scheduler and gD stay in problem space; only the buffers and the MMA are swapped
+        pm, pn = (bn, bm) if swap else (bm, bn)
+        M, N = cute.size(gD, mode=[0]), cute.size(gD, mode=[1])
+        K = cute.size(tma_tensor_a, mode=[1])
+        num_groups = cute.size(offsets, mode=[0]) - 1
+        num_n_blocks = ceil_div(N, pn)
+        k_tile_count = ceil_div(K, bk)
+
+        smem = cutlass.utils.SmemAllocator()
+        stg = smem.allocate(self.storage)
+        sA = stg.sA.get_tensor(a_smem.outer, swizzle=a_smem.inner)
+        sB = stg.sB.get_tensor(b_smem.outer, swizzle=b_smem.inner)
+        sSFA = stg.sSFA.get_tensor(sfa_smem)
+        if cutlass.const_expr(not cfg.mma.swap_ab):
+            sSFA_tma = cute.make_tensor(sSFA.iterator, sfa_tma_smem)
+        sSFB = stg.sSFB.get_tensor(sfb_smem)
+        if cutlass.const_expr(cfg.store.METHOD is not StoreMethod.DIRECT_STG):
+            if cutlass.const_expr(cfg.union_smem):
+                sC_stages = cute.make_tensor(
+                    cute.recast_ptr(stg.sA.data_ptr(), dtype=cfg.store.out_dtype), epi_smem)
+            else:
+                sC_stages = stg.sC.get_tensor(epi_smem.outer, swizzle=epi_smem.inner)
+            # one epilogue stage today (StoreConfig.epi_stage); the index rotates once there are more
+            sC = cute.slice_(sC_stages, (None, None, 0))
+        else:
+            gD_t = cute.make_tensor(gD.iterator, cute.make_layout((N, M), stride=(1, N)))
+        ab_full, ab_empty = stg.ab_full.data_ptr(), stg.ab_empty.data_ptr()
+        sf_full, sf_empty = stg.sf_full.data_ptr(), stg.sf_empty.data_ptr()
+        # a zero-length MemRange yields the next field's address, so an unused handle stays None
+        store_full = stg.store_full.data_ptr() if cutlass.const_expr(cfg.store.HAS_STORE_WARP) else None
+        store_empty = (stg.store_empty.data_ptr()
+                       if cutlass.const_expr(cfg.store.METHOD is not StoreMethod.DIRECT_STG) else None)
+        sfull, sempty = stg.sfull.data_ptr(), stg.sempty.data_ptr()
+        sWork = stg.work.get_tensor(cute.make_layout((cfg.sched_stages, cfg.fields)))
+
+        # the copy lanes plus SFA's own TMA arrival, which swap-AB drops by putting SFA on cp.async too
+        sf_arrivals = cfg.load_sf.NUM_SCALE_COPY_THREADS + (0 if cfg.mma.swap_ab else 1)
+        if warp_idx == 0:
+            with cute.arch.elect_one():
+                for s in cutlass.range_constexpr(cfg.ab_stage):
+                    cute.arch.mbarrier_init(ab_full + s, 1)
+                    cute.arch.mbarrier_init(ab_empty + s, cfg.mma_threads)
+                    cute.arch.mbarrier_init(sf_full + s, sf_arrivals)
+                    cute.arch.mbarrier_init(sf_empty + s, cfg.mma_threads)
+                for s in cutlass.range_constexpr(cfg.store_stages):
+                    if cutlass.const_expr(cfg.store.HAS_STORE_WARP):
+                        cute.arch.mbarrier_init(store_full + s, cfg.mma_threads)
+                    if cutlass.const_expr(cfg.store.METHOD is not StoreMethod.DIRECT_STG):
+                        cute.arch.mbarrier_init(store_empty + s, cfg.store_threads)
+                for s in cutlass.range_constexpr(cfg.sched_stages):
+                    cute.arch.mbarrier_init(sfull + s, 1)
+                    cute.arch.mbarrier_init(sempty + s, cfg.num_sched_consumers)
+        cute.arch.mbarrier_init_fence()
+        cute.arch.barrier()
+
+        sf_atom = cute.make_copy_atom(cpasync.CopyG2SOp(), cfg.load_sf.sf_dtype, num_bits_per_copy=32)
+        # built before any warp-role branch: a config method call inside one carries cfg across it
+        if cutlass.const_expr(cfg.store.METHOD is not StoreMethod.DIRECT_STG):
+            st_atom = cute.make_copy_atom(cute.nvgpu.CopyUniversalOp(), cfg.store.out_dtype)
+            tiled_st = cfg.store.make_tiled_s2g(st_atom, cfg.TILE)
+
+        if cfg.is_prod_wg(warp_idx):
+            cute.arch.setmaxregister_decrease(cfg.reg_prod)
+
+            if warp_idx == cfg.sched_warp:
+                sched = scheduler.MoeTileScheduler.create(pm, num_groups, num_n_blocks, self.grid_x, bidx, offsets)
+                prod = scheduler.MoeSchedProducer.create(cfg.sched_stages)
+                has, e, m_tile, n_tile, m_off, m_bnd = sched.get_next_block(offsets)
+                while has:
+                    # published in the kernel's own axes, so no consumer carries a swap of its own
+                    if cutlass.const_expr(swap):
+                        m_tile, n_tile = n_tile, m_tile
+                    prod.publish(sWork, sfull, sempty,
+                                 scheduler.MoeWorkTile(m_tile, n_tile, e, m_off, m_bnd, i32(1)))
+                    has, e, m_tile, n_tile, m_off, m_bnd = sched.get_next_block(offsets)
+                prod.publish_sentinel(sWork, sfull, sempty)
+
+            if warp_idx == cfg.ab_warp:
+                cons = scheduler.MoeSchedConsumer.create(cfg.sched_stages)
+                tile = cons.get_next_tile(sWork, sfull, sempty)
+                ab_stage, ab_phase, store_phase = i32(0), i32(1), i32(1)
+                while tile.valid != i32(0):
+                    # sC overlays sA, and ab_empty alone would let this warp refill it mid-epilogue
+                    if cutlass.const_expr(cfg.union_smem):
+                        cute.arch.mbarrier_wait(store_empty, store_phase)
+                        store_phase ^= 1
+                    loader = load_ab_swap if cutlass.const_expr(swap) else load_ab
+                    ab_stage, ab_phase = loader(
+                        tma_atom_a, tma_atom_b, tma_tensor_a, tma_tensor_b, sA, sB, cfg.TILE, tile,
+                        ab_full, ab_empty, self.ab_bytes, k_tile_count, cfg.ab_stage,
+                        ab_stage, ab_phase)
+                    tile = cons.get_next_tile(sWork, sfull, sempty)
+
+            if warp_idx == cfg.sf_warp:
+                cons = scheduler.MoeSchedConsumer.create(cfg.sched_stages)
+                tile = cons.get_next_tile(sWork, sfull, sempty)
+                sf_stage, sf_phase = i32(0), i32(1)
+                while tile.valid != i32(0):
+                    if cutlass.const_expr(cfg.mma.swap_ab):
+                        sf_stage, sf_phase = load_sf(
+                            gSFA, sSFA, gSFB, sSFB, sf_atom, tile, sf_full, sf_empty,
+                            cfg.load_sf.NUM_SCALE_COPY_THREADS, k_tile_count, self.sf_stages,
+                            sf_stage, sf_phase)
+                    else:
+                        sf_stage, sf_phase = load_sf_tma(
+                            tma_atom_sfa, tma_tensor_sfa, sSFA_tma, sf_atom, gSFB, sSFB, tile,
+                            sf_full, sf_empty, self.sfa_bytes, cfg.load_sf.NUM_SCALE_COPY_THREADS,
+                            k_tile_count, self.sf_stages, sf_stage, sf_phase)
+                    tile = cons.get_next_tile(sWork, sfull, sempty)
+
+            if cutlass.const_expr(cfg.store.HAS_STORE_WARP):
+                if warp_idx == cfg.store_warp:
+                    store_tid = tidx - cfg.store_warp * 32
+                    thr_st = tiled_st.get_slice(store_tid)
+                    cons = scheduler.MoeSchedConsumer.create(cfg.sched_stages)
+                    tile = cons.get_next_tile(sWork, sfull, sempty)
+                    store_cons_phase = i32(0)
+                    while tile.valid != i32(0):
+                        cute.arch.mbarrier_wait(store_full, store_cons_phase)
+                        gD_tile = cute.local_tile(cute.domain_offset((tile.m_offset, 0), gD), (bm, bn), (tile.m_block, tile.n_block))
+                        store_output.store_predicated(
+                            st_atom, thr_st, store_output.smem_to_reg(thr_st, sC), gD_tile, (bm, bn),
+                            tile.m_offset + tile.m_block * bm, tile.n_block * bn, tile.m_boundary, N)
+                        cute.arch.mbarrier_arrive(store_empty)
+                        store_cons_phase ^= 1
+                        tile = cons.get_next_tile(sWork, sfull, sempty)
+
+        else:
+            cute.arch.setmaxregister_increase(cfg.reg_math)
+            thr = tiledmma.get_slice(tidx)
+            if cutlass.const_expr(cfg.store.METHOD is StoreMethod.R2G_WG):
+                thr_st = tiled_st.get_slice(tidx)
+            cons = scheduler.MoeSchedConsumer.create(cfg.sched_stages)
+            tile = cons.get_next_tile(sWork, sfull, sempty)
+            read_stage, ab_phase, store_phase = i32(0), i32(0), i32(1)
+            while tile.valid != i32(0):
+                acc, read_stage, ab_phase = mma(
+                    tiledmma, cfg.mma, cfg.load_sf, sA, sB, sSFA, sSFB, (bm, bn),
+                    cfg.ACC, cfg.load_ab.a_dtype, cfg.load_ab.b_smem_dtype,
+                    self.a_is_m_major, self.b_is_n_major, tidx,
+                    ab_full, ab_empty, sf_full, sf_empty,
+                    k_tile_count, cfg.ab_stage, read_stage, ab_phase)
+                if cutlass.const_expr(cfg.store.METHOD is StoreMethod.DIRECT_STG):
+                    store_swap(acc, thr, gD_t, tile, (bm, bn), N, cfg.store.out_dtype)
+                elif cutlass.const_expr(cfg.store.HAS_STORE_WARP):
+                    store_phase = store_staged(acc, thr, sC, cfg.store.out_dtype,
+                                               store_full, store_empty, store_phase)
+                else:
+                    store_wg(acc, thr, thr_st, sC, st_atom, gD, tile, (bm, bn), N,
+                             cfg.store.out_dtype, store_empty, cfg.epi_bar_id, cfg.mma_threads)
+                tile = cons.get_next_tile(sWork, sfull, sempty)
+
+
+def _stream():
+    return cuda.CUstream(torch.cuda.current_stream().cuda_stream)
+
+
+def make_args(a_q, a_scale, b_q, b_scale, out, m_indptr):
+    sf = lambda t: from_dlpack(t.contiguous(), assumed_align=16).mark_layout_dynamic()
+    return (from_dlpack(a_q).mark_layout_dynamic(), from_dlpack(b_q).mark_layout_dynamic(),
+            sf(a_scale), sf(b_scale), from_dlpack(out).mark_layout_dynamic(),
+            from_dlpack(m_indptr).mark_layout_dynamic(), _stream())

--- a/flashinfer/grouped_mm/kernels/cutedsl/sm120_moe/moe_gemm_mxfp8_mxfp4.py
+++ b/flashinfer/grouped_mm/kernels/cutedsl/sm120_moe/moe_gemm_mxfp8_mxfp4.py
@@ -1,0 +1,664 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+"""Self-written CuteDSL act-MXFP8 x weight-MXFP4 token-packed grouped MoE GEMM for SM120a."""
+import torch
+
+import cuda.bindings.driver as cuda
+import cutlass
+import cutlass.cute as cute
+import cutlass.utils
+import cutlass.cute.nvgpu.warp.mma as warp_mma
+from cutlass.cute.nvgpu import cpasync
+from cutlass.cute.runtime import from_dlpack
+
+from .core.sm120_gemm_builder import (
+    Sm120GemmBuilder, MmaConfig, LoadABConfig, StoreMethod, STORE_CONFIGS)
+from .core.sm120_blockscaled_layout import Sm120SfConfigMxfp8Mxfp4
+from .core._common import SF_M_ALIGN
+from .core._common import ceil_div
+from .core import scheduler, store_output
+
+
+# The arm's SF granularity contract; the op layer reads it here rather than keeping a copy.
+GRANK_A, GRANK_B = 128, 32
+ATOM_MNK = (16, 8, 32)
+
+
+def is_swapab(tile):
+    return ATOM_MNK[0] > tile[0]  # bm == 8
+
+
+def make_cfg(tile, ab_stage, store=StoreMethod.R2G_WG, grank_a=GRANK_A):
+    """``tile`` in is problem space; everything the builder sees below is kernel space, never mixed."""
+    e4m3, fp4, f32, bf16, i8, ue8m0 = (cutlass.Float8E4M3FN, cutlass.Float4E2M1FN, cutlass.Float32,
+                                       cutlass.BFloat16, cutlass.Int8, cutlass.Float8E8M0FNU)
+    num_math_warps = 8
+    bm, bn, bk = tile
+    swap = is_swapab(tile)
+    if swap:
+        bm, bn = bn, bm
+        a_dtype, b_dtype = fp4, e4m3
+        unpack = dict(a_smem_dtype=i8, a_tma_internal=i8, a_unpack_bits=4)
+        grank_a, grank_b = GRANK_B, grank_a
+        store = StoreMethod.DIRECT_STG
+    else:
+        # DIRECT_STG is the swapped epilogue: store_swap writes D^T and indexes with n_block
+        assert store is not StoreMethod.DIRECT_STG, (
+            f"{store} needs the swapped geometry; this tile is not swap-AB")
+        a_dtype, b_dtype = e4m3, fp4
+        unpack = dict(b_smem_dtype=i8, b_tma_internal=i8, b_unpack_bits=4)
+        grank_b = GRANK_B
+    tile = (bm, bn, bk)
+    # the whole warpgroup drains sC itself, which is what lets sC alias sA instead of costing smem
+    union = store is StoreMethod.R2G_WG
+    return Sm120GemmBuilder(
+        MmaConfig(warp_mma.MmaMXF8F6F4Op(a_dtype, b_dtype, f32, ue8m0), tile[:2], num_math_warps,
+                  swap_ab=swap),
+        LoadABConfig(tile, ab_stage, a_dtype, b_dtype, **unpack),
+        Sm120SfConfigMxfp8Mxfp4(grank_a, grank_b),
+        STORE_CONFIGS[store](bf16, num_math_warps * 32),
+        ab_stage, tile, epi_bar_id=3, union_smem=union)
+
+
+@cute.jit
+def load_ab(tma_atom_a, tma_atom_b, tma_atom_sfb, tma_tensor_a, tma_tensor_b, tma_tensor_sfb,
+            sA, sB, sSFB, tile_mnk, tile, ab_full, ab_empty, ab_bytes, k_tile_count,
+            ab_stages, ab_phase):
+    """One tile's A/B/SFB G2S: partition A at the expert's row offset, then run the k-loop."""
+    i32 = cutlass.Int32
+    cluster = cute.make_layout((1, 1, 1))
+    multicast = cute.make_layout(cute.slice_(cluster, (0, None, 0)).shape)
+    mA = cute.domain_offset((tile.m_offset, 0), tma_tensor_a)
+    gA_mkl = cute.local_tile(mA, cute.slice_(tile_mnk, (None, 0, None)), (None, None))
+    tAsA, tAgA = cpasync.tma_partition(tma_atom_a, i32(0), multicast, cute.group_modes(sA, 0, 2),
+                                       cute.group_modes(gA_mkl, 0, 2))
+    gB_nkl = cute.local_tile(tma_tensor_b, cute.slice_(tile_mnk, (0, None, None)), (None, None, None))
+    tBsB, tBgB = cpasync.tma_partition(tma_atom_b, i32(0), multicast, cute.group_modes(sB, 0, 2),
+                                       cute.group_modes(gB_nkl, 0, 2))
+    gSFB_nl = cute.local_tile(tma_tensor_sfb, (tile_mnk[1], 1), (None, None, None))
+    tBsSFB, tBgSFB = cpasync.tma_partition(tma_atom_sfb, i32(0), multicast,
+                                           cute.group_modes(sSFB, 0, 2), cute.group_modes(gSFB_nl, 0, 2))
+    for kt_base in cutlass.range(0, k_tile_count, ab_stages):
+        for s in cutlass.range_constexpr(ab_stages):
+            kt = kt_base + s
+            cute.arch.mbarrier_wait(ab_empty + s, ab_phase)
+            with cute.arch.elect_one():
+                cute.arch.mbarrier_arrive_and_expect_tx(ab_full + s, ab_bytes)
+            cute.copy(tma_atom_a, tAgA[(None, tile.m_block, kt)], tAsA[(None, s)], tma_bar_ptr=ab_full + s)
+            cute.copy(tma_atom_b, tBgB[(None, tile.n_block, kt, tile.group)], tBsB[(None, s)], tma_bar_ptr=ab_full + s)
+            cute.copy(tma_atom_sfb, tBgSFB[(None, tile.n_block, kt, tile.group)], tBsSFB[(None, s)], tma_bar_ptr=ab_full + s)
+        ab_phase ^= 1
+    return ab_phase
+
+
+@cute.jit
+def load_ab_swap(tma_atom_a, tma_atom_b, tma_atom_sfa, tma_tensor_a, tma_tensor_b, tma_tensor_sfa,
+                 sA, sB, sSFA, tile_mnk, tile, ab_full, ab_empty, ab_bytes, k_tile_count,
+                 ab_stages, ab_phase):
+    """A/B/SFA G2S with the operands exchanged; the swap makes SFA the side that rides this ring."""
+    i32 = cutlass.Int32
+    cluster = cute.make_layout((1, 1, 1))
+    multicast = cute.make_layout(cute.slice_(cluster, (0, None, 0)).shape)
+    gA_mkl = cute.local_tile(tma_tensor_a, cute.slice_(tile_mnk, (None, 0, None)), (None, None, None))
+    tAsA, tAgA = cpasync.tma_partition(tma_atom_a, i32(0), multicast, cute.group_modes(sA, 0, 2),
+                                       cute.group_modes(gA_mkl, 0, 2))
+    mB = cute.domain_offset((tile.m_offset, 0), tma_tensor_b)
+    gB_nkl = cute.local_tile(mB, cute.slice_(tile_mnk, (0, None, None)), (None, None))
+    tBsB, tBgB = cpasync.tma_partition(tma_atom_b, i32(0), multicast, cute.group_modes(sB, 0, 2),
+                                       cute.group_modes(gB_nkl, 0, 2))
+    gSFA_ml = cute.local_tile(tma_tensor_sfa, (tile_mnk[0], 1), (None, None, None))
+    tAsSFA, tAgSFA = cpasync.tma_partition(tma_atom_sfa, i32(0), multicast,
+                                           cute.group_modes(sSFA, 0, 2), cute.group_modes(gSFA_ml, 0, 2))
+    for kt_base in cutlass.range(0, k_tile_count, ab_stages):
+        for s in cutlass.range_constexpr(ab_stages):
+            kt = kt_base + s
+            cute.arch.mbarrier_wait(ab_empty + s, ab_phase)
+            with cute.arch.elect_one():
+                cute.arch.mbarrier_arrive_and_expect_tx(ab_full + s, ab_bytes)
+            cute.copy(tma_atom_a, tAgA[(None, tile.n_block, kt, tile.group)], tAsA[(None, s)], tma_bar_ptr=ab_full + s)
+            cute.copy(tma_atom_b, tBgB[(None, tile.m_block, kt)], tBsB[(None, s)], tma_bar_ptr=ab_full + s)
+            cute.copy(tma_atom_sfa, tAgSFA[(None, tile.n_block, kt, tile.group)], tAsSFA[(None, s)], tma_bar_ptr=ab_full + s)
+        ab_phase ^= 1
+    return ab_phase
+
+
+@cute.jit
+def load_sf(tma_atom_sfa, tma_tensor_sfa, sSFA, tile_m, tile, sf_full, sf_empty, sfa_bytes,
+            m_align, num_sf_cycles, sf_stages, sf_phase):
+    """One tile's SFA G2S, issued in whole SF cycles."""
+    i32 = cutlass.Int32
+    cluster = cute.make_layout((1, 1, 1))
+    multicast = cute.make_layout(cute.slice_(cluster, (0, None, 0)).shape)
+    sf_m_off = (tile.m_offset + tile.group * i32(m_align - 1)) & i32(-m_align)
+    mSFA = cute.domain_offset((sf_m_off, 0, 0), tma_tensor_sfa)
+    gSFA_ml = cute.local_tile(mSFA, (tile_m, 1), (None, None, None))
+    tAsSFA, tAgSFA = cpasync.tma_partition(tma_atom_sfa, i32(0), multicast,
+                                           cute.group_modes(sSFA, 0, 2), cute.group_modes(gSFA_ml, 0, 2))
+    for sf_cycle in cutlass.range(0, num_sf_cycles):
+        for s in cutlass.range_constexpr(sf_stages):
+            cute.arch.mbarrier_wait(sf_empty + s, sf_phase)
+            with cute.arch.elect_one():
+                cute.arch.mbarrier_arrive_and_expect_tx(sf_full + s, sfa_bytes)
+            cute.copy(tma_atom_sfa, tAgSFA[(None, tile.m_block, sf_cycle * sf_stages + s, 0)],
+                      tAsSFA[(None, s)], tma_bar_ptr=sf_full + s)
+        sf_phase ^= 1
+    return sf_phase
+
+
+@cute.jit
+def load_sf_swap(tma_atom_sfb, tma_tensor_sfb, sSFB, tile_n, tile, sf_full, sf_empty, sfb_bytes,
+                 m_align, num_sf_cycles, sf_stages, sf_phase):
+    """The token-side SF, which the exchange makes the coarse one, so it is SFB that gets this warp."""
+    i32 = cutlass.Int32
+    cluster = cute.make_layout((1, 1, 1))
+    multicast = cute.make_layout(cute.slice_(cluster, (0, None, 0)).shape)
+    sf_m_off = (tile.m_offset + tile.group * i32(m_align - 1)) & i32(-m_align)
+    mSFB = cute.domain_offset((sf_m_off, 0, 0), tma_tensor_sfb)
+    gSFB_nl = cute.local_tile(mSFB, (tile_n, 1), (None, None, None))
+    tBsSFB, tBgSFB = cpasync.tma_partition(tma_atom_sfb, i32(0), multicast,
+                                           cute.group_modes(sSFB, 0, 2), cute.group_modes(gSFB_nl, 0, 2))
+    for sf_cycle in cutlass.range(0, num_sf_cycles):
+        for s in cutlass.range_constexpr(sf_stages):
+            cute.arch.mbarrier_wait(sf_empty + s, sf_phase)
+            with cute.arch.elect_one():
+                cute.arch.mbarrier_arrive_and_expect_tx(sf_full + s, sfb_bytes)
+            cute.copy(tma_atom_sfb, tBgSFB[(None, tile.m_block, sf_cycle * sf_stages + s, 0)],
+                      tBsSFB[(None, s)], tma_bar_ptr=sf_full + s)
+        sf_phase ^= 1
+    return sf_phase
+
+
+@cute.jit
+def mma(tiledmma, mma_cfg, sf_cfg, sA, sB, sSFA, sSFB, tile_mn, bk, acc_dtype,
+        a_dtype, b_smem_dtype, a_is_m_major, unpack_bits, tidx,
+        ab_full, ab_empty, sf_full, sf_empty,
+        num_sf_cycles, sf_stages, kt_per_pack_a, ab_stages, ab_phase, sf_phase,
+        union_smem, epi_bar_id, mma_threads):
+    """One tile's math: the SF cycle outside, the A/B ring masked off the position inside it."""
+    bm, bn = tile_mn
+    thr = tiledmma.get_slice(tidx)
+    tCrA = tiledmma.make_fragment_A(thr.partition_A(sA)[None, None, None, 0])
+    tCrB = tiledmma.make_fragment_B(thr.partition_B(sB)[None, None, None, 0])
+    acc = cute.make_rmem_tensor(tiledmma.partition_shape_C((bm, bn)), acc_dtype)
+    s2r_a = mma_cfg.make_s2r_a(tiledmma, a_dtype, a_is_m_major)
+    s2r_b = mma_cfg.make_s2r_b(tiledmma, b_smem_dtype, False, unpack_bits)
+    thr_a, thr_b = s2r_a.get_slice(tidx), s2r_b.get_slice(tidx)
+    tCrA_v, tCrB_v = thr_a.retile(tCrA), thr_b.retile(tCrB)
+    s2r_sfa = sf_cfg.make_s2r_sf(sf_cfg.get_layoutSFA_TV(tiledmma), (cute.size(tiledmma.permutation_mnk[0]), 1))
+    s2r_sfb = sf_cfg.make_s2r_sf(sf_cfg.get_layoutSFB_TV(tiledmma), (cute.size(tiledmma.permutation_mnk[1]), 1))
+    thr_sfa, thr_sfb = s2r_sfa.get_slice(tidx), s2r_sfb.get_slice(tidx)
+    tCrSFA = sf_cfg.partition_fragment_SFA(cute.slice_(sSFA, (None, None, 0)), thr, tidx)
+    tCrSFA_frg = sf_cfg.make_sfa_ue8m0_view(tCrSFA, bk)
+    tCrSFB = sf_cfg.partition_fragment_SFB(cute.slice_(sSFB, (None, None, 0)), thr, tidx)
+    tCrSFB_frg = sf_cfg.make_sfb_ue8m0_view(tCrSFB, bk)
+    k_blocks = cute.size(tCrA_v, mode=[2])
+
+    acc.fill(0.0)
+    for sf_cycle in cutlass.range(0, num_sf_cycles - 1):
+        for sf_stage in cutlass.range_constexpr(sf_stages):
+            cute.arch.mbarrier_wait(sf_full + sf_stage, sf_phase)
+            cute.copy(s2r_sfa, thr_sfa.partition_S(cute.slice_(sSFA, (None, None, sf_stage))),
+                      thr_sfa.retile(tCrSFA))
+            for k_in_sf in cutlass.range_constexpr(kt_per_pack_a):
+                s = (sf_stage * kt_per_pack_a + k_in_sf) & (ab_stages - 1)
+                cute.arch.mbarrier_wait(ab_full + s, ab_phase)
+                cute.copy(s2r_sfb, thr_sfb.partition_S(cute.slice_(sSFB, (None, None, s))),
+                          thr_sfb.retile(tCrSFB))
+                tAsA_s = thr_a.partition_S(sA)[None, None, None, s]
+                tBsB_s = thr_b.partition_S(sB)[None, None, None, s]
+                for k in cutlass.range_constexpr(0, k_blocks):
+                    cute.copy(s2r_a, tAsA_s[None, None, k], tCrA_v[None, None, k])
+                    cute.copy(s2r_b, tBsB_s[None, None, k], tCrB_v[None, None, k])
+                # e2m1 lands in the low nibble; MXF8F6F4 wants it mid-byte (mma_traits_sm120.hpp:210-216)
+                tCrB_i8 = cute.recast_tensor(tCrB, cutlass.Int8)
+                tCrB_i8.store(tCrB_i8.load() * cutlass.Int8(4))
+                for k_block in cutlass.range_constexpr(0, k_blocks):
+                    cute.gemm(tiledmma, acc,
+                              [tCrA[None, None, k_block], tCrSFA_frg[None, None, k_block, k_in_sf]],
+                              [tCrB[None, None, k_block], tCrSFB_frg[None, None, k_block, 0]], acc)
+                cute.arch.mbarrier_arrive(ab_empty + s)
+                if cutlass.const_expr(s == ab_stages - 1):
+                    ab_phase ^= 1
+            cute.arch.mbarrier_arrive(sf_empty + sf_stage)
+        sf_phase ^= 1
+    # unrolled so is_last_k_tile is trace-time constant (upstream kernel_impl.cuh:313-341)
+    for sf_stage in cutlass.range_constexpr(sf_stages):
+        cute.arch.mbarrier_wait(sf_full + sf_stage, sf_phase)
+        cute.copy(s2r_sfa, thr_sfa.partition_S(cute.slice_(sSFA, (None, None, sf_stage))),
+                  thr_sfa.retile(tCrSFA))
+        for k_in_sf in cutlass.range_constexpr(kt_per_pack_a):
+            s = (sf_stage * kt_per_pack_a + k_in_sf) & (ab_stages - 1)
+            cute.arch.mbarrier_wait(ab_full + s, ab_phase)
+            cute.copy(s2r_sfb, thr_sfb.partition_S(cute.slice_(sSFB, (None, None, s))),
+                      thr_sfb.retile(tCrSFB))
+            tAsA_s = thr_a.partition_S(sA)[None, None, None, s]
+            tBsB_s = thr_b.partition_S(sB)[None, None, None, s]
+            for k in cutlass.range_constexpr(0, k_blocks):
+                cute.copy(s2r_a, tAsA_s[None, None, k], tCrA_v[None, None, k])
+                cute.copy(s2r_b, tBsB_s[None, None, k], tCrB_v[None, None, k])
+            # e2m1 lands in the low nibble; MXF8F6F4 wants it mid-byte (mma_traits_sm120.hpp:210-216)
+            tCrB_i8 = cute.recast_tensor(tCrB, cutlass.Int8)
+            tCrB_i8.store(tCrB_i8.load() * cutlass.Int8(4))
+            if cutlass.const_expr(union_smem and sf_stage == sf_stages - 1
+                                  and k_in_sf == kt_per_pack_a - 1):
+                cute.arch.barrier(barrier_id=epi_bar_id, number_of_threads=mma_threads)
+            for k_block in cutlass.range_constexpr(0, k_blocks):
+                cute.gemm(tiledmma, acc,
+                          [tCrA[None, None, k_block], tCrSFA_frg[None, None, k_block, k_in_sf]],
+                          [tCrB[None, None, k_block], tCrSFB_frg[None, None, k_block, 0]], acc)
+            cute.arch.mbarrier_arrive(ab_empty + s)
+            if cutlass.const_expr(s == ab_stages - 1):
+                ab_phase ^= 1
+        cute.arch.mbarrier_arrive(sf_empty + sf_stage)
+    sf_phase ^= 1
+    return acc, ab_phase, sf_phase
+
+
+@cute.jit
+def mma_swap(tiledmma, mma_cfg, sf_cfg, sA, sB, sSFA, sSFB, tile_mn, bk, acc_dtype,
+             a_smem_dtype, b_dtype, unpack_bits, tidx,
+             ab_full, ab_empty, sf_full, sf_empty,
+             num_sf_cycles, sf_stages, kt_per_pack_b, ab_stages, ab_phase, sf_phase,
+        union_smem, epi_bar_id, mma_threads):
+    """Mirror of mma: the exchange makes SFB the coarse side, so SFB owns the outer cycle."""
+    bm, bn = tile_mn
+    thr = tiledmma.get_slice(tidx)
+    tCrA = tiledmma.make_fragment_A(thr.partition_A(sA)[None, None, None, 0])
+    tCrB = tiledmma.make_fragment_B(thr.partition_B(sB)[None, None, None, 0])
+    acc = cute.make_rmem_tensor(tiledmma.partition_shape_C((bm, bn)), acc_dtype)
+    s2r_a = mma_cfg.make_s2r_a(tiledmma, a_smem_dtype, False, unpack_bits)
+    s2r_b = mma_cfg.make_s2r_b(tiledmma, b_dtype, False)
+    thr_a, thr_b = s2r_a.get_slice(tidx), s2r_b.get_slice(tidx)
+    tCrA_v, tCrB_v = thr_a.retile(tCrA), thr_b.retile(tCrB)
+    s2r_sfa = sf_cfg.make_s2r_sf(sf_cfg.get_layoutSFA_TV(tiledmma), (cute.size(tiledmma.permutation_mnk[0]), 1))
+    s2r_sfb = sf_cfg.make_s2r_sf(sf_cfg.get_layoutSFB_TV(tiledmma), (cute.size(tiledmma.permutation_mnk[1]), 1))
+    thr_sfa, thr_sfb = s2r_sfa.get_slice(tidx), s2r_sfb.get_slice(tidx)
+    tCrSFA = sf_cfg.partition_fragment_SFA(cute.slice_(sSFA, (None, None, 0)), thr, tidx)
+    tCrSFA_frg = sf_cfg.make_sfa_ue8m0_view(tCrSFA, bk)
+    tCrSFB = sf_cfg.partition_fragment_SFB(cute.slice_(sSFB, (None, None, 0)), thr, tidx)
+    tCrSFB_frg = sf_cfg.make_sfb_ue8m0_view(tCrSFB, bk)
+    k_blocks = cute.size(tCrA_v, mode=[2])
+
+    acc.fill(0.0)
+    for sf_cycle in cutlass.range(0, num_sf_cycles - 1):
+        for sf_stage in cutlass.range_constexpr(sf_stages):
+            cute.arch.mbarrier_wait(sf_full + sf_stage, sf_phase)
+            cute.copy(s2r_sfb, thr_sfb.partition_S(cute.slice_(sSFB, (None, None, sf_stage))),
+                      thr_sfb.retile(tCrSFB))
+            for k_in_sf in cutlass.range_constexpr(kt_per_pack_b):
+                s = (sf_stage * kt_per_pack_b + k_in_sf) & (ab_stages - 1)
+                cute.arch.mbarrier_wait(ab_full + s, ab_phase)
+                cute.copy(s2r_sfa, thr_sfa.partition_S(cute.slice_(sSFA, (None, None, s))),
+                          thr_sfa.retile(tCrSFA))
+                tAsA_s = thr_a.partition_S(sA)[None, None, None, s]
+                tBsB_s = thr_b.partition_S(sB)[None, None, None, s]
+                for k in cutlass.range_constexpr(0, k_blocks):
+                    cute.copy(s2r_a, tAsA_s[None, None, k], tCrA_v[None, None, k])
+                    cute.copy(s2r_b, tBsB_s[None, None, k], tCrB_v[None, None, k])
+                # the fp4 ABI shift follows the tensor, which the swap puts on A
+                tCrA_i8 = cute.recast_tensor(tCrA, cutlass.Int8)
+                tCrA_i8.store(tCrA_i8.load() * cutlass.Int8(4))
+                for k_block in cutlass.range_constexpr(0, k_blocks):
+                    cute.gemm(tiledmma, acc,
+                              [tCrA[None, None, k_block], tCrSFA_frg[None, None, k_block, 0]],
+                              [tCrB[None, None, k_block], tCrSFB_frg[None, None, k_block, k_in_sf]], acc)
+                cute.arch.mbarrier_arrive(ab_empty + s)
+                if cutlass.const_expr(s == ab_stages - 1):
+                    ab_phase ^= 1
+            cute.arch.mbarrier_arrive(sf_empty + sf_stage)
+        sf_phase ^= 1
+    # unrolled so is_last_k_tile is trace-time constant (upstream kernel_impl.cuh:313-341)
+    for sf_stage in cutlass.range_constexpr(sf_stages):
+        cute.arch.mbarrier_wait(sf_full + sf_stage, sf_phase)
+        cute.copy(s2r_sfb, thr_sfb.partition_S(cute.slice_(sSFB, (None, None, sf_stage))),
+                  thr_sfb.retile(tCrSFB))
+        for k_in_sf in cutlass.range_constexpr(kt_per_pack_b):
+            s = (sf_stage * kt_per_pack_b + k_in_sf) & (ab_stages - 1)
+            cute.arch.mbarrier_wait(ab_full + s, ab_phase)
+            cute.copy(s2r_sfa, thr_sfa.partition_S(cute.slice_(sSFA, (None, None, s))),
+                      thr_sfa.retile(tCrSFA))
+            tAsA_s = thr_a.partition_S(sA)[None, None, None, s]
+            tBsB_s = thr_b.partition_S(sB)[None, None, None, s]
+            for k in cutlass.range_constexpr(0, k_blocks):
+                cute.copy(s2r_a, tAsA_s[None, None, k], tCrA_v[None, None, k])
+                cute.copy(s2r_b, tBsB_s[None, None, k], tCrB_v[None, None, k])
+            # the fp4 ABI shift follows the tensor, which the swap puts on A
+            tCrA_i8 = cute.recast_tensor(tCrA, cutlass.Int8)
+            tCrA_i8.store(tCrA_i8.load() * cutlass.Int8(4))
+            if cutlass.const_expr(union_smem and sf_stage == sf_stages - 1
+                                  and k_in_sf == kt_per_pack_b - 1):
+                cute.arch.barrier(barrier_id=epi_bar_id, number_of_threads=mma_threads)
+            for k_block in cutlass.range_constexpr(0, k_blocks):
+                cute.gemm(tiledmma, acc,
+                          [tCrA[None, None, k_block], tCrSFA_frg[None, None, k_block, 0]],
+                          [tCrB[None, None, k_block], tCrSFB_frg[None, None, k_block, k_in_sf]], acc)
+            cute.arch.mbarrier_arrive(ab_empty + s)
+            if cutlass.const_expr(s == ab_stages - 1):
+                ab_phase ^= 1
+        cute.arch.mbarrier_arrive(sf_empty + sf_stage)
+    sf_phase ^= 1
+    return acc, ab_phase, sf_phase
+
+
+@cute.jit
+def store_staged(acc, thr, sC, out_dtype, store_full, store_empty, store_phase):
+    """Hand the tile to the store warp through its own sC and go back to the math."""
+    cute.arch.mbarrier_wait(store_empty, store_phase)
+    store_output.acc_to_smem(store_output.convert_acc(acc, out_dtype), thr, sC)
+    cute.arch.mbarrier_arrive(store_full)
+    return store_phase ^ 1
+
+
+@cute.jit
+def store_swap(acc, thr, gD_t, tile, tile_mn, n_total, out_dtype):
+    """Straight from the MMA's C partition to gmem through D^T: axis 0 is the output channel."""
+    bm, bn = tile_mn
+    gD_tile = cute.local_tile(cute.domain_offset((0, tile.m_offset), gD_t), (bm, bn),
+                              (tile.n_block, tile.m_block))
+    store_output.store_direct(thr, store_output.convert_acc(acc, out_dtype), gD_tile, (bm, bn),
+                              tile.n_block * bm, tile.m_offset + tile.m_block * bn,
+                              n_total, tile.m_boundary)
+
+
+class CutedslSm120MoeMxfp8Mxfp4Grouped:
+    def __init__(self, cfg, grid_x):
+        self.cfg = cfg
+        self.grid_x = grid_x
+        self.mma = cfg.mma
+        self.sf = cfg.load_sf
+        bk = cfg.TILE[2]
+        swap = cfg.mma.swap_ab
+        kt_fine = self.sf.k_tiles_per_pack_a(bk) if swap else self.sf.k_tiles_per_pack_b(bk)
+        assert kt_fine == 1, (
+            f"tile-K {bk} puts {kt_fine} k-tiles in one fine-side SF pack; that side shares the A/B "
+            f"ring and needs exactly one")
+        kt_per_coarse_cycle = ((self.sf.sfb_stages(cfg.ab_stage, bk) * self.sf.k_tiles_per_pack_b(bk))
+                               if swap else
+                               (self.sf.sfa_stages(cfg.ab_stage, bk) * self.sf.k_tiles_per_pack_a(bk)))
+        assert kt_per_coarse_cycle % cfg.ab_stage == 0, (
+            f"the A/B ring of {cfg.ab_stage} does not divide the {kt_per_coarse_cycle} k-tiles of one "
+            f"coarse-SF cycle; every stage index in the k-loop is a trace-time constant that has to "
+            f"repeat with that cycle")
+        self.sched_warp = cfg.sched_warp
+        self.ab_warp = cfg.ab_warp
+        self.sf_warp = cfg.sf_warp
+
+    @cute.jit
+    def __call__(self, gA: cute.Tensor, gB_u8: cute.Tensor, gSFA_u8: cute.Tensor, gSFB_u8: cute.Tensor,
+                 gD: cute.Tensor, offsets: cute.Tensor, stream):
+        cfg = self.cfg
+        tiledmma = cfg.mma.make_tiled_mma(cfg.TILE)
+        gB_e = cute.recast_tensor(gB_u8, cutlass.Float4E2M1FN)
+        E, N, K = cute.size(gB_e, mode=[0]), cute.size(gB_e, mode=[1]), cute.size(gB_e, mode=[2])
+        gW = cute.make_tensor(gB_e.iterator, cute.make_layout((N, K, E), stride=(K, 1, N * K)))
+        M = cute.size(gA, mode=[0])
+        m_padded_sf = cute.size(gSFA_u8, mode=[1]) // 4
+        sf_dtype = cfg.load_sf.sf_dtype
+        # every operand and every scale changes places here and nowhere else
+        if cutlass.const_expr(cfg.mma.swap_ab):
+            t_a, t_b = gW, gA
+            gSFA = cute.make_tensor(cute.recast_ptr(gSFB_u8.iterator, dtype=sf_dtype),
+                                    self.sf.deduce_sfa_layout(N, K, E))
+            gSFB = cute.make_tensor(cute.recast_ptr(gSFA_u8.iterator, dtype=sf_dtype),
+                                    self.sf.deduce_sfb_layout(m_padded_sf, K, 1))
+        else:
+            t_a, t_b = gA, gW
+            gSFA = cute.make_tensor(cute.recast_ptr(gSFA_u8.iterator, dtype=sf_dtype),
+                                    self.sf.deduce_sfa_layout(m_padded_sf, K, 1))
+            gSFB = cute.make_tensor(cute.recast_ptr(gSFB_u8.iterator, dtype=sf_dtype),
+                                    self.sf.deduce_sfb_layout(N, K, E))
+        a_layout = cutlass.utils.LayoutEnum.from_tensor(t_a)
+        b_layout = cutlass.utils.LayoutEnum.from_tensor(t_b)
+        assert a_layout.is_k_major_a() and b_layout.is_k_major_b(), "LoadABConfig is k-major only"
+        a_smem = cfg.load_ab.make_smem_layout_a()
+        b_smem = cfg.load_ab.make_smem_layout_b()
+        epi_smem = cfg.store.make_smem_layout(cfg.TILE)
+        self.a_is_m_major = a_layout.is_m_major_a()
+
+        bm, bn, bk = cfg.TILE[0], cfg.TILE[1], cfg.TILE[2]
+        sfa_stages = cfg.load_sf.sfa_stages(cfg.ab_stage, bk)
+        sfb_stages = cfg.load_sf.sfb_stages(cfg.ab_stage, bk)
+        sfa_smem = cfg.load_sf.make_smem_layout_sfa(bm, sfa_stages)
+        sfb_smem = cfg.load_sf.make_smem_layout_sfb(bn, sfb_stages)
+
+        tma_atom_a, tma_tensor_a = cfg.load_ab.make_tma_atom_a(t_a, a_smem)
+        tma_atom_b, tma_tensor_b = cfg.load_ab.make_tma_atom_b(t_b, b_smem)
+        tma_atom_sfa, tma_tensor_sfa = cpasync.make_tiled_tma_atom(
+            cpasync.CopyBulkTensorTileG2SOp(), gSFA, cute.slice_(sfa_smem, (None, None, 0)), (bm, 1), num_multicast=1)
+        tma_atom_sfb, tma_tensor_sfb = cpasync.make_tiled_tma_atom(
+            cpasync.CopyBulkTensorTileG2SOp(), gSFB, cute.slice_(sfb_smem, (None, None, 0)), (bn, 1), num_multicast=1)
+
+        ring_smem = sfa_smem if cutlass.const_expr(cfg.mma.swap_ab) else sfb_smem
+        warp_smem = sfb_smem if cutlass.const_expr(cfg.mma.swap_ab) else sfa_smem
+        coarse_stages = sfb_stages if cutlass.const_expr(cfg.mma.swap_ab) else sfa_stages
+        self.ab_sfb_bytes = (cfg.load_ab.tma_bytes_ab
+                         + cute.size_in_bytes(sf_dtype, cute.slice_(ring_smem, (None, None, 0))))
+        self.sf_bytes = cute.size_in_bytes(sf_dtype, cute.slice_(warp_smem, (None, None, 0)))
+
+        # what the store method does not use is not allocated
+        store_full_bars = cfg.store_stages if cfg.store.HAS_STORE_WARP else 0
+        store_empty_bars = 0 if cfg.store.METHOD is StoreMethod.DIRECT_STG else cfg.store_stages
+        epi_elems = cute.cosize(epi_smem) if cfg.store.METHOD is StoreMethod.STAGED_R2G else 0
+
+        @cute.struct
+        class SharedStorage:
+            ab_full: cute.struct.MemRange[cfg.I64, cfg.ab_stage]
+            ab_empty: cute.struct.MemRange[cfg.I64, cfg.ab_stage]
+            sf_full: cute.struct.MemRange[cfg.I64, coarse_stages]
+            sf_empty: cute.struct.MemRange[cfg.I64, coarse_stages]
+            store_full: cute.struct.MemRange[cfg.I64, store_full_bars]
+            store_empty: cute.struct.MemRange[cfg.I64, store_empty_bars]
+            sfull: cute.struct.MemRange[cfg.I64, cfg.sched_stages]
+            sempty: cute.struct.MemRange[cfg.I64, cfg.sched_stages]
+            work: cute.struct.MemRange[cfg.I32, cfg.sched_stages * cfg.fields]
+            sA: cute.struct.Align[cute.struct.MemRange[cfg.load_ab.a_smem_dtype, cute.cosize(a_smem)], 128]
+            sB: cute.struct.Align[cute.struct.MemRange[cfg.load_ab.b_smem_dtype, cute.cosize(b_smem)], 128]
+            sSFB: cute.struct.Align[cute.struct.MemRange[cfg.load_sf.sf_dtype, cute.cosize(sfb_smem)], 128]
+            sSFA: cute.struct.Align[cute.struct.MemRange[cfg.load_sf.sf_dtype, cute.cosize(sfa_smem)], 128]
+            sC: cute.struct.Align[cute.struct.MemRange[cfg.store.out_dtype, epi_elems], 128]
+
+        # keep the analytic cost model honest against the struct the kernel really allocates
+        assert cfg.smem_bytes <= SharedStorage.__sizeof__() <= cfg.smem_bytes + cfg.MBAR_RESERVE, (
+            f"smem model {cfg.smem_bytes} B vs allocated {SharedStorage.__sizeof__()} B")
+
+        self.storage = SharedStorage
+        self.kernel(tiledmma, tma_atom_a, tma_atom_b, tma_atom_sfa, tma_atom_sfb,
+                    tma_tensor_a, tma_tensor_b, tma_tensor_sfa, tma_tensor_sfb, gD, offsets,
+                    a_smem, b_smem, sfa_smem, sfb_smem, epi_smem).launch(
+            grid=[self.grid_x, 1, 1], block=[cfg.threads, 1, 1], stream=stream)
+
+    @cute.kernel
+    def kernel(self, tiledmma, tma_atom_a, tma_atom_b, tma_atom_sfa, tma_atom_sfb,
+               tma_tensor_a: cute.Tensor, tma_tensor_b: cute.Tensor, tma_tensor_sfa: cute.Tensor,
+               tma_tensor_sfb: cute.Tensor, gD: cute.Tensor, offsets: cute.Tensor,
+               a_smem, b_smem, sfa_smem, sfb_smem, epi_smem):
+        cfg = self.cfg
+        i32 = cutlass.Int32
+        tidx, _, _ = cute.arch.thread_idx()
+        warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx())
+        bidx, _, _ = cute.arch.block_idx()
+        bm, bn, bk = cfg.TILE[0], cfg.TILE[1], cfg.TILE[2]
+        swap = cfg.mma.swap_ab
+        # the scheduler and gD stay in problem space; only the buffers and the MMA are swapped
+        pm, pn = (bn, bm) if cutlass.const_expr(swap) else (bm, bn)
+        M, N = cute.size(gD, mode=[0]), cute.size(gD, mode=[1])
+        K = cute.size(tma_tensor_b, mode=[1])
+        num_groups = cute.size(offsets, mode=[0]) - 1
+        num_n_blocks = ceil_div(N, pn)
+        # the mirror itself: no data moves, D is just read as its own transpose
+        gD_t = cute.make_tensor(gD.iterator, cute.make_layout((N, M), stride=(1, N)))
+        # the coarse SF side owns the outer cycle, and the swap is what decides which side that is
+        grank_c = self.sf.grank_b if cutlass.const_expr(swap) else self.sf.grank_a
+        kt_per_pack_c = (self.sf.k_tiles_per_pack_b(bk) if cutlass.const_expr(swap)
+                         else self.sf.k_tiles_per_pack_a(bk))
+        sf_stages_c = (self.sf.sfb_stages(cfg.ab_stage, bk) if cutlass.const_expr(swap)
+                       else self.sf.sfa_stages(cfg.ab_stage, bk))
+        # whole cycles only, so a short final one never leaves the consumer waiting
+        num_sf_cycles = ceil_div(K, grank_c * self.sf.PACK_NSF * sf_stages_c)
+        k_tile_count = num_sf_cycles * sf_stages_c * kt_per_pack_c
+
+        smem = cutlass.utils.SmemAllocator()
+        stg = smem.allocate(self.storage)
+        sA = stg.sA.get_tensor(a_smem.outer, swizzle=a_smem.inner)
+        sB = stg.sB.get_tensor(b_smem.outer, swizzle=b_smem.inner)
+        sSFB = stg.sSFB.get_tensor(sfb_smem)
+        sSFA = stg.sSFA.get_tensor(sfa_smem)
+        if cutlass.const_expr(cfg.store.METHOD is not StoreMethod.DIRECT_STG):
+            if cutlass.const_expr(cfg.union_smem):
+                sC_stages = cute.make_tensor(
+                    cute.recast_ptr(stg.sA.data_ptr(), dtype=cfg.store.out_dtype), epi_smem)
+            else:
+                sC_stages = stg.sC.get_tensor(epi_smem.outer, swizzle=epi_smem.inner)
+            # one epilogue stage today (StoreConfig.epi_stage); the index rotates once there are more
+            sC = cute.slice_(sC_stages, (None, None, 0))
+        ab_full, ab_empty = stg.ab_full.data_ptr(), stg.ab_empty.data_ptr()
+        sf_full, sf_empty = stg.sf_full.data_ptr(), stg.sf_empty.data_ptr()
+        # a zero-length MemRange yields the next field's address, so an unused handle stays None
+        store_full = stg.store_full.data_ptr() if cutlass.const_expr(cfg.store.HAS_STORE_WARP) else None
+        store_empty = (stg.store_empty.data_ptr()
+                       if cutlass.const_expr(cfg.store.METHOD is not StoreMethod.DIRECT_STG) else None)
+        sfull, sempty = stg.sfull.data_ptr(), stg.sempty.data_ptr()
+        sWork = stg.work.get_tensor(cute.make_layout((cfg.sched_stages, cfg.fields)))
+
+        if warp_idx == 0:
+            with cute.arch.elect_one():
+                for s in cutlass.range_constexpr(cfg.ab_stage):
+                    cute.arch.mbarrier_init(ab_full + s, 1)
+                    cute.arch.mbarrier_init(ab_empty + s, cfg.mma_threads)
+                for s in cutlass.range_constexpr(sf_stages_c):
+                    cute.arch.mbarrier_init(sf_full + s, 1)
+                    cute.arch.mbarrier_init(sf_empty + s, cfg.mma_threads)
+                if cutlass.const_expr(cfg.store.HAS_STORE_WARP):
+                    cute.arch.mbarrier_init(store_full, cfg.mma_threads)
+                if cutlass.const_expr(cfg.store.METHOD is not StoreMethod.DIRECT_STG):
+                    cute.arch.mbarrier_init(store_empty, cfg.store_threads)
+                for s in cutlass.range_constexpr(cfg.sched_stages):
+                    cute.arch.mbarrier_init(sfull + s, 1)
+                    cute.arch.mbarrier_init(sempty + s, cfg.num_sched_consumers)
+        cute.arch.mbarrier_init_fence()
+        cute.arch.barrier()
+
+        # built before any warp-role branch: a config method call inside one carries cfg across it
+        if cutlass.const_expr(cfg.store.METHOD is not StoreMethod.DIRECT_STG):
+            st_atom = cute.make_copy_atom(cute.nvgpu.CopyUniversalOp(), cfg.store.out_dtype)
+            tiled_st = cfg.store.make_tiled_s2g(st_atom, cfg.TILE)
+
+        if cfg.is_prod_wg(warp_idx):
+            cute.arch.setmaxregister_decrease(cfg.reg_prod)
+
+            if warp_idx == self.sched_warp:
+                sched = scheduler.MoeTileScheduler.create(pm, num_groups, num_n_blocks, self.grid_x, bidx, offsets)
+                prod = scheduler.MoeSchedProducer.create(cfg.sched_stages)
+                has, e, m_tile, n_tile, m_off, m_bnd = sched.get_next_block(offsets)
+                while has:
+                    prod.publish(sWork, sfull, sempty,
+                                 scheduler.MoeWorkTile(m_tile, n_tile, e, m_off, m_bnd, i32(1)))
+                    has, e, m_tile, n_tile, m_off, m_bnd = sched.get_next_block(offsets)
+                prod.publish_sentinel(sWork, sfull, sempty)
+
+            if warp_idx == self.ab_warp:
+                cons = scheduler.MoeSchedConsumer.create(cfg.sched_stages)
+                tile = cons.get_next_tile(sWork, sfull, sempty)
+                abphase, stphase = i32(1), i32(1)
+                while tile.valid != i32(0):
+                    # sC overlays sA, and ab_empty alone would let this warp refill it mid-epilogue
+                    if cutlass.const_expr(cfg.union_smem):
+                        cute.arch.mbarrier_wait(store_empty, stphase)
+                        stphase ^= 1
+                    if cutlass.const_expr(swap):
+                        abphase = load_ab_swap(
+                            tma_atom_a, tma_atom_b, tma_atom_sfa, tma_tensor_a, tma_tensor_b,
+                            tma_tensor_sfa, sA, sB, sSFA, cfg.TILE, tile, ab_full, ab_empty,
+                            self.ab_sfb_bytes, k_tile_count, cfg.ab_stage, abphase)
+                    else:
+                        abphase = load_ab(
+                            tma_atom_a, tma_atom_b, tma_atom_sfb, tma_tensor_a, tma_tensor_b,
+                            tma_tensor_sfb, sA, sB, sSFB, cfg.TILE, tile, ab_full, ab_empty,
+                            self.ab_sfb_bytes, k_tile_count, cfg.ab_stage, abphase)
+                    tile = cons.get_next_tile(sWork, sfull, sempty)
+
+            if warp_idx == self.sf_warp:
+                cons = scheduler.MoeSchedConsumer.create(cfg.sched_stages)
+                tile = cons.get_next_tile(sWork, sfull, sempty)
+                sfaphase = i32(1)
+                while tile.valid != i32(0):
+                    if cutlass.const_expr(swap):
+                        sfaphase = load_sf_swap(
+                            tma_atom_sfb, tma_tensor_sfb, sSFB, bn, tile, sf_full, sf_empty,
+                            self.sf_bytes, SF_M_ALIGN, num_sf_cycles, sf_stages_c, sfaphase)
+                    else:
+                        sfaphase = load_sf(
+                            tma_atom_sfa, tma_tensor_sfa, sSFA, bm, tile, sf_full, sf_empty,
+                            self.sf_bytes, SF_M_ALIGN, num_sf_cycles, sf_stages_c, sfaphase)
+                    tile = cons.get_next_tile(sWork, sfull, sempty)
+
+            if cutlass.const_expr(cfg.store.HAS_STORE_WARP):
+                if warp_idx == cfg.store_warp:
+                    thr_st = tiled_st.get_slice(tidx - cfg.store_warp * 32)
+                    cons = scheduler.MoeSchedConsumer.create(cfg.sched_stages)
+                    tile = cons.get_next_tile(sWork, sfull, sempty)
+                    stphase = i32(0)
+                    while tile.valid != i32(0):
+                        cute.arch.mbarrier_wait(store_full, stphase)
+                        stphase ^= 1
+                        gD_tile = cute.local_tile(cute.domain_offset((tile.m_offset, 0), gD), (bm, bn), (tile.m_block, tile.n_block))
+                        store_output.store_predicated(
+                            st_atom, thr_st, store_output.smem_to_reg(thr_st, sC), gD_tile, (bm, bn),
+                            tile.m_offset + tile.m_block * bm, tile.n_block * bn, tile.m_boundary, N)
+                        cute.arch.mbarrier_arrive(store_empty)
+                        tile = cons.get_next_tile(sWork, sfull, sempty)
+
+        else:
+            cute.arch.setmaxregister_increase(cfg.reg_math)
+            thr = tiledmma.get_slice(tidx)
+            if cutlass.const_expr(cfg.store.METHOD is StoreMethod.R2G_WG):
+                thr_st = tiled_st.get_slice(tidx)
+            abphase, sfaphase, stphase = i32(0), i32(0), i32(1)
+            cons = scheduler.MoeSchedConsumer.create(cfg.sched_stages)
+            tile = cons.get_next_tile(sWork, sfull, sempty)
+            while tile.valid != i32(0):
+                if cutlass.const_expr(swap):
+                    acc, abphase, sfaphase = mma_swap(
+                        tiledmma, self.mma, self.sf, sA, sB, sSFA, sSFB, (bm, bn), bk, cfg.ACC,
+                        cfg.load_ab.a_smem_dtype, cfg.load_ab.b_dtype,
+                        cfg.load_ab.a_unpack_bits, tidx, ab_full, ab_empty, sf_full, sf_empty,
+                        num_sf_cycles, sf_stages_c, kt_per_pack_c, cfg.ab_stage, abphase, sfaphase,
+                        cfg.union_smem, cfg.epi_bar_id, cfg.mma_threads)
+                else:
+                    acc, abphase, sfaphase = mma(
+                        tiledmma, self.mma, self.sf, sA, sB, sSFA, sSFB, (bm, bn), bk, cfg.ACC,
+                        cfg.load_ab.a_dtype, cfg.load_ab.b_smem_dtype, self.a_is_m_major,
+                        cfg.load_ab.b_unpack_bits, tidx, ab_full, ab_empty, sf_full, sf_empty,
+                        num_sf_cycles, sf_stages_c, kt_per_pack_c, cfg.ab_stage, abphase, sfaphase,
+                        cfg.union_smem, cfg.epi_bar_id, cfg.mma_threads)
+
+                if cutlass.const_expr(cfg.store.METHOD is StoreMethod.DIRECT_STG):
+                    store_swap(acc, thr, gD_t, tile, (bm, bn), N, cfg.store.out_dtype)
+                elif cutlass.const_expr(cfg.store.HAS_STORE_WARP):
+                    stphase = store_staged(acc, thr, sC, cfg.store.out_dtype,
+                                           store_full, store_empty, stphase)
+                else:
+                    # the last-k-tile barrier that guards sC-over-sA already ran inside mma
+                    tD = store_output.convert_acc(acc, cfg.store.out_dtype)
+                    store_output.acc_to_smem(tD, thr, sC)
+                    cute.arch.barrier(barrier_id=cfg.epi_bar_id, number_of_threads=cfg.mma_threads)
+                    tDrD = store_output.smem_to_reg(thr_st, sC)
+                    cute.arch.barrier(barrier_id=cfg.epi_bar_id, number_of_threads=cfg.mma_threads)
+                    # sC (aliasing sA) returns to the producers before the gmem store drains
+                    cute.arch.mbarrier_arrive(store_empty)
+                    gD_tile = cute.local_tile(cute.domain_offset((tile.m_offset, 0), gD), (bm, bn), (tile.m_block, tile.n_block))
+                    store_output.store_predicated(
+                        st_atom, thr_st, tDrD, gD_tile, (bm, bn),
+                        tile.m_offset + tile.m_block * bm, tile.n_block * bn, tile.m_boundary, N)
+                tile = cons.get_next_tile(sWork, sfull, sempty)
+
+
+def _stream():
+    return cuda.CUstream(torch.cuda.current_stream().cuda_stream)
+
+
+def make_args(a_q, b_q, a_scale, b_scale, out, m_indptr):
+    sf = lambda t: from_dlpack(t.contiguous(), assumed_align=16).mark_layout_dynamic()
+    return (from_dlpack(a_q).mark_layout_dynamic(), from_dlpack(b_q).mark_layout_dynamic(),
+            sf(a_scale), sf(b_scale), from_dlpack(out).mark_layout_dynamic(),
+            from_dlpack(m_indptr).mark_layout_dynamic(), _stream())

--- a/tests/grouped_mm/test_cute_sm120_fp8.py
+++ b/tests/grouped_mm/test_cute_sm120_fp8.py
@@ -127,15 +127,16 @@ def make_inputs(m_per_expert_list, n, k, is_gated=False):
     return a_fp8, b_fp8, a_scale, b_scale, m_indptr, ref
 
 
+@pytest.mark.parametrize("backend", ["cute", "cutedsl"])
 @pytest.mark.parametrize("num_experts", [4, 8])
 @pytest.mark.parametrize("rows_per_expert", [1, 8, 192, 1024])
 @pytest.mark.parametrize("n,k", [(4096, 7168), (7168, 4096)])
-def test_moe_gemm_fp8_nt_groupwise(num_experts, rows_per_expert, n, k):
+def test_moe_gemm_fp8_nt_groupwise(num_experts, rows_per_expert, n, k, backend):
     skip_if_not_sm120()
     a, b, a_scale, b_scale, m_indptr, ref = make_inputs(
         [rows_per_expert] * num_experts, n, k
     )
-    out = moe_gemm_fp8_nt_groupwise(a, b, a_scale, b_scale, m_indptr)
+    out = moe_gemm_fp8_nt_groupwise(a, b, a_scale, b_scale, m_indptr, backend=backend)
     diff = calc_diff(out.float(), ref.float())
     assert diff < CALC_DIFF_THRESHOLD, f"calc_diff={diff:.6e}"
 
@@ -184,10 +185,11 @@ def test_moe_gemm_fp8_nt_groupwise_forced_tactic(tactic, is_gated, mpe):
     ],
     ids=["uneven", "empty_expert"],
 )
-def test_moe_gemm_fp8_nt_groupwise_irregular(m_per_expert_list):
+@pytest.mark.parametrize("backend", ["cute", "cutedsl"])
+def test_moe_gemm_fp8_nt_groupwise_irregular(m_per_expert_list, backend):
     skip_if_not_sm120()
     a, b, a_scale, b_scale, m_indptr, ref = make_inputs(m_per_expert_list, 4096, 7168)
-    out = moe_gemm_fp8_nt_groupwise(a, b, a_scale, b_scale, m_indptr)
+    out = moe_gemm_fp8_nt_groupwise(a, b, a_scale, b_scale, m_indptr, backend=backend)
     diff = calc_diff(out.float(), ref.float())
     assert diff < CALC_DIFF_THRESHOLD, f"calc_diff={diff:.6e}"
 

--- a/tests/grouped_mm/test_cute_sm120_mxfp8.py
+++ b/tests/grouped_mm/test_cute_sm120_mxfp8.py
@@ -25,6 +25,7 @@ from flashinfer.deep_gemm import get_col_major_tma_aligned_packed_tensor
 from flashinfer.grouped_mm import moe_gemm_mxfp8_nt_groupwise
 from flashinfer.grouped_mm.cute_sm120_mxfp8_groupwise.core import (
     _CuteSm120Mxfp8MoeRunner,
+    _MXFP8_MOE_PLAIN_TACTICS_GRANK32,
     _MXFP8_MOE_TACTICS,
     _MXFP8_MOE_TACTICS_GRANK128,
 )
@@ -436,7 +437,7 @@ def test_moe_gemm_mxfp8_nt_groupwise_gated(
 @pytest.mark.parametrize("is_gated", [False, True])
 @pytest.mark.parametrize(
     "k_gran,tactic",
-    [(32, tactic) for tactic in _MXFP8_MOE_TACTICS]
+    [(32, tactic) for tactic in _MXFP8_MOE_PLAIN_TACTICS_GRANK32]
     + [(128, tactic) for tactic in _MXFP8_MOE_TACTICS_GRANK128],
 )
 @pytest.mark.parametrize(
@@ -447,6 +448,8 @@ def test_moe_gemm_mxfp8_nt_groupwise_gated(
 def test_moe_gemm_mxfp8_nt_groupwise_forced_tactic(
     tactic, is_gated, k_gran, expert_rows, physical_n, k
 ):
+    if is_gated and k_gran == 32 and tactic[1:] == (128, 128):
+        pytest.skip("GranK=32 gated MXFP8 does not expose (128, 128) tuned tactic")
     skip_if_not_sm120()
     torch.random.manual_seed(0)
     num_groups = 4

--- a/tests/grouped_mm/test_cutedsl_sm120_mxfp8_mxfp4.py
+++ b/tests/grouped_mm/test_cutedsl_sm120_mxfp8_mxfp4.py
@@ -1,0 +1,217 @@
+"""
+Copyright (c) 2026 by FlashInfer team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import math
+from typing import Tuple
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+from flashinfer.grouped_mm import moe_gemm_mxfp8_mxfp4_nt_groupwise
+from flashinfer.utils import is_sm120a_supported
+
+COS_SIM_THRESHOLD = 0.99
+UE8M0_PACK_NUM = 4
+SF_M_ALIGN = 4  # a scale word is 4B, so MN must be a multiple of 4 to keep the TMA stride 16B aligned
+FP4_MAX = 6.0
+FP8_E4M3_MAX = 448.0
+
+
+def skip_if_not_sm120():
+    if not is_sm120a_supported(torch.device("cuda")):
+        pytest.skip(
+            "MXFP8 x MXFP4 cutedsl moe GEMM requires SM120 (RTX PRO 6000 Blackwell)."
+        )
+
+
+def ceil_div(x: int, y: int) -> int:
+    return (x + y - 1) // y
+
+
+def align(x: int, y: int) -> int:
+    return ceil_div(x, y) * y
+
+
+def ceil_to_ue8m0(x: torch.Tensor) -> torch.Tensor:
+    bits = x.abs().float().view(torch.int32)
+    exp = ((bits >> 23) & 0xFF) + (bits & 0x7FFFFF).bool().int()
+    return (exp.clamp(1, 254) << 23).view(torch.float32)
+
+
+def pack_ue8m0_to_int32(sf: torch.Tensor) -> torch.Tensor:
+    """Pack UE8M0 fp32 scales into int32, 4 per word, little-endian along the last dim."""
+    return (sf.contiguous().view(torch.int32) >> 23).to(torch.uint8).view(torch.int32)
+
+
+def compute_padded_offset(offset: int, problem_idx: int, alignment: int) -> int:
+    return (offset + problem_idx * (alignment - 1)) // alignment * alignment
+
+
+def per_token_cast_to_mxfp8(
+    x: torch.Tensor, gran_k: int
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Per-token MXFP8 with UE8M0 scales; returns the E4M3 codes and the fp32 UE8M0 scales."""
+    m, k = x.shape
+    padded_k = align(k, gran_k)
+    xp = torch.zeros((m, padded_k), dtype=torch.float32, device=x.device)
+    xp[:, :k] = x.float()
+    blocks = xp.view(m, padded_k // gran_k, gran_k)
+    amax = blocks.abs().amax(dim=2).clamp_min(1e-4)
+    sf = ceil_to_ue8m0(amax / FP8_E4M3_MAX)
+    codes = (blocks / sf.unsqueeze(2)).to(torch.float8_e4m3fn)
+    return codes.view(m, padded_k)[:, :k].contiguous(), sf
+
+
+def pack_mxfp8_sfa(a_sf: torch.Tensor, m_indptr: torch.Tensor) -> torch.Tensor:
+    """The A-scale ABI: MN-major int32 words, each expert starting on a 4-row aligned column."""
+    m = a_sf.shape[0]
+    sf = a_sf
+    n_sf_padded = align(sf.shape[1], UE8M0_PACK_NUM)
+    if n_sf_padded != sf.shape[1]:
+        sf = F.pad(sf, (0, n_sf_padded - sf.shape[1]))
+    packed = pack_ue8m0_to_int32(sf)
+    offsets = m_indptr.tolist()
+    num_experts = len(offsets) - 1
+    m_padded = compute_padded_offset(m, num_experts, SF_M_ALIGN)
+    out = torch.zeros(
+        packed.shape[1], m_padded, dtype=torch.int32, device=a_sf.device
+    )
+    mn_major = packed.t().contiguous()
+    for e in range(num_experts):
+        start, end = offsets[e], offsets[e + 1]
+        if start < end:
+            padded = compute_padded_offset(start, e, SF_M_ALIGN)
+            out[:, padded : padded + (end - start)] = mn_major[:, start:end]
+    return out.view(torch.uint8)
+
+
+def _e2m1_code(x: torch.Tensor) -> torch.Tensor:
+    """E2M1 code: bit 3 is the sign, bits [2:0] index the magnitude grid."""
+    boundaries = torch.tensor(
+        [0.25, 0.75, 1.25, 1.75, 2.5, 3.5, 5.0], device=x.device, dtype=x.dtype
+    )
+    idx = torch.bucketize(x.abs().clamp_max(FP4_MAX), boundaries)
+    code = idx.to(torch.uint8) | (((x < 0) & (idx != 0)).to(torch.uint8) << 3)
+    return code
+
+
+def dequant_e2m1_codes(codes: torch.Tensor) -> torch.Tensor:
+    values = torch.tensor(
+        [0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0],
+        device=codes.device,
+        dtype=torch.float32,
+    )
+    idx = (codes & 0x07).to(torch.long)
+    val = values[idx]
+    return torch.where(((codes & 0x08) != 0) & (idx != 0), -val, val)
+
+
+def per_block_cast_to_mxfp4(w: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Weight MXFP4: two E2M1 nibbles per byte along K, plus one UE8M0 scale per 32 elements."""
+    gran_k = 32
+    n, k = w.shape
+    padded_k = align(k, gran_k)
+    wp = torch.zeros((n, padded_k), dtype=torch.float32, device=w.device)
+    wp[:, :k] = w.float()
+    blocks = wp.view(n, padded_k // gran_k, gran_k)
+    amax = blocks.abs().amax(dim=2).clamp_min(1e-4)
+    sf = ceil_to_ue8m0(amax / FP4_MAX)
+    codes = _e2m1_code(blocks / sf.unsqueeze(2)).view(n, padded_k)
+    pairs = codes.view(n, padded_k // 2, 2)
+    packed = (pairs[:, :, 0] & 0x0F) | ((pairs[:, :, 1] & 0x0F) << 4)
+    return packed[:, : k // 2].contiguous(), sf
+
+
+def pack_mxfp4_sfb(sf_list) -> torch.Tensor:
+    """The B-scale ABI: MN-major int32 words per expert, MN padded so the TMA stride is 16B aligned."""
+    packed = []
+    for sf in sf_list:
+        p = pack_ue8m0_to_int32(sf).t().contiguous()
+        mn = align(p.shape[1], SF_M_ALIGN)
+        packed.append(F.pad(p, (0, mn - p.shape[1])).contiguous())
+    return torch.stack(packed).view(torch.uint8)
+
+
+def dequant_mxfp4(packed: torch.Tensor, sf: torch.Tensor) -> torch.Tensor:
+    n, half_k = packed.shape
+    k = half_k * 2
+    codes = torch.zeros(n, k, dtype=torch.uint8, device=packed.device)
+    codes[:, 0::2] = packed & 0x0F
+    codes[:, 1::2] = (packed >> 4) & 0x0F
+    return (dequant_e2m1_codes(codes).view(n, k // 32, 32) * sf[:, :, None]).view(n, k)
+
+
+def build_case(expert_rows, n, k, k_gran, seed=0):
+    """Quantize both operands and return the kernel inputs alongside the dequantized reference."""
+    torch.random.manual_seed(seed)
+    num_groups = len(expert_rows)
+    offsets = [0]
+    for rows in expert_rows:
+        offsets.append(offsets[-1] + rows)
+    token_num = offsets[-1]
+    m_indptr = torch.tensor(offsets, dtype=torch.int32, device="cuda")
+
+    a = torch.randn((token_num, k), dtype=torch.bfloat16, device="cuda")
+    b = torch.randn((num_groups, n, k), dtype=torch.bfloat16, device="cuda") / math.sqrt(
+        k
+    )
+
+    a_fp8, a_sf = per_token_cast_to_mxfp8(a, gran_k=k_gran)
+    a_scale = pack_mxfp8_sfa(a_sf, m_indptr)
+    a_deq = (
+        a_fp8.float().view(token_num, k // k_gran, k_gran) * a_sf[:, :, None]
+    ).view(token_num, k)
+
+    quantized = [per_block_cast_to_mxfp4(b[i]) for i in range(num_groups)]
+    b_fp4 = torch.stack([q.view(torch.uint8) for q, _ in quantized])
+    b_scale = pack_mxfp4_sfb([sf for _, sf in quantized])
+
+    ref = torch.zeros(token_num, n, dtype=torch.bfloat16, device="cuda")
+    for i in range(num_groups):
+        start, end = offsets[i], offsets[i + 1]
+        if start < end:
+            b_deq = dequant_mxfp4(quantized[i][0].view(torch.uint8), quantized[i][1])
+            ref[start:end] = (a_deq[start:end] @ b_deq.t()).to(torch.bfloat16)
+    return a_fp8, b_fp4, a_scale, b_scale, m_indptr, ref
+
+
+def assert_close(out: torch.Tensor, ref: torch.Tensor, what: str):
+    cos_sim = F.cosine_similarity(
+        out.reshape(-1).float(), ref.reshape(-1).float(), dim=0
+    ).item()
+    assert cos_sim > COS_SIM_THRESHOLD, f"{what} cos_sim={cos_sim:.4f} < {COS_SIM_THRESHOLD}"
+
+
+@pytest.mark.parametrize("num_groups", [2, 4])
+@pytest.mark.parametrize("rows_per_group", [1, 8, 64, 128])
+@pytest.mark.parametrize("n,k", [(2048, 3584), (3584, 2048)])
+@pytest.mark.parametrize("k_gran", [32, 128])
+def test_moe_gemm_mxfp8_mxfp4_nt_groupwise(num_groups, rows_per_group, n, k, k_gran):
+    skip_if_not_sm120()
+    a, b, a_scale, b_scale, m_indptr, ref = build_case(
+        (rows_per_group,) * num_groups, n, k, k_gran
+    )
+    out = moe_gemm_mxfp8_mxfp4_nt_groupwise(
+        a,
+        b,
+        a_scale,
+        b_scale,
+        m_indptr,
+        scale_granularity_mnk=(1, 1, k_gran),
+        out_dtype=torch.bfloat16,
+    )
+    assert_close(out, ref, "moe_gemm_mxfp8_mxfp4")


### PR DESCRIPTION
Summary
- restore the MXFP8 plain grank32 128x128 tactic
- add a CuteDSL MXFP8 x MXFP4 token-packed grouped MoE GEMM backend
- add backend="cutedsl" support to FP8 grouped MoE
- align plain FP8 moe stage policy with the updated tactic set

Included commits
- 4e1bb07b fix(sm120): restore MXFP8 plain grank32 128x128 tactic
- 2ef234c7 feat(sm120): add CuteDSL MXFP8 x MXFP4 token-packed grouped MoE GEMM
- dc9e4647 feat(sm120): add backend="cutedsl" to moe_gemm_fp8_nt_groupwise
- e9c1245b [fix] align plain fp8 moe stage policy

Validation
- branch-level development validation was completed before this PR was opened
- latest 6KD release-side verification is separate and not part of this FlashInfer PR

Notes
- head branch: CarstyYou/sm120_fused_moe
- base branch: flashinfer-ai/flashinfer:main

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added CuteDSL backend support for SM120 grouped FP8 MoE GEMM.
  - Added grouped MXFP8 activation × MXFP4 weight GEMM support.
  - Added public APIs for launching and selecting these operations.
  - Added support for additional tile sizes, scale granularities, and plain-MoE configurations.
  - Improved tactic selection and fallback behavior for supported workloads.

- **Bug Fixes**
  - Expanded valid tactic handling for non-gated granularity-32 workloads.
  - Updated kernel scheduling configurations for improved execution coverage.

- **Tests**
  - Added and expanded backend coverage, including irregular workloads and MXFP8/MXFP4 validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->