### PR TITLE
fix(attention): make PrimTS paged block-sparse metadata live

### DIFF
--- a/flashinfer/attention/prims_ts/README.md
+++ b/flashinfer/attention/prims_ts/README.md
@@ -22,16 +22,27 @@ Import all entries below from `flashinfer.attention.prims_ts`.
 The component guides define supported shapes, layouts, metadata lifetime,
 output/workspace ownership, examples, limitations, and validation commands.
 
-For `BlockSparsePagedTSWrapper`, `plan` freezes the logical fixed-Q geometry
-and copies the paged-KV row offsets and optional per-request K/V lengths into
-plan-owned storage. When lengths are provided, the scalar K/V length is the
-static maximum; each page-table row may contain spare entries beyond its live
-length. `run` consumes live physical page IDs and per-KV-head sparse routes,
-and every selected BSR block must start before that request's frozen live K
-length. A violating sorted row fails closed. Eager
-launches retain all launch tensors on the run stream; CUDA Graph users must
-keep the wrapper and Q/cache/output/runtime-metadata tensors alive and
-unmodified until replay completes.
+For `BlockSparsePagedTSWrapper`, `plan` freezes only the compact fixed-Q
+geometry, dtypes, sparse-route capacity, and `max_seq_len_kv`; it retains no
+request metadata. Every `run` reads live paged-KV row offsets, physical page
+IDs, per-request K/V lengths, per-KV-head sparse routes, and optional token
+bits from device tensors. The physical-page ID tensor is capacity: its live
+prefix ends at `paged_kv_indptr[-1]`, which may be smaller than its `numel()`.
+The caller owns the live length value contract: dense K/V lengths must be in
+`[1, max_seq_len_kv]`, and causal lengths must be in `[Sq, max_seq_len_kv]`.
+Attention reads those lengths directly; out-of-range values are unsupported
+instead of guaranteed to fail closed. Given valid lengths, invalid page-table
+or route metadata fails the affected request or row closed to finite zero
+without a host synchronization.
+
+The one-shot `block_sparse_attention_with_paged_kv_cache` API takes
+`max_seq_len_kv` as the static capacity and requires `seq_lens_kv` with the
+live per-request logical lengths. Paged PrimTS does not support packed or
+mixed/variable Q lengths.
+Eager launches retain all launch tensors on the run stream; CUDA Graph users
+must keep the wrapper and Q/cache/output/runtime-metadata tensors alive and
+unmodified until replay completes. Values may change between completed replays
+while tensor addresses, shapes, dtypes, and strides remain stable.
 
 Qualified Q64/coarse-KV profiles retain KV256 routes for page sizes 64 and
 128. Optional `kv_valid_bits` is a `torch.uint32` per-request bitset with shape

--- a/flashinfer/attention/prims_ts/README.md
+++ b/flashinfer/attention/prims_ts/README.md
@@ -28,12 +28,24 @@ request metadata. Every `run` reads live paged-KV row offsets, physical page
 IDs, per-request K/V lengths, per-KV-head sparse routes, and optional token
 bits from device tensors. The physical-page ID tensor is capacity: its live
 prefix ends at `paged_kv_indptr[-1]`, which may be smaller than its `numel()`.
-The caller owns the live length value contract: dense K/V lengths must be in
+The caller owns every live value contract: dense K/V lengths must be in
 `[1, max_seq_len_kv]`, and causal lengths must be in `[Sq, max_seq_len_kv]`.
-Attention reads those lengths directly; out-of-range values are unsupported
-instead of guaranteed to fail closed. Given valid lengths, invalid page-table
-or route metadata fails the affected request or row closed to finite zero
-without a host synchronization.
+`paged_kv_indptr` must start at zero and contain bounded, monotone rows with at
+least `ceil(seq_lens_kv[b] / page_size)` entries; every physical page ID in
+the live prefix ending at `paged_kv_indptr[-1]` must lie in `[0, P)`. Every BSR
+row must have bounded offsets, strictly increasing unique block IDs, and at
+most the planned `max_blocks_per_row` entries. Contiguous IDs must lie below
+`ceil(seq_len_kv / kv_block_size)`; paged IDs must start below the owning
+request's live K/V length.
+
+Reusable wrappers validate tensor structure but read values directly without
+host synchronization. Invalid values therefore have undefined behavior and
+may access out of bounds. Set `CUTE_DSL_ENABLE_ASSERTIONS=1` before the process
+first compiles these kernels to diagnose violations encountered while preparing
+selected routes; such assertions report asynchronously and leave the CUDA
+context unusable. The one-shot APIs instead synchronize once to validate all
+live values, including the complete physical-page-ID prefix, before creating
+their temporary plans and cannot run during CUDA Graph capture.
 
 The one-shot `block_sparse_attention_with_paged_kv_cache` API takes
 `max_seq_len_kv` as the static capacity and requires `seq_lens_kv` with the

--- a/flashinfer/attention/prims_ts/_block_sparse/compiler.py
+++ b/flashinfer/attention/prims_ts/_block_sparse/compiler.py
@@ -53,7 +53,7 @@ def _compile_block_sparse(key: _BlockSparseCompileKey) -> Callable[..., object]:
         kv_route_size=key.kv_route_size,
         has_token_bits=key.use_kv_valid_bits,
         page_size=key.page_size,
-        use_variable_seqlens_kv=key.use_variable_seqlens_kv,
+        mask_type=key.mask_type,
     )
     Int32 = cutlass.Int32
     Int64 = cutlass.Int64
@@ -183,7 +183,7 @@ def _compile_block_sparse(key: _BlockSparseCompileKey) -> Callable[..., object]:
             static_config,
             static_seq_len_kv,
             seq_lens_kv.iterator,
-            key.use_variable_seqlens_kv,
+            True,
             num_physical_kv_pages,
             k_page_stride,
             v_page_stride,

--- a/flashinfer/attention/prims_ts/_block_sparse/compiler.py
+++ b/flashinfer/attention/prims_ts/_block_sparse/compiler.py
@@ -249,7 +249,7 @@ def _compile_block_sparse(key: _BlockSparseCompileKey) -> Callable[..., object]:
             valid_bits_fake,
             row_route_offsets_fake,
             route_workspace_fake,
-            Int32(-1),
+            Int32(0),
             Float32(1.0),
         )
     else:
@@ -307,7 +307,7 @@ def _compile_block_sparse(key: _BlockSparseCompileKey) -> Callable[..., object]:
             seq_lens_kv_fake,
             row_route_offsets_fake,
             route_workspace_fake,
-            Int32(-1),
+            Int32(0),
             Int64(1),
             Int64(1),
             Int64(1),

--- a/flashinfer/attention/prims_ts/_block_sparse/config.py
+++ b/flashinfer/attention/prims_ts/_block_sparse/config.py
@@ -82,7 +82,6 @@ class _BlockSparseCompileKey:
     use_persistent_scheduler: bool
     use_parallel_sparse_kv_loads: bool
     page_size: int | None = None
-    use_variable_seqlens_kv: bool = False
 
 
 @dataclass(frozen=True)
@@ -457,7 +456,6 @@ def _resolve_block_sparse_launch_spec(
     use_kv_valid_bits: bool,
     max_row_route_capacity: int,
     page_size: int | None = None,
-    use_variable_seqlens_kv: bool = False,
 ) -> _BlockSparseLaunchSpec:
     """Resolve and cache one validated static or CLC launch.
 
@@ -502,7 +500,6 @@ def _resolve_block_sparse_launch_spec(
             use_persistent_scheduler=use_persistent_scheduler,
         ),
         page_size=page_size,
-        use_variable_seqlens_kv=use_variable_seqlens_kv,
     )
     try:
         _make_block_sparse_config(compile_key)
@@ -526,12 +523,7 @@ def _resolve_block_sparse_launch_spec(
         ("tile_size_kv", kv_route_size),
     ]
     if page_size is not None:
-        policy_entries.extend(
-            (
-                ("page_size", page_size),
-                ("use_variable_seqlens_kv", use_variable_seqlens_kv),
-            )
-        )
+        policy_entries.append(("page_size", page_size))
     policy_entries.extend(
         (
             ("use_persistent_scheduler", compile_key.use_persistent_scheduler),

--- a/flashinfer/attention/prims_ts/_block_sparse/inspection.py
+++ b/flashinfer/attention/prims_ts/_block_sparse/inspection.py
@@ -12,21 +12,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Host side of one-shot raw-BSR validation and capacity reduction.
+"""Host side of one-shot live-metadata validation and capacity reduction.
 
-The one-shot public entry point validates the tensor ABI before this module
-checks Int32 addressing limits, launches the GPU inspector, and decodes its
-fixed Int64 summary into Python planning facts. Reusable plans instead receive
-an explicit row-capacity bound. Inspection deliberately performs one packed
-device-to-host copy and does not inspect token-mask contents or build run-time
-route metadata.
+The one-shot public entry points validate tensor structure before this module
+launches GPU inspectors and decodes their fixed Int64 summary into Python
+planning facts. Reusable plans instead receive an explicit row-capacity bound.
+Inspection deliberately performs one packed device-to-host copy and does not
+inspect token-mask contents or build run-time route metadata.
 """
 
-from dataclasses import dataclass
+from collections.abc import Callable
 
 import torch
 
-from .common import _SIGNED_INT32_MAX
+from .config import _BlockSparseStaticProfile
 
 
 # Device summary ABI; keep this order synchronized with block_sparse_inspect.py:
@@ -34,22 +33,12 @@ from .common import _SIGNED_INT32_MAX
 _SUMMARY_FIELDS = 2
 
 
-@dataclass(frozen=True)
-class _BlockSparseInspection:
-    """Planning facts derived from caller-owned canonical BSR metadata.
-
-    ``max_row_block_count`` is the semantic BSR-block bound used by the
-    one-shot entry point to create a temporary capacity-only plan.
-    """
-
-    max_row_block_count: int
-
-
-def _validate_int32_extent(value: int, name: str) -> None:
-    """Reject a validated positive extent that device Int32 cannot represent."""
-
-    if value > _SIGNED_INT32_MAX:
-        raise OverflowError(f"{name} must fit in signed int32")
+def _bsr_error_reason(error_code: int) -> str:
+    return {
+        1: "indices in each row must be strictly increasing and unique",
+        2: "indices must select an in-range KV block",
+        3: "each indptr row range must be bounded and monotone",
+    }.get(error_code, f"unknown validation error {error_code}")
 
 
 def _raise_for_noncanonical_bsr(summary_values: tuple[int, ...]) -> None:
@@ -58,27 +47,70 @@ def _raise_for_noncanonical_bsr(summary_values: tuple[int, ...]) -> None:
     error_code = summary_values[0]
     if error_code == 0:
         return
-    reason = {
-        1: "indices in each row must be strictly increasing and unique",
-        2: "indices must select an in-range KV block",
-        3: "each indptr row range must be bounded and monotone",
-    }.get(error_code, f"unknown validation error {error_code}")
+    reason = _bsr_error_reason(error_code)
     raise ValueError(f"block_indptr/block_indices must form canonical BSR: {reason}")
+
+
+def _raise_for_invalid_paged_metadata(
+    summary_values: tuple[int, ...],
+    *,
+    minimum_seq_len_kv: int,
+    max_seq_len_kv: int,
+) -> None:
+    """Decode the strongest paged request or live-BSR validation failure."""
+
+    error_code = summary_values[0]
+    if error_code == 0:
+        return
+    reason = {
+        4: (f"seq_lens_kv values must lie in [{minimum_seq_len_kv}, {max_seq_len_kv}]"),
+        5: (
+            "paged_kv_indptr must start at zero and each row must be "
+            "bounded and monotone"
+        ),
+        6: "paged_kv_indptr rows must contain enough pages for seq_lens_kv",
+        7: "paged_kv_indices must contain an in-range physical page ID",
+    }.get(error_code)
+    if reason is None:
+        reason = (
+            "block_indptr/block_indices must form canonical BSR for live "
+            f"seq_lens_kv: {_bsr_error_reason(error_code)}"
+        )
+    raise ValueError(reason)
+
+
+def _collect_inspection_summary(
+    device: torch.device,
+    stream: torch.cuda.Stream,
+    launch: Callable[[torch.Tensor, int], None],
+) -> tuple[int, ...]:
+    """Run inspectors under one capture-safe stream context and copy once."""
+
+    device_index = device.index
+    if device_index is None:
+        device_index = torch.cuda.current_device()
+    if torch.cuda.is_current_stream_capturing():
+        raise RuntimeError(
+            "block-sparse inspection is unsupported during CUDA Graph capture"
+        )
+    with torch.cuda.device(device_index), torch.cuda.stream(stream):
+        if torch.cuda.is_current_stream_capturing():
+            raise RuntimeError(
+                "block-sparse inspection is unsupported during CUDA Graph capture"
+            )
+        summary_gpu = torch.zeros(_SUMMARY_FIELDS, dtype=torch.int64, device=device)
+        launch(summary_gpu, device_index)
+        return tuple(int(value) for value in summary_gpu.tolist())
 
 
 def _inspect_block_sparse_bsr(
     block_indptr: torch.Tensor,
     block_indices: torch.Tensor,
     *,
-    batch_size: int,
-    num_kv_heads: int,
-    seq_len_q: int,
-    seq_len_kv: int,
-    q_block_size: int,
-    kv_block_size: int,
+    static: _BlockSparseStaticProfile,
     stream: torch.cuda.Stream,
-) -> _BlockSparseInspection:
-    """Inspect raw BSR on its CUDA device and return host planning facts.
+) -> int:
+    """Inspect raw BSR and return its maximum semantic row width.
 
     ``block_indptr`` is contiguous Int32
     ``[B, Hkv, ceil(Sq / q_block_size) + 1]`` and stores absolute ranges into
@@ -86,66 +118,96 @@ def _inspect_block_sparse_bsr(
 
     The GPU validates each referenced range before reading it, reduces all rows
     into one zero-initialized Int64[2], and this function performs the sole D2H
-    synchronization before returning an immutable ``_BlockSparseInspection``.
-    The run-time prepare kernel resolves current BSR indices and token bits into
-    fixed-stride route metadata.
+    synchronization before returning the semantic BSR-block bound. The run-time
+    prepare kernel resolves current BSR indices and token bits into fixed-stride
+    route metadata.
     """
-
-    for value, name in (
-        (batch_size, "batch_size"),
-        (num_kv_heads, "num_kv_heads"),
-        (seq_len_q, "seq_len_q"),
-        (seq_len_kv, "seq_len_kv"),
-    ):
-        _validate_int32_extent(value, name)
-
-    device = block_indptr.device
-    device_index = device.index
-    if device_index is None:
-        device_index = torch.cuda.current_device()
-
-    # Checking the caller's current stream first avoids entering another
-    # device/stream context while an enclosing graph capture is active.
-    if torch.cuda.is_current_stream_capturing():
-        raise RuntimeError(
-            "block-sparse inspection is unsupported during CUDA Graph capture"
-        )
 
     from ..kernels.fmha_decode.block_sparse_inspect import (
         compile_block_sparse_inspection,
     )
 
-    with torch.cuda.device(device_index), torch.cuda.stream(stream):
-        if torch.cuda.is_current_stream_capturing():
-            raise RuntimeError(
-                "block-sparse inspection is unsupported during CUDA Graph capture"
-            )
-        summary_gpu = torch.zeros(
-            _SUMMARY_FIELDS,
-            dtype=torch.int64,
-            device=device,
-        )
+    def launch(summary: torch.Tensor, device_index: int) -> None:
         inspect_bsr = compile_block_sparse_inspection(
             device_index=device_index,
-            batch_size=batch_size,
-            num_kv_heads=num_kv_heads,
-            seq_len_q=seq_len_q,
-            seq_len_kv=seq_len_kv,
-            q_block_size=q_block_size,
-            kv_block_size=kv_block_size,
+            batch_size=static.batch_size,
+            num_kv_heads=static.num_kv_heads,
+            seq_len_q=static.seq_len_q,
+            seq_len_kv=static.seq_len_kv,
+            q_block_size=static.q_block_size,
+            kv_block_size=static.kv_block_size,
         )
-        inspect_bsr(
-            block_indptr,
-            block_indices,
-            summary_gpu,
-        )
-        summary_values = tuple(int(value) for value in summary_gpu.tolist())
+        inspect_bsr(block_indptr, block_indices, None, summary)
 
