### PR TITLE
fix(sm120): align MXFP8 plain tactic and FP8 moe stage policy

### DIFF
--- a/csrc/cute_sm120_mxfp8_groupwise/cute_sm120_fp8_runner.cu
+++ b/csrc/cute_sm120_mxfp8_groupwise/cute_sm120_fp8_runner.cu
@@ -476,11 +476,11 @@ void CuteSm120Fp8GemmRunner<ElementType, OutElementType, AccumElementType, Block
                                          cudaStream_t stream, float const* SFA, float const* SFB,
                                          int tactic_tile_m, int tactic_tile_n) {
   constexpr auto kGT = sm120_common::GemmType::MGroupedContiguousWithZeroPadding;
-  using KT_M32 = sm120_blockscaling::SM120BlockScalingBuilder<32, 128, 128, 2, 1, 128, 128, kGT>;
-  using KT_M64 = sm120_blockscaling::SM120BlockScalingBuilder<64, 128, 128, 2, 1, 128, 128, kGT>;
-  using KT_M128 = sm120_blockscaling::SM120BlockScalingBuilder<128, 128, 128, 2, 1, 128, 128, kGT>;
+  using KT_M32 = sm120_blockscaling::SM120BlockScalingBuilder<32, 128, 128, 4, 1, 128, 128, kGT>;
+  using KT_M64 = sm120_blockscaling::SM120BlockScalingBuilder<64, 128, 128, 4, 1, 128, 128, kGT>;
+  using KT_M128 = sm120_blockscaling::SM120BlockScalingBuilder<128, 128, 128, 3, 1, 128, 128, kGT>;
   using KT_SWAPAB =
-      sm120_blockscaling::SM120BlockScalingBuilder<128, 8, 128, 2, 128, 1, 128, kGT, true>;
+      sm120_blockscaling::SM120BlockScalingBuilder<128, 8, 128, 4, 128, 1, 128, kGT, true>;
 
   auto ptr_A = reinterpret_cast<typename KT_M64::ElementA const*>(A);
   auto ptr_B = reinterpret_cast<typename KT_M64::ElementB const*>(B);

--- a/csrc/cute_sm120_mxfp8_groupwise/cute_sm120_fp8_runner.cu
+++ b/csrc/cute_sm120_mxfp8_groupwise/cute_sm120_fp8_runner.cu
@@ -431,11 +431,14 @@ void CuteSm120Fp8GemmRunner<ElementType, OutElementType, AccumElementType, Block
                                    int shape_n, int shape_k, cudaStream_t stream, float const* SFA,
                                    float const* SFB) {
   constexpr auto kGT = sm120_common::GemmType::MGroupedContiguousWithZeroPadding;
-  using KT_M32 = sm120_blockscaling::SM120BlockScalingBuilder<32, 128, 128, 2, 1, 128, 128, kGT>;
-  using KT_M64 = sm120_blockscaling::SM120BlockScalingBuilder<64, 128, 128, 2, 1, 128, 128, kGT>;
-  using KT_M128 = sm120_blockscaling::SM120BlockScalingBuilder<128, 128, 128, 2, 1, 128, 128, kGT>;
+  using KT_M32 =
+      sm120_blockscaling::SM120BlockScalingBuilder<32, 128, 128, 4, 1, 128, 128, kGT, false>;
+  using KT_M64 =
+      sm120_blockscaling::SM120BlockScalingBuilder<64, 128, 128, 4, 1, 128, 128, kGT, false>;
+  using KT_M128 =
+      sm120_blockscaling::SM120BlockScalingBuilder<128, 128, 128, 3, 1, 128, 128, kGT, false>;
   using KT_SWAPAB_N8 =
-      sm120_blockscaling::SM120BlockScalingBuilder<128, 8, 128, 2, 128, 1, 128, kGT, true>;
+      sm120_blockscaling::SM120BlockScalingBuilder<128, 8, 128, 4, 128, 1, 128, kGT, true>;
 
   auto ptr_A = reinterpret_cast<typename KT_M128::ElementA const*>(A);
   auto ptr_B = reinterpret_cast<typename KT_M128::ElementB const*>(B);

--- a/csrc/cute_sm120_mxfp8_groupwise/cute_sm120_mxfp8_runner.cu
+++ b/csrc/cute_sm120_mxfp8_groupwise/cute_sm120_mxfp8_runner.cu
@@ -325,8 +325,8 @@ void CuteSm120Mxfp8GemmRunner<ElementType, OutElementType, AccumElementType,
                       (tactic_tile_m == 128 && tactic_tile_n == 128);
   TVM_FFI_ICHECK(valid_tactic) << "unsupported MXFP8 MoE tactic (TileM, TileN)=(" << tactic_tile_m
                                << ", " << tactic_tile_n << ")";
-  TVM_FFI_ICHECK(tactic_tile_m != 128 || tactic_tile_n != 128 || granK == 128)
-      << "unsupported MXFP8 GranK=32 MoE tactic (TileM, TileN)=(128, 128)";
+  TVM_FFI_ICHECK(tactic_tile_m != 128 || tactic_tile_n != 128 || !is_gated || granK == 128)
+      << "unsupported gated MXFP8 GranK=32 MoE tactic (TileM, TileN)=(128, 128)";
   DISPATCH_GRAN_K(granK, GRAN_K, {
     if (is_gated) {
       fused_moe_mxfp8_nt_groupwise_tuned_impl<GRAN_K>(D, A, B, token_offset, num_experts,
@@ -415,6 +415,7 @@ void CuteSm120Mxfp8GemmRunner<ElementType, OutElementType, AccumElementType,
   using KT_M64_N128 =
       sm120_blockscaled::SM120BlockScaledBuilder<64, 128, kTileK_M64, 4, GranK, kGT>;
   using KT_M128_N64 = sm120_blockscaled::SM120BlockScaledBuilder<128, 64, 64, 4, GranK, kGT>;
+  using KT_M128_N128 = sm120_blockscaled::SM120BlockScaledBuilder<128, 128, 64, 4, GranK, kGT>;
   using KT_M32_N128 = sm120_blockscaled::SM120BlockScaledBuilder<32, 128, 128, 4, GranK, kGT>;
   using KT_SWAPAB_N8 = sm120_blockscaled::SM120BlockScaledBuilder<128, 8, 128, 4, GranK, kGT, true>;
 
@@ -447,8 +448,7 @@ void CuteSm120Mxfp8GemmRunner<ElementType, OutElementType, AccumElementType,
     sm120_blockscaled::launch_moe_gemm<KT_M128_N64>(ptr_A, ptr_B, ptr_SFA, ptr_SFB, ptr_D,
                                                     total_rows, shape_n, shape_k, num_experts,
                                                     token_offset, num_sms, stream);
-  } else if constexpr (GranK == 128) {
-    using KT_M128_N128 = sm120_blockscaled::SM120BlockScaledBuilder<128, 128, 64, 4, GranK, kGT>;
+  } else {
     sm120_blockscaled::launch_moe_gemm<KT_M128_N128>(ptr_A, ptr_B, ptr_SFA, ptr_SFB, ptr_D,
                                                      total_rows, shape_n, shape_k, num_experts,
                                                      token_offset, num_sms, stream);

--- a/csrc/cute_sm120_mxfp8_groupwise/cute_sm120_mxfp8_runner.cu
+++ b/csrc/cute_sm120_mxfp8_groupwise/cute_sm120_mxfp8_runner.cu
@@ -317,16 +317,20 @@ void CuteSm120Mxfp8GemmRunner<ElementType, OutElementType, AccumElementType,
                                       int shape_n, int shape_k, cudaStream_t stream,
                                       int32_t const* SFA, int32_t const* SFB, int granK,
                                       int tactic_tile_m, int tactic_tile_n, bool is_gated) {
-  bool valid_tactic = (tactic_tile_m == 32 && tactic_tile_n == 128) ||
-                      (tactic_tile_m == 64 && tactic_tile_n == 64) ||
-                      (tactic_tile_m == 64 && tactic_tile_n == 128) ||
-                      (tactic_tile_m == 128 && tactic_tile_n == 8) ||
-                      (tactic_tile_m == 128 && tactic_tile_n == 64) ||
-                      (tactic_tile_m == 128 && tactic_tile_n == 128);
-  TVM_FFI_ICHECK(valid_tactic) << "unsupported MXFP8 MoE tactic (TileM, TileN)=(" << tactic_tile_m
-                               << ", " << tactic_tile_n << ")";
-  TVM_FFI_ICHECK(tactic_tile_m != 128 || tactic_tile_n != 128 || !is_gated || granK == 128)
-      << "unsupported gated MXFP8 GranK=32 MoE tactic (TileM, TileN)=(128, 128)";
+  bool valid_plain = (tactic_tile_m == 32 && tactic_tile_n == 128) ||
+                     (tactic_tile_m == 64 && tactic_tile_n == 64) ||
+                     (tactic_tile_m == 64 && tactic_tile_n == 128) ||
+                     (tactic_tile_m == 128 && tactic_tile_n == 128) ||
+                     (tactic_tile_m == 128 && tactic_tile_n == 8);
+  bool valid_gated = (tactic_tile_m == 32 && tactic_tile_n == 128) ||
+                     (tactic_tile_m == 64 && tactic_tile_n == 64) ||
+                     (tactic_tile_m == 64 && tactic_tile_n == 128) ||
+                     (tactic_tile_m == 128 && tactic_tile_n == 64) ||
+                     (tactic_tile_m == 128 && tactic_tile_n == 8) ||
+                     (granK == 128 && tactic_tile_m == 128 && tactic_tile_n == 128);
+  TVM_FFI_ICHECK(is_gated ? valid_gated : valid_plain)
+      << "unsupported MXFP8 MoE tactic (TileM, TileN)=(" << tactic_tile_m << ", " << tactic_tile_n
+      << ")";
   DISPATCH_GRAN_K(granK, GRAN_K, {
     if (is_gated) {
       fused_moe_mxfp8_nt_groupwise_tuned_impl<GRAN_K>(D, A, B, token_offset, num_experts,
@@ -414,18 +418,17 @@ void CuteSm120Mxfp8GemmRunner<ElementType, OutElementType, AccumElementType,
   using KT_M64_N64 = sm120_blockscaled::SM120BlockScaledBuilder<64, 64, kTileK_M64, 4, GranK, kGT>;
   using KT_M64_N128 =
       sm120_blockscaled::SM120BlockScaledBuilder<64, 128, kTileK_M64, 4, GranK, kGT>;
-  using KT_M128_N64 = sm120_blockscaled::SM120BlockScaledBuilder<128, 64, 64, 4, GranK, kGT>;
   using KT_M128_N128 = sm120_blockscaled::SM120BlockScaledBuilder<128, 128, 64, 4, GranK, kGT>;
   using KT_M32_N128 = sm120_blockscaled::SM120BlockScaledBuilder<32, 128, 128, 4, GranK, kGT>;
   using KT_SWAPAB_N8 = sm120_blockscaled::SM120BlockScaledBuilder<128, 8, 128, 4, GranK, kGT, true>;
 
-  auto ptr_A = reinterpret_cast<typename KT_M128_N64::ElementA*>(const_cast<void*>(A));
-  auto ptr_B = reinterpret_cast<typename KT_M128_N64::ElementB*>(const_cast<void*>(B));
+  auto ptr_A = reinterpret_cast<typename KT_M128_N128::ElementA*>(const_cast<void*>(A));
+  auto ptr_B = reinterpret_cast<typename KT_M128_N128::ElementB*>(const_cast<void*>(B));
   auto ptr_SFA =
-      reinterpret_cast<typename KT_M128_N64::SFConfig::ElementSFLoad*>(const_cast<int32_t*>(SFA));
+      reinterpret_cast<typename KT_M128_N128::SFConfig::ElementSFLoad*>(const_cast<int32_t*>(SFA));
   auto ptr_SFB =
-      reinterpret_cast<typename KT_M128_N64::SFConfig::ElementSFLoad*>(const_cast<int32_t*>(SFB));
-  auto ptr_D = reinterpret_cast<typename KT_M128_N64::ElementD*>(D);
+      reinterpret_cast<typename KT_M128_N128::SFConfig::ElementSFLoad*>(const_cast<int32_t*>(SFB));
+  auto ptr_D = reinterpret_cast<typename KT_M128_N128::ElementD*>(D);
   int num_sms = sm120_blockscaled::get_num_sms();
 
   if (tactic_tile_m == 128 && tactic_tile_n == 8) {
@@ -442,10 +445,6 @@ void CuteSm120Mxfp8GemmRunner<ElementType, OutElementType, AccumElementType,
                                                    token_offset, num_sms, stream);
   } else if (tactic_tile_m == 64) {
     sm120_blockscaled::launch_moe_gemm<KT_M64_N128>(ptr_A, ptr_B, ptr_SFA, ptr_SFB, ptr_D,
-                                                    total_rows, shape_n, shape_k, num_experts,
-                                                    token_offset, num_sms, stream);
-  } else if (tactic_tile_n == 64) {
-    sm120_blockscaled::launch_moe_gemm<KT_M128_N64>(ptr_A, ptr_B, ptr_SFA, ptr_SFB, ptr_D,
                                                     total_rows, shape_n, shape_k, num_experts,
                                                     token_offset, num_sms, stream);
   } else {

--- a/csrc/cute_sm120_mxfp8_groupwise/sm120_blockscaling/builder.cuh
+++ b/csrc/cute_sm120_mxfp8_groupwise/sm120_blockscaling/builder.cuh
@@ -75,7 +75,8 @@ struct SM120BlockScalingMMAConfig {
 
 template <int TileM_ = 128, int TileN_ = 128, int TileK_ = 128, int Stages_ = 4,
           int ScaleGranularityM_ = 1, int ScaleGranularityN_ = 128, int ScaleGranularityK_ = 128,
-          sm120_common::GemmType GemmType_ = sm120_common::GemmType::Normal, bool SwapAB_ = false>
+          sm120_common::GemmType GemmType_ = sm120_common::GemmType::Normal,
+          bool SwapAB_ = false>
 struct SM120BlockScalingBuilder {
   using ElementA = cute::float_e4m3_t;
   using ElementB = cute::float_e4m3_t;
@@ -90,9 +91,7 @@ struct SM120BlockScalingBuilder {
                                        GemmType_ == sm120_common::GemmType::MGroupedMasked);
   static constexpr bool kUseTmaStore =
       sm120_common::utils::EnableTmaStore<kFlat, kSwapAB, TileN_, kPerBatchAB>();
-  static constexpr bool kUseStagedR2G =
-      GemmType_ == sm120_common::GemmType::MGroupedContiguousWithZeroPadding && !SwapAB_ &&
-      TileM_ >= 64;
+  static constexpr bool kUseStagedR2G = false;
   static constexpr bool kUnionSmem = !kUseTmaStore && !kUseStagedR2G;
   static constexpr int AB_Stages = Stages_;
   static constexpr uint32_t LoadRegisterRequirement = kUseStagedR2G ? 88 : 40;

--- a/csrc/cute_sm120_mxfp8_groupwise/sm120_blockscaling/builder.cuh
+++ b/csrc/cute_sm120_mxfp8_groupwise/sm120_blockscaling/builder.cuh
@@ -75,8 +75,7 @@ struct SM120BlockScalingMMAConfig {
 
 template <int TileM_ = 128, int TileN_ = 128, int TileK_ = 128, int Stages_ = 4,
           int ScaleGranularityM_ = 1, int ScaleGranularityN_ = 128, int ScaleGranularityK_ = 128,
-          sm120_common::GemmType GemmType_ = sm120_common::GemmType::Normal,
-          bool SwapAB_ = false>
+          sm120_common::GemmType GemmType_ = sm120_common::GemmType::Normal, bool SwapAB_ = false>
 struct SM120BlockScalingBuilder {
   using ElementA = cute::float_e4m3_t;
   using ElementB = cute::float_e4m3_t;

--- a/flashinfer/grouped_mm/cute_sm120_fp8_groupwise/core.py
+++ b/flashinfer/grouped_mm/cute_sm120_fp8_groupwise/core.py
@@ -35,7 +35,7 @@ from .._sm120_moe_autotune import (
 from ..cute_sm120_mxfp8_groupwise import _check_m_indptr
 
 
-_FP8_MOE_TACTIC_SCHEMA_VERSION = 3
+_FP8_MOE_TACTIC_SCHEMA_VERSION = 4
 _FP8_MOE_PLAIN_TACTICS = (
     (_FP8_MOE_TACTIC_SCHEMA_VERSION, 32, 128),
     (_FP8_MOE_TACTIC_SCHEMA_VERSION, 64, 128),

--- a/flashinfer/grouped_mm/cute_sm120_mxfp8_groupwise/core.py
+++ b/flashinfer/grouped_mm/cute_sm120_mxfp8_groupwise/core.py
@@ -29,18 +29,20 @@ from ...utils import supported_compute_capability
 from .._sm120_moe_autotune import SM120_MOE_TUNING_CONFIG, Sm120MoeTunableRunner
 
 
-_MXFP8_MOE_TACTIC_SCHEMA_VERSION = 2
-_MXFP8_MOE_TACTICS = (
+_MXFP8_MOE_TACTIC_SCHEMA_VERSION = 3
+_MXFP8_MOE_COMMON_TACTICS = (
     (_MXFP8_MOE_TACTIC_SCHEMA_VERSION, 32, 128),
     (_MXFP8_MOE_TACTIC_SCHEMA_VERSION, 64, 64),
     (_MXFP8_MOE_TACTIC_SCHEMA_VERSION, 64, 128),
-    (_MXFP8_MOE_TACTIC_SCHEMA_VERSION, 128, 64),
     (_MXFP8_MOE_TACTIC_SCHEMA_VERSION, 128, 8),
 )
-_MXFP8_MOE_PLAIN_TACTICS_GRANK32 = _MXFP8_MOE_TACTICS + (
+_MXFP8_MOE_PLAIN_TACTICS = _MXFP8_MOE_COMMON_TACTICS + (
     (_MXFP8_MOE_TACTIC_SCHEMA_VERSION, 128, 128),
 )
-_MXFP8_MOE_TACTICS_GRANK128 = _MXFP8_MOE_TACTICS + (
+_MXFP8_MOE_GATED_TACTICS = _MXFP8_MOE_COMMON_TACTICS + (
+    (_MXFP8_MOE_TACTIC_SCHEMA_VERSION, 128, 64),
+)
+_MXFP8_MOE_GATED_TACTICS_GRANK128 = _MXFP8_MOE_GATED_TACTICS + (
     (_MXFP8_MOE_TACTIC_SCHEMA_VERSION, 128, 128),
 )
 
@@ -119,16 +121,12 @@ class _CuteSm120Mxfp8MoeRunner(Sm120MoeTunableRunner):
     ) -> None:
         if is_gated:
             tactics = (
-                _MXFP8_MOE_TACTICS_GRANK128
+                _MXFP8_MOE_GATED_TACTICS_GRANK128
                 if scale_granularity_mnk[2] == 128
-                else _MXFP8_MOE_TACTICS
+                else _MXFP8_MOE_GATED_TACTICS
             )
         else:
-            tactics = (
-                _MXFP8_MOE_TACTICS_GRANK128
-                if scale_granularity_mnk[2] == 128
-                else _MXFP8_MOE_PLAIN_TACTICS_GRANK32
-            )
+            tactics = _MXFP8_MOE_PLAIN_TACTICS
         super().__init__(
             out,
             is_gated,

--- a/flashinfer/grouped_mm/cute_sm120_mxfp8_groupwise/core.py
+++ b/flashinfer/grouped_mm/cute_sm120_mxfp8_groupwise/core.py
@@ -37,6 +37,9 @@ _MXFP8_MOE_TACTICS = (
     (_MXFP8_MOE_TACTIC_SCHEMA_VERSION, 128, 64),
     (_MXFP8_MOE_TACTIC_SCHEMA_VERSION, 128, 8),
 )
+_MXFP8_MOE_PLAIN_TACTICS_GRANK32 = _MXFP8_MOE_TACTICS + (
+    (_MXFP8_MOE_TACTIC_SCHEMA_VERSION, 128, 128),
+)
 _MXFP8_MOE_TACTICS_GRANK128 = _MXFP8_MOE_TACTICS + (
     (_MXFP8_MOE_TACTIC_SCHEMA_VERSION, 128, 128),
 )
@@ -114,11 +117,18 @@ class _CuteSm120Mxfp8MoeRunner(Sm120MoeTunableRunner):
         scale_granularity_mnk: Tuple[int, int, int],
         scale_major_mode: str,
     ) -> None:
-        tactics = (
-            _MXFP8_MOE_TACTICS_GRANK128
-            if scale_granularity_mnk[2] == 128
-            else _MXFP8_MOE_TACTICS
-        )
+        if is_gated:
+            tactics = (
+                _MXFP8_MOE_TACTICS_GRANK128
+                if scale_granularity_mnk[2] == 128
+                else _MXFP8_MOE_TACTICS
+            )
+        else:
+            tactics = (
+                _MXFP8_MOE_TACTICS_GRANK128
+                if scale_granularity_mnk[2] == 128
+                else _MXFP8_MOE_PLAIN_TACTICS_GRANK32
+            )
         super().__init__(
             out,
             is_gated,

--- a/tests/grouped_mm/test_cute_sm120_mxfp8.py
+++ b/tests/grouped_mm/test_cute_sm120_mxfp8.py
@@ -25,8 +25,9 @@ from flashinfer.deep_gemm import get_col_major_tma_aligned_packed_tensor
 from flashinfer.grouped_mm import moe_gemm_mxfp8_nt_groupwise
 from flashinfer.grouped_mm.cute_sm120_mxfp8_groupwise.core import (
     _CuteSm120Mxfp8MoeRunner,
-    _MXFP8_MOE_PLAIN_TACTICS_GRANK32,
-    _MXFP8_MOE_TACTICS_GRANK128,
+    _MXFP8_MOE_GATED_TACTICS,
+    _MXFP8_MOE_GATED_TACTICS_GRANK128,
+    _MXFP8_MOE_PLAIN_TACTICS,
 )
 from flashinfer.utils import is_sm120a_supported
 
@@ -433,11 +434,15 @@ def test_moe_gemm_mxfp8_nt_groupwise_gated(
     )
 
 
-@pytest.mark.parametrize("is_gated", [False, True])
 @pytest.mark.parametrize(
-    "k_gran,tactic",
-    [(32, tactic) for tactic in _MXFP8_MOE_PLAIN_TACTICS_GRANK32]
-    + [(128, tactic) for tactic in _MXFP8_MOE_TACTICS_GRANK128],
+    "is_gated,k_gran,tactic",
+    [
+        (False, k_gran, tactic)
+        for k_gran in (32, 128)
+        for tactic in _MXFP8_MOE_PLAIN_TACTICS
+    ]
+    + [(True, 32, tactic) for tactic in _MXFP8_MOE_GATED_TACTICS]
+    + [(True, 128, tactic) for tactic in _MXFP8_MOE_GATED_TACTICS_GRANK128],
 )
 @pytest.mark.parametrize(
     "expert_rows,physical_n,k",
@@ -447,8 +452,6 @@ def test_moe_gemm_mxfp8_nt_groupwise_gated(
 def test_moe_gemm_mxfp8_nt_groupwise_forced_tactic(
     tactic, is_gated, k_gran, expert_rows, physical_n, k
 ):
-    if is_gated and k_gran == 32 and tactic[1:] == (128, 128):
-        pytest.skip("GranK=32 gated MXFP8 does not expose (128, 128) tuned tactic")
     skip_if_not_sm120()
     torch.random.manual_seed(0)
     num_groups = 4

--- a/tests/grouped_mm/test_cute_sm120_mxfp8.py
+++ b/tests/grouped_mm/test_cute_sm120_mxfp8.py
@@ -26,7 +26,6 @@ from flashinfer.grouped_mm import moe_gemm_mxfp8_nt_groupwise
 from flashinfer.grouped_mm.cute_sm120_mxfp8_groupwise.core import (
     _CuteSm120Mxfp8MoeRunner,
     _MXFP8_MOE_PLAIN_TACTICS_GRANK32,
-    _MXFP8_MOE_TACTICS,
     _MXFP8_MOE_TACTICS_GRANK128,
 )
 from flashinfer.utils import is_sm120a_supported

--- a/tests/grouped_mm/test_cute_sm120_mxfp8.py
+++ b/tests/grouped_mm/test_cute_sm120_mxfp8.py
@@ -25,6 +25,7 @@ from flashinfer.deep_gemm import get_col_major_tma_aligned_packed_tensor
 from flashinfer.grouped_mm import moe_gemm_mxfp8_nt_groupwise
 from flashinfer.grouped_mm.cute_sm120_mxfp8_groupwise.core import (
     _CuteSm120Mxfp8MoeRunner,
+    _MXFP8_MOE_PLAIN_TACTICS_GRANK32,
     _MXFP8_MOE_TACTICS,
     _MXFP8_MOE_TACTICS_GRANK128,
 )
@@ -436,7 +437,7 @@ def test_moe_gemm_mxfp8_nt_groupwise_gated(
 @pytest.mark.parametrize("is_gated", [False, True])
 @pytest.mark.parametrize(
     "k_gran,tactic",
-    [(32, tactic) for tactic in _MXFP8_MOE_TACTICS]
+    [(32, tactic) for tactic in _MXFP8_MOE_PLAIN_TACTICS_GRANK32]
     + [(128, tactic) for tactic in _MXFP8_MOE_TACTICS_GRANK128],
 )
 @pytest.mark.parametrize(
@@ -447,6 +448,8 @@ def test_moe_gemm_mxfp8_nt_groupwise_gated(
 def test_moe_gemm_mxfp8_nt_groupwise_forced_tactic(
     tactic, is_gated, k_gran, expert_rows, physical_n, k
 ):
+    if is_gated and k_gran == 32 and tactic[1:] == (128, 128):
+        pytest.skip("GranK=32 gated MXFP8 does not expose (128, 128) tuned tactic")
     skip_if_not_sm120()
     torch.random.manual_seed(0)
     num_groups = 4


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

This PR separates the SM120 MXFP8 plain and gated MoE tactic contracts, aligns the FP8 plain fallback/tuned stage policy, and invalidates stale autotuner cache entries after the tactic and implementation changes.

MXFP8 tactic contract:

- plain GranK=32/128 supports `M128N128`
- gated GranK=32 supports `M128N64` and does not expose `M128N128`
- gated GranK=128 supports both `M128N64` and the existing `M128N128`
- Python registries, C++ validation, leaf dispatch, and forced-tactic tests use the same contract

FP8 stage/store contract:

- plain fallback/tuned M32/M64/M128/SwapAB stages are `4/4/3/4`
- gated fallback/tuned stages remain `2/2/2/2`
- all FP8 blockscaling paths disable staged R2G
- gated non-SwapAB retains the existing load/store physical split; SwapAB retains Direct-STG

The gated stage limit is resource-qualified on RTX PRO 6000 Blackwell Server Edition. Stage3 requests for M32/M64/M128/SwapAB are `120832/141312/117760/103424` bytes, all above the `101376`-byte opt-in dynamic-SMEM cap. Gated GranK=32 `M128N128K64 S4` likewise compiles but cannot launch because its dynamic-SMEM request is invalid, so it remains excluded.

The PR contains only the 6KD-aligned SM120 CuTe C++ changes and intentionally excludes the CuteDSL grouped MoE additions.

Validation on an exclusive 188-SM RTX PRO 6000 Blackwell Server Edition GPU:

- `tests/grouped_mm/test_cute_sm120_fp8.py`: 107 passed
- `tests/grouped_mm/test_cute_sm120_mxfp8.py`: 343 passed
- gated GranK=128 `M128N128K64 S4`: JIT compile and forced correctness passed
- `pre-commit run --all-files`: all hooks passed, including clang-format, mypy, and ruff

## 🔍 Related Issues

N/A

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

Please focus on the plain/gated tactic separation, the GranK-dependent gated `M128N128` guard, and the FP8 plain-versus-gated stage policy.

