### PR TITLE
fix: support class method re-exports in API checker

### DIFF
--- a/.github/workflows/pr-api-doc-checks.yml
+++ b/.github/workflows/pr-api-doc-checks.yml
@@ -23,6 +23,11 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
+      - name: Test public API checker
+        id: public_api_tests
+        continue-on-error: true
+        run: python -m unittest discover -s scripts/tests -p 'test_check_pr_api_diff.py' -v
+
       - name: Check public API signature and export changes
         id: public_api
         continue-on-error: true
@@ -68,6 +73,7 @@ jobs:
       - name: Record non-blocking checker status
         if: always()
         env:
+          PUBLIC_API_TEST_OUTCOME: ${{ steps.public_api_tests.outcome }}
           PUBLIC_API_OUTCOME: ${{ steps.public_api.outcome }}
           STATIC_DOCUMENTATION_OUTCOME: ${{ steps.static_documentation.outcome }}
         run: |
@@ -78,6 +84,7 @@ jobs:
           from pathlib import Path
 
           outcomes = {
+              "public_api_tests": os.environ["PUBLIC_API_TEST_OUTCOME"],
               "public_api": os.environ["PUBLIC_API_OUTCOME"],
               "static_documentation": os.environ["STATIC_DOCUMENTATION_OUTCOME"],
           }

--- a/scripts/check_pr_api_diff.py
+++ b/scripts/check_pr_api_diff.py
@@ -113,8 +113,66 @@ def parameters(
     )
 
 
+def is_none_annotation(node: ast.expr) -> bool:
+    return isinstance(node, ast.Constant) and node.value is None
+
+
+def typing_annotation_name(node: ast.expr) -> str | None:
+    if isinstance(node, ast.Name):
+        return node.id
+    if (
+        isinstance(node, ast.Attribute)
+        and isinstance(node.value, ast.Name)
+        and node.value.id == "typing"
+    ):
+        return node.attr
+    return None
+
+
+def optional_annotation_payload(node: ast.expr) -> ast.expr | None:
+    if isinstance(node, ast.Subscript):
+        annotation_name = typing_annotation_name(node.value)
+        if annotation_name == "Optional":
+            return node.slice
+        if annotation_name == "Union" and isinstance(node.slice, ast.Tuple):
+            elements = node.slice.elts
+            if len(elements) == 2:
+                if is_none_annotation(elements[0]):
+                    return elements[1]
+                if is_none_annotation(elements[1]):
+                    return elements[0]
+    if isinstance(node, ast.BinOp) and isinstance(node.op, ast.BitOr):
+        if is_none_annotation(node.left):
+            return node.right
+        if is_none_annotation(node.right):
+            return node.left
+    return None
+
+
+def is_compatible_annotation(before: str | None, after: str | None) -> bool:
+    if before == after:
+        return True
+    if before is None or after is None:
+        return False
+    try:
+        before_node = ast.parse(before, mode="eval").body
+        after_node = ast.parse(after, mode="eval").body
+    except SyntaxError:
+        return False
+    payload = optional_annotation_payload(after_node)
+    return payload is not None and ast.dump(before_node) == ast.dump(payload)
+
+
+def is_compatible_parameter(before: ApiParameter, after: ApiParameter) -> bool:
+    return (
+        before.name == after.name
+        and is_compatible_annotation(before.annotation, after.annotation)
+        and (before.default is None or before.default == after.default)
+    )
+
+
 def is_compatible_signature_extension(before: ApiFunction, after: ApiFunction) -> bool:
-    """Return whether *after* only appends optional parameters.
+    """Return whether *after* is a narrowly compatible input widening.
 
     Existing ``*args``/``**kwargs`` APIs are kept conservative: a new named
     parameter can consume arguments that the old implementation forwarded.
@@ -122,25 +180,50 @@ def is_compatible_signature_extension(before: ApiFunction, after: ApiFunction) -
     if (
         before.is_async != after.is_async
         or before.return_annotation != after.return_annotation
-        or before.positional_only != after.positional_only
         or before.vararg != after.vararg
         or before.kwarg != after.kwarg
         or before.vararg is not None
         or before.kwarg is not None
     ):
         return False
