### PR TITLE
feat(attention): add variant_owns_mask for JIT variants that own the full mask

### DIFF
--- a/flashinfer/prefill.py
+++ b/flashinfer/prefill.py
@@ -1652,6 +1652,7 @@ class BatchPrefillWithPagedKVCacheWrapper:
         backend: str = "auto",
         jit_args: Optional[List[Any]] = None,
         jit_kwargs: Optional[Dict[str, Any]] = None,
+        variant_owns_mask: bool = False,
     ) -> None:
         r"""Constructor of :class:`BatchPrefillWithPagedKVCacheWrapper`.
 
@@ -1718,11 +1719,31 @@ class BatchPrefillWithPagedKVCacheWrapper:
 
         jit_kwargs : Optional[Dict[str, Any]]
             The keyword arguments to create the JIT module, defaults to None.
+
+        variant_owns_mask : bool
+            If ``True``, the attention variant supplied through ``jit_args`` computes the
+            complete attention mask in its ``LogitsMask`` hook, and :attr:`MaskMode.CUSTOM`
+            is selected without a mask tensor: the kernel evaluates ``LogitsMask`` on every
+            KV tile instead of only on the causal/window boundary tiles, and no
+            ``custom_mask``/``packed_custom_mask`` needs to be passed to :meth:`plan`.
+            Requires ``jit_args``, because the default attention variant dereferences the
+            custom mask buffer under :attr:`MaskMode.CUSTOM`. Only supported with
+            ``backend="fa2"`` (the SM90 batch prefill kernels reject
+            :attr:`MaskMode.CUSTOM`), and incompatible with ``prefix_len_ptr``
+            (multi-item scoring), which selects a different mask mode.
+            Defaults to ``False``.
         """
         _check_workspace_buffer_alignment(
             float_workspace_buffer, "float_workspace_buffer"
         )
         _check_kv_layout(kv_layout)
+
+        if variant_owns_mask and backend != "fa2":
+            raise ValueError(
+                "variant_owns_mask is only supported on the fa2 backend: the "
+                "SM90 (fa3) batch prefill kernels return cudaErrorNotSupported "
+                "under MaskMode.CUSTOM."
+            )
 
         self._cute_dsl_wrapper = None
         if backend == "cute-dsl":
@@ -1746,6 +1767,14 @@ class BatchPrefillWithPagedKVCacheWrapper:
             self._jit_module = None
             self._jit_additional_tensor_names = []
             self._jit_additional_scalar_names = []
+
+        if variant_owns_mask and self._jit_module is None:
+            raise ValueError(
+                "variant_owns_mask requires a custom JIT module (jit_args): the "
+                "default attention variant dereferences the custom mask buffer "
+                "under MaskMode.CUSTOM."
+            )
+        self._variant_owns_mask = variant_owns_mask
 
         self._kv_layout = kv_layout
         if backend == "cudnn":
@@ -2319,6 +2348,12 @@ class BatchPrefillWithPagedKVCacheWrapper:
                 bitorder="little",
             )
 
+        if prefix_len_ptr is not None and self._variant_owns_mask:
+            raise ValueError(
+                "prefix_len_ptr (multi-item scoring) selects "
+                "MaskMode.MULTIITEMSCORING, which overrides the MaskMode.CUSTOM "
+                "required by variant_owns_mask; the two are incompatible."
+            )
         self._prefix_len_ptr = prefix_len_ptr
         self._token_pos_in_items_ptr = token_pos_in_items_ptr
         self._token_pos_in_items_len = token_pos_in_items_len
@@ -2969,7 +3004,7 @@ class BatchPrefillWithPagedKVCacheWrapper:
                 key_block_scales = key_block_scales.transpose(-3, -2).contiguous()
                 value_block_scales = value_block_scales.transpose(-3, -2).contiguous()
 
-        if self._custom_mask_buf is not None:
+        if self._custom_mask_buf is not None or self._variant_owns_mask:
             mask_mode = MaskMode.CUSTOM.value
         else:
             if self._causal:
@@ -3294,6 +3329,7 @@ class BatchPrefillWithRaggedKVCacheWrapper:
         backend: str = "auto",
         jit_args: Optional[List[Any]] = None,
         jit_kwargs: Optional[Dict[str, Any]] = None,
