### PR TITLE
fix(gemm): probe for CuTe DSL without importing cute_dsl.utils

### DIFF
--- a/flashinfer/gemm/kernels/__init__.py
+++ b/flashinfer/gemm/kernels/__init__.py
@@ -29,14 +29,22 @@ Supported architectures:
 - SM107 (Rubin): bmm_fp8_rubin.py
 """
 
-from flashinfer.cute_dsl.utils import (
-    is_cute_dsl_available,
-    is_rubin_cute_dsl_available,
+import importlib.util
+
+# Probed here rather than imported from cute_dsl.utils, which has a top-level
+# `import cutlass` and so is unimportable in the wheel build envs (#4651).
+_CUTE_DSL_AVAILABLE = (
+    importlib.util.find_spec("cutlass") is not None
+    and importlib.util.find_spec("cutlass.cute") is not None
+)
+_RUBIN_CUTE_DSL_AVAILABLE = (
+    _CUTE_DSL_AVAILABLE
+    and importlib.util.find_spec("cutlass.utils.rubin_helpers") is not None
 )
 
 __all__ = []
 
-if is_cute_dsl_available():
+if _CUTE_DSL_AVAILABLE:
     from .bmm_fp8_wrapper import (
         bmm_fp8_cute_dsl,
         cute_bmm_fp8_can_implement,
@@ -47,7 +55,7 @@ if is_cute_dsl_available():
 
     # SM107 kernels need CuTe DSL >= 4.8; skip the re-export on older DSL so
     # that importing FlashInfer still works there.
-    if is_rubin_cute_dsl_available():
+    if _RUBIN_CUTE_DSL_AVAILABLE:
         from .bmm_fp8_rubin import SM107PersistentDenseGemmKernel
 
     __all__ += [
@@ -62,5 +70,5 @@ if is_cute_dsl_available():
         "PersistentDenseGemmKernel",
     ]
 
-    if is_rubin_cute_dsl_available():
+    if _RUBIN_CUTE_DSL_AVAILABLE:
         __all__ += ["SM107PersistentDenseGemmKernel"]

--- a/flashinfer/gemm/kernels/__init__.py
+++ b/flashinfer/gemm/kernels/__init__.py
@@ -31,8 +31,8 @@ Supported architectures:
 
 import importlib.util
 
-# Probed here rather than imported from cute_dsl.utils, which has a top-level
-# `import cutlass` and so is unimportable in the wheel build envs (#4651).
+# cute_dsl.utils has a top-level `import cutlass`, so the guard cannot be
+# imported without the thing it guards (#4651).
 _CUTE_DSL_AVAILABLE = (
     importlib.util.find_spec("cutlass") is not None
     and importlib.util.find_spec("cutlass.cute") is not None


### PR DESCRIPTION
## 📌 Description

Nightly Release has been red since Aug 20 ([run 32321975995](https://github.com/flashinfer-ai/flashinfer/actions/runs/32321975995), [run 32437535825](https://github.com/flashinfer-ai/flashinfer/actions/runs/32437535825)). `build-flashinfer-cubin` and all six `build-flashinfer-jit-cache` matrix jobs fail with:

```
ModuleNotFoundError: No module named 'cutlass'
```

`create-release`, `test-nightly-build`, and `update-wheel-index` are skipped as a result, so no nightly wheels have published for two days.

### Root cause

`flashinfer/gemm/kernels/__init__.py` imports the CuTe DSL availability probe at module scope:

```python
from flashinfer.cute_dsl.utils import (
    is_cute_dsl_available,
    is_rubin_cute_dsl_available,
)
```

`is_cute_dsl_available()` is itself safe — it only calls `importlib.util.find_spec`. The problem is where it lives: `flashinfer/cute_dsl/utils.py` line 25 does an unconditional top-level `import cutlass`. **The guard cannot be imported without the thing it guards.**

Because `flashinfer/__init__.py` → `gemm` → `gemm_base.py:66` → `.kernels.utils` reaches it, this turned the optional CuTe DSL into a hard dependency of plain `import flashinfer`.

Both wheel build backends import the package while building:

- `flashinfer-cubin/build_backend.py:21` — `from flashinfer.artifacts import download_artifacts`
- `flashinfer-jit-cache/build_backend.py:121` — `from flashinfer import aot`

Neither `build-system.requires` list includes `nvidia-cutlass-dsl`, since CuTe DSL is intentionally optional. Regular PR CI *does* have it installed, which is why this passed review and only surfaced in the nightly.

Note that `flashinfer/gemm/__init__.py`, `flashinfer/quantization/__init__.py`, and `flashinfer/__init__.py` all reach `cute_dsl.utils` too, but each wraps the import in `try/except ImportError` or `contextlib.suppress(ImportError)`. `gemm/kernels/__init__.py` was the only unguarded site.

### Regression point

Introduced by #4526 (`f0922749`, merged Aug 19 23:36 UTC), which added the CuTe DSL block to a previously import-free `__init__.py`. The `import cutlass` in `cute_dsl/utils.py` is much older and was harmless until something eagerly imported it.

Bisected by simulating the build env (dropping `cutlass` from the interpreter path):

| ref | result |
| --- | --- |
| `d3ff85a9` (#4526 parent) | `import flashinfer OK` |
| `f0922749` (#4526) | reproduces the CI traceback line for line |
| `46fc99b9` (base) | still broken |

### ⚠️ `release-v0.6.18` is affected too

`release-v0.6.18` carries #4526 as cherry-pick `d5e45b38` and has the identical unguarded import. Tags `v0.6.18rc4` through `v0.6.18rc7` all contain it (`rc1`–`rc3` do not), and `release.yml` builds both wheels with the same isolated `python -m build --wheel`. **This fix needs cherry-picking to `release-v0.6.18` or the v0.6.18 release build will fail the same way.** Happy to open that PR once this lands.

### Relationship to #4469

[#4469](https://github.com/flashinfer-ai/flashinfer/pull/4469) (open) independently works around this by overriding `get_requires_for_build_wheel` in both build backends to inject `nvidia-cutlass-dsl` into the isolated build env. That makes the builds pass without addressing the import itself — the "mask it with a build dep" route issue #4651 explicitly argued against. It is also why `release.yml` run 32502902466 was green on Aug 21 despite building culprit-containing code.

The two PRs do not conflict textually (this one touches only `flashinfer/gemm/kernels/__init__.py`), but **maintainers should decide which approach is canonical rather than landing both silently.** My view: keeping `import flashinfer` working without the optional CuTe DSL is a property worth preserving on its own merits, independent of what the build envs install.

### Why inline the probe

`flashinfer/topk_varlen/topk_varlen.py:48` already duplicates this exact probe with an explicit comment:

```python
# Check for the Python CuTe DSL package without importing it (and without
# importing cute_dsl/utils.py, which has top-level `import cutlass`).
```

and `flashinfer/fused_moe/runners.py:2647` imports it lazily inside a function for the same reason. Both probes are pure `find_spec` calls, so inlining loses nothing.

Neither `is_cute_dsl_available` nor `is_rubin_cute_dsl_available` was in this module's `__all__`, nothing in the tree imports them from `flashinfer.gemm.kernels`, and `git tag --contains f0922749` is empty — they have never shipped in a release. Backward-compatibility risk is effectively zero.

**This does add a third copy of the probe, which is real copy-paste debt.** The better long-term fix is to move the probes into an import-light module that `cute_dsl/utils.py` also uses — note `flashinfer/cutile/cutile_common.py` already does exactly this for the *cuTile* optional dependency ("This module intentionally has no `cuda.tile` imports so it stays importable..."), so CuTe DSL is the outlier. Making `cute_dsl/utils.py` itself lazily importable is a genuine refactor: it has six top-level `cutlass` imports and needs them at import time for a `Pointer` subclass, two `@dsl_user_op` decorators, and eagerly-evaluated annotations. I kept this PR minimal to unblock the nightly and am happy to follow up, or to instead delete the re-exports outright (issue #4651's suggestion — I tested it and nothing breaks) if reviewers prefer that.

## 🔍 Related Issues

Closes #4651

## 🚀 Pull Request Checklist

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

## 🧪 Tests

- [ ] Tests have been added or updated as needed. — **no test added; see Reviewer Notes**
- [x] All tests are passing (`unittest`, etc.).

### Repro

In an interpreter with `cutlass` removed from `sys.path` (simulating the PEP 517 build env), exercising the two build-backend entry points:

```python
import importlib.util, sys
sys.path[:] = [p for p in sys.path if "nvidia_cutlass_dsl" not in p]
assert importlib.util.find_spec("cutlass") is None

from flashinfer.artifacts import download_artifacts   # flashinfer-cubin
from flashinfer import aot                            # flashinfer-jit-cache
```

Before this change both raise `ModuleNotFoundError: No module named 'cutlass'`; after, both import cleanly.

### Test plan

- **Without `cutlass`:** `import flashinfer` succeeds and both build-backend entry points import cleanly; both fail on unpatched `46fc99b9`. Pushing past the import, `aot.gen_all_modules(sm_capabilities={"sm100": True})` enumerates all JIT specs in a cutlass-free interpreter.
- **Real isolated wheel build:** `python -m build --wheel` on `flashinfer-cubin` from this branch, with default PEP 517 isolation, completes with exit 0 and produces a wheel. The isolated env installs only the nine declared requires, with no `cutlass` anywhere. That is the whole `build-flashinfer-cubin` job reproduced locally and green.
- **With `cutlass` installed:** `flashinfer.gemm.kernels.__all__` is byte-identical to baseline (same 5 names), `flashinfer.gemm.__all__` and `dir(flashinfer)` unchanged. The Rubin probe correctly reports `False` on the installed DSL 4.7; simulating a DSL that exposes `cutlass.utils.rubin_helpers` makes both base and this branch reach the SM107 import at exactly the same point.
- `pre-commit run --files flashinfer/gemm/kernels/__init__.py` — all hooks pass (mypy, ruff check, ruff format).
- **GPU (B200, SM100):** `pytest tests/gemm/test_bmm_fp8.py` gives `4 failed, 2 passed, 1 skipped` on both this branch and baseline `46fc99b9`, same 4 test IDs. To be clear about what this does and does not show: those failures are local `ninja` JIT build errors in an editable checkout, unrelated to this change, and every CuTe DSL case in that suite is SM107-gated so it skips on a B200. The run is evidence of *no regression*, not evidence that the changed code path is covered. The namespace diff and the DSL-4.8 simulation above are the real neutrality evidence.

## Reviewer Notes

**No test is added, and I want to be straight that this is a gap rather than an impossibility.** My earlier framing (that the regression is unobservable from the test suite) was too strong: the repro above is CPU-only and runs in about two seconds, so a regression test is entirely feasible. What is true is that no *existing* job would catch it, because PR CI always installs `nvidia-cutlass-dsl`.

Two concrete options, and I am happy to add either or both here rather than as follow-up:

1. `tests/utils/test_import_without_cute_dsl.py` — resolve the cutlass wheel directory via `find_spec("cutlass").submodule_search_locations[0]`, skip if that directory *is* `purelib` (otherwise the subprocess would lose `torch` too), then run `python -c "import flashinfer"` with that path entry removed and assert exit 0.
2. A sibling job in `.github/workflows/pre-commit.yml` (already a lightweight `ubuntu-latest` job on every PR) that installs CPU torch and the package *without* the DSL and runs `python -c "import flashinfer"`.

Without one of these, the underlying hazard — the top-level `import cutlass` in `cute_dsl/utils.py` — stays live and the next eager importer breaks the nightly again with zero PR-CI signal.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of optional GPU kernel capabilities.
  * Prevented unsupported kernel integrations from being exposed when required components are unavailable.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->