### PR TITLE
perf(moe): tune SM103 NVFP4 8K fallback

### DIFF
--- a/csrc/trtllm_fused_moe_kernel_launcher.cu
+++ b/csrc/trtllm_fused_moe_kernel_launcher.cu
@@ -4040,9 +4040,10 @@ Array<Tensor> trtllm_fp4_block_scale_moe(
       static_cast<RoutingInputMode>(routing_input_mode) == RoutingInputMode::PackedPrecomputed &&
       mDtypeAct == btg::Dtype::E2m1 && mDtypeWeights == btg::Dtype::E2m1 &&
       num_tokens == 8192 && num_experts == 384 && top_k == 8 && hidden_size == 7168 &&
-      intermediate_size == 512 && local_expert_offset == 0 && local_num_experts == 384 &&
-      nFusedShared == 0 && !routing_bias.has_value() && !gemm1_bias.has_value() &&
-      !gemm1_lora_delta.has_value() && !gemm1_alpha.has_value() && !gemm1_beta.has_value() &&
+      output.size(1) == hidden_size && intermediate_size == 512 && local_expert_offset == 0 &&
+      local_num_experts == 384 && nFusedShared == 0 && !routing_bias.has_value() &&
+      !gemm1_bias.has_value() && !gemm1_lora_delta.has_value() && !gemm1_alpha.has_value() &&
+      !gemm1_beta.has_value() &&
       !gemm1_clamp_limit.has_value() && !gemm2_bias.has_value() &&
       output1_scales_scalar.has_value() && output1_scales_gate_scalar.has_value() &&
       output2_scales_scalar.has_value() && !per_token_scales.has_value() &&

--- a/csrc/trtllm_fused_moe_kernel_launcher.cu
+++ b/csrc/trtllm_fused_moe_kernel_launcher.cu
@@ -4027,8 +4027,44 @@ Array<Tensor> trtllm_fp4_block_scale_moe(
     launchers_map[curr_tile_N] = std::move(launcher);
   }
 
-  auto const [tile_N, config] = resolveMoeTileAndConfig(config_index, mSupportedTileN, num_tokens,
-                                                        totalExpertsPerToken, totalLocalExperts);
+  auto resolved_tactic = resolveMoeTileAndConfig(config_index, mSupportedTileN, num_tokens,
+                                                 totalExpertsPerToken, totalLocalExperts);
+
+  // On SM103, the exact no-bias routed NVFP4 workload from #4190 is consistently faster with
+  // [tile_N=256, config=1] than with the generic fallback's tile_N=128 choice. Keep the
+  // override as narrow as the measured workload: all explicit tactics and every other
+  // architecture, shape, dtype, epilogue, routing mode, and PDL setting retain the generic
+  // fallback policy.
+  bool const matches_sm103_nvfp4_8k_fallback =
+      config_index[0] == -1 && config_index[1] == -1 &&
+      static_cast<RoutingInputMode>(routing_input_mode) == RoutingInputMode::PackedPrecomputed &&
+      mDtypeAct == btg::Dtype::E2m1 && mDtypeWeights == btg::Dtype::E2m1 &&
+      num_tokens == 8192 && num_experts == 384 && top_k == 8 && hidden_size == 7168 &&
+      intermediate_size == 512 && local_expert_offset == 0 && local_num_experts == 384 &&
+      nFusedShared == 0 && !routing_bias.has_value() && !gemm1_bias.has_value() &&
+      !gemm1_lora_delta.has_value() && !gemm1_alpha.has_value() && !gemm1_beta.has_value() &&
+      !gemm1_clamp_limit.has_value() && !gemm2_bias.has_value() &&
+      output1_scales_scalar.has_value() && output1_scales_gate_scalar.has_value() &&
+      output2_scales_scalar.has_value() && !per_token_scales.has_value() &&
+      routing_method_type == static_cast<int64_t>(RoutingMethodType::Renormalize) &&
+      n_group.value_or(0) == 0 && topk_group.value_or(0) == 0 &&
+      !routed_scaling_factor.has_value() && do_finalize && enable_pdl &&
+      act_type == static_cast<int64_t>(ActivationType::Swiglu) &&
+      !routing_replay_out.has_value() && da_routing_metadata.empty() && da_body_workspace.empty() &&
+      !is_da_body_preparation;
+  if (matches_sm103_nvfp4_8k_fallback) {
+    int device_major = 0;
+    int device_minor = 0;
+    CHECK_CUDA_ERROR(cudaDeviceGetAttribute(&device_major, cudaDevAttrComputeCapabilityMajor,
+                                            hidden_states.device().device_id));
+    CHECK_CUDA_ERROR(cudaDeviceGetAttribute(&device_minor, cudaDevAttrComputeCapabilityMinor,
+                                            hidden_states.device().device_id));
+    if (device_major == 10 && device_minor == 3) {
+      resolved_tactic = {256, 1};
+    }
+  }
+
+  auto const [tile_N, config] = resolved_tactic;
 
   // Get the launcher for the selected tile_N
   auto launcher_it = launchers_map.find(static_cast<int32_t>(tile_N));

--- a/csrc/trtllm_fused_moe_kernel_launcher.cu
+++ b/csrc/trtllm_fused_moe_kernel_launcher.cu
@@ -4038,21 +4038,19 @@ Array<Tensor> trtllm_fp4_block_scale_moe(
   bool const matches_sm103_nvfp4_8k_fallback =
       config_index[0] == -1 && config_index[1] == -1 &&
       static_cast<RoutingInputMode>(routing_input_mode) == RoutingInputMode::PackedPrecomputed &&
-      mDtypeAct == btg::Dtype::E2m1 && mDtypeWeights == btg::Dtype::E2m1 &&
-      num_tokens == 8192 && num_experts == 384 && top_k == 8 && hidden_size == 7168 &&
-      output.size(1) == hidden_size && intermediate_size == 512 && local_expert_offset == 0 &&
-      local_num_experts == 384 && nFusedShared == 0 && !routing_bias.has_value() &&
-      !gemm1_bias.has_value() && !gemm1_lora_delta.has_value() && !gemm1_alpha.has_value() &&
-      !gemm1_beta.has_value() &&
+      mDtypeAct == btg::Dtype::E2m1 && mDtypeWeights == btg::Dtype::E2m1 && num_tokens == 8192 &&
+      num_experts == 384 && top_k == 8 && hidden_size == 7168 && output.size(1) == hidden_size &&
+      intermediate_size == 512 && local_expert_offset == 0 && local_num_experts == 384 &&
+      nFusedShared == 0 && !routing_bias.has_value() && !gemm1_bias.has_value() &&
+      !gemm1_lora_delta.has_value() && !gemm1_alpha.has_value() && !gemm1_beta.has_value() &&
       !gemm1_clamp_limit.has_value() && !gemm2_bias.has_value() &&
       output1_scales_scalar.has_value() && output1_scales_gate_scalar.has_value() &&
       output2_scales_scalar.has_value() && !per_token_scales.has_value() &&
       routing_method_type == static_cast<int64_t>(RoutingMethodType::Renormalize) &&
       n_group.value_or(0) == 0 && topk_group.value_or(0) == 0 &&
       !routed_scaling_factor.has_value() && do_finalize && enable_pdl &&
-      act_type == static_cast<int64_t>(ActivationType::Swiglu) &&
-      !routing_replay_out.has_value() && da_routing_metadata.empty() && da_body_workspace.empty() &&
-      !is_da_body_preparation;
+      act_type == static_cast<int64_t>(ActivationType::Swiglu) && !routing_replay_out.has_value() &&
+      da_routing_metadata.empty() && da_body_workspace.empty() && !is_da_body_preparation;
   if (matches_sm103_nvfp4_8k_fallback) {
     int device_major = 0;
     int device_minor = 0;

--- a/tests/moe/test_trtllm_gen_moe_autotune_tactics.py
+++ b/tests/moe/test_trtllm_gen_moe_autotune_tactics.py
@@ -492,8 +492,8 @@ def test_nvfp4_per_tensor_small_shape_all_tactics_are_correct():
     )
 
 
-def test_nvfp4_sm103_8k_fallback_matches_measured_tactic():
-    """The guarded SM103 8K fallback must execute the measured [256, 1] tactic."""
+def test_nvfp4_sm103_8k_fallback_matches_reference_tactics():
+    """The guarded SM103 fallback matches the original and measured tactics."""
     if get_compute_capability(torch.device(device="cuda")) != (10, 3):
         pytest.skip("Requires exact SM103.")
 
@@ -564,14 +564,24 @@ def test_nvfp4_sm103_8k_fallback_matches_measured_tactic():
     )
     assert [256, 1] in [list(tactic) for tactic in valid_tactics]
 
-    AutoTuner.get()._logged_file_hits.discard(_TEST_LOG_KEY_FP4)
     fallback = _run(None)
-    measured_tactic = _run([256, 1])
 
+    AutoTuner.get()._logged_file_hits.discard(_TEST_LOG_KEY_FP4)
+    original_fallback = _run([128, -1])
+    assert _TEST_LOG_KEY_FP4 in AutoTuner.get()._logged_file_hits, (
+        "the original [128, -1] fallback was not dispatched through the autotuner cache"
+    )
+
+    AutoTuner.get()._logged_file_hits.discard(_TEST_LOG_KEY_FP4)
+    measured_tactic = _run([256, 1])
     assert _TEST_LOG_KEY_FP4 in AutoTuner.get()._logged_file_hits, (
         "the explicit [256, 1] tactic was not dispatched through the autotuner cache"
     )
+
     assert torch.isfinite(fallback).all()
+    assert torch.isfinite(original_fallback).all()
+    assert torch.isfinite(measured_tactic).all()
+    assert torch.equal(fallback, original_fallback)
     assert torch.equal(fallback, measured_tactic)
 
 

--- a/tests/moe/test_trtllm_gen_moe_autotune_tactics.py
+++ b/tests/moe/test_trtllm_gen_moe_autotune_tactics.py
@@ -492,6 +492,89 @@ def test_nvfp4_per_tensor_small_shape_all_tactics_are_correct():
     )
 
 
