### PR TITLE
fix(attention): enable SM121 FMHA v2 prefill

### DIFF
--- a/flashinfer/prefill.py
+++ b/flashinfer/prefill.py
@@ -5759,7 +5759,7 @@ def fmha_v2_prefill_sm120(
     ``scale_bmm2`` and contains the V dequantization scale. If either is
     omitted, the kernel uses the corresponding host-encoded scale.
 
-    This entry point is validated for SM120. SM121 support is not enabled.
+    This entry point is validated for SM120 and SM121.
 
     Parameters
     ----------

--- a/flashinfer/prefill.py
+++ b/flashinfer/prefill.py
@@ -5782,13 +5782,10 @@ def fmha_v2_prefill_sm120(
     scale_bmm1_d, scale_bmm2_d : torch.Tensor, optional
         Persistent one-element FP32 CUDA scale tensors overriding host scales.
     """
-    if not is_sm12x_supported(query.device) or torch.cuda.get_device_capability(
+    if not is_sm12x_supported(query.device) or get_compute_capability(
         query.device
-    ) != (12, 0):
-        raise ValueError(
-            "fmha_v2_prefill_sm120 is only supported on SM120 GPUs; "
-            "SM121 has not been validated."
-        )
+    ) not in ((12, 0), (12, 1)):
+        raise ValueError("fmha_v2_prefill_sm120 is only supported on SM120/SM121 GPUs.")
     if query.ndim != 4 or key.ndim != 4 or value.ndim != 4 or out.ndim != 4:
         raise ValueError("query, key, value, and out must be 4D BSHD tensors.")
     if query.dtype != torch.float8_e4m3fn:

--- a/tests/attention/conftest.py
+++ b/tests/attention/conftest.py
@@ -168,7 +168,12 @@ def _fmha_v2_specs(items):
     # test item (~2.4k items would grind for many minutes).
     fmha_keys = set()  # (layout, dtype, o_dtype-or-None)
     sink_keys = set()  # (dtype, use_swa, head_dim)
-    need_sm120_module = False
+    test_names = {it.name.split("[")[0] for it in items}
+    need_sm120_module = sm12x and any(
+        name == "test_fmha_v2_prefill_deepseek"
+        or name.startswith("test_fmha_v2_prefill_sm120")
+        for name in test_names
+    )
     for it in items:
         cs = getattr(it, "callspec", None)
         if cs is None:
@@ -176,7 +181,6 @@ def _fmha_v2_specs(items):
         p = cs.params
         fn = it.name.split("[")[0]
         if fn == "test_fmha_v2_prefill_deepseek":
-            need_sm120_module = sm12x
             continue
         if fn == "test_trtllm_fmha_v2_prefill_sm120_large_head_dim" and not sm12x:
             continue  # test skips on non-SM12x


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

Enable `fmha_v2_prefill_sm120` on SM121 after validating the existing kernel on an NVIDIA DGX Spark with a GB10 GPU.

`is_sm12x_supported` continues to enforce the minimum CUDA version. The explicit `(12, 0)` and `(12, 1)` list limits execution to validated SM12x variants.

The JIT prebuild collector is updated because selecting the direct SM120/SM121 tests previously caused the module to compile after the prebuild stage.

## 🔍 Related Issues

Fixes #4600.
Alternative to #4606.

## 🚀 Pull Request Checklist

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit`.
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run `pre-commit run --all-files`.

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [ ] All tests are passing.

Targeted validation:

`pytest tests/attention/test_fmha_v2_prefill.py -v -k "test_fmha_v2_prefill_sm120"`

Result:

`26 passed, 2462 deselected`

Hardware:

- NVIDIA DGX Spark
- NVIDIA GB10
- Compute capability 12.1
- CUDA 13.0
- PyTorch 2.13.0+cu130

Numerical comparisons passed within the existing test tolerances. Device-scale, CUDA Graph, validation, and async-enqueue cases passed.

## Reviewer Notes

The 26 tests affected by #4600 pass on SM121.

A local full-file run was stopped during the existing DeepSeek `seq_len=8192` case after the Spark became unresponsive. That path was already enabled on SM121 and is not changed by this PR.

Please run the internal `unit_test_spark` matrix for `tests/attention/test_fmha_v2_prefill.py` on cu129 and cu130.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for FMHA v2 prefill operations on SM121 GPUs alongside SM120.
  * Expanded compatible GPU detection for supported prefill workloads.

* **Bug Fixes**
  * Updated GPU compatibility messaging to accurately reflect supported hardware.
  * Improved setup for relevant FMHA v2 prefill scenarios, ensuring supported tests are enabled and recognized correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->