### PR TITLE
fix(jit): separate TGV SM100 target module identities

### DIFF
--- a/flashinfer/jit/gemm/core.py
+++ b/flashinfer/jit/gemm/core.py
@@ -807,9 +807,12 @@ def gen_tgv_gemm_sm10x_module(
         )
 
     dtype_str = "bf16" if dtype == torch.bfloat16 else "fp16"
-    module_name = f"tgv_gemm_{dtype_str}"
+    target = "sm100f" if use_sm_100f else "sm100a"
+    module_name = f"tgv_gemm_{dtype_str}_{target}"
 
-    gen_directory = jit_env.FLASHINFER_GEN_SRC_DIR / f"gen_tgv_gemm_{dtype_str}"
+    gen_directory = (
+        jit_env.FLASHINFER_GEN_SRC_DIR / f"gen_tgv_gemm_{dtype_str}_{target}"
+    )
     os.makedirs(gen_directory, exist_ok=True)
     source_paths = [
         jit_env.FLASHINFER_CSRC_DIR / "tgv_gemm.cu",

--- a/tests/jit/test_tgv_gemm_jit.py
+++ b/tests/jit/test_tgv_gemm_jit.py
@@ -16,11 +16,17 @@ from types import SimpleNamespace
 
 import torch
 
+from flashinfer.jit import core as jit_core
 from flashinfer.jit import env as jit_env
 from flashinfer.jit.gemm.core import gen_tgv_gemm_sm10x_module
 
 
 def test_tgv_gemm_target_specific_jit_specs_and_aot_inventory(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        jit_core.current_compilation_context,
+        "TARGET_CUDA_ARCHS",
+        {(10, "0a"), (10, "3a")},
+    )
     monkeypatch.setattr(jit_env, "FLASHINFER_GEN_SRC_DIR", tmp_path / "generated")
 
     specs = [

--- a/tests/jit/test_tgv_gemm_jit.py
+++ b/tests/jit/test_tgv_gemm_jit.py
@@ -20,9 +20,7 @@ from flashinfer.jit import env as jit_env
 from flashinfer.jit.gemm.core import gen_tgv_gemm_sm10x_module
 
 
-def test_tgv_gemm_target_specific_jit_specs_and_aot_inventory(
-    monkeypatch, tmp_path
-):
+def test_tgv_gemm_target_specific_jit_specs_and_aot_inventory(monkeypatch, tmp_path):
     monkeypatch.setattr(jit_env, "FLASHINFER_GEN_SRC_DIR", tmp_path / "generated")
 
     specs = [
@@ -79,9 +77,7 @@ def test_tgv_gemm_target_specific_jit_specs_and_aot_inventory(
         monkeypatch.setattr(
             aot,
             generator_name,
-            lambda *args, _name=generator_name, **kwargs: SimpleNamespace(
-                name=_name
-            ),
+            lambda *args, _name=generator_name, **kwargs: SimpleNamespace(name=_name),
         )
 
     inventory = aot.gen_all_modules(

--- a/tests/jit/test_tgv_gemm_jit.py
+++ b/tests/jit/test_tgv_gemm_jit.py
@@ -1,0 +1,108 @@
+# Copyright (c) 2026 by FlashInfer team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from types import SimpleNamespace
+
+import torch
+
+from flashinfer.jit import env as jit_env
+from flashinfer.jit.gemm.core import gen_tgv_gemm_sm10x_module
+
+
+def test_tgv_gemm_target_specific_jit_specs_and_aot_inventory(
+    monkeypatch, tmp_path
+):
+    monkeypatch.setattr(jit_env, "FLASHINFER_GEN_SRC_DIR", tmp_path / "generated")
+
+    specs = [
+        gen_tgv_gemm_sm10x_module(torch.bfloat16, use_sm_100f=False),
+        gen_tgv_gemm_sm10x_module(torch.float16, use_sm_100f=False),
+        gen_tgv_gemm_sm10x_module(torch.bfloat16, use_sm_100f=True),
+        gen_tgv_gemm_sm10x_module(torch.float16, use_sm_100f=True),
+    ]
+    assert [spec.name for spec in specs] == [
+        "tgv_gemm_bf16_sm100a",
+        "tgv_gemm_fp16_sm100a",
+        "tgv_gemm_bf16_sm100f",
+        "tgv_gemm_fp16_sm100f",
+    ]
+    assert [spec.sources[1].parent.name for spec in specs] == [
+        "gen_tgv_gemm_bf16_sm100a",
+        "gen_tgv_gemm_fp16_sm100a",
+        "gen_tgv_gemm_bf16_sm100f",
+        "gen_tgv_gemm_fp16_sm100f",
+    ]
+    assert [
+        [flag for flag in spec.extra_cuda_cflags if flag.startswith("-gencode=")]
+        for spec in specs
+    ] == [
+        ["-gencode=arch=compute_100a,code=sm_100a"],
+        ["-gencode=arch=compute_100a,code=sm_100a"],
+        ["-gencode=arch=compute_100f,code=sm_100f"],
+        ["-gencode=arch=compute_100f,code=sm_100f"],
+    ]
+
+    from flashinfer import aot
+
+    monkeypatch.setattr(aot, "gen_attention", lambda *args: ())
+    for generator_name in [
+        "gen_spdlog_module",
+        "gen_gemm_module",
+        "gen_bgmv_moe_module",
+        "gen_hash_topk_module",
+        "gen_fp4_quantization_sm100_module",
+        "gen_cutlass_fused_moe_sm100_module",
+        "gen_gemm_sm100_module",
+        "gen_gemm_sm100_module_cutlass_fp4",
+        "gen_gemm_sm100_module_cutlass_nvfp4_svdquant",
+        "gen_gemm_sm100_module_cutlass_fp8",
+        "gen_gemm_sm100_module_cutlass_mxfp8",
+        "gen_mxfp8_quantization_sm100_module",
+        "gen_trtllm_gen_gemm_module",
+        "gen_trtllm_low_latency_gemm_module",
+        "gen_trtllm_gen_fused_moe_sm100_module",
+        "gen_moe_utils_module",
+        "gen_mm_bf16_cublaslt_module",
+        "gen_cudnn_fmha_module",
+    ]:
+        monkeypatch.setattr(
+            aot,
+            generator_name,
+            lambda *args, _name=generator_name, **kwargs: SimpleNamespace(
+                name=_name
+            ),
+        )
+
+    inventory = aot.gen_all_modules(
+        [],
+        [],
+        [],
+        [],
+        [],
+        [],
+        {"sm100": True, "sm100f": True},
+        False,
+        False,
+        False,
+        True,
+        False,
+        False,
+        False,
+    )
+    assert [spec.name for spec in inventory if spec.name.startswith("tgv_gemm_")] == [
+        "tgv_gemm_bf16_sm100a",
+        "tgv_gemm_fp16_sm100a",
+        "tgv_gemm_bf16_sm100f",
+        "tgv_gemm_fp16_sm100f",
+    ]

--- a/tests/trace/test_tgv_gemm_sm100_reference_correctness.py
+++ b/tests/trace/test_tgv_gemm_sm100_reference_correctness.py
@@ -30,10 +30,7 @@ def test_tgv_gemm_sm100_reference_correctness(shape_kwargs):
     inputs = tgv_gemm_sm100_trace.init(**shape_kwargs)
     assert inputs["b"].shape == (shape_kwargs["K"], shape_kwargs["N"])
     assert inputs["b"].stride(0) == 1, "tgv_gemm_sm100 expects column-major b"
-    try:
-        api_out = tgv_gemm_sm100(inputs["a"], inputs["b"], inputs["bias"])
-    except Exception as exc:
-        pytest.skip(f"tgv_gemm_sm100 unavailable: {exc}")
+    api_out = tgv_gemm_sm100(inputs["a"], inputs["b"], inputs["bias"])
     torch.cuda.synchronize()
     ref_out = tgv_gemm_sm100_trace.reference(inputs["a"], inputs["b"], inputs["bias"])
     # Matches tests/gemm/test_tgv_gemm.py: bf16 * K=1024 accumulation makes

--- a/tests/trace/test_tgv_gemm_sm100_reference_correctness.py
+++ b/tests/trace/test_tgv_gemm_sm100_reference_correctness.py
@@ -17,15 +17,11 @@ from tests.trace.reference_utils import (
     ],
 )
 def test_tgv_gemm_sm100_reference_correctness(shape_kwargs):
-    """tgv_gemm_sm100 kernel (SM100 only in practice) vs reference (a @ b + bias)."""
+    """TGV SM100-family kernel vs the a @ b + bias reference."""
     from flashinfer.utils import is_sm100f_supported
 
-    # The kernel's Python gate accepts SM100 or SM103 (see
-    # gemm_base._match_sm_version) but the precompiled cubin only has an
-    # SM100 kernel image; calling on SM103 crashes with "no kernel image"
-    # inside CUDA (uncatchable via try/except). Restrict to SM100.
-    if _cc() != (10, 0):
-        pytest.skip("tgv_gemm_sm100 cubin is only built for SM100")
+    if _cc() not in [(10, 0), (10, 3)]:
+        pytest.skip("tgv_gemm_sm100 requires SM100 or SM103")
     if not is_sm100f_supported(torch.device("cuda")):
         pytest.skip("tgv_gemm_sm100 requires SM100f support (CUDA 12.9+)")
     from flashinfer import tgv_gemm_sm100

--- a/tests/trace/test_tgv_gemm_sm100_reference_correctness.py
+++ b/tests/trace/test_tgv_gemm_sm100_reference_correctness.py
@@ -3,10 +3,7 @@
 import torch
 import pytest
 
-from tests.trace.reference_utils import (
-    _cc,
-    _check,
-)
+from tests.trace.reference_utils import _check
 
 
 @pytest.mark.parametrize(
@@ -18,9 +15,9 @@ from tests.trace.reference_utils import (
 )
 def test_tgv_gemm_sm100_reference_correctness(shape_kwargs):
     """TGV SM100-family kernel vs the a @ b + bias reference."""
-    from flashinfer.utils import is_sm100f_supported
+    from flashinfer.utils import get_compute_capability, is_sm100f_supported
 
-    if _cc() not in [(10, 0), (10, 3)]:
+    if get_compute_capability(torch.device("cuda")) not in [(10, 0), (10, 3)]:
         pytest.skip("tgv_gemm_sm100 requires SM100 or SM103")
     if not is_sm100f_supported(torch.device("cuda")):
         pytest.skip("tgv_gemm_sm100 requires SM100f support (CUDA 12.9+)")


### PR DESCRIPTION
## 📌 Description

This change gives the TGV BF16/FP16 SM100a and SM100f builds distinct JIT/AOT identities:

- `tgv_gemm_{bf16|fp16}_sm100a`
- `tgv_gemm_{bf16|fp16}_sm100f`

The generated-source directories carry the same target suffix. Kernel sources, arithmetic, architecture flags, public API, runner behavior, autotune keys, and tactic space are unchanged.

The collision matters on B300 because `tgv_gemm_sm100` requests the SM100f family, while multi-architecture AOT generation asks for SM100a first and deduplicates specs by name. On the baseline, the retained same-named SM100a image shadows the requested image and fails on CC 10.3 with `cudaErrorNoKernelImageForDevice`.

The focused regression test covers all four dtype/target specs, their target-specific generated paths and exact architecture flags, and the real AOT inventory after first-wins name deduplication. The existing trace correctness test now includes SM103 after the rebuilt SM100f image passed on B300.

No performance improvement is claimed. The candidate compiles the same SM100f TGV sources and is parity with the baseline JIT path under the bounded regression gate.

## 🔍 Related Issues

- Related issue: https://github.com/heiheiha798/flashinfer/issues/5
- Fork draft engineering record: https://github.com/heiheiha798/flashinfer/pull/6

## Validation

Baseline: `5366177a074e27df7db527f5b744c77dfd748484`

Candidate: `2438fa19d55c31380c7459898e0a0fe6d4b487c3`

Environment: NVIDIA B300 SXM6 AC (CC 10.3, 148 SMs), driver 580.126.09, CUDA/nvcc 13.0/13.0.88, Python 3.12.3, PyTorch 2.9.1+cu130, FlashInfer 0.6.18. GPU compilation and validation ran through Slurm.

Baseline Job 4871 reproduced the collision in two fresh JIT-disabled processes: both selected the staged SM100a artifact and terminated with CUDA error 209 (`no kernel image is available for execution on the device`). The wrapper itself ended nonzero because its original classifier expected a catchable Python status instead of the native CUDA 209 process exit; the two raw process exits are the gate evidence.

Candidate Job 4875 completed successfully:

- focused ruff, format, and Python syntax checks passed;
- the focused JIT/AOT identity inventory test passed;
- all four target artifacts had distinct names and the expected SM100a/SM100f flags;
- the JIT-disabled B300 AOT matrix passed 16/16 across BF16/FP16, bias, PDL, and caller-output variants;
- `tests/gemm/test_tgv_gemm.py` passed 90/90;
- the SM103 trace correctness test passed 2/2;
- fresh-cache BF16 and FP16 JIT cases passed with cosine similarities 0.99609375 and 0.99951171875.

The current head adds only two review-requested test corrections after Job 4875. At the current head, the focused JIT-spec regression passed in a no-device CPU process, and focused ruff, format, Python syntax, pre-commit, and `git diff --check` checks passed.

### Performance regression check

This is an availability fix, not a speedup. Job 4877 ran the unchanged 26-case BF16 TGV benchmark suite in one B300 allocation using isolated caches and paired process order. Twenty-four rows were below the repeatable 2% threshold. Two very short rows triggered a bounded diagnostic because each initially showed the same 0.0002016 ms median delta.

Job 4926 then used a single neutral exact-bucket tune, fixed tactics, ten fresh timed processes, balanced `B,C / C,B / B,C / C,B / B,C` ordering, CUDA graphs, 30 aggregate warmups, and 100 observations of 100 launches each:

| Shape | Baseline p10/p50/p90 (ms) | Candidate p10/p50/p90 (ms) | Paired ratio p10/p50/p90 | Pairs >2% | Result |
|---|---:|---:|---:|---:|---|
| M32 N7168 K2048, no bias, tactic 8 | 0.00476512 / 0.00476832 / 0.00477021 | 0.00476426 / 0.00476880 / 0.00477123 | 0.99907 / 1.00007 / 1.00105 | 0/5 | parity |
| M1 N2880 K1024, bias, tactic 0 | 0.00323430 / 0.00323472 / 0.00323914 | 0.00323478 / 0.00323808 / 0.00324096 | 0.99947 / 0.99995 / 1.00190 | 0/5 | parity |

CUPTI was unavailable, and the benchmark helper could not provide closure-driven cold-L2 timing because the closure exposed no tensor arguments. The diagnostic is therefore warm-L2 CUDA-event evidence and is used only to resolve the two short-kernel signals, not as an absolute-latency replacement for the unchanged suite.

## 🚀 Pull Request Checklist

### ✅ Pre-commit Checks

- [ ] I have installed `pre-commit` and its hooks in the source environment.
- [x] Full `uvx pre-commit run --all-files --show-diff-on-failure` passed at current head `b853d1e6` against current upstream `main` via a detached synthetic merge preflight.
- [x] Focused pre-commit passed for all three changed Python files (file hygiene, mypy, ruff check, and ruff format).
- [x] `git diff --check` passed against the current upstream base.

### 🧪 Tests

- [x] Tests were added or updated for module identity, AOT inventory, and SM103 trace correctness.
- [x] Focused tests and the B300 AOT/JIT correctness matrix passed as described above.
- [ ] The whole repository test suite was not run.

## Reviewer Notes

- Renaming deliberately invalidates old name-addressed TGV caches; affected users may see a one-time JIT rebuild.
- Multi-architecture AOT packages retain two additional SM100f TGV modules that were previously dropped, modestly increasing build time and package size.
- Physical GPU validation used one 148-SM B300/x86_64 node. SM100a generation and flags were covered statically and by artifact build, but no physical B200 runtime was available.
- The current head's final two commits only adjust tests; the runtime implementation is the one validated in Job 4875.
- CUPTI, closure-driven cold-L2 timing for the unchanged suite, and the whole-repository test suite remain unavailable or unrun as disclosed above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved SM100 TGV GEMM build isolation so `sm100a` and `sm100f` variants no longer share generated outputs.

- **Tests**
  - Added coverage for target-specific module names, source directories, compiler flags, and ahead-of-time module inventories.
  - Expanded reference correctness testing to support SM100 and SM103 architectures.
  - Kernel errors now surface directly during correctness tests instead of being silently skipped.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