+def test_nvfp4_sm103_8k_fallback_matches_measured_tactic():
+    """The guarded SM103 8K fallback must execute the measured [256, 1] tactic."""
+    if get_compute_capability(torch.device(device="cuda")) != (10, 3):
+        pytest.skip("Requires exact SM103.")
+
+    torch.manual_seed(0)
+    device = torch.device("cuda:0")
+    num_tokens = 8192
+    hidden_size = 7168
+    intermediate_size = 512
+    num_experts = 384
+    top_k = 8
+    inputs = _build_fp4_routed_moe_inputs(
+        num_tokens=num_tokens,
+        hidden_size=hidden_size,
+        intermediate_size=intermediate_size,
+        top_k=top_k,
+        num_experts=num_experts,
+        quant_mode="NvFP4xNvFP4",
+        routing_method_type=RoutingMethodType.Renormalize,
+        device=device,
+    )
+    profile_shapes = _moe_profile_shapes(inputs, num_tokens, num_tokens)
+
+    def _run(tactic: list[int] | None) -> torch.Tensor:
+        _force_tactic_in_autotuner_cache(profile_shapes, tactic, custom_op=_TEST_OP_FP4)
+        output = trtllm_fp4_block_scale_routed_moe(
+            topk_ids=inputs["packed_topk"],
+            routing_bias=None,
+            hidden_states=inputs["hidden_states"],
+            hidden_states_scale=inputs["hidden_states_scale"],
+            gemm1_weights=inputs["w13"],
+            gemm1_weights_scale=inputs["w13_scale"],
+            gemm1_bias=None,
+            gemm1_alpha=None,
+            gemm1_beta=None,
+            gemm1_clamp_limit=None,
+            gemm2_weights=inputs["w2"],
+            gemm2_weights_scale=inputs["w2_scale"],
+            gemm2_bias=None,
+            output1_scale_scalar=inputs["output1_scale_scalar"],
+            output1_scale_gate_scalar=inputs["output1_scale_gate_scalar"],
+            output2_scale_scalar=inputs["output2_scale_scalar"],
+            num_experts=num_experts,
+            top_k=top_k,
+            n_group=None,
+            topk_group=None,
+            intermediate_size=intermediate_size,
+            local_expert_offset=0,
+            local_num_experts=num_experts,
+            routed_scaling_factor=None,
+            routing_method_type=RoutingMethodType.Renormalize.value,
+            do_finalize=True,
+            enable_pdl=True,
+            activation_type=ActivationType.Swiglu.value,
+            tune_max_num_tokens=num_tokens,
+        )[0]
+        torch.cuda.synchronize()
+        return output.clone()
+
+    moe_op = gen_trtllm_gen_fused_moe_sm100_module().build_and_load()
+    valid_tactics = _enumerate_valid_tactics(
+        moe_op,
+        "NvFP4xNvFP4",
+        top_k,
+        hidden_size,
+        intermediate_size,
+        num_experts,
+        num_tokens,
+    )
+    assert [256, 1] in [list(tactic) for tactic in valid_tactics]
+
+    AutoTuner.get()._logged_file_hits.discard(_TEST_LOG_KEY_FP4)
+    fallback = _run(None)
+    measured_tactic = _run([256, 1])
+
+    assert _TEST_LOG_KEY_FP4 in AutoTuner.get()._logged_file_hits, (
+        "the explicit [256, 1] tactic was not dispatched through the autotuner cache"
+    )
+    assert torch.isfinite(fallback).all()
+    assert torch.equal(fallback, measured_tactic)
+
+
 @pytest.mark.parametrize("quant_mode", ["NvFP4xNvFP4", "MxFP4xMxFP8", "MxFP4xBf16"])
 @pytest.mark.parametrize("num_tokens", [16, 23, 128])
 @pytest.mark.parametrize("hidden_size", [4096, 7168])


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