+        variant_owns_mask: bool = False,
     ) -> None:
         r"""Constructor of :class:`BatchPrefillWithRaggedKVCacheWrapper`.
 
@@ -3348,8 +3384,27 @@ class BatchPrefillWithRaggedKVCacheWrapper:
 
         jit_kwargs : Optional[Dict[str, Any]]
             The keyword arguments to create the JIT module, defaults to None.
+
+        variant_owns_mask : bool
+            If ``True``, the attention variant supplied through ``jit_args`` computes the
+            complete attention mask in its ``LogitsMask`` hook, and :attr:`MaskMode.CUSTOM`
+            is selected without a mask tensor: the kernel evaluates ``LogitsMask`` on every
+            KV tile instead of only on the causal/window boundary tiles, and no
+            ``custom_mask``/``packed_custom_mask`` needs to be passed to :meth:`plan`.
+            Requires ``jit_args``, because the default attention variant dereferences the
+            custom mask buffer under :attr:`MaskMode.CUSTOM`. Only supported with
+            ``backend="fa2"`` (the SM90 batch prefill kernels reject
+            :attr:`MaskMode.CUSTOM`), and incompatible with ``prefix_len_ptr``
+            (multi-item scoring), which selects a different mask mode.
+            Defaults to ``False``.
         """
         _check_kv_layout(kv_layout)
+        if variant_owns_mask and backend != "fa2":
+            raise ValueError(
+                "variant_owns_mask is only supported on the fa2 backend: the "
+                "SM90 (fa3) batch prefill kernels return cudaErrorNotSupported "
+                "under MaskMode.CUSTOM."
+            )
         if jit_args is not None and backend != "cute-dsl":
             if jit_kwargs is None:
                 jit_kwargs = {}
@@ -3362,6 +3417,14 @@ class BatchPrefillWithRaggedKVCacheWrapper:
         else:
             self._jit_module = None
             self._jit_additional_tensor_names = []
+
+        if variant_owns_mask and self._jit_module is None:
+            raise ValueError(
+                "variant_owns_mask requires a custom JIT module (jit_args): the "
+                "default attention variant dereferences the custom mask buffer "
+                "under MaskMode.CUSTOM."
+            )
+        self._variant_owns_mask = variant_owns_mask
 
         self._cute_dsl_wrapper = None
         if backend == "cute-dsl":
@@ -3691,6 +3754,12 @@ class BatchPrefillWithRaggedKVCacheWrapper:
         self._cached_o_data_type = o_data_type
         kv_len_arr = kv_indptr_host[1:] - kv_indptr_host[:-1]
 
+        if prefix_len_ptr is not None and self._variant_owns_mask:
+            raise ValueError(
+                "prefix_len_ptr (multi-item scoring) selects "
+                "MaskMode.MULTIITEMSCORING, which overrides the MaskMode.CUSTOM "
+                "required by variant_owns_mask; the two are incompatible."
+            )
         self._prefix_len_ptr = prefix_len_ptr
         self._token_pos_in_items_ptr = token_pos_in_items_ptr
         self._token_pos_in_items_len = token_pos_in_items_len
@@ -4318,7 +4387,7 @@ class BatchPrefillWithRaggedKVCacheWrapper:
             k = k.to(torch.float16)
             v = v.to(torch.float16)
 
-        if self._custom_mask_buf is not None:
+        if self._custom_mask_buf is not None or self._variant_owns_mask:
             mask_mode = MaskMode.CUSTOM.value
         else:
             if self._causal:

--- a/tests/utils/test_jit_example.py
+++ b/tests/utils/test_jit_example.py
@@ -11,7 +11,7 @@ from flashinfer.jit.attention import (
     gen_customize_single_prefill_module,
 )
 from flashinfer.prefill import single_prefill_with_kv_cache_with_jit_module
-from flashinfer.utils import MaskMode, is_sm90a_supported
+from flashinfer.utils import MaskMode, get_compute_capability, is_sm90a_supported
 
 
 def test_single_decode_mask():
