### PR TITLE
fix(moe): avoid FP8 scale overflow for subnormal inputs

### DIFF
--- a/csrc/nv_internal/tensorrt_llm/kernels/cutlass_kernels/fp8_blockscale_gemm/fp8_blockscale_gemm_kernel.cuh
+++ b/csrc/nv_internal/tensorrt_llm/kernels/cutlass_kernels/fp8_blockscale_gemm/fp8_blockscale_gemm_kernel.cuh
@@ -24,6 +24,7 @@
 #include <cute/arch/cluster_sm90.hpp>
 #include <cute/arch/copy_sm90_desc.hpp>
 #include <cute/arch/copy_sm90_tma.hpp>
+#include <limits>
 #include <optional>
 #include <string>
 #include <vector>
@@ -827,6 +828,17 @@ __forceinline__ __device__ T find_max_elem_in_warp(T value) {
   return value;
 }
 
+// Form the reciprocal from a normal FP32 dequantization scale. Directly computing
+// 448 / amax overflows for tiny nonzero activation blocks (#2595).
+__forceinline__ __device__ float fp8_quantization_scale(float amax, float& dequant_scale) {
+  if (amax == 0.f) {
+    dequant_scale = 1.f;
+    return 1.f;
+  }
+  dequant_scale = fmaxf(amax / 448.f, std::numeric_limits<float>::min());
+  return 1.f / dequant_scale;
+}
+
 template <typename InputType, typename OutputType, typename ScaleType = float>
 __global__ void scale_1x128_kernel(OutputType* output, ScaleType* scales,
                                    InputType const* const input, int dim_x, int dim_y) {
@@ -868,10 +880,11 @@ __global__ void scale_1x128_kernel(OutputType* output, ScaleType* scales,
     }
 
     InputType amax = find_max_elem_in_warp(input_amax);
-    ScaleType scale = amax != InputType(0.f) ? 448.f / ScaleType(amax) : 1.f;
+    float dequant_scale;
+    ScaleType scale = ScaleType(fp8_quantization_scale(float(amax), dequant_scale));
 
     if (lane_id == 0) {
-      scales[(size_t)scales_idx_x * stride_scale_dim_y + scales_idx_y] = ScaleType(1.f / scale);
+      scales[(size_t)scales_idx_x * stride_scale_dim_y + scales_idx_y] = ScaleType(dequant_scale);
     }
 
     OutputType* output_line = output + (size_t)scales_idx_y * dim_x + scales_idx_x * 128;
@@ -985,10 +998,11 @@ __global__ void scale_1x128_kernel(OutputType* output, float* scales, InputType 
     //     __hmax(__hmax(__habs(input_frag[0]), __habs(input_frag[1])),
     //         __hmax(__habs(input_frag[2]), __habs(input_frag[3]))));
 
-    float scale = amax != InputType(0.f) ? 448.f / float(amax) : 1.f;
+    float dequant_scale;
+    float scale = fp8_quantization_scale(float(amax), dequant_scale);
 
     if (kernel_utils::elect_one_sync(lane_id)) {
-      scale_output = float(1.f / scale);
+      scale_output = dequant_scale;
     }
 
     for (int i = 0; i < 4; i++) {
@@ -1048,11 +1062,12 @@ __global__ void scale_1x128_reshape_kernel(OutputType* output, ScaleType* scales
     }
 
     InputType amax = find_max_elem_in_warp(input_amax);
-    ScaleType scale = amax != InputType(0.f) ? 448.f / ScaleType(amax) : 1.f;
+    float dequant_scale;
+    ScaleType scale = ScaleType(fp8_quantization_scale(float(amax), dequant_scale));
 
     if (lane_id == 0) {
       scales[(size_t)scales_idx_h * scales_along_dim_x * stride_scale_dim_y +
-             (size_t)scales_idx_x * stride_scale_dim_y + scales_idx_y] = ScaleType(1.f / scale);
+             (size_t)scales_idx_x * stride_scale_dim_y + scales_idx_y] = ScaleType(dequant_scale);
     }
 
     OutputType* output_line = output + (size_t)scales_idx_h * dim_y * dim_x +
@@ -1108,10 +1123,11 @@ __global__ void scale_128x128_kernel(OutputType* output, ScaleType* scales,
     }
 
     InputType amax = find_max_elem_in_warp(input_amax);
-    ScaleType scale = amax != InputType(0.f) ? 448.f / ScaleType(amax) : 1.f;
+    float dequant_scale;
+    ScaleType scale = ScaleType(fp8_quantization_scale(float(amax), dequant_scale));
 
     if (lane_id == 0) {
-      scales[scales_idx_y * scales_along_dim_x + scales_idx_x] = ScaleType(1.f / scale);
+      scales[scales_idx_y * scales_along_dim_x + scales_idx_x] = ScaleType(dequant_scale);
     }
 
     input_line = input + scales_idx_y * 128 * dim_x + scales_idx_x * 128;

--- a/tests/moe/test_trtllm_cutlass_fused_moe.py
+++ b/tests/moe/test_trtllm_cutlass_fused_moe.py
@@ -1467,6 +1467,77 @@ def test_moe_fp8_block_scaling(
         torch.testing.assert_close(flash_output, ref_output, rtol=1e-1, atol=1e-1)
 
 
+@pytest.mark.skipif(
+    not is_sm90a_supported(torch.device("cuda")),
+    reason="DeepSeek FP8 block scaling requires Hopper",
+)
+def test_moe_fp8_block_scaling_tiny_fc1_output():
+    """Regression test for #2595: tiny FC1 outputs must stay finite and nonzero."""
+    num_tokens, hidden_size, intermediate_size = 4, 128, 128
+    num_experts, top_k = 2, 2
+
+    x = torch.ones(num_tokens, hidden_size, dtype=torch.bfloat16, device="cuda")
+    w31 = torch.ones(
+        num_experts,
+        2 * intermediate_size,
+        hidden_size,
+        dtype=torch.float32,
+        device="cuda",
+    ).to(torch.float8_e4m3fn)
+    w2 = torch.ones(
+        num_experts,
+        hidden_size,
+        intermediate_size,
+        dtype=torch.float32,
+        device="cuda",
+    ).to(torch.float8_e4m3fn)
+    selected_experts = torch.tensor(
+        [[0, 1]] * num_tokens, dtype=torch.int32, device="cuda"
+    )
+    routing_weights = torch.full(
+        (num_tokens, top_k), 0.5, dtype=torch.float32, device="cuda"
+    )
+    w31_scales = torch.full(
+        (num_experts, 2, 1), 1e-20, dtype=torch.float32, device="cuda"
+    )
+    w2_scales = torch.ones((num_experts, 1, 1), dtype=torch.float32, device="cuda")
+    w31_reference = w31.float() * w31_scales.repeat_interleave(128, dim=1)
+    w2_reference = w2.float() * w2_scales.repeat_interleave(128, dim=1)
+    reference = compute_with_experts(
+        num_experts,
+        x.float(),
+        w31_reference,
+        w2_reference,
+        selected_experts,
+        routing_weights,
+    )
+
+    output = torch.empty_like(x)
+    fused_moe.cutlass_fused_moe(
+        x,
+        selected_experts,
+        routing_weights,
+        w31,
+        w2,
+        torch.bfloat16,
+        quant_scales=[w31_scales, w2_scales],
+        output=output,
+        use_deepseek_fp8_block_scale=True,
+        enable_pdl=False,
+    )
+
+    assert torch.isfinite(reference).all()
+    assert torch.count_nonzero(reference) == reference.numel()
+    assert torch.isfinite(output).all()
+    assert torch.count_nonzero(output) == output.numel()
+    torch.testing.assert_close(
+        output.float(),
+        reference,
+        rtol=1e-1,
+        atol=0,
+    )
+
+
 def quant_mxfp4_batches(a, num_experts):
     quant_a = []
     sfs = []


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

The CUTLASS FP8 MoE kernels use `448 / amax` to quantize FC1 output.
For a very small nonzero block, this division can overflow FP32. The
quantized values then become non-finite, and FC2 can return NaN.

This change first computes the dequantization scale, `amax / 448`. It clamps
that value to the smallest normal FP32 value, then takes the reciprocal. This
keeps both scales finite. A block whose maximum is zero still uses scale 1.

The same helper is used in the four block-quantization kernels that had the
same division pattern.

The regression test uses fixed inputs. They produce a tiny but nonzero FC1
output that makes the old division overflow. The test checks that the result
is finite, nonzero, and close to a direct FP32 reference.

## 🔍 Related Issues

Fixes #2595

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see the [pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

Validation:

- NVIDIA H100 80GB HBM3, SM90
- CUDA 13.0, PyTorch 2.13.0+cu130
- Unpatched run: FlashInfer commit `76704c45003cabaa832d59896080f91dca23f74b`
- Patched source rebased onto FlashInfer commit `8cd56793b032bf8469da6d3b3487a26304e98765`
- The changed kernel file is the same in both upstream commits.
- Before the fix: the failing probe returned 512 NaN values out of 512 values.
- Before the fix: the fixed-input test returned zero; its FP32 reference was `1.0486e-34`.
- After the fix: all 11 scale probes returned finite values.
- Regression test: `1 passed, 3 warnings in 86.68s`.
- Full `pre-commit run --all-files`: passed.

All tests run for this change passed. The full hardware matrix will run in CI.

## Reviewer Notes

This bug is separate from #3650. That PR handles NaNs from padded grouped-GEMM
rows. This PR prevents an FP32 overflow while quantizing a valid FC1 output
block.

TensorRT-LLM still has the same `448 / amax` pattern in its copy of this
kernel. I can send the same fix upstream after this change is reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved FP8 block-scaling stability for very small and zero-valued scales.
  * Prevented invalid or non-finite dequantization values during FP8 calculations.
  * Preserved reliable outputs for FP8 fused mixture-of-experts operations.

* **Tests**
  * Added regression coverage for extremely small FP8 scales on Hopper hardware.
  * Verified outputs remain finite, nonzero, and numerically accurate across FP8 fused mixture-of-experts calculations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->