-    if (
-        after.positional_or_keyword[: len(before.positional_or_keyword)]
-        != before.positional_or_keyword
-        or after.keyword_only[: len(before.keyword_only)] != before.keyword_only
+    if len(before.positional_only) != len(after.positional_only) or not all(
+        is_compatible_parameter(old, new)
+        for old, new in zip(
+            before.positional_only,
+            after.positional_only,
+            strict=True,
+        )
     ):
         return False
 
-    added = (
-        after.positional_or_keyword[len(before.positional_or_keyword) :]
-        + after.keyword_only[len(before.keyword_only) :]
+    old_positional = before.positional_or_keyword
+    new_positional = after.positional_or_keyword
+    if len(new_positional) < len(old_positional) or not all(
+        is_compatible_parameter(old, new)
+        for old, new in zip(
+            old_positional,
+            new_positional[: len(old_positional)],
+            strict=True,
+        )
+    ):
+        return False
+    if any(item.default is None for item in new_positional[len(old_positional) :]):
+        return False
+
+    old_keyword_only = {item.name: item for item in before.keyword_only}
+    new_keyword_only = {item.name: item for item in after.keyword_only}
+    if not old_keyword_only.keys() <= new_keyword_only.keys():
+        return False
+    if any(
+        not is_compatible_parameter(item, new_keyword_only[name])
+        for name, item in old_keyword_only.items()
+    ):
+        return False
+    return all(
+        item.default is not None
+        for name, item in new_keyword_only.items()
+        if name not in old_keyword_only
     )
-    return bool(added) and all(item.default is not None for item in added)
 
 
 def is_compatible_api(before: ApiFunction, after: ApiFunction) -> bool:
@@ -263,8 +346,13 @@ def resolve_import_module(node: ast.ImportFrom, path: str) -> str | None:
     return module
 
 
-def module_reexports(path: str, source: str | None) -> dict[str, tuple[str, str]]:
-    """Return public aliases as exported name -> (target module, target name)."""
+ReexportTarget = tuple[str, str]
+
+
+def module_reexports(
+    path: str, source: str | None
+) -> dict[str, tuple[ReexportTarget, ...]]:
+    """Return public aliases and every direct target imported for each name."""
     if source is None:
         return {}
     try:
@@ -272,7 +360,7 @@ def module_reexports(path: str, source: str | None) -> dict[str, tuple[str, str]
     except SyntaxError:
         return {}
 
-    result: dict[str, tuple[str, str]] = {}
+    result: dict[str, set[ReexportTarget]] = {}
     for node in module_scope_imports(tree):
         module = resolve_import_module(node, path)
         if not module:
@@ -280,8 +368,28 @@ def module_reexports(path: str, source: str | None) -> dict[str, tuple[str, str]
         for alias in node.names:
             exported_name = alias.asname or alias.name
             if exported_name != "*":
-                result[exported_name] = (module, alias.name)
-    return result
+                result.setdefault(exported_name, set()).add((module, alias.name))
+    return {
+        exported_name: tuple(sorted(targets))
+        for exported_name, targets in result.items()
+    }
+
+
+def resolve_reexported_api(
+    qualified_name: str,
+    reexports: dict[str, tuple[ReexportTarget, ...]],
+) -> ReexportTarget | None:
+    """Resolve an exact API or one direct ``ExportedClass.member`` alias."""
+    exported_name, separator, member_name = qualified_name.partition(".")
+    if separator and (not member_name or "." in member_name):
+        return None
+    targets = reexports.get(exported_name, ())
+    if len(targets) != 1:
+        return None
+    target_module, target_name = targets[0]
+    if member_name:
+        target_name = f"{target_name}.{member_name}"
+    return target_module, target_name
 
 
 def module_apis(
@@ -411,7 +519,7 @@ def check(base: str, head: str) -> list[PrFinding]:
         )
         for name in sorted(set(old) - set(new)):
             api = old[name]
-            target = reexports.get(name)
+            target = resolve_reexported_api(name, reexports)
             if target:
                 target_module, target_name = target
                 target_api = module_apis(head, target_module, target_cache).get(

--- a/scripts/check_pr_api_diff.py
+++ b/scripts/check_pr_api_diff.py
@@ -293,7 +293,20 @@ class ModuleScopeImportFromVisitor(ast.NodeVisitor):
         self.imports.append(node)
 
     def visit_If(self, node: ast.If) -> None:
-        if isinstance(node.test, ast.Name) and node.test.id == "TYPE_CHECKING":
+        is_type_checking = (
+            isinstance(node.test, ast.Name) and node.test.id == "TYPE_CHECKING"
+        )
+        is_main_guard = (
+            isinstance(node.test, ast.Compare)
+            and isinstance(node.test.left, ast.Name)
+            and node.test.left.id == "__name__"
+            and len(node.test.ops) == 1
+            and isinstance(node.test.ops[0], ast.Eq)
+            and len(node.test.comparators) == 1
+            and isinstance(node.test.comparators[0], ast.Constant)
+            and node.test.comparators[0].value == "__main__"
+        )
+        if is_type_checking or is_main_guard:
             for child in node.orelse:
                 self.visit(child)
             return

--- a/scripts/check_pr_api_diff.py
+++ b/scripts/check_pr_api_diff.py
@@ -284,13 +284,20 @@ def extract_public_apis(path: str, source: str | None) -> dict[str, ApiFunction]
 
 
 class ModuleScopeImportFromVisitor(ast.NodeVisitor):
-    """Collect imports visible at module scope, including guarded imports."""
+    """Collect module-scope imports that can be visible at runtime."""
 
     def __init__(self) -> None:
         self.imports: list[ast.ImportFrom] = []
 
     def visit_ImportFrom(self, node: ast.ImportFrom) -> None:
         self.imports.append(node)
+
+    def visit_If(self, node: ast.If) -> None:
+        if isinstance(node.test, ast.Name) and node.test.id == "TYPE_CHECKING":
+            for child in node.orelse:
+                self.visit(child)
+            return
+        self.generic_visit(node)
 
     def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
         return

--- a/scripts/check_pr_api_diff.py
+++ b/scripts/check_pr_api_diff.py
@@ -295,6 +295,11 @@ class ModuleScopeImportFromVisitor(ast.NodeVisitor):
     def visit_If(self, node: ast.If) -> None:
         is_type_checking = (
             isinstance(node.test, ast.Name) and node.test.id == "TYPE_CHECKING"
+        ) or (
+            isinstance(node.test, ast.Attribute)
+            and isinstance(node.test.value, ast.Name)
+            and node.test.value.id == "typing"
+            and node.test.attr == "TYPE_CHECKING"
         )
         is_main_guard = (
             isinstance(node.test, ast.Compare)

--- a/scripts/tests/test_check_pr_api_diff.py
+++ b/scripts/tests/test_check_pr_api_diff.py
@@ -1,0 +1,335 @@
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import textwrap
+import unittest
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Iterator
+
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+import check_pr_api_diff as api_diff  # noqa: E402
+
+
+def api_function(signature: str) -> api_diff.ApiFunction:
+    source = textwrap.dedent(
+        f"""
+        @flashinfer_api
+        {signature}:
+            pass
+        """
+    )
+    return api_diff.extract_public_apis("flashinfer/example.py", source)["api"]
+
+
+def class_source(name: str, signature: str) -> str:
+    return textwrap.dedent(
+        f"""
+        class {name}:
+            @flashinfer_api
+            {signature}:
+                pass
+        """
+    )
+
+
+def run_git(repo: Path, *args: str) -> str:
+    return subprocess.check_output(
+        ["git", *args],
+        cwd=repo,
+        text=True,
+        stderr=subprocess.DEVNULL,
+    ).strip()
+
+
+def commit_snapshot(repo: Path, files: dict[str, str], message: str) -> str:
+    for child in repo.iterdir():
+        if child.name == ".git":
+            continue
+        if child.is_dir():
+            shutil.rmtree(child)
+        else:
+            child.unlink()
+
+    for relative_path, source in files.items():
+        path = repo / relative_path
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(source, encoding="utf-8")
+
+    run_git(repo, "add", "-A")
+    run_git(repo, "commit", "-q", "-m", message)
+    return run_git(repo, "rev-parse", "HEAD")
+
+
+@contextmanager
+def working_directory(path: Path) -> Iterator[None]:
+    previous = Path.cwd()
+    os.chdir(path)
+    try:
+        yield
+    finally:
+        os.chdir(previous)
+
+
+def compare_snapshots(
+    base_files: dict[str, str], head_files: dict[str, str]
+) -> list[api_diff.PrFinding]:
+    with tempfile.TemporaryDirectory() as directory:
+        repo = Path(directory)
+        run_git(repo, "init", "-q")
+        run_git(repo, "config", "user.name", "API checker test")
+        run_git(repo, "config", "user.email", "api-checker@example.com")
+        base = commit_snapshot(repo, base_files, "base")
+        head = commit_snapshot(repo, head_files, "head")
+        with working_directory(repo):
+            return api_diff.check(base, head)
+
+
+class SignatureCompatibilityTest(unittest.TestCase):
+    def test_compatible_signature_changes(self) -> None:
+        cases = (
+            (
+                "keyword-only insertion",
+                "def api(value: int, *, first: int = 1, last: int = 2) -> None",
+                "def api(value: int, *, first: int = 1, inserted: str = 'x', last: int = 2) -> None",
+            ),
+            (
+                "keyword-only reorder and append",
+                "def api(value: int, *, first: int = 1, last: int = 2) -> None",
+                "def api(value: int, *, last: int = 2, first: int = 1, appended: bool = False) -> None",
+            ),
+            (
+                "optional positional append",
+                "def api(value: int) -> None",
+                "def api(value: int, added: str = 'x') -> None",
+            ),
+            (
+                "required parameter gains default",
+                "def api(first: int, second: str) -> None",
+                "def api(first: int = 1, second: str = 'x') -> None",
+            ),
+            (
+                "positional-only parameter widens",
+                "def api(value: Tensor, /) -> None",
+                "def api(value: Optional[Tensor] = None, /) -> None",
+            ),
+            (
+                "Optional annotation",
+                "def api(value: Tensor) -> None",
+                "def api(value: Optional[Tensor] = None) -> None",
+            ),
+            (
+                "qualified Optional annotation",
+                "def api(value: Tensor) -> None",
+                "def api(value: typing.Optional[Tensor] = None) -> None",
+            ),
+            (
+                "Union with None annotation",
+                "def api(value: Tensor) -> None",
+                "def api(value: Union[Tensor, None] = None) -> None",
+            ),
+            (
+                "pipe union with None annotation",
+                "def api(value: Tensor) -> None",
+                "def api(value: Tensor | None = None) -> None",
+            ),
+        )
+
+        for name, before, after in cases:
+            with self.subTest(name):
+                self.assertTrue(
+                    api_diff.is_compatible_api(
+                        api_function(before),
+                        api_function(after),
+                    )
+                )
+
+    def test_breaking_signature_changes(self) -> None:
+        cases = (
+            (
+                "positional-only kind changed",
+                "def api(value: int, /) -> None",
+                "def api(value: int) -> None",
+            ),
+            (
+                "positional parameter removed",
+                "def api(first: int, second: str) -> None",
+                "def api(first: int) -> None",
+            ),
+            (
+                "positional parameter renamed",
+                "def api(first: int, second: str) -> None",
+                "def api(renamed: int, second: str) -> None",
+            ),
+            (
+                "positional parameters reordered",
+                "def api(first: int, second: str) -> None",
+                "def api(second: str, first: int) -> None",
+            ),
+            (
+                "positional parameter inserted",
+                "def api(first: int, second: str) -> None",
+                "def api(first: int, inserted: bool = False, second: str = 'x') -> None",
+            ),
+            (
+                "existing default changed",
+                "def api(value: int = 1) -> None",
+                "def api(value: int = 2) -> None",
+            ),
+            (
+                "annotation narrowed",
+                "def api(value: Optional[int] = None) -> None",
+                "def api(value: int = 0) -> None",
+            ),
+            (
+                "general union widening",
+                "def api(value: int) -> None",
+                "def api(value: int | str) -> None",
+            ),
+            (
+                "unrelated Optional attribute",
+                "def api(value: Tensor) -> None",
+                "def api(value: custom.Optional[Tensor] = None) -> None",
+            ),
+            (
+                "new required keyword-only parameter",
+                "def api(value: int) -> None",
+                "def api(value: int, *, required: str) -> None",
+            ),
+            (
+                "new named parameter before varargs",
+                "def api(value: int, *args: object) -> None",
+                "def api(value: int, added: str = 'x', *args: object) -> None",
+            ),
+            (
+                "new named parameter before kwargs",
+                "def api(value: int, **kwargs: object) -> None",
+                "def api(value: int, added: str = 'x', **kwargs: object) -> None",
+            ),
+            (
+                "return annotation changed",
+                "def api(value: int) -> int",
+                "def api(value: int) -> str",
+            ),
+            (
+                "function became async",
+                "def api(value: int) -> None",
+                "async def api(value: int) -> None",
+            ),
+        )
+
+        for name, before, after in cases:
+            with self.subTest(name):
+                self.assertFalse(
+                    api_diff.is_compatible_api(
+                        api_function(before),
+                        api_function(after),
+                    )
+                )
+
+
+class ClassReexportIntegrationTest(unittest.TestCase):
+    def test_class_member_reexport_outcomes(self) -> None:
+        base = {
+            "flashinfer/public.py": class_source(
+                "Exported",
+                "def member(self, value: Tensor, *, mode: str = 'fast') -> None",
+            )
+        }
+        compatible_target = class_source(
+            "Target",
+            "def member(self, value: Optional[Tensor] = None, *, mode: str = 'fast', metadata: object = None) -> None",
+        )
+        cases: tuple[tuple[str, dict[str, str], tuple[str, ...]], ...] = (
+            (
+                "direct compatible re-export",
+                {
+                    "flashinfer/public.py": "from flashinfer.impl import Target as Exported\n",
+                    "flashinfer/impl.py": compatible_target,
+                },
+                (),
+            ),
+            (
+                "duplicate identical re-export",
+                {
+                    "flashinfer/public.py": (
+                        "from flashinfer.impl import Target as Exported\n"
+                        "from flashinfer.impl import Target as Exported\n"
+                    ),
+                    "flashinfer/impl.py": compatible_target,
+                },
+                (),
+            ),
+            (
+                "conflicting re-export",
+                {
+                    "flashinfer/public.py": (
+                        "from flashinfer.first import Target as Exported\n"
+                        "from flashinfer.second import Target as Exported\n"
+                    ),
+                    "flashinfer/first.py": compatible_target,
+                    "flashinfer/second.py": compatible_target,
+                },
+                ("public_api_removed",),
+            ),
+            (
+                "breaking target signature",
+                {
+                    "flashinfer/public.py": "from flashinfer.impl import Target as Exported\n",
+                    "flashinfer/impl.py": class_source(
+                        "Target",
+                        "def member(self, renamed: Tensor, *, mode: str = 'fast') -> None",
+                    ),
+                },
+                ("public_api_signature_changed",),
+            ),
+            (
+                "missing target member",
+                {
+                    "flashinfer/public.py": "from flashinfer.impl import Target as Exported\n",
+                    "flashinfer/impl.py": "class Target:\n    pass\n",
+                },
+                ("public_api_removed",),
+            ),
+        )
+
+        for name, head, expected_checks in cases:
+            with self.subTest(name):
+                self.assertEqual(
+                    tuple(finding.check for finding in compare_snapshots(base, head)),
+                    expected_checks,
+                )
+
+    def test_exact_function_reexports_keep_working(self) -> None:
+        base = {
+            "flashinfer/public.py": textwrap.dedent(
+                """
+                @flashinfer_api
+                def exported(value: int) -> None:
+                    pass
+                """
+            )
+        }
+        head = {
+            "flashinfer/public.py": "from flashinfer.impl import target as exported\n",
+            "flashinfer/impl.py": textwrap.dedent(
+                """
+                @flashinfer_api
+                def target(value: int) -> None:
+                    pass
+                """
+            ),
+        }
+
+        self.assertEqual(compare_snapshots(base, head), [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_check_pr_api_diff.py
+++ b/scripts/tests/test_check_pr_api_diff.py
@@ -268,6 +268,29 @@ class ClassReexportIntegrationTest(unittest.TestCase):
                 (),
             ),
             (
+                "runtime-guarded re-export",
+                {
+                    "flashinfer/public.py": (
+                        "if runtime_condition:\n"
+                        "    from flashinfer.impl import Target as Exported\n"
+                    ),
+                    "flashinfer/impl.py": compatible_target,
+                },
+                (),
+            ),
+            (
+                "TYPE_CHECKING-only re-export",
+                {
+                    "flashinfer/public.py": (
+                        "from typing import TYPE_CHECKING\n\n"
+                        "if TYPE_CHECKING:\n"
+                        "    from flashinfer.impl import Target as Exported\n"
+                    ),
+                    "flashinfer/impl.py": compatible_target,
+                },
+                ("public_api_removed",),
+            ),
+            (
                 "conflicting re-export",
                 {
                     "flashinfer/public.py": (

--- a/scripts/tests/test_check_pr_api_diff.py
+++ b/scripts/tests/test_check_pr_api_diff.py
@@ -291,6 +291,17 @@ class ClassReexportIntegrationTest(unittest.TestCase):
                 ("public_api_removed",),
             ),
             (
+                "__main__-guarded re-export",
+                {
+                    "flashinfer/public.py": (
+                        'if __name__ == "__main__":\n'
+                        "    from flashinfer.impl import Target as Exported\n"
+                    ),
+                    "flashinfer/impl.py": compatible_target,
+                },
+                ("public_api_removed",),
+            ),
+            (
                 "conflicting re-export",
                 {
                     "flashinfer/public.py": (

--- a/scripts/tests/test_check_pr_api_diff.py
+++ b/scripts/tests/test_check_pr_api_diff.py
@@ -291,6 +291,18 @@ class ClassReexportIntegrationTest(unittest.TestCase):
                 ("public_api_removed",),
             ),
             (
+                "typing.TYPE_CHECKING-only re-export",
+                {
+                    "flashinfer/public.py": (
+                        "import typing\n\n"
+                        "if typing.TYPE_CHECKING:\n"
+                        "    from flashinfer.impl import Target as Exported\n"
+                    ),
+                    "flashinfer/impl.py": compatible_target,
+                },
+                ("public_api_removed",),
+            ),
+            (
                 "__main__-guarded re-export",
                 {
                     "flashinfer/public.py": (


### PR DESCRIPTION
## 📌 Description

Teach the public API checker to resolve decorated `Class.member` APIs through direct, one-hop class re-exports. The signature comparison now accepts narrowly compatible input widening, including required parameters gaining defaults, `T` widening to an Optional form, and optional keyword-only additions compared by name. Positional changes, return changes, varargs, kwargs, ambiguous aliases, and missing targets remain conservative findings.

Add dependency-free unit and integration coverage for compatible and breaking signatures, class-member re-exports, ambiguous or missing targets, and existing function re-exports. Run the focused checker tests in the advisory PR API workflow and record their outcome separately.

## 🔍 Related Issues

N/A

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

Please focus on the intentionally narrow compatibility policy and one-hop re-export boundary. Validation included the focused unittest suite, changed-file pre-commit checks, focused mypy, `py_compile`, `git diff --check`, and a fixed base/head comparison that reported zero findings. Full repository and GPU/runtime test suites were not run because this change is limited to the dependency-free PR checker.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved public API compatibility checks for positional-only, keyword-only, optional, and defaulted parameters.
  - More accurately detects breaking changes involving annotations, return types, renamed or removed APIs, and re-exported members.
  - Resolves direct and class-member re-exports more reliably, including duplicate, conflicting, and conditionally defined exports.

- **Tests**
  - Added comprehensive coverage for compatible and breaking signature changes, re-exports, and API comparison scenarios.

- **Chores**
  - CI now includes checker test results in advisory warnings and workflow summaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->