### PR TITLE
ci: scope CUTLASS DSL pin to images

### DIFF
--- a/.github/workflows/release-ci-docker.yml
+++ b/.github/workflows/release-ci-docker.yml
@@ -7,7 +7,7 @@ on:
       - main
     paths:
       - '.python-version'
-      - 'build_utils.py'
+      - 'ci/image_dependencies.py'
       - 'ci/validate_cuda_versions.py'
       - 'docker/**'
       - 'ci/cuda-versions.json'
@@ -18,7 +18,7 @@ on:
       - main
     paths:
       - '.python-version'
-      - 'build_utils.py'
+      - 'ci/image_dependencies.py'
       - 'ci/validate_cuda_versions.py'
       - 'docker/**'
       - 'ci/cuda-versions.json'
@@ -161,7 +161,7 @@ jobs:
           git fetch --no-tags --depth=1 origin main
           if git diff --quiet "${EXPECTED_SHA}" "$(git rev-parse FETCH_HEAD)" -- \
             .python-version \
-            build_utils.py \
+            ci/image_dependencies.py \
             docker \
             ci/cuda-versions.json \
             .github/workflows/release-ci-docker.yml \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,8 @@ on:
       - 'build_utils.py'
       - 'ci/cuda-versions.json'
       - 'ci/validate_cuda_versions.py'
+      - 'flashinfer-cubin/build_backend.py'
+      - 'flashinfer-jit-cache/build_backend.py'
       - 'scripts/build_flashinfer_jit_cache_whl.sh'
 
 jobs:

--- a/build_utils.py
+++ b/build_utils.py
@@ -16,34 +16,9 @@ limitations under the License.
 
 """Shared build utilities for flashinfer packages."""
 
-import json
-import os
 import subprocess
 from pathlib import Path
 from typing import Optional
-
-
-CI_CONFIG_FILE = Path(__file__).parent / "ci" / "cuda-versions.json"
-
-
-def get_build_dependency_requirements(
-    cuda_major: Optional[str] = None,
-) -> list[str]:
-    """Return exact build dependencies selected by the shared CI policy."""
-    if cuda_major is None:
-        cuda_major = os.environ.get("CUDA_MAJOR")
-
-    with CI_CONFIG_FILE.open() as config_file:
-        config = json.load(config_file)
-
-    requirements = []
-    for package, dependency in config["build_dependencies"].items():
-        extras = dependency.get("cuda_major_extras", {}).get(cuda_major, [])
-        package_spec = package
-        if extras:
-            package_spec += f"[{','.join(extras)}]"
-        requirements.append(f"{package_spec}=={dependency['version']}")
-    return requirements
 
 
 def get_git_version(cwd: Optional[Path] = None) -> str:

