### PR TITLE
fix(sm120): bucket extra_topk in the sparse-MLA DSv4 decode autotuner

### DIFF
--- a/flashinfer/mla/_sparse_mla_sm120.py
+++ b/flashinfer/mla/_sparse_mla_sm120.py
@@ -59,6 +59,7 @@ from ..autotuner import (
 )
 from ..jit.mla import gen_sparse_mla_sm120_module
 from ..utils import (
+    last_positive_power_of_2,
     register_custom_op,
     register_fake_op,
     supported_compute_capability,
@@ -839,11 +840,12 @@ def _get_sparse_mla_decode_dsv4_module():
             attn_sink = inputs[7] if len(inputs) > 7 else None
             extra_indices = inputs[8] if len(inputs) > 8 else None
             extra_topk_length = inputs[9] if len(inputs) > 9 else None
-            extra_topk = extra_indices.shape[-1] if extra_indices is not None else 0
+            # extra_topk is bucketed by the tuning config; pinning its exact
+            # value here would turn every untuned width into a cache miss.
             return (
                 topk_length is not None,
                 attn_sink is not None,
-                int(extra_topk),
+                extra_indices is not None,
                 extra_topk_length is not None,
             )
 
@@ -856,7 +858,7 @@ def _get_sparse_mla_decode_dsv4_module():
             topk = indices.shape[-1]
             extra_indices = inputs[8] if len(inputs) > 8 else None
             extra_topk = extra_indices.shape[-1] if extra_indices is not None else 0
-            num_splits = (topk + _BI - 1) // _BI + (extra_topk + _BI - 1) // _BI
+            num_splits = _decode_dsv4_num_splits(topk, extra_topk)
             # tactic encodes chunks_per_block (1..num_splits).
             return list(range(1, num_splits + 1))
 
@@ -885,7 +887,7 @@ def _get_sparse_mla_decode_dsv4_module():
                 extra_topk_length = kwargs.get("extra_topk_length")
             topk = indices.shape[-1]  # 2D [T, topk] or 3D [T, 1, topk]
             extra_topk = extra_indices.shape[-1] if extra_indices is not None else 0
-            num_splits = (topk + _BI - 1) // _BI + (extra_topk + _BI - 1) // _BI
+            num_splits = _decode_dsv4_num_splits(topk, extra_topk)
             cpb_override = tactic if tactic > 0 else -1
             module.sparse_mla_sm120_decode_dsv4(
                 q,
@@ -921,6 +923,33 @@ def _decode_dsv4_map_to_token_bucket(x):
         if x <= b:
             return b
     return buckets[-1]
+
+
+def _decode_dsv4_num_splits(topk: int, extra_topk: int = 0) -> int:
+    """Split-K partitions: one per ``_BI``-wide tile of each index set."""
+    return (topk + _BI - 1) // _BI + (extra_topk + _BI - 1) // _BI
+
+
+def _decode_dsv4_map_to_extra_topk_bucket(x: int) -> int:
+    """Round extra_topk down to a power of 2, at least one ``_BI`` tile.
+
+    Rounding down keeps every tuned tactic valid: chunks_per_block must not
+    exceed num_splits, which only grows with extra_topk, and the C++ launcher
+    silently falls back to its heuristic on an out-of-range override.
+    """
+    return max(_BI, last_positive_power_of_2(x))
+
+
+def _decode_dsv4_extra_topk_buckets(x: int) -> tuple[int, ...]:
+    """Power-of-2 extra_topk buckets from one tile up to x's bucket, so one
+    tuning pass at the largest served width also covers the smaller ones."""
+    top = _decode_dsv4_map_to_extra_topk_bucket(x)
+    buckets = []
+    b = _BI
+    while b <= top:
+        buckets.append(b)
+        b *= 2
+    return tuple(buckets)
 
 
 def _decode_dsv4_init_q(shapes, dtype, device):
@@ -963,16 +992,51 @@ def _decode_dsv4_inputs_pre_hook(inputs):
 
 
 @functools.cache
-def _decode_dsv4_tuning_config() -> TuningConfig:
-    return TuningConfig(
-        dynamic_tensor_specs=(
-            DynamicTensorSpec(
-                input_idx=(0, 1, 6, 8, 9),
-                dim_idx=(0, 0, 0, 0, 0),
-                gen_tuning_buckets=_decode_dsv4_num_token_buckets,
-                map_to_tuning_buckets=_decode_dsv4_map_to_token_bucket,
-            ),
+def _decode_dsv4_tuning_config(has_extra: bool) -> TuningConfig:
+    """Decode-dsv4 tuning config; ``has_extra`` is ``extra_indices is not None``.
+
+    With a secondary cache, extra_topk (last dim of extra_indices) is a second
+    tuned axis and the split count of mid_out/mid_lse follows it. A ``None``
+    extra_indices has no such dim, hence the flag.
+    """
+    dynamic_tensor_specs: tuple[DynamicTensorSpec, ...] = (
+        DynamicTensorSpec(
+            input_idx=(0, 1, 6, 8, 9),
+            dim_idx=(0, 0, 0, 0, 0),
+            gen_tuning_buckets=_decode_dsv4_num_token_buckets,
+            map_to_tuning_buckets=_decode_dsv4_map_to_token_bucket,
         ),
+    )
+    # Constrain T (dim 0) of all output/scratch tensors to q's T so the
+    # autotuner's synthesised q propagates to mid_out (2), mid_lse (3),
+    # output (4), out_lse (5). Without these constraints, the kernel
+    # writes past the real tensors' T dim → IMA.
+    constraint_specs: tuple[ConstraintSpec, ...] = (
+        ConstraintSpec(2, 0, lambda shapes: shapes[0][0]),  # mid_out
+        ConstraintSpec(3, 0, lambda shapes: shapes[0][0]),  # mid_lse
+        ConstraintSpec(4, 0, lambda shapes: shapes[0][0]),  # output
+        ConstraintSpec(5, 0, lambda shapes: shapes[0][0]),  # out_lse
+    )
+    if has_extra:
+        dynamic_tensor_specs += (
+            DynamicTensorSpec(
+                input_idx=(8,),
+                dim_idx=(-1,),
+                gen_tuning_buckets=_decode_dsv4_extra_topk_buckets,
+                map_to_tuning_buckets=_decode_dsv4_map_to_extra_topk_bucket,
+            ),
+        )
+
+        # num_splits (dim 2) of the scratch follows the bucketed extra_topk.
+        def _num_splits(shapes):
+            return _decode_dsv4_num_splits(shapes[1][-1], shapes[8][-1])
+
+        constraint_specs += (
+            ConstraintSpec(2, 2, _num_splits),  # mid_out
+            ConstraintSpec(3, 2, _num_splits),  # mid_lse
+        )
+    return TuningConfig(
+        dynamic_tensor_specs=dynamic_tensor_specs,
         tensor_initializers=(
             (0, _decode_dsv4_init_q),
             (1, _decode_dsv4_init_indices),
@@ -981,16 +1045,7 @@ def _decode_dsv4_tuning_config() -> TuningConfig:
             (9, _decode_dsv4_init_topk_length),
         ),
         inputs_pre_hook=_decode_dsv4_inputs_pre_hook,
-        # Constrain T (dim 0) of all output/scratch tensors to q's T so the
-        # autotuner's synthesised q propagates to mid_out (2), mid_lse (3),
-        # output (4), out_lse (5). Without these constraints, the kernel
-        # writes past the real tensors' T dim → IMA.
-        constraint_specs=(
-            ConstraintSpec(2, 0, lambda shapes: shapes[0][0]),  # mid_out
-            ConstraintSpec(3, 0, lambda shapes: shapes[0][0]),  # mid_lse
-            ConstraintSpec(4, 0, lambda shapes: shapes[0][0]),  # output
-            ConstraintSpec(5, 0, lambda shapes: shapes[0][0]),  # out_lse
-        ),
+        constraint_specs=constraint_specs,
     )
 
 
@@ -1240,7 +1295,10 @@ def sparse_mla_sm120_decode_dsv4(
     - ``chunks_per_block`` explicitly given → use that value directly (no
       autotuning).
     - Otherwise, if a ``with autotune(...)`` context is active or a previous
-      tuning run cached this shape → use the AutoTuner's choice.
+      tuning run cached this shape → use the AutoTuner's choice. Tuning
+      sweeps the num_tokens buckets and, with a secondary cache, power-of-2
+      ``extra_topk`` buckets up to the tuned width; lookups round
+      ``extra_topk`` down, so tune with the largest width you serve.
     - Otherwise → fall back to the C++ closed-form heuristic.
 
     Parameters
@@ -1311,9 +1369,7 @@ def sparse_mla_sm120_decode_dsv4(
     if not tuner.is_tuning_mode:
         T_bucket = _decode_dsv4_map_to_token_bucket(q.shape[0])
         extra_topk = extra_indices.shape[-1] if extra_indices is not None else 0
-        num_splits = (indices.shape[-1] + _BI - 1) // _BI + (
-            extra_topk + _BI - 1
-        ) // _BI
+        num_splits = _decode_dsv4_num_splits(indices.shape[-1], extra_topk)
         hot_key = (
             T_bucket,
             q.shape[1],
@@ -1336,7 +1392,7 @@ def sparse_mla_sm120_decode_dsv4(
     chosen, tactic = tuner.choose_one(
         "sparse_mla_sm120_decode_dsv4",
         [runner],
-        _decode_dsv4_tuning_config(),
+        _decode_dsv4_tuning_config(extra_indices is not None),
         inputs,
         **forward_kwargs,
     )
@@ -1345,9 +1401,7 @@ def sparse_mla_sm120_decode_dsv4(
     if int(tactic) > 0:
         T_bucket = _decode_dsv4_map_to_token_bucket(q.shape[0])
         extra_topk = extra_indices.shape[-1] if extra_indices is not None else 0
-        num_splits = (indices.shape[-1] + _BI - 1) // _BI + (
-            extra_topk + _BI - 1
-        ) // _BI
+        num_splits = _decode_dsv4_num_splits(indices.shape[-1], extra_topk)
         hot_key = (
             T_bucket,
             q.shape[1],

--- a/flashinfer/mla/_sparse_mla_sm120.py
+++ b/flashinfer/mla/_sparse_mla_sm120.py
@@ -1027,8 +1027,8 @@ def _decode_dsv4_tuning_config(has_extra: bool) -> TuningConfig:
             ),
         )
 
-        # num_splits (dim 2) of the scratch follows the bucketed extra_topk.
         def _num_splits(shapes):
+            """Scratch split count (dim 2) for the profile's bucketed widths."""
             return _decode_dsv4_num_splits(shapes[1][-1], shapes[8][-1])
 
         constraint_specs += (

--- a/tests/attention/test_sparse_mla_sm120.py
+++ b/tests/attention/test_sparse_mla_sm120.py
@@ -621,13 +621,17 @@ def test_sparse_mla_sm120_decode_dsv4_dual_large_extra_topk() -> None:
     torch.testing.assert_close(output.squeeze(1), ref_out, atol=5e-2, rtol=5e-2)
 
 
-def test_sparse_mla_sm120_decode_dsv4_autotune_covers_extra_topk_buckets() -> None:
+def test_sparse_mla_sm120_decode_dsv4_autotune_covers_extra_topk_buckets(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
     """One tuning pass covers every power-of-2 extra_topk bucket at or below
     the tuned width; wider widths stay on the heuristic until re-tuned."""
     from flashinfer import autotune
     from flashinfer.autotuner import AutoTuner
     from flashinfer.mla._sparse_mla_sm120 import _decode_dsv4_hot_cache
 
+    # Keep a previously saved default disk cache from resolving tactics here.
+    monkeypatch.setenv("FLASHINFER_AUTOTUNE_DIR", str(tmp_path))
     torch.manual_seed(0)
     device = torch.device("cuda")
     num_tokens, num_heads, topk = 4, 16, 128
@@ -636,6 +640,7 @@ def test_sparse_mla_sm120_decode_dsv4_autotune_covers_extra_topk_buckets() -> No
     s_kv = num_blocks * pbs
 
     def make_cache() -> tuple[torch.Tensor, torch.Tensor]:
+        """Random packed DSv4 cache and its dequantized reference."""
         bf16 = (
             torch.randn(num_blocks, pbs, 1, d_qk, device=device, dtype=torch.bfloat16)
             / 10.0
@@ -658,6 +663,7 @@ def test_sparse_mla_sm120_decode_dsv4_autotune_covers_extra_topk_buckets() -> No
     sm_scale = d_qk**-0.5
 
     def run(extra_topk: int) -> None:
+        """Decode with a secondary cache of this width and check the output."""
         extra_idx = torch.randint(
             0, s_kv, (num_tokens, extra_topk), device=device, dtype=torch.int32
         )
@@ -693,7 +699,7 @@ def test_sparse_mla_sm120_decode_dsv4_autotune_covers_extra_topk_buckets() -> No
         torch.testing.assert_close(output, ref_out, atol=5e-2, rtol=5e-2)
 
     def tuned_tactic(extra_topk: int) -> int | None:
-        # The hot cache only records tactics resolved from tuned entries.
+        """Tactic the hot cache recorded for this width, if one was tuned."""
         return next(
             (t for k, t in _decode_dsv4_hot_cache.items() if k[3] == extra_topk), None
         )

--- a/tests/attention/test_sparse_mla_sm120.py
+++ b/tests/attention/test_sparse_mla_sm120.py
@@ -621,6 +621,99 @@ def test_sparse_mla_sm120_decode_dsv4_dual_large_extra_topk() -> None:
     torch.testing.assert_close(output.squeeze(1), ref_out, atol=5e-2, rtol=5e-2)
 
 
+def test_sparse_mla_sm120_decode_dsv4_autotune_covers_extra_topk_buckets() -> None:
+    """One tuning pass covers every power-of-2 extra_topk bucket at or below
+    the tuned width; wider widths stay on the heuristic until re-tuned."""
+    from flashinfer import autotune
+    from flashinfer.autotuner import AutoTuner
+    from flashinfer.mla._sparse_mla_sm120 import _decode_dsv4_hot_cache
+
+    torch.manual_seed(0)
+    device = torch.device("cuda")
+    num_tokens, num_heads, topk = 4, 16, 128
+    d_qk, d_v = 512, 512
+    pbs, num_blocks = 64, 16
+    s_kv = num_blocks * pbs
+
+    def make_cache() -> tuple[torch.Tensor, torch.Tensor]:
+        bf16 = (
+            torch.randn(num_blocks, pbs, 1, d_qk, device=device, dtype=torch.bfloat16)
+            / 10.0
+        ).clamp(-1, 1)
+        packed = quantize_kv_dsv4(bf16)
+        return packed, dequantize_kv_dsv4(packed)
+
+    main_packed, main_dequant = make_cache()
+    extra_packed, extra_dequant = make_cache()
+    virtual_kv = torch.cat(
+        [main_dequant.reshape(-1, d_qk), extra_dequant.reshape(-1, d_qk)], dim=0
+    ).reshape(-1, 1, 1, d_qk)
+    q = (
+        torch.randn(num_tokens, num_heads, d_qk, device=device, dtype=torch.bfloat16)
+        / 10.0
+    ).clamp(-1, 1)
+    main_idx = torch.randint(
+        0, s_kv, (num_tokens, topk), device=device, dtype=torch.int32
+    )
+    sm_scale = d_qk**-0.5
+
+    def run(extra_topk: int) -> None:
+        extra_idx = torch.randint(
+            0, s_kv, (num_tokens, extra_topk), device=device, dtype=torch.int32
+        )
+        output = torch.zeros(
+            (num_tokens, num_heads, d_v), dtype=torch.bfloat16, device=device
+        )
+        out_lse = torch.zeros(
+            (num_tokens, num_heads), dtype=torch.float32, device=device
+        )
+        mid_out, mid_lse = _make_decode_scratch(
+            num_tokens, num_heads, topk, d_v, device, extra_topk=extra_topk
+        )
+        sparse_mla_sm120_paged_attention(
+            q,
+            main_packed,
+            main_idx,
+            output,
+            out_lse,
+            sm_scale,
+            d_v=d_v,
+            extra_kv_cache=extra_packed,
+            extra_indices=extra_idx,
+            mid_out=mid_out,
+            mid_lse=mid_lse,
+        )
+        ref_out, _ = _ref_sparse_attn(
+            q,
+            virtual_kv,
+            torch.cat([main_idx, extra_idx + s_kv], dim=-1),
+            sm_scale,
+            d_v,
+        )
+        torch.testing.assert_close(output, ref_out, atol=5e-2, rtol=5e-2)
+
+    def tuned_tactic(extra_topk: int) -> int | None:
+        # The hot cache only records tactics resolved from tuned entries.
+        return next(
+            (t for k, t in _decode_dsv4_hot_cache.items() if k[3] == extra_topk), None
+        )
+
+    tuner = AutoTuner.get()
+    tuner.clear_cache()
+    _decode_dsv4_hot_cache.clear()
+    try:
+        with autotune(True):
+            run(1024)
+        for extra_topk in (256, 384, 1024):
+            run(extra_topk)
+            assert tuned_tactic(extra_topk) is not None, extra_topk
+        run(2048)
+        assert tuned_tactic(2048) is None
+    finally:
+        tuner.clear_cache()
+        _decode_dsv4_hot_cache.clear()
+
+
 _DSV3_2_DECODE_HEADS = [8, 16, 32, 64, 128]
 
 

--- a/tests/autotuner/test_autotuner_core.py
+++ b/tests/autotuner/test_autotuner_core.py
@@ -20,6 +20,8 @@ from flashinfer.mla._core import (
 )
 from flashinfer.mla._sparse_mla_sm120 import (
     _decode_dsv3_2_tuning_config,
+    _decode_dsv4_extra_topk_buckets,
+    _decode_dsv4_map_to_extra_topk_bucket,
     _decode_dsv4_tuning_config,
 )
 from flashinfer.tllm_enums import (
@@ -2007,14 +2009,82 @@ def test_mla_decode_tuning_config_is_memoized(
 def test_sparse_mla_tuning_config_initializer_indices():
     """Sparse MLA configs retain each initializer's original input index."""
 
-    assert set(dict(_decode_dsv4_tuning_config().tensor_initializers)) == {
-        0,
-        1,
-        6,
-        8,
-        9,
-    }
+    for has_extra in (False, True):
+        initializers = _decode_dsv4_tuning_config(has_extra).tensor_initializers
+        assert set(dict(initializers)) == {0, 1, 6, 8, 9}
     assert set(dict(_decode_dsv3_2_tuning_config().tensor_initializers)) == {0, 1, 6}
+
+
+@pytest.mark.parametrize(
+    "extra_topk,expected_bucket,expected_buckets",
+    [
+        (32, 64, (64,)),
+        (100, 64, (64,)),
+        (1024, 1024, (64, 128, 256, 512, 1024)),
+        (1536, 1024, (64, 128, 256, 512, 1024)),
+        (8192, 8192, (64, 128, 256, 512, 1024, 2048, 4096, 8192)),
+    ],
+)
+def test_sparse_mla_dsv4_extra_topk_buckets(
+    extra_topk, expected_bucket, expected_buckets
+):
+    """extra_topk rounds down to a power of 2 (at least one 64-wide tile) and
+    one tuning pass generates every bucket from one tile up to that value."""
+    assert _decode_dsv4_map_to_extra_topk_bucket(extra_topk) == expected_bucket
+    assert _decode_dsv4_extra_topk_buckets(extra_topk) == expected_buckets
+
+
+def _sparse_mla_dsv4_decode_shapes(num_tokens, num_heads, topk, extra_topk):
+    """Input shapes in the order sparse_mla_sm120_decode_dsv4 hands to the tuner.
+
+    ``extra_topk == 0`` stands for ``extra_indices=None`` (shape ``(0,)``).
+    """
+    num_splits = (topk + 63) // 64 + (extra_topk + 63) // 64
+    has_extra = extra_topk > 0
+    return (
+        (num_tokens, num_heads, 512),  # q
+        (num_tokens, topk),  # indices
+        (num_tokens, num_heads, num_splits, 512),  # mid_out
+        (num_tokens, num_heads, num_splits),  # mid_lse
+        (num_tokens, num_heads, 512),  # output
+        (num_tokens, num_heads),  # out_lse
+        (num_tokens,),  # topk_length
+        (num_heads,),  # attn_sink
+        (num_tokens, extra_topk) if has_extra else (0,),  # extra_indices
+        (num_tokens,) if has_extra else (0,),  # extra_topk_length
+    )
+
+
+@pytest.mark.parametrize(
+    "extra_topk,expected_bucket", [(256, 256), (1536, 1024), (8192, 8192)]
+)
+def test_find_nearest_profile_sparse_mla_dsv4_buckets_extra_topk(
+    extra_topk, expected_bucket
+):
+    """With a secondary cache the profile buckets extra_topk and wildcards the
+    split count of the scratch tensors, so all widths in a bucket share one
+    cache entry."""
+    config = _decode_dsv4_tuning_config(True)
+    profile = AutoTuner._find_nearest_profile(
+        _sparse_mla_dsv4_decode_shapes(58, 32, 128, extra_topk), config
+    )
+    assert profile[8] == (64, expected_bucket)
+    assert profile[2] == (-1, 32, -1, 512)
+    assert profile[3] == (-1, 32, -1)
+    assert profile == AutoTuner._find_nearest_profile(
+        _sparse_mla_dsv4_decode_shapes(58, 32, 128, expected_bucket), config
+    )
+
+
+def test_find_nearest_profile_sparse_mla_dsv4_without_extra():
+    """Without a secondary cache only the token axis is dynamic."""
+    profile = AutoTuner._find_nearest_profile(
+        _sparse_mla_dsv4_decode_shapes(58, 32, 128, 0),
+        _decode_dsv4_tuning_config(False),
+    )
+    assert profile[1] == (64, 128)
+    assert profile[2] == (-1, 32, 2, 512)
+    assert profile[8] == (64,)
 
 
 def test_find_nearest_profile_cache_dedups_mla_decode_config():


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## Description

`sparse_mla_sm120_decode_dsv4` tunes `chunks_per_block` through the AutoTuner, but `_decode_dsv4_tuning_config()` only declared `num_tokens` as a dynamic axis. `extra_topk` (the last dim of `extra_indices`), the `num_splits` dim of `mid_out`/`mid_lse`, and the runner's `get_cache_key_extras` were all matched exactly. Any `extra_topk` the warm-up pass did not physically run was therefore a guaranteed cache miss: each such decode step logged `No tuned config covers ...` and ran the C++ heuristic. DeepSeek-V4-Flash serving switches between several dense widths, so this hit production shapes on every step.

This PR makes `extra_topk` a second tuned axis:

- A `DynamicTensorSpec` on the last dim of `extra_indices` with power-of-2 buckets from one 64-wide tile up to the tuned width. Lookups round down: `chunks_per_block` must not exceed `num_splits`, which only grows with `extra_topk`, so a tactic tuned at a smaller bucket is always valid. The launcher silently drops an out-of-range override and re-enters the heuristic, which is exactly the cliff this fixes.
- `ConstraintSpec`s so the `num_splits` dim of the synthesized `mid_out`/`mid_lse` follows the bucketed width and is a wildcard in the cache key.
- The runner keys on `extra_indices is not None` instead of the exact width.
- `_decode_dsv4_tuning_config(has_extra)`, because a `None` input is a `(0,)` placeholder with no last dim to bucket. The no-extra config is unchanged.

One tuning pass at the largest served width now covers every width at or below it; wider widths stay on the heuristic with the existing warning, so tune with the largest width you serve. Cache keys for this op change, so entries saved by older versions miss once and get re-tuned. Tuning at `extra_topk=8192` runs 6 x 8 = 48 profiles, about the same work as tuning the four production widths one by one today.

Measured on an RTX 5070 Ti with T=12, H=32, topk=128, page size 64. Before: tuning once at `extra_topk=8192` produced 6 cache entries and 256, 1024, 1536 and 2048 all missed with the warning. After: 48 entries and every width hits (1536 maps to the 1024 bucket). Kernel time per call, all columns launched through the explicit `chunks_per_block` path, cold L2, median of 100 (`flashinfer.testing.bench_gpu_time`):

| extra_topk | heuristic | tuned tactic | best cpb |
| --- | --- | --- | --- |
| 256 | 48.6 us | 36.4 us (cpb 3) | 36.4 us (cpb 3) |
| 1024 | 67.1 us | 69.1 us (cpb 9) | 63.0 us (cpb 7) |
| 2048 | 97.8 us | 99.9 us (cpb 17) | 85.9 us (cpb 14) |
| 8192 | 242.9 us | 273.7 us (cpb 65) | 216.5 us (cpb 24) |

This PR changes which shapes get a tuned tactic, not how the tactic for a profile is picked: before this change the exactly tuned 8192 shape picked cpb 63 on the same card. On this GPU the pick is optimal at 256 and off the cold-L2 optimum for wider shapes, because profiling synthesizes indices in `[0, 256)` and runs on a small cache-resident working set. That is a separate measurement-quality topic. The GB10 numbers in the issue (heuristic 657 us vs tuned 360 us at 8192) show how much the tuned tactic can matter there.

## Related Issues

Closes #4598

## Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

- `tests/autotuner/test_autotuner_core.py` (CPU): bucket helpers, nearest-profile bucketing of `extra_topk` with a wildcarded `num_splits`, and the no-extra config.
- `tests/attention/test_sparse_mla_sm120.py::test_sparse_mla_sm120_decode_dsv4_autotune_covers_extra_topk_buckets` (SM12x): tune once at 1024, then 256, 384 and 1024 resolve to a tuned tactic and match the reference; 2048 stays on the heuristic.

On an RTX 5070 Ti: `pytest tests/attention/test_sparse_mla_sm120.py -k "decode_dsv4 or decode_dsv3_2"` 140 passed; `pytest tests/autotuner/test_autotuner_core.py` 121 passed (`test_value_aware_profiles_expert_distributions_in_one_transaction` fails the same way on `main`, unrelated); `pre-commit run` on the changed files is clean.

## Reviewer Notes

`dim_idx=(-1,)` addresses the last dim because the public entry accepts `extra_indices` as `[T, E]` or `[T, 1, E]`; the autotuner only uses `dim_idx` as a plain list index. The per-process hot cache keeps its exact-shape key since it only memoizes an already resolved tactic.
