### PR TITLE
fix(moe): use the N-dim SF alignment in the NVFP4 fc1 weight scale check

### DIFF
--- a/csrc/fused_moe/cutlass_backend/flashinfer_cutlass_fused_moe_binding.cu
+++ b/csrc/fused_moe/cutlass_backend/flashinfer_cutlass_fused_moe_binding.cu
@@ -1397,33 +1397,22 @@ class FusedMoeRunner : public tvm::ffi::ModuleObj {
       // Check shapes
       TVM_FFI_ICHECK(fc1_act_global.ndim() == 0 || fc1_act_global.size(0) == num_experts_on_rank)
           << "fc1 act global must be scalar or (num_experts_on_rank,)";
-      if (isGatedActivation(base_activation_type)) {
-        TVM_FFI_ICHECK(
-            fc1_weight_block.size(0) == num_experts_on_rank &&
-            fc1_weight_block.size(1) ==
-                TmaWarpSpecializedGroupedGemmInput::alignToSfDim(
-                    inter_size, TmaWarpSpecializedGroupedGemmInput::MinKDimAlignmentNVFP4) *
-                    2 &&
-            fc1_weight_block.size(2) * FP8_PER_INT32 *
-                    TmaWarpSpecializedGroupedGemmInput::NVFP4BlockScaleVectorSize ==
-                TmaWarpSpecializedGroupedGemmInput::alignToSfDim(
-                    hidden_size, TmaWarpSpecializedGroupedGemmInput::MinKDimAlignmentNVFP4))
-            << "fc1 weight block size must be (num_experts_on_rank, inter_size * 2, hidden_size // "
-               "4 "
-               "// block_scale_vector_size)";
-      } else {
-        TVM_FFI_ICHECK(
-            fc1_weight_block.size(0) == num_experts_on_rank &&
-            fc1_weight_block.size(1) ==
-                TmaWarpSpecializedGroupedGemmInput::alignToSfDim(
-                    inter_size, TmaWarpSpecializedGroupedGemmInput::MinKDimAlignmentNVFP4) &&
-            fc1_weight_block.size(2) * FP8_PER_INT32 *
-                    TmaWarpSpecializedGroupedGemmInput::NVFP4BlockScaleVectorSize ==
-                TmaWarpSpecializedGroupedGemmInput::alignToSfDim(
-                    hidden_size, TmaWarpSpecializedGroupedGemmInput::MinKDimAlignmentNVFP4))
-            << "fc1 weight block size must be (num_experts_on_rank, inter_size, hidden_size // 4 "
-               "// block_scale_vector_size)";
-      }
+      // The SF outer dim covers the whole fc1 GEMM N extent (doubled when gated) padded to
+      // MinNDimAlignmentNVFP4, matching getOffsetWeightSF.
+      int64_t const fc1_out_size =
+          isGatedActivation(base_activation_type) ? inter_size * 2 : inter_size;
+      TVM_FFI_ICHECK(
+          fc1_weight_block.size(0) == num_experts_on_rank &&
+          fc1_weight_block.size(1) ==
+              TmaWarpSpecializedGroupedGemmInput::alignToSfDim(
+                  fc1_out_size, TmaWarpSpecializedGroupedGemmInput::MinNDimAlignmentNVFP4) &&
+          fc1_weight_block.size(2) * FP8_PER_INT32 *
+                  TmaWarpSpecializedGroupedGemmInput::NVFP4BlockScaleVectorSize ==
+              TmaWarpSpecializedGroupedGemmInput::alignToSfDim(
+                  hidden_size, TmaWarpSpecializedGroupedGemmInput::MinKDimAlignmentNVFP4))
+          << "fc1 weight block size must be (num_experts_on_rank, inter_size"
+          << (fc1_out_size != inter_size ? " * 2" : "")
+          << ", hidden_size // 4 // block_scale_vector_size)";
 
       TVM_FFI_ICHECK_EQ(fc1_global.size(0), num_experts_on_rank)
           << "fc1 global size must be (num_experts_on_rank,)";

--- a/csrc/fused_moe/cutlass_backend/flashinfer_cutlass_fused_moe_binding.cu
+++ b/csrc/fused_moe/cutlass_backend/flashinfer_cutlass_fused_moe_binding.cu
@@ -1401,18 +1401,18 @@ class FusedMoeRunner : public tvm::ffi::ModuleObj {
       // MinNDimAlignmentNVFP4, matching getOffsetWeightSF.
       int64_t const fc1_out_size =
           isGatedActivation(base_activation_type) ? inter_size * 2 : inter_size;
+      int64_t const fc1_sf_rows = TmaWarpSpecializedGroupedGemmInput::alignToSfDim(
+          fc1_out_size, TmaWarpSpecializedGroupedGemmInput::MinNDimAlignmentNVFP4);
       TVM_FFI_ICHECK(
           fc1_weight_block.size(0) == num_experts_on_rank &&
-          fc1_weight_block.size(1) ==
-              TmaWarpSpecializedGroupedGemmInput::alignToSfDim(
-                  fc1_out_size, TmaWarpSpecializedGroupedGemmInput::MinNDimAlignmentNVFP4) &&
+          fc1_weight_block.size(1) == fc1_sf_rows &&
           fc1_weight_block.size(2) * FP8_PER_INT32 *
                   TmaWarpSpecializedGroupedGemmInput::NVFP4BlockScaleVectorSize ==
               TmaWarpSpecializedGroupedGemmInput::alignToSfDim(
                   hidden_size, TmaWarpSpecializedGroupedGemmInput::MinKDimAlignmentNVFP4))
           << "fc1 weight block size must be (num_experts_on_rank, inter_size"
-          << (fc1_out_size != inter_size ? " * 2" : "")
-          << ", hidden_size // 4 // block_scale_vector_size)";
+          << (fc1_out_size != inter_size ? " * 2" : "") << " aligned to 128 (= " << fc1_sf_rows
+          << "), hidden_size // 4 // block_scale_vector_size)";
 
       TVM_FFI_ICHECK_EQ(fc1_global.size(0), num_experts_on_rank)
           << "fc1 global size must be (num_experts_on_rank,)";

--- a/tests/moe/test_trtllm_cutlass_fused_moe.py
+++ b/tests/moe/test_trtllm_cutlass_fused_moe.py
@@ -2253,8 +2253,8 @@ def test_moe_nvfp4_unswizzled_input_sf():
 @pytest.mark.parametrize("quantized_input", [False])
 @pytest.mark.parametrize(
     "activation_type",
-    [ActivationType.Swiglu],
-    ids=["swiglu"],
+    [ActivationType.Swiglu, ActivationType.Relu2],
+    ids=["swiglu", "relu2"],
 )
 @pytest.mark.parametrize("use_4over6", [False, True])
 @pytest.mark.skipif(
@@ -2279,6 +2279,9 @@ def test_moe_nvfp4_unaligned_hidden_size(
     When hidden_size/sf_block_size is not a multiple of 4, block_scale_interleave
     pads the scale columns, inflating numel(). This caused weight_scale_vec_size
     to be computed incorrectly (e.g. 31 instead of 32). See issue #2847.
+
+    Relu2 covers the non-gated FC1 SF shape check (issue #4653): the 160/192
+    intermediate sizes pad the FC1 SF rows to 256, which the check rejected.
     """
     if top_k > num_experts:
         pytest.skip(


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## Description

`cutlass_fused_moe` rejected valid NVFP4 weights whenever the fc1 GEMM N extent is not a multiple of 128, e.g. the non-gated Nemotron-3-Nano shape `hidden_size=2688, intermediate_size=1856` with Relu2 from #4653.

The NVFP4 branch of `getQuantParams` validated `fc1_weight_block.size(1)` with `MinKDimAlignmentNVFP4` (64). Swizzled scale factors pad the outer dim to `MinNDimAlignmentNVFP4` (128): that is what `fp4_quantize` produces, what the fc2 check in the same function already expects, and what `getOffsetWeightSF` uses for the per-expert SF stride. A non-gated `inter_size=1856` therefore arrives with 1920 SF rows while the check demanded 1856.

The check now compares against `alignToSfDim(fc1_out_size, MinNDimAlignmentNVFP4)`, with `fc1_out_size` doubled for gated activations, mirroring the kernel's stride computation. The gated case is unchanged because `align(n, 64) * 2 == align(2n, 128)`. For non-gated shapes, everything `fp4_quantize` produces is now accepted; tensors sized to the old 64-aligned expectation are rejected, which is also correct since they are smaller than the stride the kernel reads with.

## Related Issues

Closes #4653

## Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

- `test_moe_nvfp4_unaligned_hidden_size` now also runs Relu2: the 160/192 intermediate sizes pad the FC1 SF rows to 256 and fail the old check (verified: they fail on the unpatched binding, pass with the fix).
- On an RTX 5070 Ti (SM120, CUDA 13.2): `pytest tests/moe/test_trtllm_cutlass_fused_moe.py` 122 passed, 54 skipped (the NVFP4 selection alone: 76 passed, 1 skipped).
- The issue's repro command completes: `python3 benchmarks/flashinfer_benchmark.py --routine cutlass_fused_moe --num_tokens 1 --hidden_size 2688 --intermediate_size 1856 --num_experts 128 --top_k 6 --cutlass_variant nvfp4 --input_dtype bfloat16 --activation-type Relu2` reports median 0.073 ms instead of the shape assertion.

## Reviewer Notes

The issue's full shape is exercised through the benchmark rather than the unit test: at `hidden_size=2688` the elementwise comparison against the dequantized torch reference is dominated by accumulated fp4 quantization noise on near-zero outputs (this affects gated shapes of that size on main too, independent of this change), so the regression test uses the existing small unaligned shapes, which hit the same check with the same 64-vs-128 mismatch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved NVFP4 fused MoE validation for models with unaligned hidden or intermediate dimensions.
  * Corrected handling of gated and non-gated FC1 scale shapes, including padded intermediate dimensions.
  * Added support coverage for both SwiGLU and Relu2 activation types in these scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->