--- a/ci/cuda-versions.json
+++ b/ci/cuda-versions.json
@@ -1,5 +1,5 @@
 {
-  "build_dependencies": {
+  "ci_image_dependencies": {
     "nvidia-cutlass-dsl": {
       "version": "4.7.0",
       "cuda_major_extras": {

--- a/ci/image_dependencies.py
+++ b/ci/image_dependencies.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""Resolve exact Python dependencies installed in FlashInfer CI images."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Any
+
+
+CONFIG_FILE = Path(__file__).with_name("cuda-versions.json")
+
+
+def get_ci_image_dependency_requirements(
+    cuda_major: str, config: dict[str, Any]
+) -> list[str]:
+    """Return exact CI image requirements for a CUDA major version."""
+    requirements = []
+    for package, dependency in config["ci_image_dependencies"].items():
+        extras = dependency.get("cuda_major_extras", {}).get(cuda_major, [])
+        package_spec = package
+        if extras:
+            package_spec += f"[{','.join(extras)}]"
+        requirements.append(f"{package_spec}=={dependency['version']}")
+    return requirements
+
+
+def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("cuda_major", help="CUDA major version, such as 12 or 13")
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Print one requirement per line for shell consumers."""
+    args = _parse_args(argv)
+    if not args.cuda_major.isdigit():
+        raise SystemExit(f"ERROR: invalid CUDA major version: {args.cuda_major!r}")
+
+    config = json.loads(CONFIG_FILE.read_text())
+    print(*get_ci_image_dependency_requirements(args.cuda_major, config), sep="\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ci/validate_cuda_versions.py
+++ b/ci/validate_cuda_versions.py
@@ -17,6 +17,10 @@ PYTORCH_INDEX_PATTERN = re.compile(r"^(?:nightly/)?cu[0-9]+$")
 IMAGE_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._/-]*:[A-Za-z0-9_][A-Za-z0-9._-]*$")
 CUDNN_PATTERN = re.compile(r"^[0-9]+(?:\.[0-9]+){3}$")
 ARCH_LIST_PATTERN = re.compile(r"^[0-9]+\.[0-9]+[a-z]?(?: [0-9]+\.[0-9]+[a-z]?)*$")
+PACKAGE_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
+PACKAGE_VERSION_PATTERN = re.compile(r"^[0-9]+(?:\.[0-9]+)+(?:[A-Za-z0-9.+-]*)?$")
+CUDA_MAJOR_PATTERN = re.compile(r"^[0-9]+$")
+EXTRA_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
 
 
 class ConfigError(ValueError):
@@ -45,6 +49,43 @@ def _entries(config: dict[str, Any], section: str) -> list[dict[str, Any]]:
     return [
         _mapping(entry, f"{section}[{index}]") for index, entry in enumerate(entries)
     ]
+
+
+def _validate_ci_image_dependencies(config: dict[str, Any]) -> None:
+    dependencies = _mapping(
+        config.get("ci_image_dependencies"), "ci_image_dependencies"
+    )
+    if not dependencies:
+        raise ConfigError("ci_image_dependencies must not be empty")
+
+    for package, value in dependencies.items():
+        context = f"ci_image_dependencies.{package}"
+        if not isinstance(package, str) or PACKAGE_PATTERN.fullmatch(package) is None:
+            raise ConfigError(f"invalid CI image dependency name: {package!r}")
+        dependency = _mapping(value, context)
+        _string(dependency, "version", context, PACKAGE_VERSION_PATTERN)
+        cuda_extras = _mapping(
+            dependency.get("cuda_major_extras", {}),
+            f"{context}.cuda_major_extras",
+        )
+        for cuda_major, extras in cuda_extras.items():
+            extras_context = f"{context}.cuda_major_extras.{cuda_major}"
+            if (
+                not isinstance(cuda_major, str)
+                or CUDA_MAJOR_PATTERN.fullmatch(cuda_major) is None
+            ):
+                raise ConfigError(f"invalid CUDA major key: {cuda_major!r}")
+            if not isinstance(extras, list) or not extras:
+                raise ConfigError(f"{extras_context} must be a non-empty array")
+            if any(
+                not isinstance(extra, str) or EXTRA_PATTERN.fullmatch(extra) is None
+                for extra in extras
+            ):
+                raise ConfigError(
+                    f"{extras_context} contains invalid extras: {extras!r}"
+                )
+            if len(extras) != len(set(extras)):
+                raise ConfigError(f"{extras_context} contains duplicate extras")
 
 
 def _validate_identity(entry: dict[str, Any], context: str) -> tuple[str, str, str]:
@@ -105,7 +146,7 @@ def _validate_devcontainer(
 def validate_cuda_config(config: Any, repo_root: Path) -> None:
     """Validate matrix syntax, safe values, and cross-file consistency."""
     config = _mapping(config, "CUDA configuration")
-    _mapping(config.get("build_dependencies"), "build_dependencies")
+    _validate_ci_image_dependencies(config)
     runtime_entries = _entries(config, "runtime")
     jit_entries = _entries(config, "jit_cache")
 

--- a/docker/Dockerfile.ci
+++ b/docker/Dockerfile.ci
@@ -30,9 +30,10 @@ ENV TRITON_PTXAS_PATH="/usr/local/cuda/bin/ptxas"
 ENV FLASHINFER_PYTORCH_INDEX="${PYTORCH_INDEX}"
 ENV FLASHINFER_CUDNN_VERSION="${CUDNN_VERSION}"
 
+# Keep exact CI image-only dependency policy separate from package build hooks.
 COPY requirements.txt /install/requirements.txt
-COPY build_utils.py /install/build_utils.py
-COPY ci/cuda-versions.json /install/ci/cuda-versions.json
+COPY ci/cuda-versions.json /install/cuda-versions.json
+COPY ci/image_dependencies.py /install/image_dependencies.py
 COPY docker/install/install_python_packages.sh /install/install_python_packages.sh
 RUN bash /install/install_python_packages.sh "${PYTORCH_INDEX}" "${CUDNN_VERSION}"
 

--- a/docker/install/install_python_packages.sh
+++ b/docker/install/install_python_packages.sh
@@ -37,14 +37,12 @@ CUDA_TAG="${PYTORCH_INDEX##*/}"  # nightly/cu134 -> cu134
 CUDA_MAJOR="${CUDA_TAG:2:2}"     # cu129 -> 12, cu134 -> 13
 CUDA_MINOR="${CUDA_TAG:4}"       # cu129 -> 9, cu134 -> 4
 PYTORCH_INDEX_URL="https://download.pytorch.org/whl/${PYTORCH_INDEX}"
-BUILD_DEPENDENCY_OUTPUT="$(
-  PYTHONPATH=/install python3 -c \
-    'import sys; from build_utils import get_build_dependency_requirements; print(*get_build_dependency_requirements(sys.argv[1]), sep="\n")' \
-    "${CUDA_MAJOR}"
+CI_IMAGE_DEPENDENCY_OUTPUT="$(
+  python3 /install/image_dependencies.py "${CUDA_MAJOR}"
 )"
-BUILD_DEPENDENCIES=()
-if [[ -n "${BUILD_DEPENDENCY_OUTPUT}" ]]; then
-  mapfile -t BUILD_DEPENDENCIES <<< "${BUILD_DEPENDENCY_OUTPUT}"
+CI_IMAGE_DEPENDENCIES=()
+if [[ -n "${CI_IMAGE_DEPENDENCY_OUTPUT}" ]]; then
+  mapfile -t CI_IMAGE_DEPENDENCIES <<< "${CI_IMAGE_DEPENDENCY_OUTPUT}"
 fi
 
 # Install torch with specific CUDA version first, followed by others in requirements.txt, and then others.
@@ -85,7 +83,7 @@ pip3 install \
   responses pytest scipy build wheel \
   "${CUDA_PYTHON}" \
   "${NVSHMEM4PY}" \
-  "${BUILD_DEPENDENCIES[@]}"
+  "${CI_IMAGE_DEPENDENCIES[@]}"
 
 # Torch 2.13's cu129/cu130 wheels exact-pin cuDNN 9.20, but current FlashInfer
 # uses cuDNN 9.21-9.24 APIs and 9.20 has a known incomplete sublibrary set.

--- a/docker/test_ci_image.py
+++ b/docker/test_ci_image.py
@@ -6,12 +6,14 @@ from __future__ import annotations
 import argparse
 import importlib
 import importlib.metadata
+import json
 import os
 import platform
 import re
 import shutil
 import subprocess
 from collections.abc import Sequence
+from pathlib import Path
 from typing import NoReturn
 
 
@@ -55,6 +57,20 @@ def _expected_cudnn_backend(version: str) -> int:
     except (TypeError, ValueError):
         _fail(f"invalid cuDNN package version: {version}")
     return major * 10000 + minor * 100 + patch
+
+
+def _expected_ci_image_dependencies(
+    config_path: Path = Path("/install/cuda-versions.json"),
+) -> dict[str, str]:
+    try:
+        config = json.loads(config_path.read_text())
+        dependencies = config["ci_image_dependencies"]
+        return {
+            package: dependency["version"]
+            for package, dependency in dependencies.items()
+        }
+    except (OSError, KeyError, TypeError, json.JSONDecodeError) as error:
+        _fail(f"could not read CI image dependency policy: {error}")
 
 
 def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
@@ -115,15 +131,24 @@ def main(argv: Sequence[str] | None = None) -> int:
     if actual_backend != expected_backend:
         _fail(f"cuDNN backend is {actual_backend}; expected {expected_backend}")
 
+    expected_ci_dependencies = _expected_ci_image_dependencies()
+    for distribution, expected_version in expected_ci_dependencies.items():
+        actual_version = importlib.metadata.version(distribution)
+        if actual_version != expected_version:
+            _fail(
+                f"CI image dependency {distribution} is {actual_version}; "
+                f"expected {expected_version}"
+            )
+
     distributions = (
         "apache-tvm-ffi",
         "cuda-python",
         cudnn_package,
         "nvidia-cudnn-frontend",
-        "nvidia-cutlass-dsl",
+        *expected_ci_dependencies,
         "torch",
     )
-    for distribution in distributions:
+    for distribution in dict.fromkeys(distributions):
         print(f"{distribution}=={importlib.metadata.version(distribution)}")
     print(f"architecture={actual_machine}")
     print(f"cuda={torch.version.cuda}")

--- a/flashinfer-cubin/build_backend.py
+++ b/flashinfer-cubin/build_backend.py
@@ -10,7 +10,7 @@ from setuptools import build_meta as _orig
 # Add parent directory to path to import artifacts module
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
-from build_utils import get_build_dependency_requirements, get_git_version
+from build_utils import get_git_version
 
 # Skip version check when building flashinfer-cubin package
 os.environ["FLASHINFER_DISABLE_VERSION_CHECK"] = "1"
@@ -107,21 +107,11 @@ def build_editable(wheel_directory, config_settings=None, metadata_directory=Non
     return _orig.build_editable(wheel_directory, config_settings, metadata_directory)
 
 
-def get_requires_for_build_wheel(config_settings=None):
-    """Install configured dependencies in the isolated wheel build env."""
-    return [
-        *_orig.get_requires_for_build_wheel(config_settings),
-        *get_build_dependency_requirements(),
-    ]
-
-
-def get_requires_for_build_editable(config_settings=None):
-    """Install configured dependencies in the isolated editable build env."""
-    get_requires = getattr(_orig, "get_requires_for_build_editable", None)
-    requirements = [] if get_requires is None else get_requires(config_settings)
-    return [*requirements, *get_build_dependency_requirements()]
-
-
-# Pass through hooks that do not need additional build dependencies.
+# This backend only downloads precompiled artifacts; it does not compile CuTe
+# DSL kernels. Pass through the standard setuptools dependency hooks unchanged.
+get_requires_for_build_wheel = _orig.get_requires_for_build_wheel
+get_requires_for_build_editable = getattr(
+    _orig, "get_requires_for_build_editable", None
+)
 prepare_metadata_for_build_wheel = _orig.prepare_metadata_for_build_wheel
 prepare_metadata_for_build_editable = _orig.prepare_metadata_for_build_editable

--- a/flashinfer-jit-cache/build_backend.py
+++ b/flashinfer-jit-cache/build_backend.py
@@ -24,7 +24,7 @@ from wheel.bdist_wheel import bdist_wheel
 # Add parent directory to path to import flashinfer modules
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
-from build_utils import get_build_dependency_requirements, get_git_version
+from build_utils import get_git_version
 
 # Skip version check when building flashinfer-jit-cache package
 os.environ["FLASHINFER_DISABLE_VERSION_CHECK"] = "1"
@@ -253,16 +253,11 @@ def prepare_metadata_for_build_editable(metadata_directory, config_settings=None
         )
 
 
-def get_requires_for_build_wheel(config_settings=None):
-    """Install configured dependencies in the isolated wheel build env."""
-    return [
-        *_orig.get_requires_for_build_wheel(config_settings),
-        *get_build_dependency_requirements(),
-    ]
-
-
-def get_requires_for_build_editable(config_settings=None):
-    """Install configured dependencies in the isolated editable build env."""
-    get_requires = getattr(_orig, "get_requires_for_build_editable", None)
-    requirements = [] if get_requires is None else get_requires(config_settings)
-    return [*requirements, *get_build_dependency_requirements()]
+# CuTe DSL kernels are intentionally excluded from the JIT-cache AOT build.
+# The generated NVCC modules use the C++ headers in 3rdparty/cutlass, not the
+# nvidia-cutlass-dsl Python package, so the standard setuptools requirements are
+# sufficient for isolated builds.
+get_requires_for_build_wheel = _orig.get_requires_for_build_wheel
+get_requires_for_build_editable = getattr(
+    _orig, "get_requires_for_build_editable", None
+)

--- a/scripts/build_in_container.sh
+++ b/scripts/build_in_container.sh
@@ -125,18 +125,12 @@ uv pip install --python "${VENV}/bin/python" --no-deps \
 # resolver during the editable `-e .` resolution (nvidia-nvjitlink METADATA
 # mismatch). Installing the leaf deps first + `--no-deps -e .` sidesteps that.
 # nccl4py>=0.3.1 = NCCL-EP (nccl.ep + bundled libnccl_ep.so); cuda-python and
-# nccl4py's cuda.core/cuda-bindings come along here.
-BUILD_DEPENDENCY_OUTPUT="$(
-    PYTHONPATH="${REPO_ROOT}" "${VENV}/bin/python" -c \
-        'from build_utils import get_build_dependency_requirements; print(*get_build_dependency_requirements("13"), sep="\n")'
-)"
-BUILD_DEPENDENCIES=()
-if [[ -n "${BUILD_DEPENDENCY_OUTPUT}" ]]; then
-    mapfile -t BUILD_DEPENDENCIES <<< "${BUILD_DEPENDENCY_OUTPUT}"
-fi
+# nccl4py's cuda.core/cuda-bindings come along here. CuTe DSL is a runtime
+# dependency in this environment, matching the project's cu13 optional extra;
+# it is not a Python build-system dependency.
 uv pip install --python "${VENV}/bin/python" \
     numpy einops ninja nvidia-ml-py click requests tabulate tqdm \
-    "${BUILD_DEPENDENCIES[@]}" "nvidia-cudnn-frontend>=1.13.0" \
+    "nvidia-cutlass-dsl[cu13]>=4.7.0a0" "nvidia-cudnn-frontend>=1.13.0" \
     "cuda-tile>=1.4.0" "cuda-python>=13.0" "nccl4py>=0.3.1" \
     "nvidia-nccl-cu13>=2.30.7"   # B200 NCCL-EP needs >=2.30.7; load this first on LD_LIBRARY_PATH
 


### PR DESCRIPTION
## 📌 Description

- Rename the shared policy from `build_dependencies` to `ci_image_dependencies` and move its resolver out of `build_utils.py`.
- Keep `nvidia-cutlass-dsl==4.7.0` in CUDA CI images, selecting the `cu13` extra for CUDA 13, and verify the exact configured version in the image smoke test.
- Remove CUTLASS DSL from the isolated PEP 517 requirements of `flashinfer-jit-cache` and `flashinfer-cubin`; those builders use vendored C++ CUTLASS headers or download precompiled artifacts rather than compiling Python CuTe DSL kernels.
- Make backend changes trigger the release workflow so the isolated artifact builds validate this boundary in presubmit.

## 🔍 Related Issues

None.

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

Validated locally with the CUDA configuration validator and negative policy cases, exact CUDA 12/13 dependency resolution checks, Python and shell syntax checks, focused pre-commit, ShellCheck, and actionlint. Docker image builds and isolated artifact builds are delegated to PR CI.

## Reviewer Notes

The JIT-cache AOT pass does not include CuTe-DSL kernels. Its CUTLASS-named NVCC modules use `3rdparty/cutlass`; the cubin package only downloads and verifies precompiled artifacts. Please focus review on the dependency boundary and the image-policy naming.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added centralized CUDA CI image dependency resolution with exact package versions and CUDA-specific extras.
  * Added validation for dependency names, versions, CUDA versions, extras, and duplicates.
  * CI image checks now verify installed packages against the configured versions.

* **Bug Fixes**
  * Updated release workflows to run when relevant dependency and build configuration files change.
  * Improved CI image dependency installation and diagnostics.

* **Chores**
  * Simplified package build dependency handling and explicitly installed CuTe DSL for container builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->