@@ -507,6 +507,8 @@ def test_batch_prefill_variant_owns_mask():
     so every interior tile is masked as well. The sequences here are long
     enough to have interior tiles for every CTA_TILE_KV configuration.
     """
+    if get_compute_capability(torch.device("cuda")) < (8, 0):
+        pytest.skip("variant_owns_mask FA2 JIT test is validated on SM80+.")
     torch.manual_seed(42)
     jit_args = _owned_mask_jit_args("batch_prefill_variant_owns_mask")
 
@@ -646,6 +648,8 @@ def test_variant_owns_mask_requires_jit_module():
 @pytest.mark.parametrize("paged", [True, False])
 def test_variant_owns_mask_rejects_multi_item_scoring(paged):
     """prefix_len_ptr selects MULTIITEMSCORING, which would override CUSTOM."""
+    if get_compute_capability(torch.device("cuda")) < (8, 0):
+        pytest.skip("variant_owns_mask FA2 JIT test is validated on SM80+.")
     jit_args = _owned_mask_jit_args("batch_prefill_variant_owns_mask")
     float_workspace_buffer = torch.empty(
         128 * 1024 * 1024, dtype=torch.uint8, device="cuda"

--- a/tests/utils/test_jit_example.py
+++ b/tests/utils/test_jit_example.py
@@ -452,6 +452,252 @@ def test_batch_prefill_flash_sigmoid():
     torch.testing.assert_close(o_paged, o_ref, rtol=2e-2, atol=2e-2)
 
 
+variant_owned_window_decl = r"""
+struct WindowOwnedMask : AttentionVariantBase {
+  static constexpr bool use_softmax = true;
+
+  uint32_t window_left, qo_len, kv_len;
+  float sm_scale_log2;
+
+  // Create closure
+  template <typename Params>
+  __device__ __host__ WindowOwnedMask(const Params& params, uint32_t batch_idx,
+                                      uint8_t* smem_ptr) {
+    qo_len = params.get_qo_len(batch_idx);
+    kv_len = params.get_kv_len(batch_idx);
+    // The mask owns the window: keep KV traversal un-pruned.
+    window_left = kv_len;
+    sm_scale_log2 = params.sm_scale * math::log2e;
+  }
+
+  REGISTER_LOGITS_MASK(params, batch_idx, qo_idx, kv_idx, qo_head_idx, kv_head_idx, {
+    // Clamp the CTA_TILE_Q padding lanes whose results are discarded.
+    const uint32_t q_local = qo_idx < qo_len ? qo_idx : qo_len - 1;
+    const uint32_t q_abs = kv_len - qo_len + q_local;
+    return (kv_idx <= q_abs) && (q_abs - kv_idx < uint32_t(params.mask_window));
+  })
+};
+"""
+
+
+def _owned_mask_jit_args(uri):
+    return (
+        uri,
+        torch.float16,  # dtype_q
+        torch.float16,  # dtype_kv
+        torch.float16,  # dtype_o
+        torch.int32,  # idtype
+        128,  # hidden_dim_qk
+        128,  # hidden_dim_vo
+        [],  # additional_tensor_names
+        [],  # additional_tensor_dtypes
+        ["mask_window", "sm_scale"],  # additional_scalar_names
+        ["double", "double"],  # additional_scalar_dtypes
+        "WindowOwnedMask",
+        variant_owned_window_decl,
+    )
+
+
+def test_batch_prefill_variant_owns_mask():
+    """A JIT variant that owns the full mask must get MaskMode::CUSTOM.
+
+    Without a mask tensor, ``causal=False`` selects MaskMode::kNone, under
+    which the FA2 kernel only evaluates ``LogitsMask`` on boundary KV tiles.
+    ``variant_owns_mask=True`` selects MaskMode::CUSTOM without a mask tensor
+    so every interior tile is masked as well. The sequences here are long
+    enough to have interior tiles for every CTA_TILE_KV configuration.
+    """
+    torch.manual_seed(42)
+    jit_args = _owned_mask_jit_args("batch_prefill_variant_owns_mask")
+
+    num_qo_heads = 8
+    num_kv_heads = 8
+    head_dim = 128
+    mask_window = 32.0
+    sm_scale = 1.0 / math.sqrt(head_dim)
+    lens = [(128, 2048), (64, 1024)]
+
+    qo_indptr_host = torch.tensor(
+        [0] + list(torch.tensor([q for q, _ in lens]).cumsum(0)), dtype=torch.int32
+    )
+    kv_indptr_host = torch.tensor(
+        [0] + list(torch.tensor([kv for _, kv in lens]).cumsum(0)), dtype=torch.int32
+    )
+    total_q = int(qo_indptr_host[-1])
+    total_kv = int(kv_indptr_host[-1])
+    q = torch.randn(total_q, num_qo_heads, head_dim, dtype=torch.float16, device="cuda")
+    k = torch.randn(
+        total_kv, num_kv_heads, head_dim, dtype=torch.float16, device="cuda"
+    )
+    v = torch.randn(
+        total_kv, num_kv_heads, head_dim, dtype=torch.float16, device="cuda"
+    )
+
+    def ref_output():
+        outs = []
+        for i, (qo_len, kv_len) in enumerate(lens):
+            qs = q[qo_indptr_host[i] : qo_indptr_host[i + 1]].float()
+            ks = k[kv_indptr_host[i] : kv_indptr_host[i + 1]].float()
+            vs = v[kv_indptr_host[i] : kv_indptr_host[i + 1]].float()
+            q_abs = torch.arange(kv_len - qo_len, kv_len, device="cuda").view(-1, 1)
+            kv_pos = torch.arange(kv_len, device="cuda").view(1, -1)
+            mask = (kv_pos <= q_abs) & (q_abs - kv_pos < mask_window)
+            scores = torch.einsum("qhd,khd->hqk", qs, ks) * sm_scale
+            scores = scores.masked_fill(~mask.unsqueeze(0), float("-inf"))
+            outs.append(torch.einsum("hqk,khd->qhd", torch.softmax(scores, dim=-1), vs))
+        return torch.cat(outs, dim=0)
+
+    o_ref = ref_output()
+    float_workspace_buffer = torch.empty(
+        128 * 1024 * 1024, dtype=torch.uint8, device="cuda"
+    )
+
+    def plan_ragged(wrapper):
+        wrapper.plan(
+            qo_indptr_host,
+            kv_indptr_host,
+            num_qo_heads,
+            num_kv_heads,
+            head_dim,
+            causal=False,
+            q_data_type=torch.float16,
+            kv_data_type=torch.float16,
+        )
+
+    wrapper = flashinfer.BatchPrefillWithRaggedKVCacheWrapper(
+        float_workspace_buffer,
+        kv_layout="NHD",
+        backend="fa2",
+        jit_args=jit_args,
+        variant_owns_mask=True,
+    )
+    plan_ragged(wrapper)
+    o = wrapper.run(q, k, v, mask_window, sm_scale)
+    torch.testing.assert_close(o.float(), o_ref, rtol=2e-2, atol=2e-2)
+
+    # Same variant without the flag: MaskMode::kNone skips LogitsMask on
+    # interior KV tiles, so the window must NOT be applied there.
+    wrapper_none = flashinfer.BatchPrefillWithRaggedKVCacheWrapper(
+        float_workspace_buffer,
+        kv_layout="NHD",
+        backend="fa2",
+        jit_args=jit_args,
+    )
+    plan_ragged(wrapper_none)
+    o_none = wrapper_none.run(q, k, v, mask_window, sm_scale)
+    assert (o_none.float() - o_ref).abs().max() > 1e-2, (
+        "MaskMode::kNone unexpectedly applied the variant mask on interior "
+        "tiles; variant_owns_mask would be redundant"
+    )
+
+    # Paged wrapper, page_size=1 identity table.
+    wrapper_paged = flashinfer.BatchPrefillWithPagedKVCacheWrapper(
+        float_workspace_buffer,
+        kv_layout="NHD",
+        backend="fa2",
+        jit_args=jit_args,
+        variant_owns_mask=True,
+    )
+    kv_indices_host = torch.arange(0, total_kv, dtype=torch.int32)
+    paged_kv_last_page_len_host = torch.full((len(lens),), 1, dtype=torch.int32)
+    wrapper_paged.plan(
+        qo_indptr_host,
+        kv_indptr_host,
+        kv_indices_host,
+        paged_kv_last_page_len_host,
+        num_qo_heads,
+        num_kv_heads,
+        head_dim,
+        1,
+        causal=False,
+        q_data_type=torch.float16,
+        kv_data_type=torch.float16,
+    )
+    o_paged = wrapper_paged.run(q, (k, v), mask_window, sm_scale)
+    torch.testing.assert_close(o_paged.float(), o_ref, rtol=2e-2, atol=2e-2)
+
+
+def test_variant_owns_mask_requires_jit_module():
+    float_workspace_buffer = torch.empty(
+        128 * 1024 * 1024, dtype=torch.uint8, device="cuda"
+    )
+    for cls in (
+        flashinfer.BatchPrefillWithPagedKVCacheWrapper,
+        flashinfer.BatchPrefillWithRaggedKVCacheWrapper,
+    ):
+        with pytest.raises(ValueError, match="variant_owns_mask requires"):
+            cls(
+                float_workspace_buffer,
+                kv_layout="NHD",
+                backend="fa2",
+                variant_owns_mask=True,
+            )
+        # Rejected before any JIT build: the SM90 batch prefill kernels
+        # return cudaErrorNotSupported under MaskMode.CUSTOM.
+        with pytest.raises(ValueError, match="only supported on the fa2 backend"):
+            cls(
+                float_workspace_buffer,
+                kv_layout="NHD",
+                backend="fa3",
+                variant_owns_mask=True,
+            )
+
+
+@pytest.mark.parametrize("paged", [True, False])
+def test_variant_owns_mask_rejects_multi_item_scoring(paged):
+    """prefix_len_ptr selects MULTIITEMSCORING, which would override CUSTOM."""
+    jit_args = _owned_mask_jit_args("batch_prefill_variant_owns_mask")
+    float_workspace_buffer = torch.empty(
+        128 * 1024 * 1024, dtype=torch.uint8, device="cuda"
+    )
+    qo_indptr = torch.tensor([0, 8], dtype=torch.int32)
+    kv_indptr = torch.tensor([0, 8], dtype=torch.int32)
+    prefix_len_ptr = torch.zeros(1, dtype=torch.uint32, device="cuda")
+    if paged:
+        wrapper = flashinfer.BatchPrefillWithPagedKVCacheWrapper(
+            float_workspace_buffer,
+            kv_layout="NHD",
+            backend="fa2",
+            jit_args=jit_args,
+            variant_owns_mask=True,
+        )
+        with pytest.raises(ValueError, match="incompatible"):
+            wrapper.plan(
+                qo_indptr,
+                kv_indptr,
+                torch.arange(0, 8, dtype=torch.int32),
+                torch.full((1,), 1, dtype=torch.int32),
+                8,
+                8,
+                128,
+                1,
+                causal=False,
+                q_data_type=torch.float16,
+                kv_data_type=torch.float16,
+                prefix_len_ptr=prefix_len_ptr,
+            )
+    else:
+        wrapper = flashinfer.BatchPrefillWithRaggedKVCacheWrapper(
+            float_workspace_buffer,
+            kv_layout="NHD",
+            backend="fa2",
+            jit_args=jit_args,
+            variant_owns_mask=True,
+        )
+        with pytest.raises(ValueError, match="incompatible"):
+            wrapper.plan(
+                qo_indptr,
+                kv_indptr,
+                8,
+                8,
+                128,
+                causal=False,
+                q_data_type=torch.float16,
+                kv_data_type=torch.float16,
+                prefix_len_ptr=prefix_len_ptr,
+            )
+
+
 def test_batch_prefill_sm90_flash_sigmoid():
     if not is_sm90a_supported(torch.device("cuda")):
         pytest.skip("SM90A is not supported")

--- a/tests/utils/test_jit_example.py
+++ b/tests/utils/test_jit_example.py
@@ -507,8 +507,8 @@ def test_batch_prefill_variant_owns_mask():
     so every interior tile is masked as well. The sequences here are long
     enough to have interior tiles for every CTA_TILE_KV configuration.
     """
