### PR TITLE
fix(fmha): select CGA reduction for MLA H512 decode

### DIFF
--- a/include/flashinfer/trtllm/fmha/fmhaKernels.cuh
+++ b/include/flashinfer/trtllm/fmha/fmhaKernels.cuh
@@ -535,6 +535,13 @@ class TllmGenFmhaKernel {
     }
   }
 
+  bool hasCgaSmemReductionKernel(RunnerParams const& params,
+                                 SelectKernelParams selectKernelParams) const {
+    selectKernelParams.mMultiCtasKvMode = MultiCtasKvMode::CgaSmemReduction;
+    auto const hashId = hashFromRunnerParams(params, selectKernelParams).first;
+    return mKernelMetaMap.find(hashId) != mKernelMetaMap.end();
+  }
+
   // Compute the number of CTAs in X, Y and Z dimension and the cluster size in the X dimension.
   void computeCtaAndClusterConfig(CtaLaunchParams& ctaLaunchParams, RunnerParams const& params,
                                   KernelMeta const& kernelMeta,
@@ -669,17 +676,25 @@ class TllmGenFmhaKernel {
         selectKernelParams.mSelectNewKernel = true;
       }
 
+      // The P32 cubin inventory contains an H576/V512 CGA kernel for the split-V
+      // headDimPerCtaV=128 form. Let the first selection pass split V, then use CGA for the
+      // exact one-token decode shape when the matching dtype-specific cubin is registered.
+      bool const useMlaH512Cga = isDsv3MinLatencyMode && params.mMaxSeqLenQ == 1 &&
+                                 selectKernelParams.mNumTokensPerPage == 32 &&
+                                 selectKernelParams.mHeadDimPerCtaV == 128 &&
+                                 selectKernelParams.mTileSizeQ == 16 &&
+                                 hasCgaSmemReductionKernel(params, selectKernelParams);
+      bool const useCgaSmemReduction =
+          (!isDsv3MinLatencyMode && params.mHeadDimV < 512) || useMlaH512Cga;
+
       // Enable the CgaSmemReduction if the numCtasPerSeqKv <= 16 as the maximum cluster dimension
       // is 16. Only the swapsMmaAbForGeneration kernel supports the CgaSmemReduction for now.
-      // headDimV >= 512 is excluded: the current trtllm-gen cubin ships no SwapsMmaAb
-      // CgaSmemReduction kernels at headDimV >= 512 (covers both MLA headDimQk=576/V=512 and
-      // non-MLA H=512), and for tileSizeQ >= 32 the CGA variant also exceeds the device smem
-      // limit. This guard can be narrowed once trtllm-gen ships a cubin with the
-      // tileSizeQ>=32 + headDimPerCtaV>=512 skip predicate.
-      if (!isDsv3MinLatencyMode && numCtasPerSeqKv > 1 && numCtasPerSeqKv <= 16 &&
+      // Other headDimV >= 512 shapes remain excluded because the cubin inventory is incomplete,
+      // and tileSizeQ >= 32 CGA variants can exceed the device shared-memory limit.
+      if (useCgaSmemReduction && numCtasPerSeqKv > 1 && numCtasPerSeqKv <= 16 &&
           isSwapsMmaAbForGenerationKernel(selectKernelParams.mKernelType) &&
           isGmemReduction(selectKernelParams.mMultiCtasKvMode) &&
-          !selectKernelParams.mForceGmemReduction && params.mHeadDimV < 512) {
+          !selectKernelParams.mForceGmemReduction) {
         selectKernelParams.mMultiCtasKvMode = MultiCtasKvMode::CgaSmemReduction;
         // Need to select a different kernel.
         selectKernelParams.mSelectNewKernel = true;

--- a/tests/attention/test_trtllm_gen_mla.py
+++ b/tests/attention/test_trtllm_gen_mla.py
@@ -1264,6 +1264,77 @@ def test_trtllm_batch_decode_q1_mla():
     )
 
 
+def test_trtllm_batch_decode_q1_mla_uses_cga_kernel():
+    if get_compute_capability(torch.device("cuda")) != (10, 0):
+        pytest.skip("MLA H512 CGA kernel selection is specific to SM100")
+
+    device = "cuda:0"
+    batch_size = 1
+    num_heads = 128
+    page_size = 32
+    max_seq_len = 4096
+    head_dim_qk = 576
+    head_dim_v = 512
+    num_pages = max_seq_len // page_size
+
+    query = torch.randn(
+        batch_size,
+        1,
+        num_heads,
+        head_dim_qk,
+        dtype=torch.bfloat16,
+        device=device,
+    ).to(torch.float8_e4m3fn)
+    kv_cache = torch.randn(
+        num_pages,
+        1,
+        page_size,
+        head_dim_qk,
+        dtype=torch.bfloat16,
+        device=device,
+    ).to(torch.float8_e4m3fn)
+    block_tables = torch.arange(num_pages, dtype=torch.int32, device=device).unsqueeze(
+        0
+    )
+    seq_lens = torch.tensor([max_seq_len], dtype=torch.int32, device=device)
+    workspace_buffer = torch.empty(workspace_size, dtype=torch.int8, device=device)
+
+    def run_decode():
+        return flashinfer.decode.trtllm_batch_decode_with_kv_cache_mla(
+            query=query,
+            kv_cache=kv_cache,
+            workspace_buffer=workspace_buffer,
+            qk_nope_head_dim=128,
+            kv_lora_rank=head_dim_v,
+            qk_rope_head_dim=64,
+            block_tables=block_tables,
+            seq_lens=seq_lens,
+            max_seq_len=max_seq_len,
+            bmm1_scale=1.0 / (192**0.5),
+            bmm2_scale=1.0,
+            enable_pdl=False,
+            backend="trtllm-gen",
+        )
+
+    # Warm up JIT compilation so the profile contains only the runtime selection and launch.
+    run_decode()
+    torch.cuda.synchronize()
+    with torch.profiler.profile(
+        activities=[
+            torch.profiler.ProfilerActivity.CPU,
+            torch.profiler.ProfilerActivity.CUDA,
+        ]
+    ) as kernel_profile:
+        run_decode()
+        torch.cuda.synchronize()
+
+    fmha_kernel_names = {
+        event.name for event in kernel_profile.events() if event.name.startswith("fmha")
+    }
+    expected_kernel = "HQk576HV512HVPerCta128PagedKvDenseP32MultiCtasKvCga"
+    assert any(expected_kernel in name for name in fmha_kernel_names), fmha_kernel_names
+
+
 def test_trtllm_batch_decode_grouped_mla_fixed_q_batch_stride():
     trtllm_batch_decode_mla(
         MLALayerDimensions(deepseek_mla_dimensions, 8),


### PR DESCRIPTION
## 📌 Description

The TensorRT-LLM MLA generation path was selecting the global-memory reduction kernel for one-token H576/V512 paged decode even though FlashInfer ships a matching CGA shared-memory reduction cubin.

The selector currently excludes all `isDsv3MinLatencyMode` and `headDimV >= 512` shapes from CGA. This change narrowly enables CGA for the Q1, P32, split-V (`headDimPerCtaV=128`, `tileSizeQ=16`) MLA decode shape, and only when the exact dtype-specific CGA cubin hash is present in the registered kernel metadata. Existing occupancy fallback and exclusions for other H512 shapes remain unchanged.

Related TensorRT-LLM regression: https://github.com/NVIDIA/TensorRT-LLM/pull/18054

### B200 performance

Configuration: FP8 E4M3 Q/KV, BF16 output, batch 1, Q length 1, KV length 4096, 128 query heads, Hqk=576, Hv=512, page size 32.

| Selection | Kernel time avg | Kernel time median | Direct benchmark |
| --- | ---: | ---: | ---: |
| Gmem reduction | 12.0875 us | 12.032 us | 0.0137 ms |
| CGA Smem reduction | 11.4622 us | 11.456 us | 0.0130 ms |

The CGA selection improves average kernel time by 5.17% and median kernel time by 4.79% in the nsys traces.

Selected CGA kernel:

`fmhaSm100fKernel_QkvE4m3OBfloat16HQk576HV512HVPerCta128PagedKvDenseP32MultiCtasKvCgaVarSeqQ16Kv256StaticSwapsAbForGen`

Previous Gmem kernel:

`fmhaSm100fKernel_QkvE4m3OBfloat16HQk576HV512HVPerCta128PagedKvDenseP32MultiCtasKvVarSeqQ16Kv256StaticSwapsAbForGen`

## 🧪 Tests

- Added `test_trtllm_batch_decode_q1_mla_uses_cga_kernel`, which warms up the JIT, profiles the exact B200 regression shape, and asserts that the launched CUDA kernel is the CGA variant.
- `python3 -m pytest -q tests/attention/test_trtllm_gen_mla.py -k test_trtllm_batch_decode_q1_mla` (`2 passed`)
- `pre-commit run --files include/flashinfer/trtllm/fmha/fmhaKernels.cuh tests/attention/test_trtllm_gen_mla.py`
- B200 direct benchmark and nsys A/B profiling for the configuration above

## Reviewer Notes

The `mKernelMetaMap` lookup is intentional: it prevents the selector from requesting CGA for page-size, tile, or dtype variants whose cubin is not included in the installed artifact.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Enabled shared-memory reduction for additional eligible attention workloads when a compatible kernel is available.
  * Added support for select sub-512-value shapes and a specific DSV3 configuration.
  * Preserved existing safeguards for unsupported configurations and forced global-memory reduction.

* **Bug Fixes**
  * Added regression coverage to verify expected attention-kernel selection for supported FP8 decode workloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->