### PR TITLE
ci: disable sccache for cu134 nvcc

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,7 @@ on:
       - 'ci/cuda-versions.json'
       - 'ci/validate_cuda_versions.py'
       - 'scripts/build_flashinfer_jit_cache_whl.sh'
+      - 'scripts/jit_cache_build_common.sh'
 
 jobs:
   setup:

--- a/scripts/jit_cache_build_common.sh
+++ b/scripts/jit_cache_build_common.sh
@@ -129,8 +129,20 @@ setup_sccache() {
   export SCCACHE_BASEDIRS="${source_root}${SCCACHE_BASEDIRS:+:${SCCACHE_BASEDIRS}}"
   export SCCACHE_S3_KEY_PREFIX="${key_prefix}"
   export SCCACHE_IDLE_TIMEOUT=0
-  export FLASHINFER_NVCC_LAUNCHER="sccache"
   export FLASHINFER_CXX_LAUNCHER="sccache"
+
+  # sccache v0.17 cannot parse CUDA 13.3+ nvcc dry-run output, which can leave
+  # fatbinary without its input cubins. Keep host C++ caching enabled, but run
+  # cu134 nvcc directly until a release includes the upstream fix:
+  # https://github.com/mozilla/sccache/pull/2722
+  case "${CUDA_VERSION:-}" in
+    13.4|134)
+      unset FLASHINFER_NVCC_LAUNCHER
+      ;;
+    *)
+      export FLASHINFER_NVCC_LAUNCHER="sccache"
+      ;;
+  esac
 
   # Avoid leaking AWS credentials under set -x.
   local _sccache_xtrace=0
@@ -155,6 +167,8 @@ setup_sccache() {
   echo "sccache region: ${SCCACHE_REGION}"
   echo "sccache prefix: ${SCCACHE_S3_KEY_PREFIX}"
   echo "sccache basedirs: ${SCCACHE_BASEDIRS}"
+  echo "sccache cxx launcher: ${FLASHINFER_CXX_LAUNCHER}"
+  echo "sccache nvcc launcher: ${FLASHINFER_NVCC_LAUNCHER:-disabled}"
 
   if [ -n "${SCCACHE_STATS_DIR:-}" ]; then
     mkdir -p "${SCCACHE_STATS_DIR}"


### PR DESCRIPTION
## 📌 Description

CUDA 13.4 changes `nvcc --dryrun` output in a way that sccache v0.17.0 parses incorrectly. The missing compile steps later surface as `fatbinary` failures because the expected cubins were never produced.

- Bypass sccache for cu134 NVCC invocations while keeping host C++ compilation cached.
- Accept both CUDA version forms used by the release/nightly (`13.4`) and PR (`134`) build paths.
- Trigger the Release dry-run matrix when the shared JIT-cache helper changes, so both cu134 architecture jobs exercise this workaround before merge.
- Remove the guard once the pinned sccache release includes the upstream CUDA 13.3+ fix.

## 🔍 Related Issues

- Upstream fix: [mozilla/sccache#2722](https://github.com/mozilla/sccache/pull/2722)
- Failing nightly: [run 32544126473](https://github.com/flashinfer-ai/flashinfer/actions/runs/32544126473)

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

Focused validation passed:

- `bash -n scripts/jit_cache_build_common.sh`
- `shellcheck scripts/jit_cache_build_common.sh`
- Mocked launcher checks for CUDA `13.4`, `134`, and `13.0`
- Release workflow YAML parse
- `pre-commit run --all-files`
- `git diff --check`

## Reviewer Notes

This intentionally disables only the affected NVCC launcher for cu134. The sccache server and host C++ launcher remain enabled so safe cache hits are preserved. The Release workflow should provide the end-to-end cu134 x86_64 and aarch64 validation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CUDA 13.4 build compatibility by avoiding an incompatible compiler-cache path.
  * Preserved compiler caching for other supported CUDA versions.

* **Chores**
  * Updated release automation to recognize changes affecting shared build tooling.
  * Added clearer build logs showing which compiler-cache launchers are enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->