This PR narrows the native fallback for one measured TensorRT-LLM fused-MoE workload. On an exact SM103 device, an untuned packed-precomputed routed NVFP4 x NVFP4 call with the measured 8K-token shape selects tactic `[256, 1]` instead of the generic tile-N 128 fallback.

The override requires the complete measured workload:

- T=8192, E=384, top-k=8, H=7168, and I=512
- full-width finalized output, Renormalize routing, PDL enabled, and Swiglu
- no routing/GEMM bias, LoRA delta, activation modifier, explicit per-token scale, fused shared expert, or distribution-aware workspace
- an input tactic of exactly `[-1, -1]`

Explicit tactics and every other architecture, shape, dtype, epilogue, routing mode, PDL setting, and the 16K path retain the generic fallback policy. Reserved-SM allocation and policy are unchanged.

The regression test compares the candidate default with both the original generic fallback bypass `[128, -1]` and explicit tactic `[256, 1]` on SM103.

### Performance results

The benchmark used a 148-SM NVIDIA B300 (CC 10.3), seed 0, 30 warmups, 100 CUDA-graph samples, cold L2, and CUDA events because CUPTI was unavailable. The problem was routed NVFP4 x NVFP4 with E=384, top-k=8, H=7168, I=512, no GEMM biases, and PDL enabled at 8K and disabled at 16K.

