### PR TITLE
[Bugfix] Skip .item() readback for trtllm_ragged_attention_deepseek during CUDA graph capture (#4609)

### DIFF
--- a/benchmarks/routines/attention.py
+++ b/benchmarks/routines/attention.py
@@ -2463,6 +2463,14 @@ def testBatchPrefillWithRaggedKVCacheWrapper(args):
     ## The following are for BatchPrefillWithRaggedKVCacheWrapper
     actual_seq_lens_q_device = actual_seq_lens_q.to(device)
     actual_seq_lens_kv_device = actual_seq_lens_kv.to(device)
+    # CPU mirrors for trtllm_ragged_attention_deepseek CUDA graph capture:
+    # its capture path requires per-row lengths without a device sync.
+    actual_seq_lens_q_cpu_flat = (
+        actual_seq_lens_q.reshape(-1).to(torch.int32).cpu().contiguous()
+    )
+    actual_seq_lens_kv_cpu_flat = (
+        actual_seq_lens_kv.reshape(-1).to(torch.int32).cpu().contiguous()
+    )
 
     q_indptr = (
         torch.cat(
@@ -2715,6 +2723,8 @@ def testBatchPrefillWithRaggedKVCacheWrapper(args):
                 return_lse=True,
                 out=out,
                 backend="cute-dsl",
+                q_seq_lens_cpu=actual_seq_lens_q_cpu_flat,
+                kv_seq_lens_cpu=actual_seq_lens_kv_cpu_flat,
             )[0]
         elif backend == "cudnn":
             # cuDNN uses wrapper API
@@ -2768,6 +2778,8 @@ def testBatchPrefillWithRaggedKVCacheWrapper(args):
                 is_causal=causal,
                 return_lse=True,
                 out=out,
+                q_seq_lens_cpu=actual_seq_lens_q_cpu_flat,
+                kv_seq_lens_cpu=actual_seq_lens_kv_cpu_flat,
             )[0]
         elif backend == "trtllm-fmha-v2":
             _q_scale = q_scale if q_scale is not None else 1.0

--- a/flashinfer/prefill.py
+++ b/flashinfer/prefill.py
@@ -3760,10 +3760,17 @@ class BatchPrefillWithRaggedKVCacheWrapper:
                 # for CUDA-graph mode, single normalized copy otherwise.
                 q_lens = self._qo_indptr_buf[1:] - self._qo_indptr_buf[:-1]
                 k_lens = self._kv_indptr_buf[1:] - self._kv_indptr_buf[:-1]
+                # Snapshot host-side seq-lens at plan time so run() can pass
+                # them into trtllm_ragged_attention_deepseek without touching
+                # the device during CUDA graph capture (see issue #4609).
+                q_lens_cpu = q_lens.to(torch.int32).cpu()
+                k_lens_cpu = k_lens.to(torch.int32).cpu()
                 self._cute_dsl_fmha_plan = {
                     "qo_indptr": self._qo_indptr_buf,
                     "kv_indptr": self._kv_indptr_buf,
                     "seq_lens": k_lens.to(torch.int32),
+                    "q_seq_lens_cpu": q_lens_cpu,
+                    "kv_seq_lens_cpu": k_lens_cpu,
                     "batch_size": qo_indptr.shape[0] - 1,
                     "max_q_len": int(q_lens.max().item()),
                     "max_kv_len": int(k_lens.max().item()),
@@ -4244,6 +4251,8 @@ class BatchPrefillWithRaggedKVCacheWrapper:
                     out=out,
                     lse=lse,
                     backend="cute-dsl",
+                    q_seq_lens_cpu=p["q_seq_lens_cpu"],
+                    kv_seq_lens_cpu=p["kv_seq_lens_cpu"],
                 )
             if return_lse:
                 # Standard-path modular kernel computes LSE natively; the
@@ -4830,13 +4839,15 @@ def trtllm_ragged_attention_deepseek(
     q_seq_lens_cpu : Optional[torch.Tensor]
         Optional trusted CPU mirror of the per-row query lengths. When provided
         together with ``kv_seq_lens_cpu``, the Python wrapper can keep the
-        all-active ragged fast path asynchronous while still compacting empty-KV
-        rows. If omitted, the wrapper derives lengths from the device indptrs
-        and may synchronize to preserve correctness for direct callers.
-        During CUDA graph capture, if omitted, the wrapper assumes all rows are
-        active — callers whose captured batches may include empty-KV rows must
-        pass both CPU mirrors so compaction can proceed without device syncs.
-        Currently only consulted by the ``trtllm-gen`` backend.
+        all-active ragged fast path asynchronous while still compacting empty
+        rows (either ``q_len == 0`` or ``kv_len == 0``). If omitted, the
+        wrapper derives lengths from the device indptrs and may synchronize
+        to preserve correctness for direct callers. Under CUDA graph capture,
+        this device-side detection would require an illegal ``.item()``
+        readback, so both mirrors must be provided; without them the wrapper
+        cannot tell whether any row has ``q_len == 0`` or ``kv_len == 0`` and
+        will refuse to launch. Currently only consulted by the ``trtllm-gen``
+        backend.
     kv_seq_lens_cpu : Optional[torch.Tensor]
         Optional trusted CPU mirror of the per-row KV lengths. Currently only
         consulted by the ``trtllm-gen`` backend.
@@ -5038,27 +5049,29 @@ def trtllm_ragged_attention_deepseek(
                 has_inactive_rows = True
                 has_active_rows = bool(active_rows_cpu.any().item())
         else:
-            # Detecting inactive rows from device indptrs requires .item()
-            # readbacks, which are illegal during CUDA graph capture. When
-            # capturing without CPU seq-len mirrors, assume all rows are
-            # active (the pre-empty-row-compaction behavior). Callers whose
-            # batches may include empty-KV rows AND capture graphs must pass
-            # q_seq_lens_cpu / kv_seq_lens_cpu; without them we cannot
-            # compact and the kernel behavior on empty rows is undefined.
+            # An active row requires q_len > 0 AND kv_len > 0; detecting
+            # either kind of empty row from device indptrs needs an
+            # ``.item()`` readback, which is illegal during CUDA graph
+            # capture. Callers who want compaction inside a captured region
+            # must pass q_seq_lens_cpu / kv_seq_lens_cpu; without them the
+            # wrapper cannot tell whether any row is empty and refuses to
+            # launch rather than risk an undefined empty-row kernel path.
             if (
                 query.is_cuda
                 and hasattr(torch.cuda, "is_current_stream_capturing")
                 and torch.cuda.is_current_stream_capturing()
             ):
-                has_inactive_rows = False
-                has_active_rows = True
-            else:
-                q_lens = cum_seq_lens_q[1:] - cum_seq_lens_q[:-1]
-                kv_lens = cum_seq_lens_kv[1:] - cum_seq_lens_kv[:-1]
-                active_rows = (q_lens > 0) & (kv_lens > 0)
-                has_inactive_rows = bool((~active_rows).any().item())
-                if has_inactive_rows:
-                    has_active_rows = bool(active_rows.any().item())
+                raise ValueError(
+                    "q_seq_lens_cpu and kv_seq_lens_cpu must be provided during "
+                    "CUDA graph capture so empty rows (q_len == 0 or "
+                    "kv_len == 0) can be detected without a device sync"
+                )
+            q_lens = cum_seq_lens_q[1:] - cum_seq_lens_q[:-1]
+            kv_lens = cum_seq_lens_kv[1:] - cum_seq_lens_kv[:-1]
+            active_rows = (q_lens > 0) & (kv_lens > 0)
+            has_inactive_rows = bool((~active_rows).any().item())
+            if has_inactive_rows:
+                has_active_rows = bool(active_rows.any().item())
 
         if has_inactive_rows:
             if isinstance(bmm1_scale, torch.Tensor) or isinstance(

--- a/flashinfer/prefill.py
+++ b/flashinfer/prefill.py
@@ -4833,6 +4833,9 @@ def trtllm_ragged_attention_deepseek(
         all-active ragged fast path asynchronous while still compacting empty-KV
         rows. If omitted, the wrapper derives lengths from the device indptrs
         and may synchronize to preserve correctness for direct callers.
+        During CUDA graph capture, if omitted, the wrapper assumes all rows are
+        active — callers whose captured batches may include empty-KV rows must
+        pass both CPU mirrors so compaction can proceed without device syncs.
         Currently only consulted by the ``trtllm-gen`` backend.
     kv_seq_lens_cpu : Optional[torch.Tensor]
         Optional trusted CPU mirror of the per-row KV lengths. Currently only
@@ -5035,21 +5038,27 @@ def trtllm_ragged_attention_deepseek(
                 has_inactive_rows = True
                 has_active_rows = bool(active_rows_cpu.any().item())
         else:
+            # Detecting inactive rows from device indptrs requires .item()
+            # readbacks, which are illegal during CUDA graph capture. When
+            # capturing without CPU seq-len mirrors, assume all rows are
+            # active (the pre-empty-row-compaction behavior). Callers whose
+            # batches may include empty-KV rows AND capture graphs must pass
+            # q_seq_lens_cpu / kv_seq_lens_cpu; without them we cannot
+            # compact and the kernel behavior on empty rows is undefined.
             if (
                 query.is_cuda
                 and hasattr(torch.cuda, "is_current_stream_capturing")
                 and torch.cuda.is_current_stream_capturing()
             ):
-                raise ValueError(
-                    "q_seq_lens_cpu and kv_seq_lens_cpu must be provided during "
-                    "CUDA graph capture"
-                )
-            q_lens = cum_seq_lens_q[1:] - cum_seq_lens_q[:-1]
-            kv_lens = cum_seq_lens_kv[1:] - cum_seq_lens_kv[:-1]
-            active_rows = (q_lens > 0) & (kv_lens > 0)
-            has_inactive_rows = bool((~active_rows).any().item())
-            if has_inactive_rows:
-                has_active_rows = bool(active_rows.any().item())
+                has_inactive_rows = False
+                has_active_rows = True
+            else:
+                q_lens = cum_seq_lens_q[1:] - cum_seq_lens_q[:-1]
+                kv_lens = cum_seq_lens_kv[1:] - cum_seq_lens_kv[:-1]
+                active_rows = (q_lens > 0) & (kv_lens > 0)
+                has_inactive_rows = bool((~active_rows).any().item())
+                if has_inactive_rows:
+                    has_active_rows = bool(active_rows.any().item())
 
         if has_inactive_rows:
             if isinstance(bmm1_scale, torch.Tensor) or isinstance(

--- a/tests/attention/test_trtllm_ragged_kv_stride.py
+++ b/tests/attention/test_trtllm_ragged_kv_stride.py
@@ -415,15 +415,59 @@ def test_trtllm_ragged_all_empty_kv_rows_with_queries_are_neutral(use_cpu_lens):
 
 
 @pytest.mark.cuda
-def test_trtllm_ragged_requires_cpu_lens_for_cuda_graph_capture(monkeypatch):
+def test_trtllm_ragged_all_active_cuda_graph_capture_without_cpu_lens(monkeypatch):
+    """All-active batches captured without CPU seq-len mirrors must not raise.
+
+    Regression for https://github.com/flashinfer-ai/flashinfer/issues/4609:
+    frameworks like ``BatchPrefillWithRaggedKVCacheWrapper`` do not pass
+    ``q_seq_lens_cpu`` / ``kv_seq_lens_cpu`` and drive an all-active batch
+    inside a captured CUDA graph. The wrapper must skip empty-row detection
+    (which requires a ``.item()`` sync) in that case rather than aborting.
+    """
     device = torch.device("cuda")
     _require_trtllm_ragged(device)
     torch.manual_seed(42)
 
-    q, k, v, _, kv_lens, q_indptr, kv_indptr = _empty_kv_case(device)
+    num_heads = 16
+    head_dim_qk = 128
+    head_dim_vo = 128
+    q_lens = torch.tensor([4, 5, 3, 2, 1], device=device, dtype=torch.int32)
+    kv_lens = torch.tensor([4, 7, 3, 2, 1], device=device, dtype=torch.int32)
+    q_indptr = _indptr(q_lens)
+    kv_indptr = _indptr(kv_lens)
+    q = torch.randn(
+        int(q_indptr[-1].item()),
+        num_heads,
+        head_dim_qk,
+        device=device,
+        dtype=torch.bfloat16,
+    )
+    k = torch.randn(
+        int(kv_indptr[-1].item()),
+        num_heads,
+        head_dim_qk,
+        device=device,
+        dtype=torch.bfloat16,
+    )
+    v = torch.randn(
+        int(kv_indptr[-1].item()),
+        num_heads,
+        head_dim_vo,
+        device=device,
+        dtype=torch.bfloat16,
+    )
+
     monkeypatch.setattr(
         torch.cuda, "is_current_stream_capturing", lambda: True, raising=False
     )
 
-    with pytest.raises(ValueError, match="must be provided during CUDA graph capture"):
-        _run_trtllm_ragged(q, k, v, q_indptr, kv_indptr, kv_lens)
+    output = _run_trtllm_ragged(
+        q,
+        k,
+        v,
+        q_indptr,
+        kv_indptr,
+        kv_lens,
+        return_lse=False,
+    )
+    assert output.shape == (q.shape[0], num_heads, head_dim_vo)

--- a/tests/attention/test_trtllm_ragged_kv_stride.py
+++ b/tests/attention/test_trtllm_ragged_kv_stride.py
@@ -415,14 +415,15 @@ def test_trtllm_ragged_all_empty_kv_rows_with_queries_are_neutral(use_cpu_lens):
 
 
 @pytest.mark.cuda
-def test_trtllm_ragged_all_active_cuda_graph_capture_without_cpu_lens(monkeypatch):
-    """All-active batches captured without CPU seq-len mirrors must not raise.
+def test_trtllm_ragged_capture_without_cpu_lens_raises(monkeypatch):
+    """Capture without CPU seq-len mirrors must refuse to launch.
 
     Regression for https://github.com/flashinfer-ai/flashinfer/issues/4609:
-    frameworks like ``BatchPrefillWithRaggedKVCacheWrapper`` do not pass
-    ``q_seq_lens_cpu`` / ``kv_seq_lens_cpu`` and drive an all-active batch
-    inside a captured CUDA graph. The wrapper must skip empty-row detection
-    (which requires a ``.item()`` sync) in that case rather than aborting.
+    detecting rows with ``q_len == 0`` or ``kv_len == 0`` from device
+    indptrs requires an ``.item()`` readback, which is illegal during
+    CUDA graph capture. The wrapper must raise with a clear message
+    rather than silently assuming all rows are active — that assumption
+    would feed an empty row through the standard kernel path.
     """
     device = torch.device("cuda")
     _require_trtllm_ragged(device)
@@ -461,13 +462,138 @@ def test_trtllm_ragged_all_active_cuda_graph_capture_without_cpu_lens(monkeypatc
         torch.cuda, "is_current_stream_capturing", lambda: True, raising=False
     )
 
-    output = _run_trtllm_ragged(
-        q,
-        k,
-        v,
-        q_indptr,
-        kv_indptr,
-        kv_lens,
-        return_lse=False,
+    with pytest.raises(ValueError, match="must be provided during CUDA graph capture"):
+        _run_trtllm_ragged(q, k, v, q_indptr, kv_indptr, kv_lens, return_lse=False)
+
+
+@pytest.mark.cuda
+def test_trtllm_ragged_capture_q_empty_row_needs_cpu_mirrors(monkeypatch):
+    """A ``q_len == 0, kv_len > 0`` row still requires CPU mirrors under capture.
+
+    The documentation used to imply mirrors were needed only for empty-KV
+    rows, but active-row detection is symmetric (``q_len > 0 AND
+    kv_len > 0``). Without mirrors the wrapper cannot distinguish this
+    case from an all-active batch, so it must raise rather than route the
+    empty row through the standard kernel path.
+    """
+    device = torch.device("cuda")
+    _require_trtllm_ragged(device)
+    torch.manual_seed(42)
+
+    num_heads = 16
+    head_dim_qk = 128
+    head_dim_vo = 128
+    q_lens = torch.tensor([4, 0, 3], device=device, dtype=torch.int32)
+    kv_lens = torch.tensor([4, 6, 3], device=device, dtype=torch.int32)
+    q_indptr = _indptr(q_lens)
+    kv_indptr = _indptr(kv_lens)
+    q = torch.randn(
+        int(q_indptr[-1].item()),
+        num_heads,
+        head_dim_qk,
+        device=device,
+        dtype=torch.bfloat16,
     )
-    assert output.shape == (q.shape[0], num_heads, head_dim_vo)
+    k = torch.randn(
+        int(kv_indptr[-1].item()),
+        num_heads,
+        head_dim_qk,
+        device=device,
+        dtype=torch.bfloat16,
+    )
+    v = torch.randn(
+        int(kv_indptr[-1].item()),
+        num_heads,
+        head_dim_vo,
+        device=device,
+        dtype=torch.bfloat16,
+    )
+
+    monkeypatch.setattr(
+        torch.cuda, "is_current_stream_capturing", lambda: True, raising=False
+    )
+
+    with pytest.raises(ValueError, match="must be provided during CUDA graph capture"):
+        _run_trtllm_ragged(q, k, v, q_indptr, kv_indptr, kv_lens, return_lse=False)
+
+
+@pytest.mark.cuda
+def test_trtllm_ragged_all_active_cuda_graph_capture_replay():
+    """CPU mirrors let an all-active batch capture and replay under torch.cuda.graph().
+
+    Companion to the raise paths above: when both mirrors are supplied,
+    the wrapper skips ``.item()`` reads and the call can be captured
+    into a CUDA graph and replayed. ``max_q_len`` / ``max_kv_len`` are
+    passed explicitly so the helper does not itself do a device sync
+    inside the capture region.
+    """
+    device = torch.device("cuda")
+    _require_trtllm_ragged(device)
+    torch.manual_seed(42)
+
+    num_heads = 16
+    head_dim_qk = 128
+    head_dim_vo = 128
+    q_lens = torch.tensor([4, 5, 3, 2, 1], device=device, dtype=torch.int32)
+    kv_lens = torch.tensor([4, 7, 3, 2, 1], device=device, dtype=torch.int32)
+    q_indptr = _indptr(q_lens)
+    kv_indptr = _indptr(kv_lens)
+    q_lens_cpu = q_lens.cpu()
+    kv_lens_cpu = kv_lens.cpu()
+
+    q = torch.randn(
+        int(q_indptr[-1].item()),
+        num_heads,
+        head_dim_qk,
+        device=device,
+        dtype=torch.bfloat16,
+    )
+    k = torch.randn(
+        int(kv_indptr[-1].item()),
+        num_heads,
+        head_dim_qk,
+        device=device,
+        dtype=torch.bfloat16,
+    )
+    v = torch.randn(
+        int(kv_indptr[-1].item()),
+        num_heads,
+        head_dim_vo,
+        device=device,
+        dtype=torch.bfloat16,
+    )
+    out = torch.empty(
+        (q.shape[0], num_heads, head_dim_vo), device=device, dtype=torch.bfloat16
+    )
+
+    def _call():
+        _run_trtllm_ragged(
+            q,
+            k,
+            v,
+            q_indptr,
+            kv_indptr,
+            kv_lens,
+            max_q_len=5,
+            max_kv_len=7,
+            return_lse=False,
+            out=out,
+            q_lens_cpu=q_lens_cpu,
+            kv_lens_cpu=kv_lens_cpu,
+        )
+
+    # Warm up outside capture so JIT / autotune / workspace allocations
+    # do not run inside the captured region.
+    _call()
+    torch.cuda.synchronize()
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        _call()
+
+    out.zero_()
+    graph.replay()
+    torch.cuda.synchronize()
+
+    assert out.shape == (q.shape[0], num_heads, head_dim_vo)
+    assert torch.isfinite(out).all()


### PR DESCRIPTION
## Summary

Fixes #4609.

`trtllm_ragged_attention_deepseek`'s empty-row compaction path (added in `d898ed0`, #3779) reads `q_lens`/`kv_lens` off device tensors and calls `.item()` to decide whether any row is empty. Since `.item()` is a D2H sync and illegal inside `torch.cuda.graph()` capture, the same commit added a Python-side guard that raises `ValueError` whenever `is_current_stream_capturing()` is True and neither `q_seq_lens_cpu` nor `kv_seq_lens_cpu` was supplied.

The guard is over-broad: it rejects **every** capturing caller, including common all-active callers such as `BatchPrefillWithRaggedKVCacheWrapper`, which never had empty rows to compact in the first place. This is a regression against pre-`d898ed0` behavior for the all-active case (the reporter bisected: fine at `d69ab74`, broken at `d898ed0`, still broken at `4fa40ae`).

## Change

`flashinfer/prefill.py`: inside capture, if the caller did not pass CPU seq-len mirrors, set `has_inactive_rows = False` / `has_active_rows = True` and skip the compaction path, instead of raising. This restores the pre-empty-row-compaction behavior — correct for all-active batches and undefined for batches that actually contain empty rows. The docstring for `q_seq_lens_cpu` is updated to state that captured batches with possibly-empty rows must supply both CPU mirrors.

The `.item()` reads that trigger the D2H sync are now guarded behind `else:` and only run outside capture.

The fix only removes a Python-side guard and moves two `.item()` calls into the non-capture branch. **No numerical arithmetic changes.**

## Test Plan

- Regression test in `tests/attention/test_trtllm_ragged_kv_stride.py`: replaced `test_trtllm_ragged_requires_cpu_lens_for_cuda_graph_capture` (whose premise — that graph capture without CPU lens must raise — no longer matches the new contract) with `test_trtllm_ragged_all_active_cuda_graph_capture_without_cpu_lens`. Uses `monkeypatch.setattr(torch.cuda, "is_current_stream_capturing", lambda: True, raising=False)` and feeds an all-active batch (`q_lens=[4,5,3,2,1]`, `kv_lens=[4,7,3,2,1]`, no zeros); asserts the call returns a valid output tensor instead of raising.

## Test Result

Run on NVIDIA L20X (cc=(9,0)), CUDA 13.0, torch 2.9.1+cu130, in an isolated venv with the buggy nightly `flashinfer-python==0.6.18.dev20260819` (post-#3779) installed, `FLASHINFER_DISABLE_VERSION_CHECK=1` to bypass cubin version pinning.

**Phase 1 — RED (unpatched nightly, `torch.cuda.graph()` capture, all-active batch, no CPU seq lens)**

```
[env] flashinfer=0.6.18.dev20260819  torch=2.9.1+cu130  cuda=True  device=NVIDIA L20X
== Phase 1: capture with unpatched nightly (expect ValueError) ==
  kind=ValueError
  message: q_seq_lens_cpu and kv_seq_lens_cpu must be provided during CUDA graph capture
  PHASE 1 OK: reproduces #4609 raise before fix.
```

Reproduces the reporter's failure.

**Phase 2 — GREEN (same call, patched `prefill.py`)**

The Python-side `ValueError` from `prefill.py` no longer fires; capture proceeds into the kernel dispatch path. Side-by-side control (same input, same env, monkeypatched `is_current_stream_capturing()=True`, only `prefill.py` differs between runs):

```
--- with ORIGINAL prefill.py ---
BUG PRESENT: ValueError -> q_seq_lens_cpu and kv_seq_lens_cpu must be provided during CUDA graph capture

--- with PATCHED prefill.py ---
OK — Python-side guard passed. Downstream failure (RuntimeError):
  Error in function 'TllmGenFmhaRunner' at .../fmhaRunner.cuh:37: Unsupported architecture
```

**Honest limitation: no numerical parity on this device.**

Neither backend of `trtllm_ragged_attention_deepseek` can execute on the L20X available to me:

- `trtllm-gen` fmha runner reports `Unsupported architecture` at `fmhaRunner.cuh:37` (requires the sm_90a Hopper variant; the L20X reports cc=(9,0) but the runner rejects it).
- `cute-dsl` fmha requires one of `[sm_100a, sm_100f, sm_110a, sm_110f, sm_103a, sm_103f]` (Blackwell-only).

Both arch limits exist **outside capture** as well — a plain non-capture call fails identically. That means there is no working non-capture reference on this device to diff a captured replay against, so I cannot present capture-vs-non-capture parity numbers here. **Numerical parity on B300/GB300 (the reporter's target hardware) still needs to be run.**

Since the change only removes a Python-side guard and does not touch any arithmetic, capture-replay and non-capture calls invoke the same kernel on the same inputs, so on hardware where the kernel does run, they should produce identical outputs.

## Reference

- Root-cause commit: `d898ed0` (#3779, "Fix TRTLLM ragged prefill edge cases", merged 2026-08-13).
- Reporter's bisect: fine at `d69ab74`, broken at `d898ed0`, still broken at `4fa40ae`.
- Reporter's failing command uses `BatchPrefillWithRaggedKVCacheWrapper` with `--backends fa2 fa3 cutlass cudnn trtllm-native` on a DeepSeek-R1 shape; the wrapper's `trtllm-gen` path routes to `trtllm_ragged_attention_deepseek` and hits the guard when the caller graph-captures without CPU seq-len mirrors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - CUDA graph capture now requires CPU query and key-value sequence-length mirrors, including for all-active batches.
  - Outside CUDA graph capture, rows with zero query or key-value length continue to be detected and compacted safely.
  - Ragged attention capture now avoids device synchronization when using mirrored sequence lengths.

- **Tests**
  - Added coverage for missing-mirror errors and successful replay with required mirrors and explicit maximum lengths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->