-    if get_compute_capability(torch.device("cuda")) < (8, 0):
-        pytest.skip("variant_owns_mask FA2 JIT test is validated on SM80+.")
+    if get_compute_capability(torch.device("cuda")) < (7, 5):
+        pytest.skip("FA2 prefill JIT requires SM75 or newer.")
     torch.manual_seed(42)
     jit_args = _owned_mask_jit_args("batch_prefill_variant_owns_mask")
 
@@ -648,8 +648,8 @@ def test_variant_owns_mask_requires_jit_module():
 @pytest.mark.parametrize("paged", [True, False])
 def test_variant_owns_mask_rejects_multi_item_scoring(paged):
     """prefix_len_ptr selects MULTIITEMSCORING, which would override CUSTOM."""
-    if get_compute_capability(torch.device("cuda")) < (8, 0):
-        pytest.skip("variant_owns_mask FA2 JIT test is validated on SM80+.")
+    if get_compute_capability(torch.device("cuda")) < (7, 5):
+        pytest.skip("FA2 prefill JIT requires SM75 or newer.")
     jit_args = _owned_mask_jit_args("batch_prefill_variant_owns_mask")
     float_workspace_buffer = torch.empty(
         128 * 1024 * 1024, dtype=torch.uint8, device="cuda"


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

A custom JIT attention variant can compute the complete attention mask inside its `REGISTER_LOGITS_MASK` hook from compact side metadata (for example per-query ranges passed as additional tensors), without ever materializing a `custom_mask`/`packed_custom_mask` tensor.

The FA2 batch prefill kernel only evaluates `LogitsMask` on **every** KV tile under `MaskMode::kCustom`; under `kNone`/`kCausal` it is evaluated only on the causal/window boundary tiles:

```cpp
// include/flashinfer/attention/prefill.cuh
if (MASK_MODE == MaskMode::kCustom) {
  logits_mask<KTraits>(...);
} else {
  if (iter >= mask_iteration || iter < window_iteration) {
    logits_mask<KTraits>(...);
  }
}
```

Today the only way to select `MaskMode::kCustom` is to pass a mask tensor to `plan()`. For a mask-owning variant this defeats the point: the dense mask costs `O(qo_len * kv_len)` memory even though the kernel never needs its contents (e.g. 16384 query tokens against a 262144-token KV is a 4 GiB boolean mask, still 512 MiB packed), and a variant relying on `causal=False` alone silently loses its mask on interior KV tiles once sequences span more than one KV tile.

This PR adds an explicit `variant_owns_mask: bool = False` constructor flag to `BatchPrefillWithPagedKVCacheWrapper` and `BatchPrefillWithRaggedKVCacheWrapper` that selects `MaskMode::kCustom` independently of the mask buffer. The flag is fail-closed on three fronts:

- requires `jit_args` — the default attention variant dereferences the custom mask buffer under `MaskMode::kCustom`;
- rejected for any backend other than `fa2`, before the JIT module is built — the SM90 batch prefill kernels return `cudaErrorNotSupported` under `MaskMode::kCustom` (`include/flashinfer/attention/hopper/prefill_sm90.cuh`);
- `plan()` rejects `prefix_len_ptr` — multi-item scoring selects `MaskMode::MULTIITEMSCORING`, which would silently override `CUSTOM`.

No existing code path changes behavior when the flag is left at its default.

## 🔍 Related Issues

N/A

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.) — I ran the targeted tests below plus the neighboring JIT-wrapper regression test on SM80, not the full suite.

