### PR TITLE
fix(sampling): isolate softmax partial reductions across streams

### DIFF
--- a/include/flashinfer/sampling.cuh
+++ b/include/flashinfer/sampling.cuh
@@ -421,8 +421,8 @@ __global__ FLASHINFER_SAMPLING_LAUNCH_BOUNDS(BLOCK_THREADS) void OnlineSoftmaxFu
 
 template <uint32_t BLOCK_THREADS, uint32_t VEC_SIZE, typename DType>
 __global__ FLASHINFER_SAMPLING_LAUNCH_BOUNDS(BLOCK_THREADS) void OnlineSoftmaxMapKernel(
-    DType* logits, PartialSoftmaxResult* partial_results, DType* temperature_arr,
-    float temperature_val, uint32_t d, uint32_t num_slices) {
+    DType* logits, DType* partial_results_buffer, DType* temperature_arr, float temperature_val,
+    uint32_t d, uint32_t num_slices) {
   const uint32_t bx = blockIdx.x;
   const uint32_t by = blockIdx.y;  // slice index
   const uint32_t tx = threadIdx.x;
@@ -497,7 +497,8 @@ __global__ FLASHINFER_SAMPLING_LAUNCH_BOUNDS(BLOCK_THREADS) void OnlineSoftmaxMa
   running_denominator = temp_storage.shared_state.denominator;
 
   if (tx == 0) {
-    partial_results[bx * num_slices + by] = {running_max, running_denominator};
+    auto partial_results = reinterpret_cast<PartialSoftmaxResult*>(partial_results_buffer + bx * d);
+    partial_results[by] = {running_max, running_denominator};
   }
 #if (__CUDACC_VER_MAJOR__ >= 12 && defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
   asm volatile("griddepcontrol.launch_dependents;");
@@ -506,7 +507,7 @@ __global__ FLASHINFER_SAMPLING_LAUNCH_BOUNDS(BLOCK_THREADS) void OnlineSoftmaxMa
 
 template <uint32_t BLOCK_THREADS, uint32_t VEC_SIZE, typename DType>
 __global__ FLASHINFER_SAMPLING_LAUNCH_BOUNDS(BLOCK_THREADS) void OnlineSoftmaxReduceKernel(
-    DType* logits, DType* output, PartialSoftmaxResult* partial_results, DType* temperature_arr,
+    DType* logits, DType* output, DType* partial_results_buffer, DType* temperature_arr,
     float temperature_val, uint32_t d, uint32_t num_slices) {
   const uint32_t bx = blockIdx.x;
   const uint32_t tx = threadIdx.x;
@@ -521,13 +522,14 @@ __global__ FLASHINFER_SAMPLING_LAUNCH_BOUNDS(BLOCK_THREADS) void OnlineSoftmaxRe
   const Float2SoftmaxReduceOp reduce_op;
 
   float2 thread_aggregate = make_float2(-cuda::std::numeric_limits<float>::infinity(), 0.0f);
+  auto partial_results = reinterpret_cast<PartialSoftmaxResult*>(partial_results_buffer + bx * d);
 
 #if (__CUDACC_VER_MAJOR__ >= 12 && defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
   asm volatile("griddepcontrol.wait;");
 #endif
 
   for (uint32_t i = tx; i < num_slices; i += BLOCK_THREADS) {
-    PartialSoftmaxResult partial = partial_results[bx * num_slices + i];
+    PartialSoftmaxResult partial = partial_results[i];
     float2 partial_pair = make_float2(partial.max_val, partial.denominator);
     thread_aggregate = reduce_op(thread_aggregate, partial_pair);
   }
@@ -1347,14 +1349,10 @@ cudaError_t OnlineSoftmax(DType* logits, DType* output, uint32_t batch_size, uin
           // Path A: Vocab-Splitting Strategy for small-batch & large-vocab
           uint32_t num_slices = ceil_div(d, DEFAULT_SLICE_SIZE);
 
-          const size_t partial_buffer_size = batch_size * num_slices * sizeof(PartialSoftmaxResult);
-          if (workspace_buffer_size_in_bytes < partial_buffer_size) {
-            return cudaErrorInvalidValue;
-          }
-
-          AlignedAllocator allocator(workspace_buffer, workspace_buffer_size_in_bytes);
-          auto partial_results = allocator.aligned_alloc<PartialSoftmaxResult>(
-              partial_buffer_size, alignof(PartialSoftmaxResult), "softmax_workspace");
+          // Each output row is private to this invocation and much larger than
+          // its slice partials. Phase 2 loads all partials before normalizing
+          // and overwriting the row, so the output safely doubles as scratch.
+          auto partial_results_buffer = output;
 
           // Phase 1: Map-Reduce across vocab slices
           dim3 phase1_nblks(batch_size, num_slices);
@@ -1362,8 +1360,9 @@ cudaError_t OnlineSoftmax(DType* logits, DType* output, uint32_t batch_size, uin
           size_t smem_size = sizeof(OnlineSoftmaxTempStorage<BLOCK_THREADS>);
 
           auto phase1_kernel = OnlineSoftmaxMapKernel<BLOCK_THREADS, VEC_SIZE, DType>;
-          void* phase1_args[] = {&logits, &partial_results, &temperature_arr, &temperature_val,
-                                 &d,      &num_slices};
+          void* phase1_args[] = {
+              &logits,    &partial_results_buffer, &temperature_arr, &temperature_val, &d,
+              &num_slices};
 
           FLASHINFER_CUDA_CALL(cudaFuncSetAttribute(
               phase1_kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size));
@@ -1381,9 +1380,9 @@ cudaError_t OnlineSoftmax(DType* logits, DType* output, uint32_t batch_size, uin
             config.attrs = attribute;
             config.numAttrs = 1;
 
-            FLASHINFER_CUDA_CALL(cudaLaunchKernelEx(&config, phase1_kernel, logits, partial_results,
-                                                    temperature_arr, temperature_val, d,
-                                                    num_slices));
+            FLASHINFER_CUDA_CALL(cudaLaunchKernelEx(&config, phase1_kernel, logits,
+                                                    partial_results_buffer, temperature_arr,
+                                                    temperature_val, d, num_slices));
           } else {
             FLASHINFER_CUDA_CALL(cudaLaunchKernel((void*)phase1_kernel, phase1_nblks, phase1_nthrs,
                                                   phase1_args, smem_size, stream));
@@ -1394,8 +1393,9 @@ cudaError_t OnlineSoftmax(DType* logits, DType* output, uint32_t batch_size, uin
           dim3 phase2_nthrs(BLOCK_THREADS);
 
           auto phase2_kernel = OnlineSoftmaxReduceKernel<BLOCK_THREADS, VEC_SIZE, DType>;
-          void* phase2_args[] = {&logits,          &output, &partial_results, &temperature_arr,
-                                 &temperature_val, &d,      &num_slices};
+          void* phase2_args[] = {&logits,          &output,          &partial_results_buffer,
+                                 &temperature_arr, &temperature_val, &d,
+                                 &num_slices};
 
           FLASHINFER_CUDA_CALL(cudaFuncSetAttribute(
               phase2_kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size));
@@ -1414,7 +1414,7 @@ cudaError_t OnlineSoftmax(DType* logits, DType* output, uint32_t batch_size, uin
             config.numAttrs = 1;
 
             FLASHINFER_CUDA_CALL(cudaLaunchKernelEx(&config, phase2_kernel, logits, output,
-                                                    partial_results, temperature_arr,
+                                                    partial_results_buffer, temperature_arr,
                                                     temperature_val, d, num_slices));
           } else {
             FLASHINFER_CUDA_CALL(cudaLaunchKernel((void*)phase2_kernel, phase2_nblks, phase2_nthrs,

--- a/tests/utils/test_sampling.py
+++ b/tests/utils/test_sampling.py
@@ -76,6 +76,50 @@ def test_softmax(
     assert torch.allclose(probs, probs_ref, atol=1e-5)
 
 
+@pytest.mark.parametrize("api", ["sampling", "logits_pipe"])
+def test_softmax_concurrent_streams(api):
+    batch_size = 128
+    vocab_size = 131072
+    iterations = 10
+
+    torch.manual_seed(42)
+    logits = [
+        torch.randn(batch_size, vocab_size, device="cuda:0"),
+        torch.randn(batch_size, vocab_size, device="cuda:0") * 2.0 + 3.0,
+    ]
+    references = [torch.softmax(value, dim=-1) for value in logits]
+
+    if api == "sampling":
+
+        def run_softmax(value):
+            return flashinfer.sampling.softmax(value, enable_pdl=False)
+
+    else:
+        from flashinfer.logits_processor import LogitsPipe, Softmax, Temperature
+
+        pipe = LogitsPipe([Temperature(), Softmax(enable_pdl=False)], compile=True)
+
+        def run_softmax(value):
+            return pipe(value, temperature=1.0)
+
+    # Warm up the split-vocabulary path before launching work on side streams.
+    for value in logits:
+        run_softmax(value)
+    torch.cuda.synchronize()
+
+    streams = [torch.cuda.Stream(), torch.cuda.Stream()]
+    outputs = [[], []]
+    for _ in range(iterations):
+        for stream_index, stream in enumerate(streams):
+            with torch.cuda.stream(stream):
+                outputs[stream_index].append(run_softmax(logits[stream_index]))
+    torch.cuda.synchronize()
+
+    for stream_outputs, reference in zip(outputs, references, strict=True):
+        for output in stream_outputs:
+            torch.testing.assert_close(output, reference, atol=1e-5, rtol=1e-5)
+
+
 @pytest.mark.parametrize("vocab_size", [111, 32000, 128256])
 @pytest.mark.parametrize(
     "distribution",


### PR DESCRIPTION
## 📌 Description

The split-vocabulary `OnlineSoftmax` path used a module-global 1 MiB workspace for partial reductions. Calls on different CUDA streams therefore aliased the same storage: one call's phase-1 kernels could overwrite another call's partials before its phase-2 reduction consumed them.

This change stores each row's partial reductions in the beginning of that invocation's output row. Phase 2 loads all partials before its block synchronization and only then writes normalized values, so the row can safely double as scratch. The existing external workspace argument is preserved for ABI compatibility, and the hot path adds no allocation or stream lookup.

A regression test interleaves large-vocabulary softmax calls on two CUDA streams through both `flashinfer.sampling.softmax` and the compiled `LogitsPipe([Temperature(), Softmax()])` path.

Base: `2f519edced8b027f8aee960bc622346e510e2cfa`

Head: `4a04a72ead82f652f912147cfd04023746743e84`

### Reproduction and performance check

Environment: NVIDIA GeForce RTX 3090 (SM86), CUDA 13.0, PyTorch `2.13.0+cu130`, one GPU.

Before the fix, a two-stream stress run at `(batch_size=128, vocab_size=131072)` produced 17 incorrect outputs out of 80 calls. The worst row-sum error was `0.9897358`. The added pytest regression also failed on the original kernel with 21.7% mismatched elements in an affected output.

After the fix, both API variants pass 10 interleaved calls per stream, and both variants pass CUDA Graph capture/replay.

Serial no-regression benchmark: 20 warmups, 10 rounds, 200 calls/round for `1x32000` and 100 calls/round for `128x131072`. Values are wall-time median in microseconds with `[p10, p90]`:

| Shape | Before | After |
| --- | ---: | ---: |
| `1x32000` | `13.239 [12.856, 13.400]` | `12.736 [12.426, 13.369]` |
| `128x131072` | `252.476 [247.567, 255.461]` | `247.885 [247.624, 249.330]` |

The intervals overlap; this is a no-regression check rather than a speedup claim.

## 🔍 Related Issues

No matching open issue or PR was found for the softmax workspace race. The active top-k stream-safety work does not touch `OnlineSoftmax` or this workspace.

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

Changed-file hooks pass with:

```bash
pre-commit run --files include/flashinfer/sampling.cuh tests/utils/test_sampling.py
```

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All targeted tests are passing.

```text
7 passed, 2 warnings in 80.13s
sampling: PASS       # CUDA Graph replay
logits_pipe: PASS    # CUDA Graph replay
```

The warnings are pre-existing CUTLASS DSL deprecation warnings from `tests/conftest.py`.

## Reviewer Notes

Please focus on the ordering argument in `OnlineSoftmaxReduceKernel`: every thread loads its row's partials before the block reduction and explicit synchronization, while output writes begin only afterward. The external workspace parameters remain in place to avoid broadening this correctness fix into an ABI change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved online softmax processing by reusing available output memory for intermediate calculations.
  * Reduced temporary memory usage and allocation overhead during softmax operations.

* **Bug Fixes**
  * Added coverage to verify consistent softmax results when operations run concurrently on multiple CUDA streams.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->