### PR TITLE
fix: stop SM110 emitting MoE cluster shapes its dispatch path rejects

### DIFF
--- a/csrc/nv_internal/tensorrt_llm/kernels/cutlass_kernels/cutlass_heuristic.cpp
+++ b/csrc/nv_internal/tensorrt_llm/kernels/cutlass_kernels/cutlass_heuristic.cpp
@@ -562,7 +562,11 @@ std::vector<CutlassGemmConfig> get_candidate_configs_sm110(
   std::vector<CutlassGemmConfig> candidate_configs;
   for (int cluster_m = 1; cluster_m <= 2; cluster_m++) {
     bool Is2SM = cluster_m == 2;
-    for (int cluster_n = 1; cluster_n <= 2; cluster_n++) {
+    // SM110 shares the SM100 dispatch path, which uses a runtime cluster shape and
+    // therefore supports only 1x1x1 and 2x1x1 (see are_tile_shapes_supported_sm100).
+    // Emitting cluster_n == 2 produces candidates that always TLLM_THROW at dispatch:
+    // "Unsupported tile (64, 64, 64) and cluster (1, 2, 1) shape combination for arch 100".
+    for (int cluster_n = 1; cluster_n <= 1; cluster_n++) {
       std::vector base = {// M=128
                           CutlassTileConfigSM100::CtaShape128x128x128B,
                           CutlassTileConfigSM100::CtaShape128x256x128B};


### PR DESCRIPTION
## 📌 Description

On Jetson AGX Thor (SM110a) an NVFP4 MoE GEMM aborts with:

```
Unsupported tile (64, 64, 64) and cluster (1, 2, 1) shape combination for arch 100.
```

Root cause is a mismatch between the SM110 **candidate generator** and the SM100 **dispatch predicate** that SM110 shares:

1. `flashinfer/fused_moe/core.py` maps backend `"110"` to the SM100 module, so SM110 kernels instantiate with `Arch::kMinComputeCapability == 100`.
2. `get_candidate_configs_sm110()` enumerates `cluster_n` over `{1, 2}`, emitting `ClusterShape_1x2x1` and `2x2x1`.
3. Dispatch validates candidates with `are_tile_shapes_supported_sm100()`, whose first statement is:

```cpp
// We use a runtime cluster shape for SM100, so we only support 1x1x1 and 2x1x1 cluster shapes.
if (cute::size<0>(ClusterShape{}) > 2 || cute::size<1>(ClusterShape{}) != 1 ||
    cute::size<2>(ClusterShape{}) != 1) {
  return false;
}
```

Every candidate with `cluster_n == 2` therefore fails, and the `SHAPE_CASE` macro in `moe_gemm_template_dispatch_tma_ws.h` turns that into a runtime `TLLM_THROW`. The reported failure is exactly this pairing: `CtaShape64x64x128B` (from the one-SM tile list) with `ClusterShape_1x2x1`.

The live SM100 generator does not emit N=2 clusters — `get_candidate_configs_sm100` delegates to `get_candidate_configs_sm100_dynamic_cluster_shape`, which uses only `cluster1sm` and `cluster2sm`. Notably a **deprecated** `get_candidate_configs_sm100` is still present, commented out, in the same file, containing the identical `cluster_n <= 2` loop — `get_candidate_configs_sm110` appears to be a copy of it, and so inherited an enumeration the live SM100 path had already abandoned when it moved to the runtime-cluster-shape approach.

This restricts the SM110 generator to `cluster_n == 1`, matching the constraint the dispatch predicate already enforces. The restriction is a property of this code path (a runtime cluster shape is used), not of the tile sizes, so the fix stops generating invalid candidates rather than widening the predicate.

## 🔍 Related Issues

Fixes #3134

## 🚀 Pull Request Checklist

### ✅ Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> Being upfront: I have **not** run `pre-commit` locally — this was authored against the packaged source on the target device rather than a full checkout. The change is one loop bound plus comments (all under 100 columns), so it should be formatting-neutral, but please let CI be the judge and I will fix anything it flags.

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

No regression test is included: reproducing the throw requires an SM110 device, which I do not believe is present in CI. If you would like one, I am happy to add a host-side unit test asserting that every config returned by `get_candidate_configs_sm110()` satisfies `are_tile_shapes_supported_sm100()`'s cluster constraint — that would catch this class of generator/predicate drift without needing the hardware. Say the word and I will push it.

## Reviewer Notes

Two things worth a reviewer's attention:

1. **Is `cluster_n == 1` the right fix, or should SM110 get its own predicate?** I chose to restrict the generator because the 1x1x1/2x1x1 limit is documented as a property of the runtime-cluster-shape dispatch path shared by SM100 and SM110, not as a hardware limit. If SM110 is intended to support 2-SM-wide clusters through a different path, the correct fix is different and I would rather be told than guess.
2. **The constraint is currently enforced only at dispatch time, as a throw.** Asserting it at generation time would turn this class of bug into a CI failure instead of a user-visible crash on first MoE forward pass. Out of scope here, but it is what would have prevented the original.

Verified on the target device (Jetson AGX Thor, SM110, CUDA 13, vLLM 0.27.1 + FlashInfer): all five FlashInfer NVFP4 MoE backends are currently gated off for SM110 in vLLM with a comment citing this issue, so this is the blocker for re-enabling them there.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TensorRT-LLM kernel configuration selection for SM110 GPUs.
  * Prevented unsupported cluster configurations from being selected, improving dispatch reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->