### PR TITLE
[bugfix] include ASan interface header only when ASan is on

### DIFF
--- a/csrc/nv_internal/cpp/common/memoryUtils.cu
+++ b/csrc/nv_internal/cpp/common/memoryUtils.cu
@@ -14,11 +14,25 @@
  * limitations under the License.
  */
 
+// Detect AddressSanitizer before any include: <sanitizer/asan_interface.h> is shipped by the
+// sanitizer runtime (libasan) rather than by the compiler itself on some distros (e.g. Fedora),
+// so including it unconditionally breaks the JIT build on hosts that never asked for ASan.
+#ifdef __has_feature
+#if __has_feature(address_sanitizer)
+#define TLLM_HAS_ASAN
+#endif
+#elif defined(__SANITIZE_ADDRESS__)
+#define TLLM_HAS_ASAN
+#endif
+
 #include <curand_kernel.h>
-#include <sanitizer/asan_interface.h>
 #include <sys/stat.h>
 
 #include <unordered_map>
+
+#if defined(TLLM_HAS_ASAN)
+#include <sanitizer/asan_interface.h>
+#endif
 
 #include "tensorrt_llm/common/assert.h"
 #include "tensorrt_llm/common/cudaTypeUtils.cuh"
@@ -27,14 +41,6 @@
 
 namespace tensorrt_llm {
 namespace common {
-
-#ifdef __has_feature
-#if __has_feature(address_sanitizer)
-#define TLLM_HAS_ASAN
-#endif
-#elif defined(__SANITIZE_ADDRESS__)
-#define TLLM_HAS_ASAN
-#endif
 
 cudaError_t cudaMemcpyAsyncSanitized(void* dst, void const* src, size_t count,
                                      enum cudaMemcpyKind kind, cudaStream_t stream) {

--- a/tests/jit/test_jit_cpp_ext.py
+++ b/tests/jit/test_jit_cpp_ext.py
@@ -1,4 +1,5 @@
 import subprocess
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
@@ -234,6 +235,28 @@ def test_jit_spec_post_load_adapter_applies_to_jit_and_aot_load_paths(
 
     assert spec.load(path if is_aot else None) == ("wrapped", raw_module)
     assert seen == [raw_module]
+
+
+def test_asan_interface_header_is_only_included_under_asan():
+    """``<sanitizer/asan_interface.h>`` is shipped by the sanitizer runtime rather than
+    by the compiler on some distros, so the JIT sources must not include it unless
+    AddressSanitizer is actually enabled. See #4470."""
+    repo_root = Path(__file__).resolve().parents[2]
+    source = (
+        repo_root / "csrc" / "nv_internal" / "cpp" / "common" / "memoryUtils.cu"
+    ).read_text()
+
+    lines = [line.strip() for line in source.splitlines() if line.strip()]
+    include_idx = [
+        i
+        for i, line in enumerate(lines)
+        if line == "#include <sanitizer/asan_interface.h>"
+    ]
+
+    assert include_idx, "expected memoryUtils.cu to still reference the ASan interface"
+    for i in include_idx:
+        assert lines[i - 1] == "#if defined(TLLM_HAS_ASAN)"
+        assert lines[i + 1] == "#endif"
 
 
 def test_customize_batch_prefill_nvfp4_large_head_uses_prefill_flags(


### PR DESCRIPTION
# Issue #4470 — JIT build fails on a missing `sanitizer/asan_interface.h`

## 1. Root cause

`csrc/nv_internal/cpp/common/memoryUtils.cu` included the AddressSanitizer
interface header unconditionally:

```cpp
#include <curand_kernel.h>
#include <sanitizer/asan_interface.h>
#include <sys/stat.h>
```

The only thing that header provides to this translation unit is
`ASAN_POISON_MEMORY_REGION` / `ASAN_UNPOISON_MEMORY_REGION`, and both are used
exclusively inside `cudaMemcpyAsyncSanitized()` under `#if defined(TLLM_HAS_ASAN)`
— i.e. only when the host compiler was actually invoked with
`-fsanitize=address`. In every other build the header is pulled in and then
nothing from it is used.

`sanitizer/asan_interface.h` is not part of the base C/C++ compiler
installation on all distributions: it ships with the sanitizer runtime package.
On Fedora 44 / GCC 15 it lives in `libasan` (the header sits under
`/usr/lib/gcc/x86_64-redhat-linux/15/include/sanitizer/`), which is not a
dependency of `gcc-c++`. A stock Fedora 44 toolchain therefore has no such
header, and the compile aborts with
`fatal error: sanitizer/asan_interface.h: No such file or directory`.

This is not an obscure corner of the tree: `memoryUtils.cu` is a source of
several JIT modules — `flashinfer/jit/fused_moe.py`, `flashinfer/jit/moe_utils.py`,
`flashinfer/jit/gemm/fp8_blockscale.py`, `flashinfer/jit/dsv3_optimizations.py`
and the SM90 MoE-EP shim — so the first MoE or FP8 block-scale GEMM call on such
a host fails to build.

## 2. The fix and why

Move the existing `TLLM_HAS_ASAN` detection block above the include list and
wrap the header in it:

```cpp
#ifdef __has_feature
#if __has_feature(address_sanitizer)
#define TLLM_HAS_ASAN
#endif
#elif defined(__SANITIZE_ADDRESS__)
#define TLLM_HAS_ASAN
#endif
...
#if defined(TLLM_HAS_ASAN)
#include <sanitizer/asan_interface.h>
#endif
```

The detection logic itself is unchanged — it is the same block that already
guards the function body, just hoisted so it is evaluated before the include.
The header is now included under exactly the same condition as the code that
needs it, so:

* non-ASan builds (all normal JIT/AOT builds) never touch the header, and no
  longer require the sanitizer runtime to be installed;
* ASan builds are unaffected — `-fsanitize=address` defines
  `__SANITIZE_ADDRESS__` (GCC) or sets `__has_feature(address_sanitizer)`
  (Clang), the header is included, and `ASAN_{,UN}POISON_MEMORY_REGION` resolve
  as before.

This keeps the change to the two edits needed to fix the include; nothing about
the ASan behaviour, the public API, or any other source is touched. There is no
new environment variable or build flag to document.

## 3. Files changed

| File | Change |
|------|--------|
| `csrc/nv_internal/cpp/common/memoryUtils.cu` | Hoist the `TLLM_HAS_ASAN` detection above the includes; guard `#include <sanitizer/asan_interface.h>` with it. |
| `tests/jit/test_jit_cpp_ext.py` | Add `test_asan_interface_header_is_only_included_under_asan`, a source-level regression test asserting the include stays inside a `#if defined(TLLM_HAS_ASAN)` / `#endif` pair. |

`tests/jit/test_jit_cpp_ext.py` was chosen because it already holds the
JIT-build-configuration tests, and the repo already has precedent for
source-text assertions over `csrc/` (`tests/jit/test_flash_kda_decode_jit.py`,
`tests/model_optimizations/test_tinygemm2_sm100.py`).

## 4. Risk / uncertainty

* **Low risk.** The preprocessor condition guarding the include is identical to
  the one already guarding the only code that consumes it, so a build that
  compiled before still compiles and behaves the same.
* One nuance worth naming: under nvcc, `__SANITIZE_ADDRESS__` is a *host*
  compiler macro, so during the device pass `TLLM_HAS_ASAN` may be undefined
  even in an ASan build. That was already true of the `#if defined(TLLM_HAS_ASAN)`
  around the function body before this change, so the include and the body stay
  consistent with each other; this patch does not introduce or change that
  behaviour.
* I could not run a real end-to-end JIT compile in this environment: there is no
  CUDA toolkit and no `torch` install here (`pyenv` reports the pinned 3.10
  interpreter is missing), so `pytest` cannot import `flashinfer`. Verification
  was done at the preprocessor level (below) plus the source-level regression
  test. A maintainer running the MoE/GEMM tests on a normal CUDA host is the
  remaining confirmation.
* `memoryUtils.cu` is a vendored TensorRT-LLM file, so this delta will need to
  be re-applied if the file is re-synced from upstream. It is a two-hunk,
  self-documenting change, and the comment states why.

## 5. How it was verified

1. **Located every consumer.** `grep -rn "asan_interface\|ASAN_"` over `csrc/`
   and `include/` shows `memoryUtils.cu` is the only file that includes the
   header, and `memoryUtils.h` only declares the function — no other TU depends
   on the header being transitively pulled in.
2. **Preprocessor probe, both directions.** Extracted the patched guard region
   into a standalone TU and put a stub `sanitizer/asan_interface.h` containing
   `#error "ASAN_HEADER_REACHED"` first on the include path:
   * `g++ -std=c++17 -I<stub> -fsyntax-only probe.cc` → compiles cleanly, the
     header is never opened (this is the Fedora 44 case, and it fails on the
     pre-patch source).
   * `g++ -std=c++17 -I<stub> -fsanitize=address -fsyntax-only probe.cc` →
     hits `ASAN_HEADER_REACHED`, confirming ASan builds still include it.
3. **Regression test checked against both revisions.** Ran the new test's
   assertion body against the patched file (passes) and against
   `git show HEAD:csrc/nv_internal/cpp/common/memoryUtils.cu` (fails, as it
   should — the include is not guarded there).
4. **Formatters.** `clang-format` on `memoryUtils.cu` produces no diff, and
   `ruff format` / `ruff check` pass on `tests/jit/test_jit_cpp_ext.py`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility on systems without AddressSanitizer support by conditionally loading sanitizer-specific functionality.

* **Tests**
  * Added regression coverage to verify sanitizer interfaces are enabled only when supported.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->