### PR TITLE
feat(moe): stride-aware routing_logits for trtllm-gen MoE routing

### DIFF
--- a/csrc/fused_moe/trtllm_backend/trtllm_fused_moe_routing_custom.cuh
+++ b/csrc/fused_moe/trtllm_backend/trtllm_fused_moe_routing_custom.cuh
@@ -88,7 +88,7 @@ __global__ void __launch_bounds__(KernelParams::MaxNumExperts <= 1024 ? KernelPa
 
   int32_t const warpIdx = __shfl_sync(0xffffffff, threadIdx.x / WarpSize, 0);
   int32_t const laneIdx = cutlass::arch::LaneId();
-  auto scoreOffset = warpIdx * params.mNumExperts;
+  int64_t const scoreOffset = int64_t{warpIdx} * params.mStrideScores;
   bool validToken = warpIdx < params.mNumTokens;
 
   static constexpr int VecSize = KernelParams::MaxNumExperts / WarpSize;
@@ -461,7 +461,7 @@ __global__ void routingIndicesDynBlockKernel(KernelParams params) {
       BaseType warpTopKScore[KernelParams::MaxNumTopExperts];
       int32_t warpTopKExpertIdx[KernelParams::MaxNumTopExperts];
 
-      auto scoreOff = tokenIdx * params.mNumExperts;
+      int64_t const scoreOff = int64_t{tokenIdx} * params.mStrideScores;
       KernelParams::ExpertSelectPolicy::template apply<BaseType, InputT, VecSize,
                                                        KernelParams::MaxNumTopExperts>(
           warp, warpTopKScore, warpTopKExpertIdx, laneIdx, params.mNumExperts, params.mTopK,
@@ -736,7 +736,7 @@ __device__ __forceinline__ void routingIndicesClusterKernelBody(
   int32_t const warpIdx = __shfl_sync(0xffffffff, threadIdx.x / WarpSize, 0);
   int32_t const laneIdx = cutlass::arch::LaneId();
   auto warpTokenIdx = clusterBlockRank * ClusterNumWarps + warpIdx;
-  auto scoreOffset = warpTokenIdx * params.mNumExperts;
+  int64_t const scoreOffset = int64_t{warpTokenIdx} * params.mStrideScores;
   bool validToken = warpTokenIdx < params.mNumTokens;
   auto block = cg::this_thread_block();
   auto warp = cg::tiled_partition<WarpSize>(block);
@@ -1033,7 +1033,7 @@ __global__ void __launch_bounds__(
   // in this case, each warp represents a token, and we use a grid-stride loop
   // over all warps/tokens
   for (int tokenIdx = globalWarpIdx; tokenIdx < params.mNumTokens; tokenIdx += globalWarpStride) {
-    auto scoreOffset = tokenIdx * params.mNumExperts;
+    int64_t const scoreOffset = int64_t{tokenIdx} * params.mStrideScores;
 
     BaseType laneTopKScore;
     int32_t laneTopKExpertIdx;
@@ -1242,7 +1242,7 @@ __global__ void __launch_bounds__(kBlockScoresKernelBlockDim)
     // Phase 1: block-parallel preprocess.  Dispatches on PreProc so the kernel
     // works for all registered preprocess policies (single-pass NoOp / Sigmoid /
     // SigmoidBias, two-pass Softmax).
-    int64_t const scoreBase = int64_t{tokenIdx} * int64_t{params.mNumExperts};
+    int64_t const scoreBase = int64_t{tokenIdx} * params.mStrideScores;
     if constexpr (std::is_same_v<PreProc, SoftmaxPreprocess>) {
       // Softmax needs block-level reductions; pass the block size as a template
       // parameter so it can construct cub::BlockReduce with the right size.

--- a/csrc/fused_moe/trtllm_backend/trtllm_fused_moe_routing_deepseek.cu
+++ b/csrc/fused_moe/trtllm_backend/trtllm_fused_moe_routing_deepseek.cu
@@ -155,7 +155,7 @@ __global__ void routingMainKernel(KernelParams params) {
     // to false is enough to keep them from doing any out-of-bounds reads or smem writes.
     expertSelected = (warpIdx < params.mNumExpertGroups) && (laneIdx < params.mNumExpertsPerGroup);
   }
-  auto scoreIdx = int64_t{blockIdx.x} * int64_t{params.mNumExperts} + threadExpert;
+  auto scoreIdx = int64_t{blockIdx.x} * params.mStrideScores + threadExpert;
   auto biasVal = (expertSelected && params.mPtrRoutingBias != nullptr)
                      ? static_cast<OutputT>(
                            loadScalar(params.mPtrRoutingBias, threadExpert, params.mDtypeBias))

--- a/csrc/fused_moe/trtllm_backend/trtllm_fused_moe_routing_llama4.cu
+++ b/csrc/fused_moe/trtllm_backend/trtllm_fused_moe_routing_llama4.cu
@@ -112,7 +112,7 @@ __global__ void __launch_bounds__(WarpSize) routingIndicesWarpKernel(KernelParam
     // for each token, we load the scores then use `reduceTopK` for this.
     // each thread works on 4 experts, so a local reduction is done before
     for (int tokenIdx = 0; tokenIdx < params.mNumTokens; ++tokenIdx) {
-      auto scoreOffset = tokenIdx * params.mNumExperts;
+      int64_t const scoreOffset = int64_t{tokenIdx} * params.mStrideScores;
       int32_t warpMaxExpertIdx[MaxNumTopExperts];
       InputT warpMaxScore[MaxNumTopExperts];
 
@@ -342,7 +342,7 @@ __global__ void __cluster_dims__(NumBlocksPerCluster, 1, 1) __launch_bounds__(Nu
 
   // TODO(mjoux): expand to more tokens (possibly)
   auto warpTokenIdx = clusterBlockRank * NumWarps + warpIdx;
-  auto scoreOffset = warpTokenIdx * params.mNumExperts;
+  int64_t const scoreOffset = int64_t{warpTokenIdx} * params.mStrideScores;
   bool validToken = warpTokenIdx < params.mNumTokens;
   InputT minScore = InputT{-INFINITY};
 
@@ -446,7 +446,7 @@ __global__ void __launch_bounds__(KernelParams::MaxNumExperts)
   // in this case, each warp represents a token, and we use a grid-stride loop
   // over all warps/tokens
   for (int tokenIdx = globalWarpIdx; tokenIdx < params.mNumTokens; tokenIdx += globalWarpStride) {
-    auto scoreOffset = tokenIdx * params.mNumExperts;
+    int64_t const scoreOffset = int64_t{tokenIdx} * params.mStrideScores;
     int32_t warpMaxExpertIdx[MaxNumTopExperts];
     InputT warpMaxScore[MaxNumTopExperts];
 

--- a/csrc/fused_moe/trtllm_backend/trtllm_fused_moe_routing_runner.cu
+++ b/csrc/fused_moe/trtllm_backend/trtllm_fused_moe_routing_runner.cu
@@ -61,7 +61,8 @@ void Runner::run(void* routingLogits, void* routingBias, int32_t numTokens, int3
                  int32_t* numNonExitingCtas, btg::Dtype dtypeElt, btg::Dtype dtypeBias,
                  bool useRoutingScalesOnInput, bool useDeepSeekFp8,
                  RoutingMethodType routingMethodType, cudaStream_t stream, btg::Dtype dtypeLogits,
-                 bool normTopkProb, int16_t* routing_replay_out, bool enable_pdl) {
+                 bool normTopkProb, int16_t* routing_replay_out, bool enable_pdl,
+                 int64_t routingLogitsStride) {
   if (routingMethodType == RoutingMethodType::DeepSeekV3 && nGroup <= 1) {
     // Only the grouped DeepSeek kernel below populates the fused shared-expert
     // slots; routingCustom leaves them untouched, so reject rather than return
@@ -89,6 +90,7 @@ void Runner::run(void* routingLogits, void* routingBias, int32_t numTokens, int3
     routingData.mSumEpsilon = 1e-20f;
 
     routingData.mPtrScores = expertIds == nullptr ? routingLogits : nullptr;
+    routingData.mStrideScores = routingLogitsStride;
     routingData.mPtrTopKIds = expertIds;
     routingData.mPtrTopKPacked = routingExpertIndexes;
     routingData.mPtrExpertCounts = expertCountHistogram;
@@ -132,6 +134,7 @@ void Runner::run(void* routingLogits, void* routingBias, int32_t numTokens, int3
     routingData.mSumEpsilon = 1e-20f;
 
     routingData.mPtrScores = expertIds == nullptr ? routingLogits : nullptr;
+    routingData.mStrideScores = routingLogitsStride;
     routingData.mPtrTopKIds = expertIds;
     routingData.mPtrTopKPacked = routingExpertIndexes;
     routingData.mPtrExpertCounts = expertCountHistogram;
@@ -185,6 +188,7 @@ void Runner::run(void* routingLogits, void* routingBias, int32_t numTokens, int3
     routingData.mPtrRoutingBias = routingBias;
     // Pre-computed routing support: when expertIds is provided, use it directly
     routingData.mPtrScores = expertIds == nullptr ? routingLogits : nullptr;
+    routingData.mStrideScores = routingLogitsStride;
     routingData.mPtrTopKIds = expertIds;
     routingData.mNumTokens = numTokens;
     routingData.mNumExperts = numExperts;
@@ -245,6 +249,7 @@ void Runner::run(void* routingLogits, void* routingBias, int32_t numTokens, int3
     // input:
     // Pre-computed routing support: when expertIds is provided, use it directly
     routingData.mPtrScores = expertIds == nullptr ? routingLogits : nullptr;
+    routingData.mStrideScores = routingLogitsStride;
     routingData.mPtrTopKIds = expertIds;
     routingData.mNumTokens = numTokens;
     routingData.mNumExperts = numExperts;
@@ -314,6 +319,7 @@ void Runner::run(void* routingLogits, void* routingBias, int32_t numTokens, int3
 
     // Pre-computed routing support: when expertIds is provided, use it directly
     routingData.mPtrScores = expertIds == nullptr ? routingLogits : nullptr;
+    routingData.mStrideScores = routingLogitsStride;
     routingData.mPtrTopKIds = expertIds;
 
     //

--- a/csrc/trtllm_fused_moe_kernel_launcher.cu
+++ b/csrc/trtllm_fused_moe_kernel_launcher.cu
@@ -1137,6 +1137,15 @@ class FusedMoeLauncher {
       TVM_FFI_ICHECK_EQ(routing_logits.value().size(1), args->num_experts)
           << "routing_logits dim1 must match num_experts.";
 
+      // The routing kernels index score rows with a row stride, so a strided
+      // (e.g. sliced) logits tensor is fine, but each row must be contiguous
+      // and rows must not overlap.
+      TVM_FFI_ICHECK_EQ(routing_logits.value().stride(1), 1)
+          << "routing_logits must be contiguous along the expert dimension.";
+      TVM_FFI_ICHECK(routing_logits.value().size(0) == 1 ||
+                     routing_logits.value().stride(0) >= args->num_experts)
+          << "routing_logits rows must not overlap: stride(0) must be >= num_experts.";
+
       // Check dtype
       TVM_FFI_ICHECK(routing_logits.value().dtype() == dl_float32 ||
                      routing_logits.value().dtype() == dl_bfloat16)
@@ -1516,7 +1525,7 @@ class FusedMoeLauncher {
         static_cast<int*>(num_non_exiting_ctas.data_ptr()), args->mDtypeElt, mRoutingBiasDtype,
         use_routing_scales_on_input, use_deep_seek_fp8,
         static_cast<RoutingMethodType>(routing_method_type), routing_stream, mRoutingLogitsDtype,
-        norm_topk_prob, replay_ptr, enable_pdl);
+        norm_topk_prob, replay_ptr, enable_pdl, args->routing_logits_stride);
 
     check_moe();
     prepare_moe(moe_tactic);
@@ -1557,6 +1566,7 @@ void FusedMoeLauncher::init_common(
   this->device_version = std::make_tuple(major, minor);
 
   args->routing_logits = routing_logits.has_value() ? routing_logits.value().data_ptr() : nullptr;
+  args->routing_logits_stride = routing_logits.has_value() ? routing_logits.value().stride(0) : 0;
   args->routing_bias = routing_bias.has_value() ? routing_bias.value().data_ptr() : nullptr;
   args->hidden_states = hidden_states.data_ptr();
   args->gemm1_weights = gemm1_weights.data_ptr();
@@ -2612,7 +2622,7 @@ class Fp8BlockScaleLauncher : public FusedMoeLauncher {
         static_cast<int*>(num_non_exiting_ctas.data_ptr()), args->mDtypeElt, mRoutingBiasDtype,
         use_routing_scales_on_input, use_deep_seek_fp8,
         static_cast<RoutingMethodType>(routing_method_type), routing_stream, mRoutingLogitsDtype,
-        norm_topk_prob, replay_ptr, enable_pdl);
+        norm_topk_prob, replay_ptr, enable_pdl, args->routing_logits_stride);
 
     check_moe();
     prepare_moe(moe_tactic);
@@ -3288,23 +3298,23 @@ class FP4BlockScaleLauncher : public FusedMoeLauncher {
       replay_ptr = reinterpret_cast<int16_t*>(routing_replay_out.value().data_ptr());
     }
 
-    routing_runner.run(args->routing_logits, args->routing_bias, args->num_tokens,
-                       args->num_experts, args->top_k, args->num_fused_shared_experts,
-                       args->n_group, args->topk_group, args->local_expert_offset,
-                       args->local_num_experts, args->routed_scaling_factor,
-                       static_cast<int*>(topk_ids.data_ptr()),
-                       static_cast<int*>(expert_count_histogram.data_ptr()),
-                       static_cast<int*>(total_num_padded_tokens.data_ptr()),
-                       static_cast<int*>(expanded_idx_to_permuted_idx.data_ptr()),
-                       static_cast<int*>(permuted_idx_to_expanded_idx_ptr()),
-                       static_cast<int*>(permuted_idx_to_token_idx.data_ptr()), expert_ids_param,
-                       expert_weights_param, static_cast<int*>(num_tokens_per_expert.data_ptr()),
-                       static_cast<int*>(cta_idx_xy_to_batch_idx.data_ptr()),
-                       static_cast<int*>(cta_idx_xy_to_mn_limit.data_ptr()),
-                       static_cast<int*>(num_non_exiting_ctas.data_ptr()), args->mDtypeElt,
-                       mRoutingBiasDtype, use_routing_scales_on_input, use_deep_seek_fp8,
-                       static_cast<RoutingMethodType>(routing_method_type), routing_stream,
-                       mRoutingLogitsDtype, norm_topk_prob, replay_ptr, enable_pdl);
+    routing_runner.run(
+        args->routing_logits, args->routing_bias, args->num_tokens, args->num_experts, args->top_k,
+        args->num_fused_shared_experts, args->n_group, args->topk_group, args->local_expert_offset,
+        args->local_num_experts, args->routed_scaling_factor,
+        static_cast<int*>(topk_ids.data_ptr()),
+        static_cast<int*>(expert_count_histogram.data_ptr()),
+        static_cast<int*>(total_num_padded_tokens.data_ptr()),
+        static_cast<int*>(expanded_idx_to_permuted_idx.data_ptr()),
+        static_cast<int*>(permuted_idx_to_expanded_idx_ptr()),
+        static_cast<int*>(permuted_idx_to_token_idx.data_ptr()), expert_ids_param,
+        expert_weights_param, static_cast<int*>(num_tokens_per_expert.data_ptr()),
+        static_cast<int*>(cta_idx_xy_to_batch_idx.data_ptr()),
+        static_cast<int*>(cta_idx_xy_to_mn_limit.data_ptr()),
+        static_cast<int*>(num_non_exiting_ctas.data_ptr()), args->mDtypeElt, mRoutingBiasDtype,
+        use_routing_scales_on_input, use_deep_seek_fp8,
+        static_cast<RoutingMethodType>(routing_method_type), routing_stream, mRoutingLogitsDtype,
+        norm_topk_prob, replay_ptr, enable_pdl, args->routing_logits_stride);
 
     check_moe();
     prepare_moe(moe_tactic);
@@ -4364,6 +4374,12 @@ void trtllm_moe_canonicalize_routing(
       << "hidden_states and routing_logits must have the same token count.";
   TVM_FFI_ICHECK(local_num_experts > 0 && local_expert_offset + local_num_experts <= num_experts)
       << "the local expert range must lie within routing_logits.";
+  // Strided (e.g. sliced) logits are supported, but each row must be contiguous
+  // and rows must not overlap.
+  TVM_FFI_ICHECK_EQ(routing_logits.stride(1), 1)
+      << "routing_logits must be contiguous along the expert dimension.";
+  TVM_FFI_ICHECK(num_tokens == 1 || routing_logits.stride(0) >= num_experts)
+      << "routing_logits rows must not overlap: stride(0) must be >= num_experts.";
 
   btg::Dtype dtype_elt;
   if (hidden_states.dtype() == dl_float16) {
@@ -4402,7 +4418,8 @@ void trtllm_moe_canonicalize_routing(
       static_cast<int*>(buffers.num_non_exiting_ctas.data_ptr()), dtype_elt, routing_bias_dtype,
       use_routing_scales_on_input, use_deep_seek_fp8,
       static_cast<RoutingMethodType>(routing_method_type), stream, routing_logits_dtype,
-      norm_topk_prob, static_cast<int16_t*>(buffers.routing_replay_ids.data_ptr()), enable_pdl);
+      norm_topk_prob, static_cast<int16_t*>(buffers.routing_replay_ids.data_ptr()), enable_pdl,
+      routing_logits.stride(0));
 }
 
 /// Allocate graph-stable routing metadata storage for each requested tile without launching work.

--- a/csrc/trtllm_fused_moe_routing_binding.cu
+++ b/csrc/trtllm_fused_moe_routing_binding.cu
@@ -36,6 +36,10 @@ using tvm::ffi::TensorView;
  * see flashinfer/fused_moe/trtllm_gen_routing.py for the expected shapes.
  *
  *   routing_logits              : [num_tokens, num_experts] float32 or bfloat16
+ *                                 rows must be contiguous and non-overlapping,
+ *                                 but the token dimension may be strided (a
+ *                                 view into a wider router-output buffer is
+ *                                 fine)
  *   routing_bias                : [num_experts] float32 or bfloat16 (optional)
  *   topk_packed                 : [num_tokens, top_k + num_fused_shared_experts] int32 (scratch)
  *                                 PackedScoreIdx pipeline scratch, layout (score << 16) | idx;
@@ -64,13 +68,18 @@ void trtllm_gen_routing(TensorView routing_logits, Optional<TensorView> routing_
                         int64_t topk_group, int64_t local_expert_offset, int64_t local_num_experts,
                         double routed_scaling_factor, int64_t tile_tokens_dim,
                         int64_t routing_method_type, bool norm_topk_prob, bool enable_pdl) {
-  CHECK_INPUT(routing_logits);
+  // The routing kernels index score rows with a row stride, so only the expert
+  // dimension has to be contiguous; the token dimension may be strided.
+  CHECK_LAST_DIM_CONTIGUOUS_INPUT(routing_logits);
   CHECK_DIM(2, routing_logits);
   TVM_FFI_ICHECK(routing_logits.dtype() == dl_float32 || routing_logits.dtype() == dl_bfloat16)
       << "routing_logits must be float32 or bfloat16";
 
   int64_t const num_tokens = routing_logits.sizes()[0];
   int64_t const num_experts = routing_logits.sizes()[1];
+  TVM_FFI_ICHECK(num_tokens == 1 || routing_logits.stride(0) >= num_experts)
+      << "routing_logits rows must not overlap: stride(0) must be >= num_experts, got "
+      << routing_logits.stride(0) << " for num_experts=" << num_experts;
   int64_t const total_experts_per_token = top_k + num_fused_shared_experts;
   int64_t const total_num_experts = num_experts + num_fused_shared_experts;
 
@@ -185,7 +194,8 @@ void trtllm_gen_routing(TensorView routing_logits, Optional<TensorView> routing_
       /*dtypeElt=*/btg::Dtype::Bfloat16, dtype_bias,
       /*useRoutingScalesOnInput=*/false, /*useDeepSeekFp8=*/false,
       static_cast<RoutingMethodType>(routing_method_type), stream, dtype_logits, norm_topk_prob,
-      /*routing_replay_out=*/nullptr, enable_pdl);
+      /*routing_replay_out=*/nullptr, enable_pdl,
+      /*routingLogitsStride=*/routing_logits.stride(0));
 }
 
 }  // namespace flashinfer::trtllm_gen_routing

--- a/flashinfer/fused_moe/runners.py
+++ b/flashinfer/fused_moe/runners.py
@@ -163,8 +163,20 @@ def _validate_logits_inputs(
             f"({num_tokens}, {num_experts}) (num_tokens, num_experts) — "
             "routing scores are over the GLOBAL expert set."
         )
-    if not logits.is_contiguous():
-        raise ValueError(f"{runner}: routing_logits must be contiguous.")
+    # The trtllm-gen routing kernels index score rows with a row stride, so a
+    # strided (e.g. sliced) logits tensor is fine as long as each row is
+    # contiguous and rows do not overlap. See DataBase::mStrideScores in
+    # include/flashinfer/trtllm/fused_moe/RoutingKernel.h.
+    if logits.stride(1) != 1:
+        raise ValueError(
+            f"{runner}: routing_logits must be contiguous along the expert "
+            f"dimension (stride(1) == 1), got strides {logits.stride()}."
+        )
+    if num_tokens > 1 and logits.stride(0) < num_experts:
+        raise ValueError(
+            f"{runner}: routing_logits rows must not overlap: stride(0) must be "
+            f">= num_experts ({num_experts}), got strides {logits.stride()}."
+        )
     if act.routing_bias is not None:
         if act.routing_bias.dtype not in (torch.bfloat16, torch.float32):
             raise TypeError(

--- a/flashinfer/fused_moe/trtllm_gen_routing.py
+++ b/flashinfer/fused_moe/trtllm_gen_routing.py
@@ -116,6 +116,20 @@ def _check_trtllm_gen_routing_supported(
             f"routing_logits must be float32 or bfloat16, got {routing_logits.dtype}"
         )
     num_experts = routing_logits.shape[1]
+    # The kernels read score rows with a row stride, so the token dimension may
+    # be strided; each row still has to be contiguous.
+    if routing_logits.stride(1) != 1:
+        raise ValueError(
+            "routing_logits must be contiguous along the expert dimension "
+            f"(stride(1) == 1), got strides {routing_logits.stride()}"
+        )
+    if routing_logits.shape[0] > 1 and routing_logits.stride(0) < num_experts:
+        # A zero row stride is the kernels' "tightly packed" sentinel, so
+        # overlapping rows cannot be expressed unambiguously.
+        raise ValueError(
+            "routing_logits rows must not overlap: stride(0) must be >= "
+            f"num_experts ({num_experts}), got strides {routing_logits.stride()}"
+        )
     if not 1 <= top_k <= num_experts:
         raise ValueError(f"top_k must be in [1, num_experts], got {top_k}")
     if routing_bias is not None and routing_bias.numel() != num_experts:
@@ -232,7 +246,10 @@ def trtllm_gen_routing(
     ----------
     routing_logits : torch.Tensor
         Router logits of shape ``(num_tokens, num_experts)``, ``float32`` or
-        ``bfloat16``.
+        ``bfloat16``. Need not be contiguous: the token dimension may be
+        strided (e.g. a slice of a wider router-output buffer), as long as each
+        row is contiguous (``stride(1) == 1``) and rows do not overlap
+        (``stride(0) >= num_experts``).
     routing_bias : Optional[torch.Tensor]
         Per-expert routing bias of shape ``(num_experts,)``, ``float32`` or
         ``bfloat16`` (used by DeepSeekV3/MiniMax2-style methods).

--- a/include/flashinfer/trtllm/fused_moe/RoutingKernel.h
+++ b/include/flashinfer/trtllm/fused_moe/RoutingKernel.h
@@ -93,7 +93,7 @@ struct DataBase {
   // If it is given, it represents the scores without sigmoid activation for
   // each token and expert.
   // note: if it is provided, we always re-compute the top1 scores
-  // dim: [mNumTokens, mNumExperts]
+  // dim: [mNumTokens, mNumExperts], rows `mStrideScores` elements apart
   void const* mPtrScores{nullptr};
 
   //
@@ -130,6 +130,17 @@ struct DataBase {
   int16_t* mPtrRoutingReplayOut{nullptr};
   // optional: final token count for each expert, separate from histogram scratch
   int32_t* mPtrNumTokensPerExpert{nullptr};
+  // Row stride of `mPtrScores` in elements, i.e. the distance between the score
+  // rows of two consecutive tokens. 0 (the default) means the rows are tightly
+  // packed and the stride is mNumExperts; any other value must be >= mNumExperts
+  // (0 is the "packed" sentinel, so it cannot double as an overlapping stride).
+  // Only the token dimension may be strided: the scores *within* a row must stay
+  // contiguous (unit expert stride), which is what a view into a wider router
+  // output looks like (e.g. `logits[:, :num_experts]` of a padded buffer, or a
+  // token slice of a larger allocation).
+  // NOTE: appended at the end of the struct for the same reason as
+  // mPtrRoutingReplayOut above.
+  int64_t mStrideScores{0};
 };
 
 template <typename InputT_, typename OutputT_, int MaxNumExperts_, int MaxNumTopExperts_>
@@ -176,6 +187,10 @@ struct KernelParamsBase {
   bool mUseContiguousRouteWindows = false;
   // Optional final token count for each expert, separate from histogram scratch.
   int32_t* mPtrNumTokensPerExpert = nullptr;
+  // Resolved row stride of mPtrScores in elements (see DataBase::mStrideScores).
+  // Always positive after setBaseParams(), so kernels index score rows with it
+  // unconditionally instead of assuming tightly packed rows.
+  int64_t mStrideScores = 0;
 
   // Public initialization function - make it a template to accept different Data types
   template <typename DataType>
@@ -196,6 +211,12 @@ struct KernelParamsBase {
     mPtrScores = (InputT const*)data.mPtrScores;
     mPtrRoutingReplayOut = data.mPtrRoutingReplayOut;
     mPtrNumTokensPerExpert = data.mPtrNumTokensPerExpert;
+    // Resolve the "tightly packed" default here so the kernels never have to.
+    // Note this must stay ahead of any host-side mutation of mNumExperts (the
+    // DeepSeek path bumps it by the fused shared experts *after* launching the
+    // score-reading kernel).
+    mStrideScores =
+        data.mStrideScores > 0 ? data.mStrideScores : static_cast<int64_t>(data.mNumExperts);
 
     mNumTokens = data.mNumTokens;
     mNumExperts = data.mNumExperts;

--- a/include/flashinfer/trtllm/fused_moe/runner.h
+++ b/include/flashinfer/trtllm/fused_moe/runner.h
@@ -150,7 +150,8 @@ class Runner {
            batchedGemm::trtllm::gen::Dtype dtypeBias, bool useRoutingScalesOnInput,
            bool useDeepSeekFp8, RoutingMethodType routingMethodType, cudaStream_t stream,
            batchedGemm::trtllm::gen::Dtype dtypeLogits, bool normTopkProb = true,
-           int16_t* routing_replay_out = nullptr, bool enable_pdl = true);
+           int16_t* routing_replay_out = nullptr, bool enable_pdl = true,
+           int64_t routingLogitsStride = 0);
 
  private:
   friend class MoE::Runner;
@@ -308,8 +309,12 @@ namespace btg = batchedGemm::trtllm::gen;
 struct MoERunnerArgs {
   void* routing_logits = nullptr;  // [num_tokens, num_experts] in float, generated after
                                    // gemm(hidden_state, routing_weights)
-  void* routing_bias = nullptr;    // [num_experts] in bfloat16 for now = mDtypeExpW
-  void* hidden_states = nullptr;   // [num_tokens, hidden_size] in fp8 = mDtypeElt
+  // Row stride of routing_logits in elements; 0 means tightly packed
+  // (== num_experts), otherwise >= num_experts. Rows themselves must be
+  // contiguous. See DataBase::mStrideScores in RoutingKernel.h.
+  int64_t routing_logits_stride = 0;
+  void* routing_bias = nullptr;   // [num_experts] in bfloat16 for now = mDtypeExpW
+  void* hidden_states = nullptr;  // [num_tokens, hidden_size] in fp8 = mDtypeElt
   // [hidden_size/128, num_tokens] in float for e4m3 DS recipe
   // and [num_tokens, hidden_size/16] in float for e2m1
   void* hidden_states_scale = nullptr;

--- a/tests/moe/test_trtllm_gen_routed_fused_moe.py
+++ b/tests/moe/test_trtllm_gen_routed_fused_moe.py
@@ -926,6 +926,88 @@ def _run_trtllm_gen_bf16_routed_fused_moe_case(
     assert mismatch_pct < 10, f"Mismatch percentage is {mismatch_pct:.2f}%"
 
 
+def test_trtllm_gen_bf16_moe_strided_routing_logits():
+    """A strided routing_logits view must match its contiguous copy.
+
+    The routing kernels index score rows with a row stride
+    (DataBase::mStrideScores in RoutingKernel.h), so a window into a wider
+    router-output buffer is a supported input. This anchors the stride plumbing
+    through the fused launcher; the routing kernels themselves are covered
+    per-method by tests/moe/test_trtllm_gen_routing.py::test_strided_logits.
+    """
+    compute_capability = get_compute_capability(torch.device(device="cuda"))
+    if compute_capability[0] not in [10]:
+        pytest.skip("These tests are only guaranteed to work on SM100 and SM103 GPUs.")
+    torch.manual_seed(42)
+    device = torch.device("cuda:0")
+    enable_pdl = device_support_pdl(device)
+    num_tokens, hidden_size, intermediate_size = 64, 1024, 1024
+    num_experts, top_k = 8, 2
+
+    logits = torch.rand(num_tokens, num_experts, device=device).to(torch.bfloat16)
+    # Window into a wider buffer, offset in both dimensions. The padding holds a
+    # value far above any real logit, so reading it would change the selection.
+    wide = torch.full(
+        (num_tokens + 3, num_experts + 5), 100.0, device=device, dtype=torch.bfloat16
+    )
+    strided_logits = wide[3:, 5:]
+    strided_logits.copy_(logits)
+    assert strided_logits.stride() == (num_experts + 5, 1)
+
+    hidden_states = (
+        torch.randn(num_tokens, hidden_size, device=device).to(torch.bfloat16) * 0.1
+    )
+    gemm1_weights = torch.randn(
+        num_experts, 2 * intermediate_size, hidden_size, device=device
+    ).to(torch.bfloat16)
+    gemm2_weights = torch.randn(
+        num_experts, hidden_size, intermediate_size, device=device
+    ).to(torch.bfloat16)
+    block_k = 128
+    gemm1_weights = torch.stack(
+        [
+            convert_to_block_layout(
+                shuffle_matrix_a(gemm1_weights[i].view(torch.uint8), 64), block_k
+            )
+            for i in range(num_experts)
+        ]
+    ).view(torch.bfloat16)
+    gemm2_weights = torch.stack(
+        [
+            convert_to_block_layout(
+                shuffle_matrix_a(gemm2_weights[i].view(torch.uint8), 64), block_k
+            )
+            for i in range(num_experts)
+        ]
+    ).view(torch.bfloat16)
+
+    def run(routing_logits):
+        return trtllm_bf16_moe(
+            routing_logits=routing_logits,
+            routing_bias=None,
+            hidden_states=hidden_states,
+            gemm1_weights=gemm1_weights,
+            gemm2_weights=gemm2_weights,
+            num_experts=num_experts,
+            top_k=top_k,
+            n_group=None,
+            topk_group=None,
+            intermediate_size=intermediate_size,
+            local_expert_offset=0,
+            local_num_experts=num_experts,
+            routed_scaling_factor=None,
+            routing_method_type=RoutingMethodType.Renormalize.value,
+            use_shuffled_weight=True,
+            weight_layout=WeightLayout.BlockMajorK,
+            do_finalize=True,
+            enable_pdl=enable_pdl,
+        )
+
+    # Identical inputs reached through a different row stride: the kernels are
+    # deterministic here, so the outputs must match exactly.
+    torch.testing.assert_close(run(strided_logits), run(logits), atol=0.0, rtol=0.0)
+
+
 @pytest.mark.parametrize("num_tokens", [8, 64])
 @pytest.mark.parametrize("hidden_size", [1024, 2048])
 @pytest.mark.parametrize("intermediate_size", [1024, 2048])

--- a/tests/moe/test_trtllm_gen_routing.py
+++ b/tests/moe/test_trtllm_gen_routing.py
@@ -376,6 +376,136 @@ def test_large_batch_smoke(routing_method, num_experts, top_k):
         )
 
 
+# ---------------------------------------------------------------------------
+# Strided logits
+#
+# The kernels index score rows with a row stride (DataBase::mStrideScores), so
+# routing_logits only has to be contiguous along the expert dimension (with
+# non-overlapping rows). A view into a wider router-output buffer -- e.g.
+# logits[:, :E] of a padded GEMM output, or a token slice of a larger
+# allocation -- must give exactly the same result as its contiguous copy.
+# ---------------------------------------------------------------------------
+
+
+def make_strided_view(logits, token_pad=3, expert_pad=5):
+    """Window into a wider buffer whose contents equal ``logits``.
+
+    Rows sit ``num_experts + expert_pad`` elements apart and the window starts
+    at a non-zero offset in both dimensions, so a kernel that assumes tightly
+    packed rows reads the wrong data. The padding is filled with a value far
+    above any real logit: if it were read as a score it would win topK and fail
+    the selection check, rather than silently passing as a plausible logit.
+    """
+    num_tokens, num_experts = logits.shape
+    buf = torch.full(
+        (num_tokens + token_pad, num_experts + expert_pad),
+        100.0,
+        dtype=logits.dtype,
+        device=logits.device,
+    )
+    view = buf[token_pad:, expert_pad:]
+    view.copy_(logits)
+    # (a single-row view still reports as contiguous, hence the stride check)
+    assert view.stride() == (num_experts + expert_pad, 1)
+    return view
+
+
+# num_tokens spans the score-reading kernels: the single-block kernel (<= 4
+# tokens), the cluster / block-scores path, and the large-batch coop path.
+@pytest.mark.parametrize("num_tokens", [1, 150, 4096])
+@pytest.mark.parametrize(
+    "routing_method",
+    [
+        pytest.param(RoutingMethodType.Renormalize, id="Renormalize"),
+        pytest.param(RoutingMethodType.DeepSeekV3, id="DeepSeekV3"),
+        pytest.param(RoutingMethodType.Llama4, id="Llama4"),
+    ],
+)
+def test_strided_logits(routing_method, num_tokens):
+    """One case per routing-kernel family: routingCustom, DeepSeek, Llama4."""
+    num_experts, tile_tokens_dim = 128, 8
+    seed = stable_seed("strided", int(routing_method), num_tokens)
+    logits = make_logits(num_tokens, num_experts, torch.float32, seed)
+    strided = make_strided_view(logits)
+
+    if routing_method == RoutingMethodType.DeepSeekV3:
+        top_k, n_group, topk_group, routed_scaling = 8, 4, 2, 2.5
+        bias = make_bias(num_experts, torch.bfloat16, seed + 1)
+        run_and_check(
+            routing_method,
+            lambda: routing_reference_no_aux(
+                logits,
+                bias,
+                top_k,
+                n_group,
+                topk_group,
+                routed_scaling,
+                tile_tokens_dim,
+            ),
+            strided,
+            top_k,
+            tile_tokens_dim,
+            routing_bias=bias,
+            n_group=n_group,
+            topk_group=topk_group,
+            routed_scaling_factor=routed_scaling,
+        )
+    elif routing_method == RoutingMethodType.Llama4:
+        top_k = 1
+        run_and_check(
+            routing_method,
+            lambda: routing_reference_no_aux(
+                logits,
+                None,
+                top_k,
+                0,
+                0,
+                1.0,
+                tile_tokens_dim,
+                use_routing_scales_on_input=True,
+            ),
+            strided,
+            top_k,
+            tile_tokens_dim,
+        )
+    else:
+        top_k = 8
+        run_and_check(
+            routing_method,
+            lambda: routing_reference_renormalize(
+                logits, top_k, num_experts, tile_tokens_dim
+            ),
+            strided,
+            top_k,
+            tile_tokens_dim,
+        )
+
+
+def test_overlapping_logits_rejected():
+    """Rows must not overlap, which also rules out a broadcast (0-stride) view.
+
+    A zero row stride is the kernels' "tightly packed" sentinel
+    (DataBase::mStrideScores), so an overlapping stride cannot be expressed
+    unambiguously and is refused instead of being read back as packed.
+    """
+    num_experts = 64
+    row = make_logits(1, num_experts, torch.float32, stable_seed("broadcast"))
+    broadcast = row.expand(96, num_experts)
+    assert broadcast.stride() == (0, 1)
+    with pytest.raises(ValueError, match="rows must not overlap"):
+        trtllm_gen_routing(broadcast, None, RoutingMethodType.Renormalize, 4)
+
+
+def test_expert_strided_logits_rejected():
+    """Only the token dimension may be strided; rows must stay contiguous."""
+    logits = make_logits(8, 16, torch.float32, 0)
+    # Same values and shape, but stride(1) == 8: an expert-major layout.
+    expert_major = logits.t().contiguous().t()
+    assert expert_major.stride(1) != 1
+    with pytest.raises(ValueError, match="contiguous along the expert dimension"):
+        trtllm_gen_routing(expert_major, None, RoutingMethodType.Renormalize, 4)
+
+
 def test_invalid_group_args_rejected():
     """Grouped-routing argument validation at the FFI boundary.
 


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

The trtllm-gen routing kernels indexed a token's score row as `tokenIdx * mNumExperts`, so `routing_logits` had to be tightly packed. A caller holding a *view* into a wider router-output buffer — a slice of a padded GEMM output, a token window of a larger allocation, `logits[:, :num_experts]` of a fused router — had to materialize a contiguous copy before every MoE call. Worse, `FusedMoeLauncher::check_routing_logits()` never checked contiguity at all, so a strided tensor silently produced **wrong routing** on the fused path.

This PR makes the routing input stride-aware.

- Add `DataBase::mStrideScores`: the row stride of `mPtrScores` in elements, resolved once in `KernelParamsBase::setBaseParams()`. `0` keeps the tightly packed default (`mNumExperts`), so every existing caller is unaffected. The field is appended at the end of the struct, following the convention already used for `mPtrRoutingReplayOut`.

- Index every score row with that stride, in `int64`: 5 sites in `trtllm_fused_moe_routing_custom.cuh` (block, dyn-block, cluster, coop/histogram-scores, block-scores), 3 in `trtllm_fused_moe_routing_llama4.cu`, 1 in `trtllm_fused_moe_routing_deepseek.cu`. The resolution in `setBaseParams()` deliberately stays ahead of the DeepSeek path's post-launch `mNumExperts` bump for fused shared experts.

- Score loads are already scalar (`ptrScores[e]`, no vectorized global loads), so only the *token* dimension is strided. Rows must stay unit-stride, and — because `0` is the "tightly packed" sentinel — must not overlap.

- Plumb the stride through `Routing::Runner::run` (trailing defaulted argument), `MoERunnerArgs::routing_logits_stride` (set once in `FusedMoeLauncher::init_common`) and both FFI entry points.

- Move the boundary checks from "must be contiguous" to "expert dimension contiguous, rows non-overlapping": the standalone routing binding, the fused-MoE launcher (which gains the contiguity check it was missing) and `runners.py::_validate_logits_inputs`.

## Performance impact

Measured on **GB300 (SM103)**, `trtllm_gen_routing` with `RoutingMethodType.Renormalize`, fp32 logits, `tile_tokens_dim=8`. Timing is the raw FFI op with pre-allocated outputs (so the numbers are the routing kernels, not the Python wrapper), `bench_gpu_time` with CUDA events and cold L2, median of the measured iterations. The strided input is a window into a buffer whose row pitch is `num_experts + 16`.

### 1. Contiguous logits — no regression

The packed path is unchanged work: the stride resolves to `mNumExperts` and the offset multiply moves from `int32` to `int64`.

| E | K | Tokens | main (us) | this PR (us) | Ratio |
|---:|---:|---:|---:|---:|---:|
| 256 | 8 | 8 | 8.192 | 8.192 | 1.0000x |
| 256 | 8 | 128 | 11.264 | 11.968 | 1.0625x |
| 256 | 8 | 1,024 | 14.048 | 14.048 | 1.0000x |
| 256 | 8 | 4,096 | 18.144 | 17.440 | 0.9612x |
| 256 | 8 | 8,192 | 20.480 | 21.648 | 1.0570x |
| 512 | 8 | 8 | 10.240 | 10.240 | 1.0000x |
| 512 | 8 | 128 | 11.264 | 11.968 | 1.0625x |
| 512 | 8 | 1,024 | 22.208 | 20.800 | 0.9366x |
| 512 | 8 | 4,096 | 24.576 | 24.576 | 1.0000x |
| 512 | 8 | 8,192 | 32.480 | 32.480 | 1.0000x |
| 1024 | 8 | 8 | 18.720 | 17.440 | 0.9316x |
| 1024 | 8 | 128 | 17.408 | 17.408 | 1.0000x |
| 1024 | 8 | 1,024 | 33.824 | 34.496 | 1.0199x |
| 1024 | 8 | 4,096 | 70.656 | 71.296 | 1.0091x |
| 1024 | 8 | 8,192 | 121.856 | 122.848 | 1.0081x |
| 1024 | 32 | 8 | 21.504 | 20.800 | 0.9673x |
| 1024 | 32 | 128 | 19.488 | 19.488 | 1.0000x |
| 1024 | 32 | 1,024 | 38.624 | 38.912 | 1.0075x |
| 1024 | 32 | 4,096 | 84.000 | 84.960 | 1.0114x |
| 1024 | 32 | 8,192 | 144.384 | 145.376 | 1.0069x |
| 2048 | 32 | 8 | 52.256 | 52.256 | 1.0000x |
| 2048 | 32 | 128 | 47.104 | 46.784 | 0.9932x |
| 2048 | 32 | 1,024 | 142.336 | 142.336 | 1.0000x |
| 2048 | 32 | 4,096 | 458.752 | 457.728 | 0.9978x |
| 2048 | 32 | 8,192 | 879.616 | 879.616 | 1.0000x |

Mean ratio **1.0013x** (min 0.9316x, max 1.0625x). The spread is run-to-run noise at the shapes whose runtime is close to the ~1 µs CUDA-event granularity; every shape above ~30 µs lands within ±2%.

### 2. Strided logits — the copy is gone

Before this PR the only way to route a strided view was to copy it first (on the standalone path; on the fused path the copy was mandatory but unchecked). This compares `.contiguous()` + routing on `main` against routing the view directly.

| E | K | Tokens | main: `.contiguous()` + routing (us) | this PR: routing on the view (us) | Speedup | Gain |
|---:|---:|---:|---:|---:|---:|---:|
| 256 | 8 | 8 | 10.560 | 8.192 | 1.2891x | +28.91% |
| 256 | 8 | 128 | 13.344 | 11.968 | 1.1150x | +11.50% |
| 256 | 8 | 1,024 | 18.144 | 13.344 | 1.3597x | +35.97% |
| 256 | 8 | 4,096 | 22.240 | 18.112 | 1.2279x | +22.79% |
| 256 | 8 | 8,192 | 28.416 | 22.240 | 1.2777x | +27.77% |
| 512 | 8 | 8 | 11.264 | 10.240 | 1.1000x | +10.00% |
| 512 | 8 | 128 | 13.568 | 11.296 | 1.2011x | +20.11% |
| 512 | 8 | 1,024 | 24.256 | 21.568 | 1.1246x | +12.46% |
| 512 | 8 | 4,096 | 32.448 | 25.536 | 1.2707x | +27.07% |
| 512 | 8 | 8,192 | 43.008 | 32.480 | 1.3241x | +32.41% |
| 1024 | 8 | 8 | 20.480 | 17.536 | 1.1679x | +16.79% |
| 1024 | 8 | 128 | 19.712 | 17.408 | 1.1324x | +13.24% |
| 1024 | 8 | 1,024 | 36.576 | 32.768 | 1.1162x | +11.62% |
| 1024 | 8 | 4,096 | 75.744 | 70.656 | 1.0720x | +7.20% |
| 1024 | 8 | 8,192 | 129.376 | 119.840 | 1.0796x | +7.96% |
| 1024 | 32 | 8 | 21.760 | 20.800 | 1.0462x | +4.62% |
| 1024 | 32 | 128 | 23.552 | 19.488 | 1.2085x | +20.85% |
| 1024 | 32 | 1,024 | 40.960 | 38.880 | 1.0535x | +5.35% |
| 1024 | 32 | 4,096 | 87.840 | 83.648 | 1.0501x | +5.01% |
| 1024 | 32 | 8,192 | 147.264 | 142.752 | 1.0316x | +3.16% |
| 2048 | 32 | 8 | 52.512 | 52.224 | 1.0055x | +0.55% |
| 2048 | 32 | 128 | 46.368 | 47.104 | 0.9844x | -1.56% |
| 2048 | 32 | 1,024 | 137.184 | 142.304 | 0.9640x | -3.60% |
| 2048 | 32 | 4,096 | 432.560 | 457.856 | 0.9448x | -5.52% |
| 2048 | 32 | 8,192 | 893.952 | 880.640 | 1.0151x | +1.51% |

Mean speedup **1.1265x**.

The four non-positive rows are all at E=2048/K=32, and they are a **measurement artifact that flatters the baseline**: the timed `.contiguous()` leaves the logits in L2 for the routing kernel that follows, while the strided run reads a cold buffer (`cold_l2_cache=True`). At that shape the routing kernel is memory-bound over a 32 MiB logits tensor, and a warm L2 is worth far more than the copy:

```
E=2048 K=32 T=4096: cold-L2 462.9 us, warm-L2 400.6 us, delta 62.3 us   (copy is ~10 us)
E=256  K=8  T=8192: cold-L2  21.5 us, warm-L2  20.7 us, delta  0.9 us
```

In a real pipeline the logits come straight out of the router GEMM and are hot either way, so the copy's cost is the honest delta; the table's small-E rows are the representative case.

## 🔍 Related Issues

Follow-up to #4152 (which optimized these same TopK / routing kernels).

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

Run on GB300 (SM103):

- `tests/moe/test_trtllm_gen_routing.py`: **679 passed, 24 skipped**. New:
  - `test_strided_logits[Renormalize|DeepSeekV3|Llama4 × 1|150|4096 tokens]` — one case per routing-kernel family, over token counts that select the single-block, cluster/block-scores and large-batch coop paths. The strided view is a window into a wider buffer whose padding holds `100.0`, so a read outside the window changes the selection and fails the check.
  - `test_expert_strided_logits_rejected`, `test_overlapping_logits_rejected`.
- `tests/moe/test_trtllm_gen_routed_fused_moe.py`: **48 passed** (`-k bf16`), including the new `test_trtllm_gen_bf16_moe_strided_routing_logits`, which asserts a strided view is *bit-identical* to its contiguous copy end-to-end through `trtllm_bf16_moe`.
- `tests/moe/test_unified_moe_fp8.py::test_block_fp8_layer_and_direct_runner_match_reference`: 2 passed.

## Reviewer Notes

- **Sentinel choice.** `mStrideScores == 0` means "tightly packed" so that every existing caller keeps working without touching its `Data` initialization. The cost is that a genuinely zero row stride (a `torch.expand` broadcast view) cannot be expressed, so overlapping rows are rejected at the boundary rather than silently reinterpreted as packed. If broadcast logits are ever wanted, the sentinel would need to become `-1` and every caller updated.
- **Only the token dimension is strided.** Making the expert dimension strided too would require touching each score load in `RoutingCustomPolicy.cuh` and would cost the coalescing the kernels rely on; the FFI checks reject it explicitly instead.
- `int64` row offsets replace `int32` ones at the score-read sites, which also removes a latent overflow at `num_tokens * stride > 2^31`.
- Other routing inputs (`mPtrTopKIds`, `mPtrTopKPacked`) are untouched and still require packed `[num_tokens, top_k]` layouts.

AI-assisted: implemented with Claude Code.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for routing logits with strided token rows, provided each expert row remains contiguous and rows do not overlap.
  - Extended fused MoE routing across supported routing methods and data types to correctly process strided inputs.
  - Updated API documentation and validation to describe supported tensor layouts.

- **Tests**
  - Added coverage confirming strided inputs match contiguous results.
  - Added validation tests for overlapping rows and non-contiguous expert dimensions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->