### PR TITLE
[release-v0.6.18] fix(gemm): probe for CuTe DSL without importing cute_dsl.utils

### DIFF
--- a/flashinfer/gemm/kernels/__init__.py
+++ b/flashinfer/gemm/kernels/__init__.py
@@ -29,14 +29,22 @@ Supported architectures:
 - SM107 (Rubin): bmm_fp8_rubin.py
 """
 
-from flashinfer.cute_dsl.utils import (
-    is_cute_dsl_available,
-    is_rubin_cute_dsl_available,
+import importlib.util
+
+# Probed here rather than imported from cute_dsl.utils, which has a top-level
+# `import cutlass` and so is unimportable in the wheel build envs (#4651).
+_CUTE_DSL_AVAILABLE = (
+    importlib.util.find_spec("cutlass") is not None
+    and importlib.util.find_spec("cutlass.cute") is not None
+)
+_RUBIN_CUTE_DSL_AVAILABLE = (
+    _CUTE_DSL_AVAILABLE
+    and importlib.util.find_spec("cutlass.utils.rubin_helpers") is not None
 )
 
 __all__ = []
 
-if is_cute_dsl_available():
+if _CUTE_DSL_AVAILABLE:
     from .bmm_fp8_wrapper import (
         bmm_fp8_cute_dsl,
         cute_bmm_fp8_can_implement,
@@ -47,7 +55,7 @@ if is_cute_dsl_available():
 
     # SM107 kernels need CuTe DSL >= 4.8; skip the re-export on older DSL so
     # that importing FlashInfer still works there.
-    if is_rubin_cute_dsl_available():
+    if _RUBIN_CUTE_DSL_AVAILABLE:
         from .bmm_fp8_rubin import SM107PersistentDenseGemmKernel
 
     __all__ += [
@@ -62,5 +70,5 @@ if is_cute_dsl_available():
         "PersistentDenseGemmKernel",
     ]
 
-    if is_rubin_cute_dsl_available():
+    if _RUBIN_CUTE_DSL_AVAILABLE:
         __all__ += ["SM107PersistentDenseGemmKernel"]

--- a/flashinfer/gemm/kernels/__init__.py
+++ b/flashinfer/gemm/kernels/__init__.py
@@ -31,8 +31,8 @@ Supported architectures:
 
 import importlib.util
 
-# Probed here rather than imported from cute_dsl.utils, which has a top-level
-# `import cutlass` and so is unimportable in the wheel build envs (#4651).
+# cute_dsl.utils has a top-level `import cutlass`, so the guard cannot be
+# imported without the thing it guards (#4651).
 _CUTE_DSL_AVAILABLE = (
     importlib.util.find_spec("cutlass") is not None
     and importlib.util.find_spec("cutlass.cute") is not None


### PR DESCRIPTION
## 📌 Description

Cherry-pick of #4668 to `release-v0.6.18`.

`release-v0.6.18` carries #4526 as cherry-pick `d5e45b38` and therefore has the same unguarded import that has been breaking the nightly wheel builds on `main` since Aug 20:

```
ModuleNotFoundError: No module named 'cutlass'
```

`flashinfer/gemm/kernels/__init__.py` imports the CuTe DSL availability probe at module scope from `flashinfer/cute_dsl/utils.py`, which does an unconditional top-level `import cutlass`. The guard cannot be imported without the thing it guards, so the optional CuTe DSL becomes a hard requirement of plain `import flashinfer`.

Both wheel build backends import the package while building and neither declares `nvidia-cutlass-dsl` in `build-system.requires`:

- `flashinfer-cubin/build_backend.py:21` — `from flashinfer.artifacts import download_artifacts`
- `flashinfer-jit-cache/build_backend.py:121` — `from flashinfer import aot`

### Why this matters for the release

`release.yml` builds `flashinfer-cubin` and `flashinfer-jit-cache` with the same isolated `python -m build --wheel` the nightly uses, so **the v0.6.18 release build fails the same way without this.**

Affected tags, verified with `git merge-base --is-ancestor d5e45b38 <tag>`:

| tag | affected |
| --- | --- |
| `v0.6.18rc1` – `v0.6.18rc3` | no |
| `v0.6.18rc4` – `v0.6.18rc7` | **yes** |

The file is byte-identical to `main`'s pre-fix version, so both commits cherry-picked cleanly with no conflicts and no adaptation.

## 🔍 Related Issues

Cherry-pick of #4668. Refs #4651 — leaving the issue to be closed by the `main` PR.

## 🚀 Pull Request Checklist

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

## 🧪 Tests

- [ ] Tests have been added or updated as needed. — none added; see #4668 Reviewer Notes
- [x] All tests are passing (`unittest`, etc.).

### Test plan

Verified on this branch, not just inherited from #4668:

- **Without `cutlass`** (simulating the isolated build env by dropping the `nvidia_cutlass_dsl` entry from `sys.path`): both build-backend entry points import cleanly on this branch, and both fail on unpatched `v0.6.18rc7` (`3b3e688a`) with the reported traceback.
- **With `cutlass` installed:** `flashinfer.gemm.kernels.__all__` is identical between this branch and `rc7` — the same five names (`bmm_fp8_cute_dsl`, `cute_bmm_fp8_can_implement`, `SM107_AUTOTUNE_CONFIGS`, `get_valid_sm107_configs`, `PersistentDenseGemmKernel`).
- `pre-commit run --files flashinfer/gemm/kernels/__init__.py` — all hooks pass (mypy, ruff check, ruff format).

Repro:

```python
import importlib.util, sys
sys.path[:] = [p for p in sys.path if "nvidia_cutlass_dsl" not in p]
assert importlib.util.find_spec("cutlass") is None

from flashinfer.artifacts import download_artifacts   # flashinfer-cubin
from flashinfer import aot                            # flashinfer-jit-cache
```

## Reviewer Notes

Ordering is up to maintainers — this can land before #4668 if you want to unblock an rc8 sooner, since the two are independent and touch the same single file identically.

Note also that #4469 (open, targets `main`) works around the same failure by injecting `nvidia-cutlass-dsl` into both build backends' `get_requires_for_build_wheel`. If that approach is preferred over fixing the import, this cherry-pick becomes unnecessary — worth deciding before merging both.