Clean baseline job `4766` reproduced the fallback gap at commit `ad8bb37b26281de4d3dd52447edc952924e6562a`:

| T | Repetition | Generic fallback (ms) | Autotuned `[256, 1]` (ms) | Gap |
|---:|---:|---:|---:|---:|
| 8192 | 1 | 1.496944 | 1.308213 | 14.4266% |
| 8192 | 2 | 1.498168 | 1.308885 | 14.4614% |
| 8192 | 3 | 1.498576 | 1.309042 | 14.4789% |
| 16384 | 1 | 2.458262 | 2.440554 | 0.7256% |
| 16384 | 2 | 2.458179 | 2.440654 | 0.7180% |
| 16384 | 3 | 2.458779 | 2.440250 | 0.7593% |

Clean-head job `4794` gated on exact commit `a08373754955052468a9113ca00e31f47c15dbd7`, used a clean tracked worktree and a fresh isolated build workspace, and completed with `ExitCode=0:0`:

| T | Repetition | Candidate default (ms) | Autotuned (ms) | Autotuned winner | Gap |
|---:|---:|---:|---:|:---:|---:|
| 8192 | 1 | 0.901480 | 0.900074 | `[256, 1]` | 0.1563% |
| 8192 | 2 | 0.901861 | 0.901702 | `[256, 0]` | 0.0176% |
| 8192 | 3 | 0.901917 | 0.901907 | `[256, 0]` | 0.0011% |
| 16384 | 1 | 1.741275 | 1.684141 | `[256, 1]` | 3.3925% |
| 16384 | 2 | 1.741376 | 1.684026 | `[256, 1]` | 3.4056% |
| 16384 | 3 | 1.741382 | 1.683832 | `[256, 1]` | 3.4178% |