-    _raise_for_noncanonical_bsr(summary_values)
-    # This positional decode is the host mirror of the device summary ABI.
-    return _BlockSparseInspection(
-        max_row_block_count=summary_values[1],
+    summary_values = _collect_inspection_summary(
+        block_indptr.device,
+        stream,
+        launch,
     )
 
+    _raise_for_noncanonical_bsr(summary_values)
+    return summary_values[1]
 
-__all__ = ["_BlockSparseInspection", "_inspect_block_sparse_bsr"]
+
+def _inspect_paged_block_sparse_metadata(
+    block_indptr: torch.Tensor,
+    block_indices: torch.Tensor,
+    paged_kv_indptr: torch.Tensor,
+    paged_kv_indices: torch.Tensor,
+    seq_lens_kv: torch.Tensor,
+    *,
+    static: _BlockSparseStaticProfile,
+    num_physical_kv_pages: int,
+    stream: torch.cuda.Stream,
+) -> int:
+    """Inspect paged requests and return the maximum live BSR row width."""
+
+    page_size = static.page_size
+    if page_size is None:
+        raise TypeError("paged inspection requires a paged static profile")
+    minimum_seq_len_kv = static.seq_len_q if static.mask_type == "causal" else 1
+
+    from ..kernels.fmha_decode.block_sparse_inspect import (
+        compile_paged_block_sparse_metadata_inspection,
+    )
+
+    def launch(summary: torch.Tensor, device_index: int) -> None:
+        inspect_metadata = compile_paged_block_sparse_metadata_inspection(
+            device_index=device_index,
+            batch_size=static.batch_size,
+            num_kv_heads=static.num_kv_heads,
+            seq_len_q=static.seq_len_q,
+            minimum_seq_len_kv=minimum_seq_len_kv,
+            max_seq_len_kv=static.seq_len_kv,
+            q_block_size=static.q_block_size,
+            kv_block_size=static.kv_block_size,
+            page_size=page_size,
+        )
+        inspect_metadata(
+            block_indptr,
+            block_indices,
+            paged_kv_indptr,
+            paged_kv_indices,
+            seq_lens_kv,
+            num_physical_kv_pages,
+            summary,
+        )
+
+    summary_values = _collect_inspection_summary(
+        block_indptr.device,
+        stream,
+        launch,
+    )
+
+    _raise_for_invalid_paged_metadata(
+        summary_values,
+        minimum_seq_len_kv=minimum_seq_len_kv,
+        max_seq_len_kv=static.seq_len_kv,
+    )
+    return summary_values[1]
+
+
+__all__ = [
+    "_inspect_block_sparse_bsr",
+    "_inspect_paged_block_sparse_metadata",
+]

--- a/flashinfer/attention/prims_ts/_block_sparse/plan.py
+++ b/flashinfer/attention/prims_ts/_block_sparse/plan.py
@@ -59,104 +59,6 @@ def _serialize_plan(
 
 
 @dataclass(frozen=True)
-class _PagedKVPlanMetadata:
-    """Plan-owned metadata required only by paged K/V storage."""
-
-    page_size: int
-    paged_kv_indptr: torch.Tensor
-    seq_lens_kv: torch.Tensor
-    num_page_indices: int
-    use_variable_seqlens_kv: bool
-
-
-def _snapshot_paged_kv_plan_metadata(
-    paged_kv_indptr: torch.Tensor,
-    seq_lens_kv: torch.Tensor | None,
-    *,
-    static: _BlockSparseStaticProfile,
-    device: torch.device,
-    plan_stream: torch.cuda.Stream,
-) -> _PagedKVPlanMetadata:
-    """Validate and copy stable paged inputs into one final plan object."""
-
-    assert static.page_size is not None
-    if seq_lens_kv is not None:
-        if not isinstance(seq_lens_kv, torch.Tensor):
-            raise TypeError("seq_lens_kv must be a torch.Tensor")
-        if seq_lens_kv.dtype != torch.int32:
-            raise TypeError("seq_lens_kv must have dtype torch.int32")
-        if seq_lens_kv.ndim != 1:
-            raise ValueError("seq_lens_kv must be one-dimensional")
-        if seq_lens_kv.device != device:
-            raise ValueError(
-                f"seq_lens_kv must be on planned device {device}, "
-                f"got {seq_lens_kv.device}"
-            )
-        if tuple(seq_lens_kv.shape) != (static.batch_size,):
-            raise ValueError(f"seq_lens_kv must have shape ({static.batch_size},)")
-        if not seq_lens_kv.is_contiguous():
-            raise ValueError("seq_lens_kv must be contiguous")
-        if seq_lens_kv.data_ptr() % 4 != 0:
-            raise ValueError("seq_lens_kv data pointer must be 4-byte aligned")
-
-    with torch.cuda.device(device), torch.cuda.stream(plan_stream):
-        indptr_values = tuple(int(value) for value in paged_kv_indptr.tolist())
-        if indptr_values[0] != 0:
-            raise ValueError("paged_kv_indptr must start at zero")
-        for begin, end in zip(indptr_values[:-1], indptr_values[1:], strict=True):
-            if end < begin:
-                raise ValueError("paged_kv_indptr must be monotonic non-decreasing")
-
-        if seq_lens_kv is None:
-            seq_lens_kv_values = (static.seq_len_kv,) * static.batch_size
-        else:
-            seq_lens_kv_values = tuple(int(value) for value in seq_lens_kv.tolist())
-
-        lower_bound = static.seq_len_q if static.mask_type == "causal" else 1
-        for request_idx, (live_kv, begin, end) in enumerate(
-            zip(
-                seq_lens_kv_values,
-                indptr_values[:-1],
-                indptr_values[1:],
-                strict=True,
-            )
-        ):
-            if not lower_bound <= live_kv <= static.seq_len_kv:
-                raise ValueError(
-                    "seq_lens_kv values must be in "
-                    f"[{lower_bound}, {static.seq_len_kv}]"
-                )
-            required_pages = ceil_div(live_kv, static.page_size)
-            available_pages = end - begin
-            if available_pages < required_pages:
-                qualifier = " for live seq_lens_kv" if seq_lens_kv is not None else ""
-                raise ValueError(
-                    "each paged_kv_indptr request must contain at least "
-                    f"{required_pages} pages{qualifier}; request {request_idx} "
-                    f"contains {available_pages}"
-                )
-
-        use_variable_seqlens_kv = any(
-            live_kv != static.seq_len_kv for live_kv in seq_lens_kv_values
-        )
-        return _PagedKVPlanMetadata(
-            page_size=static.page_size,
-            paged_kv_indptr=torch.tensor(
-                indptr_values,
-                dtype=torch.int32,
-                device=device,
-            ),
-            seq_lens_kv=torch.tensor(
-                seq_lens_kv_values,
-                dtype=torch.int32,
-                device=device,
-            ),
-            num_page_indices=indptr_values[-1],
-            use_variable_seqlens_kv=use_variable_seqlens_kv,
-        )
-
-
-@dataclass(frozen=True)
 class _BlockSparsePlanState:
     """One complete launch state published by a block-sparse wrapper.
 
@@ -195,6 +97,7 @@ class _BlockSparsePlanState:
     kv_dtype: torch.dtype
     output_dtype: torch.dtype
     use_kv_valid_bits: bool
+    page_size: int | None
 
     # Only an unmasked specialization needs a shape-correct ABI placeholder.
     dummy_kv_valid_bits: torch.Tensor | None
@@ -212,7 +115,6 @@ class _BlockSparsePlanState:
     # All plan-stream work happens-before run after waiting on this event.
     ready_event: torch.cuda.Event
     ready_stream_handle: int
-    paged_kv: _PagedKVPlanMetadata | None
 
 
 def _allocate_dummy_kv_valid_bits(
@@ -277,14 +179,10 @@ def _build_block_sparse_plan_state(
     device: torch.device,
     device_index: int,
     plan_stream: torch.cuda.Stream,
-    paged_kv: _PagedKVPlanMetadata | None,
 ) -> _BlockSparsePlanState:
     """Build and close one complete state after storage validation."""
 
     assert static.max_blocks_per_row is not None
-    assert (static.page_size is None) == (paged_kv is None)
-    if paged_kv is not None:
-        assert static.page_size == paged_kv.page_size
     max_row_route_capacity = ceil_div(
         static.max_blocks_per_row * static.kv_block_size,
         static.kv_route_size,
@@ -319,9 +217,6 @@ def _build_block_sparse_plan_state(
             mask_type=static.mask_type,
             use_kv_valid_bits=static.use_kv_valid_bits,
             max_row_route_capacity=max_row_route_capacity,
-            use_variable_seqlens_kv=(
-                False if paged_kv is None else paged_kv.use_variable_seqlens_kv
-            ),
         )
         policy = (
             *spec.policy,
@@ -357,6 +252,7 @@ def _build_block_sparse_plan_state(
         kv_dtype=static.kv_dtype,
         output_dtype=static.output_dtype,
         use_kv_valid_bits=static.use_kv_valid_bits,
+        page_size=static.page_size,
         dummy_kv_valid_bits=dummy_kv_valid_bits,
         row_route_offsets=row_route_offsets,
         route_workspace=route_workspace,
@@ -365,7 +261,6 @@ def _build_block_sparse_plan_state(
         compiled=compiled,
         ready_event=ready_event,
         ready_stream_handle=plan_stream.cuda_stream,
-        paged_kv=paged_kv,
     )
 
 
@@ -384,19 +279,14 @@ def _wait_and_record_block_sparse_plan(
         state.dummy_kv_valid_bits.record_stream(stream)
     state.row_route_offsets.record_stream(stream)
     state.route_workspace.record_stream(stream)
-    if state.paged_kv is not None:
-        state.paged_kv.paged_kv_indptr.record_stream(stream)
-        state.paged_kv.seq_lens_kv.record_stream(stream)
 
 
 __all__ = [
     "_BlockSparsePlanState",
-    "_PagedKVPlanMetadata",
     "_allocate_dummy_kv_valid_bits",
     "_allocate_route_storage",
     "_build_block_sparse_plan_state",
     "_record_block_sparse_plan_ready_event",
     "_serialize_plan",
-    "_snapshot_paged_kv_plan_metadata",
     "_wait_and_record_block_sparse_plan",
 ]

--- a/flashinfer/attention/prims_ts/_block_sparse/runtime.py
+++ b/flashinfer/attention/prims_ts/_block_sparse/runtime.py
@@ -42,17 +42,21 @@ class _ContiguousKVStorage:
 
 @dataclass(frozen=True)
 class _PagedKVStorage:
-    """Live paged-K/V runtime storage validated against one frozen paged plan."""
+    """Paged K/V storage and request metadata consumed by one live run."""
 
     paged_kv_cache: PagedKVCache
+    paged_kv_indptr: torch.Tensor
     paged_kv_indices: torch.Tensor
+    seq_lens_kv: torch.Tensor
 
 
 @dataclass(frozen=True)
 class _PagedKVLaunchPayload:
     """Launch-only live paged metadata derived during shared validation."""
 
+    paged_kv_indptr: torch.Tensor
     paged_kv_indices: torch.Tensor
+    seq_lens_kv: torch.Tensor
     num_physical_kv_pages: int
     k_page_stride: int
     v_page_stride: int
@@ -72,22 +76,6 @@ class _BlockSparseRunArgs:
     kv_valid_bits_is_live: bool
     sm_scale: float
     paged_kv: _PagedKVLaunchPayload | None
-
-
-class _PagedKVPlanMetadataLike(Protocol):
-    """Minimal paged-plan metadata consumed by shared runtime validation."""
-
-    @property
-    def page_size(self) -> int: ...
-
-    @property
-    def paged_kv_indptr(self) -> torch.Tensor: ...
-
-    @property
-    def seq_lens_kv(self) -> torch.Tensor: ...
-
-    @property
-    def num_page_indices(self) -> int: ...
 
 
 class _BlockSparsePlanStateLike(Protocol):
@@ -130,6 +118,9 @@ class _BlockSparsePlanStateLike(Protocol):
     def use_kv_valid_bits(self) -> bool: ...
 
     @property
+    def page_size(self) -> int | None: ...
+
+    @property
     def dummy_kv_valid_bits(self) -> torch.Tensor | None: ...
 
     @property
@@ -143,9 +134,6 @@ class _BlockSparsePlanStateLike(Protocol):
 
     @property
     def compiled(self) -> Callable[..., object]: ...
-
-    @property
-    def paged_kv(self) -> _PagedKVPlanMetadataLike | None: ...
 
 
 def _validate_metadata_tensor(
@@ -269,22 +257,6 @@ def _resolve_effective_kv_valid_bits(
     return dummy_kv_valid_bits
 
 
-def _require_contiguous_plan_state(
-    state: _BlockSparsePlanStateLike,
-) -> None:
-    if state.paged_kv is not None:
-        raise TypeError("contiguous K/V storage requires a contiguous plan state")
-
-
-def _require_paged_plan_state(
-    state: _BlockSparsePlanStateLike,
-) -> _PagedKVPlanMetadataLike:
-    paged_kv = state.paged_kv
-    if paged_kv is None:
-        raise TypeError("paged K/V storage requires a paged plan state")
-    return paged_kv
-
-
 def validate_block_sparse_run(
     q: torch.Tensor,
     kv_storage: _ContiguousKVStorage | _PagedKVStorage,
@@ -335,7 +307,8 @@ def validate_block_sparse_run(
     paged_kv: _PagedKVLaunchPayload | None = None
     overlap_inputs: tuple[tuple[str, torch.Tensor], ...]
     if isinstance(kv_storage, _ContiguousKVStorage):
-        _require_contiguous_plan_state(state)
+        if state.page_size is not None:
+            raise TypeError("contiguous K/V storage requires a contiguous plan state")
         kv_shape = (
             state.batch_size,
             state.seq_len_kv,
@@ -363,7 +336,9 @@ def validate_block_sparse_run(
             ("route_workspace", state.route_workspace),
         )
     elif isinstance(kv_storage, _PagedKVStorage):
-        paged_plan = _require_paged_plan_state(state)
+        page_size = state.page_size
+        if page_size is None:
+            raise TypeError("paged K/V storage requires a paged plan state")
         (
             k,
             v,
@@ -384,7 +359,7 @@ def validate_block_sparse_run(
         )
         expected_geometry = (
             state.num_kv_heads,
-            paged_plan.page_size,
+            page_size,
             state.head_dim,
         )
         if runtime_geometry != expected_geometry:
@@ -397,15 +372,32 @@ def validate_block_sparse_run(
                 f"K/V dtype must match the plan ({state.kv_dtype}), got {k.dtype}"
             )
         _validate_metadata_tensor(
+            kv_storage.paged_kv_indptr,
+            "paged_kv_indptr",
+            ndim=1,
+            dtype=torch.int32,
+            expected_device=state.device,
+            expected_shape=(state.batch_size + 1,),
+        )
+        _validate_metadata_tensor(
             kv_storage.paged_kv_indices,
             "paged_kv_indices",
             ndim=1,
             dtype=torch.int32,
             expected_device=state.device,
-            expected_shape=(paged_plan.num_page_indices,),
+        )
+        _validate_metadata_tensor(
+            kv_storage.seq_lens_kv,
+            "seq_lens_kv",
+            ndim=1,
+            dtype=torch.int32,
+            expected_device=state.device,
+            expected_shape=(state.batch_size,),
         )
         paged_kv = _PagedKVLaunchPayload(
+            paged_kv_indptr=kv_storage.paged_kv_indptr,
             paged_kv_indices=kv_storage.paged_kv_indices,
+            seq_lens_kv=kv_storage.seq_lens_kv,
             num_physical_kv_pages=num_physical_kv_pages,
             k_page_stride=k_page_stride,
             v_page_stride=v_page_stride,
@@ -417,9 +409,9 @@ def validate_block_sparse_run(
             ("block_indptr", block_indptr),
             ("block_indices", block_indices),
             ("kv_valid_bits", effective_kv_valid_bits),
-            ("paged_kv_indptr", paged_plan.paged_kv_indptr),
+            ("paged_kv_indptr", kv_storage.paged_kv_indptr),
             ("paged_kv_indices", kv_storage.paged_kv_indices),
-            ("seq_lens_kv", paged_plan.seq_lens_kv),
+            ("seq_lens_kv", kv_storage.seq_lens_kv),
             ("row_route_offsets", state.row_route_offsets),
             ("route_workspace", state.route_workspace),
         )
@@ -470,7 +462,9 @@ def record_block_sparse_run_args(
     if run_args.kv_valid_bits_is_live:
         run_args.kv_valid_bits.record_stream(stream)
     if run_args.paged_kv is not None:
+        run_args.paged_kv.paged_kv_indptr.record_stream(stream)
         run_args.paged_kv.paged_kv_indices.record_stream(stream)
+        run_args.paged_kv.seq_lens_kv.record_stream(stream)
 
 
 def launch_block_sparse(
@@ -481,7 +475,6 @@ def launch_block_sparse(
     """Invoke the exact contiguous or paged ABI chosen by validated payload."""
 
     if run_args.paged_kv is None:
-        _require_contiguous_plan_state(state)
         state.compiled(
             run_args.q,
             run_args.k,
@@ -496,7 +489,6 @@ def launch_block_sparse(
             run_args.sm_scale,
         )
     else:
-        paged_plan = _require_paged_plan_state(state)
         state.compiled(
             run_args.q,
             run_args.k,
@@ -505,9 +497,9 @@ def launch_block_sparse(
             run_args.block_indptr,
             run_args.block_indices,
             run_args.kv_valid_bits,
-            paged_plan.paged_kv_indptr,
+            run_args.paged_kv.paged_kv_indptr,
             run_args.paged_kv.paged_kv_indices,
-            paged_plan.seq_lens_kv,
+            run_args.paged_kv.seq_lens_kv,
             state.row_route_offsets,
             state.route_workspace,
             state.max_blocks_per_row,

--- a/flashinfer/attention/prims_ts/_block_sparse/runtime.py
+++ b/flashinfer/attention/prims_ts/_block_sparse/runtime.py
@@ -14,10 +14,9 @@
 
 """Runtime validation and launch adapter for block-sparse attention."""
 
-from collections.abc import Callable
 from dataclasses import dataclass
 import math
-from typing import Protocol
+from typing import TYPE_CHECKING
 
 import torch
 
@@ -30,6 +29,9 @@ from ..decode import (
     _validate_scale,
 )
 from .common import _SIGNED_INT32_MAX
+
+if TYPE_CHECKING:
+    from .plan import _BlockSparsePlanState
 
 
 @dataclass(frozen=True)
@@ -76,64 +78,6 @@ class _BlockSparseRunArgs:
     kv_valid_bits_is_live: bool
     sm_scale: float
     paged_kv: _PagedKVLaunchPayload | None
-
-
-class _BlockSparsePlanStateLike(Protocol):
-    """Structural launch state shared by contiguous and paged wrappers."""
-
-    @property
-    def device(self) -> torch.device: ...
-
-    @property
-    def batch_size(self) -> int: ...
-
-    @property
-    def seq_len_q(self) -> int: ...
-
-    @property
-    def seq_len_kv(self) -> int: ...
-
-    @property
-    def num_qo_heads(self) -> int: ...
-
-    @property
-    def num_kv_heads(self) -> int: ...
-
-    @property
-    def head_dim(self) -> int: ...
-
-    @property
-    def q_block_size(self) -> int: ...
-
-    @property
-    def q_dtype(self) -> torch.dtype: ...
-
-    @property
-    def kv_dtype(self) -> torch.dtype: ...
-
-    @property
-    def output_dtype(self) -> torch.dtype: ...
-
-    @property
-    def use_kv_valid_bits(self) -> bool: ...
-
-    @property
-    def page_size(self) -> int | None: ...
-
-    @property
-    def dummy_kv_valid_bits(self) -> torch.Tensor | None: ...
-
-    @property
-    def row_route_offsets(self) -> torch.Tensor: ...
-
-    @property
-    def route_workspace(self) -> torch.Tensor: ...
-
-    @property
-    def max_blocks_per_row(self) -> int: ...
-
-    @property
-    def compiled(self) -> Callable[..., object]: ...
 
 
 def _validate_metadata_tensor(
@@ -215,6 +159,31 @@ def validate_block_sparse_metadata(
         raise ValueError("kv_valid_bits must be None when use_kv_valid_bits=False")
 
 
+def validate_paged_kv_metadata(
+    paged_kv_indptr: torch.Tensor,
+    paged_kv_indices: torch.Tensor,
+    seq_lens_kv: torch.Tensor,
+    *,
+    device: torch.device,
+    batch_size: int,
+) -> None:
+    """Validate the shared structural ABI for live paged request metadata."""
+
+    for tensor, name, shape in (
+        (paged_kv_indptr, "paged_kv_indptr", (batch_size + 1,)),
+        (paged_kv_indices, "paged_kv_indices", None),
+        (seq_lens_kv, "seq_lens_kv", (batch_size,)),
+    ):
+        _validate_metadata_tensor(
+            tensor,
+            name,
+            ndim=1,
+            dtype=torch.int32,
+            expected_device=device,
+            expected_shape=shape,
+        )
+
+
 def _validate_bshd_tensor(
     tensor: torch.Tensor,
     name: str,
@@ -240,28 +209,11 @@ def _validate_bshd_tensor(
     _validate_16byte_alignment(tensor, name)
 
 
-def _resolve_effective_kv_valid_bits(
-    *,
-    kv_valid_bits: torch.Tensor | None,
-    dummy_kv_valid_bits: torch.Tensor | None,
-    use_kv_valid_bits: bool,
-    missing_dummy_message: str,
-) -> torch.Tensor:
-    """Resolve the always-present runtime mask tensor for one launch."""
-
-    if use_kv_valid_bits:
-        assert kv_valid_bits is not None
-        return kv_valid_bits
-    if dummy_kv_valid_bits is None:
-        raise RuntimeError(missing_dummy_message)
-    return dummy_kv_valid_bits
-
-
 def validate_block_sparse_run(
     q: torch.Tensor,
     kv_storage: _ContiguousKVStorage | _PagedKVStorage,
     *,
-    state: _BlockSparsePlanStateLike,
+    state: "_BlockSparsePlanState",
     block_indptr: torch.Tensor,
     block_indices: torch.Tensor,
     kv_valid_bits: torch.Tensor | None,
@@ -289,12 +241,13 @@ def validate_block_sparse_run(
         q_block_size=state.q_block_size,
         use_kv_valid_bits=state.use_kv_valid_bits,
     )
-    effective_kv_valid_bits = _resolve_effective_kv_valid_bits(
-        kv_valid_bits=kv_valid_bits,
-        dummy_kv_valid_bits=state.dummy_kv_valid_bits,
-        use_kv_valid_bits=state.use_kv_valid_bits,
-        missing_dummy_message="unmasked block-sparse plan is missing its dummy mask",
-    )
+    if state.use_kv_valid_bits:
+        assert kv_valid_bits is not None
+        effective_kv_valid_bits = kv_valid_bits
+    else:
+        effective_kv_valid_bits = state.dummy_kv_valid_bits
+        if effective_kv_valid_bits is None:
+            raise RuntimeError("unmasked block-sparse plan is missing its dummy mask")
 
     q_shape = (state.batch_size, state.seq_len_q, state.num_qo_heads, state.head_dim)
     _validate_bshd_tensor(
@@ -371,28 +324,12 @@ def validate_block_sparse_run(
             raise ValueError(
                 f"K/V dtype must match the plan ({state.kv_dtype}), got {k.dtype}"
             )
-        _validate_metadata_tensor(
+        validate_paged_kv_metadata(
             kv_storage.paged_kv_indptr,
-            "paged_kv_indptr",
-            ndim=1,
-            dtype=torch.int32,
-            expected_device=state.device,
-            expected_shape=(state.batch_size + 1,),
-        )
-        _validate_metadata_tensor(
             kv_storage.paged_kv_indices,
-            "paged_kv_indices",
-            ndim=1,
-            dtype=torch.int32,
-            expected_device=state.device,
-        )
-        _validate_metadata_tensor(
             kv_storage.seq_lens_kv,
-            "seq_lens_kv",
-            ndim=1,
-            dtype=torch.int32,
-            expected_device=state.device,
-            expected_shape=(state.batch_size,),
+            device=state.device,
+            batch_size=state.batch_size,
         )
         paged_kv = _PagedKVLaunchPayload(
             paged_kv_indptr=kv_storage.paged_kv_indptr,
@@ -470,7 +407,7 @@ def record_block_sparse_run_args(
 def launch_block_sparse(
     run_args: _BlockSparseRunArgs,
     *,
-    state: _BlockSparsePlanStateLike,
+    state: "_BlockSparsePlanState",
 ) -> torch.Tensor:
     """Invoke the exact contiguous or paged ABI chosen by validated payload."""
 
@@ -520,4 +457,5 @@ __all__ = [
     "record_block_sparse_run_args",
     "validate_block_sparse_metadata",
     "validate_block_sparse_run",
+    "validate_paged_kv_metadata",
 ]

--- a/flashinfer/attention/prims_ts/block_sparse.py
+++ b/flashinfer/attention/prims_ts/block_sparse.py
@@ -36,7 +36,9 @@ import torch
 from flashinfer.api_logging import flashinfer_api
 from flashinfer.trace.templates.attention import (
     prims_ts_block_sparse_trace,
+    prims_ts_block_sparse_wrapper_trace_dispatch,
     prims_ts_paged_block_sparse_trace_dispatch,
+    prims_ts_paged_block_sparse_wrapper_trace_dispatch,
 )
 
 from ._block_sparse.config import (
@@ -218,7 +220,7 @@ class BlockSparseTSWrapper(_BlockSparseWrapperBase):
         # previously published revision intact and runnable.
         self._plan_state = candidate
 
-    @flashinfer_api
+    @flashinfer_api(trace=prims_ts_block_sparse_wrapper_trace_dispatch)
     def run(
         self,
         q: torch.Tensor,
@@ -556,7 +558,7 @@ class BlockSparsePagedTSWrapper(_BlockSparseWrapperBase):
             )
         self._plan_state = candidate
 
-    @flashinfer_api
+    @flashinfer_api(trace=prims_ts_paged_block_sparse_wrapper_trace_dispatch)
     def run(
         self,
         q: torch.Tensor,

--- a/flashinfer/attention/prims_ts/block_sparse.py
+++ b/flashinfer/attention/prims_ts/block_sparse.py
@@ -22,8 +22,10 @@ compiled adapter on the caller's CUDA stream. The one-shot entry point retains
 synchronous canonical-BSR inspection to derive its temporary plan capacity.
 
 ``BlockSparsePagedTSWrapper`` shares the same scheduling policy and decode
-kernel, but freezes request-level page spans and sequence lengths at plan time
-while accepting physical page IDs and sparse routes at run time.
+kernel, but plans only fixed Q geometry and maximum K/V capacity. Page spans,
+physical page IDs, sequence lengths, sparse routes, and token bits are all live
+run inputs. The caller owns the live sequence-length value contract; route
+preparation validates page and sparse-route structure on device.
 """
 
 import threading
@@ -49,7 +51,6 @@ from ._block_sparse.plan import (
     _BlockSparsePlanState,
     _build_block_sparse_plan_state,
     _serialize_plan,
-    _snapshot_paged_kv_plan_metadata,
     _wait_and_record_block_sparse_plan,
 )
 from ._block_sparse.runtime import (
@@ -212,7 +213,6 @@ class BlockSparseTSWrapper(_BlockSparseWrapperBase):
                 device=device,
                 device_index=device_index,
                 plan_stream=plan_stream,
-                paged_kv=None,
             )
         # This is the only wrapper mutation. Every failure above leaves the
         # previously published revision intact and runnable.
@@ -465,7 +465,7 @@ def block_sparse_attention(
 def _validate_paged_kv_indptr_tensor(
     paged_kv_indptr: torch.Tensor,
 ) -> tuple[torch.device, int]:
-    """Validate the plan-owned page-row source without reading its values."""
+    """Validate live page-row storage without reading device-side values."""
 
     if not isinstance(paged_kv_indptr, torch.Tensor):
         raise TypeError("paged_kv_indptr must be a torch.Tensor")
@@ -485,19 +485,14 @@ def _validate_paged_kv_indptr_tensor(
 
 
 class BlockSparsePagedTSWrapper(_BlockSparseWrapperBase):
-    """Plan stable logical geometry and run with live sparse/page mappings."""
-
-    def _published_state(self) -> _BlockSparsePlanState:
-        state = super()._published_state()
-        assert state.paged_kv is not None
-        return state
+    """Plan fixed capacity and run with entirely live request metadata."""
 
     @_serialize_plan
     def plan(
         self,
-        paged_kv_indptr: torch.Tensor,
+        batch_size: int,
         seq_len_q: int,
-        seq_len_kv: int,
+        max_seq_len_kv: int,
         num_qo_heads: int,
         num_kv_heads: int,
         head_dim: int,
@@ -505,26 +500,21 @@ class BlockSparsePagedTSWrapper(_BlockSparseWrapperBase):
         kv_block_size: int,
         page_size: int,
         *,
+        device: torch.device | str | int,
         max_blocks_per_row: int,
         use_kv_valid_bits: bool,
-        seq_lens_kv: torch.Tensor | None = None,
         mask_type: Literal["dense", "causal"] = "dense",
         q_data_type: torch.dtype = torch.float16,
         kv_data_type: torch.dtype | None = None,
         o_data_type: torch.dtype | None = None,
     ) -> None:
-        """Plan fixed-Q geometry and snapshot stable page and length metadata.
+        """Plan fixed-Q geometry and a maximum variable-K capacity.
 
-        Without ``seq_lens_kv``, ``seq_len_kv`` is the exact shared K/V length.
-        With it, ``seq_len_kv`` is a static maximum and ``seq_lens_kv`` supplies
-        one length per request. Both ``paged_kv_indptr`` and ``seq_lens_kv`` are
-        copied through a D2H snapshot, validated, and republished as plan-owned
-        CUDA tensors. Changing either therefore requires a new plan.
-
-        Each page-table row needs only ``ceil(seq_lens_kv[b] / page_size)``
-        live entries; extra entries are spare capacity and are not read. Physical
-        page IDs and block-sparse routes remain runtime inputs, so graph replays
-        may remap them in place between completed replays.
+        The plan stores no request metadata. Every run supplies live page-table
+        offsets, page IDs, sequence lengths, sparse routes, and optional token
+        bits. ``max_seq_len_kv`` fixes compilation and mask capacity. Attention
+        consumes caller-owned live lengths directly, without a plan-owned copy
+        or device-to-host validation.
 
         ``q_block_size`` may be any positive signed-Int32 value satisfying
         ``q_block_size * (Hq / Hkv) % 8 == 0``. This row-purity condition keeps
@@ -533,11 +523,10 @@ class BlockSparsePagedTSWrapper(_BlockSparseWrapperBase):
         multiple of 64.
         """
 
-        source_device, batch_size = _validate_paged_kv_indptr_tensor(paged_kv_indptr)
         static = _validate_block_sparse_static_profile(
             batch_size=batch_size,
             seq_len_q=seq_len_q,
-            seq_len_kv=seq_len_kv,
+            seq_len_kv=max_seq_len_kv,
             num_qo_heads=num_qo_heads,
             num_kv_heads=num_kv_heads,
             head_dim=head_dim,
@@ -552,26 +541,18 @@ class BlockSparsePagedTSWrapper(_BlockSparseWrapperBase):
             max_blocks_per_row=max_blocks_per_row,
         )
         assert static.page_size is not None
-        device, device_index = _resolve_cuda_device(source_device)
+        device, device_index = _resolve_cuda_device(device)
         plan_stream = torch.cuda.current_stream(device)
         with torch.cuda.device(device_index), torch.cuda.stream(plan_stream):
             if torch.cuda.is_current_stream_capturing():
                 raise RuntimeError(
                     "paged block-sparse planning is unsupported during CUDA Graph capture"
                 )
-            paged_kv = _snapshot_paged_kv_plan_metadata(
-                paged_kv_indptr,
-                seq_lens_kv,
-                static=static,
-                device=device,
-                plan_stream=plan_stream,
-            )
             candidate = _build_block_sparse_plan_state(
                 static,
                 device=device,
                 device_index=device_index,
                 plan_stream=plan_stream,
-                paged_kv=paged_kv,
             )
         self._plan_state = candidate
 
@@ -580,7 +561,9 @@ class BlockSparsePagedTSWrapper(_BlockSparseWrapperBase):
         self,
         q: torch.Tensor,
         paged_kv_cache: PagedKVCache,
+        paged_kv_indptr: torch.Tensor,
         paged_kv_indices: torch.Tensor,
+        seq_lens_kv: torch.Tensor,
         block_indptr: torch.Tensor,
         block_indices: torch.Tensor,
         *,
@@ -588,24 +571,24 @@ class BlockSparsePagedTSWrapper(_BlockSparseWrapperBase):
         sm_scale: float | None = None,
         out: torch.Tensor | None = None,
     ) -> torch.Tensor:
-        """Launch with live physical page IDs and per-KV-head sparse routes.
+        """Launch with live lengths, page tables, and sparse routes.
 
         Q and O are compact ``[B, Sq, Hq, D]`` tensors, including ``Sq=1``.
         The cache is either combined ``[P, 2, Hkv, page, D]`` or a ``(K, V)``
         tuple whose members are ``[P, Hkv, page, D]`` with compact inner HND
         strides and arbitrary non-overlapping outer page strides.
 
-        ``paged_kv_indices`` is compact Int32 with the exact final extent
-        snapshotted from ``paged_kv_indptr`` by :meth:`plan`. Its page IDs,
-        ``block_indptr``, ``block_indices``, and optional token bits are read at
-        run time. Within every sparse row, BSR block IDs must be strictly
-        increasing and unique. Each selected block must start before the
-        request's frozen live K/V length (the static ``seq_len_kv`` for a
-        fixed-length plan). Because the row is sorted, preparation validates
-        this live bound from its final block. ``max_blocks_per_row`` applies to
-        the provided live row. Referenced physical page IDs must be in
-        ``[0, P)``; an invalid BSR or page ID makes its affected row fail closed
-        to finite zero without reading a K/V payload out of bounds.
+        ``paged_kv_indptr`` is compact Int32 ``[B + 1]``;
+        ``paged_kv_indices`` is compact Int32 with capacity at least its live
+        final offset; and ``seq_lens_kv`` is compact Int32 ``[B]``. All values
+        are read on device. The caller must keep every dense length in
+        ``[1, max_seq_len_kv]`` and every causal length in
+        ``[Sq, max_seq_len_kv]``. Values outside those ranges violate the live
+        metadata contract and are not guaranteed to fail closed. Given valid
+        lengths, a noncanonical page row, insufficient page capacity, a bad
+        physical page ID, or an invalid BSR row fails only the affected
+        request/row closed to finite zero. No runtime value validation
+        synchronizes or copies metadata to the host.
 
         In eager execution, ``record_stream`` extends the allocator lifetime of
         every launch tensor (Q, normalized K/V, O, BSR metadata, token bits,
@@ -625,9 +608,13 @@ class BlockSparsePagedTSWrapper(_BlockSparseWrapperBase):
             Either a combined cache ``[P, 2, Hkv, page_size, D]`` or a
             ``(K, V)`` tuple whose tensors are
             ``[P, Hkv, page_size, D]``.
+        paged_kv_indptr : torch.Tensor
+            Contiguous Int32 live request offsets with shape ``[B + 1]``.
         paged_kv_indices : torch.Tensor
-            Contiguous Int32 physical page IDs. Its length must equal the
-            final offset snapshotted from ``paged_kv_indptr`` during planning.
+            Contiguous Int32 physical-page ID capacity.
+        seq_lens_kv : torch.Tensor
+            Contiguous Int32 live logical K/V lengths with shape ``[B]``.
+            Values must satisfy the dense or causal bounds above.
         block_indptr : torch.Tensor
             Contiguous Int32 BSR row offsets with shape
             ``[B, Hkv, ceil(Sq / q_block_size) + 1]``.
@@ -636,7 +623,7 @@ class BlockSparsePagedTSWrapper(_BlockSparseWrapperBase):
             ``block_indptr``.
         kv_valid_bits : torch.Tensor, optional
             Contiguous UInt32 logical-token validity bitmap
-            ``[B, ceil(seq_len_kv / 32)]``. Supply it exactly when the plan
+            ``[B, ceil(max_seq_len_kv / 32)]``. Supply it exactly when the plan
             enabled token validity bits.
         sm_scale : float, optional
             Softmax scale. Defaults to ``1 / sqrt(D)``.
@@ -656,7 +643,9 @@ class BlockSparsePagedTSWrapper(_BlockSparseWrapperBase):
             q,
             _PagedKVStorage(
                 paged_kv_cache=paged_kv_cache,
+                paged_kv_indptr=paged_kv_indptr,
                 paged_kv_indices=paged_kv_indices,
+                seq_lens_kv=seq_lens_kv,
             ),
             state=state,
             block_indptr=block_indptr,
@@ -679,8 +668,8 @@ def block_sparse_attention_with_paged_kv_cache(
     q_block_size: int,
     kv_block_size: int,
     *,
-    seq_len_kv: int,
-    seq_lens_kv: torch.Tensor | None = None,
+    max_seq_len_kv: int,
+    seq_lens_kv: torch.Tensor,
     kv_valid_bits: torch.Tensor | None = None,
     mask_type: Literal["dense", "causal"] = "dense",
     sm_scale: float | None = None,
@@ -688,10 +677,10 @@ def block_sparse_attention_with_paged_kv_cache(
 ) -> torch.Tensor:
     """Plan and run one fixed-Q paged block-sparse attention launch.
 
-    This one-shot entry point mirrors :class:`BlockSparsePagedTSWrapper`: the
-    logical request-to-page spans come from ``paged_kv_indptr`` and optional
-    ``seq_lens_kv``, while live physical page IDs and sparse routes still come
-    from ``paged_kv_indices`` plus BSR metadata at run time.
+    This convenience entry point creates a capacity-only temporary plan and
+    forwards all request metadata through the live run API. Per-request logical
+    lengths are always explicit and must satisfy the same trusted-value contract
+    as :meth:`BlockSparsePagedTSWrapper.run`.
 
     Parameters
     ----------
@@ -717,14 +706,13 @@ def block_sparse_attention_with_paged_kv_cache(
     kv_block_size : int
         Number of logical KV tokens represented by one BSR block ID; it must
         be 8, 16, 32, or a positive multiple of 64.
-    seq_len_kv : int
-        Exact shared logical KV length, or the maximum logical length when
-        ``seq_lens_kv`` is provided.
-    seq_lens_kv : torch.Tensor, optional
+    max_seq_len_kv : int
+        Static maximum logical K/V length used for planning.
+    seq_lens_kv : torch.Tensor
         Contiguous Int32 per-request logical KV lengths with shape ``[B]``.
     kv_valid_bits : torch.Tensor, optional
         Contiguous UInt32 logical-token validity bitmap
-        ``[B, ceil(seq_len_kv / 32)]``.
+        ``[B, ceil(max_seq_len_kv / 32)]``.
     mask_type : {"dense", "causal"}, optional
         Attention mask applied inside each selected sparse block.
     sm_scale : float, optional
@@ -778,7 +766,7 @@ def block_sparse_attention_with_paged_kv_cache(
     static = _validate_block_sparse_static_profile(
         batch_size=batch_size,
         seq_len_q=seq_len_q,
-        seq_len_kv=seq_len_kv,
+        seq_len_kv=max_seq_len_kv,
         num_qo_heads=num_qo_heads,
         num_kv_heads=num_kv_heads,
         head_dim=head_dim,
@@ -802,7 +790,7 @@ def block_sparse_attention_with_paged_kv_cache(
     wrapper = BlockSparsePagedTSWrapper()
     assert static.page_size is not None
     wrapper.plan(
-        paged_kv_indptr,
+        static.batch_size,
         static.seq_len_q,
         static.seq_len_kv,
         static.num_qo_heads,
@@ -811,9 +799,9 @@ def block_sparse_attention_with_paged_kv_cache(
         static.q_block_size,
         static.kv_block_size,
         static.page_size,
+        device=metadata_device,
         max_blocks_per_row=inspection.max_row_block_count,
         use_kv_valid_bits=static.use_kv_valid_bits,
-        seq_lens_kv=seq_lens_kv,
         mask_type=static.mask_type,
         q_data_type=static.q_dtype,
         kv_data_type=static.kv_dtype,
@@ -822,7 +810,9 @@ def block_sparse_attention_with_paged_kv_cache(
     return wrapper.run(
         q,
         paged_kv_cache,
+        paged_kv_indptr,
         paged_kv_indices,
+        seq_lens_kv,
         block_indptr,
         block_indices,
         kv_valid_bits=kv_valid_bits,

--- a/flashinfer/attention/prims_ts/block_sparse.py
+++ b/flashinfer/attention/prims_ts/block_sparse.py
@@ -24,8 +24,9 @@ synchronous canonical-BSR inspection to derive its temporary plan capacity.
 ``BlockSparsePagedTSWrapper`` shares the same scheduling policy and decode
 kernel, but plans only fixed Q geometry and maximum K/V capacity. Page spans,
 physical page IDs, sequence lengths, sparse routes, and token bits are all live
-run inputs. The caller owns the live sequence-length value contract; route
-preparation validates page and sparse-route structure on device.
+run inputs. Reusable runs validate their tensor ABI but trust their values,
+while the paged one-shot API synchronously validates both before creating its
+temporary plan.
 """
 
 import threading
@@ -41,13 +42,10 @@ from flashinfer.trace.templates.attention import (
     prims_ts_paged_block_sparse_wrapper_trace_dispatch,
 )
 
-from ._block_sparse.config import (
-    _BlockSparseStaticProfile,
-    _validate_block_sparse_static_profile,
-)
+from ._block_sparse.config import _validate_block_sparse_static_profile
 from ._block_sparse.inspection import (
-    _BlockSparseInspection,
     _inspect_block_sparse_bsr,
+    _inspect_paged_block_sparse_metadata,
 )
 from ._block_sparse.plan import (
     _BlockSparsePlanState,
@@ -63,6 +61,7 @@ from ._block_sparse.runtime import (
     record_block_sparse_run_args as _record_block_sparse_run_args,
     validate_block_sparse_metadata as _validate_block_sparse_metadata,
     validate_block_sparse_run as _validate_block_sparse_run,
+    validate_paged_kv_metadata as _validate_paged_kv_metadata,
 )
 from .decode import (
     PagedKVCache,
@@ -176,10 +175,11 @@ class BlockSparseTSWrapper(_BlockSparseWrapperBase):
         explicitly.
 
         Planning does not inspect routing values and does not synchronize the
-        host. Runtime preparation validates ranges and capacity without dynamic
-        allocation. The one-shot :func:`block_sparse_attention` entry point
-        retains synchronous canonical-BSR inspection so it can derive the
-        smallest semantic row bound for that call.
+        host. Reusable runs trust those values; assertion-enabled CuTe DSL
+        builds diagnose contract violations on device. The one-shot
+        :func:`block_sparse_attention` entry point retains synchronous
+        canonical-BSR inspection so it can derive the smallest semantic row
+        bound for that call.
 
         Concurrent plans are serialized; run keeps using the published state.
         One revision has one mutable route workspace, so its runs must be
@@ -247,10 +247,10 @@ class BlockSparseTSWrapper(_BlockSparseWrapperBase):
         ``[B, Hkv, ceil(Sq / q_block_size) + 1]`` and indexes compact
         ``block_indices``. Every row must fit the planned semantic-block
         capacity; referenced block IDs must be strictly increasing, unique,
-        and in range. Runtime value violations cannot raise a synchronous host
-        exception: preparation marks only the invalid row with a negative
-        header, attention consumes it as empty, and that row's output is finite
-        zero without reading route payload. A masked plan requires
+        and in range. Reusable runs trust these device-side values. CuTe DSL
+        assertions can diagnose violations when enabled before compilation;
+        otherwise invalid values have undefined behavior and may access out of
+        bounds. A masked plan requires
         ``kv_valid_bits`` with shape
         ``[B, ceil(Skv / 32)]`` and dtype UInt32; an unmasked plan requires
         ``None``. Routing tensors may have different identities on every run.
@@ -300,41 +300,6 @@ class BlockSparseTSWrapper(_BlockSparseWrapperBase):
             out=out,
         )
         return self._launch_validated_run(state, run_args, run_stream)
-
-
-def _inspect_one_shot_block_sparse_routes(
-    block_indptr: torch.Tensor,
-    block_indices: torch.Tensor,
-    kv_valid_bits: torch.Tensor | None,
-    *,
-    static: _BlockSparseStaticProfile,
-    device: torch.device,
-) -> _BlockSparseInspection:
-    """Validate and synchronously inspect one one-shot canonical BSR pattern."""
-
-    _validate_block_sparse_metadata(
-        block_indptr,
-        block_indices,
-        kv_valid_bits,
-        device=device,
-        batch_size=static.batch_size,
-        seq_len_q=static.seq_len_q,
-        seq_len_kv=static.seq_len_kv,
-        num_kv_heads=static.num_kv_heads,
-        q_block_size=static.q_block_size,
-        use_kv_valid_bits=static.use_kv_valid_bits,
-    )
-    return _inspect_block_sparse_bsr(
-        block_indptr,
-        block_indices,
-        batch_size=static.batch_size,
-        num_kv_heads=static.num_kv_heads,
-        seq_len_q=static.seq_len_q,
-        seq_len_kv=static.seq_len_kv,
-        q_block_size=static.q_block_size,
-        kv_block_size=static.kv_block_size,
-        stream=torch.cuda.current_stream(device),
-    )
 
 
 @flashinfer_api(trace=prims_ts_block_sparse_trace)
@@ -426,12 +391,23 @@ def block_sparse_attention(
         output_dtype=q.dtype if out is None else out.dtype,
     )
     device, _ = _resolve_cuda_device(q.device)
-    inspection = _inspect_one_shot_block_sparse_routes(
+    _validate_block_sparse_metadata(
         block_indptr,
         block_indices,
         kv_valid_bits,
-        static=static,
         device=device,
+        batch_size=static.batch_size,
+        seq_len_q=static.seq_len_q,
+        seq_len_kv=static.seq_len_kv,
+        num_kv_heads=static.num_kv_heads,
+        q_block_size=static.q_block_size,
+        use_kv_valid_bits=static.use_kv_valid_bits,
+    )
+    max_blocks_per_row = _inspect_block_sparse_bsr(
+        block_indptr,
+        block_indices,
+        static=static,
+        stream=torch.cuda.current_stream(device),
     )
 
     wrapper = BlockSparseTSWrapper()
@@ -445,7 +421,7 @@ def block_sparse_attention(
         static.q_block_size,
         static.kv_block_size,
         device=device,
-        max_blocks_per_row=inspection.max_row_block_count,
+        max_blocks_per_row=max_blocks_per_row,
         use_kv_valid_bits=static.use_kv_valid_bits,
         mask_type=static.mask_type,
         q_data_type=static.q_dtype,
@@ -462,28 +438,6 @@ def block_sparse_attention(
         sm_scale=sm_scale,
         out=out,
     )
-
-
-def _validate_paged_kv_indptr_tensor(
-    paged_kv_indptr: torch.Tensor,
-) -> tuple[torch.device, int]:
-    """Validate live page-row storage without reading device-side values."""
-
-    if not isinstance(paged_kv_indptr, torch.Tensor):
-        raise TypeError("paged_kv_indptr must be a torch.Tensor")
-    if paged_kv_indptr.dtype != torch.int32:
-        raise TypeError("paged_kv_indptr must have dtype torch.int32")
-    if paged_kv_indptr.ndim != 1:
-        raise ValueError("paged_kv_indptr must be one-dimensional")
-    if paged_kv_indptr.device.type != "cuda":
-        raise ValueError("paged_kv_indptr must be a CUDA tensor")
-    if not paged_kv_indptr.is_contiguous():
-        raise ValueError("paged_kv_indptr must be contiguous")
-    if paged_kv_indptr.data_ptr() % 4 != 0:
-        raise ValueError("paged_kv_indptr data pointer must be 4-byte aligned")
-    if paged_kv_indptr.numel() < 2:
-        raise ValueError("paged_kv_indptr must describe at least one request")
-    return paged_kv_indptr.device, paged_kv_indptr.numel() - 1
 
 
 class BlockSparsePagedTSWrapper(_BlockSparseWrapperBase):
@@ -585,12 +539,17 @@ class BlockSparsePagedTSWrapper(_BlockSparseWrapperBase):
         final offset; and ``seq_lens_kv`` is compact Int32 ``[B]``. All values
         are read on device. The caller must keep every dense length in
         ``[1, max_seq_len_kv]`` and every causal length in
-        ``[Sq, max_seq_len_kv]``. Values outside those ranges violate the live
-        metadata contract and are not guaranteed to fail closed. Given valid
-        lengths, a noncanonical page row, insufficient page capacity, a bad
-        physical page ID, or an invalid BSR row fails only the affected
-        request/row closed to finite zero. No runtime value validation
-        synchronizes or copies metadata to the host.
+        ``[Sq, max_seq_len_kv]``. ``paged_kv_indptr`` must start at zero and
+        contain bounded, monotone rows with at least
+        ``ceil(seq_lens_kv[b] / page_size)`` entries. Every page ID in its live
+        prefix must lie in ``[0, P)``. Each BSR row must contain strictly
+        increasing, unique block IDs whose final block starts before that
+        request's live K/V length, and its width must not exceed the planned
+        ``max_blocks_per_row``. Reusable runs trust all of these device-side
+        values; assertion-enabled CuTe DSL builds diagnose violations
+        encountered while preparing selected routes, while default builds
+        leave invalid values undefined and may access out of bounds. No runtime
+        value validation synchronizes or copies metadata to the host.
 
         In eager execution, ``record_stream`` extends the allocator lifetime of
         every launch tensor (Q, normalized K/V, O, BSR metadata, token bits,
@@ -679,10 +638,12 @@ def block_sparse_attention_with_paged_kv_cache(
 ) -> torch.Tensor:
     """Plan and run one fixed-Q paged block-sparse attention launch.
 
-    This convenience entry point creates a capacity-only temporary plan and
-    forwards all request metadata through the live run API. Per-request logical
-    lengths are always explicit and must satisfy the same trusted-value contract
-    as :meth:`BlockSparsePagedTSWrapper.run`.
+    This convenience entry point synchronously validates live page and sparse
+    metadata, including the complete live physical-page-ID prefix, creates a
+    capacity-only temporary plan, then forwards the inspected tensors through
+    the trusted live run API. It cannot run during CUDA Graph capture; plan a
+    wrapper outside capture and capture only
+    :meth:`BlockSparsePagedTSWrapper.run` instead.
 
     Parameters
     ----------
@@ -735,23 +696,20 @@ def block_sparse_attention_with_paged_kv_cache(
     if out is not None and not isinstance(out, torch.Tensor):
         raise TypeError("out must be a torch.Tensor")
 
-    metadata_device, batch_size = _validate_paged_kv_indptr_tensor(paged_kv_indptr)
-    if metadata_device != q.device:
-        raise ValueError(
-            f"paged_kv_indptr must be on q.device {q.device}, got {metadata_device}"
-        )
-
-    batch_q, seq_len_q, num_qo_heads, head_dim = map(int, q.shape)
-    if batch_q != batch_size:
-        raise ValueError(
-            "the paged metadata batch size must equal q.shape[0]: "
-            f"expected {batch_q}, got {batch_size}"
-        )
+    batch_size, seq_len_q, num_qo_heads, head_dim = map(int, q.shape)
+    metadata_device, _ = _resolve_cuda_device(q.device)
+    _validate_paged_kv_metadata(
+        paged_kv_indptr,
+        paged_kv_indices,
+        seq_lens_kv,
+        device=metadata_device,
+        batch_size=batch_size,
+    )
 
     (
         k_cache,
         _,
-        _,
+        num_physical_kv_pages,
         num_kv_heads,
         page_size,
         runtime_head_dim,
@@ -781,12 +739,27 @@ def block_sparse_attention_with_paged_kv_cache(
         kv_dtype=k_cache.dtype,
         output_dtype=q.dtype if out is None else out.dtype,
     )
-    inspection = _inspect_one_shot_block_sparse_routes(
+    _validate_block_sparse_metadata(
         block_indptr,
         block_indices,
         kv_valid_bits,
-        static=static,
         device=metadata_device,
+        batch_size=static.batch_size,
+        seq_len_q=static.seq_len_q,
+        seq_len_kv=static.seq_len_kv,
+        num_kv_heads=static.num_kv_heads,
+        q_block_size=static.q_block_size,
+        use_kv_valid_bits=static.use_kv_valid_bits,
+    )
+    max_blocks_per_row = _inspect_paged_block_sparse_metadata(
+        block_indptr,
+        block_indices,
+        paged_kv_indptr,
+        paged_kv_indices,
+        seq_lens_kv,
+        static=static,
+        num_physical_kv_pages=num_physical_kv_pages,
+        stream=torch.cuda.current_stream(metadata_device),
     )
 
     wrapper = BlockSparsePagedTSWrapper()
@@ -802,7 +775,7 @@ def block_sparse_attention_with_paged_kv_cache(
         static.kv_block_size,
         static.page_size,
         device=metadata_device,
-        max_blocks_per_row=inspection.max_row_block_count,
+        max_blocks_per_row=max_blocks_per_row,
         use_kv_valid_bits=static.use_kv_valid_bits,
         mask_type=static.mask_type,
         q_data_type=static.q_dtype,

--- a/flashinfer/attention/prims_ts/kernels/fmha_decode/block_sparse_inspect.py
+++ b/flashinfer/attention/prims_ts/kernels/fmha_decode/block_sparse_inspect.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Validate canonical BSR and reduce its maximum semantic row width.
+"""Validate paged request metadata and canonical BSR for one-shot planning.
 
 A BSR Q-block row is one ``block_indptr`` row keyed by
 ``(batch, kv_head, q_block)``. The maximum row width gives the one-shot API the
@@ -20,9 +20,10 @@ same semantic ``max_blocks_per_row`` bound that reusable plans receive from
 their caller. Token-mask contents belong to the run-time prepare kernel and
 are not read here.
 
-Four warps validate four BSR Q-block rows per CTA and publish one validation
-status plus the maximum row width in one Int64 summary. No per-route payload
-is constructed.
+Paged inspection first validates live sequence lengths and page rows, then
+four warps validate four BSR Q-block rows per CTA. Both publish one validation
+status plus the maximum row width in one Int64 summary; no route payload is
+constructed.
 """
 
 import functools
@@ -32,6 +33,8 @@ import cutlass
 import cutlass.cute as cute
 import torch
 from cuda.bindings import driver as cuda_drv
+
+from .fmha_decode_resources.helpers_common import _warp_broadcast_i32
 
 _WARPS_PER_CTA = 4
 _WARP_SIZE = 32
@@ -47,6 +50,10 @@ _BSR_ERROR_NONE = 0
 _BSR_ERROR_NOT_STRICTLY_INCREASING = 1
 _BSR_ERROR_INDEX_OUT_OF_RANGE = 2
 _BSR_ERROR_INVALID_INDPTR = 3
+_ERROR_INVALID_SEQ_LEN = 4
+_ERROR_INVALID_PAGE_INDPTR = 5
+_ERROR_INSUFFICIENT_PAGE_CAPACITY = 6
+_ERROR_INVALID_PHYSICAL_PAGE_ID = 7
 
 
 @cute.jit
@@ -55,50 +62,119 @@ def _validate_bsr_row_lane(
     bsr_row_begin: cutlass.Int32,
     bsr_row_end: cutlass.Int32,
     lane_idx: cutlass.Int32,
-    num_kv_blocks: cutlass.Constexpr[int],
+    num_kv_blocks: cutlass.Int32,
 ) -> cutlass.Int32:
     """Validate one lane stripe of a canonical ordered BSR row."""
 
     error_code = cutlass.Int32(_BSR_ERROR_NONE)
-    selected_kv_block_count = bsr_row_end - bsr_row_begin
-    bsr_entry_offset = lane_idx
+    selected_kv_block_count = cutlass.Int64(bsr_row_end) - cutlass.Int64(bsr_row_begin)
+    bsr_entry_offset = cutlass.Int64(lane_idx)
     while bsr_entry_offset < selected_kv_block_count:
-        entry_position = bsr_row_begin + bsr_entry_offset
+        entry_position = cutlass.Int64(bsr_row_begin) + bsr_entry_offset
         block_id = cutlass.Int32(block_indices[entry_position])
         in_range = block_id >= 0 and block_id < num_kv_blocks
         if not in_range:
             error_code = cutlass.Int32(_BSR_ERROR_INDEX_OUT_OF_RANGE)
         else:
-            if entry_position > bsr_row_begin:
-                previous_block_id = cutlass.Int32(block_indices[entry_position - 1])
+            if entry_position > cutlass.Int64(bsr_row_begin):
+                previous_block_id = cutlass.Int32(
+                    block_indices[entry_position - cutlass.Int64(1)]
+                )
                 if (
                     block_id <= previous_block_id
                     and error_code < _BSR_ERROR_NOT_STRICTLY_INCREASING
                 ):
                     error_code = cutlass.Int32(_BSR_ERROR_NOT_STRICTLY_INCREASING)
-        bsr_entry_offset += _WARP_SIZE
+        bsr_entry_offset += cutlass.Int64(_WARP_SIZE)
     return error_code
 
 
+@cute.jit
+def _inspect_bsr_row(
+    block_indptr: cute.Tensor,
+    block_indices: cute.Tensor,
+    batch_idx: cutlass.Int32,
+    kv_head_idx: cutlass.Int32,
+    q_block_row_idx: cutlass.Int32,
+    lane_idx: cutlass.Int32,
+    bsr_row_is_valid: cutlass.Boolean,
+    num_kv_blocks: cutlass.Int32,
+) -> tuple[cutlass.Int32, cutlass.Int32]:
+    """Validate one BSR row against a static or live Int32 upper bound."""
+
+    bsr_row_begin = cutlass.Int32(0)
+    bsr_row_end = cutlass.Int32(0)
+    row_range_is_valid = cutlass.Int32(0)
+    if lane_idx == cutlass.Int32(0) and bsr_row_is_valid:
+        bsr_row_begin = cutlass.Int32(
+            block_indptr[batch_idx, kv_head_idx, q_block_row_idx]
+        )
+        bsr_row_end = cutlass.Int32(
+            block_indptr[batch_idx, kv_head_idx, q_block_row_idx + 1]
+        )
+        row_range_is_valid = cutlass.Int32(
+            bsr_row_begin >= cutlass.Int32(0)
+            and bsr_row_begin <= bsr_row_end
+            and bsr_row_end <= cutlass.Int32(cute.size(block_indices))
+        )
+    bsr_row_begin = _warp_broadcast_i32(bsr_row_begin, 0)
+    bsr_row_end = _warp_broadcast_i32(bsr_row_end, 0)
+    row_range_is_valid = _warp_broadcast_i32(row_range_is_valid, 0)
+
+    error_code = cutlass.Int32(_BSR_ERROR_NONE)
+    if bsr_row_is_valid:
+        if row_range_is_valid == cutlass.Int32(0):
+            error_code = cutlass.Int32(_BSR_ERROR_INVALID_INDPTR)
+        else:
+            error_code = _validate_bsr_row_lane(
+                block_indices,
+                bsr_row_begin,
+                bsr_row_end,
+                lane_idx,
+                num_kv_blocks,
+            )
+    error_code = cutlass.Int32(cute.arch.warp_redux_sync(error_code, "max"))
+    return error_code, bsr_row_end - bsr_row_begin
+
+
+@cute.jit
+def _inspect_live_paged_bsr_row(
+    block_indptr: cute.Tensor,
+    block_indices: cute.Tensor,
+    seq_lens_kv: cute.Tensor,
+    batch_idx: cutlass.Int32,
+    kv_head_idx: cutlass.Int32,
+    q_block_row_idx: cutlass.Int32,
+    lane_idx: cutlass.Int32,
+    bsr_row_is_valid: cutlass.Boolean,
+    kv_block_size: cutlass.Constexpr[int],
+) -> tuple[cutlass.Int32, cutlass.Int32]:
+    """Inspect one live BSR row against the current request sequence length."""
+
+    error_code = cutlass.Int32(_BSR_ERROR_NONE)
+    selected_kv_block_count = cutlass.Int32(0)
+    num_live_kv_blocks = cutlass.Int32(0)
+    if lane_idx == cutlass.Int32(0) and bsr_row_is_valid:
+        live_seq_len_kv = cutlass.Int32(seq_lens_kv[batch_idx])
+        num_live_kv_blocks = (live_seq_len_kv - cutlass.Int32(1)) // cutlass.Int32(
+            kv_block_size
+        ) + cutlass.Int32(1)
+    num_live_kv_blocks = _warp_broadcast_i32(num_live_kv_blocks, 0)
+    error_code, selected_kv_block_count = _inspect_bsr_row(
+        block_indptr,
+        block_indices,
+        batch_idx,
+        kv_head_idx,
+        q_block_row_idx,
+        lane_idx,
+        bsr_row_is_valid,
+        num_live_kv_blocks,
+    )
+    return error_code, selected_kv_block_count
+
+
 class _InspectBlockSparseBsr:
-    """Validate canonical BSR and reduce the facts needed by ``plan()``.
-
-    The runtime inputs are compact tensors with the following ABI:
-
-    * ``block_indptr``: Int32 ``[B, Hkv, num_q_block_rows + 1]`` offsets;
-    * ``block_indices``: Int32 ``[nnz]`` semantic KV-block IDs;
-    * ``summary``: zero-initialized Int64 ``[2]`` output.
-
-    One 128-thread CTA contains four independent warps, and each warp handles
-    one flattened ``(batch, kv_head, q_block_row)``. Lanes validate the row's
-    index stripe, then lane zero contributes its planning bound:
-
-    * ``[0]`` highest validation error code (zero means canonical BSR);
-    * ``[1]`` maximum semantic BSR-block count of any row.
-
-    No per-route metadata is produced here; the run-time prepare kernel
-    consumes the caller's BSR and current token mask before attention.
-    """
+    """Validate canonical BSR against static or live request metadata."""
 
     def __init__(
         self,
@@ -106,28 +182,33 @@ class _InspectBlockSparseBsr:
         batch_size: int,
         num_kv_heads: int,
         seq_len_q: int,
-        seq_len_kv: int,
+        seq_len_kv: int | None,
         q_block_size: int,
         kv_block_size: int,
     ) -> None:
         self.num_kv_heads = num_kv_heads
         self.num_q_block_rows = (seq_len_q + q_block_size - 1) // q_block_size
-        self.num_kv_blocks = (seq_len_kv + kv_block_size - 1) // kv_block_size
+        self.num_kv_blocks = (
+            0
+            if seq_len_kv is None
+            else (seq_len_kv + kv_block_size - 1) // kv_block_size
+        )
+        self.kv_block_size = kv_block_size
         self.total_bsr_row_count = batch_size * num_kv_heads * self.num_q_block_rows
 
     @cute.jit
-    def __call__(
+    def _launch(
         self,
         block_indptr: cute.Tensor,
         block_indices: cute.Tensor,
+        seq_lens_kv: cute.Tensor | None,
         summary: cute.Tensor,
         stream: cuda_drv.CUstream,
     ) -> None:
-        """Launch four BSR-row inspectors per CTA on ``stream``."""
-
         self.kernel(
             block_indptr,
             block_indices,
+            seq_lens_kv,
             summary,
         ).launch(
             grid=[
@@ -144,16 +225,14 @@ class _InspectBlockSparseBsr:
         self,
         block_indptr: cute.Tensor,
         block_indices: cute.Tensor,
+        seq_lens_kv: cute.Tensor | None,
         summary: cute.Tensor,
     ) -> None:
-        """Validate rows and atomically reduce their plan-time statistics."""
-
         thread_idx, _, _ = cute.arch.thread_idx()
         block_idx, _, _ = cute.arch.block_idx()
         warp_idx = thread_idx // _WARP_SIZE
         lane_idx = thread_idx % _WARP_SIZE
 
-        # Q-block row is the fastest-moving dimension, then head and batch.
         linear_bsr_row_idx = block_idx * _WARPS_PER_CTA + warp_idx
         bsr_row_is_valid = linear_bsr_row_idx < self.total_bsr_row_count
         safe_linear_bsr_row_idx = (
@@ -164,55 +243,218 @@ class _InspectBlockSparseBsr:
         kv_head_idx = linear_batch_head_idx % self.num_kv_heads
         batch_idx = linear_batch_head_idx // self.num_kv_heads
 
-        bsr_row_begin = cutlass.Int32(0)
-        bsr_row_end = cutlass.Int32(0)
-        bsr_row_range_is_valid = cutlass.Boolean(False)
-        num_indices = cutlass.Int32(cute.size(block_indices))
-        error_code = cutlass.Int32(_BSR_ERROR_NONE)
-
-        if bsr_row_is_valid:
-            bsr_row_begin = cutlass.Int32(
-                block_indptr[batch_idx, kv_head_idx, q_block_row_idx]
+        if cutlass.const_expr(seq_lens_kv is None):
+            error_code, selected_kv_block_count = _inspect_bsr_row(
+                block_indptr,
+                block_indices,
+                batch_idx,
+                kv_head_idx,
+                q_block_row_idx,
+                lane_idx,
+                bsr_row_is_valid,
+                cutlass.Int32(self.num_kv_blocks),
             )
-            bsr_row_end = cutlass.Int32(
-                block_indptr[batch_idx, kv_head_idx, q_block_row_idx + 1]
+        else:
+            error_code, selected_kv_block_count = _inspect_live_paged_bsr_row(
+                block_indptr,
+                block_indices,
+                seq_lens_kv,
+                batch_idx,
+                kv_head_idx,
+                q_block_row_idx,
+                lane_idx,
+                bsr_row_is_valid,
+                self.kv_block_size,
             )
-            bsr_row_range_is_valid = cutlass.Boolean(
-                bsr_row_begin >= 0
-                and bsr_row_begin <= bsr_row_end
-                and bsr_row_end <= num_indices
-            )
-            if not bsr_row_range_is_valid:
-                error_code = cutlass.Int32(_BSR_ERROR_INVALID_INDPTR)
-            else:
-                error_code = _validate_bsr_row_lane(
-                    block_indices,
-                    bsr_row_begin,
-                    bsr_row_end,
-                    lane_idx,
-                    self.num_kv_blocks,
-                )
 
-        # Numeric error codes encode reporting priority. Both this warp
-        # reduction and summary[0]'s atomic max retain the strongest error.
-        bsr_row_error_code = cutlass.Int32(cute.arch.warp_redux_sync(error_code, "max"))
-
-        if lane_idx == 0 and bsr_row_is_valid:
-            if bsr_row_error_code != _BSR_ERROR_NONE:
+        if lane_idx == cutlass.Int32(0) and bsr_row_is_valid:
+            if error_code != cutlass.Int32(_BSR_ERROR_NONE):
                 cute.arch.atomic_max(
                     summary.iterator + _SUMMARY_ERROR_CODE,
-                    cutlass.Int64(bsr_row_error_code),
+                    cutlass.Int64(error_code),
                     sem="relaxed",
                     scope="gpu",
                 )
             else:
-                selected_kv_block_count = bsr_row_end - bsr_row_begin
                 cute.arch.atomic_max(
                     summary.iterator + _SUMMARY_MAX_BSR_BLOCK_COUNT,
                     cutlass.Int64(selected_kv_block_count),
                     sem="relaxed",
                     scope="gpu",
                 )
+
+    @cute.jit
+    def __call__(
+        self,
+        block_indptr: cute.Tensor,
+        block_indices: cute.Tensor,
+        seq_lens_kv: cute.Tensor | None,
+        summary: cute.Tensor,
+        stream: cuda_drv.CUstream,
+    ) -> None:
+        self._launch(block_indptr, block_indices, seq_lens_kv, summary, stream)
+
+
+class _InspectPagedKvMetadata:
+    """Validate live lengths and page rows with one warp per request."""
+
+    def __init__(
+        self,
+        *,
+        batch_size: int,
+        minimum_seq_len_kv: int,
+        max_seq_len_kv: int,
+        page_size: int,
+    ) -> None:
+        self.batch_size = batch_size
+        self.minimum_seq_len_kv = minimum_seq_len_kv
+        self.max_seq_len_kv = max_seq_len_kv
+        self.page_size = page_size
+
+    @cute.jit
+    def __call__(
+        self,
+        paged_kv_indptr: cute.Tensor,
+        paged_kv_indices: cute.Tensor,
+        seq_lens_kv: cute.Tensor,
+        num_physical_kv_pages: cutlass.Int64,
+        summary: cute.Tensor,
+        stream: cuda_drv.CUstream,
+    ) -> None:
+        self.kernel(
+            paged_kv_indptr,
+            paged_kv_indices,
+            seq_lens_kv,
+            num_physical_kv_pages,
+            summary,
+        ).launch(
+            grid=[
+                (self.batch_size + _WARPS_PER_CTA - 1) // _WARPS_PER_CTA,
+                1,
+                1,
+            ],
+            block=[_THREADS_PER_CTA, 1, 1],
+            stream=stream,
+        )
+
+    @cute.kernel
+    def kernel(
+        self,
+        paged_kv_indptr: cute.Tensor,
+        paged_kv_indices: cute.Tensor,
+        seq_lens_kv: cute.Tensor,
+        num_physical_kv_pages: cutlass.Int64,
+        summary: cute.Tensor,
+    ) -> None:
+        thread_idx, _, _ = cute.arch.thread_idx()
+        block_idx, _, _ = cute.arch.block_idx()
+        warp_idx = thread_idx // _WARP_SIZE
+        lane_idx = thread_idx % _WARP_SIZE
+        batch_idx = block_idx * _WARPS_PER_CTA + warp_idx
+        request_is_valid = batch_idx < self.batch_size
+
+        request_begin = cutlass.Int32(0)
+        request_end = cutlass.Int32(0)
+        request_range_is_valid = cutlass.Int32(0)
+        error_code = cutlass.Int32(_BSR_ERROR_NONE)
+        if lane_idx == 0 and request_is_valid:
+            seq_len_kv = cutlass.Int32(seq_lens_kv[batch_idx])
+            seq_len_is_valid = cutlass.Boolean(
+                seq_len_kv >= cutlass.Int32(self.minimum_seq_len_kv)
+                and seq_len_kv <= cutlass.Int32(self.max_seq_len_kv)
+            )
+            if not seq_len_is_valid:
+                error_code = cutlass.Int32(_ERROR_INVALID_SEQ_LEN)
+
+            request_begin = cutlass.Int32(paged_kv_indptr[batch_idx])
+            request_end = cutlass.Int32(paged_kv_indptr[batch_idx + 1])
+            num_page_indices = cutlass.Int32(cute.size(paged_kv_indices))
+            request_range_is_valid = cutlass.Int32(
+                paged_kv_indptr[cutlass.Int32(0)] == cutlass.Int32(0)
+                and request_begin >= cutlass.Int32(0)
+                and request_begin <= request_end
+                and request_end <= num_page_indices
+            )
+            if request_range_is_valid == cutlass.Int32(0):
+                error_code = cutlass.Int32(_ERROR_INVALID_PAGE_INDPTR)
+            elif seq_len_is_valid:
+                required_pages = (seq_len_kv - cutlass.Int32(1)) // cutlass.Int32(
+                    self.page_size
+                ) + cutlass.Int32(1)
+                if request_end - request_begin < required_pages:
+                    error_code = cutlass.Int32(_ERROR_INSUFFICIENT_PAGE_CAPACITY)
+
+        request_begin = _warp_broadcast_i32(request_begin, 0)
+        request_end = _warp_broadcast_i32(request_end, 0)
+        request_range_is_valid = _warp_broadcast_i32(request_range_is_valid, 0)
+        if request_is_valid and request_range_is_valid != cutlass.Int32(0):
+            page_offset = cutlass.Int64(lane_idx)
+            request_page_count = cutlass.Int64(request_end) - cutlass.Int64(
+                request_begin
+            )
+            while page_offset < request_page_count:
+                page_position = cutlass.Int64(request_begin) + page_offset
+                physical_page_id = cutlass.Int32(paged_kv_indices[page_position])
+                if (
+                    physical_page_id < cutlass.Int32(0)
+                    or cutlass.Int64(physical_page_id) >= num_physical_kv_pages
+                ):
+                    error_code = cutlass.Int32(_ERROR_INVALID_PHYSICAL_PAGE_ID)
+                page_offset += cutlass.Int64(_WARP_SIZE)
+
+        error_code = cutlass.Int32(cute.arch.warp_redux_sync(error_code, "max"))
+        if (
+            lane_idx == cutlass.Int32(0)
+            and request_is_valid
+            and error_code != cutlass.Int32(_BSR_ERROR_NONE)
+        ):
+            cute.arch.atomic_max(
+                summary.iterator + _SUMMARY_ERROR_CODE,
+                cutlass.Int64(error_code),
+                sem="relaxed",
+                scope="gpu",
+            )
+
+
+class _InspectPagedBlockSparseMetadata:
+    """Launch request inspection before live-BSR inspection into one summary."""
+
+    def __init__(
+        self,
+        *,
+        inspect_requests: Callable[..., None],
+        inspect_bsr: Callable[..., None],
+    ) -> None:
+        self.inspect_requests = inspect_requests
+        self.inspect_bsr = inspect_bsr
+
+    @cute.jit
+    def __call__(
+        self,
+        block_indptr: cute.Tensor,
+        block_indices: cute.Tensor,
+        paged_kv_indptr: cute.Tensor,
+        paged_kv_indices: cute.Tensor,
+        seq_lens_kv: cute.Tensor,
+        num_physical_kv_pages: cutlass.Int64,
+        summary: cute.Tensor,
+        stream: cuda_drv.CUstream,
+    ) -> None:
+        self.inspect_requests(
+            paged_kv_indptr,
+            paged_kv_indices,
+            seq_lens_kv,
+            num_physical_kv_pages,
+            summary,
+            stream,
+        )
+        self.inspect_bsr(
+            block_indptr,
+            block_indices,
+            seq_lens_kv,
+            summary,
+            stream,
+        )
 
 
 def _fake_compact(
@@ -267,10 +509,72 @@ def compile_block_sparse_inspection(
                 alignment=4,
             ),
             _fake_compact(cutlass.Int32, (logical_nnz,), alignment=4),
+            None,
             _fake_compact(cutlass.Int64, (_SUMMARY_FIELDS,), alignment=8),
             stream,
             options=_COMPILE_OPTIONS,
         )
 
 
-__all__ = ["compile_block_sparse_inspection"]
+@functools.cache
+def compile_paged_block_sparse_metadata_inspection(
+    *,
+    device_index: int,
+    batch_size: int,
+    num_kv_heads: int,
+    seq_len_q: int,
+    minimum_seq_len_kv: int,
+    max_seq_len_kv: int,
+    q_block_size: int,
+    kv_block_size: int,
+    page_size: int,
+) -> Callable[..., None]:
+    """Compile one paged metadata entry that launches request then live-BSR."""
+
+    num_q_block_rows = (seq_len_q + q_block_size - 1) // q_block_size
+    logical_page_capacity = cute.sym_int()
+    logical_nnz = cute.sym_int()
+    stream = cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=True)
+
+    inspect_requests = _InspectPagedKvMetadata(
+        batch_size=batch_size,
+        minimum_seq_len_kv=minimum_seq_len_kv,
+        max_seq_len_kv=max_seq_len_kv,
+        page_size=page_size,
+    )
+    inspect_bsr = _InspectBlockSparseBsr(
+        batch_size=batch_size,
+        num_kv_heads=num_kv_heads,
+        seq_len_q=seq_len_q,
+        seq_len_kv=None,
+        q_block_size=q_block_size,
+        kv_block_size=kv_block_size,
+    )
+    inspect_paged_block_sparse_metadata = _InspectPagedBlockSparseMetadata(
+        inspect_requests=inspect_requests,
+        inspect_bsr=inspect_bsr,
+    )
+
+    with torch.cuda.device(device_index):
+        return cute.compile(
+            inspect_paged_block_sparse_metadata,
+            _fake_compact(
+                cutlass.Int32,
+                (batch_size, num_kv_heads, num_q_block_rows + 1),
+                alignment=4,
+            ),
+            _fake_compact(cutlass.Int32, (logical_nnz,), alignment=4),
+            _fake_compact(cutlass.Int32, (batch_size + 1,), alignment=4),
+            _fake_compact(cutlass.Int32, (logical_page_capacity,), alignment=4),
+            _fake_compact(cutlass.Int32, (batch_size,), alignment=4),
+            cutlass.Int64(1),
+            _fake_compact(cutlass.Int64, (_SUMMARY_FIELDS,), alignment=8),
+            stream,
+            options=_COMPILE_OPTIONS,
+        )
+
+
+__all__ = [
+    "compile_block_sparse_inspection",
+    "compile_paged_block_sparse_metadata_inspection",
+]

--- a/flashinfer/attention/prims_ts/kernels/fmha_decode/block_sparse_prepare.py
+++ b/flashinfer/attention/prims_ts/kernels/fmha_decode/block_sparse_prepare.py
@@ -601,10 +601,10 @@ class _PrepareBlockSparseRoutes:
         kv_route_size: int,
         has_token_bits: bool,
         page_size: int | None = None,
-        use_variable_seqlens_kv: bool = False,
+        mask_type: str,
     ) -> None:
-        if use_variable_seqlens_kv and page_size is None:
-            raise ValueError("use_variable_seqlens_kv requires page_size")
+        if mask_type not in ("dense", "causal"):
+            raise ValueError(f"unsupported mask_type: {mask_type}")
         num_q_block_rows = (seq_len_q + q_block_size - 1) // q_block_size
         num_rows = batch_size * num_kv_heads * num_q_block_rows
         layout = _BlockSparseRouteLayout.create(
@@ -625,12 +625,7 @@ class _PrepareBlockSparseRoutes:
         )
         self.route_layout = layout
         self.page_size = page_size if page_size is not None else 1
-        self.use_variable_seqlens_kv = use_variable_seqlens_kv
-        self.required_pages_per_request = (
-            (seq_len_kv + self.page_size - 1) // self.page_size
-            if layout.is_paged
-            else 0
-        )
+        self.minimum_seq_len_kv = seq_len_q if mask_type == "causal" else 1
         self.physical_page_ids_word_offset = (
             layout.physical_page_ids_word_offset if layout.is_paged else 0
         )
@@ -711,55 +706,77 @@ class _PrepareBlockSparseRoutes:
         request_page_count = cutlass.Int32(0)
         live_num_kv_valid_words = cutlass.Int32(self.cfg.num_kv_valid_words)
         if cutlass.const_expr(self.route_layout.is_paged):
-            required_pages = cutlass.Int32(self.required_pages_per_request)
+            required_pages = cutlass.Int32(0)
             request_page_range_is_valid = cutlass.Int32(0)
             row_fits_live_k = cutlass.Int32(0)
+            live_seq_len_is_valid = cutlass.Int32(0)
             if lane_idx == cutlass.Int32(0) and row_is_valid:
-                if cutlass.const_expr(self.use_variable_seqlens_kv):
-                    live_seq_len_kv = cutlass.Int32(seq_lens_kv[batch_idx])
+                raw_seq_len_kv = cutlass.Int32(seq_lens_kv[batch_idx])
+                live_seq_len_kv = cutlass.Int32(self.minimum_seq_len_kv)
+                live_seq_len_is_valid = cutlass.Int32(
+                    raw_seq_len_kv >= cutlass.Int32(self.minimum_seq_len_kv)
+                    and raw_seq_len_kv <= cutlass.Int32(self.cfg.seq_len_kv)
+                )
+                if live_seq_len_is_valid != cutlass.Int32(0):
+                    live_seq_len_kv = raw_seq_len_kv
+
+                metadata_starts_at_zero = cutlass.Boolean(
+                    paged_kv_indptr[cutlass.Int32(0)] == cutlass.Int32(0)
+                )
+                if (
+                    live_seq_len_is_valid != cutlass.Int32(0)
+                    and metadata_starts_at_zero
+                ):
                     required_pages = _positive_i32_ceil_div(
                         live_seq_len_kv,
                         self.page_size,
                     )
-                if row_is_canonical and _bsr_row_fits_live_k(
-                    block_indices,
-                    row_begin,
-                    row_end,
-                    self.cfg.kv_block_size,
-                    live_seq_len_kv,
-                ):
-                    row_fits_live_k = cutlass.Int32(1)
-                    page_indptr_size = cutlass.Int32(cute.size(paged_kv_indptr))
-                    page_indptr_entry_is_valid = cutlass.Boolean(
-                        batch_idx >= cutlass.Int32(0)
-                        and batch_idx + cutlass.Int32(1) < page_indptr_size
-                    )
-                    if page_indptr_entry_is_valid:
-                        request_begin = cutlass.Int32(paged_kv_indptr[batch_idx])
-                        request_end = cutlass.Int32(
-                            paged_kv_indptr[batch_idx + cutlass.Int32(1)]
+                    if row_is_canonical and _bsr_row_fits_live_k(
+                        block_indices,
+                        row_begin,
+                        row_end,
+                        self.cfg.kv_block_size,
+                        live_seq_len_kv,
+                    ):
+                        row_fits_live_k = cutlass.Int32(1)
+                        page_indptr_size = cutlass.Int32(cute.size(paged_kv_indptr))
+                        page_indptr_entry_is_valid = cutlass.Boolean(
+                            batch_idx >= cutlass.Int32(0)
+                            and batch_idx + cutlass.Int32(1) < page_indptr_size
                         )
-                        num_page_indices = cutlass.Int32(cute.size(paged_kv_indices))
-                        request_page_range_is_valid = cutlass.Int32(
-                            _paged_request_page_range_is_valid(
-                                request_begin,
-                                request_end,
-                                num_page_indices,
-                                required_pages,
+                        if page_indptr_entry_is_valid:
+                            request_begin = cutlass.Int32(paged_kv_indptr[batch_idx])
+                            request_end = cutlass.Int32(
+                                paged_kv_indptr[batch_idx + cutlass.Int32(1)]
                             )
-                        )
-                        if request_page_range_is_valid != cutlass.Int32(0):
-                            request_page_count = required_pages
+                            num_page_indices = cutlass.Int32(
+                                cute.size(paged_kv_indices)
+                            )
+                            request_page_range_is_valid = cutlass.Int32(
+                                _paged_request_page_range_is_valid(
+                                    request_begin,
+                                    request_end,
+                                    num_page_indices,
+                                    required_pages,
+                                )
+                            )
+                            if request_page_range_is_valid != cutlass.Int32(0):
+                                request_page_count = required_pages
             request_begin = _warp_broadcast_i32(request_begin, 0)
             live_seq_len_kv = _warp_broadcast_i32(live_seq_len_kv, 0)
             request_page_count = _warp_broadcast_i32(request_page_count, 0)
             row_fits_live_k = _warp_broadcast_i32(row_fits_live_k, 0)
+            live_seq_len_is_valid = _warp_broadcast_i32(
+                live_seq_len_is_valid,
+                0,
+            )
             request_page_range_is_valid = _warp_broadcast_i32(
                 request_page_range_is_valid,
                 0,
             )
             row_is_canonical = cutlass.Boolean(
                 row_is_canonical
+                and live_seq_len_is_valid != cutlass.Int32(0)
                 and row_fits_live_k != cutlass.Int32(0)
                 and request_page_range_is_valid != cutlass.Int32(0)
             )

--- a/flashinfer/attention/prims_ts/kernels/fmha_decode/block_sparse_prepare.py
+++ b/flashinfer/attention/prims_ts/kernels/fmha_decode/block_sparse_prepare.py
@@ -23,9 +23,8 @@ row's live routes, while four warps share a CTA.
 ``row_route_offsets`` is a separate plan-owned immutable Int32 tensor.
 ``route_workspace`` contains only mutable row counts and route metadata
 described by ``_BlockSparseRouteLayout``. Payload outside each live row
-count is intentionally stale. ``max_blocks_per_row`` is a run-time Int32
-scalar: ``-1`` disables the semantic bound, while a non-negative value keeps a
-declared BSR-block limit distinct from packed-route capacity.
+count is intentionally stale. ``max_blocks_per_row`` is the plan-declared
+semantic BSR-block limit, which remains distinct from packed-route capacity.
 """
 
 import math
@@ -34,9 +33,9 @@ from dataclasses import dataclass
 import cutlass
 import cutlass.cute as cute
 from cuda.bindings import driver as cuda_drv
+from cutlass.cute.testing import assert_ as runtime_assert
 from cutlass.experimental import primitives as prims
 
-from ..._block_sparse.common import _SIGNED_INT32_MAX
 from ..._block_sparse.prepared import (
     _PREPARED_ROUTE_IS_FULL_FLAG,
     _BlockSparseRouteLayout,
@@ -67,11 +66,8 @@ class _PreparedRouteConfig:
     route_flags_word_offset: int
     token_words_word_offset: int
     has_token_bits: bool
-    num_kv_valid_words: int
     route_metadata_stride_words: int
     route_metadata_base_word_offset: int
-    route_capacity_block_scale_num: int
-    route_capacity_block_scale_den: int
 
     @staticmethod
     def create(
@@ -86,7 +82,6 @@ class _PreparedRouteConfig:
         """Build shared prepare geometry without adding a storage-mode flag."""
 
         num_q_block_rows = (seq_len_q + q_block_size - 1) // q_block_size
-        capacity_gcd = math.gcd(layout.kv_route_size, kv_block_size)
         return _PreparedRouteConfig(
             num_kv_heads=num_kv_heads,
             num_q_block_rows=num_q_block_rows,
@@ -105,11 +100,8 @@ class _PreparedRouteConfig:
                 else 0
             ),
             has_token_bits=layout.has_token_bits,
-            num_kv_valid_words=(seq_len_kv + 31) // 32,
             route_metadata_stride_words=layout.route_metadata_stride_words,
             route_metadata_base_word_offset=layout.route_metadata_base_word_offset,
-            route_capacity_block_scale_num=layout.kv_route_size // capacity_gcd,
-            route_capacity_block_scale_den=kv_block_size // capacity_gcd,
         )
 
 
@@ -139,42 +131,19 @@ def _retained_atom_count(
         atoms_per_block = kv_block_size // atom_size
         retained_atoms = (row_nnz - cutlass.Int32(1)) * cutlass.Int32(atoms_per_block)
         last_block_idx = cutlass.Int32(block_indices[row_end - cutlass.Int32(1)])
-        num_kv_blocks = _positive_i32_ceil_div(seq_len_kv, kv_block_size)
-        retained_last_atoms = cutlass.Int32(atoms_per_block)
-        last_block_is_in_range = cutlass.Boolean(
-            last_block_idx >= cutlass.Int32(0)
-            and last_block_idx < cutlass.Int32(num_kv_blocks)
+        last_block_origin = last_block_idx * cutlass.Int32(kv_block_size)
+        remaining_tokens = cutlass.Int32(seq_len_kv) - last_block_origin
+        runtime_assert(
+            remaining_tokens > cutlass.Int32(0),
+            "block_indices row exceeds the live KV block range",
         )
-        if last_block_is_in_range:
-            last_block_origin = last_block_idx * cutlass.Int32(kv_block_size)
-            remaining_tokens = cutlass.Int32(seq_len_kv) - last_block_origin
-            retained_last_atoms = cutlass.Int32(0)
-            if remaining_tokens > cutlass.Int32(0):
-                retained_last_atoms = (
-                    remaining_tokens - cutlass.Int32(1)
-                ) // cutlass.Int32(atom_size) + cutlass.Int32(1)
-                if retained_last_atoms > cutlass.Int32(atoms_per_block):
-                    retained_last_atoms = cutlass.Int32(atoms_per_block)
+        retained_last_atoms = (remaining_tokens - cutlass.Int32(1)) // cutlass.Int32(
+            atom_size
+        ) + cutlass.Int32(1)
+        if retained_last_atoms > cutlass.Int32(atoms_per_block):
+            retained_last_atoms = cutlass.Int32(atoms_per_block)
         retained_atoms = retained_atoms + retained_last_atoms
     return retained_atoms
-
-
-@cute.jit
-def _bsr_row_fits_live_k(
-    block_indices: cute.Tensor,
-    row_begin: cutlass.Int32,
-    row_end: cutlass.Int32,
-    kv_block_size: cutlass.Constexpr[int],
-    seq_len_kv: cutlass.Int32,
-) -> cutlass.Boolean:
-    """Check a canonical sorted row's live bound from its final block."""
-
-    row_fits = cutlass.Boolean(True)
-    if row_end > row_begin:
-        last_block_idx = cutlass.Int32(block_indices[row_end - cutlass.Int32(1)])
-        last_block_origin = last_block_idx * cutlass.Int32(kv_block_size)
-        row_fits = cutlass.Boolean(last_block_origin < seq_len_kv)
-    return row_fits
 
 
 @cute.jit
@@ -199,18 +168,11 @@ def _resolve_route_logical_atom_origin(
     logical_origin = cutlass.Int32(-1)
     if valid:
         block_idx = cutlass.Int32(block_indices[row_begin + bsr_entry_offset])
-        num_kv_blocks = _positive_i32_ceil_div(seq_len_kv, kv_block_size)
-        valid = cutlass.Boolean(
-            block_idx >= cutlass.Int32(0) and block_idx < cutlass.Int32(num_kv_blocks)
-        )
+        block_origin = block_idx * cutlass.Int32(kv_block_size)
+        atom_offset = atom_in_block * cutlass.Int32(atom_size)
+        valid = cutlass.Boolean(atom_offset < cutlass.Int32(seq_len_kv) - block_origin)
         if valid:
-            block_origin = block_idx * cutlass.Int32(kv_block_size)
-            atom_offset = atom_in_block * cutlass.Int32(atom_size)
-            valid = cutlass.Boolean(
-                atom_offset < cutlass.Int32(seq_len_kv) - block_origin
-            )
-            if valid:
-                logical_origin = block_origin + atom_offset
+            logical_origin = block_origin + atom_offset
     return logical_origin, valid
 
 
@@ -227,7 +189,6 @@ def _load_coarse_token_word(
     atom_size: cutlass.Constexpr[int],
     logical_origins_per_route: cutlass.Constexpr[int],
     seq_len_kv: cutlass.Int32,
-    num_kv_valid_words: cutlass.Int32,
 ) -> cutlass.Uint32:
     """Load one logical K32 word from a coarse atom larger than K32."""
 
@@ -247,21 +208,14 @@ def _load_coarse_token_word(
         seq_len_kv,
     )
     logical_word_origin = logical_origin + word_in_atom * cutlass.Int32(32)
-    if (
-        valid
-        and logical_word_origin >= cutlass.Int32(0)
-        and logical_word_origin < cutlass.Int32(seq_len_kv)
-    ):
+    if valid and logical_word_origin < cutlass.Int32(seq_len_kv):
         valid_bits_word_idx = logical_word_origin >> cutlass.Int32(5)
-        if valid_bits_word_idx >= cutlass.Int32(
-            0
-        ) and valid_bits_word_idx < cutlass.Int32(num_kv_valid_words):
-            logical_word = cutlass.Uint32(kv_valid_bits[batch_idx, valid_bits_word_idx])
-            remaining_tokens = cutlass.Int32(seq_len_kv) - logical_word_origin
-            if remaining_tokens < cutlass.Int32(32):
-                logical_word = logical_word & (
-                    (cutlass.Uint32(1) << remaining_tokens) - cutlass.Uint32(1)
-                )
+        logical_word = cutlass.Uint32(kv_valid_bits[batch_idx, valid_bits_word_idx])
+        remaining_tokens = cutlass.Int32(seq_len_kv) - logical_word_origin
+        if remaining_tokens < cutlass.Int32(32):
+            logical_word = logical_word & (
+                (cutlass.Uint32(1) << remaining_tokens) - cutlass.Uint32(1)
+            )
     return logical_word
 
 
@@ -273,24 +227,20 @@ def _load_atom_token_chunk(
     origin_is_valid: cutlass.Boolean,
     atom_size: cutlass.Constexpr[int],
     seq_len_kv: cutlass.Int32,
-    num_kv_valid_words: cutlass.Int32,
 ) -> cutlass.Uint32:
     """Load the <=K32 mask chunk owned by one resolved-origin lane."""
 
     token_chunk = cutlass.Uint32(0)
-    if origin_is_valid and logical_origin >= cutlass.Int32(0):
+    if origin_is_valid:
         valid_bits_word_idx = logical_origin >> cutlass.Int32(5)
-        if valid_bits_word_idx >= cutlass.Int32(
-            0
-        ) and valid_bits_word_idx < cutlass.Int32(num_kv_valid_words):
-            source_word = cutlass.Uint32(kv_valid_bits[batch_idx, valid_bits_word_idx])
-            token_chunk = source_word >> (logical_origin & cutlass.Int32(31))
-            token_chunk = token_chunk & cutlass.Uint32((1 << atom_size) - 1)
-            remaining_tokens = cutlass.Int32(seq_len_kv) - logical_origin
-            if remaining_tokens < cutlass.Int32(atom_size):
-                token_chunk = token_chunk & (
-                    (cutlass.Uint32(1) << remaining_tokens) - cutlass.Uint32(1)
-                )
+        source_word = cutlass.Uint32(kv_valid_bits[batch_idx, valid_bits_word_idx])
+        token_chunk = source_word >> (logical_origin & cutlass.Int32(31))
+        token_chunk = token_chunk & cutlass.Uint32((1 << atom_size) - 1)
+        remaining_tokens = cutlass.Int32(seq_len_kv) - logical_origin
+        if remaining_tokens < cutlass.Int32(atom_size):
+            token_chunk = token_chunk & (
+                (cutlass.Uint32(1) << remaining_tokens) - cutlass.Uint32(1)
+            )
     return token_chunk
 
 
@@ -302,13 +252,12 @@ def _resolve_prepared_bsr_row(
     lane_idx: cutlass.Int32,
     row_is_valid: cutlass.Boolean,
     cfg: cutlass.Constexpr[_PreparedRouteConfig],
-) -> tuple[cutlass.Int32, cutlass.Int32, cutlass.Int32, cutlass.Boolean]:
-    """Resolve and validate one canonical runtime BSR row."""
+) -> tuple[cutlass.Int32, cutlass.Int32, cutlass.Int32]:
+    """Resolve one trusted canonical runtime BSR row."""
 
     row_begin = cutlass.Int32(0)
     row_end = cutlass.Int32(0)
     batch_idx = cutlass.Int32(0)
-    row_range_is_valid = cutlass.Int32(0)
     if lane_idx == cutlass.Int32(0) and row_is_valid:
         q_block_row_idx = linear_row_idx % cfg.num_q_block_rows
         linear_batch_head_idx = linear_row_idx // cfg.num_q_block_rows
@@ -319,18 +268,18 @@ def _resolve_prepared_bsr_row(
             block_indptr[batch_idx, kv_head_idx, q_block_row_idx + 1]
         )
         num_indices = cutlass.Int32(cute.size(block_indices))
-        row_range_is_valid = cutlass.Int32(
+        runtime_assert(
             row_begin >= cutlass.Int32(0)
             and row_begin <= row_end
-            and row_end <= num_indices
+            and row_end <= num_indices,
+            "block_indptr row must be bounded and monotone",
         )
     row_begin = _warp_broadcast_i32(row_begin, 0)
     row_end = _warp_broadcast_i32(row_end, 0)
     batch_idx = _warp_broadcast_i32(batch_idx, 0)
-    row_range_is_valid = _warp_broadcast_i32(row_range_is_valid, 0)
 
     row_error_code = cutlass.Int32(0)
-    if row_is_valid and row_range_is_valid != cutlass.Int32(0):
+    if row_is_valid:
         row_error_code = _validate_bsr_row_lane(
             block_indices,
             row_begin,
@@ -339,10 +288,12 @@ def _resolve_prepared_bsr_row(
             cfg.num_kv_blocks,
         )
     row_error_code = cutlass.Int32(cute.arch.warp_redux_sync(row_error_code, "max"))
-    row_is_canonical = cutlass.Boolean(
-        row_range_is_valid != cutlass.Int32(0) and row_error_code == cutlass.Int32(0)
-    )
-    return row_begin, row_end, batch_idx, row_is_canonical
+    if lane_idx == cutlass.Int32(0) and row_is_valid:
+        runtime_assert(
+            row_error_code == cutlass.Int32(0),
+            "block_indices row must be canonical and in range",
+        )
+    return row_begin, row_end, batch_idx
 
 
 @cute.jit
@@ -352,7 +303,6 @@ def _publish_prepared_route_count(
     route_workspace: cute.Tensor,
     row_begin: cutlass.Int32,
     row_end: cutlass.Int32,
-    row_is_canonical: cutlass.Boolean,
     linear_row_idx: cutlass.Int32,
     lane_idx: cutlass.Int32,
     row_is_valid: cutlass.Boolean,
@@ -360,58 +310,32 @@ def _publish_prepared_route_count(
     seq_len_kv: cutlass.Int32,
     cfg: cutlass.Constexpr[_PreparedRouteConfig],
 ) -> tuple[cutlass.Int32, cutlass.Int32]:
-    """Validate row capacity, publish its header, and return its live span."""
+    """Assert semantic capacity, publish the header, and return its live span."""
 
-    route_count = cutlass.Int32(0)
     row_route_begin = cutlass.Int32(0)
+    required_route_count = cutlass.Int32(0)
     if lane_idx == cutlass.Int32(0) and row_is_valid:
         row_route_begin = cutlass.Int32(row_route_offsets[linear_row_idx])
-        row_route_end = cutlass.Int32(
-            row_route_offsets[linear_row_idx + cutlass.Int32(1)]
+        selected_block_count = row_end - row_begin
+        runtime_assert(
+            selected_block_count <= max_blocks_per_row,
+            "selected BSR blocks exceed planned semantic capacity",
         )
-        row_route_capacity = row_route_end - row_route_begin
-        # An invalid row retains this negative header and emits no payload;
-        # the attention consumer clamps it to an empty row after synchronization.
-        stored_route_count = cutlass.Int32(-1)
-        if row_is_canonical:
-            selected_block_count = row_end - row_begin
-            route_block_capacity = (
-                row_route_capacity * cutlass.Int32(cfg.route_capacity_block_scale_num)
-            ) // cutlass.Int32(cfg.route_capacity_block_scale_den)
-            block_count_fits = cutlass.Boolean(
-                selected_block_count <= route_block_capacity
-                and (
-                    max_blocks_per_row < cutlass.Int32(0)
-                    or selected_block_count <= max_blocks_per_row
-                )
-            )
-            if block_count_fits:
-                retained_atom_count = _retained_atom_count(
-                    block_indices,
-                    row_begin,
-                    row_end,
-                    cfg.kv_block_size,
-                    cfg.atom_size,
-                    seq_len_kv,
-                )
-                required_route_count = (
-                    retained_atom_count
-                    + cutlass.Int32(cfg.logical_origins_per_route - 1)
-                ) // cutlass.Int32(cfg.logical_origins_per_route)
-                if required_route_count <= row_route_capacity:
-                    route_count = required_route_count
-                    stored_route_count = required_route_count
-                else:
-                    # Keep a capacity violation visible without an OOB write.
-                    stored_route_count = -required_route_count
-            else:
-                # Preserve the semantic BSR-block bound even when fine blocks
-                # pack several entries into one prepared route.
-                stored_route_count = -selected_block_count
-        route_workspace[linear_row_idx] = stored_route_count
-    route_count = _warp_broadcast_i32(route_count, 0)
+        retained_atom_count = _retained_atom_count(
+            block_indices,
+            row_begin,
+            row_end,
+            cfg.kv_block_size,
+            cfg.atom_size,
+            seq_len_kv,
+        )
+        required_route_count = (
+            retained_atom_count + cutlass.Int32(cfg.logical_origins_per_route - 1)
+        ) // cutlass.Int32(cfg.logical_origins_per_route)
+        route_workspace[linear_row_idx] = required_route_count
     row_route_begin = _warp_broadcast_i32(row_route_begin, 0)
-    return route_count, row_route_begin
+    required_route_count = _warp_broadcast_i32(required_route_count, 0)
+    return required_route_count, row_route_begin
 
 
 @cute.jit
@@ -426,17 +350,15 @@ def _store_prepared_route_validity(
     lane_idx: cutlass.Int32,
     logical_origin: cutlass.Int32,
     logical_origin_is_valid: cutlass.Boolean,
-    stored_atom_is_valid: cutlass.Boolean,
     stored_atom_is_full: cutlass.Boolean,
     route_metadata_word_index: cutlass.Int32,
     seq_len_kv: cutlass.Int32,
-    num_kv_valid_words: cutlass.Int32,
     cfg: cutlass.Constexpr[_PreparedRouteConfig],
-) -> cutlass.Int32:
+) -> None:
     """Store storage-independent atom, token, and route validity metadata."""
 
     stored_atom_valid_mask = cutlass.Int32(
-        cute.arch.vote_ballot_sync(stored_atom_is_valid)
+        cute.arch.vote_ballot_sync(logical_origin_is_valid)
     )
     structural_route_is_full = cute.arch.vote_all_sync(
         lane_idx >= cutlass.Int32(cfg.logical_origins_per_route) or stored_atom_is_full
@@ -452,7 +374,6 @@ def _store_prepared_route_validity(
                 logical_origin_is_valid,
                 cfg.atom_size,
                 seq_len_kv,
-                num_kv_valid_words,
             )
             atoms_per_word = 32 // cfg.atom_size
             if lane_idx < cutlass.Int32(cfg.logical_origins_per_route):
@@ -500,7 +421,6 @@ def _store_prepared_route_validity(
                     cfg.atom_size,
                     cfg.logical_origins_per_route,
                     seq_len_kv,
-                    num_kv_valid_words,
                 )
                 route_workspace[
                     route_metadata_word_index
@@ -526,7 +446,6 @@ def _store_prepared_route_validity(
             if route_is_full
             else cutlass.Int32(0)
         )
-    return stored_atom_valid_mask
 
 
 @cute.jit
@@ -550,40 +469,33 @@ def _paged_request_page_range_is_valid(
 def _resolve_paged_route_atom_page_id(
     paged_kv_indices: cute.Tensor,
     request_begin: cutlass.Int32,
-    request_page_count: cutlass.Int32,
     logical_origin: cutlass.Int32,
     logical_origin_is_valid: cutlass.Boolean,
+    lane_idx: cutlass.Int32,
     page_size: cutlass.Constexpr[int],
     num_physical_kv_pages: cutlass.Int64,
-) -> tuple[cutlass.Int32, cutlass.Boolean]:
-    """Resolve one selected logical atom without an out-of-range index load."""
+) -> cutlass.Int32:
+    """Resolve one trusted selected logical atom to its raw physical page ID."""
 
     physical_page_id = cutlass.Int32(-1)
-    page_id_is_valid = cutlass.Boolean(False)
-    if logical_origin_is_valid and logical_origin >= cutlass.Int32(0):
+    page_id_is_valid = cutlass.Boolean(True)
+    if logical_origin_is_valid:
         logical_page_idx = logical_origin // cutlass.Int32(page_size)
-        if (
-            logical_page_idx >= cutlass.Int32(0)
-            and logical_page_idx < request_page_count
-        ):
-            candidate_page_id = cutlass.Int64(
-                paged_kv_indices[request_begin + logical_page_idx]
-            )
-            page_id_is_valid = cutlass.Boolean(
-                candidate_page_id >= cutlass.Int64(0)
-                and candidate_page_id < num_physical_kv_pages
-                and candidate_page_id <= cutlass.Int64(_SIGNED_INT32_MAX)
-            )
-            if page_id_is_valid:
-                physical_page_id = cutlass.Int32(candidate_page_id)
-    return physical_page_id, page_id_is_valid
-
-
-@cute.jit
-def _invalid_paged_route_count(route_count: cutlass.Int32) -> cutlass.Int32:
-    """Encode a fail-closed paged row without the negative-zero ambiguity."""
-
-    return -route_count - cutlass.Int32(1)
+        candidate_page_id = cutlass.Int32(
+            paged_kv_indices[request_begin + logical_page_idx]
+        )
+        physical_page_id = candidate_page_id
+        page_id_is_valid = cutlass.Boolean(
+            candidate_page_id >= cutlass.Int32(0)
+            and cutlass.Int64(candidate_page_id) < num_physical_kv_pages
+        )
+    page_ids_are_valid = cute.arch.vote_all_sync(page_id_is_valid)
+    if lane_idx == cutlass.Int32(0):
+        runtime_assert(
+            page_ids_are_valid,
+            "paged_kv_indices contains an out-of-range physical page ID",
+        )
+    return physical_page_id
 
 
 class _PrepareBlockSparseRoutes:
@@ -692,7 +604,7 @@ class _PrepareBlockSparseRoutes:
         linear_row_idx = block_idx * _WARPS_PER_CTA + warp_idx
         row_is_valid = linear_row_idx < self.cfg.num_rows
 
-        row_begin, row_end, batch_idx, row_is_canonical = _resolve_prepared_bsr_row(
+        row_begin, row_end, batch_idx = _resolve_prepared_bsr_row(
             block_indptr,
             block_indices,
             linear_row_idx,
@@ -703,84 +615,41 @@ class _PrepareBlockSparseRoutes:
 
         request_begin = cutlass.Int32(0)
         live_seq_len_kv = cutlass.Int32(self.cfg.seq_len_kv)
-        request_page_count = cutlass.Int32(0)
-        live_num_kv_valid_words = cutlass.Int32(self.cfg.num_kv_valid_words)
         if cutlass.const_expr(self.route_layout.is_paged):
-            required_pages = cutlass.Int32(0)
-            request_page_range_is_valid = cutlass.Int32(0)
-            row_fits_live_k = cutlass.Int32(0)
-            live_seq_len_is_valid = cutlass.Int32(0)
+            raw_seq_len_kv = cutlass.Int32(self.cfg.seq_len_kv)
             if lane_idx == cutlass.Int32(0) and row_is_valid:
                 raw_seq_len_kv = cutlass.Int32(seq_lens_kv[batch_idx])
-                live_seq_len_kv = cutlass.Int32(self.minimum_seq_len_kv)
-                live_seq_len_is_valid = cutlass.Int32(
+                runtime_assert(
                     raw_seq_len_kv >= cutlass.Int32(self.minimum_seq_len_kv)
-                    and raw_seq_len_kv <= cutlass.Int32(self.cfg.seq_len_kv)
+                    and raw_seq_len_kv <= cutlass.Int32(self.cfg.seq_len_kv),
+                    "seq_lens_kv is outside the planned live-length range",
                 )
-                if live_seq_len_is_valid != cutlass.Int32(0):
-                    live_seq_len_kv = raw_seq_len_kv
+            raw_seq_len_kv = _warp_broadcast_i32(raw_seq_len_kv, 0)
+            live_seq_len_kv = raw_seq_len_kv
 
+            if lane_idx == cutlass.Int32(0) and row_is_valid:
+                required_pages = _positive_i32_ceil_div(
+                    live_seq_len_kv,
+                    self.page_size,
+                )
+                request_begin = cutlass.Int32(paged_kv_indptr[batch_idx])
+                request_end = cutlass.Int32(
+                    paged_kv_indptr[batch_idx + cutlass.Int32(1)]
+                )
                 metadata_starts_at_zero = cutlass.Boolean(
                     paged_kv_indptr[cutlass.Int32(0)] == cutlass.Int32(0)
                 )
-                if (
-                    live_seq_len_is_valid != cutlass.Int32(0)
-                    and metadata_starts_at_zero
-                ):
-                    required_pages = _positive_i32_ceil_div(
-                        live_seq_len_kv,
-                        self.page_size,
-                    )
-                    if row_is_canonical and _bsr_row_fits_live_k(
-                        block_indices,
-                        row_begin,
-                        row_end,
-                        self.cfg.kv_block_size,
-                        live_seq_len_kv,
-                    ):
-                        row_fits_live_k = cutlass.Int32(1)
-                        page_indptr_size = cutlass.Int32(cute.size(paged_kv_indptr))
-                        page_indptr_entry_is_valid = cutlass.Boolean(
-                            batch_idx >= cutlass.Int32(0)
-                            and batch_idx + cutlass.Int32(1) < page_indptr_size
-                        )
-                        if page_indptr_entry_is_valid:
-                            request_begin = cutlass.Int32(paged_kv_indptr[batch_idx])
-                            request_end = cutlass.Int32(
-                                paged_kv_indptr[batch_idx + cutlass.Int32(1)]
-                            )
-                            num_page_indices = cutlass.Int32(
-                                cute.size(paged_kv_indices)
-                            )
-                            request_page_range_is_valid = cutlass.Int32(
-                                _paged_request_page_range_is_valid(
-                                    request_begin,
-                                    request_end,
-                                    num_page_indices,
-                                    required_pages,
-                                )
-                            )
-                            if request_page_range_is_valid != cutlass.Int32(0):
-                                request_page_count = required_pages
+                runtime_assert(
+                    metadata_starts_at_zero
+                    and _paged_request_page_range_is_valid(
+                        request_begin,
+                        request_end,
+                        cutlass.Int32(cute.size(paged_kv_indices)),
+                        required_pages,
+                    ),
+                    "paged_kv_indptr row lacks the required live page capacity",
+                )
             request_begin = _warp_broadcast_i32(request_begin, 0)
-            live_seq_len_kv = _warp_broadcast_i32(live_seq_len_kv, 0)
-            request_page_count = _warp_broadcast_i32(request_page_count, 0)
-            row_fits_live_k = _warp_broadcast_i32(row_fits_live_k, 0)
-            live_seq_len_is_valid = _warp_broadcast_i32(
-                live_seq_len_is_valid,
-                0,
-            )
-            request_page_range_is_valid = _warp_broadcast_i32(
-                request_page_range_is_valid,
-                0,
-            )
-            row_is_canonical = cutlass.Boolean(
-                row_is_canonical
-                and live_seq_len_is_valid != cutlass.Int32(0)
-                and row_fits_live_k != cutlass.Int32(0)
-                and request_page_range_is_valid != cutlass.Int32(0)
-            )
-            live_num_kv_valid_words = _positive_i32_ceil_div(live_seq_len_kv, 32)
 
         route_count, row_route_begin = _publish_prepared_route_count(
             block_indices,
@@ -788,7 +657,6 @@ class _PrepareBlockSparseRoutes:
             route_workspace,
             row_begin,
             row_end,
-            row_is_canonical,
             linear_row_idx,
             lane_idx,
             row_is_valid,
@@ -806,7 +674,6 @@ class _PrepareBlockSparseRoutes:
             logical_origin = cutlass.Int32(-1)
             logical_origin_is_valid = cutlass.Boolean(False)
             physical_page_id = cutlass.Int32(-1)
-            load_origin_is_valid = cutlass.Boolean(False)
             atom_is_full = cutlass.Boolean(False)
             if lane_idx < cutlass.Int32(self.cfg.logical_origins_per_route):
                 (
@@ -823,25 +690,22 @@ class _PrepareBlockSparseRoutes:
                     self.cfg.logical_origins_per_route,
                     live_seq_len_kv,
                 )
-                load_origin_is_valid = logical_origin_is_valid
-                if cutlass.const_expr(self.route_layout.is_paged):
-                    (
-                        physical_page_id,
-                        load_origin_is_valid,
-                    ) = _resolve_paged_route_atom_page_id(
-                        paged_kv_indices,
-                        request_begin,
-                        request_page_count,
-                        logical_origin,
-                        logical_origin_is_valid,
-                        self.page_size,
-                        num_physical_kv_pages,
-                    )
-                if load_origin_is_valid:
-                    atom_is_full = cutlass.Boolean(
-                        logical_origin
-                        <= live_seq_len_kv - cutlass.Int32(self.cfg.atom_size)
-                    )
+            if cutlass.const_expr(self.route_layout.is_paged):
+                physical_page_id = _resolve_paged_route_atom_page_id(
+                    paged_kv_indices,
+                    request_begin,
+                    logical_origin,
+                    logical_origin_is_valid,
+                    lane_idx,
+                    self.page_size,
+                    num_physical_kv_pages,
+                )
+            if logical_origin_is_valid:
+                atom_is_full = cutlass.Boolean(
+                    logical_origin
+                    <= live_seq_len_kv - cutlass.Int32(self.cfg.atom_size)
+                )
+            if lane_idx < cutlass.Int32(self.cfg.logical_origins_per_route):
                 route_workspace[route_metadata_word_index + lane_idx] = logical_origin
                 if cutlass.const_expr(self.route_layout.is_paged):
                     route_workspace[
@@ -850,11 +714,7 @@ class _PrepareBlockSparseRoutes:
                         + lane_idx
                     ] = physical_page_id
 
-            if cutlass.const_expr(self.route_layout.is_paged):
-                logical_origin_valid_mask = cutlass.Int32(
-                    cute.arch.vote_ballot_sync(logical_origin_is_valid)
-                )
-            stored_atom_valid_mask = _store_prepared_route_validity(
+            _store_prepared_route_validity(
                 block_indices,
                 kv_valid_bits,
                 route_workspace,
@@ -865,20 +725,9 @@ class _PrepareBlockSparseRoutes:
                 lane_idx,
                 logical_origin,
                 logical_origin_is_valid,
-                load_origin_is_valid,
                 atom_is_full,
                 route_metadata_word_index,
                 live_seq_len_kv,
-                live_num_kv_valid_words,
                 self.cfg,
             )
-
-            if cutlass.const_expr(self.route_layout.is_paged):
-                if lane_idx == cutlass.Int32(0):
-                    # Page validity is a strict subset of logical validity. Any
-                    # mismatch means a selected atom had a bad locator.
-                    if stored_atom_valid_mask != logical_origin_valid_mask:
-                        route_workspace[linear_row_idx] = _invalid_paged_route_count(
-                            route_count
-                        )
             route_idx = route_idx + cutlass.Int32(1)

--- a/flashinfer/attention/prims_ts/kernels/fmha_decode/fmha_decode_tasks.py
+++ b/flashinfer/attention/prims_ts/kernels/fmha_decode/fmha_decode_tasks.py
@@ -653,9 +653,6 @@ def _load_prepared_sparse_row_warp(
         loaded_route_count = cutlass.Int32(row_route_counts[row_address])
     row_route_begin = _warp_broadcast_i32(loaded_row_route_begin, 0)
     route_count = _warp_broadcast_i32(loaded_route_count, 0)
-    # Prepare encodes an invalid range or capacity overflow as a negative
-    # header. Fail closed without touching that row's metadata slice.
-    route_count = cute.math.max(route_count, cutlass.Int32(0))
     return row_route_begin, route_count
 
 

--- a/flashinfer/trace/templates/attention.py
+++ b/flashinfer/trace/templates/attention.py
@@ -260,7 +260,9 @@ def _make_prims_ts_block_sparse_trace() -> TraceTemplate:
         "num_q_block_offsets": Var(
             description="Number of BSR row offsets per batch and KV head."
         ),
-        "num_block_indices": Var(description="Number of selected KV blocks."),
+        "num_block_indices": Var(
+            description="Capacity of the runtime KV-block ID tensor."
+        ),
         "num_kv_valid_words": Var(
             description="Number of optional token-validity words per batch."
         ),
@@ -281,7 +283,10 @@ def _make_prims_ts_block_sparse_trace() -> TraceTemplate:
         "block_indices": Tensor(
             ["num_block_indices"],
             dtype="int32",
-            description="Selected KV block IDs, consumed by the one-shot call.",
+            description=(
+                "Runtime KV-block ID capacity; only entries referenced by "
+                "block_indptr are live."
+            ),
         ),
         "kv_valid_bits": Tensor(
             ["batch_size", "num_kv_valid_words"],
@@ -345,7 +350,10 @@ def _make_prims_ts_paged_block_sparse_trace(*, combined: bool) -> TraceTemplate:
     contiguous = _make_prims_ts_block_sparse_trace()
     cache_form = "combined" if combined else "tuple"
     axes = dict(contiguous.axes)
-    axes["seq_len_kv"] = Var(description="Static maximum logical K/V length.")
+    del axes["seq_len_kv"]
+    axes["max_seq_len_kv"] = Var(
+        description="Static maximum logical K/V length planned for every request."
+    )
     axes.update(
         {
             "num_pages": Var(
@@ -355,7 +363,12 @@ def _make_prims_ts_paged_block_sparse_trace(*, combined: bool) -> TraceTemplate:
             "num_page_offsets": Var(
                 description="Length of the request-to-page indptr array."
             ),
-            "num_page_indices": Var(description="Number of runtime physical page IDs."),
+            "num_page_indices": Var(
+                description=(
+                    "Capacity of the runtime physical-page ID tensor; the final "
+                    "live page-table offset may be smaller."
+                )
+            ),
         }
     )
     if combined:
@@ -398,22 +411,28 @@ def _make_prims_ts_paged_block_sparse_trace(*, combined: bool) -> TraceTemplate:
             "paged_kv_indptr": Tensor(
                 ["num_page_offsets"],
                 dtype="int32",
-                description="Request offsets into paged_kv_indices.",
+                description=(
+                    "Live request offsets into paged_kv_indices, read for this call."
+                ),
             ),
             "paged_kv_indices": Tensor(
                 ["num_page_indices"],
                 dtype="int32",
-                description="Runtime physical page IDs.",
+                description=(
+                    "Runtime physical-page ID capacity; only the prefix ending at "
+                    "paged_kv_indptr[-1] is live."
+                ),
             ),
-            "seq_len_kv": Scalar(
+            "max_seq_len_kv": Scalar(
                 "int32",
-                description="Static maximum logical K/V length.",
+                description="Static maximum logical K/V length used for planning.",
             ),
             "seq_lens_kv": Tensor(
                 ["batch_size"],
                 dtype="int32",
-                optional=True,
-                description="Optional per-request logical K/V lengths.",
+                description=(
+                    "Live per-request logical K/V lengths read for this call."
+                ),
             ),
         }
     )
@@ -423,17 +442,25 @@ def _make_prims_ts_paged_block_sparse_trace(*, combined: bool) -> TraceTemplate:
         name_prefix=f"prims_ts_paged_block_sparse_{cache_form}",
         description=(
             "One-shot PrimTS block-sparse MHA/GQA/MQA attention over compact "
-            f"BSHD Q, the {cache_form} HND paged KV cache form, request page "
-            "tables, and per-KV-head BSR metadata."
+            f"fixed-length BSHD Q, the {cache_form} HND paged KV cache form, "
+            "and live request page tables, K/V lengths, and per-KV-head BSR "
+            "metadata."
         ),
         axes=axes,
         inputs=inputs,
         outputs=dict(contiguous.outputs),
         constraints=[
-            *contiguous.constraints,
+            *(
+                constraint.replace("seq_len_kv", "max_seq_len_kv")
+                for constraint in contiguous.constraints
+            ),
             "num_page_offsets == batch_size + 1",
-            "num_page_indices == paged_kv_indptr[-1].item()",
-            "seq_lens_kv is None or max(seq_lens_kv) <= seq_len_kv",
+            "paged_kv_indptr[0].item() == 0",
+            "min(paged_kv_indptr[1:] - paged_kv_indptr[:-1]) >= 0",
+            "paged_kv_indptr[-1].item() <= num_page_indices",
+            "max_seq_len_kv >= (seq_len_q if mask_type == 'causal' else 1)",
+            "min(seq_lens_kv) >= (seq_len_q if mask_type == 'causal' else 1)",
+            "max(seq_lens_kv) <= max_seq_len_kv",
             "page_size in (16, 32, 64, 128)",
             "page_size >= (kv_block_size if kv_block_size < 64 else 64)",
             "page_size % (kv_block_size if kv_block_size < 64 else 64) == 0",

--- a/flashinfer/trace/templates/attention.py
+++ b/flashinfer/trace/templates/attention.py
@@ -488,6 +488,170 @@ prims_ts_paged_block_sparse_trace_dispatch.templates = list(  # type: ignore[att
 )
 
 
+def _copy_scalar_as_optional(inputs: dict[str, Tensor | Scalar], name: str) -> None:
+    """Mark one plan-owned scalar as optional without mutating another template."""
+
+    descriptor = inputs[name]
+    assert isinstance(descriptor, Scalar)
+    inputs[name] = Scalar(
+        descriptor.dtype,
+        param=descriptor.param,
+        optional=True,
+        description=descriptor.description,
+    )
+
+
+def _copy_tensor_with_description(
+    inputs: dict[str, Tensor | Scalar], name: str, description: str
+) -> None:
+    """Replace one inherited tensor descriptor without mutating its template."""
+
+    descriptor = inputs[name]
+    assert isinstance(descriptor, Tensor)
+    inputs[name] = Tensor(
+        list(descriptor.dim_names),
+        param=descriptor.param,
+        tuple_idx=descriptor.tuple_idx,
+        dtype=descriptor.dtype,
+        dtype_from=descriptor.dtype_from,
+        optional=descriptor.optional,
+        description=description,
+    )
+
+
+def _make_block_sparse_wrapper_inputs(
+    one_shot: TraceTemplate, plan_scalars: tuple[str, ...]
+) -> dict[str, Tensor | Scalar]:
+    """Adapt one-shot inputs to the reusable wrapper lifecycle."""
+
+    inputs = dict(one_shot.inputs)
+    for name in plan_scalars:
+        _copy_scalar_as_optional(inputs, name)
+    _copy_tensor_with_description(
+        inputs,
+        "block_indptr",
+        "Absolute offsets into live block_indices for this wrapper run.",
+    )
+    _copy_tensor_with_description(
+        inputs,
+        "kv_valid_bits",
+        (
+            "Batch-only token validity bits: token t uses bit t % 32 of word "
+            "t // 32 (LSB-first); one means valid. Padding bits beyond the "
+            "planned K/V capacity are ignored."
+        ),
+    )
+    return inputs
+
+
+def _make_prims_ts_block_sparse_wrapper_trace() -> TraceTemplate:
+    """Describe ``BlockSparseTSWrapper.run`` and its plan-owned geometry."""
+
+    one_shot = _make_prims_ts_block_sparse_trace()
+    axes = dict(one_shot.axes)
+    # Unlike the one-shot API, run() does not receive these plan-owned values.
+    # Keep them as optional schema context, matching the dense PrimTS wrapper
+    # traces, rather than emitting unresolved Const axes.
+    del axes["q_block_size"], axes["kv_block_size"]
+    inputs = _make_block_sparse_wrapper_inputs(
+        one_shot, ("q_block_size", "kv_block_size", "mask_type")
+    )
+    return TraceTemplate(
+        op_type=one_shot.op_type,
+        name_prefix="prims_ts_block_sparse_wrapper",
+        description=(
+            "Reusable PrimTS block-sparse MHA/GQA/MQA attention over compact "
+            "BSHD Q/K/V and live per-KV-head BSR metadata. Block geometry and "
+            "mask type are retained by plan() and represented as optional "
+            "trace context."
+        ),
+        axes=axes,
+        inputs=inputs,
+        outputs=dict(one_shot.outputs),
+        constraints=list(one_shot.constraints),
+        tags=list(one_shot.tags),
+    )
+
+
+_PRIMS_TS_BLOCK_SPARSE_WRAPPER_TRACE = _make_prims_ts_block_sparse_wrapper_trace()
+
+
+def _require_prims_ts_block_sparse_wrapper_state(
+    kwargs: dict[str, object], wrapper_name: str
+) -> None:
+    """Require bound-method tracing after the reusable wrapper is planned."""
+
+    wrapper = kwargs.get("self")
+    if wrapper is None:
+        raise ValueError(
+            f"Tracing {wrapper_name}.run requires the live wrapper's plan state. "
+            "Use flashinfer.fi_trace(wrapper.run, ...) instead of "
+            "wrapper.run.fi_trace(...)."
+        )
+    if getattr(wrapper, "_plan_state", None) is None:
+        raise RuntimeError("plan() must be called before run()")
+
+
+def prims_ts_block_sparse_wrapper_trace_dispatch(**kwargs):
+    """Trace a planned contiguous block-sparse wrapper run."""
+
+    _require_prims_ts_block_sparse_wrapper_state(kwargs, "BlockSparseTSWrapper")
+    return _PRIMS_TS_BLOCK_SPARSE_WRAPPER_TRACE
+
+
+prims_ts_block_sparse_wrapper_trace_dispatch.templates = [  # type: ignore[attr-defined]
+    _PRIMS_TS_BLOCK_SPARSE_WRAPPER_TRACE
+]
+
+
+def _make_prims_ts_paged_block_sparse_wrapper_trace(*, combined: bool) -> TraceTemplate:
+    """Describe ``BlockSparsePagedTSWrapper.run`` for one cache form."""
+
+    one_shot = _make_prims_ts_paged_block_sparse_trace(combined=combined)
+    cache_form = "combined" if combined else "tuple"
+    axes = dict(one_shot.axes)
+    del axes["q_block_size"], axes["kv_block_size"]
+    inputs = _make_block_sparse_wrapper_inputs(
+        one_shot,
+        ("q_block_size", "kv_block_size", "max_seq_len_kv", "mask_type"),
+    )
+    return TraceTemplate(
+        op_type=one_shot.op_type,
+        name_prefix=f"prims_ts_paged_block_sparse_wrapper_{cache_form}",
+        description=(
+            "Reusable PrimTS block-sparse MHA/GQA/MQA attention over compact "
+            f"fixed-length BSHD Q, the {cache_form} HND paged KV cache form, "
+            "and live page tables, K/V lengths, and per-KV-head BSR metadata. "
+            "Static K/V capacity, block geometry, and mask type are retained "
+            "by plan() and represented as optional trace context."
+        ),
+        axes=axes,
+        inputs=inputs,
+        outputs=dict(one_shot.outputs),
+        constraints=list(one_shot.constraints),
+        tags=list(one_shot.tags),
+    )
+
+
+_PRIMS_TS_PAGED_BLOCK_SPARSE_WRAPPER_TRACES = {
+    combined: _make_prims_ts_paged_block_sparse_wrapper_trace(combined=combined)
+    for combined in (False, True)
+}
+
+
+def prims_ts_paged_block_sparse_wrapper_trace_dispatch(**kwargs):
+    """Trace a planned paged block-sparse wrapper for either cache form."""
+
+    _require_prims_ts_block_sparse_wrapper_state(kwargs, "BlockSparsePagedTSWrapper")
+    combined = isinstance(kwargs.get("paged_kv_cache"), torch.Tensor)
+    return _PRIMS_TS_PAGED_BLOCK_SPARSE_WRAPPER_TRACES[combined]
+
+
+prims_ts_paged_block_sparse_wrapper_trace_dispatch.templates = list(  # type: ignore[attr-defined]
+    _PRIMS_TS_PAGED_BLOCK_SPARSE_WRAPPER_TRACES.values()
+)
+
+
 # PrimTS decode schemas. Query storage is part of the public ABI, so fixed SQ1,
 # fixed multi-Q, and packed Q use distinct templates. In particular, a rank-3
 # query is not sufficient to identify packed mode: ``qo_indptr is not None`` is

--- a/tests/attention/test_attention_ts_block_sparse.py
+++ b/tests/attention/test_attention_ts_block_sparse.py
@@ -16,13 +16,18 @@
 
 from __future__ import annotations
 
-from contextlib import nullcontext
+from contextlib import contextmanager, nullcontext
 from dataclasses import dataclass, fields, replace
 import importlib
 import inspect
 import math
+import os
+from pathlib import Path
+import subprocess
+import sys
+import textwrap
 from types import SimpleNamespace
-from typing import get_args
+from typing import Callable, get_args
 import warnings
 
 import pytest
@@ -1009,6 +1014,121 @@ def test_public_paged_wrapper_uses_only_live_run_metadata() -> None:
     )
 
 
+def test_reusable_block_sparse_metadata_is_trusted_with_opt_in_assertions() -> None:
+    """Reusable prepare keeps assertions opt-in and has no fail-closed path."""
+
+    from flashinfer.attention.prims_ts._block_sparse import (
+        compiler as block_sparse_compiler,
+    )
+    from flashinfer.attention.prims_ts.kernels.fmha_decode import (
+        block_sparse_prepare,
+        fmha_decode_tasks,
+    )
+
+    kernel_source = inspect.getsource(
+        block_sparse_prepare._PrepareBlockSparseRoutes.kernel
+    )
+    publish_source = inspect.getsource(
+        block_sparse_prepare._publish_prepared_route_count
+    )
+    consumer_source = inspect.getsource(
+        fmha_decode_tasks._load_prepared_sparse_row_warp
+    )
+
+    assert callable(block_sparse_prepare.runtime_assert)
+    assert "--enable-assertions" not in block_sparse_compiler._COMPILE_OPTIONS
+    assert (
+        "live_seq_len_kv = cutlass.Int32(self.minimum_seq_len_kv)" not in kernel_source
+    )
+    assert "live_seq_len_kv = raw_seq_len_kv" in kernel_source
+    assert all(
+        fragment not in publish_source
+        for fragment in (
+            "stored_route_count",
+            "-required_route_count",
+            "-selected_block_count",
+        )
+    )
+    assert "cute.math.max(route_count" not in consumer_source
+
+
+@pytest.mark.skipif(
+    os.environ.get("FLASHINFER_TEST_DEVICE_ASSERT") != "1",
+    reason="fatal device assertions require explicit isolated-test opt-in",
+)
+@_REQUIRES_PRIMTS_GPU
+@pytest.mark.arch_blackwell
+def test_reusable_paged_invalid_seq_len_triggers_one_device_assert(
+    tmp_path: Path,
+) -> None:
+    """One invalid request reports once without poisoning pytest's CUDA context."""
+
+    script = textwrap.dedent(
+        """
+        import torch
+
+        from flashinfer.attention.prims_ts.block_sparse import (
+            BlockSparsePagedTSWrapper,
+        )
+
+        q = torch.empty((1, 64, 1, 128), device="cuda", dtype=torch.float16)
+        paged_kv_cache = torch.empty(
+            (1, 2, 1, 64, 128), device="cuda", dtype=torch.float16
+        )
+        paged_kv_indptr = torch.tensor([0, 1], device="cuda", dtype=torch.int32)
+        paged_kv_indices = torch.tensor([0], device="cuda", dtype=torch.int32)
+        seq_lens_kv = torch.tensor([0], device="cuda", dtype=torch.int32)
+        block_indptr = torch.tensor([[[0, 1]]], device="cuda", dtype=torch.int32)
+        block_indices = torch.tensor([0], device="cuda", dtype=torch.int32)
+
+        wrapper = BlockSparsePagedTSWrapper()
+        wrapper.plan(
+            1,
+            64,
+            128,
+            1,
+            1,
+            128,
+            64,
+            64,
+            64,
+            device=q.device,
+            max_blocks_per_row=1,
+            use_kv_valid_bits=False,
+        )
+        wrapper.run(
+            q,
+            paged_kv_cache,
+            paged_kv_indptr,
+            paged_kv_indices,
+            seq_lens_kv,
+            block_indptr,
+            block_indices,
+        )
+        torch.cuda.synchronize()
+        print("UNEXPECTED_SUCCESS", flush=True)
+        """
+    )
+    env = dict(
+        os.environ,
+        CUTE_DSL_ENABLE_ASSERTIONS="1",
+        CUTE_DSL_CACHE_DIR=os.fspath(tmp_path),
+        PYTHONPATH=os.pathsep.join(path for path in sys.path if path),
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        timeout=180,
+        env=env,
+    )
+    output = result.stdout + result.stderr
+    assertion_message = "seq_lens_kv is outside the planned live-length range"
+    assert result.returncode != 0, output
+    assert "UNEXPECTED_SUCCESS" not in output, output
+    assert output.count(assertion_message) == 1, output
+
+
 def test_block_sparse_plan_rejects_cuda_graph_capture_before_allocation(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -1118,16 +1238,12 @@ def test_one_shot_rejects_invalid_static_profile_before_inspection(
 
 def test_one_shot_inspection_publishes_only_the_semantic_row_bound() -> None:
     from flashinfer.attention.prims_ts._block_sparse.inspection import (
-        _BlockSparseInspection,
         _inspect_block_sparse_bsr,
     )
     from flashinfer.attention.prims_ts.kernels.fmha_decode.block_sparse_inspect import (
         compile_block_sparse_inspection,
     )
 
-    assert [field.name for field in fields(_BlockSparseInspection)] == [
-        "max_row_block_count"
-    ]
     assert (
         "kv_route_size" not in inspect.signature(_inspect_block_sparse_bsr).parameters
     )
@@ -3070,6 +3186,390 @@ def test_static_fallback_reselects_sparse_load_policy(
     assert policy["use_parallel_sparse_kv_loads"] is True
 
 
+@dataclass(frozen=True)
+class _PagedOneShotCase:
+    lengths: tuple[int, ...] = (64,)
+    page_ptr: tuple[int, ...] = (0, 1)
+    pages: tuple[int, ...] = (0,)
+    mask: str = "dense"
+    bsr: tuple[int, ...] = (0,)
+    bsr_ptr: object | None = None
+
+    def arguments(self) -> dict[str, object]:
+        batch = len(self.lengths)
+        bsr_ptr = self.bsr_ptr
+        if bsr_ptr is None:
+            bsr_ptr = tuple(((idx, idx + 1),) for idx in range(batch))
+        cuda_i32 = {"device": "cuda", "dtype": torch.int32}
+        return {
+            "q": torch.empty(
+                (batch, 64, 1, _HEAD_DIM),
+                device="cuda",
+                dtype=torch.float16,
+            ),
+            "paged_kv_cache": torch.empty(
+                (2, 2, 1, 64, _HEAD_DIM),
+                device="cuda",
+                dtype=torch.float16,
+            ),
+            "paged_kv_indptr": torch.tensor(self.page_ptr, **cuda_i32),
+            "paged_kv_indices": torch.tensor(self.pages, **cuda_i32),
+            "block_indptr": torch.tensor(bsr_ptr, **cuda_i32),
+            "block_indices": torch.tensor(self.bsr, **cuda_i32),
+            "q_block_size": 64,
+            "kv_block_size": 64,
+            "max_seq_len_kv": 128,
+            "seq_lens_kv": torch.tensor(self.lengths, **cuda_i32),
+            "kv_valid_bits": torch.empty((batch, 4), device="cuda", dtype=torch.uint32),
+            "mask_type": self.mask,
+        }
+
+
+class _MetadataTensorAbiOverride(torch.Tensor):
+    _violation: str
+
+    @classmethod
+    def wrap(cls, tensor: torch.Tensor, violation: str) -> torch.Tensor:
+        result = tensor.as_subclass(cls)
+        result._violation = violation
+        return result
+
+    def data_ptr(self) -> int:
+        pointer = super().data_ptr()
+        return pointer + 1 if self._violation == "alignment" else pointer
+
+    def numel(self) -> int:
+        return 1 << 31 if self._violation == "int32_extent" else super().numel()
+
+
+def _fail_if_planned(
+    monkeypatch: pytest.MonkeyPatch, wrapper_type: type[object]
+) -> None:
+    monkeypatch.setattr(
+        wrapper_type,
+        "plan",
+        lambda *_args, **_kwargs: pytest.fail("plan() must not be reached"),
+    )
+
+
+@_REQUIRES_PRIMTS_GPU
+@pytest.mark.arch_blackwell
+@pytest.mark.parametrize(
+    ("case", "message"),
+    (
+        (_PagedOneShotCase((0,)), r"seq_lens_kv.*\[1, 128\]"),
+        (_PagedOneShotCase((129,), (0, 2), (0, 1)), r"seq_lens_kv.*\[1, 128\]"),
+        (_PagedOneShotCase((63,), mask="causal"), r"seq_lens_kv.*\[64, 128\]"),
+        (
+            _PagedOneShotCase(page_ptr=(1, 2), pages=(0, 1)),
+            r"paged_kv_indptr.*start at zero",
+        ),
+        (
+            _PagedOneShotCase((64, 64), (0, 2, 1), (0, 1), bsr=(0, 0)),
+            r"paged_kv_indptr.*bounded and monotone",
+        ),
+        (
+            _PagedOneShotCase(page_ptr=(0, 2)),
+            r"paged_kv_indptr.*bounded and monotone",
+        ),
+        (_PagedOneShotCase((65,)), r"paged_kv_indptr.*enough pages.*seq_lens_kv"),
+        (_PagedOneShotCase(pages=(2,)), r"paged_kv_indices.*physical page ID"),
+        (
+            _PagedOneShotCase(page_ptr=(0, 2), pages=(0, 2)),
+            r"paged_kv_indices.*physical page ID",
+        ),
+        (
+            _PagedOneShotCase((128, 64), (0, 2, 3), (0, 1, 0), bsr=(1, 1)),
+            r"block_indptr/block_indices.*live seq_lens_kv",
+        ),
+    ),
+)
+def test_paged_one_shot_rejects_invalid_live_metadata_before_plan(
+    monkeypatch: pytest.MonkeyPatch,
+    case: _PagedOneShotCase,
+    message: str,
+) -> None:
+    _fail_if_planned(
+        monkeypatch,
+        block_sparse_module.BlockSparsePagedTSWrapper,
+    )
+    with pytest.raises(ValueError, match=message):
+        block_sparse_module.block_sparse_attention_with_paged_kv_cache(
+            **case.arguments()
+        )
+
+
+@_REQUIRES_PRIMTS_GPU
+@pytest.mark.arch_blackwell
+@pytest.mark.parametrize(
+    "case",
+    (
+        _PagedOneShotCase((1,)),
+        _PagedOneShotCase((128,), (0, 2), (1, 1)),
+        _PagedOneShotCase(pages=(0, 2), mask="causal"),
+        _PagedOneShotCase(
+            (64, 128),
+            (0, 1, 3),
+            (0, 0, 1),
+            bsr=(0, 1),
+            bsr_ptr=(((0, 1),), ((1, 2),)),
+        ),
+    ),
+    ids=(
+        "dense-min",
+        "dense-max-duplicate",
+        "causal-min-spare",
+        "batch-live-bounds",
+    ),
+)
+def test_paged_one_shot_accepts_valid_live_metadata_capacity(
+    monkeypatch: pytest.MonkeyPatch,
+    case: _PagedOneShotCase,
+) -> None:
+    calls: list[tuple[str, object]] = []
+    sentinel = object()
+
+    wrapper = block_sparse_module.BlockSparsePagedTSWrapper
+    monkeypatch.setattr(
+        wrapper,
+        "plan",
+        lambda _self, *_a, **kw: calls.append(("plan", kw["max_blocks_per_row"])),
+    )
+    monkeypatch.setattr(
+        wrapper,
+        "run",
+        lambda *_a, **_kw: calls.append(("run", None)) or sentinel,
+    )
+    if case.bsr_ptr is None:
+        case = replace(case, bsr_ptr=(((1, 2),),), bsr=(-1, 0, -1))
+    result = block_sparse_module.block_sparse_attention_with_paged_kv_cache(
+        **case.arguments()
+    )
+    assert result is sentinel
+    assert calls == [("plan", 1), ("run", None)]
+
+
+@_REQUIRES_PRIMTS_GPU
+@pytest.mark.arch_blackwell
+@pytest.mark.parametrize(
+    ("field", "violation"),
+    [
+        pytest.param(field, violation, id=f"{field}-{violation}")
+        for field in ("paged_kv_indptr", "paged_kv_indices", "seq_lens_kv")
+        for violation in (
+            "rank",
+            "dtype",
+            "device",
+            "compactness",
+            "alignment",
+            "int32_extent",
+        )
+    ]
+    + [
+        pytest.param(field, "shape", id=f"{field}-shape")
+        for field in ("paged_kv_indptr", "seq_lens_kv")
+    ],
+)
+def test_paged_one_shot_rejects_invalid_metadata_abi_before_plan(
+    monkeypatch: pytest.MonkeyPatch,
+    field: str,
+    violation: str,
+) -> None:
+    error_type = {
+        "dtype": TypeError,
+        "int32_extent": OverflowError,
+    }.get(violation, ValueError)
+    messages = {
+        "rank": f"{field} must be rank 1",
+        "dtype": f"{field} must have dtype torch.int32",
+        "device": f"{field} must be on planned device cuda",
+        "compactness": f"{field} must have compact rank-1 strides",
+        "alignment": f"{field} data pointer must be 4-byte aligned",
+        "int32_extent": rf"{field}\.numel\(\).*signed int32",
+        "shape": rf"{field} must have shape "
+        + (r"\(2,\)" if field == "paged_kv_indptr" else r"\(1,\)"),
+    }
+    _fail_if_planned(
+        monkeypatch,
+        block_sparse_module.BlockSparsePagedTSWrapper,
+    )
+    arguments = _PagedOneShotCase().arguments()
+    tensor = arguments[field]
+    assert isinstance(tensor, torch.Tensor)
+    if violation == "rank":
+        arguments[field] = tensor.unsqueeze(0)
+    elif violation == "dtype":
+        arguments[field] = tensor.to(torch.int64)
+    elif violation == "device":
+        arguments[field] = tensor.cpu()
+    elif violation == "compactness":
+        arguments[field] = torch.empty(
+            tensor.numel() * 2, dtype=tensor.dtype, device=tensor.device
+        )[::2]
+    elif violation in ("alignment", "int32_extent"):
+        arguments[field] = _MetadataTensorAbiOverride.wrap(tensor, violation)
+    elif field == "paged_kv_indptr":
+        arguments[field] = torch.tensor([0, 1, 1], dtype=torch.int32, device="cuda")
+    else:
+        arguments[field] = torch.tensor([64, 64], dtype=torch.int32, device="cuda")
+    with pytest.raises(error_type, match=messages[violation]):
+        block_sparse_module.block_sparse_attention_with_paged_kv_cache(**arguments)
+
+
+def test_paged_inspection_launches_share_one_summary(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from flashinfer.attention.prims_ts._block_sparse import inspection
+    from flashinfer.attention.prims_ts.kernels.fmha_decode import block_sparse_inspect
+
+    inspect_paged = inspection._inspect_paged_block_sparse_metadata
+
+    tolist_calls: list[None] = []
+    summary = SimpleNamespace(tolist=lambda: tolist_calls.append(None) or [0, 3])
+    stream = object()
+    active_stream: list[object] = []
+    compile_kwargs: list[dict[str, object]] = []
+    invocations: list[tuple[object, object]] = []
+
+    @contextmanager
+    def use_stream(selected: object) -> object:
+        active_stream.append(selected)
+        yield
+        active_stream.pop()
+
+    def compile_paged_block_sparse_metadata_inspection(
+        **kwargs: object,
+    ) -> Callable[..., None]:
+        compile_kwargs.append(kwargs)
+
+        def launch(*args: object) -> None:
+            invocations.append((args[-1], active_stream[-1]))
+
+        return launch
+
+    monkeypatch.setattr(
+        block_sparse_inspect,
+        "compile_paged_block_sparse_metadata_inspection",
+        compile_paged_block_sparse_metadata_inspection,
+        raising=False,
+    )
+    monkeypatch.setattr(inspection.torch, "zeros", lambda *_a, **_k: summary)
+    monkeypatch.setattr(inspection.torch.cuda, "current_device", lambda: 0)
+    monkeypatch.setattr(inspection.torch.cuda, "device", lambda _d: nullcontext())
+    monkeypatch.setattr(inspection.torch.cuda, "stream", use_stream)
+    monkeypatch.setattr(
+        inspection.torch.cuda, "is_current_stream_capturing", lambda: False
+    )
+
+    metadata = tuple(
+        torch.tensor(value, dtype=torch.int32)
+        for value in ([[[0, 1]]], [0], [0, 1], [0], [64])
+    )
+    result = inspect_paged(
+        *metadata,
+        static=SimpleNamespace(
+            batch_size=1,
+            num_kv_heads=1,
+            seq_len_q=64,
+            seq_len_kv=128,
+            q_block_size=64,
+            kv_block_size=64,
+            page_size=64,
+            mask_type="dense",
+        ),
+        num_physical_kv_pages=2,
+        stream=stream,
+    )
+    assert len(compile_kwargs) == 1
+    assert len(invocations) == 1
+    assert compile_kwargs[0]["minimum_seq_len_kv"] == 1
+    assert invocations == [(summary, stream)]
+    assert len(tolist_calls) == 1
+    assert result == 3
+
+
+def test_paged_metadata_compile_adapter_launch_order_contract() -> None:
+    from flashinfer.attention.prims_ts.kernels.fmha_decode import block_sparse_inspect
+
+    call_sequence: list[tuple[str, tuple[object, ...]]] = []
+
+    class _FakeInspector:
+        def __init__(self, name: str) -> None:
+            self.name = name
+
+        def __call__(self, *args: object) -> None:
+            call_sequence.append((self.name, args))
+
+    adapter = block_sparse_inspect._InspectPagedBlockSparseMetadata(
+        inspect_requests=_FakeInspector("request"),
+        inspect_bsr=_FakeInspector("bsr"),
+    )
+    block_indptr = object()
+    block_indices = object()
+    paged_kv_indptr = object()
+    paged_kv_indices = object()
+    seq_lens_kv = object()
+    num_physical_kv_pages = object()
+    summary = object()
+    stream = object()
+
+    block_sparse_inspect._InspectPagedBlockSparseMetadata.__call__.__wrapped__(
+        adapter,
+        block_indptr,
+        block_indices,
+        paged_kv_indptr,
+        paged_kv_indices,
+        seq_lens_kv,
+        num_physical_kv_pages,
+        summary,
+        stream,
+    )
+
+    assert [name for name, _ in call_sequence] == ["request", "bsr"]
+    _, request_args = call_sequence[0]
+    _, bsr_args = call_sequence[1]
+    assert request_args == (
+        paged_kv_indptr,
+        paged_kv_indices,
+        seq_lens_kv,
+        num_physical_kv_pages,
+        summary,
+        stream,
+    )
+    assert bsr_args == (
+        block_indptr,
+        block_indices,
+        seq_lens_kv,
+        summary,
+        stream,
+    )
+    assert request_args[-2] is summary
+    assert request_args[-1] is stream
+    assert bsr_args[-2] is summary
+    assert bsr_args[-1] is stream
+    assert request_args[-2] is bsr_args[-2]
+    assert request_args[-1] is bsr_args[-1]
+
+
+def test_metadata_inspection_scan_positions_use_int64() -> None:
+    from flashinfer.attention.prims_ts.kernels.fmha_decode import block_sparse_inspect
+
+    contracts = (
+        (
+            block_sparse_inspect._validate_bsr_row_lane,
+            ("selected_kv_block_count", "bsr_entry_offset", "entry_position"),
+        ),
+        (
+            block_sparse_inspect._InspectPagedKvMetadata.kernel,
+            ("request_page_count", "page_offset", "page_position"),
+        ),
+    )
+    for target, names in contracts:
+        source = inspect.getsource(target)
+        assert all(f"{name} = cutlass.Int64(" in source for name in names)
+        assert "+= cutlass.Int64(_WARP_SIZE)" in source
+
+
 @_REQUIRES_PRIMTS_GPU
 @pytest.mark.arch_blackwell
 @pytest.mark.parametrize(
@@ -3086,10 +3586,15 @@ def test_static_fallback_reselects_sparse_load_policy(
     ),
 )
 def test_one_shot_rejects_noncanonical_bsr(
+    monkeypatch: pytest.MonkeyPatch,
     indptr: list[list[list[int]]],
     indices: tuple[int, ...],
     message: str,
 ) -> None:
+    _fail_if_planned(
+        monkeypatch,
+        block_sparse_module.BlockSparseTSWrapper,
+    )
     block_indptr = torch.tensor(indptr, device="cuda", dtype=torch.int32)
     block_indices = torch.tensor(indices, device="cuda", dtype=torch.int32)
     q = torch.empty((1, 64, 1, _HEAD_DIM), device="cuda", dtype=torch.float16)
@@ -3105,110 +3610,6 @@ def test_one_shot_rejects_noncanonical_bsr(
             64,
             64,
         )
-
-
-@_REQUIRES_PRIMTS_GPU
-@pytest.mark.arch_blackwell
-@torch.no_grad()
-def test_block_capacity_is_not_weakened_by_route_packing() -> None:
-    """Runtime preparation enforces the semantic block bound before packing."""
-
-    block_indptr = torch.tensor([[[0, 2]]], device="cuda", dtype=torch.int32)
-    block_indices = torch.tensor([0, 1], device="cuda", dtype=torch.int32)
-    # A prepared route may pack multiple B64 semantic blocks. Reserve the
-    # second index slot, then prove that replay still enforces max_blocks=1.
-    block_indptr.copy_(torch.tensor([[[0, 1]]], device="cuda", dtype=torch.int32))
-    block_indices[1] = -1
-    valid_bits = torch.full(
-        (1, 4),
-        0xFFFFFFFF,
-        device="cuda",
-        dtype=torch.uint32,
-    )
-    wrapper = block_sparse_module.BlockSparseTSWrapper()
-    _plan(
-        wrapper,
-        block_indptr,
-        block_indices,
-        kv_valid_bits=valid_bits,
-        max_blocks_per_row=1,
-    )
-    q = torch.randn((1, 64, 1, _HEAD_DIM), device="cuda", dtype=torch.float16)
-    k = torch.randn((1, 128, 1, _HEAD_DIM), device="cuda", dtype=torch.float16)
-    v = torch.randn_like(k)
-    block_indices.copy_(torch.tensor([0, 1], device="cuda", dtype=torch.int32))
-    block_indptr.copy_(torch.tensor([[[0, 2]]], device="cuda", dtype=torch.int32))
-
-    overflow = wrapper.run(
-        q,
-        k,
-        v,
-        block_indptr,
-        block_indices,
-        kv_valid_bits=valid_bits,
-    )
-    torch.cuda.synchronize()
-
-    state = wrapper._published_state()
-    assert state.route_workspace[0].item() < 0
-    assert torch.count_nonzero(overflow).item() == 0
-
-    # Contract-invalid live IDs must still fail safely before address
-    # arithmetic; in particular, the token-mask path must not read word -1.
-    block_indices[0] = -1
-    block_indptr.copy_(torch.tensor([[[0, 1]]], device="cuda", dtype=torch.int32))
-    invalid_index = wrapper.run(
-        q,
-        k,
-        v,
-        block_indptr,
-        block_indices,
-        kv_valid_bits=valid_bits,
-    )
-    torch.cuda.synchronize()
-    assert torch.count_nonzero(invalid_index).item() == 0
-
-
-@_REQUIRES_PRIMTS_GPU
-@pytest.mark.arch_blackwell
-@pytest.mark.parametrize(
-    "indices",
-    (
-        pytest.param((0, 0), id="duplicate"),
-        pytest.param((2, 1), id="unsorted"),
-        pytest.param((0, 4, 2), id="mixed-valid-out-of-range"),
-    ),
-)
-@torch.no_grad()
-def test_runtime_routes_fail_closed_for_noncanonical_row(
-    indices: tuple[int, ...],
-) -> None:
-    """Prepare rejects the whole row before retaining any partial route."""
-
-    block_indptr = torch.tensor(
-        [[[0, len(indices)]]],
-        device="cuda",
-        dtype=torch.int32,
-    )
-    block_indices = torch.tensor(indices, device="cuda", dtype=torch.int32)
-    wrapper = block_sparse_module.BlockSparseTSWrapper()
-    _plan(
-        wrapper,
-        block_indptr,
-        block_indices,
-        seq_len_kv=256,
-        max_blocks_per_row=3,
-    )
-    q = torch.zeros((1, 64, 1, _HEAD_DIM), device="cuda", dtype=torch.float16)
-    k = torch.zeros((1, 256, 1, _HEAD_DIM), device="cuda", dtype=torch.float16)
-    v = torch.ones_like(k)
-
-    out = wrapper.run(q, k, v, block_indptr, block_indices)
-    torch.cuda.synchronize()
-
-    state = wrapper._published_state()
-    assert state.route_workspace[0].item() < 0
-    assert torch.count_nonzero(out).item() == 0
 
 
 @_REQUIRES_PRIMTS_GPU
@@ -3928,17 +4329,6 @@ def test_runtime_routes_repartition_rows_with_declared_capacity() -> None:
     torch.testing.assert_close(initial, initial_expected, rtol=1e-2, atol=1e-2)
     torch.testing.assert_close(replay, replay_expected, rtol=1e-2, atol=1e-2)
 
-    # Exceeding the declared envelope is still a caller error, but prepare
-    # fails closed instead of overwriting the following row's route slice.
-    block_indices[:4].copy_(
-        torch.tensor([0, 1, 2, 3], device="cuda", dtype=torch.int32)
-    )
-    block_indptr.copy_(torch.tensor([[[0, 4, 4]]], device="cuda", dtype=torch.int32))
-    overflow = wrapper.run(q, k, v, block_indptr, block_indices, sm_scale=sm_scale)
-    torch.cuda.synchronize()
-    assert state.route_workspace[0].item() == -4
-    assert torch.count_nonzero(overflow).item() == 0
-
 
 @_REQUIRES_PRIMTS_GPU
 @pytest.mark.arch_blackwell
@@ -4220,7 +4610,7 @@ def test_public_paged_gqa_graph_reloads_routes_and_pages(
     expected_kv_tile: int,
     dtype: torch.dtype,
 ) -> None:
-    """Public KV128/KV256 plans reload routes/pages and fail bad rows closed."""
+    """Public KV128/KV256 plans reload valid routes and pages."""
 
     torch.manual_seed(20260814)
     case = _Case(
@@ -4255,18 +4645,6 @@ def test_public_paged_gqa_graph_reloads_routes_and_pages(
             ((0,),),
         ),
     )
-    patterns_invalid = (
-        (
-            ((second_page_block,),),
-            ((0,),),
-        ),
-    )
-    patterns_fail_closed = (
-        (
-            ((),),
-            ((0,),),
-        ),
-    )
 
     def padded_bsr(patterns: object) -> tuple[torch.Tensor, torch.Tensor]:
         indptr, indices = _make_bsr(patterns)
@@ -4276,10 +4654,8 @@ def test_public_paged_gqa_graph_reloads_routes_and_pages(
 
     indptr_a, indices_a = padded_bsr(patterns_a)
     indptr_b, indices_b = padded_bsr(patterns_b)
-    indptr_invalid, indices_invalid = padded_bsr(patterns_invalid)
     page_ids_a = torch.tensor([0, 1], device="cuda", dtype=torch.int32)
     page_ids_b = torch.tensor([2, 3], device="cuda", dtype=torch.int32)
-    page_ids_invalid = torch.tensor([2, 4], device="cuda", dtype=torch.int32)
 
     q = torch.randn((1, 8, 16, _HEAD_DIM), device="cuda", dtype=case.dtype) * 0.25
     k_pages = (
@@ -4329,18 +4705,8 @@ def test_public_paged_gqa_graph_reloads_routes_and_pages(
     all_tokens = (frozenset(range(case.seq_len_kv)),)
     k_a, v_a = logical_kv((0, 1))
     k_b, v_b = logical_kv((2, 3))
-    k_fail_closed, v_fail_closed = logical_kv((2, 0))
     expected_a = _reference(case, q, k_a, v_a, patterns_a, all_tokens, sm_scale)
     expected_b = _reference(case, q, k_b, v_b, patterns_b, all_tokens, sm_scale)
-    expected_fail_closed = _reference(
-        case,
-        q,
-        k_fail_closed,
-        v_fail_closed,
-        patterns_fail_closed,
-        all_tokens,
-        sm_scale,
-    )
     assert not torch.allclose(
         expected_a.float(), expected_b.float(), rtol=1e-3, atol=1e-3
     )
@@ -4424,20 +4790,6 @@ def test_public_paged_gqa_graph_reloads_routes_and_pages(
     replay()
     assert torch.isfinite(graph_out).all()
     torch.testing.assert_close(graph_out, expected_b, rtol=1e-2, atol=1e-2)
-
-    block_indptr.copy_(indptr_invalid)
-    block_indices.copy_(indices_invalid)
-    paged_kv_indices.copy_(page_ids_invalid)
-    replay()
-    assert torch.isfinite(graph_out).all()
-    assert torch.count_nonzero(graph_out[:, :, :8]).item() == 0
-    assert torch.count_nonzero(graph_out[:, :, 8:]).item() > 0
-    torch.testing.assert_close(
-        graph_out,
-        expected_fail_closed,
-        rtol=1e-2,
-        atol=1e-2,
-    )
     assert wrapper._published_state() is planned_state
 
 
@@ -4731,58 +5083,5 @@ def test_public_paged_varlen_gqa_q64_kv256_graph_reloads_live_pages_bits_and_spa
     kv_valid_bits.copy_(kv_valid_bits_b)
     replay()
     assert torch.isfinite(graph_out).all()
-    torch.testing.assert_close(graph_out, expected_b, rtol=1e-2, atol=1e-2)
-
-    def assert_batch0_fails_closed() -> None:
-        replay()
-        assert torch.isfinite(graph_out).all()
-        assert torch.count_nonzero(graph_out[0]).item() == 0
-        torch.testing.assert_close(
-            graph_out[1:],
-            expected_b[1:],
-            rtol=1e-2,
-            atol=1e-2,
-        )
-
-    invalid_page_ids = page_ids_b.clone()
-    invalid_page_ids[0] = num_physical_pages
-    paged_kv_indices.copy_(invalid_page_ids)
-    replay()
-    assert torch.isfinite(graph_out).all()
-    assert torch.count_nonzero(graph_out[0, :, :8]).item() == 0
-    torch.testing.assert_close(
-        graph_out[0, :, 8:],
-        expected_b[0, :, 8:],
-        rtol=1e-2,
-        atol=1e-2,
-    )
-    torch.testing.assert_close(graph_out[1:], expected_b[1:], rtol=1e-2, atol=1e-2)
-
-    paged_kv_indices.copy_(page_ids_b)
-    paged_kv_indptr.copy_(torch.tensor([0, 1, 3], device="cuda", dtype=torch.int32))
-    paged_kv_indices.copy_(torch.tensor([1, 2, 5, 4], device="cuda", dtype=torch.int32))
-    assert_batch0_fails_closed()
-
-    paged_kv_indptr.copy_(torch.tensor([1, 3, 4], device="cuda", dtype=torch.int32))
-    paged_kv_indices.copy_(page_ids_b)
-    replay()
-    assert torch.count_nonzero(graph_out).item() == 0
-
-    paged_kv_indptr.copy_(torch.tensor([0, 3, 2], device="cuda", dtype=torch.int32))
-    replay()
-    assert torch.isfinite(graph_out).all()
-    torch.testing.assert_close(graph_out[:1], expected_b[:1], rtol=1e-2, atol=1e-2)
-    assert torch.count_nonzero(graph_out[1]).item() == 0
-
-    paged_kv_indptr.copy_(torch.tensor([0, 3, 5], device="cuda", dtype=torch.int32))
-    replay()
-    assert torch.isfinite(graph_out).all()
-    torch.testing.assert_close(graph_out[:1], expected_b[:1], rtol=1e-2, atol=1e-2)
-    assert torch.count_nonzero(graph_out[1]).item() == 0
-
-    paged_kv_indptr.copy_(paged_kv_indptr_b)
-    paged_kv_indices.copy_(page_ids_b)
-    seq_lens_kv.copy_(seq_lens_b)
-    replay()
     torch.testing.assert_close(graph_out, expected_b, rtol=1e-2, atol=1e-2)
     assert wrapper._published_state() is planned_state

--- a/tests/attention/test_attention_ts_block_sparse.py
+++ b/tests/attention/test_attention_ts_block_sparse.py
@@ -818,6 +818,114 @@ def test_block_sparse_wrapper_routes_are_run_inputs() -> None:
     assert "num_heads" not in state_fields
 
 
+def test_block_sparse_contiguous_wrapper_trace_uses_bound_plan_state() -> None:
+    """Trace a reusable contiguous run while keeping plan geometry optional."""
+
+    from flashinfer.fi_trace import fi_trace
+
+    wrapper = block_sparse_module.BlockSparseTSWrapper()
+    q = torch.empty((2, 64, 8, 128), dtype=torch.float16)
+    k = torch.empty((2, 256, 4, 128), dtype=torch.float16)
+    v = torch.empty_like(k)
+    kwargs = {
+        "q": q,
+        "k": k,
+        "v": v,
+        "block_indptr": torch.empty((2, 4, 2), dtype=torch.int32),
+        "block_indices": torch.empty((16,), dtype=torch.int32),
+    }
+
+    with pytest.raises(
+        ValueError,
+        match=r"requires the live wrapper's plan state.*flashinfer\.fi_trace",
+    ):
+        wrapper.run.fi_trace(**kwargs)
+    with pytest.raises(RuntimeError, match=r"plan\(\) must be called before run\(\)"):
+        fi_trace(wrapper.run, **kwargs)
+
+    # A successful plan atomically publishes this state. Its contents are not
+    # needed to select the single contiguous schema, so avoid a CUDA plan here.
+    wrapper._plan_state = SimpleNamespace()
+    defn = fi_trace(wrapper.run, **kwargs)
+    assert defn["name"].startswith("prims_ts_block_sparse_wrapper")
+    assert defn["inputs"]["q"]["shape"] == [
+        "batch_size",
+        "seq_len_q",
+        "num_qo_heads",
+        "head_dim",
+    ]
+    assert defn["inputs"]["k"]["shape"] == [
+        "batch_size",
+        "seq_len_kv",
+        "num_kv_heads",
+        "head_dim",
+    ]
+    for name in ("q_block_size", "kv_block_size", "mask_type"):
+        assert defn["inputs"][name]["optional"] is True
+    assert defn["inputs"]["block_indptr"].get("optional") is not True
+
+
+def test_block_sparse_paged_wrapper_trace_uses_bound_plan_state() -> None:
+    """Trace both public paged-cache forms with live run metadata."""
+
+    from flashinfer.fi_trace import fi_trace
+
+    wrapper = block_sparse_module.BlockSparsePagedTSWrapper()
+    q = torch.empty((2, 4, 8, 128), dtype=torch.bfloat16)
+    k_cache = torch.empty((8, 4, 64, 128), dtype=torch.bfloat16)
+    v_cache = torch.empty_like(k_cache)
+    common_kwargs = {
+        "q": q,
+        "paged_kv_indptr": torch.empty((3,), dtype=torch.int32),
+        "paged_kv_indices": torch.empty((8,), dtype=torch.int32),
+        "seq_lens_kv": torch.empty((2,), dtype=torch.int32),
+        "block_indptr": torch.empty((2, 4, 2), dtype=torch.int32),
+        "block_indices": torch.empty((16,), dtype=torch.int32),
+    }
+
+    with pytest.raises(
+        ValueError,
+        match=r"requires the live wrapper's plan state.*flashinfer\.fi_trace",
+    ):
+        wrapper.run.fi_trace(paged_kv_cache=(k_cache, v_cache), **common_kwargs)
+    with pytest.raises(RuntimeError, match=r"plan\(\) must be called before run\(\)"):
+        fi_trace(
+            wrapper.run,
+            paged_kv_cache=(k_cache, v_cache),
+            **common_kwargs,
+        )
+
+    wrapper._plan_state = SimpleNamespace()
+    cache_forms = (
+        ((k_cache, v_cache), "tuple"),
+        (torch.stack((k_cache, v_cache), dim=1), "combined"),
+    )
+    for paged_kv_cache, cache_form in cache_forms:
+        defn = fi_trace(
+            wrapper.run,
+            paged_kv_cache=paged_kv_cache,
+            **common_kwargs,
+        )
+        assert defn["name"].startswith(
+            f"prims_ts_paged_block_sparse_wrapper_{cache_form}"
+        )
+        for name in (
+            "q_block_size",
+            "kv_block_size",
+            "max_seq_len_kv",
+            "mask_type",
+        ):
+            assert defn["inputs"][name]["optional"] is True
+        for name in (
+            "paged_kv_indptr",
+            "paged_kv_indices",
+            "seq_lens_kv",
+            "block_indptr",
+            "block_indices",
+        ):
+            assert defn["inputs"][name].get("optional") is not True
+
+
 def test_public_paged_wrapper_uses_only_live_run_metadata() -> None:
     """Paged plans own capacity, while attention consumes caller live lengths."""
 

--- a/tests/attention/test_attention_ts_block_sparse.py
+++ b/tests/attention/test_attention_ts_block_sparse.py
@@ -818,6 +818,89 @@ def test_block_sparse_wrapper_routes_are_run_inputs() -> None:
     assert "num_heads" not in state_fields
 
 
+def test_public_paged_wrapper_uses_only_live_run_metadata() -> None:
+    """Paged plans own capacity, while attention consumes caller live lengths."""
+
+    from flashinfer.attention.prims_ts._block_sparse import (
+        compiler as block_sparse_compiler,
+    )
+    from flashinfer.attention.prims_ts._block_sparse import (
+        runtime as block_sparse_runtime,
+    )
+    from flashinfer.attention.prims_ts.kernels.fmha_decode import (
+        block_sparse_prepare,
+    )
+
+    plan_parameters = inspect.signature(
+        block_sparse_module.BlockSparsePagedTSWrapper.plan
+    ).parameters
+    assert tuple(plan_parameters)[:10] == (
+        "self",
+        "batch_size",
+        "seq_len_q",
+        "max_seq_len_kv",
+        "num_qo_heads",
+        "num_kv_heads",
+        "head_dim",
+        "q_block_size",
+        "kv_block_size",
+        "page_size",
+    )
+    assert {"paged_kv_indptr", "paged_kv_indices", "seq_lens_kv"}.isdisjoint(
+        plan_parameters
+    )
+    for name in (
+        "device",
+        "max_blocks_per_row",
+        "use_kv_valid_bits",
+    ):
+        assert plan_parameters[name].default is inspect.Parameter.empty
+
+    run_parameters = inspect.signature(
+        block_sparse_module.BlockSparsePagedTSWrapper.run
+    ).parameters
+    for name in (
+        "paged_kv_indptr",
+        "paged_kv_indices",
+        "seq_lens_kv",
+        "block_indptr",
+        "block_indices",
+    ):
+        assert run_parameters[name].default is inspect.Parameter.empty
+
+    one_shot_parameters = inspect.signature(
+        block_sparse_module.block_sparse_attention_with_paged_kv_cache
+    ).parameters
+    assert "max_seq_len_kv" in one_shot_parameters
+    assert "seq_len_kv" not in one_shot_parameters
+    assert one_shot_parameters["max_seq_len_kv"].default is inspect.Parameter.empty
+    assert one_shot_parameters["seq_lens_kv"].default is inspect.Parameter.empty
+
+    state_fields = {
+        field.name for field in fields(block_sparse_plan._BlockSparsePlanState)
+    }
+    assert {
+        "paged_kv_indptr",
+        "paged_kv_indices",
+        "seq_lens_kv",
+        "paged_kv",
+        "validated_seq_lens_kv",
+    }.isdisjoint(state_fields)
+    assert "page_size" in state_fields
+    assert "validated_seq_lens_kv" not in {
+        field.name for field in fields(block_sparse_runtime._PagedKVLaunchPayload)
+    }
+    assert (
+        "validated_seq_lens_kv"
+        not in inspect.signature(
+            block_sparse_prepare._PrepareBlockSparseRoutes.__call__
+        ).parameters
+    )
+    assert "validated_seq_lens_kv" not in inspect.getsource(
+        block_sparse_compiler._compile_block_sparse
+    )
+
+
 def test_block_sparse_plan_rejects_cuda_graph_capture_before_allocation(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -1795,7 +1878,6 @@ def test_paged_route_seam_extends_only_the_shared_compile_key() -> None:
         "use_persistent_scheduler",
         "use_parallel_sparse_kv_loads",
         "page_size",
-        "use_variable_seqlens_kv",
     )
     assert not hasattr(block_sparse_module, "_BlockSparseExecutionPolicy")
     assert not hasattr(block_sparse_module, "_resolve_block_sparse_execution_policy")
@@ -2170,7 +2252,7 @@ def test_gqa_runtime_uses_distinct_q_and_kv_head_shapes() -> None:
         dummy_kv_valid_bits=torch.zeros((1, 2), dtype=torch.uint32),
         row_route_offsets=torch.zeros(2, dtype=torch.int32),
         route_workspace=torch.zeros(4, dtype=torch.int32),
-        paged_kv=None,
+        page_size=None,
     )
     q = torch.empty((1, 8, 8, _HEAD_DIM), dtype=torch.float16)
     k = torch.empty((1, 64, 1, _HEAD_DIM), dtype=torch.float16)
@@ -2238,7 +2320,7 @@ def test_contiguous_launch_forwards_the_exact_compiled_adapter_abi() -> None:
     )
 
     state = SimpleNamespace(
-        paged_kv=None,
+        page_size=None,
         row_route_offsets=object(),
         route_workspace=object(),
         max_blocks_per_row=3,
@@ -2283,6 +2365,75 @@ def test_contiguous_launch_forwards_the_exact_compiled_adapter_abi() -> None:
             state.row_route_offsets,
             state.route_workspace,
             3,
+            1.25,
+        )
+    ]
+
+
+def test_paged_launch_forwards_caller_live_lengths_to_attention() -> None:
+    from flashinfer.attention.prims_ts._block_sparse.runtime import (
+        _BlockSparseRunArgs,
+        _PagedKVLaunchPayload,
+        launch_block_sparse,
+    )
+
+    calls: list[tuple[object, ...]] = []
+    state = SimpleNamespace(
+        page_size=64,
+        row_route_offsets=object(),
+        route_workspace=object(),
+        max_blocks_per_row=3,
+        compiled=lambda *args: calls.append(args),
+    )
+    values = {
+        name: object()
+        for name in (
+            "q",
+            "k",
+            "v",
+            "out",
+            "block_indptr",
+            "block_indices",
+            "kv_valid_bits",
+        )
+    }
+    live_seq_lens_kv = object()
+    paged_kv = _PagedKVLaunchPayload(
+        paged_kv_indptr=object(),
+        paged_kv_indices=object(),
+        seq_lens_kv=live_seq_lens_kv,
+        num_physical_kv_pages=17,
+        k_page_stride=19,
+        v_page_stride=23,
+    )
+    run_args = _BlockSparseRunArgs(
+        **values,
+        kv_valid_bits_is_live=True,
+        sm_scale=1.25,
+        paged_kv=paged_kv,
+    )
+
+    result = launch_block_sparse(run_args, state=state)
+
+    assert result is run_args.out
+    assert calls == [
+        (
+            run_args.q,
+            run_args.k,
+            run_args.v,
+            run_args.out,
+            run_args.block_indptr,
+            run_args.block_indices,
+            run_args.kv_valid_bits,
+            paged_kv.paged_kv_indptr,
+            paged_kv.paged_kv_indices,
+            live_seq_lens_kv,
+            state.row_route_offsets,
+            state.route_workspace,
+            3,
+            17,
+            19,
+            23,
             1.25,
         )
     ]
@@ -2338,7 +2489,7 @@ def test_runtime_output_must_not_alias_sparse_metadata(aliased_name: str) -> Non
             dummy_kv_valid_bits=None,
             row_route_offsets=torch.zeros(2, dtype=torch.int32),
             route_workspace=torch.zeros(4, dtype=torch.int32),
-            paged_kv=None,
+            page_size=None,
         )
         validate_block_sparse_run(
             q,
@@ -2384,7 +2535,7 @@ def test_runtime_output_must_not_alias_plan_owned_route_workspace() -> None:
         dummy_kv_valid_bits=torch.zeros((1, 1), dtype=torch.uint32),
         row_route_offsets=torch.zeros(2, dtype=torch.int32),
         route_workspace=route_workspace,
-        paged_kv=None,
+        page_size=None,
     )
 
     with pytest.raises(
@@ -3703,6 +3854,7 @@ def test_public_paged_one_shot_q64_kv256_gqa_matches_reference() -> None:
         expected_kv_tile=256,
     )
     page_size = 64
+    live_seq_len_kv = 96
     paged_kv_indptr = torch.tensor([0, 2], device="cuda", dtype=torch.int32)
     paged_kv_indices = torch.tensor([0, 2], device="cuda", dtype=torch.int32)
     block_indptr, block_indices = _make_bsr(
@@ -3757,7 +3909,7 @@ def test_public_paged_one_shot_q64_kv256_gqa_matches_reference() -> None:
                 ((1,),),
             ),
         ),
-        (frozenset(range(case.seq_len_kv)),),
+        (frozenset(range(live_seq_len_kv)),),
         sm_scale,
     )
 
@@ -3770,7 +3922,8 @@ def test_public_paged_one_shot_q64_kv256_gqa_matches_reference() -> None:
         block_indices,
         case.q_block_size,
         case.kv_block_size,
-        seq_len_kv=case.seq_len_kv,
+        max_seq_len_kv=case.seq_len_kv,
+        seq_lens_kv=torch.tensor([live_seq_len_kv], dtype=torch.int32, device=q.device),
         sm_scale=sm_scale,
     )
     torch.cuda.synchronize()
@@ -3873,8 +4026,14 @@ def test_public_paged_gqa_small_q_blocks_match_reference(
     )
 
     wrapper = prims_ts.BlockSparsePagedTSWrapper()
+    seq_lens_kv = torch.full(
+        (case.batch_size,),
+        case.seq_len_kv,
+        device="cuda",
+        dtype=torch.int32,
+    )
     wrapper.plan(
-        paged_kv_indptr,
+        case.batch_size,
         case.seq_len_q,
         case.seq_len_kv,
         case.num_heads,
@@ -3883,6 +4042,7 @@ def test_public_paged_gqa_small_q_blocks_match_reference(
         case.q_block_size,
         case.kv_block_size,
         page_size,
+        device=q.device,
         max_blocks_per_row=3,
         use_kv_valid_bits=False,
         mask_type="dense",
@@ -3896,7 +4056,9 @@ def test_public_paged_gqa_small_q_blocks_match_reference(
     actual = wrapper.run(
         q,
         paged_kv_cache,
+        paged_kv_indptr,
         paged_kv_indices,
+        seq_lens_kv,
         block_indptr,
         block_indices,
         sm_scale=sm_scale,
@@ -3910,7 +4072,9 @@ def test_public_paged_gqa_small_q_blocks_match_reference(
         captured = wrapper.run(
             q,
             paged_kv_cache,
+            paged_kv_indptr,
             paged_kv_indices,
+            seq_lens_kv,
             block_indptr,
             block_indices,
             sm_scale=sm_scale,
@@ -4077,9 +4241,15 @@ def test_public_paged_gqa_graph_reloads_routes_and_pages(
     block_indices = indices_a.clone()
     paged_kv_indices = page_ids_a.clone()
     paged_kv_indptr = torch.tensor([0, 2], device="cuda", dtype=torch.int32)
+    seq_lens_kv = torch.full(
+        (case.batch_size,),
+        case.seq_len_kv,
+        device="cuda",
+        dtype=torch.int32,
+    )
     wrapper = prims_ts.BlockSparsePagedTSWrapper()
     wrapper.plan(
-        paged_kv_indptr,
+        case.batch_size,
         case.seq_len_q,
         case.seq_len_kv,
         case.num_heads,
@@ -4088,6 +4258,7 @@ def test_public_paged_gqa_graph_reloads_routes_and_pages(
         case.q_block_size,
         case.kv_block_size,
         page_size,
+        device=q.device,
         max_blocks_per_row=2,
         use_kv_valid_bits=False,
         mask_type="dense",
@@ -4102,7 +4273,9 @@ def test_public_paged_gqa_graph_reloads_routes_and_pages(
     eager = wrapper.run(
         q,
         paged_kv_cache,
+        paged_kv_indptr,
         paged_kv_indices,
+        seq_lens_kv,
         block_indptr,
         block_indices,
         sm_scale=sm_scale,
@@ -4116,7 +4289,9 @@ def test_public_paged_gqa_graph_reloads_routes_and_pages(
         captured = wrapper.run(
             q,
             paged_kv_cache,
+            paged_kv_indptr,
             paged_kv_indices,
+            seq_lens_kv,
             block_indptr,
             block_indices,
             sm_scale=sm_scale,
@@ -4164,7 +4339,7 @@ def test_public_paged_gqa_graph_reloads_routes_and_pages(
 def test_public_paged_varlen_gqa_q64_kv256_graph_reloads_live_pages_bits_and_sparse_routes() -> (
     None
 ):
-    """Varlen-K plan snapshots live lengths while graph replays remap live routes."""
+    """One graph reloads every live paged input while its plan stays fixed."""
 
     torch.manual_seed(20260814)
     case = _Case(
@@ -4187,7 +4362,10 @@ def test_public_paged_varlen_gqa_q64_kv256_graph_reloads_live_pages_bits_and_spa
     num_physical_pages = 6
     max_nnz = 6
     sm_scale = _HEAD_DIM**-0.5
-    seq_lens_kv = torch.tensor([48, 128], device="cuda", dtype=torch.int32)
+    seq_lens_a = torch.tensor([48, 128], device="cuda", dtype=torch.int32)
+    seq_lens_b = torch.tensor([96, 64], device="cuda", dtype=torch.int32)
+    paged_kv_indptr_a = torch.tensor([0, 1, 4], device="cuda", dtype=torch.int32)
+    paged_kv_indptr_b = torch.tensor([0, 2, 3], device="cuda", dtype=torch.int32)
     patterns_a = (
         (
             ((0,),),
@@ -4200,12 +4378,12 @@ def test_public_paged_varlen_gqa_q64_kv256_graph_reloads_live_pages_bits_and_spa
     )
     patterns_b = (
         (
-            ((0,),),
-            ((0,),),
+            ((0, 1),),
+            ((1,),),
         ),
         (
-            ((1,),),
-            ((0, 1),),
+            ((0,),),
+            ((0,),),
         ),
     )
 
@@ -4295,19 +4473,17 @@ def test_public_paged_varlen_gqa_q64_kv256_graph_reloads_live_pages_bits_and_spa
         frozenset(range(case.seq_len_kv)),
     )
     valid_by_batch_b = (
-        frozenset(range(48)),
         frozenset(range(96)),
+        frozenset(token for token in range(64) if token % 5 != 2),
     )
     kv_valid_bits_a = _pack_token_mask(case.seq_len_kv, valid_by_batch_a)
     kv_valid_bits_b = _pack_token_mask(case.seq_len_kv, valid_by_batch_b)
-    page_ids_a = torch.tensor([0, 2, 3, 6], device="cuda", dtype=torch.int32)
-    page_ids_b = torch.tensor([1, 4, 2, 6], device="cuda", dtype=torch.int32)
+    page_ids_a = torch.tensor([0, 2, 3, 5], device="cuda", dtype=torch.int32)
+    page_ids_b = torch.tensor([1, 4, 2, 5], device="cuda", dtype=torch.int32)
 
-    caller_seq_lens = seq_lens_kv.clone()
     wrapper = prims_ts.BlockSparsePagedTSWrapper()
-    paged_kv_indptr = torch.tensor([0, 1, 4], device="cuda", dtype=torch.int32)
     wrapper.plan(
-        paged_kv_indptr,
+        case.batch_size,
         case.seq_len_q,
         case.seq_len_kv,
         case.num_heads,
@@ -4316,31 +4492,29 @@ def test_public_paged_varlen_gqa_q64_kv256_graph_reloads_live_pages_bits_and_spa
         case.q_block_size,
         case.kv_block_size,
         page_size,
+        device=q.device,
         max_blocks_per_row=2,
         use_kv_valid_bits=True,
-        seq_lens_kv=caller_seq_lens,
         mask_type=case.mask_type,
         q_data_type=case.dtype,
     )
-    caller_seq_lens.fill_(case.seq_len_kv)
     planned_state = wrapper._published_state()
-    assert planned_state.paged_kv is not None
-    assert planned_state.paged_kv.seq_lens_kv.tolist() == [48, 128]
+    assert planned_state.page_size == page_size
     assert ("tile_size_q", case.expected_q_tile) in wrapper._policy
     assert ("tile_size_kv", case.expected_kv_tile) in wrapper._policy
-    assert ("use_variable_seqlens_kv", True) in wrapper._policy
 
     k_a, v_a = logical_kv(((0, 1), (2, 3)))
-    k_b, v_b = logical_kv(((1, 0), (4, 2)))
+    k_b, v_b = logical_kv(((1, 4), (2, 0)))
 
     def varlen_reference(
         k: torch.Tensor,
         v: torch.Tensor,
         patterns: object,
         valid_by_batch: tuple[frozenset[int], ...],
+        seq_lens_kv: tuple[int, int],
     ) -> torch.Tensor:
         outputs: list[torch.Tensor] = []
-        for batch_idx, live_kv in enumerate((48, 128)):
+        for batch_idx, live_kv in enumerate(seq_lens_kv):
             live_case = replace(case, batch_size=1, seq_len_kv=live_kv)
             outputs.append(
                 _reference(
@@ -4361,8 +4535,20 @@ def test_public_paged_varlen_gqa_q64_kv256_graph_reloads_live_pages_bits_and_spa
             )
         return torch.cat(outputs)
 
-    expected_a = varlen_reference(k_a, v_a, patterns_a, valid_by_batch_a)
-    expected_b = varlen_reference(k_b, v_b, patterns_b, valid_by_batch_b)
+    expected_a = varlen_reference(
+        k_a,
+        v_a,
+        patterns_a,
+        valid_by_batch_a,
+        (48, 128),
+    )
+    expected_b = varlen_reference(
+        k_b,
+        v_b,
+        patterns_b,
+        valid_by_batch_b,
+        (96, 64),
+    )
     wrong_static_a0 = _reference(
         replace(case, batch_size=1),
         q[:1],
@@ -4385,12 +4571,16 @@ def test_public_paged_varlen_gqa_q64_kv256_graph_reloads_live_pages_bits_and_spa
     block_indptr = indptr_a.clone()
     block_indices = indices_a.clone()
     paged_kv_indices = page_ids_a.clone()
+    paged_kv_indptr = paged_kv_indptr_a.clone()
+    seq_lens_kv = seq_lens_a.clone()
     kv_valid_bits = kv_valid_bits_a.clone()
 
     eager = wrapper.run(
         q,
         paged_kv_cache,
+        paged_kv_indptr,
         paged_kv_indices,
+        seq_lens_kv,
         block_indptr,
         block_indices,
         kv_valid_bits=kv_valid_bits,
@@ -4405,7 +4595,9 @@ def test_public_paged_varlen_gqa_q64_kv256_graph_reloads_live_pages_bits_and_spa
         captured = wrapper.run(
             q,
             paged_kv_cache,
+            paged_kv_indptr,
             paged_kv_indices,
+            seq_lens_kv,
             block_indptr,
             block_indices,
             kv_valid_bits=kv_valid_bits,
@@ -4425,21 +4617,64 @@ def test_public_paged_varlen_gqa_q64_kv256_graph_reloads_live_pages_bits_and_spa
 
     block_indptr.copy_(indptr_b)
     block_indices.copy_(indices_b)
+    paged_kv_indptr.copy_(paged_kv_indptr_b)
     paged_kv_indices.copy_(page_ids_b)
+    seq_lens_kv.copy_(seq_lens_b)
     kv_valid_bits.copy_(kv_valid_bits_b)
     replay()
     assert torch.isfinite(graph_out).all()
     torch.testing.assert_close(graph_out, expected_b, rtol=1e-2, atol=1e-2)
+
+    def assert_batch0_fails_closed() -> None:
+        replay()
+        assert torch.isfinite(graph_out).all()
+        assert torch.count_nonzero(graph_out[0]).item() == 0
+        torch.testing.assert_close(
+            graph_out[1:],
+            expected_b[1:],
+            rtol=1e-2,
+            atol=1e-2,
+        )
 
     invalid_page_ids = page_ids_b.clone()
     invalid_page_ids[0] = num_physical_pages
     paged_kv_indices.copy_(invalid_page_ids)
     replay()
     assert torch.isfinite(graph_out).all()
-    assert torch.count_nonzero(graph_out[0]).item() == 0
+    assert torch.count_nonzero(graph_out[0, :, :8]).item() == 0
+    torch.testing.assert_close(
+        graph_out[0, :, 8:],
+        expected_b[0, :, 8:],
+        rtol=1e-2,
+        atol=1e-2,
+    )
     torch.testing.assert_close(graph_out[1:], expected_b[1:], rtol=1e-2, atol=1e-2)
 
     paged_kv_indices.copy_(page_ids_b)
+    paged_kv_indptr.copy_(torch.tensor([0, 1, 3], device="cuda", dtype=torch.int32))
+    paged_kv_indices.copy_(torch.tensor([1, 2, 5, 4], device="cuda", dtype=torch.int32))
+    assert_batch0_fails_closed()
+
+    paged_kv_indptr.copy_(torch.tensor([1, 3, 4], device="cuda", dtype=torch.int32))
+    paged_kv_indices.copy_(page_ids_b)
+    replay()
+    assert torch.count_nonzero(graph_out).item() == 0
+
+    paged_kv_indptr.copy_(torch.tensor([0, 3, 2], device="cuda", dtype=torch.int32))
+    replay()
+    assert torch.isfinite(graph_out).all()
+    torch.testing.assert_close(graph_out[:1], expected_b[:1], rtol=1e-2, atol=1e-2)
+    assert torch.count_nonzero(graph_out[1]).item() == 0
+
+    paged_kv_indptr.copy_(torch.tensor([0, 3, 5], device="cuda", dtype=torch.int32))
+    replay()
+    assert torch.isfinite(graph_out).all()
+    torch.testing.assert_close(graph_out[:1], expected_b[:1], rtol=1e-2, atol=1e-2)
+    assert torch.count_nonzero(graph_out[1]).item() == 0
+
+    paged_kv_indptr.copy_(paged_kv_indptr_b)
+    paged_kv_indices.copy_(page_ids_b)
+    seq_lens_kv.copy_(seq_lens_b)
     replay()
     torch.testing.assert_close(graph_out, expected_b, rtol=1e-2, atol=1e-2)
     assert wrapper._published_state() is planned_state

--- a/tests/trace/example.py
+++ b/tests/trace/example.py
@@ -82,8 +82,11 @@ mxfp8_grouped_quantize_k4096.json
 nvfp4_kv_dequantize_paged_h2_dk64_dv128_ps4.json
 nvfp4_kv_dequantize_paged_hnd_h2_dk64_dv128_ps4.json
 prims_ts_block_sparse_h8_kv8_d128_qb64_kb64.json
+prims_ts_block_sparse_wrapper_h8_kv8_d128.json
 prims_ts_paged_block_sparse_combined_h8_kv8_d128_qb64_kb64_ps64.json
 prims_ts_paged_block_sparse_tuple_h8_kv8_d128_qb64_kb64_ps64.json
+prims_ts_paged_block_sparse_wrapper_combined_h8_kv8_d128_ps64.json
+prims_ts_paged_block_sparse_wrapper_tuple_h8_kv8_d128_ps64.json
 quantize_nvfp4_smooth_N3072.json
 rmsnorm_h4096.json
 rmsnorm_h7168.json
@@ -133,6 +136,8 @@ import flashinfer.fused_moe
 import flashinfer.activation
 import flashinfer.cascade
 from flashinfer.attention.prims_ts.block_sparse import (
+    BlockSparsePagedTSWrapper,
+    BlockSparseTSWrapper,
     block_sparse_attention,
     block_sparse_attention_with_paged_kv_cache,
 )
@@ -636,8 +641,9 @@ v_r = torch.randn(512, num_kv, head_dim, dtype=torch.bfloat16, device=device)
 rag.run(q_r, k_r, v_r)
 
 # ── PrimTS block-sparse (fixed-top-k MHA, compact BSHD) ───────────────────
-# Trace directly so this example covers the public schemas without compiling
-# the SM100/SM103 kernel or executing an unplanned reusable wrapper.
+# Trace the one-shot APIs directly so their schemas remain available without
+# compiling the SM100/SM103 kernel. Reusable-wrapper traces below use a real
+# plan and are guarded for machines that cannot build the PrimTS kernel.
 bs_B, bs_Sq, bs_Skv, bs_H, bs_D = 2, 128, 512, 8, 128
 bs_q_block, bs_kv_block, bs_topk = 64, 64, 4
 bs_num_q_blocks = (bs_Sq + bs_q_block - 1) // bs_q_block
@@ -724,6 +730,61 @@ for bs_paged_cache in ((bs_k_cache, bs_v_cache), bs_combined_cache):
         mask_type="dense",
         out=bs_out,
     )
+
+with contextlib.suppress(Exception):
+    bs_wrapper = BlockSparseTSWrapper()
+    bs_wrapper.plan(
+        bs_B,
+        bs_Sq,
+        bs_Skv,
+        bs_H,
+        bs_H,
+        bs_D,
+        bs_q_block,
+        bs_kv_block,
+        device=device,
+        max_blocks_per_row=bs_topk,
+        use_kv_valid_bits=True,
+    )
+    bs_wrapper.run(
+        bs_q,
+        bs_k,
+        bs_v,
+        bs_block_indptr,
+        bs_block_indices,
+        kv_valid_bits=bs_valid_bits,
+        out=bs_out,
+    )
+
+
+with contextlib.suppress(Exception):
+    bs_paged_wrapper = BlockSparsePagedTSWrapper()
+    bs_paged_wrapper.plan(
+        bs_B,
+        bs_Sq,
+        bs_Skv,
+        bs_H,
+        bs_H,
+        bs_D,
+        bs_q_block,
+        bs_kv_block,
+        bs_page_size,
+        device=device,
+        max_blocks_per_row=bs_topk,
+        use_kv_valid_bits=True,
+    )
+    for bs_paged_cache in ((bs_k_cache, bs_v_cache), bs_combined_cache):
+        bs_paged_wrapper.run(
+            bs_q,
+            bs_paged_cache,
+            bs_paged_kv_indptr,
+            bs_paged_kv_indices,
+            bs_seq_lens_kv,
+            bs_block_indptr,
+            bs_block_indices,
+            kv_valid_bits=bs_valid_bits,
+            out=bs_out,
+        )
 # ── MLA paged decode (DeepSeek-V3 TP=8, h=16/ckv=512/kpe=64) ─────────────────
 mla_b, mla_h, ckv, kpe = 128, 16, 512, 64
 

--- a/tests/trace/example.py
+++ b/tests/trace/example.py
@@ -685,7 +685,14 @@ bs_num_pages = bs_B * bs_pages_per_request
 bs_paged_kv_indptr = (
     torch.arange(bs_B + 1, dtype=torch.int32, device=device) * bs_pages_per_request
 )
-bs_paged_kv_indices = torch.arange(bs_num_pages, dtype=torch.int32, device=device)
+# Keep one spare entry to demonstrate that this tensor is capacity: the live
+# prefix is selected by bs_paged_kv_indptr[-1].
+bs_paged_kv_indices = torch.cat(
+    (
+        torch.arange(bs_num_pages, dtype=torch.int32, device=device),
+        torch.zeros(1, dtype=torch.int32, device=device),
+    )
+)
 bs_seq_lens_kv = torch.tensor(
     [bs_Skv - bs_page_size // 2, bs_Skv], dtype=torch.int32, device=device
 )
@@ -711,7 +718,7 @@ for bs_paged_cache in ((bs_k_cache, bs_v_cache), bs_combined_cache):
         block_indices=bs_block_indices,
         q_block_size=bs_q_block,
         kv_block_size=bs_kv_block,
-        seq_len_kv=bs_Skv,
+        max_seq_len_kv=bs_Skv,
         seq_lens_kv=bs_seq_lens_kv,
         kv_valid_bits=bs_valid_bits,
         mask_type="dense",

--- a/tests/trace/example.py
+++ b/tests/trace/example.py
@@ -699,9 +699,9 @@ bs_paged_kv_indices = torch.cat(
         torch.zeros(1, dtype=torch.int32, device=device),
     )
 )
-bs_seq_lens_kv = torch.tensor(
-    [bs_Skv - bs_page_size // 2, bs_Skv], dtype=torch.int32, device=device
-)
+bs_seq_lens_kv = torch.full((bs_B,), bs_Skv, dtype=torch.int32, device=device)
+# Exercise a live length that does not fill its last page.
+bs_seq_lens_kv[0] = bs_Skv - bs_page_size // 2
 bs_k_cache = torch.randn(
     bs_num_pages,
     bs_H,

--- a/tests/trace/fi_trace_out/prims_ts_block_sparse_h8_kv8_d128_qb64_kb64.json
+++ b/tests/trace/fi_trace_out/prims_ts_block_sparse_h8_kv8_d128_qb64_kb64.json
@@ -39,7 +39,7 @@
     },
     "num_block_indices": {
       "type": "var",
-      "description": "Number of selected KV blocks."
+      "description": "Capacity of the runtime KV-block ID tensor."
     },
     "num_kv_valid_words": {
       "type": "var",
@@ -107,7 +107,7 @@
         "num_block_indices"
       ],
       "dtype": "int32",
-      "description": "Selected KV block IDs, consumed by the one-shot call."
+      "description": "Runtime KV-block ID capacity; only entries referenced by block_indptr are live."
     },
     "kv_valid_bits": {
       "shape": [

--- a/tests/trace/fi_trace_out/prims_ts_block_sparse_wrapper_h8_kv8_d128.json
+++ b/tests/trace/fi_trace_out/prims_ts_block_sparse_wrapper_h8_kv8_d128.json
@@ -1,0 +1,147 @@
+{
+  "name": "prims_ts_block_sparse_wrapper_h8_kv8_d128",
+  "description": "Reusable PrimTS block-sparse MHA/GQA/MQA attention over compact BSHD Q/K/V and live per-KV-head BSR metadata. Block geometry and mask type are retained by plan() and represented as optional trace context.",
+  "op_type": "block_sparse",
+  "tags": [
+    "fi_api:flashinfer.attention.prims_ts.block_sparse.BlockSparseTSWrapper.run",
+    "backend:prims-ts",
+    "sparse:block",
+    "status:experimental"
+  ],
+  "axes": {
+    "batch_size": {
+      "type": "var",
+      "description": "Number of requests."
+    },
+    "seq_len_q": {
+      "type": "var",
+      "description": "Fixed query length per request."
+    },
+    "seq_len_kv": {
+      "type": "var",
+      "description": "Fixed key/value length per request."
+    },
+    "num_qo_heads": {
+      "type": "const",
+      "value": 8
+    },
+    "num_kv_heads": {
+      "type": "const",
+      "value": 8
+    },
+    "head_dim": {
+      "type": "const",
+      "value": 128
+    },
+    "num_q_block_offsets": {
+      "type": "var",
+      "description": "Number of BSR row offsets per batch and KV head."
+    },
+    "num_block_indices": {
+      "type": "var",
+      "description": "Capacity of the runtime KV-block ID tensor."
+    },
+    "num_kv_valid_words": {
+      "type": "var",
+      "description": "Number of optional token-validity words per batch."
+    }
+  },
+  "constraints": [
+    "num_qo_heads % num_kv_heads == 0",
+    "num_qo_heads // num_kv_heads in (1, 2, 4, 8, 16, 32)",
+    "head_dim == 128",
+    "q_block_size > 0",
+    "(q_block_size * (num_qo_heads // num_kv_heads)) % 8 == 0",
+    "kv_block_size in (8, 16, 32) or (kv_block_size > 0 and kv_block_size % 64 == 0)",
+    "num_q_block_offsets == (seq_len_q + q_block_size - 1) // q_block_size + 1",
+    "kv_valid_bits is None or num_kv_valid_words == (seq_len_kv + 31) // 32",
+    "mask_type is None or mask_type in ('dense', 'causal')"
+  ],
+  "inputs": {
+    "q": {
+      "shape": [
+        "batch_size",
+        "seq_len_q",
+        "num_qo_heads",
+        "head_dim"
+      ],
+      "dtype": "float16"
+    },
+    "k": {
+      "shape": [
+        "batch_size",
+        "seq_len_kv",
+        "num_kv_heads",
+        "head_dim"
+      ],
+      "dtype": "float16"
+    },
+    "v": {
+      "shape": [
+        "batch_size",
+        "seq_len_kv",
+        "num_kv_heads",
+        "head_dim"
+      ],
+      "dtype": "float16"
+    },
+    "block_indptr": {
+      "shape": [
+        "batch_size",
+        "num_kv_heads",
+        "num_q_block_offsets"
+      ],
+      "dtype": "int32",
+      "description": "Absolute offsets into live block_indices for this wrapper run."
+    },
+    "block_indices": {
+      "shape": [
+        "num_block_indices"
+      ],
+      "dtype": "int32",
+      "description": "Runtime KV-block ID capacity; only entries referenced by block_indptr are live."
+    },
+    "kv_valid_bits": {
+      "shape": [
+        "batch_size",
+        "num_kv_valid_words"
+      ],
+      "dtype": "uint32",
+      "optional": true,
+      "description": "Batch-only token validity bits: token t uses bit t % 32 of word t // 32 (LSB-first); one means valid. Padding bits beyond the planned K/V capacity are ignored."
+    },
+    "q_block_size": {
+      "shape": null,
+      "dtype": "int32",
+      "optional": true
+    },
+    "kv_block_size": {
+      "shape": null,
+      "dtype": "int32",
+      "optional": true
+    },
+    "mask_type": {
+      "shape": null,
+      "dtype": "string",
+      "optional": true
+    },
+    "sm_scale": {
+      "shape": null,
+      "dtype": "float32",
+      "optional": true
+    }
+  },
+  "outputs": {
+    "output": {
+      "shape": [
+        "batch_size",
+        "seq_len_q",
+        "num_qo_heads",
+        "head_dim"
+      ],
+      "dtype": "float16",
+      "param": "out"
+    }
+  },
+  "check": "def standard_check(\n    reference_outputs: Any,\n    actual_outputs: Any,\n    *,\n    rtol: Optional[float] = None,\n    atol: Optional[float] = None,\n    max_mismatch_pct: float = 0.0,\n    min_cos_sim: Optional[float] = 1.0 - 1e-3,\n) -> bool:\n    \"\"\"Default trace correctness check used when a template does not override it.\"\"\"\n    from flashinfer.trace import default_check\n\n    return default_check(\n        reference_outputs,\n        actual_outputs,\n        rtol=rtol,\n        atol=atol,\n        max_mismatch_pct=max_mismatch_pct,\n        min_cos_sim=min_cos_sim,\n    )\n"
+}

--- a/tests/trace/fi_trace_out/prims_ts_paged_block_sparse_combined_h8_kv8_d128_qb64_kb64_ps64.json
+++ b/tests/trace/fi_trace_out/prims_ts_paged_block_sparse_combined_h8_kv8_d128_qb64_kb64_ps64.json
@@ -1,6 +1,6 @@
 {
   "name": "prims_ts_paged_block_sparse_combined_h8_kv8_d128_qb64_kb64_ps64",
-  "description": "One-shot PrimTS block-sparse MHA/GQA/MQA attention over compact BSHD Q, the combined HND paged KV cache form, request page tables, and per-KV-head BSR metadata.",
+  "description": "One-shot PrimTS block-sparse MHA/GQA/MQA attention over compact fixed-length BSHD Q, the combined HND paged KV cache form, and live request page tables, K/V lengths, and per-KV-head BSR metadata.",
   "op_type": "block_sparse",
   "tags": [
     "fi_api:flashinfer.attention.prims_ts.block_sparse.block_sparse_attention_with_paged_kv_cache",
@@ -17,10 +17,6 @@
     "seq_len_q": {
       "type": "var",
       "description": "Fixed query length per request."
-    },
-    "seq_len_kv": {
-      "type": "var",
-      "description": "Static maximum logical K/V length."
     },
     "num_qo_heads": {
       "type": "const",
@@ -40,7 +36,7 @@
     },
     "num_block_indices": {
       "type": "var",
-      "description": "Number of selected KV blocks."
+      "description": "Capacity of the runtime KV-block ID tensor."
     },
     "num_kv_valid_words": {
       "type": "var",
@@ -53,6 +49,10 @@
     "kv_block_size": {
       "type": "const",
       "value": 64
+    },
+    "max_seq_len_kv": {
+      "type": "var",
+      "description": "Static maximum logical K/V length planned for every request."
     },
     "num_pages": {
       "type": "var",
@@ -68,7 +68,7 @@
     },
     "num_page_indices": {
       "type": "var",
-      "description": "Number of runtime physical page IDs."
+      "description": "Capacity of the runtime physical-page ID tensor; the final live page-table offset may be smaller."
     },
     "kv_planes": {
       "type": "const",
@@ -84,11 +84,15 @@
     "(q_block_size * (num_qo_heads // num_kv_heads)) % 8 == 0",
     "kv_block_size in (8, 16, 32) or (kv_block_size > 0 and kv_block_size % 64 == 0)",
     "num_q_block_offsets == (seq_len_q + q_block_size - 1) // q_block_size + 1",
-    "kv_valid_bits is None or num_kv_valid_words == (seq_len_kv + 31) // 32",
+    "kv_valid_bits is None or num_kv_valid_words == (max_seq_len_kv + 31) // 32",
     "mask_type is None or mask_type in ('dense', 'causal')",
     "num_page_offsets == batch_size + 1",
-    "num_page_indices == paged_kv_indptr[-1].item()",
-    "seq_lens_kv is None or max(seq_lens_kv) <= seq_len_kv",
+    "paged_kv_indptr[0].item() == 0",
+    "min(paged_kv_indptr[1:] - paged_kv_indptr[:-1]) >= 0",
+    "paged_kv_indptr[-1].item() <= num_page_indices",
+    "max_seq_len_kv >= (seq_len_q if mask_type == 'causal' else 1)",
+    "min(seq_lens_kv) >= (seq_len_q if mask_type == 'causal' else 1)",
+    "max(seq_lens_kv) <= max_seq_len_kv",
     "page_size in (16, 32, 64, 128)",
     "page_size >= (kv_block_size if kv_block_size < 64 else 64)",
     "page_size % (kv_block_size if kv_block_size < 64 else 64) == 0",
@@ -118,7 +122,7 @@
         "num_block_indices"
       ],
       "dtype": "int32",
-      "description": "Selected KV block IDs, consumed by the one-shot call."
+      "description": "Runtime KV-block ID capacity; only entries referenced by block_indptr are live."
     },
     "kv_valid_bits": {
       "shape": [
@@ -163,27 +167,26 @@
         "num_page_offsets"
       ],
       "dtype": "int32",
-      "description": "Request offsets into paged_kv_indices."
+      "description": "Live request offsets into paged_kv_indices, read for this call."
     },
     "paged_kv_indices": {
       "shape": [
         "num_page_indices"
       ],
       "dtype": "int32",
-      "description": "Runtime physical page IDs."
+      "description": "Runtime physical-page ID capacity; only the prefix ending at paged_kv_indptr[-1] is live."
     },
-    "seq_len_kv": {
+    "max_seq_len_kv": {
       "shape": null,
       "dtype": "int32",
-      "description": "Static maximum logical K/V length."
+      "description": "Static maximum logical K/V length used for planning."
     },
     "seq_lens_kv": {
       "shape": [
         "batch_size"
       ],
       "dtype": "int32",
-      "optional": true,
-      "description": "Optional per-request logical K/V lengths."
+      "description": "Live per-request logical K/V lengths read for this call."
     }
   },
   "outputs": {

--- a/tests/trace/fi_trace_out/prims_ts_paged_block_sparse_tuple_h8_kv8_d128_qb64_kb64_ps64.json
+++ b/tests/trace/fi_trace_out/prims_ts_paged_block_sparse_tuple_h8_kv8_d128_qb64_kb64_ps64.json
@@ -1,6 +1,6 @@
 {
   "name": "prims_ts_paged_block_sparse_tuple_h8_kv8_d128_qb64_kb64_ps64",
-  "description": "One-shot PrimTS block-sparse MHA/GQA/MQA attention over compact BSHD Q, the tuple HND paged KV cache form, request page tables, and per-KV-head BSR metadata.",
+  "description": "One-shot PrimTS block-sparse MHA/GQA/MQA attention over compact fixed-length BSHD Q, the tuple HND paged KV cache form, and live request page tables, K/V lengths, and per-KV-head BSR metadata.",
   "op_type": "block_sparse",
   "tags": [
     "fi_api:flashinfer.attention.prims_ts.block_sparse.block_sparse_attention_with_paged_kv_cache",
@@ -17,10 +17,6 @@
     "seq_len_q": {
       "type": "var",
       "description": "Fixed query length per request."
-    },
-    "seq_len_kv": {
-      "type": "var",
-      "description": "Static maximum logical K/V length."
     },
     "num_qo_heads": {
       "type": "const",
@@ -40,7 +36,7 @@
     },
     "num_block_indices": {
       "type": "var",
-      "description": "Number of selected KV blocks."
+      "description": "Capacity of the runtime KV-block ID tensor."
     },
     "num_kv_valid_words": {
       "type": "var",
@@ -53,6 +49,10 @@
     "kv_block_size": {
       "type": "const",
       "value": 64
+    },
+    "max_seq_len_kv": {
+      "type": "var",
+      "description": "Static maximum logical K/V length planned for every request."
     },
     "num_pages": {
       "type": "var",
@@ -68,7 +68,7 @@
     },
     "num_page_indices": {
       "type": "var",
-      "description": "Number of runtime physical page IDs."
+      "description": "Capacity of the runtime physical-page ID tensor; the final live page-table offset may be smaller."
     }
   },
   "constraints": [
@@ -79,11 +79,15 @@
     "(q_block_size * (num_qo_heads // num_kv_heads)) % 8 == 0",
     "kv_block_size in (8, 16, 32) or (kv_block_size > 0 and kv_block_size % 64 == 0)",
     "num_q_block_offsets == (seq_len_q + q_block_size - 1) // q_block_size + 1",
-    "kv_valid_bits is None or num_kv_valid_words == (seq_len_kv + 31) // 32",
+    "kv_valid_bits is None or num_kv_valid_words == (max_seq_len_kv + 31) // 32",
     "mask_type is None or mask_type in ('dense', 'causal')",
     "num_page_offsets == batch_size + 1",
-    "num_page_indices == paged_kv_indptr[-1].item()",
-    "seq_lens_kv is None or max(seq_lens_kv) <= seq_len_kv",
+    "paged_kv_indptr[0].item() == 0",
+    "min(paged_kv_indptr[1:] - paged_kv_indptr[:-1]) >= 0",
+    "paged_kv_indptr[-1].item() <= num_page_indices",
+    "max_seq_len_kv >= (seq_len_q if mask_type == 'causal' else 1)",
+    "min(seq_lens_kv) >= (seq_len_q if mask_type == 'causal' else 1)",
+    "max(seq_lens_kv) <= max_seq_len_kv",
     "page_size in (16, 32, 64, 128)",
     "page_size >= (kv_block_size if kv_block_size < 64 else 64)",
     "page_size % (kv_block_size if kv_block_size < 64 else 64) == 0"
@@ -112,7 +116,7 @@
         "num_block_indices"
       ],
       "dtype": "int32",
-      "description": "Selected KV block IDs, consumed by the one-shot call."
+      "description": "Runtime KV-block ID capacity; only entries referenced by block_indptr are live."
     },
     "kv_valid_bits": {
       "shape": [
@@ -166,27 +170,26 @@
         "num_page_offsets"
       ],
       "dtype": "int32",
-      "description": "Request offsets into paged_kv_indices."
+      "description": "Live request offsets into paged_kv_indices, read for this call."
     },
     "paged_kv_indices": {
       "shape": [
         "num_page_indices"
       ],
       "dtype": "int32",
-      "description": "Runtime physical page IDs."
+      "description": "Runtime physical-page ID capacity; only the prefix ending at paged_kv_indptr[-1] is live."
     },
-    "seq_len_kv": {
+    "max_seq_len_kv": {
       "shape": null,
       "dtype": "int32",
-      "description": "Static maximum logical K/V length."
+      "description": "Static maximum logical K/V length used for planning."
     },
     "seq_lens_kv": {
       "shape": [
         "batch_size"
       ],
       "dtype": "int32",
-      "optional": true,
-      "description": "Optional per-request logical K/V lengths."
+      "description": "Live per-request logical K/V lengths read for this call."
     }
   },
   "outputs": {

--- a/tests/trace/fi_trace_out/prims_ts_paged_block_sparse_wrapper_combined_h8_kv8_d128_ps64.json
+++ b/tests/trace/fi_trace_out/prims_ts_paged_block_sparse_wrapper_combined_h8_kv8_d128_ps64.json
@@ -1,0 +1,200 @@
+{
+  "name": "prims_ts_paged_block_sparse_wrapper_combined_h8_kv8_d128_ps64",
+  "description": "Reusable PrimTS block-sparse MHA/GQA/MQA attention over compact fixed-length BSHD Q, the combined HND paged KV cache form, and live page tables, K/V lengths, and per-KV-head BSR metadata. Static K/V capacity, block geometry, and mask type are retained by plan() and represented as optional trace context.",
+  "op_type": "block_sparse",
+  "tags": [
+    "fi_api:flashinfer.attention.prims_ts.block_sparse.BlockSparsePagedTSWrapper.run",
+    "backend:prims-ts",
+    "sparse:block",
+    "status:experimental",
+    "kv-cache:paged"
+  ],
+  "axes": {
+    "batch_size": {
+      "type": "var",
+      "description": "Number of requests."
+    },
+    "seq_len_q": {
+      "type": "var",
+      "description": "Fixed query length per request."
+    },
+    "num_qo_heads": {
+      "type": "const",
+      "value": 8
+    },
+    "num_kv_heads": {
+      "type": "const",
+      "value": 8
+    },
+    "head_dim": {
+      "type": "const",
+      "value": 128
+    },
+    "num_q_block_offsets": {
+      "type": "var",
+      "description": "Number of BSR row offsets per batch and KV head."
+    },
+    "num_block_indices": {
+      "type": "var",
+      "description": "Capacity of the runtime KV-block ID tensor."
+    },
+    "num_kv_valid_words": {
+      "type": "var",
+      "description": "Number of optional token-validity words per batch."
+    },
+    "max_seq_len_kv": {
+      "type": "var",
+      "description": "Static maximum logical K/V length planned for every request."
+    },
+    "num_pages": {
+      "type": "var",
+      "description": "Total number of allocated physical KV pages."
+    },
+    "page_size": {
+      "type": "const",
+      "value": 64
+    },
+    "num_page_offsets": {
+      "type": "var",
+      "description": "Length of the request-to-page indptr array."
+    },
+    "num_page_indices": {
+      "type": "var",
+      "description": "Capacity of the runtime physical-page ID tensor; the final live page-table offset may be smaller."
+    },
+    "kv_planes": {
+      "type": "const",
+      "value": 2,
+      "description": "K/V plane count; required to be 2."
+    }
+  },
+  "constraints": [
+    "num_qo_heads % num_kv_heads == 0",
+    "num_qo_heads // num_kv_heads in (1, 2, 4, 8, 16, 32)",
+    "head_dim == 128",
+    "q_block_size > 0",
+    "(q_block_size * (num_qo_heads // num_kv_heads)) % 8 == 0",
+    "kv_block_size in (8, 16, 32) or (kv_block_size > 0 and kv_block_size % 64 == 0)",
+    "num_q_block_offsets == (seq_len_q + q_block_size - 1) // q_block_size + 1",
+    "kv_valid_bits is None or num_kv_valid_words == (max_seq_len_kv + 31) // 32",
+    "mask_type is None or mask_type in ('dense', 'causal')",
+    "num_page_offsets == batch_size + 1",
+    "paged_kv_indptr[0].item() == 0",
+    "min(paged_kv_indptr[1:] - paged_kv_indptr[:-1]) >= 0",
+    "paged_kv_indptr[-1].item() <= num_page_indices",
+    "max_seq_len_kv >= (seq_len_q if mask_type == 'causal' else 1)",
+    "min(seq_lens_kv) >= (seq_len_q if mask_type == 'causal' else 1)",
+    "max(seq_lens_kv) <= max_seq_len_kv",
+    "page_size in (16, 32, 64, 128)",
+    "page_size >= (kv_block_size if kv_block_size < 64 else 64)",
+    "page_size % (kv_block_size if kv_block_size < 64 else 64) == 0",
+    "kv_planes == 2"
+  ],
+  "inputs": {
+    "q": {
+      "shape": [
+        "batch_size",
+        "seq_len_q",
+        "num_qo_heads",
+        "head_dim"
+      ],
+      "dtype": "float16"
+    },
+    "block_indptr": {
+      "shape": [
+        "batch_size",
+        "num_kv_heads",
+        "num_q_block_offsets"
+      ],
+      "dtype": "int32",
+      "description": "Absolute offsets into live block_indices for this wrapper run."
+    },
+    "block_indices": {
+      "shape": [
+        "num_block_indices"
+      ],
+      "dtype": "int32",
+      "description": "Runtime KV-block ID capacity; only entries referenced by block_indptr are live."
+    },
+    "kv_valid_bits": {
+      "shape": [
+        "batch_size",
+        "num_kv_valid_words"
+      ],
+      "dtype": "uint32",
+      "optional": true,
+      "description": "Batch-only token validity bits: token t uses bit t % 32 of word t // 32 (LSB-first); one means valid. Padding bits beyond the planned K/V capacity are ignored."
+    },
+    "q_block_size": {
+      "shape": null,
+      "dtype": "int32",
+      "optional": true
+    },
+    "kv_block_size": {
+      "shape": null,
+      "dtype": "int32",
+      "optional": true
+    },
+    "mask_type": {
+      "shape": null,
+      "dtype": "string",
+      "optional": true
+    },
+    "sm_scale": {
+      "shape": null,
+      "dtype": "float32",
+      "optional": true
+    },
+    "paged_kv_cache": {
+      "shape": [
+        "num_pages",
+        "kv_planes",
+        "num_kv_heads",
+        "page_size",
+        "head_dim"
+      ],
+      "dtype": "float16",
+      "description": "Combined K/V pages in HND layout."
+    },
+    "paged_kv_indptr": {
+      "shape": [
+        "num_page_offsets"
+      ],
+      "dtype": "int32",
+      "description": "Live request offsets into paged_kv_indices, read for this call."
+    },
+    "paged_kv_indices": {
+      "shape": [
+        "num_page_indices"
+      ],
+      "dtype": "int32",
+      "description": "Runtime physical-page ID capacity; only the prefix ending at paged_kv_indptr[-1] is live."
+    },
+    "max_seq_len_kv": {
+      "shape": null,
+      "dtype": "int32",
+      "optional": true,
+      "description": "Static maximum logical K/V length used for planning."
+    },
+    "seq_lens_kv": {
+      "shape": [
+        "batch_size"
+      ],
+      "dtype": "int32",
+      "description": "Live per-request logical K/V lengths read for this call."
+    }
+  },
+  "outputs": {
+    "output": {
+      "shape": [
+        "batch_size",
+        "seq_len_q",
+        "num_qo_heads",
+        "head_dim"
+      ],
+      "dtype": "float16",
+      "param": "out"
+    }
+  },
+  "check": "def standard_check(\n    reference_outputs: Any,\n    actual_outputs: Any,\n    *,\n    rtol: Optional[float] = None,\n    atol: Optional[float] = None,\n    max_mismatch_pct: float = 0.0,\n    min_cos_sim: Optional[float] = 1.0 - 1e-3,\n) -> bool:\n    \"\"\"Default trace correctness check used when a template does not override it.\"\"\"\n    from flashinfer.trace import default_check\n\n    return default_check(\n        reference_outputs,\n        actual_outputs,\n        rtol=rtol,\n        atol=atol,\n        max_mismatch_pct=max_mismatch_pct,\n        min_cos_sim=min_cos_sim,\n    )\n"
+}

--- a/tests/trace/fi_trace_out/prims_ts_paged_block_sparse_wrapper_tuple_h8_kv8_d128_ps64.json
+++ b/tests/trace/fi_trace_out/prims_ts_paged_block_sparse_wrapper_tuple_h8_kv8_d128_ps64.json
@@ -1,0 +1,203 @@
+{
+  "name": "prims_ts_paged_block_sparse_wrapper_tuple_h8_kv8_d128_ps64",
+  "description": "Reusable PrimTS block-sparse MHA/GQA/MQA attention over compact fixed-length BSHD Q, the tuple HND paged KV cache form, and live page tables, K/V lengths, and per-KV-head BSR metadata. Static K/V capacity, block geometry, and mask type are retained by plan() and represented as optional trace context.",
+  "op_type": "block_sparse",
+  "tags": [
+    "fi_api:flashinfer.attention.prims_ts.block_sparse.BlockSparsePagedTSWrapper.run",
+    "backend:prims-ts",
+    "sparse:block",
+    "status:experimental",
+    "kv-cache:paged"
+  ],
+  "axes": {
+    "batch_size": {
+      "type": "var",
+      "description": "Number of requests."
+    },
+    "seq_len_q": {
+      "type": "var",
+      "description": "Fixed query length per request."
+    },
+    "num_qo_heads": {
+      "type": "const",
+      "value": 8
+    },
+    "num_kv_heads": {
+      "type": "const",
+      "value": 8
+    },
+    "head_dim": {
+      "type": "const",
+      "value": 128
+    },
+    "num_q_block_offsets": {
+      "type": "var",
+      "description": "Number of BSR row offsets per batch and KV head."
+    },
+    "num_block_indices": {
+      "type": "var",
+      "description": "Capacity of the runtime KV-block ID tensor."
+    },
+    "num_kv_valid_words": {
+      "type": "var",
+      "description": "Number of optional token-validity words per batch."
+    },
+    "max_seq_len_kv": {
+      "type": "var",
+      "description": "Static maximum logical K/V length planned for every request."
+    },
+    "num_pages": {
+      "type": "var",
+      "description": "Total number of allocated physical KV pages."
+    },
+    "page_size": {
+      "type": "const",
+      "value": 64
+    },
+    "num_page_offsets": {
+      "type": "var",
+      "description": "Length of the request-to-page indptr array."
+    },
+    "num_page_indices": {
+      "type": "var",
+      "description": "Capacity of the runtime physical-page ID tensor; the final live page-table offset may be smaller."
+    }
+  },
+  "constraints": [
+    "num_qo_heads % num_kv_heads == 0",
+    "num_qo_heads // num_kv_heads in (1, 2, 4, 8, 16, 32)",
+    "head_dim == 128",
+    "q_block_size > 0",
+    "(q_block_size * (num_qo_heads // num_kv_heads)) % 8 == 0",
+    "kv_block_size in (8, 16, 32) or (kv_block_size > 0 and kv_block_size % 64 == 0)",
+    "num_q_block_offsets == (seq_len_q + q_block_size - 1) // q_block_size + 1",
+    "kv_valid_bits is None or num_kv_valid_words == (max_seq_len_kv + 31) // 32",
+    "mask_type is None or mask_type in ('dense', 'causal')",
+    "num_page_offsets == batch_size + 1",
+    "paged_kv_indptr[0].item() == 0",
+    "min(paged_kv_indptr[1:] - paged_kv_indptr[:-1]) >= 0",
+    "paged_kv_indptr[-1].item() <= num_page_indices",
+    "max_seq_len_kv >= (seq_len_q if mask_type == 'causal' else 1)",
+    "min(seq_lens_kv) >= (seq_len_q if mask_type == 'causal' else 1)",
+    "max(seq_lens_kv) <= max_seq_len_kv",
+    "page_size in (16, 32, 64, 128)",
+    "page_size >= (kv_block_size if kv_block_size < 64 else 64)",
+    "page_size % (kv_block_size if kv_block_size < 64 else 64) == 0"
+  ],
+  "inputs": {
+    "q": {
+      "shape": [
+        "batch_size",
+        "seq_len_q",
+        "num_qo_heads",
+        "head_dim"
+      ],
+      "dtype": "float16"
+    },
+    "block_indptr": {
+      "shape": [
+        "batch_size",
+        "num_kv_heads",
+        "num_q_block_offsets"
+      ],
+      "dtype": "int32",
+      "description": "Absolute offsets into live block_indices for this wrapper run."
+    },
+    "block_indices": {
+      "shape": [
+        "num_block_indices"
+      ],
+      "dtype": "int32",
+      "description": "Runtime KV-block ID capacity; only entries referenced by block_indptr are live."
+    },
+    "kv_valid_bits": {
+      "shape": [
+        "batch_size",
+        "num_kv_valid_words"
+      ],
+      "dtype": "uint32",
+      "optional": true,
+      "description": "Batch-only token validity bits: token t uses bit t % 32 of word t // 32 (LSB-first); one means valid. Padding bits beyond the planned K/V capacity are ignored."
+    },
+    "q_block_size": {
+      "shape": null,
+      "dtype": "int32",
+      "optional": true
+    },
+    "kv_block_size": {
+      "shape": null,
+      "dtype": "int32",
+      "optional": true
+    },
+    "mask_type": {
+      "shape": null,
+      "dtype": "string",
+      "optional": true
+    },
+    "sm_scale": {
+      "shape": null,
+      "dtype": "float32",
+      "optional": true
+    },
+    "k_cache": {
+      "shape": [
+        "num_pages",
+        "num_kv_heads",
+        "page_size",
+        "head_dim"
+      ],
+      "dtype": "float16",
+      "description": "K pages in the separate HND paged-cache form."
+    },
+    "v_cache": {
+      "shape": [
+        "num_pages",
+        "num_kv_heads",
+        "page_size",
+        "head_dim"
+      ],
+      "dtype": "float16",
+      "description": "V pages in the separate HND paged-cache form."
+    },
+    "paged_kv_indptr": {
+      "shape": [
+        "num_page_offsets"
+      ],
+      "dtype": "int32",
+      "description": "Live request offsets into paged_kv_indices, read for this call."
+    },
+    "paged_kv_indices": {
+      "shape": [
+        "num_page_indices"
+      ],
+      "dtype": "int32",
+      "description": "Runtime physical-page ID capacity; only the prefix ending at paged_kv_indptr[-1] is live."
+    },
+    "max_seq_len_kv": {
+      "shape": null,
+      "dtype": "int32",
+      "optional": true,
+      "description": "Static maximum logical K/V length used for planning."
+    },
+    "seq_lens_kv": {
+      "shape": [
+        "batch_size"
+      ],
+      "dtype": "int32",
+      "description": "Live per-request logical K/V lengths read for this call."
+    }
+  },
+  "outputs": {
+    "output": {
+      "shape": [
+        "batch_size",
+        "seq_len_q",
+        "num_qo_heads",
+        "head_dim"
+      ],
+      "dtype": "float16",
+      "param": "out"
+    }
+  },
+  "check": "def standard_check(\n    reference_outputs: Any,\n    actual_outputs: Any,\n    *,\n    rtol: Optional[float] = None,\n    atol: Optional[float] = None,\n    max_mismatch_pct: float = 0.0,\n    min_cos_sim: Optional[float] = 1.0 - 1e-3,\n) -> bool:\n    \"\"\"Default trace correctness check used when a template does not override it.\"\"\"\n    from flashinfer.trace import default_check\n\n    return default_check(\n        reference_outputs,\n        actual_outputs,\n        rtol=rtol,\n        atol=atol,\n        max_mismatch_pct=max_mismatch_pct,\n        min_cos_sim=min_cos_sim,\n    )\n"
+}

--- a/tests/trace/test_fi_trace_template_consistency.py
+++ b/tests/trace/test_fi_trace_template_consistency.py
@@ -175,7 +175,7 @@ def assert_template_axes_covered(
     )
 
 
-_ALLOWED_CONSTRAINT_BUILTINS = {"max"}
+_ALLOWED_CONSTRAINT_BUILTINS = {"max", "min"}
 
 
 def assert_template_constraints_valid(
@@ -512,7 +512,7 @@ def test_prims_ts_block_sparse_trace_describes_gqa_contract():
         "q",
         "paged_kv_indptr",
         "paged_kv_indices",
-        "seq_len_kv",
+        "max_seq_len_kv",
         "seq_lens_kv",
         "block_indptr",
         "block_indices",
@@ -525,6 +525,20 @@ def test_prims_ts_block_sparse_trace_describes_gqa_contract():
     for template in (tuple_trace, combined_trace):
         assert common_inputs <= template.inputs.keys()
         assert "paged KV" in template.description
+        assert "max_seq_len_kv" in template.axes
+        assert "seq_len_kv" not in template.axes
+        assert template.inputs["max_seq_len_kv"].param is None
+        assert not template.inputs["seq_lens_kv"].optional
+        assert "paged_kv_indptr[-1].item() <= num_page_indices" in template.constraints
+        assert (
+            "max_seq_len_kv >= (seq_len_q if mask_type == 'causal' else 1)"
+            in template.constraints
+        )
+        assert (
+            "min(seq_lens_kv) >= (seq_len_q if mask_type == 'causal' else 1)"
+            in template.constraints
+        )
+        assert "max(seq_lens_kv) <= max_seq_len_kv" in template.constraints
 
     assert tuple_trace.inputs["k_cache"].param == "paged_kv_cache"
     assert tuple_trace.inputs["k_cache"].tuple_idx == 0

--- a/tests/trace/test_fi_trace_template_consistency.py
+++ b/tests/trace/test_fi_trace_template_consistency.py
@@ -373,6 +373,14 @@ _PAIR_IDS = [label for _, _, label in _ALL_PAIRS]
 _EXPECTED_PRIMTS_TRACE_VARIANTS = {
     (
         "flashinfer.attention.prims_ts.block_sparse",
+        "BlockSparseTSWrapper.run",
+    ): 1,
+    (
+        "flashinfer.attention.prims_ts.block_sparse",
+        "BlockSparsePagedTSWrapper.run",
+    ): 2,
+    (
+        "flashinfer.attention.prims_ts.block_sparse",
         "block_sparse_attention",
     ): 1,
     (
@@ -432,7 +440,7 @@ def test_attention_ts_trace_registry_coverage():
         if func.__module__.startswith("flashinfer.attention.prims_ts")
     )
     assert discovered == Counter(_EXPECTED_PRIMTS_TRACE_VARIANTS)
-    assert sum(discovered.values()) == 51
+    assert sum(discovered.values()) == 54
 
 
 def test_attention_ts_trace_constraints_match_cache_axes():
@@ -440,7 +448,9 @@ def test_attention_ts_trace_constraints_match_cache_axes():
     from flashinfer.trace.templates.attention import (
         attention_ts_decode_trace_dispatch,
         prims_ts_block_sparse_trace,
+        prims_ts_block_sparse_wrapper_trace_dispatch,
         prims_ts_paged_block_sparse_trace_dispatch,
+        prims_ts_paged_block_sparse_wrapper_trace_dispatch,
         prims_ts_decode_mla_one_shot_trace_dispatch,
         prims_ts_decode_mla_trace_dispatch,
         prims_ts_decode_mla_wrapper_trace_dispatch,
@@ -461,6 +471,8 @@ def test_attention_ts_trace_constraints_match_cache_axes():
     block_sparse_templates = (
         prims_ts_block_sparse_trace,
         *prims_ts_paged_block_sparse_trace_dispatch.templates,
+        *prims_ts_block_sparse_wrapper_trace_dispatch.templates,
+        *prims_ts_paged_block_sparse_wrapper_trace_dispatch.templates,
     )
     for dispatch in (*fmha_dispatches, *mla_dispatches):
         for template in dispatch.templates:
@@ -489,7 +501,9 @@ def test_attention_ts_trace_constraints_match_cache_axes():
 def test_prims_ts_block_sparse_trace_describes_gqa_contract():
     from flashinfer.trace.templates.attention import (
         prims_ts_block_sparse_trace,
+        prims_ts_block_sparse_wrapper_trace_dispatch,
         prims_ts_paged_block_sparse_trace_dispatch,
+        prims_ts_paged_block_sparse_wrapper_trace_dispatch,
     )
 
     constraints = set(prims_ts_block_sparse_trace.constraints)
@@ -563,6 +577,26 @@ def test_prims_ts_block_sparse_trace_describes_gqa_contract():
         prims_ts_paged_block_sparse_trace_dispatch(paged_kv_cache=combined_cache)
         is combined_trace
     )
+
+    contiguous_wrapper_trace = prims_ts_block_sparse_wrapper_trace_dispatch.templates[0]
+    assert contiguous_wrapper_trace.name_prefix == "prims_ts_block_sparse_wrapper"
+    wrapper_paged_templates = {
+        template.name_prefix: template
+        for template in prims_ts_paged_block_sparse_wrapper_trace_dispatch.templates
+    }
+    assert set(wrapper_paged_templates) == {
+        "prims_ts_paged_block_sparse_wrapper_tuple",
+        "prims_ts_paged_block_sparse_wrapper_combined",
+    }
+    for template in (
+        contiguous_wrapper_trace,
+        *wrapper_paged_templates.values(),
+    ):
+        assert "Reusable" in template.description
+        for name in ("q_block_size", "kv_block_size", "mask_type"):
+            assert template.inputs[name].optional
+    for template in wrapper_paged_templates.values():
+        assert template.inputs["max_seq_len_kv"].optional
 
 
 def test_attention_ts_sq4_trace_dispatch_covers_all_public_decode_apis():


### PR DESCRIPTION
## 📌 Description

A follow-up to #4474 that makes paged PrimTS block-sparse attention consume live request metadata.

- Keep only static geometry and capacity in `BlockSparsePagedTSWrapper.plan()`.
- Pass live page indptr, page IDs, KV sequence lengths, BSR routes, and validity bits to `run()`.
- Reusable wrappers validate tensor structure on the host but trust device-side metadata values. Invalid values are unsupported and may access out of bounds; setting `CUTE_DSL_ENABLE_ASSERTIONS=1` before kernel compilation enables diagnostic device assertions.
- One-shot APIs synchronously inspect live paged-KV and BSR values before planning and execution.
- Add reusable wrapper trace schemas for contiguous, paged tuple-cache, and paged combined-cache forms, with CUDA Graph coverage.

This lets one static capacity plan be reused across decode steps and CUDA Graph replays.

### Intentional API migration

This intentionally changes the experimental paged block-sparse API introduced by #4474. The old API appeared in nightly builds but has not shipped in a stable or RC release.

- `plan()` now takes `batch_size`, `max_seq_len_kv`, and `device`; it no longer snapshots `paged_kv_indptr` or `seq_lens_kv`.
- `run()` now takes live `paged_kv_indptr`, `paged_kv_indices`, and `seq_lens_kv`.
- `block_sparse_attention_with_paged_kv_cache()` now uses `max_seq_len_kv` and requires `seq_lens_kv`.

Nightly users must move request metadata from `plan()` to each `run()` call and keep tensor addresses stable across CUDA Graph replay.

## 🔍 Related Issues

Dependency for the TensorRT-LLM PrimTS block-sparse / VisualGen VSA integration.

## 🚀 Pull Request Checklist

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit`.
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks on all changed files and fixed all reported issues.

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All relevant focused tests are passing.

Validation:
- Focused block-sparse/trace checks after rebase: `21 passed`.
- Full trace template consistency: `750 passed`.
- Batch-aware trace cleanup: `7 passed, 743 deselected`.
- Pre-commit on changed files: passed.

## Reviewer Notes

The paged kernel ABI already accepted page metadata and KV lengths as runtime tensors. This change removes wrapper-side snapshots and always selects the dynamic-length specialization for paged storage; it does not change the FMHA math kernel.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Paged block-sparse attention now accepts live per-request sequence lengths and page mappings at execution time.
  * Planning uses static capacity limits, while reusable wrappers consume current runtime metadata.
  * Added reusable wrapper tracing for contiguous and paged cache formats.
  * One-shot APIs validate live metadata before execution; reusable APIs support optional assertion diagnostics.

* **Documentation**
  * Updated APIs, trace schemas, examples, and guidance to distinguish static capacities from live runtime metadata.
  * Documented requirements and limitations for CUDA Graph capture and invalid runtime values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
