### PR TITLE
perf(gemm): cut per-call host overhead on the GEMM dispatch path (auto 200 -> 59 us)

### DIFF
--- a/benchmarks/bench_host_overhead.py
+++ b/benchmarks/bench_host_overhead.py
@@ -1,0 +1,100 @@
+"""Per-call HOST (CPU) overhead of the GEMM dispatch path.
+
+Host cost only matters when it exceeds the kernel, which is the eager
+LLM-serving regime: small M, weights already resident.  This measures enqueue
+rate -- N calls with no per-call sync, on a shape whose kernel is far cheaper
+than the dispatch -- so wall/N is the host cost.
+
+    python benchmarks/bench_host_overhead.py [--json out.json] [--compare base.json]
+
+Use --compare to print a before/after table when changing the dispatch path.
+"""
+
+import argparse
+import json
+import time
+
+import torch
+
+import flashinfer
+
+DEFAULT_SHAPE = (8, 2048, 2048)  # M, N, K -- kernel ~2 us, dispatch dominates
+
+
+def bench(fn, reps=300, warmup=50):
+    for _ in range(warmup):
+        fn()
+    torch.cuda.synchronize()
+    best = float("inf")
+    for _ in range(5):
+        t0 = time.perf_counter()
+        for _ in range(reps):
+            fn()
+        torch.cuda.synchronize()
+        best = min(best, (time.perf_counter() - t0) / reps * 1e6)
+    return best
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument(
+        "--shape",
+        type=int,
+        nargs=3,
+        default=list(DEFAULT_SHAPE),
+        metavar=("M", "N", "K"),
+    )
+    ap.add_argument("--reps", type=int, default=300)
+    ap.add_argument("--json", type=str, default="")
+    ap.add_argument("--compare", type=str, default="")
+    args = ap.parse_args()
+
+    dev = torch.device("cuda:0")
+    m, n, k = args.shape
+    a = torch.randn(m, k, device=dev, dtype=torch.bfloat16)
+    b = torch.randn(k, n, device=dev, dtype=torch.bfloat16).t().contiguous().t()
+    out = torch.empty(m, n, device=dev, dtype=torch.bfloat16)
+
+    props = torch.cuda.get_device_properties(0)
+    print(
+        f"{props.name} sm{props.major}{props.minor} | mm_bf16 M={m} N={n} K={k} "
+        f"| torch {torch.__version__} | flashinfer {flashinfer.__version__}"
+    )
+
+    results = {"torch.mm": bench(lambda: torch.mm(a, b, out=out), args.reps)}
+    for backend in ("auto", "cudnn", "cublaslt", "cutlass", "tgv", "tinygemm"):
+        try:
+            flashinfer.mm_bf16(a, b, out=out, backend=backend)
+        except Exception as exc:
+            print(f"  skip {backend}: {str(exc)[:60]}")
+            continue
+        results[f"mm_bf16({backend})"] = bench(
+            lambda x=backend: flashinfer.mm_bf16(a, b, out=out, backend=x), args.reps
+        )
+
+    base = None
+    if args.compare:
+        with open(args.compare) as f:
+            base = json.load(f)["results"]
+    width = max(len(x) for x in results)
+    print(
+        f"\n{'':<{width}}  {'us/call':>9s}"
+        + (f"{'baseline':>10s}{'delta':>10s}" if base else "")
+    )
+    for name, us in results.items():
+        line = f"{name:<{width}}  {us:9.1f}"
+        if base and name in base:
+            d = us - base[name]
+            line += f"{base[name]:10.1f}{d:+10.1f}"
+        print(line)
+
+    if args.json:
+        with open(args.json, "w") as f:
+            json.dump(
+                {"shape": [m, n, k], "gpu": props.name, "results": results}, f, indent=1
+            )
+        print(f"\n-> {args.json}")
+
+
+if __name__ == "__main__":
+    main()

--- a/flashinfer/autotuner/autotuner.py
+++ b/flashinfer/autotuner/autotuner.py
@@ -4,6 +4,7 @@ import functools
 import hashlib
 import importlib
 import inspect
+import logging
 import itertools
 import json
 import os
@@ -1639,12 +1640,20 @@ class AutoTuner:
                 # Record the cache miss config.
                 # Expect no cache miss in inference. Thus, any cache miss should be recorded.
                 if not is_cache_hit:
-                    logger.debug(
-                        f"[AutoTuner]: Using fallback tactic for {custom_op} with input shapes {input_shapes}"
-                    )
-                    logger.debug(
-                        f"[AutoTuner]: Generated key{AutoTuner._get_cache_key(custom_op, runners[0], input_shapes, tuning_config, runners[0].get_cache_key_extras(inputs))}"
-                    )
+                    if logger.isEnabledFor(logging.DEBUG):
+                        logger.debug(
+                            "[AutoTuner]: Using fallback tactic for %s with input "
+                            "shapes %s; generated key %s",
+                            custom_op,
+                            input_shapes,
+                            AutoTuner._get_cache_key(
+                                custom_op,
+                                runners[0],
+                                input_shapes,
+                                tuning_config,
+                                runners[0].get_cache_key_extras(inputs),
+                            ),
+                        )
 
                     # If the user has loaded an autotune cache (via
                     # ``autotune(cache=...)``) or warmed up profiling
@@ -1667,14 +1676,17 @@ class AutoTuner:
                     # ``ProfilingCacheKey`` instances and ``_file_configs``
                     # keys are ``str((custom_op, runner_class_name, profile))``,
                     # so we filter by ``custom_op`` on each.
-                    op_has_profiling = any(
+                    # Both probes are O(cache size); `or` short-circuits, and the
+                    # file scan is skipped entirely when no config file is loaded.
+                    has_tune_data = any(
                         k.custom_op == custom_op for k in self.profiling_cache
+                    ) or (
+                        bool(self._file_configs)
+                        and any(
+                            k.startswith(f"({custom_op!r}, ")
+                            for k in self._file_configs
+                        )
                     )
-                    file_key_op_prefix = f"({repr(custom_op)}, "
-                    op_has_file = any(
-                        k.startswith(file_key_op_prefix) for k in self._file_configs
-                    )
-                    has_tune_data = op_has_profiling or op_has_file
                     if has_tune_data:
                         try:
                             signature = self._find_nearest_profile(

--- a/flashinfer/gemm/gemm_base.py
+++ b/flashinfer/gemm/gemm_base.py
@@ -2958,6 +2958,22 @@ def _validate_bf16_output_dtype(dtype: torch.dtype):
         )
 
 
+def _effective_cache_m(tuning_config, actual_m: int, spec_idx: int = 0) -> int:
+    """Bucket ``actual_m`` with the *currently effective* tuning buckets.
+
+    Resolved per call rather than captured when the runner is built: the mapper
+    reflects the active ``autotune(tuning_buckets=..., round_up=...)`` override,
+    so a runner constructed under one context must not keep serving another
+    context's buckets.  Capturing it at construction is also what makes the
+    runner factories unsafe to memoize -- the graph's ``cache_m`` would freeze at
+    whatever was effective on the first call and silently stop matching the key
+    the AutoTuner looks the tactic up under.
+    """
+    return AutoTuner.get().get_effective_map_to_tuning_buckets(
+        tuning_config, spec_idx=spec_idx
+    )(actual_m)
+
+
 @functools.lru_cache(maxsize=2048)
 def build_cudnn_gemm_fp4_graph(
     a_shape,
@@ -3962,14 +3978,10 @@ def _cudnn_gemm_fp8(
 
 
 def _cudnn_gemm_fp8_runner():
-    m_bucket_mapper = AutoTuner.get().get_effective_map_to_tuning_buckets(
-        _FP8_GEMM_SM100_TUNING_CONFIG, spec_idx=0
-    )
-
     class CudnnFp8GemmRunner(TunableRunner):
         def __init__(self):
             super().__init__()
-            self._m_bucket_mapper = m_bucket_mapper
+            self._tuning_config = _FP8_GEMM_SM100_TUNING_CONFIG
             self._use_override_shape = _is_cudnn_override_shape_available()
 
         def get_cache_key_extras(self, inputs: List[torch.Tensor]) -> tuple:
@@ -3981,7 +3993,7 @@ def _cudnn_gemm_fp8_runner():
             actual_m = a.shape[-2]
             k = a.shape[-1]
             n = b.shape[-1]
-            cache_m = self._m_bucket_mapper(actual_m)
+            cache_m = _effective_cache_m(self._tuning_config, actual_m)
 
             # tactic value only be 0 or -1 to hit the graph cache
             return build_cudnn_gemm_fp8_graph_override_shape(
@@ -4445,10 +4457,6 @@ def _cudnn_gemm_bf16_runner(
     ``a.stride()[-1] == 1`` / ``b.stride()[-2] == 1``.
     """
 
-    m_bucket_mapper = AutoTuner.get().get_effective_map_to_tuning_buckets(
-        _BF16_GEMM_SM100_TUNING_CONFIG, spec_idx=0
-    )
-
     class CudnnBf16GemmRunner(TunableRunner):
         def __init__(
             self,
@@ -4456,7 +4464,7 @@ def _cudnn_gemm_bf16_runner(
             is_b_k_major: Optional[bool],
         ):
             super().__init__()
-            self._m_bucket_mapper = m_bucket_mapper
+            self._tuning_config = _BF16_GEMM_SM100_TUNING_CONFIG
             # Default to k-major (the convention torch.rand-synthesized
             # profile tensors use) when caller didn't specify.
             self._is_a_k_major = True if is_a_k_major is None else is_a_k_major
@@ -4483,7 +4491,7 @@ def _cudnn_gemm_bf16_runner(
             # contiguous tensor regardless of the real layout, so reading
             # its stride would build a different graph than the runtime
             # call, breaking tactic-index alignment.
-            cache_m = self._m_bucket_mapper(actual_m)
+            cache_m = _effective_cache_m(self._tuning_config, actual_m)
 
             graph = build_cudnn_gemm_bf16_graph_override_shape(
                 batch=batch,
@@ -5400,14 +5408,10 @@ def _cudnn_mm_mxfp8_runner():
     per-shape graph is built (HEURISTICS_CHOICE).
     """
 
-    m_bucket_mapper = AutoTuner.get().get_effective_map_to_tuning_buckets(
-        _MM_MXFP8_TUNING_CONFIG, spec_idx=0
-    )
-
     class CudnnMmMxfp8GemmRunner(TunableRunner):
         def __init__(self):
             super().__init__()
-            self._m_bucket_mapper = m_bucket_mapper
+            self._tuning_config = _MM_MXFP8_TUNING_CONFIG
             self._use_override_shape = _is_cudnn_override_shape_available()
 
         def get_cache_key_extras(self, inputs: List[torch.Tensor]) -> tuple:
@@ -5419,7 +5423,7 @@ def _cudnn_mm_mxfp8_runner():
             actual_m = a.shape[0]
             k = a.shape[1]
             n = b.shape[1]
-            cache_m = self._m_bucket_mapper(actual_m)
+            cache_m = _effective_cache_m(self._tuning_config, actual_m)
             return build_cudnn_gemm_mxfp8_graph_override_shape(
                 batch=1,
                 n=n,
@@ -5805,14 +5809,10 @@ def _cudnn_gemm_fp4_runner(tuning_config):
         runtime-time produce the same ``cache_m`` for the same input.
     """
 
-    m_bucket_mapper = AutoTuner.get().get_effective_map_to_tuning_buckets(
-        tuning_config, spec_idx=0
-    )
-
     class CudnnFp4GemmRunner(TunableRunner):
         def __init__(self):
             super().__init__()
-            self._m_bucket_mapper = m_bucket_mapper
+            self._tuning_config = tuning_config
             self._use_override_shape = _is_cudnn_override_shape_available()
 
         def _get_override_graph(
@@ -5828,14 +5828,14 @@ def _cudnn_gemm_fp4_runner(tuning_config):
 
             # cache_m must match the AutoTuner cache key so the runtime
             # graph is the SAME graph the autotuner profiled tactics on.
-            # ``self._m_bucket_mapper`` is the *currently effective*
+            # ``_effective_cache_m`` resolves the *currently effective*
             # ``map_to_tuning_buckets`` (with any
             # ``autotune(tuning_buckets=..., round_up=...)`` override
             # applied).  Sharing the mapper keeps cache_m and the tactic
             # cache key in lockstep -- otherwise a tactic profiled on
             # graph ``cache_m=A`` is silently applied to graph ``cache_m=B``
             # at runtime, which has a different plan-index meaning.
-            cache_m = self._m_bucket_mapper(actual_m)
+            cache_m = _effective_cache_m(self._tuning_config, actual_m)
 
             graph = build_cudnn_gemm_fp4_graph_override_shape(
                 batch=batch,
@@ -9483,14 +9483,10 @@ def _cudnn_gemm_mxfp8(
 
 
 def _cudnn_gemm_mxfp8_runner():
-    m_bucket_mapper = AutoTuner.get().get_effective_map_to_tuning_buckets(
-        _FP8_GEMM_SM100_TUNING_CONFIG, spec_idx=0
-    )
-
     class CudnnMxfp8GemmRunner(TunableRunner):
         def __init__(self):
             super().__init__()
-            self._m_bucket_mapper = m_bucket_mapper
+            self._tuning_config = _FP8_GEMM_SM100_TUNING_CONFIG
             self._use_override_shape = _is_cudnn_override_shape_available()
 
         def get_cache_key_extras(self, inputs: List[torch.Tensor]) -> tuple:
@@ -9502,7 +9498,7 @@ def _cudnn_gemm_mxfp8_runner():
             actual_m = a.shape[-2]
             k = a.shape[-1]
             n = b.shape[-1]
-            cache_m = self._m_bucket_mapper(actual_m)
+            cache_m = _effective_cache_m(self._tuning_config, actual_m)
 
             return build_cudnn_gemm_mxfp8_graph_override_shape(
                 batch=batch,

--- a/flashinfer/gemm/gemm_base.py
+++ b/flashinfer/gemm/gemm_base.py
@@ -2933,22 +2933,32 @@ def clear_cudnn_graph_cache() -> None:
     AutoTuner.get().clear_cache()
 
 
-# One cudnn handle per each GPU
+# One cudnn handle per each GPU, plus the stream each one is currently bound to
 _cudnn_handles: dict[int, int] = {}
+_cudnn_handle_streams: dict[int, int] = {}
 
 
 def _get_cudnn_handle(device, stream: torch.cuda.Stream):
-    """Create and return a cached cuDNN handle."""
+    """Create and return a cached cuDNN handle bound to ``stream``."""
     global _cudnn_handles
     device_id = device.index
 
     if _cudnn_handles.get(device_id) is None:
         _check_cudnn_availability()
         _cudnn_handles[device_id] = cudnn.create_handle()
-        print("cudnn_handle created for device_id = {}\n".format(device_id))
-    cudnn.set_stream(_cudnn_handles[device_id], stream.cuda_stream)
+        logger.debug("created cuDNN handle for device_id %s", device_id)
+    handle = _cudnn_handles[device_id]
 
-    return _cudnn_handles[device_id]
+    # cudnnSetStream re-runs its green-context detection and per-priority stream-pool
+    # driver queries on every call (~2.4 us) even when the stream has not changed, so
+    # only call it when the binding actually differs.  Keyed on the raw stream handle:
+    # re-binding the same pointer is a no-op for cuDNN, so an ABA on it is harmless.
+    stream_id = stream.cuda_stream
+    if _cudnn_handle_streams.get(device_id) != stream_id:
+        cudnn.set_stream(handle, stream_id)
+        _cudnn_handle_streams[device_id] = stream_id
+
+    return handle
 
 
 def _validate_fp8_output_dtype(dtype: torch.dtype):

--- a/flashinfer/gemm/gemm_base.py
+++ b/flashinfer/gemm/gemm_base.py
@@ -296,7 +296,7 @@ def get_gemm_module():
 
     # Register the module
     _gemm_module = SimpleNamespace(
-        cublas_fp8_gemm_runner=cublas_fp8_gemm_runner,
+        cublas_fp8_gemm_runner=functools.lru_cache(maxsize=64)(cublas_fp8_gemm_runner),
         cutlass_segment_gemm=cutlass_segment_gemm,
     )
 
@@ -1156,7 +1156,9 @@ def get_gemm_sm120_module_cutlass_fp8():
 
     # Register the module
     return SimpleNamespace(
-        cutlass_fp8_gemm_runner=cutlass_fp8_gemm_runner,
+        cutlass_fp8_gemm_runner=functools.lru_cache(maxsize=64)(
+            cutlass_fp8_gemm_runner
+        ),
     )
 
 
@@ -1196,7 +1198,9 @@ def get_gemm_sm100_module_cutlass_fp8():
 
     # Register the module
     return SimpleNamespace(
-        cutlass_fp8_gemm_runner=cutlass_fp8_gemm_runner,
+        cutlass_fp8_gemm_runner=functools.lru_cache(maxsize=64)(
+            cutlass_fp8_gemm_runner
+        ),
     )
 
 
@@ -1257,7 +1261,9 @@ def get_gemm_sm100_module_cutlass_bf16():
         return CutlassBf16GemmRunner()
 
     return SimpleNamespace(
-        cutlass_bf16_gemm_runner=cutlass_bf16_gemm_runner,
+        cutlass_bf16_gemm_runner=functools.lru_cache(maxsize=64)(
+            cutlass_bf16_gemm_runner
+        ),
     )
 
 
@@ -1378,7 +1384,9 @@ def get_mm_bf16_cublaslt_module():
         return CublasltBf16GemmRunner()
 
     return SimpleNamespace(
-        cublaslt_bf16_gemm_runner=cublaslt_bf16_gemm_runner,
+        cublaslt_bf16_gemm_runner=functools.lru_cache(maxsize=64)(
+            cublaslt_bf16_gemm_runner
+        ),
     )
 
 
@@ -1403,6 +1411,7 @@ _BF16_GEMM_SM100_TUNING_CONFIG = TuningConfig(
 )
 
 
+@functools.lru_cache(maxsize=64)
 def _tinygemm_bf16_gemm_runner():
     module = get_tinygemm2_module()
 
@@ -1949,7 +1958,9 @@ def _create_cutlass_fp4_gemm_module(module, op_name: str, tuner_name: str):
         return CutlassFp4GemmRunner()
 
     return SimpleNamespace(
-        cutlass_fp4_gemm_runner=cutlass_fp4_gemm_runner,
+        cutlass_fp4_gemm_runner=functools.lru_cache(maxsize=64)(
+            cutlass_fp4_gemm_runner
+        ),
     )
 
 
@@ -3977,6 +3988,7 @@ def _cudnn_gemm_fp8(
     return out
 
 
+@functools.lru_cache(maxsize=64)
 def _cudnn_gemm_fp8_runner():
     class CudnnFp8GemmRunner(TunableRunner):
         def __init__(self):
@@ -4429,6 +4441,7 @@ def _cudnn_gemm_bf16(
     return out
 
 
+@functools.lru_cache(maxsize=64)
 def _cudnn_gemm_bf16_runner(
     is_a_k_major: Optional[bool] = None,
     is_b_k_major: Optional[bool] = None,
@@ -4808,7 +4821,9 @@ def _create_cutlass_mxfp8_gemm_module(module, op_name: str, tuner_name: str):
         return CutlassMxfp8GemmRunner()
 
     return SimpleNamespace(
-        cutlass_mxfp8_gemm_runner=cutlass_mxfp8_gemm_runner,
+        cutlass_mxfp8_gemm_runner=functools.lru_cache(maxsize=64)(
+            cutlass_mxfp8_gemm_runner
+        ),
     )
 
 
@@ -5392,6 +5407,7 @@ def _cute_dsl_gemm_mxfp8_runner(
     return CuteDSLMxfp8GemmRunner()
 
 
+@functools.lru_cache(maxsize=64)
 def _cudnn_mm_mxfp8_runner():
     """Build a TunableRunner for the cuDNN MXFP8 (2D mm) backend.
 
@@ -5781,6 +5797,7 @@ def _cudnn_gemm_fp4(
     return out
 
 
+@functools.lru_cache(maxsize=64)
 def _cudnn_gemm_fp4_runner(tuning_config):
     """Build a CudnnFp4GemmRunner.
 
@@ -9482,6 +9499,7 @@ def _cudnn_gemm_mxfp8(
     )
 
 
+@functools.lru_cache(maxsize=64)
 def _cudnn_gemm_mxfp8_runner():
     class CudnnMxfp8GemmRunner(TunableRunner):
         def __init__(self):

--- a/flashinfer/gemm/gemm_bf16_fp4_cudnn.py
+++ b/flashinfer/gemm/gemm_bf16_fp4_cudnn.py
@@ -25,6 +25,7 @@ from ..utils import _get_cache_buf, get_native_fp4_dtype
 from .gemm_base import (
     CUDNN_AVAILABLE,
     DEFAULT_WORKSPACE_SIZE,
+    _effective_cache_m,
     UIDs,
     _check_cudnn_fp4_availability,
     _get_cudnn_handle,
@@ -375,15 +376,17 @@ _BF16_FP4_TUNING_CONFIG = TuningConfig(
 
 
 def _cudnn_bf16_fp4_runner(tuning_config):
-    """Build a ``CudnnBf16Fp4Runner`` bound to the active tuning config."""
-    m_bucket_mapper = AutoTuner.get().get_effective_map_to_tuning_buckets(
-        tuning_config, spec_idx=0
-    )
+    """Build a ``CudnnBf16Fp4Runner`` for ``tuning_config``.
+
+    The M-bucket mapper is resolved per call (see :func:`_effective_cache_m`),
+    not captured here, so an active ``autotune(tuning_buckets=...)`` override is
+    always the one that shapes the cuDNN graph.
+    """
 
     class CudnnBf16Fp4Runner(TunableRunner):
         def __init__(self):
             super().__init__()
-            self._m_bucket_mapper = m_bucket_mapper
+            self._tuning_config = tuning_config
             self._use_override_shape = _is_cudnn_override_shape_available()
 
         def get_cache_key_extras(self, inputs: List[torch.Tensor]) -> tuple:
@@ -395,7 +398,7 @@ def _cudnn_bf16_fp4_runner(tuning_config):
         ):
             actual_m, k = int(a.shape[0]), int(a.shape[1])
             n = int(b.shape[0])
-            cache_m = self._m_bucket_mapper(actual_m)
+            cache_m = _effective_cache_m(self._tuning_config, actual_m)
             return build_cudnn_bf16_fp4_graph_override_shape(
                 batch=1,
                 n=n,

--- a/flashinfer/utils.py
+++ b/flashinfer/utils.py
@@ -631,41 +631,49 @@ def get_cuda_python_version() -> str:
     return cuda.__version__
 
 
+@functools.cache
 def is_sm90a_supported(device: torch.device) -> bool:
     major, _ = get_compute_capability(device)
     return major == 9 and version_at_least(torch.version.cuda, "12.3")
 
 
+@functools.cache
 def is_sm100a_supported(device: torch.device) -> bool:
     major, _ = get_compute_capability(device)
     return major == 10 and version_at_least(torch.version.cuda, "12.8")
 
 
+@functools.cache
 def is_sm100f_supported(device: torch.device) -> bool:
     major, _ = get_compute_capability(device)
     return major == 10 and version_at_least(torch.version.cuda, "12.9")
 
 
+@functools.cache
 def is_sm110a_supported(device: torch.device) -> bool:
     major, _ = get_compute_capability(device)
     return major == 11 and version_at_least(torch.version.cuda, "13.0")
 
 
+@functools.cache
 def is_sm120a_supported(device: torch.device) -> bool:
     major, minor = get_compute_capability(device)
     return major == 12 and minor == 0 and version_at_least(torch.version.cuda, "12.8")
 
 
+@functools.cache
 def is_sm120f_supported(device: torch.device) -> bool:
     major, _ = get_compute_capability(device)
     return major == 12 and version_at_least(torch.version.cuda, "12.9")
 
 
+@functools.cache
 def is_sm121a_supported(device: torch.device) -> bool:
     major, minor = get_compute_capability(device)
     return major == 12 and minor == 1 and version_at_least(torch.version.cuda, "12.9")
 
 
+@functools.cache
 def is_sm12x_supported(device: torch.device) -> bool:
     """Check if the device is any SM12x GPU (SM120a, SM121a, or future variants).
 
@@ -1393,6 +1401,49 @@ def backend_requirement(
                 capability = major * 10 + minor
             return capability
 
+        # Validation depends only on the shapes / strides / dtypes / devices of the
+        # tensor arguments and the values of the scalar ones, so a repeat call with the
+        # same signature reaches the same verdict.  Memoise successes -- the checks
+        # themselves cost ~14-29 us/call on the GEMM APIs (sig.bind + apply_defaults +
+        # one requirement check per backend + the heuristic), which dominates the host
+        # cost of a small GEMM.  Failures are not memoised: they are off the hot path
+        # and re-raising a stored exception would lose the original context.
+        _check_memo: dict = {}
+        _CHECK_MEMO_MAX = 4096
+        _UNSUMMARISABLE = object()
+
+        def _memo_summary(value):
+            if isinstance(value, torch.Tensor):
+                return (
+                    tuple(value.shape),
+                    value.stride(),
+                    value.dtype,
+                    value.device.type,
+                    value.device.index,
+                )
+            if value is None or isinstance(value, (bool, int, float, str, torch.dtype)):
+                return value
+            return _UNSUMMARISABLE
+
+        def _memo_key(args, kwargs):
+            """Bind each summary to its parameter name.
+
+            Positional values keep their index and keyword values carry their name, so
+            ``f(a=x, b=y)`` and ``f(b=x, a=y)`` can never collide on one entry.
+            """
+            parts = []
+            for value in args:
+                summary = _memo_summary(value)
+                if summary is _UNSUMMARISABLE:
+                    return None
+                parts.append(summary)
+            for name in sorted(kwargs):
+                summary = _memo_summary(kwargs[name])
+                if summary is _UNSUMMARISABLE:
+                    return None
+                parts.append((name, summary))
+            return tuple(parts)
+
         # @brief: Wrapper function that calls the orignal, decorated function, after applying a number of checks.
         # @note that here we manually apply defaults to the arguments in the wrapper function when doing validation.
         @functools.wraps(func)
@@ -1402,6 +1453,14 @@ def backend_requirement(
             skip_check = kwargs.pop("skip_check", False)
 
             if not skip_check:
+                memo_key = _memo_key(args, kwargs)
+                if memo_key is not None:
+                    memo_hit = _check_memo.get(memo_key)
+                    if memo_hit is not None:
+                        if memo_hit[0] is not None:
+                            wrapper.suitable_auto_backends = memo_hit[0]
+                        return func(*args, **kwargs)
+
                 # Apply defaults from the function signature for validation
                 # This ensures that all parameters (including backend) have their default values
                 # if not explicitly provided by the caller
@@ -1446,6 +1505,12 @@ def backend_requirement(
                         raise ValueError(
                             f"Problem size is not supported for {func.__name__}"
                         )
+                if memo_key is not None and len(_check_memo) < _CHECK_MEMO_MAX:
+                    _check_memo[memo_key] = (
+                        getattr(wrapper, "suitable_auto_backends", None)
+                        if backend == "auto"
+                        else None,
+                    )
             elif skip_check and heuristic_func is not None:
                 if kwargs.get("backend") == "auto":
                     # This needs to be called for heuristic function
@@ -1454,6 +1519,7 @@ def backend_requirement(
 
             return func(*args, **kwargs)
 
+        wrapper.clear_check_memo = _check_memo.clear
         wrapper.is_backend_supported = is_backend_supported
         wrapper.is_compute_capability_supported = is_compute_capability_supported
         wrapper.has_backend = has_backend


### PR DESCRIPTION
## 📌 Description

**Principle: plan-time and call-time are a hard line.** Anything that depends only on
`(dtype, layout, n, k, m-bucket, device)` should be resolved once and cached; the per-call path
should be key → lookup → launch. This PR removes, layer by layer, work on the GEMM dispatch path
that violates that line.

Host cost only matters when it exceeds the kernel, which is exactly the eager LLM-serving regime
(small M, weights resident). At M=8, N=K=2048 the kernel is ~2 µs and `mm_bf16` was spending
**200 µs** of host time deciding how to run it.

Measured on SM100, bf16 M=8 N=K=2048, cuDNN 9.25.0.28.dev, with the new
`benchmarks/bench_host_overhead.py` (enqueue rate, no per-call sync):

| | before | after | |
|---|--:|--:|--:|
| `mm_bf16(backend="auto")` | 200.0 | **59.0** | −70% |
| `mm_bf16(backend="cublaslt")` | 237.2 | **31.4** | −87% |
| `mm_bf16(backend="cudnn")` | 96.8 | **44.1** | −54% |
| `mm_bf16(backend="cutlass")` | 48.8 | **22.5** | −54% |
| `mm_bf16(backend="tinygemm")` | 46.5 | **19.1** | −59% |
| `mm_bf16(backend="tgv")` | 84.0 | **61.1** | −27% |
| `torch.mm` (reference floor) | 9.7 | 9.7 | |

No kernel changes; GPU time is untouched.

### What was being recomputed, and why it cost that much

1. **The runner factories re-executed their `class` statement on every call.** Executing a bare
   `class R(TunableRunner)` + instantiating measures **7.34 µs**; instantiating a class that
   already exists is **0.08 µs**. `backend="auto"` paid this once per candidate backend — 39.8 µs
   per call to build five runners and then use one.

2. **Worse, the fresh instance reset the runner's own caches.**
   `CublasltBf16GemmRunner._algo_cache` was empty on every call, so `forward()` re-ran
   `cublasLtMatmulAlgoGetHeuristic` for *every GEMM*: **161.6 µs** with a fresh runner vs
   **11.4 µs** with a reused one. This is why cuBLASLt was the slowest backend despite having the
   cheapest launch.

3. **`@backend_requirement` re-validated everything per call** — `sig.bind` + `apply_defaults` +
   one requirement check per backend + the heuristic: 14 µs for an explicit backend, 29 µs for
   `"auto"`.

4. **Smaller repeat offenders**: the `is_sm*_supported` predicates re-parsed
   `torch.version.cuda` through `packaging.Version` (2 constructions per call); `_get_cudnn_handle`
   called `cudnnSetStream` unconditionally, which re-runs green-context detection and
   stream-priority driver queries (~2.4 µs) even when the stream has not changed; and the AutoTuner
   fallback path built its debug message eagerly, so an f-string called `_get_cache_key` +
   `get_cache_key_extras` an extra time (4.29 µs) with logging switched off.

### The ordering constraint that makes the memoization safe

Six cuDNN runner factories captured `get_effective_map_to_tuning_buckets(...)` in the factory body.
That mapper exists precisely to reflect the **currently active**
`autotune(tuning_buckets=..., round_up=...)`, so memoizing a factory that captured it would freeze
the graph's `cache_m` at whatever was effective on the first call and silently stop matching the
key the AutoTuner looks the tactic up under.

The first commit therefore resolves the mapper per call (0.51 µs) through a shared
`_effective_cache_m` helper; only then is it safe to memoize. There is a regression test for
exactly this: a runner built *before* an `autotune(tuning_buckets=...)` context still follows that
context's buckets.

## 🔍 Related

* Takes the same three hot spots #3873 identified further (all 13 runner factories rather than the
  bf16 ones) and fixes the frozen bucket-mapper that made the memoization unsafe there. Credit to
  @askliar for finding them first.
* Direction matches #3861's buckets-unification (the AutoTuner computes the bucket once and pushes
  it into `forward`) and the runner contract. Where this touches `autotuner/autotuner.py` it
  overlaps #3861: **that PR already fixes `file_key` (538cc60f) — on merge, take its version
  there**; the lazy-logging and short-circuited-probe hunks here are additive.

## 🚀 Pull Request Checklist

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

## 🧪 Tests

- [x] Numerics verified against `torch.matmul` across M ∈ {1, 8, 37, 128, 512} × 5 backends.
- [x] Behaviour preserved: an unsupported backend is still rejected, an unsupported dtype is still
      rejected, and keyword-order variants (`f(a=x, b=y)` vs `f(b=x, a=y)`) do not share a
      memoized verdict.
- [x] A cached runner still honours an `autotune(tuning_buckets=...)` context entered after it was
      built.

## Reviewer notes

* `lru_cache(maxsize=64)` rather than unbounded `cache` on the factories: these instances hold
  graph/algo caches, and #3687 was a leak fix, so the retained set stays bounded. The argument
  space is tiny (layout bools, dtypes, a tuning config).
* The validation memo stores **successes only** — re-raising a stored exception would lose the
  original context, and failures are not on the hot path.
* Follow-ups, deliberately not in this PR: hoisting the 30+ nested runner classes to module scope
  (mechanical, no behaviour change, and what makes a "runner classes are defined at import" contract
  rule enforceable); the remaining cuDNN-side cost is `graph.execute` at 24 µs, which needs
  cudnn-frontend GH #611 / prepared-execution rather than anything here.

---

<sub>Validated on SM100 with cuDNN 9.25.0.28.dev: 265 passed across `tests/utils/test_decorators.py`,
`tests/autotuner/`, `tests/gemm/test_mm_bf16.py`. 18 failures in
`test_autotuner_mla_decode.py` / `test_trtllm_fused_moe_autotuner_integration.py` reproduce
**identically on unmodified `main`** (byte-identical failure sets) — they are a JIT/csrc skew in my
local worktree harness, not a regression here; CI covers those paths properly.</sub>

<sub>note to self: claude::cc9061fd-d878-45a6-bb2e-d3dca381203a — "Cudnn heuristics latency investigation" · cwd /home/scratch.yanxu_libs/flashinfer</sub>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved GEMM execution efficiency by reusing optimized runners and reducing unnecessary GPU handle updates.
  * Accelerated backend validation and GPU capability checks through caching.
* **Bug Fixes**
  * Improved autotuning behavior so updated tuning settings and cache mappings are applied consistently.
  * Enhanced support for dynamic GEMM tuning configurations across supported precision modes.
* **Benchmarking**
  * Added a CUDA benchmark for comparing per-call GEMM overhead across supported backends, with configurable shapes, repetitions, and JSON results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->