### PR TITLE
perf(moe): prune score-routing compilation from moe_utils

### DIFF
--- a/csrc/fused_moe/trtllm_backend/trtllm_fused_moe_routing_common.cu
+++ b/csrc/fused_moe/trtllm_backend/trtllm_fused_moe_routing_common.cu
@@ -22,9 +22,9 @@ namespace moe::dev::routing {
 namespace routingCustom {
 // Forward declarations of launch functions.
 // Block/DynBlock/Cluster return whether a compiled tier covered (numExperts, topK)
-// and the kernel was actually launched; the definitions live in
-// trtllm_fused_moe_routing_custom.cuh. Keep these signatures in sync (the return
-// type is not part of the mangled name, so a mismatch would silently be UB).
+// and the kernel was actually launched; the definitions live in the per-family
+// routing translation units. Keep these signatures in sync (the return type is
+// not part of the mangled name, so a mismatch would silently be UB).
 bool launchBlockKernel(Data const& data, void* stream);
 bool launchDynBlockKernel(Data const& data, uint32_t numThreadsHist, void* stream);
 bool launchClusterKernel(Data const& data, void* stream);

--- a/csrc/fused_moe/trtllm_backend/trtllm_fused_moe_routing_custom.cuh
+++ b/csrc/fused_moe/trtllm_backend/trtllm_fused_moe_routing_custom.cuh
@@ -322,18 +322,6 @@ __global__ void __launch_bounds__(KernelParams::MaxNumExperts <= 1024 ? KernelPa
 #endif
 }
 
-// Returns whether a compiled tier covered the runtime (numExperts, topK) and the
-// kernel was actually launched. A false return means no routing output was written;
-// the caller (run) must not proceed to the downstream pipeline in that case.
-bool launchBlockKernel(Data const& data, void* stream) {
-  uint32_t const numThreadsBlock =
-      std::min(1024u, static_cast<uint32_t>(queryDispatchedMaxExperts(data)));
-  LAUNCH_ROUTING_CUSTOM(data, false, routingIndicesBlockKernel, 1, numThreadsBlock,
-                        /*smemSize=*/0,  // No dynamic smem
-                        stream);
-  return queryPolicyHasCompiledTier(data);
-}
-
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // Warp-level exclusive scan for the dynamic block kernel.
@@ -656,20 +644,6 @@ __global__ void routingIndicesDynBlockKernel(KernelParams params) {
 #endif
 }
 
-// Returns whether a compiled tier covered the runtime (numExperts, topK) and the
-// kernel was actually launched (see launchBlockKernel).
-bool launchDynBlockKernel(Data const& data, uint32_t numThreadsHist, void* stream) {
-  int32_t const maxExperts = queryDispatchedMaxExperts(data);
-  int const numSlots = data.mNumTokens * maxExperts;
-  int const smemSize = numSlots + numSlots * 2 + 128 +
-                       2 * (maxExperts / WarpSize) * static_cast<int>(sizeof(int32_t));
-  int const threads =
-      std::min(std::max(data.mNumTokens * static_cast<int>(WarpSize), maxExperts), 1024);
-
-  LAUNCH_ROUTING_CUSTOM(data, false, routingIndicesDynBlockKernel, 1, threads, smemSize, stream);
-  return queryPolicyHasCompiledTier(data);
-}
-
 #endif  // defined(FLASHINFER_ROUTING_CUSTOM_BLOCK_GROUP)
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -682,10 +656,6 @@ bool launchDynBlockKernel(Data const& data, uint32_t numThreadsHist, void* strea
 static constexpr int ClusterBlockDim256 = NumExperts256Experts;
 static constexpr int ClusterBlockDim512 = NumExperts512Experts;
 static constexpr int ClusterBlockDim1024 = NumThreads;
-static constexpr int MaxNumTokensClusterScores256 =
-    NumBlocksPerCluster * (ClusterBlockDim256 / WarpSize);
-static constexpr int MaxNumTokensClusterScores512 =
-    NumBlocksPerCluster * (ClusterBlockDim512 / WarpSize);
 
 #if defined(FLASHINFER_ROUTING_CUSTOM_CLUSTER_SMALL) || \
     defined(FLASHINFER_ROUTING_CUSTOM_CLUSTER_LARGE)
@@ -873,62 +843,9 @@ bool launchClusterKernelForBlockDim(Data const& data, void* stream) {
   return dispatched;
 }
 
-// Returns whether the cluster tier dispatch found a covering tier and launched a kernel.
-#if defined(FLASHINFER_ROUTING_CUSTOM_CLUSTER_SMALL)
-bool launchClusterKernelBlockDim256(Data const& data, void* stream) {
-  return launchClusterKernelForBlockDim<ClusterBlockDim256>(data, stream);
-}
-
-bool launchClusterKernelBlockDim512(Data const& data, void* stream) {
-  return launchClusterKernelForBlockDim<ClusterBlockDim512>(data, stream);
-}
-#endif  // defined(FLASHINFER_ROUTING_CUSTOM_CLUSTER_SMALL)
-
-#if defined(FLASHINFER_ROUTING_CUSTOM_CLUSTER_LARGE)
-bool launchClusterKernelBlockDim1024(Data const& data, void* stream) {
-  bool const useNoOpSoftmaxScores = data.mPtrScores != nullptr &&
-                                    data.mPreprocessType == RoutingPreprocessType::None &&
-                                    data.mPostprocessType == RoutingPostprocessType::Softmax;
-  if (useNoOpSoftmaxScores) {
-    return launchClusterKernelForPolicy<ClusterBlockDim1024, NoOpPreprocess, SoftmaxPostprocess>(
-        data, stream);
-  }
-
-  LAUNCH_ROUTING_CUSTOM(data, false, routingIndicesClusterKernel, NumBlocksPerCluster, NumThreads,
-                        /*smemSize=*/0,  // No dynamic smem
-                        stream);
-  return queryPolicyHasCompiledTier(data);
-}
-#endif  // defined(FLASHINFER_ROUTING_CUSTOM_CLUSTER_LARGE)
-
 #endif  // FLASHINFER_ROUTING_CUSTOM_CLUSTER_SMALL || FLASHINFER_ROUTING_CUSTOM_CLUSTER_LARGE
 
 #if defined(FLASHINFER_ROUTING_CUSTOM_ENTRY)
-
-// Returns whether a compiled tier covered the runtime (numExperts, topK) and the
-// kernel was actually launched (see launchBlockKernel).
-bool launchClusterKernel(Data const& data, void* stream) {
-  // Use the wider cluster only for permutation-only launches in the bounded high-expert/high-TopK
-  // range. Score-to-TopK fused clusters retain the general capacity-based dispatch.
-  bool const useWidePermutationCluster =
-      data.mPtrScores == nullptr &&
-      topk::isInHighExpertLaneOwnedTopKRange(data.mNumExperts, data.mTopK) &&
-      data.mNumTokens >= 32 && data.mNumTokens <= 64;
-  if (useWidePermutationCluster) {
-    return launchClusterKernelBlockDim512(data, stream);
-  }
-
-  // Each warp owns one token, so the reduced-thread cluster variants have lower token capacity.
-  // Use them only where the requested token count fits; otherwise keep the original 1024-thread
-  // launch.
-  if (data.mNumTokens <= MaxNumTokensClusterScores256) {
-    return launchClusterKernelBlockDim256(data, stream);
-  }
-  if (data.mNumTokens <= MaxNumTokensClusterScores512) {
-    return launchClusterKernelBlockDim512(data, stream);
-  }
-  return launchClusterKernelBlockDim1024(data, stream);
-}
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 //
@@ -1414,109 +1331,6 @@ bool launchBlockScoresKernel(Data const& data, void* stream) {
     }
   });
   return launched;
-}
-
-////////////////////////////////////////////////////////////////////////////////////////////////////
-//
-// 4. Coop kernel — cooperative histogram + offsets via grid-sync.
-//
-// The coop kernel only performs the post-topK permutation pipeline (histogram, prefix-scan,
-// index writes). It does not compute TopK; it reads pre-computed results from mPtrTopKPacked
-// or mPtrTopKIds. The expert tier sizes shared memory and determines the thread count. Most
-// tiers use NumTop8Experts and generic 64-entry per-thread state. Bounded high-expert/high-TopK
-// tiers can use NumTop16Experts with four entries per thread when that state covers
-// mNumTokens * mTopK.
-//
-////////////////////////////////////////////////////////////////////////////////////////////////////
-
-template <int NumExpertsTier>
-void launchCoopKernelTier(Data const& data, int numBlocksCoop, uint32_t numThreadsHist,
-                          void* stream) {
-  bool useBoundedState = false;
-  if constexpr (topk::isInHighExpertLaneOwnedTopKRange(NumExpertsTier, NumTop16Experts)) {
-    int64_t const expandedIdxSize = int64_t{data.mNumTokens} * int64_t{data.mTopK};
-    int64_t const boundedCapacity = int64_t{4} * int64_t{numBlocksCoop} * int64_t{numThreadsHist};
-    useBoundedState = data.mTopK > NumTop8Experts && data.mTopK <= NumTop16Experts &&
-                      expandedIdxSize <= boundedCapacity;
-  }
-
-  if (useBoundedState) {
-    LAUNCH_ROUTING_WITH_POLICIES(
-        data, /*coopLaunch=*/true, routingIndicesCoopKernel, numBlocksCoop, numThreadsHist,
-        /*smemSize=*/0, stream, NoOpPreprocess, NoOpPostprocess, NumExpertsTier, NumTop16Experts);
-  } else {
-    LAUNCH_ROUTING_WITH_POLICIES(
-        data, /*coopLaunch=*/true, routingIndicesCoopKernel, numBlocksCoop, numThreadsHist,
-        /*smemSize=*/0, stream, NoOpPreprocess, NoOpPostprocess, NumExpertsTier, NumTop8Experts);
-  }
-}
-
-void launchCoopKernel(Data const& data, int numBlocksCoop, uint32_t numThreadsHist, void* stream) {
-  if (data.mNumExperts <= NumExperts128Experts) {
-    LAUNCH_ROUTING_WITH_POLICIES(data, /*coopLaunch=*/true, routingIndicesCoopKernel, numBlocksCoop,
-                                 numThreadsHist, /*smemSize=*/0, stream, NoOpPreprocess,
-                                 NoOpPostprocess, NumExperts128Experts, NumTop8Experts);
-  } else if (data.mNumExperts <= NumExperts160Experts) {
-    LAUNCH_ROUTING_WITH_POLICIES(data, /*coopLaunch=*/true, routingIndicesCoopKernel, numBlocksCoop,
-                                 numThreadsHist, /*smemSize=*/0, stream, NoOpPreprocess,
-                                 NoOpPostprocess, NumExperts160Experts, NumTop8Experts);
-  } else if (data.mNumExperts <= NumExperts256Experts) {
-    LAUNCH_ROUTING_WITH_POLICIES(data, /*coopLaunch=*/true, routingIndicesCoopKernel, numBlocksCoop,
-                                 numThreadsHist, /*smemSize=*/0, stream, NoOpPreprocess,
-                                 NoOpPostprocess, NumExperts256Experts, NumTop8Experts);
-  } else if (data.mNumExperts <= NumExperts384Experts) {
-    LAUNCH_ROUTING_WITH_POLICIES(data, /*coopLaunch=*/true, routingIndicesCoopKernel, numBlocksCoop,
-                                 numThreadsHist, /*smemSize=*/0, stream, NoOpPreprocess,
-                                 NoOpPostprocess, NumExperts384Experts, NumTop8Experts);
-  } else if (data.mNumExperts <= NumExperts512Experts) {
-    LAUNCH_ROUTING_WITH_POLICIES(data, /*coopLaunch=*/true, routingIndicesCoopKernel, numBlocksCoop,
-                                 numThreadsHist, /*smemSize=*/0, stream, NoOpPreprocess,
-                                 NoOpPostprocess, NumExperts512Experts, NumTop8Experts);
-  } else if (data.mNumExperts <= NumExperts576Experts) {
-    LAUNCH_ROUTING_WITH_POLICIES(data, /*coopLaunch=*/true, routingIndicesCoopKernel, numBlocksCoop,
-                                 numThreadsHist, /*smemSize=*/0, stream, NoOpPreprocess,
-                                 NoOpPostprocess, NumExperts576Experts, NumTop8Experts);
-  } else if (data.mNumExperts <= NumExperts896Experts) {
-    launchCoopKernelTier<NumExperts896Experts>(data, numBlocksCoop, numThreadsHist, stream);
-  } else if (data.mNumExperts <= NumExperts1024Experts) {
-    launchCoopKernelTier<NumExperts1024Experts>(data, numBlocksCoop, numThreadsHist, stream);
-  } else {
-    TVM_FFI_LOG_AND_THROW(NotImplementedError)
-        << "Coop kernel does not support numExperts > " << NumExperts1024Experts << ", got "
-        << data.mNumExperts;
-  }
-}
-
-////////////////////////////////////////////////////////////////////////////////////////////////////
-//
-// 5-7. Launch wrappers for shared kernels (defined in RoutingKernel.cuh):
-//      - InitExpertCounts (zero expert counts)
-//      - Histogram kernel (histogram from packed TopK)
-//      - Offsets kernel (prefix-scan + permutation)
-//
-////////////////////////////////////////////////////////////////////////////////////////////////////
-
-void launchInitExpertCounts(Data const& data, uint32_t numThreadsHist, void* stream) {
-  LAUNCH_ROUTING_CUSTOM_NO_POLICY(data, false, routingInitExpertCounts,
-                                  (2 * data.mNumExperts - 1) / numThreadsHist + 1, numThreadsHist,
-                                  /*smemSize=*/0,  // No dynamic smem
-                                  stream);
-}
-
-void launchHistogramKernel(Data const& data, int numBlocksHistogram, uint32_t numThreadsHist,
-                           void* stream) {
-  LAUNCH_ROUTING_CUSTOM_NO_POLICY(data, false, routingIndicesHistogramKernel, numBlocksHistogram,
-                                  numThreadsHist,
-                                  /*smemSize=*/0,  // No dynamic smem
-                                  stream);
-}
-
-void launchOffsetsKernel(Data const& data, int numBlocksOffsets, uint32_t numThreadsHist,
-                         void* stream) {
-  LAUNCH_ROUTING_CUSTOM_NO_POLICY(data, false, routingIndicesOffsetsKernel, numBlocksOffsets,
-                                  numThreadsHist,
-                                  /*smemSize=*/0,  // No dynamic smem
-                                  stream);
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/csrc/fused_moe/trtllm_backend/trtllm_fused_moe_routing_custom_block.cu
+++ b/csrc/fused_moe/trtllm_backend/trtllm_fused_moe_routing_custom_block.cu
@@ -14,5 +14,37 @@
  * limitations under the License.
  */
 
+#include <algorithm>
+
 #define FLASHINFER_ROUTING_CUSTOM_BLOCK_GROUP
 #include "trtllm_fused_moe_routing_custom.cuh"
+
+namespace moe::dev::routing::routingCustom {
+
+// Returns whether a compiled tier covered the runtime (numExperts, topK) and the
+// kernel was actually launched. A false return means no routing output was written;
+// the caller (run) must not proceed to the downstream pipeline in that case.
+bool launchBlockKernel(Data const& data, void* stream) {
+  uint32_t const numThreadsBlock =
+      std::min(1024u, static_cast<uint32_t>(queryDispatchedMaxExperts(data)));
+  LAUNCH_ROUTING_CUSTOM(data, false, routingIndicesBlockKernel, 1, numThreadsBlock,
+                        /*smemSize=*/0,  // No dynamic smem
+                        stream);
+  return queryPolicyHasCompiledTier(data);
+}
+
+// Returns whether a compiled tier covered the runtime (numExperts, topK) and the
+// kernel was actually launched (see launchBlockKernel).
+bool launchDynBlockKernel(Data const& data, uint32_t numThreadsHist, void* stream) {
+  int32_t const maxExperts = queryDispatchedMaxExperts(data);
+  int const numSlots = data.mNumTokens * maxExperts;
+  int const smemSize = numSlots + numSlots * 2 + 128 +
+                       2 * (maxExperts / WarpSize) * static_cast<int>(sizeof(int32_t));
+  int const threads =
+      std::min(std::max(data.mNumTokens * static_cast<int>(WarpSize), maxExperts), 1024);
+
+  LAUNCH_ROUTING_CUSTOM(data, false, routingIndicesDynBlockKernel, 1, threads, smemSize, stream);
+  return queryPolicyHasCompiledTier(data);
+}
+
+}  // namespace moe::dev::routing::routingCustom

--- a/csrc/fused_moe/trtllm_backend/trtllm_fused_moe_routing_custom_cluster.cu
+++ b/csrc/fused_moe/trtllm_backend/trtllm_fused_moe_routing_custom_cluster.cu
@@ -16,3 +16,15 @@
 
 #define FLASHINFER_ROUTING_CUSTOM_CLUSTER_SMALL
 #include "trtllm_fused_moe_routing_custom.cuh"
+
+namespace moe::dev::routing::routingCustom {
+
+bool launchClusterKernelBlockDim256(Data const& data, void* stream) {
+  return launchClusterKernelForBlockDim<ClusterBlockDim256>(data, stream);
+}
+
+bool launchClusterKernelBlockDim512(Data const& data, void* stream) {
+  return launchClusterKernelForBlockDim<ClusterBlockDim512>(data, stream);
+}
+
+}  // namespace moe::dev::routing::routingCustom

--- a/csrc/fused_moe/trtllm_backend/trtllm_fused_moe_routing_custom_cluster_large.cu
+++ b/csrc/fused_moe/trtllm_backend/trtllm_fused_moe_routing_custom_cluster_large.cu
@@ -16,3 +16,22 @@
 
 #define FLASHINFER_ROUTING_CUSTOM_CLUSTER_LARGE
 #include "trtllm_fused_moe_routing_custom.cuh"
+
+namespace moe::dev::routing::routingCustom {
+
+bool launchClusterKernelBlockDim1024(Data const& data, void* stream) {
+  bool const useNoOpSoftmaxScores = data.mPtrScores != nullptr &&
+                                    data.mPreprocessType == RoutingPreprocessType::None &&
+                                    data.mPostprocessType == RoutingPostprocessType::Softmax;
+  if (useNoOpSoftmaxScores) {
+    return launchClusterKernelForPolicy<ClusterBlockDim1024, NoOpPreprocess, SoftmaxPostprocess>(
+        data, stream);
+  }
+
+  LAUNCH_ROUTING_CUSTOM(data, false, routingIndicesClusterKernel, NumBlocksPerCluster, NumThreads,
+                        /*smemSize=*/0,  // No dynamic smem
+                        stream);
+  return queryPolicyHasCompiledTier(data);
+}
+
+}  // namespace moe::dev::routing::routingCustom

--- a/csrc/fused_moe/trtllm_backend/trtllm_fused_moe_routing_custom_entry_launchers.cuh
+++ b/csrc/fused_moe/trtllm_backend/trtllm_fused_moe_routing_custom_entry_launchers.cuh
@@ -1,0 +1,155 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+// Implementation header included by exactly one routing entry translation unit in each JIT module.
+// It owns the launchers shared by raw-score and precomputed routing, while score selection and the
+// full routing entry point remain in trtllm_fused_moe_routing_custom.cuh.
+
+#include "flashinfer/trtllm/fused_moe/RoutingCustomPolicy.cuh"
+#include "tvm_ffi_utils.h"
+
+namespace moe::dev::routing::routingCustom {
+
+bool launchClusterKernelBlockDim256(Data const& data, void* stream);
+bool launchClusterKernelBlockDim512(Data const& data, void* stream);
+bool launchClusterKernelBlockDim1024(Data const& data, void* stream);
+
+// Returns whether a compiled tier covered the runtime (numExperts, topK) and the
+// kernel was actually launched (see launchBlockKernel).
+bool launchClusterKernel(Data const& data, void* stream) {
+  // Use the wider cluster only for permutation-only launches in the bounded high-expert/high-TopK
+  // range. Score-to-TopK fused clusters retain the general capacity-based dispatch.
+  bool const useWidePermutationCluster =
+      data.mPtrScores == nullptr &&
+      topk::isInHighExpertLaneOwnedTopKRange(data.mNumExperts, data.mTopK) &&
+      data.mNumTokens >= 32 && data.mNumTokens <= 64;
+  if (useWidePermutationCluster) {
+    return launchClusterKernelBlockDim512(data, stream);
+  }
+
+  // Each warp owns one token, so the reduced-thread cluster variants have lower token capacity.
+  // Use them only where the requested token count fits; otherwise keep the original 1024-thread
+  // launch.
+  constexpr int MaxNumTokensClusterScores256 =
+      NumBlocksPerCluster * (NumExperts256Experts / WarpSize);
+  constexpr int MaxNumTokensClusterScores512 =
+      NumBlocksPerCluster * (NumExperts512Experts / WarpSize);
+  if (data.mNumTokens <= MaxNumTokensClusterScores256) {
+    return launchClusterKernelBlockDim256(data, stream);
+  }
+  if (data.mNumTokens <= MaxNumTokensClusterScores512) {
+    return launchClusterKernelBlockDim512(data, stream);
+  }
+  return launchClusterKernelBlockDim1024(data, stream);
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+//
+// Cooperative and multi-kernel post-TopK launchers.
+//
+// The coop kernel only performs the post-TopK permutation pipeline (histogram, prefix-scan,
+// index writes). It does not compute TopK; it reads pre-computed results from mPtrTopKPacked
+// or mPtrTopKIds. The expert tier sizes shared memory and determines the thread count. Most
+// tiers use NumTop8Experts and generic 64-entry per-thread state. Bounded high-expert/high-TopK
+// tiers can use NumTop16Experts with four entries per thread when that state covers
+// mNumTokens * mTopK.
+//
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+template <int NumExpertsTier>
+void launchCoopKernelTier(Data const& data, int numBlocksCoop, uint32_t numThreadsHist,
+                          void* stream) {
+  bool useBoundedState = false;
+  if constexpr (topk::isInHighExpertLaneOwnedTopKRange(NumExpertsTier, NumTop16Experts)) {
+    int64_t const expandedIdxSize = int64_t{data.mNumTokens} * int64_t{data.mTopK};
+    int64_t const boundedCapacity = int64_t{4} * int64_t{numBlocksCoop} * int64_t{numThreadsHist};
+    useBoundedState = data.mTopK > NumTop8Experts && data.mTopK <= NumTop16Experts &&
+                      expandedIdxSize <= boundedCapacity;
+  }
+
+  if (useBoundedState) {
+    LAUNCH_ROUTING_WITH_POLICIES(
+        data, /*coopLaunch=*/true, routingIndicesCoopKernel, numBlocksCoop, numThreadsHist,
+        /*smemSize=*/0, stream, NoOpPreprocess, NoOpPostprocess, NumExpertsTier, NumTop16Experts);
+  } else {
+    LAUNCH_ROUTING_WITH_POLICIES(
+        data, /*coopLaunch=*/true, routingIndicesCoopKernel, numBlocksCoop, numThreadsHist,
+        /*smemSize=*/0, stream, NoOpPreprocess, NoOpPostprocess, NumExpertsTier, NumTop8Experts);
+  }
+}
+
+void launchCoopKernel(Data const& data, int numBlocksCoop, uint32_t numThreadsHist, void* stream) {
+  if (data.mNumExperts <= NumExperts128Experts) {
+    LAUNCH_ROUTING_WITH_POLICIES(data, /*coopLaunch=*/true, routingIndicesCoopKernel, numBlocksCoop,
+                                 numThreadsHist, /*smemSize=*/0, stream, NoOpPreprocess,
+                                 NoOpPostprocess, NumExperts128Experts, NumTop8Experts);
+  } else if (data.mNumExperts <= NumExperts160Experts) {
+    LAUNCH_ROUTING_WITH_POLICIES(data, /*coopLaunch=*/true, routingIndicesCoopKernel, numBlocksCoop,
+                                 numThreadsHist, /*smemSize=*/0, stream, NoOpPreprocess,
+                                 NoOpPostprocess, NumExperts160Experts, NumTop8Experts);
+  } else if (data.mNumExperts <= NumExperts256Experts) {
+    LAUNCH_ROUTING_WITH_POLICIES(data, /*coopLaunch=*/true, routingIndicesCoopKernel, numBlocksCoop,
+                                 numThreadsHist, /*smemSize=*/0, stream, NoOpPreprocess,
+                                 NoOpPostprocess, NumExperts256Experts, NumTop8Experts);
+  } else if (data.mNumExperts <= NumExperts384Experts) {
+    LAUNCH_ROUTING_WITH_POLICIES(data, /*coopLaunch=*/true, routingIndicesCoopKernel, numBlocksCoop,
+                                 numThreadsHist, /*smemSize=*/0, stream, NoOpPreprocess,
+                                 NoOpPostprocess, NumExperts384Experts, NumTop8Experts);
+  } else if (data.mNumExperts <= NumExperts512Experts) {
+    LAUNCH_ROUTING_WITH_POLICIES(data, /*coopLaunch=*/true, routingIndicesCoopKernel, numBlocksCoop,
+                                 numThreadsHist, /*smemSize=*/0, stream, NoOpPreprocess,
+                                 NoOpPostprocess, NumExperts512Experts, NumTop8Experts);
+  } else if (data.mNumExperts <= NumExperts576Experts) {
+    LAUNCH_ROUTING_WITH_POLICIES(data, /*coopLaunch=*/true, routingIndicesCoopKernel, numBlocksCoop,
+                                 numThreadsHist, /*smemSize=*/0, stream, NoOpPreprocess,
+                                 NoOpPostprocess, NumExperts576Experts, NumTop8Experts);
+  } else if (data.mNumExperts <= NumExperts896Experts) {
+    launchCoopKernelTier<NumExperts896Experts>(data, numBlocksCoop, numThreadsHist, stream);
+  } else if (data.mNumExperts <= NumExperts1024Experts) {
+    launchCoopKernelTier<NumExperts1024Experts>(data, numBlocksCoop, numThreadsHist, stream);
+  } else {
+    TVM_FFI_LOG_AND_THROW(NotImplementedError)
+        << "Coop kernel does not support numExperts > " << NumExperts1024Experts << ", got "
+        << data.mNumExperts;
+  }
+}
+
+void launchInitExpertCounts(Data const& data, uint32_t numThreadsHist, void* stream) {
+  LAUNCH_ROUTING_CUSTOM_NO_POLICY(data, false, routingInitExpertCounts,
+                                  (2 * data.mNumExperts - 1) / numThreadsHist + 1, numThreadsHist,
+                                  /*smemSize=*/0,  // No dynamic smem
+                                  stream);
+}
+
+void launchHistogramKernel(Data const& data, int numBlocksHistogram, uint32_t numThreadsHist,
+                           void* stream) {
+  LAUNCH_ROUTING_CUSTOM_NO_POLICY(data, false, routingIndicesHistogramKernel, numBlocksHistogram,
+                                  numThreadsHist,
+                                  /*smemSize=*/0,  // No dynamic smem
+                                  stream);
+}
+
+void launchOffsetsKernel(Data const& data, int numBlocksOffsets, uint32_t numThreadsHist,
+                         void* stream) {
+  LAUNCH_ROUTING_CUSTOM_NO_POLICY(data, false, routingIndicesOffsetsKernel, numBlocksOffsets,
+                                  numThreadsHist,
+                                  /*smemSize=*/0,  // No dynamic smem
+                                  stream);
+}
+
+}  // namespace moe::dev::routing::routingCustom

--- a/csrc/fused_moe/trtllm_backend/trtllm_fused_moe_routing_custom_post_topk_block.cu
+++ b/csrc/fused_moe/trtllm_backend/trtllm_fused_moe_routing_custom_post_topk_block.cu
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <algorithm>
+
+#define FLASHINFER_ROUTING_CUSTOM_BLOCK_GROUP
+#include "trtllm_fused_moe_routing_custom.cuh"
+
+namespace moe::dev::routing::routingCustom {
+namespace {
+
+int32_t queryPostTopKMaxExperts(Data const& data) {
+  int32_t result = getMaxNumExperts(data.mNumExperts);
+  using Pairs = typename PolicyTraits<NoOpPreprocess, SoftmaxPostprocess>::Pairs;
+  dispatchTierPairs(static_cast<Pairs*>(nullptr), data,
+                    [&](auto eTag, auto /*kTag*/) { result = decltype(eTag)::value; });
+  return result;
+}
+
+bool queryPostTopKHasCompiledTier(Data const& data) {
+  using Pairs = typename PolicyTraits<NoOpPreprocess, SoftmaxPostprocess>::Pairs;
+  return dispatchTierPairs(static_cast<Pairs*>(nullptr), data, [](auto, auto) {});
+}
+
+}  // namespace
+
+// The precomputed routing path uses one fixed policy only to select the supported
+// expert/topK tier; it never executes score preprocessing or postprocessing.
+bool launchBlockKernel(Data const& data, void* stream) {
+  uint32_t const numThreadsBlock =
+      std::min(1024u, static_cast<uint32_t>(queryPostTopKMaxExperts(data)));
+  LAUNCH_ROUTING_FOR_POLICY(data, false, routingIndicesBlockKernel, 1, numThreadsBlock,
+                            /*smemSize=*/0, stream, NoOpPreprocess, SoftmaxPostprocess);
+  return queryPostTopKHasCompiledTier(data);
+}
+
+bool launchDynBlockKernel(Data const& data, uint32_t numThreadsHist, void* stream) {
+  int32_t const maxExperts = queryPostTopKMaxExperts(data);
+  int const numSlots = data.mNumTokens * maxExperts;
+  int const smemSize = numSlots + numSlots * 2 + 128 +
+                       2 * (maxExperts / WarpSize) * static_cast<int>(sizeof(int32_t));
+  int const threads =
+      std::min(std::max(data.mNumTokens * static_cast<int>(WarpSize), maxExperts), 1024);
+
+  LAUNCH_ROUTING_FOR_POLICY(data, false, routingIndicesDynBlockKernel, 1, threads, smemSize, stream,
+                            NoOpPreprocess, SoftmaxPostprocess);
+  return queryPostTopKHasCompiledTier(data);
+}
+
+}  // namespace moe::dev::routing::routingCustom

--- a/csrc/fused_moe/trtllm_backend/trtllm_fused_moe_routing_custom_post_topk_cluster.cu
+++ b/csrc/fused_moe/trtllm_backend/trtllm_fused_moe_routing_custom_post_topk_cluster.cu
@@ -14,6 +14,19 @@
  * limitations under the License.
  */
 
-#define FLASHINFER_ROUTING_CUSTOM_ENTRY
+#define FLASHINFER_ROUTING_CUSTOM_CLUSTER_SMALL
 #include "trtllm_fused_moe_routing_custom.cuh"
-#include "trtllm_fused_moe_routing_custom_entry_launchers.cuh"
+
+namespace moe::dev::routing::routingCustom {
+
+bool launchClusterKernelBlockDim256(Data const& data, void* stream) {
+  return launchClusterKernelForPolicy<ClusterBlockDim256, NoOpPreprocess, SoftmaxPostprocess>(
+      data, stream);
+}
+
+bool launchClusterKernelBlockDim512(Data const& data, void* stream) {
+  return launchClusterKernelForPolicy<ClusterBlockDim512, NoOpPreprocess, SoftmaxPostprocess>(
+      data, stream);
+}
+
+}  // namespace moe::dev::routing::routingCustom

--- a/csrc/fused_moe/trtllm_backend/trtllm_fused_moe_routing_custom_post_topk_cluster_large.cu
+++ b/csrc/fused_moe/trtllm_backend/trtllm_fused_moe_routing_custom_post_topk_cluster_large.cu
@@ -14,6 +14,14 @@
  * limitations under the License.
  */
 
-#define FLASHINFER_ROUTING_CUSTOM_ENTRY
+#define FLASHINFER_ROUTING_CUSTOM_CLUSTER_LARGE
 #include "trtllm_fused_moe_routing_custom.cuh"
-#include "trtllm_fused_moe_routing_custom_entry_launchers.cuh"
+
+namespace moe::dev::routing::routingCustom {
+
+bool launchClusterKernelBlockDim1024(Data const& data, void* stream) {
+  return launchClusterKernelForPolicy<ClusterBlockDim1024, NoOpPreprocess, SoftmaxPostprocess>(
+      data, stream);
+}
+
+}  // namespace moe::dev::routing::routingCustom

--- a/csrc/fused_moe/trtllm_backend/trtllm_fused_moe_routing_custom_post_topk_entry.cu
+++ b/csrc/fused_moe/trtllm_backend/trtllm_fused_moe_routing_custom_post_topk_entry.cu
@@ -14,6 +14,4 @@
  * limitations under the License.
  */
 
-#define FLASHINFER_ROUTING_CUSTOM_ENTRY
-#include "trtllm_fused_moe_routing_custom.cuh"
 #include "trtllm_fused_moe_routing_custom_entry_launchers.cuh"

--- a/csrc/moe_utils_binding.cu
+++ b/csrc/moe_utils_binding.cu
@@ -333,7 +333,7 @@ TVM_FFI_DLL_EXPORT_TYPED_FUNC(flashinfer_moe_activation_bf16, moe_activation_bf1
 
 // ============================ moeSort bindings ============================
 // moe_sort - Sort tokens by expert assignment and generate mapping tensors
-// This uses DeepSeekV3 routing method with pre-computed expert selections
+// This uses the shared routing pipeline with pre-computed expert selections.
 //
 // Returns via output pointers:
 // - tile_idx_to_expert_idx: [max_num_tiles], mapping from tile to local expert index
@@ -367,8 +367,8 @@ void moe_sort(
     // Optional: explicit CUDA stream pointer for CUDA graph compatibility
     // If 0, uses TVM FFI's current stream
     int64_t cuda_stream_ptr) {
-  // Set up the routing data structure
-  moe::dev::routing::routingDeepSeek::Data routingData;
+  // Set up the routing-neutral post-TopK data structure.
+  moe::dev::routing::routingCustom::Data routingData{};
 
   // Configure dtypes
   routingData.mDtypeOutput = batchedGemm::trtllm::gen::Dtype::Bfloat16;
@@ -409,28 +409,26 @@ void moe_sort(
   routingData.mLocalExpertsStrideLog2 = 0;
   routingData.mNumLocalExperts = num_local_experts;
 
-  // Fused shared expert fields — unused in cute DSL moe_sort path, but must be zero-initialized
-  // because the routing kernel reads mNumFusedSharedExperts unconditionally (adds it to numExperts
-  // and topK at lines 576-577 of trtllm_fused_moe_routing_deepseek.cu).
+  // CuTe DSL moe_sort has no fused shared expert. Keep the shared post-TopK metadata explicit.
   routingData.mNumFusedSharedExperts = 0;
   routingData.mSharedExpertTokenOffset = 0;
   routingData.mSharedExpertNumTokens = 0;
   routingData.mTotalExpertsPerToken = top_k;
 
-  // DeepSeekV3 specific parameters
-  // For moe_sort, we use n_group=1, topk_group=1 since experts are already selected
-  routingData.mNumExpertGroups = 1;
-  routingData.mNumLimitedGroups = 1;
-  routingData.mRouteScale = 1.0f;
-  routingData.mSumEpsilon = 1e-20f;
-  routingData.mUseRoutingSoftmax = false;
+  // moe_sort already receives selected experts and weights, so call the shared post-TopK pipeline
+  // without compiling score-routing implementations.
+  FLASHINFER_CHECK(routingData.mPtrTopKIds != nullptr,
+                   "Routing kernel requires at least one input parameter");
+  FLASHINFER_CHECK(routingData.mTopK > 0, "mTopK must be positive");
+  FLASHINFER_CHECK(routingData.mPtrTopKWeights != nullptr,
+                   "When mPtrTopKIds is provided, mPtrTopKWeights must also be provided for "
+                   "precomputed routing.");
 
-  // Run the routing kernel
   // Use explicit stream if provided (for CUDA graph compatibility), otherwise fall back to TVM FFI
   // stream
   cudaStream_t stream =
       cuda_stream_ptr != 0 ? reinterpret_cast<cudaStream_t>(cuda_stream_ptr) : get_current_stream();
-  moe::dev::routing::routingDeepSeek::run(routingData, stream);
+  moe::dev::routing::runPostTopKPipeline(routingData, stream);
 }
 
 TVM_FFI_DLL_EXPORT_TYPED_FUNC(flashinfer_moe_sort, moe_sort);

--- a/flashinfer/fused_moe/cute_dsl/moe_utils.py
+++ b/flashinfer/fused_moe/cute_dsl/moe_utils.py
@@ -544,8 +544,8 @@ def moe_sort(
     Sort tokens by expert assignment and generate mapping tensors.
 
     This function performs token sorting and index mapping computation required
-    for grouped GEMM operations in MoE. It uses the same algorithm as TRT-LLM's
-    moe_sort with DeepSeekV3 routing method.
+    for grouped GEMM operations in MoE. It uses TRT-LLM Gen's shared post-TopK
+    routing pipeline.
 
     Note: This function does NOT physically reorder data - use moe_permute() for that.
 

--- a/flashinfer/jit/moe_utils.py
+++ b/flashinfer/jit/moe_utils.py
@@ -36,7 +36,7 @@ def gen_moe_utils_module() -> JitSpec:
       output slice before GEMM2 finalize. Mirrors TRT-LLM's
       ``moe_output_memset_inplace`` Path A.
     - moeActivation: Apply activation functions with optional FP4 quantization
-    - moeSort: Sort tokens by expert assignment (DeepSeekV3 routing)
+    - moeSort: Sort tokens by precomputed expert assignment
     """
     # Lazy imports to avoid circular dependency:
     # artifacts.py imports from jit.cubin_loader, which triggers jit/__init__.py,
@@ -97,15 +97,13 @@ def gen_moe_utils_module() -> JitSpec:
             jit_env.FLASHINFER_CSRC_DIR / "nv_internal/cpp/common/memoryUtils.cu",
             # Routing kernels for moe_sort
             jit_env.FLASHINFER_CSRC_DIR
-            / "fused_moe/trtllm_backend/trtllm_fused_moe_routing_deepseek.cu",
+            / "fused_moe/trtllm_backend/trtllm_fused_moe_routing_custom_post_topk_block.cu",
             jit_env.FLASHINFER_CSRC_DIR
-            / "fused_moe/trtllm_backend/trtllm_fused_moe_routing_custom_block.cu",
+            / "fused_moe/trtllm_backend/trtllm_fused_moe_routing_custom_post_topk_cluster.cu",
             jit_env.FLASHINFER_CSRC_DIR
-            / "fused_moe/trtllm_backend/trtllm_fused_moe_routing_custom_cluster.cu",
+            / "fused_moe/trtllm_backend/trtllm_fused_moe_routing_custom_post_topk_cluster_large.cu",
             jit_env.FLASHINFER_CSRC_DIR
-            / "fused_moe/trtllm_backend/trtllm_fused_moe_routing_custom_cluster_large.cu",
-            jit_env.FLASHINFER_CSRC_DIR
-            / "fused_moe/trtllm_backend/trtllm_fused_moe_routing_custom_entry.cu",
+            / "fused_moe/trtllm_backend/trtllm_fused_moe_routing_custom_post_topk_entry.cu",
             jit_env.FLASHINFER_CSRC_DIR
             / "fused_moe/trtllm_backend/trtllm_fused_moe_routing_common.cu",
         ],


### PR DESCRIPTION
## 📌 Description

@humansand

This is a one-commit compilation-surface follow-up to merged #4082, with no
API or output-contract change.

`moe_sort` accepts precomputed top-k expert IDs and weights, but `moe_utils`
currently compiles the full raw-score routing wrapper family. This PR keeps the
existing post-topK routing/permutation implementation and gives `moe_utils` a
narrower, source-owned wrapper family.

- **Direct binding path:** constructs a zero-initialized `routingCustom::Data`
  descriptor from the precomputed expert IDs/weights, applies the existing
  input validation, and calls `runPostTopKPipeline` directly.
- **#4635-style source split:** adds block, small-cluster, large-cluster, and
  entry wrapper translation units alongside the four generic wrappers split by
  #4635. Each source owns its launcher definitions: the generic sources retain
  runtime policy dispatch, while the policy-bearing post-topK block/cluster
  sources instantiate only `NoOpPreprocess + SoftmaxPostprocess`. No new
  build-mode selector is needed.
- **Source-list pruning:** `gen_moe_utils_module()` selects the four post-topK
  wrappers and no longer lists the DeepSeek raw-score translation unit.
  Specialization is expressed by source selection; the JIT spec adds no
  caller-specific compile flag.
- **Preserved implementation:** block, dynamic-block, cluster, cooperative,
  histogram, offset, EP-window, PDL, and permutation algorithms remain the
  existing implementation introduced by #2803. The fail-closed tier checks
  from #3840 and high-expert/high-topK tiers from #4152 remain selected through
  the same `PolicyTraits` definitions.
- **Shared entry launchers:** cooperative, histogram, offset, and cluster
  selection launchers are extracted with unchanged dispatch behavior into one
  implementation header included by exactly one entry translation unit per JIT
  module. Shared cooperative/utility launchers retain their existing
  `NoOpPreprocess + NoOpPostprocess` instantiations. Raw-score selection and the
  full routing entry point stay in the generic entry source.
- **Generic routing preserved:** #4082's `trtllm_gen_routing` source list and
  runtime dispatch are unchanged. Its four sources now own the same launcher
  bodies that previously lived in the shared implementation header.
- **Minimal shared policy surface:** `RoutingCustomPolicy.cuh` is unchanged;
  `trtllm_fused_moe_routing_common.cu` changes only its launcher-ownership
  comment.
- **No interface change:** the Python API, exported FFI registration/signature,
  tensor layouts, and output semantics are unchanged. This does not add a new
  sorter or JIT module.
- **Measured gain on one C1 B200:** isolated `moe_utils` build/load improves
  from 194.29 s to 71.93 s (62.98%, 2.70x); W4A16 cold first run improves from
  245.19 s to 120.99 s (50.66%, 2.03x); the W4A4 confirmation pair improves
  from 244.03 s to 121.28 s (50.30%, 2.01x).

### Why source selection is needed

A separate, earlier direct-call-only control removed the DeepSeek entry source
and invoked `runPostTopKPipeline` directly, but retained the four generic
custom-routing wrappers. One isolated cold build/load took 193.865 seconds;
that campaign's repeated #4082 baseline mean was 194.635 seconds, so the
control did not provide a meaningful gain. The generic block/cluster
translation units still instantiated the full policy matrix and dominated the
critical path. The fresh controlled tables below are a separate exact-source
campaign.

The final change therefore narrows those four translation units through source
selection without changing their kernel algorithms.

Specialization is controlled only by the source list. The post-topK sources own
their fixed-policy launchers, the generic sources own their runtime-dispatched
launchers, and both entry sources reuse the same post-topK implementation
header. There is no `FLASHINFER_ROUTING_POST_TOPK_ONLY`, caller-specific JIT
flag, duplicated routing algorithm, or new exported ABI.

### Stack / review scope

- **Built on:** merged #4082
- **Direct parent / measured baseline:**
  `fb28d7242b3506a2348265962041acc1fb56cca4`
- **This PR's only commit and timed candidate:**
  `4a17da2169e96559e1321524c5186d81f6880fd8`
- **Direct delta:** 14 files, 381 insertions, 213 deletions
- **Stable patch ID:** `656c0b9a3152243ad3d5d8cf64837e6b003f7370`
- **Review command:**
  `git diff fb28d7242b3506a2348265962041acc1fb56cca4..4a17da2169e96559e1321524c5186d81f6880fd8`

GitHub displays the single reviewable commit above.

## 🔍 Related Issues

- Builds on merged #4082.
- Reuses the shared post-topK pipeline introduced by #2803.
- Tracked in #4561; the optimized `moe_utils` path is shared by SM10x CuTe DSL
  W4A4 and W4A16.
- Follows the compilation-surface pruning approach used by #4635: narrow one
  JIT module's sources/template instantiations without replacing the underlying
  implementation.
- Supersedes #4677, which only added a focused test and did not reduce the
  production compilation overhead.

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

Targeted changed-file hooks passed:

```text
check for added large files..............................................Passed
check for case conflicts.................................................Passed
check for merge conflicts................................................Passed
check for broken symlinks............................(no files to check)Skipped
fix end of files.........................................................Passed
mixed line ending........................................................Passed
fix requirements.txt.................................(no files to check)Skipped
trim trailing whitespace.................................................Passed
Tabs remover.............................................................Passed
CRLF end-lines remover...................................................Passed
clang-format.............................................................Passed
mypy.....................................................................Passed
ruff check...............................................................Passed
ruff format..............................................................Passed
```

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

No test file changes are needed for this source specialization; the
existing W4A4, W4A16, EP, CUDA-graph, poisoned-buffer, and route-window tests
were run below. The full repository suite was not run.

### C1 environment and timing method

- Hardware: 1x NVIDIA B200 on C1 (`B200-130`), SM100, driver 580.126.09
- Image: `nvcr.io/nvidia/pytorch:26.05-py3`
- Runtime image ID reported by the C1 pod:
  `nvcr.io/nvidia/pytorch@sha256:222d8b18e671be5c3ef91cb41727a2572a0b23f59ded6c39f373a96946f6f2ba`
- CUDA/nvcc: 13.2 / `Build cuda_13.2.r13.2/compiler.37668154_0`
- Python: 3.12.3
- PyTorch: `2.12.0a0+5aff3928d8.nv26.05`
- CuTe DSL: 4.7.0; TVM FFI: 0.1.13.post3
- Baseline: merged #4082,
  `fb28d7242b3506a2348265962041acc1fb56cca4`
- Measured candidate / current PR head:
  `4a17da2169e96559e1321524c5186d81f6880fd8`

All compile measurements were serialized on the same node. Isolated
`moe_utils` and W4A16 used A/B/A/B order; W4A4 used one fresh A/B confirmation
pair. Every observation used:

```bash
export CUDA_VISIBLE_DEVICES=0
export FLASHINFER_CUDA_ARCH_LIST=10.0a
export MAX_JOBS=4
export FLASHINFER_NVCC_THREADS=1
export FLASHINFER_JIT_VERBOSE=0
export FLASHINFER_JIT_DEBUG=0
export FLASHINFER_DISABLE_VERSION_CHECK=1
unset FLASHINFER_DISABLE_JIT
```

Each run used a unique empty `FLASHINFER_WORKSPACE_BASE`. The W4A4/W4A16 runs
also used the same preseeded
`FLASHINFER_CUBIN_DIR=/hai-workspace/fi-source-owned-validation/cubins`, making
the FlashInfer JIT build cold while excluding artifact-download variance. The
unique workspaces were under
`/hai-workspace/fi-source-owned-validation/workspaces`. CuTe DSL and other
machine-level caches were shared symmetrically between arms.
`FLASHINFER_JIT_VERBOSE=0` is important here because verbose mode also enables
debug compilation in this revision.

The affected module is shared by SM10x CuTe DSL W4A4 and W4A16: W4A4
per-tensor/per-token execution and W4A16 execution both call the same
`moe_sort` helper, whose native binding has no activation- or weight-quantization
field. The separate SM12x/B12x W4A4 path is outside this claim.

### W4A4 CuTe DSL MoE cold first-run time

Both revisions ran the exact same existing W4A4 test:

```bash
python3 -m pytest -q \
  'tests/moe/test_cute_dsl_fused_moe.py::TestMoeSortBufferInitPoisoned::test_wrapper_with_poisoned_moe_sort_buffers[1-256]'
```

The workload uses W4A4 per-tensor quantization, 256 tokens, hidden size 256,
intermediate size 512, 256 experts, top-k 8, and route tile 128. Times are
end-to-end pytest wall time, including cold FlashInfer JIT compilation, first
execution, and assertions.

| Order | Revision | Wall time (s) | pytest result |
|---|---|---:|---|
| A1 | merged #4082 baseline | 244.035 | 1 passed in 241.00 s |
| B1 | source-owned candidate | 121.282 | 1 passed in 118.18 s |

Cold wall time is **122.752 seconds lower** (**50.301%**), or **2.012x
faster**. This is compilation/first-run evidence, not kernel-runtime
performance.

<details>
<summary>Raw W4A4 timing summaries and wrapper JSON</summary>

```text
A1
1 passed, 112 warnings in 241.00s (0:04:01)
{"child_maxrss_kib": 1833096, "child_system_s": 22.086493, "child_user_s": 729.311933, "command": ["python3", "-m", "pytest", "-q", "tests/moe/test_cute_dsl_fused_moe.py::TestMoeSortBufferInitPoisoned::test_wrapper_with_poisoned_moe_sort_buffers[1-256]"], "returncode": 0, "wall_s": 244.0345314303413}

B1
1 passed, 112 warnings in 118.18s (0:01:58)
{"child_maxrss_kib": 1758584, "child_system_s": 17.013674, "child_user_s": 301.99465, "command": ["python3", "-m", "pytest", "-q", "tests/moe/test_cute_dsl_fused_moe.py::TestMoeSortBufferInitPoisoned::test_wrapper_with_poisoned_moe_sort_buffers[1-256]"], "returncode": 0, "wall_s": 121.28239695169032}
```

</details>

### W4A16 CuTe DSL MoE cold first-run time

Both revisions ran the exact same existing test:

```bash
python3 -m pytest -q \
  'tests/moe/test_cute_dsl_fused_moe.py::TestCuteDslMoeW4A16::test_route_tile_boundary_accuracy[route32-mixed]'
```

The workload has 33 tokens, hidden size 256, intermediate size 512, 8 experts,
top-k 2, and route tile 32. Times are end-to-end pytest wall time, including
cold FlashInfer JIT compilation, first execution, and assertions.

| Order | Revision | Wall time (s) | pytest result |
|---|---|---:|---|
| A1 | merged #4082 baseline | 244.167 | 1 passed in 240.64 s |
| B1 | source-owned candidate | 121.352 | 1 passed in 117.92 s |
| A2 | merged #4082 baseline | 246.206 | 1 passed in 242.81 s |
| B2 | source-owned candidate | 120.621 | 1 passed in 117.26 s |
| Mean | merged #4082 baseline | **245.186** | |
| Mean | source-owned candidate | **120.987** | |

Mean cold wall time is **124.200 seconds lower** (**50.655%**), or **2.027x
faster**. This is compilation/first-run evidence, not kernel-runtime
performance.

<details>
<summary>Raw W4A16 timing summaries and wrapper JSON</summary>

```text
A1
1 passed, 70 warnings in 240.64s (0:04:00)
{"child_maxrss_kib": 1835088, "child_system_s": 22.401692, "child_user_s": 726.829076, "command": ["python3", "-m", "pytest", "-q", "tests/moe/test_cute_dsl_fused_moe.py::TestCuteDslMoeW4A16::test_route_tile_boundary_accuracy[route32-mixed]"], "returncode": 0, "wall_s": 244.1670428980142}

B1
1 passed, 70 warnings in 117.92s (0:01:57)
{"child_maxrss_kib": 1764972, "child_system_s": 16.945436, "child_user_s": 299.812712, "command": ["python3", "-m", "pytest", "-q", "tests/moe/test_cute_dsl_fused_moe.py::TestCuteDslMoeW4A16::test_route_tile_boundary_accuracy[route32-mixed]"], "returncode": 0, "wall_s": 121.35227965656668}

A2
1 passed, 70 warnings in 242.81s (0:04:02)
{"child_maxrss_kib": 1836924, "child_system_s": 22.082143, "child_user_s": 729.628651, "command": ["python3", "-m", "pytest", "-q", "tests/moe/test_cute_dsl_fused_moe.py::TestCuteDslMoeW4A16::test_route_tile_boundary_accuracy[route32-mixed]"], "returncode": 0, "wall_s": 246.20575772970915}

B2
1 passed, 70 warnings in 117.26s (0:01:57)
{"child_maxrss_kib": 1764800, "child_system_s": 16.972199, "child_user_s": 299.935187, "command": ["python3", "-m", "pytest", "-q", "tests/moe/test_cute_dsl_fused_moe.py::TestCuteDslMoeW4A16::test_route_tile_boundary_accuracy[route32-mixed]"], "returncode": 0, "wall_s": 120.62074816320091}
```

</details>

### Isolated `moe_utils` cold build/load time

The isolated measurement constructs `gen_moe_utils_module()` and times only
`spec.build_and_load()`.

```bash
python3 tools/bench_moe_utils_compile.py
```

| Order | Revision | Build/load (s) | Child user (s) | Peak RSS (KiB) |
|---|---|---:|---:|---:|
| A1 | merged #4082 baseline | 193.250 | 670.089 | 1,836,228 |
| B1 | source-owned candidate | 71.522 | 241.157 | 1,435,648 |
| A2 | merged #4082 baseline | 195.339 | 668.136 | 1,838,508 |
| B2 | source-owned candidate | 72.347 | 241.802 | 1,435,648 |
| Mean | merged #4082 baseline | **194.294** | 669.112 | 1,837,368 |
| Mean | source-owned candidate | **71.934** | 241.479 | 1,435,648 |

Mean build/load time is **122.360 seconds lower** (**62.977%**), or **2.701x
faster**. Peak RSS is 21.86% lower.

<details>
<summary>Inner helper timing records</summary>

```text
A1 {"build_load_s": 193.25006359629333, "child_maxrss_kib": 1836228, "child_system_s": 16.92401, "child_user_s": 670.088806, "import_s": 1.854558078572154, "spec_s": 0.05412162560969591, "total_s": 195.15874330047518}
B1 {"build_load_s": 71.5215839985758, "child_maxrss_kib": 1435648, "child_system_s": 12.844921, "child_user_s": 241.156824, "import_s": 2.3918502628803253, "spec_s": 0.05478984583169222, "total_s": 73.96822410728782}
A2 {"build_load_s": 195.33860528748482, "child_maxrss_kib": 1838508, "child_system_s": 17.549271, "child_user_s": 668.136111, "import_s": 1.8825766574591398, "spec_s": 0.05577211454510689, "total_s": 197.27695405948907}
B2 {"build_load_s": 72.34676724579185, "child_maxrss_kib": 1435648, "child_system_s": 13.071671, "child_user_s": 241.801897, "import_s": 1.878258178010583, "spec_s": 0.057754297740757465, "total_s": 74.28277972154319}
```

</details>

The isolated metric begins after import and JIT-spec construction; neither
interval is included in `build_load_s`.

The final cold artifacts also confirm that `moe_utils.so` shrinks from
12,382,280 to 5,680,624 bytes and its build directory from 32,220,922 to
14,808,052 bytes. Candidate `build.ninja` selects four post-topK wrapper sources
and no DeepSeek source; it contains no caller-specific or post-topK compile
flag. `RoutingCustomPolicy.cuh` is unchanged, while the common source changes
only its launcher-ownership comment. The separately built generic routing
module retains #4082's source list and runtime policy dispatch; its fresh
`build.ninja` has 9 CUDA edges and no specialization flag.

### Correctness and coexistence

Existing targeted tests, rerun against the current source tree with warmed
module caches:

```bash
python3 -m pytest -q \
  'tests/moe/test_cute_dsl_fused_moe.py::TestCuteDslFusedMoeFunctional::test_finalize_handles_cluster_padding_and_partial_tiles[256-w4a4-per-tensor]' \
  'tests/moe/test_cute_dsl_fused_moe.py::TestCuteDslFusedMoeFunctional::test_deterministic_finalize_numerical_accuracy[swiglu-per-tensor]' \
  'tests/moe/test_cute_dsl_fused_moe.py::TestExpertParallelism::test_functional_with_ep[8-w4a4-per-token-False]' \
  'tests/moe/test_cute_dsl_fused_moe.py::TestCuteDslMoEWrapper::test_wrapper_cuda_graph[256-64-w4a4-per-tensor-True]' \
  'tests/moe/test_cute_dsl_fused_moe.py::TestMoeSortBufferInitPoisoned::test_wrapper_with_poisoned_moe_sort_buffers[32-256]' \
  'tests/moe/test_moe_sort_route_windows.py::test_permutation_is_a_bijection_over_local_routes[256-at-threshold]' \
  'tests/moe/test_cute_dsl_fused_moe.py::TestCuteDslMoeW4A16::test_route_tile_boundary_accuracy[route32-mixed]' \
  'tests/moe/test_cute_dsl_fused_moe.py::TestExpertParallelism::test_functional_with_ep[8-w4a16-False]' \
  'tests/moe/test_cute_dsl_fused_moe.py::TestCuteDslMoEWrapper::test_wrapper_cuda_graph[256-64-w4a16-False]' \
  'tests/moe/test_moe_sort_route_windows.py::test_permutation_is_a_bijection_over_local_routes[128-at-threshold]'
```

```text
10 passed, 706 warnings in 8.03s
```

Additional project-side validation:

```text
PASS semantic parity: 10 canonical case result(s) match exactly
baseline=fb28d7242b3506a2348265962041acc1fb56cca4 candidate=4a17da2169e96559e1321524c5186d81f6880fd8
PASS load order: moe-first
PASS load order: routing-first
```

The parity matrix covers static/dynamic block, small/large cluster, tile 192,
EP, the 65,536-token contiguous-window path, forced multi-kernel routing, PDL
on/off, and CUDA graph replay. Graph outputs are poisoned after capture, then
replayed with both original and mutated inputs and compared with eager output.
Each report rejects AOT/preexisting builds and hashes the imported source tree,
all JIT sources, final library, and `build.ninja`. The parity campaign also set
`FLASHINFER_TRTLLM_MOE_OVERLAP_RESERVED_SMS=8`.

The load-order check builds the current candidate's generic
`trtllm_gen_routing` DSO, keeps both candidate DSOs resident, and exercises the
generic `SigmoidRenorm` raw-score path against a Torch reference before
repeating specialized `moe_sort`, in both load orders. The existing large
generic `Renormalize` oracle test also passed (`1 passed, 3 warnings in 1.78s`).

The cold W4A4/W4A16 runs above both compiled and passed at the exact candidate
commit. A single-module AOT-equivalent build/package/load compiled all 12
`moe_utils` source objects, produced a 5,680,624-byte DSO with SHA-256
`49bb01608f87669a743174c699fd58891484a5b4781524033ab70edf0d00b8c1`, and
loaded it with `FLASHINFER_DISABLE_JIT=1`. Both DSO load orders then passed from
the AOT layout with JIT disabled.

### Limitations

- Validation is targeted to one B200 with CUDA 13.2; the full repository suite
  and other GPU/toolkit combinations were not run.
- Timing is for cold FlashInfer compilation/first load, not steady-state kernel
  latency or throughput.
- The W4A4/W4A16 timing arms used the same preseeded cubin/header artifact
  cache, and machine-level CuTe DSL caches were shared symmetrically. Every
  FlashInfer JIT workspace for cold timing, parity, and load-order validation
  was unique and initially empty. The 10-case regression matrix intentionally
  reused a warmed candidate workspace and is not timing evidence.
- The semantic parity matrix uses valid unique top-k expert assignments.
- A single-module `moe_utils` AOT-equivalent build/package/load and AOT-layout
  GPU runtime smoke was exercised; the full FlashInfer AOT/jit-cache package
  build was not run.

## Reviewer Notes

Please focus review on:

- direct use of the shared `runPostTopKPipeline` for precomputed IDs/weights;
- whether the four post-topK wrappers preserve the launcher ABI and tier
  coverage of their generic counterparts;
- the source-list boundary: `moe_utils` selects the post-topK wrapper family,
  while #4082's generic routing module retains its original sources;
- the source-owned generic launcher bodies and shared entry implementation
  header, including the one-entry-TU ownership contract.
