### PR TITLE
fix: Correctly wire scale_qkvo to cute-dsl fmha backends

### DIFF
--- a/flashinfer/prefill.py
+++ b/flashinfer/prefill.py
@@ -4193,10 +4193,6 @@ class BatchPrefillWithRaggedKVCacheWrapper:
             )
             return out
         elif self._backend == "cute-dsl":
-            if any(s is not None for s in (q_scale, k_scale, v_scale, o_scale)):
-                raise NotImplementedError(
-                    "cute-dsl backend does not support FP8 scale parameters"
-                )
             if kv_cache_sf is not None:
                 raise NotImplementedError(
                     "cute-dsl backend does not support NVFP4 packed KV cache "
@@ -4223,6 +4219,14 @@ class BatchPrefillWithRaggedKVCacheWrapper:
                 # separate-V-dtype variants).  Windowed plans stay on the
                 # modular path for every V dtype.
                 p = self._cute_dsl_fmha_plan
+                bmm1_scale = (
+                    p["sm_scale"]
+                    * (q_scale if q_scale is not None else 1.0)
+                    * (k_scale if k_scale is not None else 1.0)
+                )
+                bmm2_scale = (v_scale if v_scale is not None else 1.0) * (
+                    o_scale if o_scale is not None else 1.0
+                )
                 return trtllm_ragged_attention_deepseek(
                     query=q,
                     key=k,
@@ -4231,8 +4235,8 @@ class BatchPrefillWithRaggedKVCacheWrapper:
                     seq_lens=p["seq_lens"],
                     max_q_len=p["max_q_len"],
                     max_kv_len=p["max_kv_len"],
-                    bmm1_scale=p["sm_scale"],
-                    bmm2_scale=1.0,
+                    bmm1_scale=bmm1_scale,
+                    bmm2_scale=bmm2_scale,
                     o_sf_scale=1.0,
                     batch_size=p["batch_size"],
                     window_left=p["window_left"],
@@ -4244,6 +4248,11 @@ class BatchPrefillWithRaggedKVCacheWrapper:
                     out=out,
                     lse=lse,
                     backend="cute-dsl",
+                )
+            # Modular CuTe DSL backend does not support scale parameters.
+            if any(s is not None for s in (q_scale, k_scale, v_scale, o_scale)):
+                raise NotImplementedError(
+                    "cute-dsl backend does not support FP8 scale parameters"
                 )
             if return_lse:
                 # Standard-path modular kernel computes LSE natively; the

--- a/flashinfer/prefill.py
+++ b/flashinfer/prefill.py
@@ -4224,7 +4224,7 @@ class BatchPrefillWithRaggedKVCacheWrapper:
                     * (q_scale if q_scale is not None else 1.0)
                     * (k_scale if k_scale is not None else 1.0)
                 )
-                bmm2_scale = (v_scale if v_scale is not None else 1.0) * (
+                bmm2_scale = (v_scale if v_scale is not None else 1.0) / (
                     o_scale if o_scale is not None else 1.0
                 )
                 return trtllm_ragged_attention_deepseek(

--- a/tests/attention/test_cute_dsl_fmha_backend.py
+++ b/tests/attention/test_cute_dsl_fmha_backend.py
@@ -135,8 +135,10 @@ def test_deepseek_cute_dsl(dtype_qk, dtype_vo, Dqk, Dvo):
         (torch.float8_e4m3fn, torch.float8_e4m3fn),
     ],
 )
+@pytest.mark.parametrize("scale_bmm1", [1.0, 0.8])
+@pytest.mark.parametrize("scale_bmm2", [1.0, 0.6])
 @pytest.mark.parametrize("causal", [False, True])
-def test_batch_prefill_cute_dsl(dtype_qk, dtype_vo, causal):
+def test_batch_prefill_cute_dsl(dtype_qk, dtype_vo, scale_bmm1, scale_bmm2, causal):
     torch.manual_seed(0)
     b, s, Hq, Hk, D = 2, 1024, 8, 8, 128
     qo = _indptr([s] * b)
@@ -150,19 +152,19 @@ def test_batch_prefill_cute_dsl(dtype_qk, dtype_vo, causal):
         ws, kv_layout="NHD", backend="cute-dsl"
     )
     w.plan(qo, kv, Hq, Hk, D, causal=causal, q_data_type=dtype_qk)
-    o = w.run(q, k, v)
-    ref = _ragged_ref(qr, kr, vr, qo, kv, sm, causal=causal)
-    atol = 4e-2 if min(dtype_qk.itemsize, dtype_vo.itemsize) == 1 else 6e-3
+    o = w.run(q, k, v, q_scale=scale_bmm1, v_scale=scale_bmm2)
+    ref = _ragged_ref(qr, kr, vr, qo, kv, sm * scale_bmm1, causal=causal) * scale_bmm2
+    atol = 4.5e-2 if min(dtype_qk.itemsize, dtype_vo.itemsize) == 1 else 6e-3
     torch.testing.assert_close(o.float(), ref.float(), atol=atol, rtol=atol)
 
     # Check whether the caller provided out and returned out match
     out_buf = torch.empty_like(o)
-    o_explicit = w.run(q, k, v, out=out_buf)
+    o_explicit = w.run(q, k, v, q_scale=scale_bmm1, v_scale=scale_bmm2, out=out_buf)
     assert o_explicit.dtype == o.dtype
     torch.testing.assert_close(o_explicit, o, rtol=0, atol=0)
 
     # LSE is now supported for standard attention.
-    o2, lse = w.run(q, k, v, return_lse=True)
+    o2, lse = w.run(q, k, v, q_scale=scale_bmm1, v_scale=scale_bmm2, return_lse=True)
     torch.testing.assert_close(o2.float(), o.float(), atol=1e-2, rtol=1e-2)
     assert lse.shape == (total, Hq)
 


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

Correctly wire scale_qkvo to cute-dsl fmha backends.

`scale_q`, `scale_k`, and `scale_v` was forbidden previously because modular CuTeDSL FMHA didn't support quantization. Now we have multiple variants with FP8 quantization support, so this wiring becomes a hard prerequisite.

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved FP8 scale handling for dense and causal attention operations.
  - Corrected value and output scaling during attention computation.
  - Clarified validation behavior for unsupported scaling options in modular attention execution.
  - Ensured scaled attention results remain accurate across supported execution modes.
- **Tests**
  - Expanded verification to cover scaled outputs and log-sum-exp results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->