### PR TITLE
feat(attention): support head dim 64 in TRTLLM ragged attention

### DIFF
--- a/flashinfer/prefill.py
+++ b/flashinfer/prefill.py
@@ -4992,13 +4992,17 @@ def trtllm_ragged_attention_deepseek(
         uses_spcompress, "uses_spcompress", query.device
     )
     is_dsr1 = query.shape[2] == 192 and key.shape[2] == 192 and value.shape[2] == 128
+    is_head_dim_64 = (
+        query.shape[2] == 64 and key.shape[2] == 64 and value.shape[2] == 64
+    )
     is_smaller_dimensions = (
         query.shape[2] == 128 and key.shape[2] == 128 and value.shape[2] == 128
     )
     is_glm5 = query.shape[2] == 256 and key.shape[2] == 256 and value.shape[2] == 256
-    assert is_dsr1 or is_smaller_dimensions or is_glm5, (
+    assert is_dsr1 or is_head_dim_64 or is_smaller_dimensions or is_glm5, (
         f"Unsupported head dimensions: query={query.shape[2]}, key={key.shape[2]}, value={value.shape[2]}. "
-        "Supported: (192, 192, 128) for DeepSeek-R1, (128, 128, 128), or (256, 256, 256) for GLM-5."
+        "Supported: (192, 192, 128) for DeepSeek-R1, (64, 64, 64), "
+        "(128, 128, 128), or (256, 256, 256) for GLM-5."
     )
 
     if enable_pdl is None:

--- a/tests/attention/test_trtllm_ragged_dit.py
+++ b/tests/attention/test_trtllm_ragged_dit.py
@@ -1,12 +1,14 @@
 """
 Tests for DiT (Diffusion Transformer) oriented ragged attention kernels.
 
-Covers three variants:
-1. Q/K/V all FP8 E4M3 (standard case)
-2. Q/K in BF16, V in FP8 E4M3 (DiT: BMM1 in BF16, BMM2 in FP8)
-3. BF16 Q/K/V quantized on GPU to SageAttention INT8/FP8, then run by attention
+Covers four variants:
+1. Q/K/V all BF16
+2. Q/K/V all FP8 E4M3 (standard case)
+3. Q/K in BF16, V in FP8 E4M3 (DiT: BMM1 in BF16, BMM2 in FP8)
+4. BF16 Q/K/V quantized on GPU to SageAttention INT8/FP8, then run by attention
 
-All tests run on SM100/SM103 only (Blackwell).
+Non-Sage tests run on SM10x targets (SM100/SM103/SM107).
+SageAttention INT8 tests require SM100.
 """
 
 import math
@@ -86,18 +88,93 @@ def _ragged_reference_bf16(
 
 
 # ---------------------------------------------------------------------------
-# Test 1: Q/K/V all FP8
+# Test 1: Q/K/V all BF16 at head_dim=64
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.skipif(
-    CC_MAJOR != 10, reason="DiT attention tests require SM100/SM103 (Blackwell)."
+    CC_MAJOR != 10, reason="DiT attention tests require an SM10x target."
+)
+@pytest.mark.parametrize("causal", [False, True])
+@pytest.mark.parametrize("skips_softmax", [False, True])
+def test_trtllm_ragged_dit_qkv_bf16_head_dim_64(
+    causal: bool,
+    skips_softmax: bool,
+):
+    torch.manual_seed(42)
+    device = GPU_DEVICE
+    batch_size = 2
+    num_heads = 8
+    head_dim = 64
+
+    q_lens = torch.tensor([256, 192], dtype=torch.int32, device=device)
+    kv_lens = torch.tensor([512, 384], dtype=torch.int32, device=device)
+    total_q = int(q_lens.sum())
+    total_kv = int(kv_lens.sum())
+
+    q = torch.randn(total_q, num_heads, head_dim, device=device, dtype=torch.bfloat16)
+    k = torch.randn(total_kv, num_heads, head_dim, device=device, dtype=torch.bfloat16)
+    v = torch.randn(total_kv, num_heads, head_dim, device=device, dtype=torch.bfloat16)
+
+    scale = 1.0 / math.sqrt(head_dim)
+    qo_indptr = torch.cat(
+        [torch.zeros(1, dtype=torch.int32, device=device), q_lens.cumsum(0).int()]
+    )
+    kv_indptr = torch.cat(
+        [torch.zeros(1, dtype=torch.int32, device=device), kv_lens.cumsum(0).int()]
+    )
+
+    out_trtllm = flashinfer.prefill.trtllm_ragged_attention_deepseek(
+        q,
+        k,
+        v,
+        _get_workspace(),
+        kv_lens,
+        int(q_lens.max()),
+        int(kv_lens.max()),
+        scale,
+        1.0,
+        -1,
+        batch_size,
+        -1,
+        qo_indptr,
+        kv_indptr,
+        False,
+        causal,
+        False,
+        skip_softmax_threshold_scale_factor=1e-30 if skips_softmax else None,
+    )
+
+    out_ref = _ragged_reference_bf16(
+        q,
+        k,
+        v,
+        q_lens,
+        kv_lens,
+        scale,
+        causal,
+    )
+    torch.testing.assert_close(
+        out_trtllm.float(),
+        out_ref.float(),
+        atol=1e-2,
+        rtol=1e-2,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 2: Q/K/V all FP8
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(
+    CC_MAJOR != 10, reason="DiT attention tests require an SM10x target."
 )
 @pytest.mark.parametrize("causal", [False])
 @pytest.mark.parametrize("batch_size", [1, 4])
 @pytest.mark.parametrize("s_qo,s_kv", [(512, 512), (256, 512)])
 @pytest.mark.parametrize("num_heads", [1, 8])
-@pytest.mark.parametrize("head_dim", [128])
+@pytest.mark.parametrize("head_dim", [64, 128])
 def test_trtllm_ragged_dit_qkv_fp8(
     causal: bool,
     batch_size: int,
@@ -177,18 +254,18 @@ def test_trtllm_ragged_dit_qkv_fp8(
 
 
 # ---------------------------------------------------------------------------
-# Test 2: Q/K in BF16, V in FP8 E4M3 (DiT mixed-dtype)
+# Test 3: Q/K in BF16, V in FP8 E4M3 (DiT mixed-dtype)
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.skipif(
-    CC_MAJOR != 10, reason="DiT attention tests require SM100/SM103 (Blackwell)."
+    CC_MAJOR != 10, reason="DiT attention tests require an SM10x target."
 )
 @pytest.mark.parametrize("causal", [False])
 @pytest.mark.parametrize("batch_size", [1, 4])
 @pytest.mark.parametrize("s_qo,s_kv", [(512, 512), (256, 512)])
 @pytest.mark.parametrize("num_heads", [1, 8])
-@pytest.mark.parametrize("head_dim", [128])
+@pytest.mark.parametrize("head_dim", [64, 128])
 def test_trtllm_ragged_dit_qk_bf16_v_fp8(
     causal: bool,
     batch_size: int,
@@ -269,7 +346,7 @@ def test_trtllm_ragged_dit_qk_bf16_v_fp8(
 
 
 # ---------------------------------------------------------------------------
-# Test 3: Q/K quantized to INT8, V to FP8 E4M3, with SageAttention block scaling
+# Test 4: Q/K quantized to INT8, V to FP8 E4M3, with SageAttention block scaling
 # ---------------------------------------------------------------------------
 
 
@@ -281,7 +358,7 @@ def test_trtllm_ragged_dit_qk_bf16_v_fp8(
 @pytest.mark.parametrize("batch_size", [1, 2])
 @pytest.mark.parametrize("s_qo,s_kv", [(256, 256), (1560, 1560), (512, 2048)])
 @pytest.mark.parametrize("num_heads", [1, 8])
-@pytest.mark.parametrize("head_dim", [128])
+@pytest.mark.parametrize("head_dim", [64, 128])
 @pytest.mark.parametrize("sage_blk_q", [1])
 @pytest.mark.parametrize("sage_blk_k", [4, 16])
 @pytest.mark.parametrize("smooth_k", [False, True])


### PR DESCRIPTION
## 📌 Description

This PR allows `trtllm_ragged_attention_deepseek` to accept symmetric
`(64, 64, 64)` Q/K/V head dimensions for non-paged `SeparateQkv` ragged
attention. This is needed by the vLLM-Omni LTX ragged-prefill path, which is
currently rejected by the Python wrapper before TRTLLM-GEN kernel selection.

It also:

- adds an all-BF16 head-dim-64 numerical regression test covering dense/causal
  masks and skip-softmax on/off;
- extends the existing FP8, BF16-QK/FP8-V, and SageAttention DiT test matrices
  to head dim 64; and
- documents the actual SM10x coverage of the non-Sage tests.

## 🔍 Related Issues

N/A

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

Local checks completed:

```text
git diff --check
python syntax checks for both changed Python files
ruff 0.14.10 check flashinfer/prefill.py tests/attention/test_trtllm_ragged_dit.py
ruff 0.14.10 format --check flashinfer/prefill.py tests/attention/test_trtllm_ragged_dit.py
pytest --collect-only -q tests/attention/test_trtllm_ragged_dit.py
```

The test file collects 135 cases. This PR adds 68 head-dim-64 cases.

GPU correctness remains blocked on publication of the ordinary H64
`SeparateQkv` cubins described below.

## Reviewer Notes

### Cubin dependency

The current public TRTLLM-GEN FMHA artifact contains 156
`H64 + SeparateQkv` records, but all of them are SageAttention variants. It
contains no ordinary H64 `SeparateQkv` cubins.

On an NVIDIA B300 (SM103), the dense BF16 regression reaches the launcher and
currently fails with:

```text
Missing TRTLLM-GEN kernel ragged attention: qkvLayout=0, maskType=0, kernelType=0, tileScheduler=1, ... headDimPerCtaV=64, headDimQk=64, headDimV=64, ... skipsSoftmax=0
```

The `cubin_publishing` FMHA export should use the existing TRTLLM-GEN exporter
and match the test surface:

- layout/head dim: non-paged `SeparateQkv`, QK/V head dim 64;
- BF16 Q/K/V/O: dense and causal, skip-softmax off and on;
- FP8 E4M3 Q/K/V with BF16 output: dense, skip-softmax off;
- BF16 Q/K with FP8 E4M3 V and BF16 output: dense, skip-softmax off; and
- SM10x package targets, including SM100/SM103/SM107.

The SageAttention INT8-QK/FP8-V H64 variants exercised by this PR are already
present in the current artifact. No TRTLLM-GEN source change is expected for
the added legal combinations.

Before marking this PR ready for review:

1. update the FMHA export configuration in `cubin_publishing` and run the
   existing exporter;
2. merge the publishing MR and have an administrator publish the regenerated
   artifact;
3. update `ArtifactPath.TRTLLM_GEN_FMHA` and its checksum in
   `flashinfer/artifacts.py`; and
4. run the authorized GPU CI matrix against the new artifact.