`tests/utils/test_jit_example.py::test_batch_prefill_variant_owns_mask` uses a variant that owns a sliding-window mask on sequences long enough to contain interior KV tiles for every `CTA_TILE_KV` configuration, and asserts on SM80 FA2:

- with `variant_owns_mask=True`, both the ragged and the paged wrapper match a dense reference (`torch.testing.assert_close`);
- the same variant **without** the flag (`MaskMode::kNone`) does not apply the mask on interior tiles, pinning the boundary-only behavior this flag exists to bypass.

`test_variant_owns_mask_requires_jit_module` checks the constructor rejections (no JIT module; non-fa2 backend, raised before any JIT build), and `test_variant_owns_mask_rejects_multi_item_scoring` checks the `plan()` rejection of `prefix_len_ptr`.

```bash
pytest tests/utils/test_jit_example.py::test_batch_prefill_variant_owns_mask \
       tests/utils/test_jit_example.py::test_variant_owns_mask_requires_jit_module \
       tests/utils/test_jit_example.py::test_variant_owns_mask_rejects_multi_item_scoring
# 4 passed (the multi-item-scoring rejection is parameterized over both wrappers)
pytest tests/utils/test_jit_example.py::test_batch_prefill_flash_sigmoid
# 1 passed (JIT wrapper path regression check)
```

## Reviewer Notes

The run-time change is a single condition in each wrapper's `run()`: `if self._custom_mask_buf is not None or self._variant_owns_mask:`. `plan()`'s module selection is untouched — its `use_custom_mask` argument only feeds `determine_attention_backend()`, which is not reached when a JIT module is supplied.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an option for custom FA2 attention variants to provide and manage their own masks during batch prefill.
  * Supported both paged and ragged KV-cache workflows.
  * Added validation for required JIT configuration and unsupported scoring or backend combinations.

* **Tests**
  * Added coverage for custom masking behavior, reference output matching, hardware compatibility, and invalid configuration handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

