### PR TITLE
fix: align the nvidia-cutlass-dsl floor on release-v0.6.18 with main (>=4.6.2a0)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -29,7 +29,7 @@ nccl4py>=0.3.1
 ninja
 numpy
 nvidia-cudnn-frontend>=1.25.0
-nvidia-cutlass-dsl>=4.7.0a0
+nvidia-cutlass-dsl>=4.6.2a0
 nvidia-ml-py
 packaging>=24.2
 requests


### PR DESCRIPTION
## Summary

`requirements.txt` on `release-v0.6.18` requires `nvidia-cutlass-dsl>=4.7.0a0`, while `main` requires `>=4.6.2a0`. This lowers the release branch to match, making the two files byte-identical.

The divergence is an artifact of the rc4 cherry-pick: it captured an intermediate head of #4526, which had only relaxed the previous `==4.7.0` hard pin to `>=4.7.0a0`. The head that actually merged to `main` (f0922749) lowered the floor to `>=4.6.2a0`. This line is the only remaining difference between the two branches' `requirements.txt`.

## Why it matters

`requirements.txt` is the base `install_requires` — `pyproject.toml` sets `dynamic = ["dependencies"]` with `dependencies = {file = ["requirements.txt"]}`. A 4.7-only floor there makes a plain `pip install` unsatisfiable alongside `quack-kernels` 0.6.4, which hard-pins `nvidia-cutlass-dsl==4.6.2` (the same conflict #4555 / #4556 worked around with `--no-deps` in CI).

Nothing that currently gets 4.7 loses it:

| Install path | DSL requirement | Changed? |
| --- | --- | --- |
| base (`requirements.txt`) | `>=4.6.2a0` | yes, was `>=4.7.0a0` |
| `[cu12]` / `[cu13]` extras (`pyproject.toml`) | `>=4.7.0a0` | no — already matches `main` |
| CI (`scripts/test_utils.sh`) | `>=4.7.0a0`, installed explicitly | no |

Kernels that genuinely need the newer DSL are gated at runtime, not by this floor: `is_rubin_cute_dsl_available()` plus the arch probes now consulted by #4649 and #4710. On a 4.6.2 environment those paths deselect the backend and fall back instead of failing with `KeyError: 'sm_107a'` from inside the DSL.

## Test plan

- [x] `requirements.txt` is byte-identical to `upstream/main`
- [x] `pyproject.toml` cu12/cu13 extras unchanged and already equal to `main`
- [x] pre-commit clean (including the `fix requirements.txt` hook, so no reordering needed)
- [ ] CI on this branch — the DSL version CI resolves is unaffected, since `scripts/test_utils.sh` installs `>=4.7.0a0` explicitly

Metadata-only change; no code paths touched.