The candidate 8K default remained within 0.157% of the independently autotuned winner in all three repetitions. This does not claim `[256, 1]` is the unique winner. The 16K path is not overridden and stayed below the predeclared 5% change gate. A separate reserved-SM=0 diagnostic was also at parity at 8K: 0.901379 ms candidate default versus 0.899840 ms for `[256, 1]` (0.1711%).

The fresh workspace built a different effective cold artifact set from the baseline workspace, so the absolute baseline and candidate latencies are not presented as a controlled before/after subtraction. Job `4766` establishes the fallback gap; job `4794` establishes that this exact committed candidate builds and reaches current autotuning parity. The full commands, raw-result interpretation, and embedded exact rerun driver are preserved in the [fork draft PR](https://github.com/heiheiha798/flashinfer/pull/2).

### Correctness

In both reserved-SM processes, job `4794` used nonzero NVFP4 scales and compared:

- candidate default `[-1, -1]`
- original generic fallback bypass `[128, -1]`
- explicit measured tactic `[256, 1]`

All outputs were finite. The candidate was bitwise equal to both reference paths, with maximum absolute output 358400.0.

## 🔍 Related Issues

- Upstream report: https://github.com/flashinfer-ai/flashinfer/issues/4190
- Fork tracking issue: https://github.com/heiheiha798/flashinfer/issues/1
- Fork engineering record and exact reproducer: https://github.com/heiheiha798/flashinfer/pull/2

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [ ] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

- [x] `git diff --check`
- [x] Python syntax check for the targeted test and exact driver
- [x] Shell syntax check for the Slurm driver

`uvx --from pre-commit pre-commit run --all-files` passed at repaired head `d094c6cb10280e5865a8d100c1f79cce6cd90a0e`; this includes clang-format, mypy, Ruff check, Ruff format, and the repository hygiene hooks.

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).
- [ ] Standard pytest invocation. The existing environment did not contain `pytest`; no dependency was installed.
- [x] Clean-head/fresh-cache build and standalone three-way correctness oracle in Slurm job `4794`.
- [x] Baseline reproduction in job `4766` and clean-head candidate measurements in job `4794`.

## Reviewer Notes

Adjacent token boundaries were not run. The final code uses an exact `num_tokens == 8192` predicate, so adjacent counts statically retain the generic fallback; runtime coverage is not claimed. The three repetitions reuse one deterministic routing realization. Validation used a 148-SM B300/x86_64 system, while the historical report used a 152-SM GB300/aarch64 stack. CUDA-graph measurements do not include the eager host cost of the two device-attribute queries. No other architecture/dtype matrix or fork/upstream CI was run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance**
  - Improved FP4 Mixture-of-Experts execution for a specific SM103 NVFP4 workload by selecting a more effective tactic for large, packed-routing workloads.

- **Bug Fixes**
  - Ensured optimized and fallback tactics produce consistent, finite results.

- **Tests**
  - Added coverage for SM103 NVFP4 workloads, validating tactic selection, fallback behavior, output stability, and numerical validity across supported execution paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
